### PR TITLE
update Pixel digitizer thresholds for Run3

### DIFF
--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -38,6 +38,13 @@ def _modifyPixelDigitizerForPhase1Pixel( digitizer ) :
     digitizer.UseReweighting = cms.bool(True)
     digitizer.KillBadFEDChannels = cms.bool(True)
 
+def _modifyPixelDigitizerForRun3( digitizer ):
+
+    digitizer.ThresholdInElectrons_FPix = cms.double(1600.0)
+    digitizer.ThresholdInElectrons_BPix = cms.double(1600.0)
+    digitizer.ThresholdInElectrons_BPix_L1 = cms.double(1300.0)
+    digitizer.ThresholdInElectrons_BPix_L2 = cms.double(1600.0)
+
 SiPixelSimBlock = cms.PSet(
     SiPixelQualityLabel = cms.string(''),
     KillBadFEDChannels = cms.bool(False),
@@ -109,6 +116,13 @@ from CalibTracker.SiPixelESProducers.SiPixelQualityESProducer_cfi import siPixel
 from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
 run2_SiPixel_2018.toModify(siPixelQualityESProducer,siPixelQualityLabel = 'forDigitizer',)
 run2_SiPixel_2018.toModify(SiPixelSimBlock, SiPixelQualityLabel = 'forDigitizer',)
+
+# change the digitizer threshold for Run3
+# - new layer1 installed: expected improvement in timing alignment of L1 and L2
+# - update the rest of the detector to 1600e 
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(SiPixelSimBlock, func=_modifyPixelDigitizerForRun3)
 
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 premix_stage1.toModify(SiPixelSimBlock,


### PR DESCRIPTION
#### PR description:

Phase1 Pixel digitization thresholds for Run 3 era are modified to match the expected behavior during LHC Run3.
This PR contains:
   * updated BPix L1 thresholds: decrease from 3000 to 1300 electrons
   * updated BPix L2 thresholds: decrease from 2600 to 1600 electrons
   * updated BPix L3/L4 thresholds: decrease from 2000 to 1600 electrons
   * updated FPix thresholds: decrease from 2000 to 1600 electrons

This PR de facto undoes the worsening of the resolution introduced in PR https://github.com/cms-sw/cmssw/pull/20775 where thresholds were increased to match the prelminiary resolution measurements in 2017 data.
We do expect an improvement for the BPix L1 and L2 thresholds from the better timing alignment of the two layers readouts with the installation of the new BPix L1 over LS2.
The expected impact on physics will be a slight improvement of pixel related tracking quantities.

#### PR validation:

Code compiles and the dumping of cmsDriver output configuration confirms the desired thresholds are assigned. 
There is not yet a physics output based validation (in progress), that is why this PR is proposed as draft. We will make it regular once the comparisons are available.

#### if this PR is a backport please specify the original PR:

This is not a backport

cc: @tsusa @tvami @leaca