### PR TITLE
Fix compilation problems with gcc 9 in FWCore/ParameterSet

### DIFF
--- a/FWCore/ParameterSet/src/Entry.cc
+++ b/FWCore/ParameterSet/src/Entry.cc
@@ -123,11 +123,11 @@ static constexpr std::string_view c2t(char iCode) {
       return s_types[index];
     }
   }
-  return nullptr;
+  return std::string_view();
 }
 
 static constexpr std::array<std::string_view, 255> fillTable() {
-  std::array<std::string_view, 255> table_ = {{nullptr}};
+  std::array<std::string_view, 255> table_ = {{std::string_view()}};
   static_assert(not c2t(kTvBool).empty());
   table_[kTvBool] = c2t(kTvBool);
   static_assert(not c2t(kTbool).empty());


### PR DESCRIPTION
#### PR description:

gcc 9 did not like the use of nullptr and wants default construction of std::string_view.

#### PR validation:

Built and ran unit tests using gcc 9.