### PR TITLE
FWCore/Framework: Move function call outside of assert

### DIFF
--- a/FWCore/Framework/test/stubs/TestModuleChangeLooper.cc
+++ b/FWCore/Framework/test/stubs/TestModuleChangeLooper.cc
@@ -52,8 +52,8 @@ public:
 
     edm::ParameterSet newPSet(*pset);
     newPSet.addParameter<int>("ivalue", ++m_expectedValue);
-
-    assert(moduleChanger()->changeModule(m_tag.label(), newPSet));
+    auto success = moduleChanger()->changeModule(m_tag.label(), newPSet);
+    assert(success && "moduleChanger()->changeModule(m_tag.label(), newPSet)");
 
     return iCount == 2 ? kStop : kContinue;
   }


### PR DESCRIPTION
Found while building with spack. If NDEBUG is set by an external product header before assert is included then the assert macro effectively does not run whatever is inside the assert macro. In this case the function call
moduleChanger()->changeModule(m_tag.label(), newPSet)
was never compiled into the code which causes the test to fail.

