### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/DataFormats/BTauReco/interface/BaseTagInfo.h
+++ b/DataFormats/BTauReco/interface/BaseTagInfo.h
@@ -8,41 +8,31 @@
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"
 
 namespace reco {
- 
-class BaseTagInfo {
-public:
-  BaseTagInfo(void) { }
 
-  virtual ~BaseTagInfo(void) { }
+  class BaseTagInfo {
+  public:
+    BaseTagInfo(void) {}
 
-  /// clone
-  virtual BaseTagInfo * clone(void) const {
-    return new BaseTagInfo(*this);
-  }
-  
-  /// returns a polymorphic reference to the tagged jet
-  virtual edm::RefToBase<Jet> jet(void) const { 
-    return edm::RefToBase<Jet>() ; 
-  }
+    virtual ~BaseTagInfo(void) {}
 
-  /// returns a list of tracks associated to the jet
-  virtual TrackRefVector tracks(void) const {
-    return TrackRefVector();
-  }
+    /// clone
+    virtual BaseTagInfo* clone(void) const { return new BaseTagInfo(*this); }
 
-  /// check if the algorithm is using the tracks or not
-  virtual bool hasTracks(void) const {
-    return false;
-  }
-  
-  /// returns a description of the extended informations in a TaggingVariableList
-  virtual TaggingVariableList taggingVariables(void) const {
-    return TaggingVariableList();
-  }
-};
+    /// returns a polymorphic reference to the tagged jet
+    virtual edm::RefToBase<Jet> jet(void) const { return edm::RefToBase<Jet>(); }
 
-DECLARE_EDM_REFS( BaseTagInfo )
+    /// returns a list of tracks associated to the jet
+    virtual TrackRefVector tracks(void) const { return TrackRefVector(); }
 
-}
+    /// check if the algorithm is using the tracks or not
+    virtual bool hasTracks(void) const { return false; }
 
-#endif // DataFormats_BTauReco_BaseTagInfo_h
+    /// returns a description of the extended informations in a TaggingVariableList
+    virtual TaggingVariableList taggingVariables(void) const { return TaggingVariableList(); }
+  };
+
+  DECLARE_EDM_REFS(BaseTagInfo)
+
+}  // namespace reco
+
+#endif  // DataFormats_BTauReco_BaseTagInfo_h

--- a/DataFormats/BTauReco/interface/BoostedDoubleSVTagInfo.h
+++ b/DataFormats/BTauReco/interface/BoostedDoubleSVTagInfo.h
@@ -9,31 +9,29 @@
 
 namespace reco {
 
-class BoostedDoubleSVTagInfo : public BaseTagInfo {
-public:
-  BoostedDoubleSVTagInfo(void) { }
+  class BoostedDoubleSVTagInfo : public BaseTagInfo {
+  public:
+    BoostedDoubleSVTagInfo(void) {}
 
-  BoostedDoubleSVTagInfo(
-    const TaggingVariableList & list,
-    const edm::Ref<std::vector<CandSecondaryVertexTagInfo> > & svTagInfoRef) :
-      m_list(list),
-      m_svTagInfoRef(svTagInfoRef) { }
+    BoostedDoubleSVTagInfo(const TaggingVariableList& list,
+                           const edm::Ref<std::vector<CandSecondaryVertexTagInfo> >& svTagInfoRef)
+        : m_list(list), m_svTagInfoRef(svTagInfoRef) {}
 
-  ~BoostedDoubleSVTagInfo(void) override { }
+    ~BoostedDoubleSVTagInfo(void) override {}
 
-  BoostedDoubleSVTagInfo* clone(void) const override { return new BoostedDoubleSVTagInfo(*this); }
+    BoostedDoubleSVTagInfo* clone(void) const override { return new BoostedDoubleSVTagInfo(*this); }
 
-  edm::RefToBase<Jet> jet(void) const override { return m_svTagInfoRef->jet(); }
+    edm::RefToBase<Jet> jet(void) const override { return m_svTagInfoRef->jet(); }
 
-  TaggingVariableList taggingVariables(void) const override { return m_list; }
+    TaggingVariableList taggingVariables(void) const override { return m_list; }
 
-protected:
-  TaggingVariableList                                 m_list;
-  edm::Ref<std::vector<CandSecondaryVertexTagInfo> >  m_svTagInfoRef;
-};
+  protected:
+    TaggingVariableList m_list;
+    edm::Ref<std::vector<CandSecondaryVertexTagInfo> > m_svTagInfoRef;
+  };
 
-DECLARE_EDM_REFS( BoostedDoubleSVTagInfo )
+  DECLARE_EDM_REFS(BoostedDoubleSVTagInfo)
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_BoostedDoubleSVTagInfo_h
+#endif  // DataFormats_BTauReco_BoostedDoubleSVTagInfo_h

--- a/DataFormats/BTauReco/interface/BoostedDoubleSVTagInfoFeatures.h
+++ b/DataFormats/BTauReco/interface/BoostedDoubleSVTagInfoFeatures.h
@@ -3,42 +3,40 @@
 
 namespace btagbtvdeep {
 
-class BoostedDoubleSVTagInfoFeatures {
-
-  // Note: these variables are intended to match the variables defined in DataFormats/BTauReco/interface/TaggingVariable.h
+  class BoostedDoubleSVTagInfoFeatures {
+    // Note: these variables are intended to match the variables defined in DataFormats/BTauReco/interface/TaggingVariable.h
 
   public:
-    float jetNTracks; // tracks associated to jet
-    float jetNSecondaryVertices; // number of reconstructed possible secondary vertices in jet
-    float trackSip3dSig_0; // 1st largest track 3D signed impact parameter significance
-    float trackSip3dSig_1; // 2nd largest track 3D signed impact parameter significance
-    float trackSip3dSig_2; // 3rd largest track 3D signed impact parameter significance
-    float trackSip3dSig_3; // 4th largest track 3D signed impact parameter significance
-    float tau1_trackSip3dSig_0; // 1st largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis
-    float tau1_trackSip3dSig_1; // 2nd largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis
-    float tau2_trackSip3dSig_0; // 1st largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis
-    float tau2_trackSip3dSig_1; // 2nd largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis
-    float trackSip2dSigAboveBottom_0;// track 2D signed impact parameter significance of 1st track lifting mass above bottom
-    float trackSip2dSigAboveBottom_1;// track 2D signed impact parameter significance of 2nd track lifting mass above bottom
-    float trackSip2dSigAboveCharm; // track 2D signed impact parameter significance of first track lifting mass above charm
-    float tau1_trackEtaRel_0; // 1st smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
-    float tau1_trackEtaRel_1; // 2nd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
-    float tau1_trackEtaRel_2; // 3rd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
-    float tau2_trackEtaRel_0; // 1st smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
-    float tau2_trackEtaRel_1; // 2nd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
-    float tau2_trackEtaRel_2; // 3rd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
-    float tau1_vertexMass; // mass of track sum at secondary vertex associated to the 1st N-subjettiness axis
-    float tau1_vertexEnergyRatio; // ratio of energy at secondary vertex over total energy associated to the 1st N-subjettiness axis
-    float tau1_flightDistance2dSig; // transverse distance significance between primary and secondary vertex associated to the 1st N-subjettiness axis
-    float tau1_vertexDeltaR; // pseudoangular distance between the 1st N-subjettiness axis and secondary vertex direction
-    float tau2_vertexMass; // mass of track sum at secondary vertex associated to the 2nd N-subjettiness axis
-    float tau2_vertexEnergyRatio; // ratio of energy at secondary vertex over total energy associated to the 2nd N-subjettiness axis
-    float tau2_flightDistance2dSig; // transverse distance significance between primary and secondary vertex associated to the 2nd N-subjettiness axis
-    float tau2_vertexDeltaR; // pseudoangular distance between the 2nd N-subjettiness axis and secondary vertex direction (NOT USED!)
-    float z_ratio; // z ratio
+    float jetNTracks;             // tracks associated to jet
+    float jetNSecondaryVertices;  // number of reconstructed possible secondary vertices in jet
+    float trackSip3dSig_0;        // 1st largest track 3D signed impact parameter significance
+    float trackSip3dSig_1;        // 2nd largest track 3D signed impact parameter significance
+    float trackSip3dSig_2;        // 3rd largest track 3D signed impact parameter significance
+    float trackSip3dSig_3;        // 4th largest track 3D signed impact parameter significance
+    float tau1_trackSip3dSig_0;  // 1st largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis
+    float tau1_trackSip3dSig_1;  // 2nd largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis
+    float tau2_trackSip3dSig_0;  // 1st largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis
+    float tau2_trackSip3dSig_1;  // 2nd largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis
+    float trackSip2dSigAboveBottom_0;  // track 2D signed impact parameter significance of 1st track lifting mass above bottom
+    float trackSip2dSigAboveBottom_1;  // track 2D signed impact parameter significance of 2nd track lifting mass above bottom
+    float trackSip2dSigAboveCharm;  // track 2D signed impact parameter significance of first track lifting mass above charm
+    float tau1_trackEtaRel_0;  // 1st smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
+    float tau1_trackEtaRel_1;  // 2nd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
+    float tau1_trackEtaRel_2;  // 3rd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
+    float tau2_trackEtaRel_0;  // 1st smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
+    float tau2_trackEtaRel_1;  // 2nd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
+    float tau2_trackEtaRel_2;  // 3rd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
+    float tau1_vertexMass;  // mass of track sum at secondary vertex associated to the 1st N-subjettiness axis
+    float tau1_vertexEnergyRatio;  // ratio of energy at secondary vertex over total energy associated to the 1st N-subjettiness axis
+    float tau1_flightDistance2dSig;  // transverse distance significance between primary and secondary vertex associated to the 1st N-subjettiness axis
+    float tau1_vertexDeltaR;  // pseudoangular distance between the 1st N-subjettiness axis and secondary vertex direction
+    float tau2_vertexMass;    // mass of track sum at secondary vertex associated to the 2nd N-subjettiness axis
+    float tau2_vertexEnergyRatio;  // ratio of energy at secondary vertex over total energy associated to the 2nd N-subjettiness axis
+    float tau2_flightDistance2dSig;  // transverse distance significance between primary and secondary vertex associated to the 2nd N-subjettiness axis
+    float tau2_vertexDeltaR;  // pseudoangular distance between the 2nd N-subjettiness axis and secondary vertex direction (NOT USED!)
+    float z_ratio;  // z ratio
+  };
 
-};
+}  // namespace btagbtvdeep
 
-}
-
-#endif //DataFormats_BTauReco_BoostedDoubleSVTagInfoFeatures_h
+#endif  //DataFormats_BTauReco_BoostedDoubleSVTagInfoFeatures_h

--- a/DataFormats/BTauReco/interface/CATopJetTagInfo.h
+++ b/DataFormats/BTauReco/interface/CATopJetTagInfo.h
@@ -1,13 +1,12 @@
 #ifndef AnalysisDataFormats_TopObjects_interface_CATopJetTagInfo_h
 #define AnalysisDataFormats_TopObjects_interface_CATopJetTagInfo_h
 
-
 // \class CATopJetTagInfo
-// 
+//
 // \short tag info for Cambridge-Aachen based subjet top-jet tagging algorithm
 // CATopJetTagInfo is a class to hold the discriminator variables for the
 // CATopJet Tagging algorithm.
-// 
+//
 //
 // \author Salvatore Rappoccio
 // \version first version on 27 Aug 2008
@@ -18,48 +17,45 @@
 #include <vector>
 
 namespace reco {
- 
-class CATopJetProperties {
-public:
-  CATopJetProperties() {
-    nSubJets = 0;
-    minMass = 0.;
-    topMass = 0.;
-    wMass = 0.;
-  }
-  int                 nSubJets;        //<! Number of subjets
-  double              minMass;         //<! Minimum invariant mass pairing
-  double              topMass;         //<! Jet mass
-  double              wMass;           //<! Closest mass to W mass
-};
 
- class CATopJetTagInfo : public JetTagInfo {
-public:
-  typedef edm::RefToBase<Jet> jet_type;
-  typedef CATopJetProperties  properties_type;
-    
+  class CATopJetProperties {
+  public:
+    CATopJetProperties() {
+      nSubJets = 0;
+      minMass = 0.;
+      topMass = 0.;
+      wMass = 0.;
+    }
+    int nSubJets;    //<! Number of subjets
+    double minMass;  //<! Minimum invariant mass pairing
+    double topMass;  //<! Jet mass
+    double wMass;    //<! Closest mass to W mass
+  };
+
+  class CATopJetTagInfo : public JetTagInfo {
+  public:
+    typedef edm::RefToBase<Jet> jet_type;
+    typedef CATopJetProperties properties_type;
+
     CATopJetTagInfo(void) {}
 
     ~CATopJetTagInfo(void) override {}
-  
-    CATopJetTagInfo* clone(void) const override { return new CATopJetTagInfo(*this); }
-    
-    const properties_type & properties() const {
-      return properties_;
-    }
 
-    void insert(const edm::RefToBase<Jet> & jet, const CATopJetProperties & properties) {
+    CATopJetTagInfo* clone(void) const override { return new CATopJetTagInfo(*this); }
+
+    const properties_type& properties() const { return properties_; }
+
+    void insert(const edm::RefToBase<Jet>& jet, const CATopJetProperties& properties) {
       setJetRef(jet);
       properties_ = properties;
     }
 
-protected:
+  protected:
     properties_type properties_;
+  };
 
-};
+  DECLARE_EDM_REFS(CATopJetTagInfo)
 
-DECLARE_EDM_REFS( CATopJetTagInfo )
+}  // namespace reco
 
-}
-
-#endif // AnalysisDataFormats_TopObjects_interface_CATopJetTagInfo_h
+#endif  // AnalysisDataFormats_TopObjects_interface_CATopJetTagInfo_h

--- a/DataFormats/BTauReco/interface/CandIPTagInfo.h
+++ b/DataFormats/BTauReco/interface/CandIPTagInfo.h
@@ -7,11 +7,10 @@
 #include "DataFormats/BTauReco/interface/IPTagInfo.h"
 
 namespace reco {
-typedef IPTagInfo<std::vector<CandidatePtr>,JetTagInfo> CandIPTagInfo;
+  typedef IPTagInfo<std::vector<CandidatePtr>, JetTagInfo> CandIPTagInfo;
 
+  DECLARE_EDM_REFS(CandIPTagInfo)
 
-DECLARE_EDM_REFS( CandIPTagInfo )
-
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/BTauReco/interface/CandSecondaryVertexTagInfo.h
+++ b/DataFormats/BTauReco/interface/CandSecondaryVertexTagInfo.h
@@ -6,10 +6,10 @@
 
 namespace reco {
 
-typedef reco::TemplatedSecondaryVertexTagInfo<reco::CandIPTagInfo,reco::VertexCompositePtrCandidate> CandSecondaryVertexTagInfo;
+  typedef reco::TemplatedSecondaryVertexTagInfo<reco::CandIPTagInfo, reco::VertexCompositePtrCandidate>
+      CandSecondaryVertexTagInfo;
 
+  DECLARE_EDM_REFS(CandSecondaryVertexTagInfo)
 
-DECLARE_EDM_REFS(CandSecondaryVertexTagInfo)
-
-}
-#endif // DataFormats_BTauReco_CandSecondaryVertexTagInfo_h
+}  // namespace reco
+#endif  // DataFormats_BTauReco_CandSecondaryVertexTagInfo_h

--- a/DataFormats/BTauReco/interface/CandSoftLeptonTagInfo.h
+++ b/DataFormats/BTauReco/interface/CandSoftLeptonTagInfo.h
@@ -10,10 +10,10 @@
 
 namespace reco {
 
-typedef TemplatedSoftLeptonTagInfo<CandidatePtr> CandSoftLeptonTagInfo;
+  typedef TemplatedSoftLeptonTagInfo<CandidatePtr> CandSoftLeptonTagInfo;
 
-DECLARE_EDM_REFS( CandSoftLeptonTagInfo )
+  DECLARE_EDM_REFS(CandSoftLeptonTagInfo)
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_CandSoftLeptonTagInfo_h
+#endif  // DataFormats_BTauReco_CandSoftLeptonTagInfo_h

--- a/DataFormats/BTauReco/interface/ChargedCandidateFeatures.h
+++ b/DataFormats/BTauReco/interface/ChargedCandidateFeatures.h
@@ -3,10 +3,8 @@
 
 namespace btagbtvdeep {
 
-class ChargedCandidateFeatures {
-
+  class ChargedCandidateFeatures {
   public:
-
     float ptrel;
     float puppiw;
     float vtx_ass;
@@ -22,16 +20,14 @@ class ChargedCandidateFeatures {
     float btagPf_trackSip2dVal;
     float btagPf_trackSip2dSig;
 
-
     float btagPf_trackJetDistVal;
 
     float chi2;
     float quality;
 
     float drminsv;
+  };
 
-};
+}  // namespace btagbtvdeep
 
-}
-
-#endif //DataFormats_BTauReco_ChargedCandidateFeatures_h
+#endif  //DataFormats_BTauReco_ChargedCandidateFeatures_h

--- a/DataFormats/BTauReco/interface/CombinedTauTagInfo.h
+++ b/DataFormats/BTauReco/interface/CombinedTauTagInfo.h
@@ -23,172 +23,189 @@ namespace reco {
 
   class CombinedTauTagInfo : public JTATagInfo {
   public:
-    CombinedTauTagInfo(){}
+    CombinedTauTagInfo() {}
     CombinedTauTagInfo(const JetTracksAssociationRef& jtaRef) : JTATagInfo(jtaRef) {
-      thecandidate_passed_trackerselection=false;
-      thecandidate_is_GoodTauCandidate=false;
-      thecandidate_is_infact_GoodElectronCandidate=false;
-      thecandidate_is_infact_GoodMuonCandidate=false;
-      thecandidate_needs_LikelihoodRatio_discrimination=false;
+      thecandidate_passed_trackerselection = false;
+      thecandidate_is_GoodTauCandidate = false;
+      thecandidate_is_infact_GoodElectronCandidate = false;
+      thecandidate_is_infact_GoodMuonCandidate = false;
+      thecandidate_needs_LikelihoodRatio_discrimination = false;
       filtered_Tks_.clear();
       signal_Tks_.clear();
       isol_Tks_.clear();
-      theleadTk_signedipt_significance=NAN;
-      theleadTk_signedip3D_significance=NAN;
-      thesignedflightpath_significance=NAN;
-      theTksEt_o_JetEt=NAN;
-      theneutralE=NAN;
-      theisolneutralE=NAN;
-      theisolneutralEtsum=NAN;
-      theneutralECALClus_number=std::numeric_limits<int>::quiet_NaN();
-      theneutralECALClus_radius=NAN;
-      theneutralE_o_TksEneutralE=NAN;
-      theisolneutralE_o_TksEneutralE=NAN;
-      theneutralE_ratio=NAN;
+      theleadTk_signedipt_significance = NAN;
+      theleadTk_signedip3D_significance = NAN;
+      thesignedflightpath_significance = NAN;
+      theTksEt_o_JetEt = NAN;
+      theneutralE = NAN;
+      theisolneutralE = NAN;
+      theisolneutralEtsum = NAN;
+      theneutralECALClus_number = std::numeric_limits<int>::quiet_NaN();
+      theneutralECALClus_radius = NAN;
+      theneutralE_o_TksEneutralE = NAN;
+      theisolneutralE_o_TksEneutralE = NAN;
+      theneutralE_ratio = NAN;
       thealternatrecJet_HepLV.setPx(NAN);
       thealternatrecJet_HepLV.setPy(NAN);
       thealternatrecJet_HepLV.setPz(NAN);
       thealternatrecJet_HepLV.setE(NAN);
-      theECALEt_o_leadTkPt=NAN;
-      theHCALEt_o_leadTkPt=NAN;
+      theECALEt_o_leadTkPt = NAN;
+      theHCALEt_o_leadTkPt = NAN;
     }
-    ~CombinedTauTagInfo() override {};
-    
-    // float discriminator() returns 0.        if candidate did not pass tracker selection,   
-    //                               1.        if candidate passed tracker selection and did not contain neutral ECAL clus.,   
-    //                               0<=  <=1  if candidate passed tracker selection, contained neutral ECAL clus. and went through the likelihood ratio mechanism,   
-    //                               NaN       the values of the likelihood functions PDFs are 0 (test the result of discriminator() with bool isnan(.));   
-    
+    ~CombinedTauTagInfo() override{};
+
+    // float discriminator() returns 0.        if candidate did not pass tracker selection,
+    //                               1.        if candidate passed tracker selection and did not contain neutral ECAL clus.,
+    //                               0<=  <=1  if candidate passed tracker selection, contained neutral ECAL clus. and went through the likelihood ratio mechanism,
+    //                               NaN       the values of the likelihood functions PDFs are 0 (test the result of discriminator() with bool isnan(.));
+
     //the reference to the IsolatedTauTagInfo
-    const IsolatedTauTagInfoRef & isolatedtautaginfoRef() const { return IsolatedTauTagInfoRef_; }
-    void setisolatedtautaginfoRef(const IsolatedTauTagInfoRef & x) { IsolatedTauTagInfoRef_ = x; }
-   
+    const IsolatedTauTagInfoRef& isolatedtautaginfoRef() const { return IsolatedTauTagInfoRef_; }
+    void setisolatedtautaginfoRef(const IsolatedTauTagInfoRef& x) { IsolatedTauTagInfoRef_ = x; }
+
     //get the tracks from the JetTag
     const TrackRefVector& allTks() const { return m_jetTracksAssociation->second; }
-   
+
     //the tracks considered in the isolation strip and signal cone selections
     const TrackRefVector& selectedTks() const { return filtered_Tks_; }
-    void setselectedTks(const TrackRefVector& x) { filtered_Tks_=x; }
-    
+    void setselectedTks(const TrackRefVector& x) { filtered_Tks_ = x; }
+
     //the tracks in the signal cone
     const TrackRefVector& signalTks() const { return signal_Tks_; }
-    void setsignalTks(const TrackRefVector& x) { signal_Tks_=x; }
-   
-    int signalTks_qsum()const{              // NaN : (int)(signal_Tks_.size())=0;   
-      int signal_Tks_qsum_=std::numeric_limits<int>::quiet_NaN();   
-      if((int)(signal_Tks_.size())!=0){   
-	signal_Tks_qsum_=0;   
-	for(TrackRefVector::const_iterator iTk=signal_Tks_.begin();iTk!=signal_Tks_.end();iTk++){   
-	  signal_Tks_qsum_+=(**iTk).charge();   
-	}   
-      }   
-      return signal_Tks_qsum_;   
-    } 
-    
+    void setsignalTks(const TrackRefVector& x) { signal_Tks_ = x; }
+
+    int signalTks_qsum() const {  // NaN : (int)(signal_Tks_.size())=0;
+      int signal_Tks_qsum_ = std::numeric_limits<int>::quiet_NaN();
+      if ((int)(signal_Tks_.size()) != 0) {
+        signal_Tks_qsum_ = 0;
+        for (TrackRefVector::const_iterator iTk = signal_Tks_.begin(); iTk != signal_Tks_.end(); iTk++) {
+          signal_Tks_qsum_ += (**iTk).charge();
+        }
+      }
+      return signal_Tks_qsum_;
+    }
+
     //the tracks in the isolation band
     const TrackRefVector& isolTks() const { return isol_Tks_; }
-    void setisolTks(const TrackRefVector& x) { isol_Tks_=x; }
-     
-    CombinedTauTagInfo* clone() const override{return new CombinedTauTagInfo(*this );}
-    
-    bool passed_trackerselection()const{return(thecandidate_passed_trackerselection);}
-    void setpassed_trackerselection(bool x){thecandidate_passed_trackerselection=x;}
+    void setisolTks(const TrackRefVector& x) { isol_Tks_ = x; }
 
-   bool is_GoodTauCandidate()const{return(thecandidate_is_GoodTauCandidate);} // true : passed tracker sel. and no neutral activity inside jet;
-   void setis_GoodTauCandidate(bool x){thecandidate_is_GoodTauCandidate=x;}
+    CombinedTauTagInfo* clone() const override { return new CombinedTauTagInfo(*this); }
 
-   bool infact_GoodElectronCandidate()const{return(thecandidate_is_infact_GoodElectronCandidate);} // true : passed tracker sel., contains 1 signal tk, e-identified through (ECALEt_o_leadTkPt(),HCALEt_o_leadTkPt()) space;
-   void setinfact_GoodElectronCandidate(bool x){thecandidate_is_infact_GoodElectronCandidate=x;} 
+    bool passed_trackerselection() const { return (thecandidate_passed_trackerselection); }
+    void setpassed_trackerselection(bool x) { thecandidate_passed_trackerselection = x; }
 
-   bool infact_GoodMuonCandidate()const{return(thecandidate_is_infact_GoodMuonCandidate);} // true : passed tracker sel., contains 1 signal tk, mu-identified through (ECALEt_o_leadTkPt(),HCALEt_o_leadTkPt()) space;
-   void setinfact_GoodMuonCandidate(bool x){thecandidate_is_infact_GoodMuonCandidate=x;}
+    bool is_GoodTauCandidate() const {
+      return (thecandidate_is_GoodTauCandidate);
+    }  // true : passed tracker sel. and no neutral activity inside jet;
+    void setis_GoodTauCandidate(bool x) { thecandidate_is_GoodTauCandidate = x; }
 
-   bool needs_LikelihoodRatio_discrimination()const{return(thecandidate_needs_LikelihoodRatio_discrimination);} // true : passed tracker sel. and neutral activity inside jet;
-   void setneeds_LikelihoodRatio_discrimination(bool x){thecandidate_needs_LikelihoodRatio_discrimination=x;}
+    bool infact_GoodElectronCandidate() const {
+      return (thecandidate_is_infact_GoodElectronCandidate);
+    }  // true : passed tracker sel., contains 1 signal tk, e-identified through (ECALEt_o_leadTkPt(),HCALEt_o_leadTkPt()) space;
+    void setinfact_GoodElectronCandidate(bool x) { thecandidate_is_infact_GoodElectronCandidate = x; }
 
-   double leadTk_signedipt_significance()const{return (theleadTk_signedipt_significance);}  // NaN : failure;
-   void setleadTk_signedipt_significance(double x){theleadTk_signedipt_significance=x;}
+    bool infact_GoodMuonCandidate() const {
+      return (thecandidate_is_infact_GoodMuonCandidate);
+    }  // true : passed tracker sel., contains 1 signal tk, mu-identified through (ECALEt_o_leadTkPt(),HCALEt_o_leadTkPt()) space;
+    void setinfact_GoodMuonCandidate(bool x) { thecandidate_is_infact_GoodMuonCandidate = x; }
 
-   double leadTk_signedip3D_significance()const{return(theleadTk_signedip3D_significance);}  // NaN : failure;
-   void setleadTk_signedip3D_significance(double x){theleadTk_signedip3D_significance=x;}
+    bool needs_LikelihoodRatio_discrimination() const {
+      return (thecandidate_needs_LikelihoodRatio_discrimination);
+    }  // true : passed tracker sel. and neutral activity inside jet;
+    void setneeds_LikelihoodRatio_discrimination(bool x) { thecandidate_needs_LikelihoodRatio_discrimination = x; }
 
-   double signedflightpath_significance()const{return (thesignedflightpath_significance);}  // NaN : failure, did not build a SV.;
-   void setsignedflightpath_significance(double x){thesignedflightpath_significance=x;}
-   
-   // Ettks/Etjet;
-   double TksEt_o_JetEt()const{return(theTksEt_o_JetEt);} 
-   void setTksEt_o_JetEt(double x){theTksEt_o_JetEt=x;}
+    double leadTk_signedipt_significance() const { return (theleadTk_signedipt_significance); }  // NaN : failure;
+    void setleadTk_signedipt_significance(double x) { theleadTk_signedipt_significance = x; }
 
-   // Eneutr.clus.;
-   double neutralE()const{return(theneutralE);} 
-   void setneutralE(double x){theneutralE=x;}
+    double leadTk_signedip3D_significance() const { return (theleadTk_signedip3D_significance); }  // NaN : failure;
+    void setleadTk_signedip3D_significance(double x) { theleadTk_signedip3D_significance = x; }
 
-   // Eneutr.clus.,isol.band;
-   double isolneutralE()const{return(theisolneutralE);} 
-   void setisolneutralE(double x){theisolneutralE=x;}
+    double signedflightpath_significance() const {
+      return (thesignedflightpath_significance);
+    }  // NaN : failure, did not build a SV.;
+    void setsignedflightpath_significance(double x) { thesignedflightpath_significance = x; }
 
-   // sum of Etneutr.clus.,isol.band;
-   double isolneutralEtsum()const{return(theisolneutralEtsum);} 
-   void setisolneutralEtsum(double x){theisolneutralEtsum=x;}
+    // Ettks/Etjet;
+    double TksEt_o_JetEt() const { return (theTksEt_o_JetEt); }
+    void setTksEt_o_JetEt(double x) { theTksEt_o_JetEt = x; }
 
-   int neutralECALClus_number()const{return(theneutralECALClus_number);}
-   void setneutralECALClus_number(int x){theneutralECALClus_number=x;}
+    // Eneutr.clus.;
+    double neutralE() const { return (theneutralE); }
+    void setneutralE(double x) { theneutralE = x; }
 
-   //mean DRneutr.clus.-lead.tk
-   double neutralECALClus_radius()const{return(theneutralECALClus_radius);} // NaN : neutralECALClus_number()=0;
-   void setneutralECALClus_radius(double x){theneutralECALClus_radius=x;}
+    // Eneutr.clus.,isol.band;
+    double isolneutralE() const { return (theisolneutralE); }
+    void setisolneutralE(double x) { theisolneutralE = x; }
 
-   // Eneutr.clus. / (Eneutr.clus. + Etks) , Etks built with tks impulsion and charged pi mass hypothesis; 
-   double neutralE_o_TksEneutralE()const{return(theneutralE_o_TksEneutralE);} 
-   void setneutralE_o_TksEneutralE(double x){theneutralE_o_TksEneutralE=x;} 
+    // sum of Etneutr.clus.,isol.band;
+    double isolneutralEtsum() const { return (theisolneutralEtsum); }
+    void setisolneutralEtsum(double x) { theisolneutralEtsum = x; }
 
-   // Eneutr.clus.,isol.band / (Eneutr.clus. + Etks);
-   double isolneutralE_o_TksEneutralE()const{return(theisolneutralE_o_TksEneutralE);} 
-   void setisolneutralE_o_TksEneutralE(double x){theisolneutralE_o_TksEneutralE=x;}
+    int neutralECALClus_number() const { return (theneutralECALClus_number); }
+    void setneutralECALClus_number(int x) { theneutralECALClus_number = x; }
 
-   // Eneutr.clus.,isol.band / Eneutr.clus.;
-   double neutralE_ratio()const{return(theneutralE_ratio);} // NaN : neutralECALClus_number()=0;
-   void setneutralE_ratio(double x){theneutralE_ratio=x;}
+    //mean DRneutr.clus.-lead.tk
+    double neutralECALClus_radius() const { return (theneutralECALClus_radius); }  // NaN : neutralECALClus_number()=0;
+    void setneutralECALClus_radius(double x) { theneutralECALClus_radius = x; }
 
-   CLHEP::HepLorentzVector alternatrecJet_HepLV()const{return(thealternatrecJet_HepLV);} // rec. pi+/- candidates + neutral ECAL clus. combined;   
-   void setalternatrecJet_HepLV(CLHEP::HepLorentzVector x){thealternatrecJet_HepLV=x;}
+    // Eneutr.clus. / (Eneutr.clus. + Etks) , Etks built with tks impulsion and charged pi mass hypothesis;
+    double neutralE_o_TksEneutralE() const { return (theneutralE_o_TksEneutralE); }
+    void setneutralE_o_TksEneutralE(double x) { theneutralE_o_TksEneutralE = x; }
 
-   // EtECAL*/Ptlead.tk        *using ECAL cell hits inside a DR cone around lead tk ECAL impact point direction;
-   double ECALEt_o_leadTkPt()const{return(theECALEt_o_leadTkPt);} // NaN : failure when trying to find the lead. tk contact on ECAL surface point; 
-   void setECALEt_o_leadTkPt(double x){theECALEt_o_leadTkPt=x;}
+    // Eneutr.clus.,isol.band / (Eneutr.clus. + Etks);
+    double isolneutralE_o_TksEneutralE() const { return (theisolneutralE_o_TksEneutralE); }
+    void setisolneutralE_o_TksEneutralE(double x) { theisolneutralE_o_TksEneutralE = x; }
 
-   // EtHCAL**/Ptlead.tk;      **using HCAL tower hits inside a DR cone around lead tk ECAL impact point direction; 
-   double HCALEt_o_leadTkPt()const{return(theHCALEt_o_leadTkPt);} // NaN : failure when trying to find the lead. tk contact on ECAL surface point; 
-   void setHCALEt_o_leadTkPt(double x){theHCALEt_o_leadTkPt=x;}
- private:
-   IsolatedTauTagInfoRef IsolatedTauTagInfoRef_;
-   TrackRefVector filtered_Tks_;
-   TrackRefVector signal_Tks_;
-   TrackRefVector isol_Tks_;
-   bool thecandidate_passed_trackerselection;
-   bool thecandidate_is_GoodTauCandidate;
-   bool thecandidate_is_infact_GoodElectronCandidate;
-   bool thecandidate_is_infact_GoodMuonCandidate;
-   bool thecandidate_needs_LikelihoodRatio_discrimination;
-   double theleadTk_signedipt_significance;
-   double theleadTk_signedip3D_significance;
-   double thesignedflightpath_significance;
-   double theTksEt_o_JetEt;
-   double theneutralE;
-   double theisolneutralE;
-   double theisolneutralEtsum;
-   int theneutralECALClus_number;
-   double theneutralECALClus_radius;
-   double theneutralE_o_TksEneutralE;
-   double theisolneutralE_o_TksEneutralE;
-   double theneutralE_ratio;
-   CLHEP::HepLorentzVector thealternatrecJet_HepLV;
-   double theECALEt_o_leadTkPt;
-   double theHCALEt_o_leadTkPt;
- };
+    // Eneutr.clus.,isol.band / Eneutr.clus.;
+    double neutralE_ratio() const { return (theneutralE_ratio); }  // NaN : neutralECALClus_number()=0;
+    void setneutralE_ratio(double x) { theneutralE_ratio = x; }
 
- DECLARE_EDM_REFS( CombinedTauTagInfo )
+    CLHEP::HepLorentzVector alternatrecJet_HepLV() const {
+      return (thealternatrecJet_HepLV);
+    }  // rec. pi+/- candidates + neutral ECAL clus. combined;
+    void setalternatrecJet_HepLV(CLHEP::HepLorentzVector x) { thealternatrecJet_HepLV = x; }
 
-}
+    // EtECAL*/Ptlead.tk        *using ECAL cell hits inside a DR cone around lead tk ECAL impact point direction;
+    double ECALEt_o_leadTkPt() const {
+      return (theECALEt_o_leadTkPt);
+    }  // NaN : failure when trying to find the lead. tk contact on ECAL surface point;
+    void setECALEt_o_leadTkPt(double x) { theECALEt_o_leadTkPt = x; }
 
-#endif // DataFormsts_BTauReco_CombinedTauTagInfo_h
+    // EtHCAL**/Ptlead.tk;      **using HCAL tower hits inside a DR cone around lead tk ECAL impact point direction;
+    double HCALEt_o_leadTkPt() const {
+      return (theHCALEt_o_leadTkPt);
+    }  // NaN : failure when trying to find the lead. tk contact on ECAL surface point;
+    void setHCALEt_o_leadTkPt(double x) { theHCALEt_o_leadTkPt = x; }
+
+  private:
+    IsolatedTauTagInfoRef IsolatedTauTagInfoRef_;
+    TrackRefVector filtered_Tks_;
+    TrackRefVector signal_Tks_;
+    TrackRefVector isol_Tks_;
+    bool thecandidate_passed_trackerselection;
+    bool thecandidate_is_GoodTauCandidate;
+    bool thecandidate_is_infact_GoodElectronCandidate;
+    bool thecandidate_is_infact_GoodMuonCandidate;
+    bool thecandidate_needs_LikelihoodRatio_discrimination;
+    double theleadTk_signedipt_significance;
+    double theleadTk_signedip3D_significance;
+    double thesignedflightpath_significance;
+    double theTksEt_o_JetEt;
+    double theneutralE;
+    double theisolneutralE;
+    double theisolneutralEtsum;
+    int theneutralECALClus_number;
+    double theneutralECALClus_radius;
+    double theneutralE_o_TksEneutralE;
+    double theisolneutralE_o_TksEneutralE;
+    double theneutralE_ratio;
+    CLHEP::HepLorentzVector thealternatrecJet_HepLV;
+    double theECALEt_o_leadTkPt;
+    double theHCALEt_o_leadTkPt;
+  };
+
+  DECLARE_EDM_REFS(CombinedTauTagInfo)
+
+}  // namespace reco
+
+#endif  // DataFormsts_BTauReco_CombinedTauTagInfo_h

--- a/DataFormats/BTauReco/interface/DeepBoostedJetFeatures.h
+++ b/DataFormats/BTauReco/interface/DeepBoostedJetFeatures.h
@@ -8,62 +8,55 @@
 
 namespace btagbtvdeep {
 
-class DeepBoostedJetFeatures {
+  class DeepBoostedJetFeatures {
+  public:
+    bool empty() const { return is_empty_; }
 
-public:
+    void add(const std::string& name) { feature_map_[name]; }
 
-  bool empty() const {
-    return is_empty_;
-  }
+    void reserve(const std::string& name, unsigned capacity) { feature_map_[name].reserve(capacity); }
 
-  void add(const std::string& name){
-    feature_map_[name];
-  }
-
-  void reserve(const std::string& name, unsigned capacity){
-    feature_map_[name].reserve(capacity);
-  }
-
-  void fill(const std::string& name, float value){
-    auto item = feature_map_.find(name);
-    if (item != feature_map_.end()){
-      item->second.push_back(value);
-      is_empty_ = false;
-    }else{
-      throw cms::Exception("InvalidArgument") << "[DeepBoostedJetFeatures::fill()] Feature " << name << " has not been registered";
-    }
-  }
-
-  void set(const std::string& name, const std::vector<float>& vec){
-    feature_map_[name] = vec;
-  }
-
-  void check_consistency(const std::vector<std::string> &names) const {
-    if (names.empty()) return;
-    const auto ref_len = get(names.front()).size();
-    for (unsigned i=1; i<names.size(); ++i){
-      if (get(names[i]).size() != ref_len){
-        throw cms::Exception("InvalidArgument") << "[DeepBoostedJetFeatures::check_consistency()] Inconsistent variable length "
-            << get(names[i]).size() << " for " << names[i] << ", should be " << ref_len;
+    void fill(const std::string& name, float value) {
+      auto item = feature_map_.find(name);
+      if (item != feature_map_.end()) {
+        item->second.push_back(value);
+        is_empty_ = false;
+      } else {
+        throw cms::Exception("InvalidArgument")
+            << "[DeepBoostedJetFeatures::fill()] Feature " << name << " has not been registered";
       }
     }
-  }
 
-  const std::vector<float>& get(const std::string& name) const {
-    auto item = feature_map_.find(name);
-    if (item != feature_map_.end()){
-      return item->second;
-    }else{
-      throw cms::Exception("InvalidArgument") << "[DeepBoostedJetFeatures::get()] Feature " << name << " does not exist!";
+    void set(const std::string& name, const std::vector<float>& vec) { feature_map_[name] = vec; }
+
+    void check_consistency(const std::vector<std::string>& names) const {
+      if (names.empty())
+        return;
+      const auto ref_len = get(names.front()).size();
+      for (unsigned i = 1; i < names.size(); ++i) {
+        if (get(names[i]).size() != ref_len) {
+          throw cms::Exception("InvalidArgument")
+              << "[DeepBoostedJetFeatures::check_consistency()] Inconsistent variable length " << get(names[i]).size()
+              << " for " << names[i] << ", should be " << ref_len;
+        }
+      }
     }
-  }
 
-private:
-  bool is_empty_ = true;
-  std::unordered_map<std::string, std::vector<float>> feature_map_;
+    const std::vector<float>& get(const std::string& name) const {
+      auto item = feature_map_.find(name);
+      if (item != feature_map_.end()) {
+        return item->second;
+      } else {
+        throw cms::Exception("InvalidArgument")
+            << "[DeepBoostedJetFeatures::get()] Feature " << name << " does not exist!";
+      }
+    }
 
-};
+  private:
+    bool is_empty_ = true;
+    std::unordered_map<std::string, std::vector<float>> feature_map_;
+  };
 
-}
+}  // namespace btagbtvdeep
 
-#endif // DataFormats_BTauReco_DeepBoostedJetFeatures_h
+#endif  // DataFormats_BTauReco_DeepBoostedJetFeatures_h

--- a/DataFormats/BTauReco/interface/DeepBoostedJetTagInfo.h
+++ b/DataFormats/BTauReco/interface/DeepBoostedJetTagInfo.h
@@ -6,10 +6,10 @@
 
 namespace reco {
 
-typedef  FeaturesTagInfo<btagbtvdeep::DeepBoostedJetFeatures> DeepBoostedJetTagInfo;
+  typedef FeaturesTagInfo<btagbtvdeep::DeepBoostedJetFeatures> DeepBoostedJetTagInfo;
 
-DECLARE_EDM_REFS( DeepBoostedJetTagInfo )
+  DECLARE_EDM_REFS(DeepBoostedJetTagInfo)
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_DeepBoostedJetTagInfo_h
+#endif  // DataFormats_BTauReco_DeepBoostedJetTagInfo_h

--- a/DataFormats/BTauReco/interface/DeepDoubleXFeatures.h
+++ b/DataFormats/BTauReco/interface/DeepDoubleXFeatures.h
@@ -10,17 +10,11 @@
 
 namespace btagbtvdeep {
 
-class DeepDoubleXFeatures {
-
+  class DeepDoubleXFeatures {
   public:
+    bool empty() const { return is_empty_; }
 
-    bool empty() const {
-      return is_empty_;
-    }  
-  
-    void filled(){
-      is_empty_ = false;
-    } 
+    void filled() { is_empty_ = false; }
 
     JetFeatures jet_features;
     BoostedDoubleSVTagInfoFeatures tag_info_features;
@@ -29,13 +23,12 @@ class DeepDoubleXFeatures {
 
     std::vector<ChargedCandidateFeatures> c_pf_features;
 
-    std::size_t npv; // used by deep flavour     
+    std::size_t npv;  // used by deep flavour
 
   private:
     bool is_empty_ = true;
+  };
 
-};    
+}  // namespace btagbtvdeep
 
-}  
-
-#endif //DataFormats_BTauReco_DeepDoubleXFeatures_h
+#endif  //DataFormats_BTauReco_DeepDoubleXFeatures_h

--- a/DataFormats/BTauReco/interface/DeepDoubleXTagInfo.h
+++ b/DataFormats/BTauReco/interface/DeepDoubleXTagInfo.h
@@ -6,10 +6,10 @@
 
 namespace reco {
 
-typedef  FeaturesTagInfo<btagbtvdeep::DeepDoubleXFeatures> DeepDoubleXTagInfo;
+  typedef FeaturesTagInfo<btagbtvdeep::DeepDoubleXFeatures> DeepDoubleXTagInfo;
 
-DECLARE_EDM_REFS( DeepDoubleXTagInfo )
+  DECLARE_EDM_REFS(DeepDoubleXTagInfo)
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_DeepDoubleXTagInfo_h
+#endif  // DataFormats_BTauReco_DeepDoubleXTagInfo_h

--- a/DataFormats/BTauReco/interface/DeepFlavourFeatures.h
+++ b/DataFormats/BTauReco/interface/DeepFlavourFeatures.h
@@ -12,24 +12,21 @@
 
 namespace btagbtvdeep {
 
-class DeepFlavourFeatures {
-
+  class DeepFlavourFeatures {
   public:
     JetFeatures jet_features;
     ShallowTagInfoFeatures tag_info_features;
-    
+
     std::vector<SecondaryVertexFeatures> sv_features;
 
     std::vector<NeutralCandidateFeatures> n_pf_features;
     std::vector<ChargedCandidateFeatures> c_pf_features;
-    
+
     std::vector<SeedingTrackFeatures> seed_features;
-     
-    std::size_t npv; // used by deep flavour
 
-};    
+    std::size_t npv;  // used by deep flavour
+  };
 
+}  // namespace btagbtvdeep
 
-}  
-
-#endif //DataFormats_BTauReco_DeepFlavourFeatures_h
+#endif  //DataFormats_BTauReco_DeepFlavourFeatures_h

--- a/DataFormats/BTauReco/interface/DeepFlavourTagInfo.h
+++ b/DataFormats/BTauReco/interface/DeepFlavourTagInfo.h
@@ -6,10 +6,10 @@
 
 namespace reco {
 
-typedef  FeaturesTagInfo<btagbtvdeep::DeepFlavourFeatures> DeepFlavourTagInfo;
+  typedef FeaturesTagInfo<btagbtvdeep::DeepFlavourFeatures> DeepFlavourTagInfo;
 
-DECLARE_EDM_REFS( DeepFlavourTagInfo )
+  DECLARE_EDM_REFS(DeepFlavourTagInfo)
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_DeepFlavourTagInfo_h
+#endif  // DataFormats_BTauReco_DeepFlavourTagInfo_h

--- a/DataFormats/BTauReco/interface/FeaturesTagInfo.h
+++ b/DataFormats/BTauReco/interface/FeaturesTagInfo.h
@@ -8,33 +8,29 @@
 
 namespace reco {
 
-template<class Features> class FeaturesTagInfo : public BaseTagInfo {
-
+  template <class Features>
+  class FeaturesTagInfo : public BaseTagInfo {
   public:
-
     FeaturesTagInfo() {}
 
-    FeaturesTagInfo(const Features & features,
-                    const  edm::RefToBase<Jet> & jet_ref) :
-      features_(features),
-      jet_ref_(jet_ref) {}
+    FeaturesTagInfo(const Features& features, const edm::RefToBase<Jet>& jet_ref)
+        : features_(features), jet_ref_(jet_ref) {}
 
     edm::RefToBase<Jet> jet() const override { return jet_ref_; }
 
-    const Features & features() const { return features_; }
+    const Features& features() const { return features_; }
 
     ~FeaturesTagInfo() override {}
     // without overidding clone from base class will be store/retrieved
     FeaturesTagInfo* clone(void) const override { return new FeaturesTagInfo(*this); }
-
 
     CMS_CLASS_VERSION(3)
 
   private:
     Features features_;
     edm::RefToBase<Jet> jet_ref_;
-};
+  };
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_FeaturesTagInfo_h
+#endif  // DataFormats_BTauReco_FeaturesTagInfo_h

--- a/DataFormats/BTauReco/interface/HTTTopJetTagInfo.h
+++ b/DataFormats/BTauReco/interface/HTTTopJetTagInfo.h
@@ -1,13 +1,12 @@
 #ifndef DataFormats_BTauReco_interface_HTTTopJetTagInfo_h
 #define DataFormats_BTauReco_interface_HTTTopJetTagInfo_h
 
-
 // \class HTTTopJetTagInfo
-// 
+//
 // \short specific tag info for HEPTopTagger tagging algorithm
 // HTTTopJetTagInfo is a class to hold the discriminator variables for the
 // HEPTopTagger algorithm.
-// 
+//
 //
 // \author Gregor Kasieczka (based on  CATopJetTagInfo by Salvatore Rappoccio)
 // \version first version on 25 Sep 2014
@@ -18,81 +17,79 @@
 #include <vector>
 
 namespace reco {
- 
-class HTTTopJetProperties {
-public:
-  HTTTopJetProperties() : fjPt(0.),
-    fjMass(0.),
-    fjEta(0.),
-    fjPhi(0.),
-    topMass(0.),
-    unfilteredMass(0.),
-    prunedMass(0.),
-    fRec(0.),
-    massRatioPassed(0.),
-    ropt(0.),
-    roptCalc(0.),
-    ptForRoptCalc(0.),
-    tau1Unfiltered(0.),
-    tau2Unfiltered(0.),
-    tau3Unfiltered(0.),
-    tau1Filtered(0.),
-    tau2Filtered(0.),
-    tau3Filtered(0.),
-    qWeight(0.),
-    qEpsilon(0.),
-    qSigmaM(0.) {}
 
-  double              fjPt;             //<! Mass of the inital Fatjet passed to the TT
-  double              fjMass;           //<! Mass of the inital Fatjet passed to the TT
-  double              fjEta;            //<! Mass of the inital Fatjet passed to the TT
-  double              fjPhi;            //<! Mass of the inital Fatjet passed to the TT
-  double              topMass;          //<! Mass of the HTT top quark candidate [GeV]
-  double              unfilteredMass;   //<! Unfiltered mass of the triplet [GeV]
-  double              prunedMass;       //<! Mass of the pruned fat jet [GeV]
-  double              fRec;             //<! Minimum distance of m_ij/m_123 from m_W/m_top
-  double              massRatioPassed;  //<! Did the candidate pass the default mass ratio? 
-  double              ropt;             //<! R_opt found in Optimal procedure. 
-  double              roptCalc;         //<! R_opt calc for a top quark based on filtered fat-jet pT.
-  double              ptForRoptCalc;    //<! Filtered initial fatjet pT calculation of Ropt 
-  double              tau1Unfiltered;   //<! 1-subjettiness, no filtering
-  double              tau2Unfiltered;   //<! 2-subjettiness, no filtering
-  double              tau3Unfiltered;   //<! 3-subjettiness, no filtering
-  double              tau1Filtered;     //<! 1-subjettiness, with filtering
-  double              tau2Filtered;     //<! 2-subjettiness, with filtering
-  double              tau3Filtered;     //<! 3-subjettiness, with filtering
-  double              qWeight;          //<! maximal weight of jet using Q-jet approach
-  double              qEpsilon;         //<! fraction of jets tagged with Q-jets
-  double              qSigmaM;          //<! Width of Q-jet mass distribution
-};
+  class HTTTopJetProperties {
+  public:
+    HTTTopJetProperties()
+        : fjPt(0.),
+          fjMass(0.),
+          fjEta(0.),
+          fjPhi(0.),
+          topMass(0.),
+          unfilteredMass(0.),
+          prunedMass(0.),
+          fRec(0.),
+          massRatioPassed(0.),
+          ropt(0.),
+          roptCalc(0.),
+          ptForRoptCalc(0.),
+          tau1Unfiltered(0.),
+          tau2Unfiltered(0.),
+          tau3Unfiltered(0.),
+          tau1Filtered(0.),
+          tau2Filtered(0.),
+          tau3Filtered(0.),
+          qWeight(0.),
+          qEpsilon(0.),
+          qSigmaM(0.) {}
 
- class HTTTopJetTagInfo : public JetTagInfo {
-public:
-  typedef edm::RefToBase<Jet> jet_type;
-  typedef HTTTopJetProperties  properties_type;
-    
+    double fjPt;             //<! Mass of the inital Fatjet passed to the TT
+    double fjMass;           //<! Mass of the inital Fatjet passed to the TT
+    double fjEta;            //<! Mass of the inital Fatjet passed to the TT
+    double fjPhi;            //<! Mass of the inital Fatjet passed to the TT
+    double topMass;          //<! Mass of the HTT top quark candidate [GeV]
+    double unfilteredMass;   //<! Unfiltered mass of the triplet [GeV]
+    double prunedMass;       //<! Mass of the pruned fat jet [GeV]
+    double fRec;             //<! Minimum distance of m_ij/m_123 from m_W/m_top
+    double massRatioPassed;  //<! Did the candidate pass the default mass ratio?
+    double ropt;             //<! R_opt found in Optimal procedure.
+    double roptCalc;         //<! R_opt calc for a top quark based on filtered fat-jet pT.
+    double ptForRoptCalc;    //<! Filtered initial fatjet pT calculation of Ropt
+    double tau1Unfiltered;   //<! 1-subjettiness, no filtering
+    double tau2Unfiltered;   //<! 2-subjettiness, no filtering
+    double tau3Unfiltered;   //<! 3-subjettiness, no filtering
+    double tau1Filtered;     //<! 1-subjettiness, with filtering
+    double tau2Filtered;     //<! 2-subjettiness, with filtering
+    double tau3Filtered;     //<! 3-subjettiness, with filtering
+    double qWeight;          //<! maximal weight of jet using Q-jet approach
+    double qEpsilon;         //<! fraction of jets tagged with Q-jets
+    double qSigmaM;          //<! Width of Q-jet mass distribution
+  };
+
+  class HTTTopJetTagInfo : public JetTagInfo {
+  public:
+    typedef edm::RefToBase<Jet> jet_type;
+    typedef HTTTopJetProperties properties_type;
+
     HTTTopJetTagInfo(void) {}
 
     ~HTTTopJetTagInfo(void) override {}
-  
-    HTTTopJetTagInfo* clone(void) const override { return new HTTTopJetTagInfo(*this); }
-    
-    const properties_type & properties() const {
-      return properties_;
-    }
 
-    void insert(const edm::RefToBase<Jet> & jet, const HTTTopJetProperties & properties) {
+    HTTTopJetTagInfo* clone(void) const override { return new HTTTopJetTagInfo(*this); }
+
+    const properties_type& properties() const { return properties_; }
+
+    void insert(const edm::RefToBase<Jet>& jet, const HTTTopJetProperties& properties) {
       setJetRef(jet);
       properties_ = properties;
     }
 
-protected:
+  protected:
     properties_type properties_;
+  };
 
-};
+  DECLARE_EDM_REFS(HTTTopJetTagInfo)
 
-DECLARE_EDM_REFS( HTTTopJetTagInfo )
+}  // namespace reco
 
-}
-
-#endif // AnalysisDataFormats_TopObjects_interface_HTTTopJetTagInfo_h
+#endif  // AnalysisDataFormats_TopObjects_interface_HTTTopJetTagInfo_h

--- a/DataFormats/BTauReco/interface/IPTagInfo.h
+++ b/DataFormats/BTauReco/interface/IPTagInfo.h
@@ -19,62 +19,62 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 namespace reco {
-namespace btag {
+  namespace btag {
 
-inline  const reco::Track * toTrack(const reco::TrackBaseRef & t) {return &(*t);}
-inline  const reco::Track * toTrack(const reco::TrackRef & t) {return &(*t);}
-inline  const reco::Track * toTrack(const reco::CandidatePtr & c) {return (*c).bestTrack();}
- 
-  struct TrackIPData {
-    GlobalPoint closestToJetAxis;
-    GlobalPoint closestToGhostTrack;
-    Measurement1D ip2d;
-    Measurement1D ip3d;
-    Measurement1D distanceToJetAxis;
-    Measurement1D distanceToGhostTrack;
-    float ghostTrackWeight;
-  };
-  struct variableJTAParameters {
-    double a_dR, b_dR, a_pT, b_pT;
-    double min_pT,  max_pT;
-    double min_pT_dRcut,  max_pT_dRcut;
-    double max_pT_trackPTcut;
-  };
-  enum SortCriteria { IP3DSig = 0, Prob3D, IP2DSig, Prob2D, 
-                      IP3DValue, IP2DValue };
+    inline const reco::Track* toTrack(const reco::TrackBaseRef& t) { return &(*t); }
+    inline const reco::Track* toTrack(const reco::TrackRef& t) { return &(*t); }
+    inline const reco::Track* toTrack(const reco::CandidatePtr& c) { return (*c).bestTrack(); }
 
-}
+    struct TrackIPData {
+      GlobalPoint closestToJetAxis;
+      GlobalPoint closestToGhostTrack;
+      Measurement1D ip2d;
+      Measurement1D ip3d;
+      Measurement1D distanceToJetAxis;
+      Measurement1D distanceToGhostTrack;
+      float ghostTrackWeight;
+    };
+    struct variableJTAParameters {
+      double a_dR, b_dR, a_pT, b_pT;
+      double min_pT, max_pT;
+      double min_pT_dRcut, max_pT_dRcut;
+      double max_pT_trackPTcut;
+    };
+    enum SortCriteria { IP3DSig = 0, Prob3D, IP2DSig, Prob2D, IP3DValue, IP2DValue };
 
+  }  // namespace btag
 
-
-template <class Container, class Base>
-class IPTagInfo : public Base {
-public:
+  template <class Container, class Base>
+  class IPTagInfo : public Base {
+  public:
     typedef Container input_container;
     typedef Base base_class;
 
-  IPTagInfo(
-    const std::vector<btag::TrackIPData> & ipData,
-    const std::vector<float> & prob2d,
-    const std::vector<float> & prob3d,
-    const Container & selected,
-    const Base & base,
-    const edm::Ref<VertexCollection> & pv,
-    const GlobalVector & axis,
-    const TrackRef & ghostTrack) :
-      Base(base), m_data(ipData),  m_prob2d(prob2d),
-      m_prob3d(prob3d), m_selected(selected), m_pv(pv),
-      m_axis(axis), m_ghostTrack(ghostTrack) {}
+    IPTagInfo(const std::vector<btag::TrackIPData>& ipData,
+              const std::vector<float>& prob2d,
+              const std::vector<float>& prob3d,
+              const Container& selected,
+              const Base& base,
+              const edm::Ref<VertexCollection>& pv,
+              const GlobalVector& axis,
+              const TrackRef& ghostTrack)
+        : Base(base),
+          m_data(ipData),
+          m_prob2d(prob2d),
+          m_prob3d(prob3d),
+          m_selected(selected),
+          m_pv(pv),
+          m_axis(axis),
+          m_ghostTrack(ghostTrack) {}
 
-  IPTagInfo() {}
-  
-  ~IPTagInfo() override {}
-  
-  /// clone
-  IPTagInfo * clone(void) const override
-  { return new IPTagInfo(*this); }
+    IPTagInfo() {}
 
- /**
+    ~IPTagInfo() override {}
+
+    /// clone
+    IPTagInfo* clone(void) const override { return new IPTagInfo(*this); }
+
+    /**
    Check if probability information is globally available 
    impact parameters in the collection
 
@@ -82,28 +82,25 @@ public:
    if some problem occured
   */
 
-  virtual bool hasProbabilities() const
-  { return m_data.size() == m_prob3d.size(); }
-  
-  /**
+    virtual bool hasProbabilities() const { return m_data.size() == m_prob3d.size(); }
+
+    /**
    Vectors of TrackIPData orderd as the selectedTracks()
    */
-  const std::vector<btag::TrackIPData> & impactParameterData() const
-  { return m_data; }
+    const std::vector<btag::TrackIPData>& impactParameterData() const { return m_data; }
 
-  /**
+    /**
    Return the vector of tracks for which the IP information is available
    Quality cuts are applied to reject fake tracks  
   */
-  const Container & selected() const { return m_selected; }
+    const Container& selected() const { return m_selected; }
 
-//legacy name for compatibility 
-  const Container & selectedTracks() const { return m_selected; }
-  
-  const std::vector<float> & probabilities(int ip) const {return (ip==0)?m_prob3d:m_prob2d; }
+    //legacy name for compatibility
+    const Container& selectedTracks() const { return m_selected; }
 
+    const std::vector<float>& probabilities(int ip) const { return (ip == 0) ? m_prob3d : m_prob2d; }
 
-  /**
+    /**
    Return the list of track index sorted by mode
    A cut can is specified to select only tracks with
    IP value or significance > cut 
@@ -111,225 +108,218 @@ public:
    probability < cut
    (according to the specified mode)
   */
-  std::vector<size_t> sortedIndexesWithCut(float cut, btag::SortCriteria mode = reco::btag::IP3DSig) const;
+    std::vector<size_t> sortedIndexesWithCut(float cut, btag::SortCriteria mode = reco::btag::IP3DSig) const;
 
-  /**
+    /**
    variable jet-to track association:
    returns vector of bool, indicating for each track whether it passed 
    the variable JTA.
   */
-  std::vector<bool> variableJTA(const btag::variableJTAParameters &params) const;
-  static bool passVariableJTA(const btag::variableJTAParameters &params, double jetpt, double trackpt, double jettrackdr) ;
+    std::vector<bool> variableJTA(const btag::variableJTAParameters& params) const;
+    static bool passVariableJTA(const btag::variableJTAParameters& params,
+                                double jetpt,
+                                double trackpt,
+                                double jettrackdr);
 
-  /**
+    /**
    Return the list of track index sorted by mode
-  */ 
-  std::vector<size_t> sortedIndexes(btag::SortCriteria mode = reco::btag::IP3DSig) const;
-  Container sorted(const std::vector<size_t>& indexes) const;
-  Container sortedTracks(const std::vector<size_t>& indexes) const {return sorted(indexes);}
+  */
+    std::vector<size_t> sortedIndexes(btag::SortCriteria mode = reco::btag::IP3DSig) const;
+    Container sorted(const std::vector<size_t>& indexes) const;
+    Container sortedTracks(const std::vector<size_t>& indexes) const { return sorted(indexes); }
 
-  TaggingVariableList taggingVariables(void) const override; 
- 
-  const edm::Ref<VertexCollection> & primaryVertex() const { return m_pv; }
+    TaggingVariableList taggingVariables(void) const override;
 
-  const GlobalVector & axis() const { return m_axis; }
-  const TrackRef & ghostTrack() const { return m_ghostTrack; }
- 
-  const Track * selectedTrack(size_t i) const {return reco::btag::toTrack(m_selected[i]);}
+    const edm::Ref<VertexCollection>& primaryVertex() const { return m_pv; }
 
-  // Used by ROOT storage
-  CMS_CLASS_VERSION(11)
+    const GlobalVector& axis() const { return m_axis; }
+    const TrackRef& ghostTrack() const { return m_ghostTrack; }
 
-private:
-  std::vector<btag::TrackIPData> m_data;
-  std::vector<float> m_prob2d;   
-  std::vector<float> m_prob3d;   
-  Container m_selected;
-  edm::Ref<VertexCollection> m_pv;
-  GlobalVector m_axis;
-  TrackRef m_ghostTrack;
-};
+    const Track* selectedTrack(size_t i) const { return reco::btag::toTrack(m_selected[i]); }
 
+    // Used by ROOT storage
+    CMS_CLASS_VERSION(11)
 
-//Explicit templates:
-//template <> const Track *IPTagInfo<TrackRefVector,JTATagInfo>::selectedTrack(size_t i) const {return &(*m_selected[i]);}
-//template <> const Track *IPTagInfo<std::vector<CandidatePtr>,BaseTagInfo>::selectedTrack(size_t i) const {return (*m_selected[i]).bestTrack();}
+  private:
+    std::vector<btag::TrackIPData> m_data;
+    std::vector<float> m_prob2d;
+    std::vector<float> m_prob3d;
+    Container m_selected;
+    edm::Ref<VertexCollection> m_pv;
+    GlobalVector m_axis;
+    TrackRef m_ghostTrack;
+  };
 
-template <class Container, class Base> TaggingVariableList IPTagInfo<Container,Base>::taggingVariables(void) const {
-  TaggingVariableList vars;
+  //Explicit templates:
+  //template <> const Track *IPTagInfo<TrackRefVector,JTATagInfo>::selectedTrack(size_t i) const {return &(*m_selected[i]);}
+  //template <> const Track *IPTagInfo<std::vector<CandidatePtr>,BaseTagInfo>::selectedTrack(size_t i) const {return (*m_selected[i]).bestTrack();}
 
-  math::XYZVector jetDir = Base::jet()->momentum().Unit();
-  bool havePv = primaryVertex().isNonnull();
-  GlobalPoint pv;
-  if (havePv)
-    pv = GlobalPoint(primaryVertex()->x(),
-                     primaryVertex()->y(),
-                     primaryVertex()->z());
+  template <class Container, class Base>
+  TaggingVariableList IPTagInfo<Container, Base>::taggingVariables(void) const {
+    TaggingVariableList vars;
 
-  std::vector<size_t> indexes = sortedIndexes(); // use default criterium
-  for(std::vector<size_t>::const_iterator it = indexes.begin();
-      it != indexes.end(); ++it)
-   {
-     using namespace ROOT::Math;
-     const Track * track = selectedTrack(*it);
-     const btag::TrackIPData *data = &m_data[*it];
-     const math::XYZVector& trackMom = track->momentum();
-     double trackMag = std::sqrt(trackMom.Mag2());
+    math::XYZVector jetDir = Base::jet()->momentum().Unit();
+    bool havePv = primaryVertex().isNonnull();
+    GlobalPoint pv;
+    if (havePv)
+      pv = GlobalPoint(primaryVertex()->x(), primaryVertex()->y(), primaryVertex()->z());
 
-     vars.insert(btau::trackMomentum, trackMag, true);
-     vars.insert(btau::trackEta, trackMom.Eta(), true);
-     vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir, trackMom), true);
-     vars.insert(btau::trackPtRel, VectorUtil::Perp(trackMom, jetDir), true);
-     vars.insert(btau::trackPPar, jetDir.Dot(trackMom), true);
-     vars.insert(btau::trackDeltaR, VectorUtil::DeltaR(trackMom, jetDir), true);
-     vars.insert(btau::trackPtRatio, VectorUtil::Perp(trackMom, jetDir) / trackMag, true);
-     vars.insert(btau::trackPParRatio, jetDir.Dot(trackMom) / trackMag, true);
-     vars.insert(btau::trackSip3dVal, data->ip3d.value(), true);
-     vars.insert(btau::trackSip3dSig, data->ip3d.significance(), true);
-     vars.insert(btau::trackSip2dVal, data->ip2d.value(), true);
-     vars.insert(btau::trackSip2dSig, data->ip2d.significance(), true);
-     vars.insert(btau::trackDecayLenVal, havePv ? (data->closestToJetAxis - pv).mag() : -1.0, true);
-     vars.insert(btau::trackJetDistVal, data->distanceToJetAxis.value(), true);
-     vars.insert(btau::trackJetDistSig, data->distanceToJetAxis.significance(), true);
-     vars.insert(btau::trackGhostTrackDistVal, data->distanceToGhostTrack.value(), true);
-     vars.insert(btau::trackGhostTrackDistSig, data->distanceToGhostTrack.significance(), true);
-     vars.insert(btau::trackGhostTrackWeight, data->ghostTrackWeight, true);
-     vars.insert(btau::trackChi2, track->normalizedChi2(), true);
-     vars.insert(btau::trackNTotalHits, track->hitPattern().numberOfValidHits(), true);
-     vars.insert(btau::trackNPixelHits, track->hitPattern().numberOfValidPixelHits(), true);
-   } 
-  vars.finalize();
-  return vars;
-}
+    std::vector<size_t> indexes = sortedIndexes();  // use default criterium
+    for (std::vector<size_t>::const_iterator it = indexes.begin(); it != indexes.end(); ++it) {
+      using namespace ROOT::Math;
+      const Track* track = selectedTrack(*it);
+      const btag::TrackIPData* data = &m_data[*it];
+      const math::XYZVector& trackMom = track->momentum();
+      double trackMag = std::sqrt(trackMom.Mag2());
 
-template<class Container, class Base> Container IPTagInfo<Container,Base>::sorted(const std::vector<size_t>& indexes) const
-{
- Container tr;
- for(size_t i =0 ; i < indexes.size(); i++) tr.push_back(m_selected[indexes[i]]);
- return tr;
-}
-
-template<class Container, class Base> std::vector<bool> IPTagInfo<Container,Base>::variableJTA(const btag::variableJTAParameters &params) const{
-  
-  std::vector<bool> result;
-
-  //Jet parameters
-  double jetpT = Base::jet()->pt();
-  math::XYZVector jetDir = Base::jet()->momentum().Unit();
-
-  for(size_t  i = 0 ; i<  m_selected.size();  i++) {
-    
-    //Track parameters
-    const Track * track =  selectedTrack(i);    
-    double trackpT = track->pt();
-    const math::XYZVector& trackMom = track->momentum();
-
-    // do the math in passVariableJTA
-    result.push_back(passVariableJTA( params, jetpT, trackpT, ROOT::Math::VectorUtil::DeltaR(trackMom, jetDir)));
-
-  }  
-  
-  return result;
-}
-
-
-
-
-template<class Container, class Base> std::vector<size_t> IPTagInfo<Container,Base>::sortedIndexes(btag::SortCriteria mode) const
-{
- using namespace reco::btag;
- float cut=-1e99;
- if((mode == Prob3D || mode == Prob2D)) cut=1e99;
- return sortedIndexesWithCut(cut,mode);
-}
-
-template<class Container, class Base> std::vector<size_t> IPTagInfo<Container,Base>::sortedIndexesWithCut(float cut, btag::SortCriteria mode) const
-{
- std::multimap<float,size_t> sortedIdx;
- size_t nSelectedTracks = m_selected.size();
- std::vector<size_t> result;
- using namespace reco::btag;
- 
-//check if probabilities are available
- if((mode == Prob3D || mode == Prob2D) && ! hasProbabilities()) 
-  {
-   return result;
+      vars.insert(btau::trackMomentum, trackMag, true);
+      vars.insert(btau::trackEta, trackMom.Eta(), true);
+      vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir, trackMom), true);
+      vars.insert(btau::trackPtRel, VectorUtil::Perp(trackMom, jetDir), true);
+      vars.insert(btau::trackPPar, jetDir.Dot(trackMom), true);
+      vars.insert(btau::trackDeltaR, VectorUtil::DeltaR(trackMom, jetDir), true);
+      vars.insert(btau::trackPtRatio, VectorUtil::Perp(trackMom, jetDir) / trackMag, true);
+      vars.insert(btau::trackPParRatio, jetDir.Dot(trackMom) / trackMag, true);
+      vars.insert(btau::trackSip3dVal, data->ip3d.value(), true);
+      vars.insert(btau::trackSip3dSig, data->ip3d.significance(), true);
+      vars.insert(btau::trackSip2dVal, data->ip2d.value(), true);
+      vars.insert(btau::trackSip2dSig, data->ip2d.significance(), true);
+      vars.insert(btau::trackDecayLenVal, havePv ? (data->closestToJetAxis - pv).mag() : -1.0, true);
+      vars.insert(btau::trackJetDistVal, data->distanceToJetAxis.value(), true);
+      vars.insert(btau::trackJetDistSig, data->distanceToJetAxis.significance(), true);
+      vars.insert(btau::trackGhostTrackDistVal, data->distanceToGhostTrack.value(), true);
+      vars.insert(btau::trackGhostTrackDistSig, data->distanceToGhostTrack.significance(), true);
+      vars.insert(btau::trackGhostTrackWeight, data->ghostTrackWeight, true);
+      vars.insert(btau::trackChi2, track->normalizedChi2(), true);
+      vars.insert(btau::trackNTotalHits, track->hitPattern().numberOfValidHits(), true);
+      vars.insert(btau::trackNPixelHits, track->hitPattern().numberOfValidPixelHits(), true);
+    }
+    vars.finalize();
+    return vars;
   }
 
- for(size_t i=0;i<nSelectedTracks;i++) 
-  {
-     float sortingKey;
-     switch(mode)
-     {
-      case IP3DSig:
-           sortingKey=m_data[i].ip3d.significance();
-           break;
-      case IP2DSig:
-           sortingKey=m_data[i].ip2d.significance();
-           break;
-      case IP3DValue:
-           sortingKey=m_data[i].ip3d.value();
-           break;
-      case IP2DValue:
-           sortingKey=m_data[i].ip2d.value();
-           break;
-      case Prob3D:
-           sortingKey=m_prob3d[i];
-           break;
-      case Prob2D:
-           sortingKey=m_prob2d[i];
-           break;
-
-      default:
-       sortingKey=i;
-     }   
-     sortedIdx.insert(std::pair<float,size_t>(sortingKey,i));
+  template <class Container, class Base>
+  Container IPTagInfo<Container, Base>::sorted(const std::vector<size_t>& indexes) const {
+    Container tr;
+    for (size_t i = 0; i < indexes.size(); i++)
+      tr.push_back(m_selected[indexes[i]]);
+    return tr;
   }
 
-//Descending: 
-if(mode == IP3DSig || mode == IP2DSig ||mode ==  IP3DValue || mode == IP2DValue)
- { 
-   for(std::multimap<float,size_t>::reverse_iterator it = sortedIdx.rbegin(); it!=sortedIdx.rend(); it++)
-    if(it->first >= cut) result.push_back(it->second);
- } else
-//Ascending:
- {
-  for(std::multimap<float,size_t>::iterator it = sortedIdx.begin(); it!=sortedIdx.end(); it++)
-    if(it->first <= cut) result.push_back(it->second);
- }
- return result;
-}
+  template <class Container, class Base>
+  std::vector<bool> IPTagInfo<Container, Base>::variableJTA(const btag::variableJTAParameters& params) const {
+    std::vector<bool> result;
 
-template<class Container, class Base> bool IPTagInfo<Container,Base>::passVariableJTA(const btag::variableJTAParameters &params, double jetpT, double trackpT, double jettrackdR) {
+    //Jet parameters
+    double jetpT = Base::jet()->pt();
+    math::XYZVector jetDir = Base::jet()->momentum().Unit();
 
-  bool pass = false;
+    for (size_t i = 0; i < m_selected.size(); i++) {
+      //Track parameters
+      const Track* track = selectedTrack(i);
+      double trackpT = track->pt();
+      const math::XYZVector& trackMom = track->momentum();
 
-  // intermediate pt range (between min_pT and max_pT), apply variable JTA !
-  if ( jetpT > params.min_pT && jetpT < params.max_pT ) {
-    double deltaRfunction_highpt = -jetpT * params.a_dR + params.b_dR;
-    double ptfunction_highpt = jetpT * params.a_pT + params.b_pT;
-    
-    if (jettrackdR < deltaRfunction_highpt
-	&&
-	trackpT > ptfunction_highpt) 
-      pass = true;
-    
-    //  cout << "IPTagInfo: passVariableJTA: dR and TrackpT " << jettrackdR << " " << trackpT << endl;
-    
-    //high pt range, apply fixed default cuts
-  }else if (jetpT > params.max_pT ) {
-    if (jettrackdR < params.max_pT_dRcut
-	&&
-	trackpT > params.max_pT_trackPTcut)
-      pass = true;
+      // do the math in passVariableJTA
+      result.push_back(passVariableJTA(params, jetpT, trackpT, ROOT::Math::VectorUtil::DeltaR(trackMom, jetDir)));
+    }
 
-    // low pt range, apply fixed default cuts
-  }else {
-    if (jettrackdR < params.min_pT_dRcut)
-      pass = true;
+    return result;
   }
-  
-  return pass;
-}
-}
+
+  template <class Container, class Base>
+  std::vector<size_t> IPTagInfo<Container, Base>::sortedIndexes(btag::SortCriteria mode) const {
+    using namespace reco::btag;
+    float cut = -1e99;
+    if ((mode == Prob3D || mode == Prob2D))
+      cut = 1e99;
+    return sortedIndexesWithCut(cut, mode);
+  }
+
+  template <class Container, class Base>
+  std::vector<size_t> IPTagInfo<Container, Base>::sortedIndexesWithCut(float cut, btag::SortCriteria mode) const {
+    std::multimap<float, size_t> sortedIdx;
+    size_t nSelectedTracks = m_selected.size();
+    std::vector<size_t> result;
+    using namespace reco::btag;
+
+    //check if probabilities are available
+    if ((mode == Prob3D || mode == Prob2D) && !hasProbabilities()) {
+      return result;
+    }
+
+    for (size_t i = 0; i < nSelectedTracks; i++) {
+      float sortingKey;
+      switch (mode) {
+        case IP3DSig:
+          sortingKey = m_data[i].ip3d.significance();
+          break;
+        case IP2DSig:
+          sortingKey = m_data[i].ip2d.significance();
+          break;
+        case IP3DValue:
+          sortingKey = m_data[i].ip3d.value();
+          break;
+        case IP2DValue:
+          sortingKey = m_data[i].ip2d.value();
+          break;
+        case Prob3D:
+          sortingKey = m_prob3d[i];
+          break;
+        case Prob2D:
+          sortingKey = m_prob2d[i];
+          break;
+
+        default:
+          sortingKey = i;
+      }
+      sortedIdx.insert(std::pair<float, size_t>(sortingKey, i));
+    }
+
+    //Descending:
+    if (mode == IP3DSig || mode == IP2DSig || mode == IP3DValue || mode == IP2DValue) {
+      for (std::multimap<float, size_t>::reverse_iterator it = sortedIdx.rbegin(); it != sortedIdx.rend(); it++)
+        if (it->first >= cut)
+          result.push_back(it->second);
+    } else
+    //Ascending:
+    {
+      for (std::multimap<float, size_t>::iterator it = sortedIdx.begin(); it != sortedIdx.end(); it++)
+        if (it->first <= cut)
+          result.push_back(it->second);
+    }
+    return result;
+  }
+
+  template <class Container, class Base>
+  bool IPTagInfo<Container, Base>::passVariableJTA(const btag::variableJTAParameters& params,
+                                                   double jetpT,
+                                                   double trackpT,
+                                                   double jettrackdR) {
+    bool pass = false;
+
+    // intermediate pt range (between min_pT and max_pT), apply variable JTA !
+    if (jetpT > params.min_pT && jetpT < params.max_pT) {
+      double deltaRfunction_highpt = -jetpT * params.a_dR + params.b_dR;
+      double ptfunction_highpt = jetpT * params.a_pT + params.b_pT;
+
+      if (jettrackdR < deltaRfunction_highpt && trackpT > ptfunction_highpt)
+        pass = true;
+
+      //  cout << "IPTagInfo: passVariableJTA: dR and TrackpT " << jettrackdR << " " << trackpT << endl;
+
+      //high pt range, apply fixed default cuts
+    } else if (jetpT > params.max_pT) {
+      if (jettrackdR < params.max_pT_dRcut && trackpT > params.max_pT_trackPTcut)
+        pass = true;
+
+      // low pt range, apply fixed default cuts
+    } else {
+      if (jettrackdR < params.min_pT_dRcut)
+        pass = true;
+    }
+
+    return pass;
+  }
+}  // namespace reco
 #endif

--- a/DataFormats/BTauReco/interface/IsolatedTauTagInfo.h
+++ b/DataFormats/BTauReco/interface/IsolatedTauTagInfo.h
@@ -4,7 +4,7 @@
 //
 // \class IsolatedTauTagInfo
 // \short Extended object for the Tau Isolation algorithm.
-// contains the result and the methods used in the ConeIsolation Algorithm, to create the 
+// contains the result and the methods used in the ConeIsolation Algorithm, to create the
 // object to be made persistent on RECO
 //
 // \author: Simone Gennai, based on ORCA class by S. Gennai and F. Moortgat
@@ -15,64 +15,85 @@
 #include "DataFormats/BTauReco/interface/JTATagInfo.h"
 #include "DataFormats/JetReco/interface/JetTracksAssociation.h"
 
-namespace reco { 
+namespace reco {
 
   class IsolatedTauTagInfo : public JTATagInfo {
   public:
     //default constructor
-    IsolatedTauTagInfo( void ) : 
-      JTATagInfo(),
-	selectedTracks_()
-	
-    { 
-    }
+    IsolatedTauTagInfo(void)
+        : JTATagInfo(),
+          selectedTracks_()
 
-    IsolatedTauTagInfo( const TrackRefVector & tracks, const JetTracksAssociationRef & jtaRef ) :
-      JTATagInfo(jtaRef),
-      selectedTracks_(tracks)
-    { }   
+    {}
+
+    IsolatedTauTagInfo(const TrackRefVector& tracks, const JetTracksAssociationRef& jtaRef)
+        : JTATagInfo(jtaRef), selectedTracks_(tracks) {}
 
     //destructor
     ~IsolatedTauTagInfo() override {}
-    
+
     //get the tracks from the jetTag
     const TrackRefVector allTracks() const { return tracks(); }
 
     //get the selected tracks used to computed the isolation
-    const TrackRefVector  selectedTracks() const {return selectedTracks_;}
-    
-    IsolatedTauTagInfo* clone() const override { return new IsolatedTauTagInfo( *this ); }
-  
+    const TrackRefVector selectedTracks() const { return selectedTracks_; }
+
+    IsolatedTauTagInfo* clone() const override { return new IsolatedTauTagInfo(*this); }
+
     // default discriminator: returns the value of the discriminator of the jet tag, i.e. the one computed with the parameters taken from the cfg file
     float discriminator() const { return m_discriminator; }
     //set discriminator value
-     void setDiscriminator(double discriminator) { m_discriminator = discriminator; }
+    void setDiscriminator(double discriminator) { m_discriminator = discriminator; }
 
     // methods to be used to recomputed the isolation with a new set of parameters
-    float discriminator( float m_cone, float sig_cone, float iso_con, float pt_min_lt, float pt_min_tk, int nTracksIsoRing = 0) const;
-    float discriminator( const math::XYZVector& myVector, float m_cone, float sig_cone, float iso_con, float pt_min_lt, float pt_min_tk, int nTracksIsoRing) const;
+    float discriminator(
+        float m_cone, float sig_cone, float iso_con, float pt_min_lt, float pt_min_tk, int nTracksIsoRing = 0) const;
+    float discriminator(const math::XYZVector& myVector,
+                        float m_cone,
+                        float sig_cone,
+                        float iso_con,
+                        float pt_min_lt,
+                        float pt_min_tk,
+                        int nTracksIsoRing) const;
     // Used in case the PV is not considered
-    float discriminator( float m_cone, float sig_cone, float iso_con, float pt_min_lt, float pt_min_tk, int nTracksIsoRing, float dz_lt) const;
-    float discriminator( const math::XYZVector& myVector, float m_cone, float sig_cone, float iso_con, float pt_min_lt, float pt_min_tk, int nTracksIsoRing, float dz_lt) const;
-    
-    // return all tracks in a cone of size "size" around a direction "direction" 
-    const TrackRefVector tracksInCone(const math::XYZVector& myVector, const float size, const float pt_min ) const;
-    const TrackRefVector tracksInCone(const math::XYZVector& myVector, const float size, const float pt_min, const float z_pv, const float dz_lt ) const;
-    
+    float discriminator(float m_cone,
+                        float sig_cone,
+                        float iso_con,
+                        float pt_min_lt,
+                        float pt_min_tk,
+                        int nTracksIsoRing,
+                        float dz_lt) const;
+    float discriminator(const math::XYZVector& myVector,
+                        float m_cone,
+                        float sig_cone,
+                        float iso_con,
+                        float pt_min_lt,
+                        float pt_min_tk,
+                        int nTracksIsoRing,
+                        float dz_lt) const;
+
+    // return all tracks in a cone of size "size" around a direction "direction"
+    const TrackRefVector tracksInCone(const math::XYZVector& myVector, const float size, const float pt_min) const;
+    const TrackRefVector tracksInCone(const math::XYZVector& myVector,
+                                      const float size,
+                                      const float pt_min,
+                                      const float z_pv,
+                                      const float dz_lt) const;
+
     // return the leading track in a given cone around the jet axis or a given direction
-    void setLeadingTrack(const TrackRef) ; 
+    void setLeadingTrack(const TrackRef);
     const TrackRef leadingSignalTrack() const;
-    const TrackRef  leadingSignalTrack(const float rm_cone, const float pt_min) const;
-    const TrackRef  leadingSignalTrack(const math::XYZVector& myVector, const float rm_cone, const float pt_min) const;
-     
+    const TrackRef leadingSignalTrack(const float rm_cone, const float pt_min) const;
+    const TrackRef leadingSignalTrack(const math::XYZVector& myVector, const float rm_cone, const float pt_min) const;
+
   private:
     double m_discriminator;
     TrackRefVector selectedTracks_;
     TrackRef leadTrack_;
   };
 
-  DECLARE_EDM_REFS( IsolatedTauTagInfo )
+  DECLARE_EDM_REFS(IsolatedTauTagInfo)
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_IsolatedTauTagInfo_h
+#endif  // DataFormats_BTauReco_IsolatedTauTagInfo_h

--- a/DataFormats/BTauReco/interface/JTATagInfo.h
+++ b/DataFormats/BTauReco/interface/JTATagInfo.h
@@ -6,31 +6,30 @@
 #include "DataFormats/JetReco/interface/JetTracksAssociation.h"
 
 namespace reco {
- 
-class JTATagInfo : public BaseTagInfo {
-public:
-  
-  JTATagInfo(void) : m_jetTracksAssociation() { }
-  JTATagInfo(const JetTracksAssociationRef & jtaRef) : m_jetTracksAssociation(jtaRef) { }
 
-  ~JTATagInfo(void) override { }
-  
-  JTATagInfo* clone(void) const override { return new JTATagInfo(*this); }
+  class JTATagInfo : public BaseTagInfo {
+  public:
+    JTATagInfo(void) : m_jetTracksAssociation() {}
+    JTATagInfo(const JetTracksAssociationRef& jtaRef) : m_jetTracksAssociation(jtaRef) {}
 
-  edm::RefToBase<Jet>     jet(void)    const override { return m_jetTracksAssociation->first ; }
-  TrackRefVector          tracks(void) const override { return m_jetTracksAssociation->second; }
-  const JetTracksAssociationRef & jtaRef(void) const { return m_jetTracksAssociation; }
+    ~JTATagInfo(void) override {}
 
-  bool hasTracks(void) const override { return true; }
-  
-  void setJTARef(const JetTracksAssociationRef & jtaRef) { m_jetTracksAssociation = jtaRef; } 
-  
-protected:
-  JetTracksAssociationRef m_jetTracksAssociation;
-};
+    JTATagInfo* clone(void) const override { return new JTATagInfo(*this); }
 
-DECLARE_EDM_REFS( JTATagInfo )
+    edm::RefToBase<Jet> jet(void) const override { return m_jetTracksAssociation->first; }
+    TrackRefVector tracks(void) const override { return m_jetTracksAssociation->second; }
+    const JetTracksAssociationRef& jtaRef(void) const { return m_jetTracksAssociation; }
 
-}
+    bool hasTracks(void) const override { return true; }
 
-#endif // DataFormats_BTauReco_JTATagInfo_h
+    void setJTARef(const JetTracksAssociationRef& jtaRef) { m_jetTracksAssociation = jtaRef; }
+
+  protected:
+    JetTracksAssociationRef m_jetTracksAssociation;
+  };
+
+  DECLARE_EDM_REFS(JTATagInfo)
+
+}  // namespace reco
+
+#endif  // DataFormats_BTauReco_JTATagInfo_h

--- a/DataFormats/BTauReco/interface/JetEisolAssociation.h
+++ b/DataFormats/BTauReco/interface/JetEisolAssociation.h
@@ -1,9 +1,9 @@
 #ifndef BTauReco_JetEisolAssociation_h
 #define BTauReco_JetEisolAssociation_h
 // \class JetEisolAssociation
-// 
+//
 // \short association of tracks to jet (was JetWithEisol)
-// 
+//
 //
 
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
@@ -13,23 +13,16 @@
 #include <vector>
 
 namespace reco {
-  typedef 
-  std::vector<std::pair<edm::RefToBase<Jet>, float>  >
-    JetEisolAssociationCollection;
-    
-  typedef
-  JetEisolAssociationCollection::value_type JetEisolAssociation;
-  
-  typedef
-  edm::Ref<JetEisolAssociationCollection> JetEisolAssociationRef;
+  typedef std::vector<std::pair<edm::RefToBase<Jet>, float> > JetEisolAssociationCollection;
 
-  typedef
-  edm::FwdRef<JetEisolAssociationCollection> JetEisolAssociationFwdRef;
-  
-  typedef
-  edm::RefProd<JetEisolAssociationCollection> JetEisolAssociationRefProd;
-  
-  typedef
-  edm::RefVector<JetEisolAssociationCollection> JetEisolAssociationRefVector; 
-}
+  typedef JetEisolAssociationCollection::value_type JetEisolAssociation;
+
+  typedef edm::Ref<JetEisolAssociationCollection> JetEisolAssociationRef;
+
+  typedef edm::FwdRef<JetEisolAssociationCollection> JetEisolAssociationFwdRef;
+
+  typedef edm::RefProd<JetEisolAssociationCollection> JetEisolAssociationRefProd;
+
+  typedef edm::RefVector<JetEisolAssociationCollection> JetEisolAssociationRefVector;
+}  // namespace reco
 #endif

--- a/DataFormats/BTauReco/interface/JetFeatures.h
+++ b/DataFormats/BTauReco/interface/JetFeatures.h
@@ -3,18 +3,15 @@
 
 namespace btagbtvdeep {
 
-class JetFeatures {
-
+  class JetFeatures {
   public:
-
     float pt;
     float eta;
     float phi;
     float mass;
     float energy;
+  };
 
-};
+}  // namespace btagbtvdeep
 
-}
-
-#endif //DataFormats_BTauReco_JetFeatures_h
+#endif  //DataFormats_BTauReco_JetFeatures_h

--- a/DataFormats/BTauReco/interface/JetTag.h
+++ b/DataFormats/BTauReco/interface/JetTag.h
@@ -1,22 +1,21 @@
 #ifndef DataFormats_BTauReco_JetTag_h
 #define DataFormats_BTauReco_JetTag_h
 // \class JetTag
-// 
-// \short base class for persistent tagging result 
+//
+// \short base class for persistent tagging result
 // JetTag is a simple class with a reference to a jet, it's extended tagging niformations, and a tagging discriminant
-// 
+//
 //
 // \author Marcel Vos, Andrea Rizzi, Andrea Bocci based on ORCA version by Christian Weiser, Andrea Rizzi
 // \version first version on January 12, 2006
-
 
 #include "DataFormats/JetReco/interface/JetFloatAssociation.h"
 
 namespace reco {
 
-typedef JetFloatAssociation::value_type JetTag;
-typedef JetFloatAssociation::Container JetTagCollection;
+  typedef JetFloatAssociation::value_type JetTag;
+  typedef JetFloatAssociation::Container JetTagCollection;
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_JetTag_h
+#endif  // DataFormats_BTauReco_JetTag_h

--- a/DataFormats/BTauReco/interface/JetTagInfo.h
+++ b/DataFormats/BTauReco/interface/JetTagInfo.h
@@ -5,33 +5,35 @@
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 
 namespace reco {
- 
-class JetTagInfo : public BaseTagInfo {
-public:
-  JetTagInfo(void) : m_jet() { }
 
-  template <typename T>
-  JetTagInfo(const edm::Ref<T> & jetRef) : m_jet(jetRef) { }
+  class JetTagInfo : public BaseTagInfo {
+  public:
+    JetTagInfo(void) : m_jet() {}
 
-  JetTagInfo(const edm::RefToBase<Jet> & jetRef) : m_jet(jetRef) { }
+    template <typename T>
+    JetTagInfo(const edm::Ref<T>& jetRef) : m_jet(jetRef) {}
 
-  ~JetTagInfo(void) override { }
-  
-  JetTagInfo* clone(void) const override { return new JetTagInfo(*this); }
+    JetTagInfo(const edm::RefToBase<Jet>& jetRef) : m_jet(jetRef) {}
 
-  edm::RefToBase<Jet> jet(void) const override { return m_jet; }
-  
-  template <typename T>
-  void setJetRef(const edm::Ref<T> & jetRef) { m_jet = edm::RefToBase<Jet>( jetRef ); } 
- 
-  void setJetRef(const edm::RefToBase<Jet> & jetRef) { m_jet = edm::RefToBase<Jet>( jetRef ); } 
+    ~JetTagInfo(void) override {}
 
-protected:
-  edm::RefToBase<Jet> m_jet;
-};
+    JetTagInfo* clone(void) const override { return new JetTagInfo(*this); }
 
-DECLARE_EDM_REFS( JetTagInfo )
+    edm::RefToBase<Jet> jet(void) const override { return m_jet; }
 
-}
+    template <typename T>
+    void setJetRef(const edm::Ref<T>& jetRef) {
+      m_jet = edm::RefToBase<Jet>(jetRef);
+    }
 
-#endif // DataFormats_BTauReco_JetTagInfo_h
+    void setJetRef(const edm::RefToBase<Jet>& jetRef) { m_jet = edm::RefToBase<Jet>(jetRef); }
+
+  protected:
+    edm::RefToBase<Jet> m_jet;
+  };
+
+  DECLARE_EDM_REFS(JetTagInfo)
+
+}  // namespace reco
+
+#endif  // DataFormats_BTauReco_JetTagInfo_h

--- a/DataFormats/BTauReco/interface/NeutralCandidateFeatures.h
+++ b/DataFormats/BTauReco/interface/NeutralCandidateFeatures.h
@@ -3,10 +3,8 @@
 
 namespace btagbtvdeep {
 
-class NeutralCandidateFeatures {
-
+  class NeutralCandidateFeatures {
   public:
-
     float ptrel;
 
     float puppiw;
@@ -15,9 +13,8 @@ class NeutralCandidateFeatures {
 
     float hadFrac;
     float drminsv;
+  };
 
-};
+}  // namespace btagbtvdeep
 
-}
-
-#endif //DataFormats_BTauReco_NeutralCandidateFeatures_h
+#endif  //DataFormats_BTauReco_NeutralCandidateFeatures_h

--- a/DataFormats/BTauReco/interface/ParticleMasses.h
+++ b/DataFormats/BTauReco/interface/ParticleMasses.h
@@ -3,12 +3,12 @@
 
 namespace reco {
 
-namespace ParticleMasses {
-	const double k0     = 0.497648;
-	const double kPlus  = 0.493677;
-	const double piPlus = 0.13957;
-}
+  namespace ParticleMasses {
+    const double k0 = 0.497648;
+    const double kPlus = 0.493677;
+    const double piPlus = 0.13957;
+  }  // namespace ParticleMasses
 
-} // namespace reco
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_ParticleMasses_h
+#endif  // DataFormats_BTauReco_ParticleMasses_h

--- a/DataFormats/BTauReco/interface/RefMacros.h
+++ b/DataFormats/BTauReco/interface/RefMacros.h
@@ -7,11 +7,11 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
 
-#define DECLARE_EDM_REFS( class_name )                                          \
-  typedef std::vector< class_name > class_name ## Collection;                   \
-  typedef edm::Ref< class_name ## Collection>       class_name ## Ref;          \
-  typedef edm::FwdRef< class_name ## Collection>       class_name ## FwdRef;    \
-  typedef edm::RefProd< class_name ## Collection>   class_name ## RefProd;      \
-  typedef edm::RefVector< class_name ## Collection> class_name ## RefVector;
-      
-#endif // RefMacros_h
+#define DECLARE_EDM_REFS(class_name)                                \
+  typedef std::vector<class_name> class_name##Collection;           \
+  typedef edm::Ref<class_name##Collection> class_name##Ref;         \
+  typedef edm::FwdRef<class_name##Collection> class_name##FwdRef;   \
+  typedef edm::RefProd<class_name##Collection> class_name##RefProd; \
+  typedef edm::RefVector<class_name##Collection> class_name##RefVector;
+
+#endif  // RefMacros_h

--- a/DataFormats/BTauReco/interface/SecondaryVertexFeatures.h
+++ b/DataFormats/BTauReco/interface/SecondaryVertexFeatures.h
@@ -3,10 +3,8 @@
 
 namespace btagbtvdeep {
 
-class SecondaryVertexFeatures {
-
+  class SecondaryVertexFeatures {
   public:
-
     float pt;
     float mass;
 
@@ -19,12 +17,11 @@ class SecondaryVertexFeatures {
     float dxysig;
     float d3d;
     float d3dsig;
-    
+
     float costhetasvpv;
     float enratio;
+  };
 
-};
+}  // namespace btagbtvdeep
 
-}
-
-#endif //DataFormats_BTauReco_SecondaryVertexFeatures_h
+#endif  //DataFormats_BTauReco_SecondaryVertexFeatures_h

--- a/DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h
+++ b/DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h
@@ -6,10 +6,9 @@
 
 namespace reco {
 
-typedef reco::TemplatedSecondaryVertexTagInfo<reco::TrackIPTagInfo,reco::Vertex> SecondaryVertexTagInfo;
+  typedef reco::TemplatedSecondaryVertexTagInfo<reco::TrackIPTagInfo, reco::Vertex> SecondaryVertexTagInfo;
 
+  DECLARE_EDM_REFS(SecondaryVertexTagInfo)
 
-DECLARE_EDM_REFS(SecondaryVertexTagInfo)
-
-}
-#endif // DataFormats_BTauReco_SecondaryVertexTagInfo_h
+}  // namespace reco
+#endif  // DataFormats_BTauReco_SecondaryVertexTagInfo_h

--- a/DataFormats/BTauReco/interface/SeedingTrackFeatures.h
+++ b/DataFormats/BTauReco/interface/SeedingTrackFeatures.h
@@ -6,24 +6,22 @@
 
 namespace btagbtvdeep {
 
-class SeedingTrackFeatures {
-
+  class SeedingTrackFeatures {
   public:
-
     float pt;
     float eta;
     float phi;
-    float mass;    
+    float mass;
     float dz;
     float dxy;
     float ip3D;
     float sip3D;
     float ip2D;
-    float sip2D;    
+    float sip2D;
     float signedIp3D;
     float signedSip3D;
     float signedIp2D;
-    float signedSip2D;  
+    float signedSip2D;
     float trackProbability3D;
     float trackProbability2D;
     float chi2reduced;
@@ -31,12 +29,10 @@ class SeedingTrackFeatures {
     float nHits;
     float jetAxisDistance;
     float jetAxisDlength;
-    
+
     std::vector<btagbtvdeep::TrackPairFeatures> nearTracks;
-    
+  };
 
-};
+}  // namespace btagbtvdeep
 
-}
-
-#endif 
+#endif

--- a/DataFormats/BTauReco/interface/ShallowTagInfo.h
+++ b/DataFormats/BTauReco/interface/ShallowTagInfo.h
@@ -9,31 +9,27 @@
 
 namespace reco {
 
-class ShallowTagInfo : public BaseTagInfo {
-public:
-  ShallowTagInfo(void) { }
+  class ShallowTagInfo : public BaseTagInfo {
+  public:
+    ShallowTagInfo(void) {}
 
-  ShallowTagInfo(
-    const TaggingVariableList & list,
-    const edm::RefToBase<Jet> & jetref) :
-      list_(list),
-      jetRef_(jetref) { }
+    ShallowTagInfo(const TaggingVariableList& list, const edm::RefToBase<Jet>& jetref) : list_(list), jetRef_(jetref) {}
 
-  ~ShallowTagInfo(void) override { }
+    ~ShallowTagInfo(void) override {}
 
-  ShallowTagInfo* clone(void) const override { return new ShallowTagInfo(*this); }
+    ShallowTagInfo* clone(void) const override { return new ShallowTagInfo(*this); }
 
-  edm::RefToBase<Jet> jet(void) const override { return jetRef_; }
+    edm::RefToBase<Jet> jet(void) const override { return jetRef_; }
 
-  TaggingVariableList taggingVariables(void) const override { return list_; }
+    TaggingVariableList taggingVariables(void) const override { return list_; }
 
-protected:
-  /*const*/ TaggingVariableList  list_;
-	/*const*/ edm::RefToBase<Jet>  jetRef_;
-};
+  protected:
+    /*const*/ TaggingVariableList list_;
+    /*const*/ edm::RefToBase<Jet> jetRef_;
+  };
 
-DECLARE_EDM_REFS( ShallowTagInfo )
+  DECLARE_EDM_REFS(ShallowTagInfo)
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_ShallowTagInfo_h
+#endif  // DataFormats_BTauReco_ShallowTagInfo_h

--- a/DataFormats/BTauReco/interface/ShallowTagInfoFeatures.h
+++ b/DataFormats/BTauReco/interface/ShallowTagInfoFeatures.h
@@ -3,24 +3,21 @@
 
 namespace btagbtvdeep {
 
-class ShallowTagInfoFeatures {
-
+  class ShallowTagInfoFeatures {
   public:
-
     // jet general
-    float trackSumJetEtRatio;      // ratio of track sum transverse energy over jet energy
-    float trackSumJetDeltaR;       // pseudoangular distance between jet axis and track fourvector sum
-    float trackSip2dValAboveCharm; // track 2D signed impact parameter of first track lifting mass above charm
-    float trackSip2dSigAboveCharm; // track 2D signed impact parameter significance of first track lifting mass above charm
-    float trackSip3dValAboveCharm; // track 3D signed impact parameter of first track lifting mass above charm
-    float trackSip3dSigAboveCharm; // track 3D signed impact parameter significance of first track lifting mass above charm
-    float vertexCategory;          // category of secondary vertex (Reco, Pseudo, No)
+    float trackSumJetEtRatio;       // ratio of track sum transverse energy over jet energy
+    float trackSumJetDeltaR;        // pseudoangular distance between jet axis and track fourvector sum
+    float trackSip2dValAboveCharm;  // track 2D signed impact parameter of first track lifting mass above charm
+    float trackSip2dSigAboveCharm;  // track 2D signed impact parameter significance of first track lifting mass above charm
+    float trackSip3dValAboveCharm;  // track 3D signed impact parameter of first track lifting mass above charm
+    float trackSip3dSigAboveCharm;  // track 3D signed impact parameter significance of first track lifting mass above charm
+    float vertexCategory;           // category of secondary vertex (Reco, Pseudo, No)
     // track info
-    float jetNTracksEtaRel; // tracks associated to jet for which trackEtaRel is calculated
-    float jetNSelectedTracks;    
+    float jetNTracksEtaRel;  // tracks associated to jet for which trackEtaRel is calculated
+    float jetNSelectedTracks;
+  };
 
-};
+}  // namespace btagbtvdeep
 
-}
-
-#endif //DataFormats_BTauReco_ShallowTagInfoFeatures_h
+#endif  //DataFormats_BTauReco_ShallowTagInfoFeatures_h

--- a/DataFormats/BTauReco/interface/SoftLeptonTagInfo.h
+++ b/DataFormats/BTauReco/interface/SoftLeptonTagInfo.h
@@ -10,10 +10,10 @@
 
 namespace reco {
 
-typedef TemplatedSoftLeptonTagInfo<TrackBaseRef> SoftLeptonTagInfo;
+  typedef TemplatedSoftLeptonTagInfo<TrackBaseRef> SoftLeptonTagInfo;
 
-DECLARE_EDM_REFS( SoftLeptonTagInfo )
+  DECLARE_EDM_REFS(SoftLeptonTagInfo)
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_SoftLeptonTagInfo_h
+#endif  // DataFormats_BTauReco_SoftLeptonTagInfo_h

--- a/DataFormats/BTauReco/interface/TaggingVariable.h
+++ b/DataFormats/BTauReco/interface/TaggingVariable.h
@@ -19,154 +19,152 @@ namespace reco {
 
   namespace btau {
 
-    inline double etaRel(const math::XYZVector &dir, const math::XYZVector &track)
-    {
-            double momPar = dir.Dot(track);
-            double energy = std::sqrt(track.Mag2() +
-                                      ROOT::Math::Square(reco::ParticleMasses::piPlus));
+    inline double etaRel(const math::XYZVector& dir, const math::XYZVector& track) {
+      double momPar = dir.Dot(track);
+      double energy = std::sqrt(track.Mag2() + ROOT::Math::Square(reco::ParticleMasses::piPlus));
 
-            return 0.5 * std::log((energy + momPar) / (energy - momPar));
+      return 0.5 * std::log((energy + momPar) / (energy - momPar));
     }
 
     // define the enum in a namespace to avoid polluting reco with all the enum values
     enum TaggingVariableName {
-      jetEnergy = 0,                            // jet energy
-      jetPt,                                    // jet transverse momentum
-      trackJetPt,                               // track-based jet transverse momentum
-      jetEta,                                   // jet pseudorapidity
-      jetAbsEta,                                // jet pseudorapidity
-      jetPhi,                                   // jet polar angle
-      jetNTracks,                               // tracks associated to jet
-      jetNSelectedTracks,                       // tracks associated to jet
-      jetNTracksEtaRel,                         // number of tracks for which etaRel is computed
+      jetEnergy = 0,       // jet energy
+      jetPt,               // jet transverse momentum
+      trackJetPt,          // track-based jet transverse momentum
+      jetEta,              // jet pseudorapidity
+      jetAbsEta,           // jet pseudorapidity
+      jetPhi,              // jet polar angle
+      jetNTracks,          // tracks associated to jet
+      jetNSelectedTracks,  // tracks associated to jet
+      jetNTracksEtaRel,    // number of tracks for which etaRel is computed
 
-      trackMomentum,                            // track momentum
-      trackEta,                                 // track pseudorapidity
-      trackPhi,                                 // track polar angle
+      trackMomentum,  // track momentum
+      trackEta,       // track pseudorapidity
+      trackPhi,       // track polar angle
 
-      trackCharge,                              // track charge
+      trackCharge,  // track charge
 
-      trackPtRel,                               // track transverse momentum, relative to the jet axis
-      trackPPar,                                // track parallel momentum, along the jet axis
-      trackEtaRel,                              // track pseudorapidity, relative to the jet axis
-      trackDeltaR,                              // track pseudoangular distance from the jet axis
-      trackPtRatio,                             // track transverse momentum, relative to the jet axis, normalized to its energy
-      trackPParRatio,                           // track parallel momentum, along the jet axis, normalized to its energy
+      trackPtRel,      // track transverse momentum, relative to the jet axis
+      trackPPar,       // track parallel momentum, along the jet axis
+      trackEtaRel,     // track pseudorapidity, relative to the jet axis
+      trackDeltaR,     // track pseudoangular distance from the jet axis
+      trackPtRatio,    // track transverse momentum, relative to the jet axis, normalized to its energy
+      trackPParRatio,  // track parallel momentum, along the jet axis, normalized to its energy
 
-      trackSip2dVal,                            // track 2D signed impact parameter
-      trackSip2dSig,                            // track 2D signed impact parameter significance
-      trackSip3dVal,                            // track 3D signed impact parameter
-      trackSip3dSig,                            // track 3D signed impact parameter significance
-      trackDecayLenVal,                         // track decay length
-      trackDecayLenSig,                         // track decay length significance
-      trackJetDistVal,                          // minimum track approach distance to jet axis
-      trackJetDistSig,                          // minimum track approach distance to jet axis significance
-      trackGhostTrackDistVal,                   // minimum approach distance to ghost track
-      trackGhostTrackDistSig,                   // minimum approach distance to ghost track significance
-      trackGhostTrackWeight,                    // weight of track participation in ghost track fit
+      trackSip2dVal,           // track 2D signed impact parameter
+      trackSip2dSig,           // track 2D signed impact parameter significance
+      trackSip3dVal,           // track 3D signed impact parameter
+      trackSip3dSig,           // track 3D signed impact parameter significance
+      trackDecayLenVal,        // track decay length
+      trackDecayLenSig,        // track decay length significance
+      trackJetDistVal,         // minimum track approach distance to jet axis
+      trackJetDistSig,         // minimum track approach distance to jet axis significance
+      trackGhostTrackDistVal,  // minimum approach distance to ghost track
+      trackGhostTrackDistSig,  // minimum approach distance to ghost track significance
+      trackGhostTrackWeight,   // weight of track participation in ghost track fit
 
-      trackSumJetEtRatio,                       // ratio of track sum transverse energy over jet energy
-      trackSumJetDeltaR,                        // pseudoangular distance between jet axis and track fourvector sum
+      trackSumJetEtRatio,  // ratio of track sum transverse energy over jet energy
+      trackSumJetDeltaR,   // pseudoangular distance between jet axis and track fourvector sum
 
-      vertexCategory,                           // category of secondary vertex (Reco, Pseudo, No)
-      vertexLeptonCategory,                     // category of secondary vertex & soft lepton (RecoNo, PseudoNo, NoNo, RecoMu, PseudoMu, NoMu, RecoEl, PseudoEl, NoEl)
+      vertexCategory,  // category of secondary vertex (Reco, Pseudo, No)
+      vertexLeptonCategory,  // category of secondary vertex & soft lepton (RecoNo, PseudoNo, NoNo, RecoMu, PseudoMu, NoMu, RecoEl, PseudoEl, NoEl)
 
-      jetNSecondaryVertices,                    // number of reconstructed possible secondary vertices in jet
-      jetNSingleTrackVertices,                  // number of single-track ghost-track vertices
+      jetNSecondaryVertices,    // number of reconstructed possible secondary vertices in jet
+      jetNSingleTrackVertices,  // number of single-track ghost-track vertices
 
-      vertexMass,                               // mass of track sum at secondary vertex
-      vertexNTracks,                            // number of tracks at secondary vertex
-      vertexFitProb,                            // vertex fit probability
+      vertexMass,     // mass of track sum at secondary vertex
+      vertexNTracks,  // number of tracks at secondary vertex
+      vertexFitProb,  // vertex fit probability
 
-      vertexEnergyRatio,                        // ratio of energy at secondary vertex over total energy
-      vertexJetDeltaR,                          // pseudoangular distance between jet axis and secondary vertex direction
-      
-      flightDistance1dVal,                      // Longitudinal distance along the z-axis between primary and secondary vertex
-      flightDistance1dSig,                      // Longitudinal distance significance along the z-axis between primary and secondary vertex
-      flightDistance2dVal,                      // transverse distance between primary and secondary vertex
-      flightDistance2dSig,                      // transverse distance significance between primary and secondary vertex
-      flightDistance3dVal,                      // distance between primary and secondary vertex
-      flightDistance3dSig,                      // distance significance between primary and secondary vertex
+      vertexEnergyRatio,  // ratio of energy at secondary vertex over total energy
+      vertexJetDeltaR,    // pseudoangular distance between jet axis and secondary vertex direction
 
-      trackSip2dValAboveCharm,                  // track 2D signed impact parameter of first track lifting mass above charm
-      trackSip2dSigAboveCharm,                  // track 2D signed impact parameter significance of first track lifting mass above charm
-      trackSip3dValAboveCharm,                  // track 3D signed impact parameter of first track lifting mass above charm
-      trackSip3dSigAboveCharm,                  // track 3D signed impact parameter significance of first track lifting mass above charm
+      flightDistance1dVal,  // Longitudinal distance along the z-axis between primary and secondary vertex
+      flightDistance1dSig,  // Longitudinal distance significance along the z-axis between primary and secondary vertex
+      flightDistance2dVal,  // transverse distance between primary and secondary vertex
+      flightDistance2dSig,  // transverse distance significance between primary and secondary vertex
+      flightDistance3dVal,  // distance between primary and secondary vertex
+      flightDistance3dSig,  // distance significance between primary and secondary vertex
 
-      leptonQuality,                            // lepton identification quality
-      leptonQuality2,                           // lepton identification quality 2
+      trackSip2dValAboveCharm,  // track 2D signed impact parameter of first track lifting mass above charm
+      trackSip2dSigAboveCharm,  // track 2D signed impact parameter significance of first track lifting mass above charm
+      trackSip3dValAboveCharm,  // track 3D signed impact parameter of first track lifting mass above charm
+      trackSip3dSigAboveCharm,  // track 3D signed impact parameter significance of first track lifting mass above charm
 
-      trackP0Par,                               // track momentum along the jet axis, in the jet rest frame
-      trackP0ParRatio,                          // track momentum along the jet axis, in the jet rest frame, normalized to its energy"
-      trackChi2,                                // track fit chi2
-      trackNTotalHits,                          // number of valid total hits
-      trackNPixelHits,                          // number of valid pixel hits
+      leptonQuality,   // lepton identification quality
+      leptonQuality2,  // lepton identification quality 2
 
-      chargedHadronEnergyFraction,              // fraction of the jet energy coming from charged hadrons
-      neutralHadronEnergyFraction,              // fraction of the jet energy coming from neutral hadrons
-      photonEnergyFraction,                     // fraction of the jet energy coming from photons
-      electronEnergyFraction,                   // fraction of the jet energy coming from electrons
-      muonEnergyFraction,                       // fraction of the jet energy coming from muons
-      chargedHadronMultiplicity,                // number of charged hadrons in the jet
-      neutralHadronMultiplicity,                // number of neutral hadrons in the jet
-      photonMultiplicity,                       // number of photons in the jet
-      electronMultiplicity,                     // number of electrons in the jet
-      muonMultiplicity,                         // number of muons in the jet
-      hadronMultiplicity,                       // sum of number of charged and neutral hadrons in the jet
-      hadronPhotonMultiplicity,                 // sum of number of charged and neutral hadrons and photons in the jet
-      totalMultiplicity,                        // sum of number of charged and neutral hadrons, photons, electrons and muons in the jet
+      trackP0Par,       // track momentum along the jet axis, in the jet rest frame
+      trackP0ParRatio,  // track momentum along the jet axis, in the jet rest frame, normalized to its energy"
+      trackChi2,        // track fit chi2
+      trackNTotalHits,  // number of valid total hits
+      trackNPixelHits,  // number of valid pixel hits
 
-      massVertexEnergyFraction,                 // vertexmass times fraction of the vertex energy w.r.t. the jet energy
-      vertexBoostOverSqrtJetPt,                 // variable related to the boost of the vertex system in flight direction
+      chargedHadronEnergyFraction,  // fraction of the jet energy coming from charged hadrons
+      neutralHadronEnergyFraction,  // fraction of the jet energy coming from neutral hadrons
+      photonEnergyFraction,         // fraction of the jet energy coming from photons
+      electronEnergyFraction,       // fraction of the jet energy coming from electrons
+      muonEnergyFraction,           // fraction of the jet energy coming from muons
+      chargedHadronMultiplicity,    // number of charged hadrons in the jet
+      neutralHadronMultiplicity,    // number of neutral hadrons in the jet
+      photonMultiplicity,           // number of photons in the jet
+      electronMultiplicity,         // number of electrons in the jet
+      muonMultiplicity,             // number of muons in the jet
+      hadronMultiplicity,           // sum of number of charged and neutral hadrons in the jet
+      hadronPhotonMultiplicity,     // sum of number of charged and neutral hadrons and photons in the jet
+      totalMultiplicity,  // sum of number of charged and neutral hadrons, photons, electrons and muons in the jet
 
-      leptonSip2d,                              // 2D signed impact parameter of the soft lepton
-      leptonSip3d,                              // 3D signed impact parameter of the soft lepton
-      leptonPtRel,                              // transverse momentum of the soft lepton wrt. the jet axis
-      leptonP0Par,                              // momentum of the soft lepton along the jet direction, in the jet rest frame
-      leptonEtaRel,                             // pseudo)rapidity of the soft lepton along jet axis
-      leptonDeltaR,                             // pseudo)angular distance of the soft lepton to jet axis
-      leptonRatio,                              // momentum of the soft lepton over jet energy
-      leptonRatioRel,                           // momentum of the soft lepton parallel to jet axis over jet energy
-      electronMVA,                              // mva output from electron ID
+      massVertexEnergyFraction,  // vertexmass times fraction of the vertex energy w.r.t. the jet energy
+      vertexBoostOverSqrtJetPt,  // variable related to the boost of the vertex system in flight direction
+
+      leptonSip2d,     // 2D signed impact parameter of the soft lepton
+      leptonSip3d,     // 3D signed impact parameter of the soft lepton
+      leptonPtRel,     // transverse momentum of the soft lepton wrt. the jet axis
+      leptonP0Par,     // momentum of the soft lepton along the jet direction, in the jet rest frame
+      leptonEtaRel,    // pseudo)rapidity of the soft lepton along jet axis
+      leptonDeltaR,    // pseudo)angular distance of the soft lepton to jet axis
+      leptonRatio,     // momentum of the soft lepton over jet energy
+      leptonRatioRel,  // momentum of the soft lepton parallel to jet axis over jet energy
+      electronMVA,     // mva output from electron ID
 
       // ### specific to boosted double-b tagger (see BTV-15-002 PAS for more details) ###
-      trackSip3dSig_0,                          // 1st largest track 3D signed impact parameter significance
-      trackSip3dSig_1,                          // 2nd largest track 3D signed impact parameter significance
-      trackSip3dSig_2,                          // 3rd largest track 3D signed impact parameter significance
-      trackSip3dSig_3,                          // 4th largest track 3D signed impact parameter significance
-      tau1_trackSip3dSig_0,                     // 1st largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis
-      tau1_trackSip3dSig_1,                     // 2nd largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis
-      tau2_trackSip3dSig_0,                     // 1st largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis
-      tau2_trackSip3dSig_1,                     // 2nd largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis
-      trackSip2dSigAboveBottom_0,               // track 2D signed impact parameter significance of 1st track lifting mass above bottom
-      trackSip2dSigAboveBottom_1,               // track 2D signed impact parameter significance of 2nd track lifting mass above bottom
-      tau1_trackEtaRel_0,                       // 1st smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
-      tau1_trackEtaRel_1,                       // 2nd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
-      tau1_trackEtaRel_2,                       // 3rd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
-      tau2_trackEtaRel_0,                       // 1st smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
-      tau2_trackEtaRel_1,                       // 2nd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
-      tau2_trackEtaRel_2,                       // 3rd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
-      tau1_vertexMass,                          // mass of track sum at secondary vertex associated to the 1st N-subjettiness axis
-      tau1_vertexEnergyRatio,                   // ratio of energy at secondary vertex over total energy associated to the 1st N-subjettiness axis
-      tau1_flightDistance2dSig,                 // transverse distance significance between primary and secondary vertex associated to the 1st N-subjettiness axis
-      tau1_vertexDeltaR,                        // pseudoangular distance between the 1st N-subjettiness axis and secondary vertex direction
-      tau2_vertexMass,                          // mass of track sum at secondary vertex associated to the 2nd N-subjettiness axis
-      tau2_vertexEnergyRatio,                   // ratio of energy at secondary vertex over total energy associated to the 2nd N-subjettiness axis
-      tau2_flightDistance2dSig,                 // transverse distance significance between primary and secondary vertex associated to the 2nd N-subjettiness axis
-      tau2_vertexDeltaR,                        // pseudoangular distance between the 2nd N-subjettiness axis and secondary vertex direction
-      z_ratio,                                  // z ratio
-	  
-      Jet_SoftMu,               								// discriminator output of SoftMuon Tagger, used as input to (Deep)CMVA
-      Jet_SoftEl,								                // discriminator output of SoftElectron Tagger, used as input to (Deep)CMVA
-      Jet_JBP,									                // discriminator output of JPB Tagger, used as input to (Deep)CMVA
-      Jet_JP,									                  // discriminator output of JP Tagger, used as input to (Deep)CMVA
+      trackSip3dSig_0,  // 1st largest track 3D signed impact parameter significance
+      trackSip3dSig_1,  // 2nd largest track 3D signed impact parameter significance
+      trackSip3dSig_2,  // 3rd largest track 3D signed impact parameter significance
+      trackSip3dSig_3,  // 4th largest track 3D signed impact parameter significance
+      tau1_trackSip3dSig_0,  // 1st largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis
+      tau1_trackSip3dSig_1,  // 2nd largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis
+      tau2_trackSip3dSig_0,  // 1st largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis
+      tau2_trackSip3dSig_1,  // 2nd largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis
+      trackSip2dSigAboveBottom_0,  // track 2D signed impact parameter significance of 1st track lifting mass above bottom
+      trackSip2dSigAboveBottom_1,  // track 2D signed impact parameter significance of 2nd track lifting mass above bottom
+      tau1_trackEtaRel_0,  // 1st smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
+      tau1_trackEtaRel_1,  // 2nd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
+      tau1_trackEtaRel_2,  // 3rd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis
+      tau2_trackEtaRel_0,  // 1st smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
+      tau2_trackEtaRel_1,  // 2nd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
+      tau2_trackEtaRel_2,  // 3rd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis
+      tau1_vertexMass,  // mass of track sum at secondary vertex associated to the 1st N-subjettiness axis
+      tau1_vertexEnergyRatio,  // ratio of energy at secondary vertex over total energy associated to the 1st N-subjettiness axis
+      tau1_flightDistance2dSig,  // transverse distance significance between primary and secondary vertex associated to the 1st N-subjettiness axis
+      tau1_vertexDeltaR,  // pseudoangular distance between the 1st N-subjettiness axis and secondary vertex direction
+      tau2_vertexMass,    // mass of track sum at secondary vertex associated to the 2nd N-subjettiness axis
+      tau2_vertexEnergyRatio,  // ratio of energy at secondary vertex over total energy associated to the 2nd N-subjettiness axis
+      tau2_flightDistance2dSig,  // transverse distance significance between primary and secondary vertex associated to the 2nd N-subjettiness axis
+      tau2_vertexDeltaR,  // pseudoangular distance between the 2nd N-subjettiness axis and secondary vertex direction
+      z_ratio,            // z ratio
+
+      Jet_SoftMu,  // discriminator output of SoftMuon Tagger, used as input to (Deep)CMVA
+      Jet_SoftEl,  // discriminator output of SoftElectron Tagger, used as input to (Deep)CMVA
+      Jet_JBP,     // discriminator output of JPB Tagger, used as input to (Deep)CMVA
+      Jet_JP,      // discriminator output of JP Tagger, used as input to (Deep)CMVA
       // #################################################################################
 
-      algoDiscriminator,                        // discriminator output of an algorithm
+      algoDiscriminator,  // discriminator output of an algorithm
 
       lastTaggingVariable
     };
-  }
+  }  // namespace btau
 
   // import only TaggingVariableName type into reco namespace
   using btau::TaggingVariableName;
@@ -174,27 +172,20 @@ namespace reco {
   extern const char* const TaggingVariableDescription[];
   extern const char* const TaggingVariableTokens[];
 
-  TaggingVariableName getTaggingVariableName ( const std::string & name );
+  TaggingVariableName getTaggingVariableName(const std::string& name);
 
   typedef float TaggingValue;
-  
+
   // cannot use a const member since the STL containers relie on the default assignment operator
   // typedef std::pair< const TaggingVariableName, TaggingValue > TaggingVariable;
-  typedef std::pair< TaggingVariableName, TaggingValue > TaggingVariable;
+  typedef std::pair<TaggingVariableName, TaggingValue> TaggingVariable;
 
   struct TaggingVariableCompare {
-    bool operator() (const TaggingVariable& i, const TaggingVariable& j) {
-      return i.first < j.first;
-    }
+    bool operator()(const TaggingVariable& i, const TaggingVariable& j) { return i.first < j.first; }
 
-    bool operator() (const TaggingVariable& i, TaggingVariableName tag) {
-      return i.first < tag;
-    }
+    bool operator()(const TaggingVariable& i, TaggingVariableName tag) { return i.first < tag; }
 
-    bool operator() (TaggingVariableName tag, const TaggingVariable& i) {
-      return tag < i.first;
-    }
-
+    bool operator()(TaggingVariableName tag, const TaggingVariable& i) { return tag < i.first; }
   };
 
   // implementation via std::vector where
@@ -202,13 +193,14 @@ namespace reco {
   //  - extraction is done via binary search
   class TaggingVariableList {
   public:
-    TaggingVariableList() : m_list() { }
-    TaggingVariableList( const TaggingVariableList& list ) : m_list( list.m_list ) { }
+    TaggingVariableList() : m_list() {}
+    TaggingVariableList(const TaggingVariableList& list) : m_list(list.m_list) {}
 
     // [begin, end) must identify a valid range of iterators to TaggingVariableList
     template <typename InputIterator>
-    TaggingVariableList( const InputIterator begin, const InputIterator end ) : m_list() {
-      static_assert(( boost::is_convertible< const TaggingVariableList, typename boost::pointee<InputIterator>::type >::value ));
+    TaggingVariableList(const InputIterator begin, const InputIterator end) : m_list() {
+      static_assert(
+          (boost::is_convertible<const TaggingVariableList, typename boost::pointee<InputIterator>::type>::value));
       for (const InputIterator i = begin; i != end; i++)
         insert(*i);
     }
@@ -216,42 +208,39 @@ namespace reco {
     /**
      *  STL-like accessors 
      */
-    typedef std::vector < TaggingVariable >::const_iterator const_iterator;
-    typedef std::pair < const_iterator, const_iterator > range;
+    typedef std::vector<TaggingVariable>::const_iterator const_iterator;
+    typedef std::pair<const_iterator, const_iterator> range;
     size_t size() const { return m_list.size(); }
     const_iterator begin() const { return m_list.begin(); }
     const_iterator end() const { return m_list.end(); }
-    void push_back ( const TaggingVariable & t ) { m_list.push_back ( t ); }
+    void push_back(const TaggingVariable& t) { m_list.push_back(t); }
 
-    ~TaggingVariableList() { }
-
+    ~TaggingVariableList() {}
 
   private:
-    std::vector< TaggingVariable > m_list;
-      
+    std::vector<TaggingVariable> m_list;
+
   public:
-    bool checkTag( TaggingVariableName tag ) const;
-    
-    void insert( const TaggingVariable & variable, bool delayed = false );
-    void insert( const TaggingVariableList & list );
-    void insert( TaggingVariableName tag, TaggingValue value, bool delayed = false );
-    void insert( TaggingVariableName tag, const std::vector<TaggingValue> & values, bool delayed = false );
+    bool checkTag(TaggingVariableName tag) const;
 
-    void finalize( void );
-    
-    TaggingValue get( TaggingVariableName tag ) const;
-    TaggingValue get( TaggingVariableName tag, TaggingValue defaultValue ) const;
-    std::vector<TaggingValue> getList( TaggingVariableName tag, bool throwOnEmptyList = true ) const;
+    void insert(const TaggingVariable& variable, bool delayed = false);
+    void insert(const TaggingVariableList& list);
+    void insert(TaggingVariableName tag, TaggingValue value, bool delayed = false);
+    void insert(TaggingVariableName tag, const std::vector<TaggingValue>& values, bool delayed = false);
 
-    range getRange( TaggingVariableName tag ) const;
+    void finalize(void);
 
-    TaggingValue operator[]( TaggingVariableName tag ) const {
-      return get( tag );
-    }
+    TaggingValue get(TaggingVariableName tag) const;
+    TaggingValue get(TaggingVariableName tag, TaggingValue defaultValue) const;
+    std::vector<TaggingValue> getList(TaggingVariableName tag, bool throwOnEmptyList = true) const;
+
+    range getRange(TaggingVariableName tag) const;
+
+    TaggingValue operator[](TaggingVariableName tag) const { return get(tag); }
   };
 
-  DECLARE_EDM_REFS( TaggingVariableList )
+  DECLARE_EDM_REFS(TaggingVariableList)
 
-}
+}  // namespace reco
 
-#endif // DataFormats_BTauReco_TaggingVariable_h
+#endif  // DataFormats_BTauReco_TaggingVariable_h

--- a/DataFormats/BTauReco/interface/TauImpactParameterInfo.h
+++ b/DataFormats/BTauReco/interface/TauImpactParameterInfo.h
@@ -8,18 +8,14 @@
 #include "DataFormats/BTauReco/interface/IsolatedTauTagInfo.h"
 
 namespace reco {
- 
+
   struct TauImpactParameterTrackData {
     Measurement1D transverseIp;
     Measurement1D ip3D;
   };
 
-  typedef edm::AssociationMap <
-            edm::OneToValue<
-              reco::TrackCollection,
-              reco::TauImpactParameterTrackData
-            >
-          > TrackTauImpactParameterAssociationCollection;
+  typedef edm::AssociationMap<edm::OneToValue<reco::TrackCollection, reco::TauImpactParameterTrackData> >
+      TrackTauImpactParameterAssociationCollection;
 
   typedef TrackTauImpactParameterAssociationCollection::value_type TrackTauImpactParameterAssociation;
 
@@ -27,25 +23,25 @@ namespace reco {
   public:
     TauImpactParameterInfo() {}
     virtual ~TauImpactParameterInfo() {}
-    
-    virtual TauImpactParameterInfo* clone() const { return new TauImpactParameterInfo( * this ); }
-    
-    float discriminator(double,double,double,bool,bool) const;
+
+    virtual TauImpactParameterInfo *clone() const { return new TauImpactParameterInfo(*this); }
+
+    float discriminator(double, double, double, bool, bool) const;
     float discriminator() const;
-    
-    const TauImpactParameterTrackData * getTrackData(const reco::TrackRef &) const;
+
+    const TauImpactParameterTrackData *getTrackData(const reco::TrackRef &) const;
     void storeTrackData(const reco::TrackRef &, const TauImpactParameterTrackData &);
-    
-    const IsolatedTauTagInfoRef & getIsolatedTauTag() const;
+
+    const IsolatedTauTagInfoRef &getIsolatedTauTag() const;
     void setIsolatedTauTag(const IsolatedTauTagInfoRef &);
-    
+
   private:
     TrackTauImpactParameterAssociationCollection trackDataMap;
-    IsolatedTauTagInfoRef                        isolatedTaus;
+    IsolatedTauTagInfoRef isolatedTaus;
   };
- 
-  DECLARE_EDM_REFS( TauImpactParameterInfo )
 
-}
+  DECLARE_EDM_REFS(TauImpactParameterInfo)
 
-#endif // DataFormats_BTauReco_TauImpactParameterInfo_h
+}  // namespace reco
+
+#endif  // DataFormats_BTauReco_TauImpactParameterInfo_h

--- a/DataFormats/BTauReco/interface/TauMassTagInfo.h
+++ b/DataFormats/BTauReco/interface/TauMassTagInfo.h
@@ -11,50 +11,48 @@
 #include "DataFormats/BTauReco/interface/IsolatedTauTagInfo.h"
 
 namespace reco {
- 
+
   class TauMassTagInfo : public JTATagInfo {
   public:
-
-    typedef edm::AssociationMap < edm::OneToValue<BasicClusterCollection,
-      float, unsigned short> > ClusterTrackAssociationCollection;
+    typedef edm::AssociationMap<edm::OneToValue<BasicClusterCollection, float, unsigned short> >
+        ClusterTrackAssociationCollection;
 
     typedef ClusterTrackAssociationCollection::value_type ClusterTrackAssociation;
 
     TauMassTagInfo() {}
     ~TauMassTagInfo() override {}
-    
-    TauMassTagInfo* clone() const override { return new TauMassTagInfo( * this ); }
-    
+
+    TauMassTagInfo* clone() const override { return new TauMassTagInfo(*this); }
+
     //default discriminator: returns the discriminator of the jet tag
-    float discriminator() const {return -1. ;}
-    
-    float discriminator(double matching_cone, double leading_trk_pt,
-                                   double signal_cone, double cluster_track_cone, 
-                                   double m_cut) const;
-    
-    void  setIsolatedTauTag(const IsolatedTauTagInfoRef);
+    float discriminator() const { return -1.; }
+
+    float discriminator(
+        double matching_cone, double leading_trk_pt, double signal_cone, double cluster_track_cone, double m_cut) const;
+
+    void setIsolatedTauTag(const IsolatedTauTagInfoRef);
     const IsolatedTauTagInfoRef& getIsolatedTauTag() const;
 
-    void storeClusterTrackCollection(reco::BasicClusterRef clusterRef,float dr);
-    TauMassTagInfo::ClusterTrackAssociationCollection clusterTrackCollection() const { return clusterMap;}
+    void storeClusterTrackCollection(reco::BasicClusterRef clusterRef, float dr);
+    TauMassTagInfo::ClusterTrackAssociationCollection clusterTrackCollection() const { return clusterMap; }
 
-    double getInvariantMassTrk(double matching_cone,double leading_trk_pt, double signal_cone) const;    
-    double getInvariantMass(double matching_cone,double leading_trk_pt, double signal_cone,
-                                double cluster_track_cone) const;    
+    double getInvariantMassTrk(double matching_cone, double leading_trk_pt, double signal_cone) const;
+    double getInvariantMass(double matching_cone,
+                            double leading_trk_pt,
+                            double signal_cone,
+                            double cluster_track_cone) const;
 
   private:
+    bool calculateTrkP4(double matching_cone,
+                        double leading_trk_pt,
+                        double signal_cone,
+                        math::XYZTLorentzVector& p4) const;
 
-    bool calculateTrkP4(double matching_cone,double leading_trk_pt, double signal_cone, 
-                            math::XYZTLorentzVector& p4) const;
-
-    IsolatedTauTagInfoRef             isolatedTau;
-    ClusterTrackAssociationCollection clusterMap; // const?
-
+    IsolatedTauTagInfoRef isolatedTau;
+    ClusterTrackAssociationCollection clusterMap;  // const?
   };
- 
-  DECLARE_EDM_REFS( TauMassTagInfo )
 
-}
+  DECLARE_EDM_REFS(TauMassTagInfo)
+
+}  // namespace reco
 #endif
-
-

--- a/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
+++ b/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
@@ -22,310 +22,287 @@
 #include "DataFormats/GeometryVector/interface/VectorUtil.h"
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"
 
-
-
-
 namespace reco {
-namespace btag{
-inline float weight(const reco::TrackRef & t, const reco::Vertex &v) {return v.trackWeight(t);}
-inline float weight(const reco::CandidatePtr & c, const reco::VertexCompositePtrCandidate &v) {return std::find(v.daughterPtrVector().begin(),v.daughterPtrVector().end(),c)!=v.daughterPtrVector().end();}
+  namespace btag {
+    inline float weight(const reco::TrackRef &t, const reco::Vertex &v) { return v.trackWeight(t); }
+    inline float weight(const reco::CandidatePtr &c, const reco::VertexCompositePtrCandidate &v) {
+      return std::find(v.daughterPtrVector().begin(), v.daughterPtrVector().end(), c) != v.daughterPtrVector().end();
+    }
 
-        struct TrackData {
-                enum Status {
-                        trackSelected = 0,
-                        trackUsedForVertexFit,
-                        trackAssociatedToVertex
-                };
+    struct TrackData {
+      enum Status { trackSelected = 0, trackUsedForVertexFit, trackAssociatedToVertex };
 
-                inline bool usedForVertexFit() const
-                { return (int)svStatus >= (int)trackUsedForVertexFit; }
-                inline bool associatedToVertex() const
-                { return (int)svStatus >= (int)trackAssociatedToVertex; }
-                inline bool associatedToVertex(unsigned int index) const
-                { return (int)svStatus == (int)trackAssociatedToVertex + (int)index; }
+      inline bool usedForVertexFit() const { return (int)svStatus >= (int)trackUsedForVertexFit; }
+      inline bool associatedToVertex() const { return (int)svStatus >= (int)trackAssociatedToVertex; }
+      inline bool associatedToVertex(unsigned int index) const {
+        return (int)svStatus == (int)trackAssociatedToVertex + (int)index;
+      }
 
-                Status  svStatus;
-        };
-	typedef std::pair<unsigned int, TrackData> IndexedTrackData;
+      Status svStatus;
+    };
+    typedef std::pair<unsigned int, TrackData> IndexedTrackData;
 
-}
-template <class IPTI, class VTX> 
-class TemplatedSecondaryVertexTagInfo : public BaseTagInfo {
-    public:
-	typedef reco::btag::TrackData TrackData;
-	typedef reco::btag::IndexedTrackData IndexedTrackData;
+  }  // namespace btag
+  template <class IPTI, class VTX>
+  class TemplatedSecondaryVertexTagInfo : public BaseTagInfo {
+  public:
+    typedef reco::btag::TrackData TrackData;
+    typedef reco::btag::IndexedTrackData IndexedTrackData;
 
-        struct VertexData {
-                VTX                             vertex;
-                Measurement1D                   dist1d,dist2d, dist3d;
-                GlobalVector                    direction;
-		
-		// Used by ROOT storage
-		CMS_CLASS_VERSION(12)
-        };
+    struct VertexData {
+      VTX vertex;
+      Measurement1D dist1d, dist2d, dist3d;
+      GlobalVector direction;
 
-        struct TrackFinder {
-                TrackFinder(const typename IPTI::input_container &tracks,
-                            const typename IPTI::input_container::value_type &track) :
-                        tracks(tracks), track(track) {}
+      // Used by ROOT storage
+      CMS_CLASS_VERSION(12)
+    };
 
-                bool operator () (const IndexedTrackData &idt)
-                { return tracks[idt.first] == track; }
+    struct TrackFinder {
+      TrackFinder(const typename IPTI::input_container &tracks, const typename IPTI::input_container::value_type &track)
+          : tracks(tracks), track(track) {}
 
-                const typename IPTI::input_container    &tracks;
-                const typename IPTI::input_container::value_type          &track;
-        };
+      bool operator()(const IndexedTrackData &idt) { return tracks[idt.first] == track; }
 
-        struct VertexTrackSelector {
-                bool operator () (const IndexedTrackData &idt)
-                { return idt.second.associatedToVertex(); }
-        };
+      const typename IPTI::input_container &tracks;
+      const typename IPTI::input_container::value_type &track;
+    };
 
-        struct IndexedVertexTrackSelector {
-                IndexedVertexTrackSelector(unsigned int index) :
-                        index(index) {}
+    struct VertexTrackSelector {
+      bool operator()(const IndexedTrackData &idt) { return idt.second.associatedToVertex(); }
+    };
 
-                bool operator () (const IndexedTrackData &idt)
-                { return idt.second.associatedToVertex(index); }
+    struct IndexedVertexTrackSelector {
+      IndexedVertexTrackSelector(unsigned int index) : index(index) {}
 
-                unsigned int index;
-        };
+      bool operator()(const IndexedTrackData &idt) { return idt.second.associatedToVertex(index); }
 
+      unsigned int index;
+    };
 
+    typedef typename IPTI::input_container input_container;
 
-	typedef typename IPTI::input_container input_container;
+    TemplatedSecondaryVertexTagInfo() {}
+    ~TemplatedSecondaryVertexTagInfo() override {}
 
-	TemplatedSecondaryVertexTagInfo() {}
-	~TemplatedSecondaryVertexTagInfo() override {}
+    TemplatedSecondaryVertexTagInfo(const std::vector<IndexedTrackData> &trackData,
+                                    const std::vector<VertexData> &svData,
+                                    unsigned int vertexCandidates,
+                                    const edm::Ref<std::vector<IPTI> > &);
 
-	TemplatedSecondaryVertexTagInfo(
-	                const std::vector<IndexedTrackData> &trackData,
-			const std::vector<VertexData> &svData,
-			unsigned int vertexCandidates,
-			 const edm::Ref<std::vector<IPTI> >&);
+    /// clone
+    TemplatedSecondaryVertexTagInfo *clone(void) const override { return new TemplatedSecondaryVertexTagInfo(*this); }
 
-        /// clone
-        TemplatedSecondaryVertexTagInfo * clone(void) const override {
-            return new TemplatedSecondaryVertexTagInfo(*this);
-        }
-  
-	const edm::Ref<std::vector<IPTI> > &trackIPTagInfoRef() const
-	{ return m_trackIPTagInfoRef; }
+    const edm::Ref<std::vector<IPTI> > &trackIPTagInfoRef() const { return m_trackIPTagInfoRef; }
 
-	edm::RefToBase<Jet> jet(void) const override
-	{ return m_trackIPTagInfoRef->jet(); }
+    edm::RefToBase<Jet> jet(void) const override { return m_trackIPTagInfoRef->jet(); }
 
-//	virtual input_container ipTracks(void) const
-//	{ return m_trackIPTagInfoRef->tracks(); }
+    //	virtual input_container ipTracks(void) const
+    //	{ return m_trackIPTagInfoRef->tracks(); }
 
-//AR TODO is it needed?
-//	const JetTracksAssociationRef &jtaRef(void) const
-//	{ return m_trackIPTagInfoRef->jtaRef(); }
+    //AR TODO is it needed?
+    //	const JetTracksAssociationRef &jtaRef(void) const
+    //	{ return m_trackIPTagInfoRef->jtaRef(); }
 
-	const VTX &secondaryVertex(unsigned int index) const
-	{ return m_svData[index].vertex; }
+    const VTX &secondaryVertex(unsigned int index) const { return m_svData[index].vertex; }
 
-	unsigned int nSelectedTracks() const { return m_trackData.size(); }
-	unsigned int nVertexTracks() const;
-	unsigned int nVertexTracks(unsigned int index) const;
-	unsigned int nVertices() const { return m_svData.size(); }
-	unsigned int nVertexCandidates() const { return m_vertexCandidates; }
+    unsigned int nSelectedTracks() const { return m_trackData.size(); }
+    unsigned int nVertexTracks() const;
+    unsigned int nVertexTracks(unsigned int index) const;
+    unsigned int nVertices() const { return m_svData.size(); }
+    unsigned int nVertexCandidates() const { return m_vertexCandidates; }
 
-	input_container selectedTracks() const;
-	input_container vertexTracks() const;
-	input_container vertexTracks(unsigned int index) const;
+    input_container selectedTracks() const;
+    input_container vertexTracks() const;
+    input_container vertexTracks(unsigned int index) const;
 
-	typename input_container::value_type track(unsigned int index) const;
-	unsigned int findTrack(const typename input_container::value_type &track) const;
+    typename input_container::value_type track(unsigned int index) const;
+    unsigned int findTrack(const typename input_container::value_type &track) const;
 
-	const TrackData &trackData(unsigned int index) const;
-	const TrackData &trackData(const typename input_container::value_type &track) const;
+    const TrackData &trackData(unsigned int index) const;
+    const TrackData &trackData(const typename input_container::value_type &track) const;
 
-	const reco::btag::TrackIPData &trackIPData(unsigned int index) const;
-	const reco::btag::TrackIPData &trackIPData(const typename input_container::value_type &track) const;
+    const reco::btag::TrackIPData &trackIPData(unsigned int index) const;
+    const reco::btag::TrackIPData &trackIPData(const typename input_container::value_type &track) const;
 
-	float trackWeight(unsigned int svIndex, unsigned int trackindex) const;
-	float trackWeight(unsigned int svIndex, const typename input_container::value_type &track) const;
+    float trackWeight(unsigned int svIndex, unsigned int trackindex) const;
+    float trackWeight(unsigned int svIndex, const typename input_container::value_type &track) const;
 
-	Measurement1D
-	flightDistance(unsigned int index, int dim =0) const{
-          if(dim==1)      return m_svData[index].dist1d;
-          else if(dim==2) return m_svData[index].dist2d;
-          else            return m_svData[index].dist3d;
-        }
-	const GlobalVector &flightDirection(unsigned int index) const
-	{ return m_svData[index].direction; }
-	TaggingVariableList taggingVariables() const override;
-	
-	// Used by ROOT storage
-	CMS_CLASS_VERSION(11)
+    Measurement1D flightDistance(unsigned int index, int dim = 0) const {
+      if (dim == 1)
+        return m_svData[index].dist1d;
+      else if (dim == 2)
+        return m_svData[index].dist2d;
+      else
+        return m_svData[index].dist3d;
+    }
+    const GlobalVector &flightDirection(unsigned int index) const { return m_svData[index].direction; }
+    TaggingVariableList taggingVariables() const override;
 
-    private:
-	std::vector<IndexedTrackData>		m_trackData;
-	std::vector<VertexData>			m_svData;
-	unsigned int				m_vertexCandidates;
+    // Used by ROOT storage
+    CMS_CLASS_VERSION(11)
 
-	edm::Ref<std::vector<IPTI> >		m_trackIPTagInfoRef;
-};
+  private:
+    std::vector<IndexedTrackData> m_trackData;
+    std::vector<VertexData> m_svData;
+    unsigned int m_vertexCandidates;
 
+    edm::Ref<std::vector<IPTI> > m_trackIPTagInfoRef;
+  };
 
-template<class IPTI,class VTX>  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::TemplatedSecondaryVertexTagInfo(
-                const std::vector<IndexedTrackData> &trackData,
-		const std::vector<VertexData> &svData,
-		unsigned int vertexCandidates,
-		const edm::Ref<std::vector<IPTI> > & trackIPTagInfoRef) :
-	m_trackData(trackData),
-	m_svData(svData),
-	m_vertexCandidates(vertexCandidates),
-	m_trackIPTagInfoRef(trackIPTagInfoRef)
-{
-}
+  template <class IPTI, class VTX>
+  TemplatedSecondaryVertexTagInfo<IPTI, VTX>::TemplatedSecondaryVertexTagInfo(
+      const std::vector<IndexedTrackData> &trackData,
+      const std::vector<VertexData> &svData,
+      unsigned int vertexCandidates,
+      const edm::Ref<std::vector<IPTI> > &trackIPTagInfoRef)
+      : m_trackData(trackData),
+        m_svData(svData),
+        m_vertexCandidates(vertexCandidates),
+        m_trackIPTagInfoRef(trackIPTagInfoRef) {}
 
-template<class IPTI,class VTX> unsigned int  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::nVertexTracks() const
-{
-	return std::count_if(m_trackData.begin(), m_trackData.end(),
-	                     VertexTrackSelector());
-}
+  template <class IPTI, class VTX>
+  unsigned int TemplatedSecondaryVertexTagInfo<IPTI, VTX>::nVertexTracks() const {
+    return std::count_if(m_trackData.begin(), m_trackData.end(), VertexTrackSelector());
+  }
 
-template<class IPTI,class VTX> unsigned int  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::nVertexTracks(unsigned int index) const
-{
-	return std::count_if(m_trackData.begin(), m_trackData.end(),
-	                     IndexedVertexTrackSelector(index));
-}
+  template <class IPTI, class VTX>
+  unsigned int TemplatedSecondaryVertexTagInfo<IPTI, VTX>::nVertexTracks(unsigned int index) const {
+    return std::count_if(m_trackData.begin(), m_trackData.end(), IndexedVertexTrackSelector(index));
+  }
 
-template<class IPTI,class VTX> 
-typename reco::TemplatedSecondaryVertexTagInfo<IPTI,VTX>::input_container  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::selectedTracks() const
-{
-	input_container trackRefs;
-	const input_container &trackIPTrackRefs =
-				m_trackIPTagInfoRef->selectedTracks();
+  template <class IPTI, class VTX>
+  typename reco::TemplatedSecondaryVertexTagInfo<IPTI, VTX>::input_container
+  TemplatedSecondaryVertexTagInfo<IPTI, VTX>::selectedTracks() const {
+    input_container trackRefs;
+    const input_container &trackIPTrackRefs = m_trackIPTagInfoRef->selectedTracks();
 
-	for(typename std::vector<typename reco::TemplatedSecondaryVertexTagInfo<IPTI,VTX>::IndexedTrackData>::const_iterator iter =
-		m_trackData.begin(); iter != m_trackData.end(); iter++)
+    for (typename std::vector<
+             typename reco::TemplatedSecondaryVertexTagInfo<IPTI, VTX>::IndexedTrackData>::const_iterator iter =
+             m_trackData.begin();
+         iter != m_trackData.end();
+         iter++)
 
-		trackRefs.push_back(trackIPTrackRefs[iter->first]);
+      trackRefs.push_back(trackIPTrackRefs[iter->first]);
 
-	return trackRefs;
-}
+    return trackRefs;
+  }
 
-template<class IPTI,class VTX> 
-typename TemplatedSecondaryVertexTagInfo<IPTI,VTX>::input_container  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::vertexTracks() const
-{
-	input_container trackRefs;
-	const input_container &trackIPTrackRefs =
-				m_trackIPTagInfoRef->selectedTracks();
+  template <class IPTI, class VTX>
+  typename TemplatedSecondaryVertexTagInfo<IPTI, VTX>::input_container
+  TemplatedSecondaryVertexTagInfo<IPTI, VTX>::vertexTracks() const {
+    input_container trackRefs;
+    const input_container &trackIPTrackRefs = m_trackIPTagInfoRef->selectedTracks();
 
-	for(typename std::vector<typename reco::TemplatedSecondaryVertexTagInfo<IPTI,VTX>::IndexedTrackData>::const_iterator iter =
-		m_trackData.begin(); iter != m_trackData.end(); iter++)
+    for (typename std::vector<
+             typename reco::TemplatedSecondaryVertexTagInfo<IPTI, VTX>::IndexedTrackData>::const_iterator iter =
+             m_trackData.begin();
+         iter != m_trackData.end();
+         iter++)
 
-		if (iter->second.associatedToVertex())
-			trackRefs.push_back(trackIPTrackRefs[iter->first]);
+      if (iter->second.associatedToVertex())
+        trackRefs.push_back(trackIPTrackRefs[iter->first]);
 
-	return trackRefs;
-}  
+    return trackRefs;
+  }
 
-template<class IPTI,class VTX> 
-typename TemplatedSecondaryVertexTagInfo<IPTI,VTX>::input_container  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::vertexTracks(unsigned int index) const
-{
-	input_container trackRefs;
-	const input_container &trackIPTrackRefs =
-				m_trackIPTagInfoRef->selectedTracks();
+  template <class IPTI, class VTX>
+  typename TemplatedSecondaryVertexTagInfo<IPTI, VTX>::input_container
+  TemplatedSecondaryVertexTagInfo<IPTI, VTX>::vertexTracks(unsigned int index) const {
+    input_container trackRefs;
+    const input_container &trackIPTrackRefs = m_trackIPTagInfoRef->selectedTracks();
 
-	for(typename std::vector<typename reco::TemplatedSecondaryVertexTagInfo<IPTI,VTX>::IndexedTrackData>::const_iterator iter =
-		m_trackData.begin(); iter != m_trackData.end(); iter++)
+    for (typename std::vector<
+             typename reco::TemplatedSecondaryVertexTagInfo<IPTI, VTX>::IndexedTrackData>::const_iterator iter =
+             m_trackData.begin();
+         iter != m_trackData.end();
+         iter++)
 
-		if (iter->second.associatedToVertex(index))
-			trackRefs.push_back(trackIPTrackRefs[iter->first]);
+      if (iter->second.associatedToVertex(index))
+        trackRefs.push_back(trackIPTrackRefs[iter->first]);
 
-	return trackRefs;
-}  
+    return trackRefs;
+  }
 
-template<class IPTI,class VTX> typename TemplatedSecondaryVertexTagInfo<IPTI,VTX>::input_container::value_type  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::track(unsigned int index) const
-{
-	return m_trackIPTagInfoRef->selectedTracks()[m_trackData[index].first];
-}
+  template <class IPTI, class VTX>
+  typename TemplatedSecondaryVertexTagInfo<IPTI, VTX>::input_container::value_type
+  TemplatedSecondaryVertexTagInfo<IPTI, VTX>::track(unsigned int index) const {
+    return m_trackIPTagInfoRef->selectedTracks()[m_trackData[index].first];
+  }
 
-template<class IPTI,class VTX> unsigned int  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::findTrack(const typename input_container::value_type &track) const
-{
-	typename std::vector<typename reco::TemplatedSecondaryVertexTagInfo<IPTI,VTX>::IndexedTrackData>::const_iterator pos =
-		std::find_if(m_trackData.begin(), m_trackData.end(),
-		             TrackFinder(m_trackIPTagInfoRef->selectedTracks(),
-		                         track));
+  template <class IPTI, class VTX>
+  unsigned int TemplatedSecondaryVertexTagInfo<IPTI, VTX>::findTrack(
+      const typename input_container::value_type &track) const {
+    typename std::vector<typename reco::TemplatedSecondaryVertexTagInfo<IPTI, VTX>::IndexedTrackData>::const_iterator
+        pos = std::find_if(
+            m_trackData.begin(), m_trackData.end(), TrackFinder(m_trackIPTagInfoRef->selectedTracks(), track));
 
-	if (pos == m_trackData.end())
-		throw edm::Exception(edm::errors::InvalidReference)
-			<< "Track not found in "
-			   " TemplatedSecondaryVertexTagInfo<IPTI,VTX>::findTrack." << std::endl;
+    if (pos == m_trackData.end())
+      throw edm::Exception(edm::errors::InvalidReference) << "Track not found in "
+                                                             " TemplatedSecondaryVertexTagInfo<IPTI,VTX>::findTrack."
+                                                          << std::endl;
 
-	return pos - m_trackData.begin();
-}
+    return pos - m_trackData.begin();
+  }
 
-template<class IPTI,class VTX>
-const typename   TemplatedSecondaryVertexTagInfo<IPTI,VTX>::TrackData&  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::trackData(unsigned int index) const
-{
-	return m_trackData[index].second;
-}
+  template <class IPTI, class VTX>
+  const typename TemplatedSecondaryVertexTagInfo<IPTI, VTX>::TrackData &
+  TemplatedSecondaryVertexTagInfo<IPTI, VTX>::trackData(unsigned int index) const {
+    return m_trackData[index].second;
+  }
 
-template<class IPTI,class VTX>
-const typename  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::TrackData&  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::trackData(const typename input_container::value_type &track) const
-{
-	return m_trackData[findTrack(track)].second;
-}
+  template <class IPTI, class VTX>
+  const typename TemplatedSecondaryVertexTagInfo<IPTI, VTX>::TrackData &
+  TemplatedSecondaryVertexTagInfo<IPTI, VTX>::trackData(const typename input_container::value_type &track) const {
+    return m_trackData[findTrack(track)].second;
+  }
 
-template<class IPTI,class VTX> 
-const reco::btag::TrackIPData& TemplatedSecondaryVertexTagInfo<IPTI,VTX>::trackIPData(unsigned int index) const
-{
-	return m_trackIPTagInfoRef->impactParameterData()[
-						m_trackData[index].first];
-}
+  template <class IPTI, class VTX>
+  const reco::btag::TrackIPData &TemplatedSecondaryVertexTagInfo<IPTI, VTX>::trackIPData(unsigned int index) const {
+    return m_trackIPTagInfoRef->impactParameterData()[m_trackData[index].first];
+  }
 
-template<class IPTI,class VTX>
-const reco::btag::TrackIPData& TemplatedSecondaryVertexTagInfo<IPTI,VTX>::trackIPData(const typename input_container::value_type &track) const
-{
-	return trackIPData(findTrack(track));
-}
+  template <class IPTI, class VTX>
+  const reco::btag::TrackIPData &TemplatedSecondaryVertexTagInfo<IPTI, VTX>::trackIPData(
+      const typename input_container::value_type &track) const {
+    return trackIPData(findTrack(track));
+  }
 
-template<class IPTI,class VTX> float  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::trackWeight(unsigned int svIndex,
-                                          const typename input_container::value_type &track) const
-{
-	return reco::btag::weight(track,m_svData[svIndex].vertex);
-}
+  template <class IPTI, class VTX>
+  float TemplatedSecondaryVertexTagInfo<IPTI, VTX>::trackWeight(
+      unsigned int svIndex, const typename input_container::value_type &track) const {
+    return reco::btag::weight(track, m_svData[svIndex].vertex);
+  }
 
-template<class IPTI,class VTX> float  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::trackWeight(unsigned int svIndex,
-                                          unsigned int trackIndex) const
-{
-	return trackWeight(svIndex, track(trackIndex));
-}
+  template <class IPTI, class VTX>
+  float TemplatedSecondaryVertexTagInfo<IPTI, VTX>::trackWeight(unsigned int svIndex, unsigned int trackIndex) const {
+    return trackWeight(svIndex, track(trackIndex));
+  }
 
-template<class IPTI,class VTX> TaggingVariableList  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::taggingVariables() const
-{
-	TaggingVariableList vars;
+  template <class IPTI, class VTX>
+  TaggingVariableList TemplatedSecondaryVertexTagInfo<IPTI, VTX>::taggingVariables() const {
+    TaggingVariableList vars;
 
-	for(typename std::vector<typename TemplatedSecondaryVertexTagInfo<IPTI,VTX>::VertexData>::const_iterator iter = m_svData.begin();
-	    iter != m_svData.end(); iter++) {
-                vars.insert(btau::flightDistance1dVal,
-                                        iter->dist1d.value(), true);
-                vars.insert(btau::flightDistance1dSig,
-                                        iter->dist1d.significance(), true); 
-		vars.insert(btau::flightDistance2dVal,
-					iter->dist2d.value(), true);
-		vars.insert(btau::flightDistance2dSig,
-					iter->dist2d.significance(), true);
-		vars.insert(btau::flightDistance3dVal,
-					iter->dist3d.value(), true);
-		vars.insert(btau::flightDistance3dSig,
-					iter->dist3d.significance(), true);
+    for (typename std::vector<typename TemplatedSecondaryVertexTagInfo<IPTI, VTX>::VertexData>::const_iterator iter =
+             m_svData.begin();
+         iter != m_svData.end();
+         iter++) {
+      vars.insert(btau::flightDistance1dVal, iter->dist1d.value(), true);
+      vars.insert(btau::flightDistance1dSig, iter->dist1d.significance(), true);
+      vars.insert(btau::flightDistance2dVal, iter->dist2d.value(), true);
+      vars.insert(btau::flightDistance2dSig, iter->dist2d.significance(), true);
+      vars.insert(btau::flightDistance3dVal, iter->dist3d.value(), true);
+      vars.insert(btau::flightDistance3dSig, iter->dist3d.significance(), true);
 
-		vars.insert(btau::vertexJetDeltaR,
-			Geom::deltaR(iter->direction, jet()->momentum()), true);
-	}
+      vars.insert(btau::vertexJetDeltaR, Geom::deltaR(iter->direction, jet()->momentum()), true);
+    }
 
-	vars.insert(btau::jetNSecondaryVertices, m_vertexCandidates, true);
-	vars.insert(btau::vertexNTracks, nVertexTracks(), true);
+    vars.insert(btau::jetNSecondaryVertices, m_vertexCandidates, true);
+    vars.insert(btau::vertexNTracks, nVertexTracks(), true);
 
-	vars.finalize();
-	return vars;
-}
+    vars.finalize();
+    return vars;
+  }
 
-}
-#endif // DataFormats_BTauReco_TemplatedSecondaryVertexTagInfo_h
+}  // namespace reco
+#endif  // DataFormats_BTauReco_TemplatedSecondaryVertexTagInfo_h

--- a/DataFormats/BTauReco/interface/TemplatedSoftLeptonTagInfo.h
+++ b/DataFormats/BTauReco/interface/TemplatedSoftLeptonTagInfo.h
@@ -12,132 +12,117 @@
 
 namespace reco {
 
-class SoftLeptonProperties {
-public:
-    SoftLeptonProperties() :
-        sip2dsig(    std::numeric_limits<float>::quiet_NaN() ),
-        sip3dsig(    std::numeric_limits<float>::quiet_NaN() ),
-        sip2d(    std::numeric_limits<float>::quiet_NaN() ),
-        sip3d(    std::numeric_limits<float>::quiet_NaN() ),
-        ptRel(    std::numeric_limits<float>::quiet_NaN() ),
-        p0Par(    std::numeric_limits<float>::quiet_NaN() ),
-        etaRel(   std::numeric_limits<float>::quiet_NaN() ),
-        deltaR(   std::numeric_limits<float>::quiet_NaN() ),
-        ratio(    std::numeric_limits<float>::quiet_NaN() ),
-        ratioRel( std::numeric_limits<float>::quiet_NaN() ),
-        elec_mva( std::numeric_limits<float>::quiet_NaN() ),
-        charge(   -10 )
-    { }
+  class SoftLeptonProperties {
+  public:
+    SoftLeptonProperties()
+        : sip2dsig(std::numeric_limits<float>::quiet_NaN()),
+          sip3dsig(std::numeric_limits<float>::quiet_NaN()),
+          sip2d(std::numeric_limits<float>::quiet_NaN()),
+          sip3d(std::numeric_limits<float>::quiet_NaN()),
+          ptRel(std::numeric_limits<float>::quiet_NaN()),
+          p0Par(std::numeric_limits<float>::quiet_NaN()),
+          etaRel(std::numeric_limits<float>::quiet_NaN()),
+          deltaR(std::numeric_limits<float>::quiet_NaN()),
+          ratio(std::numeric_limits<float>::quiet_NaN()),
+          ratioRel(std::numeric_limits<float>::quiet_NaN()),
+          elec_mva(std::numeric_limits<float>::quiet_NaN()),
+          charge(-10) {}
 
-    float sip2dsig;                            // 2D signed impact parameter significance
-    float sip3dsig;                            // 3D signed impact parameter significance
-    float sip2d;                            // 2D signed impact parameter
-    float sip3d;                            // 3D signed impact parameter
-    float ptRel;                            // transverse momentum wrt. the jet axis
-    float p0Par;                            // momentum along the jet direction, in the jet rest frame
+    float sip2dsig;  // 2D signed impact parameter significance
+    float sip3dsig;  // 3D signed impact parameter significance
+    float sip2d;     // 2D signed impact parameter
+    float sip3d;     // 3D signed impact parameter
+    float ptRel;     // transverse momentum wrt. the jet axis
+    float p0Par;     // momentum along the jet direction, in the jet rest frame
 
-    float etaRel;                           // (pseudo)rapidity along jet axis
-    float deltaR;                           // (pseudo)angular distance to jet axis
-    float ratio;                            // momentum over jet energy
-    float ratioRel;                         // momentum parallel to jet axis over jet energy
+    float etaRel;    // (pseudo)rapidity along jet axis
+    float deltaR;    // (pseudo)angular distance to jet axis
+    float ratio;     // momentum over jet energy
+    float ratioRel;  // momentum parallel to jet axis over jet energy
 
     float elec_mva;
 
     int charge;
 
     struct Quality {
-        static const float undef;
+      static const float undef;
 
-	// these first two entries work for both electrons and muons,
-	// entries afterwards can be specific to either one
-	// electrons & muons shared the same indicies to avoid waste of space
-        enum Generic {
-            leptonId = 0,
-            btagLeptonCands
-        };
+      // these first two entries work for both electrons and muons,
+      // entries afterwards can be specific to either one
+      // electrons & muons shared the same indicies to avoid waste of space
+      enum Generic { leptonId = 0, btagLeptonCands };
 
-        enum Electron {
-            pfElectronId = 0,
-            btagElectronCands,
-	    egammaElectronId
-        };
+      enum Electron { pfElectronId = 0, btagElectronCands, egammaElectronId };
 
-        enum Muon {
-            muonId = 0,
-	    btagMuonCands
-        };
+      enum Muon { muonId = 0, btagMuonCands };
 
-        template<typename T> static inline T byName(const char *name)
-        { return static_cast<T>(internalByName(name)); }
+      template <typename T>
+      static inline T byName(const char *name) {
+        return static_cast<T>(internalByName(name));
+      }
 
-      private:
-        static unsigned int internalByName(const char *name);
+    private:
+      static unsigned int internalByName(const char *name);
     };
 
     // check to see if quality has been set
 
-    inline float hasQuality() const
-    { return quality() != Quality::undef; }
-    inline float hasQuality(Quality::Generic qual) const
-    { return quality((unsigned int)qual, false) != Quality::undef; }
-    inline float hasQuality(Quality::Muon qual) const
-    { return quality((unsigned int)qual, false) != Quality::undef; }
-    inline float hasQuality(Quality::Electron qual) const
-    { return quality((unsigned int)qual, false) != Quality::undef; }
+    inline float hasQuality() const { return quality() != Quality::undef; }
+    inline float hasQuality(Quality::Generic qual) const {
+      return quality((unsigned int)qual, false) != Quality::undef;
+    }
+    inline float hasQuality(Quality::Muon qual) const { return quality((unsigned int)qual, false) != Quality::undef; }
+    inline float hasQuality(Quality::Electron qual) const {
+      return quality((unsigned int)qual, false) != Quality::undef;
+    }
 
     // retrieve lepton quality
 
-    inline float quality(Quality::Generic qual, bool throwIfUndefined = true) const
-    { return quality((unsigned int)qual, throwIfUndefined); }
-    inline float quality(Quality::Muon qual, bool throwIfUndefined = true) const
-    { return quality((unsigned int)qual, throwIfUndefined); }
-    inline float quality(Quality::Electron qual, bool throwIfUndefined = true) const
-    { return quality((unsigned int)qual, throwIfUndefined); }
+    inline float quality(Quality::Generic qual, bool throwIfUndefined = true) const {
+      return quality((unsigned int)qual, throwIfUndefined);
+    }
+    inline float quality(Quality::Muon qual, bool throwIfUndefined = true) const {
+      return quality((unsigned int)qual, throwIfUndefined);
+    }
+    inline float quality(Quality::Electron qual, bool throwIfUndefined = true) const {
+      return quality((unsigned int)qual, throwIfUndefined);
+    }
 
     // default value
     inline float quality() const { return quality(0, false); }
 
     // set lepton quality
 
-    inline void setQuality(Quality::Generic qual, float value)
-    { setQuality((unsigned int)qual, value); }
-    inline void setQuality(Quality::Muon qual, float value)
-    { setQuality((unsigned int)qual, value); }
-    inline void setQuality(Quality::Electron qual, float value)
-    { setQuality((unsigned int)qual, value); }
+    inline void setQuality(Quality::Generic qual, float value) { setQuality((unsigned int)qual, value); }
+    inline void setQuality(Quality::Muon qual, float value) { setQuality((unsigned int)qual, value); }
+    inline void setQuality(Quality::Electron qual, float value) { setQuality((unsigned int)qual, value); }
 
-private:
+  private:
     float quality(unsigned int index, bool throwIfUndefined) const;
     void setQuality(unsigned int index, float value);
 
-    std::vector<float> qualities_;          // lepton qualities
-};
+    std::vector<float> qualities_;  // lepton qualities
+  };
 
-template<class REF>
-class TemplatedSoftLeptonTagInfo : public JetTagInfo {
-public:
-    typedef std::vector< std::pair< REF, SoftLeptonProperties > > LeptonMap;
-    
+  template <class REF>
+  class TemplatedSoftLeptonTagInfo : public JetTagInfo {
+  public:
+    typedef std::vector<std::pair<REF, SoftLeptonProperties> > LeptonMap;
+
     TemplatedSoftLeptonTagInfo(void) : m_leptons() {}
 
     ~TemplatedSoftLeptonTagInfo(void) override {}
-  
-    TemplatedSoftLeptonTagInfo* clone(void) const override { return new TemplatedSoftLeptonTagInfo(*this); }
 
-    unsigned int leptons(void) const { 
-        return m_leptons.size(); 
-    } 
+    TemplatedSoftLeptonTagInfo *clone(void) const override { return new TemplatedSoftLeptonTagInfo(*this); }
 
-    const REF & lepton(size_t i) const {
-        return m_leptons[i].first;
-    }
-    
-    const SoftLeptonProperties & properties(size_t i) const {
-        return m_leptons[i].second;
-    }
+    unsigned int leptons(void) const { return m_leptons.size(); }
 
-    void insert(const REF & lepton, const SoftLeptonProperties & properties) {
-        m_leptons.push_back( std::pair< REF, SoftLeptonProperties > (lepton, properties) );
+    const REF &lepton(size_t i) const { return m_leptons[i].first; }
+
+    const SoftLeptonProperties &properties(size_t i) const { return m_leptons[i].second; }
+
+    void insert(const REF &lepton, const SoftLeptonProperties &properties) {
+      m_leptons.push_back(std::pair<REF, SoftLeptonProperties>(lepton, properties));
     }
 
     /// returns a description of the extended informations in a TaggingVariableList
@@ -146,47 +131,49 @@ public:
     // Used by ROOT storage
     CMS_CLASS_VERSION(2)
 
-private:
+  private:
     LeptonMap m_leptons;
+  };
 
-};
+  template <class REF>
+  TaggingVariableList TemplatedSoftLeptonTagInfo<REF>::taggingVariables(void) const {
+    TaggingVariableList list;
 
-template<class REF>
-TaggingVariableList TemplatedSoftLeptonTagInfo<REF>::taggingVariables(void) const {
-  TaggingVariableList list;
+    const Jet &jet = *(this->jet());
+    list.insert(TaggingVariable(btau::jetEnergy, jet.energy()), true);
+    list.insert(TaggingVariable(btau::jetPt, jet.et()), true);
+    list.insert(TaggingVariable(btau::jetEta, jet.eta()), true);
+    list.insert(TaggingVariable(btau::jetPhi, jet.phi()), true);
 
-  const Jet & jet = *( this->jet() );
-  list.insert( TaggingVariable(btau::jetEnergy, jet.energy()), true );
-  list.insert( TaggingVariable(btau::jetPt,     jet.et()),     true );
-  list.insert( TaggingVariable(btau::jetEta,    jet.eta()),    true );
-  list.insert( TaggingVariable(btau::jetPhi,    jet.phi()),    true );
+    for (unsigned int i = 0; i < m_leptons.size(); ++i) {
+      const REF &trackRef = m_leptons[i].first;
+      list.insert(TaggingVariable(btau::trackMomentum, reco::btag::toTrack(trackRef)->p()), true);
+      list.insert(TaggingVariable(btau::trackEta, reco::btag::toTrack(trackRef)->eta()), true);
+      list.insert(TaggingVariable(btau::trackPhi, reco::btag::toTrack(trackRef)->phi()), true);
+      list.insert(TaggingVariable(btau::trackChi2, reco::btag::toTrack(trackRef)->normalizedChi2()), true);
+      const SoftLeptonProperties &data = m_leptons[i].second;
+      list.insert(TaggingVariable(btau::leptonQuality, data.quality(SoftLeptonProperties::Quality::leptonId, false)),
+                  true);
+      list.insert(
+          TaggingVariable(btau::leptonQuality2, data.quality(SoftLeptonProperties::Quality::btagLeptonCands, false)),
+          true);
+      list.insert(TaggingVariable(btau::trackSip2dVal, data.sip2d), true);
+      list.insert(TaggingVariable(btau::trackSip3dVal, data.sip3d), true);
+      list.insert(TaggingVariable(btau::trackSip2dSig, data.sip2dsig), true);
+      list.insert(TaggingVariable(btau::trackSip3dSig, data.sip3dsig), true);
+      list.insert(TaggingVariable(btau::trackPtRel, data.ptRel), true);
+      list.insert(TaggingVariable(btau::trackP0Par, data.p0Par), true);
+      list.insert(TaggingVariable(btau::trackEtaRel, data.etaRel), true);
+      list.insert(TaggingVariable(btau::trackDeltaR, data.deltaR), true);
+      list.insert(TaggingVariable(btau::trackPParRatio, data.ratioRel), true);
+      list.insert(TaggingVariable(btau::electronMVA, data.elec_mva), true);
+      list.insert(TaggingVariable(btau::trackCharge, data.charge), true);
+    }
 
-  for (unsigned int i = 0; i < m_leptons.size(); ++i) {
-    const REF & trackRef = m_leptons[i].first;
-    list.insert( TaggingVariable(btau::trackMomentum,  reco::btag::toTrack(trackRef)->p()),     true );
-    list.insert( TaggingVariable(btau::trackEta,       reco::btag::toTrack(trackRef)->eta()),   true );
-    list.insert( TaggingVariable(btau::trackPhi,       reco::btag::toTrack(trackRef)->phi()),   true );
-    list.insert( TaggingVariable(btau::trackChi2,      reco::btag::toTrack(trackRef)->normalizedChi2()), true );
-    const SoftLeptonProperties & data = m_leptons[i].second;
-    list.insert( TaggingVariable(btau::leptonQuality,  data.quality(SoftLeptonProperties::Quality::leptonId, false)), true );
-    list.insert( TaggingVariable(btau::leptonQuality2, data.quality(SoftLeptonProperties::Quality::btagLeptonCands, false)), true );
-    list.insert( TaggingVariable(btau::trackSip2dVal,  data.sip2d),    true );
-    list.insert( TaggingVariable(btau::trackSip3dVal,  data.sip3d),    true );
-    list.insert( TaggingVariable(btau::trackSip2dSig,  data.sip2dsig),    true );
-    list.insert( TaggingVariable(btau::trackSip3dSig,  data.sip3dsig),    true );
-    list.insert( TaggingVariable(btau::trackPtRel,     data.ptRel),    true );
-    list.insert( TaggingVariable(btau::trackP0Par,     data.p0Par),    true );
-    list.insert( TaggingVariable(btau::trackEtaRel,    data.etaRel),   true );
-    list.insert( TaggingVariable(btau::trackDeltaR,    data.deltaR),   true );
-    list.insert( TaggingVariable(btau::trackPParRatio, data.ratioRel), true );
-    list.insert( TaggingVariable(btau::electronMVA,    data.elec_mva), true );
-    list.insert( TaggingVariable(btau::trackCharge,    data.charge),   true );
+    list.finalize();
+    return list;
   }
 
-  list.finalize();
-  return list;
-}
+}  // namespace reco
 
-}
-
-#endif // DataFormats_BTauReco_TemplatedSoftLeptonTagInfo_h
+#endif  // DataFormats_BTauReco_TemplatedSoftLeptonTagInfo_h

--- a/DataFormats/BTauReco/interface/TrackCountingTagInfo.h
+++ b/DataFormats/BTauReco/interface/TrackCountingTagInfo.h
@@ -7,88 +7,79 @@
 #include "DataFormats/BTauReco/interface/JTATagInfo.h"
 
 namespace reco {
- 
-class TrackCountingTagInfo : public JTATagInfo
- {
+
+  class TrackCountingTagInfo : public JTATagInfo {
   public:
+    TrackCountingTagInfo(const std::vector<double>& significance2d,
+                         const std::vector<double>& significance3d,
+                         const std::vector<int>& trackOrder2d,
+                         const std::vector<int>& trackOrder3d,
+                         const JetTracksAssociationRef& jtaRef)
+        : JTATagInfo(jtaRef),
+          m_significance2d(significance2d),
+          m_significance3d(significance3d),
+          m_trackOrder2d(trackOrder2d),
+          m_trackOrder3d(trackOrder3d) {}
 
- TrackCountingTagInfo(
-   const std::vector<double>& significance2d,
-   const std::vector<double>& significance3d,
-   const std::vector<int>& trackOrder2d,
-   const std::vector<int>& trackOrder3d,const JetTracksAssociationRef & jtaRef) : JTATagInfo(jtaRef),
-     m_significance2d(significance2d),
-     m_significance3d(significance3d),
-     m_trackOrder2d(trackOrder2d),
-     m_trackOrder3d(trackOrder3d)     {}
+    TrackCountingTagInfo() {}
 
-  TrackCountingTagInfo() {}
-  
-  ~TrackCountingTagInfo() override {}
-  
-  /* virtual const Track & track(size_t n,int ipType) const
+    ~TrackCountingTagInfo() override {}
+
+    /* virtual const Track & track(size_t n,int ipType) const
   {
     return tracks()[trackIndex(n,ipType)];
   } */
 
-  virtual float significance(size_t n,int ip) const 
-   {
-    if(ip == 0)
-    {
-     if(n <m_significance3d.size())
-      return m_significance3d[n];  
+    virtual float significance(size_t n, int ip) const {
+      if (ip == 0) {
+        if (n < m_significance3d.size())
+          return m_significance3d[n];
+      } else {
+        if (n < m_significance2d.size())
+          return m_significance2d[n];
+      }
+      return -10.;
     }
-    else
-    {
-     if(n <m_significance2d.size())
-      return m_significance2d[n];  
-    }
-    return -10.; 
-   }
 
-   virtual int trackIndex(size_t n,int ip) const
-   {
-    if(ip == 0)
-    {
-     if(n <m_significance3d.size())
-      return m_trackOrder3d[n];
+    virtual int trackIndex(size_t n, int ip) const {
+      if (ip == 0) {
+        if (n < m_significance3d.size())
+          return m_trackOrder3d[n];
+      } else {
+        if (n < m_significance2d.size())
+          return m_trackOrder2d[n];
+      }
+      return 0;
     }
-    else
-    {
-     if(n <m_significance2d.size())
-      return m_trackOrder2d[n];
-    }
-    return 0;
-   }
 
-   
- /**
+    /**
   Recompute discriminator using nth track i.p. significance.
   ipType = 0 means 3d impact parameter
   ipType = 1 means transverse impact parameter
  */
-  virtual float discriminator(size_t nth, int ipType) const { return significance(nth-1,ipType); }
- 
-  virtual int selectedTracks(int ipType) const
-  {
-   if(ipType == 0) return m_significance3d.size();
-   else return m_significance2d.size();
-  }   
-  
-  TrackCountingTagInfo* clone() const override { return new TrackCountingTagInfo( * this ); }
- 
+    virtual float discriminator(size_t nth, int ipType) const { return significance(nth - 1, ipType); }
+
+    virtual int selectedTracks(int ipType) const {
+      if (ipType == 0)
+        return m_significance3d.size();
+      else
+        return m_significance2d.size();
+    }
+
+    TrackCountingTagInfo* clone() const override { return new TrackCountingTagInfo(*this); }
+
   private:
-   std::vector<double> m_significance2d;  //create a smarter container instead of 
-   std::vector<double> m_significance3d;  //create a smarter container instead of 
-   std::vector<int> m_trackOrder2d;       // this  pair of vectors. 
-   std::vector<int> m_trackOrder3d;       // this  pair of vectors. 
- };
+    std::vector<double> m_significance2d;  //create a smarter container instead of
+    std::vector<double> m_significance3d;  //create a smarter container instead of
+    std::vector<int> m_trackOrder2d;       // this  pair of vectors.
+    std::vector<int> m_trackOrder3d;       // this  pair of vectors.
+  };
 
-//typedef edm::ExtCollection< TrackCountingTagInfo,JetTagCollection> TrackCountingExtCollection;
-//typedef edm::OneToOneAssociation<JetTagCollection, TrackCountingTagInfo> TrackCountingExtCollection;
- 
-DECLARE_EDM_REFS( TrackCountingTagInfo )
+  //typedef edm::ExtCollection< TrackCountingTagInfo,JetTagCollection> TrackCountingExtCollection;
+  //typedef edm::OneToOneAssociation<JetTagCollection, TrackCountingTagInfo> TrackCountingExtCollection;
 
-}
+  DECLARE_EDM_REFS(TrackCountingTagInfo)
 
-#endif // DataFormats_BTauReco_BJetTagTrackCounting_h
+}  // namespace reco
+
+#endif  // DataFormats_BTauReco_BJetTagTrackCounting_h

--- a/DataFormats/BTauReco/interface/TrackIPTagInfo.h
+++ b/DataFormats/BTauReco/interface/TrackIPTagInfo.h
@@ -7,11 +7,10 @@
 #include "DataFormats/BTauReco/interface/IPTagInfo.h"
 
 namespace reco {
-typedef IPTagInfo<TrackRefVector,JTATagInfo> TrackIPTagInfo;
+  typedef IPTagInfo<TrackRefVector, JTATagInfo> TrackIPTagInfo;
 
+  DECLARE_EDM_REFS(TrackIPTagInfo)
 
-DECLARE_EDM_REFS( TrackIPTagInfo )
-
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/BTauReco/interface/TrackPairFeatures.h
+++ b/DataFormats/BTauReco/interface/TrackPairFeatures.h
@@ -3,10 +3,8 @@
 
 namespace btagbtvdeep {
 
-class TrackPairFeatures {
-
+  class TrackPairFeatures {
   public:
-
     float pt;
     float eta;
     float phi;
@@ -18,34 +16,33 @@ class TrackPairFeatures {
     float ip2D;
     float sip2D;
     float distPCA;
-    float dsigPCA;      
+    float dsigPCA;
     float x_PCAonSeed;
     float y_PCAonSeed;
-    float z_PCAonSeed;      
+    float z_PCAonSeed;
     float xerr_PCAonSeed;
     float yerr_PCAonSeed;
-    float zerr_PCAonSeed;      
+    float zerr_PCAonSeed;
     float x_PCAonTrack;
     float y_PCAonTrack;
-    float z_PCAonTrack;      
+    float z_PCAonTrack;
     float xerr_PCAonTrack;
     float yerr_PCAonTrack;
-    float zerr_PCAonTrack; 
+    float zerr_PCAonTrack;
     float dotprodTrack;
     float dotprodSeed;
     float dotprodTrackSeed2D;
     float dotprodTrackSeed3D;
     float dotprodTrackSeedVectors2D;
-    float dotprodTrackSeedVectors3D;      
+    float dotprodTrackSeedVectors3D;
     float pvd_PCAonSeed;
     float pvd_PCAonTrack;
     float dist_PCAjetAxis;
     float dotprod_PCAjetMomenta;
     float deta_PCAjetDirs;
     float dphi_PCAjetDirs;
+  };
 
-};
+}  // namespace btagbtvdeep
 
-}
-
-#endif 
+#endif

--- a/DataFormats/BTauReco/interface/TrackProbabilityTagInfo.h
+++ b/DataFormats/BTauReco/interface/TrackProbabilityTagInfo.h
@@ -7,89 +7,82 @@
 #include "DataFormats/JetReco/interface/JetTracksAssociation.h"
 
 namespace reco {
- 
-class TrackProbabilityTagInfo : public JTATagInfo
- {
+
+  class TrackProbabilityTagInfo : public JTATagInfo {
   public:
+    TrackProbabilityTagInfo(const std::vector<double>& probability2d,
+                            const std::vector<double>& probability3d,
+                            const std::vector<int>& trackOrder2d,
+                            const std::vector<int>& trackOrder3d,
+                            const JetTracksAssociationRef& jtaRef)
+        : JTATagInfo(jtaRef),
+          m_probability2d(probability2d),
+          m_probability3d(probability3d),
+          m_trackOrder2d(trackOrder2d),
+          m_trackOrder3d(trackOrder3d) {}
 
- TrackProbabilityTagInfo(
-   const std::vector<double>& probability2d,
-   const std::vector<double>& probability3d,
-   const std::vector<int>& trackOrder2d,
-   const std::vector<int>& trackOrder3d,const JetTracksAssociationRef & jtaRef) : JTATagInfo(jtaRef),
-     m_probability2d(probability2d),
-     m_probability3d(probability3d),
-     m_trackOrder2d(trackOrder2d),
-     m_trackOrder3d(trackOrder3d)     {}
+    TrackProbabilityTagInfo() {}
 
-  TrackProbabilityTagInfo() {}
-  
-  ~TrackProbabilityTagInfo() override {}
+    ~TrackProbabilityTagInfo() override {}
 
-int factorial(int n) const
-{
- if(n<2) return 1;
- else return n*factorial(n-1);
-}
-  
-  virtual float probability(size_t n,int ip) const 
-   {
-    if(ip == 0)
-    {
-     if(n <m_probability3d.size())
-      return m_probability3d[n];  
+    int factorial(int n) const {
+      if (n < 2)
+        return 1;
+      else
+        return n * factorial(n - 1);
     }
-    else
-    {
-     if(n <m_probability2d.size())
-      return m_probability2d[n];  
+
+    virtual float probability(size_t n, int ip) const {
+      if (ip == 0) {
+        if (n < m_probability3d.size())
+          return m_probability3d[n];
+      } else {
+        if (n < m_probability2d.size())
+          return m_probability2d[n];
+      }
+      return -10.;
     }
-    return -10.; 
-   }
 
-  virtual float jetProbability(int ip, float minTrackProb) const
-{
+    virtual float jetProbability(int ip, float minTrackProb) const {
+      const std::vector<double>* vp;
+      if (ip == 0)
+        vp = &m_probability3d;
+      else
+        vp = &m_probability2d;
+      const std::vector<double>& v = *vp;
 
- const std::vector<double> * vp;
-   if(ip==0) vp= &m_probability3d;
-   else vp= &m_probability2d;
-   const std::vector<double> & v =*vp;
+      int ngoodtracks = v.size();
+      double SumJet = 0.;
 
-   int ngoodtracks=v.size();
-   double SumJet=0.;
+      for (std::vector<double>::const_iterator q = v.begin(); q != v.end(); q++) {
+        SumJet += (*q > minTrackProb) ? log(*q) : log(minTrackProb);
+      }
 
-  for(std::vector<double>::const_iterator q = v.begin(); q != v.end(); q++){
-    SumJet+=(*q>minTrackProb)?log(*q):log(minTrackProb);
-  }
+      double ProbJet;
+      double Loginvlog = 0;
 
-  double ProbJet;
-  double Loginvlog=0;
+      if (SumJet < 0.) {
+        if (ngoodtracks >= 2) {
+          Loginvlog = log(-SumJet);
+        }
+        double Prob = 1.;
+        for (int l = 1; l != ngoodtracks; l++) {
+          Prob += exp(l * Loginvlog - log(1. * factorial(l)));
+        }
+        double LogProb = log(Prob);
+        ProbJet = std::min(exp(std::max(LogProb + SumJet, -30.)), 1.);
+      } else {
+        ProbJet = 1.;
+      }
+      if (ProbJet > 1)
+        std::cout << "ProbJet too high: " << ProbJet << std::endl;
 
-  if(SumJet<0.){
-    if(ngoodtracks>=2){
-      Loginvlog=log(-SumJet);
+      //double LogProbJet=-log(ProbJet);
+      //return 1.-ProbJet;
+      return -log10(ProbJet) / 4.;
     }
-    double Prob=1.;
-    for(int l=1; l!=ngoodtracks; l++){
 
-      Prob+=exp(l*Loginvlog-log(1.*factorial(l)));
-    }
-    double LogProb=log(Prob);
-    ProbJet=
-      std::min(exp(std::max(LogProb+SumJet,-30.)),1.);
-  }else{
-    ProbJet=1.;
-  }
-  if(ProbJet>1)
-   std::cout << "ProbJet too high: "  << ProbJet << std::endl;
-
-  //double LogProbJet=-log(ProbJet);
-  //return 1.-ProbJet;
-  return -log10(ProbJet)/4.;
-}
-
-   
- /**
+    /**
   Recompute discriminator 
   ipType = 0 means 3d impact parameter
   ipType = 1 means transverse impact parameter
@@ -97,46 +90,40 @@ int factorial(int n) const
   minProb is the minimum probability allowed  for a single track. Tracks with lower probability 
   are considered with a probability = minProb.
  */
-  virtual float discriminator(int ipType, float minProb) const { return jetProbability(ipType,minProb); }
+    virtual float discriminator(int ipType, float minProb) const { return jetProbability(ipType, minProb); }
 
-  virtual int selectedTracks(int ipType) const
-  {
-   if(ipType == 0) return m_probability3d.size();
-   else return m_probability2d.size();
-  }
-     virtual int trackIndex(size_t n,int ip) const
-   {
-    if(ip == 0)
-    {
-     if(n <m_probability3d.size())
-      return m_trackOrder3d[n];
+    virtual int selectedTracks(int ipType) const {
+      if (ipType == 0)
+        return m_probability3d.size();
+      else
+        return m_probability2d.size();
     }
-    else
-    {
-     if(n <m_probability2d.size())
-      return m_trackOrder2d[n];
+    virtual int trackIndex(size_t n, int ip) const {
+      if (ip == 0) {
+        if (n < m_probability3d.size())
+          return m_trackOrder3d[n];
+      } else {
+        if (n < m_probability2d.size())
+          return m_trackOrder2d[n];
+      }
+      return 0;
     }
-    return 0;
-   }
- 
-  virtual const Track & track(size_t n,int ipType) const
-  {
-    return *tracks()[trackIndex(n,ipType)];
-  }
- 
-  TrackProbabilityTagInfo* clone() const override { return new TrackProbabilityTagInfo( * this ); }
-  
+
+    virtual const Track& track(size_t n, int ipType) const { return *tracks()[trackIndex(n, ipType)]; }
+
+    TrackProbabilityTagInfo* clone() const override { return new TrackProbabilityTagInfo(*this); }
+
   private:
-   std::vector<double> m_probability2d;     //
-   std::vector<double> m_probability3d;     // create a smarter container instead of 
-   std::vector<int> m_trackOrder2d;         // this pair of vectors. 
-   std::vector<int> m_trackOrder3d;         //
- };
+    std::vector<double> m_probability2d;  //
+    std::vector<double> m_probability3d;  // create a smarter container instead of
+    std::vector<int> m_trackOrder2d;      // this pair of vectors.
+    std::vector<int> m_trackOrder3d;      //
+  };
 
-//typedef edm::ExtCollection< TrackProbabilityTagInfo,JetTagCollection> TrackProbabilityExtCollection;
-//typedef edm::OneToOneAssociation<JetTagCollection, TrackProbabilityTagInfo> TrackProbabilityExtCollection;
- 
-DECLARE_EDM_REFS( TrackProbabilityTagInfo )
+  //typedef edm::ExtCollection< TrackProbabilityTagInfo,JetTagCollection> TrackProbabilityExtCollection;
+  //typedef edm::OneToOneAssociation<JetTagCollection, TrackProbabilityTagInfo> TrackProbabilityExtCollection;
 
-}
+  DECLARE_EDM_REFS(TrackProbabilityTagInfo)
+
+}  // namespace reco
 #endif

--- a/DataFormats/BTauReco/interface/VertexTypes.h
+++ b/DataFormats/BTauReco/interface/VertexTypes.h
@@ -4,9 +4,9 @@
 #include <string>
 
 namespace reco {
-namespace btag {
-  namespace Vertices {
-    /** Type of secondary vertex found in jet:
+  namespace btag {
+    namespace Vertices {
+      /** Type of secondary vertex found in jet:
      *  - RecoVertex   : a secondary vertex has been fitted from
      *                   a selection of tracks
      *  - PseudoVertex : no RecoVertex has been found but tracks
@@ -15,16 +15,16 @@ namespace btag {
      *  - NoVertex     : neither of the above attemps were successfull
      *  - NotDefined   : if anything went wrong, set to this value
      */
-    enum VertexType {RecoVertex=0, PseudoVertex=1, NoVertex=2, UndefVertex=99 };
+      enum VertexType { RecoVertex = 0, PseudoVertex = 1, NoVertex = 2, UndefVertex = 99 };
 
-    /**
+      /**
      *  convenience functions that return descriptive strings, rather than
      *  integral types
      */
-    std::string name ( VertexType );
-    VertexType type ( const std::string & );
-  }
-}
-}
+      std::string name(VertexType);
+      VertexType type(const std::string&);
+    }  // namespace Vertices
+  }    // namespace btag
+}  // namespace reco
 
 #endif

--- a/DataFormats/BTauReco/src/IsolatedTauTagInfo.cc
+++ b/DataFormats/BTauReco/src/IsolatedTauTagInfo.cc
@@ -1,178 +1,192 @@
 #include "DataFormats/BTauReco/interface/IsolatedTauTagInfo.h"
-#include "DataFormats/TrackReco/interface/Track.h" 
-#include "DataFormats/TrackReco/interface/TrackFwd.h" 
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include <Math/GenVector/VectorUtil.h>
 
 using namespace edm;
 using namespace reco;
 
-const RefVector<TrackCollection> IsolatedTauTagInfo::tracksInCone( const math::XYZVector& myVector, const float size,  const float pt_min) const { 
-  
+const RefVector<TrackCollection> IsolatedTauTagInfo::tracksInCone(const math::XYZVector& myVector,
+                                                                  const float size,
+                                                                  const float pt_min) const {
   RefVector<TrackCollection> tmp;
- 
+
   RefVector<TrackCollection>::const_iterator myTrack = selectedTracks_.begin();
-  for(;myTrack != selectedTracks_.end(); myTrack++)
-    {
-      const math::XYZVector trackMomentum = (*myTrack)->momentum() ;
-      float pt_tk = (*myTrack)->pt();
-      float deltaR = ROOT::Math::VectorUtil::DeltaR(myVector, trackMomentum);
-      if ( deltaR < size && pt_tk > pt_min) tmp.push_back( *myTrack);
-      }
+  for (; myTrack != selectedTracks_.end(); myTrack++) {
+    const math::XYZVector trackMomentum = (*myTrack)->momentum();
+    float pt_tk = (*myTrack)->pt();
+    float deltaR = ROOT::Math::VectorUtil::DeltaR(myVector, trackMomentum);
+    if (deltaR < size && pt_tk > pt_min)
+      tmp.push_back(*myTrack);
+  }
 
   //  sort(tmp.begin(), tmp.end(), SortByDescendingTrackPt());
   return tmp;
 }
 
-const RefVector<TrackCollection> IsolatedTauTagInfo::tracksInCone( const math::XYZVector& myVector, const float size,  const float pt_min, const float z_pv, const float dz_lt) const { 
-  
+const RefVector<TrackCollection> IsolatedTauTagInfo::tracksInCone(
+    const math::XYZVector& myVector, const float size, const float pt_min, const float z_pv, const float dz_lt) const {
   RefVector<TrackCollection> tmp;
- 
+
   RefVector<TrackCollection>::const_iterator myTrack = selectedTracks_.begin();
-  for(;myTrack != selectedTracks_.end(); myTrack++)
-    {
-      const math::XYZVector trackMomentum = (*myTrack)->momentum() ;
-      float pt_tk = (*myTrack)->pt();
-      float deltaR = ROOT::Math::VectorUtil::DeltaR(myVector, trackMomentum);
-      if ( deltaR < size && pt_tk > pt_min && fabs((*myTrack)->dz() - z_pv) < dz_lt) tmp.push_back( *myTrack);
-      }
+  for (; myTrack != selectedTracks_.end(); myTrack++) {
+    const math::XYZVector trackMomentum = (*myTrack)->momentum();
+    float pt_tk = (*myTrack)->pt();
+    float deltaR = ROOT::Math::VectorUtil::DeltaR(myVector, trackMomentum);
+    if (deltaR < size && pt_tk > pt_min && fabs((*myTrack)->dz() - z_pv) < dz_lt)
+      tmp.push_back(*myTrack);
+  }
 
   //  sort(tmp.begin(), tmp.end(), SortByDescendingTrackPt());
   return tmp;
 }
 
+void IsolatedTauTagInfo::setLeadingTrack(const TrackRef leadTk) { leadTrack_ = leadTk; }
 
-void IsolatedTauTagInfo::setLeadingTrack(const TrackRef leadTk) {
-  leadTrack_ = leadTk ;
-
-}
-
-const TrackRef  IsolatedTauTagInfo::leadingSignalTrack() const {
-  return leadTrack_;
-}
+const TrackRef IsolatedTauTagInfo::leadingSignalTrack() const { return leadTrack_; }
 
 const TrackRef IsolatedTauTagInfo::leadingSignalTrack(const float rm_cone, const float pt_min) const {
+  const Jet& myjet = *jet();
+  math::XYZVector jet3Vec(myjet.px(), myjet.py(), myjet.pz());
 
-  const Jet & myjet = * jet(); 
-  math::XYZVector jet3Vec   (myjet.px(),myjet.py(),myjet.pz()) ;
-
-  const  RefVector<TrackCollection>  sTracks = tracksInCone(jet3Vec, rm_cone, pt_min);
+  const RefVector<TrackCollection> sTracks = tracksInCone(jet3Vec, rm_cone, pt_min);
   TrackRef leadTk;
   float pt_cut = pt_min;
-  if (!sTracks.empty()) 
-    {
-      RefVector<TrackCollection>::const_iterator myTrack =sTracks.begin();
-      for(;myTrack!=sTracks.end();myTrack++)
-	{
-	  if((*myTrack)->pt() > pt_cut) {
-	    leadTk = *myTrack;
-	    pt_cut = (*myTrack)->pt();
-	  }
-	}
+  if (!sTracks.empty()) {
+    RefVector<TrackCollection>::const_iterator myTrack = sTracks.begin();
+    for (; myTrack != sTracks.end(); myTrack++) {
+      if ((*myTrack)->pt() > pt_cut) {
+        leadTk = *myTrack;
+        pt_cut = (*myTrack)->pt();
+      }
     }
+  }
   return leadTk;
 }
 
-
-const TrackRef  IsolatedTauTagInfo::leadingSignalTrack(const math::XYZVector& myVector, const float rm_cone, const float pt_min) const {
+const TrackRef IsolatedTauTagInfo::leadingSignalTrack(const math::XYZVector& myVector,
+                                                      const float rm_cone,
+                                                      const float pt_min) const {
   const RefVector<TrackCollection> sTracks = tracksInCone(myVector, rm_cone, pt_min);
   TrackRef leadTk;
   float pt_cut = pt_min;
-  if (!sTracks.empty()) 
-    {
-      RefVector<TrackCollection>::const_iterator myTrack =sTracks.begin();
-      for(;myTrack!=sTracks.end();myTrack++)
-	{
-	  if((*myTrack)->pt() > pt_cut) {
-	    leadTk = *myTrack;
-	    pt_cut = (*myTrack)->pt();
-	  }
-	}
+  if (!sTracks.empty()) {
+    RefVector<TrackCollection>::const_iterator myTrack = sTracks.begin();
+    for (; myTrack != sTracks.end(); myTrack++) {
+      if ((*myTrack)->pt() > pt_cut) {
+        leadTk = *myTrack;
+        pt_cut = (*myTrack)->pt();
+      }
     }
+  }
   return leadTk;
 }
 
-float IsolatedTauTagInfo::discriminator(float m_cone, float sig_cone, float iso_cone, float pt_min_lt, float pt_min_tk, int nTracksIsoRing) const
-{
+float IsolatedTauTagInfo::discriminator(
+    float m_cone, float sig_cone, float iso_cone, float pt_min_lt, float pt_min_tk, int nTracksIsoRing) const {
   double myDiscriminator = 0.;
   const TrackRef leadTk = leadingSignalTrack(m_cone, pt_min_lt);
 
-  if(!leadTk) {
+  if (!leadTk) {
     return myDiscriminator;
   }
   //if signal cone is greater then the isolation cone and the leadTk exists, the jet is isolated.
-  if(sig_cone > iso_cone) return 1.;
+  if (sig_cone > iso_cone)
+    return 1.;
 
-  math::XYZVector trackMomentum = leadTk->momentum() ;
+  math::XYZVector trackMomentum = leadTk->momentum();
   const RefVector<TrackCollection> signalTracks = tracksInCone(trackMomentum, sig_cone, pt_min_tk);
-  const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk); 
-  
+  const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk);
+
   if (!signalTracks.empty() && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
-    myDiscriminator=1;
+    myDiscriminator = 1;
 
   return myDiscriminator;
 }
 
-float IsolatedTauTagInfo::discriminator(const math::XYZVector& myVector, float m_cone, float sig_cone, float iso_cone, float pt_min_lt, float pt_min_tk, int nTracksIsoRing) const
-{
+float IsolatedTauTagInfo::discriminator(const math::XYZVector& myVector,
+                                        float m_cone,
+                                        float sig_cone,
+                                        float iso_cone,
+                                        float pt_min_lt,
+                                        float pt_min_tk,
+                                        int nTracksIsoRing) const {
   double myDiscriminator = 0;
   //if signal cone is greater then the isolation cone and the leadTk exists, the jet is isolated.
-  if(sig_cone > iso_cone) return 1.;
+  if (sig_cone > iso_cone)
+    return 1.;
 
-const  TrackRef leadTk = leadingSignalTrack(myVector, m_cone, pt_min_lt);
-  if(!leadTk) return myDiscriminator;
+  const TrackRef leadTk = leadingSignalTrack(myVector, m_cone, pt_min_lt);
+  if (!leadTk)
+    return myDiscriminator;
 
   //if signal cone is greater then the isolation cone and the leadTk exists, the jet is isolated.
-  if(sig_cone > iso_cone) return 1.;
+  if (sig_cone > iso_cone)
+    return 1.;
 
-  math::XYZVector trackMomentum = leadTk->momentum() ;
+  math::XYZVector trackMomentum = leadTk->momentum();
   const RefVector<TrackCollection> signalTracks = tracksInCone(trackMomentum, sig_cone, pt_min_tk);
-  const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk); 
-  
+  const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk);
+
   if (!signalTracks.empty() && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
-    myDiscriminator=1;
+    myDiscriminator = 1;
 
   return myDiscriminator;
 }
 
-float IsolatedTauTagInfo::discriminator(float m_cone, float sig_cone, float iso_cone, float pt_min_lt, float pt_min_tk, int nTracksIsoRing, float dz_lt) const
-{
+float IsolatedTauTagInfo::discriminator(float m_cone,
+                                        float sig_cone,
+                                        float iso_cone,
+                                        float pt_min_lt,
+                                        float pt_min_tk,
+                                        int nTracksIsoRing,
+                                        float dz_lt) const {
   double myDiscriminator = 0;
 
   const TrackRef leadTk = leadingSignalTrack(m_cone, pt_min_lt);
 
-  if(!leadTk) {
+  if (!leadTk) {
     return myDiscriminator;
   }
   //if signal cone is greater then the isolation cone and the leadTk exists, the jet is isolated.
-  if(sig_cone > iso_cone) return 1.;
+  if (sig_cone > iso_cone)
+    return 1.;
 
-  math::XYZVector trackMomentum = leadTk->momentum() ;
+  math::XYZVector trackMomentum = leadTk->momentum();
   float z_pv = leadTk->dz();
   const RefVector<TrackCollection> signalTracks = tracksInCone(trackMomentum, sig_cone, pt_min_tk, z_pv, dz_lt);
-  const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk, z_pv, dz_lt); 
-  
+  const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk, z_pv, dz_lt);
+
   if (!signalTracks.empty() && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
-    myDiscriminator=1;
+    myDiscriminator = 1;
 
   return myDiscriminator;
 }
 
-float IsolatedTauTagInfo::discriminator(const math::XYZVector& myVector, float m_cone, float sig_cone, float iso_cone, float pt_min_lt, float pt_min_tk, int nTracksIsoRing, float dz_lt) const
-{
+float IsolatedTauTagInfo::discriminator(const math::XYZVector& myVector,
+                                        float m_cone,
+                                        float sig_cone,
+                                        float iso_cone,
+                                        float pt_min_lt,
+                                        float pt_min_tk,
+                                        int nTracksIsoRing,
+                                        float dz_lt) const {
   double myDiscriminator = 0;
 
-const  TrackRef leadTk = leadingSignalTrack(myVector, m_cone, pt_min_lt);
-  if(!leadTk) return myDiscriminator;
+  const TrackRef leadTk = leadingSignalTrack(myVector, m_cone, pt_min_lt);
+  if (!leadTk)
+    return myDiscriminator;
   //if signal cone is greater then the isolation cone and the leadTk exists, the jet is isolated.
-  if(sig_cone > iso_cone) return 1.;
+  if (sig_cone > iso_cone)
+    return 1.;
 
-  math::XYZVector trackMomentum = leadTk->momentum() ;
+  math::XYZVector trackMomentum = leadTk->momentum();
   float z_pv = leadTk->dz();
   const RefVector<TrackCollection> signalTracks = tracksInCone(trackMomentum, sig_cone, pt_min_tk, z_pv, dz_lt);
-  const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk, z_pv, dz_lt); 
-  
+  const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk, z_pv, dz_lt);
+
   if (!signalTracks.empty() && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
-    myDiscriminator=1;
+    myDiscriminator = 1;
 
   return myDiscriminator;
 }

--- a/DataFormats/BTauReco/src/TaggingVariable.cc
+++ b/DataFormats/BTauReco/src/TaggingVariable.cc
@@ -7,344 +7,383 @@ using namespace std;
 
 namespace reco {
 
-const char* const TaggingVariableDescription[] = {
-  /* [jetEnergy]                                = */ "jet energy",
-  /* [jetPt]                                    = */ "jet transverse momentum",
-  /* [trackJetPt]                               = */ "track-based jet transverse momentum",
-  /* [jetEta]                                   = */ "jet pseudorapidity",
-  /* [jetAbsEta]                                = */ "jet absolute pseudorapidity",
-  /* [jetPhi]                                   = */ "jet polar angle",
-  /* [jetNTracks]                               = */ "tracks associated to jet",
-  /* [jetNSelectedTracks]                       = */ "selected tracks in the jet",
-  /* [jetNTracksEtaRel]                         = */ "number of tracks for which etaRel is computed",
+  const char* const TaggingVariableDescription[] = {
+      /* [jetEnergy]                                = */ "jet energy",
+      /* [jetPt]                                    = */ "jet transverse momentum",
+      /* [trackJetPt]                               = */ "track-based jet transverse momentum",
+      /* [jetEta]                                   = */ "jet pseudorapidity",
+      /* [jetAbsEta]                                = */ "jet absolute pseudorapidity",
+      /* [jetPhi]                                   = */ "jet polar angle",
+      /* [jetNTracks]                               = */ "tracks associated to jet",
+      /* [jetNSelectedTracks]                       = */ "selected tracks in the jet",
+      /* [jetNTracksEtaRel]                         = */ "number of tracks for which etaRel is computed",
 
-  /* [trackMomentum]                            = */ "track momentum",
-  /* [trackEta]                                 = */ "track pseudorapidity",
-  /* [trackPhi]                                 = */ "track polar angle",
+      /* [trackMomentum]                            = */ "track momentum",
+      /* [trackEta]                                 = */ "track pseudorapidity",
+      /* [trackPhi]                                 = */ "track polar angle",
 
-  /* [trackCharge]                              = */ "track charge",
+      /* [trackCharge]                              = */ "track charge",
 
-  /* [trackPtRel]                               = */ "track transverse momentum, relative to the jet axis",
-  /* [trackPPar]                                = */ "track parallel momentum, along the jet axis",
-  /* [trackEtaRel]                              = */ "track pseudorapidity, relative to the jet axis",
-  /* [trackDeltaR]                              = */ "track pseudoangular distance from the jet axis",
-  /* [trackPtRatio]                             = */ "track transverse momentum, relative to the jet axis, normalized to its energy",
-  /* [trackPParRatio]                           = */ "track parallel momentum, along the jet axis, normalized to its energy",
+      /* [trackPtRel]                               = */ "track transverse momentum, relative to the jet axis",
+      /* [trackPPar]                                = */ "track parallel momentum, along the jet axis",
+      /* [trackEtaRel]                              = */ "track pseudorapidity, relative to the jet axis",
+      /* [trackDeltaR]                              = */ "track pseudoangular distance from the jet axis",
+      /* [trackPtRatio]                             = */
+      "track transverse momentum, relative to the jet axis, normalized to its energy",
+      /* [trackPParRatio]                           = */
+      "track parallel momentum, along the jet axis, normalized to its energy",
 
-  /* [trackSip2dVal]                            = */ "track 2D signed impact parameter",
-  /* [trackSip2dSig]                            = */ "track 2D signed impact parameter significance",
-  /* [trackSip3dVal]                            = */ "track 3D signed impact parameter",
-  /* [trackSip3dSig]                            = */ "track 3D signed impact parameter significance",
-  /* [trackDecayLenVal]                         = */ "track decay length",
-  /* [trackDecayLenSig]                         = */ "track decay length significance",
-  /* [trackJetDistVal]                          = */ "minimum track approach distance to jet axis",
-  /* [trackJetDistSig]                          = */ "minimum track approach distance to jet axis signifiance",
-  /* [trackGhostTrackDistVal]                   = */ "minimum approach distance to ghost track",
-  /* [trackGhostTrackDistSig]                   = */ "minimum approach distance to ghost track significance",
-  /* [trackGhostTrackWeight]                    = */ "weight of track participation in ghost track fit",
+      /* [trackSip2dVal]                            = */ "track 2D signed impact parameter",
+      /* [trackSip2dSig]                            = */ "track 2D signed impact parameter significance",
+      /* [trackSip3dVal]                            = */ "track 3D signed impact parameter",
+      /* [trackSip3dSig]                            = */ "track 3D signed impact parameter significance",
+      /* [trackDecayLenVal]                         = */ "track decay length",
+      /* [trackDecayLenSig]                         = */ "track decay length significance",
+      /* [trackJetDistVal]                          = */ "minimum track approach distance to jet axis",
+      /* [trackJetDistSig]                          = */ "minimum track approach distance to jet axis signifiance",
+      /* [trackGhostTrackDistVal]                   = */ "minimum approach distance to ghost track",
+      /* [trackGhostTrackDistSig]                   = */ "minimum approach distance to ghost track significance",
+      /* [trackGhostTrackWeight]                    = */ "weight of track participation in ghost track fit",
 
-  /* [trackSumJetEtRatio]                       = */ "ratio of track sum transverse energy over jet energy",
-  /* [trackSumJetDeltaR]                        = */ "pseudoangular distance between jet axis and track fourvector sum",
+      /* [trackSumJetEtRatio]                       = */ "ratio of track sum transverse energy over jet energy",
+      /* [trackSumJetDeltaR]                        = */
+      "pseudoangular distance between jet axis and track fourvector sum",
 
-  /* [vertexCategory]                           = */ "category of secondary vertex (Reco, Pseudo, No)",
-  /* [vertexLeptonCategory]                     = */ "category of secondary vertex & soft lepton (RecoNo, PseudoNo, NoNo, RecoMu, PseudoMu, NoMu, RecoEl, PseudoEl, NoEl)",
+      /* [vertexCategory]                           = */ "category of secondary vertex (Reco, Pseudo, No)",
+      /* [vertexLeptonCategory]                     = */
+      "category of secondary vertex & soft lepton (RecoNo, PseudoNo, NoNo, RecoMu, PseudoMu, NoMu, RecoEl, PseudoEl, "
+      "NoEl)",
 
-  /* [jetNSecondaryVertices]                    = */ "number of reconstructed possible secondary vertices in jet",
-  /* [jetNSingleTrackVertices]                  = */ "number of single-track ghost-track vertices",
+      /* [jetNSecondaryVertices]                    = */ "number of reconstructed possible secondary vertices in jet",
+      /* [jetNSingleTrackVertices]                  = */ "number of single-track ghost-track vertices",
 
-  /* [vertexMass]                               = */ "mass of track sum at secondary vertex",
-  /* [vertexNTracks]                            = */ "number of tracks at secondary vertex",
-  /* [vertexFitProb]                            = */ "vertex fit probability",
+      /* [vertexMass]                               = */ "mass of track sum at secondary vertex",
+      /* [vertexNTracks]                            = */ "number of tracks at secondary vertex",
+      /* [vertexFitProb]                            = */ "vertex fit probability",
 
-  /* [vertexEnergyRatio]                        = */ "ratio of energy at secondary vertex over total energy",
-  /* [vertexJetDeltaR]                          = */ "pseudoangular distance between jet axis and secondary vertex direction",
-  
-  /* [flightDistance1dVal]                      = */ "Longitudinal distance along the z-axis between primary and secondary vertex",
-  /* [flightDistance1dSig]                      = */ "Longitudinal distance significance along the z-axis between primary and secondary vertex",
-  /* [flightDistance2dVal]                      = */ "transverse distance between primary and secondary vertex",
-  /* [flightDistance2dSig]                      = */ "transverse distance significance between primary and secondary vertex",
-  /* [flightDistance3dVal]                      = */ "distance between primary and secondary vertex",
-  /* [flightDistance3dSig]                      = */ "distance significance between primary and secondary vertex",
+      /* [vertexEnergyRatio]                        = */ "ratio of energy at secondary vertex over total energy",
+      /* [vertexJetDeltaR]                          = */
+      "pseudoangular distance between jet axis and secondary vertex direction",
 
-  /* [trackSip2dValAboveCharm]                  = */ "track 2D signed impact parameter of first track lifting mass above charm",
-  /* [trackSip2dSigAboveCharm]                  = */ "track 2D signed impact parameter significance of first track lifting mass above charm",
-  /* [trackSip3dValAboveCharm]                  = */ "track 3D signed impact parameter of first track lifting mass above charm",
-  /* [trackSip3dSigAboveCharm]                  = */ "track 3D signed impact parameter significance of first track lifting mass above charm",
+      /* [flightDistance1dVal]                      = */
+      "Longitudinal distance along the z-axis between primary and secondary vertex",
+      /* [flightDistance1dSig]                      = */
+      "Longitudinal distance significance along the z-axis between primary and secondary vertex",
+      /* [flightDistance2dVal]                      = */ "transverse distance between primary and secondary vertex",
+      /* [flightDistance2dSig]                      = */
+      "transverse distance significance between primary and secondary vertex",
+      /* [flightDistance3dVal]                      = */ "distance between primary and secondary vertex",
+      /* [flightDistance3dSig]                      = */ "distance significance between primary and secondary vertex",
 
-  /* [trackP0Par]                               = */ "track momentum along the jet axis, in the jet rest frame",
-  /* [trackP0ParRatio]                          = */ "track momentum along the jet axis, in the jet rest frame, normalized to its energy"
-  /* [trackChi2]                                = */ "chi2 of the track fit",
-  /* [trackNTotalHits]                          = */ "number of valid total hits",
-  /* [trackNPixelHits]                          = */ "number of valid pixel hits",
+      /* [trackSip2dValAboveCharm]                  = */
+      "track 2D signed impact parameter of first track lifting mass above charm",
+      /* [trackSip2dSigAboveCharm]                  = */
+      "track 2D signed impact parameter significance of first track lifting mass above charm",
+      /* [trackSip3dValAboveCharm]                  = */
+      "track 3D signed impact parameter of first track lifting mass above charm",
+      /* [trackSip3dSigAboveCharm]                  = */
+      "track 3D signed impact parameter significance of first track lifting mass above charm",
 
-  /* [leptonQuality]                            = */ "lepton identification quality",
-  /* [leptonQuality2]                           = */ "lepton identification quality 2",
+      /* [trackP0Par]                               = */ "track momentum along the jet axis, in the jet rest frame",
+      /* [trackP0ParRatio]                          = */
+      "track momentum along the jet axis, in the jet rest frame, normalized to its energy"
+      /* [trackChi2]                                = */ "chi2 of the track fit",
+      /* [trackNTotalHits]                          = */ "number of valid total hits",
+      /* [trackNPixelHits]                          = */ "number of valid pixel hits",
 
-  /* [chargedHadronEnergyFraction]              = */ "fraction of the jet energy coming from charged hadrons",
-  /* [neutralHadronEnergyFraction]              = */ "fraction of the jet energy coming from neutral hadrons",
-  /* [photonEnergyFraction]                     = */ "fraction of the jet energy coming from photons",
-  /* [electronEnergyFraction]                   = */ "fraction of the jet energy coming from electrons",
-  /* [muonEnergyFraction]                       = */ "fraction of the jet energy coming from muons",
-  /* [chargedHadronMultiplicity]                = */ "number of charged hadrons in the jet",
-  /* [neutralHadronMultiplicity]                = */ "number of neutral hadrons in the jet",
-  /* [photonMultiplicity]                       = */ "number of photons in the jet",
-  /* [electronMultiplicity]                     = */ "number of electrons in the jet",
-  /* [muonMultiplicity]                         = */ "number of muons in the jet",
-  /* [hadronMultiplicity]                       = */ "total number of charged and neutral hadrons in the jet",
-  /* [hadronPhotonMultiplicity]                 = */ "total number of photons, charged and neutral hadrons in the jet",
-  /* [totalMultiplicity]                        = */ "total number of photons, electrons, muons, charged and neutral hadrons in the jet",
+      /* [leptonQuality]                            = */ "lepton identification quality",
+      /* [leptonQuality2]                           = */ "lepton identification quality 2",
 
-  /* [massVertexEnergyFraction]                 = */ "vertexmass times fraction of the vertex energy w.r.t. the jet energy",
-  /* [vertexBoostOverSqrtJetPt]                 = */ "variable related to the boost of the vertex system in flight direction",
+      /* [chargedHadronEnergyFraction]              = */ "fraction of the jet energy coming from charged hadrons",
+      /* [neutralHadronEnergyFraction]              = */ "fraction of the jet energy coming from neutral hadrons",
+      /* [photonEnergyFraction]                     = */ "fraction of the jet energy coming from photons",
+      /* [electronEnergyFraction]                   = */ "fraction of the jet energy coming from electrons",
+      /* [muonEnergyFraction]                       = */ "fraction of the jet energy coming from muons",
+      /* [chargedHadronMultiplicity]                = */ "number of charged hadrons in the jet",
+      /* [neutralHadronMultiplicity]                = */ "number of neutral hadrons in the jet",
+      /* [photonMultiplicity]                       = */ "number of photons in the jet",
+      /* [electronMultiplicity]                     = */ "number of electrons in the jet",
+      /* [muonMultiplicity]                         = */ "number of muons in the jet",
+      /* [hadronMultiplicity]                       = */ "total number of charged and neutral hadrons in the jet",
+      /* [hadronPhotonMultiplicity]                 = */
+      "total number of photons, charged and neutral hadrons in the jet",
+      /* [totalMultiplicity]                        = */
+      "total number of photons, electrons, muons, charged and neutral hadrons in the jet",
 
-  /* [leptonSip2d]                              = */ "2D signed impact parameter of the soft lepton",
-  /* [leptonSip3d]                              = */ "3D signed impact parameter of the soft lepton",
-  /* [leptonPtRel]                              = */ "transverse momentum of the soft lepton wrt. the jet axis",
-  /* [leptonP0Par]                              = */ "momentum of the soft lepton along the jet direction, in the jet rest frame",
-  /* [leptonEtaRel]                             = */ "pseudo)rapidity of the soft lepton along jet axis",
-  /* [leptonDeltaR]                             = */ "pseudo)angular distance of the soft lepton to jet axis",
-  /* [leptonRatio]                              = */ "momentum of the soft lepton over jet energy",
-  /* [leptonRatioRel]                           = */ "momentum of the soft lepton parallel to jet axis over jet energy",
-  /* [electronMVA]                              = */ "mva output of the electron ID",
+      /* [massVertexEnergyFraction]                 = */
+      "vertexmass times fraction of the vertex energy w.r.t. the jet energy",
+      /* [vertexBoostOverSqrtJetPt]                 = */
+      "variable related to the boost of the vertex system in flight direction",
 
-  /* [trackSip3dSig_0]                          = */ "1st largest track 3D signed impact parameter significance",
-  /* [trackSip3dSig_1]                          = */ "2nd largest track 3D signed impact parameter significance",
-  /* [trackSip3dSig_2]                          = */ "3rd largest track 3D signed impact parameter significance",
-  /* [trackSip3dSig_3]                          = */ "4th largest track 3D signed impact parameter significance",
-  /* [tau1_trackSip3dSig_0]                     = */ "1st largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis",
-  /* [tau1_trackSip3dSig_1]                     = */ "2nd largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis",
-  /* [tau2_trackSip3dSig_0]                     = */ "1st largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis",
-  /* [tau2_trackSip3dSig_1]                     = */ "2nd largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis",
-  /* [trackSip2dSigAboveBottom_0]               = */ "track 2D signed impact parameter significance of 1st track lifting mass above bottom",
-  /* [trackSip2dSigAboveBottom_1]               = */ "track 2D signed impact parameter significance of 2nd track lifting mass above bottom",
-  /* [tau1_trackEtaRel_0]                       = */ "1st smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis",
-  /* [tau1_trackEtaRel_1]                       = */ "2nd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis",
-  /* [tau1_trackEtaRel_2]                       = */ "3rd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis",
-  /* [tau2_trackEtaRel_0]                       = */ "1st smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis",
-  /* [tau2_trackEtaRel_1]                       = */ "2nd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis",
-  /* [tau2_trackEtaRel_2]                       = */ "3rd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis",
-  /* [tau1_vertexMass]                          = */ "mass of track sum at secondary vertex associated to the 1st N-subjettiness axis",
-  /* [tau1_vertexEnergyRatio]                   = */ "ratio of energy at secondary vertex over total energy associated to the 1st N-subjettiness axis",
-  /* [tau1_flightDistance2dSig]                 = */ "transverse distance significance between primary and secondary vertex associated to the 1st N-subjettiness axis",
-  /* [tau1_vertexDeltaR]                        = */ "pseudoangular distance between the 1st N-subjettiness axis and secondary vertex direction",
-  /* [tau2_vertexMass]                          = */ "mass of track sum at secondary vertex associated to the 2nd N-subjettiness axis",
-  /* [tau2_vertexEnergyRatio]                   = */ "ratio of energy at secondary vertex over total energy associated to the 2nd N-subjettiness axis",
-  /* [tau2_flightDistance2dSig]                 = */ "transverse distance significance between primary and secondary vertex associated to the 2nd N-subjettiness axis",
-  /* [tau2_vertexDeltaR]                        = */ "pseudoangular distance between the 2nd N-subjettiness axis and secondary vertex direction",
-  /* [z_ratio]                                  = */ "z ratio",
-  /* [Jet_SoftMu]                               = */ "SoftMu Tagger discriminator",
-  /* [Jet_SoftEl]                               = */ "SoftEl Tagger discriminator",
-  /* [Jet_JBP]                                  = */ "JBP Tagger discriminator",
-  /* [Jet_JP]                                   = */ "JP Tagger discriminator",
+      /* [leptonSip2d]                              = */ "2D signed impact parameter of the soft lepton",
+      /* [leptonSip3d]                              = */ "3D signed impact parameter of the soft lepton",
+      /* [leptonPtRel]                              = */ "transverse momentum of the soft lepton wrt. the jet axis",
+      /* [leptonP0Par]                              = */
+      "momentum of the soft lepton along the jet direction, in the jet rest frame",
+      /* [leptonEtaRel]                             = */ "pseudo)rapidity of the soft lepton along jet axis",
+      /* [leptonDeltaR]                             = */ "pseudo)angular distance of the soft lepton to jet axis",
+      /* [leptonRatio]                              = */ "momentum of the soft lepton over jet energy",
+      /* [leptonRatioRel]                           = */
+      "momentum of the soft lepton parallel to jet axis over jet energy",
+      /* [electronMVA]                              = */ "mva output of the electron ID",
 
-  /* [algoDiscriminator]                        = */ "discriminator output of an algorithm",
+      /* [trackSip3dSig_0]                          = */ "1st largest track 3D signed impact parameter significance",
+      /* [trackSip3dSig_1]                          = */ "2nd largest track 3D signed impact parameter significance",
+      /* [trackSip3dSig_2]                          = */ "3rd largest track 3D signed impact parameter significance",
+      /* [trackSip3dSig_3]                          = */ "4th largest track 3D signed impact parameter significance",
+      /* [tau1_trackSip3dSig_0]                     = */
+      "1st largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis",
+      /* [tau1_trackSip3dSig_1]                     = */
+      "2nd largest track 3D signed impact parameter significance associated to the 1st N-subjettiness axis",
+      /* [tau2_trackSip3dSig_0]                     = */
+      "1st largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis",
+      /* [tau2_trackSip3dSig_1]                     = */
+      "2nd largest track 3D signed impact parameter significance associated to the 2nd N-subjettiness axis",
+      /* [trackSip2dSigAboveBottom_0]               = */
+      "track 2D signed impact parameter significance of 1st track lifting mass above bottom",
+      /* [trackSip2dSigAboveBottom_1]               = */
+      "track 2D signed impact parameter significance of 2nd track lifting mass above bottom",
+      /* [tau1_trackEtaRel_0]                       = */
+      "1st smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis",
+      /* [tau1_trackEtaRel_1]                       = */
+      "2nd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis",
+      /* [tau1_trackEtaRel_2]                       = */
+      "3rd smallest track pseudorapidity, relative to the jet axis, associated to the 1st N-subjettiness axis",
+      /* [tau2_trackEtaRel_0]                       = */
+      "1st smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis",
+      /* [tau2_trackEtaRel_1]                       = */
+      "2nd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis",
+      /* [tau2_trackEtaRel_2]                       = */
+      "3rd smallest track pseudorapidity, relative to the jet axis, associated to the 2nd N-subjettiness axis",
+      /* [tau1_vertexMass]                          = */
+      "mass of track sum at secondary vertex associated to the 1st N-subjettiness axis",
+      /* [tau1_vertexEnergyRatio]                   = */
+      "ratio of energy at secondary vertex over total energy associated to the 1st N-subjettiness axis",
+      /* [tau1_flightDistance2dSig]                 = */
+      "transverse distance significance between primary and secondary vertex associated to the 1st N-subjettiness axis",
+      /* [tau1_vertexDeltaR]                        = */
+      "pseudoangular distance between the 1st N-subjettiness axis and secondary vertex direction",
+      /* [tau2_vertexMass]                          = */
+      "mass of track sum at secondary vertex associated to the 2nd N-subjettiness axis",
+      /* [tau2_vertexEnergyRatio]                   = */
+      "ratio of energy at secondary vertex over total energy associated to the 2nd N-subjettiness axis",
+      /* [tau2_flightDistance2dSig]                 = */
+      "transverse distance significance between primary and secondary vertex associated to the 2nd N-subjettiness axis",
+      /* [tau2_vertexDeltaR]                        = */
+      "pseudoangular distance between the 2nd N-subjettiness axis and secondary vertex direction",
+      /* [z_ratio]                                  = */ "z ratio",
+      /* [Jet_SoftMu]                               = */ "SoftMu Tagger discriminator",
+      /* [Jet_SoftEl]                               = */ "SoftEl Tagger discriminator",
+      /* [Jet_JBP]                                  = */ "JBP Tagger discriminator",
+      /* [Jet_JP]                                   = */ "JP Tagger discriminator",
 
-  /* [lastTaggingVariable]                      = */ ""
-};
+      /* [algoDiscriminator]                        = */ "discriminator output of an algorithm",
 
-const char* const TaggingVariableTokens[] = {
-  /* [jetEnergy]                                = */ "jetEnergy",
-  /* [jetPt]                                    = */ "jetPt",
-  /* [trackJetPt]                               = */ "trackJetPt",
-  /* [jetEta]                                   = */ "jetEta",
-  /* [jetAbsEta]                                = */ "jetAbsEta",
-  /* [jetPhi]                                   = */ "jetPhi",
-  /* [jetNTracks]                               = */ "jetNTracks",
-  /* [jetNSelectedTracks]                       = */ "jetNSelectedTracks",
-  /* [jetNTracksEtaRel]                         = */ "jetNTracksEtaRel",
+      /* [lastTaggingVariable]                      = */ ""};
 
-  /* [trackMomentum]                            = */ "trackMomentum",
-  /* [trackEta]                                 = */ "trackEta",
-  /* [trackPhi]                                 = */ "trackPhi",
+  const char* const TaggingVariableTokens[] = {
+      /* [jetEnergy]                                = */ "jetEnergy",
+      /* [jetPt]                                    = */ "jetPt",
+      /* [trackJetPt]                               = */ "trackJetPt",
+      /* [jetEta]                                   = */ "jetEta",
+      /* [jetAbsEta]                                = */ "jetAbsEta",
+      /* [jetPhi]                                   = */ "jetPhi",
+      /* [jetNTracks]                               = */ "jetNTracks",
+      /* [jetNSelectedTracks]                       = */ "jetNSelectedTracks",
+      /* [jetNTracksEtaRel]                         = */ "jetNTracksEtaRel",
 
-  /* [trackCharge]                              = */ "trackCharge",
+      /* [trackMomentum]                            = */ "trackMomentum",
+      /* [trackEta]                                 = */ "trackEta",
+      /* [trackPhi]                                 = */ "trackPhi",
 
-  /* [trackPtRel]                               = */ "trackPtRel",
-  /* [trackPPar]                                = */ "trackPPar",
-  /* [trackEtaRel]                              = */ "trackEtaRel",
-  /* [trackDeltaR]                              = */ "trackDeltaR",
-  /* [trackPtRatio]                             = */ "trackPtRatio",
-  /* [trackPParRatio]                           = */ "trackPParRatio",
+      /* [trackCharge]                              = */ "trackCharge",
 
-  /* [trackSip2dVal]                            = */ "trackSip2dVal",
-  /* [trackSip2dSig]                            = */ "trackSip2dSig",
-  /* [trackSip3dVal]                            = */ "trackSip3dVal",
-  /* [trackSip3dSig]                            = */ "trackSip3dSig",
-  /* [trackDecayLenVal]                         = */ "trackDecayLenVal",
-  /* [trackDecayLenSig]                         = */ "trackDecayLenSig",
-  /* [trackJetDistVal]                          = */ "trackJetDist",    //FIXME
-  /* [trackJetDistSig]                          = */ "trackJetDistSig",
-  /* [trackGhostTrackDistVal]                   = */ "trackGhostTrackDistVal",
-  /* [trackGhostTrackDistSig]                   = */ "trackGhostTrackDistSig",
-  /* [trackGhostTrackWeight]                    = */ "trackGhostTrackWeight",
+      /* [trackPtRel]                               = */ "trackPtRel",
+      /* [trackPPar]                                = */ "trackPPar",
+      /* [trackEtaRel]                              = */ "trackEtaRel",
+      /* [trackDeltaR]                              = */ "trackDeltaR",
+      /* [trackPtRatio]                             = */ "trackPtRatio",
+      /* [trackPParRatio]                           = */ "trackPParRatio",
 
-  /* [trackSumJetEtRatio]                       = */ "trackSumJetEtRatio",
-  /* [trackSumJetDeltaR]                        = */ "trackSumJetDeltaR",
+      /* [trackSip2dVal]                            = */ "trackSip2dVal",
+      /* [trackSip2dSig]                            = */ "trackSip2dSig",
+      /* [trackSip3dVal]                            = */ "trackSip3dVal",
+      /* [trackSip3dSig]                            = */ "trackSip3dSig",
+      /* [trackDecayLenVal]                         = */ "trackDecayLenVal",
+      /* [trackDecayLenSig]                         = */ "trackDecayLenSig",
+      /* [trackJetDistVal]                          = */ "trackJetDist",  //FIXME
+      /* [trackJetDistSig]                          = */ "trackJetDistSig",
+      /* [trackGhostTrackDistVal]                   = */ "trackGhostTrackDistVal",
+      /* [trackGhostTrackDistSig]                   = */ "trackGhostTrackDistSig",
+      /* [trackGhostTrackWeight]                    = */ "trackGhostTrackWeight",
 
-  /* [vertexCategory]                           = */ "vertexCategory",
-  /* [vertexLeptonCategory]                     = */ "vertexLeptonCategory",
+      /* [trackSumJetEtRatio]                       = */ "trackSumJetEtRatio",
+      /* [trackSumJetDeltaR]                        = */ "trackSumJetDeltaR",
 
-  /* [jetNSecondaryVertices]                    = */ "jetNSecondaryVertices",
-  /* [jetNSingleTrackVertices]                  = */ "jetNSingleTrackVertices",
+      /* [vertexCategory]                           = */ "vertexCategory",
+      /* [vertexLeptonCategory]                     = */ "vertexLeptonCategory",
 
-  /* [vertexMass]                               = */ "vertexMass",
-  /* [vertexNTracks]                            = */ "vertexNTracks",
-  /* [vertexFitProb]                            = */ "vertexFitProb",
+      /* [jetNSecondaryVertices]                    = */ "jetNSecondaryVertices",
+      /* [jetNSingleTrackVertices]                  = */ "jetNSingleTrackVertices",
 
-  /* [vertexEnergyRatio]                        = */ "vertexEnergyRatio",
-  /* [vertexJetDeltaR]                          = */ "vertexJetDeltaR",
+      /* [vertexMass]                               = */ "vertexMass",
+      /* [vertexNTracks]                            = */ "vertexNTracks",
+      /* [vertexFitProb]                            = */ "vertexFitProb",
 
-  /* [flightDistance1dVal]                      = */ "flightDistance1dVal",
-  /* [flightDistance1dSig]                      = */ "flightDistance1dSig", 
-  /* [flightDistance2dVal]                      = */ "flightDistance2dVal",
-  /* [flightDistance2dSig]                      = */ "flightDistance2dSig",
-  /* [flightDistance3dVal]                      = */ "flightDistance3dVal",
-  /* [flightDistance3dSig]                      = */ "flightDistance3dSig",
+      /* [vertexEnergyRatio]                        = */ "vertexEnergyRatio",
+      /* [vertexJetDeltaR]                          = */ "vertexJetDeltaR",
 
-  /* [trackSip2dValAboveCharm]                  = */ "trackSip2dValAboveCharm",
-  /* [trackSip2dSigAboveCharm]                  = */ "trackSip2dSigAboveCharm",
-  /* [trackSip3dValAboveCharm]                  = */ "trackSip3dValAboveCharm",
-  /* [trackSip3dSigAboveCharm]                  = */ "trackSip3dSigAboveCharm",
+      /* [flightDistance1dVal]                      = */ "flightDistance1dVal",
+      /* [flightDistance1dSig]                      = */ "flightDistance1dSig",
+      /* [flightDistance2dVal]                      = */ "flightDistance2dVal",
+      /* [flightDistance2dSig]                      = */ "flightDistance2dSig",
+      /* [flightDistance3dVal]                      = */ "flightDistance3dVal",
+      /* [flightDistance3dSig]                      = */ "flightDistance3dSig",
 
-  /* [leptonQuality]                            = */ "leptonQuality",
-  /* [leptonQuality2]                           = */ "leptonQuality2",
+      /* [trackSip2dValAboveCharm]                  = */ "trackSip2dValAboveCharm",
+      /* [trackSip2dSigAboveCharm]                  = */ "trackSip2dSigAboveCharm",
+      /* [trackSip3dValAboveCharm]                  = */ "trackSip3dValAboveCharm",
+      /* [trackSip3dSigAboveCharm]                  = */ "trackSip3dSigAboveCharm",
 
-  /* [trackP0Par]                               = */ "trackP0Par",
-  /* [trackP0ParRatio]                          = */ "trackP0ParRatio",
-  /* [trackChi2]                                = */ "trackChi2",
-  /* [trackNTotalHits]                          = */ "trackNTotalHits",
-  /* [trackNPixelHits]                          = */ "trackNPixelHits",
+      /* [leptonQuality]                            = */ "leptonQuality",
+      /* [leptonQuality2]                           = */ "leptonQuality2",
 
+      /* [trackP0Par]                               = */ "trackP0Par",
+      /* [trackP0ParRatio]                          = */ "trackP0ParRatio",
+      /* [trackChi2]                                = */ "trackChi2",
+      /* [trackNTotalHits]                          = */ "trackNTotalHits",
+      /* [trackNPixelHits]                          = */ "trackNPixelHits",
 
-  /* [chargedHadronEnergyFraction]              = */ "chargedHadronEnergyFraction",
-  /* [neutralHadronEnergyFraction]              = */ "neutralHadronEnergyFraction",
-  /* [photonEnergyFraction]                     = */ "photonEnergyFraction",
-  /* [electronEnergyFraction]                   = */ "electronEnergyFraction",
-  /* [muonEnergyFraction]                       = */ "muonEnergyFraction",
-  /* [chargedHadronMultiplicity]                = */ "chargedHadronMultiplicity",
-  /* [neutralHadronMultiplicity]                = */ "neutralHadronMultiplicity",
-  /* [photonMultiplicity]                       = */ "photonMultiplicity",
-  /* [electronMultiplicity]                     = */ "electronMultiplicity",
-  /* [muonMultiplicity]                         = */ "muonMultiplicity",
-  /* [hadronMultiplicity]                       = */ "hadronMultiplicity",
-  /* [hadronPhotonMultiplicity]                 = */ "hadronPhotonMultiplicity",
-  /* [totalMultiplicity]                        = */ "totalMultiplicity",
+      /* [chargedHadronEnergyFraction]              = */ "chargedHadronEnergyFraction",
+      /* [neutralHadronEnergyFraction]              = */ "neutralHadronEnergyFraction",
+      /* [photonEnergyFraction]                     = */ "photonEnergyFraction",
+      /* [electronEnergyFraction]                   = */ "electronEnergyFraction",
+      /* [muonEnergyFraction]                       = */ "muonEnergyFraction",
+      /* [chargedHadronMultiplicity]                = */ "chargedHadronMultiplicity",
+      /* [neutralHadronMultiplicity]                = */ "neutralHadronMultiplicity",
+      /* [photonMultiplicity]                       = */ "photonMultiplicity",
+      /* [electronMultiplicity]                     = */ "electronMultiplicity",
+      /* [muonMultiplicity]                         = */ "muonMultiplicity",
+      /* [hadronMultiplicity]                       = */ "hadronMultiplicity",
+      /* [hadronPhotonMultiplicity]                 = */ "hadronPhotonMultiplicity",
+      /* [totalMultiplicity]                        = */ "totalMultiplicity",
 
-  /* [massVertexEnergyFraction]                 = */ "massVertexEnergyFraction",
-  /* [vertexBoostOverSqrtJetPt]                 = */ "vertexBoostOverSqrtJetPt",
+      /* [massVertexEnergyFraction]                 = */ "massVertexEnergyFraction",
+      /* [vertexBoostOverSqrtJetPt]                 = */ "vertexBoostOverSqrtJetPt",
 
-  /* [leptonSip2d]                              = */ "leptonSip2d",
-  /* [leptonSip3d]                              = */ "leptonSip3d",
-  /* [leptonPtRel]                              = */ "leptonPtRel",
-  /* [leptonP0Par]                              = */ "leptonP0Par",
-  /* [leptonEtaRel]                             = */ "leptonEtaRel",
-  /* [leptonDeltaR]                             = */ "leptonDeltaR",
-  /* [leptonRatio]                              = */ "leptonRatio",
-  /* [leptonRatioRel]                           = */ "leptonRatioRel",
-  /* [electronMVA]                              = */ "electronMVA",
+      /* [leptonSip2d]                              = */ "leptonSip2d",
+      /* [leptonSip3d]                              = */ "leptonSip3d",
+      /* [leptonPtRel]                              = */ "leptonPtRel",
+      /* [leptonP0Par]                              = */ "leptonP0Par",
+      /* [leptonEtaRel]                             = */ "leptonEtaRel",
+      /* [leptonDeltaR]                             = */ "leptonDeltaR",
+      /* [leptonRatio]                              = */ "leptonRatio",
+      /* [leptonRatioRel]                           = */ "leptonRatioRel",
+      /* [electronMVA]                              = */ "electronMVA",
 
-  /* [trackSip3dSig_0]                          = */ "trackSip3dSig_0",
-  /* [trackSip3dSig_1]                          = */ "trackSip3dSig_1",
-  /* [trackSip3dSig_2]                          = */ "trackSip3dSig_2",
-  /* [trackSip3dSig_3]                          = */ "trackSip3dSig_3",
-  /* [tau1_trackSip3dSig_0]                     = */ "tau1_trackSip3dSig_0",
-  /* [tau1_trackSip3dSig_1]                     = */ "tau1_trackSip3dSig_1",
-  /* [tau2_trackSip3dSig_0]                     = */ "tau2_trackSip3dSig_0",
-  /* [tau2_trackSip3dSig_1]                     = */ "tau2_trackSip3dSig_1",
-  /* [trackSip2dSigAboveBottom_0]               = */ "trackSip2dSigAboveBottom_0",
-  /* [trackSip2dSigAboveBottom_1]               = */ "trackSip2dSigAboveBottom_1",
-  /* [tau1_trackEtaRel_0]                       = */ "tau1_trackEtaRel_0",
-  /* [tau1_trackEtaRel_1]                       = */ "tau1_trackEtaRel_1",
-  /* [tau1_trackEtaRel_2]                       = */ "tau1_trackEtaRel_2",
-  /* [tau2_trackEtaRel_0]                       = */ "tau2_trackEtaRel_0",
-  /* [tau2_trackEtaRel_1]                       = */ "tau2_trackEtaRel_1",
-  /* [tau2_trackEtaRel_2]                       = */ "tau2_trackEtaRel_2",
-  /* [tau1_vertexMass]                          = */ "tau1_vertexMass",
-  /* [tau1_vertexEnergyRatio]                   = */ "tau1_vertexEnergyRatio",
-  /* [tau1_flightDistance2dSig]                 = */ "tau1_flightDistance2dSig",
-  /* [tau1_vertexDeltaR]                        = */ "tau1_vertexDeltaR",
-  /* [tau2_vertexMass]                          = */ "tau2_vertexMass",
-  /* [tau2_vertexEnergyRatio]                   = */ "tau2_vertexEnergyRatio",
-  /* [tau2_flightDistance2dSig]                 = */ "tau2_flightDistance2dSig",
-  /* [tau2_vertexDeltaR]                        = */ "tau2_vertexDeltaR",
-  /* [z_ratio]                                  = */ "z_ratio",
-  /* [Jet_SoftMu]                               = */ "Jet_SoftMu",
-  /* [Jet_SoftEl]                               = */ "Jet_SoftEl",
-  /* [Jet_JBP]                                  = */ "Jet_JBP",
-  /* [Jet_JP]                                   = */ "Jet_JP",
+      /* [trackSip3dSig_0]                          = */ "trackSip3dSig_0",
+      /* [trackSip3dSig_1]                          = */ "trackSip3dSig_1",
+      /* [trackSip3dSig_2]                          = */ "trackSip3dSig_2",
+      /* [trackSip3dSig_3]                          = */ "trackSip3dSig_3",
+      /* [tau1_trackSip3dSig_0]                     = */ "tau1_trackSip3dSig_0",
+      /* [tau1_trackSip3dSig_1]                     = */ "tau1_trackSip3dSig_1",
+      /* [tau2_trackSip3dSig_0]                     = */ "tau2_trackSip3dSig_0",
+      /* [tau2_trackSip3dSig_1]                     = */ "tau2_trackSip3dSig_1",
+      /* [trackSip2dSigAboveBottom_0]               = */ "trackSip2dSigAboveBottom_0",
+      /* [trackSip2dSigAboveBottom_1]               = */ "trackSip2dSigAboveBottom_1",
+      /* [tau1_trackEtaRel_0]                       = */ "tau1_trackEtaRel_0",
+      /* [tau1_trackEtaRel_1]                       = */ "tau1_trackEtaRel_1",
+      /* [tau1_trackEtaRel_2]                       = */ "tau1_trackEtaRel_2",
+      /* [tau2_trackEtaRel_0]                       = */ "tau2_trackEtaRel_0",
+      /* [tau2_trackEtaRel_1]                       = */ "tau2_trackEtaRel_1",
+      /* [tau2_trackEtaRel_2]                       = */ "tau2_trackEtaRel_2",
+      /* [tau1_vertexMass]                          = */ "tau1_vertexMass",
+      /* [tau1_vertexEnergyRatio]                   = */ "tau1_vertexEnergyRatio",
+      /* [tau1_flightDistance2dSig]                 = */ "tau1_flightDistance2dSig",
+      /* [tau1_vertexDeltaR]                        = */ "tau1_vertexDeltaR",
+      /* [tau2_vertexMass]                          = */ "tau2_vertexMass",
+      /* [tau2_vertexEnergyRatio]                   = */ "tau2_vertexEnergyRatio",
+      /* [tau2_flightDistance2dSig]                 = */ "tau2_flightDistance2dSig",
+      /* [tau2_vertexDeltaR]                        = */ "tau2_vertexDeltaR",
+      /* [z_ratio]                                  = */ "z_ratio",
+      /* [Jet_SoftMu]                               = */ "Jet_SoftMu",
+      /* [Jet_SoftEl]                               = */ "Jet_SoftEl",
+      /* [Jet_JBP]                                  = */ "Jet_JBP",
+      /* [Jet_JP]                                   = */ "Jet_JP",
 
-  /* [algoDiscriminator]                        = */ "algoDiscriminator",
+      /* [algoDiscriminator]                        = */ "algoDiscriminator",
 
-  /* [lastTaggingVariable]                      = */ "lastTaggingVariable"
-};
+      /* [lastTaggingVariable]                      = */ "lastTaggingVariable"};
 
-btau::TaggingVariableName getTaggingVariableName( const std::string & name )
-{
-  for (int i = 0; i <= reco::btau::lastTaggingVariable; i++)
-    if (name == TaggingVariableTokens[i])
-      return (reco::btau::TaggingVariableName) (i);
-  return btau::lastTaggingVariable;
-}
-
-// check if a tag is present in the TaggingVariableList
-bool TaggingVariableList::checkTag( TaggingVariableName tag ) const {
-  return binary_search( m_list.begin(), m_list.end(), tag, TaggingVariableCompare() );
-}
-
-void TaggingVariableList::insert( const TaggingVariable & variable, bool delayed /* = false */ ) {
-  m_list.push_back( variable );
-  if (not delayed) finalize();
-}
-
-void TaggingVariableList::insert( TaggingVariableName tag, TaggingValue value, bool delayed /* = false */ ) {
-  m_list.push_back( TaggingVariable( tag, value ) );
-  if (not delayed) finalize();
-}
-
-void TaggingVariableList::insert( TaggingVariableName tag, const std::vector<TaggingValue> & values, bool delayed /* = false */ ) {
-  for (std::vector<TaggingValue>::const_iterator i = values.begin(); i != values.end(); i++) {
-    m_list.push_back( TaggingVariable(tag, *i) );
+  btau::TaggingVariableName getTaggingVariableName(const std::string& name) {
+    for (int i = 0; i <= reco::btau::lastTaggingVariable; i++)
+      if (name == TaggingVariableTokens[i])
+        return (reco::btau::TaggingVariableName)(i);
+    return btau::lastTaggingVariable;
   }
-  if (not delayed) finalize();
-}
 
-void TaggingVariableList::insert( const TaggingVariableList & list ) {
-  std::vector<TaggingVariable>::size_type size = m_list.size();
-  m_list.insert( m_list.end(), list.m_list.begin(), list.m_list.end() );
-  inplace_merge( m_list.begin(), m_list.begin() + size, m_list.end(), TaggingVariableCompare() );
-}
+  // check if a tag is present in the TaggingVariableList
+  bool TaggingVariableList::checkTag(TaggingVariableName tag) const {
+    return binary_search(m_list.begin(), m_list.end(), tag, TaggingVariableCompare());
+  }
 
-void TaggingVariableList::finalize( void ) {
-  stable_sort( m_list.begin(), m_list.end(), TaggingVariableCompare() );
-}
+  void TaggingVariableList::insert(const TaggingVariable& variable, bool delayed /* = false */) {
+    m_list.push_back(variable);
+    if (not delayed)
+      finalize();
+  }
 
-TaggingValue TaggingVariableList::get( TaggingVariableName tag ) const {
-  range r = getRange(tag);
-  if (r.first == r.second)
-    throw edm::Exception( edm::errors::InvalidReference )
-                  << "TaggingVariable " << tag << " is not present in the collection";
-  return r.first->second;
-}
+  void TaggingVariableList::insert(TaggingVariableName tag, TaggingValue value, bool delayed /* = false */) {
+    m_list.push_back(TaggingVariable(tag, value));
+    if (not delayed)
+      finalize();
+  }
 
-TaggingValue TaggingVariableList::get( TaggingVariableName tag, TaggingValue defaultValue ) const {
-  range r = getRange(tag);
-  if ( r.first == r.second )
-    return defaultValue;
-  return r.first->second;
-}
+  void TaggingVariableList::insert(TaggingVariableName tag,
+                                   const std::vector<TaggingValue>& values,
+                                   bool delayed /* = false */) {
+    for (std::vector<TaggingValue>::const_iterator i = values.begin(); i != values.end(); i++) {
+      m_list.push_back(TaggingVariable(tag, *i));
+    }
+    if (not delayed)
+      finalize();
+  }
 
-std::vector<TaggingValue> TaggingVariableList::getList( TaggingVariableName tag, bool throwOnEmptyList ) const {
-  range r = getRange( tag );
-  if ( throwOnEmptyList && r.first == r.second )
-    throw edm::Exception( edm::errors::InvalidReference )
-                  << "TaggingVariable " << tag << " is not present in the collection";
-  std::vector<TaggingValue> list( r.second - r.first );
-  transform( r.first, r.second, list.begin(), [](TaggingVariable const& x) { return x.second;} );
-  return list;
-}
+  void TaggingVariableList::insert(const TaggingVariableList& list) {
+    std::vector<TaggingVariable>::size_type size = m_list.size();
+    m_list.insert(m_list.end(), list.m_list.begin(), list.m_list.end());
+    inplace_merge(m_list.begin(), m_list.begin() + size, m_list.end(), TaggingVariableCompare());
+  }
 
-TaggingVariableList::range TaggingVariableList::getRange( TaggingVariableName tag ) const {
-  return equal_range( m_list.begin(), m_list.end(), tag, TaggingVariableCompare() );
-}
+  void TaggingVariableList::finalize(void) { stable_sort(m_list.begin(), m_list.end(), TaggingVariableCompare()); }
 
-} // namespace reco
+  TaggingValue TaggingVariableList::get(TaggingVariableName tag) const {
+    range r = getRange(tag);
+    if (r.first == r.second)
+      throw edm::Exception(edm::errors::InvalidReference)
+          << "TaggingVariable " << tag << " is not present in the collection";
+    return r.first->second;
+  }
+
+  TaggingValue TaggingVariableList::get(TaggingVariableName tag, TaggingValue defaultValue) const {
+    range r = getRange(tag);
+    if (r.first == r.second)
+      return defaultValue;
+    return r.first->second;
+  }
+
+  std::vector<TaggingValue> TaggingVariableList::getList(TaggingVariableName tag, bool throwOnEmptyList) const {
+    range r = getRange(tag);
+    if (throwOnEmptyList && r.first == r.second)
+      throw edm::Exception(edm::errors::InvalidReference)
+          << "TaggingVariable " << tag << " is not present in the collection";
+    std::vector<TaggingValue> list(r.second - r.first);
+    transform(r.first, r.second, list.begin(), [](TaggingVariable const& x) { return x.second; });
+    return list;
+  }
+
+  TaggingVariableList::range TaggingVariableList::getRange(TaggingVariableName tag) const {
+    return equal_range(m_list.begin(), m_list.end(), tag, TaggingVariableCompare());
+  }
+
+}  // namespace reco

--- a/DataFormats/BTauReco/src/TauImpactParameterInfo.cc
+++ b/DataFormats/BTauReco/src/TauImpactParameterInfo.cc
@@ -1,55 +1,49 @@
 #include "DataFormats/BTauReco/interface/TauImpactParameterInfo.h"
-#include "DataFormats/TrackReco/interface/Track.h" 
+#include "DataFormats/TrackReco/interface/Track.h"
 
 using namespace edm;
 using namespace reco;
 using namespace std;
 
-float reco::TauImpactParameterInfo::discriminator (double ip_min,double ip_max,double sip_min,bool use_sign, bool use3D) const {
+float reco::TauImpactParameterInfo::discriminator(
+    double ip_min, double ip_max, double sip_min, bool use_sign, bool use3D) const {
+  double discriminator = isolatedTaus->discriminator();
 
-	double discriminator = isolatedTaus->discriminator();
+  const TrackRef leadingTrack = isolatedTaus->leadingSignalTrack(0.4, 1.);
 
-	const TrackRef leadingTrack = isolatedTaus->leadingSignalTrack(0.4,1.);
+  if (!leadingTrack.isNull()) {
+    const TauImpactParameterTrackData* ipData = getTrackData(leadingTrack);
+    Measurement1D ip = ipData->transverseIp;
+    if (use3D)
+      ip = ipData->ip3D;
 
-	if(! leadingTrack.isNull()){
-	  const TauImpactParameterTrackData* ipData = getTrackData(leadingTrack);
-	  Measurement1D ip = ipData->transverseIp;
-	  if(use3D) ip = ipData->ip3D;
-
-	  if( ip.value() < ip_min ||
-	      ip.value() > ip_max ||
-	      ip.significance() < sip_min ){
-		discriminator = 0;
-	  }
-	}
-	return discriminator;
+    if (ip.value() < ip_min || ip.value() > ip_max || ip.significance() < sip_min) {
+      discriminator = 0;
+    }
+  }
+  return discriminator;
 }
 float reco::TauImpactParameterInfo::discriminator() const {
-        //default discriminator: returns the value of the discriminator of the jet tag
-	return isolatedTaus->discriminator();
+  //default discriminator: returns the value of the discriminator of the jet tag
+  return isolatedTaus->discriminator();
 }
 
-const reco::TauImpactParameterTrackData* TauImpactParameterInfo::getTrackData(const reco::TrackRef & trackRef) const {
+const reco::TauImpactParameterTrackData* TauImpactParameterInfo::getTrackData(const reco::TrackRef& trackRef) const {
+  reco::TrackTauImpactParameterAssociationCollection::const_iterator iter = trackDataMap.find(trackRef);
 
-        reco::TrackTauImpactParameterAssociationCollection::const_iterator iter
-	    = trackDataMap.find(trackRef);
+  if (iter != trackDataMap.end())
+    return &(iter->val);
 
-        if (iter != trackDataMap.end()) return &(iter->val);
-
-	return nullptr; // if track not found return 0
+  return nullptr;  // if track not found return 0
 }
 
-void reco::TauImpactParameterInfo::storeTrackData(const reco::TrackRef & trackRef,
-                  const reco::TauImpactParameterTrackData& trackData) {
-
-	trackDataMap.insert(trackRef, trackData);
+void reco::TauImpactParameterInfo::storeTrackData(const reco::TrackRef& trackRef,
+                                                  const reco::TauImpactParameterTrackData& trackData) {
+  trackDataMap.insert(trackRef, trackData);
 }
 
-void reco::TauImpactParameterInfo::setIsolatedTauTag(const IsolatedTauTagInfoRef & isolationRef){
-	isolatedTaus = isolationRef;
+void reco::TauImpactParameterInfo::setIsolatedTauTag(const IsolatedTauTagInfoRef& isolationRef) {
+  isolatedTaus = isolationRef;
 }
 
-const IsolatedTauTagInfoRef& reco::TauImpactParameterInfo::getIsolatedTauTag() const {
-        return isolatedTaus;
-}
-
+const IsolatedTauTagInfoRef& reco::TauImpactParameterInfo::getIsolatedTauTag() const { return isolatedTaus; }

--- a/DataFormats/BTauReco/src/TauMassTagInfo.cc
+++ b/DataFormats/BTauReco/src/TauMassTagInfo.cc
@@ -1,67 +1,61 @@
 #include "DataFormats/BTauReco/interface/TauMassTagInfo.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h" 
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/Common/interface/RefVector.h"
 
 using namespace edm;
 using namespace reco;
 using namespace std;
 
-float reco::TauMassTagInfo::discriminator(double matching_cone, double leading_trk_pt,
-                                   double signal_cone, double cluster_track_cone, 
-                                   double m_cut) const {
+float reco::TauMassTagInfo::discriminator(
+    double matching_cone, double leading_trk_pt, double signal_cone, double cluster_track_cone, double m_cut) const {
   float discriminator = 0.0;
-  double invariantMass = getInvariantMass(matching_cone,leading_trk_pt, signal_cone,cluster_track_cone);  
-  if (invariantMass >= 0.0 && invariantMass < m_cut ) discriminator = 1.0;
+  double invariantMass = getInvariantMass(matching_cone, leading_trk_pt, signal_cone, cluster_track_cone);
+  if (invariantMass >= 0.0 && invariantMass < m_cut)
+    discriminator = 1.0;
   return discriminator;
 }
 //
 // -- Set IsolatedTauTag
 //
-void reco::TauMassTagInfo::setIsolatedTauTag(const IsolatedTauTagInfoRef isolationRef){
-   isolatedTau = isolationRef;
-}
+void reco::TauMassTagInfo::setIsolatedTauTag(const IsolatedTauTagInfoRef isolationRef) { isolatedTau = isolationRef; }
 //
 // -- Get IsolatedTauTag
 //
-const IsolatedTauTagInfoRef& reco::TauMassTagInfo::getIsolatedTauTag() const {
-   return isolatedTau;
-}
+const IsolatedTauTagInfoRef& reco::TauMassTagInfo::getIsolatedTauTag() const { return isolatedTau; }
 //
 // -- Set Cluster Collection
 //
-void reco::TauMassTagInfo::storeClusterTrackCollection(reco::BasicClusterRef clusterRef,float dr) {
-  
+void reco::TauMassTagInfo::storeClusterTrackCollection(reco::BasicClusterRef clusterRef, float dr) {
   clusterMap.insert(clusterRef, dr);
 }
 //
 // -- Calculate 4 momentum vector from tracks only
 //
-bool reco::TauMassTagInfo::calculateTrkP4(double matching_cone, 
-                       double leading_trk_pt, double signal_cone, 
-                       math::XYZTLorentzVector& p4) const {
-
-
-  const TrackRef leadTk= isolatedTau->leadingSignalTrack(matching_cone,leading_trk_pt);
+bool reco::TauMassTagInfo::calculateTrkP4(double matching_cone,
+                                          double leading_trk_pt,
+                                          double signal_cone,
+                                          math::XYZTLorentzVector& p4) const {
+  const TrackRef leadTk = isolatedTau->leadingSignalTrack(matching_cone, leading_trk_pt);
   if (!leadTk) {
-    std::cout <<" TauMassTagInfo::  No Leading Track !!  " << std::endl;    
+    std::cout << " TauMassTagInfo::  No Leading Track !!  " << std::endl;
     return false;
   }
   math::XYZVector momentum = (*leadTk).momentum();
-  const RefVector<TrackCollection> signalTracks = 
-                 isolatedTau->tracksInCone(momentum,signal_cone,1.0);
-//  if (signalTracks.size() == 0 || signalTracks.size()%2 == 0) return false;
-  if (signalTracks.empty()) return false;
+  const RefVector<TrackCollection> signalTracks = isolatedTau->tracksInCone(momentum, signal_cone, 1.0);
+  //  if (signalTracks.size() == 0 || signalTracks.size()%2 == 0) return false;
+  if (signalTracks.empty())
+    return false;
 
   double px_inv = 0.0;
   double py_inv = 0.0;
   double pz_inv = 0.0;
-  double e_inv  = 0.0;
-  for (RefVector<TrackCollection>::const_iterator itrack = signalTracks.begin(); 
-               itrack != signalTracks.end(); itrack++) {
+  double e_inv = 0.0;
+  for (RefVector<TrackCollection>::const_iterator itrack = signalTracks.begin(); itrack != signalTracks.end();
+       itrack++) {
     double p = (*itrack)->p();
-    double energy = sqrt(p*p + 0.139*0.139); // use correct value!
+    double energy = sqrt(p * p + 0.139 * 0.139);  // use correct value!
     px_inv += (*itrack)->px();
     py_inv += (*itrack)->py();
     pz_inv += (*itrack)->pz();
@@ -78,40 +72,41 @@ bool reco::TauMassTagInfo::calculateTrkP4(double matching_cone,
 //
 // -- Get Invariant Mass
 //
-double reco::TauMassTagInfo::getInvariantMassTrk(double matching_cone, 
-                       double leading_trk_pt, double signal_cone) const 
-{
+double reco::TauMassTagInfo::getInvariantMassTrk(double matching_cone,
+                                                 double leading_trk_pt,
+                                                 double signal_cone) const {
   math::XYZTLorentzVector totalP4;
-  if (!calculateTrkP4(matching_cone,leading_trk_pt, signal_cone, totalP4)) return -1.0;
+  if (!calculateTrkP4(matching_cone, leading_trk_pt, signal_cone, totalP4))
+    return -1.0;
   return totalP4.M();
 }
 //
 // -- Get Invariant Mass
 //
-double reco::TauMassTagInfo::getInvariantMass(double matching_cone, 
-                       double leading_trk_pt, double signal_cone, 
-                       double track_cone) const 
-{
-
+double reco::TauMassTagInfo::getInvariantMass(double matching_cone,
+                                              double leading_trk_pt,
+                                              double signal_cone,
+                                              double track_cone) const {
   math::XYZTLorentzVector totalP4;
-  if (!calculateTrkP4(matching_cone, leading_trk_pt, signal_cone, totalP4)) return -1.0;
+  if (!calculateTrkP4(matching_cone, leading_trk_pt, signal_cone, totalP4))
+    return -1.0;
 
   // Add Clusters away from tracks
-  for (ClusterTrackAssociationCollection::const_iterator mapIter = clusterMap.begin(); 
-                                                         mapIter != clusterMap.end(); mapIter++) {
-    const reco::BasicClusterRef & iclus = mapIter->key;
-    float dr  = mapIter->val;
+  for (ClusterTrackAssociationCollection::const_iterator mapIter = clusterMap.begin(); mapIter != clusterMap.end();
+       mapIter++) {
+    const reco::BasicClusterRef& iclus = mapIter->key;
+    float dr = mapIter->val;
     if (dr > track_cone) {
       math::XYZVector clus3Vec(iclus->x(), iclus->y(), iclus->z());
-      double e  = iclus->energy(); 
+      double e = iclus->energy();
       double theta = clus3Vec.theta();
-      double phi   = clus3Vec.phi();
-      double px    = e * sin(theta) * cos(phi);
-      double py    = e * sin(theta) * sin(phi);
-      double pz    = e * cos(theta);
-      math::XYZTLorentzVector p4(px,py,pz,e);
-      totalP4 += p4;  
-    }           
+      double phi = clus3Vec.phi();
+      double px = e * sin(theta) * cos(phi);
+      double py = e * sin(theta) * sin(phi);
+      double pz = e * cos(theta);
+      math::XYZTLorentzVector p4(px, py, pz, e);
+      totalP4 += p4;
+    }
   }
   return totalP4.M();
 }

--- a/DataFormats/BTauReco/src/TemplatedSoftLeptonTagInfo.cc
+++ b/DataFormats/BTauReco/src/TemplatedSoftLeptonTagInfo.cc
@@ -7,57 +7,51 @@
 
 namespace reco {
 
-using namespace btau;
+  using namespace btau;
 
-const float SoftLeptonProperties::Quality::undef = -999.0;
+  const float SoftLeptonProperties::Quality::undef = -999.0;
 
-unsigned int SoftLeptonProperties::Quality::internalByName(const char *name)
-{
-  if (std::strcmp(name, "") == 0)
-    return 0;
+  unsigned int SoftLeptonProperties::Quality::internalByName(const char *name) {
+    if (std::strcmp(name, "") == 0)
+      return 0;
 
-  if (std::strcmp(name, "leptonId") == 0)
-    return leptonId;
-  else if (std::strcmp(name, "btagLeptonCands") == 0)
-    return btagLeptonCands;
+    if (std::strcmp(name, "leptonId") == 0)
+      return leptonId;
+    else if (std::strcmp(name, "btagLeptonCands") == 0)
+      return btagLeptonCands;
 
-  if (std::strcmp(name, "pfElectronId") == 0)
-    return pfElectronId;
-  else if (std::strcmp(name, "btagElectronCands") == 0)
-    return btagElectronCands;
+    if (std::strcmp(name, "pfElectronId") == 0)
+      return pfElectronId;
+    else if (std::strcmp(name, "btagElectronCands") == 0)
+      return btagElectronCands;
 
-  if (std::strcmp(name, "muonId") == 0)
-    return muonId;
-  else if (std::strcmp(name, "btagMuonCands") == 0)
-    return btagMuonCands;
+    if (std::strcmp(name, "muonId") == 0)
+      return muonId;
+    else if (std::strcmp(name, "btagMuonCands") == 0)
+      return btagMuonCands;
 
-  throw edm::Exception(edm::errors::Configuration) 
-    << "Requested lepton quality \"" << name
-    << "\" not found in SoftLeptonProperties::Quality::byName"
-    << std::endl;
-}
+    throw edm::Exception(edm::errors::Configuration)
+        << "Requested lepton quality \"" << name << "\" not found in SoftLeptonProperties::Quality::byName"
+        << std::endl;
+  }
 
-float SoftLeptonProperties::quality(unsigned int index, bool throwIfUndefined) const
-{
-  float qual = Quality::undef;
-  if (index < qualities_.size())
-    qual = qualities_[index];
+  float SoftLeptonProperties::quality(unsigned int index, bool throwIfUndefined) const {
+    float qual = Quality::undef;
+    if (index < qualities_.size())
+      qual = qualities_[index];
 
-  if (qual == Quality::undef && throwIfUndefined)
-    throw edm::Exception(edm::errors::InvalidReference)
-      << "Requested lepton quality not found in SoftLeptonProperties::Quality"
-      << std::endl;
+    if (qual == Quality::undef && throwIfUndefined)
+      throw edm::Exception(edm::errors::InvalidReference)
+          << "Requested lepton quality not found in SoftLeptonProperties::Quality" << std::endl;
 
-  return qual;
-}
-  
-void SoftLeptonProperties::setQuality(unsigned int index, float qual)
-{
-  if (qualities_.size() <= index)
-    qualities_.resize(index + 1, Quality::undef);
+    return qual;
+  }
 
-  qualities_[index] = qual;
-}
+  void SoftLeptonProperties::setQuality(unsigned int index, float qual) {
+    if (qualities_.size() <= index)
+      qualities_.resize(index + 1, Quality::undef);
 
-}
+    qualities_[index] = qual;
+  }
 
+}  // namespace reco

--- a/DataFormats/BTauReco/src/VertexTypes.cc
+++ b/DataFormats/BTauReco/src/VertexTypes.cc
@@ -5,32 +5,34 @@ using namespace std;
 
 namespace reco {
 
-std::string btag::Vertices::name ( VertexType v )
-{
-  switch (v)
-  {
-    case NoVertex:
-      return "NoVertex";
-    case PseudoVertex:
-      return "PseudoVertex";
-    case RecoVertex:
-      return "RecoVertex";
-    default:
-      return "???";
+  std::string btag::Vertices::name(VertexType v) {
+    switch (v) {
+      case NoVertex:
+        return "NoVertex";
+      case PseudoVertex:
+        return "PseudoVertex";
+      case RecoVertex:
+        return "RecoVertex";
+      default:
+        return "???";
+    }
   }
-}
 
-btag::Vertices::VertexType btag::Vertices::type ( const std::string & s )
-{
-  if ( s=="NoVertex" || s=="No" ) return NoVertex;
-  if ( s=="PseudoVertex" || s=="Pseudo" ) return PseudoVertex;
-  if ( s=="RecoVertex" || s=="Reco" ) return RecoVertex;
+  btag::Vertices::VertexType btag::Vertices::type(const std::string& s) {
+    if (s == "NoVertex" || s == "No")
+      return NoVertex;
+    if (s == "PseudoVertex" || s == "Pseudo")
+      return PseudoVertex;
+    if (s == "RecoVertex" || s == "Reco")
+      return RecoVertex;
 
-  int i = atoi ( s.c_str() );
-  if ( i > 0 ) return ( VertexType ) (i);
-  if ( ( i==0 ) && s == "0" ) return ( VertexType ) (i);
+    int i = atoi(s.c_str());
+    if (i > 0)
+      return (VertexType)(i);
+    if ((i == 0) && s == "0")
+      return (VertexType)(i);
 
-  return UndefVertex;
-}
+    return UndefVertex;
+  }
 
-}
+}  // namespace reco

--- a/DataFormats/BTauReco/src/classes.h
+++ b/DataFormats/BTauReco/src/classes.h
@@ -58,12 +58,9 @@
 #include "DataFormats/BTauReco/interface/DeepDoubleXTagInfo.h"
 #include "DataFormats/BTauReco/interface/DeepBoostedJetTagInfo.h"
 
-
-
 namespace reco {
-    typedef TrackTauImpactParameterAssociationCollection::map_type          TrackTauImpactParameterAssociationMapType;
-    typedef TrackTauImpactParameterAssociationCollection::ref_type          TrackTauImpactParameterAssociationRefType;
-    typedef TauMassTagInfo::ClusterTrackAssociationCollection::map_type     TauMassTagInfo_ClusterTrackAssociationMapType;
-    typedef TauMassTagInfo::ClusterTrackAssociationCollection::ref_type     TauMassTagInfo_ClusterTrackAssociationRefType;
-}
-
+  typedef TrackTauImpactParameterAssociationCollection::map_type TrackTauImpactParameterAssociationMapType;
+  typedef TrackTauImpactParameterAssociationCollection::ref_type TrackTauImpactParameterAssociationRefType;
+  typedef TauMassTagInfo::ClusterTrackAssociationCollection::map_type TauMassTagInfo_ClusterTrackAssociationMapType;
+  typedef TauMassTagInfo::ClusterTrackAssociationCollection::ref_type TauMassTagInfo_ClusterTrackAssociationRefType;
+}  // namespace reco

--- a/RecoBTag/FeatureTools/interface/BoostedDoubleSVTagInfoConverter.h
+++ b/RecoBTag/FeatureTools/interface/BoostedDoubleSVTagInfoConverter.h
@@ -9,11 +9,9 @@
 
 namespace btagbtvdeep {
 
-  void doubleBTagToFeatures(const reco::TaggingVariableList & tag_info_vars,
-			    BoostedDoubleSVTagInfoFeatures & tag_info_features) ;
+  void doubleBTagToFeatures(const reco::TaggingVariableList& tag_info_vars,
+                            BoostedDoubleSVTagInfoFeatures& tag_info_features);
 
 }
 
-#endif //RecoBTag_FeatureTools_BoostedDoubleSVTagInfoConverter_h
-
-
+#endif  //RecoBTag_FeatureTools_BoostedDoubleSVTagInfoConverter_h

--- a/RecoBTag/FeatureTools/interface/ChargedCandidateConverter.h
+++ b/RecoBTag/FeatureTools/interface/ChargedCandidateConverter.h
@@ -12,62 +12,60 @@
 namespace btagbtvdeep {
 
   template <typename CandidateType>
-    void commonCandidateToFeatures(const CandidateType * c_pf,
-				   const reco::Jet & jet,
-				   const TrackInfoBuilder & track_info,
-				   const float & drminpfcandsv, const float & jetR,
-				   ChargedCandidateFeatures & c_pf_features,
-				   const bool flip = false) {
-
-
+  void commonCandidateToFeatures(const CandidateType* c_pf,
+                                 const reco::Jet& jet,
+                                 const TrackInfoBuilder& track_info,
+                                 const float& drminpfcandsv,
+                                 const float& jetR,
+                                 ChargedCandidateFeatures& c_pf_features,
+                                 const bool flip = false) {
     float trackSip2dVal = track_info.getTrackSip2dVal();
     float trackSip2dSig = track_info.getTrackSip2dSig();
     float trackSip3dVal = track_info.getTrackSip3dVal();
     float trackSip3dSig = track_info.getTrackSip3dSig();
-    if(flip == true){
+    if (flip == true) {
       trackSip2dVal = -trackSip2dVal;
       trackSip2dSig = -trackSip2dSig;
       trackSip3dSig = -trackSip3dSig;
       trackSip3dVal = -trackSip3dVal;
     }
 
-    c_pf_features.ptrel = catch_infs_and_bound(c_pf->pt()/jet.pt(),
-					       0,-1,0,-1);
+    c_pf_features.ptrel = catch_infs_and_bound(c_pf->pt() / jet.pt(), 0, -1, 0, -1);
 
-    c_pf_features.btagPf_trackEtaRel     =catch_infs_and_bound(track_info.getTrackEtaRel(),  0,-5,15);
-    c_pf_features.btagPf_trackPtRel      =catch_infs_and_bound(track_info.getTrackPtRel(),   0,-1,4);
-    c_pf_features.btagPf_trackPPar       =catch_infs_and_bound(track_info.getTrackPPar(),    0,-1e5,1e5 );
-    c_pf_features.btagPf_trackDeltaR     =catch_infs_and_bound(track_info.getTrackDeltaR(),  0,-5,5 );
-    c_pf_features.btagPf_trackPtRatio    =catch_infs_and_bound(track_info.getTrackPtRatio(), 0,-1,10);
-    c_pf_features.btagPf_trackPParRatio  =catch_infs_and_bound(track_info.getTrackPParRatio(),0,-10,100);
-    c_pf_features.btagPf_trackSip3dVal   =catch_infs_and_bound(trackSip3dVal, 0, -1,1e5 );
-    c_pf_features.btagPf_trackSip3dSig   =catch_infs_and_bound(trackSip3dSig, 0, -1,4e4 );
-    c_pf_features.btagPf_trackSip2dVal   =catch_infs_and_bound(trackSip2dVal, 0, -1,70 );
-    c_pf_features.btagPf_trackSip2dSig   =catch_infs_and_bound(trackSip2dSig, 0, -1,4e4 );
-    c_pf_features.btagPf_trackJetDistVal =catch_infs_and_bound(track_info.getTrackJetDistVal(),0,-20,1 );
+    c_pf_features.btagPf_trackEtaRel = catch_infs_and_bound(track_info.getTrackEtaRel(), 0, -5, 15);
+    c_pf_features.btagPf_trackPtRel = catch_infs_and_bound(track_info.getTrackPtRel(), 0, -1, 4);
+    c_pf_features.btagPf_trackPPar = catch_infs_and_bound(track_info.getTrackPPar(), 0, -1e5, 1e5);
+    c_pf_features.btagPf_trackDeltaR = catch_infs_and_bound(track_info.getTrackDeltaR(), 0, -5, 5);
+    c_pf_features.btagPf_trackPtRatio = catch_infs_and_bound(track_info.getTrackPtRatio(), 0, -1, 10);
+    c_pf_features.btagPf_trackPParRatio = catch_infs_and_bound(track_info.getTrackPParRatio(), 0, -10, 100);
+    c_pf_features.btagPf_trackSip3dVal = catch_infs_and_bound(trackSip3dVal, 0, -1, 1e5);
+    c_pf_features.btagPf_trackSip3dSig = catch_infs_and_bound(trackSip3dSig, 0, -1, 4e4);
+    c_pf_features.btagPf_trackSip2dVal = catch_infs_and_bound(trackSip2dVal, 0, -1, 70);
+    c_pf_features.btagPf_trackSip2dSig = catch_infs_and_bound(trackSip2dSig, 0, -1, 4e4);
+    c_pf_features.btagPf_trackJetDistVal = catch_infs_and_bound(track_info.getTrackJetDistVal(), 0, -20, 1);
 
-    c_pf_features.drminsv = catch_infs_and_bound(drminpfcandsv,0,-1.*jetR,0,-1.*jetR);
-
+    c_pf_features.drminsv = catch_infs_and_bound(drminpfcandsv, 0, -1. * jetR, 0, -1. * jetR);
   }
 
-  void packedCandidateToFeatures(const pat::PackedCandidate * c_pf,
-				 const pat::Jet & jet,
-				 const TrackInfoBuilder & track_info,
-				 const float drminpfcandsv, const float jetR,
-				 ChargedCandidateFeatures & c_pf_features,
-				 const bool flip = false) ;
+  void packedCandidateToFeatures(const pat::PackedCandidate* c_pf,
+                                 const pat::Jet& jet,
+                                 const TrackInfoBuilder& track_info,
+                                 const float drminpfcandsv,
+                                 const float jetR,
+                                 ChargedCandidateFeatures& c_pf_features,
+                                 const bool flip = false);
 
+  void recoCandidateToFeatures(const reco::PFCandidate* c_pf,
+                               const reco::Jet& jet,
+                               const TrackInfoBuilder& track_info,
+                               const float drminpfcandsv,
+                               const float jetR,
+                               const float puppiw,
+                               const int pv_ass_quality,
+                               const reco::VertexRef& pv,
+                               ChargedCandidateFeatures& c_pf_features,
+                               const bool flip = false);
 
-  void recoCandidateToFeatures(const reco::PFCandidate * c_pf,
-			       const reco::Jet & jet,
-			       const TrackInfoBuilder & track_info,
-			       const float drminpfcandsv, const float jetR, const float puppiw,
-			       const int pv_ass_quality,
-			       const reco::VertexRef & pv,
-			       ChargedCandidateFeatures & c_pf_features,
-			       const bool flip = false) ;
+}  // namespace btagbtvdeep
 
-
-}
-
-#endif //RecoBTag_FeatureTools_ChargedCandidateConverter_h
+#endif  //RecoBTag_FeatureTools_ChargedCandidateConverter_h

--- a/RecoBTag/FeatureTools/interface/JetConverter.h
+++ b/RecoBTag/FeatureTools/interface/JetConverter.h
@@ -9,18 +9,15 @@ namespace btagbtvdeep {
 
   class JetConverter {
   public:
-
-    static void jetToFeatures(const reco::Jet & jet,
-			      JetFeatures & jet_features) {
-      jet_features.pt = jet.pt(); // uncorrected
+    static void jetToFeatures(const reco::Jet& jet, JetFeatures& jet_features) {
+      jet_features.pt = jet.pt();  // uncorrected
       jet_features.eta = jet.eta();
-      jet_features.phi = jet.phi();   
+      jet_features.phi = jet.phi();
       jet_features.mass = jet.mass();
       jet_features.energy = jet.energy();
     }
   };
 
-}
+}  // namespace btagbtvdeep
 
-#endif //RecoBTag_FeatureTools_JetConverter_h
-
+#endif  //RecoBTag_FeatureTools_JetConverter_h

--- a/RecoBTag/FeatureTools/interface/NeutralCandidateConverter.h
+++ b/RecoBTag/FeatureTools/interface/NeutralCandidateConverter.h
@@ -9,44 +9,36 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-
 namespace btagbtvdeep {
 
+  void packedCandidateToFeatures(const pat::PackedCandidate* n_pf,
+                                 const pat::Jet& jet,
+                                 const float drminpfcandsv,
+                                 const float jetR,
+                                 NeutralCandidateFeatures& n_pf_features);
 
-
-  void packedCandidateToFeatures(const pat::PackedCandidate * n_pf,
-				 const pat::Jet & jet,
-				 const float drminpfcandsv, const float jetR,
-				 NeutralCandidateFeatures & n_pf_features) ;
-
-
-  void recoCandidateToFeatures(const reco::PFCandidate * n_pf,
-			       const reco::Jet & jet,
-			       const float drminpfcandsv, const float jetR, const float puppiw,
-			       NeutralCandidateFeatures & n_pf_features) ;
-
+  void recoCandidateToFeatures(const reco::PFCandidate* n_pf,
+                               const reco::Jet& jet,
+                               const float drminpfcandsv,
+                               const float jetR,
+                               const float puppiw,
+                               NeutralCandidateFeatures& n_pf_features);
 
   template <typename CandidateType>
-    static void commonCandidateToFeatures(const CandidateType * n_pf,
-					  const reco::Jet & jet,
-					  const float & drminpfcandsv, const float & jetR,
-					  NeutralCandidateFeatures & n_pf_features) {
-
-    n_pf_features.ptrel = catch_infs_and_bound(n_pf->pt()/jet.pt(),
-					       0,-1,0,-1);
-    n_pf_features.deltaR = catch_infs_and_bound(reco::deltaR(*n_pf,jet),
-						0,-0.6,0,-0.6);
+  static void commonCandidateToFeatures(const CandidateType* n_pf,
+                                        const reco::Jet& jet,
+                                        const float& drminpfcandsv,
+                                        const float& jetR,
+                                        NeutralCandidateFeatures& n_pf_features) {
+    n_pf_features.ptrel = catch_infs_and_bound(n_pf->pt() / jet.pt(), 0, -1, 0, -1);
+    n_pf_features.deltaR = catch_infs_and_bound(reco::deltaR(*n_pf, jet), 0, -0.6, 0, -0.6);
     n_pf_features.isGamma = 0;
-    if(std::abs(n_pf->pdgId())==22)  n_pf_features.isGamma = 1;
+    if (std::abs(n_pf->pdgId()) == 22)
+      n_pf_features.isGamma = 1;
 
-
-    n_pf_features.drminsv = catch_infs_and_bound(drminpfcandsv,
-						 0,-1.*jetR,0,-1.*jetR);
-
+    n_pf_features.drminsv = catch_infs_and_bound(drminpfcandsv, 0, -1. * jetR, 0, -1. * jetR);
   }
 
+}  // namespace btagbtvdeep
 
-
-}
-
-#endif //RecoBTag_FeatureTools_NeutralCandidateConverter_h
+#endif  //RecoBTag_FeatureTools_NeutralCandidateConverter_h

--- a/RecoBTag/FeatureTools/interface/SecondaryVertexConverter.h
+++ b/RecoBTag/FeatureTools/interface/SecondaryVertexConverter.h
@@ -10,13 +10,12 @@
 
 namespace btagbtvdeep {
 
-
-  void svToFeatures( const reco::VertexCompositePtrCandidate & sv,
-		     const reco::Vertex & pv, const reco::Jet & jet,
-		     SecondaryVertexFeatures & sv_features,
-		     const bool flip = false) ;
-
+  void svToFeatures(const reco::VertexCompositePtrCandidate& sv,
+                    const reco::Vertex& pv,
+                    const reco::Jet& jet,
+                    SecondaryVertexFeatures& sv_features,
+                    const bool flip = false);
 
 }
 
-#endif //RecoBTag_FeatureTools_SecondaryVertexConverter_h
+#endif  //RecoBTag_FeatureTools_SecondaryVertexConverter_h

--- a/RecoBTag/FeatureTools/interface/SeedingTrackInfoBuilder.h
+++ b/RecoBTag/FeatureTools/interface/SeedingTrackInfoBuilder.h
@@ -5,41 +5,46 @@
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "RecoBTag/TrackProbability/interface/HistogramProbabilityEstimator.h"
 
-namespace btagbtvdeep{
-    
-class SeedingTrackInfoBuilder{
-public:
+namespace btagbtvdeep {
+
+  class SeedingTrackInfoBuilder {
+  public:
     SeedingTrackInfoBuilder();
 
-    void buildSeedingTrackInfo(const reco::TransientTrack * it , const reco::Vertex & pv,  const reco::Jet & jet,/*GlobalVector jetdirection,*/ 
-                               float mass, const std::pair<bool,Measurement1D> & ip, const std::pair<bool,Measurement1D> & ip2d,
-                               float jet_distance, float jaxis_dlength, HistogramProbabilityEstimator* m_probabilityEstimator, bool m_computeProbabilities);
+    void buildSeedingTrackInfo(const reco::TransientTrack* it,
+                               const reco::Vertex& pv,
+                               const reco::Jet& jet, /*GlobalVector jetdirection,*/
+                               float mass,
+                               const std::pair<bool, Measurement1D>& ip,
+                               const std::pair<bool, Measurement1D>& ip2d,
+                               float jet_distance,
+                               float jaxis_dlength,
+                               HistogramProbabilityEstimator* m_probabilityEstimator,
+                               bool m_computeProbabilities);
 
-    const float pt() const {return pt_;}
-    const float eta() const {return eta_;}
-    const float phi() const {return phi_;}
-    const float mass() const {return mass_;}
-    const float dz() const {return dz_;}
-    const float dxy() const {return dxy_;}
-    const float ip3d() const {return ip3D_;}
-    const float sip3d() const {return sip3D_;}
-    const float ip2d() const {return ip2D_;}
-    const float sip2d() const {return sip2D_;}
-    const float ip3d_Signed() const {return ip3D_signed_;}
-    const float sip3d_Signed() const {return sip3D_signed_;}
-    const float ip2d_Signed() const {return ip2D_signed_;}
-    const float sip2d_Signed() const {return sip2D_signed_;}
-    const float chi2reduced() const {return chi2reduced_;}
-    const float nPixelHits() const {return nPixelHits_;}
-    const float nHits() const {return nHits_;}
-    const float jetAxisDistance() const {return jetAxisDistance_;}
-    const float jetAxisDlength() const {return jetAxisDlength_;}
-    const float trackProbability3D() const {return trackProbability3D_;}
-    const float trackProbability2D() const {return trackProbability2D_;}   
+    const float pt() const { return pt_; }
+    const float eta() const { return eta_; }
+    const float phi() const { return phi_; }
+    const float mass() const { return mass_; }
+    const float dz() const { return dz_; }
+    const float dxy() const { return dxy_; }
+    const float ip3d() const { return ip3D_; }
+    const float sip3d() const { return sip3D_; }
+    const float ip2d() const { return ip2D_; }
+    const float sip2d() const { return sip2D_; }
+    const float ip3d_Signed() const { return ip3D_signed_; }
+    const float sip3d_Signed() const { return sip3D_signed_; }
+    const float ip2d_Signed() const { return ip2D_signed_; }
+    const float sip2d_Signed() const { return sip2D_signed_; }
+    const float chi2reduced() const { return chi2reduced_; }
+    const float nPixelHits() const { return nPixelHits_; }
+    const float nHits() const { return nHits_; }
+    const float jetAxisDistance() const { return jetAxisDistance_; }
+    const float jetAxisDlength() const { return jetAxisDlength_; }
+    const float trackProbability3D() const { return trackProbability3D_; }
+    const float trackProbability2D() const { return trackProbability2D_; }
 
-
-private:
-
+  private:
     float pt_;
     float eta_;
     float phi_;
@@ -61,10 +66,7 @@ private:
     float jetAxisDlength_;
     float trackProbability3D_;
     float trackProbability2D_;
+  };
+}  // namespace btagbtvdeep
 
-    
-
-};
-}
-
-#endif //RecoBTag_FeatureTools_SeedingTrackInfoBuilder_h 
+#endif  //RecoBTag_FeatureTools_SeedingTrackInfoBuilder_h

--- a/RecoBTag/FeatureTools/interface/SeedingTracksConverter.h
+++ b/RecoBTag/FeatureTools/interface/SeedingTracksConverter.h
@@ -21,16 +21,19 @@
 
 namespace btagbtvdeep {
 
-        void seedingTracksToFeatures(  const std::vector<reco::TransientTrack> & selectedTracks,
-                                       const std::vector<float> & masses,
-                                       const reco::Jet & jet,
-                                       const reco::Vertex & pv,
-                                       HistogramProbabilityEstimator* probabilityEstimator,
-                                       bool computeProbabilities,
-                                       std::vector<btagbtvdeep::SeedingTrackFeatures> & seedingT_features_vector
-                                    ) ;
+  void seedingTracksToFeatures(const std::vector<reco::TransientTrack>& selectedTracks,
+                               const std::vector<float>& masses,
+                               const reco::Jet& jet,
+                               const reco::Vertex& pv,
+                               HistogramProbabilityEstimator* probabilityEstimator,
+                               bool computeProbabilities,
+                               std::vector<btagbtvdeep::SeedingTrackFeatures>& seedingT_features_vector);
 
-        float logWithOffset(float v, float logOffset=0) {if (v==0.) return 0.; return logOffset + log(std::fabs(v))*std::copysign(1.f, v);};
-}
+  float logWithOffset(float v, float logOffset = 0) {
+    if (v == 0.)
+      return 0.;
+    return logOffset + log(std::fabs(v)) * std::copysign(1.f, v);
+  };
+}  // namespace btagbtvdeep
 
-#endif //RecoBTag_FeatureTools_SeedingTracksConverter_h
+#endif  //RecoBTag_FeatureTools_SeedingTracksConverter_h

--- a/RecoBTag/FeatureTools/interface/ShallowTagInfoConverter.h
+++ b/RecoBTag/FeatureTools/interface/ShallowTagInfoConverter.h
@@ -9,11 +9,8 @@
 
 namespace btagbtvdeep {
 
-  void bTagToFeatures(const reco::TaggingVariableList & tag_info_vars,
-		      ShallowTagInfoFeatures & tag_info_features);
+  void bTagToFeatures(const reco::TaggingVariableList& tag_info_vars, ShallowTagInfoFeatures& tag_info_features);
 
 }
 
-#endif //RecoBTag_FeatureTools_ShallowTagInfoConverter_h
-
-
+#endif  //RecoBTag_FeatureTools_ShallowTagInfoConverter_h

--- a/RecoBTag/FeatureTools/interface/TrackInfoBuilder.h
+++ b/RecoBTag/FeatureTools/interface/TrackInfoBuilder.h
@@ -6,31 +6,33 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
-namespace btagbtvdeep{
+namespace btagbtvdeep {
 
-// adapted from DeepNtuples
-class TrackInfoBuilder{
-public:
-    TrackInfoBuilder(edm::ESHandle<TransientTrackBuilder> & build);
+  // adapted from DeepNtuples
+  class TrackInfoBuilder {
+  public:
+    TrackInfoBuilder(edm::ESHandle<TransientTrackBuilder>& build);
 
-    void buildTrackInfo(const reco::Candidate * candidate ,const math::XYZVector&  jetDir, GlobalVector refjetdirection, const reco::Vertex & pv);
-    const float getTrackDeltaR() const {return trackDeltaR_;}
-    const float getTrackEta() const {return trackEta_;}
-    const float getTrackEtaRel() const {return trackEtaRel_;}
-    const float getTrackJetDistSig() const {return trackJetDistSig_;}
-    const float getTrackJetDistVal() const {return trackJetDistVal_;}
-    const float getTrackMomentum() const {return trackMomentum_;}
-    const float getTrackPPar() const {return trackPPar_;}
-    const float getTrackPParRatio() const {return trackPParRatio_;}
-    const float getTrackPtRatio() const {return trackPtRatio_;}
-    const float getTrackPtRel() const {return trackPtRel_;}
-    const float getTrackSip2dSig() const {return trackSip2dSig_;}
-    const float getTrackSip2dVal() const {return trackSip2dVal_;}
-    const float getTrackSip3dSig() const {return trackSip3dSig_;}
-    const float getTrackSip3dVal() const {return trackSip3dVal_;}
+    void buildTrackInfo(const reco::Candidate* candidate,
+                        const math::XYZVector& jetDir,
+                        GlobalVector refjetdirection,
+                        const reco::Vertex& pv);
+    const float getTrackDeltaR() const { return trackDeltaR_; }
+    const float getTrackEta() const { return trackEta_; }
+    const float getTrackEtaRel() const { return trackEtaRel_; }
+    const float getTrackJetDistSig() const { return trackJetDistSig_; }
+    const float getTrackJetDistVal() const { return trackJetDistVal_; }
+    const float getTrackMomentum() const { return trackMomentum_; }
+    const float getTrackPPar() const { return trackPPar_; }
+    const float getTrackPParRatio() const { return trackPParRatio_; }
+    const float getTrackPtRatio() const { return trackPtRatio_; }
+    const float getTrackPtRel() const { return trackPtRel_; }
+    const float getTrackSip2dSig() const { return trackSip2dSig_; }
+    const float getTrackSip2dVal() const { return trackSip2dVal_; }
+    const float getTrackSip3dSig() const { return trackSip3dSig_; }
+    const float getTrackSip3dVal() const { return trackSip3dVal_; }
 
-private:
-
+  private:
     edm::ESHandle<TransientTrackBuilder> builder_;
 
     float trackMomentum_;
@@ -48,9 +50,8 @@ private:
 
     float trackJetDistVal_;
     float trackJetDistSig_;
+  };
 
-};
+}  // namespace btagbtvdeep
 
-}
-
-#endif //RecoBTag_FeatureTools_TrackInfoBuilder_h
+#endif  //RecoBTag_FeatureTools_TrackInfoBuilder_h

--- a/RecoBTag/FeatureTools/interface/TrackPairInfoBuilder.h
+++ b/RecoBTag/FeatureTools/interface/TrackPairInfoBuilder.h
@@ -6,65 +6,65 @@
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h"
 
+namespace btagbtvdeep {
 
-namespace btagbtvdeep{
-
-class TrackPairInfoBuilder{
-public:
+  class TrackPairInfoBuilder {
+  public:
     TrackPairInfoBuilder();
 
-    void buildTrackPairInfo(const reco::TransientTrack * it , const reco::TransientTrack * tt, const reco::Vertex & pv, float mass, GlobalVector jetdirection,
-                            const std::pair<bool,Measurement1D> & t_ip, const std::pair<bool,Measurement1D> & t_ip2d );
+    void buildTrackPairInfo(const reco::TransientTrack* it,
+                            const reco::TransientTrack* tt,
+                            const reco::Vertex& pv,
+                            float mass,
+                            GlobalVector jetdirection,
+                            const std::pair<bool, Measurement1D>& t_ip,
+                            const std::pair<bool, Measurement1D>& t_ip2d);
 
-    const float track_pt() const {return track_pt_;}
-    const float track_eta() const {return track_eta_;}
-    const float track_phi() const {return track_phi_;}
-    const float track_dz() const {return track_dz_;}
-    const float track_dxy() const {return track_dxy_;}
-    const float pca_distance() const {return pca_distance_;}
-    const float pca_significance() const {return pca_significance_; }   
-    const float pcaSeed_x() const {return pcaSeed_x_;}
-    const float pcaSeed_y() const {return pcaSeed_y_;}
-    const float pcaSeed_z() const {return pcaSeed_z_;}
-    const float pcaSeed_xerr() const {return pcaSeed_xerr_;}
-    const float pcaSeed_yerr() const {return pcaSeed_yerr_;}
-    const float pcaSeed_zerr() const {return pcaSeed_zerr_;}
-    const float pcaTrack_x() const {return pcaTrack_x_;}
-    const float pcaTrack_y() const {return pcaTrack_y_;}
-    const float pcaTrack_z() const {return pcaTrack_z_;}
-    const float pcaTrack_xerr() const {return pcaTrack_xerr_;}
-    const float pcaTrack_yerr() const {return pcaTrack_yerr_;}
-    const float pcaTrack_zerr() const {return pcaTrack_zerr_;}    
-    const float dotprodTrack() const {return dotprodTrack_;}
-    const float dotprodSeed() const {return dotprodSeed_;}
-    const float pcaSeed_dist() const {return pcaSeed_dist_;}
-    const float pcaTrack_dist() const {return pcaTrack_dist_;}    
-    const float track_candMass() const {return track_candMass_;}
-    const float track_ip2d() const {return track_ip2d_;}
-    const float track_ip2dSig() const {return track_ip2dSig_;}
-    const float track_ip3d() const {return track_ip3d_;}
-    const float track_ip3dSig() const {return track_ip3dSig_; }   
-    const float dotprodTrackSeed2D() const {return dotprodTrackSeed2D_;}
-    const float dotprodTrackSeed2DV() const {return dotprodTrackSeed2DV_;}
-    const float dotprodTrackSeed3D() const {return dotprodTrackSeed3D_;}
-    const float dotprodTrackSeed3DV() const {return dotprodTrackSeed3DV_;}    
-    const float pca_jetAxis_dist() const {return pca_jetAxis_dist_;}
-    const float pca_jetAxis_dotprod() const {return pca_jetAxis_dotprod_;}
-    const float pca_jetAxis_dEta() const {return pca_jetAxis_dEta_;}
-    const float pca_jetAxis_dPhi() const {return pca_jetAxis_dPhi_;}
-    
-    
+    const float track_pt() const { return track_pt_; }
+    const float track_eta() const { return track_eta_; }
+    const float track_phi() const { return track_phi_; }
+    const float track_dz() const { return track_dz_; }
+    const float track_dxy() const { return track_dxy_; }
+    const float pca_distance() const { return pca_distance_; }
+    const float pca_significance() const { return pca_significance_; }
+    const float pcaSeed_x() const { return pcaSeed_x_; }
+    const float pcaSeed_y() const { return pcaSeed_y_; }
+    const float pcaSeed_z() const { return pcaSeed_z_; }
+    const float pcaSeed_xerr() const { return pcaSeed_xerr_; }
+    const float pcaSeed_yerr() const { return pcaSeed_yerr_; }
+    const float pcaSeed_zerr() const { return pcaSeed_zerr_; }
+    const float pcaTrack_x() const { return pcaTrack_x_; }
+    const float pcaTrack_y() const { return pcaTrack_y_; }
+    const float pcaTrack_z() const { return pcaTrack_z_; }
+    const float pcaTrack_xerr() const { return pcaTrack_xerr_; }
+    const float pcaTrack_yerr() const { return pcaTrack_yerr_; }
+    const float pcaTrack_zerr() const { return pcaTrack_zerr_; }
+    const float dotprodTrack() const { return dotprodTrack_; }
+    const float dotprodSeed() const { return dotprodSeed_; }
+    const float pcaSeed_dist() const { return pcaSeed_dist_; }
+    const float pcaTrack_dist() const { return pcaTrack_dist_; }
+    const float track_candMass() const { return track_candMass_; }
+    const float track_ip2d() const { return track_ip2d_; }
+    const float track_ip2dSig() const { return track_ip2dSig_; }
+    const float track_ip3d() const { return track_ip3d_; }
+    const float track_ip3dSig() const { return track_ip3dSig_; }
+    const float dotprodTrackSeed2D() const { return dotprodTrackSeed2D_; }
+    const float dotprodTrackSeed2DV() const { return dotprodTrackSeed2DV_; }
+    const float dotprodTrackSeed3D() const { return dotprodTrackSeed3D_; }
+    const float dotprodTrackSeed3DV() const { return dotprodTrackSeed3DV_; }
+    const float pca_jetAxis_dist() const { return pca_jetAxis_dist_; }
+    const float pca_jetAxis_dotprod() const { return pca_jetAxis_dotprod_; }
+    const float pca_jetAxis_dEta() const { return pca_jetAxis_dEta_; }
+    const float pca_jetAxis_dPhi() const { return pca_jetAxis_dPhi_; }
 
-
-private:
-
+  private:
     float track_pt_;
     float track_eta_;
     float track_phi_;
     float track_dz_;
     float track_dxy_;
     float pca_distance_;
-    float pca_significance_;    
+    float pca_significance_;
     float pcaSeed_x_;
     float pcaSeed_y_;
     float pcaSeed_z_;
@@ -76,27 +76,26 @@ private:
     float pcaTrack_z_;
     float pcaTrack_xerr_;
     float pcaTrack_yerr_;
-    float pcaTrack_zerr_;    
+    float pcaTrack_zerr_;
     float dotprodTrack_;
     float dotprodSeed_;
     float pcaSeed_dist_;
-    float pcaTrack_dist_;    
+    float pcaTrack_dist_;
     float track_candMass_;
     float track_ip2d_;
     float track_ip2dSig_;
     float track_ip3d_;
-    float track_ip3dSig_;    
+    float track_ip3dSig_;
     float dotprodTrackSeed2D_;
     float dotprodTrackSeed2DV_;
     float dotprodTrackSeed3D_;
-    float dotprodTrackSeed3DV_;    
+    float dotprodTrackSeed3DV_;
     float pca_jetAxis_dist_;
     float pca_jetAxis_dotprod_;
     float pca_jetAxis_dEta_;
     float pca_jetAxis_dPhi_;
+  };
 
-};
+}  // namespace btagbtvdeep
 
-}
-
-#endif //RecoBTag_FeatureTools_TrackPairInfoBuilder_h
+#endif  //RecoBTag_FeatureTools_TrackPairInfoBuilder_h

--- a/RecoBTag/FeatureTools/interface/deep_helpers.h
+++ b/RecoBTag/FeatureTools/interface/deep_helpers.h
@@ -18,16 +18,15 @@
 namespace btagbtvdeep {
 
   // remove infs and NaNs with value  (adapted from DeepNTuples)
-  const float catch_infs(const float in,
-			 const float replace_value = 0.);
+  const float catch_infs(const float in, const float replace_value = 0.);
 
   // remove infs/NaN and bound (adapted from DeepNTuples)
   const float catch_infs_and_bound(const float in,
-				   const float replace_value,
-				   const float lowerbound,
-				   const float upperbound,
-				   const float offset=0.,
-				   const bool use_offsets = true);
+                                   const float replace_value,
+                                   const float lowerbound,
+                                   const float upperbound,
+                                   const float offset = 0.,
+                                   const bool use_offsets = true);
 
   // 2D distance between SV and PV (adapted from DeepNTuples)
   Measurement1D vertexDxy(const reco::VertexCompositePtrCandidate &svcand, const reco::Vertex &pv);
@@ -39,41 +38,41 @@ namespace btagbtvdeep {
   float vertexDdotP(const reco::VertexCompositePtrCandidate &sv, const reco::Vertex &pv);
 
   // helper to order vertices by significance (adapted from DeepNTuples)
-  template < typename SVType, typename PVType>
-    bool sv_vertex_comparator(const SVType & sva, const SVType & svb, const PVType & pv) {
-    auto adxy = vertexDxy(sva,pv);
-    auto bdxy = vertexDxy(svb,pv);
-    float aval= adxy.value();
-    float bval= bdxy.value();
-    float aerr= adxy.error();
-    float berr= bdxy.error();
+  template <typename SVType, typename PVType>
+  bool sv_vertex_comparator(const SVType &sva, const SVType &svb, const PVType &pv) {
+    auto adxy = vertexDxy(sva, pv);
+    auto bdxy = vertexDxy(svb, pv);
+    float aval = adxy.value();
+    float bval = bdxy.value();
+    float aerr = adxy.error();
+    float berr = bdxy.error();
 
-    float asig= catch_infs(aval/aerr,0.);
-    float bsig= catch_infs(bval/berr,0.);
-    return bsig<asig;
+    float asig = catch_infs(aval / aerr, 0.);
+    float bsig = catch_infs(bval / berr, 0.);
+    return bsig < asig;
   }
 
   // write tagging variables to vector (adapted from DeepNTuples)
   template <typename T>
-    int dump_vector(reco::TaggingVariableList& from, T* to,
-		    reco::btau::TaggingVariableName name, const size_t max) {
-    std::vector<T> vals = from.getList(name ,false);
-    size_t size=std::min(vals.size(),max);
-    if(size > 0){
-      for(size_t i=0;i<vals.size();i++){
-        to[i]=catch_infs(vals[i],-0.1);
+  int dump_vector(reco::TaggingVariableList &from, T *to, reco::btau::TaggingVariableName name, const size_t max) {
+    std::vector<T> vals = from.getList(name, false);
+    size_t size = std::min(vals.size(), max);
+    if (size > 0) {
+      for (size_t i = 0; i < vals.size(); i++) {
+        to[i] = catch_infs(vals[i], -0.1);
       }
     }
     return size;
   }
 
   // compute minimum dr between SVs and a candidate (from DeepNTuples, now polymorphic)
-  float mindrsvpfcand(const std::vector<reco::VertexCompositePtrCandidate> & svs,
-                      const reco::Candidate* cand, float mindr=0.4);
+  float mindrsvpfcand(const std::vector<reco::VertexCompositePtrCandidate> &svs,
+                      const reco::Candidate *cand,
+                      float mindr = 0.4);
 
   // mimic the calculation in PackedCandidate
-  float vtx_ass_from_pfcand(const reco::PFCandidate &pfcand, int pv_ass_quality, const reco::VertexRef & pv);
+  float vtx_ass_from_pfcand(const reco::PFCandidate &pfcand, int pv_ass_quality, const reco::VertexRef &pv);
   float quality_from_pfcand(const reco::PFCandidate &pfcand);
   float lost_inner_hits_from_pfcand(const reco::PFCandidate &pfcand);
-}
-#endif //RecoBTag_FeatureTools_deep_helpers_h
+}  // namespace btagbtvdeep
+#endif  //RecoBTag_FeatureTools_deep_helpers_h

--- a/RecoBTag/FeatureTools/interface/sorting_modules.h
+++ b/RecoBTag/FeatureTools/interface/sorting_modules.h
@@ -7,78 +7,79 @@
 
 #include "FWCore/Utilities/interface/isFinite.h"
 
-namespace btagbtvdeep{
+namespace btagbtvdeep {
 
-/*
+  /*
  * the std::sort function needs a strict ordering.
  * means if your_function(a,b) is true, than your_function(b,a) must be false for all a and b
  */
 
-template <class T>
-class SortingClass{
-
+  template <class T>
+  class SortingClass {
   public:
+    SortingClass() : sortValA(0), sortValB(0), sortValC(0), t_(0) {}
 
-    SortingClass():sortValA(0),sortValB(0),sortValC(0),t_(0) {}
+    SortingClass(const T& t, float sortA, float sortB = 0, float sortC = 0)
+        : t_(t), sortValA(sortA), sortValB(sortB), sortValC(sortC) {}
 
-    SortingClass(const T& t, float sortA, float sortB=0, float sortC=0) :
-      t_(t), sortValA(sortA), sortValB(sortB), sortValC(sortC) {}
+    const T& get() const { return t_; }
 
-    const T& get() const {return t_;}
+    enum compareResult { cmp_smaller, cmp_greater, cmp_invalid };
 
-    enum compareResult{cmp_smaller,cmp_greater,cmp_invalid};
-
-    static inline compareResult compare(const SortingClass& a, const SortingClass& b,int validx=0){
-        float vala=a.sortValA;
-        float valb=b.sortValA;
-        if(validx==1){
-            vala=a.sortValB;
-            valb=b.sortValB;
-        }else if(validx==2){
-            vala=a.sortValC;
-            valb=b.sortValC;
-        }
-        if(edm::isFinite(vala) && edm::isFinite(valb) && valb!=vala){
-            if(vala>valb) return cmp_greater;
-            else return cmp_smaller;
-        }
-        if(edm::isFinite(vala) && !edm::isFinite(valb))
-            return cmp_greater;
-        if(!edm::isFinite(vala) && edm::isFinite(valb))
-            return cmp_smaller;
-        return cmp_invalid;
+    static inline compareResult compare(const SortingClass& a, const SortingClass& b, int validx = 0) {
+      float vala = a.sortValA;
+      float valb = b.sortValA;
+      if (validx == 1) {
+        vala = a.sortValB;
+        valb = b.sortValB;
+      } else if (validx == 2) {
+        vala = a.sortValC;
+        valb = b.sortValC;
+      }
+      if (edm::isFinite(vala) && edm::isFinite(valb) && valb != vala) {
+        if (vala > valb)
+          return cmp_greater;
+        else
+          return cmp_smaller;
+      }
+      if (edm::isFinite(vala) && !edm::isFinite(valb))
+        return cmp_greater;
+      if (!edm::isFinite(vala) && edm::isFinite(valb))
+        return cmp_smaller;
+      return cmp_invalid;
     }
 
-       //hierarchical sort
-    static bool compareByABC(const SortingClass& a, const SortingClass& b){
-
-        compareResult tmpres=compare(a,b,0);
-        if(tmpres==cmp_smaller) return true;
-        if(tmpres==cmp_greater) return false;
-
-        tmpres=compare(a,b,1);
-        if(tmpres==cmp_smaller) return true;
-        if(tmpres==cmp_greater) return false;
-
-        tmpres=compare(a,b,2);
-        if(tmpres==cmp_smaller) return true;
-        if(tmpres==cmp_greater) return false;
-
+    //hierarchical sort
+    static bool compareByABC(const SortingClass& a, const SortingClass& b) {
+      compareResult tmpres = compare(a, b, 0);
+      if (tmpres == cmp_smaller)
+        return true;
+      if (tmpres == cmp_greater)
         return false;
 
+      tmpres = compare(a, b, 1);
+      if (tmpres == cmp_smaller)
+        return true;
+      if (tmpres == cmp_greater)
+        return false;
+
+      tmpres = compare(a, b, 2);
+      if (tmpres == cmp_smaller)
+        return true;
+      if (tmpres == cmp_greater)
+        return false;
+
+      return false;
     }
 
-    static bool compareByABCInv(const SortingClass& a, const SortingClass& b){
-			return compareByABC(b,a);
-    }
+    static bool compareByABCInv(const SortingClass& a, const SortingClass& b) { return compareByABC(b, a); }
 
- private:
-
+  private:
     T t_;
-    float sortValA,sortValB,sortValC;
-};
+    float sortValA, sortValB, sortValC;
+  };
 
-std::vector<std::size_t> invertSortingVector(const std::vector<SortingClass<std::size_t> > & in);
+  std::vector<std::size_t> invertSortingVector(const std::vector<SortingClass<std::size_t> >& in);
 
-}
-#endif //RecoBTag_FeatureTools_sorting_modules_h
+}  // namespace btagbtvdeep
+#endif  //RecoBTag_FeatureTools_sorting_modules_h

--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -31,8 +31,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  typedef std::vector<reco::DeepBoostedJetTagInfo>
-      DeepBoostedJetTagInfoCollection;
+  typedef std::vector<reco::DeepBoostedJetTagInfo> DeepBoostedJetTagInfoCollection;
   typedef reco::VertexCompositePtrCandidateCollection SVCollection;
   typedef reco::VertexCollection VertexCollection;
 
@@ -71,55 +70,55 @@ private:
   const reco::Vertex *pv_ = nullptr;
 };
 
-const std::vector<std::string>
-    DeepBoostedJetTagInfoProducer::particle_features_{
-        "pfcand_puppiw",        "pfcand_hcalFrac",     "pfcand_VTX_ass",
-        "pfcand_lostInnerHits", "pfcand_quality",      "pfcand_charge",
-        "pfcand_isEl",          "pfcand_isMu",         "pfcand_isChargedHad",
-        "pfcand_isGamma",       "pfcand_isNeutralHad", "pfcand_phirel",
-        "pfcand_etarel",        "pfcand_deltaR",       "pfcand_abseta",
-        "pfcand_ptrel_log",     "pfcand_erel_log",     "pfcand_pt_log",
-        "pfcand_drminsv",       "pfcand_drsubjet1",    "pfcand_drsubjet2",
-        "pfcand_normchi2",      "pfcand_dz",           "pfcand_dzsig",
-        "pfcand_dxy",           "pfcand_dxysig",       "pfcand_dptdpt",
-        "pfcand_detadeta",      "pfcand_dphidphi",     "pfcand_dxydxy",
-        "pfcand_dzdz",          "pfcand_dxydz",        "pfcand_dphidxy",
-        "pfcand_dlambdadz",     "pfcand_btagEtaRel",   "pfcand_btagPtRatio",
-        "pfcand_btagPParRatio", "pfcand_btagSip2dVal", "pfcand_btagSip2dSig",
-        "pfcand_btagSip3dVal",  "pfcand_btagSip3dSig", "pfcand_btagJetDistVal",
-    };
-
-const std::vector<std::string> DeepBoostedJetTagInfoProducer::sv_features_{
-    "sv_phirel",    "sv_etarel",   "sv_deltaR", "sv_abseta",  "sv_mass",
-    "sv_ptrel_log", "sv_erel_log", "sv_pt_log", "sv_ntracks", "sv_normchi2",
-    "sv_dxy",       "sv_dxysig",   "sv_d3d",    "sv_d3dsig",  "sv_costhetasvpv",
+const std::vector<std::string> DeepBoostedJetTagInfoProducer::particle_features_{
+    "pfcand_puppiw",        "pfcand_hcalFrac",       "pfcand_VTX_ass",      "pfcand_lostInnerHits",
+    "pfcand_quality",       "pfcand_charge",         "pfcand_isEl",         "pfcand_isMu",
+    "pfcand_isChargedHad",  "pfcand_isGamma",        "pfcand_isNeutralHad", "pfcand_phirel",
+    "pfcand_etarel",        "pfcand_deltaR",         "pfcand_abseta",       "pfcand_ptrel_log",
+    "pfcand_erel_log",      "pfcand_pt_log",         "pfcand_drminsv",      "pfcand_drsubjet1",
+    "pfcand_drsubjet2",     "pfcand_normchi2",       "pfcand_dz",           "pfcand_dzsig",
+    "pfcand_dxy",           "pfcand_dxysig",         "pfcand_dptdpt",       "pfcand_detadeta",
+    "pfcand_dphidphi",      "pfcand_dxydxy",         "pfcand_dzdz",         "pfcand_dxydz",
+    "pfcand_dphidxy",       "pfcand_dlambdadz",      "pfcand_btagEtaRel",   "pfcand_btagPtRatio",
+    "pfcand_btagPParRatio", "pfcand_btagSip2dVal",   "pfcand_btagSip2dSig", "pfcand_btagSip3dVal",
+    "pfcand_btagSip3dSig",  "pfcand_btagJetDistVal",
 };
 
-DeepBoostedJetTagInfoProducer::DeepBoostedJetTagInfoProducer(
-    const edm::ParameterSet &iConfig)
-    : has_puppi_weighted_daughters_(
-          iConfig.getParameter<bool>("has_puppi_weighted_daughters")),
+const std::vector<std::string> DeepBoostedJetTagInfoProducer::sv_features_{
+    "sv_phirel",
+    "sv_etarel",
+    "sv_deltaR",
+    "sv_abseta",
+    "sv_mass",
+    "sv_ptrel_log",
+    "sv_erel_log",
+    "sv_pt_log",
+    "sv_ntracks",
+    "sv_normchi2",
+    "sv_dxy",
+    "sv_dxysig",
+    "sv_d3d",
+    "sv_d3dsig",
+    "sv_costhetasvpv",
+};
+
+DeepBoostedJetTagInfoProducer::DeepBoostedJetTagInfoProducer(const edm::ParameterSet &iConfig)
+    : has_puppi_weighted_daughters_(iConfig.getParameter<bool>("has_puppi_weighted_daughters")),
       jet_radius_(iConfig.getParameter<double>("jet_radius")),
       min_jet_pt_(iConfig.getParameter<double>("min_jet_pt")),
-      min_pt_for_track_properties_(
-          iConfig.getParameter<double>("min_pt_for_track_properties")),
-      jet_token_(consumes<edm::View<reco::Jet>>(
-          iConfig.getParameter<edm::InputTag>("jets"))),
-      vtx_token_(consumes<VertexCollection>(
-          iConfig.getParameter<edm::InputTag>("vertices"))),
-      sv_token_(consumes<SVCollection>(
-          iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
-      use_puppi_value_map_(false), use_pvasq_value_map_(false) {
-  const auto &puppi_value_map_tag =
-      iConfig.getParameter<edm::InputTag>("puppi_value_map");
+      min_pt_for_track_properties_(iConfig.getParameter<double>("min_pt_for_track_properties")),
+      jet_token_(consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
+      vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
+      sv_token_(consumes<SVCollection>(iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
+      use_puppi_value_map_(false),
+      use_pvasq_value_map_(false) {
+  const auto &puppi_value_map_tag = iConfig.getParameter<edm::InputTag>("puppi_value_map");
   if (!puppi_value_map_tag.label().empty()) {
-    puppi_value_map_token_ =
-        consumes<edm::ValueMap<float>>(puppi_value_map_tag);
+    puppi_value_map_token_ = consumes<edm::ValueMap<float>>(puppi_value_map_tag);
     use_puppi_value_map_ = true;
   }
 
-  const auto &pvas_tag =
-      iConfig.getParameter<edm::InputTag>("vertex_associator");
+  const auto &pvas_tag = iConfig.getParameter<edm::InputTag>("vertex_associator");
   if (!pvas_tag.label().empty()) {
     pvasq_value_map_token_ = consumes<edm::ValueMap<int>>(pvas_tag);
     pvas_token_ = consumes<edm::Association<VertexCollection>>(pvas_tag);
@@ -131,8 +130,7 @@ DeepBoostedJetTagInfoProducer::DeepBoostedJetTagInfoProducer(
 
 DeepBoostedJetTagInfoProducer::~DeepBoostedJetTagInfoProducer() {}
 
-void DeepBoostedJetTagInfoProducer::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void DeepBoostedJetTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // pfDeepBoostedJetTagInfos
   edm::ParameterSetDescription desc;
   desc.add<bool>("has_puppi_weighted_daughters", true);
@@ -140,18 +138,14 @@ void DeepBoostedJetTagInfoProducer::fillDescriptions(
   desc.add<double>("min_jet_pt", 150);
   desc.add<double>("min_pt_for_track_properties", -1);
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
-  desc.add<edm::InputTag>("secondary_vertices",
-                          edm::InputTag("inclusiveCandidateSecondaryVertices"));
+  desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("inclusiveCandidateSecondaryVertices"));
   desc.add<edm::InputTag>("jets", edm::InputTag("ak8PFJetsPuppi"));
   desc.add<edm::InputTag>("puppi_value_map", edm::InputTag("puppi"));
-  desc.add<edm::InputTag>(
-      "vertex_associator",
-      edm::InputTag("primaryVertexAssociation", "original"));
+  desc.add<edm::InputTag>("vertex_associator", edm::InputTag("primaryVertexAssociation", "original"));
   descriptions.add("pfDeepBoostedJetTagInfos", desc);
 }
 
-void DeepBoostedJetTagInfoProducer::produce(edm::Event &iEvent,
-                                            const edm::EventSetup &iSetup) {
+void DeepBoostedJetTagInfoProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   auto output_tag_infos = std::make_unique<DeepBoostedJetTagInfoCollection>();
 
   edm::Handle<edm::View<reco::Jet>> jets;
@@ -161,15 +155,14 @@ void DeepBoostedJetTagInfoProducer::produce(edm::Event &iEvent,
   if (vtxs_->empty()) {
     // produce empty TagInfos in case no primary vertex
     iEvent.put(std::move(output_tag_infos));
-    return; // exit event
+    return;  // exit event
   }
   // primary vertex
   pv_ = &vtxs_->at(0);
 
   iEvent.getByToken(sv_token_, svs_);
 
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",
-                                         track_builder_);
+  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", track_builder_);
 
   if (use_puppi_value_map_) {
     iEvent.getByToken(puppi_value_map_token_, puppi_value_map_);
@@ -217,13 +210,11 @@ void DeepBoostedJetTagInfoProducer::produce(edm::Event &iEvent,
   iEvent.put(std::move(output_tag_infos));
 }
 
-void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
-    DeepBoostedJetFeatures &fts, const reco::Jet &jet) {
+void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures &fts, const reco::Jet &jet) {
   // require the input to be a pat::Jet
   const auto *patJet = dynamic_cast<const pat::Jet *>(&jet);
   if (!patJet) {
-    throw edm::Exception(edm::errors::InvalidReference)
-        << "Input is not a pat::Jet.";
+    throw edm::Exception(edm::errors::InvalidReference) << "Input is not a pat::Jet.";
   }
 
   // do nothing if jet does not have constituents
@@ -237,8 +228,7 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
 
   std::map<reco::CandidatePtr::key_type, float> puppi_wgt_cache;
   auto puppiWgt = [&](const reco::CandidatePtr &cand) {
-    const auto *pack_cand =
-        dynamic_cast<const pat::PackedCandidate *>(&(*cand));
+    const auto *pack_cand = dynamic_cast<const pat::PackedCandidate *>(&(*cand));
     const auto *reco_cand = dynamic_cast<const reco::PFCandidate *>(&(*cand));
     float wgt = 1.;
     if (pack_cand) {
@@ -247,13 +237,11 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
       if (use_puppi_value_map_) {
         wgt = (*puppi_value_map_)[cand];
       } else {
-        throw edm::Exception(edm::errors::InvalidReference)
-            << "Puppi value map is missing";
+        throw edm::Exception(edm::errors::InvalidReference) << "Puppi value map is missing";
       }
     } else {
-      throw edm::Exception(edm::errors::InvalidReference)
-          << "Cannot convert to either pat::PackedCandidate or "
-             "reco::PFCandidate";
+      throw edm::Exception(edm::errors::InvalidReference) << "Cannot convert to either pat::PackedCandidate or "
+                                                             "reco::PFCandidate";
     }
     puppi_wgt_cache[cand.key()] = wgt;
     return wgt;
@@ -268,17 +256,15 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
   }
   // sort by (Puppi-weighted) pt
   if (!has_puppi_weighted_daughters_) {
-    std::sort(daughters.begin(), daughters.end(),
-              [&puppi_wgt_cache](const reco::CandidatePtr &a,
-                                 const reco::CandidatePtr &b) {
-                return puppi_wgt_cache.at(a.key()) * a->pt() >
-                       puppi_wgt_cache.at(b.key()) * b->pt();
+    std::sort(daughters.begin(),
+              daughters.end(),
+              [&puppi_wgt_cache](const reco::CandidatePtr &a, const reco::CandidatePtr &b) {
+                return puppi_wgt_cache.at(a.key()) * a->pt() > puppi_wgt_cache.at(b.key()) * b->pt();
               });
   } else {
-    std::sort(daughters.begin(), daughters.end(),
-              [](const reco::CandidatePtr &a, const reco::CandidatePtr &b) {
-                return a->pt() > b->pt();
-              });
+    std::sort(daughters.begin(), daughters.end(), [](const reco::CandidatePtr &a, const reco::CandidatePtr &b) {
+      return a->pt() > b->pt();
+    });
   }
 
   // reserve space
@@ -292,8 +278,7 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
   };
 
   for (const auto &cand : daughters) {
-    const auto *packed_cand =
-        dynamic_cast<const pat::PackedCandidate *>(&(*cand));
+    const auto *packed_cand = dynamic_cast<const pat::PackedCandidate *>(&(*cand));
     const auto *reco_cand = dynamic_cast<const reco::PFCandidate *>(&(*cand));
 
     auto puppiP4 = cand->p4();
@@ -312,9 +297,7 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
       fts.fill("pfcand_hcalFrac", hcal_fraction);
       fts.fill("pfcand_VTX_ass", packed_cand->pvAssociationQuality());
       fts.fill("pfcand_lostInnerHits", packed_cand->lostInnerHits());
-      fts.fill("pfcand_quality", packed_cand->bestTrack()
-                                     ? packed_cand->bestTrack()->qualityMask()
-                                     : 0);
+      fts.fill("pfcand_quality", packed_cand->bestTrack() ? packed_cand->bestTrack()->qualityMask() : 0);
 
       fts.fill("pfcand_charge", packed_cand->charge());
       fts.fill("pfcand_isEl", std::abs(packed_cand->pdgId()) == 11);
@@ -325,40 +308,27 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
 
       // impact parameters
       fts.fill("pfcand_dz", catch_infs(packed_cand->dz()));
-      fts.fill("pfcand_dzsig",
-               packed_cand->bestTrack()
-                   ? catch_infs(packed_cand->dz() / packed_cand->dzError())
-                   : 0);
+      fts.fill("pfcand_dzsig", packed_cand->bestTrack() ? catch_infs(packed_cand->dz() / packed_cand->dzError()) : 0);
       fts.fill("pfcand_dxy", catch_infs(packed_cand->dxy()));
       fts.fill("pfcand_dxysig",
-               packed_cand->bestTrack()
-                   ? catch_infs(packed_cand->dxy() / packed_cand->dxyError())
-                   : 0);
+               packed_cand->bestTrack() ? catch_infs(packed_cand->dxy() / packed_cand->dxyError()) : 0);
 
     } else if (reco_cand) {
       // get vertex association quality
-      int pv_ass_quality = 0; // fallback value
+      int pv_ass_quality = 0;  // fallback value
       float vtx_ass = 0;
       if (use_pvasq_value_map_) {
         pv_ass_quality = (*pvasq_value_map_)[cand];
         const reco::VertexRef &PV_orig = (*pvas_)[cand];
         vtx_ass = vtx_ass_from_pfcand(*reco_cand, pv_ass_quality, PV_orig);
       } else {
-        throw edm::Exception(edm::errors::InvalidReference)
-            << "Vertex association missing";
+        throw edm::Exception(edm::errors::InvalidReference) << "Vertex association missing";
       }
 
-      fts.fill("pfcand_hcalFrac",
-               reco_cand->hcalEnergy() /
-                   (reco_cand->ecalEnergy() + reco_cand->hcalEnergy()));
+      fts.fill("pfcand_hcalFrac", reco_cand->hcalEnergy() / (reco_cand->ecalEnergy() + reco_cand->hcalEnergy()));
       fts.fill("pfcand_VTX_ass", vtx_ass);
-      fts.fill("pfcand_lostInnerHits",
-               useTrackProperties(reco_cand)
-                   ? lost_inner_hits_from_pfcand(*reco_cand)
-                   : 0);
-      fts.fill("pfcand_quality", useTrackProperties(reco_cand)
-                                     ? quality_from_pfcand(*reco_cand)
-                                     : 0);
+      fts.fill("pfcand_lostInnerHits", useTrackProperties(reco_cand) ? lost_inner_hits_from_pfcand(*reco_cand) : 0);
+      fts.fill("pfcand_quality", useTrackProperties(reco_cand) ? quality_from_pfcand(*reco_cand) : 0);
 
       fts.fill("pfcand_charge", reco_cand->charge());
       fts.fill("pfcand_isEl", std::abs(reco_cand->pdgId()) == 11);
@@ -384,10 +354,8 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
     fts.fill("pfcand_deltaR", reco::deltaR(puppiP4, jet));
     fts.fill("pfcand_abseta", std::abs(puppiP4.eta()));
 
-    fts.fill("pfcand_ptrel_log",
-             catch_infs(std::log(puppiP4.pt() / jet.pt()), -99));
-    fts.fill("pfcand_erel_log",
-             catch_infs(std::log(puppiP4.energy() / jet.energy()), -99));
+    fts.fill("pfcand_ptrel_log", catch_infs(std::log(puppiP4.pt() / jet.pt()), -99));
+    fts.fill("pfcand_erel_log", catch_infs(std::log(puppiP4.energy() / jet.energy()), -99));
     fts.fill("pfcand_pt_log", catch_infs(std::log(puppiP4.pt()), -99));
 
     double minDR = 999;
@@ -400,14 +368,11 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
 
     // subjets
     auto subjets = patJet->subjets();
-    std::sort(subjets.begin(), subjets.end(),
-              [](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) {
-                return p1->pt() > p2->pt();
-              }); // sort by pt
-    fts.fill("pfcand_drsubjet1",
-             !subjets.empty() ? reco::deltaR(*cand, *subjets.at(0)) : -1);
-    fts.fill("pfcand_drsubjet2",
-             subjets.size() > 1 ? reco::deltaR(*cand, *subjets.at(1)) : -1);
+    std::sort(subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) {
+      return p1->pt() > p2->pt();
+    });  // sort by pt
+    fts.fill("pfcand_drsubjet1", !subjets.empty() ? reco::deltaR(*cand, *subjets.at(0)) : -1);
+    fts.fill("pfcand_drsubjet2", subjets.size() > 1 ? reco::deltaR(*cand, *subjets.at(1)) : -1);
 
     const reco::Track *trk = nullptr;
     if (packed_cand) {
@@ -416,13 +381,10 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
       trk = reco_cand->bestTrack();
     }
     if (trk) {
-      fts.fill("pfcand_normchi2",
-               catch_infs(std::floor(trk->normalizedChi2())));
+      fts.fill("pfcand_normchi2", catch_infs(std::floor(trk->normalizedChi2())));
 
       // track covariance
-      auto cov = [&](unsigned i, unsigned j) {
-        return catch_infs(trk->covariance(i, j));
-      };
+      auto cov = [&](unsigned i, unsigned j) { return catch_infs(trk->covariance(i, j)); };
       fts.fill("pfcand_dptdpt", cov(0, 0));
       fts.fill("pfcand_detadeta", cov(1, 1));
       fts.fill("pfcand_dphidphi", cov(2, 2));
@@ -466,8 +428,7 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(
   }
 }
 
-void DeepBoostedJetTagInfoProducer::fillSVFeatures(DeepBoostedJetFeatures &fts,
-                                                   const reco::Jet &jet) {
+void DeepBoostedJetTagInfoProducer::fillSVFeatures(DeepBoostedJetFeatures &fts, const reco::Jet &jet) {
   std::vector<const reco::VertexCompositePtrCandidate *> jetSVs;
   for (const auto &sv : *svs_) {
     if (reco::deltaR2(sv, jet) < jet_radius_ * jet_radius_) {
@@ -475,9 +436,9 @@ void DeepBoostedJetTagInfoProducer::fillSVFeatures(DeepBoostedJetFeatures &fts,
     }
   }
   // sort by dxy significance
-  std::sort(jetSVs.begin(), jetSVs.end(),
-            [&](const reco::VertexCompositePtrCandidate *sva,
-                const reco::VertexCompositePtrCandidate *svb) {
+  std::sort(jetSVs.begin(),
+            jetSVs.end(),
+            [&](const reco::VertexCompositePtrCandidate *sva, const reco::VertexCompositePtrCandidate *svb) {
               return sv_vertex_comparator(*sva, *svb, *pv_);
             });
 
@@ -497,8 +458,7 @@ void DeepBoostedJetTagInfoProducer::fillSVFeatures(DeepBoostedJetFeatures &fts,
     fts.fill("sv_mass", sv->mass());
 
     fts.fill("sv_ptrel_log", catch_infs(std::log(sv->pt() / jet.pt()), -99));
-    fts.fill("sv_erel_log",
-             catch_infs(std::log(sv->energy() / jet.energy()), -99));
+    fts.fill("sv_erel_log", catch_infs(std::log(sv->energy() / jet.energy()), -99));
     fts.fill("sv_pt_log", catch_infs(std::log(sv->pt()), -99));
 
     // sv properties

--- a/RecoBTag/FeatureTools/plugins/DeepDoubleXTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepDoubleXTagInfoProducer.cc
@@ -34,322 +34,268 @@
 
 #include "RecoBTag/FeatureTools/interface/deep_helpers.h"
 
-class DeepDoubleXTagInfoProducer : public edm::stream::EDProducer<>
-{
-
+class DeepDoubleXTagInfoProducer : public edm::stream::EDProducer<> {
 public:
-    explicit DeepDoubleXTagInfoProducer(const edm::ParameterSet&);
-    ~DeepDoubleXTagInfoProducer() override;
+  explicit DeepDoubleXTagInfoProducer(const edm::ParameterSet&);
+  ~DeepDoubleXTagInfoProducer() override;
 
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-    typedef std::vector<reco::DeepDoubleXTagInfo> DeepDoubleXTagInfoCollection;
-    typedef reco::VertexCompositePtrCandidateCollection SVCollection;
-    typedef reco::VertexCollection VertexCollection;
-    typedef edm::View<reco::BoostedDoubleSVTagInfo>
-        BoostedDoubleSVTagInfoCollection;
+  typedef std::vector<reco::DeepDoubleXTagInfo> DeepDoubleXTagInfoCollection;
+  typedef reco::VertexCompositePtrCandidateCollection SVCollection;
+  typedef reco::VertexCollection VertexCollection;
+  typedef edm::View<reco::BoostedDoubleSVTagInfo> BoostedDoubleSVTagInfoCollection;
 
-    void beginStream(edm::StreamID) override
-    {
-    }
-    void produce(edm::Event&, const edm::EventSetup&) override;
-    void endStream() override
-    {
-    }
+  void beginStream(edm::StreamID) override {}
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override {}
 
-    const double jet_radius_;
-    const double min_jet_pt_;
-    const double min_candidate_pt_;
+  const double jet_radius_;
+  const double min_jet_pt_;
+  const double min_candidate_pt_;
 
-    edm::EDGetTokenT<edm::View<reco::Jet>> jet_token_;
-    edm::EDGetTokenT<VertexCollection> vtx_token_;
-    edm::EDGetTokenT<SVCollection> sv_token_;
-    edm::EDGetTokenT<BoostedDoubleSVTagInfoCollection> shallow_tag_info_token_;
+  edm::EDGetTokenT<edm::View<reco::Jet>> jet_token_;
+  edm::EDGetTokenT<VertexCollection> vtx_token_;
+  edm::EDGetTokenT<SVCollection> sv_token_;
+  edm::EDGetTokenT<BoostedDoubleSVTagInfoCollection> shallow_tag_info_token_;
 };
 
-DeepDoubleXTagInfoProducer::DeepDoubleXTagInfoProducer(
-    const edm::ParameterSet& iConfig)
-    : jet_radius_(iConfig.getParameter<double>("jet_radius"))
-    , min_jet_pt_(iConfig.getParameter<double>("min_jet_pt"))
-    , min_candidate_pt_(iConfig.getParameter<double>("min_candidate_pt"))
-    , jet_token_(consumes<edm::View<reco::Jet>>(
-          iConfig.getParameter<edm::InputTag>("jets")))
-    , vtx_token_(consumes<VertexCollection>(
-          iConfig.getParameter<edm::InputTag>("vertices")))
-    , sv_token_(consumes<SVCollection>(
-          iConfig.getParameter<edm::InputTag>("secondary_vertices")))
-    , shallow_tag_info_token_(consumes<BoostedDoubleSVTagInfoCollection>(
-          iConfig.getParameter<edm::InputTag>("shallow_tag_infos")))
-{
-    produces<DeepDoubleXTagInfoCollection>();
+DeepDoubleXTagInfoProducer::DeepDoubleXTagInfoProducer(const edm::ParameterSet& iConfig)
+    : jet_radius_(iConfig.getParameter<double>("jet_radius")),
+      min_jet_pt_(iConfig.getParameter<double>("min_jet_pt")),
+      min_candidate_pt_(iConfig.getParameter<double>("min_candidate_pt")),
+      jet_token_(consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
+      vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
+      sv_token_(consumes<SVCollection>(iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
+      shallow_tag_info_token_(
+          consumes<BoostedDoubleSVTagInfoCollection>(iConfig.getParameter<edm::InputTag>("shallow_tag_infos"))) {
+  produces<DeepDoubleXTagInfoCollection>();
 }
 
-DeepDoubleXTagInfoProducer::~DeepDoubleXTagInfoProducer()
-{
+DeepDoubleXTagInfoProducer::~DeepDoubleXTagInfoProducer() {}
+
+void DeepDoubleXTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // pfDeepDoubleXTagInfos
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("shallow_tag_infos", edm::InputTag("pfBoostedDoubleSVAK8TagInfos"));
+  desc.add<double>("jet_radius", 0.8);
+  desc.add<double>("min_jet_pt", 150);
+  desc.add<double>("min_candidate_pt", 0.95);
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("inclusiveCandidateSecondaryVertices"));
+  desc.add<edm::InputTag>("jets", edm::InputTag("ak8PFJetsCHS"));
+  descriptions.add("pfDeepDoubleXTagInfos", desc);
 }
 
-void DeepDoubleXTagInfoProducer::fillDescriptions(
-    edm::ConfigurationDescriptions& descriptions)
-{
-    // pfDeepDoubleXTagInfos
-    edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("shallow_tag_infos",
-        edm::InputTag("pfBoostedDoubleSVAK8TagInfos"));
-    desc.add<double>("jet_radius", 0.8);
-    desc.add<double>("min_jet_pt", 150);
-    desc.add<double>("min_candidate_pt", 0.95);
-    desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
-    desc.add<edm::InputTag>("secondary_vertices",
-        edm::InputTag("inclusiveCandidateSecondaryVertices"));
-    desc.add<edm::InputTag>("jets", edm::InputTag("ak8PFJetsCHS"));
-    descriptions.add("pfDeepDoubleXTagInfos", desc);
-}
+void DeepDoubleXTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto output_tag_infos = std::make_unique<DeepDoubleXTagInfoCollection>();
 
-void DeepDoubleXTagInfoProducer::produce(edm::Event& iEvent,
-    const edm::EventSetup& iSetup)
-{
+  edm::Handle<edm::View<reco::Jet>> jets;
+  iEvent.getByToken(jet_token_, jets);
 
-    auto output_tag_infos = std::make_unique<DeepDoubleXTagInfoCollection>();
+  edm::Handle<VertexCollection> vtxs;
+  iEvent.getByToken(vtx_token_, vtxs);
+  if (vtxs->empty()) {
+    // produce empty TagInfos in case no primary vertex
+    iEvent.put(std::move(output_tag_infos));
+    return;  // exit event
+  }
+  // reference to primary vertex
+  const auto& pv = vtxs->at(0);
 
-    edm::Handle<edm::View<reco::Jet>> jets;
-    iEvent.getByToken(jet_token_, jets);
+  edm::Handle<SVCollection> svs;
+  iEvent.getByToken(sv_token_, svs);
 
-    edm::Handle<VertexCollection> vtxs;
-    iEvent.getByToken(vtx_token_, vtxs);
-    if (vtxs->empty())
-    {
-        // produce empty TagInfos in case no primary vertex
-        iEvent.put(std::move(output_tag_infos));
-        return; // exit event
-    }
-    // reference to primary vertex
-    const auto& pv = vtxs->at(0);
+  edm::Handle<BoostedDoubleSVTagInfoCollection> shallow_tag_infos;
+  iEvent.getByToken(shallow_tag_info_token_, shallow_tag_infos);
 
-    edm::Handle<SVCollection> svs;
-    iEvent.getByToken(sv_token_, svs);
+  edm::ESHandle<TransientTrackBuilder> track_builder;
+  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", track_builder);
 
-    edm::Handle<BoostedDoubleSVTagInfoCollection> shallow_tag_infos;
-    iEvent.getByToken(shallow_tag_info_token_, shallow_tag_infos);
+  for (std::size_t jet_n = 0; jet_n < jets->size(); jet_n++) {
+    // create data containing structure
+    btagbtvdeep::DeepDoubleXFeatures features;
 
-    edm::ESHandle<TransientTrackBuilder> track_builder;
-    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",
-        track_builder);
+    // reco jet reference (use as much as possible)
+    const auto& jet = jets->at(jet_n);
 
-    for (std::size_t jet_n = 0; jet_n < jets->size(); jet_n++)
-    {
-
-        // create data containing structure
-        btagbtvdeep::DeepDoubleXFeatures features;
-
-        // reco jet reference (use as much as possible)
-        const auto& jet = jets->at(jet_n);
-
-        edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
-	if (jet.pt() > min_jet_pt_)
-        {
-          features.filled();
-        // TagInfoCollection not in an associative container so search for matchs
-        const edm::View<reco::BoostedDoubleSVTagInfo>& taginfos = *shallow_tag_infos;
-        edm::Ptr<reco::BoostedDoubleSVTagInfo> match;
-        // Try first by 'same index'
-        if ((jet_n < taginfos.size()) && (taginfos[jet_n].jet() == jet_ref))
-        {
-            match = taginfos.ptrAt(jet_n);
+    edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
+    if (jet.pt() > min_jet_pt_) {
+      features.filled();
+      // TagInfoCollection not in an associative container so search for matchs
+      const edm::View<reco::BoostedDoubleSVTagInfo>& taginfos = *shallow_tag_infos;
+      edm::Ptr<reco::BoostedDoubleSVTagInfo> match;
+      // Try first by 'same index'
+      if ((jet_n < taginfos.size()) && (taginfos[jet_n].jet() == jet_ref)) {
+        match = taginfos.ptrAt(jet_n);
+      } else {
+        // otherwise fall back to a simple search
+        for (auto itTI = taginfos.begin(), edTI = taginfos.end(); itTI != edTI; ++itTI) {
+          if (itTI->jet() == jet_ref) {
+            match = taginfos.ptrAt(itTI - taginfos.begin());
+            break;
+          }
         }
-        else
-        {
-            // otherwise fall back to a simple search
-            for (auto itTI = taginfos.begin(), edTI = taginfos.end(); itTI != edTI;
-                 ++itTI)
-            {
-                if (itTI->jet() == jet_ref)
-                {
-                    match = taginfos.ptrAt(itTI - taginfos.begin());
-                    break;
-                }
+      }
+      reco::BoostedDoubleSVTagInfo tag_info;
+      if (match.isNonnull()) {
+        tag_info = *match;
+      }  // will be default values otherwise
+
+      // fill basic jet features
+      btagbtvdeep::JetConverter::jetToFeatures(jet, features.jet_features);
+
+      // fill number of pv
+      features.npv = vtxs->size();
+
+      // fill features from BoostedDoubleSVTagInfo
+      const auto& tag_info_vars = tag_info.taggingVariables();
+      btagbtvdeep::doubleBTagToFeatures(tag_info_vars, features.tag_info_features);
+
+      // copy which will be sorted
+      auto svs_sorted = *svs;
+      // sort by dxy
+      std::sort(svs_sorted.begin(), svs_sorted.end(), [&pv](const auto& sva, const auto& svb) {
+        return btagbtvdeep::sv_vertex_comparator(sva, svb, pv);
+      });
+      // fill features from secondary vertices
+      for (const auto& sv : svs_sorted) {
+        if (reco::deltaR(sv, jet) > jet_radius_)
+          continue;
+        else {
+          features.sv_features.emplace_back();
+          // in C++17 could just get from emplace_back output
+          auto& sv_features = features.sv_features.back();
+          btagbtvdeep::svToFeatures(sv, pv, jet, sv_features);
+        }
+      }
+
+      // stuff required for dealing with pf candidates
+      math::XYZVector jet_dir = jet.momentum().Unit();
+      GlobalVector jet_ref_track_dir(jet.px(), jet.py(), jet.pz());
+
+      std::vector<btagbtvdeep::SortingClass<size_t>> c_sorted;
+
+      // to cache the TrackInfo
+      std::map<unsigned int, btagbtvdeep::TrackInfoBuilder> trackinfos;
+
+      // unsorted reference to sv
+      const auto& svs_unsorted = *svs;
+      // fill collection, from DeepTNtuples plus some styling
+      // std::vector<const pat::PackedCandidate*> daughters;
+      std::vector<const reco::Candidate*> daughters;
+      for (unsigned int i = 0; i < jet.numberOfDaughters(); i++) {
+        auto const* cand = jet.daughter(i);
+        auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
+        auto reco_cand = dynamic_cast<const reco::PFCandidate*>(cand);
+        if (packed_cand) {
+          if (cand->numberOfDaughters() > 0) {
+            for (unsigned int k = 0; k < cand->numberOfDaughters(); k++) {
+              daughters.push_back(dynamic_cast<const pat::PackedCandidate*>(cand->daughter(k)));
             }
+          } else {
+            auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
+            daughters.push_back(packed_cand);
+          }
+        } else if (reco_cand) {
+          // need some edm::Ptr or edm::Ref if reco candidates
+          // dynamical casting to pointers, null if not possible
+          daughters.push_back(reco_cand);
         }
-        reco::BoostedDoubleSVTagInfo tag_info;
-        if (match.isNonnull())
-        {
-            tag_info = *match;
-        } // will be default values otherwise
+      }
 
-        // fill basic jet features
-        btagbtvdeep::JetConverter::jetToFeatures(jet, features.jet_features);
+      for (unsigned int i = 0; i < daughters.size(); i++) {
+        auto const* cand = daughters.at(i);
 
-        // fill number of pv
-        features.npv = vtxs->size();
-
-        // fill features from BoostedDoubleSVTagInfo
-        const auto& tag_info_vars = tag_info.taggingVariables();
-        btagbtvdeep::doubleBTagToFeatures(tag_info_vars,
-            features.tag_info_features);
-
-        // copy which will be sorted
-        auto svs_sorted = *svs;
-        // sort by dxy
-        std::sort(svs_sorted.begin(), svs_sorted.end(),
-            [&pv](const auto& sva, const auto& svb) {
-                return btagbtvdeep::sv_vertex_comparator(sva, svb, pv);
-            });
-        // fill features from secondary vertices
-        for (const auto& sv : svs_sorted)
-        {
-            if (reco::deltaR(sv, jet) > jet_radius_)
-                continue;
-            else
-            {
-                features.sv_features.emplace_back();
-                // in C++17 could just get from emplace_back output
-                auto& sv_features = features.sv_features.back();
-                btagbtvdeep::svToFeatures(sv, pv, jet, sv_features);
-            }
+        if (cand) {
+          // candidates under 950MeV (configurable) are not considered
+          // might change if we use also white-listing
+          if (cand->pt() < min_candidate_pt_)
+            continue;
+          if (cand->charge() != 0) {
+            auto& trackinfo = trackinfos.emplace(i, track_builder).first->second;
+            trackinfo.buildTrackInfo(cand, jet_dir, jet_ref_track_dir, pv);
+            c_sorted.emplace_back(i,
+                                  trackinfo.getTrackSip2dSig(),
+                                  -btagbtvdeep::mindrsvpfcand(svs_unsorted, cand, jet_radius_),
+                                  cand->pt() / jet.pt());
+          }
         }
+      }
 
-        // stuff required for dealing with pf candidates
-        math::XYZVector jet_dir = jet.momentum().Unit();
-        GlobalVector jet_ref_track_dir(jet.px(), jet.py(), jet.pz());
+      // sort collections (open the black-box if you please)
+      std::sort(c_sorted.begin(), c_sorted.end(), btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
 
-        std::vector<btagbtvdeep::SortingClass<size_t>> c_sorted;
+      std::vector<size_t> c_sortedindices;
 
-        // to cache the TrackInfo
-        std::map<unsigned int, btagbtvdeep::TrackInfoBuilder> trackinfos;
+      // this puts 0 everywhere and the right position in ind
+      c_sortedindices = btagbtvdeep::invertSortingVector(c_sorted);
 
-        // unsorted reference to sv
-        const auto& svs_unsorted = *svs;
-        // fill collection, from DeepTNtuples plus some styling
-        // std::vector<const pat::PackedCandidate*> daughters;
-        std::vector<const reco::Candidate*> daughters;
-        for (unsigned int i = 0; i < jet.numberOfDaughters(); i++)
-        {
-            auto const* cand = jet.daughter(i);
+      // set right size to vectors
+      features.c_pf_features.clear();
+      features.c_pf_features.resize(c_sorted.size());
+
+      for (unsigned int i = 0; i < daughters.size(); i++) {
+        auto const* cand = daughters.at(i);
+        if (cand) {
+          // candidates under 950MeV are not considered
+          // might change if we use also white-listing
+          if (cand->pt() < 0.95)
+            continue;
+
+          // get PUPPI weight from value map
+          float puppiw = 1.0;  // fallback value
+
+          float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, cand, jet_radius_);
+
+          if (cand->charge() != 0) {
+            // is charged candidate
+            auto entry = c_sortedindices.at(i);
+            // get cached track info
+            auto& trackinfo = trackinfos.at(i);
+            // get_ref to vector element
+            auto& c_pf_features = features.c_pf_features.at(entry);
+            // fill feature structure
             auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
             auto reco_cand = dynamic_cast<const reco::PFCandidate*>(cand);
-            if (packed_cand)
-            {
-                if (cand->numberOfDaughters() > 0)
-                {
-                    for (unsigned int k = 0; k < cand->numberOfDaughters(); k++)
-                    {
-                        daughters.push_back(
-                            dynamic_cast<const pat::PackedCandidate*>(cand->daughter(k)));
-                    }
+            if (packed_cand) {
+              btagbtvdeep::packedCandidateToFeatures(
+                  packed_cand, jet, trackinfo, drminpfcandsv, static_cast<float>(jet_radius_), c_pf_features);
+            } else if (reco_cand) {
+              // get vertex association quality
+              int pv_ass_quality = 0;  // fallback value
+              // getting the PV as PackedCandidatesProducer
+              // but using not the slimmed but original vertices
+              auto ctrack = reco_cand->bestTrack();
+              int pvi = -1;
+              float dist = 1e99;
+              for (size_t ii = 0; ii < vtxs->size(); ii++) {
+                float dz = (ctrack) ? std::abs(ctrack->dz(((*vtxs)[ii]).position())) : 0;
+                if (dz < dist) {
+                  pvi = ii;
+                  dist = dz;
                 }
-                else
-                {
-                    auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
-                    daughters.push_back(packed_cand);
-                }
+              }
+              auto pv = reco::VertexRef(vtxs, pvi);
+              btagbtvdeep::recoCandidateToFeatures(reco_cand,
+                                                   jet,
+                                                   trackinfo,
+                                                   drminpfcandsv,
+                                                   static_cast<float>(jet_radius_),
+                                                   puppiw,
+                                                   pv_ass_quality,
+                                                   pv,
+                                                   c_pf_features);
             }
-            else if (reco_cand)
-            {
-                // need some edm::Ptr or edm::Ref if reco candidates
-                // dynamical casting to pointers, null if not possible
-                daughters.push_back(reco_cand);
-            }
+          }
         }
-
-        for (unsigned int i = 0; i < daughters.size(); i++)
-        {
-            auto const* cand = daughters.at(i);
-
-            if (cand)
-            {
-                // candidates under 950MeV (configurable) are not considered
-                // might change if we use also white-listing
-                if (cand->pt() < min_candidate_pt_)
-                    continue;
-                if (cand->charge() != 0)
-                {
-                    auto& trackinfo = trackinfos.emplace(i, track_builder).first->second;
-                    trackinfo.buildTrackInfo(cand, jet_dir, jet_ref_track_dir, pv);
-                    c_sorted.emplace_back(
-                        i, trackinfo.getTrackSip2dSig(),
-                        -btagbtvdeep::mindrsvpfcand(svs_unsorted, cand, jet_radius_),
-                        cand->pt() / jet.pt());
-                }
-            }
-        }
-
-        // sort collections (open the black-box if you please)
-        std::sort(c_sorted.begin(), c_sorted.end(),
-            btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
-
-        std::vector<size_t> c_sortedindices;
-
-        // this puts 0 everywhere and the right position in ind
-        c_sortedindices = btagbtvdeep::invertSortingVector(c_sorted);
-
-        // set right size to vectors
-        features.c_pf_features.clear();
-        features.c_pf_features.resize(c_sorted.size());
-
-        for (unsigned int i = 0; i < daughters.size(); i++)
-        {
-            auto const* cand = daughters.at(i);
-            if (cand)
-            {
-                // candidates under 950MeV are not considered
-                // might change if we use also white-listing
-                if (cand->pt() < 0.95)
-                    continue;
-
-                // get PUPPI weight from value map
-                float puppiw = 1.0; // fallback value
-
-                float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, cand, jet_radius_);
-
-                if (cand->charge() != 0)
-                {
-                    // is charged candidate
-                    auto entry = c_sortedindices.at(i);
-                    // get cached track info
-                    auto& trackinfo = trackinfos.at(i);
-                    // get_ref to vector element
-                    auto& c_pf_features = features.c_pf_features.at(entry);
-                    // fill feature structure
-                    auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
-		    auto reco_cand = dynamic_cast<const reco::PFCandidate*>(cand);
-                    if (packed_cand)
-                    {
-                        btagbtvdeep::packedCandidateToFeatures(
-                            packed_cand, jet, trackinfo, drminpfcandsv,
-                            static_cast<float>(jet_radius_), c_pf_features);
-                    }
-                    else if (reco_cand)
-                    {
-                        // get vertex association quality
-                        int pv_ass_quality = 0; // fallback value
-                        // getting the PV as PackedCandidatesProducer
-                        // but using not the slimmed but original vertices
-                        auto ctrack = reco_cand->bestTrack();
-                        int pvi = -1;
-                        float dist = 1e99;
-                        for (size_t ii = 0; ii < vtxs->size(); ii++)
-                        {
-                            float dz = (ctrack) ? std::abs(ctrack->dz(((*vtxs)[ii]).position())) : 0;
-                            if (dz < dist)
-                            {
-                                pvi = ii;
-                                dist = dz;
-                            }
-                        }
-                        auto pv = reco::VertexRef(vtxs, pvi);
-                        btagbtvdeep::recoCandidateToFeatures(
-                            reco_cand, jet, trackinfo, drminpfcandsv,
-                            static_cast<float>(jet_radius_), puppiw, pv_ass_quality, pv,
-                            c_pf_features);
-                    }
-                }
-            }
-        }
-	}
-        output_tag_infos->emplace_back(features, jet_ref);
+      }
     }
+    output_tag_infos->emplace_back(features, jet_ref);
+  }
 
-    iEvent.put(std::move(output_tag_infos));
+  iEvent.put(std::move(output_tag_infos));
 }
 
 // define this as a plug-in

--- a/RecoBTag/FeatureTools/plugins/DeepFlavourTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepFlavourTagInfoProducer.cc
@@ -56,100 +56,91 @@ class HistogramProbabilityEstimator;
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 
 class DeepFlavourTagInfoProducer : public edm::stream::EDProducer<> {
+public:
+  explicit DeepFlavourTagInfoProducer(const edm::ParameterSet&);
+  ~DeepFlavourTagInfoProducer() override;
 
-  public:
-	  explicit DeepFlavourTagInfoProducer(const edm::ParameterSet&);
-	  ~DeepFlavourTagInfoProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-	  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+private:
+  typedef std::vector<reco::DeepFlavourTagInfo> DeepFlavourTagInfoCollection;
+  typedef reco::VertexCompositePtrCandidateCollection SVCollection;
+  typedef reco::VertexCollection VertexCollection;
+  typedef edm::View<reco::ShallowTagInfo> ShallowTagInfoCollection;
 
-  private:
-    typedef std::vector<reco::DeepFlavourTagInfo> DeepFlavourTagInfoCollection;
-    typedef reco::VertexCompositePtrCandidateCollection SVCollection;
-    typedef reco::VertexCollection VertexCollection;
-    typedef edm::View<reco::ShallowTagInfo> ShallowTagInfoCollection;
+  void beginStream(edm::StreamID) override {}
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override {}
 
-	  void beginStream(edm::StreamID) override {}
-	  void produce(edm::Event&, const edm::EventSetup&) override;
-	  void endStream() override {}
+  const double jet_radius_;
+  const double min_candidate_pt_;
+  const bool flip_;
 
+  edm::EDGetTokenT<edm::View<reco::Jet>> jet_token_;
+  edm::EDGetTokenT<VertexCollection> vtx_token_;
+  edm::EDGetTokenT<SVCollection> sv_token_;
+  edm::EDGetTokenT<ShallowTagInfoCollection> shallow_tag_info_token_;
+  edm::EDGetTokenT<edm::ValueMap<float>> puppi_value_map_token_;
+  edm::EDGetTokenT<edm::ValueMap<int>> pvasq_value_map_token_;
+  edm::EDGetTokenT<edm::Association<VertexCollection>> pvas_token_;
+  edm::EDGetTokenT<edm::View<reco::Candidate>> candidateToken_;
 
-    const double jet_radius_;
-    const double min_candidate_pt_;
-    const bool flip_;
+  bool use_puppi_value_map_;
+  bool use_pvasq_value_map_;
 
-    edm::EDGetTokenT<edm::View<reco::Jet>>  jet_token_;
-    edm::EDGetTokenT<VertexCollection> vtx_token_;
-    edm::EDGetTokenT<SVCollection> sv_token_;
-    edm::EDGetTokenT<ShallowTagInfoCollection> shallow_tag_info_token_;
-    edm::EDGetTokenT<edm::ValueMap<float>> puppi_value_map_token_;
-    edm::EDGetTokenT<edm::ValueMap<int>> pvasq_value_map_token_;
-    edm::EDGetTokenT<edm::Association<VertexCollection>> pvas_token_;
-    edm::EDGetTokenT<edm::View<reco::Candidate> > candidateToken_;
-    
-    bool use_puppi_value_map_;
-    bool use_pvasq_value_map_;
+  bool fallback_puppi_weight_;
+  bool fallback_vertex_association_;
 
-    bool fallback_puppi_weight_;
-    bool fallback_vertex_association_;
-    
-    bool run_deepVertex_;
-    
-    //TrackProbability
-    void checkEventSetup(const edm::EventSetup& iSetup);
-    std::unique_ptr<HistogramProbabilityEstimator> probabilityEstimator_;
-    bool compute_probabilities_;
-    unsigned long long calibrationCacheId2D_; 
-    unsigned long long calibrationCacheId3D_;
-    
-    const double min_jet_pt_;
-    const double max_jet_eta_;
-    
+  bool run_deepVertex_;
 
+  //TrackProbability
+  void checkEventSetup(const edm::EventSetup& iSetup);
+  std::unique_ptr<HistogramProbabilityEstimator> probabilityEstimator_;
+  bool compute_probabilities_;
+  unsigned long long calibrationCacheId2D_;
+  unsigned long long calibrationCacheId3D_;
+
+  const double min_jet_pt_;
+  const double max_jet_eta_;
 };
 
-DeepFlavourTagInfoProducer::DeepFlavourTagInfoProducer(const edm::ParameterSet& iConfig) :
-  jet_radius_(iConfig.getParameter<double>("jet_radius")),
-  min_candidate_pt_(iConfig.getParameter<double>("min_candidate_pt")),
-  flip_(iConfig.getParameter<bool>("flip")),
-  jet_token_(consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("jets"))),
-  vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
-  sv_token_(consumes<SVCollection>(iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
-  shallow_tag_info_token_(consumes<ShallowTagInfoCollection>(iConfig.getParameter<edm::InputTag>("shallow_tag_infos"))),
-  candidateToken_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("candidates"))),
-  use_puppi_value_map_(false),
-  use_pvasq_value_map_(false),
-  fallback_puppi_weight_(iConfig.getParameter<bool>("fallback_puppi_weight")),
-  fallback_vertex_association_(iConfig.getParameter<bool>("fallback_vertex_association")),
-  run_deepVertex_(iConfig.getParameter<bool>("run_deepVertex")),
-  compute_probabilities_(iConfig.getParameter<bool>("compute_probabilities")),
-  min_jet_pt_(iConfig.getParameter<double>("min_jet_pt")),
-  max_jet_eta_(iConfig.getParameter<double>("max_jet_eta"))
-{
+DeepFlavourTagInfoProducer::DeepFlavourTagInfoProducer(const edm::ParameterSet& iConfig)
+    : jet_radius_(iConfig.getParameter<double>("jet_radius")),
+      min_candidate_pt_(iConfig.getParameter<double>("min_candidate_pt")),
+      flip_(iConfig.getParameter<bool>("flip")),
+      jet_token_(consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
+      vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
+      sv_token_(consumes<SVCollection>(iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
+      shallow_tag_info_token_(
+          consumes<ShallowTagInfoCollection>(iConfig.getParameter<edm::InputTag>("shallow_tag_infos"))),
+      candidateToken_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("candidates"))),
+      use_puppi_value_map_(false),
+      use_pvasq_value_map_(false),
+      fallback_puppi_weight_(iConfig.getParameter<bool>("fallback_puppi_weight")),
+      fallback_vertex_association_(iConfig.getParameter<bool>("fallback_vertex_association")),
+      run_deepVertex_(iConfig.getParameter<bool>("run_deepVertex")),
+      compute_probabilities_(iConfig.getParameter<bool>("compute_probabilities")),
+      min_jet_pt_(iConfig.getParameter<double>("min_jet_pt")),
+      max_jet_eta_(iConfig.getParameter<double>("max_jet_eta")) {
   produces<DeepFlavourTagInfoCollection>();
 
-  const auto & puppi_value_map_tag = iConfig.getParameter<edm::InputTag>("puppi_value_map");
+  const auto& puppi_value_map_tag = iConfig.getParameter<edm::InputTag>("puppi_value_map");
   if (!puppi_value_map_tag.label().empty()) {
     puppi_value_map_token_ = consumes<edm::ValueMap<float>>(puppi_value_map_tag);
     use_puppi_value_map_ = true;
   }
 
-  const auto & pvas_tag = iConfig.getParameter<edm::InputTag>("vertex_associator");
+  const auto& pvas_tag = iConfig.getParameter<edm::InputTag>("vertex_associator");
   if (!pvas_tag.label().empty()) {
     pvasq_value_map_token_ = consumes<edm::ValueMap<int>>(pvas_tag);
     pvas_token_ = consumes<edm::Association<VertexCollection>>(pvas_tag);
     use_pvasq_value_map_ = true;
   }
-
 }
 
+DeepFlavourTagInfoProducer::~DeepFlavourTagInfoProducer() {}
 
-DeepFlavourTagInfoProducer::~DeepFlavourTagInfoProducer()
-{
-}
-
-void DeepFlavourTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
+void DeepFlavourTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfDeepFlavourTagInfos
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("shallow_tag_infos", edm::InputTag("pfDeepCSVTagInfos"));
@@ -161,7 +152,7 @@ void DeepFlavourTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("inclusiveCandidateSecondaryVertices"));
   desc.add<edm::InputTag>("jets", edm::InputTag("ak4PFJetsCHS"));
   desc.add<edm::InputTag>("candidates", edm::InputTag("packedPFCandidates"));
-  desc.add<edm::InputTag>("vertex_associator", edm::InputTag("primaryVertexAssociation","original"));
+  desc.add<edm::InputTag>("vertex_associator", edm::InputTag("primaryVertexAssociation", "original"));
   desc.add<bool>("fallback_puppi_weight", false);
   desc.add<bool>("fallback_vertex_association", false);
   desc.add<bool>("run_deepVertex", false);
@@ -171,11 +162,10 @@ void DeepFlavourTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions
   descriptions.add("pfDeepFlavourTagInfos", desc);
 }
 
-void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
+void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto output_tag_infos = std::make_unique<DeepFlavourTagInfoCollection>();
-  if (compute_probabilities_) checkEventSetup(iSetup);
+  if (compute_probabilities_)
+    checkEventSetup(iSetup);
 
   edm::Handle<edm::View<reco::Jet>> jets;
   iEvent.getByToken(jet_token_, jets);
@@ -185,12 +175,12 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
   if (vtxs->empty()) {
     // produce empty TagInfos in case no primary vertex
     iEvent.put(std::move(output_tag_infos));
-    return; // exit event
+    return;  // exit event
   }
   // reference to primary vertex
-  const auto & pv = vtxs->at(0);
-  
-  edm::Handle<edm::View<reco::Candidate> > tracks;
+  const auto& pv = vtxs->at(0);
+
+  edm::Handle<edm::View<reco::Candidate>> tracks;
   iEvent.getByToken(candidateToken_, tracks);
 
   edm::Handle<SVCollection> svs;
@@ -198,15 +188,14 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
 
   edm::Handle<ShallowTagInfoCollection> shallow_tag_infos;
   iEvent.getByToken(shallow_tag_info_token_, shallow_tag_infos);
-  double negative_cut = 0;//used only with flip_
-  if (flip_){//FIXME: Check if can do even less often than once per event
-    const edm::Provenance *prov = shallow_tag_infos.provenance();
+  double negative_cut = 0;  //used only with flip_
+  if (flip_) {              //FIXME: Check if can do even less often than once per event
+    const edm::Provenance* prov = shallow_tag_infos.provenance();
     const edm::ParameterSet& psetFromProvenance = edm::parameterSet(*prov);
-    negative_cut = ( ( psetFromProvenance.getParameter<edm::ParameterSet>("computer")
-                       ).getParameter<edm::ParameterSet>("trackSelection")
-                     ).getParameter<double>("sip3dSigMax");
+    negative_cut = ((psetFromProvenance.getParameter<edm::ParameterSet>("computer"))
+                        .getParameter<edm::ParameterSet>("trackSelection"))
+                       .getParameter<double>("sip3dSigMax");
   }
-
 
   edm::Handle<edm::ValueMap<float>> puppi_value_map;
   if (use_puppi_value_map_) {
@@ -228,43 +217,46 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
 
   if (run_deepVertex_)  //make a collection of selected transient tracks for deepvertex outside of the jet loop
   {
-    for(typename edm::View<reco::Candidate>::const_iterator track = tracks->begin(); track != tracks->end(); ++track) {
-        unsigned int k = track - tracks->begin();
-        if(track->bestTrack() != nullptr && track->pt()>0.5) { 
-            if (std::fabs(track->vz()-pv.z())<0.5)  {
-                selectedTracks.push_back(track_builder->build(tracks->ptrAt(k)));
-                masses.push_back(track->mass());  }
-            }
+    for (typename edm::View<reco::Candidate>::const_iterator track = tracks->begin(); track != tracks->end(); ++track) {
+      unsigned int k = track - tracks->begin();
+      if (track->bestTrack() != nullptr && track->pt() > 0.5) {
+        if (std::fabs(track->vz() - pv.z()) < 0.5) {
+          selectedTracks.push_back(track_builder->build(tracks->ptrAt(k)));
+          masses.push_back(track->mass());
         }
-  } 
+      }
+    }
+  }
 
-  for (std::size_t jet_n = 0; jet_n <  jets->size(); jet_n++) {
-
+  for (std::size_t jet_n = 0; jet_n < jets->size(); jet_n++) {
     // create data containing structure
     btagbtvdeep::DeepFlavourFeatures features;
 
     // reco jet reference (use as much as possible)
-    const auto & jet = jets->at(jet_n);
+    const auto& jet = jets->at(jet_n);
     // dynamical casting to pointers, null if not possible
-    const auto * pf_jet = dynamic_cast<const reco::PFJet *>(&jet);
-    const auto * pat_jet = dynamic_cast<const pat::Jet *>(&jet);
+    const auto* pf_jet = dynamic_cast<const reco::PFJet*>(&jet);
+    const auto* pat_jet = dynamic_cast<const pat::Jet*>(&jet);
     edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
     // TagInfoCollection not in an associative container so search for matchs
-    const edm::View<reco::ShallowTagInfo> & taginfos = *shallow_tag_infos;
+    const edm::View<reco::ShallowTagInfo>& taginfos = *shallow_tag_infos;
     edm::Ptr<reco::ShallowTagInfo> match;
     // Try first by 'same index'
     if ((jet_n < taginfos.size()) && (taginfos[jet_n].jet() == jet_ref)) {
-        match = taginfos.ptrAt(jet_n);
+      match = taginfos.ptrAt(jet_n);
     } else {
       // otherwise fail back to a simple search
       for (auto itTI = taginfos.begin(), edTI = taginfos.end(); itTI != edTI; ++itTI) {
-        if (itTI->jet() == jet_ref) { match = taginfos.ptrAt( itTI - taginfos.begin() ); break; }
+        if (itTI->jet() == jet_ref) {
+          match = taginfos.ptrAt(itTI - taginfos.begin());
+          break;
+        }
       }
     }
     reco::ShallowTagInfo tag_info;
     if (match.isNonnull()) {
       tag_info = *match;
-    } // will be default values otherwise
+    }  // will be default values otherwise
 
     // fill basic jet features
     btagbtvdeep::JetConverter::jetToFeatures(jet, features.jet_features);
@@ -272,70 +264,67 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
     // fill number of pv
     features.npv = vtxs->size();
     math::XYZVector jet_dir = jet.momentum().Unit();
-    GlobalVector jet_ref_track_dir(jet.px(),
-                                   jet.py(),
-                                   jet.pz());
+    GlobalVector jet_ref_track_dir(jet.px(), jet.py(), jet.pz());
 
     // fill features from ShallowTagInfo
-    const auto & tag_info_vars = tag_info.taggingVariables();
+    const auto& tag_info_vars = tag_info.taggingVariables();
     btagbtvdeep::bTagToFeatures(tag_info_vars, features.tag_info_features);
 
     // copy which will be sorted
     auto svs_sorted = *svs;
     // sort by dxy
-    std::sort(svs_sorted.begin(), svs_sorted.end(),
-              [&pv](const auto & sva, const auto &svb)
-              { return btagbtvdeep::sv_vertex_comparator(sva, svb, pv); });
+    std::sort(svs_sorted.begin(), svs_sorted.end(), [&pv](const auto& sva, const auto& svb) {
+      return btagbtvdeep::sv_vertex_comparator(sva, svb, pv);
+    });
     // fill features from secondary vertices
-    for (const auto & sv : svs_sorted) {
-      if (reco::deltaR2(sv, jet_dir) > (jet_radius_*jet_radius_)) continue;
+    for (const auto& sv : svs_sorted) {
+      if (reco::deltaR2(sv, jet_dir) > (jet_radius_ * jet_radius_))
+        continue;
       else {
         features.sv_features.emplace_back();
         // in C++17 could just get from emplace_back output
-        auto & sv_features = features.sv_features.back();
+        auto& sv_features = features.sv_features.back();
         btagbtvdeep::svToFeatures(sv, pv, jet, sv_features, flip_);
       }
     }
 
     // stuff required for dealing with pf candidates
 
-    std::vector<btagbtvdeep::SortingClass<size_t> > c_sorted, n_sorted;
+    std::vector<btagbtvdeep::SortingClass<size_t>> c_sorted, n_sorted;
 
     // to cache the TrackInfo
     std::map<unsigned int, btagbtvdeep::TrackInfoBuilder> trackinfos;
 
     // unsorted reference to sv
-    const auto & svs_unsorted = *svs;
+    const auto& svs_unsorted = *svs;
     // fill collection, from DeepTNtuples plus some styling
-    for (unsigned int i = 0; i <  jet.numberOfDaughters(); i++){
-        auto cand = jet.daughter(i);
-        if(cand){
-          // candidates under 950MeV (configurable) are not considered
-          // might change if we use also white-listing
-          if (cand->pt()< min_candidate_pt_) continue;
-          if (cand->charge() != 0) {
-            auto & trackinfo = trackinfos.emplace(i,track_builder).first->second;
-            trackinfo.buildTrackInfo(cand,jet_dir,jet_ref_track_dir,pv);
-            c_sorted.emplace_back(i, trackinfo.getTrackSip2dSig(),
-                    -btagbtvdeep::mindrsvpfcand(svs_unsorted,cand), cand->pt()/jet.pt());
-          } else {
-            n_sorted.emplace_back(i, -1,
-                    -btagbtvdeep::mindrsvpfcand(svs_unsorted,cand), cand->pt()/jet.pt());
-          }
+    for (unsigned int i = 0; i < jet.numberOfDaughters(); i++) {
+      auto cand = jet.daughter(i);
+      if (cand) {
+        // candidates under 950MeV (configurable) are not considered
+        // might change if we use also white-listing
+        if (cand->pt() < min_candidate_pt_)
+          continue;
+        if (cand->charge() != 0) {
+          auto& trackinfo = trackinfos.emplace(i, track_builder).first->second;
+          trackinfo.buildTrackInfo(cand, jet_dir, jet_ref_track_dir, pv);
+          c_sorted.emplace_back(
+              i, trackinfo.getTrackSip2dSig(), -btagbtvdeep::mindrsvpfcand(svs_unsorted, cand), cand->pt() / jet.pt());
+        } else {
+          n_sorted.emplace_back(i, -1, -btagbtvdeep::mindrsvpfcand(svs_unsorted, cand), cand->pt() / jet.pt());
         }
+      }
     }
 
     // sort collections (open the black-box if you please)
-    std::sort(c_sorted.begin(),c_sorted.end(),
-      btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
-    std::sort(n_sorted.begin(),n_sorted.end(),
-      btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
+    std::sort(c_sorted.begin(), c_sorted.end(), btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
+    std::sort(n_sorted.begin(), n_sorted.end(), btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
 
-    std::vector<size_t> c_sortedindices,n_sortedindices;
+    std::vector<size_t> c_sortedindices, n_sortedindices;
 
     // this puts 0 everywhere and the right position in ind
-    c_sortedindices=btagbtvdeep::invertSortingVector(c_sorted);
-    n_sortedindices=btagbtvdeep::invertSortingVector(n_sorted);
+    c_sortedindices = btagbtvdeep::invertSortingVector(c_sorted);
+    n_sortedindices = btagbtvdeep::invertSortingVector(n_sorted);
 
     // set right size to vectors
     features.c_pf_features.clear();
@@ -343,131 +332,142 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
     features.n_pf_features.clear();
     features.n_pf_features.resize(n_sorted.size());
 
+    for (unsigned int i = 0; i < jet.numberOfDaughters(); i++) {
+      // get pointer and check that is correct
+      auto cand = dynamic_cast<const reco::Candidate*>(jet.daughter(i));
+      if (!cand)
+        continue;
+      // candidates under 950MeV are not considered
+      // might change if we use also white-listing
+      if (cand->pt() < 0.95)
+        continue;
 
-  for (unsigned int i = 0; i <  jet.numberOfDaughters(); i++){
+      auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
+      auto reco_cand = dynamic_cast<const reco::PFCandidate*>(cand);
 
-    // get pointer and check that is correct
-    auto cand = dynamic_cast<const reco::Candidate *>(jet.daughter(i));
-    if(!cand) continue;
-    // candidates under 950MeV are not considered
-    // might change if we use also white-listing
-    if (cand->pt()<0.95) continue;
-
-    auto packed_cand = dynamic_cast<const pat::PackedCandidate *>(cand);
-    auto reco_cand = dynamic_cast<const reco::PFCandidate *>(cand);
-
-    // need some edm::Ptr or edm::Ref if reco candidates
-    reco::PFCandidatePtr reco_ptr;
-    if (pf_jet) {
-      reco_ptr = pf_jet->getPFConstituent(i);
-    } else if (pat_jet && reco_cand) {
-      reco_ptr = pat_jet->getPFConstituent(i);
-    }
-    // get PUPPI weight from value map
-    float puppiw = 1.0; // fallback value
-    if (reco_cand && use_puppi_value_map_) {
-      puppiw = (*puppi_value_map)[reco_ptr];
-    } else if (reco_cand && !fallback_puppi_weight_) {
-      throw edm::Exception(edm::errors::InvalidReference, "PUPPI value map missing") <<
-        "use fallback_puppi_weight option to use " << puppiw << "as default";
-    }
-
-    float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, cand);
-
-    if (cand->charge() != 0) {
-      // is charged candidate
-      auto entry = c_sortedindices.at(i);
-      // get cached track info
-      auto & trackinfo = trackinfos.at(i);
-      if(flip_ && (trackinfo.getTrackSip3dSig() > negative_cut)){continue;}
-      // get_ref to vector element
-      auto & c_pf_features = features.c_pf_features.at(entry);
-      // fill feature structure
-      if (packed_cand) {
-        btagbtvdeep::packedCandidateToFeatures(packed_cand, jet, trackinfo,
-					       drminpfcandsv, static_cast<float> (jet_radius_), c_pf_features, flip_);
-      } else if (reco_cand) {
-        // get vertex association quality
-        int pv_ass_quality = 0; // fallback value
-        if (use_pvasq_value_map_) {
-          pv_ass_quality = (*pvasq_value_map)[reco_ptr];
-        } else if (!fallback_vertex_association_) {
-          throw edm::Exception(edm::errors::InvalidReference, "vertex association missing") <<
-          "use fallback_vertex_association option to use" << pv_ass_quality <<
-          "as default quality and closest dz PV as criteria";
-        }
-        // getting the PV as PackedCandidatesProducer
-        // but using not the slimmed but original vertices
-        auto ctrack = reco_cand->bestTrack();
-        int pvi=-1;
-        float dist=1e99;
-        for(size_t ii=0;ii<vtxs->size();ii++){
-          float dz = (ctrack) ? std::abs(ctrack->dz(((*vtxs)[ii]).position())) : 0;
-          if(dz<dist) {pvi=ii;dist=dz; }
-        }
-        auto PV = reco::VertexRef(vtxs, pvi);
-        if (use_pvasq_value_map_) {
-          const reco::VertexRef & PV_orig = (*pvas)[reco_ptr];
-          if(PV_orig.isNonnull()) PV = reco::VertexRef(vtxs, PV_orig.key());
-        }
-        btagbtvdeep::recoCandidateToFeatures(reco_cand, jet, trackinfo,
-					     drminpfcandsv,  static_cast<float> (jet_radius_), puppiw,
-					     pv_ass_quality, PV, c_pf_features, flip_);
+      // need some edm::Ptr or edm::Ref if reco candidates
+      reco::PFCandidatePtr reco_ptr;
+      if (pf_jet) {
+        reco_ptr = pf_jet->getPFConstituent(i);
+      } else if (pat_jet && reco_cand) {
+        reco_ptr = pat_jet->getPFConstituent(i);
       }
-    } else {
-      // is neutral candidate
-      auto entry = n_sortedindices.at(i);
-      // get_ref to vector element
-      auto & n_pf_features = features.n_pf_features.at(entry);
-      // fill feature structure
-      if (packed_cand) {
-        btagbtvdeep::packedCandidateToFeatures(packed_cand, jet, drminpfcandsv, static_cast<float> (jet_radius_),
-                                                                          n_pf_features);
-      } else if (reco_cand) {
-        btagbtvdeep::recoCandidateToFeatures(reco_cand, jet, drminpfcandsv, static_cast<float> (jet_radius_), puppiw,
-                                                                        n_pf_features);
+      // get PUPPI weight from value map
+      float puppiw = 1.0;  // fallback value
+      if (reco_cand && use_puppi_value_map_) {
+        puppiw = (*puppi_value_map)[reco_ptr];
+      } else if (reco_cand && !fallback_puppi_weight_) {
+        throw edm::Exception(edm::errors::InvalidReference, "PUPPI value map missing")
+            << "use fallback_puppi_weight option to use " << puppiw << "as default";
+      }
+
+      float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, cand);
+
+      if (cand->charge() != 0) {
+        // is charged candidate
+        auto entry = c_sortedindices.at(i);
+        // get cached track info
+        auto& trackinfo = trackinfos.at(i);
+        if (flip_ && (trackinfo.getTrackSip3dSig() > negative_cut)) {
+          continue;
+        }
+        // get_ref to vector element
+        auto& c_pf_features = features.c_pf_features.at(entry);
+        // fill feature structure
+        if (packed_cand) {
+          btagbtvdeep::packedCandidateToFeatures(
+              packed_cand, jet, trackinfo, drminpfcandsv, static_cast<float>(jet_radius_), c_pf_features, flip_);
+        } else if (reco_cand) {
+          // get vertex association quality
+          int pv_ass_quality = 0;  // fallback value
+          if (use_pvasq_value_map_) {
+            pv_ass_quality = (*pvasq_value_map)[reco_ptr];
+          } else if (!fallback_vertex_association_) {
+            throw edm::Exception(edm::errors::InvalidReference, "vertex association missing")
+                << "use fallback_vertex_association option to use" << pv_ass_quality
+                << "as default quality and closest dz PV as criteria";
+          }
+          // getting the PV as PackedCandidatesProducer
+          // but using not the slimmed but original vertices
+          auto ctrack = reco_cand->bestTrack();
+          int pvi = -1;
+          float dist = 1e99;
+          for (size_t ii = 0; ii < vtxs->size(); ii++) {
+            float dz = (ctrack) ? std::abs(ctrack->dz(((*vtxs)[ii]).position())) : 0;
+            if (dz < dist) {
+              pvi = ii;
+              dist = dz;
+            }
+          }
+          auto PV = reco::VertexRef(vtxs, pvi);
+          if (use_pvasq_value_map_) {
+            const reco::VertexRef& PV_orig = (*pvas)[reco_ptr];
+            if (PV_orig.isNonnull())
+              PV = reco::VertexRef(vtxs, PV_orig.key());
+          }
+          btagbtvdeep::recoCandidateToFeatures(reco_cand,
+                                               jet,
+                                               trackinfo,
+                                               drminpfcandsv,
+                                               static_cast<float>(jet_radius_),
+                                               puppiw,
+                                               pv_ass_quality,
+                                               PV,
+                                               c_pf_features,
+                                               flip_);
+        }
+      } else {
+        // is neutral candidate
+        auto entry = n_sortedindices.at(i);
+        // get_ref to vector element
+        auto& n_pf_features = features.n_pf_features.at(entry);
+        // fill feature structure
+        if (packed_cand) {
+          btagbtvdeep::packedCandidateToFeatures(
+              packed_cand, jet, drminpfcandsv, static_cast<float>(jet_radius_), n_pf_features);
+        } else if (reco_cand) {
+          btagbtvdeep::recoCandidateToFeatures(
+              reco_cand, jet, drminpfcandsv, static_cast<float>(jet_radius_), puppiw, n_pf_features);
+        }
       }
     }
 
+    if (run_deepVertex_) {
+      if (jet.pt() > min_jet_pt_ && std::fabs(jet.eta()) < max_jet_eta_)  //jet thresholds
+        btagbtvdeep::seedingTracksToFeatures(selectedTracks,
+                                             masses,
+                                             jet,
+                                             pv,
+                                             probabilityEstimator_.get(),
+                                             compute_probabilities_,
+                                             features.seed_features);
+    }
 
-  }
-  
-  if (run_deepVertex_)
-  {
-      if (jet.pt()>min_jet_pt_ && std::fabs(jet.eta())<max_jet_eta_) //jet thresholds
-          btagbtvdeep::seedingTracksToFeatures(selectedTracks, masses, jet, pv, probabilityEstimator_.get(), compute_probabilities_, features.seed_features); 
-  }
-   
-  output_tag_infos->emplace_back(features, jet_ref);
-      
+    output_tag_infos->emplace_back(features, jet_ref);
   }
 
   iEvent.put(std::move(output_tag_infos));
-
 }
 
+void DeepFlavourTagInfoProducer::checkEventSetup(const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace edm::eventsetup;
 
-void DeepFlavourTagInfoProducer::checkEventSetup(const edm::EventSetup & iSetup) {
-    using namespace edm;
-    using namespace edm::eventsetup;
-    
-    const EventSetupRecord & re2D= iSetup.get<BTagTrackProbability2DRcd>();
-    const EventSetupRecord & re3D= iSetup.get<BTagTrackProbability3DRcd>();
-    unsigned long long cacheId2D= re2D.cacheIdentifier();
-    unsigned long long cacheId3D= re3D.cacheIdentifier();
-    if(cacheId2D!=calibrationCacheId2D_ || cacheId3D!=calibrationCacheId3D_  )  //Calibration changed
-    {
-        ESHandle<TrackProbabilityCalibration> calib2DHandle;
-        iSetup.get<BTagTrackProbability2DRcd>().get(calib2DHandle);
-        ESHandle<TrackProbabilityCalibration> calib3DHandle;
-        iSetup.get<BTagTrackProbability3DRcd>().get(calib3DHandle);
-        probabilityEstimator_.reset(new HistogramProbabilityEstimator(calib3DHandle.product(),calib2DHandle.product()));
-        
-    }
-    
-    calibrationCacheId3D_=cacheId3D;
-    calibrationCacheId2D_=cacheId2D;
-    
+  const EventSetupRecord& re2D = iSetup.get<BTagTrackProbability2DRcd>();
+  const EventSetupRecord& re3D = iSetup.get<BTagTrackProbability3DRcd>();
+  unsigned long long cacheId2D = re2D.cacheIdentifier();
+  unsigned long long cacheId3D = re3D.cacheIdentifier();
+  if (cacheId2D != calibrationCacheId2D_ || cacheId3D != calibrationCacheId3D_)  //Calibration changed
+  {
+    ESHandle<TrackProbabilityCalibration> calib2DHandle;
+    iSetup.get<BTagTrackProbability2DRcd>().get(calib2DHandle);
+    ESHandle<TrackProbabilityCalibration> calib3DHandle;
+    iSetup.get<BTagTrackProbability3DRcd>().get(calib3DHandle);
+    probabilityEstimator_.reset(new HistogramProbabilityEstimator(calib3DHandle.product(), calib2DHandle.product()));
+  }
+
+  calibrationCacheId3D_ = cacheId3D;
+  calibrationCacheId2D_ = cacheId2D;
 }
 
 //define this as a plug-in

--- a/RecoBTag/FeatureTools/src/BoostedDoubleSVTagInfoConverter.cc
+++ b/RecoBTag/FeatureTools/src/BoostedDoubleSVTagInfoConverter.cc
@@ -7,9 +7,8 @@
 
 namespace btagbtvdeep {
 
-  void doubleBTagToFeatures(const reco::TaggingVariableList & tag_info_vars,
-			    BoostedDoubleSVTagInfoFeatures & tag_info_features) {
-
+  void doubleBTagToFeatures(const reco::TaggingVariableList& tag_info_vars,
+                            BoostedDoubleSVTagInfoFeatures& tag_info_features) {
     tag_info_features.jetNTracks = tag_info_vars.get(reco::btau::jetNTracks, -999);
     tag_info_features.jetNSecondaryVertices = tag_info_vars.get(reco::btau::jetNSecondaryVertices, -999);
     tag_info_features.trackSip3dSig_0 = tag_info_vars.get(reco::btau::trackSip3dSig_0, -999);
@@ -36,12 +35,8 @@ namespace btagbtvdeep {
     tag_info_features.tau2_vertexMass = tag_info_vars.get(reco::btau::tau2_vertexMass, -999);
     tag_info_features.tau2_vertexEnergyRatio = tag_info_vars.get(reco::btau::tau2_vertexEnergyRatio, -999);
     tag_info_features.tau2_flightDistance2dSig = tag_info_vars.get(reco::btau::tau2_flightDistance2dSig, -999);
-    tag_info_features.tau2_vertexDeltaR = tag_info_vars.get(reco::btau::tau2_vertexDeltaR, -999); // not used
+    tag_info_features.tau2_vertexDeltaR = tag_info_vars.get(reco::btau::tau2_vertexDeltaR, -999);  // not used
     tag_info_features.z_ratio = tag_info_vars.get(reco::btau::z_ratio, -999);
-
   }
 
-}
-
-
-
+}  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/ChargedCandidateConverter.cc
+++ b/RecoBTag/FeatureTools/src/ChargedCandidateConverter.cc
@@ -1,15 +1,14 @@
 #include "RecoBTag/FeatureTools/interface/ChargedCandidateConverter.h"
 
-
 namespace btagbtvdeep {
 
-  void packedCandidateToFeatures(const pat::PackedCandidate * c_pf,
-				 const pat::Jet & jet,
-				 const TrackInfoBuilder & track_info,
-				 const float drminpfcandsv, const float jetR,
-				 ChargedCandidateFeatures & c_pf_features,
-				 const bool flip) {
-
+  void packedCandidateToFeatures(const pat::PackedCandidate* c_pf,
+                                 const pat::Jet& jet,
+                                 const TrackInfoBuilder& track_info,
+                                 const float drminpfcandsv,
+                                 const float jetR,
+                                 ChargedCandidateFeatures& c_pf_features,
+                                 const bool flip) {
     commonCandidateToFeatures(c_pf, jet, track_info, drminpfcandsv, jetR, c_pf_features, flip);
 
     c_pf_features.vtx_ass = c_pf->pvAssociationQuality();
@@ -19,37 +18,35 @@ namespace btagbtvdeep {
     // if PackedCandidate does not have TrackDetails this gives an Exception
     // because unpackCovariance might be called for pseudoTrack/bestTrack
     if (c_pf->hasTrackDetails()) {
-      const auto & pseudo_track =  c_pf->pseudoTrack();
-      c_pf_features.chi2 = catch_infs_and_bound(pseudo_track.normalizedChi2(),300,-1,300);
+      const auto& pseudo_track = c_pf->pseudoTrack();
+      c_pf_features.chi2 = catch_infs_and_bound(pseudo_track.normalizedChi2(), 300, -1, 300);
       // this returns the quality enum not a mask.
       c_pf_features.quality = pseudo_track.qualityMask();
     } else {
       // default negative chi2 and loose track if notTrackDetails
-      c_pf_features.chi2 = catch_infs_and_bound(-1,300,-1,300);
-      c_pf_features.quality =(1 << reco::TrackBase::loose);
+      c_pf_features.chi2 = catch_infs_and_bound(-1, 300, -1, 300);
+      c_pf_features.quality = (1 << reco::TrackBase::loose);
     }
-
   }
 
-  void recoCandidateToFeatures(const reco::PFCandidate * c_pf,
-			       const reco::Jet & jet,
-			       const TrackInfoBuilder & track_info,
-			       const float drminpfcandsv, const float jetR, const float puppiw,
-			       const int pv_ass_quality,
-			       const reco::VertexRef & pv,
-			       ChargedCandidateFeatures & c_pf_features,
-			       const bool flip) {
-
+  void recoCandidateToFeatures(const reco::PFCandidate* c_pf,
+                               const reco::Jet& jet,
+                               const TrackInfoBuilder& track_info,
+                               const float drminpfcandsv,
+                               const float jetR,
+                               const float puppiw,
+                               const int pv_ass_quality,
+                               const reco::VertexRef& pv,
+                               ChargedCandidateFeatures& c_pf_features,
+                               const bool flip) {
     commonCandidateToFeatures(c_pf, jet, track_info, drminpfcandsv, jetR, c_pf_features, flip);
 
     c_pf_features.vtx_ass = vtx_ass_from_pfcand(*c_pf, pv_ass_quality, pv);
     c_pf_features.puppiw = puppiw;
 
-    const auto & pseudo_track =  (c_pf->bestTrack()) ? *c_pf->bestTrack() : reco::Track();
-    c_pf_features.chi2 = catch_infs_and_bound(std::floor(pseudo_track.normalizedChi2()),300,-1,300);
+    const auto& pseudo_track = (c_pf->bestTrack()) ? *c_pf->bestTrack() : reco::Track();
+    c_pf_features.chi2 = catch_infs_and_bound(std::floor(pseudo_track.normalizedChi2()), 300, -1, 300);
     c_pf_features.quality = quality_from_pfcand(*c_pf);
-
   }
 
-}
-
+}  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/JetConverter.cc
+++ b/RecoBTag/FeatureTools/src/JetConverter.cc
@@ -1,4 +1,1 @@
 #include "RecoBTag/FeatureTools/interface/JetConverter.h"
-
-
-

--- a/RecoBTag/FeatureTools/src/NeutralCandidateConverter.cc
+++ b/RecoBTag/FeatureTools/src/NeutralCandidateConverter.cc
@@ -2,39 +2,34 @@
 
 namespace btagbtvdeep {
 
-
-
-  void packedCandidateToFeatures(const pat::PackedCandidate * n_pf,
-				 const pat::Jet & jet,
-				 const float drminpfcandsv, const float jetR,
-				 NeutralCandidateFeatures & n_pf_features) {
-
+  void packedCandidateToFeatures(const pat::PackedCandidate* n_pf,
+                                 const pat::Jet& jet,
+                                 const float drminpfcandsv,
+                                 const float jetR,
+                                 NeutralCandidateFeatures& n_pf_features) {
     commonCandidateToFeatures(n_pf, jet, drminpfcandsv, jetR, n_pf_features);
 
     n_pf_features.hadFrac = n_pf->hcalFraction();
     n_pf_features.puppiw = n_pf->puppiWeight();
-
   }
 
-  void recoCandidateToFeatures(const reco::PFCandidate * n_pf,
-			       const reco::Jet & jet,
-			       const float drminpfcandsv, const float jetR, const float puppiw,
-			       NeutralCandidateFeatures & n_pf_features) {
-
+  void recoCandidateToFeatures(const reco::PFCandidate* n_pf,
+                               const reco::Jet& jet,
+                               const float drminpfcandsv,
+                               const float jetR,
+                               const float puppiw,
+                               NeutralCandidateFeatures& n_pf_features) {
     commonCandidateToFeatures(n_pf, jet, drminpfcandsv, jetR, n_pf_features);
     n_pf_features.puppiw = puppiw;
 
     // need to get a value map and more stuff to do properly
     // otherwise will be different than for PackedCandidates
     // https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
-    if(abs(n_pf->pdgId()) == 1 || abs(n_pf->pdgId()) == 130) {
-      n_pf_features.hadFrac = n_pf->hcalEnergy()/(n_pf->ecalEnergy()+n_pf->hcalEnergy());
+    if (abs(n_pf->pdgId()) == 1 || abs(n_pf->pdgId()) == 130) {
+      n_pf_features.hadFrac = n_pf->hcalEnergy() / (n_pf->ecalEnergy() + n_pf->hcalEnergy());
     } else {
       n_pf_features.hadFrac = 0;
     }
-
   }
 
-
-}
-
+}  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/SecondaryVertexConverter.cc
+++ b/RecoBTag/FeatureTools/src/SecondaryVertexConverter.cc
@@ -9,33 +9,26 @@
 
 namespace btagbtvdeep {
 
-
-  void svToFeatures( const reco::VertexCompositePtrCandidate & sv,
-		     const reco::Vertex & pv, const reco::Jet & jet,
-		     SecondaryVertexFeatures & sv_features,
-		     const bool flip) {
-
+  void svToFeatures(const reco::VertexCompositePtrCandidate& sv,
+                    const reco::Vertex& pv,
+                    const reco::Jet& jet,
+                    SecondaryVertexFeatures& sv_features,
+                    const bool flip) {
     math::XYZVector jet_dir = jet.momentum().Unit();
     sv_features.pt = sv.pt();
-    sv_features.deltaR = catch_infs_and_bound(std::fabs(reco::deltaR(sv, jet_dir))-0.5,
-					      0,-2,0);
+    sv_features.deltaR = catch_infs_and_bound(std::fabs(reco::deltaR(sv, jet_dir)) - 0.5, 0, -2, 0);
     sv_features.mass = sv.mass();
     sv_features.ntracks = sv.numberOfDaughters();
     sv_features.chi2 = sv.vertexChi2();
-    sv_features.normchi2 = catch_infs_and_bound(sv_features.chi2/sv.vertexNdof(),
-						1000, -1000, 1000);
-    const auto & dxy_meas = vertexDxy(sv,pv);
+    sv_features.normchi2 = catch_infs_and_bound(sv_features.chi2 / sv.vertexNdof(), 1000, -1000, 1000);
+    const auto& dxy_meas = vertexDxy(sv, pv);
     sv_features.dxy = dxy_meas.value();
-    sv_features.dxysig = catch_infs_and_bound(dxy_meas.value()/dxy_meas.error(),
-					      0,-1,800);
-    const auto & d3d_meas = vertexD3d(sv,pv);
+    sv_features.dxysig = catch_infs_and_bound(dxy_meas.value() / dxy_meas.error(), 0, -1, 800);
+    const auto& d3d_meas = vertexD3d(sv, pv);
     sv_features.d3d = d3d_meas.value();
-    sv_features.d3dsig = catch_infs_and_bound(d3d_meas.value()/d3d_meas.error(),
-					      0,-1,800);
-    sv_features.costhetasvpv = (flip ? -1.f : 1.f)* vertexDdotP(sv,pv);
-    sv_features.enratio = sv.energy()/jet.energy();
-
+    sv_features.d3dsig = catch_infs_and_bound(d3d_meas.value() / d3d_meas.error(), 0, -1, 800);
+    sv_features.costhetasvpv = (flip ? -1.f : 1.f) * vertexDdotP(sv, pv);
+    sv_features.enratio = sv.energy() / jet.energy();
   }
 
-}
-
+}  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/SeedingTrackInfoBuilder.cc
+++ b/RecoBTag/FeatureTools/src/SeedingTrackInfoBuilder.cc
@@ -4,12 +4,12 @@
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-#include "RecoBTag/TrackProbability/interface/HistogramProbabilityEstimator.h" 
+#include "RecoBTag/TrackProbability/interface/HistogramProbabilityEstimator.h"
 
-namespace btagbtvdeep{
+namespace btagbtvdeep {
 
-     SeedingTrackInfoBuilder::SeedingTrackInfoBuilder():
-        pt_(0),
+  SeedingTrackInfoBuilder::SeedingTrackInfoBuilder()
+      : pt_(0),
         eta_(0),
         phi_(0),
         mass_(0),
@@ -29,73 +29,70 @@ namespace btagbtvdeep{
         jetAxisDistance_(0),
         jetAxisDlength_(0),
         trackProbability3D_(0),
-        trackProbability2D_(0)
-{
+        trackProbability2D_(0) {}
 
-}
+  void SeedingTrackInfoBuilder::buildSeedingTrackInfo(const reco::TransientTrack* it,
+                                                      const reco::Vertex& pv,
+                                                      const reco::Jet& jet, /*GlobalVector jetdirection,*/
+                                                      float mass,
+                                                      const std::pair<bool, Measurement1D>& ip,
+                                                      const std::pair<bool, Measurement1D>& ip2d,
+                                                      float jet_distance,
+                                                      float jaxis_dlength,
+                                                      HistogramProbabilityEstimator* m_probabilityEstimator,
+                                                      bool m_computeProbabilities = false) {
+    GlobalPoint pvp(pv.x(), pv.y(), pv.z());
+    GlobalVector jetdirection(jet.px(), jet.py(), jet.pz());
 
+    auto const& aTrack = it->track();
 
-    void SeedingTrackInfoBuilder::buildSeedingTrackInfo(const reco::TransientTrack * it , const reco::Vertex & pv,  const reco::Jet & jet,/*GlobalVector jetdirection,*/ 
-                                                        float mass, const std::pair<bool,Measurement1D> & ip, const std::pair<bool,Measurement1D> & ip2d,
-                                                        float jet_distance, float jaxis_dlength, HistogramProbabilityEstimator* m_probabilityEstimator, bool m_computeProbabilities=false ){
-        
-        GlobalPoint pvp(pv.x(),pv.y(),pv.z());
-        GlobalVector jetdirection(jet.px(),jet.py(),jet.pz());
-        
-        auto const& aTrack = it->track();
-        
-        pt_=aTrack.pt();
-        eta_=aTrack.eta();
-        phi_=aTrack.phi();
-        dz_=aTrack.dz(pv.position());
-        dxy_=aTrack.dxy(pv.position());
-        mass_=mass;        
-        
-        std::pair<bool,Measurement1D> ipSigned = IPTools::signedImpactParameter3D(*it,jetdirection, pv);        
-        std::pair<bool,Measurement1D> ip2dSigned = IPTools::signedTransverseImpactParameter(*it,jetdirection, pv);         
-        
-        ip3D_=ip.second.value();
-        sip3D_=ip.second.significance();
-        ip2D_=ip2d.second.value();
-        sip2D_=ip2d.second.significance();
-        ip3D_signed_=ipSigned.second.value();
-        sip3D_signed_=ipSigned.second.significance();
-        ip2D_signed_=ip2dSigned.second.value();
-        sip2D_signed_=ip2dSigned.second.significance();
+    pt_ = aTrack.pt();
+    eta_ = aTrack.eta();
+    phi_ = aTrack.phi();
+    dz_ = aTrack.dz(pv.position());
+    dxy_ = aTrack.dxy(pv.position());
+    mass_ = mass;
 
-        chi2reduced_=aTrack.normalizedChi2();
-        nPixelHits_=aTrack.hitPattern().numberOfValidPixelHits();
-        nHits_=aTrack.hitPattern().numberOfValidHits();
-        
-        jetAxisDistance_=std::fabs(jet_distance);
-        jetAxisDlength_=jaxis_dlength;
-        
-        trackProbability3D_=0.5;
-        trackProbability2D_=0.5;
-        
-        if (m_computeProbabilities) {
-            
-            //probability with 3D ip
-            std::pair<bool,double> probability = m_probabilityEstimator->probability(false,0,ip.second.significance(),aTrack,jet,pv);
-            double prob3D=(probability.first ? probability.second : -1.);
-                        
-            //probability with 2D ip                  
-            probability = m_probabilityEstimator->probability(false,1,ip2d.second.significance(),aTrack,jet,pv);
-            double prob2D=(probability.first ? probability.second : -1.);
-                                
-            trackProbability3D_=prob3D;
-            trackProbability2D_=prob2D;            
-            
-        } 
-        
-        if (!edm::isFinite(trackProbability3D_)) trackProbability3D_=0.5;
-        if (!edm::isFinite(trackProbability2D_)) trackProbability2D_=0.5;
+    std::pair<bool, Measurement1D> ipSigned = IPTools::signedImpactParameter3D(*it, jetdirection, pv);
+    std::pair<bool, Measurement1D> ip2dSigned = IPTools::signedTransverseImpactParameter(*it, jetdirection, pv);
 
+    ip3D_ = ip.second.value();
+    sip3D_ = ip.second.significance();
+    ip2D_ = ip2d.second.value();
+    sip2D_ = ip2d.second.significance();
+    ip3D_signed_ = ipSigned.second.value();
+    sip3D_signed_ = ipSigned.second.significance();
+    ip2D_signed_ = ip2dSigned.second.value();
+    sip2D_signed_ = ip2dSigned.second.significance();
 
+    chi2reduced_ = aTrack.normalizedChi2();
+    nPixelHits_ = aTrack.hitPattern().numberOfValidPixelHits();
+    nHits_ = aTrack.hitPattern().numberOfValidHits();
+
+    jetAxisDistance_ = std::fabs(jet_distance);
+    jetAxisDlength_ = jaxis_dlength;
+
+    trackProbability3D_ = 0.5;
+    trackProbability2D_ = 0.5;
+
+    if (m_computeProbabilities) {
+      //probability with 3D ip
+      std::pair<bool, double> probability =
+          m_probabilityEstimator->probability(false, 0, ip.second.significance(), aTrack, jet, pv);
+      double prob3D = (probability.first ? probability.second : -1.);
+
+      //probability with 2D ip
+      probability = m_probabilityEstimator->probability(false, 1, ip2d.second.significance(), aTrack, jet, pv);
+      double prob2D = (probability.first ? probability.second : -1.);
+
+      trackProbability3D_ = prob3D;
+      trackProbability2D_ = prob2D;
     }
-    
 
+    if (!edm::isFinite(trackProbability3D_))
+      trackProbability3D_ = 0.5;
+    if (!edm::isFinite(trackProbability2D_))
+      trackProbability2D_ = 0.5;
+  }
 
-
-
-}
+}  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc
+++ b/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc
@@ -20,218 +20,204 @@
 
 namespace btagbtvdeep {
 
-        void seedingTracksToFeatures(  const std::vector<reco::TransientTrack> & selectedTracks,
-                                       const std::vector<float> & masses,
-                                       const reco::Jet & jet,
-                                       const reco::Vertex & pv,
-                                       HistogramProbabilityEstimator* probabilityEstimator,
-                                       bool computeProbabilities,
-                                       std::vector<btagbtvdeep::SeedingTrackFeatures> & seedingT_features_vector
-                                    ) 
+  void seedingTracksToFeatures(const std::vector<reco::TransientTrack>& selectedTracks,
+                               const std::vector<float>& masses,
+                               const reco::Jet& jet,
+                               const reco::Vertex& pv,
+                               HistogramProbabilityEstimator* probabilityEstimator,
+                               bool computeProbabilities,
+                               std::vector<btagbtvdeep::SeedingTrackFeatures>& seedingT_features_vector)
 
-        {
- 
-            GlobalVector jetdirection(jet.px(),jet.py(),jet.pz());
-            GlobalPoint pvp(pv.x(),pv.y(),pv.z());
+  {
+    GlobalVector jetdirection(jet.px(), jet.py(), jet.pz());
+    GlobalPoint pvp(pv.x(), pv.y(), pv.z());
 
-            std::multimap<double,std::pair<btagbtvdeep::SeedingTrackInfoBuilder,std::vector<btagbtvdeep::TrackPairFeatures>>> sortedSeedsMap;
-            std::multimap<double,btagbtvdeep::TrackPairInfoBuilder> sortedNeighboursMap;
-            
-            std::vector<btagbtvdeep::TrackPairFeatures> tp_features_vector;            
-            
-            sortedSeedsMap.clear();
-            seedingT_features_vector.clear();
-            
-            std::vector<std::pair<bool,Measurement1D>> absIP3D(selectedTracks.size()); 
-            std::vector<std::pair<bool,Measurement1D>> absIP2D(selectedTracks.size());
-            std::vector<bool> absIP3D_filled(selectedTracks.size(), false);
-            std::vector<bool> absIP2D_filled(selectedTracks.size(), false);
+    std::multimap<double, std::pair<btagbtvdeep::SeedingTrackInfoBuilder, std::vector<btagbtvdeep::TrackPairFeatures>>>
+        sortedSeedsMap;
+    std::multimap<double, btagbtvdeep::TrackPairInfoBuilder> sortedNeighboursMap;
 
-            unsigned int selTrackCount=0;
+    std::vector<btagbtvdeep::TrackPairFeatures> tp_features_vector;
 
-            for(auto const& it : selectedTracks){
-                
-                selTrackCount+=1;
-                sortedNeighboursMap.clear();
-                tp_features_vector.clear();        
-                
-                if (reco::deltaR(it.track(), jet) > 0.4) continue;
-                
-                std::pair<bool,Measurement1D> ip = IPTools::absoluteImpactParameter3D(it, pv);
+    sortedSeedsMap.clear();
+    seedingT_features_vector.clear();
 
-                absIP3D[selTrackCount-1]=ip;
-                absIP3D_filled[selTrackCount-1]=true;
+    std::vector<std::pair<bool, Measurement1D>> absIP3D(selectedTracks.size());
+    std::vector<std::pair<bool, Measurement1D>> absIP2D(selectedTracks.size());
+    std::vector<bool> absIP3D_filled(selectedTracks.size(), false);
+    std::vector<bool> absIP2D_filled(selectedTracks.size(), false);
 
-                std::pair<double, Measurement1D> jet_dist =IPTools::jetTrackDistance(it, jetdirection, pv); 
-                TrajectoryStateOnSurface closest = IPTools::closestApproachToJet(it.impactPointState(),pv, jetdirection,it.field());
-                float length=999;
-                if (closest.isValid()) length=(closest.globalPosition() - pvp).mag();
-                
-                
-                if (!(ip.first && ip.second.value() >= 0.0 &&
-                      ip.second.significance() >= 1.0 && 
-                      ip.second.value() <= 9999. &&
-                      ip.second.significance() <= 9999. &&
-                      it.track().normalizedChi2()<5. &&
-                      std::fabs(it.track().dxy(pv.position())) < 2 &&
-                      std::fabs(it.track().dz(pv.position())) < 17 &&
-                      jet_dist.second.value()<0.07 &&
-                      length<5. )) 
-                    continue;                
-                
-                std::pair<bool,Measurement1D> ip2d = IPTools::absoluteTransverseImpactParameter(it, pv);
+    unsigned int selTrackCount = 0;
 
-                absIP2D[selTrackCount-1]=ip2d;
-                absIP2D_filled[selTrackCount-1]=true;
-                
-                btagbtvdeep::SeedingTrackInfoBuilder seedInfo;
-                seedInfo.buildSeedingTrackInfo(&(it), pv, jet, masses[selTrackCount-1], ip, ip2d, jet_dist.second.value(), length, probabilityEstimator, computeProbabilities);
+    for (auto const& it : selectedTracks) {
+      selTrackCount += 1;
+      sortedNeighboursMap.clear();
+      tp_features_vector.clear();
 
-                unsigned int neighbourTrackCount=0;
-                
-                for(auto const& tt : selectedTracks){
-                    
-                    neighbourTrackCount+=1;
+      if (reco::deltaR(it.track(), jet) > 0.4)
+        continue;
 
-                    if(neighbourTrackCount==selTrackCount) continue;
-                    if(std::fabs(pv.z()-tt.track().vz())>0.1) continue;
+      std::pair<bool, Measurement1D> ip = IPTools::absoluteImpactParameter3D(it, pv);
 
-                    //avoid calling IPs twice
-                    if(!absIP2D_filled[neighbourTrackCount-1])
-                    {
-                        absIP2D[neighbourTrackCount-1]=IPTools::absoluteTransverseImpactParameter(tt,pv);
-                        absIP2D_filled[neighbourTrackCount-1]=true;
-                    }
+      absIP3D[selTrackCount - 1] = ip;
+      absIP3D_filled[selTrackCount - 1] = true;
 
-                    if(!absIP3D_filled[neighbourTrackCount-1])
-                    {
-                        absIP3D[neighbourTrackCount-1]= IPTools::absoluteImpactParameter3D(tt,pv); 
-                        absIP3D_filled[neighbourTrackCount-1]=true;
-                    }
+      std::pair<double, Measurement1D> jet_dist = IPTools::jetTrackDistance(it, jetdirection, pv);
+      TrajectoryStateOnSurface closest =
+          IPTools::closestApproachToJet(it.impactPointState(), pv, jetdirection, it.field());
+      float length = 999;
+      if (closest.isValid())
+        length = (closest.globalPosition() - pvp).mag();
 
-                    std::pair<bool,Measurement1D> t_ip = absIP3D[neighbourTrackCount-1];
-                    std::pair<bool,Measurement1D> t_ip2d = absIP2D[neighbourTrackCount-1];
+      if (!(ip.first && ip.second.value() >= 0.0 && ip.second.significance() >= 1.0 && ip.second.value() <= 9999. &&
+            ip.second.significance() <= 9999. && it.track().normalizedChi2() < 5. &&
+            std::fabs(it.track().dxy(pv.position())) < 2 && std::fabs(it.track().dz(pv.position())) < 17 &&
+            jet_dist.second.value() < 0.07 && length < 5.))
+        continue;
 
-                    btagbtvdeep::TrackPairInfoBuilder trackPairInfo;
-                    trackPairInfo.buildTrackPairInfo(&(it),&(tt),pv,masses[neighbourTrackCount-1],jetdirection, t_ip, t_ip2d);
-                    sortedNeighboursMap.insert(std::make_pair(trackPairInfo.pca_distance(), trackPairInfo));
-                    
-                }
-      
-                int max_counter=0;
+      std::pair<bool, Measurement1D> ip2d = IPTools::absoluteTransverseImpactParameter(it, pv);
 
-                for(auto const& im: sortedNeighboursMap){
-                                
-                    if(max_counter>=20) break;
-                    btagbtvdeep::TrackPairFeatures tp_features;
-                    
-                    auto const& tp = im.second;
-                    
-                    tp_features.pt=(tp.track_pt()==0) ? 0: 1.0/tp.track_pt();
-                    tp_features.eta=tp.track_eta();
-                    tp_features.phi=tp.track_phi();
-                    tp_features.mass=tp.track_candMass();
-                    tp_features.dz=logWithOffset(tp.track_dz());
-                    tp_features.dxy=logWithOffset(tp.track_dxy());
-                    tp_features.ip3D=log(tp.track_ip3d());
-                    tp_features.sip3D=log(tp.track_ip3dSig());
-                    tp_features.ip2D=log(tp.track_ip2d());
-                    tp_features.sip2D=log(tp.track_ip2dSig());
-                    tp_features.distPCA=log(tp.pca_distance());
-                    tp_features.dsigPCA=log(tp.pca_significance());
-                    tp_features.x_PCAonSeed=tp.pcaSeed_x();
-                    tp_features.y_PCAonSeed=tp.pcaSeed_y();
-                    tp_features.z_PCAonSeed=tp.pcaSeed_z();
-                    tp_features.xerr_PCAonSeed=tp.pcaSeed_xerr();
-                    tp_features.yerr_PCAonSeed=tp.pcaSeed_yerr();
-                    tp_features.zerr_PCAonSeed=tp.pcaSeed_zerr();
-                    tp_features.x_PCAonTrack=tp.pcaTrack_x();
-                    tp_features.y_PCAonTrack=tp.pcaTrack_y();
-                    tp_features.z_PCAonTrack=tp.pcaTrack_z();
-                    tp_features.xerr_PCAonTrack=tp.pcaTrack_xerr();
-                    tp_features.yerr_PCAonTrack=tp.pcaTrack_yerr();
-                    tp_features.zerr_PCAonTrack=tp.pcaTrack_zerr();
-                    tp_features.dotprodTrack=tp.dotprodTrack();
-                    tp_features.dotprodSeed=tp.dotprodSeed();
-                    tp_features.dotprodTrackSeed2D=tp.dotprodTrackSeed2D();
-                    tp_features.dotprodTrackSeed3D=tp.dotprodTrackSeed3D();
-                    tp_features.dotprodTrackSeedVectors2D=tp.dotprodTrackSeed2DV();
-                    tp_features.dotprodTrackSeedVectors3D=tp.dotprodTrackSeed3DV();
-                    tp_features.pvd_PCAonSeed=log(tp.pcaSeed_dist());
-                    tp_features.pvd_PCAonTrack=log(tp.pcaTrack_dist());
-                    tp_features.dist_PCAjetAxis=log(tp.pca_jetAxis_dist());
-                    tp_features.dotprod_PCAjetMomenta=tp.pca_jetAxis_dotprod();
-                    tp_features.deta_PCAjetDirs=log(tp.pca_jetAxis_dEta());
-                    tp_features.dphi_PCAjetDirs=tp.pca_jetAxis_dPhi();
-                    
-                    
-                    max_counter=max_counter+1;
-                    tp_features_vector.push_back(tp_features);             
-                    
-                    
-                } 
+      absIP2D[selTrackCount - 1] = ip2d;
+      absIP2D_filled[selTrackCount - 1] = true;
 
-                sortedSeedsMap.insert(std::make_pair(-seedInfo.sip3d_Signed(), std::make_pair(seedInfo,tp_features_vector)));
-            
-            }
+      btagbtvdeep::SeedingTrackInfoBuilder seedInfo;
+      seedInfo.buildSeedingTrackInfo(&(it),
+                                     pv,
+                                     jet,
+                                     masses[selTrackCount - 1],
+                                     ip,
+                                     ip2d,
+                                     jet_dist.second.value(),
+                                     length,
+                                     probabilityEstimator,
+                                     computeProbabilities);
 
+      unsigned int neighbourTrackCount = 0;
 
-            int max_counter_seed=0;
+      for (auto const& tt : selectedTracks) {
+        neighbourTrackCount += 1;
 
-            for(auto const& im: sortedSeedsMap){
-                
-                if(max_counter_seed>=10) break;
-                
-                btagbtvdeep::SeedingTrackFeatures seed_features;            
+        if (neighbourTrackCount == selTrackCount)
+          continue;
+        if (std::fabs(pv.z() - tt.track().vz()) > 0.1)
+          continue;
 
-                auto const& seed = im.second.first;
-                
-                seed_features.nearTracks=im.second.second;
-                seed_features.pt=(seed.pt()==0) ? 0: 1.0/seed.pt();
-                seed_features.eta=seed.eta();
-                seed_features.phi=seed.phi();
-                seed_features.mass=seed.mass();
-                seed_features.dz=logWithOffset(seed.dz());
-                seed_features.dxy=logWithOffset(seed.dxy());
-                seed_features.ip3D=log(seed.ip3d());
-                seed_features.sip3D=log(seed.sip3d());
-                seed_features.ip2D=log(seed.ip2d());
-                seed_features.sip2D=log(seed.sip2d());
-                seed_features.signedIp3D=logWithOffset(seed.ip3d_Signed());
-                seed_features.signedSip3D=logWithOffset(seed.sip3d_Signed());
-                seed_features.signedIp2D=logWithOffset(seed.ip2d_Signed());
-                seed_features.signedSip2D=logWithOffset(seed.sip2d_Signed());
-                seed_features.trackProbability3D=seed.trackProbability3D();
-                seed_features.trackProbability2D=seed.trackProbability2D();
-                seed_features.chi2reduced=seed.chi2reduced();
-                seed_features.nPixelHits=seed.nPixelHits();
-                seed_features.nHits=seed.nHits();
-                seed_features.jetAxisDistance=log(seed.jetAxisDistance());
-                seed_features.jetAxisDlength=log(seed.jetAxisDlength());
-                
-        
-                max_counter_seed=max_counter_seed+1;
-                seedingT_features_vector.push_back(seed_features);
+        //avoid calling IPs twice
+        if (!absIP2D_filled[neighbourTrackCount - 1]) {
+          absIP2D[neighbourTrackCount - 1] = IPTools::absoluteTransverseImpactParameter(tt, pv);
+          absIP2D_filled[neighbourTrackCount - 1] = true;
+        }
 
-                
-            }
-            
-            
-            if (sortedSeedsMap.size()<10){
-                
-                for (unsigned int i=sortedSeedsMap.size(); i<10; i++){
-                    
-                    
-                    std::vector<btagbtvdeep::TrackPairFeatures> tp_features_zeropad(20);
-                    btagbtvdeep::SeedingTrackFeatures seed_features_zeropad;
-                    seed_features_zeropad.nearTracks=tp_features_zeropad;
-                    seedingT_features_vector.push_back(seed_features_zeropad);
-                    
-                }    
-                
-            }          
-          
+        if (!absIP3D_filled[neighbourTrackCount - 1]) {
+          absIP3D[neighbourTrackCount - 1] = IPTools::absoluteImpactParameter3D(tt, pv);
+          absIP3D_filled[neighbourTrackCount - 1] = true;
+        }
+
+        std::pair<bool, Measurement1D> t_ip = absIP3D[neighbourTrackCount - 1];
+        std::pair<bool, Measurement1D> t_ip2d = absIP2D[neighbourTrackCount - 1];
+
+        btagbtvdeep::TrackPairInfoBuilder trackPairInfo;
+        trackPairInfo.buildTrackPairInfo(&(it), &(tt), pv, masses[neighbourTrackCount - 1], jetdirection, t_ip, t_ip2d);
+        sortedNeighboursMap.insert(std::make_pair(trackPairInfo.pca_distance(), trackPairInfo));
+      }
+
+      int max_counter = 0;
+
+      for (auto const& im : sortedNeighboursMap) {
+        if (max_counter >= 20)
+          break;
+        btagbtvdeep::TrackPairFeatures tp_features;
+
+        auto const& tp = im.second;
+
+        tp_features.pt = (tp.track_pt() == 0) ? 0 : 1.0 / tp.track_pt();
+        tp_features.eta = tp.track_eta();
+        tp_features.phi = tp.track_phi();
+        tp_features.mass = tp.track_candMass();
+        tp_features.dz = logWithOffset(tp.track_dz());
+        tp_features.dxy = logWithOffset(tp.track_dxy());
+        tp_features.ip3D = log(tp.track_ip3d());
+        tp_features.sip3D = log(tp.track_ip3dSig());
+        tp_features.ip2D = log(tp.track_ip2d());
+        tp_features.sip2D = log(tp.track_ip2dSig());
+        tp_features.distPCA = log(tp.pca_distance());
+        tp_features.dsigPCA = log(tp.pca_significance());
+        tp_features.x_PCAonSeed = tp.pcaSeed_x();
+        tp_features.y_PCAonSeed = tp.pcaSeed_y();
+        tp_features.z_PCAonSeed = tp.pcaSeed_z();
+        tp_features.xerr_PCAonSeed = tp.pcaSeed_xerr();
+        tp_features.yerr_PCAonSeed = tp.pcaSeed_yerr();
+        tp_features.zerr_PCAonSeed = tp.pcaSeed_zerr();
+        tp_features.x_PCAonTrack = tp.pcaTrack_x();
+        tp_features.y_PCAonTrack = tp.pcaTrack_y();
+        tp_features.z_PCAonTrack = tp.pcaTrack_z();
+        tp_features.xerr_PCAonTrack = tp.pcaTrack_xerr();
+        tp_features.yerr_PCAonTrack = tp.pcaTrack_yerr();
+        tp_features.zerr_PCAonTrack = tp.pcaTrack_zerr();
+        tp_features.dotprodTrack = tp.dotprodTrack();
+        tp_features.dotprodSeed = tp.dotprodSeed();
+        tp_features.dotprodTrackSeed2D = tp.dotprodTrackSeed2D();
+        tp_features.dotprodTrackSeed3D = tp.dotprodTrackSeed3D();
+        tp_features.dotprodTrackSeedVectors2D = tp.dotprodTrackSeed2DV();
+        tp_features.dotprodTrackSeedVectors3D = tp.dotprodTrackSeed3DV();
+        tp_features.pvd_PCAonSeed = log(tp.pcaSeed_dist());
+        tp_features.pvd_PCAonTrack = log(tp.pcaTrack_dist());
+        tp_features.dist_PCAjetAxis = log(tp.pca_jetAxis_dist());
+        tp_features.dotprod_PCAjetMomenta = tp.pca_jetAxis_dotprod();
+        tp_features.deta_PCAjetDirs = log(tp.pca_jetAxis_dEta());
+        tp_features.dphi_PCAjetDirs = tp.pca_jetAxis_dPhi();
+
+        max_counter = max_counter + 1;
+        tp_features_vector.push_back(tp_features);
+      }
+
+      sortedSeedsMap.insert(std::make_pair(-seedInfo.sip3d_Signed(), std::make_pair(seedInfo, tp_features_vector)));
     }
-      
-    
-}
+
+    int max_counter_seed = 0;
+
+    for (auto const& im : sortedSeedsMap) {
+      if (max_counter_seed >= 10)
+        break;
+
+      btagbtvdeep::SeedingTrackFeatures seed_features;
+
+      auto const& seed = im.second.first;
+
+      seed_features.nearTracks = im.second.second;
+      seed_features.pt = (seed.pt() == 0) ? 0 : 1.0 / seed.pt();
+      seed_features.eta = seed.eta();
+      seed_features.phi = seed.phi();
+      seed_features.mass = seed.mass();
+      seed_features.dz = logWithOffset(seed.dz());
+      seed_features.dxy = logWithOffset(seed.dxy());
+      seed_features.ip3D = log(seed.ip3d());
+      seed_features.sip3D = log(seed.sip3d());
+      seed_features.ip2D = log(seed.ip2d());
+      seed_features.sip2D = log(seed.sip2d());
+      seed_features.signedIp3D = logWithOffset(seed.ip3d_Signed());
+      seed_features.signedSip3D = logWithOffset(seed.sip3d_Signed());
+      seed_features.signedIp2D = logWithOffset(seed.ip2d_Signed());
+      seed_features.signedSip2D = logWithOffset(seed.sip2d_Signed());
+      seed_features.trackProbability3D = seed.trackProbability3D();
+      seed_features.trackProbability2D = seed.trackProbability2D();
+      seed_features.chi2reduced = seed.chi2reduced();
+      seed_features.nPixelHits = seed.nPixelHits();
+      seed_features.nHits = seed.nHits();
+      seed_features.jetAxisDistance = log(seed.jetAxisDistance());
+      seed_features.jetAxisDlength = log(seed.jetAxisDlength());
+
+      max_counter_seed = max_counter_seed + 1;
+      seedingT_features_vector.push_back(seed_features);
+    }
+
+    if (sortedSeedsMap.size() < 10) {
+      for (unsigned int i = sortedSeedsMap.size(); i < 10; i++) {
+        std::vector<btagbtvdeep::TrackPairFeatures> tp_features_zeropad(20);
+        btagbtvdeep::SeedingTrackFeatures seed_features_zeropad;
+        seed_features_zeropad.nearTracks = tp_features_zeropad;
+        seedingT_features_vector.push_back(seed_features_zeropad);
+      }
+    }
+  }
+
+}  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/ShallowTagInfoConverter.cc
+++ b/RecoBTag/FeatureTools/src/ShallowTagInfoConverter.cc
@@ -8,25 +8,18 @@
 
 namespace btagbtvdeep {
 
-  static constexpr std::size_t max_jetNSelectedTracks =100;
+  static constexpr std::size_t max_jetNSelectedTracks = 100;
 
-
-  void bTagToFeatures(const reco::TaggingVariableList & tag_info_vars,
-		      ShallowTagInfoFeatures & tag_info_features) {
-
-    tag_info_features.trackSumJetEtRatio         = tag_info_vars.get(reco::btau::trackSumJetEtRatio, -999);
-    tag_info_features.trackSumJetDeltaR          = tag_info_vars.get(reco::btau::trackSumJetDeltaR, -999);
-    tag_info_features.vertexCategory             = tag_info_vars.get(reco::btau::vertexCategory, -999);
-    tag_info_features.trackSip2dValAboveCharm    = tag_info_vars.get(reco::btau::trackSip2dValAboveCharm, -999);
-    tag_info_features.trackSip2dSigAboveCharm    = tag_info_vars.get(reco::btau::trackSip2dSigAboveCharm, -999);
-    tag_info_features.trackSip3dValAboveCharm    = tag_info_vars.get(reco::btau::trackSip3dValAboveCharm, -999);
-    tag_info_features.trackSip3dSigAboveCharm    = tag_info_vars.get(reco::btau::trackSip3dSigAboveCharm, -999);
+  void bTagToFeatures(const reco::TaggingVariableList& tag_info_vars, ShallowTagInfoFeatures& tag_info_features) {
+    tag_info_features.trackSumJetEtRatio = tag_info_vars.get(reco::btau::trackSumJetEtRatio, -999);
+    tag_info_features.trackSumJetDeltaR = tag_info_vars.get(reco::btau::trackSumJetDeltaR, -999);
+    tag_info_features.vertexCategory = tag_info_vars.get(reco::btau::vertexCategory, -999);
+    tag_info_features.trackSip2dValAboveCharm = tag_info_vars.get(reco::btau::trackSip2dValAboveCharm, -999);
+    tag_info_features.trackSip2dSigAboveCharm = tag_info_vars.get(reco::btau::trackSip2dSigAboveCharm, -999);
+    tag_info_features.trackSip3dValAboveCharm = tag_info_vars.get(reco::btau::trackSip3dValAboveCharm, -999);
+    tag_info_features.trackSip3dSigAboveCharm = tag_info_vars.get(reco::btau::trackSip3dSigAboveCharm, -999);
     tag_info_features.jetNTracksEtaRel = tag_info_vars.get(reco::btau::jetNTracksEtaRel, -1);
-    tag_info_features.jetNSelectedTracks = std::min(tag_info_vars.getList(reco::btau::trackMomentum, false).size(),
-						    max_jetNSelectedTracks);
-
+    tag_info_features.jetNSelectedTracks =
+        std::min(tag_info_vars.getList(reco::btau::trackMomentum, false).size(), max_jetNSelectedTracks);
   }
-}
-
-
-
+}  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/TrackInfoBuilder.cc
+++ b/RecoBTag/FeatureTools/src/TrackInfoBuilder.cc
@@ -9,11 +9,11 @@
 #include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
 #include "TVector3.h"
 
-namespace btagbtvdeep{
+namespace btagbtvdeep {
 
-// adapted from DeepNtuples
-     TrackInfoBuilder::TrackInfoBuilder(edm::ESHandle<TransientTrackBuilder> & build):
-        builder_(build),
+  // adapted from DeepNtuples
+  TrackInfoBuilder::TrackInfoBuilder(edm::ESHandle<TransientTrackBuilder> &build)
+      : builder_(build),
         trackMomentum_(0),
         trackEta_(0),
         trackEtaRel_(0),
@@ -27,80 +27,69 @@ namespace btagbtvdeep{
         trackSip3dVal_(0),
         trackSip3dSig_(0),
         trackJetDistVal_(0),
-        trackJetDistSig_(0)
-{
+        trackJetDistSig_(0) {}
 
-}
+  void TrackInfoBuilder::buildTrackInfo(const reco::Candidate *candidate,
+                                        const math::XYZVector &jetDir,
+                                        GlobalVector refjetdirection,
+                                        const reco::Vertex &pv) {
+    TVector3 jetDir3(jetDir.x(), jetDir.y(), jetDir.z());
 
-
-    void TrackInfoBuilder::buildTrackInfo(const reco::Candidate * candidate ,const math::XYZVector&  jetDir, GlobalVector refjetdirection, const reco::Vertex & pv){
-        TVector3 jetDir3(jetDir.x(),jetDir.y(),jetDir.z());
-
-
-        // deal with PAT/AOD polymorphism to get track
-        const reco::Track * track_ptr = nullptr;
-        auto packed_candidate = dynamic_cast<const pat::PackedCandidate *>(candidate);
-        auto pf_candidate = dynamic_cast<const reco::PFCandidate *>(candidate);
-        if (pf_candidate) {
-          track_ptr = pf_candidate->bestTrack(); // trackRef was sometimes null
-        } else if (packed_candidate && packed_candidate->hasTrackDetails()) {
-          // if PackedCandidate does not have TrackDetails this gives an Exception
-          // because unpackCovariance might be called for pseudoTrack/bestTrack
-          track_ptr = &(packed_candidate->pseudoTrack());
-        }
-
-        if(!track_ptr) {
-          TVector3 trackMom3(
-            candidate->momentum().x(),
-            candidate->momentum().y(),
-            candidate->momentum().z()
-            );
-          trackMomentum_=candidate->p();
-          trackEta_= candidate->eta();
-          trackEtaRel_=reco::btau::etaRel(jetDir, candidate->momentum());
-          trackPtRel_=trackMom3.Perp(jetDir3);
-          trackPPar_=jetDir.Dot(candidate->momentum());
-          trackDeltaR_=reco::deltaR(candidate->momentum(), jetDir);
-          trackPtRatio_=trackMom3.Perp(jetDir3) / candidate->p();
-          trackPParRatio_=jetDir.Dot(candidate->momentum()) / candidate->p();
-          trackSip2dVal_=0.;
-          trackSip2dSig_=0.;
-          trackSip3dVal_=0.;
-          trackSip3dSig_=0.;
-          trackJetDistVal_=0.;
-          trackJetDistSig_=0.;
-          return;
-        }
-
-        math::XYZVector trackMom = track_ptr->momentum();
-        double trackMag = std::sqrt(trackMom.Mag2());
-        TVector3 trackMom3(trackMom.x(),trackMom.y(),trackMom.z());
-
-        trackMomentum_=std::sqrt(trackMom.Mag2());
-        trackEta_= trackMom.Eta();
-        trackEtaRel_=reco::btau::etaRel(jetDir, trackMom);
-        trackPtRel_=trackMom3.Perp(jetDir3);
-        trackPPar_=jetDir.Dot(trackMom);
-        trackDeltaR_=reco::deltaR(trackMom, jetDir);
-        trackPtRatio_=trackMom3.Perp(jetDir3) / trackMag;
-        trackPParRatio_=jetDir.Dot(trackMom) / trackMag;
-
-        reco::TransientTrack transientTrack;
-        transientTrack=builder_->build(*track_ptr);
-        Measurement1D meas_ip2d=IPTools::signedTransverseImpactParameter(transientTrack, refjetdirection, pv).second;
-        Measurement1D meas_ip3d=IPTools::signedImpactParameter3D(transientTrack, refjetdirection, pv).second;
-        Measurement1D jetdist=IPTools::jetTrackDistance(transientTrack, refjetdirection, pv).second;
-        trackSip2dVal_=static_cast<float>(meas_ip2d.value());
-        trackSip2dSig_=static_cast<float>(meas_ip2d.significance());
-        trackSip3dVal_=static_cast<float>(meas_ip3d.value());
-        trackSip3dSig_=static_cast<float>(meas_ip3d.significance());
-        trackJetDistVal_=static_cast<float>(jetdist.value());
-        trackJetDistSig_=static_cast<float>(jetdist.significance());
-
+    // deal with PAT/AOD polymorphism to get track
+    const reco::Track *track_ptr = nullptr;
+    auto packed_candidate = dynamic_cast<const pat::PackedCandidate *>(candidate);
+    auto pf_candidate = dynamic_cast<const reco::PFCandidate *>(candidate);
+    if (pf_candidate) {
+      track_ptr = pf_candidate->bestTrack();  // trackRef was sometimes null
+    } else if (packed_candidate && packed_candidate->hasTrackDetails()) {
+      // if PackedCandidate does not have TrackDetails this gives an Exception
+      // because unpackCovariance might be called for pseudoTrack/bestTrack
+      track_ptr = &(packed_candidate->pseudoTrack());
     }
 
+    if (!track_ptr) {
+      TVector3 trackMom3(candidate->momentum().x(), candidate->momentum().y(), candidate->momentum().z());
+      trackMomentum_ = candidate->p();
+      trackEta_ = candidate->eta();
+      trackEtaRel_ = reco::btau::etaRel(jetDir, candidate->momentum());
+      trackPtRel_ = trackMom3.Perp(jetDir3);
+      trackPPar_ = jetDir.Dot(candidate->momentum());
+      trackDeltaR_ = reco::deltaR(candidate->momentum(), jetDir);
+      trackPtRatio_ = trackMom3.Perp(jetDir3) / candidate->p();
+      trackPParRatio_ = jetDir.Dot(candidate->momentum()) / candidate->p();
+      trackSip2dVal_ = 0.;
+      trackSip2dSig_ = 0.;
+      trackSip3dVal_ = 0.;
+      trackSip3dSig_ = 0.;
+      trackJetDistVal_ = 0.;
+      trackJetDistSig_ = 0.;
+      return;
+    }
 
+    math::XYZVector trackMom = track_ptr->momentum();
+    double trackMag = std::sqrt(trackMom.Mag2());
+    TVector3 trackMom3(trackMom.x(), trackMom.y(), trackMom.z());
 
+    trackMomentum_ = std::sqrt(trackMom.Mag2());
+    trackEta_ = trackMom.Eta();
+    trackEtaRel_ = reco::btau::etaRel(jetDir, trackMom);
+    trackPtRel_ = trackMom3.Perp(jetDir3);
+    trackPPar_ = jetDir.Dot(trackMom);
+    trackDeltaR_ = reco::deltaR(trackMom, jetDir);
+    trackPtRatio_ = trackMom3.Perp(jetDir3) / trackMag;
+    trackPParRatio_ = jetDir.Dot(trackMom) / trackMag;
 
-}
+    reco::TransientTrack transientTrack;
+    transientTrack = builder_->build(*track_ptr);
+    Measurement1D meas_ip2d = IPTools::signedTransverseImpactParameter(transientTrack, refjetdirection, pv).second;
+    Measurement1D meas_ip3d = IPTools::signedImpactParameter3D(transientTrack, refjetdirection, pv).second;
+    Measurement1D jetdist = IPTools::jetTrackDistance(transientTrack, refjetdirection, pv).second;
+    trackSip2dVal_ = static_cast<float>(meas_ip2d.value());
+    trackSip2dSig_ = static_cast<float>(meas_ip2d.significance());
+    trackSip3dVal_ = static_cast<float>(meas_ip3d.value());
+    trackSip3dSig_ = static_cast<float>(meas_ip3d.significance());
+    trackJetDistVal_ = static_cast<float>(jetdist.value());
+    trackJetDistSig_ = static_cast<float>(jetdist.significance());
+  }
 
+}  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/TrackPairInfoBuilder.cc
+++ b/RecoBTag/FeatureTools/src/TrackPairInfoBuilder.cc
@@ -4,19 +4,20 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
-namespace btagbtvdeep{
+namespace btagbtvdeep {
 
-     TrackPairInfoBuilder::TrackPairInfoBuilder(): 
+  TrackPairInfoBuilder::TrackPairInfoBuilder()
+      :
 
         track_pt_(0),
         track_eta_(0),
         track_phi_(0),
         track_dz_(0),
         track_dxy_(0),
-                
+
         pca_distance_(0),
         pca_significance_(0),
-        
+
         pcaSeed_x_(0),
         pcaSeed_y_(0),
         pcaSeed_z_(0),
@@ -29,125 +30,120 @@ namespace btagbtvdeep{
         pcaTrack_xerr_(0),
         pcaTrack_yerr_(0),
         pcaTrack_zerr_(0),
-        
+
         dotprodTrack_(0),
         dotprodSeed_(0),
         pcaSeed_dist_(0),
         pcaTrack_dist_(0),
-        
+
         track_candMass_(0),
         track_ip2d_(0),
         track_ip2dSig_(0),
         track_ip3d_(0),
         track_ip3dSig_(0),
-        
+
         dotprodTrackSeed2D_(0),
         dotprodTrackSeed2DV_(0),
         dotprodTrackSeed3D_(0),
         dotprodTrackSeed3DV_(0),
-        
+
         pca_jetAxis_dist_(0),
         pca_jetAxis_dotprod_(0),
         pca_jetAxis_dEta_(0),
         pca_jetAxis_dPhi_(0)
-        
-{
 
-}
+  {}
 
+  void TrackPairInfoBuilder::buildTrackPairInfo(const reco::TransientTrack* it,
+                                                const reco::TransientTrack* tt,
+                                                const reco::Vertex& pv,
+                                                float mass,
+                                                GlobalVector jetdirection,
+                                                const std::pair<bool, Measurement1D>& t_ip,
+                                                const std::pair<bool, Measurement1D>& t_ip2d) {
+    GlobalPoint pvp(pv.x(), pv.y(), pv.z());
 
-    void TrackPairInfoBuilder::buildTrackPairInfo(const reco::TransientTrack * it , const reco::TransientTrack * tt, const reco::Vertex & pv, float mass, GlobalVector jetdirection, 
-                                                  const std::pair<bool,Measurement1D> & t_ip, const std::pair<bool,Measurement1D> & t_ip2d  )
-    {
-        
-        GlobalPoint pvp(pv.x(),pv.y(),pv.z());
-        
-        VertexDistance3D distanceComputer;
-        TwoTrackMinimumDistance dist;
-        
-        auto const& iImpactState = it->impactPointState();
-        auto const& tImpactState = tt->impactPointState();
-        
-        if(dist.calculate(tImpactState,iImpactState)) {
-            
-            GlobalPoint ttPoint          = dist.points().first;
-            GlobalError ttPointErr       = tImpactState.cartesianError().position();
-            GlobalPoint seedPosition     = dist.points().second;
-            GlobalError seedPositionErr  = iImpactState.cartesianError().position();
-            
-            Measurement1D m = distanceComputer.distance(VertexState(seedPosition,seedPositionErr), VertexState(ttPoint, ttPointErr));
-            
-            GlobalPoint cp(dist.crossingPoint()); 
+    VertexDistance3D distanceComputer;
+    TwoTrackMinimumDistance dist;
 
-            GlobalVector pairMomentum((Basic3DVector<float>) (it->track().momentum()+tt->track().momentum()));
-            GlobalVector pvToPCA(cp-pvp);
+    auto const& iImpactState = it->impactPointState();
+    auto const& tImpactState = tt->impactPointState();
 
-            float pvToPCAseed = (seedPosition-pvp).mag();
-            float pvToPCAtrack = (ttPoint-pvp).mag();
-            float distance = dist.distance();
+    if (dist.calculate(tImpactState, iImpactState)) {
+      GlobalPoint ttPoint = dist.points().first;
+      GlobalError ttPointErr = tImpactState.cartesianError().position();
+      GlobalPoint seedPosition = dist.points().second;
+      GlobalError seedPositionErr = iImpactState.cartesianError().position();
 
-            GlobalVector trackDir2D(tImpactState.globalDirection().x(),tImpactState.globalDirection().y(),0.); 
-            GlobalVector seedDir2D(iImpactState.globalDirection().x(),iImpactState.globalDirection().y(),0.); 
-            GlobalVector trackPCADir2D(ttPoint.x()-pvp.x(),ttPoint.y()-pvp.y(),0.);
-            GlobalVector seedPCADir2D(seedPosition.x()-pvp.x(),seedPosition.y()-pvp.y(),0.);
+      Measurement1D m =
+          distanceComputer.distance(VertexState(seedPosition, seedPositionErr), VertexState(ttPoint, ttPointErr));
 
-            float dotprodTrack = (ttPoint-pvp).unit().dot(tImpactState.globalDirection().unit());
-            float dotprodSeed = (seedPosition-pvp).unit().dot(iImpactState.globalDirection().unit());
+      GlobalPoint cp(dist.crossingPoint());
 
-            Line::PositionType pos(pvp);
-            Line::DirectionType dir(jetdirection);
-            Line::DirectionType pairMomentumDir(pairMomentum);
-            Line jetLine(pos,dir);   
-            Line PCAMomentumLine(cp,pairMomentumDir);
+      GlobalVector pairMomentum((Basic3DVector<float>)(it->track().momentum() + tt->track().momentum()));
+      GlobalVector pvToPCA(cp - pvp);
 
-           
-            track_pt_=tt->track().pt();
-            track_eta_=tt->track().eta();
-            track_phi_=tt->track().phi();
-            track_dz_=tt->track().dz(pv.position());
-            track_dxy_=tt->track().dxy(pv.position());
+      float pvToPCAseed = (seedPosition - pvp).mag();
+      float pvToPCAtrack = (ttPoint - pvp).mag();
+      float distance = dist.distance();
 
+      GlobalVector trackDir2D(tImpactState.globalDirection().x(), tImpactState.globalDirection().y(), 0.);
+      GlobalVector seedDir2D(iImpactState.globalDirection().x(), iImpactState.globalDirection().y(), 0.);
+      GlobalVector trackPCADir2D(ttPoint.x() - pvp.x(), ttPoint.y() - pvp.y(), 0.);
+      GlobalVector seedPCADir2D(seedPosition.x() - pvp.x(), seedPosition.y() - pvp.y(), 0.);
 
-            pca_distance_=distance;
-            pca_significance_=m.significance();
+      float dotprodTrack = (ttPoint - pvp).unit().dot(tImpactState.globalDirection().unit());
+      float dotprodSeed = (seedPosition - pvp).unit().dot(iImpactState.globalDirection().unit());
 
-            pcaSeed_x_=seedPosition.x();
-            pcaSeed_y_=seedPosition.y();
-            pcaSeed_z_=seedPosition.z();
-            pcaSeed_xerr_=seedPositionErr.cxx();
-            pcaSeed_yerr_=seedPositionErr.cyy();
-            pcaSeed_zerr_=seedPositionErr.czz();
-            pcaTrack_x_=ttPoint.x();
-            pcaTrack_y_=ttPoint.y();
-            pcaTrack_z_=ttPoint.z();
-            pcaTrack_xerr_=ttPointErr.cxx();
-            pcaTrack_yerr_=ttPointErr.cyy();
-            pcaTrack_zerr_=ttPointErr.czz();
+      Line::PositionType pos(pvp);
+      Line::DirectionType dir(jetdirection);
+      Line::DirectionType pairMomentumDir(pairMomentum);
+      Line jetLine(pos, dir);
+      Line PCAMomentumLine(cp, pairMomentumDir);
 
-            dotprodTrack_=dotprodTrack;
-            dotprodSeed_=dotprodSeed;
-            pcaSeed_dist_=pvToPCAseed;
-            pcaTrack_dist_=pvToPCAtrack;
+      track_pt_ = tt->track().pt();
+      track_eta_ = tt->track().eta();
+      track_phi_ = tt->track().phi();
+      track_dz_ = tt->track().dz(pv.position());
+      track_dxy_ = tt->track().dxy(pv.position());
 
-            track_candMass_=mass;  
-            track_ip2d_=t_ip2d.second.value();
-            track_ip2dSig_=t_ip2d.second.significance();
-            track_ip3d_=t_ip.second.value();
-            track_ip3dSig_=t_ip.second.significance();
+      pca_distance_ = distance;
+      pca_significance_ = m.significance();
 
-            dotprodTrackSeed2D_=trackDir2D.unit().dot(seedDir2D.unit());
-            dotprodTrackSeed3D_=iImpactState.globalDirection().unit().dot(tImpactState.globalDirection().unit());
-            dotprodTrackSeed2DV_=trackPCADir2D.unit().dot(seedPCADir2D.unit());
-            dotprodTrackSeed3DV_=(seedPosition-pvp).unit().dot((ttPoint-pvp).unit());
+      pcaSeed_x_ = seedPosition.x();
+      pcaSeed_y_ = seedPosition.y();
+      pcaSeed_z_ = seedPosition.z();
+      pcaSeed_xerr_ = seedPositionErr.cxx();
+      pcaSeed_yerr_ = seedPositionErr.cyy();
+      pcaSeed_zerr_ = seedPositionErr.czz();
+      pcaTrack_x_ = ttPoint.x();
+      pcaTrack_y_ = ttPoint.y();
+      pcaTrack_z_ = ttPoint.z();
+      pcaTrack_xerr_ = ttPointErr.cxx();
+      pcaTrack_yerr_ = ttPointErr.cyy();
+      pcaTrack_zerr_ = ttPointErr.czz();
 
-            pca_jetAxis_dist_=jetLine.distance(cp).mag();
-            pca_jetAxis_dotprod_=pairMomentum.unit().dot(jetdirection.unit());
-            pca_jetAxis_dEta_=std::fabs(pvToPCA.eta()-jetdirection.eta());
-            pca_jetAxis_dPhi_=std::fabs(pvToPCA.phi()-jetdirection.phi());
+      dotprodTrack_ = dotprodTrack;
+      dotprodSeed_ = dotprodSeed;
+      pcaSeed_dist_ = pvToPCAseed;
+      pcaTrack_dist_ = pvToPCAtrack;
 
+      track_candMass_ = mass;
+      track_ip2d_ = t_ip2d.second.value();
+      track_ip2dSig_ = t_ip2d.second.significance();
+      track_ip3d_ = t_ip.second.value();
+      track_ip3dSig_ = t_ip.second.significance();
 
+      dotprodTrackSeed2D_ = trackDir2D.unit().dot(seedDir2D.unit());
+      dotprodTrackSeed3D_ = iImpactState.globalDirection().unit().dot(tImpactState.globalDirection().unit());
+      dotprodTrackSeed2DV_ = trackPCADir2D.unit().dot(seedPCADir2D.unit());
+      dotprodTrackSeed3DV_ = (seedPosition - pvp).unit().dot((ttPoint - pvp).unit());
+
+      pca_jetAxis_dist_ = jetLine.distance(cp).mag();
+      pca_jetAxis_dotprod_ = pairMomentum.unit().dot(jetdirection.unit());
+      pca_jetAxis_dEta_ = std::fabs(pvToPCA.eta() - jetdirection.eta());
+      pca_jetAxis_dPhi_ = std::fabs(pvToPCA.phi() - jetdirection.phi());
     }
-    }
-    
-    
-}
+  }
+
+}  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -3,27 +3,25 @@
 
 namespace btagbtvdeep {
 
-  constexpr static int qualityMap[8]  = {1,0,1,1,4,4,5,6};
+  constexpr static int qualityMap[8] = {1, 0, 1, 1, 4, 4, 5, 6};
 
   enum qualityFlagsShiftsAndMasks {
     assignmentQualityMask = 0x7,
     assignmentQualityShift = 0,
-    trackHighPurityMask  = 0x8,
-    trackHighPurityShift=3,
+    trackHighPurityMask = 0x8,
+    trackHighPurityShift = 3,
     lostInnerHitsMask = 0x30,
-    lostInnerHitsShift=4,
+    lostInnerHitsShift = 4,
     muonFlagsMask = 0x0600,
-    muonFlagsShift=9
+    muonFlagsShift = 9
   };
 
-
   // remove infs and NaNs with value  (adapted from DeepNTuples)
-  const float catch_infs(const float in,
-			 const float replace_value) {
-    if(in==in){ // check if NaN
-      if(std::isinf(in))
+  const float catch_infs(const float in, const float replace_value) {
+    if (in == in) {  // check if NaN
+      if (std::isinf(in))
         return replace_value;
-      else if(in < -1e32 || in > 1e32)
+      else if (in < -1e32 || in > 1e32)
         return replace_value;
       return in;
     }
@@ -32,79 +30,79 @@ namespace btagbtvdeep {
 
   // remove infs/NaN and bound (adapted from DeepNTuples)
   const float catch_infs_and_bound(const float in,
-				   const float replace_value,
-				   const float lowerbound,
-				   const float upperbound,
-				   const float offset,
-				   const bool use_offsets){
-    float withoutinfs=catch_infs(in,replace_value);
-    if(withoutinfs+offset<lowerbound) return lowerbound;
-    if(withoutinfs+offset>upperbound) return upperbound;
-    if(use_offsets)
-      withoutinfs+=offset;
+                                   const float replace_value,
+                                   const float lowerbound,
+                                   const float upperbound,
+                                   const float offset,
+                                   const bool use_offsets) {
+    float withoutinfs = catch_infs(in, replace_value);
+    if (withoutinfs + offset < lowerbound)
+      return lowerbound;
+    if (withoutinfs + offset > upperbound)
+      return upperbound;
+    if (use_offsets)
+      withoutinfs += offset;
     return withoutinfs;
   }
 
-
   // 2D distance between SV and PV (adapted from DeepNTuples)
-  Measurement1D vertexDxy(const reco::VertexCompositePtrCandidate &svcand, const reco::Vertex &pv)  {
+  Measurement1D vertexDxy(const reco::VertexCompositePtrCandidate &svcand, const reco::Vertex &pv) {
     VertexDistanceXY dist;
-    reco::Vertex::CovarianceMatrix csv; svcand.fillVertexCovariance(csv);
+    reco::Vertex::CovarianceMatrix csv;
+    svcand.fillVertexCovariance(csv);
     reco::Vertex svtx(svcand.vertex(), csv);
     return dist.distance(svtx, pv);
   }
 
   //3D distance between SV and PV (adapted from DeepNTuples)
-  Measurement1D vertexD3d(const reco::VertexCompositePtrCandidate &svcand, const reco::Vertex &pv)  {
+  Measurement1D vertexD3d(const reco::VertexCompositePtrCandidate &svcand, const reco::Vertex &pv) {
     VertexDistance3D dist;
-    reco::Vertex::CovarianceMatrix csv; svcand.fillVertexCovariance(csv);
+    reco::Vertex::CovarianceMatrix csv;
+    svcand.fillVertexCovariance(csv);
     reco::Vertex svtx(svcand.vertex(), csv);
     return dist.distance(svtx, pv);
   }
 
   // dot product between SV and PV (adapted from DeepNTuples)
-  float vertexDdotP(const reco::VertexCompositePtrCandidate &sv, const reco::Vertex &pv)  {
+  float vertexDdotP(const reco::VertexCompositePtrCandidate &sv, const reco::Vertex &pv) {
     reco::Candidate::Vector p = sv.momentum();
     reco::Candidate::Vector d(sv.vx() - pv.x(), sv.vy() - pv.y(), sv.vz() - pv.z());
     return p.Unit().Dot(d.Unit());
   }
 
   // compute minimum dr between SVs and a candidate (from DeepNTuples, now polymorphic)
-  float mindrsvpfcand(const std::vector<reco::VertexCompositePtrCandidate> & svs,
-                      const reco::Candidate* cand, float mindr) {
-
-    for (unsigned int i0=0; i0<svs.size(); ++i0) {
-
-      float tempdr = reco::deltaR(svs[i0],*cand);
-      if (tempdr<mindr) { mindr = tempdr; }
-
+  float mindrsvpfcand(const std::vector<reco::VertexCompositePtrCandidate> &svs,
+                      const reco::Candidate *cand,
+                      float mindr) {
+    for (unsigned int i0 = 0; i0 < svs.size(); ++i0) {
+      float tempdr = reco::deltaR(svs[i0], *cand);
+      if (tempdr < mindr) {
+        mindr = tempdr;
+      }
     }
     return mindr;
   }
 
   // instantiate template
-  template bool sv_vertex_comparator<reco::VertexCompositePtrCandidate, reco::Vertex>(const reco::VertexCompositePtrCandidate&,
-										      const reco::VertexCompositePtrCandidate&,
-										      const reco::Vertex&);
+  template bool sv_vertex_comparator<reco::VertexCompositePtrCandidate, reco::Vertex>(
+      const reco::VertexCompositePtrCandidate &, const reco::VertexCompositePtrCandidate &, const reco::Vertex &);
 
-  float vtx_ass_from_pfcand(const reco::PFCandidate& pfcand, int pv_ass_quality, const reco::VertexRef & pv) {
+  float vtx_ass_from_pfcand(const reco::PFCandidate &pfcand, int pv_ass_quality, const reco::VertexRef &pv) {
     float vtx_ass = pat::PackedCandidate::PVAssociationQuality(qualityMap[pv_ass_quality]);
-    if (pfcand.trackRef().isNonnull() &&
-        pv->trackWeight(pfcand.trackRef()) > 0.5 &&
-        pv_ass_quality == 7) {
+    if (pfcand.trackRef().isNonnull() && pv->trackWeight(pfcand.trackRef()) > 0.5 && pv_ass_quality == 7) {
       vtx_ass = pat::PackedCandidate::UsedInFitTight;
     }
     return vtx_ass;
   }
 
-  float quality_from_pfcand(const reco::PFCandidate& pfcand) {
-    const auto & pseudo_track =  (pfcand.bestTrack()) ? *pfcand.bestTrack() : reco::Track();
+  float quality_from_pfcand(const reco::PFCandidate &pfcand) {
+    const auto &pseudo_track = (pfcand.bestTrack()) ? *pfcand.bestTrack() : reco::Track();
     // conditions from PackedCandidate producer
     bool highPurity = pfcand.trackRef().isNonnull() && pseudo_track.quality(reco::Track::highPurity);
     // do same bit operations than in PackedCandidate
     uint16_t qualityFlags = 0;
     qualityFlags = (qualityFlags & ~trackHighPurityMask) | ((highPurity << trackHighPurityShift) & trackHighPurityMask);
-    bool isHighPurity = (qualityFlags & trackHighPurityMask)>>trackHighPurityShift;
+    bool isHighPurity = (qualityFlags & trackHighPurityMask) >> trackHighPurityShift;
     // to do as in TrackBase
     uint8_t quality = (1 << reco::TrackBase::loose);
     if (isHighPurity) {
@@ -113,15 +111,14 @@ namespace btagbtvdeep {
     return quality;
   }
 
-  float lost_inner_hits_from_pfcand(const reco::PFCandidate& pfcand) {
-    const auto & pseudo_track =  (pfcand.bestTrack()) ? *pfcand.bestTrack() : reco::Track();
+  float lost_inner_hits_from_pfcand(const reco::PFCandidate &pfcand) {
+    const auto &pseudo_track = (pfcand.bestTrack()) ? *pfcand.bestTrack() : reco::Track();
     // conditions from PackedCandidate producer
     bool highPurity = pfcand.trackRef().isNonnull() && pseudo_track.quality(reco::Track::highPurity);
     // do same bit operations than in PackedCandidate
     uint16_t qualityFlags = 0;
     qualityFlags = (qualityFlags & ~trackHighPurityMask) | ((highPurity << trackHighPurityShift) & trackHighPurityMask);
-    return int16_t((qualityFlags & lostInnerHitsMask)>>lostInnerHitsShift)-1;
+    return int16_t((qualityFlags & lostInnerHitsMask) >> lostInnerHitsShift) - 1;
   }
 
-}
-
+}  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/sorting_modules.cc
+++ b/RecoBTag/FeatureTools/src/sorting_modules.cc
@@ -3,20 +3,21 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include <iostream>
 
-namespace btagbtvdeep{
+namespace btagbtvdeep {
 
-std::vector<std::size_t> invertSortingVector(const std::vector<SortingClass<std::size_t> > & in){
-    std::size_t max=0;
-    for(const auto& s:in){
-        if(s.get()>max)max=s.get();
+  std::vector<std::size_t> invertSortingVector(const std::vector<SortingClass<std::size_t> >& in) {
+    std::size_t max = 0;
+    for (const auto& s : in) {
+      if (s.get() > max)
+        max = s.get();
     }
 
-    std::vector<std::size_t> out(max+1,0);
-    for(std::size_t i=0;i<in.size();i++){
-        out.at(in[i].get())=i;
+    std::vector<std::size_t> out(max + 1, 0);
+    for (std::size_t i = 0; i < in.size(); i++) {
+      out.at(in[i].get()) = i;
     }
 
     return out;
-}
+  }
 
-}
+}  // namespace btagbtvdeep

--- a/RecoBTag/TensorFlow/interface/tensor_fillers.h
+++ b/RecoBTag/TensorFlow/interface/tensor_fillers.h
@@ -14,58 +14,53 @@ namespace btagbtvdeep {
   // the memory, so it is most performant to get the pointer to the first
   // value and use pointer arithmetic to iterate through the next pointers.
 
-  void jet_tensor_filler(tensorflow::Tensor & tensor,
+  void jet_tensor_filler(tensorflow::Tensor& tensor,
                          std::size_t jet_n,
-                         const btagbtvdeep::DeepFlavourFeatures & features) ;
-                         
-  void jet4vec_tensor_filler(tensorflow::Tensor & tensor,
-                         std::size_t jet_n,
-                         const btagbtvdeep::DeepFlavourFeatures & features) ;                        
+                         const btagbtvdeep::DeepFlavourFeatures& features);
 
-  void db_tensor_filler(tensorflow::Tensor & tensor,
-                         std::size_t jet_n,
-                         const btagbtvdeep::DeepDoubleXFeatures & features) ;
-  
-  void c_pf_tensor_filler(tensorflow::Tensor & tensor,
+  void jet4vec_tensor_filler(tensorflow::Tensor& tensor,
+                             std::size_t jet_n,
+                             const btagbtvdeep::DeepFlavourFeatures& features);
+
+  void db_tensor_filler(tensorflow::Tensor& tensor,
+                        std::size_t jet_n,
+                        const btagbtvdeep::DeepDoubleXFeatures& features);
+
+  void c_pf_tensor_filler(tensorflow::Tensor& tensor,
                           std::size_t jet_n,
                           std::size_t c_pf_n,
-                          const btagbtvdeep::ChargedCandidateFeatures & c_pf_features);
+                          const btagbtvdeep::ChargedCandidateFeatures& c_pf_features);
 
-  
-  void c_pf_reduced_tensor_filler(tensorflow::Tensor & tensor,
-                          std::size_t jet_n,
-                          std::size_t c_pf_n,
-                          const btagbtvdeep::ChargedCandidateFeatures & c_pf_features);
+  void c_pf_reduced_tensor_filler(tensorflow::Tensor& tensor,
+                                  std::size_t jet_n,
+                                  std::size_t c_pf_n,
+                                  const btagbtvdeep::ChargedCandidateFeatures& c_pf_features);
 
-
-  void n_pf_tensor_filler(tensorflow::Tensor & tensor,
+  void n_pf_tensor_filler(tensorflow::Tensor& tensor,
                           std::size_t jet_n,
                           std::size_t n_pf_n,
-                          const btagbtvdeep::NeutralCandidateFeatures & n_pf_features) ;
+                          const btagbtvdeep::NeutralCandidateFeatures& n_pf_features);
 
+  void sv_tensor_filler(tensorflow::Tensor& tensor,
+                        std::size_t jet_n,
+                        std::size_t sv_n,
+                        const btagbtvdeep::SecondaryVertexFeatures& sv_features);
 
-  void sv_tensor_filler(tensorflow::Tensor & tensor,
-                          std::size_t jet_n,
-                          std::size_t sv_n,
-                          const btagbtvdeep::SecondaryVertexFeatures & sv_features) ;
+  void sv_reduced_tensor_filler(tensorflow::Tensor& tensor,
+                                std::size_t jet_n,
+                                std::size_t sv_n,
+                                const btagbtvdeep::SecondaryVertexFeatures& sv_features);
 
-  
-  void sv_reduced_tensor_filler(tensorflow::Tensor & tensor,
-                          std::size_t jet_n,
-                          std::size_t sv_n,
-                          const btagbtvdeep::SecondaryVertexFeatures & sv_features) ;
-
-  
-  void seed_tensor_filler(tensorflow::Tensor & tensor,
+  void seed_tensor_filler(tensorflow::Tensor& tensor,
                           std::size_t jet_n,
                           std::size_t seed_n,
-                          const btagbtvdeep::SeedingTrackFeatures & seed_features);
+                          const btagbtvdeep::SeedingTrackFeatures& seed_features);
 
-  void neighbourTracks_tensor_filler(tensorflow::Tensor & tensor,
-                          std::size_t jet_n,
-                          std::size_t seed_n,
-                          const btagbtvdeep::SeedingTrackFeatures & seed_features);
+  void neighbourTracks_tensor_filler(tensorflow::Tensor& tensor,
+                                     std::size_t jet_n,
+                                     std::size_t seed_n,
+                                     const btagbtvdeep::SeedingTrackFeatures& seed_features);
 
-}
+}  // namespace btagbtvdeep
 
 #endif

--- a/RecoBTag/TensorFlow/plugins/DeepDoubleXTFJetTagsProducer.cc
+++ b/RecoBTag/TensorFlow/plugins/DeepDoubleXTFJetTagsProducer.cc
@@ -27,64 +27,55 @@
 // is protected via std::atomic, which should not affect the performance as it is only accessed in
 // the module constructor and not in the actual produce loop.
 struct DeepDoubleXTFCache {
-  DeepDoubleXTFCache() : graphDef(nullptr) {
-  }
+  DeepDoubleXTFCache() : graphDef(nullptr) {}
 
   std::atomic<tensorflow::GraphDef*> graphDef;
 };
 
 class DeepDoubleXTFJetTagsProducer : public edm::stream::EDProducer<edm::GlobalCache<DeepDoubleXTFCache>> {
+public:
+  explicit DeepDoubleXTFJetTagsProducer(const edm::ParameterSet&, const DeepDoubleXTFCache*);
+  ~DeepDoubleXTFJetTagsProducer() override;
 
-  public:
-    explicit DeepDoubleXTFJetTagsProducer(const edm::ParameterSet&, const DeepDoubleXTFCache*);
-    ~DeepDoubleXTFJetTagsProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
-    static void fillDescriptions(edm::ConfigurationDescriptions&);
+  static std::unique_ptr<DeepDoubleXTFCache> initializeGlobalCache(const edm::ParameterSet&);
+  static void globalEndJob(const DeepDoubleXTFCache*);
 
-    static std::unique_ptr<DeepDoubleXTFCache> initializeGlobalCache(const edm::ParameterSet&);
-    static void globalEndJob(const DeepDoubleXTFCache*);
+  enum InputIndexes { kGlobal = 0, kChargedCandidates = 1, kVertices = 2 };
 
-    enum InputIndexes {
-      kGlobal = 0,
-      kChargedCandidates = 1,
-      kVertices = 2
-    };
+  enum OutputIndexes { kJetFlavour = 0 };
 
-    enum OutputIndexes {
-      kJetFlavour = 0
-    };
+private:
+  typedef std::vector<reco::DeepDoubleXTagInfo> TagInfoCollection;
+  typedef reco::JetTagCollection JetTagCollection;
 
-  private:
-    typedef std::vector<reco::DeepDoubleXTagInfo> TagInfoCollection;
-    typedef reco::JetTagCollection JetTagCollection;
+  void beginStream(edm::StreamID) override {}
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override {}
 
-    void beginStream(edm::StreamID) override {}
-    void produce(edm::Event&, const edm::EventSetup&) override;
-    void endStream() override {}
+  const edm::EDGetTokenT<TagInfoCollection> src_;
+  std::vector<std::pair<std::string, std::vector<unsigned int>>> flav_pairs_;
+  std::vector<std::string> input_names_;
+  std::vector<std::string> output_names_;
+  std::vector<std::string> lp_names_;
 
-    const edm::EDGetTokenT< TagInfoCollection > src_;
-    std::vector<std::pair<std::string,std::vector<unsigned int>>> flav_pairs_;
-    std::vector<std::string> input_names_;
-    std::vector<std::string> output_names_;
-    std::vector<std::string> lp_names_;
-
-    // session for TF evaluation
-    tensorflow::Session* session_;
-    // vector of learning phase tensors, i.e., boolean scalar tensors pointing to false
-    std::vector<tensorflow::Tensor> lp_tensors_;
-    // flag to evaluate model batch or jet by jet
-    bool batch_eval_;
+  // session for TF evaluation
+  tensorflow::Session* session_;
+  // vector of learning phase tensors, i.e., boolean scalar tensors pointing to false
+  std::vector<tensorflow::Tensor> lp_tensors_;
+  // flag to evaluate model batch or jet by jet
+  bool batch_eval_;
 };
 
 DeepDoubleXTFJetTagsProducer::DeepDoubleXTFJetTagsProducer(const edm::ParameterSet& iConfig,
-  const DeepDoubleXTFCache* cache) :
-  src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-  input_names_(iConfig.getParameter<std::vector<std::string>>("input_names")),
-  output_names_(iConfig.getParameter<std::vector<std::string>>("output_names")),
-  lp_names_(iConfig.getParameter<std::vector<std::string>>("lp_names")),
-  session_(nullptr),
-  batch_eval_(iConfig.getParameter<bool>("batch_eval"))
-{
+                                                           const DeepDoubleXTFCache* cache)
+    : src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      input_names_(iConfig.getParameter<std::vector<std::string>>("input_names")),
+      output_names_(iConfig.getParameter<std::vector<std::string>>("output_names")),
+      lp_names_(iConfig.getParameter<std::vector<std::string>>("lp_names")),
+      session_(nullptr),
+      batch_eval_(iConfig.getParameter<bool>("batch_eval")) {
   // get threading config and build session options
   size_t nThreads = iConfig.getParameter<unsigned int>("nThreads");
   std::string singleThreadPool = iConfig.getParameter<std::string>("singleThreadPool");
@@ -95,14 +86,13 @@ DeepDoubleXTFJetTagsProducer::DeepDoubleXTFJetTagsProducer(const edm::ParameterS
   session_ = tensorflow::createSession(cache->graphDef, sessionOptions);
 
   // get output names from flav_table
-  const auto & flav_pset = iConfig.getParameter<edm::ParameterSet>("flav_table");
+  const auto& flav_pset = iConfig.getParameter<edm::ParameterSet>("flav_table");
   for (const auto flav_pair : flav_pset.tbl()) {
-    const auto & flav_name = flav_pair.first;
-    flav_pairs_.emplace_back(flav_name,
-                             flav_pset.getParameter<std::vector<unsigned int>>(flav_name));
+    const auto& flav_name = flav_pair.first;
+    flav_pairs_.emplace_back(flav_name, flav_pset.getParameter<std::vector<unsigned int>>(flav_name));
   }
 
-  for (const auto & flav_pair : flav_pairs_) {
+  for (const auto& flav_pair : flav_pairs_) {
     produces<JetTagCollection>(flav_pair.first);
   }
 
@@ -116,32 +106,26 @@ DeepDoubleXTFJetTagsProducer::DeepDoubleXTFJetTagsProducer(const edm::ParameterS
   }
 }
 
-DeepDoubleXTFJetTagsProducer::~DeepDoubleXTFJetTagsProducer()
-{
+DeepDoubleXTFJetTagsProducer::~DeepDoubleXTFJetTagsProducer() {
   // close and delete the session
   if (session_ != nullptr) {
     tensorflow::closeSession(session_);
   }
 }
 
-void DeepDoubleXTFJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
-
+void DeepDoubleXTFJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfDeepDoubleBvLJetTags
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("pfDeepDoubleXTagInfos"));
-  desc.add<std::vector<std::string>>("input_names", 
-    { "input_1", "input_2", "input_3" });
-  desc.add<std::vector<std::string>>("lp_names",
-    { "db_input_batchnorm/keras_learning_phase" });
-  desc.add<std::vector<std::string>>("output_names",
-    { "ID_pred/Softmax" });
+  desc.add<std::vector<std::string>>("input_names", {"input_1", "input_2", "input_3"});
+  desc.add<std::vector<std::string>>("lp_names", {"db_input_batchnorm/keras_learning_phase"});
+  desc.add<std::vector<std::string>>("output_names", {"ID_pred/Softmax"});
 
   desc.add<bool>("batch_eval", false);
 
   desc.add<unsigned int>("nThreads", 1);
   desc.add<std::string>("singleThreadPool", "no_threads");
-	
+
   edm::ParameterSetDescription psBvL;
   psBvL.add<std::vector<unsigned int>>("probQCD", {0});
   psBvL.add<std::vector<unsigned int>>("probHbb", {1});
@@ -158,31 +142,29 @@ void DeepDoubleXTFJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptio
   using PDFIP = edm::ParameterDescription<edm::FileInPath>;
   using PDPSD = edm::ParameterDescription<edm::ParameterSetDescription>;
   using PDCases = edm::ParameterDescriptionCases<std::string>;
-  auto flavorCases = [&](){ return
-    "BvL" >> (PDPSD("flav_table", psBvL, true) and 
-              PDFIP("graph_path",  FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDB.pb"), true) ) or
-    "CvL" >> (PDPSD("flav_table", psCvL, true) and 
-              PDFIP("graph_path",  FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDC.pb"), true) ) or
-    "CvB" >> (PDPSD("flav_table", psCvB, true) and 
-              PDFIP("graph_path",  FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDCvB.pb"), true)); 
+  auto flavorCases = [&]() {
+    return "BvL" >> (PDPSD("flav_table", psBvL, true) and
+                     PDFIP("graph_path", FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDB.pb"), true)) or
+           "CvL" >> (PDPSD("flav_table", psCvL, true) and
+                     PDFIP("graph_path", FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDC.pb"), true)) or
+           "CvB" >> (PDPSD("flav_table", psCvB, true) and
+                     PDFIP("graph_path", FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDCvB.pb"), true));
   };
   auto descBvL(desc);
-  descBvL.ifValue( edm::ParameterDescription<std::string>("flavor", "BvL", true), flavorCases());
+  descBvL.ifValue(edm::ParameterDescription<std::string>("flavor", "BvL", true), flavorCases());
   descriptions.add("pfDeepDoubleBvLJetTags", descBvL);
 
   auto descCvL(desc);
-  descCvL.ifValue( edm::ParameterDescription<std::string>("flavor", "CvL", true), flavorCases());
+  descCvL.ifValue(edm::ParameterDescription<std::string>("flavor", "CvL", true), flavorCases());
   descriptions.add("pfDeepDoubleCvLJetTags", descCvL);
 
   auto descCvB(desc);
-  descCvB.ifValue( edm::ParameterDescription<std::string>("flavor", "CvB", true), flavorCases());
+  descCvB.ifValue(edm::ParameterDescription<std::string>("flavor", "CvB", true), flavorCases());
   descriptions.add("pfDeepDoubleCvBJetTags", descCvB);
-
 }
 
 std::unique_ptr<DeepDoubleXTFCache> DeepDoubleXTFJetTagsProducer::initializeGlobalCache(
-  const edm::ParameterSet& iConfig)
-{
+    const edm::ParameterSet& iConfig) {
   // set the tensorflow log level to error
   tensorflow::setLogging("3");
 
@@ -196,46 +178,43 @@ std::unique_ptr<DeepDoubleXTFCache> DeepDoubleXTFJetTagsProducer::initializeGlob
   return std::unique_ptr<DeepDoubleXTFCache>(cache);
 }
 
-void DeepDoubleXTFJetTagsProducer::globalEndJob(const DeepDoubleXTFCache* cache)
-{
+void DeepDoubleXTFJetTagsProducer::globalEndJob(const DeepDoubleXTFCache* cache) {
   if (cache->graphDef != nullptr) {
     delete cache->graphDef;
   }
 }
 
-void DeepDoubleXTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  
+void DeepDoubleXTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<TagInfoCollection> tag_infos;
   iEvent.getByToken(src_, tag_infos);
-  
+
   // initialize output collection
   std::vector<std::unique_ptr<JetTagCollection>> output_tags;
-  for (std::size_t i=0; i < flav_pairs_.size(); i++) {
+  for (std::size_t i = 0; i < flav_pairs_.size(); i++) {
     if (!tag_infos->empty()) {
       auto jet_ref = tag_infos->begin()->jet();
-      output_tags.emplace_back(std::make_unique<JetTagCollection>(
-            edm::makeRefToBaseProdFrom(jet_ref, iEvent)));
+      output_tags.emplace_back(std::make_unique<JetTagCollection>(edm::makeRefToBaseProdFrom(jet_ref, iEvent)));
     } else {
       output_tags.emplace_back(std::make_unique<JetTagCollection>());
     }
   }
-  
-  // count jets to actually run inference on   
+
+  // count jets to actually run inference on
   int64_t n_jets = 0;
-  for (std::size_t i=0; i < tag_infos->size(); i++){
-    const auto & features = tag_infos->at(i).features();
-    if (!features.empty()) n_jets += 1 ;
+  for (std::size_t i = 0; i < tag_infos->size(); i++) {
+    const auto& features = tag_infos->at(i).features();
+    if (!features.empty())
+      n_jets += 1;
   }
   // count all jets to generate output_tags for each and set to default (-1)
   const int64_t n_jets_all = tag_infos->size();
   // either all jets or one per batch for the time being
   const int64_t n_batch_jets = batch_eval_ ? n_jets_all : 1;
-  
-  std::vector<tensorflow::TensorShape> input_sizes {
-    {n_batch_jets, 1, 27},     // input_1 - global double-b features
-    {n_batch_jets, 60, 8},     // input_2 - charged pf
-    {n_batch_jets, 5, 2},      // input_3 - vertices 
+
+  std::vector<tensorflow::TensorShape> input_sizes{
+      {n_batch_jets, 1, 27},  // input_1 - global double-b features
+      {n_batch_jets, 60, 8},  // input_2 - charged pf
+      {n_batch_jets, 5, 2},   // input_3 - vertices
   };
 
   // create a list of named tensors, i.e. a vector of (string, Tensor) pairs, with proper size to
@@ -245,85 +224,80 @@ void DeepDoubleXTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventS
   input_tensors.resize(input_sizes.size() + lp_tensors_.size());
 
   // add actual input tensors that hold physics information
-  for (std::size_t i=0; i < input_sizes.size(); i++) {
-    input_tensors[i] = tensorflow::NamedTensor(
-      input_names_[i], tensorflow::Tensor(tensorflow::DT_FLOAT, input_sizes.at(i)));
+  for (std::size_t i = 0; i < input_sizes.size(); i++) {
+    input_tensors[i] =
+        tensorflow::NamedTensor(input_names_[i], tensorflow::Tensor(tensorflow::DT_FLOAT, input_sizes.at(i)));
   }
 
   // add learning-phase tensors behind them
-  for (std::size_t i=0; i < lp_tensors_.size(); i++) {
+  for (std::size_t i = 0; i < lp_tensors_.size(); i++) {
     input_tensors[input_sizes.size() + i] = tensorflow::NamedTensor(lp_names_[i], lp_tensors_[i]);
   }
-  
-  std::size_t n_batches = n_jets_all/n_batch_jets; // either 1 or n_jets
-  for (std::size_t batch_n=0; batch_n < n_batches; batch_n++) {
+
+  std::size_t n_batches = n_jets_all / n_batch_jets;  // either 1 or n_jets
+  for (std::size_t batch_n = 0; batch_n < n_batches; batch_n++) {
     // tensors have to be zeroed before filling per batch
-    for (std::size_t i=0; i < input_sizes.size(); i++) {
+    for (std::size_t i = 0; i < input_sizes.size(); i++) {
       input_tensors[i].second.flat<float>().setZero();
     }
     // don't run batch unless filled
     bool run_this_batch = false;
     // fill values of the input tensors
-    for (std::size_t jet_bn=0; jet_bn < (std::size_t) n_batch_jets; jet_bn++) {
-
+    for (std::size_t jet_bn = 0; jet_bn < (std::size_t)n_batch_jets; jet_bn++) {
       // global jet index (jet_bn is the jet batch index)
-      std::size_t jet_n = batch_n*n_batch_jets + jet_bn;
+      std::size_t jet_n = batch_n * n_batch_jets + jet_bn;
       // only fill if features not empty
-      const auto & features = tag_infos->at(jet_n).features();
-      if (features.empty()) continue ;
+      const auto& features = tag_infos->at(jet_n).features();
+      if (features.empty())
+        continue;
       // if at least one jet has features, run inferences
       run_this_batch = true;
       // jet and other global features
       db_tensor_filler(input_tensors.at(kGlobal).second, jet_bn, features);
 
       // c_pf candidates
-      auto max_c_pf_n = std::min(features.c_pf_features.size(),
-        (std::size_t) input_sizes.at(kChargedCandidates).dim_size(1));
-      for (std::size_t c_pf_n=0; c_pf_n < max_c_pf_n; c_pf_n++) {
-        const auto & c_pf_features = features.c_pf_features.at(c_pf_n);
-        c_pf_reduced_tensor_filler(input_tensors.at(kChargedCandidates).second,
-                           jet_bn, c_pf_n, c_pf_features);
+      auto max_c_pf_n =
+          std::min(features.c_pf_features.size(), (std::size_t)input_sizes.at(kChargedCandidates).dim_size(1));
+      for (std::size_t c_pf_n = 0; c_pf_n < max_c_pf_n; c_pf_n++) {
+        const auto& c_pf_features = features.c_pf_features.at(c_pf_n);
+        c_pf_reduced_tensor_filler(input_tensors.at(kChargedCandidates).second, jet_bn, c_pf_n, c_pf_features);
       }
-      
+
       // sv candidates
-      auto max_sv_n = std::min(features.sv_features.size(),
-        (std::size_t) input_sizes.at(kVertices).dim_size(1));
-      for (std::size_t sv_n=0; sv_n < max_sv_n; sv_n++) {
-        const auto & sv_features = features.sv_features.at(sv_n);
-        sv_reduced_tensor_filler(input_tensors.at(kVertices).second,
-                         jet_bn, sv_n, sv_features);
+      auto max_sv_n = std::min(features.sv_features.size(), (std::size_t)input_sizes.at(kVertices).dim_size(1));
+      for (std::size_t sv_n = 0; sv_n < max_sv_n; sv_n++) {
+        const auto& sv_features = features.sv_features.at(sv_n);
+        sv_reduced_tensor_filler(input_tensors.at(kVertices).second, jet_bn, sv_n, sv_features);
       }
-      
     }
     // run the session
     std::vector<tensorflow::Tensor> outputs;
-    if (run_this_batch){
-    tensorflow::run(session_, input_tensors, output_names_, &outputs);
-    } 
+    if (run_this_batch) {
+      tensorflow::run(session_, input_tensors, output_names_, &outputs);
+    }
     // set output values for flavour probs
-    for (std::size_t jet_bn=0; jet_bn < (std::size_t) n_batch_jets; jet_bn++) {
-
+    for (std::size_t jet_bn = 0; jet_bn < (std::size_t)n_batch_jets; jet_bn++) {
       // global jet index (jet_bn is the jet batch index)
-      std::size_t jet_n = batch_n*n_batch_jets + jet_bn;
+      std::size_t jet_n = batch_n * n_batch_jets + jet_bn;
 
-      const auto & features = tag_infos->at(jet_n).features();     
-      const auto & jet_ref = tag_infos->at(jet_n).jet();
-      for (std::size_t flav_n=0; flav_n < flav_pairs_.size(); flav_n++) {
-        const auto & flav_pair = flav_pairs_.at(flav_n);
+      const auto& features = tag_infos->at(jet_n).features();
+      const auto& jet_ref = tag_infos->at(jet_n).jet();
+      for (std::size_t flav_n = 0; flav_n < flav_pairs_.size(); flav_n++) {
+        const auto& flav_pair = flav_pairs_.at(flav_n);
         float o_sum = 0.;
         if (!features.empty()) {
-          for (const unsigned int & ind : flav_pair.second) {
+          for (const unsigned int& ind : flav_pair.second) {
             o_sum += outputs.at(kJetFlavour).matrix<float>()(jet_bn, ind);
           }
           (*(output_tags.at(flav_n)))[jet_ref] = o_sum;
         } else {
-          (*(output_tags.at(flav_n)))[jet_ref] = -1.; 
+          (*(output_tags.at(flav_n)))[jet_ref] = -1.;
         }
       }
-    }  
+    }
   }
 
-  for (std::size_t i=0; i < flav_pairs_.size(); i++) {
+  for (std::size_t i = 0; i < flav_pairs_.size(); i++) {
     iEvent.put(std::move(output_tags[i]), flav_pairs_.at(i).first);
   }
 }

--- a/RecoBTag/TensorFlow/plugins/DeepFlavourTFJetTagsProducer.cc
+++ b/RecoBTag/TensorFlow/plugins/DeepFlavourTFJetTagsProducer.cc
@@ -27,67 +27,58 @@
 // is protected via std::atomic, which should not affect the performance as it is only accessed in
 // the module constructor and not in the actual produce loop.
 struct DeepFlavourTFCache {
-  DeepFlavourTFCache() : graphDef(nullptr) {
-  }
+  DeepFlavourTFCache() : graphDef(nullptr) {}
 
   std::atomic<tensorflow::GraphDef*> graphDef;
 };
 
 class DeepFlavourTFJetTagsProducer : public edm::stream::EDProducer<edm::GlobalCache<DeepFlavourTFCache>> {
+public:
+  explicit DeepFlavourTFJetTagsProducer(const edm::ParameterSet&, const DeepFlavourTFCache*);
+  ~DeepFlavourTFJetTagsProducer() override;
 
-  public:
-    explicit DeepFlavourTFJetTagsProducer(const edm::ParameterSet&, const DeepFlavourTFCache*);
-    ~DeepFlavourTFJetTagsProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
-    static void fillDescriptions(edm::ConfigurationDescriptions&);
+  static std::unique_ptr<DeepFlavourTFCache> initializeGlobalCache(const edm::ParameterSet&);
+  static void globalEndJob(const DeepFlavourTFCache*);
 
-    static std::unique_ptr<DeepFlavourTFCache> initializeGlobalCache(const edm::ParameterSet&);
-    static void globalEndJob(const DeepFlavourTFCache*);
+  enum InputIndexes { kGlobal = 0, kChargedCandidates = 1, kNeutralCandidates = 2, kVertices = 3, kJetPt = 4 };
 
-    enum InputIndexes {
-      kGlobal = 0,
-      kChargedCandidates = 1,
-      kNeutralCandidates = 2,
-      kVertices = 3,
-      kJetPt = 4
-    };
+  enum OutputIndexes {
+    kJetFlavour = 0,
+    kRegJetPt = 1,
+  };
 
-    enum OutputIndexes {
-      kJetFlavour = 0,
-      kRegJetPt = 1,
-    };
+private:
+  typedef std::vector<reco::DeepFlavourTagInfo> TagInfoCollection;
+  typedef reco::JetTagCollection JetTagCollection;
 
-  private:
-    typedef std::vector<reco::DeepFlavourTagInfo> TagInfoCollection;
-    typedef reco::JetTagCollection JetTagCollection;
+  void beginStream(edm::StreamID) override {}
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override {}
 
-    void beginStream(edm::StreamID) override {}
-    void produce(edm::Event&, const edm::EventSetup&) override;
-    void endStream() override {}
+  const edm::EDGetTokenT<TagInfoCollection> src_;
+  std::vector<std::pair<std::string, std::vector<unsigned int>>> flav_pairs_;
+  std::vector<std::string> input_names_;
+  std::vector<std::string> output_names_;
+  std::vector<std::string> lp_names_;
 
-    const edm::EDGetTokenT< TagInfoCollection > src_;
-    std::vector<std::pair<std::string,std::vector<unsigned int>>> flav_pairs_;
-    std::vector<std::string> input_names_;
-    std::vector<std::string> output_names_;
-    std::vector<std::string> lp_names_;
-
-    // session for TF evaluation
-    tensorflow::Session* session_;
-    // vector of learning phase tensors, i.e., boolean scalar tensors pointing to false
-    std::vector<tensorflow::Tensor> lp_tensors_;
-    // flag to evaluate model batch or jet by jet
-    bool batch_eval_;
+  // session for TF evaluation
+  tensorflow::Session* session_;
+  // vector of learning phase tensors, i.e., boolean scalar tensors pointing to false
+  std::vector<tensorflow::Tensor> lp_tensors_;
+  // flag to evaluate model batch or jet by jet
+  bool batch_eval_;
 };
 
 DeepFlavourTFJetTagsProducer::DeepFlavourTFJetTagsProducer(const edm::ParameterSet& iConfig,
-  const DeepFlavourTFCache* cache) :
-  src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-  input_names_(iConfig.getParameter<std::vector<std::string>>("input_names")),
-  output_names_(iConfig.getParameter<std::vector<std::string>>("output_names")),
-  lp_names_(iConfig.getParameter<std::vector<std::string>>("lp_names")),
-  session_(nullptr),
-  batch_eval_(iConfig.getParameter<bool>("batch_eval"))
-{
+                                                           const DeepFlavourTFCache* cache)
+    : src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      input_names_(iConfig.getParameter<std::vector<std::string>>("input_names")),
+      output_names_(iConfig.getParameter<std::vector<std::string>>("output_names")),
+      lp_names_(iConfig.getParameter<std::vector<std::string>>("lp_names")),
+      session_(nullptr),
+      batch_eval_(iConfig.getParameter<bool>("batch_eval")) {
   // get threading config and build session options
   size_t nThreads = iConfig.getParameter<unsigned int>("nThreads");
   std::string singleThreadPool = iConfig.getParameter<std::string>("singleThreadPool");
@@ -98,14 +89,13 @@ DeepFlavourTFJetTagsProducer::DeepFlavourTFJetTagsProducer(const edm::ParameterS
   session_ = tensorflow::createSession(cache->graphDef, sessionOptions);
 
   // get output names from flav_table
-  const auto & flav_pset = iConfig.getParameter<edm::ParameterSet>("flav_table");
+  const auto& flav_pset = iConfig.getParameter<edm::ParameterSet>("flav_table");
   for (const auto flav_pair : flav_pset.tbl()) {
-    const auto & flav_name = flav_pair.first;
-    flav_pairs_.emplace_back(flav_name,
-                             flav_pset.getParameter<std::vector<unsigned int>>(flav_name));
+    const auto& flav_name = flav_pair.first;
+    flav_pairs_.emplace_back(flav_name, flav_pset.getParameter<std::vector<unsigned int>>(flav_name));
   }
 
-  for (const auto & flav_pair : flav_pairs_) {
+  for (const auto& flav_pair : flav_pairs_) {
     produces<JetTagCollection>(flav_pair.first);
   }
 
@@ -119,28 +109,22 @@ DeepFlavourTFJetTagsProducer::DeepFlavourTFJetTagsProducer(const edm::ParameterS
   }
 }
 
-DeepFlavourTFJetTagsProducer::~DeepFlavourTFJetTagsProducer()
-{
+DeepFlavourTFJetTagsProducer::~DeepFlavourTFJetTagsProducer() {
   // close and delete the session
   if (session_ != nullptr) {
     tensorflow::closeSession(session_);
   }
 }
 
-void DeepFlavourTFJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
-
+void DeepFlavourTFJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfDeepFlavourJetTags
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("pfDeepFlavourTagInfos"));
-  desc.add<std::vector<std::string>>("input_names", 
-    { "input_1", "input_2", "input_3", "input_4", "input_5" });
+  desc.add<std::vector<std::string>>("input_names", {"input_1", "input_2", "input_3", "input_4", "input_5"});
   desc.add<edm::FileInPath>("graph_path",
-    edm::FileInPath("RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb"));
-  desc.add<std::vector<std::string>>("lp_names",
-    { "cpf_input_batchnorm/keras_learning_phase" });
-  desc.add<std::vector<std::string>>("output_names",
-    { "ID_pred/Softmax", "regression_pred/BiasAdd" });
+                            edm::FileInPath("RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb"));
+  desc.add<std::vector<std::string>>("lp_names", {"cpf_input_batchnorm/keras_learning_phase"});
+  desc.add<std::vector<std::string>>("output_names", {"ID_pred/Softmax", "regression_pred/BiasAdd"});
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::vector<unsigned int>>("probb", {0});
@@ -161,8 +145,7 @@ void DeepFlavourTFJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptio
 }
 
 std::unique_ptr<DeepFlavourTFCache> DeepFlavourTFJetTagsProducer::initializeGlobalCache(
-  const edm::ParameterSet& iConfig)
-{
+    const edm::ParameterSet& iConfig) {
   // set the tensorflow log level to error
   tensorflow::setLogging("3");
 
@@ -176,26 +159,22 @@ std::unique_ptr<DeepFlavourTFCache> DeepFlavourTFJetTagsProducer::initializeGlob
   return std::unique_ptr<DeepFlavourTFCache>(cache);
 }
 
-void DeepFlavourTFJetTagsProducer::globalEndJob(const DeepFlavourTFCache* cache)
-{
+void DeepFlavourTFJetTagsProducer::globalEndJob(const DeepFlavourTFCache* cache) {
   if (cache->graphDef != nullptr) {
     delete cache->graphDef;
   }
 }
 
-void DeepFlavourTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
+void DeepFlavourTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<TagInfoCollection> tag_infos;
   iEvent.getByToken(src_, tag_infos);
 
   // initialize output collection
   std::vector<std::unique_ptr<JetTagCollection>> output_tags;
-  for (std::size_t i=0; i < flav_pairs_.size(); i++) {
+  for (std::size_t i = 0; i < flav_pairs_.size(); i++) {
     if (!tag_infos->empty()) {
       auto jet_ref = tag_infos->begin()->jet();
-      output_tags.emplace_back(std::make_unique<JetTagCollection>(
-            edm::makeRefToBaseProdFrom(jet_ref, iEvent)));
+      output_tags.emplace_back(std::make_unique<JetTagCollection>(edm::makeRefToBaseProdFrom(jet_ref, iEvent)));
     } else {
       output_tags.emplace_back(std::make_unique<JetTagCollection>());
     }
@@ -203,14 +182,14 @@ void DeepFlavourTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventS
 
   const int64_t n_jets = tag_infos->size();
   // either all jets or one per batch for the time being
-  const int64_t n_batch_jets = batch_eval_ ?  n_jets : 1;
+  const int64_t n_batch_jets = batch_eval_ ? n_jets : 1;
 
-  std::vector<tensorflow::TensorShape> input_sizes {
-    {n_batch_jets, 15},         // input_1 - global jet features
-    {n_batch_jets, 25, 16},     // input_2 - charged pf
-    {n_batch_jets, 25, 6},      // input_3 - neutral pf
-    {n_batch_jets, 4, 12},      // input_4 - vertices 
-    {n_batch_jets, 1}           // input_5 - jet pt for reg 
+  std::vector<tensorflow::TensorShape> input_sizes{
+      {n_batch_jets, 15},      // input_1 - global jet features
+      {n_batch_jets, 25, 16},  // input_2 - charged pf
+      {n_batch_jets, 25, 6},   // input_3 - neutral pf
+      {n_batch_jets, 4, 12},   // input_4 - vertices
+      {n_batch_jets, 1}        // input_5 - jet pt for reg
   };
 
   // create a list of named tensors, i.e. a vector of (string, Tensor) pairs, with proper size to
@@ -220,59 +199,53 @@ void DeepFlavourTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventS
   input_tensors.resize(input_sizes.size() + lp_tensors_.size());
 
   // add actual input tensors that hold physics information
-  for (std::size_t i=0; i < input_sizes.size(); i++) {
-    input_tensors[i] = tensorflow::NamedTensor(
-      input_names_[i], tensorflow::Tensor(tensorflow::DT_FLOAT, input_sizes.at(i)));
+  for (std::size_t i = 0; i < input_sizes.size(); i++) {
+    input_tensors[i] =
+        tensorflow::NamedTensor(input_names_[i], tensorflow::Tensor(tensorflow::DT_FLOAT, input_sizes.at(i)));
   }
 
   // add learning-phase tensors behind them
-  for (std::size_t i=0; i < lp_tensors_.size(); i++) {
+  for (std::size_t i = 0; i < lp_tensors_.size(); i++) {
     input_tensors[input_sizes.size() + i] = tensorflow::NamedTensor(lp_names_[i], lp_tensors_[i]);
   }
 
-  std::size_t n_batches = n_jets/n_batch_jets; // either 1 or n_jets
-  for (std::size_t batch_n=0; batch_n < n_batches; batch_n++) {
-
+  std::size_t n_batches = n_jets / n_batch_jets;  // either 1 or n_jets
+  for (std::size_t batch_n = 0; batch_n < n_batches; batch_n++) {
     // tensors have to be zeroed before filling per batch
-    for (std::size_t i=0; i < input_sizes.size(); i++) {
+    for (std::size_t i = 0; i < input_sizes.size(); i++) {
       input_tensors[i].second.flat<float>().setZero();
     }
 
     // fill values of the input tensors
-    for (std::size_t jet_bn=0; jet_bn < (std::size_t) n_batch_jets; jet_bn++) {
-
+    for (std::size_t jet_bn = 0; jet_bn < (std::size_t)n_batch_jets; jet_bn++) {
       // global jet index (jet_bn is the jet batch index)
-      std::size_t jet_n = batch_n*n_batch_jets + jet_bn;
+      std::size_t jet_n = batch_n * n_batch_jets + jet_bn;
 
       // jet and other global features
-      const auto & features = tag_infos->at(jet_n).features();
+      const auto& features = tag_infos->at(jet_n).features();
       jet_tensor_filler(input_tensors.at(kGlobal).second, jet_bn, features);
 
       // c_pf candidates
-      auto max_c_pf_n = std::min(features.c_pf_features.size(),
-        (std::size_t) input_sizes.at(kChargedCandidates).dim_size(1));
-      for (std::size_t c_pf_n=0; c_pf_n < max_c_pf_n; c_pf_n++) {
-        const auto & c_pf_features = features.c_pf_features.at(c_pf_n);
-        c_pf_tensor_filler(input_tensors.at(kChargedCandidates).second,
-                           jet_bn, c_pf_n, c_pf_features);
+      auto max_c_pf_n =
+          std::min(features.c_pf_features.size(), (std::size_t)input_sizes.at(kChargedCandidates).dim_size(1));
+      for (std::size_t c_pf_n = 0; c_pf_n < max_c_pf_n; c_pf_n++) {
+        const auto& c_pf_features = features.c_pf_features.at(c_pf_n);
+        c_pf_tensor_filler(input_tensors.at(kChargedCandidates).second, jet_bn, c_pf_n, c_pf_features);
       }
 
       // n_pf candidates
-      auto max_n_pf_n = std::min(features.n_pf_features.size(),
-        (std::size_t) input_sizes.at(kNeutralCandidates).dim_size(1));
-      for (std::size_t n_pf_n=0; n_pf_n < max_n_pf_n; n_pf_n++) {
-        const auto & n_pf_features = features.n_pf_features.at(n_pf_n);
-        n_pf_tensor_filler(input_tensors.at(kNeutralCandidates).second,
-                           jet_bn, n_pf_n, n_pf_features);
+      auto max_n_pf_n =
+          std::min(features.n_pf_features.size(), (std::size_t)input_sizes.at(kNeutralCandidates).dim_size(1));
+      for (std::size_t n_pf_n = 0; n_pf_n < max_n_pf_n; n_pf_n++) {
+        const auto& n_pf_features = features.n_pf_features.at(n_pf_n);
+        n_pf_tensor_filler(input_tensors.at(kNeutralCandidates).second, jet_bn, n_pf_n, n_pf_features);
       }
 
       // sv candidates
-      auto max_sv_n = std::min(features.sv_features.size(),
-        (std::size_t) input_sizes.at(kVertices).dim_size(1));
-      for (std::size_t sv_n=0; sv_n < max_sv_n; sv_n++) {
-        const auto & sv_features = features.sv_features.at(sv_n);
-        sv_tensor_filler(input_tensors.at(kVertices).second,
-                         jet_bn, sv_n, sv_features);
+      auto max_sv_n = std::min(features.sv_features.size(), (std::size_t)input_sizes.at(kVertices).dim_size(1));
+      for (std::size_t sv_n = 0; sv_n < max_sv_n; sv_n++) {
+        const auto& sv_features = features.sv_features.at(sv_n);
+        sv_tensor_filler(input_tensors.at(kVertices).second, jet_bn, sv_n, sv_features);
       }
 
       // last input: jet pt
@@ -284,16 +257,15 @@ void DeepFlavourTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventS
     tensorflow::run(session_, input_tensors, output_names_, &outputs);
 
     // set output values for flavour probs
-    for (std::size_t jet_bn=0; jet_bn < (std::size_t) n_batch_jets; jet_bn++) {
-
+    for (std::size_t jet_bn = 0; jet_bn < (std::size_t)n_batch_jets; jet_bn++) {
       // global jet index (jet_bn is the jet batch index)
-      std::size_t jet_n = batch_n*n_batch_jets + jet_bn;
+      std::size_t jet_n = batch_n * n_batch_jets + jet_bn;
 
-      const auto & jet_ref = tag_infos->at(jet_n).jet();
-      for (std::size_t flav_n=0; flav_n < flav_pairs_.size(); flav_n++) {
-        const auto & flav_pair = flav_pairs_.at(flav_n);
+      const auto& jet_ref = tag_infos->at(jet_n).jet();
+      for (std::size_t flav_n = 0; flav_n < flav_pairs_.size(); flav_n++) {
+        const auto& flav_pair = flav_pairs_.at(flav_n);
         float o_sum = 0.;
-        for (const unsigned int & ind : flav_pair.second) {
+        for (const unsigned int& ind : flav_pair.second) {
           o_sum += outputs.at(kJetFlavour).matrix<float>()(jet_bn, ind);
         }
         (*(output_tags.at(flav_n)))[jet_ref] = o_sum;
@@ -301,10 +273,9 @@ void DeepFlavourTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventS
     }
   }
 
-  for (std::size_t i=0; i < flav_pairs_.size(); i++) {
+  for (std::size_t i = 0; i < flav_pairs_.size(); i++) {
     iEvent.put(std::move(output_tags[i]), flav_pairs_.at(i).first);
   }
-
 }
 
 //define this as a plug-in

--- a/RecoBTag/TensorFlow/plugins/DeepVertexTFJetTagsProducer.cc
+++ b/RecoBTag/TensorFlow/plugins/DeepVertexTFJetTagsProducer.cc
@@ -18,7 +18,6 @@
 
 #include "RecoBTag/TensorFlow/interface/tensor_fillers.h"
 
-
 // Declaration of the data structure that is hold by the edm::GlobalCache.
 // In TensorFlow, the computational graph is stored in a stateless graph object which can be shared
 // by multiple session instances which handle the initialization of variables related to the graph.
@@ -28,75 +27,69 @@
 // is protected via std::atomic, which should not affect the performance as it is only accessed in
 // the module constructor and not in the actual produce loop.
 struct DeepVertexTFCache {
-  DeepVertexTFCache() : graphDef(nullptr) {
-  }
+  DeepVertexTFCache() : graphDef(nullptr) {}
 
   std::atomic<tensorflow::GraphDef*> graphDef;
 };
 
-
 class DeepVertexTFJetTagsProducer : public edm::stream::EDProducer<edm::GlobalCache<DeepVertexTFCache>> {
+public:
+  explicit DeepVertexTFJetTagsProducer(const edm::ParameterSet&, const DeepVertexTFCache*);
+  ~DeepVertexTFJetTagsProducer() override;
 
-  public:
-    explicit DeepVertexTFJetTagsProducer(const edm::ParameterSet&, const DeepVertexTFCache*);
-    ~DeepVertexTFJetTagsProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
-    static void fillDescriptions(edm::ConfigurationDescriptions&);
+  static std::unique_ptr<DeepVertexTFCache> initializeGlobalCache(const edm::ParameterSet&);
+  static void globalEndJob(const DeepVertexTFCache*);
 
-    static std::unique_ptr<DeepVertexTFCache> initializeGlobalCache(const edm::ParameterSet&);
-    static void globalEndJob(const DeepVertexTFCache*);
+  enum InputIndexes {
+    kGlobal = 0,
+    kSeedingTracks = 1,
+    kNeighbourTracks = 2,
 
-    enum InputIndexes {
-      kGlobal = 0,
-      kSeedingTracks = 1,
-      kNeighbourTracks = 2,
-      
-    };
+  };
 
-    enum OutputIndexes {
-      kJetFlavour = 0,     
-        
-    };
-    
-  private:
-    typedef std::vector<reco::DeepFlavourTagInfo> TagInfoCollection;
-    typedef reco::JetTagCollection JetTagCollection;
+  enum OutputIndexes {
+    kJetFlavour = 0,
 
-    void beginStream(edm::StreamID) override {}
-    void produce(edm::Event&, const edm::EventSetup&) override;
-    void endStream() override {}
+  };
 
-    const edm::EDGetTokenT< TagInfoCollection > src_;
-    std::vector<std::pair<std::string,std::vector<unsigned int>>> flav_pairs_;
-    std::vector<std::string> input_names_;
-    std::vector<std::string> output_names_;
-    std::vector<std::string> lp_names_;
+private:
+  typedef std::vector<reco::DeepFlavourTagInfo> TagInfoCollection;
+  typedef reco::JetTagCollection JetTagCollection;
 
-    // session for TF evaluation
-    tensorflow::Session* session_;
-    // vector of learning phase tensors, i.e., boolean scalar tensors pointing to false
-    std::vector<tensorflow::Tensor> lp_tensors_;
-    // flag to evaluate model batch or jet by jet
-    bool batch_eval_;
-    
-    const double min_jet_pt_;  
-    const double max_jet_eta_;
-    
-    
+  void beginStream(edm::StreamID) override {}
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override {}
+
+  const edm::EDGetTokenT<TagInfoCollection> src_;
+  std::vector<std::pair<std::string, std::vector<unsigned int>>> flav_pairs_;
+  std::vector<std::string> input_names_;
+  std::vector<std::string> output_names_;
+  std::vector<std::string> lp_names_;
+
+  // session for TF evaluation
+  tensorflow::Session* session_;
+  // vector of learning phase tensors, i.e., boolean scalar tensors pointing to false
+  std::vector<tensorflow::Tensor> lp_tensors_;
+  // flag to evaluate model batch or jet by jet
+  bool batch_eval_;
+
+  const double min_jet_pt_;
+  const double max_jet_eta_;
 };
 
-
 DeepVertexTFJetTagsProducer::DeepVertexTFJetTagsProducer(const edm::ParameterSet& iConfig,
-  const DeepVertexTFCache* cache) :
-  src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-  input_names_(iConfig.getParameter<std::vector<std::string>>("input_names")),
-  output_names_(iConfig.getParameter<std::vector<std::string>>("output_names")),
-  lp_names_(iConfig.getParameter<std::vector<std::string>>("lp_names")),
-  session_(nullptr),
-  batch_eval_(iConfig.getParameter<bool>("batch_eval")),
-  min_jet_pt_(iConfig.getParameter<double>("min_jet_pt")),
-  max_jet_eta_(iConfig.getParameter<double>("max_jet_eta"))
-  
+                                                         const DeepVertexTFCache* cache)
+    : src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      input_names_(iConfig.getParameter<std::vector<std::string>>("input_names")),
+      output_names_(iConfig.getParameter<std::vector<std::string>>("output_names")),
+      lp_names_(iConfig.getParameter<std::vector<std::string>>("lp_names")),
+      session_(nullptr),
+      batch_eval_(iConfig.getParameter<bool>("batch_eval")),
+      min_jet_pt_(iConfig.getParameter<double>("min_jet_pt")),
+      max_jet_eta_(iConfig.getParameter<double>("max_jet_eta"))
+
 {
   // get threading config and build session options
   size_t nThreads = iConfig.getParameter<unsigned int>("nThreads");
@@ -108,14 +101,13 @@ DeepVertexTFJetTagsProducer::DeepVertexTFJetTagsProducer(const edm::ParameterSet
   session_ = tensorflow::createSession(cache->graphDef, sessionOptions);
 
   // get output names from flav_table
-  const auto & flav_pset = iConfig.getParameter<edm::ParameterSet>("flav_table");
+  const auto& flav_pset = iConfig.getParameter<edm::ParameterSet>("flav_table");
   for (const auto flav_pair : flav_pset.tbl()) {
-    const auto & flav_name = flav_pair.first;
-    flav_pairs_.emplace_back(flav_name,
-                             flav_pset.getParameter<std::vector<unsigned int>>(flav_name));
+    const auto& flav_name = flav_pair.first;
+    flav_pairs_.emplace_back(flav_name, flav_pset.getParameter<std::vector<unsigned int>>(flav_name));
   }
 
-  for (const auto & flav_pair : flav_pairs_) {
+  for (const auto& flav_pair : flav_pairs_) {
     produces<JetTagCollection>(flav_pair.first);
   }
 
@@ -129,33 +121,39 @@ DeepVertexTFJetTagsProducer::DeepVertexTFJetTagsProducer(const edm::ParameterSet
   }
 }
 
-
-DeepVertexTFJetTagsProducer::~DeepVertexTFJetTagsProducer()
-{
+DeepVertexTFJetTagsProducer::~DeepVertexTFJetTagsProducer() {
   // close and delete the session
   if (session_ != nullptr) {
     tensorflow::closeSession(session_);
   }
 }
 
-
-void DeepVertexTFJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
-
+void DeepVertexTFJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfDeepVertexJetTags
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("pfDeepFlavourTagInfos"));
-  desc.add<std::vector<std::string>>("input_names", 
-    { "input_1", "input_2", "input_3",  "input_4","input_5","input_6","input_7","input_8","input_9","input_10","input_11","input_12" });
-  desc.add<edm::FileInPath>("graph_path",     edm::FileInPath("RecoBTag/Combined/data/DeepVertex/Converted_retraining.pb"));
-  desc.add<std::vector<std::string>>("lp_names",    { });
-  desc.add<std::vector<std::string>>("output_names",     { "output_node0" }); ///SIGMOID
+  desc.add<std::vector<std::string>>("input_names",
+                                     {"input_1",
+                                      "input_2",
+                                      "input_3",
+                                      "input_4",
+                                      "input_5",
+                                      "input_6",
+                                      "input_7",
+                                      "input_8",
+                                      "input_9",
+                                      "input_10",
+                                      "input_11",
+                                      "input_12"});
+  desc.add<edm::FileInPath>("graph_path", edm::FileInPath("RecoBTag/Combined/data/DeepVertex/Converted_retraining.pb"));
+  desc.add<std::vector<std::string>>("lp_names", {});
+  desc.add<std::vector<std::string>>("output_names", {"output_node0"});  ///SIGMOID
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<std::vector<unsigned int>>("probb",   {0});
-    psd0.add<std::vector<unsigned int>>("probc",   {1});
+    psd0.add<std::vector<unsigned int>>("probb", {0});
+    psd0.add<std::vector<unsigned int>>("probc", {1});
     psd0.add<std::vector<unsigned int>>("probuds", {2});
-    psd0.add<std::vector<unsigned int>>("probg",   {3});
+    psd0.add<std::vector<unsigned int>>("probg", {3});
     desc.add<edm::ParameterSetDescription>("flav_table", psd0);
   }
 
@@ -168,9 +166,7 @@ void DeepVertexTFJetTagsProducer::fillDescriptions(edm::ConfigurationDescription
   descriptions.add("pfDeepVertexJetTags", desc);
 }
 
-std::unique_ptr<DeepVertexTFCache> DeepVertexTFJetTagsProducer::initializeGlobalCache(
-  const edm::ParameterSet& iConfig)
-{
+std::unique_ptr<DeepVertexTFCache> DeepVertexTFJetTagsProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {
   // set the tensorflow log level to error
   tensorflow::setLogging("3");
 
@@ -184,146 +180,138 @@ std::unique_ptr<DeepVertexTFCache> DeepVertexTFJetTagsProducer::initializeGlobal
   return std::unique_ptr<DeepVertexTFCache>(cache);
 }
 
-void DeepVertexTFJetTagsProducer::globalEndJob(const DeepVertexTFCache* cache)
-{
+void DeepVertexTFJetTagsProducer::globalEndJob(const DeepVertexTFCache* cache) {
   if (cache->graphDef != nullptr) {
     delete cache->graphDef;
   }
 }
 
-
-void DeepVertexTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void DeepVertexTFJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<TagInfoCollection> tag_infos;
   iEvent.getByToken(src_, tag_infos);
 
   // initialize output collection
   std::vector<std::unique_ptr<JetTagCollection>> output_tags;
-  for (std::size_t i=0; i < flav_pairs_.size(); i++) {
+  for (std::size_t i = 0; i < flav_pairs_.size(); i++) {
     if (!tag_infos->empty()) {
       auto jet_ref = tag_infos->begin()->jet();
-      output_tags.emplace_back(std::make_unique<JetTagCollection>(
-            edm::makeRefToBaseProdFrom(jet_ref, iEvent)));
+      output_tags.emplace_back(std::make_unique<JetTagCollection>(edm::makeRefToBaseProdFrom(jet_ref, iEvent)));
     } else {
       output_tags.emplace_back(std::make_unique<JetTagCollection>());
     }
   }
 
-   //changes wrt to DeepFlavour from here
-   
+  //changes wrt to DeepFlavour from here
+
   const int64_t n_jets = tag_infos->size();
   // either all jets or one per batch for the time being
   const int64_t n_batch_jets = batch_eval_ ? n_jets : 1;
-  
-  std::vector<tensorflow::TensorShape> input_sizes {
-    {n_batch_jets, 4},         // input_1 - global jet features
- 
-    {n_batch_jets, 10, 21},     // input_2 - seeds 
-    {n_batch_jets,20, 36},      // input_3 - neighbours  
-    {n_batch_jets,20, 36},      // input_4 - neighbours  
-    {n_batch_jets,20, 36},      // input_5 - neighbours  
-    {n_batch_jets,20, 36},      // input_6 - neighbours  
-    {n_batch_jets,20, 36},      // input_7 - neighbours  
-    {n_batch_jets,20, 36},      // input_8 - neighbours  
-    {n_batch_jets,20, 36},      // input_9 - neighbours  
-    {n_batch_jets,20, 36},      // input_10 - neighbours  
-    {n_batch_jets,20, 36},      // input_11 - neighbours  
-    {n_batch_jets,20, 36},      // input_12 - neighbours 
-    
+
+  std::vector<tensorflow::TensorShape> input_sizes{
+      {n_batch_jets, 4},  // input_1 - global jet features
+
+      {n_batch_jets, 10, 21},  // input_2 - seeds
+      {n_batch_jets, 20, 36},  // input_3 - neighbours
+      {n_batch_jets, 20, 36},  // input_4 - neighbours
+      {n_batch_jets, 20, 36},  // input_5 - neighbours
+      {n_batch_jets, 20, 36},  // input_6 - neighbours
+      {n_batch_jets, 20, 36},  // input_7 - neighbours
+      {n_batch_jets, 20, 36},  // input_8 - neighbours
+      {n_batch_jets, 20, 36},  // input_9 - neighbours
+      {n_batch_jets, 20, 36},  // input_10 - neighbours
+      {n_batch_jets, 20, 36},  // input_11 - neighbours
+      {n_batch_jets, 20, 36},  // input_12 - neighbours
+
   };
-  
-  
+
   // create a list of named tensors, i.e. a vector of (string, Tensor) pairs, with proper size to
   // prevent element copying that would occur via push_back's
   // the default Tensor constructor creates a scalar so this should be fine w.r.t. to memory
   tensorflow::NamedTensorList input_tensors;
-  input_tensors.resize(input_sizes.size() ); //+ lp_tensors_.size());
-  
+  input_tensors.resize(input_sizes.size());  //+ lp_tensors_.size());
+
   // add actual input tensors that hold physics information
-  for (std::size_t i=0; i < input_sizes.size(); i++) {
-    input_tensors[i] = tensorflow::NamedTensor(
-      input_names_[i], tensorflow::Tensor(tensorflow::DT_FLOAT, input_sizes.at(i)));
+  for (std::size_t i = 0; i < input_sizes.size(); i++) {
+    input_tensors[i] =
+        tensorflow::NamedTensor(input_names_[i], tensorflow::Tensor(tensorflow::DT_FLOAT, input_sizes.at(i)));
   }
-  
-   // add learning-phase tensors behind them
-  for (std::size_t i=0; i < lp_tensors_.size(); i++) {
-  input_tensors[input_sizes.size() + i] = tensorflow::NamedTensor(lp_names_[i], lp_tensors_[i]);
-  }  
-    
-  std::size_t n_batches = n_jets/n_batch_jets; // either 1 or n_jets
-  
-  for (std::size_t batch_n=0; batch_n < n_batches; batch_n++) {      
-      
-    bool run_session=true; //run session can be skipped for unintersting jets only when n_batch_jets==1
-      
+
+  // add learning-phase tensors behind them
+  for (std::size_t i = 0; i < lp_tensors_.size(); i++) {
+    input_tensors[input_sizes.size() + i] = tensorflow::NamedTensor(lp_names_[i], lp_tensors_[i]);
+  }
+
+  std::size_t n_batches = n_jets / n_batch_jets;  // either 1 or n_jets
+
+  for (std::size_t batch_n = 0; batch_n < n_batches; batch_n++) {
+    bool run_session = true;  //run session can be skipped for unintersting jets only when n_batch_jets==1
+
     // tensors have to be zeroed before filling per batch
-    for (std::size_t i=0; i < input_sizes.size(); i++) {
+    for (std::size_t i = 0; i < input_sizes.size(); i++) {
       input_tensors[i].second.flat<float>().setZero();
     }
 
     // fill values of the input tensors
-    for (std::size_t jet_bn=0; jet_bn < (std::size_t) n_batch_jets; jet_bn++) {
-
+    for (std::size_t jet_bn = 0; jet_bn < (std::size_t)n_batch_jets; jet_bn++) {
       // global jet index (jet_bn is the jet batch index)
-      std::size_t jet_n = batch_n*n_batch_jets + jet_bn;
+      std::size_t jet_n = batch_n * n_batch_jets + jet_bn;
 
       // jet and other global features
-      const auto & features = tag_infos->at(jet_n).features();   
-            
+      const auto& features = tag_infos->at(jet_n).features();
+
       //check if jet needs btag with n_batch_jets==1
-      if ((features.jet_features.pt<min_jet_pt_ || std::fabs(features.jet_features.eta)>max_jet_eta_) && n_batch_jets==1) { run_session=false; continue;  }
+      if ((features.jet_features.pt < min_jet_pt_ || std::fabs(features.jet_features.eta) > max_jet_eta_) &&
+          n_batch_jets == 1) {
+        run_session = false;
+        continue;
+      }
 
       jet4vec_tensor_filler(input_tensors.at(kGlobal).second, jet_bn, features);
 
       // seed features
-      auto max_seed_n = std::min(features.seed_features.size(), (std::size_t) input_sizes.at(kSeedingTracks).dim_size(1));
-      
-      for (std::size_t seed_n=0; seed_n < max_seed_n; seed_n++) {
-        const auto & seed_features = features.seed_features.at(seed_n);
-        
-        seed_tensor_filler(input_tensors.at(kSeedingTracks).second, jet_bn, seed_n, seed_features);            
-        neighbourTracks_tensor_filler(input_tensors.at(kNeighbourTracks+seed_n).second,  jet_bn, seed_n,  seed_features);
-     
+      auto max_seed_n =
+          std::min(features.seed_features.size(), (std::size_t)input_sizes.at(kSeedingTracks).dim_size(1));
+
+      for (std::size_t seed_n = 0; seed_n < max_seed_n; seed_n++) {
+        const auto& seed_features = features.seed_features.at(seed_n);
+
+        seed_tensor_filler(input_tensors.at(kSeedingTracks).second, jet_bn, seed_n, seed_features);
+        neighbourTracks_tensor_filler(
+            input_tensors.at(kNeighbourTracks + seed_n).second, jet_bn, seed_n, seed_features);
       }
-      
-   
-    }//different block
+
+    }  //different block
 
     // run the session
     std::vector<tensorflow::Tensor> outputs;
     // std::cout <<"Input size" <<  input_tensors.size() << std::endl;
-    if (run_session) tensorflow::run(session_, input_tensors, output_names_, &outputs);
+    if (run_session)
+      tensorflow::run(session_, input_tensors, output_names_, &outputs);
 
     // set output values for flavour probs
-    for (std::size_t jet_bn=0; jet_bn < (std::size_t) n_batch_jets; jet_bn++) {
-
+    for (std::size_t jet_bn = 0; jet_bn < (std::size_t)n_batch_jets; jet_bn++) {
       // global jet index (jet_bn is the jet batch index)
-      std::size_t jet_n = batch_n*n_batch_jets + jet_bn;
+      std::size_t jet_n = batch_n * n_batch_jets + jet_bn;
 
-      const auto & jet_ref = tag_infos->at(jet_n).jet();
-      for (std::size_t flav_n=0; flav_n < flav_pairs_.size(); flav_n++) {
-        const auto & flav_pair = flav_pairs_.at(flav_n);
+      const auto& jet_ref = tag_infos->at(jet_n).jet();
+      for (std::size_t flav_n = 0; flav_n < flav_pairs_.size(); flav_n++) {
+        const auto& flav_pair = flav_pairs_.at(flav_n);
         float o_sum = 0.;
-        for (const unsigned int & ind : flav_pair.second) {
-          if (run_session) o_sum += outputs.at(kJetFlavour).matrix<float>()(jet_bn, ind);
-          else o_sum=-2;
+        for (const unsigned int& ind : flav_pair.second) {
+          if (run_session)
+            o_sum += outputs.at(kJetFlavour).matrix<float>()(jet_bn, ind);
+          else
+            o_sum = -2;
         }
         (*(output_tags.at(flav_n)))[jet_ref] = o_sum;
       }
     }
-  }  
-  
-
-  for (std::size_t i=0; i < flav_pairs_.size(); i++) {
-      iEvent.put(std::move(output_tags[i]), flav_pairs_.at(i).first);
   }
 
+  for (std::size_t i = 0; i < flav_pairs_.size(); i++) {
+    iEvent.put(std::move(output_tags[i]), flav_pairs_.at(i).first);
+  }
 }
-
-
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(DeepVertexTFJetTagsProducer);
-
-

--- a/RecoBTag/TensorFlow/src/tensor_fillers.cc
+++ b/RecoBTag/TensorFlow/src/tensor_fillers.cc
@@ -9,15 +9,14 @@ namespace btagbtvdeep {
   // the memory, so it is most performant to get the pointer to the first
   // value and use pointer arithmetic to iterate through the next pointers.
 
-  void jet_tensor_filler(tensorflow::Tensor & tensor,
+  void jet_tensor_filler(tensorflow::Tensor& tensor,
                          std::size_t jet_n,
-                         const btagbtvdeep::DeepFlavourFeatures & features) {
-
+                         const btagbtvdeep::DeepFlavourFeatures& features) {
     float* ptr = &tensor.matrix<float>()(jet_n, 0);
 
     // jet variables
-    const auto & jet_features = features.jet_features;
-    *ptr     = jet_features.pt;
+    const auto& jet_features = features.jet_features;
+    *ptr = jet_features.pt;
     *(++ptr) = jet_features.eta;
     // number of elements in different collections
     *(++ptr) = features.c_pf_features.size();
@@ -25,7 +24,7 @@ namespace btagbtvdeep {
     *(++ptr) = features.sv_features.size();
     *(++ptr) = features.npv;
     // variables from ShallowTagInfo
-    const auto & tag_info_features = features.tag_info_features;
+    const auto& tag_info_features = features.tag_info_features;
     *(++ptr) = tag_info_features.trackSumJetEtRatio;
     *(++ptr) = tag_info_features.trackSumJetDeltaR;
     *(++ptr) = tag_info_features.vertexCategory;
@@ -35,72 +34,66 @@ namespace btagbtvdeep {
     *(++ptr) = tag_info_features.trackSip3dSigAboveCharm;
     *(++ptr) = tag_info_features.jetNSelectedTracks;
     *(++ptr) = tag_info_features.jetNTracksEtaRel;
-
   }
-  
-  void jet4vec_tensor_filler(tensorflow::Tensor & tensor,
-                         std::size_t jet_n,
-                         const btagbtvdeep::DeepFlavourFeatures & features) {
 
+  void jet4vec_tensor_filler(tensorflow::Tensor& tensor,
+                             std::size_t jet_n,
+                             const btagbtvdeep::DeepFlavourFeatures& features) {
     float* ptr = &tensor.matrix<float>()(jet_n, 0);
 
     // jet 4 vector variables
-    const auto & jet_features = features.jet_features;
-    *ptr     = jet_features.pt;
+    const auto& jet_features = features.jet_features;
+    *ptr = jet_features.pt;
     *(++ptr) = jet_features.eta;
     *(++ptr) = jet_features.phi;
     *(++ptr) = jet_features.mass;
-    
-
   }
 
-  void db_tensor_filler(tensorflow::Tensor & tensor,
-                         std::size_t jet_n,
-                         const btagbtvdeep::DeepDoubleXFeatures & features) {
-
+  void db_tensor_filler(tensorflow::Tensor& tensor,
+                        std::size_t jet_n,
+                        const btagbtvdeep::DeepDoubleXFeatures& features) {
     float* ptr = &tensor.tensor<float, 3>()(jet_n, 0, 0);
 
     // variables from BoostedDoubleSVTagInfo
-    const auto & tag_info_features = features.tag_info_features;
+    const auto& tag_info_features = features.tag_info_features;
     *ptr = tag_info_features.jetNTracks;
     *(++ptr) = tag_info_features.jetNSecondaryVertices;
-    *(++ptr) = tag_info_features.tau1_trackEtaRel_0; 
-    *(++ptr) = tag_info_features.tau1_trackEtaRel_1; 
-    *(++ptr) = tag_info_features.tau1_trackEtaRel_2; 
-    *(++ptr) = tag_info_features.tau2_trackEtaRel_0; 
-    *(++ptr) = tag_info_features.tau2_trackEtaRel_1; 
-    *(++ptr) = tag_info_features.tau2_trackEtaRel_2; 
-    *(++ptr) = tag_info_features.tau1_flightDistance2dSig; 
-    *(++ptr) = tag_info_features.tau2_flightDistance2dSig; 
-    *(++ptr) = tag_info_features.tau1_vertexDeltaR; 
+    *(++ptr) = tag_info_features.tau1_trackEtaRel_0;
+    *(++ptr) = tag_info_features.tau1_trackEtaRel_1;
+    *(++ptr) = tag_info_features.tau1_trackEtaRel_2;
+    *(++ptr) = tag_info_features.tau2_trackEtaRel_0;
+    *(++ptr) = tag_info_features.tau2_trackEtaRel_1;
+    *(++ptr) = tag_info_features.tau2_trackEtaRel_2;
+    *(++ptr) = tag_info_features.tau1_flightDistance2dSig;
+    *(++ptr) = tag_info_features.tau2_flightDistance2dSig;
+    *(++ptr) = tag_info_features.tau1_vertexDeltaR;
     // Note: this variable is not used in the 27-input BDT
     //    *(++ptr) = tag_info_features.tau2_vertexDeltaR;
-    *(++ptr) = tag_info_features.tau1_vertexEnergyRatio; 
-    *(++ptr) = tag_info_features.tau2_vertexEnergyRatio; 
-    *(++ptr) = tag_info_features.tau1_vertexMass; 
-    *(++ptr) = tag_info_features.tau2_vertexMass; 
+    *(++ptr) = tag_info_features.tau1_vertexEnergyRatio;
+    *(++ptr) = tag_info_features.tau2_vertexEnergyRatio;
+    *(++ptr) = tag_info_features.tau1_vertexMass;
+    *(++ptr) = tag_info_features.tau2_vertexMass;
     *(++ptr) = tag_info_features.trackSip2dSigAboveBottom_0;
     *(++ptr) = tag_info_features.trackSip2dSigAboveBottom_1;
     *(++ptr) = tag_info_features.trackSip2dSigAboveCharm;
-    *(++ptr) = tag_info_features.trackSip3dSig_0; 
-    *(++ptr) = tag_info_features.tau1_trackSip3dSig_0; 
-    *(++ptr) = tag_info_features.tau1_trackSip3dSig_1; 
-    *(++ptr) = tag_info_features.trackSip3dSig_1; 
-    *(++ptr) = tag_info_features.tau2_trackSip3dSig_0; 
-    *(++ptr) = tag_info_features.tau2_trackSip3dSig_1; 
-    *(++ptr) = tag_info_features.trackSip3dSig_2; 
-    *(++ptr) = tag_info_features.trackSip3dSig_3; 
+    *(++ptr) = tag_info_features.trackSip3dSig_0;
+    *(++ptr) = tag_info_features.tau1_trackSip3dSig_0;
+    *(++ptr) = tag_info_features.tau1_trackSip3dSig_1;
+    *(++ptr) = tag_info_features.trackSip3dSig_1;
+    *(++ptr) = tag_info_features.tau2_trackSip3dSig_0;
+    *(++ptr) = tag_info_features.tau2_trackSip3dSig_1;
+    *(++ptr) = tag_info_features.trackSip3dSig_2;
+    *(++ptr) = tag_info_features.trackSip3dSig_3;
     *(++ptr) = tag_info_features.z_ratio;
   }
 
-  void c_pf_tensor_filler(tensorflow::Tensor & tensor,
+  void c_pf_tensor_filler(tensorflow::Tensor& tensor,
                           std::size_t jet_n,
                           std::size_t c_pf_n,
-                          const btagbtvdeep::ChargedCandidateFeatures & c_pf_features) {
-
+                          const btagbtvdeep::ChargedCandidateFeatures& c_pf_features) {
     float* ptr = &tensor.tensor<float, 3>()(jet_n, c_pf_n, 0);
 
-    *ptr     = c_pf_features.btagPf_trackEtaRel;
+    *ptr = c_pf_features.btagPf_trackEtaRel;
     *(++ptr) = c_pf_features.btagPf_trackPtRel;
     *(++ptr) = c_pf_features.btagPf_trackPPar;
     *(++ptr) = c_pf_features.btagPf_trackDeltaR;
@@ -116,17 +109,15 @@ namespace btagbtvdeep {
     *(++ptr) = c_pf_features.puppiw;
     *(++ptr) = c_pf_features.chi2;
     *(++ptr) = c_pf_features.quality;
-
   }
-  
-  void c_pf_reduced_tensor_filler(tensorflow::Tensor & tensor,
-                          std::size_t jet_n,
-                          std::size_t c_pf_n,
-                          const btagbtvdeep::ChargedCandidateFeatures & c_pf_features) {
 
+  void c_pf_reduced_tensor_filler(tensorflow::Tensor& tensor,
+                                  std::size_t jet_n,
+                                  std::size_t c_pf_n,
+                                  const btagbtvdeep::ChargedCandidateFeatures& c_pf_features) {
     float* ptr = &tensor.tensor<float, 3>()(jet_n, c_pf_n, 0);
 
-    *ptr     = c_pf_features.btagPf_trackEtaRel;
+    *ptr = c_pf_features.btagPf_trackEtaRel;
     *(++ptr) = c_pf_features.btagPf_trackPtRatio;
     *(++ptr) = c_pf_features.btagPf_trackPParRatio;
     *(++ptr) = c_pf_features.btagPf_trackSip2dVal;
@@ -134,35 +125,29 @@ namespace btagbtvdeep {
     *(++ptr) = c_pf_features.btagPf_trackSip3dVal;
     *(++ptr) = c_pf_features.btagPf_trackSip3dSig;
     *(++ptr) = c_pf_features.btagPf_trackJetDistVal;
-
   }
 
-
-  void n_pf_tensor_filler(tensorflow::Tensor & tensor,
+  void n_pf_tensor_filler(tensorflow::Tensor& tensor,
                           std::size_t jet_n,
                           std::size_t n_pf_n,
-                          const btagbtvdeep::NeutralCandidateFeatures & n_pf_features) {
-
+                          const btagbtvdeep::NeutralCandidateFeatures& n_pf_features) {
     float* ptr = &tensor.tensor<float, 3>()(jet_n, n_pf_n, 0);
 
-    *ptr     = n_pf_features.ptrel;
+    *ptr = n_pf_features.ptrel;
     *(++ptr) = n_pf_features.deltaR;
     *(++ptr) = n_pf_features.isGamma;
     *(++ptr) = n_pf_features.hadFrac;
     *(++ptr) = n_pf_features.drminsv;
     *(++ptr) = n_pf_features.puppiw;
-
   }
-  
-  
-  void sv_tensor_filler(tensorflow::Tensor & tensor,
-                          std::size_t jet_n,
-                          std::size_t sv_n,
-                          const btagbtvdeep::SecondaryVertexFeatures & sv_features) {
 
+  void sv_tensor_filler(tensorflow::Tensor& tensor,
+                        std::size_t jet_n,
+                        std::size_t sv_n,
+                        const btagbtvdeep::SecondaryVertexFeatures& sv_features) {
     float* ptr = &tensor.tensor<float, 3>()(jet_n, sv_n, 0);
 
-    *ptr     = sv_features.pt;
+    *ptr = sv_features.pt;
     *(++ptr) = sv_features.deltaR;
     *(++ptr) = sv_features.mass;
     *(++ptr) = sv_features.ntracks;
@@ -174,112 +159,93 @@ namespace btagbtvdeep {
     *(++ptr) = sv_features.d3dsig;
     *(++ptr) = sv_features.costhetasvpv;
     *(++ptr) = sv_features.enratio;
-
   }
 
-  
-  void sv_reduced_tensor_filler(tensorflow::Tensor & tensor,
-                          std::size_t jet_n,
-                          std::size_t sv_n,
-                          const btagbtvdeep::SecondaryVertexFeatures & sv_features) {
-
+  void sv_reduced_tensor_filler(tensorflow::Tensor& tensor,
+                                std::size_t jet_n,
+                                std::size_t sv_n,
+                                const btagbtvdeep::SecondaryVertexFeatures& sv_features) {
     float* ptr = &tensor.tensor<float, 3>()(jet_n, sv_n, 0);
 
-    *ptr     = sv_features.d3d;
+    *ptr = sv_features.d3d;
     *(++ptr) = sv_features.d3dsig;
-
   }
-  
-  
-  void seed_tensor_filler(tensorflow::Tensor & tensor,
+
+  void seed_tensor_filler(tensorflow::Tensor& tensor,
                           std::size_t jet_n,
                           std::size_t seed_n,
-                          const btagbtvdeep::SeedingTrackFeatures & seed_features) {
+                          const btagbtvdeep::SeedingTrackFeatures& seed_features) {
+    float* ptr = &tensor.tensor<float, 3>()(jet_n, seed_n, 0);
 
+    *ptr = seed_features.pt;
+    *(++ptr) = seed_features.eta;
+    *(++ptr) = seed_features.phi;
+    *(++ptr) = seed_features.mass;
+    *(++ptr) = seed_features.dz;
+    *(++ptr) = seed_features.dxy;
+    *(++ptr) = seed_features.ip3D;
+    *(++ptr) = seed_features.sip3D;
+    *(++ptr) = seed_features.ip2D;
+    *(++ptr) = seed_features.sip2D;
+    *(++ptr) = seed_features.signedIp3D;
+    *(++ptr) = seed_features.signedSip3D;
+    *(++ptr) = seed_features.signedIp2D;
+    *(++ptr) = seed_features.signedSip2D;
+    *(++ptr) = seed_features.trackProbability3D;
+    *(++ptr) = seed_features.trackProbability2D;
+    *(++ptr) = seed_features.chi2reduced;
+    *(++ptr) = seed_features.nPixelHits;
+    *(++ptr) = seed_features.nHits;
+    *(++ptr) = seed_features.jetAxisDistance;
+    *(++ptr) = seed_features.jetAxisDlength;
+  }
 
-    float* ptr = &tensor.tensor<float, 3>()(jet_n, seed_n, 0);    
-    
-     *ptr     = seed_features.pt;
-     *(++ptr) = seed_features.eta;
-     *(++ptr) = seed_features.phi;
-     *(++ptr) = seed_features.mass;    
-     *(++ptr) = seed_features.dz;
-     *(++ptr) = seed_features.dxy;
-     *(++ptr) = seed_features.ip3D;
-     *(++ptr) = seed_features.sip3D;
-     *(++ptr) = seed_features.ip2D;
-     *(++ptr) = seed_features.sip2D;    
-     *(++ptr) = seed_features.signedIp3D;
-     *(++ptr) = seed_features.signedSip3D;
-     *(++ptr) = seed_features.signedIp2D;
-     *(++ptr) = seed_features.signedSip2D;  
-     *(++ptr) = seed_features.trackProbability3D;
-     *(++ptr) = seed_features.trackProbability2D;
-     *(++ptr) = seed_features.chi2reduced;
-     *(++ptr) = seed_features.nPixelHits;
-     *(++ptr) = seed_features.nHits;
-     *(++ptr) = seed_features.jetAxisDistance;
-     *(++ptr) = seed_features.jetAxisDlength;
-     
-  }  
-  
-  void neighbourTracks_tensor_filler(tensorflow::Tensor & tensor,
-                          std::size_t jet_n,
-                          std::size_t seed_n,
-                          const btagbtvdeep::SeedingTrackFeatures & seed_features) {
+  void neighbourTracks_tensor_filler(tensorflow::Tensor& tensor,
+                                     std::size_t jet_n,
+                                     std::size_t seed_n,
+                                     const btagbtvdeep::SeedingTrackFeatures& seed_features) {
+    std::vector<btagbtvdeep::TrackPairFeatures> neighbourTracks_features = seed_features.nearTracks;
 
-    
-    std::vector<btagbtvdeep::TrackPairFeatures> neighbourTracks_features = seed_features.nearTracks;      
-   
-    
-    for(unsigned int t_i=0; t_i<neighbourTracks_features.size(); t_i++){  
+    for (unsigned int t_i = 0; t_i < neighbourTracks_features.size(); t_i++) {
+      float* ptr = &tensor.tensor<float, 3>()(jet_n, t_i, 0);
 
-     float* ptr = &tensor.tensor<float, 3>()(jet_n, t_i,  0);    
-        
-     *ptr  = neighbourTracks_features[t_i].pt;
-     *(++ptr) = neighbourTracks_features[t_i].eta;
-     *(++ptr) = neighbourTracks_features[t_i].phi;     
-     *(++ptr) = neighbourTracks_features[t_i].dz;
-     *(++ptr) = neighbourTracks_features[t_i].dxy;     
-     *(++ptr) = neighbourTracks_features[t_i].mass;     
-     *(++ptr) = neighbourTracks_features[t_i].ip3D;
-     *(++ptr) = neighbourTracks_features[t_i].sip3D;
-     *(++ptr) = neighbourTracks_features[t_i].ip2D;
-     *(++ptr) = neighbourTracks_features[t_i].sip2D;
-     *(++ptr) = neighbourTracks_features[t_i].distPCA;
-     *(++ptr) = neighbourTracks_features[t_i].dsigPCA;      
-     *(++ptr) = neighbourTracks_features[t_i].x_PCAonSeed;
-     *(++ptr) = neighbourTracks_features[t_i].y_PCAonSeed;
-     *(++ptr) = neighbourTracks_features[t_i].z_PCAonSeed;      
-     *(++ptr) = neighbourTracks_features[t_i].xerr_PCAonSeed;
-     *(++ptr) = neighbourTracks_features[t_i].yerr_PCAonSeed;
-     *(++ptr) = neighbourTracks_features[t_i].zerr_PCAonSeed;      
-     *(++ptr) = neighbourTracks_features[t_i].x_PCAonTrack;
-     *(++ptr) = neighbourTracks_features[t_i].y_PCAonTrack;
-     *(++ptr) = neighbourTracks_features[t_i].z_PCAonTrack;      
-     *(++ptr) = neighbourTracks_features[t_i].xerr_PCAonTrack;
-     *(++ptr) = neighbourTracks_features[t_i].yerr_PCAonTrack;
-     *(++ptr) = neighbourTracks_features[t_i].zerr_PCAonTrack; 
-     *(++ptr) = neighbourTracks_features[t_i].dotprodTrack;
-     *(++ptr) = neighbourTracks_features[t_i].dotprodSeed;
-     *(++ptr) = neighbourTracks_features[t_i].dotprodTrackSeed2D;
-     *(++ptr) = neighbourTracks_features[t_i].dotprodTrackSeed3D;
-     *(++ptr) = neighbourTracks_features[t_i].dotprodTrackSeedVectors2D;
-     *(++ptr) = neighbourTracks_features[t_i].dotprodTrackSeedVectors3D;      
-     *(++ptr) = neighbourTracks_features[t_i].pvd_PCAonSeed;
-     *(++ptr) = neighbourTracks_features[t_i].pvd_PCAonTrack;
-     *(++ptr) = neighbourTracks_features[t_i].dist_PCAjetAxis;
-     *(++ptr) = neighbourTracks_features[t_i].dotprod_PCAjetMomenta;
-     *(++ptr) = neighbourTracks_features[t_i].deta_PCAjetDirs;
-     *(++ptr) = neighbourTracks_features[t_i].dphi_PCAjetDirs;
-        
-     
+      *ptr = neighbourTracks_features[t_i].pt;
+      *(++ptr) = neighbourTracks_features[t_i].eta;
+      *(++ptr) = neighbourTracks_features[t_i].phi;
+      *(++ptr) = neighbourTracks_features[t_i].dz;
+      *(++ptr) = neighbourTracks_features[t_i].dxy;
+      *(++ptr) = neighbourTracks_features[t_i].mass;
+      *(++ptr) = neighbourTracks_features[t_i].ip3D;
+      *(++ptr) = neighbourTracks_features[t_i].sip3D;
+      *(++ptr) = neighbourTracks_features[t_i].ip2D;
+      *(++ptr) = neighbourTracks_features[t_i].sip2D;
+      *(++ptr) = neighbourTracks_features[t_i].distPCA;
+      *(++ptr) = neighbourTracks_features[t_i].dsigPCA;
+      *(++ptr) = neighbourTracks_features[t_i].x_PCAonSeed;
+      *(++ptr) = neighbourTracks_features[t_i].y_PCAonSeed;
+      *(++ptr) = neighbourTracks_features[t_i].z_PCAonSeed;
+      *(++ptr) = neighbourTracks_features[t_i].xerr_PCAonSeed;
+      *(++ptr) = neighbourTracks_features[t_i].yerr_PCAonSeed;
+      *(++ptr) = neighbourTracks_features[t_i].zerr_PCAonSeed;
+      *(++ptr) = neighbourTracks_features[t_i].x_PCAonTrack;
+      *(++ptr) = neighbourTracks_features[t_i].y_PCAonTrack;
+      *(++ptr) = neighbourTracks_features[t_i].z_PCAonTrack;
+      *(++ptr) = neighbourTracks_features[t_i].xerr_PCAonTrack;
+      *(++ptr) = neighbourTracks_features[t_i].yerr_PCAonTrack;
+      *(++ptr) = neighbourTracks_features[t_i].zerr_PCAonTrack;
+      *(++ptr) = neighbourTracks_features[t_i].dotprodTrack;
+      *(++ptr) = neighbourTracks_features[t_i].dotprodSeed;
+      *(++ptr) = neighbourTracks_features[t_i].dotprodTrackSeed2D;
+      *(++ptr) = neighbourTracks_features[t_i].dotprodTrackSeed3D;
+      *(++ptr) = neighbourTracks_features[t_i].dotprodTrackSeedVectors2D;
+      *(++ptr) = neighbourTracks_features[t_i].dotprodTrackSeedVectors3D;
+      *(++ptr) = neighbourTracks_features[t_i].pvd_PCAonSeed;
+      *(++ptr) = neighbourTracks_features[t_i].pvd_PCAonTrack;
+      *(++ptr) = neighbourTracks_features[t_i].dist_PCAjetAxis;
+      *(++ptr) = neighbourTracks_features[t_i].dotprod_PCAjetMomenta;
+      *(++ptr) = neighbourTracks_features[t_i].deta_PCAjetDirs;
+      *(++ptr) = neighbourTracks_features[t_i].dphi_PCAjetDirs;
     }
-
-
   }
-  
-  
 
-}
-
+}  // namespace btagbtvdeep

--- a/RecoTauTag/RecoTau/interface/AntiElectronIDCut2.h
+++ b/RecoTauTag/RecoTau/interface/AntiElectronIDCut2.h
@@ -19,164 +19,159 @@
 
 typedef std::pair<double, double> pdouble;
 
-class AntiElectronIDCut2 
-{
-  public:
+class AntiElectronIDCut2 {
+public:
+  AntiElectronIDCut2();
+  ~AntiElectronIDCut2();
 
-    AntiElectronIDCut2();
-    ~AntiElectronIDCut2(); 
+  double Discriminator(float TauPt,
+                       float TauEta,
+                       float TauLeadChargedPFCandPt,
+                       float TauLeadChargedPFCandEtaAtEcalEntrance,
+                       float TauLeadPFChargedHadrEoP,
+                       float TauHcal3x3OverPLead,
+                       float TauGammaEtaMom,
+                       float TauGammaPhiMom,
+                       float TauGammaEnFrac);
 
-    double Discriminator(float TauPt,
-                         float TauEta,
-                         float TauLeadChargedPFCandPt,
-                         float TauLeadChargedPFCandEtaAtEcalEntrance,
-                         float TauLeadPFChargedHadrEoP,
-                         float TauHcal3x3OverPLead,
-                         float TauGammaEtaMom,
-                         float TauGammaPhiMom,
-                         float TauGammaEnFrac
-			 );
+  double Discriminator(float TauPt,
+                       float TauEta,
+                       float TauLeadChargedPFCandPt,
+                       float TauLeadChargedPFCandEtaAtEcalEntrance,
+                       float TauLeadPFChargedHadrEoP,
+                       float TauHcal3x3OverPLead,
+                       const std::vector<float>& GammasdEta,
+                       const std::vector<float>& GammasdPhi,
+                       const std::vector<float>& GammasPt);
 
-    double Discriminator(float TauPt,
-			 float TauEta,
-			 float TauLeadChargedPFCandPt,
-			 float TauLeadChargedPFCandEtaAtEcalEntrance,
-			 float TauLeadPFChargedHadrEoP,
-			 float TauHcal3x3OverPLead,
-			 const std::vector<float>& GammasdEta,
-			 const std::vector<float>& GammasdPhi,
-			 const std::vector<float>& GammasPt
-			 );
-
-    template<typename T> 
-      double Discriminator(const T& thePFTau)
-      {
-	float TauLeadChargedPFCandEtaAtEcalEntrance = -99.;
-	float TauLeadChargedPFCandPt = -99.;
-	const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTau.signalPFCands();
-	for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
-	      pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-	  const reco::Track* track = nullptr;
-	  if ( (*pfCandidate)->trackRef().isNonnull() ) track = (*pfCandidate)->trackRef().get();
-	  else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->innerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->innerTrack().get();
-	  else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->globalTrack().isNonnull() ) track = (*pfCandidate)->muonRef()->globalTrack().get();
-	  else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->outerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->outerTrack().get();
-	  else if ( (*pfCandidate)->gsfTrackRef().isNonnull() ) track = (*pfCandidate)->gsfTrackRef().get();
-	  if ( track ) {
-	    if ( track->pt() > TauLeadChargedPFCandPt ) {
-	      TauLeadChargedPFCandEtaAtEcalEntrance = (*pfCandidate)->positionAtECALEntrance().eta();
-	      TauLeadChargedPFCandPt = track->pt();
-	    }
-	  }
-	}
-	
-	float TauPt = thePFTau.pt();
-	float TauEta = thePFTau.eta();
-	//float TauLeadPFChargedHadrHoP = 0.;
-	float TauLeadPFChargedHadrEoP = 0.;
-	if ( thePFTau.leadPFChargedHadrCand()->p() > 0. ) {
-	  //TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
-	  TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
-	}
-	
-	std::vector<float> GammasdEta;
-	std::vector<float> GammasdPhi;
-	std::vector<float> GammasPt;
-	for ( unsigned i = 0 ; i < thePFTau.signalGammaCands().size(); ++i ) {
-	  reco::CandidatePtr gamma = thePFTau.signalGammaCands().at(i);
-	  if ( thePFTau.leadChargedHadrCand().isNonnull() ) {
-	    GammasdEta.push_back(gamma->eta() - thePFTau.leadChargedHadrCand()->eta());
-	    GammasdPhi.push_back(gamma->phi() - thePFTau.leadChargedHadrCand()->phi());
-	  } else {
-	    GammasdEta.push_back(gamma->eta() - thePFTau.eta());
-	    GammasdPhi.push_back(gamma->phi() - thePFTau.phi());
-	  }
-	  GammasPt.push_back(gamma->pt());
-	}
-	
-	float TauHcal3x3OverPLead = thePFTau.hcal3x3OverPLead();
-	
-	return Discriminator(TauPt,
-			     TauEta,
-			     TauLeadChargedPFCandPt,
-			     TauLeadChargedPFCandEtaAtEcalEntrance,
-			     TauLeadPFChargedHadrEoP,
-			     TauHcal3x3OverPLead,
-			     GammasdEta,
-			     GammasdPhi,
-			     GammasPt
-			     );
-      };
-    
-    void SetBarrelCutValues(float TauLeadPFChargedHadrEoP_min,
-			    float TauLeadPFChargedHadrEoP_max,
-			    float TauHcal3x3OverPLead_max,
-			    float TauGammaEtaMom_max,
-			    float TauGammaPhiMom_max,
-			    float TauGammaEnFrac_max
-			    );
-
-    void SetEndcapCutValues(float TauLeadPFChargedHadrEoP_min_1,
-                            float TauLeadPFChargedHadrEoP_max_1,
-			    float TauLeadPFChargedHadrEoP_min_2,
-                            float TauLeadPFChargedHadrEoP_max_2,
-                            float TauHcal3x3OverPLead_max,
-                            float TauGammaEtaMom_max,
-                            float TauGammaPhiMom_max,
-                            float TauGammaEnFrac_max
-                            );
-    void ApplyCut_EcalCrack(bool keepAll_, bool rejectAll_){
-      keepAllInEcalCrack_ = keepAll_;
-      rejectAllInEcalCrack_ = rejectAll_;
-    };
-    
-    void ApplyCuts(bool applyCut_hcal3x3OverPLead, 
-		   bool applyCut_leadPFChargedHadrEoP, 
-		   bool applyCut_GammaEtaMom, 
-		   bool applyCut_GammaPhiMom, 
-		   bool applyCut_GammaEnFrac, 
-		   bool applyCut_HLTSpecific
-		   );
-
-    void SetEcalCracks(const std::vector<pdouble>& etaCracks)
-    {
-      ecalCracks_.clear();
-      for(size_t i = 0; i < etaCracks.size(); i++)
-	ecalCracks_.push_back(etaCracks[i]);
+  template <typename T>
+  double Discriminator(const T& thePFTau) {
+    float TauLeadChargedPFCandEtaAtEcalEntrance = -99.;
+    float TauLeadChargedPFCandPt = -99.;
+    const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTau.signalPFCands();
+    for (std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
+         pfCandidate != signalPFCands.end();
+         ++pfCandidate) {
+      const reco::Track* track = nullptr;
+      if ((*pfCandidate)->trackRef().isNonnull())
+        track = (*pfCandidate)->trackRef().get();
+      else if ((*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->innerTrack().isNonnull())
+        track = (*pfCandidate)->muonRef()->innerTrack().get();
+      else if ((*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->globalTrack().isNonnull())
+        track = (*pfCandidate)->muonRef()->globalTrack().get();
+      else if ((*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->outerTrack().isNonnull())
+        track = (*pfCandidate)->muonRef()->outerTrack().get();
+      else if ((*pfCandidate)->gsfTrackRef().isNonnull())
+        track = (*pfCandidate)->gsfTrackRef().get();
+      if (track) {
+        if (track->pt() > TauLeadChargedPFCandPt) {
+          TauLeadChargedPFCandEtaAtEcalEntrance = (*pfCandidate)->positionAtECALEntrance().eta();
+          TauLeadChargedPFCandPt = track->pt();
+        }
+      }
     }
-    
- private:
 
-    bool isInEcalCrack(double eta) const; 
-    
-    float TauLeadPFChargedHadrEoP_barrel_min_;
-    float TauLeadPFChargedHadrEoP_barrel_max_;
-    float TauHcal3x3OverPLead_barrel_max_;
-    float TauGammaEtaMom_barrel_max_;
-    float TauGammaPhiMom_barrel_max_;
-    float TauGammaEnFrac_barrel_max_;
-    float TauLeadPFChargedHadrEoP_endcap_min1_;
-    float TauLeadPFChargedHadrEoP_endcap_max1_;
-    float TauLeadPFChargedHadrEoP_endcap_min2_;
-    float TauLeadPFChargedHadrEoP_endcap_max2_;
-    float TauHcal3x3OverPLead_endcap_max_;
-    float TauGammaEtaMom_endcap_max_;
-    float TauGammaPhiMom_endcap_max_;
-    float TauGammaEnFrac_endcap_max_;
+    float TauPt = thePFTau.pt();
+    float TauEta = thePFTau.eta();
+    //float TauLeadPFChargedHadrHoP = 0.;
+    float TauLeadPFChargedHadrEoP = 0.;
+    if (thePFTau.leadPFChargedHadrCand()->p() > 0.) {
+      //TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
+      TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy() / thePFTau.leadPFChargedHadrCand()->p();
+    }
 
-    bool keepAllInEcalCrack_;
-    bool rejectAllInEcalCrack_;
+    std::vector<float> GammasdEta;
+    std::vector<float> GammasdPhi;
+    std::vector<float> GammasPt;
+    for (unsigned i = 0; i < thePFTau.signalGammaCands().size(); ++i) {
+      reco::CandidatePtr gamma = thePFTau.signalGammaCands().at(i);
+      if (thePFTau.leadChargedHadrCand().isNonnull()) {
+        GammasdEta.push_back(gamma->eta() - thePFTau.leadChargedHadrCand()->eta());
+        GammasdPhi.push_back(gamma->phi() - thePFTau.leadChargedHadrCand()->phi());
+      } else {
+        GammasdEta.push_back(gamma->eta() - thePFTau.eta());
+        GammasdPhi.push_back(gamma->phi() - thePFTau.phi());
+      }
+      GammasPt.push_back(gamma->pt());
+    }
 
-    bool Tau_applyCut_hcal3x3OverPLead_;
-    bool Tau_applyCut_leadPFChargedHadrEoP_;
-    bool Tau_applyCut_GammaEtaMom_;
-    bool Tau_applyCut_GammaPhiMom_;
-    bool Tau_applyCut_GammaEnFrac_;
-    bool Tau_applyCut_HLTSpecific_;
+    float TauHcal3x3OverPLead = thePFTau.hcal3x3OverPLead();
 
-    std::vector<pdouble> ecalCracks_;
-    
-    int verbosity_;
+    return Discriminator(TauPt,
+                         TauEta,
+                         TauLeadChargedPFCandPt,
+                         TauLeadChargedPFCandEtaAtEcalEntrance,
+                         TauLeadPFChargedHadrEoP,
+                         TauHcal3x3OverPLead,
+                         GammasdEta,
+                         GammasdPhi,
+                         GammasPt);
+  };
+
+  void SetBarrelCutValues(float TauLeadPFChargedHadrEoP_min,
+                          float TauLeadPFChargedHadrEoP_max,
+                          float TauHcal3x3OverPLead_max,
+                          float TauGammaEtaMom_max,
+                          float TauGammaPhiMom_max,
+                          float TauGammaEnFrac_max);
+
+  void SetEndcapCutValues(float TauLeadPFChargedHadrEoP_min_1,
+                          float TauLeadPFChargedHadrEoP_max_1,
+                          float TauLeadPFChargedHadrEoP_min_2,
+                          float TauLeadPFChargedHadrEoP_max_2,
+                          float TauHcal3x3OverPLead_max,
+                          float TauGammaEtaMom_max,
+                          float TauGammaPhiMom_max,
+                          float TauGammaEnFrac_max);
+  void ApplyCut_EcalCrack(bool keepAll_, bool rejectAll_) {
+    keepAllInEcalCrack_ = keepAll_;
+    rejectAllInEcalCrack_ = rejectAll_;
+  };
+
+  void ApplyCuts(bool applyCut_hcal3x3OverPLead,
+                 bool applyCut_leadPFChargedHadrEoP,
+                 bool applyCut_GammaEtaMom,
+                 bool applyCut_GammaPhiMom,
+                 bool applyCut_GammaEnFrac,
+                 bool applyCut_HLTSpecific);
+
+  void SetEcalCracks(const std::vector<pdouble>& etaCracks) {
+    ecalCracks_.clear();
+    for (size_t i = 0; i < etaCracks.size(); i++)
+      ecalCracks_.push_back(etaCracks[i]);
+  }
+
+private:
+  bool isInEcalCrack(double eta) const;
+
+  float TauLeadPFChargedHadrEoP_barrel_min_;
+  float TauLeadPFChargedHadrEoP_barrel_max_;
+  float TauHcal3x3OverPLead_barrel_max_;
+  float TauGammaEtaMom_barrel_max_;
+  float TauGammaPhiMom_barrel_max_;
+  float TauGammaEnFrac_barrel_max_;
+  float TauLeadPFChargedHadrEoP_endcap_min1_;
+  float TauLeadPFChargedHadrEoP_endcap_max1_;
+  float TauLeadPFChargedHadrEoP_endcap_min2_;
+  float TauLeadPFChargedHadrEoP_endcap_max2_;
+  float TauHcal3x3OverPLead_endcap_max_;
+  float TauGammaEtaMom_endcap_max_;
+  float TauGammaPhiMom_endcap_max_;
+  float TauGammaEnFrac_endcap_max_;
+
+  bool keepAllInEcalCrack_;
+  bool rejectAllInEcalCrack_;
+
+  bool Tau_applyCut_hcal3x3OverPLead_;
+  bool Tau_applyCut_leadPFChargedHadrEoP_;
+  bool Tau_applyCut_GammaEtaMom_;
+  bool Tau_applyCut_GammaPhiMom_;
+  bool Tau_applyCut_GammaEnFrac_;
+  bool Tau_applyCut_HLTSpecific_;
+
+  std::vector<pdouble> ecalCracks_;
+
+  int verbosity_;
 };
 
 #endif

--- a/RecoTauTag/RecoTau/interface/AntiElectronIDMVA6.h
+++ b/RecoTauTag/RecoTau/interface/AntiElectronIDMVA6.h
@@ -33,150 +33,143 @@
 
 #include <vector>
 
-class AntiElectronIDMVA6 
-{
-  public:
+class AntiElectronIDMVA6 {
+public:
+  AntiElectronIDMVA6(const edm::ParameterSet&);
+  ~AntiElectronIDMVA6();
 
-   AntiElectronIDMVA6(const edm::ParameterSet&);
-   ~AntiElectronIDMVA6(); 
+  void beginEvent(const edm::Event&, const edm::EventSetup&);
 
-   void beginEvent(const edm::Event&, const edm::EventSetup&);
-   
-   double MVAValue(Float_t TauPt,
-                   Float_t TauEtaAtEcalEntrance,
-                   Float_t TauPhi,
-                   Float_t TauLeadChargedPFCandPt,
-                   Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
-                   Float_t TauEmFraction,
-                   Float_t TauLeadPFChargedHadrHoP,
-                   Float_t TauLeadPFChargedHadrEoP,
-                   Float_t TauVisMassIn,
-                   Float_t TaudCrackEta,
-                   Float_t TaudCrackPhi,
-                   Float_t TauHasGsf,
-                   Int_t TauSignalPFGammaCandsIn,
-                   Int_t TauSignalPFGammaCandsOut,
-                   const std::vector<Float_t>& GammasdEtaInSigCone,
-                   const std::vector<Float_t>& GammasdPhiInSigCone,
-                   const std::vector<Float_t>& GammasPtInSigCone,
-                   const std::vector<Float_t>& GammasdEtaOutSigCone,
-                   const std::vector<Float_t>& GammasdPhiOutSigCone,
-                   const std::vector<Float_t>& GammasPtOutSigCone,
-                   Float_t ElecEta,
-                   Float_t ElecPhi,
-                   Float_t ElecEtotOverPin,
-                   Float_t ElecChi2NormGSF,
-                   Float_t ElecChi2NormKF,
-                   Float_t ElecGSFNumHits,
-                   Float_t ElecKFNumHits,
-                   Float_t ElecGSFTrackResol,
-                   Float_t ElecGSFTracklnPt,
-                   Float_t ElecPin,
-                   Float_t ElecPout,
-                   Float_t ElecEecal,
-                   Float_t ElecDeltaEta,
-                   Float_t ElecDeltaPhi,
-                   Float_t ElecMvaInSigmaEtaEta,
-                   Float_t ElecMvaInHadEnergy,
-                   Float_t ElecMvaInDeltaEta
-                  );
+  double MVAValue(Float_t TauPt,
+                  Float_t TauEtaAtEcalEntrance,
+                  Float_t TauPhi,
+                  Float_t TauLeadChargedPFCandPt,
+                  Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
+                  Float_t TauEmFraction,
+                  Float_t TauLeadPFChargedHadrHoP,
+                  Float_t TauLeadPFChargedHadrEoP,
+                  Float_t TauVisMassIn,
+                  Float_t TaudCrackEta,
+                  Float_t TaudCrackPhi,
+                  Float_t TauHasGsf,
+                  Int_t TauSignalPFGammaCandsIn,
+                  Int_t TauSignalPFGammaCandsOut,
+                  const std::vector<Float_t>& GammasdEtaInSigCone,
+                  const std::vector<Float_t>& GammasdPhiInSigCone,
+                  const std::vector<Float_t>& GammasPtInSigCone,
+                  const std::vector<Float_t>& GammasdEtaOutSigCone,
+                  const std::vector<Float_t>& GammasdPhiOutSigCone,
+                  const std::vector<Float_t>& GammasPtOutSigCone,
+                  Float_t ElecEta,
+                  Float_t ElecPhi,
+                  Float_t ElecEtotOverPin,
+                  Float_t ElecChi2NormGSF,
+                  Float_t ElecChi2NormKF,
+                  Float_t ElecGSFNumHits,
+                  Float_t ElecKFNumHits,
+                  Float_t ElecGSFTrackResol,
+                  Float_t ElecGSFTracklnPt,
+                  Float_t ElecPin,
+                  Float_t ElecPout,
+                  Float_t ElecEecal,
+                  Float_t ElecDeltaEta,
+                  Float_t ElecDeltaPhi,
+                  Float_t ElecMvaInSigmaEtaEta,
+                  Float_t ElecMvaInHadEnergy,
+                  Float_t ElecMvaInDeltaEta);
 
-   double MVAValue(Float_t TauPt,
-                   Float_t TauEtaAtEcalEntrance,
-                   Float_t TauPhi,
-                   Float_t TauLeadChargedPFCandPt,
-                   Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
-                   Float_t TauEmFraction,
-                   Float_t TauLeadPFChargedHadrHoP,
-                   Float_t TauLeadPFChargedHadrEoP,
-                   Float_t TauVisMassIn,
-                   Float_t TaudCrackEta,
-                   Float_t TaudCrackPhi,
-                   Float_t TauHasGsf,
-                   Int_t TauSignalPFGammaCandsIn,
-                   Int_t TauSignalPFGammaCandsOut,
-                   Float_t TauGammaEtaMomIn,
-                   Float_t TauGammaEtaMomOut,
-                   Float_t TauGammaPhiMomIn,
-                   Float_t TauGammaPhiMomOut,
-                   Float_t TauGammaEnFracIn,
-                   Float_t TauGammaEnFracOut,
-                   Float_t ElecEta,
-                   Float_t ElecPhi,
-                   Float_t ElecEtotOverPin,
-                   Float_t ElecChi2NormGSF,
-                   Float_t ElecChi2NormKF,
-                   Float_t ElecGSFNumHits,
-                   Float_t ElecKFNumHits,
-                   Float_t ElecGSFTrackResol,
-                   Float_t ElecGSFTracklnPt,
-                   Float_t ElecPin,
-                   Float_t ElecPout,
-                   Float_t ElecEecal,
-                   Float_t ElecDeltaEta,
-                   Float_t ElecDeltaPhi,
-                   Float_t ElecMvaInSigmaEtaEta,
-                   Float_t ElecMvaInHadEnergy,
-                   Float_t ElecMvaInDeltaEta
-                  );
+  double MVAValue(Float_t TauPt,
+                  Float_t TauEtaAtEcalEntrance,
+                  Float_t TauPhi,
+                  Float_t TauLeadChargedPFCandPt,
+                  Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
+                  Float_t TauEmFraction,
+                  Float_t TauLeadPFChargedHadrHoP,
+                  Float_t TauLeadPFChargedHadrEoP,
+                  Float_t TauVisMassIn,
+                  Float_t TaudCrackEta,
+                  Float_t TaudCrackPhi,
+                  Float_t TauHasGsf,
+                  Int_t TauSignalPFGammaCandsIn,
+                  Int_t TauSignalPFGammaCandsOut,
+                  Float_t TauGammaEtaMomIn,
+                  Float_t TauGammaEtaMomOut,
+                  Float_t TauGammaPhiMomIn,
+                  Float_t TauGammaPhiMomOut,
+                  Float_t TauGammaEnFracIn,
+                  Float_t TauGammaEnFracOut,
+                  Float_t ElecEta,
+                  Float_t ElecPhi,
+                  Float_t ElecEtotOverPin,
+                  Float_t ElecChi2NormGSF,
+                  Float_t ElecChi2NormKF,
+                  Float_t ElecGSFNumHits,
+                  Float_t ElecKFNumHits,
+                  Float_t ElecGSFTrackResol,
+                  Float_t ElecGSFTracklnPt,
+                  Float_t ElecPin,
+                  Float_t ElecPout,
+                  Float_t ElecEecal,
+                  Float_t ElecDeltaEta,
+                  Float_t ElecDeltaPhi,
+                  Float_t ElecMvaInSigmaEtaEta,
+                  Float_t ElecMvaInHadEnergy,
+                  Float_t ElecMvaInDeltaEta);
 
-   // this function can be called for all categories
-   double MVAValue(const reco::PFTau& thePFTau, 
-		   const reco::GsfElectron& theGsfEle);
-   // this function can be called for category 1 only !!
-   double MVAValue(const reco::PFTau& thePFTau);
+  // this function can be called for all categories
+  double MVAValue(const reco::PFTau& thePFTau, const reco::GsfElectron& theGsfEle);
+  // this function can be called for category 1 only !!
+  double MVAValue(const reco::PFTau& thePFTau);
 
-   // this function can be called for all categories
-   double MVAValue(const pat::Tau& theTau, 
-		   const pat::Electron& theEle);
-   // this function can be called for category 1 only !!
-   double MVAValue(const pat::Tau& theTau);
-   // track extrapolation to ECAL entrance (used to re-calculate varibales that might not be available on miniAOD)
-   bool atECalEntrance(const reco::Candidate* part, math::XYZPoint &pos);    
+  // this function can be called for all categories
+  double MVAValue(const pat::Tau& theTau, const pat::Electron& theEle);
+  // this function can be called for category 1 only !!
+  double MVAValue(const pat::Tau& theTau);
+  // track extrapolation to ECAL entrance (used to re-calculate varibales that might not be available on miniAOD)
+  bool atECalEntrance(const reco::Candidate* part, math::XYZPoint& pos);
 
- private:   
+private:
+  double dCrackEta(double eta);
+  double minimum(double a, double b);
+  double dCrackPhi(double phi, double eta);
 
-   double dCrackEta(double eta);
-   double minimum(double a,double b);
-   double dCrackPhi(double phi, double eta);
+  bool isInitialized_;
+  bool loadMVAfromDB_;
+  edm::FileInPath inputFileName_;
 
-   bool isInitialized_;
-   bool loadMVAfromDB_;
-   edm::FileInPath inputFileName_;
-   
-   std::string mvaName_NoEleMatch_woGwoGSF_BL_;
-   std::string mvaName_NoEleMatch_wGwoGSF_BL_;
-   std::string mvaName_woGwGSF_BL_;
-   std::string mvaName_wGwGSF_BL_;
-   std::string mvaName_NoEleMatch_woGwoGSF_EC_;
-   std::string mvaName_NoEleMatch_wGwoGSF_EC_;
-   std::string mvaName_woGwGSF_EC_;
-   std::string mvaName_wGwGSF_EC_;
+  std::string mvaName_NoEleMatch_woGwoGSF_BL_;
+  std::string mvaName_NoEleMatch_wGwoGSF_BL_;
+  std::string mvaName_woGwGSF_BL_;
+  std::string mvaName_wGwGSF_BL_;
+  std::string mvaName_NoEleMatch_woGwoGSF_EC_;
+  std::string mvaName_NoEleMatch_wGwoGSF_EC_;
+  std::string mvaName_woGwGSF_EC_;
+  std::string mvaName_wGwGSF_EC_;
 
-   bool usePhiAtEcalEntranceExtrapolation_;
+  bool usePhiAtEcalEntranceExtrapolation_;
 
-   Float_t* Var_NoEleMatch_woGwoGSF_Barrel_;
-   Float_t* Var_NoEleMatch_wGwoGSF_Barrel_;
-   Float_t* Var_woGwGSF_Barrel_;
-   Float_t* Var_wGwGSF_Barrel_;
-   Float_t* Var_NoEleMatch_woGwoGSF_Endcap_;
-   Float_t* Var_NoEleMatch_wGwoGSF_Endcap_;
-   Float_t* Var_woGwGSF_Endcap_;
-   Float_t* Var_wGwGSF_Endcap_;
-   
-   const GBRForest* mva_NoEleMatch_woGwoGSF_BL_;
-   const GBRForest* mva_NoEleMatch_wGwoGSF_BL_;
-   const GBRForest* mva_woGwGSF_BL_;
-   const GBRForest* mva_wGwGSF_BL_;
-   const GBRForest* mva_NoEleMatch_woGwoGSF_EC_;
-   const GBRForest* mva_NoEleMatch_wGwoGSF_EC_;
-   const GBRForest* mva_woGwGSF_EC_;
-   const GBRForest* mva_wGwGSF_EC_;
+  Float_t* Var_NoEleMatch_woGwoGSF_Barrel_;
+  Float_t* Var_NoEleMatch_wGwoGSF_Barrel_;
+  Float_t* Var_woGwGSF_Barrel_;
+  Float_t* Var_wGwGSF_Barrel_;
+  Float_t* Var_NoEleMatch_woGwoGSF_Endcap_;
+  Float_t* Var_NoEleMatch_wGwoGSF_Endcap_;
+  Float_t* Var_woGwGSF_Endcap_;
+  Float_t* Var_wGwGSF_Endcap_;
 
-   std::vector<TFile*> inputFilesToDelete_;
+  const GBRForest* mva_NoEleMatch_woGwoGSF_BL_;
+  const GBRForest* mva_NoEleMatch_wGwoGSF_BL_;
+  const GBRForest* mva_woGwGSF_BL_;
+  const GBRForest* mva_wGwGSF_BL_;
+  const GBRForest* mva_NoEleMatch_woGwoGSF_EC_;
+  const GBRForest* mva_NoEleMatch_wGwoGSF_EC_;
+  const GBRForest* mva_woGwGSF_EC_;
+  const GBRForest* mva_wGwGSF_EC_;
 
-   double bField_;
-   int verbosity_;
+  std::vector<TFile*> inputFilesToDelete_;
+
+  double bField_;
+  int verbosity_;
 };
 
 #endif

--- a/RecoTauTag/RecoTau/interface/CombinatoricGenerator.h
+++ b/RecoTauTag/RecoTau/interface/CombinatoricGenerator.h
@@ -44,12 +44,12 @@
  *
  */
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-template <typename T>
-  class Combinatoric
-  {
-    /* Combinatoric<T>
+    template <typename T>
+    class Combinatoric {
+      /* Combinatoric<T>
      *
      * Class that represents a subset of values from a collection of type T.
      *
@@ -61,184 +61,178 @@ template <typename T>
      *
      */
 
-    // Iterator over input collection
-    typedef typename T::const_iterator value_iter;
-    typedef typename T::value_type value_type;
-    typedef size_t index_type;
-    typedef typename std::vector<index_type> indices_collection;
-    typedef typename indices_collection::const_iterator index_iter;
-    typedef typename std::set<index_type> indices_set;
+      // Iterator over input collection
+      typedef typename T::const_iterator value_iter;
+      typedef typename T::value_type value_type;
+      typedef size_t index_type;
+      typedef typename std::vector<index_type> indices_collection;
+      typedef typename indices_collection::const_iterator index_iter;
+      typedef typename std::set<index_type> indices_set;
 
-    class IndexInSet {
-      /* Determine if a given index is in a set of indices */
+      class IndexInSet {
+        /* Determine if a given index is in a set of indices */
       public:
-        IndexInSet(const indices_set& combo, bool negate):
-          combo_(combo),negate_(negate){}
+        IndexInSet(const indices_set& combo, bool negate) : combo_(combo), negate_(negate) {}
         bool operator()(const index_type& index) const {
           return (negate_) ? !combo_.count(index) : combo_.count(index);
         }
+
       private:
         indices_set combo_;
         bool negate_;
-    };
+      };
 
-    class ValueAccessor
-    {
-      /* Class to extract a value from a collection given the beginning of the collection
+      class ValueAccessor {
+        /* Class to extract a value from a collection given the beginning of the collection
        * and the index into the colleciton */
       public:
-        ValueAccessor(const value_iter& begin):
-          begin_(begin){}
-        const value_type& operator()(index_type const & index) const {
-          return *(begin_+index);
-        }
+        ValueAccessor(const value_iter& begin) : begin_(begin) {}
+        const value_type& operator()(index_type const& index) const { return *(begin_ + index); }
+
       private:
         value_iter begin_;
-    };
+      };
 
     public:
+      Combinatoric(const value_iter& begin,
+                   const indices_collection& indices,
+                   const indices_collection& combo,
+                   bool done)
+          : begin_(begin),
+            combo_(combo.begin(), combo.end()),
+            comboSet_(combo.begin(), combo.end()),
+            indices_(indices),
+            done_(done),
+            valueAccessor_(begin),
+            inChoice_(comboSet_, false),
+            notInChoice_(comboSet_, true) {}
 
-    Combinatoric(const value_iter& begin, const indices_collection& indices,
-        const indices_collection& combo, bool done):
-      begin_(begin), combo_(combo.begin(), combo.end()),
-      comboSet_(combo.begin(), combo.end()),
-      indices_(indices),
-      done_(done),
-      valueAccessor_(begin), inChoice_(comboSet_, false),
-      notInChoice_(comboSet_, true) {}
+      typedef typename boost::filter_iterator<IndexInSet, index_iter> ComboIter;
+      typedef typename boost::transform_iterator<ValueAccessor, ComboIter> ValueIter;
 
-    typedef typename boost::filter_iterator<IndexInSet, index_iter> ComboIter;
-    typedef typename boost::transform_iterator<ValueAccessor, ComboIter> ValueIter;
-
-    /// The first element in the selected subset
-    ValueIter combo_begin() const { return ValueIter(ComboIter(inChoice_, indices_.begin(), indices_.end()), valueAccessor_); }
-    /// One past the last element in the selected subset
-    ValueIter combo_end() const { return ValueIter(ComboIter(inChoice_, indices_.end(), indices_.end()), valueAccessor_); }
-
-    /// The first element in the non-selected subset
-    ValueIter remainder_end() const { return ValueIter(ComboIter(notInChoice_, indices_.end(), indices_.end()), valueAccessor_); }
-    /// One past the last element in the non-selected subset
-    ValueIter remainder_begin() const { return ValueIter(ComboIter(notInChoice_, indices_.begin(), indices_.end()), valueAccessor_); }
-
-    /// Build the next cominatoric subset after the current one
-    Combinatoric<T> next() const
-    {
-      //std::cout << "building next: " << std::endl;
-      //std::cout << "current " << std::endl;
-      //std::copy(combo_.begin(), combo_.end(), std::ostream_iterator<int>(std::cout, " "));
-      //std::cout << std::endl;
-
-      indices_collection newCombo(combo_);
-
-      // Find the first value that can be updated (starting from the back
-      // max value for index is (nElements-1) - (distance from end)
-      // Examples:
-      //    189 -> 289 (will be updated to 234)
-      //    179 -> 189
-      //    123 -> 124
-      size_t distanceFromEnd = 0;
-      size_t nElements = indices_.size();
-      indices_collection::reverse_iterator pos = newCombo.rbegin();
-      for(; pos != newCombo.rend(); ++pos, ++distanceFromEnd)
-      {
-        // Check if we can update this element to the next value (without overflow)
-        // If so, increment it it, then quit
-        if( *pos < (nElements - 1 - distanceFromEnd) )
-        {
-          (*pos)++;
-          break;
-        } else {
-          // Set to 'unset value' - we need to update it!
-          (*pos) = nElements;
-        }
+      /// The first element in the selected subset
+      ValueIter combo_begin() const {
+        return ValueIter(ComboIter(inChoice_, indices_.begin(), indices_.end()), valueAccessor_);
+      }
+      /// One past the last element in the selected subset
+      ValueIter combo_end() const {
+        return ValueIter(ComboIter(inChoice_, indices_.end(), indices_.end()), valueAccessor_);
       }
 
-      //std::cout << "after update " << std::endl;
-      //std::copy(newCombo.begin(), newCombo.end(), std::ostream_iterator<int>(std::cout, " "));
-      //std::cout << std::endl;
-
-      // forward_pos points to the element *after* pos
-      indices_collection::iterator forward_pos = pos.base();
-      // Only do the updates if we have not reached all the way to the beginning!
-      // this indicates we are at the end of the iteration.  We return a combo
-      // with all values at nElements to flag that we are at the end
-      bool done = true;
-      if (forward_pos != newCombo.begin()) {
-        // Everything after pos needs to be updated.  i.e. 159 -> 167
-        index_type next_pos_value = (*pos)+1;
-        //std::cout << "next pos: " << next_pos_value << std::endl;
-        done = false;
-        for (; forward_pos != newCombo.end(); ++forward_pos, ++next_pos_value) {
-          *forward_pos = next_pos_value;
-        }
+      /// The first element in the non-selected subset
+      ValueIter remainder_end() const {
+        return ValueIter(ComboIter(notInChoice_, indices_.end(), indices_.end()), valueAccessor_);
+      }
+      /// One past the last element in the non-selected subset
+      ValueIter remainder_begin() const {
+        return ValueIter(ComboIter(notInChoice_, indices_.begin(), indices_.end()), valueAccessor_);
       }
 
-      //std::cout << "final " << std::endl;
-      //std::copy(newCombo.begin(), newCombo.end(), std::ostream_iterator<int>(std::cout, " "));
-      //std::cout << std::endl;
+      /// Build the next cominatoric subset after the current one
+      Combinatoric<T> next() const {
+        //std::cout << "building next: " << std::endl;
+        //std::cout << "current " << std::endl;
+        //std::copy(combo_.begin(), combo_.end(), std::ostream_iterator<int>(std::cout, " "));
+        //std::cout << std::endl;
 
-      //return std::unique_ptr<Combinatoric<T> >(new Combinatoric<T>(begin_, indices_, newCombo));
-      return Combinatoric<T>(begin_, indices_, newCombo, done);
-    }
+        indices_collection newCombo(combo_);
 
-    // Check if iteration is done
-    bool done() const { return done_; }
+        // Find the first value that can be updated (starting from the back
+        // max value for index is (nElements-1) - (distance from end)
+        // Examples:
+        //    189 -> 289 (will be updated to 234)
+        //    179 -> 189
+        //    123 -> 124
+        size_t distanceFromEnd = 0;
+        size_t nElements = indices_.size();
+        indices_collection::reverse_iterator pos = newCombo.rbegin();
+        for (; pos != newCombo.rend(); ++pos, ++distanceFromEnd) {
+          // Check if we can update this element to the next value (without overflow)
+          // If so, increment it it, then quit
+          if (*pos < (nElements - 1 - distanceFromEnd)) {
+            (*pos)++;
+            break;
+          } else {
+            // Set to 'unset value' - we need to update it!
+            (*pos) = nElements;
+          }
+        }
 
-    /// Return the set of selected indices
-    const indices_set& combo() const { return comboSet_; }
+        //std::cout << "after update " << std::endl;
+        //std::copy(newCombo.begin(), newCombo.end(), std::ostream_iterator<int>(std::cout, " "));
+        //std::cout << std::endl;
 
-    /// Comparison to another combination
-    bool operator==(const Combinatoric<T>& rhs) const
-    {
-      return (this->combo() == rhs.combo() && this->done() == rhs.done());
-    }
+        // forward_pos points to the element *after* pos
+        indices_collection::iterator forward_pos = pos.base();
+        // Only do the updates if we have not reached all the way to the beginning!
+        // this indicates we are at the end of the iteration.  We return a combo
+        // with all values at nElements to flag that we are at the end
+        bool done = true;
+        if (forward_pos != newCombo.begin()) {
+          // Everything after pos needs to be updated.  i.e. 159 -> 167
+          index_type next_pos_value = (*pos) + 1;
+          //std::cout << "next pos: " << next_pos_value << std::endl;
+          done = false;
+          for (; forward_pos != newCombo.end(); ++forward_pos, ++next_pos_value) {
+            *forward_pos = next_pos_value;
+          }
+        }
+
+        //std::cout << "final " << std::endl;
+        //std::copy(newCombo.begin(), newCombo.end(), std::ostream_iterator<int>(std::cout, " "));
+        //std::cout << std::endl;
+
+        //return std::unique_ptr<Combinatoric<T> >(new Combinatoric<T>(begin_, indices_, newCombo));
+        return Combinatoric<T>(begin_, indices_, newCombo, done);
+      }
+
+      // Check if iteration is done
+      bool done() const { return done_; }
+
+      /// Return the set of selected indices
+      const indices_set& combo() const { return comboSet_; }
+
+      /// Comparison to another combination
+      bool operator==(const Combinatoric<T>& rhs) const {
+        return (this->combo() == rhs.combo() && this->done() == rhs.done());
+      }
 
     private:
-    // Beginning and ending of the vector of iterators that point to our
-    // input collection
-    value_iter begin_;
-    indices_collection combo_;
-    indices_set comboSet_;
-    indices_collection indices_;
-    bool done_;
-    ValueAccessor valueAccessor_;
-    IndexInSet inChoice_;
-    IndexInSet notInChoice_;
-  };
+      // Beginning and ending of the vector of iterators that point to our
+      // input collection
+      value_iter begin_;
+      indices_collection combo_;
+      indices_set comboSet_;
+      indices_collection indices_;
+      bool done_;
+      ValueAccessor valueAccessor_;
+      IndexInSet inChoice_;
+      IndexInSet notInChoice_;
+    };
 
-template<typename T>
-  class CombinatoricIterator : public boost::iterator_facade<
-                               CombinatoricIterator<T>,
-                               const Combinatoric<T>,
-                               boost::forward_traversal_tag>
-{
-  /* An iterator over Combinatorics */
-  public:
-    typedef Combinatoric<T> value_type;
-    explicit CombinatoricIterator(const Combinatoric<T>& c):node_(c) {}
+    template <typename T>
+    class CombinatoricIterator
+        : public boost::iterator_facade<CombinatoricIterator<T>, const Combinatoric<T>, boost::forward_traversal_tag> {
+      /* An iterator over Combinatorics */
+    public:
+      typedef Combinatoric<T> value_type;
+      explicit CombinatoricIterator(const Combinatoric<T>& c) : node_(c) {}
 
-  private:
-    friend class boost::iterator_core_access;
+    private:
+      friend class boost::iterator_core_access;
 
-    bool equal(CombinatoricIterator const& other) const {
-      return this->node_ == other.node_;
-    }
+      bool equal(CombinatoricIterator const& other) const { return this->node_ == other.node_; }
 
-    void increment() {
-      node_ = node_.next();
-    }
+      void increment() { node_ = node_.next(); }
 
-    const Combinatoric<T>& dereference() const {
-      return node_;
-    }
+      const Combinatoric<T>& dereference() const { return node_; }
 
-    Combinatoric<T> node_;
-};
+      Combinatoric<T> node_;
+    };
 
-template<typename T>
-  class CombinatoricGenerator
-  {
-    /* CombinatoricGenerator
+    template <typename T>
+    class CombinatoricGenerator {
+      /* CombinatoricGenerator
      *
      * Generate combinatoric subsets of a collection of type T.
      *
@@ -247,70 +241,62 @@ template<typename T>
      * range defined by <begin> and <end>.
      */
 
-    // Iterator over input collection
-    typedef typename T::const_iterator value_iter;
-    typedef typename T::value_type value_type;
-    typedef size_t index_type;
-    typedef typename std::vector<index_type> indices_collection;
-    typedef typename indices_collection::iterator index_iter;
-    typedef typename std::set<index_type> indices_set;
+      // Iterator over input collection
+      typedef typename T::const_iterator value_iter;
+      typedef typename T::value_type value_type;
+      typedef size_t index_type;
+      typedef typename std::vector<index_type> indices_collection;
+      typedef typename indices_collection::iterator index_iter;
+      typedef typename std::set<index_type> indices_set;
 
     public:
+      typedef std::unique_ptr<CombinatoricIterator<T> > CombIterPtr;
+      typedef CombinatoricIterator<T> iterator;
+      typedef typename iterator::value_type::ValueIter combo_iterator;
 
-    typedef std::unique_ptr<CombinatoricIterator<T> > CombIterPtr;
-    typedef CombinatoricIterator<T> iterator;
-    typedef typename iterator::value_type::ValueIter combo_iterator;
+      explicit CombinatoricGenerator(const value_iter& begin, const value_iter& end, size_t choose) {
+        // Make beginning and ending index collections
+        indices_collection initialCombo(choose);
+        indices_collection finalCombo(choose);
 
-    explicit CombinatoricGenerator(const value_iter& begin, const value_iter& end, size_t choose)
-    {
-      // Make beginning and ending index collections
-      indices_collection initialCombo(choose);
-      indices_collection finalCombo(choose);
+        size_t totalElements = end - begin;
 
-      size_t totalElements = end-begin;
+        if (choose <= totalElements) {
+          indices_collection allIndices(totalElements);
+          for (size_t i = 0; i < totalElements; ++i) {
+            allIndices[i] = i;
+          }
 
-      if (choose <= totalElements) {
-        indices_collection allIndices(totalElements);
-        for(size_t i=0; i < totalElements; ++i)
-        {
-          allIndices[i] = i;
+          for (size_t i = 0; i < choose; ++i) {
+            initialCombo[i] = i;
+            // End conditions each is set at nElements
+            finalCombo[i] = totalElements;
+          }
+
+          beginning_ =
+              CombIterPtr(new CombinatoricIterator<T>(Combinatoric<T>(begin, allIndices, initialCombo, false)));
+
+          ending_ = CombIterPtr(new CombinatoricIterator<T>(Combinatoric<T>(begin, allIndices, finalCombo, true)));
+        } else {
+          // We don't have enough in the collection to return [choose] items.
+          // Return an empty collection
+          beginning_ = CombIterPtr(
+              new CombinatoricIterator<T>(Combinatoric<T>(begin, indices_collection(), indices_collection(), true)));
+
+          ending_ = CombIterPtr(
+              new CombinatoricIterator<T>(Combinatoric<T>(begin, indices_collection(), indices_collection(), true)));
         }
-
-        for(size_t i=0; i < choose; ++i)
-        {
-          initialCombo[i] = i;
-          // End conditions each is set at nElements
-          finalCombo[i] = totalElements;
-        }
-
-        beginning_ = CombIterPtr(new CombinatoricIterator<T>(Combinatoric<T>(
-                begin, allIndices, initialCombo, false)));
-
-        ending_ = CombIterPtr(new CombinatoricIterator<T>(Combinatoric<T>(
-                begin, allIndices, finalCombo, true)));
-      } else {
-        // We don't have enough in the collection to return [choose] items.
-        // Return an empty collection
-        beginning_ = CombIterPtr(new CombinatoricIterator<T>(Combinatoric<T>(
-                begin, indices_collection(), indices_collection(), true)));
-
-        ending_ = CombIterPtr(new CombinatoricIterator<T>(Combinatoric<T>(
-                begin, indices_collection(), indices_collection(), true)));
       }
-    }
 
-    CombinatoricIterator<T> begin() {
-      return *beginning_;
-    }
+      CombinatoricIterator<T> begin() { return *beginning_; }
 
-    CombinatoricIterator<T> end() {
-      return *ending_;
-    }
+      CombinatoricIterator<T> end() { return *ending_; }
 
     private:
-    CombIterPtr beginning_;
-    CombIterPtr ending_;
-  };
+      CombIterPtr beginning_;
+      CombIterPtr ending_;
+    };
 
-} } // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 #endif

--- a/RecoTauTag/RecoTau/interface/ConeTools.h
+++ b/RecoTauTag/RecoTau/interface/ConeTools.h
@@ -9,56 +9,49 @@
 
 namespace reco::tau::cone {
 
-// Predicate class that tests if a candidate lies within some deltaR (min,
-// max) about a supplied axis
-template<class CandType>
-class DeltaRFilter {
+  // Predicate class that tests if a candidate lies within some deltaR (min,
+  // max) about a supplied axis
+  template <class CandType>
+  class DeltaRFilter {
   public:
     DeltaRFilter(const reco::Candidate::LorentzVector& axis, double min, double max)
-      : eta_(axis.eta()),
-        phi_(axis.phi()),
-        min2_(min < 0. ? -min*min : min*min),
-        max2_(max*max) 
-    {}
-    bool operator()(const CandType& b) const 
-    {
+        : eta_(axis.eta()), phi_(axis.phi()), min2_(min < 0. ? -min * min : min * min), max2_(max * max) {}
+    bool operator()(const CandType& b) const {
       double dR2 = deltaR2(b.eta(), b.phi(), eta_, phi_);
       return (dR2 >= min2_ && dR2 < max2_);
     }
+
   private:
     double eta_;
     double phi_;
     const double min2_;
     const double max2_;
-};
+  };
 
-// Wrapper around DeltaRFilter to support reference types like Ptr<>
-template<class CandType>
-class DeltaRPtrFilter {
+  // Wrapper around DeltaRFilter to support reference types like Ptr<>
+  template <class CandType>
+  class DeltaRPtrFilter {
   public:
-    DeltaRPtrFilter(const reco::Candidate::LorentzVector& axis,
-                    double min, double max): filter_(axis, min, max) {}
+    DeltaRPtrFilter(const reco::Candidate::LorentzVector& axis, double min, double max) : filter_(axis, min, max) {}
     bool operator()(const CandType& b) const { return filter_(*b); }
+
   private:
     DeltaRFilter<typename CandType::value_type> filter_;
-};
+  };
 
-/* Define our filters */
-typedef DeltaRPtrFilter<PFCandidatePtr> PFCandPtrDRFilter;
-typedef boost::filter_iterator< PFCandPtrDRFilter,
-        std::vector<PFCandidatePtr>::const_iterator> PFCandPtrDRFilterIter;
+  /* Define our filters */
+  typedef DeltaRPtrFilter<PFCandidatePtr> PFCandPtrDRFilter;
+  typedef boost::filter_iterator<PFCandPtrDRFilter, std::vector<PFCandidatePtr>::const_iterator> PFCandPtrDRFilterIter;
 
-typedef DeltaRPtrFilter<CandidatePtr> CandPtrDRFilter;
-typedef boost::filter_iterator< CandPtrDRFilter,
-        std::vector<CandidatePtr>::const_iterator> CandPtrDRFilterIter;
+  typedef DeltaRPtrFilter<CandidatePtr> CandPtrDRFilter;
+  typedef boost::filter_iterator<CandPtrDRFilter, std::vector<CandidatePtr>::const_iterator> CandPtrDRFilterIter;
 
-typedef DeltaRFilter<PFRecoTauChargedHadron> ChargedHadronDRFilter;
-typedef boost::filter_iterator< ChargedHadronDRFilter,
-        std::vector<PFRecoTauChargedHadron>::const_iterator> ChargedHadronDRFilterIter;
+  typedef DeltaRFilter<PFRecoTauChargedHadron> ChargedHadronDRFilter;
+  typedef boost::filter_iterator<ChargedHadronDRFilter, std::vector<PFRecoTauChargedHadron>::const_iterator>
+      ChargedHadronDRFilterIter;
 
-typedef DeltaRFilter<RecoTauPiZero> PiZeroDRFilter;
-typedef boost::filter_iterator< PiZeroDRFilter,
-        std::vector<RecoTauPiZero>::const_iterator> PiZeroDRFilterIter;
+  typedef DeltaRFilter<RecoTauPiZero> PiZeroDRFilter;
+  typedef boost::filter_iterator<PiZeroDRFilter, std::vector<RecoTauPiZero>::const_iterator> PiZeroDRFilterIter;
 
 }  // end namespace reco::tau::cone
 

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -27,36 +27,36 @@
 
 namespace deep_tau {
 
-class TauWPThreshold {
-public:
+  class TauWPThreshold {
+  public:
     explicit TauWPThreshold(const std::string& cut_str);
     double operator()(const pat::Tau& tau) const;
 
-private:
+  private:
     std::unique_ptr<TF1> fn_;
     double value_;
-};
+  };
 
-class DeepTauCache {
-public:
+  class DeepTauCache {
+  public:
     using GraphPtr = std::shared_ptr<tensorflow::GraphDef>;
 
     DeepTauCache(const std::map<std::string, std::string>& graph_names, bool mem_mapped);
     ~DeepTauCache();
 
-   // A Session allows concurrent calls to Run(), though a Session must
-   // be created / extended by a single thread.
-   tensorflow::Session& getSession(const std::string& name = "") const { return *sessions_.at(name); }
-   const tensorflow::GraphDef& getGraph(const std::string& name = "") const { return *graphs_.at(name); }
+    // A Session allows concurrent calls to Run(), though a Session must
+    // be created / extended by a single thread.
+    tensorflow::Session& getSession(const std::string& name = "") const { return *sessions_.at(name); }
+    const tensorflow::GraphDef& getGraph(const std::string& name = "") const { return *graphs_.at(name); }
 
-private:
+  private:
     std::map<std::string, GraphPtr> graphs_;
     std::map<std::string, tensorflow::Session*> sessions_;
     std::map<std::string, std::unique_ptr<tensorflow::MemmappedEnv>> memmappedEnv_;
-};
+  };
 
-class DeepTauBase : public edm::stream::EDProducer<edm::GlobalCache<DeepTauCache>> {
-public:
+  class DeepTauBase : public edm::stream::EDProducer<edm::GlobalCache<DeepTauCache>> {
+  public:
     using TauType = pat::Tau;
     using TauDiscriminator = pat::PATTauDiscriminator;
     using TauCollection = std::vector<TauType>;
@@ -70,17 +70,17 @@ public:
     using WPMap = std::map<std::string, CutterPtr>;
 
     struct Output {
-        using ResultMap = std::map<std::string, std::unique_ptr<TauDiscriminator>>;
-        std::vector<size_t> num_, den_;
+      using ResultMap = std::map<std::string, std::unique_ptr<TauDiscriminator>>;
+      std::vector<size_t> num_, den_;
 
-        Output(const std::vector<size_t>& num, const std::vector<size_t>& den) : num_(num), den_(den) {}
+      Output(const std::vector<size_t>& num, const std::vector<size_t>& den) : num_(num), den_(den) {}
 
-        ResultMap get_value(const edm::Handle<TauCollection>& taus, const tensorflow::Tensor& pred,
-                            const WPMap& working_points) const;
+      ResultMap get_value(const edm::Handle<TauCollection>& taus,
+                          const tensorflow::Tensor& pred,
+                          const WPMap& working_points) const;
     };
 
     using OutputCollection = std::map<std::string, Output>;
-
 
     DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputs, const DeepTauCache* cache);
     ~DeepTauBase() override {}
@@ -88,21 +88,23 @@ public:
     void produce(edm::Event& event, const edm::EventSetup& es) override;
 
     static std::unique_ptr<DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg);
-    static void globalEndJob(const DeepTauCache* cache){ }
-private:
-    virtual tensorflow::Tensor getPredictions(edm::Event& event, const edm::EventSetup& es,
+    static void globalEndJob(const DeepTauCache* cache) {}
+
+  private:
+    virtual tensorflow::Tensor getPredictions(edm::Event& event,
+                                              const edm::EventSetup& es,
                                               edm::Handle<TauCollection> taus) = 0;
     virtual void createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus);
 
-protected:
+  protected:
     edm::EDGetTokenT<TauCollection> tausToken_;
     edm::EDGetTokenT<pat::PackedCandidateCollection> pfcandToken_;
     edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
     std::map<std::string, WPMap> workingPoints_;
     OutputCollection outputs_;
     const DeepTauCache* cache_;
-};
+  };
 
-} // namespace deep_tau
+}  // namespace deep_tau
 
 #endif

--- a/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
@@ -26,46 +26,45 @@
 
 namespace reco {
 
-// Forward declarations
-class Jet;
-class PFRecoTauChargedHadron;
+  // Forward declarations
+  class Jet;
+  class PFRecoTauChargedHadron;
 
-namespace tau {
+  namespace tau {
 
-class PFRecoTauChargedHadronBuilderPlugin : public RecoTauEventHolderPlugin 
-{
- public:
-  // Return a vector of pointers
-  typedef boost::ptr_vector<PFRecoTauChargedHadron> ChargedHadronVector;
-  // Storing the result in an auto ptr on function return allows
-  // allows us to safely release the ptr_vector in the virtual function
-  typedef std::auto_ptr<ChargedHadronVector> return_type;
-  explicit PFRecoTauChargedHadronBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC)
-    : RecoTauEventHolderPlugin(pset) 
-  {}
-  ~PFRecoTauChargedHadronBuilderPlugin() override {}
-  /// Build a collection of chargedHadrons from objects in the input jet
-  virtual return_type operator()(const Jet&) const = 0;
-  /// Hook called at the beginning of the event.
-  void beginEvent() override {}
-};
+    class PFRecoTauChargedHadronBuilderPlugin : public RecoTauEventHolderPlugin {
+    public:
+      // Return a vector of pointers
+      typedef boost::ptr_vector<PFRecoTauChargedHadron> ChargedHadronVector;
+      // Storing the result in an auto ptr on function return allows
+      // allows us to safely release the ptr_vector in the virtual function
+      typedef std::auto_ptr<ChargedHadronVector> return_type;
+      explicit PFRecoTauChargedHadronBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+          : RecoTauEventHolderPlugin(pset) {}
+      ~PFRecoTauChargedHadronBuilderPlugin() override {}
+      /// Build a collection of chargedHadrons from objects in the input jet
+      virtual return_type operator()(const Jet&) const = 0;
+      /// Hook called at the beginning of the event.
+      void beginEvent() override {}
+    };
 
-class PFRecoTauChargedHadronQualityPlugin : public RecoTauNamedPlugin 
-{
- public:
-  explicit PFRecoTauChargedHadronQualityPlugin(const edm::ParameterSet& pset)
-    : RecoTauNamedPlugin(pset) 
-  {}
-  ~PFRecoTauChargedHadronQualityPlugin() override {}
-  /// Return a number indicating the quality of this chargedHadron
-  virtual double operator()(const PFRecoTauChargedHadron&) const = 0;
-};
+    class PFRecoTauChargedHadronQualityPlugin : public RecoTauNamedPlugin {
+    public:
+      explicit PFRecoTauChargedHadronQualityPlugin(const edm::ParameterSet& pset) : RecoTauNamedPlugin(pset) {}
+      ~PFRecoTauChargedHadronQualityPlugin() override {}
+      /// Return a number indicating the quality of this chargedHadron
+      virtual double operator()(const PFRecoTauChargedHadron&) const = 0;
+    };
 
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
-typedef edmplugin::PluginFactory<reco::tau::PFRecoTauChargedHadronQualityPlugin*(const edm::ParameterSet&)> PFRecoTauChargedHadronQualityPluginFactory;
-typedef edmplugin::PluginFactory<reco::tau::PFRecoTauChargedHadronBuilderPlugin*(const edm::ParameterSet&, edm::ConsumesCollector &&iC)> PFRecoTauChargedHadronBuilderPluginFactory;
+typedef edmplugin::PluginFactory<reco::tau::PFRecoTauChargedHadronQualityPlugin*(const edm::ParameterSet&)>
+    PFRecoTauChargedHadronQualityPluginFactory;
+typedef edmplugin::PluginFactory<reco::tau::PFRecoTauChargedHadronBuilderPlugin*(const edm::ParameterSet&,
+                                                                                 edm::ConsumesCollector&& iC)>
+    PFRecoTauChargedHadronBuilderPluginFactory;
 
 #endif

--- a/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
@@ -11,63 +11,71 @@
  *                                                                                                                                                                                   
  */
 
-
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
-namespace reco { namespace tau {
-  /// return chi2 of the leading track ==> deprecated? <==
-  float lead_track_chi2(const reco::PFTau& tau);
-  /// return ratio of energy in ECAL over sum of energy in ECAL and HCAL
-  float eratio(const reco::PFTau& tau);
-  float eratio(const pat::Tau& tau);
-  /// return sum of pt weighted values of distance to tau candidate for all pf photon candidates, 
-  /// which are associated to signal; depending on var the distance is in 0=:dr, 1=:deta, 2=:dphi 
-  float pt_weighted_dx(const reco::PFTau& tau, int mode = 0, int var = 0, int decaymode = -1);
-  float pt_weighted_dx(const pat::Tau& tau, int mode = 0, int var = 0, int decaymode = -1);
-  /// return sum of pt weighted values of dr relative to tau candidate for all pf photon candidates,
-  /// which are associated to signal
-  inline float pt_weighted_dr_signal(const reco::PFTau& tau, int dm) {
-    return pt_weighted_dx(tau, 0, 0, dm);
-  }
-  inline float pt_weighted_dr_signal(const pat::Tau& tau, int dm) {
-    return pt_weighted_dx(tau, 0, 0, dm);
-  }
-  /// return sum of pt weighted values of deta relative to tau candidate for all pf photon candidates,
-  /// which are associated to signal
-  inline float pt_weighted_deta_strip(const reco::PFTau& tau, int dm) {
-    return pt_weighted_dx(tau, dm==10 ? 2 : 1, 1, dm);
-  }
-  inline float pt_weighted_deta_strip(const pat::Tau& tau, int dm) {
-    return pt_weighted_dx(tau, dm==10 ? 2 : 1, 1, dm);
-  }
-  /// return sum of pt weighted values of dphi relative to tau candidate for all pf photon candidates,
-  /// which are associated to signal
-  inline float pt_weighted_dphi_strip(const reco::PFTau& tau, int dm) {
-    return pt_weighted_dx(tau, dm==10 ? 2 : 1, 2, dm);
-  }
-  inline float pt_weighted_dphi_strip(const pat::Tau& tau, int dm) {
-    return pt_weighted_dx(tau, dm==10 ? 2 : 1, 2, dm);
-  }  
-  /// return sum of pt weighted values of dr relative to tau candidate for all pf photon candidates,
-  /// which are inside an isolation conde but not associated to signal
-  inline float pt_weighted_dr_iso(const reco::PFTau& tau, int dm) {
-    return pt_weighted_dx(tau, 2, 0, dm);
-  }
-  inline float pt_weighted_dr_iso(const pat::Tau& tau, int dm) {
-    return pt_weighted_dx(tau, 2, 0, dm);
-  }
-  /// return total number of pf photon candidates with pT>500 MeV, which are associated to signal
-  unsigned int n_photons_total(const reco::PFTau& tau);
-  unsigned int n_photons_total(const pat::Tau& tau);
-  
-  enum {kOldDMwoLT, kOldDMwLT, kNewDMwoLT, kNewDMwLT, kDBoldDMwLT, kDBnewDMwLT, kPWoldDMwLT, kPWnewDMwLT, 
-        kDBoldDMwLTwGJ, kDBnewDMwLTwGJ};
-  bool fillIsoMVARun2Inputs(float* mvaInput, const pat::Tau& tau, int mvaOpt, const std::string& nameCharged,
-                            const std::string& nameNeutral, const std::string& namePu, 
-                            const std::string& nameOutside, const std::string& nameFootprint);
-}} // namespaces
+namespace reco {
+  namespace tau {
+    /// return chi2 of the leading track ==> deprecated? <==
+    float lead_track_chi2(const reco::PFTau& tau);
+    /// return ratio of energy in ECAL over sum of energy in ECAL and HCAL
+    float eratio(const reco::PFTau& tau);
+    float eratio(const pat::Tau& tau);
+    /// return sum of pt weighted values of distance to tau candidate for all pf photon candidates,
+    /// which are associated to signal; depending on var the distance is in 0=:dr, 1=:deta, 2=:dphi
+    float pt_weighted_dx(const reco::PFTau& tau, int mode = 0, int var = 0, int decaymode = -1);
+    float pt_weighted_dx(const pat::Tau& tau, int mode = 0, int var = 0, int decaymode = -1);
+    /// return sum of pt weighted values of dr relative to tau candidate for all pf photon candidates,
+    /// which are associated to signal
+    inline float pt_weighted_dr_signal(const reco::PFTau& tau, int dm) { return pt_weighted_dx(tau, 0, 0, dm); }
+    inline float pt_weighted_dr_signal(const pat::Tau& tau, int dm) { return pt_weighted_dx(tau, 0, 0, dm); }
+    /// return sum of pt weighted values of deta relative to tau candidate for all pf photon candidates,
+    /// which are associated to signal
+    inline float pt_weighted_deta_strip(const reco::PFTau& tau, int dm) {
+      return pt_weighted_dx(tau, dm == 10 ? 2 : 1, 1, dm);
+    }
+    inline float pt_weighted_deta_strip(const pat::Tau& tau, int dm) {
+      return pt_weighted_dx(tau, dm == 10 ? 2 : 1, 1, dm);
+    }
+    /// return sum of pt weighted values of dphi relative to tau candidate for all pf photon candidates,
+    /// which are associated to signal
+    inline float pt_weighted_dphi_strip(const reco::PFTau& tau, int dm) {
+      return pt_weighted_dx(tau, dm == 10 ? 2 : 1, 2, dm);
+    }
+    inline float pt_weighted_dphi_strip(const pat::Tau& tau, int dm) {
+      return pt_weighted_dx(tau, dm == 10 ? 2 : 1, 2, dm);
+    }
+    /// return sum of pt weighted values of dr relative to tau candidate for all pf photon candidates,
+    /// which are inside an isolation conde but not associated to signal
+    inline float pt_weighted_dr_iso(const reco::PFTau& tau, int dm) { return pt_weighted_dx(tau, 2, 0, dm); }
+    inline float pt_weighted_dr_iso(const pat::Tau& tau, int dm) { return pt_weighted_dx(tau, 2, 0, dm); }
+    /// return total number of pf photon candidates with pT>500 MeV, which are associated to signal
+    unsigned int n_photons_total(const reco::PFTau& tau);
+    unsigned int n_photons_total(const pat::Tau& tau);
+
+    enum {
+      kOldDMwoLT,
+      kOldDMwLT,
+      kNewDMwoLT,
+      kNewDMwLT,
+      kDBoldDMwLT,
+      kDBnewDMwLT,
+      kPWoldDMwLT,
+      kPWnewDMwLT,
+      kDBoldDMwLTwGJ,
+      kDBnewDMwLTwGJ
+    };
+    bool fillIsoMVARun2Inputs(float* mvaInput,
+                              const pat::Tau& tau,
+                              int mvaOpt,
+                              const std::string& nameCharged,
+                              const std::string& nameNeutral,
+                              const std::string& namePu,
+                              const std::string& nameOutside,
+                              const std::string& nameFootprint);
+  }  // namespace tau
+}  // namespace reco
 
 #endif

--- a/RecoTauTag/RecoTau/interface/PFRecoTauTagInfoAlgorithm.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauTagInfoAlgorithm.h
@@ -3,40 +3,43 @@
 
 #include "DataFormats/TauReco/interface/PFTauTagInfo.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlock.h" 
+#include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "Math/GenVector/VectorUtil.h" 
+#include "Math/GenVector/VectorUtil.h"
 
-class  PFRecoTauTagInfoAlgorithm  {
- public:
-  PFRecoTauTagInfoAlgorithm(){}
+class PFRecoTauTagInfoAlgorithm {
+public:
+  PFRecoTauTagInfoAlgorithm() {}
   PFRecoTauTagInfoAlgorithm(const edm::ParameterSet&);
-  ~PFRecoTauTagInfoAlgorithm(){}
-  reco::PFTauTagInfo buildPFTauTagInfo(const reco::JetBaseRef&,const std::vector<reco::CandidatePtr>&,const reco::TrackRefVector&,const reco::Vertex&) const; 
- private: 
+  ~PFRecoTauTagInfoAlgorithm() {}
+  reco::PFTauTagInfo buildPFTauTagInfo(const reco::JetBaseRef&,
+                                       const std::vector<reco::CandidatePtr>&,
+                                       const reco::TrackRefVector&,
+                                       const reco::Vertex&) const;
+
+private:
   double ChargedHadrCand_tkminPt_;
   int ChargedHadrCand_tkminPixelHitsn_;
   int ChargedHadrCand_tkminTrackerHitsn_;
   double ChargedHadrCand_tkmaxipt_;
   double ChargedHadrCand_tkmaxChi2_;
   double ChargedHadrCand_tkPVmaxDZ_;
-  // 
+  //
   double NeutrHadrCand_HcalclusMinEt_;
-  // 
+  //
   double GammaCand_EcalclusMinEt_;
   double ChargedHadronsAssociationCone_;
-  // 
+  //
   double tkminPt_;
   int tkminPixelHitsn_;
   int tkminTrackerHitsn_;
   double tkmaxipt_;
   double tkmaxChi2_;
   double tkPVmaxDZ_;
-  // 
+  //
   bool UsePVconstraint_;
 };
-#endif 
-
+#endif

--- a/RecoTauTag/RecoTau/interface/PFTauDecayModeTools.h
+++ b/RecoTauTag/RecoTau/interface/PFTauDecayModeTools.h
@@ -16,27 +16,25 @@ namespace reco {
   class GenJet;
 }
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-/// Reverse mapping of decay modes into multiplicities
-unsigned int chargedHadronsInDecayMode(
-    PFTau::hadronicDecayMode mode);
+    /// Reverse mapping of decay modes into multiplicities
+    unsigned int chargedHadronsInDecayMode(PFTau::hadronicDecayMode mode);
 
-unsigned int piZerosInDecayMode(
-    PFTau::hadronicDecayMode mode);
+    unsigned int piZerosInDecayMode(PFTau::hadronicDecayMode mode);
 
-PFTau::hadronicDecayMode translateDecayMode(
-    unsigned int nCharged, unsigned int nPiZero);
+    PFTau::hadronicDecayMode translateDecayMode(unsigned int nCharged, unsigned int nPiZero);
 
-/// Convert a genTau decay mode string ('oneProng0Pi0') to the RECO enum
-PFTau::hadronicDecayMode translateGenDecayModeToReco(
-    const std::string& genName);
+    /// Convert a genTau decay mode string ('oneProng0Pi0') to the RECO enum
+    PFTau::hadronicDecayMode translateGenDecayModeToReco(const std::string& genName);
 
-/// Convert a RECO enum decay mode to a string ('oneProng0Pi0')
-std::string translateRecoDecayModeToGen(PFTau::hadronicDecayMode decayMode);
+    /// Convert a RECO enum decay mode to a string ('oneProng0Pi0')
+    std::string translateRecoDecayModeToGen(PFTau::hadronicDecayMode decayMode);
 
-PFTau::hadronicDecayMode getDecayMode(const reco::GenJet* genJet);
+    PFTau::hadronicDecayMode getDecayMode(const reco::GenJet* genJet);
 
-}}
+  }  // namespace tau
+}  // namespace reco
 
 #endif

--- a/RecoTauTag/RecoTau/interface/PFTauPrimaryVertexProducerBase.h
+++ b/RecoTauTag/RecoTau/interface/PFTauPrimaryVertexProducerBase.h
@@ -37,12 +37,12 @@
 #include <TFormula.h>
 
 class PFTauPrimaryVertexProducerBase : public edm::stream::EDProducer<> {
- public:
-  enum Alg{useInputPV=0, useFrontPV};
+public:
+  enum Alg { useInputPV = 0, useFrontPV };
 
-  struct DiscCutPair{
-    DiscCutPair():discr_(nullptr),cutFormula_(nullptr){}
-    ~DiscCutPair(){delete cutFormula_;}
+  struct DiscCutPair {
+    DiscCutPair() : discr_(nullptr), cutFormula_(nullptr) {}
+    ~DiscCutPair() { delete cutFormula_; }
     const reco::PFTauDiscriminator* discr_;
     edm::EDGetTokenT<reco::PFTauDiscriminator> inputToken_;
     double cut_;
@@ -52,20 +52,20 @@ class PFTauPrimaryVertexProducerBase : public edm::stream::EDProducer<> {
 
   explicit PFTauPrimaryVertexProducerBase(const edm::ParameterSet& iConfig);
   ~PFTauPrimaryVertexProducerBase() override;
-  void produce(edm::Event&,const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   static edm::ParameterSetDescription getDescriptionsBase();
 
   // called at the beginning of every event - override if necessary
   virtual void beginEvent(const edm::Event&, const edm::EventSetup&) {}
 
- protected:
+protected:
   // abstract function implemented in derived classes
   virtual void nonTauTracksInPV(const reco::VertexRef&,
-				const std::vector<edm::Ptr<reco::TrackBase> >&,
-				std::vector<const reco::Track*>&) = 0;
+                                const std::vector<edm::Ptr<reco::TrackBase> >&,
+                                std::vector<const reco::Track*>&) = 0;
 
- private:
+private:
   edm::EDGetTokenT<std::vector<reco::PFTau> > pftauToken_;
   edm::EDGetTokenT<edm::View<reco::Electron> > electronToken_;
   edm::EDGetTokenT<edm::View<reco::Muon> > muonToken_;

--- a/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
@@ -49,87 +49,90 @@
 
 #include <vector>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-/* Class that constructs PFTau(s) from a Jet and its associated PiZeros */
-class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin 
-{
- public:
-  typedef boost::ptr_vector<reco::PFTau> output_type;
-  typedef std::auto_ptr<output_type> return_type;
+    /* Class that constructs PFTau(s) from a Jet and its associated PiZeros */
+    class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin {
+    public:
+      typedef boost::ptr_vector<reco::PFTau> output_type;
+      typedef std::auto_ptr<output_type> return_type;
 
-  explicit RecoTauBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC)
-    : RecoTauEventHolderPlugin(pset),
-      // The vertex association configuration is specified with the quality cuts.
-    vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"),std::move(iC))
-  {
-    pfCandSrc_ = pset.getParameter<edm::InputTag>("pfCandSrc");
-    pfCand_token = iC.consumes<edm::View<reco::Candidate> >(pfCandSrc_);
-  };
+      explicit RecoTauBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+          : RecoTauEventHolderPlugin(pset),
+            // The vertex association configuration is specified with the quality cuts.
+            vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)) {
+        pfCandSrc_ = pset.getParameter<edm::InputTag>("pfCandSrc");
+        pfCand_token = iC.consumes<edm::View<reco::Candidate> >(pfCandSrc_);
+      };
 
-  ~RecoTauBuilderPlugin() override {}
+      ~RecoTauBuilderPlugin() override {}
 
-  /// Construct one or more PFTaus from the a PFJet and its asscociated
-  /// reconstructed PiZeros and regional extras i.e. objects in a 0.8 cone
-  /// about the jet
-  virtual return_type operator()(
-	    const reco::JetBaseRef&, const 
-	    std::vector<reco::PFRecoTauChargedHadron>&, 
-	    const std::vector<reco::RecoTauPiZero>&, 
-	    const std::vector<CandidatePtr>&) const = 0;
+      /// Construct one or more PFTaus from the a PFJet and its asscociated
+      /// reconstructed PiZeros and regional extras i.e. objects in a 0.8 cone
+      /// about the jet
+      virtual return_type operator()(const reco::JetBaseRef&,
+                                     const std::vector<reco::PFRecoTauChargedHadron>&,
+                                     const std::vector<reco::RecoTauPiZero>&,
+                                     const std::vector<CandidatePtr>&) const = 0;
 
-  /// Hack to be able to convert Ptrs to Refs
-  const edm::Handle<edm::View<reco::Candidate> >& getPFCands() const { return pfCands_; };
+      /// Hack to be able to convert Ptrs to Refs
+      const edm::Handle<edm::View<reco::Candidate> >& getPFCands() const { return pfCands_; };
 
-  /// Get primary vertex associated to this jet
-  reco::VertexRef primaryVertex(const reco::JetBaseRef& jet) const { return vertexAssociator_.associatedVertex(*jet); }
-  /// Get primary vertex associated to this tau
-  reco::VertexRef primaryVertex(const reco::PFTau& tau, bool useJet=false) const { return vertexAssociator_.associatedVertex(tau, useJet); }
+      /// Get primary vertex associated to this jet
+      reco::VertexRef primaryVertex(const reco::JetBaseRef& jet) const {
+        return vertexAssociator_.associatedVertex(*jet);
+      }
+      /// Get primary vertex associated to this tau
+      reco::VertexRef primaryVertex(const reco::PFTau& tau, bool useJet = false) const {
+        return vertexAssociator_.associatedVertex(tau, useJet);
+      }
 
-  // Hook called by base class at the beginning of each event. Used to update
-  // handle to PFCandidates
-  void beginEvent() override;
-    
- private:
-  edm::InputTag pfCandSrc_;
-  // Handle to PFCandidates needed to build Refs
-  edm::Handle<edm::View<reco::Candidate> > pfCands_;
-  reco::tau::RecoTauVertexAssociator vertexAssociator_;
-  edm::EDGetTokenT<edm::View<reco::Candidate> > pfCand_token;
-};
+      // Hook called by base class at the beginning of each event. Used to update
+      // handle to PFCandidates
+      void beginEvent() override;
 
-/* Class that updates a PFTau's members (i.e. electron variables) */
-class RecoTauModifierPlugin : public RecoTauEventHolderPlugin 
-{
- public:
-  explicit RecoTauModifierPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
-    : RecoTauEventHolderPlugin(pset)
-  {}
-  ~RecoTauModifierPlugin() override {}
-  // Modify an existing PFTau (i.e. add electron rejection, etc)
-  virtual void operator()(PFTau&) const = 0;
-  void beginEvent() override {}
-  virtual void endEvent() {}
-};
+    private:
+      edm::InputTag pfCandSrc_;
+      // Handle to PFCandidates needed to build Refs
+      edm::Handle<edm::View<reco::Candidate> > pfCands_;
+      reco::tau::RecoTauVertexAssociator vertexAssociator_;
+      edm::EDGetTokenT<edm::View<reco::Candidate> > pfCand_token;
+    };
 
-/* Class that returns a double value indicating the quality of a given tau */
-class RecoTauCleanerPlugin : public RecoTauEventHolderPlugin 
-{
- public:
-  explicit RecoTauCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC )
-    : RecoTauEventHolderPlugin(pset)
-  {}
-  ~RecoTauCleanerPlugin() override {}
-  // Modify an existing PFTau (i.e. add electron rejection, etc)
-  virtual double operator()(const PFTauRef&) const = 0;
-  void beginEvent() override {}
-};
-} } // end namespace reco::tau
+    /* Class that updates a PFTau's members (i.e. electron variables) */
+    class RecoTauModifierPlugin : public RecoTauEventHolderPlugin {
+    public:
+      explicit RecoTauModifierPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+          : RecoTauEventHolderPlugin(pset) {}
+      ~RecoTauModifierPlugin() override {}
+      // Modify an existing PFTau (i.e. add electron rejection, etc)
+      virtual void operator()(PFTau&) const = 0;
+      void beginEvent() override {}
+      virtual void endEvent() {}
+    };
+
+    /* Class that returns a double value indicating the quality of a given tau */
+    class RecoTauCleanerPlugin : public RecoTauEventHolderPlugin {
+    public:
+      explicit RecoTauCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+          : RecoTauEventHolderPlugin(pset) {}
+      ~RecoTauCleanerPlugin() override {}
+      // Modify an existing PFTau (i.e. add electron rejection, etc)
+      virtual double operator()(const PFTauRef&) const = 0;
+      void beginEvent() override {}
+    };
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
-typedef edmplugin::PluginFactory<reco::tau::RecoTauBuilderPlugin*(const edm::ParameterSet&, edm::ConsumesCollector &&iC)> RecoTauBuilderPluginFactory;
-typedef edmplugin::PluginFactory<reco::tau::RecoTauModifierPlugin*(const edm::ParameterSet&, edm::ConsumesCollector &&iC)> RecoTauModifierPluginFactory;
-typedef edmplugin::PluginFactory<reco::tau::RecoTauCleanerPlugin*(const edm::ParameterSet&, edm::ConsumesCollector &&iC)> RecoTauCleanerPluginFactory;
+typedef edmplugin::PluginFactory<reco::tau::RecoTauBuilderPlugin*(const edm::ParameterSet&, edm::ConsumesCollector&& iC)>
+    RecoTauBuilderPluginFactory;
+typedef edmplugin::PluginFactory<reco::tau::RecoTauModifierPlugin*(const edm::ParameterSet&,
+                                                                   edm::ConsumesCollector&& iC)>
+    RecoTauModifierPluginFactory;
+typedef edmplugin::PluginFactory<reco::tau::RecoTauCleanerPlugin*(const edm::ParameterSet&, edm::ConsumesCollector&& iC)>
+    RecoTauCleanerPluginFactory;
 
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauCleaningTools.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCleaningTools.h
@@ -5,59 +5,55 @@
 
 namespace reco::tau {
 
-template<typename RankingList, typename Type>
+  template <typename RankingList, typename Type>
   class RecoTauLexicographicalRanking {
-    public:
-      // Store our list of ranking functions and intialize the vectors
-      // that hold the comparison result
-      explicit RecoTauLexicographicalRanking(const RankingList& rankers):
-        rankers_(rankers) {}
-      // Predicate to compare a and b
-      bool operator()(const Type& a, const Type& b) const {
-        typename RankingList::const_iterator ranker = rankers_.begin();
-        while (ranker != rankers_.end()) {
-          double aResult = (*ranker)(a);
-          double bResult = (*ranker)(b);
-          if (aResult != bResult)
-            return (aResult < bResult);
-          ++ranker;
-        }
-        // If all aare equal return false
-        return false;
+  public:
+    // Store our list of ranking functions and intialize the vectors
+    // that hold the comparison result
+    explicit RecoTauLexicographicalRanking(const RankingList& rankers) : rankers_(rankers) {}
+    // Predicate to compare a and b
+    bool operator()(const Type& a, const Type& b) const {
+      typename RankingList::const_iterator ranker = rankers_.begin();
+      while (ranker != rankers_.end()) {
+        double aResult = (*ranker)(a);
+        double bResult = (*ranker)(b);
+        if (aResult != bResult)
+          return (aResult < bResult);
+        ++ranker;
       }
-    private:
-      const RankingList& rankers_;
+      // If all aare equal return false
+      return false;
+    }
+
+  private:
+    const RankingList& rankers_;
   };
 
-template<typename Container, class OverlapFunction>
-Container cleanOverlaps(const Container& dirty) {
-  typedef typename Container::const_iterator Iterator;
-  // Output container of clean objects
-  Container clean;
-  OverlapFunction overlapChecker;
-  for (Iterator candidate = dirty.begin(); candidate != dirty.end();
-       ++candidate) {
-    // Check if this overlaps with a pizero already in the clean list
-    bool overlaps = false;
-    for (Iterator cleaned = clean.begin();
-         cleaned != clean.end() && !overlaps; ++cleaned) {
-      overlaps = overlapChecker(*candidate, *cleaned);
+  template <typename Container, class OverlapFunction>
+  Container cleanOverlaps(const Container& dirty) {
+    typedef typename Container::const_iterator Iterator;
+    // Output container of clean objects
+    Container clean;
+    OverlapFunction overlapChecker;
+    for (Iterator candidate = dirty.begin(); candidate != dirty.end(); ++candidate) {
+      // Check if this overlaps with a pizero already in the clean list
+      bool overlaps = false;
+      for (Iterator cleaned = clean.begin(); cleaned != clean.end() && !overlaps; ++cleaned) {
+        overlaps = overlapChecker(*candidate, *cleaned);
+      }
+      // If it didn't overlap with anything clean, add it to the clean list
+      if (!overlaps)
+        clean.insert(clean.end(), *candidate);
     }
-    // If it didn't overlap with anything clean, add it to the clean list
-    if (!overlaps)
-      clean.insert(clean.end(), *candidate);
+    return clean;
   }
-  return clean;
-}
 
-template<typename T>
-class SortByDescendingPt {
+  template <typename T>
+  class SortByDescendingPt {
   public:
-    bool operator()(const T& a, const T& b) const {
-      return a.pt() > b.pt();
-    }
-};
+    bool operator()(const T& a, const T& b) const { return a.pt() > b.pt(); }
+  };
 
-}  // end reco::tau namespace
+}  // namespace reco::tau
 
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -27,135 +27,128 @@
 
 #include <boost/type_traits/is_base_of.hpp>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class SortPFCandsDescendingPt {
-  public:
-    bool operator()(const CandidatePtr& a, const CandidatePtr& b) const {
-      return a->pt() > b->pt();
+    class SortPFCandsDescendingPt {
+    public:
+      bool operator()(const CandidatePtr& a, const CandidatePtr& b) const { return a->pt() > b->pt(); }
+    };
+
+    /// Filter a collection of objects that are convertible to CandidatePtrs
+    /// by PFCandidate ID
+    template <typename Iterator>
+    std::vector<CandidatePtr> filterPFCandidates(const Iterator& begin,
+                                                 const Iterator& end,
+                                                 int pdgId,
+                                                 bool sort = true) {
+      std::vector<CandidatePtr> output;
+      for (Iterator iter = begin; iter != end; ++iter) {
+        reco::CandidatePtr ptr(*iter);
+        if (std::abs(ptr->pdgId()) == pdgId)
+          output.push_back(ptr);
+      }
+      if (sort)
+        std::sort(output.begin(), output.end(), SortPFCandsDescendingPt());
+      return output;
     }
-};
 
-/// Filter a collection of objects that are convertible to CandidatePtrs
-/// by PFCandidate ID
-template<typename Iterator> std::vector<CandidatePtr>
-filterPFCandidates(const Iterator& begin, const Iterator& end,
-    int pdgId, bool sort=true) {
-  std::vector<CandidatePtr> output;
-  for(Iterator iter = begin; iter != end; ++iter) {
-    reco::CandidatePtr ptr(*iter);
-    if (std::abs(ptr->pdgId()) == pdgId)
-      output.push_back(ptr);
-  }
-  if (sort) std::sort(output.begin(), output.end(), SortPFCandsDescendingPt());
-  return output;
-}
+    /// Extract pfCandidates of a given particle Id from a PFJet.  If sort is true,
+    /// candidates will be sorted by descending PT. Internally translates to pdgId
+    std::vector<CandidatePtr> pfCandidates(const Jet& jet, int particleId, bool sort = true);
 
-/// Extract pfCandidates of a given particle Id from a PFJet.  If sort is true,
-/// candidates will be sorted by descending PT. Internally translates to pdgId
-std::vector<CandidatePtr> pfCandidates(const Jet& jet,
-                                         int particleId, bool sort=true);
+    /// Extract pfCandidates of a that match a list of particle Ids from a PFJet
+    std::vector<CandidatePtr> pfCandidates(const Jet& jet, const std::vector<int>& particleIds, bool sort = true);
 
-/// Extract pfCandidates of a that match a list of particle Ids from a PFJet
-std::vector<CandidatePtr> pfCandidates(const Jet& jet,
-                                         const std::vector<int>& particleIds,
-                                         bool sort=true);
+    /// Extract pfCandidates of a given PDG Id from a PFJet.  If sort is true,
+    /// candidates will be sorted by descending PT
+    std::vector<CandidatePtr> pfCandidatesByPdgId(const Jet& jet, int pdgId, bool sort = true);
 
-/// Extract pfCandidates of a given PDG Id from a PFJet.  If sort is true,
-/// candidates will be sorted by descending PT
-std::vector<CandidatePtr> pfCandidatesByPdgId(const Jet& jet,
-                                         int pdgId, bool sort=true);
+    /// Extract pfCandidates of a that match a list of PDG Ids from a PFJet
+    std::vector<CandidatePtr> pfCandidatesByPdgId(const Jet& jet, const std::vector<int>& pdgIds, bool sort = true);
 
-/// Extract pfCandidates of a that match a list of PDG Ids from a PFJet
-std::vector<CandidatePtr> pfCandidatesByPdgId(const Jet& jet,
-                                         const std::vector<int>& pdgIds,
-                                         bool sort=true);
+    /// Extract all non-neutral candidates from a PFJet
+    std::vector<CandidatePtr> pfChargedCands(const Jet& jet, bool sort = true);
 
-/// Extract all non-neutral candidates from a PFJet
-std::vector<CandidatePtr> pfChargedCands(const Jet& jet, bool sort=true);
+    /// Extract all pfGammas from a PFJet
+    std::vector<CandidatePtr> pfGammas(const Jet& jet, bool sort = true);
 
-/// Extract all pfGammas from a PFJet
-std::vector<CandidatePtr> pfGammas(const Jet& jet, bool sort=true);
+    /// Flatten a list of pi zeros into a list of there constituent PFCandidates
+    std::vector<CandidatePtr> flattenPiZeros(const std::vector<RecoTauPiZero>::const_iterator&,
+                                             const std::vector<RecoTauPiZero>::const_iterator&);
+    std::vector<CandidatePtr> flattenPiZeros(const std::vector<RecoTauPiZero>&);
 
-/// Flatten a list of pi zeros into a list of there constituent PFCandidates
-std::vector<CandidatePtr> flattenPiZeros(const std::vector<RecoTauPiZero>::const_iterator&, const std::vector<RecoTauPiZero>::const_iterator&);
-std::vector<CandidatePtr> flattenPiZeros(const std::vector<RecoTauPiZero>&);
+    /// Convert a BaseView (View<T>) to a TRefVector
+    template <typename RefVectorType, typename BaseView>
+    RefVectorType castView(const edm::Handle<BaseView>& view) {
+      typedef typename RefVectorType::value_type OutputRef;
+      // Double check at compile time that the inheritance is okay.  It can still
+      // fail at runtime if you pass it the wrong collection.
+      static_assert((boost::is_base_of<typename BaseView::value_type, typename RefVectorType::member_type>::value));
+      RefVectorType output;
+      size_t nElements = view->size();
+      output.reserve(nElements);
+      // Cast each of our Refs
+      for (size_t i = 0; i < nElements; ++i) {
+        output.push_back(view->refAt(i).template castTo<OutputRef>());
+      }
+      return output;
+    }
 
-/// Convert a BaseView (View<T>) to a TRefVector
-template<typename RefVectorType, typename BaseView>
-RefVectorType castView(const edm::Handle<BaseView>& view) {
-  typedef typename RefVectorType::value_type OutputRef;
-  // Double check at compile time that the inheritance is okay.  It can still
-  // fail at runtime if you pass it the wrong collection.
-  static_assert(
-      (boost::is_base_of<typename BaseView::value_type,
-                         typename RefVectorType::member_type>::value));
-  RefVectorType output;
-  size_t nElements = view->size();
-  output.reserve(nElements);
-  // Cast each of our Refs
-  for (size_t i = 0; i < nElements; ++i) {
-    output.push_back(view->refAt(i).template castTo<OutputRef>());
-  }
-  return output;
-}
-
-
-/*
+    /*
  *Given a range over a container of type C, return a new 'end' iterator such
  *that at max <N> elements are taken.  If there are less than N elements in the
  *array, leave the <end>  as it is
  */
-template<typename InputIterator> InputIterator takeNElements(
-    const InputIterator& begin, const InputIterator& end, size_t N) {
-  size_t input_size = end - begin;
-  return (N > input_size) ? end : begin + N;
-}
-
-/// Sum the four vectors in a collection of PFCandidates
-template<typename InputIterator, typename FunctionPtr, typename ReturnType>
-  ReturnType sumPFVector(InputIterator begin, InputIterator end,
-      FunctionPtr func, ReturnType init) {
-    ReturnType output = init;
-    for(InputIterator cand = begin; cand != end; ++cand) {
-      //#define CALL_MEMBER_FN(object,ptrToMember)  ((object).*(ptrToMember))
-      output += ((**cand).*(func))();
+    template <typename InputIterator>
+    InputIterator takeNElements(const InputIterator& begin, const InputIterator& end, size_t N) {
+      size_t input_size = end - begin;
+      return (N > input_size) ? end : begin + N;
     }
-    return output;
-  }
 
-template<typename InputIterator> reco::Candidate::LorentzVector sumPFCandP4(
-    InputIterator begin, InputIterator end) {
-  return sumPFVector(begin, end, &Candidate::p4,
-      reco::Candidate::LorentzVector());
-}
-
-/// Sum the pT of a collection of PFCandidates
-template<typename InputIterator> double sumPFCandPt(InputIterator begin,
-    InputIterator end) {
-    return sumPFVector(begin, end, &Candidate::pt, 0.0);
-  }
-
-/// Sum the charge of a collection of PFCandidates
-template<typename InputIterator> int sumPFCandCharge(InputIterator begin,
-    InputIterator end) {
-    return sumPFVector(begin, end, &Candidate::charge, 0);
-  }
-
-template<typename InputIterator> InputIterator leadCand(InputIterator begin,
-    InputIterator end) {
-    double max_pt = 0;
-    InputIterator max_cand = begin;
-    for(InputIterator cand = begin; cand != end; ++cand) {
-      if( (*cand)->pt() > max_pt ) {
-        max_pt = (*cand)->pt();
-        max_cand = cand;
+    /// Sum the four vectors in a collection of PFCandidates
+    template <typename InputIterator, typename FunctionPtr, typename ReturnType>
+    ReturnType sumPFVector(InputIterator begin, InputIterator end, FunctionPtr func, ReturnType init) {
+      ReturnType output = init;
+      for (InputIterator cand = begin; cand != end; ++cand) {
+        //#define CALL_MEMBER_FN(object,ptrToMember)  ((object).*(ptrToMember))
+        output += ((**cand).*(func))();
       }
+      return output;
     }
-    return max_cand;
-  }
 
-math::XYZPointF atECALEntrance(const reco::Candidate* part, double bField);
+    template <typename InputIterator>
+    reco::Candidate::LorentzVector sumPFCandP4(InputIterator begin, InputIterator end) {
+      return sumPFVector(begin, end, &Candidate::p4, reco::Candidate::LorentzVector());
+    }
 
-}}  // end namespace reco::tau
+    /// Sum the pT of a collection of PFCandidates
+    template <typename InputIterator>
+    double sumPFCandPt(InputIterator begin, InputIterator end) {
+      return sumPFVector(begin, end, &Candidate::pt, 0.0);
+    }
+
+    /// Sum the charge of a collection of PFCandidates
+    template <typename InputIterator>
+    int sumPFCandCharge(InputIterator begin, InputIterator end) {
+      return sumPFVector(begin, end, &Candidate::charge, 0);
+    }
+
+    template <typename InputIterator>
+    InputIterator leadCand(InputIterator begin, InputIterator end) {
+      double max_pt = 0;
+      InputIterator max_cand = begin;
+      for (InputIterator cand = begin; cand != end; ++cand) {
+        if ((*cand)->pt() > max_pt) {
+          max_pt = (*cand)->pt();
+          max_cand = cand;
+        }
+      }
+      return max_cand;
+    }
+
+    math::XYZPointF atECALEntrance(const reco::Candidate* part, double bField);
+
+  }  // namespace tau
+}  // namespace reco
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
@@ -35,134 +35,132 @@
 #include "boost/shared_ptr.hpp"
 #include <vector>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauConstructor {
-  public:
-    enum Region {
-      kSignal,
-      kIsolation
-    };
+    class RecoTauConstructor {
+    public:
+      enum Region { kSignal, kIsolation };
 
-    enum ParticleType {
-      kChargedHadron,
-      kGamma,
-      kNeutralHadron,
-      kAll
-    };
+      enum ParticleType { kChargedHadron, kGamma, kNeutralHadron, kAll };
 
-    /// Constructor with PFCandidate Handle
-    RecoTauConstructor(const JetBaseRef& jetRef,
-        const edm::Handle<edm::View<reco::Candidate> >& pfCands,
-	bool copyGammasFromPiZeros = false,
-	const StringObjectFunction<reco::PFTau>* signalConeSize = nullptr,
-	double minAbsPhotonSumPt_insideSignalCone = 2.5, double minRelPhotonSumPt_insideSignalCone = 0.,
-	double minAbsPhotonSumPt_outsideSignalCone = 1.e+9, double minRelPhotonSumPt_outsideSignalCone = 1.e+9);
+      /// Constructor with PFCandidate Handle
+      RecoTauConstructor(const JetBaseRef& jetRef,
+                         const edm::Handle<edm::View<reco::Candidate> >& pfCands,
+                         bool copyGammasFromPiZeros = false,
+                         const StringObjectFunction<reco::PFTau>* signalConeSize = nullptr,
+                         double minAbsPhotonSumPt_insideSignalCone = 2.5,
+                         double minRelPhotonSumPt_insideSignalCone = 0.,
+                         double minAbsPhotonSumPt_outsideSignalCone = 1.e+9,
+                         double minRelPhotonSumPt_outsideSignalCone = 1.e+9);
 
-    /*
+      /*
      * Code to set leading candidates.  These are just wrappers about
      * the embedded taus methods, but with the ability to convert Ptrs
      * to Refs.
      */
 
-    /// Set leading PFChargedHadron candidate
-    template<typename T> void setleadChargedHadrCand(const T& cand) {
-      tau_->setleadChargedHadrCand(convertToPtr(cand));
-    }
-
-    /// Set leading PFGamma candidate
-    template<typename T> void setleadNeutralCand(const T& cand) {
-      tau_->setleadNeutralCand(convertToPtr(cand));
-    }
-
-    /// Set leading PF candidate
-    template<typename T> void setleadCand(const T& cand) {
-      tau_->setleadCand(convertToPtr(cand));
-    }
-
-    /// Append a PFCandidateRef/Ptr to a given collection
-    void addPFCand(Region region, ParticleType type, const CandidatePtr& ptr, bool skipAddToP4 = false);
-
-    /// Reserve a set amount of space for a given RefVector
-    void reserve(Region region, ParticleType type, size_t size);
-
-    // Add a collection of objects to a given collection
-    template<typename InputIterator>
-    void addPFCands(Region region, ParticleType type, const InputIterator& begin, const InputIterator& end) 
-    {
-      for(InputIterator iter = begin; iter != end; ++iter) {
-	addPFCand(region, type, convertToPtr(*iter));
+      /// Set leading PFChargedHadron candidate
+      template <typename T>
+      void setleadChargedHadrCand(const T& cand) {
+        tau_->setleadChargedHadrCand(convertToPtr(cand));
       }
-    }
-    
-    /// Reserve a set amount of space for the ChargedHadrons
-    void reserveTauChargedHadron(Region region, size_t size);
 
-    /// Add a ChargedHadron to the given collection
-    void addTauChargedHadron(Region region, const PFRecoTauChargedHadron& chargedHadron);
-
-    /// Add a list of charged hadrons to the input collection
-    template<typename InputIterator> void addTauChargedHadrons(Region region, const InputIterator& begin, const InputIterator& end)
-    {
-      for ( InputIterator iter = begin; iter != end; ++iter ) {
-	addTauChargedHadron(region, *iter);
+      /// Set leading PFGamma candidate
+      template <typename T>
+      void setleadNeutralCand(const T& cand) {
+        tau_->setleadNeutralCand(convertToPtr(cand));
       }
-    }
 
-    /// Reserve a set amount of space for the PiZeros
-    void reservePiZero(Region region, size_t size);
-
-    /// Add a PiZero to the given collection
-    void addPiZero(Region region, const RecoTauPiZero& piZero);
-
-    /// Add a list of pizeros to the input collection
-    template<typename InputIterator> void addPiZeros(Region region, const InputIterator& begin, const InputIterator& end)
-    {
-      for ( InputIterator iter = begin; iter != end; ++iter ) {
-	addPiZero(region, *iter);
+      /// Set leading PF candidate
+      template <typename T>
+      void setleadCand(const T& cand) {
+        tau_->setleadCand(convertToPtr(cand));
       }
-    }
 
-    // Build and return the associated tau
-    std::auto_ptr<reco::PFTau> get(bool setupLeadingCandidates=true);
+      /// Append a PFCandidateRef/Ptr to a given collection
+      void addPFCand(Region region, ParticleType type, const CandidatePtr& ptr, bool skipAddToP4 = false);
 
-    // Get the four vector of the signal objects added so far
-    const reco::Candidate::LorentzVector& p4() const { return p4_; }
+      /// Reserve a set amount of space for a given RefVector
+      void reserve(Region region, ParticleType type, size_t size);
 
-  private:
-    typedef std::pair<Region, ParticleType> CollectionKey;
-    typedef std::map<CollectionKey, std::vector<CandidatePtr>*> CollectionMap;
-    typedef boost::shared_ptr<std::vector<CandidatePtr> > SortedListPtr;
-    typedef std::map<CollectionKey, SortedListPtr> SortedCollectionMap;
+      // Add a collection of objects to a given collection
+      template <typename InputIterator>
+      void addPFCands(Region region, ParticleType type, const InputIterator& begin, const InputIterator& end) {
+        for (InputIterator iter = begin; iter != end; ++iter) {
+          addPFCand(region, type, convertToPtr(*iter));
+        }
+      }
 
-    bool copyGammas_;
+      /// Reserve a set amount of space for the ChargedHadrons
+      void reserveTauChargedHadron(Region region, size_t size);
 
-    const StringObjectFunction<reco::PFTau>* signalConeSize_;
-    double minAbsPhotonSumPt_insideSignalCone_;
-    double minRelPhotonSumPt_insideSignalCone_;
-    double minAbsPhotonSumPt_outsideSignalCone_; 
-    double minRelPhotonSumPt_outsideSignalCone_;
+      /// Add a ChargedHadron to the given collection
+      void addTauChargedHadron(Region region, const PFRecoTauChargedHadron& chargedHadron);
 
-    // Retrieve collection associated to signal/iso and type
-    std::vector<CandidatePtr>* getCollection(Region region, ParticleType type);
-    SortedListPtr getSortedCollection(Region region, ParticleType type);
+      /// Add a list of charged hadrons to the input collection
+      template <typename InputIterator>
+      void addTauChargedHadrons(Region region, const InputIterator& begin, const InputIterator& end) {
+        for (InputIterator iter = begin; iter != end; ++iter) {
+          addTauChargedHadron(region, *iter);
+        }
+      }
 
-    // Sort all our collections by PT and copy them into the tau
-    void sortAndCopyIntoTau();
+      /// Reserve a set amount of space for the PiZeros
+      void reservePiZero(Region region, size_t size);
 
-    // Helper functions for dealing with refs
-    CandidatePtr convertToPtr(const PFCandidatePtr& pfPtr) const;
-    CandidatePtr convertToPtr(const CandidatePtr& candPtr) const;
+      /// Add a PiZero to the given collection
+      void addPiZero(Region region, const RecoTauPiZero& piZero);
 
-    const edm::Handle<edm::View<reco::Candidate> >& pfCands_;
-    std::auto_ptr<reco::PFTau> tau_;
-    CollectionMap collections_;
+      /// Add a list of pizeros to the input collection
+      template <typename InputIterator>
+      void addPiZeros(Region region, const InputIterator& begin, const InputIterator& end) {
+        for (InputIterator iter = begin; iter != end; ++iter) {
+          addPiZero(region, *iter);
+        }
+      }
 
-    // Keep sorted (by descending pt) collections
-    SortedCollectionMap sortedCollections_;
+      // Build and return the associated tau
+      std::auto_ptr<reco::PFTau> get(bool setupLeadingCandidates = true);
 
-    // Keep track of the signal cone four vector in case we want it
-    reco::Candidate::LorentzVector p4_;
-};
-} } // end reco::tau namespace
+      // Get the four vector of the signal objects added so far
+      const reco::Candidate::LorentzVector& p4() const { return p4_; }
+
+    private:
+      typedef std::pair<Region, ParticleType> CollectionKey;
+      typedef std::map<CollectionKey, std::vector<CandidatePtr>*> CollectionMap;
+      typedef boost::shared_ptr<std::vector<CandidatePtr> > SortedListPtr;
+      typedef std::map<CollectionKey, SortedListPtr> SortedCollectionMap;
+
+      bool copyGammas_;
+
+      const StringObjectFunction<reco::PFTau>* signalConeSize_;
+      double minAbsPhotonSumPt_insideSignalCone_;
+      double minRelPhotonSumPt_insideSignalCone_;
+      double minAbsPhotonSumPt_outsideSignalCone_;
+      double minRelPhotonSumPt_outsideSignalCone_;
+
+      // Retrieve collection associated to signal/iso and type
+      std::vector<CandidatePtr>* getCollection(Region region, ParticleType type);
+      SortedListPtr getSortedCollection(Region region, ParticleType type);
+
+      // Sort all our collections by PT and copy them into the tau
+      void sortAndCopyIntoTau();
+
+      // Helper functions for dealing with refs
+      CandidatePtr convertToPtr(const PFCandidatePtr& pfPtr) const;
+      CandidatePtr convertToPtr(const CandidatePtr& candPtr) const;
+
+      const edm::Handle<edm::View<reco::Candidate> >& pfCands_;
+      std::auto_ptr<reco::PFTau> tau_;
+      CollectionMap collections_;
+
+      // Keep sorted (by descending pt) collections
+      SortedCollectionMap sortedCollections_;
+
+      // Keep track of the signal cone four vector in case we want it
+      reco::Candidate::LorentzVector p4_;
+    };
+  }  // namespace tau
+}  // namespace reco
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauCrossCleaning.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCrossCleaning.h
@@ -9,142 +9,140 @@
 
 namespace reco::tau::xclean {
 
-/// Transform a pizero to remove given candidates
-template<typename PtrIter>
-class CrossCleanPiZeros 
-{
- public:
-  typedef std::vector<RecoTauPiZero> PiZeroList;
+  /// Transform a pizero to remove given candidates
+  template <typename PtrIter>
+  class CrossCleanPiZeros {
+  public:
+    typedef std::vector<RecoTauPiZero> PiZeroList;
 
-  CrossCleanPiZeros(const PtrIter& chargedHadronsBegin, const PtrIter& chargedHadronsEnd, int mode = kRemoveChargedAndNeutralDaughterOverlaps) 
-    : mode_(mode)
-  {
-    initialize(chargedHadronsBegin, chargedHadronsEnd);
-  }
-
-  void initialize(const PtrIter& chargedHadronsBegin, const PtrIter& chargedHadronsEnd)
-  {
-    // CV: make sure this never gets called.
-    assert(0);
-  }
-
-  /// Return a vector of pointers to pizeros.  PiZeros that needed cleaning
-  /// are cloned, modified, and owned by this class.  The un-modified pointers
-  /// point to objects in the [input] vector.
-  PiZeroList operator()(const std::vector<RecoTauPiZero>& input) const 
-  {
-    PiZeroList output;
-    output.reserve(input.size());
-    for(auto const& piZero : input ) {
-      const RecoTauPiZero::daughters& daughters = piZero.daughterPtrVector();
-      std::set<reco::CandidatePtr> toCheck(daughters.begin(), daughters.end());
-      std::vector<reco::CandidatePtr> cleanDaughters;
-      std::set_difference(toCheck.begin(), toCheck.end(), toRemove_.begin(), toRemove_.end(), std::back_inserter(cleanDaughters));
-      if ( cleanDaughters.size() == daughters.size() ) {
-	// We don't need to clean anything, just add a pointer to current pizero
-	output.push_back(piZero);
-      } else {
-	// Otherwise rebuild
-	RecoTauPiZero newPiZero = piZero;
-	newPiZero.clearDaughters();
-	// Add our cleaned daughters.
-	for(auto const& ptr : cleanDaughters ) {
-	  newPiZero.addDaughter(ptr);
-	}
-	// Check if the pizero is not empty.  If empty, forget it.
-	if ( newPiZero.numberOfDaughters() ) {
-	  p4Builder_.set(newPiZero);
-	  // Make our ptr container take ownership.
-	  output.push_back(newPiZero);
-	}
-      }
+    CrossCleanPiZeros(const PtrIter& chargedHadronsBegin,
+                      const PtrIter& chargedHadronsEnd,
+                      int mode = kRemoveChargedAndNeutralDaughterOverlaps)
+        : mode_(mode) {
+      initialize(chargedHadronsBegin, chargedHadronsEnd);
     }
-    return output;
-  }
 
-  enum { kRemoveChargedDaughterOverlaps, kRemoveChargedAndNeutralDaughterOverlaps };
- 
- private:
-  int mode_;
-  AddFourMomenta p4Builder_;
-  std::set<reco::CandidatePtr> toRemove_;
-};
+    void initialize(const PtrIter& chargedHadronsBegin, const PtrIter& chargedHadronsEnd) {
+      // CV: make sure this never gets called.
+      assert(0);
+    }
 
-// Determine if a candidate is contained in a collection of charged hadrons or pizeros.
-template<typename PtrIter>
-class CrossCleanPtrs 
-{
- public:
-  CrossCleanPtrs(const PtrIter& particlesBegin, const PtrIter& particlesEnd)
-  {
-    initialize(particlesBegin, particlesEnd);
-  }
-
-  void initialize(const PtrIter& particlesBegin, const PtrIter& particlesEnd)
-  {
-    // CV: make sure this never gets called.
-    assert(0);
-  }
-
-  template<typename AnyPtr>
-  bool operator() (const AnyPtr& ptr) const 
-  {
-    if ( toRemove_.count(CandidatePtr(ptr)) ) return false;
-    else return true;
-  }
- private:
-  std::set<CandidatePtr> toRemove_;
-};
-
-// Predicate to filter PFCandPtrs (and those compatible to this type) by the
-// particle id
-class FilterPFCandByParticleId {
-  public:
-    FilterPFCandByParticleId(int particleId):
-      id_(particleId){};
-      template<typename PFCandCompatiblePtrType>
-      bool operator()(const PFCandCompatiblePtrType& ptr) const {
-        return ptr->particleId() == id_;
+    /// Return a vector of pointers to pizeros.  PiZeros that needed cleaning
+    /// are cloned, modified, and owned by this class.  The un-modified pointers
+    /// point to objects in the [input] vector.
+    PiZeroList operator()(const std::vector<RecoTauPiZero>& input) const {
+      PiZeroList output;
+      output.reserve(input.size());
+      for (auto const& piZero : input) {
+        const RecoTauPiZero::daughters& daughters = piZero.daughterPtrVector();
+        std::set<reco::CandidatePtr> toCheck(daughters.begin(), daughters.end());
+        std::vector<reco::CandidatePtr> cleanDaughters;
+        std::set_difference(
+            toCheck.begin(), toCheck.end(), toRemove_.begin(), toRemove_.end(), std::back_inserter(cleanDaughters));
+        if (cleanDaughters.size() == daughters.size()) {
+          // We don't need to clean anything, just add a pointer to current pizero
+          output.push_back(piZero);
+        } else {
+          // Otherwise rebuild
+          RecoTauPiZero newPiZero = piZero;
+          newPiZero.clearDaughters();
+          // Add our cleaned daughters.
+          for (auto const& ptr : cleanDaughters) {
+            newPiZero.addDaughter(ptr);
+          }
+          // Check if the pizero is not empty.  If empty, forget it.
+          if (newPiZero.numberOfDaughters()) {
+            p4Builder_.set(newPiZero);
+            // Make our ptr container take ownership.
+            output.push_back(newPiZero);
+          }
+        }
       }
+      return output;
+    }
+
+    enum { kRemoveChargedDaughterOverlaps, kRemoveChargedAndNeutralDaughterOverlaps };
+
+  private:
+    int mode_;
+    AddFourMomenta p4Builder_;
+    std::set<reco::CandidatePtr> toRemove_;
+  };
+
+  // Determine if a candidate is contained in a collection of charged hadrons or pizeros.
+  template <typename PtrIter>
+  class CrossCleanPtrs {
+  public:
+    CrossCleanPtrs(const PtrIter& particlesBegin, const PtrIter& particlesEnd) {
+      initialize(particlesBegin, particlesEnd);
+    }
+
+    void initialize(const PtrIter& particlesBegin, const PtrIter& particlesEnd) {
+      // CV: make sure this never gets called.
+      assert(0);
+    }
+
+    template <typename AnyPtr>
+    bool operator()(const AnyPtr& ptr) const {
+      if (toRemove_.count(CandidatePtr(ptr)))
+        return false;
+      else
+        return true;
+    }
+
+  private:
+    std::set<CandidatePtr> toRemove_;
+  };
+
+  // Predicate to filter PFCandPtrs (and those compatible to this type) by the
+  // particle id
+  class FilterPFCandByParticleId {
+  public:
+    FilterPFCandByParticleId(int particleId) : id_(particleId){};
+    template <typename PFCandCompatiblePtrType>
+    bool operator()(const PFCandCompatiblePtrType& ptr) const {
+      return ptr->particleId() == id_;
+    }
+
   private:
     int id_;
-};
+  };
 
-// Predicate to filter CandPtrs by the abs(pdgId)
-class FilterCandByAbsPdgId {
+  // Predicate to filter CandPtrs by the abs(pdgId)
+  class FilterCandByAbsPdgId {
   public:
-    FilterCandByAbsPdgId(int pdgId):
-      id_(pdgId){};
-      template<typename CandCompatiblePtrType>
-      bool operator()(const CandCompatiblePtrType& ptr) const {
-        return std::abs(ptr->pdgId()) == id_;
-      }
+    FilterCandByAbsPdgId(int pdgId) : id_(pdgId){};
+    template <typename CandCompatiblePtrType>
+    bool operator()(const CandCompatiblePtrType& ptr) const {
+      return std::abs(ptr->pdgId()) == id_;
+    }
+
   private:
     int id_;
-};
+  };
 
-// Create the AND of two predicates
-template<typename P1, typename P2>
-class PredicateAND {
+  // Create the AND of two predicates
+  template <typename P1, typename P2>
+  class PredicateAND {
   public:
-    PredicateAND(const P1& p1, const P2& p2):
-      p1_(p1),p2_(p2){}
+    PredicateAND(const P1& p1, const P2& p2) : p1_(p1), p2_(p2) {}
 
-    template<typename AnyPtr>
-    bool operator() (const AnyPtr& ptr) const {
+    template <typename AnyPtr>
+    bool operator()(const AnyPtr& ptr) const {
       return (p1_(ptr) && p2_(ptr));
     }
+
   private:
     const P1& p1_;
     const P2& p2_;
-};
+  };
 
-// Helper function to infer template type
-template<typename P1, typename P2>
-PredicateAND<P1, P2> makePredicateAND(const P1& p1, const P2& p2) {
-  return PredicateAND<P1, P2>(p1, p2);
-}
+  // Helper function to infer template type
+  template <typename P1, typename P2>
+  PredicateAND<P1, P2> makePredicateAND(const P1& p1, const P2& p2) {
+    return PredicateAND<P1, P2>(p1, p2);
+  }
 
-}
+}  // namespace reco::tau::xclean
 
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauMuonTools.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauMuonTools.h
@@ -10,10 +10,18 @@
 
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
-namespace reco { namespace tau {
-  void countHits(const reco::Muon& muon, std::vector<int>& numHitsDT, std::vector<int>& numHitsCSC, std::vector<int>& numHitsRPC);
-  void countMatches(const reco::Muon& muon, std::vector<int>& numMatchesDT, std::vector<int>& numMatchesCSC, std::vector<int>& numMatchesRPC);
-  std::string format_vint(const std::vector<int>& vi);
-}}  // end namespace reco::tau
+namespace reco {
+  namespace tau {
+    void countHits(const reco::Muon& muon,
+                   std::vector<int>& numHitsDT,
+                   std::vector<int>& numHitsCSC,
+                   std::vector<int>& numHitsRPC);
+    void countMatches(const reco::Muon& muon,
+                      std::vector<int>& numMatchesDT,
+                      std::vector<int>& numMatchesCSC,
+                      std::vector<int>& numMatchesRPC);
+    std::string format_vint(const std::vector<int>& vi);
+  }  // namespace tau
+}  // namespace reco
 
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h
@@ -25,40 +25,41 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace reco {
-// Forward declarations
-class Jet;
-class RecoTauPiZero;
-namespace tau {
+  // Forward declarations
+  class Jet;
+  class RecoTauPiZero;
+  namespace tau {
 
-class RecoTauPiZeroBuilderPlugin : public RecoTauEventHolderPlugin {
-  public:
-    // Return a vector of pointers
-    typedef boost::ptr_vector<RecoTauPiZero> PiZeroVector;
-    // Storing the result in an auto ptr on function return allows
-    // allows us to safely release the ptr_vector in the virtual function
-    typedef std::auto_ptr<PiZeroVector> return_type;
-    explicit RecoTauPiZeroBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC):
-        RecoTauEventHolderPlugin(pset) {}
-    ~RecoTauPiZeroBuilderPlugin() override {}
-    /// Build a collection of piZeros from objects in the input jet
-    virtual return_type operator()(const Jet&) const = 0;
-    /// Hook called at the beginning of the event.
-    void beginEvent() override {};
-};
+    class RecoTauPiZeroBuilderPlugin : public RecoTauEventHolderPlugin {
+    public:
+      // Return a vector of pointers
+      typedef boost::ptr_vector<RecoTauPiZero> PiZeroVector;
+      // Storing the result in an auto ptr on function return allows
+      // allows us to safely release the ptr_vector in the virtual function
+      typedef std::auto_ptr<PiZeroVector> return_type;
+      explicit RecoTauPiZeroBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+          : RecoTauEventHolderPlugin(pset) {}
+      ~RecoTauPiZeroBuilderPlugin() override {}
+      /// Build a collection of piZeros from objects in the input jet
+      virtual return_type operator()(const Jet&) const = 0;
+      /// Hook called at the beginning of the event.
+      void beginEvent() override{};
+    };
 
-class RecoTauPiZeroQualityPlugin : public RecoTauNamedPlugin {
-  public:
-    explicit RecoTauPiZeroQualityPlugin(const edm::ParameterSet& pset):
-        RecoTauNamedPlugin(pset) {}
-    ~RecoTauPiZeroQualityPlugin() override {}
-    /// Return a number indicating the quality of this PiZero
-    virtual double operator()(const RecoTauPiZero&) const = 0;
-};
-}}  // end namespace reco::tau
+    class RecoTauPiZeroQualityPlugin : public RecoTauNamedPlugin {
+    public:
+      explicit RecoTauPiZeroQualityPlugin(const edm::ParameterSet& pset) : RecoTauNamedPlugin(pset) {}
+      ~RecoTauPiZeroQualityPlugin() override {}
+      /// Return a number indicating the quality of this PiZero
+      virtual double operator()(const RecoTauPiZero&) const = 0;
+    };
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<reco::tau::RecoTauPiZeroQualityPlugin*
-(const edm::ParameterSet&)> RecoTauPiZeroQualityPluginFactory;
-typedef edmplugin::PluginFactory<reco::tau::RecoTauPiZeroBuilderPlugin*
-(const edm::ParameterSet&, edm::ConsumesCollector &&iC)> RecoTauPiZeroBuilderPluginFactory;
+typedef edmplugin::PluginFactory<reco::tau::RecoTauPiZeroQualityPlugin*(const edm::ParameterSet&)>
+    RecoTauPiZeroQualityPluginFactory;
+typedef edmplugin::PluginFactory<reco::tau::RecoTauPiZeroBuilderPlugin*(const edm::ParameterSet&,
+                                                                        edm::ConsumesCollector&& iC)>
+    RecoTauPiZeroBuilderPluginFactory;
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauPluginsCommon.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauPluginsCommon.h
@@ -24,22 +24,24 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauNamedPlugin {
-   /* Base class for all named RecoTau plugins */
-   public:
+    class RecoTauNamedPlugin {
+      /* Base class for all named RecoTau plugins */
+    public:
       explicit RecoTauNamedPlugin(const edm::ParameterSet& pset);
       virtual ~RecoTauNamedPlugin() {}
       const std::string& name() const;
-   private:
-      std::string name_;
-};
 
-class RecoTauEventHolderPlugin : public RecoTauNamedPlugin {
-   /* Base class for all plugins that cache the edm::Event and edm::EventSetup
+    private:
+      std::string name_;
+    };
+
+    class RecoTauEventHolderPlugin : public RecoTauNamedPlugin {
+      /* Base class for all plugins that cache the edm::Event and edm::EventSetup
     * as internal data members */
-   public:
+    public:
       explicit RecoTauEventHolderPlugin(const edm::ParameterSet& pset);
       ~RecoTauEventHolderPlugin() override {}
       // Get the internal cached copy of the event
@@ -50,9 +52,11 @@ class RecoTauEventHolderPlugin : public RecoTauNamedPlugin {
       void setup(edm::Event&, const edm::EventSetup&);
       // Called after setup(...)
       virtual void beginEvent() {}
-   private:
+
+    private:
       edm::Event* evt_;
       const edm::EventSetup* es_;
-};
-}} // end namespace reco::tau
+    };
+  }  // namespace tau
+}  // namespace reco
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
@@ -28,96 +28,99 @@
 
 #include <functional>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauQualityCuts 
-{
- public:
-  // Quality cut types
-  typedef std::function<bool (const TrackBaseRef&)> TrackQCutFunc;
-  typedef std::vector<TrackQCutFunc> TrackQCutFuncCollection;
-  typedef std::function<bool (const Candidate&)> CandQCutFunc;
-  typedef std::vector<CandQCutFunc> CandQCutFuncCollection;
-  typedef std::map<int, CandQCutFuncCollection> CandQCutFuncMap;
-  
-  explicit RecoTauQualityCuts(const edm::ParameterSet& qcuts);
+    class RecoTauQualityCuts {
+    public:
+      // Quality cut types
+      typedef std::function<bool(const TrackBaseRef&)> TrackQCutFunc;
+      typedef std::vector<TrackQCutFunc> TrackQCutFuncCollection;
+      typedef std::function<bool(const Candidate&)> CandQCutFunc;
+      typedef std::vector<CandQCutFunc> CandQCutFuncCollection;
+      typedef std::map<int, CandQCutFuncCollection> CandQCutFuncMap;
 
-  /// Update the primary vertex
-  void setPV(const reco::VertexRef& vtx) const { pv_ = vtx; }
-    
-  /// Update the leading track
-  void setLeadTrack(const reco::Track& leadTrack) const;
-  void setLeadTrack(const reco::Candidate& leadCand) const;
+      explicit RecoTauQualityCuts(const edm::ParameterSet& qcuts);
 
-  /// Update the leading track (using reference)
-  /// If null, this will set the lead track ref null.
-  void setLeadTrack(const reco::CandidateRef& leadCand) const;
+      /// Update the primary vertex
+      void setPV(const reco::VertexRef& vtx) const { pv_ = vtx; }
 
-  /// Filter a single Track
-  bool filterTrack(const reco::TrackBaseRef& track) const;
-  bool filterTrack(const reco::TrackRef& track) const;
-  bool filterTrack(const reco::Track& track) const;
-  /// or a single charged candidate
-  bool filterChargedCand(const reco::Candidate& cand) const;
+      /// Update the leading track
+      void setLeadTrack(const reco::Track& leadTrack) const;
+      void setLeadTrack(const reco::Candidate& leadCand) const;
 
-  /// Filter a collection of Tracks
-  template<typename Coll> 
-  Coll filterTracks(const Coll& coll, bool invert = false) const 
-  {
-    Coll output;
-    for(auto const& track : coll ) {
-      if ( filterTrack(track)^invert ) output.push_back(track);
-    }
-    return output;
-  }
+      /// Update the leading track (using reference)
+      /// If null, this will set the lead track ref null.
+      void setLeadTrack(const reco::CandidateRef& leadCand) const;
 
-  /// Filter a single Candidate
-  bool filterCand(const reco::Candidate& cand) const;
+      /// Filter a single Track
+      bool filterTrack(const reco::TrackBaseRef& track) const;
+      bool filterTrack(const reco::TrackRef& track) const;
+      bool filterTrack(const reco::Track& track) const;
+      /// or a single charged candidate
+      bool filterChargedCand(const reco::Candidate& cand) const;
 
-  /// Filter a Candidate held by a smart pointer or Ref
-  template<typename CandRefType>
-  bool filterCandRef(const CandRefType& cand) const { return filterCand(*cand); }
+      /// Filter a collection of Tracks
+      template <typename Coll>
+      Coll filterTracks(const Coll& coll, bool invert = false) const {
+        Coll output;
+        for (auto const& track : coll) {
+          if (filterTrack(track) ^ invert)
+            output.push_back(track);
+        }
+        return output;
+      }
 
-  /// Filter a ref vector of Candidates
-  template<typename Coll> 
-  Coll filterCandRefs(const Coll& refcoll, bool invert = false) const 
-  {
-    Coll output;
-    for(auto const& cand : refcoll ) {
-      if ( filterCandRef(cand)^invert ) output.push_back(cand);
-    }
-    return output;
-  }
+      /// Filter a single Candidate
+      bool filterCand(const reco::Candidate& cand) const;
 
- private:
-  bool filterTrack_(const reco::Track* track) const;
-  bool filterGammaCand(const reco::Candidate& cand) const;
-  bool filterNeutralHadronCand(const reco::Candidate& cand) const;
-  bool filterCandByType(const reco::Candidate& cand) const;
+      /// Filter a Candidate held by a smart pointer or Ref
+      template <typename CandRefType>
+      bool filterCandRef(const CandRefType& cand) const {
+        return filterCand(*cand);
+      }
 
-  // The current primary vertex
-  mutable reco::VertexRef pv_;
-  // The current lead track references
-  mutable const reco::Track* leadTrack_;
+      /// Filter a ref vector of Candidates
+      template <typename Coll>
+      Coll filterCandRefs(const Coll& refcoll, bool invert = false) const {
+        Coll output;
+        for (auto const& cand : refcoll) {
+          if (filterCandRef(cand) ^ invert)
+            output.push_back(cand);
+        }
+        return output;
+      }
 
-  double minTrackPt_;
-  double maxTrackChi2_;
-  int minTrackPixelHits_;
-  int minTrackHits_;
-  double maxTransverseImpactParameter_;
-  double maxDeltaZ_;
-  double maxDeltaZToLeadTrack_;
-  double minTrackVertexWeight_;
-  double minGammaEt_;
-  double minNeutralHadronEt_;
-  bool checkHitPattern_;
-  bool checkPV_;
-};
+    private:
+      bool filterTrack_(const reco::Track* track) const;
+      bool filterGammaCand(const reco::Candidate& cand) const;
+      bool filterNeutralHadronCand(const reco::Candidate& cand) const;
+      bool filterCandByType(const reco::Candidate& cand) const;
 
-// Split an input set of quality cuts into those that need to be inverted
-// to select PU (the first member) and those that are general quality cuts.
-std::pair<edm::ParameterSet, edm::ParameterSet> factorizePUQCuts(const edm::ParameterSet& inputSet);
+      // The current primary vertex
+      mutable reco::VertexRef pv_;
+      // The current lead track references
+      mutable const reco::Track* leadTrack_;
 
-}} // end reco::tau:: namespace
+      double minTrackPt_;
+      double maxTrackChi2_;
+      int minTrackPixelHits_;
+      int minTrackHits_;
+      double maxTransverseImpactParameter_;
+      double maxDeltaZ_;
+      double maxDeltaZToLeadTrack_;
+      double minTrackVertexWeight_;
+      double minGammaEt_;
+      double minNeutralHadronEt_;
+      bool checkHitPattern_;
+      bool checkPV_;
+    };
+
+    // Split an input set of quality cuts into those that need to be inverted
+    // to select PU (the first member) and those that are general quality cuts.
+    std::pair<edm::ParameterSet, edm::ParameterSet> factorizePUQCuts(const edm::ParameterSet& inputSet);
+
+  }  // namespace tau
+}  // namespace reco
 
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
@@ -37,61 +37,58 @@
 namespace edm {
   class ParameterSet;
   class Event;
-}
+}  // namespace edm
 
 namespace reco {
   class PFTau;
   class Jet;
-}
+}  // namespace reco
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauVertexAssociator {
-  public:
-    enum Algorithm {
-      kHighestPtInEvent,
-      kClosestDeltaZ,
-      kHighestWeigtForLeadTrack,
-      kCombined
+    class RecoTauVertexAssociator {
+    public:
+      enum Algorithm { kHighestPtInEvent, kClosestDeltaZ, kHighestWeigtForLeadTrack, kCombined };
+
+      RecoTauVertexAssociator(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+      virtual ~RecoTauVertexAssociator();
+      /// Get the primary vertex associated to a given jet.
+      /// Returns a null Ref if no vertex is found.
+      reco::VertexRef associatedVertex(const Jet& jet) const;
+      /// Convenience function to get the PV associated to the jet that
+      /// seeded this tau (useJet=true, old behaviour)
+      /// or leaging charged hadron if set (useJet=false).
+      reco::VertexRef associatedVertex(const PFTau& tau, bool useJet = false) const;
+      reco::VertexRef associatedVertex(const TrackBaseRef& track) const;
+      reco::VertexRef associatedVertex(const Track* track) const;
+
+      /// Load the vertices from the event.
+      void setEvent(const edm::Event& evt);
+      const Track* getLeadTrack(const Jet&) const;
+      const TrackBaseRef getLeadTrackRef(const Jet&) const;
+      const CandidatePtr getLeadCand(const Jet&) const;
+
+    private:
+      edm::InputTag vertexTag_;
+      bool vxTrkFiltering_;
+      StringCutObjectSelector<reco::Vertex>* vertexSelector_;
+      std::vector<reco::VertexRef> selectedVertices_;
+      std::string algorithm_;
+      Algorithm algo_;
+      //PJ adding quality cuts
+      RecoTauQualityCuts* qcuts_;
+      bool recoverLeadingTrk_;
+      enum { kLeadTrack, kLeadPFCand, kMinLeadTrackOrPFCand, kFirstTrack };
+      int leadingTrkOrPFCandOption_;
+      edm::EDGetTokenT<reco::VertexCollection> vxToken_;
+      // containers for holding vertices associated to jets
+      std::map<const reco::Jet*, reco::VertexRef>* jetToVertexAssociation_;
+      edm::EventNumber_t lastEvent_;
+      int verbosity_;
     };
 
-    RecoTauVertexAssociator (const edm::ParameterSet& pset,  edm::ConsumesCollector&& iC);
-    virtual ~RecoTauVertexAssociator(); 
-    /// Get the primary vertex associated to a given jet. 
-    /// Returns a null Ref if no vertex is found.
-    reco::VertexRef associatedVertex(const Jet& jet) const;
-    /// Convenience function to get the PV associated to the jet that
-    /// seeded this tau (useJet=true, old behaviour) 
-    /// or leaging charged hadron if set (useJet=false).
-    reco::VertexRef associatedVertex(const PFTau& tau, bool useJet=false) const;
-    reco::VertexRef associatedVertex(const TrackBaseRef& track) const;
-    reco::VertexRef associatedVertex(const Track* track) const;
-
-    /// Load the vertices from the event.
-    void setEvent(const edm::Event& evt);
-    const Track* getLeadTrack(const Jet&) const;
-    const TrackBaseRef getLeadTrackRef(const Jet&) const;
-    const CandidatePtr getLeadCand(const Jet&) const;
-
-  private:
-    edm::InputTag vertexTag_;
-    bool vxTrkFiltering_;
-    StringCutObjectSelector<reco::Vertex>* vertexSelector_;
-    std::vector<reco::VertexRef> selectedVertices_;
-    std::string algorithm_;
-    Algorithm algo_;
-    //PJ adding quality cuts
-    RecoTauQualityCuts* qcuts_;
-    bool recoverLeadingTrk_;
-    enum { kLeadTrack, kLeadPFCand, kMinLeadTrackOrPFCand, kFirstTrack };
-    int leadingTrkOrPFCandOption_;
-    edm::EDGetTokenT<reco::VertexCollection> vxToken_;
-    // containers for holding vertices associated to jets
-    std::map<const reco::Jet*, reco::VertexRef>* jetToVertexAssociation_;
-    edm::EventNumber_t lastEvent_;    
-    int verbosity_;
-};
-
-} /* tau */ } /* reco */
+  }  // namespace tau
+}  // namespace reco
 
 #endif /* end of include guard: RecoTauTag_RecoTau_RecoTauVertexAssociator_h */

--- a/RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h
+++ b/RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h
@@ -50,79 +50,75 @@
 #include "DataFormats/TauReco/interface/CaloTau.h"
 #include "DataFormats/TauReco/interface/CaloTauDiscriminator.h"
 
-template<class TauType, class TauDiscriminator>
+template <class TauType, class TauDiscriminator>
 class TauDiscriminationProducerBase : public edm::stream::EDProducer<> {
-  public:
-    // setup framework types for this tautype
-    typedef std::vector<TauType>        TauCollection;
-    typedef edm::Ref<TauCollection>     TauRef;
-    typedef edm::RefProd<TauCollection> TauRefProd;
+public:
+  // setup framework types for this tautype
+  typedef std::vector<TauType> TauCollection;
+  typedef edm::Ref<TauCollection> TauRef;
+  typedef edm::RefProd<TauCollection> TauRefProd;
 
-    // standard constructor from PSet
-    explicit TauDiscriminationProducerBase(const edm::ParameterSet& iConfig);
+  // standard constructor from PSet
+  explicit TauDiscriminationProducerBase(const edm::ParameterSet& iConfig);
 
-    // default constructor must not be called - it will throw an exception
-    // derived!  classes must call the parameterset constructor.
-    TauDiscriminationProducerBase();
+  // default constructor must not be called - it will throw an exception
+  // derived!  classes must call the parameterset constructor.
+  TauDiscriminationProducerBase();
 
-    ~TauDiscriminationProducerBase() override {}
+  ~TauDiscriminationProducerBase() override {}
 
-    void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-    // called at the beginning of every event - override if necessary.
-    virtual void beginEvent(const edm::Event&, const edm::EventSetup&) {}
+  // called at the beginning of every event - override if necessary.
+  virtual void beginEvent(const edm::Event&, const edm::EventSetup&) {}
 
-    // abstract functions implemented in derived classes.
-    virtual double discriminate(const TauRef& tau) const = 0;
+  // abstract functions implemented in derived classes.
+  virtual double discriminate(const TauRef& tau) const = 0;
 
-    // called at the end of event processing - override if necessary.
-    virtual void endEvent(edm::Event&) {}
+  // called at the end of event processing - override if necessary.
+  virtual void endEvent(edm::Event&) {}
 
-    struct TauDiscInfo {
-      edm::InputTag label;
-      edm::Handle<TauDiscriminator> handle;
-      edm::EDGetTokenT<TauDiscriminator> disc_token;
-      // = consumes<TauDiscriminator>(label); 
-      double cut;
-      void fill(const edm::Event& evt) { 
-	//	disc_token = consumes<TauDiscriminator>(label);
-	evt.getByToken(disc_token, handle); 
-      };
+  struct TauDiscInfo {
+    edm::InputTag label;
+    edm::Handle<TauDiscriminator> handle;
+    edm::EDGetTokenT<TauDiscriminator> disc_token;
+    // = consumes<TauDiscriminator>(label);
+    double cut;
+    void fill(const edm::Event& evt) {
+      //	disc_token = consumes<TauDiscriminator>(label);
+      evt.getByToken(disc_token, handle);
     };
+  };
 
-    static void fillProducerDescriptions(edm::ParameterSetDescription& desc);
+  static void fillProducerDescriptions(edm::ParameterSetDescription& desc);
 
-  protected:
-    //value given to taus that fail prediscriminants
-    double prediscriminantFailValue_;
+protected:
+  //value given to taus that fail prediscriminants
+  double prediscriminantFailValue_;
 
-    edm::InputTag TauProducer_;
+  edm::InputTag TauProducer_;
 
-    std::string moduleLabel_;
-    edm::EDGetTokenT<TauCollection> Tau_token;
+  std::string moduleLabel_;
+  edm::EDGetTokenT<TauCollection> Tau_token;
 
-    // current tau
-    size_t tauIndex_;
+  // current tau
+  size_t tauIndex_;
 
-  private:
-    std::vector<TauDiscInfo> prediscriminants_;
-    // select boolean operation on prediscriminants (and = 0x01, or = 0x00)
-    uint8_t andPrediscriminants_;
+private:
+  std::vector<TauDiscInfo> prediscriminants_;
+  // select boolean operation on prediscriminants (and = 0x01, or = 0x00)
+  uint8_t andPrediscriminants_;
 };
 
 // define our implementations
-typedef TauDiscriminationProducerBase<reco::PFTau, reco::PFTauDiscriminator>
-  PFTauDiscriminationProducerBase;
-typedef TauDiscriminationProducerBase<pat::Tau, pat::PATTauDiscriminator>
-  PATTauDiscriminationProducerBase;
-typedef TauDiscriminationProducerBase<reco::CaloTau, reco::CaloTauDiscriminator>
-  CaloTauDiscriminationProducerBase;
-
+typedef TauDiscriminationProducerBase<reco::PFTau, reco::PFTauDiscriminator> PFTauDiscriminationProducerBase;
+typedef TauDiscriminationProducerBase<pat::Tau, pat::PATTauDiscriminator> PATTauDiscriminationProducerBase;
+typedef TauDiscriminationProducerBase<reco::CaloTau, reco::CaloTauDiscriminator> CaloTauDiscriminationProducerBase;
 
 /// helper function retrieve the correct cfi getter string (ie PFTauProducer)
 //for this tau type
-template<class TauType> std::string getProducerString()
-{
+template <class TauType>
+std::string getProducerString() {
   // this generic one shoudl never be called.
   // these are specialized in TauDiscriminationProducerBase.cc
   throw cms::Exception("TauDiscriminationProducerBase")

--- a/RecoTauTag/RecoTau/interface/TauTagTools.h
+++ b/RecoTauTag/RecoTau/interface/TauTagTools.h
@@ -8,13 +8,43 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 namespace tautagtools {
-  reco::TrackRefVector filteredTracks(const reco::TrackRefVector& theInitialTracks, double tkminPt, int tkminPixelHitsn, int tkminTrackerHitsn, double tkmaxipt, double tkmaxChi2, const reco::Vertex& pV);
-  reco::TrackRefVector filteredTracks(const reco::TrackRefVector& theInitialTracks, double tkminPt, int tkminPixelHitsn, int tkminTrackerHitsn, double tkmaxipt, double tkmaxChi2, double tktorefpointmaxDZ, const reco::Vertex& pV, double refpoint_Z);
+  reco::TrackRefVector filteredTracks(const reco::TrackRefVector& theInitialTracks,
+                                      double tkminPt,
+                                      int tkminPixelHitsn,
+                                      int tkminTrackerHitsn,
+                                      double tkmaxipt,
+                                      double tkmaxChi2,
+                                      const reco::Vertex& pV);
+  reco::TrackRefVector filteredTracks(const reco::TrackRefVector& theInitialTracks,
+                                      double tkminPt,
+                                      int tkminPixelHitsn,
+                                      int tkminTrackerHitsn,
+                                      double tkmaxipt,
+                                      double tkmaxChi2,
+                                      double tktorefpointmaxDZ,
+                                      const reco::Vertex& pV,
+                                      double refpoint_Z);
 
-  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands, double ChargedHadrCand_tkminPt, int ChargedHadrCand_tkminPixelHitsn, int ChargedHadrCand_tkminTrackerHitsn, double ChargedHadrCand_tkmaxipt, double ChargedHadrCand_tkmaxChi2, const reco::Vertex& pV);
-  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands, double ChargedHadrCand_tkminPt, int ChargedHadrCand_tkminPixelHitsn, int ChargedHadrCand_tkminTrackerHitsn, double ChargedHadrCand_tkmaxipt, double ChargedHadrCand_tkmaxChi2, double ChargedHadrCand_tktorefpointmaxDZ, const reco::Vertex& pV, double refpoint_Z);
-  std::vector<reco::CandidatePtr> filteredPFNeutrHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands, double NeutrHadrCand_HcalclusMinEt);
-  std::vector<reco::CandidatePtr> filteredPFGammaCands(const std::vector<reco::CandidatePtr>& theInitialPFCands, double GammaCand_EcalclusMinEt);
-}
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,
+                                                             double ChargedHadrCand_tkminPt,
+                                                             int ChargedHadrCand_tkminPixelHitsn,
+                                                             int ChargedHadrCand_tkminTrackerHitsn,
+                                                             double ChargedHadrCand_tkmaxipt,
+                                                             double ChargedHadrCand_tkmaxChi2,
+                                                             const reco::Vertex& pV);
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,
+                                                             double ChargedHadrCand_tkminPt,
+                                                             int ChargedHadrCand_tkminPixelHitsn,
+                                                             int ChargedHadrCand_tkminTrackerHitsn,
+                                                             double ChargedHadrCand_tkmaxipt,
+                                                             double ChargedHadrCand_tkmaxChi2,
+                                                             double ChargedHadrCand_tktorefpointmaxDZ,
+                                                             const reco::Vertex& pV,
+                                                             double refpoint_Z);
+  std::vector<reco::CandidatePtr> filteredPFNeutrHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,
+                                                           double NeutrHadrCand_HcalclusMinEt);
+  std::vector<reco::CandidatePtr> filteredPFGammaCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,
+                                                       double GammaCand_EcalclusMinEt);
+}  // namespace tautagtools
 
 #endif

--- a/RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h
+++ b/RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h
@@ -5,13 +5,15 @@
 
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
     const reco::Track* getTrackFromChargedHadron(const reco::PFRecoTauChargedHadron& chargedHadron);
     void setChargedHadronP4(reco::PFRecoTauChargedHadron& chargedHadron, double scaleFactor_neutralPFCands = 1.0);
     reco::Candidate::LorentzVector compChargedHadronP4fromPxPyPz(double, double, double);
     reco::Candidate::LorentzVector compChargedHadronP4fromPThetaPhi(double, double, double);
 
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 #endif

--- a/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
@@ -9,389 +9,392 @@
 #include "RecoTauTag/RecoTau/interface/DeepTauBase.h"
 
 namespace {
-inline int getPFCandidateIndex(const edm::Handle<pat::PackedCandidateCollection>& pfcands,
-                               const reco::CandidatePtr& cptr)
-{
-    for(unsigned int i = 0; i < pfcands->size(); ++i) {
-        if(reco::CandidatePtr(pfcands,i) == cptr)
-            return i;
+  inline int getPFCandidateIndex(const edm::Handle<pat::PackedCandidateCollection>& pfcands,
+                                 const reco::CandidatePtr& cptr) {
+    for (unsigned int i = 0; i < pfcands->size(); ++i) {
+      if (reco::CandidatePtr(pfcands, i) == cptr)
+        return i;
     }
     return -1;
-}
-} // anonymous namespace
+  }
+}  // anonymous namespace
 
 class DPFIsolation : public deep_tau::DeepTauBase {
 public:
-    static const OutputCollection& GetOutputs()
-    {
-        const size_t tau_index = 0;
-        static const OutputCollection outputs_ = { { "VSall", Output({tau_index}, {}) } };
-        return outputs_;
-    };
+  static const OutputCollection& GetOutputs() {
+    const size_t tau_index = 0;
+    static const OutputCollection outputs_ = {{"VSall", Output({tau_index}, {})}};
+    return outputs_;
+  };
 
-    static unsigned getNumberOfParticles(unsigned graphVersion)
-    {
-        static const std::map<unsigned, unsigned> nparticles { { 0, 60 }, { 1, 36 } };
-        return nparticles.at(graphVersion);
-    }
+  static unsigned getNumberOfParticles(unsigned graphVersion) {
+    static const std::map<unsigned, unsigned> nparticles{{0, 60}, {1, 36}};
+    return nparticles.at(graphVersion);
+  }
 
-    static unsigned GetNumberOfFeatures(unsigned graphVersion)
-    {
-        static const std::map<unsigned, unsigned> nfeatures { { 0, 47 }, { 1, 51 } };
-        return nfeatures.at(graphVersion);
-    }
+  static unsigned GetNumberOfFeatures(unsigned graphVersion) {
+    static const std::map<unsigned, unsigned> nfeatures{{0, 47}, {1, 51}};
+    return nfeatures.at(graphVersion);
+  }
 
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-    {
-        edm::ParameterSetDescription desc;
-        desc.add<edm::InputTag>("pfcands", edm::InputTag("packedPFCandidates"));
-        desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
-        desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
-        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb");
-        desc.add<unsigned>("version", 0);
-        desc.add<bool>("mem_mapped", false);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("pfcands", edm::InputTag("packedPFCandidates"));
+    desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
+    desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
+    desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb");
+    desc.add<unsigned>("version", 0);
+    desc.add<bool>("mem_mapped", false);
 
-        edm::ParameterSetDescription descWP;
-        descWP.add<std::string>("VVVLoose", "0");
-        descWP.add<std::string>("VVLoose", "0");
-        descWP.add<std::string>("VLoose", "0");
-        descWP.add<std::string>("Loose", "0");
-        descWP.add<std::string>("Medium", "0");
-        descWP.add<std::string>("Tight", "0");
-        descWP.add<std::string>("VTight", "0");
-        descWP.add<std::string>("VVTight", "0");
-        descWP.add<std::string>("VVVTight", "0");
-        desc.add<edm::ParameterSetDescription>("VSallWP", descWP);
-        descriptions.add("DPFTau2016v0", desc);
-    }
+    edm::ParameterSetDescription descWP;
+    descWP.add<std::string>("VVVLoose", "0");
+    descWP.add<std::string>("VVLoose", "0");
+    descWP.add<std::string>("VLoose", "0");
+    descWP.add<std::string>("Loose", "0");
+    descWP.add<std::string>("Medium", "0");
+    descWP.add<std::string>("Tight", "0");
+    descWP.add<std::string>("VTight", "0");
+    descWP.add<std::string>("VVTight", "0");
+    descWP.add<std::string>("VVVTight", "0");
+    desc.add<edm::ParameterSetDescription>("VSallWP", descWP);
+    descriptions.add("DPFTau2016v0", desc);
+  }
 
-    explicit DPFIsolation(const edm::ParameterSet& cfg,const deep_tau::DeepTauCache* cache) :
-        DeepTauBase(cfg, GetOutputs(), cache),
-        graphVersion(cfg.getParameter<unsigned>("version"))
-    {
-        const auto& shape = cache_->getGraph().node(0).attr().at("shape").shape();
+  explicit DPFIsolation(const edm::ParameterSet& cfg, const deep_tau::DeepTauCache* cache)
+      : DeepTauBase(cfg, GetOutputs(), cache), graphVersion(cfg.getParameter<unsigned>("version")) {
+    const auto& shape = cache_->getGraph().node(0).attr().at("shape").shape();
 
-        if(!(graphVersion == 1 || graphVersion == 0 ))
-            throw cms::Exception("DPFIsolation") << "unknown version of the graph file.";
+    if (!(graphVersion == 1 || graphVersion == 0))
+      throw cms::Exception("DPFIsolation") << "unknown version of the graph file.";
 
-        if(!(shape.dim(1).size() == getNumberOfParticles(graphVersion) && shape.dim(2).size() == GetNumberOfFeatures(graphVersion)))
-            throw cms::Exception("DPFIsolation") << "number of inputs does not match the expected inputs for the given version";
-    }
+    if (!(shape.dim(1).size() == getNumberOfParticles(graphVersion) &&
+          shape.dim(2).size() == GetNumberOfFeatures(graphVersion)))
+      throw cms::Exception("DPFIsolation")
+          << "number of inputs does not match the expected inputs for the given version";
+  }
 
 private:
-    tensorflow::Tensor getPredictions(edm::Event& event, const edm::EventSetup& es,
-                                              edm::Handle<TauCollection> taus) override
-    {
-        edm::Handle<pat::PackedCandidateCollection> pfcands;
-        event.getByToken(pfcandToken_, pfcands);
+  tensorflow::Tensor getPredictions(edm::Event& event,
+                                    const edm::EventSetup& es,
+                                    edm::Handle<TauCollection> taus) override {
+    edm::Handle<pat::PackedCandidateCollection> pfcands;
+    event.getByToken(pfcandToken_, pfcands);
 
-        edm::Handle<reco::VertexCollection> vertices;
-        event.getByToken(vtxToken_, vertices);
+    edm::Handle<reco::VertexCollection> vertices;
+    event.getByToken(vtxToken_, vertices);
 
-        tensorflow::Tensor tensor(tensorflow::DT_FLOAT, {1,
-            static_cast<int>(getNumberOfParticles(graphVersion)), static_cast<int>(GetNumberOfFeatures(graphVersion))});
+    tensorflow::Tensor tensor(
+        tensorflow::DT_FLOAT,
+        {1, static_cast<int>(getNumberOfParticles(graphVersion)), static_cast<int>(GetNumberOfFeatures(graphVersion))});
 
-        tensorflow::Tensor predictions(tensorflow::DT_FLOAT, { static_cast<int>(taus->size()), 1});
+    tensorflow::Tensor predictions(tensorflow::DT_FLOAT, {static_cast<int>(taus->size()), 1});
 
-        std::vector<tensorflow::Tensor> outputs_;
+    std::vector<tensorflow::Tensor> outputs_;
 
-        float pfCandPt, pfCandPz, pfCandPtRel, pfCandPzRel, pfCandDr, pfCandDEta, pfCandDPhi, pfCandEta, pfCandDz,
-              pfCandDzErr, pfCandD0, pfCandD0D0, pfCandD0Dz, pfCandD0Dphi, pfCandPuppiWeight,
-              pfCandPixHits, pfCandHits, pfCandLostInnerHits, pfCandPdgID, pfCandCharge, pfCandFromPV,
-              pfCandVtxQuality, pfCandHighPurityTrk, pfCandTauIndMatch, pfCandDzSig, pfCandD0Sig, pfCandD0Err,
-              pfCandPtRelPtRel, pfCandDzDz, pfCandDVx_1, pfCandDVy_1, pfCandDVz_1, pfCandD_1;
-        float pvx = !vertices->empty() ? (*vertices)[0].x() : -1;
-        float pvy = !vertices->empty() ? (*vertices)[0].y() : -1;
-        float pvz = !vertices->empty() ? (*vertices)[0].z() : -1;
+    float pfCandPt, pfCandPz, pfCandPtRel, pfCandPzRel, pfCandDr, pfCandDEta, pfCandDPhi, pfCandEta, pfCandDz,
+        pfCandDzErr, pfCandD0, pfCandD0D0, pfCandD0Dz, pfCandD0Dphi, pfCandPuppiWeight, pfCandPixHits, pfCandHits,
+        pfCandLostInnerHits, pfCandPdgID, pfCandCharge, pfCandFromPV, pfCandVtxQuality, pfCandHighPurityTrk,
+        pfCandTauIndMatch, pfCandDzSig, pfCandD0Sig, pfCandD0Err, pfCandPtRelPtRel, pfCandDzDz, pfCandDVx_1,
+        pfCandDVy_1, pfCandDVz_1, pfCandD_1;
+    float pvx = !vertices->empty() ? (*vertices)[0].x() : -1;
+    float pvy = !vertices->empty() ? (*vertices)[0].y() : -1;
+    float pvz = !vertices->empty() ? (*vertices)[0].z() : -1;
 
-        bool pfCandIsBarrel;
+    bool pfCandIsBarrel;
 
-        // These variables define ranges further used for standardization
-        static constexpr float pfCandPt_max = 500.f;
-        static constexpr float pfCandPz_max = 1000.f;
-        static constexpr float pfCandPtRel_max = 1.f;
-        static constexpr float pfCandPzRel_max = 100.f;
-        static constexpr float pfCandPtRelPtRel_max = 1.f;
-        static constexpr float pfCandD0_max = 5.f;
-        static constexpr float pfCandDz_max = 5.f;
-        static constexpr float pfCandDVx_y_z_1_max = 0.05f;
-        static constexpr float pfCandD_1_max = 0.1f;
-        static constexpr float pfCandD0_z_Err_max = 1.f;
-        static constexpr float pfCandDzSig_max = 3.f;
-        static constexpr float pfCandD0Sig_max = 1.f;
-        static constexpr float pfCandDr_max = 0.5f;
-        static constexpr float pfCandEta_max = 2.75f;
-        static constexpr float pfCandDEta_max = 0.5f;
-        static constexpr float pfCandDPhi_max = 0.5f;
-        static constexpr float pfCandPixHits_max = 7.f;
-        static constexpr float pfCandHits_max = 30.f;
+    // These variables define ranges further used for standardization
+    static constexpr float pfCandPt_max = 500.f;
+    static constexpr float pfCandPz_max = 1000.f;
+    static constexpr float pfCandPtRel_max = 1.f;
+    static constexpr float pfCandPzRel_max = 100.f;
+    static constexpr float pfCandPtRelPtRel_max = 1.f;
+    static constexpr float pfCandD0_max = 5.f;
+    static constexpr float pfCandDz_max = 5.f;
+    static constexpr float pfCandDVx_y_z_1_max = 0.05f;
+    static constexpr float pfCandD_1_max = 0.1f;
+    static constexpr float pfCandD0_z_Err_max = 1.f;
+    static constexpr float pfCandDzSig_max = 3.f;
+    static constexpr float pfCandD0Sig_max = 1.f;
+    static constexpr float pfCandDr_max = 0.5f;
+    static constexpr float pfCandEta_max = 2.75f;
+    static constexpr float pfCandDEta_max = 0.5f;
+    static constexpr float pfCandDPhi_max = 0.5f;
+    static constexpr float pfCandPixHits_max = 7.f;
+    static constexpr float pfCandHits_max = 30.f;
 
-        for(size_t tau_index = 0; tau_index < taus->size(); tau_index++) {
-            pat::Tau tau = taus->at(tau_index);
-            bool isGoodTau = false;
-            const float lepRecoPt = tau.pt();
-            const float lepRecoPz = std::abs(tau.pz());
-            const float lepRecoEta = tau.eta();
-            const float lepRecoPhi = tau.phi();
+    for (size_t tau_index = 0; tau_index < taus->size(); tau_index++) {
+      pat::Tau tau = taus->at(tau_index);
+      bool isGoodTau = false;
+      const float lepRecoPt = tau.pt();
+      const float lepRecoPz = std::abs(tau.pz());
+      const float lepRecoEta = tau.eta();
+      const float lepRecoPhi = tau.phi();
 
-            if(lepRecoPt >= 30 && std::abs(lepRecoEta) < 2.3 && tau.isTauIDAvailable("againstMuonLoose3") &&
-                   tau.isTauIDAvailable("againstElectronVLooseMVA6")) {
-                isGoodTau = (tau.tauID("againstElectronVLooseMVA6") && tau.tauID("againstMuonLoose3") );
-            }
+      if (lepRecoPt >= 30 && std::abs(lepRecoEta) < 2.3 && tau.isTauIDAvailable("againstMuonLoose3") &&
+          tau.isTauIDAvailable("againstElectronVLooseMVA6")) {
+        isGoodTau = (tau.tauID("againstElectronVLooseMVA6") && tau.tauID("againstMuonLoose3"));
+      }
 
-            if (!isGoodTau) {
-                predictions.matrix<float>()(tau_index, 0) = -1;
-                continue;
-            }
+      if (!isGoodTau) {
+        predictions.matrix<float>()(tau_index, 0) = -1;
+        continue;
+      }
 
-            std::vector<unsigned int> signalCandidateInds;
+      std::vector<unsigned int> signalCandidateInds;
 
-            for(const auto c : tau.signalCands())
-                signalCandidateInds.push_back(getPFCandidateIndex(pfcands,c));
+      for (const auto c : tau.signalCands())
+        signalCandidateInds.push_back(getPFCandidateIndex(pfcands, c));
 
-            // Use of setZero results in warnings in eigen library during compilation.
-            //tensor.flat<float>().setZero();
-            const unsigned n_inputs = getNumberOfParticles(graphVersion) * GetNumberOfFeatures(graphVersion);
-            for(unsigned input_idx = 0; input_idx < n_inputs; ++input_idx)
-                tensor.flat<float>()(input_idx) = 0;
+      // Use of setZero results in warnings in eigen library during compilation.
+      //tensor.flat<float>().setZero();
+      const unsigned n_inputs = getNumberOfParticles(graphVersion) * GetNumberOfFeatures(graphVersion);
+      for (unsigned input_idx = 0; input_idx < n_inputs; ++input_idx)
+        tensor.flat<float>()(input_idx) = 0;
 
-            unsigned int iPF = 0;
-            const unsigned max_iPF = getNumberOfParticles(graphVersion);
+      unsigned int iPF = 0;
+      const unsigned max_iPF = getNumberOfParticles(graphVersion);
 
-            std::vector<unsigned int> sorted_inds(pfcands->size());
-            std::size_t n = 0;
-            std::generate(std::begin(sorted_inds), std::end(sorted_inds), [&]{ return n++; });
+      std::vector<unsigned int> sorted_inds(pfcands->size());
+      std::size_t n = 0;
+      std::generate(std::begin(sorted_inds), std::end(sorted_inds), [&] { return n++; });
 
-            std::sort(std::begin(sorted_inds), std::end(sorted_inds),
-            [&](int i1, int i2) { return pfcands->at(i1).pt() > pfcands->at(i2).pt(); } );
+      std::sort(std::begin(sorted_inds), std::end(sorted_inds), [&](int i1, int i2) {
+        return pfcands->at(i1).pt() > pfcands->at(i2).pt();
+      });
 
-            for(size_t pf_index = 0; pf_index < pfcands->size() && iPF < max_iPF; pf_index++) {
-                pat::PackedCandidate p = pfcands->at(sorted_inds.at(pf_index));
-                float deltaR_tau_p =  deltaR(p.p4(),tau.p4());
+      for (size_t pf_index = 0; pf_index < pfcands->size() && iPF < max_iPF; pf_index++) {
+        pat::PackedCandidate p = pfcands->at(sorted_inds.at(pf_index));
+        float deltaR_tau_p = deltaR(p.p4(), tau.p4());
 
-                if (p.pt() < 0.5) continue;
-                if (p.fromPV() < 0) continue;
-                if (deltaR_tau_p > 0.5) continue;
-                if (p.fromPV() < 1 && p.charge() != 0) continue;
-                pfCandPt = p.pt();
-                pfCandPtRel = p.pt()/lepRecoPt;
+        if (p.pt() < 0.5)
+          continue;
+        if (p.fromPV() < 0)
+          continue;
+        if (deltaR_tau_p > 0.5)
+          continue;
+        if (p.fromPV() < 1 && p.charge() != 0)
+          continue;
+        pfCandPt = p.pt();
+        pfCandPtRel = p.pt() / lepRecoPt;
 
-                pfCandDr = deltaR_tau_p;
-                pfCandDEta = std::abs(lepRecoEta - p.eta());
-                pfCandDPhi = std::abs(deltaPhi(lepRecoPhi, p.phi()));
-                pfCandEta = p.eta();
-                pfCandIsBarrel = (std::abs(pfCandEta) < 1.4);
-                pfCandPz = std::abs(std::sinh(pfCandEta)*pfCandPt);
-                pfCandPzRel = pfCandPz/lepRecoPz;
-                pfCandPdgID = std::abs(p.pdgId());
-                pfCandCharge = p.charge();
-                pfCandDVx_1 = p.vx() - pvx;
-                pfCandDVy_1 = p.vy() - pvy;
-                pfCandDVz_1 = p.vz() - pvz;
+        pfCandDr = deltaR_tau_p;
+        pfCandDEta = std::abs(lepRecoEta - p.eta());
+        pfCandDPhi = std::abs(deltaPhi(lepRecoPhi, p.phi()));
+        pfCandEta = p.eta();
+        pfCandIsBarrel = (std::abs(pfCandEta) < 1.4);
+        pfCandPz = std::abs(std::sinh(pfCandEta) * pfCandPt);
+        pfCandPzRel = pfCandPz / lepRecoPz;
+        pfCandPdgID = std::abs(p.pdgId());
+        pfCandCharge = p.charge();
+        pfCandDVx_1 = p.vx() - pvx;
+        pfCandDVy_1 = p.vy() - pvy;
+        pfCandDVz_1 = p.vz() - pvz;
 
-                pfCandD_1 = std::sqrt(pfCandDVx_1*pfCandDVx_1 + pfCandDVy_1*pfCandDVy_1 + pfCandDVz_1*pfCandDVz_1);
+        pfCandD_1 = std::sqrt(pfCandDVx_1 * pfCandDVx_1 + pfCandDVy_1 * pfCandDVy_1 + pfCandDVz_1 * pfCandDVz_1);
 
-                if (pfCandCharge != 0 and p.hasTrackDetails()){
-                    pfCandDz      = p.dz();
-                    pfCandDzErr   = p.dzError();
-                    pfCandDzSig   = (std::abs(p.dz()) + 0.000001)/(p.dzError() + 0.00001);
-                    pfCandD0      = p.dxy();
-                    pfCandD0Err   = p.dxyError();
-                    pfCandD0Sig   = (std::abs(p.dxy()) + 0.000001)/ (p.dxyError() + 0.00001);
-                    pfCandPixHits = p.numberOfPixelHits();
-                    pfCandHits    = p.numberOfHits();
-                    pfCandLostInnerHits = p.lostInnerHits();
-                } else {
-                    float disp = 1;
-                    int psudorand = p.pt()*1000000;
-                    if (psudorand%2 == 0) disp = -1;
-                    pfCandDz      = 5*disp;
-                    pfCandDzErr   = 0;
-                    pfCandDzSig   = 0;
-                    pfCandD0      = 5*disp;
-                    pfCandD0Err   = 0;
-                    pfCandD0Sig   = 0;
-                    pfCandPixHits = 0;
-                    pfCandHits    = 0;
-                    pfCandLostInnerHits = 2.;
-                    pfCandDVx_1   = 1;
-                    pfCandDVy_1   = 1;
-                    pfCandDVz_1   = 1;
-                    pfCandD_1     = 1;
-                }
-
-                pfCandPuppiWeight = p.puppiWeight();
-                pfCandFromPV = p.fromPV();
-                pfCandVtxQuality = p.pvAssociationQuality();
-                pfCandHighPurityTrk = p.trackHighPurity();
-                float pfCandTauIndMatch_temp = 0;
-
-                for (auto i : signalCandidateInds) {
-                    if (i == sorted_inds.at(pf_index)) pfCandTauIndMatch_temp = 1;
-                }
-
-                pfCandTauIndMatch = pfCandTauIndMatch_temp;
-                pfCandPtRelPtRel = pfCandPtRel*pfCandPtRel;
-                pfCandPt = std::min(pfCandPt, pfCandPt_max);
-                pfCandPt = pfCandPt/pfCandPt_max;
-
-                pfCandPz = std::min(pfCandPz, pfCandPz_max);
-                pfCandPz = pfCandPz/pfCandPz_max;
-
-                pfCandPtRel = std::min(pfCandPtRel, pfCandPtRel_max);
-                pfCandPzRel = std::min(pfCandPzRel, pfCandPzRel_max);
-                pfCandPzRel = pfCandPzRel/pfCandPzRel_max;
-                pfCandDr   = pfCandDr/pfCandDr_max;
-                pfCandEta  = pfCandEta/pfCandEta_max;
-                pfCandDEta = pfCandDEta/pfCandDEta_max;
-                pfCandDPhi = pfCandDPhi/pfCandDPhi_max;
-                pfCandPixHits = pfCandPixHits/pfCandPixHits_max;
-                pfCandHits = pfCandHits/pfCandHits_max;
-
-                pfCandPtRelPtRel = std::min(pfCandPtRelPtRel, pfCandPtRelPtRel_max);
-
-                pfCandD0 = std::clamp(pfCandD0, -pfCandD0_max, pfCandD0_max);
-                pfCandD0 = pfCandD0/pfCandD0_max;
-
-                pfCandDz = std::clamp(pfCandDz, -pfCandDz_max, pfCandDz_max);
-                pfCandDz = pfCandDz/pfCandDz_max;
-
-                pfCandD0Err = std::min(pfCandD0Err, pfCandD0_z_Err_max);
-                pfCandDzErr = std::min(pfCandDzErr, pfCandD0_z_Err_max);
-                pfCandDzSig = std::min(pfCandDzSig, pfCandDzSig_max);
-                pfCandDzSig = pfCandDzSig/pfCandDzSig_max;
-
-                pfCandD0Sig = std::min(pfCandD0Sig, pfCandD0Sig_max);
-                pfCandD0D0 = pfCandD0*pfCandD0;
-                pfCandDzDz = pfCandDz*pfCandDz;
-                pfCandD0Dz = pfCandD0*pfCandDz;
-                pfCandD0Dphi = pfCandD0*pfCandDPhi;
-
-                pfCandDVx_1 = std::clamp(pfCandDVx_1, -pfCandDVx_y_z_1_max, pfCandDVx_y_z_1_max);
-                pfCandDVx_1 = pfCandDVx_1/pfCandDVx_y_z_1_max;
-
-                pfCandDVy_1 = std::clamp(pfCandDVy_1, -pfCandDVx_y_z_1_max, pfCandDVx_y_z_1_max);
-                pfCandDVy_1 = pfCandDVy_1/pfCandDVx_y_z_1_max;
-
-                pfCandDVz_1 = std::clamp(pfCandDVz_1, -pfCandDVx_y_z_1_max, pfCandDVx_y_z_1_max);
-                pfCandDVz_1 = pfCandDVz_1/pfCandDVx_y_z_1_max;
-
-                pfCandD_1 = std::clamp(pfCandD_1, -pfCandD_1_max, pfCandD_1_max);
-                pfCandD_1 = pfCandD_1/ pfCandD_1_max;
-
-                if (graphVersion == 0) {
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 0) = pfCandPt;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 1) = pfCandPz;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 2) = pfCandPtRel;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 3) = pfCandPzRel;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 4) = pfCandDr;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 5) = pfCandDEta;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 6) = pfCandDPhi;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 7) = pfCandEta;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 8) = pfCandDz;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 9) = pfCandDzSig;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 10) = pfCandD0;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 11)  = pfCandD0Sig;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 12) = pfCandDzErr;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 13) = pfCandD0Err;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 14) = pfCandD0D0;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 15) = pfCandCharge==0;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 16) = pfCandCharge==1;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 17) = pfCandCharge==-1;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 18) = pfCandPdgID>22;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 19) = pfCandPdgID==22;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 20) = pfCandDzDz;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 21) = pfCandD0Dz;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 22) = pfCandD0Dphi;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 23) = pfCandPtRelPtRel;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 24) = pfCandPixHits;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 25) = pfCandHits;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 26) = pfCandLostInnerHits==-1;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 27) = pfCandLostInnerHits==0;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 28) = pfCandLostInnerHits==1;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 29) = pfCandLostInnerHits==2;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 30) = pfCandPuppiWeight;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 31) = (pfCandVtxQuality == 1);
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 32) = (pfCandVtxQuality == 5);
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 33) = (pfCandVtxQuality == 6);
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 34) = (pfCandVtxQuality == 7);
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 35) = (pfCandFromPV == 1);
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 36) = (pfCandFromPV == 2);
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 37) = (pfCandFromPV == 3);
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 38) = pfCandIsBarrel;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 39) = pfCandHighPurityTrk;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 40) = pfCandPdgID==1;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 41) = pfCandPdgID==2;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 42) = pfCandPdgID==11;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 43) = pfCandPdgID==13;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 44) = pfCandPdgID==130;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 45) = pfCandPdgID==211;
-                    tensor.tensor<float,3>()( 0, 60-1-iPF, 46) = pfCandTauIndMatch;
-                }
-
-                if (graphVersion == 1) {
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 0) = pfCandPt;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 1) = pfCandPz;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 2) = pfCandPtRel;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 3) = pfCandPzRel;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 4) = pfCandDr;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 5) = pfCandDEta;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 6) = pfCandDPhi;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 7) = pfCandEta;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 8) = pfCandDz;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 9) = pfCandDzSig;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 10) = pfCandD0;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 11) = pfCandD0Sig;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 12) = pfCandDzErr;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 13) = pfCandD0Err;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 14) = pfCandD0D0;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 15) = pfCandCharge==0;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 16) = pfCandCharge==1;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 17) = pfCandCharge==-1;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 18) = pfCandPdgID>22;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 19) = pfCandPdgID==22;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 20) = pfCandDVx_1;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 21) = pfCandDVy_1;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 22) = pfCandDVz_1;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 23) = pfCandD_1;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 24) = pfCandDzDz;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 25) = pfCandD0Dz;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 26) = pfCandD0Dphi;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 27) = pfCandPtRelPtRel;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 28) = pfCandPixHits;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 29) = pfCandHits;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 30) = pfCandLostInnerHits==-1;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 31) = pfCandLostInnerHits==0;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 32) = pfCandLostInnerHits==1;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 33) = pfCandLostInnerHits==2;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 34) = pfCandPuppiWeight;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 35) = (pfCandVtxQuality == 1);
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 36) = (pfCandVtxQuality == 5);
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 37) = (pfCandVtxQuality == 6);
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 38) = (pfCandVtxQuality == 7);
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 39) = (pfCandFromPV == 1);
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 40) = (pfCandFromPV == 2);
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 41) = (pfCandFromPV == 3);
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 42) = pfCandIsBarrel;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 43) = pfCandHighPurityTrk;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 44) = pfCandPdgID==1;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 45) = pfCandPdgID==2;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 46) = pfCandPdgID==11;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 47) = pfCandPdgID==13;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 48) = pfCandPdgID==130;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 49) = pfCandPdgID==211;
-                    tensor.tensor<float,3>()( 0, 36-1-iPF, 50) = pfCandTauIndMatch;
-                }
-                iPF++;
-            }
-            tensorflow::run(&(cache_->getSession()), { { "input_1", tensor } }, { "output_node0" }, {}, &outputs_);
-            predictions.matrix<float>()(tau_index, 0) = outputs_[0].flat<float>()(0);
+        if (pfCandCharge != 0 and p.hasTrackDetails()) {
+          pfCandDz = p.dz();
+          pfCandDzErr = p.dzError();
+          pfCandDzSig = (std::abs(p.dz()) + 0.000001) / (p.dzError() + 0.00001);
+          pfCandD0 = p.dxy();
+          pfCandD0Err = p.dxyError();
+          pfCandD0Sig = (std::abs(p.dxy()) + 0.000001) / (p.dxyError() + 0.00001);
+          pfCandPixHits = p.numberOfPixelHits();
+          pfCandHits = p.numberOfHits();
+          pfCandLostInnerHits = p.lostInnerHits();
+        } else {
+          float disp = 1;
+          int psudorand = p.pt() * 1000000;
+          if (psudorand % 2 == 0)
+            disp = -1;
+          pfCandDz = 5 * disp;
+          pfCandDzErr = 0;
+          pfCandDzSig = 0;
+          pfCandD0 = 5 * disp;
+          pfCandD0Err = 0;
+          pfCandD0Sig = 0;
+          pfCandPixHits = 0;
+          pfCandHits = 0;
+          pfCandLostInnerHits = 2.;
+          pfCandDVx_1 = 1;
+          pfCandDVy_1 = 1;
+          pfCandDVz_1 = 1;
+          pfCandD_1 = 1;
         }
-        return predictions;
+
+        pfCandPuppiWeight = p.puppiWeight();
+        pfCandFromPV = p.fromPV();
+        pfCandVtxQuality = p.pvAssociationQuality();
+        pfCandHighPurityTrk = p.trackHighPurity();
+        float pfCandTauIndMatch_temp = 0;
+
+        for (auto i : signalCandidateInds) {
+          if (i == sorted_inds.at(pf_index))
+            pfCandTauIndMatch_temp = 1;
+        }
+
+        pfCandTauIndMatch = pfCandTauIndMatch_temp;
+        pfCandPtRelPtRel = pfCandPtRel * pfCandPtRel;
+        pfCandPt = std::min(pfCandPt, pfCandPt_max);
+        pfCandPt = pfCandPt / pfCandPt_max;
+
+        pfCandPz = std::min(pfCandPz, pfCandPz_max);
+        pfCandPz = pfCandPz / pfCandPz_max;
+
+        pfCandPtRel = std::min(pfCandPtRel, pfCandPtRel_max);
+        pfCandPzRel = std::min(pfCandPzRel, pfCandPzRel_max);
+        pfCandPzRel = pfCandPzRel / pfCandPzRel_max;
+        pfCandDr = pfCandDr / pfCandDr_max;
+        pfCandEta = pfCandEta / pfCandEta_max;
+        pfCandDEta = pfCandDEta / pfCandDEta_max;
+        pfCandDPhi = pfCandDPhi / pfCandDPhi_max;
+        pfCandPixHits = pfCandPixHits / pfCandPixHits_max;
+        pfCandHits = pfCandHits / pfCandHits_max;
+
+        pfCandPtRelPtRel = std::min(pfCandPtRelPtRel, pfCandPtRelPtRel_max);
+
+        pfCandD0 = std::clamp(pfCandD0, -pfCandD0_max, pfCandD0_max);
+        pfCandD0 = pfCandD0 / pfCandD0_max;
+
+        pfCandDz = std::clamp(pfCandDz, -pfCandDz_max, pfCandDz_max);
+        pfCandDz = pfCandDz / pfCandDz_max;
+
+        pfCandD0Err = std::min(pfCandD0Err, pfCandD0_z_Err_max);
+        pfCandDzErr = std::min(pfCandDzErr, pfCandD0_z_Err_max);
+        pfCandDzSig = std::min(pfCandDzSig, pfCandDzSig_max);
+        pfCandDzSig = pfCandDzSig / pfCandDzSig_max;
+
+        pfCandD0Sig = std::min(pfCandD0Sig, pfCandD0Sig_max);
+        pfCandD0D0 = pfCandD0 * pfCandD0;
+        pfCandDzDz = pfCandDz * pfCandDz;
+        pfCandD0Dz = pfCandD0 * pfCandDz;
+        pfCandD0Dphi = pfCandD0 * pfCandDPhi;
+
+        pfCandDVx_1 = std::clamp(pfCandDVx_1, -pfCandDVx_y_z_1_max, pfCandDVx_y_z_1_max);
+        pfCandDVx_1 = pfCandDVx_1 / pfCandDVx_y_z_1_max;
+
+        pfCandDVy_1 = std::clamp(pfCandDVy_1, -pfCandDVx_y_z_1_max, pfCandDVx_y_z_1_max);
+        pfCandDVy_1 = pfCandDVy_1 / pfCandDVx_y_z_1_max;
+
+        pfCandDVz_1 = std::clamp(pfCandDVz_1, -pfCandDVx_y_z_1_max, pfCandDVx_y_z_1_max);
+        pfCandDVz_1 = pfCandDVz_1 / pfCandDVx_y_z_1_max;
+
+        pfCandD_1 = std::clamp(pfCandD_1, -pfCandD_1_max, pfCandD_1_max);
+        pfCandD_1 = pfCandD_1 / pfCandD_1_max;
+
+        if (graphVersion == 0) {
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 0) = pfCandPt;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 1) = pfCandPz;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 2) = pfCandPtRel;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 3) = pfCandPzRel;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 4) = pfCandDr;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 5) = pfCandDEta;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 6) = pfCandDPhi;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 7) = pfCandEta;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 8) = pfCandDz;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 9) = pfCandDzSig;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 10) = pfCandD0;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 11) = pfCandD0Sig;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 12) = pfCandDzErr;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 13) = pfCandD0Err;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 14) = pfCandD0D0;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 15) = pfCandCharge == 0;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 16) = pfCandCharge == 1;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 17) = pfCandCharge == -1;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 18) = pfCandPdgID > 22;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 19) = pfCandPdgID == 22;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 20) = pfCandDzDz;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 21) = pfCandD0Dz;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 22) = pfCandD0Dphi;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 23) = pfCandPtRelPtRel;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 24) = pfCandPixHits;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 25) = pfCandHits;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 26) = pfCandLostInnerHits == -1;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 27) = pfCandLostInnerHits == 0;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 28) = pfCandLostInnerHits == 1;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 29) = pfCandLostInnerHits == 2;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 30) = pfCandPuppiWeight;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 31) = (pfCandVtxQuality == 1);
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 32) = (pfCandVtxQuality == 5);
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 33) = (pfCandVtxQuality == 6);
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 34) = (pfCandVtxQuality == 7);
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 35) = (pfCandFromPV == 1);
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 36) = (pfCandFromPV == 2);
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 37) = (pfCandFromPV == 3);
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 38) = pfCandIsBarrel;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 39) = pfCandHighPurityTrk;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 40) = pfCandPdgID == 1;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 41) = pfCandPdgID == 2;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 42) = pfCandPdgID == 11;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 43) = pfCandPdgID == 13;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 44) = pfCandPdgID == 130;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 45) = pfCandPdgID == 211;
+          tensor.tensor<float, 3>()(0, 60 - 1 - iPF, 46) = pfCandTauIndMatch;
+        }
+
+        if (graphVersion == 1) {
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 0) = pfCandPt;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 1) = pfCandPz;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 2) = pfCandPtRel;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 3) = pfCandPzRel;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 4) = pfCandDr;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 5) = pfCandDEta;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 6) = pfCandDPhi;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 7) = pfCandEta;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 8) = pfCandDz;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 9) = pfCandDzSig;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 10) = pfCandD0;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 11) = pfCandD0Sig;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 12) = pfCandDzErr;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 13) = pfCandD0Err;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 14) = pfCandD0D0;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 15) = pfCandCharge == 0;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 16) = pfCandCharge == 1;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 17) = pfCandCharge == -1;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 18) = pfCandPdgID > 22;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 19) = pfCandPdgID == 22;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 20) = pfCandDVx_1;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 21) = pfCandDVy_1;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 22) = pfCandDVz_1;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 23) = pfCandD_1;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 24) = pfCandDzDz;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 25) = pfCandD0Dz;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 26) = pfCandD0Dphi;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 27) = pfCandPtRelPtRel;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 28) = pfCandPixHits;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 29) = pfCandHits;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 30) = pfCandLostInnerHits == -1;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 31) = pfCandLostInnerHits == 0;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 32) = pfCandLostInnerHits == 1;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 33) = pfCandLostInnerHits == 2;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 34) = pfCandPuppiWeight;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 35) = (pfCandVtxQuality == 1);
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 36) = (pfCandVtxQuality == 5);
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 37) = (pfCandVtxQuality == 6);
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 38) = (pfCandVtxQuality == 7);
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 39) = (pfCandFromPV == 1);
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 40) = (pfCandFromPV == 2);
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 41) = (pfCandFromPV == 3);
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 42) = pfCandIsBarrel;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 43) = pfCandHighPurityTrk;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 44) = pfCandPdgID == 1;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 45) = pfCandPdgID == 2;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 46) = pfCandPdgID == 11;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 47) = pfCandPdgID == 13;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 48) = pfCandPdgID == 130;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 49) = pfCandPdgID == 211;
+          tensor.tensor<float, 3>()(0, 36 - 1 - iPF, 50) = pfCandTauIndMatch;
+        }
+        iPF++;
+      }
+      tensorflow::run(&(cache_->getSession()), {{"input_1", tensor}}, {"output_node0"}, {}, &outputs_);
+      predictions.matrix<float>()(tau_index, 0) = outputs_[0].flat<float>()(0);
     }
+    return predictions;
+  }
 
 private:
-    unsigned graphVersion;
+  unsigned graphVersion;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -9,166 +9,421 @@
 #include "RecoTauTag/RecoTau/interface/DeepTauBase.h"
 
 namespace deep_tau {
-    constexpr int NumberOfOutputs = 4;
+  constexpr int NumberOfOutputs = 4;
 }
 
 namespace {
 
-struct dnn_inputs_2017v1 {
+  struct dnn_inputs_2017v1 {
     enum vars {
-        pt = 0, eta, mass, decayMode, chargedIsoPtSum, neutralIsoPtSum, neutralIsoPtSumWeight,
-        photonPtSumOutsideSignalCone, puCorrPtSum,
-        dxy, dxy_sig, dz, ip3d, ip3d_sig,
-        hasSecondaryVertex, flightLength_r, flightLength_dEta, flightLength_dPhi,
-        flightLength_sig, leadChargedHadrCand_pt, leadChargedHadrCand_dEta,
-        leadChargedHadrCand_dPhi, leadChargedHadrCand_mass, pt_weighted_deta_strip,
-        pt_weighted_dphi_strip, pt_weighted_dr_signal, pt_weighted_dr_iso,
-        leadingTrackNormChi2, e_ratio, gj_angle_diff, n_photons, emFraction,
-        has_gsf_track, inside_ecal_crack,
-        gsf_ele_matched, gsf_ele_pt, gsf_ele_dEta, gsf_ele_dPhi, gsf_ele_mass, gsf_ele_Ee,
-        gsf_ele_Egamma, gsf_ele_Pin, gsf_ele_Pout, gsf_ele_EtotOverPin, gsf_ele_Eecal,
-        gsf_ele_dEta_SeedClusterTrackAtCalo, gsf_ele_dPhi_SeedClusterTrackAtCalo, gsf_ele_mvaIn_sigmaEtaEta,
-        gsf_ele_mvaIn_hadEnergy,
-        gsf_ele_mvaIn_deltaEta, gsf_ele_Chi2NormGSF, gsf_ele_GSFNumHits, gsf_ele_GSFTrackResol,
-        gsf_ele_GSFTracklnPt, gsf_ele_Chi2NormKF, gsf_ele_KFNumHits,
-        leadChargedCand_etaAtEcalEntrance, leadChargedCand_pt, leadChargedHadrCand_HoP,
-        leadChargedHadrCand_EoP, tau_visMass_innerSigCone,
-        n_matched_muons, muon_pt, muon_dEta, muon_dPhi,
-        muon_n_matches_DT_1, muon_n_matches_DT_2, muon_n_matches_DT_3, muon_n_matches_DT_4,
-        muon_n_matches_CSC_1, muon_n_matches_CSC_2, muon_n_matches_CSC_3, muon_n_matches_CSC_4,
-        muon_n_hits_DT_2, muon_n_hits_DT_3, muon_n_hits_DT_4,
-        muon_n_hits_CSC_2, muon_n_hits_CSC_3, muon_n_hits_CSC_4,
-        muon_n_hits_RPC_2, muon_n_hits_RPC_3, muon_n_hits_RPC_4,
-        muon_n_stations_with_matches_03, muon_n_stations_with_hits_23,
-        signalChargedHadrCands_sum_innerSigCone_pt, signalChargedHadrCands_sum_innerSigCone_dEta,
-        signalChargedHadrCands_sum_innerSigCone_dPhi, signalChargedHadrCands_sum_innerSigCone_mass,
-        signalChargedHadrCands_sum_outerSigCone_pt, signalChargedHadrCands_sum_outerSigCone_dEta,
-        signalChargedHadrCands_sum_outerSigCone_dPhi, signalChargedHadrCands_sum_outerSigCone_mass,
-        signalChargedHadrCands_nTotal_innerSigCone, signalChargedHadrCands_nTotal_outerSigCone,
-        signalNeutrHadrCands_sum_innerSigCone_pt, signalNeutrHadrCands_sum_innerSigCone_dEta,
-        signalNeutrHadrCands_sum_innerSigCone_dPhi, signalNeutrHadrCands_sum_innerSigCone_mass,
-        signalNeutrHadrCands_sum_outerSigCone_pt, signalNeutrHadrCands_sum_outerSigCone_dEta,
-        signalNeutrHadrCands_sum_outerSigCone_dPhi, signalNeutrHadrCands_sum_outerSigCone_mass,
-        signalNeutrHadrCands_nTotal_innerSigCone, signalNeutrHadrCands_nTotal_outerSigCone,
-        signalGammaCands_sum_innerSigCone_pt, signalGammaCands_sum_innerSigCone_dEta,
-        signalGammaCands_sum_innerSigCone_dPhi, signalGammaCands_sum_innerSigCone_mass,
-        signalGammaCands_sum_outerSigCone_pt, signalGammaCands_sum_outerSigCone_dEta,
-        signalGammaCands_sum_outerSigCone_dPhi, signalGammaCands_sum_outerSigCone_mass,
-        signalGammaCands_nTotal_innerSigCone, signalGammaCands_nTotal_outerSigCone,
-        isolationChargedHadrCands_sum_pt, isolationChargedHadrCands_sum_dEta,
-        isolationChargedHadrCands_sum_dPhi, isolationChargedHadrCands_sum_mass,
-        isolationChargedHadrCands_nTotal,
-        isolationNeutrHadrCands_sum_pt, isolationNeutrHadrCands_sum_dEta,
-        isolationNeutrHadrCands_sum_dPhi, isolationNeutrHadrCands_sum_mass,
-        isolationNeutrHadrCands_nTotal,
-        isolationGammaCands_sum_pt, isolationGammaCands_sum_dEta,
-        isolationGammaCands_sum_dPhi, isolationGammaCands_sum_mass,
-        isolationGammaCands_nTotal,
-        NumberOfInputs
+      pt = 0,
+      eta,
+      mass,
+      decayMode,
+      chargedIsoPtSum,
+      neutralIsoPtSum,
+      neutralIsoPtSumWeight,
+      photonPtSumOutsideSignalCone,
+      puCorrPtSum,
+      dxy,
+      dxy_sig,
+      dz,
+      ip3d,
+      ip3d_sig,
+      hasSecondaryVertex,
+      flightLength_r,
+      flightLength_dEta,
+      flightLength_dPhi,
+      flightLength_sig,
+      leadChargedHadrCand_pt,
+      leadChargedHadrCand_dEta,
+      leadChargedHadrCand_dPhi,
+      leadChargedHadrCand_mass,
+      pt_weighted_deta_strip,
+      pt_weighted_dphi_strip,
+      pt_weighted_dr_signal,
+      pt_weighted_dr_iso,
+      leadingTrackNormChi2,
+      e_ratio,
+      gj_angle_diff,
+      n_photons,
+      emFraction,
+      has_gsf_track,
+      inside_ecal_crack,
+      gsf_ele_matched,
+      gsf_ele_pt,
+      gsf_ele_dEta,
+      gsf_ele_dPhi,
+      gsf_ele_mass,
+      gsf_ele_Ee,
+      gsf_ele_Egamma,
+      gsf_ele_Pin,
+      gsf_ele_Pout,
+      gsf_ele_EtotOverPin,
+      gsf_ele_Eecal,
+      gsf_ele_dEta_SeedClusterTrackAtCalo,
+      gsf_ele_dPhi_SeedClusterTrackAtCalo,
+      gsf_ele_mvaIn_sigmaEtaEta,
+      gsf_ele_mvaIn_hadEnergy,
+      gsf_ele_mvaIn_deltaEta,
+      gsf_ele_Chi2NormGSF,
+      gsf_ele_GSFNumHits,
+      gsf_ele_GSFTrackResol,
+      gsf_ele_GSFTracklnPt,
+      gsf_ele_Chi2NormKF,
+      gsf_ele_KFNumHits,
+      leadChargedCand_etaAtEcalEntrance,
+      leadChargedCand_pt,
+      leadChargedHadrCand_HoP,
+      leadChargedHadrCand_EoP,
+      tau_visMass_innerSigCone,
+      n_matched_muons,
+      muon_pt,
+      muon_dEta,
+      muon_dPhi,
+      muon_n_matches_DT_1,
+      muon_n_matches_DT_2,
+      muon_n_matches_DT_3,
+      muon_n_matches_DT_4,
+      muon_n_matches_CSC_1,
+      muon_n_matches_CSC_2,
+      muon_n_matches_CSC_3,
+      muon_n_matches_CSC_4,
+      muon_n_hits_DT_2,
+      muon_n_hits_DT_3,
+      muon_n_hits_DT_4,
+      muon_n_hits_CSC_2,
+      muon_n_hits_CSC_3,
+      muon_n_hits_CSC_4,
+      muon_n_hits_RPC_2,
+      muon_n_hits_RPC_3,
+      muon_n_hits_RPC_4,
+      muon_n_stations_with_matches_03,
+      muon_n_stations_with_hits_23,
+      signalChargedHadrCands_sum_innerSigCone_pt,
+      signalChargedHadrCands_sum_innerSigCone_dEta,
+      signalChargedHadrCands_sum_innerSigCone_dPhi,
+      signalChargedHadrCands_sum_innerSigCone_mass,
+      signalChargedHadrCands_sum_outerSigCone_pt,
+      signalChargedHadrCands_sum_outerSigCone_dEta,
+      signalChargedHadrCands_sum_outerSigCone_dPhi,
+      signalChargedHadrCands_sum_outerSigCone_mass,
+      signalChargedHadrCands_nTotal_innerSigCone,
+      signalChargedHadrCands_nTotal_outerSigCone,
+      signalNeutrHadrCands_sum_innerSigCone_pt,
+      signalNeutrHadrCands_sum_innerSigCone_dEta,
+      signalNeutrHadrCands_sum_innerSigCone_dPhi,
+      signalNeutrHadrCands_sum_innerSigCone_mass,
+      signalNeutrHadrCands_sum_outerSigCone_pt,
+      signalNeutrHadrCands_sum_outerSigCone_dEta,
+      signalNeutrHadrCands_sum_outerSigCone_dPhi,
+      signalNeutrHadrCands_sum_outerSigCone_mass,
+      signalNeutrHadrCands_nTotal_innerSigCone,
+      signalNeutrHadrCands_nTotal_outerSigCone,
+      signalGammaCands_sum_innerSigCone_pt,
+      signalGammaCands_sum_innerSigCone_dEta,
+      signalGammaCands_sum_innerSigCone_dPhi,
+      signalGammaCands_sum_innerSigCone_mass,
+      signalGammaCands_sum_outerSigCone_pt,
+      signalGammaCands_sum_outerSigCone_dEta,
+      signalGammaCands_sum_outerSigCone_dPhi,
+      signalGammaCands_sum_outerSigCone_mass,
+      signalGammaCands_nTotal_innerSigCone,
+      signalGammaCands_nTotal_outerSigCone,
+      isolationChargedHadrCands_sum_pt,
+      isolationChargedHadrCands_sum_dEta,
+      isolationChargedHadrCands_sum_dPhi,
+      isolationChargedHadrCands_sum_mass,
+      isolationChargedHadrCands_nTotal,
+      isolationNeutrHadrCands_sum_pt,
+      isolationNeutrHadrCands_sum_dEta,
+      isolationNeutrHadrCands_sum_dPhi,
+      isolationNeutrHadrCands_sum_mass,
+      isolationNeutrHadrCands_nTotal,
+      isolationGammaCands_sum_pt,
+      isolationGammaCands_sum_dEta,
+      isolationGammaCands_sum_dPhi,
+      isolationGammaCands_sum_mass,
+      isolationGammaCands_nTotal,
+      NumberOfInputs
     };
-};
+  };
 
-namespace dnn_inputs_2017_v2 {
+  namespace dnn_inputs_2017_v2 {
     constexpr int number_of_inner_cell = 11;
     constexpr int number_of_outer_cell = 21;
     constexpr int number_of_conv_features = 64;
     namespace TauBlockInputs {
-        enum vars {
-            rho = 0, tau_pt, tau_eta, tau_phi, tau_mass, tau_E_over_pt, tau_charge, tau_n_charged_prongs,
-            tau_n_neutral_prongs, chargedIsoPtSum, chargedIsoPtSumdR03_over_dR05, footprintCorrection,
-            neutralIsoPtSum, neutralIsoPtSumWeight_over_neutralIsoPtSum, neutralIsoPtSumWeightdR03_over_neutralIsoPtSum,
-            neutralIsoPtSumdR03_over_dR05, photonPtSumOutsideSignalCone, puCorrPtSum,
-            tau_dxy_pca_x, tau_dxy_pca_y, tau_dxy_pca_z, tau_dxy_valid, tau_dxy, tau_dxy_sig,
-            tau_ip3d_valid, tau_ip3d, tau_ip3d_sig, tau_dz, tau_dz_sig_valid, tau_dz_sig,
-            tau_flightLength_x, tau_flightLength_y, tau_flightLength_z, tau_flightLength_sig,
-            tau_pt_weighted_deta_strip, tau_pt_weighted_dphi_strip, tau_pt_weighted_dr_signal,
-            tau_pt_weighted_dr_iso, tau_leadingTrackNormChi2, tau_e_ratio_valid, tau_e_ratio,
-            tau_gj_angle_diff_valid, tau_gj_angle_diff, tau_n_photons, tau_emFraction,
-            tau_inside_ecal_crack, leadChargedCand_etaAtEcalEntrance_minus_tau_eta, NumberOfInputs
-        };
+      enum vars {
+        rho = 0,
+        tau_pt,
+        tau_eta,
+        tau_phi,
+        tau_mass,
+        tau_E_over_pt,
+        tau_charge,
+        tau_n_charged_prongs,
+        tau_n_neutral_prongs,
+        chargedIsoPtSum,
+        chargedIsoPtSumdR03_over_dR05,
+        footprintCorrection,
+        neutralIsoPtSum,
+        neutralIsoPtSumWeight_over_neutralIsoPtSum,
+        neutralIsoPtSumWeightdR03_over_neutralIsoPtSum,
+        neutralIsoPtSumdR03_over_dR05,
+        photonPtSumOutsideSignalCone,
+        puCorrPtSum,
+        tau_dxy_pca_x,
+        tau_dxy_pca_y,
+        tau_dxy_pca_z,
+        tau_dxy_valid,
+        tau_dxy,
+        tau_dxy_sig,
+        tau_ip3d_valid,
+        tau_ip3d,
+        tau_ip3d_sig,
+        tau_dz,
+        tau_dz_sig_valid,
+        tau_dz_sig,
+        tau_flightLength_x,
+        tau_flightLength_y,
+        tau_flightLength_z,
+        tau_flightLength_sig,
+        tau_pt_weighted_deta_strip,
+        tau_pt_weighted_dphi_strip,
+        tau_pt_weighted_dr_signal,
+        tau_pt_weighted_dr_iso,
+        tau_leadingTrackNormChi2,
+        tau_e_ratio_valid,
+        tau_e_ratio,
+        tau_gj_angle_diff_valid,
+        tau_gj_angle_diff,
+        tau_n_photons,
+        tau_emFraction,
+        tau_inside_ecal_crack,
+        leadChargedCand_etaAtEcalEntrance_minus_tau_eta,
+        NumberOfInputs
+      };
     }
 
     namespace EgammaBlockInputs {
-        enum vars {
-            rho = 0, tau_pt, tau_eta, tau_inside_ecal_crack, pfCand_ele_valid, pfCand_ele_rel_pt,
-            pfCand_ele_deta, pfCand_ele_dphi, pfCand_ele_pvAssociationQuality, pfCand_ele_puppiWeight,
-            pfCand_ele_charge, pfCand_ele_lostInnerHits, pfCand_ele_numberOfPixelHits, pfCand_ele_vertex_dx,
-            pfCand_ele_vertex_dy, pfCand_ele_vertex_dz, pfCand_ele_vertex_dx_tauFL, pfCand_ele_vertex_dy_tauFL,
-            pfCand_ele_vertex_dz_tauFL, pfCand_ele_hasTrackDetails, pfCand_ele_dxy, pfCand_ele_dxy_sig,
-            pfCand_ele_dz, pfCand_ele_dz_sig, pfCand_ele_track_chi2_ndof, pfCand_ele_track_ndof,
-            ele_valid, ele_rel_pt, ele_deta, ele_dphi, ele_cc_valid, ele_cc_ele_rel_energy, ele_cc_gamma_rel_energy,
-            ele_cc_n_gamma, ele_rel_trackMomentumAtVtx, ele_rel_trackMomentumAtCalo, ele_rel_trackMomentumOut,
-            ele_rel_trackMomentumAtEleClus, ele_rel_trackMomentumAtVtxWithConstraint,
-            ele_rel_ecalEnergy, ele_ecalEnergy_sig, ele_eSuperClusterOverP,
-            ele_eSeedClusterOverP, ele_eSeedClusterOverPout, ele_eEleClusterOverPout,
-            ele_deltaEtaSuperClusterTrackAtVtx, ele_deltaEtaSeedClusterTrackAtCalo,
-            ele_deltaEtaEleClusterTrackAtCalo, ele_deltaPhiEleClusterTrackAtCalo,
-            ele_deltaPhiSuperClusterTrackAtVtx, ele_deltaPhiSeedClusterTrackAtCalo,
-            ele_mvaInput_earlyBrem, ele_mvaInput_lateBrem, ele_mvaInput_sigmaEtaEta,
-            ele_mvaInput_hadEnergy, ele_mvaInput_deltaEta, ele_gsfTrack_normalizedChi2,
-            ele_gsfTrack_numberOfValidHits, ele_rel_gsfTrack_pt, ele_gsfTrack_pt_sig,
-            ele_has_closestCtfTrack, ele_closestCtfTrack_normalizedChi2, ele_closestCtfTrack_numberOfValidHits,
-            pfCand_gamma_valid, pfCand_gamma_rel_pt, pfCand_gamma_deta, pfCand_gamma_dphi,
-            pfCand_gamma_pvAssociationQuality, pfCand_gamma_fromPV, pfCand_gamma_puppiWeight,
-            pfCand_gamma_puppiWeightNoLep, pfCand_gamma_lostInnerHits, pfCand_gamma_numberOfPixelHits,
-            pfCand_gamma_vertex_dx, pfCand_gamma_vertex_dy, pfCand_gamma_vertex_dz, pfCand_gamma_vertex_dx_tauFL,
-            pfCand_gamma_vertex_dy_tauFL, pfCand_gamma_vertex_dz_tauFL, pfCand_gamma_hasTrackDetails,
-            pfCand_gamma_dxy, pfCand_gamma_dxy_sig, pfCand_gamma_dz, pfCand_gamma_dz_sig,
-            pfCand_gamma_track_chi2_ndof, pfCand_gamma_track_ndof,
-            NumberOfInputs
-        };
+      enum vars {
+        rho = 0,
+        tau_pt,
+        tau_eta,
+        tau_inside_ecal_crack,
+        pfCand_ele_valid,
+        pfCand_ele_rel_pt,
+        pfCand_ele_deta,
+        pfCand_ele_dphi,
+        pfCand_ele_pvAssociationQuality,
+        pfCand_ele_puppiWeight,
+        pfCand_ele_charge,
+        pfCand_ele_lostInnerHits,
+        pfCand_ele_numberOfPixelHits,
+        pfCand_ele_vertex_dx,
+        pfCand_ele_vertex_dy,
+        pfCand_ele_vertex_dz,
+        pfCand_ele_vertex_dx_tauFL,
+        pfCand_ele_vertex_dy_tauFL,
+        pfCand_ele_vertex_dz_tauFL,
+        pfCand_ele_hasTrackDetails,
+        pfCand_ele_dxy,
+        pfCand_ele_dxy_sig,
+        pfCand_ele_dz,
+        pfCand_ele_dz_sig,
+        pfCand_ele_track_chi2_ndof,
+        pfCand_ele_track_ndof,
+        ele_valid,
+        ele_rel_pt,
+        ele_deta,
+        ele_dphi,
+        ele_cc_valid,
+        ele_cc_ele_rel_energy,
+        ele_cc_gamma_rel_energy,
+        ele_cc_n_gamma,
+        ele_rel_trackMomentumAtVtx,
+        ele_rel_trackMomentumAtCalo,
+        ele_rel_trackMomentumOut,
+        ele_rel_trackMomentumAtEleClus,
+        ele_rel_trackMomentumAtVtxWithConstraint,
+        ele_rel_ecalEnergy,
+        ele_ecalEnergy_sig,
+        ele_eSuperClusterOverP,
+        ele_eSeedClusterOverP,
+        ele_eSeedClusterOverPout,
+        ele_eEleClusterOverPout,
+        ele_deltaEtaSuperClusterTrackAtVtx,
+        ele_deltaEtaSeedClusterTrackAtCalo,
+        ele_deltaEtaEleClusterTrackAtCalo,
+        ele_deltaPhiEleClusterTrackAtCalo,
+        ele_deltaPhiSuperClusterTrackAtVtx,
+        ele_deltaPhiSeedClusterTrackAtCalo,
+        ele_mvaInput_earlyBrem,
+        ele_mvaInput_lateBrem,
+        ele_mvaInput_sigmaEtaEta,
+        ele_mvaInput_hadEnergy,
+        ele_mvaInput_deltaEta,
+        ele_gsfTrack_normalizedChi2,
+        ele_gsfTrack_numberOfValidHits,
+        ele_rel_gsfTrack_pt,
+        ele_gsfTrack_pt_sig,
+        ele_has_closestCtfTrack,
+        ele_closestCtfTrack_normalizedChi2,
+        ele_closestCtfTrack_numberOfValidHits,
+        pfCand_gamma_valid,
+        pfCand_gamma_rel_pt,
+        pfCand_gamma_deta,
+        pfCand_gamma_dphi,
+        pfCand_gamma_pvAssociationQuality,
+        pfCand_gamma_fromPV,
+        pfCand_gamma_puppiWeight,
+        pfCand_gamma_puppiWeightNoLep,
+        pfCand_gamma_lostInnerHits,
+        pfCand_gamma_numberOfPixelHits,
+        pfCand_gamma_vertex_dx,
+        pfCand_gamma_vertex_dy,
+        pfCand_gamma_vertex_dz,
+        pfCand_gamma_vertex_dx_tauFL,
+        pfCand_gamma_vertex_dy_tauFL,
+        pfCand_gamma_vertex_dz_tauFL,
+        pfCand_gamma_hasTrackDetails,
+        pfCand_gamma_dxy,
+        pfCand_gamma_dxy_sig,
+        pfCand_gamma_dz,
+        pfCand_gamma_dz_sig,
+        pfCand_gamma_track_chi2_ndof,
+        pfCand_gamma_track_ndof,
+        NumberOfInputs
+      };
     }
 
     namespace MuonBlockInputs {
-        enum vars {
-            rho = 0, tau_pt, tau_eta, tau_inside_ecal_crack, pfCand_muon_valid, pfCand_muon_rel_pt,
-            pfCand_muon_deta, pfCand_muon_dphi, pfCand_muon_pvAssociationQuality, pfCand_muon_fromPV,
-            pfCand_muon_puppiWeight, pfCand_muon_charge, pfCand_muon_lostInnerHits, pfCand_muon_numberOfPixelHits,
-            pfCand_muon_vertex_dx, pfCand_muon_vertex_dy, pfCand_muon_vertex_dz, pfCand_muon_vertex_dx_tauFL,
-            pfCand_muon_vertex_dy_tauFL, pfCand_muon_vertex_dz_tauFL,pfCand_muon_hasTrackDetails, pfCand_muon_dxy,
-            pfCand_muon_dxy_sig, pfCand_muon_dz, pfCand_muon_dz_sig, pfCand_muon_track_chi2_ndof,
-            pfCand_muon_track_ndof, muon_valid, muon_rel_pt, muon_deta, muon_dphi, muon_dxy, muon_dxy_sig,
-            muon_normalizedChi2_valid, muon_normalizedChi2, muon_numberOfValidHits, muon_segmentCompatibility,
-            muon_caloCompatibility, muon_pfEcalEnergy_valid, muon_rel_pfEcalEnergy, muon_n_matches_DT_1,
-            muon_n_matches_DT_2,  muon_n_matches_DT_3, muon_n_matches_DT_4, muon_n_matches_CSC_1,
-            muon_n_matches_CSC_2, muon_n_matches_CSC_3, muon_n_matches_CSC_4, muon_n_matches_RPC_1,
-            muon_n_matches_RPC_2, muon_n_matches_RPC_3, muon_n_matches_RPC_4, muon_n_hits_DT_1, muon_n_hits_DT_2,
-            muon_n_hits_DT_3, muon_n_hits_DT_4, muon_n_hits_CSC_1, muon_n_hits_CSC_2, muon_n_hits_CSC_3,
-            muon_n_hits_CSC_4, muon_n_hits_RPC_1, muon_n_hits_RPC_2, muon_n_hits_RPC_3, muon_n_hits_RPC_4,
-            NumberOfInputs
-        };
+      enum vars {
+        rho = 0,
+        tau_pt,
+        tau_eta,
+        tau_inside_ecal_crack,
+        pfCand_muon_valid,
+        pfCand_muon_rel_pt,
+        pfCand_muon_deta,
+        pfCand_muon_dphi,
+        pfCand_muon_pvAssociationQuality,
+        pfCand_muon_fromPV,
+        pfCand_muon_puppiWeight,
+        pfCand_muon_charge,
+        pfCand_muon_lostInnerHits,
+        pfCand_muon_numberOfPixelHits,
+        pfCand_muon_vertex_dx,
+        pfCand_muon_vertex_dy,
+        pfCand_muon_vertex_dz,
+        pfCand_muon_vertex_dx_tauFL,
+        pfCand_muon_vertex_dy_tauFL,
+        pfCand_muon_vertex_dz_tauFL,
+        pfCand_muon_hasTrackDetails,
+        pfCand_muon_dxy,
+        pfCand_muon_dxy_sig,
+        pfCand_muon_dz,
+        pfCand_muon_dz_sig,
+        pfCand_muon_track_chi2_ndof,
+        pfCand_muon_track_ndof,
+        muon_valid,
+        muon_rel_pt,
+        muon_deta,
+        muon_dphi,
+        muon_dxy,
+        muon_dxy_sig,
+        muon_normalizedChi2_valid,
+        muon_normalizedChi2,
+        muon_numberOfValidHits,
+        muon_segmentCompatibility,
+        muon_caloCompatibility,
+        muon_pfEcalEnergy_valid,
+        muon_rel_pfEcalEnergy,
+        muon_n_matches_DT_1,
+        muon_n_matches_DT_2,
+        muon_n_matches_DT_3,
+        muon_n_matches_DT_4,
+        muon_n_matches_CSC_1,
+        muon_n_matches_CSC_2,
+        muon_n_matches_CSC_3,
+        muon_n_matches_CSC_4,
+        muon_n_matches_RPC_1,
+        muon_n_matches_RPC_2,
+        muon_n_matches_RPC_3,
+        muon_n_matches_RPC_4,
+        muon_n_hits_DT_1,
+        muon_n_hits_DT_2,
+        muon_n_hits_DT_3,
+        muon_n_hits_DT_4,
+        muon_n_hits_CSC_1,
+        muon_n_hits_CSC_2,
+        muon_n_hits_CSC_3,
+        muon_n_hits_CSC_4,
+        muon_n_hits_RPC_1,
+        muon_n_hits_RPC_2,
+        muon_n_hits_RPC_3,
+        muon_n_hits_RPC_4,
+        NumberOfInputs
+      };
     }
 
     namespace HadronBlockInputs {
-        enum vars {
-            rho = 0, tau_pt, tau_eta, tau_inside_ecal_crack, pfCand_chHad_valid,
-            pfCand_chHad_rel_pt, pfCand_chHad_deta, pfCand_chHad_dphi, pfCand_chHad_leadChargedHadrCand,
-            pfCand_chHad_pvAssociationQuality, pfCand_chHad_fromPV, pfCand_chHad_puppiWeight,
-            pfCand_chHad_puppiWeightNoLep, pfCand_chHad_charge, pfCand_chHad_lostInnerHits,
-            pfCand_chHad_numberOfPixelHits, pfCand_chHad_vertex_dx, pfCand_chHad_vertex_dy,
-            pfCand_chHad_vertex_dz, pfCand_chHad_vertex_dx_tauFL, pfCand_chHad_vertex_dy_tauFL,
-            pfCand_chHad_vertex_dz_tauFL, pfCand_chHad_hasTrackDetails, pfCand_chHad_dxy,
-            pfCand_chHad_dxy_sig, pfCand_chHad_dz, pfCand_chHad_dz_sig, pfCand_chHad_track_chi2_ndof,
-            pfCand_chHad_track_ndof, pfCand_chHad_hcalFraction, pfCand_chHad_rawCaloFraction,
-            pfCand_nHad_valid, pfCand_nHad_rel_pt, pfCand_nHad_deta, pfCand_nHad_dphi,
-            pfCand_nHad_puppiWeight, pfCand_nHad_puppiWeightNoLep, pfCand_nHad_hcalFraction, NumberOfInputs
-        };
+      enum vars {
+        rho = 0,
+        tau_pt,
+        tau_eta,
+        tau_inside_ecal_crack,
+        pfCand_chHad_valid,
+        pfCand_chHad_rel_pt,
+        pfCand_chHad_deta,
+        pfCand_chHad_dphi,
+        pfCand_chHad_leadChargedHadrCand,
+        pfCand_chHad_pvAssociationQuality,
+        pfCand_chHad_fromPV,
+        pfCand_chHad_puppiWeight,
+        pfCand_chHad_puppiWeightNoLep,
+        pfCand_chHad_charge,
+        pfCand_chHad_lostInnerHits,
+        pfCand_chHad_numberOfPixelHits,
+        pfCand_chHad_vertex_dx,
+        pfCand_chHad_vertex_dy,
+        pfCand_chHad_vertex_dz,
+        pfCand_chHad_vertex_dx_tauFL,
+        pfCand_chHad_vertex_dy_tauFL,
+        pfCand_chHad_vertex_dz_tauFL,
+        pfCand_chHad_hasTrackDetails,
+        pfCand_chHad_dxy,
+        pfCand_chHad_dxy_sig,
+        pfCand_chHad_dz,
+        pfCand_chHad_dz_sig,
+        pfCand_chHad_track_chi2_ndof,
+        pfCand_chHad_track_ndof,
+        pfCand_chHad_hcalFraction,
+        pfCand_chHad_rawCaloFraction,
+        pfCand_nHad_valid,
+        pfCand_nHad_rel_pt,
+        pfCand_nHad_deta,
+        pfCand_nHad_dphi,
+        pfCand_nHad_puppiWeight,
+        pfCand_nHad_puppiWeightNoLep,
+        pfCand_nHad_hcalFraction,
+        NumberOfInputs
+      };
     }
-}
+  }  // namespace dnn_inputs_2017_v2
 
-template<typename LVector1, typename LVector2>
-float dEta(const LVector1& p4, const LVector2& tau_p4)
-{
+  template <typename LVector1, typename LVector2>
+  float dEta(const LVector1& p4, const LVector2& tau_p4) {
     return static_cast<float>(p4.eta() - tau_p4.eta());
-}
+  }
 
-template<typename LVector1, typename LVector2>
-float dPhi(const LVector1& p4_1, const LVector2& p4_2)
-{
+  template <typename LVector1, typename LVector2>
+  float dPhi(const LVector1& p4_1, const LVector2& p4_2) {
     return static_cast<float>(reco::deltaPhi(p4_2.phi(), p4_1.phi()));
-}
+  }
 
-struct MuonHitMatchV1 {
+  struct MuonHitMatchV1 {
     static constexpr int n_muon_stations = 4;
 
     std::map<int, std::vector<UInt_t>> n_matches, n_hits;
@@ -176,337 +431,338 @@ struct MuonHitMatchV1 {
     const pat::Muon* best_matched_muon{nullptr};
     double deltaR2_best_match{-1};
 
-    MuonHitMatchV1()
-    {
-        n_matches[MuonSubdetId::DT].assign(n_muon_stations, 0);
-        n_matches[MuonSubdetId::CSC].assign(n_muon_stations, 0);
-        n_matches[MuonSubdetId::RPC].assign(n_muon_stations, 0);
-        n_hits[MuonSubdetId::DT].assign(n_muon_stations, 0);
-        n_hits[MuonSubdetId::CSC].assign(n_muon_stations, 0);
-        n_hits[MuonSubdetId::RPC].assign(n_muon_stations, 0);
+    MuonHitMatchV1() {
+      n_matches[MuonSubdetId::DT].assign(n_muon_stations, 0);
+      n_matches[MuonSubdetId::CSC].assign(n_muon_stations, 0);
+      n_matches[MuonSubdetId::RPC].assign(n_muon_stations, 0);
+      n_hits[MuonSubdetId::DT].assign(n_muon_stations, 0);
+      n_hits[MuonSubdetId::CSC].assign(n_muon_stations, 0);
+      n_hits[MuonSubdetId::RPC].assign(n_muon_stations, 0);
     }
 
-    void addMatchedMuon(const pat::Muon& muon, const pat::Tau& tau)
-    {
-        static constexpr int n_stations = 4;
+    void addMatchedMuon(const pat::Muon& muon, const pat::Tau& tau) {
+      static constexpr int n_stations = 4;
 
-        ++n_muons;
-        const double dR2 = reco::deltaR2(tau.p4(), muon.p4());
-        if(!best_matched_muon || dR2 < deltaR2_best_match) {
-            best_matched_muon = &muon;
-            deltaR2_best_match = dR2;
-        }
+      ++n_muons;
+      const double dR2 = reco::deltaR2(tau.p4(), muon.p4());
+      if (!best_matched_muon || dR2 < deltaR2_best_match) {
+        best_matched_muon = &muon;
+        deltaR2_best_match = dR2;
+      }
 
-        for(const auto& segment : muon.matches()) {
-            if(segment.segmentMatches.empty()) continue;
-            if(n_matches.count(segment.detector()))
-                ++n_matches.at(segment.detector()).at(segment.station() - 1);
-        }
+      for (const auto& segment : muon.matches()) {
+        if (segment.segmentMatches.empty())
+          continue;
+        if (n_matches.count(segment.detector()))
+          ++n_matches.at(segment.detector()).at(segment.station() - 1);
+      }
 
-        if(muon.outerTrack().isNonnull()) {
-            const auto& hit_pattern = muon.outerTrack()->hitPattern();
-            for(int hit_index = 0; hit_index < hit_pattern.numberOfAllHits(reco::HitPattern::TRACK_HITS); ++hit_index) {
-                auto hit_id = hit_pattern.getHitPattern(reco::HitPattern::TRACK_HITS, hit_index);
-                if(hit_id == 0) break;
-                if(hit_pattern.muonHitFilter(hit_id) && (hit_pattern.getHitType(hit_id) == TrackingRecHit::valid
-                                                         || hit_pattern.getHitType(hit_id == TrackingRecHit::bad))) {
-                    const int station = hit_pattern.getMuonStation(hit_id) - 1;
-                    if(station > 0 && station < n_stations) {
-                        std::vector<UInt_t>* muon_n_hits = nullptr;
-                        if(hit_pattern.muonDTHitFilter(hit_id))
-                            muon_n_hits = &n_hits.at(MuonSubdetId::DT);
-                        else if(hit_pattern.muonCSCHitFilter(hit_id))
-                            muon_n_hits = &n_hits.at(MuonSubdetId::CSC);
-                        else if(hit_pattern.muonRPCHitFilter(hit_id))
-                            muon_n_hits = &n_hits.at(MuonSubdetId::RPC);
+      if (muon.outerTrack().isNonnull()) {
+        const auto& hit_pattern = muon.outerTrack()->hitPattern();
+        for (int hit_index = 0; hit_index < hit_pattern.numberOfAllHits(reco::HitPattern::TRACK_HITS); ++hit_index) {
+          auto hit_id = hit_pattern.getHitPattern(reco::HitPattern::TRACK_HITS, hit_index);
+          if (hit_id == 0)
+            break;
+          if (hit_pattern.muonHitFilter(hit_id) && (hit_pattern.getHitType(hit_id) == TrackingRecHit::valid ||
+                                                    hit_pattern.getHitType(hit_id == TrackingRecHit::bad))) {
+            const int station = hit_pattern.getMuonStation(hit_id) - 1;
+            if (station > 0 && station < n_stations) {
+              std::vector<UInt_t>* muon_n_hits = nullptr;
+              if (hit_pattern.muonDTHitFilter(hit_id))
+                muon_n_hits = &n_hits.at(MuonSubdetId::DT);
+              else if (hit_pattern.muonCSCHitFilter(hit_id))
+                muon_n_hits = &n_hits.at(MuonSubdetId::CSC);
+              else if (hit_pattern.muonRPCHitFilter(hit_id))
+                muon_n_hits = &n_hits.at(MuonSubdetId::RPC);
 
-                        if(muon_n_hits)
-                            ++muon_n_hits->at(station);
-                    }
-                }
+              if (muon_n_hits)
+                ++muon_n_hits->at(station);
             }
+          }
         }
+      }
     }
 
-    static std::vector<const pat::Muon*> findMatchedMuons(const pat::Tau& tau, const pat::MuonCollection& muons,
-                                                           double deltaR, double minPt)
-    {
-        const reco::Muon* hadr_cand_muon = nullptr;
-        if(tau.leadPFChargedHadrCand().isNonnull() && tau.leadPFChargedHadrCand()->muonRef().isNonnull())
-            hadr_cand_muon = tau.leadPFChargedHadrCand()->muonRef().get();
-        std::vector<const pat::Muon*> matched_muons;
-        const double dR2 = deltaR*deltaR;
-        for(const pat::Muon& muon : muons) {
-            const reco::Muon* reco_muon = &muon;
-            if(muon.pt() <= minPt) continue;
-            if(reco_muon == hadr_cand_muon) continue;
-            if(reco::deltaR2(tau.p4(), muon.p4()) >= dR2) continue;
-            matched_muons.push_back(&muon);
+    static std::vector<const pat::Muon*> findMatchedMuons(const pat::Tau& tau,
+                                                          const pat::MuonCollection& muons,
+                                                          double deltaR,
+                                                          double minPt) {
+      const reco::Muon* hadr_cand_muon = nullptr;
+      if (tau.leadPFChargedHadrCand().isNonnull() && tau.leadPFChargedHadrCand()->muonRef().isNonnull())
+        hadr_cand_muon = tau.leadPFChargedHadrCand()->muonRef().get();
+      std::vector<const pat::Muon*> matched_muons;
+      const double dR2 = deltaR * deltaR;
+      for (const pat::Muon& muon : muons) {
+        const reco::Muon* reco_muon = &muon;
+        if (muon.pt() <= minPt)
+          continue;
+        if (reco_muon == hadr_cand_muon)
+          continue;
+        if (reco::deltaR2(tau.p4(), muon.p4()) >= dR2)
+          continue;
+        matched_muons.push_back(&muon);
+      }
+      return matched_muons;
+    }
+
+    template <typename dnn, typename TensorElemGet>
+    void fillTensor(const TensorElemGet& get, const pat::Tau& tau, float default_value) const {
+      get(dnn::n_matched_muons) = n_muons;
+      get(dnn::muon_pt) = best_matched_muon != nullptr ? best_matched_muon->p4().pt() : default_value;
+      get(dnn::muon_dEta) = best_matched_muon != nullptr ? dEta(best_matched_muon->p4(), tau.p4()) : default_value;
+      get(dnn::muon_dPhi) = best_matched_muon != nullptr ? dPhi(best_matched_muon->p4(), tau.p4()) : default_value;
+      get(dnn::muon_n_matches_DT_1) = n_matches.at(MuonSubdetId::DT).at(0);
+      get(dnn::muon_n_matches_DT_2) = n_matches.at(MuonSubdetId::DT).at(1);
+      get(dnn::muon_n_matches_DT_3) = n_matches.at(MuonSubdetId::DT).at(2);
+      get(dnn::muon_n_matches_DT_4) = n_matches.at(MuonSubdetId::DT).at(3);
+      get(dnn::muon_n_matches_CSC_1) = n_matches.at(MuonSubdetId::CSC).at(0);
+      get(dnn::muon_n_matches_CSC_2) = n_matches.at(MuonSubdetId::CSC).at(1);
+      get(dnn::muon_n_matches_CSC_3) = n_matches.at(MuonSubdetId::CSC).at(2);
+      get(dnn::muon_n_matches_CSC_4) = n_matches.at(MuonSubdetId::CSC).at(3);
+      get(dnn::muon_n_hits_DT_2) = n_hits.at(MuonSubdetId::DT).at(1);
+      get(dnn::muon_n_hits_DT_3) = n_hits.at(MuonSubdetId::DT).at(2);
+      get(dnn::muon_n_hits_DT_4) = n_hits.at(MuonSubdetId::DT).at(3);
+      get(dnn::muon_n_hits_CSC_2) = n_hits.at(MuonSubdetId::CSC).at(1);
+      get(dnn::muon_n_hits_CSC_3) = n_hits.at(MuonSubdetId::CSC).at(2);
+      get(dnn::muon_n_hits_CSC_4) = n_hits.at(MuonSubdetId::CSC).at(3);
+      get(dnn::muon_n_hits_RPC_2) = n_hits.at(MuonSubdetId::RPC).at(1);
+      get(dnn::muon_n_hits_RPC_3) = n_hits.at(MuonSubdetId::RPC).at(2);
+      get(dnn::muon_n_hits_RPC_4) = n_hits.at(MuonSubdetId::RPC).at(3);
+      get(dnn::muon_n_stations_with_matches_03) = countMuonStationsWithMatches(0, 3);
+      get(dnn::muon_n_stations_with_hits_23) = countMuonStationsWithHits(2, 3);
+    }
+
+  private:
+    unsigned countMuonStationsWithMatches(size_t first_station, size_t last_station) const {
+      static const std::map<int, std::vector<bool>> masks = {
+          {MuonSubdetId::DT, {false, false, false, false}},
+          {MuonSubdetId::CSC, {true, false, false, false}},
+          {MuonSubdetId::RPC, {false, false, false, false}},
+      };
+      unsigned cnt = 0;
+      for (unsigned n = first_station; n <= last_station; ++n) {
+        for (const auto& match : n_matches) {
+          if (!masks.at(match.first).at(n) && match.second.at(n) > 0)
+            ++cnt;
         }
-        return matched_muons;
+      }
+      return cnt;
     }
 
-    template<typename dnn, typename TensorElemGet>
-    void fillTensor(const TensorElemGet& get, const pat::Tau& tau, float default_value) const
-    {
-        get(dnn::n_matched_muons) = n_muons;
-        get(dnn::muon_pt) = best_matched_muon != nullptr ? best_matched_muon->p4().pt() : default_value;
-        get(dnn::muon_dEta) = best_matched_muon != nullptr
-                ? dEta(best_matched_muon->p4(), tau.p4()) : default_value;
-        get(dnn::muon_dPhi) = best_matched_muon != nullptr
-                ? dPhi(best_matched_muon->p4(), tau.p4()) : default_value;
-        get(dnn::muon_n_matches_DT_1) = n_matches.at(MuonSubdetId::DT).at(0);
-        get(dnn::muon_n_matches_DT_2) = n_matches.at(MuonSubdetId::DT).at(1);
-        get(dnn::muon_n_matches_DT_3) = n_matches.at(MuonSubdetId::DT).at(2);
-        get(dnn::muon_n_matches_DT_4) = n_matches.at(MuonSubdetId::DT).at(3);
-        get(dnn::muon_n_matches_CSC_1) = n_matches.at(MuonSubdetId::CSC).at(0);
-        get(dnn::muon_n_matches_CSC_2) = n_matches.at(MuonSubdetId::CSC).at(1);
-        get(dnn::muon_n_matches_CSC_3) = n_matches.at(MuonSubdetId::CSC).at(2);
-        get(dnn::muon_n_matches_CSC_4) = n_matches.at(MuonSubdetId::CSC).at(3);
-        get(dnn::muon_n_hits_DT_2) = n_hits.at(MuonSubdetId::DT).at(1);
-        get(dnn::muon_n_hits_DT_3) = n_hits.at(MuonSubdetId::DT).at(2);
-        get(dnn::muon_n_hits_DT_4) = n_hits.at(MuonSubdetId::DT).at(3);
-        get(dnn::muon_n_hits_CSC_2) = n_hits.at(MuonSubdetId::CSC).at(1);
-        get(dnn::muon_n_hits_CSC_3) = n_hits.at(MuonSubdetId::CSC).at(2);
-        get(dnn::muon_n_hits_CSC_4) = n_hits.at(MuonSubdetId::CSC).at(3);
-        get(dnn::muon_n_hits_RPC_2) = n_hits.at(MuonSubdetId::RPC).at(1);
-        get(dnn::muon_n_hits_RPC_3) = n_hits.at(MuonSubdetId::RPC).at(2);
-        get(dnn::muon_n_hits_RPC_4) = n_hits.at(MuonSubdetId::RPC).at(3);
-        get(dnn::muon_n_stations_with_matches_03) = countMuonStationsWithMatches(0, 3);
-        get(dnn::muon_n_stations_with_hits_23) = countMuonStationsWithHits(2, 3);
-    }
+    unsigned countMuonStationsWithHits(size_t first_station, size_t last_station) const {
+      static const std::map<int, std::vector<bool>> masks = {
+          {MuonSubdetId::DT, {false, false, false, false}},
+          {MuonSubdetId::CSC, {false, false, false, false}},
+          {MuonSubdetId::RPC, {false, false, false, false}},
+      };
 
-private:
-    unsigned countMuonStationsWithMatches(size_t first_station, size_t last_station) const
-    {
-        static const std::map<int, std::vector<bool>> masks = {
-            { MuonSubdetId::DT, { false, false, false, false } },
-            { MuonSubdetId::CSC, { true, false, false, false } },
-            { MuonSubdetId::RPC, { false, false, false, false } },
-        };
-        unsigned cnt = 0;
-        for(unsigned n = first_station; n <= last_station; ++n) {
-            for(const auto& match : n_matches) {
-                if(!masks.at(match.first).at(n) && match.second.at(n) > 0) ++cnt;
-            }
+      unsigned cnt = 0;
+      for (unsigned n = first_station; n <= last_station; ++n) {
+        for (const auto& hit : n_hits) {
+          if (!masks.at(hit.first).at(n) && hit.second.at(n) > 0)
+            ++cnt;
         }
-        return cnt;
+      }
+      return cnt;
     }
+  };
 
-    unsigned countMuonStationsWithHits(size_t first_station, size_t last_station) const
-    {
-        static const std::map<int, std::vector<bool>> masks = {
-            { MuonSubdetId::DT, { false, false, false, false } },
-            { MuonSubdetId::CSC, { false, false, false, false } },
-            { MuonSubdetId::RPC, { false, false, false, false } },
-        };
-
-        unsigned cnt = 0;
-        for(unsigned n = first_station; n <= last_station; ++n) {
-            for(const auto& hit : n_hits) {
-                if(!masks.at(hit.first).at(n) && hit.second.at(n) > 0) ++cnt;
-            }
-        }
-        return cnt;
-    }
-};
-
-
-
-struct MuonHitMatchV2 {
-
+  struct MuonHitMatchV2 {
     static constexpr size_t n_muon_stations = 4;
     static constexpr int first_station_id = 1;
     static constexpr int last_station_id = first_station_id + n_muon_stations - 1;
     using CountArray = std::array<unsigned, n_muon_stations>;
     using CountMap = std::map<int, CountArray>;
 
-    const std::vector<int>& consideredSubdets()
-    {
-        static const std::vector<int> subdets = { MuonSubdetId::DT, MuonSubdetId::CSC, MuonSubdetId::RPC };
-        return subdets;
+    const std::vector<int>& consideredSubdets() {
+      static const std::vector<int> subdets = {MuonSubdetId::DT, MuonSubdetId::CSC, MuonSubdetId::RPC};
+      return subdets;
     }
 
-    const std::string& subdetName(int subdet)
-    {
-        static const std::map<int, std::string> subdet_names = {
-            { MuonSubdetId::DT, "DT" }, { MuonSubdetId::CSC, "CSC" }, { MuonSubdetId::RPC, "RPC" }
-        };
-        if(!subdet_names.count(subdet))
-            throw cms::Exception("MuonHitMatch") << "Subdet name for subdet id " << subdet << " not found.";
-        return subdet_names.at(subdet);
+    const std::string& subdetName(int subdet) {
+      static const std::map<int, std::string> subdet_names = {
+          {MuonSubdetId::DT, "DT"}, {MuonSubdetId::CSC, "CSC"}, {MuonSubdetId::RPC, "RPC"}};
+      if (!subdet_names.count(subdet))
+        throw cms::Exception("MuonHitMatch") << "Subdet name for subdet id " << subdet << " not found.";
+      return subdet_names.at(subdet);
     }
 
-    size_t getStationIndex(int station, bool throw_exception) const
-    {
-        if(station < first_station_id || station > last_station_id) {
-            if(throw_exception)
-                throw cms::Exception("MuonHitMatch") << "Station id is out of range";
-            return std::numeric_limits<size_t>::max();
+    size_t getStationIndex(int station, bool throw_exception) const {
+      if (station < first_station_id || station > last_station_id) {
+        if (throw_exception)
+          throw cms::Exception("MuonHitMatch") << "Station id is out of range";
+        return std::numeric_limits<size_t>::max();
+      }
+      return static_cast<size_t>(station - 1);
+    }
+
+    MuonHitMatchV2(const pat::Muon& muon) {
+      for (int subdet : consideredSubdets()) {
+        n_matches[subdet].fill(0);
+        n_hits[subdet].fill(0);
+      }
+
+      countMatches(muon, n_matches);
+      countHits(muon, n_hits);
+    }
+
+    void countMatches(const pat::Muon& muon, CountMap& n_matches) {
+      for (const auto& segment : muon.matches()) {
+        if (segment.segmentMatches.empty() && segment.rpcMatches.empty())
+          continue;
+        if (n_matches.count(segment.detector())) {
+          const size_t station_index = getStationIndex(segment.station(), true);
+          ++n_matches.at(segment.detector()).at(station_index);
         }
-        return static_cast<size_t>(station - 1);
+      }
     }
 
-    MuonHitMatchV2(const pat::Muon& muon)
-    {
-        for(int subdet : consideredSubdets()) {
-            n_matches[subdet].fill(0);
-            n_hits[subdet].fill(0);
-        }
+    void countHits(const pat::Muon& muon, CountMap& n_hits) {
+      if (muon.outerTrack().isNonnull()) {
+        const auto& hit_pattern = muon.outerTrack()->hitPattern();
+        for (int hit_index = 0; hit_index < hit_pattern.numberOfAllHits(reco::HitPattern::TRACK_HITS); ++hit_index) {
+          auto hit_id = hit_pattern.getHitPattern(reco::HitPattern::TRACK_HITS, hit_index);
+          if (hit_id == 0)
+            break;
+          if (hit_pattern.muonHitFilter(hit_id) && (hit_pattern.getHitType(hit_id) == TrackingRecHit::valid ||
+                                                    hit_pattern.getHitType(hit_id) == TrackingRecHit::bad)) {
+            const size_t station_index = getStationIndex(hit_pattern.getMuonStation(hit_id), false);
+            if (station_index < n_muon_stations) {
+              CountArray* muon_n_hits = nullptr;
+              if (hit_pattern.muonDTHitFilter(hit_id))
+                muon_n_hits = &n_hits.at(MuonSubdetId::DT);
+              else if (hit_pattern.muonCSCHitFilter(hit_id))
+                muon_n_hits = &n_hits.at(MuonSubdetId::CSC);
+              else if (hit_pattern.muonRPCHitFilter(hit_id))
+                muon_n_hits = &n_hits.at(MuonSubdetId::RPC);
 
-        countMatches(muon, n_matches);
-        countHits(muon, n_hits);
-    }
-
-    void countMatches(const pat::Muon& muon, CountMap& n_matches)
-    {
-        for(const auto& segment : muon.matches()) {
-            if(segment.segmentMatches.empty() && segment.rpcMatches.empty()) continue;
-            if(n_matches.count(segment.detector())) {
-                const size_t station_index = getStationIndex(segment.station(), true);
-                ++n_matches.at(segment.detector()).at(station_index);
+              if (muon_n_hits)
+                ++muon_n_hits->at(station_index);
             }
+          }
         }
+      }
     }
 
-    void countHits(const pat::Muon& muon, CountMap& n_hits)
-    {
-        if(muon.outerTrack().isNonnull()) {
-            const auto& hit_pattern = muon.outerTrack()->hitPattern();
-            for(int hit_index = 0; hit_index < hit_pattern.numberOfAllHits(reco::HitPattern::TRACK_HITS); ++hit_index) {
-                auto hit_id = hit_pattern.getHitPattern(reco::HitPattern::TRACK_HITS, hit_index);
-                if(hit_id == 0) break;
-                if(hit_pattern.muonHitFilter(hit_id) && (hit_pattern.getHitType(hit_id) == TrackingRecHit::valid
-                                                         || hit_pattern.getHitType(hit_id) == TrackingRecHit::bad)) {
-                    const size_t station_index = getStationIndex(hit_pattern.getMuonStation(hit_id), false);
-                    if(station_index < n_muon_stations) {
-                        CountArray* muon_n_hits = nullptr;
-                        if(hit_pattern.muonDTHitFilter(hit_id))
-                            muon_n_hits = &n_hits.at(MuonSubdetId::DT);
-                        else if(hit_pattern.muonCSCHitFilter(hit_id))
-                            muon_n_hits = &n_hits.at(MuonSubdetId::CSC);
-                        else if(hit_pattern.muonRPCHitFilter(hit_id))
-                            muon_n_hits = &n_hits.at(MuonSubdetId::RPC);
+    unsigned nMatches(int subdet, int station) const {
+      if (!n_matches.count(subdet))
+        throw cms::Exception("MuonHitMatch") << "Subdet " << subdet << " not found.";
+      const size_t station_index = getStationIndex(station, true);
+      return n_matches.at(subdet).at(station_index);
+    }
 
-                        if(muon_n_hits)
-                            ++muon_n_hits->at(station_index);
-                    }
-                }
-            }
+    unsigned nHits(int subdet, int station) const {
+      if (!n_hits.count(subdet))
+        throw cms::Exception("MuonHitMatch") << "Subdet " << subdet << " not found.";
+      const size_t station_index = getStationIndex(station, true);
+      return n_hits.at(subdet).at(station_index);
+    }
+
+    unsigned countMuonStationsWithMatches(int first_station, int last_station) const {
+      static const std::map<int, std::vector<bool>> masks = {
+          {MuonSubdetId::DT, {false, false, false, false}},
+          {MuonSubdetId::CSC, {true, false, false, false}},
+          {MuonSubdetId::RPC, {false, false, false, false}},
+      };
+      const size_t first_station_index = getStationIndex(first_station, true);
+      const size_t last_station_index = getStationIndex(last_station, true);
+      unsigned cnt = 0;
+      for (size_t n = first_station_index; n <= last_station_index; ++n) {
+        for (const auto& match : n_matches) {
+          if (!masks.at(match.first).at(n) && match.second.at(n) > 0)
+            ++cnt;
         }
+      }
+      return cnt;
     }
 
-    unsigned nMatches(int subdet, int station) const
-    {
-        if(!n_matches.count(subdet))
-            throw cms::Exception("MuonHitMatch") << "Subdet " << subdet << " not found.";
-        const size_t station_index = getStationIndex(station, true);
-        return n_matches.at(subdet).at(station_index);
-    }
+    unsigned countMuonStationsWithHits(int first_station, int last_station) const {
+      static const std::map<int, std::vector<bool>> masks = {
+          {MuonSubdetId::DT, {false, false, false, false}},
+          {MuonSubdetId::CSC, {false, false, false, false}},
+          {MuonSubdetId::RPC, {false, false, false, false}},
+      };
 
-    unsigned nHits(int subdet, int station) const
-    {
-        if(!n_hits.count(subdet))
-            throw cms::Exception("MuonHitMatch") << "Subdet " << subdet << " not found.";
-        const size_t station_index = getStationIndex(station, true);
-        return n_hits.at(subdet).at(station_index);
-    }
-
-    unsigned countMuonStationsWithMatches(int first_station, int last_station) const
-    {
-        static const std::map<int, std::vector<bool>> masks = {
-            { MuonSubdetId::DT, { false, false, false, false } },
-            { MuonSubdetId::CSC, { true, false, false, false } },
-            { MuonSubdetId::RPC, { false, false, false, false } },
-        };
-        const size_t first_station_index = getStationIndex(first_station, true);
-        const size_t last_station_index = getStationIndex(last_station, true);
-        unsigned cnt = 0;
-        for(size_t n = first_station_index; n <= last_station_index; ++n) {
-            for(const auto& match : n_matches) {
-                if(!masks.at(match.first).at(n) && match.second.at(n) > 0) ++cnt;
-            }
+      const size_t first_station_index = getStationIndex(first_station, true);
+      const size_t last_station_index = getStationIndex(last_station, true);
+      unsigned cnt = 0;
+      for (size_t n = first_station_index; n <= last_station_index; ++n) {
+        for (const auto& hit : n_hits) {
+          if (!masks.at(hit.first).at(n) && hit.second.at(n) > 0)
+            ++cnt;
         }
-        return cnt;
+      }
+      return cnt;
     }
 
-    unsigned countMuonStationsWithHits(int first_station, int last_station) const
-    {
-        static const std::map<int, std::vector<bool>> masks = {
-            { MuonSubdetId::DT, { false, false, false, false } },
-            { MuonSubdetId::CSC, { false, false, false, false } },
-            { MuonSubdetId::RPC, { false, false, false, false } },
-        };
-
-        const size_t first_station_index = getStationIndex(first_station, true);
-        const size_t last_station_index = getStationIndex(last_station, true);
-        unsigned cnt = 0;
-        for(size_t n = first_station_index; n <= last_station_index; ++n) {
-            for(const auto& hit : n_hits) {
-                if(!masks.at(hit.first).at(n) && hit.second.at(n) > 0) ++cnt;
-            }
-        }
-        return cnt;
-    }
-
-    private:
+  private:
     CountMap n_matches, n_hits;
-};
+  };
 
-enum class CellObjectType { PfCand_electron, PfCand_muon, PfCand_chargedHadron, PfCand_neutralHadron,
-                            PfCand_gamma, Electron, Muon, Other };
+  enum class CellObjectType {
+    PfCand_electron,
+    PfCand_muon,
+    PfCand_chargedHadron,
+    PfCand_neutralHadron,
+    PfCand_gamma,
+    Electron,
+    Muon,
+    Other
+  };
 
-template<typename Object>
-CellObjectType GetCellObjectType(const Object&);
-template<>
-CellObjectType GetCellObjectType(const pat::Electron&) { return CellObjectType::Electron; }
-template<>
-CellObjectType GetCellObjectType(const pat::Muon&) { return CellObjectType::Muon; }
+  template <typename Object>
+  CellObjectType GetCellObjectType(const Object&);
+  template <>
+  CellObjectType GetCellObjectType(const pat::Electron&) {
+    return CellObjectType::Electron;
+  }
+  template <>
+  CellObjectType GetCellObjectType(const pat::Muon&) {
+    return CellObjectType::Muon;
+  }
 
-template<>
-CellObjectType GetCellObjectType(const pat::PackedCandidate& cand)
-{
-    static const std::map<int, CellObjectType> obj_types = {
-        { 11, CellObjectType::PfCand_electron },
-        { 13, CellObjectType::PfCand_muon },
-        { 22, CellObjectType::PfCand_gamma },
-        { 130, CellObjectType::PfCand_neutralHadron },
-        { 211, CellObjectType::PfCand_chargedHadron }
-    };
+  template <>
+  CellObjectType GetCellObjectType(const pat::PackedCandidate& cand) {
+    static const std::map<int, CellObjectType> obj_types = {{11, CellObjectType::PfCand_electron},
+                                                            {13, CellObjectType::PfCand_muon},
+                                                            {22, CellObjectType::PfCand_gamma},
+                                                            {130, CellObjectType::PfCand_neutralHadron},
+                                                            {211, CellObjectType::PfCand_chargedHadron}};
 
     auto iter = obj_types.find(std::abs(cand.pdgId()));
-    if(iter == obj_types.end())
-        return CellObjectType::Other;
+    if (iter == obj_types.end())
+      return CellObjectType::Other;
     return iter->second;
-}
+  }
 
-
-using Cell = std::map<CellObjectType, size_t>;
-struct CellIndex {
+  using Cell = std::map<CellObjectType, size_t>;
+  struct CellIndex {
     int eta, phi;
 
-    bool operator<(const CellIndex& other) const
-    {
-        if(eta != other.eta) return eta < other.eta;
-        return phi < other.phi;
+    bool operator<(const CellIndex& other) const {
+      if (eta != other.eta)
+        return eta < other.eta;
+      return phi < other.phi;
     }
-};
+  };
 
-class CellGrid {
-public:
+  class CellGrid {
+  public:
     using Map = std::map<CellIndex, Cell>;
     using const_iterator = Map::const_iterator;
 
-    CellGrid(unsigned n_cells_eta, unsigned n_cells_phi, double cell_size_eta, double cell_size_phi) :
-        nCellsEta(n_cells_eta), nCellsPhi(n_cells_phi), nTotal(nCellsEta * nCellsPhi),
-        cellSizeEta(cell_size_eta), cellSizePhi(cell_size_phi)
-    {
-        if(nCellsEta % 2 != 1 || nCellsEta < 1)
-            throw cms::Exception("DeepTauId") << "Invalid number of eta cells.";
-        if(nCellsPhi % 2 != 1 || nCellsPhi < 1)
-            throw cms::Exception("DeepTauId") << "Invalid number of phi cells.";
-        if(cellSizeEta <= 0 || cellSizePhi <= 0)
-            throw cms::Exception("DeepTauId") << "Invalid cell size.";
+    CellGrid(unsigned n_cells_eta, unsigned n_cells_phi, double cell_size_eta, double cell_size_phi)
+        : nCellsEta(n_cells_eta),
+          nCellsPhi(n_cells_phi),
+          nTotal(nCellsEta * nCellsPhi),
+          cellSizeEta(cell_size_eta),
+          cellSizePhi(cell_size_phi) {
+      if (nCellsEta % 2 != 1 || nCellsEta < 1)
+        throw cms::Exception("DeepTauId") << "Invalid number of eta cells.";
+      if (nCellsPhi % 2 != 1 || nCellsPhi < 1)
+        throw cms::Exception("DeepTauId") << "Invalid number of phi cells.";
+      if (cellSizeEta <= 0 || cellSizePhi <= 0)
+        throw cms::Exception("DeepTauId") << "Invalid cell size.";
     }
 
     int maxEtaIndex() const { return static_cast<int>((nCellsEta - 1) / 2); }
@@ -516,18 +772,18 @@ public:
     int getEtaTensorIndex(const CellIndex& cellIndex) const { return cellIndex.eta + maxEtaIndex(); }
     int getPhiTensorIndex(const CellIndex& cellIndex) const { return cellIndex.phi + maxPhiIndex(); }
 
-    bool tryGetCellIndex(double deltaEta, double deltaPhi, CellIndex& cellIndex) const
-    {
-        static auto getCellIndex = [](double x, double maxX, double size, int& index) {
-            const double absX = std::abs(x);
-            if(absX > maxX) return false;
-            const double absIndex = std::floor(std::abs(absX / size - 0.5));
-            index = static_cast<int>(std::copysign(absIndex, x));
-            return true;
-        };
+    bool tryGetCellIndex(double deltaEta, double deltaPhi, CellIndex& cellIndex) const {
+      static auto getCellIndex = [](double x, double maxX, double size, int& index) {
+        const double absX = std::abs(x);
+        if (absX > maxX)
+          return false;
+        const double absIndex = std::floor(std::abs(absX / size - 0.5));
+        index = static_cast<int>(std::copysign(absIndex, x));
+        return true;
+      };
 
-        return getCellIndex(deltaEta, maxDeltaEta(), cellSizeEta, cellIndex.eta)
-               && getCellIndex(deltaPhi, maxDeltaPhi(), cellSizePhi, cellIndex.phi);
+      return getCellIndex(deltaEta, maxDeltaEta(), cellSizeEta, cellIndex.eta) &&
+             getCellIndex(deltaPhi, maxDeltaPhi(), cellSizePhi, cellIndex.phi);
     }
 
     Cell& operator[](const CellIndex& cellIndex) { return cells[cellIndex]; }
@@ -537,1157 +793,1250 @@ public:
     const_iterator begin() const { return cells.begin(); }
     const_iterator end() const { return cells.end(); }
 
-public:
+  public:
     const unsigned nCellsEta, nCellsPhi, nTotal;
     const double cellSizeEta, cellSizePhi;
 
-private:
+  private:
     std::map<CellIndex, Cell> cells;
-};
+  };
 
-} // anonymous namespace
+}  // anonymous namespace
 
 class DeepTauId : public deep_tau::DeepTauBase {
 public:
+  static constexpr float default_value = -999.;
 
-    static constexpr float default_value = -999.;
+  static const OutputCollection& GetOutputs() {
+    static constexpr size_t e_index = 0, mu_index = 1, tau_index = 2, jet_index = 3;
+    static const OutputCollection outputs_ = {
+        {"VSe", Output({tau_index}, {e_index, tau_index})},
+        {"VSmu", Output({tau_index}, {mu_index, tau_index})},
+        {"VSjet", Output({tau_index}, {jet_index, tau_index})},
+    };
+    return outputs_;
+  }
 
-    static const OutputCollection& GetOutputs()
-    {
-        static constexpr size_t e_index = 0, mu_index = 1, tau_index = 2, jet_index = 3;
-        static const OutputCollection outputs_ = {
-            { "VSe", Output({tau_index}, {e_index, tau_index}) },
-            { "VSmu", Output({tau_index}, {mu_index, tau_index}) },
-            { "VSjet", Output({tau_index}, {jet_index, tau_index}) },
-        };
-        return outputs_;
-    }
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("electrons", edm::InputTag("slimmedElectrons"));
+    desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
+    desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
+    desc.add<edm::InputTag>("pfcands", edm::InputTag("packedPFCandidates"));
+    desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
+    desc.add<edm::InputTag>("rho", edm::InputTag("fixedGridRhoAll"));
+    desc.add<std::vector<std::string>>("graph_file",
+                                       {"RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6.pb"});
+    desc.add<bool>("mem_mapped", false);
+    desc.add<unsigned>("version", 2);
+    desc.add<int>("debug_level", 0);
 
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-    {
-        edm::ParameterSetDescription desc;
-        desc.add<edm::InputTag>("electrons", edm::InputTag("slimmedElectrons"));
-        desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
-        desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
-        desc.add<edm::InputTag>("pfcands", edm::InputTag("packedPFCandidates"));
-        desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
-        desc.add<edm::InputTag>("rho", edm::InputTag("fixedGridRhoAll"));
-        desc.add<std::vector<std::string>>("graph_file", {"RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6.pb"});
-        desc.add<bool>("mem_mapped", false);
-        desc.add<unsigned>("version", 2);
-        desc.add<int>("debug_level", 0);
-
-        edm::ParameterSetDescription descWP;
-        descWP.add<std::string>("VVVLoose", "0");
-        descWP.add<std::string>("VVLoose", "0");
-        descWP.add<std::string>("VLoose", "0");
-        descWP.add<std::string>("Loose", "0");
-        descWP.add<std::string>("Medium", "0");
-        descWP.add<std::string>("Tight", "0");
-        descWP.add<std::string>("VTight", "0");
-        descWP.add<std::string>("VVTight", "0");
-        descWP.add<std::string>("VVVTight", "0");
-        desc.add<edm::ParameterSetDescription>("VSeWP", descWP);
-        desc.add<edm::ParameterSetDescription>("VSmuWP", descWP);
-        desc.add<edm::ParameterSetDescription>("VSjetWP", descWP);
-        descriptions.add("DeepTau", desc);
-    }
+    edm::ParameterSetDescription descWP;
+    descWP.add<std::string>("VVVLoose", "0");
+    descWP.add<std::string>("VVLoose", "0");
+    descWP.add<std::string>("VLoose", "0");
+    descWP.add<std::string>("Loose", "0");
+    descWP.add<std::string>("Medium", "0");
+    descWP.add<std::string>("Tight", "0");
+    descWP.add<std::string>("VTight", "0");
+    descWP.add<std::string>("VVTight", "0");
+    descWP.add<std::string>("VVVTight", "0");
+    desc.add<edm::ParameterSetDescription>("VSeWP", descWP);
+    desc.add<edm::ParameterSetDescription>("VSmuWP", descWP);
+    desc.add<edm::ParameterSetDescription>("VSjetWP", descWP);
+    descriptions.add("DeepTau", desc);
+  }
 
 public:
-    explicit DeepTauId(const edm::ParameterSet& cfg, const deep_tau::DeepTauCache* cache) :
-        DeepTauBase(cfg, GetOutputs(), cache),
+  explicit DeepTauId(const edm::ParameterSet& cfg, const deep_tau::DeepTauCache* cache)
+      : DeepTauBase(cfg, GetOutputs(), cache),
         electrons_token_(consumes<ElectronCollection>(cfg.getParameter<edm::InputTag>("electrons"))),
         muons_token_(consumes<MuonCollection>(cfg.getParameter<edm::InputTag>("muons"))),
         rho_token_(consumes<double>(cfg.getParameter<edm::InputTag>("rho"))),
         version(cfg.getParameter<unsigned>("version")),
-        debug_level(cfg.getParameter<int>("debug_level"))
-    {
-        if(version == 1) {
-            input_layer_ = cache_->getGraph().node(0).name();
-            output_layer_ = cache_->getGraph().node(cache_->getGraph().node_size() - 1).name();
-            const auto& shape = cache_->getGraph().node(0).attr().at("shape").shape();
-            if(shape.dim(1).size() != dnn_inputs_2017v1::NumberOfInputs)
-                throw cms::Exception("DeepTauId") << "number of inputs does not match the expected inputs for the given version";
-        } else if(version == 2) {
-            tauBlockTensor_ =  std::make_shared<tensorflow::Tensor>(tensorflow::DT_FLOAT, tensorflow::TensorShape{ 1,
-                dnn_inputs_2017_v2::TauBlockInputs::NumberOfInputs});
-            for(size_t n = 0; n < 2; ++n) {
-                const bool is_inner = n == 0;
-                const auto n_cells = is_inner ? dnn_inputs_2017_v2::number_of_inner_cell
-                                              : dnn_inputs_2017_v2::number_of_outer_cell;
-                eGammaTensor_[is_inner] = std::make_shared<tensorflow::Tensor>(tensorflow::DT_FLOAT,
-                    tensorflow::TensorShape{1, 1, 1, dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs});
-                muonTensor_[is_inner] = std::make_shared<tensorflow::Tensor>(tensorflow::DT_FLOAT,
-                    tensorflow::TensorShape{1, 1, 1, dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs});
-                hadronsTensor_[is_inner] = std::make_shared<tensorflow::Tensor>(tensorflow::DT_FLOAT,
-                    tensorflow::TensorShape{1, 1, 1, dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs});
-                convTensor_[is_inner] = std::make_shared<tensorflow::Tensor>(tensorflow::DT_FLOAT,
-                    tensorflow::TensorShape{1, n_cells, n_cells, dnn_inputs_2017_v2::number_of_conv_features});
-                zeroOutputTensor_[is_inner] = std::make_shared<tensorflow::Tensor>(tensorflow::DT_FLOAT,
-                    tensorflow::TensorShape{1, 1, 1, dnn_inputs_2017_v2::number_of_conv_features});
+        debug_level(cfg.getParameter<int>("debug_level")) {
+    if (version == 1) {
+      input_layer_ = cache_->getGraph().node(0).name();
+      output_layer_ = cache_->getGraph().node(cache_->getGraph().node_size() - 1).name();
+      const auto& shape = cache_->getGraph().node(0).attr().at("shape").shape();
+      if (shape.dim(1).size() != dnn_inputs_2017v1::NumberOfInputs)
+        throw cms::Exception("DeepTauId")
+            << "number of inputs does not match the expected inputs for the given version";
+    } else if (version == 2) {
+      tauBlockTensor_ = std::make_shared<tensorflow::Tensor>(
+          tensorflow::DT_FLOAT, tensorflow::TensorShape{1, dnn_inputs_2017_v2::TauBlockInputs::NumberOfInputs});
+      for (size_t n = 0; n < 2; ++n) {
+        const bool is_inner = n == 0;
+        const auto n_cells =
+            is_inner ? dnn_inputs_2017_v2::number_of_inner_cell : dnn_inputs_2017_v2::number_of_outer_cell;
+        eGammaTensor_[is_inner] = std::make_shared<tensorflow::Tensor>(
+            tensorflow::DT_FLOAT,
+            tensorflow::TensorShape{1, 1, 1, dnn_inputs_2017_v2::EgammaBlockInputs::NumberOfInputs});
+        muonTensor_[is_inner] = std::make_shared<tensorflow::Tensor>(
+            tensorflow::DT_FLOAT,
+            tensorflow::TensorShape{1, 1, 1, dnn_inputs_2017_v2::MuonBlockInputs::NumberOfInputs});
+        hadronsTensor_[is_inner] = std::make_shared<tensorflow::Tensor>(
+            tensorflow::DT_FLOAT,
+            tensorflow::TensorShape{1, 1, 1, dnn_inputs_2017_v2::HadronBlockInputs::NumberOfInputs});
+        convTensor_[is_inner] = std::make_shared<tensorflow::Tensor>(
+            tensorflow::DT_FLOAT,
+            tensorflow::TensorShape{1, n_cells, n_cells, dnn_inputs_2017_v2::number_of_conv_features});
+        zeroOutputTensor_[is_inner] = std::make_shared<tensorflow::Tensor>(
+            tensorflow::DT_FLOAT, tensorflow::TensorShape{1, 1, 1, dnn_inputs_2017_v2::number_of_conv_features});
 
-
-                eGammaTensor_[is_inner]->flat<float>().setZero();
-                muonTensor_[is_inner]->flat<float>().setZero();
-                hadronsTensor_[is_inner]->flat<float>().setZero();
-                getPartialPredictions(*zeroOutputTensor_[is_inner], is_inner, 0, 0);
-
-            }
-        } else {
-            throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
-        }
-
+        eGammaTensor_[is_inner]->flat<float>().setZero();
+        muonTensor_[is_inner]->flat<float>().setZero();
+        hadronsTensor_[is_inner]->flat<float>().setZero();
+        getPartialPredictions(*zeroOutputTensor_[is_inner], is_inner, 0, 0);
+      }
+    } else {
+      throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
     }
+  }
 
-    static std::unique_ptr<deep_tau::DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg)
-    {
-        return DeepTauBase::initializeGlobalCache(cfg);
-    }
+  static std::unique_ptr<deep_tau::DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg) {
+    return DeepTauBase::initializeGlobalCache(cfg);
+  }
 
-    static void globalEndJob(const deep_tau::DeepTauCache* cache_)
-    {
-        return DeepTauBase::globalEndJob(cache_);
-    }
-private:
-    static constexpr float pi = M_PI;
-
-    template<typename T>
-    static float getValue(T value)
-    {
-        return std::isnormal(value) ? static_cast<float>(value) : 0.f;
-    }
-
-    template<typename T>
-    static float getValueLinear(T value, float min_value, float max_value, bool positive)
-    {
-        const float fixed_value = getValue(value);
-        const float clamped_value = std::clamp(fixed_value, min_value, max_value);
-        float transformed_value = (clamped_value - min_value) / (max_value - min_value);
-        if(!positive)
-            transformed_value = transformed_value * 2 - 1;
-        return transformed_value;
-    }
-
-    template<typename T>
-    static float getValueNorm(T value, float mean, float sigma, float n_sigmas_max = 5)
-    {
-        const float fixed_value = getValue(value);
-        const float norm_value = (fixed_value - mean) / sigma;
-        return std::clamp(norm_value, -n_sigmas_max, n_sigmas_max);
-    }
-
-    static bool calculateElectronClusterVarsV2(const pat::Electron& ele, float& cc_ele_energy, float& cc_gamma_energy,
-                                             int& cc_n_gamma)
-    {
-        cc_ele_energy = cc_gamma_energy = 0;
-        cc_n_gamma = 0;
-        const auto& superCluster = ele.superCluster();
-        if(superCluster.isNonnull() && superCluster.isAvailable() && superCluster->clusters().isNonnull()
-            && superCluster->clusters().isAvailable()) {
-            for(auto iter = superCluster->clustersBegin(); iter != superCluster->clustersEnd(); ++iter) {
-                const float energy = static_cast<float>((*iter)->energy());
-                if(iter == superCluster->clustersBegin())
-                    cc_ele_energy += energy;
-                else {
-                    cc_gamma_energy += energy;
-                    ++cc_n_gamma;
-                }
-            }
-            return true;
-        } else
-            return false;
-    }
-
-    inline void checkInputs(const tensorflow::Tensor& inputs, const char* block_name, int n_inputs, int n_eta = 1,
-                            int n_phi = 1) const
-    {
-        if(debug_level >= 1){
-            for(int eta = 0; eta < n_eta; ++eta){
-                for(int phi = 0; phi < n_phi; phi++){
-                    for(int k = 0; k < n_inputs; ++k) {
-                        const float input = n_eta == 1 && n_phi == 1
-                                          ? inputs.matrix<float>()(0, k) : inputs.tensor<float,4>()(0, eta, phi, k);
-                        if(std::isnan(input))
-                            throw cms::Exception("DeepTauId") << "in the " << block_name << ", input is NaN for eta_index = "
-                                                              << n_eta << ", phi_index = " << n_phi << ", input_index = " << k;
-                        if(debug_level >= 2)
-                            std::cout << block_name << "," << eta << ","<< phi << "," << k << "," << std::setprecision(5) << std::fixed << input << '\n';
-                    }
-                }
-            }
-        }
-    }
+  static void globalEndJob(const deep_tau::DeepTauCache* cache_) { return DeepTauBase::globalEndJob(cache_); }
 
 private:
-    tensorflow::Tensor getPredictions(edm::Event& event, const edm::EventSetup& es,
-                                      edm::Handle<TauCollection> taus) override
-    {
-        edm::Handle<pat::ElectronCollection> electrons;
-        event.getByToken(electrons_token_, electrons);
+  static constexpr float pi = M_PI;
 
-        edm::Handle<pat::MuonCollection> muons;
-        event.getByToken(muons_token_, muons);
+  template <typename T>
+  static float getValue(T value) {
+    return std::isnormal(value) ? static_cast<float>(value) : 0.f;
+  }
 
-        edm::Handle<pat::PackedCandidateCollection> pfCands;
-        event.getByToken(pfcandToken_, pfCands);
+  template <typename T>
+  static float getValueLinear(T value, float min_value, float max_value, bool positive) {
+    const float fixed_value = getValue(value);
+    const float clamped_value = std::clamp(fixed_value, min_value, max_value);
+    float transformed_value = (clamped_value - min_value) / (max_value - min_value);
+    if (!positive)
+      transformed_value = transformed_value * 2 - 1;
+    return transformed_value;
+  }
 
-        edm::Handle<reco::VertexCollection> vertices;
-        event.getByToken(vtxToken_, vertices);
+  template <typename T>
+  static float getValueNorm(T value, float mean, float sigma, float n_sigmas_max = 5) {
+    const float fixed_value = getValue(value);
+    const float norm_value = (fixed_value - mean) / sigma;
+    return std::clamp(norm_value, -n_sigmas_max, n_sigmas_max);
+  }
 
-        edm::Handle<double> rho;
-        event.getByToken(rho_token_, rho);
-
-        tensorflow::Tensor predictions(tensorflow::DT_FLOAT, { static_cast<int>(taus->size()),
-                                       deep_tau::NumberOfOutputs});
-        for(size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
-            std::vector<tensorflow::Tensor> pred_vector;
-            if(version == 1)
-                getPredictionsV1(taus->at(tau_index), *electrons, *muons, pred_vector);
-            else if(version == 2)
-                getPredictionsV2(taus->at(tau_index), *electrons, *muons, *pfCands, vertices->at(0), *rho, pred_vector);
-            else
-                throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
-            for(int k = 0; k < deep_tau::NumberOfOutputs; ++k) {
-                const float pred = pred_vector[0].flat<float>()(k);
-                if(!(pred >= 0 && pred <= 1))
-                    throw cms::Exception("DeepTauId") << "invalid prediction = " << pred << " for tau_index = "
-                                                      << tau_index << ", pred_index = " << k;
-                predictions.matrix<float>()(tau_index, k) = pred;
-            }
+  static bool calculateElectronClusterVarsV2(const pat::Electron& ele,
+                                             float& cc_ele_energy,
+                                             float& cc_gamma_energy,
+                                             int& cc_n_gamma) {
+    cc_ele_energy = cc_gamma_energy = 0;
+    cc_n_gamma = 0;
+    const auto& superCluster = ele.superCluster();
+    if (superCluster.isNonnull() && superCluster.isAvailable() && superCluster->clusters().isNonnull() &&
+        superCluster->clusters().isAvailable()) {
+      for (auto iter = superCluster->clustersBegin(); iter != superCluster->clustersEnd(); ++iter) {
+        const float energy = static_cast<float>((*iter)->energy());
+        if (iter == superCluster->clustersBegin())
+          cc_ele_energy += energy;
+        else {
+          cc_gamma_energy += energy;
+          ++cc_n_gamma;
         }
-        return predictions;
-    }
+      }
+      return true;
+    } else
+      return false;
+  }
 
-    void getPredictionsV1(const TauType& tau, const pat::ElectronCollection& electrons,
-                          const pat::MuonCollection& muons, std::vector<tensorflow::Tensor>& pred_vector)
-    {
-        const tensorflow::Tensor& inputs = createInputsV1<dnn_inputs_2017v1>(tau, electrons, muons);
-        tensorflow::run(&(cache_->getSession()), { { input_layer_, inputs } }, { output_layer_ }, &pred_vector);
-    }
-
-    void getPredictionsV2(const TauType& tau, const pat::ElectronCollection& electrons,
-                          const pat::MuonCollection& muons, const pat::PackedCandidateCollection& pfCands,
-                          const reco::Vertex& pv, double rho, std::vector<tensorflow::Tensor>& pred_vector)
-    {
-        CellGrid inner_grid(dnn_inputs_2017_v2::number_of_inner_cell, dnn_inputs_2017_v2::number_of_inner_cell,
-                            0.02, 0.02);
-        CellGrid outer_grid(dnn_inputs_2017_v2::number_of_outer_cell, dnn_inputs_2017_v2::number_of_outer_cell,
-                            0.05, 0.05);
-        fillGrids(tau, electrons, inner_grid, outer_grid);
-        fillGrids(tau, muons, inner_grid, outer_grid);
-        fillGrids(tau, pfCands, inner_grid, outer_grid);
-
-        createTauBlockInputs(tau, pv, rho);
-        createConvFeatures(tau, pv, rho, electrons, muons, pfCands, inner_grid, true);
-        createConvFeatures(tau, pv, rho, electrons, muons, pfCands, outer_grid, false);
-
-        tensorflow::run(&(cache_->getSession("core")),
-            { { "input_tau", *tauBlockTensor_ },
-              { "input_inner", *convTensor_.at(true)}, { "input_outer", *convTensor_.at(false) } },
-            { "main_output/Softmax" }, &pred_vector);
-    }
-
-    template<typename Collection>
-    void fillGrids(const TauType& tau, const Collection& objects, CellGrid& inner_grid, CellGrid& outer_grid)
-    {
-        static constexpr double outer_dR2 = 0.25;//0.5^2
-        const double inner_radius = getInnerSignalConeRadius(tau.polarP4().pt());
-        const double inner_dR2 = std::pow(inner_radius, 2);
-
-        const auto addObject = [&](size_t n, double deta, double dphi, CellGrid& grid) {
-            const auto& obj = objects.at(n);
-            const CellObjectType obj_type = GetCellObjectType(obj);
-            if(obj_type  == CellObjectType::Other) return;
-            CellIndex cell_index;
-            if(grid.tryGetCellIndex(deta, dphi, cell_index)) {
-                Cell& cell = grid[cell_index];
-                auto iter = cell.find(obj_type);
-                if(iter != cell.end()) {
-                     const auto& prev_obj = objects.at(iter->second);
-                     if(obj.polarP4().pt() > prev_obj.polarP4().pt())
-                        iter->second = n;
-                } else {
-                    cell[obj_type] = n;
-                }
-            }
-        };
-
-        for(size_t n = 0; n < objects.size(); ++n) {
-            const auto& obj = objects.at(n);
-            const double deta = obj.polarP4().eta() - tau.polarP4().eta();
-            const double dphi = reco::deltaPhi(obj.polarP4().phi(), tau.polarP4().phi());
-            const double dR2 = std::pow(deta, 2) + std::pow(dphi, 2);
-            if(dR2 < inner_dR2)
-                addObject(n, deta, dphi, inner_grid);
-            if(dR2 < outer_dR2)
-                addObject(n, deta, dphi, outer_grid);
+  inline void checkInputs(
+      const tensorflow::Tensor& inputs, const char* block_name, int n_inputs, int n_eta = 1, int n_phi = 1) const {
+    if (debug_level >= 1) {
+      for (int eta = 0; eta < n_eta; ++eta) {
+        for (int phi = 0; phi < n_phi; phi++) {
+          for (int k = 0; k < n_inputs; ++k) {
+            const float input =
+                n_eta == 1 && n_phi == 1 ? inputs.matrix<float>()(0, k) : inputs.tensor<float, 4>()(0, eta, phi, k);
+            if (std::isnan(input))
+              throw cms::Exception("DeepTauId") << "in the " << block_name << ", input is NaN for eta_index = " << n_eta
+                                                << ", phi_index = " << n_phi << ", input_index = " << k;
+            if (debug_level >= 2)
+              std::cout << block_name << "," << eta << "," << phi << "," << k << "," << std::setprecision(5)
+                        << std::fixed << input << '\n';
+          }
         }
+      }
     }
+  }
 
-    void getPartialPredictions(tensorflow::Tensor& convTensor, bool is_inner, int eta_index, int phi_index)
-    {
-        std::vector<tensorflow::Tensor> pred_vector;
-        if(is_inner) {
-            tensorflow::run(&(cache_->getSession("inner")),
-                { { "input_inner_egamma", *eGammaTensor_.at(is_inner) },
-                  { "input_inner_muon", *muonTensor_.at(is_inner) },
-                  { "input_inner_hadrons", *hadronsTensor_.at(is_inner) }, },
-                { "inner_all_dropout_4/Identity" }, &pred_vector);
+private:
+  tensorflow::Tensor getPredictions(edm::Event& event,
+                                    const edm::EventSetup& es,
+                                    edm::Handle<TauCollection> taus) override {
+    edm::Handle<pat::ElectronCollection> electrons;
+    event.getByToken(electrons_token_, electrons);
+
+    edm::Handle<pat::MuonCollection> muons;
+    event.getByToken(muons_token_, muons);
+
+    edm::Handle<pat::PackedCandidateCollection> pfCands;
+    event.getByToken(pfcandToken_, pfCands);
+
+    edm::Handle<reco::VertexCollection> vertices;
+    event.getByToken(vtxToken_, vertices);
+
+    edm::Handle<double> rho;
+    event.getByToken(rho_token_, rho);
+
+    tensorflow::Tensor predictions(tensorflow::DT_FLOAT, {static_cast<int>(taus->size()), deep_tau::NumberOfOutputs});
+    for (size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
+      std::vector<tensorflow::Tensor> pred_vector;
+      if (version == 1)
+        getPredictionsV1(taus->at(tau_index), *electrons, *muons, pred_vector);
+      else if (version == 2)
+        getPredictionsV2(taus->at(tau_index), *electrons, *muons, *pfCands, vertices->at(0), *rho, pred_vector);
+      else
+        throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
+      for (int k = 0; k < deep_tau::NumberOfOutputs; ++k) {
+        const float pred = pred_vector[0].flat<float>()(k);
+        if (!(pred >= 0 && pred <= 1))
+          throw cms::Exception("DeepTauId")
+              << "invalid prediction = " << pred << " for tau_index = " << tau_index << ", pred_index = " << k;
+        predictions.matrix<float>()(tau_index, k) = pred;
+      }
+    }
+    return predictions;
+  }
+
+  void getPredictionsV1(const TauType& tau,
+                        const pat::ElectronCollection& electrons,
+                        const pat::MuonCollection& muons,
+                        std::vector<tensorflow::Tensor>& pred_vector) {
+    const tensorflow::Tensor& inputs = createInputsV1<dnn_inputs_2017v1>(tau, electrons, muons);
+    tensorflow::run(&(cache_->getSession()), {{input_layer_, inputs}}, {output_layer_}, &pred_vector);
+  }
+
+  void getPredictionsV2(const TauType& tau,
+                        const pat::ElectronCollection& electrons,
+                        const pat::MuonCollection& muons,
+                        const pat::PackedCandidateCollection& pfCands,
+                        const reco::Vertex& pv,
+                        double rho,
+                        std::vector<tensorflow::Tensor>& pred_vector) {
+    CellGrid inner_grid(dnn_inputs_2017_v2::number_of_inner_cell, dnn_inputs_2017_v2::number_of_inner_cell, 0.02, 0.02);
+    CellGrid outer_grid(dnn_inputs_2017_v2::number_of_outer_cell, dnn_inputs_2017_v2::number_of_outer_cell, 0.05, 0.05);
+    fillGrids(tau, electrons, inner_grid, outer_grid);
+    fillGrids(tau, muons, inner_grid, outer_grid);
+    fillGrids(tau, pfCands, inner_grid, outer_grid);
+
+    createTauBlockInputs(tau, pv, rho);
+    createConvFeatures(tau, pv, rho, electrons, muons, pfCands, inner_grid, true);
+    createConvFeatures(tau, pv, rho, electrons, muons, pfCands, outer_grid, false);
+
+    tensorflow::run(&(cache_->getSession("core")),
+                    {{"input_tau", *tauBlockTensor_},
+                     {"input_inner", *convTensor_.at(true)},
+                     {"input_outer", *convTensor_.at(false)}},
+                    {"main_output/Softmax"},
+                    &pred_vector);
+  }
+
+  template <typename Collection>
+  void fillGrids(const TauType& tau, const Collection& objects, CellGrid& inner_grid, CellGrid& outer_grid) {
+    static constexpr double outer_dR2 = 0.25;  //0.5^2
+    const double inner_radius = getInnerSignalConeRadius(tau.polarP4().pt());
+    const double inner_dR2 = std::pow(inner_radius, 2);
+
+    const auto addObject = [&](size_t n, double deta, double dphi, CellGrid& grid) {
+      const auto& obj = objects.at(n);
+      const CellObjectType obj_type = GetCellObjectType(obj);
+      if (obj_type == CellObjectType::Other)
+        return;
+      CellIndex cell_index;
+      if (grid.tryGetCellIndex(deta, dphi, cell_index)) {
+        Cell& cell = grid[cell_index];
+        auto iter = cell.find(obj_type);
+        if (iter != cell.end()) {
+          const auto& prev_obj = objects.at(iter->second);
+          if (obj.polarP4().pt() > prev_obj.polarP4().pt())
+            iter->second = n;
         } else {
-            tensorflow::run(&(cache_->getSession("outer")),
-                { { "input_outer_egamma", *eGammaTensor_.at(is_inner) },
-                  { "input_outer_muon", *muonTensor_.at(is_inner) },
-                  { "input_outer_hadrons", *hadronsTensor_.at(is_inner) }, },
-                { "outer_all_dropout_4/Identity" }, &pred_vector);
+          cell[obj_type] = n;
         }
-        setCellConvFeatures(convTensor, pred_vector.at(0), eta_index, phi_index);
+      }
+    };
+
+    for (size_t n = 0; n < objects.size(); ++n) {
+      const auto& obj = objects.at(n);
+      const double deta = obj.polarP4().eta() - tau.polarP4().eta();
+      const double dphi = reco::deltaPhi(obj.polarP4().phi(), tau.polarP4().phi());
+      const double dR2 = std::pow(deta, 2) + std::pow(dphi, 2);
+      if (dR2 < inner_dR2)
+        addObject(n, deta, dphi, inner_grid);
+      if (dR2 < outer_dR2)
+        addObject(n, deta, dphi, outer_grid);
     }
+  }
 
-    void createConvFeatures(const TauType& tau, const reco::Vertex& pv, double rho,
-                            const pat::ElectronCollection& electrons, const pat::MuonCollection& muons,
-                            const pat::PackedCandidateCollection& pfCands, const CellGrid& grid, bool is_inner)
-    {
-        tensorflow::Tensor& convTensor = *convTensor_.at(is_inner);
-        for(int eta = -grid.maxEtaIndex(); eta <= grid.maxEtaIndex(); ++eta) {
-            for(int phi = -grid.maxPhiIndex(); phi <= grid.maxPhiIndex(); ++phi) {
-                const CellIndex cell_index{eta, phi};
-                const int eta_index = grid.getEtaTensorIndex(cell_index);
-                const int phi_index = grid.getPhiTensorIndex(cell_index);
-
-                const auto cell_iter = grid.find(cell_index);
-                if(cell_iter != grid.end()) {
-                    const Cell& cell = cell_iter->second;
-                    createEgammaBlockInputs(tau, pv, rho, electrons, pfCands, cell, is_inner);
-                    createMuonBlockInputs(tau, pv, rho, muons, pfCands, cell, is_inner);
-                    createHadronsBlockInputs(tau, pv, rho, pfCands, cell, is_inner);
-                    getPartialPredictions(convTensor, is_inner, eta_index, phi_index);
-                } else {
-                    setCellConvFeatures(convTensor, *zeroOutputTensor_[is_inner], eta_index, phi_index);
-                }
-            }
-        }
+  void getPartialPredictions(tensorflow::Tensor& convTensor, bool is_inner, int eta_index, int phi_index) {
+    std::vector<tensorflow::Tensor> pred_vector;
+    if (is_inner) {
+      tensorflow::run(&(cache_->getSession("inner")),
+                      {
+                          {"input_inner_egamma", *eGammaTensor_.at(is_inner)},
+                          {"input_inner_muon", *muonTensor_.at(is_inner)},
+                          {"input_inner_hadrons", *hadronsTensor_.at(is_inner)},
+                      },
+                      {"inner_all_dropout_4/Identity"},
+                      &pred_vector);
+    } else {
+      tensorflow::run(&(cache_->getSession("outer")),
+                      {
+                          {"input_outer_egamma", *eGammaTensor_.at(is_inner)},
+                          {"input_outer_muon", *muonTensor_.at(is_inner)},
+                          {"input_outer_hadrons", *hadronsTensor_.at(is_inner)},
+                      },
+                      {"outer_all_dropout_4/Identity"},
+                      &pred_vector);
     }
+    setCellConvFeatures(convTensor, pred_vector.at(0), eta_index, phi_index);
+  }
 
-    void setCellConvFeatures(tensorflow::Tensor& convTensor, const tensorflow::Tensor& features,
-                             int eta_index, int phi_index)
-    {
-        for(int n = 0; n < dnn_inputs_2017_v2::number_of_conv_features; ++n)
-            convTensor.tensor<float, 4>()(0, eta_index, phi_index, n) = features.tensor<float, 4>()(0, 0, 0, n);
+  void createConvFeatures(const TauType& tau,
+                          const reco::Vertex& pv,
+                          double rho,
+                          const pat::ElectronCollection& electrons,
+                          const pat::MuonCollection& muons,
+                          const pat::PackedCandidateCollection& pfCands,
+                          const CellGrid& grid,
+                          bool is_inner) {
+    tensorflow::Tensor& convTensor = *convTensor_.at(is_inner);
+    for (int eta = -grid.maxEtaIndex(); eta <= grid.maxEtaIndex(); ++eta) {
+      for (int phi = -grid.maxPhiIndex(); phi <= grid.maxPhiIndex(); ++phi) {
+        const CellIndex cell_index{eta, phi};
+        const int eta_index = grid.getEtaTensorIndex(cell_index);
+        const int phi_index = grid.getPhiTensorIndex(cell_index);
+
+        const auto cell_iter = grid.find(cell_index);
+        if (cell_iter != grid.end()) {
+          const Cell& cell = cell_iter->second;
+          createEgammaBlockInputs(tau, pv, rho, electrons, pfCands, cell, is_inner);
+          createMuonBlockInputs(tau, pv, rho, muons, pfCands, cell, is_inner);
+          createHadronsBlockInputs(tau, pv, rho, pfCands, cell, is_inner);
+          getPartialPredictions(convTensor, is_inner, eta_index, phi_index);
+        } else {
+          setCellConvFeatures(convTensor, *zeroOutputTensor_[is_inner], eta_index, phi_index);
+        }
+      }
     }
+  }
 
-    void createTauBlockInputs(const TauType& tau, const reco::Vertex& pv, double rho)
-    {
-        namespace dnn = dnn_inputs_2017_v2::TauBlockInputs;
+  void setCellConvFeatures(tensorflow::Tensor& convTensor,
+                           const tensorflow::Tensor& features,
+                           int eta_index,
+                           int phi_index) {
+    for (int n = 0; n < dnn_inputs_2017_v2::number_of_conv_features; ++n)
+      convTensor.tensor<float, 4>()(0, eta_index, phi_index, n) = features.tensor<float, 4>()(0, 0, 0, n);
+  }
 
-        tensorflow::Tensor& inputs = *tauBlockTensor_;
-        inputs.flat<float>().setZero();
+  void createTauBlockInputs(const TauType& tau, const reco::Vertex& pv, double rho) {
+    namespace dnn = dnn_inputs_2017_v2::TauBlockInputs;
 
-        const auto& get = [&](int var_index) -> float& { return inputs.matrix<float>()(0, var_index); };
+    tensorflow::Tensor& inputs = *tauBlockTensor_;
+    inputs.flat<float>().setZero();
 
-        auto leadChargedHadrCand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand().get());
+    const auto& get = [&](int var_index) -> float& { return inputs.matrix<float>()(0, var_index); };
 
-        get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
-        get(dnn::tau_pt) =  getValueLinear(tau.polarP4().pt(), 20.f, 1000.f, true);
-        get(dnn::tau_eta) = getValueLinear(tau.polarP4().eta(), -2.3f, 2.3f, false);
-        get(dnn::tau_phi) = getValueLinear(tau.polarP4().phi(), -pi, pi, false);
-        get(dnn::tau_mass) = getValueNorm(tau.polarP4().mass(), 0.6669f, 0.6553f);
-        get(dnn::tau_E_over_pt) = getValueLinear(tau.p4().energy() / tau.p4().pt(), 1.f, 5.2f, true);
-        get(dnn::tau_charge) = getValue(tau.charge());
-        get(dnn::tau_n_charged_prongs) = getValueLinear(tau.decayMode() / 5 + 1, 1, 3, true);
-        get(dnn::tau_n_neutral_prongs) = getValueLinear(tau.decayMode() % 5, 0, 2, true);
-        get(dnn::chargedIsoPtSum) = getValueNorm(tau.tauID("chargedIsoPtSum"), 47.78f, 123.5f);
-        get(dnn::chargedIsoPtSumdR03_over_dR05) = getValue(tau.tauID("chargedIsoPtSumdR03") / tau.tauID("chargedIsoPtSum"));
-        get(dnn::footprintCorrection) = getValueNorm(tau.tauID("footprintCorrectiondR03"), 9.029f, 26.42f);
-        get(dnn::neutralIsoPtSum) = getValueNorm(tau.tauID("neutralIsoPtSum"), 57.59f, 155.3f);
-        get(dnn::neutralIsoPtSumWeight_over_neutralIsoPtSum) =
-            getValue(tau.tauID("neutralIsoPtSumWeight") / tau.tauID("neutralIsoPtSum"));
-        get(dnn::neutralIsoPtSumWeightdR03_over_neutralIsoPtSum) =
-            getValue(tau.tauID("neutralIsoPtSumWeightdR03") / tau.tauID("neutralIsoPtSum"));
-        get(dnn::neutralIsoPtSumdR03_over_dR05) = getValue(tau.tauID("neutralIsoPtSumdR03") / tau.tauID("neutralIsoPtSum"));
-        get(dnn::photonPtSumOutsideSignalCone) = getValueNorm(tau.tauID("photonPtSumOutsideSignalConedR03"), 1.731f, 6.846f);
-        get(dnn::puCorrPtSum) = getValueNorm(tau.tauID("puCorrPtSum"), 22.38f, 16.34f);
-        get(dnn::tau_dxy_pca_x) = getValueNorm(tau.dxy_PCA().x(), -0.0241f, 0.0074f);
-        get(dnn::tau_dxy_pca_y) = getValueNorm(tau.dxy_PCA().y(),0.0675f, 0.0128f);
-        get(dnn::tau_dxy_pca_z) = getValueNorm(tau.dxy_PCA().z(), 0.7973f, 3.456f);
+    auto leadChargedHadrCand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand().get());
 
-        const bool tau_dxy_valid = std::isnormal(tau.dxy()) && tau.dxy() > - 10 && std::isnormal(tau.dxy_error())
-            && tau.dxy_error() > 0;
-        if(tau_dxy_valid){
-            get(dnn::tau_dxy_valid) = tau_dxy_valid;
-            get(dnn::tau_dxy) = getValueNorm(tau.dxy(), 0.0018f, 0.0085f);
-            get(dnn::tau_dxy_sig) = getValueNorm(std::abs(tau.dxy())/tau.dxy_error(), 2.26f, 4.191f);
-        }
-        const bool tau_ip3d_valid = std::isnormal(tau.ip3d()) && tau.ip3d() > - 10 && std::isnormal(tau.ip3d_error())
-            && tau.ip3d_error() > 0;
-        if(tau_ip3d_valid){
-            get(dnn::tau_ip3d_valid) = tau_ip3d_valid;
-            get(dnn::tau_ip3d) = getValueNorm(tau.ip3d(), 0.0026f, 0.0114f);
-            get(dnn::tau_ip3d_sig) = getValueNorm(std::abs(tau.ip3d()) / tau.ip3d_error(), 2.928f, 4.466f);
-        }
-        if(leadChargedHadrCand){
-            get(dnn::tau_dz) = getValueNorm(leadChargedHadrCand->dz(), 0.f, 0.0190f);
-            const bool tau_dz_sig_valid = leadChargedHadrCand->hasTrackDetails() && std::isnormal(leadChargedHadrCand->dz())
-                && std::isnormal(leadChargedHadrCand->dzError()) && leadChargedHadrCand->dzError() > 0;
-            get(dnn::tau_dz_sig_valid) = tau_dz_sig_valid;
-            const double dzError = leadChargedHadrCand->hasTrackDetails() ? leadChargedHadrCand->dzError() : default_value;
-            get(dnn::tau_dz_sig) = getValueNorm(std::abs(leadChargedHadrCand->dz()) / dzError, 4.717f, 11.78f);
-        }
-        get(dnn::tau_flightLength_x) = getValueNorm(tau.flightLength().x(), -0.0003f, 0.7362f);
-        get(dnn::tau_flightLength_y) = getValueNorm(tau.flightLength().y(), -0.0009f, 0.7354f);
-        get(dnn::tau_flightLength_z) = getValueNorm(tau.flightLength().z(), -0.0022f, 1.993f);
-        // get(dnn::tau_flightLength_sig) = getValueNorm(tau.flightLengthSig(), -4.78f, 9.573f);
-        get(dnn::tau_flightLength_sig) = 0.55756444; //This value is set due to a bug in the training
-        get(dnn::tau_pt_weighted_deta_strip) = getValueLinear(reco::tau::pt_weighted_deta_strip(tau, tau.decayMode()), 0, 1, true);
+    get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
+    get(dnn::tau_pt) = getValueLinear(tau.polarP4().pt(), 20.f, 1000.f, true);
+    get(dnn::tau_eta) = getValueLinear(tau.polarP4().eta(), -2.3f, 2.3f, false);
+    get(dnn::tau_phi) = getValueLinear(tau.polarP4().phi(), -pi, pi, false);
+    get(dnn::tau_mass) = getValueNorm(tau.polarP4().mass(), 0.6669f, 0.6553f);
+    get(dnn::tau_E_over_pt) = getValueLinear(tau.p4().energy() / tau.p4().pt(), 1.f, 5.2f, true);
+    get(dnn::tau_charge) = getValue(tau.charge());
+    get(dnn::tau_n_charged_prongs) = getValueLinear(tau.decayMode() / 5 + 1, 1, 3, true);
+    get(dnn::tau_n_neutral_prongs) = getValueLinear(tau.decayMode() % 5, 0, 2, true);
+    get(dnn::chargedIsoPtSum) = getValueNorm(tau.tauID("chargedIsoPtSum"), 47.78f, 123.5f);
+    get(dnn::chargedIsoPtSumdR03_over_dR05) = getValue(tau.tauID("chargedIsoPtSumdR03") / tau.tauID("chargedIsoPtSum"));
+    get(dnn::footprintCorrection) = getValueNorm(tau.tauID("footprintCorrectiondR03"), 9.029f, 26.42f);
+    get(dnn::neutralIsoPtSum) = getValueNorm(tau.tauID("neutralIsoPtSum"), 57.59f, 155.3f);
+    get(dnn::neutralIsoPtSumWeight_over_neutralIsoPtSum) =
+        getValue(tau.tauID("neutralIsoPtSumWeight") / tau.tauID("neutralIsoPtSum"));
+    get(dnn::neutralIsoPtSumWeightdR03_over_neutralIsoPtSum) =
+        getValue(tau.tauID("neutralIsoPtSumWeightdR03") / tau.tauID("neutralIsoPtSum"));
+    get(dnn::neutralIsoPtSumdR03_over_dR05) = getValue(tau.tauID("neutralIsoPtSumdR03") / tau.tauID("neutralIsoPtSum"));
+    get(dnn::photonPtSumOutsideSignalCone) =
+        getValueNorm(tau.tauID("photonPtSumOutsideSignalConedR03"), 1.731f, 6.846f);
+    get(dnn::puCorrPtSum) = getValueNorm(tau.tauID("puCorrPtSum"), 22.38f, 16.34f);
+    get(dnn::tau_dxy_pca_x) = getValueNorm(tau.dxy_PCA().x(), -0.0241f, 0.0074f);
+    get(dnn::tau_dxy_pca_y) = getValueNorm(tau.dxy_PCA().y(), 0.0675f, 0.0128f);
+    get(dnn::tau_dxy_pca_z) = getValueNorm(tau.dxy_PCA().z(), 0.7973f, 3.456f);
 
-        get(dnn::tau_pt_weighted_dphi_strip) = getValueLinear(reco::tau::pt_weighted_dphi_strip(tau, tau.decayMode()), 0, 1, true);
-        get(dnn::tau_pt_weighted_dr_signal) = getValueNorm(reco::tau::pt_weighted_dr_signal(tau, tau.decayMode()), 0.0052f, 0.01433f);
-        get(dnn::tau_pt_weighted_dr_iso) = getValueLinear(reco::tau::pt_weighted_dr_iso(tau,tau.decayMode()), 0, 1, true);
-        get(dnn::tau_leadingTrackNormChi2) = getValueNorm(tau.leadingTrackNormChi2(), 1.538f, 4.401f);
-        const auto eratio = reco::tau::eratio(tau);
-        const bool tau_e_ratio_valid = std::isnormal(eratio) && eratio > 0.f;
-        get(dnn::tau_e_ratio_valid) = tau_e_ratio_valid;
-        get(dnn::tau_e_ratio) = tau_e_ratio_valid ? getValueLinear(eratio, 0, 1, true) : 0.f;
-        const double gj_angle_diff = calculateGottfriedJacksonAngleDifference(tau);
-        const bool tau_gj_angle_diff_valid = (std::isnormal(gj_angle_diff) || gj_angle_diff == 0) && gj_angle_diff >= 0;
-        get(dnn::tau_gj_angle_diff_valid) = tau_gj_angle_diff_valid;
-        get(dnn::tau_gj_angle_diff) = tau_gj_angle_diff_valid ? getValueLinear(gj_angle_diff, 0, pi, true) : 0;
-        get(dnn::tau_n_photons) = getValueNorm(reco::tau::n_photons_total(tau), 2.95f, 3.927f);
-        get(dnn::tau_emFraction) = getValueLinear(tau.emFraction_MVA(), -1, 1, false);
-        get(dnn::tau_inside_ecal_crack) = getValue(isInEcalCrack(tau.p4().eta()));
-        get(dnn::leadChargedCand_etaAtEcalEntrance_minus_tau_eta) =
-            getValueNorm(tau.etaAtEcalEntranceLeadChargedCand() - tau.p4().eta(), 0.0042f, 0.0323f);
-
-        checkInputs(inputs, "tau_block",  dnn::NumberOfInputs);
+    const bool tau_dxy_valid =
+        std::isnormal(tau.dxy()) && tau.dxy() > -10 && std::isnormal(tau.dxy_error()) && tau.dxy_error() > 0;
+    if (tau_dxy_valid) {
+      get(dnn::tau_dxy_valid) = tau_dxy_valid;
+      get(dnn::tau_dxy) = getValueNorm(tau.dxy(), 0.0018f, 0.0085f);
+      get(dnn::tau_dxy_sig) = getValueNorm(std::abs(tau.dxy()) / tau.dxy_error(), 2.26f, 4.191f);
     }
-
-    void createEgammaBlockInputs(const TauType& tau, const reco::Vertex& pv, double rho,
-                                 const pat::ElectronCollection& electrons,
-                                 const pat::PackedCandidateCollection& pfCands,
-                                 const Cell& cell_map, bool is_inner)
-    {
-        namespace dnn = dnn_inputs_2017_v2::EgammaBlockInputs;
-
-        tensorflow::Tensor& inputs = *eGammaTensor_.at(is_inner);
-        inputs.flat<float>().setZero();
-
-        const auto& get = [&](int var_index) -> float& {
-            return inputs.tensor<float,4>()(0, 0, 0, var_index);
-        };
-
-        const bool valid_index_pf_ele = cell_map.count(CellObjectType::PfCand_electron);
-        const bool valid_index_pf_gamma = cell_map.count(CellObjectType::PfCand_gamma);
-        const bool valid_index_ele = cell_map.count(CellObjectType::Electron);
-
-        if(!cell_map.empty()){
-            get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
-            get(dnn::tau_pt) =  getValueLinear(tau.polarP4().pt(), 20.f, 1000.f, true);
-            get(dnn::tau_eta) = getValueLinear(tau.polarP4().eta(), -2.3f, 2.3f, false);
-            get(dnn::tau_inside_ecal_crack) = getValue(isInEcalCrack(tau.polarP4().eta()));
-        }
-        if(valid_index_pf_ele){
-            size_t index_pf_ele = cell_map.at(CellObjectType::PfCand_electron);
-
-            get(dnn::pfCand_ele_valid) = valid_index_pf_ele;
-            get(dnn::pfCand_ele_rel_pt) = getValueNorm(pfCands.at(index_pf_ele).polarP4().pt() / tau.polarP4().pt(),
-                is_inner ? 0.9792f : 0.304f, is_inner ? 0.5383f : 1.845f);
-            get(dnn::pfCand_ele_deta) = getValueLinear(pfCands.at(index_pf_ele).polarP4().eta() - tau.polarP4().eta(),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::pfCand_ele_dphi) = getValueLinear(dPhi(tau.polarP4(), pfCands.at(index_pf_ele).polarP4()),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::pfCand_ele_pvAssociationQuality) = getValueLinear<int>(pfCands.at(index_pf_ele).pvAssociationQuality(), 0, 7, true);
-            get(dnn::pfCand_ele_puppiWeight) = getValue(pfCands.at(index_pf_ele).puppiWeight());
-            get(dnn::pfCand_ele_charge) = getValue(pfCands.at(index_pf_ele).charge());
-            get(dnn::pfCand_ele_lostInnerHits) = getValue<int>(pfCands.at(index_pf_ele).lostInnerHits());
-            get(dnn::pfCand_ele_numberOfPixelHits) = getValueLinear(pfCands.at(index_pf_ele).numberOfPixelHits(), 0, 10, true);
-            get(dnn::pfCand_ele_vertex_dx) = getValueNorm(pfCands.at(index_pf_ele).vertex().x() - pv.position().x(), 0.f, 0.1221f);
-            get(dnn::pfCand_ele_vertex_dy) = getValueNorm(pfCands.at(index_pf_ele).vertex().y() - pv.position().y(), 0.f, 0.1226f);
-            get(dnn::pfCand_ele_vertex_dz) = getValueNorm(pfCands.at(index_pf_ele).vertex().z() - pv.position().z(), 0.001f, 1.024f);
-            get(dnn::pfCand_ele_vertex_dx_tauFL) = getValueNorm(pfCands.at(index_pf_ele).vertex().x() -
-                pv.position().x() - tau.flightLength().x(), 0.f, 0.3411f);
-            get(dnn::pfCand_ele_vertex_dy_tauFL) = getValueNorm(pfCands.at(index_pf_ele).vertex().y() -
-                pv.position().y() - tau.flightLength().y(), 0.0003f, 0.3385f);
-            get(dnn::pfCand_ele_vertex_dz_tauFL) = getValueNorm(pfCands.at(index_pf_ele).vertex().z() -
-                pv.position().z() - tau.flightLength().z(), 0.f, 1.307f);
-
-            const bool hasTrackDetails = pfCands.at(index_pf_ele).hasTrackDetails();
-            if(hasTrackDetails){
-                get(dnn::pfCand_ele_hasTrackDetails) = hasTrackDetails;
-                get(dnn::pfCand_ele_dxy) = getValueNorm(pfCands.at(index_pf_ele).dxy(), 0.f, 0.171f);
-                get(dnn::pfCand_ele_dxy_sig) = getValueNorm(std::abs(pfCands.at(index_pf_ele).dxy()) /
-                    pfCands.at(index_pf_ele).dxyError(), 1.634f, 6.45f);
-                get(dnn::pfCand_ele_dz) =  getValueNorm(pfCands.at(index_pf_ele).dz(), 0.001f, 1.02f);
-                get(dnn::pfCand_ele_dz_sig) =  getValueNorm(std::abs(pfCands.at(index_pf_ele).dz()) /
-                    pfCands.at(index_pf_ele).dzError(), 24.56f, 210.4f);
-                get(dnn::pfCand_ele_track_chi2_ndof) = getValueNorm(pfCands.at(index_pf_ele).pseudoTrack().chi2() /
-                    pfCands.at(index_pf_ele).pseudoTrack().ndof(), 2.272f, 8.439f);
-                get(dnn::pfCand_ele_track_ndof) = getValueNorm(pfCands.at(index_pf_ele).pseudoTrack().ndof(), 15.18f, 3.203f);
-            }
-        }
-        if(valid_index_pf_gamma){
-            size_t index_pf_gamma = cell_map.at(CellObjectType::PfCand_gamma);
-            get(dnn::pfCand_gamma_valid) = valid_index_pf_gamma;
-            get(dnn::pfCand_gamma_rel_pt) = getValueNorm(pfCands.at(index_pf_gamma).polarP4().pt() / tau.polarP4().pt(),
-                is_inner ? 0.6048f : 0.02576f, is_inner ? 1.669f : 0.3833f);
-            get(dnn::pfCand_gamma_deta) = getValueLinear(pfCands.at(index_pf_gamma).polarP4().eta() - tau.polarP4().eta(),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::pfCand_gamma_dphi) = getValueLinear(dPhi(tau.polarP4(), pfCands.at(index_pf_gamma).polarP4()),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::pfCand_gamma_pvAssociationQuality) =
-                getValueLinear<int>(pfCands.at(index_pf_gamma).pvAssociationQuality(), 0, 7, true);
-            get(dnn::pfCand_gamma_fromPV) = getValueLinear<int>(pfCands.at(index_pf_gamma).fromPV(), 0, 3, true);
-            get(dnn::pfCand_gamma_puppiWeight) = getValue(pfCands.at(index_pf_gamma).puppiWeight());
-            get(dnn::pfCand_gamma_puppiWeightNoLep) = getValue(pfCands.at(index_pf_gamma).puppiWeightNoLep());
-            get(dnn::pfCand_gamma_lostInnerHits) = getValue<int>(pfCands.at(index_pf_gamma).lostInnerHits());
-            get(dnn::pfCand_gamma_numberOfPixelHits) = getValueLinear(pfCands.at(index_pf_gamma).numberOfPixelHits(), 0, 7, true);
-            get(dnn::pfCand_gamma_vertex_dx) = getValueNorm(pfCands.at(index_pf_gamma).vertex().x() - pv.position().x(), 0.f, 0.0067f);
-            get(dnn::pfCand_gamma_vertex_dy) = getValueNorm(pfCands.at(index_pf_gamma).vertex().y() - pv.position().y(), 0.f, 0.0069f);
-            get(dnn::pfCand_gamma_vertex_dz) = getValueNorm(pfCands.at(index_pf_gamma).vertex().z() - pv.position().z(), 0.f, 0.0578f);
-            get(dnn::pfCand_gamma_vertex_dx_tauFL) = getValueNorm(pfCands.at(index_pf_gamma).vertex().x() -
-                pv.position().x() - tau.flightLength().x(), 0.001f, 0.9565f);
-            get(dnn::pfCand_gamma_vertex_dy_tauFL) = getValueNorm(pfCands.at(index_pf_gamma).vertex().y() -
-                pv.position().y() - tau.flightLength().y(), 0.0008f, 0.9592f);
-            get(dnn::pfCand_gamma_vertex_dz_tauFL) = getValueNorm(pfCands.at(index_pf_gamma).vertex().z() -
-                pv.position().z() - tau.flightLength().z(), 0.0038f, 2.154f);
-
-            const bool hasTrackDetails = pfCands.at(index_pf_gamma).hasTrackDetails();
-            if(hasTrackDetails){
-                get(dnn::pfCand_gamma_hasTrackDetails) = hasTrackDetails;
-                get(dnn::pfCand_gamma_dxy) = getValueNorm(pfCands.at(index_pf_gamma).dxy(), 0.0004f, 0.882f);
-                get(dnn::pfCand_gamma_dxy_sig) = getValueNorm(std::abs(pfCands.at(index_pf_gamma).dxy()) /
-                    pfCands.at(index_pf_gamma).dxyError(), 4.271f, 63.78f);
-                get(dnn::pfCand_gamma_dz) =  getValueNorm(pfCands.at(index_pf_gamma).dz(), 0.0071f, 5.285f);
-                get(dnn::pfCand_gamma_dz_sig) =  getValueNorm(std::abs(pfCands.at(index_pf_gamma).dz()) /
-                    pfCands.at(index_pf_gamma).dzError(), 162.1f, 622.4f);
-                get(dnn::pfCand_gamma_track_chi2_ndof) = pfCands.at(index_pf_gamma).pseudoTrack().ndof() > 0 ?
-                    getValueNorm(pfCands.at(index_pf_gamma).pseudoTrack().chi2() /
-                                 pfCands.at(index_pf_gamma).pseudoTrack().ndof(), 4.268f, 15.47f) : 0;
-                get(dnn::pfCand_gamma_track_ndof) = pfCands.at(index_pf_gamma).pseudoTrack().ndof() > 0 ?
-                    getValueNorm(pfCands.at(index_pf_gamma).pseudoTrack().ndof(), 12.25f, 4.774f) : 0;
-            }
-        }
-        if(valid_index_ele){
-            size_t index_ele = cell_map.at(CellObjectType::Electron);
-
-            get(dnn::ele_valid) = valid_index_ele;
-            get(dnn::ele_rel_pt) = getValueNorm(electrons.at(index_ele).polarP4().pt() / tau.polarP4().pt(),
-                is_inner ? 1.067f : 0.5111f, is_inner ? 1.521f : 2.765f);
-            get(dnn::ele_deta) = getValueLinear(electrons.at(index_ele).polarP4().eta() - tau.polarP4().eta(),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::ele_dphi) = getValueLinear(dPhi(tau.polarP4(), electrons.at(index_ele).polarP4()),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-
-            float cc_ele_energy, cc_gamma_energy;
-            int cc_n_gamma;
-            const bool cc_valid = calculateElectronClusterVarsV2(electrons.at(index_ele), cc_ele_energy, cc_gamma_energy, cc_n_gamma);
-            if(cc_valid){
-                get(dnn::ele_cc_valid) = cc_valid;
-                get(dnn::ele_cc_ele_rel_energy) = getValueNorm(cc_ele_energy / electrons.at(index_ele).polarP4().pt(), 1.729f, 1.644f);
-                get(dnn::ele_cc_gamma_rel_energy) = getValueNorm(cc_gamma_energy / cc_ele_energy, 0.1439f, 0.3284f);
-                get(dnn::ele_cc_n_gamma) = getValueNorm(cc_n_gamma, 1.794f, 2.079f);
-            }
-            get(dnn::ele_rel_trackMomentumAtVtx) = getValueNorm(electrons.at(index_ele).trackMomentumAtVtx().R() /
-                electrons.at(index_ele).polarP4().pt(), 1.531f, 1.424f);
-            get(dnn::ele_rel_trackMomentumAtCalo) =  getValueNorm(electrons.at(index_ele).trackMomentumAtCalo().R() /
-                electrons.at(index_ele).polarP4().pt(), 1.531f, 1.424f);
-            get(dnn::ele_rel_trackMomentumOut) = getValueNorm(electrons.at(index_ele).trackMomentumOut().R() /
-                electrons.at(index_ele).polarP4().pt(), 0.7735f, 0.935f);
-            get(dnn::ele_rel_trackMomentumAtEleClus) = getValueNorm(electrons.at(index_ele).trackMomentumAtEleClus().R() /
-                electrons.at(index_ele).polarP4().pt(), 0.7735f, 0.935f);
-            get(dnn::ele_rel_trackMomentumAtVtxWithConstraint) =
-                getValueNorm(electrons.at(index_ele).trackMomentumAtVtxWithConstraint().R() /
-                electrons.at(index_ele).polarP4().pt(), 1.625f, 1.581f);
-            get(dnn::ele_rel_ecalEnergy) = getValueNorm(electrons.at(index_ele).ecalEnergy() /
-                electrons.at(index_ele).polarP4().pt(), 1.993f, 1.308f);
-            get(dnn::ele_ecalEnergy_sig) =  getValueNorm(electrons.at(index_ele).ecalEnergy() /
-                electrons.at(index_ele).ecalEnergyError(), 70.25f, 58.16f);
-            get(dnn::ele_eSuperClusterOverP) =  getValueNorm(electrons.at(index_ele).eSuperClusterOverP(), 2.432f, 15.13f);
-            get(dnn::ele_eSeedClusterOverP) = getValueNorm(electrons.at(index_ele).eSeedClusterOverP(), 2.034f, 13.96f);
-            get(dnn::ele_eSeedClusterOverPout) = getValueNorm(electrons.at(index_ele).eSeedClusterOverPout(), 6.64f, 36.8f);
-            get(dnn::ele_eEleClusterOverPout) = getValueNorm(electrons.at(index_ele).eEleClusterOverPout(), 4.183f, 20.63f);
-            get(dnn::ele_deltaEtaSuperClusterTrackAtVtx) =
-                getValueNorm(electrons.at(index_ele).deltaEtaSuperClusterTrackAtVtx(),0.f, 0.0363f);
-            get(dnn::ele_deltaEtaSeedClusterTrackAtCalo) =
-                getValueNorm(electrons.at(index_ele).deltaEtaSeedClusterTrackAtCalo(), -0.0001f, 0.0512f);
-            get(dnn::ele_deltaEtaEleClusterTrackAtCalo) =
-                getValueNorm(electrons.at(index_ele).deltaEtaEleClusterTrackAtCalo(), -0.0001f, 0.0541f);
-            get(dnn::ele_deltaPhiEleClusterTrackAtCalo) =
-                getValueNorm(electrons.at(index_ele).deltaPhiEleClusterTrackAtCalo(), 0.0002f, 0.0553f);
-            get(dnn::ele_deltaPhiSuperClusterTrackAtVtx) =
-                getValueNorm(electrons.at(index_ele).deltaPhiSuperClusterTrackAtVtx(), 0.0001f, 0.0523f);
-            get(dnn::ele_deltaPhiSeedClusterTrackAtCalo) =
-                getValueNorm(electrons.at(index_ele).deltaPhiSeedClusterTrackAtCalo(), 0.0004f, 0.0777f);
-            get(dnn::ele_mvaInput_earlyBrem) = getValue(electrons.at(index_ele).mvaInput().earlyBrem);
-            get(dnn::ele_mvaInput_lateBrem) = getValue(electrons.at(index_ele).mvaInput().lateBrem);
-            get(dnn::ele_mvaInput_sigmaEtaEta) = getValueNorm(electrons.at(index_ele).mvaInput().sigmaEtaEta,0.0008f, 0.0052f);
-            get(dnn::ele_mvaInput_hadEnergy) = getValueNorm(electrons.at(index_ele).mvaInput().hadEnergy, 14.04f, 69.48f);
-            get(dnn::ele_mvaInput_deltaEta) = getValueNorm(electrons.at(index_ele).mvaInput().deltaEta, 0.0099f, 0.0851f);
-
-            const auto& gsfTrack = electrons.at(index_ele).gsfTrack();
-            if(gsfTrack.isNonnull()){
-                get(dnn::ele_gsfTrack_normalizedChi2) = getValueNorm(gsfTrack->normalizedChi2(), 3.049f, 10.39f);
-                get(dnn::ele_gsfTrack_numberOfValidHits) = getValueNorm(gsfTrack->numberOfValidHits(), 16.52f, 2.806f);
-                get(dnn::ele_rel_gsfTrack_pt) = getValueNorm(gsfTrack->pt() / electrons.at(index_ele).polarP4().pt(), 1.355f, 16.81f);
-                get(dnn::ele_gsfTrack_pt_sig) = getValueNorm(gsfTrack->pt() / gsfTrack->ptError(), 5.046f, 3.119f);
-            }
-            const auto& closestCtfTrack = electrons.at(index_ele).closestCtfTrackRef();
-            const bool has_closestCtfTrack = closestCtfTrack.isNonnull();
-            if(has_closestCtfTrack){
-                get(dnn::ele_has_closestCtfTrack) = has_closestCtfTrack;
-                get(dnn::ele_closestCtfTrack_normalizedChi2) = getValueNorm(closestCtfTrack->normalizedChi2(), 2.411f, 6.98f);
-                get(dnn::ele_closestCtfTrack_numberOfValidHits) = getValueNorm(closestCtfTrack->numberOfValidHits(), 15.16f, 5.26f);
-            }
-        }
-        checkInputs(inputs, is_inner ? "egamma_inner_block" : "egamma_outer_block", dnn::NumberOfInputs);
+    const bool tau_ip3d_valid =
+        std::isnormal(tau.ip3d()) && tau.ip3d() > -10 && std::isnormal(tau.ip3d_error()) && tau.ip3d_error() > 0;
+    if (tau_ip3d_valid) {
+      get(dnn::tau_ip3d_valid) = tau_ip3d_valid;
+      get(dnn::tau_ip3d) = getValueNorm(tau.ip3d(), 0.0026f, 0.0114f);
+      get(dnn::tau_ip3d_sig) = getValueNorm(std::abs(tau.ip3d()) / tau.ip3d_error(), 2.928f, 4.466f);
     }
+    if (leadChargedHadrCand) {
+      get(dnn::tau_dz) = getValueNorm(leadChargedHadrCand->dz(), 0.f, 0.0190f);
+      const bool tau_dz_sig_valid = leadChargedHadrCand->hasTrackDetails() &&
+                                    std::isnormal(leadChargedHadrCand->dz()) &&
+                                    std::isnormal(leadChargedHadrCand->dzError()) && leadChargedHadrCand->dzError() > 0;
+      get(dnn::tau_dz_sig_valid) = tau_dz_sig_valid;
+      const double dzError = leadChargedHadrCand->hasTrackDetails() ? leadChargedHadrCand->dzError() : default_value;
+      get(dnn::tau_dz_sig) = getValueNorm(std::abs(leadChargedHadrCand->dz()) / dzError, 4.717f, 11.78f);
+    }
+    get(dnn::tau_flightLength_x) = getValueNorm(tau.flightLength().x(), -0.0003f, 0.7362f);
+    get(dnn::tau_flightLength_y) = getValueNorm(tau.flightLength().y(), -0.0009f, 0.7354f);
+    get(dnn::tau_flightLength_z) = getValueNorm(tau.flightLength().z(), -0.0022f, 1.993f);
+    // get(dnn::tau_flightLength_sig) = getValueNorm(tau.flightLengthSig(), -4.78f, 9.573f);
+    get(dnn::tau_flightLength_sig) = 0.55756444;  //This value is set due to a bug in the training
+    get(dnn::tau_pt_weighted_deta_strip) =
+        getValueLinear(reco::tau::pt_weighted_deta_strip(tau, tau.decayMode()), 0, 1, true);
 
-    void createMuonBlockInputs(const TauType& tau, const reco::Vertex& pv, double rho,
-                               const pat::MuonCollection& muons,
+    get(dnn::tau_pt_weighted_dphi_strip) =
+        getValueLinear(reco::tau::pt_weighted_dphi_strip(tau, tau.decayMode()), 0, 1, true);
+    get(dnn::tau_pt_weighted_dr_signal) =
+        getValueNorm(reco::tau::pt_weighted_dr_signal(tau, tau.decayMode()), 0.0052f, 0.01433f);
+    get(dnn::tau_pt_weighted_dr_iso) = getValueLinear(reco::tau::pt_weighted_dr_iso(tau, tau.decayMode()), 0, 1, true);
+    get(dnn::tau_leadingTrackNormChi2) = getValueNorm(tau.leadingTrackNormChi2(), 1.538f, 4.401f);
+    const auto eratio = reco::tau::eratio(tau);
+    const bool tau_e_ratio_valid = std::isnormal(eratio) && eratio > 0.f;
+    get(dnn::tau_e_ratio_valid) = tau_e_ratio_valid;
+    get(dnn::tau_e_ratio) = tau_e_ratio_valid ? getValueLinear(eratio, 0, 1, true) : 0.f;
+    const double gj_angle_diff = calculateGottfriedJacksonAngleDifference(tau);
+    const bool tau_gj_angle_diff_valid = (std::isnormal(gj_angle_diff) || gj_angle_diff == 0) && gj_angle_diff >= 0;
+    get(dnn::tau_gj_angle_diff_valid) = tau_gj_angle_diff_valid;
+    get(dnn::tau_gj_angle_diff) = tau_gj_angle_diff_valid ? getValueLinear(gj_angle_diff, 0, pi, true) : 0;
+    get(dnn::tau_n_photons) = getValueNorm(reco::tau::n_photons_total(tau), 2.95f, 3.927f);
+    get(dnn::tau_emFraction) = getValueLinear(tau.emFraction_MVA(), -1, 1, false);
+    get(dnn::tau_inside_ecal_crack) = getValue(isInEcalCrack(tau.p4().eta()));
+    get(dnn::leadChargedCand_etaAtEcalEntrance_minus_tau_eta) =
+        getValueNorm(tau.etaAtEcalEntranceLeadChargedCand() - tau.p4().eta(), 0.0042f, 0.0323f);
+
+    checkInputs(inputs, "tau_block", dnn::NumberOfInputs);
+  }
+
+  void createEgammaBlockInputs(const TauType& tau,
+                               const reco::Vertex& pv,
+                               double rho,
+                               const pat::ElectronCollection& electrons,
                                const pat::PackedCandidateCollection& pfCands,
-                               const Cell& cell_map, bool is_inner)
-    {
-        namespace dnn = dnn_inputs_2017_v2::MuonBlockInputs;
+                               const Cell& cell_map,
+                               bool is_inner) {
+    namespace dnn = dnn_inputs_2017_v2::EgammaBlockInputs;
 
-        tensorflow::Tensor& inputs = *muonTensor_.at(is_inner);
-        inputs.flat<float>().setZero();
+    tensorflow::Tensor& inputs = *eGammaTensor_.at(is_inner);
+    inputs.flat<float>().setZero();
 
-        const auto& get = [&](int var_index) -> float& {
-            return inputs.tensor<float,4>()(0, 0, 0, var_index);
-        };
+    const auto& get = [&](int var_index) -> float& { return inputs.tensor<float, 4>()(0, 0, 0, var_index); };
 
-        const bool valid_index_pf_muon = cell_map.count(CellObjectType::PfCand_muon);
-        const bool valid_index_muon = cell_map.count(CellObjectType::Muon);
+    const bool valid_index_pf_ele = cell_map.count(CellObjectType::PfCand_electron);
+    const bool valid_index_pf_gamma = cell_map.count(CellObjectType::PfCand_gamma);
+    const bool valid_index_ele = cell_map.count(CellObjectType::Electron);
 
-        if(!cell_map.empty()){
-            get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
-            get(dnn::tau_pt) =  getValueLinear(tau.polarP4().pt(), 20.f, 1000.f, true);
-            get(dnn::tau_eta) = getValueLinear(tau.polarP4().eta(), -2.3f, 2.3f, false);
-            get(dnn::tau_inside_ecal_crack) = getValue(isInEcalCrack(tau.polarP4().eta()));
+    if (!cell_map.empty()) {
+      get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
+      get(dnn::tau_pt) = getValueLinear(tau.polarP4().pt(), 20.f, 1000.f, true);
+      get(dnn::tau_eta) = getValueLinear(tau.polarP4().eta(), -2.3f, 2.3f, false);
+      get(dnn::tau_inside_ecal_crack) = getValue(isInEcalCrack(tau.polarP4().eta()));
+    }
+    if (valid_index_pf_ele) {
+      size_t index_pf_ele = cell_map.at(CellObjectType::PfCand_electron);
+
+      get(dnn::pfCand_ele_valid) = valid_index_pf_ele;
+      get(dnn::pfCand_ele_rel_pt) = getValueNorm(pfCands.at(index_pf_ele).polarP4().pt() / tau.polarP4().pt(),
+                                                 is_inner ? 0.9792f : 0.304f,
+                                                 is_inner ? 0.5383f : 1.845f);
+      get(dnn::pfCand_ele_deta) = getValueLinear(pfCands.at(index_pf_ele).polarP4().eta() - tau.polarP4().eta(),
+                                                 is_inner ? -0.1f : -0.5f,
+                                                 is_inner ? 0.1f : 0.5f,
+                                                 false);
+      get(dnn::pfCand_ele_dphi) = getValueLinear(dPhi(tau.polarP4(), pfCands.at(index_pf_ele).polarP4()),
+                                                 is_inner ? -0.1f : -0.5f,
+                                                 is_inner ? 0.1f : 0.5f,
+                                                 false);
+      get(dnn::pfCand_ele_pvAssociationQuality) =
+          getValueLinear<int>(pfCands.at(index_pf_ele).pvAssociationQuality(), 0, 7, true);
+      get(dnn::pfCand_ele_puppiWeight) = getValue(pfCands.at(index_pf_ele).puppiWeight());
+      get(dnn::pfCand_ele_charge) = getValue(pfCands.at(index_pf_ele).charge());
+      get(dnn::pfCand_ele_lostInnerHits) = getValue<int>(pfCands.at(index_pf_ele).lostInnerHits());
+      get(dnn::pfCand_ele_numberOfPixelHits) =
+          getValueLinear(pfCands.at(index_pf_ele).numberOfPixelHits(), 0, 10, true);
+      get(dnn::pfCand_ele_vertex_dx) =
+          getValueNorm(pfCands.at(index_pf_ele).vertex().x() - pv.position().x(), 0.f, 0.1221f);
+      get(dnn::pfCand_ele_vertex_dy) =
+          getValueNorm(pfCands.at(index_pf_ele).vertex().y() - pv.position().y(), 0.f, 0.1226f);
+      get(dnn::pfCand_ele_vertex_dz) =
+          getValueNorm(pfCands.at(index_pf_ele).vertex().z() - pv.position().z(), 0.001f, 1.024f);
+      get(dnn::pfCand_ele_vertex_dx_tauFL) = getValueNorm(
+          pfCands.at(index_pf_ele).vertex().x() - pv.position().x() - tau.flightLength().x(), 0.f, 0.3411f);
+      get(dnn::pfCand_ele_vertex_dy_tauFL) = getValueNorm(
+          pfCands.at(index_pf_ele).vertex().y() - pv.position().y() - tau.flightLength().y(), 0.0003f, 0.3385f);
+      get(dnn::pfCand_ele_vertex_dz_tauFL) =
+          getValueNorm(pfCands.at(index_pf_ele).vertex().z() - pv.position().z() - tau.flightLength().z(), 0.f, 1.307f);
+
+      const bool hasTrackDetails = pfCands.at(index_pf_ele).hasTrackDetails();
+      if (hasTrackDetails) {
+        get(dnn::pfCand_ele_hasTrackDetails) = hasTrackDetails;
+        get(dnn::pfCand_ele_dxy) = getValueNorm(pfCands.at(index_pf_ele).dxy(), 0.f, 0.171f);
+        get(dnn::pfCand_ele_dxy_sig) =
+            getValueNorm(std::abs(pfCands.at(index_pf_ele).dxy()) / pfCands.at(index_pf_ele).dxyError(), 1.634f, 6.45f);
+        get(dnn::pfCand_ele_dz) = getValueNorm(pfCands.at(index_pf_ele).dz(), 0.001f, 1.02f);
+        get(dnn::pfCand_ele_dz_sig) =
+            getValueNorm(std::abs(pfCands.at(index_pf_ele).dz()) / pfCands.at(index_pf_ele).dzError(), 24.56f, 210.4f);
+        get(dnn::pfCand_ele_track_chi2_ndof) =
+            getValueNorm(pfCands.at(index_pf_ele).pseudoTrack().chi2() / pfCands.at(index_pf_ele).pseudoTrack().ndof(),
+                         2.272f,
+                         8.439f);
+        get(dnn::pfCand_ele_track_ndof) = getValueNorm(pfCands.at(index_pf_ele).pseudoTrack().ndof(), 15.18f, 3.203f);
+      }
+    }
+    if (valid_index_pf_gamma) {
+      size_t index_pf_gamma = cell_map.at(CellObjectType::PfCand_gamma);
+      get(dnn::pfCand_gamma_valid) = valid_index_pf_gamma;
+      get(dnn::pfCand_gamma_rel_pt) = getValueNorm(pfCands.at(index_pf_gamma).polarP4().pt() / tau.polarP4().pt(),
+                                                   is_inner ? 0.6048f : 0.02576f,
+                                                   is_inner ? 1.669f : 0.3833f);
+      get(dnn::pfCand_gamma_deta) = getValueLinear(pfCands.at(index_pf_gamma).polarP4().eta() - tau.polarP4().eta(),
+                                                   is_inner ? -0.1f : -0.5f,
+                                                   is_inner ? 0.1f : 0.5f,
+                                                   false);
+      get(dnn::pfCand_gamma_dphi) = getValueLinear(dPhi(tau.polarP4(), pfCands.at(index_pf_gamma).polarP4()),
+                                                   is_inner ? -0.1f : -0.5f,
+                                                   is_inner ? 0.1f : 0.5f,
+                                                   false);
+      get(dnn::pfCand_gamma_pvAssociationQuality) =
+          getValueLinear<int>(pfCands.at(index_pf_gamma).pvAssociationQuality(), 0, 7, true);
+      get(dnn::pfCand_gamma_fromPV) = getValueLinear<int>(pfCands.at(index_pf_gamma).fromPV(), 0, 3, true);
+      get(dnn::pfCand_gamma_puppiWeight) = getValue(pfCands.at(index_pf_gamma).puppiWeight());
+      get(dnn::pfCand_gamma_puppiWeightNoLep) = getValue(pfCands.at(index_pf_gamma).puppiWeightNoLep());
+      get(dnn::pfCand_gamma_lostInnerHits) = getValue<int>(pfCands.at(index_pf_gamma).lostInnerHits());
+      get(dnn::pfCand_gamma_numberOfPixelHits) =
+          getValueLinear(pfCands.at(index_pf_gamma).numberOfPixelHits(), 0, 7, true);
+      get(dnn::pfCand_gamma_vertex_dx) =
+          getValueNorm(pfCands.at(index_pf_gamma).vertex().x() - pv.position().x(), 0.f, 0.0067f);
+      get(dnn::pfCand_gamma_vertex_dy) =
+          getValueNorm(pfCands.at(index_pf_gamma).vertex().y() - pv.position().y(), 0.f, 0.0069f);
+      get(dnn::pfCand_gamma_vertex_dz) =
+          getValueNorm(pfCands.at(index_pf_gamma).vertex().z() - pv.position().z(), 0.f, 0.0578f);
+      get(dnn::pfCand_gamma_vertex_dx_tauFL) = getValueNorm(
+          pfCands.at(index_pf_gamma).vertex().x() - pv.position().x() - tau.flightLength().x(), 0.001f, 0.9565f);
+      get(dnn::pfCand_gamma_vertex_dy_tauFL) = getValueNorm(
+          pfCands.at(index_pf_gamma).vertex().y() - pv.position().y() - tau.flightLength().y(), 0.0008f, 0.9592f);
+      get(dnn::pfCand_gamma_vertex_dz_tauFL) = getValueNorm(
+          pfCands.at(index_pf_gamma).vertex().z() - pv.position().z() - tau.flightLength().z(), 0.0038f, 2.154f);
+
+      const bool hasTrackDetails = pfCands.at(index_pf_gamma).hasTrackDetails();
+      if (hasTrackDetails) {
+        get(dnn::pfCand_gamma_hasTrackDetails) = hasTrackDetails;
+        get(dnn::pfCand_gamma_dxy) = getValueNorm(pfCands.at(index_pf_gamma).dxy(), 0.0004f, 0.882f);
+        get(dnn::pfCand_gamma_dxy_sig) = getValueNorm(
+            std::abs(pfCands.at(index_pf_gamma).dxy()) / pfCands.at(index_pf_gamma).dxyError(), 4.271f, 63.78f);
+        get(dnn::pfCand_gamma_dz) = getValueNorm(pfCands.at(index_pf_gamma).dz(), 0.0071f, 5.285f);
+        get(dnn::pfCand_gamma_dz_sig) = getValueNorm(
+            std::abs(pfCands.at(index_pf_gamma).dz()) / pfCands.at(index_pf_gamma).dzError(), 162.1f, 622.4f);
+        get(dnn::pfCand_gamma_track_chi2_ndof) = pfCands.at(index_pf_gamma).pseudoTrack().ndof() > 0
+                                                     ? getValueNorm(pfCands.at(index_pf_gamma).pseudoTrack().chi2() /
+                                                                        pfCands.at(index_pf_gamma).pseudoTrack().ndof(),
+                                                                    4.268f,
+                                                                    15.47f)
+                                                     : 0;
+        get(dnn::pfCand_gamma_track_ndof) =
+            pfCands.at(index_pf_gamma).pseudoTrack().ndof() > 0
+                ? getValueNorm(pfCands.at(index_pf_gamma).pseudoTrack().ndof(), 12.25f, 4.774f)
+                : 0;
+      }
+    }
+    if (valid_index_ele) {
+      size_t index_ele = cell_map.at(CellObjectType::Electron);
+
+      get(dnn::ele_valid) = valid_index_ele;
+      get(dnn::ele_rel_pt) = getValueNorm(electrons.at(index_ele).polarP4().pt() / tau.polarP4().pt(),
+                                          is_inner ? 1.067f : 0.5111f,
+                                          is_inner ? 1.521f : 2.765f);
+      get(dnn::ele_deta) = getValueLinear(electrons.at(index_ele).polarP4().eta() - tau.polarP4().eta(),
+                                          is_inner ? -0.1f : -0.5f,
+                                          is_inner ? 0.1f : 0.5f,
+                                          false);
+      get(dnn::ele_dphi) = getValueLinear(dPhi(tau.polarP4(), electrons.at(index_ele).polarP4()),
+                                          is_inner ? -0.1f : -0.5f,
+                                          is_inner ? 0.1f : 0.5f,
+                                          false);
+
+      float cc_ele_energy, cc_gamma_energy;
+      int cc_n_gamma;
+      const bool cc_valid =
+          calculateElectronClusterVarsV2(electrons.at(index_ele), cc_ele_energy, cc_gamma_energy, cc_n_gamma);
+      if (cc_valid) {
+        get(dnn::ele_cc_valid) = cc_valid;
+        get(dnn::ele_cc_ele_rel_energy) =
+            getValueNorm(cc_ele_energy / electrons.at(index_ele).polarP4().pt(), 1.729f, 1.644f);
+        get(dnn::ele_cc_gamma_rel_energy) = getValueNorm(cc_gamma_energy / cc_ele_energy, 0.1439f, 0.3284f);
+        get(dnn::ele_cc_n_gamma) = getValueNorm(cc_n_gamma, 1.794f, 2.079f);
+      }
+      get(dnn::ele_rel_trackMomentumAtVtx) = getValueNorm(
+          electrons.at(index_ele).trackMomentumAtVtx().R() / electrons.at(index_ele).polarP4().pt(), 1.531f, 1.424f);
+      get(dnn::ele_rel_trackMomentumAtCalo) = getValueNorm(
+          electrons.at(index_ele).trackMomentumAtCalo().R() / electrons.at(index_ele).polarP4().pt(), 1.531f, 1.424f);
+      get(dnn::ele_rel_trackMomentumOut) = getValueNorm(
+          electrons.at(index_ele).trackMomentumOut().R() / electrons.at(index_ele).polarP4().pt(), 0.7735f, 0.935f);
+      get(dnn::ele_rel_trackMomentumAtEleClus) =
+          getValueNorm(electrons.at(index_ele).trackMomentumAtEleClus().R() / electrons.at(index_ele).polarP4().pt(),
+                       0.7735f,
+                       0.935f);
+      get(dnn::ele_rel_trackMomentumAtVtxWithConstraint) = getValueNorm(
+          electrons.at(index_ele).trackMomentumAtVtxWithConstraint().R() / electrons.at(index_ele).polarP4().pt(),
+          1.625f,
+          1.581f);
+      get(dnn::ele_rel_ecalEnergy) =
+          getValueNorm(electrons.at(index_ele).ecalEnergy() / electrons.at(index_ele).polarP4().pt(), 1.993f, 1.308f);
+      get(dnn::ele_ecalEnergy_sig) = getValueNorm(
+          electrons.at(index_ele).ecalEnergy() / electrons.at(index_ele).ecalEnergyError(), 70.25f, 58.16f);
+      get(dnn::ele_eSuperClusterOverP) = getValueNorm(electrons.at(index_ele).eSuperClusterOverP(), 2.432f, 15.13f);
+      get(dnn::ele_eSeedClusterOverP) = getValueNorm(electrons.at(index_ele).eSeedClusterOverP(), 2.034f, 13.96f);
+      get(dnn::ele_eSeedClusterOverPout) = getValueNorm(electrons.at(index_ele).eSeedClusterOverPout(), 6.64f, 36.8f);
+      get(dnn::ele_eEleClusterOverPout) = getValueNorm(electrons.at(index_ele).eEleClusterOverPout(), 4.183f, 20.63f);
+      get(dnn::ele_deltaEtaSuperClusterTrackAtVtx) =
+          getValueNorm(electrons.at(index_ele).deltaEtaSuperClusterTrackAtVtx(), 0.f, 0.0363f);
+      get(dnn::ele_deltaEtaSeedClusterTrackAtCalo) =
+          getValueNorm(electrons.at(index_ele).deltaEtaSeedClusterTrackAtCalo(), -0.0001f, 0.0512f);
+      get(dnn::ele_deltaEtaEleClusterTrackAtCalo) =
+          getValueNorm(electrons.at(index_ele).deltaEtaEleClusterTrackAtCalo(), -0.0001f, 0.0541f);
+      get(dnn::ele_deltaPhiEleClusterTrackAtCalo) =
+          getValueNorm(electrons.at(index_ele).deltaPhiEleClusterTrackAtCalo(), 0.0002f, 0.0553f);
+      get(dnn::ele_deltaPhiSuperClusterTrackAtVtx) =
+          getValueNorm(electrons.at(index_ele).deltaPhiSuperClusterTrackAtVtx(), 0.0001f, 0.0523f);
+      get(dnn::ele_deltaPhiSeedClusterTrackAtCalo) =
+          getValueNorm(electrons.at(index_ele).deltaPhiSeedClusterTrackAtCalo(), 0.0004f, 0.0777f);
+      get(dnn::ele_mvaInput_earlyBrem) = getValue(electrons.at(index_ele).mvaInput().earlyBrem);
+      get(dnn::ele_mvaInput_lateBrem) = getValue(electrons.at(index_ele).mvaInput().lateBrem);
+      get(dnn::ele_mvaInput_sigmaEtaEta) =
+          getValueNorm(electrons.at(index_ele).mvaInput().sigmaEtaEta, 0.0008f, 0.0052f);
+      get(dnn::ele_mvaInput_hadEnergy) = getValueNorm(electrons.at(index_ele).mvaInput().hadEnergy, 14.04f, 69.48f);
+      get(dnn::ele_mvaInput_deltaEta) = getValueNorm(electrons.at(index_ele).mvaInput().deltaEta, 0.0099f, 0.0851f);
+
+      const auto& gsfTrack = electrons.at(index_ele).gsfTrack();
+      if (gsfTrack.isNonnull()) {
+        get(dnn::ele_gsfTrack_normalizedChi2) = getValueNorm(gsfTrack->normalizedChi2(), 3.049f, 10.39f);
+        get(dnn::ele_gsfTrack_numberOfValidHits) = getValueNorm(gsfTrack->numberOfValidHits(), 16.52f, 2.806f);
+        get(dnn::ele_rel_gsfTrack_pt) =
+            getValueNorm(gsfTrack->pt() / electrons.at(index_ele).polarP4().pt(), 1.355f, 16.81f);
+        get(dnn::ele_gsfTrack_pt_sig) = getValueNorm(gsfTrack->pt() / gsfTrack->ptError(), 5.046f, 3.119f);
+      }
+      const auto& closestCtfTrack = electrons.at(index_ele).closestCtfTrackRef();
+      const bool has_closestCtfTrack = closestCtfTrack.isNonnull();
+      if (has_closestCtfTrack) {
+        get(dnn::ele_has_closestCtfTrack) = has_closestCtfTrack;
+        get(dnn::ele_closestCtfTrack_normalizedChi2) = getValueNorm(closestCtfTrack->normalizedChi2(), 2.411f, 6.98f);
+        get(dnn::ele_closestCtfTrack_numberOfValidHits) =
+            getValueNorm(closestCtfTrack->numberOfValidHits(), 15.16f, 5.26f);
+      }
+    }
+    checkInputs(inputs, is_inner ? "egamma_inner_block" : "egamma_outer_block", dnn::NumberOfInputs);
+  }
+
+  void createMuonBlockInputs(const TauType& tau,
+                             const reco::Vertex& pv,
+                             double rho,
+                             const pat::MuonCollection& muons,
+                             const pat::PackedCandidateCollection& pfCands,
+                             const Cell& cell_map,
+                             bool is_inner) {
+    namespace dnn = dnn_inputs_2017_v2::MuonBlockInputs;
+
+    tensorflow::Tensor& inputs = *muonTensor_.at(is_inner);
+    inputs.flat<float>().setZero();
+
+    const auto& get = [&](int var_index) -> float& { return inputs.tensor<float, 4>()(0, 0, 0, var_index); };
+
+    const bool valid_index_pf_muon = cell_map.count(CellObjectType::PfCand_muon);
+    const bool valid_index_muon = cell_map.count(CellObjectType::Muon);
+
+    if (!cell_map.empty()) {
+      get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
+      get(dnn::tau_pt) = getValueLinear(tau.polarP4().pt(), 20.f, 1000.f, true);
+      get(dnn::tau_eta) = getValueLinear(tau.polarP4().eta(), -2.3f, 2.3f, false);
+      get(dnn::tau_inside_ecal_crack) = getValue(isInEcalCrack(tau.polarP4().eta()));
+    }
+    if (valid_index_pf_muon) {
+      size_t index_pf_muon = cell_map.at(CellObjectType::PfCand_muon);
+
+      get(dnn::pfCand_muon_valid) = valid_index_pf_muon;
+      get(dnn::pfCand_muon_rel_pt) = getValueNorm(pfCands.at(index_pf_muon).polarP4().pt() / tau.polarP4().pt(),
+                                                  is_inner ? 0.9509f : 0.0861f,
+                                                  is_inner ? 0.4294f : 0.4065f);
+      get(dnn::pfCand_muon_deta) = getValueLinear(pfCands.at(index_pf_muon).polarP4().eta() - tau.polarP4().eta(),
+                                                  is_inner ? -0.1f : -0.5f,
+                                                  is_inner ? 0.1f : 0.5f,
+                                                  false);
+      get(dnn::pfCand_muon_dphi) = getValueLinear(dPhi(tau.polarP4(), pfCands.at(index_pf_muon).polarP4()),
+                                                  is_inner ? -0.1f : -0.5f,
+                                                  is_inner ? 0.1f : 0.5f,
+                                                  false);
+      get(dnn::pfCand_muon_pvAssociationQuality) =
+          getValueLinear<int>(pfCands.at(index_pf_muon).pvAssociationQuality(), 0, 7, true);
+      get(dnn::pfCand_muon_fromPV) = getValueLinear<int>(pfCands.at(index_pf_muon).fromPV(), 0, 3, true);
+      get(dnn::pfCand_muon_puppiWeight) = getValue(pfCands.at(index_pf_muon).puppiWeight());
+      get(dnn::pfCand_muon_charge) = getValue(pfCands.at(index_pf_muon).charge());
+      get(dnn::pfCand_muon_lostInnerHits) = getValue<int>(pfCands.at(index_pf_muon).lostInnerHits());
+      get(dnn::pfCand_muon_numberOfPixelHits) =
+          getValueLinear(pfCands.at(index_pf_muon).numberOfPixelHits(), 0, 11, true);
+      get(dnn::pfCand_muon_vertex_dx) =
+          getValueNorm(pfCands.at(index_pf_muon).vertex().x() - pv.position().x(), -0.0007f, 0.6869f);
+      get(dnn::pfCand_muon_vertex_dy) =
+          getValueNorm(pfCands.at(index_pf_muon).vertex().y() - pv.position().y(), 0.0001f, 0.6784f);
+      get(dnn::pfCand_muon_vertex_dz) =
+          getValueNorm(pfCands.at(index_pf_muon).vertex().z() - pv.position().z(), -0.0117f, 4.097f);
+      get(dnn::pfCand_muon_vertex_dx_tauFL) = getValueNorm(
+          pfCands.at(index_pf_muon).vertex().x() - pv.position().x() - tau.flightLength().x(), -0.0001f, 0.8642f);
+      get(dnn::pfCand_muon_vertex_dy_tauFL) = getValueNorm(
+          pfCands.at(index_pf_muon).vertex().y() - pv.position().y() - tau.flightLength().y(), 0.0004f, 0.8561f);
+      get(dnn::pfCand_muon_vertex_dz_tauFL) = getValueNorm(
+          pfCands.at(index_pf_muon).vertex().z() - pv.position().z() - tau.flightLength().z(), -0.0118f, 4.405f);
+
+      const bool hasTrackDetails = pfCands.at(index_pf_muon).hasTrackDetails();
+      if (hasTrackDetails) {
+        get(dnn::pfCand_muon_hasTrackDetails) = hasTrackDetails;
+        get(dnn::pfCand_muon_dxy) = getValueNorm(pfCands.at(index_pf_muon).dxy(), -0.0045f, 0.9655f);
+        get(dnn::pfCand_muon_dxy_sig) = getValueNorm(
+            std::abs(pfCands.at(index_pf_muon).dxy()) / pfCands.at(index_pf_muon).dxyError(), 4.575f, 42.36f);
+        get(dnn::pfCand_muon_dz) = getValueNorm(pfCands.at(index_pf_muon).dz(), -0.0117f, 4.097f);
+        get(dnn::pfCand_muon_dz_sig) = getValueNorm(
+            std::abs(pfCands.at(index_pf_muon).dz()) / pfCands.at(index_pf_muon).dzError(), 80.37f, 343.3f);
+        get(dnn::pfCand_muon_track_chi2_ndof) = getValueNorm(
+            pfCands.at(index_pf_muon).pseudoTrack().chi2() / pfCands.at(index_pf_muon).pseudoTrack().ndof(),
+            0.69f,
+            1.711f);
+        get(dnn::pfCand_muon_track_ndof) = getValueNorm(pfCands.at(index_pf_muon).pseudoTrack().ndof(), 17.5f, 5.11f);
+      }
+    }
+    if (valid_index_muon) {
+      size_t index_muon = cell_map.at(CellObjectType::Muon);
+
+      get(dnn::muon_valid) = valid_index_muon;
+      get(dnn::muon_rel_pt) = getValueNorm(muons.at(index_muon).polarP4().pt() / tau.polarP4().pt(),
+                                           is_inner ? 0.7966f : 0.2678f,
+                                           is_inner ? 3.402f : 3.592f);
+      get(dnn::muon_deta) = getValueLinear(muons.at(index_muon).polarP4().eta() - tau.polarP4().eta(),
+                                           is_inner ? -0.1f : -0.5f,
+                                           is_inner ? 0.1f : 0.5f,
+                                           false);
+      get(dnn::muon_dphi) = getValueLinear(
+          dPhi(tau.polarP4(), muons.at(index_muon).polarP4()), is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
+      get(dnn::muon_dxy) = getValueNorm(muons.at(index_muon).dB(pat::Muon::PV2D), 0.0019f, 1.039f);
+      get(dnn::muon_dxy_sig) =
+          getValueNorm(std::abs(muons.at(index_muon).dB(pat::Muon::PV2D)) / muons.at(index_muon).edB(pat::Muon::PV2D),
+                       8.98f,
+                       71.17f);
+
+      const bool normalizedChi2_valid =
+          muons.at(index_muon).globalTrack().isNonnull() && muons.at(index_muon).normChi2() >= 0;
+      if (normalizedChi2_valid) {
+        get(dnn::muon_normalizedChi2_valid) = normalizedChi2_valid;
+        get(dnn::muon_normalizedChi2) = getValueNorm(muons.at(index_muon).normChi2(), 21.52f, 265.8f);
+        if (muons.at(index_muon).innerTrack().isNonnull())
+          get(dnn::muon_numberOfValidHits) = getValueNorm(muons.at(index_muon).numberOfValidHits(), 21.84f, 10.59f);
+      }
+      get(dnn::muon_segmentCompatibility) = getValue(muons.at(index_muon).segmentCompatibility());
+      get(dnn::muon_caloCompatibility) = getValue(muons.at(index_muon).caloCompatibility());
+
+      const bool pfEcalEnergy_valid = muons.at(index_muon).pfEcalEnergy() >= 0;
+      if (pfEcalEnergy_valid) {
+        get(dnn::muon_pfEcalEnergy_valid) = pfEcalEnergy_valid;
+        get(dnn::muon_rel_pfEcalEnergy) =
+            getValueNorm(muons.at(index_muon).pfEcalEnergy() / muons.at(index_muon).polarP4().pt(), 0.2273f, 0.4865f);
+      }
+
+      MuonHitMatchV2 hit_match(muons.at(index_muon));
+      static const std::map<int, std::pair<int, int>> muonMatchHitVars = {
+          {MuonSubdetId::DT, {dnn::muon_n_matches_DT_1, dnn::muon_n_hits_DT_1}},
+          {MuonSubdetId::CSC, {dnn::muon_n_matches_CSC_1, dnn::muon_n_hits_CSC_1}},
+          {MuonSubdetId::RPC, {dnn::muon_n_matches_RPC_1, dnn::muon_n_hits_RPC_1}}};
+
+      static const std::map<int, std::vector<float>> muonMatchVarLimits = {
+          {MuonSubdetId::DT, {2, 2, 2, 2}}, {MuonSubdetId::CSC, {6, 2, 2, 2}}, {MuonSubdetId::RPC, {7, 6, 4, 4}}};
+
+      static const std::map<int, std::vector<float>> muonHitVarLimits = {{MuonSubdetId::DT, {12, 12, 12, 8}},
+                                                                         {MuonSubdetId::CSC, {24, 12, 12, 12}},
+                                                                         {MuonSubdetId::RPC, {4, 4, 2, 2}}};
+
+      for (int subdet : hit_match.MuonHitMatchV2::consideredSubdets()) {
+        const auto& matchHitVar = muonMatchHitVars.at(subdet);
+        const auto& matchLimits = muonMatchVarLimits.at(subdet);
+        const auto& hitLimits = muonHitVarLimits.at(subdet);
+        for (int station = MuonHitMatchV2::first_station_id; station <= MuonHitMatchV2::last_station_id; ++station) {
+          const unsigned n_matches = hit_match.nMatches(subdet, station);
+          const unsigned n_hits = hit_match.nHits(subdet, station);
+          get(matchHitVar.first + station - 1) = getValueLinear(n_matches, 0, matchLimits.at(station - 1), true);
+          get(matchHitVar.second + station - 1) = getValueLinear(n_hits, 0, hitLimits.at(station - 1), true);
         }
-        if(valid_index_pf_muon){
-            size_t index_pf_muon = cell_map.at(CellObjectType::PfCand_muon);
+      }
+    }
+    checkInputs(inputs, is_inner ? "muon_inner_block" : "muon_outer_block", dnn::NumberOfInputs);
+  }
 
-            get(dnn::pfCand_muon_valid) = valid_index_pf_muon;
-            get(dnn::pfCand_muon_rel_pt) = getValueNorm(pfCands.at(index_pf_muon).polarP4().pt() / tau.polarP4().pt(),
-                is_inner ?  0.9509f : 0.0861f, is_inner ? 0.4294f : 0.4065f);
-            get(dnn::pfCand_muon_deta) = getValueLinear(pfCands.at(index_pf_muon).polarP4().eta() - tau.polarP4().eta(),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::pfCand_muon_dphi) = getValueLinear(dPhi(tau.polarP4(), pfCands.at(index_pf_muon).polarP4()),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::pfCand_muon_pvAssociationQuality) = getValueLinear<int>(pfCands.at(index_pf_muon).pvAssociationQuality(), 0, 7, true);
-            get(dnn::pfCand_muon_fromPV) = getValueLinear<int>(pfCands.at(index_pf_muon).fromPV(), 0, 3, true);
-            get(dnn::pfCand_muon_puppiWeight) = getValue(pfCands.at(index_pf_muon).puppiWeight());
-            get(dnn::pfCand_muon_charge) = getValue(pfCands.at(index_pf_muon).charge());
-            get(dnn::pfCand_muon_lostInnerHits) = getValue<int>(pfCands.at(index_pf_muon).lostInnerHits());
-            get(dnn::pfCand_muon_numberOfPixelHits) = getValueLinear(pfCands.at(index_pf_muon).numberOfPixelHits(), 0, 11, true);
-            get(dnn::pfCand_muon_vertex_dx) = getValueNorm(pfCands.at(index_pf_muon).vertex().x() - pv.position().x(), -0.0007f, 0.6869f);
-            get(dnn::pfCand_muon_vertex_dy) = getValueNorm(pfCands.at(index_pf_muon).vertex().y() - pv.position().y(), 0.0001f, 0.6784f);
-            get(dnn::pfCand_muon_vertex_dz) = getValueNorm(pfCands.at(index_pf_muon).vertex().z() - pv.position().z(), -0.0117f, 4.097f);
-            get(dnn::pfCand_muon_vertex_dx_tauFL) = getValueNorm(pfCands.at(index_pf_muon).vertex().x() -
-                pv.position().x() - tau.flightLength().x(), -0.0001f, 0.8642f);
-            get(dnn::pfCand_muon_vertex_dy_tauFL) = getValueNorm(pfCands.at(index_pf_muon).vertex().y() -
-                pv.position().y() - tau.flightLength().y(), 0.0004f, 0.8561f);
-            get(dnn::pfCand_muon_vertex_dz_tauFL) = getValueNorm(pfCands.at(index_pf_muon).vertex().z() -
-                pv.position().z() - tau.flightLength().z(), -0.0118f, 4.405f);
+  void createHadronsBlockInputs(const TauType& tau,
+                                const reco::Vertex& pv,
+                                double rho,
+                                const pat::PackedCandidateCollection& pfCands,
+                                const Cell& cell_map,
+                                bool is_inner) {
+    namespace dnn = dnn_inputs_2017_v2::HadronBlockInputs;
 
-            const bool hasTrackDetails = pfCands.at(index_pf_muon).hasTrackDetails();
-            if(hasTrackDetails){
-                get(dnn::pfCand_muon_hasTrackDetails) = hasTrackDetails;
-                get(dnn::pfCand_muon_dxy) = getValueNorm(pfCands.at(index_pf_muon).dxy(), -0.0045f, 0.9655f);
-                get(dnn::pfCand_muon_dxy_sig) = getValueNorm(std::abs(pfCands.at(index_pf_muon).dxy()) /
-                    pfCands.at(index_pf_muon).dxyError(), 4.575f, 42.36f);
-                get(dnn::pfCand_muon_dz) =  getValueNorm(pfCands.at(index_pf_muon).dz(), -0.0117f, 4.097f);
-                get(dnn::pfCand_muon_dz_sig) =  getValueNorm(std::abs(pfCands.at(index_pf_muon).dz()) /
-                    pfCands.at(index_pf_muon).dzError(), 80.37f, 343.3f);
-                get(dnn::pfCand_muon_track_chi2_ndof) =  getValueNorm(pfCands.at(index_pf_muon).pseudoTrack().chi2() /
-                    pfCands.at(index_pf_muon).pseudoTrack().ndof(), 0.69f, 1.711f);
-                get(dnn::pfCand_muon_track_ndof) =  getValueNorm(pfCands.at(index_pf_muon).pseudoTrack().ndof(), 17.5f, 5.11f);
-            }
-        }
-        if(valid_index_muon){
-            size_t index_muon = cell_map.at(CellObjectType::Muon);
+    tensorflow::Tensor& inputs = *hadronsTensor_.at(is_inner);
+    inputs.flat<float>().setZero();
 
-            get(dnn::muon_valid) = valid_index_muon;
-            get(dnn::muon_rel_pt) = getValueNorm(muons.at(index_muon).polarP4().pt() / tau.polarP4().pt(),
-                is_inner ?  0.7966f : 0.2678f, is_inner ? 3.402f : 3.592f);
-            get(dnn::muon_deta) = getValueLinear(muons.at(index_muon).polarP4().eta() - tau.polarP4().eta(),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::muon_dphi) = getValueLinear(dPhi(tau.polarP4(), muons.at(index_muon).polarP4()),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::muon_dxy) = getValueNorm(muons.at(index_muon).dB(pat::Muon::PV2D), 0.0019f, 1.039f);
-            get(dnn::muon_dxy_sig) = getValueNorm(std::abs(muons.at(index_muon).dB(pat::Muon::PV2D)) /
-                muons.at(index_muon).edB(pat::Muon::PV2D), 8.98f, 71.17f);
+    const auto& get = [&](int var_index) -> float& { return inputs.tensor<float, 4>()(0, 0, 0, var_index); };
 
-            const bool normalizedChi2_valid = muons.at(index_muon).globalTrack().isNonnull() && muons.at(index_muon).normChi2() >= 0;
-            if(normalizedChi2_valid){
-                get(dnn::muon_normalizedChi2_valid) = normalizedChi2_valid;
-                get(dnn::muon_normalizedChi2) = getValueNorm(muons.at(index_muon).normChi2(), 21.52f, 265.8f);
-                if(muons.at(index_muon).innerTrack().isNonnull())
-                    get(dnn::muon_numberOfValidHits) = getValueNorm(muons.at(index_muon).numberOfValidHits(), 21.84f, 10.59f);
-            }
-            get(dnn::muon_segmentCompatibility) = getValue(muons.at(index_muon).segmentCompatibility());
-            get(dnn::muon_caloCompatibility) = getValue(muons.at(index_muon).caloCompatibility());
+    const bool valid_chH = cell_map.count(CellObjectType::PfCand_chargedHadron);
+    const bool valid_nH = cell_map.count(CellObjectType::PfCand_neutralHadron);
 
-            const bool pfEcalEnergy_valid = muons.at(index_muon).pfEcalEnergy() >= 0;
-            if(pfEcalEnergy_valid){
-                get(dnn::muon_pfEcalEnergy_valid) = pfEcalEnergy_valid;
-                get(dnn::muon_rel_pfEcalEnergy) = getValueNorm(muons.at(index_muon).pfEcalEnergy() /
-                    muons.at(index_muon).polarP4().pt(), 0.2273f, 0.4865f);
-            }
+    if (!cell_map.empty()) {
+      get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
+      get(dnn::tau_pt) = getValueLinear(tau.polarP4().pt(), 20.f, 1000.f, true);
+      get(dnn::tau_eta) = getValueLinear(tau.polarP4().eta(), -2.3f, 2.3f, false);
+      get(dnn::tau_inside_ecal_crack) = getValue(isInEcalCrack(tau.polarP4().eta()));
+    }
+    if (valid_chH) {
+      size_t index_chH = cell_map.at(CellObjectType::PfCand_chargedHadron);
 
-            MuonHitMatchV2 hit_match(muons.at(index_muon));
-            static const std::map<int, std::pair<int, int>> muonMatchHitVars = {
-                { MuonSubdetId::DT, { dnn::muon_n_matches_DT_1, dnn::muon_n_hits_DT_1 } },
-                { MuonSubdetId::CSC, { dnn::muon_n_matches_CSC_1, dnn::muon_n_hits_CSC_1 } },
-                { MuonSubdetId::RPC, { dnn::muon_n_matches_RPC_1, dnn::muon_n_hits_RPC_1 } }
-            };
+      get(dnn::pfCand_chHad_valid) = valid_chH;
+      get(dnn::pfCand_chHad_rel_pt) = getValueNorm(pfCands.at(index_chH).polarP4().pt() / tau.polarP4().pt(),
+                                                   is_inner ? 0.2564f : 0.0194f,
+                                                   is_inner ? 0.8607f : 0.1865f);
+      get(dnn::pfCand_chHad_deta) = getValueLinear(pfCands.at(index_chH).polarP4().eta() - tau.polarP4().eta(),
+                                                   is_inner ? -0.1f : -0.5f,
+                                                   is_inner ? 0.1f : 0.5f,
+                                                   false);
+      get(dnn::pfCand_chHad_dphi) = getValueLinear(dPhi(tau.polarP4(), pfCands.at(index_chH).polarP4()),
+                                                   is_inner ? -0.1f : -0.5f,
+                                                   is_inner ? 0.1f : 0.5f,
+                                                   false);
+      get(dnn::pfCand_chHad_leadChargedHadrCand) = getValue(
+          &pfCands.at(index_chH) == dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand().get()));
+      get(dnn::pfCand_chHad_pvAssociationQuality) =
+          getValueLinear<int>(pfCands.at(index_chH).pvAssociationQuality(), 0, 7, true);
+      get(dnn::pfCand_chHad_fromPV) = getValueLinear<int>(pfCands.at(index_chH).fromPV(), 0, 3, true);
+      get(dnn::pfCand_chHad_puppiWeight) = getValue(pfCands.at(index_chH).puppiWeight());
+      get(dnn::pfCand_chHad_puppiWeightNoLep) = getValue(pfCands.at(index_chH).puppiWeightNoLep());
+      get(dnn::pfCand_chHad_charge) = getValue(pfCands.at(index_chH).charge());
+      get(dnn::pfCand_chHad_lostInnerHits) = getValue<int>(pfCands.at(index_chH).lostInnerHits());
+      get(dnn::pfCand_chHad_numberOfPixelHits) = getValueLinear(pfCands.at(index_chH).numberOfPixelHits(), 0, 12, true);
+      get(dnn::pfCand_chHad_vertex_dx) =
+          getValueNorm(pfCands.at(index_chH).vertex().x() - pv.position().x(), 0.0005f, 1.735f);
+      get(dnn::pfCand_chHad_vertex_dy) =
+          getValueNorm(pfCands.at(index_chH).vertex().y() - pv.position().y(), -0.0008f, 1.752f);
+      get(dnn::pfCand_chHad_vertex_dz) =
+          getValueNorm(pfCands.at(index_chH).vertex().z() - pv.position().z(), -0.0201f, 8.333f);
+      get(dnn::pfCand_chHad_vertex_dx_tauFL) = getValueNorm(
+          pfCands.at(index_chH).vertex().x() - pv.position().x() - tau.flightLength().x(), -0.0014f, 1.93f);
+      get(dnn::pfCand_chHad_vertex_dy_tauFL) = getValueNorm(
+          pfCands.at(index_chH).vertex().y() - pv.position().y() - tau.flightLength().y(), 0.0022f, 1.948f);
+      get(dnn::pfCand_chHad_vertex_dz_tauFL) = getValueNorm(
+          pfCands.at(index_chH).vertex().z() - pv.position().z() - tau.flightLength().z(), -0.0138f, 8.622f);
 
-            static const std::map<int, std::vector<float>> muonMatchVarLimits = {
-                { MuonSubdetId::DT, { 2, 2, 2, 2 } },
-                { MuonSubdetId::CSC, { 6, 2, 2, 2 } },
-                { MuonSubdetId::RPC, { 7, 6, 4, 4 } }
-            };
+      const bool hasTrackDetails = pfCands.at(index_chH).hasTrackDetails();
+      if (hasTrackDetails) {
+        get(dnn::pfCand_chHad_hasTrackDetails) = hasTrackDetails;
+        get(dnn::pfCand_chHad_dxy) = getValueNorm(pfCands.at(index_chH).dxy(), -0.012f, 2.386f);
+        get(dnn::pfCand_chHad_dxy_sig) =
+            getValueNorm(std::abs(pfCands.at(index_chH).dxy()) / pfCands.at(index_chH).dxyError(), 6.417f, 36.28f);
+        get(dnn::pfCand_chHad_dz) = getValueNorm(pfCands.at(index_chH).dz(), -0.0246f, 7.618f);
+        get(dnn::pfCand_chHad_dz_sig) =
+            getValueNorm(std::abs(pfCands.at(index_chH).dz()) / pfCands.at(index_chH).dzError(), 301.3f, 491.1f);
+        get(dnn::pfCand_chHad_track_chi2_ndof) =
+            pfCands.at(index_chH).pseudoTrack().ndof() > 0
+                ? getValueNorm(pfCands.at(index_chH).pseudoTrack().chi2() / pfCands.at(index_chH).pseudoTrack().ndof(),
+                               0.7876f,
+                               3.694f)
+                : 0;
+        get(dnn::pfCand_chHad_track_ndof) =
+            pfCands.at(index_chH).pseudoTrack().ndof() > 0
+                ? getValueNorm(pfCands.at(index_chH).pseudoTrack().ndof(), 13.92f, 6.581f)
+                : 0;
+      }
+      get(dnn::pfCand_chHad_hcalFraction) = getValue(pfCands.at(index_chH).hcalFraction());
+      get(dnn::pfCand_chHad_rawCaloFraction) = getValueLinear(pfCands.at(index_chH).rawCaloFraction(), 0.f, 2.6f, true);
+    }
+    if (valid_nH) {
+      size_t index_nH = cell_map.at(CellObjectType::PfCand_neutralHadron);
 
-            static const std::map<int, std::vector<float>> muonHitVarLimits = {
-                { MuonSubdetId::DT, { 12, 12, 12, 8 } },
-                { MuonSubdetId::CSC, { 24, 12, 12, 12 } },
-                { MuonSubdetId::RPC, { 4, 4, 2, 2 } }
-            };
+      get(dnn::pfCand_nHad_valid) = valid_nH;
+      get(dnn::pfCand_nHad_rel_pt) = getValueNorm(pfCands.at(index_nH).polarP4().pt() / tau.polarP4().pt(),
+                                                  is_inner ? 0.3163f : 0.0502f,
+                                                  is_inner ? 0.2769f : 0.4266f);
+      get(dnn::pfCand_nHad_deta) = getValueLinear(pfCands.at(index_nH).polarP4().eta() - tau.polarP4().eta(),
+                                                  is_inner ? -0.1f : -0.5f,
+                                                  is_inner ? 0.1f : 0.5f,
+                                                  false);
+      get(dnn::pfCand_nHad_dphi) = getValueLinear(
+          dPhi(tau.polarP4(), pfCands.at(index_nH).polarP4()), is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
+      get(dnn::pfCand_nHad_puppiWeight) = getValue(pfCands.at(index_nH).puppiWeight());
+      get(dnn::pfCand_nHad_puppiWeightNoLep) = getValue(pfCands.at(index_nH).puppiWeightNoLep());
+      get(dnn::pfCand_nHad_hcalFraction) = getValue(pfCands.at(index_nH).hcalFraction());
+    }
+    checkInputs(inputs, is_inner ? "hadron_inner_block" : "hadron_outer_block", dnn::NumberOfInputs);
+  }
 
-            for(int subdet : hit_match.MuonHitMatchV2::consideredSubdets()) {
-                const auto& matchHitVar = muonMatchHitVars.at(subdet);
-                const auto& matchLimits = muonMatchVarLimits.at(subdet);
-                const auto& hitLimits = muonHitVarLimits.at(subdet);
-                for(int station = MuonHitMatchV2::first_station_id; station <= MuonHitMatchV2::last_station_id; ++station) {
-                    const unsigned n_matches = hit_match.nMatches(subdet, station);
-                    const unsigned n_hits = hit_match.nHits(subdet, station);
-                    get(matchHitVar.first + station - 1) = getValueLinear(n_matches, 0, matchLimits.at(station - 1), true);
-                    get(matchHitVar.second + station - 1) = getValueLinear(n_hits, 0, hitLimits.at(station - 1), true);
-                }
-            }
-        }
-        checkInputs(inputs, is_inner ? "muon_inner_block" : "muon_outer_block", dnn::NumberOfInputs);
+  template <typename dnn>
+  tensorflow::Tensor createInputsV1(const TauType& tau,
+                                    const ElectronCollection& electrons,
+                                    const MuonCollection& muons) const {
+    static constexpr bool check_all_set = false;
+    static constexpr float default_value_for_set_check = -42;
+
+    tensorflow::Tensor inputs(tensorflow::DT_FLOAT, {1, dnn_inputs_2017v1::NumberOfInputs});
+    const auto& get = [&](int var_index) -> float& { return inputs.matrix<float>()(0, var_index); };
+    auto leadChargedHadrCand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand().get());
+
+    if (check_all_set) {
+      for (int var_index = 0; var_index < dnn::NumberOfInputs; ++var_index) {
+        get(var_index) = default_value_for_set_check;
+      }
     }
 
-    void createHadronsBlockInputs(const TauType& tau, const reco::Vertex& pv, double rho,
-                                  const pat::PackedCandidateCollection& pfCands,
-                                  const Cell& cell_map, bool is_inner)
-    {
-        namespace dnn = dnn_inputs_2017_v2::HadronBlockInputs;
+    get(dnn::pt) = tau.p4().pt();
+    get(dnn::eta) = tau.p4().eta();
+    get(dnn::mass) = tau.p4().mass();
+    get(dnn::decayMode) = tau.decayMode();
+    get(dnn::chargedIsoPtSum) = tau.tauID("chargedIsoPtSum");
+    get(dnn::neutralIsoPtSum) = tau.tauID("neutralIsoPtSum");
+    get(dnn::neutralIsoPtSumWeight) = tau.tauID("neutralIsoPtSumWeight");
+    get(dnn::photonPtSumOutsideSignalCone) = tau.tauID("photonPtSumOutsideSignalCone");
+    get(dnn::puCorrPtSum) = tau.tauID("puCorrPtSum");
+    get(dnn::dxy) = tau.dxy();
+    get(dnn::dxy_sig) = tau.dxy_Sig();
+    get(dnn::dz) = leadChargedHadrCand ? leadChargedHadrCand->dz() : default_value;
+    get(dnn::ip3d) = tau.ip3d();
+    get(dnn::ip3d_sig) = tau.ip3d_Sig();
+    get(dnn::hasSecondaryVertex) = tau.hasSecondaryVertex();
+    get(dnn::flightLength_r) = tau.flightLength().R();
+    get(dnn::flightLength_dEta) = dEta(tau.flightLength(), tau.p4());
+    get(dnn::flightLength_dPhi) = dPhi(tau.flightLength(), tau.p4());
+    get(dnn::flightLength_sig) = tau.flightLengthSig();
+    get(dnn::leadChargedHadrCand_pt) = leadChargedHadrCand ? leadChargedHadrCand->p4().Pt() : default_value;
+    get(dnn::leadChargedHadrCand_dEta) =
+        leadChargedHadrCand ? dEta(leadChargedHadrCand->p4(), tau.p4()) : default_value;
+    get(dnn::leadChargedHadrCand_dPhi) =
+        leadChargedHadrCand ? dPhi(leadChargedHadrCand->p4(), tau.p4()) : default_value;
+    get(dnn::leadChargedHadrCand_mass) = leadChargedHadrCand ? leadChargedHadrCand->p4().mass() : default_value;
+    get(dnn::pt_weighted_deta_strip) = reco::tau::pt_weighted_deta_strip(tau, tau.decayMode());
+    get(dnn::pt_weighted_dphi_strip) = reco::tau::pt_weighted_dphi_strip(tau, tau.decayMode());
+    get(dnn::pt_weighted_dr_signal) = reco::tau::pt_weighted_dr_signal(tau, tau.decayMode());
+    get(dnn::pt_weighted_dr_iso) = reco::tau::pt_weighted_dr_iso(tau, tau.decayMode());
+    get(dnn::leadingTrackNormChi2) = tau.leadingTrackNormChi2();
+    get(dnn::e_ratio) = reco::tau::eratio(tau);
+    get(dnn::gj_angle_diff) = calculateGottfriedJacksonAngleDifference(tau);
+    get(dnn::n_photons) = reco::tau::n_photons_total(tau);
+    get(dnn::emFraction) = tau.emFraction_MVA();
+    get(dnn::has_gsf_track) = leadChargedHadrCand && std::abs(leadChargedHadrCand->pdgId()) == 11;
+    get(dnn::inside_ecal_crack) = isInEcalCrack(tau.p4().Eta());
+    auto gsf_ele = findMatchedElectron(tau, electrons, 0.3);
+    get(dnn::gsf_ele_matched) = gsf_ele != nullptr;
+    get(dnn::gsf_ele_pt) = gsf_ele != nullptr ? gsf_ele->p4().Pt() : default_value;
+    get(dnn::gsf_ele_dEta) = gsf_ele != nullptr ? dEta(gsf_ele->p4(), tau.p4()) : default_value;
+    get(dnn::gsf_ele_dPhi) = gsf_ele != nullptr ? dPhi(gsf_ele->p4(), tau.p4()) : default_value;
+    get(dnn::gsf_ele_mass) = gsf_ele != nullptr ? gsf_ele->p4().mass() : default_value;
+    calculateElectronClusterVars(gsf_ele, get(dnn::gsf_ele_Ee), get(dnn::gsf_ele_Egamma));
+    get(dnn::gsf_ele_Pin) = gsf_ele != nullptr ? gsf_ele->trackMomentumAtVtx().R() : default_value;
+    get(dnn::gsf_ele_Pout) = gsf_ele != nullptr ? gsf_ele->trackMomentumOut().R() : default_value;
+    get(dnn::gsf_ele_EtotOverPin) = get(dnn::gsf_ele_Pin) > 0
+                                        ? (get(dnn::gsf_ele_Ee) + get(dnn::gsf_ele_Egamma)) / get(dnn::gsf_ele_Pin)
+                                        : default_value;
+    get(dnn::gsf_ele_Eecal) = gsf_ele != nullptr ? gsf_ele->ecalEnergy() : default_value;
+    get(dnn::gsf_ele_dEta_SeedClusterTrackAtCalo) =
+        gsf_ele != nullptr ? gsf_ele->deltaEtaSeedClusterTrackAtCalo() : default_value;
+    get(dnn::gsf_ele_dPhi_SeedClusterTrackAtCalo) =
+        gsf_ele != nullptr ? gsf_ele->deltaPhiSeedClusterTrackAtCalo() : default_value;
+    get(dnn::gsf_ele_mvaIn_sigmaEtaEta) = gsf_ele != nullptr ? gsf_ele->mvaInput().sigmaEtaEta : default_value;
+    get(dnn::gsf_ele_mvaIn_hadEnergy) = gsf_ele != nullptr ? gsf_ele->mvaInput().hadEnergy : default_value;
+    get(dnn::gsf_ele_mvaIn_deltaEta) = gsf_ele != nullptr ? gsf_ele->mvaInput().deltaEta : default_value;
 
-        tensorflow::Tensor& inputs = *hadronsTensor_.at(is_inner);
-        inputs.flat<float>().setZero();
-
-
-        const auto& get = [&](int var_index) -> float& {
-            return inputs.tensor<float,4>()(0, 0, 0, var_index);
-        };
-
-        const bool valid_chH = cell_map.count(CellObjectType::PfCand_chargedHadron);
-        const bool valid_nH = cell_map.count(CellObjectType::PfCand_neutralHadron);
-
-        if(!cell_map.empty()){
-            get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
-            get(dnn::tau_pt) =  getValueLinear(tau.polarP4().pt(), 20.f, 1000.f, true);
-            get(dnn::tau_eta) = getValueLinear(tau.polarP4().eta(), -2.3f, 2.3f, false);
-            get(dnn::tau_inside_ecal_crack) = getValue(isInEcalCrack(tau.polarP4().eta()));
-        }
-        if(valid_chH){
-            size_t index_chH = cell_map.at(CellObjectType::PfCand_chargedHadron);
-
-            get(dnn::pfCand_chHad_valid) = valid_chH;
-            get(dnn::pfCand_chHad_rel_pt) = getValueNorm(pfCands.at(index_chH).polarP4().pt() / tau.polarP4().pt(),
-                is_inner ? 0.2564f : 0.0194f, is_inner ? 0.8607f : 0.1865f);
-            get(dnn::pfCand_chHad_deta) = getValueLinear(pfCands.at(index_chH).polarP4().eta() - tau.polarP4().eta(),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::pfCand_chHad_dphi) = getValueLinear(dPhi(tau.polarP4(),pfCands.at(index_chH).polarP4()),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::pfCand_chHad_leadChargedHadrCand) = getValue(&pfCands.at(index_chH) ==
-                dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand().get()));
-            get(dnn::pfCand_chHad_pvAssociationQuality) =
-                getValueLinear<int>(pfCands.at(index_chH).pvAssociationQuality(), 0, 7, true);
-            get(dnn::pfCand_chHad_fromPV) = getValueLinear<int>(pfCands.at(index_chH).fromPV(), 0, 3, true);
-            get(dnn::pfCand_chHad_puppiWeight) = getValue(pfCands.at(index_chH).puppiWeight());
-            get(dnn::pfCand_chHad_puppiWeightNoLep) = getValue(pfCands.at(index_chH).puppiWeightNoLep());
-            get(dnn::pfCand_chHad_charge) =  getValue(pfCands.at(index_chH).charge());
-            get(dnn::pfCand_chHad_lostInnerHits) = getValue<int>(pfCands.at(index_chH).lostInnerHits());
-            get(dnn::pfCand_chHad_numberOfPixelHits) = getValueLinear(pfCands.at(index_chH).numberOfPixelHits(), 0, 12, true);
-            get(dnn::pfCand_chHad_vertex_dx) = getValueNorm(pfCands.at(index_chH).vertex().x() - pv.position().x(), 0.0005f, 1.735f);
-            get(dnn::pfCand_chHad_vertex_dy) = getValueNorm(pfCands.at(index_chH).vertex().y() - pv.position().y(), -0.0008f, 1.752f);
-            get(dnn::pfCand_chHad_vertex_dz) = getValueNorm(pfCands.at(index_chH).vertex().z() - pv.position().z(), -0.0201f, 8.333f);
-            get(dnn::pfCand_chHad_vertex_dx_tauFL) = getValueNorm(pfCands.at(index_chH).vertex().x() - pv.position().x()
-                - tau.flightLength().x(), -0.0014f, 1.93f);
-            get(dnn::pfCand_chHad_vertex_dy_tauFL) = getValueNorm(pfCands.at(index_chH).vertex().y() - pv.position().y()
-                - tau.flightLength().y(), 0.0022f, 1.948f);
-            get(dnn::pfCand_chHad_vertex_dz_tauFL) = getValueNorm(pfCands.at(index_chH).vertex().z() - pv.position().z()
-                - tau.flightLength().z(), -0.0138f, 8.622f);
-
-            const bool hasTrackDetails = pfCands.at(index_chH).hasTrackDetails();
-            if(hasTrackDetails){
-                get(dnn::pfCand_chHad_hasTrackDetails) = hasTrackDetails;
-                get(dnn::pfCand_chHad_dxy) = getValueNorm(pfCands.at(index_chH).dxy(), -0.012f, 2.386f);
-                get(dnn::pfCand_chHad_dxy_sig) = getValueNorm(std::abs(pfCands.at(index_chH).dxy()) /
-                    pfCands.at(index_chH).dxyError(), 6.417f, 36.28f);
-                get(dnn::pfCand_chHad_dz) =  getValueNorm(pfCands.at(index_chH).dz(), -0.0246f, 7.618f);
-                get(dnn::pfCand_chHad_dz_sig) =  getValueNorm(std::abs(pfCands.at(index_chH).dz()) /
-                    pfCands.at(index_chH).dzError(), 301.3f, 491.1f);
-                get(dnn::pfCand_chHad_track_chi2_ndof) = pfCands.at(index_chH).pseudoTrack().ndof() > 0 ?
-                    getValueNorm(pfCands.at(index_chH).pseudoTrack().chi2() /
-                    pfCands.at(index_chH).pseudoTrack().ndof(), 0.7876f, 3.694f) : 0;
-                get(dnn::pfCand_chHad_track_ndof) = pfCands.at(index_chH).pseudoTrack().ndof() > 0 ?
-                    getValueNorm(pfCands.at(index_chH).pseudoTrack().ndof(), 13.92f, 6.581f) : 0;
-            }
-            get(dnn::pfCand_chHad_hcalFraction) = getValue(pfCands.at(index_chH).hcalFraction());
-            get(dnn::pfCand_chHad_rawCaloFraction) = getValueLinear(pfCands.at(index_chH).rawCaloFraction(), 0.f, 2.6f, true);
-        }
-        if(valid_nH){
-            size_t index_nH = cell_map.at(CellObjectType::PfCand_neutralHadron);
-
-            get(dnn::pfCand_nHad_valid) = valid_nH;
-            get(dnn::pfCand_nHad_rel_pt) = getValueNorm(pfCands.at(index_nH).polarP4().pt() / tau.polarP4().pt(),
-                is_inner ? 0.3163f : 0.0502f, is_inner ? 0.2769f : 0.4266f);
-            get(dnn::pfCand_nHad_deta) = getValueLinear(pfCands.at(index_nH).polarP4().eta() - tau.polarP4().eta(),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::pfCand_nHad_dphi) = getValueLinear(dPhi(tau.polarP4(),pfCands.at(index_nH).polarP4()),
-                is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-            get(dnn::pfCand_nHad_puppiWeight) = getValue(pfCands.at(index_nH).puppiWeight());
-            get(dnn::pfCand_nHad_puppiWeightNoLep) = getValue(pfCands.at(index_nH).puppiWeightNoLep());
-            get(dnn::pfCand_nHad_hcalFraction) = getValue(pfCands.at(index_nH).hcalFraction());
-        }
-        checkInputs(inputs, is_inner ? "hadron_inner_block" : "hadron_outer_block", dnn::NumberOfInputs);
+    get(dnn::gsf_ele_Chi2NormGSF) = default_value;
+    get(dnn::gsf_ele_GSFNumHits) = default_value;
+    get(dnn::gsf_ele_GSFTrackResol) = default_value;
+    get(dnn::gsf_ele_GSFTracklnPt) = default_value;
+    if (gsf_ele != nullptr && gsf_ele->gsfTrack().isNonnull()) {
+      get(dnn::gsf_ele_Chi2NormGSF) = gsf_ele->gsfTrack()->normalizedChi2();
+      get(dnn::gsf_ele_GSFNumHits) = gsf_ele->gsfTrack()->numberOfValidHits();
+      if (gsf_ele->gsfTrack()->pt() > 0) {
+        get(dnn::gsf_ele_GSFTrackResol) = gsf_ele->gsfTrack()->ptError() / gsf_ele->gsfTrack()->pt();
+        get(dnn::gsf_ele_GSFTracklnPt) = std::log10(gsf_ele->gsfTrack()->pt());
+      }
     }
 
-    template<typename dnn>
-    tensorflow::Tensor createInputsV1(const TauType& tau, const ElectronCollection& electrons,
-                                      const MuonCollection& muons) const
-    {
-        static constexpr bool check_all_set = false;
-        static constexpr float default_value_for_set_check = -42;
+    get(dnn::gsf_ele_Chi2NormKF) = default_value;
+    get(dnn::gsf_ele_KFNumHits) = default_value;
+    if (gsf_ele != nullptr && gsf_ele->closestCtfTrackRef().isNonnull()) {
+      get(dnn::gsf_ele_Chi2NormKF) = gsf_ele->closestCtfTrackRef()->normalizedChi2();
+      get(dnn::gsf_ele_KFNumHits) = gsf_ele->closestCtfTrackRef()->numberOfValidHits();
+    }
+    get(dnn::leadChargedCand_etaAtEcalEntrance) = tau.etaAtEcalEntranceLeadChargedCand();
+    get(dnn::leadChargedCand_pt) = tau.ptLeadChargedCand();
 
-        tensorflow::Tensor inputs(tensorflow::DT_FLOAT, { 1, dnn_inputs_2017v1::NumberOfInputs});
-        const auto& get = [&](int var_index) -> float& { return inputs.matrix<float>()(0, var_index); };
-        auto leadChargedHadrCand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand().get());
-
-        if(check_all_set) {
-            for(int var_index = 0; var_index < dnn::NumberOfInputs; ++var_index) {
-                get(var_index) = default_value_for_set_check;
-            }
-        }
-
-        get(dnn::pt) = tau.p4().pt();
-        get(dnn::eta) = tau.p4().eta();
-        get(dnn::mass) = tau.p4().mass();
-        get(dnn::decayMode) = tau.decayMode();
-        get(dnn::chargedIsoPtSum) = tau.tauID("chargedIsoPtSum");
-        get(dnn::neutralIsoPtSum) = tau.tauID("neutralIsoPtSum");
-        get(dnn::neutralIsoPtSumWeight) = tau.tauID("neutralIsoPtSumWeight");
-        get(dnn::photonPtSumOutsideSignalCone) = tau.tauID("photonPtSumOutsideSignalCone");
-        get(dnn::puCorrPtSum) = tau.tauID("puCorrPtSum");
-        get(dnn::dxy) = tau.dxy();
-        get(dnn::dxy_sig) = tau.dxy_Sig();
-        get(dnn::dz) = leadChargedHadrCand ? leadChargedHadrCand->dz() : default_value;
-        get(dnn::ip3d) = tau.ip3d();
-        get(dnn::ip3d_sig) = tau.ip3d_Sig();
-        get(dnn::hasSecondaryVertex) = tau.hasSecondaryVertex();
-        get(dnn::flightLength_r) = tau.flightLength().R();
-        get(dnn::flightLength_dEta) = dEta(tau.flightLength(), tau.p4());
-        get(dnn::flightLength_dPhi) = dPhi(tau.flightLength(), tau.p4());
-        get(dnn::flightLength_sig) = tau.flightLengthSig();
-        get(dnn::leadChargedHadrCand_pt) = leadChargedHadrCand ? leadChargedHadrCand->p4().Pt() : default_value;
-        get(dnn::leadChargedHadrCand_dEta) = leadChargedHadrCand
-                ? dEta(leadChargedHadrCand->p4(), tau.p4()) : default_value;
-        get(dnn::leadChargedHadrCand_dPhi) = leadChargedHadrCand
-                ? dPhi(leadChargedHadrCand->p4(), tau.p4()) : default_value;
-        get(dnn::leadChargedHadrCand_mass) = leadChargedHadrCand
-                ? leadChargedHadrCand->p4().mass() : default_value;
-        get(dnn::pt_weighted_deta_strip) = reco::tau::pt_weighted_deta_strip(tau, tau.decayMode());
-        get(dnn::pt_weighted_dphi_strip) = reco::tau::pt_weighted_dphi_strip(tau, tau.decayMode());
-        get(dnn::pt_weighted_dr_signal) = reco::tau::pt_weighted_dr_signal(tau, tau.decayMode());
-        get(dnn::pt_weighted_dr_iso) = reco::tau::pt_weighted_dr_iso(tau, tau.decayMode());
-        get(dnn::leadingTrackNormChi2) = tau.leadingTrackNormChi2();
-        get(dnn::e_ratio) = reco::tau::eratio(tau);
-        get(dnn::gj_angle_diff) = calculateGottfriedJacksonAngleDifference(tau);
-        get(dnn::n_photons) = reco::tau::n_photons_total(tau);
-        get(dnn::emFraction) = tau.emFraction_MVA();
-        get(dnn::has_gsf_track) = leadChargedHadrCand && std::abs(leadChargedHadrCand->pdgId()) == 11;
-        get(dnn::inside_ecal_crack) = isInEcalCrack(tau.p4().Eta());
-        auto gsf_ele = findMatchedElectron(tau, electrons, 0.3);
-        get(dnn::gsf_ele_matched) = gsf_ele != nullptr;
-        get(dnn::gsf_ele_pt) = gsf_ele != nullptr ? gsf_ele->p4().Pt() : default_value;
-        get(dnn::gsf_ele_dEta) = gsf_ele != nullptr ? dEta(gsf_ele->p4(), tau.p4()) : default_value;
-        get(dnn::gsf_ele_dPhi) = gsf_ele != nullptr ? dPhi(gsf_ele->p4(), tau.p4()) : default_value;
-        get(dnn::gsf_ele_mass) = gsf_ele != nullptr ? gsf_ele->p4().mass() : default_value;
-        calculateElectronClusterVars(gsf_ele, get(dnn::gsf_ele_Ee), get(dnn::gsf_ele_Egamma));
-        get(dnn::gsf_ele_Pin) = gsf_ele != nullptr ? gsf_ele->trackMomentumAtVtx().R() : default_value;
-        get(dnn::gsf_ele_Pout) = gsf_ele != nullptr ? gsf_ele->trackMomentumOut().R() : default_value;
-        get(dnn::gsf_ele_EtotOverPin) = get(dnn::gsf_ele_Pin) > 0
-                ? (get(dnn::gsf_ele_Ee) + get(dnn::gsf_ele_Egamma)) / get(dnn::gsf_ele_Pin)
-                : default_value;
-        get(dnn::gsf_ele_Eecal) = gsf_ele != nullptr ? gsf_ele->ecalEnergy() : default_value;
-        get(dnn::gsf_ele_dEta_SeedClusterTrackAtCalo) = gsf_ele != nullptr
-                ? gsf_ele->deltaEtaSeedClusterTrackAtCalo() : default_value;
-        get(dnn::gsf_ele_dPhi_SeedClusterTrackAtCalo) = gsf_ele != nullptr
-                ? gsf_ele->deltaPhiSeedClusterTrackAtCalo() : default_value;
-        get(dnn::gsf_ele_mvaIn_sigmaEtaEta) = gsf_ele != nullptr
-                ? gsf_ele->mvaInput().sigmaEtaEta : default_value;
-        get(dnn::gsf_ele_mvaIn_hadEnergy) = gsf_ele != nullptr ? gsf_ele->mvaInput().hadEnergy : default_value;
-        get(dnn::gsf_ele_mvaIn_deltaEta) = gsf_ele != nullptr ? gsf_ele->mvaInput().deltaEta : default_value;
-
-        get(dnn::gsf_ele_Chi2NormGSF) = default_value;
-        get(dnn::gsf_ele_GSFNumHits) = default_value;
-        get(dnn::gsf_ele_GSFTrackResol) = default_value;
-        get(dnn::gsf_ele_GSFTracklnPt) = default_value;
-        if(gsf_ele != nullptr && gsf_ele->gsfTrack().isNonnull()) {
-            get(dnn::gsf_ele_Chi2NormGSF) = gsf_ele->gsfTrack()->normalizedChi2();
-            get(dnn::gsf_ele_GSFNumHits) = gsf_ele->gsfTrack()->numberOfValidHits();
-            if(gsf_ele->gsfTrack()->pt() > 0) {
-                get(dnn::gsf_ele_GSFTrackResol) = gsf_ele->gsfTrack()->ptError() / gsf_ele->gsfTrack()->pt();
-                get(dnn::gsf_ele_GSFTracklnPt) = std::log10(gsf_ele->gsfTrack()->pt());
-            }
-        }
-
-        get(dnn::gsf_ele_Chi2NormKF) = default_value;
-        get(dnn::gsf_ele_KFNumHits) = default_value;
-        if(gsf_ele != nullptr && gsf_ele->closestCtfTrackRef().isNonnull()) {
-            get(dnn::gsf_ele_Chi2NormKF) = gsf_ele->closestCtfTrackRef()->normalizedChi2();
-            get(dnn::gsf_ele_KFNumHits) = gsf_ele->closestCtfTrackRef()->numberOfValidHits();
-        }
-        get(dnn::leadChargedCand_etaAtEcalEntrance) = tau.etaAtEcalEntranceLeadChargedCand();
-        get(dnn::leadChargedCand_pt) = tau.ptLeadChargedCand();
-
-        get(dnn::leadChargedHadrCand_HoP) = default_value;
-        get(dnn::leadChargedHadrCand_EoP) = default_value;
-        if(tau.leadChargedHadrCand()->pt() > 0) {
-            get(dnn::leadChargedHadrCand_HoP) = tau.hcalEnergyLeadChargedHadrCand()
-                                                    / tau.leadChargedHadrCand()->pt();
-            get(dnn::leadChargedHadrCand_EoP) = tau.ecalEnergyLeadChargedHadrCand()
-                                                    / tau.leadChargedHadrCand()->pt();
-        }
-
-        MuonHitMatchV1 muon_hit_match;
-        if(tau.leadPFChargedHadrCand().isNonnull() && tau.leadPFChargedHadrCand()->muonRef().isNonnull())
-            muon_hit_match.addMatchedMuon(*tau.leadPFChargedHadrCand()->muonRef(), tau);
-
-        auto matched_muons = muon_hit_match.findMatchedMuons(tau, muons, 0.3, 5);
-        for(auto muon : matched_muons)
-            muon_hit_match.addMatchedMuon(*muon, tau);
-        muon_hit_match.fillTensor<dnn>(get, tau, default_value);
-
-        LorentzVectorXYZ signalChargedHadrCands_sumIn, signalChargedHadrCands_sumOut;
-        processSignalPFComponents(tau, tau.signalChargedHadrCands(),
-                                  signalChargedHadrCands_sumIn, signalChargedHadrCands_sumOut,
-                                  get(dnn::signalChargedHadrCands_sum_innerSigCone_pt),
-                                  get(dnn::signalChargedHadrCands_sum_innerSigCone_dEta),
-                                  get(dnn::signalChargedHadrCands_sum_innerSigCone_dPhi),
-                                  get(dnn::signalChargedHadrCands_sum_innerSigCone_mass),
-                                  get(dnn::signalChargedHadrCands_sum_outerSigCone_pt),
-                                  get(dnn::signalChargedHadrCands_sum_outerSigCone_dEta),
-                                  get(dnn::signalChargedHadrCands_sum_outerSigCone_dPhi),
-                                  get(dnn::signalChargedHadrCands_sum_outerSigCone_mass),
-                                  get(dnn::signalChargedHadrCands_nTotal_innerSigCone),
-                                  get(dnn::signalChargedHadrCands_nTotal_outerSigCone));
-
-        LorentzVectorXYZ signalNeutrHadrCands_sumIn, signalNeutrHadrCands_sumOut;
-        processSignalPFComponents(tau, tau.signalNeutrHadrCands(),
-                                  signalNeutrHadrCands_sumIn, signalNeutrHadrCands_sumOut,
-                                  get(dnn::signalNeutrHadrCands_sum_innerSigCone_pt),
-                                  get(dnn::signalNeutrHadrCands_sum_innerSigCone_dEta),
-                                  get(dnn::signalNeutrHadrCands_sum_innerSigCone_dPhi),
-                                  get(dnn::signalNeutrHadrCands_sum_innerSigCone_mass),
-                                  get(dnn::signalNeutrHadrCands_sum_outerSigCone_pt),
-                                  get(dnn::signalNeutrHadrCands_sum_outerSigCone_dEta),
-                                  get(dnn::signalNeutrHadrCands_sum_outerSigCone_dPhi),
-                                  get(dnn::signalNeutrHadrCands_sum_outerSigCone_mass),
-                                  get(dnn::signalNeutrHadrCands_nTotal_innerSigCone),
-                                  get(dnn::signalNeutrHadrCands_nTotal_outerSigCone));
-
-
-        LorentzVectorXYZ signalGammaCands_sumIn, signalGammaCands_sumOut;
-        processSignalPFComponents(tau, tau.signalGammaCands(),
-                                  signalGammaCands_sumIn, signalGammaCands_sumOut,
-                                  get(dnn::signalGammaCands_sum_innerSigCone_pt),
-                                  get(dnn::signalGammaCands_sum_innerSigCone_dEta),
-                                  get(dnn::signalGammaCands_sum_innerSigCone_dPhi),
-                                  get(dnn::signalGammaCands_sum_innerSigCone_mass),
-                                  get(dnn::signalGammaCands_sum_outerSigCone_pt),
-                                  get(dnn::signalGammaCands_sum_outerSigCone_dEta),
-                                  get(dnn::signalGammaCands_sum_outerSigCone_dPhi),
-                                  get(dnn::signalGammaCands_sum_outerSigCone_mass),
-                                  get(dnn::signalGammaCands_nTotal_innerSigCone),
-                                  get(dnn::signalGammaCands_nTotal_outerSigCone));
-
-        LorentzVectorXYZ isolationChargedHadrCands_sum;
-        processIsolationPFComponents(tau, tau.isolationChargedHadrCands(), isolationChargedHadrCands_sum,
-                                     get(dnn::isolationChargedHadrCands_sum_pt),
-                                     get(dnn::isolationChargedHadrCands_sum_dEta),
-                                     get(dnn::isolationChargedHadrCands_sum_dPhi),
-                                     get(dnn::isolationChargedHadrCands_sum_mass),
-                                     get(dnn::isolationChargedHadrCands_nTotal));
-
-        LorentzVectorXYZ isolationNeutrHadrCands_sum;
-        processIsolationPFComponents(tau, tau.isolationNeutrHadrCands(), isolationNeutrHadrCands_sum,
-                                     get(dnn::isolationNeutrHadrCands_sum_pt),
-                                     get(dnn::isolationNeutrHadrCands_sum_dEta),
-                                     get(dnn::isolationNeutrHadrCands_sum_dPhi),
-                                     get(dnn::isolationNeutrHadrCands_sum_mass),
-                                     get(dnn::isolationNeutrHadrCands_nTotal));
-
-        LorentzVectorXYZ isolationGammaCands_sum;
-        processIsolationPFComponents(tau, tau.isolationGammaCands(), isolationGammaCands_sum,
-                                     get(dnn::isolationGammaCands_sum_pt),
-                                     get(dnn::isolationGammaCands_sum_dEta),
-                                     get(dnn::isolationGammaCands_sum_dPhi),
-                                     get(dnn::isolationGammaCands_sum_mass),
-                                     get(dnn::isolationGammaCands_nTotal));
-
-        get(dnn::tau_visMass_innerSigCone) = (signalGammaCands_sumIn + signalChargedHadrCands_sumIn).mass();
-
-        if(check_all_set) {
-            for(int var_index = 0; var_index < dnn::NumberOfInputs; ++var_index) {
-                if(get(var_index) == default_value_for_set_check)
-                    throw cms::Exception("DeepTauId: variable with index = ") << var_index << " is not set.";
-            }
-        }
-
-        return inputs;
+    get(dnn::leadChargedHadrCand_HoP) = default_value;
+    get(dnn::leadChargedHadrCand_EoP) = default_value;
+    if (tau.leadChargedHadrCand()->pt() > 0) {
+      get(dnn::leadChargedHadrCand_HoP) = tau.hcalEnergyLeadChargedHadrCand() / tau.leadChargedHadrCand()->pt();
+      get(dnn::leadChargedHadrCand_EoP) = tau.ecalEnergyLeadChargedHadrCand() / tau.leadChargedHadrCand()->pt();
     }
 
-    static void calculateElectronClusterVars(const pat::Electron* ele, float& elecEe, float& elecEgamma)
-    {
-        if(ele) {
-            elecEe = elecEgamma = 0;
-            auto superCluster = ele->superCluster();
-            if(superCluster.isNonnull() && superCluster.isAvailable() && superCluster->clusters().isNonnull()
-                    && superCluster->clusters().isAvailable()) {
-                for(auto iter = superCluster->clustersBegin(); iter != superCluster->clustersEnd(); ++iter) {
-                    const double energy = (*iter)->energy();
-                    if(iter == superCluster->clustersBegin()) elecEe += energy;
-                    else elecEgamma += energy;
-                }
-            }
-        } else {
-            elecEe = elecEgamma = default_value;
+    MuonHitMatchV1 muon_hit_match;
+    if (tau.leadPFChargedHadrCand().isNonnull() && tau.leadPFChargedHadrCand()->muonRef().isNonnull())
+      muon_hit_match.addMatchedMuon(*tau.leadPFChargedHadrCand()->muonRef(), tau);
+
+    auto matched_muons = muon_hit_match.findMatchedMuons(tau, muons, 0.3, 5);
+    for (auto muon : matched_muons)
+      muon_hit_match.addMatchedMuon(*muon, tau);
+    muon_hit_match.fillTensor<dnn>(get, tau, default_value);
+
+    LorentzVectorXYZ signalChargedHadrCands_sumIn, signalChargedHadrCands_sumOut;
+    processSignalPFComponents(tau,
+                              tau.signalChargedHadrCands(),
+                              signalChargedHadrCands_sumIn,
+                              signalChargedHadrCands_sumOut,
+                              get(dnn::signalChargedHadrCands_sum_innerSigCone_pt),
+                              get(dnn::signalChargedHadrCands_sum_innerSigCone_dEta),
+                              get(dnn::signalChargedHadrCands_sum_innerSigCone_dPhi),
+                              get(dnn::signalChargedHadrCands_sum_innerSigCone_mass),
+                              get(dnn::signalChargedHadrCands_sum_outerSigCone_pt),
+                              get(dnn::signalChargedHadrCands_sum_outerSigCone_dEta),
+                              get(dnn::signalChargedHadrCands_sum_outerSigCone_dPhi),
+                              get(dnn::signalChargedHadrCands_sum_outerSigCone_mass),
+                              get(dnn::signalChargedHadrCands_nTotal_innerSigCone),
+                              get(dnn::signalChargedHadrCands_nTotal_outerSigCone));
+
+    LorentzVectorXYZ signalNeutrHadrCands_sumIn, signalNeutrHadrCands_sumOut;
+    processSignalPFComponents(tau,
+                              tau.signalNeutrHadrCands(),
+                              signalNeutrHadrCands_sumIn,
+                              signalNeutrHadrCands_sumOut,
+                              get(dnn::signalNeutrHadrCands_sum_innerSigCone_pt),
+                              get(dnn::signalNeutrHadrCands_sum_innerSigCone_dEta),
+                              get(dnn::signalNeutrHadrCands_sum_innerSigCone_dPhi),
+                              get(dnn::signalNeutrHadrCands_sum_innerSigCone_mass),
+                              get(dnn::signalNeutrHadrCands_sum_outerSigCone_pt),
+                              get(dnn::signalNeutrHadrCands_sum_outerSigCone_dEta),
+                              get(dnn::signalNeutrHadrCands_sum_outerSigCone_dPhi),
+                              get(dnn::signalNeutrHadrCands_sum_outerSigCone_mass),
+                              get(dnn::signalNeutrHadrCands_nTotal_innerSigCone),
+                              get(dnn::signalNeutrHadrCands_nTotal_outerSigCone));
+
+    LorentzVectorXYZ signalGammaCands_sumIn, signalGammaCands_sumOut;
+    processSignalPFComponents(tau,
+                              tau.signalGammaCands(),
+                              signalGammaCands_sumIn,
+                              signalGammaCands_sumOut,
+                              get(dnn::signalGammaCands_sum_innerSigCone_pt),
+                              get(dnn::signalGammaCands_sum_innerSigCone_dEta),
+                              get(dnn::signalGammaCands_sum_innerSigCone_dPhi),
+                              get(dnn::signalGammaCands_sum_innerSigCone_mass),
+                              get(dnn::signalGammaCands_sum_outerSigCone_pt),
+                              get(dnn::signalGammaCands_sum_outerSigCone_dEta),
+                              get(dnn::signalGammaCands_sum_outerSigCone_dPhi),
+                              get(dnn::signalGammaCands_sum_outerSigCone_mass),
+                              get(dnn::signalGammaCands_nTotal_innerSigCone),
+                              get(dnn::signalGammaCands_nTotal_outerSigCone));
+
+    LorentzVectorXYZ isolationChargedHadrCands_sum;
+    processIsolationPFComponents(tau,
+                                 tau.isolationChargedHadrCands(),
+                                 isolationChargedHadrCands_sum,
+                                 get(dnn::isolationChargedHadrCands_sum_pt),
+                                 get(dnn::isolationChargedHadrCands_sum_dEta),
+                                 get(dnn::isolationChargedHadrCands_sum_dPhi),
+                                 get(dnn::isolationChargedHadrCands_sum_mass),
+                                 get(dnn::isolationChargedHadrCands_nTotal));
+
+    LorentzVectorXYZ isolationNeutrHadrCands_sum;
+    processIsolationPFComponents(tau,
+                                 tau.isolationNeutrHadrCands(),
+                                 isolationNeutrHadrCands_sum,
+                                 get(dnn::isolationNeutrHadrCands_sum_pt),
+                                 get(dnn::isolationNeutrHadrCands_sum_dEta),
+                                 get(dnn::isolationNeutrHadrCands_sum_dPhi),
+                                 get(dnn::isolationNeutrHadrCands_sum_mass),
+                                 get(dnn::isolationNeutrHadrCands_nTotal));
+
+    LorentzVectorXYZ isolationGammaCands_sum;
+    processIsolationPFComponents(tau,
+                                 tau.isolationGammaCands(),
+                                 isolationGammaCands_sum,
+                                 get(dnn::isolationGammaCands_sum_pt),
+                                 get(dnn::isolationGammaCands_sum_dEta),
+                                 get(dnn::isolationGammaCands_sum_dPhi),
+                                 get(dnn::isolationGammaCands_sum_mass),
+                                 get(dnn::isolationGammaCands_nTotal));
+
+    get(dnn::tau_visMass_innerSigCone) = (signalGammaCands_sumIn + signalChargedHadrCands_sumIn).mass();
+
+    if (check_all_set) {
+      for (int var_index = 0; var_index < dnn::NumberOfInputs; ++var_index) {
+        if (get(var_index) == default_value_for_set_check)
+          throw cms::Exception("DeepTauId: variable with index = ") << var_index << " is not set.";
+      }
+    }
+
+    return inputs;
+  }
+
+  static void calculateElectronClusterVars(const pat::Electron* ele, float& elecEe, float& elecEgamma) {
+    if (ele) {
+      elecEe = elecEgamma = 0;
+      auto superCluster = ele->superCluster();
+      if (superCluster.isNonnull() && superCluster.isAvailable() && superCluster->clusters().isNonnull() &&
+          superCluster->clusters().isAvailable()) {
+        for (auto iter = superCluster->clustersBegin(); iter != superCluster->clustersEnd(); ++iter) {
+          const double energy = (*iter)->energy();
+          if (iter == superCluster->clustersBegin())
+            elecEe += energy;
+          else
+            elecEgamma += energy;
         }
+      }
+    } else {
+      elecEe = elecEgamma = default_value;
+    }
+  }
+
+  template <typename CandidateCollection>
+  static void processSignalPFComponents(const pat::Tau& tau,
+                                        const CandidateCollection& candidates,
+                                        LorentzVectorXYZ& p4_inner,
+                                        LorentzVectorXYZ& p4_outer,
+                                        float& pt_inner,
+                                        float& dEta_inner,
+                                        float& dPhi_inner,
+                                        float& m_inner,
+                                        float& pt_outer,
+                                        float& dEta_outer,
+                                        float& dPhi_outer,
+                                        float& m_outer,
+                                        float& n_inner,
+                                        float& n_outer) {
+    p4_inner = LorentzVectorXYZ(0, 0, 0, 0);
+    p4_outer = LorentzVectorXYZ(0, 0, 0, 0);
+    n_inner = 0;
+    n_outer = 0;
+
+    const double innerSigCone_radius = getInnerSignalConeRadius(tau.pt());
+    for (const auto& cand : candidates) {
+      const double dR = reco::deltaR(cand->p4(), tau.leadChargedHadrCand()->p4());
+      const bool isInside_innerSigCone = dR < innerSigCone_radius;
+      if (isInside_innerSigCone) {
+        p4_inner += cand->p4();
+        ++n_inner;
+      } else {
+        p4_outer += cand->p4();
+        ++n_outer;
+      }
     }
 
-    template<typename CandidateCollection>
-    static void processSignalPFComponents(const pat::Tau& tau, const CandidateCollection& candidates,
-                                          LorentzVectorXYZ& p4_inner, LorentzVectorXYZ& p4_outer,
-                                          float& pt_inner, float& dEta_inner, float& dPhi_inner, float& m_inner,
-                                          float& pt_outer, float& dEta_outer, float& dPhi_outer, float& m_outer,
-                                          float& n_inner, float& n_outer)
-    {
-        p4_inner = LorentzVectorXYZ(0, 0, 0, 0);
-        p4_outer = LorentzVectorXYZ(0, 0, 0, 0);
-        n_inner = 0;
-        n_outer = 0;
+    pt_inner = n_inner != 0 ? p4_inner.Pt() : default_value;
+    dEta_inner = n_inner != 0 ? dEta(p4_inner, tau.p4()) : default_value;
+    dPhi_inner = n_inner != 0 ? dPhi(p4_inner, tau.p4()) : default_value;
+    m_inner = n_inner != 0 ? p4_inner.mass() : default_value;
 
-        const double innerSigCone_radius = getInnerSignalConeRadius(tau.pt());
-        for(const auto& cand : candidates) {
-            const double dR = reco::deltaR(cand->p4(), tau.leadChargedHadrCand()->p4());
-            const bool isInside_innerSigCone = dR < innerSigCone_radius;
-            if(isInside_innerSigCone) {
-                p4_inner += cand->p4();
-                ++n_inner;
-            } else {
-                p4_outer += cand->p4();
-                ++n_outer;
-            }
-        }
+    pt_outer = n_outer != 0 ? p4_outer.Pt() : default_value;
+    dEta_outer = n_outer != 0 ? dEta(p4_outer, tau.p4()) : default_value;
+    dPhi_outer = n_outer != 0 ? dPhi(p4_outer, tau.p4()) : default_value;
+    m_outer = n_outer != 0 ? p4_outer.mass() : default_value;
+  }
 
-        pt_inner = n_inner != 0 ? p4_inner.Pt() : default_value;
-        dEta_inner = n_inner != 0 ? dEta(p4_inner, tau.p4()) : default_value;
-        dPhi_inner = n_inner != 0 ? dPhi(p4_inner, tau.p4()) : default_value;
-        m_inner = n_inner != 0 ? p4_inner.mass() : default_value;
+  template <typename CandidateCollection>
+  static void processIsolationPFComponents(const pat::Tau& tau,
+                                           const CandidateCollection& candidates,
+                                           LorentzVectorXYZ& p4,
+                                           float& pt,
+                                           float& d_eta,
+                                           float& d_phi,
+                                           float& m,
+                                           float& n) {
+    p4 = LorentzVectorXYZ(0, 0, 0, 0);
+    n = 0;
 
-        pt_outer = n_outer != 0 ? p4_outer.Pt() : default_value;
-        dEta_outer = n_outer != 0 ? dEta(p4_outer, tau.p4()) : default_value;
-        dPhi_outer = n_outer != 0 ? dPhi(p4_outer, tau.p4()) : default_value;
-        m_outer = n_outer != 0 ? p4_outer.mass() : default_value;
+    for (const auto& cand : candidates) {
+      p4 += cand->p4();
+      ++n;
     }
 
-    template<typename CandidateCollection>
-    static void processIsolationPFComponents(const pat::Tau& tau, const CandidateCollection& candidates,
-                                             LorentzVectorXYZ& p4, float& pt, float& d_eta, float& d_phi, float& m,
-                                             float& n)
-    {
-        p4 = LorentzVectorXYZ(0, 0, 0, 0);
-        n = 0;
+    pt = n != 0 ? p4.Pt() : default_value;
+    d_eta = n != 0 ? dEta(p4, tau.p4()) : default_value;
+    d_phi = n != 0 ? dPhi(p4, tau.p4()) : default_value;
+    m = n != 0 ? p4.mass() : default_value;
+  }
 
-        for(const auto& cand : candidates) {
-            p4 += cand->p4();
-            ++n;
-        }
+  static double getInnerSignalConeRadius(double pt) {
+    static constexpr double min_pt = 30., min_radius = 0.05, cone_opening_coef = 3.;
+    // This is equivalent of the original formula (std::max(std::min(0.1, 3.0/pt), 0.05)
+    return std::max(cone_opening_coef / std::max(pt, min_pt), min_radius);
+  }
 
-        pt = n != 0 ? p4.Pt() : default_value;
-        d_eta = n != 0 ? dEta(p4, tau.p4()) : default_value;
-        d_phi = n != 0 ? dPhi(p4, tau.p4()) : default_value;
-        m = n != 0 ? p4.mass() : default_value;
+  // Copied from https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc#L218
+  static bool calculateGottfriedJacksonAngleDifference(const pat::Tau& tau, double& gj_diff) {
+    if (tau.hasSecondaryVertex()) {
+      static constexpr double mTau = 1.77682;
+      const double mAOne = tau.p4().M();
+      const double pAOneMag = tau.p();
+      const double argumentThetaGJmax = (std::pow(mTau, 2) - std::pow(mAOne, 2)) / (2 * mTau * pAOneMag);
+      const double argumentThetaGJmeasured =
+          tau.p4().Vect().Dot(tau.flightLength()) / (pAOneMag * tau.flightLength().R());
+      if (std::abs(argumentThetaGJmax) <= 1. && std::abs(argumentThetaGJmeasured) <= 1.) {
+        double thetaGJmax = std::asin(argumentThetaGJmax);
+        double thetaGJmeasured = std::acos(argumentThetaGJmeasured);
+        gj_diff = thetaGJmeasured - thetaGJmax;
+        return true;
+      }
     }
+    return false;
+  }
 
-    static double getInnerSignalConeRadius(double pt)
-    {
-        static constexpr double min_pt = 30., min_radius = 0.05, cone_opening_coef = 3.;
-        // This is equivalent of the original formula (std::max(std::min(0.1, 3.0/pt), 0.05)
-        return std::max(cone_opening_coef / std::max(pt, min_pt), min_radius);
-    }
+  static float calculateGottfriedJacksonAngleDifference(const pat::Tau& tau) {
+    double gj_diff;
+    if (calculateGottfriedJacksonAngleDifference(tau, gj_diff))
+      return static_cast<float>(gj_diff);
+    return default_value;
+  }
 
-     // Copied from https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc#L218
-    static bool calculateGottfriedJacksonAngleDifference(const pat::Tau& tau, double& gj_diff)
-    {
-        if(tau.hasSecondaryVertex()) {
-            static constexpr double mTau = 1.77682;
-            const double mAOne = tau.p4().M();
-            const double pAOneMag = tau.p();
-            const double argumentThetaGJmax = (std::pow(mTau,2) - std::pow(mAOne,2) ) / ( 2 * mTau * pAOneMag );
-            const double argumentThetaGJmeasured = tau.p4().Vect().Dot(tau.flightLength())
-                    / ( pAOneMag * tau.flightLength().R() );
-            if ( std::abs(argumentThetaGJmax) <= 1. && std::abs(argumentThetaGJmeasured) <= 1. ) {
-                double thetaGJmax = std::asin( argumentThetaGJmax );
-                double thetaGJmeasured = std::acos( argumentThetaGJmeasured );
-                gj_diff = thetaGJmeasured - thetaGJmax;
-                return true;
-            }
-        }
-        return false;
-    }
+  static bool isInEcalCrack(double eta) {
+    const double abs_eta = std::abs(eta);
+    return abs_eta > 1.46 && abs_eta < 1.558;
+  }
 
-    static float calculateGottfriedJacksonAngleDifference(const pat::Tau& tau)
-    {
-        double gj_diff;
-        if(calculateGottfriedJacksonAngleDifference(tau, gj_diff))
-            return static_cast<float>(gj_diff);
-        return default_value;
+  static const pat::Electron* findMatchedElectron(const pat::Tau& tau,
+                                                  const pat::ElectronCollection& electrons,
+                                                  double deltaR) {
+    const double dR2 = deltaR * deltaR;
+    const pat::Electron* matched_ele = nullptr;
+    for (const auto& ele : electrons) {
+      if (reco::deltaR2(tau.p4(), ele.p4()) < dR2 && (!matched_ele || matched_ele->pt() < ele.pt())) {
+        matched_ele = &ele;
+      }
     }
-
-    static bool isInEcalCrack(double eta)
-    {
-        const double abs_eta = std::abs(eta);
-        return abs_eta > 1.46 && abs_eta < 1.558;
-    }
-
-    static const pat::Electron* findMatchedElectron(const pat::Tau& tau, const pat::ElectronCollection& electrons,
-                                                    double deltaR)
-    {
-        const double dR2 = deltaR*deltaR;
-        const pat::Electron* matched_ele = nullptr;
-        for(const auto& ele : electrons) {
-            if(reco::deltaR2(tau.p4(), ele.p4()) < dR2 && (!matched_ele || matched_ele->pt() < ele.pt())) {
-                matched_ele = &ele;
-            }
-        }
-        return matched_ele;
-    }
+    return matched_ele;
+  }
 
 private:
-    edm::EDGetTokenT<ElectronCollection> electrons_token_;
-    edm::EDGetTokenT<MuonCollection> muons_token_;
-    edm::EDGetTokenT<double> rho_token_;
-    std::string input_layer_, output_layer_;
-    const unsigned version;
-    const int debug_level;
-    std::shared_ptr<tensorflow::Tensor> tauBlockTensor_;
-    std::array<std::shared_ptr<tensorflow::Tensor>, 2> eGammaTensor_, muonTensor_, hadronsTensor_,
-                                                       convTensor_, zeroOutputTensor_;
+  edm::EDGetTokenT<ElectronCollection> electrons_token_;
+  edm::EDGetTokenT<MuonCollection> muons_token_;
+  edm::EDGetTokenT<double> rho_token_;
+  std::string input_layer_, output_layer_;
+  const unsigned version;
+  const int debug_level;
+  std::shared_ptr<tensorflow::Tensor> tauBlockTensor_;
+  std::array<std::shared_ptr<tensorflow::Tensor>, 2> eGammaTensor_, muonTensor_, hadronsTensor_, convTensor_,
+      zeroOutputTensor_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminantCutMultiplexer.cc
@@ -36,114 +36,107 @@
 #include "TFormula.h"
 #include "TFile.h"
 
-class PATTauDiscriminantCutMultiplexer : public PATTauDiscriminationProducerBase
-{
-  public:
-    explicit PATTauDiscriminantCutMultiplexer(const edm::ParameterSet& pset);
+class PATTauDiscriminantCutMultiplexer : public PATTauDiscriminationProducerBase {
+public:
+  explicit PATTauDiscriminantCutMultiplexer(const edm::ParameterSet& pset);
 
-    ~PATTauDiscriminantCutMultiplexer() override;
-    double discriminate(const pat::TauRef&) const override;
-    void beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) override;
+  ~PATTauDiscriminantCutMultiplexer() override;
+  double discriminate(const pat::TauRef&) const override;
+  void beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  private:
-    std::string moduleLabel_;
-	
-    bool loadMVAfromDB_;
-    edm::FileInPath inputFileName_;
-	
-    struct DiscriminantCutEntry
-    {
-    DiscriminantCutEntry()
-      : cutVariable_(),
-        cutFunction_(),
-	mode_(kUndefined)
-    {}
-    ~DiscriminantCutEntry()
-    {
-    }
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  std::string moduleLabel_;
+
+  bool loadMVAfromDB_;
+  edm::FileInPath inputFileName_;
+
+  struct DiscriminantCutEntry {
+    DiscriminantCutEntry() : cutVariable_(), cutFunction_(), mode_(kUndefined) {}
+    ~DiscriminantCutEntry() {}
     double cutValue_;
     std::string cutName_;
     std::unique_ptr<StringObjectFunction<pat::Tau>> cutVariable_;
     std::unique_ptr<const TGraph> cutFunction_;
     enum { kUndefined, kFixedCut, kVariableCut };
     int mode_;
-    };
-    typedef std::map<int, std::unique_ptr<DiscriminantCutEntry>> DiscriminantCutMap;
-    DiscriminantCutMap cuts_;
-	
-    std::string mvaOutputNormalizationName_;
-    std::unique_ptr<const TFormula> mvaOutput_normalization_;
-	
-    bool isInitialized_;
-	
-    edm::InputTag toMultiplex_;
-    edm::InputTag key_;
-    edm::Handle<pat::PATTauDiscriminator> toMultiplexHandle_;
-    edm::Handle<pat::PATTauDiscriminator> keyHandle_;
-    edm::EDGetTokenT<pat::PATTauDiscriminator> toMultiplex_token;
-    edm::EDGetTokenT<pat::PATTauDiscriminator> key_token;
-	
-    int verbosity_;
+  };
+  typedef std::map<int, std::unique_ptr<DiscriminantCutEntry>> DiscriminantCutMap;
+  DiscriminantCutMap cuts_;
+
+  std::string mvaOutputNormalizationName_;
+  std::unique_ptr<const TFormula> mvaOutput_normalization_;
+
+  bool isInitialized_;
+
+  edm::InputTag toMultiplex_;
+  edm::InputTag key_;
+  edm::Handle<pat::PATTauDiscriminator> toMultiplexHandle_;
+  edm::Handle<pat::PATTauDiscriminator> keyHandle_;
+  edm::EDGetTokenT<pat::PATTauDiscriminator> toMultiplex_token;
+  edm::EDGetTokenT<pat::PATTauDiscriminator> key_token;
+
+  int verbosity_;
 };
 
-namespace
-{
+namespace {
   std::unique_ptr<TFile> openInputFile(const edm::FileInPath& inputFileName) {
-    if ( inputFileName.location() == edm::FileInPath::Unknown){  throw cms::Exception("PATTauDiscriminantCutMultiplexer::loadObjectFromFile") 
-      << " Failed to find File = " << inputFileName << " !!\n";
+    if (inputFileName.location() == edm::FileInPath::Unknown) {
+      throw cms::Exception("PATTauDiscriminantCutMultiplexer::loadObjectFromFile")
+          << " Failed to find File = " << inputFileName << " !!\n";
     }
-    return std::unique_ptr<TFile>{ new TFile(inputFileName.fullPath().data()) };
+    return std::unique_ptr<TFile>{new TFile(inputFileName.fullPath().data())};
   }
-	
+
   template <typename T>
-  std::unique_ptr<const T> loadObjectFromFile(TFile& inputFile, const std::string& objectName)
-  {
+  std::unique_ptr<const T> loadObjectFromFile(TFile& inputFile, const std::string& objectName) {
     const T* object = dynamic_cast<T*>(inputFile.Get(objectName.data()));
-    if ( !object )
-      throw cms::Exception("PATTauDiscriminantCutMultiplexer::loadObjectFromFile") 
-	<< " Failed to load Object = " << objectName.data() << " from file = " << inputFile.GetName() << " !!\n";
+    if (!object)
+      throw cms::Exception("PATTauDiscriminantCutMultiplexer::loadObjectFromFile")
+          << " Failed to load Object = " << objectName.data() << " from file = " << inputFile.GetName() << " !!\n";
     //Need to use TObject::Clone since the type T might be a base class
-    return std::unique_ptr<const T>{ static_cast<T*>(object->Clone()) };
+    return std::unique_ptr<const T>{static_cast<T*>(object->Clone())};
   }
-	
-  std::unique_ptr<const TGraph> loadTGraphFromDB(const edm::EventSetup& es, const std::string& graphName, const int& verbosity_ = 0)
-  {
-    if(verbosity_){
+
+  std::unique_ptr<const TGraph> loadTGraphFromDB(const edm::EventSetup& es,
+                                                 const std::string& graphName,
+                                                 const int& verbosity_ = 0) {
+    if (verbosity_) {
       std::cout << "<loadTGraphFromDB>:" << std::endl;
       std::cout << " graphName = " << graphName << std::endl;
     }
     edm::ESHandle<PhysicsTGraphPayload> graphPayload;
     es.get<PhysicsTGraphPayloadRcd>().get(graphName, graphPayload);
-    return std::unique_ptr<const TGraph>{ new TGraph(*graphPayload.product()) };
-  }  
-	
-  std::unique_ptr<TFormula> loadTFormulaFromDB(const edm::EventSetup& es, const std::string& formulaName, const TString& newName, const int& verbosity_ = 0)
-  {
-    if(verbosity_){
+    return std::unique_ptr<const TGraph>{new TGraph(*graphPayload.product())};
+  }
+
+  std::unique_ptr<TFormula> loadTFormulaFromDB(const edm::EventSetup& es,
+                                               const std::string& formulaName,
+                                               const TString& newName,
+                                               const int& verbosity_ = 0) {
+    if (verbosity_) {
       std::cout << "<loadTFormulaFromDB>:" << std::endl;
       std::cout << " formulaName = " << formulaName << std::endl;
     }
     edm::ESHandle<PhysicsTFormulaPayload> formulaPayload;
     es.get<PhysicsTFormulaPayloadRcd>().get(formulaName, formulaPayload);
-	
-    if ( formulaPayload->formulas().size() == 1 && formulaPayload->limits().size() == 1 ) {
-      return std::unique_ptr<TFormula> {new TFormula(newName, formulaPayload->formulas().at(0).data()) };
+
+    if (formulaPayload->formulas().size() == 1 && formulaPayload->limits().size() == 1) {
+      return std::unique_ptr<TFormula>{new TFormula(newName, formulaPayload->formulas().at(0).data())};
     } else {
-      throw cms::Exception("PATTauDiscriminantCutMultiplexer::loadTFormulaFromDB") 
-	<< "Failed to load TFormula = " << formulaName << " from Database !!\n";
+      throw cms::Exception("PATTauDiscriminantCutMultiplexer::loadTFormulaFromDB")
+          << "Failed to load TFormula = " << formulaName << " from Database !!\n";
     }
     return std::unique_ptr<TFormula>{};
-  } 
-}
+  }
+}  // namespace
 
 PATTauDiscriminantCutMultiplexer::PATTauDiscriminantCutMultiplexer(const edm::ParameterSet& cfg)
-  : PATTauDiscriminationProducerBase(cfg),
-    moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-    mvaOutput_normalization_(),
-    isInitialized_(false)
-{
-  
+    : PATTauDiscriminationProducerBase(cfg),
+      moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+      mvaOutput_normalization_(),
+      isInitialized_(false) {
   toMultiplex_ = cfg.getParameter<edm::InputTag>("toMultiplex");
   toMultiplex_token = consumes<pat::PATTauDiscriminator>(toMultiplex_);
   key_ = cfg.getParameter<edm::InputTag>("key");
@@ -151,70 +144,71 @@ PATTauDiscriminantCutMultiplexer::PATTauDiscriminantCutMultiplexer(const edm::Pa
 
   verbosity_ = cfg.getParameter<int>("verbosity");
   loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
-  if ( !loadMVAfromDB_ ) {
-      inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
+  if (!loadMVAfromDB_) {
+    inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
   }
-  if(verbosity_)  std::cout << moduleLabel_ << " loadMVA = " << loadMVAfromDB_ << std::endl;
-  mvaOutputNormalizationName_ = cfg.getParameter<std::string>("mvaOutput_normalization");  // default value is "" which should just overwrite existing value with same empty string
+  if (verbosity_)
+    std::cout << moduleLabel_ << " loadMVA = " << loadMVAfromDB_ << std::endl;
+  mvaOutputNormalizationName_ = cfg.getParameter<std::string>(
+      "mvaOutput_normalization");  // default value is "" which should just overwrite existing value with same empty string
 
   // Setup our cut map
   typedef std::vector<edm::ParameterSet> VPSet;
   VPSet mapping = cfg.getParameter<VPSet>("mapping");
-  for ( VPSet::const_iterator mappingEntry = mapping.begin();
-	mappingEntry != mapping.end(); ++mappingEntry ) {
+  for (VPSet::const_iterator mappingEntry = mapping.begin(); mappingEntry != mapping.end(); ++mappingEntry) {
     unsigned category = mappingEntry->getParameter<uint32_t>("category");
     std::unique_ptr<DiscriminantCutEntry> cut{new DiscriminantCutEntry()};
-    if ( mappingEntry->existsAs<double>("cut") ) {
+    if (mappingEntry->existsAs<double>("cut")) {
       cut->cutValue_ = mappingEntry->getParameter<double>("cut");
       cut->mode_ = DiscriminantCutEntry::kFixedCut;
-    } else if ( mappingEntry->existsAs<std::string>("cut") ) {
+    } else if (mappingEntry->existsAs<std::string>("cut")) {
       cut->cutName_ = mappingEntry->getParameter<std::string>("cut");
       std::string cutVariable_string = mappingEntry->getParameter<std::string>("variable");
-      cut->cutVariable_.reset( new StringObjectFunction<pat::Tau>(cutVariable_string) );
+      cut->cutVariable_.reset(new StringObjectFunction<pat::Tau>(cutVariable_string));
       cut->mode_ = DiscriminantCutEntry::kVariableCut;
     } else {
-      throw cms::Exception("PATTauDiscriminantCutMultiplexer") 
-        << " Undefined Configuration Parameter 'cut' !!\n";
+      throw cms::Exception("PATTauDiscriminantCutMultiplexer") << " Undefined Configuration Parameter 'cut' !!\n";
     }
     cuts_[category] = std::move(cut);
   }
   verbosity_ = cfg.getParameter<int>("verbosity");
-  if(verbosity_) std::cout << "constructed " << moduleLabel_ << std::endl;
+  if (verbosity_)
+    std::cout << "constructed " << moduleLabel_ << std::endl;
 }
 
-PATTauDiscriminantCutMultiplexer::~PATTauDiscriminantCutMultiplexer()
-{
-}
+PATTauDiscriminantCutMultiplexer::~PATTauDiscriminantCutMultiplexer() {}
 
-void PATTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const edm::EventSetup& es) 
-{
-  if(verbosity_) std::cout << " begin! " << moduleLabel_ << " " << isInitialized_ << std::endl;
-  if ( !isInitialized_ ) {
+void PATTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
+  if (verbosity_)
+    std::cout << " begin! " << moduleLabel_ << " " << isInitialized_ << std::endl;
+  if (!isInitialized_) {
     //Only open the file once and we can close it when this routine is done
     // since all objects gotten from the file will have been copied
     std::unique_ptr<TFile> inputFile;
-    if ( !mvaOutputNormalizationName_.empty() ) {
-      if ( !loadMVAfromDB_ ) {
-	inputFile = openInputFile(inputFileName_);
-	mvaOutput_normalization_ = loadObjectFromFile<TFormula>(*inputFile, mvaOutputNormalizationName_);
+    if (!mvaOutputNormalizationName_.empty()) {
+      if (!loadMVAfromDB_) {
+        inputFile = openInputFile(inputFileName_);
+        mvaOutput_normalization_ = loadObjectFromFile<TFormula>(*inputFile, mvaOutputNormalizationName_);
       } else {
-	auto temp = loadTFormulaFromDB(es, mvaOutputNormalizationName_, Form("%s_mvaOutput_normalization", moduleLabel_.data()), verbosity_);
-	mvaOutput_normalization_ = std::move(temp);
+        auto temp = loadTFormulaFromDB(
+            es, mvaOutputNormalizationName_, Form("%s_mvaOutput_normalization", moduleLabel_.data()), verbosity_);
+        mvaOutput_normalization_ = std::move(temp);
       }
     }
-    for ( DiscriminantCutMap::iterator cut = cuts_.begin();
-	  cut != cuts_.end(); ++cut ) {
-      if ( cut->second->mode_ == DiscriminantCutEntry::kVariableCut ) {
-	if ( !loadMVAfromDB_ ) {
-	  if(not inputFile) {
-	    inputFile = openInputFile(inputFileName_);
-	  }
-	  if(verbosity_) std::cout << "Loading from file" << inputFileName_ << std::endl;
-	  cut->second->cutFunction_ = loadObjectFromFile<TGraph>(*inputFile, cut->second->cutName_);
-	} else {
-	  if(verbosity_) std::cout << "Loading from DB" << std::endl;
-	  cut->second->cutFunction_ = loadTGraphFromDB(es, cut->second->cutName_, verbosity_);
-	}
+    for (DiscriminantCutMap::iterator cut = cuts_.begin(); cut != cuts_.end(); ++cut) {
+      if (cut->second->mode_ == DiscriminantCutEntry::kVariableCut) {
+        if (!loadMVAfromDB_) {
+          if (not inputFile) {
+            inputFile = openInputFile(inputFileName_);
+          }
+          if (verbosity_)
+            std::cout << "Loading from file" << inputFileName_ << std::endl;
+          cut->second->cutFunction_ = loadObjectFromFile<TGraph>(*inputFile, cut->second->cutName_);
+        } else {
+          if (verbosity_)
+            std::cout << "Loading from DB" << std::endl;
+          cut->second->cutFunction_ = loadTGraphFromDB(es, cut->second->cutName_, verbosity_);
+        }
       }
     }
     isInitialized_ = true;
@@ -224,61 +218,62 @@ void PATTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const e
   evt.getByToken(key_token, keyHandle_);
 }
 
-double
-PATTauDiscriminantCutMultiplexer::discriminate(const pat::TauRef& tau) const
-{
-  if ( verbosity_ ) {
+double PATTauDiscriminantCutMultiplexer::discriminate(const pat::TauRef& tau) const {
+  if (verbosity_) {
     std::cout << "<PATTauDiscriminantCutMultiplexer::discriminate>:" << std::endl;
     std::cout << " moduleLabel = " << moduleLabel_ << std::endl;
   }
 
   double disc_result = (*toMultiplexHandle_)[tau];
-  if ( verbosity_ ) {
-    std::cout << "disc_result = " <<  disc_result << std::endl;
+  if (verbosity_) {
+    std::cout << "disc_result = " << disc_result << std::endl;
   }
-  if ( mvaOutput_normalization_ ) {
+  if (mvaOutput_normalization_) {
     disc_result = mvaOutput_normalization_->Eval(disc_result);
     //if ( disc_result > 1. ) disc_result = 1.;
     //if ( disc_result < 0. ) disc_result = 0.;
-    if ( verbosity_ ) {
-      std::cout << "disc_result (normalized) = " <<  disc_result << std::endl;
+    if (verbosity_) {
+      std::cout << "disc_result (normalized) = " << disc_result << std::endl;
     }
   }
   double key_result = (*keyHandle_)[tau];
   DiscriminantCutMap::const_iterator cutIter = cuts_.find(TMath::Nint(key_result));
 
-  
   // Return null if it doesn't exist
-  if ( cutIter == cuts_.end() ) {
+  if (cutIter == cuts_.end()) {
     return prediscriminantFailValue_;
   }
   // See if the discriminator passes our cuts
   bool passesCuts = false;
-  if ( cutIter->second->mode_ == DiscriminantCutEntry::kFixedCut ) {
+  if (cutIter->second->mode_ == DiscriminantCutEntry::kFixedCut) {
     passesCuts = (disc_result > cutIter->second->cutValue_);
-    if ( verbosity_ ) {
-      std::cout << "cutValue (fixed) = " << cutIter->second->cutValue_ << " --> passesCuts = " << passesCuts << std::endl;
+    if (verbosity_) {
+      std::cout << "cutValue (fixed) = " << cutIter->second->cutValue_ << " --> passesCuts = " << passesCuts
+                << std::endl;
     }
-  } else if ( cutIter->second->mode_ == DiscriminantCutEntry::kVariableCut ) {
+  } else if (cutIter->second->mode_ == DiscriminantCutEntry::kVariableCut) {
     double cutVariable = (*cutIter->second->cutVariable_)(*tau);
     double xMin, xMax, dummy;
     cutIter->second->cutFunction_->GetPoint(0, xMin, dummy);
     cutIter->second->cutFunction_->GetPoint(cutIter->second->cutFunction_->GetN() - 1, xMax, dummy);
     const double epsilon = 1.e-3;
-    if      ( cutVariable < (xMin + epsilon) ) cutVariable = xMin + epsilon;
-    else if ( cutVariable > (xMax - epsilon) ) cutVariable = xMax - epsilon;
+    if (cutVariable < (xMin + epsilon))
+      cutVariable = xMin + epsilon;
+    else if (cutVariable > (xMax - epsilon))
+      cutVariable = xMax - epsilon;
     double cutValue = cutIter->second->cutFunction_->Eval(cutVariable);
     passesCuts = (disc_result > cutValue);
-    if ( verbosity_ ) {
-      std::cout << "cutValue (@" << cutVariable << ") = " << cutValue << " --> passesCuts = " << passesCuts << std::endl;
+    if (verbosity_) {
+      std::cout << "cutValue (@" << cutVariable << ") = " << cutValue << " --> passesCuts = " << passesCuts
+                << std::endl;
     }
-  } else assert(0);
+  } else
+    assert(0);
 
   return passesCuts;
 }
 
-void
-PATTauDiscriminantCutMultiplexer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PATTauDiscriminantCutMultiplexer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // patTauDiscriminantCutMultiplexer
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("toMultiplex", edm::InputTag("fixme"));
@@ -286,7 +281,7 @@ PATTauDiscriminantCutMultiplexer::fillDescriptions(edm::ConfigurationDescription
   {
     edm::ParameterSetDescription desc_mapping;
     desc_mapping.add<unsigned int>("category");
-    desc_mapping.setAllowAnything(); //option cut can be double or (string plus additional option variable)
+    desc_mapping.setAllowAnything();  //option cut can be double or (string plus additional option variable)
 
     std::vector<edm::ParameterSet> vpsd_mapping;
     edm::ParameterSet psd1;
@@ -301,7 +296,7 @@ PATTauDiscriminantCutMultiplexer::fillDescriptions(edm::ConfigurationDescription
   }
   desc.add<edm::FileInPath>("inputFileName", edm::FileInPath("RecoTauTag/RecoTau/data/emptyMVAinputFile"));
   desc.add<bool>("loadMVAfromDB", true);
-  fillProducerDescriptions(desc); // inherited from the base
+  fillProducerDescriptions(desc);  // inherited from the base
   desc.add<std::string>("mvaOutput_normalization", "");
   desc.add<edm::InputTag>("key", edm::InputTag("fixme"));
   descriptions.add("patTauDiscriminantCutMultiplexer", desc);

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationAgainstElectronMVA6.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationAgainstElectronMVA6.cc
@@ -24,14 +24,10 @@
 
 using namespace pat;
 
-class PATTauDiscriminationAgainstElectronMVA6 : public PATTauDiscriminationProducerBase  
-{
- public:
+class PATTauDiscriminationAgainstElectronMVA6 : public PATTauDiscriminationProducerBase {
+public:
   explicit PATTauDiscriminationAgainstElectronMVA6(const edm::ParameterSet& cfg)
-    : PATTauDiscriminationProducerBase(cfg),
-      mva_(),
-      category_output_()
-  {
+      : PATTauDiscriminationProducerBase(cfg), mva_(), category_output_() {
     mva_ = std::make_unique<AntiElectronIDMVA6>(cfg);
 
     srcElectrons = cfg.getParameter<edm::InputTag>("srcElectrons");
@@ -49,15 +45,16 @@ class PATTauDiscriminationAgainstElectronMVA6 : public PATTauDiscriminationProdu
 
   void endEvent(edm::Event&) override;
 
-  ~PATTauDiscriminationAgainstElectronMVA6() override{}
+  ~PATTauDiscriminationAgainstElectronMVA6() override {}
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 private:
   bool isInEcalCrack(double) const;
 
   std::string moduleLabel_;
   std::unique_ptr<AntiElectronIDMVA6> mva_;
-  
+
   edm::InputTag srcElectrons;
   edm::EDGetTokenT<pat::ElectronCollection> electronToken;
   edm::Handle<pat::ElectronCollection> Electrons;
@@ -70,8 +67,7 @@ private:
   int verbosity_;
 };
 
-void PATTauDiscriminationAgainstElectronMVA6::beginEvent(const edm::Event& evt, const edm::EventSetup& es)
-{
+void PATTauDiscriminationAgainstElectronMVA6::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
   mva_->beginEvent(evt, es);
 
   evt.getByToken(Tau_token, taus_);
@@ -80,105 +76,107 @@ void PATTauDiscriminationAgainstElectronMVA6::beginEvent(const edm::Event& evt, 
   evt.getByToken(electronToken, Electrons);
 }
 
-double PATTauDiscriminationAgainstElectronMVA6::discriminate(const TauRef& theTauRef) const
-{
+double PATTauDiscriminationAgainstElectronMVA6::discriminate(const TauRef& theTauRef) const {
   double mvaValue = 1.;
   double category = -1.;
   bool isGsfElectronMatched = false;
   float deltaRDummy = 9.9;
   const float ECALBarrelEndcapEtaBorder = 1.479;
-  float tauEtaAtEcalEntrance = theTauRef->etaAtEcalEntrance();  
+  float tauEtaAtEcalEntrance = theTauRef->etaAtEcalEntrance();
   float leadChargedPFCandEtaAtEcalEntrance = theTauRef->etaAtEcalEntranceLeadChargedCand();
-      
-  if( (*theTauRef).leadChargedHadrCand().isNonnull()) {
+
+  if ((*theTauRef).leadChargedHadrCand().isNonnull()) {
     int numSignalPFGammaCandsInSigCone = 0;
     const reco::CandidatePtrVector signalGammaCands = theTauRef->signalGammaCands();
-    for ( const auto & gamma : signalGammaCands ) {
+    for (const auto& gamma : signalGammaCands) {
       double dR = deltaR(gamma->p4(), theTauRef->leadChargedHadrCand()->p4());
-      double signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, theTauRef->pt())));      
+      double signalrad = std::max(0.05, std::min(0.10, 3.0 / std::max(1.0, theTauRef->pt())));
       // gammas inside the tau signal cone
       if (dR < signalrad) {
         numSignalPFGammaCandsInSigCone += 1;
       }
     }
     // loop over the electrons
-    for ( const auto & theElectron : *Electrons ) {
-      if ( theElectron.pt() > 10. ) { // CV: only take electrons above some minimal energy/Pt into account...	
-	double deltaREleTau = deltaR(theElectron.p4(), theTauRef->p4());
-	deltaRDummy = deltaREleTau;
-	if( deltaREleTau < 0.3 ){ 	
-	  double mva_match = mva_->MVAValue(*theTauRef, theElectron);
-	  bool hasGsfTrack = false;
-          pat::PackedCandidate const* packedLeadTauCand = dynamic_cast<pat::PackedCandidate const*>(theTauRef->leadChargedHadrCand().get());
-          if( abs(packedLeadTauCand->pdgId()) == 11 ) 
-	    hasGsfTrack = true;
-	  if ( !hasGsfTrack )
+    for (const auto& theElectron : *Electrons) {
+      if (theElectron.pt() > 10.) {  // CV: only take electrons above some minimal energy/Pt into account...
+        double deltaREleTau = deltaR(theElectron.p4(), theTauRef->p4());
+        deltaRDummy = deltaREleTau;
+        if (deltaREleTau < 0.3) {
+          double mva_match = mva_->MVAValue(*theTauRef, theElectron);
+          bool hasGsfTrack = false;
+          pat::PackedCandidate const* packedLeadTauCand =
+              dynamic_cast<pat::PackedCandidate const*>(theTauRef->leadChargedHadrCand().get());
+          if (abs(packedLeadTauCand->pdgId()) == 11)
+            hasGsfTrack = true;
+          if (!hasGsfTrack)
             hasGsfTrack = theElectron.gsfTrack().isNonnull();
 
-	  // veto taus that go to Ecal crack
-	  if ( vetoEcalCracks_ && (isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance)) ) {
-	    // add category index
-	    category_output_->setValue(tauIndex_, category);
-	    // return MVA output value
-	    return -99;
-	  }
-	  // Veto taus that go to Ecal crack
-	  if( std::abs(tauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder ){ // Barrel
-	    if( numSignalPFGammaCandsInSigCone == 0 && hasGsfTrack ){
-	      category = 5.;
-	    }
-	    else if ( numSignalPFGammaCandsInSigCone >= 1 && hasGsfTrack ) {
-	      category = 7.;
-	    }
-	  } else { // Endcap
-	    if ( numSignalPFGammaCandsInSigCone == 0 && hasGsfTrack ) {
-	      category = 13.;
-	    }
-	    else if ( numSignalPFGammaCandsInSigCone >= 1 && hasGsfTrack ) {
-	      category = 15.;
-	    }
-	  }
-	  mvaValue = std::min(mvaValue, mva_match);
-	  isGsfElectronMatched = true;	
-	 } // deltaR < 0.3
-       } // electron pt > 10
-     } // end of loop over electrons
+          // veto taus that go to Ecal crack
+          if (vetoEcalCracks_ &&
+              (isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance))) {
+            // add category index
+            category_output_->setValue(tauIndex_, category);
+            // return MVA output value
+            return -99;
+          }
+          // Veto taus that go to Ecal crack
+          if (std::abs(tauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder) {  // Barrel
+            if (numSignalPFGammaCandsInSigCone == 0 && hasGsfTrack) {
+              category = 5.;
+            } else if (numSignalPFGammaCandsInSigCone >= 1 && hasGsfTrack) {
+              category = 7.;
+            }
+          } else {  // Endcap
+            if (numSignalPFGammaCandsInSigCone == 0 && hasGsfTrack) {
+              category = 13.;
+            } else if (numSignalPFGammaCandsInSigCone >= 1 && hasGsfTrack) {
+              category = 15.;
+            }
+          }
+          mvaValue = std::min(mvaValue, mva_match);
+          isGsfElectronMatched = true;
+        }  // deltaR < 0.3
+      }    // electron pt > 10
+    }      // end of loop over electrons
 
-    if ( !isGsfElectronMatched ) {
+    if (!isGsfElectronMatched) {
       mvaValue = mva_->MVAValue(*theTauRef);
       bool hasGsfTrack = false;
-      pat::PackedCandidate const* packedLeadTauCand = dynamic_cast<pat::PackedCandidate const*>(theTauRef->leadChargedHadrCand().get());
-      if( abs(packedLeadTauCand->pdgId()) == 11 ) hasGsfTrack = true;
-          
+      pat::PackedCandidate const* packedLeadTauCand =
+          dynamic_cast<pat::PackedCandidate const*>(theTauRef->leadChargedHadrCand().get());
+      if (abs(packedLeadTauCand->pdgId()) == 11)
+        hasGsfTrack = true;
+
       // veto taus that go to Ecal crack
-      if (  vetoEcalCracks_ && (isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance)) ) {
-	// add category index
-	category_output_->setValue(tauIndex_, category);
-	// return MVA output value
-	return -99;
+      if (vetoEcalCracks_ &&
+          (isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance))) {
+        // add category index
+        category_output_->setValue(tauIndex_, category);
+        // return MVA output value
+        return -99;
       }
-      // veto taus that go to Ecal crack     
-      if( std::abs(tauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder ){ // Barrel
-	if( numSignalPFGammaCandsInSigCone == 0 && !hasGsfTrack ){
-	  category = 0.;
-	}
-	else if ( numSignalPFGammaCandsInSigCone >= 1 && !hasGsfTrack ) {
-	  category = 2.;
-	}
-      } else { // Endcap
-	if ( numSignalPFGammaCandsInSigCone == 0 && !hasGsfTrack ) {
-	  category = 8.;
-	}
-	else if ( numSignalPFGammaCandsInSigCone >= 1 && !hasGsfTrack ) {
-	  category = 10.;
-	}
+      // veto taus that go to Ecal crack
+      if (std::abs(tauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder) {  // Barrel
+        if (numSignalPFGammaCandsInSigCone == 0 && !hasGsfTrack) {
+          category = 0.;
+        } else if (numSignalPFGammaCandsInSigCone >= 1 && !hasGsfTrack) {
+          category = 2.;
+        }
+      } else {  // Endcap
+        if (numSignalPFGammaCandsInSigCone == 0 && !hasGsfTrack) {
+          category = 8.;
+        } else if (numSignalPFGammaCandsInSigCone >= 1 && !hasGsfTrack) {
+          category = 10.;
+        }
       }
     }
   }
-  if ( verbosity_ ) {
-    edm::LogPrint("PATTauAgainstEleMVA6") << "<PATTauDiscriminationAgainstElectronMVA6::discriminate>:" ;
-    edm::LogPrint("PATTauAgainstEleMVA6") << " tau: Pt = " << theTauRef->pt() << ", eta = " << theTauRef->eta() << ", phi = " << theTauRef->phi();
-    edm::LogPrint("PATTauAgainstEleMVA6") << " deltaREleTau = " << deltaRDummy << ", isGsfElectronMatched = " << isGsfElectronMatched;
+  if (verbosity_) {
+    edm::LogPrint("PATTauAgainstEleMVA6") << "<PATTauDiscriminationAgainstElectronMVA6::discriminate>:";
+    edm::LogPrint("PATTauAgainstEleMVA6")
+        << " tau: Pt = " << theTauRef->pt() << ", eta = " << theTauRef->eta() << ", phi = " << theTauRef->phi();
+    edm::LogPrint("PATTauAgainstEleMVA6")
+        << " deltaREleTau = " << deltaRDummy << ", isGsfElectronMatched = " << isGsfElectronMatched;
     edm::LogPrint("PATTauAgainstEleMVA6") << " #Prongs = " << theTauRef->signalChargedHadrCands().size();
     edm::LogPrint("PATTauAgainstEleMVA6") << " MVA = " << mvaValue << ", category = " << category;
   }
@@ -188,21 +186,17 @@ double PATTauDiscriminationAgainstElectronMVA6::discriminate(const TauRef& theTa
   return mvaValue;
 }
 
-void PATTauDiscriminationAgainstElectronMVA6::endEvent(edm::Event& evt)
-{
+void PATTauDiscriminationAgainstElectronMVA6::endEvent(edm::Event& evt) {
   // add all category indices to event
   evt.put(std::move(category_output_), "category");
 }
 
-bool
-PATTauDiscriminationAgainstElectronMVA6::isInEcalCrack(double eta) const
-{
+bool PATTauDiscriminationAgainstElectronMVA6::isInEcalCrack(double eta) const {
   double absEta = fabs(eta);
   return (absEta > 1.460 && absEta < 1.558);
 }
 
-void
-PATTauDiscriminationAgainstElectronMVA6::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PATTauDiscriminationAgainstElectronMVA6::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // patTauDiscriminationAgainstElectronMVA6
   edm::ParameterSetDescription desc;
   desc.add<double>("minMVANoEleMatchWOgWOgsfBL", 0.0);

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
@@ -45,192 +45,212 @@
 
 using namespace pat;
 
-namespace
-{
-  const GBRForest* loadMVAfromFile(const edm::FileInPath& inputFileName, const std::string& mvaName, std::vector<TFile*>& inputFilesToDelete)
-  {
-    if ( inputFileName.location() == edm::FileInPath::Unknown ) throw cms::Exception("PATTauDiscriminationByIsolationMVARun2::loadMVA")
-      << " Failed to find File = " << inputFileName << " !!\n"; 
+namespace {
+  const GBRForest* loadMVAfromFile(const edm::FileInPath& inputFileName,
+                                   const std::string& mvaName,
+                                   std::vector<TFile*>& inputFilesToDelete) {
+    if (inputFileName.location() == edm::FileInPath::Unknown)
+      throw cms::Exception("PATTauDiscriminationByIsolationMVARun2::loadMVA")
+          << " Failed to find File = " << inputFileName << " !!\n";
     TFile* inputFile = new TFile(inputFileName.fullPath().data());
-	
+
     //const GBRForest* mva = dynamic_cast<GBRForest*>(inputFile->Get(mvaName.data())); // CV: dynamic_cast<GBRForest*> fails for some reason ?!
     const GBRForest* mva = (GBRForest*)inputFile->Get(mvaName.data());
-    if ( !mva )
+    if (!mva)
       throw cms::Exception("PATTauDiscriminationByIsolationMVARun2::loadMVA")
-        << " Failed to load MVA = " << mvaName.data() << " from file = " << inputFileName.fullPath().data() << " !!\n";
-	
-     inputFilesToDelete.push_back(inputFile);
-	  
-     return mva;
+          << " Failed to load MVA = " << mvaName.data() << " from file = " << inputFileName.fullPath().data()
+          << " !!\n";
+
+    inputFilesToDelete.push_back(inputFile);
+
+    return mva;
   }
-	
-  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName)
-  {
+
+  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName) {
     edm::ESHandle<GBRForest> mva;
     es.get<GBRWrapperRcd>().get(mvaName, mva);
     return mva.product();
   }
-}
+}  // namespace
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class PATTauDiscriminationByMVAIsolationRun2 : public PATTauDiscriminationProducerBase
-{
-  public:
-    explicit PATTauDiscriminationByMVAIsolationRun2(const edm::ParameterSet& cfg)
-      : PATTauDiscriminationProducerBase(cfg),
-        moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-	mvaReader_(nullptr),
-	mvaInput_(nullptr),
-	category_output_()
-    {
-       mvaName_ = cfg.getParameter<std::string>("mvaName");
-       loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
-       if ( !loadMVAfromDB_ ) {
-	   inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
-       }
-       std::string mvaOpt_string = cfg.getParameter<std::string>("mvaOpt");
-       if      ( mvaOpt_string == "oldDMwoLT" ) mvaOpt_ = kOldDMwoLT;
-       else if ( mvaOpt_string == "oldDMwLT"  ) mvaOpt_ = kOldDMwLT;
-       else if ( mvaOpt_string == "newDMwoLT" ) mvaOpt_ = kNewDMwoLT;
-       else if ( mvaOpt_string == "newDMwLT"  ) mvaOpt_ = kNewDMwLT;
-       else if ( mvaOpt_string == "DBoldDMwLT"  ) mvaOpt_ = kDBoldDMwLT;
-       else if ( mvaOpt_string == "DBnewDMwLT"  ) mvaOpt_ = kDBnewDMwLT;
-       else if ( mvaOpt_string == "PWoldDMwLT"  ) mvaOpt_ = kPWoldDMwLT;
-       else if ( mvaOpt_string == "PWnewDMwLT"  ) mvaOpt_ = kPWnewDMwLT;
-       else if ( mvaOpt_string == "DBoldDMwLTwGJ" ) mvaOpt_ = kDBoldDMwLTwGJ;
-       else if ( mvaOpt_string == "DBnewDMwLTwGJ" ) mvaOpt_ = kDBnewDMwLTwGJ;
-       else throw cms::Exception("PATTauDiscriminationByMVAIsolationRun2")
-         << " Invalid Configuration Parameter 'mvaOpt' = " << mvaOpt_string << " !!\n";
-		    
-       if      ( mvaOpt_ == kOldDMwoLT || mvaOpt_ == kNewDMwoLT ) mvaInput_ = new float[6];
-       else if ( mvaOpt_ == kOldDMwLT  || mvaOpt_ == kNewDMwLT  ) mvaInput_ = new float[12];
-       else if ( mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT ||
-                 mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT ||
-                 mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ) mvaInput_ = new float[23];
-       else assert(0);
+    class PATTauDiscriminationByMVAIsolationRun2 : public PATTauDiscriminationProducerBase {
+    public:
+      explicit PATTauDiscriminationByMVAIsolationRun2(const edm::ParameterSet& cfg)
+          : PATTauDiscriminationProducerBase(cfg),
+            moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+            mvaReader_(nullptr),
+            mvaInput_(nullptr),
+            category_output_() {
+        mvaName_ = cfg.getParameter<std::string>("mvaName");
+        loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
+        if (!loadMVAfromDB_) {
+          inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
+        }
+        std::string mvaOpt_string = cfg.getParameter<std::string>("mvaOpt");
+        if (mvaOpt_string == "oldDMwoLT")
+          mvaOpt_ = kOldDMwoLT;
+        else if (mvaOpt_string == "oldDMwLT")
+          mvaOpt_ = kOldDMwLT;
+        else if (mvaOpt_string == "newDMwoLT")
+          mvaOpt_ = kNewDMwoLT;
+        else if (mvaOpt_string == "newDMwLT")
+          mvaOpt_ = kNewDMwLT;
+        else if (mvaOpt_string == "DBoldDMwLT")
+          mvaOpt_ = kDBoldDMwLT;
+        else if (mvaOpt_string == "DBnewDMwLT")
+          mvaOpt_ = kDBnewDMwLT;
+        else if (mvaOpt_string == "PWoldDMwLT")
+          mvaOpt_ = kPWoldDMwLT;
+        else if (mvaOpt_string == "PWnewDMwLT")
+          mvaOpt_ = kPWnewDMwLT;
+        else if (mvaOpt_string == "DBoldDMwLTwGJ")
+          mvaOpt_ = kDBoldDMwLTwGJ;
+        else if (mvaOpt_string == "DBnewDMwLTwGJ")
+          mvaOpt_ = kDBnewDMwLTwGJ;
+        else
+          throw cms::Exception("PATTauDiscriminationByMVAIsolationRun2")
+              << " Invalid Configuration Parameter 'mvaOpt' = " << mvaOpt_string << " !!\n";
 
-       chargedIsoPtSums_ = cfg.getParameter<std::string>("srcChargedIsoPtSum");
-       neutralIsoPtSums_ = cfg.getParameter<std::string>("srcNeutralIsoPtSum");
-       puCorrPtSums_ = cfg.getParameter<std::string>("srcPUcorrPtSum");
-       photonPtSumOutsideSignalCone_ = cfg.getParameter<std::string>("srcPhotonPtSumOutsideSignalCone");
-       footprintCorrection_ = cfg.getParameter<std::string>("srcFootprintCorrection");
-		  
-       verbosity_ = cfg.getParameter<int>("verbosity");
+        if (mvaOpt_ == kOldDMwoLT || mvaOpt_ == kNewDMwoLT)
+          mvaInput_ = new float[6];
+        else if (mvaOpt_ == kOldDMwLT || mvaOpt_ == kNewDMwLT)
+          mvaInput_ = new float[12];
+        else if (mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT || mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT ||
+                 mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ)
+          mvaInput_ = new float[23];
+        else
+          assert(0);
 
-       produces<pat::PATTauDiscriminator>("category");
-    }  
+        chargedIsoPtSums_ = cfg.getParameter<std::string>("srcChargedIsoPtSum");
+        neutralIsoPtSums_ = cfg.getParameter<std::string>("srcNeutralIsoPtSum");
+        puCorrPtSums_ = cfg.getParameter<std::string>("srcPUcorrPtSum");
+        photonPtSumOutsideSignalCone_ = cfg.getParameter<std::string>("srcPhotonPtSumOutsideSignalCone");
+        footprintCorrection_ = cfg.getParameter<std::string>("srcFootprintCorrection");
 
-    void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+        verbosity_ = cfg.getParameter<int>("verbosity");
 
-    double discriminate(const TauRef&) const override;
-
-    void endEvent(edm::Event&) override;
-
-    ~PATTauDiscriminationByMVAIsolationRun2() override
-    {
-      if(!loadMVAfromDB_) delete mvaReader_;
-      delete[] mvaInput_;
-      for ( std::vector<TFile*>::iterator it = inputFilesToDelete_.begin();
-	    it != inputFilesToDelete_.end(); ++it ) {
-        delete (*it);
+        produces<pat::PATTauDiscriminator>("category");
       }
+
+      void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+
+      double discriminate(const TauRef&) const override;
+
+      void endEvent(edm::Event&) override;
+
+      ~PATTauDiscriminationByMVAIsolationRun2() override {
+        if (!loadMVAfromDB_)
+          delete mvaReader_;
+        delete[] mvaInput_;
+        for (std::vector<TFile*>::iterator it = inputFilesToDelete_.begin(); it != inputFilesToDelete_.end(); ++it) {
+          delete (*it);
+        }
+      }
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    private:
+      std::string moduleLabel_;
+
+      std::string mvaName_;
+      bool loadMVAfromDB_;
+      edm::FileInPath inputFileName_;
+      const GBRForest* mvaReader_;
+      int mvaOpt_;
+      float* mvaInput_;
+
+      std::string chargedIsoPtSums_;
+      std::string neutralIsoPtSums_;
+      std::string puCorrPtSums_;
+      std::string photonPtSumOutsideSignalCone_;
+      std::string footprintCorrection_;
+
+      edm::Handle<TauCollection> taus_;
+      std::unique_ptr<pat::PATTauDiscriminator> category_output_;
+      std::vector<TFile*> inputFilesToDelete_;
+
+      int verbosity_;
+    };
+
+    void PATTauDiscriminationByMVAIsolationRun2::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
+      if (!mvaReader_) {
+        if (loadMVAfromDB_) {
+          mvaReader_ = loadMVAfromDB(es, mvaName_);
+        } else {
+          mvaReader_ = loadMVAfromFile(inputFileName_, mvaName_, inputFilesToDelete_);
+        }
+      }
+
+      evt.getByToken(Tau_token, taus_);
+      category_output_.reset(new pat::PATTauDiscriminator(TauRefProd(taus_)));
     }
 
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    double PATTauDiscriminationByMVAIsolationRun2::discriminate(const TauRef& tau) const {
+      // CV: define dummy category index in order to use RecoTauDiscriminantCutMultiplexer module to appy WP cuts
+      double category = 0.;
+      category_output_->setValue(tauIndex_, category);
 
-  private:
-		
-    std::string moduleLabel_;
-		
-    std::string mvaName_;
-    bool loadMVAfromDB_;
-    edm::FileInPath inputFileName_;
-    const GBRForest* mvaReader_;
-    int mvaOpt_;
-    float* mvaInput_;
+      // CV: computation of MVA value requires presence of leading charged hadron
+      if (tau->leadChargedHadrCand().isNull())
+        return 0.;
 
-    std::string chargedIsoPtSums_;
-    std::string neutralIsoPtSums_;
-    std::string puCorrPtSums_;
-    std::string photonPtSumOutsideSignalCone_;
-    std::string footprintCorrection_;
-		
-    edm::Handle<TauCollection> taus_;
-    std::unique_ptr<pat::PATTauDiscriminator> category_output_;		
-    std::vector<TFile*> inputFilesToDelete_;
-    	
-    int verbosity_;
-};
-
-void PATTauDiscriminationByMVAIsolationRun2::beginEvent(const edm::Event& evt, const edm::EventSetup& es)
-{
-  if( !mvaReader_ ) {
-    if ( loadMVAfromDB_ ) {
-      mvaReader_ = loadMVAfromDB(es, mvaName_);
-    } else {
-      mvaReader_ = loadMVAfromFile(inputFileName_, mvaName_, inputFilesToDelete_);
+      if (reco::tau::fillIsoMVARun2Inputs(mvaInput_,
+                                          *tau,
+                                          mvaOpt_,
+                                          chargedIsoPtSums_,
+                                          neutralIsoPtSums_,
+                                          puCorrPtSums_,
+                                          photonPtSumOutsideSignalCone_,
+                                          footprintCorrection_)) {
+        double mvaValue = mvaReader_->GetClassifier(mvaInput_);
+        if (verbosity_) {
+          edm::LogPrint("PATTauDiscByMVAIsolRun2") << "<PATTauDiscriminationByMVAIsolationRun2::discriminate>:";
+          edm::LogPrint("PATTauDiscByMVAIsolRun2") << " tau: Pt = " << tau->pt() << ", eta = " << tau->eta();
+          edm::LogPrint("PATTauDiscByMVAIsolRun2")
+              << " isolation: charged = " << tau->tauID(chargedIsoPtSums_)
+              << ", neutral = " << tau->tauID(neutralIsoPtSums_) << ", PUcorr = " << tau->tauID(puCorrPtSums_);
+          edm::LogPrint("PATTauDiscByMVAIsolRun2") << " decay mode = " << tau->decayMode();
+          edm::LogPrint("PATTauDiscByMVAIsolRun2")
+              << " impact parameter: distance = " << tau->dxy() << ", significance = " << tau->dxy_Sig();
+          edm::LogPrint("PATTauDiscByMVAIsolRun2") << " has decay vertex = " << tau->hasSecondaryVertex() << ":"
+                                                   << ", significance = " << tau->flightLengthSig();
+          edm::LogPrint("PATTauDiscByMVAIsolRun2") << "--> mvaValue = " << mvaValue;
+        }
+        return mvaValue;
+      }
+      return -1.;
     }
-  }
-	
-  evt.getByToken(Tau_token, taus_);
-  category_output_.reset(new pat::PATTauDiscriminator(TauRefProd(taus_)));
-}
 
-double PATTauDiscriminationByMVAIsolationRun2::discriminate(const TauRef& tau) const
-{
-  // CV: define dummy category index in order to use RecoTauDiscriminantCutMultiplexer module to appy WP cuts
-  double category = 0.; 
-  category_output_->setValue(tauIndex_, category);
-	
-  // CV: computation of MVA value requires presence of leading charged hadron
-  if ( tau->leadChargedHadrCand().isNull() ) return 0.;
-
-  if (reco::tau::fillIsoMVARun2Inputs(mvaInput_, *tau, mvaOpt_, chargedIsoPtSums_, neutralIsoPtSums_, puCorrPtSums_, photonPtSumOutsideSignalCone_, footprintCorrection_)) {
-    double mvaValue = mvaReader_->GetClassifier(mvaInput_);
-    if ( verbosity_ ) {
-      edm::LogPrint("PATTauDiscByMVAIsolRun2") << "<PATTauDiscriminationByMVAIsolationRun2::discriminate>:";
-      edm::LogPrint("PATTauDiscByMVAIsolRun2") << " tau: Pt = " << tau->pt() << ", eta = " << tau->eta();
-      edm::LogPrint("PATTauDiscByMVAIsolRun2") << " isolation: charged = " << tau->tauID(chargedIsoPtSums_) << ", neutral = " << tau->tauID(neutralIsoPtSums_) << ", PUcorr = " << tau->tauID(puCorrPtSums_);
-      edm::LogPrint("PATTauDiscByMVAIsolRun2") << " decay mode = " << tau->decayMode();
-      edm::LogPrint("PATTauDiscByMVAIsolRun2") << " impact parameter: distance = " << tau->dxy() << ", significance = " << tau->dxy_Sig();
-      edm::LogPrint("PATTauDiscByMVAIsolRun2") << " has decay vertex = " << tau->hasSecondaryVertex() << ":"
-                                               << ", significance = " << tau->flightLengthSig();
-      edm::LogPrint("PATTauDiscByMVAIsolRun2") << "--> mvaValue = " << mvaValue;
+    void PATTauDiscriminationByMVAIsolationRun2::endEvent(edm::Event& evt) {
+      // add all category indices to event
+      evt.put(std::move(category_output_), "category");
     }
-    return mvaValue;
-  } 
-  return -1.;
-}
 
-void PATTauDiscriminationByMVAIsolationRun2::endEvent(edm::Event& evt)
-{
-  // add all category indices to event
-  evt.put(std::move(category_output_), "category");
-}
+    void PATTauDiscriminationByMVAIsolationRun2::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      // patTauDiscriminationByMVAIsolationRun2
+      edm::ParameterSetDescription desc;
 
-void
-PATTauDiscriminationByMVAIsolationRun2::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  // patTauDiscriminationByMVAIsolationRun2
-  edm::ParameterSetDescription desc;
+      desc.add<std::string>("mvaName");
+      desc.add<bool>("loadMVAfromDB");
+      desc.addOptional<edm::FileInPath>("inputFileName");
+      desc.add<std::string>("mvaOpt");
 
-  desc.add<std::string>("mvaName");
-  desc.add<bool>("loadMVAfromDB");
-  desc.addOptional<edm::FileInPath>("inputFileName");
-  desc.add<std::string>("mvaOpt");
+      desc.add<std::string>("srcChargedIsoPtSum");
+      desc.add<std::string>("srcNeutralIsoPtSum");
+      desc.add<std::string>("srcPUcorrPtSum");
+      desc.add<std::string>("srcPhotonPtSumOutsideSignalCone");
+      desc.add<std::string>("srcFootprintCorrection");
+      desc.add<int>("verbosity", 0);
 
-  desc.add<std::string>("srcChargedIsoPtSum");
-  desc.add<std::string>("srcNeutralIsoPtSum");
-  desc.add<std::string>("srcPUcorrPtSum");
-  desc.add<std::string>("srcPhotonPtSumOutsideSignalCone");
-  desc.add<std::string>("srcFootprintCorrection");
-  desc.add<int>("verbosity", 0);
+      fillProducerDescriptions(desc);  // inherited from the base
 
-  fillProducerDescriptions(desc); // inherited from the base
+      descriptions.add("patTauDiscriminationByMVAIsolationRun2", desc);
+    }
 
-  descriptions.add("patTauDiscriminationByMVAIsolationRun2", desc);
-}
+    DEFINE_FWK_MODULE(PATTauDiscriminationByMVAIsolationRun2);
 
-DEFINE_FWK_MODULE(PATTauDiscriminationByMVAIsolationRun2);
-
-}} //namespace
+  }  // namespace tau
+}  // namespace reco

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
@@ -48,293 +48,316 @@
 #include <cmath>
 #include <algorithm>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-template<class TrackClass>
-class PFRecoTauChargedHadronFromGenericTrackPlugin : public PFRecoTauChargedHadronBuilderPlugin 
-{
- public:
-  explicit PFRecoTauChargedHadronFromGenericTrackPlugin(const edm::ParameterSet&, edm::ConsumesCollector && iC);
-  ~PFRecoTauChargedHadronFromGenericTrackPlugin() override;
-  // Return type is auto_ptr<ChargedHadronVector>
-  return_type operator()(const reco::Jet&) const override;
-  // Hook to update PV information
-  void beginEvent() override;
-  
- private:
-  bool filterTrack(const edm::Handle<std::vector<TrackClass> >&, size_t iTrack) const;
-  void setChargedHadronTrack(PFRecoTauChargedHadron& chargedHadron, const edm::Ptr<TrackClass>& track) const;
-  double getTrackPtError(const TrackClass& track) const;
-  XYZTLorentzVector getTrackPos(const TrackClass& track) const;
+    template <class TrackClass>
+    class PFRecoTauChargedHadronFromGenericTrackPlugin : public PFRecoTauChargedHadronBuilderPlugin {
+    public:
+      explicit PFRecoTauChargedHadronFromGenericTrackPlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+      ~PFRecoTauChargedHadronFromGenericTrackPlugin() override;
+      // Return type is auto_ptr<ChargedHadronVector>
+      return_type operator()(const reco::Jet&) const override;
+      // Hook to update PV information
+      void beginEvent() override;
 
-  RecoTauVertexAssociator vertexAssociator_;
+    private:
+      bool filterTrack(const edm::Handle<std::vector<TrackClass> >&, size_t iTrack) const;
+      void setChargedHadronTrack(PFRecoTauChargedHadron& chargedHadron, const edm::Ptr<TrackClass>& track) const;
+      double getTrackPtError(const TrackClass& track) const;
+      XYZTLorentzVector getTrackPos(const TrackClass& track) const;
 
-  RecoTauQualityCuts* qcuts_;
+      RecoTauVertexAssociator vertexAssociator_;
 
-  edm::InputTag srcTracks_;
-  edm::EDGetTokenT<std::vector<TrackClass> > Tracks_token;
-  double dRcone_;
-  bool dRconeLimitedToJetArea_;
+      RecoTauQualityCuts* qcuts_;
 
-  double dRmergeNeutralHadron_;
-  double dRmergePhoton_;
+      edm::InputTag srcTracks_;
+      edm::EDGetTokenT<std::vector<TrackClass> > Tracks_token;
+      double dRcone_;
+      bool dRconeLimitedToJetArea_;
 
-  math::XYZVector magneticFieldStrength_;
+      double dRmergeNeutralHadron_;
+      double dRmergePhoton_;
 
-  mutable int numWarnings_;
-  int maxWarnings_;
+      math::XYZVector magneticFieldStrength_;
 
-  int verbosity_;
-};
+      mutable int numWarnings_;
+      int maxWarnings_;
 
-template<class TrackClass>
-PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::PFRecoTauChargedHadronFromGenericTrackPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC)
-    : PFRecoTauChargedHadronBuilderPlugin(pset,std::move(iC)),
-      vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"),std::move(iC)),
-    qcuts_(nullptr)
-{
-  edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
-  qcuts_ = new RecoTauQualityCuts(qcuts_pset);
+      int verbosity_;
+    };
 
-  srcTracks_ = pset.getParameter<edm::InputTag>("srcTracks");
-  Tracks_token = iC.consumes<std::vector<TrackClass> >(srcTracks_);
-  dRcone_ = pset.getParameter<double>("dRcone");
-  dRconeLimitedToJetArea_ = pset.getParameter<bool>("dRconeLimitedToJetArea");
+    template <class TrackClass>
+    PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::PFRecoTauChargedHadronFromGenericTrackPlugin(
+        const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : PFRecoTauChargedHadronBuilderPlugin(pset, std::move(iC)),
+          vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)),
+          qcuts_(nullptr) {
+      edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
+      qcuts_ = new RecoTauQualityCuts(qcuts_pset);
 
-  dRmergeNeutralHadron_ = pset.getParameter<double>("dRmergeNeutralHadron");
-  dRmergePhoton_ = pset.getParameter<double>("dRmergePhoton");
+      srcTracks_ = pset.getParameter<edm::InputTag>("srcTracks");
+      Tracks_token = iC.consumes<std::vector<TrackClass> >(srcTracks_);
+      dRcone_ = pset.getParameter<double>("dRcone");
+      dRconeLimitedToJetArea_ = pset.getParameter<bool>("dRconeLimitedToJetArea");
 
-  numWarnings_ = 0;
-  maxWarnings_ = 3;
+      dRmergeNeutralHadron_ = pset.getParameter<double>("dRmergeNeutralHadron");
+      dRmergePhoton_ = pset.getParameter<double>("dRmergePhoton");
 
-  verbosity_ = pset.getParameter<int>("verbosity");
-}
+      numWarnings_ = 0;
+      maxWarnings_ = 3;
 
-template<class TrackClass>
-PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::~PFRecoTauChargedHadronFromGenericTrackPlugin()
-{
-  delete qcuts_;
-}
+      verbosity_ = pset.getParameter<int>("verbosity");
+    }
 
-// Update the primary vertex
-template<class TrackClass>
-void PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::beginEvent() 
-{
-  vertexAssociator_.setEvent(*this->evt());
+    template <class TrackClass>
+    PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::~PFRecoTauChargedHadronFromGenericTrackPlugin() {
+      delete qcuts_;
+    }
 
-  edm::ESHandle<MagneticField> magneticField;
-  const edm::EventSetup* evtSetup(this->evtSetup());
-  evtSetup->get<IdealMagneticFieldRecord>().get(magneticField);
-  magneticFieldStrength_ = magneticField->inTesla(GlobalPoint(0.,0.,0.));
-}
+    // Update the primary vertex
+    template <class TrackClass>
+    void PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::beginEvent() {
+      vertexAssociator_.setEvent(*this->evt());
 
-template<>
-bool PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track>::filterTrack(const edm::Handle<std::vector<reco::Track> >& tracks, size_t iTrack) const {
-// ignore tracks which fail quality cuts
-  reco::TrackRef trackRef(tracks, iTrack);
-  return qcuts_->filterTrack(trackRef);
-}
+      edm::ESHandle<MagneticField> magneticField;
+      const edm::EventSetup* evtSetup(this->evtSetup());
+      evtSetup->get<IdealMagneticFieldRecord>().get(magneticField);
+      magneticFieldStrength_ = magneticField->inTesla(GlobalPoint(0., 0., 0.));
+    }
 
-template<>
-bool PFRecoTauChargedHadronFromGenericTrackPlugin<pat::PackedCandidate>::filterTrack(const edm::Handle<std::vector<pat::PackedCandidate> >& tracks, size_t iTrack) const {
-  // ignore tracks which fail quality cuts
-  const pat::PackedCandidate& cand = (*tracks)[iTrack];
-  if (cand.charge() == 0)
-    return false;
+    template <>
+    bool PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track>::filterTrack(
+        const edm::Handle<std::vector<reco::Track> >& tracks, size_t iTrack) const {
+      // ignore tracks which fail quality cuts
+      reco::TrackRef trackRef(tracks, iTrack);
+      return qcuts_->filterTrack(trackRef);
+    }
 
-  return qcuts_->filterChargedCand(cand);
-}
+    template <>
+    bool PFRecoTauChargedHadronFromGenericTrackPlugin<pat::PackedCandidate>::filterTrack(
+        const edm::Handle<std::vector<pat::PackedCandidate> >& tracks, size_t iTrack) const {
+      // ignore tracks which fail quality cuts
+      const pat::PackedCandidate& cand = (*tracks)[iTrack];
+      if (cand.charge() == 0)
+        return false;
 
-template<>
-void PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track>::setChargedHadronTrack(PFRecoTauChargedHadron& chargedHadron, const edm::Ptr<reco::Track>& track) const {
-  chargedHadron.track_ = track;
-}
+      return qcuts_->filterChargedCand(cand);
+    }
 
-template<>
-void PFRecoTauChargedHadronFromGenericTrackPlugin<pat::PackedCandidate>::setChargedHadronTrack(PFRecoTauChargedHadron& chargedHadron, const edm::Ptr<pat::PackedCandidate>& track) const {
-  chargedHadron.lostTrackCandidate_ = track;
-}
+    template <>
+    void PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track>::setChargedHadronTrack(
+        PFRecoTauChargedHadron& chargedHadron, const edm::Ptr<reco::Track>& track) const {
+      chargedHadron.track_ = track;
+    }
 
-template<>
-double PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track>::getTrackPtError(const reco::Track& track) const {
-  return track.ptError();
-}
+    template <>
+    void PFRecoTauChargedHadronFromGenericTrackPlugin<pat::PackedCandidate>::setChargedHadronTrack(
+        PFRecoTauChargedHadron& chargedHadron, const edm::Ptr<pat::PackedCandidate>& track) const {
+      chargedHadron.lostTrackCandidate_ = track;
+    }
 
-template<>
-double PFRecoTauChargedHadronFromGenericTrackPlugin<pat::PackedCandidate>::getTrackPtError(const pat::PackedCandidate& cand) const {
-  double trackPtError = 0.06; // MB: Approximate avarage track PtError by 2.5% (barrel), 4% (transition), 6% (endcaps) lostTracks w/o detailed track information available (after TRK-11-001)
-  const reco::Track* track(cand.bestTrack());
-  if(track != nullptr) {
-    trackPtError = track->ptError();
-  } else {
-    if( std::abs(cand.eta()) < 0.9 )
-      trackPtError = 0.025;
-    else if( std::abs(cand.eta()) < 1.4 )
-      trackPtError = 0.04;
-  }
-  return trackPtError;
-}
+    template <>
+    double PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track>::getTrackPtError(const reco::Track& track) const {
+      return track.ptError();
+    }
 
-template<>
-XYZTLorentzVector PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track>::getTrackPos(const reco::Track& track) const {
-  return XYZTLorentzVector(track.referencePoint().x(), track.referencePoint().y(), track.referencePoint().z(), 0.);
-}
-
-template<>
-XYZTLorentzVector PFRecoTauChargedHadronFromGenericTrackPlugin<pat::PackedCandidate>::getTrackPos(const pat::PackedCandidate& track) const {
-  return XYZTLorentzVector(track.vertex().x(), track.vertex().y(), track.vertex().z(), 0.);
-}
-
-
-namespace
-{
-  struct Candidate_withDistance 
-  {
-    reco::CandidatePtr pfCandidate_;
-    double distance_;
-  };
-
-  bool isSmallerDistance(const Candidate_withDistance& cand1, const Candidate_withDistance& cand2)
-  {
-    return (cand1.distance_ < cand2.distance_);
-  }
-}
-
-template<class TrackClass>
-typename PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::return_type PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::operator()(const reco::Jet& jet) const 
-{
-  if ( verbosity_ ) {
-    edm::LogPrint("TauChHFromTrack") << "<PFRecoTauChargedHadronFromGenericTrackPlugin::operator()>:" ;
-    edm::LogPrint("TauChHFromTrack") << " pluginName = " << name() ;
-  }
-
-  ChargedHadronVector output;
-
-  const edm::Event& evt = (*this->evt());
-
-  edm::Handle<std::vector<TrackClass> > tracks;
-  evt.getByToken(Tracks_token, tracks);
-
-  qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
-  float jEta=jet.eta();
-  float jPhi=jet.phi();
-  size_t numTracks = tracks->size();
-  for ( size_t iTrack = 0; iTrack < numTracks; ++iTrack ) {
-    const TrackClass& track = (*tracks)[iTrack];
-
-    // consider tracks in vicinity of tau-jet candidate only
-    double dR = deltaR(track.eta(), track.phi(), jEta,jPhi);
-    double dRmatch = dRcone_;
-    if ( dRconeLimitedToJetArea_ ) {
-      double jetArea = jet.jetArea();
-      if ( jetArea > 0. ) {
-	dRmatch = std::min(dRmatch, sqrt(jetArea/M_PI));
+    template <>
+    double PFRecoTauChargedHadronFromGenericTrackPlugin<pat::PackedCandidate>::getTrackPtError(
+        const pat::PackedCandidate& cand) const {
+      double trackPtError =
+          0.06;  // MB: Approximate avarage track PtError by 2.5% (barrel), 4% (transition), 6% (endcaps) lostTracks w/o detailed track information available (after TRK-11-001)
+      const reco::Track* track(cand.bestTrack());
+      if (track != nullptr) {
+        trackPtError = track->ptError();
       } else {
-	if ( numWarnings_ < maxWarnings_ ) {
-	  edm::LogInfo("PFRecoTauChargedHadronFromGenericTrackPlugin::operator()") 
-	    << "Jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << " has area = " << jetArea << " !!" << std::endl;
-	  ++numWarnings_;
-	}
-	dRmatch = 0.1;
+        if (std::abs(cand.eta()) < 0.9)
+          trackPtError = 0.025;
+        else if (std::abs(cand.eta()) < 1.4)
+          trackPtError = 0.04;
       }
+      return trackPtError;
     }
-    if ( dR > dRmatch ) continue;
 
-    if (!this->filterTrack(tracks, iTrack)) continue;
+    template <>
+    XYZTLorentzVector PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track>::getTrackPos(
+        const reco::Track& track) const {
+      return XYZTLorentzVector(track.referencePoint().x(), track.referencePoint().y(), track.referencePoint().z(), 0.);
+    }
 
-    reco::Candidate::Charge trackCharge_int = 0;
-    if ( track.charge() > 0. ) trackCharge_int = +1;
-    else if ( track.charge() < 0. ) trackCharge_int = -1;
+    template <>
+    XYZTLorentzVector PFRecoTauChargedHadronFromGenericTrackPlugin<pat::PackedCandidate>::getTrackPos(
+        const pat::PackedCandidate& track) const {
+      return XYZTLorentzVector(track.vertex().x(), track.vertex().y(), track.vertex().z(), 0.);
+    }
 
-    const double chargedPionMass = 0.13957; // GeV
-    double chargedPionP  = track.p();
-    double chargedPionEn = TMath::Sqrt(chargedPionP*chargedPionP + chargedPionMass*chargedPionMass);
-    reco::Candidate::LorentzVector chargedPionP4(track.px(), track.py(), track.pz(), chargedPionEn);
+    namespace {
+      struct Candidate_withDistance {
+        reco::CandidatePtr pfCandidate_;
+        double distance_;
+      };
 
-    reco::Vertex::Point vtx(0.,0.,0.);
-    if ( vertexAssociator_.associatedVertex(jet).isNonnull() ) vtx = vertexAssociator_.associatedVertex(jet)->position();
-
-    std::auto_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(trackCharge_int, chargedPionP4, vtx, 0, true, PFRecoTauChargedHadron::kTrack));
-
-    setChargedHadronTrack(*chargedHadron, edm::Ptr<TrackClass>(tracks, iTrack));
-
-    // CV: Take code for propagating track to ECAL entrance 
-    //     from RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
-    //     to make sure propagation is done in the same way as for charged PFCandidates.
-    //     
-    //     The following replacements need to be made
-    //       outerMomentum -> momentum
-    //       outerPosition -> referencePoint
-    //     in order to run on AOD input
-    //    (outerMomentum and outerPosition require access to reco::TrackExtra objects, which are available in RECO only)
-    //
-    XYZTLorentzVector chargedPionPos(getTrackPos(track));
-    RawParticle p(chargedPionP4, chargedPionPos);
-    p.setCharge(track.charge());
-    BaseParticlePropagator trackPropagator(p, 0., 0., magneticFieldStrength_.z());
-    trackPropagator.propagateToEcalEntrance(false);
-    if ( trackPropagator.getSuccess() != 0 ) { 
-      chargedHadron->positionAtECALEntrance_ = trackPropagator.particle().vertex();
-    } else {
-      if ( chargedPionP4.pt() > 2. and std::abs(chargedPionP4.eta()) < 3. ) {
-	edm::LogWarning("PFRecoTauChargedHadronFromGenericTrackPlugin::operator()") 
-	  << "Failed to propagate track: Pt = " << track.pt() << ", eta = " << track.eta() << ", phi = " << track.phi() << " to ECAL entrance !!" << std::endl;
+      bool isSmallerDistance(const Candidate_withDistance& cand1, const Candidate_withDistance& cand2) {
+        return (cand1.distance_ < cand2.distance_);
       }
-      chargedHadron->positionAtECALEntrance_ = math::XYZPointF(0.,0.,0.);
-    }
+    }  // namespace
 
-    std::vector<Candidate_withDistance> neutralJetConstituents_withDistance;
-    for ( const auto& jetConstituent : jet.daughterPtrVector() ) {
-      int pdgId = jetConstituent->pdgId();
-      if ( !(pdgId == 130 || pdgId == 22) ) continue;
-      double dR = deltaR(atECALEntrance(&*jetConstituent, magneticFieldStrength_.z()), chargedHadron->positionAtECALEntrance_);
-      double dRmerge = -1.;      
-      if      ( pdgId == 130 ) dRmerge = dRmergeNeutralHadron_;
-      else if ( pdgId == 22 ) dRmerge = dRmergePhoton_;
-      if ( dR < dRmerge ) {
-	Candidate_withDistance jetConstituent_withDistance;
-	jetConstituent_withDistance.pfCandidate_ = jetConstituent;
-	jetConstituent_withDistance.distance_ = dR;
-	neutralJetConstituents_withDistance.push_back(jetConstituent_withDistance);
-	chargedHadron->addDaughter(jetConstituent);
+    template <class TrackClass>
+    typename PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::return_type
+    PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::operator()(const reco::Jet& jet) const {
+      if (verbosity_) {
+        edm::LogPrint("TauChHFromTrack") << "<PFRecoTauChargedHadronFromGenericTrackPlugin::operator()>:";
+        edm::LogPrint("TauChHFromTrack") << " pluginName = " << name();
       }
-    }
-    std::sort(neutralJetConstituents_withDistance.begin(), neutralJetConstituents_withDistance.end(), isSmallerDistance);
 
-    const double caloResolutionCoeff = 1.0; // CV: approximate ECAL + HCAL calorimeter resolution for hadrons by 100%*sqrt(E)
-    double resolutionTrackP = track.p()*(getTrackPtError(track)/track.pt());
-    double neutralEnSum = 0.;
-    for ( std::vector<Candidate_withDistance>::const_iterator nextNeutral = neutralJetConstituents_withDistance.begin();
-	  nextNeutral != neutralJetConstituents_withDistance.end(); ++nextNeutral ) {
-      double nextNeutralEn = nextNeutral->pfCandidate_->energy();      
-      double resolutionCaloEn = caloResolutionCoeff*sqrt(neutralEnSum + nextNeutralEn);
-      double resolution = sqrt(resolutionTrackP*resolutionTrackP + resolutionCaloEn*resolutionCaloEn);
-      if ( (neutralEnSum + nextNeutralEn) < (track.p() + 2.*resolution) ) {
-	chargedHadron->neutralPFCandidates_.push_back(nextNeutral->pfCandidate_);
-	neutralEnSum += nextNeutralEn;
-      } else {
-	break;
+      ChargedHadronVector output;
+
+      const edm::Event& evt = (*this->evt());
+
+      edm::Handle<std::vector<TrackClass> > tracks;
+      evt.getByToken(Tracks_token, tracks);
+
+      qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
+      float jEta = jet.eta();
+      float jPhi = jet.phi();
+      size_t numTracks = tracks->size();
+      for (size_t iTrack = 0; iTrack < numTracks; ++iTrack) {
+        const TrackClass& track = (*tracks)[iTrack];
+
+        // consider tracks in vicinity of tau-jet candidate only
+        double dR = deltaR(track.eta(), track.phi(), jEta, jPhi);
+        double dRmatch = dRcone_;
+        if (dRconeLimitedToJetArea_) {
+          double jetArea = jet.jetArea();
+          if (jetArea > 0.) {
+            dRmatch = std::min(dRmatch, sqrt(jetArea / M_PI));
+          } else {
+            if (numWarnings_ < maxWarnings_) {
+              edm::LogInfo("PFRecoTauChargedHadronFromGenericTrackPlugin::operator()")
+                  << "Jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi()
+                  << " has area = " << jetArea << " !!" << std::endl;
+              ++numWarnings_;
+            }
+            dRmatch = 0.1;
+          }
+        }
+        if (dR > dRmatch)
+          continue;
+
+        if (!this->filterTrack(tracks, iTrack))
+          continue;
+
+        reco::Candidate::Charge trackCharge_int = 0;
+        if (track.charge() > 0.)
+          trackCharge_int = +1;
+        else if (track.charge() < 0.)
+          trackCharge_int = -1;
+
+        const double chargedPionMass = 0.13957;  // GeV
+        double chargedPionP = track.p();
+        double chargedPionEn = TMath::Sqrt(chargedPionP * chargedPionP + chargedPionMass * chargedPionMass);
+        reco::Candidate::LorentzVector chargedPionP4(track.px(), track.py(), track.pz(), chargedPionEn);
+
+        reco::Vertex::Point vtx(0., 0., 0.);
+        if (vertexAssociator_.associatedVertex(jet).isNonnull())
+          vtx = vertexAssociator_.associatedVertex(jet)->position();
+
+        std::auto_ptr<PFRecoTauChargedHadron> chargedHadron(
+            new PFRecoTauChargedHadron(trackCharge_int, chargedPionP4, vtx, 0, true, PFRecoTauChargedHadron::kTrack));
+
+        setChargedHadronTrack(*chargedHadron, edm::Ptr<TrackClass>(tracks, iTrack));
+
+        // CV: Take code for propagating track to ECAL entrance
+        //     from RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
+        //     to make sure propagation is done in the same way as for charged PFCandidates.
+        //
+        //     The following replacements need to be made
+        //       outerMomentum -> momentum
+        //       outerPosition -> referencePoint
+        //     in order to run on AOD input
+        //    (outerMomentum and outerPosition require access to reco::TrackExtra objects, which are available in RECO only)
+        //
+        XYZTLorentzVector chargedPionPos(getTrackPos(track));
+        RawParticle p(chargedPionP4, chargedPionPos);
+        p.setCharge(track.charge());
+        BaseParticlePropagator trackPropagator(p, 0., 0., magneticFieldStrength_.z());
+        trackPropagator.propagateToEcalEntrance(false);
+        if (trackPropagator.getSuccess() != 0) {
+          chargedHadron->positionAtECALEntrance_ = trackPropagator.particle().vertex();
+        } else {
+          if (chargedPionP4.pt() > 2. and std::abs(chargedPionP4.eta()) < 3.) {
+            edm::LogWarning("PFRecoTauChargedHadronFromGenericTrackPlugin::operator()")
+                << "Failed to propagate track: Pt = " << track.pt() << ", eta = " << track.eta()
+                << ", phi = " << track.phi() << " to ECAL entrance !!" << std::endl;
+          }
+          chargedHadron->positionAtECALEntrance_ = math::XYZPointF(0., 0., 0.);
+        }
+
+        std::vector<Candidate_withDistance> neutralJetConstituents_withDistance;
+        for (const auto& jetConstituent : jet.daughterPtrVector()) {
+          int pdgId = jetConstituent->pdgId();
+          if (!(pdgId == 130 || pdgId == 22))
+            continue;
+          double dR = deltaR(atECALEntrance(&*jetConstituent, magneticFieldStrength_.z()),
+                             chargedHadron->positionAtECALEntrance_);
+          double dRmerge = -1.;
+          if (pdgId == 130)
+            dRmerge = dRmergeNeutralHadron_;
+          else if (pdgId == 22)
+            dRmerge = dRmergePhoton_;
+          if (dR < dRmerge) {
+            Candidate_withDistance jetConstituent_withDistance;
+            jetConstituent_withDistance.pfCandidate_ = jetConstituent;
+            jetConstituent_withDistance.distance_ = dR;
+            neutralJetConstituents_withDistance.push_back(jetConstituent_withDistance);
+            chargedHadron->addDaughter(jetConstituent);
+          }
+        }
+        std::sort(
+            neutralJetConstituents_withDistance.begin(), neutralJetConstituents_withDistance.end(), isSmallerDistance);
+
+        const double caloResolutionCoeff =
+            1.0;  // CV: approximate ECAL + HCAL calorimeter resolution for hadrons by 100%*sqrt(E)
+        double resolutionTrackP = track.p() * (getTrackPtError(track) / track.pt());
+        double neutralEnSum = 0.;
+        for (std::vector<Candidate_withDistance>::const_iterator nextNeutral =
+                 neutralJetConstituents_withDistance.begin();
+             nextNeutral != neutralJetConstituents_withDistance.end();
+             ++nextNeutral) {
+          double nextNeutralEn = nextNeutral->pfCandidate_->energy();
+          double resolutionCaloEn = caloResolutionCoeff * sqrt(neutralEnSum + nextNeutralEn);
+          double resolution = sqrt(resolutionTrackP * resolutionTrackP + resolutionCaloEn * resolutionCaloEn);
+          if ((neutralEnSum + nextNeutralEn) < (track.p() + 2. * resolution)) {
+            chargedHadron->neutralPFCandidates_.push_back(nextNeutral->pfCandidate_);
+            neutralEnSum += nextNeutralEn;
+          } else {
+            break;
+          }
+        }
+
+        setChargedHadronP4(*chargedHadron);
+
+        if (verbosity_) {
+          edm::LogPrint("TauChHFromTrack") << *chargedHadron;
+        }
+
+        output.push_back(chargedHadron);
       }
+
+      return output.release();
     }
 
-    setChargedHadronP4(*chargedHadron);
+    typedef PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track> PFRecoTauChargedHadronFromTrackPlugin;
+    typedef PFRecoTauChargedHadronFromGenericTrackPlugin<pat::PackedCandidate> PFRecoTauChargedHadronFromLostTrackPlugin;
 
-    if ( verbosity_ ) {
-      edm::LogPrint("TauChHFromTrack") << *chargedHadron;
-    }
-
-    output.push_back(chargedHadron);
-  }
-
-  return output.release();
-}
-
-typedef PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track> PFRecoTauChargedHadronFromTrackPlugin;
-typedef PFRecoTauChargedHadronFromGenericTrackPlugin<pat::PackedCandidate> PFRecoTauChargedHadronFromLostTrackPlugin;
-
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_EDM_PLUGIN(PFRecoTauChargedHadronBuilderPluginFactory, reco::tau::PFRecoTauChargedHadronFromTrackPlugin, "PFRecoTauChargedHadronFromTrackPlugin");
-DEFINE_EDM_PLUGIN(PFRecoTauChargedHadronBuilderPluginFactory, reco::tau::PFRecoTauChargedHadronFromLostTrackPlugin, "PFRecoTauChargedHadronFromLostTrackPlugin");
+DEFINE_EDM_PLUGIN(PFRecoTauChargedHadronBuilderPluginFactory,
+                  reco::tau::PFRecoTauChargedHadronFromTrackPlugin,
+                  "PFRecoTauChargedHadronFromTrackPlugin");
+DEFINE_EDM_PLUGIN(PFRecoTauChargedHadronBuilderPluginFactory,
+                  reco::tau::PFRecoTauChargedHadronFromLostTrackPlugin,
+                  "PFRecoTauChargedHadronFromLostTrackPlugin");

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -34,237 +34,261 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h"
 #include "RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h"
 
-
 #include <memory>
 
-namespace reco 
-{ 
+namespace reco {
 
-namespace tau
-{ 
+  namespace tau {
 
-class PFRecoTauChargedHadronFromPFCandidatePlugin : public PFRecoTauChargedHadronBuilderPlugin 
-{
- public:
-  explicit PFRecoTauChargedHadronFromPFCandidatePlugin(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
-  ~PFRecoTauChargedHadronFromPFCandidatePlugin() override;
-  // Return type is auto_ptr<ChargedHadronVector>
-  return_type operator()(const reco::Jet&) const override;
-  // Hook to update PV information
-  void beginEvent() override;
-  
- private:
-  typedef std::vector<reco::CandidatePtr> CandPtrs;
+    class PFRecoTauChargedHadronFromPFCandidatePlugin : public PFRecoTauChargedHadronBuilderPlugin {
+    public:
+      explicit PFRecoTauChargedHadronFromPFCandidatePlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+      ~PFRecoTauChargedHadronFromPFCandidatePlugin() override;
+      // Return type is auto_ptr<ChargedHadronVector>
+      return_type operator()(const reco::Jet&) const override;
+      // Hook to update PV information
+      void beginEvent() override;
 
-  RecoTauVertexAssociator vertexAssociator_;
+    private:
+      typedef std::vector<reco::CandidatePtr> CandPtrs;
 
-  RecoTauQualityCuts* qcuts_;
+      RecoTauVertexAssociator vertexAssociator_;
 
-  std::vector<int> inputParticleIds_;  // type of candidates to clusterize
+      RecoTauQualityCuts* qcuts_;
 
-  double dRmergeNeutralHadronWrtChargedHadron_;
-  double dRmergeNeutralHadronWrtNeutralHadron_;
-  double dRmergeNeutralHadronWrtElectron_;
-  double dRmergeNeutralHadronWrtOther_;
-  int minBlockElementMatchesNeutralHadron_;
-  int maxUnmatchedBlockElementsNeutralHadron_;
-  double dRmergePhotonWrtChargedHadron_;
-  double dRmergePhotonWrtNeutralHadron_;
-  double dRmergePhotonWrtElectron_;
-  double dRmergePhotonWrtOther_;
-  int minBlockElementMatchesPhoton_;
-  int maxUnmatchedBlockElementsPhoton_;
-  double minMergeNeutralHadronEt_;
-  double minMergeGammaEt_;
-  double minMergeChargedHadronPt_;
+      std::vector<int> inputParticleIds_;  // type of candidates to clusterize
 
-  double bField_;
+      double dRmergeNeutralHadronWrtChargedHadron_;
+      double dRmergeNeutralHadronWrtNeutralHadron_;
+      double dRmergeNeutralHadronWrtElectron_;
+      double dRmergeNeutralHadronWrtOther_;
+      int minBlockElementMatchesNeutralHadron_;
+      int maxUnmatchedBlockElementsNeutralHadron_;
+      double dRmergePhotonWrtChargedHadron_;
+      double dRmergePhotonWrtNeutralHadron_;
+      double dRmergePhotonWrtElectron_;
+      double dRmergePhotonWrtOther_;
+      int minBlockElementMatchesPhoton_;
+      int maxUnmatchedBlockElementsPhoton_;
+      double minMergeNeutralHadronEt_;
+      double minMergeGammaEt_;
+      double minMergeChargedHadronPt_;
 
-  int verbosity_;
-};
+      double bField_;
 
-  PFRecoTauChargedHadronFromPFCandidatePlugin::PFRecoTauChargedHadronFromPFCandidatePlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC)
-    : PFRecoTauChargedHadronBuilderPlugin(pset,std::move(iC)),
-      vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"),std::move(iC)),
-    qcuts_(nullptr)
-{
-  edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
-  qcuts_ = new RecoTauQualityCuts(qcuts_pset);
+      int verbosity_;
+    };
 
-  inputParticleIds_ = pset.getParameter<std::vector<int> >("chargedHadronCandidatesParticleIds");
+    PFRecoTauChargedHadronFromPFCandidatePlugin::PFRecoTauChargedHadronFromPFCandidatePlugin(
+        const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : PFRecoTauChargedHadronBuilderPlugin(pset, std::move(iC)),
+          vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)),
+          qcuts_(nullptr) {
+      edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
+      qcuts_ = new RecoTauQualityCuts(qcuts_pset);
 
-  dRmergeNeutralHadronWrtChargedHadron_ = pset.getParameter<double>("dRmergeNeutralHadronWrtChargedHadron");
-  dRmergeNeutralHadronWrtNeutralHadron_ = pset.getParameter<double>("dRmergeNeutralHadronWrtNeutralHadron");
-  dRmergeNeutralHadronWrtElectron_ = pset.getParameter<double>("dRmergeNeutralHadronWrtElectron");
-  dRmergeNeutralHadronWrtOther_ = pset.getParameter<double>("dRmergeNeutralHadronWrtOther");
-  minBlockElementMatchesNeutralHadron_ = pset.getParameter<int>("minBlockElementMatchesNeutralHadron");
-  maxUnmatchedBlockElementsNeutralHadron_ = pset.getParameter<int>("maxUnmatchedBlockElementsNeutralHadron");
-  dRmergePhotonWrtChargedHadron_ = pset.getParameter<double>("dRmergePhotonWrtChargedHadron");
-  dRmergePhotonWrtNeutralHadron_ = pset.getParameter<double>("dRmergePhotonWrtNeutralHadron");
-  dRmergePhotonWrtElectron_ = pset.getParameter<double>("dRmergePhotonWrtElectron");
-  dRmergePhotonWrtOther_ = pset.getParameter<double>("dRmergePhotonWrtOther");
-  minBlockElementMatchesPhoton_ = pset.getParameter<int>("minBlockElementMatchesPhoton");
-  maxUnmatchedBlockElementsPhoton_ = pset.getParameter<int>("maxUnmatchedBlockElementsPhoton");
-  minMergeNeutralHadronEt_ = pset.getParameter<double>("minMergeNeutralHadronEt");
-  minMergeGammaEt_ = pset.getParameter<double>("minMergeGammaEt"); 
-  minMergeChargedHadronPt_ = pset.getParameter<double>("minMergeChargedHadronPt"); 
+      inputParticleIds_ = pset.getParameter<std::vector<int> >("chargedHadronCandidatesParticleIds");
 
-  verbosity_ = pset.getParameter<int>("verbosity");
-}
-  
-PFRecoTauChargedHadronFromPFCandidatePlugin::~PFRecoTauChargedHadronFromPFCandidatePlugin()
-{
-  delete qcuts_;
-}
+      dRmergeNeutralHadronWrtChargedHadron_ = pset.getParameter<double>("dRmergeNeutralHadronWrtChargedHadron");
+      dRmergeNeutralHadronWrtNeutralHadron_ = pset.getParameter<double>("dRmergeNeutralHadronWrtNeutralHadron");
+      dRmergeNeutralHadronWrtElectron_ = pset.getParameter<double>("dRmergeNeutralHadronWrtElectron");
+      dRmergeNeutralHadronWrtOther_ = pset.getParameter<double>("dRmergeNeutralHadronWrtOther");
+      minBlockElementMatchesNeutralHadron_ = pset.getParameter<int>("minBlockElementMatchesNeutralHadron");
+      maxUnmatchedBlockElementsNeutralHadron_ = pset.getParameter<int>("maxUnmatchedBlockElementsNeutralHadron");
+      dRmergePhotonWrtChargedHadron_ = pset.getParameter<double>("dRmergePhotonWrtChargedHadron");
+      dRmergePhotonWrtNeutralHadron_ = pset.getParameter<double>("dRmergePhotonWrtNeutralHadron");
+      dRmergePhotonWrtElectron_ = pset.getParameter<double>("dRmergePhotonWrtElectron");
+      dRmergePhotonWrtOther_ = pset.getParameter<double>("dRmergePhotonWrtOther");
+      minBlockElementMatchesPhoton_ = pset.getParameter<int>("minBlockElementMatchesPhoton");
+      maxUnmatchedBlockElementsPhoton_ = pset.getParameter<int>("maxUnmatchedBlockElementsPhoton");
+      minMergeNeutralHadronEt_ = pset.getParameter<double>("minMergeNeutralHadronEt");
+      minMergeGammaEt_ = pset.getParameter<double>("minMergeGammaEt");
+      minMergeChargedHadronPt_ = pset.getParameter<double>("minMergeChargedHadronPt");
 
-// Update the primary vertex
-void PFRecoTauChargedHadronFromPFCandidatePlugin::beginEvent() 
-{
-  vertexAssociator_.setEvent(*evt());
-  
-  edm::ESHandle<MagneticField> pSetup;
-  evtSetup()->get<IdealMagneticFieldRecord>().get(pSetup);
-  bField_ = pSetup->inTesla(GlobalPoint(0,0,0)).z();
-}
+      verbosity_ = pset.getParameter<int>("verbosity");
+    }
 
-namespace
-{
-  bool isMatchedByBlockElement(const reco::PFCandidate& pfCandidate1, const reco::PFCandidate& pfCandidate2, int minMatches1, int minMatches2, int maxUnmatchedBlockElements1plus2)
-  {
-    reco::PFCandidate::ElementsInBlocks blockElements1 = pfCandidate1.elementsInBlocks();
-    int numBlocks1 = blockElements1.size();
-    reco::PFCandidate::ElementsInBlocks blockElements2 = pfCandidate2.elementsInBlocks();
-    int numBlocks2 = blockElements2.size();
-    int numBlocks_matched = 0;
-    for ( reco::PFCandidate::ElementsInBlocks::const_iterator blockElement1 = blockElements1.begin();
-	  blockElement1 != blockElements1.end(); ++blockElement1 ) {
-      bool isMatched = false;
-      for ( reco::PFCandidate::ElementsInBlocks::const_iterator blockElement2 = blockElements2.begin();
-	    blockElement2 != blockElements2.end(); ++blockElement2 ) {
-	if ( blockElement1->first.id()  == blockElement2->first.id()  && 
-	     blockElement1->first.key() == blockElement2->first.key() && 
-	     blockElement1->second      == blockElement2->second      ) {
-	  isMatched = true;
-	}
+    PFRecoTauChargedHadronFromPFCandidatePlugin::~PFRecoTauChargedHadronFromPFCandidatePlugin() { delete qcuts_; }
+
+    // Update the primary vertex
+    void PFRecoTauChargedHadronFromPFCandidatePlugin::beginEvent() {
+      vertexAssociator_.setEvent(*evt());
+
+      edm::ESHandle<MagneticField> pSetup;
+      evtSetup()->get<IdealMagneticFieldRecord>().get(pSetup);
+      bField_ = pSetup->inTesla(GlobalPoint(0, 0, 0)).z();
+    }
+
+    namespace {
+      bool isMatchedByBlockElement(const reco::PFCandidate& pfCandidate1,
+                                   const reco::PFCandidate& pfCandidate2,
+                                   int minMatches1,
+                                   int minMatches2,
+                                   int maxUnmatchedBlockElements1plus2) {
+        reco::PFCandidate::ElementsInBlocks blockElements1 = pfCandidate1.elementsInBlocks();
+        int numBlocks1 = blockElements1.size();
+        reco::PFCandidate::ElementsInBlocks blockElements2 = pfCandidate2.elementsInBlocks();
+        int numBlocks2 = blockElements2.size();
+        int numBlocks_matched = 0;
+        for (reco::PFCandidate::ElementsInBlocks::const_iterator blockElement1 = blockElements1.begin();
+             blockElement1 != blockElements1.end();
+             ++blockElement1) {
+          bool isMatched = false;
+          for (reco::PFCandidate::ElementsInBlocks::const_iterator blockElement2 = blockElements2.begin();
+               blockElement2 != blockElements2.end();
+               ++blockElement2) {
+            if (blockElement1->first.id() == blockElement2->first.id() &&
+                blockElement1->first.key() == blockElement2->first.key() &&
+                blockElement1->second == blockElement2->second) {
+              isMatched = true;
+            }
+          }
+          if (isMatched)
+            ++numBlocks_matched;
+        }
+        assert(numBlocks_matched <= numBlocks1);
+        assert(numBlocks_matched <= numBlocks2);
+        if (numBlocks_matched >= minMatches1 && numBlocks_matched >= minMatches2 &&
+            ((numBlocks1 - numBlocks_matched) + (numBlocks2 - numBlocks_matched)) <= maxUnmatchedBlockElements1plus2) {
+          return true;
+        } else {
+          return false;
+        }
       }
-      if ( isMatched ) ++numBlocks_matched;
-    }
-    assert(numBlocks_matched <= numBlocks1);
-    assert(numBlocks_matched <= numBlocks2);
-    if ( numBlocks_matched >= minMatches1 && numBlocks_matched >= minMatches2 &&
-	 ((numBlocks1 - numBlocks_matched) + (numBlocks2 - numBlocks_matched)) <= maxUnmatchedBlockElements1plus2 ) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-}
+    }  // namespace
 
-PFRecoTauChargedHadronFromPFCandidatePlugin::return_type PFRecoTauChargedHadronFromPFCandidatePlugin::operator()(const reco::Jet& jet) const 
-{
-  if ( verbosity_ ) {
-    edm::LogPrint("TauChHadronFromPF") << "<PFRecoTauChargedHadronFromPFCandidatePlugin::operator()>:";
-    edm::LogPrint("TauChHadronFromPF") << " pluginName = " << name() ;
-  }
-
-  ChargedHadronVector output;
-
-  // Get the candidates passing our quality cuts
-  qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
-  CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputParticleIds_));
-
-  for ( CandPtrs::iterator cand = candsVector.begin();
-	cand != candsVector.end(); ++cand ) {
-    if ( verbosity_ ) {
-      edm::LogPrint("TauChHadronFromPF") << "processing PFCandidate: Pt = " << (*cand)->pt() << ", eta = " << (*cand)->eta() << ", phi = " << (*cand)->phi() 
-		<< " (pdgId = " << (*cand)->pdgId() << ", charge = " << (*cand)->charge() << ")" ;
-    }
-    
-    PFRecoTauChargedHadron::PFRecoTauChargedHadronAlgorithm algo = PFRecoTauChargedHadron::kUndefined;
-    if ( std::abs((*cand)->charge()) > 0.5 ) algo = PFRecoTauChargedHadron::kChargedPFCandidate;
-    else algo = PFRecoTauChargedHadron::kPFNeutralHadron;
-    std::auto_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(**cand, algo));
-    
-    const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(&**cand);
-    if (pfCand) {
-      if ( pfCand->trackRef().isNonnull() ) chargedHadron->track_ = edm::refToPtr(pfCand->trackRef());
-      else if ( pfCand->muonRef().isNonnull() && pfCand->muonRef()->innerTrack().isNonnull()  ) chargedHadron->track_ = edm::refToPtr(pfCand->muonRef()->innerTrack());
-      else if ( pfCand->muonRef().isNonnull() && pfCand->muonRef()->globalTrack().isNonnull() ) chargedHadron->track_ = edm::refToPtr(pfCand->muonRef()->globalTrack());
-      else if ( pfCand->muonRef().isNonnull() && pfCand->muonRef()->outerTrack().isNonnull()  ) chargedHadron->track_ = edm::refToPtr(pfCand->muonRef()->outerTrack());
-      else if ( pfCand->gsfTrackRef().isNonnull() ) chargedHadron->track_ = edm::refToPtr(pfCand->gsfTrackRef());
-    } // TauReco@MiniAOD: Tracks only available dynamically, so no possiblity to save ref here; checked by code downstream
-
-    chargedHadron->positionAtECALEntrance_ = atECALEntrance(&**cand, bField_);
-    chargedHadron->chargedPFCandidate_ = (*cand);
-    chargedHadron->addDaughter(*cand);
-    
-    int pdgId = std::abs(chargedHadron->chargedPFCandidate_->pdgId());
-
-    if ( chargedHadron->pt() > minMergeChargedHadronPt_ ) {
-      for (const auto& jetConstituent : jet.daughterPtrVector()) {
-	// CV: take care of not double-counting energy in case "charged" PFCandidate is in fact a PFNeutralHadron
-	if ( jetConstituent == chargedHadron->chargedPFCandidate_ ) continue;
-	
-	int jetConstituentPdgId = std::abs(jetConstituent->pdgId());
-	if ( !(jetConstituentPdgId == 130 || jetConstituentPdgId == 22) ) continue;
-
-	double dR = deltaR(atECALEntrance(jetConstituent.get(), bField_), atECALEntrance(chargedHadron->chargedPFCandidate_.get(), bField_));
-	double dRmerge = -1.;      
-	int minBlockElementMatches = 1000;
-	int maxUnmatchedBlockElements = 0;
-	double minMergeEt = 1.e+6;
-	if ( jetConstituentPdgId == 130 ) {
-	  if      ( pdgId == 211  ) dRmerge = dRmergeNeutralHadronWrtChargedHadron_;
-	  else if ( pdgId == 130 ) dRmerge = dRmergeNeutralHadronWrtNeutralHadron_;
-	  else if ( pdgId == 11  ) dRmerge = dRmergeNeutralHadronWrtElectron_;
-	  else                                                        dRmerge = dRmergeNeutralHadronWrtOther_;
-	  minBlockElementMatches = minBlockElementMatchesNeutralHadron_;
-	  maxUnmatchedBlockElements = maxUnmatchedBlockElementsNeutralHadron_;
-	  minMergeEt = minMergeNeutralHadronEt_;
-	} else if ( jetConstituentPdgId == 22 ) {
-	  if      ( pdgId == 211  ) dRmerge = dRmergePhotonWrtChargedHadron_;
-	  else if ( pdgId == 130 ) dRmerge = dRmergePhotonWrtNeutralHadron_;
-	  else if ( pdgId == 11  ) dRmerge = dRmergePhotonWrtElectron_;
-	  else                                                        dRmerge = dRmergePhotonWrtOther_;
-	  minBlockElementMatches = minBlockElementMatchesPhoton_;
-	  maxUnmatchedBlockElements = maxUnmatchedBlockElementsPhoton_;
-	  minMergeEt = minMergeGammaEt_;
-	}
-
-	if (jetConstituent->et() > minMergeEt) {
-	  if (dR < dRmerge) {
-	    chargedHadron->neutralPFCandidates_.push_back(jetConstituent);
-	    chargedHadron->addDaughter(jetConstituent);
-	  }
-	  else {
-	    // TauReco@MiniAOD: No access to PF blocks at MiniAOD level, but the code below seems to have very minor impact
-	    const reco::PFCandidate* pfJetConstituent = dynamic_cast<const reco::PFCandidate*>(jetConstituent.get());
-	    if (pfCand != nullptr && pfJetConstituent != nullptr) {
-	      if (isMatchedByBlockElement(*pfJetConstituent, *pfCand, minBlockElementMatches, minBlockElementMatches, maxUnmatchedBlockElements)) {
-		chargedHadron->neutralPFCandidates_.push_back(jetConstituent);
-		chargedHadron->addDaughter(jetConstituent);
-	      }
-	    }
-	  }
-	}
+    PFRecoTauChargedHadronFromPFCandidatePlugin::return_type PFRecoTauChargedHadronFromPFCandidatePlugin::operator()(
+        const reco::Jet& jet) const {
+      if (verbosity_) {
+        edm::LogPrint("TauChHadronFromPF") << "<PFRecoTauChargedHadronFromPFCandidatePlugin::operator()>:";
+        edm::LogPrint("TauChHadronFromPF") << " pluginName = " << name();
       }
+
+      ChargedHadronVector output;
+
+      // Get the candidates passing our quality cuts
+      qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
+      CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputParticleIds_));
+
+      for (CandPtrs::iterator cand = candsVector.begin(); cand != candsVector.end(); ++cand) {
+        if (verbosity_) {
+          edm::LogPrint("TauChHadronFromPF")
+              << "processing PFCandidate: Pt = " << (*cand)->pt() << ", eta = " << (*cand)->eta()
+              << ", phi = " << (*cand)->phi() << " (pdgId = " << (*cand)->pdgId() << ", charge = " << (*cand)->charge()
+              << ")";
+        }
+
+        PFRecoTauChargedHadron::PFRecoTauChargedHadronAlgorithm algo = PFRecoTauChargedHadron::kUndefined;
+        if (std::abs((*cand)->charge()) > 0.5)
+          algo = PFRecoTauChargedHadron::kChargedPFCandidate;
+        else
+          algo = PFRecoTauChargedHadron::kPFNeutralHadron;
+        std::auto_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(**cand, algo));
+
+        const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(&**cand);
+        if (pfCand) {
+          if (pfCand->trackRef().isNonnull())
+            chargedHadron->track_ = edm::refToPtr(pfCand->trackRef());
+          else if (pfCand->muonRef().isNonnull() && pfCand->muonRef()->innerTrack().isNonnull())
+            chargedHadron->track_ = edm::refToPtr(pfCand->muonRef()->innerTrack());
+          else if (pfCand->muonRef().isNonnull() && pfCand->muonRef()->globalTrack().isNonnull())
+            chargedHadron->track_ = edm::refToPtr(pfCand->muonRef()->globalTrack());
+          else if (pfCand->muonRef().isNonnull() && pfCand->muonRef()->outerTrack().isNonnull())
+            chargedHadron->track_ = edm::refToPtr(pfCand->muonRef()->outerTrack());
+          else if (pfCand->gsfTrackRef().isNonnull())
+            chargedHadron->track_ = edm::refToPtr(pfCand->gsfTrackRef());
+        }  // TauReco@MiniAOD: Tracks only available dynamically, so no possiblity to save ref here; checked by code downstream
+
+        chargedHadron->positionAtECALEntrance_ = atECALEntrance(&**cand, bField_);
+        chargedHadron->chargedPFCandidate_ = (*cand);
+        chargedHadron->addDaughter(*cand);
+
+        int pdgId = std::abs(chargedHadron->chargedPFCandidate_->pdgId());
+
+        if (chargedHadron->pt() > minMergeChargedHadronPt_) {
+          for (const auto& jetConstituent : jet.daughterPtrVector()) {
+            // CV: take care of not double-counting energy in case "charged" PFCandidate is in fact a PFNeutralHadron
+            if (jetConstituent == chargedHadron->chargedPFCandidate_)
+              continue;
+
+            int jetConstituentPdgId = std::abs(jetConstituent->pdgId());
+            if (!(jetConstituentPdgId == 130 || jetConstituentPdgId == 22))
+              continue;
+
+            double dR = deltaR(atECALEntrance(jetConstituent.get(), bField_),
+                               atECALEntrance(chargedHadron->chargedPFCandidate_.get(), bField_));
+            double dRmerge = -1.;
+            int minBlockElementMatches = 1000;
+            int maxUnmatchedBlockElements = 0;
+            double minMergeEt = 1.e+6;
+            if (jetConstituentPdgId == 130) {
+              if (pdgId == 211)
+                dRmerge = dRmergeNeutralHadronWrtChargedHadron_;
+              else if (pdgId == 130)
+                dRmerge = dRmergeNeutralHadronWrtNeutralHadron_;
+              else if (pdgId == 11)
+                dRmerge = dRmergeNeutralHadronWrtElectron_;
+              else
+                dRmerge = dRmergeNeutralHadronWrtOther_;
+              minBlockElementMatches = minBlockElementMatchesNeutralHadron_;
+              maxUnmatchedBlockElements = maxUnmatchedBlockElementsNeutralHadron_;
+              minMergeEt = minMergeNeutralHadronEt_;
+            } else if (jetConstituentPdgId == 22) {
+              if (pdgId == 211)
+                dRmerge = dRmergePhotonWrtChargedHadron_;
+              else if (pdgId == 130)
+                dRmerge = dRmergePhotonWrtNeutralHadron_;
+              else if (pdgId == 11)
+                dRmerge = dRmergePhotonWrtElectron_;
+              else
+                dRmerge = dRmergePhotonWrtOther_;
+              minBlockElementMatches = minBlockElementMatchesPhoton_;
+              maxUnmatchedBlockElements = maxUnmatchedBlockElementsPhoton_;
+              minMergeEt = minMergeGammaEt_;
+            }
+
+            if (jetConstituent->et() > minMergeEt) {
+              if (dR < dRmerge) {
+                chargedHadron->neutralPFCandidates_.push_back(jetConstituent);
+                chargedHadron->addDaughter(jetConstituent);
+              } else {
+                // TauReco@MiniAOD: No access to PF blocks at MiniAOD level, but the code below seems to have very minor impact
+                const reco::PFCandidate* pfJetConstituent =
+                    dynamic_cast<const reco::PFCandidate*>(jetConstituent.get());
+                if (pfCand != nullptr && pfJetConstituent != nullptr) {
+                  if (isMatchedByBlockElement(*pfJetConstituent,
+                                              *pfCand,
+                                              minBlockElementMatches,
+                                              minBlockElementMatches,
+                                              maxUnmatchedBlockElements)) {
+                    chargedHadron->neutralPFCandidates_.push_back(jetConstituent);
+                    chargedHadron->addDaughter(jetConstituent);
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        setChargedHadronP4(*chargedHadron);
+
+        if (verbosity_) {
+          edm::LogPrint("TauChHadronFromPF") << *chargedHadron;
+        }
+        // Update the vertex
+        if (chargedHadron->daughterPtr(0).isNonnull())
+          chargedHadron->setVertex(chargedHadron->daughterPtr(0)->vertex());
+        output.push_back(chargedHadron);
+      }
+
+      return output.release();
     }
 
-    setChargedHadronP4(*chargedHadron);
-
-    if ( verbosity_ ) {
-      edm::LogPrint("TauChHadronFromPF") << *chargedHadron;
-    }
-    // Update the vertex
-    if ( chargedHadron->daughterPtr(0).isNonnull() ) chargedHadron->setVertex(chargedHadron->daughterPtr(0)->vertex());
-    output.push_back(chargedHadron);
-  }
-
-  return output.release();
-}
-
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_EDM_PLUGIN(PFRecoTauChargedHadronBuilderPluginFactory, reco::tau::PFRecoTauChargedHadronFromPFCandidatePlugin, "PFRecoTauChargedHadronFromPFCandidatePlugin");
+DEFINE_EDM_PLUGIN(PFRecoTauChargedHadronBuilderPluginFactory,
+                  reco::tau::PFRecoTauChargedHadronFromPFCandidatePlugin,
+                  "PFRecoTauChargedHadronFromPFCandidatePlugin");

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -51,8 +51,7 @@
 #include <functional>
 #include <cmath>
 
-class PFRecoTauChargedHadronProducer : public edm::stream::EDProducer<> 
-{
+class PFRecoTauChargedHadronProducer : public edm::stream::EDProducer<> {
 public:
   typedef reco::tau::PFRecoTauChargedHadronBuilderPlugin Builder;
   typedef reco::tau::PFRecoTauChargedHadronQualityPlugin Ranker;
@@ -63,9 +62,9 @@ public:
   template <typename T>
   void print(const T& chargedHadrons);
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
+private:
   typedef boost::ptr_vector<Builder> builderList;
   typedef boost::ptr_vector<Ranker> rankerList;
   typedef boost::ptr_vector<reco::PFRecoTauChargedHadron> ChargedHadronVector;
@@ -88,35 +87,33 @@ public:
   std::auto_ptr<ChargedHadronPredicate> predicate_;
 
   // output selector
-  std::auto_ptr<StringCutObjectSelector<reco::PFRecoTauChargedHadron> > outputSelector_;
+  std::auto_ptr<StringCutObjectSelector<reco::PFRecoTauChargedHadron>> outputSelector_;
 
   // flag to enable/disable debug print-out
   int verbosity_;
 };
 
-PFRecoTauChargedHadronProducer::PFRecoTauChargedHadronProducer(const edm::ParameterSet& cfg) 
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-{
+PFRecoTauChargedHadronProducer::PFRecoTauChargedHadronProducer(const edm::ParameterSet& cfg)
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
   srcJets_ = cfg.getParameter<edm::InputTag>("jetSrc");
   Jets_token = consumes<reco::JetView>(srcJets_);
   minJetPt_ = cfg.getParameter<double>("minJetPt");
   maxJetAbsEta_ = cfg.getParameter<double>("maxJetAbsEta");
   verbosity_ = cfg.getParameter<int>("verbosity");
-  
+
   // get set of ChargedHadron builder plugins
   edm::VParameterSet psets_builders = cfg.getParameter<edm::VParameterSet>("builders");
-  for ( edm::VParameterSet::const_iterator pset = psets_builders.begin();
-	pset != psets_builders.end(); ++pset ) {
+  for (edm::VParameterSet::const_iterator pset = psets_builders.begin(); pset != psets_builders.end(); ++pset) {
     std::string pluginType = pset->getParameter<std::string>("plugin");
     edm::ParameterSet pset_modified = (*pset);
     pset_modified.addParameter<int>("verbosity", verbosity_);
-    builders_.push_back(PFRecoTauChargedHadronBuilderPluginFactory::get()->create(pluginType, pset_modified, consumesCollector()));
+    builders_.push_back(
+        PFRecoTauChargedHadronBuilderPluginFactory::get()->create(pluginType, pset_modified, consumesCollector()));
   }
-  
+
   // get set of plugins for ranking ChargedHadrons in quality
   edm::VParameterSet psets_rankers = cfg.getParameter<edm::VParameterSet>("ranking");
-  for ( edm::VParameterSet::const_iterator pset = psets_rankers.begin();
-	pset != psets_rankers.end(); ++pset ) {
+  for (edm::VParameterSet::const_iterator pset = psets_rankers.begin(); pset != psets_rankers.end(); ++pset) {
     std::string pluginType = pset->getParameter<std::string>("plugin");
     edm::ParameterSet pset_modified = (*pset);
     pset_modified.addParameter<int>("verbosity", verbosity_);
@@ -125,32 +122,31 @@ PFRecoTauChargedHadronProducer::PFRecoTauChargedHadronProducer(const edm::Parame
 
   // build the sorting predicate
   predicate_ = std::auto_ptr<ChargedHadronPredicate>(new ChargedHadronPredicate(rankers_));
-  
+
   // check if we want to apply a final output selection
   std::string selection = cfg.getParameter<std::string>("outputSelection");
-  if ( !selection.empty() ) {
+  if (!selection.empty()) {
     outputSelector_.reset(new StringCutObjectSelector<reco::PFRecoTauChargedHadron>(selection));
   }
 
   produces<reco::PFJetChargedHadronAssociation>();
 }
 
-void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
-{
-  if ( verbosity_ ) {
-    edm::LogPrint("PFRecoTauChHProducer")<< "<PFRecoTauChargedHadronProducer::produce>:" ;
-    edm::LogPrint("PFRecoTauChHProducer")<< " moduleLabel = " << moduleLabel_ ;
+void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  if (verbosity_) {
+    edm::LogPrint("PFRecoTauChHProducer") << "<PFRecoTauChargedHadronProducer::produce>:";
+    edm::LogPrint("PFRecoTauChHProducer") << " moduleLabel = " << moduleLabel_;
   }
 
   // give each of our plugins a chance at doing something with the edm::Event
-  for(auto& builder : builders_ ) {
+  for (auto& builder : builders_) {
     builder.setup(evt, es);
   }
-  
+
   // get a view of our jets via the base candidates
   edm::Handle<reco::JetView> jets;
   evt.getByToken(Jets_token, jets);
-  
+
   // convert the view to a RefVector of actual PFJets
   edm::RefToBaseVector<reco::Jet> pfJets;
   size_t nElements = jets->size();
@@ -161,35 +157,34 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
   // make our association
   std::unique_ptr<reco::PFJetChargedHadronAssociation> pfJetChargedHadronAssociations;
 
-
-  if ( !pfJets.empty() ) {
+  if (!pfJets.empty()) {
     pfJetChargedHadronAssociations = std::make_unique<reco::PFJetChargedHadronAssociation>(reco::JetRefBaseProd(jets));
   } else {
     pfJetChargedHadronAssociations = std::make_unique<reco::PFJetChargedHadronAssociation>();
   }
 
   // loop over our jets
-  for(const auto& pfJet : pfJets ) {
-    
-    if(pfJet->pt() - minJetPt_ < 1e-5) continue;
-    if(std::abs(pfJet->eta()) - maxJetAbsEta_ > -1e-5) continue;
+  for (const auto& pfJet : pfJets) {
+    if (pfJet->pt() - minJetPt_ < 1e-5)
+      continue;
+    if (std::abs(pfJet->eta()) - maxJetAbsEta_ > -1e-5)
+      continue;
 
     // build global list of ChargedHadron candidates for each jet
     ChargedHadronList uncleanedChargedHadrons;
 
     // merge candidates reconstructed by all desired algorithm plugins
-    for(auto const& builder : builders_ ) {
+    for (auto const& builder : builders_) {
       try {
         ChargedHadronVector result(builder(*pfJet));
-	if ( verbosity_ ) {
-	  edm::LogPrint("PFRecoTauChHProducer")<< "result of builder = " << builder.name() << ":" ;
-	  print(result);
-	}
+        if (verbosity_) {
+          edm::LogPrint("PFRecoTauChHProducer") << "result of builder = " << builder.name() << ":";
+          print(result);
+        }
         uncleanedChargedHadrons.transfer(uncleanedChargedHadrons.end(), result);
-      } catch ( cms::Exception& exception ) {
+      } catch (cms::Exception& exception) {
         edm::LogError("BuilderPluginException")
-            << "Exception caught in builder plugin " << builder.name()
-            << ", rethrowing" << std::endl;
+            << "Exception caught in builder plugin " << builder.name() << ", rethrowing" << std::endl;
         throw exception;
       }
     }
@@ -205,96 +200,114 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
     std::list<etaPhiPair> tracksInCleanCollection;
     std::set<reco::CandidatePtr> neutralPFCandsInCleanCollection;
 
-    while ( !uncleanedChargedHadrons.empty() ) {
-      
+    while (!uncleanedChargedHadrons.empty()) {
       // get next best ChargedHadron candidate
       std::auto_ptr<reco::PFRecoTauChargedHadron> nextChargedHadron(uncleanedChargedHadrons.pop_front().release());
-      if ( verbosity_ ) {
-	edm::LogPrint("PFRecoTauChHProducer")<< "processing nextChargedHadron:" ;
-	edm::LogPrint("PFRecoTauChHProducer")<< (*nextChargedHadron);
+      if (verbosity_) {
+        edm::LogPrint("PFRecoTauChHProducer") << "processing nextChargedHadron:";
+        edm::LogPrint("PFRecoTauChHProducer") << (*nextChargedHadron);
       }
 
       // discard candidates which fail final output selection
-      if ( !(*outputSelector_)(*nextChargedHadron) ) continue;
+      if (!(*outputSelector_)(*nextChargedHadron))
+        continue;
 
       const reco::Track* track = nullptr;
-      if ( nextChargedHadron->getChargedPFCandidate().isNonnull() ) {
-	const reco::PFCandidate* chargedPFCand = dynamic_cast<const reco::PFCandidate*> (&*nextChargedHadron->getChargedPFCandidate());
+      if (nextChargedHadron->getChargedPFCandidate().isNonnull()) {
+        const reco::PFCandidate* chargedPFCand =
+            dynamic_cast<const reco::PFCandidate*>(&*nextChargedHadron->getChargedPFCandidate());
         if (chargedPFCand) {
-          if ( chargedPFCand->trackRef().isNonnull() ) track = chargedPFCand->trackRef().get();
-          else if ( chargedPFCand->muonRef().isNonnull() && chargedPFCand->muonRef()->innerTrack().isNonnull()  ) track = chargedPFCand->muonRef()->innerTrack().get();
-          else if ( chargedPFCand->muonRef().isNonnull() && chargedPFCand->muonRef()->globalTrack().isNonnull() ) track = chargedPFCand->muonRef()->globalTrack().get();
-          else if ( chargedPFCand->muonRef().isNonnull() && chargedPFCand->muonRef()->outerTrack().isNonnull()  ) track = chargedPFCand->muonRef()->outerTrack().get();
-          else if ( chargedPFCand->gsfTrackRef().isNonnull() ) track = chargedPFCand->gsfTrackRef().get();
+          if (chargedPFCand->trackRef().isNonnull())
+            track = chargedPFCand->trackRef().get();
+          else if (chargedPFCand->muonRef().isNonnull() && chargedPFCand->muonRef()->innerTrack().isNonnull())
+            track = chargedPFCand->muonRef()->innerTrack().get();
+          else if (chargedPFCand->muonRef().isNonnull() && chargedPFCand->muonRef()->globalTrack().isNonnull())
+            track = chargedPFCand->muonRef()->globalTrack().get();
+          else if (chargedPFCand->muonRef().isNonnull() && chargedPFCand->muonRef()->outerTrack().isNonnull())
+            track = chargedPFCand->muonRef()->outerTrack().get();
+          else if (chargedPFCand->gsfTrackRef().isNonnull())
+            track = chargedPFCand->gsfTrackRef().get();
         }
-      } 
-      if ( nextChargedHadron->getTrack().isNonnull() && !track ) {
-	track = nextChargedHadron->getTrack().get();
+      }
+      if (nextChargedHadron->getTrack().isNonnull() && !track) {
+        track = nextChargedHadron->getTrack().get();
       }
 
       // discard candidate in case its track is "used" by any ChargedHadron in the clean collection
       bool isTrack_overlap = false;
-      if ( track ) {
-	double track_eta = track->eta();
-	double track_phi = track->phi();
-	for ( std::list<etaPhiPair>::const_iterator trackInCleanCollection = tracksInCleanCollection.begin();
-	      trackInCleanCollection != tracksInCleanCollection.end(); ++trackInCleanCollection ) {
-	  double dR = deltaR(track_eta, track_phi, trackInCleanCollection->first, trackInCleanCollection->second);
-	  if ( dR < 1.e-4 ) isTrack_overlap = true;
-	}
+      if (track) {
+        double track_eta = track->eta();
+        double track_phi = track->phi();
+        for (std::list<etaPhiPair>::const_iterator trackInCleanCollection = tracksInCleanCollection.begin();
+             trackInCleanCollection != tracksInCleanCollection.end();
+             ++trackInCleanCollection) {
+          double dR = deltaR(track_eta, track_phi, trackInCleanCollection->first, trackInCleanCollection->second);
+          if (dR < 1.e-4)
+            isTrack_overlap = true;
+        }
       }
-      if ( verbosity_ ) {
-	edm::LogPrint("PFRecoTauChHProducer")<< "isTrack_overlap = " << isTrack_overlap ;
+      if (verbosity_) {
+        edm::LogPrint("PFRecoTauChHProducer") << "isTrack_overlap = " << isTrack_overlap;
       }
-      if ( isTrack_overlap ) continue;
+      if (isTrack_overlap)
+        continue;
 
       // discard ChargedHadron candidates without track in case they are close to neutral PFCandidates "used" by ChargedHadron candidates in the clean collection
       bool isNeutralPFCand_overlap = false;
-      if ( nextChargedHadron->algoIs(reco::PFRecoTauChargedHadron::kPFNeutralHadron) ) {
-	for ( std::set<reco::CandidatePtr>::const_iterator neutralPFCandInCleanCollection = neutralPFCandsInCleanCollection.begin();
-	      neutralPFCandInCleanCollection != neutralPFCandsInCleanCollection.end(); ++neutralPFCandInCleanCollection ) {
-          if ( (*neutralPFCandInCleanCollection) == nextChargedHadron->getChargedPFCandidate() )  isNeutralPFCand_overlap = true;
+      if (nextChargedHadron->algoIs(reco::PFRecoTauChargedHadron::kPFNeutralHadron)) {
+        for (std::set<reco::CandidatePtr>::const_iterator neutralPFCandInCleanCollection =
+                 neutralPFCandsInCleanCollection.begin();
+             neutralPFCandInCleanCollection != neutralPFCandsInCleanCollection.end();
+             ++neutralPFCandInCleanCollection) {
+          if ((*neutralPFCandInCleanCollection) == nextChargedHadron->getChargedPFCandidate())
+            isNeutralPFCand_overlap = true;
+        }
+      }
+      if (verbosity_) {
+        edm::LogPrint("PFRecoTauChHProducer") << "isNeutralPFCand_overlap = " << isNeutralPFCand_overlap;
+      }
+      if (isNeutralPFCand_overlap)
+        continue;
 
-	}
-      }
-      if ( verbosity_ ) {
-	edm::LogPrint("PFRecoTauChHProducer")<< "isNeutralPFCand_overlap = " << isNeutralPFCand_overlap ;
-      }
-      if ( isNeutralPFCand_overlap ) continue;
-      
       // find neutral PFCandidates that are not "used" by any ChargedHadron in the clean collection
       std::vector<reco::CandidatePtr> uniqueNeutralPFCands;
       std::set_difference(nextChargedHadron->getNeutralPFCandidates().begin(),
-			  nextChargedHadron->getNeutralPFCandidates().end(),
-			  neutralPFCandsInCleanCollection.begin(),
-			  neutralPFCandsInCleanCollection.end(),
-			  std::back_inserter(uniqueNeutralPFCands));
-      
-      if ( uniqueNeutralPFCands.size() == nextChargedHadron->getNeutralPFCandidates().size() ) { // all neutral PFCandidates are unique, add ChargedHadron candidate to clean collection
-	if ( track ) tracksInCleanCollection.push_back(std::make_pair(track->eta(), track->phi()));
-	neutralPFCandsInCleanCollection.insert(nextChargedHadron->getNeutralPFCandidates().begin(), nextChargedHadron->getNeutralPFCandidates().end());
-	if ( verbosity_ ) {
-	  edm::LogPrint("PFRecoTauChHProducer")<< "--> adding nextChargedHadron to output collection." ;
-	}
-	cleanedChargedHadrons.push_back(*nextChargedHadron);
-      } else { // remove overlapping neutral PFCandidates, reevaluate ranking criterion and process ChargedHadron candidate again
-	nextChargedHadron->neutralPFCandidates_.clear();
-    for(auto const& neutralPFCand : uniqueNeutralPFCands ) {
+                          nextChargedHadron->getNeutralPFCandidates().end(),
+                          neutralPFCandsInCleanCollection.begin(),
+                          neutralPFCandsInCleanCollection.end(),
+                          std::back_inserter(uniqueNeutralPFCands));
+
+      if (uniqueNeutralPFCands.size() ==
+          nextChargedHadron->getNeutralPFCandidates()
+              .size()) {  // all neutral PFCandidates are unique, add ChargedHadron candidate to clean collection
+        if (track)
+          tracksInCleanCollection.push_back(std::make_pair(track->eta(), track->phi()));
+        neutralPFCandsInCleanCollection.insert(nextChargedHadron->getNeutralPFCandidates().begin(),
+                                               nextChargedHadron->getNeutralPFCandidates().end());
+        if (verbosity_) {
+          edm::LogPrint("PFRecoTauChHProducer") << "--> adding nextChargedHadron to output collection.";
+        }
+        cleanedChargedHadrons.push_back(*nextChargedHadron);
+      } else {  // remove overlapping neutral PFCandidates, reevaluate ranking criterion and process ChargedHadron candidate again
+        nextChargedHadron->neutralPFCandidates_.clear();
+        for (auto const& neutralPFCand : uniqueNeutralPFCands) {
           nextChargedHadron->neutralPFCandidates_.push_back(neutralPFCand);
         }
-	// update ChargedHadron four-momentum
-	reco::tau::setChargedHadronP4(*nextChargedHadron);
-	// reinsert ChargedHadron candidate into list of uncleaned candidates,
-	// at position according to new rank
-	ChargedHadronList::iterator insertionPoint = std::lower_bound(uncleanedChargedHadrons.begin(), uncleanedChargedHadrons.end(), *nextChargedHadron, *predicate_);
-	if ( verbosity_ ) {
-	  edm::LogPrint("PFRecoTauChHProducer")<< "--> removing non-unique neutral PFCandidates and reinserting nextChargedHadron in uncleaned collection." ;
-	}
+        // update ChargedHadron four-momentum
+        reco::tau::setChargedHadronP4(*nextChargedHadron);
+        // reinsert ChargedHadron candidate into list of uncleaned candidates,
+        // at position according to new rank
+        ChargedHadronList::iterator insertionPoint = std::lower_bound(
+            uncleanedChargedHadrons.begin(), uncleanedChargedHadrons.end(), *nextChargedHadron, *predicate_);
+        if (verbosity_) {
+          edm::LogPrint("PFRecoTauChHProducer") << "--> removing non-unique neutral PFCandidates and reinserting "
+                                                   "nextChargedHadron in uncleaned collection.";
+        }
         uncleanedChargedHadrons.insert(insertionPoint, nextChargedHadron);
       }
     }
 
-    if ( verbosity_ ) {
+    if (verbosity_) {
       print(cleanedChargedHadrons);
     }
 
@@ -306,23 +319,21 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
 }
 
 template <typename T>
-void PFRecoTauChargedHadronProducer::print(const T& chargedHadrons) 
-{
-  for ( typename T::const_iterator chargedHadron = chargedHadrons.begin();
-	chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
+void PFRecoTauChargedHadronProducer::print(const T& chargedHadrons) {
+  for (typename T::const_iterator chargedHadron = chargedHadrons.begin(); chargedHadron != chargedHadrons.end();
+       ++chargedHadron) {
     edm::LogPrint("PFRecoTauChHProducer") << (*chargedHadron);
-    edm::LogPrint("PFRecoTauChHProducer") << "Rankers:" ;
-    for ( rankerList::const_iterator ranker = rankers_.begin();
-	  ranker != rankers_.end(); ++ranker) {
+    edm::LogPrint("PFRecoTauChHProducer") << "Rankers:";
+    for (rankerList::const_iterator ranker = rankers_.begin(); ranker != rankers_.end(); ++ranker) {
       const unsigned width = 25;
-      edm::LogPrint("PFRecoTauChHProducer") << " " << std::setiosflags(std::ios::left) << std::setw(width) << ranker->name()
-	     << " " << std::resetiosflags(std::ios::left) << std::setprecision(3) << (*ranker)(*chargedHadron) << std::endl;
+      edm::LogPrint("PFRecoTauChHProducer")
+          << " " << std::setiosflags(std::ios::left) << std::setw(width) << ranker->name() << " "
+          << std::resetiosflags(std::ios::left) << std::setprecision(3) << (*ranker)(*chargedHadron) << std::endl;
     }
   }
 }
 
-void
-PFRecoTauChargedHadronProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauChargedHadronProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // ak4PFJetsRecoTauChargedHadrons
   edm::ParameterSetDescription desc;
   {
@@ -394,11 +405,11 @@ PFRecoTauChargedHadronProducer::fillDescriptions(edm::ConfigurationDescriptions&
       pset_isolationQualityCuts.add<double>("minGammaEt", 1.5);
       pset_isolationQualityCuts.add<unsigned int>("minTrackHits", 8);
       pset_isolationQualityCuts.add<double>("maxTransverseImpactParameter", 0.03);
-      pset_isolationQualityCuts.addOptional<bool>("useTracksInsteadOfPFHadrons"); 
+      pset_isolationQualityCuts.addOptional<bool>("useTracksInsteadOfPFHadrons");
 
       edm::ParameterSetDescription pset_qualityCuts;
-      pset_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts",    pset_signalQualityCuts);
-      pset_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts",   pset_vxAssocQualityCuts);
+      pset_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts", pset_signalQualityCuts);
+      pset_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts", pset_vxAssocQualityCuts);
       pset_qualityCuts.add<edm::ParameterSetDescription>("isolationQualityCuts", pset_isolationQualityCuts);
       pset_qualityCuts.add<std::string>("leadingTrkOrPFCandOption", "leadPFCand");
       pset_qualityCuts.add<std::string>("pvFindingAlgo", "closestInDeltaZ");
@@ -428,11 +439,11 @@ PFRecoTauChargedHadronProducer::fillDescriptions(edm::ConfigurationDescriptions&
     desc_builders.addOptional<double>("dRmergeNeutralHadronWrtChargedHadron");
 
     edm::ParameterSet pset_builders;
-    pset_builders.addParameter<std::string>("name","");
-    pset_builders.addParameter<std::string>("plugin","");
+    pset_builders.addParameter<std::string>("name", "");
+    pset_builders.addParameter<std::string>("plugin", "");
     edm::ParameterSet qualityCuts;
-    pset_builders.addParameter<edm::ParameterSet>("qualityCuts",qualityCuts);
-    pset_builders.addParameter<int>("verbosity",0);
+    pset_builders.addParameter<edm::ParameterSet>("qualityCuts", qualityCuts);
+    pset_builders.addParameter<int>("verbosity", 0);
     std::vector<edm::ParameterSet> vpsd_builders;
     vpsd_builders.push_back(pset_builders);
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronQualityPlugins.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronQualityPlugins.cc
@@ -12,38 +12,42 @@
 #include "RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h"
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
 
-#include "CommonTools/Utils/interface/StringCutObjectSelector.h" 
-#include "CommonTools/Utils/interface/StringObjectFunction.h" 
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class PFRecoTauChargedHadronStringQuality : public PFRecoTauChargedHadronQualityPlugin
-{
- public:
-  explicit PFRecoTauChargedHadronStringQuality(const edm::ParameterSet&);
-  ~PFRecoTauChargedHadronStringQuality() override {}
-  double operator()(const PFRecoTauChargedHadron&) const override;
- private:
-  const StringCutObjectSelector<PFRecoTauChargedHadron> selector_;
-  const StringObjectFunction<PFRecoTauChargedHadron> function_;
-  double failResult_;
-};
+    class PFRecoTauChargedHadronStringQuality : public PFRecoTauChargedHadronQualityPlugin {
+    public:
+      explicit PFRecoTauChargedHadronStringQuality(const edm::ParameterSet&);
+      ~PFRecoTauChargedHadronStringQuality() override {}
+      double operator()(const PFRecoTauChargedHadron&) const override;
 
-PFRecoTauChargedHadronStringQuality::PFRecoTauChargedHadronStringQuality(const edm::ParameterSet& pset)
-  : PFRecoTauChargedHadronQualityPlugin(pset),
-    selector_(pset.getParameter<std::string>("selection")),
-    function_(pset.getParameter<std::string>("selectionPassFunction")),
-    failResult_(pset.getParameter<double>("selectionFailValue")) 
-{}
+    private:
+      const StringCutObjectSelector<PFRecoTauChargedHadron> selector_;
+      const StringObjectFunction<PFRecoTauChargedHadron> function_;
+      double failResult_;
+    };
 
-double PFRecoTauChargedHadronStringQuality::operator()(const PFRecoTauChargedHadron& cand) const
-{
-  if ( selector_(cand) ) return function_(cand);
-  else return failResult_;
-}
+    PFRecoTauChargedHadronStringQuality::PFRecoTauChargedHadronStringQuality(const edm::ParameterSet& pset)
+        : PFRecoTauChargedHadronQualityPlugin(pset),
+          selector_(pset.getParameter<std::string>("selection")),
+          function_(pset.getParameter<std::string>("selectionPassFunction")),
+          failResult_(pset.getParameter<double>("selectionFailValue")) {}
 
-}} // end namespace reco::tau
+    double PFRecoTauChargedHadronStringQuality::operator()(const PFRecoTauChargedHadron& cand) const {
+      if (selector_(cand))
+        return function_(cand);
+      else
+        return failResult_;
+    }
+
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_EDM_PLUGIN(PFRecoTauChargedHadronQualityPluginFactory, reco::tau::PFRecoTauChargedHadronStringQuality, "PFRecoTauChargedHadronStringQuality");
+DEFINE_EDM_PLUGIN(PFRecoTauChargedHadronQualityPluginFactory,
+                  reco::tau::PFRecoTauChargedHadronStringQuality,
+                  "PFRecoTauChargedHadronStringQuality");

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauCorrectedInvariantMassProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauCorrectedInvariantMassProducer.cc
@@ -23,44 +23,43 @@
 #include <FWCore/ParameterSet/interface/ParameterSetDescription.h>
 
 namespace {
-using namespace reco;
+  using namespace reco;
 
-class PFRecoTauCorrectedInvariantMassProducer : public PFTauDiscriminationProducerBase  {
-   public:
-      explicit PFRecoTauCorrectedInvariantMassProducer(const edm::ParameterSet& iConfig):PFTauDiscriminationProducerBase(iConfig){
-         PFTauDecayModeProducer_     = iConfig.getParameter<edm::InputTag>("PFTauDecayModeProducer");
-      }
-      ~PFRecoTauCorrectedInvariantMassProducer() override{} 
-      double discriminate(const PFTauRef& pfTau) const override;
-      void beginEvent(const edm::Event& event, const edm::EventSetup& evtSetup) override;
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-   private:
-      edm::InputTag PFTauDecayModeProducer_;
-      edm::Handle<PFTauDecayModeAssociation> theDMAssoc;
-};
+  class PFRecoTauCorrectedInvariantMassProducer : public PFTauDiscriminationProducerBase {
+  public:
+    explicit PFRecoTauCorrectedInvariantMassProducer(const edm::ParameterSet& iConfig)
+        : PFTauDiscriminationProducerBase(iConfig) {
+      PFTauDecayModeProducer_ = iConfig.getParameter<edm::InputTag>("PFTauDecayModeProducer");
+    }
+    ~PFRecoTauCorrectedInvariantMassProducer() override {}
+    double discriminate(const PFTauRef& pfTau) const override;
+    void beginEvent(const edm::Event& event, const edm::EventSetup& evtSetup) override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-void PFRecoTauCorrectedInvariantMassProducer::beginEvent(const edm::Event& event, const edm::EventSetup& evtSetup)
-{
-   // Get the PFTau Decay Modes
-   event.getByLabel(PFTauDecayModeProducer_, theDMAssoc);
-}
+  private:
+    edm::InputTag PFTauDecayModeProducer_;
+    edm::Handle<PFTauDecayModeAssociation> theDMAssoc;
+  };
 
-double PFRecoTauCorrectedInvariantMassProducer::discriminate(const PFTauRef& thePFTauRef) const
-{
-   const PFTauDecayMode& theDecayMode = (*theDMAssoc)[thePFTauRef];
-   return theDecayMode.mass();
-}
+  void PFRecoTauCorrectedInvariantMassProducer::beginEvent(const edm::Event& event, const edm::EventSetup& evtSetup) {
+    // Get the PFTau Decay Modes
+    event.getByLabel(PFTauDecayModeProducer_, theDMAssoc);
+  }
 
-void
-PFRecoTauCorrectedInvariantMassProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  // pfRecoTauCorrectedInvariantMassProducer
-  edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("PFTauDecayModeProducer");
+  double PFRecoTauCorrectedInvariantMassProducer::discriminate(const PFTauRef& thePFTauRef) const {
+    const PFTauDecayMode& theDecayMode = (*theDMAssoc)[thePFTauRef];
+    return theDecayMode.mass();
+  }
 
-  fillProducerDescriptions(desc); // inherited from the base
+  void PFRecoTauCorrectedInvariantMassProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    // pfRecoTauCorrectedInvariantMassProducer
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("PFTauDecayModeProducer");
 
-  descriptions.add("pfRecoTauCorrectedInvariantMassProducer", desc);
-}
+    fillProducerDescriptions(desc);  // inherited from the base
 
-}
+    descriptions.add("pfRecoTauCorrectedInvariantMassProducer", desc);
+  }
+
+}  // namespace
 DEFINE_FWK_MODULE(PFRecoTauCorrectedInvariantMassProducer);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDecayModeIndexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDecayModeIndexProducer.cc
@@ -19,47 +19,46 @@
 
 namespace {
 
-using namespace reco;
+  using namespace reco;
 
-class PFRecoTauDecayModeIndexProducer final : public PFTauDiscriminationProducerBase {
-   public:
-      explicit PFRecoTauDecayModeIndexProducer(const edm::ParameterSet& iConfig):PFTauDiscriminationProducerBase(iConfig) {   
-         PFTauDecayModeProducer_     = iConfig.getParameter<edm::InputTag>("PFTauDecayModeProducer");
-      }
-      ~PFRecoTauDecayModeIndexProducer() override{} 
-      double discriminate(const PFTauRef& thePFTauRef) const override ;
-      void beginEvent(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-   private:
-      edm::InputTag PFTauDecayModeProducer_;
-      edm::Handle<PFTauDecayModeAssociation> decayModes_; // holds the PFTauDecayModes for the current event
-};
+  class PFRecoTauDecayModeIndexProducer final : public PFTauDiscriminationProducerBase {
+  public:
+    explicit PFRecoTauDecayModeIndexProducer(const edm::ParameterSet& iConfig)
+        : PFTauDiscriminationProducerBase(iConfig) {
+      PFTauDecayModeProducer_ = iConfig.getParameter<edm::InputTag>("PFTauDecayModeProducer");
+    }
+    ~PFRecoTauDecayModeIndexProducer() override {}
+    double discriminate(const PFTauRef& thePFTauRef) const override;
+    void beginEvent(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+  private:
+    edm::InputTag PFTauDecayModeProducer_;
+    edm::Handle<PFTauDecayModeAssociation> decayModes_;  // holds the PFTauDecayModes for the current event
+  };
 
-void PFRecoTauDecayModeIndexProducer::beginEvent(const edm::Event& event, const edm::EventSetup& evtSetup)
-{
-   // Get the PFTau Decay Modes
-   event.getByLabel(PFTauDecayModeProducer_, decayModes_);
-}
+  void PFRecoTauDecayModeIndexProducer::beginEvent(const edm::Event& event, const edm::EventSetup& evtSetup) {
+    // Get the PFTau Decay Modes
+    event.getByLabel(PFTauDecayModeProducer_, decayModes_);
+  }
 
-double PFRecoTauDecayModeIndexProducer::discriminate(const PFTauRef& thePFTauRef) const
-{
-   int theDecayModeIndex = -1;
+  double PFRecoTauDecayModeIndexProducer::discriminate(const PFTauRef& thePFTauRef) const {
+    int theDecayModeIndex = -1;
 
-   const PFTauDecayMode& theDecayMode = (*decayModes_)[thePFTauRef];
+    const PFTauDecayMode& theDecayMode = (*decayModes_)[thePFTauRef];
 
-   // retrieve decay mode
-   theDecayModeIndex = static_cast<int>(theDecayMode.getDecayMode()); 
+    // retrieve decay mode
+    theDecayModeIndex = static_cast<int>(theDecayMode.getDecayMode());
 
-   if (theDecayModeIndex < 0) theDecayModeIndex = -1;
+    if (theDecayModeIndex < 0)
+      theDecayModeIndex = -1;
 
-   return theDecayModeIndex;
-}
-  
-}
+    return theDecayModeIndex;
+  }
 
-void
-PFRecoTauDecayModeIndexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+}  // namespace
+
+void PFRecoTauDecayModeIndexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfTauDecayModeIndexProducer
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("PFTauDecayModeProducer", edm::InputTag("pfRecoTauDecayModeProducer"));

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron.cc
@@ -12,124 +12,109 @@
 
 namespace {
 
-using namespace reco;
+  using namespace reco;
 
-class PFRecoTauDiscriminationAgainstElectron final : public PFTauDiscriminationProducerBase  {
-   public:
-      explicit PFRecoTauDiscriminationAgainstElectron(const edm::ParameterSet& iConfig):PFTauDiscriminationProducerBase(iConfig) {
+  class PFRecoTauDiscriminationAgainstElectron final : public PFTauDiscriminationProducerBase {
+  public:
+    explicit PFRecoTauDiscriminationAgainstElectron(const edm::ParameterSet& iConfig)
+        : PFTauDiscriminationProducerBase(iConfig) {
+      emFraction_maxValue_ = iConfig.getParameter<double>("EmFraction_maxValue");
+      applyCut_emFraction_ = iConfig.getParameter<bool>("ApplyCut_EmFraction");
+      hcalTotOverPLead_minValue_ = iConfig.getParameter<double>("HcalTotOverPLead_minValue");
+      applyCut_hcalTotOverPLead_ = iConfig.getParameter<bool>("ApplyCut_HcalTotOverPLead");
+      hcalMaxOverPLead_minValue_ = iConfig.getParameter<double>("HcalMaxOverPLead_minValue");
+      applyCut_hcalMaxOverPLead_ = iConfig.getParameter<bool>("ApplyCut_HcalMaxOverPLead");
+      hcal3x3OverPLead_minValue_ = iConfig.getParameter<double>("Hcal3x3OverPLead_minValue");
 
-         emFraction_maxValue_              = iConfig.getParameter<double>("EmFraction_maxValue");
-         applyCut_emFraction_              = iConfig.getParameter<bool>("ApplyCut_EmFraction");
-         hcalTotOverPLead_minValue_        = iConfig.getParameter<double>("HcalTotOverPLead_minValue");
-         applyCut_hcalTotOverPLead_        = iConfig.getParameter<bool>("ApplyCut_HcalTotOverPLead");
-         hcalMaxOverPLead_minValue_        = iConfig.getParameter<double>("HcalMaxOverPLead_minValue");
-         applyCut_hcalMaxOverPLead_        = iConfig.getParameter<bool>("ApplyCut_HcalMaxOverPLead");
-         hcal3x3OverPLead_minValue_        = iConfig.getParameter<double>("Hcal3x3OverPLead_minValue");
+      applyCut_hcal3x3OverPLead_ = iConfig.getParameter<bool>("ApplyCut_Hcal3x3OverPLead");
+      EOverPLead_minValue_ = iConfig.getParameter<double>("EOverPLead_minValue");
+      EOverPLead_maxValue_ = iConfig.getParameter<double>("EOverPLead_maxValue");
+      applyCut_EOverPLead_ = iConfig.getParameter<bool>("ApplyCut_EOverPLead");
+      bremsRecoveryEOverPLead_minValue_ = iConfig.getParameter<double>("BremsRecoveryEOverPLead_minValue");
+      bremsRecoveryEOverPLead_maxValue_ = iConfig.getParameter<double>("BremsRecoveryEOverPLead_maxValue");
 
-         applyCut_hcal3x3OverPLead_        = iConfig.getParameter<bool>("ApplyCut_Hcal3x3OverPLead");
-         EOverPLead_minValue_              = iConfig.getParameter<double>("EOverPLead_minValue");
-         EOverPLead_maxValue_              = iConfig.getParameter<double>("EOverPLead_maxValue");
-         applyCut_EOverPLead_              = iConfig.getParameter<bool>("ApplyCut_EOverPLead");
-         bremsRecoveryEOverPLead_minValue_ = iConfig.getParameter<double>("BremsRecoveryEOverPLead_minValue");
-         bremsRecoveryEOverPLead_maxValue_ = iConfig.getParameter<double>("BremsRecoveryEOverPLead_maxValue");
+      applyCut_bremsRecoveryEOverPLead_ = iConfig.getParameter<bool>("ApplyCut_BremsRecoveryEOverPLead");
 
-         applyCut_bremsRecoveryEOverPLead_ = iConfig.getParameter<bool>("ApplyCut_BremsRecoveryEOverPLead");
+      applyCut_electronPreID_ = iConfig.getParameter<bool>("ApplyCut_ElectronPreID");
 
-         applyCut_electronPreID_           = iConfig.getParameter<bool>("ApplyCut_ElectronPreID");
+      applyCut_electronPreID_2D_ = iConfig.getParameter<bool>("ApplyCut_ElectronPreID_2D");
 
-         applyCut_electronPreID_2D_        = iConfig.getParameter<bool>("ApplyCut_ElectronPreID_2D");
+      elecPreID0_EOverPLead_maxValue_ = iConfig.getParameter<double>("ElecPreID0_EOverPLead_maxValue");
+      elecPreID0_HOverPLead_minValue_ = iConfig.getParameter<double>("ElecPreID0_HOverPLead_minValue");
+      elecPreID1_EOverPLead_maxValue_ = iConfig.getParameter<double>("ElecPreID1_EOverPLead_maxValue");
+      elecPreID1_HOverPLead_minValue_ = iConfig.getParameter<double>("ElecPreID1_HOverPLead_minValue");
 
-         elecPreID0_EOverPLead_maxValue_   = iConfig.getParameter<double>("ElecPreID0_EOverPLead_maxValue");
-         elecPreID0_HOverPLead_minValue_   = iConfig.getParameter<double>("ElecPreID0_HOverPLead_minValue");
-         elecPreID1_EOverPLead_maxValue_   = iConfig.getParameter<double>("ElecPreID1_EOverPLead_maxValue");
-         elecPreID1_HOverPLead_minValue_   = iConfig.getParameter<double>("ElecPreID1_HOverPLead_minValue");
+      applyCut_PFElectronMVA_ = iConfig.getParameter<bool>("ApplyCut_PFElectronMVA");
+      pfelectronMVA_maxValue_ = iConfig.getParameter<double>("PFElectronMVA_maxValue");
 
+      applyCut_ecalCrack_ = iConfig.getParameter<bool>("ApplyCut_EcalCrackCut");
 
-         applyCut_PFElectronMVA_           = iConfig.getParameter<bool>("ApplyCut_PFElectronMVA");
-         pfelectronMVA_maxValue_           = iConfig.getParameter<double>("PFElectronMVA_maxValue");
+      applyCut_bremCombined_ = iConfig.getParameter<bool>("ApplyCut_BremCombined");
+      bremCombined_fraction_ = iConfig.getParameter<double>("BremCombined_Fraction");
+      bremCombined_maxHOP_ = iConfig.getParameter<double>("BremCombined_HOP");
+      bremCombined_minMass_ = iConfig.getParameter<double>("BremCombined_Mass");
+      bremCombined_stripSize_ = iConfig.getParameter<double>("BremCombined_StripSize");
+    }
 
+    double discriminate(const PFTauRef& pfTau) const override;
 
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-         applyCut_ecalCrack_               = iConfig.getParameter<bool>("ApplyCut_EcalCrackCut");
+    ~PFRecoTauDiscriminationAgainstElectron() override {}
 
-         applyCut_bremCombined_            = iConfig.getParameter<bool>("ApplyCut_BremCombined");
-         bremCombined_fraction_            = iConfig.getParameter<double>("BremCombined_Fraction");
-         bremCombined_maxHOP_              = iConfig.getParameter<double>("BremCombined_HOP");
-         bremCombined_minMass_             = iConfig.getParameter<double>("BremCombined_Mass");
-         bremCombined_stripSize_           = iConfig.getParameter<double>("BremCombined_StripSize");
+  private:
+    bool isInEcalCrack(double) const;
+    edm::InputTag PFTauProducer_;
+    bool applyCut_emFraction_;
+    double emFraction_maxValue_;
+    bool applyCut_hcalTotOverPLead_;
+    double hcalTotOverPLead_minValue_;
+    bool applyCut_hcalMaxOverPLead_;
+    double hcalMaxOverPLead_minValue_;
+    bool applyCut_hcal3x3OverPLead_;
+    double hcal3x3OverPLead_minValue_;
 
-      }
+    bool applyCut_EOverPLead_;
+    double EOverPLead_minValue_;
+    double EOverPLead_maxValue_;
+    bool applyCut_bremsRecoveryEOverPLead_;
+    double bremsRecoveryEOverPLead_minValue_;
+    double bremsRecoveryEOverPLead_maxValue_;
 
-      double discriminate(const PFTauRef& pfTau) const override;
+    bool applyCut_electronPreID_;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    bool applyCut_electronPreID_2D_;
+    double elecPreID0_EOverPLead_maxValue_;
+    double elecPreID0_HOverPLead_minValue_;
+    double elecPreID1_EOverPLead_maxValue_;
+    double elecPreID1_HOverPLead_minValue_;
 
-      ~PFRecoTauDiscriminationAgainstElectron() override{}
+    bool applyCut_PFElectronMVA_;
+    double pfelectronMVA_maxValue_;
+    bool applyCut_ecalCrack_;
 
-   private:
-      bool isInEcalCrack(double) const;
-      edm::InputTag PFTauProducer_;
-      bool applyCut_emFraction_;
-      double emFraction_maxValue_;
-      bool applyCut_hcalTotOverPLead_;
-      double hcalTotOverPLead_minValue_;
-      bool applyCut_hcalMaxOverPLead_;
-      double hcalMaxOverPLead_minValue_;
-      bool applyCut_hcal3x3OverPLead_;
-      double hcal3x3OverPLead_minValue_;
+    bool applyCut_bremCombined_;
+    double bremCombined_fraction_;
+    double bremCombined_maxHOP_;
+    double bremCombined_minMass_;
+    double bremCombined_stripSize_;
+  };
 
-      bool applyCut_EOverPLead_;
-      double EOverPLead_minValue_;
-      double EOverPLead_maxValue_;
-      bool applyCut_bremsRecoveryEOverPLead_;
-      double bremsRecoveryEOverPLead_minValue_;
-      double bremsRecoveryEOverPLead_maxValue_;
-
-      bool applyCut_electronPreID_;
-
-      bool applyCut_electronPreID_2D_;
-      double elecPreID0_EOverPLead_maxValue_;
-      double elecPreID0_HOverPLead_minValue_;
-      double elecPreID1_EOverPLead_maxValue_;
-      double elecPreID1_HOverPLead_minValue_;
-
-      bool applyCut_PFElectronMVA_;
-      double pfelectronMVA_maxValue_;
-      bool applyCut_ecalCrack_;
-
-      bool   applyCut_bremCombined_;
-      double bremCombined_fraction_;
-      double bremCombined_maxHOP_;
-      double bremCombined_minMass_;
-      double bremCombined_stripSize_;
-
-
-
-};
-
-double PFRecoTauDiscriminationAgainstElectron::discriminate(const PFTauRef& thePFTauRef) const 
-{
-
-
-
+  double PFRecoTauDiscriminationAgainstElectron::discriminate(const PFTauRef& thePFTauRef) const {
     // ensure tau has at least one charged object
 
-    if( (*thePFTauRef).leadPFChargedHadrCand().isNull() )
-    {
-       return 0.;
-    } else
-    {
-       // Check if track goes to Ecal crack
-       TrackRef myleadTk;
-       myleadTk=(*thePFTauRef).leadPFChargedHadrCand()->trackRef();
-       math::XYZPointF myleadTkEcalPos = (*thePFTauRef).leadPFChargedHadrCand()->positionAtECALEntrance();
-       if(myleadTk.isNonnull())
-       {
-          if (applyCut_ecalCrack_ && isInEcalCrack(myleadTkEcalPos.eta()))
-          {
-             return 0.;
-          }
-       }
+    if ((*thePFTauRef).leadPFChargedHadrCand().isNull()) {
+      return 0.;
+    } else {
+      // Check if track goes to Ecal crack
+      TrackRef myleadTk;
+      myleadTk = (*thePFTauRef).leadPFChargedHadrCand()->trackRef();
+      math::XYZPointF myleadTkEcalPos = (*thePFTauRef).leadPFChargedHadrCand()->positionAtECALEntrance();
+      if (myleadTk.isNonnull()) {
+        if (applyCut_ecalCrack_ && isInEcalCrack(myleadTkEcalPos.eta())) {
+          return 0.;
+        }
+      }
     }
 
     bool decision = false;
@@ -140,67 +125,64 @@ double PFRecoTauDiscriminationAgainstElectron::discriminate(const PFTauRef& theP
 
     if (applyCut_emFraction_) {
       if ((*thePFTauRef).emFraction() > emFraction_maxValue_) {
-	emfPass = false;
+        emfPass = false;
       }
     }
     if (applyCut_hcalTotOverPLead_) {
       if ((*thePFTauRef).hcalTotOverPLead() < hcalTotOverPLead_minValue_) {
-	htotPass = false;
+        htotPass = false;
       }
     }
     if (applyCut_hcalMaxOverPLead_) {
       if ((*thePFTauRef).hcalMaxOverPLead() < hcalMaxOverPLead_minValue_) {
-	hmaxPass = false;
+        hmaxPass = false;
       }
     }
     if (applyCut_hcal3x3OverPLead_) {
       if ((*thePFTauRef).hcal3x3OverPLead() < hcal3x3OverPLead_minValue_) {
-	h3x3Pass = false;
+        h3x3Pass = false;
       }
     }
     if (applyCut_EOverPLead_) {
       if ((*thePFTauRef).ecalStripSumEOverPLead() > EOverPLead_minValue_ &&
-	  (*thePFTauRef).ecalStripSumEOverPLead() < EOverPLead_maxValue_) {
-	estripPass = false;
+          (*thePFTauRef).ecalStripSumEOverPLead() < EOverPLead_maxValue_) {
+        estripPass = false;
       } else {
-	estripPass = true;
+        estripPass = true;
       }
     }
     if (applyCut_bremsRecoveryEOverPLead_) {
       if ((*thePFTauRef).bremsRecoveryEOverPLead() > bremsRecoveryEOverPLead_minValue_ &&
-	  (*thePFTauRef).bremsRecoveryEOverPLead() < bremsRecoveryEOverPLead_maxValue_) {
-	erecovPass = false;
+          (*thePFTauRef).bremsRecoveryEOverPLead() < bremsRecoveryEOverPLead_maxValue_) {
+        erecovPass = false;
       } else {
-	erecovPass = true;
+        erecovPass = true;
       }
     }
     if (applyCut_electronPreID_) {
       if ((*thePFTauRef).electronPreIDDecision()) {
-	epreidPass = false;
-      }  else {
-	epreidPass = true;
+        epreidPass = false;
+      } else {
+        epreidPass = true;
       }
     }
 
     if (applyCut_electronPreID_2D_) {
-      if (
-	  ((*thePFTauRef).electronPreIDDecision() &&
-	   ((*thePFTauRef).ecalStripSumEOverPLead() < elecPreID1_EOverPLead_maxValue_ ||
-	    (*thePFTauRef).hcal3x3OverPLead() > elecPreID1_HOverPLead_minValue_))
-	  ||
-	  (!(*thePFTauRef).electronPreIDDecision() &&
-	   ((*thePFTauRef).ecalStripSumEOverPLead() < elecPreID0_EOverPLead_maxValue_ ||
-	    (*thePFTauRef).hcal3x3OverPLead() > elecPreID0_HOverPLead_minValue_))
-	  ){
-	epreid2DPass = true;
-      }  else {
-	epreid2DPass = false;
+      if (((*thePFTauRef).electronPreIDDecision() &&
+           ((*thePFTauRef).ecalStripSumEOverPLead() < elecPreID1_EOverPLead_maxValue_ ||
+            (*thePFTauRef).hcal3x3OverPLead() > elecPreID1_HOverPLead_minValue_)) ||
+          (!(*thePFTauRef).electronPreIDDecision() &&
+           ((*thePFTauRef).ecalStripSumEOverPLead() < elecPreID0_EOverPLead_maxValue_ ||
+            (*thePFTauRef).hcal3x3OverPLead() > elecPreID0_HOverPLead_minValue_))) {
+        epreid2DPass = true;
+      } else {
+        epreid2DPass = false;
       }
     }
 
     if (applyCut_PFElectronMVA_) {
-      if ((*thePFTauRef).electronPreIDOutput()>pfelectronMVA_maxValue_) {
-	mvaPass = false;
+      if ((*thePFTauRef).electronPreIDOutput() > pfelectronMVA_maxValue_) {
+        mvaPass = false;
       }
     }
     if (applyCut_bremCombined_) {
@@ -208,47 +190,39 @@ double PFRecoTauDiscriminationAgainstElectron::discriminate(const PFTauRef& theP
         // No KF track found
         return 0;
       }
-      if(thePFTauRef->signalPFChargedHadrCands().size()==1 && thePFTauRef->signalPFGammaCands().empty()) {
-	if(thePFTauRef->leadPFChargedHadrCand()->hcalEnergy()/thePFTauRef->leadPFChargedHadrCand()->trackRef()->p()<bremCombined_maxHOP_)
-	  bremCombinedPass = false;
-      }
-      else if(thePFTauRef->signalPFChargedHadrCands().size()==1 && !thePFTauRef->signalPFGammaCands().empty()) {
-	//calculate the brem ratio energy
-	float bremEnergy=0.;
-	float emEnergy=0.;
-	for(unsigned int Nc = 0 ;Nc < thePFTauRef->signalPFGammaCands().size();++Nc)
-	  {
-	    PFCandidatePtr cand = thePFTauRef->signalPFGammaCands().at(Nc);
-	    if(fabs(thePFTauRef->leadPFChargedHadrCand()->trackRef()->eta()-cand->eta())<bremCombined_stripSize_)
-	      bremEnergy+=cand->energy();
-	    emEnergy+=cand->energy();
-	  }
-	if(bremEnergy/emEnergy>bremCombined_fraction_&&thePFTauRef->mass()<bremCombined_minMass_)
-	  bremCombinedPass = false;
-
+      if (thePFTauRef->signalPFChargedHadrCands().size() == 1 && thePFTauRef->signalPFGammaCands().empty()) {
+        if (thePFTauRef->leadPFChargedHadrCand()->hcalEnergy() / thePFTauRef->leadPFChargedHadrCand()->trackRef()->p() <
+            bremCombined_maxHOP_)
+          bremCombinedPass = false;
+      } else if (thePFTauRef->signalPFChargedHadrCands().size() == 1 && !thePFTauRef->signalPFGammaCands().empty()) {
+        //calculate the brem ratio energy
+        float bremEnergy = 0.;
+        float emEnergy = 0.;
+        for (unsigned int Nc = 0; Nc < thePFTauRef->signalPFGammaCands().size(); ++Nc) {
+          PFCandidatePtr cand = thePFTauRef->signalPFGammaCands().at(Nc);
+          if (fabs(thePFTauRef->leadPFChargedHadrCand()->trackRef()->eta() - cand->eta()) < bremCombined_stripSize_)
+            bremEnergy += cand->energy();
+          emEnergy += cand->energy();
+        }
+        if (bremEnergy / emEnergy > bremCombined_fraction_ && thePFTauRef->mass() < bremCombined_minMass_)
+          bremCombinedPass = false;
       }
     }
 
-    decision = emfPass && htotPass && hmaxPass &&
-      h3x3Pass && estripPass && erecovPass && epreidPass && epreid2DPass && mvaPass &&bremCombinedPass;
+    decision = emfPass && htotPass && hmaxPass && h3x3Pass && estripPass && erecovPass && epreidPass && epreid2DPass &&
+               mvaPass && bremCombinedPass;
 
     return (decision ? 1. : 0.);
-}
+  }
 
-bool
-PFRecoTauDiscriminationAgainstElectron::isInEcalCrack(double eta) const
-{
-  eta = fabs(eta);
-  return (eta < 0.018 ||
-	  (eta>0.423 && eta<0.461) ||
-	  (eta>0.770 && eta<0.806) ||
-	  (eta>1.127 && eta<1.163) ||
-	  (eta>1.460 && eta<1.558));
-}
-}
+  bool PFRecoTauDiscriminationAgainstElectron::isInEcalCrack(double eta) const {
+    eta = fabs(eta);
+    return (eta < 0.018 || (eta > 0.423 && eta < 0.461) || (eta > 0.770 && eta < 0.806) ||
+            (eta > 1.127 && eta < 1.163) || (eta > 1.460 && eta < 1.558));
+  }
+}  // namespace
 
-void
-PFRecoTauDiscriminationAgainstElectron::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauDiscriminationAgainstElectron::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfRecoTauDiscriminationAgainstElectron
   edm::ParameterSetDescription desc;
   desc.add<bool>("ApplyCut_ElectronPreID_2D", false);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron2.cc
@@ -25,16 +25,14 @@
 #include <sstream>
 #include <fstream>
 #include <vector>
- 
+
 using namespace reco;
 typedef std::pair<double, double> pdouble;
 
-class PFRecoTauDiscriminationAgainstElectron2 : public PFTauDiscriminationProducerBase  {
+class PFRecoTauDiscriminationAgainstElectron2 : public PFTauDiscriminationProducerBase {
 public:
   explicit PFRecoTauDiscriminationAgainstElectron2(const edm::ParameterSet& iConfig)
-    : PFTauDiscriminationProducerBase(iConfig)
-  {
-
+      : PFTauDiscriminationProducerBase(iConfig) {
     LeadPFChargedHadrEoP_barrel_min_ = iConfig.getParameter<double>("LeadPFChargedHadrEoP_barrel_min");
     LeadPFChargedHadrEoP_barrel_max_ = iConfig.getParameter<double>("LeadPFChargedHadrEoP_barrel_max");
     Hcal3x3OverPLead_barrel_max_ = iConfig.getParameter<double>("Hcal3x3OverPLead_barrel_max");
@@ -50,17 +48,17 @@ public:
     GammaPhiMom_endcap_max_ = iConfig.getParameter<double>("GammaPhiMom_endcap_max");
     GammaEnFrac_endcap_max_ = iConfig.getParameter<double>("GammaEnFrac_endcap_max");
     keepTausInEcalCrack_ = iConfig.getParameter<bool>("keepTausInEcalCrack");
-    rejectTausInEcalCrack_ = iConfig.getParameter<bool>("rejectTausInEcalCrack"); 
+    rejectTausInEcalCrack_ = iConfig.getParameter<bool>("rejectTausInEcalCrack");
 
-    applyCut_hcal3x3OverPLead_ = iConfig.getParameter<bool>("applyCut_hcal3x3OverPLead");  
-    applyCut_leadPFChargedHadrEoP_ = iConfig.getParameter<bool>("applyCut_leadPFChargedHadrEoP");  
-    applyCut_GammaEtaMom_ = iConfig.getParameter<bool>("applyCut_GammaEtaMom");  
-    applyCut_GammaPhiMom_ = iConfig.getParameter<bool>("applyCut_GammaPhiMom");  
-    applyCut_GammaEnFrac_ = iConfig.getParameter<bool>("applyCut_GammaEnFrac");  
+    applyCut_hcal3x3OverPLead_ = iConfig.getParameter<bool>("applyCut_hcal3x3OverPLead");
+    applyCut_leadPFChargedHadrEoP_ = iConfig.getParameter<bool>("applyCut_leadPFChargedHadrEoP");
+    applyCut_GammaEtaMom_ = iConfig.getParameter<bool>("applyCut_GammaEtaMom");
+    applyCut_GammaPhiMom_ = iConfig.getParameter<bool>("applyCut_GammaPhiMom");
+    applyCut_GammaEnFrac_ = iConfig.getParameter<bool>("applyCut_GammaEnFrac");
     applyCut_HLTSpecific_ = iConfig.getParameter<bool>("applyCut_HLTSpecific");
 
     etaCracks_string_ = iConfig.getParameter<std::vector<std::string>>("etaCracks");
-    
+
     verbosity_ = iConfig.getParameter<int>("verbosity");
 
     cuts2_ = new AntiElectronIDCut2();
@@ -69,18 +67,18 @@ public:
   void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
   double discriminate(const PFTauRef&) const override;
-  
-  ~PFRecoTauDiscriminationAgainstElectron2() override
-  {  }
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  ~PFRecoTauDiscriminationAgainstElectron2() override {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 private:
   bool isInEcalCrack(double) const;
   std::vector<pdouble> etaCracks_;
   std::vector<std::string> etaCracks_string_;
 
   AntiElectronIDCut2* cuts2_;
-  
+
   double LeadPFChargedHadrEoP_barrel_min_;
   double LeadPFChargedHadrEoP_barrel_max_;
   double Hcal3x3OverPLead_barrel_max_;
@@ -99,52 +97,49 @@ private:
   bool keepTausInEcalCrack_;
   bool rejectTausInEcalCrack_;
 
-  bool applyCut_hcal3x3OverPLead_; 
-  bool applyCut_leadPFChargedHadrEoP_; 
-  bool applyCut_GammaEtaMom_; 
-  bool applyCut_GammaPhiMom_; 
-  bool applyCut_GammaEnFrac_; 
+  bool applyCut_hcal3x3OverPLead_;
+  bool applyCut_leadPFChargedHadrEoP_;
+  bool applyCut_GammaEtaMom_;
+  bool applyCut_GammaPhiMom_;
+  bool applyCut_GammaEnFrac_;
   bool applyCut_HLTSpecific_;
 
   int verbosity_;
 };
 
-void PFRecoTauDiscriminationAgainstElectron2::beginEvent(const edm::Event& evt, const edm::EventSetup& es)
-{
+void PFRecoTauDiscriminationAgainstElectron2::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
   cuts2_->SetBarrelCutValues(LeadPFChargedHadrEoP_barrel_min_,
-                            LeadPFChargedHadrEoP_barrel_max_,
-                            Hcal3x3OverPLead_barrel_max_,
-                            GammaEtaMom_barrel_max_,
-                            GammaPhiMom_barrel_max_,
-                            GammaEnFrac_barrel_max_
-                            );
-  
+                             LeadPFChargedHadrEoP_barrel_max_,
+                             Hcal3x3OverPLead_barrel_max_,
+                             GammaEtaMom_barrel_max_,
+                             GammaPhiMom_barrel_max_,
+                             GammaEnFrac_barrel_max_);
+
   cuts2_->SetEndcapCutValues(LeadPFChargedHadrEoP_endcap_min1_,
-                            LeadPFChargedHadrEoP_endcap_max1_,
-                            LeadPFChargedHadrEoP_endcap_min2_,
-                            LeadPFChargedHadrEoP_endcap_max2_,
-                            Hcal3x3OverPLead_endcap_max_,
-                            GammaEtaMom_endcap_max_,
-                            GammaPhiMom_endcap_max_,
-                            GammaEnFrac_endcap_max_
-                            );
+                             LeadPFChargedHadrEoP_endcap_max1_,
+                             LeadPFChargedHadrEoP_endcap_min2_,
+                             LeadPFChargedHadrEoP_endcap_max2_,
+                             Hcal3x3OverPLead_endcap_max_,
+                             GammaEtaMom_endcap_max_,
+                             GammaPhiMom_endcap_max_,
+                             GammaEnFrac_endcap_max_);
 
   cuts2_->ApplyCut_EcalCrack(keepTausInEcalCrack_, rejectTausInEcalCrack_);
 
-  cuts2_->ApplyCuts(applyCut_hcal3x3OverPLead_,  
-		    applyCut_leadPFChargedHadrEoP_,  
-		    applyCut_GammaEtaMom_,  
-		    applyCut_GammaPhiMom_,  
-		    applyCut_GammaEnFrac_,  
-		    applyCut_HLTSpecific_ 
-		    );
+  cuts2_->ApplyCuts(applyCut_hcal3x3OverPLead_,
+                    applyCut_leadPFChargedHadrEoP_,
+                    applyCut_GammaEtaMom_,
+                    applyCut_GammaPhiMom_,
+                    applyCut_GammaEnFrac_,
+                    applyCut_HLTSpecific_);
   //Ecal cracks in eta
   etaCracks_.clear();
   TPRegexp regexpParser_range("([0-9.e+/-]+):([0-9.e+/-]+)");
-  for ( std::vector<std::string>::const_iterator etaCrack = etaCracks_string_.begin();
-	etaCrack != etaCracks_string_.end(); ++etaCrack ) {
+  for (std::vector<std::string>::const_iterator etaCrack = etaCracks_string_.begin();
+       etaCrack != etaCracks_string_.end();
+       ++etaCrack) {
     TObjArray* subStrings = regexpParser_range.MatchS(etaCrack->data());
-    if ( subStrings->GetEntries() == 3 ) {
+    if (subStrings->GetEntries() == 3) {
       //std::cout << "substrings(1) = " << ((TObjString*)subStrings->At(1))->GetString() << std::endl;
       double range_begin = ((TObjString*)subStrings->At(1))->GetString().Atof();
       //std::cout << "substrings(2) = " << ((TObjString*)subStrings->At(2))->GetString() << std::endl;
@@ -152,31 +147,26 @@ void PFRecoTauDiscriminationAgainstElectron2::beginEvent(const edm::Event& evt, 
       etaCracks_.push_back(pdouble(range_begin, range_end));
     }
   }
-  
-  cuts2_->SetEcalCracks(etaCracks_);
 
+  cuts2_->SetEcalCracks(etaCracks_);
 }
 
-double PFRecoTauDiscriminationAgainstElectron2::discriminate(const PFTauRef& thePFTauRef) const
-{
+double PFRecoTauDiscriminationAgainstElectron2::discriminate(const PFTauRef& thePFTauRef) const {
   double discriminator = 0.;
-  
+
   // ensure tau has at least one charged object
 
-  if( (*thePFTauRef).leadChargedHadrCand().isNull() )
-    {
-      return 0.;
-    } 
-  else
-    {
-      discriminator = cuts2_->Discriminator(*thePFTauRef);
-    }
+  if ((*thePFTauRef).leadChargedHadrCand().isNull()) {
+    return 0.;
+  } else {
+    discriminator = cuts2_->Discriminator(*thePFTauRef);
+  }
 
-
-  if ( verbosity_ ) {
-    std::cout<<" Taus : "<<TauProducer_<<std::endl;
+  if (verbosity_) {
+    std::cout << " Taus : " << TauProducer_ << std::endl;
     std::cout << "<PFRecoTauDiscriminationAgainstElectron2::discriminate>:" << std::endl;
-    std::cout << " tau: Pt = " << thePFTauRef->pt() << ", eta = " << thePFTauRef->eta() << ", phi = " << thePFTauRef->phi() << std::endl;
+    std::cout << " tau: Pt = " << thePFTauRef->pt() << ", eta = " << thePFTauRef->eta()
+              << ", phi = " << thePFTauRef->phi() << std::endl;
     std::cout << " discriminator value = " << discriminator << std::endl;
     std::cout << " Prongs in tau: " << thePFTauRef->signalChargedHadrCands().size() << std::endl;
   }
@@ -184,19 +174,13 @@ double PFRecoTauDiscriminationAgainstElectron2::discriminate(const PFTauRef& the
   return discriminator;
 }
 
-bool
-PFRecoTauDiscriminationAgainstElectron2::isInEcalCrack(double eta) const
-{
+bool PFRecoTauDiscriminationAgainstElectron2::isInEcalCrack(double eta) const {
   eta = fabs(eta);
-  return (eta < 0.018 ||
-          (eta>0.423 && eta<0.461) ||
-          (eta>0.770 && eta<0.806) ||
-          (eta>1.127 && eta<1.163) ||
-          (eta>1.460 && eta<1.558));
+  return (eta < 0.018 || (eta > 0.423 && eta < 0.461) || (eta > 0.770 && eta < 0.806) || (eta > 1.127 && eta < 1.163) ||
+          (eta > 1.460 && eta < 1.558));
 }
 
-void
-PFRecoTauDiscriminationAgainstElectron2::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauDiscriminationAgainstElectron2::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfRecoTauDiscriminationAgainstElectron2
   edm::ParameterSetDescription desc;
   desc.add<bool>("rejectTausInEcalCrack", false);
@@ -233,13 +217,14 @@ PFRecoTauDiscriminationAgainstElectron2::fillDescriptions(edm::ConfigurationDesc
   desc.add<double>("GammaEnFrac_endcap_max", 0.2);
   desc.add<bool>("applyCut_hcal3x3OverPLead", true);
   desc.add<bool>("applyCut_GammaEtaMom", false);
-  desc.add<std::vector<std::string>>("etaCracks", {
-    "0.0:0.018",
-    "0.423:0.461",
-    "0.770:0.806",
-    "1.127:1.163",
-    "1.460:1.558",
-  });
+  desc.add<std::vector<std::string>>("etaCracks",
+                                     {
+                                         "0.0:0.018",
+                                         "0.423:0.461",
+                                         "0.770:0.806",
+                                         "1.127:1.163",
+                                         "1.460:1.558",
+                                     });
   desc.add<double>("Hcal3x3OverPLead_barrel_max", 0.2);
   descriptions.add("pfRecoTauDiscriminationAgainstElectron2", desc);
 }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon.cc
@@ -18,28 +18,26 @@
 
 using namespace reco;
 
-class PFRecoTauDiscriminationAgainstMuon : public PFTauDiscriminationProducerBase 
-{
- public:
+class PFRecoTauDiscriminationAgainstMuon : public PFTauDiscriminationProducerBase {
+public:
   explicit PFRecoTauDiscriminationAgainstMuon(const edm::ParameterSet& iConfig)
-    : PFTauDiscriminationProducerBase(iConfig) 
-  {   
-    discriminatorOption_  = iConfig.getParameter<std::string>("discriminatorOption");  
-    hop_  = iConfig.getParameter<double>("HoPMin");  
-    a  = iConfig.getParameter<double>("a");  
-    b  = iConfig.getParameter<double>("b");  
-    c  = iConfig.getParameter<double>("c");  	 
+      : PFTauDiscriminationProducerBase(iConfig) {
+    discriminatorOption_ = iConfig.getParameter<std::string>("discriminatorOption");
+    hop_ = iConfig.getParameter<double>("HoPMin");
+    a = iConfig.getParameter<double>("a");
+    b = iConfig.getParameter<double>("b");
+    c = iConfig.getParameter<double>("c");
     maxNumberOfMatches_ = iConfig.getParameter<int>("maxNumberOfMatches");
     checkNumMatches_ = iConfig.getParameter<bool>("checkNumMatches");
   }
 
-  ~PFRecoTauDiscriminationAgainstMuon() override {} 
+  ~PFRecoTauDiscriminationAgainstMuon() override {}
 
   double discriminate(const PFTauRef& pfTau) const override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:  
+private:
   std::string discriminatorOption_;
   double hop_;
   double a;
@@ -49,61 +47,72 @@ class PFRecoTauDiscriminationAgainstMuon : public PFTauDiscriminationProducerBas
   bool checkNumMatches_;
 };
 
-double PFRecoTauDiscriminationAgainstMuon::discriminate(const PFTauRef& thePFTauRef) const
-{
+double PFRecoTauDiscriminationAgainstMuon::discriminate(const PFTauRef& thePFTauRef) const {
   bool decision = true;
 
-  if ( thePFTauRef->hasMuonReference() ) {
-
+  if (thePFTauRef->hasMuonReference()) {
     MuonRef muonref = thePFTauRef->leadPFChargedHadrCand()->muonRef();
-    if ( discriminatorOption_ == "noSegMatch" ) {
-      if ( muonref ->numberOfMatches() > maxNumberOfMatches_ ) decision = false;
+    if (discriminatorOption_ == "noSegMatch") {
+      if (muonref->numberOfMatches() > maxNumberOfMatches_)
+        decision = false;
     } else if (discriminatorOption_ == "twoDCut") {
       double seg = muon::segmentCompatibility(*muonref);
-      double calo= muonref->caloCompatibility(); 
-      double border = calo * a + seg * b +c;
-      if ( border > 0 ) decision = false; 
-    } else if ( discriminatorOption_ == "merePresence" ) {
+      double calo = muonref->caloCompatibility();
+      double border = calo * a + seg * b + c;
+      if (border > 0)
+        decision = false;
+    } else if (discriminatorOption_ == "merePresence") {
       decision = false;
-    } else if (discriminatorOption_ == "combined" ) { // testing purpose only
+    } else if (discriminatorOption_ == "combined") {  // testing purpose only
       unsigned int muType = 0;
-      if      ( muonref->isGlobalMuon()  ) muType = 1;
-      else if ( muonref->isCaloMuon()    ) muType = 2;
-      else if ( muonref->isTrackerMuon() ) muType = 3;
+      if (muonref->isGlobalMuon())
+        muType = 1;
+      else if (muonref->isCaloMuon())
+        muType = 2;
+      else if (muonref->isTrackerMuon())
+        muType = 3;
       float muonEnergyFraction = 0.;
       const reco::PFJet* pfJetPtr = dynamic_cast<const reco::PFJet*>(thePFTauRef->pfTauTagInfoRef()->pfjetRef().get());
       if (pfJetPtr) {
-          muonEnergyFraction = pfJetPtr->chargedMuEnergyFraction();
-      } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFJets, and this outdated algorithm was not updated to cope with PFTaus made from other Jets.\n";
+        muonEnergyFraction = pfJetPtr->chargedMuEnergyFraction();
+      } else
+        throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFJets, and this outdated algorithm was "
+                                                 "not updated to cope with PFTaus made from other Jets.\n";
       bool eta_veto = false;
       bool phi_veto = false;
-      if ( fabs(muonref->eta()) > 2.3 || (fabs(muonref->eta()) > 1.4 && fabs(muonref->eta()) < 1.6)) eta_veto = true;
-      if ( muonref->phi() < 0.1 && muonref->phi() > -0.1) phi_veto = true;
-      if ( muType != 1 || muonref ->numberOfMatches() > 0 || eta_veto || phi_veto || muonEnergyFraction > 0.9 ) decision = false; // as place holder
-    } else if ( discriminatorOption_ == "noAllArbitrated" || discriminatorOption_ == "noAllArbitratedWithHOP" ) {
-      if(checkNumMatches_ && muonref ->numberOfMatches() > maxNumberOfMatches_) decision = false;
-      if ( muon::isGoodMuon(*muonref, muon::AllArbitrated) ) decision = false;      
-    } else if ( discriminatorOption_ == "HOP" ) { 
-      decision = true; // only calo. muon cut requested: keep all tau candidates, regardless of signals in muon system
+      if (fabs(muonref->eta()) > 2.3 || (fabs(muonref->eta()) > 1.4 && fabs(muonref->eta()) < 1.6))
+        eta_veto = true;
+      if (muonref->phi() < 0.1 && muonref->phi() > -0.1)
+        phi_veto = true;
+      if (muType != 1 || muonref->numberOfMatches() > 0 || eta_veto || phi_veto || muonEnergyFraction > 0.9)
+        decision = false;  // as place holder
+    } else if (discriminatorOption_ == "noAllArbitrated" || discriminatorOption_ == "noAllArbitratedWithHOP") {
+      if (checkNumMatches_ && muonref->numberOfMatches() > maxNumberOfMatches_)
+        decision = false;
+      if (muon::isGoodMuon(*muonref, muon::AllArbitrated))
+        decision = false;
+    } else if (discriminatorOption_ == "HOP") {
+      decision = true;  // only calo. muon cut requested: keep all tau candidates, regardless of signals in muon system
     } else {
-      throw edm::Exception(edm::errors::UnimplementedFeature) 
-	<< " Invalid Discriminator option = " << discriminatorOption_ << " --> please check cfi file !!\n";
+      throw edm::Exception(edm::errors::UnimplementedFeature)
+          << " Invalid Discriminator option = " << discriminatorOption_ << " --> please check cfi file !!\n";
     }
-  } // valid muon ref
+  }  // valid muon ref
 
   // Additional calo. muon cut: veto one prongs compatible with MIP signature
-  if ( discriminatorOption_ == "HOP" || discriminatorOption_ == "noAllArbitratedWithHOP" ) {
-    if ( thePFTauRef->leadPFChargedHadrCand().isNonnull() ) {
-      double muonCaloEn = thePFTauRef->leadPFChargedHadrCand()->hcalEnergy() + thePFTauRef->leadPFChargedHadrCand()->ecalEnergy();
-      if ( thePFTauRef->decayMode() == 0 && muonCaloEn < (hop_*thePFTauRef->leadPFChargedHadrCand()->p()) ) decision = false;
+  if (discriminatorOption_ == "HOP" || discriminatorOption_ == "noAllArbitratedWithHOP") {
+    if (thePFTauRef->leadPFChargedHadrCand().isNonnull()) {
+      double muonCaloEn =
+          thePFTauRef->leadPFChargedHadrCand()->hcalEnergy() + thePFTauRef->leadPFChargedHadrCand()->ecalEnergy();
+      if (thePFTauRef->decayMode() == 0 && muonCaloEn < (hop_ * thePFTauRef->leadPFChargedHadrCand()->p()))
+        decision = false;
     }
   }
 
   return (decision ? 1. : 0.);
-} 
+}
 
-void
-PFRecoTauDiscriminationAgainstMuon::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauDiscriminationAgainstMuon::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfRecoTauDiscriminationAgainstMuon
   edm::ParameterSetDescription desc;
   desc.add<double>("a", 0.5);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
@@ -34,252 +34,287 @@ using reco::tau::format_vint;
 
 namespace {
 
-class PFRecoTauDiscriminationAgainstMuon2 final : public PFTauDiscriminationProducerBase
-{
-  enum { kLoose, kMedium, kTight, kCustom };
- public:
-  explicit PFRecoTauDiscriminationAgainstMuon2(const edm::ParameterSet& cfg)
-    : PFTauDiscriminationProducerBase(cfg),
-      moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-  {   
-    std::string discriminatorOption_string  = cfg.getParameter<std::string>("discriminatorOption");  
-    if      ( discriminatorOption_string == "loose"  ) discriminatorOption_ = kLoose;
-    else if ( discriminatorOption_string == "medium" ) discriminatorOption_ = kMedium;
-    else if ( discriminatorOption_string == "tight"  ) discriminatorOption_ = kTight;
-    else if ( discriminatorOption_string == "custom" ) discriminatorOption_ = kCustom;
-    else throw edm::Exception(edm::errors::UnimplementedFeature) 
-      << " Invalid Configuration parameter 'discriminatorOption' = " << discriminatorOption_string << " !!\n";
-    hop_ = cfg.getParameter<double>("HoPMin"); 
-    maxNumberOfMatches_ = cfg.getParameter<int>("maxNumberOfMatches");
-    doCaloMuonVeto_     = cfg.getParameter<bool>("doCaloMuonVeto");
-    maxNumberOfHitsLast2Stations_ = cfg.getParameter<int>("maxNumberOfHitsLast2Stations");
+  class PFRecoTauDiscriminationAgainstMuon2 final : public PFTauDiscriminationProducerBase {
+    enum { kLoose, kMedium, kTight, kCustom };
+
+  public:
+    explicit PFRecoTauDiscriminationAgainstMuon2(const edm::ParameterSet& cfg)
+        : PFTauDiscriminationProducerBase(cfg), moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
+      std::string discriminatorOption_string = cfg.getParameter<std::string>("discriminatorOption");
+      if (discriminatorOption_string == "loose")
+        discriminatorOption_ = kLoose;
+      else if (discriminatorOption_string == "medium")
+        discriminatorOption_ = kMedium;
+      else if (discriminatorOption_string == "tight")
+        discriminatorOption_ = kTight;
+      else if (discriminatorOption_string == "custom")
+        discriminatorOption_ = kCustom;
+      else
+        throw edm::Exception(edm::errors::UnimplementedFeature)
+            << " Invalid Configuration parameter 'discriminatorOption' = " << discriminatorOption_string << " !!\n";
+      hop_ = cfg.getParameter<double>("HoPMin");
+      maxNumberOfMatches_ = cfg.getParameter<int>("maxNumberOfMatches");
+      doCaloMuonVeto_ = cfg.getParameter<bool>("doCaloMuonVeto");
+      maxNumberOfHitsLast2Stations_ = cfg.getParameter<int>("maxNumberOfHitsLast2Stations");
       srcMuons_ = cfg.getParameter<edm::InputTag>("srcMuons");
       Muons_token = consumes<reco::MuonCollection>(srcMuons_);
       dRmuonMatch_ = cfg.getParameter<double>("dRmuonMatch");
       dRmuonMatchLimitedToJetArea_ = cfg.getParameter<bool>("dRmuonMatchLimitedToJetArea");
       minPtMatchedMuon_ = cfg.getParameter<double>("minPtMatchedMuon");
-    typedef std::vector<int> vint;
-    maskMatchesDT_  = cfg.getParameter<vint>("maskMatchesDT");
-    maskMatchesCSC_ = cfg.getParameter<vint>("maskMatchesCSC");
-    maskMatchesRPC_ = cfg.getParameter<vint>("maskMatchesRPC");
-    maskHitsDT_     = cfg.getParameter<vint>("maskHitsDT");
-    maskHitsCSC_    = cfg.getParameter<vint>("maskHitsCSC");
-    maskHitsRPC_    = cfg.getParameter<vint>("maskHitsRPC");
-    numWarnings_ = 0;
-    maxWarnings_ = 3;
-    verbosity_ = cfg.getParameter<int>("verbosity");
-   }
-  ~PFRecoTauDiscriminationAgainstMuon2() override {} 
-
-  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-
-  double discriminate(const reco::PFTauRef&) const override;
-
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-
- private:  
-  std::string moduleLabel_;
-  int discriminatorOption_;
-  double hop_;
-  int maxNumberOfMatches_;
-  bool doCaloMuonVeto_;
-  int maxNumberOfHitsLast2Stations_;
-  edm::InputTag srcMuons_;
-  edm::Handle<reco::MuonCollection> muons_;
-  edm::EDGetTokenT<reco::MuonCollection> Muons_token;
-  double dRmuonMatch_;
-  bool dRmuonMatchLimitedToJetArea_;
-  double minPtMatchedMuon_;
-  std::vector<int> maskMatchesDT_;
-  std::vector<int> maskMatchesCSC_;
-  std::vector<int> maskMatchesRPC_;
-  std::vector<int> maskHitsDT_;
-  std::vector<int> maskHitsCSC_;
-  std::vector<int> maskHitsRPC_;
-  mutable int numWarnings_;
-  int maxWarnings_;
-  int verbosity_;
-};
-
-void PFRecoTauDiscriminationAgainstMuon2::beginEvent(const edm::Event& evt, const edm::EventSetup& es) 
-{
-  if ( !srcMuons_.label().empty() ) {
-    evt.getByToken(Muons_token, muons_);
-  }
-}
-
-double PFRecoTauDiscriminationAgainstMuon2::discriminate(const reco::PFTauRef& pfTau) const
-{
-  if ( verbosity_ ) {
-    edm::LogPrint("PFTauAgainstMuon2") << "<PFRecoTauDiscriminationAgainstMuon2::discriminate>:" ;
-    edm::LogPrint("PFTauAgainstMuon2") << " moduleLabel = " << moduleLabel_ ;
-    edm::LogPrint("PFTauAgainstMuon2") << "tau #" << pfTau.key() << ": Pt = " << pfTau->pt() << ", eta = " << pfTau->eta() << ", phi = " << pfTau->phi() ;   
-  }
-
-  std::vector<int> numMatchesDT(4);
-  std::vector<int> numMatchesCSC(4);
-  std::vector<int> numMatchesRPC(4);
-  std::vector<int> numHitsDT(4);
-  std::vector<int> numHitsCSC(4);
-  std::vector<int> numHitsRPC(4);
-  for ( int iStation = 0; iStation < 4; ++iStation ) {
-    numMatchesDT[iStation]  = 0;
-    numMatchesCSC[iStation] = 0;
-    numMatchesRPC[iStation] = 0;    
-    numHitsDT[iStation]     = 0;
-    numHitsCSC[iStation]    = 0;
-    numHitsRPC[iStation]    = 0;
-  } 
-
-  const reco::PFCandidatePtr& pfLeadChargedHadron = pfTau->leadPFChargedHadrCand();
-  if ( pfLeadChargedHadron.isNonnull() ) {
-    reco::MuonRef muonRef = pfLeadChargedHadron->muonRef();
-    if ( muonRef.isNonnull() ) {
-      if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuon2") << " has muonRef." ;
-      reco::tau::countMatches(*muonRef, numMatchesDT, numMatchesCSC, numMatchesRPC);
-      reco::tau::countHits(*muonRef, numHitsDT, numHitsCSC, numHitsRPC);
+      typedef std::vector<int> vint;
+      maskMatchesDT_ = cfg.getParameter<vint>("maskMatchesDT");
+      maskMatchesCSC_ = cfg.getParameter<vint>("maskMatchesCSC");
+      maskMatchesRPC_ = cfg.getParameter<vint>("maskMatchesRPC");
+      maskHitsDT_ = cfg.getParameter<vint>("maskHitsDT");
+      maskHitsCSC_ = cfg.getParameter<vint>("maskHitsCSC");
+      maskHitsRPC_ = cfg.getParameter<vint>("maskHitsRPC");
+      numWarnings_ = 0;
+      maxWarnings_ = 3;
+      verbosity_ = cfg.getParameter<int>("verbosity");
     }
-  }
-  
-  if ( !srcMuons_.label().empty() ) {
-    size_t numMuons = muons_->size();
-    for ( size_t idxMuon = 0; idxMuon < numMuons; ++idxMuon ) {
-      reco::MuonRef muon(muons_, idxMuon);
-      if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuon2") << "muon #" << muon.key() << ": Pt = " << muon->pt() << ", eta = " << muon->eta() << ", phi = " << muon->phi() ;
-      if ( !(muon->pt() > minPtMatchedMuon_) ) {
-	if ( verbosity_ ){ edm::LogPrint("PFTauAgainstMuon2") << " fails Pt cut --> skipping it." ;}
-	continue;
-       }
-      if ( pfLeadChargedHadron.isNonnull()) {
-	reco::MuonRef muonRef = pfLeadChargedHadron->muonRef();
-	if (muonRef.isNonnull() && muon == pfLeadChargedHadron->muonRef() ) {
-	  if ( verbosity_ ) { edm::LogPrint("PFTauAgainstMuon2") << " matches muonRef of tau --> skipping it."; }
-	  continue;
-	}
-      }
-      double dR = deltaR(muon->p4(), pfTau->p4());
-      double dRmatch = dRmuonMatch_;
-      if ( dRmuonMatchLimitedToJetArea_ ) {
-	double jetArea = 0.;
-	if ( pfTau->jetRef().isNonnull() ) jetArea = pfTau->jetRef()->jetArea();
-	if ( jetArea > 0. ) {
-	  dRmatch = TMath::Min(dRmatch, TMath::Sqrt(jetArea/TMath::Pi()));
-	} else {
-	  if ( numWarnings_ < maxWarnings_ ) {
-	    edm::LogInfo("PFRecoTauDiscriminationAgainstMuon2::discriminate") 
-	      << "Jet associated to Tau: Pt = " << pfTau->pt() << ", eta = " << pfTau->eta() << ", phi = " << pfTau->phi() << " has area = " << jetArea << " !!" ;
-	    ++numWarnings_;
-	  }
-	  dRmatch = 0.1;
-	}
-      }
-      if ( dR < dRmatch ) {
-	if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuon2") << " overlaps with tau, dR = " << dR ;
-	reco::tau::countMatches(*muon, numMatchesDT, numMatchesCSC, numMatchesRPC);
-	reco::tau::countHits(*muon, numHitsDT, numHitsCSC, numHitsRPC);
-      }
+    ~PFRecoTauDiscriminationAgainstMuon2() override {}
+
+    void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+
+    double discriminate(const reco::PFTauRef&) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    std::string moduleLabel_;
+    int discriminatorOption_;
+    double hop_;
+    int maxNumberOfMatches_;
+    bool doCaloMuonVeto_;
+    int maxNumberOfHitsLast2Stations_;
+    edm::InputTag srcMuons_;
+    edm::Handle<reco::MuonCollection> muons_;
+    edm::EDGetTokenT<reco::MuonCollection> Muons_token;
+    double dRmuonMatch_;
+    bool dRmuonMatchLimitedToJetArea_;
+    double minPtMatchedMuon_;
+    std::vector<int> maskMatchesDT_;
+    std::vector<int> maskMatchesCSC_;
+    std::vector<int> maskMatchesRPC_;
+    std::vector<int> maskHitsDT_;
+    std::vector<int> maskHitsCSC_;
+    std::vector<int> maskHitsRPC_;
+    mutable int numWarnings_;
+    int maxWarnings_;
+    int verbosity_;
+  };
+
+  void PFRecoTauDiscriminationAgainstMuon2::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
+    if (!srcMuons_.label().empty()) {
+      evt.getByToken(Muons_token, muons_);
     }
   }
 
-  int numStationsWithMatches = 0;
-  for ( int iStation = 0; iStation < 4; ++iStation ) {
-    if ( numMatchesDT[iStation]  > 0 && !maskMatchesDT_[iStation]  ) ++numStationsWithMatches;
-    if ( numMatchesCSC[iStation] > 0 && !maskMatchesCSC_[iStation] ) ++numStationsWithMatches;
-    if ( numMatchesRPC[iStation] > 0 && !maskMatchesRPC_[iStation] ) ++numStationsWithMatches;
-  }
+  double PFRecoTauDiscriminationAgainstMuon2::discriminate(const reco::PFTauRef& pfTau) const {
+    if (verbosity_) {
+      edm::LogPrint("PFTauAgainstMuon2") << "<PFRecoTauDiscriminationAgainstMuon2::discriminate>:";
+      edm::LogPrint("PFTauAgainstMuon2") << " moduleLabel = " << moduleLabel_;
+      edm::LogPrint("PFTauAgainstMuon2") << "tau #" << pfTau.key() << ": Pt = " << pfTau->pt()
+                                         << ", eta = " << pfTau->eta() << ", phi = " << pfTau->phi();
+    }
 
-  int numLast2StationsWithHits = 0;
-  for ( int iStation = 2; iStation < 4; ++iStation ) {
-    if ( numHitsDT[iStation]  > 0 && !maskHitsDT_[iStation]  ) ++numLast2StationsWithHits;
-    if ( numHitsCSC[iStation] > 0 && !maskHitsCSC_[iStation] ) ++numLast2StationsWithHits;
-    if ( numHitsRPC[iStation] > 0 && !maskHitsRPC_[iStation] ) ++numLast2StationsWithHits;
-  }
+    std::vector<int> numMatchesDT(4);
+    std::vector<int> numMatchesCSC(4);
+    std::vector<int> numMatchesRPC(4);
+    std::vector<int> numHitsDT(4);
+    std::vector<int> numHitsCSC(4);
+    std::vector<int> numHitsRPC(4);
+    for (int iStation = 0; iStation < 4; ++iStation) {
+      numMatchesDT[iStation] = 0;
+      numMatchesCSC[iStation] = 0;
+      numMatchesRPC[iStation] = 0;
+      numHitsDT[iStation] = 0;
+      numHitsCSC[iStation] = 0;
+      numHitsRPC[iStation] = 0;
+    }
 
-  if ( verbosity_ ) {
-    edm::LogPrint("PFTauAgainstMuon2") << "numMatchesDT  = " << format_vint(numMatchesDT)  ;
-    edm::LogPrint("PFTauAgainstMuon2") << "numMatchesCSC = " << format_vint(numMatchesCSC) ;
-    edm::LogPrint("PFTauAgainstMuon2") << "numMatchesRPC = " << format_vint(numMatchesRPC) ;
-    edm::LogPrint("PFTauAgainstMuon2") << " --> numStationsWithMatches = " << numStationsWithMatches ;
-    edm::LogPrint("PFTauAgainstMuon2") << "numHitsDT  = " << format_vint(numHitsDT)  ;
-    edm::LogPrint("PFTauAgainstMuon2") << "numHitsCSC = " << format_vint(numHitsCSC) ;
-    edm::LogPrint("PFTauAgainstMuon2") << "numHitsRPC = " << format_vint(numHitsRPC) ;
-    edm::LogPrint("PFTauAgainstMuon2") << " --> numLast2StationsWithHits = " << numLast2StationsWithHits ;
-  }
-  
-  bool passesCaloMuonVeto = true;
-  if ( pfLeadChargedHadron.isNonnull() ) {
-    double energyECALplusHCAL = pfLeadChargedHadron->ecalEnergy() + pfLeadChargedHadron->hcalEnergy();
-    if ( verbosity_ ) {
-      if ( pfLeadChargedHadron->trackRef().isNonnull() ) {
-	edm::LogPrint("PFTauAgainstMuon2") << "decayMode = " << pfTau->decayMode() << ", energy(ECAL+HCAL) = " << energyECALplusHCAL << ", leadPFChargedHadronP = " << pfLeadChargedHadron->trackRef()->p() ;
-      } else if ( pfLeadChargedHadron->gsfTrackRef().isNonnull() ) {
-	edm::LogPrint("PFTauAgainstMuon2") << "decayMode = " << pfTau->decayMode() << ", energy(ECAL+HCAL) = " << energyECALplusHCAL << ", leadPFChargedHadronP = " << pfLeadChargedHadron->gsfTrackRef()->p() ;
+    const reco::PFCandidatePtr& pfLeadChargedHadron = pfTau->leadPFChargedHadrCand();
+    if (pfLeadChargedHadron.isNonnull()) {
+      reco::MuonRef muonRef = pfLeadChargedHadron->muonRef();
+      if (muonRef.isNonnull()) {
+        if (verbosity_)
+          edm::LogPrint("PFTauAgainstMuon2") << " has muonRef.";
+        reco::tau::countMatches(*muonRef, numMatchesDT, numMatchesCSC, numMatchesRPC);
+        reco::tau::countHits(*muonRef, numHitsDT, numHitsCSC, numHitsRPC);
       }
     }
-    const reco::Track* leadTrack = nullptr;
-    if ( pfLeadChargedHadron->trackRef().isNonnull() )
-      leadTrack = pfLeadChargedHadron->trackRef().get();
-    else if ( pfLeadChargedHadron->gsfTrackRef().isNonnull() )
-      leadTrack = pfLeadChargedHadron->gsfTrackRef().get();
-    if ( pfTau->decayMode() == 0 && leadTrack && energyECALplusHCAL < (hop_*leadTrack->p()) )
-      passesCaloMuonVeto = false;
+
+    if (!srcMuons_.label().empty()) {
+      size_t numMuons = muons_->size();
+      for (size_t idxMuon = 0; idxMuon < numMuons; ++idxMuon) {
+        reco::MuonRef muon(muons_, idxMuon);
+        if (verbosity_)
+          edm::LogPrint("PFTauAgainstMuon2") << "muon #" << muon.key() << ": Pt = " << muon->pt()
+                                             << ", eta = " << muon->eta() << ", phi = " << muon->phi();
+        if (!(muon->pt() > minPtMatchedMuon_)) {
+          if (verbosity_) {
+            edm::LogPrint("PFTauAgainstMuon2") << " fails Pt cut --> skipping it.";
+          }
+          continue;
+        }
+        if (pfLeadChargedHadron.isNonnull()) {
+          reco::MuonRef muonRef = pfLeadChargedHadron->muonRef();
+          if (muonRef.isNonnull() && muon == pfLeadChargedHadron->muonRef()) {
+            if (verbosity_) {
+              edm::LogPrint("PFTauAgainstMuon2") << " matches muonRef of tau --> skipping it.";
+            }
+            continue;
+          }
+        }
+        double dR = deltaR(muon->p4(), pfTau->p4());
+        double dRmatch = dRmuonMatch_;
+        if (dRmuonMatchLimitedToJetArea_) {
+          double jetArea = 0.;
+          if (pfTau->jetRef().isNonnull())
+            jetArea = pfTau->jetRef()->jetArea();
+          if (jetArea > 0.) {
+            dRmatch = TMath::Min(dRmatch, TMath::Sqrt(jetArea / TMath::Pi()));
+          } else {
+            if (numWarnings_ < maxWarnings_) {
+              edm::LogInfo("PFRecoTauDiscriminationAgainstMuon2::discriminate")
+                  << "Jet associated to Tau: Pt = " << pfTau->pt() << ", eta = " << pfTau->eta()
+                  << ", phi = " << pfTau->phi() << " has area = " << jetArea << " !!";
+              ++numWarnings_;
+            }
+            dRmatch = 0.1;
+          }
+        }
+        if (dR < dRmatch) {
+          if (verbosity_)
+            edm::LogPrint("PFTauAgainstMuon2") << " overlaps with tau, dR = " << dR;
+          reco::tau::countMatches(*muon, numMatchesDT, numMatchesCSC, numMatchesRPC);
+          reco::tau::countHits(*muon, numHitsDT, numHitsCSC, numHitsRPC);
+        }
+      }
+    }
+
+    int numStationsWithMatches = 0;
+    for (int iStation = 0; iStation < 4; ++iStation) {
+      if (numMatchesDT[iStation] > 0 && !maskMatchesDT_[iStation])
+        ++numStationsWithMatches;
+      if (numMatchesCSC[iStation] > 0 && !maskMatchesCSC_[iStation])
+        ++numStationsWithMatches;
+      if (numMatchesRPC[iStation] > 0 && !maskMatchesRPC_[iStation])
+        ++numStationsWithMatches;
+    }
+
+    int numLast2StationsWithHits = 0;
+    for (int iStation = 2; iStation < 4; ++iStation) {
+      if (numHitsDT[iStation] > 0 && !maskHitsDT_[iStation])
+        ++numLast2StationsWithHits;
+      if (numHitsCSC[iStation] > 0 && !maskHitsCSC_[iStation])
+        ++numLast2StationsWithHits;
+      if (numHitsRPC[iStation] > 0 && !maskHitsRPC_[iStation])
+        ++numLast2StationsWithHits;
+    }
+
+    if (verbosity_) {
+      edm::LogPrint("PFTauAgainstMuon2") << "numMatchesDT  = " << format_vint(numMatchesDT);
+      edm::LogPrint("PFTauAgainstMuon2") << "numMatchesCSC = " << format_vint(numMatchesCSC);
+      edm::LogPrint("PFTauAgainstMuon2") << "numMatchesRPC = " << format_vint(numMatchesRPC);
+      edm::LogPrint("PFTauAgainstMuon2") << " --> numStationsWithMatches = " << numStationsWithMatches;
+      edm::LogPrint("PFTauAgainstMuon2") << "numHitsDT  = " << format_vint(numHitsDT);
+      edm::LogPrint("PFTauAgainstMuon2") << "numHitsCSC = " << format_vint(numHitsCSC);
+      edm::LogPrint("PFTauAgainstMuon2") << "numHitsRPC = " << format_vint(numHitsRPC);
+      edm::LogPrint("PFTauAgainstMuon2") << " --> numLast2StationsWithHits = " << numLast2StationsWithHits;
+    }
+
+    bool passesCaloMuonVeto = true;
+    if (pfLeadChargedHadron.isNonnull()) {
+      double energyECALplusHCAL = pfLeadChargedHadron->ecalEnergy() + pfLeadChargedHadron->hcalEnergy();
+      if (verbosity_) {
+        if (pfLeadChargedHadron->trackRef().isNonnull()) {
+          edm::LogPrint("PFTauAgainstMuon2")
+              << "decayMode = " << pfTau->decayMode() << ", energy(ECAL+HCAL) = " << energyECALplusHCAL
+              << ", leadPFChargedHadronP = " << pfLeadChargedHadron->trackRef()->p();
+        } else if (pfLeadChargedHadron->gsfTrackRef().isNonnull()) {
+          edm::LogPrint("PFTauAgainstMuon2")
+              << "decayMode = " << pfTau->decayMode() << ", energy(ECAL+HCAL) = " << energyECALplusHCAL
+              << ", leadPFChargedHadronP = " << pfLeadChargedHadron->gsfTrackRef()->p();
+        }
+      }
+      const reco::Track* leadTrack = nullptr;
+      if (pfLeadChargedHadron->trackRef().isNonnull())
+        leadTrack = pfLeadChargedHadron->trackRef().get();
+      else if (pfLeadChargedHadron->gsfTrackRef().isNonnull())
+        leadTrack = pfLeadChargedHadron->gsfTrackRef().get();
+      if (pfTau->decayMode() == 0 && leadTrack && energyECALplusHCAL < (hop_ * leadTrack->p()))
+        passesCaloMuonVeto = false;
+    }
+
+    double discriminatorValue = 0.;
+    if (discriminatorOption_ == kLoose && numStationsWithMatches <= maxNumberOfMatches_)
+      discriminatorValue = 1.;
+    else if (discriminatorOption_ == kMedium && numStationsWithMatches <= maxNumberOfMatches_ &&
+             numLast2StationsWithHits <= maxNumberOfHitsLast2Stations_)
+      discriminatorValue = 1.;
+    else if (discriminatorOption_ == kTight && numStationsWithMatches <= maxNumberOfMatches_ &&
+             numLast2StationsWithHits <= maxNumberOfHitsLast2Stations_ && passesCaloMuonVeto)
+      discriminatorValue = 1.;
+    else if (discriminatorOption_ == kCustom) {
+      bool pass = true;
+      if (maxNumberOfMatches_ >= 0 && numStationsWithMatches > maxNumberOfMatches_)
+        pass = false;
+      if (maxNumberOfHitsLast2Stations_ >= 0 && numLast2StationsWithHits > maxNumberOfHitsLast2Stations_)
+        pass = false;
+      if (doCaloMuonVeto_ && !passesCaloMuonVeto)
+        pass = false;
+      discriminatorValue = pass ? 1. : 0.;
+    }
+    if (verbosity_)
+      edm::LogPrint("PFTauAgainstMuon2") << "--> returning discriminatorValue = " << discriminatorValue;
+
+    return discriminatorValue;
   }
-  
-  double discriminatorValue = 0.;
-  if      ( discriminatorOption_ == kLoose  && numStationsWithMatches <= maxNumberOfMatches_                                                                                    ) discriminatorValue = 1.;
-  else if ( discriminatorOption_ == kMedium && numStationsWithMatches <= maxNumberOfMatches_ && numLast2StationsWithHits <= maxNumberOfHitsLast2Stations_                       ) discriminatorValue = 1.;
-  else if ( discriminatorOption_ == kTight  && numStationsWithMatches <= maxNumberOfMatches_ && numLast2StationsWithHits <= maxNumberOfHitsLast2Stations_ && passesCaloMuonVeto ) discriminatorValue = 1.;
-  else if ( discriminatorOption_ == kCustom ) {
-    bool pass = true;
-    if ( maxNumberOfMatches_ >= 0 && numStationsWithMatches > maxNumberOfMatches_ ) pass = false;
-    if ( maxNumberOfHitsLast2Stations_ >= 0 && numLast2StationsWithHits > maxNumberOfHitsLast2Stations_ ) pass = false;
-    if ( doCaloMuonVeto_ && !passesCaloMuonVeto ) pass = false;
-    discriminatorValue = pass ? 1.: 0.;
-  }
-  if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuon2") << "--> returning discriminatorValue = " << discriminatorValue ;
 
-  return discriminatorValue;
-} 
+}  // namespace
 
-}
-
-void
-PFRecoTauDiscriminationAgainstMuon2::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauDiscriminationAgainstMuon2::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfRecoTauDiscriminationAgainstMuon2
   edm::ParameterSetDescription desc;
-  desc.add<std::vector<int>>("maskHitsRPC", {
-    0,
-    0,
-    0,
-    0,
-  });
+  desc.add<std::vector<int>>("maskHitsRPC",
+                             {
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                             });
   desc.add<int>("maxNumberOfHitsLast2Stations", 0);
-  desc.add<std::vector<int>>("maskMatchesRPC", {
-    0,
-    0,
-    0,
-    0,
-  });
-  desc.add<std::vector<int>>("maskMatchesCSC", {
-    1,
-    0,
-    0,
-    0,
-  });
-  desc.add<std::vector<int>>("maskHitsCSC", {
-    0,
-    0,
-    0,
-    0,
-  });
+  desc.add<std::vector<int>>("maskMatchesRPC",
+                             {
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                             });
+  desc.add<std::vector<int>>("maskMatchesCSC",
+                             {
+                                 1,
+                                 0,
+                                 0,
+                                 0,
+                             });
+  desc.add<std::vector<int>>("maskHitsCSC",
+                             {
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                             });
   desc.add<edm::InputTag>("PFTauProducer", edm::InputTag("pfRecoTauProducer"));
   desc.add<int>("verbosity", 0);
-  desc.add<std::vector<int>>("maskMatchesDT", {
-    0,
-    0,
-    0,
-    0,
-  });
+  desc.add<std::vector<int>>("maskMatchesDT",
+                             {
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                             });
   desc.add<double>("minPtMatchedMuon", 5.0);
   desc.add<bool>("dRmuonMatchLimitedToJetArea", false);
   {
@@ -287,14 +322,14 @@ PFRecoTauDiscriminationAgainstMuon2::fillDescriptions(edm::ConfigurationDescript
     psd0.add<std::string>("BooleanOperator", "and");
     {
       edm::ParameterSetDescription psd1;
-      psd1.add<double>("cut"); //, 0.5);
-      psd1.add<edm::InputTag>("Producer"); //, edm::InputTag("pfRecoTauDiscriminationByLeadingTrackFinding"));
-      psd0.addOptional<edm::ParameterSetDescription>("leadTrack", psd1); // optional with default? 
+      psd1.add<double>("cut");              //, 0.5);
+      psd1.add<edm::InputTag>("Producer");  //, edm::InputTag("pfRecoTauDiscriminationByLeadingTrackFinding"));
+      psd0.addOptional<edm::ParameterSetDescription>("leadTrack", psd1);  // optional with default?
     }
     // Prediscriminants can be
     // Prediscriminants = noPrediscriminants,
     // as in RecoTauTag/Configuration/python/HPSPFTaus_cff.py
-    // 
+    //
     // and the definition is:
     // RecoTauTag/RecoTau/python/TauDiscriminatorTools.py
     // # Require no prediscriminants
@@ -305,12 +340,13 @@ PFRecoTauDiscriminationAgainstMuon2::fillDescriptions(edm::ConfigurationDescript
     // otherwise it inserts the leadTrack with Producer = InpuTag(...) and does not find the corresponding output during the run
     desc.add<edm::ParameterSetDescription>("Prediscriminants", psd0);
   }
-  desc.add<std::vector<int>>("maskHitsDT", {
-    0,
-    0,
-    0,
-    0,
-  });
+  desc.add<std::vector<int>>("maskHitsDT",
+                             {
+                                 0,
+                                 0,
+                                 0,
+                                 0,
+                             });
   desc.add<double>("HoPMin", 0.2);
   desc.add<int>("maxNumberOfMatches", 0);
   desc.add<std::string>("discriminatorOption", "loose");

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonMVA.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonMVA.cc
@@ -38,216 +38,217 @@
 
 using namespace reco;
 
-namespace
-{
-  const GBRForest* loadMVAfromFile(const edm::FileInPath& inputFileName, const std::string& mvaName, std::vector<TFile*>& inputFilesToDelete)
-  {
-    if ( inputFileName.location() == edm::FileInPath::Unknown ) throw cms::Exception("PFRecoTauDiscriminationAgainstMuonMVA::loadMVA")
-      << " Failed to find File = " << inputFileName << " !!\n";
+namespace {
+  const GBRForest* loadMVAfromFile(const edm::FileInPath& inputFileName,
+                                   const std::string& mvaName,
+                                   std::vector<TFile*>& inputFilesToDelete) {
+    if (inputFileName.location() == edm::FileInPath::Unknown)
+      throw cms::Exception("PFRecoTauDiscriminationAgainstMuonMVA::loadMVA")
+          << " Failed to find File = " << inputFileName << " !!\n";
     TFile* inputFile = new TFile(inputFileName.fullPath().data());
-  
+
     //const GBRForest* mva = dynamic_cast<GBRForest*>(inputFile->Get(mvaName.data())); // CV: dynamic_cast<GBRForest*> fails for some reason ?!
     const GBRForest* mva = (GBRForest*)inputFile->Get(mvaName.data());
-    if ( !mva )
+    if (!mva)
       throw cms::Exception("PFRecoTauDiscriminationAgainstMuonMVA::loadMVA")
-        << " Failed to load MVA = " << mvaName.data() << " from file = " << inputFileName.fullPath().data() << " !!\n";
+          << " Failed to load MVA = " << mvaName.data() << " from file = " << inputFileName.fullPath().data()
+          << " !!\n";
 
     inputFilesToDelete.push_back(inputFile);
 
     return mva;
   }
 
-  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName)
-  {
+  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName) {
     edm::ESHandle<GBRForest> mva;
     es.get<GBRWrapperRcd>().get(mvaName, mva);
     return mva.product();
   }
 
+  class PFRecoTauDiscriminationAgainstMuonMVA final : public PFTauDiscriminationProducerBase {
+  public:
+    explicit PFRecoTauDiscriminationAgainstMuonMVA(const edm::ParameterSet& cfg)
+        : PFTauDiscriminationProducerBase(cfg),
+          moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+          mvaReader_(nullptr),
+          mvaInput_(nullptr) {
+      mvaName_ = cfg.getParameter<std::string>("mvaName");
+      loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
+      if (!loadMVAfromDB_) {
+        inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
+      }
+      mvaInput_ = new float[11];
 
-class PFRecoTauDiscriminationAgainstMuonMVA final : public PFTauDiscriminationProducerBase  
-{
- public:
-  explicit PFRecoTauDiscriminationAgainstMuonMVA(const edm::ParameterSet& cfg)
-    : PFTauDiscriminationProducerBase(cfg),
-      moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-      mvaReader_(nullptr),
-      mvaInput_(nullptr)
-  {
-    mvaName_ = cfg.getParameter<std::string>("mvaName");
-    loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
-    if ( !loadMVAfromDB_ ) {
-	inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
+      srcMuons_ = cfg.getParameter<edm::InputTag>("srcMuons");
+      Muons_token = consumes<reco::MuonCollection>(srcMuons_);
+      dRmuonMatch_ = cfg.getParameter<double>("dRmuonMatch");
+
+      verbosity_ = cfg.getParameter<int>("verbosity");
+
+      produces<PFTauDiscriminator>("category");
     }
-    mvaInput_ = new float[11];
-    
-    srcMuons_ = cfg.getParameter<edm::InputTag>("srcMuons");
-    Muons_token=consumes<reco::MuonCollection>(srcMuons_);
-    dRmuonMatch_ = cfg.getParameter<double>("dRmuonMatch");
 
-    verbosity_ = cfg.getParameter<int>("verbosity");
+    void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
-    produces<PFTauDiscriminator>("category");
-  }
+    double discriminate(const PFTauRef&) const override;
 
-  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+    void endEvent(edm::Event&) override;
 
-  double discriminate(const PFTauRef&) const override;
-
-  void endEvent(edm::Event&) override;
-
-  ~PFRecoTauDiscriminationAgainstMuonMVA() override
-  {
-    if ( !loadMVAfromDB_ ) delete mvaReader_;
-    delete[] mvaInput_;
-    for ( std::vector<TFile*>::iterator it = inputFilesToDelete_.begin();
-	  it != inputFilesToDelete_.end(); ++it ) {
-      delete (*it);
-    }
-  }
-
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-
- private:
-
-  std::string moduleLabel_;
-
-  std::string mvaName_;
-  bool loadMVAfromDB_;
-  edm::FileInPath inputFileName_;
-  const GBRForest* mvaReader_;
-  float* mvaInput_;
-
-  edm::InputTag srcMuons_;
-  edm::Handle<reco::MuonCollection> muons_;
-  edm::EDGetTokenT<reco::MuonCollection> Muons_token;
-  double dRmuonMatch_;
-
-  edm::Handle<TauCollection> taus_;
-  std::unique_ptr<PFTauDiscriminator> category_output_;
-
-  std::vector<TFile*> inputFilesToDelete_;
-
-  int verbosity_;
-};
-
-void PFRecoTauDiscriminationAgainstMuonMVA::beginEvent(const edm::Event& evt, const edm::EventSetup& es)
-{ 
-  if ( !mvaReader_ ) {
-    if ( loadMVAfromDB_ ) {
-      mvaReader_ = loadMVAfromDB(es, mvaName_);
-    } else {
-      mvaReader_ = loadMVAfromFile(inputFileName_, mvaName_, inputFilesToDelete_);
-    }
-  }
-
-  evt.getByToken(Muons_token, muons_);
-
-  evt.getByToken(Tau_token, taus_);
-  category_output_.reset(new PFTauDiscriminator(TauRefProd(taus_)));
-}
-
-namespace
-{
-  void countHits(const reco::Muon& muon, std::vector<int>& numHitsDT, std::vector<int>& numHitsCSC, std::vector<int>& numHitsRPC)
-  {
-    if ( muon.outerTrack().isNonnull() ) {
-      const reco::HitPattern &muonHitPattern = muon.outerTrack()->hitPattern();
-      for (int iHit = 0; iHit < muonHitPattern.numberOfAllHits(HitPattern::TRACK_HITS); ++iHit) {
-          uint32_t hit = muonHitPattern.getHitPattern(HitPattern::TRACK_HITS, iHit);
-	if ( hit == 0 ) break;	    
-	if ( muonHitPattern.muonHitFilter(hit) && (muonHitPattern.getHitType(hit) == TrackingRecHit::valid || muonHitPattern.getHitType(hit) == TrackingRecHit::bad) ) {
-	  int muonStation = muonHitPattern.getMuonStation(hit) - 1; // CV: map into range 0..3
-	  if ( muonStation >= 0 && muonStation < 4 ) {
-	    if      ( muonHitPattern.muonDTHitFilter(hit)  ) ++numHitsDT[muonStation];
-	    else if ( muonHitPattern.muonCSCHitFilter(hit) ) ++numHitsCSC[muonStation];
-	    else if ( muonHitPattern.muonRPCHitFilter(hit) ) ++numHitsRPC[muonStation];
-	  }
-	}
+    ~PFRecoTauDiscriminationAgainstMuonMVA() override {
+      if (!loadMVAfromDB_)
+        delete mvaReader_;
+      delete[] mvaInput_;
+      for (std::vector<TFile*>::iterator it = inputFilesToDelete_.begin(); it != inputFilesToDelete_.end(); ++it) {
+        delete (*it);
       }
     }
-  }
-}
 
-double PFRecoTauDiscriminationAgainstMuonMVA::discriminate(const PFTauRef& tau) const
-{
-  if ( verbosity_ ) {
-    edm::LogPrint("PFTauAgainstMuonMVA") << "<PFRecoTauDiscriminationAgainstMuonMVA::discriminate>:";
-    edm::LogPrint("PFTauAgainstMuonMVA") << " moduleLabel = " << moduleLabel_;
-  }
-  
-  // CV: define dummy category index in order to use RecoTauDiscriminantCutMultiplexer module to appy WP cuts
-  double category = 0.; 
-  category_output_->setValue(tauIndex_, category);
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  // CV: computation of anti-muon MVA value requires presence of leading charged hadron
-  if ( tau->leadPFChargedHadrCand().isNull() ) return 0.;
+  private:
+    std::string moduleLabel_;
 
-  mvaInput_[0]  = TMath::Abs(tau->eta());
-  double tauCaloEnECAL = 0.;
-  double tauCaloEnHCAL = 0.;
-  const std::vector<reco::PFCandidatePtr>& tauSignalPFCands = tau->signalPFCands();
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator tauSignalPFCand = tauSignalPFCands.begin();
-	tauSignalPFCand != tauSignalPFCands.end(); ++tauSignalPFCand ) {
-    tauCaloEnECAL += (*tauSignalPFCand)->ecalEnergy();
-    tauCaloEnHCAL += (*tauSignalPFCand)->hcalEnergy();
-  }
-  mvaInput_[1]  = TMath::Sqrt(TMath::Max(0., tauCaloEnECAL));
-  mvaInput_[2]  = TMath::Sqrt(TMath::Max(0., tauCaloEnHCAL));
-  mvaInput_[3]  = tau->leadPFChargedHadrCand()->pt()/TMath::Max(1.,Double_t(tau->pt()));
-  mvaInput_[4]  = TMath::Sqrt(TMath::Max(0., tau->leadPFChargedHadrCand()->ecalEnergy()));
-  mvaInput_[5]  = TMath::Sqrt(TMath::Max(0., tau->leadPFChargedHadrCand()->hcalEnergy()));
-  int numMatches = 0;
-  std::vector<int> numHitsDT(4);
-  std::vector<int> numHitsCSC(4);
-  std::vector<int> numHitsRPC(4);
-  for ( int iStation = 0; iStation < 4; ++iStation ) {
-    numHitsDT[iStation]  = 0;
-    numHitsCSC[iStation] = 0;
-    numHitsRPC[iStation] = 0;
-  }
-  if ( tau->leadPFChargedHadrCand().isNonnull() ) {
-    reco::MuonRef muonRef = tau->leadPFChargedHadrCand()->muonRef();      
-    if ( muonRef.isNonnull() ) {
-      numMatches = muonRef->numberOfMatches(reco::Muon::NoArbitration);
-      countHits(*muonRef, numHitsDT, numHitsCSC, numHitsRPC);
+    std::string mvaName_;
+    bool loadMVAfromDB_;
+    edm::FileInPath inputFileName_;
+    const GBRForest* mvaReader_;
+    float* mvaInput_;
+
+    edm::InputTag srcMuons_;
+    edm::Handle<reco::MuonCollection> muons_;
+    edm::EDGetTokenT<reco::MuonCollection> Muons_token;
+    double dRmuonMatch_;
+
+    edm::Handle<TauCollection> taus_;
+    std::unique_ptr<PFTauDiscriminator> category_output_;
+
+    std::vector<TFile*> inputFilesToDelete_;
+
+    int verbosity_;
+  };
+
+  void PFRecoTauDiscriminationAgainstMuonMVA::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
+    if (!mvaReader_) {
+      if (loadMVAfromDB_) {
+        mvaReader_ = loadMVAfromDB(es, mvaName_);
+      } else {
+        mvaReader_ = loadMVAfromFile(inputFileName_, mvaName_, inputFilesToDelete_);
+      }
     }
+
+    evt.getByToken(Muons_token, muons_);
+
+    evt.getByToken(Tau_token, taus_);
+    category_output_.reset(new PFTauDiscriminator(TauRefProd(taus_)));
   }
-  size_t numMuons = muons_->size();
-  for ( size_t idxMuon = 0; idxMuon < numMuons; ++idxMuon ) {
-    reco::MuonRef muon(muons_, idxMuon);
-    if ( tau->leadPFChargedHadrCand().isNonnull() && tau->leadPFChargedHadrCand()->muonRef().isNonnull() && muon == tau->leadPFChargedHadrCand()->muonRef() ) {	
-      continue;
+
+  namespace {
+    void countHits(const reco::Muon& muon,
+                   std::vector<int>& numHitsDT,
+                   std::vector<int>& numHitsCSC,
+                   std::vector<int>& numHitsRPC) {
+      if (muon.outerTrack().isNonnull()) {
+        const reco::HitPattern& muonHitPattern = muon.outerTrack()->hitPattern();
+        for (int iHit = 0; iHit < muonHitPattern.numberOfAllHits(HitPattern::TRACK_HITS); ++iHit) {
+          uint32_t hit = muonHitPattern.getHitPattern(HitPattern::TRACK_HITS, iHit);
+          if (hit == 0)
+            break;
+          if (muonHitPattern.muonHitFilter(hit) && (muonHitPattern.getHitType(hit) == TrackingRecHit::valid ||
+                                                    muonHitPattern.getHitType(hit) == TrackingRecHit::bad)) {
+            int muonStation = muonHitPattern.getMuonStation(hit) - 1;  // CV: map into range 0..3
+            if (muonStation >= 0 && muonStation < 4) {
+              if (muonHitPattern.muonDTHitFilter(hit))
+                ++numHitsDT[muonStation];
+              else if (muonHitPattern.muonCSCHitFilter(hit))
+                ++numHitsCSC[muonStation];
+              else if (muonHitPattern.muonRPCHitFilter(hit))
+                ++numHitsRPC[muonStation];
+            }
+          }
+        }
+      }
     }
-    double dR = deltaR(muon->p4(), tau->p4());
-    if ( dR < dRmuonMatch_ ) {
-      numMatches += muon->numberOfMatches(reco::Muon::NoArbitration);
-      countHits(*muon, numHitsDT, numHitsCSC, numHitsRPC);
+  }  // namespace
+
+  double PFRecoTauDiscriminationAgainstMuonMVA::discriminate(const PFTauRef& tau) const {
+    if (verbosity_) {
+      edm::LogPrint("PFTauAgainstMuonMVA") << "<PFRecoTauDiscriminationAgainstMuonMVA::discriminate>:";
+      edm::LogPrint("PFTauAgainstMuonMVA") << " moduleLabel = " << moduleLabel_;
     }
+
+    // CV: define dummy category index in order to use RecoTauDiscriminantCutMultiplexer module to appy WP cuts
+    double category = 0.;
+    category_output_->setValue(tauIndex_, category);
+
+    // CV: computation of anti-muon MVA value requires presence of leading charged hadron
+    if (tau->leadPFChargedHadrCand().isNull())
+      return 0.;
+
+    mvaInput_[0] = TMath::Abs(tau->eta());
+    double tauCaloEnECAL = 0.;
+    double tauCaloEnHCAL = 0.;
+    const std::vector<reco::PFCandidatePtr>& tauSignalPFCands = tau->signalPFCands();
+    for (std::vector<reco::PFCandidatePtr>::const_iterator tauSignalPFCand = tauSignalPFCands.begin();
+         tauSignalPFCand != tauSignalPFCands.end();
+         ++tauSignalPFCand) {
+      tauCaloEnECAL += (*tauSignalPFCand)->ecalEnergy();
+      tauCaloEnHCAL += (*tauSignalPFCand)->hcalEnergy();
+    }
+    mvaInput_[1] = TMath::Sqrt(TMath::Max(0., tauCaloEnECAL));
+    mvaInput_[2] = TMath::Sqrt(TMath::Max(0., tauCaloEnHCAL));
+    mvaInput_[3] = tau->leadPFChargedHadrCand()->pt() / TMath::Max(1., Double_t(tau->pt()));
+    mvaInput_[4] = TMath::Sqrt(TMath::Max(0., tau->leadPFChargedHadrCand()->ecalEnergy()));
+    mvaInput_[5] = TMath::Sqrt(TMath::Max(0., tau->leadPFChargedHadrCand()->hcalEnergy()));
+    int numMatches = 0;
+    std::vector<int> numHitsDT(4);
+    std::vector<int> numHitsCSC(4);
+    std::vector<int> numHitsRPC(4);
+    for (int iStation = 0; iStation < 4; ++iStation) {
+      numHitsDT[iStation] = 0;
+      numHitsCSC[iStation] = 0;
+      numHitsRPC[iStation] = 0;
+    }
+    if (tau->leadPFChargedHadrCand().isNonnull()) {
+      reco::MuonRef muonRef = tau->leadPFChargedHadrCand()->muonRef();
+      if (muonRef.isNonnull()) {
+        numMatches = muonRef->numberOfMatches(reco::Muon::NoArbitration);
+        countHits(*muonRef, numHitsDT, numHitsCSC, numHitsRPC);
+      }
+    }
+    size_t numMuons = muons_->size();
+    for (size_t idxMuon = 0; idxMuon < numMuons; ++idxMuon) {
+      reco::MuonRef muon(muons_, idxMuon);
+      if (tau->leadPFChargedHadrCand().isNonnull() && tau->leadPFChargedHadrCand()->muonRef().isNonnull() &&
+          muon == tau->leadPFChargedHadrCand()->muonRef()) {
+        continue;
+      }
+      double dR = deltaR(muon->p4(), tau->p4());
+      if (dR < dRmuonMatch_) {
+        numMatches += muon->numberOfMatches(reco::Muon::NoArbitration);
+        countHits(*muon, numHitsDT, numHitsCSC, numHitsRPC);
+      }
+    }
+    mvaInput_[6] = numMatches;
+    mvaInput_[7] = numHitsDT[0] + numHitsCSC[0] + numHitsRPC[0];
+    mvaInput_[8] = numHitsDT[1] + numHitsCSC[1] + numHitsRPC[1];
+    mvaInput_[9] = numHitsDT[2] + numHitsCSC[2] + numHitsRPC[2];
+    mvaInput_[10] = numHitsDT[3] + numHitsCSC[3] + numHitsRPC[3];
+
+    double mvaValue = mvaReader_->GetClassifier(mvaInput_);
+    if (verbosity_) {
+      edm::LogPrint("PFTauAgainstMuonMVA") << "mvaValue = " << mvaValue;
+    }
+    return mvaValue;
   }
-  mvaInput_[6]  = numMatches;
-  mvaInput_[7]  = numHitsDT[0] + numHitsCSC[0] + numHitsRPC[0];
-  mvaInput_[8]  = numHitsDT[1] + numHitsCSC[1] + numHitsRPC[1];
-  mvaInput_[9]  = numHitsDT[2] + numHitsCSC[2] + numHitsRPC[2];
-  mvaInput_[10] = numHitsDT[3] + numHitsCSC[3] + numHitsRPC[3];
 
-  double mvaValue = mvaReader_->GetClassifier(mvaInput_);
-  if ( verbosity_ ) {
-    edm::LogPrint("PFTauAgainstMuonMVA") << "mvaValue = " << mvaValue;
+  void PFRecoTauDiscriminationAgainstMuonMVA::endEvent(edm::Event& evt) {
+    // add all category indices to event
+    evt.put(std::move(category_output_), "category");
   }
-  return mvaValue;
-}
 
-void PFRecoTauDiscriminationAgainstMuonMVA::endEvent(edm::Event& evt)
-{
-  // add all category indices to event
-  evt.put(std::move(category_output_), "category");
-}
+}  // namespace
 
-}
-
-void
-PFRecoTauDiscriminationAgainstMuonMVA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauDiscriminationAgainstMuonMVA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfRecoTauDiscriminationAgainstMuonMVA
   edm::ParameterSetDescription desc;
   desc.add<double>("mvaMin", 0.0);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonSimple.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonSimple.cc
@@ -32,225 +32,241 @@ using reco::tau::format_vint;
 
 namespace {
 
-class PFRecoTauDiscriminationAgainstMuonSimple final : public PFTauDiscriminationProducerBase
-{
- public:
-  explicit PFRecoTauDiscriminationAgainstMuonSimple(const edm::ParameterSet& cfg)
-    : PFTauDiscriminationProducerBase(cfg),
-      moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-  {   
-    hop_ = cfg.getParameter<double>("HoPMin");
-    doCaloMuonVeto_ = cfg.getParameter<bool>("doCaloMuonVeto");
-    srcPatMuons_ = cfg.getParameter<edm::InputTag>("srcPatMuons");
-    Muons_token = consumes<pat::MuonCollection>(srcPatMuons_);
-    dRmuonMatch_ = cfg.getParameter<double>("dRmuonMatch");
-    dRmuonMatchLimitedToJetArea_ = cfg.getParameter<bool>("dRmuonMatchLimitedToJetArea");
-    minPtMatchedMuon_ = cfg.getParameter<double>("minPtMatchedMuon");
-    maxNumberOfMatches_ = cfg.getParameter<int>("maxNumberOfMatches");
-    maxNumberOfHitsLast2Stations_ = cfg.getParameter<int>("maxNumberOfHitsLast2Stations");
-    typedef std::vector<int> vint;
-    maskMatchesDT_  = cfg.getParameter<vint>("maskMatchesDT");
-    maskMatchesCSC_ = cfg.getParameter<vint>("maskMatchesCSC");
-    maskMatchesRPC_ = cfg.getParameter<vint>("maskMatchesRPC");
-    maskHitsDT_     = cfg.getParameter<vint>("maskHitsDT");
-    maskHitsCSC_    = cfg.getParameter<vint>("maskHitsCSC");
-    maskHitsRPC_    = cfg.getParameter<vint>("maskHitsRPC");
-    maxNumberOfSTAMuons_ = cfg.getParameter<int>("maxNumberOfSTAMuons");
-    maxNumberOfRPCMuons_ = cfg.getParameter<int>("maxNumberOfRPCMuons");
+  class PFRecoTauDiscriminationAgainstMuonSimple final : public PFTauDiscriminationProducerBase {
+  public:
+    explicit PFRecoTauDiscriminationAgainstMuonSimple(const edm::ParameterSet& cfg)
+        : PFTauDiscriminationProducerBase(cfg), moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
+      hop_ = cfg.getParameter<double>("HoPMin");
+      doCaloMuonVeto_ = cfg.getParameter<bool>("doCaloMuonVeto");
+      srcPatMuons_ = cfg.getParameter<edm::InputTag>("srcPatMuons");
+      Muons_token = consumes<pat::MuonCollection>(srcPatMuons_);
+      dRmuonMatch_ = cfg.getParameter<double>("dRmuonMatch");
+      dRmuonMatchLimitedToJetArea_ = cfg.getParameter<bool>("dRmuonMatchLimitedToJetArea");
+      minPtMatchedMuon_ = cfg.getParameter<double>("minPtMatchedMuon");
+      maxNumberOfMatches_ = cfg.getParameter<int>("maxNumberOfMatches");
+      maxNumberOfHitsLast2Stations_ = cfg.getParameter<int>("maxNumberOfHitsLast2Stations");
+      typedef std::vector<int> vint;
+      maskMatchesDT_ = cfg.getParameter<vint>("maskMatchesDT");
+      maskMatchesCSC_ = cfg.getParameter<vint>("maskMatchesCSC");
+      maskMatchesRPC_ = cfg.getParameter<vint>("maskMatchesRPC");
+      maskHitsDT_ = cfg.getParameter<vint>("maskHitsDT");
+      maskHitsCSC_ = cfg.getParameter<vint>("maskHitsCSC");
+      maskHitsRPC_ = cfg.getParameter<vint>("maskHitsRPC");
+      maxNumberOfSTAMuons_ = cfg.getParameter<int>("maxNumberOfSTAMuons");
+      maxNumberOfRPCMuons_ = cfg.getParameter<int>("maxNumberOfRPCMuons");
 
-    numWarnings_ = 0;
-    maxWarnings_ = 3;
-    verbosity_ = cfg.exists("verbosity") ? cfg.getParameter<int>("verbosity") : 0;
-   }
-  ~PFRecoTauDiscriminationAgainstMuonSimple() override {} 
-
-  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-
-  double discriminate(const reco::PFTauRef&) const override;
-
- private:  
-  std::string moduleLabel_;
-  int discriminatorOption_;
-  double hop_;
-  bool doCaloMuonVeto_;
-  edm::InputTag srcPatMuons_;
-  edm::Handle<pat::MuonCollection> muons_;
-  edm::EDGetTokenT<pat::MuonCollection> Muons_token;
-  double dRmuonMatch_;
-  bool dRmuonMatchLimitedToJetArea_;
-  double minPtMatchedMuon_;
-  int maxNumberOfMatches_;
-  std::vector<int> maskMatchesDT_;
-  std::vector<int> maskMatchesCSC_;
-  std::vector<int> maskMatchesRPC_;
-  int maxNumberOfHitsLast2Stations_;
-  std::vector<int> maskHitsDT_;
-  std::vector<int> maskHitsCSC_;
-  std::vector<int> maskHitsRPC_;
-  int maxNumberOfSTAMuons_, maxNumberOfRPCMuons_;
-
-  mutable int numWarnings_;
-  int maxWarnings_;
-  int verbosity_;
-};
-
-void PFRecoTauDiscriminationAgainstMuonSimple::beginEvent(const edm::Event& evt, const edm::EventSetup& es) 
-{
-  evt.getByToken(Muons_token, muons_);
-}
-
-double PFRecoTauDiscriminationAgainstMuonSimple::discriminate(const reco::PFTauRef& pfTau) const
-{
-  if ( verbosity_ ) {
-    edm::LogPrint("PFTauAgainstMuonSimple") << "<PFRecoTauDiscriminationAgainstMuonSimple::discriminate>:" ;
-    edm::LogPrint("PFTauAgainstMuonSimple") << " moduleLabel = " << moduleLabel_ ;
-    edm::LogPrint("PFTauAgainstMuonSimple") << "tau #" << pfTau.key() << ": Pt = " << pfTau->pt() << ", eta = " << pfTau->eta() << ", phi = " << pfTau->phi() << ", decay mode = " << pfTau->decayMode() ;   
-  }
-
-  //if (pfTau->decayMode() >= 5) return true; //MB: accept all multi-prongs??
-
-  const reco::CandidatePtr& pfLeadChargedHadron = pfTau->leadChargedHadrCand();
-  bool passesCaloMuonVeto = true;
-  if ( pfLeadChargedHadron.isNonnull() ) {
-    const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(pfLeadChargedHadron.get());
-    if ( pCand != nullptr ) {
-      double rawCaloEnergyFraction = pCand->rawCaloFraction();
-      //if ( !(rawCaloEnergyFraction > 0.) ) rawCaloEnergyFraction = 99; //MB: hack against cases when rawCaloEnergyFraction is not stored; it makes performance of the H/P cut rather poor
-      if ( verbosity_ ) {
-	edm::LogPrint("PFTauAgainstMuonSimple") << "decayMode = " << pfTau->decayMode() << ", rawCaloEnergy(ECAL+HCAL)Fraction = " << rawCaloEnergyFraction << ", leadPFChargedHadronP = " << pCand->p() << ", leadPFChargedHadron pdgId = " << pCand->pdgId();
-      }
-      if ( pfTau->decayMode() == 0 && rawCaloEnergyFraction < hop_ ) passesCaloMuonVeto = false;
+      numWarnings_ = 0;
+      maxWarnings_ = 3;
+      verbosity_ = cfg.exists("verbosity") ? cfg.getParameter<int>("verbosity") : 0;
     }
-  }
-  if ( doCaloMuonVeto_ && !passesCaloMuonVeto ) {
-    if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuonSimple") << "--> CaloMuonVeto failed, returning 0";
-    return 0.;
+    ~PFRecoTauDiscriminationAgainstMuonSimple() override {}
+
+    void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+
+    double discriminate(const reco::PFTauRef&) const override;
+
+  private:
+    std::string moduleLabel_;
+    int discriminatorOption_;
+    double hop_;
+    bool doCaloMuonVeto_;
+    edm::InputTag srcPatMuons_;
+    edm::Handle<pat::MuonCollection> muons_;
+    edm::EDGetTokenT<pat::MuonCollection> Muons_token;
+    double dRmuonMatch_;
+    bool dRmuonMatchLimitedToJetArea_;
+    double minPtMatchedMuon_;
+    int maxNumberOfMatches_;
+    std::vector<int> maskMatchesDT_;
+    std::vector<int> maskMatchesCSC_;
+    std::vector<int> maskMatchesRPC_;
+    int maxNumberOfHitsLast2Stations_;
+    std::vector<int> maskHitsDT_;
+    std::vector<int> maskHitsCSC_;
+    std::vector<int> maskHitsRPC_;
+    int maxNumberOfSTAMuons_, maxNumberOfRPCMuons_;
+
+    mutable int numWarnings_;
+    int maxWarnings_;
+    int verbosity_;
+  };
+
+  void PFRecoTauDiscriminationAgainstMuonSimple::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
+    evt.getByToken(Muons_token, muons_);
   }
 
-  //iterate over muons to find ones to use for discrimination
-  std::vector<const pat::Muon*> muonsToCheck;
-  size_t numMuons = muons_->size();
-  for ( size_t idxMuon = 0; idxMuon < numMuons; ++idxMuon ) {
-    bool matched = false;
-    const pat::MuonRef muon(muons_, idxMuon);
-    if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuonSimple") << "muon #" << muon.key() << ": Pt = " << muon->pt() << ", eta = " << muon->eta() << ", phi = " << muon->phi() ;
-    //firsty check if the muon corrsponds with the leading tau particle
-    for ( size_t iCand = 0; iCand < muon->numberOfSourceCandidatePtrs(); ++iCand) {
-      const reco::CandidatePtr& srcCand = muon->sourceCandidatePtr(iCand);
-      if (srcCand.isNonnull() && pfLeadChargedHadron.isNonnull() &&
-	  srcCand.id()==pfLeadChargedHadron.id() &&
-	  srcCand.key()==pfLeadChargedHadron.key() ) {
-	muonsToCheck.push_back(muon.get());
-	matched = true;
-	if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuonSimple") << " tau has muonRef." ;
-	break;
+  double PFRecoTauDiscriminationAgainstMuonSimple::discriminate(const reco::PFTauRef& pfTau) const {
+    if (verbosity_) {
+      edm::LogPrint("PFTauAgainstMuonSimple") << "<PFRecoTauDiscriminationAgainstMuonSimple::discriminate>:";
+      edm::LogPrint("PFTauAgainstMuonSimple") << " moduleLabel = " << moduleLabel_;
+      edm::LogPrint("PFTauAgainstMuonSimple")
+          << "tau #" << pfTau.key() << ": Pt = " << pfTau->pt() << ", eta = " << pfTau->eta()
+          << ", phi = " << pfTau->phi() << ", decay mode = " << pfTau->decayMode();
+    }
+
+    //if (pfTau->decayMode() >= 5) return true; //MB: accept all multi-prongs??
+
+    const reco::CandidatePtr& pfLeadChargedHadron = pfTau->leadChargedHadrCand();
+    bool passesCaloMuonVeto = true;
+    if (pfLeadChargedHadron.isNonnull()) {
+      const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(pfLeadChargedHadron.get());
+      if (pCand != nullptr) {
+        double rawCaloEnergyFraction = pCand->rawCaloFraction();
+        //if ( !(rawCaloEnergyFraction > 0.) ) rawCaloEnergyFraction = 99; //MB: hack against cases when rawCaloEnergyFraction is not stored; it makes performance of the H/P cut rather poor
+        if (verbosity_) {
+          edm::LogPrint("PFTauAgainstMuonSimple")
+              << "decayMode = " << pfTau->decayMode()
+              << ", rawCaloEnergy(ECAL+HCAL)Fraction = " << rawCaloEnergyFraction
+              << ", leadPFChargedHadronP = " << pCand->p() << ", leadPFChargedHadron pdgId = " << pCand->pdgId();
+        }
+        if (pfTau->decayMode() == 0 && rawCaloEnergyFraction < hop_)
+          passesCaloMuonVeto = false;
       }
     }
-    if (matched) continue;
-    //check dR matching
-    if ( !(muon->pt() > minPtMatchedMuon_) ) {
-      if ( verbosity_ ){ edm::LogPrint("PFTauAgainstMuonSimple") << " fails Pt cut --> skipping it." ;}
-      continue;
+    if (doCaloMuonVeto_ && !passesCaloMuonVeto) {
+      if (verbosity_)
+        edm::LogPrint("PFTauAgainstMuonSimple") << "--> CaloMuonVeto failed, returning 0";
+      return 0.;
     }
-    double dR = deltaR(muon->p4(), pfTau->p4());
-    double dRmatch = dRmuonMatch_;
-    if ( dRmuonMatchLimitedToJetArea_ ) {
-      double jetArea = 0.;
-      if ( pfTau->jetRef().isNonnull() ) jetArea = pfTau->jetRef()->jetArea();
-      if ( jetArea > 0. ) {
-	dRmatch = TMath::Min(dRmatch, TMath::Sqrt(jetArea/TMath::Pi()));
-      } else {
-	if ( numWarnings_ < maxWarnings_ ) {
-	  edm::LogInfo("PFRecoTauDiscriminationAgainstMuonSimple::discriminate") 
-	    << "Jet associated to Tau: Pt = " << pfTau->pt() << ", eta = " << pfTau->eta() << ", phi = " << pfTau->phi() << " has area = " << jetArea << " !!" ;
-	  ++numWarnings_;
-	}
-	dRmatch = pfTau->signalConeSize();
+
+    //iterate over muons to find ones to use for discrimination
+    std::vector<const pat::Muon*> muonsToCheck;
+    size_t numMuons = muons_->size();
+    for (size_t idxMuon = 0; idxMuon < numMuons; ++idxMuon) {
+      bool matched = false;
+      const pat::MuonRef muon(muons_, idxMuon);
+      if (verbosity_)
+        edm::LogPrint("PFTauAgainstMuonSimple") << "muon #" << muon.key() << ": Pt = " << muon->pt()
+                                                << ", eta = " << muon->eta() << ", phi = " << muon->phi();
+      //firsty check if the muon corrsponds with the leading tau particle
+      for (size_t iCand = 0; iCand < muon->numberOfSourceCandidatePtrs(); ++iCand) {
+        const reco::CandidatePtr& srcCand = muon->sourceCandidatePtr(iCand);
+        if (srcCand.isNonnull() && pfLeadChargedHadron.isNonnull() && srcCand.id() == pfLeadChargedHadron.id() &&
+            srcCand.key() == pfLeadChargedHadron.key()) {
+          muonsToCheck.push_back(muon.get());
+          matched = true;
+          if (verbosity_)
+            edm::LogPrint("PFTauAgainstMuonSimple") << " tau has muonRef.";
+          break;
+        }
       }
-      dRmatch = TMath::Max(dRmatch,pfTau->signalConeSize());
-      if ( dR < dRmatch ) {
-	if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuonSimple") << " overlaps with tau, dR = " << dR ;
-	muonsToCheck.push_back(muon.get());
+      if (matched)
+        continue;
+      //check dR matching
+      if (!(muon->pt() > minPtMatchedMuon_)) {
+        if (verbosity_) {
+          edm::LogPrint("PFTauAgainstMuonSimple") << " fails Pt cut --> skipping it.";
+        }
+        continue;
+      }
+      double dR = deltaR(muon->p4(), pfTau->p4());
+      double dRmatch = dRmuonMatch_;
+      if (dRmuonMatchLimitedToJetArea_) {
+        double jetArea = 0.;
+        if (pfTau->jetRef().isNonnull())
+          jetArea = pfTau->jetRef()->jetArea();
+        if (jetArea > 0.) {
+          dRmatch = TMath::Min(dRmatch, TMath::Sqrt(jetArea / TMath::Pi()));
+        } else {
+          if (numWarnings_ < maxWarnings_) {
+            edm::LogInfo("PFRecoTauDiscriminationAgainstMuonSimple::discriminate")
+                << "Jet associated to Tau: Pt = " << pfTau->pt() << ", eta = " << pfTau->eta()
+                << ", phi = " << pfTau->phi() << " has area = " << jetArea << " !!";
+            ++numWarnings_;
+          }
+          dRmatch = pfTau->signalConeSize();
+        }
+        dRmatch = TMath::Max(dRmatch, pfTau->signalConeSize());
+        if (dR < dRmatch) {
+          if (verbosity_)
+            edm::LogPrint("PFTauAgainstMuonSimple") << " overlaps with tau, dR = " << dR;
+          muonsToCheck.push_back(muon.get());
+        }
       }
     }
+    //now examine selected muons
+    bool pass = true;
+    std::vector<int> numMatchesDT(4);
+    std::vector<int> numMatchesCSC(4);
+    std::vector<int> numMatchesRPC(4);
+    std::vector<int> numHitsDT(4);
+    std::vector<int> numHitsCSC(4);
+    std::vector<int> numHitsRPC(4);
+    //MB: clear counters of matched segments and hits globally as in the AgainstMuon2 discriminant, but note that they will sum for all matched muons. However it is not likely that there is more than one matched muon.
+    for (int iStation = 0; iStation < 4; ++iStation) {
+      numMatchesDT[iStation] = 0;
+      numMatchesCSC[iStation] = 0;
+      numMatchesRPC[iStation] = 0;
+      numHitsDT[iStation] = 0;
+      numHitsCSC[iStation] = 0;
+      numHitsRPC[iStation] = 0;
+    }
+    int numSTAMuons = 0, numRPCMuons = 0;
+    if (verbosity_ && !muonsToCheck.empty())
+      edm::LogPrint("PFTauAgainstMuonSimple") << "Muons to check (" << muonsToCheck.size() << "):";
+    size_t iMu = 0;
+    for (const auto& mu : muonsToCheck) {
+      if (mu->isStandAloneMuon())
+        numSTAMuons++;
+      if (mu->muonID("RPCMuLoose"))
+        numRPCMuons++;
+      reco::tau::countMatches(*mu, numMatchesDT, numMatchesCSC, numMatchesRPC);
+      int numStationsWithMatches = 0;
+      for (int iStation = 0; iStation < 4; ++iStation) {
+        if (numMatchesDT[iStation] > 0 && !maskMatchesDT_[iStation])
+          ++numStationsWithMatches;
+        if (numMatchesCSC[iStation] > 0 && !maskMatchesCSC_[iStation])
+          ++numStationsWithMatches;
+        if (numMatchesRPC[iStation] > 0 && !maskMatchesRPC_[iStation])
+          ++numStationsWithMatches;
+      }
+      reco::tau::countHits(*mu, numHitsDT, numHitsCSC, numHitsRPC);
+      int numLast2StationsWithHits = 0;
+      for (int iStation = 2; iStation < 4; ++iStation) {
+        if (numHitsDT[iStation] > 0 && !maskHitsDT_[iStation])
+          ++numLast2StationsWithHits;
+        if (numHitsCSC[iStation] > 0 && !maskHitsCSC_[iStation])
+          ++numLast2StationsWithHits;
+        if (numHitsRPC[iStation] > 0 && !maskHitsRPC_[iStation])
+          ++numLast2StationsWithHits;
+      }
+      if (verbosity_)
+        edm::LogPrint("PFTauAgainstMuonSimple")
+            << "\t" << iMu << ": Pt = " << mu->pt() << ", eta = " << mu->eta() << ", phi = " << mu->phi() << "\n\t"
+            << "   isSTA: " << mu->isStandAloneMuon() << ", isRPCLoose: " << mu->muonID("RPCMuLoose")
+            << "\n\t   numMatchesDT  = " << format_vint(numMatchesDT)
+            << "\n\t   numMatchesCSC = " << format_vint(numMatchesCSC)
+            << "\n\t   numMatchesRPC = " << format_vint(numMatchesRPC)
+            << "\n\t   --> numStationsWithMatches = " << numStationsWithMatches
+            << "\n\t   numHitsDT  = " << format_vint(numHitsDT) << "\n\t   numHitsCSC = " << format_vint(numHitsCSC)
+            << "\n\t   numHitsRPC = " << format_vint(numHitsRPC)
+            << "\n\t   --> numLast2StationsWithHits = " << numLast2StationsWithHits;
+      if (maxNumberOfMatches_ >= 0 && numStationsWithMatches > maxNumberOfMatches_) {
+        pass = false;
+        break;
+      }
+      if (maxNumberOfHitsLast2Stations_ >= 0 && numLast2StationsWithHits > maxNumberOfHitsLast2Stations_) {
+        pass = false;
+        break;
+      }
+      if (maxNumberOfSTAMuons_ >= 0 && numSTAMuons > maxNumberOfSTAMuons_) {
+        pass = false;
+        break;
+      }
+      if (maxNumberOfRPCMuons_ >= 0 && numRPCMuons > maxNumberOfRPCMuons_) {
+        pass = false;
+        break;
+      }
+      iMu++;
+    }
+
+    double discriminatorValue = pass ? 1. : 0.;
+    if (verbosity_)
+      edm::LogPrint("PFTauAgainstMuonSimple") << "--> returning discriminatorValue = " << discriminatorValue;
+
+    return discriminatorValue;
   }
-  //now examine selected muons
-  bool pass = true;
-  std::vector<int> numMatchesDT(4);
-  std::vector<int> numMatchesCSC(4);
-  std::vector<int> numMatchesRPC(4);
-  std::vector<int> numHitsDT(4);
-  std::vector<int> numHitsCSC(4);
-  std::vector<int> numHitsRPC(4);
-  //MB: clear counters of matched segments and hits globally as in the AgainstMuon2 discriminant, but note that they will sum for all matched muons. However it is not likely that there is more than one matched muon.
-  for ( int iStation = 0; iStation < 4; ++iStation ) {
-    numMatchesDT[iStation]  = 0;
-    numMatchesCSC[iStation] = 0;
-    numMatchesRPC[iStation] = 0;
-    numHitsDT[iStation]  = 0;
-    numHitsCSC[iStation] = 0;
-    numHitsRPC[iStation] = 0;
-  } 
-  int numSTAMuons=0, numRPCMuons=0;
-  if ( verbosity_ && !muonsToCheck.empty() ) edm::LogPrint("PFTauAgainstMuonSimple") << "Muons to check (" << muonsToCheck.size() << "):";
-  size_t iMu = 0;
-  for (const auto &mu: muonsToCheck) {
-    if ( mu->isStandAloneMuon() ) numSTAMuons++;
-    if ( mu->muonID("RPCMuLoose") ) numRPCMuons++;
-    reco::tau::countMatches(*mu, numMatchesDT, numMatchesCSC, numMatchesRPC);
-    int numStationsWithMatches = 0;
-    for ( int iStation = 0; iStation < 4; ++iStation ) {
-      if ( numMatchesDT[iStation]  > 0 && !maskMatchesDT_[iStation]  ) ++numStationsWithMatches;
-      if ( numMatchesCSC[iStation] > 0 && !maskMatchesCSC_[iStation] ) ++numStationsWithMatches;
-      if ( numMatchesRPC[iStation] > 0 && !maskMatchesRPC_[iStation] ) ++numStationsWithMatches;
-    }
-    reco::tau::countHits(*mu, numHitsDT, numHitsCSC, numHitsRPC);
-    int numLast2StationsWithHits = 0;
-    for ( int iStation = 2; iStation < 4; ++iStation ) {
-      if ( numHitsDT[iStation]  > 0 && !maskHitsDT_[iStation]  ) ++numLast2StationsWithHits;
-      if ( numHitsCSC[iStation] > 0 && !maskHitsCSC_[iStation] ) ++numLast2StationsWithHits;
-      if ( numHitsRPC[iStation] > 0 && !maskHitsRPC_[iStation] ) ++numLast2StationsWithHits;
-    }
-    if ( verbosity_ )
-      edm::LogPrint("PFTauAgainstMuonSimple") 
-	<< "\t" << iMu << ": Pt = " << mu->pt() << ", eta = " << mu->eta() << ", phi = " << mu->phi() 
-	<< "\n\t" 
-	<< "   isSTA: "<<mu->isStandAloneMuon()
-	<< ", isRPCLoose: "<<mu->muonID("RPCMuLoose")
-	<< "\n\t   numMatchesDT  = " << format_vint(numMatchesDT)
-	<< "\n\t   numMatchesCSC = " << format_vint(numMatchesCSC)
-	<< "\n\t   numMatchesRPC = " << format_vint(numMatchesRPC)
-	<< "\n\t   --> numStationsWithMatches = " << numStationsWithMatches
-	<< "\n\t   numHitsDT  = " << format_vint(numHitsDT)
-	<< "\n\t   numHitsCSC = " << format_vint(numHitsCSC)
-	<< "\n\t   numHitsRPC = " << format_vint(numHitsRPC)
-	<< "\n\t   --> numLast2StationsWithHits = " << numLast2StationsWithHits ;
-    if ( maxNumberOfMatches_ >= 0 && numStationsWithMatches > maxNumberOfMatches_ ) {
-      pass = false;
-      break;
-    }
-    if ( maxNumberOfHitsLast2Stations_ >= 0 && numLast2StationsWithHits > maxNumberOfHitsLast2Stations_ ) {
-      pass = false;
-      break;
-    }
-    if ( maxNumberOfSTAMuons_ >= 0 && numSTAMuons > maxNumberOfSTAMuons_ ) {
-      pass = false;
-      break;
-    }
-    if ( maxNumberOfRPCMuons_ >= 0 && numRPCMuons > maxNumberOfRPCMuons_ ) {
-      pass = false;
-      break;
-    }
-    iMu++;
-  }
 
-  double discriminatorValue = pass ? 1.: 0.;
-  if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuonSimple") << "--> returning discriminatorValue = " << discriminatorValue ;
-
-  return discriminatorValue;
-} 
-
-}
+}  // namespace
 
 DEFINE_FWK_MODULE(PFRecoTauDiscriminationAgainstMuonSimple);
-

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
@@ -13,31 +13,26 @@
 
 namespace {
   // Apply a hypothesis on the mass of the strips.
-  math::XYZTLorentzVector applyMassConstraint(const math::XYZTLorentzVector& vec, double mass) 
-  {
-    double factor = sqrt(vec.energy()*vec.energy() - mass*mass)/vec.P();
-    return math::XYZTLorentzVector(vec.px()*factor, vec.py()*factor, vec.pz()*factor, vec.energy());
+  math::XYZTLorentzVector applyMassConstraint(const math::XYZTLorentzVector& vec, double mass) {
+    double factor = sqrt(vec.energy() * vec.energy() - mass * mass) / vec.P();
+    return math::XYZTLorentzVector(vec.px() * factor, vec.py() * factor, vec.pz() * factor, vec.energy());
   }
-}
+}  // namespace
 
-class PFRecoTauDiscriminationByHPSSelection : public PFTauDiscriminationProducerBase 
-{
- public:
+class PFRecoTauDiscriminationByHPSSelection : public PFTauDiscriminationProducerBase {
+public:
   explicit PFRecoTauDiscriminationByHPSSelection(const edm::ParameterSet&);
   ~PFRecoTauDiscriminationByHPSSelection() override;
   double discriminate(const reco::PFTauRef&) const override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
+private:
   typedef StringObjectFunction<reco::PFTau> TauFunc;
 
-  struct DecayModeCuts 
-  {
-    DecayModeCuts()
-      : maxMass_(nullptr)
-    {}
-    ~DecayModeCuts() {} // CV: maxMass object gets deleted by PFRecoTauDiscriminationByHPSSelection destructor
+  struct DecayModeCuts {
+    DecayModeCuts() : maxMass_(nullptr) {}
+    ~DecayModeCuts() {}  // CV: maxMass object gets deleted by PFRecoTauDiscriminationByHPSSelection destructor
     unsigned nTracksMin_;
     unsigned nChargedPFCandsMin_;
     double minMass_;
@@ -53,28 +48,27 @@ class PFRecoTauDiscriminationByHPSSelection : public PFTauDiscriminationProducer
   typedef std::pair<unsigned int, unsigned int> IntPair;
   typedef std::pair<double, double> DoublePair;
   typedef std::map<IntPair, DecayModeCuts> DecayModeCutMap;
-  
+
   DecayModeCutMap decayModeCuts_;
   double matchingCone_;
   double minPt_;
 
   bool requireTauChargedHadronsToBeChargedPFCands_;
-  
+
   int minPixelHits_;
 
   int verbosity_;
 };
 
 PFRecoTauDiscriminationByHPSSelection::PFRecoTauDiscriminationByHPSSelection(const edm::ParameterSet& pset)
-  : PFTauDiscriminationProducerBase(pset)
-{
+    : PFTauDiscriminationProducerBase(pset) {
   // Get the matchign cut
   matchingCone_ = pset.getParameter<double>("matchingCone");
   minPt_ = pset.getParameter<double>("minTauPt");
   // Get the mass cuts for each decay mode
   typedef std::vector<edm::ParameterSet> VPSet;
   const VPSet& decayModes = pset.getParameter<VPSet>("decayModes");
-  for(auto const& decayMode : decayModes ) {
+  for (auto const& decayMode : decayModes) {
     // The mass window(s)
     DecayModeCuts cuts;
     cuts.nTracksMin_ = decayMode.getParameter<unsigned>("nTracksMin");
@@ -89,146 +83,143 @@ PFRecoTauDiscriminationByHPSSelection::PFRecoTauDiscriminationByHPSSelection(con
     cuts.maxPi0Mass_ = decayMode.getParameter<double>("maxPi0Mass");
     cuts.assumeStripMass_ = decayMode.getParameter<double>("assumeStripMass");
     decayModeCuts_.insert(std::make_pair(
-            // The decay mode as a key
-            std::make_pair(
-                decayMode.getParameter<uint32_t>("nCharged"),
-                decayMode.getParameter<uint32_t>("nPiZeros")),
-            cuts
-          ));
+        // The decay mode as a key
+        std::make_pair(decayMode.getParameter<uint32_t>("nCharged"), decayMode.getParameter<uint32_t>("nPiZeros")),
+        cuts));
   }
   requireTauChargedHadronsToBeChargedPFCands_ = pset.getParameter<bool>("requireTauChargedHadronsToBeChargedPFCands");
   minPixelHits_ = pset.getParameter<int>("minPixelHits");
   verbosity_ = pset.getParameter<int>("verbosity");
-  
-
 }
 
-PFRecoTauDiscriminationByHPSSelection::~PFRecoTauDiscriminationByHPSSelection()
-{
-  for ( DecayModeCutMap::iterator it = decayModeCuts_.begin();
-	it != decayModeCuts_.end(); ++it ) {
+PFRecoTauDiscriminationByHPSSelection::~PFRecoTauDiscriminationByHPSSelection() {
+  for (DecayModeCutMap::iterator it = decayModeCuts_.begin(); it != decayModeCuts_.end(); ++it) {
     delete it->second.maxMass_;
   }
 }
 
 namespace {
-  inline const reco::Track* getTrack(const reco::Candidate& cand)
-  {
+  inline const reco::Track* getTrack(const reco::Candidate& cand) {
     const reco::PFCandidate* pfCandPtr = dynamic_cast<const reco::PFCandidate*>(&cand);
     if (pfCandPtr) {
-      if      ( pfCandPtr->trackRef().isNonnull()    ) return pfCandPtr->trackRef().get();
-      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return pfCandPtr->gsfTrackRef().get();
-      else return nullptr;
+      if (pfCandPtr->trackRef().isNonnull())
+        return pfCandPtr->trackRef().get();
+      else if (pfCandPtr->gsfTrackRef().isNonnull())
+        return pfCandPtr->gsfTrackRef().get();
+      else
+        return nullptr;
     }
     const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
     if (packedCand && packedCand->hasTrackDetails())
-    	return &packedCand->pseudoTrack();
+      return &packedCand->pseudoTrack();
 
     return nullptr;
   }
-}
+}  // namespace
 
-double
-PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef& tau) const
-{
-  if ( verbosity_ ) {
-    edm::LogPrint("PFTauByHPSSelect") << "<PFRecoTauDiscriminationByHPSSelection::discriminate>:" ;
-    edm::LogPrint("PFTauByHPSSelect") << " nCharged = " << tau->signalTauChargedHadronCandidates().size() ;
-    edm::LogPrint("PFTauByHPSSelect") << " nPiZeros = " << tau->signalPiZeroCandidates().size() ;
+double PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef& tau) const {
+  if (verbosity_) {
+    edm::LogPrint("PFTauByHPSSelect") << "<PFRecoTauDiscriminationByHPSSelection::discriminate>:";
+    edm::LogPrint("PFTauByHPSSelect") << " nCharged = " << tau->signalTauChargedHadronCandidates().size();
+    edm::LogPrint("PFTauByHPSSelect") << " nPiZeros = " << tau->signalPiZeroCandidates().size();
   }
 
   // Check if we pass the min pt
-  if ( tau->pt() < minPt_ ) {
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauByHPSSelect") << " fails minPt cut." ;
+  if (tau->pt() < minPt_) {
+    if (verbosity_) {
+      edm::LogPrint("PFTauByHPSSelect") << " fails minPt cut.";
     }
     return 0.0;
   }
 
   // See if we select this decay mode
-  DecayModeCutMap::const_iterator massWindowIter =
-      decayModeCuts_.find(std::make_pair(tau->signalTauChargedHadronCandidates().size(),
-                                         tau->signalPiZeroCandidates().size()));
+  DecayModeCutMap::const_iterator massWindowIter = decayModeCuts_.find(
+      std::make_pair(tau->signalTauChargedHadronCandidates().size(), tau->signalPiZeroCandidates().size()));
   // Check if decay mode is supported
-  if ( massWindowIter == decayModeCuts_.end() ) {
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauByHPSSelect") << " fails mass-window definition requirement." ;
+  if (massWindowIter == decayModeCuts_.end()) {
+    if (verbosity_) {
+      edm::LogPrint("PFTauByHPSSelect") << " fails mass-window definition requirement.";
     }
     return 0.0;
   }
   const DecayModeCuts& massWindow = massWindowIter->second;
 
-  if ( massWindow.nTracksMin_ > 0 ) {
+  if (massWindow.nTracksMin_ > 0) {
     unsigned int nTracks = 0;
     const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons = tau->signalTauChargedHadronCandidates();
-    for ( std::vector<reco::PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
-	  chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
-      if ( chargedHadron->algoIs(reco::PFRecoTauChargedHadron::kChargedPFCandidate) || chargedHadron->algoIs(reco::PFRecoTauChargedHadron::kTrack) ) {
-	++nTracks;
+    for (std::vector<reco::PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
+         chargedHadron != chargedHadrons.end();
+         ++chargedHadron) {
+      if (chargedHadron->algoIs(reco::PFRecoTauChargedHadron::kChargedPFCandidate) ||
+          chargedHadron->algoIs(reco::PFRecoTauChargedHadron::kTrack)) {
+        ++nTracks;
       }
     }
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauByHPSSelect") << "nTracks = " << nTracks << " (min = " << massWindow.nTracksMin_ << ")" ;
+    if (verbosity_) {
+      edm::LogPrint("PFTauByHPSSelect") << "nTracks = " << nTracks << " (min = " << massWindow.nTracksMin_ << ")";
     }
-    if ( nTracks < massWindow.nTracksMin_ ) {
-      if ( verbosity_ ) {
-	edm::LogPrint("PFTauByHPSSelect") << " fails nTracks requirement for mass-window." ;
+    if (nTracks < massWindow.nTracksMin_) {
+      if (verbosity_) {
+        edm::LogPrint("PFTauByHPSSelect") << " fails nTracks requirement for mass-window.";
       }
       return 0.0;
     }
   }
-  if ( massWindow.nChargedPFCandsMin_ > 0 ) {
+  if (massWindow.nChargedPFCandsMin_ > 0) {
     unsigned int nChargedPFCands = 0;
     const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons = tau->signalTauChargedHadronCandidates();
-    for ( std::vector<reco::PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
-	  chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
-      if ( chargedHadron->algoIs(reco::PFRecoTauChargedHadron::kChargedPFCandidate) ) {
-	++nChargedPFCands;
+    for (std::vector<reco::PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
+         chargedHadron != chargedHadrons.end();
+         ++chargedHadron) {
+      if (chargedHadron->algoIs(reco::PFRecoTauChargedHadron::kChargedPFCandidate)) {
+        ++nChargedPFCands;
       }
     }
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauByHPSSelect") << "nChargedPFCands = " << nChargedPFCands << " (min = " << massWindow.nChargedPFCandsMin_ << ")" ;
+    if (verbosity_) {
+      edm::LogPrint("PFTauByHPSSelect") << "nChargedPFCands = " << nChargedPFCands
+                                        << " (min = " << massWindow.nChargedPFCandsMin_ << ")";
     }
-    if ( nChargedPFCands < massWindow.nChargedPFCandsMin_ ) {
-      if ( verbosity_ ) {
-	edm::LogPrint("PFTauByHPSSelect") << " fails nChargedPFCands requirement for mass-window." ;
+    if (nChargedPFCands < massWindow.nChargedPFCandsMin_) {
+      if (verbosity_) {
+        edm::LogPrint("PFTauByHPSSelect") << " fails nChargedPFCands requirement for mass-window.";
       }
       return 0.0;
     }
   }
 
   math::XYZTLorentzVector tauP4 = tau->p4();
-  if ( verbosity_ ) {
-    edm::LogPrint("PFTauByHPSSelect") << "tau: Pt = " << tauP4.pt() << ", eta = " << tauP4.eta() << ", phi = " << tauP4.phi() << ", mass = " << tauP4.mass() ;
+  if (verbosity_) {
+    edm::LogPrint("PFTauByHPSSelect") << "tau: Pt = " << tauP4.pt() << ", eta = " << tauP4.eta()
+                                      << ", phi = " << tauP4.phi() << ", mass = " << tauP4.mass();
   }
   // Find the total pizero p4
   reco::Candidate::LorentzVector stripsP4;
-  for(auto const& cand : tau->signalPiZeroCandidates()){
+  for (auto const& cand : tau->signalPiZeroCandidates()) {
     const math::XYZTLorentzVector& candP4 = cand.p4();
     stripsP4 += candP4;
   }
 
   // Apply strip mass assumption corrections
   if (massWindow.assumeStripMass_ >= 0) {
-    for(auto const& cand : tau->signalPiZeroCandidates()){
+    for (auto const& cand : tau->signalPiZeroCandidates()) {
       const math::XYZTLorentzVector& uncorrected = cand.p4();
-      math::XYZTLorentzVector corrected = 
-        applyMassConstraint(uncorrected, massWindow.assumeStripMass_);
+      math::XYZTLorentzVector corrected = applyMassConstraint(uncorrected, massWindow.assumeStripMass_);
       math::XYZTLorentzVector correction = corrected - uncorrected;
       tauP4 += correction;
       stripsP4 += correction;
     }
   }
-  if ( verbosity_ ) {
-    edm::LogPrint("PFTauByHPSSelect") << "strips: Pt = " << stripsP4.pt() << ", eta = " << stripsP4.eta() << ", phi = " << stripsP4.phi() << ", mass = " << stripsP4.mass() ;
+  if (verbosity_) {
+    edm::LogPrint("PFTauByHPSSelect") << "strips: Pt = " << stripsP4.pt() << ", eta = " << stripsP4.eta()
+                                      << ", phi = " << stripsP4.phi() << ", mass = " << stripsP4.mass();
   }
 
   // Check if tau fails mass cut
   double maxMass_value = (*massWindow.maxMass_)(*tau);
-  double bendCorrection_mass = ( massWindow.applyBendCorrection_mass_ ) ? tau->bendCorrMass() : 0.;
-  if ( !((tauP4.M() - bendCorrection_mass) < maxMass_value && (tauP4.M() + bendCorrection_mass) > massWindow.minMass_) ) {
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauByHPSSelect") << " fails tau mass-window cut." ;
+  double bendCorrection_mass = (massWindow.applyBendCorrection_mass_) ? tau->bendCorrMass() : 0.;
+  if (!((tauP4.M() - bendCorrection_mass) < maxMass_value && (tauP4.M() + bendCorrection_mass) > massWindow.minMass_)) {
+    if (verbosity_) {
+      edm::LogPrint("PFTauByHPSSelect") << " fails tau mass-window cut.";
     }
     return 0.0;
   }
@@ -236,111 +227,114 @@ PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef& tau) c
   //     irrespective of bendCorrection_mass
   reco::Candidate::LorentzVector tauP4_charged;
   const std::vector<reco::PFRecoTauChargedHadron>& signalChargedHadrons = tau->signalTauChargedHadronCandidates();
-  for ( std::vector<reco::PFRecoTauChargedHadron>::const_iterator signalChargedHadron = signalChargedHadrons.begin();
-	signalChargedHadron != signalChargedHadrons.end(); ++signalChargedHadron ) {
+  for (std::vector<reco::PFRecoTauChargedHadron>::const_iterator signalChargedHadron = signalChargedHadrons.begin();
+       signalChargedHadron != signalChargedHadrons.end();
+       ++signalChargedHadron) {
     tauP4_charged += signalChargedHadron->p4();
   }
-  if ( !(tauP4_charged.mass() < maxMass_value) ) {
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauByHPSSelect") << " fails tau mass-window cut." ;
+  if (!(tauP4_charged.mass() < maxMass_value)) {
+    if (verbosity_) {
+      edm::LogPrint("PFTauByHPSSelect") << " fails tau mass-window cut.";
     }
     return 0.0;
   }
-  
+
   // Check if it fails the pi0 IM cut
-  if ( stripsP4.M() > massWindow.maxPi0Mass_ ||
-       stripsP4.M() < massWindow.minPi0Mass_ ) {
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauByHPSSelect") << " fails strip mass-window cut." ;
+  if (stripsP4.M() > massWindow.maxPi0Mass_ || stripsP4.M() < massWindow.minPi0Mass_) {
+    if (verbosity_) {
+      edm::LogPrint("PFTauByHPSSelect") << " fails strip mass-window cut.";
     }
     return 0.0;
   }
 
   // Check if tau passes matching cone cut
   //edm::LogPrint("PFTauByHPSSelect") << "dR(tau, jet) = " << deltaR(tauP4, tau->jetRef()->p4()) ;
-  if ( deltaR(tauP4, tau->jetRef()->p4()) > matchingCone_ ) {
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauByHPSSelect") << " fails matching-cone cut." ;
+  if (deltaR(tauP4, tau->jetRef()->p4()) > matchingCone_) {
+    if (verbosity_) {
+      edm::LogPrint("PFTauByHPSSelect") << " fails matching-cone cut.";
     }
     return 0.0;
   }
-  
+
   // Check if tau passes cone cut
   double cone_size = tau->signalConeSize();
   // Check if any charged objects fail the signal cone cut
   for (auto const& cand : tau->signalTauChargedHadronCandidates()) {
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauByHPSSelect") << "dR(tau, signalPFChargedHadr) = " << deltaR(cand.p4(), tauP4) ;
+    if (verbosity_) {
+      edm::LogPrint("PFTauByHPSSelect") << "dR(tau, signalPFChargedHadr) = " << deltaR(cand.p4(), tauP4);
     }
-    if ( deltaR(cand.p4(), tauP4) > cone_size ) {
-      if ( verbosity_ ) {
-	edm::LogPrint("PFTauByHPSSelect") << " fails signal-cone cut for charged hadron(s)." ;
+    if (deltaR(cand.p4(), tauP4) > cone_size) {
+      if (verbosity_) {
+        edm::LogPrint("PFTauByHPSSelect") << " fails signal-cone cut for charged hadron(s).";
       }
       return 0.0;
     }
   }
   // Now check the pizeros
   for (auto const& cand : tau->signalPiZeroCandidates()) {
-    double bendCorrection_eta = ( massWindow.applyBendCorrection_eta_ ) ? cand.bendCorrEta() : 0.;
+    double bendCorrection_eta = (massWindow.applyBendCorrection_eta_) ? cand.bendCorrEta() : 0.;
     double dEta = std::max(0., fabs(cand.eta() - tauP4.eta()) - bendCorrection_eta);
-    double bendCorrection_phi = ( massWindow.applyBendCorrection_phi_ ) ? cand.bendCorrPhi() : 0.;
+    double bendCorrection_phi = (massWindow.applyBendCorrection_phi_) ? cand.bendCorrPhi() : 0.;
     double dPhi = std::max(0., std::abs(reco::deltaPhi(cand.phi(), tauP4.phi())) - bendCorrection_phi);
-    double dR2 = dEta*dEta + dPhi*dPhi;
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauByHPSSelect") << "dR2(tau, signalPiZero) = " << dR2 ;
+    double dR2 = dEta * dEta + dPhi * dPhi;
+    if (verbosity_) {
+      edm::LogPrint("PFTauByHPSSelect") << "dR2(tau, signalPiZero) = " << dR2;
     }
-    if ( dR2 > cone_size*cone_size ) {
-      if ( verbosity_ ) {
-	edm::LogPrint("PFTauByHPSSelect") << " fails signal-cone cut for strip(s)." ;
+    if (dR2 > cone_size * cone_size) {
+      if (verbosity_) {
+        edm::LogPrint("PFTauByHPSSelect") << " fails signal-cone cut for strip(s).";
       }
       return 0.0;
     }
   }
 
-  if ( requireTauChargedHadronsToBeChargedPFCands_ ) {
-    for(auto const& cand : tau->signalTauChargedHadronCandidates()) {
-      if ( verbosity_ ) {
-	std::string algo_string;
-	if      ( cand.algo() == reco::PFRecoTauChargedHadron::kChargedPFCandidate ) algo_string = "ChargedPFCandidate";
-	else if ( cand.algo() == reco::PFRecoTauChargedHadron::kTrack              ) algo_string = "Track";
-	else if ( cand.algo() == reco::PFRecoTauChargedHadron::kPFNeutralHadron    ) algo_string = "PFNeutralHadron";
-	else                                                                         algo_string = "Undefined";
-	edm::LogPrint("PFTauByHPSSelect") << "algo(signalPFChargedHadr) = " << algo_string ;
+  if (requireTauChargedHadronsToBeChargedPFCands_) {
+    for (auto const& cand : tau->signalTauChargedHadronCandidates()) {
+      if (verbosity_) {
+        std::string algo_string;
+        if (cand.algo() == reco::PFRecoTauChargedHadron::kChargedPFCandidate)
+          algo_string = "ChargedPFCandidate";
+        else if (cand.algo() == reco::PFRecoTauChargedHadron::kTrack)
+          algo_string = "Track";
+        else if (cand.algo() == reco::PFRecoTauChargedHadron::kPFNeutralHadron)
+          algo_string = "PFNeutralHadron";
+        else
+          algo_string = "Undefined";
+        edm::LogPrint("PFTauByHPSSelect") << "algo(signalPFChargedHadr) = " << algo_string;
       }
-      if ( !(cand.algo() == reco::PFRecoTauChargedHadron::kChargedPFCandidate) ) {
-	if ( verbosity_ ) {
-	  edm::LogPrint("PFTauByHPSSelect") << " fails cut on PFRecoTauChargedHadron algo." ;
-	}
-	return 0.0;
+      if (!(cand.algo() == reco::PFRecoTauChargedHadron::kChargedPFCandidate)) {
+        if (verbosity_) {
+          edm::LogPrint("PFTauByHPSSelect") << " fails cut on PFRecoTauChargedHadron algo.";
+        }
+        return 0.0;
       }
     }
   }
 
-  if ( minPixelHits_ > 0 ) {
+  if (minPixelHits_ > 0) {
     int numPixelHits = 0;
     for (const auto& chargedHadrCand : tau->signalChargedHadrCands()) {
       const reco::Track* track = getTrack(*chargedHadrCand);
       if (track != nullptr) {
-	numPixelHits += track->hitPattern().numberOfValidPixelHits();
+        numPixelHits += track->hitPattern().numberOfValidPixelHits();
       }
     }
-    if ( !(numPixelHits >= minPixelHits_) ) {
-      if ( verbosity_ ) {
-	edm::LogPrint("PFTauByHPSSelect") << " fails cut on sum of pixel hits." ;
+    if (!(numPixelHits >= minPixelHits_)) {
+      if (verbosity_) {
+        edm::LogPrint("PFTauByHPSSelect") << " fails cut on sum of pixel hits.";
       }
       return 0.0;
     }
   }
 
   // Otherwise, we pass!
-  if ( verbosity_ ) {
-    edm::LogPrint("PFTauByHPSSelect") << " passes all cuts." ;
+  if (verbosity_) {
+    edm::LogPrint("PFTauByHPSSelect") << " passes all cuts.";
   }
   return 1.0;
 }
 
-void
-PFRecoTauDiscriminationByHPSSelection::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauDiscriminationByHPSSelection::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // hpsSelectionDiscriminator
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("PFTauProducer", edm::InputTag("combinatoricRecoTaus"));

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -25,18 +25,14 @@
 using namespace reco;
 using namespace std;
 
-class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBase  
-{
- public:
+class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBase {
+public:
   explicit PFRecoTauDiscriminationByIsolation(const edm::ParameterSet& pset)
-    : PFTauDiscriminationProducerBase(pset),
-      moduleLabel_(pset.getParameter<std::string>("@module_label")),
-      qualityCutsPSet_(pset.getParameter<edm::ParameterSet>("qualityCuts")) 
-  {
-    includeTracks_ = pset.getParameter<bool>(
-      "ApplyDiscriminationByTrackerIsolation");
-    includeGammas_ = pset.getParameter<bool>(
-      "ApplyDiscriminationByECALIsolation");
+      : PFTauDiscriminationProducerBase(pset),
+        moduleLabel_(pset.getParameter<std::string>("@module_label")),
+        qualityCutsPSet_(pset.getParameter<edm::ParameterSet>("qualityCuts")) {
+    includeTracks_ = pset.getParameter<bool>("ApplyDiscriminationByTrackerIsolation");
+    includeGammas_ = pset.getParameter<bool>("ApplyDiscriminationByECALIsolation");
 
     calculateWeights_ = pset.getParameter<bool>("ApplyDiscriminationByWeightedECALIsolation");
 
@@ -47,7 +43,7 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
 
     // RIC: allow to relax the isolation completely beyond a given tau pt
     minPtForNoIso_ = pset.getParameter<double>("minTauPtForNoIso");
-    
+
     applyOccupancyCut_ = pset.getParameter<bool>("applyOccupancyCut");
     maximumOccupancy_ = pset.getParameter<uint32_t>("maximumOccupancy");
 
@@ -58,145 +54,137 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
     maximumRelativeSumPt_ = pset.getParameter<double>("relativeSumPtCut");
     offsetRelativeSumPt_ = pset.getParameter<double>("relativeSumPtOffset");
 
-    storeRawOccupancy_                     = pset.getParameter<bool>("storeRawOccupancy");
-    storeRawSumPt_                         = pset.getParameter<bool>("storeRawSumPt");
-    storeRawPUsumPt_                       = pset.getParameter<bool>("storeRawPUsumPt");
-    storeRawFootprintCorrection_           = pset.getParameter<bool>("storeRawFootprintCorrection");
+    storeRawOccupancy_ = pset.getParameter<bool>("storeRawOccupancy");
+    storeRawSumPt_ = pset.getParameter<bool>("storeRawSumPt");
+    storeRawPUsumPt_ = pset.getParameter<bool>("storeRawPUsumPt");
+    storeRawFootprintCorrection_ = pset.getParameter<bool>("storeRawFootprintCorrection");
     storeRawPhotonSumPt_outsideSignalCone_ = pset.getParameter<bool>("storeRawPhotonSumPt_outsideSignalCone");
 
     // Sanity check on requested options.  We can't apply cuts and store the
     // raw output at the same time
-    if ( applySumPtCut_ || applyOccupancyCut_ || applyRelativeSumPtCut_ ) {
-      if ( storeRawSumPt_ || storeRawOccupancy_ || storeRawPUsumPt_ ) {
-	throw cms::Exception("BadIsoConfig") 
-	  << "A 'store raw' and a 'apply cut' option have been set to true "
-	  << "simultaneously.  These options are mutually exclusive.";
+    if (applySumPtCut_ || applyOccupancyCut_ || applyRelativeSumPtCut_) {
+      if (storeRawSumPt_ || storeRawOccupancy_ || storeRawPUsumPt_) {
+        throw cms::Exception("BadIsoConfig") << "A 'store raw' and a 'apply cut' option have been set to true "
+                                             << "simultaneously.  These options are mutually exclusive.";
       }
     }
-    
+
     // sanity check2 - can't use weighted and unweighted iso at the same time
-    if ( includeGammas_ && calculateWeights_ ) {
+    if (includeGammas_ && calculateWeights_) {
       throw cms::Exception("BasIsoConfig")
-	<< "Both 'ApplyDiscriminationByECALIsolation' and 'ApplyDiscriminationByWeightedECALIsolation' "
-	<< "have been set to true. These options are mutually exclusive.";
+          << "Both 'ApplyDiscriminationByECALIsolation' and 'ApplyDiscriminationByWeightedECALIsolation' "
+          << "have been set to true. These options are mutually exclusive.";
     }
-    
+
     // Can only store one type
     int numStoreOptions = 0;
-    if ( storeRawSumPt_                         ) ++numStoreOptions;
-    if ( storeRawOccupancy_                     ) ++numStoreOptions;
-    if ( storeRawPUsumPt_                       ) ++numStoreOptions;
-    if ( storeRawFootprintCorrection_           ) ++numStoreOptions;
-    if ( storeRawPhotonSumPt_outsideSignalCone_ ) ++numStoreOptions;
-    if ( numStoreOptions > 1 ) {
-      throw cms::Exception("BadIsoConfig") 
-	<< "Multiple 'store sum pt' and/or 'store occupancy' options are set."
-	<< " These options are mutually exclusive.";
+    if (storeRawSumPt_)
+      ++numStoreOptions;
+    if (storeRawOccupancy_)
+      ++numStoreOptions;
+    if (storeRawPUsumPt_)
+      ++numStoreOptions;
+    if (storeRawFootprintCorrection_)
+      ++numStoreOptions;
+    if (storeRawPhotonSumPt_outsideSignalCone_)
+      ++numStoreOptions;
+    if (numStoreOptions > 1) {
+      throw cms::Exception("BadIsoConfig") << "Multiple 'store sum pt' and/or 'store occupancy' options are set."
+                                           << " These options are mutually exclusive.";
     }
 
     customIsoCone_ = pset.getParameter<double>("customOuterCone");
 
     applyPhotonPtSumOutsideSignalConeCut_ = pset.getParameter<bool>("applyPhotonPtSumOutsideSignalConeCut");
-    if ( applyPhotonPtSumOutsideSignalConeCut_ ) {
+    if (applyPhotonPtSumOutsideSignalConeCut_) {
       maxAbsPhotonSumPt_outsideSignalCone_ = pset.getParameter<double>("maxAbsPhotonSumPt_outsideSignalCone");
       maxRelPhotonSumPt_outsideSignalCone_ = pset.getParameter<double>("maxRelPhotonSumPt_outsideSignalCone");
     }
-    
+
     applyFootprintCorrection_ = pset.getParameter<bool>("applyFootprintCorrection");
-    if ( applyFootprintCorrection_ || storeRawFootprintCorrection_ ) {
+    if (applyFootprintCorrection_ || storeRawFootprintCorrection_) {
       edm::VParameterSet cfgFootprintCorrections = pset.getParameter<edm::VParameterSet>("footprintCorrections");
-      for ( edm::VParameterSet::const_iterator cfgFootprintCorrection = cfgFootprintCorrections.begin();
-	    cfgFootprintCorrection != cfgFootprintCorrections.end(); ++cfgFootprintCorrection ) {
-	std::string selection = cfgFootprintCorrection->getParameter<std::string>("selection");
-	std::string offset = cfgFootprintCorrection->getParameter<std::string>("offset");
-	std::unique_ptr<FootprintCorrection> footprintCorrection(new FootprintCorrection(selection, offset));
-	footprintCorrections_.push_back(std::move(footprintCorrection));
+      for (edm::VParameterSet::const_iterator cfgFootprintCorrection = cfgFootprintCorrections.begin();
+           cfgFootprintCorrection != cfgFootprintCorrections.end();
+           ++cfgFootprintCorrection) {
+        std::string selection = cfgFootprintCorrection->getParameter<std::string>("selection");
+        std::string offset = cfgFootprintCorrection->getParameter<std::string>("offset");
+        std::unique_ptr<FootprintCorrection> footprintCorrection(new FootprintCorrection(selection, offset));
+        footprintCorrections_.push_back(std::move(footprintCorrection));
       }
     }
 
     // Get the quality cuts specific to the isolation region
-    edm::ParameterSet isolationQCuts = qualityCutsPSet_.getParameterSet(
-      "isolationQualityCuts");
+    edm::ParameterSet isolationQCuts = qualityCutsPSet_.getParameterSet("isolationQualityCuts");
 
     qcuts_.reset(new tau::RecoTauQualityCuts(isolationQCuts));
 
-    vertexAssociator_.reset(
-      new tau::RecoTauVertexAssociator(qualityCutsPSet_,consumesCollector()));
+    vertexAssociator_.reset(new tau::RecoTauVertexAssociator(qualityCutsPSet_, consumesCollector()));
 
     applyDeltaBeta_ = pset.getParameter<bool>("applyDeltaBetaCorrection");
 
-    if ( applyDeltaBeta_ || calculateWeights_ ) {
+    if (applyDeltaBeta_ || calculateWeights_) {
       // Factorize the isolation QCuts into those that are used to
       // select PU and those that are not.
       std::pair<edm::ParameterSet, edm::ParameterSet> puFactorizedIsoQCuts =
-	reco::tau::factorizePUQCuts(isolationQCuts);
+          reco::tau::factorizePUQCuts(isolationQCuts);
 
       // Determine the pt threshold for the PU tracks
       // First check if the user specifies explicitly the cut.
       // For that the user has to provide a >= 0  value for the PtCutOverride.
       bool deltaBetaPUTrackPtCutOverride = pset.getParameter<bool>("deltaBetaPUTrackPtCutOverride");
-      if ( deltaBetaPUTrackPtCutOverride ) {
-	double deltaBetaPUTrackPtCutOverride_val = pset.getParameter<double>("deltaBetaPUTrackPtCutOverride_val");
-	puFactorizedIsoQCuts.second.addParameter<double>(
-	  "minTrackPt",
-	  deltaBetaPUTrackPtCutOverride_val);
+      if (deltaBetaPUTrackPtCutOverride) {
+        double deltaBetaPUTrackPtCutOverride_val = pset.getParameter<double>("deltaBetaPUTrackPtCutOverride_val");
+        puFactorizedIsoQCuts.second.addParameter<double>("minTrackPt", deltaBetaPUTrackPtCutOverride_val);
       } else {
-	// Secondly take it from the minGammaEt
-	puFactorizedIsoQCuts.second.addParameter<double>(
-          "minTrackPt",
-	  isolationQCuts.getParameter<double>("minGammaEt"));
+        // Secondly take it from the minGammaEt
+        puFactorizedIsoQCuts.second.addParameter<double>("minTrackPt",
+                                                         isolationQCuts.getParameter<double>("minGammaEt"));
       }
 
-      pileupQcutsPUTrackSelection_.reset(new tau::RecoTauQualityCuts(
-        puFactorizedIsoQCuts.first));
+      pileupQcutsPUTrackSelection_.reset(new tau::RecoTauQualityCuts(puFactorizedIsoQCuts.first));
 
-      pileupQcutsGeneralQCuts_.reset(new tau::RecoTauQualityCuts(
-        puFactorizedIsoQCuts.second));
+      pileupQcutsGeneralQCuts_.reset(new tau::RecoTauQualityCuts(puFactorizedIsoQCuts.second));
 
       pfCandSrc_ = pset.getParameter<edm::InputTag>("particleFlowSrc");
       pfCand_token = consumes<edm::View<reco::Candidate> >(pfCandSrc_);
       vertexSrc_ = pset.getParameter<edm::InputTag>("vertexSrc");
       vertex_token = consumes<reco::VertexCollection>(vertexSrc_);
-      deltaBetaCollectionCone_ = pset.getParameter<double>(
-        "isoConeSizeForDeltaBeta");
-      std::string deltaBetaFactorFormula =
-	pset.getParameter<string>("deltaBetaFactor");
-      deltaBetaFormula_.reset(
-        new TFormula("DB_corr", deltaBetaFactorFormula.c_str()));
+      deltaBetaCollectionCone_ = pset.getParameter<double>("isoConeSizeForDeltaBeta");
+      std::string deltaBetaFactorFormula = pset.getParameter<string>("deltaBetaFactor");
+      deltaBetaFormula_.reset(new TFormula("DB_corr", deltaBetaFactorFormula.c_str()));
     }
 
     applyRhoCorrection_ = pset.getParameter<bool>("applyRhoCorrection");
-    if ( applyRhoCorrection_ ) {
+    if (applyRhoCorrection_) {
       rhoProducer_ = pset.getParameter<edm::InputTag>("rhoProducer");
-      rho_token=consumes<double>(rhoProducer_);
+      rho_token = consumes<double>(rhoProducer_);
       rhoConeSize_ = pset.getParameter<double>("rhoConeSize");
-      rhoUEOffsetCorrection_ =
-	pset.getParameter<double>("rhoUEOffsetCorrection");
+      rhoUEOffsetCorrection_ = pset.getParameter<double>("rhoUEOffsetCorrection");
     }
     useAllPFCands_ = pset.getParameter<bool>("UseAllPFCandsForWeights");
 
     verbosity_ = pset.getParameter<int>("verbosity");
   }
 
-  ~PFRecoTauDiscriminationByIsolation() override
-  {
-  }
+  ~PFRecoTauDiscriminationByIsolation() override {}
 
   void beginEvent(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
   double discriminate(const PFTauRef& pfTau) const override;
 
-  inline  double weightedSum(const std::vector<CandidatePtr>& inColl_, double eta, double phi) const {
+  inline double weightedSum(const std::vector<CandidatePtr>& inColl_, double eta, double phi) const {
     double out = 1.0;
-    for (auto const & inObj_ : inColl_){
-      double sum = (inObj_->pt()*inObj_->pt())/(deltaR2(eta,phi,inObj_->eta(),inObj_->phi()));
-      if(sum > 1.0) out *= sum;
+    for (auto const& inObj_ : inColl_) {
+      double sum = (inObj_->pt() * inObj_->pt()) / (deltaR2(eta, phi, inObj_->eta(), inObj_->phi()));
+      if (sum > 1.0)
+        out *= sum;
     }
     return out;
   }
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
+private:
   std::string moduleLabel_;
 
   edm::ParameterSet qualityCutsPSet_;
@@ -205,9 +193,9 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   // Inverted QCut which selects tracks with bad DZ/trackWeight
   std::auto_ptr<tau::RecoTauQualityCuts> pileupQcutsPUTrackSelection_;
   std::auto_ptr<tau::RecoTauQualityCuts> pileupQcutsGeneralQCuts_;
-  
+
   std::auto_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
-  
+
   bool includeTracks_;
   bool includeGammas_;
   bool calculateWeights_;
@@ -222,18 +210,15 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   double customIsoCone_;
   // RIC:
   double minPtForNoIso_;
-  
+
   bool applyPhotonPtSumOutsideSignalConeCut_;
   double maxAbsPhotonSumPt_outsideSignalCone_;
   double maxRelPhotonSumPt_outsideSignalCone_;
 
   bool applyFootprintCorrection_;
-  struct FootprintCorrection
-  {
+  struct FootprintCorrection {
     FootprintCorrection(const std::string& selection, const std::string& offset)
-      : selection_(selection),
-	offset_(offset)
-    {}
+        : selection_(selection), offset_(offset) {}
     ~FootprintCorrection() {}
     StringCutObjectSelector<PFTau> selection_;
     StringObjectFunction<PFTau> offset_;
@@ -263,7 +248,7 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   double deltaBetaCollectionCone_;
   std::auto_ptr<TFormula> deltaBetaFormula_;
   double deltaBetaFactorThisEvent_;
-  
+
   // Rho correction
   bool applyRhoCorrection_;
   bool useAllPFCands_;
@@ -278,8 +263,7 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   int verbosity_;
 };
 
-void PFRecoTauDiscriminationByIsolation::beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) 
-{
+void PFRecoTauDiscriminationByIsolation::beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) {
   // NB: The use of the PV in this context is necessitated by its use in
   // applying quality cuts to the different objects in the isolation cone
   // The vertex associator contains the logic to select the appropriate vertex
@@ -288,16 +272,16 @@ void PFRecoTauDiscriminationByIsolation::beginEvent(const edm::Event& event, con
 
   // If we are applying the delta beta correction, we need to get the PF
   // candidates from the event so we can find the PU tracks.
-  if ( applyDeltaBeta_ || calculateWeights_ ) {
+  if (applyDeltaBeta_ || calculateWeights_) {
     // Collect all the PF pile up tracks
     edm::Handle<edm::View<reco::Candidate> > pfCandidates;
     event.getByToken(pfCand_token, pfCandidates);
     chargedPFCandidatesInEvent_.clear();
     chargedPFCandidatesInEvent_.reserve(pfCandidates->size());
     size_t numPFCandidates = pfCandidates->size();
-    for ( size_t i = 0; i < numPFCandidates; ++i ) {
+    for (size_t i = 0; i < numPFCandidates; ++i) {
       reco::CandidatePtr pfCandidate(pfCandidates, i);
-      if ( pfCandidate->charge() != 0 ) {
+      if (pfCandidate->charge() != 0) {
         chargedPFCandidatesInEvent_.push_back(pfCandidate);
       }
     }
@@ -309,19 +293,16 @@ void PFRecoTauDiscriminationByIsolation::beginEvent(const edm::Event& event, con
     deltaBetaFactorThisEvent_ = deltaBetaFormula_->Eval(nVtxThisEvent);
   }
 
-  if ( applyRhoCorrection_ ) {
+  if (applyRhoCorrection_) {
     edm::Handle<double> rhoHandle_;
     event.getByToken(rho_token, rhoHandle_);
-    rhoThisEvent_ = (*rhoHandle_ - rhoUEOffsetCorrection_)*
-      (3.14159)*rhoConeSize_*rhoConeSize_;
+    rhoThisEvent_ = (*rhoHandle_ - rhoUEOffsetCorrection_) * (3.14159) * rhoConeSize_ * rhoConeSize_;
   }
 }
 
-double
-PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
-{
-    LogDebug("discriminate") << " tau: Pt = " << pfTau->pt() << ", eta = " << pfTau->eta() << ", phi = " << pfTau->phi();
-    LogDebug("discriminate") << *pfTau ;
+double PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const {
+  LogDebug("discriminate") << " tau: Pt = " << pfTau->pt() << ", eta = " << pfTau->eta() << ", phi = " << pfTau->phi();
+  LogDebug("discriminate") << *pfTau;
 
   // collect the objects we are working with (ie tracks, tracks+gammas, etc)
   std::vector<CandidatePtr> isoCharged_;
@@ -340,29 +321,31 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
   reco::VertexRef pv = vertexAssociator_->associatedVertex(*pfTau);
   // Let the quality cuts know which the vertex to use when applying selections
   // on dz, etc.
-  if ( verbosity_ ) {
-    if ( pv.isNonnull() ) {
-      LogTrace("discriminate") << "pv: x = " << pv->position().x() << ", y = " << pv->position().y() << ", z = " << pv->position().z() ;
+  if (verbosity_) {
+    if (pv.isNonnull()) {
+      LogTrace("discriminate") << "pv: x = " << pv->position().x() << ", y = " << pv->position().y()
+                               << ", z = " << pv->position().z();
     } else {
-      LogTrace("discriminate") << "pv: N/A" ;
+      LogTrace("discriminate") << "pv: N/A";
     }
-    if ( pfTau->leadChargedHadrCand().isNonnull() ) {
-      LogTrace("discriminate") << "leadPFChargedHadron:" 
-		<< " Pt = " << pfTau->leadChargedHadrCand()->pt() << "," 
-		<< " eta = " << pfTau->leadChargedHadrCand()->eta() << "," 
-		<< " phi = " << pfTau->leadChargedHadrCand()->phi() ;
+    if (pfTau->leadChargedHadrCand().isNonnull()) {
+      LogTrace("discriminate") << "leadPFChargedHadron:"
+                               << " Pt = " << pfTau->leadChargedHadrCand()->pt() << ","
+                               << " eta = " << pfTau->leadChargedHadrCand()->eta() << ","
+                               << " phi = " << pfTau->leadChargedHadrCand()->phi();
     } else {
-      LogTrace("discriminate") << "leadPFChargedHadron: N/A" ; 
+      LogTrace("discriminate") << "leadPFChargedHadron: N/A";
     }
   }
 
   // CV: isolation is not well defined in case primary vertex or leading charged hadron do not exist
-  if ( !(pv.isNonnull() && pfTau->leadChargedHadrCand().isNonnull()) ) return 0.;
+  if (!(pv.isNonnull() && pfTau->leadChargedHadrCand().isNonnull()))
+    return 0.;
 
   qcuts_->setPV(pv);
   qcuts_->setLeadTrack(*pfTau->leadChargedHadrCand());
 
-  if ( applyDeltaBeta_ || calculateWeights_) {
+  if (applyDeltaBeta_ || calculateWeights_) {
     pileupQcutsGeneralQCuts_->setPV(pv);
     pileupQcutsGeneralQCuts_->setLeadTrack(*pfTau->leadChargedHadrCand());
     pileupQcutsPUTrackSelection_->setPV(pv);
@@ -370,18 +353,18 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
   }
 
   // Load the tracks if they are being used.
-  if ( includeTracks_ ) {
-    for( auto const & cand : pfTau->isolationChargedHadrCands() ) {
-      if ( qcuts_->filterCandRef(cand) ) {
-	LogTrace("discriminate") << "adding charged iso cand with pt " << cand->pt() ;
+  if (includeTracks_) {
+    for (auto const& cand : pfTau->isolationChargedHadrCands()) {
+      if (qcuts_->filterCandRef(cand)) {
+        LogTrace("discriminate") << "adding charged iso cand with pt " << cand->pt();
         isoCharged_.push_back(cand);
       }
     }
   }
-  if ( includeGammas_ || calculateWeights_ ) {
-    for( auto const & cand : pfTau->isolationGammaCands() ) {
-      if ( qcuts_->filterCandRef(cand) ) {
-	LogTrace("discriminate") << "adding neutral iso cand with pt " << cand->pt() ;
+  if (includeGammas_ || calculateWeights_) {
+    for (auto const& cand : pfTau->isolationGammaCands()) {
+      if (qcuts_->filterCandRef(cand)) {
+        LogTrace("discriminate") << "adding neutral iso cand with pt " << cand->pt();
         isoNeutral_.push_back(cand);
       }
     }
@@ -391,221 +374,227 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
   typedef reco::tau::cone::DeltaRFilter<Candidate> DRFilter2;
 
   // If desired, get PU tracks.
-  if ( applyDeltaBeta_ || calculateWeights_) {
+  if (applyDeltaBeta_ || calculateWeights_) {
     // First select by inverted the DZ/track weight cuts. True = invert
-    if ( verbosity_ ) {
+    if (verbosity_) {
       std::cout << "Initial PFCands: " << chargedPFCandidatesInEvent_.size() << std::endl;
     }
 
-    std::vector<CandidatePtr> allPU =
-      pileupQcutsPUTrackSelection_->filterCandRefs(
-          chargedPFCandidatesInEvent_, true);
+    std::vector<CandidatePtr> allPU = pileupQcutsPUTrackSelection_->filterCandRefs(chargedPFCandidatesInEvent_, true);
 
-    std::vector<CandidatePtr> allNPU =
-      pileupQcutsPUTrackSelection_->filterCandRefs(
-	  chargedPFCandidatesInEvent_);
-      LogTrace("discriminate") << "After track cuts: " << allPU.size() ;
+    std::vector<CandidatePtr> allNPU = pileupQcutsPUTrackSelection_->filterCandRefs(chargedPFCandidatesInEvent_);
+    LogTrace("discriminate") << "After track cuts: " << allPU.size();
 
     // Now apply the rest of the cuts, like pt, and TIP, tracker hits, etc
-    if ( !useAllPFCands_ ) {
-      std::vector<CandidatePtr> cleanPU =
-        pileupQcutsGeneralQCuts_->filterCandRefs(allPU);
+    if (!useAllPFCands_) {
+      std::vector<CandidatePtr> cleanPU = pileupQcutsGeneralQCuts_->filterCandRefs(allPU);
 
-      std::vector<CandidatePtr> cleanNPU =
-        pileupQcutsGeneralQCuts_->filterCandRefs(allNPU);
+      std::vector<CandidatePtr> cleanNPU = pileupQcutsGeneralQCuts_->filterCandRefs(allNPU);
 
-      LogTrace("discriminate") << "After cleaning cuts: " << cleanPU.size() ;
+      LogTrace("discriminate") << "After cleaning cuts: " << cleanPU.size();
 
       // Only select PU tracks inside the isolation cone.
       DRFilter deltaBetaFilter(pfTau->p4(), 0, deltaBetaCollectionCone_);
-      for ( auto const & cand : cleanPU ) {
-	if ( deltaBetaFilter(cand) )  isoPU_.push_back(cand);
+      for (auto const& cand : cleanPU) {
+        if (deltaBetaFilter(cand))
+          isoPU_.push_back(cand);
       }
-      
-      for ( auto const & cand : cleanNPU ) {
-	if ( deltaBetaFilter(cand) ) chPV_.push_back(cand);
+
+      for (auto const& cand : cleanNPU) {
+        if (deltaBetaFilter(cand))
+          chPV_.push_back(cand);
       }
-      LogTrace("discriminate") << "After cone cuts: " << isoPU_.size() << " " << chPV_.size() ;
+      LogTrace("discriminate") << "After cone cuts: " << isoPU_.size() << " " << chPV_.size();
     } else {
       isoPU_ = std::move(allPU);
       chPV_ = std::move(allNPU);
     }
   }
 
-  if ( calculateWeights_ ) {
-    for ( auto const & isoObject : isoNeutral_ ) {
-      if ( isoObject->charge() != 0 ) {
-	// weight only neutral objects
-	isoNeutralWeight_.push_back(*isoObject);
-	continue;
+  if (calculateWeights_) {
+    for (auto const& isoObject : isoNeutral_) {
+      if (isoObject->charge() != 0) {
+        // weight only neutral objects
+        isoNeutralWeight_.push_back(*isoObject);
+        continue;
       }
 
       double eta = isoObject->eta();
       double phi = isoObject->phi();
-      double sumNPU = 0.5*log(weightedSum(chPV_, eta, phi));
-      
-      double sumPU = 0.5*log(weightedSum(isoPU_, eta, phi));
+      double sumNPU = 0.5 * log(weightedSum(chPV_, eta, phi));
+
+      double sumPU = 0.5 * log(weightedSum(isoPU_, eta, phi));
       LeafCandidate neutral(*isoObject);
-      if ( (sumNPU + sumPU) > 0 ) neutral.setP4(((sumNPU)/(sumNPU + sumPU))*neutral.p4());
-      
+      if ((sumNPU + sumPU) > 0)
+        neutral.setP4(((sumNPU) / (sumNPU + sumPU)) * neutral.p4());
+
       isoNeutralWeight_.push_back(neutral);
     }
   }
-  
+
   // Check if we want a custom iso cone
-  if ( customIsoCone_ >= 0. ) {
+  if (customIsoCone_ >= 0.) {
     DRFilter filter(pfTau->p4(), 0, customIsoCone_);
     DRFilter2 filter2(pfTau->p4(), 0, customIsoCone_);
     std::vector<CandidatePtr> isoCharged_filter;
     std::vector<CandidatePtr> isoNeutral_filter;
     CandidateCollection isoNeutralWeight_filter;
     // Remove all the objects not in our iso cone
-    for( auto const & isoObject : isoCharged_ ) {
-      if ( filter(isoObject) ) isoCharged_filter.push_back(isoObject);
+    for (auto const& isoObject : isoCharged_) {
+      if (filter(isoObject))
+        isoCharged_filter.push_back(isoObject);
     }
-    if(!calculateWeights_){
-      for( auto const & isoObject : isoNeutral_ ) {
-	if ( filter(isoObject) ) isoNeutral_filter.push_back(isoObject);
+    if (!calculateWeights_) {
+      for (auto const& isoObject : isoNeutral_) {
+        if (filter(isoObject))
+          isoNeutral_filter.push_back(isoObject);
       }
       isoNeutral_ = isoNeutral_filter;
-    }else{
-      for( auto const & isoObject : isoNeutralWeight_){
-	if ( filter2(isoObject) ) isoNeutralWeight_filter.push_back(isoObject);
+    } else {
+      for (auto const& isoObject : isoNeutralWeight_) {
+        if (filter2(isoObject))
+          isoNeutralWeight_filter.push_back(isoObject);
       }
       isoNeutralWeight_ = isoNeutralWeight_filter;
     }
     isoCharged_ = isoCharged_filter;
   }
 
-  bool failsOccupancyCut     = false;
-  bool failsSumPtCut         = false;
+  bool failsOccupancyCut = false;
+  bool failsSumPtCut = false;
   bool failsRelativeSumPtCut = false;
 
-//--- nObjects requirement
+  //--- nObjects requirement
   int neutrals = isoNeutral_.size();
 
-  if ( applyDeltaBeta_ ) {
-    neutrals -= TMath::Nint(deltaBetaFactorThisEvent_*isoPU_.size());
+  if (applyDeltaBeta_) {
+    neutrals -= TMath::Nint(deltaBetaFactorThisEvent_ * isoPU_.size());
   }
-  if ( neutrals < 0 ) {
+  if (neutrals < 0) {
     neutrals = 0;
   }
 
   size_t nOccupants = isoCharged_.size() + neutrals;
 
-  failsOccupancyCut = ( nOccupants > maximumOccupancy_ );
+  failsOccupancyCut = (nOccupants > maximumOccupancy_);
 
   double footprintCorrection_value = 0.;
-  if ( applyFootprintCorrection_ || storeRawFootprintCorrection_ ) {
-    for ( std::vector<std::unique_ptr<FootprintCorrection> >::const_iterator footprintCorrection = footprintCorrections_.begin();
-	  footprintCorrection != footprintCorrections_.end(); ++footprintCorrection ) {
-      if ( (*footprintCorrection)->selection_(*pfTau) ) {
-	footprintCorrection_value = (*footprintCorrection)->offset_(*pfTau);
+  if (applyFootprintCorrection_ || storeRawFootprintCorrection_) {
+    for (std::vector<std::unique_ptr<FootprintCorrection> >::const_iterator footprintCorrection =
+             footprintCorrections_.begin();
+         footprintCorrection != footprintCorrections_.end();
+         ++footprintCorrection) {
+      if ((*footprintCorrection)->selection_(*pfTau)) {
+        footprintCorrection_value = (*footprintCorrection)->offset_(*pfTau);
       }
     }
   }
 
   double totalPt = 0.;
   double puPt = 0.;
-//--- Sum PT requirement
-  if ( applySumPtCut_ || applyRelativeSumPtCut_ || storeRawSumPt_ || storeRawPUsumPt_ ) {
+  //--- Sum PT requirement
+  if (applySumPtCut_ || applyRelativeSumPtCut_ || storeRawSumPt_ || storeRawPUsumPt_) {
     double chargedPt = 0.;
     double neutralPt = 0.;
     double weightedNeutralPt = 0.;
-    for ( auto const & isoObject : isoCharged_ ) {
+    for (auto const& isoObject : isoCharged_) {
       chargedPt += isoObject->pt();
     }
-    if ( !calculateWeights_ ) {
-      for ( auto const & isoObject : isoNeutral_ ) {
-	neutralPt += isoObject->pt();
+    if (!calculateWeights_) {
+      for (auto const& isoObject : isoNeutral_) {
+        neutralPt += isoObject->pt();
       }
     } else {
-      for ( auto const & isoObject : isoNeutralWeight_ ) {
-	weightedNeutralPt += isoObject.pt();
+      for (auto const& isoObject : isoNeutralWeight_) {
+        weightedNeutralPt += isoObject.pt();
       }
     }
-    for ( auto const & isoObject : isoPU_ ) {
+    for (auto const& isoObject : isoPU_) {
       puPt += isoObject->pt();
     }
-    LogTrace("discriminate") << "chargedPt = " << chargedPt ;
-    LogTrace("discriminate") << "neutralPt = " << neutralPt ;
-    LogTrace("discriminate") << "weighted neutral Pt = " << weightedNeutralPt ;
-    LogTrace("discriminate") << "puPt = " << puPt << " (delta-beta corr. = " << (deltaBetaFactorThisEvent_*puPt) << ")" ;
-    
-    if ( calculateWeights_ ) {
+    LogTrace("discriminate") << "chargedPt = " << chargedPt;
+    LogTrace("discriminate") << "neutralPt = " << neutralPt;
+    LogTrace("discriminate") << "weighted neutral Pt = " << weightedNeutralPt;
+    LogTrace("discriminate") << "puPt = " << puPt << " (delta-beta corr. = " << (deltaBetaFactorThisEvent_ * puPt)
+                             << ")";
+
+    if (calculateWeights_) {
       neutralPt = weightedNeutralPt;
     }
 
-    if ( applyDeltaBeta_ ) {
-      neutralPt -= (deltaBetaFactorThisEvent_*puPt);
+    if (applyDeltaBeta_) {
+      neutralPt -= (deltaBetaFactorThisEvent_ * puPt);
     }
-    
-    if ( applyFootprintCorrection_ ) {
+
+    if (applyFootprintCorrection_) {
       neutralPt -= footprintCorrection_value;
     }
-    
-    if ( applyRhoCorrection_ ) {
+
+    if (applyRhoCorrection_) {
       neutralPt -= rhoThisEvent_;
     }
 
-    if ( neutralPt < 0. ) {
+    if (neutralPt < 0.) {
       neutralPt = 0.;
     }
 
     totalPt = chargedPt + weightGammas_ * neutralPt;
-    LogTrace("discriminate") << "totalPt = " << totalPt << " (cut = " << maximumSumPt_ << ")" ;
+    LogTrace("discriminate") << "totalPt = " << totalPt << " (cut = " << maximumSumPt_ << ")";
 
     failsSumPtCut = (totalPt > maximumSumPt_);
 
-//--- Relative Sum PT requirement
-    failsRelativeSumPtCut = (totalPt > ((pfTau->pt() - offsetRelativeSumPt_)*maximumRelativeSumPt_));
+    //--- Relative Sum PT requirement
+    failsRelativeSumPtCut = (totalPt > ((pfTau->pt() - offsetRelativeSumPt_) * maximumRelativeSumPt_));
   }
-    
+
   bool failsPhotonPtSumOutsideSignalConeCut = false;
   double photonSumPt_outsideSignalCone = 0.;
-  if ( applyPhotonPtSumOutsideSignalConeCut_ || storeRawPhotonSumPt_outsideSignalCone_ ) {
+  if (applyPhotonPtSumOutsideSignalConeCut_ || storeRawPhotonSumPt_outsideSignalCone_) {
     const std::vector<reco::CandidatePtr>& signalGammas = pfTau->signalGammaCands();
-    for ( std::vector<reco::CandidatePtr>::const_iterator signalGamma = signalGammas.begin();
-	  signalGamma != signalGammas.end(); ++signalGamma ) {
+    for (std::vector<reco::CandidatePtr>::const_iterator signalGamma = signalGammas.begin();
+         signalGamma != signalGammas.end();
+         ++signalGamma) {
       double dR = deltaR(pfTau->eta(), pfTau->phi(), (*signalGamma)->eta(), (*signalGamma)->phi());
-      if ( dR > pfTau->signalConeSize() ) photonSumPt_outsideSignalCone += (*signalGamma)->pt();
+      if (dR > pfTau->signalConeSize())
+        photonSumPt_outsideSignalCone += (*signalGamma)->pt();
     }
-    if ( photonSumPt_outsideSignalCone > maxAbsPhotonSumPt_outsideSignalCone_ || photonSumPt_outsideSignalCone > (maxRelPhotonSumPt_outsideSignalCone_*pfTau->pt()) ) {
+    if (photonSumPt_outsideSignalCone > maxAbsPhotonSumPt_outsideSignalCone_ ||
+        photonSumPt_outsideSignalCone > (maxRelPhotonSumPt_outsideSignalCone_ * pfTau->pt())) {
       failsPhotonPtSumOutsideSignalConeCut = true;
     }
   }
 
-  bool fails = (applyOccupancyCut_ && failsOccupancyCut) ||
-    (applySumPtCut_ && failsSumPtCut) ||
-    (applyRelativeSumPtCut_ && failsRelativeSumPtCut) ||
-    (applyPhotonPtSumOutsideSignalConeCut_ && failsPhotonPtSumOutsideSignalConeCut);
+  bool fails = (applyOccupancyCut_ && failsOccupancyCut) || (applySumPtCut_ && failsSumPtCut) ||
+               (applyRelativeSumPtCut_ && failsRelativeSumPtCut) ||
+               (applyPhotonPtSumOutsideSignalConeCut_ && failsPhotonPtSumOutsideSignalConeCut);
 
-
-  if (pfTau->pt() > minPtForNoIso_ && minPtForNoIso_ > 0.){
+  if (pfTau->pt() > minPtForNoIso_ && minPtForNoIso_ > 0.) {
     return 1.;
-    LogDebug("discriminate") << "tau pt = " << pfTau->pt() <<  "\t  min cutoff pt = " << minPtForNoIso_ ;
+    LogDebug("discriminate") << "tau pt = " << pfTau->pt() << "\t  min cutoff pt = " << minPtForNoIso_;
   }
-  
+
   // We did error checking in the constructor, so this is safe.
-  if ( storeRawSumPt_ ) {
+  if (storeRawSumPt_) {
     return totalPt;
-  } else if ( storeRawPUsumPt_ ) {
-    if ( applyDeltaBeta_ ) return puPt;
-    else if ( applyRhoCorrection_ ) return rhoThisEvent_;
-    else return 0.;
-  } else if ( storeRawOccupancy_ ) {
+  } else if (storeRawPUsumPt_) {
+    if (applyDeltaBeta_)
+      return puPt;
+    else if (applyRhoCorrection_)
+      return rhoThisEvent_;
+    else
+      return 0.;
+  } else if (storeRawOccupancy_) {
     return nOccupants;
-  } else if ( storeRawFootprintCorrection_ ) {
+  } else if (storeRawFootprintCorrection_) {
     return footprintCorrection_value;
-  } else if ( storeRawPhotonSumPt_outsideSignalCone_ ) {
+  } else if (storeRawPhotonSumPt_outsideSignalCone_) {
     return photonSumPt_outsideSignalCone;
   } else {
     return (fails ? 0. : 1.);
   }
 }
 
-void
-PFRecoTauDiscriminationByIsolation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauDiscriminationByIsolation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfRecoTauDiscriminationByIsolation
   edm::ParameterSetDescription desc;
   desc.add<bool>("storeRawFootprintCorrection", false);
@@ -648,8 +637,8 @@ PFRecoTauDiscriminationByIsolation::fillDescriptions(edm::ConfigurationDescripti
     pset_isolationQualityCuts.addOptional<bool>("useTracksInsteadOfPFHadrons");
 
     edm::ParameterSetDescription pset_qualityCuts;
-    pset_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts",    pset_signalQualityCuts);
-    pset_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts",   pset_vxAssocQualityCuts);
+    pset_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts", pset_signalQualityCuts);
+    pset_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts", pset_vxAssocQualityCuts);
     pset_qualityCuts.add<edm::ParameterSetDescription>("isolationQualityCuts", pset_isolationQualityCuts);
     pset_qualityCuts.add<std::string>("leadingTrkOrPFCandOption", "leadPFCand");
     pset_qualityCuts.add<std::string>("pvFindingAlgo", "closestInDeltaZ");

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByLeadingObjectPtCut.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByLeadingObjectPtCut.cc
@@ -11,50 +11,45 @@
 
 using namespace reco;
 
-class PFRecoTauDiscriminationByLeadingObjectPtCut : public PFTauDiscriminationProducerBase  {
-   public:
-      explicit PFRecoTauDiscriminationByLeadingObjectPtCut(const edm::ParameterSet& iConfig):PFTauDiscriminationProducerBase(iConfig){   
-         chargedOnly_     = iConfig.getParameter<bool>("UseOnlyChargedHadrons");
-         minPtLeadObject_ = iConfig.getParameter<double>("MinPtLeadingObject");
-      }
-      ~PFRecoTauDiscriminationByLeadingObjectPtCut() override{} 
-      double discriminate(const PFTauRef& pfTau) const override;
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-   private:
-      bool chargedOnly_;
-      double minPtLeadObject_;
+class PFRecoTauDiscriminationByLeadingObjectPtCut : public PFTauDiscriminationProducerBase {
+public:
+  explicit PFRecoTauDiscriminationByLeadingObjectPtCut(const edm::ParameterSet& iConfig)
+      : PFTauDiscriminationProducerBase(iConfig) {
+    chargedOnly_ = iConfig.getParameter<bool>("UseOnlyChargedHadrons");
+    minPtLeadObject_ = iConfig.getParameter<double>("MinPtLeadingObject");
+  }
+  ~PFRecoTauDiscriminationByLeadingObjectPtCut() override {}
+  double discriminate(const PFTauRef& pfTau) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  bool chargedOnly_;
+  double minPtLeadObject_;
 };
 
-double PFRecoTauDiscriminationByLeadingObjectPtCut::discriminate(const PFTauRef& thePFTauRef) const
-{
-   double leadObjectPt = -1.;
-   if( chargedOnly_ )
-   {
-      // consider only charged hadrons.  note that the leadChargedHadrCand is the highest pt
-      // charged signal cone object above the quality cut level (typically 0.5 GeV).  
-      if( thePFTauRef->leadChargedHadrCand().isNonnull() )
-      {
-         leadObjectPt = thePFTauRef->leadChargedHadrCand()->pt();
-      }
-   } 
-   else
-   {
-      // If using the 'leading pion' option, require that:
-      //   1) at least one charged hadron exists above threshold (thePFTauRef->leadChargedHadrCand().isNonnull())
-      //   2) the lead PFCand exists.  In the case that the highest pt charged hadron is above the PFRecoTauProducer threshold 
-      //      (typically 5 GeV), the leadCand and the leadChargedHadrCand are the same object.  If the leadChargedHadrCand
-      //      is below 5GeV, but there exists a neutral PF particle > 5 GeV, it is set to be the leadCand
-      if( thePFTauRef->leadCand().isNonnull() && thePFTauRef->leadChargedHadrCand().isNonnull() )
-      {
-         leadObjectPt = thePFTauRef->leadCand()->pt();
-      }
-   }
+double PFRecoTauDiscriminationByLeadingObjectPtCut::discriminate(const PFTauRef& thePFTauRef) const {
+  double leadObjectPt = -1.;
+  if (chargedOnly_) {
+    // consider only charged hadrons.  note that the leadChargedHadrCand is the highest pt
+    // charged signal cone object above the quality cut level (typically 0.5 GeV).
+    if (thePFTauRef->leadChargedHadrCand().isNonnull()) {
+      leadObjectPt = thePFTauRef->leadChargedHadrCand()->pt();
+    }
+  } else {
+    // If using the 'leading pion' option, require that:
+    //   1) at least one charged hadron exists above threshold (thePFTauRef->leadChargedHadrCand().isNonnull())
+    //   2) the lead PFCand exists.  In the case that the highest pt charged hadron is above the PFRecoTauProducer threshold
+    //      (typically 5 GeV), the leadCand and the leadChargedHadrCand are the same object.  If the leadChargedHadrCand
+    //      is below 5GeV, but there exists a neutral PF particle > 5 GeV, it is set to be the leadCand
+    if (thePFTauRef->leadCand().isNonnull() && thePFTauRef->leadChargedHadrCand().isNonnull()) {
+      leadObjectPt = thePFTauRef->leadCand()->pt();
+    }
+  }
 
-   return ( leadObjectPt > minPtLeadObject_ ? 1. : 0. );
+  return (leadObjectPt > minPtLeadObject_ ? 1. : 0.);
 }
 
-void
-PFRecoTauDiscriminationByLeadingObjectPtCut::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauDiscriminationByLeadingObjectPtCut::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfRecoTauDiscriminationByLeadingObjectPtCut
   edm::ParameterSetDescription desc;
   desc.add<double>("MinPtLeadingObject", 5.0);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolationRun2.cc
@@ -38,355 +38,375 @@
 
 using namespace reco;
 
-namespace
-{
-  const GBRForest* loadMVAfromFile(const edm::FileInPath& inputFileName, const std::string& mvaName, std::vector<TFile*>& inputFilesToDelete)
-  {
-    if ( inputFileName.location() == edm::FileInPath::Unknown ) throw cms::Exception("PFRecoTauDiscriminationByIsolationMVA2::loadMVA") 
-      << " Failed to find File = " << inputFileName << " !!\n";
+namespace {
+  const GBRForest* loadMVAfromFile(const edm::FileInPath& inputFileName,
+                                   const std::string& mvaName,
+                                   std::vector<TFile*>& inputFilesToDelete) {
+    if (inputFileName.location() == edm::FileInPath::Unknown)
+      throw cms::Exception("PFRecoTauDiscriminationByIsolationMVA2::loadMVA")
+          << " Failed to find File = " << inputFileName << " !!\n";
     TFile* inputFile = new TFile(inputFileName.fullPath().data());
-  
+
     //const GBRForest* mva = dynamic_cast<GBRForest*>(inputFile->Get(mvaName.data())); // CV: dynamic_cast<GBRForest*> fails for some reason ?!
     const GBRForest* mva = (GBRForest*)inputFile->Get(mvaName.data());
-    if ( !mva )
+    if (!mva)
       throw cms::Exception("PFRecoTauDiscriminationByIsolationMVA2::loadMVA")
-        << " Failed to load MVA = " << mvaName.data() << " from file = " << inputFileName.fullPath().data() << " !!\n";
+          << " Failed to load MVA = " << mvaName.data() << " from file = " << inputFileName.fullPath().data()
+          << " !!\n";
 
     inputFilesToDelete.push_back(inputFile);
-    
+
     return mva;
   }
 
-  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName)
-  {
+  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName) {
     edm::ESHandle<GBRForest> mva;
     es.get<GBRWrapperRcd>().get(mvaName, mva);
     return mva.product();
   }
-}
+}  // namespace
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class PFRecoTauDiscriminationByMVAIsolationRun2 : public PFTauDiscriminationProducerBase  
-{
- public:
-  explicit PFRecoTauDiscriminationByMVAIsolationRun2(const edm::ParameterSet& cfg)
-    : PFTauDiscriminationProducerBase(cfg),
-      moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-      mvaReader_(nullptr),
-      mvaInput_(nullptr),
-      category_output_()
-  {
-    mvaName_ = cfg.getParameter<std::string>("mvaName");
-    loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
-    if ( !loadMVAfromDB_ ) {
-	inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
-    }    
-    std::string mvaOpt_string = cfg.getParameter<std::string>("mvaOpt");
-    if      ( mvaOpt_string == "oldDMwoLT" ) mvaOpt_ = kOldDMwoLT;
-    else if ( mvaOpt_string == "oldDMwLT"  ) mvaOpt_ = kOldDMwLT;
-    else if ( mvaOpt_string == "newDMwoLT" ) mvaOpt_ = kNewDMwoLT;
-    else if ( mvaOpt_string == "newDMwLT"  ) mvaOpt_ = kNewDMwLT;
-    else if ( mvaOpt_string == "DBoldDMwLT"  ) mvaOpt_ = kDBoldDMwLT;
-    else if ( mvaOpt_string == "DBnewDMwLT"  ) mvaOpt_ = kDBnewDMwLT;
-    else if ( mvaOpt_string == "PWoldDMwLT"  ) mvaOpt_ = kPWoldDMwLT;
-    else if ( mvaOpt_string == "PWnewDMwLT"  ) mvaOpt_ = kPWnewDMwLT;
-    else if ( mvaOpt_string == "DBoldDMwLTwGJ" ) mvaOpt_ = kDBoldDMwLTwGJ;
-    else if ( mvaOpt_string == "DBnewDMwLTwGJ" ) mvaOpt_ = kDBnewDMwLTwGJ;
-    else throw cms::Exception("PFRecoTauDiscriminationByMVAIsolationRun2")
-      << " Invalid Configuration Parameter 'mvaOpt' = " << mvaOpt_string << " !!\n";
-    
-    if      ( mvaOpt_ == kOldDMwoLT || mvaOpt_ == kNewDMwoLT ) mvaInput_ = new float[6];
-    else if ( mvaOpt_ == kOldDMwLT  || mvaOpt_ == kNewDMwLT  ) mvaInput_ = new float[12];
-    else if ( mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT ||
-	      mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT ||
-          mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ) mvaInput_ = new float[23];
-    else assert(0);
-
-    TauTransverseImpactParameters_token = consumes<PFTauTIPAssociationByRef>(cfg.getParameter<edm::InputTag>("srcTauTransverseImpactParameters"));
-    
-    ChargedIsoPtSum_token = consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("srcChargedIsoPtSum"));
-    NeutralIsoPtSum_token = consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("srcNeutralIsoPtSum"));
-    PUcorrPtSum_token = consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("srcPUcorrPtSum"));
-    PhotonPtSumOutsideSignalCone_token = consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("srcPhotonPtSumOutsideSignalCone"));
-    FootprintCorrection_token = consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("srcFootprintCorrection"));
-  
-    verbosity_ = cfg.getParameter<int>("verbosity");
-
-    produces<PFTauDiscriminator>("category");
-  }
-
-  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-
-  double discriminate(const PFTauRef&) const override;
-
-  void endEvent(edm::Event&) override;
-
-  ~PFRecoTauDiscriminationByMVAIsolationRun2() override
-  {
-    if(!loadMVAfromDB_) delete mvaReader_;
-    delete[] mvaInput_;
-    for ( std::vector<TFile*>::iterator it = inputFilesToDelete_.begin();
-	  it != inputFilesToDelete_.end(); ++it ) {
-      delete (*it);
-    }
-  }
-
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
- private:
-
-  std::string moduleLabel_;
-
-  std::string mvaName_;
-  bool loadMVAfromDB_;
-  edm::FileInPath inputFileName_;
-  const GBRForest* mvaReader_;
-  int mvaOpt_;
-  float* mvaInput_;
-  
-  typedef edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> > PFTauTIPAssociationByRef;
-  edm::EDGetTokenT<PFTauTIPAssociationByRef> TauTransverseImpactParameters_token;
-  edm::Handle<PFTauTIPAssociationByRef> tauLifetimeInfos;
-
-  edm::EDGetTokenT<reco::PFTauDiscriminator> ChargedIsoPtSum_token;
-  edm::Handle<reco::PFTauDiscriminator> chargedIsoPtSums_;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> NeutralIsoPtSum_token;
-  edm::Handle<reco::PFTauDiscriminator> neutralIsoPtSums_;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> PUcorrPtSum_token;
-  edm::Handle<reco::PFTauDiscriminator> puCorrPtSums_;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> PhotonPtSumOutsideSignalCone_token;
-  edm::Handle<reco::PFTauDiscriminator> photonPtSumOutsideSignalCone_;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> FootprintCorrection_token;
-  edm::Handle<reco::PFTauDiscriminator> footprintCorrection_;
-
-  edm::Handle<TauCollection> taus_;
-  std::unique_ptr<PFTauDiscriminator> category_output_;
-
-  std::vector<TFile*> inputFilesToDelete_;
-
-  int verbosity_;
-};
-
-void PFRecoTauDiscriminationByMVAIsolationRun2::beginEvent(const edm::Event& evt, const edm::EventSetup& es)
-{
-  if ( !mvaReader_ ) {
-    if ( loadMVAfromDB_ ) {
-      mvaReader_ = loadMVAfromDB(es, mvaName_);
-    } else {
-      mvaReader_ = loadMVAfromFile(inputFileName_, mvaName_, inputFilesToDelete_);
-    }
-  }
-
-  evt.getByToken(TauTransverseImpactParameters_token, tauLifetimeInfos);
-
-  evt.getByToken(ChargedIsoPtSum_token, chargedIsoPtSums_);
-  evt.getByToken(NeutralIsoPtSum_token, neutralIsoPtSums_);
-  evt.getByToken(PUcorrPtSum_token, puCorrPtSums_);
-  evt.getByToken(PhotonPtSumOutsideSignalCone_token, photonPtSumOutsideSignalCone_);
-  evt.getByToken(FootprintCorrection_token, footprintCorrection_);
-  
-  evt.getByToken(Tau_token, taus_);
-  category_output_.reset(new PFTauDiscriminator(TauRefProd(taus_)));
-}
-
-double PFRecoTauDiscriminationByMVAIsolationRun2::discriminate(const PFTauRef& tau) const
-{
-  // CV: define dummy category index in order to use RecoTauDiscriminantCutMultiplexer module to appy WP cuts
-  double category = 0.; 
-  category_output_->setValue(tauIndex_, category);
-
-  // CV: computation of MVA value requires presence of leading charged hadron
-  if ( tau->leadChargedHadrCand().isNull() ) return 0.;
-
-  int tauDecayMode = tau->decayMode();
-
-  if ( ((mvaOpt_ == kOldDMwoLT || mvaOpt_ == kOldDMwLT || mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kDBoldDMwLTwGJ)
-        && (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 10))
-       ||
-       ((mvaOpt_ == kNewDMwoLT || mvaOpt_ == kNewDMwLT || mvaOpt_ == kDBnewDMwLT || mvaOpt_ == kPWnewDMwLT || mvaOpt_ == kDBnewDMwLTwGJ)
-        && (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 || tauDecayMode == 10 || tauDecayMode == 11))
-  ) {
-
-    float chargedIsoPtSum = (*chargedIsoPtSums_)[tau];
-    float neutralIsoPtSum = (*neutralIsoPtSums_)[tau];
-    float puCorrPtSum     = (*puCorrPtSums_)[tau];
-    float photonPtSumOutsideSignalCone = (*photonPtSumOutsideSignalCone_)[tau];
-    float footprintCorrection = (*footprintCorrection_)[tau];
-    
-    const reco::PFTauTransverseImpactParameter& tauLifetimeInfo = *(*tauLifetimeInfos)[tau];
-    
-    float decayDistX = tauLifetimeInfo.flightLength().x();
-    float decayDistY = tauLifetimeInfo.flightLength().y();
-    float decayDistZ = tauLifetimeInfo.flightLength().z();
-    float decayDistMag = std::sqrt(decayDistX*decayDistX + decayDistY*decayDistY + decayDistZ*decayDistZ);
-
-    float nPhoton = (float)reco::tau::n_photons_total(*tau);
-    float ptWeightedDetaStrip = reco::tau::pt_weighted_deta_strip(*tau, tauDecayMode);
-    float ptWeightedDphiStrip = reco::tau::pt_weighted_dphi_strip(*tau, tauDecayMode);
-    float ptWeightedDrSignal = reco::tau::pt_weighted_dr_signal(*tau, tauDecayMode);
-    float ptWeightedDrIsolation = reco::tau::pt_weighted_dr_iso(*tau, tauDecayMode);
-    float leadingTrackChi2 = reco::tau::lead_track_chi2(*tau);
-    float eRatio = reco::tau::eratio(*tau);
-
-    // Difference between measured and maximally allowed Gottfried-Jackson angle
-    float gjAngleDiff = -999;
-    if ( tauDecayMode == 10 ) {
-        double mTau = 1.77682;
-        double mAOne = tau->p4().M();
-        double pAOneMag = tau->p();
-        double argumentThetaGJmax = (std::pow(mTau,2) - std::pow(mAOne,2) ) / ( 2 * mTau * pAOneMag );
-        double argumentThetaGJmeasured = ( tau->p4().px() * decayDistX + tau->p4().py() * decayDistY + tau->p4().pz() * decayDistZ ) / ( pAOneMag * decayDistMag );
-        if ( std::abs(argumentThetaGJmax) <= 1. && std::abs(argumentThetaGJmeasured) <= 1. ) {
-            double thetaGJmax = std::asin( argumentThetaGJmax );
-            double thetaGJmeasured = std::acos( argumentThetaGJmeasured );
-            gjAngleDiff = thetaGJmeasured - thetaGJmax;
+    class PFRecoTauDiscriminationByMVAIsolationRun2 : public PFTauDiscriminationProducerBase {
+    public:
+      explicit PFRecoTauDiscriminationByMVAIsolationRun2(const edm::ParameterSet& cfg)
+          : PFTauDiscriminationProducerBase(cfg),
+            moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+            mvaReader_(nullptr),
+            mvaInput_(nullptr),
+            category_output_() {
+        mvaName_ = cfg.getParameter<std::string>("mvaName");
+        loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
+        if (!loadMVAfromDB_) {
+          inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
         }
+        std::string mvaOpt_string = cfg.getParameter<std::string>("mvaOpt");
+        if (mvaOpt_string == "oldDMwoLT")
+          mvaOpt_ = kOldDMwoLT;
+        else if (mvaOpt_string == "oldDMwLT")
+          mvaOpt_ = kOldDMwLT;
+        else if (mvaOpt_string == "newDMwoLT")
+          mvaOpt_ = kNewDMwoLT;
+        else if (mvaOpt_string == "newDMwLT")
+          mvaOpt_ = kNewDMwLT;
+        else if (mvaOpt_string == "DBoldDMwLT")
+          mvaOpt_ = kDBoldDMwLT;
+        else if (mvaOpt_string == "DBnewDMwLT")
+          mvaOpt_ = kDBnewDMwLT;
+        else if (mvaOpt_string == "PWoldDMwLT")
+          mvaOpt_ = kPWoldDMwLT;
+        else if (mvaOpt_string == "PWnewDMwLT")
+          mvaOpt_ = kPWnewDMwLT;
+        else if (mvaOpt_string == "DBoldDMwLTwGJ")
+          mvaOpt_ = kDBoldDMwLTwGJ;
+        else if (mvaOpt_string == "DBnewDMwLTwGJ")
+          mvaOpt_ = kDBnewDMwLTwGJ;
+        else
+          throw cms::Exception("PFRecoTauDiscriminationByMVAIsolationRun2")
+              << " Invalid Configuration Parameter 'mvaOpt' = " << mvaOpt_string << " !!\n";
+
+        if (mvaOpt_ == kOldDMwoLT || mvaOpt_ == kNewDMwoLT)
+          mvaInput_ = new float[6];
+        else if (mvaOpt_ == kOldDMwLT || mvaOpt_ == kNewDMwLT)
+          mvaInput_ = new float[12];
+        else if (mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT || mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT ||
+                 mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ)
+          mvaInput_ = new float[23];
+        else
+          assert(0);
+
+        TauTransverseImpactParameters_token =
+            consumes<PFTauTIPAssociationByRef>(cfg.getParameter<edm::InputTag>("srcTauTransverseImpactParameters"));
+
+        ChargedIsoPtSum_token =
+            consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("srcChargedIsoPtSum"));
+        NeutralIsoPtSum_token =
+            consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("srcNeutralIsoPtSum"));
+        PUcorrPtSum_token = consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("srcPUcorrPtSum"));
+        PhotonPtSumOutsideSignalCone_token =
+            consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("srcPhotonPtSumOutsideSignalCone"));
+        FootprintCorrection_token =
+            consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("srcFootprintCorrection"));
+
+        verbosity_ = cfg.getParameter<int>("verbosity");
+
+        produces<PFTauDiscriminator>("category");
+      }
+
+      void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+
+      double discriminate(const PFTauRef&) const override;
+
+      void endEvent(edm::Event&) override;
+
+      ~PFRecoTauDiscriminationByMVAIsolationRun2() override {
+        if (!loadMVAfromDB_)
+          delete mvaReader_;
+        delete[] mvaInput_;
+        for (std::vector<TFile*>::iterator it = inputFilesToDelete_.begin(); it != inputFilesToDelete_.end(); ++it) {
+          delete (*it);
+        }
+      }
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    private:
+      std::string moduleLabel_;
+
+      std::string mvaName_;
+      bool loadMVAfromDB_;
+      edm::FileInPath inputFileName_;
+      const GBRForest* mvaReader_;
+      int mvaOpt_;
+      float* mvaInput_;
+
+      typedef edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> >
+          PFTauTIPAssociationByRef;
+      edm::EDGetTokenT<PFTauTIPAssociationByRef> TauTransverseImpactParameters_token;
+      edm::Handle<PFTauTIPAssociationByRef> tauLifetimeInfos;
+
+      edm::EDGetTokenT<reco::PFTauDiscriminator> ChargedIsoPtSum_token;
+      edm::Handle<reco::PFTauDiscriminator> chargedIsoPtSums_;
+      edm::EDGetTokenT<reco::PFTauDiscriminator> NeutralIsoPtSum_token;
+      edm::Handle<reco::PFTauDiscriminator> neutralIsoPtSums_;
+      edm::EDGetTokenT<reco::PFTauDiscriminator> PUcorrPtSum_token;
+      edm::Handle<reco::PFTauDiscriminator> puCorrPtSums_;
+      edm::EDGetTokenT<reco::PFTauDiscriminator> PhotonPtSumOutsideSignalCone_token;
+      edm::Handle<reco::PFTauDiscriminator> photonPtSumOutsideSignalCone_;
+      edm::EDGetTokenT<reco::PFTauDiscriminator> FootprintCorrection_token;
+      edm::Handle<reco::PFTauDiscriminator> footprintCorrection_;
+
+      edm::Handle<TauCollection> taus_;
+      std::unique_ptr<PFTauDiscriminator> category_output_;
+
+      std::vector<TFile*> inputFilesToDelete_;
+
+      int verbosity_;
+    };
+
+    void PFRecoTauDiscriminationByMVAIsolationRun2::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
+      if (!mvaReader_) {
+        if (loadMVAfromDB_) {
+          mvaReader_ = loadMVAfromDB(es, mvaName_);
+        } else {
+          mvaReader_ = loadMVAfromFile(inputFileName_, mvaName_, inputFilesToDelete_);
+        }
+      }
+
+      evt.getByToken(TauTransverseImpactParameters_token, tauLifetimeInfos);
+
+      evt.getByToken(ChargedIsoPtSum_token, chargedIsoPtSums_);
+      evt.getByToken(NeutralIsoPtSum_token, neutralIsoPtSums_);
+      evt.getByToken(PUcorrPtSum_token, puCorrPtSums_);
+      evt.getByToken(PhotonPtSumOutsideSignalCone_token, photonPtSumOutsideSignalCone_);
+      evt.getByToken(FootprintCorrection_token, footprintCorrection_);
+
+      evt.getByToken(Tau_token, taus_);
+      category_output_.reset(new PFTauDiscriminator(TauRefProd(taus_)));
     }
 
-    if ( mvaOpt_ == kOldDMwoLT || mvaOpt_ == kNewDMwoLT ) {
-      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
-      mvaInput_[1]  = std::abs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f*puCorrPtSum));
-      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
-      mvaInput_[5]  = tauDecayMode;
-    } else if ( mvaOpt_ == kOldDMwLT || mvaOpt_ == kNewDMwLT  ) {
-      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
-      mvaInput_[1]  = std::abs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f*puCorrPtSum));
-      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
-      mvaInput_[5]  = tauDecayMode;
-      mvaInput_[6]  = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
-      mvaInput_[7]  = std::sqrt(std::abs(std::min(1.f, (float)tauLifetimeInfo.dxy())));
-      mvaInput_[8]  = std::min(10.f, std::abs((float)tauLifetimeInfo.dxy_Sig()));
-      mvaInput_[9]  = ( tauLifetimeInfo.hasSecondaryVertex() ) ? 1. : 0.;
-      mvaInput_[10] = std::sqrt(decayDistMag);
-      mvaInput_[11] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
-    } else if ( mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT ) {
-      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
-      mvaInput_[1]  = std::abs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
-      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
-      mvaInput_[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
-      mvaInput_[6]  = tauDecayMode;
-      mvaInput_[7]  = std::min(30.f, nPhoton);
-      mvaInput_[8]  = std::min(0.5f, ptWeightedDetaStrip);
-      mvaInput_[9]  = std::min(0.5f, ptWeightedDphiStrip);
-      mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
-      mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
-      mvaInput_[12] = std::min(100.f, leadingTrackChi2);
-      mvaInput_[13] = std::min(1.f, eRatio);
-      mvaInput_[14]  = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
-      mvaInput_[15]  = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.dxy())));
-      mvaInput_[16]  = std::min(10.f, std::abs((float)tauLifetimeInfo.dxy_Sig()));
-      mvaInput_[17]  = std::copysign(+1.f, (float)tauLifetimeInfo.ip3d());
-      mvaInput_[18]  = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.ip3d())));
-      mvaInput_[19]  = std::min(10.f, std::abs((float)tauLifetimeInfo.ip3d_Sig()));
-      mvaInput_[20]  = ( tauLifetimeInfo.hasSecondaryVertex() ) ? 1. : 0.;
-      mvaInput_[21] = std::sqrt(decayDistMag);
-      mvaInput_[22] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
-    } else if ( mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT ) {
-      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
-      mvaInput_[1]  = std::abs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
-      mvaInput_[4]  = std::log(std::max(1.e-2f, footprintCorrection));
-      mvaInput_[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
-      mvaInput_[6]  = tauDecayMode;
-      mvaInput_[7]  = std::min(30.f, nPhoton);
-      mvaInput_[8]  = std::min(0.5f, ptWeightedDetaStrip);
-      mvaInput_[9]  = std::min(0.5f, ptWeightedDphiStrip);
-      mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
-      mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
-      mvaInput_[12] = std::min(100.f, leadingTrackChi2);
-      mvaInput_[13] = std::min(1.f, eRatio);
-      mvaInput_[14]  = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
-      mvaInput_[15]  = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.dxy())));
-      mvaInput_[16]  = std::min(10.f, std::abs((float)tauLifetimeInfo.dxy_Sig()));
-      mvaInput_[17]  = std::copysign(+1.f, (float)tauLifetimeInfo.ip3d());
-      mvaInput_[18]  = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.ip3d())));
-      mvaInput_[19]  = std::min(10.f, std::abs((float)tauLifetimeInfo.ip3d_Sig()));
-      mvaInput_[20]  = ( tauLifetimeInfo.hasSecondaryVertex() ) ? 1. : 0.;
-      mvaInput_[21] = std::sqrt(decayDistMag);
-      mvaInput_[22] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
-    } else if ( mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ ) {
-      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
-      mvaInput_[1]  = std::abs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
-      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
-      mvaInput_[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
-      mvaInput_[6]  = tauDecayMode;
-      mvaInput_[7]  = std::min(30.f, nPhoton);
-      mvaInput_[8]  = std::min(0.5f, ptWeightedDetaStrip);
-      mvaInput_[9]  = std::min(0.5f, ptWeightedDphiStrip);
-      mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
-      mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
-      mvaInput_[12] = std::min(1.f, eRatio);
-      mvaInput_[13]  = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
-      mvaInput_[14]  = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.dxy())));
-      mvaInput_[15]  = std::min(10.f, std::abs((float)tauLifetimeInfo.dxy_Sig()));
-      mvaInput_[16]  = std::copysign(+1.f, (float)tauLifetimeInfo.ip3d());
-      mvaInput_[17]  = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.ip3d())));
-      mvaInput_[18]  = std::min(10.f, std::abs((float)tauLifetimeInfo.ip3d_Sig()));
-      mvaInput_[19]  = ( tauLifetimeInfo.hasSecondaryVertex() ) ? 1. : 0.;
-      mvaInput_[20] = std::sqrt(decayDistMag);
-      mvaInput_[21] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
-      mvaInput_[22] = std::max(-1.f, gjAngleDiff);
+    double PFRecoTauDiscriminationByMVAIsolationRun2::discriminate(const PFTauRef& tau) const {
+      // CV: define dummy category index in order to use RecoTauDiscriminantCutMultiplexer module to appy WP cuts
+      double category = 0.;
+      category_output_->setValue(tauIndex_, category);
+
+      // CV: computation of MVA value requires presence of leading charged hadron
+      if (tau->leadChargedHadrCand().isNull())
+        return 0.;
+
+      int tauDecayMode = tau->decayMode();
+
+      if (((mvaOpt_ == kOldDMwoLT || mvaOpt_ == kOldDMwLT || mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kPWoldDMwLT ||
+            mvaOpt_ == kDBoldDMwLTwGJ) &&
+           (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 10)) ||
+          ((mvaOpt_ == kNewDMwoLT || mvaOpt_ == kNewDMwLT || mvaOpt_ == kDBnewDMwLT || mvaOpt_ == kPWnewDMwLT ||
+            mvaOpt_ == kDBnewDMwLTwGJ) &&
+           (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 ||
+            tauDecayMode == 10 || tauDecayMode == 11))) {
+        float chargedIsoPtSum = (*chargedIsoPtSums_)[tau];
+        float neutralIsoPtSum = (*neutralIsoPtSums_)[tau];
+        float puCorrPtSum = (*puCorrPtSums_)[tau];
+        float photonPtSumOutsideSignalCone = (*photonPtSumOutsideSignalCone_)[tau];
+        float footprintCorrection = (*footprintCorrection_)[tau];
+
+        const reco::PFTauTransverseImpactParameter& tauLifetimeInfo = *(*tauLifetimeInfos)[tau];
+
+        float decayDistX = tauLifetimeInfo.flightLength().x();
+        float decayDistY = tauLifetimeInfo.flightLength().y();
+        float decayDistZ = tauLifetimeInfo.flightLength().z();
+        float decayDistMag = std::sqrt(decayDistX * decayDistX + decayDistY * decayDistY + decayDistZ * decayDistZ);
+
+        float nPhoton = (float)reco::tau::n_photons_total(*tau);
+        float ptWeightedDetaStrip = reco::tau::pt_weighted_deta_strip(*tau, tauDecayMode);
+        float ptWeightedDphiStrip = reco::tau::pt_weighted_dphi_strip(*tau, tauDecayMode);
+        float ptWeightedDrSignal = reco::tau::pt_weighted_dr_signal(*tau, tauDecayMode);
+        float ptWeightedDrIsolation = reco::tau::pt_weighted_dr_iso(*tau, tauDecayMode);
+        float leadingTrackChi2 = reco::tau::lead_track_chi2(*tau);
+        float eRatio = reco::tau::eratio(*tau);
+
+        // Difference between measured and maximally allowed Gottfried-Jackson angle
+        float gjAngleDiff = -999;
+        if (tauDecayMode == 10) {
+          double mTau = 1.77682;
+          double mAOne = tau->p4().M();
+          double pAOneMag = tau->p();
+          double argumentThetaGJmax = (std::pow(mTau, 2) - std::pow(mAOne, 2)) / (2 * mTau * pAOneMag);
+          double argumentThetaGJmeasured =
+              (tau->p4().px() * decayDistX + tau->p4().py() * decayDistY + tau->p4().pz() * decayDistZ) /
+              (pAOneMag * decayDistMag);
+          if (std::abs(argumentThetaGJmax) <= 1. && std::abs(argumentThetaGJmeasured) <= 1.) {
+            double thetaGJmax = std::asin(argumentThetaGJmax);
+            double thetaGJmeasured = std::acos(argumentThetaGJmeasured);
+            gjAngleDiff = thetaGJmeasured - thetaGJmax;
+          }
+        }
+
+        if (mvaOpt_ == kOldDMwoLT || mvaOpt_ == kNewDMwoLT) {
+          mvaInput_[0] = std::log(std::max(1.f, (float)tau->pt()));
+          mvaInput_[1] = std::abs((float)tau->eta());
+          mvaInput_[2] = std::log(std::max(1.e-2f, chargedIsoPtSum));
+          mvaInput_[3] = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f * puCorrPtSum));
+          mvaInput_[4] = std::log(std::max(1.e-2f, puCorrPtSum));
+          mvaInput_[5] = tauDecayMode;
+        } else if (mvaOpt_ == kOldDMwLT || mvaOpt_ == kNewDMwLT) {
+          mvaInput_[0] = std::log(std::max(1.f, (float)tau->pt()));
+          mvaInput_[1] = std::abs((float)tau->eta());
+          mvaInput_[2] = std::log(std::max(1.e-2f, chargedIsoPtSum));
+          mvaInput_[3] = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f * puCorrPtSum));
+          mvaInput_[4] = std::log(std::max(1.e-2f, puCorrPtSum));
+          mvaInput_[5] = tauDecayMode;
+          mvaInput_[6] = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
+          mvaInput_[7] = std::sqrt(std::abs(std::min(1.f, (float)tauLifetimeInfo.dxy())));
+          mvaInput_[8] = std::min(10.f, std::abs((float)tauLifetimeInfo.dxy_Sig()));
+          mvaInput_[9] = (tauLifetimeInfo.hasSecondaryVertex()) ? 1. : 0.;
+          mvaInput_[10] = std::sqrt(decayDistMag);
+          mvaInput_[11] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
+        } else if (mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT) {
+          mvaInput_[0] = std::log(std::max(1.f, (float)tau->pt()));
+          mvaInput_[1] = std::abs((float)tau->eta());
+          mvaInput_[2] = std::log(std::max(1.e-2f, chargedIsoPtSum));
+          mvaInput_[3] = std::log(std::max(1.e-2f, neutralIsoPtSum));
+          mvaInput_[4] = std::log(std::max(1.e-2f, puCorrPtSum));
+          mvaInput_[5] = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
+          mvaInput_[6] = tauDecayMode;
+          mvaInput_[7] = std::min(30.f, nPhoton);
+          mvaInput_[8] = std::min(0.5f, ptWeightedDetaStrip);
+          mvaInput_[9] = std::min(0.5f, ptWeightedDphiStrip);
+          mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
+          mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
+          mvaInput_[12] = std::min(100.f, leadingTrackChi2);
+          mvaInput_[13] = std::min(1.f, eRatio);
+          mvaInput_[14] = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
+          mvaInput_[15] = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.dxy())));
+          mvaInput_[16] = std::min(10.f, std::abs((float)tauLifetimeInfo.dxy_Sig()));
+          mvaInput_[17] = std::copysign(+1.f, (float)tauLifetimeInfo.ip3d());
+          mvaInput_[18] = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.ip3d())));
+          mvaInput_[19] = std::min(10.f, std::abs((float)tauLifetimeInfo.ip3d_Sig()));
+          mvaInput_[20] = (tauLifetimeInfo.hasSecondaryVertex()) ? 1. : 0.;
+          mvaInput_[21] = std::sqrt(decayDistMag);
+          mvaInput_[22] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
+        } else if (mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT) {
+          mvaInput_[0] = std::log(std::max(1.f, (float)tau->pt()));
+          mvaInput_[1] = std::abs((float)tau->eta());
+          mvaInput_[2] = std::log(std::max(1.e-2f, chargedIsoPtSum));
+          mvaInput_[3] = std::log(std::max(1.e-2f, neutralIsoPtSum));
+          mvaInput_[4] = std::log(std::max(1.e-2f, footprintCorrection));
+          mvaInput_[5] = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
+          mvaInput_[6] = tauDecayMode;
+          mvaInput_[7] = std::min(30.f, nPhoton);
+          mvaInput_[8] = std::min(0.5f, ptWeightedDetaStrip);
+          mvaInput_[9] = std::min(0.5f, ptWeightedDphiStrip);
+          mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
+          mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
+          mvaInput_[12] = std::min(100.f, leadingTrackChi2);
+          mvaInput_[13] = std::min(1.f, eRatio);
+          mvaInput_[14] = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
+          mvaInput_[15] = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.dxy())));
+          mvaInput_[16] = std::min(10.f, std::abs((float)tauLifetimeInfo.dxy_Sig()));
+          mvaInput_[17] = std::copysign(+1.f, (float)tauLifetimeInfo.ip3d());
+          mvaInput_[18] = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.ip3d())));
+          mvaInput_[19] = std::min(10.f, std::abs((float)tauLifetimeInfo.ip3d_Sig()));
+          mvaInput_[20] = (tauLifetimeInfo.hasSecondaryVertex()) ? 1. : 0.;
+          mvaInput_[21] = std::sqrt(decayDistMag);
+          mvaInput_[22] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
+        } else if (mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ) {
+          mvaInput_[0] = std::log(std::max(1.f, (float)tau->pt()));
+          mvaInput_[1] = std::abs((float)tau->eta());
+          mvaInput_[2] = std::log(std::max(1.e-2f, chargedIsoPtSum));
+          mvaInput_[3] = std::log(std::max(1.e-2f, neutralIsoPtSum));
+          mvaInput_[4] = std::log(std::max(1.e-2f, puCorrPtSum));
+          mvaInput_[5] = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
+          mvaInput_[6] = tauDecayMode;
+          mvaInput_[7] = std::min(30.f, nPhoton);
+          mvaInput_[8] = std::min(0.5f, ptWeightedDetaStrip);
+          mvaInput_[9] = std::min(0.5f, ptWeightedDphiStrip);
+          mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
+          mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
+          mvaInput_[12] = std::min(1.f, eRatio);
+          mvaInput_[13] = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
+          mvaInput_[14] = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.dxy())));
+          mvaInput_[15] = std::min(10.f, std::abs((float)tauLifetimeInfo.dxy_Sig()));
+          mvaInput_[16] = std::copysign(+1.f, (float)tauLifetimeInfo.ip3d());
+          mvaInput_[17] = std::sqrt(std::min(1.f, std::abs((float)tauLifetimeInfo.ip3d())));
+          mvaInput_[18] = std::min(10.f, std::abs((float)tauLifetimeInfo.ip3d_Sig()));
+          mvaInput_[19] = (tauLifetimeInfo.hasSecondaryVertex()) ? 1. : 0.;
+          mvaInput_[20] = std::sqrt(decayDistMag);
+          mvaInput_[21] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
+          mvaInput_[22] = std::max(-1.f, gjAngleDiff);
+        }
+
+        double mvaValue = mvaReader_->GetClassifier(mvaInput_);
+        if (verbosity_) {
+          edm::LogPrint("PFTauDiscByMVAIsol2") << "<PFRecoTauDiscriminationByMVAIsolationRun2::discriminate>:";
+          edm::LogPrint("PFTauDiscByMVAIsol2") << " tau: Pt = " << tau->pt() << ", eta = " << tau->eta();
+          edm::LogPrint("PFTauDiscByMVAIsol2") << " isolation: charged = " << chargedIsoPtSum
+                                               << ", neutral = " << neutralIsoPtSum << ", PUcorr = " << puCorrPtSum;
+          edm::LogPrint("PFTauDiscByMVAIsol2") << " decay mode = " << tauDecayMode;
+          edm::LogPrint("PFTauDiscByMVAIsol2") << " impact parameter: distance = " << tauLifetimeInfo.dxy()
+                                               << ", significance = " << tauLifetimeInfo.dxy_Sig();
+          edm::LogPrint("PFTauDiscByMVAIsol2")
+              << " has decay vertex = " << tauLifetimeInfo.hasSecondaryVertex() << ":"
+              << " distance = " << decayDistMag << ", significance = " << tauLifetimeInfo.flightLengthSig();
+          edm::LogPrint("PFTauDiscByMVAIsol2") << "--> mvaValue = " << mvaValue;
+        }
+        return mvaValue;
+      } else {
+        return -1.;
+      }
     }
 
-    double mvaValue = mvaReader_->GetClassifier(mvaInput_);
-    if ( verbosity_ ) {
-      edm::LogPrint("PFTauDiscByMVAIsol2") << "<PFRecoTauDiscriminationByMVAIsolationRun2::discriminate>:";
-      edm::LogPrint("PFTauDiscByMVAIsol2") << " tau: Pt = " << tau->pt() << ", eta = " << tau->eta();
-      edm::LogPrint("PFTauDiscByMVAIsol2") << " isolation: charged = " << chargedIsoPtSum << ", neutral = " << neutralIsoPtSum << ", PUcorr = " << puCorrPtSum;
-      edm::LogPrint("PFTauDiscByMVAIsol2") << " decay mode = " << tauDecayMode;
-      edm::LogPrint("PFTauDiscByMVAIsol2") << " impact parameter: distance = " << tauLifetimeInfo.dxy() << ", significance = " << tauLifetimeInfo.dxy_Sig();
-      edm::LogPrint("PFTauDiscByMVAIsol2") << " has decay vertex = " << tauLifetimeInfo.hasSecondaryVertex() << ":"
-					   << " distance = " << decayDistMag << ", significance = " << tauLifetimeInfo.flightLengthSig();
-      edm::LogPrint("PFTauDiscByMVAIsol2") << "--> mvaValue = " << mvaValue;
+    void PFRecoTauDiscriminationByMVAIsolationRun2::endEvent(edm::Event& evt) {
+      // add all category indices to event
+      evt.put(std::move(category_output_), "category");
     }
-    return mvaValue;
-  } else {
-    return -1.;
-  }
-}
 
-void PFRecoTauDiscriminationByMVAIsolationRun2::endEvent(edm::Event& evt)
-{
-  // add all category indices to event
-  evt.put(std::move(category_output_), "category");
-}
+    void PFRecoTauDiscriminationByMVAIsolationRun2::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      // pfRecoTauDiscriminationByMVAIsolationRun2
+      edm::ParameterSetDescription desc;
 
+      desc.add<std::string>("mvaName");
+      desc.add<bool>("loadMVAfromDB");
+      desc.addOptional<edm::FileInPath>("inputFileName");
+      desc.add<std::string>("mvaOpt");
 
-void
-PFRecoTauDiscriminationByMVAIsolationRun2::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  // pfRecoTauDiscriminationByMVAIsolationRun2
-  edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("srcTauTransverseImpactParameters");
+      desc.add<edm::InputTag>("srcChargedIsoPtSum");
+      desc.add<edm::InputTag>("srcNeutralIsoPtSum");
+      desc.add<edm::InputTag>("srcPUcorrPtSum");
 
-  desc.add<std::string>("mvaName");
-  desc.add<bool>("loadMVAfromDB");
-  desc.addOptional<edm::FileInPath>("inputFileName");
-  desc.add<std::string>("mvaOpt");
+      desc.add<edm::InputTag>("srcPhotonPtSumOutsideSignalCone");
+      desc.add<edm::InputTag>("srcFootprintCorrection");
 
-  desc.add<edm::InputTag>("srcTauTransverseImpactParameters");
-  desc.add<edm::InputTag>("srcChargedIsoPtSum");
-  desc.add<edm::InputTag>("srcNeutralIsoPtSum");
-  desc.add<edm::InputTag>("srcPUcorrPtSum");
+      desc.add<int>("verbosity", 0);
 
-  desc.add<edm::InputTag>("srcPhotonPtSumOutsideSignalCone");
-  desc.add<edm::InputTag>("srcFootprintCorrection");
+      fillProducerDescriptions(desc);  // inherited from the base
 
-  desc.add<int>("verbosity", 0);
+      descriptions.add("pfRecoTauDiscriminationByMVAIsolationRun2", desc);
+    }
 
-  fillProducerDescriptions(desc); // inherited from the base
+    DEFINE_FWK_MODULE(PFRecoTauDiscriminationByMVAIsolationRun2);
 
-  descriptions.add("pfRecoTauDiscriminationByMVAIsolationRun2", desc);
-}
-
-
-DEFINE_FWK_MODULE(PFRecoTauDiscriminationByMVAIsolationRun2);
-
-}} //namespace
+  }  // namespace tau
+}  // namespace reco

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
@@ -17,69 +17,71 @@ using namespace reco;
 using namespace std;
 using namespace edm;
 
-class PFRecoTauDiscriminationByNProngs : public PFTauDiscriminationProducerBase  {
-    public:
-	explicit PFRecoTauDiscriminationByNProngs(const ParameterSet&);
-      	~PFRecoTauDiscriminationByNProngs() override{}
+class PFRecoTauDiscriminationByNProngs : public PFTauDiscriminationProducerBase {
+public:
+  explicit PFRecoTauDiscriminationByNProngs(const ParameterSet&);
+  ~PFRecoTauDiscriminationByNProngs() override {}
 
-	void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-	double discriminate(const reco::PFTauRef&) const override;
+  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+  double discriminate(const reco::PFTauRef&) const override;
 
-        static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    private:
-	std::unique_ptr<tau::RecoTauQualityCuts> qcuts_;
-	std::unique_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-	uint32_t minN,maxN;
-	bool booleanOutput;
-	edm::ParameterSet qualityCuts;
+private:
+  std::unique_ptr<tau::RecoTauQualityCuts> qcuts_;
+  std::unique_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
+
+  uint32_t minN, maxN;
+  bool booleanOutput;
+  edm::ParameterSet qualityCuts;
 };
 
-PFRecoTauDiscriminationByNProngs::PFRecoTauDiscriminationByNProngs(const ParameterSet& iConfig):
-  PFTauDiscriminationProducerBase(iConfig),
-  qualityCuts(iConfig.getParameterSet("qualityCuts"))
-{
-        minN          = iConfig.getParameter<uint32_t>("MinN");
-	maxN          = iConfig.getParameter<uint32_t>("MaxN");
-        booleanOutput = iConfig.getParameter<bool>("BooleanOutput");
+PFRecoTauDiscriminationByNProngs::PFRecoTauDiscriminationByNProngs(const ParameterSet& iConfig)
+    : PFTauDiscriminationProducerBase(iConfig), qualityCuts(iConfig.getParameterSet("qualityCuts")) {
+  minN = iConfig.getParameter<uint32_t>("MinN");
+  maxN = iConfig.getParameter<uint32_t>("MaxN");
+  booleanOutput = iConfig.getParameter<bool>("BooleanOutput");
 
-	qcuts_.reset(new tau::RecoTauQualityCuts(qualityCuts.getParameterSet("signalQualityCuts")));
-	vertexAssociator_.reset(new tau::RecoTauVertexAssociator(qualityCuts,consumesCollector()));
+  qcuts_.reset(new tau::RecoTauQualityCuts(qualityCuts.getParameterSet("signalQualityCuts")));
+  vertexAssociator_.reset(new tau::RecoTauVertexAssociator(qualityCuts, consumesCollector()));
 }
 
-void PFRecoTauDiscriminationByNProngs::beginEvent(const Event& iEvent, const EventSetup& iSetup){
-	vertexAssociator_->setEvent(iEvent);
+void PFRecoTauDiscriminationByNProngs::beginEvent(const Event& iEvent, const EventSetup& iSetup) {
+  vertexAssociator_->setEvent(iEvent);
 }
 
-double PFRecoTauDiscriminationByNProngs::discriminate(const PFTauRef& tau) const{
+double PFRecoTauDiscriminationByNProngs::discriminate(const PFTauRef& tau) const {
+  reco::VertexRef pv = vertexAssociator_->associatedVertex(*tau);
+  const CandidatePtr leadingTrack = tau->leadChargedHadrCand();
 
-	reco::VertexRef pv = vertexAssociator_->associatedVertex(*tau);
-	const CandidatePtr leadingTrack = tau->leadChargedHadrCand();
+  uint np = 0;
+  if (leadingTrack.isNonnull() && pv.isNonnull()) {
+    qcuts_->setPV(pv);
+    qcuts_->setLeadTrack(*tau->leadChargedHadrCand());
 
-	uint np = 0;
-	if(leadingTrack.isNonnull() && pv.isNonnull()){
-	    qcuts_->setPV(pv);
-	    qcuts_->setLeadTrack(*tau->leadChargedHadrCand());
+    for (auto const& cand : tau->signalChargedHadrCands()) {
+      if (qcuts_->filterCandRef(cand))
+        np++;
+    }
+  }
 
-	    for(auto const& cand : tau->signalChargedHadrCands() ) {
-	        if ( qcuts_->filterCandRef(cand) ) np++;
- 	    }
-	}
+  bool accepted = false;
+  if (maxN == 0) {
+    if (np == 1 || np == 3)
+      accepted = true;
+  } else {
+    if (np >= minN && np <= maxN)
+      accepted = true;
+  }
 
-	bool accepted = false;
-	if(maxN == 0){
-	    if(np == 1 || np == 3) accepted = true;
-	}else{
-	    if(np >= minN && np <= maxN) accepted = true;
-	}
-
-	if(!accepted) np = 0;
-	if(booleanOutput) return accepted;
-	return np;
+  if (!accepted)
+    np = 0;
+  if (booleanOutput)
+    return accepted;
+  return np;
 }
 
-void
-PFRecoTauDiscriminationByNProngs::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauDiscriminationByNProngs::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // pfRecoTauDiscriminationByNProngs
   edm::ParameterSetDescription desc;
 
@@ -118,8 +120,8 @@ PFRecoTauDiscriminationByNProngs::fillDescriptions(edm::ConfigurationDescription
     pset_isolationQualityCuts.addOptional<bool>("useTracksInsteadOfPFHadrons");
 
     edm::ParameterSetDescription pset_qualityCuts;
-    pset_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts",    pset_signalQualityCuts);
-    pset_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts",   pset_vxAssocQualityCuts);
+    pset_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts", pset_signalQualityCuts);
+    pset_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts", pset_vxAssocQualityCuts);
     pset_qualityCuts.add<edm::ParameterSetDescription>("isolationQualityCuts", pset_isolationQualityCuts);
     pset_qualityCuts.add<std::string>("leadingTrkOrPFCandOption", "leadPFCand");
     pset_qualityCuts.add<std::string>("pvFindingAlgo", "closestInDeltaZ");
@@ -144,4 +146,3 @@ PFRecoTauDiscriminationByNProngs::fillDescriptions(edm::ConfigurationDescription
 }
 
 DEFINE_FWK_MODULE(PFRecoTauDiscriminationByNProngs);
-

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
@@ -32,444 +32,476 @@
 #include <vector>
 #include <cmath>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class PFRecoTauEnergyAlgorithmPlugin : public RecoTauModifierPlugin
-{
- public:
+    class PFRecoTauEnergyAlgorithmPlugin : public RecoTauModifierPlugin {
+    public:
+      explicit PFRecoTauEnergyAlgorithmPlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+      ~PFRecoTauEnergyAlgorithmPlugin() override;
+      void operator()(reco::PFTau&) const override;
+      void beginEvent() override;
+      void endEvent() override;
 
-  explicit PFRecoTauEnergyAlgorithmPlugin(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
-  ~PFRecoTauEnergyAlgorithmPlugin() override;
-  void operator()(reco::PFTau&) const override;
-  void beginEvent() override;
-  void endEvent() override;
+    private:
+      double dRaddNeutralHadron_;
+      double minNeutralHadronEt_;
+      double dRaddPhoton_;
+      double minGammaEt_;
 
- private:
-  
-  double dRaddNeutralHadron_;
-  double minNeutralHadronEt_;
-  double dRaddPhoton_;
-  double minGammaEt_;
+      int verbosity_;
+    };
 
-  int verbosity_;
-};
+    PFRecoTauEnergyAlgorithmPlugin::PFRecoTauEnergyAlgorithmPlugin(const edm::ParameterSet& cfg,
+                                                                   edm::ConsumesCollector&& iC)
+        : RecoTauModifierPlugin(cfg, std::move(iC)),
+          dRaddNeutralHadron_(cfg.getParameter<double>("dRaddNeutralHadron")),
+          minNeutralHadronEt_(cfg.getParameter<double>("minNeutralHadronEt")),
+          dRaddPhoton_(cfg.getParameter<double>("dRaddPhoton")),
+          minGammaEt_(cfg.getParameter<double>("minGammaEt")),
+          verbosity_(cfg.getParameter<int>("verbosity")) {}
 
-PFRecoTauEnergyAlgorithmPlugin::PFRecoTauEnergyAlgorithmPlugin(const edm::ParameterSet& cfg, edm::ConsumesCollector &&iC)
-    : RecoTauModifierPlugin(cfg, std::move(iC)),
-    dRaddNeutralHadron_(cfg.getParameter<double>("dRaddNeutralHadron")),
-    minNeutralHadronEt_(cfg.getParameter<double>("minNeutralHadronEt")),
-    dRaddPhoton_(cfg.getParameter<double>("dRaddPhoton")),
-    minGammaEt_(cfg.getParameter<double>("minGammaEt")),
-    verbosity_(cfg.getParameter<int>("verbosity"))
-{}
+    PFRecoTauEnergyAlgorithmPlugin::~PFRecoTauEnergyAlgorithmPlugin() {}
 
-PFRecoTauEnergyAlgorithmPlugin::~PFRecoTauEnergyAlgorithmPlugin()
-{}
+    void PFRecoTauEnergyAlgorithmPlugin::beginEvent() {}
 
-void PFRecoTauEnergyAlgorithmPlugin::beginEvent()
-{}
-
-namespace
-{
-  double getTrackPerr2(const reco::Track& track)
-  {
-    double trackPerr = track.p()*(track.ptError()/track.pt());
-    return trackPerr*trackPerr;
-  }
-
-  void updateTauP4(reco::PFTau& tau, double sf, const reco::Candidate::LorentzVector& addP4)
-  {
-    // preserve tau candidate mass when adding extra neutral energy
-    double tauPx_modified = tau.px() + sf*addP4.px();
-    double tauPy_modified = tau.py() + sf*addP4.py();
-    double tauPz_modified = tau.pz() + sf*addP4.pz();
-    double tauMass = tau.mass();
-    double tauEn_modified = sqrt(tauPx_modified*tauPx_modified + tauPy_modified*tauPy_modified + tauPz_modified*tauPz_modified + tauMass*tauMass);
-    reco::Candidate::LorentzVector tauP4_modified(tauPx_modified, tauPy_modified, tauPz_modified, tauEn_modified);
-    tau.setP4(tauP4_modified);
-  }
-
-  void killTau(reco::PFTau& tau)
-  {
-    reco::Candidate::LorentzVector tauP4_modified(0.,0.,0.,0.);
-    tau.setP4(tauP4_modified);
-    tau.setStatus(-1);
-  }
-}
-
-template<class Base, class Der>
-bool isPtrEqual(const edm::Ptr<Base>& b, const edm::Ptr<Der>& d) {
-  return edm::Ptr<Der>(b) == d;
-}
-
-template<class Base>
-bool isPtrEqual(const edm::Ptr<Base>& b, const edm::Ptr<Base>& d) {
-  return b == d;
-}
-
-void PFRecoTauEnergyAlgorithmPlugin::operator()(reco::PFTau& tau) const
-{
-  if ( verbosity_ ) {
-    std::cout << "<PFRecoTauEnergyAlgorithmPlugin::operator()>:" << std::endl;
-    std::cout << "tau: Pt = " << tau.pt() << ", eta = " << tau.eta() << ", phi = " << tau.phi() << " (En = " << tau.energy() << ", decayMode = " << tau.decayMode() << ")" << std::endl;
-  }
-
-  // Add high Pt PFNeutralHadrons and PFGammas that are not "used" by tau decay mode object
-  std::vector<reco::CandidatePtr> addNeutrals;
-  reco::Candidate::LorentzVector addNeutralsSumP4;
-  const auto& jetConstituents = tau.jetRef()->daughterPtrVector();
-  for (const auto& jetConstituent : jetConstituents) {
-    
-    int jetConstituentPdgId = std::abs(jetConstituent->pdgId());
-    if ( !((jetConstituentPdgId == 130    && jetConstituent->et() > minNeutralHadronEt_) ||
-	   (jetConstituentPdgId == 22 && jetConstituent->et() > minGammaEt_        )) ) continue;
-
-    bool isSignalCand = false;
-    const auto& signalCands = tau.signalCands();
-    for (const auto& signalCand : signalCands) {
-      if ( isPtrEqual(jetConstituent, signalCand) ) isSignalCand = true;
-    }
-    if ( isSignalCand ) continue;
-    
-    double dR = deltaR(jetConstituent->p4(), tau.p4());
-    double dRadd = -1.;      
-    if      ( jetConstituentPdgId == 130    ) dRadd = dRaddNeutralHadron_;
-    else if ( jetConstituentPdgId == 22 ) dRadd = dRaddPhoton_;
-    if ( dR < dRadd ) {
-      addNeutrals.push_back(jetConstituent);
-      addNeutralsSumP4 += jetConstituent->p4();
-    }
-  }
-  if ( verbosity_ ) {
-    std::cout << "addNeutralsSumP4: En = " << addNeutralsSumP4.energy() << std::endl;
-  }
-  
-  unsigned numNonPFCandTracks = 0;
-  double nonPFCandTracksSumP = 0.;
-  double nonPFCandTracksSumPerr2 = 0.;
-  const std::vector<PFRecoTauChargedHadron>& chargedHadrons = tau.signalTauChargedHadronCandidatesRestricted();
-  for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
-	chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
-    if ( chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack) ) {
-      ++numNonPFCandTracks;
-      const reco::Track* chargedHadronTrack = getTrackFromChargedHadron(*chargedHadron);
-      if ( chargedHadronTrack != nullptr ) {
-	nonPFCandTracksSumP += chargedHadronTrack->p();
-	nonPFCandTracksSumPerr2 += getTrackPerr2(*chargedHadronTrack);
+    namespace {
+      double getTrackPerr2(const reco::Track& track) {
+        double trackPerr = track.p() * (track.ptError() / track.pt());
+        return trackPerr * trackPerr;
       }
-    }
-  }
-  if ( verbosity_ ) {
-    std::cout << "nonPFCandTracksSumP = " << nonPFCandTracksSumP << " +/- " << sqrt(nonPFCandTracksSumPerr2) 
-	      << " (numNonPFCandTracks = " << numNonPFCandTracks << ")" << std::endl;
-  }
- 
-  if ( numNonPFCandTracks == 0 ) {
-    // This is the easy case: 
-    // All tau energy is taken from PFCandidates reconstructed by PFlow algorithm
-    // and there is no issue with double-counting of energy.
-    if ( verbosity_ ) {
-      std::cout << "easy case: all tracks are associated to PFCandidates --> leaving tau momentum untouched." << std::endl;
-    }
-    updateTauP4(tau, 1., addNeutralsSumP4);
-    return;
-  } else {
-    // This is the difficult case: 
-    // The tau energy needs to be computed for an arbitrary mix of charged and neutral PFCandidates plus reco::Tracks.
-    // We need to make sure not to double-count energy deposited by reco::Track in ECAL and/or HCAL as neutral PFCandidates.
-    
-    // Check if we have enough energy in collection of PFNeutralHadrons and PFGammas that are not "used" by tau decay mode object
-    // to balance track momenta:
-    if ( nonPFCandTracksSumP < addNeutralsSumP4.energy() ) {
-      double scaleFactor = 1. - nonPFCandTracksSumP/addNeutralsSumP4.energy();
-      if ( !(scaleFactor >= 0. && scaleFactor <= 1.) ) {
-	edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()") 
-	  << "Failed to compute tau energy --> killing tau candidate !!" << std::endl;
-	killTau(tau);
-	return;
+
+      void updateTauP4(reco::PFTau& tau, double sf, const reco::Candidate::LorentzVector& addP4) {
+        // preserve tau candidate mass when adding extra neutral energy
+        double tauPx_modified = tau.px() + sf * addP4.px();
+        double tauPy_modified = tau.py() + sf * addP4.py();
+        double tauPz_modified = tau.pz() + sf * addP4.pz();
+        double tauMass = tau.mass();
+        double tauEn_modified = sqrt(tauPx_modified * tauPx_modified + tauPy_modified * tauPy_modified +
+                                     tauPz_modified * tauPz_modified + tauMass * tauMass);
+        reco::Candidate::LorentzVector tauP4_modified(tauPx_modified, tauPy_modified, tauPz_modified, tauEn_modified);
+        tau.setP4(tauP4_modified);
       }
-      if ( verbosity_ ) {
-	std::cout << "case (2): addNeutralsSumEn > nonPFCandTracksSumP --> adjusting tau momentum." << std::endl;
+
+      void killTau(reco::PFTau& tau) {
+        reco::Candidate::LorentzVector tauP4_modified(0., 0., 0., 0.);
+        tau.setP4(tauP4_modified);
+        tau.setStatus(-1);
       }
-      updateTauP4(tau, scaleFactor, addNeutralsSumP4);
-      return;
+    }  // namespace
+
+    template <class Base, class Der>
+    bool isPtrEqual(const edm::Ptr<Base>& b, const edm::Ptr<Der>& d) {
+      return edm::Ptr<Der>(b) == d;
     }
 
-    // Determine which neutral PFCandidates are close to PFChargedHadrons
-    // and have been merged into ChargedHadrons
-    std::vector<reco::CandidatePtr> mergedNeutrals;
-    reco::Candidate::LorentzVector mergedNeutralsSumP4;
-    for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
-	  chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
-      if ( chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack) ) {
-	const std::vector<reco::CandidatePtr>& neutralPFCands = chargedHadron->getNeutralPFCandidates();
-	for ( std::vector<reco::CandidatePtr>::const_iterator neutralPFCand = neutralPFCands.begin();
-	      neutralPFCand != neutralPFCands.end(); ++neutralPFCand ) {
-	  mergedNeutrals.push_back(*neutralPFCand);
-	  mergedNeutralsSumP4 += (*neutralPFCand)->p4();
-	}
-      }
-    }
-    if ( verbosity_ ) {
-      std::cout << "mergedNeutralsSumP4: En = " << mergedNeutralsSumP4.energy() << std::endl;
+    template <class Base>
+    bool isPtrEqual(const edm::Ptr<Base>& b, const edm::Ptr<Base>& d) {
+      return b == d;
     }
 
-    // Check if track momenta are balanced by sum of PFNeutralHadrons and PFGammas that are not "used" by tau decay mode object
-    // plus neutral PFCandidates close to PFChargedHadrons:
-    if ( nonPFCandTracksSumP < (addNeutralsSumP4.energy() + mergedNeutralsSumP4.energy()) ) {
-      double scaleFactor = ((addNeutralsSumP4.energy() + mergedNeutralsSumP4.energy()) - nonPFCandTracksSumP)/mergedNeutralsSumP4.energy();
-      if ( !(scaleFactor >= 0. && scaleFactor <= 1.) ) {
-      	edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()") 
-	  << "Failed to compute tau energy --> killing tau candidate !!" << std::endl;
-	killTau(tau);
-	return;
+    void PFRecoTauEnergyAlgorithmPlugin::operator()(reco::PFTau& tau) const {
+      if (verbosity_) {
+        std::cout << "<PFRecoTauEnergyAlgorithmPlugin::operator()>:" << std::endl;
+        std::cout << "tau: Pt = " << tau.pt() << ", eta = " << tau.eta() << ", phi = " << tau.phi()
+                  << " (En = " << tau.energy() << ", decayMode = " << tau.decayMode() << ")" << std::endl;
       }
-      reco::Candidate::LorentzVector diffP4;
-      size_t numChargedHadrons = chargedHadrons.size();
-      for ( size_t iChargedHadron = 0; iChargedHadron < numChargedHadrons; ++iChargedHadron ) {
-	const PFRecoTauChargedHadron& chargedHadron = chargedHadrons[iChargedHadron];
-	if ( !chargedHadron.getNeutralPFCandidates().empty() ) {
-	  PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
-	  setChargedHadronP4(chargedHadron_modified, scaleFactor);
-	  tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
-	  diffP4 += (chargedHadron.p4() - chargedHadron_modified.p4());
-	}
-      }
-      if ( verbosity_ ) {
-	std::cout << "case (3): (addNeutralsSumEn + mergedNeutralsSumEn) > nonPFCandTracksSumP --> adjusting tau momentum." << std::endl;
-      }
-      updateTauP4(tau, -1., diffP4);
-      return;
-    }
 
-    // Determine energy sum of all PFNeutralHadrons interpreted as ChargedHadrons with missing track
-    unsigned numChargedHadronNeutrals = 0;
-    std::vector<reco::CandidatePtr> chargedHadronNeutrals;
-    reco::Candidate::LorentzVector chargedHadronNeutralsSumP4;
-    for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
-	  chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
-      if ( chargedHadron->algoIs(PFRecoTauChargedHadron::kPFNeutralHadron) ) {
-	++numChargedHadronNeutrals;
-	chargedHadronNeutrals.push_back(chargedHadron->getChargedPFCandidate());
-	chargedHadronNeutralsSumP4 += chargedHadron->getChargedPFCandidate()->p4();
+      // Add high Pt PFNeutralHadrons and PFGammas that are not "used" by tau decay mode object
+      std::vector<reco::CandidatePtr> addNeutrals;
+      reco::Candidate::LorentzVector addNeutralsSumP4;
+      const auto& jetConstituents = tau.jetRef()->daughterPtrVector();
+      for (const auto& jetConstituent : jetConstituents) {
+        int jetConstituentPdgId = std::abs(jetConstituent->pdgId());
+        if (!((jetConstituentPdgId == 130 && jetConstituent->et() > minNeutralHadronEt_) ||
+              (jetConstituentPdgId == 22 && jetConstituent->et() > minGammaEt_)))
+          continue;
+
+        bool isSignalCand = false;
+        const auto& signalCands = tau.signalCands();
+        for (const auto& signalCand : signalCands) {
+          if (isPtrEqual(jetConstituent, signalCand))
+            isSignalCand = true;
+        }
+        if (isSignalCand)
+          continue;
+
+        double dR = deltaR(jetConstituent->p4(), tau.p4());
+        double dRadd = -1.;
+        if (jetConstituentPdgId == 130)
+          dRadd = dRaddNeutralHadron_;
+        else if (jetConstituentPdgId == 22)
+          dRadd = dRaddPhoton_;
+        if (dR < dRadd) {
+          addNeutrals.push_back(jetConstituent);
+          addNeutralsSumP4 += jetConstituent->p4();
+        }
       }
-    }
-    if ( verbosity_ ) {
-      std::cout << "chargedHadronNeutralsSumP4: En = " << chargedHadronNeutralsSumP4.energy() 
-		<< " (numChargedHadronNeutrals = " << numChargedHadronNeutrals << ")" << std::endl;
-    }
-    
-    // Check if sum of PFNeutralHadrons and PFGammas that are not "used" by tau decay mode object
-    // plus neutral PFCandidates close to PFChargedHadrons plus PFNeutralHadrons interpreted as ChargedHadrons with missing track balances track momenta
-    if ( nonPFCandTracksSumP < (addNeutralsSumP4.energy() + mergedNeutralsSumP4.energy() + chargedHadronNeutralsSumP4.energy()) ) {
-      double scaleFactor = ((addNeutralsSumP4.energy() + mergedNeutralsSumP4.energy() + chargedHadronNeutralsSumP4.energy()) - nonPFCandTracksSumP)/chargedHadronNeutralsSumP4.energy();
-      if ( !(scaleFactor >= 0. && scaleFactor <= 1.) ) {
-      	edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()") 
-	  << "Failed to compute tau energy --> killing tau candidate !!" << std::endl;
-	killTau(tau);
-	return;
+      if (verbosity_) {
+        std::cout << "addNeutralsSumP4: En = " << addNeutralsSumP4.energy() << std::endl;
       }
-      reco::Candidate::LorentzVector diffP4;
-      size_t numChargedHadrons = chargedHadrons.size();
-      for ( size_t iChargedHadron = 0; iChargedHadron < numChargedHadrons; ++iChargedHadron ) {
-	const PFRecoTauChargedHadron& chargedHadron = chargedHadrons[iChargedHadron];
-	if ( chargedHadron.algoIs(PFRecoTauChargedHadron::kPFNeutralHadron) ) {
-	  PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
-	  chargedHadron_modified.neutralPFCandidates_.clear();
-	  const CandidatePtr& chargedPFCand = chargedHadron.getChargedPFCandidate();
-	  double chargedHadronPx_modified = scaleFactor*chargedPFCand->px();
-	  double chargedHadronPy_modified = scaleFactor*chargedPFCand->py();
-	  double chargedHadronPz_modified = scaleFactor*chargedPFCand->pz();
-	  reco::Candidate::LorentzVector chargedHadronP4_modified = compChargedHadronP4fromPxPyPz(chargedHadronPx_modified, chargedHadronPy_modified, chargedHadronPz_modified);	  
-	  chargedHadron_modified.setP4(chargedHadronP4_modified);
-	  tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
-	  diffP4 += (chargedHadron.p4() - chargedHadron_modified.p4());
-	}
-      }
-      if ( verbosity_ ) {
-	std::cout << "case (4): (addNeutralsSumEn + mergedNeutralsSumEn + chargedHadronNeutralsSumEn) > nonPFCandTracksSumP --> adjusting momenta of tau and chargedHadrons." << std::endl;
-      }
-      updateTauP4(tau, -1., diffP4);
-      return;
-    } else {
-      double allTracksSumP = 0.;
-      double allTracksSumPerr2 = 0.;
-      const std::vector<PFRecoTauChargedHadron> chargedHadrons = tau.signalTauChargedHadronCandidatesRestricted();
-      for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
-	    chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
-	if ( chargedHadron->algoIs(PFRecoTauChargedHadron::kChargedPFCandidate) || chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack) ) {
+
+      unsigned numNonPFCandTracks = 0;
+      double nonPFCandTracksSumP = 0.;
+      double nonPFCandTracksSumPerr2 = 0.;
+      const std::vector<PFRecoTauChargedHadron>& chargedHadrons = tau.signalTauChargedHadronCandidatesRestricted();
+      for (std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
+           chargedHadron != chargedHadrons.end();
+           ++chargedHadron) {
+        if (chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack)) {
+          ++numNonPFCandTracks;
           const reco::Track* chargedHadronTrack = getTrackFromChargedHadron(*chargedHadron);
-	  if ( chargedHadronTrack != nullptr ) {
-	    allTracksSumP += chargedHadronTrack->p();
-	    allTracksSumPerr2 += getTrackPerr2(*chargedHadronTrack);
-	  } else {
-	    edm::LogInfo("PFRecoTauEnergyAlgorithmPlugin::operator()") 
-	      << "PFRecoTauChargedHadron has no associated reco::Track !!";
-	    if ( verbosity_ ) {
-	      chargedHadron->print();
-	    }
-	  }
-	}
-      }
-      if ( verbosity_ ) {
-	std::cout << "allTracksSumP = " << allTracksSumP << " +/- " << sqrt(allTracksSumPerr2) << std::endl;
-      }
-      double allNeutralsSumEn = 0.;
-      const auto& signalCands = tau.signalCands();
-      for (const auto& signalCand : signalCands) {
-	if ( verbosity_ ) {
-	  std::cout << "Candidate #" << signalCand.id() << ":" << signalCand.key() << ":" 
-		    << " Pt = " << (signalCand)->pt() << ", eta = " << (signalCand)->eta() << ", phi = " << (signalCand)->phi() << std::endl;
-        }
-        const PFCandidate* pfCand = dynamic_cast<const PFCandidate*>(&*signalCand);
-        if (pfCand) {
-          if (verbosity_) {
-	    std::cout << "calorimeter energy:" 
-		    << " ECAL = " << (pfCand)->ecalEnergy() << "," 
-		    << " HCAL = " << (pfCand)->hcalEnergy() << ","
-		    << " HO = " << (pfCand)->hoEnergy() << std::endl;
-	  }
-          // TauReco@MiniAOD: This info is not yet available in miniAOD.
-	  if ( edm::isFinite(pfCand->ecalEnergy()) ) allNeutralsSumEn += pfCand->ecalEnergy();
-	  if ( edm::isFinite(pfCand->hcalEnergy()) ) allNeutralsSumEn += pfCand->hcalEnergy();
-	  if ( edm::isFinite(pfCand->hoEnergy())   ) allNeutralsSumEn += pfCand->hoEnergy();
+          if (chargedHadronTrack != nullptr) {
+            nonPFCandTracksSumP += chargedHadronTrack->p();
+            nonPFCandTracksSumPerr2 += getTrackPerr2(*chargedHadronTrack);
+          }
         }
       }
-      allNeutralsSumEn += addNeutralsSumP4.energy();
-      if ( allNeutralsSumEn < 0. ) allNeutralsSumEn = 0.;
-      if ( verbosity_ ) {
-	std::cout << "allNeutralsSumEn = " << allNeutralsSumEn << std::endl;
+      if (verbosity_) {
+        std::cout << "nonPFCandTracksSumP = " << nonPFCandTracksSumP << " +/- " << sqrt(nonPFCandTracksSumPerr2)
+                  << " (numNonPFCandTracks = " << numNonPFCandTracks << ")" << std::endl;
       }
-      if ( allNeutralsSumEn > allTracksSumP ) {
-	// Adjust momenta of neutral PFCandidates merged into ChargedHadrons
-	size_t numChargedHadrons = chargedHadrons.size();
-	for ( size_t iChargedHadron = 0; iChargedHadron < numChargedHadrons; ++iChargedHadron ) {
-	  const PFRecoTauChargedHadron& chargedHadron = chargedHadrons[iChargedHadron];
-	  if ( chargedHadron.algoIs(PFRecoTauChargedHadron::kChargedPFCandidate) ) {
-	    PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
-	    chargedHadron_modified.neutralPFCandidates_.clear();
-	    chargedHadron_modified.setP4(chargedHadron.getChargedPFCandidate()->p4());
-	    if ( verbosity_ ) {
-	      std::cout << "chargedHadron #" << iChargedHadron << ": changing En = " << chargedHadron.energy() << " to " << chargedHadron_modified.energy() << std::endl;
-	    }
-	    tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
-	  } else if ( chargedHadron.algoIs(PFRecoTauChargedHadron::kTrack) ) {
-	    PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
-	    chargedHadron_modified.neutralPFCandidates_.clear();
-	    reco::Candidate::LorentzVector chargedHadronP4_modified(0.,0.,0.,0.);
-	    const reco::Track* chTrack = getTrackFromChargedHadron(chargedHadron);
-	    if ( chTrack != nullptr ) {
-	      double chargedHadronPx_modified     = chTrack->px();
-	      double chargedHadronPy_modified = chTrack->py();
-	      double chargedHadronPz_modified   = chTrack->pz();
-	      chargedHadronP4_modified = compChargedHadronP4fromPxPyPz(chargedHadronPx_modified, chargedHadronPy_modified, chargedHadronPz_modified);
-	    } else {
-	      edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()") 
-		<< "PFRecoTauChargedHadron has no associated reco::Track !!" << std::endl;
-	      if ( verbosity_ ) {
-		chargedHadron.print();
-	      }
-	    }
-	    chargedHadron_modified.setP4(chargedHadronP4_modified);
-	    if ( verbosity_ ) {
-	      std::cout << "chargedHadron #" << iChargedHadron << ": changing En = " << chargedHadron.energy() << " to " << chargedHadron_modified.energy() << std::endl;
-	    }
-	    tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
-	  }
-	}
-	double scaleFactor = allNeutralsSumEn/tau.energy();
-	if ( verbosity_ ) {
-	  std::cout << "case (5): allNeutralsSumEn > allTracksSumP --> adjusting momenta of tau and chargedHadrons." << std::endl;
-	}
-	updateTauP4(tau, scaleFactor - 1., tau.p4());
-	return;
+
+      if (numNonPFCandTracks == 0) {
+        // This is the easy case:
+        // All tau energy is taken from PFCandidates reconstructed by PFlow algorithm
+        // and there is no issue with double-counting of energy.
+        if (verbosity_) {
+          std::cout << "easy case: all tracks are associated to PFCandidates --> leaving tau momentum untouched."
+                    << std::endl;
+        }
+        updateTauP4(tau, 1., addNeutralsSumP4);
+        return;
       } else {
-	if ( numChargedHadronNeutrals == 0 && tau.signalPiZeroCandidates().empty() ) {
-	  // Adjust momenta of ChargedHadrons build from reco::Tracks to match sum of energy deposits in ECAL + HCAL + HO
-	  size_t numChargedHadrons = chargedHadrons.size();
-	  for ( size_t iChargedHadron = 0; iChargedHadron < numChargedHadrons; ++iChargedHadron ) {
-	    const PFRecoTauChargedHadron& chargedHadron = chargedHadrons[iChargedHadron];
-	    if ( chargedHadron.algoIs(PFRecoTauChargedHadron::kChargedPFCandidate) || chargedHadron.algoIs(PFRecoTauChargedHadron::kTrack) ) {
-	      PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
-	      chargedHadron_modified.neutralPFCandidates_.clear();
-	      reco::Candidate::LorentzVector chargedHadronP4_modified(0.,0.,0.,0.);
-	      const reco::Track* chargedHadronTrack = getTrackFromChargedHadron(chargedHadron);
-	      if ( chargedHadronTrack != nullptr ) {
-		double trackP = chargedHadronTrack->p();
-		double trackPerr2 = getTrackPerr2(*chargedHadronTrack);	  
-		if ( verbosity_ ) {
-		  std::cout << "trackP = " << trackP << " +/- " << sqrt(trackPerr2) << std::endl;
-		}
-		// CV: adjust track momenta such that difference beeen (measuredTrackP - adjustedTrackP)/sigmaMeasuredTrackP is minimal
-		//    (expression derived using Mathematica)
-		double trackP_modified = 
-                  (trackP*(allTracksSumPerr2 - trackPerr2) 
-                 + trackPerr2*(allNeutralsSumEn - (allTracksSumP - trackP)))/
-                  allTracksSumPerr2;
-	        // CV: trackP_modified may actually become negative in case sum of energy deposits in ECAL + HCAL + HO is small
-		//     and one of the tracks has a significantly larger momentum uncertainty than the other tracks.
-		//     In this case set track momentum to small positive value.
-		if ( trackP_modified < 1.e-1 ) trackP_modified = 1.e-1;
-		if ( verbosity_ ) {
-		  std::cout << "trackP (modified) = " << trackP_modified << std::endl;
-		}
-		double scaleFactor = trackP_modified/trackP;
-		if ( !(scaleFactor >= 0. && scaleFactor <= 1.) ) {
-		  edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()") 
-		    << "Failed to compute tau energy --> killing tau candidate !!" << std::endl;
-		  killTau(tau);
-		  return;
-		}
-		double chargedHadronPx_modified = scaleFactor*chargedHadronTrack->px();
-		double chargedHadronPy_modified = scaleFactor*chargedHadronTrack->py();
-		double chargedHadronPz_modified = scaleFactor*chargedHadronTrack->pz();
-		chargedHadronP4_modified = compChargedHadronP4fromPxPyPz(chargedHadronPx_modified, chargedHadronPy_modified, chargedHadronPz_modified);
-	      } else {
-		edm::LogInfo("PFRecoTauEnergyAlgorithmPlugin::operator()") 
-		  << "PFRecoTauChargedHadron has no associated reco::Track !!";
-		if ( verbosity_ ) {
-		  chargedHadron.print();
-		}
-	      }	     
-	      chargedHadron_modified.setP4(chargedHadronP4_modified);
-	      if ( verbosity_ ) {
-		std::cout << "chargedHadron #" << iChargedHadron << ": changing En = " << chargedHadron.energy() << " to " << chargedHadron_modified.energy() << std::endl;
-	      }
-	      tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
-	    }
-	  }
-	  double scaleFactor = allNeutralsSumEn/tau.energy();
-	  if ( verbosity_ ) {
-	    std::cout << "case (6): allNeutralsSumEn < allTracksSumP --> adjusting momenta of tau and chargedHadrons." << std::endl;
-	  }
-	  updateTauP4(tau, scaleFactor - 1., tau.p4());
-	  return;
-	} else {
-	  // Interpretation of PFNeutralHadrons as ChargedHadrons with missing track and/or reconstruction of extra PiZeros 
-	  // is not compatible with the fact that sum of reco::Track momenta exceeds sum of energy deposits in ECAL + HCAL + HO:
-	  // kill tau candidate (by setting its four-vector to zero)
-	  if ( verbosity_ ) {
-	    std::cout << "case (7): allNeutralsSumEn < allTracksSumP not compatible with tau decay mode hypothesis --> killing tau candidate." << std::endl;
-	  }
-	  killTau(tau);
-	  return;
-	}
+        // This is the difficult case:
+        // The tau energy needs to be computed for an arbitrary mix of charged and neutral PFCandidates plus reco::Tracks.
+        // We need to make sure not to double-count energy deposited by reco::Track in ECAL and/or HCAL as neutral PFCandidates.
+
+        // Check if we have enough energy in collection of PFNeutralHadrons and PFGammas that are not "used" by tau decay mode object
+        // to balance track momenta:
+        if (nonPFCandTracksSumP < addNeutralsSumP4.energy()) {
+          double scaleFactor = 1. - nonPFCandTracksSumP / addNeutralsSumP4.energy();
+          if (!(scaleFactor >= 0. && scaleFactor <= 1.)) {
+            edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()")
+                << "Failed to compute tau energy --> killing tau candidate !!" << std::endl;
+            killTau(tau);
+            return;
+          }
+          if (verbosity_) {
+            std::cout << "case (2): addNeutralsSumEn > nonPFCandTracksSumP --> adjusting tau momentum." << std::endl;
+          }
+          updateTauP4(tau, scaleFactor, addNeutralsSumP4);
+          return;
+        }
+
+        // Determine which neutral PFCandidates are close to PFChargedHadrons
+        // and have been merged into ChargedHadrons
+        std::vector<reco::CandidatePtr> mergedNeutrals;
+        reco::Candidate::LorentzVector mergedNeutralsSumP4;
+        for (std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
+             chargedHadron != chargedHadrons.end();
+             ++chargedHadron) {
+          if (chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack)) {
+            const std::vector<reco::CandidatePtr>& neutralPFCands = chargedHadron->getNeutralPFCandidates();
+            for (std::vector<reco::CandidatePtr>::const_iterator neutralPFCand = neutralPFCands.begin();
+                 neutralPFCand != neutralPFCands.end();
+                 ++neutralPFCand) {
+              mergedNeutrals.push_back(*neutralPFCand);
+              mergedNeutralsSumP4 += (*neutralPFCand)->p4();
+            }
+          }
+        }
+        if (verbosity_) {
+          std::cout << "mergedNeutralsSumP4: En = " << mergedNeutralsSumP4.energy() << std::endl;
+        }
+
+        // Check if track momenta are balanced by sum of PFNeutralHadrons and PFGammas that are not "used" by tau decay mode object
+        // plus neutral PFCandidates close to PFChargedHadrons:
+        if (nonPFCandTracksSumP < (addNeutralsSumP4.energy() + mergedNeutralsSumP4.energy())) {
+          double scaleFactor = ((addNeutralsSumP4.energy() + mergedNeutralsSumP4.energy()) - nonPFCandTracksSumP) /
+                               mergedNeutralsSumP4.energy();
+          if (!(scaleFactor >= 0. && scaleFactor <= 1.)) {
+            edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()")
+                << "Failed to compute tau energy --> killing tau candidate !!" << std::endl;
+            killTau(tau);
+            return;
+          }
+          reco::Candidate::LorentzVector diffP4;
+          size_t numChargedHadrons = chargedHadrons.size();
+          for (size_t iChargedHadron = 0; iChargedHadron < numChargedHadrons; ++iChargedHadron) {
+            const PFRecoTauChargedHadron& chargedHadron = chargedHadrons[iChargedHadron];
+            if (!chargedHadron.getNeutralPFCandidates().empty()) {
+              PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
+              setChargedHadronP4(chargedHadron_modified, scaleFactor);
+              tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
+              diffP4 += (chargedHadron.p4() - chargedHadron_modified.p4());
+            }
+          }
+          if (verbosity_) {
+            std::cout << "case (3): (addNeutralsSumEn + mergedNeutralsSumEn) > nonPFCandTracksSumP --> adjusting tau "
+                         "momentum."
+                      << std::endl;
+          }
+          updateTauP4(tau, -1., diffP4);
+          return;
+        }
+
+        // Determine energy sum of all PFNeutralHadrons interpreted as ChargedHadrons with missing track
+        unsigned numChargedHadronNeutrals = 0;
+        std::vector<reco::CandidatePtr> chargedHadronNeutrals;
+        reco::Candidate::LorentzVector chargedHadronNeutralsSumP4;
+        for (std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
+             chargedHadron != chargedHadrons.end();
+             ++chargedHadron) {
+          if (chargedHadron->algoIs(PFRecoTauChargedHadron::kPFNeutralHadron)) {
+            ++numChargedHadronNeutrals;
+            chargedHadronNeutrals.push_back(chargedHadron->getChargedPFCandidate());
+            chargedHadronNeutralsSumP4 += chargedHadron->getChargedPFCandidate()->p4();
+          }
+        }
+        if (verbosity_) {
+          std::cout << "chargedHadronNeutralsSumP4: En = " << chargedHadronNeutralsSumP4.energy()
+                    << " (numChargedHadronNeutrals = " << numChargedHadronNeutrals << ")" << std::endl;
+        }
+
+        // Check if sum of PFNeutralHadrons and PFGammas that are not "used" by tau decay mode object
+        // plus neutral PFCandidates close to PFChargedHadrons plus PFNeutralHadrons interpreted as ChargedHadrons with missing track balances track momenta
+        if (nonPFCandTracksSumP <
+            (addNeutralsSumP4.energy() + mergedNeutralsSumP4.energy() + chargedHadronNeutralsSumP4.energy())) {
+          double scaleFactor =
+              ((addNeutralsSumP4.energy() + mergedNeutralsSumP4.energy() + chargedHadronNeutralsSumP4.energy()) -
+               nonPFCandTracksSumP) /
+              chargedHadronNeutralsSumP4.energy();
+          if (!(scaleFactor >= 0. && scaleFactor <= 1.)) {
+            edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()")
+                << "Failed to compute tau energy --> killing tau candidate !!" << std::endl;
+            killTau(tau);
+            return;
+          }
+          reco::Candidate::LorentzVector diffP4;
+          size_t numChargedHadrons = chargedHadrons.size();
+          for (size_t iChargedHadron = 0; iChargedHadron < numChargedHadrons; ++iChargedHadron) {
+            const PFRecoTauChargedHadron& chargedHadron = chargedHadrons[iChargedHadron];
+            if (chargedHadron.algoIs(PFRecoTauChargedHadron::kPFNeutralHadron)) {
+              PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
+              chargedHadron_modified.neutralPFCandidates_.clear();
+              const CandidatePtr& chargedPFCand = chargedHadron.getChargedPFCandidate();
+              double chargedHadronPx_modified = scaleFactor * chargedPFCand->px();
+              double chargedHadronPy_modified = scaleFactor * chargedPFCand->py();
+              double chargedHadronPz_modified = scaleFactor * chargedPFCand->pz();
+              reco::Candidate::LorentzVector chargedHadronP4_modified = compChargedHadronP4fromPxPyPz(
+                  chargedHadronPx_modified, chargedHadronPy_modified, chargedHadronPz_modified);
+              chargedHadron_modified.setP4(chargedHadronP4_modified);
+              tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
+              diffP4 += (chargedHadron.p4() - chargedHadron_modified.p4());
+            }
+          }
+          if (verbosity_) {
+            std::cout << "case (4): (addNeutralsSumEn + mergedNeutralsSumEn + chargedHadronNeutralsSumEn) > "
+                         "nonPFCandTracksSumP --> adjusting momenta of tau and chargedHadrons."
+                      << std::endl;
+          }
+          updateTauP4(tau, -1., diffP4);
+          return;
+        } else {
+          double allTracksSumP = 0.;
+          double allTracksSumPerr2 = 0.;
+          const std::vector<PFRecoTauChargedHadron> chargedHadrons = tau.signalTauChargedHadronCandidatesRestricted();
+          for (std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
+               chargedHadron != chargedHadrons.end();
+               ++chargedHadron) {
+            if (chargedHadron->algoIs(PFRecoTauChargedHadron::kChargedPFCandidate) ||
+                chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack)) {
+              const reco::Track* chargedHadronTrack = getTrackFromChargedHadron(*chargedHadron);
+              if (chargedHadronTrack != nullptr) {
+                allTracksSumP += chargedHadronTrack->p();
+                allTracksSumPerr2 += getTrackPerr2(*chargedHadronTrack);
+              } else {
+                edm::LogInfo("PFRecoTauEnergyAlgorithmPlugin::operator()")
+                    << "PFRecoTauChargedHadron has no associated reco::Track !!";
+                if (verbosity_) {
+                  chargedHadron->print();
+                }
+              }
+            }
+          }
+          if (verbosity_) {
+            std::cout << "allTracksSumP = " << allTracksSumP << " +/- " << sqrt(allTracksSumPerr2) << std::endl;
+          }
+          double allNeutralsSumEn = 0.;
+          const auto& signalCands = tau.signalCands();
+          for (const auto& signalCand : signalCands) {
+            if (verbosity_) {
+              std::cout << "Candidate #" << signalCand.id() << ":" << signalCand.key() << ":"
+                        << " Pt = " << (signalCand)->pt() << ", eta = " << (signalCand)->eta()
+                        << ", phi = " << (signalCand)->phi() << std::endl;
+            }
+            const PFCandidate* pfCand = dynamic_cast<const PFCandidate*>(&*signalCand);
+            if (pfCand) {
+              if (verbosity_) {
+                std::cout << "calorimeter energy:"
+                          << " ECAL = " << (pfCand)->ecalEnergy() << ","
+                          << " HCAL = " << (pfCand)->hcalEnergy() << ","
+                          << " HO = " << (pfCand)->hoEnergy() << std::endl;
+              }
+              // TauReco@MiniAOD: This info is not yet available in miniAOD.
+              if (edm::isFinite(pfCand->ecalEnergy()))
+                allNeutralsSumEn += pfCand->ecalEnergy();
+              if (edm::isFinite(pfCand->hcalEnergy()))
+                allNeutralsSumEn += pfCand->hcalEnergy();
+              if (edm::isFinite(pfCand->hoEnergy()))
+                allNeutralsSumEn += pfCand->hoEnergy();
+            }
+          }
+          allNeutralsSumEn += addNeutralsSumP4.energy();
+          if (allNeutralsSumEn < 0.)
+            allNeutralsSumEn = 0.;
+          if (verbosity_) {
+            std::cout << "allNeutralsSumEn = " << allNeutralsSumEn << std::endl;
+          }
+          if (allNeutralsSumEn > allTracksSumP) {
+            // Adjust momenta of neutral PFCandidates merged into ChargedHadrons
+            size_t numChargedHadrons = chargedHadrons.size();
+            for (size_t iChargedHadron = 0; iChargedHadron < numChargedHadrons; ++iChargedHadron) {
+              const PFRecoTauChargedHadron& chargedHadron = chargedHadrons[iChargedHadron];
+              if (chargedHadron.algoIs(PFRecoTauChargedHadron::kChargedPFCandidate)) {
+                PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
+                chargedHadron_modified.neutralPFCandidates_.clear();
+                chargedHadron_modified.setP4(chargedHadron.getChargedPFCandidate()->p4());
+                if (verbosity_) {
+                  std::cout << "chargedHadron #" << iChargedHadron << ": changing En = " << chargedHadron.energy()
+                            << " to " << chargedHadron_modified.energy() << std::endl;
+                }
+                tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
+              } else if (chargedHadron.algoIs(PFRecoTauChargedHadron::kTrack)) {
+                PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
+                chargedHadron_modified.neutralPFCandidates_.clear();
+                reco::Candidate::LorentzVector chargedHadronP4_modified(0., 0., 0., 0.);
+                const reco::Track* chTrack = getTrackFromChargedHadron(chargedHadron);
+                if (chTrack != nullptr) {
+                  double chargedHadronPx_modified = chTrack->px();
+                  double chargedHadronPy_modified = chTrack->py();
+                  double chargedHadronPz_modified = chTrack->pz();
+                  chargedHadronP4_modified = compChargedHadronP4fromPxPyPz(
+                      chargedHadronPx_modified, chargedHadronPy_modified, chargedHadronPz_modified);
+                } else {
+                  edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()")
+                      << "PFRecoTauChargedHadron has no associated reco::Track !!" << std::endl;
+                  if (verbosity_) {
+                    chargedHadron.print();
+                  }
+                }
+                chargedHadron_modified.setP4(chargedHadronP4_modified);
+                if (verbosity_) {
+                  std::cout << "chargedHadron #" << iChargedHadron << ": changing En = " << chargedHadron.energy()
+                            << " to " << chargedHadron_modified.energy() << std::endl;
+                }
+                tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
+              }
+            }
+            double scaleFactor = allNeutralsSumEn / tau.energy();
+            if (verbosity_) {
+              std::cout << "case (5): allNeutralsSumEn > allTracksSumP --> adjusting momenta of tau and chargedHadrons."
+                        << std::endl;
+            }
+            updateTauP4(tau, scaleFactor - 1., tau.p4());
+            return;
+          } else {
+            if (numChargedHadronNeutrals == 0 && tau.signalPiZeroCandidates().empty()) {
+              // Adjust momenta of ChargedHadrons build from reco::Tracks to match sum of energy deposits in ECAL + HCAL + HO
+              size_t numChargedHadrons = chargedHadrons.size();
+              for (size_t iChargedHadron = 0; iChargedHadron < numChargedHadrons; ++iChargedHadron) {
+                const PFRecoTauChargedHadron& chargedHadron = chargedHadrons[iChargedHadron];
+                if (chargedHadron.algoIs(PFRecoTauChargedHadron::kChargedPFCandidate) ||
+                    chargedHadron.algoIs(PFRecoTauChargedHadron::kTrack)) {
+                  PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
+                  chargedHadron_modified.neutralPFCandidates_.clear();
+                  reco::Candidate::LorentzVector chargedHadronP4_modified(0., 0., 0., 0.);
+                  const reco::Track* chargedHadronTrack = getTrackFromChargedHadron(chargedHadron);
+                  if (chargedHadronTrack != nullptr) {
+                    double trackP = chargedHadronTrack->p();
+                    double trackPerr2 = getTrackPerr2(*chargedHadronTrack);
+                    if (verbosity_) {
+                      std::cout << "trackP = " << trackP << " +/- " << sqrt(trackPerr2) << std::endl;
+                    }
+                    // CV: adjust track momenta such that difference beeen (measuredTrackP - adjustedTrackP)/sigmaMeasuredTrackP is minimal
+                    //    (expression derived using Mathematica)
+                    double trackP_modified = (trackP * (allTracksSumPerr2 - trackPerr2) +
+                                              trackPerr2 * (allNeutralsSumEn - (allTracksSumP - trackP))) /
+                                             allTracksSumPerr2;
+                    // CV: trackP_modified may actually become negative in case sum of energy deposits in ECAL + HCAL + HO is small
+                    //     and one of the tracks has a significantly larger momentum uncertainty than the other tracks.
+                    //     In this case set track momentum to small positive value.
+                    if (trackP_modified < 1.e-1)
+                      trackP_modified = 1.e-1;
+                    if (verbosity_) {
+                      std::cout << "trackP (modified) = " << trackP_modified << std::endl;
+                    }
+                    double scaleFactor = trackP_modified / trackP;
+                    if (!(scaleFactor >= 0. && scaleFactor <= 1.)) {
+                      edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()")
+                          << "Failed to compute tau energy --> killing tau candidate !!" << std::endl;
+                      killTau(tau);
+                      return;
+                    }
+                    double chargedHadronPx_modified = scaleFactor * chargedHadronTrack->px();
+                    double chargedHadronPy_modified = scaleFactor * chargedHadronTrack->py();
+                    double chargedHadronPz_modified = scaleFactor * chargedHadronTrack->pz();
+                    chargedHadronP4_modified = compChargedHadronP4fromPxPyPz(
+                        chargedHadronPx_modified, chargedHadronPy_modified, chargedHadronPz_modified);
+                  } else {
+                    edm::LogInfo("PFRecoTauEnergyAlgorithmPlugin::operator()")
+                        << "PFRecoTauChargedHadron has no associated reco::Track !!";
+                    if (verbosity_) {
+                      chargedHadron.print();
+                    }
+                  }
+                  chargedHadron_modified.setP4(chargedHadronP4_modified);
+                  if (verbosity_) {
+                    std::cout << "chargedHadron #" << iChargedHadron << ": changing En = " << chargedHadron.energy()
+                              << " to " << chargedHadron_modified.energy() << std::endl;
+                  }
+                  tau.signalTauChargedHadronCandidatesRestricted()[iChargedHadron] = chargedHadron_modified;
+                }
+              }
+              double scaleFactor = allNeutralsSumEn / tau.energy();
+              if (verbosity_) {
+                std::cout
+                    << "case (6): allNeutralsSumEn < allTracksSumP --> adjusting momenta of tau and chargedHadrons."
+                    << std::endl;
+              }
+              updateTauP4(tau, scaleFactor - 1., tau.p4());
+              return;
+            } else {
+              // Interpretation of PFNeutralHadrons as ChargedHadrons with missing track and/or reconstruction of extra PiZeros
+              // is not compatible with the fact that sum of reco::Track momenta exceeds sum of energy deposits in ECAL + HCAL + HO:
+              // kill tau candidate (by setting its four-vector to zero)
+              if (verbosity_) {
+                std::cout << "case (7): allNeutralsSumEn < allTracksSumP not compatible with tau decay mode hypothesis "
+                             "--> killing tau candidate."
+                          << std::endl;
+              }
+              killTau(tau);
+              return;
+            }
+          }
+        }
       }
+
+      // CV: You should never come here.
+      if (verbosity_) {
+        std::cout << "undefined case: you should never come here !!" << std::endl;
+      }
+      assert(0);
     }
-  }
 
-  // CV: You should never come here.
-  if ( verbosity_ ) {
-    std::cout << "undefined case: you should never come here !!" << std::endl;
-  }
-  assert(0);
-}
+    void PFRecoTauEnergyAlgorithmPlugin::endEvent() {}
 
-void PFRecoTauEnergyAlgorithmPlugin::endEvent()
-{}
-
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_EDM_PLUGIN(RecoTauModifierPluginFactory, reco::tau::PFRecoTauEnergyAlgorithmPlugin, "PFRecoTauEnergyAlgorithmPlugin");
+DEFINE_EDM_PLUGIN(RecoTauModifierPluginFactory,
+                  reco::tau::PFRecoTauEnergyAlgorithmPlugin,
+                  "PFRecoTauEnergyAlgorithmPlugin");

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauMassPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauMassPlugin.cc
@@ -19,62 +19,59 @@
 
 #include <TMath.h>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class PFRecoTauMassPlugin : public RecoTauModifierPlugin
-{
- public:
+    class PFRecoTauMassPlugin : public RecoTauModifierPlugin {
+    public:
+      explicit PFRecoTauMassPlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+      ~PFRecoTauMassPlugin() override;
+      void operator()(PFTau&) const override;
+      void beginEvent() override;
+      void endEvent() override;
 
-  explicit PFRecoTauMassPlugin(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
-  ~PFRecoTauMassPlugin() override;
-  void operator()(PFTau&) const override;
-  void beginEvent() override;
-  void endEvent() override;
+    private:
+      int verbosity_;
+    };
 
- private:
-  
-  int verbosity_;
-};
-
-  PFRecoTauMassPlugin::PFRecoTauMassPlugin(const edm::ParameterSet& cfg, edm::ConsumesCollector &&iC)
-    : RecoTauModifierPlugin(cfg, std::move(iC))
-{
-  verbosity_ = cfg.getParameter<int>("verbosity");
-}
-
-PFRecoTauMassPlugin::~PFRecoTauMassPlugin()
-{}
-
-void PFRecoTauMassPlugin::beginEvent()
-{}
-
-void PFRecoTauMassPlugin::operator()(PFTau& tau) const
-{
-  if ( verbosity_ ) {
-    std::cout << "<PFRecoTauMassPlugin::operator()>:" << std::endl;
-    std::cout << "tau: Pt = " << tau.pt() << ", eta = " << tau.eta() << ", phi = " << tau.phi() << ", mass = " << tau.mass() << " (decayMode = " << tau.decayMode() << ")" << std::endl;
-  }
-
-  if ( tau.decayMode() == reco::PFTau::kOneProng0PiZero ) {
-    double tauEn = tau.energy();
-    const double chargedPionMass = 0.13957; // GeV
-    if ( tauEn < chargedPionMass ) tauEn = chargedPionMass;
-    double tauP_modified = TMath::Sqrt(tauEn*tauEn - chargedPionMass*chargedPionMass);
-    double tauPx_modified = TMath::Cos(tau.phi())*TMath::Sin(tau.theta())*tauP_modified;
-    double tauPy_modified = TMath::Sin(tau.phi())*TMath::Sin(tau.theta())*tauP_modified;
-    double tauPz_modified = TMath::Cos(tau.theta())*tauP_modified;
-    reco::Candidate::LorentzVector tauP4_modified(tauPx_modified, tauPy_modified, tauPz_modified, tauEn);
-    if ( verbosity_ ) {
-      std::cout << "--> setting tauP4: Pt = " << tauP4_modified.pt() << ", eta = " << tauP4_modified.eta() << ", phi = " << tauP4_modified.phi() << ", mass = " << tauP4_modified.mass() << std::endl;
+    PFRecoTauMassPlugin::PFRecoTauMassPlugin(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+        : RecoTauModifierPlugin(cfg, std::move(iC)) {
+      verbosity_ = cfg.getParameter<int>("verbosity");
     }
-    tau.setP4(tauP4_modified);
-  }
-}
 
-void PFRecoTauMassPlugin::endEvent()
-{}
+    PFRecoTauMassPlugin::~PFRecoTauMassPlugin() {}
 
-}} // end namespace reco::tau
+    void PFRecoTauMassPlugin::beginEvent() {}
+
+    void PFRecoTauMassPlugin::operator()(PFTau& tau) const {
+      if (verbosity_) {
+        std::cout << "<PFRecoTauMassPlugin::operator()>:" << std::endl;
+        std::cout << "tau: Pt = " << tau.pt() << ", eta = " << tau.eta() << ", phi = " << tau.phi()
+                  << ", mass = " << tau.mass() << " (decayMode = " << tau.decayMode() << ")" << std::endl;
+      }
+
+      if (tau.decayMode() == reco::PFTau::kOneProng0PiZero) {
+        double tauEn = tau.energy();
+        const double chargedPionMass = 0.13957;  // GeV
+        if (tauEn < chargedPionMass)
+          tauEn = chargedPionMass;
+        double tauP_modified = TMath::Sqrt(tauEn * tauEn - chargedPionMass * chargedPionMass);
+        double tauPx_modified = TMath::Cos(tau.phi()) * TMath::Sin(tau.theta()) * tauP_modified;
+        double tauPy_modified = TMath::Sin(tau.phi()) * TMath::Sin(tau.theta()) * tauP_modified;
+        double tauPz_modified = TMath::Cos(tau.theta()) * tauP_modified;
+        reco::Candidate::LorentzVector tauP4_modified(tauPx_modified, tauPy_modified, tauPz_modified, tauEn);
+        if (verbosity_) {
+          std::cout << "--> setting tauP4: Pt = " << tauP4_modified.pt() << ", eta = " << tauP4_modified.eta()
+                    << ", phi = " << tauP4_modified.phi() << ", mass = " << tauP4_modified.mass() << std::endl;
+        }
+        tau.setP4(tauP4_modified);
+      }
+    }
+
+    void PFRecoTauMassPlugin::endEvent() {}
+
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
@@ -36,12 +36,13 @@ using namespace edm;
 using namespace std;
 
 class PFRecoTauTagInfoProducer : public edm::global::EDProducer<> {
- public:
+public:
   explicit PFRecoTauTagInfoProducer(const edm::ParameterSet& iConfig);
   ~PFRecoTauTagInfoProducer() override;
-  void produce(edm::StreamID, edm::Event&,const edm::EventSetup&) const override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
- private:
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
   std::unique_ptr<const PFRecoTauTagInfoAlgorithm> PFRecoTauTagInfoAlgo_;
   edm::InputTag PFCandidateProducer_;
   edm::InputTag PFJetTracksAssociatorProducer_;
@@ -55,64 +56,64 @@ class PFRecoTauTagInfoProducer : public edm::global::EDProducer<> {
   edm::EDGetTokenT<VertexCollection> PV_token;
 };
 
-PFRecoTauTagInfoProducer::PFRecoTauTagInfoProducer(const edm::ParameterSet& iConfig){
-
-  PFCandidateProducer_                = iConfig.getParameter<edm::InputTag>("PFCandidateProducer");
-  PFJetTracksAssociatorProducer_      = iConfig.getParameter<edm::InputTag>("PFJetTracksAssociatorProducer");
-  PVProducer_                         = iConfig.getParameter<edm::InputTag>("PVProducer");
-  smearedPVsigmaX_                    = iConfig.getParameter<double>("smearedPVsigmaX");
-  smearedPVsigmaY_                    = iConfig.getParameter<double>("smearedPVsigmaY");
-  smearedPVsigmaZ_                    = iConfig.getParameter<double>("smearedPVsigmaZ");	
-  PFRecoTauTagInfoAlgo_.reset( new PFRecoTauTagInfoAlgorithm(iConfig) );
+PFRecoTauTagInfoProducer::PFRecoTauTagInfoProducer(const edm::ParameterSet& iConfig) {
+  PFCandidateProducer_ = iConfig.getParameter<edm::InputTag>("PFCandidateProducer");
+  PFJetTracksAssociatorProducer_ = iConfig.getParameter<edm::InputTag>("PFJetTracksAssociatorProducer");
+  PVProducer_ = iConfig.getParameter<edm::InputTag>("PVProducer");
+  smearedPVsigmaX_ = iConfig.getParameter<double>("smearedPVsigmaX");
+  smearedPVsigmaY_ = iConfig.getParameter<double>("smearedPVsigmaY");
+  smearedPVsigmaZ_ = iConfig.getParameter<double>("smearedPVsigmaZ");
+  PFRecoTauTagInfoAlgo_.reset(new PFRecoTauTagInfoAlgorithm(iConfig));
   PFCandidate_token = consumes<PFCandidateCollection>(PFCandidateProducer_);
   PFJetTracksAssociator_token = consumes<JetTracksAssociationCollection>(PFJetTracksAssociatorProducer_);
   PV_token = consumes<VertexCollection>(PVProducer_);
-  produces<PFTauTagInfoCollection>();      
+  produces<PFTauTagInfoCollection>();
 }
-PFRecoTauTagInfoProducer::~PFRecoTauTagInfoProducer(){
-}
+PFRecoTauTagInfoProducer::~PFRecoTauTagInfoProducer() {}
 
 void PFRecoTauTagInfoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   edm::Handle<JetTracksAssociationCollection> thePFJetTracksAssociatorCollection;
-  iEvent.getByToken(PFJetTracksAssociator_token,thePFJetTracksAssociatorCollection);
+  iEvent.getByToken(PFJetTracksAssociator_token, thePFJetTracksAssociatorCollection);
   // *** access the PFCandidateCollection in the event in order to retrieve the PFCandidateRefVector which constitutes each PFJet
   edm::Handle<PFCandidateCollection> thePFCandidateCollection;
-  iEvent.getByToken(PFCandidate_token,thePFCandidateCollection);
+  iEvent.getByToken(PFCandidate_token, thePFCandidateCollection);
   vector<CandidatePtr> thePFCandsInTheEvent;
-  for(unsigned int i_PFCand=0;i_PFCand!=thePFCandidateCollection->size();i_PFCand++) { 
-        thePFCandsInTheEvent.push_back(CandidatePtr(thePFCandidateCollection,i_PFCand));
+  for (unsigned int i_PFCand = 0; i_PFCand != thePFCandidateCollection->size(); i_PFCand++) {
+    thePFCandsInTheEvent.push_back(CandidatePtr(thePFCandidateCollection, i_PFCand));
   }
   // ***
   // query a rec/sim PV
   edm::Handle<VertexCollection> thePVs;
-  iEvent.getByToken(PV_token,thePVs);
-  const VertexCollection vertCollection=*(thePVs.product());
-  math::XYZPoint V(0,0,-1000.);
+  iEvent.getByToken(PV_token, thePVs);
+  const VertexCollection vertCollection = *(thePVs.product());
+  math::XYZPoint V(0, 0, -1000.);
 
   Vertex thePV;
-  if(!vertCollection.empty()) thePV =*(vertCollection.begin());
-else{
+  if (!vertCollection.empty())
+    thePV = *(vertCollection.begin());
+  else {
     Vertex::Error SimPVError;
-    SimPVError(0,0)=15.*15.;
-    SimPVError(1,1)=15.*15.;
-    SimPVError(2,2)=15.*15.;
-    Vertex::Point SimPVPoint(0.,0.,-1000.);
-    thePV=Vertex(SimPVPoint,SimPVError,1,1,1);    
+    SimPVError(0, 0) = 15. * 15.;
+    SimPVError(1, 1) = 15. * 15.;
+    SimPVError(2, 2) = 15. * 15.;
+    Vertex::Point SimPVPoint(0., 0., -1000.);
+    thePV = Vertex(SimPVPoint, SimPVError, 1, 1, 1);
   }
-  
-  auto resultExt = std::make_unique<PFTauTagInfoCollection>();  
-  for(JetTracksAssociationCollection::const_iterator iAssoc=thePFJetTracksAssociatorCollection->begin();iAssoc!=thePFJetTracksAssociatorCollection->end();iAssoc++){
-    PFTauTagInfo myPFTauTagInfo=PFRecoTauTagInfoAlgo_->buildPFTauTagInfo(JetBaseRef((*iAssoc).first),thePFCandsInTheEvent,(*iAssoc).second,thePV);
+
+  auto resultExt = std::make_unique<PFTauTagInfoCollection>();
+  for (JetTracksAssociationCollection::const_iterator iAssoc = thePFJetTracksAssociatorCollection->begin();
+       iAssoc != thePFJetTracksAssociatorCollection->end();
+       iAssoc++) {
+    PFTauTagInfo myPFTauTagInfo = PFRecoTauTagInfoAlgo_->buildPFTauTagInfo(
+        JetBaseRef((*iAssoc).first), thePFCandsInTheEvent, (*iAssoc).second, thePV);
     resultExt->push_back(myPFTauTagInfo);
   }
-  
 
   //  OrphanHandle<PFTauTagInfoCollection> myPFTauTagInfoCollection=iEvent.put(std::move(resultExt));
   iEvent.put(std::move(resultExt));
 }
 
-void
-PFRecoTauTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecoTauTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   {
     // pfRecoTauTagInfoProducerInsideOut
     edm::ParameterSetDescription desc;

--- a/RecoTauTag/RecoTau/plugins/PFTauDiscriminatorLogicalAndProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauDiscriminatorLogicalAndProducer.cc
@@ -19,32 +19,30 @@
 using namespace reco;
 
 class PFTauDiscriminatorLogicalAndProducer : public PFTauDiscriminationProducerBase {
-   public:
-      explicit PFTauDiscriminatorLogicalAndProducer(const edm::ParameterSet&);
-      ~PFTauDiscriminatorLogicalAndProducer() override{};
-      double discriminate(const PFTauRef& pfTau) const override;
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-   private:
-      double passResult_;
+public:
+  explicit PFTauDiscriminatorLogicalAndProducer(const edm::ParameterSet&);
+  ~PFTauDiscriminatorLogicalAndProducer() override{};
+  double discriminate(const PFTauRef& pfTau) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  double passResult_;
 };
 
-PFTauDiscriminatorLogicalAndProducer::PFTauDiscriminatorLogicalAndProducer(const edm::ParameterSet& iConfig):PFTauDiscriminationProducerBase(iConfig)
-{
-   passResult_               = iConfig.getParameter<double>("PassValue");
-   prediscriminantFailValue_ = iConfig.getParameter<double>("FailValue"); //defined in base class
+PFTauDiscriminatorLogicalAndProducer::PFTauDiscriminatorLogicalAndProducer(const edm::ParameterSet& iConfig)
+    : PFTauDiscriminationProducerBase(iConfig) {
+  passResult_ = iConfig.getParameter<double>("PassValue");
+  prediscriminantFailValue_ = iConfig.getParameter<double>("FailValue");  //defined in base class
 }
 
-double
-PFTauDiscriminatorLogicalAndProducer::discriminate(const PFTauRef& pfTau) const 
-{
-   // if this function is called on a tau, it is has passed (in the base class)
-   // the set of prediscriminants, using the prescribed boolean operation.  thus 
-   // we only need to return TRUE
-   return passResult_;
+double PFTauDiscriminatorLogicalAndProducer::discriminate(const PFTauRef& pfTau) const {
+  // if this function is called on a tau, it is has passed (in the base class)
+  // the set of prediscriminants, using the prescribed boolean operation.  thus
+  // we only need to return TRUE
+  return passResult_;
 }
 
-void
-PFTauDiscriminatorLogicalAndProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFTauDiscriminatorLogicalAndProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // PFTauDiscriminatorLogicalAndProducer
   edm::ParameterSetDescription desc;
 

--- a/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
@@ -5,92 +5,91 @@
 
 /// MiniAOD implementation of the PFTauPrimaryVertexProducer plugin
 class PFTauMiniAODPrimaryVertexProducer final : public PFTauPrimaryVertexProducerBase {
-
- public:
-  explicit PFTauMiniAODPrimaryVertexProducer(const edm::ParameterSet& iConfig);
+public:
+  explicit PFTauMiniAODPrimaryVertexProducer(const edm::ParameterSet &iConfig);
   ~PFTauMiniAODPrimaryVertexProducer() override;
 
-  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  void beginEvent(const edm::Event &, const edm::EventSetup &) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
- protected:
-  void nonTauTracksInPV(const reco::VertexRef&,
-			const std::vector<edm::Ptr<reco::TrackBase> >&,
-			std::vector<const reco::Track*>&) override;
+protected:
+  void nonTauTracksInPV(const reco::VertexRef &,
+                        const std::vector<edm::Ptr<reco::TrackBase> > &,
+                        std::vector<const reco::Track *> &) override;
 
- private:
-  void nonTauTracksInPVFromPackedCands(const size_t&,
-				       const pat::PackedCandidateCollection&,
-				       const std::vector<edm::Ptr<reco::TrackBase> >&,
-				       std::vector<const reco::Track*> &);
+private:
+  void nonTauTracksInPVFromPackedCands(const size_t &,
+                                       const pat::PackedCandidateCollection &,
+                                       const std::vector<edm::Ptr<reco::TrackBase> > &,
+                                       std::vector<const reco::Track *> &);
 
   edm::EDGetTokenT<pat::PackedCandidateCollection> packedCandsToken_, lostCandsToken_;
   edm::Handle<pat::PackedCandidateCollection> packedCands_, lostCands_;
-
 };
 
-PFTauMiniAODPrimaryVertexProducer::PFTauMiniAODPrimaryVertexProducer(const edm::ParameterSet& iConfig):
-  PFTauPrimaryVertexProducerBase::PFTauPrimaryVertexProducerBase(iConfig),
-  packedCandsToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedCandidatesTag"))),
-  lostCandsToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("lostCandidatesTag"))) {}
+PFTauMiniAODPrimaryVertexProducer::PFTauMiniAODPrimaryVertexProducer(const edm::ParameterSet &iConfig)
+    : PFTauPrimaryVertexProducerBase::PFTauPrimaryVertexProducerBase(iConfig),
+      packedCandsToken_(
+          consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedCandidatesTag"))),
+      lostCandsToken_(
+          consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("lostCandidatesTag"))) {}
 
-PFTauMiniAODPrimaryVertexProducer::~PFTauMiniAODPrimaryVertexProducer(){}
+PFTauMiniAODPrimaryVertexProducer::~PFTauMiniAODPrimaryVertexProducer() {}
 
-void PFTauMiniAODPrimaryVertexProducer::beginEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup){
-
+void PFTauMiniAODPrimaryVertexProducer::beginEvent(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   //Get candidate collections
   iEvent.getByToken(packedCandsToken_, packedCands_);
   iEvent.getByToken(lostCandsToken_, lostCands_);
 }
 
 void PFTauMiniAODPrimaryVertexProducer::nonTauTracksInPV(const reco::VertexRef &thePVRef,
-							 const std::vector<edm::Ptr<reco::TrackBase> > &tauTracks,
-							 std::vector<const reco::Track*> &nonTauTracks){
-
+                                                         const std::vector<edm::Ptr<reco::TrackBase> > &tauTracks,
+                                                         std::vector<const reco::Track *> &nonTauTracks) {
   //Find non-tau tracks associated to thePV
   //PackedCandidates first...
-  if(packedCands_.isValid()) {
-    nonTauTracksInPVFromPackedCands(thePVRef.key(),*packedCands_,tauTracks,nonTauTracks);
+  if (packedCands_.isValid()) {
+    nonTauTracksInPVFromPackedCands(thePVRef.key(), *packedCands_, tauTracks, nonTauTracks);
   }
   //then lostCandidates
-  if(lostCands_.isValid()) {
-    nonTauTracksInPVFromPackedCands(thePVRef.key(),*lostCands_,tauTracks,nonTauTracks);
+  if (lostCands_.isValid()) {
+    nonTauTracksInPVFromPackedCands(thePVRef.key(), *lostCands_, tauTracks, nonTauTracks);
   }
 }
 
-void PFTauMiniAODPrimaryVertexProducer::nonTauTracksInPVFromPackedCands(const size_t &thePVkey,
-									const pat::PackedCandidateCollection &cands,
-									const std::vector<edm::Ptr<reco::TrackBase> > &tauTracks,
-									std::vector<const reco::Track*> &nonTauTracks){
-
+void PFTauMiniAODPrimaryVertexProducer::nonTauTracksInPVFromPackedCands(
+    const size_t &thePVkey,
+    const pat::PackedCandidateCollection &cands,
+    const std::vector<edm::Ptr<reco::TrackBase> > &tauTracks,
+    std::vector<const reco::Track *> &nonTauTracks) {
   //Find candidates/tracks associated to thePV
-  for(const auto& cand: cands){
-    if(cand.vertexRef().isNull()) continue;
+  for (const auto &cand : cands) {
+    if (cand.vertexRef().isNull())
+      continue;
     int quality = cand.pvAssociationQuality();
-    if(cand.vertexRef().key()!=thePVkey ||
-       (quality!=pat::PackedCandidate::UsedInFitTight &&
-	quality!=pat::PackedCandidate::UsedInFitLoose)) continue;
+    if (cand.vertexRef().key() != thePVkey ||
+        (quality != pat::PackedCandidate::UsedInFitTight && quality != pat::PackedCandidate::UsedInFitLoose))
+      continue;
     const reco::Track *track = cand.bestTrack();
-    if(track == nullptr) continue;
+    if (track == nullptr)
+      continue;
     //Remove signal (tau) tracks
     //MB: Only deltaR deltaPt overlap removal possible (?)
-    //MB: It should be fine as pat objects stores same track info with same presision 
+    //MB: It should be fine as pat objects stores same track info with same presision
     bool matched = false;
-    for(const auto& tauTrack: tauTracks){
-      if(std::abs(tauTrack->eta()-track->eta())<0.005
-	 && std::abs(deltaPhi(tauTrack->phi(),track->phi()))<0.005
-	 && std::abs(tauTrack->pt()/track->pt()-1.)<0.005
-	 ){
-	matched = true;
-	break;
+    for (const auto &tauTrack : tauTracks) {
+      if (std::abs(tauTrack->eta() - track->eta()) < 0.005 &&
+          std::abs(deltaPhi(tauTrack->phi(), track->phi())) < 0.005 &&
+          std::abs(tauTrack->pt() / track->pt() - 1.) < 0.005) {
+        matched = true;
+        break;
       }
     }
-    if( !matched ) nonTauTracks.push_back(track);
+    if (!matched)
+      nonTauTracks.push_back(track);
   }
 }
 
-void
-PFTauMiniAODPrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFTauMiniAODPrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   auto desc = PFTauPrimaryVertexProducerBase::getDescriptionsBase();
   desc.add<edm::InputTag>("lostCandidatesTag", edm::InputTag("lostTracks"));
   desc.add<edm::InputTag>("packedCandidatesTag", edm::InputTag("packedPFCandidates"));

--- a/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
@@ -3,45 +3,42 @@
 
 /// RECO/AOD implementation of the PFTauPrimaryVertexProducer plugin
 class PFTauPrimaryVertexProducer final : public PFTauPrimaryVertexProducerBase {
-
- public:
+public:
   explicit PFTauPrimaryVertexProducer(const edm::ParameterSet& iConfig);
   ~PFTauPrimaryVertexProducer() override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- protected:
+protected:
   void nonTauTracksInPV(const reco::VertexRef&,
-			const std::vector<edm::Ptr<reco::TrackBase> >&,
-			std::vector<const reco::Track*>&) override;
-
+                        const std::vector<edm::Ptr<reco::TrackBase> >&,
+                        std::vector<const reco::Track*>&) override;
 };
 
+PFTauPrimaryVertexProducer::PFTauPrimaryVertexProducer(const edm::ParameterSet& iConfig)
+    : PFTauPrimaryVertexProducerBase::PFTauPrimaryVertexProducerBase(iConfig) {}
 
-PFTauPrimaryVertexProducer::PFTauPrimaryVertexProducer(const edm::ParameterSet& iConfig): 
-  PFTauPrimaryVertexProducerBase::PFTauPrimaryVertexProducerBase(iConfig) {}
+PFTauPrimaryVertexProducer::~PFTauPrimaryVertexProducer() {}
 
-PFTauPrimaryVertexProducer::~PFTauPrimaryVertexProducer(){}
-
-void PFTauPrimaryVertexProducer::nonTauTracksInPV(const reco::VertexRef &thePVRef,
-						  const std::vector<edm::Ptr<reco::TrackBase> > &tauTracks,
-						  std::vector<const reco::Track*> &nonTauTracks){
-
+void PFTauPrimaryVertexProducer::nonTauTracksInPV(const reco::VertexRef& thePVRef,
+                                                  const std::vector<edm::Ptr<reco::TrackBase> >& tauTracks,
+                                                  std::vector<const reco::Track*>& nonTauTracks) {
   //Find non-tau tracks associated to thePV
-  for(reco::Vertex::trackRef_iterator vtxTrkRef=thePVRef->tracks_begin();vtxTrkRef!=thePVRef->tracks_end();vtxTrkRef++){
+  for (reco::Vertex::trackRef_iterator vtxTrkRef = thePVRef->tracks_begin(); vtxTrkRef != thePVRef->tracks_end();
+       vtxTrkRef++) {
     bool matched = false;
-    for(const auto& tauTrack : tauTracks){
+    for (const auto& tauTrack : tauTracks) {
       if (tauTrack.id() == vtxTrkRef->id() && tauTrack.key() == vtxTrkRef->key()) {
-	matched = true;
-	break;
+        matched = true;
+        break;
       }
     }
-    if( !matched ) nonTauTracks.push_back((*vtxTrkRef).get());
+    if (!matched)
+      nonTauTracks.push_back((*vtxTrkRef).get());
   }
 }
 
-void
-PFTauPrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFTauPrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   auto desc = PFTauPrimaryVertexProducerBase::getDescriptionsBase();
   descriptions.add("pfTauPrimaryVertexProducer", desc);
 }

--- a/RecoTauTag/RecoTau/plugins/PFTauSelector.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauSelector.cc
@@ -7,4 +7,3 @@
 typedef ObjectSelectorStream<PFTauSelectorDefinition> PFTauSelector;
 
 DEFINE_FWK_MODULE(PFTauSelector);
-

--- a/RecoTauTag/RecoTau/plugins/PFTauSelectorDefinition.h
+++ b/RecoTauTag/RecoTau/plugins/PFTauSelectorDefinition.h
@@ -14,10 +14,9 @@
 #include <iostream>
 
 struct PFTauSelectorDefinition {
-
   typedef reco::PFTauCollection collection;
-  typedef edm::Handle< collection > HandleToCollection;
-  typedef std::vector< const reco::PFTau *> container;
+  typedef edm::Handle<collection> HandleToCollection;
+  typedef std::vector<const reco::PFTau*> container;
   typedef container::const_iterator const_iterator;
 
   struct DiscCutPair {
@@ -27,11 +26,10 @@ struct PFTauSelectorDefinition {
   };
   typedef std::vector<DiscCutPair> DiscCutPairVec;
 
-  PFTauSelectorDefinition (const edm::ParameterSet &cfg, edm::ConsumesCollector && iC) {
-    std::vector<edm::ParameterSet> discriminators =
-      cfg.getParameter<std::vector<edm::ParameterSet> >("discriminators");
+  PFTauSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) {
+    std::vector<edm::ParameterSet> discriminators = cfg.getParameter<std::vector<edm::ParameterSet> >("discriminators");
     // Build each of our cuts
-    for(auto const& pset : discriminators) {
+    for (auto const& pset : discriminators) {
       DiscCutPair newCut;
       newCut.inputToken = iC.consumes<reco::PFTauDiscriminator>(pset.getParameter<edm::InputTag>("discriminator"));
       newCut.cut = pset.getParameter<double>("selectionCut");
@@ -40,26 +38,23 @@ struct PFTauSelectorDefinition {
 
     // Build a string cut if desired
     if (cfg.exists("cut")) {
-      cut_.reset(new StringCutObjectSelector<reco::PFTau>(
-            cfg.getParameter<std::string>( "cut" )));
+      cut_.reset(new StringCutObjectSelector<reco::PFTau>(cfg.getParameter<std::string>("cut")));
     }
   }
 
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
 
-  void select(const HandleToCollection & hc, const edm::Event & e,
-      const edm::EventSetup& s) {
+  void select(const HandleToCollection& hc, const edm::Event& e, const edm::EventSetup& s) {
     selected_.clear();
 
     if (!hc.isValid()) {
       throw cms::Exception("PFTauSelectorBadHandle")
-        << "an invalid PFTau handle with ProductID"
-        << hc.id() << " passed to PFTauSelector.";
+          << "an invalid PFTau handle with ProductID" << hc.id() << " passed to PFTauSelector.";
     }
 
     // Load each discriminator
-    for(auto& disc : discriminators_) {
+    for (auto& disc : discriminators_) {
       e.getByToken(disc.inputToken, disc.handle);
     }
 
@@ -68,7 +63,7 @@ struct PFTauSelectorDefinition {
       bool passed = true;
       reco::PFTauRef tau(hc, iTau);
       // Check if it passed all the discrimiantors
-      for(auto const& disc : discriminators_) {
+      for (auto const& disc : discriminators_) {
         // Check this discriminator passes
         if (!((*disc.handle)[tau] > disc.cut)) {
           passed = false;
@@ -83,16 +78,14 @@ struct PFTauSelectorDefinition {
       if (passed)
         selected_.push_back(tau.get());
     }
-  } // end select()
+  }  // end select()
 
   size_t size() const { return selected_.size(); }
 
- private:
+private:
   container selected_;
   DiscCutPairVec discriminators_;
   std::auto_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
-
 };
 
 #endif
-

--- a/RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc
@@ -8,7 +8,6 @@
  * Thanks goes to Christian Veelken and Evan Klose Friis for their help and suggestions.
  */
 
-
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -53,136 +52,145 @@ using namespace edm;
 using namespace std;
 
 class PFTauTransverseImpactParameters : public edm::stream::EDProducer<> {
- public:
-  enum CMSSWPerigee{aCurv=0,aTheta,aPhi,aTip,aLip};
+public:
+  enum CMSSWPerigee { aCurv = 0, aTheta, aPhi, aTip, aLip };
   explicit PFTauTransverseImpactParameters(const edm::ParameterSet& iConfig);
   ~PFTauTransverseImpactParameters() override;
-  void produce(edm::Event&,const edm::EventSetup&) override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
-  edm::EDGetTokenT<std::vector<reco::PFTau> > PFTauToken_;
-  edm::EDGetTokenT<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef> > > PFTauPVAToken_;
-  edm::EDGetTokenT<edm::AssociationVector<PFTauRefProd,std::vector<std::vector<reco::VertexRef> > > > PFTauSVAToken_;
+private:
+  edm::EDGetTokenT<std::vector<reco::PFTau>> PFTauToken_;
+  edm::EDGetTokenT<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef>>> PFTauPVAToken_;
+  edm::EDGetTokenT<edm::AssociationVector<PFTauRefProd, std::vector<std::vector<reco::VertexRef>>>> PFTauSVAToken_;
   bool useFullCalculation_;
 };
 
-PFTauTransverseImpactParameters::PFTauTransverseImpactParameters(const edm::ParameterSet& iConfig):
-  PFTauToken_(consumes<std::vector<reco::PFTau> >(iConfig.getParameter<edm::InputTag>("PFTauTag"))),
-  PFTauPVAToken_(consumes<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef> > >(iConfig.getParameter<edm::InputTag>("PFTauPVATag"))),
-  PFTauSVAToken_(consumes<edm::AssociationVector<PFTauRefProd,std::vector<std::vector<reco::VertexRef> > > >(iConfig.getParameter<edm::InputTag>("PFTauSVATag"))),
-  useFullCalculation_(iConfig.getParameter<bool>("useFullCalculation"))
-{
-  produces<edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> > >(); 
+PFTauTransverseImpactParameters::PFTauTransverseImpactParameters(const edm::ParameterSet& iConfig)
+    : PFTauToken_(consumes<std::vector<reco::PFTau>>(iConfig.getParameter<edm::InputTag>("PFTauTag"))),
+      PFTauPVAToken_(consumes<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef>>>(
+          iConfig.getParameter<edm::InputTag>("PFTauPVATag"))),
+      PFTauSVAToken_(consumes<edm::AssociationVector<PFTauRefProd, std::vector<std::vector<reco::VertexRef>>>>(
+          iConfig.getParameter<edm::InputTag>("PFTauSVATag"))),
+      useFullCalculation_(iConfig.getParameter<bool>("useFullCalculation")) {
+  produces<edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>();
   produces<PFTauTransverseImpactParameterCollection>("PFTauTIP");
 }
 
-PFTauTransverseImpactParameters::~PFTauTransverseImpactParameters(){
-
-}
+PFTauTransverseImpactParameters::~PFTauTransverseImpactParameters() {}
 
 namespace {
-  inline const reco::Track* getTrack(const Candidate& cand)
-  {
+  inline const reco::Track* getTrack(const Candidate& cand) {
     const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
     if (pfCandPtr != nullptr) {
-      if      ( pfCandPtr->trackRef().isNonnull()    ) return pfCandPtr->trackRef().get();
-      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return pfCandPtr->gsfTrackRef().get();
-      else return nullptr;
+      if (pfCandPtr->trackRef().isNonnull())
+        return pfCandPtr->trackRef().get();
+      else if (pfCandPtr->gsfTrackRef().isNonnull())
+        return pfCandPtr->gsfTrackRef().get();
+      else
+        return nullptr;
     }
     const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
     if (packedCand != nullptr && packedCand->hasTrackDetails())
-        return &packedCand->pseudoTrack();
+      return &packedCand->pseudoTrack();
 
-   return nullptr;
+    return nullptr;
   }
-}
+}  // namespace
 
-void PFTauTransverseImpactParameters::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
+void PFTauTransverseImpactParameters::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Obtain Collections
   edm::ESHandle<TransientTrackBuilder> transTrackBuilder;
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",transTrackBuilder);
-  
-  edm::Handle<std::vector<reco::PFTau> > Tau;
-  iEvent.getByToken(PFTauToken_,Tau);
+  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", transTrackBuilder);
 
-  edm::Handle<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef> > > PFTauPVA;
-  iEvent.getByToken(PFTauPVAToken_,PFTauPVA);
+  edm::Handle<std::vector<reco::PFTau>> Tau;
+  iEvent.getByToken(PFTauToken_, Tau);
 
-  edm::Handle<edm::AssociationVector<PFTauRefProd,std::vector<std::vector<reco::VertexRef> > > > PFTauSVA;
-  iEvent.getByToken(PFTauSVAToken_,PFTauSVA);
+  edm::Handle<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef>>> PFTauPVA;
+  iEvent.getByToken(PFTauPVAToken_, PFTauPVA);
+
+  edm::Handle<edm::AssociationVector<PFTauRefProd, std::vector<std::vector<reco::VertexRef>>>> PFTauSVA;
+  iEvent.getByToken(PFTauSVAToken_, PFTauSVA);
 
   // Set Association Map
-  auto AVPFTauTIP = std::make_unique< edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>(PFTauRefProd(Tau));
+  auto AVPFTauTIP =
+      std::make_unique<edm::AssociationVector<PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>(
+          PFTauRefProd(Tau));
   auto TIPCollection_out = std::make_unique<PFTauTransverseImpactParameterCollection>();
-  reco::PFTauTransverseImpactParameterRefProd TIPRefProd_out = iEvent.getRefBeforePut<reco::PFTauTransverseImpactParameterCollection>("PFTauTIP");
+  reco::PFTauTransverseImpactParameterRefProd TIPRefProd_out =
+      iEvent.getRefBeforePut<reco::PFTauTransverseImpactParameterCollection>("PFTauTIP");
 
   // For each Tau Run Algorithim
-  if(Tau.isValid()) {
-    for(reco::PFTauCollection::size_type iPFTau = 0; iPFTau < Tau->size(); iPFTau++) {
+  if (Tau.isValid()) {
+    for (reco::PFTauCollection::size_type iPFTau = 0; iPFTau < Tau->size(); iPFTau++) {
       reco::PFTauRef RefPFTau(Tau, iPFTau);
-      const reco::VertexRef PV=PFTauPVA->value(RefPFTau.key());
-      const std::vector<reco::VertexRef> SV=PFTauSVA->value(RefPFTau.key());
+      const reco::VertexRef PV = PFTauPVA->value(RefPFTau.key());
+      const std::vector<reco::VertexRef> SV = PFTauSVA->value(RefPFTau.key());
       double dxy(-999), dxy_err(-999);
-      reco::Vertex::Point poca(0,0,0);
+      reco::Vertex::Point poca(0, 0, 0);
       double ip3d(-999), ip3d_err(-999);
-      reco::Vertex::Point ip3d_poca(0,0,0);
-      if(RefPFTau->leadChargedHadrCand().isNonnull()){
-	const reco::Track* track = getTrack(*RefPFTau->leadChargedHadrCand());
-	if(track != nullptr){
-	  if(useFullCalculation_){
-	    reco::TransientTrack transTrk=transTrackBuilder->build(*track);
-	    GlobalVector direction(RefPFTau->p4().px(), RefPFTau->p4().py(), RefPFTau->p4().pz()); //To compute sign of IP
-	    std::pair<bool,Measurement1D> signed_IP2D = IPTools::signedTransverseImpactParameter(transTrk, direction, (*PV));
-	    dxy=signed_IP2D.second.value();
-	    dxy_err=signed_IP2D.second.error();
-	    std::pair<bool,Measurement1D> signed_IP3D = IPTools::signedImpactParameter3D(transTrk, direction, (*PV));
-	    ip3d=signed_IP3D.second.value();
-	    ip3d_err=signed_IP3D.second.error();
-	    TransverseImpactPointExtrapolator extrapolator(transTrk.field());
-	    GlobalPoint pos  = extrapolator.extrapolate(transTrk.impactPointState(), RecoVertex::convertPos(PV->position())).globalPosition();
-	    poca=reco::Vertex::Point(pos.x(),pos.y(),pos.z());
-	    AnalyticalImpactPointExtrapolator extrapolator3D(transTrk.field());
-	    GlobalPoint pos3d = extrapolator3D.extrapolate(transTrk.impactPointState(),RecoVertex::convertPos(PV->position())).globalPosition();
-	    ip3d_poca=reco::Vertex::Point(pos3d.x(),pos3d.y(),pos3d.z());
-	  }
-	  else{
-	    dxy_err=track->d0Error();
-	    dxy=track->dxy(PV->position());
-	    ip3d_err=track->dzError(); //store dz, ip3d not available
-	    ip3d=track->dz(PV->position()); //store dz, ip3d not available
-	  }
-	}
+      reco::Vertex::Point ip3d_poca(0, 0, 0);
+      if (RefPFTau->leadChargedHadrCand().isNonnull()) {
+        const reco::Track* track = getTrack(*RefPFTau->leadChargedHadrCand());
+        if (track != nullptr) {
+          if (useFullCalculation_) {
+            reco::TransientTrack transTrk = transTrackBuilder->build(*track);
+            GlobalVector direction(
+                RefPFTau->p4().px(), RefPFTau->p4().py(), RefPFTau->p4().pz());  //To compute sign of IP
+            std::pair<bool, Measurement1D> signed_IP2D =
+                IPTools::signedTransverseImpactParameter(transTrk, direction, (*PV));
+            dxy = signed_IP2D.second.value();
+            dxy_err = signed_IP2D.second.error();
+            std::pair<bool, Measurement1D> signed_IP3D = IPTools::signedImpactParameter3D(transTrk, direction, (*PV));
+            ip3d = signed_IP3D.second.value();
+            ip3d_err = signed_IP3D.second.error();
+            TransverseImpactPointExtrapolator extrapolator(transTrk.field());
+            GlobalPoint pos =
+                extrapolator.extrapolate(transTrk.impactPointState(), RecoVertex::convertPos(PV->position()))
+                    .globalPosition();
+            poca = reco::Vertex::Point(pos.x(), pos.y(), pos.z());
+            AnalyticalImpactPointExtrapolator extrapolator3D(transTrk.field());
+            GlobalPoint pos3d =
+                extrapolator3D.extrapolate(transTrk.impactPointState(), RecoVertex::convertPos(PV->position()))
+                    .globalPosition();
+            ip3d_poca = reco::Vertex::Point(pos3d.x(), pos3d.y(), pos3d.z());
+          } else {
+            dxy_err = track->d0Error();
+            dxy = track->dxy(PV->position());
+            ip3d_err = track->dzError();       //store dz, ip3d not available
+            ip3d = track->dz(PV->position());  //store dz, ip3d not available
+          }
+        }
       }
-      if(!SV.empty()){
-	reco::Vertex::CovarianceMatrix cov;
-	reco::Vertex::Point v(SV.at(0)->x()-PV->x(),SV.at(0)->y()-PV->y(),SV.at(0)->z()-PV->z());
-	for(int i=0;i<reco::Vertex::dimension;i++){
-	  for(int j=0;j<reco::Vertex::dimension;j++){
-	    cov(i,j)=SV.at(0)->covariance(i,j)+PV->covariance(i,j);
-	  }
-	}
-	GlobalVector direction(RefPFTau->px(),RefPFTau->py(),RefPFTau->pz());
-	double vSig = SecondaryVertex::computeDist3d(*PV,*SV.at(0),direction,true).significance();
-	reco::PFTauTransverseImpactParameter TIPV(poca,dxy,dxy_err,ip3d_poca,ip3d,ip3d_err,PV,v,vSig,SV.at(0));
-	reco::PFTauTransverseImpactParameterRef TIPVRef=reco::PFTauTransverseImpactParameterRef(TIPRefProd_out,TIPCollection_out->size());
+      if (!SV.empty()) {
+        reco::Vertex::CovarianceMatrix cov;
+        reco::Vertex::Point v(SV.at(0)->x() - PV->x(), SV.at(0)->y() - PV->y(), SV.at(0)->z() - PV->z());
+        for (int i = 0; i < reco::Vertex::dimension; i++) {
+          for (int j = 0; j < reco::Vertex::dimension; j++) {
+            cov(i, j) = SV.at(0)->covariance(i, j) + PV->covariance(i, j);
+          }
+        }
+        GlobalVector direction(RefPFTau->px(), RefPFTau->py(), RefPFTau->pz());
+        double vSig = SecondaryVertex::computeDist3d(*PV, *SV.at(0), direction, true).significance();
+        reco::PFTauTransverseImpactParameter TIPV(poca, dxy, dxy_err, ip3d_poca, ip3d, ip3d_err, PV, v, vSig, SV.at(0));
+        reco::PFTauTransverseImpactParameterRef TIPVRef =
+            reco::PFTauTransverseImpactParameterRef(TIPRefProd_out, TIPCollection_out->size());
         TIPCollection_out->push_back(TIPV);
-        AVPFTauTIP->setValue(iPFTau,TIPVRef);
-      }
-      else{ 
-	reco::PFTauTransverseImpactParameter TIPV(poca,dxy,dxy_err,ip3d_poca,ip3d,ip3d_err,PV);
-	reco::PFTauTransverseImpactParameterRef TIPVRef=reco::PFTauTransverseImpactParameterRef(TIPRefProd_out,TIPCollection_out->size());
-	TIPCollection_out->push_back(TIPV);
-	AVPFTauTIP->setValue(iPFTau,TIPVRef);
+        AVPFTauTIP->setValue(iPFTau, TIPVRef);
+      } else {
+        reco::PFTauTransverseImpactParameter TIPV(poca, dxy, dxy_err, ip3d_poca, ip3d, ip3d_err, PV);
+        reco::PFTauTransverseImpactParameterRef TIPVRef =
+            reco::PFTauTransverseImpactParameterRef(TIPRefProd_out, TIPCollection_out->size());
+        TIPCollection_out->push_back(TIPV);
+        AVPFTauTIP->setValue(iPFTau, TIPVRef);
       }
     }
   }
-  iEvent.put(std::move(TIPCollection_out),"PFTauTIP");
+  iEvent.put(std::move(TIPCollection_out), "PFTauTIP");
   iEvent.put(std::move(AVPFTauTIP));
 }
 
-void
-PFTauTransverseImpactParameters::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFTauTransverseImpactParameters::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // PFTauTransverseImpactParameters
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("PFTauPVATag", edm::InputTag("PFTauPrimaryVertexProducer"));

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
@@ -16,510 +16,489 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauConstructor.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h"
 
-#include <algorithm> 
+#include <algorithm>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-typedef std::vector<reco::PFRecoTauChargedHadron> ChargedHadronList;
-typedef tau::CombinatoricGenerator<ChargedHadronList> ChargedHadronCombo;
-typedef std::vector<RecoTauPiZero> PiZeroList;
-typedef tau::CombinatoricGenerator<PiZeroList> PiZeroCombo;
+    typedef std::vector<reco::PFRecoTauChargedHadron> ChargedHadronList;
+    typedef tau::CombinatoricGenerator<ChargedHadronList> ChargedHadronCombo;
+    typedef std::vector<RecoTauPiZero> PiZeroList;
+    typedef tau::CombinatoricGenerator<PiZeroList> PiZeroCombo;
 
-class RecoTauBuilderCombinatoricPlugin : public RecoTauBuilderPlugin 
-{
- public:
-  explicit RecoTauBuilderCombinatoricPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC);
-  ~RecoTauBuilderCombinatoricPlugin() override {}
+    class RecoTauBuilderCombinatoricPlugin : public RecoTauBuilderPlugin {
+    public:
+      explicit RecoTauBuilderCombinatoricPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+      ~RecoTauBuilderCombinatoricPlugin() override {}
 
-  return_type operator()(
-      const reco::JetBaseRef&, 
-      const std::vector<reco::PFRecoTauChargedHadron>&, 
-      const std::vector<RecoTauPiZero>&, 
-      const std::vector<CandidatePtr>&) const override;
+      return_type operator()(const reco::JetBaseRef&,
+                             const std::vector<reco::PFRecoTauChargedHadron>&,
+                             const std::vector<RecoTauPiZero>&,
+                             const std::vector<CandidatePtr>&) const override;
 
- private:
-  RecoTauQualityCuts qcuts_;
+    private:
+      RecoTauQualityCuts qcuts_;
 
-  double isolationConeSize_;
+      double isolationConeSize_;
 
-  struct decayModeInfo 
-  {
-    uint32_t maxPiZeros_;
-    uint32_t maxPFCHs_;
-    uint32_t nCharged_;
-    uint32_t nPiZeros_;
-  };
-  std::vector<decayModeInfo> decayModesToBuild_;
+      struct decayModeInfo {
+        uint32_t maxPiZeros_;
+        uint32_t maxPFCHs_;
+        uint32_t nCharged_;
+        uint32_t nPiZeros_;
+      };
+      std::vector<decayModeInfo> decayModesToBuild_;
 
-  StringObjectFunction<reco::PFTau> signalConeSize_;
-  double minAbsPhotonSumPt_insideSignalCone_;
-  double minRelPhotonSumPt_insideSignalCone_;
-  double minAbsPhotonSumPt_outsideSignalCone_;
-  double minRelPhotonSumPt_outsideSignalCone_;
+      StringObjectFunction<reco::PFTau> signalConeSize_;
+      double minAbsPhotonSumPt_insideSignalCone_;
+      double minRelPhotonSumPt_insideSignalCone_;
+      double minAbsPhotonSumPt_outsideSignalCone_;
+      double minRelPhotonSumPt_outsideSignalCone_;
 
-  int verbosity_;
-};
+      int verbosity_;
+    };
 
-RecoTauBuilderCombinatoricPlugin::RecoTauBuilderCombinatoricPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC)
-  : RecoTauBuilderPlugin(pset, std::move(iC)),
-    qcuts_(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts")),
-    isolationConeSize_(pset.getParameter<double>("isolationConeSize")),
-    signalConeSize_(pset.getParameter<std::string>("signalConeSize")),
-    minAbsPhotonSumPt_insideSignalCone_(pset.getParameter<double>("minAbsPhotonSumPt_insideSignalCone")),
-    minRelPhotonSumPt_insideSignalCone_(pset.getParameter<double>("minRelPhotonSumPt_insideSignalCone")),
-    minAbsPhotonSumPt_outsideSignalCone_(pset.getParameter<double>("minAbsPhotonSumPt_outsideSignalCone")),
-    minRelPhotonSumPt_outsideSignalCone_(pset.getParameter<double>("minRelPhotonSumPt_outsideSignalCone"))
-{
-  typedef std::vector<edm::ParameterSet> VPSet;
-  const VPSet& decayModes = pset.getParameter<VPSet>("decayModes");
-  for ( VPSet::const_iterator decayMode = decayModes.begin();
-	decayMode != decayModes.end(); ++decayMode ) {
-    decayModeInfo info;
-    info.nCharged_ = decayMode->getParameter<uint32_t>("nCharged");
-    info.nPiZeros_ = decayMode->getParameter<uint32_t>("nPiZeros");
-    info.maxPFCHs_ = decayMode->getParameter<uint32_t>("maxTracks");
-    info.maxPiZeros_ = decayMode->getParameter<uint32_t>("maxPiZeros");
-    decayModesToBuild_.push_back(info);
-  }
-
-  verbosity_ = pset.getParameter<int>("verbosity");
-}
-
-// define template specialization for cross-cleaning 
-namespace xclean
-{
-  template<>
-  inline void CrossCleanPiZeros<ChargedHadronCombo::combo_iterator>::initialize(const ChargedHadronCombo::combo_iterator& chargedHadronsBegin, const ChargedHadronCombo::combo_iterator& chargedHadronsEnd) 
-  {
-    // Get the list of objects we need to clean
-    for ( ChargedHadronCombo::combo_iterator chargedHadron = chargedHadronsBegin; chargedHadron != chargedHadronsEnd; ++chargedHadron ) {
-      // CV: Remove PFGammas that are merged into TauChargedHadrons from isolation PiZeros, but not from signal PiZeros.
-      //     The overlap between PFGammas contained in signal PiZeros and merged into TauChargedHadrons
-      //     is resolved by RecoTauConstructor::addTauChargedHadron,
-      //     which gives preference to PFGammas that are within PiZeros and removes those PFGammas from TauChargedHadrons.
-      if ( mode_ == kRemoveChargedDaughterOverlaps ) {
-	if ( chargedHadron->getChargedPFCandidate().isNonnull() ) toRemove_.insert(reco::CandidatePtr(chargedHadron->getChargedPFCandidate()));
-      } else if ( mode_ == kRemoveChargedAndNeutralDaughterOverlaps ) {
-	const reco::CompositePtrCandidate::daughters& daughters = chargedHadron->daughterPtrVector();
-	for ( reco::CompositePtrCandidate::daughters::const_iterator daughter = daughters.begin();
-	      daughter != daughters.end(); ++daughter ) {
-	  toRemove_.insert(reco::CandidatePtr(*daughter));
-	}
-      } else assert(0);
-    }
-  }
-
-  template<>
-  inline void CrossCleanPtrs<PiZeroList::const_iterator>::initialize(const PiZeroList::const_iterator& piZerosBegin, const PiZeroList::const_iterator& piZerosEnd) 
-  {
-    for(auto const& ptr : flattenPiZeros(piZerosBegin, piZerosEnd) ) {
-      toRemove_.insert(CandidatePtr(ptr));
-    }
-  }
-
-  template<>
-  inline void CrossCleanPtrs<ChargedHadronCombo::combo_iterator>::initialize(const ChargedHadronCombo::combo_iterator& chargedHadronsBegin, const ChargedHadronCombo::combo_iterator& chargedHadronsEnd) 
-  {
-    //std::cout << "<CrossCleanPtrs<ChargedHadronCombo>::initialize>:" << std::endl;
-    for ( ChargedHadronCombo::combo_iterator chargedHadron = chargedHadronsBegin; chargedHadron != chargedHadronsEnd; ++chargedHadron ) {
-      const reco::CompositePtrCandidate::daughters& daughters = chargedHadron->daughterPtrVector();
-      for ( reco::CompositePtrCandidate::daughters::const_iterator daughter = daughters.begin();
-	    daughter != daughters.end(); ++daughter ) {	
-	//std::cout << " adding PFCandidate = " << daughter->id() << ":" << daughter->key() << std::endl;
-	toRemove_.insert(reco::CandidatePtr(*daughter));
+    RecoTauBuilderCombinatoricPlugin::RecoTauBuilderCombinatoricPlugin(const edm::ParameterSet& pset,
+                                                                       edm::ConsumesCollector&& iC)
+        : RecoTauBuilderPlugin(pset, std::move(iC)),
+          qcuts_(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts")),
+          isolationConeSize_(pset.getParameter<double>("isolationConeSize")),
+          signalConeSize_(pset.getParameter<std::string>("signalConeSize")),
+          minAbsPhotonSumPt_insideSignalCone_(pset.getParameter<double>("minAbsPhotonSumPt_insideSignalCone")),
+          minRelPhotonSumPt_insideSignalCone_(pset.getParameter<double>("minRelPhotonSumPt_insideSignalCone")),
+          minAbsPhotonSumPt_outsideSignalCone_(pset.getParameter<double>("minAbsPhotonSumPt_outsideSignalCone")),
+          minRelPhotonSumPt_outsideSignalCone_(pset.getParameter<double>("minRelPhotonSumPt_outsideSignalCone")) {
+      typedef std::vector<edm::ParameterSet> VPSet;
+      const VPSet& decayModes = pset.getParameter<VPSet>("decayModes");
+      for (VPSet::const_iterator decayMode = decayModes.begin(); decayMode != decayModes.end(); ++decayMode) {
+        decayModeInfo info;
+        info.nCharged_ = decayMode->getParameter<uint32_t>("nCharged");
+        info.nPiZeros_ = decayMode->getParameter<uint32_t>("nPiZeros");
+        info.maxPFCHs_ = decayMode->getParameter<uint32_t>("maxTracks");
+        info.maxPiZeros_ = decayMode->getParameter<uint32_t>("maxPiZeros");
+        decayModesToBuild_.push_back(info);
       }
-    }
-  }
 
-  template<>
-  inline void CrossCleanPtrs<ChargedHadronList::const_iterator>::initialize(const ChargedHadronList::const_iterator& chargedHadronsBegin, const ChargedHadronList::const_iterator& chargedHadronsEnd) 
-  {
-    //std::cout << "<CrossCleanPtrs<ChargedHadronList>::initialize>:" << std::endl;
-    for ( ChargedHadronList::const_iterator chargedHadron = chargedHadronsBegin; chargedHadron != chargedHadronsEnd; ++chargedHadron ) {
-      const reco::CompositePtrCandidate::daughters& daughters = chargedHadron->daughterPtrVector();
-      for ( reco::CompositePtrCandidate::daughters::const_iterator daughter = daughters.begin();
-	    daughter != daughters.end(); ++daughter ) {
-	//std::cout << " adding PFCandidate = " << daughter->id() << ":" << daughter->key() << std::endl;
-	toRemove_.insert(reco::CandidatePtr(*daughter));
+      verbosity_ = pset.getParameter<int>("verbosity");
+    }
+
+    // define template specialization for cross-cleaning
+    namespace xclean {
+      template <>
+      inline void CrossCleanPiZeros<ChargedHadronCombo::combo_iterator>::initialize(
+          const ChargedHadronCombo::combo_iterator& chargedHadronsBegin,
+          const ChargedHadronCombo::combo_iterator& chargedHadronsEnd) {
+        // Get the list of objects we need to clean
+        for (ChargedHadronCombo::combo_iterator chargedHadron = chargedHadronsBegin; chargedHadron != chargedHadronsEnd;
+             ++chargedHadron) {
+          // CV: Remove PFGammas that are merged into TauChargedHadrons from isolation PiZeros, but not from signal PiZeros.
+          //     The overlap between PFGammas contained in signal PiZeros and merged into TauChargedHadrons
+          //     is resolved by RecoTauConstructor::addTauChargedHadron,
+          //     which gives preference to PFGammas that are within PiZeros and removes those PFGammas from TauChargedHadrons.
+          if (mode_ == kRemoveChargedDaughterOverlaps) {
+            if (chargedHadron->getChargedPFCandidate().isNonnull())
+              toRemove_.insert(reco::CandidatePtr(chargedHadron->getChargedPFCandidate()));
+          } else if (mode_ == kRemoveChargedAndNeutralDaughterOverlaps) {
+            const reco::CompositePtrCandidate::daughters& daughters = chargedHadron->daughterPtrVector();
+            for (reco::CompositePtrCandidate::daughters::const_iterator daughter = daughters.begin();
+                 daughter != daughters.end();
+                 ++daughter) {
+              toRemove_.insert(reco::CandidatePtr(*daughter));
+            }
+          } else
+            assert(0);
+        }
       }
-    }
-  }
-}
 
-namespace
-{
-  // auxiliary class for sorting pizeros by descending transverse momentum
-  class SortPi0sDescendingPt 
-  {
-   public:
-    bool operator()(const RecoTauPiZero& a, const RecoTauPiZero& b) const 
-    {
-      return a.pt() > b.pt();
-    }  
-  };
-
-  double square(double x)
-  {
-    return x*x;
-  }
-}
-
-RecoTauBuilderCombinatoricPlugin::return_type
-RecoTauBuilderCombinatoricPlugin::operator()(
-    const reco::JetBaseRef& jet, 
-    const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons, 
-    const std::vector<RecoTauPiZero>& piZeros, 
-    const std::vector<CandidatePtr>& regionalExtras) const 
-{
-  if ( verbosity_ ) {
-    std::cout << "<RecoTauBuilderCombinatoricPlugin::operator()>:" << std::endl;
-    std::cout << " processing jet: Pt = " << jet->pt() << ", eta = " << jet->eta() << ", phi = " << jet->eta() << ","
-	      << " mass = " << jet->mass() << ", area = " << jet->jetArea() << std::endl;
-  }
-  
-  // Define output.  
-  output_type output;
-  
-  // Update the primary vertex used by the quality cuts.  The PV is supplied by
-  // the base class.
-  qcuts_.setPV( primaryVertex(jet) );
-  
-  typedef std::vector<CandidatePtr> CandPtrs;
-  
-  if ( verbosity_ ) {
-    std::cout << "#chargedHadrons = " << chargedHadrons.size() << std::endl;
-    int idx = 0;
-    for ( ChargedHadronList::const_iterator chargedHadron = chargedHadrons.begin();
-	  chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
-      std::cout << "chargedHadron #" << idx << ":" << std::endl;
-      chargedHadron->print(std::cout);
-      ++idx;
-    }
-    std::cout << "#piZeros = " << piZeros.size() << std::endl;
-    idx = 0;
-    for ( PiZeroList::const_iterator piZero = piZeros.begin();
-   	  piZero != piZeros.end(); ++piZero ) {
-      std::cout << "piZero #" << idx << ":" << std::endl;
-      piZero->print(std::cout);
-      ++idx;
-    }
-  }
-
-  CandPtrs pfchs = qcuts_.filterCandRefs(pfChargedCands(*jet));
-  CandPtrs pfnhs = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 130));
-  CandPtrs pfgammas = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 22));
-
-  /// Apply quality cuts to the regional junk around the jet.  Note that the
-  /// particle contents of the junk is exclusive to the jet content.
-  CandPtrs regionalJunk = qcuts_.filterCandRefs(regionalExtras);
-    
-  // Loop over the decay modes we want to build
-  for ( std::vector<decayModeInfo>::const_iterator decayMode = decayModesToBuild_.begin();
-	decayMode != decayModesToBuild_.end(); ++decayMode ) {
-    // Find how many piZeros are in this decay mode
-    size_t piZerosToBuild = decayMode->nPiZeros_;
-    // Find how many tracks are in this decay mode
-    size_t tracksToBuild = decayMode->nCharged_;
-    if ( verbosity_ ) {
-      std::cout << "piZerosToBuild = " << piZerosToBuild << std::endl;
-      std::cout << "#piZeros = " << piZeros.size() << std::endl;
-      std::cout << "tracksToBuild = " << tracksToBuild << std::endl;
-      std::cout << "#chargedHadrons = " << chargedHadrons.size() << std::endl;      
-    }
-    
-    // Skip decay mode if jet doesn't have the multiplicity to support it
-    if ( chargedHadrons.size() < tracksToBuild ) continue;
-
-    // Find the start and end of potential signal tracks
-    ChargedHadronList::const_iterator chargedHadron_begin = chargedHadrons.begin();
-    ChargedHadronList::const_iterator chargedHadron_end = chargedHadrons.end();
-    chargedHadron_end = takeNElements(chargedHadron_begin, chargedHadron_end, decayMode->maxPFCHs_);
-
-    // Build our track combo generator
-    ChargedHadronCombo trackCombos(chargedHadron_begin, chargedHadron_end, tracksToBuild);
-
-    CandPtrs::iterator pfch_end = pfchs.end();
-    pfch_end = takeNElements(pfchs.begin(), pfch_end, decayMode->maxPFCHs_);
-
-    //-------------------------------------------------------
-    // Begin combinatoric loop for this decay mode
-    //-------------------------------------------------------
-    
-    // Loop over the different combinations of tracks
-    for ( ChargedHadronCombo::iterator trackCombo = trackCombos.begin();
-	  trackCombo != trackCombos.end(); ++trackCombo ) {
-      xclean::CrossCleanPiZeros<ChargedHadronCombo::combo_iterator> signalPiZeroXCleaner(
-          trackCombo->combo_begin(), trackCombo->combo_end(), 
-	  xclean::CrossCleanPiZeros<ChargedHadronCombo::combo_iterator>::kRemoveChargedDaughterOverlaps);
-
-      PiZeroList cleanSignalPiZeros = signalPiZeroXCleaner(piZeros);
-      
-      // CV: sort collection of cross-cleaned pi0s by descending Pt
-      std::sort(cleanSignalPiZeros.begin(), cleanSignalPiZeros.end(), SortPi0sDescendingPt());
-      
-      // Skip decay mode if we don't have enough remaining clean pizeros to
-      // build it.
-      if ( cleanSignalPiZeros.size() < piZerosToBuild ) continue;
-      
-      // Find the start and end of potential signal tracks
-      PiZeroList::iterator signalPiZero_begin = cleanSignalPiZeros.begin();
-      PiZeroList::iterator signalPiZero_end = cleanSignalPiZeros.end();
-      signalPiZero_end = takeNElements(signalPiZero_begin, signalPiZero_end, decayMode->maxPiZeros_);
-      
-      // Build our piZero combo generator     
-      PiZeroCombo piZeroCombos(signalPiZero_begin, signalPiZero_end, piZerosToBuild);
-      // Loop over the different combinations of PiZeros
-      for ( PiZeroCombo::iterator piZeroCombo = piZeroCombos.begin();
-            piZeroCombo != piZeroCombos.end(); ++piZeroCombo ) {
-        // Output tau
-        RecoTauConstructor tau(
-          jet, getPFCands(), true, 
-	  &signalConeSize_, 
-	  minAbsPhotonSumPt_insideSignalCone_, minRelPhotonSumPt_insideSignalCone_, minAbsPhotonSumPt_outsideSignalCone_, minRelPhotonSumPt_outsideSignalCone_);
-        // Reserve space in our collections
-        tau.reserve(
-	    RecoTauConstructor::kSignal,
-	    RecoTauConstructor::kChargedHadron, tracksToBuild);
-        tau.reserve(
-            RecoTauConstructor::kSignal,
-            RecoTauConstructor::kGamma, 2*piZerosToBuild); // k-factor = 2
-        tau.reservePiZero(RecoTauConstructor::kSignal, piZerosToBuild);
-	
-	xclean::CrossCleanPiZeros<ChargedHadronCombo::combo_iterator> isolationPiZeroXCleaner(
-          trackCombo->combo_begin(), trackCombo->combo_end(), 
-	  xclean::CrossCleanPiZeros<ChargedHadronCombo::combo_iterator>::kRemoveChargedAndNeutralDaughterOverlaps);
-
-	PiZeroList precleanedIsolationPiZeros = isolationPiZeroXCleaner(piZeros);
-	std::set<reco::CandidatePtr> toRemove;
-	for ( PiZeroCombo::combo_iterator signalPiZero = piZeroCombo->combo_begin();
-	      signalPiZero != piZeroCombo->combo_end(); ++signalPiZero ) {
-	  toRemove.insert(signalPiZero->daughterPtrVector().begin(), signalPiZero->daughterPtrVector().end());
-	}
-	PiZeroList cleanIsolationPiZeros;
-	for(auto const& precleanedPiZero : precleanedIsolationPiZeros ) {
-	  std::set<reco::CandidatePtr> toCheck(precleanedPiZero.daughterPtrVector().begin(), precleanedPiZero.daughterPtrVector().end());
-	  std::vector<reco::CandidatePtr> cleanDaughters;
-	  std::set_difference(toCheck.begin(), toCheck.end(), toRemove.begin(), toRemove.end(), std::back_inserter(cleanDaughters));
-	  // CV: piZero is signal piZero if at least one daughter overlaps
-	  if ( cleanDaughters.size() == precleanedPiZero.daughterPtrVector().size() ) {
-	    cleanIsolationPiZeros.push_back(precleanedPiZero);
-	  }
-	}
-	if ( verbosity_ ) {
-	  std::cout << "#cleanIsolationPiZeros = " << cleanIsolationPiZeros.size() << std::endl;
-	  int idx = 0;
-	  for ( PiZeroList::const_iterator piZero = cleanIsolationPiZeros.begin();
-		piZero != cleanIsolationPiZeros.end(); ++piZero ) {
-	    std::cout << "piZero #" << idx << ":" << std::endl;
-	    piZero->print(std::cout);
-	    ++idx;
-	  }
-	}
-
-        // FIXME - are all these reserves okay?  will they get propagated to the
-        // dataformat size if they are wrong?
-        tau.reserve(
-            RecoTauConstructor::kIsolation,
-            RecoTauConstructor::kChargedHadron, chargedHadrons.size() - tracksToBuild);
-        tau.reserve(
-            RecoTauConstructor::kIsolation,
-	    RecoTauConstructor::kGamma,
-	    (piZeros.size() - piZerosToBuild)*2);
-        tau.reservePiZero(
-	    RecoTauConstructor::kIsolation,
-	    (piZeros.size() - piZerosToBuild));
-
-        // Get signal PiZero constituents and add them to the tau.
-        // The sub-gammas are automatically added.
-        tau.addPiZeros(
-            RecoTauConstructor::kSignal,
-            piZeroCombo->combo_begin(), piZeroCombo->combo_end());
-
-	// Set signal and isolation components for charged hadrons, after
-        // converting them to a PFCandidateRefVector
-	//
-	// NOTE: signal ChargedHadrons need to be added **after** signal PiZeros
-	//       to avoid double-counting PFGammas as part of PiZero and merged with ChargedHadron
-	//
-        tau.addTauChargedHadrons(
-            RecoTauConstructor::kSignal, 
-            trackCombo->combo_begin(), trackCombo->combo_end());
-
-        // Now build isolation collections
-        // Load our isolation tools
-        using namespace reco::tau::cone;
-        CandPtrDRFilter isolationConeFilter(tau.p4(), -0.1, isolationConeSize_);
-
-        // Cross cleaning predicate: Remove any PFCandidatePtrs that are contained within existing ChargedHadrons or PiZeros.  
-	// The predicate will return false for any object that overlaps with chargedHadrons or cleanPiZeros.
-	//  1.) to select charged PFCandidates within jet that are not signalPFChargedHadrons 
-	typedef xclean::CrossCleanPtrs<ChargedHadronCombo::combo_iterator> pfChargedHadronXCleanerType;
-	pfChargedHadronXCleanerType pfChargedHadronXCleaner_comboChargedHadrons(trackCombo->combo_begin(), trackCombo->combo_end());
-	// And this cleaning filter predicate with our Iso cone filter
-        xclean::PredicateAND<CandPtrDRFilter, pfChargedHadronXCleanerType> pfCandFilter_comboChargedHadrons(isolationConeFilter, pfChargedHadronXCleaner_comboChargedHadrons);
-	//  2.) to select neutral PFCandidates within jet
-	xclean::CrossCleanPtrs<ChargedHadronList::const_iterator> pfChargedHadronXCleaner_allChargedHadrons(chargedHadrons.begin(), chargedHadrons.end());
-	xclean::CrossCleanPtrs<PiZeroList::const_iterator> piZeroXCleaner(piZeros.begin(), piZeros.end());
-	typedef xclean::PredicateAND<xclean::CrossCleanPtrs<ChargedHadronList::const_iterator>, xclean::CrossCleanPtrs<PiZeroList::const_iterator> > pfCandXCleanerType;
-        pfCandXCleanerType pfCandXCleaner_allChargedHadrons(pfChargedHadronXCleaner_allChargedHadrons, piZeroXCleaner);
-        // And this cleaning filter predicate with our Iso cone filter
-        xclean::PredicateAND<CandPtrDRFilter, pfCandXCleanerType> pfCandFilter_allChargedHadrons(isolationConeFilter, pfCandXCleaner_allChargedHadrons);
-
-	ChargedHadronDRFilter isolationConeFilterChargedHadron(tau.p4(), -0.1, isolationConeSize_);
-        PiZeroDRFilter isolationConeFilterPiZero(tau.p4(), -0.1, isolationConeSize_);
-
-        // Additionally make predicates to select the different PF object types
-        // of the regional junk objects to add
-        typedef xclean::PredicateAND<xclean::FilterCandByAbsPdgId,
-	    CandPtrDRFilter> RegionalJunkConeAndIdFilter;
-
-        xclean::FilterCandByAbsPdgId
-          pfchCandSelector(211);
-        xclean::FilterCandByAbsPdgId
-          pfgammaCandSelector(22);
-        xclean::FilterCandByAbsPdgId
-          pfnhCandSelector(130);
-
-        RegionalJunkConeAndIdFilter pfChargedJunk(
-            pfchCandSelector, // select charged stuff from junk
-            isolationConeFilter); // only take those in iso cone
-
-        RegionalJunkConeAndIdFilter pfGammaJunk(
-            pfgammaCandSelector, // select gammas from junk
-            isolationConeFilter); // only take those in iso cone
-
-        RegionalJunkConeAndIdFilter pfNeutralJunk(
-            pfnhCandSelector, // select neutral stuff from junk
-            isolationConeFilter); // select stuff in iso cone
- 	
-        tau.addPiZeros(
-            RecoTauConstructor::kIsolation,
-            boost::make_filter_iterator(
-                isolationConeFilterPiZero,
-                cleanIsolationPiZeros.begin(), cleanIsolationPiZeros.end()),
-            boost::make_filter_iterator(
-                isolationConeFilterPiZero,
-                cleanIsolationPiZeros.end(), cleanIsolationPiZeros.end()));
-
-        // Filter the isolation candidates in a DR cone
-	//
-	// NOTE: isolation ChargedHadrons need to be added **after** signal and isolation PiZeros
-	//       to avoid double-counting PFGammas as part of PiZero and merged with ChargedHadron
-	//
-	if ( verbosity_ >= 2 ) {
-	  std::cout << "adding isolation PFChargedHadrons from trackCombo:" << std::endl;
-	}
-        tau.addTauChargedHadrons(
-            RecoTauConstructor::kIsolation,
-            boost::make_filter_iterator(
-                isolationConeFilterChargedHadron,
-                trackCombo->remainder_begin(), trackCombo->remainder_end()),
-            boost::make_filter_iterator(
-                isolationConeFilterChargedHadron,
-                trackCombo->remainder_end(), trackCombo->remainder_end()));
-
-        // Add all the candidates that weren't included in the combinatoric
-        // generation
-	if ( verbosity_ >= 2 ) {
-	  std::cout << "adding isolation PFChargedHadrons not considered in trackCombo:" << std::endl;
-	}
-        tau.addPFCands(
-            RecoTauConstructor::kIsolation, RecoTauConstructor::kChargedHadron,
-            boost::make_filter_iterator(
-                pfCandFilter_comboChargedHadrons,
-                pfch_end, pfchs.end()),
-            boost::make_filter_iterator(
-                pfCandFilter_comboChargedHadrons,
-                pfchs.end(), pfchs.end()));
-        // Add all charged candidates that are in the iso cone but weren't in the
-        // original PFJet
-	if ( verbosity_ >= 2 ) {
-	  std::cout << "adding isolation PFChargedHadrons from 'regional junk':" << std::endl;
-	}
-        tau.addPFCands(
-            RecoTauConstructor::kIsolation, RecoTauConstructor::kChargedHadron,
-            boost::make_filter_iterator(
-                pfChargedJunk, regionalJunk.begin(), regionalJunk.end()),
-            boost::make_filter_iterator(
-                pfChargedJunk, regionalJunk.end(), regionalJunk.end()));
-	
-	// Add all PFGamma constituents of the jet that are not part of a PiZero
-	if ( verbosity_ >= 2 ) {
-	  std::cout << "adding isolation PFGammas not considered in PiZeros:" << std::endl;
-	}
-        tau.addPFCands(
-	    RecoTauConstructor::kIsolation, RecoTauConstructor::kGamma,
-            boost::make_filter_iterator(
-                pfCandFilter_allChargedHadrons,
-		pfgammas.begin(), pfgammas.end()),
-            boost::make_filter_iterator(
-                pfCandFilter_allChargedHadrons,
-		pfgammas.end(), pfgammas.end()));
-        // Add all gammas that are in the iso cone but weren't in the
-        // orginal PFJet
-        tau.addPFCands(
-            RecoTauConstructor::kIsolation, RecoTauConstructor::kGamma,
-            boost::make_filter_iterator(
-                pfGammaJunk, regionalJunk.begin(), regionalJunk.end()),
-            boost::make_filter_iterator(
-                pfGammaJunk, regionalJunk.end(), regionalJunk.end()));
-
-        // Add all the neutral hadron candidates to the isolation collection
-        tau.addPFCands(
-            RecoTauConstructor::kIsolation, RecoTauConstructor::kNeutralHadron,
-            boost::make_filter_iterator(
-                pfCandFilter_allChargedHadrons,
-                pfnhs.begin(), pfnhs.end()),
-            boost::make_filter_iterator(
-                pfCandFilter_allChargedHadrons,
-                pfnhs.end(), pfnhs.end()));
-        // Add all the neutral hadrons from the region collection that are in
-        // the iso cone to the tau
-        tau.addPFCands(
-            RecoTauConstructor::kIsolation,  RecoTauConstructor::kNeutralHadron,
-            boost::make_filter_iterator(
-              pfNeutralJunk, regionalJunk.begin(), regionalJunk.end()),
-            boost::make_filter_iterator(
-              pfNeutralJunk, regionalJunk.end(), regionalJunk.end()));
-
-        std::auto_ptr<reco::PFTau> tauPtr = tau.get(true);
-	
-	// Set event vertex position for tau
-	reco::VertexRef primaryVertexRef = primaryVertex(*tauPtr);
-	if ( primaryVertexRef.isNonnull() ) {
-	  tauPtr->setVertex(primaryVertexRef->position());
-	}
-
-	double tauEn = tauPtr->energy();
-	double tauPz = tauPtr->pz();
-        const double chargedPionMass = 0.13957; // GeV
-	double tauMass = std::max(tauPtr->mass(), chargedPionMass);
-	double bendCorrMass2 = 0.;
-	const std::vector<RecoTauPiZero>& piZeros = tauPtr->signalPiZeroCandidates();
-	for (auto const& piZero : piZeros ) {
-	  double piZeroEn = piZero.energy();
-	  double piZeroPx = piZero.px();
-	  double piZeroPy = piZero.py();
-	  double piZeroPz = piZero.pz();	  
-	  double tau_wo_piZeroPx = tauPtr->px() - piZeroPx;
-	  double tau_wo_piZeroPy = tauPtr->py() - piZeroPy;
-	  // CV: Compute effect of varying strip four-vector by eta and phi correction on tau mass
-	  //    (derrivative of tau mass by strip eta, phi has been computed using Mathematica) 
-	  bendCorrMass2 += square(((piZeroPz*tauEn - piZeroEn*tauPz)/tauMass)*piZero.bendCorrEta());
-	  bendCorrMass2 += square(((piZeroPy*tau_wo_piZeroPx - piZeroPx*tau_wo_piZeroPy)/tauMass)*piZero.bendCorrPhi());
-	}
-	//edm::LogPrint("RecoTauBuilderCombinatoricPlugin") << "bendCorrMass2 = " << sqrt(bendCorrMass2) << std::endl;
-	tauPtr->setBendCorrMass(sqrt(bendCorrMass2));
-
-        output.push_back(tauPtr);
+      template <>
+      inline void CrossCleanPtrs<PiZeroList::const_iterator>::initialize(const PiZeroList::const_iterator& piZerosBegin,
+                                                                         const PiZeroList::const_iterator& piZerosEnd) {
+        for (auto const& ptr : flattenPiZeros(piZerosBegin, piZerosEnd)) {
+          toRemove_.insert(CandidatePtr(ptr));
+        }
       }
+
+      template <>
+      inline void CrossCleanPtrs<ChargedHadronCombo::combo_iterator>::initialize(
+          const ChargedHadronCombo::combo_iterator& chargedHadronsBegin,
+          const ChargedHadronCombo::combo_iterator& chargedHadronsEnd) {
+        //std::cout << "<CrossCleanPtrs<ChargedHadronCombo>::initialize>:" << std::endl;
+        for (ChargedHadronCombo::combo_iterator chargedHadron = chargedHadronsBegin; chargedHadron != chargedHadronsEnd;
+             ++chargedHadron) {
+          const reco::CompositePtrCandidate::daughters& daughters = chargedHadron->daughterPtrVector();
+          for (reco::CompositePtrCandidate::daughters::const_iterator daughter = daughters.begin();
+               daughter != daughters.end();
+               ++daughter) {
+            //std::cout << " adding PFCandidate = " << daughter->id() << ":" << daughter->key() << std::endl;
+            toRemove_.insert(reco::CandidatePtr(*daughter));
+          }
+        }
+      }
+
+      template <>
+      inline void CrossCleanPtrs<ChargedHadronList::const_iterator>::initialize(
+          const ChargedHadronList::const_iterator& chargedHadronsBegin,
+          const ChargedHadronList::const_iterator& chargedHadronsEnd) {
+        //std::cout << "<CrossCleanPtrs<ChargedHadronList>::initialize>:" << std::endl;
+        for (ChargedHadronList::const_iterator chargedHadron = chargedHadronsBegin; chargedHadron != chargedHadronsEnd;
+             ++chargedHadron) {
+          const reco::CompositePtrCandidate::daughters& daughters = chargedHadron->daughterPtrVector();
+          for (reco::CompositePtrCandidate::daughters::const_iterator daughter = daughters.begin();
+               daughter != daughters.end();
+               ++daughter) {
+            //std::cout << " adding PFCandidate = " << daughter->id() << ":" << daughter->key() << std::endl;
+            toRemove_.insert(reco::CandidatePtr(*daughter));
+          }
+        }
+      }
+    }  // namespace xclean
+
+    namespace {
+      // auxiliary class for sorting pizeros by descending transverse momentum
+      class SortPi0sDescendingPt {
+      public:
+        bool operator()(const RecoTauPiZero& a, const RecoTauPiZero& b) const { return a.pt() > b.pt(); }
+      };
+
+      double square(double x) { return x * x; }
+    }  // namespace
+
+    RecoTauBuilderCombinatoricPlugin::return_type RecoTauBuilderCombinatoricPlugin::operator()(
+        const reco::JetBaseRef& jet,
+        const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons,
+        const std::vector<RecoTauPiZero>& piZeros,
+        const std::vector<CandidatePtr>& regionalExtras) const {
+      if (verbosity_) {
+        std::cout << "<RecoTauBuilderCombinatoricPlugin::operator()>:" << std::endl;
+        std::cout << " processing jet: Pt = " << jet->pt() << ", eta = " << jet->eta() << ", phi = " << jet->eta()
+                  << ","
+                  << " mass = " << jet->mass() << ", area = " << jet->jetArea() << std::endl;
+      }
+
+      // Define output.
+      output_type output;
+
+      // Update the primary vertex used by the quality cuts.  The PV is supplied by
+      // the base class.
+      qcuts_.setPV(primaryVertex(jet));
+
+      typedef std::vector<CandidatePtr> CandPtrs;
+
+      if (verbosity_) {
+        std::cout << "#chargedHadrons = " << chargedHadrons.size() << std::endl;
+        int idx = 0;
+        for (ChargedHadronList::const_iterator chargedHadron = chargedHadrons.begin();
+             chargedHadron != chargedHadrons.end();
+             ++chargedHadron) {
+          std::cout << "chargedHadron #" << idx << ":" << std::endl;
+          chargedHadron->print(std::cout);
+          ++idx;
+        }
+        std::cout << "#piZeros = " << piZeros.size() << std::endl;
+        idx = 0;
+        for (PiZeroList::const_iterator piZero = piZeros.begin(); piZero != piZeros.end(); ++piZero) {
+          std::cout << "piZero #" << idx << ":" << std::endl;
+          piZero->print(std::cout);
+          ++idx;
+        }
+      }
+
+      CandPtrs pfchs = qcuts_.filterCandRefs(pfChargedCands(*jet));
+      CandPtrs pfnhs = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 130));
+      CandPtrs pfgammas = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 22));
+
+      /// Apply quality cuts to the regional junk around the jet.  Note that the
+      /// particle contents of the junk is exclusive to the jet content.
+      CandPtrs regionalJunk = qcuts_.filterCandRefs(regionalExtras);
+
+      // Loop over the decay modes we want to build
+      for (std::vector<decayModeInfo>::const_iterator decayMode = decayModesToBuild_.begin();
+           decayMode != decayModesToBuild_.end();
+           ++decayMode) {
+        // Find how many piZeros are in this decay mode
+        size_t piZerosToBuild = decayMode->nPiZeros_;
+        // Find how many tracks are in this decay mode
+        size_t tracksToBuild = decayMode->nCharged_;
+        if (verbosity_) {
+          std::cout << "piZerosToBuild = " << piZerosToBuild << std::endl;
+          std::cout << "#piZeros = " << piZeros.size() << std::endl;
+          std::cout << "tracksToBuild = " << tracksToBuild << std::endl;
+          std::cout << "#chargedHadrons = " << chargedHadrons.size() << std::endl;
+        }
+
+        // Skip decay mode if jet doesn't have the multiplicity to support it
+        if (chargedHadrons.size() < tracksToBuild)
+          continue;
+
+        // Find the start and end of potential signal tracks
+        ChargedHadronList::const_iterator chargedHadron_begin = chargedHadrons.begin();
+        ChargedHadronList::const_iterator chargedHadron_end = chargedHadrons.end();
+        chargedHadron_end = takeNElements(chargedHadron_begin, chargedHadron_end, decayMode->maxPFCHs_);
+
+        // Build our track combo generator
+        ChargedHadronCombo trackCombos(chargedHadron_begin, chargedHadron_end, tracksToBuild);
+
+        CandPtrs::iterator pfch_end = pfchs.end();
+        pfch_end = takeNElements(pfchs.begin(), pfch_end, decayMode->maxPFCHs_);
+
+        //-------------------------------------------------------
+        // Begin combinatoric loop for this decay mode
+        //-------------------------------------------------------
+
+        // Loop over the different combinations of tracks
+        for (ChargedHadronCombo::iterator trackCombo = trackCombos.begin(); trackCombo != trackCombos.end();
+             ++trackCombo) {
+          xclean::CrossCleanPiZeros<ChargedHadronCombo::combo_iterator> signalPiZeroXCleaner(
+              trackCombo->combo_begin(),
+              trackCombo->combo_end(),
+              xclean::CrossCleanPiZeros<ChargedHadronCombo::combo_iterator>::kRemoveChargedDaughterOverlaps);
+
+          PiZeroList cleanSignalPiZeros = signalPiZeroXCleaner(piZeros);
+
+          // CV: sort collection of cross-cleaned pi0s by descending Pt
+          std::sort(cleanSignalPiZeros.begin(), cleanSignalPiZeros.end(), SortPi0sDescendingPt());
+
+          // Skip decay mode if we don't have enough remaining clean pizeros to
+          // build it.
+          if (cleanSignalPiZeros.size() < piZerosToBuild)
+            continue;
+
+          // Find the start and end of potential signal tracks
+          PiZeroList::iterator signalPiZero_begin = cleanSignalPiZeros.begin();
+          PiZeroList::iterator signalPiZero_end = cleanSignalPiZeros.end();
+          signalPiZero_end = takeNElements(signalPiZero_begin, signalPiZero_end, decayMode->maxPiZeros_);
+
+          // Build our piZero combo generator
+          PiZeroCombo piZeroCombos(signalPiZero_begin, signalPiZero_end, piZerosToBuild);
+          // Loop over the different combinations of PiZeros
+          for (PiZeroCombo::iterator piZeroCombo = piZeroCombos.begin(); piZeroCombo != piZeroCombos.end();
+               ++piZeroCombo) {
+            // Output tau
+            RecoTauConstructor tau(jet,
+                                   getPFCands(),
+                                   true,
+                                   &signalConeSize_,
+                                   minAbsPhotonSumPt_insideSignalCone_,
+                                   minRelPhotonSumPt_insideSignalCone_,
+                                   minAbsPhotonSumPt_outsideSignalCone_,
+                                   minRelPhotonSumPt_outsideSignalCone_);
+            // Reserve space in our collections
+            tau.reserve(RecoTauConstructor::kSignal, RecoTauConstructor::kChargedHadron, tracksToBuild);
+            tau.reserve(RecoTauConstructor::kSignal, RecoTauConstructor::kGamma, 2 * piZerosToBuild);  // k-factor = 2
+            tau.reservePiZero(RecoTauConstructor::kSignal, piZerosToBuild);
+
+            xclean::CrossCleanPiZeros<ChargedHadronCombo::combo_iterator> isolationPiZeroXCleaner(
+                trackCombo->combo_begin(),
+                trackCombo->combo_end(),
+                xclean::CrossCleanPiZeros<ChargedHadronCombo::combo_iterator>::kRemoveChargedAndNeutralDaughterOverlaps);
+
+            PiZeroList precleanedIsolationPiZeros = isolationPiZeroXCleaner(piZeros);
+            std::set<reco::CandidatePtr> toRemove;
+            for (PiZeroCombo::combo_iterator signalPiZero = piZeroCombo->combo_begin();
+                 signalPiZero != piZeroCombo->combo_end();
+                 ++signalPiZero) {
+              toRemove.insert(signalPiZero->daughterPtrVector().begin(), signalPiZero->daughterPtrVector().end());
+            }
+            PiZeroList cleanIsolationPiZeros;
+            for (auto const& precleanedPiZero : precleanedIsolationPiZeros) {
+              std::set<reco::CandidatePtr> toCheck(precleanedPiZero.daughterPtrVector().begin(),
+                                                   precleanedPiZero.daughterPtrVector().end());
+              std::vector<reco::CandidatePtr> cleanDaughters;
+              std::set_difference(
+                  toCheck.begin(), toCheck.end(), toRemove.begin(), toRemove.end(), std::back_inserter(cleanDaughters));
+              // CV: piZero is signal piZero if at least one daughter overlaps
+              if (cleanDaughters.size() == precleanedPiZero.daughterPtrVector().size()) {
+                cleanIsolationPiZeros.push_back(precleanedPiZero);
+              }
+            }
+            if (verbosity_) {
+              std::cout << "#cleanIsolationPiZeros = " << cleanIsolationPiZeros.size() << std::endl;
+              int idx = 0;
+              for (PiZeroList::const_iterator piZero = cleanIsolationPiZeros.begin();
+                   piZero != cleanIsolationPiZeros.end();
+                   ++piZero) {
+                std::cout << "piZero #" << idx << ":" << std::endl;
+                piZero->print(std::cout);
+                ++idx;
+              }
+            }
+
+            // FIXME - are all these reserves okay?  will they get propagated to the
+            // dataformat size if they are wrong?
+            tau.reserve(RecoTauConstructor::kIsolation,
+                        RecoTauConstructor::kChargedHadron,
+                        chargedHadrons.size() - tracksToBuild);
+            tau.reserve(
+                RecoTauConstructor::kIsolation, RecoTauConstructor::kGamma, (piZeros.size() - piZerosToBuild) * 2);
+            tau.reservePiZero(RecoTauConstructor::kIsolation, (piZeros.size() - piZerosToBuild));
+
+            // Get signal PiZero constituents and add them to the tau.
+            // The sub-gammas are automatically added.
+            tau.addPiZeros(RecoTauConstructor::kSignal, piZeroCombo->combo_begin(), piZeroCombo->combo_end());
+
+            // Set signal and isolation components for charged hadrons, after
+            // converting them to a PFCandidateRefVector
+            //
+            // NOTE: signal ChargedHadrons need to be added **after** signal PiZeros
+            //       to avoid double-counting PFGammas as part of PiZero and merged with ChargedHadron
+            //
+            tau.addTauChargedHadrons(RecoTauConstructor::kSignal, trackCombo->combo_begin(), trackCombo->combo_end());
+
+            // Now build isolation collections
+            // Load our isolation tools
+            using namespace reco::tau::cone;
+            CandPtrDRFilter isolationConeFilter(tau.p4(), -0.1, isolationConeSize_);
+
+            // Cross cleaning predicate: Remove any PFCandidatePtrs that are contained within existing ChargedHadrons or PiZeros.
+            // The predicate will return false for any object that overlaps with chargedHadrons or cleanPiZeros.
+            //  1.) to select charged PFCandidates within jet that are not signalPFChargedHadrons
+            typedef xclean::CrossCleanPtrs<ChargedHadronCombo::combo_iterator> pfChargedHadronXCleanerType;
+            pfChargedHadronXCleanerType pfChargedHadronXCleaner_comboChargedHadrons(trackCombo->combo_begin(),
+                                                                                    trackCombo->combo_end());
+            // And this cleaning filter predicate with our Iso cone filter
+            xclean::PredicateAND<CandPtrDRFilter, pfChargedHadronXCleanerType> pfCandFilter_comboChargedHadrons(
+                isolationConeFilter, pfChargedHadronXCleaner_comboChargedHadrons);
+            //  2.) to select neutral PFCandidates within jet
+            xclean::CrossCleanPtrs<ChargedHadronList::const_iterator> pfChargedHadronXCleaner_allChargedHadrons(
+                chargedHadrons.begin(), chargedHadrons.end());
+            xclean::CrossCleanPtrs<PiZeroList::const_iterator> piZeroXCleaner(piZeros.begin(), piZeros.end());
+            typedef xclean::PredicateAND<xclean::CrossCleanPtrs<ChargedHadronList::const_iterator>,
+                                         xclean::CrossCleanPtrs<PiZeroList::const_iterator> >
+                pfCandXCleanerType;
+            pfCandXCleanerType pfCandXCleaner_allChargedHadrons(pfChargedHadronXCleaner_allChargedHadrons,
+                                                                piZeroXCleaner);
+            // And this cleaning filter predicate with our Iso cone filter
+            xclean::PredicateAND<CandPtrDRFilter, pfCandXCleanerType> pfCandFilter_allChargedHadrons(
+                isolationConeFilter, pfCandXCleaner_allChargedHadrons);
+
+            ChargedHadronDRFilter isolationConeFilterChargedHadron(tau.p4(), -0.1, isolationConeSize_);
+            PiZeroDRFilter isolationConeFilterPiZero(tau.p4(), -0.1, isolationConeSize_);
+
+            // Additionally make predicates to select the different PF object types
+            // of the regional junk objects to add
+            typedef xclean::PredicateAND<xclean::FilterCandByAbsPdgId, CandPtrDRFilter> RegionalJunkConeAndIdFilter;
+
+            xclean::FilterCandByAbsPdgId pfchCandSelector(211);
+            xclean::FilterCandByAbsPdgId pfgammaCandSelector(22);
+            xclean::FilterCandByAbsPdgId pfnhCandSelector(130);
+
+            RegionalJunkConeAndIdFilter pfChargedJunk(pfchCandSelector,      // select charged stuff from junk
+                                                      isolationConeFilter);  // only take those in iso cone
+
+            RegionalJunkConeAndIdFilter pfGammaJunk(pfgammaCandSelector,   // select gammas from junk
+                                                    isolationConeFilter);  // only take those in iso cone
+
+            RegionalJunkConeAndIdFilter pfNeutralJunk(pfnhCandSelector,      // select neutral stuff from junk
+                                                      isolationConeFilter);  // select stuff in iso cone
+
+            tau.addPiZeros(RecoTauConstructor::kIsolation,
+                           boost::make_filter_iterator(
+                               isolationConeFilterPiZero, cleanIsolationPiZeros.begin(), cleanIsolationPiZeros.end()),
+                           boost::make_filter_iterator(
+                               isolationConeFilterPiZero, cleanIsolationPiZeros.end(), cleanIsolationPiZeros.end()));
+
+            // Filter the isolation candidates in a DR cone
+            //
+            // NOTE: isolation ChargedHadrons need to be added **after** signal and isolation PiZeros
+            //       to avoid double-counting PFGammas as part of PiZero and merged with ChargedHadron
+            //
+            if (verbosity_ >= 2) {
+              std::cout << "adding isolation PFChargedHadrons from trackCombo:" << std::endl;
+            }
+            tau.addTauChargedHadrons(
+                RecoTauConstructor::kIsolation,
+                boost::make_filter_iterator(
+                    isolationConeFilterChargedHadron, trackCombo->remainder_begin(), trackCombo->remainder_end()),
+                boost::make_filter_iterator(
+                    isolationConeFilterChargedHadron, trackCombo->remainder_end(), trackCombo->remainder_end()));
+
+            // Add all the candidates that weren't included in the combinatoric
+            // generation
+            if (verbosity_ >= 2) {
+              std::cout << "adding isolation PFChargedHadrons not considered in trackCombo:" << std::endl;
+            }
+            tau.addPFCands(RecoTauConstructor::kIsolation,
+                           RecoTauConstructor::kChargedHadron,
+                           boost::make_filter_iterator(pfCandFilter_comboChargedHadrons, pfch_end, pfchs.end()),
+                           boost::make_filter_iterator(pfCandFilter_comboChargedHadrons, pfchs.end(), pfchs.end()));
+            // Add all charged candidates that are in the iso cone but weren't in the
+            // original PFJet
+            if (verbosity_ >= 2) {
+              std::cout << "adding isolation PFChargedHadrons from 'regional junk':" << std::endl;
+            }
+            tau.addPFCands(RecoTauConstructor::kIsolation,
+                           RecoTauConstructor::kChargedHadron,
+                           boost::make_filter_iterator(pfChargedJunk, regionalJunk.begin(), regionalJunk.end()),
+                           boost::make_filter_iterator(pfChargedJunk, regionalJunk.end(), regionalJunk.end()));
+
+            // Add all PFGamma constituents of the jet that are not part of a PiZero
+            if (verbosity_ >= 2) {
+              std::cout << "adding isolation PFGammas not considered in PiZeros:" << std::endl;
+            }
+            tau.addPFCands(
+                RecoTauConstructor::kIsolation,
+                RecoTauConstructor::kGamma,
+                boost::make_filter_iterator(pfCandFilter_allChargedHadrons, pfgammas.begin(), pfgammas.end()),
+                boost::make_filter_iterator(pfCandFilter_allChargedHadrons, pfgammas.end(), pfgammas.end()));
+            // Add all gammas that are in the iso cone but weren't in the
+            // orginal PFJet
+            tau.addPFCands(RecoTauConstructor::kIsolation,
+                           RecoTauConstructor::kGamma,
+                           boost::make_filter_iterator(pfGammaJunk, regionalJunk.begin(), regionalJunk.end()),
+                           boost::make_filter_iterator(pfGammaJunk, regionalJunk.end(), regionalJunk.end()));
+
+            // Add all the neutral hadron candidates to the isolation collection
+            tau.addPFCands(RecoTauConstructor::kIsolation,
+                           RecoTauConstructor::kNeutralHadron,
+                           boost::make_filter_iterator(pfCandFilter_allChargedHadrons, pfnhs.begin(), pfnhs.end()),
+                           boost::make_filter_iterator(pfCandFilter_allChargedHadrons, pfnhs.end(), pfnhs.end()));
+            // Add all the neutral hadrons from the region collection that are in
+            // the iso cone to the tau
+            tau.addPFCands(RecoTauConstructor::kIsolation,
+                           RecoTauConstructor::kNeutralHadron,
+                           boost::make_filter_iterator(pfNeutralJunk, regionalJunk.begin(), regionalJunk.end()),
+                           boost::make_filter_iterator(pfNeutralJunk, regionalJunk.end(), regionalJunk.end()));
+
+            std::auto_ptr<reco::PFTau> tauPtr = tau.get(true);
+
+            // Set event vertex position for tau
+            reco::VertexRef primaryVertexRef = primaryVertex(*tauPtr);
+            if (primaryVertexRef.isNonnull()) {
+              tauPtr->setVertex(primaryVertexRef->position());
+            }
+
+            double tauEn = tauPtr->energy();
+            double tauPz = tauPtr->pz();
+            const double chargedPionMass = 0.13957;  // GeV
+            double tauMass = std::max(tauPtr->mass(), chargedPionMass);
+            double bendCorrMass2 = 0.;
+            const std::vector<RecoTauPiZero>& piZeros = tauPtr->signalPiZeroCandidates();
+            for (auto const& piZero : piZeros) {
+              double piZeroEn = piZero.energy();
+              double piZeroPx = piZero.px();
+              double piZeroPy = piZero.py();
+              double piZeroPz = piZero.pz();
+              double tau_wo_piZeroPx = tauPtr->px() - piZeroPx;
+              double tau_wo_piZeroPy = tauPtr->py() - piZeroPy;
+              // CV: Compute effect of varying strip four-vector by eta and phi correction on tau mass
+              //    (derrivative of tau mass by strip eta, phi has been computed using Mathematica)
+              bendCorrMass2 += square(((piZeroPz * tauEn - piZeroEn * tauPz) / tauMass) * piZero.bendCorrEta());
+              bendCorrMass2 +=
+                  square(((piZeroPy * tau_wo_piZeroPx - piZeroPx * tau_wo_piZeroPy) / tauMass) * piZero.bendCorrPhi());
+            }
+            //edm::LogPrint("RecoTauBuilderCombinatoricPlugin") << "bendCorrMass2 = " << sqrt(bendCorrMass2) << std::endl;
+            tauPtr->setBendCorrMass(sqrt(bendCorrMass2));
+
+            output.push_back(tauPtr);
+          }
+        }
+      }
+
+      return output.release();
     }
-  }
 
-  return output.release();
-}
-
-}}  // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauBuilderPluginFactory,

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -27,453 +27,402 @@
 
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-typedef std::vector<RecoTauPiZero> PiZeroList;
-  
-class RecoTauBuilderConePlugin : public RecoTauBuilderPlugin {
-  public:
-  explicit RecoTauBuilderConePlugin(const edm::ParameterSet& pset,edm::ConsumesCollector &&iC);
-    ~RecoTauBuilderConePlugin() override {}
-    // Build a tau from a jet
-    return_type operator()(const reco::JetBaseRef& jet,
-	const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons,
-        const std::vector<RecoTauPiZero>& piZeros,
-        const std::vector<CandidatePtr>& regionalExtras) const override;
-  private:
-    RecoTauQualityCuts qcuts_;
+    typedef std::vector<RecoTauPiZero> PiZeroList;
 
-    bool usePFLeptonsAsChargedHadrons_;
+    class RecoTauBuilderConePlugin : public RecoTauBuilderPlugin {
+    public:
+      explicit RecoTauBuilderConePlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+      ~RecoTauBuilderConePlugin() override {}
+      // Build a tau from a jet
+      return_type operator()(const reco::JetBaseRef& jet,
+                             const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons,
+                             const std::vector<RecoTauPiZero>& piZeros,
+                             const std::vector<CandidatePtr>& regionalExtras) const override;
 
-    double leadObjecPtThreshold_;
+    private:
+      RecoTauQualityCuts qcuts_;
 
-    /* String function to extract values from PFJets */
-    typedef StringObjectFunction<reco::Jet> JetFunc;
+      bool usePFLeptonsAsChargedHadrons_;
 
-    // Cone defintions
-    JetFunc matchingCone_;
-    JetFunc signalConeChargedHadrons_;
-    JetFunc isoConeChargedHadrons_;
-    JetFunc signalConePiZeros_;
-    StringObjectFunction<reco::PFTau> signalConeSizeToStore_;
-    JetFunc isoConePiZeros_;
-    JetFunc signalConeNeutralHadrons_;
-    JetFunc isoConeNeutralHadrons_;
+      double leadObjecPtThreshold_;
 
-    int maxSignalConeChargedHadrons_;
-    double minAbsPhotonSumPt_insideSignalCone_;
-    double minRelPhotonSumPt_insideSignalCone_;
+      /* String function to extract values from PFJets */
+      typedef StringObjectFunction<reco::Jet> JetFunc;
 
-    void setTauQuantities(reco::PFTau& aTau,
-			  double minAbsPhotonSumPt_insideSignalCone = 2.5,
-			  double minRelPhotonSumPt_insideSignalCone = 0.,
-			  double minAbsPhotonSumPt_outsideSignalCone = 1.e+9,
-			  double minRelPhotonSumPt_outsideSignalCone = 1.e+9) const;
+      // Cone defintions
+      JetFunc matchingCone_;
+      JetFunc signalConeChargedHadrons_;
+      JetFunc isoConeChargedHadrons_;
+      JetFunc signalConePiZeros_;
+      StringObjectFunction<reco::PFTau> signalConeSizeToStore_;
+      JetFunc isoConePiZeros_;
+      JetFunc signalConeNeutralHadrons_;
+      JetFunc isoConeNeutralHadrons_;
 
-};
+      int maxSignalConeChargedHadrons_;
+      double minAbsPhotonSumPt_insideSignalCone_;
+      double minRelPhotonSumPt_insideSignalCone_;
 
-// ctor - initialize all of our variables
-RecoTauBuilderConePlugin::RecoTauBuilderConePlugin(
-						   const edm::ParameterSet& pset, edm::ConsumesCollector &&iC):RecoTauBuilderPlugin(pset,std::move(iC)),
-    qcuts_(pset.getParameterSet(
-          "qualityCuts").getParameterSet("signalQualityCuts")),
-    usePFLeptonsAsChargedHadrons_(pset.getParameter<bool>("usePFLeptons")),
-    leadObjecPtThreshold_(pset.getParameter<double>("leadObjectPt")),
-    matchingCone_(pset.getParameter<std::string>("matchingCone")),
-    signalConeChargedHadrons_(pset.getParameter<std::string>(
-            "signalConeChargedHadrons")),
-    isoConeChargedHadrons_(
-        pset.getParameter<std::string>("isoConeChargedHadrons")),
-    signalConePiZeros_(
-        pset.getParameter<std::string>("signalConePiZeros")),
-    signalConeSizeToStore_(//MB: stored inside PFTau and used to compte photon-pt-out-of-signal-cone and DM hypothsis
-	pset.getParameter<std::string>("signalConePiZeros")),
-    isoConePiZeros_(
-        pset.getParameter<std::string>("isoConePiZeros")),
-    signalConeNeutralHadrons_(
-        pset.getParameter<std::string>("signalConeNeutralHadrons")),
-    isoConeNeutralHadrons_(
-        pset.getParameter<std::string>("isoConeNeutralHadrons")), 
-    maxSignalConeChargedHadrons_(
-        pset.getParameter<int>("maxSignalConeChargedHadrons")),
-    minAbsPhotonSumPt_insideSignalCone_(
-        pset.getParameter<double>("minAbsPhotonSumPt_insideSignalCone")),
-    minRelPhotonSumPt_insideSignalCone_(
-	pset.getParameter<double>("minRelPhotonSumPt_insideSignalCone"))
+      void setTauQuantities(reco::PFTau& aTau,
+                            double minAbsPhotonSumPt_insideSignalCone = 2.5,
+                            double minRelPhotonSumPt_insideSignalCone = 0.,
+                            double minAbsPhotonSumPt_outsideSignalCone = 1.e+9,
+                            double minRelPhotonSumPt_outsideSignalCone = 1.e+9) const;
+    };
 
-{}
+    // ctor - initialize all of our variables
+    RecoTauBuilderConePlugin::RecoTauBuilderConePlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : RecoTauBuilderPlugin(pset, std::move(iC)),
+          qcuts_(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts")),
+          usePFLeptonsAsChargedHadrons_(pset.getParameter<bool>("usePFLeptons")),
+          leadObjecPtThreshold_(pset.getParameter<double>("leadObjectPt")),
+          matchingCone_(pset.getParameter<std::string>("matchingCone")),
+          signalConeChargedHadrons_(pset.getParameter<std::string>("signalConeChargedHadrons")),
+          isoConeChargedHadrons_(pset.getParameter<std::string>("isoConeChargedHadrons")),
+          signalConePiZeros_(pset.getParameter<std::string>("signalConePiZeros")),
+          signalConeSizeToStore_(  //MB: stored inside PFTau and used to compte photon-pt-out-of-signal-cone and DM hypothsis
+              pset.getParameter<std::string>("signalConePiZeros")),
+          isoConePiZeros_(pset.getParameter<std::string>("isoConePiZeros")),
+          signalConeNeutralHadrons_(pset.getParameter<std::string>("signalConeNeutralHadrons")),
+          isoConeNeutralHadrons_(pset.getParameter<std::string>("isoConeNeutralHadrons")),
+          maxSignalConeChargedHadrons_(pset.getParameter<int>("maxSignalConeChargedHadrons")),
+          minAbsPhotonSumPt_insideSignalCone_(pset.getParameter<double>("minAbsPhotonSumPt_insideSignalCone")),
+          minRelPhotonSumPt_insideSignalCone_(pset.getParameter<double>("minRelPhotonSumPt_insideSignalCone"))
 
-namespace xclean 
-{ 
-  // define template specialization for cross-cleaning
-  template<>
-  inline void CrossCleanPiZeros<cone::CandPtrDRFilterIter>::initialize(const cone::CandPtrDRFilterIter& signalTracksBegin, const cone::CandPtrDRFilterIter& signalTracksEnd) 
-  {
-    // Get the list of objects we need to clean
-    for ( cone::CandPtrDRFilterIter signalTrack = signalTracksBegin; signalTrack != signalTracksEnd; ++signalTrack ) {
-      toRemove_.insert(reco::CandidatePtr(*signalTrack));
-    }
-  }
-  
-  template<>
-  inline void CrossCleanPtrs<PiZeroList::const_iterator>::initialize(const PiZeroList::const_iterator& piZerosBegin, const PiZeroList::const_iterator& piZerosEnd) 
-  {
-    for(auto const& ptr : flattenPiZeros(piZerosBegin, piZerosEnd) ) {
-      toRemove_.insert(CandidatePtr(ptr));
-    }
-  }
-}
+    {}
 
-void RecoTauBuilderConePlugin::setTauQuantities(reco::PFTau& aTau,
-						double minAbsPhotonSumPt_insideSignalCone,
-						double minRelPhotonSumPt_insideSignalCone,
-						double minAbsPhotonSumPt_outsideSignalCone,
-						double minRelPhotonSumPt_outsideSignalCone) const {
-  //MB: Set tau quantities which are computed by RecoTauConstructor::get() 
-  //    method with PFRecoTauChargedHadrons not used here
-  
-  // Set charge
-  int charge = 0;
-  int leadCharge = aTau.leadChargedHadrCand().isNonnull() ? aTau.leadChargedHadrCand()->charge() : 0;
-  const std::vector<reco::CandidatePtr>& pfChs = aTau.signalChargedHadrCands();
-  for(const reco::CandidatePtr& pfCh : pfChs){
-    charge += pfCh->charge();
-  }
-  charge = charge==0 ? leadCharge : charge;
-  aTau.setCharge(charge);
-  
-  // Set PDG id
-  aTau.setPdgId(aTau.charge() < 0 ? 15 : -15); 
-  
-  // Set Decay Mode
-  PFTau::hadronicDecayMode dm = PFTau::kNull; 
-  unsigned int nPiZeros = 0;
-  const std::vector<RecoTauPiZero>& piZeros = aTau.signalPiZeroCandidates();
-  for(const RecoTauPiZero& piZero : piZeros) {
-    double photonSumPt_insideSignalCone = 0.;
-    double photonSumPt_outsideSignalCone = 0.;
-    int numPhotons = piZero.numberOfDaughters();
-    for(int idxPhoton = 0; idxPhoton < numPhotons; ++idxPhoton) {
-      const reco::Candidate* photon = piZero.daughter(idxPhoton);
-      double dR = deltaR(photon->p4(), aTau.p4());
-      if(dR < aTau.signalConeSize() ){
-	photonSumPt_insideSignalCone += photon->pt();
-      } else {
-	photonSumPt_outsideSignalCone += photon->pt();
+    namespace xclean {
+      // define template specialization for cross-cleaning
+      template <>
+      inline void CrossCleanPiZeros<cone::CandPtrDRFilterIter>::initialize(
+          const cone::CandPtrDRFilterIter& signalTracksBegin, const cone::CandPtrDRFilterIter& signalTracksEnd) {
+        // Get the list of objects we need to clean
+        for (cone::CandPtrDRFilterIter signalTrack = signalTracksBegin; signalTrack != signalTracksEnd; ++signalTrack) {
+          toRemove_.insert(reco::CandidatePtr(*signalTrack));
+        }
       }
+
+      template <>
+      inline void CrossCleanPtrs<PiZeroList::const_iterator>::initialize(const PiZeroList::const_iterator& piZerosBegin,
+                                                                         const PiZeroList::const_iterator& piZerosEnd) {
+        for (auto const& ptr : flattenPiZeros(piZerosBegin, piZerosEnd)) {
+          toRemove_.insert(CandidatePtr(ptr));
+        }
+      }
+    }  // namespace xclean
+
+    void RecoTauBuilderConePlugin::setTauQuantities(reco::PFTau& aTau,
+                                                    double minAbsPhotonSumPt_insideSignalCone,
+                                                    double minRelPhotonSumPt_insideSignalCone,
+                                                    double minAbsPhotonSumPt_outsideSignalCone,
+                                                    double minRelPhotonSumPt_outsideSignalCone) const {
+      //MB: Set tau quantities which are computed by RecoTauConstructor::get()
+      //    method with PFRecoTauChargedHadrons not used here
+
+      // Set charge
+      int charge = 0;
+      int leadCharge = aTau.leadChargedHadrCand().isNonnull() ? aTau.leadChargedHadrCand()->charge() : 0;
+      const std::vector<reco::CandidatePtr>& pfChs = aTau.signalChargedHadrCands();
+      for (const reco::CandidatePtr& pfCh : pfChs) {
+        charge += pfCh->charge();
+      }
+      charge = charge == 0 ? leadCharge : charge;
+      aTau.setCharge(charge);
+
+      // Set PDG id
+      aTau.setPdgId(aTau.charge() < 0 ? 15 : -15);
+
+      // Set Decay Mode
+      PFTau::hadronicDecayMode dm = PFTau::kNull;
+      unsigned int nPiZeros = 0;
+      const std::vector<RecoTauPiZero>& piZeros = aTau.signalPiZeroCandidates();
+      for (const RecoTauPiZero& piZero : piZeros) {
+        double photonSumPt_insideSignalCone = 0.;
+        double photonSumPt_outsideSignalCone = 0.;
+        int numPhotons = piZero.numberOfDaughters();
+        for (int idxPhoton = 0; idxPhoton < numPhotons; ++idxPhoton) {
+          const reco::Candidate* photon = piZero.daughter(idxPhoton);
+          double dR = deltaR(photon->p4(), aTau.p4());
+          if (dR < aTau.signalConeSize()) {
+            photonSumPt_insideSignalCone += photon->pt();
+          } else {
+            photonSumPt_outsideSignalCone += photon->pt();
+          }
+        }
+        if (photonSumPt_insideSignalCone > minAbsPhotonSumPt_insideSignalCone ||
+            photonSumPt_insideSignalCone > (minRelPhotonSumPt_insideSignalCone * aTau.pt()) ||
+            photonSumPt_outsideSignalCone > minAbsPhotonSumPt_outsideSignalCone ||
+            photonSumPt_outsideSignalCone > (minRelPhotonSumPt_outsideSignalCone * aTau.pt()))
+          ++nPiZeros;
+      }
+      // Find the maximum number of PiZeros our parameterization can hold
+      const unsigned int maxPiZeros = PFTau::kOneProngNPiZero;
+      // Determine our track index
+      unsigned int nCharged = pfChs.size();
+      if (nCharged > 0) {
+        unsigned int trackIndex = (nCharged - 1) * (maxPiZeros + 1);
+        // Check if we handle the given number of tracks
+        if (trackIndex >= PFTau::kRareDecayMode)
+          dm = PFTau::kRareDecayMode;
+        else
+          dm = static_cast<PFTau::hadronicDecayMode>(trackIndex + std::min(nPiZeros, maxPiZeros));
+      } else {
+        dm = PFTau::kNull;
+      }
+      aTau.setDecayMode(dm);
+      return;
     }
-    if( photonSumPt_insideSignalCone  > minAbsPhotonSumPt_insideSignalCone  || photonSumPt_insideSignalCone  > (minRelPhotonSumPt_insideSignalCone*aTau.pt())  ||
-	photonSumPt_outsideSignalCone > minAbsPhotonSumPt_outsideSignalCone || photonSumPt_outsideSignalCone > (minRelPhotonSumPt_outsideSignalCone*aTau.pt()) ) ++nPiZeros;
-  }
-  // Find the maximum number of PiZeros our parameterization can hold
-  const unsigned int maxPiZeros = PFTau::kOneProngNPiZero;
-  // Determine our track index
-  unsigned int nCharged = pfChs.size();
-  if(nCharged>0){
-    unsigned int trackIndex = (nCharged - 1)*(maxPiZeros + 1);
-    // Check if we handle the given number of tracks
-    if(trackIndex >= PFTau::kRareDecayMode) 
-      dm = PFTau::kRareDecayMode;    
-    else
-      dm = static_cast<PFTau::hadronicDecayMode>(trackIndex + std::min(nPiZeros,maxPiZeros) );
-  }
-  else{
-    dm = PFTau::kNull;
-  }
-  aTau.setDecayMode(dm);
-  return;
-}
 
-RecoTauBuilderConePlugin::return_type RecoTauBuilderConePlugin::operator()(
-    const reco::JetBaseRef& jet,
-    const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons, 
-    const std::vector<RecoTauPiZero>& piZeros,
-    const std::vector<CandidatePtr>& regionalExtras) const {
-  //std::cout << "<RecoTauBuilderConePlugin::operator()>:" << std::endl;
-  //std::cout << " jet: Pt = " << jet->pt() << ", eta = " << jet->eta() << ", phi = " << jet->phi() << std::endl;
+    RecoTauBuilderConePlugin::return_type RecoTauBuilderConePlugin::operator()(
+        const reco::JetBaseRef& jet,
+        const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons,
+        const std::vector<RecoTauPiZero>& piZeros,
+        const std::vector<CandidatePtr>& regionalExtras) const {
+      //std::cout << "<RecoTauBuilderConePlugin::operator()>:" << std::endl;
+      //std::cout << " jet: Pt = " << jet->pt() << ", eta = " << jet->eta() << ", phi = " << jet->phi() << std::endl;
 
-  // Get access to our cone tools
-  using namespace cone;
-  // Define output.  We only produce one tau per jet for the cone algo.
-  output_type output;
+      // Get access to our cone tools
+      using namespace cone;
+      // Define output.  We only produce one tau per jet for the cone algo.
+      output_type output;
 
-  // Our tau builder - the true indicates to automatically copy gamma candidates
-  // from the pizeros.
-  RecoTauConstructor tau(jet, getPFCands(), true, 
-			 &signalConeSizeToStore_, 
-			 minAbsPhotonSumPt_insideSignalCone_, 
-			 minRelPhotonSumPt_insideSignalCone_);
-  // Setup our quality cuts to use the current vertex (supplied by base class)
-  qcuts_.setPV(primaryVertex(jet));
+      // Our tau builder - the true indicates to automatically copy gamma candidates
+      // from the pizeros.
+      RecoTauConstructor tau(jet,
+                             getPFCands(),
+                             true,
+                             &signalConeSizeToStore_,
+                             minAbsPhotonSumPt_insideSignalCone_,
+                             minRelPhotonSumPt_insideSignalCone_);
+      // Setup our quality cuts to use the current vertex (supplied by base class)
+      qcuts_.setPV(primaryVertex(jet));
 
-  typedef std::vector<CandidatePtr> CandPtrs;
+      typedef std::vector<CandidatePtr> CandPtrs;
 
-  // Get the PF Charged hadrons + quality cuts
-  CandPtrs pfchs;
-  if (!usePFLeptonsAsChargedHadrons_) {
-    pfchs = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 211));
-  } else {
-    // Check if we want to include electrons in muons in "charged hadron"
-    // collection.  This is the preferred behavior, as the PF lepton selections
-    // are very loose.
-    pfchs = qcuts_.filterCandRefs(pfChargedCands(*jet));
-  }
+      // Get the PF Charged hadrons + quality cuts
+      CandPtrs pfchs;
+      if (!usePFLeptonsAsChargedHadrons_) {
+        pfchs = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 211));
+      } else {
+        // Check if we want to include electrons in muons in "charged hadron"
+        // collection.  This is the preferred behavior, as the PF lepton selections
+        // are very loose.
+        pfchs = qcuts_.filterCandRefs(pfChargedCands(*jet));
+      }
 
-  // CV: sort collection of PF Charged hadrons by descending Pt
-  std::sort(pfchs.begin(), pfchs.end(), SortPFCandsDescendingPt());
+      // CV: sort collection of PF Charged hadrons by descending Pt
+      std::sort(pfchs.begin(), pfchs.end(), SortPFCandsDescendingPt());
 
-  // Get the PF gammas
-  CandPtrs pfGammas = qcuts_.filterCandRefs(
-      pfCandidatesByPdgId(*jet, 22));
-  // Neutral hadrons
-  CandPtrs pfnhs = qcuts_.filterCandRefs(
-      pfCandidatesByPdgId(*jet, 130));
+      // Get the PF gammas
+      CandPtrs pfGammas = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 22));
+      // Neutral hadrons
+      CandPtrs pfnhs = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 130));
 
-  // All the extra junk
-  CandPtrs regionalJunk = qcuts_.filterCandRefs(regionalExtras);
+      // All the extra junk
+      CandPtrs regionalJunk = qcuts_.filterCandRefs(regionalExtras);
 
-  /***********************************************
+      /***********************************************
    ******     Lead Candidate Finding    **********
    ***********************************************/
 
-  // Define our matching cone and filters
-  double matchingCone = matchingCone_(*jet);
-  CandPtrDRFilter matchingConeFilter(jet->p4(), 0, matchingCone);
+      // Define our matching cone and filters
+      double matchingCone = matchingCone_(*jet);
+      CandPtrDRFilter matchingConeFilter(jet->p4(), 0, matchingCone);
 
-  // Find the maximum PFCharged hadron in the matching cone.  The call to
-  // PFCandidates always a sorted list, so we can just take the first if it
-  // if it exists.
-  CandidatePtr leadPFCH;
-  CandPtrs::iterator leadPFCH_iter =
-      std::find_if(pfchs.begin(), pfchs.end(), matchingConeFilter);
+      // Find the maximum PFCharged hadron in the matching cone.  The call to
+      // PFCandidates always a sorted list, so we can just take the first if it
+      // if it exists.
+      CandidatePtr leadPFCH;
+      CandPtrs::iterator leadPFCH_iter = std::find_if(pfchs.begin(), pfchs.end(), matchingConeFilter);
 
-  if (leadPFCH_iter != pfchs.end()) {
-    leadPFCH = *leadPFCH_iter;
-    // Set leading candidate
-    tau.setleadChargedHadrCand(leadPFCH);
-  } else {
-    // If there is no leading charged candidate at all, return nothing - the
-    // producer class that owns the plugin will build a null tau if desired.
-    return output.release();
-  }
+      if (leadPFCH_iter != pfchs.end()) {
+        leadPFCH = *leadPFCH_iter;
+        // Set leading candidate
+        tau.setleadChargedHadrCand(leadPFCH);
+      } else {
+        // If there is no leading charged candidate at all, return nothing - the
+        // producer class that owns the plugin will build a null tau if desired.
+        return output.release();
+      }
 
-  // Find the leading neutral candidate
-  CandidatePtr leadPFGamma;
-  CandPtrs::iterator leadPFGamma_iter =
-      std::find_if(pfGammas.begin(), pfGammas.end(), matchingConeFilter);
+      // Find the leading neutral candidate
+      CandidatePtr leadPFGamma;
+      CandPtrs::iterator leadPFGamma_iter = std::find_if(pfGammas.begin(), pfGammas.end(), matchingConeFilter);
 
-  if (leadPFGamma_iter != pfGammas.end()) {
-    leadPFGamma = *leadPFGamma_iter;
-    // Set leading neutral candidate
-    tau.setleadNeutralCand(leadPFGamma);
-  }
+      if (leadPFGamma_iter != pfGammas.end()) {
+        leadPFGamma = *leadPFGamma_iter;
+        // Set leading neutral candidate
+        tau.setleadNeutralCand(leadPFGamma);
+      }
 
-  CandidatePtr leadPFCand;
-  // Always use the leadPFCH if it is above our threshold
-  if (leadPFCH.isNonnull() && leadPFCH->pt() > leadObjecPtThreshold_) {
-    leadPFCand = leadPFCH;
-  } else if (leadPFGamma.isNonnull() &&
-             leadPFGamma->pt() > leadObjecPtThreshold_) {
-    // Otherwise use the lead Gamma if it is above threshold
-    leadPFCand = leadPFGamma;
-  } else {
-    // If both are too low PT, just take the charged one
-    leadPFCand = leadPFCH;
-  }
+      CandidatePtr leadPFCand;
+      // Always use the leadPFCH if it is above our threshold
+      if (leadPFCH.isNonnull() && leadPFCH->pt() > leadObjecPtThreshold_) {
+        leadPFCand = leadPFCH;
+      } else if (leadPFGamma.isNonnull() && leadPFGamma->pt() > leadObjecPtThreshold_) {
+        // Otherwise use the lead Gamma if it is above threshold
+        leadPFCand = leadPFGamma;
+      } else {
+        // If both are too low PT, just take the charged one
+        leadPFCand = leadPFCH;
+      }
 
-  tau.setleadCand(leadPFCand);
+      tau.setleadCand(leadPFCand);
 
-  // Our cone axis is defined about the lead charged hadron
-  reco::Candidate::LorentzVector coneAxis = leadPFCH->p4();
+      // Our cone axis is defined about the lead charged hadron
+      reco::Candidate::LorentzVector coneAxis = leadPFCH->p4();
 
-  /***********************************************
+      /***********************************************
    ******     Cone Construction         **********
    ***********************************************/
 
-  // Define the signal and isolation cone sizes for this jet and build filters
-  // to select elements in the given DeltaR regions
+      // Define the signal and isolation cone sizes for this jet and build filters
+      // to select elements in the given DeltaR regions
 
-  CandPtrDRFilter signalConePFCHFilter(
-      coneAxis, -0.1, signalConeChargedHadrons_(*jet));
-  CandPtrDRFilter signalConePFNHFilter(
-      coneAxis, -0.1, signalConeNeutralHadrons_(*jet));
-  PiZeroDRFilter signalConePiZeroFilter(
-      coneAxis, -0.1, signalConePiZeros_(*jet));
+      CandPtrDRFilter signalConePFCHFilter(coneAxis, -0.1, signalConeChargedHadrons_(*jet));
+      CandPtrDRFilter signalConePFNHFilter(coneAxis, -0.1, signalConeNeutralHadrons_(*jet));
+      PiZeroDRFilter signalConePiZeroFilter(coneAxis, -0.1, signalConePiZeros_(*jet));
 
-  CandPtrDRFilter isoConePFCHFilter(
-      coneAxis, signalConeChargedHadrons_(*jet), isoConeChargedHadrons_(*jet));
-  CandPtrDRFilter isoConePFGammaFilter(
-      coneAxis, signalConePiZeros_(*jet), isoConePiZeros_(*jet));
-  CandPtrDRFilter isoConePFNHFilter(
-      coneAxis, signalConeNeutralHadrons_(*jet), isoConeNeutralHadrons_(*jet));
-  PiZeroDRFilter isoConePiZeroFilter(
-      coneAxis, signalConePiZeros_(*jet), isoConePiZeros_(*jet));
+      CandPtrDRFilter isoConePFCHFilter(coneAxis, signalConeChargedHadrons_(*jet), isoConeChargedHadrons_(*jet));
+      CandPtrDRFilter isoConePFGammaFilter(coneAxis, signalConePiZeros_(*jet), isoConePiZeros_(*jet));
+      CandPtrDRFilter isoConePFNHFilter(coneAxis, signalConeNeutralHadrons_(*jet), isoConeNeutralHadrons_(*jet));
+      PiZeroDRFilter isoConePiZeroFilter(coneAxis, signalConePiZeros_(*jet), isoConePiZeros_(*jet));
 
-  // Additionally make predicates to select the different PF object types
-  // of the regional junk objects to add to the iso cone.
-  typedef xclean::PredicateAND<xclean::FilterCandByAbsPdgId, CandPtrDRFilter> RegionalJunkConeAndIdFilter;
+      // Additionally make predicates to select the different PF object types
+      // of the regional junk objects to add to the iso cone.
+      typedef xclean::PredicateAND<xclean::FilterCandByAbsPdgId, CandPtrDRFilter> RegionalJunkConeAndIdFilter;
 
-  xclean::FilterCandByAbsPdgId pfchCandSelector(211);
-  xclean::FilterCandByAbsPdgId pfgammaCandSelector(22);
-  xclean::FilterCandByAbsPdgId pfnhCandSelector(130);
+      xclean::FilterCandByAbsPdgId pfchCandSelector(211);
+      xclean::FilterCandByAbsPdgId pfgammaCandSelector(22);
+      xclean::FilterCandByAbsPdgId pfnhCandSelector(130);
 
-  // Predicate to select the regional junk in the iso cone by PF id
-  RegionalJunkConeAndIdFilter pfChargedJunk(
-      pfchCandSelector, // select charged stuff from junk
-      isoConePFCHFilter // only take those in iso cone
+      // Predicate to select the regional junk in the iso cone by PF id
+      RegionalJunkConeAndIdFilter pfChargedJunk(pfchCandSelector,  // select charged stuff from junk
+                                                isoConePFCHFilter  // only take those in iso cone
       );
 
-  RegionalJunkConeAndIdFilter pfGammaJunk(
-      pfgammaCandSelector, // select gammas from junk
-      isoConePFGammaFilter // only take those in iso cone
+      RegionalJunkConeAndIdFilter pfGammaJunk(pfgammaCandSelector,  // select gammas from junk
+                                              isoConePFGammaFilter  // only take those in iso cone
       );
 
-  RegionalJunkConeAndIdFilter pfNeutralJunk(
-      pfnhCandSelector, // select neutral stuff from junk
-      isoConePFNHFilter // select stuff in iso cone
+      RegionalJunkConeAndIdFilter pfNeutralJunk(pfnhCandSelector,  // select neutral stuff from junk
+                                                isoConePFNHFilter  // select stuff in iso cone
       );
 
-  // Build filter iterators select the signal charged stuff.
-  CandPtrDRFilterIter signalPFCHCands_begin(
-      signalConePFCHFilter, pfchs.begin(), pfchs.end());
-  CandPtrDRFilterIter signalPFCHCands_end(
-      signalConePFCHFilter, pfchs.end(), pfchs.end());
-  CandPtrs signalPFCHs;
-  int numSignalPFCHs = 0;
-  CandPtrs isolationPFCHs;
-  int numIsolationPFCHs = 0;
-  for ( CandPtrDRFilterIter iter = signalPFCHCands_begin; iter != signalPFCHCands_end; ++iter ) {
-    if ( numSignalPFCHs < maxSignalConeChargedHadrons_ || maxSignalConeChargedHadrons_ == -1 ) {
-      //std::cout << "adding signalPFCH #" << numSignalPFCHs << ": Pt = " << (*iter)->pt() << ", eta = " << (*iter)->eta() << ", phi = " << (*iter)->phi() << std::endl;
-      signalPFCHs.push_back(*iter);
-      ++numSignalPFCHs;
-    } else {
-      //std::cout << "maxSignalConeChargedHadrons reached" 
-      //	  << " --> adding isolationPFCH #" << numIsolationPFCHs << ": Pt = " << (*iter)->pt() << ", eta = " << (*iter)->eta() << ", phi = " << (*iter)->phi() << std::endl;
-      isolationPFCHs.push_back(*iter);
-      ++numIsolationPFCHs;
+      // Build filter iterators select the signal charged stuff.
+      CandPtrDRFilterIter signalPFCHCands_begin(signalConePFCHFilter, pfchs.begin(), pfchs.end());
+      CandPtrDRFilterIter signalPFCHCands_end(signalConePFCHFilter, pfchs.end(), pfchs.end());
+      CandPtrs signalPFCHs;
+      int numSignalPFCHs = 0;
+      CandPtrs isolationPFCHs;
+      int numIsolationPFCHs = 0;
+      for (CandPtrDRFilterIter iter = signalPFCHCands_begin; iter != signalPFCHCands_end; ++iter) {
+        if (numSignalPFCHs < maxSignalConeChargedHadrons_ || maxSignalConeChargedHadrons_ == -1) {
+          //std::cout << "adding signalPFCH #" << numSignalPFCHs << ": Pt = " << (*iter)->pt() << ", eta = " << (*iter)->eta() << ", phi = " << (*iter)->phi() << std::endl;
+          signalPFCHs.push_back(*iter);
+          ++numSignalPFCHs;
+        } else {
+          //std::cout << "maxSignalConeChargedHadrons reached"
+          //	  << " --> adding isolationPFCH #" << numIsolationPFCHs << ": Pt = " << (*iter)->pt() << ", eta = " << (*iter)->eta() << ", phi = " << (*iter)->phi() << std::endl;
+          isolationPFCHs.push_back(*iter);
+          ++numIsolationPFCHs;
+        }
+      }
+      CandPtrs::const_iterator signalPFCHs_begin = signalPFCHs.begin();
+      CandPtrs::const_iterator signalPFCHs_end = signalPFCHs.end();
+
+      // Cross clean pi zero content using signal cone charged hadron constituents.
+      xclean::CrossCleanPiZeros<CandPtrDRFilterIter> piZeroXCleaner(signalPFCHCands_begin, signalPFCHCands_end);
+      std::vector<reco::RecoTauPiZero> cleanPiZeros = piZeroXCleaner(piZeros);
+
+      // For the rest of the constituents, we need to filter any constituents that
+      // are already contained in the pizeros (i.e. electrons)
+      xclean::CrossCleanPtrs<PiZeroList::const_iterator> pfCandXCleaner(cleanPiZeros.begin(), cleanPiZeros.end());
+
+      auto isolationPFCHCands_begin(boost::make_filter_iterator(
+          xclean::makePredicateAND(isoConePFCHFilter, pfCandXCleaner), pfchs.begin(), pfchs.end()));
+      auto isolationPFCHCands_end(boost::make_filter_iterator(
+          xclean::makePredicateAND(isoConePFCHFilter, pfCandXCleaner), pfchs.end(), pfchs.end()));
+      for (auto iter = isolationPFCHCands_begin; iter != isolationPFCHCands_end; ++iter) {
+        //std::cout << "adding isolationPFCH #" << numIsolationPFCHs << ": Pt = " << (*iter)->pt() << ", eta = " << (*iter)->eta() << ", phi = " << (*iter)->phi() << std::endl;
+        isolationPFCHs.push_back(*iter);
+        ++numIsolationPFCHs;
+      }
+      CandPtrs::const_iterator isolationPFCHs_begin = isolationPFCHs.begin();
+      CandPtrs::const_iterator isolationPFCHs_end = isolationPFCHs.end();
+
+      // Build signal charged hadrons
+      tau.addPFCands(
+          RecoTauConstructor::kSignal, RecoTauConstructor::kChargedHadron, signalPFCHs_begin, signalPFCHs_end);
+
+      tau.addPFCands(RecoTauConstructor::kSignal,
+                     RecoTauConstructor::kNeutralHadron,
+                     boost::make_filter_iterator(
+                         xclean::makePredicateAND(signalConePFNHFilter, pfCandXCleaner), pfnhs.begin(), pfnhs.end()),
+                     boost::make_filter_iterator(
+                         xclean::makePredicateAND(signalConePFNHFilter, pfCandXCleaner), pfnhs.end(), pfnhs.end()));
+
+      // Build signal PiZeros
+      tau.addPiZeros(RecoTauConstructor::kSignal,
+                     PiZeroDRFilterIter(signalConePiZeroFilter, cleanPiZeros.begin(), cleanPiZeros.end()),
+                     PiZeroDRFilterIter(signalConePiZeroFilter, cleanPiZeros.end(), cleanPiZeros.end()));
+
+      // Build isolation charged hadrons
+      tau.addPFCands(
+          RecoTauConstructor::kIsolation, RecoTauConstructor::kChargedHadron, isolationPFCHs_begin, isolationPFCHs_end);
+
+      // Add all the stuff in the isolation cone that wasn't in the jet constituents
+      tau.addPFCands(RecoTauConstructor::kIsolation,
+                     RecoTauConstructor::kChargedHadron,
+                     boost::make_filter_iterator(pfChargedJunk, regionalJunk.begin(), regionalJunk.end()),
+                     boost::make_filter_iterator(pfChargedJunk, regionalJunk.end(), regionalJunk.end()));
+
+      // Build isolation neutral hadrons
+      tau.addPFCands(RecoTauConstructor::kIsolation,
+                     RecoTauConstructor::kNeutralHadron,
+                     boost::make_filter_iterator(
+                         xclean::makePredicateAND(isoConePFNHFilter, pfCandXCleaner), pfnhs.begin(), pfnhs.end()),
+                     boost::make_filter_iterator(
+                         xclean::makePredicateAND(isoConePFNHFilter, pfCandXCleaner), pfnhs.end(), pfnhs.end()));
+
+      // Add regional stuff not in jet
+      tau.addPFCands(RecoTauConstructor::kIsolation,
+                     RecoTauConstructor::kNeutralHadron,
+                     boost::make_filter_iterator(pfNeutralJunk, regionalJunk.begin(), regionalJunk.end()),
+                     boost::make_filter_iterator(pfNeutralJunk, regionalJunk.end(), regionalJunk.end()));
+
+      // Build isolation PiZeros
+      tau.addPiZeros(RecoTauConstructor::kIsolation,
+                     PiZeroDRFilterIter(isoConePiZeroFilter, cleanPiZeros.begin(), cleanPiZeros.end()),
+                     PiZeroDRFilterIter(isoConePiZeroFilter, cleanPiZeros.end(), cleanPiZeros.end()));
+
+      // Add regional stuff not in jet
+      tau.addPFCands(RecoTauConstructor::kIsolation,
+                     RecoTauConstructor::kGamma,
+                     boost::make_filter_iterator(pfGammaJunk, regionalJunk.begin(), regionalJunk.end()),
+                     boost::make_filter_iterator(pfGammaJunk, regionalJunk.end(), regionalJunk.end()));
+
+      // Put our built tau in the output - 'false' indicates don't build the
+      // leading candidates, we already did that explicitly above.
+
+      std::auto_ptr<reco::PFTau> tauPtr = tau.get(false);
+
+      // Set event vertex position for tau
+      reco::VertexRef primaryVertexRef = primaryVertex(*tauPtr);
+      if (primaryVertexRef.isNonnull())
+        tauPtr->setVertex(primaryVertexRef->position());
+
+      // Set missing tau quantities
+      setTauQuantities(*tauPtr, minAbsPhotonSumPt_insideSignalCone_, minRelPhotonSumPt_insideSignalCone_);
+
+      output.push_back(tauPtr);
+      return output.release();
     }
-  }
-  CandPtrs::const_iterator signalPFCHs_begin = signalPFCHs.begin();
-  CandPtrs::const_iterator signalPFCHs_end = signalPFCHs.end();
-
-  // Cross clean pi zero content using signal cone charged hadron constituents.
-  xclean::CrossCleanPiZeros<CandPtrDRFilterIter> piZeroXCleaner(
-      signalPFCHCands_begin, signalPFCHCands_end);
-  std::vector<reco::RecoTauPiZero> cleanPiZeros = piZeroXCleaner(piZeros);
-
-  // For the rest of the constituents, we need to filter any constituents that
-  // are already contained in the pizeros (i.e. electrons)
-  xclean::CrossCleanPtrs<PiZeroList::const_iterator> pfCandXCleaner(cleanPiZeros.begin(), cleanPiZeros.end());
-
-  auto isolationPFCHCands_begin(
-      boost::make_filter_iterator(
-        xclean::makePredicateAND(isoConePFCHFilter, pfCandXCleaner),
-	pfchs.begin(), pfchs.end()));
-  auto isolationPFCHCands_end(
-      boost::make_filter_iterator(
-	xclean::makePredicateAND(isoConePFCHFilter, pfCandXCleaner),
-	pfchs.end(), pfchs.end()));
-  for ( auto iter = isolationPFCHCands_begin; iter != isolationPFCHCands_end; ++iter ) {
-    //std::cout << "adding isolationPFCH #" << numIsolationPFCHs << ": Pt = " << (*iter)->pt() << ", eta = " << (*iter)->eta() << ", phi = " << (*iter)->phi() << std::endl;
-    isolationPFCHs.push_back(*iter);
-    ++numIsolationPFCHs;
-  }
-  CandPtrs::const_iterator isolationPFCHs_begin = isolationPFCHs.begin();
-  CandPtrs::const_iterator isolationPFCHs_end = isolationPFCHs.end();
-
-  // Build signal charged hadrons
-  tau.addPFCands(RecoTauConstructor::kSignal,
-                 RecoTauConstructor::kChargedHadron,
-                 signalPFCHs_begin, signalPFCHs_end);
-
-  tau.addPFCands(RecoTauConstructor::kSignal,
-                 RecoTauConstructor::kNeutralHadron,
-                 boost::make_filter_iterator(
-                   xclean::makePredicateAND(signalConePFNHFilter, pfCandXCleaner),
-                   pfnhs.begin(), pfnhs.end()),
-                 boost::make_filter_iterator(
-                   xclean::makePredicateAND(signalConePFNHFilter, pfCandXCleaner),
-                   pfnhs.end(), pfnhs.end()));
-
-  // Build signal PiZeros
-  tau.addPiZeros(RecoTauConstructor::kSignal,
-                 PiZeroDRFilterIter(signalConePiZeroFilter,
-                                    cleanPiZeros.begin(), cleanPiZeros.end()),
-                 PiZeroDRFilterIter(signalConePiZeroFilter,
-                                    cleanPiZeros.end(), cleanPiZeros.end()));
-
-  // Build isolation charged hadrons
-  tau.addPFCands(RecoTauConstructor::kIsolation,
-                 RecoTauConstructor::kChargedHadron,
-		 isolationPFCHs_begin, isolationPFCHs_end);
-
-  // Add all the stuff in the isolation cone that wasn't in the jet constituents
-  tau.addPFCands(RecoTauConstructor::kIsolation,
-                 RecoTauConstructor::kChargedHadron,
-                 boost::make_filter_iterator(
-                   pfChargedJunk, regionalJunk.begin(), regionalJunk.end()),
-                 boost::make_filter_iterator(
-                   pfChargedJunk, regionalJunk.end(), regionalJunk.end())
-      );
-
-  // Build isolation neutral hadrons
-  tau.addPFCands(RecoTauConstructor::kIsolation,
-                 RecoTauConstructor::kNeutralHadron,
-                 boost::make_filter_iterator(
-                   xclean::makePredicateAND(isoConePFNHFilter, pfCandXCleaner),
-                   pfnhs.begin(), pfnhs.end()),
-                 boost::make_filter_iterator(
-                   xclean::makePredicateAND(isoConePFNHFilter, pfCandXCleaner),
-                   pfnhs.end(), pfnhs.end()));
-
-  // Add regional stuff not in jet
-  tau.addPFCands(RecoTauConstructor::kIsolation,
-                 RecoTauConstructor::kNeutralHadron,
-                 boost::make_filter_iterator(
-                   pfNeutralJunk, regionalJunk.begin(), regionalJunk.end()),
-                 boost::make_filter_iterator(
-                   pfNeutralJunk, regionalJunk.end(), regionalJunk.end())
-      );
-
-  // Build isolation PiZeros
-  tau.addPiZeros(RecoTauConstructor::kIsolation,
-                 PiZeroDRFilterIter(isoConePiZeroFilter, cleanPiZeros.begin(),
-                                    cleanPiZeros.end()),
-                 PiZeroDRFilterIter(isoConePiZeroFilter, cleanPiZeros.end(),
-                                    cleanPiZeros.end()));
-
-  // Add regional stuff not in jet
-  tau.addPFCands(RecoTauConstructor::kIsolation,
-                 RecoTauConstructor::kGamma,
-                 boost::make_filter_iterator(
-                   pfGammaJunk, regionalJunk.begin(), regionalJunk.end()),
-                 boost::make_filter_iterator(
-                   pfGammaJunk, regionalJunk.end(), regionalJunk.end())
-      );
-
-  // Put our built tau in the output - 'false' indicates don't build the
-  // leading candidates, we already did that explicitly above.
-
-  std::auto_ptr<reco::PFTau> tauPtr = tau.get(false);
-
-  // Set event vertex position for tau
-  reco::VertexRef primaryVertexRef = primaryVertex(*tauPtr);
-  if ( primaryVertexRef.isNonnull() )
-    tauPtr->setVertex(primaryVertexRef->position());
-
-  // Set missing tau quantities
-  setTauQuantities(*tauPtr,
-  		   minAbsPhotonSumPt_insideSignalCone_,
-  		   minRelPhotonSumPt_insideSignalCone_
-		   );
-
-  output.push_back(tauPtr);
-  return output.release();
-}
-}}  // end namespace reco::tauk
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(RecoTauBuilderPluginFactory,
-                  reco::tau::RecoTauBuilderConePlugin,
-                  "RecoTauBuilderConePlugin");
+DEFINE_EDM_PLUGIN(RecoTauBuilderPluginFactory, reco::tau::RecoTauBuilderConePlugin, "RecoTauBuilderConePlugin");

--- a/RecoTauTag/RecoTau/plugins/RecoTauChargeCleanerPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauChargeCleanerPlugin.cc
@@ -13,46 +13,48 @@
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauChargeCleanerPlugin : public RecoTauCleanerPlugin
-{
-public:
-	explicit RecoTauChargeCleanerPlugin(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
-	~RecoTauChargeCleanerPlugin() override {}
-	double operator()(const PFTauRef& tau) const override;
+    class RecoTauChargeCleanerPlugin : public RecoTauCleanerPlugin {
+    public:
+      explicit RecoTauChargeCleanerPlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+      ~RecoTauChargeCleanerPlugin() override {}
+      double operator()(const PFTauRef& tau) const override;
 
-private:
-	std::vector<unsigned> nprongs_;
-	double failResult_;
-	int charge_;
-};
+    private:
+      std::vector<unsigned> nprongs_;
+      double failResult_;
+      int charge_;
+    };
 
-RecoTauChargeCleanerPlugin::RecoTauChargeCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC)
-	: RecoTauCleanerPlugin(pset,std::move(iC)),
-	  nprongs_(pset.getParameter<std::vector<unsigned> >("nprongs")),
-	  failResult_(pset.getParameter<double>("selectionFailValue")),
-	  charge_(pset.getParameter<int>("passForCharge"))
-{}
+    RecoTauChargeCleanerPlugin::RecoTauChargeCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : RecoTauCleanerPlugin(pset, std::move(iC)),
+          nprongs_(pset.getParameter<std::vector<unsigned> >("nprongs")),
+          failResult_(pset.getParameter<double>("selectionFailValue")),
+          charge_(pset.getParameter<int>("passForCharge")) {}
 
-double RecoTauChargeCleanerPlugin::operator()(const PFTauRef& cand) const
-{
-	int charge = 0;
-	unsigned nChargedPFCandidate(0), nTrack(0);
-	for(auto const& tauCand : cand->signalTauChargedHadronCandidates()){
-		charge += tauCand.charge();
-		if(tauCand.algoIs(reco::PFRecoTauChargedHadron::kChargedPFCandidate)) nChargedPFCandidate++;
-		else if(tauCand.algoIs(reco::PFRecoTauChargedHadron::kTrack)) nTrack++;
-	}
+    double RecoTauChargeCleanerPlugin::operator()(const PFTauRef& cand) const {
+      int charge = 0;
+      unsigned nChargedPFCandidate(0), nTrack(0);
+      for (auto const& tauCand : cand->signalTauChargedHadronCandidates()) {
+        charge += tauCand.charge();
+        if (tauCand.algoIs(reco::PFRecoTauChargedHadron::kChargedPFCandidate))
+          nChargedPFCandidate++;
+        else if (tauCand.algoIs(reco::PFRecoTauChargedHadron::kTrack))
+          nTrack++;
+      }
 
-	for(auto nprong : nprongs_){
-		if(nChargedPFCandidate+nTrack == nprong) return abs(charge)-charge_;
-	}
+      for (auto nprong : nprongs_) {
+        if (nChargedPFCandidate + nTrack == nprong)
+          return abs(charge) - charge_;
+      }
 
-	return failResult_;
-}
+      return failResult_;
+    }
 
-}}
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauChargedHadronMultiplicityCleanerPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauChargedHadronMultiplicityCleanerPlugin.cc
@@ -9,41 +9,46 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h"
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauChargedHadronMultiplicityCleanerPlugin : public RecoTauCleanerPlugin 
-{
- public:
-  RecoTauChargedHadronMultiplicityCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+    class RecoTauChargedHadronMultiplicityCleanerPlugin : public RecoTauCleanerPlugin {
+    public:
+      RecoTauChargedHadronMultiplicityCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
 
-  // Get ranking value for a given tau Ref
-  double operator()(const reco::PFTauRef&) const override;
-};
+      // Get ranking value for a given tau Ref
+      double operator()(const reco::PFTauRef&) const override;
+    };
 
-RecoTauChargedHadronMultiplicityCleanerPlugin::RecoTauChargedHadronMultiplicityCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
-  : RecoTauCleanerPlugin(pset,std::move(iC)) 
-{}
+    RecoTauChargedHadronMultiplicityCleanerPlugin::RecoTauChargedHadronMultiplicityCleanerPlugin(
+        const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : RecoTauCleanerPlugin(pset, std::move(iC)) {}
 
-double RecoTauChargedHadronMultiplicityCleanerPlugin::operator()(const reco::PFTauRef& tau) const 
-{
-  // Get the ranking value for this tau. 
-  // N.B. lower value means more "tau like"!
-  double result = 0.;
-  const std::vector<PFRecoTauChargedHadron>& chargedHadrons = tau->signalTauChargedHadronCandidates();
-  for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
-	chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
-    if      ( chargedHadron->algo() == PFRecoTauChargedHadron::kChargedPFCandidate ) result -= 8.;
-    else if ( chargedHadron->algo() == PFRecoTauChargedHadron::kTrack              ) result -= 4.;
-    else if ( chargedHadron->algo() == PFRecoTauChargedHadron::kPFNeutralHadron    ) result -= 2.;
-    else                                                                             result -= 1.;
-  }
-  return result;
-}
+    double RecoTauChargedHadronMultiplicityCleanerPlugin::operator()(const reco::PFTauRef& tau) const {
+      // Get the ranking value for this tau.
+      // N.B. lower value means more "tau like"!
+      double result = 0.;
+      const std::vector<PFRecoTauChargedHadron>& chargedHadrons = tau->signalTauChargedHadronCandidates();
+      for (std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
+           chargedHadron != chargedHadrons.end();
+           ++chargedHadron) {
+        if (chargedHadron->algo() == PFRecoTauChargedHadron::kChargedPFCandidate)
+          result -= 8.;
+        else if (chargedHadron->algo() == PFRecoTauChargedHadron::kTrack)
+          result -= 4.;
+        else if (chargedHadron->algo() == PFRecoTauChargedHadron::kPFNeutralHadron)
+          result -= 2.;
+        else
+          result -= 1.;
+      }
+      return result;
+    }
 
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 // Register our plugin
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(RecoTauCleanerPluginFactory, 
-    reco::tau::RecoTauChargedHadronMultiplicityCleanerPlugin, 
-    "RecoTauChargedHadronMultiplicityCleanerPlugin");
+DEFINE_EDM_PLUGIN(RecoTauCleanerPluginFactory,
+                  reco::tau::RecoTauChargedHadronMultiplicityCleanerPlugin,
+                  "RecoTauChargedHadronMultiplicityCleanerPlugin");

--- a/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
@@ -40,153 +40,150 @@
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
-template<typename Prod>
-class RecoTauCleanerImpl : public edm::stream::EDProducer<>
-{
+template <typename Prod>
+class RecoTauCleanerImpl : public edm::stream::EDProducer<> {
   typedef reco::tau::RecoTauCleanerPlugin Cleaner;
-  struct CleanerEntryType
-  {
+  struct CleanerEntryType {
     std::shared_ptr<Cleaner> plugin_;
     float tolerance_;
   };
-  typedef std::vector<std::unique_ptr<CleanerEntryType> > CleanerList;
+  typedef std::vector<std::unique_ptr<CleanerEntryType>> CleanerList;
   // Define our output type - i.e. reco::PFTau OR reco::PFTauRef
   typedef typename Prod::value_type output_type;
 
   // Predicate that determines if two taus 'overlap' i.e. share a base PFJet
-  class RemoveDuplicateJets 
-  {
-   public:
+  class RemoveDuplicateJets {
+  public:
     bool operator()(const reco::PFTauRef& a, const reco::PFTauRef& b) const { return (a->jetRef() == b->jetRef()); }
   };
 
- public:
+public:
   explicit RecoTauCleanerImpl(const edm::ParameterSet& pset);
   ~RecoTauCleanerImpl() override;
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
+private:
   edm::InputTag tauSrc_;
   CleanerList cleaners_;
   // Optional selection on the output of the taus
-  std::unique_ptr<const StringCutObjectSelector<reco::PFTau> > outputSelector_;
+  std::unique_ptr<const StringCutObjectSelector<reco::PFTau>> outputSelector_;
   edm::EDGetTokenT<reco::PFTauCollection> tau_token;
   int verbosity_;
 };
 
-template<typename Prod>
-RecoTauCleanerImpl<Prod>::RecoTauCleanerImpl(const edm::ParameterSet& pset) 
-{
+template <typename Prod>
+RecoTauCleanerImpl<Prod>::RecoTauCleanerImpl(const edm::ParameterSet& pset) {
   tauSrc_ = pset.getParameter<edm::InputTag>("src");
-  tau_token=consumes<reco::PFTauCollection>(tauSrc_);
+  tau_token = consumes<reco::PFTauCollection>(tauSrc_);
   // Build our list of quality plugins
   typedef std::vector<edm::ParameterSet> VPSet;
   // Get each of our tau builders
   const VPSet& cleaners = pset.getParameter<VPSet>("cleaners");
-  for ( VPSet::const_iterator cleanerPSet = cleaners.begin();
-	cleanerPSet != cleaners.end(); ++cleanerPSet ) {
+  for (VPSet::const_iterator cleanerPSet = cleaners.begin(); cleanerPSet != cleaners.end(); ++cleanerPSet) {
     auto cleanerEntry = std::make_unique<CleanerEntryType>();
     // Get plugin name
     const std::string& pluginType = cleanerPSet->getParameter<std::string>("plugin");
     // Build the plugin
-    cleanerEntry->plugin_ = std::unique_ptr<Cleaner>{RecoTauCleanerPluginFactory::get()->create(pluginType, *cleanerPSet, consumesCollector())};
+    cleanerEntry->plugin_ = std::unique_ptr<Cleaner>{
+        RecoTauCleanerPluginFactory::get()->create(pluginType, *cleanerPSet, consumesCollector())};
     cleanerEntry->tolerance_ = cleanerPSet->getParameter<double>("tolerance");
     cleaners_.emplace_back(std::move(cleanerEntry));
   }
 
   // Check if we want to apply a final output selection
   std::string selection = pset.getParameter<std::string>("outputSelection");
-  if ( !selection.empty() ) {
+  if (!selection.empty()) {
     outputSelector_ = std::make_unique<StringCutObjectSelector<reco::PFTau>>(selection);
   }
 
   // Enable/disable debug output
   verbosity_ = pset.getParameter<int>("verbosity");
 
-  // Build the predicate that ranks our taus.  
+  // Build the predicate that ranks our taus.
   produces<Prod>();
 }
 
-template<typename Prod>
-RecoTauCleanerImpl<Prod>::~RecoTauCleanerImpl() 
-{  
-}
+template <typename Prod>
+RecoTauCleanerImpl<Prod>::~RecoTauCleanerImpl() {}
 
 namespace {
-// Template to convert a ref to desired output type
-template<typename T> const T convert(const reco::PFTauRef &tau);
+  // Template to convert a ref to desired output type
+  template <typename T>
+  const T convert(const reco::PFTauRef& tau);
 
   //template<> const edm::RefToBase<reco::PFTau>
   //convert<edm::RefToBase<reco::PFTau> >(const reco::PFTauRef &tau) {
   // return edm::RefToBase<reco::PFTau>(tau);
   //}
 
-template<> const reco::PFTauRef
-convert<reco::PFTauRef>(const reco::PFTauRef &tau) { return tau; }
+  template <>
+  const reco::PFTauRef convert<reco::PFTauRef>(const reco::PFTauRef& tau) {
+    return tau;
+  }
 
-template<> const reco::PFTau
-convert<reco::PFTau>(const reco::PFTauRef &tau) { return *tau; }
-}
+  template <>
+  const reco::PFTau convert<reco::PFTau>(const reco::PFTauRef& tau) {
+    return *tau;
+  }
+}  // namespace
 
-namespace
-{
+namespace {
   template <typename T>
-  std::string format_vT(const std::vector<T>& vT)
-  {
-    std::ostringstream os;  
+  std::string format_vT(const std::vector<T>& vT) {
+    std::ostringstream os;
     os << "{ ";
     unsigned numEntries = vT.size();
-    for ( unsigned iEntry = 0; iEntry < numEntries; ++iEntry ) {
+    for (unsigned iEntry = 0; iEntry < numEntries; ++iEntry) {
       os << vT[iEntry];
-      if ( iEntry < (numEntries - 1) ) os << ", ";
+      if (iEntry < (numEntries - 1))
+        os << ", ";
     }
     os << " }";
     return os.str();
   }
 
-  struct PFTauRankType
-  {
-    PFTauRankType(const reco::PFTauRef& tauRef)
-      : idx_(tauRef.key()),
-	tauRef_(tauRef)
-    {}
+  struct PFTauRankType {
+    PFTauRankType(const reco::PFTauRef& tauRef) : idx_(tauRef.key()), tauRef_(tauRef) {}
     ~PFTauRankType() {}
-    void print(const std::string& label) const
-    {
+    void print(const std::string& label) const {
       std::cout << label << " (" << tauRef_.id() << ":" << tauRef_.key() << ", idx = " << idx_ << "):";
       assert(tauRef_.key() == idx_);
-      std::cout << " Pt = " << tauRef_->pt() << ", eta = " << tauRef_->eta() << ", phi = " << tauRef_->phi() << ", mass = " << tauRef_->mass() << " (decayMode = " << tauRef_->decayMode() << ")";
+      std::cout << " Pt = " << tauRef_->pt() << ", eta = " << tauRef_->eta() << ", phi = " << tauRef_->phi()
+                << ", mass = " << tauRef_->mass() << " (decayMode = " << tauRef_->decayMode() << ")";
       std::cout << std::endl;
       std::cout << "associated jet:";
-      if ( tauRef_->jetRef().isNonnull() ) {
-	std::cout << " Pt = " << tauRef_->jetRef()->pt() << ", eta = " << tauRef_->jetRef()->eta() << ", phi = " << tauRef_->jetRef()->phi() 
-		  << ", mass = " << tauRef_->jetRef()->mass() << ", area = " << tauRef_->jetRef()->jetArea();
-      }
-      else std::cout << " N/A";
+      if (tauRef_->jetRef().isNonnull()) {
+        std::cout << " Pt = " << tauRef_->jetRef()->pt() << ", eta = " << tauRef_->jetRef()->eta()
+                  << ", phi = " << tauRef_->jetRef()->phi() << ", mass = " << tauRef_->jetRef()->mass()
+                  << ", area = " << tauRef_->jetRef()->jetArea();
+      } else
+        std::cout << " N/A";
       std::cout << std::endl;
-      const std::vector<reco::PFRecoTauChargedHadron>& signalTauChargedHadronCandidates = tauRef_->signalTauChargedHadronCandidates();
+      const std::vector<reco::PFRecoTauChargedHadron>& signalTauChargedHadronCandidates =
+          tauRef_->signalTauChargedHadronCandidates();
       size_t numChargedHadrons = signalTauChargedHadronCandidates.size();
-      for ( size_t iChargedHadron = 0; iChargedHadron < numChargedHadrons; ++iChargedHadron ) {
-	const reco::PFRecoTauChargedHadron& chargedHadron = signalTauChargedHadronCandidates.at(iChargedHadron);
-	std::cout << " chargedHadron #" << iChargedHadron << ":" << std::endl;
-	chargedHadron.print(std::cout);
+      for (size_t iChargedHadron = 0; iChargedHadron < numChargedHadrons; ++iChargedHadron) {
+        const reco::PFRecoTauChargedHadron& chargedHadron = signalTauChargedHadronCandidates.at(iChargedHadron);
+        std::cout << " chargedHadron #" << iChargedHadron << ":" << std::endl;
+        chargedHadron.print(std::cout);
       }
       const std::vector<reco::RecoTauPiZero>& signalPiZeroCandidates = tauRef_->signalPiZeroCandidates();
       size_t numPiZeros = signalPiZeroCandidates.size();
       std::cout << "signalPiZeroCandidates = " << numPiZeros << std::endl;
-      for ( size_t iPiZero = 0; iPiZero < numPiZeros; ++iPiZero ) {
-	const reco::RecoTauPiZero& piZero = signalPiZeroCandidates.at(iPiZero);
-	std::cout << " piZero #" << iPiZero << ": Pt = " << piZero.pt() << ", eta = " << piZero.eta() << ", phi = " << piZero.phi() << ", mass = " << piZero.mass() << std::endl;
+      for (size_t iPiZero = 0; iPiZero < numPiZeros; ++iPiZero) {
+        const reco::RecoTauPiZero& piZero = signalPiZeroCandidates.at(iPiZero);
+        std::cout << " piZero #" << iPiZero << ": Pt = " << piZero.pt() << ", eta = " << piZero.eta()
+                  << ", phi = " << piZero.phi() << ", mass = " << piZero.mass() << std::endl;
       }
       const auto& isolationCands = tauRef_->isolationCands();
       size_t numCands = isolationCands.size();
       std::cout << "isolationCands = " << numCands << std::endl;
-      for ( size_t iCand = 0; iCand < numCands; ++iCand ) {
-	const auto& cand = isolationCands.at(iCand);
-	std::cout << " pfCand #" << iCand << " (" << cand.id() << ":" << cand.key() << "):" 
-		  << " Pt = " << cand->pt() << ", eta = " << cand->eta() << ", phi = " << cand->phi() << std::endl;
+      for (size_t iCand = 0; iCand < numCands; ++iCand) {
+        const auto& cand = isolationCands.at(iCand);
+        std::cout << " pfCand #" << iCand << " (" << cand.id() << ":" << cand.key() << "):"
+                  << " Pt = " << cand->pt() << ", eta = " << cand->eta() << ", phi = " << cand->phi() << std::endl;
       }
       std::cout << " ranks = " << format_vT(ranks_) << std::endl;
       std::cout << " tolerances = " << format_vT(tolerances_) << std::endl;
@@ -197,39 +194,38 @@ namespace
     std::vector<float> ranks_;
     std::vector<float> tolerances_;
   };
-    
-  bool isHigherRank(const PFTauRankType* tau1, const PFTauRankType* tau2)
-  {
+
+  bool isHigherRank(const PFTauRankType* tau1, const PFTauRankType* tau2) {
     //std::cout << "<isHigherRank>:" << std::endl;
     //std::cout << "tau1 @ " << tau1;
-    //tau1->print("");    
+    //tau1->print("");
     //std::cout << "tau2 @ " << tau2;
     //tau2->print("");
     assert(tau1->N_ == tau1->ranks_.size());
     assert(tau1->N_ == tau2->ranks_.size());
     assert(tau1->N_ == tau1->tolerances_.size());
-    for ( size_t i = 0; i < tau1->N_; ++i ) {
+    for (size_t i = 0; i < tau1->N_; ++i) {
       const float& val1 = tau1->ranks_[i];
       const float& val2 = tau2->ranks_[i];
-      double av = 0.5*(val1 + val2);  
-      double thresh = av*tau1->tolerances_[i];
-      if      ( val1 < (val2 - thresh) ) return true;
-      else if ( val2 < (val1 - thresh) ) return false;
+      double av = 0.5 * (val1 + val2);
+      double thresh = av * tau1->tolerances_[i];
+      if (val1 < (val2 - thresh))
+        return true;
+      else if (val2 < (val1 - thresh))
+        return false;
     }
     return true;
   }
-}
+}  // namespace
 
-template<typename Prod>
-void RecoTauCleanerImpl<Prod>::produce(edm::Event& evt, const edm::EventSetup& es) 
-{
-  if ( verbosity_ ) {
+template <typename Prod>
+void RecoTauCleanerImpl<Prod>::produce(edm::Event& evt, const edm::EventSetup& es) {
+  if (verbosity_) {
     std::cout << "<RecoTauCleanerImpl::produce>:" << std::endl;
   }
 
   // Update all our cleaners with the event info if they need it
-  for ( typename CleanerList::iterator cleaner = cleaners_.begin();
-	cleaner != cleaners_.end(); ++cleaner ) {
+  for (typename CleanerList::iterator cleaner = cleaners_.begin(); cleaner != cleaners_.end(); ++cleaner) {
     (*cleaner)->plugin_->setup(evt, es);
   }
 
@@ -240,19 +236,18 @@ void RecoTauCleanerImpl<Prod>::produce(edm::Event& evt, const edm::EventSetup& e
   // Sort the input tau refs according to our predicate
   std::list<PFTauRankType*> rankedTaus;
   size_t N = inputTaus->size();
-  for ( size_t idx = 0; idx < N; ++idx ) {
+  for (size_t idx = 0; idx < N; ++idx) {
     reco::PFTauRef inputRef(inputTaus, idx);
-    PFTauRankType* rankedTau = new PFTauRankType(inputRef);    
+    PFTauRankType* rankedTau = new PFTauRankType(inputRef);
     rankedTau->N_ = cleaners_.size();
     rankedTau->ranks_.reserve(rankedTau->N_);
     rankedTau->tolerances_.reserve(rankedTau->N_);
-    for ( typename CleanerList::const_iterator cleaner = cleaners_.begin();
-	  cleaner != cleaners_.end(); ++cleaner ) {
+    for (typename CleanerList::const_iterator cleaner = cleaners_.begin(); cleaner != cleaners_.end(); ++cleaner) {
       rankedTau->ranks_.push_back((*(*cleaner)->plugin_)(inputRef));
-      rankedTau->tolerances_.push_back((*cleaner)->tolerance_);      
+      rankedTau->tolerances_.push_back((*cleaner)->tolerance_);
     }
-    if ( verbosity_ ) {
-      std::ostringstream os;  
+    if (verbosity_) {
+      std::ostringstream os;
       os << "rankedTau #" << idx;
       rankedTau->print(os.str());
     }
@@ -264,11 +259,12 @@ void RecoTauCleanerImpl<Prod>::produce(edm::Event& evt, const edm::EventSetup& e
   typedef std::vector<reco::PFTauRef> PFTauRefs;
   PFTauRefs dirty(inputTaus->size());
   size_t idx_sorted = 0;
-  for ( std::list<PFTauRankType*>::const_iterator rankedTau = rankedTaus.begin();
-	rankedTau != rankedTaus.end(); ++rankedTau ) {
+  for (std::list<PFTauRankType*>::const_iterator rankedTau = rankedTaus.begin(); rankedTau != rankedTaus.end();
+       ++rankedTau) {
     dirty[idx_sorted] = (*rankedTau)->tauRef_;
-    if ( verbosity_ ) {
-      std::cout << "dirty[" << idx_sorted << "] = " << dirty[idx_sorted].id() << ":" << dirty[idx_sorted].key() << std::endl;
+    if (verbosity_) {
+      std::cout << "dirty[" << idx_sorted << "] = " << dirty[idx_sorted].id() << ":" << dirty[idx_sorted].key()
+                << std::endl;
     }
     delete (*rankedTau);
     ++idx_sorted;
@@ -282,14 +278,13 @@ void RecoTauCleanerImpl<Prod>::produce(edm::Event& evt, const edm::EventSetup& e
   //output->reserve(cleanTaus.size());
 
   // Copy clean refs into output
-  for ( PFTauRefs::const_iterator tau = cleanTaus.begin();
-	tau != cleanTaus.end(); ++tau ) {
+  for (PFTauRefs::const_iterator tau = cleanTaus.begin(); tau != cleanTaus.end(); ++tau) {
     // If we are applying an output selection, check if it passes
     bool selected = true;
-    if ( outputSelector_.get() && !(*outputSelector_)(**tau) ) {
+    if (outputSelector_.get() && !(*outputSelector_)(**tau)) {
       selected = false;
     }
-    if ( selected ) {
+    if (selected) {
       output->push_back(convert<output_type>(*tau));
     }
   }
@@ -300,8 +295,7 @@ typedef RecoTauCleanerImpl<reco::PFTauCollection> RecoTauCleaner;
 typedef RecoTauCleanerImpl<reco::PFTauRefVector> RecoTauRefCleaner;
 
 template <>
-void
-RecoTauCleanerImpl<reco::PFTauCollection>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void RecoTauCleanerImpl<reco::PFTauCollection>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // RecoTauCleaner
   edm::ParameterSetDescription desc;
   desc.add<std::string>("outputSelection", "");
@@ -336,7 +330,11 @@ RecoTauCleanerImpl<reco::PFTauCollection>::fillDescriptions(edm::ConfigurationDe
       cleaner_Charge.addParameter<std::string>("plugin", "RecoTauChargeCleanerPlugin");
       cleaner_Charge.addParameter<int>("passForCharge", 1);
       cleaner_Charge.addParameter<double>("selectionFailValue", 0);
-      cleaner_Charge.addParameter<std::vector<unsigned int>>("nprongs", {1, 3,});
+      cleaner_Charge.addParameter<std::vector<unsigned int>>("nprongs",
+                                                             {
+                                                                 1,
+                                                                 3,
+                                                             });
       cleaner_Charge.addParameter<double>("tolerance", 0);
       default_cleaners.push_back(cleaner_Charge);
     }
@@ -387,7 +385,8 @@ RecoTauCleanerImpl<reco::PFTauCollection>::fillDescriptions(edm::ConfigurationDe
       edm::ParameterSet temp2;
       temp2.addParameter<std::string>("name", "CombinedIsolation");
       temp2.addParameter<std::string>("plugin", "RecoTauStringCleanerPlugin");
-      temp2.addParameter<std::string>("selectionPassFunction", "isolationPFChargedHadrCandsPtSum() + isolationPFGammaCandsEtSum()");
+      temp2.addParameter<std::string>("selectionPassFunction",
+                                      "isolationPFChargedHadrCandsPtSum() + isolationPFGammaCandsEtSum()");
       temp2.addParameter<std::string>("selection", "leadPFCand().isNonnull()");
       temp2.addParameter<double>("selectionFailValue", 1000.0);
       temp2.addParameter<double>("tolerance", 0);
@@ -403,13 +402,11 @@ RecoTauCleanerImpl<reco::PFTauCollection>::fillDescriptions(edm::ConfigurationDe
 }
 
 template <>
-void
-RecoTauCleanerImpl<reco::PFTauRefVector>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-// there was no cfi file for this plugin
+void RecoTauCleanerImpl<reco::PFTauRefVector>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // there was no cfi file for this plugin
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(RecoTauCleaner);
 DEFINE_FWK_MODULE(RecoTauRefCleaner);
-

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCleanerPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCleanerPlugin.cc
@@ -10,47 +10,49 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h"
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauDiscriminantCleanerPlugin : public RecoTauCleanerPlugin {
-  public:
-  RecoTauDiscriminantCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC);
-    ~RecoTauDiscriminantCleanerPlugin() override{}
+    class RecoTauDiscriminantCleanerPlugin : public RecoTauCleanerPlugin {
+    public:
+      RecoTauDiscriminantCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+      ~RecoTauDiscriminantCleanerPlugin() override {}
 
-    // Get discriminant value for a given tau Ref
-    double operator()(const reco::PFTauRef&) const override;
-    // Hook called from base class at the beginning of each event
-    void beginEvent() override;
+      // Get discriminant value for a given tau Ref
+      double operator()(const reco::PFTauRef&) const override;
+      // Hook called from base class at the beginning of each event
+      void beginEvent() override;
 
-  private:
-    edm::InputTag discriminatorSrc_;
-    edm::Handle<PFTauDiscriminator> discriminator_;
-  edm::EDGetTokenT<PFTauDiscriminator> discriminator_token;
-};
+    private:
+      edm::InputTag discriminatorSrc_;
+      edm::Handle<PFTauDiscriminator> discriminator_;
+      edm::EDGetTokenT<PFTauDiscriminator> discriminator_token;
+    };
 
-RecoTauDiscriminantCleanerPlugin::RecoTauDiscriminantCleanerPlugin(
-								   const edm::ParameterSet& pset, edm::ConsumesCollector &&iC):RecoTauCleanerPlugin(pset,std::move(iC)) {
-  discriminatorSrc_ = pset.getParameter<edm::InputTag>("src");
-  discriminator_token = iC.consumes<PFTauDiscriminator>(discriminatorSrc_);
-}
+    RecoTauDiscriminantCleanerPlugin::RecoTauDiscriminantCleanerPlugin(const edm::ParameterSet& pset,
+                                                                       edm::ConsumesCollector&& iC)
+        : RecoTauCleanerPlugin(pset, std::move(iC)) {
+      discriminatorSrc_ = pset.getParameter<edm::InputTag>("src");
+      discriminator_token = iC.consumes<PFTauDiscriminator>(discriminatorSrc_);
+    }
 
-void RecoTauDiscriminantCleanerPlugin::beginEvent() {
-  // Load our handle to the discriminators from the event
-  evt()->getByToken(discriminator_token, discriminator_);
-}
+    void RecoTauDiscriminantCleanerPlugin::beginEvent() {
+      // Load our handle to the discriminators from the event
+      evt()->getByToken(discriminator_token, discriminator_);
+    }
 
-double RecoTauDiscriminantCleanerPlugin::operator()(
-    const reco::PFTauRef& tau) const {
-  // Get the discriminator result for this tau. N.B. result is negated!  lower 
-  // = more "tau like"! This is opposite to the normal case.
-  double result = -(*discriminator_)[tau];
-  return result;
-}
+    double RecoTauDiscriminantCleanerPlugin::operator()(const reco::PFTauRef& tau) const {
+      // Get the discriminator result for this tau. N.B. result is negated!  lower
+      // = more "tau like"! This is opposite to the normal case.
+      double result = -(*discriminator_)[tau];
+      return result;
+    }
 
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 // Register our plugin
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(RecoTauCleanerPluginFactory, 
-    reco::tau::RecoTauDiscriminantCleanerPlugin, 
-    "RecoTauDiscriminantCleanerPlugin");
+DEFINE_EDM_PLUGIN(RecoTauCleanerPluginFactory,
+                  reco::tau::RecoTauDiscriminantCleanerPlugin,
+                  "RecoTauDiscriminantCleanerPlugin");

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
@@ -34,33 +34,25 @@
 #include "TFormula.h"
 #include "TFile.h"
 
-class RecoTauDiscriminantCutMultiplexer : public PFTauDiscriminationProducerBase 
-{
- public:
+class RecoTauDiscriminantCutMultiplexer : public PFTauDiscriminationProducerBase {
+public:
   explicit RecoTauDiscriminantCutMultiplexer(const edm::ParameterSet& pset);
 
   ~RecoTauDiscriminantCutMultiplexer() override;
   double discriminate(const reco::PFTauRef&) const override;
   void beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
+private:
   std::string moduleLabel_;
 
   bool loadMVAfromDB_;
   edm::FileInPath inputFileName_;
 
-  struct DiscriminantCutEntry
-  {
-    DiscriminantCutEntry()
-      : cutVariable_(),
-	cutFunction_(),
-	mode_(kUndefined)
-    {}
-    ~DiscriminantCutEntry()
-    {
-    }
+  struct DiscriminantCutEntry {
+    DiscriminantCutEntry() : cutVariable_(), cutFunction_(), mode_(kUndefined) {}
+    ~DiscriminantCutEntry() {}
     double cutValue_;
     std::string cutName_;
     std::unique_ptr<StringObjectFunction<reco::PFTau>> cutVariable_;
@@ -86,63 +78,63 @@ class RecoTauDiscriminantCutMultiplexer : public PFTauDiscriminationProducerBase
   int verbosity_;
 };
 
-namespace
-{
+namespace {
   std::unique_ptr<TFile> openInputFile(const edm::FileInPath& inputFileName) {
-    if ( inputFileName.location() == edm::FileInPath::Unknown){  throw cms::Exception("RecoTauDiscriminantCutMultiplexer::loadObjectFromFile") 
-      << " Failed to find File = " << inputFileName << " !!\n";
+    if (inputFileName.location() == edm::FileInPath::Unknown) {
+      throw cms::Exception("RecoTauDiscriminantCutMultiplexer::loadObjectFromFile")
+          << " Failed to find File = " << inputFileName << " !!\n";
     }
-    return std::unique_ptr<TFile>{ new TFile(inputFileName.fullPath().data()) };
+    return std::unique_ptr<TFile>{new TFile(inputFileName.fullPath().data())};
   }
 
   template <typename T>
-  std::unique_ptr<const T> loadObjectFromFile(TFile& inputFile, const std::string& objectName)
-  {
+  std::unique_ptr<const T> loadObjectFromFile(TFile& inputFile, const std::string& objectName) {
     const T* object = dynamic_cast<T*>(inputFile.Get(objectName.data()));
-    if ( !object )
-      throw cms::Exception("RecoTauDiscriminantCutMultiplexer::loadObjectFromFile") 
-        << " Failed to load Object = " << objectName.data() << " from file = " << inputFile.GetName() << " !!\n";
+    if (!object)
+      throw cms::Exception("RecoTauDiscriminantCutMultiplexer::loadObjectFromFile")
+          << " Failed to load Object = " << objectName.data() << " from file = " << inputFile.GetName() << " !!\n";
     //Need to use TObject::Clone since the type T might be a base class
-    return std::unique_ptr<const T>{ static_cast<T*>(object->Clone()) };
+    return std::unique_ptr<const T>{static_cast<T*>(object->Clone())};
   }
 
-  std::unique_ptr<const TGraph> loadTGraphFromDB(const edm::EventSetup& es, const std::string& graphName, const int& verbosity_ = 0)
-  {
-    if(verbosity_){
+  std::unique_ptr<const TGraph> loadTGraphFromDB(const edm::EventSetup& es,
+                                                 const std::string& graphName,
+                                                 const int& verbosity_ = 0) {
+    if (verbosity_) {
       std::cout << "<loadTGraphFromDB>:" << std::endl;
       std::cout << " graphName = " << graphName << std::endl;
     }
     edm::ESHandle<PhysicsTGraphPayload> graphPayload;
     es.get<PhysicsTGraphPayloadRcd>().get(graphName, graphPayload);
-    return std::unique_ptr<const TGraph>{ new TGraph(*graphPayload.product()) };
-  }  
+    return std::unique_ptr<const TGraph>{new TGraph(*graphPayload.product())};
+  }
 
-  std::unique_ptr<TFormula> loadTFormulaFromDB(const edm::EventSetup& es, const std::string& formulaName, const TString& newName, const int& verbosity_ = 0)
-  {
-    if(verbosity_){
+  std::unique_ptr<TFormula> loadTFormulaFromDB(const edm::EventSetup& es,
+                                               const std::string& formulaName,
+                                               const TString& newName,
+                                               const int& verbosity_ = 0) {
+    if (verbosity_) {
       std::cout << "<loadTFormulaFromDB>:" << std::endl;
       std::cout << " formulaName = " << formulaName << std::endl;
     }
     edm::ESHandle<PhysicsTFormulaPayload> formulaPayload;
     es.get<PhysicsTFormulaPayloadRcd>().get(formulaName, formulaPayload);
 
-    if ( formulaPayload->formulas().size() == 1 && formulaPayload->limits().size() == 1 ) {
-      return std::unique_ptr<TFormula> {new TFormula(newName, formulaPayload->formulas().at(0).data()) };
+    if (formulaPayload->formulas().size() == 1 && formulaPayload->limits().size() == 1) {
+      return std::unique_ptr<TFormula>{new TFormula(newName, formulaPayload->formulas().at(0).data())};
     } else {
-      throw cms::Exception("RecoTauDiscriminantCutMultiplexer::loadTFormulaFromDB") 
-	<< "Failed to load TFormula = " << formulaName << " from Database !!\n";
+      throw cms::Exception("RecoTauDiscriminantCutMultiplexer::loadTFormulaFromDB")
+          << "Failed to load TFormula = " << formulaName << " from Database !!\n";
     }
     return std::unique_ptr<TFormula>{};
-  }  
-}
+  }
+}  // namespace
 
 RecoTauDiscriminantCutMultiplexer::RecoTauDiscriminantCutMultiplexer(const edm::ParameterSet& cfg)
-  : PFTauDiscriminationProducerBase(cfg),
-    moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-    mvaOutput_normalization_(),
-    isInitialized_(false)
-{
-  
+    : PFTauDiscriminationProducerBase(cfg),
+      moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+      mvaOutput_normalization_(),
+      isInitialized_(false) {
   toMultiplex_ = cfg.getParameter<edm::InputTag>("toMultiplex");
   toMultiplex_token = consumes<reco::PFTauDiscriminator>(toMultiplex_);
   key_ = cfg.getParameter<edm::InputTag>("key");
@@ -151,71 +143,71 @@ RecoTauDiscriminantCutMultiplexer::RecoTauDiscriminantCutMultiplexer(const edm::
   verbosity_ = cfg.getParameter<int>("verbosity");
 
   loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
-  if ( !loadMVAfromDB_ ) {
-      inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
+  if (!loadMVAfromDB_) {
+    inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
   }
-  if(verbosity_)  std::cout << moduleLabel_ << " loadMVA = " << loadMVAfromDB_ << std::endl;
-  mvaOutputNormalizationName_ = cfg.getParameter<std::string>("mvaOutput_normalization"); 
+  if (verbosity_)
+    std::cout << moduleLabel_ << " loadMVA = " << loadMVAfromDB_ << std::endl;
+  mvaOutputNormalizationName_ = cfg.getParameter<std::string>("mvaOutput_normalization");
 
   // Setup our cut map
   typedef std::vector<edm::ParameterSet> VPSet;
   VPSet mapping = cfg.getParameter<VPSet>("mapping");
-  for ( VPSet::const_iterator mappingEntry = mapping.begin();
-	mappingEntry != mapping.end(); ++mappingEntry ) {
+  for (VPSet::const_iterator mappingEntry = mapping.begin(); mappingEntry != mapping.end(); ++mappingEntry) {
     unsigned category = mappingEntry->getParameter<uint32_t>("category");
     std::unique_ptr<DiscriminantCutEntry> cut{new DiscriminantCutEntry()};
-    if ( mappingEntry->existsAs<double>("cut") ) {
+    if (mappingEntry->existsAs<double>("cut")) {
       cut->cutValue_ = mappingEntry->getParameter<double>("cut");
       cut->mode_ = DiscriminantCutEntry::kFixedCut;
-    } else if ( mappingEntry->existsAs<std::string>("cut") ) {
+    } else if (mappingEntry->existsAs<std::string>("cut")) {
       cut->cutName_ = mappingEntry->getParameter<std::string>("cut");
       std::string cutVariable_string = mappingEntry->getParameter<std::string>("variable");
-      cut->cutVariable_.reset( new StringObjectFunction<reco::PFTau>(cutVariable_string) );
+      cut->cutVariable_.reset(new StringObjectFunction<reco::PFTau>(cutVariable_string));
       cut->mode_ = DiscriminantCutEntry::kVariableCut;
     } else {
-      throw cms::Exception("RecoTauDiscriminantCutMultiplexer") 
-        << " Undefined Configuration Parameter 'cut' !!\n";
+      throw cms::Exception("RecoTauDiscriminantCutMultiplexer") << " Undefined Configuration Parameter 'cut' !!\n";
     }
     cuts_[category] = std::move(cut);
   }
 
   verbosity_ = cfg.getParameter<int>("verbosity");
-  if(verbosity_) std::cout << "constructed " << moduleLabel_ << std::endl;
+  if (verbosity_)
+    std::cout << "constructed " << moduleLabel_ << std::endl;
 }
 
-RecoTauDiscriminantCutMultiplexer::~RecoTauDiscriminantCutMultiplexer()
-{
-}
+RecoTauDiscriminantCutMultiplexer::~RecoTauDiscriminantCutMultiplexer() {}
 
-void RecoTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const edm::EventSetup& es) 
-{
-  if(verbosity_) std::cout << " begin! " << moduleLabel_ << " " << isInitialized_ << std::endl;
-  if ( !isInitialized_ ) {
+void RecoTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
+  if (verbosity_)
+    std::cout << " begin! " << moduleLabel_ << " " << isInitialized_ << std::endl;
+  if (!isInitialized_) {
     //Only open the file once and we can close it when this routine is done
     // since all objects gotten from the file will have been copied
     std::unique_ptr<TFile> inputFile;
-    if ( !mvaOutputNormalizationName_.empty() ) {
-      if ( !loadMVAfromDB_ ) {
-	inputFile = openInputFile(inputFileName_);
-	mvaOutput_normalization_ = loadObjectFromFile<TFormula>(*inputFile, mvaOutputNormalizationName_);
+    if (!mvaOutputNormalizationName_.empty()) {
+      if (!loadMVAfromDB_) {
+        inputFile = openInputFile(inputFileName_);
+        mvaOutput_normalization_ = loadObjectFromFile<TFormula>(*inputFile, mvaOutputNormalizationName_);
       } else {
-	auto temp = loadTFormulaFromDB(es, mvaOutputNormalizationName_, Form("%s_mvaOutput_normalization", moduleLabel_.data()), verbosity_);
-	mvaOutput_normalization_ = std::move(temp);
+        auto temp = loadTFormulaFromDB(
+            es, mvaOutputNormalizationName_, Form("%s_mvaOutput_normalization", moduleLabel_.data()), verbosity_);
+        mvaOutput_normalization_ = std::move(temp);
       }
     }
-    for ( DiscriminantCutMap::iterator cut = cuts_.begin();
-	  cut != cuts_.end(); ++cut ) {
-      if ( cut->second->mode_ == DiscriminantCutEntry::kVariableCut ) {
-	if ( !loadMVAfromDB_ ) {
-	  if(not inputFile) {
-	    inputFile = openInputFile(inputFileName_);
-	  }
-	  if(verbosity_) std::cout << "Loading from file" << inputFileName_ << std::endl;
-	  cut->second->cutFunction_ = loadObjectFromFile<TGraph>(*inputFile, cut->second->cutName_);
-	} else {
-	  if(verbosity_) std::cout << "Loading from DB" << std::endl;
-	  cut->second->cutFunction_ = loadTGraphFromDB(es, cut->second->cutName_, verbosity_);
-	}
+    for (DiscriminantCutMap::iterator cut = cuts_.begin(); cut != cuts_.end(); ++cut) {
+      if (cut->second->mode_ == DiscriminantCutEntry::kVariableCut) {
+        if (!loadMVAfromDB_) {
+          if (not inputFile) {
+            inputFile = openInputFile(inputFileName_);
+          }
+          if (verbosity_)
+            std::cout << "Loading from file" << inputFileName_ << std::endl;
+          cut->second->cutFunction_ = loadObjectFromFile<TGraph>(*inputFile, cut->second->cutName_);
+        } else {
+          if (verbosity_)
+            std::cout << "Loading from DB" << std::endl;
+          cut->second->cutFunction_ = loadTGraphFromDB(es, cut->second->cutName_, verbosity_);
+        }
       }
     }
     isInitialized_ = true;
@@ -225,61 +217,62 @@ void RecoTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const 
   evt.getByToken(key_token, keyHandle_);
 }
 
-double
-RecoTauDiscriminantCutMultiplexer::discriminate(const reco::PFTauRef& tau) const
-{
-  if ( verbosity_ ) {
+double RecoTauDiscriminantCutMultiplexer::discriminate(const reco::PFTauRef& tau) const {
+  if (verbosity_) {
     std::cout << "<RecoTauDiscriminantCutMultiplexer::discriminate>:" << std::endl;
     std::cout << " moduleLabel = " << moduleLabel_ << std::endl;
   }
 
   double disc_result = (*toMultiplexHandle_)[tau];
-  if ( verbosity_ ) {
-    std::cout << "disc_result = " <<  disc_result << std::endl;
+  if (verbosity_) {
+    std::cout << "disc_result = " << disc_result << std::endl;
   }
-  if ( mvaOutput_normalization_ ) {
+  if (mvaOutput_normalization_) {
     disc_result = mvaOutput_normalization_->Eval(disc_result);
     //if ( disc_result > 1. ) disc_result = 1.;
     //if ( disc_result < 0. ) disc_result = 0.;
-    if ( verbosity_ ) {
-      std::cout << "disc_result (normalized) = " <<  disc_result << std::endl;
+    if (verbosity_) {
+      std::cout << "disc_result (normalized) = " << disc_result << std::endl;
     }
   }
   double key_result = (*keyHandle_)[tau];
   DiscriminantCutMap::const_iterator cutIter = cuts_.find(TMath::Nint(key_result));
 
-  
   // Return null if it doesn't exist
-  if ( cutIter == cuts_.end() ) {
+  if (cutIter == cuts_.end()) {
     return prediscriminantFailValue_;
   }
   // See if the discriminator passes our cuts
   bool passesCuts = false;
-  if ( cutIter->second->mode_ == DiscriminantCutEntry::kFixedCut ) {
+  if (cutIter->second->mode_ == DiscriminantCutEntry::kFixedCut) {
     passesCuts = (disc_result > cutIter->second->cutValue_);
-    if ( verbosity_ ) {
-      std::cout << "cutValue (fixed) = " << cutIter->second->cutValue_ << " --> passesCuts = " << passesCuts << std::endl;
+    if (verbosity_) {
+      std::cout << "cutValue (fixed) = " << cutIter->second->cutValue_ << " --> passesCuts = " << passesCuts
+                << std::endl;
     }
-  } else if ( cutIter->second->mode_ == DiscriminantCutEntry::kVariableCut ) {
+  } else if (cutIter->second->mode_ == DiscriminantCutEntry::kVariableCut) {
     double cutVariable = (*cutIter->second->cutVariable_)(*tau);
     double xMin, xMax, dummy;
     cutIter->second->cutFunction_->GetPoint(0, xMin, dummy);
     cutIter->second->cutFunction_->GetPoint(cutIter->second->cutFunction_->GetN() - 1, xMax, dummy);
     const double epsilon = 1.e-3;
-    if      ( cutVariable < (xMin + epsilon) ) cutVariable = xMin + epsilon;
-    else if ( cutVariable > (xMax - epsilon) ) cutVariable = xMax - epsilon;
+    if (cutVariable < (xMin + epsilon))
+      cutVariable = xMin + epsilon;
+    else if (cutVariable > (xMax - epsilon))
+      cutVariable = xMax - epsilon;
     double cutValue = cutIter->second->cutFunction_->Eval(cutVariable);
     passesCuts = (disc_result > cutValue);
-    if ( verbosity_ ) {
-      std::cout << "cutValue (@" << cutVariable << ") = " << cutValue << " --> passesCuts = " << passesCuts << std::endl;
+    if (verbosity_) {
+      std::cout << "cutValue (@" << cutVariable << ") = " << cutValue << " --> passesCuts = " << passesCuts
+                << std::endl;
     }
-  } else assert(0);
+  } else
+    assert(0);
 
   return passesCuts;
 }
 
-void
-RecoTauDiscriminantCutMultiplexer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void RecoTauDiscriminantCutMultiplexer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // recoTauDiscriminantCutMultiplexer
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("toMultiplex", edm::InputTag("fixme"));
@@ -287,10 +280,10 @@ RecoTauDiscriminantCutMultiplexer::fillDescriptions(edm::ConfigurationDescriptio
 
   {
     edm::ParameterSet pset_mapping;
-    pset_mapping.addParameter<unsigned int>("category",0);
-    pset_mapping.addParameter<double>("cut",0.);
+    pset_mapping.addParameter<unsigned int>("category", 0);
+    pset_mapping.addParameter<double>("cut", 0.);
     edm::ParameterSetDescription desc_mapping;
-    desc_mapping.add<unsigned int>("category",0);
+    desc_mapping.add<unsigned int>("category", 0);
     desc_mapping.addNode(edm::ParameterDescription<std::string>("cut", true) xor
                          edm::ParameterDescription<double>("cut", true));
     // it seems the parameter string "variable" exists only when "cut" is string
@@ -299,16 +292,15 @@ RecoTauDiscriminantCutMultiplexer::fillDescriptions(edm::ConfigurationDescriptio
     //  desc_mapping.add<double>("cut",0.);
     std::vector<edm::ParameterSet> vpsd_mapping;
     vpsd_mapping.push_back(pset_mapping);
-    desc.addVPSet("mapping",desc_mapping,vpsd_mapping);
+    desc.addVPSet("mapping", desc_mapping, vpsd_mapping);
   }
- 
+
   desc.add<edm::FileInPath>("inputFileName", edm::FileInPath("RecoTauTag/RecoTau/data/emptyMVAinputFile"));
   desc.add<bool>("loadMVAfromDB", true);
-  fillProducerDescriptions(desc); // inherited from the base
+  fillProducerDescriptions(desc);  // inherited from the base
   desc.add<std::string>("mvaOutput_normalization", "");
   desc.add<edm::InputTag>("key", edm::InputTag("fixme"));
   descriptions.add("recoTauDiscriminantCutMultiplexerDefault", desc);
 }
-
 
 DEFINE_FWK_MODULE(RecoTauDiscriminantCutMultiplexer);

--- a/RecoTauTag/RecoTau/plugins/RecoTauElectronRejectionPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauElectronRejectionPlugin.cc
@@ -19,208 +19,207 @@
 #include <Math/VectorUtil.h>
 #include <algorithm>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauElectronRejectionPlugin : public RecoTauModifierPlugin {
-  public:
-  explicit RecoTauElectronRejectionPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC);
-    ~RecoTauElectronRejectionPlugin() override {}
-    void operator()(PFTau&) const override;
-  private:
-    double ElecPreIDLeadTkMatch_maxDR_;
-    double EcalStripSumE_minClusEnergy_;
-    double EcalStripSumE_deltaEta_;
-    double EcalStripSumE_deltaPhiOverQ_minValue_;
-    double EcalStripSumE_deltaPhiOverQ_maxValue_;
-    double maximumForElectrionPreIDOutput_;
-    std::string DataType_;
-};
+    class RecoTauElectronRejectionPlugin : public RecoTauModifierPlugin {
+    public:
+      explicit RecoTauElectronRejectionPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+      ~RecoTauElectronRejectionPlugin() override {}
+      void operator()(PFTau&) const override;
 
-RecoTauElectronRejectionPlugin::RecoTauElectronRejectionPlugin(
-  const edm::ParameterSet& pset, edm::ConsumesCollector && iC):RecoTauModifierPlugin(pset,std::move(iC)) {
-  // Load parameters
-  ElecPreIDLeadTkMatch_maxDR_ =
-    pset.getParameter<double>("ElecPreIDLeadTkMatch_maxDR");
-  EcalStripSumE_minClusEnergy_ =
-    pset.getParameter<double>("EcalStripSumE_minClusEnergy");
-  EcalStripSumE_deltaEta_ =
-    pset.getParameter<double>("EcalStripSumE_deltaEta");
-  EcalStripSumE_deltaPhiOverQ_minValue_ =
-    pset.getParameter<double>("EcalStripSumE_deltaPhiOverQ_minValue");
-  EcalStripSumE_deltaPhiOverQ_maxValue_ =
-    pset.getParameter<double>("EcalStripSumE_deltaPhiOverQ_maxValue");
-  maximumForElectrionPreIDOutput_ =
-    pset.getParameter<double>("maximumForElectrionPreIDOutput");
-  DataType_ = pset.getParameter<std::string>("DataType");
-}
+    private:
+      double ElecPreIDLeadTkMatch_maxDR_;
+      double EcalStripSumE_minClusEnergy_;
+      double EcalStripSumE_deltaEta_;
+      double EcalStripSumE_deltaPhiOverQ_minValue_;
+      double EcalStripSumE_deltaPhiOverQ_maxValue_;
+      double maximumForElectrionPreIDOutput_;
+      std::string DataType_;
+    };
 
-namespace {
-bool checkPos(std::vector<math::XYZPoint> CalPos,math::XYZPoint CandPos) {
-  bool flag = false;
-  for (unsigned int i=0;i<CalPos.size();i++) {
-    if (CalPos[i] == CandPos) {
-      flag = true;
-      break;
+    RecoTauElectronRejectionPlugin::RecoTauElectronRejectionPlugin(const edm::ParameterSet& pset,
+                                                                   edm::ConsumesCollector&& iC)
+        : RecoTauModifierPlugin(pset, std::move(iC)) {
+      // Load parameters
+      ElecPreIDLeadTkMatch_maxDR_ = pset.getParameter<double>("ElecPreIDLeadTkMatch_maxDR");
+      EcalStripSumE_minClusEnergy_ = pset.getParameter<double>("EcalStripSumE_minClusEnergy");
+      EcalStripSumE_deltaEta_ = pset.getParameter<double>("EcalStripSumE_deltaEta");
+      EcalStripSumE_deltaPhiOverQ_minValue_ = pset.getParameter<double>("EcalStripSumE_deltaPhiOverQ_minValue");
+      EcalStripSumE_deltaPhiOverQ_maxValue_ = pset.getParameter<double>("EcalStripSumE_deltaPhiOverQ_maxValue");
+      maximumForElectrionPreIDOutput_ = pset.getParameter<double>("maximumForElectrionPreIDOutput");
+      DataType_ = pset.getParameter<std::string>("DataType");
     }
-  }
-  return flag;
-}
-}
 
-void RecoTauElectronRejectionPlugin::operator()(PFTau& tau) const {
-  // copy pasted from PFRecoTauAlgorithm...
-  double myECALenergy             =  0.;
-  double myHCALenergy             =  0.;
-  double myHCALenergy3x3          =  0.;
-  double myMaximumHCALPFClusterE  =  0.;
-  double myMaximumHCALPFClusterEt =  0.;
-  double myStripClusterE          =  0.;
-  double myEmfrac                 = -1.;
-  double myElectronPreIDOutput    = -1111.;
-  bool   myElecPreid              =  false;
-  reco::TrackRef myElecTrk;
-
-  typedef std::pair<reco::PFBlockRef, unsigned> ElementInBlock;
-  typedef std::vector< ElementInBlock > ElementsInBlocks;
-
-  PFCandidatePtr myleadPFChargedCand = tau.leadPFChargedHadrCand();
-  // Build list of PFCands in tau
-  std::vector<PFCandidatePtr> myPFCands;
-  myPFCands.reserve(tau.isolationPFCands().size()+tau.signalPFCands().size());
-
-  std::copy(tau.isolationPFCands().begin(), tau.isolationPFCands().end(),
-      std::back_inserter(myPFCands));
-  std::copy(tau.signalPFCands().begin(), tau.signalPFCands().end(),
-      std::back_inserter(myPFCands));
-
-  //Use the electron rejection only in case there is a charged leading pion
-  if(myleadPFChargedCand.isNonnull()){
-    myElectronPreIDOutput = myleadPFChargedCand->mva_e_pi();
-
-    math::XYZPointF myElecTrkEcalPos = myleadPFChargedCand->positionAtECALEntrance();
-    myElecTrk = myleadPFChargedCand->trackRef();//Electron candidate
-
-    if(myElecTrk.isNonnull()) {
-      //FROM AOD
-      if(DataType_ == "AOD"){
-        // Corrected Cluster energies
-        for(int i=0;i<(int)myPFCands.size();i++){
-          myHCALenergy += myPFCands[i]->hcalEnergy();
-          myECALenergy += myPFCands[i]->ecalEnergy();
-
-          math::XYZPointF candPos;
-          if (myPFCands[i]->particleId()==1 || myPFCands[i]->particleId()==2)//if charged hadron or electron
-            candPos = myPFCands[i]->positionAtECALEntrance();
-          else
-            candPos = math::XYZPointF(myPFCands[i]->px(),myPFCands[i]->py(),myPFCands[i]->pz());
-
-          double deltaR   = ROOT::Math::VectorUtil::DeltaR(myElecTrkEcalPos,candPos);
-          double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myElecTrkEcalPos,candPos);
-          double deltaEta = std::abs(myElecTrkEcalPos.eta()-candPos.eta());
-          double deltaPhiOverQ = deltaPhi/(double)myElecTrk->charge();
-
-          if (myPFCands[i]->ecalEnergy() >= EcalStripSumE_minClusEnergy_ && deltaEta < EcalStripSumE_deltaEta_ &&
-              deltaPhiOverQ > EcalStripSumE_deltaPhiOverQ_minValue_  && deltaPhiOverQ < EcalStripSumE_deltaPhiOverQ_maxValue_) {
-            myStripClusterE += myPFCands[i]->ecalEnergy();
-          }
-          if (deltaR<0.184) {
-            myHCALenergy3x3 += myPFCands[i]->hcalEnergy();
-          }
-          if (myPFCands[i]->hcalEnergy()>myMaximumHCALPFClusterE) {
-            myMaximumHCALPFClusterE = myPFCands[i]->hcalEnergy();
-          }
-          if ((myPFCands[i]->hcalEnergy()*fabs(sin(candPos.Theta())))>myMaximumHCALPFClusterEt) {
-            myMaximumHCALPFClusterEt = (myPFCands[i]->hcalEnergy()*fabs(sin(candPos.Theta())));
+    namespace {
+      bool checkPos(std::vector<math::XYZPoint> CalPos, math::XYZPoint CandPos) {
+        bool flag = false;
+        for (unsigned int i = 0; i < CalPos.size(); i++) {
+          if (CalPos[i] == CandPos) {
+            flag = true;
+            break;
           }
         }
+        return flag;
+      }
+    }  // namespace
 
-      } else if(DataType_ == "RECO"){ //From RECO
-        // Against double counting of clusters
-        std::vector<math::XYZPoint> hcalPosV; hcalPosV.clear();
-        std::vector<math::XYZPoint> ecalPosV; ecalPosV.clear();
-        for(int i=0;i<(int)myPFCands.size();i++){
-          const ElementsInBlocks& elts = myPFCands[i]->elementsInBlocks();
-          for(ElementsInBlocks::const_iterator it=elts.begin(); it!=elts.end(); ++it) {
-            const reco::PFBlock& block = *(it->first);
-            unsigned indexOfElementInBlock = it->second;
-            const edm::OwnVector< reco::PFBlockElement >& elements = block.elements();
-            assert(indexOfElementInBlock<elements.size());
+    void RecoTauElectronRejectionPlugin::operator()(PFTau& tau) const {
+      // copy pasted from PFRecoTauAlgorithm...
+      double myECALenergy = 0.;
+      double myHCALenergy = 0.;
+      double myHCALenergy3x3 = 0.;
+      double myMaximumHCALPFClusterE = 0.;
+      double myMaximumHCALPFClusterEt = 0.;
+      double myStripClusterE = 0.;
+      double myEmfrac = -1.;
+      double myElectronPreIDOutput = -1111.;
+      bool myElecPreid = false;
+      reco::TrackRef myElecTrk;
 
-            const reco::PFBlockElement& element = elements[indexOfElementInBlock];
+      typedef std::pair<reco::PFBlockRef, unsigned> ElementInBlock;
+      typedef std::vector<ElementInBlock> ElementsInBlocks;
 
-            if(element.type()==reco::PFBlockElement::HCAL) {
-              math::XYZPoint clusPos = element.clusterRef()->position();
-              double en = (double)element.clusterRef()->energy();
-              double et = (double)element.clusterRef()->energy()*fabs(sin(clusPos.Theta()));
-              if (en>myMaximumHCALPFClusterE) {
-                myMaximumHCALPFClusterE = en;
+      PFCandidatePtr myleadPFChargedCand = tau.leadPFChargedHadrCand();
+      // Build list of PFCands in tau
+      std::vector<PFCandidatePtr> myPFCands;
+      myPFCands.reserve(tau.isolationPFCands().size() + tau.signalPFCands().size());
+
+      std::copy(tau.isolationPFCands().begin(), tau.isolationPFCands().end(), std::back_inserter(myPFCands));
+      std::copy(tau.signalPFCands().begin(), tau.signalPFCands().end(), std::back_inserter(myPFCands));
+
+      //Use the electron rejection only in case there is a charged leading pion
+      if (myleadPFChargedCand.isNonnull()) {
+        myElectronPreIDOutput = myleadPFChargedCand->mva_e_pi();
+
+        math::XYZPointF myElecTrkEcalPos = myleadPFChargedCand->positionAtECALEntrance();
+        myElecTrk = myleadPFChargedCand->trackRef();  //Electron candidate
+
+        if (myElecTrk.isNonnull()) {
+          //FROM AOD
+          if (DataType_ == "AOD") {
+            // Corrected Cluster energies
+            for (int i = 0; i < (int)myPFCands.size(); i++) {
+              myHCALenergy += myPFCands[i]->hcalEnergy();
+              myECALenergy += myPFCands[i]->ecalEnergy();
+
+              math::XYZPointF candPos;
+              if (myPFCands[i]->particleId() == 1 || myPFCands[i]->particleId() == 2)  //if charged hadron or electron
+                candPos = myPFCands[i]->positionAtECALEntrance();
+              else
+                candPos = math::XYZPointF(myPFCands[i]->px(), myPFCands[i]->py(), myPFCands[i]->pz());
+
+              double deltaR = ROOT::Math::VectorUtil::DeltaR(myElecTrkEcalPos, candPos);
+              double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myElecTrkEcalPos, candPos);
+              double deltaEta = std::abs(myElecTrkEcalPos.eta() - candPos.eta());
+              double deltaPhiOverQ = deltaPhi / (double)myElecTrk->charge();
+
+              if (myPFCands[i]->ecalEnergy() >= EcalStripSumE_minClusEnergy_ && deltaEta < EcalStripSumE_deltaEta_ &&
+                  deltaPhiOverQ > EcalStripSumE_deltaPhiOverQ_minValue_ &&
+                  deltaPhiOverQ < EcalStripSumE_deltaPhiOverQ_maxValue_) {
+                myStripClusterE += myPFCands[i]->ecalEnergy();
               }
-              if (et>myMaximumHCALPFClusterEt) {
-                myMaximumHCALPFClusterEt = et;
+              if (deltaR < 0.184) {
+                myHCALenergy3x3 += myPFCands[i]->hcalEnergy();
               }
-              if (!checkPos(hcalPosV,clusPos)) {
-                hcalPosV.push_back(clusPos);
-                myHCALenergy += en;
-                double deltaR = ROOT::Math::VectorUtil::DeltaR(myElecTrkEcalPos,clusPos);
-                if (deltaR<0.184) {
-                  myHCALenergy3x3 += en;
-                }
+              if (myPFCands[i]->hcalEnergy() > myMaximumHCALPFClusterE) {
+                myMaximumHCALPFClusterE = myPFCands[i]->hcalEnergy();
               }
-            } else if(element.type()==reco::PFBlockElement::ECAL) {
-              double en = (double)element.clusterRef()->energy();
-              math::XYZPoint clusPos = element.clusterRef()->position();
-              if (!checkPos(ecalPosV,clusPos)) {
-                ecalPosV.push_back(clusPos);
-                myECALenergy += en;
-                double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myElecTrkEcalPos,clusPos);
-                double deltaEta = std::abs(myElecTrkEcalPos.eta()-clusPos.eta());
-                double deltaPhiOverQ = deltaPhi/(double)myElecTrk->charge();
-                if (en >= EcalStripSumE_minClusEnergy_ && deltaEta<EcalStripSumE_deltaEta_ && deltaPhiOverQ > EcalStripSumE_deltaPhiOverQ_minValue_ && deltaPhiOverQ < EcalStripSumE_deltaPhiOverQ_maxValue_) {
-                  myStripClusterE += en;
-                }
+              if ((myPFCands[i]->hcalEnergy() * fabs(sin(candPos.Theta()))) > myMaximumHCALPFClusterEt) {
+                myMaximumHCALPFClusterEt = (myPFCands[i]->hcalEnergy() * fabs(sin(candPos.Theta())));
               }
             }
-          } //end elements in blocks
-        } //end loop over PFcands
-      } //end RECO case
-    } // end check for null electrk
-  } // end check for null pfChargedHadrCand
 
-  if ((myHCALenergy+myECALenergy)>0.)
-    myEmfrac = myECALenergy/(myHCALenergy+myECALenergy);
-  tau.setemFraction((float)myEmfrac);
+          } else if (DataType_ == "RECO") {  //From RECO
+            // Against double counting of clusters
+            std::vector<math::XYZPoint> hcalPosV;
+            hcalPosV.clear();
+            std::vector<math::XYZPoint> ecalPosV;
+            ecalPosV.clear();
+            for (int i = 0; i < (int)myPFCands.size(); i++) {
+              const ElementsInBlocks& elts = myPFCands[i]->elementsInBlocks();
+              for (ElementsInBlocks::const_iterator it = elts.begin(); it != elts.end(); ++it) {
+                const reco::PFBlock& block = *(it->first);
+                unsigned indexOfElementInBlock = it->second;
+                const edm::OwnVector<reco::PFBlockElement>& elements = block.elements();
+                assert(indexOfElementInBlock < elements.size());
 
-  // scale the appropriate quantities by the momentum of the electron if it exists
-  if (myElecTrk.isNonnull())
-  {
-    float myElectronMomentum = (float)myElecTrk->p();
-    if (myElectronMomentum > 0.)
-    {
-      myHCALenergy            /= myElectronMomentum;
-      myMaximumHCALPFClusterE /= myElectronMomentum;
-      myHCALenergy3x3         /= myElectronMomentum;
-      myStripClusterE         /= myElectronMomentum;
+                const reco::PFBlockElement& element = elements[indexOfElementInBlock];
+
+                if (element.type() == reco::PFBlockElement::HCAL) {
+                  math::XYZPoint clusPos = element.clusterRef()->position();
+                  double en = (double)element.clusterRef()->energy();
+                  double et = (double)element.clusterRef()->energy() * fabs(sin(clusPos.Theta()));
+                  if (en > myMaximumHCALPFClusterE) {
+                    myMaximumHCALPFClusterE = en;
+                  }
+                  if (et > myMaximumHCALPFClusterEt) {
+                    myMaximumHCALPFClusterEt = et;
+                  }
+                  if (!checkPos(hcalPosV, clusPos)) {
+                    hcalPosV.push_back(clusPos);
+                    myHCALenergy += en;
+                    double deltaR = ROOT::Math::VectorUtil::DeltaR(myElecTrkEcalPos, clusPos);
+                    if (deltaR < 0.184) {
+                      myHCALenergy3x3 += en;
+                    }
+                  }
+                } else if (element.type() == reco::PFBlockElement::ECAL) {
+                  double en = (double)element.clusterRef()->energy();
+                  math::XYZPoint clusPos = element.clusterRef()->position();
+                  if (!checkPos(ecalPosV, clusPos)) {
+                    ecalPosV.push_back(clusPos);
+                    myECALenergy += en;
+                    double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myElecTrkEcalPos, clusPos);
+                    double deltaEta = std::abs(myElecTrkEcalPos.eta() - clusPos.eta());
+                    double deltaPhiOverQ = deltaPhi / (double)myElecTrk->charge();
+                    if (en >= EcalStripSumE_minClusEnergy_ && deltaEta < EcalStripSumE_deltaEta_ &&
+                        deltaPhiOverQ > EcalStripSumE_deltaPhiOverQ_minValue_ &&
+                        deltaPhiOverQ < EcalStripSumE_deltaPhiOverQ_maxValue_) {
+                      myStripClusterE += en;
+                    }
+                  }
+                }
+              }  //end elements in blocks
+            }    //end loop over PFcands
+          }      //end RECO case
+        }        // end check for null electrk
+      }          // end check for null pfChargedHadrCand
+
+      if ((myHCALenergy + myECALenergy) > 0.)
+        myEmfrac = myECALenergy / (myHCALenergy + myECALenergy);
+      tau.setemFraction((float)myEmfrac);
+
+      // scale the appropriate quantities by the momentum of the electron if it exists
+      if (myElecTrk.isNonnull()) {
+        float myElectronMomentum = (float)myElecTrk->p();
+        if (myElectronMomentum > 0.) {
+          myHCALenergy /= myElectronMomentum;
+          myMaximumHCALPFClusterE /= myElectronMomentum;
+          myHCALenergy3x3 /= myElectronMomentum;
+          myStripClusterE /= myElectronMomentum;
+        }
+      }
+      tau.sethcalTotOverPLead((float)myHCALenergy);
+      tau.sethcalMaxOverPLead((float)myMaximumHCALPFClusterE);
+      tau.sethcal3x3OverPLead((float)myHCALenergy3x3);
+      tau.setecalStripSumEOverPLead((float)myStripClusterE);
+      tau.setmaximumHCALPFClusterEt(myMaximumHCALPFClusterEt);
+      tau.setelectronPreIDOutput(myElectronPreIDOutput);
+      if (myElecTrk.isNonnull())
+        tau.setelectronPreIDTrack(myElecTrk);
+      if (myElectronPreIDOutput > maximumForElectrionPreIDOutput_)
+        myElecPreid = true;
+      tau.setelectronPreIDDecision(myElecPreid);
+
+      // These need to be filled!
+      //tau.setbremsRecoveryEOverPLead(my...);
+
+      /* End elecron rejection */
     }
-  }
-  tau.sethcalTotOverPLead((float)myHCALenergy);
-  tau.sethcalMaxOverPLead((float)myMaximumHCALPFClusterE);
-  tau.sethcal3x3OverPLead((float)myHCALenergy3x3);
-  tau.setecalStripSumEOverPLead((float)myStripClusterE);
-  tau.setmaximumHCALPFClusterEt(myMaximumHCALPFClusterEt);
-  tau.setelectronPreIDOutput(myElectronPreIDOutput);
-  if (myElecTrk.isNonnull())
-    tau.setelectronPreIDTrack(myElecTrk);
-  if (myElectronPreIDOutput > maximumForElectrionPreIDOutput_)
-    myElecPreid = true;
-  tau.setelectronPreIDDecision(myElecPreid);
-
-  // These need to be filled!
-  //tau.setbremsRecoveryEOverPLead(my...);
-
-  /* End elecron rejection */
-}
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauModifierPluginFactory,
-    reco::tau::RecoTauElectronRejectionPlugin,
-    "RecoTauElectronRejectionPlugin");
+                  reco::tau::RecoTauElectronRejectionPlugin,
+                  "RecoTauElectronRejectionPlugin");

--- a/RecoTauTag/RecoTau/plugins/RecoTauEnergyRecoveryPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauEnergyRecoveryPlugin2.cc
@@ -1,4 +1,4 @@
-  /*
+/*
  * =============================================================================
  *       Filename:  RecoTauEnergyRecoveryPlugin2.cc
  *
@@ -32,50 +32,47 @@
 
 #include <algorithm>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauEnergyRecoveryPlugin2 : public RecoTauModifierPlugin
-{
- public:
+    class RecoTauEnergyRecoveryPlugin2 : public RecoTauModifierPlugin {
+    public:
+      explicit RecoTauEnergyRecoveryPlugin2(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+      ~RecoTauEnergyRecoveryPlugin2() override;
+      void operator()(PFTau&) const override;
+      void beginEvent() override;
 
-  explicit RecoTauEnergyRecoveryPlugin2(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
-  ~RecoTauEnergyRecoveryPlugin2() override;
-  void operator()(PFTau&) const override;
-  void beginEvent() override;
+    private:
+      double dRcone_;
+    };
 
- private:
+    RecoTauEnergyRecoveryPlugin2::RecoTauEnergyRecoveryPlugin2(const edm::ParameterSet& cfg,
+                                                               edm::ConsumesCollector&& iC)
+        : RecoTauModifierPlugin(cfg, std::move(iC)), dRcone_(cfg.getParameter<double>("dRcone")) {}
 
-  double dRcone_;
-};
+    RecoTauEnergyRecoveryPlugin2::~RecoTauEnergyRecoveryPlugin2() {}
 
-  RecoTauEnergyRecoveryPlugin2::RecoTauEnergyRecoveryPlugin2(const edm::ParameterSet& cfg, edm::ConsumesCollector &&iC)
-    : RecoTauModifierPlugin(cfg, std::move(iC)),
-    dRcone_(cfg.getParameter<double>("dRcone"))
-{}
+    void RecoTauEnergyRecoveryPlugin2::beginEvent() {}
 
-RecoTauEnergyRecoveryPlugin2::~RecoTauEnergyRecoveryPlugin2()
-{}
+    void RecoTauEnergyRecoveryPlugin2::operator()(PFTau& tau) const {
+      reco::Candidate::LorentzVector tauAltP4(0., 0., 0., 0.);
 
-void RecoTauEnergyRecoveryPlugin2::beginEvent()
-{}
+      std::vector<reco::CandidatePtr> pfJetConstituents = tau.jetRef()->getJetConstituents();
+      for (std::vector<reco::CandidatePtr>::const_iterator pfJetConstituent = pfJetConstituents.begin();
+           pfJetConstituent != pfJetConstituents.end();
+           ++pfJetConstituent) {
+        double dR = deltaR((*pfJetConstituent)->p4(), tau.p4());
+        if (dR < dRcone_)
+          tauAltP4 += (*pfJetConstituent)->p4();
+      }
 
-void RecoTauEnergyRecoveryPlugin2::operator()(PFTau& tau) const
-{
-  reco::Candidate::LorentzVector tauAltP4(0.,0.,0.,0.);
-  
-  std::vector<reco::CandidatePtr> pfJetConstituents = tau.jetRef()->getJetConstituents();
-  for ( std::vector<reco::CandidatePtr>::const_iterator pfJetConstituent = pfJetConstituents.begin();
-	pfJetConstituent != pfJetConstituents.end(); ++pfJetConstituent ) {
-    double dR = deltaR((*pfJetConstituent)->p4(), tau.p4());
-    if ( dR < dRcone_ ) tauAltP4 += (*pfJetConstituent)->p4();
-  }
+      tau.setalternatLorentzVect(tauAltP4);
+    }
 
-  tau.setalternatLorentzVect(tauAltP4);
-}
-
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauModifierPluginFactory,
-    reco::tau::RecoTauEnergyRecoveryPlugin2,
-    "RecoTauEnergyRecoveryPlugin2");
+                  reco::tau::RecoTauEnergyRecoveryPlugin2,
+                  "RecoTauEnergyRecoveryPlugin2");

--- a/RecoTauTag/RecoTau/plugins/RecoTauImpactParameterSignificancePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauImpactParameterSignificancePlugin.cc
@@ -25,74 +25,71 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauImpactParameterSignificancePlugin : public RecoTauModifierPlugin {
-  public:
-    explicit RecoTauImpactParameterSignificancePlugin(
-						      const edm::ParameterSet& pset,edm::ConsumesCollector &&iC);
-    ~RecoTauImpactParameterSignificancePlugin() override {}
-    void operator()(PFTau& tau) const override;
-    void beginEvent() override;
-  private:
-    RecoTauVertexAssociator vertexAssociator_;
-    const TransientTrackBuilder *builder_;
-};
+    class RecoTauImpactParameterSignificancePlugin : public RecoTauModifierPlugin {
+    public:
+      explicit RecoTauImpactParameterSignificancePlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+      ~RecoTauImpactParameterSignificancePlugin() override {}
+      void operator()(PFTau& tau) const override;
+      void beginEvent() override;
 
-RecoTauImpactParameterSignificancePlugin
-::RecoTauImpactParameterSignificancePlugin(const edm::ParameterSet& pset,edm::ConsumesCollector &&iC)
-  :RecoTauModifierPlugin(pset,std::move(iC)),
-   vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"),std::move(iC)){}
+    private:
+      RecoTauVertexAssociator vertexAssociator_;
+      const TransientTrackBuilder* builder_;
+    };
 
-void RecoTauImpactParameterSignificancePlugin::beginEvent() {
-  vertexAssociator_.setEvent(*evt());
-  // Get tranisent track builder.
-  edm::ESHandle<TransientTrackBuilder> myTransientTrackBuilder;
-  evtSetup()->get<TransientTrackRecord>().get("TransientTrackBuilder",
-                                              myTransientTrackBuilder);
-  builder_= myTransientTrackBuilder.product();
-}
+    RecoTauImpactParameterSignificancePlugin ::RecoTauImpactParameterSignificancePlugin(const edm::ParameterSet& pset,
+                                                                                        edm::ConsumesCollector&& iC)
+        : RecoTauModifierPlugin(pset, std::move(iC)),
+          vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)) {}
 
-namespace 
-{
-  inline const reco::Track* getTrack(const Candidate& cand)
-  {
-    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
-    if (pfCandPtr) {
-      if (pfCandPtr->trackRef().isNonnull())
-        return pfCandPtr->trackRef().get();
-      else
+    void RecoTauImpactParameterSignificancePlugin::beginEvent() {
+      vertexAssociator_.setEvent(*evt());
+      // Get tranisent track builder.
+      edm::ESHandle<TransientTrackBuilder> myTransientTrackBuilder;
+      evtSetup()->get<TransientTrackRecord>().get("TransientTrackBuilder", myTransientTrackBuilder);
+      builder_ = myTransientTrackBuilder.product();
+    }
+
+    namespace {
+      inline const reco::Track* getTrack(const Candidate& cand) {
+        const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+        if (pfCandPtr) {
+          if (pfCandPtr->trackRef().isNonnull())
+            return pfCandPtr->trackRef().get();
+          else
+            return nullptr;
+        }
+
+        const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+        if (packedCand && packedCand->hasTrackDetails())
+          return &packedCand->pseudoTrack();
+
         return nullptr;
+      }
+    }  // namespace
+
+    void RecoTauImpactParameterSignificancePlugin::operator()(PFTau& tau) const {
+      // Get the transient lead track
+      if (tau.leadChargedHadrCand().isNonnull()) {
+        const reco::Track* leadTrack = getTrack(*tau.leadChargedHadrCand());
+        if (leadTrack != nullptr) {
+          const TransientTrack track = builder_->build(leadTrack);
+          GlobalVector direction(tau.jetRef()->px(), tau.jetRef()->py(), tau.jetRef()->pz());
+          VertexRef pv = vertexAssociator_.associatedVertex(tau);
+          // Compute the significance
+          std::pair<bool, Measurement1D> ipsig = IPTools::signedImpactParameter3D(track, direction, *pv);
+          if (ipsig.first)
+            tau.setleadPFChargedHadrCandsignedSipt(ipsig.second.significance());
+        }
+      }
     }
-    
-    const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
-    if (packedCand && packedCand->hasTrackDetails())
-      return &packedCand->pseudoTrack();
 
-    return nullptr;
-  }
-}
-
-void RecoTauImpactParameterSignificancePlugin::operator()(PFTau& tau) const {
-  // Get the transient lead track
-  if (tau.leadChargedHadrCand().isNonnull()) {
-    const reco::Track* leadTrack = getTrack(*tau.leadChargedHadrCand());
-    if (leadTrack != nullptr) {
-      const TransientTrack track = builder_->build(leadTrack);
-      GlobalVector direction(tau.jetRef()->px(), tau.jetRef()->py(),
-                             tau.jetRef()->pz());
-      VertexRef pv = vertexAssociator_.associatedVertex(tau);
-      // Compute the significance
-      std::pair<bool,Measurement1D> ipsig =
-          IPTools::signedImpactParameter3D(track, direction, *pv);
-      if (ipsig.first)
-        tau.setleadPFChargedHadrCandsignedSipt(ipsig.second.significance());
-    }
-  }
-}
-
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauModifierPluginFactory,
-    reco::tau::RecoTauImpactParameterSignificancePlugin,
-    "RecoTauImpactParameterSignificancePlugin");
+                  reco::tau::RecoTauImpactParameterSignificancePlugin,
+                  "RecoTauImpactParameterSignificancePlugin");

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
@@ -23,85 +23,83 @@
 
 #include "CommonTools/CandUtils/interface/AddFourMomenta.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauPiZeroCombinatoricPlugin : public RecoTauPiZeroBuilderPlugin {
-  public:
-  explicit RecoTauPiZeroCombinatoricPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC);
-    ~RecoTauPiZeroCombinatoricPlugin() override {}
-    // Return type is unique_ptr<PiZeroVector>
-    return_type operator()(const reco::Jet& jet) const override;
+    class RecoTauPiZeroCombinatoricPlugin : public RecoTauPiZeroBuilderPlugin {
+    public:
+      explicit RecoTauPiZeroCombinatoricPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+      ~RecoTauPiZeroCombinatoricPlugin() override {}
+      // Return type is unique_ptr<PiZeroVector>
+      return_type operator()(const reco::Jet& jet) const override;
 
-  private:
-    RecoTauQualityCuts qcuts_;
-    double minMass_;
-    double maxMass_;
-    unsigned int maxInputGammas_;
-    unsigned int choose_;
-    AddFourMomenta p4Builder_;
-};
+    private:
+      RecoTauQualityCuts qcuts_;
+      double minMass_;
+      double maxMass_;
+      unsigned int maxInputGammas_;
+      unsigned int choose_;
+      AddFourMomenta p4Builder_;
+    };
 
-RecoTauPiZeroCombinatoricPlugin::RecoTauPiZeroCombinatoricPlugin(
-    const edm::ParameterSet& pset, edm::ConsumesCollector &&iC):RecoTauPiZeroBuilderPlugin(pset,std::move(iC)),
-    qcuts_(pset.getParameterSet(
-          "qualityCuts").getParameterSet("signalQualityCuts")) {
-  minMass_ = pset.getParameter<double>("minMass");
-  maxMass_ = pset.getParameter<double>("maxMass");
-  maxInputGammas_ = pset.getParameter<unsigned int>("maxInputGammas");
-  choose_ = pset.getParameter<unsigned int>("choose");
-}
-
-RecoTauPiZeroCombinatoricPlugin::return_type
-RecoTauPiZeroCombinatoricPlugin::operator()(
-    const reco::Jet& jet) const {
-  // Get list of gamma candidates
-  typedef std::vector<reco::CandidatePtr> CandPtrs;
-  typedef CandPtrs::const_iterator CandIter;
-  PiZeroVector output;
-
-  CandPtrs pfGammaCands = qcuts_.filterCandRefs(pfGammas(jet));
-  // Check if we have anything to do...
-  if (pfGammaCands.size() < choose_)
-    return output.release();
-
-  // Define the valid range of gammas to use
-  CandIter start_iter = pfGammaCands.begin();
-  CandIter end_iter = pfGammaCands.end();
-
-  // Only take the desired number of piZeros
-  end_iter = takeNElements(start_iter, end_iter, maxInputGammas_);
-
-  // Build the combinatoric generator
-  typedef CombinatoricGenerator<CandPtrs> ComboGenerator;
-  ComboGenerator generator(start_iter, end_iter, choose_);
-
-  // Find all possible combinations
-  for (ComboGenerator::iterator combo = generator.begin();
-      combo != generator.end(); ++combo) {
-    const Candidate::LorentzVector totalP4;
-    std::unique_ptr<RecoTauPiZero> piZero(
-        new RecoTauPiZero(0, totalP4, Candidate::Point(0, 0, 0),
-                          111, 10001, true, RecoTauPiZero::kCombinatoric));
-    // Add our daughters from this combination
-    for (ComboGenerator::combo_iterator candidate = combo->combo_begin();
-        candidate != combo->combo_end();  ++candidate) {
-      piZero->addDaughter(*candidate);
+    RecoTauPiZeroCombinatoricPlugin::RecoTauPiZeroCombinatoricPlugin(const edm::ParameterSet& pset,
+                                                                     edm::ConsumesCollector&& iC)
+        : RecoTauPiZeroBuilderPlugin(pset, std::move(iC)),
+          qcuts_(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts")) {
+      minMass_ = pset.getParameter<double>("minMass");
+      maxMass_ = pset.getParameter<double>("maxMass");
+      maxInputGammas_ = pset.getParameter<unsigned int>("maxInputGammas");
+      choose_ = pset.getParameter<unsigned int>("choose");
     }
-    p4Builder_.set(*piZero);
 
-    if (piZero->daughterPtr(0).isNonnull())
-      piZero->setVertex(piZero->daughterPtr(0)->vertex());
+    RecoTauPiZeroCombinatoricPlugin::return_type RecoTauPiZeroCombinatoricPlugin::operator()(
+        const reco::Jet& jet) const {
+      // Get list of gamma candidates
+      typedef std::vector<reco::CandidatePtr> CandPtrs;
+      typedef CandPtrs::const_iterator CandIter;
+      PiZeroVector output;
 
-    if ((maxMass_ < 0 || piZero->mass() < maxMass_) &&
-        piZero->mass() > minMass_)
-      output.push_back(piZero.get());
-  }
-  return output.release();
-}
+      CandPtrs pfGammaCands = qcuts_.filterCandRefs(pfGammas(jet));
+      // Check if we have anything to do...
+      if (pfGammaCands.size() < choose_)
+        return output.release();
 
-}}  // end namespace reco::tau
+      // Define the valid range of gammas to use
+      CandIter start_iter = pfGammaCands.begin();
+      CandIter end_iter = pfGammaCands.end();
+
+      // Only take the desired number of piZeros
+      end_iter = takeNElements(start_iter, end_iter, maxInputGammas_);
+
+      // Build the combinatoric generator
+      typedef CombinatoricGenerator<CandPtrs> ComboGenerator;
+      ComboGenerator generator(start_iter, end_iter, choose_);
+
+      // Find all possible combinations
+      for (ComboGenerator::iterator combo = generator.begin(); combo != generator.end(); ++combo) {
+        const Candidate::LorentzVector totalP4;
+        std::unique_ptr<RecoTauPiZero> piZero(
+            new RecoTauPiZero(0, totalP4, Candidate::Point(0, 0, 0), 111, 10001, true, RecoTauPiZero::kCombinatoric));
+        // Add our daughters from this combination
+        for (ComboGenerator::combo_iterator candidate = combo->combo_begin(); candidate != combo->combo_end();
+             ++candidate) {
+          piZero->addDaughter(*candidate);
+        }
+        p4Builder_.set(*piZero);
+
+        if (piZero->daughterPtr(0).isNonnull())
+          piZero->setVertex(piZero->daughterPtr(0)->vertex());
+
+        if ((maxMass_ < 0 || piZero->mass() < maxMass_) && piZero->mass() > minMass_)
+          output.push_back(piZero.get());
+      }
+      return output.release();
+    }
+
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauPiZeroBuilderPluginFactory,
-    reco::tau::RecoTauPiZeroCombinatoricPlugin,
-    "RecoTauPiZeroCombinatoricPlugin");
+                  reco::tau::RecoTauPiZeroCombinatoricPlugin,
+                  "RecoTauPiZeroCombinatoricPlugin");

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -39,48 +39,44 @@
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 class RecoTauPiZeroProducer : public edm::stream::EDProducer<> {
-  public:
-    typedef reco::tau::RecoTauPiZeroBuilderPlugin Builder;
-    typedef reco::tau::RecoTauPiZeroQualityPlugin Ranker;
+public:
+  typedef reco::tau::RecoTauPiZeroBuilderPlugin Builder;
+  typedef reco::tau::RecoTauPiZeroQualityPlugin Ranker;
 
-    explicit RecoTauPiZeroProducer(const edm::ParameterSet& pset);
-    ~RecoTauPiZeroProducer() override {}
-    void produce(edm::Event& evt, const edm::EventSetup& es) override;
-    void print(const std::vector<reco::RecoTauPiZero>& piZeros,
-               std::ostream& out);
+  explicit RecoTauPiZeroProducer(const edm::ParameterSet& pset);
+  ~RecoTauPiZeroProducer() override {}
+  void produce(edm::Event& evt, const edm::EventSetup& es) override;
+  void print(const std::vector<reco::RecoTauPiZero>& piZeros, std::ostream& out);
 
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  private:
-    typedef boost::ptr_vector<Builder> builderList;
-    typedef boost::ptr_vector<Ranker> rankerList;
-    typedef boost::ptr_vector<reco::RecoTauPiZero> PiZeroVector;
-    typedef boost::ptr_list<reco::RecoTauPiZero> PiZeroList;
+private:
+  typedef boost::ptr_vector<Builder> builderList;
+  typedef boost::ptr_vector<Ranker> rankerList;
+  typedef boost::ptr_vector<reco::RecoTauPiZero> PiZeroVector;
+  typedef boost::ptr_list<reco::RecoTauPiZero> PiZeroList;
 
-    typedef reco::tau::RecoTauLexicographicalRanking<rankerList,
-            reco::RecoTauPiZero> PiZeroPredicate;
+  typedef reco::tau::RecoTauLexicographicalRanking<rankerList, reco::RecoTauPiZero> PiZeroPredicate;
 
-    builderList builders_;
-    rankerList rankers_;
-    std::auto_ptr<PiZeroPredicate> predicate_;
-    double piZeroMass_;
+  builderList builders_;
+  rankerList rankers_;
+  std::auto_ptr<PiZeroPredicate> predicate_;
+  double piZeroMass_;
 
-    // Output selector
-    std::auto_ptr<StringCutObjectSelector<reco::RecoTauPiZero> >
-      outputSelector_;
+  // Output selector
+  std::auto_ptr<StringCutObjectSelector<reco::RecoTauPiZero>> outputSelector_;
 
-    //consumes interface
-    edm::EDGetTokenT<reco::JetView> cand_token;
+  //consumes interface
+  edm::EDGetTokenT<reco::JetView> cand_token;
 
-    double minJetPt_;
-    double maxJetAbsEta_;
+  double minJetPt_;
+  double maxJetAbsEta_;
 
-    int verbosity_;
+  int verbosity_;
 };
 
-RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset) 
-{
-  cand_token = consumes<reco::JetView>( pset.getParameter<edm::InputTag>("jetSrc"));
+RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset) {
+  cand_token = consumes<reco::JetView>(pset.getParameter<edm::InputTag>("jetSrc"));
   minJetPt_ = pset.getParameter<double>("minJetPt");
   maxJetAbsEta_ = pset.getParameter<double>("maxJetAbsEta");
 
@@ -91,24 +87,19 @@ RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset)
   // Get each of our PiZero builders
   const VPSet& builders = pset.getParameter<VPSet>("builders");
 
-  for (VPSet::const_iterator builderPSet = builders.begin();
-      builderPSet != builders.end(); ++builderPSet) {
+  for (VPSet::const_iterator builderPSet = builders.begin(); builderPSet != builders.end(); ++builderPSet) {
     // Get plugin name
-    const std::string& pluginType =
-      builderPSet->getParameter<std::string>("plugin");
+    const std::string& pluginType = builderPSet->getParameter<std::string>("plugin");
     // Build the plugin
-    builders_.push_back(RecoTauPiZeroBuilderPluginFactory::get()->create(
-          pluginType, *builderPSet, consumesCollector()));
+    builders_.push_back(
+        RecoTauPiZeroBuilderPluginFactory::get()->create(pluginType, *builderPSet, consumesCollector()));
   }
 
   // Get each of our quality rankers
   const VPSet& rankers = pset.getParameter<VPSet>("ranking");
-  for (VPSet::const_iterator rankerPSet = rankers.begin();
-      rankerPSet != rankers.end(); ++rankerPSet) {
-    const std::string& pluginType =
-      rankerPSet->getParameter<std::string>("plugin");
-    rankers_.push_back(RecoTauPiZeroQualityPluginFactory::get()->create(
-          pluginType, *rankerPSet));
+  for (VPSet::const_iterator rankerPSet = rankers.begin(); rankerPSet != rankers.end(); ++rankerPSet) {
+    const std::string& pluginType = rankerPSet->getParameter<std::string>("plugin");
+    rankers_.push_back(RecoTauPiZeroQualityPluginFactory::get()->create(pluginType, *rankerPSet));
   }
 
   // Build the sorting predicate
@@ -117,8 +108,7 @@ RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset)
   // now all producers apply a final output selection
   std::string selection = pset.getParameter<std::string>("outputSelection");
   if (!selection.empty()) {
-    outputSelector_.reset(
-        new StringCutObjectSelector<reco::RecoTauPiZero>(selection));
+    outputSelector_.reset(new StringCutObjectSelector<reco::RecoTauPiZero>(selection));
   }
 
   verbosity_ = pset.getParameter<int>("verbosity");
@@ -126,14 +116,13 @@ RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset)
   produces<reco::JetPiZeroAssociation>();
 }
 
-void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
-{
+void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   // Get a view of our jets via the base candidates
   edm::Handle<reco::JetView> jetView;
   evt.getByToken(cand_token, jetView);
 
   // Give each of our plugins a chance at doing something with the edm::Event
-  for(auto& builder : builders_) {
+  for (auto& builder : builders_) {
     builder.setup(evt, es);
   }
 
@@ -147,20 +136,21 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   for (size_t i = 0; i < nJets; ++i) {
     const reco::JetBaseRef jet(jetView->refAt(i));
 
-    if(jet->pt() - minJetPt_ < 1e-5) continue;
-    if(std::abs(jet->eta()) - maxJetAbsEta_ > -1e-5) continue;
+    if (jet->pt() - minJetPt_ < 1e-5)
+      continue;
+    if (std::abs(jet->eta()) - maxJetAbsEta_ > -1e-5)
+      continue;
     // Build our global list of RecoTauPiZero
     PiZeroList dirtyPiZeros;
 
     // Compute the pi zeros from this jet for all the desired algorithms
-    for(auto const& builder : builders_) {
+    for (auto const& builder : builders_) {
       try {
         PiZeroVector result(builder(*jet));
         dirtyPiZeros.transfer(dirtyPiZeros.end(), result);
-      } catch ( cms::Exception &exception) {
+      } catch (cms::Exception& exception) {
         edm::LogError("BuilderPluginException")
-            << "Exception caught in builder plugin " << builder.name()
-            << ", rethrowing" << std::endl;
+            << "Exception caught in builder plugin " << builder.name() << ", rethrowing" << std::endl;
         throw exception;
       }
     }
@@ -172,8 +162,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     std::set<reco::CandidatePtr> photonsInCleanCollection;
     while (!dirtyPiZeros.empty()) {
       // Pull our candidate pi zero from the front of the list
-      std::auto_ptr<reco::RecoTauPiZero> toAdd(
-          dirtyPiZeros.pop_front().release());
+      std::auto_ptr<reco::RecoTauPiZero> toAdd(dirtyPiZeros.pop_front().release());
       // If this doesn't pass our basic selection, discard it.
       if (!(*outputSelector_)(*toAdd)) {
         continue;
@@ -192,33 +181,33 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
       } else if (uniqueGammas.size() == toAdd->daughterPtrVector().size()) {
         // Check if it is composed entirely of unique gammas.  In this case
         // immediately add it to the clean collection.
-        photonsInCleanCollection.insert(toAdd->daughterPtrVector().begin(),
-                                        toAdd->daughterPtrVector().end());
+        photonsInCleanCollection.insert(toAdd->daughterPtrVector().begin(), toAdd->daughterPtrVector().end());
         cleanPiZeros.push_back(*toAdd);
       } else {
         // Otherwise update the pizero that contains only the unique gammas and
         // add it back into the sorted list of dirty PiZeros
         toAdd->clearDaughters();
         // Add each of the unique daughters back to the pizero
-        for(auto const& gamma : uniqueGammas) {
+        for (auto const& gamma : uniqueGammas) {
           toAdd->addDaughter(gamma);
         }
         // Update the four vector
         AddFourMomenta p4Builder_;
         p4Builder_.set(*toAdd);
         // Put this pi zero back into the collection of sorted dirty pizeros
-        PiZeroList::iterator insertionPoint = std::lower_bound(
-            dirtyPiZeros.begin(), dirtyPiZeros.end(), *toAdd, *predicate_);
+        PiZeroList::iterator insertionPoint =
+            std::lower_bound(dirtyPiZeros.begin(), dirtyPiZeros.end(), *toAdd, *predicate_);
         dirtyPiZeros.insert(insertionPoint, toAdd);
       }
     }
     // Apply the mass hypothesis if desired
     if (piZeroMass_ >= 0) {
-      for( auto& cleanPiZero: cleanPiZeros )
-         { cleanPiZero.setMass(this->piZeroMass_);};
+      for (auto& cleanPiZero : cleanPiZeros) {
+        cleanPiZero.setMass(this->piZeroMass_);
+      };
     }
     // Add to association
-    if ( verbosity_ >= 2 ) {
+    if (verbosity_ >= 2) {
       print(cleanPiZeros, std::cout);
     }
     association->setValue(jet.key(), cleanPiZeros);
@@ -227,38 +216,33 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 }
 
 // Print some helpful information
-void RecoTauPiZeroProducer::print(
-    const std::vector<reco::RecoTauPiZero>& piZeros, std::ostream& out) {
+void RecoTauPiZeroProducer::print(const std::vector<reco::RecoTauPiZero>& piZeros, std::ostream& out) {
   const unsigned int width = 25;
-  for(auto const& piZero : piZeros) {
+  for (auto const& piZero : piZeros) {
     out << piZero;
     out << "* Rankers:" << std::endl;
-    for (rankerList::const_iterator ranker = rankers_.begin();
-        ranker != rankers_.end(); ++ranker) {
-      out << "* " << std::setiosflags(std::ios::left)
-        << std::setw(width) << ranker->name()
-        << " " << std::resetiosflags(std::ios::left)
-        << std::setprecision(3) << (*ranker)(piZero);
+    for (rankerList::const_iterator ranker = rankers_.begin(); ranker != rankers_.end(); ++ranker) {
+      out << "* " << std::setiosflags(std::ios::left) << std::setw(width) << ranker->name() << " "
+          << std::resetiosflags(std::ios::left) << std::setprecision(3) << (*ranker)(piZero);
       out << std::endl;
     }
   }
 }
 
-void
-RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // common parameter descriptions
   edm::ParameterSetDescription desc_ranking;
-  desc_ranking.add<std::string>("selectionPassFunction","Func");
-  desc_ranking.add<double>("selectionFailValue",1000);
-  desc_ranking.add<std::string>("selection","Sel");
-  desc_ranking.add<std::string>("name","name");
-  desc_ranking.add<std::string>("plugin","plugin");
+  desc_ranking.add<std::string>("selectionPassFunction", "Func");
+  desc_ranking.add<double>("selectionFailValue", 1000);
+  desc_ranking.add<std::string>("selection", "Sel");
+  desc_ranking.add<std::string>("name", "name");
+  desc_ranking.add<std::string>("plugin", "plugin");
   edm::ParameterSet pset_ranking;
-  pset_ranking.addParameter<std::string>("selectionPassFunction","");
-  pset_ranking.addParameter<double>("selectionFailValue",1000);
-  pset_ranking.addParameter<std::string>("selection","");
-  pset_ranking.addParameter<std::string>("name","");
-  pset_ranking.addParameter<std::string>("plugin","");
+  pset_ranking.addParameter<std::string>("selectionPassFunction", "");
+  pset_ranking.addParameter<double>("selectionFailValue", 1000);
+  pset_ranking.addParameter<std::string>("selection", "");
+  pset_ranking.addParameter<std::string>("name", "");
+  pset_ranking.addParameter<std::string>("plugin", "");
   std::vector<edm::ParameterSet> vpsd_ranking;
   vpsd_ranking.push_back(pset_ranking);
 
@@ -296,8 +280,8 @@ RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc_isolationQualityCuts.addOptional<bool>("useTracksInsteadOfPFHadrons");
 
   edm::ParameterSetDescription desc_qualityCuts;
-  desc_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts",    desc_signalQualityCuts);
-  desc_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts",   desc_vxAssocQualityCuts);
+  desc_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts", desc_signalQualityCuts);
+  desc_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts", desc_vxAssocQualityCuts);
   desc_qualityCuts.add<edm::ParameterSetDescription>("isolationQualityCuts", desc_isolationQualityCuts);
   desc_qualityCuts.add<std::string>("leadingTrkOrPFCandOption", "leadPFCand");
   desc_qualityCuts.add<std::string>("pvFindingAlgo", "closestInDeltaZ");
@@ -306,11 +290,11 @@ RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc_qualityCuts.add<bool>("recoverLeadingTrk", false);
 
   edm::ParameterSet pset_builders;
-  pset_builders.addParameter<std::string>("name","");
-  pset_builders.addParameter<std::string>("plugin","");
+  pset_builders.addParameter<std::string>("name", "");
+  pset_builders.addParameter<std::string>("plugin", "");
   edm::ParameterSet qualityCuts;
-  pset_builders.addParameter<edm::ParameterSet>("qualityCuts",qualityCuts);
-  pset_builders.addParameter<int>("verbosity",0);
+  pset_builders.addParameter<edm::ParameterSet>("qualityCuts", qualityCuts);
+  pset_builders.addParameter<int>("verbosity", 0);
 
   {
     // Tailored on ak4PFJetsLegacyHPSPiZeros
@@ -340,13 +324,13 @@ RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
     }
     desc_builders.addOptional<double>("stripEtaAssociationDistance", 0.05);
     desc_builders.addOptional<double>("stripPhiAssociationDistance", 0.2);
-    
+
     desc_builders.add<edm::ParameterSetDescription>("qualityCuts", desc_qualityCuts);
-    
+
     desc_builders.add<std::string>("name");
     desc_builders.add<std::string>("plugin");
     desc_builders.add<int>("verbosity", 0);
-    
+
     desc_builders.addOptional<bool>("makeCombinatoricStrips");
     desc_builders.addOptional<int>("maxStripBuildIterations");
     desc_builders.addOptional<double>("minGammaEtStripAdd");
@@ -361,9 +345,7 @@ RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
     desc.addVPSet("builders", desc_builders, vpsd_builders);
 
     descriptions.add("recoTauPiZeroProducer", desc);
-
   }
-
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroQualityPlugins.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroQualityPlugins.cc
@@ -13,39 +13,41 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
 
-#include "CommonTools/Utils/interface/StringCutObjectSelector.h" 
-#include "CommonTools/Utils/interface/StringObjectFunction.h" 
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauPiZeroStringQuality : public RecoTauPiZeroQualityPlugin {
-  public:
-    explicit RecoTauPiZeroStringQuality(const edm::ParameterSet&);
-    ~RecoTauPiZeroStringQuality() override {}
-    double operator()(const RecoTauPiZero&) const override;
-  private:
-    const StringCutObjectSelector<RecoTauPiZero> selector_;
-    const StringObjectFunction<RecoTauPiZero> function_;
-    double failResult_;
-};
+    class RecoTauPiZeroStringQuality : public RecoTauPiZeroQualityPlugin {
+    public:
+      explicit RecoTauPiZeroStringQuality(const edm::ParameterSet&);
+      ~RecoTauPiZeroStringQuality() override {}
+      double operator()(const RecoTauPiZero&) const override;
 
-RecoTauPiZeroStringQuality::RecoTauPiZeroStringQuality(
-    const edm::ParameterSet& pset): RecoTauPiZeroQualityPlugin(pset),
-  selector_(pset.getParameter<std::string>("selection")),
-  function_(pset.getParameter<std::string>("selectionPassFunction")),
-  failResult_(pset.getParameter<double>("selectionFailValue")) {}
+    private:
+      const StringCutObjectSelector<RecoTauPiZero> selector_;
+      const StringObjectFunction<RecoTauPiZero> function_;
+      double failResult_;
+    };
 
-double RecoTauPiZeroStringQuality::operator()(const RecoTauPiZero& cand) const{
-  if(selector_(cand)) {
-    return function_(cand);
-  } 
-  else {
-    return failResult_;
-  }
-}
-}} // end namespace reco::tau
+    RecoTauPiZeroStringQuality::RecoTauPiZeroStringQuality(const edm::ParameterSet& pset)
+        : RecoTauPiZeroQualityPlugin(pset),
+          selector_(pset.getParameter<std::string>("selection")),
+          function_(pset.getParameter<std::string>("selectionPassFunction")),
+          failResult_(pset.getParameter<double>("selectionFailValue")) {}
+
+    double RecoTauPiZeroStringQuality::operator()(const RecoTauPiZero& cand) const {
+      if (selector_(cand)) {
+        return function_(cand);
+      } else {
+        return failResult_;
+      }
+    }
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(RecoTauPiZeroQualityPluginFactory, 
-    reco::tau::RecoTauPiZeroStringQuality, 
-    "RecoTauPiZeroStringQuality");
+DEFINE_EDM_PLUGIN(RecoTauPiZeroQualityPluginFactory,
+                  reco::tau::RecoTauPiZeroStringQuality,
+                  "RecoTauPiZeroStringQuality");

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -30,172 +30,160 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h"
 #include "RecoTauTag/RecoTau/interface/CombinatoricGenerator.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-namespace {
-// Apply a hypothesis on the mass of the strips.
-math::XYZTLorentzVector applyMassConstraint(
-    const math::XYZTLorentzVector& vec,double mass) {
-  double factor = sqrt(vec.energy()*vec.energy()-mass*mass)/vec.P();
-  return math::XYZTLorentzVector(
-      vec.px()*factor,vec.py()*factor,vec.pz()*factor,vec.energy());
-}
-}
+    namespace {
+      // Apply a hypothesis on the mass of the strips.
+      math::XYZTLorentzVector applyMassConstraint(const math::XYZTLorentzVector& vec, double mass) {
+        double factor = sqrt(vec.energy() * vec.energy() - mass * mass) / vec.P();
+        return math::XYZTLorentzVector(vec.px() * factor, vec.py() * factor, vec.pz() * factor, vec.energy());
+      }
+    }  // namespace
 
+    class RecoTauPiZeroStripPlugin : public RecoTauPiZeroBuilderPlugin {
+    public:
+      explicit RecoTauPiZeroStripPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+      ~RecoTauPiZeroStripPlugin() override {}
+      // Return type is unique_ptr<PiZeroVector>
+      return_type operator()(const reco::Jet& jet) const override;
+      // Hook to update PV information
+      void beginEvent() override;
 
-class RecoTauPiZeroStripPlugin : public RecoTauPiZeroBuilderPlugin {
-  public:
-  explicit RecoTauPiZeroStripPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC);
-    ~RecoTauPiZeroStripPlugin() override {}
-    // Return type is unique_ptr<PiZeroVector>
-    return_type operator()(const reco::Jet& jet) const override;
-    // Hook to update PV information
-    void beginEvent() override;
+    private:
+      RecoTauQualityCuts qcuts_;
+      RecoTauVertexAssociator vertexAssociator_;
 
-  private:
-    RecoTauQualityCuts qcuts_;
-    RecoTauVertexAssociator vertexAssociator_;
+      std::vector<int> inputParticleIds_;  //type of candidates to clusterize
+      double etaAssociationDistance_;      //eta Clustering Association Distance
+      double phiAssociationDistance_;      //phi Clustering Association Distance
 
-    std::vector<int> inputParticleIds_; //type of candidates to clusterize
-    double etaAssociationDistance_;//eta Clustering Association Distance
-    double phiAssociationDistance_;//phi Clustering Association Distance
+      // Parameters for build strip combinations
+      bool combineStrips_;
+      int maxStrips_;
+      double combinatoricStripMassHypo_;
 
-    // Parameters for build strip combinations
-    bool combineStrips_;
-    int maxStrips_;
-    double combinatoricStripMassHypo_;
+      AddFourMomenta p4Builder_;
+    };
 
-    AddFourMomenta p4Builder_;
-};
-
-RecoTauPiZeroStripPlugin::RecoTauPiZeroStripPlugin(
-    const edm::ParameterSet& pset, edm::ConsumesCollector && iC):
-    RecoTauPiZeroBuilderPlugin(pset,std::move(iC)),
-    qcuts_(pset.getParameterSet(
-          "qualityCuts").getParameterSet("signalQualityCuts")),
-    vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"),std::move(iC)) {
-  inputParticleIds_ = pset.getParameter<std::vector<int> >(
-      "stripCandidatesParticleIds");
-  etaAssociationDistance_ = pset.getParameter<double>(
-      "stripEtaAssociationDistance");
-  phiAssociationDistance_ = pset.getParameter<double>(
-      "stripPhiAssociationDistance");
-  combineStrips_ = pset.getParameter<bool>("makeCombinatoricStrips");
-  if (combineStrips_) {
-    maxStrips_ = pset.getParameter<int>("maxInputStrips");
-    combinatoricStripMassHypo_ =
-      pset.getParameter<double>("stripMassWhenCombining");
-  }
-}
-
-// Update the primary vertex
-void RecoTauPiZeroStripPlugin::beginEvent() {
-  vertexAssociator_.setEvent(*evt());
-}
-
-RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
-    const reco::Jet& jet) const {
-  // Get list of gamma candidates
-  typedef std::vector<reco::CandidatePtr> CandPtrs;
-  typedef CandPtrs::iterator CandIter;
-  PiZeroVector output;
-
-  // Get the candidates passing our quality cuts
-  qcuts_.setPV(vertexAssociator_.associatedVertex(jet));
-  CandPtrs candsVector = qcuts_.filterCandRefs(pfCandidates(jet, inputParticleIds_));
-  //PFCandPtrs candsVector = qcuts_.filterCandRefs(pfGammas(jet));
-
-  // Convert to stl::list to allow fast deletions
-  typedef std::list<reco::CandidatePtr> CandPtrList;
-  typedef std::list<reco::CandidatePtr>::iterator CandPtrListIter;
-  CandPtrList cands;
-  cands.insert(cands.end(), candsVector.begin(), candsVector.end());
-
-  while (!cands.empty()) {
-    // Seed this new strip, and delete it from future strips
-    CandidatePtr seed = cands.front();
-    cands.pop_front();
-
-    // Add a new candidate to our collection using this seed
-    std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(
-            *seed, RecoTauPiZero::kStrips));
-    strip->addDaughter(seed);
-
-    // Find all other objects in the strip
-    CandPtrListIter stripCand = cands.begin();
-    while(stripCand != cands.end()) {
-      if( fabs(strip->eta() - (*stripCand)->eta()) < etaAssociationDistance_
-          && fabs(deltaPhi(*strip, **stripCand)) < phiAssociationDistance_ ) {
-        // Add candidate to strip
-        strip->addDaughter(*stripCand);
-        // Update the strips four momenta
-        p4Builder_.set(*strip);
-        // Delete this candidate from future strips and move on to
-        // the next potential candidate
-        stripCand = cands.erase(stripCand);
-      } else {
-        // This candidate isn't compatabile - just move to the next candidate
-        ++stripCand;
+    RecoTauPiZeroStripPlugin::RecoTauPiZeroStripPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : RecoTauPiZeroBuilderPlugin(pset, std::move(iC)),
+          qcuts_(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts")),
+          vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)) {
+      inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
+      etaAssociationDistance_ = pset.getParameter<double>("stripEtaAssociationDistance");
+      phiAssociationDistance_ = pset.getParameter<double>("stripPhiAssociationDistance");
+      combineStrips_ = pset.getParameter<bool>("makeCombinatoricStrips");
+      if (combineStrips_) {
+        maxStrips_ = pset.getParameter<int>("maxInputStrips");
+        combinatoricStripMassHypo_ = pset.getParameter<double>("stripMassWhenCombining");
       }
     }
-    // Update the vertex
-    if (strip->daughterPtr(0).isNonnull())
-      strip->setVertex(strip->daughterPtr(0)->vertex());
-    output.push_back(strip.get());
-  }
 
-  // Check if we want to combine our strips
-  if (combineStrips_ && output.size() > 1) {
-    PiZeroVector stripCombinations;
-    // Sort the output by descending pt
-    output.sort(output.begin(), output.end(),
-        boost::bind(&RecoTauPiZero::pt, _1) >
-        boost::bind(&RecoTauPiZero::pt, _2));
-    // Get the end of interesting set of strips to try and combine
-    PiZeroVector::const_iterator end_iter = takeNElements(
-        output.begin(), output.end(), maxStrips_);
+    // Update the primary vertex
+    void RecoTauPiZeroStripPlugin::beginEvent() { vertexAssociator_.setEvent(*evt()); }
 
-    // Look at all the combinations
-    for (PiZeroVector::const_iterator first = output.begin();
-        first != end_iter-1; ++first) {
-      for (PiZeroVector::const_iterator second = first+1;
-          second != end_iter; ++second) {
-        Candidate::LorentzVector firstP4 = first->p4();
-        Candidate::LorentzVector secondP4 = second->p4();
-        // If we assume a certain mass for each strip apply it here.
-        firstP4 = applyMassConstraint(firstP4, combinatoricStripMassHypo_);
-        secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
-        Candidate::LorentzVector totalP4 = firstP4 + secondP4;
-        // Make our new combined strip
-        std::unique_ptr<RecoTauPiZero> combinedStrips(
-            new RecoTauPiZero(0, totalP4,
-              Candidate::Point(0, 0, 0),
-              //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
-              111, 10001, true, RecoTauPiZero::kUndefined));
+    RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(const reco::Jet& jet) const {
+      // Get list of gamma candidates
+      typedef std::vector<reco::CandidatePtr> CandPtrs;
+      typedef CandPtrs::iterator CandIter;
+      PiZeroVector output;
 
-        // Now loop over the strip members
-        for(auto const& gamma : first->daughterPtrVector()) {
-          combinedStrips->addDaughter(gamma);
-        }
-        for(auto const& gamma : second->daughterPtrVector()) {
-          combinedStrips->addDaughter(gamma);
+      // Get the candidates passing our quality cuts
+      qcuts_.setPV(vertexAssociator_.associatedVertex(jet));
+      CandPtrs candsVector = qcuts_.filterCandRefs(pfCandidates(jet, inputParticleIds_));
+      //PFCandPtrs candsVector = qcuts_.filterCandRefs(pfGammas(jet));
+
+      // Convert to stl::list to allow fast deletions
+      typedef std::list<reco::CandidatePtr> CandPtrList;
+      typedef std::list<reco::CandidatePtr>::iterator CandPtrListIter;
+      CandPtrList cands;
+      cands.insert(cands.end(), candsVector.begin(), candsVector.end());
+
+      while (!cands.empty()) {
+        // Seed this new strip, and delete it from future strips
+        CandidatePtr seed = cands.front();
+        cands.pop_front();
+
+        // Add a new candidate to our collection using this seed
+        std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seed, RecoTauPiZero::kStrips));
+        strip->addDaughter(seed);
+
+        // Find all other objects in the strip
+        CandPtrListIter stripCand = cands.begin();
+        while (stripCand != cands.end()) {
+          if (fabs(strip->eta() - (*stripCand)->eta()) < etaAssociationDistance_ &&
+              fabs(deltaPhi(*strip, **stripCand)) < phiAssociationDistance_) {
+            // Add candidate to strip
+            strip->addDaughter(*stripCand);
+            // Update the strips four momenta
+            p4Builder_.set(*strip);
+            // Delete this candidate from future strips and move on to
+            // the next potential candidate
+            stripCand = cands.erase(stripCand);
+          } else {
+            // This candidate isn't compatabile - just move to the next candidate
+            ++stripCand;
+          }
         }
         // Update the vertex
-        if (combinedStrips->daughterPtr(0).isNonnull())
-          combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
-        // Add to our collection of combined strips
-        stripCombinations.push_back(combinedStrips.get());
+        if (strip->daughterPtr(0).isNonnull())
+          strip->setVertex(strip->daughterPtr(0)->vertex());
+        output.push_back(strip.get());
       }
-    }
-    // When done doing all the combinations, add the combined strips to the
-    // output.
-    output.transfer(output.end(), stripCombinations);
-  }
 
-  return output.release();
-}
-}} // end namespace reco::tau
+      // Check if we want to combine our strips
+      if (combineStrips_ && output.size() > 1) {
+        PiZeroVector stripCombinations;
+        // Sort the output by descending pt
+        output.sort(
+            output.begin(), output.end(), boost::bind(&RecoTauPiZero::pt, _1) > boost::bind(&RecoTauPiZero::pt, _2));
+        // Get the end of interesting set of strips to try and combine
+        PiZeroVector::const_iterator end_iter = takeNElements(output.begin(), output.end(), maxStrips_);
+
+        // Look at all the combinations
+        for (PiZeroVector::const_iterator first = output.begin(); first != end_iter - 1; ++first) {
+          for (PiZeroVector::const_iterator second = first + 1; second != end_iter; ++second) {
+            Candidate::LorentzVector firstP4 = first->p4();
+            Candidate::LorentzVector secondP4 = second->p4();
+            // If we assume a certain mass for each strip apply it here.
+            firstP4 = applyMassConstraint(firstP4, combinatoricStripMassHypo_);
+            secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
+            Candidate::LorentzVector totalP4 = firstP4 + secondP4;
+            // Make our new combined strip
+            std::unique_ptr<RecoTauPiZero> combinedStrips(
+                new RecoTauPiZero(0,
+                                  totalP4,
+                                  Candidate::Point(0, 0, 0),
+                                  //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
+                                  111,
+                                  10001,
+                                  true,
+                                  RecoTauPiZero::kUndefined));
+
+            // Now loop over the strip members
+            for (auto const& gamma : first->daughterPtrVector()) {
+              combinedStrips->addDaughter(gamma);
+            }
+            for (auto const& gamma : second->daughterPtrVector()) {
+              combinedStrips->addDaughter(gamma);
+            }
+            // Update the vertex
+            if (combinedStrips->daughterPtr(0).isNonnull())
+              combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
+            // Add to our collection of combined strips
+            stripCombinations.push_back(combinedStrips.get());
+          }
+        }
+        // When done doing all the combinations, add the combined strips to the
+        // output.
+        output.transfer(output.end(), stripCombinations);
+      }
+
+      return output.release();
+    }
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(RecoTauPiZeroBuilderPluginFactory,
-    reco::tau::RecoTauPiZeroStripPlugin, "RecoTauPiZeroStripPlugin");
+DEFINE_EDM_PLUGIN(RecoTauPiZeroBuilderPluginFactory, reco::tau::RecoTauPiZeroStripPlugin, "RecoTauPiZeroStripPlugin");

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -38,309 +38,319 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 //-------------------------------------------------------------------------------
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-namespace {
-  // Apply a hypothesis on the mass of the strips.
-  math::XYZTLorentzVector applyMassConstraint(
-      const math::XYZTLorentzVector& vec,double mass) {
-    double factor = sqrt(vec.energy()*vec.energy()-mass*mass)/vec.P();
-    return math::XYZTLorentzVector(
-        vec.px()*factor,vec.py()*factor,vec.pz()*factor,vec.energy());
-  }
-}
-
-class RecoTauPiZeroStripPlugin2 : public RecoTauPiZeroBuilderPlugin 
-{
- public:
-  explicit RecoTauPiZeroStripPlugin2(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
-  ~RecoTauPiZeroStripPlugin2() override;
-  // Return type is auto_ptr<PiZeroVector>
-  return_type operator()(const reco::Jet&) const override;
-  // Hook to update PV information
-  void beginEvent() override;
-  
- private:
-  typedef std::vector<reco::CandidatePtr> CandPtrs;
-  void addCandsToStrip(RecoTauPiZero&, CandPtrs&, const std::vector<bool>&, std::set<size_t>&, bool&) const;
-
-  RecoTauVertexAssociator vertexAssociator_;
-
-  RecoTauQualityCuts* qcuts_;
-  bool applyElecTrackQcuts_;
-  double minGammaEtStripSeed_;
-  double minGammaEtStripAdd_;
-
-  double minStripEt_;
-
-  std::vector<int> inputParticleIds_;  // type of candidates to clusterize
-  double etaAssociationDistance_; // size of strip clustering window in eta direction
-  double phiAssociationDistance_; // size of strip clustering window in phi direction
-
-  bool updateStripAfterEachDaughter_;
-  int maxStripBuildIterations_;
-
-  // Parameters for build strip combinations
-  bool combineStrips_;
-  int maxStrips_;
-  double combinatoricStripMassHypo_;
-
-  AddFourMomenta p4Builder_;
-
-  int verbosity_;
-};
-
-RecoTauPiZeroStripPlugin2::RecoTauPiZeroStripPlugin2(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC)
-  : RecoTauPiZeroBuilderPlugin(pset, std::move(iC)),
-    vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)),
-    qcuts_(nullptr)
-{
-  minGammaEtStripSeed_ = pset.getParameter<double>("minGammaEtStripSeed");
-  minGammaEtStripAdd_ = pset.getParameter<double>("minGammaEtStripAdd");
-
-  minStripEt_ = pset.getParameter<double>("minStripEt");
-  
-  edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
-//-------------------------------------------------------------------------------
-// CV: disable track quality cuts for PFElectronsPFElectron
-//       (treat PFElectrons like PFGammas for the purpose of building eta-phi strips)
-  applyElecTrackQcuts_ = pset.getParameter<bool>("applyElecTrackQcuts");
-  if ( !applyElecTrackQcuts_ ) {
-    qcuts_pset.addParameter<double>("minTrackPt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
-    qcuts_pset.addParameter<double>("maxTrackChi2", 1.e+9);
-    qcuts_pset.addParameter<double>("maxTransverseImpactParameter", 1.e+9);
-    qcuts_pset.addParameter<double>("maxDeltaZ", 1.e+9);
-    qcuts_pset.addParameter<double>("minTrackVertexWeight", -1.);
-    qcuts_pset.addParameter<unsigned>("minTrackPixelHits", 0);
-    qcuts_pset.addParameter<unsigned>("minTrackHits", 0);
-  }
-//-------------------------------------------------------------------------------
-  qcuts_pset.addParameter<double>("minGammaEt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
-  qcuts_ = new RecoTauQualityCuts(qcuts_pset);
-
-  inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
-  etaAssociationDistance_ = pset.getParameter<double>("stripEtaAssociationDistance");
-  phiAssociationDistance_ = pset.getParameter<double>("stripPhiAssociationDistance");
-
-  updateStripAfterEachDaughter_ = pset.getParameter<bool>("updateStripAfterEachDaughter");
-  maxStripBuildIterations_ = pset.getParameter<int>("maxStripBuildIterations");
-
-  combineStrips_ = pset.getParameter<bool>("makeCombinatoricStrips");
-  if ( combineStrips_ ) {
-    maxStrips_ = pset.getParameter<int>("maxInputStrips");
-    combinatoricStripMassHypo_ = pset.getParameter<double>("stripMassWhenCombining");
-  }
-
-  verbosity_ = pset.getParameter<int>("verbosity");
-}
-  
-RecoTauPiZeroStripPlugin2::~RecoTauPiZeroStripPlugin2()
-{
-  delete qcuts_;
-}
-
-// Update the primary vertex
-void RecoTauPiZeroStripPlugin2::beginEvent() 
-{
-  vertexAssociator_.setEvent(*evt());
-}
-
-void RecoTauPiZeroStripPlugin2::addCandsToStrip(RecoTauPiZero& strip, CandPtrs& cands, const std::vector<bool>& candFlags, 
-						std::set<size_t>& candIdsCurrentStrip, bool& isCandAdded) const
-{
-  if ( verbosity_ >= 1 ) {
-    edm::LogPrint("RecoTauPiZeroStripPlugin2") << "<RecoTauPiZeroStripPlugin2::addCandsToStrip>:" ;
-  }
-  size_t numCands = cands.size();
-  for ( size_t candId = 0; candId < numCands; ++candId ) {
-    if ( (!candFlags[candId]) && candIdsCurrentStrip.find(candId) == candIdsCurrentStrip.end() ) { // do not include same cand twice
-      reco::CandidatePtr cand = cands[candId];
-      if ( fabs(strip.eta() - cand->eta()) < etaAssociationDistance_ && // check if cand is within eta-phi window centered on strip 
-	   fabs(strip.phi() - cand->phi()) < phiAssociationDistance_ ) {
-	if ( verbosity_ >= 2 ) {
-	  edm::LogPrint("RecoTauPiZeroStripPlugin2") << "--> adding PFCand #" << candId << " (" << cand.id() << ":" << cand.key() << "): Et = " << cand->et() << ", eta = " << cand->eta() << ", phi = " << cand->phi() ;
-	}
-	strip.addDaughter(cand);
-	if ( updateStripAfterEachDaughter_ ) p4Builder_.set(strip);
-	isCandAdded = true;
-	candIdsCurrentStrip.insert(candId);
+    namespace {
+      // Apply a hypothesis on the mass of the strips.
+      math::XYZTLorentzVector applyMassConstraint(const math::XYZTLorentzVector& vec, double mass) {
+        double factor = sqrt(vec.energy() * vec.energy() - mass * mass) / vec.P();
+        return math::XYZTLorentzVector(vec.px() * factor, vec.py() * factor, vec.pz() * factor, vec.energy());
       }
-    }
-  }
-}
+    }  // namespace
 
-namespace 
-{
-  void markCandsInStrip(std::vector<bool>& candFlags, const std::set<size_t>& candIds)
-  {
-    for ( std::set<size_t>::const_iterator candId = candIds.begin();
-	  candId != candIds.end(); ++candId ) {
-      candFlags[*candId] = true;
-    }
-  }
+    class RecoTauPiZeroStripPlugin2 : public RecoTauPiZeroBuilderPlugin {
+    public:
+      explicit RecoTauPiZeroStripPlugin2(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+      ~RecoTauPiZeroStripPlugin2() override;
+      // Return type is auto_ptr<PiZeroVector>
+      return_type operator()(const reco::Jet&) const override;
+      // Hook to update PV information
+      void beginEvent() override;
 
-  inline const reco::TrackBaseRef getTrack(const Candidate& cand)
-  {
-    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
-    if (pfCandPtr) {
-      if      ( pfCandPtr->trackRef().isNonnull()    ) return reco::TrackBaseRef(pfCandPtr->trackRef());
-      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
-      else return reco::TrackBaseRef();
-    }
+    private:
+      typedef std::vector<reco::CandidatePtr> CandPtrs;
+      void addCandsToStrip(RecoTauPiZero&, CandPtrs&, const std::vector<bool>&, std::set<size_t>&, bool&) const;
 
-    return reco::TrackBaseRef();
-  }
-}
+      RecoTauVertexAssociator vertexAssociator_;
 
-RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(const reco::Jet& jet) const 
-{
-  if ( verbosity_ >= 1 ) {
-    edm::LogPrint("RecoTauPiZeroStripPlugin2") << "<RecoTauPiZeroStripPlugin2::operator()>:" ;
-    edm::LogPrint("RecoTauPiZeroStripPlugin2") << " minGammaEtStripSeed = " << minGammaEtStripSeed_ ;
-    edm::LogPrint("RecoTauPiZeroStripPlugin2") << " minGammaEtStripAdd = " << minGammaEtStripAdd_ ;
-    edm::LogPrint("RecoTauPiZeroStripPlugin2") << " minStripEt = " << minStripEt_ ;
-  }
+      RecoTauQualityCuts* qcuts_;
+      bool applyElecTrackQcuts_;
+      double minGammaEtStripSeed_;
+      double minGammaEtStripAdd_;
 
-  PiZeroVector output;
+      double minStripEt_;
 
-  // Get the candidates passing our quality cuts
-  qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
-  CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputParticleIds_));
+      std::vector<int> inputParticleIds_;  // type of candidates to clusterize
+      double etaAssociationDistance_;      // size of strip clustering window in eta direction
+      double phiAssociationDistance_;      // size of strip clustering window in phi direction
 
-  // Convert to stl::list to allow fast deletions
-  CandPtrs seedCands;
-  CandPtrs addCands;
-  int idx = 0;
-  for ( CandPtrs::iterator cand = candsVector.begin();
-	cand != candsVector.end(); ++cand ) {
-    if ( verbosity_ >= 1 ) {
-      edm::LogPrint("RecoTauPiZeroStripPlugin2") << "PFGamma #" << idx << " (" << cand->id() << ":" << cand->key() << "): Et = " << (*cand)->et() << ", eta = " << (*cand)->eta() << ", phi = " << (*cand)->phi() ;
-    } 
-    if ( (*cand)->et() > minGammaEtStripSeed_ ) {
-      if ( verbosity_ >= 2 ) {
-	edm::LogPrint("RecoTauPiZeroStripPlugin2") << "--> assigning seedCandId = " << seedCands.size() ;
-        const reco::TrackBaseRef candTrack = getTrack(**cand);
-        if ( candTrack.isNonnull() ) {
-	  edm::LogPrint("RecoTauPiZeroStripPlugin2") << "track: Pt = " << candTrack->pt() << " eta = " << candTrack->eta() << ", phi = " << candTrack->phi() << ", charge = " << candTrack->charge() ;
-	  edm::LogPrint("RecoTauPiZeroStripPlugin2") << " (dZ = " << candTrack->dz(vertexAssociator_.associatedVertex(jet)->position()) << ", dXY = " << candTrack->dxy(vertexAssociator_.associatedVertex(jet)->position()) << "," 
-		    << " numHits = " << candTrack->hitPattern().numberOfValidTrackerHits() << ", numPxlHits = " << candTrack->hitPattern().numberOfValidPixelHits() << "," 
-		    << " chi2 = " << candTrack->normalizedChi2() << ", dPt/Pt = " << (candTrack->ptError()/candTrack->pt()) << ")" ;
-	}
+      bool updateStripAfterEachDaughter_;
+      int maxStripBuildIterations_;
+
+      // Parameters for build strip combinations
+      bool combineStrips_;
+      int maxStrips_;
+      double combinatoricStripMassHypo_;
+
+      AddFourMomenta p4Builder_;
+
+      int verbosity_;
+    };
+
+    RecoTauPiZeroStripPlugin2::RecoTauPiZeroStripPlugin2(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : RecoTauPiZeroBuilderPlugin(pset, std::move(iC)),
+          vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)),
+          qcuts_(nullptr) {
+      minGammaEtStripSeed_ = pset.getParameter<double>("minGammaEtStripSeed");
+      minGammaEtStripAdd_ = pset.getParameter<double>("minGammaEtStripAdd");
+
+      minStripEt_ = pset.getParameter<double>("minStripEt");
+
+      edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
+      //-------------------------------------------------------------------------------
+      // CV: disable track quality cuts for PFElectronsPFElectron
+      //       (treat PFElectrons like PFGammas for the purpose of building eta-phi strips)
+      applyElecTrackQcuts_ = pset.getParameter<bool>("applyElecTrackQcuts");
+      if (!applyElecTrackQcuts_) {
+        qcuts_pset.addParameter<double>("minTrackPt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
+        qcuts_pset.addParameter<double>("maxTrackChi2", 1.e+9);
+        qcuts_pset.addParameter<double>("maxTransverseImpactParameter", 1.e+9);
+        qcuts_pset.addParameter<double>("maxDeltaZ", 1.e+9);
+        qcuts_pset.addParameter<double>("minTrackVertexWeight", -1.);
+        qcuts_pset.addParameter<unsigned>("minTrackPixelHits", 0);
+        qcuts_pset.addParameter<unsigned>("minTrackHits", 0);
       }
-      seedCands.push_back(*cand);
-    } else if ( (*cand)->et() > minGammaEtStripAdd_  ) {
-      if ( verbosity_ >= 2 ) {
-	edm::LogPrint("RecoTauPiZeroStripPlugin2") << "--> assigning addCandId = " << addCands.size() ;
+      //-------------------------------------------------------------------------------
+      qcuts_pset.addParameter<double>("minGammaEt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
+      qcuts_ = new RecoTauQualityCuts(qcuts_pset);
+
+      inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
+      etaAssociationDistance_ = pset.getParameter<double>("stripEtaAssociationDistance");
+      phiAssociationDistance_ = pset.getParameter<double>("stripPhiAssociationDistance");
+
+      updateStripAfterEachDaughter_ = pset.getParameter<bool>("updateStripAfterEachDaughter");
+      maxStripBuildIterations_ = pset.getParameter<int>("maxStripBuildIterations");
+
+      combineStrips_ = pset.getParameter<bool>("makeCombinatoricStrips");
+      if (combineStrips_) {
+        maxStrips_ = pset.getParameter<int>("maxInputStrips");
+        combinatoricStripMassHypo_ = pset.getParameter<double>("stripMassWhenCombining");
       }
-      addCands.push_back(*cand);
-    }
-    ++idx;
-  }
 
-  std::vector<bool> seedCandFlags(seedCands.size()); // true/false: seedCand is already/not yet included in strip
-  std::vector<bool> addCandFlags(addCands.size());   // true/false: addCand  is already/not yet included in strip
-
-  std::set<size_t> seedCandIdsCurrentStrip;
-  std::set<size_t> addCandIdsCurrentStrip;
-
-  size_t idxSeed = 0;
-  while ( idxSeed < seedCands.size() ) {
-    if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << "processing seed #" << idxSeed ;
-
-    seedCandIdsCurrentStrip.clear();
-    addCandIdsCurrentStrip.clear();
-
-    std::auto_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
-    strip->addDaughter(seedCands[idxSeed]);
-    seedCandIdsCurrentStrip.insert(idxSeed);
-
-    bool isCandAdded;
-    int stripBuildIteration = 0;
-    do {
-      isCandAdded = false;
-
-      //if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << " adding seedCands to strip..." ;
-      addCandsToStrip(*strip, seedCands, seedCandFlags, seedCandIdsCurrentStrip, isCandAdded);
-      //if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << " adding addCands to strip..." ;
-      addCandsToStrip(*strip, addCands,  addCandFlags,  addCandIdsCurrentStrip, isCandAdded);
-
-      if ( !updateStripAfterEachDaughter_ ) p4Builder_.set(*strip);
-
-      ++stripBuildIteration;
-    } while ( isCandAdded && (stripBuildIteration < maxStripBuildIterations_ || maxStripBuildIterations_ == -1) );
-
-    if ( strip->et() > minStripEt_ ) { // strip passed Et cuts, add it to the event
-      if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << "Building strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi() ;
-
-      // Update the vertex
-      if ( strip->daughterPtr(0).isNonnull() ) strip->setVertex(strip->daughterPtr(0)->vertex());
-      output.push_back(strip);
-
-      // Mark daughters as being part of this strip
-      markCandsInStrip(seedCandFlags, seedCandIdsCurrentStrip);
-      markCandsInStrip(addCandFlags,  addCandIdsCurrentStrip);
-    } else { // strip failed Et cuts, just skip it
-      if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << "Discarding strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi() ;
+      verbosity_ = pset.getParameter<int>("verbosity");
     }
 
-    ++idxSeed;
-    while ( idxSeed < seedCands.size() && seedCandFlags[idxSeed] ) {
-      ++idxSeed; // fast-forward to next seed cand not yet included in any strip
-    }
-  }
+    RecoTauPiZeroStripPlugin2::~RecoTauPiZeroStripPlugin2() { delete qcuts_; }
 
-  // Check if we want to combine our strips
-  if ( combineStrips_ && output.size() > 1 ) {
-    PiZeroVector stripCombinations;
-    // Sort the output by descending pt
-    output.sort(output.begin(), output.end(),
-        boost::bind(&RecoTauPiZero::pt, _1) >
-        boost::bind(&RecoTauPiZero::pt, _2));
-    // Get the end of interesting set of strips to try and combine
-    PiZeroVector::const_iterator end_iter = takeNElements(
-        output.begin(), output.end(), maxStrips_);
+    // Update the primary vertex
+    void RecoTauPiZeroStripPlugin2::beginEvent() { vertexAssociator_.setEvent(*evt()); }
 
-    // Look at all the combinations
-    for ( PiZeroVector::const_iterator first = output.begin();
-	  first != end_iter-1; ++first ) {
-      for ( PiZeroVector::const_iterator second = first+1;
-	    second != end_iter; ++second ) {
-        Candidate::LorentzVector firstP4 = first->p4();
-        Candidate::LorentzVector secondP4 = second->p4();
-        // If we assume a certain mass for each strip apply it here.
-        firstP4 = applyMassConstraint(firstP4, combinatoricStripMassHypo_);
-        secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
-        Candidate::LorentzVector totalP4 = firstP4 + secondP4;
-        // Make our new combined strip
-        std::auto_ptr<RecoTauPiZero> combinedStrips(
-            new RecoTauPiZero(0, totalP4,
-              Candidate::Point(0, 0, 0),
-              //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
-              111, 10001, true, RecoTauPiZero::kUndefined));
-
-        // Now loop over the strip members
-        for(auto const& gamma : first->daughterPtrVector()) {
-          combinedStrips->addDaughter(gamma);
+    void RecoTauPiZeroStripPlugin2::addCandsToStrip(RecoTauPiZero& strip,
+                                                    CandPtrs& cands,
+                                                    const std::vector<bool>& candFlags,
+                                                    std::set<size_t>& candIdsCurrentStrip,
+                                                    bool& isCandAdded) const {
+      if (verbosity_ >= 1) {
+        edm::LogPrint("RecoTauPiZeroStripPlugin2") << "<RecoTauPiZeroStripPlugin2::addCandsToStrip>:";
+      }
+      size_t numCands = cands.size();
+      for (size_t candId = 0; candId < numCands; ++candId) {
+        if ((!candFlags[candId]) &&
+            candIdsCurrentStrip.find(candId) == candIdsCurrentStrip.end()) {  // do not include same cand twice
+          reco::CandidatePtr cand = cands[candId];
+          if (fabs(strip.eta() - cand->eta()) <
+                  etaAssociationDistance_ &&  // check if cand is within eta-phi window centered on strip
+              fabs(strip.phi() - cand->phi()) < phiAssociationDistance_) {
+            if (verbosity_ >= 2) {
+              edm::LogPrint("RecoTauPiZeroStripPlugin2")
+                  << "--> adding PFCand #" << candId << " (" << cand.id() << ":" << cand.key()
+                  << "): Et = " << cand->et() << ", eta = " << cand->eta() << ", phi = " << cand->phi();
+            }
+            strip.addDaughter(cand);
+            if (updateStripAfterEachDaughter_)
+              p4Builder_.set(strip);
+            isCandAdded = true;
+            candIdsCurrentStrip.insert(candId);
+          }
         }
-        for(auto const& gamma : second->daughterPtrVector()) {
-          combinedStrips->addDaughter(gamma);
-        }
-        // Update the vertex
-        if ( combinedStrips->daughterPtr(0).isNonnull() )
-          combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
-        // Add to our collection of combined strips
-        stripCombinations.push_back(combinedStrips);
       }
     }
-    // When done doing all the combinations, add the combined strips to the
-    // output.
-    output.transfer(output.end(), stripCombinations);
-  }
 
-  return output.release();
-}
-}} // end namespace reco::tau
+    namespace {
+      void markCandsInStrip(std::vector<bool>& candFlags, const std::set<size_t>& candIds) {
+        for (std::set<size_t>::const_iterator candId = candIds.begin(); candId != candIds.end(); ++candId) {
+          candFlags[*candId] = true;
+        }
+      }
+
+      inline const reco::TrackBaseRef getTrack(const Candidate& cand) {
+        const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+        if (pfCandPtr) {
+          if (pfCandPtr->trackRef().isNonnull())
+            return reco::TrackBaseRef(pfCandPtr->trackRef());
+          else if (pfCandPtr->gsfTrackRef().isNonnull())
+            return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
+          else
+            return reco::TrackBaseRef();
+        }
+
+        return reco::TrackBaseRef();
+      }
+    }  // namespace
+
+    RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(const reco::Jet& jet) const {
+      if (verbosity_ >= 1) {
+        edm::LogPrint("RecoTauPiZeroStripPlugin2") << "<RecoTauPiZeroStripPlugin2::operator()>:";
+        edm::LogPrint("RecoTauPiZeroStripPlugin2") << " minGammaEtStripSeed = " << minGammaEtStripSeed_;
+        edm::LogPrint("RecoTauPiZeroStripPlugin2") << " minGammaEtStripAdd = " << minGammaEtStripAdd_;
+        edm::LogPrint("RecoTauPiZeroStripPlugin2") << " minStripEt = " << minStripEt_;
+      }
+
+      PiZeroVector output;
+
+      // Get the candidates passing our quality cuts
+      qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
+      CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputParticleIds_));
+
+      // Convert to stl::list to allow fast deletions
+      CandPtrs seedCands;
+      CandPtrs addCands;
+      int idx = 0;
+      for (CandPtrs::iterator cand = candsVector.begin(); cand != candsVector.end(); ++cand) {
+        if (verbosity_ >= 1) {
+          edm::LogPrint("RecoTauPiZeroStripPlugin2")
+              << "PFGamma #" << idx << " (" << cand->id() << ":" << cand->key() << "): Et = " << (*cand)->et()
+              << ", eta = " << (*cand)->eta() << ", phi = " << (*cand)->phi();
+        }
+        if ((*cand)->et() > minGammaEtStripSeed_) {
+          if (verbosity_ >= 2) {
+            edm::LogPrint("RecoTauPiZeroStripPlugin2") << "--> assigning seedCandId = " << seedCands.size();
+            const reco::TrackBaseRef candTrack = getTrack(**cand);
+            if (candTrack.isNonnull()) {
+              edm::LogPrint("RecoTauPiZeroStripPlugin2")
+                  << "track: Pt = " << candTrack->pt() << " eta = " << candTrack->eta()
+                  << ", phi = " << candTrack->phi() << ", charge = " << candTrack->charge();
+              edm::LogPrint("RecoTauPiZeroStripPlugin2")
+                  << " (dZ = " << candTrack->dz(vertexAssociator_.associatedVertex(jet)->position())
+                  << ", dXY = " << candTrack->dxy(vertexAssociator_.associatedVertex(jet)->position()) << ","
+                  << " numHits = " << candTrack->hitPattern().numberOfValidTrackerHits()
+                  << ", numPxlHits = " << candTrack->hitPattern().numberOfValidPixelHits() << ","
+                  << " chi2 = " << candTrack->normalizedChi2()
+                  << ", dPt/Pt = " << (candTrack->ptError() / candTrack->pt()) << ")";
+            }
+          }
+          seedCands.push_back(*cand);
+        } else if ((*cand)->et() > minGammaEtStripAdd_) {
+          if (verbosity_ >= 2) {
+            edm::LogPrint("RecoTauPiZeroStripPlugin2") << "--> assigning addCandId = " << addCands.size();
+          }
+          addCands.push_back(*cand);
+        }
+        ++idx;
+      }
+
+      std::vector<bool> seedCandFlags(seedCands.size());  // true/false: seedCand is already/not yet included in strip
+      std::vector<bool> addCandFlags(addCands.size());    // true/false: addCand  is already/not yet included in strip
+
+      std::set<size_t> seedCandIdsCurrentStrip;
+      std::set<size_t> addCandIdsCurrentStrip;
+
+      size_t idxSeed = 0;
+      while (idxSeed < seedCands.size()) {
+        if (verbosity_ >= 2)
+          edm::LogPrint("RecoTauPiZeroStripPlugin2") << "processing seed #" << idxSeed;
+
+        seedCandIdsCurrentStrip.clear();
+        addCandIdsCurrentStrip.clear();
+
+        std::auto_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
+        strip->addDaughter(seedCands[idxSeed]);
+        seedCandIdsCurrentStrip.insert(idxSeed);
+
+        bool isCandAdded;
+        int stripBuildIteration = 0;
+        do {
+          isCandAdded = false;
+
+          //if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << " adding seedCands to strip..." ;
+          addCandsToStrip(*strip, seedCands, seedCandFlags, seedCandIdsCurrentStrip, isCandAdded);
+          //if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << " adding addCands to strip..." ;
+          addCandsToStrip(*strip, addCands, addCandFlags, addCandIdsCurrentStrip, isCandAdded);
+
+          if (!updateStripAfterEachDaughter_)
+            p4Builder_.set(*strip);
+
+          ++stripBuildIteration;
+        } while (isCandAdded && (stripBuildIteration < maxStripBuildIterations_ || maxStripBuildIterations_ == -1));
+
+        if (strip->et() > minStripEt_) {  // strip passed Et cuts, add it to the event
+          if (verbosity_ >= 2)
+            edm::LogPrint("RecoTauPiZeroStripPlugin2")
+                << "Building strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi();
+
+          // Update the vertex
+          if (strip->daughterPtr(0).isNonnull())
+            strip->setVertex(strip->daughterPtr(0)->vertex());
+          output.push_back(strip);
+
+          // Mark daughters as being part of this strip
+          markCandsInStrip(seedCandFlags, seedCandIdsCurrentStrip);
+          markCandsInStrip(addCandFlags, addCandIdsCurrentStrip);
+        } else {  // strip failed Et cuts, just skip it
+          if (verbosity_ >= 2)
+            edm::LogPrint("RecoTauPiZeroStripPlugin2")
+                << "Discarding strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi();
+        }
+
+        ++idxSeed;
+        while (idxSeed < seedCands.size() && seedCandFlags[idxSeed]) {
+          ++idxSeed;  // fast-forward to next seed cand not yet included in any strip
+        }
+      }
+
+      // Check if we want to combine our strips
+      if (combineStrips_ && output.size() > 1) {
+        PiZeroVector stripCombinations;
+        // Sort the output by descending pt
+        output.sort(
+            output.begin(), output.end(), boost::bind(&RecoTauPiZero::pt, _1) > boost::bind(&RecoTauPiZero::pt, _2));
+        // Get the end of interesting set of strips to try and combine
+        PiZeroVector::const_iterator end_iter = takeNElements(output.begin(), output.end(), maxStrips_);
+
+        // Look at all the combinations
+        for (PiZeroVector::const_iterator first = output.begin(); first != end_iter - 1; ++first) {
+          for (PiZeroVector::const_iterator second = first + 1; second != end_iter; ++second) {
+            Candidate::LorentzVector firstP4 = first->p4();
+            Candidate::LorentzVector secondP4 = second->p4();
+            // If we assume a certain mass for each strip apply it here.
+            firstP4 = applyMassConstraint(firstP4, combinatoricStripMassHypo_);
+            secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
+            Candidate::LorentzVector totalP4 = firstP4 + secondP4;
+            // Make our new combined strip
+            std::auto_ptr<RecoTauPiZero> combinedStrips(
+                new RecoTauPiZero(0,
+                                  totalP4,
+                                  Candidate::Point(0, 0, 0),
+                                  //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
+                                  111,
+                                  10001,
+                                  true,
+                                  RecoTauPiZero::kUndefined));
+
+            // Now loop over the strip members
+            for (auto const& gamma : first->daughterPtrVector()) {
+              combinedStrips->addDaughter(gamma);
+            }
+            for (auto const& gamma : second->daughterPtrVector()) {
+              combinedStrips->addDaughter(gamma);
+            }
+            // Update the vertex
+            if (combinedStrips->daughterPtr(0).isNonnull())
+              combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
+            // Add to our collection of combined strips
+            stripCombinations.push_back(combinedStrips);
+          }
+        }
+        // When done doing all the combinations, add the combined strips to the
+        // output.
+        output.transfer(output.end(), stripCombinations);
+      }
+
+      return output.release();
+    }
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(RecoTauPiZeroBuilderPluginFactory,
-    reco::tau::RecoTauPiZeroStripPlugin2, "RecoTauPiZeroStripPlugin2");
+DEFINE_EDM_PLUGIN(RecoTauPiZeroBuilderPluginFactory, reco::tau::RecoTauPiZeroStripPlugin2, "RecoTauPiZeroStripPlugin2");

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
@@ -41,356 +41,369 @@
 #include "TString.h"
 #include "TFormula.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-namespace {
-  // Apply a hypothesis on the mass of the strips.
-  math::XYZTLorentzVector applyMassConstraint(
-      const math::XYZTLorentzVector& vec,double mass) {
-    double factor = sqrt(vec.energy()*vec.energy()-mass*mass)/vec.P();
-    return math::XYZTLorentzVector(
-        vec.px()*factor,vec.py()*factor,vec.pz()*factor,vec.energy());
-  }
-}
-
-class RecoTauPiZeroStripPlugin3 : public RecoTauPiZeroBuilderPlugin 
-{
- public:
-  explicit RecoTauPiZeroStripPlugin3(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
-  ~RecoTauPiZeroStripPlugin3() override;
-  // Return type is auto_ptr<PiZeroVector>
-  return_type operator()(const reco::Jet&) const override;
-  // Hook to update PV information
-  void beginEvent() override;
-  
- private:
-  typedef std::vector<reco::CandidatePtr> CandPtrs;
-  void addCandsToStrip(RecoTauPiZero&, CandPtrs&, const std::vector<bool>&, std::set<size_t>&, bool&) const;
-
-  RecoTauVertexAssociator vertexAssociator_;
-
-  std::unique_ptr<RecoTauQualityCuts> qcuts_;
-  bool applyElecTrackQcuts_;
-  double minGammaEtStripSeed_;
-  double minGammaEtStripAdd_;
-
-  double minStripEt_;
-
-  std::vector<int> inputParticleIds_;  // type of candidates to clusterize
-  std::unique_ptr<const TFormula> etaAssociationDistance_; // size of strip clustering window in eta direction
-  std::unique_ptr<const TFormula> phiAssociationDistance_; // size of strip clustering window in phi direction
-
-  bool updateStripAfterEachDaughter_;
-  int maxStripBuildIterations_;
-
-  // Parameters for build strip combinations
-  bool combineStrips_;
-  int maxStrips_;
-  double combinatoricStripMassHypo_;
-
-  AddFourMomenta p4Builder_;
-
-  int verbosity_;
-};
-
-namespace
-{
-  std::unique_ptr<TFormula> makeFunction(const std::string& functionName, const edm::ParameterSet& pset)
-  {
-    TString formula = pset.getParameter<std::string>("function");
-    formula = formula.ReplaceAll("pT", "x");
-    std::unique_ptr<TFormula> function(new TFormula(functionName.data(), formula.Data()));
-    int numParameter = function->GetNpar();
-    for ( int idxParameter = 0; idxParameter < numParameter; ++idxParameter ) {
-      std::string parameterName = Form("par%i", idxParameter);
-      double parameter = pset.getParameter<double>(parameterName);
-      function->SetParameter(idxParameter, parameter);
-    }
-    return function;
-  }
-}
-
-RecoTauPiZeroStripPlugin3::RecoTauPiZeroStripPlugin3(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC)
-  : RecoTauPiZeroBuilderPlugin(pset, std::move(iC)),
-    vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)), qcuts_(nullptr), etaAssociationDistance_(nullptr), phiAssociationDistance_(nullptr)
-{
-  minGammaEtStripSeed_ = pset.getParameter<double>("minGammaEtStripSeed");
-  minGammaEtStripAdd_ = pset.getParameter<double>("minGammaEtStripAdd");
-
-  minStripEt_ = pset.getParameter<double>("minStripEt");
-  
-  edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
-//-------------------------------------------------------------------------------
-// CV: disable track quality cuts for PFElectronsPFElectron
-//       (treat PFElectrons like PFGammas for the purpose of building eta-phi strips)
-  applyElecTrackQcuts_ = pset.getParameter<bool>("applyElecTrackQcuts");
-  if ( !applyElecTrackQcuts_ ) {
-    qcuts_pset.addParameter<double>("minTrackPt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
-    qcuts_pset.addParameter<double>("maxTrackChi2", 1.e+9);
-    qcuts_pset.addParameter<double>("maxTransverseImpactParameter", 1.e+9);
-    qcuts_pset.addParameter<double>("maxDeltaZ", 1.e+9);
-    qcuts_pset.addParameter<double>("minTrackVertexWeight", -1.);
-    qcuts_pset.addParameter<unsigned>("minTrackPixelHits", 0);
-    qcuts_pset.addParameter<unsigned>("minTrackHits", 0);
-  }
-//-------------------------------------------------------------------------------
-  qcuts_pset.addParameter<double>("minGammaEt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
-  //qcuts_ = new RecoTauQualityCuts(qcuts_pset);
-  //std::unique_ptr<RecoTauQualityCuts> qcuts_(new RecoTauQualityCuts(qcuts_pset));
-
-  qcuts_.reset(new RecoTauQualityCuts(qcuts_pset));
-
-  inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
-  const edm::ParameterSet& stripSize_eta_pset = pset.getParameterSet("stripEtaAssociationDistanceFunc");
-  etaAssociationDistance_ = makeFunction("etaAssociationDistance", stripSize_eta_pset);
-  const edm::ParameterSet& stripSize_phi_pset = pset.getParameterSet("stripPhiAssociationDistanceFunc");
-  phiAssociationDistance_ = makeFunction("phiAssociationDistance", stripSize_phi_pset);
-
-  updateStripAfterEachDaughter_ = pset.getParameter<bool>("updateStripAfterEachDaughter");
-  maxStripBuildIterations_ = pset.getParameter<int>("maxStripBuildIterations");
-
-  combineStrips_ = pset.getParameter<bool>("makeCombinatoricStrips");
-  if ( combineStrips_ ) {
-    maxStrips_ = pset.getParameter<int>("maxInputStrips");
-    combinatoricStripMassHypo_ = pset.getParameter<double>("stripMassWhenCombining");
-  }
-
-  verbosity_ = pset.getParameter<int>("verbosity");
-}
-RecoTauPiZeroStripPlugin3::~RecoTauPiZeroStripPlugin3()
-{
-} 
-
-// Update the primary vertex
-void RecoTauPiZeroStripPlugin3::beginEvent() 
-{
-  vertexAssociator_.setEvent(*evt());
-}
-
-void RecoTauPiZeroStripPlugin3::addCandsToStrip(RecoTauPiZero& strip, CandPtrs& cands, const std::vector<bool>& candFlags, 
-						std::set<size_t>& candIdsCurrentStrip, bool& isCandAdded) const
-{
-  if ( verbosity_ >= 1 ) {
-    edm::LogPrint("RecoTauPiZeroStripPlugin3") << "<RecoTauPiZeroStripPlugin3::addCandsToStrip>:" ;
-  }
-  size_t numCands = cands.size();
-  for ( size_t candId = 0; candId < numCands; ++candId ) {
-    if ( (!candFlags[candId]) && candIdsCurrentStrip.find(candId) == candIdsCurrentStrip.end() ) { // do not include same cand twice
-      reco::CandidatePtr cand = cands[candId];
-      double etaAssociationDistance_value = etaAssociationDistance_->Eval(strip.pt()) + etaAssociationDistance_->Eval(cand->pt());
-      double phiAssociationDistance_value = phiAssociationDistance_->Eval(strip.pt()) + phiAssociationDistance_->Eval(cand->pt());
-      if ( fabs(strip.eta() - cand->eta()) < etaAssociationDistance_value && // check if cand is within eta-phi window centered on strip 
-	   reco::deltaPhi(strip.phi(), cand->phi()) < phiAssociationDistance_value ) {
-	if ( verbosity_ >= 2 ) {
-	  edm::LogPrint("RecoTauPiZeroStripPlugin3") << "--> adding PFCand #" << candId << " (" << cand.id() << ":" << cand.key() << "): Et = " << cand->et() << ", eta = " << cand->eta() << ", phi = " << cand->phi() ;
-	}
-	strip.addDaughter(cand);
-	if ( updateStripAfterEachDaughter_ ) p4Builder_.set(strip);
-	isCandAdded = true;
-	candIdsCurrentStrip.insert(candId);
+    namespace {
+      // Apply a hypothesis on the mass of the strips.
+      math::XYZTLorentzVector applyMassConstraint(const math::XYZTLorentzVector& vec, double mass) {
+        double factor = sqrt(vec.energy() * vec.energy() - mass * mass) / vec.P();
+        return math::XYZTLorentzVector(vec.px() * factor, vec.py() * factor, vec.pz() * factor, vec.energy());
       }
-    }
-  }
-}
+    }  // namespace
 
-namespace
-{
-  void markCandsInStrip(std::vector<bool>& candFlags, const std::set<size_t>& candIds)
-  {
-    for ( std::set<size_t>::const_iterator candId = candIds.begin();
-	  candId != candIds.end(); ++candId ) {
-      candFlags[*candId] = true;
-    }
-  }
+    class RecoTauPiZeroStripPlugin3 : public RecoTauPiZeroBuilderPlugin {
+    public:
+      explicit RecoTauPiZeroStripPlugin3(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+      ~RecoTauPiZeroStripPlugin3() override;
+      // Return type is auto_ptr<PiZeroVector>
+      return_type operator()(const reco::Jet&) const override;
+      // Hook to update PV information
+      void beginEvent() override;
 
-  // The following method has not been adapted to work with PackedCandidates,
-  // however, it is only used for printing/debugging and can be adapted when
-  // needed.
-  inline const reco::TrackBaseRef getTrack(const Candidate& cand)
-  {
-    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
-    if (pfCandPtr) {
-      if      ( pfCandPtr->trackRef().isNonnull()    ) return reco::TrackBaseRef(pfCandPtr->trackRef());
-      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
-      else return reco::TrackBaseRef();
-    }
-    
-    return reco::TrackBaseRef();
-  }
-}
+    private:
+      typedef std::vector<reco::CandidatePtr> CandPtrs;
+      void addCandsToStrip(RecoTauPiZero&, CandPtrs&, const std::vector<bool>&, std::set<size_t>&, bool&) const;
 
-RecoTauPiZeroStripPlugin3::return_type RecoTauPiZeroStripPlugin3::operator()(const reco::Jet& jet) const 
-{
-  if ( verbosity_ >= 1 ) {
-    edm::LogPrint("RecoTauPiZeroStripPlugin3") << "<RecoTauPiZeroStripPlugin3::operator()>:" ;
-    edm::LogPrint("RecoTauPiZeroStripPlugin3") << " minGammaEtStripSeed = " << minGammaEtStripSeed_ ;
-    edm::LogPrint("RecoTauPiZeroStripPlugin3") << " minGammaEtStripAdd = " << minGammaEtStripAdd_ ;
-    edm::LogPrint("RecoTauPiZeroStripPlugin3") << " minStripEt = " << minStripEt_ ;
-  }
+      RecoTauVertexAssociator vertexAssociator_;
 
-  PiZeroVector output;
+      std::unique_ptr<RecoTauQualityCuts> qcuts_;
+      bool applyElecTrackQcuts_;
+      double minGammaEtStripSeed_;
+      double minGammaEtStripAdd_;
 
-  // Get the candidates passing our quality cuts
-  qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
-  CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputParticleIds_));
+      double minStripEt_;
 
-  // Convert to stl::list to allow fast deletions
-  CandPtrs seedCands;
-  CandPtrs addCands;
-  int idx = 0;
-  for ( CandPtrs::iterator cand = candsVector.begin();
-	cand != candsVector.end(); ++cand ) {
-    if ( verbosity_ >= 1 ) {
-      edm::LogPrint("RecoTauPiZeroStripPlugin3") << "PFGamma #" << idx << " (" << cand->id() << ":" << cand->key() << "): Et = " << (*cand)->et() << ", eta = " << (*cand)->eta() << ", phi = " << (*cand)->phi() ;
-    } 
-    if ( (*cand)->et() > minGammaEtStripSeed_ ) {
-      if ( verbosity_ >= 2 ) {
-	edm::LogPrint("RecoTauPiZeroStripPlugin3") << "--> assigning seedCandId = " << seedCands.size() ;
-        const reco::TrackBaseRef candTrack = getTrack(**cand);
-        if ( candTrack.isNonnull() ) {
-	  edm::LogPrint("RecoTauPiZeroStripPlugin3") << "track: Pt = " << candTrack->pt() << " eta = " << candTrack->eta() << ", phi = " << candTrack->phi() << ", charge = " << candTrack->charge() ;
-	  edm::LogPrint("RecoTauPiZeroStripPlugin3") << " (dZ = " << candTrack->dz(vertexAssociator_.associatedVertex(jet)->position()) << ", dXY = " << candTrack->dxy(vertexAssociator_.associatedVertex(jet)->position()) << "," 
-		    << " numHits = " << candTrack->hitPattern().numberOfValidTrackerHits() << ", numPxlHits = " << candTrack->hitPattern().numberOfValidPixelHits() << "," 
-		    << " chi2 = " << candTrack->normalizedChi2() << ", dPt/Pt = " << (candTrack->ptError()/candTrack->pt()) << ")" ;
-	}
-      }
-      seedCands.push_back(*cand);
-    } else if ( (*cand)->et() > minGammaEtStripAdd_  ) {
-      if ( verbosity_ >= 2 ) {
-	edm::LogPrint("RecoTauPiZeroStripPlugin3") << "--> assigning addCandId = " << addCands.size() ;
-      }
-      addCands.push_back(*cand);
-    }
-    ++idx;
-  }
+      std::vector<int> inputParticleIds_;                       // type of candidates to clusterize
+      std::unique_ptr<const TFormula> etaAssociationDistance_;  // size of strip clustering window in eta direction
+      std::unique_ptr<const TFormula> phiAssociationDistance_;  // size of strip clustering window in phi direction
 
-  std::vector<bool> seedCandFlags(seedCands.size()); // true/false: seedCand is already/not yet included in strip
-  std::vector<bool> addCandFlags(addCands.size());   // true/false: addCand  is already/not yet included in strip
+      bool updateStripAfterEachDaughter_;
+      int maxStripBuildIterations_;
 
-  std::set<size_t> seedCandIdsCurrentStrip;
-  std::set<size_t> addCandIdsCurrentStrip;
+      // Parameters for build strip combinations
+      bool combineStrips_;
+      int maxStrips_;
+      double combinatoricStripMassHypo_;
 
-  size_t idxSeed = 0;
-  while ( idxSeed < seedCands.size() ) {
-    if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin3") << "processing seed #" << idxSeed ;
+      AddFourMomenta p4Builder_;
 
-    seedCandIdsCurrentStrip.clear();
-    addCandIdsCurrentStrip.clear();
+      int verbosity_;
+    };
 
-    std::auto_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
-    strip->addDaughter(seedCands[idxSeed]);
-    seedCandIdsCurrentStrip.insert(idxSeed);
-
-    bool isCandAdded;
-    int stripBuildIteration = 0;
-    do {
-      isCandAdded = false;
-
-      //if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin3") << " adding seedCands to strip..." ;
-      addCandsToStrip(*strip, seedCands, seedCandFlags, seedCandIdsCurrentStrip, isCandAdded);
-      //if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin3") << " adding addCands to strip..." ;
-      addCandsToStrip(*strip, addCands,  addCandFlags,  addCandIdsCurrentStrip, isCandAdded);
-
-      if ( !updateStripAfterEachDaughter_ ) p4Builder_.set(*strip);
-
-      ++stripBuildIteration;
-    } while ( isCandAdded && (stripBuildIteration < maxStripBuildIterations_ || maxStripBuildIterations_ == -1) );
-
-    if ( strip->et() > minStripEt_ ) { // strip passed Et cuts, add it to the event
-      if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin3") << "Building strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi() ;
-
-      // Update the vertex
-      if ( strip->daughterPtr(0).isNonnull() ) strip->setVertex(strip->daughterPtr(0)->vertex());
-      output.push_back(strip);
-
-      // Mark daughters as being part of this strip
-      markCandsInStrip(seedCandFlags, seedCandIdsCurrentStrip);
-      markCandsInStrip(addCandFlags,  addCandIdsCurrentStrip);
-    } else { // strip failed Et cuts, just skip it
-      if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin3") << "Discarding strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi() ;
-    }
-
-    ++idxSeed;
-    while ( idxSeed < seedCands.size() && seedCandFlags[idxSeed] ) {
-      ++idxSeed; // fast-forward to next seed cand not yet included in any strip
-    }
-  }
-
-  // Check if we want to combine our strips
-  if ( combineStrips_ && output.size() > 1 ) {
-    PiZeroVector stripCombinations;
-    // Sort the output by descending pt
-    output.sort(output.begin(), output.end(),
-        boost::bind(&RecoTauPiZero::pt, _1) >
-        boost::bind(&RecoTauPiZero::pt, _2));
-    // Get the end of interesting set of strips to try and combine
-    PiZeroVector::const_iterator end_iter = takeNElements(
-        output.begin(), output.end(), maxStrips_);
-
-    // Look at all the combinations
-    for ( PiZeroVector::const_iterator first = output.begin();
-	  first != end_iter-1; ++first ) {
-      for ( PiZeroVector::const_iterator second = first+1;
-	    second != end_iter; ++second ) {
-        Candidate::LorentzVector firstP4 = first->p4();
-        Candidate::LorentzVector secondP4 = second->p4();
-        // If we assume a certain mass for each strip apply it here.
-        firstP4 = applyMassConstraint(firstP4, combinatoricStripMassHypo_);
-        secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
-        Candidate::LorentzVector totalP4 = firstP4 + secondP4;
-        // Make our new combined strip
-        std::auto_ptr<RecoTauPiZero> combinedStrips(
-            new RecoTauPiZero(0, totalP4,
-              Candidate::Point(0, 0, 0),
-              //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
-              111, 10001, true, RecoTauPiZero::kUndefined));
-
-        // Now loop over the strip members
-        for ( auto const& gamma : first->daughterPtrVector()) {
-          combinedStrips->addDaughter(gamma);
+    namespace {
+      std::unique_ptr<TFormula> makeFunction(const std::string& functionName, const edm::ParameterSet& pset) {
+        TString formula = pset.getParameter<std::string>("function");
+        formula = formula.ReplaceAll("pT", "x");
+        std::unique_ptr<TFormula> function(new TFormula(functionName.data(), formula.Data()));
+        int numParameter = function->GetNpar();
+        for (int idxParameter = 0; idxParameter < numParameter; ++idxParameter) {
+          std::string parameterName = Form("par%i", idxParameter);
+          double parameter = pset.getParameter<double>(parameterName);
+          function->SetParameter(idxParameter, parameter);
         }
-        for ( auto const& gamma : second->daughterPtrVector()) {
-          combinedStrips->addDaughter(gamma);
-        }
-        // Update the vertex
-        if ( combinedStrips->daughterPtr(0).isNonnull() ) {
-          combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
-	}
+        return function;
+      }
+    }  // namespace
 
-        // Add to our collection of combined strips
-        stripCombinations.push_back(combinedStrips);
+    RecoTauPiZeroStripPlugin3::RecoTauPiZeroStripPlugin3(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : RecoTauPiZeroBuilderPlugin(pset, std::move(iC)),
+          vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)),
+          qcuts_(nullptr),
+          etaAssociationDistance_(nullptr),
+          phiAssociationDistance_(nullptr) {
+      minGammaEtStripSeed_ = pset.getParameter<double>("minGammaEtStripSeed");
+      minGammaEtStripAdd_ = pset.getParameter<double>("minGammaEtStripAdd");
+
+      minStripEt_ = pset.getParameter<double>("minStripEt");
+
+      edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
+      //-------------------------------------------------------------------------------
+      // CV: disable track quality cuts for PFElectronsPFElectron
+      //       (treat PFElectrons like PFGammas for the purpose of building eta-phi strips)
+      applyElecTrackQcuts_ = pset.getParameter<bool>("applyElecTrackQcuts");
+      if (!applyElecTrackQcuts_) {
+        qcuts_pset.addParameter<double>("minTrackPt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
+        qcuts_pset.addParameter<double>("maxTrackChi2", 1.e+9);
+        qcuts_pset.addParameter<double>("maxTransverseImpactParameter", 1.e+9);
+        qcuts_pset.addParameter<double>("maxDeltaZ", 1.e+9);
+        qcuts_pset.addParameter<double>("minTrackVertexWeight", -1.);
+        qcuts_pset.addParameter<unsigned>("minTrackPixelHits", 0);
+        qcuts_pset.addParameter<unsigned>("minTrackHits", 0);
+      }
+      //-------------------------------------------------------------------------------
+      qcuts_pset.addParameter<double>("minGammaEt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
+      //qcuts_ = new RecoTauQualityCuts(qcuts_pset);
+      //std::unique_ptr<RecoTauQualityCuts> qcuts_(new RecoTauQualityCuts(qcuts_pset));
+
+      qcuts_.reset(new RecoTauQualityCuts(qcuts_pset));
+
+      inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
+      const edm::ParameterSet& stripSize_eta_pset = pset.getParameterSet("stripEtaAssociationDistanceFunc");
+      etaAssociationDistance_ = makeFunction("etaAssociationDistance", stripSize_eta_pset);
+      const edm::ParameterSet& stripSize_phi_pset = pset.getParameterSet("stripPhiAssociationDistanceFunc");
+      phiAssociationDistance_ = makeFunction("phiAssociationDistance", stripSize_phi_pset);
+
+      updateStripAfterEachDaughter_ = pset.getParameter<bool>("updateStripAfterEachDaughter");
+      maxStripBuildIterations_ = pset.getParameter<int>("maxStripBuildIterations");
+
+      combineStrips_ = pset.getParameter<bool>("makeCombinatoricStrips");
+      if (combineStrips_) {
+        maxStrips_ = pset.getParameter<int>("maxInputStrips");
+        combinatoricStripMassHypo_ = pset.getParameter<double>("stripMassWhenCombining");
+      }
+
+      verbosity_ = pset.getParameter<int>("verbosity");
+    }
+    RecoTauPiZeroStripPlugin3::~RecoTauPiZeroStripPlugin3() {}
+
+    // Update the primary vertex
+    void RecoTauPiZeroStripPlugin3::beginEvent() { vertexAssociator_.setEvent(*evt()); }
+
+    void RecoTauPiZeroStripPlugin3::addCandsToStrip(RecoTauPiZero& strip,
+                                                    CandPtrs& cands,
+                                                    const std::vector<bool>& candFlags,
+                                                    std::set<size_t>& candIdsCurrentStrip,
+                                                    bool& isCandAdded) const {
+      if (verbosity_ >= 1) {
+        edm::LogPrint("RecoTauPiZeroStripPlugin3") << "<RecoTauPiZeroStripPlugin3::addCandsToStrip>:";
+      }
+      size_t numCands = cands.size();
+      for (size_t candId = 0; candId < numCands; ++candId) {
+        if ((!candFlags[candId]) &&
+            candIdsCurrentStrip.find(candId) == candIdsCurrentStrip.end()) {  // do not include same cand twice
+          reco::CandidatePtr cand = cands[candId];
+          double etaAssociationDistance_value =
+              etaAssociationDistance_->Eval(strip.pt()) + etaAssociationDistance_->Eval(cand->pt());
+          double phiAssociationDistance_value =
+              phiAssociationDistance_->Eval(strip.pt()) + phiAssociationDistance_->Eval(cand->pt());
+          if (fabs(strip.eta() - cand->eta()) <
+                  etaAssociationDistance_value &&  // check if cand is within eta-phi window centered on strip
+              reco::deltaPhi(strip.phi(), cand->phi()) < phiAssociationDistance_value) {
+            if (verbosity_ >= 2) {
+              edm::LogPrint("RecoTauPiZeroStripPlugin3")
+                  << "--> adding PFCand #" << candId << " (" << cand.id() << ":" << cand.key()
+                  << "): Et = " << cand->et() << ", eta = " << cand->eta() << ", phi = " << cand->phi();
+            }
+            strip.addDaughter(cand);
+            if (updateStripAfterEachDaughter_)
+              p4Builder_.set(strip);
+            isCandAdded = true;
+            candIdsCurrentStrip.insert(candId);
+          }
+        }
       }
     }
-    // When done doing all the combinations, add the combined strips to the
-    // output.
-    output.transfer(output.end(), stripCombinations);
-  }
 
-  // Compute correction to account for spread of photon energy in eta and phi
-  // in case charged pions make nuclear interactions or photons convert within the tracking detector
-  for ( PiZeroVector::iterator strip = output.begin();
-	  strip != output.end(); ++strip ) {
-    double bendCorrEta = 0.;
-    double bendCorrPhi = 0.;
-    double energySum   = 0.;
-    for (auto const& gamma : strip->daughterPtrVector()) {
-      bendCorrEta += (gamma->energy()*etaAssociationDistance_->Eval(gamma->pt()));
-      bendCorrPhi += (gamma->energy()*phiAssociationDistance_->Eval(gamma->pt()));
-      energySum += gamma->energy();
+    namespace {
+      void markCandsInStrip(std::vector<bool>& candFlags, const std::set<size_t>& candIds) {
+        for (std::set<size_t>::const_iterator candId = candIds.begin(); candId != candIds.end(); ++candId) {
+          candFlags[*candId] = true;
+        }
+      }
+
+      // The following method has not been adapted to work with PackedCandidates,
+      // however, it is only used for printing/debugging and can be adapted when
+      // needed.
+      inline const reco::TrackBaseRef getTrack(const Candidate& cand) {
+        const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+        if (pfCandPtr) {
+          if (pfCandPtr->trackRef().isNonnull())
+            return reco::TrackBaseRef(pfCandPtr->trackRef());
+          else if (pfCandPtr->gsfTrackRef().isNonnull())
+            return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
+          else
+            return reco::TrackBaseRef();
+        }
+
+        return reco::TrackBaseRef();
+      }
+    }  // namespace
+
+    RecoTauPiZeroStripPlugin3::return_type RecoTauPiZeroStripPlugin3::operator()(const reco::Jet& jet) const {
+      if (verbosity_ >= 1) {
+        edm::LogPrint("RecoTauPiZeroStripPlugin3") << "<RecoTauPiZeroStripPlugin3::operator()>:";
+        edm::LogPrint("RecoTauPiZeroStripPlugin3") << " minGammaEtStripSeed = " << minGammaEtStripSeed_;
+        edm::LogPrint("RecoTauPiZeroStripPlugin3") << " minGammaEtStripAdd = " << minGammaEtStripAdd_;
+        edm::LogPrint("RecoTauPiZeroStripPlugin3") << " minStripEt = " << minStripEt_;
+      }
+
+      PiZeroVector output;
+
+      // Get the candidates passing our quality cuts
+      qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
+      CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputParticleIds_));
+
+      // Convert to stl::list to allow fast deletions
+      CandPtrs seedCands;
+      CandPtrs addCands;
+      int idx = 0;
+      for (CandPtrs::iterator cand = candsVector.begin(); cand != candsVector.end(); ++cand) {
+        if (verbosity_ >= 1) {
+          edm::LogPrint("RecoTauPiZeroStripPlugin3")
+              << "PFGamma #" << idx << " (" << cand->id() << ":" << cand->key() << "): Et = " << (*cand)->et()
+              << ", eta = " << (*cand)->eta() << ", phi = " << (*cand)->phi();
+        }
+        if ((*cand)->et() > minGammaEtStripSeed_) {
+          if (verbosity_ >= 2) {
+            edm::LogPrint("RecoTauPiZeroStripPlugin3") << "--> assigning seedCandId = " << seedCands.size();
+            const reco::TrackBaseRef candTrack = getTrack(**cand);
+            if (candTrack.isNonnull()) {
+              edm::LogPrint("RecoTauPiZeroStripPlugin3")
+                  << "track: Pt = " << candTrack->pt() << " eta = " << candTrack->eta()
+                  << ", phi = " << candTrack->phi() << ", charge = " << candTrack->charge();
+              edm::LogPrint("RecoTauPiZeroStripPlugin3")
+                  << " (dZ = " << candTrack->dz(vertexAssociator_.associatedVertex(jet)->position())
+                  << ", dXY = " << candTrack->dxy(vertexAssociator_.associatedVertex(jet)->position()) << ","
+                  << " numHits = " << candTrack->hitPattern().numberOfValidTrackerHits()
+                  << ", numPxlHits = " << candTrack->hitPattern().numberOfValidPixelHits() << ","
+                  << " chi2 = " << candTrack->normalizedChi2()
+                  << ", dPt/Pt = " << (candTrack->ptError() / candTrack->pt()) << ")";
+            }
+          }
+          seedCands.push_back(*cand);
+        } else if ((*cand)->et() > minGammaEtStripAdd_) {
+          if (verbosity_ >= 2) {
+            edm::LogPrint("RecoTauPiZeroStripPlugin3") << "--> assigning addCandId = " << addCands.size();
+          }
+          addCands.push_back(*cand);
+        }
+        ++idx;
+      }
+
+      std::vector<bool> seedCandFlags(seedCands.size());  // true/false: seedCand is already/not yet included in strip
+      std::vector<bool> addCandFlags(addCands.size());    // true/false: addCand  is already/not yet included in strip
+
+      std::set<size_t> seedCandIdsCurrentStrip;
+      std::set<size_t> addCandIdsCurrentStrip;
+
+      size_t idxSeed = 0;
+      while (idxSeed < seedCands.size()) {
+        if (verbosity_ >= 2)
+          edm::LogPrint("RecoTauPiZeroStripPlugin3") << "processing seed #" << idxSeed;
+
+        seedCandIdsCurrentStrip.clear();
+        addCandIdsCurrentStrip.clear();
+
+        std::auto_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
+        strip->addDaughter(seedCands[idxSeed]);
+        seedCandIdsCurrentStrip.insert(idxSeed);
+
+        bool isCandAdded;
+        int stripBuildIteration = 0;
+        do {
+          isCandAdded = false;
+
+          //if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin3") << " adding seedCands to strip..." ;
+          addCandsToStrip(*strip, seedCands, seedCandFlags, seedCandIdsCurrentStrip, isCandAdded);
+          //if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin3") << " adding addCands to strip..." ;
+          addCandsToStrip(*strip, addCands, addCandFlags, addCandIdsCurrentStrip, isCandAdded);
+
+          if (!updateStripAfterEachDaughter_)
+            p4Builder_.set(*strip);
+
+          ++stripBuildIteration;
+        } while (isCandAdded && (stripBuildIteration < maxStripBuildIterations_ || maxStripBuildIterations_ == -1));
+
+        if (strip->et() > minStripEt_) {  // strip passed Et cuts, add it to the event
+          if (verbosity_ >= 2)
+            edm::LogPrint("RecoTauPiZeroStripPlugin3")
+                << "Building strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi();
+
+          // Update the vertex
+          if (strip->daughterPtr(0).isNonnull())
+            strip->setVertex(strip->daughterPtr(0)->vertex());
+          output.push_back(strip);
+
+          // Mark daughters as being part of this strip
+          markCandsInStrip(seedCandFlags, seedCandIdsCurrentStrip);
+          markCandsInStrip(addCandFlags, addCandIdsCurrentStrip);
+        } else {  // strip failed Et cuts, just skip it
+          if (verbosity_ >= 2)
+            edm::LogPrint("RecoTauPiZeroStripPlugin3")
+                << "Discarding strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi();
+        }
+
+        ++idxSeed;
+        while (idxSeed < seedCands.size() && seedCandFlags[idxSeed]) {
+          ++idxSeed;  // fast-forward to next seed cand not yet included in any strip
+        }
+      }
+
+      // Check if we want to combine our strips
+      if (combineStrips_ && output.size() > 1) {
+        PiZeroVector stripCombinations;
+        // Sort the output by descending pt
+        output.sort(
+            output.begin(), output.end(), boost::bind(&RecoTauPiZero::pt, _1) > boost::bind(&RecoTauPiZero::pt, _2));
+        // Get the end of interesting set of strips to try and combine
+        PiZeroVector::const_iterator end_iter = takeNElements(output.begin(), output.end(), maxStrips_);
+
+        // Look at all the combinations
+        for (PiZeroVector::const_iterator first = output.begin(); first != end_iter - 1; ++first) {
+          for (PiZeroVector::const_iterator second = first + 1; second != end_iter; ++second) {
+            Candidate::LorentzVector firstP4 = first->p4();
+            Candidate::LorentzVector secondP4 = second->p4();
+            // If we assume a certain mass for each strip apply it here.
+            firstP4 = applyMassConstraint(firstP4, combinatoricStripMassHypo_);
+            secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
+            Candidate::LorentzVector totalP4 = firstP4 + secondP4;
+            // Make our new combined strip
+            std::auto_ptr<RecoTauPiZero> combinedStrips(
+                new RecoTauPiZero(0,
+                                  totalP4,
+                                  Candidate::Point(0, 0, 0),
+                                  //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
+                                  111,
+                                  10001,
+                                  true,
+                                  RecoTauPiZero::kUndefined));
+
+            // Now loop over the strip members
+            for (auto const& gamma : first->daughterPtrVector()) {
+              combinedStrips->addDaughter(gamma);
+            }
+            for (auto const& gamma : second->daughterPtrVector()) {
+              combinedStrips->addDaughter(gamma);
+            }
+            // Update the vertex
+            if (combinedStrips->daughterPtr(0).isNonnull()) {
+              combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
+            }
+
+            // Add to our collection of combined strips
+            stripCombinations.push_back(combinedStrips);
+          }
+        }
+        // When done doing all the combinations, add the combined strips to the
+        // output.
+        output.transfer(output.end(), stripCombinations);
+      }
+
+      // Compute correction to account for spread of photon energy in eta and phi
+      // in case charged pions make nuclear interactions or photons convert within the tracking detector
+      for (PiZeroVector::iterator strip = output.begin(); strip != output.end(); ++strip) {
+        double bendCorrEta = 0.;
+        double bendCorrPhi = 0.;
+        double energySum = 0.;
+        for (auto const& gamma : strip->daughterPtrVector()) {
+          bendCorrEta += (gamma->energy() * etaAssociationDistance_->Eval(gamma->pt()));
+          bendCorrPhi += (gamma->energy() * phiAssociationDistance_->Eval(gamma->pt()));
+          energySum += gamma->energy();
+        }
+        if (energySum > 1.e-2) {
+          bendCorrEta /= energySum;
+          bendCorrPhi /= energySum;
+        }
+        //std::cout << "stripPt = " << strip->pt() << ": bendCorrEta = " << bendCorrEta << ", bendCorrPhi = " << bendCorrPhi << std::endl;
+        strip->setBendCorrEta(bendCorrEta);
+        strip->setBendCorrPhi(bendCorrPhi);
+      }
+
+      return output.release();
     }
-    if ( energySum > 1.e-2 ) {
-      bendCorrEta /= energySum;
-      bendCorrPhi /= energySum;
-    }
-    //std::cout << "stripPt = " << strip->pt() << ": bendCorrEta = " << bendCorrEta << ", bendCorrPhi = " << bendCorrPhi << std::endl;
-    strip->setBendCorrEta(bendCorrEta);
-    strip->setBendCorrPhi(bendCorrPhi);
-  }
-  
-  return output.release();
-}
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(RecoTauPiZeroBuilderPluginFactory,
-    reco::tau::RecoTauPiZeroStripPlugin3, "RecoTauPiZeroStripPlugin3");
+DEFINE_EDM_PLUGIN(RecoTauPiZeroBuilderPluginFactory, reco::tau::RecoTauPiZeroStripPlugin3, "RecoTauPiZeroStripPlugin3");

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
@@ -21,39 +21,37 @@
 
 namespace reco::tau {
 
-class RecoTauPiZeroTrivialPlugin : public RecoTauPiZeroBuilderPlugin {
+  class RecoTauPiZeroTrivialPlugin : public RecoTauPiZeroBuilderPlugin {
   public:
-  explicit RecoTauPiZeroTrivialPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC);
+    explicit RecoTauPiZeroTrivialPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
     ~RecoTauPiZeroTrivialPlugin() override {}
     return_type operator()(const reco::Jet& jet) const override;
+
   private:
     RecoTauQualityCuts qcuts_;
-};
+  };
 
-RecoTauPiZeroTrivialPlugin::RecoTauPiZeroTrivialPlugin(
-						       const edm::ParameterSet& pset, edm::ConsumesCollector &&iC):RecoTauPiZeroBuilderPlugin(pset,std::move(iC)),
-    qcuts_(pset.getParameterSet(
-          "qualityCuts").getParameterSet("signalQualityCuts")) {}
+  RecoTauPiZeroTrivialPlugin::RecoTauPiZeroTrivialPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+      : RecoTauPiZeroBuilderPlugin(pset, std::move(iC)),
+        qcuts_(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts")) {}
 
-RecoTauPiZeroBuilderPlugin::return_type RecoTauPiZeroTrivialPlugin::operator()(
-    const reco::Jet& jet) const {
-  std::vector<CandidatePtr> pfGammaCands = qcuts_.filterCandRefs(pfGammas(jet));
-  PiZeroVector output;
-  output.reserve(pfGammaCands.size());
+  RecoTauPiZeroBuilderPlugin::return_type RecoTauPiZeroTrivialPlugin::operator()(const reco::Jet& jet) const {
+    std::vector<CandidatePtr> pfGammaCands = qcuts_.filterCandRefs(pfGammas(jet));
+    PiZeroVector output;
+    output.reserve(pfGammaCands.size());
 
-  for(auto const& gamma : pfGammaCands) {
-    std::auto_ptr<RecoTauPiZero> piZero(new RecoTauPiZero(
-            0, (*gamma).p4(), (*gamma).vertex(), 22, 1000, true,
-            RecoTauPiZero::kTrivial));
-    piZero->addDaughter(gamma);
-    output.push_back(piZero);
+    for (auto const& gamma : pfGammaCands) {
+      std::auto_ptr<RecoTauPiZero> piZero(
+          new RecoTauPiZero(0, (*gamma).p4(), (*gamma).vertex(), 22, 1000, true, RecoTauPiZero::kTrivial));
+      piZero->addDaughter(gamma);
+      output.push_back(piZero);
+    }
+    return output.release();
   }
-  return output.release();
-}
 
-} // end reco::tau
+}  // namespace reco::tau
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauPiZeroBuilderPluginFactory,
-    reco::tau::RecoTauPiZeroTrivialPlugin,
-    "RecoTauPiZeroTrivialPlugin");
+                  reco::tau::RecoTauPiZeroTrivialPlugin,
+                  "RecoTauPiZeroTrivialPlugin");

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroUnembedder.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroUnembedder.cc
@@ -27,15 +27,15 @@
 #include "DataFormats/TauReco/interface/RecoTauPiZeroFwd.h"
 
 class RecoTauPiZeroUnembedder : public edm::stream::EDProducer<> {
-  public:
-    RecoTauPiZeroUnembedder(const edm::ParameterSet& pset);
-    ~RecoTauPiZeroUnembedder() override{}
-    void produce(edm::Event& evt, const edm::EventSetup& es) override;
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+public:
+  RecoTauPiZeroUnembedder(const edm::ParameterSet& pset);
+  ~RecoTauPiZeroUnembedder() override {}
+  void produce(edm::Event& evt, const edm::EventSetup& es) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  private:
-    edm::InputTag src_;
-    edm::EDGetTokenT<reco::CandidateView> token; 
+private:
+  edm::InputTag src_;
+  edm::EDGetTokenT<reco::CandidateView> token;
 };
 
 RecoTauPiZeroUnembedder::RecoTauPiZeroUnembedder(const edm::ParameterSet& pset) {
@@ -51,12 +51,10 @@ void RecoTauPiZeroUnembedder::produce(edm::Event& evt, const edm::EventSetup& es
   edm::Handle<reco::CandidateView> tauView;
   evt.getByToken(token, tauView);
 
-  reco::PFTauRefVector taus =
-      reco::tau::castView<reco::PFTauRefVector>(tauView);
+  reco::PFTauRefVector taus = reco::tau::castView<reco::PFTauRefVector>(tauView);
 
   // Get the reference to the product of where the final pizeros will end up
-  reco::RecoTauPiZeroRefProd piZeroProd =
-    evt.getRefBeforePut<reco::RecoTauPiZeroCollection>("pizeros");
+  reco::RecoTauPiZeroRefProd piZeroProd = evt.getRefBeforePut<reco::RecoTauPiZeroCollection>("pizeros");
 
   for (size_t iTau = 0; iTau < taus.size(); ++iTau) {
     // Make a copy
@@ -67,23 +65,19 @@ void RecoTauPiZeroUnembedder::produce(edm::Event& evt, const edm::EventSetup& es
 
     // Copy the PiZeros into the new vector, while updating what refs they will
     // have
-    const reco::RecoTauPiZeroCollection& signalPiZeros =
-      myTau.signalPiZeroCandidates();
+    const reco::RecoTauPiZeroCollection& signalPiZeros = myTau.signalPiZeroCandidates();
 
     for (size_t iPiZero = 0; iPiZero < signalPiZeros.size(); ++iPiZero) {
       piZerosOut->push_back(signalPiZeros[iPiZero]);
       // Figure out what the ref for this pizero will be in the new coll.
-      signalPiZeroRefs.push_back(
-          reco::RecoTauPiZeroRef(piZeroProd, piZerosOut->size()-1));
+      signalPiZeroRefs.push_back(reco::RecoTauPiZeroRef(piZeroProd, piZerosOut->size() - 1));
     }
 
-    const reco::RecoTauPiZeroCollection& isolationPiZeroCandidates =
-      myTau.isolationPiZeroCandidates();
+    const reco::RecoTauPiZeroCollection& isolationPiZeroCandidates = myTau.isolationPiZeroCandidates();
     for (size_t iPiZero = 0; iPiZero < isolationPiZeroCandidates.size(); ++iPiZero) {
       piZerosOut->push_back(isolationPiZeroCandidates[iPiZero]);
       // Figure out what the ref for this pizero will be in the new coll.
-      isolationPiZeroRefs.push_back(
-          reco::RecoTauPiZeroRef(piZeroProd, piZerosOut->size()-1));
+      isolationPiZeroRefs.push_back(reco::RecoTauPiZeroRef(piZeroProd, piZerosOut->size() - 1));
     }
 
     myTau.setSignalPiZeroCandidatesRefs(signalPiZeroRefs);
@@ -96,8 +90,7 @@ void RecoTauPiZeroUnembedder::produce(edm::Event& evt, const edm::EventSetup& es
   evt.put(std::move(tausOut));
 }
 
-void
-RecoTauPiZeroUnembedder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void RecoTauPiZeroUnembedder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // RecoTauPiZeroUnembedder
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("hpsPFTauProducerSansRefs"));

--- a/RecoTauTag/RecoTau/plugins/RecoTauPileUpVertexSelector.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPileUpVertexSelector.cc
@@ -5,7 +5,6 @@
  *
  */
 
-
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -22,30 +21,28 @@
 #include <algorithm>
 
 class RecoTauPileUpVertexSelector : public edm::stream::EDFilter<> {
-  public:
-    explicit RecoTauPileUpVertexSelector(const edm::ParameterSet &pset);
-    ~RecoTauPileUpVertexSelector() override {}
-    bool filter(edm::Event& evt, const edm::EventSetup& es) override;
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  private:
-    edm::InputTag src_;
-    double minPt_;
-    bool filter_;
-    edm::EDGetTokenT<reco::VertexCollection> token;
+public:
+  explicit RecoTauPileUpVertexSelector(const edm::ParameterSet& pset);
+  ~RecoTauPileUpVertexSelector() override {}
+  bool filter(edm::Event& evt, const edm::EventSetup& es) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  edm::InputTag src_;
+  double minPt_;
+  bool filter_;
+  edm::EDGetTokenT<reco::VertexCollection> token;
 };
 
-RecoTauPileUpVertexSelector::RecoTauPileUpVertexSelector(
-    const edm::ParameterSet& pset):minPt_(
-      pset.getParameter<double>("minTrackSumPt")) {
+RecoTauPileUpVertexSelector::RecoTauPileUpVertexSelector(const edm::ParameterSet& pset)
+    : minPt_(pset.getParameter<double>("minTrackSumPt")) {
   src_ = pset.getParameter<edm::InputTag>("src");
   token = consumes<reco::VertexCollection>(src_);
   filter_ = pset.getParameter<bool>("filter");
   produces<reco::VertexCollection>();
 }
 
-
-bool RecoTauPileUpVertexSelector::filter(
-    edm::Event& evt, const edm::EventSetup& es) {
+bool RecoTauPileUpVertexSelector::filter(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<reco::VertexCollection> vertices_;
   evt.getByToken(token, vertices_);
   auto output = std::make_unique<reco::VertexCollection>();
@@ -54,15 +51,13 @@ bool RecoTauPileUpVertexSelector::filter(
     // Copy over all the vertices that have associatd tracks with pt greater
     // than the threshold.  The predicate function is the VertexTrackPtSumFilter
     // better name: copy_if_not
-    std::remove_copy_if(vertices_->begin()+1, vertices_->end(),
-        std::back_inserter(*output), [this](auto const& vtx){
-          double trackPtSum = 0.;
-          for ( reco::Vertex::trackRef_iterator track = vtx.tracks_begin();
-              track != vtx.tracks_end(); ++track ) {
-            trackPtSum += (*track)->pt();
-          }
-          return trackPtSum > this->minPt_;
-        });
+    std::remove_copy_if(vertices_->begin() + 1, vertices_->end(), std::back_inserter(*output), [this](auto const& vtx) {
+      double trackPtSum = 0.;
+      for (reco::Vertex::trackRef_iterator track = vtx.tracks_begin(); track != vtx.tracks_end(); ++track) {
+        trackPtSum += (*track)->pt();
+      }
+      return trackPtSum > this->minPt_;
+    });
   }
   size_t nPUVtx = output->size();
   evt.put(std::move(output));
@@ -73,8 +68,7 @@ bool RecoTauPileUpVertexSelector::filter(
     return nPUVtx;
 }
 
-void
-RecoTauPileUpVertexSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void RecoTauPileUpVertexSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // recoTauPileUpVertexSelector
   edm::ParameterSetDescription desc;
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -43,9 +43,8 @@
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
-class RecoTauProducer : public edm::stream::EDProducer<> 
-{
- public:
+class RecoTauProducer : public edm::stream::EDProducer<> {
+public:
   typedef reco::tau::RecoTauBuilderPlugin Builder;
   typedef reco::tau::RecoTauModifierPlugin Modifier;
   typedef std::vector<std::unique_ptr<Builder>> BuilderList;
@@ -55,9 +54,9 @@ class RecoTauProducer : public edm::stream::EDProducer<>
   ~RecoTauProducer() override {}
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
+private:
   edm::InputTag jetSrc_;
   edm::InputTag jetRegionSrc_;
   edm::InputTag chargedHadronSrc_;
@@ -65,42 +64,40 @@ class RecoTauProducer : public edm::stream::EDProducer<>
 
   double minJetPt_;
   double maxJetAbsEta_;
- //token definition
+  //token definition
   edm::EDGetTokenT<reco::JetView> jet_token;
-  edm::EDGetTokenT<edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView> > > jetRegion_token;
+  edm::EDGetTokenT<edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView>>> jetRegion_token;
   edm::EDGetTokenT<reco::PFJetChargedHadronAssociation> chargedHadron_token;
   edm::EDGetTokenT<reco::JetPiZeroAssociation> piZero_token;
 
   BuilderList builders_;
   ModifierList modifiers_;
   // Optional selection on the output of the taus
-  std::unique_ptr<StringCutObjectSelector<reco::PFTau> > outputSelector_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFTau>> outputSelector_;
   // Whether or not to add build a tau from a jet for which the builders
   // return no taus.  The tau will have no content, only the four vector of
   // the orginal jet.
   bool buildNullTaus_;
 };
 
-RecoTauProducer::RecoTauProducer(const edm::ParameterSet& pset) 
-{
+RecoTauProducer::RecoTauProducer(const edm::ParameterSet& pset) {
   jetSrc_ = pset.getParameter<edm::InputTag>("jetSrc");
   jetRegionSrc_ = pset.getParameter<edm::InputTag>("jetRegionSrc");
   chargedHadronSrc_ = pset.getParameter<edm::InputTag>("chargedHadronSrc");
   piZeroSrc_ = pset.getParameter<edm::InputTag>("piZeroSrc");
-  
+
   minJetPt_ = pset.getParameter<double>("minJetPt");
   maxJetAbsEta_ = pset.getParameter<double>("maxJetAbsEta");
   //consumes definition
-  jet_token=consumes<reco::JetView>(jetSrc_);
-  jetRegion_token = consumes<edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView> > >(jetRegionSrc_);
-  chargedHadron_token = consumes<reco::PFJetChargedHadronAssociation>(chargedHadronSrc_); 
+  jet_token = consumes<reco::JetView>(jetSrc_);
+  jetRegion_token = consumes<edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView>>>(jetRegionSrc_);
+  chargedHadron_token = consumes<reco::PFJetChargedHadronAssociation>(chargedHadronSrc_);
   piZero_token = consumes<reco::JetPiZeroAssociation>(piZeroSrc_);
 
   typedef std::vector<edm::ParameterSet> VPSet;
   // Get each of our tau builders
   const VPSet& builders = pset.getParameter<VPSet>("builders");
-  for ( VPSet::const_iterator builderPSet = builders.begin();
-	builderPSet != builders.end(); ++builderPSet ) {
+  for (VPSet::const_iterator builderPSet = builders.begin(); builderPSet != builders.end(); ++builderPSet) {
     // Get plugin name
     const std::string& pluginType = builderPSet->getParameter<std::string>("plugin");
     // Build the plugin
@@ -108,8 +105,7 @@ RecoTauProducer::RecoTauProducer(const edm::ParameterSet& pset)
   }
 
   const VPSet& modfiers = pset.getParameter<VPSet>("modifiers");
-  for ( VPSet::const_iterator modfierPSet = modfiers.begin();
-	modfierPSet != modfiers.end(); ++modfierPSet) {
+  for (VPSet::const_iterator modfierPSet = modfiers.begin(); modfierPSet != modfiers.end(); ++modfierPSet) {
     // Get plugin name
     const std::string& pluginType = modfierPSet->getParameter<std::string>("plugin");
     // Build the plugin
@@ -118,7 +114,7 @@ RecoTauProducer::RecoTauProducer(const edm::ParameterSet& pset)
 
   // Check if we want to apply a final output selection
   std::string selection = pset.getParameter<std::string>("outputSelection");
-  if ( !selection.empty() ) {
+  if (!selection.empty()) {
     outputSelector_.reset(new StringCutObjectSelector<reco::PFTau>(selection));
   }
   buildNullTaus_ = pset.getParameter<bool>("buildNullTaus");
@@ -126,16 +122,15 @@ RecoTauProducer::RecoTauProducer(const edm::ParameterSet& pset)
   produces<reco::PFTauCollection>();
 }
 
-void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
-{
+void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   // Get the jet input collection via a view of Candidates
   edm::Handle<reco::JetView> jetView;
   evt.getByToken(jet_token, jetView);
-    
+
   // Get the jet region producer
-  edm::Handle<edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView> > > jetRegionHandle;
+  edm::Handle<edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView>>> jetRegionHandle;
   evt.getByToken(jetRegion_token, jetRegionHandle);
-  
+
   // Get the charged hadron input collection
   edm::Handle<reco::PFJetChargedHadronAssociation> chargedHadronAssoc;
   evt.getByToken(chargedHadron_token, chargedHadronAssoc);
@@ -145,27 +140,28 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   evt.getByToken(piZero_token, piZeroAssoc);
 
   // Update all our builders and modifiers with the event info
-  for (auto& builder: builders_) {
+  for (auto& builder : builders_) {
     builder->setup(evt, es);
   }
-  for (auto& modifier: modifiers_) {
+  for (auto& modifier : modifiers_) {
     modifier->setup(evt, es);
   }
 
   // Create output collection
   auto output = std::make_unique<reco::PFTauCollection>();
   output->reserve(jetView->size());
-  
+
   // Loop over the jets and build the taus for each jet
   for (size_t i_j = 0; i_j < jetView->size(); ++i_j) {
     const auto& jetRef = jetView->refAt(i_j);
     // Get the jet with extra constituents from an area around the jet
-    if(jetRef->pt() - minJetPt_ < 1e-5) continue;
-    if(std::abs(jetRef->eta()) - maxJetAbsEta_ > -1e-5) continue;
+    if (jetRef->pt() - minJetPt_ < 1e-5)
+      continue;
+    if (std::abs(jetRef->eta()) - maxJetAbsEta_ > -1e-5)
+      continue;
     reco::JetBaseRef jetRegionRef = (*jetRegionHandle)[jetRef];
-    if ( jetRegionRef.isNull() ) {
-      throw cms::Exception("BadJetRegionRef") 
-	<< "No jet region can be found for the current jet: " << jetRef.id();
+    if (jetRegionRef.isNull()) {
+      throw cms::Exception("BadJetRegionRef") << "No jet region can be found for the current jet: " << jetRef.id();
     }
     // Remove all the jet constituents from the jet extras
     std::vector<reco::CandidatePtr> jetCands = jetRef->daughterPtrVector();
@@ -178,14 +174,16 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 
     // This can actually be less than zero, if the jet has really crazy soft
     // stuff really far away from the jet axis.
-    if ( allRegionalCands.size() > jetCands.size() ) {
+    if (allRegionalCands.size() > jetCands.size()) {
       uniqueRegionalCands.reserve(allRegionalCands.size() - jetCands.size());
     }
 
     // Subtract the jet cands from the regional cands
-    std::set_difference(allRegionalCands.begin(), allRegionalCands.end(),
-			jetCands.begin(), jetCands.end(),
-			std::back_inserter(uniqueRegionalCands));
+    std::set_difference(allRegionalCands.begin(),
+                        allRegionalCands.end(),
+                        jetCands.begin(),
+                        jetCands.end(),
+                        std::back_inserter(uniqueRegionalCands));
 
     // Get the charged hadrons associated with this jet
     const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons = (*chargedHadronAssoc)[jetRef];
@@ -194,20 +192,21 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     const std::vector<reco::RecoTauPiZero>& piZeros = (*piZeroAssoc)[jetRef];
     // Loop over our builders and create the set of taus for this jet
     unsigned int nTausBuilt = 0;
-    for ( const auto& builder: builders_ ) {
+    for (const auto& builder : builders_) {
       // Get a ptr_vector of taus from the builder
-      reco::tau::RecoTauBuilderPlugin::output_type taus((*builder)(jetRef, chargedHadrons, piZeros, uniqueRegionalCands));
+      reco::tau::RecoTauBuilderPlugin::output_type taus(
+          (*builder)(jetRef, chargedHadrons, piZeros, uniqueRegionalCands));
 
       // Make sure all taus have their jetref set correctly
       std::for_each(taus.begin(), taus.end(), boost::bind(&reco::PFTau::setjetRef, _1, reco::JetBaseRef(jetRef)));
       // Copy without selection
-      if ( !outputSelector_.get() ) {
+      if (!outputSelector_.get()) {
         output->insert(output->end(), taus.begin(), taus.end());
         nTausBuilt += taus.size();
       } else {
         // Copy only those that pass the selection.
-        for(auto const& tau : taus ) {
-          if ( (*outputSelector_)(tau) ) {
+        for (auto const& tau : taus) {
+          if ((*outputSelector_)(tau)) {
             nTausBuilt++;
             output->push_back(tau);
           }
@@ -217,7 +216,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     // If we didn't build *any* taus for this jet, build a null tau if desired.
     // The null PFTau has no content, but it's four vector is set to that of the
     // jet.
-    if ( !nTausBuilt && buildNullTaus_ ) {
+    if (!nTausBuilt && buildNullTaus_) {
       reco::PFTau nullTau(std::numeric_limits<int>::quiet_NaN(), jetRef->p4());
       nullTau.setjetRef(reco::JetBaseRef(jetRef));
       output->push_back(nullTau);
@@ -225,22 +224,20 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   }
 
   // Loop over the taus we have created and apply our modifiers to the taus
-  for ( reco::PFTauCollection::iterator tau = output->begin();
-	tau != output->end(); ++tau ) {
-    for ( const auto& modifier: modifiers_ ) {
+  for (reco::PFTauCollection::iterator tau = output->begin(); tau != output->end(); ++tau) {
+    for (const auto& modifier : modifiers_) {
       (*modifier)(*tau);
     }
   }
-  
-  for ( auto& modifier: modifiers_ ) {
+
+  for (auto& modifier : modifiers_) {
     modifier->endEvent();
   }
-  
+
   evt.put(std::move(output));
 }
 
-void
-RecoTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void RecoTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // combinatoricRecoTaus
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("piZeroSrc", edm::InputTag("ak4PFJetsRecoTauPiZeros"));
@@ -279,8 +276,8 @@ RecoTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   pset_isolationQualityCuts.addOptional<bool>("useTracksInsteadOfPFHadrons");
 
   edm::ParameterSetDescription pset_qualityCuts;
-  pset_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts",    pset_signalQualityCuts);
-  pset_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts",   pset_vxAssocQualityCuts);
+  pset_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts", pset_signalQualityCuts);
+  pset_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts", pset_vxAssocQualityCuts);
   pset_qualityCuts.add<edm::ParameterSetDescription>("isolationQualityCuts", pset_isolationQualityCuts);
   pset_qualityCuts.add<std::string>("leadingTrkOrPFCandOption", "leadPFCand");
   pset_qualityCuts.add<std::string>("pvFindingAlgo", "closestInDeltaZ");
@@ -337,7 +334,7 @@ RecoTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
     desc_builders.add<double>("minAbsPhotonSumPt_insideSignalCone", 2.5);
     desc_builders.add<double>("minRelPhotonSumPt_insideSignalCone", 0.1);
     desc_builders.add<edm::InputTag>("pfCandSrc", edm::InputTag("particleFlow"));
-    
+
     desc_builders.addOptional<std::string>("signalConeSize");
     desc_builders.addOptional<double>("isolationConeSize");
     desc_builders.addOptional<double>("minAbsPhotonSumPt_outsideSignalCone");
@@ -356,16 +353,15 @@ RecoTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
     std::vector<edm::ParameterSet> vpset_default;
     {
       edm::ParameterSet pset_default_builders;
-      pset_default_builders.addParameter<std::string>("name","");
-      pset_default_builders.addParameter<std::string>("plugin","");
-      pset_default_builders.addParameter<int>("verbosity",0);
+      pset_default_builders.addParameter<std::string>("name", "");
+      pset_default_builders.addParameter<std::string>("plugin", "");
+      pset_default_builders.addParameter<int>("verbosity", 0);
       pset_default_builders.addParameter<double>("minAbsPhotonSumPt_insideSignalCone", 2.5);
       pset_default_builders.addParameter<double>("minRelPhotonSumPt_insideSignalCone", 0.1);
       pset_default_builders.addParameter<edm::InputTag>("pfCandSrc", edm::InputTag("particleFlow"));
       vpset_default.push_back(pset_default_builders);
     }
     desc.addVPSet("builders", desc_builders, vpset_default);
-
   }
 
   desc.add<bool>("buildNullTaus", false);

--- a/RecoTauTag/RecoTau/plugins/RecoTauSoftTwoProngTausCleanerPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauSoftTwoProngTausCleanerPlugin.cc
@@ -10,43 +10,46 @@
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
 #include "RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauSoftTwoProngTausCleanerPlugin : public RecoTauCleanerPlugin 
-{
- public:
-  RecoTauSoftTwoProngTausCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+    class RecoTauSoftTwoProngTausCleanerPlugin : public RecoTauCleanerPlugin {
+    public:
+      RecoTauSoftTwoProngTausCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
 
-  // Get ranking value for a given tau Ref
-  double operator()(const reco::PFTauRef&) const override;
- private:
-  double minTrackPt_;
-};
+      // Get ranking value for a given tau Ref
+      double operator()(const reco::PFTauRef&) const override;
 
-RecoTauSoftTwoProngTausCleanerPlugin::RecoTauSoftTwoProngTausCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
-  : RecoTauCleanerPlugin(pset,std::move(iC)) 
-{
-  minTrackPt_ = pset.getParameter<double>("minTrackPt");
-}
+    private:
+      double minTrackPt_;
+    };
 
-double RecoTauSoftTwoProngTausCleanerPlugin::operator()(const reco::PFTauRef& tau) const 
-{
-  double result = 0.;
-  const std::vector<PFRecoTauChargedHadron>& chargedHadrons = tau->signalTauChargedHadronCandidates();
-  if ( chargedHadrons.size() == 2 ) {
-    for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
-	  chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
-      const reco::Track* track = getTrackFromChargedHadron(*chargedHadron);
-      if ( !(track != nullptr && track->pt() > minTrackPt_) ) result += 1.e+3;
+    RecoTauSoftTwoProngTausCleanerPlugin::RecoTauSoftTwoProngTausCleanerPlugin(const edm::ParameterSet& pset,
+                                                                               edm::ConsumesCollector&& iC)
+        : RecoTauCleanerPlugin(pset, std::move(iC)) {
+      minTrackPt_ = pset.getParameter<double>("minTrackPt");
     }
-  }
-  return result;
-}
 
-}} // end namespace reco::tau
+    double RecoTauSoftTwoProngTausCleanerPlugin::operator()(const reco::PFTauRef& tau) const {
+      double result = 0.;
+      const std::vector<PFRecoTauChargedHadron>& chargedHadrons = tau->signalTauChargedHadronCandidates();
+      if (chargedHadrons.size() == 2) {
+        for (std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
+             chargedHadron != chargedHadrons.end();
+             ++chargedHadron) {
+          const reco::Track* track = getTrackFromChargedHadron(*chargedHadron);
+          if (!(track != nullptr && track->pt() > minTrackPt_))
+            result += 1.e+3;
+        }
+      }
+      return result;
+    }
+
+  }  // namespace tau
+}  // namespace reco
 
 // Register our plugin
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(RecoTauCleanerPluginFactory, 
-    reco::tau::RecoTauSoftTwoProngTausCleanerPlugin, 
-    "RecoTauSoftTwoProngTausCleanerPlugin");
+DEFINE_EDM_PLUGIN(RecoTauCleanerPluginFactory,
+                  reco::tau::RecoTauSoftTwoProngTausCleanerPlugin,
+                  "RecoTauSoftTwoProngTausCleanerPlugin");

--- a/RecoTauTag/RecoTau/plugins/RecoTauStringCleanerPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauStringCleanerPlugin.cc
@@ -19,35 +19,36 @@
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauStringCleanerPlugin : public RecoTauCleanerPlugin 
-{
- public:
-  explicit RecoTauStringCleanerPlugin(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
-  ~RecoTauStringCleanerPlugin() override {}
-  double operator()(const PFTauRef& tau) const override;
+    class RecoTauStringCleanerPlugin : public RecoTauCleanerPlugin {
+    public:
+      explicit RecoTauStringCleanerPlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+      ~RecoTauStringCleanerPlugin() override {}
+      double operator()(const PFTauRef& tau) const override;
 
- private:
-  const StringCutObjectSelector<PFTau> selector_;
-  const StringObjectFunction<PFTau> function_;
-  double failResult_;
-};
+    private:
+      const StringCutObjectSelector<PFTau> selector_;
+      const StringObjectFunction<PFTau> function_;
+      double failResult_;
+    };
 
-RecoTauStringCleanerPlugin::RecoTauStringCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC)
-  : RecoTauCleanerPlugin(pset,std::move(iC)),
-    selector_(pset.getParameter<std::string>("selection")),
-    function_(pset.getParameter<std::string>("selectionPassFunction")),
-    failResult_(pset.getParameter<double>("selectionFailValue")) 
-{}
+    RecoTauStringCleanerPlugin::RecoTauStringCleanerPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : RecoTauCleanerPlugin(pset, std::move(iC)),
+          selector_(pset.getParameter<std::string>("selection")),
+          function_(pset.getParameter<std::string>("selectionPassFunction")),
+          failResult_(pset.getParameter<double>("selectionFailValue")) {}
 
-double RecoTauStringCleanerPlugin::operator()(const PFTauRef& cand) const 
-{
-  if ( selector_(*cand) ) return function_(*cand);
-  else return failResult_;
-}
+    double RecoTauStringCleanerPlugin::operator()(const PFTauRef& cand) const {
+      if (selector_(*cand))
+        return function_(*cand);
+      else
+        return failResult_;
+    }
 
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauTauTagInfoWorkaroundModifier.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauTauTagInfoWorkaroundModifier.cc
@@ -14,50 +14,51 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-class RecoTauTagInfoWorkaroundModifer : public RecoTauModifierPlugin {
-  public:
-  explicit RecoTauTagInfoWorkaroundModifer(const edm::ParameterSet &pset, edm::ConsumesCollector &&iC);
-    ~RecoTauTagInfoWorkaroundModifer() override {}
-    void operator()(PFTau&) const override;
-    // Called by base class
-    void beginEvent() override;
-  private:
-    edm::InputTag pfTauTagInfoSrc_;
-    edm::Handle<PFTauTagInfoCollection> infos_;
-  edm::EDGetTokenT<PFTauTagInfoCollection> pfTauTagInfo_token;
-};
+    class RecoTauTagInfoWorkaroundModifer : public RecoTauModifierPlugin {
+    public:
+      explicit RecoTauTagInfoWorkaroundModifer(const edm::ParameterSet &pset, edm::ConsumesCollector &&iC);
+      ~RecoTauTagInfoWorkaroundModifer() override {}
+      void operator()(PFTau &) const override;
+      // Called by base class
+      void beginEvent() override;
 
-RecoTauTagInfoWorkaroundModifer::RecoTauTagInfoWorkaroundModifer(
-   const edm::ParameterSet &pset, edm::ConsumesCollector &&iC):RecoTauModifierPlugin(pset,std::move(iC)) {
-  pfTauTagInfoSrc_ = pset.getParameter<edm::InputTag>("pfTauTagInfoSrc");
-  pfTauTagInfo_token = iC.consumes<PFTauTagInfoCollection>(pfTauTagInfoSrc_);
-}
+    private:
+      edm::InputTag pfTauTagInfoSrc_;
+      edm::Handle<PFTauTagInfoCollection> infos_;
+      edm::EDGetTokenT<PFTauTagInfoCollection> pfTauTagInfo_token;
+    };
 
-// Load our tau tag infos from the event
-void RecoTauTagInfoWorkaroundModifer::beginEvent() {
-
-  evt()->getByToken(pfTauTagInfo_token, infos_);
-}
-
-void RecoTauTagInfoWorkaroundModifer::operator()(PFTau& tau) const {
-  // Find the PFTauTagInfo that comes from the same PFJet
-  JetBaseRef tauJetRef = tau.jetRef();
-  for(size_t iInfo = 0; iInfo < infos_->size(); ++iInfo) {
-    // Get jet ref from tau tag info
-    PFTauTagInfoRef infoRef = PFTauTagInfoRef(infos_, iInfo);
-    JetBaseRef infoJetRef = infoRef->pfjetRef();
-    // Check if they come from the same jet
-    if (infoJetRef == tauJetRef) {
-      // This tau "comes" from this PFJetRef
-      tau.setpfTauTagInfoRef(infoRef);
-      break;
+    RecoTauTagInfoWorkaroundModifer::RecoTauTagInfoWorkaroundModifer(const edm::ParameterSet &pset,
+                                                                     edm::ConsumesCollector &&iC)
+        : RecoTauModifierPlugin(pset, std::move(iC)) {
+      pfTauTagInfoSrc_ = pset.getParameter<edm::InputTag>("pfTauTagInfoSrc");
+      pfTauTagInfo_token = iC.consumes<PFTauTagInfoCollection>(pfTauTagInfoSrc_);
     }
-  }
-}
-}}  // end namespace reco::tau
+
+    // Load our tau tag infos from the event
+    void RecoTauTagInfoWorkaroundModifer::beginEvent() { evt()->getByToken(pfTauTagInfo_token, infos_); }
+
+    void RecoTauTagInfoWorkaroundModifer::operator()(PFTau &tau) const {
+      // Find the PFTauTagInfo that comes from the same PFJet
+      JetBaseRef tauJetRef = tau.jetRef();
+      for (size_t iInfo = 0; iInfo < infos_->size(); ++iInfo) {
+        // Get jet ref from tau tag info
+        PFTauTagInfoRef infoRef = PFTauTagInfoRef(infos_, iInfo);
+        JetBaseRef infoJetRef = infoRef->pfjetRef();
+        // Check if they come from the same jet
+        if (infoJetRef == tauJetRef) {
+          // This tau "comes" from this PFJetRef
+          tau.setpfTauTagInfoRef(infoRef);
+          break;
+        }
+      }
+    }
+  }  // namespace tau
+}  // namespace reco
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauModifierPluginFactory,
-    reco::tau::RecoTauTagInfoWorkaroundModifer,
-    "RecoTauTagInfoWorkaroundModifer");
+                  reco::tau::RecoTauTagInfoWorkaroundModifer,
+                  "RecoTauTagInfoWorkaroundModifer");

--- a/RecoTauTag/RecoTau/plugins/RecoTauTwoProngFilter.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauTwoProngFilter.cc
@@ -13,74 +13,70 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-namespace 
-{
-  // Delete an element from a ptr vector
-  std::vector<CandidatePtr> deleteFrom(const CandidatePtr& ptr, const std::vector<CandidatePtr>& collection) 
-  {
-    std::vector<CandidatePtr> output;
-    for ( std::vector<CandidatePtr>::const_iterator cand = collection.begin();
-	  cand != collection.end(); ++cand ) {
-      if ( (*cand) != ptr) output.push_back(*cand);
+    namespace {
+      // Delete an element from a ptr vector
+      std::vector<CandidatePtr> deleteFrom(const CandidatePtr& ptr, const std::vector<CandidatePtr>& collection) {
+        std::vector<CandidatePtr> output;
+        for (std::vector<CandidatePtr>::const_iterator cand = collection.begin(); cand != collection.end(); ++cand) {
+          if ((*cand) != ptr)
+            output.push_back(*cand);
+        }
+        return output;
+      }
+    }  // namespace
+
+    class RecoTauTwoProngFilter : public RecoTauModifierPlugin {
+    public:
+      explicit RecoTauTwoProngFilter(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
+      ~RecoTauTwoProngFilter() override {}
+      void operator()(PFTau&) const override;
+
+    private:
+      double minPtFractionForSecondProng_;
+    };
+
+    RecoTauTwoProngFilter::RecoTauTwoProngFilter(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : RecoTauModifierPlugin(pset, std::move(iC)) {
+      minPtFractionForSecondProng_ = pset.getParameter<double>("minPtFractionForSecondProng");
     }
-    return output;
-  }
-}
 
-class RecoTauTwoProngFilter : public RecoTauModifierPlugin {
-  public:
-  explicit RecoTauTwoProngFilter(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC);
-    ~RecoTauTwoProngFilter() override {}
-    void operator()(PFTau&) const override;
-  private:
-    double minPtFractionForSecondProng_;
-};
+    void RecoTauTwoProngFilter::operator()(PFTau& tau) const {
+      if (tau.signalChargedHadrCands().size() == 2) {
+        const std::vector<CandidatePtr>& signalCharged = tau.signalChargedHadrCands();
+        size_t indexOfHighestPt = (signalCharged[0]->pt() > signalCharged[1]->pt()) ? 0 : 1;
+        size_t indexOfLowerPt = (indexOfHighestPt) ? 0 : 1;
+        double ratio = signalCharged[indexOfLowerPt]->pt() / signalCharged[indexOfHighestPt]->pt();
 
-  RecoTauTwoProngFilter::RecoTauTwoProngFilter(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC):RecoTauModifierPlugin(pset,std::move(iC)) {
-  minPtFractionForSecondProng_ = pset.getParameter<double>("minPtFractionForSecondProng");
-}
+        if (ratio < minPtFractionForSecondProng_) {
+          CandidatePtr keep = signalCharged[indexOfHighestPt];
+          CandidatePtr filter = signalCharged[indexOfLowerPt];
+          // Make our new signal charged candidate collection
+          std::vector<CandidatePtr> newSignalCharged;
+          newSignalCharged.push_back(keep);
+          std::vector<CandidatePtr> newSignal = deleteFrom(filter, tau.signalCands());
 
-void RecoTauTwoProngFilter::operator()(PFTau& tau) const {
-  if (tau.signalChargedHadrCands().size() == 2) {
-    const std::vector<CandidatePtr>& signalCharged = tau.signalChargedHadrCands();
-    size_t indexOfHighestPt =
-        (signalCharged[0]->pt() > signalCharged[1]->pt()) ? 0 : 1;
-    size_t indexOfLowerPt   = ( indexOfHighestPt ) ? 0 : 1;
-    double ratio = signalCharged[indexOfLowerPt]->pt()/
-        signalCharged[indexOfHighestPt]->pt();
+          // Copy our filtered cand to isolation
+          std::vector<CandidatePtr> newIsolationCharged = tau.isolationChargedHadrCands();
+          newIsolationCharged.push_back(filter);
+          std::vector<CandidatePtr> newIsolation = tau.isolationCands();
+          newIsolation.push_back(filter);
 
-    if (ratio < minPtFractionForSecondProng_) {
-      CandidatePtr keep = signalCharged[indexOfHighestPt];
-      CandidatePtr filter = signalCharged[indexOfLowerPt];
-      // Make our new signal charged candidate collection
-      std::vector<CandidatePtr> newSignalCharged;
-      newSignalCharged.push_back(keep);
-      std::vector<CandidatePtr> newSignal = deleteFrom(filter, tau.signalCands());
-
-      // Copy our filtered cand to isolation
-      std::vector<CandidatePtr> newIsolationCharged =
-          tau.isolationChargedHadrCands();
-      newIsolationCharged.push_back(filter);
-      std::vector<CandidatePtr> newIsolation = tau.isolationCands();
-      newIsolation.push_back(filter);
-
-      // Update tau members
-      tau.setP4(tau.p4() - filter->p4());
-      tau.setisolationPFChargedHadrCandsPtSum(
-          tau.isolationPFChargedHadrCandsPtSum() - filter->pt());
-      tau.setCharge(tau.charge() - filter->charge());
-      // Update tau constituents
-      tau.setsignalChargedHadrCands(newSignalCharged);
-      tau.setsignalCands(newSignal);
-      tau.setisolationChargedHadrCands(newIsolationCharged);
-      tau.setisolationCands(newIsolation);
+          // Update tau members
+          tau.setP4(tau.p4() - filter->p4());
+          tau.setisolationPFChargedHadrCandsPtSum(tau.isolationPFChargedHadrCandsPtSum() - filter->pt());
+          tau.setCharge(tau.charge() - filter->charge());
+          // Update tau constituents
+          tau.setsignalChargedHadrCands(newSignalCharged);
+          tau.setsignalCands(newSignal);
+          tau.setisolationChargedHadrCands(newIsolationCharged);
+          tau.setisolationCands(newIsolation);
+        }
+      }
     }
-  }
-}
-}}  // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(RecoTauModifierPluginFactory,
-    reco::tau::RecoTauTwoProngFilter,
-    "RecoTauTwoProngFilter");
+DEFINE_EDM_PLUGIN(RecoTauModifierPluginFactory, reco::tau::RecoTauTwoProngFilter, "RecoTauTwoProngFilter");

--- a/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstCaloMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstCaloMuon.cc
@@ -48,264 +48,260 @@
 
 namespace {
 
-using namespace reco;
+  using namespace reco;
 
-// define acess to lead. track for CaloTaus
-template <typename T>
-class TauLeadTrackExtractor
-{
- public:
-  reco::TrackRef getLeadTrack(const T& tau) const
-  {
-    return tau.leadTrack();
-  }
-  double getTrackPtSum(const T& tau) const
-  {
-    double trackPtSum = 0.;
-    for ( TrackRefVector::const_iterator signalTrack = tau.signalTracks().begin();
-	  signalTrack != tau.signalTracks().end(); ++signalTrack ) {
-      trackPtSum += (*signalTrack)->pt();
+  // define acess to lead. track for CaloTaus
+  template <typename T>
+  class TauLeadTrackExtractor {
+  public:
+    reco::TrackRef getLeadTrack(const T& tau) const { return tau.leadTrack(); }
+    double getTrackPtSum(const T& tau) const {
+      double trackPtSum = 0.;
+      for (TrackRefVector::const_iterator signalTrack = tau.signalTracks().begin();
+           signalTrack != tau.signalTracks().end();
+           ++signalTrack) {
+        trackPtSum += (*signalTrack)->pt();
+      }
+      return trackPtSum;
     }
-    return trackPtSum;
-  }
-};
+  };
 
-// define acess to lead. track for PFTaus
-template <>
-class TauLeadTrackExtractor<reco::PFTau>
-{
- public:
-  reco::TrackRef getLeadTrack(const reco::PFTau& tau) const
-  {
-    return tau.leadPFChargedHadrCand()->trackRef();
-  }
-  double getTrackPtSum(const reco::PFTau& tau) const
-  {
-    double trackPtSum = 0.;
-    for ( std::vector<CandidatePtr>::const_iterator signalTrack = tau.signalChargedHadrCands().begin();
-	  signalTrack != tau.signalChargedHadrCands().end(); ++signalTrack ) {
-      trackPtSum += (*signalTrack)->pt();
+  // define acess to lead. track for PFTaus
+  template <>
+  class TauLeadTrackExtractor<reco::PFTau> {
+  public:
+    reco::TrackRef getLeadTrack(const reco::PFTau& tau) const { return tau.leadPFChargedHadrCand()->trackRef(); }
+    double getTrackPtSum(const reco::PFTau& tau) const {
+      double trackPtSum = 0.;
+      for (std::vector<CandidatePtr>::const_iterator signalTrack = tau.signalChargedHadrCands().begin();
+           signalTrack != tau.signalChargedHadrCands().end();
+           ++signalTrack) {
+        trackPtSum += (*signalTrack)->pt();
+      }
+      return trackPtSum;
     }
-    return trackPtSum;
-  }
-};
+  };
 
-template<class TauType, class TauDiscriminator>
-class TauDiscriminationAgainstCaloMuon final : public TauDiscriminationProducerBase<TauType, TauDiscriminator>
-{
- public:
-  // setup framework types for this tautype
-  typedef std::vector<TauType>    TauCollection; 
-  typedef edm::Ref<TauCollection> TauRef;    
+  template <class TauType, class TauDiscriminator>
+  class TauDiscriminationAgainstCaloMuon final : public TauDiscriminationProducerBase<TauType, TauDiscriminator> {
+  public:
+    // setup framework types for this tautype
+    typedef std::vector<TauType> TauCollection;
+    typedef edm::Ref<TauCollection> TauRef;
 
-  explicit TauDiscriminationAgainstCaloMuon(const edm::ParameterSet&);
-  ~TauDiscriminationAgainstCaloMuon() override {} 
+    explicit TauDiscriminationAgainstCaloMuon(const edm::ParameterSet&);
+    ~TauDiscriminationAgainstCaloMuon() override {}
 
-  // called at the beginning of every event
-  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+    // called at the beginning of every event
+    void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
-  double discriminate(const TauRef&) const override;
+    double discriminate(const TauRef&) const override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:  
-  edm::InputTag srcEcalRecHitsBarrel_;
-  edm::Handle<EcalRecHitCollection> ebRecHits_;
-  edm::InputTag srcEcalRecHitsEndcap_;
-  edm::Handle<EcalRecHitCollection> eeRecHits_;
-  edm::InputTag srcHcalRecHits_;
-  edm::Handle<HBHERecHitCollection> hbheRecHits_;
+  private:
+    edm::InputTag srcEcalRecHitsBarrel_;
+    edm::Handle<EcalRecHitCollection> ebRecHits_;
+    edm::InputTag srcEcalRecHitsEndcap_;
+    edm::Handle<EcalRecHitCollection> eeRecHits_;
+    edm::InputTag srcHcalRecHits_;
+    edm::Handle<HBHERecHitCollection> hbheRecHits_;
 
-  edm::InputTag srcVertex_;
-  GlobalPoint eventVertexPosition_;
+    edm::InputTag srcVertex_;
+    GlobalPoint eventVertexPosition_;
 
-  const TransientTrackBuilder* trackBuilder_;
-  const CaloGeometry* caloGeometry_;
+    const TransientTrackBuilder* trackBuilder_;
+    const CaloGeometry* caloGeometry_;
 
-  TauLeadTrackExtractor<TauType> leadTrackExtractor_;
+    TauLeadTrackExtractor<TauType> leadTrackExtractor_;
 
-  double minLeadTrackPt_;
-  double minLeadTrackPtFraction_;
+    double minLeadTrackPt_;
+    double minLeadTrackPtFraction_;
 
-  double drEcal_;
-  double drHcal_;
+    double drEcal_;
+    double drHcal_;
 
-  double maxEnEcal_;
-  double maxEnHcal_;
+    double maxEnEcal_;
+    double maxEnHcal_;
 
-  double maxEnToTrackRatio_;
-};
+    double maxEnToTrackRatio_;
+  };
 
-template<class TauType, class TauDiscriminator>
-TauDiscriminationAgainstCaloMuon<TauType, TauDiscriminator>::TauDiscriminationAgainstCaloMuon(const edm::ParameterSet& cfg)
-  : TauDiscriminationProducerBase<TauType, TauDiscriminator>(cfg) 
-{
-  srcEcalRecHitsBarrel_ = cfg.getParameter<edm::InputTag>("srcEcalRecHitsBarrel");
-  srcEcalRecHitsEndcap_ = cfg.getParameter<edm::InputTag>("srcEcalRecHitsEndcap");
-  srcHcalRecHits_ = cfg.getParameter<edm::InputTag>("srcHcalRecHits");
+  template <class TauType, class TauDiscriminator>
+  TauDiscriminationAgainstCaloMuon<TauType, TauDiscriminator>::TauDiscriminationAgainstCaloMuon(
+      const edm::ParameterSet& cfg)
+      : TauDiscriminationProducerBase<TauType, TauDiscriminator>(cfg) {
+    srcEcalRecHitsBarrel_ = cfg.getParameter<edm::InputTag>("srcEcalRecHitsBarrel");
+    srcEcalRecHitsEndcap_ = cfg.getParameter<edm::InputTag>("srcEcalRecHitsEndcap");
+    srcHcalRecHits_ = cfg.getParameter<edm::InputTag>("srcHcalRecHits");
 
-  srcVertex_ = cfg.getParameter<edm::InputTag>("srcVertex");
+    srcVertex_ = cfg.getParameter<edm::InputTag>("srcVertex");
 
-  minLeadTrackPt_ = cfg.getParameter<double>("minLeadTrackPt");
-  minLeadTrackPtFraction_ = cfg.getParameter<double>("minLeadTrackPtFraction");
+    minLeadTrackPt_ = cfg.getParameter<double>("minLeadTrackPt");
+    minLeadTrackPtFraction_ = cfg.getParameter<double>("minLeadTrackPtFraction");
 
-  drEcal_ = cfg.getParameter<double>("dRecal");
-  drHcal_ = cfg.getParameter<double>("dRhcal");
+    drEcal_ = cfg.getParameter<double>("dRecal");
+    drHcal_ = cfg.getParameter<double>("dRhcal");
 
-  maxEnEcal_ = cfg.getParameter<double>("maxEnEcal");
-  maxEnHcal_ = cfg.getParameter<double>("maxEnHcal");
+    maxEnEcal_ = cfg.getParameter<double>("maxEnEcal");
+    maxEnHcal_ = cfg.getParameter<double>("maxEnHcal");
 
-  maxEnToTrackRatio_ = cfg.getParameter<double>("maxEnToTrackRatio");
-}
-
-template<class TauType, class TauDiscriminator>
-void TauDiscriminationAgainstCaloMuon<TauType, TauDiscriminator>::beginEvent(const edm::Event& evt, const edm::EventSetup& evtSetup)
-{
-  evt.getByLabel(srcEcalRecHitsBarrel_, ebRecHits_);
-  evt.getByLabel(srcEcalRecHitsEndcap_, eeRecHits_);
-  evt.getByLabel(srcHcalRecHits_, hbheRecHits_);
-  
-  edm::ESHandle<TransientTrackBuilder> trackBuilderHandle;
-  evtSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilderHandle);
-  trackBuilder_ = trackBuilderHandle.product();
-  if ( !trackBuilder_ ) {
-    edm::LogError ("TauDiscriminationAgainstCaloMuon::discriminate")
-      << " Failed to access TransientTrackBuilder !!";
+    maxEnToTrackRatio_ = cfg.getParameter<double>("maxEnToTrackRatio");
   }
 
-  edm::ESHandle<CaloGeometry> caloGeometryHandle;
-  evtSetup.get<CaloGeometryRecord>().get(caloGeometryHandle);
-  caloGeometry_ = caloGeometryHandle.product();
-  if ( !caloGeometry_ ) {
-    edm::LogError ("TauDiscriminationAgainstCaloMuon::discriminate")
-      << " Failed to access CaloGeometry !!";
-  }
+  template <class TauType, class TauDiscriminator>
+  void TauDiscriminationAgainstCaloMuon<TauType, TauDiscriminator>::beginEvent(const edm::Event& evt,
+                                                                               const edm::EventSetup& evtSetup) {
+    evt.getByLabel(srcEcalRecHitsBarrel_, ebRecHits_);
+    evt.getByLabel(srcEcalRecHitsEndcap_, eeRecHits_);
+    evt.getByLabel(srcHcalRecHits_, hbheRecHits_);
 
-  edm::Handle<reco::VertexCollection> vertices;
-  evt.getByLabel(srcVertex_, vertices);
-  eventVertexPosition_ = GlobalPoint(0., 0., 0.);
-  if (!vertices->empty()) {
-    const reco::Vertex& thePrimaryEventVertex = (*vertices->begin());
-    eventVertexPosition_ = GlobalPoint(thePrimaryEventVertex.x(), thePrimaryEventVertex.y(), thePrimaryEventVertex.z());
-  }
-}		
-
-double compEcalEnergySum(const EcalRecHitCollection& ecalRecHits, 
-			 const CaloSubdetectorGeometry* detGeometry, 
-			 const reco::TransientTrack& transientTrack, double dR, 
-			 const GlobalPoint& eventVertexPosition)
-{
-  double ecalEnergySum = 0.;
-  for ( EcalRecHitCollection::const_iterator ecalRecHit = ecalRecHits.begin();
-	ecalRecHit != ecalRecHits.end(); ++ecalRecHit ) {
-    auto cellGeometry = detGeometry->getGeometry(ecalRecHit->detid());
-    
-    if ( !cellGeometry ) {
-      edm::LogError ("compEcalEnergySum") 
-	<< " Failed to access ECAL geometry for detId = " << ecalRecHit->detid().rawId()
-	<< " --> skipping !!";
-      continue;
+    edm::ESHandle<TransientTrackBuilder> trackBuilderHandle;
+    evtSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilderHandle);
+    trackBuilder_ = trackBuilderHandle.product();
+    if (!trackBuilder_) {
+      edm::LogError("TauDiscriminationAgainstCaloMuon::discriminate") << " Failed to access TransientTrackBuilder !!";
     }
 
-    const GlobalPoint& cellPosition = cellGeometry->getPosition();
-
-//--- CV: speed up computation by requiring eta-phi distance
-//        between cell position and track direction to be dR < 0.5
-    Vector3DBase<float, GlobalTag> cellPositionRelVertex = (cellPosition) - eventVertexPosition;
-    if ( deltaR(cellPositionRelVertex.eta(), cellPositionRelVertex.phi(), 
-		transientTrack.track().eta(), transientTrack.track().phi()) > 0.5 ) continue;
-
-    TrajectoryStateClosestToPoint dcaPosition = transientTrack.trajectoryStateClosestToPoint(cellPosition);
-    
-    Vector3DBase<float, GlobalTag> d = (cellPosition - dcaPosition.position());
-
-    TVector3 d3(d.x(), d.y(), d.z());
-    TVector3 dir(transientTrack.track().px(), transientTrack.track().py(), transientTrack.track().pz());
-
-    double dPerp = d3.Cross(dir.Unit()).Mag();
-    double dParl = TVector3(cellPosition.x(), cellPosition.y(), cellPosition.z()).Dot(dir.Unit());
-    
-    if ( dPerp < dR && dParl > 100. ) {
-      ecalEnergySum += ecalRecHit->energy();
+    edm::ESHandle<CaloGeometry> caloGeometryHandle;
+    evtSetup.get<CaloGeometryRecord>().get(caloGeometryHandle);
+    caloGeometry_ = caloGeometryHandle.product();
+    if (!caloGeometry_) {
+      edm::LogError("TauDiscriminationAgainstCaloMuon::discriminate") << " Failed to access CaloGeometry !!";
     }
-  }
-  
-  return ecalEnergySum;
-}
 
-double compHcalEnergySum(const HBHERecHitCollection& hcalRecHits, 
-			 const HcalGeometry* hcGeometry, 
-			 const reco::TransientTrack& transientTrack, double dR,
-			 const GlobalPoint& eventVertexPosition)
-{
-  double hcalEnergySum = 0.;
-  for ( HBHERecHitCollection::const_iterator hcalRecHit = hcalRecHits.begin();
-	hcalRecHit != hcalRecHits.end(); ++hcalRecHit ) {
-
-    const GlobalPoint cellPosition = hcGeometry->getPosition(hcalRecHit->detid());
-
-//--- CV: speed up computation by requiring eta-phi distance
-//        between cell position and track direction to be dR < 0.5
-    Vector3DBase<float, GlobalTag> cellPositionRelVertex = (cellPosition) - eventVertexPosition;
-    if ( deltaR(cellPositionRelVertex.eta(), cellPositionRelVertex.phi(), 
-		transientTrack.track().eta(), transientTrack.track().phi()) > 0.5 ) continue;
-
-    TrajectoryStateClosestToPoint dcaPosition = transientTrack.trajectoryStateClosestToPoint(cellPosition);
-    
-    Vector3DBase<float, GlobalTag> d = ((cellPosition) - dcaPosition.position());
-
-    TVector3 d3(d.x(), d.y(), d.z());
-    TVector3 dir(transientTrack.track().px(), transientTrack.track().py(), transientTrack.track().pz());
-
-    double dPerp = d3.Cross(dir.Unit()).Mag();
-    double dParl = TVector3(cellPosition.x(), cellPosition.y(), cellPosition.z()).Dot(dir.Unit());
-
-    if ( dPerp < dR && dParl > 100. ) {
-      hcalEnergySum += hcalRecHit->energy();
-    }
-  }
-  
-  return hcalEnergySum;
-}
-
-template<class TauType, class TauDiscriminator>
-double TauDiscriminationAgainstCaloMuon<TauType, TauDiscriminator>::discriminate(const TauRef& tau) const
-{
-  if ( !(trackBuilder_ && caloGeometry_) ) return 0.;
-
-  const CaloSubdetectorGeometry* ebGeometry = caloGeometry_->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-  const CaloSubdetectorGeometry* eeGeometry = caloGeometry_->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-  const HcalGeometry* hcGeometry = static_cast<const HcalGeometry*>(caloGeometry_->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
-
-  TrackRef leadTrackRef = leadTrackExtractor_.getLeadTrack(*tau);
-
-  if ( (leadTrackRef.isAvailable() || leadTrackRef.isTransient()) && leadTrackRef.isNonnull() ) {
-    double leadTrackPt = leadTrackRef->pt();
-    double trackPtSum = leadTrackExtractor_.getTrackPtSum(*tau);
-    
-    double leadTrackPtFraction = ( trackPtSum > 0. ) ? (leadTrackPt/trackPtSum) : -1.;
-    
-    if ( leadTrackPt > minLeadTrackPt_ && leadTrackPtFraction > minLeadTrackPtFraction_ ) {
-      reco::TransientTrack transientTrack = trackBuilder_->build(leadTrackRef);
-
-      double ebEnergySum = compEcalEnergySum(*ebRecHits_, ebGeometry, transientTrack, drEcal_, eventVertexPosition_);
-      double eeEnergySum = compEcalEnergySum(*eeRecHits_, eeGeometry, transientTrack, drEcal_, eventVertexPosition_);
-      double ecalEnergySum = ebEnergySum + eeEnergySum;
-      
-      double hbheEnergySum = compHcalEnergySum(*hbheRecHits_, hcGeometry, transientTrack, drHcal_, eventVertexPosition_);
-      
-      double caloEnergySum = ecalEnergySum + hbheEnergySum;
-
-      if ( ecalEnergySum <  maxEnEcal_ &&
-	   hbheEnergySum <  maxEnHcal_ &&
-	   caloEnergySum < (maxEnToTrackRatio_*leadTrackPt) ) return 0.;
+    edm::Handle<reco::VertexCollection> vertices;
+    evt.getByLabel(srcVertex_, vertices);
+    eventVertexPosition_ = GlobalPoint(0., 0., 0.);
+    if (!vertices->empty()) {
+      const reco::Vertex& thePrimaryEventVertex = (*vertices->begin());
+      eventVertexPosition_ =
+          GlobalPoint(thePrimaryEventVertex.x(), thePrimaryEventVertex.y(), thePrimaryEventVertex.z());
     }
   }
 
-  return 1.;
-}
+  double compEcalEnergySum(const EcalRecHitCollection& ecalRecHits,
+                           const CaloSubdetectorGeometry* detGeometry,
+                           const reco::TransientTrack& transientTrack,
+                           double dR,
+                           const GlobalPoint& eventVertexPosition) {
+    double ecalEnergySum = 0.;
+    for (EcalRecHitCollection::const_iterator ecalRecHit = ecalRecHits.begin(); ecalRecHit != ecalRecHits.end();
+         ++ecalRecHit) {
+      auto cellGeometry = detGeometry->getGeometry(ecalRecHit->detid());
 
-}
+      if (!cellGeometry) {
+        edm::LogError("compEcalEnergySum")
+            << " Failed to access ECAL geometry for detId = " << ecalRecHit->detid().rawId() << " --> skipping !!";
+        continue;
+      }
+
+      const GlobalPoint& cellPosition = cellGeometry->getPosition();
+
+      //--- CV: speed up computation by requiring eta-phi distance
+      //        between cell position and track direction to be dR < 0.5
+      Vector3DBase<float, GlobalTag> cellPositionRelVertex = (cellPosition)-eventVertexPosition;
+      if (deltaR(cellPositionRelVertex.eta(),
+                 cellPositionRelVertex.phi(),
+                 transientTrack.track().eta(),
+                 transientTrack.track().phi()) > 0.5)
+        continue;
+
+      TrajectoryStateClosestToPoint dcaPosition = transientTrack.trajectoryStateClosestToPoint(cellPosition);
+
+      Vector3DBase<float, GlobalTag> d = (cellPosition - dcaPosition.position());
+
+      TVector3 d3(d.x(), d.y(), d.z());
+      TVector3 dir(transientTrack.track().px(), transientTrack.track().py(), transientTrack.track().pz());
+
+      double dPerp = d3.Cross(dir.Unit()).Mag();
+      double dParl = TVector3(cellPosition.x(), cellPosition.y(), cellPosition.z()).Dot(dir.Unit());
+
+      if (dPerp < dR && dParl > 100.) {
+        ecalEnergySum += ecalRecHit->energy();
+      }
+    }
+
+    return ecalEnergySum;
+  }
+
+  double compHcalEnergySum(const HBHERecHitCollection& hcalRecHits,
+                           const HcalGeometry* hcGeometry,
+                           const reco::TransientTrack& transientTrack,
+                           double dR,
+                           const GlobalPoint& eventVertexPosition) {
+    double hcalEnergySum = 0.;
+    for (HBHERecHitCollection::const_iterator hcalRecHit = hcalRecHits.begin(); hcalRecHit != hcalRecHits.end();
+         ++hcalRecHit) {
+      const GlobalPoint cellPosition = hcGeometry->getPosition(hcalRecHit->detid());
+
+      //--- CV: speed up computation by requiring eta-phi distance
+      //        between cell position and track direction to be dR < 0.5
+      Vector3DBase<float, GlobalTag> cellPositionRelVertex = (cellPosition)-eventVertexPosition;
+      if (deltaR(cellPositionRelVertex.eta(),
+                 cellPositionRelVertex.phi(),
+                 transientTrack.track().eta(),
+                 transientTrack.track().phi()) > 0.5)
+        continue;
+
+      TrajectoryStateClosestToPoint dcaPosition = transientTrack.trajectoryStateClosestToPoint(cellPosition);
+
+      Vector3DBase<float, GlobalTag> d = ((cellPosition)-dcaPosition.position());
+
+      TVector3 d3(d.x(), d.y(), d.z());
+      TVector3 dir(transientTrack.track().px(), transientTrack.track().py(), transientTrack.track().pz());
+
+      double dPerp = d3.Cross(dir.Unit()).Mag();
+      double dParl = TVector3(cellPosition.x(), cellPosition.y(), cellPosition.z()).Dot(dir.Unit());
+
+      if (dPerp < dR && dParl > 100.) {
+        hcalEnergySum += hcalRecHit->energy();
+      }
+    }
+
+    return hcalEnergySum;
+  }
+
+  template <class TauType, class TauDiscriminator>
+  double TauDiscriminationAgainstCaloMuon<TauType, TauDiscriminator>::discriminate(const TauRef& tau) const {
+    if (!(trackBuilder_ && caloGeometry_))
+      return 0.;
+
+    const CaloSubdetectorGeometry* ebGeometry = caloGeometry_->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+    const CaloSubdetectorGeometry* eeGeometry = caloGeometry_->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
+    const HcalGeometry* hcGeometry =
+        static_cast<const HcalGeometry*>(caloGeometry_->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
+
+    TrackRef leadTrackRef = leadTrackExtractor_.getLeadTrack(*tau);
+
+    if ((leadTrackRef.isAvailable() || leadTrackRef.isTransient()) && leadTrackRef.isNonnull()) {
+      double leadTrackPt = leadTrackRef->pt();
+      double trackPtSum = leadTrackExtractor_.getTrackPtSum(*tau);
+
+      double leadTrackPtFraction = (trackPtSum > 0.) ? (leadTrackPt / trackPtSum) : -1.;
+
+      if (leadTrackPt > minLeadTrackPt_ && leadTrackPtFraction > minLeadTrackPtFraction_) {
+        reco::TransientTrack transientTrack = trackBuilder_->build(leadTrackRef);
+
+        double ebEnergySum = compEcalEnergySum(*ebRecHits_, ebGeometry, transientTrack, drEcal_, eventVertexPosition_);
+        double eeEnergySum = compEcalEnergySum(*eeRecHits_, eeGeometry, transientTrack, drEcal_, eventVertexPosition_);
+        double ecalEnergySum = ebEnergySum + eeEnergySum;
+
+        double hbheEnergySum =
+            compHcalEnergySum(*hbheRecHits_, hcGeometry, transientTrack, drHcal_, eventVertexPosition_);
+
+        double caloEnergySum = ecalEnergySum + hbheEnergySum;
+
+        if (ecalEnergySum < maxEnEcal_ && hbheEnergySum < maxEnHcal_ &&
+            caloEnergySum < (maxEnToTrackRatio_ * leadTrackPt))
+          return 0.;
+      }
+    }
+
+    return 1.;
+  }
+
+}  // namespace
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -313,9 +309,9 @@ typedef TauDiscriminationAgainstCaloMuon<PFTau, PFTauDiscriminator> PFRecoTauDis
 typedef TauDiscriminationAgainstCaloMuon<CaloTau, CaloTauDiscriminator> CaloRecoTauDiscriminationAgainstCaloMuon;
 
 // accordingly method for specific class
-template<>
-void
-TauDiscriminationAgainstCaloMuon<PFTau, PFTauDiscriminator>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+template <>
+void TauDiscriminationAgainstCaloMuon<PFTau, PFTauDiscriminator>::fillDescriptions(
+    edm::ConfigurationDescriptions& descriptions) {
   // pfRecoTauDiscriminationAgainstCaloMuon
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("srcHcalRecHits", edm::InputTag("hbhereco"));
@@ -323,7 +319,7 @@ TauDiscriminationAgainstCaloMuon<PFTau, PFTauDiscriminator>::fillDescriptions(ed
   desc.add<double>("maxEnToTrackRatio", 0.25);
   desc.add<edm::InputTag>("srcVertex", edm::InputTag("offlinePrimaryVertices"));
   desc.add<edm::InputTag>("PFTauProducer", edm::InputTag("pfRecoTauProducer"));
-  desc.add<edm::InputTag>("srcEcalRecHitsBarrel", edm::InputTag("ecalRecHit","EcalRecHitsEB"));
+  desc.add<edm::InputTag>("srcEcalRecHitsBarrel", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
   desc.add<double>("dRhcal", 25.0);
   {
     edm::ParameterSetDescription psd0;
@@ -338,15 +334,15 @@ TauDiscriminationAgainstCaloMuon<PFTau, PFTauDiscriminator>::fillDescriptions(ed
   }
   desc.add<double>("maxEnHcal", 8.0);
   desc.add<double>("dRecal", 15.0);
-  desc.add<edm::InputTag>("srcEcalRecHitsEndcap", edm::InputTag("ecalRecHit","EcalRecHitsEE"));
+  desc.add<edm::InputTag>("srcEcalRecHitsEndcap", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
   desc.add<double>("minLeadTrackPtFraction", 0.8);
   desc.add<double>("maxEnEcal", 3.0);
   descriptions.add("pfRecoTauDiscriminationAgainstCaloMuon", desc);
 }
 
-template<>
-void
-TauDiscriminationAgainstCaloMuon<CaloTau, CaloTauDiscriminator>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+template <>
+void TauDiscriminationAgainstCaloMuon<CaloTau, CaloTauDiscriminator>::fillDescriptions(
+    edm::ConfigurationDescriptions& descriptions) {
   // there was no cfi file for this plugin
 }
 

--- a/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstMuon.cc
@@ -22,113 +22,121 @@
 #include <string>
 
 namespace {
-using namespace reco;
+  using namespace reco;
 
-template<class TauType, class TauDiscriminator>
-class TauDiscriminationAgainstMuon final : public TauDiscriminationProducerBase<TauType, TauDiscriminator>
-{
- public:
-  // setup framework types for this tautype
-  typedef std::vector<TauType>    TauCollection; 
-  typedef edm::Ref<TauCollection> TauRef;    
+  template <class TauType, class TauDiscriminator>
+  class TauDiscriminationAgainstMuon final : public TauDiscriminationProducerBase<TauType, TauDiscriminator> {
+  public:
+    // setup framework types for this tautype
+    typedef std::vector<TauType> TauCollection;
+    typedef edm::Ref<TauCollection> TauRef;
 
-  explicit TauDiscriminationAgainstMuon(const edm::ParameterSet&);
-  ~TauDiscriminationAgainstMuon() override {} 
+    explicit TauDiscriminationAgainstMuon(const edm::ParameterSet&);
+    ~TauDiscriminationAgainstMuon() override {}
 
-  // called at the beginning of every event
-  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+    // called at the beginning of every event
+    void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
-  double discriminate(const TauRef&) const override;
+    double discriminate(const TauRef&) const override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:  
-  bool evaluateMuonVeto(const reco::Muon&) const;
+  private:
+    bool evaluateMuonVeto(const reco::Muon&) const;
 
-  edm::InputTag muonSource_;
-  edm::Handle<reco::MuonCollection> muons_;
-  double dRmatch_;
+    edm::InputTag muonSource_;
+    edm::Handle<reco::MuonCollection> muons_;
+    double dRmatch_;
 
-  enum { kNoSegMatch, kTwoDCut, kMerePresence, kCombined };
-  int discriminatorOption_;
+    enum { kNoSegMatch, kTwoDCut, kMerePresence, kCombined };
+    int discriminatorOption_;
 
-  double coeffCaloComp_;
-  double coeffSegmComp_;
-  double muonCompCut_;
-};
+    double coeffCaloComp_;
+    double coeffSegmComp_;
+    double muonCompCut_;
+  };
 
-template<class TauType, class TauDiscriminator>
-TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::TauDiscriminationAgainstMuon(const edm::ParameterSet& cfg)
-  : TauDiscriminationProducerBase<TauType, TauDiscriminator>(cfg) 
-{
-  muonSource_ = cfg.getParameter<edm::InputTag>("muonSource");
-  dRmatch_ = cfg.getParameter<double>("dRmatch");
+  template <class TauType, class TauDiscriminator>
+  TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::TauDiscriminationAgainstMuon(const edm::ParameterSet& cfg)
+      : TauDiscriminationProducerBase<TauType, TauDiscriminator>(cfg) {
+    muonSource_ = cfg.getParameter<edm::InputTag>("muonSource");
+    dRmatch_ = cfg.getParameter<double>("dRmatch");
 
-  std::string discriminatorOption_string = cfg.getParameter<std::string>("discriminatorOption");  
-  if      ( discriminatorOption_string == "noSegMatch"   ) discriminatorOption_ = kNoSegMatch;
-  else if ( discriminatorOption_string == "twoDCut"      ) discriminatorOption_ = kTwoDCut;
-  else if ( discriminatorOption_string == "merePresence" ) discriminatorOption_ = kMerePresence;
-  else if ( discriminatorOption_string == "combined"     ) discriminatorOption_ = kCombined;
-  else {
-    throw edm::Exception(edm::errors::UnimplementedFeature) << " Invalid Discriminator Option! Please check cfi file \n";
+    std::string discriminatorOption_string = cfg.getParameter<std::string>("discriminatorOption");
+    if (discriminatorOption_string == "noSegMatch")
+      discriminatorOption_ = kNoSegMatch;
+    else if (discriminatorOption_string == "twoDCut")
+      discriminatorOption_ = kTwoDCut;
+    else if (discriminatorOption_string == "merePresence")
+      discriminatorOption_ = kMerePresence;
+    else if (discriminatorOption_string == "combined")
+      discriminatorOption_ = kCombined;
+    else {
+      throw edm::Exception(edm::errors::UnimplementedFeature)
+          << " Invalid Discriminator Option! Please check cfi file \n";
+    }
+
+    coeffCaloComp_ = cfg.getParameter<double>("caloCompCoefficient");
+    coeffSegmComp_ = cfg.getParameter<double>("segmCompCoefficient");
+    muonCompCut_ = cfg.getParameter<double>("muonCompCut");
   }
 
-  coeffCaloComp_ = cfg.getParameter<double>("caloCompCoefficient");
-  coeffSegmComp_ = cfg.getParameter<double>("segmCompCoefficient");
-  muonCompCut_ = cfg.getParameter<double>("muonCompCut");
-}
-
-template<class TauType, class TauDiscriminator>
-void TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::beginEvent(const edm::Event& evt, const edm::EventSetup& evtSetup)
-{
-  evt.getByLabel(muonSource_, muons_);	
-}		
-
-template<class TauType, class TauDiscriminator>
-bool TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::evaluateMuonVeto(const reco::Muon& muon) const 
-{
-  bool decision = true;	
-
-  if ( discriminatorOption_ == kNoSegMatch ) {
-    if ( muon.numberOfMatches() > 0 ) decision = false;
-  } else if ( discriminatorOption_ == kTwoDCut ) {
-    double segmComp = muon::segmentCompatibility(muon);
-    double caloComp = muon.caloCompatibility(); 
-    if ( (coeffCaloComp_*segmComp + coeffSegmComp_*caloComp) > muonCompCut_ ) decision = false;
-  } else if ( discriminatorOption_ == kMerePresence ) {
-    decision = false;
-  } else if ( discriminatorOption_ == kCombined ) { // testing purpose only
-    unsigned int muonType = 0;
-    if      ( muon.isGlobalMuon()  ) muonType = 1;
-    else if ( muon.isCaloMuon()    ) muonType = 2;
-    else if ( muon.isTrackerMuon() ) muonType = 3;
-
-    bool eta_veto = ( fabs(muon.eta()) > 2.3 || (fabs(muon.eta()) > 1.4 && fabs(muon.eta()) < 1.6) ) ? true : false;
-    bool phi_veto = ( muon.phi() < 0.1 && muon.phi() > -0.1 ) ? true : false;
-
-    if ( muonType != 1 || muon.numberOfMatches() > 0 || eta_veto || phi_veto ) decision = false;
+  template <class TauType, class TauDiscriminator>
+  void TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::beginEvent(const edm::Event& evt,
+                                                                           const edm::EventSetup& evtSetup) {
+    evt.getByLabel(muonSource_, muons_);
   }
 
-  return decision;
-}
+  template <class TauType, class TauDiscriminator>
+  bool TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::evaluateMuonVeto(const reco::Muon& muon) const {
+    bool decision = true;
 
-template<class TauType, class TauDiscriminator>
-double TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::discriminate(const TauRef& tau) const 
-{
-  bool decision = true;	
+    if (discriminatorOption_ == kNoSegMatch) {
+      if (muon.numberOfMatches() > 0)
+        decision = false;
+    } else if (discriminatorOption_ == kTwoDCut) {
+      double segmComp = muon::segmentCompatibility(muon);
+      double caloComp = muon.caloCompatibility();
+      if ((coeffCaloComp_ * segmComp + coeffSegmComp_ * caloComp) > muonCompCut_)
+        decision = false;
+    } else if (discriminatorOption_ == kMerePresence) {
+      decision = false;
+    } else if (discriminatorOption_ == kCombined) {  // testing purpose only
+      unsigned int muonType = 0;
+      if (muon.isGlobalMuon())
+        muonType = 1;
+      else if (muon.isCaloMuon())
+        muonType = 2;
+      else if (muon.isTrackerMuon())
+        muonType = 3;
 
-  for ( reco::MuonCollection::const_iterator muon = muons_->begin();
-	muon != muons_->end(); ++muon ) {
-    if ( reco::deltaR(muon->p4(), tau->p4()) < dRmatch_ ) decision &= evaluateMuonVeto(*muon);
+      bool eta_veto = (fabs(muon.eta()) > 2.3 || (fabs(muon.eta()) > 1.4 && fabs(muon.eta()) < 1.6)) ? true : false;
+      bool phi_veto = (muon.phi() < 0.1 && muon.phi() > -0.1) ? true : false;
+
+      if (muonType != 1 || muon.numberOfMatches() > 0 || eta_veto || phi_veto)
+        decision = false;
+    }
+
+    return decision;
   }
 
-  return (decision ? 1. : 0.);
-}
-}
+  template <class TauType, class TauDiscriminator>
+  double TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::discriminate(const TauRef& tau) const {
+    bool decision = true;
 
-template<class TauType, class TauDiscriminator>
-void TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-//CaloRecoTauDiscriminationAgainstMuon::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    for (reco::MuonCollection::const_iterator muon = muons_->begin(); muon != muons_->end(); ++muon) {
+      if (reco::deltaR(muon->p4(), tau->p4()) < dRmatch_)
+        decision &= evaluateMuonVeto(*muon);
+    }
+
+    return (decision ? 1. : 0.);
+  }
+}  // namespace
+
+template <class TauType, class TauDiscriminator>
+void TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::fillDescriptions(
+    edm::ConfigurationDescriptions& descriptions) {
+  //CaloRecoTauDiscriminationAgainstMuon::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // caloRecoTauDiscriminationAgainstMuon
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("CaloTauProducer", edm::InputTag("caloRecoTauProducer"));

--- a/RecoTauTag/RecoTau/src/AntiElectronIDCut2.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDCut2.cc
@@ -8,157 +8,140 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include <TMath.h>
 
-AntiElectronIDCut2::AntiElectronIDCut2()
-{
-  //default, keep all taus in cracks for HLT 
+AntiElectronIDCut2::AntiElectronIDCut2() {
+  //default, keep all taus in cracks for HLT
   keepAllInEcalCrack_ = true;
   rejectAllInEcalCrack_ = false;
 
   //Default Cuts to be applied
-  Tau_applyCut_hcal3x3OverPLead_ = true; 
-  Tau_applyCut_leadPFChargedHadrEoP_ = true; 
-  Tau_applyCut_GammaEtaMom_ = true; 
-  Tau_applyCut_GammaPhiMom_ = false; 
-  Tau_applyCut_GammaEnFrac_ = false; 
-  Tau_applyCut_HLTSpecific_ = true; 
+  Tau_applyCut_hcal3x3OverPLead_ = true;
+  Tau_applyCut_leadPFChargedHadrEoP_ = true;
+  Tau_applyCut_GammaEtaMom_ = true;
+  Tau_applyCut_GammaPhiMom_ = false;
+  Tau_applyCut_GammaEnFrac_ = false;
+  Tau_applyCut_HLTSpecific_ = true;
 
   verbosity_ = 0;
-
 }
 
-AntiElectronIDCut2::~AntiElectronIDCut2()
-{}
+AntiElectronIDCut2::~AntiElectronIDCut2() {}
 
-double
-AntiElectronIDCut2::Discriminator(float TauPt,
-                                  float TauEta,
-                                  float TauLeadChargedPFCandPt,
-                                  float TauLeadChargedPFCandEtaAtEcalEntrance,
-                                  float TauLeadPFChargedHadrEoP,
-                                  float TauHcal3x3OverPLead,
-				  float TauGammaEtaMom,
-				  float TauGammaPhiMom,
-				  float TauGammaEnFrac)
-{
-
-  if(verbosity_){  
-    std::cout<<"Tau GammaEnFrac "<<TauGammaEnFrac<<std::endl;  
-    std::cout<<"Tau GammaEtaMom "<<TauGammaEtaMom<<std::endl;  
-    std::cout<<"Tau GammaPhiMom "<<TauGammaPhiMom<<std::endl;  
-    std::cout<<"Tau Hcal3x3OverPLead "<<TauHcal3x3OverPLead<<std::endl;
-    std::cout<<"Tau LeadPFChargedHadrEoP "<<TauLeadPFChargedHadrEoP<<std::endl;
-    std::cout<<"Tau LeadChargedPFCandEtaAtEcalEntrance "<<TauLeadChargedPFCandEtaAtEcalEntrance<<std::endl;
-    std::cout<<"Tau LeadChargedPFCandPt "<<TauLeadChargedPFCandPt<<std::endl;
-    std::cout<<"Tau Eta "<<TauEta<<std::endl;
-    std::cout<<"Tau Pt "<<TauPt<<std::endl;
+double AntiElectronIDCut2::Discriminator(float TauPt,
+                                         float TauEta,
+                                         float TauLeadChargedPFCandPt,
+                                         float TauLeadChargedPFCandEtaAtEcalEntrance,
+                                         float TauLeadPFChargedHadrEoP,
+                                         float TauHcal3x3OverPLead,
+                                         float TauGammaEtaMom,
+                                         float TauGammaPhiMom,
+                                         float TauGammaEnFrac) {
+  if (verbosity_) {
+    std::cout << "Tau GammaEnFrac " << TauGammaEnFrac << std::endl;
+    std::cout << "Tau GammaEtaMom " << TauGammaEtaMom << std::endl;
+    std::cout << "Tau GammaPhiMom " << TauGammaPhiMom << std::endl;
+    std::cout << "Tau Hcal3x3OverPLead " << TauHcal3x3OverPLead << std::endl;
+    std::cout << "Tau LeadPFChargedHadrEoP " << TauLeadPFChargedHadrEoP << std::endl;
+    std::cout << "Tau LeadChargedPFCandEtaAtEcalEntrance " << TauLeadChargedPFCandEtaAtEcalEntrance << std::endl;
+    std::cout << "Tau LeadChargedPFCandPt " << TauLeadChargedPFCandPt << std::endl;
+    std::cout << "Tau Eta " << TauEta << std::endl;
+    std::cout << "Tau Pt " << TauPt << std::endl;
   }
-  
+
   // ensure tau has at least one charged object
-  if( TauLeadChargedPFCandPt <= 0 )
-    {
-      return 0.;
-    }
-  else {
+  if (TauLeadChargedPFCandPt <= 0) {
+    return 0.;
+  } else {
     // Check if track goes to Ecal Crack
-    if(isInEcalCrack(TauLeadChargedPFCandEtaAtEcalEntrance))
-      {
-	if(keepAllInEcalCrack_)
-	  return 1.0;
-	else if(rejectAllInEcalCrack_)
-	  return 0.;
-      }
+    if (isInEcalCrack(TauLeadChargedPFCandEtaAtEcalEntrance)) {
+      if (keepAllInEcalCrack_)
+        return 1.0;
+      else if (rejectAllInEcalCrack_)
+        return 0.;
+    }
   }
-  
+
   bool decision = false;
   //Apply separate cuts for barrel and endcap
-  if(TMath::Abs(TauEta) < 1.479)
-    {
-      
-      //Apply cut for barrel
-      if(Tau_applyCut_GammaEnFrac_ && TauGammaEnFrac > TauGammaEnFrac_barrel_max_)  
-        decision = true;
+  if (TMath::Abs(TauEta) < 1.479) {
+    //Apply cut for barrel
+    if (Tau_applyCut_GammaEnFrac_ && TauGammaEnFrac > TauGammaEnFrac_barrel_max_)
+      decision = true;
 
-      if(Tau_applyCut_GammaPhiMom_ && TauGammaPhiMom > TauGammaPhiMom_barrel_max_) 
-        decision = true;
+    if (Tau_applyCut_GammaPhiMom_ && TauGammaPhiMom > TauGammaPhiMom_barrel_max_)
+      decision = true;
 
-      if(Tau_applyCut_GammaEtaMom_ && TauGammaEtaMom > TauGammaEtaMom_barrel_max_)
-	decision = true;
+    if (Tau_applyCut_GammaEtaMom_ && TauGammaEtaMom > TauGammaEtaMom_barrel_max_)
+      decision = true;
 
-      if(Tau_applyCut_hcal3x3OverPLead_ && TauHcal3x3OverPLead > TauHcal3x3OverPLead_barrel_max_)
-	decision = true;
+    if (Tau_applyCut_hcal3x3OverPLead_ && TauHcal3x3OverPLead > TauHcal3x3OverPLead_barrel_max_)
+      decision = true;
 
-      if(Tau_applyCut_leadPFChargedHadrEoP_ &&
-	 (TauLeadPFChargedHadrEoP < TauLeadPFChargedHadrEoP_barrel_min_ ||
-	  TauLeadPFChargedHadrEoP > TauLeadPFChargedHadrEoP_barrel_max_)) 
-	decision = true;
-    }
-  else {
-    
+    if (Tau_applyCut_leadPFChargedHadrEoP_ && (TauLeadPFChargedHadrEoP < TauLeadPFChargedHadrEoP_barrel_min_ ||
+                                               TauLeadPFChargedHadrEoP > TauLeadPFChargedHadrEoP_barrel_max_))
+      decision = true;
+  } else {
     //Apply cut for endcap
-    if(Tau_applyCut_GammaEnFrac_ && TauGammaEnFrac > TauGammaEnFrac_endcap_max_)   
-      decision = true; 
- 
-    if(Tau_applyCut_GammaPhiMom_ && TauGammaPhiMom > TauGammaPhiMom_endcap_max_)  
-      decision = true;
-    
-    if(Tau_applyCut_GammaEtaMom_ && TauGammaEtaMom > TauGammaEtaMom_endcap_max_)
+    if (Tau_applyCut_GammaEnFrac_ && TauGammaEnFrac > TauGammaEnFrac_endcap_max_)
       decision = true;
 
-    //This cut is for both offline and HLT. For offline, use cut 0.99-1.01, 
+    if (Tau_applyCut_GammaPhiMom_ && TauGammaPhiMom > TauGammaPhiMom_endcap_max_)
+      decision = true;
+
+    if (Tau_applyCut_GammaEtaMom_ && TauGammaEtaMom > TauGammaEtaMom_endcap_max_)
+      decision = true;
+
+    //This cut is for both offline and HLT. For offline, use cut 0.99-1.01,
     //For HLT use cut 0.7-1.3
-    if(Tau_applyCut_leadPFChargedHadrEoP_ &&
-       (TauLeadPFChargedHadrEoP < TauLeadPFChargedHadrEoP_endcap_min1_ ||
-	TauLeadPFChargedHadrEoP > TauLeadPFChargedHadrEoP_endcap_max1_)) 
+    if (Tau_applyCut_leadPFChargedHadrEoP_ && (TauLeadPFChargedHadrEoP < TauLeadPFChargedHadrEoP_endcap_min1_ ||
+                                               TauLeadPFChargedHadrEoP > TauLeadPFChargedHadrEoP_endcap_max1_))
       decision = true;
 
     //This cut is only for HLT. For HLT, use cut like 0.99-1.01 & H3x3/P>0.1
-    //For offline, keep the values same as above : 0.99-1.01 & H3x3/P>0, otherwise it may select events in a wrong way. 
-    if(Tau_applyCut_HLTSpecific_ && 
-       (TauLeadPFChargedHadrEoP < TauLeadPFChargedHadrEoP_endcap_min2_ || 
-	TauLeadPFChargedHadrEoP > TauLeadPFChargedHadrEoP_endcap_max2_) &&
-       TauHcal3x3OverPLead > TauHcal3x3OverPLead_endcap_max_)
+    //For offline, keep the values same as above : 0.99-1.01 & H3x3/P>0, otherwise it may select events in a wrong way.
+    if (Tau_applyCut_HLTSpecific_ &&
+        (TauLeadPFChargedHadrEoP < TauLeadPFChargedHadrEoP_endcap_min2_ ||
+         TauLeadPFChargedHadrEoP > TauLeadPFChargedHadrEoP_endcap_max2_) &&
+        TauHcal3x3OverPLead > TauHcal3x3OverPLead_endcap_max_)
       decision = true;
   }
 
   return (decision ? 1. : 0.);
-}  
+}
 
-double
-AntiElectronIDCut2::Discriminator(float TauPt,
-				  float TauEta,
-				  float TauLeadChargedPFCandPt,
-				  float TauLeadChargedPFCandEtaAtEcalEntrance,
-				  float TauLeadPFChargedHadrEoP,
-				  float TauHcal3x3OverPLead,
-				  const std::vector<float>& GammasdEta,
-				  const std::vector<float>& GammasdPhi,
-				  const std::vector<float>& GammasPt
-				  )
-{
-
-  double sumPt  = 0.;
-  double dEta2  = 0.;
-  double dPhi2  = 0.;
-  for ( unsigned int i = 0 ; i < GammasPt.size() ; ++i ) {
-    double pt_i  = GammasPt[i];
+double AntiElectronIDCut2::Discriminator(float TauPt,
+                                         float TauEta,
+                                         float TauLeadChargedPFCandPt,
+                                         float TauLeadChargedPFCandEtaAtEcalEntrance,
+                                         float TauLeadPFChargedHadrEoP,
+                                         float TauHcal3x3OverPLead,
+                                         const std::vector<float>& GammasdEta,
+                                         const std::vector<float>& GammasdPhi,
+                                         const std::vector<float>& GammasPt) {
+  double sumPt = 0.;
+  double dEta2 = 0.;
+  double dPhi2 = 0.;
+  for (unsigned int i = 0; i < GammasPt.size(); ++i) {
+    double pt_i = GammasPt[i];
     double phi_i = GammasdPhi[i];
-    if ( GammasdPhi[i] > TMath::Pi() ) phi_i = GammasdPhi[i] - 2*TMath::Pi();
-    else if ( GammasdPhi[i] < -TMath::Pi() ) phi_i = GammasdPhi[i] + 2*TMath::Pi();
+    if (GammasdPhi[i] > TMath::Pi())
+      phi_i = GammasdPhi[i] - 2 * TMath::Pi();
+    else if (GammasdPhi[i] < -TMath::Pi())
+      phi_i = GammasdPhi[i] + 2 * TMath::Pi();
     double eta_i = GammasdEta[i];
-    sumPt  +=  pt_i;
-    dEta2  += (pt_i*eta_i*eta_i);
-    dPhi2  += (pt_i*phi_i*phi_i);
+    sumPt += pt_i;
+    dEta2 += (pt_i * eta_i * eta_i);
+    dPhi2 += (pt_i * phi_i * phi_i);
   }
 
-  float TauGammaEnFrac = sumPt/TauPt;
+  float TauGammaEnFrac = sumPt / TauPt;
 
-  if ( sumPt > 0. ) {
+  if (sumPt > 0.) {
     dEta2 /= sumPt;
     dPhi2 /= sumPt;
   }
 
-  float TauGammaEtaMom = TMath::Sqrt(dEta2)*TMath::Sqrt(TauGammaEnFrac)*TauPt;
-  float TauGammaPhiMom = TMath::Sqrt(dPhi2)*TMath::Sqrt(TauGammaEnFrac)*TauPt;
+  float TauGammaEtaMom = TMath::Sqrt(dEta2) * TMath::Sqrt(TauGammaEnFrac) * TauPt;
+  float TauGammaPhiMom = TMath::Sqrt(dPhi2) * TMath::Sqrt(TauGammaEnFrac) * TauPt;
 
   return Discriminator(TauPt,
                        TauEta,
@@ -168,19 +151,15 @@ AntiElectronIDCut2::Discriminator(float TauPt,
                        TauHcal3x3OverPLead,
                        TauGammaEtaMom,
                        TauGammaPhiMom,
-		       TauGammaEnFrac
-		       );
+                       TauGammaEnFrac);
 }
 
-void 
-AntiElectronIDCut2::SetBarrelCutValues(float TauLeadPFChargedHadrEoP_min,
-				       float TauLeadPFChargedHadrEoP_max,
-				       float TauHcal3x3OverPLead_max,
-				       float TauGammaEtaMom_max,
-				       float TauGammaPhiMom_max,
-				       float TauGammaEnFrac_max
-				       )
-{
+void AntiElectronIDCut2::SetBarrelCutValues(float TauLeadPFChargedHadrEoP_min,
+                                            float TauLeadPFChargedHadrEoP_max,
+                                            float TauHcal3x3OverPLead_max,
+                                            float TauGammaEtaMom_max,
+                                            float TauGammaPhiMom_max,
+                                            float TauGammaEnFrac_max) {
   TauLeadPFChargedHadrEoP_barrel_min_ = TauLeadPFChargedHadrEoP_min;
   TauLeadPFChargedHadrEoP_barrel_max_ = TauLeadPFChargedHadrEoP_max;
   TauHcal3x3OverPLead_barrel_max_ = TauHcal3x3OverPLead_max;
@@ -189,17 +168,14 @@ AntiElectronIDCut2::SetBarrelCutValues(float TauLeadPFChargedHadrEoP_min,
   TauGammaEnFrac_barrel_max_ = TauGammaEnFrac_max;
 }
 
-void 
-AntiElectronIDCut2::SetEndcapCutValues(float TauLeadPFChargedHadrEoP_min_1,
-				       float TauLeadPFChargedHadrEoP_max_1,
-				       float TauLeadPFChargedHadrEoP_min_2,
-				       float TauLeadPFChargedHadrEoP_max_2,
-				       float TauHcal3x3OverPLead_max,
-				       float TauGammaEtaMom_max,
-				       float TauGammaPhiMom_max,
-				       float TauGammaEnFrac_max
-				       )
-{
+void AntiElectronIDCut2::SetEndcapCutValues(float TauLeadPFChargedHadrEoP_min_1,
+                                            float TauLeadPFChargedHadrEoP_max_1,
+                                            float TauLeadPFChargedHadrEoP_min_2,
+                                            float TauLeadPFChargedHadrEoP_max_2,
+                                            float TauHcal3x3OverPLead_max,
+                                            float TauGammaEtaMom_max,
+                                            float TauGammaPhiMom_max,
+                                            float TauGammaEnFrac_max) {
   TauLeadPFChargedHadrEoP_endcap_min1_ = TauLeadPFChargedHadrEoP_min_1;
   TauLeadPFChargedHadrEoP_endcap_max1_ = TauLeadPFChargedHadrEoP_max_1;
   TauLeadPFChargedHadrEoP_endcap_min2_ = TauLeadPFChargedHadrEoP_min_2;
@@ -210,34 +186,27 @@ AntiElectronIDCut2::SetEndcapCutValues(float TauLeadPFChargedHadrEoP_min_1,
   TauGammaEnFrac_endcap_max_ = TauGammaEnFrac_max;
 }
 
-void
-AntiElectronIDCut2::ApplyCuts(bool applyCut_hcal3x3OverPLead,  
-			      bool applyCut_leadPFChargedHadrEoP,  
-			      bool applyCut_GammaEtaMom,  
-			      bool applyCut_GammaPhiMom,  
-			      bool applyCut_GammaEnFrac,  
-			      bool applyCut_HLTSpecific 
-			      )
-{
-  Tau_applyCut_hcal3x3OverPLead_ = applyCut_hcal3x3OverPLead; 
-  Tau_applyCut_leadPFChargedHadrEoP_ = applyCut_leadPFChargedHadrEoP; 
-  Tau_applyCut_GammaEtaMom_ = applyCut_GammaEtaMom; 
-  Tau_applyCut_GammaPhiMom_ = applyCut_GammaPhiMom; 
-  Tau_applyCut_GammaEnFrac_ = applyCut_GammaEnFrac; 
-  Tau_applyCut_HLTSpecific_ = applyCut_HLTSpecific; 
+void AntiElectronIDCut2::ApplyCuts(bool applyCut_hcal3x3OverPLead,
+                                   bool applyCut_leadPFChargedHadrEoP,
+                                   bool applyCut_GammaEtaMom,
+                                   bool applyCut_GammaPhiMom,
+                                   bool applyCut_GammaEnFrac,
+                                   bool applyCut_HLTSpecific) {
+  Tau_applyCut_hcal3x3OverPLead_ = applyCut_hcal3x3OverPLead;
+  Tau_applyCut_leadPFChargedHadrEoP_ = applyCut_leadPFChargedHadrEoP;
+  Tau_applyCut_GammaEtaMom_ = applyCut_GammaEtaMom;
+  Tau_applyCut_GammaPhiMom_ = applyCut_GammaPhiMom;
+  Tau_applyCut_GammaEnFrac_ = applyCut_GammaEnFrac;
+  Tau_applyCut_HLTSpecific_ = applyCut_HLTSpecific;
 }
 
-bool
-AntiElectronIDCut2::isInEcalCrack(double eta) const
-{
+bool AntiElectronIDCut2::isInEcalCrack(double eta) const {
   bool in_ecal_crack = false;
 
   eta = fabs(eta);
-  for(std::vector<pdouble>::const_iterator etaCrack = ecalCracks_.begin(); 
-      etaCrack != ecalCracks_.end(); ++etaCrack)
-    if(eta >= etaCrack->first && eta < etaCrack->second)
+  for (std::vector<pdouble>::const_iterator etaCrack = ecalCracks_.begin(); etaCrack != ecalCracks_.end(); ++etaCrack)
+    if (eta >= etaCrack->first && eta < etaCrack->second)
       in_ecal_crack = true;
-  
+
   return in_ecal_crack;
 }
-

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
@@ -19,22 +19,22 @@
 #include <array>
 
 AntiElectronIDMVA6::AntiElectronIDMVA6(const edm::ParameterSet& cfg)
-  : isInitialized_(false),
-    mva_NoEleMatch_woGwoGSF_BL_(nullptr),
-    mva_NoEleMatch_wGwoGSF_BL_(nullptr),
-    mva_woGwGSF_BL_(nullptr),
-    mva_wGwGSF_BL_(nullptr),
-    mva_NoEleMatch_woGwoGSF_EC_(nullptr),
-    mva_NoEleMatch_wGwoGSF_EC_(nullptr),
-    mva_woGwGSF_EC_(nullptr),
-    mva_wGwGSF_EC_(nullptr)   
-{
-  loadMVAfromDB_ = cfg.exists("loadMVAfromDB") ? cfg.getParameter<bool>("loadMVAfromDB"): false;
-  if ( !loadMVAfromDB_ ) {
-    if(cfg.exists("inputFileName")){
+    : isInitialized_(false),
+      mva_NoEleMatch_woGwoGSF_BL_(nullptr),
+      mva_NoEleMatch_wGwoGSF_BL_(nullptr),
+      mva_woGwGSF_BL_(nullptr),
+      mva_wGwGSF_BL_(nullptr),
+      mva_NoEleMatch_woGwoGSF_EC_(nullptr),
+      mva_NoEleMatch_wGwoGSF_EC_(nullptr),
+      mva_woGwGSF_EC_(nullptr),
+      mva_wGwGSF_EC_(nullptr) {
+  loadMVAfromDB_ = cfg.exists("loadMVAfromDB") ? cfg.getParameter<bool>("loadMVAfromDB") : false;
+  if (!loadMVAfromDB_) {
+    if (cfg.exists("inputFileName")) {
       inputFileName_ = cfg.getParameter<edm::FileInPath>("inputFileName");
-    }else throw cms::Exception("MVA input not defined") << "Requested to load tau MVA input from ROOT file but no file provided in cfg file";
-    
+    } else
+      throw cms::Exception("MVA input not defined")
+          << "Requested to load tau MVA input from ROOT file but no file provided in cfg file";
   }
 
   mvaName_NoEleMatch_woGwoGSF_BL_ = cfg.getParameter<std::string>("mvaName_NoEleMatch_woGwoGSF_BL");
@@ -61,18 +61,17 @@ AntiElectronIDMVA6::AntiElectronIDMVA6(const edm::ParameterSet& cfg)
   verbosity_ = 0;
 }
 
-AntiElectronIDMVA6::~AntiElectronIDMVA6()
-{
-  delete [] Var_NoEleMatch_woGwoGSF_Barrel_;
-  delete [] Var_NoEleMatch_wGwoGSF_Barrel_;
-  delete [] Var_woGwGSF_Barrel_;
-  delete [] Var_wGwGSF_Barrel_;
-  delete [] Var_NoEleMatch_woGwoGSF_Endcap_;
-  delete [] Var_NoEleMatch_wGwoGSF_Endcap_;
-  delete [] Var_woGwGSF_Endcap_;
-  delete [] Var_wGwGSF_Endcap_;
+AntiElectronIDMVA6::~AntiElectronIDMVA6() {
+  delete[] Var_NoEleMatch_woGwoGSF_Barrel_;
+  delete[] Var_NoEleMatch_wGwoGSF_Barrel_;
+  delete[] Var_woGwGSF_Barrel_;
+  delete[] Var_wGwGSF_Barrel_;
+  delete[] Var_NoEleMatch_woGwoGSF_Endcap_;
+  delete[] Var_NoEleMatch_wGwoGSF_Endcap_;
+  delete[] Var_woGwGSF_Endcap_;
+  delete[] Var_wGwGSF_Endcap_;
 
-  if ( !loadMVAfromDB_ ){ 
+  if (!loadMVAfromDB_) {
     delete mva_NoEleMatch_woGwoGSF_BL_;
     delete mva_NoEleMatch_wGwoGSF_BL_;
     delete mva_woGwGSF_BL_;
@@ -83,65 +82,62 @@ AntiElectronIDMVA6::~AntiElectronIDMVA6()
     delete mva_wGwGSF_EC_;
   }
 
-  for ( std::vector<TFile*>::iterator it = inputFilesToDelete_.begin();
-	it != inputFilesToDelete_.end(); ++it ) {
+  for (std::vector<TFile*>::iterator it = inputFilesToDelete_.begin(); it != inputFilesToDelete_.end(); ++it) {
     delete (*it);
   }
 }
 
-namespace
-{
-  const GBRForest* loadMVAfromFile(TFile* inputFile, const std::string& mvaName)
-  {
+namespace {
+  const GBRForest* loadMVAfromFile(TFile* inputFile, const std::string& mvaName) {
     const GBRForest* mva = (GBRForest*)inputFile->Get(mvaName.data());
-    if ( !mva )
+    if (!mva)
       throw cms::Exception("PFRecoTauDiscriminationAgainstElectronMVA6::loadMVA")
-        << " Failed to load MVA = " << mvaName.data() << " from file " << " !!\n";
+          << " Failed to load MVA = " << mvaName.data() << " from file "
+          << " !!\n";
 
     return mva;
   }
 
-  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName)
-  {
+  const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName) {
     edm::ESHandle<GBRForest> mva;
     es.get<GBRWrapperRcd>().get(mvaName, mva);
     return mva.product();
   }
-}
+}  // namespace
 
-void AntiElectronIDMVA6::beginEvent(const edm::Event& evt, const edm::EventSetup& es)
-{
-  if ( !isInitialized_ ) {
-    if ( loadMVAfromDB_ ) {
+void AntiElectronIDMVA6::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
+  if (!isInitialized_) {
+    if (loadMVAfromDB_) {
       mva_NoEleMatch_woGwoGSF_BL_ = loadMVAfromDB(es, mvaName_NoEleMatch_woGwoGSF_BL_);
-      mva_NoEleMatch_wGwoGSF_BL_  = loadMVAfromDB(es, mvaName_NoEleMatch_wGwoGSF_BL_);
-      mva_woGwGSF_BL_             = loadMVAfromDB(es, mvaName_woGwGSF_BL_);
-      mva_wGwGSF_BL_              = loadMVAfromDB(es, mvaName_wGwGSF_BL_);
+      mva_NoEleMatch_wGwoGSF_BL_ = loadMVAfromDB(es, mvaName_NoEleMatch_wGwoGSF_BL_);
+      mva_woGwGSF_BL_ = loadMVAfromDB(es, mvaName_woGwGSF_BL_);
+      mva_wGwGSF_BL_ = loadMVAfromDB(es, mvaName_wGwGSF_BL_);
       mva_NoEleMatch_woGwoGSF_EC_ = loadMVAfromDB(es, mvaName_NoEleMatch_woGwoGSF_EC_);
-      mva_NoEleMatch_wGwoGSF_EC_  = loadMVAfromDB(es, mvaName_NoEleMatch_wGwoGSF_EC_);
-      mva_woGwGSF_EC_             = loadMVAfromDB(es, mvaName_woGwGSF_EC_);
-      mva_wGwGSF_EC_              = loadMVAfromDB(es, mvaName_wGwGSF_EC_);  
+      mva_NoEleMatch_wGwoGSF_EC_ = loadMVAfromDB(es, mvaName_NoEleMatch_wGwoGSF_EC_);
+      mva_woGwGSF_EC_ = loadMVAfromDB(es, mvaName_woGwGSF_EC_);
+      mva_wGwGSF_EC_ = loadMVAfromDB(es, mvaName_wGwGSF_EC_);
     } else {
-          if ( inputFileName_.location() == edm::FileInPath::Unknown ) throw cms::Exception("PFRecoTauDiscriminationAgainstElectronMVA6::loadMVA")
-          << " Failed to find File = " << inputFileName_ << " !!\n";
-          TFile* inputFile = new TFile(inputFileName_.fullPath().data());
+      if (inputFileName_.location() == edm::FileInPath::Unknown)
+        throw cms::Exception("PFRecoTauDiscriminationAgainstElectronMVA6::loadMVA")
+            << " Failed to find File = " << inputFileName_ << " !!\n";
+      TFile* inputFile = new TFile(inputFileName_.fullPath().data());
 
       mva_NoEleMatch_woGwoGSF_BL_ = loadMVAfromFile(inputFile, mvaName_NoEleMatch_woGwoGSF_BL_);
-      mva_NoEleMatch_wGwoGSF_BL_  = loadMVAfromFile(inputFile, mvaName_NoEleMatch_wGwoGSF_BL_);
-      mva_woGwGSF_BL_             = loadMVAfromFile(inputFile, mvaName_woGwGSF_BL_);
-      mva_wGwGSF_BL_              = loadMVAfromFile(inputFile, mvaName_wGwGSF_BL_);
+      mva_NoEleMatch_wGwoGSF_BL_ = loadMVAfromFile(inputFile, mvaName_NoEleMatch_wGwoGSF_BL_);
+      mva_woGwGSF_BL_ = loadMVAfromFile(inputFile, mvaName_woGwGSF_BL_);
+      mva_wGwGSF_BL_ = loadMVAfromFile(inputFile, mvaName_wGwGSF_BL_);
       mva_NoEleMatch_woGwoGSF_EC_ = loadMVAfromFile(inputFile, mvaName_NoEleMatch_woGwoGSF_EC_);
-      mva_NoEleMatch_wGwoGSF_EC_  = loadMVAfromFile(inputFile, mvaName_NoEleMatch_wGwoGSF_EC_);
-      mva_woGwGSF_EC_             = loadMVAfromFile(inputFile, mvaName_woGwGSF_EC_);
-      mva_wGwGSF_EC_              = loadMVAfromFile(inputFile, mvaName_wGwGSF_EC_);
-      inputFilesToDelete_.push_back(inputFile);  
+      mva_NoEleMatch_wGwoGSF_EC_ = loadMVAfromFile(inputFile, mvaName_NoEleMatch_wGwoGSF_EC_);
+      mva_woGwGSF_EC_ = loadMVAfromFile(inputFile, mvaName_woGwGSF_EC_);
+      mva_wGwGSF_EC_ = loadMVAfromFile(inputFile, mvaName_wGwGSF_EC_);
+      inputFilesToDelete_.push_back(inputFile);
     }
     isInitialized_ = true;
   }
 
   edm::ESHandle<MagneticField> pSetup;
   es.get<IdealMagneticFieldRecord>().get(pSetup);
-  bField_ = pSetup->inTesla(GlobalPoint(0,0,0)).z();
+  bField_ = pSetup->inTesla(GlobalPoint(0, 0, 0)).z();
 }
 
 double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
@@ -180,57 +176,60 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
                                     Float_t ElecDeltaPhi,
                                     Float_t ElecMvaInSigmaEtaEta,
                                     Float_t ElecMvaInHadEnergy,
-                                    Float_t ElecMvaInDeltaEta)
-{ 
-  double sumPt  = 0.;
-  double dEta2  = 0.;
-  double dPhi2  = 0.;
+                                    Float_t ElecMvaInDeltaEta) {
+  double sumPt = 0.;
+  double dEta2 = 0.;
+  double dPhi2 = 0.;
   double sumPt2 = 0.;
-  for ( unsigned int i = 0 ; i < GammasPtInSigCone.size() ; ++i ) {
-    double pt_i  = GammasPtInSigCone[i];
+  for (unsigned int i = 0; i < GammasPtInSigCone.size(); ++i) {
+    double pt_i = GammasPtInSigCone[i];
     double phi_i = GammasdPhiInSigCone[i];
-    if ( GammasdPhiInSigCone[i] > M_PI ) phi_i = GammasdPhiInSigCone[i] - 2*M_PI;
-    else if ( GammasdPhiInSigCone[i] < -M_PI ) phi_i = GammasdPhiInSigCone[i] + 2*M_PI;
+    if (GammasdPhiInSigCone[i] > M_PI)
+      phi_i = GammasdPhiInSigCone[i] - 2 * M_PI;
+    else if (GammasdPhiInSigCone[i] < -M_PI)
+      phi_i = GammasdPhiInSigCone[i] + 2 * M_PI;
     double eta_i = GammasdEtaInSigCone[i];
-    sumPt  +=  pt_i;
-    sumPt2 += (pt_i*pt_i);
-    dEta2  += (pt_i*eta_i*eta_i);
-    dPhi2  += (pt_i*phi_i*phi_i);
+    sumPt += pt_i;
+    sumPt2 += (pt_i * pt_i);
+    dEta2 += (pt_i * eta_i * eta_i);
+    dPhi2 += (pt_i * phi_i * phi_i);
   }
   Float_t TauGammaEnFracIn = -99.;
-  if ( TauPt > 0. ) {
-    TauGammaEnFracIn = sumPt/TauPt;
+  if (TauPt > 0.) {
+    TauGammaEnFracIn = sumPt / TauPt;
   }
-  if ( sumPt > 0. ) {
+  if (sumPt > 0.) {
     dEta2 /= sumPt;
     dPhi2 /= sumPt;
   }
-  Float_t TauGammaEtaMomIn = std::sqrt(dEta2)*std::sqrt(TauGammaEnFracIn)*TauPt;
-  Float_t TauGammaPhiMomIn = std::sqrt(dPhi2)*std::sqrt(TauGammaEnFracIn)*TauPt;
+  Float_t TauGammaEtaMomIn = std::sqrt(dEta2) * std::sqrt(TauGammaEnFracIn) * TauPt;
+  Float_t TauGammaPhiMomIn = std::sqrt(dPhi2) * std::sqrt(TauGammaEnFracIn) * TauPt;
 
-  sumPt  = 0.;
-  dEta2  = 0.;
-  dPhi2  = 0.;
+  sumPt = 0.;
+  dEta2 = 0.;
+  dPhi2 = 0.;
   sumPt2 = 0.;
-  for ( unsigned int i = 0 ; i < GammasPtOutSigCone.size() ; ++i ) {
-    double pt_i  = GammasPtOutSigCone[i];
+  for (unsigned int i = 0; i < GammasPtOutSigCone.size(); ++i) {
+    double pt_i = GammasPtOutSigCone[i];
     double phi_i = GammasdPhiOutSigCone[i];
-    if ( GammasdPhiOutSigCone[i] > M_PI ) phi_i = GammasdPhiOutSigCone[i] - 2*M_PI;
-    else if ( GammasdPhiOutSigCone[i] < -M_PI ) phi_i = GammasdPhiOutSigCone[i] + 2*M_PI;
+    if (GammasdPhiOutSigCone[i] > M_PI)
+      phi_i = GammasdPhiOutSigCone[i] - 2 * M_PI;
+    else if (GammasdPhiOutSigCone[i] < -M_PI)
+      phi_i = GammasdPhiOutSigCone[i] + 2 * M_PI;
     double eta_i = GammasdEtaOutSigCone[i];
-    sumPt  +=  pt_i;
-    sumPt2 += (pt_i*pt_i);
-    dEta2  += (pt_i*eta_i*eta_i);
-    dPhi2  += (pt_i*phi_i*phi_i);
+    sumPt += pt_i;
+    sumPt2 += (pt_i * pt_i);
+    dEta2 += (pt_i * eta_i * eta_i);
+    dPhi2 += (pt_i * phi_i * phi_i);
   }
-  Float_t TauGammaEnFracOut = sumPt/TauPt;
-  if ( sumPt > 0. ) {
+  Float_t TauGammaEnFracOut = sumPt / TauPt;
+  if (sumPt > 0.) {
     dEta2 /= sumPt;
     dPhi2 /= sumPt;
   }
-  Float_t TauGammaEtaMomOut = std::sqrt(dEta2)*std::sqrt(TauGammaEnFracOut)*TauPt;
-  Float_t TauGammaPhiMomOut = std::sqrt(dPhi2)*std::sqrt(TauGammaEnFracOut)*TauPt;
-  
+  Float_t TauGammaEtaMomOut = std::sqrt(dEta2) * std::sqrt(TauGammaEnFracOut) * TauPt;
+  Float_t TauGammaPhiMomOut = std::sqrt(dPhi2) * std::sqrt(TauGammaEnFracOut) * TauPt;
+
   return MVAValue(TauPt,
                   TauEtaAtEcalEntrance,
                   TauPhi,
@@ -306,27 +305,25 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
                                     Float_t ElecDeltaPhi,
                                     Float_t ElecMvaInSigmaEtaEta,
                                     Float_t ElecMvaInHadEnergy,
-                                    Float_t ElecMvaInDeltaEta)
-{
-
-  if ( !isInitialized_ ) {
-    throw cms::Exception("ClassNotInitialized")
-      << " AntiElectronMVA not properly initialized !!\n";
+                                    Float_t ElecMvaInDeltaEta) {
+  if (!isInitialized_) {
+    throw cms::Exception("ClassNotInitialized") << " AntiElectronMVA not properly initialized !!\n";
   }
 
   double mvaValue = -99.;
-  
+
   const float ECALBarrelEndcapEtaBorder = 1.479;
-  float ElecDeltaPinPoutOverPin = (ElecPin > 0.0) ? (std::abs(ElecPin - ElecPout)/ElecPin) : 1.0;
-  float ElecEecalOverPout = (ElecPout > 0.0) ? (ElecEecal/ElecPout) : 20.0;
-  float ElecNumHitsDiffOverSum = ((ElecGSFNumHits + ElecKFNumHits) > 0.0) ? 
-                                 ((ElecGSFNumHits - ElecKFNumHits)/(ElecGSFNumHits + ElecKFNumHits)) : 1.0;
-  
-  if ( deltaR(TauEtaAtEcalEntrance, TauPhi, ElecEta, ElecPhi) > 0.3 && TauSignalPFGammaCandsIn == 0 && TauHasGsf < 0.5) {
-    if ( std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder ){    
+  float ElecDeltaPinPoutOverPin = (ElecPin > 0.0) ? (std::abs(ElecPin - ElecPout) / ElecPin) : 1.0;
+  float ElecEecalOverPout = (ElecPout > 0.0) ? (ElecEecal / ElecPout) : 20.0;
+  float ElecNumHitsDiffOverSum = ((ElecGSFNumHits + ElecKFNumHits) > 0.0)
+                                     ? ((ElecGSFNumHits - ElecKFNumHits) / (ElecGSFNumHits + ElecKFNumHits))
+                                     : 1.0;
+
+  if (deltaR(TauEtaAtEcalEntrance, TauPhi, ElecEta, ElecPhi) > 0.3 && TauSignalPFGammaCandsIn == 0 && TauHasGsf < 0.5) {
+    if (std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder) {
       Var_NoEleMatch_woGwoGSF_Barrel_[0] = TauEtaAtEcalEntrance;
       Var_NoEleMatch_woGwoGSF_Barrel_[1] = TauLeadChargedPFCandEtaAtEcalEntrance;
-      Var_NoEleMatch_woGwoGSF_Barrel_[2] = std::min(float(2.), TauLeadChargedPFCandPt/std::max(float(1.), TauPt));
+      Var_NoEleMatch_woGwoGSF_Barrel_[2] = std::min(float(2.), TauLeadChargedPFCandPt / std::max(float(1.), TauPt));
       Var_NoEleMatch_woGwoGSF_Barrel_[3] = std::log(std::max(float(1.), TauPt));
       Var_NoEleMatch_woGwoGSF_Barrel_[4] = TauEmFraction;
       Var_NoEleMatch_woGwoGSF_Barrel_[5] = TauLeadPFChargedHadrHoP;
@@ -338,7 +335,7 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
     } else {
       Var_NoEleMatch_woGwoGSF_Endcap_[0] = TauEtaAtEcalEntrance;
       Var_NoEleMatch_woGwoGSF_Endcap_[1] = TauLeadChargedPFCandEtaAtEcalEntrance;
-      Var_NoEleMatch_woGwoGSF_Endcap_[2] = std::min(float(2.), TauLeadChargedPFCandPt/std::max(float(1.), TauPt));
+      Var_NoEleMatch_woGwoGSF_Endcap_[2] = std::min(float(2.), TauLeadChargedPFCandPt / std::max(float(1.), TauPt));
       Var_NoEleMatch_woGwoGSF_Endcap_[3] = std::log(std::max(float(1.), TauPt));
       Var_NoEleMatch_woGwoGSF_Endcap_[4] = TauEmFraction;
       Var_NoEleMatch_woGwoGSF_Endcap_[5] = TauLeadPFChargedHadrHoP;
@@ -347,19 +344,19 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       Var_NoEleMatch_woGwoGSF_Endcap_[8] = TaudCrackEta;
       mvaValue = mva_NoEleMatch_woGwoGSF_EC_->GetClassifier(Var_NoEleMatch_woGwoGSF_Endcap_);
     }
-  }
-  else if ( deltaR(TauEtaAtEcalEntrance, TauPhi, ElecEta, ElecPhi) > 0.3 && TauSignalPFGammaCandsIn > 0 && TauHasGsf < 0.5 ) {
-    if ( std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder ){
-      Var_NoEleMatch_wGwoGSF_Barrel_[0]  = TauEtaAtEcalEntrance;
-      Var_NoEleMatch_wGwoGSF_Barrel_[1]  = TauLeadChargedPFCandEtaAtEcalEntrance;
-      Var_NoEleMatch_wGwoGSF_Barrel_[2]  = std::min(float(2.), TauLeadChargedPFCandPt/std::max(float(1.), TauPt));
-      Var_NoEleMatch_wGwoGSF_Barrel_[3]  = std::log(std::max(float(1.), TauPt));
-      Var_NoEleMatch_wGwoGSF_Barrel_[4]  = TauEmFraction;
-      Var_NoEleMatch_wGwoGSF_Barrel_[5]  = TauSignalPFGammaCandsIn;
-      Var_NoEleMatch_wGwoGSF_Barrel_[6]  = TauSignalPFGammaCandsOut;
-      Var_NoEleMatch_wGwoGSF_Barrel_[7]  = TauLeadPFChargedHadrHoP;
-      Var_NoEleMatch_wGwoGSF_Barrel_[8]  = TauLeadPFChargedHadrEoP;
-      Var_NoEleMatch_wGwoGSF_Barrel_[9]  = TauVisMassIn;
+  } else if (deltaR(TauEtaAtEcalEntrance, TauPhi, ElecEta, ElecPhi) > 0.3 && TauSignalPFGammaCandsIn > 0 &&
+             TauHasGsf < 0.5) {
+    if (std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder) {
+      Var_NoEleMatch_wGwoGSF_Barrel_[0] = TauEtaAtEcalEntrance;
+      Var_NoEleMatch_wGwoGSF_Barrel_[1] = TauLeadChargedPFCandEtaAtEcalEntrance;
+      Var_NoEleMatch_wGwoGSF_Barrel_[2] = std::min(float(2.), TauLeadChargedPFCandPt / std::max(float(1.), TauPt));
+      Var_NoEleMatch_wGwoGSF_Barrel_[3] = std::log(std::max(float(1.), TauPt));
+      Var_NoEleMatch_wGwoGSF_Barrel_[4] = TauEmFraction;
+      Var_NoEleMatch_wGwoGSF_Barrel_[5] = TauSignalPFGammaCandsIn;
+      Var_NoEleMatch_wGwoGSF_Barrel_[6] = TauSignalPFGammaCandsOut;
+      Var_NoEleMatch_wGwoGSF_Barrel_[7] = TauLeadPFChargedHadrHoP;
+      Var_NoEleMatch_wGwoGSF_Barrel_[8] = TauLeadPFChargedHadrEoP;
+      Var_NoEleMatch_wGwoGSF_Barrel_[9] = TauVisMassIn;
       Var_NoEleMatch_wGwoGSF_Barrel_[10] = TauGammaEtaMomIn;
       Var_NoEleMatch_wGwoGSF_Barrel_[11] = TauGammaEtaMomOut;
       Var_NoEleMatch_wGwoGSF_Barrel_[12] = TauGammaPhiMomIn;
@@ -370,16 +367,16 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       Var_NoEleMatch_wGwoGSF_Barrel_[17] = TaudCrackPhi;
       mvaValue = mva_NoEleMatch_wGwoGSF_BL_->GetClassifier(Var_NoEleMatch_wGwoGSF_Barrel_);
     } else {
-      Var_NoEleMatch_wGwoGSF_Endcap_[0]  = TauEtaAtEcalEntrance;
-      Var_NoEleMatch_wGwoGSF_Endcap_[1]  = TauLeadChargedPFCandEtaAtEcalEntrance;
-      Var_NoEleMatch_wGwoGSF_Endcap_[2]  = std::min(float(2.), TauLeadChargedPFCandPt/std::max(float(1.), TauPt));
-      Var_NoEleMatch_wGwoGSF_Endcap_[3]  = std::log(std::max(float(1.), TauPt));
-      Var_NoEleMatch_wGwoGSF_Endcap_[4]  = TauEmFraction;
-      Var_NoEleMatch_wGwoGSF_Endcap_[5]  = TauSignalPFGammaCandsIn;
-      Var_NoEleMatch_wGwoGSF_Endcap_[6]  = TauSignalPFGammaCandsOut;
-      Var_NoEleMatch_wGwoGSF_Endcap_[7]  = TauLeadPFChargedHadrHoP;
-      Var_NoEleMatch_wGwoGSF_Endcap_[8]  = TauLeadPFChargedHadrEoP;
-      Var_NoEleMatch_wGwoGSF_Endcap_[9]  = TauVisMassIn;
+      Var_NoEleMatch_wGwoGSF_Endcap_[0] = TauEtaAtEcalEntrance;
+      Var_NoEleMatch_wGwoGSF_Endcap_[1] = TauLeadChargedPFCandEtaAtEcalEntrance;
+      Var_NoEleMatch_wGwoGSF_Endcap_[2] = std::min(float(2.), TauLeadChargedPFCandPt / std::max(float(1.), TauPt));
+      Var_NoEleMatch_wGwoGSF_Endcap_[3] = std::log(std::max(float(1.), TauPt));
+      Var_NoEleMatch_wGwoGSF_Endcap_[4] = TauEmFraction;
+      Var_NoEleMatch_wGwoGSF_Endcap_[5] = TauSignalPFGammaCandsIn;
+      Var_NoEleMatch_wGwoGSF_Endcap_[6] = TauSignalPFGammaCandsOut;
+      Var_NoEleMatch_wGwoGSF_Endcap_[7] = TauLeadPFChargedHadrHoP;
+      Var_NoEleMatch_wGwoGSF_Endcap_[8] = TauLeadPFChargedHadrEoP;
+      Var_NoEleMatch_wGwoGSF_Endcap_[9] = TauVisMassIn;
       Var_NoEleMatch_wGwoGSF_Endcap_[10] = TauGammaEtaMomIn;
       Var_NoEleMatch_wGwoGSF_Endcap_[11] = TauGammaEtaMomOut;
       Var_NoEleMatch_wGwoGSF_Endcap_[12] = TauGammaPhiMomIn;
@@ -389,26 +386,25 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       Var_NoEleMatch_wGwoGSF_Endcap_[16] = TaudCrackEta;
       mvaValue = mva_NoEleMatch_wGwoGSF_EC_->GetClassifier(Var_NoEleMatch_wGwoGSF_Endcap_);
     }
-  }    
-  else if ( TauSignalPFGammaCandsIn == 0 && TauHasGsf > 0.5 ) {
-    if ( std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder ) {
-      Var_woGwGSF_Barrel_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_woGwGSF_Barrel_[1]  = std::log(std::max(float(0.01), ElecChi2NormGSF));
-      Var_woGwGSF_Barrel_[2]  = ElecGSFNumHits;
-      Var_woGwGSF_Barrel_[3]  = std::log(std::max(float(0.01), ElecGSFTrackResol));
-      Var_woGwGSF_Barrel_[4]  = ElecGSFTracklnPt;
-      Var_woGwGSF_Barrel_[5]  = ElecNumHitsDiffOverSum;
-      Var_woGwGSF_Barrel_[6]  = std::log(std::max(float(0.01), ElecChi2NormKF));
-      Var_woGwGSF_Barrel_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
-      Var_woGwGSF_Barrel_[8]  = std::min(ElecEecalOverPout, float(20.));
-      Var_woGwGSF_Barrel_[9]  = ElecDeltaEta;
+  } else if (TauSignalPFGammaCandsIn == 0 && TauHasGsf > 0.5) {
+    if (std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder) {
+      Var_woGwGSF_Barrel_[0] = std::max(float(-0.1), ElecEtotOverPin);
+      Var_woGwGSF_Barrel_[1] = std::log(std::max(float(0.01), ElecChi2NormGSF));
+      Var_woGwGSF_Barrel_[2] = ElecGSFNumHits;
+      Var_woGwGSF_Barrel_[3] = std::log(std::max(float(0.01), ElecGSFTrackResol));
+      Var_woGwGSF_Barrel_[4] = ElecGSFTracklnPt;
+      Var_woGwGSF_Barrel_[5] = ElecNumHitsDiffOverSum;
+      Var_woGwGSF_Barrel_[6] = std::log(std::max(float(0.01), ElecChi2NormKF));
+      Var_woGwGSF_Barrel_[7] = std::min(ElecDeltaPinPoutOverPin, float(1.));
+      Var_woGwGSF_Barrel_[8] = std::min(ElecEecalOverPout, float(20.));
+      Var_woGwGSF_Barrel_[9] = ElecDeltaEta;
       Var_woGwGSF_Barrel_[10] = ElecDeltaPhi;
       Var_woGwGSF_Barrel_[11] = std::min(ElecMvaInSigmaEtaEta, float(0.01));
       Var_woGwGSF_Barrel_[12] = std::min(ElecMvaInHadEnergy, float(20.));
       Var_woGwGSF_Barrel_[13] = std::min(ElecMvaInDeltaEta, float(0.1));
       Var_woGwGSF_Barrel_[14] = TauEtaAtEcalEntrance;
       Var_woGwGSF_Barrel_[15] = TauLeadChargedPFCandEtaAtEcalEntrance;
-      Var_woGwGSF_Barrel_[16] = std::min(float(2.), TauLeadChargedPFCandPt/std::max(float(1.), TauPt));
+      Var_woGwGSF_Barrel_[16] = std::min(float(2.), TauLeadChargedPFCandPt / std::max(float(1.), TauPt));
       Var_woGwGSF_Barrel_[17] = std::log(std::max(float(1.), TauPt));
       Var_woGwGSF_Barrel_[18] = TauEmFraction;
       Var_woGwGSF_Barrel_[19] = TauLeadPFChargedHadrHoP;
@@ -418,23 +414,23 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       Var_woGwGSF_Barrel_[23] = TaudCrackPhi;
       mvaValue = mva_woGwGSF_BL_->GetClassifier(Var_woGwGSF_Barrel_);
     } else {
-      Var_woGwGSF_Endcap_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_woGwGSF_Endcap_[1]  = std::log(std::max(float(0.01), ElecChi2NormGSF));
-      Var_woGwGSF_Endcap_[2]  = ElecGSFNumHits;
-      Var_woGwGSF_Endcap_[3]  = std::log(std::max(float(0.01), ElecGSFTrackResol));
-      Var_woGwGSF_Endcap_[4]  = ElecGSFTracklnPt;
-      Var_woGwGSF_Endcap_[5]  = ElecNumHitsDiffOverSum;
-      Var_woGwGSF_Endcap_[6]  = std::log(std::max(float(0.01), ElecChi2NormKF));
-      Var_woGwGSF_Endcap_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
-      Var_woGwGSF_Endcap_[8]  = std::min(ElecEecalOverPout, float(20.));
-      Var_woGwGSF_Endcap_[9]  = ElecDeltaEta;
+      Var_woGwGSF_Endcap_[0] = std::max(float(-0.1), ElecEtotOverPin);
+      Var_woGwGSF_Endcap_[1] = std::log(std::max(float(0.01), ElecChi2NormGSF));
+      Var_woGwGSF_Endcap_[2] = ElecGSFNumHits;
+      Var_woGwGSF_Endcap_[3] = std::log(std::max(float(0.01), ElecGSFTrackResol));
+      Var_woGwGSF_Endcap_[4] = ElecGSFTracklnPt;
+      Var_woGwGSF_Endcap_[5] = ElecNumHitsDiffOverSum;
+      Var_woGwGSF_Endcap_[6] = std::log(std::max(float(0.01), ElecChi2NormKF));
+      Var_woGwGSF_Endcap_[7] = std::min(ElecDeltaPinPoutOverPin, float(1.));
+      Var_woGwGSF_Endcap_[8] = std::min(ElecEecalOverPout, float(20.));
+      Var_woGwGSF_Endcap_[9] = ElecDeltaEta;
       Var_woGwGSF_Endcap_[10] = ElecDeltaPhi;
       Var_woGwGSF_Endcap_[11] = std::min(ElecMvaInSigmaEtaEta, float(0.01));
       Var_woGwGSF_Endcap_[12] = std::min(ElecMvaInHadEnergy, float(20.));
       Var_woGwGSF_Endcap_[13] = std::min(ElecMvaInDeltaEta, float(0.1));
       Var_woGwGSF_Endcap_[14] = TauEtaAtEcalEntrance;
       Var_woGwGSF_Endcap_[15] = TauLeadChargedPFCandEtaAtEcalEntrance;
-      Var_woGwGSF_Endcap_[16] = std::min(float(2.), TauLeadChargedPFCandPt/std::max(float(1.), TauPt));
+      Var_woGwGSF_Endcap_[16] = std::min(float(2.), TauLeadChargedPFCandPt / std::max(float(1.), TauPt));
       Var_woGwGSF_Endcap_[17] = std::log(std::max(float(1.), TauPt));
       Var_woGwGSF_Endcap_[18] = TauEmFraction;
       Var_woGwGSF_Endcap_[19] = TauLeadPFChargedHadrHoP;
@@ -442,27 +438,26 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       Var_woGwGSF_Endcap_[21] = TauVisMassIn;
       Var_woGwGSF_Endcap_[22] = TaudCrackEta;
       mvaValue = mva_woGwGSF_EC_->GetClassifier(Var_woGwGSF_Endcap_);
-    } 
-  }
-  else if ( TauSignalPFGammaCandsIn > 0 && TauHasGsf > 0.5 ) {
-    if ( std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder ) {
-      Var_wGwGSF_Barrel_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_wGwGSF_Barrel_[1]  = std::log(std::max(float(0.01), ElecChi2NormGSF));
-      Var_wGwGSF_Barrel_[2]  = ElecGSFNumHits;
-      Var_wGwGSF_Barrel_[3]  = std::log(std::max(float(0.01), ElecGSFTrackResol));
-      Var_wGwGSF_Barrel_[4]  = ElecGSFTracklnPt;
-      Var_wGwGSF_Barrel_[5]  = ElecNumHitsDiffOverSum;
-      Var_wGwGSF_Barrel_[6]  = std::log(std::max(float(0.01), ElecChi2NormKF));
-      Var_wGwGSF_Barrel_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
-      Var_wGwGSF_Barrel_[8]  = std::min(ElecEecalOverPout, float(20.));
-      Var_wGwGSF_Barrel_[9]  = ElecDeltaEta;
+    }
+  } else if (TauSignalPFGammaCandsIn > 0 && TauHasGsf > 0.5) {
+    if (std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder) {
+      Var_wGwGSF_Barrel_[0] = std::max(float(-0.1), ElecEtotOverPin);
+      Var_wGwGSF_Barrel_[1] = std::log(std::max(float(0.01), ElecChi2NormGSF));
+      Var_wGwGSF_Barrel_[2] = ElecGSFNumHits;
+      Var_wGwGSF_Barrel_[3] = std::log(std::max(float(0.01), ElecGSFTrackResol));
+      Var_wGwGSF_Barrel_[4] = ElecGSFTracklnPt;
+      Var_wGwGSF_Barrel_[5] = ElecNumHitsDiffOverSum;
+      Var_wGwGSF_Barrel_[6] = std::log(std::max(float(0.01), ElecChi2NormKF));
+      Var_wGwGSF_Barrel_[7] = std::min(ElecDeltaPinPoutOverPin, float(1.));
+      Var_wGwGSF_Barrel_[8] = std::min(ElecEecalOverPout, float(20.));
+      Var_wGwGSF_Barrel_[9] = ElecDeltaEta;
       Var_wGwGSF_Barrel_[10] = ElecDeltaPhi;
       Var_wGwGSF_Barrel_[11] = std::min(ElecMvaInSigmaEtaEta, float(0.01));
       Var_wGwGSF_Barrel_[12] = std::min(ElecMvaInHadEnergy, float(20.));
       Var_wGwGSF_Barrel_[13] = std::min(ElecMvaInDeltaEta, float(0.1));
       Var_wGwGSF_Barrel_[14] = TauEtaAtEcalEntrance;
       Var_wGwGSF_Barrel_[15] = TauLeadChargedPFCandEtaAtEcalEntrance;
-      Var_wGwGSF_Barrel_[16] = std::min(float(2.), TauLeadChargedPFCandPt/std::max(float(1.), TauPt));
+      Var_wGwGSF_Barrel_[16] = std::min(float(2.), TauLeadChargedPFCandPt / std::max(float(1.), TauPt));
       Var_wGwGSF_Barrel_[17] = std::log(std::max(float(1.), TauPt));
       Var_wGwGSF_Barrel_[18] = TauEmFraction;
       Var_wGwGSF_Barrel_[19] = TauSignalPFGammaCandsIn;
@@ -480,23 +475,23 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       Var_wGwGSF_Barrel_[31] = TaudCrackPhi;
       mvaValue = mva_wGwGSF_BL_->GetClassifier(Var_wGwGSF_Barrel_);
     } else {
-      Var_wGwGSF_Endcap_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_wGwGSF_Endcap_[1]  = std::log(std::max(float(0.01), ElecChi2NormGSF));
-      Var_wGwGSF_Endcap_[2]  = ElecGSFNumHits;
-      Var_wGwGSF_Endcap_[3]  = std::log(std::max(float(0.01), ElecGSFTrackResol));
-      Var_wGwGSF_Endcap_[4]  = ElecGSFTracklnPt;
-      Var_wGwGSF_Endcap_[5]  = ElecNumHitsDiffOverSum;
-      Var_wGwGSF_Endcap_[6]  = std::log(std::max(float(0.01), ElecChi2NormKF));
-      Var_wGwGSF_Endcap_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
-      Var_wGwGSF_Endcap_[8]  = std::min(ElecEecalOverPout, float(20.));
-      Var_wGwGSF_Endcap_[9]  = ElecDeltaEta;
+      Var_wGwGSF_Endcap_[0] = std::max(float(-0.1), ElecEtotOverPin);
+      Var_wGwGSF_Endcap_[1] = std::log(std::max(float(0.01), ElecChi2NormGSF));
+      Var_wGwGSF_Endcap_[2] = ElecGSFNumHits;
+      Var_wGwGSF_Endcap_[3] = std::log(std::max(float(0.01), ElecGSFTrackResol));
+      Var_wGwGSF_Endcap_[4] = ElecGSFTracklnPt;
+      Var_wGwGSF_Endcap_[5] = ElecNumHitsDiffOverSum;
+      Var_wGwGSF_Endcap_[6] = std::log(std::max(float(0.01), ElecChi2NormKF));
+      Var_wGwGSF_Endcap_[7] = std::min(ElecDeltaPinPoutOverPin, float(1.));
+      Var_wGwGSF_Endcap_[8] = std::min(ElecEecalOverPout, float(20.));
+      Var_wGwGSF_Endcap_[9] = ElecDeltaEta;
       Var_wGwGSF_Endcap_[10] = ElecDeltaPhi;
       Var_wGwGSF_Endcap_[11] = std::min(ElecMvaInSigmaEtaEta, float(0.01));
       Var_wGwGSF_Endcap_[12] = std::min(ElecMvaInHadEnergy, float(20.));
       Var_wGwGSF_Endcap_[13] = std::min(ElecMvaInDeltaEta, float(0.1));
       Var_wGwGSF_Endcap_[14] = TauEtaAtEcalEntrance;
       Var_wGwGSF_Endcap_[15] = TauLeadChargedPFCandEtaAtEcalEntrance;
-      Var_wGwGSF_Endcap_[16] = std::min(float(2.), TauLeadChargedPFCandPt/std::max(float(1.), TauPt));
+      Var_wGwGSF_Endcap_[16] = std::min(float(2.), TauLeadChargedPFCandPt / std::max(float(1.), TauPt));
       Var_wGwGSF_Endcap_[17] = std::log(std::max(float(1.), TauPt));
       Var_wGwGSF_Endcap_[18] = TauEmFraction;
       Var_wGwGSF_Endcap_[19] = TauSignalPFGammaCandsIn;
@@ -512,13 +507,12 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       Var_wGwGSF_Endcap_[29] = TauGammaEnFracOut;
       Var_wGwGSF_Endcap_[30] = TaudCrackEta;
       mvaValue = mva_wGwGSF_EC_->GetClassifier(Var_wGwGSF_Endcap_);
-    } 
+    }
   }
   return mvaValue;
 }
 
-double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
-				    const reco::GsfElectron& theGsfEle)
+double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau, const reco::GsfElectron& theGsfEle)
 
 {
   // === tau variables ===
@@ -526,27 +520,32 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
   float sumEtaTimesEnergy = 0.;
   float sumEnergy = 0.;
   const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTau.signalPFCands();
-  for ( const auto & pfCandidate : signalPFCands ) {
-    sumEtaTimesEnergy += pfCandidate->positionAtECALEntrance().eta()*pfCandidate->energy();
+  for (const auto& pfCandidate : signalPFCands) {
+    sumEtaTimesEnergy += pfCandidate->positionAtECALEntrance().eta() * pfCandidate->energy();
     sumEnergy += pfCandidate->energy();
   }
-  if ( sumEnergy > 0. ) {
-    TauEtaAtEcalEntrance = sumEtaTimesEnergy/sumEnergy;
+  if (sumEnergy > 0.) {
+    TauEtaAtEcalEntrance = sumEtaTimesEnergy / sumEnergy;
   }
-  
+
   float TauLeadChargedPFCandEtaAtEcalEntrance = -99.;
   float TauLeadChargedPFCandPt = -99.;
-  for ( const auto & pfCandidate : signalPFCands ) {
+  for (const auto& pfCandidate : signalPFCands) {
     const reco::Track* track = nullptr;
-    if ( pfCandidate->trackRef().isNonnull() ) track = pfCandidate->trackRef().get();
-    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->innerTrack().isNonnull()  ) track = pfCandidate->muonRef()->innerTrack().get();
-    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->globalTrack().isNonnull() ) track = pfCandidate->muonRef()->globalTrack().get();
-    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->outerTrack().isNonnull()  ) track = pfCandidate->muonRef()->outerTrack().get();
-    else if ( pfCandidate->gsfTrackRef().isNonnull() ) track = pfCandidate->gsfTrackRef().get();
-    if ( track ) {
-      if ( track->pt() > TauLeadChargedPFCandPt ) {
-	TauLeadChargedPFCandEtaAtEcalEntrance = pfCandidate->positionAtECALEntrance().eta();
-	TauLeadChargedPFCandPt = track->pt();
+    if (pfCandidate->trackRef().isNonnull())
+      track = pfCandidate->trackRef().get();
+    else if (pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->innerTrack().isNonnull())
+      track = pfCandidate->muonRef()->innerTrack().get();
+    else if (pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->globalTrack().isNonnull())
+      track = pfCandidate->muonRef()->globalTrack().get();
+    else if (pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->outerTrack().isNonnull())
+      track = pfCandidate->muonRef()->outerTrack().get();
+    else if (pfCandidate->gsfTrackRef().isNonnull())
+      track = pfCandidate->gsfTrackRef().get();
+    if (track) {
+      if (track->pt() > TauLeadChargedPFCandPt) {
+        TauLeadChargedPFCandEtaAtEcalEntrance = pfCandidate->positionAtECALEntrance().eta();
+        TauLeadChargedPFCandPt = track->pt();
       }
     }
   }
@@ -555,9 +554,9 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
   Float_t TauEmFraction = std::max(thePFTau.emFraction(), (Float_t)0.);
   Float_t TauLeadPFChargedHadrHoP = 0.;
   Float_t TauLeadPFChargedHadrEoP = 0.;
-  if ( thePFTau.leadPFChargedHadrCand()->p() > 0. ) {
-    TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
-    TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
+  if (thePFTau.leadPFChargedHadrCand()->p() > 0.) {
+    TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy() / thePFTau.leadPFChargedHadrCand()->p();
+    TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy() / thePFTau.leadPFChargedHadrCand()->p();
   }
 
   std::vector<Float_t> GammasdEtaInSigCone;
@@ -566,20 +565,19 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
   std::vector<Float_t> GammasdEtaOutSigCone;
   std::vector<Float_t> GammasdPhiOutSigCone;
   std::vector<Float_t> GammasPtOutSigCone;
-  reco::Candidate::LorentzVector pfGammaSum(0,0,0,0);
-  reco::Candidate::LorentzVector pfChargedSum(0,0,0,0);
-  
-  for ( const auto & gamma : thePFTau.signalGammaCands() ) {
+  reco::Candidate::LorentzVector pfGammaSum(0, 0, 0, 0);
+  reco::Candidate::LorentzVector pfChargedSum(0, 0, 0, 0);
+
+  for (const auto& gamma : thePFTau.signalGammaCands()) {
     float dR = deltaR(gamma->p4(), thePFTau.leadChargedHadrCand()->p4());
-    float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, thePFTau.pt())));
+    float signalrad = std::max(0.05, std::min(0.10, 3.0 / std::max(1.0, thePFTau.pt())));
 
     // pfGammas inside the tau signal cone
     if (dR < signalrad) {
-      if ( thePFTau.leadChargedHadrCand().isNonnull() ) {
+      if (thePFTau.leadChargedHadrCand().isNonnull()) {
         GammasdEtaInSigCone.push_back(gamma->eta() - thePFTau.leadChargedHadrCand()->eta());
         GammasdPhiInSigCone.push_back(gamma->phi() - thePFTau.leadChargedHadrCand()->phi());
-      }
-      else {
+      } else {
         GammasdEtaInSigCone.push_back(gamma->eta() - thePFTau.eta());
         GammasdPhiInSigCone.push_back(gamma->phi() - thePFTau.phi());
       }
@@ -588,28 +586,27 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
     }
     // pfGammas outside the tau signal cone
     else {
-      if ( thePFTau.leadChargedHadrCand().isNonnull() ) {
+      if (thePFTau.leadChargedHadrCand().isNonnull()) {
         GammasdEtaOutSigCone.push_back(gamma->eta() - thePFTau.leadChargedHadrCand()->eta());
         GammasdPhiOutSigCone.push_back(gamma->phi() - thePFTau.leadChargedHadrCand()->phi());
-      } 
-      else {
+      } else {
         GammasdEtaOutSigCone.push_back(gamma->eta() - thePFTau.eta());
         GammasdPhiOutSigCone.push_back(gamma->phi() - thePFTau.phi());
       }
       GammasPtOutSigCone.push_back(gamma->pt());
     }
   }
-  
-  for ( const auto & charged : thePFTau.signalChargedHadrCands() ) {
+
+  for (const auto& charged : thePFTau.signalChargedHadrCands()) {
     float dR = deltaR(charged->p4(), thePFTau.leadChargedHadrCand()->p4());
-    float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, thePFTau.pt())));
-  
+    float signalrad = std::max(0.05, std::min(0.10, 3.0 / std::max(1.0, thePFTau.pt())));
+
     // charged particles inside the tau signal cone
     if (dR < signalrad) {
-        pfChargedSum += charged->p4();
+      pfChargedSum += charged->p4();
     }
   }
-  
+
   Int_t TauSignalPFGammaCandsIn = GammasPtInSigCone.size();
   Int_t TauSignalPFGammaCandsOut = GammasPtOutSigCone.size();
   Float_t TauVisMassIn = (pfGammaSum + pfChargedSum).mass();
@@ -617,75 +614,78 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
   Float_t TauPhi = thePFTau.phi();
   float sumPhiTimesEnergy = 0.;
   float sumEnergyPhi = 0.;
-  if ( !usePhiAtEcalEntranceExtrapolation_ ) {
-    for ( const auto & pfc : signalPFCands ) {
-      sumPhiTimesEnergy += pfc->positionAtECALEntrance().phi()*pfc->energy();
+  if (!usePhiAtEcalEntranceExtrapolation_) {
+    for (const auto& pfc : signalPFCands) {
+      sumPhiTimesEnergy += pfc->positionAtECALEntrance().phi() * pfc->energy();
       sumEnergyPhi += pfc->energy();
     }
-  }
-  else{
-    TauPhi= -99.;
-    for ( const auto & signalPFCand : signalPFCands ) {
-      reco::Candidate const*  signalCand = signalPFCand.get();
+  } else {
+    TauPhi = -99.;
+    for (const auto& signalPFCand : signalPFCands) {
+      reco::Candidate const* signalCand = signalPFCand.get();
       float phi = thePFTau.phi();
-      math::XYZPoint aPos; 
-      if ( atECalEntrance(signalCand, aPos) ) phi = aPos.Phi();
-      sumPhiTimesEnergy += phi*signalCand->energy();     
+      math::XYZPoint aPos;
+      if (atECalEntrance(signalCand, aPos))
+        phi = aPos.Phi();
+      sumPhiTimesEnergy += phi * signalCand->energy();
       sumEnergy += signalCand->energy();
     }
   }
-  if ( sumEnergyPhi > 0. ) {
-    TauPhi = sumPhiTimesEnergy/sumEnergyPhi;
+  if (sumEnergyPhi > 0.) {
+    TauPhi = sumPhiTimesEnergy / sumEnergyPhi;
   }
   Float_t TaudCrackPhi = dCrackPhi(TauPhi, TauEtaAtEcalEntrance);
   Float_t TaudCrackEta = dCrackEta(TauEtaAtEcalEntrance);
   Float_t TauHasGsf = thePFTau.leadPFChargedHadrCand()->gsfTrackRef().isNonnull();
-  
+
   // === electron variables ===
   Float_t ElecEta = theGsfEle.eta();
   Float_t ElecPhi = theGsfEle.phi();
-                  
+
   //Variables related to the electron Cluster
   Float_t ElecEe = 0.;
   Float_t ElecEgamma = 0.;
   reco::SuperClusterRef pfSuperCluster = theGsfEle.superCluster();
-  if ( pfSuperCluster.isNonnull() && pfSuperCluster.isAvailable() ) {
-    for ( reco::CaloCluster_iterator pfCluster = pfSuperCluster->clustersBegin();
-	  pfCluster != pfSuperCluster->clustersEnd(); ++pfCluster ) {
+  if (pfSuperCluster.isNonnull() && pfSuperCluster.isAvailable()) {
+    for (reco::CaloCluster_iterator pfCluster = pfSuperCluster->clustersBegin();
+         pfCluster != pfSuperCluster->clustersEnd();
+         ++pfCluster) {
       double pfClusterEn = (*pfCluster)->energy();
-      if ( pfCluster == pfSuperCluster->clustersBegin() ) ElecEe += pfClusterEn;
-      else ElecEgamma += pfClusterEn;
+      if (pfCluster == pfSuperCluster->clustersBegin())
+        ElecEe += pfClusterEn;
+      else
+        ElecEgamma += pfClusterEn;
     }
   }
-  
+
   Float_t ElecPin = std::sqrt(theGsfEle.trackMomentumAtVtx().Mag2());
-  Float_t ElecPout = std::sqrt(theGsfEle.trackMomentumOut().Mag2());  
-  Float_t ElecEtotOverPin = (ElecPin > 0.0) ? ((ElecEe + ElecEgamma)/ElecPin) : -0.1;
+  Float_t ElecPout = std::sqrt(theGsfEle.trackMomentumOut().Mag2());
+  Float_t ElecEtotOverPin = (ElecPin > 0.0) ? ((ElecEe + ElecEgamma) / ElecPin) : -0.1;
   Float_t ElecEecal = theGsfEle.ecalEnergy();
   Float_t ElecDeltaEta = theGsfEle.deltaEtaSeedClusterTrackAtCalo();
   Float_t ElecDeltaPhi = theGsfEle.deltaPhiSeedClusterTrackAtCalo();
   Float_t ElecMvaInSigmaEtaEta = (theGsfEle).mvaInput().sigmaEtaEta;
   Float_t ElecMvaInHadEnergy = (theGsfEle).mvaInput().hadEnergy;
   Float_t ElecMvaInDeltaEta = (theGsfEle).mvaInput().deltaEta;
-  
+
   //Variables related to the GsfTrack
   Float_t ElecChi2NormGSF = -99.;
   Float_t ElecGSFNumHits = -99.;
   Float_t ElecGSFTrackResol = -99.;
   Float_t ElecGSFTracklnPt = -99.;
-  if ( theGsfEle.gsfTrack().isNonnull() ) {
+  if (theGsfEle.gsfTrack().isNonnull()) {
     ElecChi2NormGSF = (theGsfEle).gsfTrack()->normalizedChi2();
     ElecGSFNumHits = (theGsfEle).gsfTrack()->numberOfValidHits();
-    if ( theGsfEle.gsfTrack()->pt() > 0. ) {
-      ElecGSFTrackResol = theGsfEle.gsfTrack()->ptError()/theGsfEle.gsfTrack()->pt();
-      ElecGSFTracklnPt = log(theGsfEle.gsfTrack()->pt())*M_LN10;
+    if (theGsfEle.gsfTrack()->pt() > 0.) {
+      ElecGSFTrackResol = theGsfEle.gsfTrack()->ptError() / theGsfEle.gsfTrack()->pt();
+      ElecGSFTracklnPt = log(theGsfEle.gsfTrack()->pt()) * M_LN10;
     }
   }
 
   //Variables related to the CtfTrack
   Float_t ElecChi2NormKF = -99.;
   Float_t ElecKFNumHits = -99.;
-  if ( theGsfEle.closestCtfTrackRef().isNonnull() ) {
+  if (theGsfEle.closestCtfTrackRef().isNonnull()) {
     ElecChi2NormKF = (theGsfEle).closestCtfTrackRef()->normalizedChi2();
     ElecKFNumHits = (theGsfEle).closestCtfTrackRef()->numberOfValidHits();
   }
@@ -729,34 +729,38 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
                   ElecMvaInDeltaEta);
 }
 
-double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
-{
+double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau) {
   // === tau variables ===
   float TauEtaAtEcalEntrance = -99.;
   float sumEtaTimesEnergy = 0.;
   float sumEnergy = 0.;
   const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTau.signalPFCands();
-  for ( const auto & pfCandidate : signalPFCands ) {
-    sumEtaTimesEnergy += pfCandidate->positionAtECALEntrance().eta()*pfCandidate->energy();
+  for (const auto& pfCandidate : signalPFCands) {
+    sumEtaTimesEnergy += pfCandidate->positionAtECALEntrance().eta() * pfCandidate->energy();
     sumEnergy += pfCandidate->energy();
   }
-  if ( sumEnergy > 0. ) {
-    TauEtaAtEcalEntrance = sumEtaTimesEnergy/sumEnergy;
+  if (sumEnergy > 0.) {
+    TauEtaAtEcalEntrance = sumEtaTimesEnergy / sumEnergy;
   }
-  
+
   float TauLeadChargedPFCandEtaAtEcalEntrance = -99.;
   float TauLeadChargedPFCandPt = -99.;
-  for ( const auto & pfCandidate : signalPFCands ) {
+  for (const auto& pfCandidate : signalPFCands) {
     const reco::Track* track = nullptr;
-    if ( pfCandidate->trackRef().isNonnull() ) track = pfCandidate->trackRef().get();
-    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->innerTrack().isNonnull()  ) track = pfCandidate->muonRef()->innerTrack().get();
-    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->globalTrack().isNonnull() ) track = pfCandidate->muonRef()->globalTrack().get();
-    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->outerTrack().isNonnull()  ) track = pfCandidate->muonRef()->outerTrack().get();
-    else if ( pfCandidate->gsfTrackRef().isNonnull() ) track = pfCandidate->gsfTrackRef().get();
-    if ( track ) {
-      if ( track->pt() > TauLeadChargedPFCandPt ) {
-	TauLeadChargedPFCandEtaAtEcalEntrance = pfCandidate->positionAtECALEntrance().eta();
-	TauLeadChargedPFCandPt = track->pt();
+    if (pfCandidate->trackRef().isNonnull())
+      track = pfCandidate->trackRef().get();
+    else if (pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->innerTrack().isNonnull())
+      track = pfCandidate->muonRef()->innerTrack().get();
+    else if (pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->globalTrack().isNonnull())
+      track = pfCandidate->muonRef()->globalTrack().get();
+    else if (pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->outerTrack().isNonnull())
+      track = pfCandidate->muonRef()->outerTrack().get();
+    else if (pfCandidate->gsfTrackRef().isNonnull())
+      track = pfCandidate->gsfTrackRef().get();
+    if (track) {
+      if (track->pt() > TauLeadChargedPFCandPt) {
+        TauLeadChargedPFCandEtaAtEcalEntrance = pfCandidate->positionAtECALEntrance().eta();
+        TauLeadChargedPFCandPt = track->pt();
       }
     }
   }
@@ -765,9 +769,9 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
   Float_t TauEmFraction = std::max(thePFTau.emFraction(), (Float_t)0.);
   Float_t TauLeadPFChargedHadrHoP = 0.;
   Float_t TauLeadPFChargedHadrEoP = 0.;
-  if ( thePFTau.leadPFChargedHadrCand()->p() > 0. ) {
-    TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
-    TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
+  if (thePFTau.leadPFChargedHadrCand()->p() > 0.) {
+    TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy() / thePFTau.leadPFChargedHadrCand()->p();
+    TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy() / thePFTau.leadPFChargedHadrCand()->p();
   }
 
   std::vector<Float_t> GammasdEtaInSigCone;
@@ -776,20 +780,19 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
   std::vector<Float_t> GammasdEtaOutSigCone;
   std::vector<Float_t> GammasdPhiOutSigCone;
   std::vector<Float_t> GammasPtOutSigCone;
-  reco::Candidate::LorentzVector pfGammaSum(0,0,0,0);
-  reco::Candidate::LorentzVector pfChargedSum(0,0,0,0);
-  
-  for ( const auto & gamma : thePFTau.signalGammaCands() ) {
+  reco::Candidate::LorentzVector pfGammaSum(0, 0, 0, 0);
+  reco::Candidate::LorentzVector pfChargedSum(0, 0, 0, 0);
+
+  for (const auto& gamma : thePFTau.signalGammaCands()) {
     float dR = deltaR(gamma->p4(), thePFTau.leadChargedHadrCand()->p4());
-    float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, thePFTau.pt())));
+    float signalrad = std::max(0.05, std::min(0.10, 3.0 / std::max(1.0, thePFTau.pt())));
 
     // pfGammas inside the tau signal cone
     if (dR < signalrad) {
-      if ( thePFTau.leadChargedHadrCand().isNonnull() ) {
+      if (thePFTau.leadChargedHadrCand().isNonnull()) {
         GammasdEtaInSigCone.push_back(gamma->eta() - thePFTau.leadChargedHadrCand()->eta());
         GammasdPhiInSigCone.push_back(gamma->phi() - thePFTau.leadChargedHadrCand()->phi());
-      }
-      else {
+      } else {
         GammasdEtaInSigCone.push_back(gamma->eta() - thePFTau.eta());
         GammasdPhiInSigCone.push_back(gamma->phi() - thePFTau.phi());
       }
@@ -798,28 +801,27 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
     }
     // pfGammas outside the tau signal cone
     else {
-      if ( thePFTau.leadChargedHadrCand().isNonnull() ) {
+      if (thePFTau.leadChargedHadrCand().isNonnull()) {
         GammasdEtaOutSigCone.push_back(gamma->eta() - thePFTau.leadChargedHadrCand()->eta());
         GammasdPhiOutSigCone.push_back(gamma->phi() - thePFTau.leadChargedHadrCand()->phi());
-      } 
-      else {
+      } else {
         GammasdEtaOutSigCone.push_back(gamma->eta() - thePFTau.eta());
         GammasdPhiOutSigCone.push_back(gamma->phi() - thePFTau.phi());
       }
       GammasPtOutSigCone.push_back(gamma->pt());
     }
   }
-  
-  for ( const auto & charged : thePFTau.signalChargedHadrCands() ) {
+
+  for (const auto& charged : thePFTau.signalChargedHadrCands()) {
     float dR = deltaR(charged->p4(), thePFTau.leadChargedHadrCand()->p4());
-    float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, thePFTau.pt())));
-  
+    float signalrad = std::max(0.05, std::min(0.10, 3.0 / std::max(1.0, thePFTau.pt())));
+
     // charged particles inside the tau signal cone
     if (dR < signalrad) {
-        pfChargedSum += charged->p4();
+      pfChargedSum += charged->p4();
     }
   }
-  
+
   Int_t TauSignalPFGammaCandsIn = GammasPtInSigCone.size();
   Int_t TauSignalPFGammaCandsOut = GammasPtOutSigCone.size();
   Float_t TauVisMassIn = (pfGammaSum + pfChargedSum).mass();
@@ -827,31 +829,30 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
   Float_t TauPhi = thePFTau.phi();
   float sumPhiTimesEnergy = 0.;
   float sumEnergyPhi = 0.;
-  if ( !usePhiAtEcalEntranceExtrapolation_ ){
-    for ( const auto & pfCandidate : signalPFCands ) {
-      sumPhiTimesEnergy += pfCandidate->positionAtECALEntrance().phi()*pfCandidate->energy();
+  if (!usePhiAtEcalEntranceExtrapolation_) {
+    for (const auto& pfCandidate : signalPFCands) {
+      sumPhiTimesEnergy += pfCandidate->positionAtECALEntrance().phi() * pfCandidate->energy();
       sumEnergyPhi += pfCandidate->energy();
     }
-  }
-  else{
-    TauPhi= -99.;
-    for ( const auto & signalPFCand : signalPFCands ) {
-      reco::Candidate const*  signalCand = signalPFCand.get();
+  } else {
+    TauPhi = -99.;
+    for (const auto& signalPFCand : signalPFCands) {
+      reco::Candidate const* signalCand = signalPFCand.get();
       float phi = thePFTau.phi();
       math::XYZPoint aPos;
-      if ( atECalEntrance(signalCand, aPos) == true ) phi = aPos.Phi();
-      sumPhiTimesEnergy += phi*signalCand->energy();     
+      if (atECalEntrance(signalCand, aPos) == true)
+        phi = aPos.Phi();
+      sumPhiTimesEnergy += phi * signalCand->energy();
       sumEnergy += signalCand->energy();
     }
   }
-  if ( sumEnergyPhi > 0. ) {
-    TauPhi = sumPhiTimesEnergy/sumEnergyPhi;
+  if (sumEnergyPhi > 0.) {
+    TauPhi = sumPhiTimesEnergy / sumEnergyPhi;
   }
   Float_t TaudCrackPhi = dCrackPhi(TauPhi, TauEtaAtEcalEntrance);
   Float_t TaudCrackEta = dCrackEta(TauEtaAtEcalEntrance);
   Float_t TauHasGsf = thePFTau.leadPFChargedHadrCand()->gsfTrackRef().isNonnull();
 
-  
   // === electron variables ===
   Float_t dummyElecEta = 9.9;
 
@@ -894,11 +895,10 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
                   0.);
 }
 
-double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron& theEle)
-{
+double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron& theEle) {
   // === tau variables ===
   float TauEtaAtEcalEntrance = theTau.etaAtEcalEntrance();
-  
+
   float TauLeadChargedPFCandEtaAtEcalEntrance = theTau.etaAtEcalEntranceLeadChargedCand();
   float TauLeadChargedPFCandPt = theTau.ptLeadChargedCand();
 
@@ -907,9 +907,9 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron&
   Float_t TauEmFraction = std::max(theTau.emFraction_MVA(), (Float_t)0.);
   Float_t TauLeadPFChargedHadrHoP = 0.;
   Float_t TauLeadPFChargedHadrEoP = 0.;
-  if ( theTau.leadChargedHadrCand()->p() > 0. ) {
-    TauLeadPFChargedHadrHoP = theTau.hcalEnergyLeadChargedHadrCand()/theTau.leadChargedHadrCand()->p();
-    TauLeadPFChargedHadrEoP = theTau.ecalEnergyLeadChargedHadrCand()/theTau.leadChargedHadrCand()->p();
+  if (theTau.leadChargedHadrCand()->p() > 0.) {
+    TauLeadPFChargedHadrHoP = theTau.hcalEnergyLeadChargedHadrCand() / theTau.leadChargedHadrCand()->p();
+    TauLeadPFChargedHadrEoP = theTau.ecalEnergyLeadChargedHadrCand() / theTau.leadChargedHadrCand()->p();
   }
 
   std::vector<Float_t> GammasdEtaInSigCone;
@@ -918,26 +918,25 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron&
   std::vector<Float_t> GammasdEtaOutSigCone;
   std::vector<Float_t> GammasdPhiOutSigCone;
   std::vector<Float_t> GammasPtOutSigCone;
-  reco::Candidate::LorentzVector pfGammaSum(0,0,0,0);
-  reco::Candidate::LorentzVector pfChargedSum(0,0,0,0);
-  
+  reco::Candidate::LorentzVector pfGammaSum(0, 0, 0, 0);
+  reco::Candidate::LorentzVector pfChargedSum(0, 0, 0, 0);
+
   const reco::CandidatePtrVector signalGammaCands = theTau.signalGammaCands();
-  for ( const auto & gamma : signalGammaCands ) {
+  for (const auto& gamma : signalGammaCands) {
     float dR = deltaR(gamma->p4(), theTau.leadChargedHadrCand()->p4());
-    float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, theTau.pt())));
+    float signalrad = std::max(0.05, std::min(0.10, 3.0 / std::max(1.0, theTau.pt())));
 
     // pfGammas inside the tau signal cone
     if (dR < signalrad) {
-      if ( theTau.leadChargedHadrCand().isNonnull() ) {
+      if (theTau.leadChargedHadrCand().isNonnull()) {
         GammasdEtaInSigCone.push_back(gamma->eta() - theTau.leadChargedHadrCand()->eta());
         GammasdPhiInSigCone.push_back(gamma->phi() - theTau.leadChargedHadrCand()->phi());
-	//A.-C. please check whether this change is safe against future trainings
+        //A.-C. please check whether this change is safe against future trainings
         //GammasdPhiInSigCone.push_back(deltaPhi((*gamma)->phi(), theTau.leadChargedHadrCand()->phi()));
-      }
-      else {
+      } else {
         GammasdEtaInSigCone.push_back(gamma->eta() - theTau.eta());
         GammasdPhiInSigCone.push_back(gamma->phi() - theTau.phi());
-	//A.-C. please check whether this change is safe against future trainings	
+        //A.-C. please check whether this change is safe against future trainings
         //GammasdPhiInSigCone.push_back(deltaPhi(gamma->phi(), theTau.phi()));
       }
       GammasPtInSigCone.push_back(gamma->pt());
@@ -945,108 +944,113 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron&
     }
     // pfGammas outside the tau signal cone
     else {
-      if ( theTau.leadChargedHadrCand().isNonnull() ) {
+      if (theTau.leadChargedHadrCand().isNonnull()) {
         GammasdEtaOutSigCone.push_back(gamma->eta() - theTau.leadChargedHadrCand()->eta());
         GammasdPhiOutSigCone.push_back(gamma->phi() - theTau.leadChargedHadrCand()->phi());
-	//A.-C. please check whether this change is safe against future trainings		
+        //A.-C. please check whether this change is safe against future trainings
         //GammasdPhiOutSigCone.push_back(deltaPhi(gamma->phi(), theTau.leadChargedHadrCand()->phi()));
-      } 
-      else {
+      } else {
         GammasdEtaOutSigCone.push_back(gamma->eta() - theTau.eta());
         GammasdPhiOutSigCone.push_back(gamma->phi() - theTau.phi());
-	//A.-C. please chaekc whether this change is safe against future trainings		
+        //A.-C. please chaekc whether this change is safe against future trainings
         //GammasdPhiOutSigCone.push_back(deltaPhi(gamma->phi(), theTau.phi()));
       }
       GammasPtOutSigCone.push_back(gamma->pt());
     }
   }
-  
+
   const reco::CandidatePtrVector signalChargedCands = theTau.signalChargedHadrCands();
-  for ( const auto & charged : signalChargedCands ) {
+  for (const auto& charged : signalChargedCands) {
     float dR = deltaR(charged->p4(), theTau.leadChargedHadrCand()->p4());
-    float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, theTau.pt())));
-  
+    float signalrad = std::max(0.05, std::min(0.10, 3.0 / std::max(1.0, theTau.pt())));
+
     // charged particles inside the tau signal cone
     if (dR < signalrad) {
       pfChargedSum += charged->p4();
     }
   }
-  
+
   Int_t TauSignalPFGammaCandsIn = GammasPtInSigCone.size();
   Int_t TauSignalPFGammaCandsOut = GammasPtOutSigCone.size();
   Float_t TauVisMassIn = (pfGammaSum + pfChargedSum).mass();
   Float_t TauPhi = -99.;
-  if ( usePhiAtEcalEntranceExtrapolation_ ) {
+  if (usePhiAtEcalEntranceExtrapolation_) {
     float sumPhiTimesEnergy = 0.;
     float sumEnergy = 0.;
     const reco::CandidatePtrVector signalCands = theTau.signalCands();
-    for ( const auto & signalCandPtr : signalCands ) {
+    for (const auto& signalCandPtr : signalCands) {
       reco::Candidate const* signalCand = signalCandPtr.get();
       float phi = theTau.phi();
       math::XYZPoint aPos;
-      if ( atECalEntrance(signalCand, aPos) == true ) phi = aPos.Phi();
-      sumPhiTimesEnergy += phi*signalCand->energy();	  
+      if (atECalEntrance(signalCand, aPos) == true)
+        phi = aPos.Phi();
+      sumPhiTimesEnergy += phi * signalCand->energy();
       sumEnergy += signalCand->energy();
     }
-    if ( sumEnergy > 0. ) {
-      TauPhi = sumPhiTimesEnergy/sumEnergy;
+    if (sumEnergy > 0.) {
+      TauPhi = sumPhiTimesEnergy / sumEnergy;
     }
-  }
-  else {
+  } else {
     TauPhi = theTau.phiAtEcalEntrance();
-  } 
+  }
 
   Float_t TaudCrackPhi = dCrackPhi(TauPhi, TauEtaAtEcalEntrance);
-  Float_t TaudCrackEta = dCrackEta(TauEtaAtEcalEntrance); 
-  
+  Float_t TaudCrackEta = dCrackEta(TauEtaAtEcalEntrance);
+
   Float_t TauHasGsf = 0;
-  pat::PackedCandidate const* packedLeadTauCand = dynamic_cast<pat::PackedCandidate const*>(theTau.leadChargedHadrCand().get());
-  if( abs(packedLeadTauCand->pdgId()) == 11 ) TauHasGsf = 1;
-  
+  pat::PackedCandidate const* packedLeadTauCand =
+      dynamic_cast<pat::PackedCandidate const*>(theTau.leadChargedHadrCand().get());
+  if (abs(packedLeadTauCand->pdgId()) == 11)
+    TauHasGsf = 1;
+
   // === electron variables ===
   Float_t ElecEta = theEle.eta();
   Float_t ElecPhi = theEle.phi();
-                  
+
   //Variables related to the electron Cluster
   Float_t ElecEe = 0.;
   Float_t ElecEgamma = 0.;
   reco::SuperClusterRef pfSuperCluster = theEle.superCluster();
-  if ( pfSuperCluster.isNonnull() && pfSuperCluster.isAvailable() ) {
-    for ( reco::CaloCluster_iterator pfCluster = pfSuperCluster->clustersBegin(); pfCluster != pfSuperCluster->clustersEnd(); ++pfCluster ) {
+  if (pfSuperCluster.isNonnull() && pfSuperCluster.isAvailable()) {
+    for (reco::CaloCluster_iterator pfCluster = pfSuperCluster->clustersBegin();
+         pfCluster != pfSuperCluster->clustersEnd();
+         ++pfCluster) {
       double pfClusterEn = (*pfCluster)->energy();
-      if ( pfCluster == pfSuperCluster->clustersBegin() ) ElecEe += pfClusterEn;
-      else ElecEgamma += pfClusterEn;
+      if (pfCluster == pfSuperCluster->clustersBegin())
+        ElecEe += pfClusterEn;
+      else
+        ElecEgamma += pfClusterEn;
     }
   }
-  
+
   Float_t ElecPin = std::sqrt(theEle.trackMomentumAtVtx().Mag2());
-  Float_t ElecPout = std::sqrt(theEle.trackMomentumOut().Mag2());  
-  Float_t ElecEtotOverPin = (ElecPin > 0.0) ? ((ElecEe + ElecEgamma)/ElecPin) : -0.1;
+  Float_t ElecPout = std::sqrt(theEle.trackMomentumOut().Mag2());
+  Float_t ElecEtotOverPin = (ElecPin > 0.0) ? ((ElecEe + ElecEgamma) / ElecPin) : -0.1;
   Float_t ElecEecal = theEle.ecalEnergy();
   Float_t ElecDeltaEta = theEle.deltaEtaSeedClusterTrackAtCalo();
   Float_t ElecDeltaPhi = theEle.deltaPhiSeedClusterTrackAtCalo();
   Float_t ElecMvaInSigmaEtaEta = (theEle).mvaInput().sigmaEtaEta;
   Float_t ElecMvaInHadEnergy = (theEle).mvaInput().hadEnergy;
   Float_t ElecMvaInDeltaEta = (theEle).mvaInput().deltaEta;
-  
+
   //Variables related to the GsfTrack
   Float_t ElecChi2NormGSF = -99.;
   Float_t ElecGSFNumHits = -99.;
   Float_t ElecGSFTrackResol = -99.;
   Float_t ElecGSFTracklnPt = -99.;
-  if ( theEle.gsfTrack().isNonnull() ) {
+  if (theEle.gsfTrack().isNonnull()) {
     ElecChi2NormGSF = (theEle).gsfTrack()->normalizedChi2();
     ElecGSFNumHits = (theEle).gsfTrack()->numberOfValidHits();
-    if ( theEle.gsfTrack()->pt() > 0. ) {
-      ElecGSFTrackResol = theEle.gsfTrack()->ptError()/theEle.gsfTrack()->pt();
-      ElecGSFTracklnPt = log(theEle.gsfTrack()->pt())*M_LN10;
+    if (theEle.gsfTrack()->pt() > 0.) {
+      ElecGSFTrackResol = theEle.gsfTrack()->ptError() / theEle.gsfTrack()->pt();
+      ElecGSFTracklnPt = log(theEle.gsfTrack()->pt()) * M_LN10;
     }
   }
 
   //Variables related to the CtfTrack
   Float_t ElecChi2NormKF = -99.;
   Float_t ElecKFNumHits = -99.;
-  if ( theEle.closestCtfTrackRef().isNonnull() ) {
+  if (theEle.closestCtfTrackRef().isNonnull()) {
     ElecChi2NormKF = (theEle).closestCtfTrackRef()->normalizedChi2();
     ElecKFNumHits = (theEle).closestCtfTrackRef()->numberOfValidHits();
   }
@@ -1090,11 +1094,10 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron&
                   ElecMvaInDeltaEta);
 }
 
-double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau)
-{
+double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau) {
   // === tau variables ===
   float TauEtaAtEcalEntrance = theTau.etaAtEcalEntrance();
-  
+
   float TauLeadChargedPFCandEtaAtEcalEntrance = theTau.etaAtEcalEntranceLeadChargedCand();
   float TauLeadChargedPFCandPt = theTau.ptLeadChargedCand();
 
@@ -1103,9 +1106,9 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau)
   Float_t TauEmFraction = std::max(theTau.emFraction_MVA(), (Float_t)0.);
   Float_t TauLeadPFChargedHadrHoP = 0.;
   Float_t TauLeadPFChargedHadrEoP = 0.;
-  if ( theTau.leadChargedHadrCand()->p() > 0. ) {
-    TauLeadPFChargedHadrHoP = theTau.hcalEnergyLeadChargedHadrCand()/theTau.leadChargedHadrCand()->p();
-    TauLeadPFChargedHadrEoP = theTau.ecalEnergyLeadChargedHadrCand()/theTau.leadChargedHadrCand()->p();
+  if (theTau.leadChargedHadrCand()->p() > 0.) {
+    TauLeadPFChargedHadrHoP = theTau.hcalEnergyLeadChargedHadrCand() / theTau.leadChargedHadrCand()->p();
+    TauLeadPFChargedHadrEoP = theTau.ecalEnergyLeadChargedHadrCand() / theTau.leadChargedHadrCand()->p();
   }
 
   std::vector<Float_t> GammasdEtaInSigCone;
@@ -1114,21 +1117,20 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau)
   std::vector<Float_t> GammasdEtaOutSigCone;
   std::vector<Float_t> GammasdPhiOutSigCone;
   std::vector<Float_t> GammasPtOutSigCone;
-  reco::Candidate::LorentzVector pfGammaSum(0,0,0,0);
-  reco::Candidate::LorentzVector pfChargedSum(0,0,0,0);
-  
+  reco::Candidate::LorentzVector pfGammaSum(0, 0, 0, 0);
+  reco::Candidate::LorentzVector pfChargedSum(0, 0, 0, 0);
+
   const reco::CandidatePtrVector signalGammaCands = theTau.signalGammaCands();
-  for ( const auto & gamma : signalGammaCands ) {
+  for (const auto& gamma : signalGammaCands) {
     float dR = deltaR(gamma->p4(), theTau.leadChargedHadrCand()->p4());
-    float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, theTau.pt())));
+    float signalrad = std::max(0.05, std::min(0.10, 3.0 / std::max(1.0, theTau.pt())));
 
     // pfGammas inside the tau signal cone
     if (dR < signalrad) {
-      if ( theTau.leadChargedHadrCand().isNonnull() ) {
+      if (theTau.leadChargedHadrCand().isNonnull()) {
         GammasdEtaInSigCone.push_back(gamma->eta() - theTau.leadChargedHadrCand()->eta());
         GammasdPhiInSigCone.push_back(gamma->phi() - theTau.leadChargedHadrCand()->phi());
-      }
-      else {
+      } else {
         GammasdEtaInSigCone.push_back(gamma->eta() - theTau.eta());
         GammasdPhiInSigCone.push_back(gamma->phi() - theTau.phi());
       }
@@ -1137,61 +1139,62 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau)
     }
     // pfGammas outside the tau signal cone
     else {
-      if ( theTau.leadChargedHadrCand().isNonnull() ) {
+      if (theTau.leadChargedHadrCand().isNonnull()) {
         GammasdEtaOutSigCone.push_back(gamma->eta() - theTau.leadChargedHadrCand()->eta());
         GammasdPhiOutSigCone.push_back(gamma->phi() - theTau.leadChargedHadrCand()->phi());
-      } 
-      else {
+      } else {
         GammasdEtaOutSigCone.push_back(gamma->eta() - theTau.eta());
         GammasdPhiOutSigCone.push_back(gamma->phi() - theTau.phi());
       }
       GammasPtOutSigCone.push_back(gamma->pt());
     }
   }
-  
+
   const reco::CandidatePtrVector signalChargedCands = theTau.signalChargedHadrCands();
-  for ( const auto & charged : signalChargedCands ) {
+  for (const auto& charged : signalChargedCands) {
     float dR = deltaR(charged->p4(), theTau.leadChargedHadrCand()->p4());
-    float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, theTau.pt())));
-  
+    float signalrad = std::max(0.05, std::min(0.10, 3.0 / std::max(1.0, theTau.pt())));
+
     // charged particles inside the tau signal cone
     if (dR < signalrad) {
-        pfChargedSum += charged->p4();
+      pfChargedSum += charged->p4();
     }
   }
-  
+
   Int_t TauSignalPFGammaCandsIn = GammasPtInSigCone.size();
   Int_t TauSignalPFGammaCandsOut = GammasPtOutSigCone.size();
   Float_t TauVisMassIn = (pfGammaSum + pfChargedSum).mass();
   Float_t TauPhi = -99.;
-  if ( usePhiAtEcalEntranceExtrapolation_ ) {
+  if (usePhiAtEcalEntranceExtrapolation_) {
     float sumPhiTimesEnergy = 0.;
     float sumEnergy = 0.;
     const reco::CandidatePtrVector signalCands = theTau.signalCands();
-    for ( const auto & signalCandPtr : signalCands ) {
+    for (const auto& signalCandPtr : signalCands) {
       reco::Candidate const* signalCand = signalCandPtr.get();
       float phi = theTau.phi();
       math::XYZPoint aPos;
-      if ( atECalEntrance(signalCand, aPos) == true ) phi = aPos.Phi();
-      sumPhiTimesEnergy += phi*signalCand->energy();	  
+      if (atECalEntrance(signalCand, aPos) == true)
+        phi = aPos.Phi();
+      sumPhiTimesEnergy += phi * signalCand->energy();
       sumEnergy += signalCand->energy();
     }
-    if ( sumEnergy > 0. ) {
-      TauPhi = sumPhiTimesEnergy/sumEnergy;
+    if (sumEnergy > 0.) {
+      TauPhi = sumPhiTimesEnergy / sumEnergy;
     }
-  }
-  else {
+  } else {
     TauPhi = theTau.phiAtEcalEntrance();
-  } 
+  }
 
   Float_t TaudCrackPhi = dCrackPhi(TauPhi, TauEtaAtEcalEntrance);
-  Float_t TaudCrackEta = dCrackEta(TauEtaAtEcalEntrance); 
-  
+  Float_t TaudCrackEta = dCrackEta(TauEtaAtEcalEntrance);
+
   Float_t TauHasGsf = 0;
-  pat::PackedCandidate const* packedLeadTauCand = dynamic_cast<pat::PackedCandidate const*>(theTau.leadChargedHadrCand().get());
+  pat::PackedCandidate const* packedLeadTauCand =
+      dynamic_cast<pat::PackedCandidate const*>(theTau.leadChargedHadrCand().get());
   //const reco::Track & pseudoTrack = packedLeadTauCand->pseudoTrack();
-  if( abs(packedLeadTauCand->pdgId()) == 11 ) TauHasGsf = 1;
-  
+  if (abs(packedLeadTauCand->pdgId()) == 11)
+    TauHasGsf = 1;
+
   // === electron variables ===
   Float_t dummyElecEta = 9.9;
 
@@ -1234,91 +1237,92 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau)
                   0.);
 }
 
-double AntiElectronIDMVA6::minimum(double a, double b)
-{
-  if ( std::abs(b) < std::abs(a) ) return b;
-  else return a;
+double AntiElectronIDMVA6::minimum(double a, double b) {
+  if (std::abs(b) < std::abs(a))
+    return b;
+  else
+    return a;
 }
 
 namespace {
 
   // IN: define locations of the 18 phi-cracks
- std::array<double,18> fill_cPhi() {
-   constexpr double pi = M_PI; // 3.14159265358979323846;
-   std::array<double,18> cPhi;
-   // IN: define locations of the 18 phi-cracks
-   cPhi[0] = 2.97025;
-   for ( unsigned iCrack = 1; iCrack <= 17; ++iCrack ) {
-     cPhi[iCrack] = cPhi[0] - 2.*iCrack*pi/18;
-   }
-   return cPhi;
- }
-     
-  const std::array<double,18> cPhi = fill_cPhi();
+  std::array<double, 18> fill_cPhi() {
+    constexpr double pi = M_PI;  // 3.14159265358979323846;
+    std::array<double, 18> cPhi;
+    // IN: define locations of the 18 phi-cracks
+    cPhi[0] = 2.97025;
+    for (unsigned iCrack = 1; iCrack <= 17; ++iCrack) {
+      cPhi[iCrack] = cPhi[0] - 2. * iCrack * pi / 18;
+    }
+    return cPhi;
+  }
 
-}
+  const std::array<double, 18> cPhi = fill_cPhi();
 
-double AntiElectronIDMVA6::dCrackPhi(double phi, double eta)
-{
-//--- compute the (unsigned) distance to the closest phi-crack in the ECAL barrel  
+}  // namespace
 
-  constexpr double pi = M_PI; // 3.14159265358979323846;
+double AntiElectronIDMVA6::dCrackPhi(double phi, double eta) {
+  //--- compute the (unsigned) distance to the closest phi-crack in the ECAL barrel
+
+  constexpr double pi = M_PI;  // 3.14159265358979323846;
 
   // IN: shift of this location if eta < 0
   constexpr double delta_cPhi = 0.00638;
 
-  double retVal = 99.; 
+  double retVal = 99.;
 
-  if ( eta >= -1.47464 && eta <= 1.47464 ) {
-
+  if (eta >= -1.47464 && eta <= 1.47464) {
     // the location is shifted
-    if ( eta < 0. ) phi += delta_cPhi;
+    if (eta < 0.)
+      phi += delta_cPhi;
 
     // CV: need to bring-back phi into interval [-pi,+pi]
-    if ( phi >  pi ) phi -= 2.*pi;
-    if ( phi < -pi ) phi += 2.*pi;
+    if (phi > pi)
+      phi -= 2. * pi;
+    if (phi < -pi)
+      phi += 2. * pi;
 
-    if ( phi >= -pi && phi <= pi ) {
-
+    if (phi >= -pi && phi <= pi) {
       // the problem of the extrema:
-      if ( phi < cPhi[17] || phi >= cPhi[0] ) {
-	if ( phi < 0. ) phi += 2.*pi;
-	retVal = minimum(phi - cPhi[0], phi - cPhi[17] - 2.*pi);        	
+      if (phi < cPhi[17] || phi >= cPhi[0]) {
+        if (phi < 0.)
+          phi += 2. * pi;
+        retVal = minimum(phi - cPhi[0], phi - cPhi[17] - 2. * pi);
       } else {
-	// between these extrema...
-	bool OK = false;
-	unsigned iCrack = 16;
-	while( !OK ) {
-	  if ( phi < cPhi[iCrack] ) {
-	    retVal = minimum(phi - cPhi[iCrack + 1], phi - cPhi[iCrack]);
-	    OK = true;
-	  } else {
-	    iCrack -= 1;
-	  }
-	}
+        // between these extrema...
+        bool OK = false;
+        unsigned iCrack = 16;
+        while (!OK) {
+          if (phi < cPhi[iCrack]) {
+            retVal = minimum(phi - cPhi[iCrack + 1], phi - cPhi[iCrack]);
+            OK = true;
+          } else {
+            iCrack -= 1;
+          }
+        }
       }
     } else {
-      retVal = 0.; // IN: if there is a problem, we assume that we are in a crack
+      retVal = 0.;  // IN: if there is a problem, we assume that we are in a crack
     }
   } else {
-    return -99.;       
+    return -99.;
   }
-  
+
   return std::abs(retVal);
 }
 
-double AntiElectronIDMVA6::dCrackEta(double eta)
-{
-//--- compute the (unsigned) distance to the closest eta-crack in the ECAL barrel
-  
+double AntiElectronIDMVA6::dCrackEta(double eta) {
+  //--- compute the (unsigned) distance to the closest eta-crack in the ECAL barrel
+
   // IN: define locations of the eta-cracks
-  double cracks[5] = { 0., 4.44747e-01, 7.92824e-01, 1.14090e+00, 1.47464e+00 };
-  
+  double cracks[5] = {0., 4.44747e-01, 7.92824e-01, 1.14090e+00, 1.47464e+00};
+
   double retVal = 99.;
-  
-  for ( int iCrack = 0; iCrack < 5 ; ++iCrack ) {
+
+  for (int iCrack = 0; iCrack < 5; ++iCrack) {
     double d = minimum(eta - cracks[iCrack], eta + cracks[iCrack]);
-    if ( std::abs(d) < std::abs(retVal) ) {
+    if (std::abs(d) < std::abs(retVal)) {
       retVal = d;
     }
   }
@@ -1326,26 +1330,20 @@ double AntiElectronIDMVA6::dCrackEta(double eta)
   return std::abs(retVal);
 }
 
-bool AntiElectronIDMVA6::atECalEntrance(const reco::Candidate* part, math::XYZPoint &pos)
-{
+bool AntiElectronIDMVA6::atECalEntrance(const reco::Candidate* part, math::XYZPoint& pos) {
   bool result = false;
-  BaseParticlePropagator theParticle =
-    BaseParticlePropagator(RawParticle(math::XYZTLorentzVector(part->px(),
-							       part->py(),
-							       part->pz(),
-							       part->energy()),
-				       math::XYZTLorentzVector(part->vertex().x(),
-							       part->vertex().y(),
-							       part->vertex().z(),
-							       0.),
-                                       part->charge()), 
-			   0.,0.,bField_);
+  BaseParticlePropagator theParticle = BaseParticlePropagator(
+      RawParticle(math::XYZTLorentzVector(part->px(), part->py(), part->pz(), part->energy()),
+                  math::XYZTLorentzVector(part->vertex().x(), part->vertex().y(), part->vertex().z(), 0.),
+                  part->charge()),
+      0.,
+      0.,
+      bField_);
   theParticle.propagateToEcalEntrance(false);
-  if(theParticle.getSuccess()!=0){
+  if (theParticle.getSuccess() != 0) {
     pos = math::XYZPoint(theParticle.particle().vertex());
     result = true;
-  }
-  else {
+  } else {
     result = false;
   }
   return result;

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -7,174 +7,169 @@
  * \author Maria Rosaria Di Domenico, University of Siena & INFN Pisa
  */
 
-
 #include "RecoTauTag/RecoTau/interface/DeepTauBase.h"
 
 namespace deep_tau {
 
-TauWPThreshold::TauWPThreshold(const std::string& cut_str)
-{
+  TauWPThreshold::TauWPThreshold(const std::string& cut_str) {
     bool simple_value = false;
     try {
-        size_t pos = 0;
-        value_ = std::stod(cut_str, &pos);
-        simple_value = (pos == cut_str.size());
-    } catch(std::invalid_argument&) {
-    } catch(std::out_of_range&) {
+      size_t pos = 0;
+      value_ = std::stod(cut_str, &pos);
+      simple_value = (pos == cut_str.size());
+    } catch (std::invalid_argument&) {
+    } catch (std::out_of_range&) {
     }
-    if(!simple_value) {
-        static const std::string prefix = "[&](double *x, double *p) { const int decayMode = p[0];"
-                                          "const double pt = p[1]; const double eta = p[2];";
-        static const int n_params = 3;
-        static const auto handler = [](int, Bool_t, const char*, const char*) -> void {};
+    if (!simple_value) {
+      static const std::string prefix =
+          "[&](double *x, double *p) { const int decayMode = p[0];"
+          "const double pt = p[1]; const double eta = p[2];";
+      static const int n_params = 3;
+      static const auto handler = [](int, Bool_t, const char*, const char*) -> void {};
 
-        const std::string fn_str = prefix + cut_str + "}";
-        auto old_handler = SetErrorHandler(handler);
-        fn_ = std::make_unique<TF1>("fn_", fn_str.c_str(), 0, 1, n_params);
-        SetErrorHandler(old_handler);
-        if(!fn_->IsValid())
-            throw cms::Exception("TauWPThreshold: invalid formula") << "Invalid WP cut formula = '" << cut_str << "'.";
+      const std::string fn_str = prefix + cut_str + "}";
+      auto old_handler = SetErrorHandler(handler);
+      fn_ = std::make_unique<TF1>("fn_", fn_str.c_str(), 0, 1, n_params);
+      SetErrorHandler(old_handler);
+      if (!fn_->IsValid())
+        throw cms::Exception("TauWPThreshold: invalid formula") << "Invalid WP cut formula = '" << cut_str << "'.";
     }
-}
+  }
 
-double TauWPThreshold::operator()(const pat::Tau& tau) const
-{
-    if(!fn_)
-        return value_;
+  double TauWPThreshold::operator()(const pat::Tau& tau) const {
+    if (!fn_)
+      return value_;
     fn_->SetParameter(0, tau.decayMode());
     fn_->SetParameter(1, tau.pt());
     fn_->SetParameter(2, tau.eta());
     return fn_->Eval(0);
-}
+  }
 
-DeepTauBase::Output::ResultMap DeepTauBase::Output::get_value(const edm::Handle<TauCollection>& taus,
-                                                              const tensorflow::Tensor& pred,
-                                                              const WPMap& working_points) const
-{
+  DeepTauBase::Output::ResultMap DeepTauBase::Output::get_value(const edm::Handle<TauCollection>& taus,
+                                                                const tensorflow::Tensor& pred,
+                                                                const WPMap& working_points) const {
     ResultMap output;
     output[""] = std::make_unique<TauDiscriminator>(TauRefProd(taus));
-    for(const auto& wp : working_points)
-        output[wp.first] = std::make_unique<TauDiscriminator>(TauRefProd(taus));
+    for (const auto& wp : working_points)
+      output[wp.first] = std::make_unique<TauDiscriminator>(TauRefProd(taus));
 
-    for(size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
-        float x = 0;
-        for(size_t num_elem : num_)
-            x += pred.matrix<float>()(tau_index, num_elem);
-        if(x != 0 && !den_.empty()) {
-            float den_val = 0;
-            for(size_t den_elem : den_)
-                den_val += pred.matrix<float>()(tau_index, den_elem);
-            x = den_val != 0 ? x / den_val : std::numeric_limits<float>::max();
-        }
-        output[""]->setValue(tau_index, x);
-        for(const auto& wp : working_points) {
-            const auto& tau = taus->at(tau_index);
-            const bool pass = x > (*wp.second)(tau);
-            output[wp.first]->setValue(tau_index, pass);
-        }
+    for (size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
+      float x = 0;
+      for (size_t num_elem : num_)
+        x += pred.matrix<float>()(tau_index, num_elem);
+      if (x != 0 && !den_.empty()) {
+        float den_val = 0;
+        for (size_t den_elem : den_)
+          den_val += pred.matrix<float>()(tau_index, den_elem);
+        x = den_val != 0 ? x / den_val : std::numeric_limits<float>::max();
+      }
+      output[""]->setValue(tau_index, x);
+      for (const auto& wp : working_points) {
+        const auto& tau = taus->at(tau_index);
+        const bool pass = x > (*wp.second)(tau);
+        output[wp.first]->setValue(tau_index, pass);
+      }
     }
     return output;
-}
+  }
 
-DeepTauBase::DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputCollection,
-                         const DeepTauCache* cache) :
-    tausToken_(consumes<TauCollection>(cfg.getParameter<edm::InputTag>("taus"))),
-    pfcandToken_(consumes<pat::PackedCandidateCollection>(cfg.getParameter<edm::InputTag>("pfcands"))),
-    vtxToken_(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
-    outputs_(outputCollection),
-    cache_(cache)
-{
-    for(const auto& output_desc : outputs_) {
-        produces<TauDiscriminator>(output_desc.first);
-        const auto& cut_pset = cfg.getParameter<edm::ParameterSet>(output_desc.first + "WP");
-        for(const std::string& wp_name : cut_pset.getParameterNames()) {
-            const auto& cut_str = cut_pset.getParameter<std::string>(wp_name);
-            workingPoints_[output_desc.first][wp_name] = std::make_unique<Cutter>(cut_str);
-            produces<TauDiscriminator>(output_desc.first + wp_name);
-        }
+  DeepTauBase::DeepTauBase(const edm::ParameterSet& cfg,
+                           const OutputCollection& outputCollection,
+                           const DeepTauCache* cache)
+      : tausToken_(consumes<TauCollection>(cfg.getParameter<edm::InputTag>("taus"))),
+        pfcandToken_(consumes<pat::PackedCandidateCollection>(cfg.getParameter<edm::InputTag>("pfcands"))),
+        vtxToken_(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
+        outputs_(outputCollection),
+        cache_(cache) {
+    for (const auto& output_desc : outputs_) {
+      produces<TauDiscriminator>(output_desc.first);
+      const auto& cut_pset = cfg.getParameter<edm::ParameterSet>(output_desc.first + "WP");
+      for (const std::string& wp_name : cut_pset.getParameterNames()) {
+        const auto& cut_str = cut_pset.getParameter<std::string>(wp_name);
+        workingPoints_[output_desc.first][wp_name] = std::make_unique<Cutter>(cut_str);
+        produces<TauDiscriminator>(output_desc.first + wp_name);
+      }
     }
-}
+  }
 
-void DeepTauBase::produce(edm::Event& event, const edm::EventSetup& es)
-{
+  void DeepTauBase::produce(edm::Event& event, const edm::EventSetup& es) {
     edm::Handle<TauCollection> taus;
     event.getByToken(tausToken_, taus);
 
     const tensorflow::Tensor& pred = getPredictions(event, es, taus);
     createOutputs(event, pred, taus);
-}
+  }
 
-void DeepTauBase::createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus)
-{
-    for(const auto& output_desc : outputs_) {
-        auto result_map = output_desc.second.get_value(taus, pred, workingPoints_.at(output_desc.first));
-        for(auto& result : result_map)
-            event.put(std::move(result.second), output_desc.first + result.first);
+  void DeepTauBase::createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus) {
+    for (const auto& output_desc : outputs_) {
+      auto result_map = output_desc.second.get_value(taus, pred, workingPoints_.at(output_desc.first));
+      for (auto& result : result_map)
+        event.put(std::move(result.second), output_desc.first + result.first);
     }
-}
+  }
 
-std::unique_ptr<DeepTauCache> DeepTauBase::initializeGlobalCache(const edm::ParameterSet& cfg )
-{
+  std::unique_ptr<DeepTauCache> DeepTauBase::initializeGlobalCache(const edm::ParameterSet& cfg) {
     const auto graph_name_vector = cfg.getParameter<std::vector<std::string>>("graph_file");
     std::map<std::string, std::string> graph_names;
-    for(const auto& entry : graph_name_vector) {
-        const size_t sep_pos = entry.find(':');
-        std::string entry_name, graph_file;
-        if(sep_pos != std::string::npos) {
-            entry_name = entry.substr(0, sep_pos);
-            graph_file = entry.substr(sep_pos + 1);
-        } else {
-            entry_name = "";
-            graph_file = entry;
-        }
-        graph_file = edm::FileInPath(graph_file).fullPath();
-        if(graph_names.count(entry_name))
-            throw cms::Exception("DeepTauCache") << "Duplicated graph entries";
-        graph_names[entry_name] = graph_file;
+    for (const auto& entry : graph_name_vector) {
+      const size_t sep_pos = entry.find(':');
+      std::string entry_name, graph_file;
+      if (sep_pos != std::string::npos) {
+        entry_name = entry.substr(0, sep_pos);
+        graph_file = entry.substr(sep_pos + 1);
+      } else {
+        entry_name = "";
+        graph_file = entry;
+      }
+      graph_file = edm::FileInPath(graph_file).fullPath();
+      if (graph_names.count(entry_name))
+        throw cms::Exception("DeepTauCache") << "Duplicated graph entries";
+      graph_names[entry_name] = graph_file;
     }
     bool mem_mapped = cfg.getParameter<bool>("mem_mapped");
     return std::make_unique<DeepTauCache>(graph_names, mem_mapped);
-}
+  }
 
-DeepTauCache::DeepTauCache(const std::map<std::string, std::string>& graph_names, bool mem_mapped)
-{
-    for(const auto& graph_entry : graph_names) {
-        tensorflow::SessionOptions options;
-        tensorflow::setThreading(options, 1, "no_threads");
+  DeepTauCache::DeepTauCache(const std::map<std::string, std::string>& graph_names, bool mem_mapped) {
+    for (const auto& graph_entry : graph_names) {
+      tensorflow::SessionOptions options;
+      tensorflow::setThreading(options, 1, "no_threads");
 
-        const std::string& entry_name = graph_entry.first;
-        const std::string& graph_file = graph_entry.second;
-        if(mem_mapped) {
-            memmappedEnv_[entry_name] = std::make_unique<tensorflow::MemmappedEnv>(tensorflow::Env::Default());
-            const tensorflow::Status mmap_status = memmappedEnv_.at(entry_name)->InitializeFromFile(graph_file);
-            if(!mmap_status.ok()) {
-                throw cms::Exception("DeepTauCache: unable to initalize memmapped environment for ")
-                    << graph_file << ". \n" << mmap_status.ToString();
-            }
-
-            graphs_[entry_name] = std::make_unique<tensorflow::GraphDef>();
-            const tensorflow::Status load_graph_status = ReadBinaryProto(memmappedEnv_.at(entry_name).get(),
-                                                                         tensorflow::MemmappedFileSystem::kMemmappedPackageDefaultGraphDef,
-                                                                         graphs_.at(entry_name).get());
-            if(!load_graph_status.ok())
-                throw cms::Exception("DeepTauCache: unable to load graph from ") << graph_file << ". \n"
-                                                                                  << mmap_status.ToString();
-            options.config.mutable_graph_options()->mutable_optimizer_options()->set_opt_level(::tensorflow::OptimizerOptions::L0);
-            options.env = memmappedEnv_.at(entry_name).get();
-
-            sessions_[entry_name] = tensorflow::createSession(graphs_.at(entry_name).get(), options);
-
-        } else {
-            graphs_[entry_name].reset(tensorflow::loadGraphDef(graph_file));
-            sessions_[entry_name] = tensorflow::createSession(graphs_.at(entry_name).get(), options);
+      const std::string& entry_name = graph_entry.first;
+      const std::string& graph_file = graph_entry.second;
+      if (mem_mapped) {
+        memmappedEnv_[entry_name] = std::make_unique<tensorflow::MemmappedEnv>(tensorflow::Env::Default());
+        const tensorflow::Status mmap_status = memmappedEnv_.at(entry_name)->InitializeFromFile(graph_file);
+        if (!mmap_status.ok()) {
+          throw cms::Exception("DeepTauCache: unable to initalize memmapped environment for ")
+              << graph_file << ". \n"
+              << mmap_status.ToString();
         }
+
+        graphs_[entry_name] = std::make_unique<tensorflow::GraphDef>();
+        const tensorflow::Status load_graph_status =
+            ReadBinaryProto(memmappedEnv_.at(entry_name).get(),
+                            tensorflow::MemmappedFileSystem::kMemmappedPackageDefaultGraphDef,
+                            graphs_.at(entry_name).get());
+        if (!load_graph_status.ok())
+          throw cms::Exception("DeepTauCache: unable to load graph from ") << graph_file << ". \n"
+                                                                           << mmap_status.ToString();
+        options.config.mutable_graph_options()->mutable_optimizer_options()->set_opt_level(
+            ::tensorflow::OptimizerOptions::L0);
+        options.env = memmappedEnv_.at(entry_name).get();
+
+        sessions_[entry_name] = tensorflow::createSession(graphs_.at(entry_name).get(), options);
+
+      } else {
+        graphs_[entry_name].reset(tensorflow::loadGraphDef(graph_file));
+        sessions_[entry_name] = tensorflow::createSession(graphs_.at(entry_name).get(), options);
+      }
     }
-}
+  }
 
-DeepTauCache::~DeepTauCache()
-{
-    for(auto& session_entry : sessions_)
-        tensorflow::closeSession(session_entry.second);
-}
+  DeepTauCache::~DeepTauCache() {
+    for (auto& session_entry : sessions_)
+      tensorflow::closeSession(session_entry.second);
+  }
 
-} // namespace deep_tau
+}  // namespace deep_tau

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -1,25 +1,31 @@
 #include "RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h"
 
 namespace {
-  struct PFTau_traits{ typedef reco::PFTau Tau_t; typedef const std::vector<reco::CandidatePtr>& Ret_t; };
-  struct PATTau_traits{ typedef pat::Tau Tau_t; typedef reco::CandidatePtrVector Ret_t; };
+  struct PFTau_traits {
+    typedef reco::PFTau Tau_t;
+    typedef const std::vector<reco::CandidatePtr>& Ret_t;
+  };
+  struct PATTau_traits {
+    typedef pat::Tau Tau_t;
+    typedef reco::CandidatePtrVector Ret_t;
+  };
 
-  template<typename T>
+  template <typename T>
   typename T::Ret_t getGammas_T(const typename T::Tau_t& tau, bool signal) {
     return typename T::Ret_t();
   }
   /// return pf photon candidates that are associated to signal
-  template<>
+  template <>
   const std::vector<reco::CandidatePtr>& getGammas_T<PFTau_traits>(const reco::PFTau& tau, bool signal) {
-    if (signal){
+    if (signal) {
       return tau.signalGammaCands();
     }
     return tau.isolationGammaCands();
   }
 
-  template<>
+  template <>
   reco::CandidatePtrVector getGammas_T<PATTau_traits>(const pat::Tau& tau, bool signal) {
-    if(signal){
+    if (signal) {
       return tau.signalGammaCands();
     }
     return tau.isolationGammaCands();
@@ -31,290 +37,302 @@ namespace {
     constexpr double stripEtaAssociationDistance_0p95_p1 = 0.658701;
     constexpr double stripPhiAssociationDistance_0p95_p0 = 0.352476;
     constexpr double stripPhiAssociationDistance_0p95_p1 = 0.707716;
-    if(photon_pt==0){
+    if (photon_pt == 0) {
       return false;
-    }      if((dphi<0.3  && dphi<std::max(0.05, stripPhiAssociationDistance_0p95_p0*std::pow(photon_pt, -stripPhiAssociationDistance_0p95_p1))) && (deta<0.15 && deta<std::max(0.05, stripEtaAssociationDistance_0p95_p0*std::pow(photon_pt, -stripEtaAssociationDistance_0p95_p1)))){
+    }
+    if ((dphi < 0.3 && dphi < std::max(0.05,
+                                       stripPhiAssociationDistance_0p95_p0 *
+                                           std::pow(photon_pt, -stripPhiAssociationDistance_0p95_p1))) &&
+        (deta < 0.15 && deta < std::max(0.05,
+                                        stripEtaAssociationDistance_0p95_p0 *
+                                            std::pow(photon_pt, -stripEtaAssociationDistance_0p95_p1)))) {
       return true;
     }
     return false;
   }
-}
+}  // namespace
 
-namespace reco { namespace tau { 
-  /// return chi2 of the leading track ==> deprecated? <==
-  float lead_track_chi2(const reco::PFTau& tau) {
-    float LeadingTracknormalizedChi2 = 0;
-    const reco::CandidatePtr& leadingCharged = tau.leadChargedHadrCand();
-    if (leadingCharged.isNonnull()) {
-      const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(leadingCharged.get());
-      if (pfcand != nullptr) {
-	reco::TrackRef tref = pfcand->trackRef();
-	if (tref.isNonnull()) {
-	  LeadingTracknormalizedChi2 = tref->normalizedChi2();
-	}
-      }
-      else {
-	const pat::PackedCandidate* patcand = dynamic_cast<const pat::PackedCandidate*>(leadingCharged.get());
-	if (patcand != nullptr && patcand->hasTrackDetails()) {
-	  LeadingTracknormalizedChi2 = patcand->pseudoTrack().normalizedChi2();
-	}
-      }
-    }
-    return LeadingTracknormalizedChi2;
-  }
-  /// return ratio of energy in ECAL over sum of energy in ECAL and HCAL
-  float eratio(const reco::PFTau& tau) {
-    float ecal_en_in_signal_pf_cands = 0;
-    float hcal_en_in_signal_pf_cands = 0;
-    for (const auto& signal_cand : tau.signalCands()) {
-      const reco::PFCandidate* signal_pfcand = dynamic_cast<const reco::PFCandidate*>(signal_cand.get());
-      if (signal_pfcand != nullptr) {
-        ecal_en_in_signal_pf_cands += signal_pfcand->ecalEnergy();
-        hcal_en_in_signal_pf_cands += signal_pfcand->hcalEnergy();
-      }
-      // TauReco@MiniAOD: recalculate for PackedCandidate if added to MiniAOD event content
-    }
-    float total = ecal_en_in_signal_pf_cands + hcal_en_in_signal_pf_cands;
-    if(total == 0.){
-      return -1.;
-    }
-    return ecal_en_in_signal_pf_cands/total;
-  }
-  float eratio(const pat::Tau& tau) {
-    float ecal_en_in_signal_cands = tau.ecalEnergy();
-    float hcal_en_in_signal_cands = tau.hcalEnergy();
-    float total = ecal_en_in_signal_cands + hcal_en_in_signal_cands;
-    if(total == 0.){
-      return -1.;
-    }
-    return ecal_en_in_signal_cands/total;
-  }
-  /// return sum of pt weighted values of distance to tau candidate for all pf photon candidates,
-  /// which are associated to signal; depending on var the distance is in 0=:dr, 1=:deta, 2=:dphi
-  template<typename T>
-  float pt_weighted_dx_T(const typename T::Tau_t& tau, int mode, int var, int decaymode) {
-    float sum_pt = 0.;
-    float sum_dx_pt = 0.;
-    float signalrad = std::max(0.05, std::min(0.1, 3./std::max(1., tau.pt())));
-    int is3prong = (decaymode==10);
-    const auto& cands = getGammas_T<T>(tau, mode < 2);
-    for (const auto& cand : cands) {
-      // only look at electrons/photons with pT > 0.5
-      if (cand->pt() < 0.5){
-        continue;
-      }
-      float dr = reco::deltaR(cand->eta(), cand->phi(), tau.eta(), tau.phi());
-      float deta = std::abs(cand->eta() - tau.eta());
-      float dphi = std::abs(reco::deltaPhi(cand->phi(), tau.phi()));
-      float pt = cand->pt();
-      bool flag = isInside(pt, deta, dphi);
-      if(is3prong==0){
-        if (mode == 2 || (mode == 0 && dr < signalrad) || (mode == 1 && dr > signalrad)) {
-          sum_pt += pt;
-          if (var == 0)
-            sum_dx_pt += pt * dr;
-          else if (var == 1)
-            sum_dx_pt += pt * deta;
-          else if (var == 2)
-            sum_dx_pt += pt * dphi;
+namespace reco {
+  namespace tau {
+    /// return chi2 of the leading track ==> deprecated? <==
+    float lead_track_chi2(const reco::PFTau& tau) {
+      float LeadingTracknormalizedChi2 = 0;
+      const reco::CandidatePtr& leadingCharged = tau.leadChargedHadrCand();
+      if (leadingCharged.isNonnull()) {
+        const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(leadingCharged.get());
+        if (pfcand != nullptr) {
+          reco::TrackRef tref = pfcand->trackRef();
+          if (tref.isNonnull()) {
+            LeadingTracknormalizedChi2 = tref->normalizedChi2();
+          }
+        } else {
+          const pat::PackedCandidate* patcand = dynamic_cast<const pat::PackedCandidate*>(leadingCharged.get());
+          if (patcand != nullptr && patcand->hasTrackDetails()) {
+            LeadingTracknormalizedChi2 = patcand->pseudoTrack().normalizedChi2();
+          }
         }
       }
-      else if(is3prong==1){
-        if( (mode==2 && flag==false) || (mode==1 && flag==true) || mode==0){
-          sum_pt += pt;
-          if (var == 0)
-            sum_dx_pt += pt * dr;
-          else if (var == 1)
-            sum_dx_pt += pt * deta;
-          else if (var == 2)
-            sum_dx_pt += pt * dphi;
+      return LeadingTracknormalizedChi2;
+    }
+    /// return ratio of energy in ECAL over sum of energy in ECAL and HCAL
+    float eratio(const reco::PFTau& tau) {
+      float ecal_en_in_signal_pf_cands = 0;
+      float hcal_en_in_signal_pf_cands = 0;
+      for (const auto& signal_cand : tau.signalCands()) {
+        const reco::PFCandidate* signal_pfcand = dynamic_cast<const reco::PFCandidate*>(signal_cand.get());
+        if (signal_pfcand != nullptr) {
+          ecal_en_in_signal_pf_cands += signal_pfcand->ecalEnergy();
+          hcal_en_in_signal_pf_cands += signal_pfcand->hcalEnergy();
+        }
+        // TauReco@MiniAOD: recalculate for PackedCandidate if added to MiniAOD event content
+      }
+      float total = ecal_en_in_signal_pf_cands + hcal_en_in_signal_pf_cands;
+      if (total == 0.) {
+        return -1.;
+      }
+      return ecal_en_in_signal_pf_cands / total;
+    }
+    float eratio(const pat::Tau& tau) {
+      float ecal_en_in_signal_cands = tau.ecalEnergy();
+      float hcal_en_in_signal_cands = tau.hcalEnergy();
+      float total = ecal_en_in_signal_cands + hcal_en_in_signal_cands;
+      if (total == 0.) {
+        return -1.;
+      }
+      return ecal_en_in_signal_cands / total;
+    }
+    /// return sum of pt weighted values of distance to tau candidate for all pf photon candidates,
+    /// which are associated to signal; depending on var the distance is in 0=:dr, 1=:deta, 2=:dphi
+    template <typename T>
+    float pt_weighted_dx_T(const typename T::Tau_t& tau, int mode, int var, int decaymode) {
+      float sum_pt = 0.;
+      float sum_dx_pt = 0.;
+      float signalrad = std::max(0.05, std::min(0.1, 3. / std::max(1., tau.pt())));
+      int is3prong = (decaymode == 10);
+      const auto& cands = getGammas_T<T>(tau, mode < 2);
+      for (const auto& cand : cands) {
+        // only look at electrons/photons with pT > 0.5
+        if (cand->pt() < 0.5) {
+          continue;
+        }
+        float dr = reco::deltaR(cand->eta(), cand->phi(), tau.eta(), tau.phi());
+        float deta = std::abs(cand->eta() - tau.eta());
+        float dphi = std::abs(reco::deltaPhi(cand->phi(), tau.phi()));
+        float pt = cand->pt();
+        bool flag = isInside(pt, deta, dphi);
+        if (is3prong == 0) {
+          if (mode == 2 || (mode == 0 && dr < signalrad) || (mode == 1 && dr > signalrad)) {
+            sum_pt += pt;
+            if (var == 0)
+              sum_dx_pt += pt * dr;
+            else if (var == 1)
+              sum_dx_pt += pt * deta;
+            else if (var == 2)
+              sum_dx_pt += pt * dphi;
+          }
+        } else if (is3prong == 1) {
+          if ((mode == 2 && flag == false) || (mode == 1 && flag == true) || mode == 0) {
+            sum_pt += pt;
+            if (var == 0)
+              sum_dx_pt += pt * dr;
+            else if (var == 1)
+              sum_dx_pt += pt * deta;
+            else if (var == 2)
+              sum_dx_pt += pt * dphi;
+          }
         }
       }
+      if (sum_pt > 0.) {
+        return sum_dx_pt / sum_pt;
+      }
+      return 0.;
     }
-    if (sum_pt > 0.){
-      return sum_dx_pt/sum_pt;
+    float pt_weighted_dx(const reco::PFTau& tau, int mode, int var, int decaymode) {
+      return pt_weighted_dx_T<PFTau_traits>(tau, mode, var, decaymode);
     }
-    return 0.;
-  }
-  float pt_weighted_dx(const reco::PFTau& tau, int mode, int var, int decaymode) {
-    return pt_weighted_dx_T<PFTau_traits>(tau, mode, var, decaymode);
-  }
-  float pt_weighted_dx(const pat::Tau& tau, int mode, int var, int decaymode) {
-    return pt_weighted_dx_T<PATTau_traits>(tau, mode, var, decaymode);
-  }
-  /// return total number of pf photon candidates with pT>500 MeV, which are associated to signal
-  unsigned int n_photons_total(const reco::PFTau& tau) {
-    unsigned int n_photons = 0;
-    for (auto& cand : tau.signalGammaCands()) {
-      if (cand->pt() > 0.5)
-        ++n_photons;
+    float pt_weighted_dx(const pat::Tau& tau, int mode, int var, int decaymode) {
+      return pt_weighted_dx_T<PATTau_traits>(tau, mode, var, decaymode);
     }
-    for (auto& cand : tau.isolationGammaCands()) {
-      if (cand->pt() > 0.5)
-        ++n_photons;
+    /// return total number of pf photon candidates with pT>500 MeV, which are associated to signal
+    unsigned int n_photons_total(const reco::PFTau& tau) {
+      unsigned int n_photons = 0;
+      for (auto& cand : tau.signalGammaCands()) {
+        if (cand->pt() > 0.5)
+          ++n_photons;
+      }
+      for (auto& cand : tau.isolationGammaCands()) {
+        if (cand->pt() > 0.5)
+          ++n_photons;
+      }
+      return n_photons;
     }
-    return n_photons;
-  }
-  unsigned int n_photons_total(const pat::Tau& tau) {
-    unsigned int n_photons = 0;
-    for (auto& cand : tau.signalGammaCands()) {
-      if (cand->pt() > 0.5) 
-        ++n_photons;
+    unsigned int n_photons_total(const pat::Tau& tau) {
+      unsigned int n_photons = 0;
+      for (auto& cand : tau.signalGammaCands()) {
+        if (cand->pt() > 0.5)
+          ++n_photons;
+      }
+      for (auto& cand : tau.isolationGammaCands()) {
+        if (cand->pt() > 0.5)
+          ++n_photons;
+      }
+      return n_photons;
     }
-    for (auto& cand : tau.isolationGammaCands()) {  
-      if (cand->pt() > 0.5)
-	++n_photons;
-    }
-    return n_photons;
-  }  
 
-  bool fillIsoMVARun2Inputs(float* mvaInput, const pat::Tau& tau, int mvaOpt, const std::string& nameCharged, 
-                            const std::string& nameNeutral, const std::string& namePu, 
-                            const std::string& nameOutside, const std::string& nameFootprint) 
-  {
-    int tauDecayMode = tau.decayMode();
-    
-  if ( ((mvaOpt == kOldDMwoLT || mvaOpt == kOldDMwLT || mvaOpt == kDBoldDMwLT || mvaOpt == kPWoldDMwLT || mvaOpt ==   kDBoldDMwLTwGJ)
-          && (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 10))
-         ||
-       ((mvaOpt == kNewDMwoLT || mvaOpt == kNewDMwLT || mvaOpt == kDBnewDMwLT || mvaOpt == kPWnewDMwLT || mvaOpt ==   kDBnewDMwLTwGJ)
-        && (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 ||   tauDecayMode == 10 || tauDecayMode == 11))
-    ) {
-  	
-      float chargedIsoPtSum = tau.tauID(nameCharged);
-      float neutralIsoPtSum = tau.tauID(nameNeutral);
-      float puCorrPtSum     = tau.tauID(namePu);
-      float photonPtSumOutsideSignalCone = tau.tauID(nameOutside);
-      float footprintCorrection = tau.tauID(nameFootprint);
-  		
-      float decayDistX = tau.flightLength().x();
-      float decayDistY = tau.flightLength().y();
-      float decayDistZ = tau.flightLength().z();
-      float decayDistMag = std::sqrt(decayDistX*decayDistX + decayDistY*decayDistY + decayDistZ*decayDistZ);
-  		
-      // --- The following 5 variables differ slightly between AOD & MiniAOD
-      //     because they are recomputed using packedCandidates saved in the tau
-      float nPhoton = reco::tau::n_photons_total(tau);
-      float ptWeightedDetaStrip = reco::tau::pt_weighted_deta_strip(tau, tauDecayMode);
-      float ptWeightedDphiStrip = reco::tau::pt_weighted_dphi_strip(tau, tauDecayMode);
-      float ptWeightedDrSignal = reco::tau::pt_weighted_dr_signal(tau, tauDecayMode);
-      float ptWeightedDrIsolation = reco::tau::pt_weighted_dr_iso(tau, tauDecayMode);
-      // ---
-      float leadingTrackChi2 = tau.leadingTrackNormChi2();
-      float eRatio = reco::tau::eratio(tau);
-  
-      // Difference between measured and maximally allowed Gottfried-Jackson angle
-      float gjAngleDiff = -999;
-      if ( tauDecayMode == 10 ) {
+    bool fillIsoMVARun2Inputs(float* mvaInput,
+                              const pat::Tau& tau,
+                              int mvaOpt,
+                              const std::string& nameCharged,
+                              const std::string& nameNeutral,
+                              const std::string& namePu,
+                              const std::string& nameOutside,
+                              const std::string& nameFootprint) {
+      int tauDecayMode = tau.decayMode();
+
+      if (((mvaOpt == kOldDMwoLT || mvaOpt == kOldDMwLT || mvaOpt == kDBoldDMwLT || mvaOpt == kPWoldDMwLT ||
+            mvaOpt == kDBoldDMwLTwGJ) &&
+           (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 10)) ||
+          ((mvaOpt == kNewDMwoLT || mvaOpt == kNewDMwLT || mvaOpt == kDBnewDMwLT || mvaOpt == kPWnewDMwLT ||
+            mvaOpt == kDBnewDMwLTwGJ) &&
+           (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 ||
+            tauDecayMode == 10 || tauDecayMode == 11))) {
+        float chargedIsoPtSum = tau.tauID(nameCharged);
+        float neutralIsoPtSum = tau.tauID(nameNeutral);
+        float puCorrPtSum = tau.tauID(namePu);
+        float photonPtSumOutsideSignalCone = tau.tauID(nameOutside);
+        float footprintCorrection = tau.tauID(nameFootprint);
+
+        float decayDistX = tau.flightLength().x();
+        float decayDistY = tau.flightLength().y();
+        float decayDistZ = tau.flightLength().z();
+        float decayDistMag = std::sqrt(decayDistX * decayDistX + decayDistY * decayDistY + decayDistZ * decayDistZ);
+
+        // --- The following 5 variables differ slightly between AOD & MiniAOD
+        //     because they are recomputed using packedCandidates saved in the tau
+        float nPhoton = reco::tau::n_photons_total(tau);
+        float ptWeightedDetaStrip = reco::tau::pt_weighted_deta_strip(tau, tauDecayMode);
+        float ptWeightedDphiStrip = reco::tau::pt_weighted_dphi_strip(tau, tauDecayMode);
+        float ptWeightedDrSignal = reco::tau::pt_weighted_dr_signal(tau, tauDecayMode);
+        float ptWeightedDrIsolation = reco::tau::pt_weighted_dr_iso(tau, tauDecayMode);
+        // ---
+        float leadingTrackChi2 = tau.leadingTrackNormChi2();
+        float eRatio = reco::tau::eratio(tau);
+
+        // Difference between measured and maximally allowed Gottfried-Jackson angle
+        float gjAngleDiff = -999;
+        if (tauDecayMode == 10) {
           double mTau = 1.77682;
           double mAOne = tau.p4().M();
           double pAOneMag = tau.p();
-          double argumentThetaGJmax = (std::pow(mTau,2) - std::pow(mAOne,2) ) / ( 2 * mTau * pAOneMag );
-        double argumentThetaGJmeasured = ( tau.p4().px() * decayDistX + tau.p4().py() * decayDistY + tau.p4().pz() * decayDistZ   ) / ( pAOneMag * decayDistMag );
-          if ( std::abs(argumentThetaGJmax) <= 1. && std::abs(argumentThetaGJmeasured) <= 1. ) {
-              double thetaGJmax = std::asin( argumentThetaGJmax );
-              double thetaGJmeasured = std::acos( argumentThetaGJmeasured );
-              gjAngleDiff = thetaGJmeasured - thetaGJmax;
+          double argumentThetaGJmax = (std::pow(mTau, 2) - std::pow(mAOne, 2)) / (2 * mTau * pAOneMag);
+          double argumentThetaGJmeasured =
+              (tau.p4().px() * decayDistX + tau.p4().py() * decayDistY + tau.p4().pz() * decayDistZ) /
+              (pAOneMag * decayDistMag);
+          if (std::abs(argumentThetaGJmax) <= 1. && std::abs(argumentThetaGJmeasured) <= 1.) {
+            double thetaGJmax = std::asin(argumentThetaGJmax);
+            double thetaGJmeasured = std::acos(argumentThetaGJmeasured);
+            gjAngleDiff = thetaGJmeasured - thetaGJmax;
           }
-      }
-  		
-      if ( mvaOpt == kOldDMwoLT || mvaOpt == kNewDMwoLT ) {
-        mvaInput[0]  = std::log(std::max(1.f, (float)tau.pt()));
-        mvaInput[1]  = std::abs((float)tau.eta());
-        mvaInput[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
-        mvaInput[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f*puCorrPtSum));
-        mvaInput[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
-        mvaInput[5]  = tauDecayMode;
-      } else if ( mvaOpt == kOldDMwLT || mvaOpt == kNewDMwLT  ) {
-        mvaInput[0]  = std::log(std::max(1.f, (float)tau.pt()));
-        mvaInput[1]  = std::abs((float)tau.eta());
-        mvaInput[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
-        mvaInput[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f*puCorrPtSum));
-        mvaInput[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
-        mvaInput[5]  = tauDecayMode;
-        mvaInput[6]  = std::copysign(+1.f, tau.dxy());
-        mvaInput[7]  = std::sqrt(std::min(1.f, std::abs(tau.dxy())));
-        mvaInput[8]  = std::min(10.f, std::abs(tau.dxy_Sig()));
-        mvaInput[9]  = ( tau.hasSecondaryVertex() ) ? 1. : 0.;
-        mvaInput[10] = std::sqrt(decayDistMag);
-        mvaInput[11] = std::min(10.f, tau.flightLengthSig());
-      } else if ( mvaOpt == kDBoldDMwLT || mvaOpt == kDBnewDMwLT ) {
-        mvaInput[0]  = std::log(std::max(1.f, (float)tau.pt()));
-        mvaInput[1]  = std::abs((float)tau.eta());
-        mvaInput[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
-        mvaInput[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
-        mvaInput[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
-        mvaInput[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
-        mvaInput[6]  = tauDecayMode;
-        mvaInput[7]  = std::min(30.f, nPhoton);
-        mvaInput[8]  = std::min(0.5f, ptWeightedDetaStrip);
-        mvaInput[9]  = std::min(0.5f, ptWeightedDphiStrip);
-        mvaInput[10] = std::min(0.5f, ptWeightedDrSignal);
-        mvaInput[11] = std::min(0.5f, ptWeightedDrIsolation);
-        mvaInput[12] = std::min(100.f, leadingTrackChi2);
-        mvaInput[13] = std::min(1.f, eRatio);
-        mvaInput[14]  = std::copysign(+1.f, tau.dxy());
-        mvaInput[15]  = std::sqrt(std::min(1.f, std::abs(tau.dxy())));
-        mvaInput[16]  = std::min(10.f, std::abs(tau.dxy_Sig()));
-        mvaInput[17]  = std::copysign(+1.f, tau.ip3d());
-        mvaInput[18]  = std::sqrt(std::min(1.f, std::abs(tau.ip3d())));
-        mvaInput[19]  = std::min(10.f, std::abs(tau.ip3d_Sig()));
-        mvaInput[20]  = ( tau.hasSecondaryVertex() ) ? 1. : 0.;
-        mvaInput[21] = std::sqrt(decayDistMag);
-        mvaInput[22] = std::min(10.f, tau.flightLengthSig());
-      } else if ( mvaOpt == kPWoldDMwLT || mvaOpt == kPWnewDMwLT ) {
-        mvaInput[0]  = std::log(std::max(1.f, (float)tau.pt()));
-        mvaInput[1]  = std::abs((float)tau.eta());
-        mvaInput[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
-        mvaInput[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
-        mvaInput[4]  = std::log(std::max(1.e-2f, footprintCorrection));
-        mvaInput[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
-        mvaInput[6]  = tauDecayMode;
-        mvaInput[7]  = std::min(30.f, nPhoton);
-        mvaInput[8]  = std::min(0.5f, ptWeightedDetaStrip);
-        mvaInput[9]  = std::min(0.5f, ptWeightedDphiStrip);
-        mvaInput[10] = std::min(0.5f, ptWeightedDrSignal);
-        mvaInput[11] = std::min(0.5f, ptWeightedDrIsolation);
-        mvaInput[12] = std::min(100.f, leadingTrackChi2);
-        mvaInput[13] = std::min(1.f, eRatio);
-        mvaInput[14]  = std::copysign(+1.f, tau.dxy());
-        mvaInput[15]  = std::sqrt(std::min(1.f, std::abs(tau.dxy())));
-        mvaInput[16]  = std::min(10.f, std::abs(tau.dxy_Sig()));
-        mvaInput[17]  = std::copysign(+1.f, tau.ip3d());
-        mvaInput[18]  = std::sqrt(std::min(1.f, std::abs(tau.ip3d())));
-        mvaInput[19]  = std::min(10.f, std::abs(tau.ip3d_Sig()));
-        mvaInput[20]  = ( tau.hasSecondaryVertex() ) ? 1. : 0.;
-        mvaInput[21] = std::sqrt(decayDistMag);
-        mvaInput[22] = std::min(10.f, tau.flightLengthSig());
-      } else if ( mvaOpt == kDBoldDMwLTwGJ || mvaOpt == kDBnewDMwLTwGJ ) {
-        mvaInput[0]  = std::log(std::max(1.f, (float)tau.pt()));
-        mvaInput[1]  = std::abs((float)tau.eta());
-        mvaInput[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
-        mvaInput[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
-        mvaInput[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
-        mvaInput[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
-        mvaInput[6]  = tauDecayMode;
-        mvaInput[7]  = std::min(30.f, nPhoton);
-        mvaInput[8]  = std::min(0.5f, ptWeightedDetaStrip);
-        mvaInput[9]  = std::min(0.5f, ptWeightedDphiStrip);
-        mvaInput[10] = std::min(0.5f, ptWeightedDrSignal);
-        mvaInput[11] = std::min(0.5f, ptWeightedDrIsolation);
-        mvaInput[12] = std::min(1.f, eRatio);
-        mvaInput[13]  = std::copysign(+1.f, tau.dxy());
-        mvaInput[14]  = std::sqrt(std::min(1.f, std::abs(tau.dxy())));
-        mvaInput[15]  = std::min(10.f, std::abs(tau.dxy_Sig()));
-        mvaInput[16]  = std::copysign(+1.f, tau.ip3d());
-        mvaInput[17]  = std::sqrt(std::min(1.f, std::abs(tau.ip3d())));
-        mvaInput[18]  = std::min(10.f, std::abs(tau.ip3d_Sig()));
-        mvaInput[19]  = ( tau.hasSecondaryVertex() ) ? 1. : 0.;
-        mvaInput[20] = std::sqrt(decayDistMag);
-        mvaInput[21] = std::min(10.f, tau.flightLengthSig());
-        mvaInput[22] = std::max(-1.f, gjAngleDiff);
-      }
-  
-      return true;
-    }
-    return false;
-  }
+        }
 
-}} // namespaces
+        if (mvaOpt == kOldDMwoLT || mvaOpt == kNewDMwoLT) {
+          mvaInput[0] = std::log(std::max(1.f, (float)tau.pt()));
+          mvaInput[1] = std::abs((float)tau.eta());
+          mvaInput[2] = std::log(std::max(1.e-2f, chargedIsoPtSum));
+          mvaInput[3] = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f * puCorrPtSum));
+          mvaInput[4] = std::log(std::max(1.e-2f, puCorrPtSum));
+          mvaInput[5] = tauDecayMode;
+        } else if (mvaOpt == kOldDMwLT || mvaOpt == kNewDMwLT) {
+          mvaInput[0] = std::log(std::max(1.f, (float)tau.pt()));
+          mvaInput[1] = std::abs((float)tau.eta());
+          mvaInput[2] = std::log(std::max(1.e-2f, chargedIsoPtSum));
+          mvaInput[3] = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f * puCorrPtSum));
+          mvaInput[4] = std::log(std::max(1.e-2f, puCorrPtSum));
+          mvaInput[5] = tauDecayMode;
+          mvaInput[6] = std::copysign(+1.f, tau.dxy());
+          mvaInput[7] = std::sqrt(std::min(1.f, std::abs(tau.dxy())));
+          mvaInput[8] = std::min(10.f, std::abs(tau.dxy_Sig()));
+          mvaInput[9] = (tau.hasSecondaryVertex()) ? 1. : 0.;
+          mvaInput[10] = std::sqrt(decayDistMag);
+          mvaInput[11] = std::min(10.f, tau.flightLengthSig());
+        } else if (mvaOpt == kDBoldDMwLT || mvaOpt == kDBnewDMwLT) {
+          mvaInput[0] = std::log(std::max(1.f, (float)tau.pt()));
+          mvaInput[1] = std::abs((float)tau.eta());
+          mvaInput[2] = std::log(std::max(1.e-2f, chargedIsoPtSum));
+          mvaInput[3] = std::log(std::max(1.e-2f, neutralIsoPtSum));
+          mvaInput[4] = std::log(std::max(1.e-2f, puCorrPtSum));
+          mvaInput[5] = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
+          mvaInput[6] = tauDecayMode;
+          mvaInput[7] = std::min(30.f, nPhoton);
+          mvaInput[8] = std::min(0.5f, ptWeightedDetaStrip);
+          mvaInput[9] = std::min(0.5f, ptWeightedDphiStrip);
+          mvaInput[10] = std::min(0.5f, ptWeightedDrSignal);
+          mvaInput[11] = std::min(0.5f, ptWeightedDrIsolation);
+          mvaInput[12] = std::min(100.f, leadingTrackChi2);
+          mvaInput[13] = std::min(1.f, eRatio);
+          mvaInput[14] = std::copysign(+1.f, tau.dxy());
+          mvaInput[15] = std::sqrt(std::min(1.f, std::abs(tau.dxy())));
+          mvaInput[16] = std::min(10.f, std::abs(tau.dxy_Sig()));
+          mvaInput[17] = std::copysign(+1.f, tau.ip3d());
+          mvaInput[18] = std::sqrt(std::min(1.f, std::abs(tau.ip3d())));
+          mvaInput[19] = std::min(10.f, std::abs(tau.ip3d_Sig()));
+          mvaInput[20] = (tau.hasSecondaryVertex()) ? 1. : 0.;
+          mvaInput[21] = std::sqrt(decayDistMag);
+          mvaInput[22] = std::min(10.f, tau.flightLengthSig());
+        } else if (mvaOpt == kPWoldDMwLT || mvaOpt == kPWnewDMwLT) {
+          mvaInput[0] = std::log(std::max(1.f, (float)tau.pt()));
+          mvaInput[1] = std::abs((float)tau.eta());
+          mvaInput[2] = std::log(std::max(1.e-2f, chargedIsoPtSum));
+          mvaInput[3] = std::log(std::max(1.e-2f, neutralIsoPtSum));
+          mvaInput[4] = std::log(std::max(1.e-2f, footprintCorrection));
+          mvaInput[5] = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
+          mvaInput[6] = tauDecayMode;
+          mvaInput[7] = std::min(30.f, nPhoton);
+          mvaInput[8] = std::min(0.5f, ptWeightedDetaStrip);
+          mvaInput[9] = std::min(0.5f, ptWeightedDphiStrip);
+          mvaInput[10] = std::min(0.5f, ptWeightedDrSignal);
+          mvaInput[11] = std::min(0.5f, ptWeightedDrIsolation);
+          mvaInput[12] = std::min(100.f, leadingTrackChi2);
+          mvaInput[13] = std::min(1.f, eRatio);
+          mvaInput[14] = std::copysign(+1.f, tau.dxy());
+          mvaInput[15] = std::sqrt(std::min(1.f, std::abs(tau.dxy())));
+          mvaInput[16] = std::min(10.f, std::abs(tau.dxy_Sig()));
+          mvaInput[17] = std::copysign(+1.f, tau.ip3d());
+          mvaInput[18] = std::sqrt(std::min(1.f, std::abs(tau.ip3d())));
+          mvaInput[19] = std::min(10.f, std::abs(tau.ip3d_Sig()));
+          mvaInput[20] = (tau.hasSecondaryVertex()) ? 1. : 0.;
+          mvaInput[21] = std::sqrt(decayDistMag);
+          mvaInput[22] = std::min(10.f, tau.flightLengthSig());
+        } else if (mvaOpt == kDBoldDMwLTwGJ || mvaOpt == kDBnewDMwLTwGJ) {
+          mvaInput[0] = std::log(std::max(1.f, (float)tau.pt()));
+          mvaInput[1] = std::abs((float)tau.eta());
+          mvaInput[2] = std::log(std::max(1.e-2f, chargedIsoPtSum));
+          mvaInput[3] = std::log(std::max(1.e-2f, neutralIsoPtSum));
+          mvaInput[4] = std::log(std::max(1.e-2f, puCorrPtSum));
+          mvaInput[5] = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
+          mvaInput[6] = tauDecayMode;
+          mvaInput[7] = std::min(30.f, nPhoton);
+          mvaInput[8] = std::min(0.5f, ptWeightedDetaStrip);
+          mvaInput[9] = std::min(0.5f, ptWeightedDphiStrip);
+          mvaInput[10] = std::min(0.5f, ptWeightedDrSignal);
+          mvaInput[11] = std::min(0.5f, ptWeightedDrIsolation);
+          mvaInput[12] = std::min(1.f, eRatio);
+          mvaInput[13] = std::copysign(+1.f, tau.dxy());
+          mvaInput[14] = std::sqrt(std::min(1.f, std::abs(tau.dxy())));
+          mvaInput[15] = std::min(10.f, std::abs(tau.dxy_Sig()));
+          mvaInput[16] = std::copysign(+1.f, tau.ip3d());
+          mvaInput[17] = std::sqrt(std::min(1.f, std::abs(tau.ip3d())));
+          mvaInput[18] = std::min(10.f, std::abs(tau.ip3d_Sig()));
+          mvaInput[19] = (tau.hasSecondaryVertex()) ? 1. : 0.;
+          mvaInput[20] = std::sqrt(decayDistMag);
+          mvaInput[21] = std::min(10.f, tau.flightLengthSig());
+          mvaInput[22] = std::max(-1.f, gjAngleDiff);
+        }
+
+        return true;
+      }
+      return false;
+    }
+
+  }  // namespace tau
+}  // namespace reco

--- a/RecoTauTag/RecoTau/src/PFRecoTauTagInfoAlgorithm.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauTagInfoAlgorithm.cc
@@ -5,62 +5,81 @@
 
 using namespace reco;
 
-PFRecoTauTagInfoAlgorithm::PFRecoTauTagInfoAlgorithm(const edm::ParameterSet& parameters){
+PFRecoTauTagInfoAlgorithm::PFRecoTauTagInfoAlgorithm(const edm::ParameterSet& parameters) {
   // parameters of the considered charged hadr. PFCandidates, based on their rec. tk properties :
-  ChargedHadronsAssociationCone_      = parameters.getParameter<double>("ChargedHadrCand_AssociationCone");
-  ChargedHadrCand_tkminPt_            = parameters.getParameter<double>("ChargedHadrCand_tkminPt");
-  ChargedHadrCand_tkminPixelHitsn_    = parameters.getParameter<int>("ChargedHadrCand_tkminPixelHitsn");
-  ChargedHadrCand_tkminTrackerHitsn_  = parameters.getParameter<int>("ChargedHadrCand_tkminTrackerHitsn");
-  ChargedHadrCand_tkmaxipt_           = parameters.getParameter<double>("ChargedHadrCand_tkmaxipt");
-  ChargedHadrCand_tkmaxChi2_          = parameters.getParameter<double>("ChargedHadrCand_tkmaxChi2");
+  ChargedHadronsAssociationCone_ = parameters.getParameter<double>("ChargedHadrCand_AssociationCone");
+  ChargedHadrCand_tkminPt_ = parameters.getParameter<double>("ChargedHadrCand_tkminPt");
+  ChargedHadrCand_tkminPixelHitsn_ = parameters.getParameter<int>("ChargedHadrCand_tkminPixelHitsn");
+  ChargedHadrCand_tkminTrackerHitsn_ = parameters.getParameter<int>("ChargedHadrCand_tkminTrackerHitsn");
+  ChargedHadrCand_tkmaxipt_ = parameters.getParameter<double>("ChargedHadrCand_tkmaxipt");
+  ChargedHadrCand_tkmaxChi2_ = parameters.getParameter<double>("ChargedHadrCand_tkmaxChi2");
   // parameters of the considered neutral hadr. PFCandidates, based on their rec. HCAL clus. properties :
-  NeutrHadrCand_HcalclusMinEt_         = parameters.getParameter<double>("NeutrHadrCand_HcalclusMinEt");
+  NeutrHadrCand_HcalclusMinEt_ = parameters.getParameter<double>("NeutrHadrCand_HcalclusMinEt");
   // parameters of the considered gamma PFCandidates, based on their rec. ECAL clus. properties :
-  GammaCand_EcalclusMinEt_             = parameters.getParameter<double>("GammaCand_EcalclusMinEt");
+  GammaCand_EcalclusMinEt_ = parameters.getParameter<double>("GammaCand_EcalclusMinEt");
   // parameters of the considered rec. Tracks (these ones catched through a JetTracksAssociation object, not through the charged hadr. PFCandidates inside the PFJet ; the motivation for considering them is the need for checking that a selection by the charged hadr. PFCandidates is equivalent to a selection by the rec. Tracks.) :
-  tkminPt_                            = parameters.getParameter<double>("tkminPt");
-  tkminPixelHitsn_                    = parameters.getParameter<int>("tkminPixelHitsn");
-  tkminTrackerHitsn_                  = parameters.getParameter<int>("tkminTrackerHitsn");
-  tkmaxipt_                           = parameters.getParameter<double>("tkmaxipt");
-  tkmaxChi2_                          = parameters.getParameter<double>("tkmaxChi2");
+  tkminPt_ = parameters.getParameter<double>("tkminPt");
+  tkminPixelHitsn_ = parameters.getParameter<int>("tkminPixelHitsn");
+  tkminTrackerHitsn_ = parameters.getParameter<int>("tkminTrackerHitsn");
+  tkmaxipt_ = parameters.getParameter<double>("tkmaxipt");
+  tkmaxChi2_ = parameters.getParameter<double>("tkmaxChi2");
   //
-  UsePVconstraint_                    = parameters.getParameter<bool>("UsePVconstraint");
-  ChargedHadrCand_tkPVmaxDZ_          = parameters.getParameter<double>("ChargedHadrCand_tkPVmaxDZ");
-  tkPVmaxDZ_                          = parameters.getParameter<double>("tkPVmaxDZ");
+  UsePVconstraint_ = parameters.getParameter<bool>("UsePVconstraint");
+  ChargedHadrCand_tkPVmaxDZ_ = parameters.getParameter<double>("ChargedHadrCand_tkPVmaxDZ");
+  tkPVmaxDZ_ = parameters.getParameter<double>("tkPVmaxDZ");
 }
 
-PFTauTagInfo PFRecoTauTagInfoAlgorithm::buildPFTauTagInfo(const JetBaseRef& thePFJet,const std::vector<reco::CandidatePtr>& thePFCandsInEvent, const TrackRefVector& theTracks,const Vertex& thePV) const {
+PFTauTagInfo PFRecoTauTagInfoAlgorithm::buildPFTauTagInfo(const JetBaseRef& thePFJet,
+                                                          const std::vector<reco::CandidatePtr>& thePFCandsInEvent,
+                                                          const TrackRefVector& theTracks,
+                                                          const Vertex& thePV) const {
   PFTauTagInfo resultExtended;
   resultExtended.setpfjetRef(thePFJet);
 
   std::vector<reco::CandidatePtr> thePFCands;
   const float jetPhi = (*thePFJet).phi();
   const float jetEta = (*thePFJet).eta();
-  auto dr2 = [jetPhi,jetEta](float phi, float eta) { return reco::deltaR2(jetEta,jetPhi,eta,phi);};
-  for (auto iPFCand : thePFCandsInEvent){
-    float delta = dr2((*iPFCand).phi(),(*iPFCand).eta());
-    if (delta < ChargedHadronsAssociationCone_*ChargedHadronsAssociationCone_)  thePFCands.push_back(iPFCand);
+  auto dr2 = [jetPhi, jetEta](float phi, float eta) { return reco::deltaR2(jetEta, jetPhi, eta, phi); };
+  for (auto iPFCand : thePFCandsInEvent) {
+    float delta = dr2((*iPFCand).phi(), (*iPFCand).eta());
+    if (delta < ChargedHadronsAssociationCone_ * ChargedHadronsAssociationCone_)
+      thePFCands.push_back(iPFCand);
   }
   bool pvIsFake = (thePV.z() < -500.);
 
   std::vector<reco::CandidatePtr> theFilteredPFChargedHadrCands;
   if (UsePVconstraint_ && !pvIsFake) {
-    theFilteredPFChargedHadrCands = tautagtools::filteredPFChargedHadrCands(thePFCands,ChargedHadrCand_tkminPt_,ChargedHadrCand_tkminPixelHitsn_,ChargedHadrCand_tkminTrackerHitsn_,ChargedHadrCand_tkmaxipt_,ChargedHadrCand_tkmaxChi2_,ChargedHadrCand_tkPVmaxDZ_, thePV, thePV.z());
+    theFilteredPFChargedHadrCands = tautagtools::filteredPFChargedHadrCands(thePFCands,
+                                                                            ChargedHadrCand_tkminPt_,
+                                                                            ChargedHadrCand_tkminPixelHitsn_,
+                                                                            ChargedHadrCand_tkminTrackerHitsn_,
+                                                                            ChargedHadrCand_tkmaxipt_,
+                                                                            ChargedHadrCand_tkmaxChi2_,
+                                                                            ChargedHadrCand_tkPVmaxDZ_,
+                                                                            thePV,
+                                                                            thePV.z());
   } else {
-    theFilteredPFChargedHadrCands = tautagtools::filteredPFChargedHadrCands(thePFCands,ChargedHadrCand_tkminPt_,ChargedHadrCand_tkminPixelHitsn_,ChargedHadrCand_tkminTrackerHitsn_,ChargedHadrCand_tkmaxipt_,ChargedHadrCand_tkmaxChi2_, thePV);
+    theFilteredPFChargedHadrCands = tautagtools::filteredPFChargedHadrCands(thePFCands,
+                                                                            ChargedHadrCand_tkminPt_,
+                                                                            ChargedHadrCand_tkminPixelHitsn_,
+                                                                            ChargedHadrCand_tkminTrackerHitsn_,
+                                                                            ChargedHadrCand_tkmaxipt_,
+                                                                            ChargedHadrCand_tkmaxChi2_,
+                                                                            thePV);
   }
   resultExtended.setPFChargedHadrCands(theFilteredPFChargedHadrCands);
-  resultExtended.setPFNeutrHadrCands(tautagtools::filteredPFNeutrHadrCands(thePFCands,NeutrHadrCand_HcalclusMinEt_));
-  resultExtended.setPFGammaCands(tautagtools::filteredPFGammaCands(thePFCands,GammaCand_EcalclusMinEt_));
+  resultExtended.setPFNeutrHadrCands(tautagtools::filteredPFNeutrHadrCands(thePFCands, NeutrHadrCand_HcalclusMinEt_));
+  resultExtended.setPFGammaCands(tautagtools::filteredPFGammaCands(thePFCands, GammaCand_EcalclusMinEt_));
 
   TrackRefVector theFilteredTracks;
   if (UsePVconstraint_ && !pvIsFake) {
-    theFilteredTracks = tautagtools::filteredTracks(theTracks,tkminPt_,tkminPixelHitsn_,tkminTrackerHitsn_,tkmaxipt_,tkmaxChi2_,tkPVmaxDZ_,thePV, thePV.z());
+    theFilteredTracks = tautagtools::filteredTracks(
+        theTracks, tkminPt_, tkminPixelHitsn_, tkminTrackerHitsn_, tkmaxipt_, tkmaxChi2_, tkPVmaxDZ_, thePV, thePV.z());
   } else {
-    theFilteredTracks = tautagtools::filteredTracks(theTracks,tkminPt_,tkminPixelHitsn_,tkminTrackerHitsn_,tkmaxipt_,tkmaxChi2_,thePV);
+    theFilteredTracks = tautagtools::filteredTracks(
+        theTracks, tkminPt_, tkminPixelHitsn_, tkminTrackerHitsn_, tkmaxipt_, tkmaxChi2_, thePV);
   }
   resultExtended.setTracks(theFilteredTracks);
 
   return resultExtended;
 }
-

--- a/RecoTauTag/RecoTau/src/PFTauDecayModeTools.cc
+++ b/RecoTauTag/RecoTau/src/PFTauDecayModeTools.cc
@@ -4,83 +4,82 @@
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "PhysicsTools/JetMCUtils/interface/JetMCTag.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-namespace {
-  struct entry {
-    char const *label;
-    reco::PFTau::hadronicDecayMode mode;
-  };
+    namespace {
+      struct entry {
+        char const *label;
+        reco::PFTau::hadronicDecayMode mode;
+      };
 
-  // Convert the string decay mode from PhysicsTools to the
-  // PFTau::hadronicDecayMode format
-  constexpr entry dmTranslatorMap[] = {
-    {"unknown", reco::PFTau::kNull},
-    {"rare", reco::PFTau::kRareDecayMode},
-    {"oneProng0Pi0", reco::PFTau::kOneProng0PiZero},
-    {"oneProng1Pi0", reco::PFTau::kOneProng1PiZero},
-    {"oneProng2Pi0", reco::PFTau::kOneProng2PiZero},
-    {"oneProngOther", reco::PFTau::kOneProngNPiZero},
-    {"threeProng0Pi0", reco::PFTau::kThreeProng0PiZero},
-    {"threeProng1Pi0", reco::PFTau::kThreeProng1PiZero},
-    {"threeProngOther", reco::PFTau::kThreeProngNPiZero},
-    {"electron", reco::PFTau::kNull},
-    {"muon", reco::PFTau::kNull},
-    {nullptr,reco::PFTau::kNull}
-  };
-  
-  constexpr bool same(char const *x, char const *y) {
-    return !*x && !*y ? true : (*x == *y && same(x+1, y+1));
-  }
+      // Convert the string decay mode from PhysicsTools to the
+      // PFTau::hadronicDecayMode format
+      constexpr entry dmTranslatorMap[] = {{"unknown", reco::PFTau::kNull},
+                                           {"rare", reco::PFTau::kRareDecayMode},
+                                           {"oneProng0Pi0", reco::PFTau::kOneProng0PiZero},
+                                           {"oneProng1Pi0", reco::PFTau::kOneProng1PiZero},
+                                           {"oneProng2Pi0", reco::PFTau::kOneProng2PiZero},
+                                           {"oneProngOther", reco::PFTau::kOneProngNPiZero},
+                                           {"threeProng0Pi0", reco::PFTau::kThreeProng0PiZero},
+                                           {"threeProng1Pi0", reco::PFTau::kThreeProng1PiZero},
+                                           {"threeProngOther", reco::PFTau::kThreeProngNPiZero},
+                                           {"electron", reco::PFTau::kNull},
+                                           {"muon", reco::PFTau::kNull},
+                                           {nullptr, reco::PFTau::kNull}};
 
-  constexpr enum reco::PFTau::hadronicDecayMode decayModeStringToId(char const *label, entry const *entries) {
-    return !entries->label ? reco::PFTau::kRareDecayMode : same(entries->label, label) ? entries->mode : decayModeStringToId(label, entries+1);
-  }
+      constexpr bool same(char const *x, char const *y) { return !*x && !*y ? true : (*x == *y && same(x + 1, y + 1)); }
 
-  constexpr char const *decayModeIdToString(reco::PFTau::hadronicDecayMode mode, entry const *entries) {
-    return !entries->label ? "unknown" : (entries->mode == mode ? entries->label : decayModeIdToString(mode, entries+1));
-  }
-}
+      constexpr enum reco::PFTau::hadronicDecayMode decayModeStringToId(char const *label, entry const *entries) {
+        return !entries->label ? reco::PFTau::kRareDecayMode
+                               : same(entries->label, label) ? entries->mode : decayModeStringToId(label, entries + 1);
+      }
 
-unsigned int chargedHadronsInDecayMode(PFTau::hadronicDecayMode mode) {
-   int modeAsInt = static_cast<int>(mode);
-   return (modeAsInt / PFTau::kOneProngNPiZero) + 1;
-}
+      constexpr char const *decayModeIdToString(reco::PFTau::hadronicDecayMode mode, entry const *entries) {
+        return !entries->label ? "unknown"
+                               : (entries->mode == mode ? entries->label : decayModeIdToString(mode, entries + 1));
+      }
+    }  // namespace
 
-unsigned int piZerosInDecayMode(PFTau::hadronicDecayMode mode) {
-   int modeAsInt = static_cast<int>(mode);
-   return (modeAsInt % PFTau::kOneProngNPiZero);
-}
+    unsigned int chargedHadronsInDecayMode(PFTau::hadronicDecayMode mode) {
+      int modeAsInt = static_cast<int>(mode);
+      return (modeAsInt / PFTau::kOneProngNPiZero) + 1;
+    }
 
-PFTau::hadronicDecayMode translateDecayMode(
-    unsigned int nCharged, unsigned int nPiZeros) {
-   // If no tracks exist, this is definitely not a tau!
-   if(!nCharged) return PFTau::kNull;
-   // Find the maximum number of PiZeros our parameterization can hold
-   const unsigned int maxPiZeros = PFTau::kOneProngNPiZero;
-   // Determine our track index
-   unsigned int trackIndex = (nCharged-1)*(maxPiZeros+1);
-   // Check if we handle the given number of tracks
-   if(trackIndex >= PFTau::kRareDecayMode) return PFTau::kRareDecayMode;
+    unsigned int piZerosInDecayMode(PFTau::hadronicDecayMode mode) {
+      int modeAsInt = static_cast<int>(mode);
+      return (modeAsInt % PFTau::kOneProngNPiZero);
+    }
 
-   nPiZeros = (nPiZeros <= maxPiZeros) ? nPiZeros : maxPiZeros;
-   return static_cast<PFTau::hadronicDecayMode>(trackIndex + nPiZeros);
-}
+    PFTau::hadronicDecayMode translateDecayMode(unsigned int nCharged, unsigned int nPiZeros) {
+      // If no tracks exist, this is definitely not a tau!
+      if (!nCharged)
+        return PFTau::kNull;
+      // Find the maximum number of PiZeros our parameterization can hold
+      const unsigned int maxPiZeros = PFTau::kOneProngNPiZero;
+      // Determine our track index
+      unsigned int trackIndex = (nCharged - 1) * (maxPiZeros + 1);
+      // Check if we handle the given number of tracks
+      if (trackIndex >= PFTau::kRareDecayMode)
+        return PFTau::kRareDecayMode;
 
-PFTau::hadronicDecayMode translateGenDecayModeToReco(
-    const std::string& name) {
-  return decayModeStringToId(name.c_str(), dmTranslatorMap);
-}
+      nPiZeros = (nPiZeros <= maxPiZeros) ? nPiZeros : maxPiZeros;
+      return static_cast<PFTau::hadronicDecayMode>(trackIndex + nPiZeros);
+    }
 
-std::string translateRecoDecayModeToGen(PFTau::hadronicDecayMode decayMode) {
-  return decayModeIdToString(decayMode, dmTranslatorMap);
-}
+    PFTau::hadronicDecayMode translateGenDecayModeToReco(const std::string &name) {
+      return decayModeStringToId(name.c_str(), dmTranslatorMap);
+    }
 
+    std::string translateRecoDecayModeToGen(PFTau::hadronicDecayMode decayMode) {
+      return decayModeIdToString(decayMode, dmTranslatorMap);
+    }
 
-PFTau::hadronicDecayMode getDecayMode(const reco::GenJet* genJet) {
-  if (!genJet)
-    return reco::PFTau::kNull;
-  return translateGenDecayModeToReco(JetMCTagUtils::genTauDecayMode(*genJet));
-}
+    PFTau::hadronicDecayMode getDecayMode(const reco::GenJet *genJet) {
+      if (!genJet)
+        return reco::PFTau::kNull;
+      return translateGenDecayModeToReco(JetMCTagUtils::genTauDecayMode(*genJet));
+    }
 
-}} // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco

--- a/RecoTauTag/RecoTau/src/PFTauPrimaryVertexProducerBase.cc
+++ b/RecoTauTag/RecoTau/src/PFTauPrimaryVertexProducerBase.cc
@@ -17,181 +17,203 @@
 
 #include <memory>
 
-PFTauPrimaryVertexProducerBase::PFTauPrimaryVertexProducerBase(const edm::ParameterSet& iConfig):
-  pftauToken_(consumes<std::vector<reco::PFTau> >(iConfig.getParameter<edm::InputTag>("PFTauTag"))),
-  electronToken_(consumes<edm::View<reco::Electron> >(iConfig.getParameter<edm::InputTag>("ElectronTag"))),
-  muonToken_(consumes<edm::View<reco::Muon> >(iConfig.getParameter<edm::InputTag>("MuonTag"))),
-  pvToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("PVTag"))),
-  beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
-  algorithm_(iConfig.getParameter<int>("Algorithm")),
-  qualityCutsPSet_(iConfig.getParameter<edm::ParameterSet>("qualityCuts")),
-  useBeamSpot_(iConfig.getParameter<bool>("useBeamSpot")),
-  useSelectedTaus_(iConfig.getParameter<bool>("useSelectedTaus")),
-  removeMuonTracks_(iConfig.getParameter<bool>("RemoveMuonTracks")),
-  removeElectronTracks_(iConfig.getParameter<bool>("RemoveElectronTracks"))
-{
+PFTauPrimaryVertexProducerBase::PFTauPrimaryVertexProducerBase(const edm::ParameterSet& iConfig)
+    : pftauToken_(consumes<std::vector<reco::PFTau>>(iConfig.getParameter<edm::InputTag>("PFTauTag"))),
+      electronToken_(consumes<edm::View<reco::Electron>>(iConfig.getParameter<edm::InputTag>("ElectronTag"))),
+      muonToken_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("MuonTag"))),
+      pvToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("PVTag"))),
+      beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+      algorithm_(iConfig.getParameter<int>("Algorithm")),
+      qualityCutsPSet_(iConfig.getParameter<edm::ParameterSet>("qualityCuts")),
+      useBeamSpot_(iConfig.getParameter<bool>("useBeamSpot")),
+      useSelectedTaus_(iConfig.getParameter<bool>("useSelectedTaus")),
+      removeMuonTracks_(iConfig.getParameter<bool>("RemoveMuonTracks")),
+      removeElectronTracks_(iConfig.getParameter<bool>("RemoveElectronTracks")) {
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  std::vector<edm::ParameterSet> discriminators = iConfig.getParameter<std::vector<edm::ParameterSet> >("discriminators");
+  std::vector<edm::ParameterSet> discriminators =
+      iConfig.getParameter<std::vector<edm::ParameterSet>>("discriminators");
   // Build each of our cuts
-  for(auto const& pset : discriminators) {
+  for (auto const& pset : discriminators) {
     DiscCutPair* newCut = new DiscCutPair();
-    newCut->inputToken_ =consumes<reco::PFTauDiscriminator>(pset.getParameter<edm::InputTag>("discriminator"));
+    newCut->inputToken_ = consumes<reco::PFTauDiscriminator>(pset.getParameter<edm::InputTag>("discriminator"));
 
-    if ( pset.existsAs<std::string>("selectionCut") ) newCut->cutFormula_ = new TFormula("selectionCut", pset.getParameter<std::string>("selectionCut").data());
-    else newCut->cut_ = pset.getParameter<double>("selectionCut");
+    if (pset.existsAs<std::string>("selectionCut"))
+      newCut->cutFormula_ = new TFormula("selectionCut", pset.getParameter<std::string>("selectionCut").data());
+    else
+      newCut->cut_ = pset.getParameter<double>("selectionCut");
     discriminators_.push_back(newCut);
   }
   // Build a string cut if desired
-  if (iConfig.exists("cut")) cut_.reset(new StringCutObjectSelector<reco::PFTau>(iConfig.getParameter<std::string>( "cut" )));
+  if (iConfig.exists("cut"))
+    cut_.reset(new StringCutObjectSelector<reco::PFTau>(iConfig.getParameter<std::string>("cut")));
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  produces<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::VertexRef> > >();
-  produces<reco::VertexCollection>("PFTauPrimaryVertices"); 
+  produces<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::VertexRef>>>();
+  produces<reco::VertexCollection>("PFTauPrimaryVertices");
 
-  vertexAssociator_.reset(new reco::tau::RecoTauVertexAssociator(qualityCutsPSet_,consumesCollector()));
+  vertexAssociator_.reset(new reco::tau::RecoTauVertexAssociator(qualityCutsPSet_, consumesCollector()));
 }
 
-PFTauPrimaryVertexProducerBase::~PFTauPrimaryVertexProducerBase(){}
+PFTauPrimaryVertexProducerBase::~PFTauPrimaryVertexProducerBase() {}
 
 namespace {
   edm::Ptr<reco::TrackBase> getTrack(const reco::Candidate& cand) {
     const reco::PFCandidate* pfCandPtr = dynamic_cast<const reco::PFCandidate*>(&cand);
     if (pfCandPtr) {
-      if      ( pfCandPtr->trackRef().isNonnull()    ) return edm::refToPtr(pfCandPtr->trackRef());
-      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return edm::refToPtr(pfCandPtr->gsfTrackRef());
-      else return edm::Ptr<reco::TrackBase>();
+      if (pfCandPtr->trackRef().isNonnull())
+        return edm::refToPtr(pfCandPtr->trackRef());
+      else if (pfCandPtr->gsfTrackRef().isNonnull())
+        return edm::refToPtr(pfCandPtr->gsfTrackRef());
+      else
+        return edm::Ptr<reco::TrackBase>();
     }
     const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
     if (pCand && pCand->hasTrackDetails()) {
       const reco::TrackBase* trkPtr = pCand->bestTrack();
-      return edm::Ptr<reco::TrackBase>(trkPtr,0);
+      return edm::Ptr<reco::TrackBase>(trkPtr, 0);
     }
     return edm::Ptr<reco::TrackBase>();
   }
-}
+}  // namespace
 
-void PFTauPrimaryVertexProducerBase::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
-  
+void PFTauPrimaryVertexProducerBase::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   beginEvent(iEvent, iSetup);
 
   // Obtain Collections
   edm::ESHandle<TransientTrackBuilder> transTrackBuilder;
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",transTrackBuilder);
-  
-  edm::Handle<std::vector<reco::PFTau> > pfTaus;
-  iEvent.getByToken(pftauToken_,pfTaus);
+  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", transTrackBuilder);
 
-  edm::Handle<edm::View<reco::Electron> > electrons;
-  if(removeElectronTracks_) iEvent.getByToken(electronToken_,electrons);
+  edm::Handle<std::vector<reco::PFTau>> pfTaus;
+  iEvent.getByToken(pftauToken_, pfTaus);
 
-  edm::Handle<edm::View<reco::Muon> > muons;
-  if(removeMuonTracks_) iEvent.getByToken(muonToken_,muons);
+  edm::Handle<edm::View<reco::Electron>> electrons;
+  if (removeElectronTracks_)
+    iEvent.getByToken(electronToken_, electrons);
 
-  edm::Handle<reco::VertexCollection > vertices;
-  iEvent.getByToken(pvToken_,vertices);
+  edm::Handle<edm::View<reco::Muon>> muons;
+  if (removeMuonTracks_)
+    iEvent.getByToken(muonToken_, muons);
+
+  edm::Handle<reco::VertexCollection> vertices;
+  iEvent.getByToken(pvToken_, vertices);
 
   edm::Handle<reco::BeamSpot> beamSpot;
-  if(useBeamSpot_) iEvent.getByToken(beamSpotToken_,beamSpot);
+  if (useBeamSpot_)
+    iEvent.getByToken(beamSpotToken_, beamSpot);
 
   // Set Association Map
-  auto avPFTauPV = std::make_unique<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::VertexRef>>>(reco::PFTauRefProd(pfTaus));
+  auto avPFTauPV = std::make_unique<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::VertexRef>>>(
+      reco::PFTauRefProd(pfTaus));
   auto vertexCollection_out = std::make_unique<reco::VertexCollection>();
   reco::VertexRefProd vertexRefProd_out = iEvent.getRefBeforePut<reco::VertexCollection>("PFTauPrimaryVertices");
 
   // Load each discriminator
-  for(auto& disc : discriminators_) {
+  for (auto& disc : discriminators_) {
     edm::Handle<reco::PFTauDiscriminator> discr;
     iEvent.getByToken(disc->inputToken_, discr);
     disc->discr_ = &(*discr);
   }
 
   // Set event for VerexAssociator if needed
-  if(useInputPV==algorithm_)
+  if (useInputPV == algorithm_)
     vertexAssociator_->setEvent(iEvent);
 
-  // For each Tau Run Algorithim 
-  if(pfTaus.isValid()){
-    for(reco::PFTauCollection::size_type iPFTau = 0; iPFTau < pfTaus->size(); iPFTau++) {
+  // For each Tau Run Algorithim
+  if (pfTaus.isValid()) {
+    for (reco::PFTauCollection::size_type iPFTau = 0; iPFTau < pfTaus->size(); iPFTau++) {
       reco::PFTauRef tau(pfTaus, iPFTau);
       reco::VertexRef thePVRef;
-      if(useInputPV==algorithm_){
-	thePVRef = vertexAssociator_->associatedVertex(*tau); 
-      }
-      else if(useFrontPV==algorithm_){
-	thePVRef = reco::VertexRef(vertices,0);
+      if (useInputPV == algorithm_) {
+        thePVRef = vertexAssociator_->associatedVertex(*tau);
+      } else if (useFrontPV == algorithm_) {
+        thePVRef = reco::VertexRef(vertices, 0);
       }
       reco::Vertex thePV = *thePVRef;
       ///////////////////////
       // Check if it passed all the discrimiantors
       bool passed(true);
-      for(auto const& disc : discriminators_) {
+      for (auto const& disc : discriminators_) {
         // Check this discriminator passes
-	bool passedDisc = true;
-	if ( disc->cutFormula_ )passedDisc = (disc->cutFormula_->Eval((*disc->discr_)[tau]) > 0.5);
-	else passedDisc = ((*disc->discr_)[tau] > disc->cut_);
-        if ( !passedDisc ){passed = false; break;}
+        bool passedDisc = true;
+        if (disc->cutFormula_)
+          passedDisc = (disc->cutFormula_->Eval((*disc->discr_)[tau]) > 0.5);
+        else
+          passedDisc = ((*disc->discr_)[tau] > disc->cut_);
+        if (!passedDisc) {
+          passed = false;
+          break;
+        }
       }
-      if (passed && cut_.get()){passed = (*cut_)(*tau);}
-      if (passed){
-	std::vector<edm::Ptr<reco::TrackBase> > signalTracks;
-	for(reco::PFTauCollection::size_type jPFTau = 0; jPFTau < pfTaus->size(); jPFTau++) {
-	  if(useSelectedTaus_ || iPFTau==jPFTau){
-	    reco::PFTauRef pfTauRef(pfTaus, jPFTau);
-	    ///////////////////////////////////////////////////////////////////////////////////////////////
-	    // Get tracks from PFTau daughters
-	    for(const auto& pfcand : pfTauRef->signalChargedHadrCands()) {
-	      if(pfcand.isNull()) continue;
-	      const edm::Ptr<reco::TrackBase>& trackPtr = getTrack(*pfcand);
-	      if(trackPtr.isNonnull()) signalTracks.push_back(trackPtr);
-	    }
-	  }
-	}
-	// Get Muon tracks
-	if(removeMuonTracks_){
-	  if(muons.isValid()) {
-	    for(const auto& muon: *muons){
-	      if(muon.track().isNonnull()) signalTracks.push_back(edm::refToPtr(muon.track()));
-	    }
-	  }
-	}
-	// Get Electron Tracks
-	if(removeElectronTracks_){
-	  if(electrons.isValid()) {
-	    for(const auto& electron: *electrons){
-	      if(electron.track().isNonnull()) signalTracks.push_back(edm::refToPtr(electron.track()));
-	      if(electron.gsfTrack().isNonnull()) signalTracks.push_back(edm::refToPtr(electron.gsfTrack()));
-	    }
-	  }
-	}
-	///////////////////////////////////////////////////////////////////////////////////////////////
-	// Get Non-Tau tracks
-	std::vector<const reco::Track*> nonTauTracks;
-	nonTauTracksInPV(thePVRef,signalTracks,nonTauTracks);
+      if (passed && cut_.get()) {
+        passed = (*cut_)(*tau);
+      }
+      if (passed) {
+        std::vector<edm::Ptr<reco::TrackBase>> signalTracks;
+        for (reco::PFTauCollection::size_type jPFTau = 0; jPFTau < pfTaus->size(); jPFTau++) {
+          if (useSelectedTaus_ || iPFTau == jPFTau) {
+            reco::PFTauRef pfTauRef(pfTaus, jPFTau);
+            ///////////////////////////////////////////////////////////////////////////////////////////////
+            // Get tracks from PFTau daughters
+            for (const auto& pfcand : pfTauRef->signalChargedHadrCands()) {
+              if (pfcand.isNull())
+                continue;
+              const edm::Ptr<reco::TrackBase>& trackPtr = getTrack(*pfcand);
+              if (trackPtr.isNonnull())
+                signalTracks.push_back(trackPtr);
+            }
+          }
+        }
+        // Get Muon tracks
+        if (removeMuonTracks_) {
+          if (muons.isValid()) {
+            for (const auto& muon : *muons) {
+              if (muon.track().isNonnull())
+                signalTracks.push_back(edm::refToPtr(muon.track()));
+            }
+          }
+        }
+        // Get Electron Tracks
+        if (removeElectronTracks_) {
+          if (electrons.isValid()) {
+            for (const auto& electron : *electrons) {
+              if (electron.track().isNonnull())
+                signalTracks.push_back(edm::refToPtr(electron.track()));
+              if (electron.gsfTrack().isNonnull())
+                signalTracks.push_back(edm::refToPtr(electron.gsfTrack()));
+            }
+          }
+        }
+        ///////////////////////////////////////////////////////////////////////////////////////////////
+        // Get Non-Tau tracks
+        std::vector<const reco::Track*> nonTauTracks;
+        nonTauTracksInPV(thePVRef, signalTracks, nonTauTracks);
 
-	///////////////////////////////////////////////////////////////////////////////////////////////
-	// Refit the vertex
-	TransientVertex transVtx;
-	std::vector<reco::TransientTrack> transTracks;
-	for(const auto track: nonTauTracks){
-	  transTracks.push_back(transTrackBuilder->build(*track));
-	}
-	bool fitOK(true);
-	if ( transTracks.size() >= 2 ) {
-	  AdaptiveVertexFitter avf;
-	  avf.setWeightThreshold(0.1); //weight per track. allow almost every fit, else --> exception
-	  if ( !useBeamSpot_ ){
-	    transVtx = avf.vertex(transTracks);
-	  } else {
-	    transVtx = avf.vertex(transTracks, *beamSpot);
-	  }
-	} else fitOK = false;
-	if ( fitOK ) thePV = transVtx;
+        ///////////////////////////////////////////////////////////////////////////////////////////////
+        // Refit the vertex
+        TransientVertex transVtx;
+        std::vector<reco::TransientTrack> transTracks;
+        for (const auto track : nonTauTracks) {
+          transTracks.push_back(transTrackBuilder->build(*track));
+        }
+        bool fitOK(true);
+        if (transTracks.size() >= 2) {
+          AdaptiveVertexFitter avf;
+          avf.setWeightThreshold(0.1);  //weight per track. allow almost every fit, else --> exception
+          if (!useBeamSpot_) {
+            transVtx = avf.vertex(transTracks);
+          } else {
+            transVtx = avf.vertex(transTracks, *beamSpot);
+          }
+        } else
+          fitOK = false;
+        if (fitOK)
+          thePV = transVtx;
       }
       reco::VertexRef vtxRef = reco::VertexRef(vertexRefProd_out, vertexCollection_out->size());
       vertexCollection_out->push_back(thePV);
       avPFTauPV->setValue(iPFTau, vtxRef);
     }
   }
-  iEvent.put(std::move(vertexCollection_out),"PFTauPrimaryVertices");
+  iEvent.put(std::move(vertexCollection_out), "PFTauPrimaryVertices");
   iEvent.put(std::move(avPFTauPV));
 }
 
@@ -241,8 +263,8 @@ edm::ParameterSetDescription PFTauPrimaryVertexProducerBase::getDescriptionsBase
     pset_isolationQualityCuts.addOptional<bool>("useTracksInsteadOfPFHadrons");
 
     edm::ParameterSetDescription pset_qualityCuts;
-    pset_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts",    pset_signalQualityCuts);
-    pset_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts",   pset_vxAssocQualityCuts);
+    pset_qualityCuts.add<edm::ParameterSetDescription>("signalQualityCuts", pset_signalQualityCuts);
+    pset_qualityCuts.add<edm::ParameterSetDescription>("vxAssocQualityCuts", pset_vxAssocQualityCuts);
     pset_qualityCuts.add<edm::ParameterSetDescription>("isolationQualityCuts", pset_isolationQualityCuts);
     pset_qualityCuts.add<std::string>("leadingTrkOrPFCandOption", "leadPFCand");
     pset_qualityCuts.add<std::string>("pvFindingAlgo", "closestInDeltaZ");
@@ -256,14 +278,14 @@ edm::ParameterSetDescription PFTauPrimaryVertexProducerBase::getDescriptionsBase
   desc.add<std::string>("cut", "pt > 18.0 & abs(eta)<2.3");
   desc.add<int>("Algorithm", 0);
   desc.add<bool>("RemoveElectronTracks", false);
-  desc.add<bool>("RemoveMuonTracks",     false);
-  desc.add<bool>("useBeamSpot",          true);
-  desc.add<bool>("useSelectedTaus",      false);
-  desc.add<edm::InputTag>("beamSpot",    edm::InputTag("offlineBeamSpot"));
+  desc.add<bool>("RemoveMuonTracks", false);
+  desc.add<bool>("useBeamSpot", true);
+  desc.add<bool>("useSelectedTaus", false);
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
   desc.add<edm::InputTag>("ElectronTag", edm::InputTag("MyElectrons"));
-  desc.add<edm::InputTag>("PFTauTag",    edm::InputTag("hpsPFTauProducer"));
-  desc.add<edm::InputTag>("MuonTag",     edm::InputTag("MyMuons"));
-  desc.add<edm::InputTag>("PVTag",       edm::InputTag("offlinePrimaryVertices"));
-  
+  desc.add<edm::InputTag>("PFTauTag", edm::InputTag("hpsPFTauProducer"));
+  desc.add<edm::InputTag>("MuonTag", edm::InputTag("MyMuons"));
+  desc.add<edm::InputTag>("PVTag", edm::InputTag("offlinePrimaryVertices"));
+
   return desc;
 }

--- a/RecoTauTag/RecoTau/src/RecoTauBuilderPlugins.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauBuilderPlugins.cc
@@ -3,20 +3,19 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-// Update our reference to the PFCandidates & PVs
-void RecoTauBuilderPlugin::beginEvent() {
-  vertexAssociator_.setEvent(*evt());
-  evt()->getByToken(pfCand_token, pfCands_);
-}
+    // Update our reference to the PFCandidates & PVs
+    void RecoTauBuilderPlugin::beginEvent() {
+      vertexAssociator_.setEvent(*evt());
+      evt()->getByToken(pfCand_token, pfCands_);
+    }
 
-}}  // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-EDM_REGISTER_PLUGINFACTORY(RecoTauBuilderPluginFactory,
-                           "RecoTauBuilderPluginFactory");
-EDM_REGISTER_PLUGINFACTORY(RecoTauModifierPluginFactory,
-                           "RecoTauModifierPluginFactory");
-EDM_REGISTER_PLUGINFACTORY(RecoTauCleanerPluginFactory,
-                           "RecoTauCleanerPluginFactory");
+EDM_REGISTER_PLUGINFACTORY(RecoTauBuilderPluginFactory, "RecoTauBuilderPluginFactory");
+EDM_REGISTER_PLUGINFACTORY(RecoTauModifierPluginFactory, "RecoTauModifierPluginFactory");
+EDM_REGISTER_PLUGINFACTORY(RecoTauCleanerPluginFactory, "RecoTauCleanerPluginFactory");

--- a/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
@@ -13,121 +13,117 @@
 typedef std::vector<reco::CandidatePtr> CandPtrs;
 typedef CandPtrs::iterator CandIter;
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-namespace {
-  // Re-implemented from PFCandidate.cc
-  int translateTypeToAbsPdgId(int type) {
-    switch( type ) {
-    case reco::PFCandidate::h:     return 211; // pi+
-    case reco::PFCandidate::e:     return 11;
-    case reco::PFCandidate::mu:    return 13;
-    case reco::PFCandidate::gamma: return 22;
-    case reco::PFCandidate::h0:    return 130; // K_L0
-    case reco::PFCandidate::h_HF:         return 1; // dummy pdg code 
-    case reco::PFCandidate::egamma_HF:    return 2;  // dummy pdg code
-    case reco::PFCandidate::X: 
-    default:    return 0;  
+    namespace {
+      // Re-implemented from PFCandidate.cc
+      int translateTypeToAbsPdgId(int type) {
+        switch (type) {
+          case reco::PFCandidate::h:
+            return 211;  // pi+
+          case reco::PFCandidate::e:
+            return 11;
+          case reco::PFCandidate::mu:
+            return 13;
+          case reco::PFCandidate::gamma:
+            return 22;
+          case reco::PFCandidate::h0:
+            return 130;  // K_L0
+          case reco::PFCandidate::h_HF:
+            return 1;  // dummy pdg code
+          case reco::PFCandidate::egamma_HF:
+            return 2;  // dummy pdg code
+          case reco::PFCandidate::X:
+          default:
+            return 0;
+        }
+      }
+    }  // namespace
+    std::vector<CandidatePtr> flattenPiZeros(const std::vector<RecoTauPiZero>::const_iterator& piZerosBegin,
+                                             const std::vector<RecoTauPiZero>::const_iterator& piZerosEnd) {
+      std::vector<CandidatePtr> output;
+
+      for (std::vector<RecoTauPiZero>::const_iterator piZero = piZerosBegin; piZero != piZerosEnd; ++piZero) {
+        for (size_t iDaughter = 0; iDaughter < piZero->numberOfDaughters(); ++iDaughter) {
+          output.push_back(CandidatePtr(piZero->daughterPtr(iDaughter)));
+        }
+      }
+      return output;
     }
-  }
-}
-std::vector<CandidatePtr>
-flattenPiZeros(const std::vector<RecoTauPiZero>::const_iterator& piZerosBegin, const std::vector<RecoTauPiZero>::const_iterator& piZerosEnd) {
-  std::vector<CandidatePtr> output;
 
-  for(std::vector<RecoTauPiZero>::const_iterator piZero = piZerosBegin;
-      piZero != piZerosEnd; ++piZero) {
-    for(size_t iDaughter = 0; iDaughter < piZero->numberOfDaughters();
-        ++iDaughter) {
-      output.push_back(CandidatePtr(piZero->daughterPtr(iDaughter)));
+    std::vector<CandidatePtr> flattenPiZeros(const std::vector<RecoTauPiZero>& piZeros) {
+      return flattenPiZeros(piZeros.begin(), piZeros.end());
     }
-  }
-  return output;
-}
 
-std::vector<CandidatePtr>
-flattenPiZeros(const std::vector<RecoTauPiZero>& piZeros) {
-  return flattenPiZeros(piZeros.begin(), piZeros.end()); 
-}
+    std::vector<reco::CandidatePtr> pfCandidates(const reco::Jet& jet, int particleId, bool sort) {
+      return pfCandidatesByPdgId(jet, translateTypeToAbsPdgId(particleId), sort);
+    }
 
-std::vector<reco::CandidatePtr> pfCandidates(const reco::Jet& jet,
-    int particleId, bool sort) {
-  return pfCandidatesByPdgId(jet, translateTypeToAbsPdgId(particleId), sort);
-}
+    std::vector<CandidatePtr> pfCandidates(const Jet& jet, const std::vector<int>& particleIds, bool sort) {
+      std::vector<int> pdgIds;
+      for (auto particleId : particleIds)
+        pdgIds.push_back(translateTypeToAbsPdgId(particleId));
+      return pfCandidatesByPdgId(jet, pdgIds, sort);
+    }
 
-std::vector<CandidatePtr> pfCandidates(const Jet& jet,
-                                         const std::vector<int>& particleIds,
-                                         bool sort) {
-  std::vector<int> pdgIds;
-  for (auto particleId : particleIds)
-    pdgIds.push_back(translateTypeToAbsPdgId(particleId));
-  return pfCandidatesByPdgId(jet, pdgIds, sort);
-}
+    std::vector<reco::CandidatePtr> pfCandidatesByPdgId(const reco::Jet& jet, int pdgId, bool sort) {
+      CandPtrs pfCands = jet.daughterPtrVector();
+      CandPtrs selectedPFCands = filterPFCandidates(pfCands.begin(), pfCands.end(), pdgId, sort);
+      return selectedPFCands;
+    }
 
-std::vector<reco::CandidatePtr> pfCandidatesByPdgId(const reco::Jet& jet,
-    int pdgId, bool sort) {
-  CandPtrs pfCands = jet.daughterPtrVector();
-  CandPtrs selectedPFCands = filterPFCandidates(
-      pfCands.begin(), pfCands.end(), pdgId, sort);
-  return selectedPFCands;
-}
+    std::vector<reco::CandidatePtr> pfCandidatesByPdgId(const reco::Jet& jet,
+                                                        const std::vector<int>& pdgIds,
+                                                        bool sort) {
+      const CandPtrs& pfCands = jet.daughterPtrVector();
+      CandPtrs output;
+      // Get each desired candidate type, unsorted for now
+      for (std::vector<int>::const_iterator pdgId = pdgIds.begin(); pdgId != pdgIds.end(); ++pdgId) {
+        CandPtrs&& selectedPFCands = filterPFCandidates(pfCands.begin(), pfCands.end(), *pdgId, false);
+        output.insert(output.end(), selectedPFCands.begin(), selectedPFCands.end());
+      }
+      if (sort)
+        std::sort(output.begin(), output.end(), SortPFCandsDescendingPt());
+      return output;
+    }
 
-std::vector<reco::CandidatePtr> pfCandidatesByPdgId(const reco::Jet& jet,
-    const std::vector<int>& pdgIds, bool sort) {
-  const CandPtrs& pfCands = jet.daughterPtrVector();
-  CandPtrs output;
-  // Get each desired candidate type, unsorted for now
-  for(std::vector<int>::const_iterator pdgId = pdgIds.begin();
-      pdgId != pdgIds.end(); ++pdgId) {
-    CandPtrs&& selectedPFCands = filterPFCandidates(pfCands.begin(), pfCands.end(), *pdgId, false);
-    output.insert(output.end(), selectedPFCands.begin(), selectedPFCands.end());
-  }
-  if (sort) std::sort(output.begin(), output.end(), SortPFCandsDescendingPt());
-  return output;
-}
+    std::vector<reco::CandidatePtr> pfGammas(const reco::Jet& jet, bool sort) { return pfCandidates(jet, 22, sort); }
 
-std::vector<reco::CandidatePtr> pfGammas(const reco::Jet& jet, bool sort) {
-  return pfCandidates(jet, 22, sort);
-}
+    std::vector<reco::CandidatePtr> pfChargedCands(const reco::Jet& jet, bool sort) {
+      const CandPtrs& pfCands = jet.daughterPtrVector();
+      CandPtrs output;
+      CandPtrs&& mus = filterPFCandidates(pfCands.begin(), pfCands.end(), 13, false);
+      CandPtrs&& es = filterPFCandidates(pfCands.begin(), pfCands.end(), 11, false);
+      CandPtrs&& chs = filterPFCandidates(pfCands.begin(), pfCands.end(), 211, false);
+      output.reserve(mus.size() + es.size() + chs.size());
+      output.insert(output.end(), mus.begin(), mus.end());
+      output.insert(output.end(), es.begin(), es.end());
+      output.insert(output.end(), chs.begin(), chs.end());
+      if (sort)
+        std::sort(output.begin(), output.end(), SortPFCandsDescendingPt());
+      return output;
+    }
 
-std::vector<reco::CandidatePtr> pfChargedCands(const reco::Jet& jet,
-                                                 bool sort) {
-  const CandPtrs& pfCands = jet.daughterPtrVector();
-  CandPtrs output;
-  CandPtrs&& mus = filterPFCandidates(pfCands.begin(), pfCands.end(), 13, false);
-  CandPtrs&& es = filterPFCandidates(pfCands.begin(), pfCands.end(), 11, false);
-  CandPtrs&& chs = filterPFCandidates(pfCands.begin(), pfCands.end(), 211, false);
-  output.reserve(mus.size() + es.size() + chs.size());
-  output.insert(output.end(), mus.begin(), mus.end());
-  output.insert(output.end(), es.begin(), es.end());
-  output.insert(output.end(), chs.begin(), chs.end());
-  if (sort) std::sort(output.begin(), output.end(), SortPFCandsDescendingPt());
-  return output;
-}
+    math::XYZPointF atECALEntrance(const reco::Candidate* part, double bField) {
+      const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(part);
+      if (pfCand)
+        return pfCand->positionAtECALEntrance();
 
-math::XYZPointF atECALEntrance(const reco::Candidate* part, double bField) {
-  const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(part);
-  if (pfCand)
-    return pfCand->positionAtECALEntrance();
+      math::XYZPointF pos;
+      BaseParticlePropagator theParticle = BaseParticlePropagator(
+          RawParticle(math::XYZTLorentzVector(part->px(), part->py(), part->pz(), part->energy()),
+                      math::XYZTLorentzVector(part->vertex().x(), part->vertex().y(), part->vertex().z(), 0.)),
+          part->charge(),
+          0.,
+          0.,
+          bField);
+      theParticle.propagateToEcalEntrance(false);
+      if (theParticle.getSuccess() != 0) {
+        pos = math::XYZPointF(theParticle.particle().vertex());
+      }
+      return pos;
+    }
 
-  math::XYZPointF pos;
-  BaseParticlePropagator theParticle =
-    BaseParticlePropagator(RawParticle(math::XYZTLorentzVector(part->px(),
-                     part->py(),
-                     part->pz(),
-                     part->energy()),
-               math::XYZTLorentzVector(part->vertex().x(),
-                     part->vertex().y(),
-                     part->vertex().z(),
-                     0.)),
-               part->charge(),
-               0.,0.,bField);
-  theParticle.propagateToEcalEntrance(false);
-  if(theParticle.getSuccess()!=0){
-    pos = math::XYZPointF(theParticle.particle().vertex());
-  }
-  return pos;
-}
-
-
-} }
+  }  // namespace tau
+}  // namespace reco

--- a/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
@@ -9,416 +9,411 @@
 
 namespace reco::tau {
 
-RecoTauConstructor::RecoTauConstructor(const JetBaseRef& jet, const edm::Handle<edm::View<reco::Candidate> >& pfCands, 
-				       bool copyGammasFromPiZeros,
-				       const StringObjectFunction<reco::PFTau>* signalConeSize,
-				       double minAbsPhotonSumPt_insideSignalCone, double minRelPhotonSumPt_insideSignalCone,
-				       double minAbsPhotonSumPt_outsideSignalCone, double minRelPhotonSumPt_outsideSignalCone)
-  : signalConeSize_(signalConeSize),
-    minAbsPhotonSumPt_insideSignalCone_(minAbsPhotonSumPt_insideSignalCone),
-    minRelPhotonSumPt_insideSignalCone_(minRelPhotonSumPt_insideSignalCone),
-    minAbsPhotonSumPt_outsideSignalCone_(minAbsPhotonSumPt_outsideSignalCone),
-    minRelPhotonSumPt_outsideSignalCone_(minRelPhotonSumPt_outsideSignalCone),
-    pfCands_(pfCands)
-{
-  // Initialize tau
-  tau_.reset(new PFTau());
+  RecoTauConstructor::RecoTauConstructor(const JetBaseRef& jet,
+                                         const edm::Handle<edm::View<reco::Candidate> >& pfCands,
+                                         bool copyGammasFromPiZeros,
+                                         const StringObjectFunction<reco::PFTau>* signalConeSize,
+                                         double minAbsPhotonSumPt_insideSignalCone,
+                                         double minRelPhotonSumPt_insideSignalCone,
+                                         double minAbsPhotonSumPt_outsideSignalCone,
+                                         double minRelPhotonSumPt_outsideSignalCone)
+      : signalConeSize_(signalConeSize),
+        minAbsPhotonSumPt_insideSignalCone_(minAbsPhotonSumPt_insideSignalCone),
+        minRelPhotonSumPt_insideSignalCone_(minRelPhotonSumPt_insideSignalCone),
+        minAbsPhotonSumPt_outsideSignalCone_(minAbsPhotonSumPt_outsideSignalCone),
+        minRelPhotonSumPt_outsideSignalCone_(minRelPhotonSumPt_outsideSignalCone),
+        pfCands_(pfCands) {
+    // Initialize tau
+    tau_.reset(new PFTau());
 
-  copyGammas_ = copyGammasFromPiZeros;
-  // Initialize our Accessors
-  collections_[std::make_pair(kSignal, kChargedHadron)] =
-      &tau_->selectedSignalChargedHadrCands_;
-  collections_[std::make_pair(kSignal, kGamma)] =
-      &tau_->selectedSignalGammaCands_;
-  collections_[std::make_pair(kSignal, kNeutralHadron)] =
-      &tau_->selectedSignalNeutrHadrCands_;
-  collections_[std::make_pair(kSignal, kAll)] =
-      &tau_->selectedSignalCands_;
+    copyGammas_ = copyGammasFromPiZeros;
+    // Initialize our Accessors
+    collections_[std::make_pair(kSignal, kChargedHadron)] = &tau_->selectedSignalChargedHadrCands_;
+    collections_[std::make_pair(kSignal, kGamma)] = &tau_->selectedSignalGammaCands_;
+    collections_[std::make_pair(kSignal, kNeutralHadron)] = &tau_->selectedSignalNeutrHadrCands_;
+    collections_[std::make_pair(kSignal, kAll)] = &tau_->selectedSignalCands_;
 
-  collections_[std::make_pair(kIsolation, kChargedHadron)] =
-      &tau_->selectedIsolationChargedHadrCands_;
-  collections_[std::make_pair(kIsolation, kGamma)] =
-      &tau_->selectedIsolationGammaCands_;
-  collections_[std::make_pair(kIsolation, kNeutralHadron)] =
-      &tau_->selectedIsolationNeutrHadrCands_;
-  collections_[std::make_pair(kIsolation, kAll)] =
-      &tau_->selectedIsolationCands_;
+    collections_[std::make_pair(kIsolation, kChargedHadron)] = &tau_->selectedIsolationChargedHadrCands_;
+    collections_[std::make_pair(kIsolation, kGamma)] = &tau_->selectedIsolationGammaCands_;
+    collections_[std::make_pair(kIsolation, kNeutralHadron)] = &tau_->selectedIsolationNeutrHadrCands_;
+    collections_[std::make_pair(kIsolation, kAll)] = &tau_->selectedIsolationCands_;
 
-  // Build our temporary sorted collections, since you can't use stl sorts on
-  // RefVectors
-  for(auto const& colkey : collections_) {
-    // Build an empty list for each collection
-    sortedCollections_[colkey.first] = SortedListPtr(
-        new SortedListPtr::element_type);
-  }
-
-  tau_->setjetRef(jet);
-}
-
-void RecoTauConstructor::addPFCand(Region region, ParticleType type, const CandidatePtr& ptr, bool skipAddToP4) {
-  LogDebug("TauConstructorAddPFCand") << " region = " << region << ", type = " << type << ": Pt = " << ptr->pt() << ", eta = " << ptr->eta() << ", phi = " << ptr->phi();
-  if ( region == kSignal ) {
-    // Keep track of the four vector of the signal vector products added so far.
-    // If a photon add it if we are not using PiZeros to build the gammas
-    if ( ((type != kGamma) || !copyGammas_) && !skipAddToP4 ) {
-      LogDebug("TauConstructorAddPFCand") << "--> adding PFCand to tauP4." ;
-      p4_ += ptr->p4();
+    // Build our temporary sorted collections, since you can't use stl sorts on
+    // RefVectors
+    for (auto const& colkey : collections_) {
+      // Build an empty list for each collection
+      sortedCollections_[colkey.first] = SortedListPtr(new SortedListPtr::element_type);
     }
+
+    tau_->setjetRef(jet);
   }
-  getSortedCollection(region, type)->push_back(ptr);
-  // Add to global collection
-  getSortedCollection(region, kAll)->push_back(ptr);
-}
 
-void RecoTauConstructor::reserve(Region region, ParticleType type, size_t size){
-  getSortedCollection(region, type)->reserve(size);
-  getCollection(region, type)->reserve(size);
-  // Reserve global collection as well
-  getSortedCollection(region, kAll)->reserve(
-      getSortedCollection(region, kAll)->size() + size);
-  getCollection(region, kAll)->reserve(
-      getCollection(region, kAll)->size() + size);
-}
-
-void RecoTauConstructor::reserveTauChargedHadron(Region region, size_t size) 
-{
-  if ( region == kSignal ) {
-    tau_->signalTauChargedHadronCandidatesRestricted().reserve(size);
-    tau_->selectedSignalChargedHadrCands_.reserve(size);
-  } else {
-    tau_->isolationTauChargedHadronCandidatesRestricted().reserve(size);
-    tau_->selectedIsolationChargedHadrCands_.reserve(size);
+  void RecoTauConstructor::addPFCand(Region region, ParticleType type, const CandidatePtr& ptr, bool skipAddToP4) {
+    LogDebug("TauConstructorAddPFCand") << " region = " << region << ", type = " << type << ": Pt = " << ptr->pt()
+                                        << ", eta = " << ptr->eta() << ", phi = " << ptr->phi();
+    if (region == kSignal) {
+      // Keep track of the four vector of the signal vector products added so far.
+      // If a photon add it if we are not using PiZeros to build the gammas
+      if (((type != kGamma) || !copyGammas_) && !skipAddToP4) {
+        LogDebug("TauConstructorAddPFCand") << "--> adding PFCand to tauP4.";
+        p4_ += ptr->p4();
+      }
+    }
+    getSortedCollection(region, type)->push_back(ptr);
+    // Add to global collection
+    getSortedCollection(region, kAll)->push_back(ptr);
   }
-}
 
-namespace
-{
-  void checkOverlap(const CandidatePtr& neutral, const std::vector<CandidatePtr>& pfGammas, bool& isUnique)
-  {
-    LogDebug("TauConstructorCheckOverlap") << " pfGammas: #entries = " << pfGammas.size();
-    for ( std::vector<CandidatePtr>::const_iterator pfGamma = pfGammas.begin();
-	  pfGamma != pfGammas.end(); ++pfGamma ) {
-      LogDebug("TauConstructorCheckOverlap") << "pfGamma = " << pfGamma->id() << ":" << pfGamma->key();
-      if ( (*pfGamma).refCore() == neutral.refCore() && (*pfGamma).key() == neutral.key() ) isUnique = false;
+  void RecoTauConstructor::reserve(Region region, ParticleType type, size_t size) {
+    getSortedCollection(region, type)->reserve(size);
+    getCollection(region, type)->reserve(size);
+    // Reserve global collection as well
+    getSortedCollection(region, kAll)->reserve(getSortedCollection(region, kAll)->size() + size);
+    getCollection(region, kAll)->reserve(getCollection(region, kAll)->size() + size);
+  }
+
+  void RecoTauConstructor::reserveTauChargedHadron(Region region, size_t size) {
+    if (region == kSignal) {
+      tau_->signalTauChargedHadronCandidatesRestricted().reserve(size);
+      tau_->selectedSignalChargedHadrCands_.reserve(size);
+    } else {
+      tau_->isolationTauChargedHadronCandidatesRestricted().reserve(size);
+      tau_->selectedIsolationChargedHadrCands_.reserve(size);
     }
   }
 
+  namespace {
+    void checkOverlap(const CandidatePtr& neutral, const std::vector<CandidatePtr>& pfGammas, bool& isUnique) {
+      LogDebug("TauConstructorCheckOverlap") << " pfGammas: #entries = " << pfGammas.size();
+      for (std::vector<CandidatePtr>::const_iterator pfGamma = pfGammas.begin(); pfGamma != pfGammas.end(); ++pfGamma) {
+        LogDebug("TauConstructorCheckOverlap") << "pfGamma = " << pfGamma->id() << ":" << pfGamma->key();
+        if ((*pfGamma).refCore() == neutral.refCore() && (*pfGamma).key() == neutral.key())
+          isUnique = false;
+      }
+    }
 
-  void checkOverlap(const CandidatePtr& neutral, const std::vector<reco::RecoTauPiZero>& piZeros, bool& isUnique)
-  {
-    LogDebug("TauConstructorCheckOverlap") << " piZeros: #entries = " << piZeros.size();
-    for ( std::vector<reco::RecoTauPiZero>::const_iterator piZero = piZeros.begin();
-	  piZero != piZeros.end(); ++piZero ) {
-      size_t numPFGammas = piZero->numberOfDaughters();
-      for ( size_t iPFGamma = 0; iPFGamma < numPFGammas; ++iPFGamma ) {
-	reco::CandidatePtr pfGamma = piZero->daughterPtr(iPFGamma);
-	LogDebug("TauConstructorCheckOverlap") << "pfGamma = " << pfGamma.id() << ":" << pfGamma.key();
-	if ( pfGamma.id() == neutral.id() && pfGamma.key() == neutral.key() ) isUnique = false;
+    void checkOverlap(const CandidatePtr& neutral, const std::vector<reco::RecoTauPiZero>& piZeros, bool& isUnique) {
+      LogDebug("TauConstructorCheckOverlap") << " piZeros: #entries = " << piZeros.size();
+      for (std::vector<reco::RecoTauPiZero>::const_iterator piZero = piZeros.begin(); piZero != piZeros.end();
+           ++piZero) {
+        size_t numPFGammas = piZero->numberOfDaughters();
+        for (size_t iPFGamma = 0; iPFGamma < numPFGammas; ++iPFGamma) {
+          reco::CandidatePtr pfGamma = piZero->daughterPtr(iPFGamma);
+          LogDebug("TauConstructorCheckOverlap") << "pfGamma = " << pfGamma.id() << ":" << pfGamma.key();
+          if (pfGamma.id() == neutral.id() && pfGamma.key() == neutral.key())
+            isUnique = false;
+        }
+      }
+    }
+  }  // namespace
+
+  void RecoTauConstructor::addTauChargedHadron(Region region, const PFRecoTauChargedHadron& chargedHadron) {
+    LogDebug("TauConstructorAddChH") << " region = " << region << ": Pt = " << chargedHadron.pt()
+                                     << ", eta = " << chargedHadron.eta() << ", phi = " << chargedHadron.phi();
+    // CV: need to make sure that PFGammas merged with ChargedHadrons are not part of PiZeros
+    const std::vector<CandidatePtr>& neutrals = chargedHadron.getNeutralPFCandidates();
+    std::vector<CandidatePtr> neutrals_cleaned;
+    for (std::vector<CandidatePtr>::const_iterator neutral = neutrals.begin(); neutral != neutrals.end(); ++neutral) {
+      LogDebug("TauConstructorAddChH") << "neutral = " << neutral->id() << ":" << neutral->key();
+      bool isUnique = true;
+      if (copyGammas_)
+        checkOverlap(*neutral, *getSortedCollection(kSignal, kGamma), isUnique);
+      else
+        checkOverlap(*neutral, tau_->signalPiZeroCandidatesRestricted(), isUnique);
+      if (region == kIsolation) {
+        if (copyGammas_)
+          checkOverlap(*neutral, *getSortedCollection(kIsolation, kGamma), isUnique);
+        else
+          checkOverlap(*neutral, tau_->isolationPiZeroCandidatesRestricted(), isUnique);
+      }
+      LogDebug("TauConstructorAddChH") << "--> isUnique = " << isUnique;
+      if (isUnique)
+        neutrals_cleaned.push_back(*neutral);
+    }
+    PFRecoTauChargedHadron chargedHadron_cleaned = chargedHadron;
+    if (neutrals_cleaned.size() != neutrals.size()) {
+      chargedHadron_cleaned.neutralPFCandidates_ = neutrals_cleaned;
+      setChargedHadronP4(chargedHadron_cleaned);
+    }
+    if (region == kSignal) {
+      tau_->signalTauChargedHadronCandidatesRestricted().push_back(chargedHadron_cleaned);
+      p4_ += chargedHadron_cleaned.p4();
+      if (chargedHadron_cleaned.getChargedPFCandidate().isNonnull()) {
+        addPFCand(kSignal, kChargedHadron, convertToPtr(chargedHadron_cleaned.getChargedPFCandidate()), true);
+      }
+      const std::vector<CandidatePtr>& neutrals = chargedHadron_cleaned.getNeutralPFCandidates();
+      for (std::vector<CandidatePtr>::const_iterator neutral = neutrals.begin(); neutral != neutrals.end(); ++neutral) {
+        if (std::abs((*neutral)->pdgId()) == 22)
+          addPFCand(kSignal, kGamma, convertToPtr(*neutral), true);
+        else if (std::abs((*neutral)->pdgId()) == 130)
+          addPFCand(kSignal, kNeutralHadron, convertToPtr(*neutral), true);
+      };
+    } else {
+      tau_->isolationTauChargedHadronCandidatesRestricted().push_back(chargedHadron_cleaned);
+      if (chargedHadron_cleaned.getChargedPFCandidate().isNonnull()) {
+        if (std::abs(chargedHadron_cleaned.getChargedPFCandidate()->pdgId()) == 211)
+          addPFCand(kIsolation, kChargedHadron, convertToPtr(chargedHadron_cleaned.getChargedPFCandidate()));
+        else if (std::abs(chargedHadron_cleaned.getChargedPFCandidate()->pdgId()) == 130)
+          addPFCand(kIsolation, kNeutralHadron, convertToPtr(chargedHadron_cleaned.getChargedPFCandidate()));
+      }
+      const std::vector<CandidatePtr>& neutrals = chargedHadron_cleaned.getNeutralPFCandidates();
+      for (std::vector<CandidatePtr>::const_iterator neutral = neutrals.begin(); neutral != neutrals.end(); ++neutral) {
+        if (std::abs((*neutral)->pdgId()) == 22)
+          addPFCand(kIsolation, kGamma, convertToPtr(*neutral));
+        else if (std::abs((*neutral)->pdgId()) == 130)
+          addPFCand(kIsolation, kNeutralHadron, convertToPtr(*neutral));
+      };
+    }
+  }
+
+  void RecoTauConstructor::reservePiZero(Region region, size_t size) {
+    if (region == kSignal) {
+      tau_->signalPiZeroCandidatesRestricted().reserve(size);
+      // If we are building the gammas with the pizeros, resize that
+      // vector as well
+      if (copyGammas_)
+        reserve(kSignal, kGamma, 2 * size);
+    } else {
+      tau_->isolationPiZeroCandidatesRestricted().reserve(size);
+      if (copyGammas_)
+        reserve(kIsolation, kGamma, 2 * size);
+    }
+  }
+
+  void RecoTauConstructor::addPiZero(Region region, const RecoTauPiZero& piZero) {
+    LogDebug("TauConstructorAddPi0") << " region = " << region << ": Pt = " << piZero.pt() << ", eta = " << piZero.eta()
+                                     << ", phi = " << piZero.phi();
+    if (region == kSignal) {
+      tau_->signalPiZeroCandidatesRestricted().push_back(piZero);
+      // Copy the daughter gammas into the gamma collection if desired
+      if (copyGammas_) {
+        // If we are using the pizeros to build the gammas, make sure we update
+        // the four vector correctly.
+        p4_ += piZero.p4();
+        addPFCands(kSignal, kGamma, piZero.daughterPtrVector().begin(), piZero.daughterPtrVector().end());
+      }
+    } else {
+      tau_->isolationPiZeroCandidatesRestricted().push_back(piZero);
+      if (copyGammas_) {
+        addPFCands(kIsolation, kGamma, piZero.daughterPtrVector().begin(), piZero.daughterPtrVector().end());
       }
     }
   }
-}
 
-void RecoTauConstructor::addTauChargedHadron(Region region, const PFRecoTauChargedHadron& chargedHadron) 
-{
-  LogDebug("TauConstructorAddChH") << " region = " << region << ": Pt = " << chargedHadron.pt() << ", eta = " << chargedHadron.eta() << ", phi = " << chargedHadron.phi();
-  // CV: need to make sure that PFGammas merged with ChargedHadrons are not part of PiZeros
-  const std::vector<CandidatePtr>& neutrals = chargedHadron.getNeutralPFCandidates();
-  std::vector<CandidatePtr> neutrals_cleaned;
-  for ( std::vector<CandidatePtr>::const_iterator neutral = neutrals.begin();
-	neutral != neutrals.end(); ++neutral ) {
-    LogDebug("TauConstructorAddChH") << "neutral = " << neutral->id() << ":" << neutral->key();
-    bool isUnique = true;
-    if ( copyGammas_ ) checkOverlap(*neutral, *getSortedCollection(kSignal, kGamma), isUnique);
-    else checkOverlap(*neutral, tau_->signalPiZeroCandidatesRestricted(), isUnique);
-    if ( region == kIsolation ) {
-      if ( copyGammas_ ) checkOverlap(*neutral, *getSortedCollection(kIsolation, kGamma), isUnique);
-      else checkOverlap(*neutral, tau_->isolationPiZeroCandidatesRestricted(), isUnique);      
-    }
-    LogDebug("TauConstructorAddChH") << "--> isUnique = " << isUnique;
-    if ( isUnique ) neutrals_cleaned.push_back(*neutral);
-  }
-  PFRecoTauChargedHadron chargedHadron_cleaned = chargedHadron;
-  if ( neutrals_cleaned.size() != neutrals.size() ) {
-    chargedHadron_cleaned.neutralPFCandidates_ = neutrals_cleaned;
-    setChargedHadronP4(chargedHadron_cleaned);
-  }
-  if ( region == kSignal ) {
-    tau_->signalTauChargedHadronCandidatesRestricted().push_back(chargedHadron_cleaned);
-    p4_ += chargedHadron_cleaned.p4();
-    if ( chargedHadron_cleaned.getChargedPFCandidate().isNonnull() ) {
-      addPFCand(kSignal, kChargedHadron, convertToPtr(chargedHadron_cleaned.getChargedPFCandidate()), true);
-    }
-    const std::vector<CandidatePtr>& neutrals = chargedHadron_cleaned.getNeutralPFCandidates();
-    for ( std::vector<CandidatePtr>::const_iterator neutral = neutrals.begin();
-	  neutral != neutrals.end(); ++neutral ) {
-      if      ( std::abs((*neutral)->pdgId()) == 22 ) addPFCand(kSignal, kGamma, convertToPtr(*neutral), true);
-      else if ( std::abs((*neutral)->pdgId()) == 130 ) addPFCand(kSignal, kNeutralHadron, convertToPtr(*neutral), true);
-    };
-  } else {
-    tau_->isolationTauChargedHadronCandidatesRestricted().push_back(chargedHadron_cleaned);
-    if ( chargedHadron_cleaned.getChargedPFCandidate().isNonnull() ) {
-      if      ( std::abs(chargedHadron_cleaned.getChargedPFCandidate()->pdgId()) == 211  ) addPFCand(kIsolation, kChargedHadron, convertToPtr(chargedHadron_cleaned.getChargedPFCandidate()));
-      else if ( std::abs(chargedHadron_cleaned.getChargedPFCandidate()->pdgId()) == 130 ) addPFCand(kIsolation, kNeutralHadron, convertToPtr(chargedHadron_cleaned.getChargedPFCandidate()));
-    }
-    const std::vector<CandidatePtr>& neutrals = chargedHadron_cleaned.getNeutralPFCandidates();
-    for ( std::vector<CandidatePtr>::const_iterator neutral = neutrals.begin();
-	  neutral != neutrals.end(); ++neutral ) {
-      if      ( std::abs((*neutral)->pdgId()) == 22 ) addPFCand(kIsolation, kGamma, convertToPtr(*neutral));
-      else if ( std::abs((*neutral)->pdgId()) == 130 ) addPFCand(kIsolation, kNeutralHadron, convertToPtr(*neutral));
-    };
-  }
-}
-
-void RecoTauConstructor::reservePiZero(Region region, size_t size) 
-{
-  if ( region == kSignal ) {
-    tau_->signalPiZeroCandidatesRestricted().reserve(size);
-    // If we are building the gammas with the pizeros, resize that
-    // vector as well
-    if ( copyGammas_ ) reserve(kSignal, kGamma, 2*size);
-  } else {
-    tau_->isolationPiZeroCandidatesRestricted().reserve(size);
-    if ( copyGammas_ ) reserve(kIsolation, kGamma, 2*size);
-  }
-}
-
-void RecoTauConstructor::addPiZero(Region region, const RecoTauPiZero& piZero) 
-{
-  LogDebug("TauConstructorAddPi0") << " region = " << region << ": Pt = " << piZero.pt() << ", eta = " << piZero.eta() << ", phi = " << piZero.phi();
-  if ( region == kSignal ) {
-    tau_->signalPiZeroCandidatesRestricted().push_back(piZero);
-    // Copy the daughter gammas into the gamma collection if desired
-    if ( copyGammas_ ) {
-      // If we are using the pizeros to build the gammas, make sure we update
-      // the four vector correctly.
-      p4_ += piZero.p4();
-      addPFCands(kSignal, kGamma, piZero.daughterPtrVector().begin(), 
-          piZero.daughterPtrVector().end());
-    }
-  } else {
-    tau_->isolationPiZeroCandidatesRestricted().push_back(piZero);
-    if ( copyGammas_ ) {
-      addPFCands(kIsolation, kGamma, piZero.daughterPtrVector().begin(),
-          piZero.daughterPtrVector().end());
-    }
-  }
-}
-
-std::vector<CandidatePtr>*
-RecoTauConstructor::getCollection(Region region, ParticleType type) {
+  std::vector<CandidatePtr>* RecoTauConstructor::getCollection(Region region, ParticleType type) {
     return collections_[std::make_pair(region, type)];
-}
-
-RecoTauConstructor::SortedListPtr
-RecoTauConstructor::getSortedCollection(Region region, ParticleType type) {
-  return sortedCollections_[std::make_pair(region, type)];
-}
-
-// Trivial converter needed for polymorphism
-CandidatePtr RecoTauConstructor::convertToPtr(
-    const CandidatePtr& pfPtr) const {
-  return pfPtr;
-}
-
-namespace {
-// Make sure the two products come from the same EDM source
-template<typename T1, typename T2>
-void checkMatchedProductIds(const T1& t1, const T2& t2) {
-    if (t1.id() != t2.id()) {
-      throw cms::Exception("MismatchedPFCandSrc") << "Error: the input tag"
-          << " for the PF candidate collection provided to the RecoTauBuilder "
-          << " does not match the one that was used to build the source jets."
-          << " Please update the pfCandSrc paramters for the PFTau builders.";
-    }
-}
-}
-
-// Convert from a CandidateRef to a Ptr
-CandidatePtr RecoTauConstructor::convertToPtr(
-    const PFCandidatePtr& candPtr) const {
-  if(candPtr.isNonnull()) {
-    checkMatchedProductIds(candPtr, pfCands_);
-    return CandidatePtr(pfCands_, candPtr.key());
-  } else return PFCandidatePtr();
-}
-
-namespace {
-template<typename T> bool ptDescending(const T& a, const T& b) {
-  return a.pt() > b.pt();
-}
-template<typename T> bool ptDescendingPtr(const T& a, const T& b) {
-  return a->pt() > b->pt();
-}
-}
-
-void RecoTauConstructor::sortAndCopyIntoTau() {
-  // The charged hadrons and pizeros are a special case, as we can sort them in situ
-  std::sort(tau_->signalTauChargedHadronCandidatesRestricted().begin(),
-            tau_->signalTauChargedHadronCandidatesRestricted().end(),
-            ptDescending<PFRecoTauChargedHadron>);
-  std::sort(tau_->isolationTauChargedHadronCandidatesRestricted().begin(),
-            tau_->isolationTauChargedHadronCandidatesRestricted().end(),
-            ptDescending<PFRecoTauChargedHadron>);
-  std::sort(tau_->signalPiZeroCandidatesRestricted().begin(),
-            tau_->signalPiZeroCandidatesRestricted().end(),
-            ptDescending<RecoTauPiZero>);
-  std::sort(tau_->isolationPiZeroCandidatesRestricted().begin(),
-            tau_->isolationPiZeroCandidatesRestricted().end(),
-            ptDescending<RecoTauPiZero>);
-
-  // Sort each of our sortable collections, and copy them into the final
-  // tau RefVector.
-  for (auto const& colkey : collections_ ) {
-    SortedListPtr sortedCollection = sortedCollections_[colkey.first];
-    std::sort(sortedCollection->begin(),
-              sortedCollection->end(),
-              ptDescendingPtr<CandidatePtr>);
-    // Copy into the real tau collection
-    for ( std::vector<CandidatePtr>::const_iterator particle = sortedCollection->begin();
-	  particle != sortedCollection->end(); ++particle ) {
-      colkey.second->push_back(*particle);
-    }
   }
-}
 
-namespace
-{
-  PFTau::hadronicDecayMode calculateDecayMode(const reco::PFTau& tau, double dRsignalCone, 
-					      double minAbsPhotonSumPt_insideSignalCone, double minRelPhotonSumPt_insideSignalCone,
-					      double minAbsPhotonSumPt_outsideSignalCone, double minRelPhotonSumPt_outsideSignalCone) 
-  {
-    unsigned int nCharged = tau.signalTauChargedHadronCandidates().size();
-    // If no tracks exist, this is definitely not a tau!
-    if ( !nCharged ) return PFTau::kNull;
+  RecoTauConstructor::SortedListPtr RecoTauConstructor::getSortedCollection(Region region, ParticleType type) {
+    return sortedCollections_[std::make_pair(region, type)];
+  }
 
-    unsigned int nPiZeros = 0;
-    const std::vector<RecoTauPiZero>& piZeros = tau.signalPiZeroCandidates();
-    for ( std::vector<RecoTauPiZero>::const_iterator piZero = piZeros.begin();
-	  piZero != piZeros.end(); ++piZero ) {
-      double photonSumPt_insideSignalCone = 0.;
-      double photonSumPt_outsideSignalCone = 0.;
-      int numPhotons = piZero->numberOfDaughters();
-      for ( int idxPhoton = 0; idxPhoton < numPhotons; ++idxPhoton ) {
-	const reco::Candidate* photon = piZero->daughter(idxPhoton);
-	double dR = deltaR(photon->p4(), tau.p4());
-	if ( dR < dRsignalCone ) {
-	  photonSumPt_insideSignalCone += photon->pt();
-	} else {
-	  photonSumPt_outsideSignalCone += photon->pt();
-	}
+  // Trivial converter needed for polymorphism
+  CandidatePtr RecoTauConstructor::convertToPtr(const CandidatePtr& pfPtr) const { return pfPtr; }
+
+  namespace {
+    // Make sure the two products come from the same EDM source
+    template <typename T1, typename T2>
+    void checkMatchedProductIds(const T1& t1, const T2& t2) {
+      if (t1.id() != t2.id()) {
+        throw cms::Exception("MismatchedPFCandSrc")
+            << "Error: the input tag"
+            << " for the PF candidate collection provided to the RecoTauBuilder "
+            << " does not match the one that was used to build the source jets."
+            << " Please update the pfCandSrc paramters for the PFTau builders.";
       }
-      if ( photonSumPt_insideSignalCone  > minAbsPhotonSumPt_insideSignalCone  || photonSumPt_insideSignalCone  > (minRelPhotonSumPt_insideSignalCone*tau.pt())  ||
-	   photonSumPt_outsideSignalCone > minAbsPhotonSumPt_outsideSignalCone || photonSumPt_outsideSignalCone > (minRelPhotonSumPt_outsideSignalCone*tau.pt()) ) ++nPiZeros;
     }
-    
-    // Find the maximum number of PiZeros our parameterization can hold
-    const unsigned int maxPiZeros = PFTau::kOneProngNPiZero;
-    
-    // Determine our track index
-    unsigned int trackIndex = (nCharged - 1)*(maxPiZeros + 1);
-    
-    // Check if we handle the given number of tracks
-    if ( trackIndex >= PFTau::kRareDecayMode ) return PFTau::kRareDecayMode;
-    
-    if ( nPiZeros > maxPiZeros ) nPiZeros = maxPiZeros;
-    return static_cast<PFTau::hadronicDecayMode>(trackIndex + nPiZeros);
+  }  // namespace
+
+  // Convert from a CandidateRef to a Ptr
+  CandidatePtr RecoTauConstructor::convertToPtr(const PFCandidatePtr& candPtr) const {
+    if (candPtr.isNonnull()) {
+      checkMatchedProductIds(candPtr, pfCands_);
+      return CandidatePtr(pfCands_, candPtr.key());
+    } else
+      return PFCandidatePtr();
   }
-}
 
-std::auto_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects) 
-{
-  LogDebug("TauConstructorGet") << "Start getting" ;
+  namespace {
+    template <typename T>
+    bool ptDescending(const T& a, const T& b) {
+      return a.pt() > b.pt();
+    }
+    template <typename T>
+    bool ptDescendingPtr(const T& a, const T& b) {
+      return a->pt() > b->pt();
+    }
+  }  // namespace
 
-  // Copy the sorted collections into the interal tau refvectors
-  sortAndCopyIntoTau();
+  void RecoTauConstructor::sortAndCopyIntoTau() {
+    // The charged hadrons and pizeros are a special case, as we can sort them in situ
+    std::sort(tau_->signalTauChargedHadronCandidatesRestricted().begin(),
+              tau_->signalTauChargedHadronCandidatesRestricted().end(),
+              ptDescending<PFRecoTauChargedHadron>);
+    std::sort(tau_->isolationTauChargedHadronCandidatesRestricted().begin(),
+              tau_->isolationTauChargedHadronCandidatesRestricted().end(),
+              ptDescending<PFRecoTauChargedHadron>);
+    std::sort(tau_->signalPiZeroCandidatesRestricted().begin(),
+              tau_->signalPiZeroCandidatesRestricted().end(),
+              ptDescending<RecoTauPiZero>);
+    std::sort(tau_->isolationPiZeroCandidatesRestricted().begin(),
+              tau_->isolationPiZeroCandidatesRestricted().end(),
+              ptDescending<RecoTauPiZero>);
 
-  // Setup all the important member variables of the tau
-  // Set charge of tau
-//  tau_->setCharge(
-//      sumPFCandCharge(getCollection(kSignal, kChargedHadron)->begin(),
-//                      getCollection(kSignal, kChargedHadron)->end()));
-  // CV: take charge of highest pT charged hadron as charge of tau,
-  //     in case tau does not have three reconstructed tracks
-  //    (either because tau is reconstructed as 2prong or because PFRecoTauChargedHadron is built from a PFNeutralHadron)
-  unsigned int nCharged = 0;
-  int charge = 0;
-  double leadChargedHadronPt = 0.;
-  int leadChargedHadronCharge = 0;
-  for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = tau_->signalTauChargedHadronCandidatesRestricted().begin();
-	chargedHadron != tau_->signalTauChargedHadronCandidatesRestricted().end(); ++chargedHadron ) {
-    if ( chargedHadron->algoIs(PFRecoTauChargedHadron::kChargedPFCandidate) || chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack) ) {
-      ++nCharged;
-      charge += chargedHadron->charge();
-      if ( chargedHadron->pt() > leadChargedHadronPt ) {	
-	leadChargedHadronPt = chargedHadron->pt();
-	leadChargedHadronCharge = chargedHadron->charge();
+    // Sort each of our sortable collections, and copy them into the final
+    // tau RefVector.
+    for (auto const& colkey : collections_) {
+      SortedListPtr sortedCollection = sortedCollections_[colkey.first];
+      std::sort(sortedCollection->begin(), sortedCollection->end(), ptDescendingPtr<CandidatePtr>);
+      // Copy into the real tau collection
+      for (std::vector<CandidatePtr>::const_iterator particle = sortedCollection->begin();
+           particle != sortedCollection->end();
+           ++particle) {
+        colkey.second->push_back(*particle);
       }
     }
   }
-  if ( nCharged == 3 ) tau_->setCharge(charge);
-  else tau_->setCharge(leadChargedHadronCharge);
 
-  // Set PDG id
-  tau_->setPdgId(tau_->charge() < 0 ? 15 : -15);
+  namespace {
+    PFTau::hadronicDecayMode calculateDecayMode(const reco::PFTau& tau,
+                                                double dRsignalCone,
+                                                double minAbsPhotonSumPt_insideSignalCone,
+                                                double minRelPhotonSumPt_insideSignalCone,
+                                                double minAbsPhotonSumPt_outsideSignalCone,
+                                                double minRelPhotonSumPt_outsideSignalCone) {
+      unsigned int nCharged = tau.signalTauChargedHadronCandidates().size();
+      // If no tracks exist, this is definitely not a tau!
+      if (!nCharged)
+        return PFTau::kNull;
 
-  // Set P4
-  tau_->setP4(p4_);
+      unsigned int nPiZeros = 0;
+      const std::vector<RecoTauPiZero>& piZeros = tau.signalPiZeroCandidates();
+      for (std::vector<RecoTauPiZero>::const_iterator piZero = piZeros.begin(); piZero != piZeros.end(); ++piZero) {
+        double photonSumPt_insideSignalCone = 0.;
+        double photonSumPt_outsideSignalCone = 0.;
+        int numPhotons = piZero->numberOfDaughters();
+        for (int idxPhoton = 0; idxPhoton < numPhotons; ++idxPhoton) {
+          const reco::Candidate* photon = piZero->daughter(idxPhoton);
+          double dR = deltaR(photon->p4(), tau.p4());
+          if (dR < dRsignalCone) {
+            photonSumPt_insideSignalCone += photon->pt();
+          } else {
+            photonSumPt_outsideSignalCone += photon->pt();
+          }
+        }
+        if (photonSumPt_insideSignalCone > minAbsPhotonSumPt_insideSignalCone ||
+            photonSumPt_insideSignalCone > (minRelPhotonSumPt_insideSignalCone * tau.pt()) ||
+            photonSumPt_outsideSignalCone > minAbsPhotonSumPt_outsideSignalCone ||
+            photonSumPt_outsideSignalCone > (minRelPhotonSumPt_outsideSignalCone * tau.pt()))
+          ++nPiZeros;
+      }
 
-  // Set Decay Mode
-  double dRsignalCone = ( signalConeSize_ ) ? (*signalConeSize_)(*tau_) : 0.5;
-  tau_->setSignalConeSize(dRsignalCone);
-  PFTau::hadronicDecayMode dm = calculateDecayMode(
-      *tau_, 
-      dRsignalCone, 
-      minAbsPhotonSumPt_insideSignalCone_, minRelPhotonSumPt_insideSignalCone_, minAbsPhotonSumPt_outsideSignalCone_, minRelPhotonSumPt_outsideSignalCone_);
-  tau_->setDecayMode(dm);
+      // Find the maximum number of PiZeros our parameterization can hold
+      const unsigned int maxPiZeros = PFTau::kOneProngNPiZero;
 
-  LogDebug("TauConstructorGet") << "Pt = " << tau_->pt() << ", eta = " << tau_->eta() << ", phi = " << tau_->phi() << ", mass = " << tau_->mass() << ", dm = " << tau_->decayMode() ;
+      // Determine our track index
+      unsigned int trackIndex = (nCharged - 1) * (maxPiZeros + 1);
 
-  // Set charged isolation quantities
-  tau_->setisolationPFChargedHadrCandsPtSum(
-      sumPFCandPt(
-        getCollection(kIsolation, kChargedHadron)->begin(),
-        getCollection(kIsolation, kChargedHadron)->end()));
+      // Check if we handle the given number of tracks
+      if (trackIndex >= PFTau::kRareDecayMode)
+        return PFTau::kRareDecayMode;
 
-  // Set gamma isolation quantities
-  tau_->setisolationPFGammaCandsEtSum(
-      sumPFCandPt(
-        getCollection(kIsolation, kGamma)->begin(),
-        getCollection(kIsolation, kGamma)->end()));
+      if (nPiZeros > maxPiZeros)
+        nPiZeros = maxPiZeros;
+      return static_cast<PFTau::hadronicDecayMode>(trackIndex + nPiZeros);
+    }
+  }  // namespace
 
-  // Set em fraction
-  tau_->setemFraction(sumPFCandPt(
-          getCollection(kSignal, kGamma)->begin(),
-          getCollection(kSignal, kGamma)->end()) / tau_->pt());
+  std::auto_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects) {
+    LogDebug("TauConstructorGet") << "Start getting";
 
-  if ( setupLeadingObjects ) {
-    typedef std::vector<CandidatePtr>::const_iterator Iter;
-    // Find the highest PT object in the signal cone
-    Iter leadingCand = leadCand(
-        getCollection(kSignal, kAll)->begin(),
-        getCollection(kSignal, kAll)->end());
+    // Copy the sorted collections into the interal tau refvectors
+    sortAndCopyIntoTau();
 
-    if ( leadingCand != getCollection(kSignal, kAll)->end() )
-      tau_->setleadCand(*leadingCand);
+    // Setup all the important member variables of the tau
+    // Set charge of tau
+    //  tau_->setCharge(
+    //      sumPFCandCharge(getCollection(kSignal, kChargedHadron)->begin(),
+    //                      getCollection(kSignal, kChargedHadron)->end()));
+    // CV: take charge of highest pT charged hadron as charge of tau,
+    //     in case tau does not have three reconstructed tracks
+    //    (either because tau is reconstructed as 2prong or because PFRecoTauChargedHadron is built from a PFNeutralHadron)
+    unsigned int nCharged = 0;
+    int charge = 0;
+    double leadChargedHadronPt = 0.;
+    int leadChargedHadronCharge = 0;
+    for (std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron =
+             tau_->signalTauChargedHadronCandidatesRestricted().begin();
+         chargedHadron != tau_->signalTauChargedHadronCandidatesRestricted().end();
+         ++chargedHadron) {
+      if (chargedHadron->algoIs(PFRecoTauChargedHadron::kChargedPFCandidate) ||
+          chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack)) {
+        ++nCharged;
+        charge += chargedHadron->charge();
+        if (chargedHadron->pt() > leadChargedHadronPt) {
+          leadChargedHadronPt = chargedHadron->pt();
+          leadChargedHadronCharge = chargedHadron->charge();
+        }
+      }
+    }
+    if (nCharged == 3)
+      tau_->setCharge(charge);
+    else
+      tau_->setCharge(leadChargedHadronCharge);
 
-    // Hardest charged object in signal cone
-    Iter leadingChargedCand = leadCand(
-        getCollection(kSignal, kChargedHadron)->begin(),
-        getCollection(kSignal, kChargedHadron)->end());
+    // Set PDG id
+    tau_->setPdgId(tau_->charge() < 0 ? 15 : -15);
 
-    if ( leadingChargedCand != getCollection(kSignal, kChargedHadron)->end() )
-      tau_->setleadChargedHadrCand(*leadingChargedCand);
+    // Set P4
+    tau_->setP4(p4_);
 
-    // Hardest gamma object in signal cone
-    Iter leadingGammaCand = leadCand(
-        getCollection(kSignal, kGamma)->begin(),
-        getCollection(kSignal, kGamma)->end());
+    // Set Decay Mode
+    double dRsignalCone = (signalConeSize_) ? (*signalConeSize_)(*tau_) : 0.5;
+    tau_->setSignalConeSize(dRsignalCone);
+    PFTau::hadronicDecayMode dm = calculateDecayMode(*tau_,
+                                                     dRsignalCone,
+                                                     minAbsPhotonSumPt_insideSignalCone_,
+                                                     minRelPhotonSumPt_insideSignalCone_,
+                                                     minAbsPhotonSumPt_outsideSignalCone_,
+                                                     minRelPhotonSumPt_outsideSignalCone_);
+    tau_->setDecayMode(dm);
 
-    if(leadingGammaCand != getCollection(kSignal, kGamma)->end())
-      tau_->setleadNeutralCand(*leadingGammaCand);
+    LogDebug("TauConstructorGet") << "Pt = " << tau_->pt() << ", eta = " << tau_->eta() << ", phi = " << tau_->phi()
+                                  << ", mass = " << tau_->mass() << ", dm = " << tau_->decayMode();
+
+    // Set charged isolation quantities
+    tau_->setisolationPFChargedHadrCandsPtSum(sumPFCandPt(getCollection(kIsolation, kChargedHadron)->begin(),
+                                                          getCollection(kIsolation, kChargedHadron)->end()));
+
+    // Set gamma isolation quantities
+    tau_->setisolationPFGammaCandsEtSum(
+        sumPFCandPt(getCollection(kIsolation, kGamma)->begin(), getCollection(kIsolation, kGamma)->end()));
+
+    // Set em fraction
+    tau_->setemFraction(sumPFCandPt(getCollection(kSignal, kGamma)->begin(), getCollection(kSignal, kGamma)->end()) /
+                        tau_->pt());
+
+    if (setupLeadingObjects) {
+      typedef std::vector<CandidatePtr>::const_iterator Iter;
+      // Find the highest PT object in the signal cone
+      Iter leadingCand = leadCand(getCollection(kSignal, kAll)->begin(), getCollection(kSignal, kAll)->end());
+
+      if (leadingCand != getCollection(kSignal, kAll)->end())
+        tau_->setleadCand(*leadingCand);
+
+      // Hardest charged object in signal cone
+      Iter leadingChargedCand =
+          leadCand(getCollection(kSignal, kChargedHadron)->begin(), getCollection(kSignal, kChargedHadron)->end());
+
+      if (leadingChargedCand != getCollection(kSignal, kChargedHadron)->end())
+        tau_->setleadChargedHadrCand(*leadingChargedCand);
+
+      // Hardest gamma object in signal cone
+      Iter leadingGammaCand = leadCand(getCollection(kSignal, kGamma)->begin(), getCollection(kSignal, kGamma)->end());
+
+      if (leadingGammaCand != getCollection(kSignal, kGamma)->end())
+        tau_->setleadNeutralCand(*leadingGammaCand);
+    }
+    return tau_;
   }
-  return tau_;
-}
-} // end namespace reco::tau
+}  // end namespace reco::tau

--- a/RecoTauTag/RecoTau/src/RecoTauMuonTools.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauMuonTools.cc
@@ -2,52 +2,68 @@
 
 #include "DataFormats/TrackReco/interface/HitPattern.h"
 
-namespace reco { namespace tau {
-  void countHits(const reco::Muon& muon, std::vector<int>& numHitsDT, std::vector<int>& numHitsCSC, std::vector<int>& numHitsRPC)
-  {
-    if ( muon.outerTrack().isNonnull() ) {
-      const reco::HitPattern &muonHitPattern = muon.outerTrack()->hitPattern();
-      for (int iHit = 0; iHit < muonHitPattern.numberOfAllHits(reco::HitPattern::TRACK_HITS); ++iHit) {
+namespace reco {
+  namespace tau {
+    void countHits(const reco::Muon& muon,
+                   std::vector<int>& numHitsDT,
+                   std::vector<int>& numHitsCSC,
+                   std::vector<int>& numHitsRPC) {
+      if (muon.outerTrack().isNonnull()) {
+        const reco::HitPattern& muonHitPattern = muon.outerTrack()->hitPattern();
+        for (int iHit = 0; iHit < muonHitPattern.numberOfAllHits(reco::HitPattern::TRACK_HITS); ++iHit) {
           uint32_t hit = muonHitPattern.getHitPattern(reco::HitPattern::TRACK_HITS, iHit);
-	if ( hit == 0 ) break;	    
-	if ( muonHitPattern.muonHitFilter(hit) && (muonHitPattern.getHitType(hit) == TrackingRecHit::valid || muonHitPattern.getHitType(hit) == TrackingRecHit::bad) ) {
-	  int muonStation = muonHitPattern.getMuonStation(hit) - 1; // CV: map into range 0..3
-	  if ( muonStation >= 0 && muonStation < 4 ) {
-	    if      ( muonHitPattern.muonDTHitFilter(hit)  ) ++numHitsDT[muonStation];
-	    else if ( muonHitPattern.muonCSCHitFilter(hit) ) ++numHitsCSC[muonStation];
-	    else if ( muonHitPattern.muonRPCHitFilter(hit) ) ++numHitsRPC[muonStation];
-	  }
-	}
+          if (hit == 0)
+            break;
+          if (muonHitPattern.muonHitFilter(hit) && (muonHitPattern.getHitType(hit) == TrackingRecHit::valid ||
+                                                    muonHitPattern.getHitType(hit) == TrackingRecHit::bad)) {
+            int muonStation = muonHitPattern.getMuonStation(hit) - 1;  // CV: map into range 0..3
+            if (muonStation >= 0 && muonStation < 4) {
+              if (muonHitPattern.muonDTHitFilter(hit))
+                ++numHitsDT[muonStation];
+              else if (muonHitPattern.muonCSCHitFilter(hit))
+                ++numHitsCSC[muonStation];
+              else if (muonHitPattern.muonRPCHitFilter(hit))
+                ++numHitsRPC[muonStation];
+            }
+          }
+        }
       }
     }
-  }
 
-  std::string format_vint(const std::vector<int>& vi)
-  {
-    std::ostringstream os;    
-    os << "{ ";
-    unsigned numEntries = vi.size();
-    for ( unsigned iEntry = 0; iEntry < numEntries; ++iEntry ) {
-      os << vi[iEntry];
-      if ( iEntry < (numEntries - 1) ) os << ", ";
+    std::string format_vint(const std::vector<int>& vi) {
+      std::ostringstream os;
+      os << "{ ";
+      unsigned numEntries = vi.size();
+      for (unsigned iEntry = 0; iEntry < numEntries; ++iEntry) {
+        os << vi[iEntry];
+        if (iEntry < (numEntries - 1))
+          os << ", ";
+      }
+      os << " }";
+      return os.str();
     }
-    os << " }";
-    return os.str();
-  }
 
-  void countMatches(const reco::Muon& muon, std::vector<int>& numMatchesDT, std::vector<int>& numMatchesCSC, std::vector<int>& numMatchesRPC)
-  {
-    const std::vector<reco::MuonChamberMatch>& muonSegments = muon.matches();
-    for ( std::vector<reco::MuonChamberMatch>::const_iterator muonSegment = muonSegments.begin();
-	  muonSegment != muonSegments.end(); ++muonSegment ) {
-      if ( muonSegment->segmentMatches.empty() ) continue;
-      int muonDetector = muonSegment->detector();
-      int muonStation = muonSegment->station() - 1;
-      assert(muonStation >= 0 && muonStation <= 3);
-      if      ( muonDetector == MuonSubdetId::DT  ) ++numMatchesDT[muonStation];
-      else if ( muonDetector == MuonSubdetId::CSC ) ++numMatchesCSC[muonStation];
-      else if ( muonDetector == MuonSubdetId::RPC ) ++numMatchesRPC[muonStation];      
+    void countMatches(const reco::Muon& muon,
+                      std::vector<int>& numMatchesDT,
+                      std::vector<int>& numMatchesCSC,
+                      std::vector<int>& numMatchesRPC) {
+      const std::vector<reco::MuonChamberMatch>& muonSegments = muon.matches();
+      for (std::vector<reco::MuonChamberMatch>::const_iterator muonSegment = muonSegments.begin();
+           muonSegment != muonSegments.end();
+           ++muonSegment) {
+        if (muonSegment->segmentMatches.empty())
+          continue;
+        int muonDetector = muonSegment->detector();
+        int muonStation = muonSegment->station() - 1;
+        assert(muonStation >= 0 && muonStation <= 3);
+        if (muonDetector == MuonSubdetId::DT)
+          ++numMatchesDT[muonStation];
+        else if (muonDetector == MuonSubdetId::CSC)
+          ++numMatchesCSC[muonStation];
+        else if (muonDetector == MuonSubdetId::RPC)
+          ++numMatchesRPC[muonStation];
+      }
     }
-  }
 
-}}  // end namespace reco::tau
+  }  // namespace tau
+}  // namespace reco

--- a/RecoTauTag/RecoTau/src/RecoTauPluginsCommon.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauPluginsCommon.cc
@@ -1,29 +1,28 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauPluginsCommon.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-// ctor
-RecoTauNamedPlugin::RecoTauNamedPlugin(const edm::ParameterSet& pset):
-  name_(pset.getParameter<std::string>("name")) {}
+    // ctor
+    RecoTauNamedPlugin::RecoTauNamedPlugin(const edm::ParameterSet& pset)
+        : name_(pset.getParameter<std::string>("name")) {}
 
-const std::string& RecoTauNamedPlugin::name() const
-{ return name_; }
+    const std::string& RecoTauNamedPlugin::name() const { return name_; }
 
-// ctor
-RecoTauEventHolderPlugin::RecoTauEventHolderPlugin(const edm::ParameterSet& pset)
-  :RecoTauNamedPlugin(pset),evt_(nullptr),es_(nullptr) {}
+    // ctor
+    RecoTauEventHolderPlugin::RecoTauEventHolderPlugin(const edm::ParameterSet& pset)
+        : RecoTauNamedPlugin(pset), evt_(nullptr), es_(nullptr) {}
 
-const edm::Event* RecoTauEventHolderPlugin::evt() const { return evt_; }
-edm::Event* RecoTauEventHolderPlugin::evt() { return evt_; }
-const edm::EventSetup* RecoTauEventHolderPlugin::evtSetup() const { return es_; }
+    const edm::Event* RecoTauEventHolderPlugin::evt() const { return evt_; }
+    edm::Event* RecoTauEventHolderPlugin::evt() { return evt_; }
+    const edm::EventSetup* RecoTauEventHolderPlugin::evtSetup() const { return es_; }
 
-void RecoTauEventHolderPlugin::setup(edm::Event& evt, const edm::EventSetup& es)
-{
-  evt_ = &evt;
-  es_ = &es;
-  // Call the virtual beginEvent() function
-  this->beginEvent();
-}
+    void RecoTauEventHolderPlugin::setup(edm::Event& evt, const edm::EventSetup& es) {
+      evt_ = &evt;
+      es_ = &es;
+      // Call the virtual beginEvent() function
+      this->beginEvent();
+    }
 
-} } // end reco::tau
-
+  }  // namespace tau
+}  // namespace reco

--- a/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
@@ -8,568 +8,556 @@
 
 namespace reco::tau {
 
-namespace {
-  const reco::Track* getTrack(const Candidate& cand) 
-  { 
-    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
-    if (pfCandPtr) {
-      // Get the KF track if it exists.  Otherwise, see if PFCandidate has a GSF track.
-      if      ( pfCandPtr->trackRef().isNonnull()    ) return pfCandPtr->trackRef().get();
-      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return pfCandPtr->gsfTrackRef().get();
-      else return nullptr;
+  namespace {
+    const reco::Track* getTrack(const Candidate& cand) {
+      const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+      if (pfCandPtr) {
+        // Get the KF track if it exists.  Otherwise, see if PFCandidate has a GSF track.
+        if (pfCandPtr->trackRef().isNonnull())
+          return pfCandPtr->trackRef().get();
+        else if (pfCandPtr->gsfTrackRef().isNonnull())
+          return pfCandPtr->gsfTrackRef().get();
+        else
+          return nullptr;
+      }
+
+      const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+      if (packedCand && packedCand->hasTrackDetails())
+        return &packedCand->pseudoTrack();
+
+      return nullptr;
     }
 
-    const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
-    if (packedCand && packedCand->hasTrackDetails())
-    	return &packedCand->pseudoTrack();
+    const reco::TrackRef getTrackRef(const Candidate& cand) {
+      const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+      if (pfCandPtr)
+        return pfCandPtr->trackRef();
 
-    return nullptr;
-  }
-
-  const reco::TrackRef getTrackRef(const Candidate& cand) 
-  {
-    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
-    if (pfCandPtr)
-      return pfCandPtr->trackRef();
-
-    return reco::TrackRef();
-  }
-
-  const reco::TrackBaseRef getGsfTrackRef(const Candidate& cand) 
-  {
-    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
-    if (pfCandPtr) {
-      return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
+      return reco::TrackRef();
     }
-    return reco::TrackBaseRef();
 
-  }
-
-
-  // Translate GsfTrackRef to TrackBaseRef
-  template <typename T>
-  reco::TrackBaseRef convertRef(const T& ref) {
-    return reco::TrackBaseRef(ref);
-  }
-}
-
-// Quality cut implementations
-namespace qcuts {
-
-bool ptMin(const TrackBaseRef& track, double cut) 
-{
-  LogDebug("TauQCuts") << "<ptMin>: Pt = " << track->pt() << ", cut = " << cut ;
-  return (track->pt() > cut);
-}
-
-bool ptMin_cand(const Candidate& cand, double cut) 
-{
-  LogDebug("TauQCuts") << "<ptMin_cand>: Pt = " << cand.pt() << ", cut = " << cut ;
-  return (cand.pt() > cut);
-}
-
-bool etMin_cand(const Candidate& cand, double cut) 
-{
-  LogDebug("TauQCuts") << "<etMin_cand>: Et = " << cand.et() << ", cut = " << cut ;
-  return (cand.et() > cut);
-}
-
-bool trkPixelHits(const Track* track, int cut) 
-{
-  // For some reason, the number of hits is signed
-  LogDebug("TauQCuts") << "<trkPixelHits>: #Pxl hits = " << track->hitPattern().numberOfValidPixelHits() << ", cut = " << cut ;
-  return (track->hitPattern().numberOfValidPixelHits() >= cut);
-}
-
-bool trkPixelHits_cand(const Candidate& cand, int cut) 
-{
-  // For some reason, the number of hits is signed
-  auto track = getTrack(cand);
-  if ( track ) {
-    LogDebug("TauQCuts") << "<trkPixelHits_cand>: #Pxl hits = " << trkPixelHits(track, cut) << ", cut = " << cut ;
-    return trkPixelHits(track, cut);
-  } else {
-    LogDebug("TauQCuts") << "<trkPixelHits_cand>: #Pxl hits = N/A, cut = " << cut ;
-    return false;
-  }
-}
-
-bool trkTrackerHits(const Track* track, int cut) 
-{
-  LogDebug("TauQCuts") << "<trkTrackerHits>: #Trk hits = " << track->hitPattern().numberOfValidHits() << ", cut = " << cut ;
-  return (track->hitPattern().numberOfValidHits() >= cut);
-}
-
-bool trkTrackerHits_cand(const Candidate& cand, int cut) 
-{
-  auto track = getTrack(cand);
-  if ( track ) {
-    LogDebug("TauQCuts") << "<trkTrackerHits>: #Trk hits = " << track->hitPattern().numberOfValidHits() << ", cut = " << cut ;
-    return trkTrackerHits(track, cut);
-  } else {
-    LogDebug("TauQCuts") << "<trkTrackerHits>: #Trk hits = N/A, cut = " << cut ;
-    return false;
-  }
-}
-
-bool trkTransverseImpactParameter(const Track* track, const reco::VertexRef* pv, double cut) 
-{
-  if ( pv->isNull() ) {
-    edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in " <<
-      "RecoTauQualityCuts is invalid. - trkTransverseImpactParameter";
-    return false;
-  }
-  LogDebug("TauQCuts") << " track: Pt = " << track->pt() << ", eta = " << track->eta() << ", phi = " << track->phi() ;
-  LogDebug("TauQCuts") << " vertex: x = " << (*pv)->position().x() << ", y = " << (*pv)->position().y() << ", z = " << (*pv)->position().z() ;
-  LogDebug("TauQCuts") << "--> dxy = " << std::fabs(track->dxy((*pv)->position())) << " (cut = " << cut << ")" ;
-  return (std::fabs(track->dxy((*pv)->position())) <= cut);
-}
-
-bool trkTransverseImpactParameter_cand(const Candidate& cand, const reco::VertexRef* pv, double cut) 
-{
-  auto track = getTrack(cand);
-  if ( track ) {
-    return trkTransverseImpactParameter(track, pv, cut);
-  } else {
-    LogDebug("TauQCuts") << "<trkTransverseImpactParameter_cand>: dXY = N/A, cut = " << cut ;
-    return false;
-  }
-}
-
-bool trkLongitudinalImpactParameter(const TrackBase* track, const reco::VertexRef* pv, double cut) 
-{
-  if ( pv->isNull() ) {
-    edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in " <<
-      "RecoTauQualityCuts is invalid. - trkLongitudinalImpactParameter";
-    return false;
-  }
-  LogDebug("TauQCuts") << " track: Pt = " << track->pt() << ", eta = " << track->eta() << ", phi = " << track->phi() ;
-  LogDebug("TauQCuts") << " vertex: x = " << (*pv)->position().x() << ", y = " << (*pv)->position().y() << ", z = " << (*pv)->position().z() ;
-  LogDebug("TauQCuts") << "--> dz = " << std::fabs(track->dz((*pv)->position())) << " (cut = " << cut << ")" ;
-  return (std::fabs(track->dz((*pv)->position())) <= cut);
-}
-
-bool trkLongitudinalImpactParameter_cand(const Candidate& cand, const reco::VertexRef* pv, double cut) 
-{
-  auto track = getTrack(cand);
-  if ( track ) {
-    return trkLongitudinalImpactParameter(track, pv, cut);
-  } else {
-    LogDebug("TauQCuts") << "<trkLongitudinalImpactParameter_cand>: dZ = N/A, cut = " << cut ;
-    return false;
-  }
-}
-
-/// DZ cut, with respect to the current lead rack
-bool trkLongitudinalImpactParameterWrtTrack(const Track* track, const Track* leadTrack, const reco::VertexRef* pv, double cut)
-{
-  if (!leadTrack) {
-    edm::LogError("QCutsNoValidLeadTrack") << "Lead track Ref in " <<
-      "RecoTauQualityCuts is invalid. - trkLongitudinalImpactParameterWrtTrack";
-    return false;
-  }
-  return (std::fabs(track->dz((*pv)->position()) - leadTrack->dz((*pv)->position())) <= cut);
-}
-
-bool trkLongitudinalImpactParameterWrtTrack_cand(const Candidate& cand, const reco::Track* leadTrack, const reco::VertexRef* pv, double cut) 
-{
-  auto track = getTrack(cand);
-  if ( track ) return trkLongitudinalImpactParameterWrtTrack(track, leadTrack, pv, cut);
-  else return false;
-}
-
-bool minTrackVertexWeight(const TrackBaseRef& track, const reco::VertexRef* pv, double cut) 
-{
-  if ( pv->isNull() ) {
-    edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in " <<
-      "RecoTauQualityCuts is invalid. - minTrackVertexWeight";
-    return false;
-  }
-  LogDebug("TauQCuts") << " track: Pt = " << track->pt() << ", eta = " << track->eta() << ", phi = " << track->phi() ;
-  LogDebug("TauQCuts") << " vertex: x = " << (*pv)->position().x() << ", y = " << (*pv)->position().y() << ", z = " << (*pv)->position().z() ;
-  LogDebug("TauQCuts") << "--> trackWeight = " << (*pv)->trackWeight(track) << " (cut = " << cut << ")" ;
-  return ((*pv)->trackWeight(track) >= cut);
-}
-
-bool minTrackVertexWeight(const TrackRef& track, const reco::VertexRef* pv, double cut) 
-{
-  if ( pv->isNull() ) {
-    edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in " <<
-      "RecoTauQualityCuts is invalid. - minTrackVertexWeight";
-    return false;
-  }
-  LogDebug("TauQCuts") << " track: Pt = " << track->pt() << ", eta = " << track->eta() << ", phi = " << track->phi() ;
-  LogDebug("TauQCuts") << " vertex: x = " << (*pv)->position().x() << ", y = " << (*pv)->position().y() << ", z = " << (*pv)->position().z() ;
-  LogDebug("TauQCuts") << "--> trackWeight = " << (*pv)->trackWeight(track) << " (cut = " << cut << ")" ;
-  return ((*pv)->trackWeight(track) >= cut);
-}
-
-bool minPackedCandVertexWeight(const pat::PackedCandidate& pCand, const reco::VertexRef* pv, double cut) {
-
-  if ( pv->isNull() ) {
-    edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in " <<
-      "RecoTauQualityCuts is invalid. - minPackedCandVertexWeight";
-    return false;
-  }
-  //there is some low granular information on track weight in the vertex available with packed cands
-  double weight = -9.9;
-  if( pCand.vertexRef().isNonnull() && pCand.vertexRef().key() == pv->key() ){
-    int quality = pCand.pvAssociationQuality();
-    if( quality == pat::PackedCandidate::UsedInFitTight ) weight = 0.6;//0.6 as proxy for weight above 0.5
-    else if( quality == pat::PackedCandidate::UsedInFitLoose ) weight = 0.1;//0.6 as proxy for weight below 0.5
-  }
-  LogDebug("TauQCuts") << " packedCand: Pt = " << pCand.pt() << ", eta = " << pCand.eta() << ", phi = " << pCand.phi() ;
-  LogDebug("TauQCuts") << " vertex: x = " << (*pv)->position().x() << ", y = " << (*pv)->position().y() << ", z = " << (*pv)->position().z() ;
-  LogDebug("TauQCuts") << "--> trackWeight from packedCand = " << weight << " (cut = " << cut << ")" ;
-  return (weight >= cut);
-}
-
-bool minTrackVertexWeight_cand(const Candidate& cand, const reco::VertexRef* pv, double cut) 
-{
-  auto track = getTrackRef(cand);
-  if ( track.isNonnull() ) {
-    return minTrackVertexWeight(track, pv, cut);
-  }
-  auto gsfTrack = getGsfTrackRef(cand);
-  if ( gsfTrack.isNonnull() ) {
-    return minTrackVertexWeight(gsfTrack, pv, cut);
-  }
-
-  const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
-  if( pCand != nullptr && cand.charge() != 0) {
-    return minPackedCandVertexWeight(*pCand, pv, cut);
-  }
-  LogDebug("TauQCuts") << "<minTrackVertexWeight_cand>: weight = N/A, cut = " << cut ;
-  return false;
-}
-
-bool trkChi2(const Track* track, double cut) 
-{
-  LogDebug("TauQCuts") << "<trkChi2>: chi^2 = " << track->normalizedChi2() << ", cut = " << cut ;
-  return (track->normalizedChi2() <= cut);
-}
-
-bool trkChi2_cand(const Candidate& cand, double cut) 
-{
-  auto track = getTrack(cand);
-  if ( track ) {
-    LogDebug("TauQCuts") << "<trkChi2_cand>: chi^2 = " << track->normalizedChi2() << ", cut = " << cut ;
-    return trkChi2(track, cut);
-  } else {
-    LogDebug("TauQCuts") << "<trkChi2_cand>: chi^2 = N/A, cut = " << cut ;
-    return false;
-  }
-}
-
-// And a set of qcuts
-bool AND(const TrackBaseRef& track, const RecoTauQualityCuts::TrackQCutFuncCollection& cuts) 
-{
-  for(auto const& func : cuts ) {
-    if ( !func(track) ) return false;
-  }
-  return true;
-}
-
-bool AND_cand(const Candidate& cand, const RecoTauQualityCuts::CandQCutFuncCollection& cuts) 
-{
-  for(auto const& func : cuts ) {
-    if ( !func(cand) ) return false;
-  }
-  return true;
-}
-
-// Get the set of Q cuts for a given type (i.e. gamma)
-bool mapAndCutByType(const Candidate& cand, const RecoTauQualityCuts::CandQCutFuncMap& funcMap) 
-{
-  // Find the cuts that for this particle type
-  RecoTauQualityCuts::CandQCutFuncMap::const_iterator cuts = funcMap.find(std::abs(cand.pdgId()));
-  // Return false if we dont' know how to deal with this particle type
-  if ( cuts == funcMap.end() ) return false; 
-  return AND_cand(cand, cuts->second); // Otherwise AND all the cuts
-}
-
-} // end qcuts implementation namespace
-
-RecoTauQualityCuts::RecoTauQualityCuts(const edm::ParameterSet &qcuts) 
-{
-  // Setup all of our predicates
-  CandQCutFuncCollection chargedHadronCuts;
-  CandQCutFuncCollection gammaCuts;
-  CandQCutFuncCollection neutralHadronCuts;
-
-  // Make sure there are no extra passed options
-  std::set<std::string> passedOptionSet;
-  std::vector<std::string> passedOptions = qcuts.getParameterNames();
-
-  for(auto const& option : passedOptions) {
-    passedOptionSet.insert(option);
-  }
-
-  unsigned int nCuts = 0;
-  auto getDouble = [&qcuts, &passedOptionSet, &nCuts](const std::string& name) {
-    if(qcuts.exists(name)) {
-      ++nCuts;
-      passedOptionSet.erase(name);
-      return qcuts.getParameter<double>(name);
+    const reco::TrackBaseRef getGsfTrackRef(const Candidate& cand) {
+      const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+      if (pfCandPtr) {
+        return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
+      }
+      return reco::TrackBaseRef();
     }
-    return -1.0;
-  };
-  auto getUint = [&qcuts, &passedOptionSet, &nCuts](const std::string& name) -> unsigned int {
-    if(qcuts.exists(name)) {
-      ++nCuts;
-      passedOptionSet.erase(name);
-      return qcuts.getParameter<unsigned int>(name);
+
+    // Translate GsfTrackRef to TrackBaseRef
+    template <typename T>
+    reco::TrackBaseRef convertRef(const T& ref) {
+      return reco::TrackBaseRef(ref);
     }
-    return 0;
-  };
+  }  // namespace
 
-  // Build all the QCuts for tracks
-  minTrackPt_ = getDouble("minTrackPt");
-  maxTrackChi2_ = getDouble("maxTrackChi2");
-  minTrackPixelHits_ = getUint("minTrackPixelHits");
-  minTrackHits_ = getUint("minTrackHits");
-  maxTransverseImpactParameter_ = getDouble("maxTransverseImpactParameter");
-  maxDeltaZ_ = getDouble("maxDeltaZ");
-  maxDeltaZToLeadTrack_ = getDouble("maxDeltaZToLeadTrack");
-  // Require tracks to contribute a minimum weight to the associated vertex.
-  minTrackVertexWeight_ = getDouble("minTrackVertexWeight");
-  
-  // Use bit-wise & to avoid conditional code
-  checkHitPattern_ = (minTrackHits_ > 0) || (minTrackPixelHits_ > 0);
-  checkPV_ = (maxTransverseImpactParameter_ >= 0) ||
-             (maxDeltaZ_ >= 0) ||
-             (maxDeltaZToLeadTrack_ >= 0) ||
-             (minTrackVertexWeight_ >= 0);
+  // Quality cut implementations
+  namespace qcuts {
 
-  // Build the QCuts for gammas
-  minGammaEt_ = getDouble("minGammaEt");
+    bool ptMin(const TrackBaseRef& track, double cut) {
+      LogDebug("TauQCuts") << "<ptMin>: Pt = " << track->pt() << ", cut = " << cut;
+      return (track->pt() > cut);
+    }
 
-  // Build QCuts for netural hadrons
-  minNeutralHadronEt_ = getDouble("minNeutralHadronEt");
+    bool ptMin_cand(const Candidate& cand, double cut) {
+      LogDebug("TauQCuts") << "<ptMin_cand>: Pt = " << cand.pt() << ", cut = " << cut;
+      return (cand.pt() > cut);
+    }
 
-  // Check if there are any remaining unparsed QCuts
-  if ( !passedOptionSet.empty() ) {
-    std::string unParsedOptions;
-    bool thereIsABadParameter = false;
-    for(auto const& option : passedOptionSet ) {
-      // Workaround for HLT - TODO FIXME
-      if ( option == "useTracksInsteadOfPFHadrons" ) {
-        // Crash if true - no one should have this option enabled.
-        if ( qcuts.getParameter<bool>("useTracksInsteadOfPFHadrons") ) {
-          throw cms::Exception("DontUseTracksInQcuts")
-            << "The obsolete exception useTracksInsteadOfPFHadrons "
-            << "is set to true in the quality cut config." << std::endl;
+    bool etMin_cand(const Candidate& cand, double cut) {
+      LogDebug("TauQCuts") << "<etMin_cand>: Et = " << cand.et() << ", cut = " << cut;
+      return (cand.et() > cut);
+    }
+
+    bool trkPixelHits(const Track* track, int cut) {
+      // For some reason, the number of hits is signed
+      LogDebug("TauQCuts") << "<trkPixelHits>: #Pxl hits = " << track->hitPattern().numberOfValidPixelHits()
+                           << ", cut = " << cut;
+      return (track->hitPattern().numberOfValidPixelHits() >= cut);
+    }
+
+    bool trkPixelHits_cand(const Candidate& cand, int cut) {
+      // For some reason, the number of hits is signed
+      auto track = getTrack(cand);
+      if (track) {
+        LogDebug("TauQCuts") << "<trkPixelHits_cand>: #Pxl hits = " << trkPixelHits(track, cut) << ", cut = " << cut;
+        return trkPixelHits(track, cut);
+      } else {
+        LogDebug("TauQCuts") << "<trkPixelHits_cand>: #Pxl hits = N/A, cut = " << cut;
+        return false;
+      }
+    }
+
+    bool trkTrackerHits(const Track* track, int cut) {
+      LogDebug("TauQCuts") << "<trkTrackerHits>: #Trk hits = " << track->hitPattern().numberOfValidHits()
+                           << ", cut = " << cut;
+      return (track->hitPattern().numberOfValidHits() >= cut);
+    }
+
+    bool trkTrackerHits_cand(const Candidate& cand, int cut) {
+      auto track = getTrack(cand);
+      if (track) {
+        LogDebug("TauQCuts") << "<trkTrackerHits>: #Trk hits = " << track->hitPattern().numberOfValidHits()
+                             << ", cut = " << cut;
+        return trkTrackerHits(track, cut);
+      } else {
+        LogDebug("TauQCuts") << "<trkTrackerHits>: #Trk hits = N/A, cut = " << cut;
+        return false;
+      }
+    }
+
+    bool trkTransverseImpactParameter(const Track* track, const reco::VertexRef* pv, double cut) {
+      if (pv->isNull()) {
+        edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in "
+                                              << "RecoTauQualityCuts is invalid. - trkTransverseImpactParameter";
+        return false;
+      }
+      LogDebug("TauQCuts") << " track: Pt = " << track->pt() << ", eta = " << track->eta()
+                           << ", phi = " << track->phi();
+      LogDebug("TauQCuts") << " vertex: x = " << (*pv)->position().x() << ", y = " << (*pv)->position().y()
+                           << ", z = " << (*pv)->position().z();
+      LogDebug("TauQCuts") << "--> dxy = " << std::fabs(track->dxy((*pv)->position())) << " (cut = " << cut << ")";
+      return (std::fabs(track->dxy((*pv)->position())) <= cut);
+    }
+
+    bool trkTransverseImpactParameter_cand(const Candidate& cand, const reco::VertexRef* pv, double cut) {
+      auto track = getTrack(cand);
+      if (track) {
+        return trkTransverseImpactParameter(track, pv, cut);
+      } else {
+        LogDebug("TauQCuts") << "<trkTransverseImpactParameter_cand>: dXY = N/A, cut = " << cut;
+        return false;
+      }
+    }
+
+    bool trkLongitudinalImpactParameter(const TrackBase* track, const reco::VertexRef* pv, double cut) {
+      if (pv->isNull()) {
+        edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in "
+                                              << "RecoTauQualityCuts is invalid. - trkLongitudinalImpactParameter";
+        return false;
+      }
+      LogDebug("TauQCuts") << " track: Pt = " << track->pt() << ", eta = " << track->eta()
+                           << ", phi = " << track->phi();
+      LogDebug("TauQCuts") << " vertex: x = " << (*pv)->position().x() << ", y = " << (*pv)->position().y()
+                           << ", z = " << (*pv)->position().z();
+      LogDebug("TauQCuts") << "--> dz = " << std::fabs(track->dz((*pv)->position())) << " (cut = " << cut << ")";
+      return (std::fabs(track->dz((*pv)->position())) <= cut);
+    }
+
+    bool trkLongitudinalImpactParameter_cand(const Candidate& cand, const reco::VertexRef* pv, double cut) {
+      auto track = getTrack(cand);
+      if (track) {
+        return trkLongitudinalImpactParameter(track, pv, cut);
+      } else {
+        LogDebug("TauQCuts") << "<trkLongitudinalImpactParameter_cand>: dZ = N/A, cut = " << cut;
+        return false;
+      }
+    }
+
+    /// DZ cut, with respect to the current lead rack
+    bool trkLongitudinalImpactParameterWrtTrack(const Track* track,
+                                                const Track* leadTrack,
+                                                const reco::VertexRef* pv,
+                                                double cut) {
+      if (!leadTrack) {
+        edm::LogError("QCutsNoValidLeadTrack")
+            << "Lead track Ref in "
+            << "RecoTauQualityCuts is invalid. - trkLongitudinalImpactParameterWrtTrack";
+        return false;
+      }
+      return (std::fabs(track->dz((*pv)->position()) - leadTrack->dz((*pv)->position())) <= cut);
+    }
+
+    bool trkLongitudinalImpactParameterWrtTrack_cand(const Candidate& cand,
+                                                     const reco::Track* leadTrack,
+                                                     const reco::VertexRef* pv,
+                                                     double cut) {
+      auto track = getTrack(cand);
+      if (track)
+        return trkLongitudinalImpactParameterWrtTrack(track, leadTrack, pv, cut);
+      else
+        return false;
+    }
+
+    bool minTrackVertexWeight(const TrackBaseRef& track, const reco::VertexRef* pv, double cut) {
+      if (pv->isNull()) {
+        edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in "
+                                              << "RecoTauQualityCuts is invalid. - minTrackVertexWeight";
+        return false;
+      }
+      LogDebug("TauQCuts") << " track: Pt = " << track->pt() << ", eta = " << track->eta()
+                           << ", phi = " << track->phi();
+      LogDebug("TauQCuts") << " vertex: x = " << (*pv)->position().x() << ", y = " << (*pv)->position().y()
+                           << ", z = " << (*pv)->position().z();
+      LogDebug("TauQCuts") << "--> trackWeight = " << (*pv)->trackWeight(track) << " (cut = " << cut << ")";
+      return ((*pv)->trackWeight(track) >= cut);
+    }
+
+    bool minTrackVertexWeight(const TrackRef& track, const reco::VertexRef* pv, double cut) {
+      if (pv->isNull()) {
+        edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in "
+                                              << "RecoTauQualityCuts is invalid. - minTrackVertexWeight";
+        return false;
+      }
+      LogDebug("TauQCuts") << " track: Pt = " << track->pt() << ", eta = " << track->eta()
+                           << ", phi = " << track->phi();
+      LogDebug("TauQCuts") << " vertex: x = " << (*pv)->position().x() << ", y = " << (*pv)->position().y()
+                           << ", z = " << (*pv)->position().z();
+      LogDebug("TauQCuts") << "--> trackWeight = " << (*pv)->trackWeight(track) << " (cut = " << cut << ")";
+      return ((*pv)->trackWeight(track) >= cut);
+    }
+
+    bool minPackedCandVertexWeight(const pat::PackedCandidate& pCand, const reco::VertexRef* pv, double cut) {
+      if (pv->isNull()) {
+        edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in "
+                                              << "RecoTauQualityCuts is invalid. - minPackedCandVertexWeight";
+        return false;
+      }
+      //there is some low granular information on track weight in the vertex available with packed cands
+      double weight = -9.9;
+      if (pCand.vertexRef().isNonnull() && pCand.vertexRef().key() == pv->key()) {
+        int quality = pCand.pvAssociationQuality();
+        if (quality == pat::PackedCandidate::UsedInFitTight)
+          weight = 0.6;  //0.6 as proxy for weight above 0.5
+        else if (quality == pat::PackedCandidate::UsedInFitLoose)
+          weight = 0.1;  //0.6 as proxy for weight below 0.5
+      }
+      LogDebug("TauQCuts") << " packedCand: Pt = " << pCand.pt() << ", eta = " << pCand.eta()
+                           << ", phi = " << pCand.phi();
+      LogDebug("TauQCuts") << " vertex: x = " << (*pv)->position().x() << ", y = " << (*pv)->position().y()
+                           << ", z = " << (*pv)->position().z();
+      LogDebug("TauQCuts") << "--> trackWeight from packedCand = " << weight << " (cut = " << cut << ")";
+      return (weight >= cut);
+    }
+
+    bool minTrackVertexWeight_cand(const Candidate& cand, const reco::VertexRef* pv, double cut) {
+      auto track = getTrackRef(cand);
+      if (track.isNonnull()) {
+        return minTrackVertexWeight(track, pv, cut);
+      }
+      auto gsfTrack = getGsfTrackRef(cand);
+      if (gsfTrack.isNonnull()) {
+        return minTrackVertexWeight(gsfTrack, pv, cut);
+      }
+
+      const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+      if (pCand != nullptr && cand.charge() != 0) {
+        return minPackedCandVertexWeight(*pCand, pv, cut);
+      }
+      LogDebug("TauQCuts") << "<minTrackVertexWeight_cand>: weight = N/A, cut = " << cut;
+      return false;
+    }
+
+    bool trkChi2(const Track* track, double cut) {
+      LogDebug("TauQCuts") << "<trkChi2>: chi^2 = " << track->normalizedChi2() << ", cut = " << cut;
+      return (track->normalizedChi2() <= cut);
+    }
+
+    bool trkChi2_cand(const Candidate& cand, double cut) {
+      auto track = getTrack(cand);
+      if (track) {
+        LogDebug("TauQCuts") << "<trkChi2_cand>: chi^2 = " << track->normalizedChi2() << ", cut = " << cut;
+        return trkChi2(track, cut);
+      } else {
+        LogDebug("TauQCuts") << "<trkChi2_cand>: chi^2 = N/A, cut = " << cut;
+        return false;
+      }
+    }
+
+    // And a set of qcuts
+    bool AND(const TrackBaseRef& track, const RecoTauQualityCuts::TrackQCutFuncCollection& cuts) {
+      for (auto const& func : cuts) {
+        if (!func(track))
+          return false;
+      }
+      return true;
+    }
+
+    bool AND_cand(const Candidate& cand, const RecoTauQualityCuts::CandQCutFuncCollection& cuts) {
+      for (auto const& func : cuts) {
+        if (!func(cand))
+          return false;
+      }
+      return true;
+    }
+
+    // Get the set of Q cuts for a given type (i.e. gamma)
+    bool mapAndCutByType(const Candidate& cand, const RecoTauQualityCuts::CandQCutFuncMap& funcMap) {
+      // Find the cuts that for this particle type
+      RecoTauQualityCuts::CandQCutFuncMap::const_iterator cuts = funcMap.find(std::abs(cand.pdgId()));
+      // Return false if we dont' know how to deal with this particle type
+      if (cuts == funcMap.end())
+        return false;
+      return AND_cand(cand, cuts->second);  // Otherwise AND all the cuts
+    }
+
+  }  // namespace qcuts
+
+  RecoTauQualityCuts::RecoTauQualityCuts(const edm::ParameterSet& qcuts) {
+    // Setup all of our predicates
+    CandQCutFuncCollection chargedHadronCuts;
+    CandQCutFuncCollection gammaCuts;
+    CandQCutFuncCollection neutralHadronCuts;
+
+    // Make sure there are no extra passed options
+    std::set<std::string> passedOptionSet;
+    std::vector<std::string> passedOptions = qcuts.getParameterNames();
+
+    for (auto const& option : passedOptions) {
+      passedOptionSet.insert(option);
+    }
+
+    unsigned int nCuts = 0;
+    auto getDouble = [&qcuts, &passedOptionSet, &nCuts](const std::string& name) {
+      if (qcuts.exists(name)) {
+        ++nCuts;
+        passedOptionSet.erase(name);
+        return qcuts.getParameter<double>(name);
+      }
+      return -1.0;
+    };
+    auto getUint = [&qcuts, &passedOptionSet, &nCuts](const std::string& name) -> unsigned int {
+      if (qcuts.exists(name)) {
+        ++nCuts;
+        passedOptionSet.erase(name);
+        return qcuts.getParameter<unsigned int>(name);
+      }
+      return 0;
+    };
+
+    // Build all the QCuts for tracks
+    minTrackPt_ = getDouble("minTrackPt");
+    maxTrackChi2_ = getDouble("maxTrackChi2");
+    minTrackPixelHits_ = getUint("minTrackPixelHits");
+    minTrackHits_ = getUint("minTrackHits");
+    maxTransverseImpactParameter_ = getDouble("maxTransverseImpactParameter");
+    maxDeltaZ_ = getDouble("maxDeltaZ");
+    maxDeltaZToLeadTrack_ = getDouble("maxDeltaZToLeadTrack");
+    // Require tracks to contribute a minimum weight to the associated vertex.
+    minTrackVertexWeight_ = getDouble("minTrackVertexWeight");
+
+    // Use bit-wise & to avoid conditional code
+    checkHitPattern_ = (minTrackHits_ > 0) || (minTrackPixelHits_ > 0);
+    checkPV_ = (maxTransverseImpactParameter_ >= 0) || (maxDeltaZ_ >= 0) || (maxDeltaZToLeadTrack_ >= 0) ||
+               (minTrackVertexWeight_ >= 0);
+
+    // Build the QCuts for gammas
+    minGammaEt_ = getDouble("minGammaEt");
+
+    // Build QCuts for netural hadrons
+    minNeutralHadronEt_ = getDouble("minNeutralHadronEt");
+
+    // Check if there are any remaining unparsed QCuts
+    if (!passedOptionSet.empty()) {
+      std::string unParsedOptions;
+      bool thereIsABadParameter = false;
+      for (auto const& option : passedOptionSet) {
+        // Workaround for HLT - TODO FIXME
+        if (option == "useTracksInsteadOfPFHadrons") {
+          // Crash if true - no one should have this option enabled.
+          if (qcuts.getParameter<bool>("useTracksInsteadOfPFHadrons")) {
+            throw cms::Exception("DontUseTracksInQcuts") << "The obsolete exception useTracksInsteadOfPFHadrons "
+                                                         << "is set to true in the quality cut config." << std::endl;
+          }
+          continue;
         }
-        continue;
+
+        // If we get to this point, there is a real unknown parameter
+        thereIsABadParameter = true;
+
+        unParsedOptions += option;
+        unParsedOptions += "\n";
       }
-      
-      // If we get to this point, there is a real unknown parameter
-      thereIsABadParameter = true;
-      
-      unParsedOptions += option;
-      unParsedOptions += "\n";
+      if (thereIsABadParameter) {
+        throw cms::Exception("BadQualityCutConfig") << " The PSet passed to the RecoTauQualityCuts class had"
+                                                    << " the following unrecognized options: " << std::endl
+                                                    << unParsedOptions;
+      }
     }
-    if ( thereIsABadParameter ) {
-      throw cms::Exception("BadQualityCutConfig")
-        << " The PSet passed to the RecoTauQualityCuts class had"
-        << " the following unrecognized options: " << std::endl
-        << unParsedOptions;
+
+    // Make sure there are at least some quality cuts
+    if (!nCuts) {
+      throw cms::Exception("BadQualityCutConfig") << " No options were passed to the quality cut class!" << std::endl;
     }
   }
 
-  // Make sure there are at least some quality cuts
-  if ( !nCuts ) {
-    throw cms::Exception("BadQualityCutConfig")
-      << " No options were passed to the quality cut class!" << std::endl;
+  std::pair<edm::ParameterSet, edm::ParameterSet> factorizePUQCuts(const edm::ParameterSet& input) {
+    edm::ParameterSet puCuts;
+    edm::ParameterSet nonPUCuts;
+
+    std::vector<std::string> inputNames = input.getParameterNames();
+    for (auto const& cut : inputNames) {
+      if (cut == "minTrackVertexWeight" || cut == "maxDeltaZ" || cut == "maxDeltaZToLeadTrack") {
+        puCuts.copyFrom(input, cut);
+      } else {
+        nonPUCuts.copyFrom(input, cut);
+      }
+    }
+    return std::make_pair(puCuts, nonPUCuts);
   }
-}
 
-std::pair<edm::ParameterSet, edm::ParameterSet> factorizePUQCuts(const edm::ParameterSet& input) 
-{
-  edm::ParameterSet puCuts;
-  edm::ParameterSet nonPUCuts;
+  bool RecoTauQualityCuts::filterTrack(const reco::TrackBaseRef& track) const {
+    if (!filterTrack_(track.get()))
+      return false;
+    if (minTrackVertexWeight_ >= 0. && !(pv_->trackWeight(convertRef(track)) >= minTrackVertexWeight_))
+      return false;
+    return true;
+  }
 
-  std::vector<std::string> inputNames = input.getParameterNames();
-  for(auto const& cut : inputNames ) {
-    if ( cut == "minTrackVertexWeight" || 
-	 cut == "maxDeltaZ"            ||
-	 cut == "maxDeltaZToLeadTrack" ) {
-      puCuts.copyFrom(input, cut);
+  bool RecoTauQualityCuts::filterTrack(const reco::TrackRef& track) const {
+    if (!filterTrack_(track.get()))
+      return false;
+    if (minTrackVertexWeight_ >= 0. && !(pv_->trackWeight(convertRef(track)) >= minTrackVertexWeight_))
+      return false;
+    return true;
+  }
+
+  bool RecoTauQualityCuts::filterTrack(const reco::Track& track) const { return filterTrack_(&track); }
+
+  bool RecoTauQualityCuts::filterTrack_(const reco::Track* track) const {
+    if (minTrackPt_ >= 0 && !(track->pt() > minTrackPt_))
+      return false;
+    if (maxTrackChi2_ >= 0 && !(track->normalizedChi2() <= maxTrackChi2_))
+      return false;
+    if (checkHitPattern_) {
+      const reco::HitPattern& hitPattern = track->hitPattern();
+      if (minTrackPixelHits_ > 0 && !(hitPattern.numberOfValidPixelHits() >= minTrackPixelHits_))
+        return false;
+      if (minTrackHits_ > 0 && !(hitPattern.numberOfValidHits() >= minTrackHits_))
+        return false;
+    }
+    if (checkPV_ && pv_.isNull()) {
+      edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in "
+                                            << "RecoTauQualityCuts is invalid. - filterTrack";
+      return false;
+    }
+
+    if (maxTransverseImpactParameter_ >= 0 &&
+        !(std::fabs(track->dxy(pv_->position())) <= maxTransverseImpactParameter_))
+      return false;
+    if (maxDeltaZ_ >= 0 && !(std::fabs(track->dz(pv_->position())) <= maxDeltaZ_))
+      return false;
+    if (maxDeltaZToLeadTrack_ >= 0) {
+      if (!leadTrack_) {
+        edm::LogError("QCutsNoValidLeadTrack") << "Lead track Ref in "
+                                               << "RecoTauQualityCuts is invalid. - filterTrack";
+        return false;
+      }
+
+      if (!(std::fabs(track->dz(pv_->position()) - leadTrack_->dz(pv_->position())) <= maxDeltaZToLeadTrack_))
+        return false;
+    }
+
+    return true;
+  }
+
+  bool RecoTauQualityCuts::filterChargedCand(const reco::Candidate& cand) const {
+    if (cand.charge() == 0)
+      return true;
+    const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+    if (pCand == nullptr)
+      return true;
+
+    //Get track, it should be present for cands with pT(charged)>0.5GeV
+    //and check track quality critera other than vertex weight
+    auto track = getTrack(cand);
+    if (track != nullptr) {
+      if (!filterTrack(*track))
+        return false;
+    } else {  //Candidates without track (pT(charged)<0.5GeV): Can still check pT and calculate dxy and dz
+      if (minTrackPt_ >= 0 && !(pCand->pt() > minTrackPt_))
+        return false;
+      if (checkPV_ && pv_.isNull()) {
+        edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in "
+                                              << "RecoTauQualityCuts is invalid. - filterChargedCand";
+        return false;
+      }
+
+      if (maxTransverseImpactParameter_ >= 0 &&
+          !(std::fabs(pCand->dxy(pv_->position())) <= maxTransverseImpactParameter_))
+        return false;
+      if (maxDeltaZ_ >= 0 && !(std::fabs(pCand->dz(pv_->position())) <= maxDeltaZ_))
+        return false;
+      if (maxDeltaZToLeadTrack_ >= 0) {
+        if (leadTrack_ == nullptr) {
+          edm::LogError("QCutsNoValidLeadTrack") << "Lead track Ref in "
+                                                 << "RecoTauQualityCuts is invalid. - filterChargedCand";
+          return false;
+        }
+
+        if (!(std::fabs(pCand->dz(pv_->position()) - leadTrack_->dz(pv_->position())) <= maxDeltaZToLeadTrack_))
+          return false;
+      }
+    }
+    if (minTrackVertexWeight_ >= 0. && !(qcuts::minPackedCandVertexWeight(*pCand, &pv_, minTrackVertexWeight_)))
+      return false;
+
+    return true;
+  }
+
+  bool RecoTauQualityCuts::filterGammaCand(const reco::Candidate& cand) const {
+    if (minGammaEt_ >= 0 && !(cand.et() > minGammaEt_))
+      return false;
+    return true;
+  }
+
+  bool RecoTauQualityCuts::filterNeutralHadronCand(const reco::Candidate& cand) const {
+    if (minNeutralHadronEt_ >= 0 && !(cand.et() > minNeutralHadronEt_))
+      return false;
+    return true;
+  }
+
+  bool RecoTauQualityCuts::filterCandByType(const reco::Candidate& cand) const {
+    switch (std::abs(cand.pdgId())) {
+      case 22:
+        return filterGammaCand(cand);
+      case 130:
+        return filterNeutralHadronCand(cand);
+      // We use the same qcuts for muons/electrons and charged hadrons.
+      case 211:
+      case 11:
+      case 13:
+        // no cuts ATM (track cuts applied in filterCand)
+        return true;
+      // Return false if we dont' know how to deal with this particle type
+      default:
+        return false;
+    };
+    return false;
+  }
+
+  bool RecoTauQualityCuts::filterCand(const reco::Candidate& cand) const {
+    auto trackRef = getTrackRef(cand);
+    bool result = true;
+
+    if (trackRef.isNonnull()) {
+      result = filterTrack(trackRef);
     } else {
-      nonPUCuts.copyFrom(input, cut);
-    }
-  }
-  return std::make_pair(puCuts, nonPUCuts);
-}
-
-bool RecoTauQualityCuts::filterTrack(const reco::TrackBaseRef& track) const
-{
-  if (!filterTrack_(track.get()))
-    return false;
-  if(minTrackVertexWeight_ >= 0. && !(pv_->trackWeight(convertRef(track)) >= minTrackVertexWeight_)) return false;
-  return true;
-}
-
-bool RecoTauQualityCuts::filterTrack(const reco::TrackRef& track) const
-{
-  if (!filterTrack_(track.get()))
-    return false;
-  if(minTrackVertexWeight_ >= 0. && !(pv_->trackWeight(convertRef(track)) >= minTrackVertexWeight_)) return false;
-  return true;
-}
-
-bool RecoTauQualityCuts::filterTrack(const reco::Track& track) const
-{
-  return filterTrack_(&track);
-}
-
-bool RecoTauQualityCuts::filterTrack_(const reco::Track* track) const
-{
-  if(minTrackPt_ >= 0 && !(track->pt() > minTrackPt_)) return false;
-  if(maxTrackChi2_ >= 0 && !(track->normalizedChi2() <= maxTrackChi2_)) return false;
-  if(checkHitPattern_) {
-    const reco::HitPattern &hitPattern = track->hitPattern();
-    if(minTrackPixelHits_ > 0 && !(hitPattern.numberOfValidPixelHits() >= minTrackPixelHits_)) return false;
-    if(minTrackHits_ > 0 && !(hitPattern.numberOfValidHits() >= minTrackHits_)) return false;
-  }
-  if(checkPV_ && pv_.isNull()) {
-    edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in " <<
-      "RecoTauQualityCuts is invalid. - filterTrack";
-    return false;
-  }
-
-  if(maxTransverseImpactParameter_ >= 0 &&
-     !(std::fabs(track->dxy(pv_->position())) <= maxTransverseImpactParameter_))
-      return false;
-  if(maxDeltaZ_ >= 0 && !(std::fabs(track->dz(pv_->position())) <= maxDeltaZ_)) return false;
-  if(maxDeltaZToLeadTrack_ >= 0) {
-    if ( !leadTrack_) {
-      edm::LogError("QCutsNoValidLeadTrack") << "Lead track Ref in " <<
-        "RecoTauQualityCuts is invalid. - filterTrack";
-      return false;
-    }
-
-    if(!(std::fabs(track->dz(pv_->position()) - leadTrack_->dz(pv_->position())) <= maxDeltaZToLeadTrack_))
-      return false;
-  }
-
-  return true;
-}
-
-bool RecoTauQualityCuts::filterChargedCand(const reco::Candidate& cand) const {
-
-  if (cand.charge() == 0)
-    return true;
-  const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
-  if (pCand == nullptr)
-    return true;
-
-  //Get track, it should be present for cands with pT(charged)>0.5GeV
-  //and check track quality critera other than vertex weight
-  auto track = getTrack(cand);
-  if (track != nullptr){
-    if (!filterTrack(*track))
-      return false;
-  } else {//Candidates without track (pT(charged)<0.5GeV): Can still check pT and calculate dxy and dz
-    if(minTrackPt_ >= 0 && !(pCand->pt() > minTrackPt_)) return false;
-    if(checkPV_ && pv_.isNull()) {
-      edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in " <<
-	"RecoTauQualityCuts is invalid. - filterChargedCand";
-      return false;
-    }
-
-    if(maxTransverseImpactParameter_ >= 0 &&
-       !(std::fabs(pCand->dxy(pv_->position())) <= maxTransverseImpactParameter_))
-      return false;
-    if(maxDeltaZ_ >= 0 && !(std::fabs(pCand->dz(pv_->position())) <= maxDeltaZ_)) return false;
-    if(maxDeltaZToLeadTrack_ >= 0) {
-      if ( leadTrack_ == nullptr) {
-	edm::LogError("QCutsNoValidLeadTrack") << "Lead track Ref in " <<
-	  "RecoTauQualityCuts is invalid. - filterChargedCand";
-	return false;
+      auto gsfTrackRef = getGsfTrackRef(cand);
+      if (gsfTrackRef.isNonnull())
+        result = filterTrack(gsfTrackRef);
+      else if (cand.charge() != 0) {
+        result = filterChargedCand(cand);
       }
+    }
 
-      if(!(std::fabs(pCand->dz(pv_->position()) - leadTrack_->dz(pv_->position())) <= maxDeltaZToLeadTrack_))
-	return false;
+    if (result)
+      result = filterCandByType(cand);
+
+    return result;
+  }
+
+  void RecoTauQualityCuts::setLeadTrack(const reco::Track& leadTrack) const { leadTrack_ = &leadTrack; }
+
+  void RecoTauQualityCuts::setLeadTrack(const reco::Candidate& leadCand) const { leadTrack_ = getTrack(leadCand); }
+
+  void RecoTauQualityCuts::setLeadTrack(const reco::CandidateRef& leadCand) const {
+    if (leadCand.isNonnull()) {
+      leadTrack_ = getTrack(*leadCand);
+    } else {
+      // Set null
+      leadTrack_ = nullptr;
     }
   }
-  if(minTrackVertexWeight_ >= 0. &&
-     !(qcuts::minPackedCandVertexWeight(*pCand, &pv_,  minTrackVertexWeight_)))
-     return false;
 
-  return true;
-}
-
-bool RecoTauQualityCuts::filterGammaCand(const reco::Candidate& cand) const {
-  if(minGammaEt_ >= 0 && !(cand.et() > minGammaEt_)) return false;
-  return true;
-}
-
-bool RecoTauQualityCuts::filterNeutralHadronCand(const reco::Candidate& cand) const {
-  if(minNeutralHadronEt_ >= 0 && !(cand.et() > minNeutralHadronEt_)) return false;
-  return true;
-}
-
-bool RecoTauQualityCuts::filterCandByType(const reco::Candidate& cand) const {
-  switch(std::abs(cand.pdgId())) {
-  case 22:
-    return filterGammaCand(cand);
-  case 130:
-    return filterNeutralHadronCand(cand);
-  // We use the same qcuts for muons/electrons and charged hadrons.
-  case 211:
-  case 11:
-  case 13:
-    // no cuts ATM (track cuts applied in filterCand)
-    return true;
-  // Return false if we dont' know how to deal with this particle type
-  default:
-    return false;
-  };
-  return false;
-}
-
-bool RecoTauQualityCuts::filterCand(const reco::Candidate& cand) const 
-{
-  auto trackRef = getTrackRef(cand);
-  bool result = true;
-
-  if (trackRef.isNonnull()) {
-    result = filterTrack(trackRef);
-  } 
-  else {
-    auto gsfTrackRef = getGsfTrackRef(cand);
-    if (gsfTrackRef.isNonnull())
-      result = filterTrack(gsfTrackRef);
-    else if (cand.charge() != 0) {
-      result = filterChargedCand(cand);
-    }
-  }
-  
-  if(result)
-    result = filterCandByType(cand);
-
-  return result;
-}
-
-void RecoTauQualityCuts::setLeadTrack(const reco::Track& leadTrack) const 
-{
-  leadTrack_ = &leadTrack;
-}
-
-void RecoTauQualityCuts::setLeadTrack(const reco::Candidate& leadCand) const 
-{
-  leadTrack_ = getTrack(leadCand);
-}
-
-void RecoTauQualityCuts::setLeadTrack(const reco::CandidateRef& leadCand) const 
-{
-  if ( leadCand.isNonnull() ) {
-    leadTrack_ = getTrack(*leadCand);
-  } else {
-    // Set null
-    leadTrack_ = nullptr;
-  }
-}
-
-} // end namespace reco::tau
+}  // end namespace reco::tau

--- a/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
@@ -12,413 +12,430 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-namespace {
-  inline const reco::Track* getTrack(const Candidate& cand)
-  {
-    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
-    if (pfCandPtr != nullptr) {
-      if      ( pfCandPtr->trackRef().isNonnull()    ) return pfCandPtr->trackRef().get();
-      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return pfCandPtr->gsfTrackRef().get();
-      else return nullptr;
-    }
-    const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
-    if (packedCand != nullptr && packedCand->hasTrackDetails())
-    	return &packedCand->pseudoTrack();
+    namespace {
+      inline const reco::Track* getTrack(const Candidate& cand) {
+        const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+        if (pfCandPtr != nullptr) {
+          if (pfCandPtr->trackRef().isNonnull())
+            return pfCandPtr->trackRef().get();
+          else if (pfCandPtr->gsfTrackRef().isNonnull())
+            return pfCandPtr->gsfTrackRef().get();
+          else
+            return nullptr;
+        }
+        const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+        if (packedCand != nullptr && packedCand->hasTrackDetails())
+          return &packedCand->pseudoTrack();
 
-   return nullptr;
-  }
+        return nullptr;
+      }
 
-  inline const reco::TrackBaseRef getTrackRef(const Candidate& cand)
-  {
-    // TauReco@MiniAOD: This version does not work on top of MiniAOD, however,
-    // it is only used for non-default track-vertex associations
-    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
-    if (pfCandPtr != nullptr) {
-      if      ( pfCandPtr->trackRef().isNonnull()    ) return reco::TrackBaseRef(pfCandPtr->trackRef());
-      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
-      else return reco::TrackBaseRef();
-    }
-    
-    return reco::TrackBaseRef();
-  }
-}
+      inline const reco::TrackBaseRef getTrackRef(const Candidate& cand) {
+        // TauReco@MiniAOD: This version does not work on top of MiniAOD, however,
+        // it is only used for non-default track-vertex associations
+        const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+        if (pfCandPtr != nullptr) {
+          if (pfCandPtr->trackRef().isNonnull())
+            return reco::TrackBaseRef(pfCandPtr->trackRef());
+          else if (pfCandPtr->gsfTrackRef().isNonnull())
+            return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
+          else
+            return reco::TrackBaseRef();
+        }
 
-// Get the highest pt track in a jet.
-// Get the KF track if it exists.  Otherwise, see if it has a GSF track.
-const reco::CandidatePtr RecoTauVertexAssociator::getLeadCand(const Jet& jet) const
-{
-  std::vector<CandidatePtr> chargedPFCands = pfChargedCands(jet, true);
-  if ( verbosity_ >= 1 ) {
-    std::cout << "<RecoTauVertexAssociator::getLeadTrack>:" << std::endl;
-    std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << std::endl;
-    std::cout << " num. chargedPFCands = " << chargedPFCands.size() << std::endl;
-    std::cout << " vxTrkFiltering = " << vxTrkFiltering_ << std::endl;
-  }
+        return reco::TrackBaseRef();
+      }
+    }  // namespace
 
-  if ( chargedPFCands.empty() ) {
-    return reco::CandidatePtr(nullptr, 0);
-  }
-  
-  std::vector<CandidatePtr> selectedPFCands;
-  if ( vxTrkFiltering_ ) {
-    selectedPFCands = qcuts_->filterCandRefs(chargedPFCands);
-  } else { 
-    selectedPFCands = chargedPFCands;
-  }
-  if ( verbosity_ >= 1 ) {
-    std::cout << " num. selectedPFCands = " << selectedPFCands.size() << std::endl;
-  }
-  
-  CandidatePtr leadCand;
-  if ( !selectedPFCands.empty() ) {
-    double leadTrackPt = 0.;
-    if ( leadingTrkOrPFCandOption_ == kFirstTrack){ leadCand=selectedPFCands[0];}
-    else {
-      for ( std::vector<CandidatePtr>::const_iterator pfCand = selectedPFCands.begin();
-	    pfCand != selectedPFCands.end(); ++pfCand ) {
-        const reco::Track* track = getTrack(**pfCand);
-        double actualTrackPt = 0. , actualTrackPtError = 0.;
-        if ( track != nullptr ) {
-          actualTrackPt = track->pt();
-          actualTrackPtError = track->ptError();
-	}
-        double trackPt = 0.;
-        if ( leadingTrkOrPFCandOption_ == kLeadTrack ) {
-	  trackPt = actualTrackPt - 2.*actualTrackPtError;
-        } else if ( leadingTrkOrPFCandOption_ == kLeadPFCand ) {
-	  trackPt = (*pfCand)->pt();
-        } else if ( leadingTrkOrPFCandOption_ == kMinLeadTrackOrPFCand ) {
-	  trackPt = std::min(actualTrackPt, (double)(*pfCand)->pt());
-	} else assert(0);
-        if ( trackPt > leadTrackPt ) {
-          leadCand = (*pfCand);
-	  leadTrackPt = trackPt;
+    // Get the highest pt track in a jet.
+    // Get the KF track if it exists.  Otherwise, see if it has a GSF track.
+    const reco::CandidatePtr RecoTauVertexAssociator::getLeadCand(const Jet& jet) const {
+      std::vector<CandidatePtr> chargedPFCands = pfChargedCands(jet, true);
+      if (verbosity_ >= 1) {
+        std::cout << "<RecoTauVertexAssociator::getLeadTrack>:" << std::endl;
+        std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << std::endl;
+        std::cout << " num. chargedPFCands = " << chargedPFCands.size() << std::endl;
+        std::cout << " vxTrkFiltering = " << vxTrkFiltering_ << std::endl;
+      }
+
+      if (chargedPFCands.empty()) {
+        return reco::CandidatePtr(nullptr, 0);
+      }
+
+      std::vector<CandidatePtr> selectedPFCands;
+      if (vxTrkFiltering_) {
+        selectedPFCands = qcuts_->filterCandRefs(chargedPFCands);
+      } else {
+        selectedPFCands = chargedPFCands;
+      }
+      if (verbosity_ >= 1) {
+        std::cout << " num. selectedPFCands = " << selectedPFCands.size() << std::endl;
+      }
+
+      CandidatePtr leadCand;
+      if (!selectedPFCands.empty()) {
+        double leadTrackPt = 0.;
+        if (leadingTrkOrPFCandOption_ == kFirstTrack) {
+          leadCand = selectedPFCands[0];
+        } else {
+          for (std::vector<CandidatePtr>::const_iterator pfCand = selectedPFCands.begin();
+               pfCand != selectedPFCands.end();
+               ++pfCand) {
+            const reco::Track* track = getTrack(**pfCand);
+            double actualTrackPt = 0., actualTrackPtError = 0.;
+            if (track != nullptr) {
+              actualTrackPt = track->pt();
+              actualTrackPtError = track->ptError();
+            }
+            double trackPt = 0.;
+            if (leadingTrkOrPFCandOption_ == kLeadTrack) {
+              trackPt = actualTrackPt - 2. * actualTrackPtError;
+            } else if (leadingTrkOrPFCandOption_ == kLeadPFCand) {
+              trackPt = (*pfCand)->pt();
+            } else if (leadingTrkOrPFCandOption_ == kMinLeadTrackOrPFCand) {
+              trackPt = std::min(actualTrackPt, (double)(*pfCand)->pt());
+            } else
+              assert(0);
+            if (trackPt > leadTrackPt) {
+              leadCand = (*pfCand);
+              leadTrackPt = trackPt;
+            }
+          }
         }
       }
+      if (leadCand.isNull()) {
+        if (recoverLeadingTrk_) {
+          leadCand = chargedPFCands[0];
+        } else {
+          return reco::CandidatePtr(nullptr, 0);
+        }
+      }
+      if (verbosity_ >= 1) {
+        std::cout << "leadCand: Pt = " << leadCand->pt() << ", eta = " << leadCand->eta()
+                  << ", phi = " << leadCand->phi() << std::endl;
+      }
+      return leadCand;
     }
-  }
-  if ( leadCand.isNull() ) {
-    if ( recoverLeadingTrk_ ) {
-      leadCand = chargedPFCands[0];
-    } else {
-      return reco::CandidatePtr(nullptr, 0);
-    } 
-  }
-  if ( verbosity_ >= 1 ) {
-    std::cout << "leadCand: Pt = " << leadCand->pt() << ", eta = " << leadCand->eta() << ", phi = " << leadCand->phi() << std::endl;
-  }
-  return leadCand;
-}
 
-const reco::Track* RecoTauVertexAssociator::getLeadTrack(const Jet& jet) const {
-  auto leadCand = getLeadCand(jet);
-  if(leadCand.isNull()) return nullptr;
-  const reco::Track* track = getTrack(*leadCand);
-  return track;
-}
-
-const reco::TrackBaseRef RecoTauVertexAssociator::getLeadTrackRef(const Jet& jet) const {
-  auto leadCand = getLeadCand(jet);
-  if(leadCand.isNull()) return reco::TrackBaseRef();
-  return getTrackRef(*leadCand);
-}
-
-namespace {
-  // Define functors which extract the relevant information from a collection of
-  // vertices.
-  double dzToTrack(const reco::VertexRef& vtx, const reco::Track* trk)
-  {
-    if ( !trk || !vtx ) {
-      return std::numeric_limits<double>::infinity();
+    const reco::Track* RecoTauVertexAssociator::getLeadTrack(const Jet& jet) const {
+      auto leadCand = getLeadCand(jet);
+      if (leadCand.isNull())
+        return nullptr;
+      const reco::Track* track = getTrack(*leadCand);
+      return track;
     }
-    return std::abs(trk->dz(vtx->position()));
-  }
-  
-  double trackWeightInVertex(const reco::VertexRef& vtx, const reco::TrackBaseRef& trk)
-  {
-    if ( !trk || !vtx ) {
-      return 0.0;
+
+    const reco::TrackBaseRef RecoTauVertexAssociator::getLeadTrackRef(const Jet& jet) const {
+      auto leadCand = getLeadCand(jet);
+      if (leadCand.isNull())
+        return reco::TrackBaseRef();
+      return getTrackRef(*leadCand);
     }
-    return vtx->trackWeight(trk);
-  }
-}
 
-RecoTauVertexAssociator::RecoTauVertexAssociator(const edm::ParameterSet& pset, edm::ConsumesCollector && iC)
-  : vertexSelector_(nullptr),
-    qcuts_(nullptr),
-    jetToVertexAssociation_(nullptr),
-    lastEvent_(0)
-{
-  //std::cout << "<RecoTauVertexAssociator::RecoTauVertexAssociator>:" << std::endl;
+    namespace {
+      // Define functors which extract the relevant information from a collection of
+      // vertices.
+      double dzToTrack(const reco::VertexRef& vtx, const reco::Track* trk) {
+        if (!trk || !vtx) {
+          return std::numeric_limits<double>::infinity();
+        }
+        return std::abs(trk->dz(vtx->position()));
+      }
 
-  vertexTag_ = edm::InputTag("offlinePrimaryVertices", "");
-  algorithm_ = "highestPtInEvent";
-  // Sanity check, will remove once HLT module configs are updated.
-  if ( !pset.exists("primaryVertexSrc") || !pset.exists("pvFindingAlgo") ) {
-    edm::LogWarning("NoVertexFindingMethodSpecified")
-      << "The PSet passed to the RecoTauVertexAssociator was incorrectly configured."
-      << " The vertex will be taken as the highest Pt vertex from the 'offlinePrimaryVertices' collection."
-      << std::endl;
-  } else {
-    vertexTag_ = pset.getParameter<edm::InputTag>("primaryVertexSrc");
-    algorithm_ = pset.getParameter<std::string>("pvFindingAlgo");
-  }
-    
-  if ( pset.exists("vxAssocQualityCuts") ) {
-    //std::cout << " reading 'vxAssocQualityCuts'" << std::endl;
-    qcuts_ = new RecoTauQualityCuts(pset.getParameterSet("vxAssocQualityCuts"));
-  } else {
-    //std::cout << " reading 'signalQualityCuts'" << std::endl;
-    qcuts_ = new RecoTauQualityCuts(pset.getParameterSet("signalQualityCuts"));
-  }
-  assert(qcuts_);
+      double trackWeightInVertex(const reco::VertexRef& vtx, const reco::TrackBaseRef& trk) {
+        if (!trk || !vtx) {
+          return 0.0;
+        }
+        return vtx->trackWeight(trk);
+      }
+    }  // namespace
 
-  vxTrkFiltering_ = false;
-  if ( !pset.exists("vertexTrackFiltering") && pset.exists("vxAssocQualityCuts") ) {
-    edm::LogWarning("NoVertexTrackFilteringSpecified")
-      << "The PSet passed to the RecoTauVertexAssociator was incorrectly configured." 
-      << " Please define vertexTrackFiltering in config file." 
-      << " No filtering of tracks to vertices will be applied."
-      << std::endl;
-  } else {
-    vxTrkFiltering_ = pset.exists("vertexTrackFiltering") ? 
-      pset.getParameter<bool>("vertexTrackFiltering") : false;
-  }
-  if ( pset.exists("vertexSelection") ) {
-    std::string vertexSelection = pset.getParameter<std::string>("vertexSelection");
-    if ( !vertexSelection.empty() ) {
-      vertexSelector_ = new StringCutObjectSelector<reco::Vertex>(vertexSelection);
+    RecoTauVertexAssociator::RecoTauVertexAssociator(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+        : vertexSelector_(nullptr), qcuts_(nullptr), jetToVertexAssociation_(nullptr), lastEvent_(0) {
+      //std::cout << "<RecoTauVertexAssociator::RecoTauVertexAssociator>:" << std::endl;
+
+      vertexTag_ = edm::InputTag("offlinePrimaryVertices", "");
+      algorithm_ = "highestPtInEvent";
+      // Sanity check, will remove once HLT module configs are updated.
+      if (!pset.exists("primaryVertexSrc") || !pset.exists("pvFindingAlgo")) {
+        edm::LogWarning("NoVertexFindingMethodSpecified")
+            << "The PSet passed to the RecoTauVertexAssociator was incorrectly configured."
+            << " The vertex will be taken as the highest Pt vertex from the 'offlinePrimaryVertices' collection."
+            << std::endl;
+      } else {
+        vertexTag_ = pset.getParameter<edm::InputTag>("primaryVertexSrc");
+        algorithm_ = pset.getParameter<std::string>("pvFindingAlgo");
+      }
+
+      if (pset.exists("vxAssocQualityCuts")) {
+        //std::cout << " reading 'vxAssocQualityCuts'" << std::endl;
+        qcuts_ = new RecoTauQualityCuts(pset.getParameterSet("vxAssocQualityCuts"));
+      } else {
+        //std::cout << " reading 'signalQualityCuts'" << std::endl;
+        qcuts_ = new RecoTauQualityCuts(pset.getParameterSet("signalQualityCuts"));
+      }
+      assert(qcuts_);
+
+      vxTrkFiltering_ = false;
+      if (!pset.exists("vertexTrackFiltering") && pset.exists("vxAssocQualityCuts")) {
+        edm::LogWarning("NoVertexTrackFilteringSpecified")
+            << "The PSet passed to the RecoTauVertexAssociator was incorrectly configured."
+            << " Please define vertexTrackFiltering in config file."
+            << " No filtering of tracks to vertices will be applied." << std::endl;
+      } else {
+        vxTrkFiltering_ = pset.exists("vertexTrackFiltering") ? pset.getParameter<bool>("vertexTrackFiltering") : false;
+      }
+      if (pset.exists("vertexSelection")) {
+        std::string vertexSelection = pset.getParameter<std::string>("vertexSelection");
+        if (!vertexSelection.empty()) {
+          vertexSelector_ = new StringCutObjectSelector<reco::Vertex>(vertexSelection);
+        }
+      }
+
+      if (algorithm_ == "highestPtInEvent") {
+        algo_ = kHighestPtInEvent;
+      } else if (algorithm_ == "closestInDeltaZ") {
+        algo_ = kClosestDeltaZ;
+      } else if (algorithm_ == "highestWeightForLeadTrack") {
+        algo_ = kHighestWeigtForLeadTrack;
+      } else if (algorithm_ == "combined") {
+        algo_ = kCombined;
+      } else {
+        throw cms::Exception("BadVertexAssociatorConfig")
+            << "Invalid Configuration parameter 'algorithm' " << algorithm_ << "."
+            << " Valid options are: 'highestPtInEvent', 'closestInDeltaZ', 'highestWeightForLeadTrack' and "
+               "'combined'.\n";
+      }
+
+      vxToken_ = iC.consumes<reco::VertexCollection>(vertexTag_);
+
+      recoverLeadingTrk_ = pset.exists("recoverLeadingTrk") ? pset.getParameter<bool>("recoverLeadingTrk") : false;
+
+      std::string leadingTrkOrPFCandOption_string = pset.exists("leadingTrkOrPFCandOption")
+                                                        ? pset.getParameter<std::string>("leadingTrkOrPFCandOption")
+                                                        : "firstTrack";
+      if (leadingTrkOrPFCandOption_string == "leadTrack")
+        leadingTrkOrPFCandOption_ = kLeadTrack;
+      else if (leadingTrkOrPFCandOption_string == "leadPFCand")
+        leadingTrkOrPFCandOption_ = kLeadPFCand;
+      else if (leadingTrkOrPFCandOption_string == "minLeadTrackOrPFCand")
+        leadingTrkOrPFCandOption_ = kMinLeadTrackOrPFCand;
+      else if (leadingTrkOrPFCandOption_string == "firstTrack")
+        leadingTrkOrPFCandOption_ = kFirstTrack;
+      else
+        throw cms::Exception("BadVertexAssociatorConfig")
+            << "Invalid Configuration parameter 'leadingTrkOrPFCandOption' " << leadingTrkOrPFCandOption_string << "."
+            << " Valid options are: 'leadTrack', 'leadPFCand', 'firstTrack'.\n";
+
+      verbosity_ = (pset.exists("verbosity")) ? pset.getParameter<int>("verbosity") : 0;
     }
-  }
-  
-  if ( algorithm_ == "highestPtInEvent" ) {
-    algo_ = kHighestPtInEvent;
-  } else if ( algorithm_ == "closestInDeltaZ" ) {
-    algo_ = kClosestDeltaZ;
-  } else if ( algorithm_ == "highestWeightForLeadTrack" ) {
-    algo_ = kHighestWeigtForLeadTrack;
-  } else if ( algorithm_ == "combined" ) {
-    algo_ = kCombined;
-  } else {
-    throw cms::Exception("BadVertexAssociatorConfig")
-      << "Invalid Configuration parameter 'algorithm' " << algorithm_ << "." 
-      << " Valid options are: 'highestPtInEvent', 'closestInDeltaZ', 'highestWeightForLeadTrack' and 'combined'.\n";
-  }
 
-  vxToken_ = iC.consumes<reco::VertexCollection>(vertexTag_);
-
-  recoverLeadingTrk_ = pset.exists("recoverLeadingTrk") ? 
-    pset.getParameter<bool>("recoverLeadingTrk") : false;
-
-  std::string leadingTrkOrPFCandOption_string = pset.exists("leadingTrkOrPFCandOption") ? pset.getParameter<std::string>("leadingTrkOrPFCandOption") : "firstTrack" ;
-  if      ( leadingTrkOrPFCandOption_string == "leadTrack"  ) leadingTrkOrPFCandOption_ = kLeadTrack;
-  else if ( leadingTrkOrPFCandOption_string == "leadPFCand" ) leadingTrkOrPFCandOption_ = kLeadPFCand;
-  else if ( leadingTrkOrPFCandOption_string == "minLeadTrackOrPFCand" ) leadingTrkOrPFCandOption_ = kMinLeadTrackOrPFCand;
-  else if ( leadingTrkOrPFCandOption_string == "firstTrack" ) leadingTrkOrPFCandOption_ = kFirstTrack;
-  else throw cms::Exception("BadVertexAssociatorConfig")
-    << "Invalid Configuration parameter 'leadingTrkOrPFCandOption' " << leadingTrkOrPFCandOption_string << "." 
-    << " Valid options are: 'leadTrack', 'leadPFCand', 'firstTrack'.\n";
-  
-  verbosity_ = ( pset.exists("verbosity") ) ?
-    pset.getParameter<int>("verbosity") : 0;
-}
-
-RecoTauVertexAssociator::~RecoTauVertexAssociator()
-{ 
-  delete vertexSelector_; 
-  delete qcuts_;
-  delete jetToVertexAssociation_;
-}
-
-void RecoTauVertexAssociator::setEvent(const edm::Event& evt) 
-{
-  edm::Handle<reco::VertexCollection> vertices;
-  evt.getByToken(vxToken_, vertices);
-  selectedVertices_.clear();
-  selectedVertices_.reserve(vertices->size());
-  for ( size_t idxVertex = 0; idxVertex < vertices->size(); ++idxVertex ) {
-    reco::VertexRef vertex(vertices, idxVertex);
-    if ( vertexSelector_ && !(*vertexSelector_)(*vertex) ) continue;
-    selectedVertices_.push_back(vertex);
-  }
-  if ( !selectedVertices_.empty() ) {
-    qcuts_->setPV(selectedVertices_[0]);
-  }
-  edm::EventNumber_t currentEvent = evt.id().event();
-  if ( currentEvent != lastEvent_ || !jetToVertexAssociation_ ) {
-    if ( !jetToVertexAssociation_ ) jetToVertexAssociation_ = new std::map<const reco::Jet*, reco::VertexRef>;
-    else jetToVertexAssociation_->clear();
-    lastEvent_ = currentEvent;
-  }
-}
-
-reco::VertexRef
-RecoTauVertexAssociator::associatedVertex(const PFTau& tau, bool useJet) const 
-{
-  if ( !useJet ) {
-    if ( tau.leadChargedHadrCand().isNonnull() ) {
-      const reco::Track* track = getTrack(*tau.leadChargedHadrCand());
-      if (track != nullptr)
-        return associatedVertex(track);
+    RecoTauVertexAssociator::~RecoTauVertexAssociator() {
+      delete vertexSelector_;
+      delete qcuts_;
+      delete jetToVertexAssociation_;
     }
-  }
-  // MB: use vertex associated to a given jet if explicitely requested or in case of missing leading track
-  reco::JetBaseRef jetRef = tau.jetRef();
-  // FIXME workaround for HLT which does not use updated data format
-  if ( jetRef.isNull() ) jetRef = tau.pfTauTagInfoRef()->pfjetRef();
-  return associatedVertex(*jetRef);
-}
 
-reco::VertexRef
-RecoTauVertexAssociator::associatedVertex(const Track* track) const 
-{
-  reco::VertexRef trkVertex = ( !selectedVertices_.empty() ) ? selectedVertices_[0] : reco::VertexRef();
-
-  // algos kHighestWeigtForLeadTrack and kCombined not supported
-  if ( algo_ == kHighestPtInEvent ) {
-    if ( !selectedVertices_.empty() ) trkVertex = selectedVertices_[0];
-  } else if ( algo_ == kClosestDeltaZ ) {
-    if ( track ) {
-      double closestDistance = 1.e+6;
-      // Find the vertex that has the lowest dZ to the track
-      int idxVertex = 0;
-      for ( std::vector<reco::VertexRef>::const_iterator selectedVertex = selectedVertices_.begin();
-	    selectedVertex != selectedVertices_.end(); ++selectedVertex ) {
-	double dZ = dzToTrack(*selectedVertex, track);
-	if ( verbosity_ ) {
-	  std::cout << "vertex #" << idxVertex << ": x = " << (*selectedVertex)->position().x() << ", y = " << (*selectedVertex)->position().y() << ", z = " << (*selectedVertex)->position().z() 
-		    << " --> dZ = " << dZ << std::endl;
-	}
-	if ( dZ < closestDistance ) {
-	  trkVertex = (*selectedVertex);
-	  closestDistance = dZ;
-	}
-	++idxVertex;
+    void RecoTauVertexAssociator::setEvent(const edm::Event& evt) {
+      edm::Handle<reco::VertexCollection> vertices;
+      evt.getByToken(vxToken_, vertices);
+      selectedVertices_.clear();
+      selectedVertices_.reserve(vertices->size());
+      for (size_t idxVertex = 0; idxVertex < vertices->size(); ++idxVertex) {
+        reco::VertexRef vertex(vertices, idxVertex);
+        if (vertexSelector_ && !(*vertexSelector_)(*vertex))
+          continue;
+        selectedVertices_.push_back(vertex);
+      }
+      if (!selectedVertices_.empty()) {
+        qcuts_->setPV(selectedVertices_[0]);
+      }
+      edm::EventNumber_t currentEvent = evt.id().event();
+      if (currentEvent != lastEvent_ || !jetToVertexAssociation_) {
+        if (!jetToVertexAssociation_)
+          jetToVertexAssociation_ = new std::map<const reco::Jet*, reco::VertexRef>;
+        else
+          jetToVertexAssociation_->clear();
+        lastEvent_ = currentEvent;
       }
     }
-  }
 
-  if ( verbosity_ >= 1 ) {
-    std::cout << "--> returning vertex: x = " << trkVertex->position().x() << ", y = " << trkVertex->position().y() << ", z = " << trkVertex->position().z() << std::endl;
-  }
-  
-  return trkVertex;
-}
-
-
-reco::VertexRef
-RecoTauVertexAssociator::associatedVertex(const TrackBaseRef& track) const 
-{
-
-  reco::VertexRef trkVertex = ( !selectedVertices_.empty() ) ? selectedVertices_[0] : reco::VertexRef();
-
-  if ( algo_ == kHighestWeigtForLeadTrack || algo_ == kCombined ) {
-    if ( track.isNonnull() ) {
-      double largestWeight = -1.;
-      // Find the vertex that has the highest association probability to the track
-      int idxVertex = 0;
-      for ( std::vector<reco::VertexRef>::const_iterator selectedVertex = selectedVertices_.begin();
-	    selectedVertex != selectedVertices_.end(); ++selectedVertex ) {
-	double weight = trackWeightInVertex(*selectedVertex, track);
-	if ( verbosity_ ) {
-	  std::cout << "vertex #" << idxVertex << ": x = " << (*selectedVertex)->position().x() << ", y = " << (*selectedVertex)->position().y() << ", z = " << (*selectedVertex)->position().z() 
-		    << " --> weight = " << weight << std::endl;
-	}
-	if ( weight > largestWeight ) {
-	  trkVertex = (*selectedVertex);
-	  largestWeight = weight;
-	}
-	++idxVertex;
+    reco::VertexRef RecoTauVertexAssociator::associatedVertex(const PFTau& tau, bool useJet) const {
+      if (!useJet) {
+        if (tau.leadChargedHadrCand().isNonnull()) {
+          const reco::Track* track = getTrack(*tau.leadChargedHadrCand());
+          if (track != nullptr)
+            return associatedVertex(track);
+        }
       }
-      // the weight was never larger than zero
-      if ( algo_ == kCombined && largestWeight < 1.e-7 ) {
-	if ( verbosity_ ) {
-	  std::cout << "No vertex had positive weight! Trying dZ instead... " << std::endl;
-	}
-	double closestDistance = 1.e+6;
-	// Find the vertex that has the lowest dZ to the leading track
-	int idxVertex = 0;
-	for ( std::vector<reco::VertexRef>::const_iterator selectedVertex = selectedVertices_.begin();
-	      selectedVertex != selectedVertices_.end(); ++selectedVertex ) {
-	  double dZ = dzToTrack(*selectedVertex, track.get());
-	  if ( verbosity_ ) {
-	    std::cout << "vertex #" << idxVertex << ": x = " << (*selectedVertex)->position().x() << ", y = " << (*selectedVertex)->position().y() << ", z = " << (*selectedVertex)->position().z() 
-		      << " --> dZ = " << dZ << std::endl;
-	  }
-	  if ( dZ < closestDistance ) {
-	    trkVertex = (*selectedVertex);
-	    closestDistance = dZ;
-	  }
-	  ++idxVertex;
-	}
-      }
+      // MB: use vertex associated to a given jet if explicitely requested or in case of missing leading track
+      reco::JetBaseRef jetRef = tau.jetRef();
+      // FIXME workaround for HLT which does not use updated data format
+      if (jetRef.isNull())
+        jetRef = tau.pfTauTagInfoRef()->pfjetRef();
+      return associatedVertex(*jetRef);
     }
-  }
 
-  if ( verbosity_ >= 1 ) {
-    std::cout << "--> returning vertex: x = " << trkVertex->position().x() << ", y = " << trkVertex->position().y() << ", z = " << trkVertex->position().z() << std::endl;
-  }
-  
-  return trkVertex;
-}
+    reco::VertexRef RecoTauVertexAssociator::associatedVertex(const Track* track) const {
+      reco::VertexRef trkVertex = (!selectedVertices_.empty()) ? selectedVertices_[0] : reco::VertexRef();
 
-reco::VertexRef
-RecoTauVertexAssociator::associatedVertex(const Jet& jet) const 
-{
-if ( verbosity_ >= 1 ) {
-    std::cout << "<RecoTauVertexAssociator::associatedVertex>:" << std::endl;
-    std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << std::endl;
-    std::cout << " num. Vertices = " << selectedVertices_.size() << std::endl;
-    std::cout << " size(jetToVertexAssociation) = " << jetToVertexAssociation_->size() << std::endl;
-    std::cout << " vertexTag = " << vertexTag_ << std::endl;
-    std::cout << " algorithm = " << algorithm_ << std::endl;
-    std::cout << " recoverLeadingTrk = " << recoverLeadingTrk_ << std::endl;
-  }
+      // algos kHighestWeigtForLeadTrack and kCombined not supported
+      if (algo_ == kHighestPtInEvent) {
+        if (!selectedVertices_.empty())
+          trkVertex = selectedVertices_[0];
+      } else if (algo_ == kClosestDeltaZ) {
+        if (track) {
+          double closestDistance = 1.e+6;
+          // Find the vertex that has the lowest dZ to the track
+          int idxVertex = 0;
+          for (std::vector<reco::VertexRef>::const_iterator selectedVertex = selectedVertices_.begin();
+               selectedVertex != selectedVertices_.end();
+               ++selectedVertex) {
+            double dZ = dzToTrack(*selectedVertex, track);
+            if (verbosity_) {
+              std::cout << "vertex #" << idxVertex << ": x = " << (*selectedVertex)->position().x()
+                        << ", y = " << (*selectedVertex)->position().y()
+                        << ", z = " << (*selectedVertex)->position().z() << " --> dZ = " << dZ << std::endl;
+            }
+            if (dZ < closestDistance) {
+              trkVertex = (*selectedVertex);
+              closestDistance = dZ;
+            }
+            ++idxVertex;
+          }
+        }
+      }
 
-  reco::VertexRef jetVertex = ( !selectedVertices_.empty() ) ? selectedVertices_[0] : reco::VertexRef();
-  const Jet* jetPtr = &jet;
+      if (verbosity_ >= 1) {
+        std::cout << "--> returning vertex: x = " << trkVertex->position().x() << ", y = " << trkVertex->position().y()
+                  << ", z = " << trkVertex->position().z() << std::endl;
+      }
 
-  // check if jet-vertex association has been determined for this jet before
-  std::map<const reco::Jet*, reco::VertexRef>::iterator vertexPtr = jetToVertexAssociation_->find(jetPtr);
-  if ( vertexPtr != jetToVertexAssociation_->end() ) {
-    jetVertex = vertexPtr->second;
-  } else {
-    // no jet-vertex association exists for this jet yet, compute it!
-    if ( algo_ == kHighestPtInEvent ) {
-      if ( !selectedVertices_.empty() ) jetVertex = selectedVertices_[0];
-    } else if ( algo_ == kClosestDeltaZ ) {
-      // find "leading" (highest Pt) track in jet
-      const reco::Track* leadTrack = getLeadTrack(jet);
-      if ( verbosity_ ) {
-	if ( leadTrack != nullptr ) std::cout << "leadTrack: Pt = " << leadTrack->pt() << ", eta = " << leadTrack->eta() << ", phi = " << leadTrack->phi() << std::endl;
-	else std::cout << "leadTrack: N/A" << std::endl;
-      }
-      if ( leadTrack != nullptr ) {
-	jetVertex = associatedVertex(leadTrack);
-      }
-    } else if (algo_ == kHighestWeigtForLeadTrack || 
-	       algo_ == kCombined ) {
-      // find "leading" (highest Pt) track in jet
-      const reco::TrackBaseRef leadTrack = getLeadTrackRef(jet);
-      if ( verbosity_ ) {
-	if ( leadTrack.isNonnull() ) std::cout << "leadTrack: Pt = " << leadTrack->pt() << ", eta = " << leadTrack->eta() << ", phi = " << leadTrack->phi() << std::endl;
-	else std::cout << "leadTrack: N/A" << std::endl;
-      }
-      if ( leadTrack.isNonnull()) {
-	jetVertex = associatedVertex(leadTrack);
-      }
+      return trkVertex;
     }
-    
-    jetToVertexAssociation_->insert(std::pair<const Jet*, reco::VertexRef>(jetPtr, jetVertex));
-  }
 
-  if ( verbosity_ >= 1 ) {
-    std::cout << "--> returning vertex: x = " << jetVertex->position().x() << ", y = " << jetVertex->position().y() << ", z = " << jetVertex->position().z() << std::endl;
-  }
-  
-  return jetVertex;
-}
+    reco::VertexRef RecoTauVertexAssociator::associatedVertex(const TrackBaseRef& track) const {
+      reco::VertexRef trkVertex = (!selectedVertices_.empty()) ? selectedVertices_[0] : reco::VertexRef();
 
-}}
+      if (algo_ == kHighestWeigtForLeadTrack || algo_ == kCombined) {
+        if (track.isNonnull()) {
+          double largestWeight = -1.;
+          // Find the vertex that has the highest association probability to the track
+          int idxVertex = 0;
+          for (std::vector<reco::VertexRef>::const_iterator selectedVertex = selectedVertices_.begin();
+               selectedVertex != selectedVertices_.end();
+               ++selectedVertex) {
+            double weight = trackWeightInVertex(*selectedVertex, track);
+            if (verbosity_) {
+              std::cout << "vertex #" << idxVertex << ": x = " << (*selectedVertex)->position().x()
+                        << ", y = " << (*selectedVertex)->position().y()
+                        << ", z = " << (*selectedVertex)->position().z() << " --> weight = " << weight << std::endl;
+            }
+            if (weight > largestWeight) {
+              trkVertex = (*selectedVertex);
+              largestWeight = weight;
+            }
+            ++idxVertex;
+          }
+          // the weight was never larger than zero
+          if (algo_ == kCombined && largestWeight < 1.e-7) {
+            if (verbosity_) {
+              std::cout << "No vertex had positive weight! Trying dZ instead... " << std::endl;
+            }
+            double closestDistance = 1.e+6;
+            // Find the vertex that has the lowest dZ to the leading track
+            int idxVertex = 0;
+            for (std::vector<reco::VertexRef>::const_iterator selectedVertex = selectedVertices_.begin();
+                 selectedVertex != selectedVertices_.end();
+                 ++selectedVertex) {
+              double dZ = dzToTrack(*selectedVertex, track.get());
+              if (verbosity_) {
+                std::cout << "vertex #" << idxVertex << ": x = " << (*selectedVertex)->position().x()
+                          << ", y = " << (*selectedVertex)->position().y()
+                          << ", z = " << (*selectedVertex)->position().z() << " --> dZ = " << dZ << std::endl;
+              }
+              if (dZ < closestDistance) {
+                trkVertex = (*selectedVertex);
+                closestDistance = dZ;
+              }
+              ++idxVertex;
+            }
+          }
+        }
+      }
+
+      if (verbosity_ >= 1) {
+        std::cout << "--> returning vertex: x = " << trkVertex->position().x() << ", y = " << trkVertex->position().y()
+                  << ", z = " << trkVertex->position().z() << std::endl;
+      }
+
+      return trkVertex;
+    }
+
+    reco::VertexRef RecoTauVertexAssociator::associatedVertex(const Jet& jet) const {
+      if (verbosity_ >= 1) {
+        std::cout << "<RecoTauVertexAssociator::associatedVertex>:" << std::endl;
+        std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << std::endl;
+        std::cout << " num. Vertices = " << selectedVertices_.size() << std::endl;
+        std::cout << " size(jetToVertexAssociation) = " << jetToVertexAssociation_->size() << std::endl;
+        std::cout << " vertexTag = " << vertexTag_ << std::endl;
+        std::cout << " algorithm = " << algorithm_ << std::endl;
+        std::cout << " recoverLeadingTrk = " << recoverLeadingTrk_ << std::endl;
+      }
+
+      reco::VertexRef jetVertex = (!selectedVertices_.empty()) ? selectedVertices_[0] : reco::VertexRef();
+      const Jet* jetPtr = &jet;
+
+      // check if jet-vertex association has been determined for this jet before
+      std::map<const reco::Jet*, reco::VertexRef>::iterator vertexPtr = jetToVertexAssociation_->find(jetPtr);
+      if (vertexPtr != jetToVertexAssociation_->end()) {
+        jetVertex = vertexPtr->second;
+      } else {
+        // no jet-vertex association exists for this jet yet, compute it!
+        if (algo_ == kHighestPtInEvent) {
+          if (!selectedVertices_.empty())
+            jetVertex = selectedVertices_[0];
+        } else if (algo_ == kClosestDeltaZ) {
+          // find "leading" (highest Pt) track in jet
+          const reco::Track* leadTrack = getLeadTrack(jet);
+          if (verbosity_) {
+            if (leadTrack != nullptr)
+              std::cout << "leadTrack: Pt = " << leadTrack->pt() << ", eta = " << leadTrack->eta()
+                        << ", phi = " << leadTrack->phi() << std::endl;
+            else
+              std::cout << "leadTrack: N/A" << std::endl;
+          }
+          if (leadTrack != nullptr) {
+            jetVertex = associatedVertex(leadTrack);
+          }
+        } else if (algo_ == kHighestWeigtForLeadTrack || algo_ == kCombined) {
+          // find "leading" (highest Pt) track in jet
+          const reco::TrackBaseRef leadTrack = getLeadTrackRef(jet);
+          if (verbosity_) {
+            if (leadTrack.isNonnull())
+              std::cout << "leadTrack: Pt = " << leadTrack->pt() << ", eta = " << leadTrack->eta()
+                        << ", phi = " << leadTrack->phi() << std::endl;
+            else
+              std::cout << "leadTrack: N/A" << std::endl;
+          }
+          if (leadTrack.isNonnull()) {
+            jetVertex = associatedVertex(leadTrack);
+          }
+        }
+
+        jetToVertexAssociation_->insert(std::pair<const Jet*, reco::VertexRef>(jetPtr, jetVertex));
+      }
+
+      if (verbosity_ >= 1) {
+        std::cout << "--> returning vertex: x = " << jetVertex->position().x() << ", y = " << jetVertex->position().y()
+                  << ", z = " << jetVertex->position().z() << std::endl;
+      }
+
+      return jetVertex;
+    }
+
+  }  // namespace tau
+}  // namespace reco

--- a/RecoTauTag/RecoTau/src/TauDiscriminationProducerBase.cc
+++ b/RecoTauTag/RecoTau/src/TauDiscriminationProducerBase.cc
@@ -5,170 +5,159 @@
 using namespace reco;
 
 // default constructor; must not be called
-template<class TauType, class TauDiscriminator>
-TauDiscriminationProducerBase<TauType, TauDiscriminator>::TauDiscriminationProducerBase()
-{
-   throw cms::Exception("TauDiscriminationProducerBase") << " -- default ctor called; derived classes must call " <<
-      "TauDiscriminationProducerBase(const ParameterSet&)";
+template <class TauType, class TauDiscriminator>
+TauDiscriminationProducerBase<TauType, TauDiscriminator>::TauDiscriminationProducerBase() {
+  throw cms::Exception("TauDiscriminationProducerBase") << " -- default ctor called; derived classes must call "
+                                                        << "TauDiscriminationProducerBase(const ParameterSet&)";
 }
 
 //--- standard constructor from PSet
-template<class TauType, class TauDiscriminator>
+template <class TauType, class TauDiscriminator>
 TauDiscriminationProducerBase<TauType, TauDiscriminator>::TauDiscriminationProducerBase(const edm::ParameterSet& iConfig)
-  : moduleLabel_(iConfig.getParameter<std::string>("@module_label"))
-{
-   // tau collection to discriminate
-   TauProducer_        = iConfig.getParameter<edm::InputTag>(getProducerString<TauType>());
-   Tau_token= consumes<TauCollection>(TauProducer_);
+    : moduleLabel_(iConfig.getParameter<std::string>("@module_label")) {
+  // tau collection to discriminate
+  TauProducer_ = iConfig.getParameter<edm::InputTag>(getProducerString<TauType>());
+  Tau_token = consumes<TauCollection>(TauProducer_);
 
-   // prediscriminant operator
-   // require the tau to pass the following prediscriminants
-   const edm::ParameterSet& prediscriminantConfig = iConfig.getParameter<edm::ParameterSet>("Prediscriminants");
+  // prediscriminant operator
+  // require the tau to pass the following prediscriminants
+  const edm::ParameterSet& prediscriminantConfig = iConfig.getParameter<edm::ParameterSet>("Prediscriminants");
 
-   // determine boolean operator used on the prediscriminants
-   std::string pdBoolOperator = prediscriminantConfig.getParameter<std::string>("BooleanOperator");
-   // convert string to lowercase
-   transform(pdBoolOperator.begin(), pdBoolOperator.end(), pdBoolOperator.begin(), ::tolower);
+  // determine boolean operator used on the prediscriminants
+  std::string pdBoolOperator = prediscriminantConfig.getParameter<std::string>("BooleanOperator");
+  // convert string to lowercase
+  transform(pdBoolOperator.begin(), pdBoolOperator.end(), pdBoolOperator.begin(), ::tolower);
 
-   if( pdBoolOperator == "and" )
-   {
-      andPrediscriminants_ = 0x1; //use chars instead of bools so we can do a bitwise trick later
-   }
-   else if ( pdBoolOperator == "or" )
-   {
-      andPrediscriminants_ = 0x0;
-   }
-   else
-   {
-      throw cms::Exception("TauDiscriminationProducerBase") << "PrediscriminantBooleanOperator defined incorrectly, options are: AND,OR";
-   }
+  if (pdBoolOperator == "and") {
+    andPrediscriminants_ = 0x1;  //use chars instead of bools so we can do a bitwise trick later
+  } else if (pdBoolOperator == "or") {
+    andPrediscriminants_ = 0x0;
+  } else {
+    throw cms::Exception("TauDiscriminationProducerBase")
+        << "PrediscriminantBooleanOperator defined incorrectly, options are: AND,OR";
+  }
 
-   // get the list of prediscriminants
-   std::vector<std::string> prediscriminantsNames = prediscriminantConfig.getParameterNamesForType<edm::ParameterSet>();
+  // get the list of prediscriminants
+  std::vector<std::string> prediscriminantsNames = prediscriminantConfig.getParameterNamesForType<edm::ParameterSet>();
 
-   for( std::vector<std::string>::const_iterator iDisc  = prediscriminantsNames.begin();
-                                       iDisc != prediscriminantsNames.end(); ++iDisc )
-   {
-      const edm::ParameterSet& iPredisc = prediscriminantConfig.getParameter<edm::ParameterSet>(*iDisc);
-      const edm::InputTag& label        = iPredisc.getParameter<edm::InputTag>("Producer");
-      double cut                        = iPredisc.getParameter<double>("cut");
+  for (std::vector<std::string>::const_iterator iDisc = prediscriminantsNames.begin();
+       iDisc != prediscriminantsNames.end();
+       ++iDisc) {
+    const edm::ParameterSet& iPredisc = prediscriminantConfig.getParameter<edm::ParameterSet>(*iDisc);
+    const edm::InputTag& label = iPredisc.getParameter<edm::InputTag>("Producer");
+    double cut = iPredisc.getParameter<double>("cut");
 
-      TauDiscInfo thisDiscriminator;
-      thisDiscriminator.label = label;
-      thisDiscriminator.cut   = cut;
-      thisDiscriminator.disc_token = consumes<TauDiscriminator>(label);
-      prediscriminants_.push_back(thisDiscriminator);
-   }
+    TauDiscInfo thisDiscriminator;
+    thisDiscriminator.label = label;
+    thisDiscriminator.cut = cut;
+    thisDiscriminator.disc_token = consumes<TauDiscriminator>(label);
+    prediscriminants_.push_back(thisDiscriminator);
+  }
 
-   prediscriminantFailValue_ = 0.;
+  prediscriminantFailValue_ = 0.;
 
-   // register product
-   produces<TauDiscriminator>();
+  // register product
+  produces<TauDiscriminator>();
 }
 
-template<class TauType, class TauDiscriminator>
-void TauDiscriminationProducerBase<TauType, TauDiscriminator>::produce(edm::Event& event, const edm::EventSetup& eventSetup)
-{
-   tauIndex_=0;
-   // setup function - does nothing in base, but can be overridden to retrieve PV or other stuff
-   beginEvent(event, eventSetup);
+template <class TauType, class TauDiscriminator>
+void TauDiscriminationProducerBase<TauType, TauDiscriminator>::produce(edm::Event& event,
+                                                                       const edm::EventSetup& eventSetup) {
+  tauIndex_ = 0;
+  // setup function - does nothing in base, but can be overridden to retrieve PV or other stuff
+  beginEvent(event, eventSetup);
 
-   // retrieve the tau collection to discriminate
-   edm::Handle<TauCollection> taus;
-   event.getByToken(Tau_token, taus);
+  // retrieve the tau collection to discriminate
+  edm::Handle<TauCollection> taus;
+  event.getByToken(Tau_token, taus);
 
-   edm::ProductID tauProductID = taus.id();
+  edm::ProductID tauProductID = taus.id();
 
-   // output product
-   auto output = std::make_unique<TauDiscriminator>(TauRefProd(taus));
+  // output product
+  auto output = std::make_unique<TauDiscriminator>(TauRefProd(taus));
 
-   size_t nTaus = taus->size();
+  size_t nTaus = taus->size();
 
-   // load prediscriminators
-   size_t nPrediscriminants = prediscriminants_.size();
-   for( size_t iDisc = 0; iDisc < nPrediscriminants; ++iDisc )
-   {
-      prediscriminants_[iDisc].fill(event);
+  // load prediscriminators
+  size_t nPrediscriminants = prediscriminants_.size();
+  for (size_t iDisc = 0; iDisc < nPrediscriminants; ++iDisc) {
+    prediscriminants_[iDisc].fill(event);
 
-      // Check to make sure the product is correct for the discriminator.
-      // If not, throw a more informative exception.
-      edm::ProductID discKeyId =
-        prediscriminants_[iDisc].handle->keyProduct().id();
-      if (tauProductID != discKeyId) {
-        throw cms::Exception("MisconfiguredPrediscriminant")
-          << "The tau collection with input tag " << TauProducer_
-          << " has product ID: " << tauProductID
-          << " but the pre-discriminator with input tag "
-          << prediscriminants_[iDisc].label
+    // Check to make sure the product is correct for the discriminator.
+    // If not, throw a more informative exception.
+    edm::ProductID discKeyId = prediscriminants_[iDisc].handle->keyProduct().id();
+    if (tauProductID != discKeyId) {
+      throw cms::Exception("MisconfiguredPrediscriminant")
+          << "The tau collection with input tag " << TauProducer_ << " has product ID: " << tauProductID
+          << " but the pre-discriminator with input tag " << prediscriminants_[iDisc].label
           << " is keyed with product ID: " << discKeyId << std::endl;
-      }
-   }
+    }
+  }
 
-   // loop over taus
-   for( size_t iTau = 0; iTau < nTaus; ++iTau )
-   {
-      // get reference to tau
-      TauRef tauRef(taus, iTau);
+  // loop over taus
+  for (size_t iTau = 0; iTau < nTaus; ++iTau) {
+    // get reference to tau
+    TauRef tauRef(taus, iTau);
 
-      bool passesPrediscriminants = ( andPrediscriminants_ ? 1 : 0 );
-      // check tau passes prediscriminants
-      for( size_t iDisc = 0; iDisc < nPrediscriminants; ++iDisc )
+    bool passesPrediscriminants = (andPrediscriminants_ ? 1 : 0);
+    // check tau passes prediscriminants
+    for (size_t iDisc = 0; iDisc < nPrediscriminants; ++iDisc) {
+      // current discriminant result for this tau
+      double discResult = (*prediscriminants_[iDisc].handle)[tauRef];
+      uint8_t thisPasses = (discResult > prediscriminants_[iDisc].cut) ? 1 : 0;
+
+      // if we are using the AND option, as soon as one fails,
+      // the result is FAIL and we can quit looping.
+      // if we are using the OR option as soon as one passes,
+      // the result is pass and we can quit looping
+
+      // truth table
+      //        |   result (thisPasses)
+      //        |     F     |     T
+      //-----------------------------------
+      // AND(T) | res=fails |  continue
+      //        |  break    |
+      //-----------------------------------
+      // OR (F) |  continue | res=passes
+      //        |           |  break
+
+      if (thisPasses ^ andPrediscriminants_)  //XOR
       {
-         // current discriminant result for this tau
-         double discResult  = (*prediscriminants_[iDisc].handle)[tauRef];
-         uint8_t thisPasses = ( discResult > prediscriminants_[iDisc].cut ) ? 1 : 0;
-
-         // if we are using the AND option, as soon as one fails,
-         // the result is FAIL and we can quit looping.
-         // if we are using the OR option as soon as one passes,
-         // the result is pass and we can quit looping
-
-         // truth table
-         //        |   result (thisPasses)
-         //        |     F     |     T
-         //-----------------------------------
-         // AND(T) | res=fails |  continue
-         //        |  break    |
-         //-----------------------------------
-         // OR (F) |  continue | res=passes
-         //        |           |  break
-
-         if( thisPasses ^ andPrediscriminants_ ) //XOR
-         {
-            passesPrediscriminants = ( andPrediscriminants_ ? 0 : 1 ); //NOR
-            break;
-         }
+        passesPrediscriminants = (andPrediscriminants_ ? 0 : 1);  //NOR
+        break;
       }
+    }
 
-      double result = prediscriminantFailValue_;
-      if( passesPrediscriminants )
-      {
-         // this tau passes the prereqs, call our implemented discrimination function
-         result = discriminate(tauRef); ++tauIndex_;
-      }
+    double result = prediscriminantFailValue_;
+    if (passesPrediscriminants) {
+      // this tau passes the prereqs, call our implemented discrimination function
+      result = discriminate(tauRef);
+      ++tauIndex_;
+    }
 
-      // store the result of this tau into our new discriminator
-      output->setValue(iTau, result);
-   }
-   event.put(std::move(output));
+    // store the result of this tau into our new discriminator
+    output->setValue(iTau, result);
+  }
+  event.put(std::move(output));
 
-   // function to put additional information into the event - does nothing in base, but can be overridden in derived classes
-   endEvent(event);
+  // function to put additional information into the event - does nothing in base, but can be overridden in derived classes
+  endEvent(event);
 }
 
-template<class TauType, class TauDiscriminator>
-void TauDiscriminationProducerBase<TauType, TauDiscriminator>::fillProducerDescriptions(edm::ParameterSetDescription& desc) {
+template <class TauType, class TauDiscriminator>
+void TauDiscriminationProducerBase<TauType, TauDiscriminator>::fillProducerDescriptions(
+    edm::ParameterSetDescription& desc) {
   // helper function, it fills the description of the Producers parameter
-  desc.add<edm::InputTag>(getProducerString<TauType>(),edm::InputTag("fixme"));
+  desc.add<edm::InputTag>(getProducerString<TauType>(), edm::InputTag("fixme"));
   {
     edm::ParameterSetDescription pset_prediscriminants;
-    pset_prediscriminants.add<std::string>("BooleanOperator","AND");
+    pset_prediscriminants.add<std::string>("BooleanOperator", "AND");
     // optional producers // will it pass if I don't specify them?
 
     {
       edm::ParameterSetDescription producer_params;
-      producer_params.add<double>("cut",0.);
-      producer_params.add<edm::InputTag>("Producer",edm::InputTag("fixme"));
+      producer_params.add<double>("cut", 0.);
+      producer_params.add<edm::InputTag>("Producer", edm::InputTag("fixme"));
 
       pset_prediscriminants.addOptional<edm::ParameterSetDescription>("leadTrack", producer_params);
       pset_prediscriminants.addOptional<edm::ParameterSetDescription>("decayMode", producer_params);
@@ -179,9 +168,18 @@ void TauDiscriminationProducerBase<TauType, TauDiscriminator>::fillProducerDescr
 }
 
 // template specialiazation to get the correct (Calo/PF)TauProducer names
-template<> std::string getProducerString<PFTau>()   { return "PFTauProducer"; }
-template<> std::string getProducerString<CaloTau>() { return "CaloTauProducer"; }
-template<> std::string getProducerString<pat::Tau>() { return "PATTauProducer"; }
+template <>
+std::string getProducerString<PFTau>() {
+  return "PFTauProducer";
+}
+template <>
+std::string getProducerString<CaloTau>() {
+  return "CaloTauProducer";
+}
+template <>
+std::string getProducerString<pat::Tau>() {
+  return "PATTauProducer";
+}
 
 // compile our desired types and make available to linker
 template class TauDiscriminationProducerBase<PFTau, PFTauDiscriminator>;

--- a/RecoTauTag/RecoTau/src/TauTagTools.cc
+++ b/RecoTauTag/RecoTau/src/TauTagTools.cc
@@ -4,96 +4,134 @@ using namespace reco;
 
 namespace tautagtools {
 
-  TrackRefVector filteredTracks(const TrackRefVector& theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2, const Vertex& pv){
+  TrackRefVector filteredTracks(const TrackRefVector& theInitialTracks,
+                                double tkminPt,
+                                int tkminPixelHitsn,
+                                int tkminTrackerHitsn,
+                                double tkmaxipt,
+                                double tkmaxChi2,
+                                const Vertex& pv) {
     TrackRefVector filteredTracks;
-    for(TrackRefVector::const_iterator iTk=theInitialTracks.begin();iTk!=theInitialTracks.end();iTk++){
-      if ((**iTk).pt()>=tkminPt &&
-	  (**iTk).normalizedChi2()<=tkmaxChi2 &&
-	  fabs((**iTk).dxy(pv.position()))<=tkmaxipt &&
-	  (**iTk).numberOfValidHits()>=tkminTrackerHitsn &&
-	  (**iTk).hitPattern().numberOfValidPixelHits()>=tkminPixelHitsn)
-	filteredTracks.push_back(*iTk);
+    for (TrackRefVector::const_iterator iTk = theInitialTracks.begin(); iTk != theInitialTracks.end(); iTk++) {
+      if ((**iTk).pt() >= tkminPt && (**iTk).normalizedChi2() <= tkmaxChi2 &&
+          fabs((**iTk).dxy(pv.position())) <= tkmaxipt && (**iTk).numberOfValidHits() >= tkminTrackerHitsn &&
+          (**iTk).hitPattern().numberOfValidPixelHits() >= tkminPixelHitsn)
+        filteredTracks.push_back(*iTk);
     }
     return filteredTracks;
   }
-  TrackRefVector filteredTracks(const TrackRefVector& theInitialTracks, double tkminPt, int tkminPixelHitsn, int tkminTrackerHitsn, double tkmaxipt, double tkmaxChi2, double tktorefpointmaxDZ, const Vertex& pv, double refpoint_Z){
+  TrackRefVector filteredTracks(const TrackRefVector& theInitialTracks,
+                                double tkminPt,
+                                int tkminPixelHitsn,
+                                int tkminTrackerHitsn,
+                                double tkmaxipt,
+                                double tkmaxChi2,
+                                double tktorefpointmaxDZ,
+                                const Vertex& pv,
+                                double refpoint_Z) {
     TrackRefVector filteredTracks;
-    for(TrackRefVector::const_iterator iTk=theInitialTracks.begin();iTk!=theInitialTracks.end();iTk++){
-      if(pv.isFake()) tktorefpointmaxDZ=30.;
-      if ((**iTk).pt()>=tkminPt &&
-	  (**iTk).normalizedChi2()<=tkmaxChi2 &&
-	  fabs((**iTk).dxy(pv.position()))<=tkmaxipt &&
-	  (**iTk).numberOfValidHits()>=tkminTrackerHitsn &&
-	  (**iTk).hitPattern().numberOfValidPixelHits()>=tkminPixelHitsn &&
-	  fabs((**iTk).dz(pv.position()))<=tktorefpointmaxDZ)
-	filteredTracks.push_back(*iTk);
+    for (TrackRefVector::const_iterator iTk = theInitialTracks.begin(); iTk != theInitialTracks.end(); iTk++) {
+      if (pv.isFake())
+        tktorefpointmaxDZ = 30.;
+      if ((**iTk).pt() >= tkminPt && (**iTk).normalizedChi2() <= tkmaxChi2 &&
+          fabs((**iTk).dxy(pv.position())) <= tkmaxipt && (**iTk).numberOfValidHits() >= tkminTrackerHitsn &&
+          (**iTk).hitPattern().numberOfValidPixelHits() >= tkminPixelHitsn &&
+          fabs((**iTk).dz(pv.position())) <= tktorefpointmaxDZ)
+        filteredTracks.push_back(*iTk);
     }
     return filteredTracks;
   }
 
-  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands, double ChargedHadrCand_tkminPt, int ChargedHadrCand_tkminPixelHitsn, int ChargedHadrCand_tkminTrackerHitsn, double ChargedHadrCand_tkmaxipt, double ChargedHadrCand_tkmaxChi2, const Vertex& pv){
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,
+                                                             double ChargedHadrCand_tkminPt,
+                                                             int ChargedHadrCand_tkminPixelHitsn,
+                                                             int ChargedHadrCand_tkminTrackerHitsn,
+                                                             double ChargedHadrCand_tkmaxipt,
+                                                             double ChargedHadrCand_tkmaxChi2,
+                                                             const Vertex& pv) {
     std::vector<reco::CandidatePtr> filteredPFChargedHadrCands;
-    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
-      if (std::abs((*iPFCand)->pdgId()) == 211 || std::abs((*iPFCand)->pdgId()) == 13 || std::abs((*iPFCand)->pdgId()) == 11){
-	// *** Whether the charged hadron candidate will be selected or not depends on its rec. tk properties. 
-	const reco::Track* PFChargedHadrCand_rectk = (*iPFCand)->bestTrack();
-	if (PFChargedHadrCand_rectk != nullptr) {
-	  if ((*PFChargedHadrCand_rectk).pt()>=ChargedHadrCand_tkminPt &&
-	      (*PFChargedHadrCand_rectk).normalizedChi2()<=ChargedHadrCand_tkmaxChi2 &&
-	      fabs((*PFChargedHadrCand_rectk).dxy(pv.position()))<=ChargedHadrCand_tkmaxipt &&
-	      (*PFChargedHadrCand_rectk).numberOfValidHits()>=ChargedHadrCand_tkminTrackerHitsn &&
-	      (*PFChargedHadrCand_rectk).hitPattern().numberOfValidPixelHits()>=ChargedHadrCand_tkminPixelHitsn) 
-	    filteredPFChargedHadrCands.push_back(*iPFCand);
-	}
+    for (std::vector<reco::CandidatePtr>::const_iterator iPFCand = theInitialPFCands.begin();
+         iPFCand != theInitialPFCands.end();
+         iPFCand++) {
+      if (std::abs((*iPFCand)->pdgId()) == 211 || std::abs((*iPFCand)->pdgId()) == 13 ||
+          std::abs((*iPFCand)->pdgId()) == 11) {
+        // *** Whether the charged hadron candidate will be selected or not depends on its rec. tk properties.
+        const reco::Track* PFChargedHadrCand_rectk = (*iPFCand)->bestTrack();
+        if (PFChargedHadrCand_rectk != nullptr) {
+          if ((*PFChargedHadrCand_rectk).pt() >= ChargedHadrCand_tkminPt &&
+              (*PFChargedHadrCand_rectk).normalizedChi2() <= ChargedHadrCand_tkmaxChi2 &&
+              fabs((*PFChargedHadrCand_rectk).dxy(pv.position())) <= ChargedHadrCand_tkmaxipt &&
+              (*PFChargedHadrCand_rectk).numberOfValidHits() >= ChargedHadrCand_tkminTrackerHitsn &&
+              (*PFChargedHadrCand_rectk).hitPattern().numberOfValidPixelHits() >= ChargedHadrCand_tkminPixelHitsn)
+            filteredPFChargedHadrCands.push_back(*iPFCand);
+        }
       }
     }
     return filteredPFChargedHadrCands;
   }
-  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands, double ChargedHadrCand_tkminPt, int ChargedHadrCand_tkminPixelHitsn, int ChargedHadrCand_tkminTrackerHitsn, double ChargedHadrCand_tkmaxipt, double ChargedHadrCand_tkmaxChi2, double ChargedHadrCand_tktorefpointmaxDZ, const Vertex& pv, double refpoint_Z){
-    if(pv.isFake()) ChargedHadrCand_tktorefpointmaxDZ = 30.;
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,
+                                                             double ChargedHadrCand_tkminPt,
+                                                             int ChargedHadrCand_tkminPixelHitsn,
+                                                             int ChargedHadrCand_tkminTrackerHitsn,
+                                                             double ChargedHadrCand_tkmaxipt,
+                                                             double ChargedHadrCand_tkmaxChi2,
+                                                             double ChargedHadrCand_tktorefpointmaxDZ,
+                                                             const Vertex& pv,
+                                                             double refpoint_Z) {
+    if (pv.isFake())
+      ChargedHadrCand_tktorefpointmaxDZ = 30.;
     std::vector<reco::CandidatePtr> filteredPFChargedHadrCands;
-    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
-      if (std::abs((*iPFCand)->pdgId()) == 211 || std::abs((*iPFCand)->pdgId()) == 13 || std::abs((*iPFCand)->pdgId()) == 11){
-	// *** Whether the charged hadron candidate will be selected or not depends on its rec. tk properties. 
-	const reco::Track* PFChargedHadrCand_rectk = (*iPFCand)->bestTrack();
-	if (PFChargedHadrCand_rectk != nullptr) {
-	  if ((*PFChargedHadrCand_rectk).pt()>=ChargedHadrCand_tkminPt &&
-	      (*PFChargedHadrCand_rectk).normalizedChi2()<=ChargedHadrCand_tkmaxChi2 &&
-	      fabs((*PFChargedHadrCand_rectk).dxy(pv.position()))<=ChargedHadrCand_tkmaxipt &&
-	      (*PFChargedHadrCand_rectk).numberOfValidHits()>=ChargedHadrCand_tkminTrackerHitsn &&
-	      (*PFChargedHadrCand_rectk).hitPattern().numberOfValidPixelHits()>=ChargedHadrCand_tkminPixelHitsn &&
-	      fabs((*PFChargedHadrCand_rectk).dz(pv.position()))<=ChargedHadrCand_tktorefpointmaxDZ)
-	    filteredPFChargedHadrCands.push_back(*iPFCand);
-	}
+    for (std::vector<reco::CandidatePtr>::const_iterator iPFCand = theInitialPFCands.begin();
+         iPFCand != theInitialPFCands.end();
+         iPFCand++) {
+      if (std::abs((*iPFCand)->pdgId()) == 211 || std::abs((*iPFCand)->pdgId()) == 13 ||
+          std::abs((*iPFCand)->pdgId()) == 11) {
+        // *** Whether the charged hadron candidate will be selected or not depends on its rec. tk properties.
+        const reco::Track* PFChargedHadrCand_rectk = (*iPFCand)->bestTrack();
+        if (PFChargedHadrCand_rectk != nullptr) {
+          if ((*PFChargedHadrCand_rectk).pt() >= ChargedHadrCand_tkminPt &&
+              (*PFChargedHadrCand_rectk).normalizedChi2() <= ChargedHadrCand_tkmaxChi2 &&
+              fabs((*PFChargedHadrCand_rectk).dxy(pv.position())) <= ChargedHadrCand_tkmaxipt &&
+              (*PFChargedHadrCand_rectk).numberOfValidHits() >= ChargedHadrCand_tkminTrackerHitsn &&
+              (*PFChargedHadrCand_rectk).hitPattern().numberOfValidPixelHits() >= ChargedHadrCand_tkminPixelHitsn &&
+              fabs((*PFChargedHadrCand_rectk).dz(pv.position())) <= ChargedHadrCand_tktorefpointmaxDZ)
+            filteredPFChargedHadrCands.push_back(*iPFCand);
+        }
       }
     }
     return filteredPFChargedHadrCands;
   }
-  
-  std::vector<reco::CandidatePtr> filteredPFNeutrHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,double NeutrHadrCand_HcalclusMinEt){
+
+  std::vector<reco::CandidatePtr> filteredPFNeutrHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,
+                                                           double NeutrHadrCand_HcalclusMinEt) {
     std::vector<reco::CandidatePtr> filteredPFNeutrHadrCands;
-    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
-      if (std::abs((*iPFCand)->pdgId()) == 130){
-	// *** Whether the neutral hadron candidate will be selected or not depends on its rec. HCAL cluster properties. 
-	if ((**iPFCand).et()>=NeutrHadrCand_HcalclusMinEt){
-	  filteredPFNeutrHadrCands.push_back(*iPFCand);
-	}
+    for (std::vector<reco::CandidatePtr>::const_iterator iPFCand = theInitialPFCands.begin();
+         iPFCand != theInitialPFCands.end();
+         iPFCand++) {
+      if (std::abs((*iPFCand)->pdgId()) == 130) {
+        // *** Whether the neutral hadron candidate will be selected or not depends on its rec. HCAL cluster properties.
+        if ((**iPFCand).et() >= NeutrHadrCand_HcalclusMinEt) {
+          filteredPFNeutrHadrCands.push_back(*iPFCand);
+        }
       }
     }
     return filteredPFNeutrHadrCands;
   }
-  
-  std::vector<reco::CandidatePtr> filteredPFGammaCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,double GammaCand_EcalclusMinEt){
+
+  std::vector<reco::CandidatePtr> filteredPFGammaCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,
+                                                       double GammaCand_EcalclusMinEt) {
     std::vector<reco::CandidatePtr> filteredPFGammaCands;
-    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
-      if (std::abs((*iPFCand)->pdgId()) == 22){
-	// *** Whether the gamma candidate will be selected or not depends on its rec. ECAL cluster properties. 
-	if ((**iPFCand).et()>=GammaCand_EcalclusMinEt){
-	  filteredPFGammaCands.push_back(*iPFCand);
-	}
+    for (std::vector<reco::CandidatePtr>::const_iterator iPFCand = theInitialPFCands.begin();
+         iPFCand != theInitialPFCands.end();
+         iPFCand++) {
+      if (std::abs((*iPFCand)->pdgId()) == 22) {
+        // *** Whether the gamma candidate will be selected or not depends on its rec. ECAL cluster properties.
+        if ((**iPFCand).et() >= GammaCand_EcalclusMinEt) {
+          filteredPFGammaCands.push_back(*iPFCand);
+        }
       }
     }
     return filteredPFGammaCands;
   }
 
-}
+}  // namespace tautagtools

--- a/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
+++ b/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
@@ -6,87 +6,96 @@
 
 #include <TMath.h>
 
-namespace reco { namespace tau {
+namespace reco {
+  namespace tau {
 
-const reco::Track* getTrackFromChargedHadron(const reco::PFRecoTauChargedHadron& chargedHadron) {
-  // Charged hadron made from track (reco::Track) - RECO/AOD only
-  if ( chargedHadron.getTrack().isNonnull()) {
-    return chargedHadron.getTrack().get();
-  }
-  // In MiniAOD, even isolated tracks are saved as candidates, so the track Ptr doesn't exist
-  const pat::PackedCandidate* chargedPFPCand = dynamic_cast<const pat::PackedCandidate*> (chargedHadron.getChargedPFCandidate().get());
-  if (chargedPFPCand != nullptr) {
-    return chargedPFPCand->bestTrack();
-  }
-  const pat::PackedCandidate* lostTrackCand = dynamic_cast<const pat::PackedCandidate*> (chargedHadron.getLostTrackCandidate().get());
-  if (lostTrackCand != nullptr) {
-    return lostTrackCand->bestTrack();
-  }
-  return nullptr;
-}
-  
-void setChargedHadronP4(reco::PFRecoTauChargedHadron& chargedHadron, double scaleFactor_neutralPFCands)
-{
-  double chargedHadronP  = 0.;
-  double chargedHadronPx = 0.;
-  double chargedHadronPy = 0.;
-  double chargedHadronPz = 0.;
-  double SumNeutrals = 0.;
-  if ( chargedHadron.algoIs(reco::PFRecoTauChargedHadron::kChargedPFCandidate) ||
-       chargedHadron.algoIs(reco::PFRecoTauChargedHadron::kPFNeutralHadron)   ) {
-    const reco::CandidatePtr& chargedPFCand = chargedHadron.getChargedPFCandidate();
-    assert(chargedPFCand.isNonnull());
-    chargedHadronP     += chargedPFCand->p();
-    chargedHadronPx     = chargedPFCand->px();
-    chargedHadronPy     = chargedPFCand->py();
-    chargedHadronPz     = chargedPFCand->pz();
-  } else if ( chargedHadron.algoIs(reco::PFRecoTauChargedHadron::kTrack) ) {
-    const reco::Track* track = getTrackFromChargedHadron(chargedHadron);
-    if (track != nullptr) {
-      chargedHadronP     += track->p();
-      chargedHadronPx     = track->px();
-      chargedHadronPy     = track->py();
-      chargedHadronPz     = track->pz();
-    } else { // lost tracks from MiniAOD that don't have track information saved
-      const reco::CandidatePtr& lostTrack = chargedHadron.getLostTrackCandidate();
-      assert(lostTrack.isNonnull());
-      chargedHadronP     += lostTrack->p();
-      chargedHadronPx     = lostTrack->px();
-      chargedHadronPy     = lostTrack->py();
-      chargedHadronPz     = lostTrack->pz();
+    const reco::Track* getTrackFromChargedHadron(const reco::PFRecoTauChargedHadron& chargedHadron) {
+      // Charged hadron made from track (reco::Track) - RECO/AOD only
+      if (chargedHadron.getTrack().isNonnull()) {
+        return chargedHadron.getTrack().get();
+      }
+      // In MiniAOD, even isolated tracks are saved as candidates, so the track Ptr doesn't exist
+      const pat::PackedCandidate* chargedPFPCand =
+          dynamic_cast<const pat::PackedCandidate*>(chargedHadron.getChargedPFCandidate().get());
+      if (chargedPFPCand != nullptr) {
+        return chargedPFPCand->bestTrack();
+      }
+      const pat::PackedCandidate* lostTrackCand =
+          dynamic_cast<const pat::PackedCandidate*>(chargedHadron.getLostTrackCandidate().get());
+      if (lostTrackCand != nullptr) {
+        return lostTrackCand->bestTrack();
+      }
+      return nullptr;
     }
-  } else assert(0);
-  const std::vector<reco::CandidatePtr>& neutralPFCands = chargedHadron.getNeutralPFCandidates();
-  for ( std::vector<reco::CandidatePtr>::const_iterator neutralPFCand = neutralPFCands.begin();
-	neutralPFCand != neutralPFCands.end(); ++neutralPFCand ) {
-    SumNeutrals += (*neutralPFCand)->p();
-  }
-  double noNeutrals=chargedHadronP;
-  chargedHadronP+=scaleFactor_neutralPFCands*SumNeutrals;
-  double ptRatio=chargedHadronP/noNeutrals;
-  chargedHadronPx*=ptRatio;
-  chargedHadronPy*=ptRatio;
-  chargedHadronPz*=ptRatio;
-  
-      
-  reco::Candidate::LorentzVector chargedHadronP4 = compChargedHadronP4fromPxPyPz(chargedHadronPx, chargedHadronPy, chargedHadronPz);
-  chargedHadron.setP4(chargedHadronP4);
-}
 
-reco::Candidate::LorentzVector compChargedHadronP4fromPxPyPz(double chargedHadronPx, double chargedHadronPy, double chargedHadronPz)
-{
-  const double chargedPionMass = 0.13957; // GeV  
-  double chargedHadronEn = sqrt(chargedHadronPx*chargedHadronPx + chargedHadronPy*chargedHadronPy + chargedHadronPz*chargedHadronPz + chargedPionMass*chargedPionMass);  
-  reco::Candidate::LorentzVector chargedHadronP4(chargedHadronPx, chargedHadronPy, chargedHadronPz, chargedHadronEn);
-  return chargedHadronP4;
-}
+    void setChargedHadronP4(reco::PFRecoTauChargedHadron& chargedHadron, double scaleFactor_neutralPFCands) {
+      double chargedHadronP = 0.;
+      double chargedHadronPx = 0.;
+      double chargedHadronPy = 0.;
+      double chargedHadronPz = 0.;
+      double SumNeutrals = 0.;
+      if (chargedHadron.algoIs(reco::PFRecoTauChargedHadron::kChargedPFCandidate) ||
+          chargedHadron.algoIs(reco::PFRecoTauChargedHadron::kPFNeutralHadron)) {
+        const reco::CandidatePtr& chargedPFCand = chargedHadron.getChargedPFCandidate();
+        assert(chargedPFCand.isNonnull());
+        chargedHadronP += chargedPFCand->p();
+        chargedHadronPx = chargedPFCand->px();
+        chargedHadronPy = chargedPFCand->py();
+        chargedHadronPz = chargedPFCand->pz();
+      } else if (chargedHadron.algoIs(reco::PFRecoTauChargedHadron::kTrack)) {
+        const reco::Track* track = getTrackFromChargedHadron(chargedHadron);
+        if (track != nullptr) {
+          chargedHadronP += track->p();
+          chargedHadronPx = track->px();
+          chargedHadronPy = track->py();
+          chargedHadronPz = track->pz();
+        } else {  // lost tracks from MiniAOD that don't have track information saved
+          const reco::CandidatePtr& lostTrack = chargedHadron.getLostTrackCandidate();
+          assert(lostTrack.isNonnull());
+          chargedHadronP += lostTrack->p();
+          chargedHadronPx = lostTrack->px();
+          chargedHadronPy = lostTrack->py();
+          chargedHadronPz = lostTrack->pz();
+        }
+      } else
+        assert(0);
+      const std::vector<reco::CandidatePtr>& neutralPFCands = chargedHadron.getNeutralPFCandidates();
+      for (std::vector<reco::CandidatePtr>::const_iterator neutralPFCand = neutralPFCands.begin();
+           neutralPFCand != neutralPFCands.end();
+           ++neutralPFCand) {
+        SumNeutrals += (*neutralPFCand)->p();
+      }
+      double noNeutrals = chargedHadronP;
+      chargedHadronP += scaleFactor_neutralPFCands * SumNeutrals;
+      double ptRatio = chargedHadronP / noNeutrals;
+      chargedHadronPx *= ptRatio;
+      chargedHadronPy *= ptRatio;
+      chargedHadronPz *= ptRatio;
 
-reco::Candidate::LorentzVector compChargedHadronP4fromPThetaPhi(double chargedHadronP, double chargedHadronTheta, double chargedHadronPhi)
-{
-  double chargedHadronPx = chargedHadronP*TMath::Cos(chargedHadronPhi)*TMath::Sin(chargedHadronTheta);
-  double chargedHadronPy = chargedHadronP*TMath::Sin(chargedHadronPhi)*TMath::Sin(chargedHadronTheta);
-  double chargedHadronPz = chargedHadronP*TMath::Cos(chargedHadronTheta);    
-  return compChargedHadronP4fromPxPyPz(chargedHadronPx, chargedHadronPy, chargedHadronPz);
-}
+      reco::Candidate::LorentzVector chargedHadronP4 =
+          compChargedHadronP4fromPxPyPz(chargedHadronPx, chargedHadronPy, chargedHadronPz);
+      chargedHadron.setP4(chargedHadronP4);
+    }
 
-}} // end namespace reco::tau
+    reco::Candidate::LorentzVector compChargedHadronP4fromPxPyPz(double chargedHadronPx,
+                                                                 double chargedHadronPy,
+                                                                 double chargedHadronPz) {
+      const double chargedPionMass = 0.13957;  // GeV
+      double chargedHadronEn = sqrt(chargedHadronPx * chargedHadronPx + chargedHadronPy * chargedHadronPy +
+                                    chargedHadronPz * chargedHadronPz + chargedPionMass * chargedPionMass);
+      reco::Candidate::LorentzVector chargedHadronP4(
+          chargedHadronPx, chargedHadronPy, chargedHadronPz, chargedHadronEn);
+      return chargedHadronP4;
+    }
+
+    reco::Candidate::LorentzVector compChargedHadronP4fromPThetaPhi(double chargedHadronP,
+                                                                    double chargedHadronTheta,
+                                                                    double chargedHadronPhi) {
+      double chargedHadronPx = chargedHadronP * TMath::Cos(chargedHadronPhi) * TMath::Sin(chargedHadronTheta);
+      double chargedHadronPy = chargedHadronP * TMath::Sin(chargedHadronPhi) * TMath::Sin(chargedHadronTheta);
+      double chargedHadronPz = chargedHadronP * TMath::Cos(chargedHadronTheta);
+      return compChargedHadronP4fromPxPyPz(chargedHadronPx, chargedHadronPy, chargedHadronPz);
+    }
+
+  }  // namespace tau
+}  // namespace reco

--- a/RecoTauTag/RecoTau/test/CombinatoricGenerator_t.cppunit.cc
+++ b/RecoTauTag/RecoTau/test/CombinatoricGenerator_t.cppunit.cc
@@ -12,21 +12,18 @@ typedef std::pair<vint, vint> ComboRemainder;
 // a list of the combo + remaining items
 typedef std::vector<ComboRemainder> VComboRemainder;
 
-template<typename G>
+template <typename G>
 VComboRemainder getAllCombinations(G& generator) {
   VComboRemainder output;
   typedef typename G::iterator iterator;
   typedef typename G::combo_iterator combo_iterator;
-  for (iterator combo = generator.begin(); combo != generator.end();
-      ++combo) {
+  for (iterator combo = generator.begin(); combo != generator.end(); ++combo) {
     ComboRemainder thisCombo;
-    for (combo_iterator item = combo->combo_begin();
-        item != combo->combo_end(); ++item) {
+    for (combo_iterator item = combo->combo_begin(); item != combo->combo_end(); ++item) {
       thisCombo.first.push_back(*item);
     }
 
-    for (combo_iterator item = combo->remainder_begin();
-        item != combo->remainder_end(); ++item) {
+    for (combo_iterator item = combo->remainder_begin(); item != combo->remainder_end(); ++item) {
       thisCombo.second.push_back(*item);
     }
 
@@ -42,91 +39,89 @@ class testCombGenerator : public CppUnit::TestFixture {
   CPPUNIT_TEST(testNormalBehavior);
   CPPUNIT_TEST_SUITE_END();
 
-  public:
+public:
+  void setup() {}
+  typedef reco::tau::CombinatoricGenerator<vint> Generator;
 
-     void setup() {}
-     typedef reco::tau::CombinatoricGenerator<vint> Generator;
+  void testNormalBehavior() {
+    std::cout << "Testing normal behavior" << std::endl;
+    vint toCombize;
+    toCombize.push_back(1);
+    toCombize.push_back(2);
+    toCombize.push_back(3);
+    toCombize.push_back(4);
 
-     void testNormalBehavior() {
-       std::cout << "Testing normal behavior" << std::endl;
-       vint toCombize;
-       toCombize.push_back(1);
-       toCombize.push_back(2);
-       toCombize.push_back(3);
-       toCombize.push_back(4);
+    Generator pairGenerator(toCombize.begin(), toCombize.end(), 2);
 
-       Generator pairGenerator(toCombize.begin(), toCombize.end(), 2);
+    VComboRemainder pairResults = getAllCombinations(pairGenerator);
 
-       VComboRemainder pairResults = getAllCombinations(pairGenerator);
+    // 4 choose 2 = 6
 
-       // 4 choose 2 = 6
+    CPPUNIT_ASSERT(pairResults.size() == 6);
 
-       CPPUNIT_ASSERT(pairResults.size() == 6);
+    ComboRemainder firstExpResult;
+    firstExpResult.first.push_back(1);
+    firstExpResult.first.push_back(2);
+    firstExpResult.second.push_back(3);
+    firstExpResult.second.push_back(4);
 
-       ComboRemainder firstExpResult;
-       firstExpResult.first.push_back(1);
-       firstExpResult.first.push_back(2);
-       firstExpResult.second.push_back(3);
-       firstExpResult.second.push_back(4);
+    CPPUNIT_ASSERT(firstExpResult == pairResults[0]);
 
-       CPPUNIT_ASSERT(firstExpResult == pairResults[0]);
+    ComboRemainder secondExpResult;
+    secondExpResult.first.push_back(1);
+    secondExpResult.first.push_back(3);
+    secondExpResult.second.push_back(2);
+    secondExpResult.second.push_back(4);
 
-       ComboRemainder secondExpResult;
-       secondExpResult.first.push_back(1);
-       secondExpResult.first.push_back(3);
-       secondExpResult.second.push_back(2);
-       secondExpResult.second.push_back(4);
+    CPPUNIT_ASSERT(secondExpResult == pairResults[1]);
 
-       CPPUNIT_ASSERT(secondExpResult == pairResults[1]);
+    ComboRemainder lastExpResult;
+    lastExpResult.first.push_back(3);
+    lastExpResult.first.push_back(4);
+    lastExpResult.second.push_back(1);
+    lastExpResult.second.push_back(2);
 
-       ComboRemainder lastExpResult;
-       lastExpResult.first.push_back(3);
-       lastExpResult.first.push_back(4);
-       lastExpResult.second.push_back(1);
-       lastExpResult.second.push_back(2);
+    Generator tripletGen(toCombize.begin(), toCombize.end(), 3);
 
-       Generator tripletGen(toCombize.begin(), toCombize.end(), 3);
+    VComboRemainder tripletResults = getAllCombinations(tripletGen);
+    CPPUNIT_ASSERT(tripletResults.size() == 4);
 
-       VComboRemainder tripletResults = getAllCombinations(tripletGen);
-       CPPUNIT_ASSERT(tripletResults.size() == 4);
+    // This one should have only one combinatoric
+    Generator quadGen(toCombize.begin(), toCombize.end(), 4);
+    VComboRemainder quadResults = getAllCombinations(quadGen);
+    CPPUNIT_ASSERT(quadResults.size() == 1);
+    // All should be in the combinatoric, none in the remainder
+    CPPUNIT_ASSERT(quadResults[0].first.size() == 4);
+    CPPUNIT_ASSERT(quadResults[0].second.size() == 0);
+  };
 
-       // This one should have only one combinatoric
-       Generator quadGen(toCombize.begin(), toCombize.end(), 4);
-       VComboRemainder quadResults = getAllCombinations(quadGen);
-       CPPUNIT_ASSERT(quadResults.size() == 1);
-       // All should be in the combinatoric, none in the remainder
-       CPPUNIT_ASSERT(quadResults[0].first.size() == 4);
-       CPPUNIT_ASSERT(quadResults[0].second.size() == 0);
-     };
+  void testLessThanDesiredCollection() {
+    std::cout << "Testing less than behavior" << std::endl;
+    vint toCombize;
+    toCombize.push_back(1);
+    toCombize.push_back(2);
 
-     void testLessThanDesiredCollection() {
-       std::cout << "Testing less than behavior" << std::endl;
-       vint toCombize;
-       toCombize.push_back(1);
-       toCombize.push_back(2);
+    Generator tripletGen(toCombize.begin(), toCombize.end(), 3);
+    VComboRemainder tripletResults = getAllCombinations(tripletGen);
+    // Can't make any combos - 2 choose 3 doesn't make sense.
+    CPPUNIT_ASSERT(tripletResults.size() == 0);
+  }
 
-       Generator tripletGen(toCombize.begin(), toCombize.end(), 3);
-       VComboRemainder tripletResults = getAllCombinations(tripletGen);
-       // Can't make any combos - 2 choose 3 doesn't make sense.
-       CPPUNIT_ASSERT(tripletResults.size() == 0);
-     }
+  void testEmptyCollection() {
+    std::cout << "Testing empty collection" << std::endl;
+    // A requested empty collection should return 1 empty combo
+    vint toCombize;
+    toCombize.push_back(1);
+    toCombize.push_back(2);
+    toCombize.push_back(3);
+    toCombize.push_back(4);
 
-     void testEmptyCollection() {
-       std::cout << "Testing empty collection" << std::endl;
-       // A requested empty collection should return 1 empty combo
-       vint toCombize;
-       toCombize.push_back(1);
-       toCombize.push_back(2);
-       toCombize.push_back(3);
-       toCombize.push_back(4);
-
-       Generator zeroGen(toCombize.begin(), toCombize.end(), 0);
-       VComboRemainder zeroResults = getAllCombinations(zeroGen);
-       CPPUNIT_ASSERT(zeroResults.size() == 1);
-       CPPUNIT_ASSERT(zeroResults[0].first.size() == 0);
-       CPPUNIT_ASSERT(zeroResults[0].second.size() == 4);
-     }
-
+    Generator zeroGen(toCombize.begin(), toCombize.end(), 0);
+    VComboRemainder zeroResults = getAllCombinations(zeroGen);
+    CPPUNIT_ASSERT(zeroResults.size() == 1);
+    CPPUNIT_ASSERT(zeroResults[0].first.size() == 0);
+    CPPUNIT_ASSERT(zeroResults[0].second.size() == 4);
+  }
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testCombGenerator);

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.cc
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.cc
@@ -2,7 +2,7 @@
 //
 // Package:    RecoTauTag/RecoTau/rerunMVAIsolationOnMiniAOD
 // Class:      rerunMVAIsolationOnMiniAOD
-// 
+//
 /**\class rerunMVAIsolationOnMiniAOD rerunMVAIsolationOnMiniAOD.cc RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Wed, 30 Mar 2016 13:39:51 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -56,82 +55,83 @@
 // constructor "usesResource("TFileService");"
 // This will improve performance in multithreaded jobs.
 
-typedef edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> > PFTauTIPAssociationByRef;
+typedef edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> >
+    PFTauTIPAssociationByRef;
 
-class rerunMVAIsolationOnMiniAOD : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
-   public:
-      explicit rerunMVAIsolationOnMiniAOD(const edm::ParameterSet&);
-      ~rerunMVAIsolationOnMiniAOD();
+class rerunMVAIsolationOnMiniAOD : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit rerunMVAIsolationOnMiniAOD(const edm::ParameterSet&);
+  ~rerunMVAIsolationOnMiniAOD();
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+private:
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
-      // ----------member data ---------------------------
-      bool verbosity_;
-      bool additionalCollectionsAvailable_;
+  // ----------member data ---------------------------
+  bool verbosity_;
+  bool additionalCollectionsAvailable_;
 
-      edm::EDGetTokenT<pat::TauCollection> tauToken_;
-      edm::EDGetTokenT<reco::PFTauCollection> pfTauToken_;
-      edm::EDGetTokenT<reco::PFTauDiscriminator> dmfNewToken_;
-      edm::EDGetTokenT<reco::PFTauDiscriminator> chargedIsoPtSumToken_;
-      edm::EDGetTokenT<reco::PFTauDiscriminator> neutralIsoPtSumToken_;
-      edm::EDGetTokenT<reco::PFTauDiscriminator> puCorrPtSumToken_;
-      edm::EDGetTokenT<reco::PFTauDiscriminator> photonPtSumOutsideSignalConeToken_;
-      edm::EDGetTokenT<reco::PFTauDiscriminator> footprintCorrectionToken_;
-      edm::EDGetTokenT<reco::PFTauDiscriminator> rawElecMVA6Token_;
-      edm::EDGetTokenT<PFTauTIPAssociationByRef> tauTIPToken_;
+  edm::EDGetTokenT<pat::TauCollection> tauToken_;
+  edm::EDGetTokenT<reco::PFTauCollection> pfTauToken_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> dmfNewToken_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> chargedIsoPtSumToken_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> neutralIsoPtSumToken_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> puCorrPtSumToken_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> photonPtSumOutsideSignalConeToken_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> footprintCorrectionToken_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> rawElecMVA6Token_;
+  edm::EDGetTokenT<PFTauTIPAssociationByRef> tauTIPToken_;
 
-      TH1D* mvaValueAOD;
-      TH1D* mvaValueMiniAOD;
-      TH1D* mvaValueDiff;
+  TH1D* mvaValueAOD;
+  TH1D* mvaValueMiniAOD;
+  TH1D* mvaValueDiff;
 
-      TH1D* differences;
-      TH1D* differencesWeighted;
+  TH1D* differences;
+  TH1D* differencesWeighted;
 
-      TH1D* difference_dxy;
-      TH1D* difference_dxySig;
-      TH1D* difference_ip3d;
-      TH1D* difference_ip3dSig;
-      TH1D* difference_flightlengthSig;
-      TH1D* difference_ptWeightedDetaStrip;
-      TH1D* difference_ptWeightedDphiStrip;
-      TH1D* difference_ptWeightedDrSignal;
-      TH1D* difference_ptWeightedDrIso;
+  TH1D* difference_dxy;
+  TH1D* difference_dxySig;
+  TH1D* difference_ip3d;
+  TH1D* difference_ip3dSig;
+  TH1D* difference_flightlengthSig;
+  TH1D* difference_ptWeightedDetaStrip;
+  TH1D* difference_ptWeightedDphiStrip;
+  TH1D* difference_ptWeightedDrSignal;
+  TH1D* difference_ptWeightedDrIso;
 
-      TH2D* mvaValue;
-      TH2D* mvaValue_vLoose;
-      TH2D* mvaValue_Loose;
-      TH2D* mvaValue_Medium;
-      TH2D* mvaValue_Tight;
-      TH2D* mvaValue_vTight;
-      TH2D* mvaValue_vvTight;
+  TH2D* mvaValue;
+  TH2D* mvaValue_vLoose;
+  TH2D* mvaValue_Loose;
+  TH2D* mvaValue_Medium;
+  TH2D* mvaValue_Tight;
+  TH2D* mvaValue_vTight;
+  TH2D* mvaValue_vvTight;
 
-      TH2D* decayMode;
-      TH2D* chargedIsoPtSum;
-      TH2D* neutralIsoPtSum;
-      TH2D* puCorrPtSum;
-      TH2D* photonPtSumOutsideSignalCone;
-      TH2D* footprintCorrection;
+  TH2D* decayMode;
+  TH2D* chargedIsoPtSum;
+  TH2D* neutralIsoPtSum;
+  TH2D* puCorrPtSum;
+  TH2D* photonPtSumOutsideSignalCone;
+  TH2D* footprintCorrection;
 
-      TH2D* decayDistMag;
-      TH2D* dxy;
-      TH2D* dxySig;
-      TH2D* ip3d;
-      TH2D* ip3dSig;
-      TH2D* hasSV;
-      TH2D* flightlengthSig;
-      TH2D* nPhoton;
-      TH2D* ptWeightedDetaStrip;
-      TH2D* ptWeightedDphiStrip;
-      TH2D* ptWeightedDrSignal;
-      TH2D* ptWeightedDrIsolation;
-      TH2D* leadTrackChi2;
-      TH2D* eRatio;
-      TH2D* mvaValue_antiEMVA6;
+  TH2D* decayDistMag;
+  TH2D* dxy;
+  TH2D* dxySig;
+  TH2D* ip3d;
+  TH2D* ip3dSig;
+  TH2D* hasSV;
+  TH2D* flightlengthSig;
+  TH2D* nPhoton;
+  TH2D* ptWeightedDetaStrip;
+  TH2D* ptWeightedDphiStrip;
+  TH2D* ptWeightedDrSignal;
+  TH2D* ptWeightedDrIsolation;
+  TH2D* leadTrackChi2;
+  TH2D* eRatio;
+  TH2D* mvaValue_antiEMVA6;
 };
 
 //
@@ -148,349 +148,485 @@ class rerunMVAIsolationOnMiniAOD : public edm::one::EDAnalyzer<edm::one::SharedR
 rerunMVAIsolationOnMiniAOD::rerunMVAIsolationOnMiniAOD(const edm::ParameterSet& iConfig)
 
 {
-   //now do what ever initialization is needed
-   tauToken_ = consumes<pat::TauCollection>(edm::InputTag("newTauIDsEmbedded"));
-   pfTauToken_ = consumes<reco::PFTauCollection>(edm::InputTag("hpsPFTauProducer","","PAT"));
-   dmfNewToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauDiscriminationByDecayModeFindingNewDMs","","PAT"));
-   chargedIsoPtSumToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauChargedIsoPtSum","","PAT"));
-   neutralIsoPtSumToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauNeutralIsoPtSum","","PAT"));
-   puCorrPtSumToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauPUcorrPtSum","","PAT"));
-   photonPtSumOutsideSignalConeToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauPhotonPtSumOutsideSignalCone","","PAT"));
-   footprintCorrectionToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauFootprintCorrection","","PAT"));
-   rawElecMVA6Token_    = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauDiscriminationagainstElectronMVA6Raw","","RECO"));
-   tauTIPToken_ = consumes<PFTauTIPAssociationByRef>(edm::InputTag("hpsPFTauTransverseImpactParameters","","PAT"));
+  //now do what ever initialization is needed
+  tauToken_ = consumes<pat::TauCollection>(edm::InputTag("newTauIDsEmbedded"));
+  pfTauToken_ = consumes<reco::PFTauCollection>(edm::InputTag("hpsPFTauProducer", "", "PAT"));
+  dmfNewToken_ =
+      consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauDiscriminationByDecayModeFindingNewDMs", "", "PAT"));
+  chargedIsoPtSumToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauChargedIsoPtSum", "", "PAT"));
+  neutralIsoPtSumToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauNeutralIsoPtSum", "", "PAT"));
+  puCorrPtSumToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauPUcorrPtSum", "", "PAT"));
+  photonPtSumOutsideSignalConeToken_ =
+      consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauPhotonPtSumOutsideSignalCone", "", "PAT"));
+  footprintCorrectionToken_ =
+      consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauFootprintCorrection", "", "PAT"));
+  rawElecMVA6Token_ =
+      consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauDiscriminationagainstElectronMVA6Raw", "", "RECO"));
+  tauTIPToken_ = consumes<PFTauTIPAssociationByRef>(edm::InputTag("hpsPFTauTransverseImpactParameters", "", "PAT"));
 
-   verbosity_ = iConfig.getParameter<int>("verbosity");
-   additionalCollectionsAvailable_ = iConfig.getParameter<bool>("additionalCollectionsAvailable");
+  verbosity_ = iConfig.getParameter<int>("verbosity");
+  additionalCollectionsAvailable_ = iConfig.getParameter<bool>("additionalCollectionsAvailable");
 
-   // book histograms
-   edm::Service<TFileService> fileService;
-   mvaValueAOD = fileService->make<TH1D>("mvaValueAOD",";MVA value;",220,-1.1,1.1);
-   mvaValueMiniAOD = fileService->make<TH1D>("mvaValueMiniAOD",";MVA value;",220,-1.1,1.1);
-   mvaValueDiff = fileService->make<TH1D>("mvaValueDiff",";|AOD - MiniAOD|;",2000,0,2);
+  // book histograms
+  edm::Service<TFileService> fileService;
+  mvaValueAOD = fileService->make<TH1D>("mvaValueAOD", ";MVA value;", 220, -1.1, 1.1);
+  mvaValueMiniAOD = fileService->make<TH1D>("mvaValueMiniAOD", ";MVA value;", 220, -1.1, 1.1);
+  mvaValueDiff = fileService->make<TH1D>("mvaValueDiff", ";|AOD - MiniAOD|;", 2000, 0, 2);
 
-   differences = fileService->make<TH1D>("differences","",24,-0.5,23.5);
-   differencesWeighted = fileService->make<TH1D>("differencesWeighted","",24,-0.5,23.5);
+  differences = fileService->make<TH1D>("differences", "", 24, -0.5, 23.5);
+  differencesWeighted = fileService->make<TH1D>("differencesWeighted", "", 24, -0.5, 23.5);
 
-   difference_dxy = fileService->make<TH1D>("difference_dxy",";|AOD - MiniAOD| (dxy);",1000,0,0.0005);
-   difference_dxySig = fileService->make<TH1D>("difference_dxySig",";|AOD - MiniAOD| (dxySig);",1000,0,0.0005);
-   difference_ip3d = fileService->make<TH1D>("difference_ip3d",";|AOD - MiniAOD| (ip3d);",1000,0,0.0005);
-   difference_ip3dSig = fileService->make<TH1D>("difference_ip3dSig",";|AOD - MiniAOD| (ip3dSig);",1000,0,0.0005);
-   difference_flightlengthSig = fileService->make<TH1D>("difference_flightlengthSig",";|AOD - MiniAOD| (flightlengthSig);",1000,0,0.0005);
-   difference_ptWeightedDetaStrip = fileService->make<TH1D>("difference_ptWeightedDetaStrip",";|AOD - MiniAOD| (ptWeightedDetaStrip);",1000,0,0.0005);
-   difference_ptWeightedDphiStrip = fileService->make<TH1D>("difference_ptWeightedDphiStrip",";|AOD - MiniAOD| (ptWeightedDphiStrip);",1000,0,0.0005);
-   difference_ptWeightedDrSignal = fileService->make<TH1D>("difference_ptWeightedDrSignal",";|AOD - MiniAOD| (ptWeightedDrSignal);",1000,0,0.0005);
-   difference_ptWeightedDrIso = fileService->make<TH1D>("difference_ptWeightedDrIso",";|AOD - MiniAOD| (ptWeightedDrIso);",1000,0,0.0005);
+  difference_dxy = fileService->make<TH1D>("difference_dxy", ";|AOD - MiniAOD| (dxy);", 1000, 0, 0.0005);
+  difference_dxySig = fileService->make<TH1D>("difference_dxySig", ";|AOD - MiniAOD| (dxySig);", 1000, 0, 0.0005);
+  difference_ip3d = fileService->make<TH1D>("difference_ip3d", ";|AOD - MiniAOD| (ip3d);", 1000, 0, 0.0005);
+  difference_ip3dSig = fileService->make<TH1D>("difference_ip3dSig", ";|AOD - MiniAOD| (ip3dSig);", 1000, 0, 0.0005);
+  difference_flightlengthSig =
+      fileService->make<TH1D>("difference_flightlengthSig", ";|AOD - MiniAOD| (flightlengthSig);", 1000, 0, 0.0005);
+  difference_ptWeightedDetaStrip = fileService->make<TH1D>(
+      "difference_ptWeightedDetaStrip", ";|AOD - MiniAOD| (ptWeightedDetaStrip);", 1000, 0, 0.0005);
+  difference_ptWeightedDphiStrip = fileService->make<TH1D>(
+      "difference_ptWeightedDphiStrip", ";|AOD - MiniAOD| (ptWeightedDphiStrip);", 1000, 0, 0.0005);
+  difference_ptWeightedDrSignal = fileService->make<TH1D>(
+      "difference_ptWeightedDrSignal", ";|AOD - MiniAOD| (ptWeightedDrSignal);", 1000, 0, 0.0005);
+  difference_ptWeightedDrIso =
+      fileService->make<TH1D>("difference_ptWeightedDrIso", ";|AOD - MiniAOD| (ptWeightedDrIso);", 1000, 0, 0.0005);
 
-   mvaValue = fileService->make<TH2D>("mvaValue",";AOD;MiniAOD",220,-1.1,1.1,220,-1.1,1.1);
-   mvaValue_vLoose = fileService->make<TH2D>("mvaValue_vLoose",";AOD;MiniAOD",2,-0.5,1.5,2,-0.5,1.5);
-   mvaValue_Loose = fileService->make<TH2D>("mvaValue_Loose",";AOD;MiniAOD",2,-0.5,1.5,2,-0.5,1.5);
-   mvaValue_Medium = fileService->make<TH2D>("mvaValue_Medium",";AOD;MiniAOD",2,-0.5,1.5,2,-0.5,1.5);
-   mvaValue_Tight = fileService->make<TH2D>("mvaValue_Tight",";AOD;MiniAOD",2,-0.5,1.5,2,-0.5,1.5);
-   mvaValue_vTight = fileService->make<TH2D>("mvaValue_vTight",";AOD;MiniAOD",2,-0.5,1.5,2,-0.5,1.5);
-   mvaValue_vvTight = fileService->make<TH2D>("mvaValue_vvTight",";AOD;MiniAOD",2,-0.5,1.5,2,-0.5,1.5);
+  mvaValue = fileService->make<TH2D>("mvaValue", ";AOD;MiniAOD", 220, -1.1, 1.1, 220, -1.1, 1.1);
+  mvaValue_vLoose = fileService->make<TH2D>("mvaValue_vLoose", ";AOD;MiniAOD", 2, -0.5, 1.5, 2, -0.5, 1.5);
+  mvaValue_Loose = fileService->make<TH2D>("mvaValue_Loose", ";AOD;MiniAOD", 2, -0.5, 1.5, 2, -0.5, 1.5);
+  mvaValue_Medium = fileService->make<TH2D>("mvaValue_Medium", ";AOD;MiniAOD", 2, -0.5, 1.5, 2, -0.5, 1.5);
+  mvaValue_Tight = fileService->make<TH2D>("mvaValue_Tight", ";AOD;MiniAOD", 2, -0.5, 1.5, 2, -0.5, 1.5);
+  mvaValue_vTight = fileService->make<TH2D>("mvaValue_vTight", ";AOD;MiniAOD", 2, -0.5, 1.5, 2, -0.5, 1.5);
+  mvaValue_vvTight = fileService->make<TH2D>("mvaValue_vvTight", ";AOD;MiniAOD", 2, -0.5, 1.5, 2, -0.5, 1.5);
 
-   decayMode = fileService->make<TH2D>("decayMode",";decay mode (AOD);decay mode (MiniAOD)",12,-0.5,11.5,12,-0.5,11.5);
-   chargedIsoPtSum = fileService->make<TH2D>("chargedIsoPtSum",";chargedIsoPtSum (AOD);chargedIsoPtSum (MiniAOD)",500,0,50,500,0,50);
-   neutralIsoPtSum = fileService->make<TH2D>("neutralIsoPtSum",";neutralIsoPtSum (AOD);neutralIsoPtSum (MiniAOD)",500,0,50,500,0,50);
-   puCorrPtSum = fileService->make<TH2D>("puCorrPtSum",";puCorrPtSum (AOD);puCorrPtSum (MiniAOD)",500,0,50,500,0,50);
-   photonPtSumOutsideSignalCone = fileService->make<TH2D>("photonPtSumOutsideSignalCone",";photonPtSumOutsideSignalCone (AOD);photonPtSumOutsideSignalCone (MiniAOD)",500,0,50,500,0,50);
-   footprintCorrection = fileService->make<TH2D>("footprintCorrection",";footprintCorrection (AOD);footprintCorrection (MiniAOD)",500,0,50,500,0,50);
+  decayMode =
+      fileService->make<TH2D>("decayMode", ";decay mode (AOD);decay mode (MiniAOD)", 12, -0.5, 11.5, 12, -0.5, 11.5);
+  chargedIsoPtSum = fileService->make<TH2D>(
+      "chargedIsoPtSum", ";chargedIsoPtSum (AOD);chargedIsoPtSum (MiniAOD)", 500, 0, 50, 500, 0, 50);
+  neutralIsoPtSum = fileService->make<TH2D>(
+      "neutralIsoPtSum", ";neutralIsoPtSum (AOD);neutralIsoPtSum (MiniAOD)", 500, 0, 50, 500, 0, 50);
+  puCorrPtSum =
+      fileService->make<TH2D>("puCorrPtSum", ";puCorrPtSum (AOD);puCorrPtSum (MiniAOD)", 500, 0, 50, 500, 0, 50);
+  photonPtSumOutsideSignalCone =
+      fileService->make<TH2D>("photonPtSumOutsideSignalCone",
+                              ";photonPtSumOutsideSignalCone (AOD);photonPtSumOutsideSignalCone (MiniAOD)",
+                              500,
+                              0,
+                              50,
+                              500,
+                              0,
+                              50);
+  footprintCorrection = fileService->make<TH2D>(
+      "footprintCorrection", ";footprintCorrection (AOD);footprintCorrection (MiniAOD)", 500, 0, 50, 500, 0, 50);
 
-   decayDistMag = fileService->make<TH2D>("decayDistMag",";decayDistMag (AOD);decayDistMag (MiniAOD)",100,0,10,100,0,10);
-   dxy = fileService->make<TH2D>("dxy",";d_{xy} (AOD);d_{xy} (MiniAOD)",100,0,0.1,100,0,0.1);
-   dxySig = fileService->make<TH2D>("dxySig",";d_{xy} significance (AOD);d_{xy} significance (MiniAOD)",10,-0.5,9.5,10,-0.5,9.5);
-   ip3d = fileService->make<TH2D>("ip3d",";ip3d (AOD);ip3d (MiniAOD)",100,0,10,100,0,10);
-   ip3dSig = fileService->make<TH2D>("ip3dSig",";ip3d significance (AOD);ip3d significance (MiniAOD)",10,-0.5,9.5,10,-0.5,9.5);
-   hasSV = fileService->make<TH2D>("hasSV",";has SV (AOD);has SV (MiniAOD)",2,-0.5,1.5,2,-0.5,1.5);
-   flightlengthSig = fileService->make<TH2D>("flightlengthSig",";flightlength significance (AOD);flightlength significance (MiniAOD)",21,-10.5,10.5,21,-10.5,10.5);
-   nPhoton = fileService->make<TH2D>("nPhoton",";nPhoton (AOD);nPhoton (MiniAOD)",20,-0.5,19.5,20,-0.5,19.5);
-   ptWeightedDetaStrip = fileService->make<TH2D>("ptWeightedDetaStrip",";ptWeightedDetaStrip (AOD);ptWeightedDetaStrip (MiniAOD)",50,0,0.5,50,0,0.5);
-   ptWeightedDphiStrip = fileService->make<TH2D>("ptWeightedDphiStrip",";ptWeightedDphiStrip (AOD);ptWeightedDphiStrip (MiniAOD)",50,0,0.5,50,0,0.5);
-   ptWeightedDrSignal = fileService->make<TH2D>("ptWeightedDrSignal",";ptWeightedDrSignal (AOD);ptWeightedDrSignal (MiniAOD)",50,0,0.5,50,0,0.5);
-   ptWeightedDrIsolation = fileService->make<TH2D>("ptWeightedDrIsolation",";ptWeightedDrIsolation (AOD);ptWeightedDrIsolation (MiniAOD)",50,0,0.5,50,0,0.5);
-   leadTrackChi2 = fileService->make<TH2D>("leadTrackChi2",";leadTrackChi2 (AOD);leadTrackChi2 (MiniAOD)",1000,0,100,1000,0,100);
-   eRatio = fileService->make<TH2D>("eRatio",";eRatio (AOD);eRatio (MiniAOD)",200,0,2,200,0,2);
-   mvaValue_antiEMVA6 = fileService->make<TH2D>("mvaValue_antiEMVA6",";AOD;MiniAOD",220,-1.1,1.1,220,-1.1,1.1);
+  decayDistMag =
+      fileService->make<TH2D>("decayDistMag", ";decayDistMag (AOD);decayDistMag (MiniAOD)", 100, 0, 10, 100, 0, 10);
+  dxy = fileService->make<TH2D>("dxy", ";d_{xy} (AOD);d_{xy} (MiniAOD)", 100, 0, 0.1, 100, 0, 0.1);
+  dxySig = fileService->make<TH2D>(
+      "dxySig", ";d_{xy} significance (AOD);d_{xy} significance (MiniAOD)", 10, -0.5, 9.5, 10, -0.5, 9.5);
+  ip3d = fileService->make<TH2D>("ip3d", ";ip3d (AOD);ip3d (MiniAOD)", 100, 0, 10, 100, 0, 10);
+  ip3dSig = fileService->make<TH2D>(
+      "ip3dSig", ";ip3d significance (AOD);ip3d significance (MiniAOD)", 10, -0.5, 9.5, 10, -0.5, 9.5);
+  hasSV = fileService->make<TH2D>("hasSV", ";has SV (AOD);has SV (MiniAOD)", 2, -0.5, 1.5, 2, -0.5, 1.5);
+  flightlengthSig = fileService->make<TH2D>("flightlengthSig",
+                                            ";flightlength significance (AOD);flightlength significance (MiniAOD)",
+                                            21,
+                                            -10.5,
+                                            10.5,
+                                            21,
+                                            -10.5,
+                                            10.5);
+  nPhoton = fileService->make<TH2D>("nPhoton", ";nPhoton (AOD);nPhoton (MiniAOD)", 20, -0.5, 19.5, 20, -0.5, 19.5);
+  ptWeightedDetaStrip = fileService->make<TH2D>(
+      "ptWeightedDetaStrip", ";ptWeightedDetaStrip (AOD);ptWeightedDetaStrip (MiniAOD)", 50, 0, 0.5, 50, 0, 0.5);
+  ptWeightedDphiStrip = fileService->make<TH2D>(
+      "ptWeightedDphiStrip", ";ptWeightedDphiStrip (AOD);ptWeightedDphiStrip (MiniAOD)", 50, 0, 0.5, 50, 0, 0.5);
+  ptWeightedDrSignal = fileService->make<TH2D>(
+      "ptWeightedDrSignal", ";ptWeightedDrSignal (AOD);ptWeightedDrSignal (MiniAOD)", 50, 0, 0.5, 50, 0, 0.5);
+  ptWeightedDrIsolation = fileService->make<TH2D>(
+      "ptWeightedDrIsolation", ";ptWeightedDrIsolation (AOD);ptWeightedDrIsolation (MiniAOD)", 50, 0, 0.5, 50, 0, 0.5);
+  leadTrackChi2 = fileService->make<TH2D>(
+      "leadTrackChi2", ";leadTrackChi2 (AOD);leadTrackChi2 (MiniAOD)", 1000, 0, 100, 1000, 0, 100);
+  eRatio = fileService->make<TH2D>("eRatio", ";eRatio (AOD);eRatio (MiniAOD)", 200, 0, 2, 200, 0, 2);
+  mvaValue_antiEMVA6 = fileService->make<TH2D>("mvaValue_antiEMVA6", ";AOD;MiniAOD", 220, -1.1, 1.1, 220, -1.1, 1.1);
 }
 
-
-rerunMVAIsolationOnMiniAOD::~rerunMVAIsolationOnMiniAOD()
-{ 
+rerunMVAIsolationOnMiniAOD::~rerunMVAIsolationOnMiniAOD() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-rerunMVAIsolationOnMiniAOD::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-	edm::Handle<pat::TauCollection> taus;
-	iEvent.getByToken(tauToken_,taus);
+void rerunMVAIsolationOnMiniAOD::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<pat::TauCollection> taus;
+  iEvent.getByToken(tauToken_, taus);
 
-	std::vector<pat::TauRef> unmatchedTaus;
+  std::vector<pat::TauRef> unmatchedTaus;
 
-	for(unsigned iTau = 0; iTau < taus->size(); iTau++)
-	{
-		pat::TauRef tau(taus,iTau);
-		float valueAOD = tau->tauID("byIsolationMVArun2v1DBoldDMwLTraw");
-		float valueMiniAOD = tau->tauID("byIsolationMVArun2v1DBoldDMwLTrawNew");//(*mvaIsoRaw)[tau];
+  for (unsigned iTau = 0; iTau < taus->size(); iTau++) {
+    pat::TauRef tau(taus, iTau);
+    float valueAOD = tau->tauID("byIsolationMVArun2v1DBoldDMwLTraw");
+    float valueMiniAOD = tau->tauID("byIsolationMVArun2v1DBoldDMwLTrawNew");  //(*mvaIsoRaw)[tau];
 
-		mvaValueAOD->Fill(valueAOD);
-		mvaValueMiniAOD->Fill(valueMiniAOD);
+    mvaValueAOD->Fill(valueAOD);
+    mvaValueMiniAOD->Fill(valueMiniAOD);
 
-		mvaValue->Fill(valueAOD,valueMiniAOD);
-		mvaValue_vLoose->Fill(tau->tauID("byVLooseIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byVLooseIsolationMVArun2v1DBoldDMwLTNew"));
-		mvaValue_Loose->Fill(tau->tauID("byLooseIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byLooseIsolationMVArun2v1DBoldDMwLTNew"));
-		mvaValue_Medium->Fill(tau->tauID("byMediumIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byMediumIsolationMVArun2v1DBoldDMwLTNew"));
-		mvaValue_Tight->Fill(tau->tauID("byTightIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byTightIsolationMVArun2v1DBoldDMwLTNew"));
-		mvaValue_vTight->Fill(tau->tauID("byVTightIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byVTightIsolationMVArun2v1DBoldDMwLTNew"));
-		mvaValue_vvTight->Fill(tau->tauID("byVVTightIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byVVTightIsolationMVArun2v1DBoldDMwLTNew"));
-		mvaValueDiff->Fill(std::abs(valueAOD - valueMiniAOD));
-                mvaValue_antiEMVA6->Fill(tau->tauID("againstElectronMVA6Raw"), tau->tauID("againstElectronMVA6RawNew"));
+    mvaValue->Fill(valueAOD, valueMiniAOD);
+    mvaValue_vLoose->Fill(tau->tauID("byVLooseIsolationMVArun2v1DBoldDMwLT"),
+                          tau->tauID("byVLooseIsolationMVArun2v1DBoldDMwLTNew"));
+    mvaValue_Loose->Fill(tau->tauID("byLooseIsolationMVArun2v1DBoldDMwLT"),
+                         tau->tauID("byLooseIsolationMVArun2v1DBoldDMwLTNew"));
+    mvaValue_Medium->Fill(tau->tauID("byMediumIsolationMVArun2v1DBoldDMwLT"),
+                          tau->tauID("byMediumIsolationMVArun2v1DBoldDMwLTNew"));
+    mvaValue_Tight->Fill(tau->tauID("byTightIsolationMVArun2v1DBoldDMwLT"),
+                         tau->tauID("byTightIsolationMVArun2v1DBoldDMwLTNew"));
+    mvaValue_vTight->Fill(tau->tauID("byVTightIsolationMVArun2v1DBoldDMwLT"),
+                          tau->tauID("byVTightIsolationMVArun2v1DBoldDMwLTNew"));
+    mvaValue_vvTight->Fill(tau->tauID("byVVTightIsolationMVArun2v1DBoldDMwLT"),
+                           tau->tauID("byVVTightIsolationMVArun2v1DBoldDMwLTNew"));
+    mvaValueDiff->Fill(std::abs(valueAOD - valueMiniAOD));
+    mvaValue_antiEMVA6->Fill(tau->tauID("againstElectronMVA6Raw"), tau->tauID("againstElectronMVA6RawNew"));
 
-		if(valueAOD != valueMiniAOD)
-			unmatchedTaus.push_back(tau);
-	}
+    if (valueAOD != valueMiniAOD)
+      unmatchedTaus.push_back(tau);
+  }
 
-	// for the following code, four additional collections are needed:
-	// - PFTaus
-	// - PFTauTIPAssociationByRef (impact parameter info)
-	// - PFCandidates
-	// - Tracks
+  // for the following code, four additional collections are needed:
+  // - PFTaus
+  // - PFTauTIPAssociationByRef (impact parameter info)
+  // - PFCandidates
+  // - Tracks
 
-	if(additionalCollectionsAvailable_)
-	{
-		edm::Handle<reco::PFTauCollection> pfTaus;
-		iEvent.getByToken(pfTauToken_,pfTaus);
+  if (additionalCollectionsAvailable_) {
+    edm::Handle<reco::PFTauCollection> pfTaus;
+    iEvent.getByToken(pfTauToken_, pfTaus);
 
-		edm::Handle<reco::PFTauDiscriminator> dmfNew;
-		iEvent.getByToken(dmfNewToken_,dmfNew);
+    edm::Handle<reco::PFTauDiscriminator> dmfNew;
+    iEvent.getByToken(dmfNewToken_, dmfNew);
 
-		edm::Handle<reco::PFTauDiscriminator> chargedIso;
-		iEvent.getByToken(chargedIsoPtSumToken_,chargedIso);
+    edm::Handle<reco::PFTauDiscriminator> chargedIso;
+    iEvent.getByToken(chargedIsoPtSumToken_, chargedIso);
 
-		edm::Handle<reco::PFTauDiscriminator> neutralIso;
-		iEvent.getByToken(neutralIsoPtSumToken_,neutralIso);
+    edm::Handle<reco::PFTauDiscriminator> neutralIso;
+    iEvent.getByToken(neutralIsoPtSumToken_, neutralIso);
 
-		edm::Handle<reco::PFTauDiscriminator> puCorr;
-		iEvent.getByToken(puCorrPtSumToken_,puCorr);
+    edm::Handle<reco::PFTauDiscriminator> puCorr;
+    iEvent.getByToken(puCorrPtSumToken_, puCorr);
 
-		edm::Handle<reco::PFTauDiscriminator> photonSumOutsideSignalCone;
-		iEvent.getByToken(photonPtSumOutsideSignalConeToken_,photonSumOutsideSignalCone);
+    edm::Handle<reco::PFTauDiscriminator> photonSumOutsideSignalCone;
+    iEvent.getByToken(photonPtSumOutsideSignalConeToken_, photonSumOutsideSignalCone);
 
-		edm::Handle<reco::PFTauDiscriminator> footPrint;
-		iEvent.getByToken(footprintCorrectionToken_,footPrint);
+    edm::Handle<reco::PFTauDiscriminator> footPrint;
+    iEvent.getByToken(footprintCorrectionToken_, footPrint);
 
-		edm::Handle<PFTauTIPAssociationByRef> tauLifetimeInfos;
-		iEvent.getByToken(tauTIPToken_,tauLifetimeInfos);
+    edm::Handle<PFTauTIPAssociationByRef> tauLifetimeInfos;
+    iEvent.getByToken(tauTIPToken_, tauLifetimeInfos);
 
-		for(unsigned iPFTau = 0; iPFTau < pfTaus->size(); iPFTau++)
-		{
-			reco::PFTauRef pfTau(pfTaus,iPFTau);
+    for (unsigned iPFTau = 0; iPFTau < pfTaus->size(); iPFTau++) {
+      reco::PFTauRef pfTau(pfTaus, iPFTau);
 
-			if((*dmfNew)[pfTau] < 0.5) continue;
+      if ((*dmfNew)[pfTau] < 0.5)
+        continue;
 
-			if((float)pfTau->pt() < 18 || std::abs((float)pfTau->eta()) > 2.3) continue;
+      if ((float)pfTau->pt() < 18 || std::abs((float)pfTau->eta()) > 2.3)
+        continue;
 
-			for(unsigned iTau = 0; iTau < unmatchedTaus.size(); iTau++)
-			{
-				if((float)pfTau->pt() != (float)unmatchedTaus.at(iTau)->pt()) continue;
-				if((float)pfTau->eta() != (float)unmatchedTaus.at(iTau)->eta()) continue;
-				if((float)pfTau->phi() != (float)unmatchedTaus.at(iTau)->phi()) continue;
-				if((float)pfTau->energy() != (float)unmatchedTaus.at(iTau)->energy()) continue;
+      for (unsigned iTau = 0; iTau < unmatchedTaus.size(); iTau++) {
+        if ((float)pfTau->pt() != (float)unmatchedTaus.at(iTau)->pt())
+          continue;
+        if ((float)pfTau->eta() != (float)unmatchedTaus.at(iTau)->eta())
+          continue;
+        if ((float)pfTau->phi() != (float)unmatchedTaus.at(iTau)->phi())
+          continue;
+        if ((float)pfTau->energy() != (float)unmatchedTaus.at(iTau)->energy())
+          continue;
 
-				decayMode->Fill(pfTau->decayMode(),unmatchedTaus.at(iTau)->decayMode());
-				chargedIsoPtSum->Fill((*chargedIso)[pfTau],unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum"));
-				neutralIsoPtSum->Fill((*neutralIso)[pfTau],unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum"));
-				puCorrPtSum->Fill((*puCorr)[pfTau],unmatchedTaus.at(iTau)->tauID("puCorrPtSum"));
-				photonPtSumOutsideSignalCone->Fill((*photonSumOutsideSignalCone)[pfTau],unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone"));
-				footprintCorrection->Fill((*footPrint)[pfTau],unmatchedTaus.at(iTau)->tauID("footprintCorrection"));
+        decayMode->Fill(pfTau->decayMode(), unmatchedTaus.at(iTau)->decayMode());
+        chargedIsoPtSum->Fill((*chargedIso)[pfTau], unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum"));
+        neutralIsoPtSum->Fill((*neutralIso)[pfTau], unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum"));
+        puCorrPtSum->Fill((*puCorr)[pfTau], unmatchedTaus.at(iTau)->tauID("puCorrPtSum"));
+        photonPtSumOutsideSignalCone->Fill((*photonSumOutsideSignalCone)[pfTau],
+                                           unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone"));
+        footprintCorrection->Fill((*footPrint)[pfTau], unmatchedTaus.at(iTau)->tauID("footprintCorrection"));
 
-				const reco::PFTauTransverseImpactParameter& tauLifetimeInfo = *(*tauLifetimeInfos)[pfTau];
+        const reco::PFTauTransverseImpactParameter& tauLifetimeInfo = *(*tauLifetimeInfos)[pfTau];
 
-				float decayDistXAOD = tauLifetimeInfo.flightLength().x();
-				float decayDistYAOD = tauLifetimeInfo.flightLength().y();
-				float decayDistZAOD = tauLifetimeInfo.flightLength().z();
-				float decayDistMagAOD = std::sqrt(decayDistXAOD*decayDistXAOD + decayDistYAOD*decayDistYAOD + decayDistZAOD*decayDistZAOD);
+        float decayDistXAOD = tauLifetimeInfo.flightLength().x();
+        float decayDistYAOD = tauLifetimeInfo.flightLength().y();
+        float decayDistZAOD = tauLifetimeInfo.flightLength().z();
+        float decayDistMagAOD =
+            std::sqrt(decayDistXAOD * decayDistXAOD + decayDistYAOD * decayDistYAOD + decayDistZAOD * decayDistZAOD);
 
-				float decayDistXMiniAOD = unmatchedTaus.at(iTau)->flightLength().x();
-				float decayDistYMiniAOD = unmatchedTaus.at(iTau)->flightLength().y();
-				float decayDistZMiniAOD = unmatchedTaus.at(iTau)->flightLength().z();
-				float decayDistMagMiniAOD = std::sqrt(decayDistXMiniAOD*decayDistXMiniAOD + decayDistYMiniAOD*decayDistYMiniAOD + decayDistZMiniAOD*decayDistZMiniAOD);
+        float decayDistXMiniAOD = unmatchedTaus.at(iTau)->flightLength().x();
+        float decayDistYMiniAOD = unmatchedTaus.at(iTau)->flightLength().y();
+        float decayDistZMiniAOD = unmatchedTaus.at(iTau)->flightLength().z();
+        float decayDistMagMiniAOD =
+            std::sqrt(decayDistXMiniAOD * decayDistXMiniAOD + decayDistYMiniAOD * decayDistYMiniAOD +
+                      decayDistZMiniAOD * decayDistZMiniAOD);
 
-				decayDistMag->Fill(decayDistMagAOD,decayDistMagMiniAOD);
-				dxy->Fill(tauLifetimeInfo.dxy(),unmatchedTaus.at(iTau)->dxy());
-				dxySig->Fill(tauLifetimeInfo.dxy_Sig(),unmatchedTaus.at(iTau)->dxy_Sig());
-				ip3d->Fill(tauLifetimeInfo.ip3d(),unmatchedTaus.at(iTau)->ip3d());
-				ip3dSig->Fill(tauLifetimeInfo.ip3d_Sig(),unmatchedTaus.at(iTau)->ip3d_Sig());
-				hasSV->Fill(tauLifetimeInfo.hasSecondaryVertex(),unmatchedTaus.at(iTau)->hasSecondaryVertex());
-				flightlengthSig->Fill(tauLifetimeInfo.flightLengthSig(),unmatchedTaus.at(iTau)->flightLengthSig());
-				nPhoton->Fill((float)reco::tau::n_photons_total(*pfTau),(float)reco::tau::n_photons_total(*unmatchedTaus.at(iTau)));
-				ptWeightedDetaStrip->Fill(reco::tau::pt_weighted_deta_strip(*pfTau, pfTau->decayMode()),reco::tau::pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()));
-				ptWeightedDphiStrip->Fill(reco::tau::pt_weighted_dphi_strip(*pfTau, pfTau->decayMode()),reco::tau::pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()));
-				ptWeightedDrSignal->Fill(reco::tau::pt_weighted_dr_signal(*pfTau, pfTau->decayMode()),reco::tau::pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()));
-				ptWeightedDrIsolation->Fill(reco::tau::pt_weighted_dr_iso(*pfTau, pfTau->decayMode()),reco::tau::pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()));
-				leadTrackChi2->Fill(reco::tau::lead_track_chi2(*pfTau),unmatchedTaus.at(iTau)->leadingTrackNormChi2());
-				eRatio->Fill(reco::tau::eratio(*pfTau),reco::tau::eratio(*unmatchedTaus.at(iTau)));
+        decayDistMag->Fill(decayDistMagAOD, decayDistMagMiniAOD);
+        dxy->Fill(tauLifetimeInfo.dxy(), unmatchedTaus.at(iTau)->dxy());
+        dxySig->Fill(tauLifetimeInfo.dxy_Sig(), unmatchedTaus.at(iTau)->dxy_Sig());
+        ip3d->Fill(tauLifetimeInfo.ip3d(), unmatchedTaus.at(iTau)->ip3d());
+        ip3dSig->Fill(tauLifetimeInfo.ip3d_Sig(), unmatchedTaus.at(iTau)->ip3d_Sig());
+        hasSV->Fill(tauLifetimeInfo.hasSecondaryVertex(), unmatchedTaus.at(iTau)->hasSecondaryVertex());
+        flightlengthSig->Fill(tauLifetimeInfo.flightLengthSig(), unmatchedTaus.at(iTau)->flightLengthSig());
+        nPhoton->Fill((float)reco::tau::n_photons_total(*pfTau),
+                      (float)reco::tau::n_photons_total(*unmatchedTaus.at(iTau)));
+        ptWeightedDetaStrip->Fill(
+            reco::tau::pt_weighted_deta_strip(*pfTau, pfTau->decayMode()),
+            reco::tau::pt_weighted_deta_strip(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode()));
+        ptWeightedDphiStrip->Fill(
+            reco::tau::pt_weighted_dphi_strip(*pfTau, pfTau->decayMode()),
+            reco::tau::pt_weighted_dphi_strip(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode()));
+        ptWeightedDrSignal->Fill(
+            reco::tau::pt_weighted_dr_signal(*pfTau, pfTau->decayMode()),
+            reco::tau::pt_weighted_dr_signal(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode()));
+        ptWeightedDrIsolation->Fill(
+            reco::tau::pt_weighted_dr_iso(*pfTau, pfTau->decayMode()),
+            reco::tau::pt_weighted_dr_iso(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode()));
+        leadTrackChi2->Fill(reco::tau::lead_track_chi2(*pfTau), unmatchedTaus.at(iTau)->leadingTrackNormChi2());
+        eRatio->Fill(reco::tau::eratio(*pfTau), reco::tau::eratio(*unmatchedTaus.at(iTau)));
 
-				if(verbosity_) std::cout << "=============================================================" << std::endl;
-				if(pfTau->pt() != unmatchedTaus.at(iTau)->pt()){
-					if(verbosity_) std::cout << "pt: PF = " << pfTau->pt() << ", pat = " << unmatchedTaus.at(iTau)->pt() << std::endl;
-					differences->Fill(0);
-					differencesWeighted->Fill(0.,std::abs(pfTau->pt()-unmatchedTaus.at(iTau)->pt()));
-				}
-				if(pfTau->eta() != unmatchedTaus.at(iTau)->eta()){
-					if(verbosity_) std::cout << "eta: PF = " << pfTau->eta() << ", pat = " << unmatchedTaus.at(iTau)->eta() << std::endl;
-					differences->Fill(1);
-					differencesWeighted->Fill(1,std::abs(pfTau->eta()-unmatchedTaus.at(iTau)->eta()));
-				}
-				if(pfTau->phi() != unmatchedTaus.at(iTau)->phi()){
-					if(verbosity_) std::cout << "phi: PF = " << pfTau->phi() << ", pat = " << unmatchedTaus.at(iTau)->phi() << std::endl;
-					differences->Fill(2);
-					differencesWeighted->Fill(2,std::abs(pfTau->phi()-unmatchedTaus.at(iTau)->phi()));
-				}
-				if(pfTau->energy() != unmatchedTaus.at(iTau)->energy()){
-					if(verbosity_) std::cout << "energy PF = " << pfTau->energy() << ", pat = " << unmatchedTaus.at(iTau)->energy() << std::endl;
-					differences->Fill(3);
-					differencesWeighted->Fill(3,std::abs(pfTau->energy()-unmatchedTaus.at(iTau)->energy()));
-				}
-				if(pfTau->decayMode() != unmatchedTaus.at(iTau)->decayMode()){
-					if(verbosity_) std::cout << "decayMode: PF = " << pfTau->decayMode() << ", pat = " << unmatchedTaus.at(iTau)->decayMode() << std::endl;
-					differences->Fill(4);
-					differencesWeighted->Fill(4,std::abs(pfTau->decayMode()-unmatchedTaus.at(iTau)->decayMode()));
-				}
-				if((*chargedIso)[pfTau] != unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum")){
-					if(verbosity_) std::cout << "chargedIso: PF = " << (*chargedIso)[pfTau] << ", pat = " << unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum") << std::endl;
-					differences->Fill(5);
-					differencesWeighted->Fill(5,std::abs((*chargedIso)[pfTau]-unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum")));
-				}
-				if((*neutralIso)[pfTau] != unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum")){
-					if(verbosity_) std::cout << "neutralIso: PF = " << (*neutralIso)[pfTau] << ", pat = " << unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum") << std::endl;
-					differences->Fill(6);
-					differencesWeighted->Fill(6,std::abs((*neutralIso)[pfTau]-unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum")));
-				}
-				if((*puCorr)[pfTau] != unmatchedTaus.at(iTau)->tauID("puCorrPtSum")){
-					if(verbosity_) std::cout << "puCorr: PF = " << (*puCorr)[pfTau] << ", pat = " << unmatchedTaus.at(iTau)->tauID("puCorrPtSum") << std::endl;
-					differences->Fill(7);
-					differencesWeighted->Fill(7,std::abs((*puCorr)[pfTau]-unmatchedTaus.at(iTau)->tauID("puCorrPtSum")));
-				}
-				if((*photonSumOutsideSignalCone)[pfTau] != unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone")){
-					if(verbosity_) std::cout << "photonSumOutsideSignalCone: PF = " << (*photonSumOutsideSignalCone)[pfTau] << ", pat = " << unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone") << std::endl;
-					differences->Fill(8);
-					differencesWeighted->Fill(8,std::abs((*photonSumOutsideSignalCone)[pfTau]-unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone")));
-				}
-				if((*footPrint)[pfTau] != unmatchedTaus.at(iTau)->tauID("footprintCorrection")){
-					if(verbosity_) std::cout << "footPrint: PF = " << (*footPrint)[pfTau] << ", pat = " << unmatchedTaus.at(iTau)->tauID("footprintCorrection") << std::endl;
-					differences->Fill(9);
-					differencesWeighted->Fill(9,std::abs((*footPrint)[pfTau]-unmatchedTaus.at(iTau)->tauID("footprintCorrection")));
-				}
-				if(decayDistMagAOD != decayDistMagMiniAOD){
-					if(verbosity_) std::cout << "decayDistMag: PF = " << decayDistMagAOD << ", pat = " << decayDistMagMiniAOD << std::endl;
-					differences->Fill(10);
-					differencesWeighted->Fill(10,std::abs(decayDistMagAOD-decayDistMagMiniAOD));
-				}
-				if(tauLifetimeInfo.dxy() != unmatchedTaus.at(iTau)->dxy()){
-					if(verbosity_) std::cout << "dxy: PF = " << tauLifetimeInfo.dxy() << ", pat = " << unmatchedTaus.at(iTau)->dxy() << std::endl;
-					differences->Fill(11);
-					differencesWeighted->Fill(11,std::abs((float)tauLifetimeInfo.dxy()-unmatchedTaus.at(iTau)->dxy()));
-					difference_dxy->Fill(std::abs(tauLifetimeInfo.dxy()-unmatchedTaus.at(iTau)->dxy()));
-				}
-				if(tauLifetimeInfo.dxy_Sig() != unmatchedTaus.at(iTau)->dxy_Sig()){
-					if(verbosity_) std::cout << "dxy_Sig: PF = " << tauLifetimeInfo.dxy_Sig() << ", pat = " << unmatchedTaus.at(iTau)->dxy_Sig() << std::endl;
-					differences->Fill(12);
-					differencesWeighted->Fill(12,std::abs((float)tauLifetimeInfo.dxy_Sig()-unmatchedTaus.at(iTau)->dxy_Sig()));
-					difference_dxySig->Fill(std::abs(tauLifetimeInfo.dxy_Sig()-unmatchedTaus.at(iTau)->dxy_Sig()));
-				}
-				if(tauLifetimeInfo.ip3d() != unmatchedTaus.at(iTau)->ip3d()){
-					if(verbosity_) std::cout << "ip3d PF: = " << tauLifetimeInfo.ip3d() << ", pat = " << unmatchedTaus.at(iTau)->ip3d() << std::endl;
-					differences->Fill(13);
-					differencesWeighted->Fill(13,std::abs((float)tauLifetimeInfo.ip3d()-unmatchedTaus.at(iTau)->ip3d()));
-					difference_ip3d->Fill(std::abs(tauLifetimeInfo.ip3d()-unmatchedTaus.at(iTau)->ip3d()));
-				}
-				if(tauLifetimeInfo.ip3d_Sig() != unmatchedTaus.at(iTau)->ip3d_Sig()){
-					if(verbosity_) std::cout << "ip3d_Sig: PF = " << tauLifetimeInfo.ip3d_Sig() << ", pat = " << unmatchedTaus.at(iTau)->ip3d_Sig() << std::endl;
-					differences->Fill(14);
-					differencesWeighted->Fill(14,std::abs((float)tauLifetimeInfo.ip3d_Sig()-unmatchedTaus.at(iTau)->ip3d_Sig()));
-					difference_ip3dSig->Fill(std::abs(tauLifetimeInfo.ip3d_Sig()-unmatchedTaus.at(iTau)->ip3d_Sig()));
-				}
-				if(tauLifetimeInfo.hasSecondaryVertex() != unmatchedTaus.at(iTau)->hasSecondaryVertex()){
-					if(verbosity_) std::cout << "hasSV: PF = " << tauLifetimeInfo.hasSecondaryVertex() << ", pat = " << unmatchedTaus.at(iTau)->hasSecondaryVertex() << std::endl;
-					differences->Fill(15);
-					differencesWeighted->Fill(15,std::abs((float)tauLifetimeInfo.hasSecondaryVertex()-unmatchedTaus.at(iTau)->hasSecondaryVertex()));
-				}
-				if(tauLifetimeInfo.flightLengthSig() != unmatchedTaus.at(iTau)->flightLengthSig()){
-					if(verbosity_) std::cout << "flightlengthSig: PF = " << tauLifetimeInfo.flightLengthSig() << ", pat = " << unmatchedTaus.at(iTau)->flightLengthSig() << std::endl;
-					differences->Fill(16);
-					differencesWeighted->Fill(16,std::abs((float)tauLifetimeInfo.flightLengthSig()-unmatchedTaus.at(iTau)->flightLengthSig()));
-					difference_flightlengthSig->Fill(std::abs(tauLifetimeInfo.flightLengthSig()-unmatchedTaus.at(iTau)->flightLengthSig()));
-				}
-				if((float)reco::tau::n_photons_total(*pfTau) != (float)reco::tau::n_photons_total(*unmatchedTaus.at(iTau))){
-					if(verbosity_) std::cout << "nPhoton PF: = " << (float)reco::tau::n_photons_total(*pfTau) << ", pat = " << (float)reco::tau::n_photons_total(*unmatchedTaus.at(iTau)) << std::endl;
-					differences->Fill(17);
-					differencesWeighted->Fill(17,std::abs((float)reco::tau::n_photons_total(*pfTau)-(float)reco::tau::n_photons_total(*unmatchedTaus.at(iTau))));
-				}
-				if(reco::tau::pt_weighted_deta_strip(*pfTau, pfTau->decayMode()) != reco::tau::pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())){
-					if(verbosity_) std::cout << "ptWeightedDetaStrip: PF = " << reco::tau::pt_weighted_deta_strip(*pfTau, pfTau->decayMode()) << ", pat = " << reco::tau::pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()) << std::endl;
-					differences->Fill(18);
-					differencesWeighted->Fill(18,std::abs(reco::tau::pt_weighted_deta_strip(*pfTau, pfTau->decayMode())-reco::tau::pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-					difference_ptWeightedDetaStrip->Fill(std::abs(reco::tau::pt_weighted_deta_strip(*pfTau, pfTau->decayMode())-reco::tau::pt_weighted_deta_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-				}
-				if(reco::tau::pt_weighted_dphi_strip(*pfTau, pfTau->decayMode()) != reco::tau::pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())){
-					if(verbosity_) std::cout << "ptWeightedDphiStrip: PF = " << reco::tau::pt_weighted_dphi_strip(*pfTau, pfTau->decayMode()) << ", pat = " << reco::tau::pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()) << std::endl;
-					differences->Fill(19);
-					differencesWeighted->Fill(19,std::abs(reco::tau::pt_weighted_dphi_strip(*pfTau, pfTau->decayMode())-reco::tau::pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-					difference_ptWeightedDphiStrip->Fill(std::abs(reco::tau::pt_weighted_dphi_strip(*pfTau, pfTau->decayMode())-reco::tau::pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-				}
-				if(reco::tau::pt_weighted_dr_signal(*pfTau, pfTau->decayMode()) != reco::tau::pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())){
-					if(verbosity_) std::cout << "ptWeightedDrSignal: PF = " << reco::tau::pt_weighted_dr_signal(*pfTau, pfTau->decayMode()) << ", pat = " << reco::tau::pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()) << std::endl;
-					differences->Fill(20);
-					differencesWeighted->Fill(20,std::abs(reco::tau::pt_weighted_dr_signal(*pfTau, pfTau->decayMode())-reco::tau::pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-					difference_ptWeightedDrSignal->Fill(std::abs(reco::tau::pt_weighted_dr_signal(*pfTau, pfTau->decayMode())-reco::tau::pt_weighted_dr_signal(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-				}
-				if(reco::tau::pt_weighted_dr_iso(*pfTau, pfTau->decayMode()) != reco::tau::pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())){
-					if(verbosity_) std::cout << "ptWeightedDrIso: PF = " << reco::tau::pt_weighted_dr_iso(*pfTau, pfTau->decayMode()) << ", pat = " << reco::tau::pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode()) << std::endl;
-					differences->Fill(21);
-					differencesWeighted->Fill(21,std::abs(reco::tau::pt_weighted_dr_iso(*pfTau, pfTau->decayMode())-reco::tau::pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-					difference_ptWeightedDrIso->Fill(std::abs(reco::tau::pt_weighted_dr_iso(*pfTau, pfTau->decayMode())-reco::tau::pt_weighted_dr_iso(*unmatchedTaus.at(iTau),unmatchedTaus.at(iTau)->decayMode())));
-				}
-				if(reco::tau::lead_track_chi2(*pfTau) != unmatchedTaus.at(iTau)->leadingTrackNormChi2()){
-					if(verbosity_) std::cout << "leadTrackChi2: PF = " << reco::tau::lead_track_chi2(*pfTau) << ", pat = " << unmatchedTaus.at(iTau)->leadingTrackNormChi2() << std::endl;
-					differences->Fill(22);
-					differencesWeighted->Fill(22,std::abs(reco::tau::lead_track_chi2(*pfTau)-unmatchedTaus.at(iTau)->leadingTrackNormChi2()));
-				}
-				if(reco::tau::eratio(*pfTau) != reco::tau::eratio(*unmatchedTaus.at(iTau))){
-					if(verbosity_) std::cout << "eRatio: PF = " << reco::tau::eratio(*pfTau) << ", pat = " << reco::tau::eratio(*unmatchedTaus.at(iTau)) << std::endl;
-					differences->Fill(23);
-					differencesWeighted->Fill(23,std::abs(reco::tau::eratio(*pfTau)-reco::tau::eratio(*unmatchedTaus.at(iTau))));
-				}
-				if(verbosity_) std::cout << "=============================================================" << std::endl;
-			}
-		}
-	}
+        if (verbosity_)
+          std::cout << "=============================================================" << std::endl;
+        if (pfTau->pt() != unmatchedTaus.at(iTau)->pt()) {
+          if (verbosity_)
+            std::cout << "pt: PF = " << pfTau->pt() << ", pat = " << unmatchedTaus.at(iTau)->pt() << std::endl;
+          differences->Fill(0);
+          differencesWeighted->Fill(0., std::abs(pfTau->pt() - unmatchedTaus.at(iTau)->pt()));
+        }
+        if (pfTau->eta() != unmatchedTaus.at(iTau)->eta()) {
+          if (verbosity_)
+            std::cout << "eta: PF = " << pfTau->eta() << ", pat = " << unmatchedTaus.at(iTau)->eta() << std::endl;
+          differences->Fill(1);
+          differencesWeighted->Fill(1, std::abs(pfTau->eta() - unmatchedTaus.at(iTau)->eta()));
+        }
+        if (pfTau->phi() != unmatchedTaus.at(iTau)->phi()) {
+          if (verbosity_)
+            std::cout << "phi: PF = " << pfTau->phi() << ", pat = " << unmatchedTaus.at(iTau)->phi() << std::endl;
+          differences->Fill(2);
+          differencesWeighted->Fill(2, std::abs(pfTau->phi() - unmatchedTaus.at(iTau)->phi()));
+        }
+        if (pfTau->energy() != unmatchedTaus.at(iTau)->energy()) {
+          if (verbosity_)
+            std::cout << "energy PF = " << pfTau->energy() << ", pat = " << unmatchedTaus.at(iTau)->energy()
+                      << std::endl;
+          differences->Fill(3);
+          differencesWeighted->Fill(3, std::abs(pfTau->energy() - unmatchedTaus.at(iTau)->energy()));
+        }
+        if (pfTau->decayMode() != unmatchedTaus.at(iTau)->decayMode()) {
+          if (verbosity_)
+            std::cout << "decayMode: PF = " << pfTau->decayMode() << ", pat = " << unmatchedTaus.at(iTau)->decayMode()
+                      << std::endl;
+          differences->Fill(4);
+          differencesWeighted->Fill(4, std::abs(pfTau->decayMode() - unmatchedTaus.at(iTau)->decayMode()));
+        }
+        if ((*chargedIso)[pfTau] != unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum")) {
+          if (verbosity_)
+            std::cout << "chargedIso: PF = " << (*chargedIso)[pfTau]
+                      << ", pat = " << unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum") << std::endl;
+          differences->Fill(5);
+          differencesWeighted->Fill(5,
+                                    std::abs((*chargedIso)[pfTau] - unmatchedTaus.at(iTau)->tauID("chargedIsoPtSum")));
+        }
+        if ((*neutralIso)[pfTau] != unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum")) {
+          if (verbosity_)
+            std::cout << "neutralIso: PF = " << (*neutralIso)[pfTau]
+                      << ", pat = " << unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum") << std::endl;
+          differences->Fill(6);
+          differencesWeighted->Fill(6,
+                                    std::abs((*neutralIso)[pfTau] - unmatchedTaus.at(iTau)->tauID("neutralIsoPtSum")));
+        }
+        if ((*puCorr)[pfTau] != unmatchedTaus.at(iTau)->tauID("puCorrPtSum")) {
+          if (verbosity_)
+            std::cout << "puCorr: PF = " << (*puCorr)[pfTau]
+                      << ", pat = " << unmatchedTaus.at(iTau)->tauID("puCorrPtSum") << std::endl;
+          differences->Fill(7);
+          differencesWeighted->Fill(7, std::abs((*puCorr)[pfTau] - unmatchedTaus.at(iTau)->tauID("puCorrPtSum")));
+        }
+        if ((*photonSumOutsideSignalCone)[pfTau] != unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone")) {
+          if (verbosity_)
+            std::cout << "photonSumOutsideSignalCone: PF = " << (*photonSumOutsideSignalCone)[pfTau]
+                      << ", pat = " << unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone") << std::endl;
+          differences->Fill(8);
+          differencesWeighted->Fill(8,
+                                    std::abs((*photonSumOutsideSignalCone)[pfTau] -
+                                             unmatchedTaus.at(iTau)->tauID("photonPtSumOutsideSignalCone")));
+        }
+        if ((*footPrint)[pfTau] != unmatchedTaus.at(iTau)->tauID("footprintCorrection")) {
+          if (verbosity_)
+            std::cout << "footPrint: PF = " << (*footPrint)[pfTau]
+                      << ", pat = " << unmatchedTaus.at(iTau)->tauID("footprintCorrection") << std::endl;
+          differences->Fill(9);
+          differencesWeighted->Fill(
+              9, std::abs((*footPrint)[pfTau] - unmatchedTaus.at(iTau)->tauID("footprintCorrection")));
+        }
+        if (decayDistMagAOD != decayDistMagMiniAOD) {
+          if (verbosity_)
+            std::cout << "decayDistMag: PF = " << decayDistMagAOD << ", pat = " << decayDistMagMiniAOD << std::endl;
+          differences->Fill(10);
+          differencesWeighted->Fill(10, std::abs(decayDistMagAOD - decayDistMagMiniAOD));
+        }
+        if (tauLifetimeInfo.dxy() != unmatchedTaus.at(iTau)->dxy()) {
+          if (verbosity_)
+            std::cout << "dxy: PF = " << tauLifetimeInfo.dxy() << ", pat = " << unmatchedTaus.at(iTau)->dxy()
+                      << std::endl;
+          differences->Fill(11);
+          differencesWeighted->Fill(11, std::abs((float)tauLifetimeInfo.dxy() - unmatchedTaus.at(iTau)->dxy()));
+          difference_dxy->Fill(std::abs(tauLifetimeInfo.dxy() - unmatchedTaus.at(iTau)->dxy()));
+        }
+        if (tauLifetimeInfo.dxy_Sig() != unmatchedTaus.at(iTau)->dxy_Sig()) {
+          if (verbosity_)
+            std::cout << "dxy_Sig: PF = " << tauLifetimeInfo.dxy_Sig()
+                      << ", pat = " << unmatchedTaus.at(iTau)->dxy_Sig() << std::endl;
+          differences->Fill(12);
+          differencesWeighted->Fill(12, std::abs((float)tauLifetimeInfo.dxy_Sig() - unmatchedTaus.at(iTau)->dxy_Sig()));
+          difference_dxySig->Fill(std::abs(tauLifetimeInfo.dxy_Sig() - unmatchedTaus.at(iTau)->dxy_Sig()));
+        }
+        if (tauLifetimeInfo.ip3d() != unmatchedTaus.at(iTau)->ip3d()) {
+          if (verbosity_)
+            std::cout << "ip3d PF: = " << tauLifetimeInfo.ip3d() << ", pat = " << unmatchedTaus.at(iTau)->ip3d()
+                      << std::endl;
+          differences->Fill(13);
+          differencesWeighted->Fill(13, std::abs((float)tauLifetimeInfo.ip3d() - unmatchedTaus.at(iTau)->ip3d()));
+          difference_ip3d->Fill(std::abs(tauLifetimeInfo.ip3d() - unmatchedTaus.at(iTau)->ip3d()));
+        }
+        if (tauLifetimeInfo.ip3d_Sig() != unmatchedTaus.at(iTau)->ip3d_Sig()) {
+          if (verbosity_)
+            std::cout << "ip3d_Sig: PF = " << tauLifetimeInfo.ip3d_Sig()
+                      << ", pat = " << unmatchedTaus.at(iTau)->ip3d_Sig() << std::endl;
+          differences->Fill(14);
+          differencesWeighted->Fill(14,
+                                    std::abs((float)tauLifetimeInfo.ip3d_Sig() - unmatchedTaus.at(iTau)->ip3d_Sig()));
+          difference_ip3dSig->Fill(std::abs(tauLifetimeInfo.ip3d_Sig() - unmatchedTaus.at(iTau)->ip3d_Sig()));
+        }
+        if (tauLifetimeInfo.hasSecondaryVertex() != unmatchedTaus.at(iTau)->hasSecondaryVertex()) {
+          if (verbosity_)
+            std::cout << "hasSV: PF = " << tauLifetimeInfo.hasSecondaryVertex()
+                      << ", pat = " << unmatchedTaus.at(iTau)->hasSecondaryVertex() << std::endl;
+          differences->Fill(15);
+          differencesWeighted->Fill(
+              15, std::abs((float)tauLifetimeInfo.hasSecondaryVertex() - unmatchedTaus.at(iTau)->hasSecondaryVertex()));
+        }
+        if (tauLifetimeInfo.flightLengthSig() != unmatchedTaus.at(iTau)->flightLengthSig()) {
+          if (verbosity_)
+            std::cout << "flightlengthSig: PF = " << tauLifetimeInfo.flightLengthSig()
+                      << ", pat = " << unmatchedTaus.at(iTau)->flightLengthSig() << std::endl;
+          differences->Fill(16);
+          differencesWeighted->Fill(
+              16, std::abs((float)tauLifetimeInfo.flightLengthSig() - unmatchedTaus.at(iTau)->flightLengthSig()));
+          difference_flightlengthSig->Fill(
+              std::abs(tauLifetimeInfo.flightLengthSig() - unmatchedTaus.at(iTau)->flightLengthSig()));
+        }
+        if ((float)reco::tau::n_photons_total(*pfTau) != (float)reco::tau::n_photons_total(*unmatchedTaus.at(iTau))) {
+          if (verbosity_)
+            std::cout << "nPhoton PF: = " << (float)reco::tau::n_photons_total(*pfTau)
+                      << ", pat = " << (float)reco::tau::n_photons_total(*unmatchedTaus.at(iTau)) << std::endl;
+          differences->Fill(17);
+          differencesWeighted->Fill(17,
+                                    std::abs((float)reco::tau::n_photons_total(*pfTau) -
+                                             (float)reco::tau::n_photons_total(*unmatchedTaus.at(iTau))));
+        }
+        if (reco::tau::pt_weighted_deta_strip(*pfTau, pfTau->decayMode()) !=
+            reco::tau::pt_weighted_deta_strip(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())) {
+          if (verbosity_)
+            std::cout << "ptWeightedDetaStrip: PF = " << reco::tau::pt_weighted_deta_strip(*pfTau, pfTau->decayMode())
+                      << ", pat = "
+                      << reco::tau::pt_weighted_deta_strip(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())
+                      << std::endl;
+          differences->Fill(18);
+          differencesWeighted->Fill(18,
+                                    std::abs(reco::tau::pt_weighted_deta_strip(*pfTau, pfTau->decayMode()) -
+                                             reco::tau::pt_weighted_deta_strip(*unmatchedTaus.at(iTau),
+                                                                               unmatchedTaus.at(iTau)->decayMode())));
+          difference_ptWeightedDetaStrip->Fill(std::abs(
+              reco::tau::pt_weighted_deta_strip(*pfTau, pfTau->decayMode()) -
+              reco::tau::pt_weighted_deta_strip(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())));
+        }
+        if (reco::tau::pt_weighted_dphi_strip(*pfTau, pfTau->decayMode()) !=
+            reco::tau::pt_weighted_dphi_strip(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())) {
+          if (verbosity_)
+            std::cout << "ptWeightedDphiStrip: PF = " << reco::tau::pt_weighted_dphi_strip(*pfTau, pfTau->decayMode())
+                      << ", pat = "
+                      << reco::tau::pt_weighted_dphi_strip(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())
+                      << std::endl;
+          differences->Fill(19);
+          differencesWeighted->Fill(19,
+                                    std::abs(reco::tau::pt_weighted_dphi_strip(*pfTau, pfTau->decayMode()) -
+                                             reco::tau::pt_weighted_dphi_strip(*unmatchedTaus.at(iTau),
+                                                                               unmatchedTaus.at(iTau)->decayMode())));
+          difference_ptWeightedDphiStrip->Fill(std::abs(
+              reco::tau::pt_weighted_dphi_strip(*pfTau, pfTau->decayMode()) -
+              reco::tau::pt_weighted_dphi_strip(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())));
+        }
+        if (reco::tau::pt_weighted_dr_signal(*pfTau, pfTau->decayMode()) !=
+            reco::tau::pt_weighted_dr_signal(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())) {
+          if (verbosity_)
+            std::cout << "ptWeightedDrSignal: PF = " << reco::tau::pt_weighted_dr_signal(*pfTau, pfTau->decayMode())
+                      << ", pat = "
+                      << reco::tau::pt_weighted_dr_signal(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())
+                      << std::endl;
+          differences->Fill(20);
+          differencesWeighted->Fill(
+              20,
+              std::abs(reco::tau::pt_weighted_dr_signal(*pfTau, pfTau->decayMode()) -
+                       reco::tau::pt_weighted_dr_signal(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())));
+          difference_ptWeightedDrSignal->Fill(
+              std::abs(reco::tau::pt_weighted_dr_signal(*pfTau, pfTau->decayMode()) -
+                       reco::tau::pt_weighted_dr_signal(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())));
+        }
+        if (reco::tau::pt_weighted_dr_iso(*pfTau, pfTau->decayMode()) !=
+            reco::tau::pt_weighted_dr_iso(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())) {
+          if (verbosity_)
+            std::cout << "ptWeightedDrIso: PF = " << reco::tau::pt_weighted_dr_iso(*pfTau, pfTau->decayMode())
+                      << ", pat = "
+                      << reco::tau::pt_weighted_dr_iso(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())
+                      << std::endl;
+          differences->Fill(21);
+          differencesWeighted->Fill(
+              21,
+              std::abs(reco::tau::pt_weighted_dr_iso(*pfTau, pfTau->decayMode()) -
+                       reco::tau::pt_weighted_dr_iso(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())));
+          difference_ptWeightedDrIso->Fill(
+              std::abs(reco::tau::pt_weighted_dr_iso(*pfTau, pfTau->decayMode()) -
+                       reco::tau::pt_weighted_dr_iso(*unmatchedTaus.at(iTau), unmatchedTaus.at(iTau)->decayMode())));
+        }
+        if (reco::tau::lead_track_chi2(*pfTau) != unmatchedTaus.at(iTau)->leadingTrackNormChi2()) {
+          if (verbosity_)
+            std::cout << "leadTrackChi2: PF = " << reco::tau::lead_track_chi2(*pfTau)
+                      << ", pat = " << unmatchedTaus.at(iTau)->leadingTrackNormChi2() << std::endl;
+          differences->Fill(22);
+          differencesWeighted->Fill(
+              22, std::abs(reco::tau::lead_track_chi2(*pfTau) - unmatchedTaus.at(iTau)->leadingTrackNormChi2()));
+        }
+        if (reco::tau::eratio(*pfTau) != reco::tau::eratio(*unmatchedTaus.at(iTau))) {
+          if (verbosity_)
+            std::cout << "eRatio: PF = " << reco::tau::eratio(*pfTau)
+                      << ", pat = " << reco::tau::eratio(*unmatchedTaus.at(iTau)) << std::endl;
+          differences->Fill(23);
+          differencesWeighted->Fill(23,
+                                    std::abs(reco::tau::eratio(*pfTau) - reco::tau::eratio(*unmatchedTaus.at(iTau))));
+        }
+        if (verbosity_)
+          std::cout << "=============================================================" << std::endl;
+      }
+    }
+  }
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-rerunMVAIsolationOnMiniAOD::beginJob()
-{
-}
+void rerunMVAIsolationOnMiniAOD::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-rerunMVAIsolationOnMiniAOD::endJob()
-{
-}
+void rerunMVAIsolationOnMiniAOD::endJob() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-rerunMVAIsolationOnMiniAOD::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void rerunMVAIsolationOnMiniAOD::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/TrackingTools/TrackAssociator/interface/CachedTrajectory.h
+++ b/TrackingTools/TrackAssociator/interface/CachedTrajectory.h
@@ -4,7 +4,7 @@
 //
 // Package:    TrackAssociator
 // Class:      CachedTrajectory
-// 
+//
 /*
 
  Description: CachedTrajectory is a transient class, which stores a set of
@@ -31,14 +31,18 @@
 #include <deque>
 #include "FWCore/Utilities/interface/Visibility.h"
 
-std::vector<SteppingHelixStateInfo> 
-propagateThoughFromIP(const SteppingHelixStateInfo& state,const Propagator* prop,
-		      const FiducialVolume& volume,int nsteps,
-		      float step, float minR, float minZ, float maxR, float maxZ);
+std::vector<SteppingHelixStateInfo> propagateThoughFromIP(const SteppingHelixStateInfo& state,
+                                                          const Propagator* prop,
+                                                          const FiducialVolume& volume,
+                                                          int nsteps,
+                                                          float step,
+                                                          float minR,
+                                                          float minZ,
+                                                          float maxR,
+                                                          float maxZ);
 
 class CachedTrajectory {
- public:
-
+public:
   const std::vector<SteppingHelixStateInfo>& getEcalTrajectory() const;
   const std::vector<SteppingHelixStateInfo>& getHcalTrajectory() const;
   const std::vector<SteppingHelixStateInfo>& getHOTrajectory() const;
@@ -46,107 +50,109 @@ class CachedTrajectory {
 
 private:
   friend class TrackDetectorAssociator;
-  friend std::vector<SteppingHelixStateInfo> 
-  propagateThoughFromIP(const SteppingHelixStateInfo& state,const Propagator* ptr,
-			const FiducialVolume& volume,int nsteps,
-			float step, float minR, float minZ, float maxR, float maxZ);
+  friend std::vector<SteppingHelixStateInfo> propagateThoughFromIP(const SteppingHelixStateInfo& state,
+                                                                   const Propagator* ptr,
+                                                                   const FiducialVolume& volume,
+                                                                   int nsteps,
+                                                                   float step,
+                                                                   float minR,
+                                                                   float minZ,
+                                                                   float maxR,
+                                                                   float maxZ);
 
   CachedTrajectory();
   enum TrajectorType { IpToEcal, IpToHcal, IpToHO, FullTrajectory };
   enum WideTrajectoryType { Ecal, Hcal, HO };
-  
+
   void reset_trajectory() dso_internal;
-  
+
   /// propagate through the whole detector, returns true if successful
   bool propagateAll(const SteppingHelixStateInfo& initialState) dso_internal;
-  
+
   void propagateForward(SteppingHelixStateInfo& state, float distance) dso_internal;
   void propagate(SteppingHelixStateInfo& state, const Plane& plane) dso_internal;
   void propagate(SteppingHelixStateInfo& state, const Cylinder& cylinder) dso_internal;
-  
+
   /// get fast to a given DetId surface using cached trajectory
   TrajectoryStateOnSurface propagate(const Plane* plane) dso_internal;
-  
+
   /// calculate trajectory change (Theta,Phi)
   /// delta = final - original
-  std::pair<float,float> trajectoryDelta( TrajectorType ) dso_internal;
-  
+  std::pair<float, float> trajectoryDelta(TrajectorType) dso_internal;
+
   void setPropagator(const Propagator* ptr) dso_internal { propagator_ = ptr; }
   void setStateAtIP(const SteppingHelixStateInfo& state) dso_internal { stateAtIP_ = state; }
-  
+
   /// get a set of points representing the trajectory between two cylinders
   /// of radius R1 and R2 and length L1 and L2. Parameter steps defines
   /// maximal number of steps in the detector.
-   void getTrajectory(std::vector<SteppingHelixStateInfo>&,
-		      const FiducialVolume&,
-		      int steps = 4) dso_internal;
-  
+  void getTrajectory(std::vector<SteppingHelixStateInfo>&, const FiducialVolume&, int steps = 4) dso_internal;
+
   void findEcalTrajectory(const FiducialVolume&) dso_internal;
   void findHcalTrajectory(const FiducialVolume&) dso_internal;
   void findHOTrajectory(const FiducialVolume&) dso_internal;
   void findPreshowerTrajectory(const FiducialVolume&) dso_internal;
-  
+
   std::vector<GlobalPoint>* getWideTrajectory(const std::vector<SteppingHelixStateInfo>&,
-					      WideTrajectoryType) dso_internal;
-  
+                                              WideTrajectoryType) dso_internal;
+
   SteppingHelixStateInfo getStateAtEcal() dso_internal;
   SteppingHelixStateInfo getStateAtPreshower() dso_internal;
   SteppingHelixStateInfo getStateAtHcal() dso_internal;
   SteppingHelixStateInfo getStateAtHO() dso_internal;
-  
-  //get the innermost state of the whole trajectory 
+
+  //get the innermost state of the whole trajectory
   SteppingHelixStateInfo getInnerState() dso_internal;
-  //get the outermost state of the whole trajectory 
+  //get the outermost state of the whole trajectory
   SteppingHelixStateInfo getOuterState() dso_internal;
-  
+
   // specify the detector global boundaries to limit the propagator
-   // units: cm
-   // HINT: use lower bounds to limit propagateAll() action within
-   //       smaller region, such as ECAL for example
-  void setMaxDetectorRadius(float r = 800.) dso_internal { maxRho_ = r;}
-  void setMaxDetectorLength(float l = 2200.) dso_internal { maxZ_ = l/2.;}
-  void setMaxHORadius(float r = 800.) dso_internal { HOmaxRho_ = r;}
-  void setMaxHOLength(float l = 2200.) dso_internal { HOmaxZ_ = l/2.;}
-  void setMinDetectorRadius(float r = 0.)  dso_internal { minRho_ = r;}
-  void setMinDetectorLength(float l = 0.)  dso_internal { minZ_ = l/2.;}
-  
-  void setPropagationStep(float s = 20.){ step_ = s;}
-  float getPropagationStep() const  dso_internal { return step_;}
-  
+  // units: cm
+  // HINT: use lower bounds to limit propagateAll() action within
+  //       smaller region, such as ECAL for example
+  void setMaxDetectorRadius(float r = 800.) dso_internal { maxRho_ = r; }
+  void setMaxDetectorLength(float l = 2200.) dso_internal { maxZ_ = l / 2.; }
+  void setMaxHORadius(float r = 800.) dso_internal { HOmaxRho_ = r; }
+  void setMaxHOLength(float l = 2200.) dso_internal { HOmaxZ_ = l / 2.; }
+  void setMinDetectorRadius(float r = 0.) dso_internal { minRho_ = r; }
+  void setMinDetectorLength(float l = 0.) dso_internal { minZ_ = l / 2.; }
+
+  void setPropagationStep(float s = 20.) { step_ = s; }
+  float getPropagationStep() const dso_internal { return step_; }
+
 protected:
-  
-  static int sign (float number) dso_internal {
-    if (number ==0) return 0;
+  static int sign(float number) dso_internal {
+    if (number == 0)
+      return 0;
     if (number > 0)
       return 1;
     else
       return -1;
   }
-  
-  std::pair<float,float> delta( const double& theta1,
-				const double& theta2,
-				const double& phi1,
-				const double& phi2) dso_internal;
-  
+
+  std::pair<float, float> delta(const double& theta1, const double& theta2, const double& phi1, const double& phi2)
+      dso_internal;
+
   float distance(const Plane* plane, int index) dso_internal {
-    if (index<0 || fullTrajectory_.empty() || (unsigned int)index >= fullTrajectory_.size()) return 0;
+    if (index < 0 || fullTrajectory_.empty() || (unsigned int)index >= fullTrajectory_.size())
+      return 0;
     return plane->localZ(fullTrajectory_[index].position());
   }
-  
+
   std::deque<SteppingHelixStateInfo> fullTrajectory_;
   std::vector<SteppingHelixStateInfo> ecalTrajectory_;
   std::vector<SteppingHelixStateInfo> hcalTrajectory_;
   std::vector<SteppingHelixStateInfo> hoTrajectory_;
   std::vector<SteppingHelixStateInfo> preshowerTrajectory_;
-  std::vector<GlobalPoint> wideEcalTrajectory_; 
+  std::vector<GlobalPoint> wideEcalTrajectory_;
   std::vector<GlobalPoint> wideHcalTrajectory_;
   std::vector<GlobalPoint> wideHOTrajectory_;
   SteppingHelixStateInfo stateAtIP_;
-  
+
   bool fullTrajectoryFilled_;
-  
+
   const Propagator* propagator_;
-  
+
   float maxRho_;
   float maxZ_;
   float HOmaxRho_;
@@ -154,6 +160,5 @@ protected:
   float minRho_;
   float minZ_;
   float step_;
-  
 };
 #endif

--- a/TrackingTools/TrackAssociator/interface/DetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/interface/DetIdAssociator.h
@@ -5,7 +5,7 @@
 //
 // Package:    TrackingTools/TrackAssociator
 // Class:      DetIdAssociator
-// 
+//
 /**\
 
  Description: Abstract base class for 3D point -> std::set<DetId>
@@ -42,125 +42,119 @@
 #include <set>
 #include <vector>
 
-class DetIdAssociator{
- public:
-   enum PropagationTarget { Barrel, ForwardEndcap, BackwardEndcap };
-   struct MapRange {
-      float dThetaPlus;
-      float dThetaMinus;
-      float dPhiPlus;
-      float dPhiMinus;
-   };
-   typedef std::vector<GlobalPoint>::const_iterator const_iterator;
-	
-   DetIdAssociator(const int nPhi, const int nEta, const double etaBinSize);
-   virtual ~DetIdAssociator(){}
-   
-   /// Preselect DetIds close to a point on the inner surface of the detector. 
-   /// "iN" is a number of the adjacent bins of the map to retrieve 
-   virtual std::set<DetId> getDetIdsCloseToAPoint(const GlobalPoint&,
-						  const int iN = 0) const;
-   virtual std::set<DetId> getDetIdsCloseToAPoint(const GlobalPoint& direction,
-						  const unsigned int iNEtaPlus,
-						  const unsigned int iNEtaMinus,
-						  const unsigned int iNPhiPlus,
-						  const unsigned int iNPhiMinus) const;
-   virtual std::set<DetId> getDetIdsCloseToAPoint(const GlobalPoint& direction,
-						  const MapRange& mapRange) const;
-   /// Preselect DetIds close to a point on the inner surface of the detector. 
-   /// "d" defines the allowed range in theta-phi space:
-   /// - theta is in [point.theta()-d, point.theta()+d]
-   /// - phi is in [point.phi()-d, point.phi()+d]
-   virtual std::set<DetId> getDetIdsCloseToAPoint(const GlobalPoint& point,
-						  const double d = 0) const;
-   /// - theta is in [point.theta()-dThetaMinus, point.theta()+dThetaPlus]
-   /// - phi is in [point.phi()-dPhiMinus, point.phi()+dPhiPlus]
-   virtual std::set<DetId> getDetIdsCloseToAPoint(const GlobalPoint& point,
-						  const double dThetaPlus,
-						  const double dThetaMinus,
-						  const double dPhiPlus,
-						  const double dPhiMinus) const;
+class DetIdAssociator {
+public:
+  enum PropagationTarget { Barrel, ForwardEndcap, BackwardEndcap };
+  struct MapRange {
+    float dThetaPlus;
+    float dThetaMinus;
+    float dPhiPlus;
+    float dPhiMinus;
+  };
+  typedef std::vector<GlobalPoint>::const_iterator const_iterator;
 
-   /// helper to see if getDetIdsInACone is useful
-   virtual bool selectAllInACone(const double dR) const {return dR > 2*M_PI && dR > maxEta_;}
+  DetIdAssociator(const int nPhi, const int nEta, const double etaBinSize);
+  virtual ~DetIdAssociator() {}
 
-   /// Find DetIds that satisfy given requirements
-   /// - inside eta-phi cone of radius dR
-   virtual std::set<DetId> getDetIdsInACone(const std::set<DetId>&,
-					    const std::vector<GlobalPoint>& trajectory,
-					    const double dR) const;
-   /// - DetIds crossed by the track
-   ///   tolerance is the radius of the trajectory used for matching
-   ///   -1 is default and represent the case with no uncertainty
-   ///   on the trajectory direction. It's the fastest option
-   /// - DetIds crossed by the track, ordered according to the order
-   ///   that they were crossed by the track flying outside the detector
-   virtual std::vector<DetId> getCrossedDetIds(const std::set<DetId>&,
-					       const std::vector<GlobalPoint>& trajectory) const;
-   virtual std::vector<DetId> getCrossedDetIds(const std::set<DetId>&,
-					       const std::vector<SteppingHelixStateInfo>& trajectory,
-					       const double toleranceInSigmas = -1) const;
-   /// look-up map eta index
-   virtual int iEta (const GlobalPoint&) const;
-   /// look-up map phi index
-   virtual int iPhi (const GlobalPoint&) const;
-   /// number of bins of the look-up map in phi dimension
-   int nPhiBins() const { return nPhi_;}
-   /// number of bins of the look-up map in eta dimension
-   int nEtaBins() const { return nEta_;}
-   /// look-up map bin size in eta dimension
-   double etaBinSize() const { return etaBinSize_;};
-   /// make the look-up map
-   virtual void buildMap();
-   /// get active detector volume
-   const FiducialVolume& volume() const;
+  /// Preselect DetIds close to a point on the inner surface of the detector.
+  /// "iN" is a number of the adjacent bins of the map to retrieve
+  virtual std::set<DetId> getDetIdsCloseToAPoint(const GlobalPoint&, const int iN = 0) const;
+  virtual std::set<DetId> getDetIdsCloseToAPoint(const GlobalPoint& direction,
+                                                 const unsigned int iNEtaPlus,
+                                                 const unsigned int iNEtaMinus,
+                                                 const unsigned int iNPhiPlus,
+                                                 const unsigned int iNPhiMinus) const;
+  virtual std::set<DetId> getDetIdsCloseToAPoint(const GlobalPoint& direction, const MapRange& mapRange) const;
+  /// Preselect DetIds close to a point on the inner surface of the detector.
+  /// "d" defines the allowed range in theta-phi space:
+  /// - theta is in [point.theta()-d, point.theta()+d]
+  /// - phi is in [point.phi()-d, point.phi()+d]
+  virtual std::set<DetId> getDetIdsCloseToAPoint(const GlobalPoint& point, const double d = 0) const;
+  /// - theta is in [point.theta()-dThetaMinus, point.theta()+dThetaPlus]
+  /// - phi is in [point.phi()-dPhiMinus, point.phi()+dPhiPlus]
+  virtual std::set<DetId> getDetIdsCloseToAPoint(const GlobalPoint& point,
+                                                 const double dThetaPlus,
+                                                 const double dThetaMinus,
+                                                 const double dPhiPlus,
+                                                 const double dPhiMinus) const;
 
-   virtual const GeomDet* getGeomDet(const DetId&) const = 0;
+  /// helper to see if getDetIdsInACone is useful
+  virtual bool selectAllInACone(const double dR) const { return dR > 2 * M_PI && dR > maxEta_; }
 
-   virtual const char* name() const = 0;
-   
- protected:
-   virtual void check_setup() const;
-   
-   virtual void dumpMapContent( int, int ) const;
-   virtual void dumpMapContent( int, int, int, int ) const;
-   
-   virtual GlobalPoint getPosition(const DetId&) const = 0;
-   virtual const unsigned int getNumberOfSubdetectors() const { return 1;}
-   virtual void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>&) const = 0;
-   virtual std::pair<const_iterator, const_iterator> getDetIdPoints(const DetId&, std::vector<GlobalPoint>&) const = 0;
-   
-   virtual bool insideElement(const GlobalPoint&, const DetId&) const = 0;
-   virtual bool crossedElement(const GlobalPoint&, 
-			       const GlobalPoint&, 
-			       const DetId&,
-			       const double toleranceInSigmas = -1,
-			       const SteppingHelixStateInfo* = nullptr ) const { return false; }
-   virtual bool nearElement(const GlobalPoint& point, 
-			    const DetId& id, 
-			    const double distance) const;
-   
-   unsigned int index(unsigned int iEta, unsigned int iPhi) const {
-     return iEta*nPhi_+iPhi;
-   }
-   void fillSet( std::set<DetId>& set, unsigned int iEta, unsigned int iPhi) const;
+  /// Find DetIds that satisfy given requirements
+  /// - inside eta-phi cone of radius dR
+  virtual std::set<DetId> getDetIdsInACone(const std::set<DetId>&,
+                                           const std::vector<GlobalPoint>& trajectory,
+                                           const double dR) const;
+  /// - DetIds crossed by the track
+  ///   tolerance is the radius of the trajectory used for matching
+  ///   -1 is default and represent the case with no uncertainty
+  ///   on the trajectory direction. It's the fastest option
+  /// - DetIds crossed by the track, ordered according to the order
+  ///   that they were crossed by the track flying outside the detector
+  virtual std::vector<DetId> getCrossedDetIds(const std::set<DetId>&, const std::vector<GlobalPoint>& trajectory) const;
+  virtual std::vector<DetId> getCrossedDetIds(const std::set<DetId>&,
+                                              const std::vector<SteppingHelixStateInfo>& trajectory,
+                                              const double toleranceInSigmas = -1) const;
+  /// look-up map eta index
+  virtual int iEta(const GlobalPoint&) const;
+  /// look-up map phi index
+  virtual int iPhi(const GlobalPoint&) const;
+  /// number of bins of the look-up map in phi dimension
+  int nPhiBins() const { return nPhi_; }
+  /// number of bins of the look-up map in eta dimension
+  int nEtaBins() const { return nEta_; }
+  /// look-up map bin size in eta dimension
+  double etaBinSize() const { return etaBinSize_; };
+  /// make the look-up map
+  virtual void buildMap();
+  /// get active detector volume
+  const FiducialVolume& volume() const;
 
-   // map parameters
-   const int nPhi_;
-   const int nEta_;
-   // The first number in the pair points to the begging
-   // of the DetId list for a given bin
-   // The second number is the number of elements in a bin
-   std::vector<std::pair<unsigned int,unsigned int> > lookupMap_;
-   std::vector<DetId> container_;
-   bool theMapIsValid_;
-   const double etaBinSize_;
-   double maxEta_;
-   double minTheta_;
-   
-   // Detector fiducial volume 
-   // approximated as a closed cylinder with non-zero width.
-   // Parameters are extracted from the active detector elements.
-   FiducialVolume volume_;
+  virtual const GeomDet* getGeomDet(const DetId&) const = 0;
+
+  virtual const char* name() const = 0;
+
+protected:
+  virtual void check_setup() const;
+
+  virtual void dumpMapContent(int, int) const;
+  virtual void dumpMapContent(int, int, int, int) const;
+
+  virtual GlobalPoint getPosition(const DetId&) const = 0;
+  virtual const unsigned int getNumberOfSubdetectors() const { return 1; }
+  virtual void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>&) const = 0;
+  virtual std::pair<const_iterator, const_iterator> getDetIdPoints(const DetId&, std::vector<GlobalPoint>&) const = 0;
+
+  virtual bool insideElement(const GlobalPoint&, const DetId&) const = 0;
+  virtual bool crossedElement(const GlobalPoint&,
+                              const GlobalPoint&,
+                              const DetId&,
+                              const double toleranceInSigmas = -1,
+                              const SteppingHelixStateInfo* = nullptr) const {
+    return false;
+  }
+  virtual bool nearElement(const GlobalPoint& point, const DetId& id, const double distance) const;
+
+  unsigned int index(unsigned int iEta, unsigned int iPhi) const { return iEta * nPhi_ + iPhi; }
+  void fillSet(std::set<DetId>& set, unsigned int iEta, unsigned int iPhi) const;
+
+  // map parameters
+  const int nPhi_;
+  const int nEta_;
+  // The first number in the pair points to the begging
+  // of the DetId list for a given bin
+  // The second number is the number of elements in a bin
+  std::vector<std::pair<unsigned int, unsigned int> > lookupMap_;
+  std::vector<DetId> container_;
+  bool theMapIsValid_;
+  const double etaBinSize_;
+  double maxEta_;
+  double minTheta_;
+
+  // Detector fiducial volume
+  // approximated as a closed cylinder with non-zero width.
+  // Parameters are extracted from the active detector elements.
+  FiducialVolume volume_;
 };
 #endif

--- a/TrackingTools/TrackAssociator/interface/DetIdInfo.h
+++ b/TrackingTools/TrackAssociator/interface/DetIdInfo.h
@@ -15,9 +15,9 @@
 class TrackerTopology;
 
 class DetIdInfo {
- public:
-  static std::string info( const DetId&, const TrackerTopology *tTopo );
-  static std::string info( const std::set<DetId>&, const TrackerTopology *tTopo );
-  static std::string info( const std::vector<DetId>&, const TrackerTopology *tTopo );
+public:
+  static std::string info(const DetId &, const TrackerTopology *tTopo);
+  static std::string info(const std::set<DetId> &, const TrackerTopology *tTopo);
+  static std::string info(const std::vector<DetId> &, const TrackerTopology *tTopo);
 };
 #endif

--- a/TrackingTools/TrackAssociator/interface/FiducialVolume.h
+++ b/TrackingTools/TrackAssociator/interface/FiducialVolume.h
@@ -5,7 +5,7 @@
 //
 // Package:    TrackAssociator
 // Class:      FiducialVolume
-// 
+//
 /*
 
  Description: detector active volume described by a closed cylinder with non-zero thickness.
@@ -14,60 +14,56 @@
 //
 // Original Author:  Dmytro Kovalskyi
 //
-/// The detector active volume is determined estimated as a non-zero thickness 
+/// The detector active volume is determined estimated as a non-zero thickness
 /// cylinder with outter dimensions maxZ and maxR. The inner dimensions are
-/// found as minimum R and Z for two cases "barrel" (|eta|<1) and 
+/// found as minimum R and Z for two cases "barrel" (|eta|<1) and
 /// "endcap" (|eta|>1.7) correspondingly
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include <vector>
 
 class FiducialVolume {
- public:
-   FiducialVolume(double tolerance = 1.0):
-     tolerance_(tolerance) { reset(); }
-   /// finilize dimension calculations, fixes dimensions in a 
-   /// case of missing barrel or endcap
-   void determinInnerDimensions();
-   /// check whether the volume is properly defined
-   bool isValid() const;
-   /// add a point that belongs to the active volume
-   void addActivePoint( const GlobalPoint& point );
-   /// invalidate the volume
-   void reset();
-   double minR(bool withTolerance = true) const 
-     { 
-       if (withTolerance && minR_>tolerance_) 
-	 return minR_-tolerance_;
-       else
-	 return minR_;
-     }
-   double maxR(bool withTolerance = true) const 
-     { 
-       if (withTolerance) 
-	 return maxR_+tolerance_;
-       else
-	 return maxR_;
-     }
-   double minZ(bool withTolerance = true) const 
-     { 
-       if (withTolerance && minZ_>tolerance_)
-	 return minZ_-tolerance_; 
-       else
-	 return minZ_;
-     }
-   double maxZ(bool withTolerance = true) const 
-     { 
-       if (withTolerance)
-	 return maxZ_+tolerance_;
-       else
-	 return maxZ_; 
-     }
- private:
-   double minR_;
-   double maxR_;
-   double minZ_;
-   double maxZ_;
-   double tolerance_;
+public:
+  FiducialVolume(double tolerance = 1.0) : tolerance_(tolerance) { reset(); }
+  /// finilize dimension calculations, fixes dimensions in a
+  /// case of missing barrel or endcap
+  void determinInnerDimensions();
+  /// check whether the volume is properly defined
+  bool isValid() const;
+  /// add a point that belongs to the active volume
+  void addActivePoint(const GlobalPoint& point);
+  /// invalidate the volume
+  void reset();
+  double minR(bool withTolerance = true) const {
+    if (withTolerance && minR_ > tolerance_)
+      return minR_ - tolerance_;
+    else
+      return minR_;
+  }
+  double maxR(bool withTolerance = true) const {
+    if (withTolerance)
+      return maxR_ + tolerance_;
+    else
+      return maxR_;
+  }
+  double minZ(bool withTolerance = true) const {
+    if (withTolerance && minZ_ > tolerance_)
+      return minZ_ - tolerance_;
+    else
+      return minZ_;
+  }
+  double maxZ(bool withTolerance = true) const {
+    if (withTolerance)
+      return maxZ_ + tolerance_;
+    else
+      return maxZ_;
+  }
+
+private:
+  double minR_;
+  double maxR_;
+  double minZ_;
+  double maxZ_;
+  double tolerance_;
 };
 #endif

--- a/TrackingTools/TrackAssociator/interface/TAMuonChamberMatch.h
+++ b/TrackingTools/TrackAssociator/interface/TAMuonChamberMatch.h
@@ -18,16 +18,16 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
 class TAMuonChamberMatch {
- public:
-   int station() const;
-   std::string info() const;
-   int detector() const { return id.subdetId(); }
+public:
+  int station() const;
+  std::string info() const;
+  int detector() const { return id.subdetId(); }
 
-   /// distance sign convention: negative - crossed chamber, positive - missed chamber
-   std::vector<TAMuonSegmentMatch> segments;
-   float localDistanceX;
-   float localDistanceY;
-   TrajectoryStateOnSurface tState;
-   DetId id;
+  /// distance sign convention: negative - crossed chamber, positive - missed chamber
+  std::vector<TAMuonSegmentMatch> segments;
+  float localDistanceX;
+  float localDistanceY;
+  TrajectoryStateOnSurface tState;
+  DetId id;
 };
 #endif

--- a/TrackingTools/TrackAssociator/interface/TAMuonSegmentMatch.h
+++ b/TrackingTools/TrackAssociator/interface/TAMuonSegmentMatch.h
@@ -9,23 +9,23 @@
 #include "DataFormats/GEMRecHit/interface/ME0SegmentCollection.h"
 
 class TAMuonSegmentMatch {
- public:
-   math::XYZPoint  segmentGlobalPosition;
-   math::XYZPoint  segmentLocalPosition;
-   math::XYZVector segmentLocalDirection;
-   float  segmentLocalErrorXX;
-   float  segmentLocalErrorYY;
-   float  segmentLocalErrorXY;
-   float  segmentLocalErrorDxDz;
-   float  segmentLocalErrorDyDz;
-   float  segmentLocalErrorXDxDz;
-   float  segmentLocalErrorYDyDz;
-   float  t0;
-   bool   hasZed;
-   bool   hasPhi;
-   DTRecSegment4DRef  dtSegmentRef;
-   CSCSegmentRef      cscSegmentRef;
-   GEMSegmentRef gemSegmentRef;
-   ME0SegmentRef me0SegmentRef;
+public:
+  math::XYZPoint segmentGlobalPosition;
+  math::XYZPoint segmentLocalPosition;
+  math::XYZVector segmentLocalDirection;
+  float segmentLocalErrorXX;
+  float segmentLocalErrorYY;
+  float segmentLocalErrorXY;
+  float segmentLocalErrorDxDz;
+  float segmentLocalErrorDyDz;
+  float segmentLocalErrorXDxDz;
+  float segmentLocalErrorYDyDz;
+  float t0;
+  bool hasZed;
+  bool hasPhi;
+  DTRecSegment4DRef dtSegmentRef;
+  CSCSegmentRef cscSegmentRef;
+  GEMSegmentRef gemSegmentRef;
+  ME0SegmentRef me0SegmentRef;
 };
 #endif

--- a/TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h
+++ b/TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h
@@ -5,7 +5,7 @@
 //
 // Package:    TrackAssociator
 // Class:      TrackAssociatorParameters
-// 
+//
 /*
 
  Description: track associator parameters
@@ -32,82 +32,82 @@
 #include "DataFormats/GEMRecHit/interface/ME0SegmentCollection.h"
 
 class TrackAssociatorParameters {
- public:
-   TrackAssociatorParameters(){}
-   TrackAssociatorParameters( const edm::ParameterSet&, edm::ConsumesCollector&& );
-   void loadParameters( const edm::ParameterSet&, edm::ConsumesCollector& );
-   
-   double dREcal;
-   double dRHcal;
-   double dRMuon;
-   
-   double dREcalPreselection;
-   double dRHcalPreselection;
-   double dRMuonPreselection;
-   double dRPreshowerPreselection;
-   
-   /// account for trajectory change for calorimeters.
-   /// allows to compute energy around original track direction 
-   /// (for example neutral particles in a jet) as well as energy
-   /// around track projection on the inner surface of a 
-   /// calorimeter. Affects performance, so use wisely.
-   bool accountForTrajectoryChangeCalo;
-   
-   // account for trajectory change in the muon detector
-   // helps to ensure that all chambers are found. 
-   // Recomended to be used in default configuration
-   // bool accountForTrajectoryChangeMuon;
+public:
+  TrackAssociatorParameters() {}
+  TrackAssociatorParameters(const edm::ParameterSet&, edm::ConsumesCollector&&);
+  void loadParameters(const edm::ParameterSet&, edm::ConsumesCollector&);
 
-   /// maximal distance from a muon chamber. Can be considered as a preselection
-   /// cut and fancier cuts can be applied in a muon producer, since the
-   /// distance from a chamber should be available as output of the TrackAssociation
-   double muonMaxDistanceX;
-   double muonMaxDistanceY;
-   double muonMaxDistanceSigmaX;
-   double muonMaxDistanceSigmaY;
-   
-   bool useEcal;
-   bool useHcal;
-   bool useHO;
-   bool useCalo;
-   bool usePreshower;
-   bool useMuon;
-   bool truthMatch;
-   bool useGEM;
-   bool useME0;
-   
-   /// Labels of the detector EDProducts 
-   edm::InputTag theEBRecHitCollectionLabel;
-   edm::InputTag theEERecHitCollectionLabel;
-   edm::InputTag theCaloTowerCollectionLabel;
-   edm::InputTag theHBHERecHitCollectionLabel;
-   edm::InputTag theHORecHitCollectionLabel;
-   edm::InputTag theDTRecSegment4DCollectionLabel;
-   edm::InputTag theCSCSegmentCollectionLabel;
-   edm::InputTag theGEMSegmentCollectionLabel;
-   edm::InputTag theME0SegmentCollectionLabel;
+  double dREcal;
+  double dRHcal;
+  double dRMuon;
 
-   // Specify if we want to widen the search pass of the crossed
-   // calorimeter elements taking into account uncertainty
-   // of the track trajectory. The parameter below
-   // specifies how many standard deviations
-   // to account for. Negative numbers are ignored
-   // and trajectory is assumed to be known perfectly
-   double trajectoryUncertaintyTolerance;
+  double dREcalPreselection;
+  double dRHcalPreselection;
+  double dRMuonPreselection;
+  double dRPreshowerPreselection;
 
-   edm::EDGetTokenT<EBRecHitCollection> EBRecHitsToken;
-   edm::EDGetTokenT<EERecHitCollection> EERecHitsToken;
-   edm::EDGetTokenT<CaloTowerCollection> caloTowersToken;
-   edm::EDGetTokenT<HBHERecHitCollection> HBHEcollToken;
-   edm::EDGetTokenT<HORecHitCollection> HOcollToken;
-   edm::EDGetTokenT<DTRecSegment4DCollection> dtSegmentsToken;
-   edm::EDGetTokenT<CSCSegmentCollection> cscSegmentsToken;
-   edm::EDGetTokenT<GEMSegmentCollection> gemSegmentsToken;
-   edm::EDGetTokenT<ME0SegmentCollection> me0SegmentsToken;
-   edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken;
-   edm::EDGetTokenT<edm::SimVertexContainer> simVerticesToken;
-   edm::EDGetTokenT<edm::PCaloHitContainer> simEcalHitsEBToken;
-   edm::EDGetTokenT<edm::PCaloHitContainer> simEcalHitsEEToken;
-   edm::EDGetTokenT<edm::PCaloHitContainer> simHcalHitsToken;
+  /// account for trajectory change for calorimeters.
+  /// allows to compute energy around original track direction
+  /// (for example neutral particles in a jet) as well as energy
+  /// around track projection on the inner surface of a
+  /// calorimeter. Affects performance, so use wisely.
+  bool accountForTrajectoryChangeCalo;
+
+  // account for trajectory change in the muon detector
+  // helps to ensure that all chambers are found.
+  // Recomended to be used in default configuration
+  // bool accountForTrajectoryChangeMuon;
+
+  /// maximal distance from a muon chamber. Can be considered as a preselection
+  /// cut and fancier cuts can be applied in a muon producer, since the
+  /// distance from a chamber should be available as output of the TrackAssociation
+  double muonMaxDistanceX;
+  double muonMaxDistanceY;
+  double muonMaxDistanceSigmaX;
+  double muonMaxDistanceSigmaY;
+
+  bool useEcal;
+  bool useHcal;
+  bool useHO;
+  bool useCalo;
+  bool usePreshower;
+  bool useMuon;
+  bool truthMatch;
+  bool useGEM;
+  bool useME0;
+
+  /// Labels of the detector EDProducts
+  edm::InputTag theEBRecHitCollectionLabel;
+  edm::InputTag theEERecHitCollectionLabel;
+  edm::InputTag theCaloTowerCollectionLabel;
+  edm::InputTag theHBHERecHitCollectionLabel;
+  edm::InputTag theHORecHitCollectionLabel;
+  edm::InputTag theDTRecSegment4DCollectionLabel;
+  edm::InputTag theCSCSegmentCollectionLabel;
+  edm::InputTag theGEMSegmentCollectionLabel;
+  edm::InputTag theME0SegmentCollectionLabel;
+
+  // Specify if we want to widen the search pass of the crossed
+  // calorimeter elements taking into account uncertainty
+  // of the track trajectory. The parameter below
+  // specifies how many standard deviations
+  // to account for. Negative numbers are ignored
+  // and trajectory is assumed to be known perfectly
+  double trajectoryUncertaintyTolerance;
+
+  edm::EDGetTokenT<EBRecHitCollection> EBRecHitsToken;
+  edm::EDGetTokenT<EERecHitCollection> EERecHitsToken;
+  edm::EDGetTokenT<CaloTowerCollection> caloTowersToken;
+  edm::EDGetTokenT<HBHERecHitCollection> HBHEcollToken;
+  edm::EDGetTokenT<HORecHitCollection> HOcollToken;
+  edm::EDGetTokenT<DTRecSegment4DCollection> dtSegmentsToken;
+  edm::EDGetTokenT<CSCSegmentCollection> cscSegmentsToken;
+  edm::EDGetTokenT<GEMSegmentCollection> gemSegmentsToken;
+  edm::EDGetTokenT<ME0SegmentCollection> me0SegmentsToken;
+  edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken;
+  edm::EDGetTokenT<edm::SimVertexContainer> simVerticesToken;
+  edm::EDGetTokenT<edm::PCaloHitContainer> simEcalHitsEBToken;
+  edm::EDGetTokenT<edm::PCaloHitContainer> simEcalHitsEEToken;
+  edm::EDGetTokenT<edm::PCaloHitContainer> simHcalHitsToken;
 };
 #endif

--- a/TrackingTools/TrackAssociator/interface/TrackDetMatchInfo.h
+++ b/TrackingTools/TrackAssociator/interface/TrackDetMatchInfo.h
@@ -12,108 +12,109 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 class TrackDetMatchInfo {
- public:
-   enum EnergyType { EcalRecHits, HcalRecHits, HORecHits, TowerTotal, TowerEcal, TowerHcal, TowerHO };
-   
-   TrackDetMatchInfo();
-   
-   /// energy in detector elements crossed by the track by types
-   double crossedEnergy( EnergyType );
-   
-   /// cone energy around the track direction at the origin (0,0,0)
-   /// ( not well defined for tracks originating away from IP)
-   double coneEnergy( double dR, EnergyType );
-   
-   /// get energy of the NxN shape (N = 2*gridSize + 1) around given detector element
-   double nXnEnergy(const DetId&, EnergyType, int gridSize = 1);
-   
-   /// get energy of the NxN shape (N = 2*gridSize + 1) around track projection
-   double nXnEnergy(EnergyType, int gridSize = 1);
+public:
+  enum EnergyType { EcalRecHits, HcalRecHits, HORecHits, TowerTotal, TowerEcal, TowerHcal, TowerHO };
 
-   /// Find detector elements with highest energy deposition
-   DetId findMaxDeposition( EnergyType );
-   DetId findMaxDeposition( EnergyType, int gridSize );
-   DetId findMaxDeposition( const DetId&, EnergyType, int gridSize );
-   
-   /// Track position at different parts of the calorimeter
-   math::XYZPoint trkGlobPosAtEcal;
-   math::XYZPoint trkGlobPosAtHcal;
-   math::XYZPoint trkGlobPosAtHO;
-   
+  TrackDetMatchInfo();
+
+  /// energy in detector elements crossed by the track by types
+  double crossedEnergy(EnergyType);
+
+  /// cone energy around the track direction at the origin (0,0,0)
+  /// ( not well defined for tracks originating away from IP)
+  double coneEnergy(double dR, EnergyType);
+
+  /// get energy of the NxN shape (N = 2*gridSize + 1) around given detector element
+  double nXnEnergy(const DetId&, EnergyType, int gridSize = 1);
+
+  /// get energy of the NxN shape (N = 2*gridSize + 1) around track projection
+  double nXnEnergy(EnergyType, int gridSize = 1);
+
+  /// Find detector elements with highest energy deposition
+  DetId findMaxDeposition(EnergyType);
+  DetId findMaxDeposition(EnergyType, int gridSize);
+  DetId findMaxDeposition(const DetId&, EnergyType, int gridSize);
+
+  /// Track position at different parts of the calorimeter
+  math::XYZPoint trkGlobPosAtEcal;
+  math::XYZPoint trkGlobPosAtHcal;
+  math::XYZPoint trkGlobPosAtHO;
+
   GlobalVector trkMomAtEcal;
   GlobalVector trkMomAtHcal;
   GlobalVector trkMomAtHO;
-   
-   bool isGoodEcal;
-   bool isGoodHcal;
-   bool isGoodCalo;
-   bool isGoodHO;
-   bool isGoodMuon;
-   
-   /// hits in the cone
-   std::vector<const EcalRecHit*> ecalRecHits;
-   std::vector<const HBHERecHit*> hcalRecHits;
-   std::vector<const HORecHit*>   hoRecHits;
-   std::vector<const CaloTower*>  towers;
 
-   /// hits in detector elements crossed by a track
-   std::vector<const EcalRecHit*> crossedEcalRecHits;
-   std::vector<const HBHERecHit*> crossedHcalRecHits;
-   std::vector<const HORecHit*>   crossedHORecHits;
-   std::vector<const CaloTower*>  crossedTowers;
+  bool isGoodEcal;
+  bool isGoodHcal;
+  bool isGoodCalo;
+  bool isGoodHO;
+  bool isGoodMuon;
 
-   /// detector elements crossed by a track 
-   /// (regardless of whether energy was deposited or not)
-   std::vector<DetId>      crossedEcalIds;
-   std::vector<DetId>      crossedHcalIds;
-   std::vector<DetId>      crossedHOIds;
-   std::vector<DetId>      crossedTowerIds;
-   std::vector<DetId>      crossedPreshowerIds;
-   
-   std::vector<TAMuonChamberMatch> chambers;
+  /// hits in the cone
+  std::vector<const EcalRecHit*> ecalRecHits;
+  std::vector<const HBHERecHit*> hcalRecHits;
+  std::vector<const HORecHit*> hoRecHits;
+  std::vector<const CaloTower*> towers;
 
-   /// track info
-   FreeTrajectoryState stateAtIP;
-   
-   /// MC truth info
-   const SimTrack* simTrack;
-   double ecalTrueEnergy;
-   double hcalTrueEnergy;
-   double hcalTrueEnergyCorrected;
-   
-   /// Obsolete methods and data members for backward compatibility.
-   /// Will be removed in future releases.
-   reco::TrackRef trackRef_;
-   SimTrackRef simTrackRef_;
-   
-   double ecalCrossedEnergy();
-   double ecalConeEnergy();
-   double hcalCrossedEnergy();
-   double hcalConeEnergy();
-   double hoCrossedEnergy();
-   double hoConeEnergy();
+  /// hits in detector elements crossed by a track
+  std::vector<const EcalRecHit*> crossedEcalRecHits;
+  std::vector<const HBHERecHit*> crossedHcalRecHits;
+  std::vector<const HORecHit*> crossedHORecHits;
+  std::vector<const CaloTower*> crossedTowers;
 
-   double ecalTowerEnergy() { return crossedEnergy(TowerEcal); }
-   double ecalTowerConeEnergy() { return coneEnergy(999,TowerEcal); }
-   double hcalTowerEnergy() { return crossedEnergy(TowerHcal); }
-   double hcalTowerConeEnergy() { return coneEnergy(999, TowerHcal); }
-   double hoTowerEnergy() { return crossedEnergy(TowerHO); }
-   double hoTowerConeEnergy() { return coneEnergy(999, TowerHO); }
+  /// detector elements crossed by a track
+  /// (regardless of whether energy was deposited or not)
+  std::vector<DetId> crossedEcalIds;
+  std::vector<DetId> crossedHcalIds;
+  std::vector<DetId> crossedHOIds;
+  std::vector<DetId> crossedTowerIds;
+  std::vector<DetId> crossedPreshowerIds;
 
-   double ecalEnergy() { return ecalCrossedEnergy(); }
-   double hcalEnergy() { return hcalCrossedEnergy(); }
-   double hoEnergy() { return hoCrossedEnergy(); }
-   
-   int numberOfSegments() const;
-   int numberOfSegmentsInStation(int station) const;
-   int numberOfSegmentsInStation(int station, int detector) const;
-   int numberOfSegmentsInDetector(int detector) const;
-   
-   void setCaloGeometry( edm::ESHandle<CaloGeometry> geometry ) { caloGeometry = geometry.product(); }
-   GlobalPoint getPosition( const DetId& );
-   std::string dumpGeometry( const DetId& );
- private:
-   bool insideCone(const DetId&, const double);
-   const CaloGeometry* caloGeometry;
+  std::vector<TAMuonChamberMatch> chambers;
+
+  /// track info
+  FreeTrajectoryState stateAtIP;
+
+  /// MC truth info
+  const SimTrack* simTrack;
+  double ecalTrueEnergy;
+  double hcalTrueEnergy;
+  double hcalTrueEnergyCorrected;
+
+  /// Obsolete methods and data members for backward compatibility.
+  /// Will be removed in future releases.
+  reco::TrackRef trackRef_;
+  SimTrackRef simTrackRef_;
+
+  double ecalCrossedEnergy();
+  double ecalConeEnergy();
+  double hcalCrossedEnergy();
+  double hcalConeEnergy();
+  double hoCrossedEnergy();
+  double hoConeEnergy();
+
+  double ecalTowerEnergy() { return crossedEnergy(TowerEcal); }
+  double ecalTowerConeEnergy() { return coneEnergy(999, TowerEcal); }
+  double hcalTowerEnergy() { return crossedEnergy(TowerHcal); }
+  double hcalTowerConeEnergy() { return coneEnergy(999, TowerHcal); }
+  double hoTowerEnergy() { return crossedEnergy(TowerHO); }
+  double hoTowerConeEnergy() { return coneEnergy(999, TowerHO); }
+
+  double ecalEnergy() { return ecalCrossedEnergy(); }
+  double hcalEnergy() { return hcalCrossedEnergy(); }
+  double hoEnergy() { return hoCrossedEnergy(); }
+
+  int numberOfSegments() const;
+  int numberOfSegmentsInStation(int station) const;
+  int numberOfSegmentsInStation(int station, int detector) const;
+  int numberOfSegmentsInDetector(int detector) const;
+
+  void setCaloGeometry(edm::ESHandle<CaloGeometry> geometry) { caloGeometry = geometry.product(); }
+  GlobalPoint getPosition(const DetId&);
+  std::string dumpGeometry(const DetId&);
+
+private:
+  bool insideCone(const DetId&, const double);
+  const CaloGeometry* caloGeometry;
 };
 #endif

--- a/TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h
+++ b/TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h
@@ -5,7 +5,7 @@
 //
 // Package:    TrackAssociator
 // Class:      TrackDetectorAssociator
-// 
+//
 /*
 
  Description: main class of tools to associate a track to calorimeter and muon detectors
@@ -46,157 +46,124 @@
 
 #include "FWCore/Utilities/interface/Visibility.h"
 
-
 class TrackDetectorAssociator {
- public:
-   TrackDetectorAssociator();
-   ~TrackDetectorAssociator();
-   
-   typedef TrackAssociatorParameters AssociatorParameters;
-   enum Direction { Any, InsideOut, OutsideIn };
-   
-   /// propagate a track across the whole detector and
-   /// find associated objects. Association is done in
-   /// two modes 
-   ///  1) an object is associated to a track only if 
-   ///     crossed by track
-   ///  2) an object is associated to a track if it is
-   ///     withing an eta-phi cone of some radius with 
-   ///     respect to a track.
-   ///     (the cone origin is at (0,0,0))
-   /// Trajectory bending in eta-phi is taking into account
-   /// when matching is performed
-   ///
-   /// associate using FreeTrajectoryState
-   TrackDetMatchInfo            associate( const edm::Event&,
-					   const edm::EventSetup&,
-					   const FreeTrajectoryState&,
-					   const AssociatorParameters& );
-   /// associate using inner and outer most states of a track
-   /// in the silicon tracker. 
-   TrackDetMatchInfo            associate( const edm::Event& iEvent,
-					   const edm::EventSetup& iSetup,
-					   const AssociatorParameters& parameters,
-					   const FreeTrajectoryState* innerState,
-					   const FreeTrajectoryState* outerState=nullptr);
-   /// associate using reco::Track
-   TrackDetMatchInfo            associate( const edm::Event&,
-					   const edm::EventSetup&,
-					   const reco::Track&,
-					   const AssociatorParameters&,
-					   Direction direction = Any );
-   /// associate using a simulated track
-   TrackDetMatchInfo            associate( const edm::Event&,
-					   const edm::EventSetup&,
-					   const SimTrack&,
-					   const SimVertex&,
-					   const AssociatorParameters& );
-   /// associate using 3-momentum, vertex and charge
-   TrackDetMatchInfo            associate( const edm::Event&,
-					   const edm::EventSetup&,
-					   const GlobalVector&,
-					   const GlobalPoint&,
-					   const int,
-					   const AssociatorParameters& );
-   /// trajector information
-   const CachedTrajectory& getCachedTrajector() const
-     {return cachedTrajectory_;}
+public:
+  TrackDetectorAssociator();
+  ~TrackDetectorAssociator();
 
-   /// use a user configured propagator
-   void setPropagator( const Propagator* );
-   
-   /// use the default propagator
-   void useDefaultPropagator();
-   
-   /// get FreeTrajectoryState from different track representations
-   static FreeTrajectoryState getFreeTrajectoryState( const edm::EventSetup&, 
-						      const reco::Track& );
-   static FreeTrajectoryState getFreeTrajectoryState( const edm::EventSetup&, 
-						      const SimTrack&, 
-						      const SimVertex& );
-   static FreeTrajectoryState getFreeTrajectoryState( const edm::EventSetup&,
-						      const GlobalVector&,
-						      const GlobalPoint&,
-						      const int);
-   
-   static bool                crossedIP(const reco::Track& track);
+  typedef TrackAssociatorParameters AssociatorParameters;
+  enum Direction { Any, InsideOut, OutsideIn };
 
- private:
-   DetIdAssociator::MapRange getMapRange( const std::pair<float,float>& delta,
-					  const float dR ) dso_internal;
+  /// propagate a track across the whole detector and
+  /// find associated objects. Association is done in
+  /// two modes
+  ///  1) an object is associated to a track only if
+  ///     crossed by track
+  ///  2) an object is associated to a track if it is
+  ///     withing an eta-phi cone of some radius with
+  ///     respect to a track.
+  ///     (the cone origin is at (0,0,0))
+  /// Trajectory bending in eta-phi is taking into account
+  /// when matching is performed
+  ///
+  /// associate using FreeTrajectoryState
+  TrackDetMatchInfo associate(const edm::Event&,
+                              const edm::EventSetup&,
+                              const FreeTrajectoryState&,
+                              const AssociatorParameters&);
+  /// associate using inner and outer most states of a track
+  /// in the silicon tracker.
+  TrackDetMatchInfo associate(const edm::Event& iEvent,
+                              const edm::EventSetup& iSetup,
+                              const AssociatorParameters& parameters,
+                              const FreeTrajectoryState* innerState,
+                              const FreeTrajectoryState* outerState = nullptr);
+  /// associate using reco::Track
+  TrackDetMatchInfo associate(const edm::Event&,
+                              const edm::EventSetup&,
+                              const reco::Track&,
+                              const AssociatorParameters&,
+                              Direction direction = Any);
+  /// associate using a simulated track
+  TrackDetMatchInfo associate(
+      const edm::Event&, const edm::EventSetup&, const SimTrack&, const SimVertex&, const AssociatorParameters&);
+  /// associate using 3-momentum, vertex and charge
+  TrackDetMatchInfo associate(const edm::Event&,
+                              const edm::EventSetup&,
+                              const GlobalVector&,
+                              const GlobalPoint&,
+                              const int,
+                              const AssociatorParameters&);
+  /// trajector information
+  const CachedTrajectory& getCachedTrajector() const { return cachedTrajectory_; }
 
-   void fillEcal(       const edm::Event&,
-			TrackDetMatchInfo&, 
-			const AssociatorParameters&) dso_internal;
-   
-   void fillCaloTowers( const edm::Event&,
-			TrackDetMatchInfo&,
-			const AssociatorParameters&) dso_internal;
-   
-   void fillHcal(       const edm::Event&,
-			TrackDetMatchInfo&,
-			const AssociatorParameters&) dso_internal;
-   
-   void fillHO(         const edm::Event&,
-			TrackDetMatchInfo&,
-			const AssociatorParameters&) dso_internal;
-  
-   void fillPreshower(  const edm::Event& iEvent,
-		        TrackDetMatchInfo& info,
-		        const AssociatorParameters&) dso_internal;
-   
-   void fillMuon(       const edm::Event&,
-			TrackDetMatchInfo&,
-			const AssociatorParameters&) dso_internal;
-   
-   void fillCaloTruth(  const edm::Event&,
-			TrackDetMatchInfo&,
-			const AssociatorParameters&) dso_internal;
-   
-   bool addTAMuonSegmentMatch(TAMuonChamberMatch&,
-			    const RecSegment*,
-			    const AssociatorParameters&) dso_internal;
-   
-   void getTAMuonChamberMatches(std::vector<TAMuonChamberMatch>& matches,
-			      const AssociatorParameters& parameters) dso_internal;
-  
-   void           init( const edm::EventSetup&) dso_internal;
-   
-   math::XYZPoint getPoint( const GlobalPoint& point)  dso_internal
-     {
-	return math::XYZPoint(point.x(),point.y(),point.z());
-     }
-   
-   math::XYZPoint getPoint( const LocalPoint& point)  dso_internal
-     {
-	return math::XYZPoint(point.x(),point.y(),point.z());
-     }
-   
-   math::XYZVector getVector( const GlobalVector& vec)  dso_internal
-     {
-	return math::XYZVector(vec.x(),vec.y(),vec.z());
-     }
-   
-   math::XYZVector getVector( const LocalVector& vec)  dso_internal
-     {
-	return math::XYZVector(vec.x(),vec.y(),vec.z());
-     }
-   
-   const Propagator* ivProp_;
-   Propagator* defProp_;
-   CachedTrajectory cachedTrajectory_;
-   bool useDefaultPropagator_;
-   
-   edm::ESHandle<DetIdAssociator> ecalDetIdAssociator_;
-   edm::ESHandle<DetIdAssociator> hcalDetIdAssociator_;
-   edm::ESHandle<DetIdAssociator>   hoDetIdAssociator_;
-   edm::ESHandle<DetIdAssociator> caloDetIdAssociator_;
-   edm::ESHandle<DetIdAssociator> muonDetIdAssociator_;
-   edm::ESHandle<DetIdAssociator> preshowerDetIdAssociator_;
-   
-   edm::ESHandle<CaloGeometry> theCaloGeometry_;
-   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry_;
-   
-   edm::ESWatcher<IdealMagneticFieldRecord>     theMagneticFeildWatcher_;
+  /// use a user configured propagator
+  void setPropagator(const Propagator*);
+
+  /// use the default propagator
+  void useDefaultPropagator();
+
+  /// get FreeTrajectoryState from different track representations
+  static FreeTrajectoryState getFreeTrajectoryState(const edm::EventSetup&, const reco::Track&);
+  static FreeTrajectoryState getFreeTrajectoryState(const edm::EventSetup&, const SimTrack&, const SimVertex&);
+  static FreeTrajectoryState getFreeTrajectoryState(const edm::EventSetup&,
+                                                    const GlobalVector&,
+                                                    const GlobalPoint&,
+                                                    const int);
+
+  static bool crossedIP(const reco::Track& track);
+
+private:
+  DetIdAssociator::MapRange getMapRange(const std::pair<float, float>& delta, const float dR) dso_internal;
+
+  void fillEcal(const edm::Event&, TrackDetMatchInfo&, const AssociatorParameters&) dso_internal;
+
+  void fillCaloTowers(const edm::Event&, TrackDetMatchInfo&, const AssociatorParameters&) dso_internal;
+
+  void fillHcal(const edm::Event&, TrackDetMatchInfo&, const AssociatorParameters&) dso_internal;
+
+  void fillHO(const edm::Event&, TrackDetMatchInfo&, const AssociatorParameters&) dso_internal;
+
+  void fillPreshower(const edm::Event& iEvent, TrackDetMatchInfo& info, const AssociatorParameters&) dso_internal;
+
+  void fillMuon(const edm::Event&, TrackDetMatchInfo&, const AssociatorParameters&) dso_internal;
+
+  void fillCaloTruth(const edm::Event&, TrackDetMatchInfo&, const AssociatorParameters&) dso_internal;
+
+  bool addTAMuonSegmentMatch(TAMuonChamberMatch&, const RecSegment*, const AssociatorParameters&) dso_internal;
+
+  void getTAMuonChamberMatches(std::vector<TAMuonChamberMatch>& matches,
+                               const AssociatorParameters& parameters) dso_internal;
+
+  void init(const edm::EventSetup&) dso_internal;
+
+  math::XYZPoint getPoint(const GlobalPoint& point) dso_internal {
+    return math::XYZPoint(point.x(), point.y(), point.z());
+  }
+
+  math::XYZPoint getPoint(const LocalPoint& point) dso_internal {
+    return math::XYZPoint(point.x(), point.y(), point.z());
+  }
+
+  math::XYZVector getVector(const GlobalVector& vec) dso_internal { return math::XYZVector(vec.x(), vec.y(), vec.z()); }
+
+  math::XYZVector getVector(const LocalVector& vec) dso_internal { return math::XYZVector(vec.x(), vec.y(), vec.z()); }
+
+  const Propagator* ivProp_;
+  Propagator* defProp_;
+  CachedTrajectory cachedTrajectory_;
+  bool useDefaultPropagator_;
+
+  edm::ESHandle<DetIdAssociator> ecalDetIdAssociator_;
+  edm::ESHandle<DetIdAssociator> hcalDetIdAssociator_;
+  edm::ESHandle<DetIdAssociator> hoDetIdAssociator_;
+  edm::ESHandle<DetIdAssociator> caloDetIdAssociator_;
+  edm::ESHandle<DetIdAssociator> muonDetIdAssociator_;
+  edm::ESHandle<DetIdAssociator> preshowerDetIdAssociator_;
+
+  edm::ESHandle<CaloGeometry> theCaloGeometry_;
+  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry_;
+
+  edm::ESWatcher<IdealMagneticFieldRecord> theMagneticFeildWatcher_;
 };
 #endif

--- a/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.cc
+++ b/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.cc
@@ -1,218 +1,228 @@
 #include "CaloDetIdAssociator.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 bool CaloDetIdAssociator::crossedElement(const GlobalPoint& point1,
-					 const GlobalPoint& point2,
-					 const DetId& id,
-					 const double toleranceInSigmas,
-					 const SteppingHelixStateInfo* initialState
-					 ) const
-{
-   std::vector<GlobalPoint> pointBuffer;
-   const std::pair<const_iterator,const_iterator>& points = getDetIdPoints(id, pointBuffer);
-   // fast check
-   bool xLess(false), xIn(false), xMore(false);
-   bool yLess(false), yIn(false), yMore(false);
-   bool zLess(false), zIn(false), zMore(false);
-   double xMin(point1.x()), xMax(point2.x());
-   double yMin(point1.y()), yMax(point2.y());
-   double zMin(point1.z()), zMax(point2.z());
-   if ( xMin>xMax ) std::swap(xMin,xMax);
-   if ( yMin>yMax ) std::swap(yMin,yMax);
-   if ( zMin>zMax ) std::swap(zMin,zMax);
-   for ( std::vector<GlobalPoint>::const_iterator it = points.first;
-	 it != points.second; ++it ){
-     if ( it->x()<xMin ){
-       xLess = true;
-     } else {
-       if ( it->x()>xMax )
-	 xMore = true;
-       else
-	 xIn = true;
-     }
-     if ( it->y()<yMin ){
-       yLess = true;
-     } else {
-       if ( it->y()>yMax )
-	 yMore = true;
-       else
-	 yIn = true;
-     }
-     if ( it->z()<zMin ){
-       zLess = true;
-     } else {
-       if ( it->z()>zMax )
-	 zMore = true;
-       else
-	 zIn = true;
-     }
-   }
-   if ( ( (xLess && !xIn && !xMore) || (!xLess && !xIn && xMore) ) ||
-	( (yLess && !yIn && !yMore) || (!yLess && !yIn && yMore) ) ||
-	( (zLess && !zIn && !zMore) || (!zLess && !zIn && zMore) ) ) return false;
+                                         const GlobalPoint& point2,
+                                         const DetId& id,
+                                         const double toleranceInSigmas,
+                                         const SteppingHelixStateInfo* initialState) const {
+  std::vector<GlobalPoint> pointBuffer;
+  const std::pair<const_iterator, const_iterator>& points = getDetIdPoints(id, pointBuffer);
+  // fast check
+  bool xLess(false), xIn(false), xMore(false);
+  bool yLess(false), yIn(false), yMore(false);
+  bool zLess(false), zIn(false), zMore(false);
+  double xMin(point1.x()), xMax(point2.x());
+  double yMin(point1.y()), yMax(point2.y());
+  double zMin(point1.z()), zMax(point2.z());
+  if (xMin > xMax)
+    std::swap(xMin, xMax);
+  if (yMin > yMax)
+    std::swap(yMin, yMax);
+  if (zMin > zMax)
+    std::swap(zMin, zMax);
+  for (std::vector<GlobalPoint>::const_iterator it = points.first; it != points.second; ++it) {
+    if (it->x() < xMin) {
+      xLess = true;
+    } else {
+      if (it->x() > xMax)
+        xMore = true;
+      else
+        xIn = true;
+    }
+    if (it->y() < yMin) {
+      yLess = true;
+    } else {
+      if (it->y() > yMax)
+        yMore = true;
+      else
+        yIn = true;
+    }
+    if (it->z() < zMin) {
+      zLess = true;
+    } else {
+      if (it->z() > zMax)
+        zMore = true;
+      else
+        zIn = true;
+    }
+  }
+  if (((xLess && !xIn && !xMore) || (!xLess && !xIn && xMore)) ||
+      ((yLess && !yIn && !yMore) || (!yLess && !yIn && yMore)) ||
+      ((zLess && !zIn && !zMore) || (!zLess && !zIn && zMore)))
+    return false;
 
-   // Define plane normal to the trajectory direction at the first point
-   GlobalVector vector = (point2-point1).unit();
-   float r21 = 0;
-   float r22 = vector.z()/sqrt(1-pow(vector.x(),2));
-   float r23 = -vector.y()/sqrt(1-pow(vector.x(),2));
-   float r31 = vector.x();
-   float r32 = vector.y();
-   float r33 = vector.z();
-   float r11 = r22*r33-r23*r32;
-   float r12 = r23*r31;
-   float r13 = -r22*r31;
-   
-   Surface::RotationType rotation(r11, r12, r13,
-				  r21, r22, r23,
-				  r31, r32, r33);
-   Plane::PlanePointer plane = Plane::build(point1, rotation);
-   double absoluteTolerance = -1;
-   if ( toleranceInSigmas>0 && initialState ){
-      TrajectoryStateOnSurface tsos = initialState->getStateOnSurface(*plane);
-      if ( tsos.isValid() and tsos.hasError()) {
-	 LocalError localErr = tsos.localError().positionError();
-	 localErr.scale(toleranceInSigmas); 
-	 float xx = localErr.xx();
-	 float xy = localErr.xy();
-	 float yy = localErr.yy();
+  // Define plane normal to the trajectory direction at the first point
+  GlobalVector vector = (point2 - point1).unit();
+  float r21 = 0;
+  float r22 = vector.z() / sqrt(1 - pow(vector.x(), 2));
+  float r23 = -vector.y() / sqrt(1 - pow(vector.x(), 2));
+  float r31 = vector.x();
+  float r32 = vector.y();
+  float r33 = vector.z();
+  float r11 = r22 * r33 - r23 * r32;
+  float r12 = r23 * r31;
+  float r13 = -r22 * r31;
 
-	 float denom = yy - xx;
-	 float phi = 0.;
-	 if(xy == 0 && denom==0) phi = M_PI_4;
-	 else phi = 0.5 * atan2(2.*xy,denom); // angle of MAJOR axis
-	 // Unrotate the error ellipse to get the semimajor and minor axes. Then place points on
-	 // the endpoints of semiminor an seminajor axes on original(rotated) error ellipse.
-	 LocalError rotErr = localErr.rotate(-phi); // xy covariance of rotErr should be zero
-	 float semi1 = sqrt(rotErr.xx());
-	 float semi2 = sqrt(rotErr.yy());
-	 absoluteTolerance = std::max(semi1,semi2);
-      }
-   }
-   
-   // distance between the points.
-   double trajectorySegmentLength = (point2-point1).mag();
+  Surface::RotationType rotation(r11, r12, r13, r21, r22, r23, r31, r32, r33);
+  Plane::PlanePointer plane = Plane::build(point1, rotation);
+  double absoluteTolerance = -1;
+  if (toleranceInSigmas > 0 && initialState) {
+    TrajectoryStateOnSurface tsos = initialState->getStateOnSurface(*plane);
+    if (tsos.isValid() and tsos.hasError()) {
+      LocalError localErr = tsos.localError().positionError();
+      localErr.scale(toleranceInSigmas);
+      float xx = localErr.xx();
+      float xy = localErr.xy();
+      float yy = localErr.yy();
 
-   // we need to find the angle that covers all points. 
-   // if it's bigger than 180 degree, we are inside
-   // otherwise we are outside, i.e. the volume is not crossed
-   bool allBehind = true;
-   bool allTooFar = true;
-   std::vector<GlobalPoint>::const_iterator p = points.first;
-   if ( p == points.second ) {
-      edm::LogWarning("TrackAssociator") << "calo geometry for element " << id.rawId() << "is empty. Ignored"; 
-      return false; 
-   }
-   LocalPoint localPoint = plane->toLocal(*p);
-   double minPhi = localPoint.phi();
-   double maxPhi = localPoint.phi();
-   if ( localPoint.z() < 0 ) 
-     allTooFar = false;
-   else {  
+      float denom = yy - xx;
+      float phi = 0.;
+      if (xy == 0 && denom == 0)
+        phi = M_PI_4;
+      else
+        phi = 0.5 * atan2(2. * xy, denom);  // angle of MAJOR axis
+      // Unrotate the error ellipse to get the semimajor and minor axes. Then place points on
+      // the endpoints of semiminor an seminajor axes on original(rotated) error ellipse.
+      LocalError rotErr = localErr.rotate(-phi);  // xy covariance of rotErr should be zero
+      float semi1 = sqrt(rotErr.xx());
+      float semi2 = sqrt(rotErr.yy());
+      absoluteTolerance = std::max(semi1, semi2);
+    }
+  }
+
+  // distance between the points.
+  double trajectorySegmentLength = (point2 - point1).mag();
+
+  // we need to find the angle that covers all points.
+  // if it's bigger than 180 degree, we are inside
+  // otherwise we are outside, i.e. the volume is not crossed
+  bool allBehind = true;
+  bool allTooFar = true;
+  std::vector<GlobalPoint>::const_iterator p = points.first;
+  if (p == points.second) {
+    edm::LogWarning("TrackAssociator") << "calo geometry for element " << id.rawId() << "is empty. Ignored";
+    return false;
+  }
+  LocalPoint localPoint = plane->toLocal(*p);
+  double minPhi = localPoint.phi();
+  double maxPhi = localPoint.phi();
+  if (localPoint.z() < 0)
+    allTooFar = false;
+  else {
+    allBehind = false;
+    if (localPoint.z() < trajectorySegmentLength)
+      allTooFar = false;
+  }
+  ++p;
+  for (; p != points.second; ++p) {
+    localPoint = plane->toLocal(*p);
+    double localPhi = localPoint.phi();
+    if (localPoint.z() < 0)
+      allTooFar = false;
+    else {
       allBehind = false;
-      if ( localPoint.z() < trajectorySegmentLength )  allTooFar = false;
-   }
-   ++p;
-   for (; p!=points.second; ++p){
-      localPoint = plane->toLocal(*p);
-      double localPhi = localPoint.phi();
-      if ( localPoint.z() < 0 ) 
-	allTooFar = false;
-      else {  
-	 allBehind = false;
-	 if ( localPoint.z() < trajectorySegmentLength )  allTooFar = false;
+      if (localPoint.z() < trajectorySegmentLength)
+        allTooFar = false;
+    }
+    if (localPhi >= minPhi && localPhi <= maxPhi)
+      continue;
+    if (localPhi + 2 * M_PI >= minPhi && localPhi + 2 * M_PI <= maxPhi)
+      continue;
+    if (localPhi - 2 * M_PI >= minPhi && localPhi - 2 * M_PI <= maxPhi)
+      continue;
+    // find the closest limit
+    if (localPhi > maxPhi) {
+      double delta1 = fabs(localPhi - maxPhi);
+      double delta2 = fabs(localPhi - 2 * M_PI - minPhi);
+      if (delta1 < delta2)
+        maxPhi = localPhi;
+      else
+        minPhi = localPhi - 2 * M_PI;
+      continue;
+    }
+    if (localPhi < minPhi) {
+      double delta1 = fabs(localPhi - minPhi);
+      double delta2 = fabs(localPhi + 2 * M_PI - maxPhi);
+      if (delta1 < delta2)
+        minPhi = localPhi;
+      else
+        maxPhi = localPhi + 2 * M_PI;
+      continue;
+    }
+    cms::Exception("FatalError")
+        << "Algorithm logic error - this should never happen. Problems with trajectory-volume matching.";
+  }
+  if (allBehind)
+    return false;
+  if (allTooFar)
+    return false;
+  if (fabs(maxPhi - minPhi) > M_PI)
+    return true;
+
+  // now if the tolerance is positive, check how far we are
+  // from the closest line segment
+  if (absoluteTolerance < 0)
+    return false;
+  double distanceToClosestLineSegment = 1e9;
+  std::vector<GlobalPoint>::const_iterator i, j;
+  for (i = points.first; i != points.second; ++i)
+    for (j = i + 1; j != points.second; ++j) {
+      LocalPoint p1(plane->toLocal(*i));
+      LocalPoint p2(plane->toLocal(*j));
+      // now we deal with high school level math to get
+      // the triangle paramaters
+      double side1squared = p1.perp2();
+      double side2squared = p2.perp2();
+      double side3squared = (p2.x() - p1.x()) * (p2.x() - p1.x()) + (p2.y() - p1.y()) * (p2.y() - p1.y());
+      double area = fabs(p1.x() * p2.y() - p2.x() * p1.y()) / 2;
+      // all triangle angles must be smaller than 90 degree
+      // otherwise the projection is out of the line segment
+      if (side1squared + side2squared > side3squared && side2squared + side3squared > side1squared &&
+          side1squared + side3squared > side1squared) {
+        double h(2 * area / sqrt(side3squared));
+        if (h < distanceToClosestLineSegment)
+          distanceToClosestLineSegment = h;
+      } else {
+        if (sqrt(side1squared) < distanceToClosestLineSegment)
+          distanceToClosestLineSegment = sqrt(side1squared);
+        if (sqrt(side2squared) < distanceToClosestLineSegment)
+          distanceToClosestLineSegment = sqrt(side2squared);
       }
-      if ( localPhi >= minPhi && localPhi <= maxPhi ) continue;
-      if ( localPhi+2*M_PI >= minPhi && localPhi+2*M_PI <= maxPhi ) continue;
-      if ( localPhi-2*M_PI >= minPhi && localPhi-2*M_PI <= maxPhi ) continue;
-      // find the closest limit
-      if ( localPhi > maxPhi ){
-	 double delta1 = fabs(localPhi-maxPhi);
-	 double delta2 = fabs(localPhi-2*M_PI-minPhi);
-	 if ( delta1 < delta2 )
-	   maxPhi = localPhi;
-	 else
-	   minPhi = localPhi-2*M_PI;
-	 continue;
-      }
-      if ( localPhi < minPhi ){
-	 double delta1 = fabs(localPhi-minPhi);
-	 double delta2 = fabs(localPhi+2*M_PI-maxPhi);
-	 if ( delta1 < delta2 )
-	   minPhi = localPhi;
-	 else
-	   maxPhi = localPhi+2*M_PI;
-	 continue;
-      }
-      cms::Exception("FatalError") << "Algorithm logic error - this should never happen. Problems with trajectory-volume matching.";
-   }
-   if ( allBehind ) return false;
-   if ( allTooFar ) return false;
-   if ( fabs(maxPhi-minPhi)>M_PI ) return true;
-   
-   // now if the tolerance is positive, check how far we are 
-   // from the closest line segment
-   if (absoluteTolerance < 0 ) return false;
-   double distanceToClosestLineSegment = 1e9;
-   std::vector<GlobalPoint>::const_iterator i,j;
-   for ( i = points.first; i != points.second; ++i )
-     for ( j = i+1; j != points.second; ++j )
-       {
-	  LocalPoint p1(plane->toLocal(*i));
-	  LocalPoint p2(plane->toLocal(*j));
-	  // now we deal with high school level math to get
-	  // the triangle paramaters
-	  double side1squared = p1.perp2();
-	  double side2squared = p2.perp2();
-	  double side3squared = (p2.x()-p1.x())*(p2.x()-p1.x()) + (p2.y()-p1.y())*(p2.y()-p1.y());
-	  double area = fabs(p1.x()*p2.y()-p2.x()*p1.y())/2;
-	  // all triangle angles must be smaller than 90 degree
-	  // otherwise the projection is out of the line segment
-	  if ( side1squared + side2squared > side3squared &&
-	       side2squared + side3squared > side1squared &&
-	       side1squared + side3squared > side1squared )
-	    {
-	       double h(2*area/sqrt(side3squared));
-	       if ( h < distanceToClosestLineSegment ) distanceToClosestLineSegment = h;
-	    }
-	  else
-	    {
-	       if ( sqrt(side1squared) < distanceToClosestLineSegment ) distanceToClosestLineSegment = sqrt(side1squared);
-	       if ( sqrt(side2squared) < distanceToClosestLineSegment ) distanceToClosestLineSegment = sqrt(side2squared);
-	    }
-       }
-   if ( distanceToClosestLineSegment < absoluteTolerance ) return true;
-   return false;
+    }
+  if (distanceToClosestLineSegment < absoluteTolerance)
+    return true;
+  return false;
 }
 
-void CaloDetIdAssociator::check_setup() const
-{
+void CaloDetIdAssociator::check_setup() const {
   DetIdAssociator::check_setup();
-  if (geometry_==nullptr) throw cms::Exception("CaloGeometry is not set");
+  if (geometry_ == nullptr)
+    throw cms::Exception("CaloGeometry is not set");
 }
-   
+
 GlobalPoint CaloDetIdAssociator::getPosition(const DetId& id) const {
   return geometry_->getSubdetectorGeometry(id)->getGeometry(id)->getPosition();
 }
-   
-void CaloDetIdAssociator::getValidDetIds(unsigned int subDectorIndex, std::vector<DetId>& detIds) const 
-{
-  if ( subDectorIndex!=0 ) cms::Exception("FatalError") << "Calo sub-dectors are all handle as one sub-system, but subDetectorIndex is not zero.\n";
+
+void CaloDetIdAssociator::getValidDetIds(unsigned int subDectorIndex, std::vector<DetId>& detIds) const {
+  if (subDectorIndex != 0)
+    cms::Exception("FatalError")
+        << "Calo sub-dectors are all handle as one sub-system, but subDetectorIndex is not zero.\n";
   detIds = geometry_->getValidDetIds(DetId::Calo, 1);
 }
-   
-std::pair<DetIdAssociator::const_iterator, DetIdAssociator::const_iterator> 
-CaloDetIdAssociator::getDetIdPoints(const DetId& id, std::vector<GlobalPoint>& points) const 
-{
+
+std::pair<DetIdAssociator::const_iterator, DetIdAssociator::const_iterator> CaloDetIdAssociator::getDetIdPoints(
+    const DetId& id, std::vector<GlobalPoint>& points) const {
   const CaloSubdetectorGeometry* subDetGeom = geometry_->getSubdetectorGeometry(id);
-  if(! subDetGeom){
-    LogDebug("TrackAssociator") << "Cannot find sub-detector geometry for " << id.rawId() <<"\n";
-    return std::pair<const_iterator,const_iterator>(dummy_.end(),dummy_.end());
+  if (!subDetGeom) {
+    LogDebug("TrackAssociator") << "Cannot find sub-detector geometry for " << id.rawId() << "\n";
+    return std::pair<const_iterator, const_iterator>(dummy_.end(), dummy_.end());
   }
   auto cellGeom = subDetGeom->getGeometry(id);
-  if(! cellGeom) {
-    LogDebug("TrackAssociator") << "Cannot find CaloCell geometry for " << id.rawId() <<"\n";
-    return std::pair<const_iterator,const_iterator>(dummy_.end(),dummy_.end());
-  } 
-  const CaloCellGeometry::CornersVec& cor (cellGeom->getCorners() ) ; 
-  return std::pair<const_iterator,const_iterator>( cor.begin(), cor.end() ) ;
+  if (!cellGeom) {
+    LogDebug("TrackAssociator") << "Cannot find CaloCell geometry for " << id.rawId() << "\n";
+    return std::pair<const_iterator, const_iterator>(dummy_.end(), dummy_.end());
+  }
+  const CaloCellGeometry::CornersVec& cor(cellGeom->getCorners());
+  return std::pair<const_iterator, const_iterator>(cor.begin(), cor.end());
 }

--- a/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.h
@@ -4,7 +4,7 @@
 //
 // Package:    TrackAssociator
 // Class:      CaloDetIdAssociator
-// 
+//
 /*
 
  Description: <one line class summary>
@@ -24,36 +24,36 @@
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
+class CaloDetIdAssociator : public DetIdAssociator {
+public:
+  CaloDetIdAssociator() : DetIdAssociator(72, 70, 0.087), geometry_(nullptr){};
+  CaloDetIdAssociator(const int nPhi, const int nEta, const double etaBinSize, CaloGeometry const* geom)
+      : DetIdAssociator(nPhi, nEta, etaBinSize), geometry_(geom){};
 
-class CaloDetIdAssociator: public DetIdAssociator{
- public:
-   CaloDetIdAssociator():DetIdAssociator(72, 70 ,0.087),geometry_(nullptr){};
- CaloDetIdAssociator(const int nPhi, const int nEta, const double etaBinSize, CaloGeometry const* geom)
-     :DetIdAssociator(nPhi, nEta, etaBinSize),geometry_(geom){};
+  const GeomDet* getGeomDet(const DetId& id) const override { return nullptr; };
 
-   const GeomDet* getGeomDet(const DetId& id) const override { return nullptr; };
+  const char* name() const override { return "CaloTowers"; }
 
-   const char* name() const override { return "CaloTowers"; }
+protected:
+  void check_setup() const override;
 
- protected:
-   void check_setup() const override;
-   
-   GlobalPoint getPosition(const DetId& id) const override;
-   
-   void getValidDetIds( unsigned int subDetectorIndex, std::vector<DetId>& ) const override;
-   
-   std::pair<const_iterator, const_iterator> getDetIdPoints(const DetId& id, std::vector<GlobalPoint>& points) const override;
+  GlobalPoint getPosition(const DetId& id) const override;
 
-   bool insideElement(const GlobalPoint& point, const DetId& id) const override{
-      return  geometry_->getSubdetectorGeometry(id)->getGeometry(id)->inside(point);
-   };
+  void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>&) const override;
 
-   bool crossedElement(const GlobalPoint&, 
-			       const GlobalPoint&, 
-			       const DetId& id,
-			       const double tolerance = -1,
-			       const SteppingHelixStateInfo* = nullptr ) const override;
-   const CaloGeometry* geometry_;
-   std::vector<GlobalPoint> dummy_;
+  std::pair<const_iterator, const_iterator> getDetIdPoints(const DetId& id,
+                                                           std::vector<GlobalPoint>& points) const override;
+
+  bool insideElement(const GlobalPoint& point, const DetId& id) const override {
+    return geometry_->getSubdetectorGeometry(id)->getGeometry(id)->inside(point);
+  };
+
+  bool crossedElement(const GlobalPoint&,
+                      const GlobalPoint&,
+                      const DetId& id,
+                      const double tolerance = -1,
+                      const SteppingHelixStateInfo* = nullptr) const override;
+  const CaloGeometry* geometry_;
+  std::vector<GlobalPoint> dummy_;
 };
 #endif

--- a/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociatorMaker.cc
+++ b/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociatorMaker.cc
@@ -2,7 +2,7 @@
 //
 // Package:     TrackingTools/TrackAssociator
 // Class  :     CaloDetIdAssociatorMaker
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -32,24 +32,19 @@
 // constructors and destructor
 //
 CaloDetIdAssociatorMaker::CaloDetIdAssociatorMaker(edm::ParameterSet const& pSet,
-                                                   edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& iCollector):
-  geomToken_{ iCollector.consumesFrom<CaloGeometry, CaloGeometryRecord>()},
-  etaBinSize{pSet.getParameter<double>("etaBinSize")},
-  nPhi{pSet.getParameter<int>("nPhi")},
-  nEta{pSet.getParameter<int>("nEta")}
-{
-}
+                                                   edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& iCollector)
+    : geomToken_{iCollector.consumesFrom<CaloGeometry, CaloGeometryRecord>()},
+      etaBinSize{pSet.getParameter<double>("etaBinSize")},
+      nPhi{pSet.getParameter<int>("nPhi")},
+      nEta{pSet.getParameter<int>("nEta")} {}
 
-std::unique_ptr<DetIdAssociator> 
-CaloDetIdAssociatorMaker::make(const DetIdAssociatorRecord& iRecord) const {
+std::unique_ptr<DetIdAssociator> CaloDetIdAssociatorMaker::make(const DetIdAssociatorRecord& iRecord) const {
   return make(iRecord.get(geomToken_), nPhi, nEta, etaBinSize);
 }
 
-std::unique_ptr<DetIdAssociator> 
-CaloDetIdAssociatorMaker::make(CaloGeometry const& iGeom, int nPhi, int nEta, double etaBinSize ) const {
-  return std::unique_ptr<DetIdAssociator>(
-                                          new CaloDetIdAssociator(nPhi, nEta, etaBinSize, &iGeom)
-                                          );
+std::unique_ptr<DetIdAssociator> CaloDetIdAssociatorMaker::make(CaloGeometry const& iGeom,
+                                                                int nPhi,
+                                                                int nEta,
+                                                                double etaBinSize) const {
+  return std::unique_ptr<DetIdAssociator>(new CaloDetIdAssociator(nPhi, nEta, etaBinSize, &iGeom));
 }
-
-

--- a/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociatorMaker.h
@@ -4,7 +4,7 @@
 //
 // Package:     TrackingTools/TrackAssociator
 // Class  :     CaloDetIdAssociatorMaker
-// 
+//
 /**\class CaloDetIdAssociatorMaker CaloDetIdAssociatorMaker.h "CaloDetIdAssociatorMaker.h"
 
  Description: [one line class summary]
@@ -33,23 +33,19 @@ class DetIdAssociatorRecord;
 class CaloGeometry;
 class CaloGeometryRecord;
 
-class CaloDetIdAssociatorMaker : public DetIdAssociatorMaker
-{
-  
- public:
-  CaloDetIdAssociatorMaker(edm::ParameterSet const&,
-                           edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& );
-  
+class CaloDetIdAssociatorMaker : public DetIdAssociatorMaker {
+public:
+  CaloDetIdAssociatorMaker(edm::ParameterSet const&, edm::ESConsumesCollectorT<DetIdAssociatorRecord>&&);
+
   // ---------- const member functions ---------------------
   std::unique_ptr<DetIdAssociator> make(const DetIdAssociatorRecord&) const final;
-  
- private:
-  virtual std::unique_ptr<DetIdAssociator> make(CaloGeometry const&, int nPhi, int nEta, double etaBinSize ) const;
+
+private:
+  virtual std::unique_ptr<DetIdAssociator> make(CaloGeometry const&, int nPhi, int nEta, double etaBinSize) const;
   const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
   const double etaBinSize;
   const int nPhi;
   const int nEta;
 };
-
 
 #endif

--- a/TrackingTools/TrackAssociator/plugins/DetIdAssociatorESProducer.cc
+++ b/TrackingTools/TrackAssociator/plugins/DetIdAssociatorESProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    DetIdAssociatorESProducer
 // Class:      DetIdAssociatorESProducer
-// 
+//
 /**\class DetIdAssociatorESProducer TrackingTools/TrackAssociator/plugins/DetIdAssociatorESProducer.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Thu Oct  4 02:28:48 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -30,7 +29,6 @@
 
 #include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
 
-
 //
 // class decleration
 //
@@ -39,10 +37,11 @@ class DetIdAssociatorESProducer : public edm::ESProducer {
 public:
   DetIdAssociatorESProducer(const edm::ParameterSet&);
   ~DetIdAssociatorESProducer() override;
-  
+
   typedef std::unique_ptr<DetIdAssociator> ReturnType;
-  
+
   ReturnType produce(const DetIdAssociatorRecord&);
+
 private:
   const std::string cName;
   std::unique_ptr<const DetIdAssociatorMaker> maker_;
@@ -59,32 +58,24 @@ private:
 //
 // constructors and destructor
 //
-DetIdAssociatorESProducer::DetIdAssociatorESProducer(const edm::ParameterSet& iConfig):
-  cName {iConfig.getParameter<std::string>("ComponentName") },
-  maker_{ DetIdAssociatorFactory::get()->create(cName, iConfig, setWhatProduced(this, cName) ) }
-{
-}
+DetIdAssociatorESProducer::DetIdAssociatorESProducer(const edm::ParameterSet& iConfig)
+    : cName{iConfig.getParameter<std::string>("ComponentName")},
+      maker_{DetIdAssociatorFactory::get()->create(cName, iConfig, setWhatProduced(this, cName))} {}
 
-
-DetIdAssociatorESProducer::~DetIdAssociatorESProducer()
-{
-}
-
+DetIdAssociatorESProducer::~DetIdAssociatorESProducer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-DetIdAssociatorESProducer::ReturnType
-DetIdAssociatorESProducer::produce(const DetIdAssociatorRecord& iRecord)
-{
-   using namespace edm::es;
-   LogTrace("TrackAssociator") << "Making DetIdAssociatorRecord with label: " << cName;
-   ReturnType dia = maker_->make(iRecord);
-   dia->buildMap();
-   LogTrace("TrackAssociator") << "Map id built for DetIdAssociatorRecord with label: " << cName;
-   return dia;
+DetIdAssociatorESProducer::ReturnType DetIdAssociatorESProducer::produce(const DetIdAssociatorRecord& iRecord) {
+  using namespace edm::es;
+  LogTrace("TrackAssociator") << "Making DetIdAssociatorRecord with label: " << cName;
+  ReturnType dia = maker_->make(iRecord);
+  dia->buildMap();
+  LogTrace("TrackAssociator") << "Map id built for DetIdAssociatorRecord with label: " << cName;
+  return dia;
 }
 
 //define this as a plug-in

--- a/TrackingTools/TrackAssociator/plugins/DetIdAssociatorFactory.cc
+++ b/TrackingTools/TrackAssociator/plugins/DetIdAssociatorFactory.cc
@@ -2,4 +2,3 @@
 #include "DetIdAssociatorFactory.h"
 
 EDM_REGISTER_PLUGINFACTORY(DetIdAssociatorFactory, "DetIdAssociatorFactory");
-

--- a/TrackingTools/TrackAssociator/plugins/DetIdAssociatorFactory.h
+++ b/TrackingTools/TrackAssociator/plugins/DetIdAssociatorFactory.h
@@ -6,6 +6,8 @@
 #include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "DetIdAssociatorMaker.h"
 
-typedef edmplugin::PluginFactory<DetIdAssociatorMaker * ( const edm::ParameterSet& pSet, edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& )> DetIdAssociatorFactory;
+typedef edmplugin::PluginFactory<DetIdAssociatorMaker*(const edm::ParameterSet& pSet,
+                                                       edm::ESConsumesCollectorT<DetIdAssociatorRecord>&&)>
+    DetIdAssociatorFactory;
 
 #endif

--- a/TrackingTools/TrackAssociator/plugins/DetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/DetIdAssociatorMaker.h
@@ -4,7 +4,7 @@
 //
 // Package:     TrackingTools/TrackAssociator
 // Class  :     DetIdAssociatorMaker
-// 
+//
 /**\class DetIdAssociatorMaker DetIdAssociatorMaker.h "DetIdAssociatorMaker.h"
 
  Description: [one line class summary]
@@ -26,28 +26,24 @@
 class DetIdAssociator;
 class DetIdAssociatorRecord;
 
-class DetIdAssociatorMaker
-{
-
- public:
+class DetIdAssociatorMaker {
+public:
   DetIdAssociatorMaker() = default;
   virtual ~DetIdAssociatorMaker() = default;
 
   // ---------- const member functions ---------------------
   virtual std::unique_ptr<DetIdAssociator> make(const DetIdAssociatorRecord&) const = 0;
-  
+
   // ---------- static member functions --------------------
-  
+
   // ---------- member functions ---------------------------
 
- private:
+private:
   DetIdAssociatorMaker(const DetIdAssociatorMaker&) = delete;
-  
-  const DetIdAssociatorMaker& operator=(const DetIdAssociatorMaker&) = delete;
-  
-  // ---------- member data --------------------------------
-  
-};
 
+  const DetIdAssociatorMaker& operator=(const DetIdAssociatorMaker&) = delete;
+
+  // ---------- member data --------------------------------
+};
 
 #endif

--- a/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociator.h
@@ -4,7 +4,7 @@
 //
 // Package:    TrackAssociator
 // Class:      EcalDetIdAssociator
-// 
+//
 /*
 
  Description: <one line class summary>
@@ -20,23 +20,21 @@
 
 #include "CaloDetIdAssociator.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
-class EcalDetIdAssociator: public CaloDetIdAssociator{
- public:
-   EcalDetIdAssociator():CaloDetIdAssociator(360,300,0.02,nullptr){};
+class EcalDetIdAssociator : public CaloDetIdAssociator {
+public:
+  EcalDetIdAssociator() : CaloDetIdAssociator(360, 300, 0.02, nullptr){};
 
-   using CaloDetIdAssociator::CaloDetIdAssociator;
+  using CaloDetIdAssociator::CaloDetIdAssociator;
 
-   const char* name() const override { return "ECAL"; }
+  const char* name() const override { return "ECAL"; }
 
- protected:
-
-   const unsigned int getNumberOfSubdetectors() const override { return 2;}
-   void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const  override{
-     if ( subDetectorIndex == 0 )
-       validIds = geometry_->getValidDetIds(DetId::Ecal, EcalBarrel);//EB
-     else
-       validIds = geometry_->getValidDetIds(DetId::Ecal, EcalEndcap);//EE
-   };
-
+protected:
+  const unsigned int getNumberOfSubdetectors() const override { return 2; }
+  void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const override {
+    if (subDetectorIndex == 0)
+      validIds = geometry_->getValidDetIds(DetId::Ecal, EcalBarrel);  //EB
+    else
+      validIds = geometry_->getValidDetIds(DetId::Ecal, EcalEndcap);  //EE
+  };
 };
 #endif

--- a/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociatorMaker.h
@@ -4,7 +4,7 @@
 //
 // Package:     TrackingTools/TrackAssociator
 // Class  :     EcalDetIdAssociatorMaker
-// 
+//
 /**\class EcalDetIdAssociatorMaker EcalDetIdAssociatorMaker.h "EcalDetIdAssociatorMaker.h"
 
  Description: [one line class summary]
@@ -26,18 +26,14 @@
 #include "CaloDetIdAssociatorMaker.h"
 #include "EcalDetIdAssociator.h"
 
-class EcalDetIdAssociatorMaker : public CaloDetIdAssociatorMaker
-{
-
- public:
+class EcalDetIdAssociatorMaker : public CaloDetIdAssociatorMaker {
+public:
   using CaloDetIdAssociatorMaker::CaloDetIdAssociatorMaker;
-  
- private:
-  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize ) const final {
-    return std::unique_ptr<DetIdAssociator>( new EcalDetIdAssociator(nPhi,nEta, etaBinSize, &geom) );
+
+private:
+  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize) const final {
+    return std::unique_ptr<DetIdAssociator>(new EcalDetIdAssociator(nPhi, nEta, etaBinSize, &geom));
   }
-
 };
-
 
 #endif

--- a/TrackingTools/TrackAssociator/plugins/HODetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/HODetIdAssociator.h
@@ -4,7 +4,7 @@
 //
 // Package:    TrackAssociator
 // Class:      HODetIdAssociator
-// 
+//
 /*
 
  Description: <one line class summary>
@@ -20,21 +20,20 @@
 
 #include "CaloDetIdAssociator.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-class HODetIdAssociator: public CaloDetIdAssociator{
- public:
-   HODetIdAssociator():CaloDetIdAssociator(72,30,0.087, nullptr){};
+class HODetIdAssociator : public CaloDetIdAssociator {
+public:
+  HODetIdAssociator() : CaloDetIdAssociator(72, 30, 0.087, nullptr){};
 
-   using CaloDetIdAssociator::CaloDetIdAssociator;
+  using CaloDetIdAssociator::CaloDetIdAssociator;
 
-   const char* name() const override { return "HO"; }
+  const char* name() const override { return "HO"; }
 
- protected:
-
-   void getValidDetIds(unsigned int subDectorIndex, std::vector<DetId>& validIds) const override
-     {
-       if ( subDectorIndex!=0 ) cms::Exception("FatalError") << 
-	 "HO sub-dectors are all handle as one sub-system, but subDetectorIndex is not zero.\n";
-       validIds = geometry_->getValidDetIds(DetId::Hcal, HcalOuter);
-     }
+protected:
+  void getValidDetIds(unsigned int subDectorIndex, std::vector<DetId>& validIds) const override {
+    if (subDectorIndex != 0)
+      cms::Exception("FatalError")
+          << "HO sub-dectors are all handle as one sub-system, but subDetectorIndex is not zero.\n";
+    validIds = geometry_->getValidDetIds(DetId::Hcal, HcalOuter);
+  }
 };
 #endif

--- a/TrackingTools/TrackAssociator/plugins/HODetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/HODetIdAssociatorMaker.h
@@ -4,7 +4,7 @@
 //
 // Package:     TrackingTools/TrackAssociator
 // Class  :     HODetIdAssociatorMaker
-// 
+//
 /**\class HODetIdAssociatorMaker HODetIdAssociatorMaker.h "HODetIdAssociatorMaker.h"
 
  Description: [one line class summary]
@@ -26,18 +26,14 @@
 #include "CaloDetIdAssociatorMaker.h"
 #include "HODetIdAssociator.h"
 
-class HODetIdAssociatorMaker : public CaloDetIdAssociatorMaker
-{
-
- public:
+class HODetIdAssociatorMaker : public CaloDetIdAssociatorMaker {
+public:
   using CaloDetIdAssociatorMaker::CaloDetIdAssociatorMaker;
-  
- private:
-  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize ) const final {
-    return std::unique_ptr<DetIdAssociator>( new HODetIdAssociator(nPhi,nEta, etaBinSize, &geom) );
+
+private:
+  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize) const final {
+    return std::unique_ptr<DetIdAssociator>(new HODetIdAssociator(nPhi, nEta, etaBinSize, &geom));
   }
-
 };
-
 
 #endif

--- a/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociator.h
@@ -4,7 +4,7 @@
 //
 // Package:    TrackAssociator
 // Class:      HcalDetIdAssociator
-// 
+//
 /*
 
  Description: <one line class summary>
@@ -20,25 +20,23 @@
 
 #include "CaloDetIdAssociator.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-class HcalDetIdAssociator: public CaloDetIdAssociator{
- public:
-   HcalDetIdAssociator():CaloDetIdAssociator(72, 70 ,0.087, nullptr){};
+class HcalDetIdAssociator : public CaloDetIdAssociator {
+public:
+  HcalDetIdAssociator() : CaloDetIdAssociator(72, 70, 0.087, nullptr){};
 
-   HcalDetIdAssociator(int hcalReg, int nPhi, int nEta, double etaBinSize, CaloGeometry const* geom):
-     CaloDetIdAssociator(nPhi, nEta, etaBinSize, geom),
-     hcalReg_{hcalReg}{}
+  HcalDetIdAssociator(int hcalReg, int nPhi, int nEta, double etaBinSize, CaloGeometry const* geom)
+      : CaloDetIdAssociator(nPhi, nEta, etaBinSize, geom), hcalReg_{hcalReg} {}
 
-   const char* name() const override { return "HCAL"; }
+  const char* name() const override { return "HCAL"; }
 
- protected:
-    
-   int hcalReg_;
-   const unsigned int getNumberOfSubdetectors() const override { return hcalReg_;}
-   void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const override {
-     if ( subDetectorIndex == 0 )
-       validIds = geometry_->getValidDetIds(DetId::Hcal, HcalBarrel);//HB
-     else
-       validIds = geometry_->getValidDetIds(DetId::Hcal, HcalEndcap);//HE
-   };
+protected:
+  int hcalReg_;
+  const unsigned int getNumberOfSubdetectors() const override { return hcalReg_; }
+  void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const override {
+    if (subDetectorIndex == 0)
+      validIds = geometry_->getValidDetIds(DetId::Hcal, HcalBarrel);  //HB
+    else
+      validIds = geometry_->getValidDetIds(DetId::Hcal, HcalEndcap);  //HE
+  };
 };
 #endif

--- a/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociatorMaker.cc
+++ b/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociatorMaker.cc
@@ -2,7 +2,7 @@
 //
 // Package:     TrackingTools/TrackAssociator
 // Class  :     HcalDetIdAssociatorMaker
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -27,10 +27,5 @@
 // constructors and destructor
 //
 HcalDetIdAssociatorMaker::HcalDetIdAssociatorMaker(edm::ParameterSet const& pSet,
-                                                   edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& iCollector):
-  CaloDetIdAssociatorMaker(pSet,std::move(iCollector) ),
-  hcalReg_{pSet.getParameter<int> ("hcalRegion")}
-{
-}
-
-
+                                                   edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& iCollector)
+    : CaloDetIdAssociatorMaker(pSet, std::move(iCollector)), hcalReg_{pSet.getParameter<int>("hcalRegion")} {}

--- a/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociatorMaker.h
@@ -4,7 +4,7 @@
 //
 // Package:     TrackingTools/TrackAssociator
 // Class  :     HcalDetIdAssociatorMaker
-// 
+//
 /**\class HcalDetIdAssociatorMaker HcalDetIdAssociatorMaker.h "HcalDetIdAssociatorMaker.h"
 
  Description: [one line class summary]
@@ -26,20 +26,16 @@
 #include "CaloDetIdAssociatorMaker.h"
 #include "HcalDetIdAssociator.h"
 
-class HcalDetIdAssociatorMaker : public CaloDetIdAssociatorMaker
-{
+class HcalDetIdAssociatorMaker : public CaloDetIdAssociatorMaker {
+public:
+  HcalDetIdAssociatorMaker(edm::ParameterSet const&, edm::ESConsumesCollectorT<DetIdAssociatorRecord>&&);
 
- public:
-  HcalDetIdAssociatorMaker(edm::ParameterSet const&,
-                           edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& );
-  
- private:
-  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize ) const final {
-    return std::unique_ptr<DetIdAssociator>( new HcalDetIdAssociator(hcalReg_, nPhi,nEta, etaBinSize, &geom) );
+private:
+  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize) const final {
+    return std::unique_ptr<DetIdAssociator>(new HcalDetIdAssociator(hcalReg_, nPhi, nEta, etaBinSize, &geom));
   }
 
   const int hcalReg_;
 };
-
 
 #endif

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.cc
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TrackAssociator
 // Class:      MuonDetIdAssociator
-// 
+//
 /*
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Fri Apr 21 10:59:41 PDT 2006
 //
 //
-
 
 #include "MuonDetIdAssociator.h"
 // #include "Utilities/Timing/interface/TimerStack.h"
@@ -30,112 +29,130 @@
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
 
 void MuonDetIdAssociator::check_setup() const {
-   if (geometry_==nullptr) throw cms::Exception("ConfigurationProblem") << "GlobalTrackingGeomtry is not set\n";
-   if (cscbadchambers_==nullptr) throw cms::Exception("ConfigurationProblem") << "CSCBadChambers is not set\n";
-   DetIdAssociator::check_setup();
+  if (geometry_ == nullptr)
+    throw cms::Exception("ConfigurationProblem") << "GlobalTrackingGeomtry is not set\n";
+  if (cscbadchambers_ == nullptr)
+    throw cms::Exception("ConfigurationProblem") << "CSCBadChambers is not set\n";
+  DetIdAssociator::check_setup();
 }
 
-const GeomDet* MuonDetIdAssociator::getGeomDet( const DetId& id ) const
-{
-   if (geometry_==nullptr) throw cms::Exception("ConfigurationProblem") << "GlobalTrackingGeomtry is not set\n";
-   const GeomDet* gd = geometry_->idToDet(id);
-   if (gd == nullptr) throw cms::Exception("NoGeometry") << "Cannot find GeomDet for DetID: " << id.rawId() <<"\n";
-   return gd;
+const GeomDet* MuonDetIdAssociator::getGeomDet(const DetId& id) const {
+  if (geometry_ == nullptr)
+    throw cms::Exception("ConfigurationProblem") << "GlobalTrackingGeomtry is not set\n";
+  const GeomDet* gd = geometry_->idToDet(id);
+  if (gd == nullptr)
+    throw cms::Exception("NoGeometry") << "Cannot find GeomDet for DetID: " << id.rawId() << "\n";
+  return gd;
 }
-
 
 GlobalPoint MuonDetIdAssociator::getPosition(const DetId& id) const {
-   Surface::PositionType point(getGeomDet(id)->surface().position());
-   return GlobalPoint(point.x(),point.y(),point.z());
+  Surface::PositionType point(getGeomDet(id)->surface().position());
+  return GlobalPoint(point.x(), point.y(), point.z());
 }
 
 void MuonDetIdAssociator::getValidDetIds(unsigned int subDectorIndex, std::vector<DetId>& validIds) const {
   validIds.clear();
-  if (geometry_==nullptr) throw cms::Exception("ConfigurationProblem") << "GlobalTrackingGeomtry is not set\n";
-  if (subDectorIndex!=0) throw cms::Exception("FatalError") << 
-    "Muon sub-dectors are all handle as one sub-system, but subDetectorIndex is not zero.\n";
+  if (geometry_ == nullptr)
+    throw cms::Exception("ConfigurationProblem") << "GlobalTrackingGeomtry is not set\n";
+  if (subDectorIndex != 0)
+    throw cms::Exception("FatalError")
+        << "Muon sub-dectors are all handle as one sub-system, but subDetectorIndex is not zero.\n";
 
-  // CSC 
-  if (! geometry_->slaveGeometry(CSCDetId()) ) throw cms::Exception("FatalError") << "Cannnot CSCGeometry\n";
-  auto const & geomDetsCSC = geometry_->slaveGeometry(CSCDetId())->dets();
-  for(auto it = geomDetsCSC.begin(); it != geomDetsCSC.end(); ++it)
+  // CSC
+  if (!geometry_->slaveGeometry(CSCDetId()))
+    throw cms::Exception("FatalError") << "Cannnot CSCGeometry\n";
+  auto const& geomDetsCSC = geometry_->slaveGeometry(CSCDetId())->dets();
+  for (auto it = geomDetsCSC.begin(); it != geomDetsCSC.end(); ++it)
     if (auto csc = dynamic_cast<const CSCChamber*>(*it)) {
-      if ((! includeBadChambers_) && (cscbadchambers_->isInBadChamber(CSCDetId(csc->id())))) continue;
+      if ((!includeBadChambers_) && (cscbadchambers_->isInBadChamber(CSCDetId(csc->id()))))
+        continue;
       validIds.push_back(csc->id());
     }
-  
+
   // DT
-  if (! geometry_->slaveGeometry(DTChamberId()) ) throw cms::Exception("FatalError") << "Cannnot DTGeometry\n";
-  auto const & geomDetsDT = geometry_->slaveGeometry(DTChamberId())->dets();
-  for(auto it = geomDetsDT.begin(); it != geomDetsDT.end(); ++it)
-    if (auto dt = dynamic_cast<const DTChamber*>(*it)) validIds.push_back(dt->id());
+  if (!geometry_->slaveGeometry(DTChamberId()))
+    throw cms::Exception("FatalError") << "Cannnot DTGeometry\n";
+  auto const& geomDetsDT = geometry_->slaveGeometry(DTChamberId())->dets();
+  for (auto it = geomDetsDT.begin(); it != geomDetsDT.end(); ++it)
+    if (auto dt = dynamic_cast<const DTChamber*>(*it))
+      validIds.push_back(dt->id());
 
   // RPC
-  if (! geometry_->slaveGeometry(RPCDetId()) ) throw cms::Exception("FatalError") << "Cannnot RPCGeometry\n";
-  auto const & geomDetsRPC = geometry_->slaveGeometry(RPCDetId())->dets();
-  for(auto it = geomDetsRPC.begin(); it != geomDetsRPC.end(); ++it)
+  if (!geometry_->slaveGeometry(RPCDetId()))
+    throw cms::Exception("FatalError") << "Cannnot RPCGeometry\n";
+  auto const& geomDetsRPC = geometry_->slaveGeometry(RPCDetId())->dets();
+  for (auto it = geomDetsRPC.begin(); it != geomDetsRPC.end(); ++it)
     if (auto rpc = dynamic_cast<const RPCChamber*>(*it)) {
-      std::vector< const RPCRoll*> rolls = (rpc->rolls());
-      for(std::vector<const RPCRoll*>::iterator r = rolls.begin(); r != rolls.end(); ++r)
-	validIds.push_back((*r)->id().rawId());
+      std::vector<const RPCRoll*> rolls = (rpc->rolls());
+      for (std::vector<const RPCRoll*>::iterator r = rolls.begin(); r != rolls.end(); ++r)
+        validIds.push_back((*r)->id().rawId());
     }
 
   // GEM
-  if (includeGEM_){
-    if (! geometry_->slaveGeometry(GEMDetId()) ) throw cms::Exception("FatalError") << "Cannnot GEMGeometry\n";
-    auto const & geomDetsGEM = geometry_->slaveGeometry(GEMDetId())->dets();
-    for(auto it = geomDetsGEM.begin(); it != geomDetsGEM.end(); ++it){
+  if (includeGEM_) {
+    if (!geometry_->slaveGeometry(GEMDetId()))
+      throw cms::Exception("FatalError") << "Cannnot GEMGeometry\n";
+    auto const& geomDetsGEM = geometry_->slaveGeometry(GEMDetId())->dets();
+    for (auto it = geomDetsGEM.begin(); it != geomDetsGEM.end(); ++it) {
       if (auto gem = dynamic_cast<const GEMSuperChamber*>(*it)) {
-	validIds.push_back(gem->id());
+        validIds.push_back(gem->id());
       }
     }
   }
   // ME0
-  if (includeME0_){
-    if (! geometry_->slaveGeometry(ME0DetId()) ) throw cms::Exception("FatalError") << "Cannnot ME0Geometry\n";
-    auto const & geomDetsME0 = geometry_->slaveGeometry(ME0DetId())->dets();
-    for(auto it = geomDetsME0.begin(); it != geomDetsME0.end(); ++it){
+  if (includeME0_) {
+    if (!geometry_->slaveGeometry(ME0DetId()))
+      throw cms::Exception("FatalError") << "Cannnot ME0Geometry\n";
+    auto const& geomDetsME0 = geometry_->slaveGeometry(ME0DetId())->dets();
+    for (auto it = geomDetsME0.begin(); it != geomDetsME0.end(); ++it) {
       if (auto me0 = dynamic_cast<const ME0Chamber*>(*it)) {
-	validIds.push_back(me0->id());
+        validIds.push_back(me0->id());
       }
     }
   }
-  
 }
 
 bool MuonDetIdAssociator::insideElement(const GlobalPoint& point, const DetId& id) const {
-   if (geometry_==nullptr) throw cms::Exception("ConfigurationProblem") << "GlobalTrackingGeomtry is not set\n";
-   LocalPoint lp = geometry_->idToDet(id)->toLocal(point);
-   return geometry_->idToDet(id)->surface().bounds().inside(lp);
+  if (geometry_ == nullptr)
+    throw cms::Exception("ConfigurationProblem") << "GlobalTrackingGeomtry is not set\n";
+  LocalPoint lp = geometry_->idToDet(id)->toLocal(point);
+  return geometry_->idToDet(id)->surface().bounds().inside(lp);
 }
 
-std::pair<DetIdAssociator::const_iterator,DetIdAssociator::const_iterator> 
-MuonDetIdAssociator::getDetIdPoints(const DetId& id, std::vector<GlobalPoint>& points) const 
-{
-   points.clear();
-   points.reserve(8);
-   const GeomDet* geomDet = getGeomDet( id );
-   
-   // the coners of muon detector elements are not stored and can be only calculated
-   // based on methods defined in the interface class Bounds:
-   //   width() - x
-   //   length() - y 
-   //   thinkness() - z
-   // NOTE: this convention is implementation specific and can fail. Both
-   //       RectangularPlaneBounds and TrapezoidalPlaneBounds use it.
-   // Even though the CSC geomtry is more complicated (trapezoid),  it's enough 
-   // to estimate which bins should contain this element. For the distance
-   // calculation from the edge, we will use exact geometry to get it right.
-	    
-   const Bounds* bounds = &(geometry_->idToDet(id)->surface().bounds());
-   points.push_back(geomDet->toGlobal(LocalPoint(+bounds->width()/2,+bounds->length()/2,+bounds->thickness()/2)));
-   points.push_back(geomDet->toGlobal(LocalPoint(-bounds->width()/2,+bounds->length()/2,+bounds->thickness()/2)));
-   points.push_back(geomDet->toGlobal(LocalPoint(+bounds->width()/2,-bounds->length()/2,+bounds->thickness()/2)));
-   points.push_back(geomDet->toGlobal(LocalPoint(-bounds->width()/2,-bounds->length()/2,+bounds->thickness()/2)));
-   points.push_back(geomDet->toGlobal(LocalPoint(+bounds->width()/2,+bounds->length()/2,-bounds->thickness()/2)));
-   points.push_back(geomDet->toGlobal(LocalPoint(-bounds->width()/2,+bounds->length()/2,-bounds->thickness()/2)));
-   points.push_back(geomDet->toGlobal(LocalPoint(+bounds->width()/2,-bounds->length()/2,-bounds->thickness()/2)));
-   points.push_back(geomDet->toGlobal(LocalPoint(-bounds->width()/2,-bounds->length()/2,-bounds->thickness()/2)));
-   
-   return std::pair<const_iterator,const_iterator>(points.begin(),points.end());
+std::pair<DetIdAssociator::const_iterator, DetIdAssociator::const_iterator> MuonDetIdAssociator::getDetIdPoints(
+    const DetId& id, std::vector<GlobalPoint>& points) const {
+  points.clear();
+  points.reserve(8);
+  const GeomDet* geomDet = getGeomDet(id);
+
+  // the coners of muon detector elements are not stored and can be only calculated
+  // based on methods defined in the interface class Bounds:
+  //   width() - x
+  //   length() - y
+  //   thinkness() - z
+  // NOTE: this convention is implementation specific and can fail. Both
+  //       RectangularPlaneBounds and TrapezoidalPlaneBounds use it.
+  // Even though the CSC geomtry is more complicated (trapezoid),  it's enough
+  // to estimate which bins should contain this element. For the distance
+  // calculation from the edge, we will use exact geometry to get it right.
+
+  const Bounds* bounds = &(geometry_->idToDet(id)->surface().bounds());
+  points.push_back(
+      geomDet->toGlobal(LocalPoint(+bounds->width() / 2, +bounds->length() / 2, +bounds->thickness() / 2)));
+  points.push_back(
+      geomDet->toGlobal(LocalPoint(-bounds->width() / 2, +bounds->length() / 2, +bounds->thickness() / 2)));
+  points.push_back(
+      geomDet->toGlobal(LocalPoint(+bounds->width() / 2, -bounds->length() / 2, +bounds->thickness() / 2)));
+  points.push_back(
+      geomDet->toGlobal(LocalPoint(-bounds->width() / 2, -bounds->length() / 2, +bounds->thickness() / 2)));
+  points.push_back(
+      geomDet->toGlobal(LocalPoint(+bounds->width() / 2, +bounds->length() / 2, -bounds->thickness() / 2)));
+  points.push_back(
+      geomDet->toGlobal(LocalPoint(-bounds->width() / 2, +bounds->length() / 2, -bounds->thickness() / 2)));
+  points.push_back(
+      geomDet->toGlobal(LocalPoint(+bounds->width() / 2, -bounds->length() / 2, -bounds->thickness() / 2)));
+  points.push_back(
+      geomDet->toGlobal(LocalPoint(-bounds->width() / 2, -bounds->length() / 2, -bounds->thickness() / 2)));
+
+  return std::pair<const_iterator, const_iterator>(points.begin(), points.end());
 }

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.h
@@ -4,7 +4,7 @@
 //
 // Package:    TrackAssociator
 // Class:      MuonDetIdAssociator
-// 
+//
 /*
 
  Description: <one line class summary>
@@ -26,44 +26,56 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "CondFormats/CSCObjects/interface/CSCBadChambers.h"
 
-class MuonDetIdAssociator: public DetIdAssociator{
- public:
-   MuonDetIdAssociator():DetIdAssociator(48, 48 , 0.125),geometry_(nullptr),cscbadchambers_(nullptr),includeBadChambers_(false){};
-   MuonDetIdAssociator(const int nPhi, const int nEta, const double etaBinSize)
-     :DetIdAssociator(nPhi, nEta, etaBinSize),geometry_(nullptr),cscbadchambers_(nullptr),includeBadChambers_(false){};
+class MuonDetIdAssociator : public DetIdAssociator {
+public:
+  MuonDetIdAssociator()
+      : DetIdAssociator(48, 48, 0.125), geometry_(nullptr), cscbadchambers_(nullptr), includeBadChambers_(false){};
+  MuonDetIdAssociator(const int nPhi, const int nEta, const double etaBinSize)
+      : DetIdAssociator(nPhi, nEta, etaBinSize),
+        geometry_(nullptr),
+        cscbadchambers_(nullptr),
+        includeBadChambers_(false){};
 
- MuonDetIdAssociator(int nPhi, int nEta, double etaBinSize, const GlobalTrackingGeometry* geom,
-                     const CSCBadChambers* badChambers, 
-                     bool includeBadChambers, bool includeGEM, bool includeME0)
-     :DetIdAssociator(nPhi, nEta, etaBinSize),geometry_(geom),cscbadchambers_(badChambers),
-    includeBadChambers_(includeBadChambers), includeGEM_(includeGEM), includeME0_(includeME0) {};
+  MuonDetIdAssociator(int nPhi,
+                      int nEta,
+                      double etaBinSize,
+                      const GlobalTrackingGeometry* geom,
+                      const CSCBadChambers* badChambers,
+                      bool includeBadChambers,
+                      bool includeGEM,
+                      bool includeME0)
+      : DetIdAssociator(nPhi, nEta, etaBinSize),
+        geometry_(geom),
+        cscbadchambers_(badChambers),
+        includeBadChambers_(includeBadChambers),
+        includeGEM_(includeGEM),
+        includeME0_(includeME0){};
 
-   virtual void setGeometry(const GlobalTrackingGeometry* ptr) { geometry_ = ptr; }
+  virtual void setGeometry(const GlobalTrackingGeometry* ptr) { geometry_ = ptr; }
 
-   virtual void setCSCBadChambers(const CSCBadChambers* ptr) { cscbadchambers_ = ptr; }
+  virtual void setCSCBadChambers(const CSCBadChambers* ptr) { cscbadchambers_ = ptr; }
 
-   const GeomDet* getGeomDet( const DetId& id ) const override;
+  const GeomDet* getGeomDet(const DetId& id) const override;
 
-   const char* name() const override { return "AllMuonDetectors"; }
-   
- protected:
-   
-   void check_setup() const override;
-   
-   GlobalPoint getPosition(const DetId& id) const override;
-   
-   void getValidDetIds(unsigned int, std::vector<DetId>&) const override;
-   
-   std::pair<const_iterator,const_iterator> getDetIdPoints(const DetId& id, std::vector<GlobalPoint>& points) const override;
+  const char* name() const override { return "AllMuonDetectors"; }
 
-   bool insideElement(const GlobalPoint& point, const DetId& id) const override;
+protected:
+  void check_setup() const override;
 
-   const GlobalTrackingGeometry* geometry_;
+  GlobalPoint getPosition(const DetId& id) const override;
 
-   const CSCBadChambers* cscbadchambers_;
-   bool includeBadChambers_;
-   bool includeGEM_;
-   bool includeME0_;
+  void getValidDetIds(unsigned int, std::vector<DetId>&) const override;
 
+  std::pair<const_iterator, const_iterator> getDetIdPoints(const DetId& id,
+                                                           std::vector<GlobalPoint>& points) const override;
+
+  bool insideElement(const GlobalPoint& point, const DetId& id) const override;
+
+  const GlobalTrackingGeometry* geometry_;
+
+  const CSCBadChambers* cscbadchambers_;
+  bool includeBadChambers_;
+  bool includeGEM_;
+  bool includeME0_;
 };
 #endif

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociatorMaker.cc
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociatorMaker.cc
@@ -2,7 +2,7 @@
 //
 // Package:     TrackingTools/TrackAssociator
 // Class  :     MuonDetIdAssociatorMaker
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -32,27 +32,23 @@
 // constructors and destructor
 //
 MuonDetIdAssociatorMaker::MuonDetIdAssociatorMaker(edm::ParameterSet const& pSet,
-                                                   edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& iCollector):
-  etaBinSize{pSet.getParameter<double>("etaBinSize")},
-  nPhi{pSet.getParameter<int>("nPhi")},
-  nEta{pSet.getParameter<int>("nEta")},
-  includeBadChambers_{pSet.getParameter<bool>("includeBadChambers")},
-  includeGEM_{pSet.getParameter<bool>("includeGEM")},
-  includeME0_{pSet.getParameter<bool>("includeME0")}
-{
+                                                   edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& iCollector)
+    : etaBinSize{pSet.getParameter<double>("etaBinSize")},
+      nPhi{pSet.getParameter<int>("nPhi")},
+      nEta{pSet.getParameter<int>("nEta")},
+      includeBadChambers_{pSet.getParameter<bool>("includeBadChambers")},
+      includeGEM_{pSet.getParameter<bool>("includeGEM")},
+      includeME0_{pSet.getParameter<bool>("includeME0")} {
   iCollector.setConsumes(geomToken_).setConsumes(badChambersToken_);
 }
 
-std::unique_ptr<DetIdAssociator> 
-MuonDetIdAssociatorMaker::make(const DetIdAssociatorRecord& iRecord) const {
-  return std::unique_ptr<DetIdAssociator>(
-                                          new MuonDetIdAssociator(nPhi, nEta, etaBinSize,
+std::unique_ptr<DetIdAssociator> MuonDetIdAssociatorMaker::make(const DetIdAssociatorRecord& iRecord) const {
+  return std::unique_ptr<DetIdAssociator>(new MuonDetIdAssociator(nPhi,
+                                                                  nEta,
+                                                                  etaBinSize,
                                                                   &iRecord.get(geomToken_),
                                                                   &iRecord.get(badChambersToken_),
                                                                   includeBadChambers_,
                                                                   includeGEM_,
-                                                                  includeME0_)
-                                          );
+                                                                  includeME0_));
 }
-
-

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociatorMaker.h
@@ -4,7 +4,7 @@
 //
 // Package:     TrackingTools/TrackAssociator
 // Class  :     MuonDetIdAssociatorMaker
-// 
+//
 /**\class MuonDetIdAssociatorMaker MuonDetIdAssociatorMaker.h "MuonDetIdAssociatorMaker.h"
 
  Description: [one line class summary]
@@ -35,17 +35,14 @@ class GlobalTrackingGeometryRecord;
 class CSCBadChambers;
 class CSCBadChambersRcd;
 
-class MuonDetIdAssociatorMaker : public DetIdAssociatorMaker
-{
-  
- public:
-  MuonDetIdAssociatorMaker(edm::ParameterSet const&,
-                           edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& );
-  
+class MuonDetIdAssociatorMaker : public DetIdAssociatorMaker {
+public:
+  MuonDetIdAssociatorMaker(edm::ParameterSet const&, edm::ESConsumesCollectorT<DetIdAssociatorRecord>&&);
+
   // ---------- const member functions ---------------------
   std::unique_ptr<DetIdAssociator> make(const DetIdAssociatorRecord&) const final;
-  
- private:
+
+private:
   edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> geomToken_;
   edm::ESGetToken<CSCBadChambers, CSCBadChambersRcd> badChambersToken_;
   const double etaBinSize;
@@ -55,6 +52,5 @@ class MuonDetIdAssociatorMaker : public DetIdAssociatorMaker
   const bool includeGEM_;
   const bool includeME0_;
 };
-
 
 #endif

--- a/TrackingTools/TrackAssociator/plugins/PreshowerDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/PreshowerDetIdAssociator.h
@@ -4,7 +4,7 @@
 //
 // Package:    TrackAssociator
 // Class:      PreshowerDetIdAssociator
-// 
+//
 /*
 
  Description: <one line class summary>
@@ -20,19 +20,19 @@
 #include "CaloDetIdAssociator.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
-class PreshowerDetIdAssociator: public CaloDetIdAssociator{
- public:
-   PreshowerDetIdAssociator():CaloDetIdAssociator(30,60,0.1,nullptr){};
+class PreshowerDetIdAssociator : public CaloDetIdAssociator {
+public:
+  PreshowerDetIdAssociator() : CaloDetIdAssociator(30, 60, 0.1, nullptr){};
 
-   using CaloDetIdAssociator::CaloDetIdAssociator; 
-     
-   const char* name() const override { return "Preshower"; }
- protected:
+  using CaloDetIdAssociator::CaloDetIdAssociator;
 
-   void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const override {
-     if ( subDetectorIndex != 0 ) throw cms::Exception("FatalError") << "Preshower has only one sub-detector for geometry. Abort.";
-     validIds = geometry_->getValidDetIds(DetId::Ecal, EcalPreshower);
-   };
+  const char* name() const override { return "Preshower"; }
 
+protected:
+  void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const override {
+    if (subDetectorIndex != 0)
+      throw cms::Exception("FatalError") << "Preshower has only one sub-detector for geometry. Abort.";
+    validIds = geometry_->getValidDetIds(DetId::Ecal, EcalPreshower);
+  };
 };
 #endif

--- a/TrackingTools/TrackAssociator/plugins/PreshowerDetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/PreshowerDetIdAssociatorMaker.h
@@ -4,7 +4,7 @@
 //
 // Package:     TrackingTools/TrackAssociator
 // Class  :     PreshowerDetIdAssociatorMaker
-// 
+//
 /**\class PreshowerDetIdAssociatorMaker PreshowerDetIdAssociatorMaker.h "PreshowerDetIdAssociatorMaker.h"
 
  Description: [one line class summary]
@@ -26,18 +26,14 @@
 
 // forward declarations
 
-class PreshowerDetIdAssociatorMaker : public CaloDetIdAssociatorMaker
-{
-
- public:
+class PreshowerDetIdAssociatorMaker : public CaloDetIdAssociatorMaker {
+public:
   using CaloDetIdAssociatorMaker::CaloDetIdAssociatorMaker;
 
- private:
-  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize ) const final {
-    return std::unique_ptr<DetIdAssociator>( new PreshowerDetIdAssociator(nPhi,nEta, etaBinSize, &geom) );
+private:
+  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize) const final {
+    return std::unique_ptr<DetIdAssociator>(new PreshowerDetIdAssociator(nPhi, nEta, etaBinSize, &geom));
   }
-
 };
-
 
 #endif

--- a/TrackingTools/TrackAssociator/plugins/modules.cc
+++ b/TrackingTools/TrackAssociator/plugins/modules.cc
@@ -1,9 +1,6 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
-
-
 #include "DetIdAssociatorFactory.h"
 #include "EcalDetIdAssociatorMaker.h"
 #include "HcalDetIdAssociatorMaker.h"
@@ -18,4 +15,3 @@ DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, HODetIdAssociatorMaker, "HODetIdAssoci
 DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, CaloDetIdAssociatorMaker, "CaloDetIdAssociator");
 DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, MuonDetIdAssociatorMaker, "MuonDetIdAssociator");
 DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, PreshowerDetIdAssociatorMaker, "PreshowerDetIdAssociator");
-

--- a/TrackingTools/TrackAssociator/src/CachedTrajectory.cc
+++ b/TrackingTools/TrackAssociator/src/CachedTrajectory.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TrackAssociator
 // Class:      CachedTrajectory
-// 
+//
 //
 //
 
@@ -15,623 +15,596 @@
 #include <deque>
 #include <algorithm>
 
-std::vector<SteppingHelixStateInfo> 
-propagateThoughFromIP(const SteppingHelixStateInfo& state,const Propagator* prop,
-		      const FiducialVolume& volume,int nsteps,
-		      float step, float minR, float minZ, float maxR, float maxZ) {
-   CachedTrajectory neckLace;
-   neckLace.setStateAtIP(state);
-   neckLace.reset_trajectory();
-   neckLace.setPropagator(prop);
-   neckLace.setPropagationStep(0.1);
-   neckLace.setMinDetectorRadius(minR);
-   neckLace.setMinDetectorLength(minZ*2.);
-   neckLace.setMaxDetectorRadius(maxR);
-   neckLace.setMaxDetectorLength(maxZ*2.);
+std::vector<SteppingHelixStateInfo> propagateThoughFromIP(const SteppingHelixStateInfo& state,
+                                                          const Propagator* prop,
+                                                          const FiducialVolume& volume,
+                                                          int nsteps,
+                                                          float step,
+                                                          float minR,
+                                                          float minZ,
+                                                          float maxR,
+                                                          float maxZ) {
+  CachedTrajectory neckLace;
+  neckLace.setStateAtIP(state);
+  neckLace.reset_trajectory();
+  neckLace.setPropagator(prop);
+  neckLace.setPropagationStep(0.1);
+  neckLace.setMinDetectorRadius(minR);
+  neckLace.setMinDetectorLength(minZ * 2.);
+  neckLace.setMaxDetectorRadius(maxR);
+  neckLace.setMaxDetectorLength(maxZ * 2.);
 
-   // Propagate track
-   bool isPropagationSuccessful = neckLace.propagateAll(state);
+  // Propagate track
+  bool isPropagationSuccessful = neckLace.propagateAll(state);
 
-   if (!isPropagationSuccessful)
-     return std::vector<SteppingHelixStateInfo> () ;
+  if (!isPropagationSuccessful)
+    return std::vector<SteppingHelixStateInfo>();
 
-   std::vector<SteppingHelixStateInfo> complicatePoints;
-   neckLace.getTrajectory(complicatePoints, volume, nsteps);
+  std::vector<SteppingHelixStateInfo> complicatePoints;
+  neckLace.getTrajectory(complicatePoints, volume, nsteps);
 
-   return complicatePoints;
-
+  return complicatePoints;
 }
 
-
-
-CachedTrajectory::CachedTrajectory():propagator_(nullptr){
-   reset_trajectory();
-   setMaxDetectorRadius();
-   setMaxDetectorLength();
-   setMinDetectorRadius();
-   setMinDetectorLength();
-   setPropagationStep();
+CachedTrajectory::CachedTrajectory() : propagator_(nullptr) {
+  reset_trajectory();
+  setMaxDetectorRadius();
+  setMaxDetectorLength();
+  setMinDetectorRadius();
+  setMinDetectorLength();
+  setPropagationStep();
 }
 
-void CachedTrajectory::propagateForward(SteppingHelixStateInfo& state, float distance)
-{
-   // defined a normal plane wrt the particle trajectory direction
-   // let's hope that I computed the rotation matrix correctly.
-   GlobalVector vector(state.momentum().unit());
-   float r21 = 0;
-   float r22 = vector.z()/sqrt(1-pow(vector.x(),2));
-   float r23 = -vector.y()/sqrt(1-pow(vector.x(),2));
-   float r31 = vector.x();
-   float r32 = vector.y();
-   float r33 = vector.z();
-   float r11 = r22*r33-r23*r32;
-   float r12 = r23*r31;
-   float r13 = -r22*r31;
-   
-   Surface::RotationType rotation(r11, r12, r13,
-				  r21, r22, r23,
-				  r31, r32, r33);
-   Plane::PlanePointer target = Plane::build(state.position()+vector*distance, rotation);
-   propagate(state, *target);
+void CachedTrajectory::propagateForward(SteppingHelixStateInfo& state, float distance) {
+  // defined a normal plane wrt the particle trajectory direction
+  // let's hope that I computed the rotation matrix correctly.
+  GlobalVector vector(state.momentum().unit());
+  float r21 = 0;
+  float r22 = vector.z() / sqrt(1 - pow(vector.x(), 2));
+  float r23 = -vector.y() / sqrt(1 - pow(vector.x(), 2));
+  float r31 = vector.x();
+  float r32 = vector.y();
+  float r33 = vector.z();
+  float r11 = r22 * r33 - r23 * r32;
+  float r12 = r23 * r31;
+  float r13 = -r22 * r31;
+
+  Surface::RotationType rotation(r11, r12, r13, r21, r22, r23, r31, r32, r33);
+  Plane::PlanePointer target = Plane::build(state.position() + vector * distance, rotation);
+  propagate(state, *target);
 }
 
-void CachedTrajectory::propagate(SteppingHelixStateInfo& state, const Plane& plane)
-{
-   if( const SteppingHelixPropagator* shp = dynamic_cast<const SteppingHelixPropagator*>(propagator_) )
-     {
-	try {
-	   shp->propagate(state, plane, state);
-	}
-	catch(cms::Exception &ex){
-           edm::LogWarning("TrackAssociator") << 
-                "Caught exception " << ex.category() << ": " << ex.explainSelf();
-	   edm::LogWarning("TrackAssociator") << "An exception is caught during the track propagation\n"
-	     << state.momentum().x() << ", " << state.momentum().y() << ", " << state.momentum().z();
-	   state = SteppingHelixStateInfo();
-	}
-     }
-   else
-     {
-	FreeTrajectoryState fts;
-	state.getFreeState( fts );
-	TrajectoryStateOnSurface stateOnSurface = propagator_->propagate(fts, plane);
-	state = SteppingHelixStateInfo( *(stateOnSurface.freeState()) );
-     }
+void CachedTrajectory::propagate(SteppingHelixStateInfo& state, const Plane& plane) {
+  if (const SteppingHelixPropagator* shp = dynamic_cast<const SteppingHelixPropagator*>(propagator_)) {
+    try {
+      shp->propagate(state, plane, state);
+    } catch (cms::Exception& ex) {
+      edm::LogWarning("TrackAssociator") << "Caught exception " << ex.category() << ": " << ex.explainSelf();
+      edm::LogWarning("TrackAssociator") << "An exception is caught during the track propagation\n"
+                                         << state.momentum().x() << ", " << state.momentum().y() << ", "
+                                         << state.momentum().z();
+      state = SteppingHelixStateInfo();
+    }
+  } else {
+    FreeTrajectoryState fts;
+    state.getFreeState(fts);
+    TrajectoryStateOnSurface stateOnSurface = propagator_->propagate(fts, plane);
+    state = SteppingHelixStateInfo(*(stateOnSurface.freeState()));
+  }
 }
 
-void CachedTrajectory::propagate(SteppingHelixStateInfo& state, const Cylinder& cylinder)
-{
-   if( const SteppingHelixPropagator* shp = dynamic_cast<const SteppingHelixPropagator*>(propagator_) )
-     {
-	try {
-	   shp->propagate(state, cylinder,state);
-	}
-	catch(cms::Exception &ex){
-           edm::LogWarning("TrackAssociator") << 
-                "Caught exception " << ex.category() << ": " << ex.explainSelf();
-	   edm::LogWarning("TrackAssociator") << "An exception is caught during the track propagation\n"
-	     << state.momentum().x() << ", " << state.momentum().y() << ", " << state.momentum().z();
-	   state = SteppingHelixStateInfo();
-	}
-     }
-   else
-     {
-	FreeTrajectoryState fts;
-	state.getFreeState( fts );
-	TrajectoryStateOnSurface stateOnSurface = propagator_->propagate(fts, cylinder);
-	state = SteppingHelixStateInfo( *(stateOnSurface.freeState()) );
-     }
+void CachedTrajectory::propagate(SteppingHelixStateInfo& state, const Cylinder& cylinder) {
+  if (const SteppingHelixPropagator* shp = dynamic_cast<const SteppingHelixPropagator*>(propagator_)) {
+    try {
+      shp->propagate(state, cylinder, state);
+    } catch (cms::Exception& ex) {
+      edm::LogWarning("TrackAssociator") << "Caught exception " << ex.category() << ": " << ex.explainSelf();
+      edm::LogWarning("TrackAssociator") << "An exception is caught during the track propagation\n"
+                                         << state.momentum().x() << ", " << state.momentum().y() << ", "
+                                         << state.momentum().z();
+      state = SteppingHelixStateInfo();
+    }
+  } else {
+    FreeTrajectoryState fts;
+    state.getFreeState(fts);
+    TrajectoryStateOnSurface stateOnSurface = propagator_->propagate(fts, cylinder);
+    state = SteppingHelixStateInfo(*(stateOnSurface.freeState()));
+  }
 }
 
-bool CachedTrajectory::propagateAll(const SteppingHelixStateInfo& initialState)
-{
-   if ( fullTrajectoryFilled_ ) {
-      edm::LogWarning("TrackAssociator") << "Reseting all trajectories. Please call reset_trajectory() explicitely to avoid this message";
-      reset_trajectory();
-   }
-	
-//   TimerStack timers(TimerStack::Disableable);
+bool CachedTrajectory::propagateAll(const SteppingHelixStateInfo& initialState) {
+  if (fullTrajectoryFilled_) {
+    edm::LogWarning("TrackAssociator")
+        << "Reseting all trajectories. Please call reset_trajectory() explicitely to avoid this message";
+    reset_trajectory();
+  }
 
-   reset_trajectory();
-   if (propagator_==nullptr) throw cms::Exception("FatalError") << "Track propagator is not defined\n";
-   SteppingHelixStateInfo currentState(initialState);
-   fullTrajectory_.push_back(currentState);
+  //   TimerStack timers(TimerStack::Disableable);
 
-   while (currentState.position().perp()<maxRho_ && fabs(currentState.position().z())<maxZ_ ){
-      LogTrace("TrackAssociator") << "[propagateAll] Propagate outward from (rho, r, z, phi) (" << 
-	currentState.position().perp() << ", " << currentState.position().mag() << ", " <<
-	currentState.position().z() << ", " << currentState.position().phi() << ")";
-      propagateForward(currentState,step_);
-     if (! currentState.isValid() ) {
-       LogTrace("TrackAssociator") << "Failed to propagate the track; moving on\n";
-       break;
-     }
-      LogTrace("TrackAssociator") << "\treached (rho, r, z, phi) (" << 
-	currentState.position().perp() << ", " << currentState.position().mag() << ", " <<
-	currentState.position().z() << ", " << currentState.position().phi() << ")";
-     fullTrajectory_.push_back(currentState);
-   }
+  reset_trajectory();
+  if (propagator_ == nullptr)
+    throw cms::Exception("FatalError") << "Track propagator is not defined\n";
+  SteppingHelixStateInfo currentState(initialState);
+  fullTrajectory_.push_back(currentState);
 
+  while (currentState.position().perp() < maxRho_ && fabs(currentState.position().z()) < maxZ_) {
+    LogTrace("TrackAssociator") << "[propagateAll] Propagate outward from (rho, r, z, phi) ("
+                                << currentState.position().perp() << ", " << currentState.position().mag() << ", "
+                                << currentState.position().z() << ", " << currentState.position().phi() << ")";
+    propagateForward(currentState, step_);
+    if (!currentState.isValid()) {
+      LogTrace("TrackAssociator") << "Failed to propagate the track; moving on\n";
+      break;
+    }
+    LogTrace("TrackAssociator") << "\treached (rho, r, z, phi) (" << currentState.position().perp() << ", "
+                                << currentState.position().mag() << ", " << currentState.position().z() << ", "
+                                << currentState.position().phi() << ")";
+    fullTrajectory_.push_back(currentState);
+  }
 
-   SteppingHelixStateInfo currentState2(initialState);
-   SteppingHelixStateInfo previousState;
-   while (currentState2.position().perp()>minRho_ || fabs(currentState2.position().z())>minZ_) {
-      previousState=currentState2;
-      propagateForward(currentState2,-step_);
-      if (! currentState2.isValid() ) {
-	 LogTrace("TrackAssociator") << "Failed to propagate the track; moving on\n";
-	 break;
-      }
-      if(previousState.position().perp()- currentState2.position().perp() < 0) { 
-	 LogTrace("TrackAssociator") << "Error: TrackAssociator has propogated the particle past the point of closest approach to IP" << std::endl;
-	 break;
-      }
-      LogTrace("TrackAssociator") << "[propagateAll] Propagated inward from (rho, r, z, phi) (" << 
-	previousState.position().perp() << ", " << previousState.position().mag() << ", " <<
-	previousState.position().z() << "," << previousState.position().phi() << ") to (" << 
-	currentState2.position().perp() << ", " << currentState2.position().mag() << ", " <<
-	currentState2.position().z() << ", " << currentState2.position().phi() << ")";
-      fullTrajectory_.push_front(currentState2);
-   }
+  SteppingHelixStateInfo currentState2(initialState);
+  SteppingHelixStateInfo previousState;
+  while (currentState2.position().perp() > minRho_ || fabs(currentState2.position().z()) > minZ_) {
+    previousState = currentState2;
+    propagateForward(currentState2, -step_);
+    if (!currentState2.isValid()) {
+      LogTrace("TrackAssociator") << "Failed to propagate the track; moving on\n";
+      break;
+    }
+    if (previousState.position().perp() - currentState2.position().perp() < 0) {
+      LogTrace("TrackAssociator")
+          << "Error: TrackAssociator has propogated the particle past the point of closest approach to IP" << std::endl;
+      break;
+    }
+    LogTrace("TrackAssociator") << "[propagateAll] Propagated inward from (rho, r, z, phi) ("
+                                << previousState.position().perp() << ", " << previousState.position().mag() << ", "
+                                << previousState.position().z() << "," << previousState.position().phi() << ") to ("
+                                << currentState2.position().perp() << ", " << currentState2.position().mag() << ", "
+                                << currentState2.position().z() << ", " << currentState2.position().phi() << ")";
+    fullTrajectory_.push_front(currentState2);
+  }
 
+  // LogTrace("TrackAssociator") << "fullTrajectory_ has " << fullTrajectory_.size() << " states with (R, z):\n";
+  // for(unsigned int i=0; i<fullTrajectory_.size(); i++) {
+  //  LogTrace("TrackAssociator") << "state " << i << ": (" << fullTrajectory_[i].position().perp() << ", "
+  //    << fullTrajectory_[i].position().z() << ")\n";
+  // }
 
-
-
-   // LogTrace("TrackAssociator") << "fullTrajectory_ has " << fullTrajectory_.size() << " states with (R, z):\n";
-   // for(unsigned int i=0; i<fullTrajectory_.size(); i++) {
-   //  LogTrace("TrackAssociator") << "state " << i << ": (" << fullTrajectory_[i].position().perp() << ", "
-   //    << fullTrajectory_[i].position().z() << ")\n";
-   // }
-
-
-
-
-
-   LogTrace("TrackAssociator") << "Done with the track propagation in the detector. Number of steps: " << fullTrajectory_.size();
-   fullTrajectoryFilled_ = true;
-   return ! fullTrajectory_.empty();
+  LogTrace("TrackAssociator") << "Done with the track propagation in the detector. Number of steps: "
+                              << fullTrajectory_.size();
+  fullTrajectoryFilled_ = true;
+  return !fullTrajectory_.empty();
 }
 
-TrajectoryStateOnSurface CachedTrajectory::propagate(const Plane* plane)
-{
-   // TimerStack timers(TimerStack::Disableable);
-   // timers.benchmark("CachedTrajectory::propagate::benchmark");
-   // timers.push("CachedTrajectory::propagate",TimerStack::FastMonitoring);
-   // timers.push("CachedTrajectory::propagate::findClosestPoint",TimerStack::FastMonitoring);
+TrajectoryStateOnSurface CachedTrajectory::propagate(const Plane* plane) {
+  // TimerStack timers(TimerStack::Disableable);
+  // timers.benchmark("CachedTrajectory::propagate::benchmark");
+  // timers.push("CachedTrajectory::propagate",TimerStack::FastMonitoring);
+  // timers.push("CachedTrajectory::propagate::findClosestPoint",TimerStack::FastMonitoring);
 
-   // Assume that all points along the trajectory are equally spread out.
-   // For simplication assume that the trajectory is just a straight
-   // line and find a point closest to the target plane. Propagate to
-   // the plane from the point.
-   
-   const float matchingDistance = 1;
-   // find the closest point to the plane
-   int leftIndex = 0;
-   int rightIndex = fullTrajectory_.size()-1;
-   int closestPointOnLeft = 0;
-   
-   // check whether the trajectory crossed the plane (signs should be different)
-   if ( sign( distance(plane, leftIndex) ) * sign( distance(plane, rightIndex) ) != -1 ) {
-      LogTrace("TrackAssociator") << "Track didn't cross the plane:\n\tleft distance: "<<distance(plane, leftIndex)
-	<<"\n\tright distance: " << distance(plane, rightIndex);
-     return TrajectoryStateOnSurface();
-   }
-   
-   while (leftIndex + 1 < rightIndex) {
-      closestPointOnLeft = int((leftIndex+rightIndex)/2);
-      float dist = distance(plane,closestPointOnLeft);
-      // LogTrace("TrackAssociator") << "Closest point on left: " << closestPointOnLeft << "\n"
-      //    << "Distance to the plane: " << dist;
-      if (fabs(dist)<matchingDistance) {
-	 // found close match, verify that we are on the left side
-	 if (closestPointOnLeft>0 && sign( distance(plane, closestPointOnLeft-1) ) * dist == -1)
-	   closestPointOnLeft--;
-	 break; 
-      }
-      
-      // check where is the plane
-      if (sign( distance(plane, leftIndex) * dist ) == -1)
-	rightIndex = closestPointOnLeft;
-      else
-	leftIndex = closestPointOnLeft;
-      
-      // LogTrace("TrackAssociator") << "Distance on left: " << distance(plane, leftIndex) << "\n"
-      //	<< "Distance to closest point: " <<  distance(plane, closestPointOnLeft) << "\n"
-      //	<< "Left index: " << leftIndex << "\n"
-      //	<< "Right index: " << rightIndex;
-      
-   }
-      LogTrace("TrackAssociator") << "closestPointOnLeft: " << closestPointOnLeft 
-        << "\n\ttrajectory point (z,R,eta,phi): " 
-        << fullTrajectory_[closestPointOnLeft].position().z() << ", "
-        << fullTrajectory_[closestPointOnLeft].position().perp() << " , "	
-        << fullTrajectory_[closestPointOnLeft].position().eta() << " , " 
-        << fullTrajectory_[closestPointOnLeft].position().phi()
-        << "\n\tplane center (z,R,eta,phi): " 
-        << plane->position().z() << ", "
-        << plane->position().perp() << " , "	
-        << plane->position().eta() << " , " 
-        << plane->position().phi();
-     
-   // propagate to the plane
-   // timers.pop_and_push("CachedTrajectory::propagate::localPropagation",TimerStack::FastMonitoring);
-   if (const SteppingHelixPropagator* shp = dynamic_cast<const SteppingHelixPropagator*>(propagator_))
-     {
-	SteppingHelixStateInfo state;
-	try { 
-	   shp->propagate(fullTrajectory_[closestPointOnLeft], *plane, state);
-	}
-	catch(cms::Exception &ex){
-           edm::LogWarning("TrackAssociator") << 
-                "Caught exception " << ex.category() << ": " << ex.explainSelf();
-	   edm::LogWarning("TrackAssociator") << "An exception is caught during the track propagation\n"
-	     << state.momentum().x() << ", " << state.momentum().y() << ", " << state.momentum().z();
-	   return TrajectoryStateOnSurface();
-	}
-	return state.getStateOnSurface(*plane);
-     }
-   else
-     {
-	FreeTrajectoryState fts;
-	fullTrajectory_[closestPointOnLeft].getFreeState(fts);
-	return propagator_->propagate(fts, *plane);
-     }
+  // Assume that all points along the trajectory are equally spread out.
+  // For simplication assume that the trajectory is just a straight
+  // line and find a point closest to the target plane. Propagate to
+  // the plane from the point.
+
+  const float matchingDistance = 1;
+  // find the closest point to the plane
+  int leftIndex = 0;
+  int rightIndex = fullTrajectory_.size() - 1;
+  int closestPointOnLeft = 0;
+
+  // check whether the trajectory crossed the plane (signs should be different)
+  if (sign(distance(plane, leftIndex)) * sign(distance(plane, rightIndex)) != -1) {
+    LogTrace("TrackAssociator") << "Track didn't cross the plane:\n\tleft distance: " << distance(plane, leftIndex)
+                                << "\n\tright distance: " << distance(plane, rightIndex);
+    return TrajectoryStateOnSurface();
+  }
+
+  while (leftIndex + 1 < rightIndex) {
+    closestPointOnLeft = int((leftIndex + rightIndex) / 2);
+    float dist = distance(plane, closestPointOnLeft);
+    // LogTrace("TrackAssociator") << "Closest point on left: " << closestPointOnLeft << "\n"
+    //    << "Distance to the plane: " << dist;
+    if (fabs(dist) < matchingDistance) {
+      // found close match, verify that we are on the left side
+      if (closestPointOnLeft > 0 && sign(distance(plane, closestPointOnLeft - 1)) * dist == -1)
+        closestPointOnLeft--;
+      break;
+    }
+
+    // check where is the plane
+    if (sign(distance(plane, leftIndex) * dist) == -1)
+      rightIndex = closestPointOnLeft;
+    else
+      leftIndex = closestPointOnLeft;
+
+    // LogTrace("TrackAssociator") << "Distance on left: " << distance(plane, leftIndex) << "\n"
+    //	<< "Distance to closest point: " <<  distance(plane, closestPointOnLeft) << "\n"
+    //	<< "Left index: " << leftIndex << "\n"
+    //	<< "Right index: " << rightIndex;
+  }
+  LogTrace("TrackAssociator") << "closestPointOnLeft: " << closestPointOnLeft << "\n\ttrajectory point (z,R,eta,phi): "
+                              << fullTrajectory_[closestPointOnLeft].position().z() << ", "
+                              << fullTrajectory_[closestPointOnLeft].position().perp() << " , "
+                              << fullTrajectory_[closestPointOnLeft].position().eta() << " , "
+                              << fullTrajectory_[closestPointOnLeft].position().phi()
+                              << "\n\tplane center (z,R,eta,phi): " << plane->position().z() << ", "
+                              << plane->position().perp() << " , " << plane->position().eta() << " , "
+                              << plane->position().phi();
+
+  // propagate to the plane
+  // timers.pop_and_push("CachedTrajectory::propagate::localPropagation",TimerStack::FastMonitoring);
+  if (const SteppingHelixPropagator* shp = dynamic_cast<const SteppingHelixPropagator*>(propagator_)) {
+    SteppingHelixStateInfo state;
+    try {
+      shp->propagate(fullTrajectory_[closestPointOnLeft], *plane, state);
+    } catch (cms::Exception& ex) {
+      edm::LogWarning("TrackAssociator") << "Caught exception " << ex.category() << ": " << ex.explainSelf();
+      edm::LogWarning("TrackAssociator") << "An exception is caught during the track propagation\n"
+                                         << state.momentum().x() << ", " << state.momentum().y() << ", "
+                                         << state.momentum().z();
+      return TrajectoryStateOnSurface();
+    }
+    return state.getStateOnSurface(*plane);
+  } else {
+    FreeTrajectoryState fts;
+    fullTrajectory_[closestPointOnLeft].getFreeState(fts);
+    return propagator_->propagate(fts, *plane);
+  }
 }
 
-std::pair<float,float> CachedTrajectory::trajectoryDelta( TrajectorType trajectoryType )
-{
-   // MEaning of trajectory change depends on its usage. In most cases we measure 
-   // change in a trajectory as difference between final track position and initial 
-   // direction. In some cases such as change of trajectory in the muon detector we 
-   // might want to compare theta-phi of two points or even find local maximum and
-   // mimimum. In general it's not essential what defenition of the trajectory change
-   // is used since we use these numbers only as a rough estimate on how much wider
-   // we should make the preselection region.
-   std::pair<float,float> result(0,0);
-   if ( ! stateAtIP_.isValid() ) { 
-      edm::LogWarning("TrackAssociator") << "State at IP is not known set. Cannot estimate trajectory change. " <<
-	"Trajectory change is not taken into account in matching";
-      return result;
-   }
-   switch (trajectoryType) {
+std::pair<float, float> CachedTrajectory::trajectoryDelta(TrajectorType trajectoryType) {
+  // MEaning of trajectory change depends on its usage. In most cases we measure
+  // change in a trajectory as difference between final track position and initial
+  // direction. In some cases such as change of trajectory in the muon detector we
+  // might want to compare theta-phi of two points or even find local maximum and
+  // mimimum. In general it's not essential what defenition of the trajectory change
+  // is used since we use these numbers only as a rough estimate on how much wider
+  // we should make the preselection region.
+  std::pair<float, float> result(0, 0);
+  if (!stateAtIP_.isValid()) {
+    edm::LogWarning("TrackAssociator") << "State at IP is not known set. Cannot estimate trajectory change. "
+                                       << "Trajectory change is not taken into account in matching";
+    return result;
+  }
+  switch (trajectoryType) {
     case IpToEcal:
-      if ( ecalTrajectory_.empty() )
-	edm::LogWarning("TrackAssociator") << "ECAL trajector is empty. Cannot estimate trajectory change. " <<
-	"Trajectory change is not taken into account in matching";
-      else return delta( stateAtIP_.momentum().theta(), ecalTrajectory_.front().position().theta(), 
-			 stateAtIP_.momentum().phi(), ecalTrajectory_.front().position().phi() );
+      if (ecalTrajectory_.empty())
+        edm::LogWarning("TrackAssociator") << "ECAL trajector is empty. Cannot estimate trajectory change. "
+                                           << "Trajectory change is not taken into account in matching";
+      else
+        return delta(stateAtIP_.momentum().theta(),
+                     ecalTrajectory_.front().position().theta(),
+                     stateAtIP_.momentum().phi(),
+                     ecalTrajectory_.front().position().phi());
       break;
     case IpToHcal:
-      if ( hcalTrajectory_.empty() )
-	edm::LogWarning("TrackAssociator") << "HCAL trajector is empty. Cannot estimate trajectory change. " <<
-	"Trajectory change is not taken into account in matching";
-      else return delta( stateAtIP_.momentum().theta(), hcalTrajectory_.front().position().theta(), 
-			 stateAtIP_.momentum().phi(),   hcalTrajectory_.front().position().phi() );
+      if (hcalTrajectory_.empty())
+        edm::LogWarning("TrackAssociator") << "HCAL trajector is empty. Cannot estimate trajectory change. "
+                                           << "Trajectory change is not taken into account in matching";
+      else
+        return delta(stateAtIP_.momentum().theta(),
+                     hcalTrajectory_.front().position().theta(),
+                     stateAtIP_.momentum().phi(),
+                     hcalTrajectory_.front().position().phi());
       break;
     case IpToHO:
-      if ( hoTrajectory_.empty() )
-	edm::LogWarning("TrackAssociator") << "HO trajector is empty. Cannot estimate trajectory change. " <<
-	"Trajectory change is not taken into account in matching";
-      else return delta( stateAtIP_.momentum().theta(), hoTrajectory_.front().position().theta(), 
-			 stateAtIP_.momentum().phi(),   hoTrajectory_.front().position().phi() );
+      if (hoTrajectory_.empty())
+        edm::LogWarning("TrackAssociator") << "HO trajector is empty. Cannot estimate trajectory change. "
+                                           << "Trajectory change is not taken into account in matching";
+      else
+        return delta(stateAtIP_.momentum().theta(),
+                     hoTrajectory_.front().position().theta(),
+                     stateAtIP_.momentum().phi(),
+                     hoTrajectory_.front().position().phi());
       break;
     case FullTrajectory:
-      if ( fullTrajectory_.empty() )
-	edm::LogWarning("TrackAssociator") << "Full trajector is empty. Cannot estimate trajectory change. " <<
-	"Trajectory change is not taken into account in matching";
-      else  return delta( stateAtIP_.momentum().theta(), fullTrajectory_.back().position().theta(), 
-			  stateAtIP_.momentum().phi(),   fullTrajectory_.back().position().phi() );
+      if (fullTrajectory_.empty())
+        edm::LogWarning("TrackAssociator") << "Full trajector is empty. Cannot estimate trajectory change. "
+                                           << "Trajectory change is not taken into account in matching";
+      else
+        return delta(stateAtIP_.momentum().theta(),
+                     fullTrajectory_.back().position().theta(),
+                     stateAtIP_.momentum().phi(),
+                     fullTrajectory_.back().position().phi());
       break;
     default:
-      edm::LogWarning("TrackAssociator") << "Unkown or not supported trajector type. Cannot estimate trajectory change. " <<
-	"Trajectory change is not taken into account in matching";
-   }
-   return result;
+      edm::LogWarning("TrackAssociator")
+          << "Unkown or not supported trajector type. Cannot estimate trajectory change. "
+          << "Trajectory change is not taken into account in matching";
+  }
+  return result;
 }
 
-std::pair<float,float> CachedTrajectory::delta(const double& theta1,
-					       const double& theta2,
-					       const double& phi1,
-					       const double& phi2)
-{
-   std::pair<float,float> result(theta2 - theta1, phi2 - phi1 );
-   // this won't work for loopers, since deltaPhi cannot be larger than Pi.
-   if ( fabs(result.second) > 2*M_PI-fabs(result.second) ) {
-      if (result.second>0) 
-	result.second -= 2*M_PI;
-      else
-	result.second += 2*M_PI;
-   }
-   return result;
+std::pair<float, float> CachedTrajectory::delta(const double& theta1,
+                                                const double& theta2,
+                                                const double& phi1,
+                                                const double& phi2) {
+  std::pair<float, float> result(theta2 - theta1, phi2 - phi1);
+  // this won't work for loopers, since deltaPhi cannot be larger than Pi.
+  if (fabs(result.second) > 2 * M_PI - fabs(result.second)) {
+    if (result.second > 0)
+      result.second -= 2 * M_PI;
+    else
+      result.second += 2 * M_PI;
+  }
+  return result;
 }
-	
+
 void CachedTrajectory::getTrajectory(std::vector<SteppingHelixStateInfo>& trajectory,
-				     const FiducialVolume& volume,
-				     int steps)
-{
-   if ( ! fullTrajectoryFilled_ ) throw cms::Exception("FatalError") << "trajectory is not defined yet. Please use propagateAll first.";
-   if ( fullTrajectory_.empty() ) {
-      LogTrace("TrackAssociator") << "Trajectory is empty. Move on";
-      return;
-   }
-   if ( ! volume.isValid() ) {
-      LogTrace("TrackAssociator") << "no trajectory is expected to be found since the fiducial volume is not valid";
-      return;
-   }
-   double step = std::max(volume.maxR()-volume.minR(),volume.maxZ()-volume.minZ())/steps;
-   
-   int closestPointOnLeft = -1;
-   
-   // check whether the trajectory crossed the region
-   if ( ! 
-	( ( fullTrajectory_.front().position().perp() < volume.maxR() && fabs(fullTrajectory_.front().position().z()) < volume.maxZ() ) &&
-	  ( fullTrajectory_.back().position().perp() > volume.minR() || fabs(fullTrajectory_.back().position().z()) > volume.minZ() ) ))
-     {
-	LogTrace("TrackAssociator") << "Track didn't cross the region (R1,R2,L1,L2): " << volume.minR() << ", " << volume.maxR() <<
-	  ", " << volume.minZ() << ", " << volume.maxZ();
-	return;
-     }
-   
-   // get distance along momentum to the surface.
-   
-   // the following code can be made faster, but it'll hardly be a significant improvement
-   // simplifications:
-   //   1) direct loop over stored trajectory points instead of some sort 
-   //      of fast root search (Newton method)
-   //   2) propagate from the closest point outside the region with the 
-   //      requested step ignoring stored trajectory points.
-   double dZ(-1.);
-   double dR(-1.);
-   int firstPointInside(-1);
-   for(unsigned int i=0; i<fullTrajectory_.size(); i++) {
-      // LogTrace("TrackAssociator") << "Trajectory info (i,perp,r1,r2,z,z1,z2): " << i << ", " << fullTrajectory_[i].position().perp() <<
-      //	", " << volume.minR() << ", " << volume.maxR() << ", " << fullTrajectory_[i].position().z() << ", " << volume.minZ() << ", " << 
-      //	volume.maxZ() << ", " << closestPointOnLeft;
-      dR = fullTrajectory_[i].position().perp()-volume.minR();
-      dZ = fabs(fullTrajectory_[i].position().z()) - volume.minZ();
-      if ( dR> 0  || dZ >0 )
-	{
-	   if (i>0) {
-	      firstPointInside = i;
-	      closestPointOnLeft = i - 1;
-	   } else {
-	      firstPointInside = 0;
-	      closestPointOnLeft = 0;
-	   }
-	   break;
-	}
-   }
-   if (closestPointOnLeft == -1) throw cms::Exception("FatalError") << "This shouls never happen - internal logic error";
-   
-   SteppingHelixStateInfo currentState(fullTrajectory_[closestPointOnLeft]);
-   if ( currentState.position().x()*currentState.momentum().x() +
-	currentState.position().y()*currentState.momentum().y() +
-	currentState.position().z()*currentState.momentum().z() < 0 )
-     step = -step;
-   
-   // propagate to the inner surface of the active volume
+                                     const FiducialVolume& volume,
+                                     int steps) {
+  if (!fullTrajectoryFilled_)
+    throw cms::Exception("FatalError") << "trajectory is not defined yet. Please use propagateAll first.";
+  if (fullTrajectory_.empty()) {
+    LogTrace("TrackAssociator") << "Trajectory is empty. Move on";
+    return;
+  }
+  if (!volume.isValid()) {
+    LogTrace("TrackAssociator") << "no trajectory is expected to be found since the fiducial volume is not valid";
+    return;
+  }
+  double step = std::max(volume.maxR() - volume.minR(), volume.maxZ() - volume.minZ()) / steps;
 
-   if (firstPointInside != closestPointOnLeft) {
-      if ( dR > 0 ) {
-	 Cylinder::CylinderPointer barrel = Cylinder::build( volume.minR(), Cylinder::PositionType (0, 0, 0), Cylinder::RotationType () );
-	 propagate(currentState, *barrel);
+  int closestPointOnLeft = -1;
+
+  // check whether the trajectory crossed the region
+  if (!((fullTrajectory_.front().position().perp() < volume.maxR() &&
+         fabs(fullTrajectory_.front().position().z()) < volume.maxZ()) &&
+        (fullTrajectory_.back().position().perp() > volume.minR() ||
+         fabs(fullTrajectory_.back().position().z()) > volume.minZ()))) {
+    LogTrace("TrackAssociator") << "Track didn't cross the region (R1,R2,L1,L2): " << volume.minR() << ", "
+                                << volume.maxR() << ", " << volume.minZ() << ", " << volume.maxZ();
+    return;
+  }
+
+  // get distance along momentum to the surface.
+
+  // the following code can be made faster, but it'll hardly be a significant improvement
+  // simplifications:
+  //   1) direct loop over stored trajectory points instead of some sort
+  //      of fast root search (Newton method)
+  //   2) propagate from the closest point outside the region with the
+  //      requested step ignoring stored trajectory points.
+  double dZ(-1.);
+  double dR(-1.);
+  int firstPointInside(-1);
+  for (unsigned int i = 0; i < fullTrajectory_.size(); i++) {
+    // LogTrace("TrackAssociator") << "Trajectory info (i,perp,r1,r2,z,z1,z2): " << i << ", " << fullTrajectory_[i].position().perp() <<
+    //	", " << volume.minR() << ", " << volume.maxR() << ", " << fullTrajectory_[i].position().z() << ", " << volume.minZ() << ", " <<
+    //	volume.maxZ() << ", " << closestPointOnLeft;
+    dR = fullTrajectory_[i].position().perp() - volume.minR();
+    dZ = fabs(fullTrajectory_[i].position().z()) - volume.minZ();
+    if (dR > 0 || dZ > 0) {
+      if (i > 0) {
+        firstPointInside = i;
+        closestPointOnLeft = i - 1;
       } else {
-	 Plane::PlanePointer endcap = Plane::build( Plane::PositionType (0, 0, 
-									 currentState.position().z()>0?volume.minZ():-volume.minZ()), 
-						    Plane::RotationType () );
-	 propagate(currentState, *endcap);
+        firstPointInside = 0;
+        closestPointOnLeft = 0;
       }
-      if ( currentState.isValid() ) trajectory.push_back(currentState);
-   } else
-     LogTrace("TrackAssociator") << "Weird message\n";
+      break;
+    }
+  }
+  if (closestPointOnLeft == -1)
+    throw cms::Exception("FatalError") << "This shouls never happen - internal logic error";
 
-   while (currentState.isValid() &&
-	  currentState.position().perp()    < volume.maxR() && 
-	  fabs(currentState.position().z()) < volume.maxZ() )
-     {
-	propagateForward(currentState,step);
-	if (! currentState.isValid() ) {
-	   LogTrace("TrackAssociator") << "Failed to propagate the track; moving on\n";
-	   break;
-	}
-	// LogTrace("TrackAssociator") << "New state (perp, z): " << currentState.position().perp() << ", " << currentState.position().z();
-	//if ( ( currentState.position().perp() < volume.maxR() && fabs(currentState.position().z()) < volume.maxZ() ) &&
-	//     ( currentState.position().perp()-volume.minR() > 0  || fabs(currentState.position().z()) - volume.minZ() >0 ) )
-	trajectory.push_back(currentState);
-     }
+  SteppingHelixStateInfo currentState(fullTrajectory_[closestPointOnLeft]);
+  if (currentState.position().x() * currentState.momentum().x() +
+          currentState.position().y() * currentState.momentum().y() +
+          currentState.position().z() * currentState.momentum().z() <
+      0)
+    step = -step;
+
+  // propagate to the inner surface of the active volume
+
+  if (firstPointInside != closestPointOnLeft) {
+    if (dR > 0) {
+      Cylinder::CylinderPointer barrel =
+          Cylinder::build(volume.minR(), Cylinder::PositionType(0, 0, 0), Cylinder::RotationType());
+      propagate(currentState, *barrel);
+    } else {
+      Plane::PlanePointer endcap =
+          Plane::build(Plane::PositionType(0, 0, currentState.position().z() > 0 ? volume.minZ() : -volume.minZ()),
+                       Plane::RotationType());
+      propagate(currentState, *endcap);
+    }
+    if (currentState.isValid())
+      trajectory.push_back(currentState);
+  } else
+    LogTrace("TrackAssociator") << "Weird message\n";
+
+  while (currentState.isValid() && currentState.position().perp() < volume.maxR() &&
+         fabs(currentState.position().z()) < volume.maxZ()) {
+    propagateForward(currentState, step);
+    if (!currentState.isValid()) {
+      LogTrace("TrackAssociator") << "Failed to propagate the track; moving on\n";
+      break;
+    }
+    // LogTrace("TrackAssociator") << "New state (perp, z): " << currentState.position().perp() << ", " << currentState.position().z();
+    //if ( ( currentState.position().perp() < volume.maxR() && fabs(currentState.position().z()) < volume.maxZ() ) &&
+    //     ( currentState.position().perp()-volume.minR() > 0  || fabs(currentState.position().z()) - volume.minZ() >0 ) )
+    trajectory.push_back(currentState);
+  }
 }
 
-void CachedTrajectory::reset_trajectory() { 
-   fullTrajectory_.clear();
-   ecalTrajectory_.clear();
-   hcalTrajectory_.clear();
-   hoTrajectory_.clear();
-   preshowerTrajectory_.clear();
-   wideEcalTrajectory_.clear();   
-   wideHcalTrajectory_.clear();
-   wideHOTrajectory_.clear();
-   fullTrajectoryFilled_ = false;
+void CachedTrajectory::reset_trajectory() {
+  fullTrajectory_.clear();
+  ecalTrajectory_.clear();
+  hcalTrajectory_.clear();
+  hoTrajectory_.clear();
+  preshowerTrajectory_.clear();
+  wideEcalTrajectory_.clear();
+  wideHcalTrajectory_.clear();
+  wideHOTrajectory_.clear();
+  fullTrajectoryFilled_ = false;
 }
 
-void CachedTrajectory::findEcalTrajectory( const FiducialVolume& volume ) {
-   LogTrace("TrackAssociator") << "getting trajectory in ECAL";
-   getTrajectory(ecalTrajectory_, volume, 4 );
-   LogTrace("TrackAssociator") << "# of points in ECAL trajectory:" << ecalTrajectory_.size();
+void CachedTrajectory::findEcalTrajectory(const FiducialVolume& volume) {
+  LogTrace("TrackAssociator") << "getting trajectory in ECAL";
+  getTrajectory(ecalTrajectory_, volume, 4);
+  LogTrace("TrackAssociator") << "# of points in ECAL trajectory:" << ecalTrajectory_.size();
 }
 
-void CachedTrajectory::findPreshowerTrajectory( const FiducialVolume& volume ) {
-   LogTrace("TrackAssociator") << "getting trajectory in Preshower";
-   getTrajectory(preshowerTrajectory_, volume, 2 );
-   LogTrace("TrackAssociator") << "# of points in Preshower trajectory:" << preshowerTrajectory_.size();
+void CachedTrajectory::findPreshowerTrajectory(const FiducialVolume& volume) {
+  LogTrace("TrackAssociator") << "getting trajectory in Preshower";
+  getTrajectory(preshowerTrajectory_, volume, 2);
+  LogTrace("TrackAssociator") << "# of points in Preshower trajectory:" << preshowerTrajectory_.size();
 }
 
-const std::vector<SteppingHelixStateInfo>& CachedTrajectory::getEcalTrajectory() const{
-   return ecalTrajectory_;
+const std::vector<SteppingHelixStateInfo>& CachedTrajectory::getEcalTrajectory() const { return ecalTrajectory_; }
+
+const std::vector<SteppingHelixStateInfo>& CachedTrajectory::getPreshowerTrajectory() const {
+  return preshowerTrajectory_;
 }
 
-const std::vector<SteppingHelixStateInfo>& CachedTrajectory::getPreshowerTrajectory() const{
-   return preshowerTrajectory_;
+void CachedTrajectory::findHcalTrajectory(const FiducialVolume& volume) {
+  LogTrace("TrackAssociator") << "getting trajectory in HCAL";
+  getTrajectory(hcalTrajectory_, volume, 4);  // more steps to account for different depth
+  LogTrace("TrackAssociator") << "# of points in HCAL trajectory:" << hcalTrajectory_.size();
 }
 
-void CachedTrajectory::findHcalTrajectory( const FiducialVolume& volume ) {
-   LogTrace("TrackAssociator") << "getting trajectory in HCAL";
-   getTrajectory(hcalTrajectory_, volume, 4 ); // more steps to account for different depth
-   LogTrace("TrackAssociator") << "# of points in HCAL trajectory:" << hcalTrajectory_.size();
+const std::vector<SteppingHelixStateInfo>& CachedTrajectory::getHcalTrajectory() const { return hcalTrajectory_; }
+
+void CachedTrajectory::findHOTrajectory(const FiducialVolume& volume) {
+  LogTrace("TrackAssociator") << "getting trajectory in HO";
+  getTrajectory(hoTrajectory_, volume, 2);
+  LogTrace("TrackAssociator") << "# of points in HO trajectory:" << hoTrajectory_.size();
 }
 
-const std::vector<SteppingHelixStateInfo>& CachedTrajectory::getHcalTrajectory() const{
-   return hcalTrajectory_;
-}
+const std::vector<SteppingHelixStateInfo>& CachedTrajectory::getHOTrajectory() const { return hoTrajectory_; }
 
-void CachedTrajectory::findHOTrajectory( const FiducialVolume& volume ) {
-   LogTrace("TrackAssociator") << "getting trajectory in HO";
-   getTrajectory(hoTrajectory_, volume, 2 );
-   LogTrace("TrackAssociator") << "# of points in HO trajectory:" << hoTrajectory_.size();
-}
-
-const std::vector<SteppingHelixStateInfo>& CachedTrajectory::getHOTrajectory() const {
-   return hoTrajectory_;
-}
-   
-std::vector<GlobalPoint>*
-CachedTrajectory::getWideTrajectory(const std::vector<SteppingHelixStateInfo>& states, 
-                                    WideTrajectoryType wideTrajectoryType) {
-   std::vector<GlobalPoint>* wideTrajectory = nullptr;
-   switch (wideTrajectoryType) {
+std::vector<GlobalPoint>* CachedTrajectory::getWideTrajectory(const std::vector<SteppingHelixStateInfo>& states,
+                                                              WideTrajectoryType wideTrajectoryType) {
+  std::vector<GlobalPoint>* wideTrajectory = nullptr;
+  switch (wideTrajectoryType) {
     case Ecal:
-       LogTrace("TrackAssociator") << "Filling ellipses in Ecal trajectory";
-       wideTrajectory = &wideEcalTrajectory_;
-       break;
+      LogTrace("TrackAssociator") << "Filling ellipses in Ecal trajectory";
+      wideTrajectory = &wideEcalTrajectory_;
+      break;
     case Hcal:
-       LogTrace("TrackAssociator") << "Filling ellipses in Hcal trajectory";
+      LogTrace("TrackAssociator") << "Filling ellipses in Hcal trajectory";
       wideTrajectory = &wideHcalTrajectory_;
       break;
     case HO:
-       LogTrace("TrackAssociator") << "Filling ellipses in HO trajectory";
-       wideTrajectory = &wideHOTrajectory_;
-       break;
-   }
-   if(!wideTrajectory) return nullptr;
+      LogTrace("TrackAssociator") << "Filling ellipses in HO trajectory";
+      wideTrajectory = &wideHOTrajectory_;
+      break;
+  }
+  if (!wideTrajectory)
+    return nullptr;
 
-   for(std::vector<SteppingHelixStateInfo>::const_iterator state= states.begin();
-       state != states.end(); state++) {
-      // defined a normal plane wrt the particle trajectory direction
-      // let's hope that I computed the rotation matrix correctly.
-      GlobalVector vector(state->momentum().unit());
-      float r21 = 0;
-      float r22 = vector.z()/sqrt(1-pow(vector.x(),2));
-      float r23 = -vector.y()/sqrt(1-pow(vector.x(),2));
-      float r31 = vector.x();
-      float r32 = vector.y();
-      float r33 = vector.z();
-      float r11 = r22*r33-r23*r32;
-      float r12 = r23*r31;
-      float r13 = -r22*r31;
-   
-      Plane::RotationType rotation(r11, r12, r13,
-                                   r21, r22, r23,
-                                   r31, r32, r33);
-      Plane* target = new Plane(state->position(), rotation);
+  for (std::vector<SteppingHelixStateInfo>::const_iterator state = states.begin(); state != states.end(); state++) {
+    // defined a normal plane wrt the particle trajectory direction
+    // let's hope that I computed the rotation matrix correctly.
+    GlobalVector vector(state->momentum().unit());
+    float r21 = 0;
+    float r22 = vector.z() / sqrt(1 - pow(vector.x(), 2));
+    float r23 = -vector.y() / sqrt(1 - pow(vector.x(), 2));
+    float r31 = vector.x();
+    float r32 = vector.y();
+    float r33 = vector.z();
+    float r11 = r22 * r33 - r23 * r32;
+    float r12 = r23 * r31;
+    float r13 = -r22 * r31;
 
-      TrajectoryStateOnSurface tsos = state->getStateOnSurface(*target);
+    Plane::RotationType rotation(r11, r12, r13, r21, r22, r23, r31, r32, r33);
+    Plane* target = new Plane(state->position(), rotation);
 
-      if (!tsos.isValid()) {
-         LogTrace("TrackAssociator") << "[getWideTrajectory] TSOS not valid";
-         continue;
-      }
-      if (!tsos.hasError()) {
-         LogTrace("TrackAssociator") << "[getWideTrajectory] TSOS does not have Errors";
-         continue;
-      }
-      LocalError localErr = tsos.localError().positionError();
-      localErr.scale(2); // get the 2 sigma ellipse
-      float xx = localErr.xx();
-      float xy = localErr.xy();
-      float yy = localErr.yy();
+    TrajectoryStateOnSurface tsos = state->getStateOnSurface(*target);
 
-      float denom = yy - xx;
-      float phi = 0.;
-      if(xy == 0 && denom==0) phi = M_PI_4;
-      else phi = 0.5 * atan2(2.*xy,denom); // angle of MAJOR axis
-      // Unrotate the error ellipse to get the semimajor and minor axes. Then place points on
-      // the endpoints of semiminor an seminajor axes on original(rotated) error ellipse.
-      LocalError rotErr = localErr.rotate(-phi); // xy covariance of rotErr should be zero
-      float semi1 = sqrt(rotErr.xx());
-      float semi2 = sqrt(rotErr.yy());
-      
-      // Just use one point if the ellipse is small
-      // if(semi1 < 0.1 && semi2 < 0.1) {
-      //   LogTrace("TrackAssociator") << "[getWideTrajectory] Error ellipse is small, using one trajectory point";
-      //   wideTrajectory->push_back(state->position());
-      //   continue;
-      // }
+    if (!tsos.isValid()) {
+      LogTrace("TrackAssociator") << "[getWideTrajectory] TSOS not valid";
+      continue;
+    }
+    if (!tsos.hasError()) {
+      LogTrace("TrackAssociator") << "[getWideTrajectory] TSOS does not have Errors";
+      continue;
+    }
+    LocalError localErr = tsos.localError().positionError();
+    localErr.scale(2);  // get the 2 sigma ellipse
+    float xx = localErr.xx();
+    float xy = localErr.xy();
+    float yy = localErr.yy();
 
-      Local2DPoint bounds[4];
-      bounds[0] = Local2DPoint(semi1*cos(phi),         semi1*sin(phi));
-      bounds[1] = Local2DPoint(semi1*cos(phi+M_PI),    semi1*sin(phi+M_PI));
-      phi += M_PI_2; // add pi/2 for the semi2 axis
-      bounds[2] = Local2DPoint(semi2*cos(phi),         semi2*sin(phi));
-      bounds[3] = Local2DPoint(semi2*cos(phi+M_PI),    semi2*sin(phi+M_PI));
+    float denom = yy - xx;
+    float phi = 0.;
+    if (xy == 0 && denom == 0)
+      phi = M_PI_4;
+    else
+      phi = 0.5 * atan2(2. * xy, denom);  // angle of MAJOR axis
+    // Unrotate the error ellipse to get the semimajor and minor axes. Then place points on
+    // the endpoints of semiminor an seminajor axes on original(rotated) error ellipse.
+    LocalError rotErr = localErr.rotate(-phi);  // xy covariance of rotErr should be zero
+    float semi1 = sqrt(rotErr.xx());
+    float semi2 = sqrt(rotErr.yy());
 
-      // LogTrace("TrackAssociator") << "Axes " << semi1 <<","<< semi2 <<"   phi "<< phi;
-      // LogTrace("TrackAssociator") << "Local error ellipse: " << bounds[0] << bounds[1] << bounds[2] << bounds[3];
+    // Just use one point if the ellipse is small
+    // if(semi1 < 0.1 && semi2 < 0.1) {
+    //   LogTrace("TrackAssociator") << "[getWideTrajectory] Error ellipse is small, using one trajectory point";
+    //   wideTrajectory->push_back(state->position());
+    //   continue;
+    // }
 
-      wideTrajectory->push_back(state->position());
-      for(int index=0; index<4; ++index)
-         wideTrajectory->push_back(target->toGlobal(bounds[index]));
+    Local2DPoint bounds[4];
+    bounds[0] = Local2DPoint(semi1 * cos(phi), semi1 * sin(phi));
+    bounds[1] = Local2DPoint(semi1 * cos(phi + M_PI), semi1 * sin(phi + M_PI));
+    phi += M_PI_2;  // add pi/2 for the semi2 axis
+    bounds[2] = Local2DPoint(semi2 * cos(phi), semi2 * sin(phi));
+    bounds[3] = Local2DPoint(semi2 * cos(phi + M_PI), semi2 * sin(phi + M_PI));
 
-      //LogTrace("TrackAssociator") <<"Global error ellipse: (" << target->toGlobal(bounds[0]) <<","<< target->toGlobal(bounds[1])
-      //         <<","<< target->toGlobal(bounds[2]) <<","<< target->toGlobal(bounds[3]) <<","<<state->position() <<")";
-   }
+    // LogTrace("TrackAssociator") << "Axes " << semi1 <<","<< semi2 <<"   phi "<< phi;
+    // LogTrace("TrackAssociator") << "Local error ellipse: " << bounds[0] << bounds[1] << bounds[2] << bounds[3];
 
-   return wideTrajectory;
+    wideTrajectory->push_back(state->position());
+    for (int index = 0; index < 4; ++index)
+      wideTrajectory->push_back(target->toGlobal(bounds[index]));
+
+    //LogTrace("TrackAssociator") <<"Global error ellipse: (" << target->toGlobal(bounds[0]) <<","<< target->toGlobal(bounds[1])
+    //         <<","<< target->toGlobal(bounds[2]) <<","<< target->toGlobal(bounds[3]) <<","<<state->position() <<")";
+  }
+
+  return wideTrajectory;
 }
 
-SteppingHelixStateInfo CachedTrajectory::getStateAtEcal()
-{
-   if ( ecalTrajectory_.empty() )
-     return SteppingHelixStateInfo();
-   else 
-     return ecalTrajectory_.front();
+SteppingHelixStateInfo CachedTrajectory::getStateAtEcal() {
+  if (ecalTrajectory_.empty())
+    return SteppingHelixStateInfo();
+  else
+    return ecalTrajectory_.front();
 }
 
-SteppingHelixStateInfo CachedTrajectory::getStateAtPreshower()
-{
-   if ( preshowerTrajectory_.empty() )
-     return SteppingHelixStateInfo();
-   else 
-     return preshowerTrajectory_.front();
+SteppingHelixStateInfo CachedTrajectory::getStateAtPreshower() {
+  if (preshowerTrajectory_.empty())
+    return SteppingHelixStateInfo();
+  else
+    return preshowerTrajectory_.front();
 }
 
-SteppingHelixStateInfo CachedTrajectory::getStateAtHcal()
-{
-   if ( hcalTrajectory_.empty() )
-     return SteppingHelixStateInfo();
-   else 
-     return hcalTrajectory_.front();
+SteppingHelixStateInfo CachedTrajectory::getStateAtHcal() {
+  if (hcalTrajectory_.empty())
+    return SteppingHelixStateInfo();
+  else
+    return hcalTrajectory_.front();
 }
 
-SteppingHelixStateInfo CachedTrajectory::getStateAtHO()
-{
-   if ( hoTrajectory_.empty() )
-     return SteppingHelixStateInfo();
-   else 
-     return hoTrajectory_.front();
+SteppingHelixStateInfo CachedTrajectory::getStateAtHO() {
+  if (hoTrajectory_.empty())
+    return SteppingHelixStateInfo();
+  else
+    return hoTrajectory_.front();
 }
-
 
 SteppingHelixStateInfo CachedTrajectory::getInnerState() {
-  if(fullTrajectory_.empty() )
+  if (fullTrajectory_.empty())
     return SteppingHelixStateInfo();
   else
     return fullTrajectory_.front();
 }
 
-
 SteppingHelixStateInfo CachedTrajectory::getOuterState() {
-  if(fullTrajectory_.empty() )
+  if (fullTrajectory_.empty())
     return SteppingHelixStateInfo();
   else
     return fullTrajectory_.back();
 }
-

--- a/TrackingTools/TrackAssociator/src/DetIdAssociator.cc
+++ b/TrackingTools/TrackAssociator/src/DetIdAssociator.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TrackAssociator
 // Class:      DetIdAssociator
-// 
+//
 /*
 
  Description: <one line class summary>
@@ -16,378 +16,373 @@
 //
 //
 
-
 #include "TrackingTools/TrackAssociator/interface/DetIdAssociator.h"
 #include "DetIdInfo.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include <map>
 
 DetIdAssociator::DetIdAssociator(const int nPhi, const int nEta, const double etaBinSize)
-  :nPhi_(nPhi),nEta_(nEta),
-   lookupMap_(nPhi_*nEta_,std::pair<unsigned int, unsigned int>(0,0)),
-  theMapIsValid_(false),etaBinSize_(etaBinSize)
-{
-   if (nEta_ <= 0 || nPhi_ <= 0) throw cms::Exception("FatalError") << "incorrect look-up map size. Cannot initialize such a map.";
-   maxEta_ = etaBinSize_*nEta_/2;
-   minTheta_ = 2*atan(exp(-maxEta_));
+    : nPhi_(nPhi),
+      nEta_(nEta),
+      lookupMap_(nPhi_ * nEta_, std::pair<unsigned int, unsigned int>(0, 0)),
+      theMapIsValid_(false),
+      etaBinSize_(etaBinSize) {
+  if (nEta_ <= 0 || nPhi_ <= 0)
+    throw cms::Exception("FatalError") << "incorrect look-up map size. Cannot initialize such a map.";
+  maxEta_ = etaBinSize_ * nEta_ / 2;
+  minTheta_ = 2 * atan(exp(-maxEta_));
 }
-   
-std::set<DetId> DetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& direction,
-							const int iN) const
-{
-   unsigned int n = 0;
-   if (iN>0) n = iN;
-   return getDetIdsCloseToAPoint(direction,n,n,n,n);
+
+std::set<DetId> DetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& direction, const int iN) const {
+  unsigned int n = 0;
+  if (iN > 0)
+    n = iN;
+  return getDetIdsCloseToAPoint(direction, n, n, n, n);
 }
 
 std::set<DetId> DetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& direction,
-							const unsigned int iNEtaPlus,
-							const unsigned int iNEtaMinus,
-							const unsigned int iNPhiPlus,
-							const unsigned int iNPhiMinus) const
-{
-   std::set<DetId> set;
-   check_setup();
-   if (! theMapIsValid_ ) throw cms::Exception("FatalError") << "map is not valid.";
-   LogTrace("TrackAssociator") << "(iNEtaPlus, iNEtaMinus, iNPhiPlus, iNPhiMinus): " <<
-     iNEtaPlus << ", " << iNEtaMinus << ", " << iNPhiPlus << ", " << iNPhiMinus;
-   LogTrace("TrackAssociator") << "point (eta,phi): " << direction.eta() << "," << direction.phi();
-   int ieta = iEta(direction);
-   int iphi = iPhi(direction);
-   LogTrace("TrackAssociator") << "(ieta,iphi): " << ieta << "," << iphi << "\n";
-   if (ieta>=0 && ieta<nEta_ && iphi>=0 && iphi<nPhi_){
-      fillSet(set,ieta,iphi);
-      // dumpMapContent(ieta,iphi);
-      // check if any neighbor bin is requested
-      if (iNEtaPlus + iNEtaMinus + iNPhiPlus + iNPhiMinus >0 ){
-	 LogTrace("TrackAssociator") << "Add neighbors (ieta,iphi): " << ieta << "," << iphi;
-	 // eta
-	 int maxIEta = ieta+iNEtaPlus;
-	 int minIEta = ieta-iNEtaMinus;
-	 if (maxIEta>=nEta_) maxIEta = nEta_-1;
-	 if (minIEta<0) minIEta = 0;
-	 // phi
-	 int maxIPhi = iphi+iNPhiPlus;
-	 int minIPhi = iphi-iNPhiMinus;
-	 if (maxIPhi-minIPhi>=nPhi_){ // all elements in phi
-	    minIPhi = 0;
-	    maxIPhi = nPhi_-1;
-	 }
-	 if(minIPhi<0) {
-	    minIPhi+=nPhi_;
-	    maxIPhi+=nPhi_;
-	 }
-	 LogTrace("TrackAssociator") << "\tieta (min,max): " << minIEta << "," << maxIEta;
-	 LogTrace("TrackAssociator") << "\tiphi (min,max): " << minIPhi << "," << maxIPhi<< "\n";
-	 // dumpMapContent(minIEta,maxIEta,minIPhi,maxIPhi);
-	 for (int i=minIEta;i<=maxIEta;i++)
-	   for (int j=minIPhi;j<=maxIPhi;j++) {
-	      if( i==ieta && j==iphi) continue; // already in the set
-	      fillSet(set,i,j%nPhi_);
-	   }
+                                                        const unsigned int iNEtaPlus,
+                                                        const unsigned int iNEtaMinus,
+                                                        const unsigned int iNPhiPlus,
+                                                        const unsigned int iNPhiMinus) const {
+  std::set<DetId> set;
+  check_setup();
+  if (!theMapIsValid_)
+    throw cms::Exception("FatalError") << "map is not valid.";
+  LogTrace("TrackAssociator") << "(iNEtaPlus, iNEtaMinus, iNPhiPlus, iNPhiMinus): " << iNEtaPlus << ", " << iNEtaMinus
+                              << ", " << iNPhiPlus << ", " << iNPhiMinus;
+  LogTrace("TrackAssociator") << "point (eta,phi): " << direction.eta() << "," << direction.phi();
+  int ieta = iEta(direction);
+  int iphi = iPhi(direction);
+  LogTrace("TrackAssociator") << "(ieta,iphi): " << ieta << "," << iphi << "\n";
+  if (ieta >= 0 && ieta < nEta_ && iphi >= 0 && iphi < nPhi_) {
+    fillSet(set, ieta, iphi);
+    // dumpMapContent(ieta,iphi);
+    // check if any neighbor bin is requested
+    if (iNEtaPlus + iNEtaMinus + iNPhiPlus + iNPhiMinus > 0) {
+      LogTrace("TrackAssociator") << "Add neighbors (ieta,iphi): " << ieta << "," << iphi;
+      // eta
+      int maxIEta = ieta + iNEtaPlus;
+      int minIEta = ieta - iNEtaMinus;
+      if (maxIEta >= nEta_)
+        maxIEta = nEta_ - 1;
+      if (minIEta < 0)
+        minIEta = 0;
+      // phi
+      int maxIPhi = iphi + iNPhiPlus;
+      int minIPhi = iphi - iNPhiMinus;
+      if (maxIPhi - minIPhi >= nPhi_) {  // all elements in phi
+        minIPhi = 0;
+        maxIPhi = nPhi_ - 1;
       }
-      
-   }
-   return set;
+      if (minIPhi < 0) {
+        minIPhi += nPhi_;
+        maxIPhi += nPhi_;
+      }
+      LogTrace("TrackAssociator") << "\tieta (min,max): " << minIEta << "," << maxIEta;
+      LogTrace("TrackAssociator") << "\tiphi (min,max): " << minIPhi << "," << maxIPhi << "\n";
+      // dumpMapContent(minIEta,maxIEta,minIPhi,maxIPhi);
+      for (int i = minIEta; i <= maxIEta; i++)
+        for (int j = minIPhi; j <= maxIPhi; j++) {
+          if (i == ieta && j == iphi)
+            continue;  // already in the set
+          fillSet(set, i, j % nPhi_);
+        }
+    }
+  }
+  return set;
+}
+
+std::set<DetId> DetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& point, const double d) const {
+  return getDetIdsCloseToAPoint(point, d, d, d, d);
 }
 
 std::set<DetId> DetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& point,
-							const double d) const
-{
-   return getDetIdsCloseToAPoint(point,d,d,d,d);
+                                                        const double dThetaPlus,
+                                                        const double dThetaMinus,
+                                                        const double dPhiPlus,
+                                                        const double dPhiMinus) const {
+  LogTrace("TrackAssociator") << "(dThetaPlus,dThetaMinus,dPhiPlus,dPhiMinus): " << dThetaPlus << ", " << dThetaMinus
+                              << ", " << dPhiPlus << ", " << dPhiMinus;
+  unsigned int n = 0;
+  if (dThetaPlus < 0 || dThetaMinus < 0 || dPhiPlus < 0 || dPhiMinus < 0)
+    return getDetIdsCloseToAPoint(point, n, n, n, n);
+  // check that region of interest overlaps with the look-up map
+  double maxTheta = point.theta() + dThetaPlus;
+  if (maxTheta > M_PI - minTheta_)
+    maxTheta = M_PI - minTheta_;
+  double minTheta = point.theta() - dThetaMinus;
+  if (minTheta < minTheta_)
+    minTheta = minTheta_;
+  if (maxTheta < minTheta_ || minTheta > M_PI - minTheta_)
+    return std::set<DetId>();
+
+  // take into account non-linear dependence of eta from
+  // theta in regions with large |eta|
+  double minEta = -log(tan(maxTheta / 2));
+  double maxEta = -log(tan(minTheta / 2));
+  unsigned int iNEtaPlus = abs(int((maxEta - point.eta()) / etaBinSize_));
+  unsigned int iNEtaMinus = abs(int((point.eta() - minEta) / etaBinSize_));
+  unsigned int iNPhiPlus = abs(int(dPhiPlus / (2 * M_PI) * nPhi_));
+  unsigned int iNPhiMinus = abs(int(dPhiMinus / (2 * M_PI) * nPhi_));
+  // add one more bin in each direction to guaranty that we don't miss anything
+  return getDetIdsCloseToAPoint(point, iNEtaPlus + 1, iNEtaMinus + 1, iNPhiPlus + 1, iNPhiMinus + 1);
 }
 
-std::set<DetId> DetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& point,
-							const double dThetaPlus,
-							const double dThetaMinus,
-							const double dPhiPlus,
-							const double dPhiMinus) const
-{
-   LogTrace("TrackAssociator") << "(dThetaPlus,dThetaMinus,dPhiPlus,dPhiMinus): " <<
-     dThetaPlus << ", " << dThetaMinus << ", " << dPhiPlus << ", " << dPhiMinus;
-   unsigned int n = 0;
-   if ( dThetaPlus<0 || dThetaMinus<0 || dPhiPlus<0 || dPhiMinus<0) 
-     return getDetIdsCloseToAPoint(point,n,n,n,n);
-   // check that region of interest overlaps with the look-up map
-   double maxTheta = point.theta()+dThetaPlus;
-   if (maxTheta > M_PI-minTheta_) maxTheta =  M_PI-minTheta_;
-   double minTheta = point.theta()-dThetaMinus;
-   if (minTheta < minTheta_) minTheta = minTheta_;
-   if ( maxTheta < minTheta_ || minTheta > M_PI-minTheta_) return std::set<DetId>();
-   
-   // take into account non-linear dependence of eta from
-   // theta in regions with large |eta|
-   double minEta = -log(tan(maxTheta/2));
-   double maxEta = -log(tan(minTheta/2));
-   unsigned int iNEtaPlus  = abs(int( ( maxEta-point.eta() )/etaBinSize_));
-   unsigned int iNEtaMinus = abs(int( ( point.eta() - minEta )/etaBinSize_));
-   unsigned int iNPhiPlus = abs(int( dPhiPlus/(2*M_PI)*nPhi_ ));
-   unsigned int iNPhiMinus  = abs(int( dPhiMinus/(2*M_PI)*nPhi_ ));
-   // add one more bin in each direction to guaranty that we don't miss anything
-   return getDetIdsCloseToAPoint(point, iNEtaPlus+1, iNEtaMinus+1, iNPhiPlus+1, iNPhiMinus+1);
+int DetIdAssociator::iEta(const GlobalPoint& point) const { return int(point.eta() / etaBinSize_ + nEta_ / 2); }
+
+int DetIdAssociator::iPhi(const GlobalPoint& point) const {
+  return int((double(point.phi()) + M_PI) / (2 * M_PI) * nPhi_);
 }
 
-
-int DetIdAssociator::iEta (const GlobalPoint& point) const
-{
-   return int(point.eta()/etaBinSize_ + nEta_/2);
-}
-
-int DetIdAssociator::iPhi (const GlobalPoint& point) const
-{
-   return int((double(point.phi())+M_PI)/(2*M_PI)*nPhi_);
-}
-
-
-void DetIdAssociator::buildMap()
-{
+void DetIdAssociator::buildMap() {
   // the map is built in two steps to create a clean memory footprint
   // 0) determine how many elements each bin has
   // 1) fill the container map
-   check_setup();
-   LogTrace("TrackAssociator")<<"building map for " << name() << "\n";
-   // clear the map
-   if (nEta_ <= 0 || nPhi_ <= 0) throw cms::Exception("FatalError") << "incorrect look-up map size. Cannot build such a map.";
-   std::vector<GlobalPoint> pointBuffer;
-   std::vector<DetId> detIdBuffer;
-   unsigned int numberOfSubDetectors = getNumberOfSubdetectors();
-   unsigned totalNumberOfElementsInTheContainer(0);
-   for ( unsigned int step = 0; step < 2; ++step){
-     unsigned int numberOfDetIdsOutsideEtaRange = 0;
-     unsigned int numberOfDetIdsActive = 0;
-     LogTrace("TrackAssociator")<< "Step: " << step;
-     for ( unsigned int subDetectorIndex = 0; subDetectorIndex < numberOfSubDetectors; ++subDetectorIndex ){
-       getValidDetIds(subDetectorIndex, detIdBuffer);
-       // This std::move prevents modification
-       std::vector<DetId> const& validIds = std::move(detIdBuffer);
-       LogTrace("TrackAssociator")<< "Number of valid DetIds for subdetector: " << subDetectorIndex << " is " <<  validIds.size();
-       for (std::vector<DetId>::const_iterator id_itr = validIds.begin(); id_itr!=validIds.end(); id_itr++) {
-	 std::pair<const_iterator,const_iterator> points = getDetIdPoints(*id_itr, pointBuffer);
-	 LogTrace("TrackAssociatorVerbose")<< "Found " << points.second-points.first << " global points to describe geometry of DetId: " 
-					   << id_itr->rawId();
-	 int etaMax(-1);
-	 int etaMin(-1);
-	 int phiMax(-1);
-	 int phiMin(-1);
-	 // this is a bit overkill, but it should be 100% proof (when debugged :)
-	 for(std::vector<GlobalPoint>::const_iterator iter = points.first; iter != points.second; iter++)
-	   {
-	     LogTrace("TrackAssociatorVerbose")<< "\tpoint (rho,phi,z): " << iter->perp() << ", " <<
-	       iter->phi() << ", " << iter->z();
-	     // FIX ME: this should be a fatal error
-	     if(edm::isNotFinite(iter->mag())||iter->mag()>1e5) { //Detector parts cannot be 1 km away or be NaN
-	       edm::LogWarning("TrackAssociator") << "Critical error! Bad detector unit geometry:\n\tDetId:" 
-						  << id_itr->rawId() << "\t mag(): " << iter->mag() << "\n" << DetIdInfo::info( *id_itr,nullptr )
-						  << "\nSkipped the element";
-	       continue;
-	     }
-	     volume_.addActivePoint(*iter);
-	     int ieta = iEta(*iter);
-	     int iphi = iPhi(*iter);
-	     if (ieta<0 || ieta>=nEta_) {
-	       LogTrace("TrackAssociator")<<"Out of range: DetId:" << id_itr->rawId() << "\t (ieta,iphi): " 
-					  << ieta << "," << iphi << "\n" << "Point: " << *iter << "\t(eta,phi): " << (*iter).eta() 
-					  << "," << (*iter).phi() << "\n center: " << getPosition(*id_itr);
-	       continue;
-	     }
-	     if ( phiMin<0 ) {
-	       // first element
-	       etaMin = ieta;
-	       etaMax = ieta;
-	       phiMin = iphi;
-	       phiMax = iphi;
-	     }else{
-	       // check for discontinuity in phi
-	       int deltaMin = abs(phiMin -iphi);
-	       int deltaMax = abs(phiMax -iphi);
-	       // assume that no single detector element has more than 3.1416 coverage in phi
-	       if ( deltaMin > nPhi_/2 && phiMin < nPhi_/2 ) phiMin+= nPhi_;
-	       if ( deltaMax > nPhi_/2 ) {
-		 if (phiMax < nPhi_/2 ) 
-		   phiMax+= nPhi_;
-		 else
-		   iphi += nPhi_;
-	       }
-	       assert (iphi>=0);
-	       if ( etaMin > ieta) etaMin = ieta;
-	       if ( etaMax < ieta) etaMax = ieta;
-	       if ( phiMin > iphi) phiMin = iphi;
-	       if ( phiMax < iphi) phiMax = iphi;
-	     }
-	   }
-	 if (etaMax<0||phiMax<0||etaMin>=nEta_||phiMin>=nPhi_) {
-	   LogTrace("TrackAssociatorVerbose")<<"Out of range or no geometry: DetId:" << id_itr->rawId() <<
-	     "\n\teta (min,max): " << etaMin << "," << etaMax <<
-	     "\n\tphi (min,max): " << phiMin << "," << phiMax <<
-	     "\nTower id: " << id_itr->rawId() << "\n";
-	   numberOfDetIdsOutsideEtaRange++;
-	   continue;
-	 }
-	 numberOfDetIdsActive++;
-	 
-	 LogTrace("TrackAssociatorVerbose") << "DetId (ieta_min,ieta_max,iphi_min,iphi_max): " << id_itr->rawId() <<
-	   ", " << etaMin << ", " << etaMax << ", " << phiMin << ", " << phiMax;
-	 for(int ieta = etaMin; ieta <= etaMax; ieta++)
-	   for(int iphi = phiMin; iphi <= phiMax; iphi++)
-	     if ( step == 0 ){
-	       lookupMap_.at(index(ieta,iphi%nPhi_)).second++;
-	       totalNumberOfElementsInTheContainer++;
-	     } else {
-	       container_.at(lookupMap_.at(index(ieta,iphi%nPhi_)).first) = *id_itr;
-	       lookupMap_.at(index(ieta,iphi%nPhi_)).first--;
-	       totalNumberOfElementsInTheContainer--;
-	     }
-       }
-     }
-     LogTrace("TrackAssociator") << "Number of elements outside the allowed range ( |eta|>"<<
-       nEta_/2*etaBinSize_ << "): " << numberOfDetIdsOutsideEtaRange << "\n";
-     LogTrace("TrackAssociator") << "Number of active DetId's mapped: " << 
-       numberOfDetIdsActive << "\n";
-     if ( step == 0 ){
-       // allocate
-       container_.resize(totalNumberOfElementsInTheContainer);
-       // fill the range index in the lookup map to point to the last element in the range
-       unsigned int index(0);
-       for ( std::vector<std::pair<unsigned int,unsigned int> >::iterator bin = lookupMap_.begin();
-	     bin != lookupMap_.end(); ++bin )
-	 {
-	   if (bin->second==0) continue;
-	   index += bin->second;
-	   bin->first = index-1;
-	 }
-     }
-   }
-   if ( totalNumberOfElementsInTheContainer != 0 )
-     throw cms::Exception("FatalError") << "Look-up map filled incorrectly. Structural problem. Get in touch with the developer.";
-   volume_.determinInnerDimensions();
-   edm::LogVerbatim("TrackAssociator") << "Fiducial volume for " << name() << " (minR, maxR, minZ, maxZ): " << 
-     volume_.minR() << ", " << volume_.maxR() << ", " << volume_.minZ() << ", " << volume_.maxZ();
-   theMapIsValid_ = true;
+  check_setup();
+  LogTrace("TrackAssociator") << "building map for " << name() << "\n";
+  // clear the map
+  if (nEta_ <= 0 || nPhi_ <= 0)
+    throw cms::Exception("FatalError") << "incorrect look-up map size. Cannot build such a map.";
+  std::vector<GlobalPoint> pointBuffer;
+  std::vector<DetId> detIdBuffer;
+  unsigned int numberOfSubDetectors = getNumberOfSubdetectors();
+  unsigned totalNumberOfElementsInTheContainer(0);
+  for (unsigned int step = 0; step < 2; ++step) {
+    unsigned int numberOfDetIdsOutsideEtaRange = 0;
+    unsigned int numberOfDetIdsActive = 0;
+    LogTrace("TrackAssociator") << "Step: " << step;
+    for (unsigned int subDetectorIndex = 0; subDetectorIndex < numberOfSubDetectors; ++subDetectorIndex) {
+      getValidDetIds(subDetectorIndex, detIdBuffer);
+      // This std::move prevents modification
+      std::vector<DetId> const& validIds = std::move(detIdBuffer);
+      LogTrace("TrackAssociator") << "Number of valid DetIds for subdetector: " << subDetectorIndex << " is "
+                                  << validIds.size();
+      for (std::vector<DetId>::const_iterator id_itr = validIds.begin(); id_itr != validIds.end(); id_itr++) {
+        std::pair<const_iterator, const_iterator> points = getDetIdPoints(*id_itr, pointBuffer);
+        LogTrace("TrackAssociatorVerbose") << "Found " << points.second - points.first
+                                           << " global points to describe geometry of DetId: " << id_itr->rawId();
+        int etaMax(-1);
+        int etaMin(-1);
+        int phiMax(-1);
+        int phiMin(-1);
+        // this is a bit overkill, but it should be 100% proof (when debugged :)
+        for (std::vector<GlobalPoint>::const_iterator iter = points.first; iter != points.second; iter++) {
+          LogTrace("TrackAssociatorVerbose")
+              << "\tpoint (rho,phi,z): " << iter->perp() << ", " << iter->phi() << ", " << iter->z();
+          // FIX ME: this should be a fatal error
+          if (edm::isNotFinite(iter->mag()) || iter->mag() > 1e5) {  //Detector parts cannot be 1 km away or be NaN
+            edm::LogWarning("TrackAssociator")
+                << "Critical error! Bad detector unit geometry:\n\tDetId:" << id_itr->rawId()
+                << "\t mag(): " << iter->mag() << "\n"
+                << DetIdInfo::info(*id_itr, nullptr) << "\nSkipped the element";
+            continue;
+          }
+          volume_.addActivePoint(*iter);
+          int ieta = iEta(*iter);
+          int iphi = iPhi(*iter);
+          if (ieta < 0 || ieta >= nEta_) {
+            LogTrace("TrackAssociator") << "Out of range: DetId:" << id_itr->rawId() << "\t (ieta,iphi): " << ieta
+                                        << "," << iphi << "\n"
+                                        << "Point: " << *iter << "\t(eta,phi): " << (*iter).eta() << ","
+                                        << (*iter).phi() << "\n center: " << getPosition(*id_itr);
+            continue;
+          }
+          if (phiMin < 0) {
+            // first element
+            etaMin = ieta;
+            etaMax = ieta;
+            phiMin = iphi;
+            phiMax = iphi;
+          } else {
+            // check for discontinuity in phi
+            int deltaMin = abs(phiMin - iphi);
+            int deltaMax = abs(phiMax - iphi);
+            // assume that no single detector element has more than 3.1416 coverage in phi
+            if (deltaMin > nPhi_ / 2 && phiMin < nPhi_ / 2)
+              phiMin += nPhi_;
+            if (deltaMax > nPhi_ / 2) {
+              if (phiMax < nPhi_ / 2)
+                phiMax += nPhi_;
+              else
+                iphi += nPhi_;
+            }
+            assert(iphi >= 0);
+            if (etaMin > ieta)
+              etaMin = ieta;
+            if (etaMax < ieta)
+              etaMax = ieta;
+            if (phiMin > iphi)
+              phiMin = iphi;
+            if (phiMax < iphi)
+              phiMax = iphi;
+          }
+        }
+        if (etaMax < 0 || phiMax < 0 || etaMin >= nEta_ || phiMin >= nPhi_) {
+          LogTrace("TrackAssociatorVerbose")
+              << "Out of range or no geometry: DetId:" << id_itr->rawId() << "\n\teta (min,max): " << etaMin << ","
+              << etaMax << "\n\tphi (min,max): " << phiMin << "," << phiMax << "\nTower id: " << id_itr->rawId()
+              << "\n";
+          numberOfDetIdsOutsideEtaRange++;
+          continue;
+        }
+        numberOfDetIdsActive++;
+
+        LogTrace("TrackAssociatorVerbose") << "DetId (ieta_min,ieta_max,iphi_min,iphi_max): " << id_itr->rawId() << ", "
+                                           << etaMin << ", " << etaMax << ", " << phiMin << ", " << phiMax;
+        for (int ieta = etaMin; ieta <= etaMax; ieta++)
+          for (int iphi = phiMin; iphi <= phiMax; iphi++)
+            if (step == 0) {
+              lookupMap_.at(index(ieta, iphi % nPhi_)).second++;
+              totalNumberOfElementsInTheContainer++;
+            } else {
+              container_.at(lookupMap_.at(index(ieta, iphi % nPhi_)).first) = *id_itr;
+              lookupMap_.at(index(ieta, iphi % nPhi_)).first--;
+              totalNumberOfElementsInTheContainer--;
+            }
+      }
+    }
+    LogTrace("TrackAssociator") << "Number of elements outside the allowed range ( |eta|>" << nEta_ / 2 * etaBinSize_
+                                << "): " << numberOfDetIdsOutsideEtaRange << "\n";
+    LogTrace("TrackAssociator") << "Number of active DetId's mapped: " << numberOfDetIdsActive << "\n";
+    if (step == 0) {
+      // allocate
+      container_.resize(totalNumberOfElementsInTheContainer);
+      // fill the range index in the lookup map to point to the last element in the range
+      unsigned int index(0);
+      for (std::vector<std::pair<unsigned int, unsigned int> >::iterator bin = lookupMap_.begin();
+           bin != lookupMap_.end();
+           ++bin) {
+        if (bin->second == 0)
+          continue;
+        index += bin->second;
+        bin->first = index - 1;
+      }
+    }
+  }
+  if (totalNumberOfElementsInTheContainer != 0)
+    throw cms::Exception("FatalError")
+        << "Look-up map filled incorrectly. Structural problem. Get in touch with the developer.";
+  volume_.determinInnerDimensions();
+  edm::LogVerbatim("TrackAssociator") << "Fiducial volume for " << name()
+                                      << " (minR, maxR, minZ, maxZ): " << volume_.minR() << ", " << volume_.maxR()
+                                      << ", " << volume_.minZ() << ", " << volume_.maxZ();
+  theMapIsValid_ = true;
 }
 
-std::set<DetId> DetIdAssociator::getDetIdsInACone(const std::set<DetId>& inset, 
-					     const std::vector<GlobalPoint>& trajectory,
-					     const double dR) const
-{
-  if ( selectAllInACone(dR)) return inset;
-   check_setup();
-   std::set<DetId> outset;
-   for(std::set<DetId>::const_iterator id_iter = inset.begin(); id_iter != inset.end(); id_iter++)
-     for(std::vector<GlobalPoint>::const_iterator point_iter = trajectory.begin(); point_iter != trajectory.end(); point_iter++)
-       if (nearElement(*point_iter,*id_iter,dR)) {
-	  outset.insert(*id_iter);
-	  break;
-       }
-   return outset;
+std::set<DetId> DetIdAssociator::getDetIdsInACone(const std::set<DetId>& inset,
+                                                  const std::vector<GlobalPoint>& trajectory,
+                                                  const double dR) const {
+  if (selectAllInACone(dR))
+    return inset;
+  check_setup();
+  std::set<DetId> outset;
+  for (std::set<DetId>::const_iterator id_iter = inset.begin(); id_iter != inset.end(); id_iter++)
+    for (std::vector<GlobalPoint>::const_iterator point_iter = trajectory.begin(); point_iter != trajectory.end();
+         point_iter++)
+      if (nearElement(*point_iter, *id_iter, dR)) {
+        outset.insert(*id_iter);
+        break;
+      }
+  return outset;
 }
 
 std::vector<DetId> DetIdAssociator::getCrossedDetIds(const std::set<DetId>& inset,
-						     const std::vector<GlobalPoint>& trajectory) const
-{
-   check_setup();
-   std::vector<DetId> output;
-   std::set<DetId> ids(inset);
-   for ( unsigned int i=0; i+1 < trajectory.size(); ++i ) {
-      std::set<DetId>::const_iterator id_iter = ids.begin();
-      while ( id_iter != ids.end() ) {
-	 if ( crossedElement(trajectory[i],trajectory[i+1],*id_iter) ){
-	    output.push_back(*id_iter);
-	    ids.erase(id_iter++);
-	 }else
-	   id_iter++;
-      }
-   }
-   return output;
+                                                     const std::vector<GlobalPoint>& trajectory) const {
+  check_setup();
+  std::vector<DetId> output;
+  std::set<DetId> ids(inset);
+  for (unsigned int i = 0; i + 1 < trajectory.size(); ++i) {
+    std::set<DetId>::const_iterator id_iter = ids.begin();
+    while (id_iter != ids.end()) {
+      if (crossedElement(trajectory[i], trajectory[i + 1], *id_iter)) {
+        output.push_back(*id_iter);
+        ids.erase(id_iter++);
+      } else
+        id_iter++;
+    }
+  }
+  return output;
 }
 
 std::vector<DetId> DetIdAssociator::getCrossedDetIds(const std::set<DetId>& inset,
-						     const std::vector<SteppingHelixStateInfo>& trajectory,
-						     const double tolerance) const
-{
-   check_setup();
-   std::vector<DetId> output;
-   std::set<DetId> ids(inset);
-   for ( unsigned int i=0; i+1 < trajectory.size(); ++i ) {
-      std::set<DetId>::const_iterator id_iter = ids.begin();
-      while ( id_iter != ids.end() ) {
-	 if ( crossedElement(trajectory[i].position(),trajectory[i+1].position(),*id_iter,tolerance,&trajectory[i]) ){
-	    output.push_back(*id_iter);
-	    ids.erase(id_iter++);
-	 }else
-	   id_iter++;
-      }
-   }
-   return output;
+                                                     const std::vector<SteppingHelixStateInfo>& trajectory,
+                                                     const double tolerance) const {
+  check_setup();
+  std::vector<DetId> output;
+  std::set<DetId> ids(inset);
+  for (unsigned int i = 0; i + 1 < trajectory.size(); ++i) {
+    std::set<DetId>::const_iterator id_iter = ids.begin();
+    while (id_iter != ids.end()) {
+      if (crossedElement(trajectory[i].position(), trajectory[i + 1].position(), *id_iter, tolerance, &trajectory[i])) {
+        output.push_back(*id_iter);
+        ids.erase(id_iter++);
+      } else
+        id_iter++;
+    }
+  }
+  return output;
 }
 
+void DetIdAssociator::dumpMapContent(int ieta, int iphi) const {
+  if (!(ieta >= 0 && ieta < nEta_ && iphi >= 0)) {
+    edm::LogWarning("TrackAssociator") << "ieta or iphi is out of range. Skipped.";
+    return;
+  }
 
-void DetIdAssociator::dumpMapContent(int ieta, int iphi) const
-{
-   if (! (ieta>=0 && ieta<nEta_ && iphi>=0) )
-     {
-	edm::LogWarning("TrackAssociator") << "ieta or iphi is out of range. Skipped.";
-	return;
-     }
-
-   std::vector<GlobalPoint> pointBuffer;
-   std::set<DetId> set;
-   fillSet(set,ieta,iphi%nPhi_);
-   LogTrace("TrackAssociator") << "Map content for cell (ieta,iphi): " << ieta << ", " << iphi%nPhi_;
-   for(std::set<DetId>::const_iterator itr = set.begin(); itr!=set.end(); itr++)
-     {
-	LogTrace("TrackAssociator") << "\tDetId " << itr->rawId() << ", geometry (x,y,z,rho,eta,phi):";
-	std::pair<const_iterator,const_iterator> points = getDetIdPoints(*itr, pointBuffer);
-	for(std::vector<GlobalPoint>::const_iterator point = points.first; point != points.second; point++)
-	  LogTrace("TrackAssociator") << "\t\t" << point->x() << ", " << point->y() << ", " << point->z() << ", "
-	  << point->perp() << ", " << point->eta() << ", " << point->phi();
-     }
+  std::vector<GlobalPoint> pointBuffer;
+  std::set<DetId> set;
+  fillSet(set, ieta, iphi % nPhi_);
+  LogTrace("TrackAssociator") << "Map content for cell (ieta,iphi): " << ieta << ", " << iphi % nPhi_;
+  for (std::set<DetId>::const_iterator itr = set.begin(); itr != set.end(); itr++) {
+    LogTrace("TrackAssociator") << "\tDetId " << itr->rawId() << ", geometry (x,y,z,rho,eta,phi):";
+    std::pair<const_iterator, const_iterator> points = getDetIdPoints(*itr, pointBuffer);
+    for (std::vector<GlobalPoint>::const_iterator point = points.first; point != points.second; point++)
+      LogTrace("TrackAssociator") << "\t\t" << point->x() << ", " << point->y() << ", " << point->z() << ", "
+                                  << point->perp() << ", " << point->eta() << ", " << point->phi();
+  }
 }
 
-void DetIdAssociator::dumpMapContent(int ieta_min, int ieta_max, int iphi_min, int iphi_max) const
-{
-   for(int i=ieta_min;i<=ieta_max;i++)
-     for(int j=iphi_min;j<=iphi_max;j++)
-       dumpMapContent(i,j);
+void DetIdAssociator::dumpMapContent(int ieta_min, int ieta_max, int iphi_min, int iphi_max) const {
+  for (int i = ieta_min; i <= ieta_max; i++)
+    for (int j = iphi_min; j <= iphi_max; j++)
+      dumpMapContent(i, j);
 }
 
-const FiducialVolume& DetIdAssociator::volume() const
-{
-   if (! theMapIsValid_ ) throw cms::Exception("FatalError") << "map is not valid.";
-   return volume_; 
+const FiducialVolume& DetIdAssociator::volume() const {
+  if (!theMapIsValid_)
+    throw cms::Exception("FatalError") << "map is not valid.";
+  return volume_;
 }
 
-std::set<DetId> DetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& direction,
-							const MapRange& mapRange) const
-{
-   return getDetIdsCloseToAPoint(direction, mapRange.dThetaPlus, mapRange.dThetaMinus,
-				 mapRange.dPhiPlus, mapRange.dPhiMinus);
-
+std::set<DetId> DetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& direction, const MapRange& mapRange) const {
+  return getDetIdsCloseToAPoint(
+      direction, mapRange.dThetaPlus, mapRange.dThetaMinus, mapRange.dPhiPlus, mapRange.dPhiMinus);
 }
 
-bool DetIdAssociator::nearElement(const GlobalPoint& point, 
-				  const DetId& id, 
-				  const double distance) const 
-{
+bool DetIdAssociator::nearElement(const GlobalPoint& point, const DetId& id, const double distance) const {
   GlobalPoint center = getPosition(id);
-  double deltaPhi(fabs(point.phi()-center.phi()));
-  if(deltaPhi>M_PI) deltaPhi = fabs(deltaPhi-M_PI*2.);
-  return (point.eta()-center.eta())*(point.eta()-center.eta()) + deltaPhi*deltaPhi < distance*distance;
+  double deltaPhi(fabs(point.phi() - center.phi()));
+  if (deltaPhi > M_PI)
+    deltaPhi = fabs(deltaPhi - M_PI * 2.);
+  return (point.eta() - center.eta()) * (point.eta() - center.eta()) + deltaPhi * deltaPhi < distance * distance;
 }
 
-void DetIdAssociator::check_setup() const
-{
-  if (nEta_==0) throw cms::Exception("FatalError") << "Number of eta bins is not set.\n";
-  if (nPhi_==0) throw cms::Exception("FatalError") << "Number of phi bins is not set.\n";
+void DetIdAssociator::check_setup() const {
+  if (nEta_ == 0)
+    throw cms::Exception("FatalError") << "Number of eta bins is not set.\n";
+  if (nPhi_ == 0)
+    throw cms::Exception("FatalError") << "Number of phi bins is not set.\n";
   // if (ivProp_==0) throw cms::Exception("FatalError") << "Track propagator is not defined\n";
-  if (etaBinSize_==0) throw cms::Exception("FatalError") << "Eta bin size is not set.\n";
+  if (etaBinSize_ == 0)
+    throw cms::Exception("FatalError") << "Eta bin size is not set.\n";
 }
 
-void DetIdAssociator::fillSet( std::set<DetId>& set, unsigned int iEta, unsigned int iPhi) const
-{
-  unsigned int i = index(iEta,iPhi);
+void DetIdAssociator::fillSet(std::set<DetId>& set, unsigned int iEta, unsigned int iPhi) const {
+  unsigned int i = index(iEta, iPhi);
   unsigned int i0 = lookupMap_.at(i).first;
   unsigned int size = lookupMap_.at(i).second;
-  for ( i = i0; i < i0+size; ++i )
+  for (i = i0; i < i0 + size; ++i)
     set.insert(container_.at(i));
 }
 
@@ -396,6 +391,5 @@ void DetIdAssociator::fillSet( std::set<DetId>& set, unsigned int iEta, unsigned
 
 #include "FWCore/Utilities/interface/typelookup.h"
 TYPELOOKUP_DATA_REG(DetIdAssociator);
-
 
 //  LocalWords:  Fiducial

--- a/TrackingTools/TrackAssociator/src/DetIdInfo.cc
+++ b/TrackingTools/TrackAssociator/src/DetIdInfo.cc
@@ -7,7 +7,7 @@
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-  
+
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
@@ -22,231 +22,158 @@
 
 #include <sstream>
 
-std::string DetIdInfo::info(const DetId& id, const TrackerTopology *tTopo) {
-   std::ostringstream oss;
-   
-   oss << "DetId: " << id.rawId() << "\n";
-   
-   switch ( id.det() ) {
-    
-     case DetId::Tracker:
-       switch ( id.subdetId() ) {
-        case StripSubdetector::TIB:
-             {
-               oss <<"TIB ";
-             }
-           break;
-        case StripSubdetector::TOB:
-             {
-               oss <<"TOB ";
-             }
-           break;
-        case StripSubdetector::TEC:
-             {
-               oss <<"TEC ";
-             }
-           break;
-        case StripSubdetector::TID:
-             {
-               oss <<"TID ";
-             }
-           break;
-        case (int) PixelSubdetector::PixelBarrel:
-             {
-               oss <<"PixBarrel ";
-             }
-           break;
-        case (int) PixelSubdetector::PixelEndcap:
-             {
-               oss <<"PixEndcap ";
-             }
-           break;
-       }
-       if ( tTopo!=nullptr)
-	 oss<< tTopo->layer(id);
-       break;
+std::string DetIdInfo::info(const DetId& id, const TrackerTopology* tTopo) {
+  std::ostringstream oss;
+
+  oss << "DetId: " << id.rawId() << "\n";
+
+  switch (id.det()) {
+    case DetId::Tracker:
+      switch (id.subdetId()) {
+        case StripSubdetector::TIB: {
+          oss << "TIB ";
+        } break;
+        case StripSubdetector::TOB: {
+          oss << "TOB ";
+        } break;
+        case StripSubdetector::TEC: {
+          oss << "TEC ";
+        } break;
+        case StripSubdetector::TID: {
+          oss << "TID ";
+        } break;
+        case (int)PixelSubdetector::PixelBarrel: {
+          oss << "PixBarrel ";
+        } break;
+        case (int)PixelSubdetector::PixelEndcap: {
+          oss << "PixEndcap ";
+        } break;
+      }
+      if (tTopo != nullptr)
+        oss << tTopo->layer(id);
+      break;
 
     case DetId::Muon:
-      switch ( id.subdetId() ) {
-       case MuonSubdetId::DT:
-	   { 
-	      DTChamberId detId(id.rawId());
-	      oss << "DT chamber (wheel, station, sector): "
-		<< detId.wheel() << ", "
-		<< detId.station() << ", "
-		<< detId.sector();
-	   }
-	 break;
-       case MuonSubdetId::CSC:
-	   {
-	      CSCDetId detId(id.rawId());
-	      oss << "CSC chamber (endcap, station, ring, chamber, layer): "
-		<< detId.endcap() << ", "
-		<< detId.station() << ", "
-		<< detId.ring() << ", "
-		<< detId.chamber() << ", "
-		<< detId.layer();
-	   }
-	 break;
-       case MuonSubdetId::RPC:
-	   { 
-	      RPCDetId detId(id.rawId());
-	      oss << "RPC chamber ";
-	      switch ( detId.region() ) {
-	       case 0:
-		 oss << "/ barrel / (wheel, station, sector, layer, subsector, roll): "
-		   << detId.ring() << ", "
-		   << detId.station() << ", "
-		   << detId.sector() << ", "
-		   << detId.layer() << ", "
-		   << detId.subsector() << ", "
-		   << detId.roll();
-		 break;
-	       case 1:
-		 oss << "/ forward endcap / (wheel, station, sector, layer, subsector, roll): "
-		   << detId.ring() << ", "
-		   << detId.station() << ", "
-		   << detId.sector() << ", "
-		   << detId.layer() << ", "
-		   << detId.subsector() << ", "
-		   << detId.roll();
-		 break;
-	       case -1:
-		 oss << "/ backward endcap / (wheel, station, sector, layer, subsector, roll): "
-		   << detId.ring() << ", "
-		   << detId.station() << ", "
-		   << detId.sector() << ", "
-		   << detId.layer() << ", "
-		   << detId.subsector() << ", "
-		   << detId.roll();
-		 break;
-	      }
-	   }
-	 break;
-       case MuonSubdetId::GEM:
-	 {
-	   GEMDetId detId(id.rawId());
-	   oss << "GEM chamber (endcap, station, ring, chamber, layer): "
-	       << detId.region() << ", "
-	       << detId.station() << ", "
-	       << detId.ring() << ", "
-	       << detId.chamber() << ", "
-	       << detId.layer();
-	 }
-	 break;
-       case MuonSubdetId::ME0:
-	 {
-	   ME0DetId detId(id.rawId());
-	   oss << "ME0 chamber (endcap, station, ring, chamber, layer): "
-	       << detId.region() << ", "
-	       << detId.station() << ", "
-	       << detId.chamber() << ", "
-	       << detId.layer();
-	 }
-	 break;
+      switch (id.subdetId()) {
+        case MuonSubdetId::DT: {
+          DTChamberId detId(id.rawId());
+          oss << "DT chamber (wheel, station, sector): " << detId.wheel() << ", " << detId.station() << ", "
+              << detId.sector();
+        } break;
+        case MuonSubdetId::CSC: {
+          CSCDetId detId(id.rawId());
+          oss << "CSC chamber (endcap, station, ring, chamber, layer): " << detId.endcap() << ", " << detId.station()
+              << ", " << detId.ring() << ", " << detId.chamber() << ", " << detId.layer();
+        } break;
+        case MuonSubdetId::RPC: {
+          RPCDetId detId(id.rawId());
+          oss << "RPC chamber ";
+          switch (detId.region()) {
+            case 0:
+              oss << "/ barrel / (wheel, station, sector, layer, subsector, roll): " << detId.ring() << ", "
+                  << detId.station() << ", " << detId.sector() << ", " << detId.layer() << ", " << detId.subsector()
+                  << ", " << detId.roll();
+              break;
+            case 1:
+              oss << "/ forward endcap / (wheel, station, sector, layer, subsector, roll): " << detId.ring() << ", "
+                  << detId.station() << ", " << detId.sector() << ", " << detId.layer() << ", " << detId.subsector()
+                  << ", " << detId.roll();
+              break;
+            case -1:
+              oss << "/ backward endcap / (wheel, station, sector, layer, subsector, roll): " << detId.ring() << ", "
+                  << detId.station() << ", " << detId.sector() << ", " << detId.layer() << ", " << detId.subsector()
+                  << ", " << detId.roll();
+              break;
+          }
+        } break;
+        case MuonSubdetId::GEM: {
+          GEMDetId detId(id.rawId());
+          oss << "GEM chamber (endcap, station, ring, chamber, layer): " << detId.region() << ", " << detId.station()
+              << ", " << detId.ring() << ", " << detId.chamber() << ", " << detId.layer();
+        } break;
+        case MuonSubdetId::ME0: {
+          ME0DetId detId(id.rawId());
+          oss << "ME0 chamber (endcap, station, ring, chamber, layer): " << detId.region() << ", " << detId.station()
+              << ", " << detId.chamber() << ", " << detId.layer();
+        } break;
       }
       break;
-    
-    case DetId::Calo:
-	{
-	   CaloTowerDetId detId( id.rawId() );
-	   oss << "CaloTower (ieta, iphi): "
-	     << detId.ieta() << ", "
-	     << detId.iphi();
-	}
-      break;
-    
+
+    case DetId::Calo: {
+      CaloTowerDetId detId(id.rawId());
+      oss << "CaloTower (ieta, iphi): " << detId.ieta() << ", " << detId.iphi();
+    } break;
+
     case DetId::Ecal:
-      switch ( id.subdetId() ) {
-       case EcalBarrel:
-	   {
-	      EBDetId detId(id);
-	      oss << "EcalBarrel (ieta, iphi, tower_ieta, tower_iphi): "
-		<< detId.ieta() << ", "
-		<< detId.iphi() << ", "
-		<< detId.tower_ieta() << ", "
-		<< detId.tower_iphi();
-	   }
-	 break;
-       case EcalEndcap:
-	   {
-	      EEDetId detId(id);
-	      oss << "EcalEndcap (ix, iy, SuperCrystal, crystal, quadrant): "
-		<< detId.ix() << ", "
-		<< detId.iy() << ", "
-		<< detId.isc() << ", "
-		<< detId.ic() << ", "
-		<< detId.iquadrant();
-	   }
-	 break;
-       case EcalPreshower:
-	 oss << "EcalPreshower";
-	 break;
-       case EcalTriggerTower:
-	 oss << "EcalTriggerTower";
-	 break;
-       case EcalLaserPnDiode:
-	 oss << "EcalLaserPnDiode";
-	 break;
+      switch (id.subdetId()) {
+        case EcalBarrel: {
+          EBDetId detId(id);
+          oss << "EcalBarrel (ieta, iphi, tower_ieta, tower_iphi): " << detId.ieta() << ", " << detId.iphi() << ", "
+              << detId.tower_ieta() << ", " << detId.tower_iphi();
+        } break;
+        case EcalEndcap: {
+          EEDetId detId(id);
+          oss << "EcalEndcap (ix, iy, SuperCrystal, crystal, quadrant): " << detId.ix() << ", " << detId.iy() << ", "
+              << detId.isc() << ", " << detId.ic() << ", " << detId.iquadrant();
+        } break;
+        case EcalPreshower:
+          oss << "EcalPreshower";
+          break;
+        case EcalTriggerTower:
+          oss << "EcalTriggerTower";
+          break;
+        case EcalLaserPnDiode:
+          oss << "EcalLaserPnDiode";
+          break;
       }
       break;
-      
-    case DetId::Hcal:
-	{
-	   HcalDetId detId(id);
-	   switch ( detId.subdet() ) {
-	    case HcalEmpty:
-	      oss << "HcalEmpty ";
-	      break;
-	    case HcalBarrel:
-	      oss << "HcalBarrel ";
-	      break;
-	    case HcalEndcap:
-	      oss << "HcalEndcap ";
-	      break;
-	    case HcalOuter:
-	      oss << "HcalOuter ";
-	      break;
-	    case HcalForward:
-	      oss << "HcalForward ";
-	      break;
-	    case HcalTriggerTower:
-	      oss << "HcalTriggerTower ";
-	      break;
-	    case HcalOther:
-	      oss << "HcalOther ";
-	      break;
-	   }
-	   oss << "(ieta, iphi, depth):"
-	     << detId.ieta() << ", "
-	     << detId.iphi() << ", "
-	     << detId.depth();
-	}
-      break;
-    default :;
-   }
-   return oss.str();
+
+    case DetId::Hcal: {
+      HcalDetId detId(id);
+      switch (detId.subdet()) {
+        case HcalEmpty:
+          oss << "HcalEmpty ";
+          break;
+        case HcalBarrel:
+          oss << "HcalBarrel ";
+          break;
+        case HcalEndcap:
+          oss << "HcalEndcap ";
+          break;
+        case HcalOuter:
+          oss << "HcalOuter ";
+          break;
+        case HcalForward:
+          oss << "HcalForward ";
+          break;
+        case HcalTriggerTower:
+          oss << "HcalTriggerTower ";
+          break;
+        case HcalOther:
+          oss << "HcalOther ";
+          break;
+      }
+      oss << "(ieta, iphi, depth):" << detId.ieta() << ", " << detId.iphi() << ", " << detId.depth();
+    } break;
+    default:;
+  }
+  return oss.str();
 }
 
-   
-std::string DetIdInfo::info(const std::set<DetId>& idSet, const TrackerTopology *tTopo) {
-   std::string text;
-   for(std::set<DetId>::const_iterator id = idSet.begin(); id != idSet.end(); id++)
-     {
-       text += info(*id, tTopo);
-	text += "\n";
-     }
-   return text;
+std::string DetIdInfo::info(const std::set<DetId>& idSet, const TrackerTopology* tTopo) {
+  std::string text;
+  for (std::set<DetId>::const_iterator id = idSet.begin(); id != idSet.end(); id++) {
+    text += info(*id, tTopo);
+    text += "\n";
+  }
+  return text;
 }
 
-std::string DetIdInfo::info(const std::vector<DetId>& idSet, const TrackerTopology *tTopo) {
-   std::string text;
-   for(std::vector<DetId>::const_iterator id = idSet.begin(); id != idSet.end(); id++)
-     {
-       text += info(*id, tTopo);
-	text += "\n";
-     }
-   return text;
+std::string DetIdInfo::info(const std::vector<DetId>& idSet, const TrackerTopology* tTopo) {
+  std::string text;
+  for (std::vector<DetId>::const_iterator id = idSet.begin(); id != idSet.end(); id++) {
+    text += info(*id, tTopo);
+    text += "\n";
+  }
+  return text;
 }
-
-   

--- a/TrackingTools/TrackAssociator/src/FiducialVolume.cc
+++ b/TrackingTools/TrackAssociator/src/FiducialVolume.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TrackAssociator
 // Class:      FiducialVolume
-// 
+//
 /*
 
  Description: detector active volume
@@ -16,29 +16,29 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-bool FiducialVolume::isValid() const
-{
-   return minR_<1e4 && maxR_ >= minR_ && minZ_<1e4 && maxZ_ >= minZ_;
+bool FiducialVolume::isValid() const { return minR_ < 1e4 && maxR_ >= minR_ && minZ_ < 1e4 && maxZ_ >= minZ_; }
+
+void FiducialVolume::addActivePoint(const GlobalPoint& point) {
+  if (point.perp() > maxR_)
+    maxR_ = point.perp();
+  if (fabs(point.eta()) < 1 && point.perp() < minR_)
+    minR_ = point.perp();
+  if (fabs(point.z()) > maxZ_)
+    maxZ_ = fabs(point.z());
+  if (fabs(point.eta()) > 1.7 && fabs(point.z()) < minZ_)
+    minZ_ = fabs(point.z());
 }
 
-void FiducialVolume::addActivePoint( const GlobalPoint& point )
-{
-   if ( point.perp() > maxR_ )                              maxR_ = point.perp();
-   if ( fabs(point.eta()) < 1 && point.perp() < minR_)      minR_ = point.perp();
-   if ( fabs(point.z()) > maxZ_ )                           maxZ_ = fabs(point.z());
-   if ( fabs(point.eta()) > 1.7 && fabs(point.z()) < minZ_) minZ_ = fabs(point.z());
+void FiducialVolume::reset() {
+  minR_ = 1e5;
+  maxR_ = -1;
+  minZ_ = 1e5;
+  maxZ_ = -1;
 }
 
-void FiducialVolume::reset()
-{
-   minR_ = 1e5;
-   maxR_ = -1; 
-   minZ_ = 1e5;
-   maxZ_ = -1;
-}
-
-void FiducialVolume::determinInnerDimensions()
-{
-   if ( maxR_ > 0 && maxR_ < minR_ ) minR_ = maxR_;
-   if ( maxZ_ > 0 && maxZ_ < minZ_ ) minZ_ = maxZ_;
+void FiducialVolume::determinInnerDimensions() {
+  if (maxR_ > 0 && maxR_ < minR_)
+    minR_ = maxR_;
+  if (maxZ_ > 0 && maxZ_ < minZ_)
+    minZ_ = maxZ_;
 }

--- a/TrackingTools/TrackAssociator/src/TAMuonChamberMatch.cc
+++ b/TrackingTools/TrackAssociator/src/TAMuonChamberMatch.cc
@@ -7,65 +7,59 @@
 #include <sstream>
 
 int TAMuonChamberMatch::station() const {
-	int muonSubdetId = id.subdetId();
+  int muonSubdetId = id.subdetId();
 
-	if(muonSubdetId==1) {//DT
-		DTChamberId segId(id.rawId());
-		return segId.station();
-	}
-	if(muonSubdetId==2) {//CSC
-		CSCDetId segId(id.rawId());
-		return segId.station();
-	}
-	if(muonSubdetId==3) {//RPC
-		RPCDetId segId(id.rawId());
-		return segId.station();
-	}
-	if(muonSubdetId==4) {//GEM
-	  GEMDetId segId(id.rawId());
-	  return segId.station();
-	}
-	if(muonSubdetId==5) {//ME0
-	  ME0DetId segId(id.rawId());
-	  return segId.station();
-	}
+  if (muonSubdetId == 1) {  //DT
+    DTChamberId segId(id.rawId());
+    return segId.station();
+  }
+  if (muonSubdetId == 2) {  //CSC
+    CSCDetId segId(id.rawId());
+    return segId.station();
+  }
+  if (muonSubdetId == 3) {  //RPC
+    RPCDetId segId(id.rawId());
+    return segId.station();
+  }
+  if (muonSubdetId == 4) {  //GEM
+    GEMDetId segId(id.rawId());
+    return segId.station();
+  }
+  if (muonSubdetId == 5) {  //ME0
+    ME0DetId segId(id.rawId());
+    return segId.station();
+  }
 
-	return -1;
+  return -1;
 }
 
 std::string TAMuonChamberMatch::info() const {
-   int muonSubdetId = id.subdetId();
-   std::ostringstream oss;
+  int muonSubdetId = id.subdetId();
+  std::ostringstream oss;
 
-   if(muonSubdetId==1) {//DT
-      DTChamberId segId(id.rawId());
-      oss << "DT chamber (wheel, station, sector): "
-	<< segId.wheel() << ", "
-	<< segId.station() << ", "
-	<< segId.sector();
-   }
-	
-   if(muonSubdetId==2) {//CSC
-      CSCDetId segId(id.rawId());
-      oss << "CSC chamber (endcap, station, ring, chamber, layer): "
-	<< segId.endcap() << ", "
-	<< segId.station() << ", "
-	<< segId.ring() << ", "
-	<< segId.chamber() << ", "
-	<< segId.layer();
-   }
-   if(muonSubdetId==3) {//RPC
-      // RPCDetId segId(id.rawId());
-      oss << "RPC chamber";
-   }
-   if(muonSubdetId==4) {//GEM
-      // GEMDetId segId(id.rawId());
-      oss << "GEM chamber";
-   }
-   if(muonSubdetId==5) {//ME0
-      // ME0DetId segId(id.rawId());
-      oss << "ME0 chamber";
-   }
+  if (muonSubdetId == 1) {  //DT
+    DTChamberId segId(id.rawId());
+    oss << "DT chamber (wheel, station, sector): " << segId.wheel() << ", " << segId.station() << ", "
+        << segId.sector();
+  }
 
-   return oss.str();
+  if (muonSubdetId == 2) {  //CSC
+    CSCDetId segId(id.rawId());
+    oss << "CSC chamber (endcap, station, ring, chamber, layer): " << segId.endcap() << ", " << segId.station() << ", "
+        << segId.ring() << ", " << segId.chamber() << ", " << segId.layer();
+  }
+  if (muonSubdetId == 3) {  //RPC
+    // RPCDetId segId(id.rawId());
+    oss << "RPC chamber";
+  }
+  if (muonSubdetId == 4) {  //GEM
+    // GEMDetId segId(id.rawId());
+    oss << "GEM chamber";
+  }
+  if (muonSubdetId == 5) {  //ME0
+    // ME0DetId segId(id.rawId());
+    oss << "ME0 chamber";
+  }
+
+  return oss.str();
 }

--- a/TrackingTools/TrackAssociator/src/TrackAssociatorParameters.cc
+++ b/TrackingTools/TrackAssociator/src/TrackAssociatorParameters.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TrackAssociator
 // Class:      TrackAssociatorParameters
-// 
+//
 /*
 
  Description: track associator parameters
@@ -15,72 +15,73 @@
 
 #include "TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h"
 
+void TrackAssociatorParameters::loadParameters(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) {
+  dREcal = iConfig.getParameter<double>("dREcal");
+  dRHcal = iConfig.getParameter<double>("dRHcal");
+  dRMuon = iConfig.getParameter<double>("dRMuon");
 
-void TrackAssociatorParameters::loadParameters( const edm::ParameterSet& iConfig, edm::ConsumesCollector &iC )
-{
-   dREcal = iConfig.getParameter<double>("dREcal");
-   dRHcal = iConfig.getParameter<double>("dRHcal");
-   dRMuon = iConfig.getParameter<double>("dRMuon");
-   
-   dREcalPreselection = iConfig.getParameter<double>("dREcalPreselection");
-   dRHcalPreselection = iConfig.getParameter<double>("dRHcalPreselection");
-   dRMuonPreselection = iConfig.getParameter<double>("dRMuonPreselection");
-   dRPreshowerPreselection = iConfig.getParameter<double>("dRPreshowerPreselection");
-   
-   muonMaxDistanceX = iConfig.getParameter<double>("muonMaxDistanceX");
-   muonMaxDistanceY = iConfig.getParameter<double>("muonMaxDistanceY");
-   muonMaxDistanceSigmaX = iConfig.getParameter<double>("muonMaxDistanceSigmaX");
-   muonMaxDistanceSigmaY = iConfig.getParameter<double>("muonMaxDistanceSigmaY");
-   
-   useEcal = iConfig.getParameter<bool>("useEcal");
-   useHcal = iConfig.getParameter<bool>("useHcal");
-   useHO   = iConfig.getParameter<bool>("useHO");
-   useCalo = iConfig.getParameter<bool>("useCalo");
-   useMuon = iConfig.getParameter<bool>("useMuon");
-   usePreshower = iConfig.getParameter<bool>("usePreshower");
-   useGEM  = iConfig.getParameter<bool>("useGEM");
-   useME0  = iConfig.getParameter<bool>("useME0");
-   
-   theEBRecHitCollectionLabel       = iConfig.getParameter<edm::InputTag>("EBRecHitCollectionLabel");
-   theEERecHitCollectionLabel       = iConfig.getParameter<edm::InputTag>("EERecHitCollectionLabel");
-   theCaloTowerCollectionLabel      = iConfig.getParameter<edm::InputTag>("CaloTowerCollectionLabel");
-   theHBHERecHitCollectionLabel     = iConfig.getParameter<edm::InputTag>("HBHERecHitCollectionLabel");
-   theHORecHitCollectionLabel       = iConfig.getParameter<edm::InputTag>("HORecHitCollectionLabel");
-   theDTRecSegment4DCollectionLabel = iConfig.getParameter<edm::InputTag>("DTRecSegment4DCollectionLabel");
-   theCSCSegmentCollectionLabel     = iConfig.getParameter<edm::InputTag>("CSCSegmentCollectionLabel");
-   theGEMSegmentCollectionLabel     = iConfig.getParameter<edm::InputTag>("GEMSegmentCollectionLabel");
-   theME0SegmentCollectionLabel     = iConfig.getParameter<edm::InputTag>("ME0SegmentCollectionLabel");
+  dREcalPreselection = iConfig.getParameter<double>("dREcalPreselection");
+  dRHcalPreselection = iConfig.getParameter<double>("dRHcalPreselection");
+  dRMuonPreselection = iConfig.getParameter<double>("dRMuonPreselection");
+  dRPreshowerPreselection = iConfig.getParameter<double>("dRPreshowerPreselection");
 
-   accountForTrajectoryChangeCalo   = iConfig.getParameter<bool>("accountForTrajectoryChangeCalo");
-   // accountForTrajectoryChangeMuon   = iConfig.getParameter<bool>("accountForTrajectoryChangeMuon");
-   
-   truthMatch = iConfig.getParameter<bool>("truthMatch");
-   muonMaxDistanceSigmaY = iConfig.getParameter<double>("trajectoryUncertaintyTolerance");
+  muonMaxDistanceX = iConfig.getParameter<double>("muonMaxDistanceX");
+  muonMaxDistanceY = iConfig.getParameter<double>("muonMaxDistanceY");
+  muonMaxDistanceSigmaX = iConfig.getParameter<double>("muonMaxDistanceSigmaX");
+  muonMaxDistanceSigmaY = iConfig.getParameter<double>("muonMaxDistanceSigmaY");
 
-   if (useEcal) {
-     EBRecHitsToken=iC.consumes<EBRecHitCollection>(theEBRecHitCollectionLabel);
-     EERecHitsToken=iC.consumes<EERecHitCollection>(theEERecHitCollectionLabel);
-   }
-   if (useCalo) caloTowersToken=iC.consumes<CaloTowerCollection>(theCaloTowerCollectionLabel);
-   if (useHcal) HBHEcollToken=iC.consumes<HBHERecHitCollection>(theHBHERecHitCollectionLabel);
-   if (useHO) HOcollToken=iC.consumes<HORecHitCollection>(theHORecHitCollectionLabel);
-   if (useMuon) {
-     dtSegmentsToken=iC.consumes<DTRecSegment4DCollection>(theDTRecSegment4DCollectionLabel);
-     cscSegmentsToken=iC.consumes<CSCSegmentCollection>(theCSCSegmentCollectionLabel);
-     if (useGEM) gemSegmentsToken=iC.consumes<GEMSegmentCollection>(theGEMSegmentCollectionLabel);
-     if (useME0) me0SegmentsToken=iC.consumes<ME0SegmentCollection>(theME0SegmentCollectionLabel);
-   }
-   if (truthMatch) {
-     simTracksToken=iC.consumes<edm::SimTrackContainer>(edm::InputTag("g4SimHits"));
-     simVerticesToken=iC.consumes<edm::SimVertexContainer>(edm::InputTag("g4SimHits"));
-     simEcalHitsEBToken=iC.consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits","EcalHitsEB"));
-     simEcalHitsEEToken=iC.consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits","EcalHitsEE"));
-     simHcalHitsToken=iC.consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits","HcalHits"));
-   }
+  useEcal = iConfig.getParameter<bool>("useEcal");
+  useHcal = iConfig.getParameter<bool>("useHcal");
+  useHO = iConfig.getParameter<bool>("useHO");
+  useCalo = iConfig.getParameter<bool>("useCalo");
+  useMuon = iConfig.getParameter<bool>("useMuon");
+  usePreshower = iConfig.getParameter<bool>("usePreshower");
+  useGEM = iConfig.getParameter<bool>("useGEM");
+  useME0 = iConfig.getParameter<bool>("useME0");
+
+  theEBRecHitCollectionLabel = iConfig.getParameter<edm::InputTag>("EBRecHitCollectionLabel");
+  theEERecHitCollectionLabel = iConfig.getParameter<edm::InputTag>("EERecHitCollectionLabel");
+  theCaloTowerCollectionLabel = iConfig.getParameter<edm::InputTag>("CaloTowerCollectionLabel");
+  theHBHERecHitCollectionLabel = iConfig.getParameter<edm::InputTag>("HBHERecHitCollectionLabel");
+  theHORecHitCollectionLabel = iConfig.getParameter<edm::InputTag>("HORecHitCollectionLabel");
+  theDTRecSegment4DCollectionLabel = iConfig.getParameter<edm::InputTag>("DTRecSegment4DCollectionLabel");
+  theCSCSegmentCollectionLabel = iConfig.getParameter<edm::InputTag>("CSCSegmentCollectionLabel");
+  theGEMSegmentCollectionLabel = iConfig.getParameter<edm::InputTag>("GEMSegmentCollectionLabel");
+  theME0SegmentCollectionLabel = iConfig.getParameter<edm::InputTag>("ME0SegmentCollectionLabel");
+
+  accountForTrajectoryChangeCalo = iConfig.getParameter<bool>("accountForTrajectoryChangeCalo");
+  // accountForTrajectoryChangeMuon   = iConfig.getParameter<bool>("accountForTrajectoryChangeMuon");
+
+  truthMatch = iConfig.getParameter<bool>("truthMatch");
+  muonMaxDistanceSigmaY = iConfig.getParameter<double>("trajectoryUncertaintyTolerance");
+
+  if (useEcal) {
+    EBRecHitsToken = iC.consumes<EBRecHitCollection>(theEBRecHitCollectionLabel);
+    EERecHitsToken = iC.consumes<EERecHitCollection>(theEERecHitCollectionLabel);
+  }
+  if (useCalo)
+    caloTowersToken = iC.consumes<CaloTowerCollection>(theCaloTowerCollectionLabel);
+  if (useHcal)
+    HBHEcollToken = iC.consumes<HBHERecHitCollection>(theHBHERecHitCollectionLabel);
+  if (useHO)
+    HOcollToken = iC.consumes<HORecHitCollection>(theHORecHitCollectionLabel);
+  if (useMuon) {
+    dtSegmentsToken = iC.consumes<DTRecSegment4DCollection>(theDTRecSegment4DCollectionLabel);
+    cscSegmentsToken = iC.consumes<CSCSegmentCollection>(theCSCSegmentCollectionLabel);
+    if (useGEM)
+      gemSegmentsToken = iC.consumes<GEMSegmentCollection>(theGEMSegmentCollectionLabel);
+    if (useME0)
+      me0SegmentsToken = iC.consumes<ME0SegmentCollection>(theME0SegmentCollectionLabel);
+  }
+  if (truthMatch) {
+    simTracksToken = iC.consumes<edm::SimTrackContainer>(edm::InputTag("g4SimHits"));
+    simVerticesToken = iC.consumes<edm::SimVertexContainer>(edm::InputTag("g4SimHits"));
+    simEcalHitsEBToken = iC.consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsEB"));
+    simEcalHitsEEToken = iC.consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsEE"));
+    simHcalHitsToken = iC.consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "HcalHits"));
+  }
 }
 
-TrackAssociatorParameters::TrackAssociatorParameters( const edm::ParameterSet& iConfig, edm::ConsumesCollector &&iC )
-{
-  loadParameters( iConfig, iC );
+TrackAssociatorParameters::TrackAssociatorParameters(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) {
+  loadParameters(iConfig, iC);
 }
-

--- a/TrackingTools/TrackAssociator/src/TrackDetMatchInfo.cc
+++ b/TrackingTools/TrackAssociator/src/TrackDetMatchInfo.cc
@@ -11,628 +11,577 @@
 #include "Math/VectorUtil.h"
 #include <algorithm>
 
-
 ///////////////////////////
 
-std::string TrackDetMatchInfo::dumpGeometry( const DetId& id )
-{
-   if ( ! caloGeometry || 
-	! caloGeometry->getSubdetectorGeometry(id) ||
-	! caloGeometry->getSubdetectorGeometry(id)->getGeometry(id)) {
-      throw cms::Exception("FatalError")  << "Failed to access geometry for DetId: " << id.rawId();
-   }
-   std::ostringstream oss;
+std::string TrackDetMatchInfo::dumpGeometry(const DetId& id) {
+  if (!caloGeometry || !caloGeometry->getSubdetectorGeometry(id) ||
+      !caloGeometry->getSubdetectorGeometry(id)->getGeometry(id)) {
+    throw cms::Exception("FatalError") << "Failed to access geometry for DetId: " << id.rawId();
+  }
+  std::ostringstream oss;
 
-   const CaloCellGeometry::CornersVec& points = caloGeometry->getSubdetectorGeometry(id)->getGeometry(id)->getCorners();
-   for( CaloCellGeometry::CornersVec::const_iterator point = points.begin();
-       point != points.end(); ++point)
-     oss << "(" << point->z() << ", " << point->perp() << ", " << point->eta() << ", " << point->phi() << "), \t";
-   return oss.str();
+  const CaloCellGeometry::CornersVec& points = caloGeometry->getSubdetectorGeometry(id)->getGeometry(id)->getCorners();
+  for (CaloCellGeometry::CornersVec::const_iterator point = points.begin(); point != points.end(); ++point)
+    oss << "(" << point->z() << ", " << point->perp() << ", " << point->eta() << ", " << point->phi() << "), \t";
+  return oss.str();
 }
 
-
-GlobalPoint TrackDetMatchInfo::getPosition( const DetId& id)
-{
-   // this part might be slow
-   if ( ! caloGeometry || 
-	! caloGeometry->getSubdetectorGeometry(id) ||
-	! caloGeometry->getSubdetectorGeometry(id)->getGeometry(id) ) {
-      throw cms::Exception("FatalError") << "Failed to access geometry for DetId: " << id.rawId();
-      return GlobalPoint(0,0,0);
-   }
-   return caloGeometry->getSubdetectorGeometry(id)->getGeometry(id)->getPosition();
+GlobalPoint TrackDetMatchInfo::getPosition(const DetId& id) {
+  // this part might be slow
+  if (!caloGeometry || !caloGeometry->getSubdetectorGeometry(id) ||
+      !caloGeometry->getSubdetectorGeometry(id)->getGeometry(id)) {
+    throw cms::Exception("FatalError") << "Failed to access geometry for DetId: " << id.rawId();
+    return GlobalPoint(0, 0, 0);
+  }
+  return caloGeometry->getSubdetectorGeometry(id)->getGeometry(id)->getPosition();
 }
 
-
-double TrackDetMatchInfo::crossedEnergy( EnergyType type )
-{
-   double energy(0);
-   switch (type) {
-    case EcalRecHits:
-	{
-	   for(std::vector<const EcalRecHit*>::const_iterator hit=crossedEcalRecHits.begin(); hit!=crossedEcalRecHits.end(); hit++)
-	     energy += (*hit)->energy();
-	}
-      break;
-    case HcalRecHits:
-	{
-	   for(std::vector<const HBHERecHit*>::const_iterator hit = crossedHcalRecHits.begin(); hit != crossedHcalRecHits.end(); hit++)
-	     energy += (*hit)->energy();
-	}
-      break;
-    case HORecHits:
-	{
-	   for(std::vector<const HORecHit*>::const_iterator hit = crossedHORecHits.begin(); hit != crossedHORecHits.end(); hit++)
-	     energy += (*hit)->energy();
-	}
-      break;
-    case TowerTotal:
-	{
-	   for(std::vector<const CaloTower*>::const_iterator hit=crossedTowers.begin(); hit!=crossedTowers.end(); hit++)
-	     energy += (*hit)->energy();
-	}
-      break;
-    case TowerEcal:
-	{
-	   for(std::vector<const CaloTower*>::const_iterator hit=crossedTowers.begin(); hit!=crossedTowers.end(); hit++)
-	     energy += (*hit)->emEnergy();
-	}
-      break;
-    case TowerHcal:
-	{
-	   for(std::vector<const CaloTower*>::const_iterator hit=crossedTowers.begin(); hit!=crossedTowers.end(); hit++)
-	     energy += (*hit)->hadEnergy();
-	}
-      break;
-    case TowerHO:
-	{
-	   for(std::vector<const CaloTower*>::const_iterator hit=crossedTowers.begin(); hit!=crossedTowers.end(); hit++)
-	     energy += (*hit)->outerEnergy();
-	}
-      break;
+double TrackDetMatchInfo::crossedEnergy(EnergyType type) {
+  double energy(0);
+  switch (type) {
+    case EcalRecHits: {
+      for (std::vector<const EcalRecHit*>::const_iterator hit = crossedEcalRecHits.begin();
+           hit != crossedEcalRecHits.end();
+           hit++)
+        energy += (*hit)->energy();
+    } break;
+    case HcalRecHits: {
+      for (std::vector<const HBHERecHit*>::const_iterator hit = crossedHcalRecHits.begin();
+           hit != crossedHcalRecHits.end();
+           hit++)
+        energy += (*hit)->energy();
+    } break;
+    case HORecHits: {
+      for (std::vector<const HORecHit*>::const_iterator hit = crossedHORecHits.begin(); hit != crossedHORecHits.end();
+           hit++)
+        energy += (*hit)->energy();
+    } break;
+    case TowerTotal: {
+      for (std::vector<const CaloTower*>::const_iterator hit = crossedTowers.begin(); hit != crossedTowers.end(); hit++)
+        energy += (*hit)->energy();
+    } break;
+    case TowerEcal: {
+      for (std::vector<const CaloTower*>::const_iterator hit = crossedTowers.begin(); hit != crossedTowers.end(); hit++)
+        energy += (*hit)->emEnergy();
+    } break;
+    case TowerHcal: {
+      for (std::vector<const CaloTower*>::const_iterator hit = crossedTowers.begin(); hit != crossedTowers.end(); hit++)
+        energy += (*hit)->hadEnergy();
+    } break;
+    case TowerHO: {
+      for (std::vector<const CaloTower*>::const_iterator hit = crossedTowers.begin(); hit != crossedTowers.end(); hit++)
+        energy += (*hit)->outerEnergy();
+    } break;
     default:
       throw cms::Exception("FatalError") << "Unknown calo energy type: " << type;
-   }
-   return energy;
+  }
+  return energy;
 }
 
 bool TrackDetMatchInfo::insideCone(const DetId& id, const double dR) {
-   GlobalPoint idPosition = getPosition(id);
-   if (idPosition.mag()<0.01) return false;
-   
-   math::XYZVector idPositionRoot( idPosition.x(), idPosition.y(), idPosition.z() );
-   math::XYZVector trackP3( stateAtIP.momentum().x(), stateAtIP.momentum().y(), stateAtIP.momentum().z() );
-   return ROOT::Math::VectorUtil::DeltaR(trackP3, idPositionRoot) < dR;
+  GlobalPoint idPosition = getPosition(id);
+  if (idPosition.mag() < 0.01)
+    return false;
+
+  math::XYZVector idPositionRoot(idPosition.x(), idPosition.y(), idPosition.z());
+  math::XYZVector trackP3(stateAtIP.momentum().x(), stateAtIP.momentum().y(), stateAtIP.momentum().z());
+  return ROOT::Math::VectorUtil::DeltaR(trackP3, idPositionRoot) < dR;
 }
 
-double TrackDetMatchInfo::coneEnergy( double dR, EnergyType type )
-{
-   double energy(0);
-   switch (type) {
-    case EcalRecHits:
-	{
-	   for(std::vector<const EcalRecHit*>::const_iterator hit=ecalRecHits.begin(); hit!=ecalRecHits.end(); hit++)
-	     if (insideCone((*hit)->detid(),dR)) energy += (*hit)->energy();
-	}
-      break;
-    case HcalRecHits:
-	{
-	   for(std::vector<const HBHERecHit*>::const_iterator hit = hcalRecHits.begin(); hit != hcalRecHits.end(); hit++)
-	     if (insideCone((*hit)->detid(),dR)) energy += (*hit)->energy();
-	}
-      break;
-    case HORecHits:
-	{
-	   for(std::vector<const HORecHit*>::const_iterator hit = hoRecHits.begin(); hit != hoRecHits.end(); hit++)
-	     if (insideCone((*hit)->detid(),dR)) energy += (*hit)->energy();
-	}
-      break;
-    case TowerTotal:
-	{
-	   for(std::vector<const CaloTower*>::const_iterator hit=crossedTowers.begin(); hit!=crossedTowers.end(); hit++)
-	     if (insideCone((*hit)->id(),dR)) energy += (*hit)->energy();
-	}
-      break;
-    case TowerEcal:
-	{
-	   for(std::vector<const CaloTower*>::const_iterator hit=crossedTowers.begin(); hit!=crossedTowers.end(); hit++)
-	     if (insideCone((*hit)->id(),dR)) energy += (*hit)->emEnergy();
-	}
-      break;
-    case TowerHcal:
-	{
-	   for(std::vector<const CaloTower*>::const_iterator hit=crossedTowers.begin(); hit!=crossedTowers.end(); hit++)
-	     if (insideCone((*hit)->id(),dR)) energy += (*hit)->hadEnergy();
-	}
-      break;
-    case TowerHO:
-	{
-	   for(std::vector<const CaloTower*>::const_iterator hit=crossedTowers.begin(); hit!=crossedTowers.end(); hit++)
-	     if (insideCone((*hit)->id(),dR)) energy += (*hit)->outerEnergy();
-	}
-      break;
+double TrackDetMatchInfo::coneEnergy(double dR, EnergyType type) {
+  double energy(0);
+  switch (type) {
+    case EcalRecHits: {
+      for (std::vector<const EcalRecHit*>::const_iterator hit = ecalRecHits.begin(); hit != ecalRecHits.end(); hit++)
+        if (insideCone((*hit)->detid(), dR))
+          energy += (*hit)->energy();
+    } break;
+    case HcalRecHits: {
+      for (std::vector<const HBHERecHit*>::const_iterator hit = hcalRecHits.begin(); hit != hcalRecHits.end(); hit++)
+        if (insideCone((*hit)->detid(), dR))
+          energy += (*hit)->energy();
+    } break;
+    case HORecHits: {
+      for (std::vector<const HORecHit*>::const_iterator hit = hoRecHits.begin(); hit != hoRecHits.end(); hit++)
+        if (insideCone((*hit)->detid(), dR))
+          energy += (*hit)->energy();
+    } break;
+    case TowerTotal: {
+      for (std::vector<const CaloTower*>::const_iterator hit = crossedTowers.begin(); hit != crossedTowers.end(); hit++)
+        if (insideCone((*hit)->id(), dR))
+          energy += (*hit)->energy();
+    } break;
+    case TowerEcal: {
+      for (std::vector<const CaloTower*>::const_iterator hit = crossedTowers.begin(); hit != crossedTowers.end(); hit++)
+        if (insideCone((*hit)->id(), dR))
+          energy += (*hit)->emEnergy();
+    } break;
+    case TowerHcal: {
+      for (std::vector<const CaloTower*>::const_iterator hit = crossedTowers.begin(); hit != crossedTowers.end(); hit++)
+        if (insideCone((*hit)->id(), dR))
+          energy += (*hit)->hadEnergy();
+    } break;
+    case TowerHO: {
+      for (std::vector<const CaloTower*>::const_iterator hit = crossedTowers.begin(); hit != crossedTowers.end(); hit++)
+        if (insideCone((*hit)->id(), dR))
+          energy += (*hit)->outerEnergy();
+    } break;
     default:
       throw cms::Exception("FatalError") << "Unknown calo energy type: " << type;
-   }
-   return energy;
+  }
+  return energy;
 }
-
 
 //////////////////////////////////////////////////
 
-double TrackDetMatchInfo::nXnEnergy(const DetId& id, EnergyType type, int gridSize)
-{
-   double energy(0);
-   if ( id.rawId() == 0 ) return 0.;
-   switch (type)  {
+double TrackDetMatchInfo::nXnEnergy(const DetId& id, EnergyType type, int gridSize) {
+  double energy(0);
+  if (id.rawId() == 0)
+    return 0.;
+  switch (type) {
     case TowerTotal:
     case TowerHcal:
     case TowerEcal:
-    case TowerHO:
-	{
-	   if ( id.det() != DetId::Calo ) {
-	      throw cms::Exception("FatalError") << "Wrong DetId. Expected CaloTower, but found:\n" <<
-		DetIdInfo::info(id,nullptr)<<"\n";
-	   }
-	   CaloTowerDetId centerId(id);
-	   for(std::vector<const CaloTower*>::const_iterator hit=towers.begin(); hit!=towers.end(); hit++) {
-	      CaloTowerDetId neighborId((*hit)->id());
-	      int dEta = abs( (centerId.ieta()<0?centerId.ieta()+1:centerId.ieta() )
-			      -(neighborId.ieta()<0?neighborId.ieta()+1:neighborId.ieta() ) ) ;
-	      int dPhi = abs( centerId.iphi()-neighborId.iphi() );
-	      if ( abs(72-dPhi) < dPhi ) dPhi = 72-dPhi;
-	      if(  dEta <= gridSize && dPhi <= gridSize ) {
-		 switch (type) {
-		  case TowerTotal:
-		    energy += (*hit)->energy();
-		    break;
-		  case TowerEcal:
-		    energy += (*hit)->emEnergy();
-		    break;
-		  case TowerHcal:
-		    energy += (*hit)->hadEnergy();
-		    break;
-		  case TowerHO:
-		    energy += (*hit)->outerEnergy();
-		    break;
-		  default:
-		    throw cms::Exception("FatalError") << "Unknown calo tower energy type: " << type;
-		 }
-	      }
-	   }
-	}
-      break;
-    case EcalRecHits:
-	{
-	   if( id.det() != DetId::Ecal || (id.subdetId() != EcalBarrel && id.subdetId() != EcalEndcap) ) {
-	      throw cms::Exception("FatalError") << "Wrong DetId. Expected EcalBarrel or EcalEndcap, but found:\n" <<
-		DetIdInfo::info(id,nullptr)<<"\n";
-	   }
-	   // Since the ECAL granularity is small and the gap between EE and EB is significant,
-	   // energy is computed only within the system that contains the central element
-	   if( id.subdetId() == EcalBarrel ) {
-	      EBDetId centerId(id);
-	      for(std::vector<const EcalRecHit*>::const_iterator hit=ecalRecHits.begin(); hit!=ecalRecHits.end(); hit++) {
-		 if ((*hit)->id().subdetId() != EcalBarrel) continue;
-		 EBDetId neighborId((*hit)->id());
-		 int dEta = abs( (centerId.ieta()<0?centerId.ieta()+1:centerId.ieta() )
-				 -(neighborId.ieta()<0?neighborId.ieta()+1:neighborId.ieta() ) ) ;
-		 int dPhi = abs( centerId.iphi()-neighborId.iphi() );
-		 if ( abs(360-dPhi) < dPhi ) dPhi = 360-dPhi;
-		 if(  dEta <= gridSize && dPhi <= gridSize ) {
-		    energy += (*hit)->energy();
-		 }
-	      }
-	   } else {
-	      // Endcap
-	      EEDetId centerId(id);
-	      for(std::vector<const EcalRecHit*>::const_iterator hit=ecalRecHits.begin(); hit!=ecalRecHits.end(); hit++) {
-		 if ((*hit)->id().subdetId() != EcalEndcap) continue;
-		 EEDetId neighborId((*hit)->id());
-		 if(  centerId.zside() == neighborId.zside() && 
-		      abs(centerId.ix()-neighborId.ix()) <= gridSize && 
-		      abs(centerId.iy()-neighborId.iy()) <= gridSize ) {
-		    energy += (*hit)->energy();
-		 }
-	      }
-	   }
-	}
-      break;
-    case HcalRecHits:
-	{
-	   if( id.det() != DetId::Hcal || (id.subdetId() != HcalBarrel && id.subdetId() != HcalEndcap) ) {
-	      throw cms::Exception("FatalError") << "Wrong DetId. Expected HE or HB, but found:\n" <<
-		DetIdInfo::info(id,nullptr)<<"\n";
-	   }
-	   HcalDetId centerId(id);
-	   for(std::vector<const HBHERecHit*>::const_iterator hit=hcalRecHits.begin(); hit!=hcalRecHits.end(); hit++) {
-	      HcalDetId neighborId((*hit)->id());
-	      int dEta = abs( (centerId.ieta()<0?centerId.ieta()+1:centerId.ieta() )
-			      -(neighborId.ieta()<0?neighborId.ieta()+1:neighborId.ieta() ) ) ;
-	      int dPhi = abs( centerId.iphi()-neighborId.iphi() );
-	      if ( abs(72-dPhi) < dPhi ) dPhi = 72-dPhi;
-	      if(  dEta <= gridSize && dPhi <= gridSize ){
-		 energy += (*hit)->energy();
-	      }
-	   }
-	}
-      break;
-    case HORecHits:
-	{
-	   if( id.det() != DetId::Hcal || (id.subdetId() != HcalOuter) ) {
-	      throw cms::Exception("FatalError") << "Wrong DetId. Expected HO, but found:\n" <<
-		DetIdInfo::info(id,nullptr)<<"\n";
-	   }
-	   HcalDetId centerId(id);
-	   for(std::vector<const HORecHit*>::const_iterator hit=hoRecHits.begin(); hit!=hoRecHits.end(); hit++) {
-	      HcalDetId neighborId((*hit)->id());
-	      int dEta = abs( (centerId.ieta()<0?centerId.ieta()+1:centerId.ieta() )
-			      -(neighborId.ieta()<0?neighborId.ieta()+1:neighborId.ieta() ) ) ;
-	      int dPhi = abs( centerId.iphi()-neighborId.iphi() );
-	      if ( abs(72-dPhi) < dPhi ) dPhi = 72-dPhi;
-	      if(  dEta <= gridSize && dPhi <= gridSize ) {
-		 energy += (*hit)->energy();
-	      }
-	   }
-	}
-      break;
+    case TowerHO: {
+      if (id.det() != DetId::Calo) {
+        throw cms::Exception("FatalError") << "Wrong DetId. Expected CaloTower, but found:\n"
+                                           << DetIdInfo::info(id, nullptr) << "\n";
+      }
+      CaloTowerDetId centerId(id);
+      for (std::vector<const CaloTower*>::const_iterator hit = towers.begin(); hit != towers.end(); hit++) {
+        CaloTowerDetId neighborId((*hit)->id());
+        int dEta = abs((centerId.ieta() < 0 ? centerId.ieta() + 1 : centerId.ieta()) -
+                       (neighborId.ieta() < 0 ? neighborId.ieta() + 1 : neighborId.ieta()));
+        int dPhi = abs(centerId.iphi() - neighborId.iphi());
+        if (abs(72 - dPhi) < dPhi)
+          dPhi = 72 - dPhi;
+        if (dEta <= gridSize && dPhi <= gridSize) {
+          switch (type) {
+            case TowerTotal:
+              energy += (*hit)->energy();
+              break;
+            case TowerEcal:
+              energy += (*hit)->emEnergy();
+              break;
+            case TowerHcal:
+              energy += (*hit)->hadEnergy();
+              break;
+            case TowerHO:
+              energy += (*hit)->outerEnergy();
+              break;
+            default:
+              throw cms::Exception("FatalError") << "Unknown calo tower energy type: " << type;
+          }
+        }
+      }
+    } break;
+    case EcalRecHits: {
+      if (id.det() != DetId::Ecal || (id.subdetId() != EcalBarrel && id.subdetId() != EcalEndcap)) {
+        throw cms::Exception("FatalError") << "Wrong DetId. Expected EcalBarrel or EcalEndcap, but found:\n"
+                                           << DetIdInfo::info(id, nullptr) << "\n";
+      }
+      // Since the ECAL granularity is small and the gap between EE and EB is significant,
+      // energy is computed only within the system that contains the central element
+      if (id.subdetId() == EcalBarrel) {
+        EBDetId centerId(id);
+        for (std::vector<const EcalRecHit*>::const_iterator hit = ecalRecHits.begin(); hit != ecalRecHits.end();
+             hit++) {
+          if ((*hit)->id().subdetId() != EcalBarrel)
+            continue;
+          EBDetId neighborId((*hit)->id());
+          int dEta = abs((centerId.ieta() < 0 ? centerId.ieta() + 1 : centerId.ieta()) -
+                         (neighborId.ieta() < 0 ? neighborId.ieta() + 1 : neighborId.ieta()));
+          int dPhi = abs(centerId.iphi() - neighborId.iphi());
+          if (abs(360 - dPhi) < dPhi)
+            dPhi = 360 - dPhi;
+          if (dEta <= gridSize && dPhi <= gridSize) {
+            energy += (*hit)->energy();
+          }
+        }
+      } else {
+        // Endcap
+        EEDetId centerId(id);
+        for (std::vector<const EcalRecHit*>::const_iterator hit = ecalRecHits.begin(); hit != ecalRecHits.end();
+             hit++) {
+          if ((*hit)->id().subdetId() != EcalEndcap)
+            continue;
+          EEDetId neighborId((*hit)->id());
+          if (centerId.zside() == neighborId.zside() && abs(centerId.ix() - neighborId.ix()) <= gridSize &&
+              abs(centerId.iy() - neighborId.iy()) <= gridSize) {
+            energy += (*hit)->energy();
+          }
+        }
+      }
+    } break;
+    case HcalRecHits: {
+      if (id.det() != DetId::Hcal || (id.subdetId() != HcalBarrel && id.subdetId() != HcalEndcap)) {
+        throw cms::Exception("FatalError") << "Wrong DetId. Expected HE or HB, but found:\n"
+                                           << DetIdInfo::info(id, nullptr) << "\n";
+      }
+      HcalDetId centerId(id);
+      for (std::vector<const HBHERecHit*>::const_iterator hit = hcalRecHits.begin(); hit != hcalRecHits.end(); hit++) {
+        HcalDetId neighborId((*hit)->id());
+        int dEta = abs((centerId.ieta() < 0 ? centerId.ieta() + 1 : centerId.ieta()) -
+                       (neighborId.ieta() < 0 ? neighborId.ieta() + 1 : neighborId.ieta()));
+        int dPhi = abs(centerId.iphi() - neighborId.iphi());
+        if (abs(72 - dPhi) < dPhi)
+          dPhi = 72 - dPhi;
+        if (dEta <= gridSize && dPhi <= gridSize) {
+          energy += (*hit)->energy();
+        }
+      }
+    } break;
+    case HORecHits: {
+      if (id.det() != DetId::Hcal || (id.subdetId() != HcalOuter)) {
+        throw cms::Exception("FatalError") << "Wrong DetId. Expected HO, but found:\n"
+                                           << DetIdInfo::info(id, nullptr) << "\n";
+      }
+      HcalDetId centerId(id);
+      for (std::vector<const HORecHit*>::const_iterator hit = hoRecHits.begin(); hit != hoRecHits.end(); hit++) {
+        HcalDetId neighborId((*hit)->id());
+        int dEta = abs((centerId.ieta() < 0 ? centerId.ieta() + 1 : centerId.ieta()) -
+                       (neighborId.ieta() < 0 ? neighborId.ieta() + 1 : neighborId.ieta()));
+        int dPhi = abs(centerId.iphi() - neighborId.iphi());
+        if (abs(72 - dPhi) < dPhi)
+          dPhi = 72 - dPhi;
+        if (dEta <= gridSize && dPhi <= gridSize) {
+          energy += (*hit)->energy();
+        }
+      }
+    } break;
     default:
       throw cms::Exception("FatalError") << "Unkown or not implemented energy type requested, type:" << type;
-   }
-   return energy;
+  }
+  return energy;
 }
 
-double TrackDetMatchInfo::nXnEnergy(EnergyType type, int gridSize)
-{
-   switch (type)  {
+double TrackDetMatchInfo::nXnEnergy(EnergyType type, int gridSize) {
+  switch (type) {
     case TowerTotal:
     case TowerHcal:
     case TowerEcal:
     case TowerHO:
-      if( crossedTowerIds.empty() ) return 0;
+      if (crossedTowerIds.empty())
+        return 0;
       return nXnEnergy(crossedTowerIds.front(), type, gridSize);
       break;
     case EcalRecHits:
-      if( crossedEcalIds.empty() ) return 0;
+      if (crossedEcalIds.empty())
+        return 0;
       return nXnEnergy(crossedEcalIds.front(), type, gridSize);
       break;
     case HcalRecHits:
-      if( crossedHcalIds.empty() ) return 0;
+      if (crossedHcalIds.empty())
+        return 0;
       return nXnEnergy(crossedHcalIds.front(), type, gridSize);
       break;
     case HORecHits:
-      if( crossedHOIds.empty() ) return 0;
+      if (crossedHOIds.empty())
+        return 0;
       return nXnEnergy(crossedHOIds.front(), type, gridSize);
       break;
     default:
       throw cms::Exception("FatalError") << "Unkown or not implemented energy type requested, type:" << type;
-   }
-   return -999;
+  }
+  return -999;
 }
 
+TrackDetMatchInfo::TrackDetMatchInfo()
+    : trkGlobPosAtEcal(0, 0, 0),
+      trkGlobPosAtHcal(0, 0, 0),
+      trkGlobPosAtHO(0, 0, 0),
+      trkMomAtEcal(0, 0, 0),
+      trkMomAtHcal(0, 0, 0),
+      trkMomAtHO(0, 0, 0),
+      isGoodEcal(false),
+      isGoodHcal(false),
+      isGoodCalo(false),
+      isGoodHO(false),
+      isGoodMuon(false),
+      simTrack(nullptr),
+      ecalTrueEnergy(-999),
+      hcalTrueEnergy(-999) {}
 
-TrackDetMatchInfo::TrackDetMatchInfo():
-       trkGlobPosAtEcal(0,0,0)
-     , trkGlobPosAtHcal(0,0,0)
-     , trkGlobPosAtHO(0,0,0)
-     , trkMomAtEcal(0,0,0)
-     , trkMomAtHcal(0,0,0)
-     , trkMomAtHO(0,0,0)
-     , isGoodEcal(false)
-     , isGoodHcal(false)
-     , isGoodCalo(false)
-     , isGoodHO(false)
-     , isGoodMuon(false)
-     , simTrack(nullptr)
-     , ecalTrueEnergy(-999)
-     , hcalTrueEnergy(-999)
-{
-}
-
-DetId TrackDetMatchInfo::findMaxDeposition( EnergyType type )
-{
-   DetId id;
-   float maxEnergy = -9999;
-   switch (type) {
-    case EcalRecHits:
-	{
-	   for(std::vector<const EcalRecHit*>::const_iterator hit=ecalRecHits.begin(); hit!=ecalRecHits.end(); hit++)
-	     if ( (*hit)->energy() > maxEnergy ) {
-		maxEnergy = (*hit)->energy();
-		id = (*hit)->detid();
-	     }
-	}
-      break;
-    case HcalRecHits:
-	{
-	   for(std::vector<const HBHERecHit*>::const_iterator hit=hcalRecHits.begin(); hit!=hcalRecHits.end(); hit++)
-	     if ( (*hit)->energy() > maxEnergy ) {
-		maxEnergy = (*hit)->energy();
-		id = (*hit)->detid();
-	     }
-	}
-      break;
-    case HORecHits:
-	{
-	   for(std::vector<const HORecHit*>::const_iterator hit=hoRecHits.begin(); hit!=hoRecHits.end(); hit++)
-	     if ( (*hit)->energy() > maxEnergy ) {
-		maxEnergy = (*hit)->energy();
-		id = (*hit)->detid();
-	     }
-	}
-      break;
+DetId TrackDetMatchInfo::findMaxDeposition(EnergyType type) {
+  DetId id;
+  float maxEnergy = -9999;
+  switch (type) {
+    case EcalRecHits: {
+      for (std::vector<const EcalRecHit*>::const_iterator hit = ecalRecHits.begin(); hit != ecalRecHits.end(); hit++)
+        if ((*hit)->energy() > maxEnergy) {
+          maxEnergy = (*hit)->energy();
+          id = (*hit)->detid();
+        }
+    } break;
+    case HcalRecHits: {
+      for (std::vector<const HBHERecHit*>::const_iterator hit = hcalRecHits.begin(); hit != hcalRecHits.end(); hit++)
+        if ((*hit)->energy() > maxEnergy) {
+          maxEnergy = (*hit)->energy();
+          id = (*hit)->detid();
+        }
+    } break;
+    case HORecHits: {
+      for (std::vector<const HORecHit*>::const_iterator hit = hoRecHits.begin(); hit != hoRecHits.end(); hit++)
+        if ((*hit)->energy() > maxEnergy) {
+          maxEnergy = (*hit)->energy();
+          id = (*hit)->detid();
+        }
+    } break;
     case TowerTotal:
     case TowerEcal:
-    case TowerHcal:
-	{
-	   for(std::vector<const CaloTower*>::const_iterator hit=towers.begin(); hit!=towers.end(); hit++)
-	     {
-		double energy = 0;
-		switch (type) {
-		 case TowerTotal:
-		   energy = (*hit)->energy();
-		   break;
-		 case TowerEcal:
-		   energy = (*hit)->emEnergy();
-		   break;
-		 case TowerHcal:
-		   energy = (*hit)->hadEnergy();
-		   break;
-		 case TowerHO:
-		   energy = (*hit)->energy();
-		   break;
-		 default:
-		   throw cms::Exception("FatalError") << "Unknown calo tower energy type: " << type;
-		}
-		if ( energy > maxEnergy ) {
-		   maxEnergy = energy;
-		   id = (*hit)->id();
-		}
-	     }
-	}
+    case TowerHcal: {
+      for (std::vector<const CaloTower*>::const_iterator hit = towers.begin(); hit != towers.end(); hit++) {
+        double energy = 0;
+        switch (type) {
+          case TowerTotal:
+            energy = (*hit)->energy();
+            break;
+          case TowerEcal:
+            energy = (*hit)->emEnergy();
+            break;
+          case TowerHcal:
+            energy = (*hit)->hadEnergy();
+            break;
+          case TowerHO:
+            energy = (*hit)->energy();
+            break;
+          default:
+            throw cms::Exception("FatalError") << "Unknown calo tower energy type: " << type;
+        }
+        if (energy > maxEnergy) {
+          maxEnergy = energy;
+          id = (*hit)->id();
+        }
+      }
+    }
     default:
-      throw cms::Exception("FatalError") << "Maximal energy deposition: unkown or not implemented energy type requested, type:" << type;
-   }
-   return id;
+      throw cms::Exception("FatalError")
+          << "Maximal energy deposition: unkown or not implemented energy type requested, type:" << type;
+  }
+  return id;
 }
 
-DetId TrackDetMatchInfo::findMaxDeposition(const DetId& id, EnergyType type, int gridSize)
-{
-   double energy_max(0);
-   DetId id_max;
-   if ( id.rawId() == 0 ) return id_max;
-   switch (type)  {
+DetId TrackDetMatchInfo::findMaxDeposition(const DetId& id, EnergyType type, int gridSize) {
+  double energy_max(0);
+  DetId id_max;
+  if (id.rawId() == 0)
+    return id_max;
+  switch (type) {
     case TowerTotal:
     case TowerHcal:
     case TowerEcal:
-    case TowerHO:
-	{
-	   if ( id.det() != DetId::Calo ) {
-	      throw cms::Exception("FatalError") << "Wrong DetId. Expected CaloTower, but found:\n" <<
-		DetIdInfo::info(id,nullptr)<<"\n";
-	   }
-	   CaloTowerDetId centerId(id);
-	   for(std::vector<const CaloTower*>::const_iterator hit=towers.begin(); hit!=towers.end(); hit++) {
-	      CaloTowerDetId neighborId((*hit)->id());
-	      int dEta = abs( (centerId.ieta()<0?centerId.ieta()+1:centerId.ieta() )
-			      -(neighborId.ieta()<0?neighborId.ieta()+1:neighborId.ieta() ) ) ;
-	      int dPhi = abs( centerId.iphi()-neighborId.iphi() );
-	      if ( abs(72-dPhi) < dPhi ) dPhi = 72-dPhi;
-	      if(  dEta <= gridSize && dPhi <= gridSize ) {
-		 switch (type) {
-		  case TowerTotal:
-		    if ( energy_max < (*hit)->energy() ){
-		       energy_max = (*hit)->energy();
-		       id_max = (*hit)->id();
-		    }
-		    break;
-		  case TowerEcal:
-		    if ( energy_max < (*hit)->emEnergy() ){
-		       energy_max = (*hit)->emEnergy();
-		       id_max = (*hit)->id();
-		    }
-		    break;
-		  case TowerHcal:
-		    if ( energy_max < (*hit)->hadEnergy() ){
-		       energy_max = (*hit)->hadEnergy();
-		       id_max = (*hit)->id();
-		    }
-		    break;
-		  case TowerHO:
-		    if ( energy_max < (*hit)->outerEnergy() ){
-		       energy_max = (*hit)->outerEnergy();
-		       id_max = (*hit)->id();
-		    }
-		    break;
-		  default:
-		    throw cms::Exception("FatalError") << "Unknown calo tower energy type: " << type;
-		 }
-	      }
-	   }
-	}
-      break;
-    case EcalRecHits:
-	{
-	   if( id.det() != DetId::Ecal || (id.subdetId() != EcalBarrel && id.subdetId() != EcalEndcap) ) {
-	      throw cms::Exception("FatalError") << "Wrong DetId. Expected EcalBarrel or EcalEndcap, but found:\n" <<
-		DetIdInfo::info(id,nullptr)<<"\n";
-	   }
-	   // Since the ECAL granularity is small and the gap between EE and EB is significant,
-	   // energy is computed only within the system that contains the central element
-	   if( id.subdetId() == EcalBarrel ) {
-	      EBDetId centerId(id);
-	      for(std::vector<const EcalRecHit*>::const_iterator hit=ecalRecHits.begin(); hit!=ecalRecHits.end(); hit++) {
-		 if ((*hit)->id().subdetId() != EcalBarrel) continue;
-		 EBDetId neighborId((*hit)->id());
-		 int dEta = abs( (centerId.ieta()<0?centerId.ieta()+1:centerId.ieta() )
-				 -(neighborId.ieta()<0?neighborId.ieta()+1:neighborId.ieta() ) ) ;
-		 int dPhi = abs( centerId.iphi()-neighborId.iphi() );
-		 if ( abs(360-dPhi) < dPhi ) dPhi = 360-dPhi;
-		 if(  dEta <= gridSize && dPhi <= gridSize ) {
-		    if ( energy_max < (*hit)->energy() ){
-		       energy_max = (*hit)->energy();
-		       id_max = (*hit)->id();
-		    }
-		 }
-	      }
-	   } else {
-	      // Endcap
-	      EEDetId centerId(id);
-	      for(std::vector<const EcalRecHit*>::const_iterator hit=ecalRecHits.begin(); hit!=ecalRecHits.end(); hit++) {
-		 if ((*hit)->id().subdetId() != EcalEndcap) continue;
-		 EEDetId neighborId((*hit)->id());
-		 if(  centerId.zside() == neighborId.zside() && 
-		      abs(centerId.ix()-neighborId.ix()) <= gridSize && 
-		      abs(centerId.iy()-neighborId.iy()) <= gridSize ) {
-		    if ( energy_max < (*hit)->energy() ){
-		       energy_max = (*hit)->energy();
-		       id_max = (*hit)->id();
-		    }
-		 }
-	      }
-	   }
-	}
-      break;
-    case HcalRecHits:
-	{
-	   if( id.det() != DetId::Hcal || (id.subdetId() != HcalBarrel && id.subdetId() != HcalEndcap) ) {
-	      throw cms::Exception("FatalError") << "Wrong DetId. Expected HE or HB, but found:\n" <<
-		DetIdInfo::info(id,nullptr)<<"\n";
-	   }
-	   HcalDetId centerId(id);
-	   for(std::vector<const HBHERecHit*>::const_iterator hit=hcalRecHits.begin(); hit!=hcalRecHits.end(); hit++) {
-	      HcalDetId neighborId((*hit)->id());
-	      int dEta = abs( (centerId.ieta()<0?centerId.ieta()+1:centerId.ieta() )
-			      -(neighborId.ieta()<0?neighborId.ieta()+1:neighborId.ieta() ) ) ;
-	      int dPhi = abs( centerId.iphi()-neighborId.iphi() );
-	      if ( abs(72-dPhi) < dPhi ) dPhi = 72-dPhi;
-	      if(  dEta <= gridSize && dPhi <= gridSize ){
-		 if ( energy_max < (*hit)->energy() ){
-		    energy_max = (*hit)->energy();
-		    id_max = (*hit)->id();
-		 }
-	      }
-	   }
-	}
-      break;
-    case HORecHits:
-	{
-	   if( id.det() != DetId::Hcal || (id.subdetId() != HcalOuter) ) {
-	      throw cms::Exception("FatalError") << "Wrong DetId. Expected HO, but found:\n" <<
-		DetIdInfo::info(id,nullptr)<<"\n";
-	   }
-	   HcalDetId centerId(id);
-	   for(std::vector<const HORecHit*>::const_iterator hit=hoRecHits.begin(); hit!=hoRecHits.end(); hit++) {
-	      HcalDetId neighborId((*hit)->id());
-	      int dEta = abs( (centerId.ieta()<0?centerId.ieta()+1:centerId.ieta() )
-			      -(neighborId.ieta()<0?neighborId.ieta()+1:neighborId.ieta() ) ) ;
-	      int dPhi = abs( centerId.iphi()-neighborId.iphi() );
-	      if ( abs(72-dPhi) < dPhi ) dPhi = 72-dPhi;
-	      if(  dEta <= gridSize && dPhi <= gridSize ) {
-		 if ( energy_max < (*hit)->energy() ){
-		    energy_max = (*hit)->energy();
-		    id_max = (*hit)->id();
-		 }
-	      }
-	   }
-	}
-      break;
+    case TowerHO: {
+      if (id.det() != DetId::Calo) {
+        throw cms::Exception("FatalError") << "Wrong DetId. Expected CaloTower, but found:\n"
+                                           << DetIdInfo::info(id, nullptr) << "\n";
+      }
+      CaloTowerDetId centerId(id);
+      for (std::vector<const CaloTower*>::const_iterator hit = towers.begin(); hit != towers.end(); hit++) {
+        CaloTowerDetId neighborId((*hit)->id());
+        int dEta = abs((centerId.ieta() < 0 ? centerId.ieta() + 1 : centerId.ieta()) -
+                       (neighborId.ieta() < 0 ? neighborId.ieta() + 1 : neighborId.ieta()));
+        int dPhi = abs(centerId.iphi() - neighborId.iphi());
+        if (abs(72 - dPhi) < dPhi)
+          dPhi = 72 - dPhi;
+        if (dEta <= gridSize && dPhi <= gridSize) {
+          switch (type) {
+            case TowerTotal:
+              if (energy_max < (*hit)->energy()) {
+                energy_max = (*hit)->energy();
+                id_max = (*hit)->id();
+              }
+              break;
+            case TowerEcal:
+              if (energy_max < (*hit)->emEnergy()) {
+                energy_max = (*hit)->emEnergy();
+                id_max = (*hit)->id();
+              }
+              break;
+            case TowerHcal:
+              if (energy_max < (*hit)->hadEnergy()) {
+                energy_max = (*hit)->hadEnergy();
+                id_max = (*hit)->id();
+              }
+              break;
+            case TowerHO:
+              if (energy_max < (*hit)->outerEnergy()) {
+                energy_max = (*hit)->outerEnergy();
+                id_max = (*hit)->id();
+              }
+              break;
+            default:
+              throw cms::Exception("FatalError") << "Unknown calo tower energy type: " << type;
+          }
+        }
+      }
+    } break;
+    case EcalRecHits: {
+      if (id.det() != DetId::Ecal || (id.subdetId() != EcalBarrel && id.subdetId() != EcalEndcap)) {
+        throw cms::Exception("FatalError") << "Wrong DetId. Expected EcalBarrel or EcalEndcap, but found:\n"
+                                           << DetIdInfo::info(id, nullptr) << "\n";
+      }
+      // Since the ECAL granularity is small and the gap between EE and EB is significant,
+      // energy is computed only within the system that contains the central element
+      if (id.subdetId() == EcalBarrel) {
+        EBDetId centerId(id);
+        for (std::vector<const EcalRecHit*>::const_iterator hit = ecalRecHits.begin(); hit != ecalRecHits.end();
+             hit++) {
+          if ((*hit)->id().subdetId() != EcalBarrel)
+            continue;
+          EBDetId neighborId((*hit)->id());
+          int dEta = abs((centerId.ieta() < 0 ? centerId.ieta() + 1 : centerId.ieta()) -
+                         (neighborId.ieta() < 0 ? neighborId.ieta() + 1 : neighborId.ieta()));
+          int dPhi = abs(centerId.iphi() - neighborId.iphi());
+          if (abs(360 - dPhi) < dPhi)
+            dPhi = 360 - dPhi;
+          if (dEta <= gridSize && dPhi <= gridSize) {
+            if (energy_max < (*hit)->energy()) {
+              energy_max = (*hit)->energy();
+              id_max = (*hit)->id();
+            }
+          }
+        }
+      } else {
+        // Endcap
+        EEDetId centerId(id);
+        for (std::vector<const EcalRecHit*>::const_iterator hit = ecalRecHits.begin(); hit != ecalRecHits.end();
+             hit++) {
+          if ((*hit)->id().subdetId() != EcalEndcap)
+            continue;
+          EEDetId neighborId((*hit)->id());
+          if (centerId.zside() == neighborId.zside() && abs(centerId.ix() - neighborId.ix()) <= gridSize &&
+              abs(centerId.iy() - neighborId.iy()) <= gridSize) {
+            if (energy_max < (*hit)->energy()) {
+              energy_max = (*hit)->energy();
+              id_max = (*hit)->id();
+            }
+          }
+        }
+      }
+    } break;
+    case HcalRecHits: {
+      if (id.det() != DetId::Hcal || (id.subdetId() != HcalBarrel && id.subdetId() != HcalEndcap)) {
+        throw cms::Exception("FatalError") << "Wrong DetId. Expected HE or HB, but found:\n"
+                                           << DetIdInfo::info(id, nullptr) << "\n";
+      }
+      HcalDetId centerId(id);
+      for (std::vector<const HBHERecHit*>::const_iterator hit = hcalRecHits.begin(); hit != hcalRecHits.end(); hit++) {
+        HcalDetId neighborId((*hit)->id());
+        int dEta = abs((centerId.ieta() < 0 ? centerId.ieta() + 1 : centerId.ieta()) -
+                       (neighborId.ieta() < 0 ? neighborId.ieta() + 1 : neighborId.ieta()));
+        int dPhi = abs(centerId.iphi() - neighborId.iphi());
+        if (abs(72 - dPhi) < dPhi)
+          dPhi = 72 - dPhi;
+        if (dEta <= gridSize && dPhi <= gridSize) {
+          if (energy_max < (*hit)->energy()) {
+            energy_max = (*hit)->energy();
+            id_max = (*hit)->id();
+          }
+        }
+      }
+    } break;
+    case HORecHits: {
+      if (id.det() != DetId::Hcal || (id.subdetId() != HcalOuter)) {
+        throw cms::Exception("FatalError") << "Wrong DetId. Expected HO, but found:\n"
+                                           << DetIdInfo::info(id, nullptr) << "\n";
+      }
+      HcalDetId centerId(id);
+      for (std::vector<const HORecHit*>::const_iterator hit = hoRecHits.begin(); hit != hoRecHits.end(); hit++) {
+        HcalDetId neighborId((*hit)->id());
+        int dEta = abs((centerId.ieta() < 0 ? centerId.ieta() + 1 : centerId.ieta()) -
+                       (neighborId.ieta() < 0 ? neighborId.ieta() + 1 : neighborId.ieta()));
+        int dPhi = abs(centerId.iphi() - neighborId.iphi());
+        if (abs(72 - dPhi) < dPhi)
+          dPhi = 72 - dPhi;
+        if (dEta <= gridSize && dPhi <= gridSize) {
+          if (energy_max < (*hit)->energy()) {
+            energy_max = (*hit)->energy();
+            id_max = (*hit)->id();
+          }
+        }
+      }
+    } break;
     default:
       throw cms::Exception("FatalError") << "Unkown or not implemented energy type requested, type:" << type;
-   }
-   return id_max;
+  }
+  return id_max;
 }
 
-DetId TrackDetMatchInfo::findMaxDeposition(EnergyType type, int gridSize)
-{
-   DetId id_max;
-   switch (type)  {
+DetId TrackDetMatchInfo::findMaxDeposition(EnergyType type, int gridSize) {
+  DetId id_max;
+  switch (type) {
     case TowerTotal:
     case TowerHcal:
     case TowerEcal:
     case TowerHO:
-      if( crossedTowerIds.empty() ) return id_max;
+      if (crossedTowerIds.empty())
+        return id_max;
       return findMaxDeposition(crossedTowerIds.front(), type, gridSize);
       break;
     case EcalRecHits:
-      if( crossedEcalIds.empty() ) return id_max;
+      if (crossedEcalIds.empty())
+        return id_max;
       return findMaxDeposition(crossedEcalIds.front(), type, gridSize);
       break;
     case HcalRecHits:
-      if( crossedHcalIds.empty() ) return id_max;
+      if (crossedHcalIds.empty())
+        return id_max;
       return findMaxDeposition(crossedHcalIds.front(), type, gridSize);
       break;
     case HORecHits:
-      if( crossedHOIds.empty() ) return id_max;
+      if (crossedHOIds.empty())
+        return id_max;
       return findMaxDeposition(crossedHOIds.front(), type, gridSize);
       break;
     default:
       throw cms::Exception("FatalError") << "Unkown or not implemented energy type requested, type:" << type;
-   }
-   return id_max;
+  }
+  return id_max;
 }
 
 ////////////////////////////////////////////////////////////////////////
 // Obsolete
 //
 
+double TrackDetMatchInfo::ecalConeEnergy() { return coneEnergy(999, EcalRecHits); }
 
+double TrackDetMatchInfo::hcalConeEnergy() { return coneEnergy(999, HcalRecHits); }
 
-double TrackDetMatchInfo::ecalConeEnergy()
-{
-   return coneEnergy (999, EcalRecHits );
-}
+double TrackDetMatchInfo::hoConeEnergy() { return coneEnergy(999, HcalRecHits); }
 
-double TrackDetMatchInfo::hcalConeEnergy()
-{
-   return coneEnergy (999, HcalRecHits );
-}
+double TrackDetMatchInfo::ecalCrossedEnergy() { return crossedEnergy(EcalRecHits); }
 
-double TrackDetMatchInfo::hoConeEnergy()
-{
-   return coneEnergy (999, HcalRecHits );
-}
+double TrackDetMatchInfo::hcalCrossedEnergy() { return crossedEnergy(HcalRecHits); }
 
-double TrackDetMatchInfo::ecalCrossedEnergy()
-{
-   return crossedEnergy( EcalRecHits );
-}
+double TrackDetMatchInfo::hoCrossedEnergy() { return crossedEnergy(HORecHits); }
 
-double TrackDetMatchInfo::hcalCrossedEnergy()
-{
-   return crossedEnergy( HcalRecHits );
-}
-
-double TrackDetMatchInfo::hoCrossedEnergy()
-{
-   return crossedEnergy( HORecHits );
-}
-      
-      
 int TrackDetMatchInfo::numberOfSegments() const {
-   int numSegments = 0;
-   for(std::vector<TAMuonChamberMatch>::const_iterator chamber=chambers.begin(); chamber!=chambers.end(); chamber++)
-     numSegments += chamber->segments.size();
-   return numSegments;
+  int numSegments = 0;
+  for (std::vector<TAMuonChamberMatch>::const_iterator chamber = chambers.begin(); chamber != chambers.end(); chamber++)
+    numSegments += chamber->segments.size();
+  return numSegments;
 }
 
 int TrackDetMatchInfo::numberOfSegmentsInStation(int station) const {
-   int numSegments = 0;
-   for(std::vector<TAMuonChamberMatch>::const_iterator chamber=chambers.begin(); chamber!=chambers.end(); chamber++)
-     if(chamber->station()==station) numSegments += chamber->segments.size();
-   return numSegments;
+  int numSegments = 0;
+  for (std::vector<TAMuonChamberMatch>::const_iterator chamber = chambers.begin(); chamber != chambers.end(); chamber++)
+    if (chamber->station() == station)
+      numSegments += chamber->segments.size();
+  return numSegments;
 }
 
 int TrackDetMatchInfo::numberOfSegmentsInStation(int station, int detector) const {
-   int numSegments = 0;
-   for(std::vector<TAMuonChamberMatch>::const_iterator chamber=chambers.begin(); chamber!=chambers.end(); chamber++)
-     if(chamber->station()==station&&chamber->detector()==detector) numSegments += chamber->segments.size();
-   return numSegments;
+  int numSegments = 0;
+  for (std::vector<TAMuonChamberMatch>::const_iterator chamber = chambers.begin(); chamber != chambers.end(); chamber++)
+    if (chamber->station() == station && chamber->detector() == detector)
+      numSegments += chamber->segments.size();
+  return numSegments;
 }
 
 int TrackDetMatchInfo::numberOfSegmentsInDetector(int detector) const {
-   int numSegments = 0;
-   for(std::vector<TAMuonChamberMatch>::const_iterator chamber=chambers.begin(); chamber!=chambers.end(); chamber++)
-     if(chamber->detector()==detector) numSegments += chamber->segments.size();
-   return numSegments;
+  int numSegments = 0;
+  for (std::vector<TAMuonChamberMatch>::const_iterator chamber = chambers.begin(); chamber != chambers.end(); chamber++)
+    if (chamber->detector() == detector)
+      numSegments += chamber->segments.size();
+  return numSegments;
 }

--- a/TrackingTools/TrackAssociator/test/CaloMatchingExample.cc
+++ b/TrackingTools/TrackAssociator/test/CaloMatchingExample.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TrackAssociator
 // Class:      CaloMatchingExample
-// 
+//
 /*
 
  Description: Example shows how to access various forms of energy deposition and store them in an ntuple
@@ -13,7 +13,6 @@
 //         Created:  Fri Apr 21 10:59:41 PDT 2006
 //
 //
-
 
 // system include files
 #include <memory>
@@ -65,7 +64,6 @@
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
@@ -82,268 +80,266 @@
 #include "CLHEP/Random/Random.h"
 
 class CaloMatchingExample : public edm::EDAnalyzer {
- public:
-   explicit CaloMatchingExample(const edm::ParameterSet&);
-   virtual ~CaloMatchingExample(){
-      file_->cd();
-      tree_->Write();
-      file_->Close();
-   }
-   
-   virtual void analyze (const edm::Event&, const edm::EventSetup&);
+public:
+  explicit CaloMatchingExample(const edm::ParameterSet&);
+  virtual ~CaloMatchingExample() {
+    file_->cd();
+    tree_->Write();
+    file_->Close();
+  }
 
- private:
-   TrackDetectorAssociator trackAssociator_;
-   bool useEcal_;
-   bool useHcal_;
-   bool useMuon_;
-   bool useOldMuonMatching_;
-   TFile* file_;
-   TTree* tree_;
-   int nTracks_;
-   
-   float ecalCrossedEnergy_[1000];
-   float ecal3x3Energy_[1000];
-   float ecal5x5Energy_[1000];
-   float ecal3x3EnergyMax_[1000];
-   float ecal5x5EnergyMax_[1000];
-   float ecalTrueEnergy_[1000];
-   float trkPosAtEcal_[1000][2];
-   float ecalMaxPos_[1000][2];
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-   float ecalCrossedEnergyRandom_[1000];
-   float ecal3x3EnergyRandom_[1000];
-   float ecal5x5EnergyRandom_[1000];
-   float ecal3x3EnergyMaxRandom_[1000];
-   float ecal5x5EnergyMaxRandom_[1000];
-   float trkPosAtEcalRandom_[1000][2];
-   float ecalMaxPosRandom_[1000][2];
+private:
+  TrackDetectorAssociator trackAssociator_;
+  bool useEcal_;
+  bool useHcal_;
+  bool useMuon_;
+  bool useOldMuonMatching_;
+  TFile* file_;
+  TTree* tree_;
+  int nTracks_;
 
-   float hcalCrossedEnergy_[1000];
-   float hcal3x3Energy_[1000];
-   float hcal5x5Energy_[1000];
-   float hcal3x3EnergyMax_[1000];
-   float hcal5x5EnergyMax_[1000];
-   float hcalTrueEnergy_[1000];
-   float hcalTrueEnergyCorrected_[1000];
-   float trkPosAtHcal_[1000][2];
-   float hcalMaxPos_[1000][2];
-   float trackPt_[1000];
+  float ecalCrossedEnergy_[1000];
+  float ecal3x3Energy_[1000];
+  float ecal5x5Energy_[1000];
+  float ecal3x3EnergyMax_[1000];
+  float ecal5x5EnergyMax_[1000];
+  float ecalTrueEnergy_[1000];
+  float trkPosAtEcal_[1000][2];
+  float ecalMaxPos_[1000][2];
 
-   float hcalCrossedEnergyRandom_[1000];
-   float hcal3x3EnergyRandom_[1000];
-   float hcal5x5EnergyRandom_[1000];
-   float hcal3x3EnergyMaxRandom_[1000];
-   float hcal5x5EnergyMaxRandom_[1000];
-   float trkPosAtHcalRandom_[1000][2];
-   float hcalMaxPosRandom_[1000][2];
+  float ecalCrossedEnergyRandom_[1000];
+  float ecal3x3EnergyRandom_[1000];
+  float ecal5x5EnergyRandom_[1000];
+  float ecal3x3EnergyMaxRandom_[1000];
+  float ecal5x5EnergyMaxRandom_[1000];
+  float trkPosAtEcalRandom_[1000][2];
+  float ecalMaxPosRandom_[1000][2];
 
-   edm::InputTag inputRecoTrackColl_;
-   TrackAssociatorParameters parameters_;
+  float hcalCrossedEnergy_[1000];
+  float hcal3x3Energy_[1000];
+  float hcal5x5Energy_[1000];
+  float hcal3x3EnergyMax_[1000];
+  float hcal5x5EnergyMax_[1000];
+  float hcalTrueEnergy_[1000];
+  float hcalTrueEnergyCorrected_[1000];
+  float trkPosAtHcal_[1000][2];
+  float hcalMaxPos_[1000][2];
+  float trackPt_[1000];
+
+  float hcalCrossedEnergyRandom_[1000];
+  float hcal3x3EnergyRandom_[1000];
+  float hcal5x5EnergyRandom_[1000];
+  float hcal3x3EnergyMaxRandom_[1000];
+  float hcal5x5EnergyMaxRandom_[1000];
+  float trkPosAtHcalRandom_[1000][2];
+  float hcalMaxPosRandom_[1000][2];
+
+  edm::InputTag inputRecoTrackColl_;
+  TrackAssociatorParameters parameters_;
 };
 
-CaloMatchingExample::CaloMatchingExample(const edm::ParameterSet& iConfig)
-{
-   CLHEP::HepRandom::createInstance();
-   file_ = new TFile( iConfig.getParameter<std::string>("outputfile").c_str(), "recreate");
-   tree_ = new TTree( "calomatch","calomatch" );
-   tree_->Branch("nTracks",&nTracks_,"nTracks/I");
-   
-   tree_->Branch("ecalCrossedEnergy", ecalCrossedEnergy_, "ecalCrossedEnergy[nTracks]/F");
-   tree_->Branch("ecal3x3Energy", ecal3x3Energy_, "ecal3x3Energy[nTracks]/F");
-   tree_->Branch("ecal5x5Energy", ecal5x5Energy_, "ecal5x5Energy[nTracks]/F");
-   tree_->Branch("ecal3x3EnergyMax", ecal3x3EnergyMax_, "ecal3x3EnergyMax[nTracks]/F");
-   tree_->Branch("ecal5x5EnergyMax", ecal5x5EnergyMax_, "ecal5x5EnergyMax[nTracks]/F");
-   tree_->Branch("ecalTrueEnergy", ecalTrueEnergy_, "ecalTrueEnergy[nTracks]/F");
-   tree_->Branch("trkPosAtEcal", trkPosAtEcal_, "trkPosAtEcal[nTracks][2]/F");
-   tree_->Branch("ecalMaxPos", ecalMaxPos_, "ecalMaxPos[nTracks][2]/F");
-   
-   tree_->Branch("ecalCrossedEnergyRandom", ecalCrossedEnergyRandom_, "ecalCrossedEnergyRandom[nTracks]/F");
-   tree_->Branch("ecal3x3EnergyRandom", ecal3x3EnergyRandom_, "ecal3x3EnergyRandom[nTracks]/F");
-   tree_->Branch("ecal5x5EnergyRandom", ecal5x5EnergyRandom_, "ecal5x5EnergyRandom[nTracks]/F");
-   tree_->Branch("ecal3x3EnergyMaxRandom", ecal3x3EnergyMaxRandom_, "ecal3x3EnergyMaxRandom[nTracks]/F");
-   tree_->Branch("ecal5x5EnergyMaxRandom", ecal5x5EnergyMaxRandom_, "ecal5x5EnergyMaxRandom[nTracks]/F");
-   tree_->Branch("trkPosAtEcalRandom", trkPosAtEcalRandom_, "trkPosAtEcalRandom[nTracks][2]/F");
-   tree_->Branch("ecalMaxPosRandom", ecalMaxPosRandom_, "ecalMaxPosRandom[nTracks][2]/F");
+CaloMatchingExample::CaloMatchingExample(const edm::ParameterSet& iConfig) {
+  CLHEP::HepRandom::createInstance();
+  file_ = new TFile(iConfig.getParameter<std::string>("outputfile").c_str(), "recreate");
+  tree_ = new TTree("calomatch", "calomatch");
+  tree_->Branch("nTracks", &nTracks_, "nTracks/I");
 
-   tree_->Branch("hcalCrossedEnergy", hcalCrossedEnergy_, "hcalCrossedEnergy[nTracks]/F");
-   tree_->Branch("hcal3x3Energy", hcal3x3Energy_, "hcal3x3Energy[nTracks]/F");
-   tree_->Branch("hcal5x5Energy", hcal5x5Energy_, "hcal5x5Energy[nTracks]/F");
-   tree_->Branch("hcal3x3EnergyMax", hcal3x3EnergyMax_, "hcal3x3EnergyMax[nTracks]/F");
-   tree_->Branch("hcal5x5EnergyMax", hcal5x5EnergyMax_, "hcal5x5EnergyMax[nTracks]/F");
-   tree_->Branch("hcalTrueEnergy", hcalTrueEnergy_, "hcalTrueEnergy[nTracks]/F");
-   tree_->Branch("hcalTrueEnergyCorrected", hcalTrueEnergyCorrected_, "hcalTrueEnergyCorrected[nTracks]/F");
-   tree_->Branch("trkPosAtHcal", trkPosAtHcal_, "trkPosAtHcal[nTracks][2]/F");
-   tree_->Branch("hcalMaxPos", hcalMaxPos_, "hcalMaxPos[nTracks][2]/F");
+  tree_->Branch("ecalCrossedEnergy", ecalCrossedEnergy_, "ecalCrossedEnergy[nTracks]/F");
+  tree_->Branch("ecal3x3Energy", ecal3x3Energy_, "ecal3x3Energy[nTracks]/F");
+  tree_->Branch("ecal5x5Energy", ecal5x5Energy_, "ecal5x5Energy[nTracks]/F");
+  tree_->Branch("ecal3x3EnergyMax", ecal3x3EnergyMax_, "ecal3x3EnergyMax[nTracks]/F");
+  tree_->Branch("ecal5x5EnergyMax", ecal5x5EnergyMax_, "ecal5x5EnergyMax[nTracks]/F");
+  tree_->Branch("ecalTrueEnergy", ecalTrueEnergy_, "ecalTrueEnergy[nTracks]/F");
+  tree_->Branch("trkPosAtEcal", trkPosAtEcal_, "trkPosAtEcal[nTracks][2]/F");
+  tree_->Branch("ecalMaxPos", ecalMaxPos_, "ecalMaxPos[nTracks][2]/F");
 
-   tree_->Branch("hcalCrossedEnergyRandom", hcalCrossedEnergyRandom_, "hcalCrossedEnergyRandom[nTracks]/F");
-   tree_->Branch("hcal3x3EnergyRandom", hcal3x3EnergyRandom_, "hcal3x3EnergyRandom[nTracks]/F");
-   tree_->Branch("hcal5x5EnergyRandom", hcal5x5EnergyRandom_, "hcal5x5EnergyRandom[nTracks]/F");
-   tree_->Branch("hcal3x3EnergyMaxRandom", hcal3x3EnergyMaxRandom_, "hcal3x3EnergyMaxRandom[nTracks]/F");
-   tree_->Branch("hcal5x5EnergyMaxRandom", hcal5x5EnergyMaxRandom_, "hcal5x5EnergyMaxRandom[nTracks]/F");
-   tree_->Branch("trkPosAtHcalRandom", trkPosAtHcalRandom_, "trkPosAtHcalRandom[nTracks][2]/F");
-   tree_->Branch("hcalMaxPosRandom", hcalMaxPosRandom_, "hcalMaxPosRandom[nTracks][2]/F");
+  tree_->Branch("ecalCrossedEnergyRandom", ecalCrossedEnergyRandom_, "ecalCrossedEnergyRandom[nTracks]/F");
+  tree_->Branch("ecal3x3EnergyRandom", ecal3x3EnergyRandom_, "ecal3x3EnergyRandom[nTracks]/F");
+  tree_->Branch("ecal5x5EnergyRandom", ecal5x5EnergyRandom_, "ecal5x5EnergyRandom[nTracks]/F");
+  tree_->Branch("ecal3x3EnergyMaxRandom", ecal3x3EnergyMaxRandom_, "ecal3x3EnergyMaxRandom[nTracks]/F");
+  tree_->Branch("ecal5x5EnergyMaxRandom", ecal5x5EnergyMaxRandom_, "ecal5x5EnergyMaxRandom[nTracks]/F");
+  tree_->Branch("trkPosAtEcalRandom", trkPosAtEcalRandom_, "trkPosAtEcalRandom[nTracks][2]/F");
+  tree_->Branch("ecalMaxPosRandom", ecalMaxPosRandom_, "ecalMaxPosRandom[nTracks][2]/F");
 
-   tree_->Branch("trackPt", trackPt_, "trackPt_[nTracks]/F");
-   
-   inputRecoTrackColl_ = iConfig.getParameter<edm::InputTag>("inputRecoTrackColl");
-   
-   // TrackAssociator parameters
-   edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
-   edm::ConsumesCollector iC = consumesCollector();
-   parameters_.loadParameters( parameters, iC );
+  tree_->Branch("hcalCrossedEnergy", hcalCrossedEnergy_, "hcalCrossedEnergy[nTracks]/F");
+  tree_->Branch("hcal3x3Energy", hcal3x3Energy_, "hcal3x3Energy[nTracks]/F");
+  tree_->Branch("hcal5x5Energy", hcal5x5Energy_, "hcal5x5Energy[nTracks]/F");
+  tree_->Branch("hcal3x3EnergyMax", hcal3x3EnergyMax_, "hcal3x3EnergyMax[nTracks]/F");
+  tree_->Branch("hcal5x5EnergyMax", hcal5x5EnergyMax_, "hcal5x5EnergyMax[nTracks]/F");
+  tree_->Branch("hcalTrueEnergy", hcalTrueEnergy_, "hcalTrueEnergy[nTracks]/F");
+  tree_->Branch("hcalTrueEnergyCorrected", hcalTrueEnergyCorrected_, "hcalTrueEnergyCorrected[nTracks]/F");
+  tree_->Branch("trkPosAtHcal", trkPosAtHcal_, "trkPosAtHcal[nTracks][2]/F");
+  tree_->Branch("hcalMaxPos", hcalMaxPos_, "hcalMaxPos[nTracks][2]/F");
 
-   trackAssociator_.useDefaultPropagator();
-   
+  tree_->Branch("hcalCrossedEnergyRandom", hcalCrossedEnergyRandom_, "hcalCrossedEnergyRandom[nTracks]/F");
+  tree_->Branch("hcal3x3EnergyRandom", hcal3x3EnergyRandom_, "hcal3x3EnergyRandom[nTracks]/F");
+  tree_->Branch("hcal5x5EnergyRandom", hcal5x5EnergyRandom_, "hcal5x5EnergyRandom[nTracks]/F");
+  tree_->Branch("hcal3x3EnergyMaxRandom", hcal3x3EnergyMaxRandom_, "hcal3x3EnergyMaxRandom[nTracks]/F");
+  tree_->Branch("hcal5x5EnergyMaxRandom", hcal5x5EnergyMaxRandom_, "hcal5x5EnergyMaxRandom[nTracks]/F");
+  tree_->Branch("trkPosAtHcalRandom", trkPosAtHcalRandom_, "trkPosAtHcalRandom[nTracks][2]/F");
+  tree_->Branch("hcalMaxPosRandom", hcalMaxPosRandom_, "hcalMaxPosRandom[nTracks][2]/F");
+
+  tree_->Branch("trackPt", trackPt_, "trackPt_[nTracks]/F");
+
+  inputRecoTrackColl_ = iConfig.getParameter<edm::InputTag>("inputRecoTrackColl");
+
+  // TrackAssociator parameters
+  edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
+  edm::ConsumesCollector iC = consumesCollector();
+  parameters_.loadParameters(parameters, iC);
+
+  trackAssociator_.useDefaultPropagator();
 }
 
-void CaloMatchingExample::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   
-   // calo geometry
-   edm::ESHandle<CaloGeometry> geometry;
-   iSetup.get<CaloGeometryRecord>().get(geometry);
-   if (! geometry.isValid()) throw cms::Exception("FatalError") << "Unable to find CaloGeometryRecord in event!\n";
+void CaloMatchingExample::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   nTracks_ = 0;
-   
-   // get reco tracks 
-   Handle<reco::TrackCollection> recoTracks;
-   iEvent.getByLabel(inputRecoTrackColl_, recoTracks);
-   if (! recoTracks.isValid() ) throw cms::Exception("FatalError") << "No reco tracks were found\n";
+  // calo geometry
+  edm::ESHandle<CaloGeometry> geometry;
+  iSetup.get<CaloGeometryRecord>().get(geometry);
+  if (!geometry.isValid())
+    throw cms::Exception("FatalError") << "Unable to find CaloGeometryRecord in event!\n";
 
-   // loop over reconstructed tracks
-   LogTrace("TrackAssociator") << "Number of reco tracks found in the event: " << recoTracks->size() ;
-   // for(SimTrackContainer::const_iterator tracksCI = simTracks->begin();
-   //    tracksCI != simTracks->end(); tracksCI++){
-   for(reco::TrackCollection::const_iterator recoTrack = recoTracks->begin();
-       recoTrack != recoTracks->end(); ++recoTrack){
-       
-      // skip low Pt tracks
-      if (recoTrack->pt() < 2) {
-	 LogTrace("TrackAssociator") << "Skipped low Pt track (Pt: " << recoTrack->pt() << ")" ;
-	 continue;
-      }
-      
-      LogTrace("TrackAssociator") << "\n-------------------------------------------------------\n Track (pt,eta,phi): " << 
-	recoTrack->pt() << " , " << recoTrack->eta() << " , " << recoTrack->phi() ;
-      
-      // Get track matching info
+  nTracks_ = 0;
 
-      LogTrace("TrackAssociator") << "===========================================================================\nDetails:\n" ;
-      TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, *recoTrack, parameters_);
-      // get some noise info (random direction)
-      ROOT::Math::RhoEtaPhiVector randomVector(10,(CLHEP::HepRandom::getTheEngine()->flat()-0.5)*6,(CLHEP::HepRandom::getTheEngine()->flat()-0.5)*2*M_PI);
-      TrackDetMatchInfo infoRandom = trackAssociator_.associate(iEvent, iSetup,      
-								GlobalVector(randomVector.x(),randomVector.y(),randomVector.z()),
-								GlobalPoint(0,0,0),
-								+1, parameters_);
-      
-      ///////////////////////////////////////////////////
-      //
-      //   Fill ntuple
-      //
-      ///////////////////////////////////////////////////
-      
-      DetId centerId;
-      DetId centerIdRandom;
-      
-      trackPt_[nTracks_] = recoTrack->pt();
-      ecalCrossedEnergy_[nTracks_] = info.crossedEnergy(TrackDetMatchInfo::EcalRecHits);
-      centerId                     = info.findMaxDeposition(TrackDetMatchInfo::EcalRecHits);
-      ecal3x3Energy_[nTracks_]     = info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 1);
-      ecal5x5Energy_[nTracks_]     = info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 2);
-      ecal3x3EnergyMax_[nTracks_]  = info.nXnEnergy(centerId, TrackDetMatchInfo::EcalRecHits, 1);
-      ecal5x5EnergyMax_[nTracks_]  = info.nXnEnergy(centerId, TrackDetMatchInfo::EcalRecHits, 2);
-      ecalTrueEnergy_[nTracks_]    = info.ecalTrueEnergy;
-      trkPosAtEcal_[nTracks_][0]   = info.trkGlobPosAtEcal.eta();
-      trkPosAtEcal_[nTracks_][1]   = info.trkGlobPosAtEcal.phi();
-      if ( geometry->getSubdetectorGeometry(centerId) &&
-	   geometry->getSubdetectorGeometry(centerId)->getGeometry(centerId) ) 
-	{
-	   GlobalPoint position = geometry->getSubdetectorGeometry(centerId)->getGeometry(centerId)->getPosition();
-	   ecalMaxPos_[nTracks_][0] = position.eta();
-	   ecalMaxPos_[nTracks_][1] = position.phi();
-	}
-      else
-	{
-	   ecalMaxPos_[nTracks_][0] = -999;
-	   ecalMaxPos_[nTracks_][1] = -999;
-	}
-      ecalCrossedEnergyRandom_[nTracks_] = infoRandom.crossedEnergy(TrackDetMatchInfo::EcalRecHits);
-      centerIdRandom                     = infoRandom.findMaxDeposition(TrackDetMatchInfo::EcalRecHits);
-      ecal3x3EnergyRandom_[nTracks_]     = infoRandom.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 1);
-      ecal5x5EnergyRandom_[nTracks_]     = infoRandom.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 2);
-      ecal3x3EnergyMaxRandom_[nTracks_]  = infoRandom.nXnEnergy(centerIdRandom, TrackDetMatchInfo::EcalRecHits, 1);
-      ecal5x5EnergyMaxRandom_[nTracks_]  = infoRandom.nXnEnergy(centerIdRandom, TrackDetMatchInfo::EcalRecHits, 2);
-      trkPosAtEcalRandom_[nTracks_][0]   = infoRandom.trkGlobPosAtEcal.eta();
-      trkPosAtEcalRandom_[nTracks_][1]   = infoRandom.trkGlobPosAtEcal.phi();
+  // get reco tracks
+  Handle<reco::TrackCollection> recoTracks;
+  iEvent.getByLabel(inputRecoTrackColl_, recoTracks);
+  if (!recoTracks.isValid())
+    throw cms::Exception("FatalError") << "No reco tracks were found\n";
 
-      hcalCrossedEnergy_[nTracks_] = info.hcalEnergy();
-      centerId                     = info.findMaxDeposition(TrackDetMatchInfo::HcalRecHits);
-      hcal3x3Energy_[nTracks_]     = info.nXnEnergy(centerId, TrackDetMatchInfo::HcalRecHits, 1);
-      hcal5x5Energy_[nTracks_]     = info.nXnEnergy(centerId, TrackDetMatchInfo::HcalRecHits, 2);
-      hcalTrueEnergy_[nTracks_]    = info.hcalTrueEnergy;
-      hcalTrueEnergyCorrected_[nTracks_]    = info.hcalTrueEnergyCorrected;
-      trkPosAtHcal_[nTracks_][0]   = info.trkGlobPosAtHcal.eta();
-      trkPosAtHcal_[nTracks_][1]   = info.trkGlobPosAtHcal.phi();
-      if ( geometry->getSubdetectorGeometry(centerId) &&
-	   geometry->getSubdetectorGeometry(centerId)->getGeometry(centerId) ) 
-	{
-	   GlobalPoint position = geometry->getSubdetectorGeometry(centerId)->getGeometry(centerId)->getPosition();
-	   hcalMaxPos_[nTracks_][0] = position.eta();
-	   hcalMaxPos_[nTracks_][1] = position.phi();
-	}
-      else
-	{
-	   hcalMaxPos_[nTracks_][0] = -999;
-	   hcalMaxPos_[nTracks_][1] = -999;
-	}
-      hcalCrossedEnergyRandom_[nTracks_] = infoRandom.crossedEnergy(TrackDetMatchInfo::HcalRecHits);
-      centerIdRandom                     = infoRandom.findMaxDeposition(TrackDetMatchInfo::HcalRecHits);
-      hcal3x3EnergyRandom_[nTracks_]     = infoRandom.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 1);
-      hcal5x5EnergyRandom_[nTracks_]     = infoRandom.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 2);
-      hcal3x3EnergyMaxRandom_[nTracks_]  = infoRandom.nXnEnergy(centerIdRandom, TrackDetMatchInfo::HcalRecHits, 1);
-      hcal5x5EnergyMaxRandom_[nTracks_]  = infoRandom.nXnEnergy(centerIdRandom, TrackDetMatchInfo::HcalRecHits, 2);
-      trkPosAtHcalRandom_[nTracks_][0]   = infoRandom.trkGlobPosAtHcal.eta();
-      trkPosAtHcalRandom_[nTracks_][1]   = infoRandom.trkGlobPosAtHcal.phi();
-      
-      // Debugging information 
-      
-      LogTrace("TrackAssociator") << "ECAL, number of crossed cells: " << info.crossedEcalRecHits.size() ;
-      LogTrace("TrackAssociator") << "ECAL, energy of crossed cells: " << info.ecalEnergy() << " GeV" ;
-      LogTrace("TrackAssociator") << "ECAL, number of cells in the cone: " << info.ecalRecHits.size() ;
-      LogTrace("TrackAssociator") << "ECAL, energy in the cone: " << info.ecalConeEnergy() << " GeV" ;
-      LogTrace("TrackAssociator") << "ECAL, true energy: " << info.ecalTrueEnergy << " GeV" ;
-      LogTrace("TrackAssociator") << "ECAL, trajectory point (z,R,eta,phi): " << info.trkGlobPosAtEcal.z() << ", "
-	<< info.trkGlobPosAtEcal.R() << " , "	<< info.trkGlobPosAtEcal.eta() << " , " 
-	<< info.trkGlobPosAtEcal.phi();
-      
-      LogTrace("TrackAssociator") << "HCAL, number of crossed elements (towers): " << info.crossedTowers.size() ;
-      LogTrace("TrackAssociator") << "HCAL, energy of crossed elements (towers): " << info.hcalTowerEnergy() << " GeV" ;
-      LogTrace("TrackAssociator") << "HCAL, number of crossed elements (hits): "   << info.crossedHcalRecHits.size() ;
-      LogTrace("TrackAssociator") << "HCAL, energy of crossed elements (hits): "   << info.hcalEnergy() << " GeV" ;
-      LogTrace("TrackAssociator") << "HCAL, number of elements in the cone (towers): " << info.towers.size() ;
-      LogTrace("TrackAssociator") << "HCAL, energy in the cone (towers): "             << info.hcalTowerConeEnergy() << " GeV" ;
-      LogTrace("TrackAssociator") << "HCAL, number of elements in the cone (hits): "   << info.hcalRecHits.size() ;
-      LogTrace("TrackAssociator") << "HCAL, energy in the cone (hits): "               << info.hcalConeEnergy() << " GeV" ;
-      LogTrace("TrackAssociator") << "HCAL, true energy: " << info.hcalTrueEnergy << " GeV" ;
-      LogTrace("TrackAssociator") << "HCAL, true energy corrected: " << info.hcalTrueEnergyCorrected << " GeV" ;
-      LogTrace("TrackAssociator") << "HCAL, trajectory point (z,R,eta,phi): " << info.trkGlobPosAtHcal.z() << ", "
-	<< info.trkGlobPosAtHcal.R() << " , "	<< info.trkGlobPosAtHcal.eta() << " , "
-	<< info.trkGlobPosAtHcal.phi();
-      
-      LogTrace("TrackAssociator") << "HO, number of crossed elements (hits): " << info.crossedHORecHits.size() ;
-      LogTrace("TrackAssociator") << "HO, energy of crossed elements (hits): " << info.hoEnergy() << " GeV" ;
-      LogTrace("TrackAssociator") << "HO, number of elements in the cone: " << info.hoRecHits.size() ;
-      LogTrace("TrackAssociator") << "HO, energy in the cone: " << info.hoConeEnergy() << " GeV" ;
-      LogTrace("TrackAssociator") << "HCAL, trajectory point (z,R,eta,phi): " << info.trkGlobPosAtHO.z() << ", "
-	<< info.trkGlobPosAtHO.R() << " , "	<< info.trkGlobPosAtHO.eta() << " , "
-	<< info.trkGlobPosAtHO.phi();
-       nTracks_++;
-   }
-   tree_->Fill();
+  // loop over reconstructed tracks
+  LogTrace("TrackAssociator") << "Number of reco tracks found in the event: " << recoTracks->size();
+  // for(SimTrackContainer::const_iterator tracksCI = simTracks->begin();
+  //    tracksCI != simTracks->end(); tracksCI++){
+  for (reco::TrackCollection::const_iterator recoTrack = recoTracks->begin(); recoTrack != recoTracks->end();
+       ++recoTrack) {
+    // skip low Pt tracks
+    if (recoTrack->pt() < 2) {
+      LogTrace("TrackAssociator") << "Skipped low Pt track (Pt: " << recoTrack->pt() << ")";
+      continue;
+    }
+
+    LogTrace("TrackAssociator") << "\n-------------------------------------------------------\n Track (pt,eta,phi): "
+                                << recoTrack->pt() << " , " << recoTrack->eta() << " , " << recoTrack->phi();
+
+    // Get track matching info
+
+    LogTrace("TrackAssociator")
+        << "===========================================================================\nDetails:\n";
+    TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, *recoTrack, parameters_);
+    // get some noise info (random direction)
+    ROOT::Math::RhoEtaPhiVector randomVector(10,
+                                             (CLHEP::HepRandom::getTheEngine()->flat() - 0.5) * 6,
+                                             (CLHEP::HepRandom::getTheEngine()->flat() - 0.5) * 2 * M_PI);
+    TrackDetMatchInfo infoRandom =
+        trackAssociator_.associate(iEvent,
+                                   iSetup,
+                                   GlobalVector(randomVector.x(), randomVector.y(), randomVector.z()),
+                                   GlobalPoint(0, 0, 0),
+                                   +1,
+                                   parameters_);
+
+    ///////////////////////////////////////////////////
+    //
+    //   Fill ntuple
+    //
+    ///////////////////////////////////////////////////
+
+    DetId centerId;
+    DetId centerIdRandom;
+
+    trackPt_[nTracks_] = recoTrack->pt();
+    ecalCrossedEnergy_[nTracks_] = info.crossedEnergy(TrackDetMatchInfo::EcalRecHits);
+    centerId = info.findMaxDeposition(TrackDetMatchInfo::EcalRecHits);
+    ecal3x3Energy_[nTracks_] = info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 1);
+    ecal5x5Energy_[nTracks_] = info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 2);
+    ecal3x3EnergyMax_[nTracks_] = info.nXnEnergy(centerId, TrackDetMatchInfo::EcalRecHits, 1);
+    ecal5x5EnergyMax_[nTracks_] = info.nXnEnergy(centerId, TrackDetMatchInfo::EcalRecHits, 2);
+    ecalTrueEnergy_[nTracks_] = info.ecalTrueEnergy;
+    trkPosAtEcal_[nTracks_][0] = info.trkGlobPosAtEcal.eta();
+    trkPosAtEcal_[nTracks_][1] = info.trkGlobPosAtEcal.phi();
+    if (geometry->getSubdetectorGeometry(centerId) &&
+        geometry->getSubdetectorGeometry(centerId)->getGeometry(centerId)) {
+      GlobalPoint position = geometry->getSubdetectorGeometry(centerId)->getGeometry(centerId)->getPosition();
+      ecalMaxPos_[nTracks_][0] = position.eta();
+      ecalMaxPos_[nTracks_][1] = position.phi();
+    } else {
+      ecalMaxPos_[nTracks_][0] = -999;
+      ecalMaxPos_[nTracks_][1] = -999;
+    }
+    ecalCrossedEnergyRandom_[nTracks_] = infoRandom.crossedEnergy(TrackDetMatchInfo::EcalRecHits);
+    centerIdRandom = infoRandom.findMaxDeposition(TrackDetMatchInfo::EcalRecHits);
+    ecal3x3EnergyRandom_[nTracks_] = infoRandom.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 1);
+    ecal5x5EnergyRandom_[nTracks_] = infoRandom.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 2);
+    ecal3x3EnergyMaxRandom_[nTracks_] = infoRandom.nXnEnergy(centerIdRandom, TrackDetMatchInfo::EcalRecHits, 1);
+    ecal5x5EnergyMaxRandom_[nTracks_] = infoRandom.nXnEnergy(centerIdRandom, TrackDetMatchInfo::EcalRecHits, 2);
+    trkPosAtEcalRandom_[nTracks_][0] = infoRandom.trkGlobPosAtEcal.eta();
+    trkPosAtEcalRandom_[nTracks_][1] = infoRandom.trkGlobPosAtEcal.phi();
+
+    hcalCrossedEnergy_[nTracks_] = info.hcalEnergy();
+    centerId = info.findMaxDeposition(TrackDetMatchInfo::HcalRecHits);
+    hcal3x3Energy_[nTracks_] = info.nXnEnergy(centerId, TrackDetMatchInfo::HcalRecHits, 1);
+    hcal5x5Energy_[nTracks_] = info.nXnEnergy(centerId, TrackDetMatchInfo::HcalRecHits, 2);
+    hcalTrueEnergy_[nTracks_] = info.hcalTrueEnergy;
+    hcalTrueEnergyCorrected_[nTracks_] = info.hcalTrueEnergyCorrected;
+    trkPosAtHcal_[nTracks_][0] = info.trkGlobPosAtHcal.eta();
+    trkPosAtHcal_[nTracks_][1] = info.trkGlobPosAtHcal.phi();
+    if (geometry->getSubdetectorGeometry(centerId) &&
+        geometry->getSubdetectorGeometry(centerId)->getGeometry(centerId)) {
+      GlobalPoint position = geometry->getSubdetectorGeometry(centerId)->getGeometry(centerId)->getPosition();
+      hcalMaxPos_[nTracks_][0] = position.eta();
+      hcalMaxPos_[nTracks_][1] = position.phi();
+    } else {
+      hcalMaxPos_[nTracks_][0] = -999;
+      hcalMaxPos_[nTracks_][1] = -999;
+    }
+    hcalCrossedEnergyRandom_[nTracks_] = infoRandom.crossedEnergy(TrackDetMatchInfo::HcalRecHits);
+    centerIdRandom = infoRandom.findMaxDeposition(TrackDetMatchInfo::HcalRecHits);
+    hcal3x3EnergyRandom_[nTracks_] = infoRandom.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 1);
+    hcal5x5EnergyRandom_[nTracks_] = infoRandom.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 2);
+    hcal3x3EnergyMaxRandom_[nTracks_] = infoRandom.nXnEnergy(centerIdRandom, TrackDetMatchInfo::HcalRecHits, 1);
+    hcal5x5EnergyMaxRandom_[nTracks_] = infoRandom.nXnEnergy(centerIdRandom, TrackDetMatchInfo::HcalRecHits, 2);
+    trkPosAtHcalRandom_[nTracks_][0] = infoRandom.trkGlobPosAtHcal.eta();
+    trkPosAtHcalRandom_[nTracks_][1] = infoRandom.trkGlobPosAtHcal.phi();
+
+    // Debugging information
+
+    LogTrace("TrackAssociator") << "ECAL, number of crossed cells: " << info.crossedEcalRecHits.size();
+    LogTrace("TrackAssociator") << "ECAL, energy of crossed cells: " << info.ecalEnergy() << " GeV";
+    LogTrace("TrackAssociator") << "ECAL, number of cells in the cone: " << info.ecalRecHits.size();
+    LogTrace("TrackAssociator") << "ECAL, energy in the cone: " << info.ecalConeEnergy() << " GeV";
+    LogTrace("TrackAssociator") << "ECAL, true energy: " << info.ecalTrueEnergy << " GeV";
+    LogTrace("TrackAssociator") << "ECAL, trajectory point (z,R,eta,phi): " << info.trkGlobPosAtEcal.z() << ", "
+                                << info.trkGlobPosAtEcal.R() << " , " << info.trkGlobPosAtEcal.eta() << " , "
+                                << info.trkGlobPosAtEcal.phi();
+
+    LogTrace("TrackAssociator") << "HCAL, number of crossed elements (towers): " << info.crossedTowers.size();
+    LogTrace("TrackAssociator") << "HCAL, energy of crossed elements (towers): " << info.hcalTowerEnergy() << " GeV";
+    LogTrace("TrackAssociator") << "HCAL, number of crossed elements (hits): " << info.crossedHcalRecHits.size();
+    LogTrace("TrackAssociator") << "HCAL, energy of crossed elements (hits): " << info.hcalEnergy() << " GeV";
+    LogTrace("TrackAssociator") << "HCAL, number of elements in the cone (towers): " << info.towers.size();
+    LogTrace("TrackAssociator") << "HCAL, energy in the cone (towers): " << info.hcalTowerConeEnergy() << " GeV";
+    LogTrace("TrackAssociator") << "HCAL, number of elements in the cone (hits): " << info.hcalRecHits.size();
+    LogTrace("TrackAssociator") << "HCAL, energy in the cone (hits): " << info.hcalConeEnergy() << " GeV";
+    LogTrace("TrackAssociator") << "HCAL, true energy: " << info.hcalTrueEnergy << " GeV";
+    LogTrace("TrackAssociator") << "HCAL, true energy corrected: " << info.hcalTrueEnergyCorrected << " GeV";
+    LogTrace("TrackAssociator") << "HCAL, trajectory point (z,R,eta,phi): " << info.trkGlobPosAtHcal.z() << ", "
+                                << info.trkGlobPosAtHcal.R() << " , " << info.trkGlobPosAtHcal.eta() << " , "
+                                << info.trkGlobPosAtHcal.phi();
+
+    LogTrace("TrackAssociator") << "HO, number of crossed elements (hits): " << info.crossedHORecHits.size();
+    LogTrace("TrackAssociator") << "HO, energy of crossed elements (hits): " << info.hoEnergy() << " GeV";
+    LogTrace("TrackAssociator") << "HO, number of elements in the cone: " << info.hoRecHits.size();
+    LogTrace("TrackAssociator") << "HO, energy in the cone: " << info.hoConeEnergy() << " GeV";
+    LogTrace("TrackAssociator") << "HCAL, trajectory point (z,R,eta,phi): " << info.trkGlobPosAtHO.z() << ", "
+                                << info.trkGlobPosAtHO.R() << " , " << info.trkGlobPosAtHO.eta() << " , "
+                                << info.trkGlobPosAtHO.phi();
+    nTracks_++;
+  }
+  tree_->Fill();
 }
 
 //define this as a plug-in

--- a/TrackingTools/TrackAssociator/test/TestTrackAssociator.cc
+++ b/TrackingTools/TrackAssociator/test/TestTrackAssociator.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TrackAssociator
 // Class:      TestTrackAssociator
-// 
+//
 /*
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Fri Apr 21 10:59:41 PDT 2006
 //
 //
-
 
 // system include files
 #include <memory>
@@ -67,7 +66,6 @@
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
@@ -82,232 +80,220 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
 class TestTrackAssociator : public edm::EDAnalyzer {
- public:
-   explicit TestTrackAssociator(const edm::ParameterSet&);
-   virtual ~TestTrackAssociator(){
-   }
-   
-   virtual void analyze (const edm::Event&, const edm::EventSetup&);
+public:
+  explicit TestTrackAssociator(const edm::ParameterSet&);
+  virtual ~TestTrackAssociator() {}
 
- private:
-   TrackDetectorAssociator trackAssociator_;
-   TrackAssociatorParameters parameters_;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+private:
+  TrackDetectorAssociator trackAssociator_;
+  TrackAssociatorParameters parameters_;
 };
 
-TestTrackAssociator::TestTrackAssociator(const edm::ParameterSet& iConfig)
-{
-   // TrackAssociator parameters
-   edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
-   edm::ConsumesCollector iC = consumesCollector();
-   parameters_.loadParameters( parameters, iC );
-   
-   trackAssociator_.useDefaultPropagator();
+TestTrackAssociator::TestTrackAssociator(const edm::ParameterSet& iConfig) {
+  // TrackAssociator parameters
+  edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
+  edm::ConsumesCollector iC = consumesCollector();
+  parameters_.loadParameters(parameters, iC);
+
+  trackAssociator_.useDefaultPropagator();
 }
 
-void TestTrackAssociator::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void TestTrackAssociator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   // get list of tracks and their vertices
-   Handle<reco::MuonCollection> muons;
-   iEvent.getByLabel("muons",muons);
-      
-   // loop 
-   LogVerbatim("TrackAssociator") << "Number of muons found in the event: " << muons->size() ;
-   for(reco::MuonCollection::const_iterator muon = muons->begin(); 
-       muon != muons->end(); ++muon){
-      
-      // skip low Pt tracks
-      if (muon->pt() < 2) {
-	 LogVerbatim("TrackAssociator") << "Skipped low Pt muon (Pt: " << muon->pt() << ")" ;
-	 continue;
+  // get list of tracks and their vertices
+  Handle<reco::MuonCollection> muons;
+  iEvent.getByLabel("muons", muons);
+
+  // loop
+  LogVerbatim("TrackAssociator") << "Number of muons found in the event: " << muons->size();
+  for (reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
+    // skip low Pt tracks
+    if (muon->pt() < 2) {
+      LogVerbatim("TrackAssociator") << "Skipped low Pt muon (Pt: " << muon->pt() << ")";
+      continue;
+    }
+
+    // skip tracks originated away from the IP
+    if (fabs(muon->vertex().rho()) > 50) {
+      LogVerbatim("TrackAssociator") << "Skipped track with large impact parameter: " << muon->vertex().rho();
+      continue;
+    }
+
+    LogVerbatim("TrackAssociator") << "\n-------------------------------------------------------\n Track (pt,eta,phi): "
+                                   << muon->pt() << " , " << muon->eta() << " , " << muon->phi();
+
+    TrackDetMatchInfo info;
+    if (muon->innerTrack().isAvailable())
+      info = trackAssociator_.associate(iEvent, iSetup, *muon->innerTrack(), parameters_);
+    else {
+      if (!muon->outerTrack().isAvailable()) {
+        LogVerbatim("TrackAssociator") << "No refernced tracks are available, skim the muon";
+        continue;
       }
-      
-      // skip tracks originated away from the IP
-      if (fabs(muon->vertex().rho()) > 50) {
-	 LogVerbatim("TrackAssociator") << "Skipped track with large impact parameter: " <<muon->vertex().rho();
-	 continue;
+      info = trackAssociator_.associate(iEvent, iSetup, *muon->outerTrack(), parameters_);
+    }
+
+    LogVerbatim("TrackAssociator") << "===========================================================================";
+    LogVerbatim("TrackAssociator")
+        << "ECAL RecHit energy: crossed, 3x3(max), 5x5(max), 3x3(direction), 5x5(direction), cone R0.5, generator";
+    DetId centerId = info.findMaxDeposition(TrackDetMatchInfo::EcalRecHits);
+    LogVerbatim("TrackAssociator") << "     " << info.crossedEnergy(TrackDetMatchInfo::EcalRecHits) << ", \t"
+                                   << info.nXnEnergy(centerId, TrackDetMatchInfo::EcalRecHits, 1) << ", \t"
+                                   << info.nXnEnergy(centerId, TrackDetMatchInfo::EcalRecHits, 2) << ", \t"
+                                   << info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 1) << ", \t"
+                                   << info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 2) << ", \t"
+                                   << info.coneEnergy(0.5, TrackDetMatchInfo::EcalRecHits) << ", \t"
+                                   << info.ecalTrueEnergy;
+    LogVerbatim("TrackAssociator") << "ECAL trajectory point (z,Rho,eta,phi), max deposit DetId";
+    LogVerbatim("TrackAssociator") << "     "
+                                   << "(" << info.trkGlobPosAtEcal.z() << ", " << info.trkGlobPosAtEcal.Rho() << ", "
+                                   << info.trkGlobPosAtEcal.eta() << ", " << info.trkGlobPosAtEcal.phi() << "), "
+                                   << centerId.rawId();
+    LogVerbatim("TrackAssociator") << "ECAL crossed DetIds with associated hits: (id, energy, z, perp, eta, phi)";
+    for (std::vector<const EcalRecHit*>::const_iterator hit = info.crossedEcalRecHits.begin();
+         hit != info.crossedEcalRecHits.end();
+         ++hit) {
+      GlobalPoint point = info.getPosition((*hit)->detid());
+      LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << " \t("
+                                     << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t"
+                                     << point.phi() << ")";
+    }
+    LogVerbatim("TrackAssociator") << "ECAL crossed DetIds: (id, z, perp, eta, phi)";
+    for (std::vector<DetId>::const_iterator id = info.crossedEcalIds.begin(); id != info.crossedEcalIds.end(); ++id) {
+      GlobalPoint point = info.getPosition(*id);
+      LogVerbatim("TrackAssociator") << "\t" << id->rawId() << " \t(" << point.z() << ", \t" << point.perp() << ", \t"
+                                     << point.eta() << ", \t" << point.phi() << ")";
+    }
+    LogVerbatim("TrackAssociator") << "ECAL associated DetIds: (id, energy, z, perp, eta, phi)";
+    for (std::vector<const EcalRecHit*>::const_iterator hit = info.ecalRecHits.begin(); hit != info.ecalRecHits.end();
+         ++hit) {
+      GlobalPoint point = info.getPosition((*hit)->detid());
+      LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << " \t("
+                                     << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t"
+                                     << point.phi() << ")";
+    }
+    LogVerbatim("TrackAssociator") << "Preshower crossed DetIds: (id, z, perp, eta, phi)";
+    for (std::vector<DetId>::const_iterator id = info.crossedPreshowerIds.begin(); id != info.crossedPreshowerIds.end();
+         ++id) {
+      GlobalPoint point = info.getPosition(*id);
+      LogVerbatim("TrackAssociator") << "\t" << id->rawId() << " \t(" << point.z() << ", \t" << point.perp() << ", \t"
+                                     << point.eta() << ", \t" << point.phi() << ")";
+    }
+
+    LogVerbatim("TrackAssociator") << "---------------------------------------------------------------------------";
+    LogVerbatim("TrackAssociator")
+        << "HCAL RecHit energy: crossed, 3x3(max), 5x5(max), 3x3(direction), 5x5(direction), cone R0.5, generator";
+    centerId = info.findMaxDeposition(TrackDetMatchInfo::HcalRecHits);
+    LogVerbatim("TrackAssociator") << "     " << info.crossedEnergy(TrackDetMatchInfo::HcalRecHits) << ", \t"
+                                   << info.nXnEnergy(centerId, TrackDetMatchInfo::HcalRecHits, 1) << ", \t"
+                                   << info.nXnEnergy(centerId, TrackDetMatchInfo::HcalRecHits, 2) << ", \t"
+                                   << info.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 1) << ", \t"
+                                   << info.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 2) << ", \t"
+                                   << info.coneEnergy(0.5, TrackDetMatchInfo::HcalRecHits) << ", \t"
+                                   << info.hcalTrueEnergyCorrected;
+    LogVerbatim("TrackAssociator") << "HCAL trajectory point (z,Rho,eta,phi), max deposit DetId";
+    LogVerbatim("TrackAssociator") << "     "
+                                   << "(" << info.trkGlobPosAtHcal.z() << ", " << info.trkGlobPosAtHcal.Rho() << ", "
+                                   << info.trkGlobPosAtHcal.eta() << ", " << info.trkGlobPosAtHcal.phi() << "), "
+                                   << centerId.rawId();
+    LogVerbatim("TrackAssociator") << "HCAL crossed DetIds with hits:";
+    for (std::vector<const HBHERecHit*>::const_iterator hit = info.crossedHcalRecHits.begin();
+         hit != info.crossedHcalRecHits.end();
+         ++hit) {
+      GlobalPoint point = info.getPosition((*hit)->detid());
+      LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << " \t("
+                                     << point.z() << ", \t" << point.perp() << ", \t" << (*hit)->id().depth() << ", \t"
+                                     << point.eta() << ", \t" << point.phi() << ")";
+    }
+    LogVerbatim("TrackAssociator") << "HCAL crossed DetIds: (id, z, perp, eta, phi)";
+    for (std::vector<DetId>::const_iterator id = info.crossedHcalIds.begin(); id != info.crossedHcalIds.end(); ++id) {
+      GlobalPoint point = info.getPosition(*id);
+      LogVerbatim("TrackAssociator") << "\t" << id->rawId() << " \t(" << point.z() << ", \t" << point.perp() << ", \t"
+                                     << point.eta() << ", \t" << point.phi() << ")";
+    }
+    LogVerbatim("TrackAssociator") << "HCAL associated DetIds: id, (energy, z, perp, depth, eta, phi)";
+    for (std::vector<const HBHERecHit*>::const_iterator hit = info.hcalRecHits.begin(); hit != info.hcalRecHits.end();
+         ++hit) {
+      GlobalPoint point = info.getPosition((*hit)->detid());
+      LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << " \t("
+                                     << point.z() << ", \t" << point.perp() << ", \t" << (*hit)->id().depth() << ", \t"
+                                     << point.eta() << ", \t" << point.phi() << ")";
+    }
+
+    LogVerbatim("TrackAssociator") << "---------------------------------------------------------------------------";
+    LogVerbatim("TrackAssociator")
+        << "HO RecHit energy: crossed, 3x3(max), 5x5(max), 3x3(direction), 5x5(direction), cone R0.5";
+    centerId = info.findMaxDeposition(TrackDetMatchInfo::HORecHits);
+    LogVerbatim("TrackAssociator") << "     " << info.crossedEnergy(TrackDetMatchInfo::HORecHits) << ", \t"
+                                   << info.nXnEnergy(centerId, TrackDetMatchInfo::HORecHits, 1) << ", \t"
+                                   << info.nXnEnergy(centerId, TrackDetMatchInfo::HORecHits, 2) << ", \t"
+                                   << info.nXnEnergy(TrackDetMatchInfo::HORecHits, 1) << ", \t"
+                                   << info.nXnEnergy(TrackDetMatchInfo::HORecHits, 2) << ", \t"
+                                   << info.coneEnergy(0.5, TrackDetMatchInfo::HORecHits);
+    LogVerbatim("TrackAssociator") << "HO trajectory point (z,Rho,eta,phi), max deposit DetId";
+    LogVerbatim("TrackAssociator") << "     "
+                                   << "(" << info.trkGlobPosAtHO.z() << ", " << info.trkGlobPosAtHO.Rho() << ", "
+                                   << info.trkGlobPosAtHO.eta() << ", " << info.trkGlobPosAtHO.phi() << "), "
+                                   << centerId.rawId();
+    LogVerbatim("TrackAssociator") << "HO crossed DetIds with hits:";
+    for (std::vector<const HORecHit*>::const_iterator hit = info.crossedHORecHits.begin();
+         hit != info.crossedHORecHits.end();
+         ++hit) {
+      GlobalPoint point = info.getPosition((*hit)->detid());
+      LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << " \t("
+                                     << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t"
+                                     << point.phi() << ")";
+    }
+    LogVerbatim("TrackAssociator") << "HO crossed DetIds: (id, z, perp, eta, phi)";
+    for (std::vector<DetId>::const_iterator id = info.crossedHOIds.begin(); id != info.crossedHOIds.end(); ++id) {
+      GlobalPoint point = info.getPosition(*id);
+      LogVerbatim("TrackAssociator") << "\t" << id->rawId() << " \t(" << point.z() << ", \t" << point.perp() << ", \t"
+                                     << point.eta() << ", \t" << point.phi() << ")";
+    }
+    LogVerbatim("TrackAssociator") << "HO associated DetIds: (id, energy,position)";
+    for (std::vector<const HORecHit*>::const_iterator hit = info.hoRecHits.begin(); hit != info.hoRecHits.end();
+         ++hit) {
+      GlobalPoint point = info.getPosition((*hit)->detid());
+      LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << " \t("
+                                     << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t"
+                                     << point.phi();
+      // << ") ## " << info.dumpGeometry((*hit)->detid());
+    }
+
+    if (parameters_.useMuon) {
+      LogVerbatim("TrackAssociator") << "Muon detector matching details: ";
+      for (std::vector<TAMuonChamberMatch>::const_iterator chamber = info.chambers.begin();
+           chamber != info.chambers.end();
+           chamber++) {
+        LogVerbatim("TrackAssociator") << chamber->info()
+                                       << "\n\t(DetId, station, edgeX, edgeY): " << chamber->id.rawId() << ", "
+                                       << chamber->station() << ", " << chamber->localDistanceX << ", "
+                                       << chamber->localDistanceY << ", ";
+        LogVerbatim("TrackAssociator") << "\t trajectory global point (z,perp,eta,phi): "
+                                       << chamber->tState.globalPosition().z() << ", "
+                                       << chamber->tState.globalPosition().perp() << ", "
+                                       << chamber->tState.globalPosition().eta() << ", "
+                                       << chamber->tState.globalPosition().phi();
+        LogVerbatim("TrackAssociator") << "\t trajectory local point (x,y): " << chamber->tState.localPosition().x()
+                                       << ", " << chamber->tState.localPosition().y();
+
+        for (std::vector<TAMuonSegmentMatch>::const_iterator segment = chamber->segments.begin();
+             segment != chamber->segments.end();
+             segment++) {
+          LogVerbatim("TrackAssociator") << "\t segment position (z,Rho,eta,phi,DetId): "
+                                         << segment->segmentGlobalPosition.z() << ", "
+                                         << segment->segmentGlobalPosition.Rho() << ", "
+                                         << segment->segmentGlobalPosition.eta() << ", "
+                                         << segment->segmentGlobalPosition.phi() << ", " << chamber->id.rawId();
+          LogVerbatim("TrackAssociator") << "\t segment local position (x,y): " << segment->segmentLocalPosition.x()
+                                         << ", " << segment->segmentLocalPosition.y();
+        }
       }
-      
-      LogVerbatim("TrackAssociator") << "\n-------------------------------------------------------\n Track (pt,eta,phi): " 
-	<< muon->pt() << " , " << muon->eta() << " , " << muon->phi() ;
-      
-      TrackDetMatchInfo info;
-      if (muon->innerTrack().isAvailable()) 
-	info = trackAssociator_.associate(iEvent, iSetup, *muon->innerTrack(), parameters_);
-      else {
-	 if (!muon->outerTrack().isAvailable()) {
-	    LogVerbatim("TrackAssociator") << "No refernced tracks are available, skim the muon";
-	    continue;
-	 }
-	 info = trackAssociator_.associate(iEvent, iSetup, *muon->outerTrack(), parameters_);
-      }
-	   
-      LogVerbatim("TrackAssociator") << "===========================================================================" ;
-      LogVerbatim("TrackAssociator") << "ECAL RecHit energy: crossed, 3x3(max), 5x5(max), 3x3(direction), 5x5(direction), cone R0.5, generator";
-      DetId centerId = info.findMaxDeposition(TrackDetMatchInfo::EcalRecHits);
-      LogVerbatim("TrackAssociator") << "     " << 
-	info.crossedEnergy(TrackDetMatchInfo::EcalRecHits) << ", \t" <<
-	info.nXnEnergy(centerId, TrackDetMatchInfo::EcalRecHits, 1) << ", \t" <<
-	info.nXnEnergy(centerId, TrackDetMatchInfo::EcalRecHits, 2) << ", \t" <<
-	info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 1) << ", \t" <<
-	info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 2) << ", \t" <<
-	info.coneEnergy(0.5, TrackDetMatchInfo::EcalRecHits) << ", \t" <<
-	info.ecalTrueEnergy;
-      LogVerbatim("TrackAssociator") << "ECAL trajectory point (z,Rho,eta,phi), max deposit DetId";
-      LogVerbatim("TrackAssociator") << "     " <<
-	"(" << info.trkGlobPosAtEcal.z() << ", " << info.trkGlobPosAtEcal.Rho() << ", " <<
-	info.trkGlobPosAtEcal.eta() << ", " << info.trkGlobPosAtEcal.phi() << "), " << centerId.rawId();
-      LogVerbatim("TrackAssociator") << "ECAL crossed DetIds with associated hits: (id, energy, z, perp, eta, phi)";
-      for(std::vector<const EcalRecHit*>::const_iterator hit = info.crossedEcalRecHits.begin(); 
-	  hit != info.crossedEcalRecHits.end(); ++hit)
-	{
-	   GlobalPoint point = info.getPosition((*hit)->detid());
-	   LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << 
-	     " \t(" << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t" << point.phi() << ")";
-	}
-      LogVerbatim("TrackAssociator") << "ECAL crossed DetIds: (id, z, perp, eta, phi)";
-      for(std::vector<DetId>::const_iterator id = info.crossedEcalIds.begin(); 
-	  id != info.crossedEcalIds.end(); ++id)
-	{
-	   GlobalPoint point = info.getPosition(*id);
-	   LogVerbatim("TrackAssociator") << "\t" << id->rawId() << 
-	     " \t(" << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t" << point.phi() << ")";
-	}
-      LogVerbatim("TrackAssociator") << "ECAL associated DetIds: (id, energy, z, perp, eta, phi)";
-      for(std::vector<const EcalRecHit*>::const_iterator hit = info.ecalRecHits.begin(); 
-	  hit != info.ecalRecHits.end(); ++hit)
-	{
-	   GlobalPoint point = info.getPosition((*hit)->detid());
-	   LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << 
-	     " \t(" << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t" << point.phi() << ")";
-	}
-      LogVerbatim("TrackAssociator") << "Preshower crossed DetIds: (id, z, perp, eta, phi)";
-      for(std::vector<DetId>::const_iterator id = info.crossedPreshowerIds.begin(); 
-	  id != info.crossedPreshowerIds.end(); ++id)
-	{
-	   GlobalPoint point = info.getPosition(*id);
-	   LogVerbatim("TrackAssociator") << "\t" << id->rawId() << 
-	     " \t(" << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t" << point.phi() << ")";
-	}
-
-      LogVerbatim("TrackAssociator") << "---------------------------------------------------------------------------" ;
-      LogVerbatim("TrackAssociator") << "HCAL RecHit energy: crossed, 3x3(max), 5x5(max), 3x3(direction), 5x5(direction), cone R0.5, generator";
-      centerId = info.findMaxDeposition(TrackDetMatchInfo::HcalRecHits);
-      LogVerbatim("TrackAssociator") << "     " << 
-	info.crossedEnergy(TrackDetMatchInfo::HcalRecHits) << ", \t" <<
-	info.nXnEnergy(centerId, TrackDetMatchInfo::HcalRecHits, 1) << ", \t" <<
-	info.nXnEnergy(centerId, TrackDetMatchInfo::HcalRecHits, 2) << ", \t" <<
-	info.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 1) << ", \t" <<
-	info.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 2) << ", \t" <<
-	info.coneEnergy(0.5, TrackDetMatchInfo::HcalRecHits) << ", \t" <<
-	info.hcalTrueEnergyCorrected;
-      LogVerbatim("TrackAssociator") << "HCAL trajectory point (z,Rho,eta,phi), max deposit DetId";
-      LogVerbatim("TrackAssociator") << "     " <<
-	"(" << info.trkGlobPosAtHcal.z() << ", " << info.trkGlobPosAtHcal.Rho() << ", " <<
-	info.trkGlobPosAtHcal.eta() << ", " << info.trkGlobPosAtHcal.phi() << "), " << centerId.rawId();
-      LogVerbatim("TrackAssociator") << "HCAL crossed DetIds with hits:";
-      for(std::vector<const HBHERecHit*>::const_iterator hit = info.crossedHcalRecHits.begin(); 
-	  hit != info.crossedHcalRecHits.end(); ++hit)
-	{
-	   GlobalPoint point = info.getPosition((*hit)->detid());
-	   LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << 
-	     " \t(" << point.z() << ", \t" << point.perp() << ", \t" << (*hit)->id().depth() << ", \t" << 
-	     point.eta() << ", \t" << point.phi() << ")";
-	}
-      LogVerbatim("TrackAssociator") << "HCAL crossed DetIds: (id, z, perp, eta, phi)";
-      for(std::vector<DetId>::const_iterator id = info.crossedHcalIds.begin(); 
-	  id != info.crossedHcalIds.end(); ++id)
-	{
-	   GlobalPoint point = info.getPosition(*id);
-	   LogVerbatim("TrackAssociator") << "\t" << id->rawId() << 
-	     " \t(" << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t" << point.phi() << ")";
-	}
-      LogVerbatim("TrackAssociator") << "HCAL associated DetIds: id, (energy, z, perp, depth, eta, phi)";
-      for(std::vector<const HBHERecHit*>::const_iterator hit = info.hcalRecHits.begin(); 
-	  hit != info.hcalRecHits.end(); ++hit)
-	{
-	   GlobalPoint point = info.getPosition((*hit)->detid());
-	   LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << 
-	     " \t(" << point.z() << ", \t" << point.perp() << ", \t" << (*hit)->id().depth() << ", \t" << 
-	     point.eta() << ", \t" << point.phi() << ")";
-	}
-
-      LogVerbatim("TrackAssociator") << "---------------------------------------------------------------------------" ;
-      LogVerbatim("TrackAssociator") << "HO RecHit energy: crossed, 3x3(max), 5x5(max), 3x3(direction), 5x5(direction), cone R0.5";
-      centerId = info.findMaxDeposition(TrackDetMatchInfo::HORecHits);
-      LogVerbatim("TrackAssociator") << "     " << 
-	info.crossedEnergy(TrackDetMatchInfo::HORecHits) << ", \t" <<
-	info.nXnEnergy(centerId, TrackDetMatchInfo::HORecHits, 1) << ", \t" <<
-	info.nXnEnergy(centerId, TrackDetMatchInfo::HORecHits, 2) << ", \t" <<
-	info.nXnEnergy(TrackDetMatchInfo::HORecHits, 1) << ", \t" <<
-	info.nXnEnergy(TrackDetMatchInfo::HORecHits, 2) << ", \t" <<
-	info.coneEnergy(0.5, TrackDetMatchInfo::HORecHits);
-      LogVerbatim("TrackAssociator") << "HO trajectory point (z,Rho,eta,phi), max deposit DetId";
-      LogVerbatim("TrackAssociator") << "     " <<
-	"(" << info.trkGlobPosAtHO.z() << ", " << info.trkGlobPosAtHO.Rho() << ", " <<
-	info.trkGlobPosAtHO.eta() << ", " << info.trkGlobPosAtHO.phi() << "), " << centerId.rawId();
-      LogVerbatim("TrackAssociator") << "HO crossed DetIds with hits:";
-      for(std::vector<const HORecHit*>::const_iterator hit = info.crossedHORecHits.begin(); 
-	  hit != info.crossedHORecHits.end(); ++hit)
-	{
-	   GlobalPoint point = info.getPosition((*hit)->detid());
-	   LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << 
-	     " \t(" << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t" << point.phi() << ")";
-	}
-      LogVerbatim("TrackAssociator") << "HO crossed DetIds: (id, z, perp, eta, phi)";
-      for(std::vector<DetId>::const_iterator id = info.crossedHOIds.begin(); 
-	  id != info.crossedHOIds.end(); ++id)
-	{
-	   GlobalPoint point = info.getPosition(*id);
-	   LogVerbatim("TrackAssociator") << "\t" << id->rawId() << 
-	     " \t(" << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t" << point.phi() << ")";
-	}
-      LogVerbatim("TrackAssociator") << "HO associated DetIds: (id, energy,position)";
-      for(std::vector<const HORecHit*>::const_iterator hit = info.hoRecHits.begin(); 
-	  hit != info.hoRecHits.end(); ++hit)
-	{
-	   GlobalPoint point = info.getPosition((*hit)->detid());
-	   LogVerbatim("TrackAssociator") << "\t" << (*hit)->detid().rawId() << ", " << (*hit)->energy() << 
-	     " \t(" << point.z() << ", \t" << point.perp() << ", \t" << point.eta() << ", \t" << point.phi();
-	       // << ") ## " << info.dumpGeometry((*hit)->detid());
-	}
-
-      if (parameters_.useMuon) {
-	 LogVerbatim("TrackAssociator") << "Muon detector matching details: " ;
-	 for(std::vector<TAMuonChamberMatch>::const_iterator chamber = info.chambers.begin();
-	     chamber!=info.chambers.end(); chamber++)
-	   {
-	      LogVerbatim("TrackAssociator") << chamber->info() << "\n\t(DetId, station, edgeX, edgeY): "
-		<< chamber->id.rawId() << ", "
-		<< chamber->station() << ", "
-		<< chamber->localDistanceX << ", "
-		<< chamber->localDistanceY << ", ";
-	      LogVerbatim("TrackAssociator") << "\t trajectory global point (z,perp,eta,phi): "
-		<< chamber->tState.globalPosition().z() << ", "
-		<< chamber->tState.globalPosition().perp() << ", "
-		<< chamber->tState.globalPosition().eta() << ", "
-		<< chamber->tState.globalPosition().phi() ;
-	      LogVerbatim("TrackAssociator") << "\t trajectory local point (x,y): "
-		<< chamber->tState.localPosition().x() << ", "
-		<< chamber->tState.localPosition().y();
-
-	      for(std::vector<TAMuonSegmentMatch>::const_iterator segment=chamber->segments.begin(); 
-		  segment!=chamber->segments.end(); segment++)
-		{
-		   LogVerbatim("TrackAssociator") << "\t segment position (z,Rho,eta,phi,DetId): " 
-		     << segment->segmentGlobalPosition.z() << ", "
-		     << segment->segmentGlobalPosition.Rho() << ", "
-		     << segment->segmentGlobalPosition.eta() << ", "
-		     << segment->segmentGlobalPosition.phi() << ", "
-		     << chamber->id.rawId();
-		   LogVerbatim("TrackAssociator") << "\t segment local position (x,y): "
-		     << segment->segmentLocalPosition.x() << ", "
-		     << segment->segmentLocalPosition.y();
-		}
-	   }
-      }
-   }
+    }
+  }
 }
 
 //define this as a plug-in


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/392//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


