### PR TITLE
Activate IrradiationBiasCorrection in Pixel CPE generic for Run3

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,9 +66,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v3', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v7', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_Candidate_2019_06_17_18_50_50', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v2',
+    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_Candidate_2019_06_17_19_08_59',
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '106X_upgrade2023_realistic_v5'
 }

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -62,7 +62,7 @@ PixelCPEGenericESProducer = cms.ESProducer("PixelCPEGenericESProducer",
 # This customizes the Run3 Pixel CPE generic reconstruction in order to activate the IrradiationBiasCorrection
 # because of the expected resolution loss due to radiation damage
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = cms.bool(True))
+run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = True)
 
 # This customization will be removed once we get the templates for phase2 pixel
 # FIXME::Is the Upgrade variable actually used?
@@ -76,5 +76,3 @@ phase2_tracker.toModify(PixelCPEGenericESProducer,
   DoCosmics = False,
   Upgrade = cms.bool(True)
 )
-
-

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -59,6 +59,11 @@ PixelCPEGenericESProducer = cms.ESProducer("PixelCPEGenericESProducer",
     MagneticFieldRecord = cms.ESInputTag(""),
 )
 
+# This customizes the Run3 Pixel CPE generic reconstruction in order to activate the IrradiationBiasCorrection
+# because of the expected resolution loss due to radiation damage
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = cms.bool(True))
+
 # This customization will be removed once we get the templates for phase2 pixel
 # FIXME::Is the Upgrade variable actually used?
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
@@ -71,4 +76,5 @@ phase2_tracker.toModify(PixelCPEGenericESProducer,
   DoCosmics = False,
   Upgrade = cms.bool(True)
 )
+
 


### PR DESCRIPTION
#### PR description:

In this PR the `IrradiationBiasCorrection` parameter for the Pixel CPE Generic algorithm is activated for the Run 3 era. 
The motivation for activating the correction is due to the expected comparatively large loss of resolution along the local y [global-z in barrel] direction for an heavily irradiated detector (as expected for the end of run3 and extended end or run3 simulation scenarios), in which carrier trapping significantly reduces Lorentz drift induced charge sharing.
As shown in [this presentation](https://indico.cern.ch/event/808415/contributions/3447906/attachments/1853234/3043117/Run3_Template_Update.pdf), without this correction most clusters are reconstructed at ±100-200μm from true y, caused by charge loss from the backplane side.

As pointed out in the review (see https://github.com/cms-sw/cmssw/pull/27183#issuecomment-502780836) the Pixel CPE conditions need to be updated to take into account the parameter is switched on. 
The `phase1_2021_realistic` and `phase1_2021_cosmics` are updated accordingly.
The diff of the two Global Tags is the following:
```bash
$ conddb diff 106X_upgrade2021_realistic_Candidate_2019_06_17_18_50_50 106X_upgrade2021_realistic_v5
[2019-06-17 21:26:38,571] INFO: Connecting to pro [frontier://PromptProd/CMS_CONDITIONS]
Record                        Label        pro::106X_upgrade2021_realistic_Candidate_2019_06_17_18_50_50 Tag  pro::106X_upgrade2021_realistic_v5 Tag                          
----------------------------  -----------  -----------------------------------------------------------------  --------------------------------------------------------------  
SiPixel2DTemplateDBObjectRcd  denominator  SiPixel2DTemplateDBObject_phase1_BoR3_HV350_Tr1300_den             SiPixel2DTemplateDBObject_phase1_38T_mc_v4_den_unirradiated     
SiPixel2DTemplateDBObjectRcd  numerator    SiPixel2DTemplateDBObject_phase1_BoR3_HV350_Tr1300_num             SiPixel2DTemplateDBObject_phase1_38T_2018_ultralegacymc_v1_num  
SiPixelGenErrorDBObjectRcd    -            SiPixelGenErrorDBObject_phase1_BoR3_HV350_Tr1300                   SiPixelGenErrorDBObject_phase1_38T_2018_ultralegacymc_v1        
SiPixelLorentzAngleRcd        -            SiPixelLorentzAngle_phase1_BoR3_HV350_Tr1300                       SiPixelLorentzAngle_phase1_2018_ultralegacymc_v1                
SiPixelLorentzAngleSimRcd     -            SiPixelLorentzAngleSim_phase1_BoR3_HV350_Tr1300                    SiPixelLorentzAngleSim_phase1_mc_v4                             
SiPixelTemplateDBObjectRcd    -            SiPixelTemplateDBObject_phase1_BoR3_HV350_Tr1300                   SiPixelTemplateDBObject_phase1_38T_2018_ultralegacymc_v1      
```
```bash
$ conddb diff 106X_upgrade2021cosmics_realistic_deco_Candidate_2019_06_17_19_08_59 106X_upgrade2021cosmics_realistic_deco_v2[2019-06-17 21:27:39,951] INFO: Connecting to pro [frontier://PromptProd/CMS_CONDITIONS]
Record                        Label        pro::106X_upgrade2021cosmics_realistic_deco_Candidate_2019_06_17_19_08_59 Tag  pro::106X_upgrade2021cosmics_realistic_deco_v2 Tag              
----------------------------  -----------  -----------------------------------------------------------------------------  --------------------------------------------------------------  
SiPixel2DTemplateDBObjectRcd  denominator  SiPixel2DTemplateDBObject_phase1_BoR3_HV350_Tr1300_den                         SiPixel2DTemplateDBObject_phase1_38T_mc_v4_den_unirradiated     
SiPixel2DTemplateDBObjectRcd  numerator    SiPixel2DTemplateDBObject_phase1_BoR3_HV350_Tr1300_num                         SiPixel2DTemplateDBObject_phase1_38T_2018_ultralegacymc_v1_num  
SiPixelGenErrorDBObjectRcd    -            SiPixelGenErrorDBObject_phase1_BoR3_HV350_Tr1300                               SiPixelGenErrorDBObject_phase1_38T_2018_ultralegacymc_v1        
SiPixelLorentzAngleRcd        -            SiPixelLorentzAngle_phase1_BoR3_HV350_Tr1300                                   SiPixelLorentzAngle_phase1_2018_ultralegacymc_v1                
SiPixelLorentzAngleSimRcd     -            SiPixelLorentzAngleSim_phase1_BoR3_HV350_Tr1300                                SiPixelLorentzAngleSim_phase1_mc_v4                             
SiPixelTemplateDBObjectRcd    -            SiPixelTemplateDBObject_phase1_BoR3_HV350_Tr1300                               SiPixelTemplateDBObject_phase1_38T_2018_ultralegacymc_v1   
```


#### PR validation:
Code compiles and the dumping of cmsDriver output configuration confirms the desired parameter value is assigned.
The activation of the parameter has been tested (together with the changes proposed in #27181) with:
```
cmsDriver.py -s GEN,SIM,DIGI,L1,DIGI2RAW,RAW2DIGI,RECO --evt_type SingleMuPt10_pythia8_cfi --fileout file:GENSIMRECO_MuPt10.root --python_filename=Run3_2023_generic_noIBC.py -n 10 --no_exec --era Run3 --beamspot Run3RoundOptics25ns13TeVHighSigmaZ --nThreads=4 —customise_commands="process.mix.digitizers.pixel.ThresholdInElectrons_BPix_L1 = cms.double(1300.0);  process.mix.digitizers.pixel.ThresholdInElectrons_BPix_L2 = cms.double(1600.0);process.mix.digitizers.pixel.ThresholdInElectrons_BPix = cms.double(1600.0); process.mix.digitizers.pixel.ThresholdInElectrons_FPix = cms.double(1600.0);process.PixelCPEGenericESProducer.IrradiationBiasCorrection = True”   --conditions 106X_mcRun3_2023_realistic_Candidate_2019_06_07_21_52_54 
```
~~There is not yet a physics output based validation (in progress), We will update the description once comparisons are available.~~
Physics validation has been shown in this presentation at the RECO / AT meeting of  14 Jun 2019 [link](https://indico.cern.ch/event/827369/contributions/3467663/attachments/1862678/3061762/tanjaReco_14062019.pdf).

#### if this PR is a backport please specify the original PR:

This PR is not a backport

cc: @tsusa @tvami @leaca @pmaksim1 @cmantill @OzAmram 