### PR TITLE
add the ability to use a seed just as a 5DHit

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -18,7 +18,7 @@ from HLTrigger.Configuration.common import *
 #     return process
 
 # use 5DHit as seed
-def customiseFor99999(process):
+def customiseFor27220(process):
    for pset in process._Process__psets.values():
        if hasattr(pset,'ComponentType'):
              if (pset.ComponentType == 'CkfTrajectoryBuilder' or pset.ComponentType == 'GroupedCkfTrajectoryBuilder'):
@@ -60,6 +60,6 @@ def customiseFor2017DtUnpacking(process):
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
-    process = customiseFor99999(process)
+    process = customiseFor27220(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -21,7 +21,9 @@ from HLTrigger.Configuration.common import *
 def customiseFor27220(process):
    for pset in process._Process__psets.values():
        if hasattr(pset,'ComponentType'):
-             if (pset.ComponentType == 'CkfTrajectoryBuilder' or pset.ComponentType == 'GroupedCkfTrajectoryBuilder'):
+             if (pset.ComponentType == 'CkfTrajectoryBuilder' or 
+                 pset.ComponentType == 'GroupedCkfTrajectoryBuilder' or
+                 pset.ComponentType == 'MuonCkfTrajectoryBuilder'):
                  if not hasattr(pset,'seedAs5DHit'):
                      pset.seedAs5DHit = cms.bool(False)
    return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -17,6 +17,14 @@ from HLTrigger.Configuration.common import *
 #                     pset.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
 #     return process
 
+# use 5DHit as seed
+def customiseFor99999(process):
+   for pset in process._Process__psets.values():
+       if hasattr(pset,'ComponentType'):
+             if (pset.ComponentType == 'CkfTrajectoryBuilder' or pset.ComponentType == 'GroupedCkfTrajectoryBuilder'):
+                 if not hasattr(pset,'seedAs5DHit'):
+                     pset.seedAs5DHit = cms.bool(False)
+   return process
 
 def customiseFor2017DtUnpacking(process):
     """Adapt the HLT to run the legacy DT unpacking
@@ -52,6 +60,6 @@ def customiseFor2017DtUnpacking(process):
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
-    # process = customiseFor12718(process)
+    process = customiseFor99999(process)
 
     return process

--- a/RecoEgamma/EgammaPhotonProducers/python/trajectoryBuilderForConversions_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/trajectoryBuilderForConversions_cfi.py
@@ -17,4 +17,4 @@ TrajectoryBuilderForConversions.maxCand = 5
 TrajectoryBuilderForConversions.lostHitPenalty = 30.
 TrajectoryBuilderForConversions.intermediateCleaning = True
 TrajectoryBuilderForConversions.alwaysUseInvalidHits = True
-
+TrajectoryBuilderForConversions.seedAs5DHit  = False

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -152,7 +152,7 @@ protected:
   StateAndLayers findStateAndLayers(const TrajectorySeed& seed, const TempTrajectory& traj) const;
 
 private:
-  void seedMeasurements(const TrajectorySeed& seed, TempTrajectory& result) const;
+  void seedMeasurements(const TrajectorySeed& seed, TempTrajectory& result, bool as5D) const;
 
 protected:
   void setData(const MeasurementTrackerEvent* data);
@@ -167,23 +167,18 @@ protected:
 protected:
   typedef TrackingComponentsRecord Chi2MeasurementEstimatorRecord;
 
-  const TrajectoryStateUpdator* theUpdator;
-  const Propagator* thePropagatorAlong;
-  const Propagator* thePropagatorOpposite;
-  const Chi2MeasurementEstimatorBase* theEstimator;
-  const TransientTrackingRecHitBuilder* theTTRHBuilder;
-  const MeasurementTrackerEvent* theMeasurementTracker;
+  const TrajectoryStateUpdator* theUpdator = nullptr;
+  const Propagator* thePropagatorAlong = nullptr;
+  const Propagator* thePropagatorOpposite = nullptr;
+  const Chi2MeasurementEstimatorBase* theEstimator = nullptr;
+  const TransientTrackingRecHitBuilder* theTTRHBuilder = nullptr;
+  const MeasurementTrackerEvent* theMeasurementTracker = nullptr;
   const NavigationSchool* theNavigationSchool = nullptr;
 
 private:
-  //  int theMaxLostHit;            /**< Maximum number of lost hits per trajectory candidate.*/
-  //  int theMaxConsecLostHit;      /**< Maximum number of consecutive lost hits
-  //                                     per trajectory candidate. */
-  //  int theMinimumNumberOfHits;   /**< Minimum number of hits for a trajectory to be returned.*/
-  //  float theChargeSignificance;  /**< Value to declare (q/p)/sig(q/p) significant. Negative: ignore. */
 
-  //  TrajectoryFilter*              theMinPtCondition;
-  //  TrajectoryFilter*              theMaxHitsCondition;
+  bool theSeedAs5DHit;
+
   std::unique_ptr<TrajectoryFilter> theFilter;      /** Filter used at end of complete tracking */
   std::unique_ptr<TrajectoryFilter> theInOutFilter; /** Filter used at end of in-out tracking */
 

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -176,7 +176,6 @@ protected:
   const NavigationSchool* theNavigationSchool = nullptr;
 
 private:
-
   bool theSeedAs5DHit;
 
   std::unique_ptr<TrajectoryFilter> theFilter;      /** Filter used at end of complete tracking */

--- a/RecoTracker/CkfPattern/python/CkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/CkfTrajectoryBuilder_cfi.py
@@ -18,7 +18,8 @@ CkfTrajectoryBuilder = cms.PSet(
     propagatorOpposite = cms.string('PropagatorWithMaterialOpposite'),
 #    propagatorOpposite = cms.string('PropagatorWithMaterialParabolicMfOpposite'),
     lostHitPenalty = cms.double(30.0),
-    #SharedSeedCheck = cms.bool(False)
+    #SharedSeedCheck = cms.bool(False),
+    seedAs5DHit  = cms.bool(False)
 )
 
 

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
@@ -37,7 +37,8 @@ GroupedCkfTrajectoryBuilder = cms.PSet(
 #    propagatorOpposite = cms.string('PropagatorWithMaterialParabolicMfOpposite'),
     # Out-in tracking will not be attempted unless this many hits
     # are on track after in-out tracking phase.
-    minNrOfHitsForRebuild = cms.int32(5)
+    minNrOfHitsForRebuild = cms.int32(5),
+    seedAs5DHit  = cms.bool(False)
 )
 
 

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -58,11 +58,11 @@ void BaseCkfTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed, Temp
       trajectoryStateTransform::transientState(pState, &(gdet->surface()), forwardPropagator(seed)->magneticField());
 
   if (as5D) {
-      TrackingRecHit::RecHitPointer recHit(new TRecHit5DParamConstraint(*gdet,outerState));
-      TSOS invalidState(gdet->surface());
-      auto hitLayer = theMeasurementTracker->geometricSearchTracker()->detLayer(pState.detId());
-      result.emplace(invalidState, outerState, recHit, 0, hitLayer);    
-      return;
+    TrackingRecHit::RecHitPointer recHit(new TRecHit5DParamConstraint(*gdet, outerState));
+    TSOS invalidState(gdet->surface());
+    auto hitLayer = theMeasurementTracker->geometricSearchTracker()->detLayer(pState.detId());
+    result.emplace(invalidState, outerState, recHit, 0, hitLayer);
+    return;
   }
 
   for (TrajectorySeed::const_iterator ihit = hitRange.first; ihit != hitRange.second; ihit++) {


### PR DESCRIPTION
With this PR we add the ability (controlled by a configurable in the trajectory builder) to use the seed ad a 5DHit.
It targets mainly HLT when the seeds come from an outside source.
w/r/t standard hitless seeds it allows to fully use the seed information in the trajectory fit.

while technically working it will require to be really operational:
   * seeds with a meaningful covariance matrix
   * retuning of the trajectory filter
   * retuning of the track classifier
   * and most probably additional work at level of HitPattern and of clients that rely on specific hits to be present in the track

tested offline and hit with default configuration and with 5DHit switched on
