### PR TITLE
Remove redundant unique_ptr constructor call from InputSourceFactory

### DIFF
--- a/FWCore/Framework/src/InputSourceFactory.cc
+++ b/FWCore/Framework/src/InputSourceFactory.cc
@@ -29,8 +29,7 @@ namespace edm {
   {
     std::string modtype = conf.getParameter<std::string>("@module_type");
     FDEBUG(1) << "InputSourceFactory: module_type = " << modtype << std::endl;
-    std::unique_ptr<InputSource> wm =
-        std::unique_ptr<InputSource>(InputSourcePluginFactory::get()->create(modtype, conf, desc));
+    auto wm = InputSourcePluginFactory::get()->create(modtype, conf, desc);
 
     if (wm.get() == nullptr) {
       throw edm::Exception(errors::Configuration, "NoSourceModule")


### PR DESCRIPTION
#### PR description:

Cleanup follow-up to #27097 (even if this code was not touched for the work leading to #27097, it got hit by my grepping patterns).

#### PR validation:

Code compiles.