### PR TITLE
zeroing PF clustering uncertainty : 106X

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -53,6 +53,7 @@ class PFClusterEMEnergyCorrector {
   bool srfAwareCorrection_;
   bool applyCrackCorrections_;
   bool applyMVACorrections_;
+  bool setEnergyUncertainty_;
 
   bool autoDetectBunchSpacing_;
   int bunchSpacingManual_;

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -132,6 +132,7 @@ void CorrectedECALPFClusterProducer::fillDescriptions(edm::ConfigurationDescript
     psd0.add<bool>("applyCrackCorrections",false);
     psd0.add<bool>("applyMVACorrections",false);
     psd0.add<bool>("srfAwareCorrection",false);    
+    psd0.add<bool>("setEnergyUncertainty",false);    
     psd0.add<bool>("autoDetectBunchSpacing",true);
     psd0.add<int>("bunchSpacing",25);
     psd0.add<double>("maxPtForMVAEvaluation",-99.);

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -19,7 +19,7 @@ PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet& 
    applyCrackCorrections_ = conf.getParameter<bool>("applyCrackCorrections");
    applyMVACorrections_ = conf.getParameter<bool>("applyMVACorrections");
    srfAwareCorrection_ = conf.getParameter<bool>("srfAwareCorrection");
-
+   setEnergyUncertainty_ = conf.getParameter<bool>("setEnergyUncertainty");
    maxPtForMVAEvaluation_ = conf.getParameter<double>("maxPtForMVAEvaluation");
      
    if (applyMVACorrections_) {
@@ -250,8 +250,9 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
       double sigmacor = sigma*ecor;
       
       cluster.setCorrectedEnergy(ecor);
-      cluster.setCorrectedEnergyUncertainty(sigmacor);
-      
+      if(setEnergyUncertainty_) cluster.setCorrectedEnergyUncertainty(sigmacor);
+      else cluster.setCorrectedEnergyUncertainty(0.);
+            
     }
     return;
   }
@@ -414,7 +415,9 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
 					   << exp(mean) << " " << ecor;
     
     cluster.setCorrectedEnergy(ecor);
-    cluster.setCorrectedEnergyUncertainty(sigmacor);
+    if(setEnergyUncertainty_) cluster.setCorrectedEnergyUncertainty(sigmacor);
+    else cluster.setCorrectedEnergyUncertainty(0.);
+       
   }
   
 }


### PR DESCRIPTION
#### PR description:

This PR zeros out the PF cluster uncertainty by default as discussed in the PPD general meeting last week. This because those values are not used anywhere, do not really make sense and will for the 2017UL be inaccurate in the endcap.

This is a super minor thing and should not hold anything. If it gets in it gets in, if it doesnt , it doesnt.

#### if this PR is a backport please specify the original PR:
backport of https://github.com/cms-sw/cmssw/pull/27182
