### PR TITLE
zeroing PF clustering uncertainty

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -56,6 +56,7 @@ private:
   bool srfAwareCorrection_;
   bool applyCrackCorrections_;
   bool applyMVACorrections_;
+  bool setEnergyUncertainty_;
 
   bool autoDetectBunchSpacing_;
   int bunchSpacingManual_;

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -131,7 +131,7 @@ void CorrectedECALPFClusterProducer::fillDescriptions(edm::ConfigurationDescript
     psd0.add<bool>("applyCrackCorrections", false);
     psd0.add<bool>("applyMVACorrections", false);
     psd0.add<bool>("srfAwareCorrection", false);
-    psd0.add<bool>("srfAwareCorrection",false);
+    psd0.add<bool>("setEnergyUncertainty",false);
     psd0.add<bool>("autoDetectBunchSpacing", true);
     psd0.add<int>("bunchSpacing", 25);
     psd0.add<double>("maxPtForMVAEvaluation", -99.);

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -131,6 +131,7 @@ void CorrectedECALPFClusterProducer::fillDescriptions(edm::ConfigurationDescript
     psd0.add<bool>("applyCrackCorrections", false);
     psd0.add<bool>("applyMVACorrections", false);
     psd0.add<bool>("srfAwareCorrection", false);
+    psd0.add<bool>("srfAwareCorrection",false);
     psd0.add<bool>("autoDetectBunchSpacing", true);
     psd0.add<int>("bunchSpacing", 25);
     psd0.add<double>("maxPtForMVAEvaluation", -99.);

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -11,12 +11,13 @@ namespace {
   double getScale(const double lo, const double hi) { return 0.5 * (hi - lo); }
 }  // namespace
 
+
 PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet &conf, edm::ConsumesCollector &&cc)
     : calibrator_(new PFEnergyCalibration) {
   applyCrackCorrections_ = conf.getParameter<bool>("applyCrackCorrections");
   applyMVACorrections_ = conf.getParameter<bool>("applyMVACorrections");
   srfAwareCorrection_ = conf.getParameter<bool>("srfAwareCorrection");
-
+  setEnergyUncertainty_ = conf.getParameter<bool>("setEnergyUncertainty");
   maxPtForMVAEvaluation_ = conf.getParameter<double>("maxPtForMVAEvaluation");
 
   if (applyMVACorrections_) {
@@ -244,7 +245,8 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
       double sigmacor = sigma * ecor;
 
       cluster.setCorrectedEnergy(ecor);
-      cluster.setCorrectedEnergyUncertainty(sigmacor);
+      if(setEnergyUncertainty_) cluster.setCorrectedEnergyUncertainty(sigmacor);
+      else cluster.setCorrectedEnergyUncertainty(0.);
     }
     return;
   }
@@ -412,7 +414,8 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
         << "response : correction = " << exp(mean) << " " << ecor;
 
     cluster.setCorrectedEnergy(ecor);
-    cluster.setCorrectedEnergyUncertainty(sigmacor);
+    if(setEnergyUncertainty_) cluster.setCorrectedEnergyUncertainty(sigmacor);
+    else cluster.setCorrectedEnergyUncertainty(0.);
   }
 }
 


### PR DESCRIPTION
#### PR description:

This PR zeros out the PF cluster uncertainty by default as discussed in the PPD general meeting last week. This because those values are not used anywhere, do not really make sense and will for the 2017UL be inaccurate in the endcap.

This is a super minor thing and should not hold anything. If it gets in it gets in, if it doesnt , it doesnt. 

