### PR TITLE
FWCore/MessageService: Run standAloneTest script with testRunner.cpp

### DIFF
--- a/FWCore/MessageService/test/BuildFile.xml
+++ b/FWCore/MessageService/test/BuildFile.xml
@@ -170,6 +170,9 @@
 </environment>
 <bin   file="standAloneTest.cpp" name="standAloneWithMessageLogger">
   <use   name="FWCore/MessageLogger"/>
+  <flags NO_TESTRUN="1"/>
+</bin>
+<bin   file="testRunner.cpp" name="standAloneWithMessageLoggerRunner">
   <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test standAlone_1.sh"/>
 </bin>
 <bin   file="trivial_main.cpp">

--- a/FWCore/MessageService/test/standAloneTest.cpp
+++ b/FWCore/MessageService/test/standAloneTest.cpp
@@ -1,3 +1,4 @@
+#define EDM_ML_DEBUG
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace edmtest {

--- a/FWCore/MessageService/test/testRunner.cpp
+++ b/FWCore/MessageService/test/testRunner.cpp
@@ -1,0 +1,3 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+
+RUNTEST()

--- a/FWCore/MessageService/test/unit_test_outputs/standAloneWithMessageLogger.cerr
+++ b/FWCore/MessageService/test/unit_test_outputs/standAloneWithMessageLogger.cerr
@@ -17,11 +17,11 @@ LogProblem  was used to send cat_A
 LogProblem  was used to send cat_B
 threshold DEBUG
 %MSG-d cat_A: 
- standAloneTest.cpp:8
+ standAloneTest.cpp:7
 LogDebug    was used to send cat_A
 %MSG
 %MSG-d cat_B: 
- standAloneTest.cpp:9
+ standAloneTest.cpp:8
 LogDebug    was used to send cat_B
 %MSG
 LogTrace    was used to send cat_A


### PR DESCRIPTION
This allows the capture of the error from sed.
Add #define NDEBUG to standAloneTest.cpp so LogDebug and LogTrace messages are produced.
Update unit_test_outputs to reflex current line numbers for messages.
