### PR TITLE
Remove redundant unique_ptr constructor calls from FastSimulation

### DIFF
--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
@@ -39,8 +39,7 @@ PixelTracksProducer::PixelTracksProducer(const edm::ParameterSet& conf) : theReg
 
   const edm::ParameterSet& regfactoryPSet = conf.getParameter<edm::ParameterSet>("RegionFactoryPSet");
   std::string regfactoryName = regfactoryPSet.getParameter<std::string>("ComponentName");
-  theRegionProducer = std::unique_ptr<TrackingRegionProducer>{
-      TrackingRegionProducerFactory::get()->create(regfactoryName, regfactoryPSet, consumesCollector())};
+  theRegionProducer = TrackingRegionProducerFactory::get()->create(regfactoryName, regfactoryPSet, consumesCollector());
 
   fitterToken = consumes<PixelFitter>(conf.getParameter<edm::InputTag>("Fitter"));
   filterToken = consumes<PixelTrackFilter>(conf.getParameter<edm::InputTag>("Filter"));

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -133,7 +133,7 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf) {
   // seed creator
   const edm::ParameterSet& seedCreatorPSet = conf.getParameter<edm::ParameterSet>("SeedCreatorPSet");
   std::string seedCreatorName = seedCreatorPSet.getParameter<std::string>("ComponentName");
-  seedCreator = std::unique_ptr<SeedCreator>{SeedCreatorFactory::get()->create(seedCreatorName, seedCreatorPSet)};
+  seedCreator = SeedCreatorFactory::get()->create(seedCreatorName, seedCreatorPSet);
 }
 
 void TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es) {

--- a/FastSimulation/Tracking/src/SeedFinderSelector.cc
+++ b/FastSimulation/Tracking/src/SeedFinderSelector.cc
@@ -28,16 +28,14 @@ SeedFinderSelector::SeedFinderSelector(const edm::ParameterSet &cfg, edm::Consum
       measurementTrackerLabel_(cfg.getParameter<std::string>("measurementTracker")) {
   if (cfg.exists("pixelTripletGeneratorFactory")) {
     const edm::ParameterSet &tripletConfig = cfg.getParameter<edm::ParameterSet>("pixelTripletGeneratorFactory");
-    pixelTripletGenerator_ = std::unique_ptr<HitTripletGeneratorFromPairAndLayers>{
-        HitTripletGeneratorFromPairAndLayersFactory::get()->create(
-            tripletConfig.getParameter<std::string>("ComponentName"), tripletConfig, consumesCollector)};
+    pixelTripletGenerator_ = HitTripletGeneratorFromPairAndLayersFactory::get()->create(
+        tripletConfig.getParameter<std::string>("ComponentName"), tripletConfig, consumesCollector);
   }
 
   if (cfg.exists("MultiHitGeneratorFactory")) {
     const edm::ParameterSet &tripletConfig = cfg.getParameter<edm::ParameterSet>("MultiHitGeneratorFactory");
-    multiHitGenerator_ =
-        std::unique_ptr<MultiHitGeneratorFromPairAndLayers>{MultiHitGeneratorFromPairAndLayersFactory::get()->create(
-            tripletConfig.getParameter<std::string>("ComponentName"), tripletConfig)};
+    multiHitGenerator_ = MultiHitGeneratorFromPairAndLayersFactory::get()->create(
+        tripletConfig.getParameter<std::string>("ComponentName"), tripletConfig);
   }
 
   if (cfg.exists("CAHitTripletGeneratorFactory")) {


### PR DESCRIPTION
#### PR description:

Cleanup follow-up to #27097.

#### PR validation:

Code compiles.