### PR TITLE
Fix copying of default-constructed WaitingTaskWithArenaHolder

### DIFF
--- a/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
+++ b/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
@@ -30,7 +30,9 @@ namespace edm {
 
   WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder(WaitingTaskWithArenaHolder const& iHolder)
       : m_task(iHolder.m_task), m_arena(iHolder.m_arena) {
-    m_task->increment_ref_count();
+    if (m_task) {
+      m_task->increment_ref_count();
+    }
   }
 
   WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder(WaitingTaskWithArenaHolder&& iOther)

--- a/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
+++ b/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
@@ -9,6 +9,7 @@
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 namespace edm {
 
@@ -30,7 +31,7 @@ namespace edm {
 
   WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder(WaitingTaskWithArenaHolder const& iHolder)
       : m_task(iHolder.m_task), m_arena(iHolder.m_arena) {
-    if (m_task) {
+    if (LIKELY(m_task != nullptr)) {
       m_task->increment_ref_count();
     }
   }


### PR DESCRIPTION
#### PR description:

While debugging/testing something else, I noticed that copying a default-constructed WaitingTaskWithArenaHolder leads to a segfault. This PR proposes a fix for the segfault.

#### PR validation:

Code compiles, and in a private test copying a default-constructed WaitingTaskWithArenaHolder works now.