### PR TITLE
Remove redundant unique_ptr constructor calls from AlCa

### DIFF
--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -204,9 +204,6 @@ private:
   /// Takes over ownership of AlignmentSurfaceDeformations.
   void writeDB(AlignmentSurfaceDeformations*, const std::string&, cond::Time_t) const;
 
-  template <typename T>
-  bool hasParameter(const edm::ParameterSet&, const std::string& name);
-
   //========================== PRIVATE DATA ====================================
   //============================================================================
 

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -56,16 +56,16 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config)
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::AlignmentProducerBase";
 
   const auto& algoConfig = config_.getParameterSet("algoConfig");
-  if (hasParameter<bool>(config_, "runAtPCL")) {
+  if (config_.existsAs<bool>("runAtPCL")) {
     // configured in main config?
     runAtPCL_ = config_.getParameter<bool>("runAtPCL");
 
-    if (hasParameter<bool>(algoConfig, "runAtPCL") && (runAtPCL_ != algoConfig.getParameter<bool>("runAtPCL"))) {
+    if (algoConfig.existsAs<bool>("runAtPCL") && (runAtPCL_ != algoConfig.getParameter<bool>("runAtPCL"))) {
       throw cms::Exception("BadConfig") << "Inconsistent settings for 'runAtPCL' in configuration of the "
                                         << "alignment producer and the alignment algorithm.";
     }
 
-  } else if (hasParameter<bool>(algoConfig, "runAtPCL")) {
+  } else if (algoConfig.existsAs<bool>("runAtPCL")) {
     // configured in algo config?
     runAtPCL_ = algoConfig.getParameter<bool>("runAtPCL");
 
@@ -931,24 +931,4 @@ void AlignmentProducerBase::writeDB(AlignmentSurfaceDeformations* alignmentSurfa
   } else {                                // poolDb->writeOne(..) takes over 'surfaceDeformation' ownership,...
     delete alignmentSurfaceDeformations;  // ...otherwise we have to delete, as promised!
   }
-}
-
-//------------------------------------------------------------------------------
-template <typename T>
-bool AlignmentProducerBase::hasParameter(const edm::ParameterSet& config, const std::string& name) {
-  try {
-    config.getParameter<T>(name);
-  } catch (const edm::Exception& e) {
-    if (e.categoryCode() == edm::errors::Configuration) {
-      if (e.message().find("MissingParameter") != std::string::npos) {
-        return false;
-      } else {
-        throw;
-      }
-    } else {
-      throw;
-    }
-  }
-
-  return true;
 }

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -266,12 +266,7 @@ void AlignmentProducerBase::createAlignmentAlgorithm() {
   algoConfig.addUntrackedParameter("enableAlignableUpdates", enableAlignableUpdates_);
 
   const auto& algoName = algoConfig.getParameter<std::string>("algoName");
-  alignmentAlgo_ =
-      std::unique_ptr<AlignmentAlgorithmBase>{AlignmentAlgorithmPluginFactory::get()->create(algoName, algoConfig)};
-
-  if (!alignmentAlgo_) {
-    throw cms::Exception("BadConfig") << "Couldn't find the called alignment algorithm: " << algoName;
-  }
+  alignmentAlgo_ = AlignmentAlgorithmPluginFactory::get()->create(algoName, algoConfig);
 }
 
 //------------------------------------------------------------------------------
@@ -279,13 +274,8 @@ void AlignmentProducerBase::createMonitors() {
   const auto& monitorConfig = config_.getParameter<edm::ParameterSet>("monitorConfig");
   auto monitors = monitorConfig.getUntrackedParameter<std::vector<std::string> >("monitors");
   for (const auto& miter : monitors) {
-    std::unique_ptr<AlignmentMonitorBase> newMonitor{
-        AlignmentMonitorPluginFactory::get()->create(miter, monitorConfig.getUntrackedParameterSet(miter))};
-
-    if (!newMonitor) {
-      throw cms::Exception("BadConfig") << "Couldn't find monitor named " << miter;
-    }
-    monitors_.emplace_back(std::move(newMonitor));
+    monitors_.emplace_back(
+        AlignmentMonitorPluginFactory::get()->create(miter, monitorConfig.getUntrackedParameterSet(miter)));
   }
 }
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -282,8 +282,7 @@ void MillePedeAlignmentAlgorithm::initialize(const edm::EventSetup &setup,
     // Get trajectory factory. In case nothing found, FrameWork will throw...
     const edm::ParameterSet fctCfg(theConfig.getParameter<edm::ParameterSet>("TrajectoryFactory"));
     const std::string fctName(fctCfg.getParameter<std::string>("TrajectoryFactoryName"));
-    theTrajectoryFactory =
-        std::unique_ptr<TrajectoryFactoryBase>(TrajectoryFactoryPlugin::get()->create(fctName, fctCfg));
+    theTrajectoryFactory = TrajectoryFactoryPlugin::get()->create(fctName, fctCfg);
   }
 
   if (this->isMode(myPedeSteerBit)) {

--- a/CalibMuon/DTCalibration/plugins/DTTPAnalyzer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTPAnalyzer.cc
@@ -74,8 +74,8 @@ DTTPAnalyzer::DTTPAnalyzer(const edm::ParameterSet& pset):
   rootFile_->cd();
 
   if(subtractT0_) 
-    tTrigSync_ = std::unique_ptr<DTTTrigBaseSync>{DTTTrigSyncFactory::get()->create(pset.getParameter<std::string>("tTrigMode"),
-                                                                                    pset.getParameter<edm::ParameterSet>("tTrigModeConfig"))};
+    tTrigSync_ = DTTTrigSyncFactory::get()->create(pset.getParameter<std::string>("tTrigMode"),
+                                                   pset.getParameter<edm::ParameterSet>("tTrigModeConfig"));
 
 }
  

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.cc
@@ -70,8 +70,8 @@ DTTTrigCalibration::DTTTrigCalibration(const edm::ParameterSet& pset) {
   doSubtractT0 = pset.getUntrackedParameter<bool>("doSubtractT0","false");
   // Get the synchronizer
   if(doSubtractT0) {
-    theSync = std::unique_ptr<DTTTrigBaseSync>{DTTTrigSyncFactory::get()->create(pset.getUntrackedParameter<string>("tTrigMode"),
-                                                                                 pset.getUntrackedParameter<ParameterSet>("tTrigModeConfig"))};
+    theSync = DTTTrigSyncFactory::get()->create(pset.getUntrackedParameter<string>("tTrigMode"),
+                                                pset.getUntrackedParameter<ParameterSet>("tTrigModeConfig"));
   }
 
   checkNoisyChannels = pset.getUntrackedParameter<bool>("checkNoisyChannels","false");


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to #27097 to remove now-redundant calls to `unique_ptr` constructor.

From `AlignmentProducerBase` I also
- removed a redundant exception throws (`PluginFactory::create()` already throws for missing plugin)
- replaced a custom `hasParameter()` with `edm::ParameterSet::existsAs()`

#### PR validation:

Code compiles.
