### PR TITLE
Remove redundant unique_ptr constructor calls from L1Trigger

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/PackingSetupFactory.cc
+++ b/EventFilter/L1TRawToDigi/plugins/PackingSetupFactory.cc
@@ -1,19 +1,12 @@
 #include "PackingSetupFactory.h"
 
-#include "FWCore/Utilities/interface/EDMException.h"
-
 EDM_REGISTER_PLUGINFACTORY(l1t::PackingSetupFactoryT, "PackingSetupFactory");
 
 namespace l1t {
   const PackingSetupFactory PackingSetupFactory::instance_;
 
   std::unique_ptr<PackingSetup> PackingSetupFactory::make(const std::string& type) const {
-    auto helper = std::unique_ptr<PackingSetup>(PackingSetupFactoryT::get()->create("l1t::" + type));
-
-    if (helper.get() == nullptr)
-      throw edm::Exception(edm::errors::Configuration, "NoSourceModule") << "cannot find packing setup " << type;
-
-    return helper;
+    return PackingSetupFactoryT::get()->create("l1t::" + type);
   }
 
   void PackingSetupFactory::fillDescription(edm::ParameterSetDescription& desc) const {

--- a/L1Trigger/L1THGCal/plugins/HGCalTowerProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTowerProducer.cc
@@ -38,8 +38,7 @@ HGCalTowerProducer::HGCalTowerProducer(const edm::ParameterSet& conf)
   //setup TowerMap parameters
   const edm::ParameterSet& towerParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& towerProcessorName = towerParamConfig.getParameter<std::string>("ProcessorName");
-  towersProcess_ =
-      std::unique_ptr<HGCalTowerProcessorBase>{HGCalTowerFactory::get()->create(towerProcessorName, towerParamConfig)};
+  towersProcess_ = HGCalTowerFactory::get()->create(towerProcessorName, towerParamConfig);
 
   produces<l1t::HGCalTowerBxCollection>(towersProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiFEReproducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiFEReproducer.cc
@@ -47,8 +47,7 @@ HGCalTriggerDigiFEReproducer::HGCalTriggerDigiFEReproducer(const edm::ParameterS
   //setup FE codec
   const edm::ParameterSet& feCodecConfig = conf.getParameterSet("FECodec");
   const std::string& feCodecName = feCodecConfig.getParameter<std::string>("CodecName");
-  codec_ =
-      std::unique_ptr<HGCalTriggerFECodecBase>{HGCalTriggerFECodecFactory::get()->create(feCodecName, feCodecConfig)};
+  codec_ = HGCalTriggerFECodecFactory::get()->create(feCodecName, feCodecConfig);
   codec_->unSetDataPayload();
 
   produces<l1t::HGCFETriggerDigiCollection>();


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to #27097 to remove now-redundant calls to `unique_ptr` constructor.

I also removed redundant exception throws from `PackingSetupFactory` (`PluginFactory::create()` already throws for missing plugin).

#### PR validation:

Code compiles.