### PR TITLE
Reco vertex adjustments

### DIFF
--- a/RecoVertex/NuclearInteractionProducer/src/NuclearLikelihood.cc
+++ b/RecoVertex/NuclearInteractionProducer/src/NuclearLikelihood.cc
@@ -4,15 +4,16 @@ void NuclearLikelihood::calculate(const reco::Vertex& vtx) {
   likelihood_ = 0.0;
   if (vtx.isValid()) {
     if (vtx.tracksSize() > 1) {
-      likelihood_ = 0.3;
-      int idBest;
+      int idBest = 0;
       int secMaxHits = secondaryTrackMaxHits(vtx, idBest);
-      if (secMaxHits > 3)
-        likelihood_ = 0.5;
-      if (secMaxHits > 4)
-        likelihood_ = 0.7;
       if ((*(vtx.tracks_begin() + idBest))->normalizedChi2() < 3.0)
         likelihood_ = 1.0;
+      else if (secMaxHits > 4)
+        likelihood_ = 0.7;
+      else if (secMaxHits > 3)
+        likelihood_ = 0.5;
+      else
+        likelihood_ = 0.3;
     }
   }
 }

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -175,7 +175,7 @@ void V0Fitter::fitAll(const edm::Event& iEvent,
 
       // the POCA should at least be in the sensitive volume
       GlobalPoint cxPt = cApp.crossingPoint();
-      if ( (cxPt.x() * cxPt.x() + cxPt.y() * cxPt.y()) > 120.*120. || std::abs(cxPt.z()) > 300.)
+      if ((cxPt.x() * cxPt.x() + cxPt.y() * cxPt.y()) > 120. * 120. || std::abs(cxPt.z()) > 300.)
         continue;
 
       // the tracks should at least point in the same quadrant
@@ -239,8 +239,8 @@ void V0Fitter::fitAll(const edm::Event& iEvent,
       }
 
       // make sure the vertex radius is within the inner track hit radius
-      double tkHitPosLimitSquared = (distMagXY - sigmaDistMagXY * innerHitPosCut_)
-	                          * (distMagXY - sigmaDistMagXY * innerHitPosCut_);
+      double tkHitPosLimitSquared =
+          (distMagXY - sigmaDistMagXY * innerHitPosCut_) * (distMagXY - sigmaDistMagXY * innerHitPosCut_);
       if (innerHitPosCut_ > 0. && positiveTrackRef->innerOk()) {
         reco::Vertex::Point posTkHitPos = positiveTrackRef->innerPosition();
         double posTkHitPosD2 = (posTkHitPos.x() - referencePos.x()) * (posTkHitPos.x() - referencePos.x()) +

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -175,7 +175,7 @@ void V0Fitter::fitAll(const edm::Event& iEvent,
 
       // the POCA should at least be in the sensitive volume
       GlobalPoint cxPt = cApp.crossingPoint();
-      if (sqrt(cxPt.x() * cxPt.x() + cxPt.y() * cxPt.y()) > 120. || std::abs(cxPt.z()) > 300.)
+      if ( (cxPt.x() * cxPt.x() + cxPt.y() * cxPt.y()) > 120.*120. || std::abs(cxPt.z()) > 300.)
         continue;
 
       // the tracks should at least point in the same quadrant
@@ -190,8 +190,8 @@ void V0Fitter::fitAll(const edm::Event& iEvent,
       double totalE = sqrt(posTSCP.momentum().mag2() + piMassSquared) + sqrt(negTSCP.momentum().mag2() + piMassSquared);
       double totalESq = totalE * totalE;
       double totalPSq = (posTSCP.momentum() + negTSCP.momentum()).mag2();
-      double mass = sqrt(totalESq - totalPSq);
-      if (mass > mPiPiCut_)
+      double massSquared = totalESq - totalPSq;
+      if (massSquared > mPiPiCut_ * mPiPiCut_)
         continue;
 
       // Fill the vector of TransientTracks to send to KVF
@@ -239,18 +239,20 @@ void V0Fitter::fitAll(const edm::Event& iEvent,
       }
 
       // make sure the vertex radius is within the inner track hit radius
+      double tkHitPosLimitSquared = (distMagXY - sigmaDistMagXY * innerHitPosCut_)
+	                          * (distMagXY - sigmaDistMagXY * innerHitPosCut_);
       if (innerHitPosCut_ > 0. && positiveTrackRef->innerOk()) {
         reco::Vertex::Point posTkHitPos = positiveTrackRef->innerPosition();
         double posTkHitPosD2 = (posTkHitPos.x() - referencePos.x()) * (posTkHitPos.x() - referencePos.x()) +
                                (posTkHitPos.y() - referencePos.y()) * (posTkHitPos.y() - referencePos.y());
-        if (sqrt(posTkHitPosD2) < (distMagXY - sigmaDistMagXY * innerHitPosCut_))
+        if (posTkHitPosD2 < tkHitPosLimitSquared)
           continue;
       }
       if (innerHitPosCut_ > 0. && negativeTrackRef->innerOk()) {
         reco::Vertex::Point negTkHitPos = negativeTrackRef->innerPosition();
         double negTkHitPosD2 = (negTkHitPos.x() - referencePos.x()) * (negTkHitPos.x() - referencePos.x()) +
                                (negTkHitPos.y() - referencePos.y()) * (negTkHitPos.y() - referencePos.y());
-        if (sqrt(negTkHitPosD2) < (distMagXY - sigmaDistMagXY * innerHitPosCut_))
+        if (negTkHitPosD2 < tkHitPosLimitSquared)
           continue;
       }
 


### PR DESCRIPTION
#### PR description:

Starting from the inspection of some static analyzer warning message, the following adjustments are proposed for two files in RecoVertex:

-  RecoVertex/NuclearInteractionProducer/src/NuclearLikelihood.cc
   - Do not let undefined idBest even if no secondary track is found in 

- RecoVertex/V0Producer/src/V0Fitter.cc
  - Avoid non necessary calculations of sqrt

#### PR validation:

It compiles
No changes expected in output