### PR TITLE
deep copy to avoid modifying original values

### DIFF
--- a/FWCore/PythonUtilities/python/LumiList.py
+++ b/FWCore/PythonUtilities/python/LumiList.py
@@ -162,7 +162,7 @@ class LumiList(object):
 
 
             if lumiList:
-                unique = [lumiList[0]]
+                unique = [copy.deepcopy(lumiList[0])]
             for pair in lumiList[1:]:
                 if pair[0] == unique[-1][1]+1:
                     unique[-1][1] = copy.deepcopy(pair[1])
@@ -180,7 +180,7 @@ class LumiList(object):
         runs = set(aruns + bruns)
         for run in runs:
             overlap = sorted(self.compactList.get(run, []) + other.compactList.get(run, []))
-            unique = [overlap[0]]
+            unique = [copy.deepcopy(overlap[0])]
             for pair in overlap[1:]:
                 if pair[0] >= unique[-1][0] and pair[0] <= unique[-1][1]+1 and pair[1] > unique[-1][1]:
                     unique[-1][1] = copy.deepcopy(pair[1])


### PR DESCRIPTION
#### PR description:

make a deep copy of the list to avoid modifying the inputs.

#### PR validation:

checked that
```
a = LumiList(runsAndLumis={'1': range(1, 6)})
b = LumiList(runsAndLumis={'1': range(1, 20)})
r = a | b
```
no longer modifies `a`

#### if this PR is a backport please specify the original PR:

not a backport