### PR TITLE
Running code-format for analysis-reconstruction

### DIFF
--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -19,91 +19,97 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-namespace tensorflow
-{
+namespace tensorflow {
 
-typedef std::pair<std::string, Tensor> NamedTensor;
-typedef std::vector<NamedTensor> NamedTensorList;
+  typedef std::pair<std::string, Tensor> NamedTensor;
+  typedef std::vector<NamedTensor> NamedTensorList;
 
-// set the tensorflow log level
-void setLogging(const std::string& level = "3");
+  // set the tensorflow log level
+  void setLogging(const std::string& level = "3");
 
-// updates the config of sessionOptions so that it uses nThreads and if 1, sets the thread pool to
-// singleThreadPool
-void setThreading(SessionOptions& sessionOptions, int nThreads,
-    const std::string& singleThreadPool = "no_threads");
+  // updates the config of sessionOptions so that it uses nThreads and if 1, sets the thread pool to
+  // singleThreadPool
+  void setThreading(SessionOptions& sessionOptions, int nThreads, const std::string& singleThreadPool = "no_threads");
 
-// loads a meta graph definition saved at exportDir using the SavedModel interface for a tag and
-// predefined sessionOptions
-// transfers ownership
-MetaGraphDef* loadMetaGraph(const std::string& exportDir, const std::string& tag,
-    SessionOptions& sessionOptions);
+  // loads a meta graph definition saved at exportDir using the SavedModel interface for a tag and
+  // predefined sessionOptions
+  // transfers ownership
+  MetaGraphDef* loadMetaGraph(const std::string& exportDir, const std::string& tag, SessionOptions& sessionOptions);
 
-// loads a meta graph definition saved at exportDir using the SavedModel interface for a tag and
-// nThreads
-// transfers ownership
-MetaGraphDef* loadMetaGraph(const std::string& exportDir,
-    const std::string& tag = kSavedModelTagServe, int nThreads = 1);
+  // loads a meta graph definition saved at exportDir using the SavedModel interface for a tag and
+  // nThreads
+  // transfers ownership
+  MetaGraphDef* loadMetaGraph(const std::string& exportDir,
+                              const std::string& tag = kSavedModelTagServe,
+                              int nThreads = 1);
 
-// loads a graph definition saved as a protobuf file at pbFile
-// transfers ownership
-GraphDef* loadGraphDef(const std::string& pbFile);
+  // loads a graph definition saved as a protobuf file at pbFile
+  // transfers ownership
+  GraphDef* loadGraphDef(const std::string& pbFile);
 
-// return a new, empty session using predefined sessionOptions
-// transfers ownership
-Session* createSession(SessionOptions& sessionOptions);
+  // return a new, empty session using predefined sessionOptions
+  // transfers ownership
+  Session* createSession(SessionOptions& sessionOptions);
 
-// return a new, empty session with nThreads
-// transfers ownership
-Session* createSession(int nThreads = 1);
+  // return a new, empty session with nThreads
+  // transfers ownership
+  Session* createSession(int nThreads = 1);
 
-// return a new session that will contain an already loaded meta graph whose exportDir must be given
-// in order to load and initialize the variables, sessionOptions are predefined
-// transfers ownership
-Session* createSession(MetaGraphDef* metaGraph, const std::string& exportDir,
-    SessionOptions& sessionOptions);
+  // return a new session that will contain an already loaded meta graph whose exportDir must be given
+  // in order to load and initialize the variables, sessionOptions are predefined
+  // transfers ownership
+  Session* createSession(MetaGraphDef* metaGraph, const std::string& exportDir, SessionOptions& sessionOptions);
 
-// return a new session that will contain an already loaded meta graph whose exportDir must be given
-// in order to load and initialize the variables, threading options are inferred from nThreads
-// transfers ownership
-Session* createSession(MetaGraphDef* metaGraph, const std::string& exportDir, int nThreads = 1);
+  // return a new session that will contain an already loaded meta graph whose exportDir must be given
+  // in order to load and initialize the variables, threading options are inferred from nThreads
+  // transfers ownership
+  Session* createSession(MetaGraphDef* metaGraph, const std::string& exportDir, int nThreads = 1);
 
-// return a new session that will contain an already loaded graph def, sessionOptions are predefined
-// transfers ownership
-Session* createSession(GraphDef* graphDef, SessionOptions& sessionOptions);
+  // return a new session that will contain an already loaded graph def, sessionOptions are predefined
+  // transfers ownership
+  Session* createSession(GraphDef* graphDef, SessionOptions& sessionOptions);
 
-// return a new session that will contain an already loaded graph def, threading options are
-// inferred from nThreads
-// transfers ownership
-Session* createSession(GraphDef* graphDef, int nThreads = 1);
+  // return a new session that will contain an already loaded graph def, threading options are
+  // inferred from nThreads
+  // transfers ownership
+  Session* createSession(GraphDef* graphDef, int nThreads = 1);
 
-// closes a session, calls its destructor, resets the pointer, and returns true on success
-bool closeSession(Session*& session);
+  // closes a session, calls its destructor, resets the pointer, and returns true on success
+  bool closeSession(Session*& session);
 
-// run the session with inputs, outputNames and targetNodes, and store output tensors
-// throws a cms exception when not successful
-void run(Session* session, const NamedTensorList& inputs,
-    const std::vector<std::string>& outputNames, const std::vector<std::string>& targetNodes,
-    std::vector<Tensor>* outputs);
+  // run the session with inputs, outputNames and targetNodes, and store output tensors
+  // throws a cms exception when not successful
+  void run(Session* session,
+           const NamedTensorList& inputs,
+           const std::vector<std::string>& outputNames,
+           const std::vector<std::string>& targetNodes,
+           std::vector<Tensor>* outputs);
 
-// run the session with inputNames, inputTensors, outputNames and targetNodes, and store output
-// tensors
-// throws a cms exception when not successful
-void run(Session* session, const std::vector<std::string>& inputNames,
-    const std::vector<Tensor>& inputTensors, const std::vector<std::string>& outputNames,
-    const std::vector<std::string>& targetNodes, std::vector<Tensor>* outputs);
+  // run the session with inputNames, inputTensors, outputNames and targetNodes, and store output
+  // tensors
+  // throws a cms exception when not successful
+  void run(Session* session,
+           const std::vector<std::string>& inputNames,
+           const std::vector<Tensor>& inputTensors,
+           const std::vector<std::string>& outputNames,
+           const std::vector<std::string>& targetNodes,
+           std::vector<Tensor>* outputs);
 
-// run the session with inputs and outputNames, and store output tensors
-// throws a cms exception when not successful
-void run(Session* session, const NamedTensorList& inputs,
-    const std::vector<std::string>& outputNames, std::vector<Tensor>* outputs);
+  // run the session with inputs and outputNames, and store output tensors
+  // throws a cms exception when not successful
+  void run(Session* session,
+           const NamedTensorList& inputs,
+           const std::vector<std::string>& outputNames,
+           std::vector<Tensor>* outputs);
 
-// run the session with inputNames, inputTensors and outputNames, and store output tensors
-// throws a cms exception when not successful
-void run(Session* session, const std::vector<std::string>& inputNames,
-    const std::vector<Tensor>& inputTensors, const std::vector<std::string>& outputNames,
-    std::vector<Tensor>* outputs);
+  // run the session with inputNames, inputTensors and outputNames, and store output tensors
+  // throws a cms exception when not successful
+  void run(Session* session,
+           const std::vector<std::string>& inputNames,
+           const std::vector<Tensor>& inputTensors,
+           const std::vector<std::string>& outputNames,
+           std::vector<Tensor>* outputs);
 
-} // namespace tensorflow
+}  // namespace tensorflow
 
-#endif // PHYSICSTOOLS_TENSORFLOW_TENSORFLOW_H
+#endif  // PHYSICSTOOLS_TENSORFLOW_TENSORFLOW_H

--- a/PhysicsTools/TensorFlow/src/NTSession.cc
+++ b/PhysicsTools/TensorFlow/src/NTSession.cc
@@ -79,1403 +79,1333 @@ Changes with respect to the original code are documented in the NTSession.h head
 
 namespace tensorflow {
 
-namespace {
+  namespace {
 
-CMS_THREAD_SAFE auto* nothreads_session_runs = monitoring::Counter<0>::New(
-    "/tensorflow/core/nothreads_session_runs",
-    "The number of times NTSession::Run() has been called.");
+    CMS_THREAD_SAFE auto* nothreads_session_runs = monitoring::Counter<0>::New(
+        "/tensorflow/core/nothreads_session_runs", "The number of times NTSession::Run() has been called.");
 
-
-// TODO(vrv): Figure out how to unify the many different functions
-// that generate RendezvousKey, since many of them have to be
-// consistent with each other.
-string GetRendezvousKey(const string& tensor_name,
-                        const DeviceAttributes& device_info,
-                        const FrameAndIter& frame_iter) {
-  return strings::StrCat(device_info.name(), ";",
-                         strings::FpToString(device_info.incarnation()), ";",
-                         device_info.name(), ";", tensor_name, ";",
-                         frame_iter.frame_id, ":", frame_iter.iter_id);
-}
-
-}  // namespace
-
-class NTSessionFactory : public SessionFactory {
- public:
-  NTSessionFactory() {}
-
-  bool AcceptsOptions(const SessionOptions& options) override {
-    return options.target == "no_threads";
-  }
-
-  Session* NewSession(const SessionOptions& options) override {
-    // Must do this before the CPU allocator is created.
-    if (options.config.graph_options().build_cost_model() > 0) {
-      EnableCPUAllocatorFullStats(true);
-    }
-    std::vector<Device*> devices;
-    const Status s = DeviceFactory::AddDevices(
-        options, "/job:localhost/replica:0/task:0", &devices);
-    if (!s.ok()) {
-      LOG(ERROR) << s;
-      return nullptr;
+    // TODO(vrv): Figure out how to unify the many different functions
+    // that generate RendezvousKey, since many of them have to be
+    // consistent with each other.
+    string GetRendezvousKey(const string& tensor_name,
+                            const DeviceAttributes& device_info,
+                            const FrameAndIter& frame_iter) {
+      return strings::StrCat(device_info.name(),
+                             ";",
+                             strings::FpToString(device_info.incarnation()),
+                             ";",
+                             device_info.name(),
+                             ";",
+                             tensor_name,
+                             ";",
+                             frame_iter.frame_id,
+                             ":",
+                             frame_iter.iter_id);
     }
 
-    NTSession* session =
-        new NTSession(options, new DeviceMgr(devices), this);
-    {
+  }  // namespace
+
+  class NTSessionFactory : public SessionFactory {
+  public:
+    NTSessionFactory() {}
+
+    bool AcceptsOptions(const SessionOptions& options) override { return options.target == "no_threads"; }
+
+    Session* NewSession(const SessionOptions& options) override {
+      // Must do this before the CPU allocator is created.
+      if (options.config.graph_options().build_cost_model() > 0) {
+        EnableCPUAllocatorFullStats(true);
+      }
+      std::vector<Device*> devices;
+      const Status s = DeviceFactory::AddDevices(options, "/job:localhost/replica:0/task:0", &devices);
+      if (!s.ok()) {
+        LOG(ERROR) << s;
+        return nullptr;
+      }
+
+      NTSession* session = new NTSession(options, new DeviceMgr(devices), this);
+      {
+        mutex_lock l(sessions_lock_);
+        sessions_.push_back(session);
+      }
+      return session;
+    }
+
+    Status Reset(const SessionOptions& options, const std::vector<string>& containers) override {
+      std::vector<NTSession*> sessions_to_reset;
+      {
+        mutex_lock l(sessions_lock_);
+        // We create a copy to ensure that we don't have a deadlock when
+        // session->Close calls the NTSessionFactory.Deregister, which
+        // acquires sessions_lock_.
+        std::swap(sessions_to_reset, sessions_);
+      }
+      Status s;
+      for (auto session : sessions_to_reset) {
+        s.Update(session->Reset(containers));
+      }
+      // TODO(suharshs): Change the Reset behavior of all SessionFactories so that
+      // it doesn't close the sessions?
+      for (auto session : sessions_to_reset) {
+        s.Update(session->Close());
+      }
+      return s;
+    }
+
+    void Deregister(const NTSession* session) {
       mutex_lock l(sessions_lock_);
-      sessions_.push_back(session);
+      sessions_.erase(std::remove(sessions_.begin(), sessions_.end(), session), sessions_.end());
     }
-    return session;
-  }
 
-  Status Reset(const SessionOptions& options,
-               const std::vector<string>& containers) override {
-    std::vector<NTSession*> sessions_to_reset;
-    {
-      mutex_lock l(sessions_lock_);
-      // We create a copy to ensure that we don't have a deadlock when
-      // session->Close calls the NTSessionFactory.Deregister, which
-      // acquires sessions_lock_.
-      std::swap(sessions_to_reset, sessions_);
+  private:
+    mutex sessions_lock_;
+    std::vector<NTSession*> sessions_ GUARDED_BY(sessions_lock_);
+  };
+
+  class NTSessionRegistrar {
+  public:
+    NTSessionRegistrar() { SessionFactory::Register("NOTHREADS_SESSION", new NTSessionFactory()); }
+  };
+  static NTSessionRegistrar registrar;
+
+  std::atomic_int_fast64_t NTSession::step_id_counter_(1);
+
+  // NOTE: On Android with a single device, there is never
+  // a risk of an OpKernel blocking indefinitely:
+  //
+  // 1) No operations do I/O that depends on other simultaneous kernels,
+  //
+  // 2) Recv nodes always complete immediately: The inputs are sent into
+  //    the local rendezvous before we start the executor, so the
+  //    corresponding recvs will not block.
+  //
+  // Based on these assumptions, we can use the same thread pool for
+  // both "non-blocking" and "blocking" OpKernels on Android.
+  //
+  // This may change down the road when we add support for multiple
+  // devices that run concurrently, in which case we will need to
+  // revisit this decision.
+  // Override to allow CMSSW FWK to schedule
+  void NTSession::SchedClosure(std::function<void()> c) { c(); }
+
+  NTSession::NTSession(const SessionOptions& options, const DeviceMgr* device_mgr, NTSessionFactory* const factory)
+      : options_(options),
+        device_mgr_(device_mgr),
+        factory_(factory),
+        cancellation_manager_(new CancellationManager()),
+        operation_timeout_in_ms_(options_.config.operation_timeout_in_ms()) {
+    // The default value of sync_on_finish will be flipped soon and this
+    // environment variable will be removed as well.
+    const Status status = ReadBoolFromEnvVar("TF_SYNC_ON_FINISH", true, &sync_on_finish_);
+    if (!status.ok()) {
+      LOG(ERROR) << status.error_message();
     }
-    Status s;
-    for (auto session : sessions_to_reset) {
-      s.Update(session->Reset(containers));
+    // NOTE(mrry): We do not need to use a unique string for the session
+    // handle, because NTSession owns its devices. This may change
+    // in future versions.
+    session_handle_ = "no_threads";
+    int devices_added = 0;
+    if (options.config.log_device_placement()) {
+      const string mapping_str = device_mgr_->DeviceMappingString();
+      if (mapping_str.empty()) {
+        printf("Device mapping: no known devices.\n");
+      } else {
+        printf("Device mapping:\n%s", mapping_str.c_str());
+      }
+      LOG(INFO) << "Device mapping:\n" << mapping_str;
     }
-    // TODO(suharshs): Change the Reset behavior of all SessionFactories so that
-    // it doesn't close the sessions?
-    for (auto session : sessions_to_reset) {
-      s.Update(session->Close());
+    for (auto d : device_mgr_->ListDevices()) {
+      devices_.push_back(d);
+      device_set_.AddDevice(d);
+      d->op_segment()->AddHold(session_handle_);
+
+      // The first device added is special: it is the 'client device' (a
+      // CPU device) from which we feed and fetch Tensors.
+      if (devices_added == 0) {
+        device_set_.set_client_device(d);
+      }
+      ++devices_added;
     }
-    return s;
   }
 
-  void Deregister(const NTSession* session) {
-    mutex_lock l(sessions_lock_);
-    sessions_.erase(std::remove(sessions_.begin(), sessions_.end(), session),
-                    sessions_.end());
-  }
-
- private:
-  mutex sessions_lock_;
-  std::vector<NTSession*> sessions_ GUARDED_BY(sessions_lock_);
-};
-
-class NTSessionRegistrar {
- public:
-  NTSessionRegistrar() {
-    SessionFactory::Register("NOTHREADS_SESSION", new NTSessionFactory());
-  }
-};
-static NTSessionRegistrar registrar;
-
-std::atomic_int_fast64_t NTSession::step_id_counter_(1);
-
-// NOTE: On Android with a single device, there is never
-// a risk of an OpKernel blocking indefinitely:
-//
-// 1) No operations do I/O that depends on other simultaneous kernels,
-//
-// 2) Recv nodes always complete immediately: The inputs are sent into
-//    the local rendezvous before we start the executor, so the
-//    corresponding recvs will not block.
-//
-// Based on these assumptions, we can use the same thread pool for
-// both "non-blocking" and "blocking" OpKernels on Android.
-//
-// This may change down the road when we add support for multiple
-// devices that run concurrently, in which case we will need to
-// revisit this decision.
-// Override to allow CMSSW FWK to schedule
-void NTSession::SchedClosure(std::function<void()> c) {
-  c();
-}
-
-NTSession::NTSession(const SessionOptions& options,
-                             const DeviceMgr* device_mgr,
-                             NTSessionFactory* const factory)
-    : options_(options),
-      device_mgr_(device_mgr),
-      factory_(factory),
-      cancellation_manager_(new CancellationManager()),
-      operation_timeout_in_ms_(options_.config.operation_timeout_in_ms()) {
-  // The default value of sync_on_finish will be flipped soon and this
-  // environment variable will be removed as well.
-  const Status status =
-      ReadBoolFromEnvVar("TF_SYNC_ON_FINISH", true, &sync_on_finish_);
-  if (!status.ok()) {
-    LOG(ERROR) << status.error_message();
-  }
-  // NOTE(mrry): We do not need to use a unique string for the session
-  // handle, because NTSession owns its devices. This may change
-  // in future versions.
-  session_handle_ = "no_threads";
-  int devices_added = 0;
-  if (options.config.log_device_placement()) {
-    const string mapping_str = device_mgr_->DeviceMappingString();
-    if (mapping_str.empty()) {
-      printf("Device mapping: no known devices.\n");
-    } else {
-      printf("Device mapping:\n%s", mapping_str.c_str());
+  NTSession::~NTSession() {
+    if (!closed_)
+      Close().IgnoreError();
+    for (auto& it : partial_runs_) {
+      it.second.reset(nullptr);
     }
-    LOG(INFO) << "Device mapping:\n" << mapping_str;
-  }
-  for (auto d : device_mgr_->ListDevices()) {
-    devices_.push_back(d);
-    device_set_.AddDevice(d);
-    d->op_segment()->AddHold(session_handle_);
-
-    // The first device added is special: it is the 'client device' (a
-    // CPU device) from which we feed and fetch Tensors.
-    if (devices_added == 0) {
-      device_set_.set_client_device(d);
+    for (auto& it : executors_) {
+      it.second.reset();
     }
-    ++devices_added;
-  }
-}
+    for (auto d : device_mgr_->ListDevices()) {
+      d->op_segment()->RemoveHold(session_handle_);
+    }
+    for (auto d : device_mgr_->ListDevices()) {
+      d->ClearResourceMgr();
+    }
+    functions_.clear();
+    delete cancellation_manager_;
 
-NTSession::~NTSession() {
-  if (!closed_) Close().IgnoreError();
-  for (auto& it : partial_runs_) {
-    it.second.reset(nullptr);
+    execution_state_.reset(nullptr);
+    flib_def_.reset(nullptr);
   }
-  for (auto& it : executors_) {
-    it.second.reset();
-  }
-  for (auto d : device_mgr_->ListDevices()) {
-    d->op_segment()->RemoveHold(session_handle_);
-  }
-  for (auto d : device_mgr_->ListDevices()) {
-    d->ClearResourceMgr();
-  }
-  functions_.clear();
-  delete cancellation_manager_;
 
-  execution_state_.reset(nullptr);
-  flib_def_.reset(nullptr);
-}
-
-Status NTSession::MaybeInitializeExecutionState(
-    const GraphDef& graph, bool* out_already_initialized) {
-  // If already initialized, do nothing.
-  if (flib_def_ && execution_state_) {
-    *out_already_initialized = true;
+  Status NTSession::MaybeInitializeExecutionState(const GraphDef& graph, bool* out_already_initialized) {
+    // If already initialized, do nothing.
+    if (flib_def_ && execution_state_) {
+      *out_already_initialized = true;
+      return Status::OK();
+    }
+    // Set up the per-session execution state.
+    // NOTE(mrry): The function library created here will be used for
+    // all subsequent extensions of the graph.
+    flib_def_.reset(new FunctionLibraryDefinition(OpRegistry::Global(), graph.library()));
+    GraphExecutionStateOptions options;
+    options.device_set = &device_set_;
+    options.session_options = &options_;
+    // TODO(mrry,suharshs): We explicitly copy `graph` so that
+    // `MakeForBaseGraph()` can take ownership of its
+    // contents. Previously this happened implicitly in calls to the
+    // `GraphExecutionState`. Other sessions call
+    // `MakeForBaseGraph` in such a way that we can destructively read
+    // the passed-in `GraphDef`. In principle we could do the same here,
+    // with a wider refactoring; we might revise the direct session so
+    // that it copies the graph fewer times.
+    GraphDef temp(graph);
+    TF_RETURN_IF_ERROR(GraphExecutionState::MakeForBaseGraph(&temp, options, &execution_state_));
+    graph_created_ = true;
+    *out_already_initialized = false;
     return Status::OK();
   }
-  // Set up the per-session execution state.
-  // NOTE(mrry): The function library created here will be used for
-  // all subsequent extensions of the graph.
-  flib_def_.reset(
-      new FunctionLibraryDefinition(OpRegistry::Global(), graph.library()));
-  GraphExecutionStateOptions options;
-  options.device_set = &device_set_;
-  options.session_options = &options_;
-  // TODO(mrry,suharshs): We explicitly copy `graph` so that
-  // `MakeForBaseGraph()` can take ownership of its
-  // contents. Previously this happened implicitly in calls to the
-  // `GraphExecutionState`. Other sessions call
-  // `MakeForBaseGraph` in such a way that we can destructively read
-  // the passed-in `GraphDef`. In principle we could do the same here,
-  // with a wider refactoring; we might revise the direct session so
-  // that it copies the graph fewer times.
-  GraphDef temp(graph);
-  TF_RETURN_IF_ERROR(
-      GraphExecutionState::MakeForBaseGraph(&temp, options, &execution_state_));
-  graph_created_ = true;
-  *out_already_initialized = false;
-  return Status::OK();
-}
 
-Status NTSession::Create(const GraphDef& graph) {
-  TF_RETURN_IF_ERROR(init_error_);
-  if (graph.node_size() > 0) {
-    mutex_lock l(graph_def_lock_);
-    if (graph_created_) {
-      return errors::AlreadyExists(
-          "A Graph has already been created for this session.");
+  Status NTSession::Create(const GraphDef& graph) {
+    TF_RETURN_IF_ERROR(init_error_);
+    if (graph.node_size() > 0) {
+      mutex_lock l(graph_def_lock_);
+      if (graph_created_) {
+        return errors::AlreadyExists("A Graph has already been created for this session.");
+      }
+      return ExtendLocked(graph);
     }
+    return Status::OK();
+  }
+
+  Status NTSession::Extend(const GraphDef& graph) {
+    TF_RETURN_IF_ERROR(CheckNotClosed());
+    mutex_lock l(graph_def_lock_);
     return ExtendLocked(graph);
   }
-  return Status::OK();
-}
 
-Status NTSession::Extend(const GraphDef& graph) {
-  TF_RETURN_IF_ERROR(CheckNotClosed());
-  mutex_lock l(graph_def_lock_);
-  return ExtendLocked(graph);
-}
-
-Status NTSession::ExtendLocked(const GraphDef& graph) {
-  bool already_initialized;
-  // If this is the first call, we can initialize the execution state
-  // with `graph` and do not need to call `Extend()`.
-  TF_RETURN_IF_ERROR(
-      MaybeInitializeExecutionState(graph, &already_initialized));
-  if (already_initialized) {
-    TF_RETURN_IF_ERROR(flib_def_->AddLibrary(graph.library()));
-    std::unique_ptr<GraphExecutionState> state;
-    TF_RETURN_IF_ERROR(execution_state_->Extend(graph, &state));
-    execution_state_.swap(state);
-  }
-  return Status::OK();
-}
-
-Status NTSession::Run(const NamedTensorList& inputs,
-                          const std::vector<string>& output_names,
-                          const std::vector<string>& target_nodes,
-                          std::vector<Tensor>* outputs) {
-  RunMetadata run_metadata;
-  return Run(RunOptions(), inputs, output_names, target_nodes, outputs,
-             &run_metadata);
-}
-
-Status NTSession::CreateDebuggerState(
-    const DebugOptions& debug_options, int64 session_run_index,
-    int64 executor_step_index, const std::vector<string>& input_names,
-    const std::vector<string>& output_names,
-    const std::vector<string>& target_names,
-    std::unique_ptr<DebuggerStateInterface>* debugger_state) {
-  TF_RETURN_IF_ERROR(
-      DebuggerStateRegistry::CreateState(debug_options, debugger_state));
-  TF_RETURN_IF_ERROR(debugger_state->get()->PublishDebugMetadata(
-      debug_options.global_step(), session_run_index, executor_step_index,
-      input_names, output_names, target_names));
-  return Status::OK();
-}
-
-Status NTSession::DecorateAndPublishGraphForDebug(
-    const DebugOptions& debug_options, Graph* graph, Device* device) {
-  std::unique_ptr<DebugGraphDecoratorInterface> decorator;
-  TF_RETURN_IF_ERROR(
-      DebugGraphDecoratorRegistry::CreateDecorator(debug_options, &decorator));
-
-  TF_RETURN_IF_ERROR(decorator->DecorateGraph(graph, device));
-  TF_RETURN_IF_ERROR(decorator->PublishGraph(*graph, device->name()));
-  return Status::OK();
-}
-
-Status NTSession::Run(const RunOptions& run_options,
-                          const NamedTensorList& inputs,
-                          const std::vector<string>& output_names,
-                          const std::vector<string>& target_nodes,
-                          std::vector<Tensor>* outputs,
-                          RunMetadata* run_metadata) {
-  TF_RETURN_IF_ERROR(CheckNotClosed());
-  nothreads_session_runs->GetCell()->IncrementBy(1);
-  {
-    mutex_lock l(graph_def_lock_);
-    if (!graph_created_) {
-      return errors::InvalidArgument(
-          "Session was not created with a graph before Run()!");
+  Status NTSession::ExtendLocked(const GraphDef& graph) {
+    bool already_initialized;
+    // If this is the first call, we can initialize the execution state
+    // with `graph` and do not need to call `Extend()`.
+    TF_RETURN_IF_ERROR(MaybeInitializeExecutionState(graph, &already_initialized));
+    if (already_initialized) {
+      TF_RETURN_IF_ERROR(flib_def_->AddLibrary(graph.library()));
+      std::unique_ptr<GraphExecutionState> state;
+      TF_RETURN_IF_ERROR(execution_state_->Extend(graph, &state));
+      execution_state_.swap(state);
     }
+    return Status::OK();
   }
 
-  // Extract the inputs names for this run of the session.
-  std::vector<string> input_tensor_names;
-  input_tensor_names.reserve(inputs.size());
-  for (const auto& it : inputs) {
-    input_tensor_names.push_back(it.first);
+  Status NTSession::Run(const NamedTensorList& inputs,
+                        const std::vector<string>& output_names,
+                        const std::vector<string>& target_nodes,
+                        std::vector<Tensor>* outputs) {
+    RunMetadata run_metadata;
+    return Run(RunOptions(), inputs, output_names, target_nodes, outputs, &run_metadata);
   }
 
-  // Check if we already have an executor for these arguments.
-  ExecutorsAndKeys* executors_and_keys;
-  RunStateArgs run_state_args(run_options.debug_options());
-
-  Executor::Args args;
-  args.step_id = step_id_counter_.fetch_add(1);
-
-  TF_RETURN_IF_ERROR(
-      GetOrCreateExecutors(input_tensor_names, output_names,
-                           target_nodes, &executors_and_keys,
-                           &run_state_args));
-  const int64 executor_step_count = executors_and_keys->step_count.fetch_add(1);
-
-  std::unique_ptr<DebuggerStateInterface> debugger_state;
-  if (!run_options.debug_options().debug_tensor_watch_opts().empty()) {
-    TF_RETURN_IF_ERROR(CreateDebuggerState(
-        run_options.debug_options(), args.step_id, executor_step_count,
-        input_tensor_names, output_names, target_nodes, &debugger_state));
+  Status NTSession::CreateDebuggerState(const DebugOptions& debug_options,
+                                        int64 session_run_index,
+                                        int64 executor_step_index,
+                                        const std::vector<string>& input_names,
+                                        const std::vector<string>& output_names,
+                                        const std::vector<string>& target_names,
+                                        std::unique_ptr<DebuggerStateInterface>* debugger_state) {
+    TF_RETURN_IF_ERROR(DebuggerStateRegistry::CreateState(debug_options, debugger_state));
+    TF_RETURN_IF_ERROR(debugger_state->get()->PublishDebugMetadata(
+        debug_options.global_step(), session_run_index, executor_step_index, input_names, output_names, target_names));
+    return Status::OK();
   }
 
-  // Configure a call frame for the step, which we use to feed and
-  // fetch values to and from the executors.
-  FunctionCallFrame call_frame(executors_and_keys->input_types,
-                               executors_and_keys->output_types);
-  gtl::InlinedVector<Tensor, 4> feed_args(inputs.size());
-  for (const auto& it : inputs) {
-    if (it.second.dtype() == DT_RESOURCE) {
-      Tensor tensor_from_handle;
-      TF_RETURN_IF_ERROR(
-          ResourceHandleToInputTensor(it.second, &tensor_from_handle));
-      feed_args[executors_and_keys->input_name_to_index[it.first]] =
-          tensor_from_handle;
-    } else {
-      feed_args[executors_and_keys->input_name_to_index[it.first]] = it.second;
-    }
-  }
-  const Status s = call_frame.SetArgs(feed_args);
-  if (errors::IsInternal(s)) {
-    return errors::InvalidArgument(s.error_message());
-  } else if (!s.ok()) {
-    return s;
+  Status NTSession::DecorateAndPublishGraphForDebug(const DebugOptions& debug_options, Graph* graph, Device* device) {
+    std::unique_ptr<DebugGraphDecoratorInterface> decorator;
+    TF_RETURN_IF_ERROR(DebugGraphDecoratorRegistry::CreateDecorator(debug_options, &decorator));
+
+    TF_RETURN_IF_ERROR(decorator->DecorateGraph(graph, device));
+    TF_RETURN_IF_ERROR(decorator->PublishGraph(*graph, device->name()));
+    return Status::OK();
   }
 
-  // Create a run state and start execution.
-  RunState run_state(args.step_id, &devices_);
-  run_state.rendez = new IntraProcessRendezvous(device_mgr_.get());
-  CancellationManager step_cancellation_manager;
-  args.call_frame = &call_frame;
-
-  // Start parallel Executors.
-  const size_t num_executors = executors_and_keys->items.size();
-  ExecutorBarrier* barrier = new ExecutorBarrier(
-      num_executors, run_state.rendez, [&run_state](const Status& ret) {
-        {
-          mutex_lock l(run_state.mu_);
-          run_state.status.Update(ret);
-        }
-        run_state.executors_done.Notify();
-      });
-
-  args.rendezvous = run_state.rendez;
-  args.cancellation_manager = &step_cancellation_manager;
-
-  args.session_state = &session_state_;
-  args.tensor_store = &run_state.tensor_store;
-  args.step_container = &run_state.step_container;
-  if (LogMemory::IsEnabled()) {
-    LogMemory::RecordStep(args.step_id, run_state_args.handle);
-  }
-  args.sync_on_finish = sync_on_finish_;
-
-  const bool do_trace = (run_options.trace_level() > RunOptions::NO_TRACE);
-
-  bool update_cost_model = false;
-  if (options_.config.graph_options().build_cost_model() > 0) {
-    const int64 build_cost_model_every =
-        options_.config.graph_options().build_cost_model();
-    const int64 build_cost_model_after =
-        options_.config.graph_options().build_cost_model_after();
-    int64 measure_step_count = executor_step_count - build_cost_model_after;
-    if (measure_step_count >= 0) {
-      update_cost_model =
-          ((measure_step_count + 1) % build_cost_model_every == 0);
-    }
-  }
-  if (do_trace || update_cost_model ||
-      run_options.report_tensor_allocations_upon_oom()) {
-    run_state.collector.reset(
-        new StepStatsCollector(run_metadata->mutable_step_stats()));
-    args.stats_collector = run_state.collector.get();
-  }
-
-  std::unique_ptr<DeviceTracer> tracer;
-  if (run_options.trace_level() >= RunOptions::HARDWARE_TRACE) {
-    tracer = CreateDeviceTracer();
-    // tracer may be NULL on platforms without accelerators.
-    if (tracer) {
-      Status s = tracer->Start();
-      if (!s.ok()) {
-        run_state.executors_done.Notify();
-        delete barrier;
-        return s;
+  Status NTSession::Run(const RunOptions& run_options,
+                        const NamedTensorList& inputs,
+                        const std::vector<string>& output_names,
+                        const std::vector<string>& target_nodes,
+                        std::vector<Tensor>* outputs,
+                        RunMetadata* run_metadata) {
+    TF_RETURN_IF_ERROR(CheckNotClosed());
+    nothreads_session_runs->GetCell()->IncrementBy(1);
+    {
+      mutex_lock l(graph_def_lock_);
+      if (!graph_created_) {
+        return errors::InvalidArgument("Session was not created with a graph before Run()!");
       }
     }
-  }
 
-  // Register this step with session's cancellation manager, so that
-  // `Session::Close()` will cancel the step.
-  const CancellationToken cancellation_token =
-      cancellation_manager_->get_cancellation_token();
-  const bool already_cancelled = !cancellation_manager_->RegisterCallback(
-      cancellation_token, [&step_cancellation_manager]() {
-        step_cancellation_manager.StartCancel();
-      });
-  if (already_cancelled) {
-    // NOTE(mrry): If we don't explicitly notify
-    // `run_state.executors_done`, the RunState destructor would
-    // block on this notification.
-    run_state.executors_done.Notify();
-    delete barrier;
-    return errors::Cancelled("Run call was cancelled");
-  }
+    // Extract the inputs names for this run of the session.
+    std::vector<string> input_tensor_names;
+    input_tensor_names.reserve(inputs.size());
+    for (const auto& it : inputs) {
+      input_tensor_names.push_back(it.first);
+    }
 
-  // pass no arguments to SchedClosure
-  // consequently, disable TF's own thread logic inside the loop
-  Executor::Args::Runner default_runner = [this](Executor::Args::Closure c) {
-    SchedClosure(std::move(c));
-  };
-  for (const auto& item : executors_and_keys->items) {
-    // TODO(zhengxq): support partial run.
-    // TODO(zhengxq): if the device picks its own threadpool, we need to assign
-    //     less threads to the main compute pool by default.
-    // thread::ThreadPool* device_thread_pool =
-    //     item.device->tensorflow_device_thread_pool();
-    // if (!device_thread_pool) {
-    //   args.runner = default_runner;
-    // } else {
-    //   args.runner = [this, device_thread_pool](Executor::Args::Closure c) {
-    //     SchedClosure(device_thread_pool, std::move(c));
-    //   };
-    // }
-    args.runner = default_runner;
-    item.executor->RunAsync(args, barrier->Get());
-  }
+    // Check if we already have an executor for these arguments.
+    ExecutorsAndKeys* executors_and_keys;
+    RunStateArgs run_state_args(run_options.debug_options());
 
-  WaitForNotification(&run_state, &step_cancellation_manager,
-                      run_options.timeout_in_ms() > 0
-                          ? run_options.timeout_in_ms()
-                          : operation_timeout_in_ms_);
+    Executor::Args args;
+    args.step_id = step_id_counter_.fetch_add(1);
 
-  if (!cancellation_manager_->DeregisterCallback(cancellation_token)) {
-    // The step has been cancelled: make sure we don't attempt to receive the
-    // outputs as this would make it block forever.
-    mutex_lock l(run_state.mu_);
-    run_state.status.Update(errors::Cancelled("Run call was cancelled"));
-  }
+    TF_RETURN_IF_ERROR(
+        GetOrCreateExecutors(input_tensor_names, output_names, target_nodes, &executors_and_keys, &run_state_args));
+    const int64 executor_step_count = executors_and_keys->step_count.fetch_add(1);
 
-  if (tracer) {
-    TF_RETURN_IF_ERROR(tracer->Stop());
-    TF_RETURN_IF_ERROR(tracer->Collect(args.stats_collector));
-  }
+    std::unique_ptr<DebuggerStateInterface> debugger_state;
+    if (!run_options.debug_options().debug_tensor_watch_opts().empty()) {
+      TF_RETURN_IF_ERROR(CreateDebuggerState(run_options.debug_options(),
+                                             args.step_id,
+                                             executor_step_count,
+                                             input_tensor_names,
+                                             output_names,
+                                             target_nodes,
+                                             &debugger_state));
+    }
 
-  {
-    mutex_lock l(run_state.mu_);
-    TF_RETURN_IF_ERROR(run_state.status);
-  }
-
-  // Receive outputs.
-  if (outputs) {
-    std::vector<Tensor> sorted_outputs;
-    const Status s = call_frame.ConsumeRetvals(&sorted_outputs);
+    // Configure a call frame for the step, which we use to feed and
+    // fetch values to and from the executors.
+    FunctionCallFrame call_frame(executors_and_keys->input_types, executors_and_keys->output_types);
+    gtl::InlinedVector<Tensor, 4> feed_args(inputs.size());
+    for (const auto& it : inputs) {
+      if (it.second.dtype() == DT_RESOURCE) {
+        Tensor tensor_from_handle;
+        TF_RETURN_IF_ERROR(ResourceHandleToInputTensor(it.second, &tensor_from_handle));
+        feed_args[executors_and_keys->input_name_to_index[it.first]] = tensor_from_handle;
+      } else {
+        feed_args[executors_and_keys->input_name_to_index[it.first]] = it.second;
+      }
+    }
+    const Status s = call_frame.SetArgs(feed_args);
     if (errors::IsInternal(s)) {
       return errors::InvalidArgument(s.error_message());
     } else if (!s.ok()) {
       return s;
     }
-    const bool unique_outputs =
-        output_names.size() == executors_and_keys->output_name_to_index.size();
-    // first_indices[i] = j implies that j is the smallest value for which
-    // output_names[i] == output_names[j].
-    std::vector<int> first_indices;
-    if (!unique_outputs) {
-      first_indices.resize(output_names.size());
-      for (int i = 0; i < static_cast<int>(output_names.size()); ++i) {
-        for (int j = 0; j <= i; ++j) {
-          if (output_names[i] == output_names[j]) {
-            first_indices[i] = j;
-            break;
+
+    // Create a run state and start execution.
+    RunState run_state(args.step_id, &devices_);
+    run_state.rendez = new IntraProcessRendezvous(device_mgr_.get());
+    CancellationManager step_cancellation_manager;
+    args.call_frame = &call_frame;
+
+    // Start parallel Executors.
+    const size_t num_executors = executors_and_keys->items.size();
+    ExecutorBarrier* barrier = new ExecutorBarrier(num_executors, run_state.rendez, [&run_state](const Status& ret) {
+      {
+        mutex_lock l(run_state.mu_);
+        run_state.status.Update(ret);
+      }
+      run_state.executors_done.Notify();
+    });
+
+    args.rendezvous = run_state.rendez;
+    args.cancellation_manager = &step_cancellation_manager;
+
+    args.session_state = &session_state_;
+    args.tensor_store = &run_state.tensor_store;
+    args.step_container = &run_state.step_container;
+    if (LogMemory::IsEnabled()) {
+      LogMemory::RecordStep(args.step_id, run_state_args.handle);
+    }
+    args.sync_on_finish = sync_on_finish_;
+
+    const bool do_trace = (run_options.trace_level() > RunOptions::NO_TRACE);
+
+    bool update_cost_model = false;
+    if (options_.config.graph_options().build_cost_model() > 0) {
+      const int64 build_cost_model_every = options_.config.graph_options().build_cost_model();
+      const int64 build_cost_model_after = options_.config.graph_options().build_cost_model_after();
+      int64 measure_step_count = executor_step_count - build_cost_model_after;
+      if (measure_step_count >= 0) {
+        update_cost_model = ((measure_step_count + 1) % build_cost_model_every == 0);
+      }
+    }
+    if (do_trace || update_cost_model || run_options.report_tensor_allocations_upon_oom()) {
+      run_state.collector.reset(new StepStatsCollector(run_metadata->mutable_step_stats()));
+      args.stats_collector = run_state.collector.get();
+    }
+
+    std::unique_ptr<DeviceTracer> tracer;
+    if (run_options.trace_level() >= RunOptions::HARDWARE_TRACE) {
+      tracer = CreateDeviceTracer();
+      // tracer may be NULL on platforms without accelerators.
+      if (tracer) {
+        Status s = tracer->Start();
+        if (!s.ok()) {
+          run_state.executors_done.Notify();
+          delete barrier;
+          return s;
+        }
+      }
+    }
+
+    // Register this step with session's cancellation manager, so that
+    // `Session::Close()` will cancel the step.
+    const CancellationToken cancellation_token = cancellation_manager_->get_cancellation_token();
+    const bool already_cancelled = !cancellation_manager_->RegisterCallback(
+        cancellation_token, [&step_cancellation_manager]() { step_cancellation_manager.StartCancel(); });
+    if (already_cancelled) {
+      // NOTE(mrry): If we don't explicitly notify
+      // `run_state.executors_done`, the RunState destructor would
+      // block on this notification.
+      run_state.executors_done.Notify();
+      delete barrier;
+      return errors::Cancelled("Run call was cancelled");
+    }
+
+    // pass no arguments to SchedClosure
+    // consequently, disable TF's own thread logic inside the loop
+    Executor::Args::Runner default_runner = [this](Executor::Args::Closure c) { SchedClosure(std::move(c)); };
+    for (const auto& item : executors_and_keys->items) {
+      // TODO(zhengxq): support partial run.
+      // TODO(zhengxq): if the device picks its own threadpool, we need to assign
+      //     less threads to the main compute pool by default.
+      // thread::ThreadPool* device_thread_pool =
+      //     item.device->tensorflow_device_thread_pool();
+      // if (!device_thread_pool) {
+      //   args.runner = default_runner;
+      // } else {
+      //   args.runner = [this, device_thread_pool](Executor::Args::Closure c) {
+      //     SchedClosure(device_thread_pool, std::move(c));
+      //   };
+      // }
+      args.runner = default_runner;
+      item.executor->RunAsync(args, barrier->Get());
+    }
+
+    WaitForNotification(&run_state,
+                        &step_cancellation_manager,
+                        run_options.timeout_in_ms() > 0 ? run_options.timeout_in_ms() : operation_timeout_in_ms_);
+
+    if (!cancellation_manager_->DeregisterCallback(cancellation_token)) {
+      // The step has been cancelled: make sure we don't attempt to receive the
+      // outputs as this would make it block forever.
+      mutex_lock l(run_state.mu_);
+      run_state.status.Update(errors::Cancelled("Run call was cancelled"));
+    }
+
+    if (tracer) {
+      TF_RETURN_IF_ERROR(tracer->Stop());
+      TF_RETURN_IF_ERROR(tracer->Collect(args.stats_collector));
+    }
+
+    {
+      mutex_lock l(run_state.mu_);
+      TF_RETURN_IF_ERROR(run_state.status);
+    }
+
+    // Receive outputs.
+    if (outputs) {
+      std::vector<Tensor> sorted_outputs;
+      const Status s = call_frame.ConsumeRetvals(&sorted_outputs);
+      if (errors::IsInternal(s)) {
+        return errors::InvalidArgument(s.error_message());
+      } else if (!s.ok()) {
+        return s;
+      }
+      const bool unique_outputs = output_names.size() == executors_and_keys->output_name_to_index.size();
+      // first_indices[i] = j implies that j is the smallest value for which
+      // output_names[i] == output_names[j].
+      std::vector<int> first_indices;
+      if (!unique_outputs) {
+        first_indices.resize(output_names.size());
+        for (int i = 0; i < static_cast<int>(output_names.size()); ++i) {
+          for (int j = 0; j <= i; ++j) {
+            if (output_names[i] == output_names[j]) {
+              first_indices[i] = j;
+              break;
+            }
           }
         }
       }
-    }
-    outputs->clear();
-    outputs->reserve(sorted_outputs.size());
-    for (int i = 0; i < static_cast<int>(output_names.size()); ++i) {
-      const string& output_name = output_names[i];
-      if (first_indices.empty() || first_indices[i] == i) {
-        outputs->emplace_back(
-            std::move(sorted_outputs[executors_and_keys
-                                         ->output_name_to_index[output_name]]));
-      } else {
-        outputs->push_back((*outputs)[first_indices[i]]);
-      }
-    }
-  }
-
-  // Save the output tensors of this run we choose to keep.
-  TF_RETURN_IF_ERROR(
-      run_state.tensor_store.SaveTensors(output_names, &session_state_));
-  if (args.stats_collector) {
-    args.stats_collector->Finalize();
-  }
-
-  // Build and return the cost model as instructed.
-  mutex_lock l(executor_lock_);
-  if (update_cost_model) {
-    // Build the cost model
-    std::unordered_map<string, const Graph*> device_to_graph;
-    for (const PerPartitionExecutorsAndLib& partition :
-         executors_and_keys->items) {
-      const Graph* graph = partition.graph;
-      const string device = partition.flib->device()->name();
-      device_to_graph[device] = graph;
-    }
-    args.stats_collector->BuildCostModel(&cost_model_manager_, device_to_graph);
-
-    // annotate stats onto cost graph.
-    CostGraphDef* cost_graph = run_metadata->mutable_cost_graph();
-    for (const auto& item : executors_and_keys->items) {
-      TF_RETURN_IF_ERROR(
-          cost_model_manager_.AddToCostGraphDef(item.graph, cost_graph));
-    }
-  }
-
-  // If requested via RunOptions, output the partition graphs.
-  if (run_options.output_partition_graphs()) {
-    protobuf::RepeatedPtrField<GraphDef>* partition_graph_defs =
-        run_metadata->mutable_partition_graphs();
-    for (const PerPartitionExecutorsAndLib& exec_and_lib :
-         executors_and_keys->items) {
-      GraphDef* partition_graph_def = partition_graph_defs->Add();
-      exec_and_lib.graph->ToGraphDef(partition_graph_def);
-    }
-  }
-
-  return Status::OK();
-}
-
-Status NTSession::PRunSetup(const std::vector<string>& input_names,
-                                const std::vector<string>& output_names,
-                                const std::vector<string>& target_nodes,
-                                string* handle) {
-  TF_RETURN_IF_ERROR(CheckNotClosed());
-  {
-    mutex_lock l(graph_def_lock_);
-    if (!graph_created_) {
-      return errors::InvalidArgument(
-          "Session was not created with a graph before PRunSetup()!");
-    }
-  }
-
-  // Check if we already have an executor for these arguments.
-  ExecutorsAndKeys* executors_and_keys;
-  // TODO(cais): TFDBG support for partial runs.
-  DebugOptions debug_options;
-  RunStateArgs run_state_args(debug_options);
-  run_state_args.is_partial_run = true;
-  TF_RETURN_IF_ERROR(GetOrCreateExecutors(input_names, output_names,
-                                          target_nodes, &executors_and_keys,
-                                          &run_state_args));
-
-  // Create the run state and save it for future PRun calls.
-  Executor::Args args;
-  args.step_id = step_id_counter_.fetch_add(1);
-  RunState* run_state =
-      new RunState(input_names, output_names, args.step_id, &devices_);
-  run_state->rendez = new IntraProcessRendezvous(device_mgr_.get());
-  {
-    mutex_lock l(executor_lock_);
-    if (!partial_runs_
-             .emplace(run_state_args.handle,
-                      std::unique_ptr<RunState>(run_state))
-             .second) {
-      return errors::Internal("The handle '", run_state_args.handle,
-                              "' created for this partial run is not unique.");
-    }
-  }
-
-  // Start parallel Executors.
-  const size_t num_executors = executors_and_keys->items.size();
-  ExecutorBarrier* barrier = new ExecutorBarrier(
-      num_executors, run_state->rendez, [run_state](const Status& ret) {
-        if (!ret.ok()) {
-          mutex_lock l(run_state->mu_);
-          run_state->status.Update(ret);
+      outputs->clear();
+      outputs->reserve(sorted_outputs.size());
+      for (int i = 0; i < static_cast<int>(output_names.size()); ++i) {
+        const string& output_name = output_names[i];
+        if (first_indices.empty() || first_indices[i] == i) {
+          outputs->emplace_back(std::move(sorted_outputs[executors_and_keys->output_name_to_index[output_name]]));
+        } else {
+          outputs->push_back((*outputs)[first_indices[i]]);
         }
-        run_state->executors_done.Notify();
-      });
-
-  args.rendezvous = run_state->rendez;
-  args.cancellation_manager = cancellation_manager_;
-  args.runner = [this](Executor::Args::Closure c) {
-    SchedClosure(std::move(c));
-  };
-  args.session_state = &session_state_;
-  args.tensor_store = &run_state->tensor_store;
-  args.step_container = &run_state->step_container;
-  if (LogMemory::IsEnabled()) {
-    LogMemory::RecordStep(args.step_id, run_state_args.handle);
-  }
-  args.sync_on_finish = sync_on_finish_;
-
-  if (options_.config.graph_options().build_cost_model()) {
-    run_state->collector.reset(new StepStatsCollector(nullptr));
-    args.stats_collector = run_state->collector.get();
-  }
-
-  for (auto& item : executors_and_keys->items) {
-    item.executor->RunAsync(args, barrier->Get());
-  }
-
-  *handle = run_state_args.handle;
-  return Status::OK();
-}
-
-Status NTSession::PRun(const string& handle, const NamedTensorList& inputs,
-                           const std::vector<string>& output_names,
-                           std::vector<Tensor>* outputs) {
-  TF_RETURN_IF_ERROR(CheckNotClosed());
-  std::vector<string> parts = str_util::Split(handle, ';');
-  const string& key = parts[0];
-  // Get the executors for this partial run.
-  ExecutorsAndKeys* executors_and_keys;
-  RunState* run_state;
-  {
-    mutex_lock l(executor_lock_);  // could use reader lock
-    auto exc_it = executors_.find(key);
-    if (exc_it == executors_.end()) {
-      return errors::InvalidArgument(
-          "Must run 'setup' before performing partial runs!");
-    }
-    executors_and_keys = exc_it->second.get();
-
-    auto prun_it = partial_runs_.find(handle);
-    if (prun_it == partial_runs_.end()) {
-      return errors::InvalidArgument(
-          "Must run 'setup' before performing partial runs!");
-    }
-    run_state = prun_it->second.get();
-
-    // Make sure that this is a new set of feeds that are still pending.
-    for (const auto& input : inputs) {
-      auto it = run_state->pending_inputs.find(input.first);
-      if (it == run_state->pending_inputs.end()) {
-        return errors::InvalidArgument(
-            "The feed ", input.first,
-            " was not specified in partial_run_setup.");
-      } else if (it->second) {
-        return errors::InvalidArgument("The feed ", input.first,
-                                       " has already been fed.");
       }
     }
-    // Check that this is a new set of fetches that are still pending.
-    for (const auto& output : output_names) {
-      auto it = run_state->pending_outputs.find(output);
-      if (it == run_state->pending_outputs.end()) {
-        return errors::InvalidArgument(
-            "The fetch ", output, " was not specified in partial_run_setup.");
-      } else if (it->second) {
-        return errors::InvalidArgument("The fetch ", output,
-                                       " has already been fetched.");
-      }
+
+    // Save the output tensors of this run we choose to keep.
+    TF_RETURN_IF_ERROR(run_state.tensor_store.SaveTensors(output_names, &session_state_));
+    if (args.stats_collector) {
+      args.stats_collector->Finalize();
     }
-  }
 
-  // Check that this new set of fetches can be computed from all the
-  // feeds we have supplied.
-  TF_RETURN_IF_ERROR(
-      CheckFetch(inputs, output_names, executors_and_keys, run_state));
-
-  // Send inputs.
-  Status s = SendPRunInputs(inputs, executors_and_keys, run_state->rendez);
-
-  // Receive outputs.
-  if (s.ok()) {
-    s = RecvPRunOutputs(output_names, executors_and_keys, run_state, outputs);
-  }
-
-  // Save the output tensors of this run we choose to keep.
-  if (s.ok()) {
-    s = run_state->tensor_store.SaveTensors(output_names, &session_state_);
-  }
-
-  {
+    // Build and return the cost model as instructed.
     mutex_lock l(executor_lock_);
-    // Delete the run state if there is an error or all fetches are done.
-    bool done = true;
-    if (s.ok()) {
-      {
+    if (update_cost_model) {
+      // Build the cost model
+      std::unordered_map<string, const Graph*> device_to_graph;
+      for (const PerPartitionExecutorsAndLib& partition : executors_and_keys->items) {
+        const Graph* graph = partition.graph;
+        const string device = partition.flib->device()->name();
+        device_to_graph[device] = graph;
+      }
+      args.stats_collector->BuildCostModel(&cost_model_manager_, device_to_graph);
+
+      // annotate stats onto cost graph.
+      CostGraphDef* cost_graph = run_metadata->mutable_cost_graph();
+      for (const auto& item : executors_and_keys->items) {
+        TF_RETURN_IF_ERROR(cost_model_manager_.AddToCostGraphDef(item.graph, cost_graph));
+      }
+    }
+
+    // If requested via RunOptions, output the partition graphs.
+    if (run_options.output_partition_graphs()) {
+      protobuf::RepeatedPtrField<GraphDef>* partition_graph_defs = run_metadata->mutable_partition_graphs();
+      for (const PerPartitionExecutorsAndLib& exec_and_lib : executors_and_keys->items) {
+        GraphDef* partition_graph_def = partition_graph_defs->Add();
+        exec_and_lib.graph->ToGraphDef(partition_graph_def);
+      }
+    }
+
+    return Status::OK();
+  }
+
+  Status NTSession::PRunSetup(const std::vector<string>& input_names,
+                              const std::vector<string>& output_names,
+                              const std::vector<string>& target_nodes,
+                              string* handle) {
+    TF_RETURN_IF_ERROR(CheckNotClosed());
+    {
+      mutex_lock l(graph_def_lock_);
+      if (!graph_created_) {
+        return errors::InvalidArgument("Session was not created with a graph before PRunSetup()!");
+      }
+    }
+
+    // Check if we already have an executor for these arguments.
+    ExecutorsAndKeys* executors_and_keys;
+    // TODO(cais): TFDBG support for partial runs.
+    DebugOptions debug_options;
+    RunStateArgs run_state_args(debug_options);
+    run_state_args.is_partial_run = true;
+    TF_RETURN_IF_ERROR(
+        GetOrCreateExecutors(input_names, output_names, target_nodes, &executors_and_keys, &run_state_args));
+
+    // Create the run state and save it for future PRun calls.
+    Executor::Args args;
+    args.step_id = step_id_counter_.fetch_add(1);
+    RunState* run_state = new RunState(input_names, output_names, args.step_id, &devices_);
+    run_state->rendez = new IntraProcessRendezvous(device_mgr_.get());
+    {
+      mutex_lock l(executor_lock_);
+      if (!partial_runs_.emplace(run_state_args.handle, std::unique_ptr<RunState>(run_state)).second) {
+        return errors::Internal("The handle '", run_state_args.handle, "' created for this partial run is not unique.");
+      }
+    }
+
+    // Start parallel Executors.
+    const size_t num_executors = executors_and_keys->items.size();
+    ExecutorBarrier* barrier = new ExecutorBarrier(num_executors, run_state->rendez, [run_state](const Status& ret) {
+      if (!ret.ok()) {
         mutex_lock l(run_state->mu_);
-        if (!run_state->status.ok()) {
-          LOG(WARNING) << "An error unrelated to this prun has been detected. "
-                       << run_state->status;
-        }
+        run_state->status.Update(ret);
       }
+      run_state->executors_done.Notify();
+    });
+
+    args.rendezvous = run_state->rendez;
+    args.cancellation_manager = cancellation_manager_;
+    args.runner = [this](Executor::Args::Closure c) { SchedClosure(std::move(c)); };
+    args.session_state = &session_state_;
+    args.tensor_store = &run_state->tensor_store;
+    args.step_container = &run_state->step_container;
+    if (LogMemory::IsEnabled()) {
+      LogMemory::RecordStep(args.step_id, run_state_args.handle);
+    }
+    args.sync_on_finish = sync_on_finish_;
+
+    if (options_.config.graph_options().build_cost_model()) {
+      run_state->collector.reset(new StepStatsCollector(nullptr));
+      args.stats_collector = run_state->collector.get();
+    }
+
+    for (auto& item : executors_and_keys->items) {
+      item.executor->RunAsync(args, barrier->Get());
+    }
+
+    *handle = run_state_args.handle;
+    return Status::OK();
+  }
+
+  Status NTSession::PRun(const string& handle,
+                         const NamedTensorList& inputs,
+                         const std::vector<string>& output_names,
+                         std::vector<Tensor>* outputs) {
+    TF_RETURN_IF_ERROR(CheckNotClosed());
+    std::vector<string> parts = str_util::Split(handle, ';');
+    const string& key = parts[0];
+    // Get the executors for this partial run.
+    ExecutorsAndKeys* executors_and_keys;
+    RunState* run_state;
+    {
+      mutex_lock l(executor_lock_);  // could use reader lock
+      auto exc_it = executors_.find(key);
+      if (exc_it == executors_.end()) {
+        return errors::InvalidArgument("Must run 'setup' before performing partial runs!");
+      }
+      executors_and_keys = exc_it->second.get();
+
+      auto prun_it = partial_runs_.find(handle);
+      if (prun_it == partial_runs_.end()) {
+        return errors::InvalidArgument("Must run 'setup' before performing partial runs!");
+      }
+      run_state = prun_it->second.get();
+
+      // Make sure that this is a new set of feeds that are still pending.
       for (const auto& input : inputs) {
         auto it = run_state->pending_inputs.find(input.first);
-        it->second = true;
+        if (it == run_state->pending_inputs.end()) {
+          return errors::InvalidArgument("The feed ", input.first, " was not specified in partial_run_setup.");
+        } else if (it->second) {
+          return errors::InvalidArgument("The feed ", input.first, " has already been fed.");
+        }
       }
-      for (const auto& name : output_names) {
-        auto it = run_state->pending_outputs.find(name);
-        it->second = true;
+      // Check that this is a new set of fetches that are still pending.
+      for (const auto& output : output_names) {
+        auto it = run_state->pending_outputs.find(output);
+        if (it == run_state->pending_outputs.end()) {
+          return errors::InvalidArgument("The fetch ", output, " was not specified in partial_run_setup.");
+        } else if (it->second) {
+          return errors::InvalidArgument("The fetch ", output, " has already been fetched.");
+        }
       }
-      done = run_state->PendingDone();
-    }
-    if (done) {
-      WaitForNotification(run_state, cancellation_manager_,
-                          operation_timeout_in_ms_);
-      partial_runs_.erase(handle);
-    }
-  }
-
-  return s;
-}
-
-Status NTSession::ResourceHandleToInputTensor(const Tensor& resource_tensor,
-                                                  Tensor* retrieved_tensor) {
-  if (resource_tensor.dtype() != DT_RESOURCE) {
-    return errors::InvalidArgument(strings::StrCat(
-        "ResourceHandleToInputTensor() received non-DT_RESOURCE Tensor: ",
-        resource_tensor.dtype()));
-  }
-
-  const ResourceHandle& resource_handle =
-      resource_tensor.scalar<ResourceHandle>()();
-
-  if (resource_handle.container() ==
-      SessionState::kTensorHandleResourceTypeName) {
-    return session_state_.GetTensor(resource_handle.name(), retrieved_tensor);
-  } else {
-    return errors::InvalidArgument(strings::StrCat(
-        "Invalid resource type hash code: ", resource_handle.hash_code(),
-        "(name: ", resource_handle.name(),
-        " type: ", resource_handle.maybe_type_name(),
-        "). Perhaps a resource tensor was being provided as a feed? That is "
-        "not currently allowed. Please file an issue at "
-        "https://github.com/tensorflow/tensorflow/issues/new, ideally with a "
-        "short code snippet that leads to this error message."));
-  }
-}
-
-Status NTSession::SendPRunInputs(const NamedTensorList& inputs,
-                                     const ExecutorsAndKeys* executors_and_keys,
-                                     IntraProcessRendezvous* rendez) {
-  Status s;
-  Rendezvous::ParsedKey parsed;
-  // Insert the input tensors into the local rendezvous by their
-  // rendezvous key.
-  for (const auto& input : inputs) {
-    auto it =
-        executors_and_keys->input_name_to_rendezvous_key.find(input.first);
-    if (it == executors_and_keys->input_name_to_rendezvous_key.end()) {
-      return errors::Internal("'", input.first, "' is not a pre-defined feed.");
-    }
-    const string& input_key = it->second;
-
-    s = Rendezvous::ParseKey(input_key, &parsed);
-    if (!s.ok()) {
-      rendez->StartAbort(s);
-      return s;
     }
 
-    if (input.second.dtype() == DT_RESOURCE) {
-      Tensor tensor_from_handle;
-      s = ResourceHandleToInputTensor(input.second, &tensor_from_handle);
-      if (s.ok()) {
-        s = rendez->Send(parsed, Rendezvous::Args(), tensor_from_handle, false);
-      }
-    } else {
-      s = rendez->Send(parsed, Rendezvous::Args(), input.second, false);
-    }
+    // Check that this new set of fetches can be computed from all the
+    // feeds we have supplied.
+    TF_RETURN_IF_ERROR(CheckFetch(inputs, output_names, executors_and_keys, run_state));
 
-    if (!s.ok()) {
-      rendez->StartAbort(s);
-      return s;
-    }
-  }
-  return Status::OK();
-}
+    // Send inputs.
+    Status s = SendPRunInputs(inputs, executors_and_keys, run_state->rendez);
 
-Status NTSession::RecvPRunOutputs(
-    const std::vector<string>& output_names,
-    const ExecutorsAndKeys* executors_and_keys, RunState* run_state,
-    std::vector<Tensor>* outputs) {
-  Status s;
-  if (!output_names.empty()) {
-    outputs->resize(output_names.size());
-  }
-
-  Rendezvous::ParsedKey parsed;
-  // Get the outputs from the rendezvous
-  for (size_t output_offset = 0; output_offset < output_names.size();
-       ++output_offset) {
-    const string& output_name = output_names[output_offset];
-    auto it =
-        executors_and_keys->output_name_to_rendezvous_key.find(output_name);
-    if (it == executors_and_keys->output_name_to_rendezvous_key.end()) {
-      return errors::Internal("'", output_name,
-                              "' is not a pre-defined fetch.");
-    }
-    const string& output_key = it->second;
-    Tensor output_tensor;
-    bool is_dead;
-    IntraProcessRendezvous* rendez = run_state->rendez;
-
-    s = Rendezvous::ParseKey(output_key, &parsed);
+    // Receive outputs.
     if (s.ok()) {
-      // Fetch data from the Rendezvous.
-      s = rendez->Recv(parsed, Rendezvous::Args(), &output_tensor, &is_dead,
-                       operation_timeout_in_ms_);
-      if (is_dead && s.ok()) {
-        s = errors::InvalidArgument("The tensor returned for ", output_name,
-                                    " was not valid.");
-      }
-    }
-    if (!s.ok()) {
-      rendez->StartAbort(s);
-      outputs->clear();
-      return s;
+      s = RecvPRunOutputs(output_names, executors_and_keys, run_state, outputs);
     }
 
-    (*outputs)[output_offset] = output_tensor;
-  }
-  return Status::OK();
-}
-
-Status NTSession::CheckFetch(const NamedTensorList& feeds,
-                                 const std::vector<string>& fetches,
-                                 const ExecutorsAndKeys* executors_and_keys,
-                                 const RunState* run_state) {
-  const Graph* graph = executors_and_keys->graph.get();
-  const NameNodeMap* name_to_node = &executors_and_keys->name_to_node;
-
-  // Build the set of pending feeds that we haven't seen.
-  std::unordered_set<TensorId, TensorId::Hasher> pending_feeds;
-  {
-    mutex_lock l(executor_lock_);
-    for (const auto& input : run_state->pending_inputs) {
-      // Skip if the feed has already been fed.
-      if (input.second) continue;
-      TensorId id(ParseTensorName(input.first));
-      auto it = name_to_node->find(id.first);
-      if (it == name_to_node->end()) {
-        return errors::NotFound("Feed ", input.first, ": not found");
-      }
-      pending_feeds.insert(id);
-    }
-  }
-  for (const auto& it : feeds) {
-    TensorId id(ParseTensorName(it.first));
-    pending_feeds.erase(id);
-  }
-
-  // Initialize the stack with the fetch nodes.
-  std::vector<const Node*> stack;
-  for (const string& fetch : fetches) {
-    TensorId id(ParseTensorName(fetch));
-    auto it = name_to_node->find(id.first);
-    if (it == name_to_node->end()) {
-      return errors::NotFound("Fetch ", fetch, ": not found");
-    }
-    stack.push_back(it->second);
-  }
-
-  // Any tensor needed for fetches can't be in pending_feeds.
-  std::vector<bool> visited(graph->num_node_ids(), false);
-  while (!stack.empty()) {
-    const Node* n = stack.back();
-    stack.pop_back();
-
-    for (const Edge* in_edge : n->in_edges()) {
-      const Node* in_node = in_edge->src();
-      if (pending_feeds.count({in_node->name(), in_edge->src_output()}) > 0) {
-        return errors::InvalidArgument("Fetch ", in_node->name(), ":",
-                                       in_edge->src_output(),
-                                       " can't be computed from the feeds"
-                                       " that have been fed so far.");
-      }
-      if (!visited[in_node->id()]) {
-        visited[in_node->id()] = true;
-        stack.push_back(in_node);
-      }
-    }
-  }
-  return Status::OK();
-}
-
-Status NTSession::GetOrCreateExecutors(
-    gtl::ArraySlice<string> inputs, gtl::ArraySlice<string> outputs,
-    gtl::ArraySlice<string> target_nodes, ExecutorsAndKeys** executors_and_keys,
-    RunStateArgs* run_state_args) {
-  int64 handle_name_counter_value = -1;
-  if (LogMemory::IsEnabled() || run_state_args->is_partial_run) {
-    handle_name_counter_value = handle_name_counter_.fetch_add(1);
-  }
-
-  string debug_tensor_watches_summary;
-  if (!run_state_args->debug_options.debug_tensor_watch_opts().empty()) {
-    debug_tensor_watches_summary = SummarizeDebugTensorWatches(
-        run_state_args->debug_options.debug_tensor_watch_opts());
-  }
-
-  // Fast lookup path, no sorting.
-  const string key = strings::StrCat(
-      str_util::Join(inputs, ","), "->", str_util::Join(outputs, ","), "/",
-      str_util::Join(target_nodes, ","), "/", run_state_args->is_partial_run,
-      "/", debug_tensor_watches_summary);
-  // Set the handle, if it's needed to log memory or for partial run.
-  if (handle_name_counter_value >= 0) {
-    run_state_args->handle =
-        strings::StrCat(key, ";", handle_name_counter_value);
-  }
-
-  // See if we already have the executors for this run.
-  {
-    mutex_lock l(executor_lock_);  // could use reader lock
-    auto it = executors_.find(key);
-    if (it != executors_.end()) {
-      *executors_and_keys = it->second.get();
-      return Status::OK();
-    }
-  }
-
-  // Slow lookup path, the unsorted key missed the cache.
-  // Sort the inputs and outputs, and look up with the sorted key in case an
-  // earlier call used a different order of inputs and outputs.
-  //
-  // We could consider some other signature instead of sorting that
-  // preserves the same property to avoid the sort in the future.
-  std::vector<string> inputs_sorted(inputs.begin(), inputs.end());
-  std::sort(inputs_sorted.begin(), inputs_sorted.end());
-  std::vector<string> outputs_sorted(outputs.begin(), outputs.end());
-  std::sort(outputs_sorted.begin(), outputs_sorted.end());
-  std::vector<string> tn_sorted(target_nodes.begin(), target_nodes.end());
-  std::sort(tn_sorted.begin(), tn_sorted.end());
-
-  const string sorted_key = strings::StrCat(
-      str_util::Join(inputs_sorted, ","), "->",
-      str_util::Join(outputs_sorted, ","), "/", str_util::Join(tn_sorted, ","),
-      "/", run_state_args->is_partial_run, "/", debug_tensor_watches_summary);
-  // Set the handle, if its needed to log memory or for partial run.
-  if (handle_name_counter_value >= 0) {
-    run_state_args->handle =
-        strings::StrCat(sorted_key, ";", handle_name_counter_value);
-  }
-
-  // See if we already have the executors for this run.
-  {
-    mutex_lock l(executor_lock_);
-    auto it = executors_.find(sorted_key);
-    if (it != executors_.end()) {
-      *executors_and_keys = it->second.get();
-      // Insert this under the original key.
-      executors_.emplace(key, it->second);
-      return Status::OK();
-    }
-  }
-
-  // Nothing found, so create the executors and store in the cache.
-  BuildGraphOptions options;
-  options.feed_endpoints = inputs_sorted;
-  options.fetch_endpoints = outputs_sorted;
-  options.target_nodes = tn_sorted;
-  options.use_function_convention = !run_state_args->is_partial_run;
-  if (!run_state_args->debug_options.debug_tensor_watch_opts().empty()) {
-    options.debug_options = run_state_args->debug_options;
-  }
-
-  std::unique_ptr<FunctionInfo> func_info(new FunctionInfo);
-  std::shared_ptr<ExecutorsAndKeys> ek(new ExecutorsAndKeys);
-
-  // The executor_lock_ is intentionally released while executor is
-  // being created.
-  std::unordered_map<string, std::unique_ptr<Graph>> graphs;
-  TF_RETURN_IF_ERROR(CreateGraphs(options, &graphs, &func_info->flib_def,
-                                  run_state_args, &ek->input_types,
-                                  &ek->output_types));
-
-  if (run_state_args->is_partial_run) {
-    ek->graph = std::move(run_state_args->graph);
-    std::unordered_set<StringPiece, StringPieceHasher> names;
-    for (const string& input : inputs) {
-      TensorId id(ParseTensorName(input));
-      names.emplace(id.first);
-    }
-    for (const string& output : outputs) {
-      TensorId id(ParseTensorName(output));
-      names.emplace(id.first);
-    }
-    for (Node* n : ek->graph->nodes()) {
-      if (names.count(n->name()) > 0) {
-        ek->name_to_node.insert({n->name(), n});
-      }
-    }
-  }
-  ek->items.reserve(graphs.size());
-  const auto& optimizer_opts =
-      options_.config.graph_options().optimizer_options();
-
-  int graph_def_version;
-  {
-    mutex_lock l(graph_def_lock_);
-    graph_def_version =
-        execution_state_->original_graph_def().versions().producer();
-  }
-  func_info->proc_flr.reset(new ProcessFunctionLibraryRuntime(
-      device_mgr_.get(), options_.env, graph_def_version,
-      func_info->flib_def.get(), optimizer_opts));
-
-  GraphOptimizer optimizer(optimizer_opts);
-  for (auto iter = graphs.begin(); iter != graphs.end(); ++iter) {
-    const string& partition_name = iter->first;
-    std::unique_ptr<Graph>& partition_graph = iter->second;
-
-    Device* device;
-    TF_RETURN_IF_ERROR(device_mgr_->LookupDevice(partition_name, &device));
-
-    ek->items.resize(ek->items.size() + 1);
-    auto* item = &(ek->items.back());
-    auto lib = func_info->proc_flr->GetFLR(partition_name);
-    if (lib == nullptr) {
-      return errors::Internal("Could not find device: ", partition_name);
-    }
-    item->flib = lib;
-
-    LocalExecutorParams params;
-    params.device = device;
-    params.function_library = lib;
-    auto opseg = device->op_segment();
-    params.create_kernel = [this, lib, opseg](const NodeDef& ndef,
-                                              OpKernel** kernel) {
-      // We do not share the kernel via the OpSegment if the node is
-      // stateless, or a function.
-      // NOTE(mrry): We must not share function kernels (implemented
-      // using `CallOp`) between subgraphs, because `CallOp::handle_`
-      // is tied to a particular subgraph. Even if the function itself
-      // is stateful, the `CallOp` that invokes it is not.
-      if (!lib->IsStateful(ndef.op()) ||
-          lib->GetFunctionLibraryDefinition()->Find(ndef.op()) != nullptr) {
-        return lib->CreateKernel(ndef, kernel);
-      }
-      auto create_fn = [lib, &ndef](OpKernel** kernel) {
-        return lib->CreateKernel(ndef, kernel);
-      };
-      // Kernels created for subgraph nodes need to be cached.  On
-      // cache miss, create_fn() is invoked to create a kernel based
-      // on the function library here + global op registry.
-      return opseg->FindOrCreate(session_handle_, ndef.name(), kernel,
-                                 create_fn);
-    };
-    params.delete_kernel = [lib](OpKernel* kernel) {
-      // If the node is stateful, opseg owns it. Otherwise, delete it.
-      if (kernel && !lib->IsStateful(kernel->type_string())) {
-        delete kernel;
-      }
-    };
-    params.node_outputs_cb = node_outputs_callback_;
-
-    optimizer.Optimize(lib, options_.env, device, &iter->second,
-                       /*shape_map=*/nullptr);
-
-    // EXPERIMENTAL: tfdbg inserts debug nodes in the graph.
-    if (!options.debug_options.debug_tensor_watch_opts().empty()) {
-      TF_RETURN_IF_ERROR(DecorateAndPublishGraphForDebug(
-          options.debug_options, partition_graph.get(), params.device));
+    // Save the output tensors of this run we choose to keep.
+    if (s.ok()) {
+      s = run_state->tensor_store.SaveTensors(output_names, &session_state_);
     }
 
-    TF_RETURN_IF_ERROR(EnsureMemoryTypes(DeviceType(device->device_type()),
-                                         device->name(),
-                                         partition_graph.get()));
-    // NewLocalExecutor takes ownership of partition_graph.
-    item->graph = partition_graph.get();
-    item->executor = nullptr;
-    item->device = device;
-    Executor* executor;
-    TF_RETURN_IF_ERROR(
-        NewLocalExecutor(params, partition_graph.release(), &executor));
-    item->executor.reset(executor);
-  }
-
-  // Cache the mapping from input/output names to graph elements to
-  // avoid recomputing it every time.
-  if (!run_state_args->is_partial_run) {
-    // For regular `Run()`, we use the function calling convention, and so
-    // maintain a mapping from input/output names to
-    // argument/return-value ordinal index.
-    for (size_t i = 0; i < inputs_sorted.size(); ++i) {
-      const string& input = inputs_sorted[i];
-      ek->input_name_to_index[input] = i;
-    }
-    for (size_t i = 0; i < outputs_sorted.size(); ++i) {
-      const string& output = outputs_sorted[i];
-      ek->output_name_to_index[output] = i;
-    }
-  } else {
-    // For `PRun()`, we use the rendezvous calling convention, and so
-    // maintain a mapping from input/output names to rendezvous keys.
-    //
-    // We always use the first device as the device name portion of the
-    // key, even if we're feeding another graph.
-    for (size_t i = 0; i < inputs_sorted.size(); ++i) {
-      const string& input = inputs_sorted[i];
-      ek->input_name_to_rendezvous_key[input] = GetRendezvousKey(
-          input, device_set_.client_device()->attributes(), FrameAndIter(0, 0));
-    }
-    for (size_t i = 0; i < outputs_sorted.size(); ++i) {
-      const string& output = outputs_sorted[i];
-      ek->output_name_to_rendezvous_key[output] =
-          GetRendezvousKey(output, device_set_.client_device()->attributes(),
-                           FrameAndIter(0, 0));
-    }
-  }
-
-  // Reacquire the lock, try to insert into the map.
-  mutex_lock l(executor_lock_);
-  functions_.push_back(std::move(func_info));
-
-  // Another thread may have created the entry before us, in which case we will
-  // reuse the already created one.
-  auto insert_result = executors_.emplace(sorted_key, ek);
-  // Insert the value under the original key, so the fast path lookup will work
-  // if the user uses the same order of inputs, outputs, and targets again.
-  executors_.emplace(key, insert_result.first->second);
-  *executors_and_keys = insert_result.first->second.get();
-
-  return Status::OK();
-}
-
-Status NTSession::CreateGraphs(
-    const BuildGraphOptions& subgraph_options,
-    std::unordered_map<string, std::unique_ptr<Graph>>* outputs,
-    std::unique_ptr<FunctionLibraryDefinition>* flib_def,
-    RunStateArgs* run_state_args, DataTypeVector* input_types,
-    DataTypeVector* output_types) {
-  mutex_lock l(graph_def_lock_);
-  std::unique_ptr<ClientGraph> client_graph;
-
-  std::unique_ptr<GraphExecutionState> temp_exec_state_holder;
-  GraphExecutionState* execution_state = nullptr;
-  if (options_.config.graph_options().place_pruned_graph()) {
-    // Because we are placing pruned graphs, we need to create a
-    // new GraphExecutionState for every new unseen graph,
-    // and then place it.
-    GraphExecutionStateOptions prune_options;
-    prune_options.device_set = &device_set_;
-    prune_options.session_options = &options_;
-    prune_options.stateful_placements = stateful_placements_;
-    TF_RETURN_IF_ERROR(GraphExecutionState::MakeForPrunedGraph(
-        execution_state_->original_graph_def().library(), prune_options,
-        execution_state_->original_graph_def(), subgraph_options,
-        &temp_exec_state_holder, &client_graph));
-    execution_state = temp_exec_state_holder.get();
-  } else {
-    execution_state = execution_state_.get();
-    TF_RETURN_IF_ERROR(
-        execution_state->BuildGraph(subgraph_options, &client_graph));
-  }
-
-  if (subgraph_options.feed_endpoints.size() !=
-      client_graph->feed_types.size()) {
-    return errors::Internal(
-        "Graph pruning failed: requested number of feed endpoints = ",
-        subgraph_options.feed_endpoints.size(),
-        " versus number of pruned feed endpoints = ",
-        client_graph->feed_types.size());
-  }
-  if (subgraph_options.fetch_endpoints.size() !=
-      client_graph->fetch_types.size()) {
-    return errors::Internal(
-        "Graph pruning failed: requested number of fetch endpoints = ",
-        subgraph_options.fetch_endpoints.size(),
-        " versus number of pruned fetch endpoints = ",
-        client_graph->fetch_types.size());
-  }
-
-  auto current_stateful_placements = execution_state->GetStatefulPlacements();
-  // Update our current state based on the execution_state's
-  // placements.  If there are any mismatches for a node,
-  // we should fail, as this should never happen.
-  for (auto placement_pair : current_stateful_placements) {
-    const string& node_name = placement_pair.first;
-    const string& placement = placement_pair.second;
-    auto iter = stateful_placements_.find(node_name);
-    if (iter == stateful_placements_.end()) {
-      stateful_placements_.insert(std::make_pair(node_name, placement));
-    } else if (iter->second != placement) {
-      return errors::Internal(
-          "Stateful placement mismatch. "
-          "Current assignment of ",
-          node_name, " to ", iter->second, " does not match ", placement);
-    }
-  }
-
-  stateful_placements_ = execution_state->GetStatefulPlacements();
-
-  // Remember the graph in run state if this is a partial run.
-  if (run_state_args->is_partial_run) {
-    run_state_args->graph.reset(new Graph(flib_def_.get()));
-    CopyGraph(*execution_state->full_graph(), run_state_args->graph.get());
-  }
-
-  // Partition the graph across devices.
-  PartitionOptions popts;
-  popts.node_to_loc = [](const Node* node) {
-    assert(node != nullptr);
-    return node->assigned_device_name();
-  };
-  popts.new_name = [this](const string& prefix) {
-    return strings::StrCat(prefix, "/_", edge_name_counter_.fetch_add(1));
-  };
-  popts.get_incarnation = [](const string& name) {
-    // The direct session does not have changing incarnation numbers.
-    // Just return '1'.
-    return 1;
-  };
-  popts.flib_def = &client_graph->graph.flib_def();
-  popts.control_flow_added = false;
-
-  std::unordered_map<string, GraphDef> partitions;
-  TF_RETURN_IF_ERROR(Partition(popts, &client_graph->graph, &partitions));
-
-  std::vector<string> device_names;
-  for (auto device : devices_) {
-    // Extract the LocalName from the device.
-    device_names.push_back(DeviceNameUtils::LocalName(device->name()));
-  }
-
-  // Check for valid partitions.
-  for (const auto& partition : partitions) {
-    const string local_partition_name =
-        DeviceNameUtils::LocalName(partition.first);
-    if (std::count(device_names.begin(), device_names.end(),
-                   local_partition_name) == 0) {
-      return errors::InvalidArgument(
-          "Creating a partition for ", local_partition_name,
-          " which doesn't exist in the list of available devices. Available "
-          "devices: ",
-          str_util::Join(device_names, ","));
-    }
-  }
-
-  for (const auto& partition : partitions) {
-    std::unique_ptr<Graph> device_graph(
-        new Graph(client_graph->flib_def.get()));
-    GraphConstructorOptions device_opts;
-    // There are internal operations (e.g., send/recv) that we now allow.
-    device_opts.allow_internal_ops = true;
-    device_opts.expect_device_spec = true;
-    TF_RETURN_IF_ERROR(ConvertGraphDefToGraph(device_opts, partition.second,
-                                              device_graph.get()));
-    outputs->emplace(partition.first, std::move(device_graph));
-  }
-
-  GraphOptimizationPassOptions optimization_options;
-  optimization_options.session_options = &options_;
-  optimization_options.flib_def = client_graph->flib_def.get();
-  optimization_options.partition_graphs = outputs;
-  TF_RETURN_IF_ERROR(OptimizationPassRegistry::Global()->RunGrouping(
-      OptimizationPassRegistry::POST_PARTITIONING, optimization_options));
-
-  Status s;
-  for (auto& partition : *outputs) {
-    const string& partition_name = partition.first;
-    std::unique_ptr<Graph>* graph = &partition.second;
-
-    VLOG(2) << "Created " << DebugString(graph->get()) << " for "
-            << partition_name;
-
-    // Give the device an opportunity to rewrite its subgraph.
-    Device* d;
-    s = device_mgr_->LookupDevice(partition_name, &d);
-    if (!s.ok()) break;
-    s = d->MaybeRewriteGraph(graph);
-    if (!s.ok()) {
-      break;
-    }
-  }
-  *flib_def = std::move(client_graph->flib_def);
-  std::swap(*input_types, client_graph->feed_types);
-  std::swap(*output_types, client_graph->fetch_types);
-  return s;
-}
-
-::tensorflow::Status NTSession::ListDevices(
-    std::vector<DeviceAttributes>* response) {
-  response->clear();
-  response->reserve(devices_.size());
-  for (Device* d : devices_) {
-    const DeviceAttributes& attrs = d->attributes();
-    response->emplace_back(attrs);
-  }
-  return ::tensorflow::Status::OK();
-}
-
-::tensorflow::Status NTSession::Reset(
-    const std::vector<string>& containers) {
-  device_mgr_->ClearContainers(containers);
-  return ::tensorflow::Status::OK();
-}
-
-::tensorflow::Status NTSession::Close() {
-  cancellation_manager_->StartCancel();
-  {
-    mutex_lock l(closed_lock_);
-    if (closed_) return ::tensorflow::Status::OK();
-    closed_ = true;
-  }
-  if (factory_ != nullptr) factory_->Deregister(this);
-  return ::tensorflow::Status::OK();
-}
-
-NTSession::RunState::RunState(
-    const std::vector<string>& pending_input_names,
-    const std::vector<string>& pending_output_names, int64 step_id,
-    const std::vector<Device*>* devices)
-    : step_container(step_id, [devices](const string& name) {
-        for (auto d : *devices) {
-          if (!d->resource_manager()->Cleanup(name).ok()) {
-            // Do nothing...
+    {
+      mutex_lock l(executor_lock_);
+      // Delete the run state if there is an error or all fetches are done.
+      bool done = true;
+      if (s.ok()) {
+        {
+          mutex_lock l(run_state->mu_);
+          if (!run_state->status.ok()) {
+            LOG(WARNING) << "An error unrelated to this prun has been detected. " << run_state->status;
           }
         }
-      }) {
-  // Initially all the feeds and fetches are pending.
-  for (auto& name : pending_input_names) {
-    pending_inputs[name] = false;
-  }
-  for (auto& name : pending_output_names) {
-    pending_outputs[name] = false;
-  }
-}
-
-NTSession::RunState::RunState(int64 step_id,
-                                  const std::vector<Device*>* devices)
-    : RunState({}, {}, step_id, devices) {}
-
-NTSession::RunState::~RunState() {
-  if (rendez != nullptr) {
-    if (!executors_done.HasBeenNotified()) {
-      rendez->StartAbort(errors::Cancelled("PRun cancellation"));
-      executors_done.WaitForNotification();
+        for (const auto& input : inputs) {
+          auto it = run_state->pending_inputs.find(input.first);
+          it->second = true;
+        }
+        for (const auto& name : output_names) {
+          auto it = run_state->pending_outputs.find(name);
+          it->second = true;
+        }
+        done = run_state->PendingDone();
+      }
+      if (done) {
+        WaitForNotification(run_state, cancellation_manager_, operation_timeout_in_ms_);
+        partial_runs_.erase(handle);
+      }
     }
-    rendez->Unref();
-  }
-}
 
-bool NTSession::RunState::PendingDone() const {
-  for (const auto& it : pending_inputs) {
-    if (!it.second) return false;
+    return s;
   }
-  for (const auto& it : pending_outputs) {
-    if (!it.second) return false;
-  }
-  return true;
-}
 
-void NTSession::WaitForNotification(RunState* run_state,
-                                        CancellationManager* cm,
-                                        int64 timeout_in_ms) {
-  const Status status =
-      WaitForNotification(&run_state->executors_done, timeout_in_ms);
-  if (!status.ok()) {
+  Status NTSession::ResourceHandleToInputTensor(const Tensor& resource_tensor, Tensor* retrieved_tensor) {
+    if (resource_tensor.dtype() != DT_RESOURCE) {
+      return errors::InvalidArgument(
+          strings::StrCat("ResourceHandleToInputTensor() received non-DT_RESOURCE Tensor: ", resource_tensor.dtype()));
+    }
+
+    const ResourceHandle& resource_handle = resource_tensor.scalar<ResourceHandle>()();
+
+    if (resource_handle.container() == SessionState::kTensorHandleResourceTypeName) {
+      return session_state_.GetTensor(resource_handle.name(), retrieved_tensor);
+    } else {
+      return errors::InvalidArgument(
+          strings::StrCat("Invalid resource type hash code: ",
+                          resource_handle.hash_code(),
+                          "(name: ",
+                          resource_handle.name(),
+                          " type: ",
+                          resource_handle.maybe_type_name(),
+                          "). Perhaps a resource tensor was being provided as a feed? That is "
+                          "not currently allowed. Please file an issue at "
+                          "https://github.com/tensorflow/tensorflow/issues/new, ideally with a "
+                          "short code snippet that leads to this error message."));
+    }
+  }
+
+  Status NTSession::SendPRunInputs(const NamedTensorList& inputs,
+                                   const ExecutorsAndKeys* executors_and_keys,
+                                   IntraProcessRendezvous* rendez) {
+    Status s;
+    Rendezvous::ParsedKey parsed;
+    // Insert the input tensors into the local rendezvous by their
+    // rendezvous key.
+    for (const auto& input : inputs) {
+      auto it = executors_and_keys->input_name_to_rendezvous_key.find(input.first);
+      if (it == executors_and_keys->input_name_to_rendezvous_key.end()) {
+        return errors::Internal("'", input.first, "' is not a pre-defined feed.");
+      }
+      const string& input_key = it->second;
+
+      s = Rendezvous::ParseKey(input_key, &parsed);
+      if (!s.ok()) {
+        rendez->StartAbort(s);
+        return s;
+      }
+
+      if (input.second.dtype() == DT_RESOURCE) {
+        Tensor tensor_from_handle;
+        s = ResourceHandleToInputTensor(input.second, &tensor_from_handle);
+        if (s.ok()) {
+          s = rendez->Send(parsed, Rendezvous::Args(), tensor_from_handle, false);
+        }
+      } else {
+        s = rendez->Send(parsed, Rendezvous::Args(), input.second, false);
+      }
+
+      if (!s.ok()) {
+        rendez->StartAbort(s);
+        return s;
+      }
+    }
+    return Status::OK();
+  }
+
+  Status NTSession::RecvPRunOutputs(const std::vector<string>& output_names,
+                                    const ExecutorsAndKeys* executors_and_keys,
+                                    RunState* run_state,
+                                    std::vector<Tensor>* outputs) {
+    Status s;
+    if (!output_names.empty()) {
+      outputs->resize(output_names.size());
+    }
+
+    Rendezvous::ParsedKey parsed;
+    // Get the outputs from the rendezvous
+    for (size_t output_offset = 0; output_offset < output_names.size(); ++output_offset) {
+      const string& output_name = output_names[output_offset];
+      auto it = executors_and_keys->output_name_to_rendezvous_key.find(output_name);
+      if (it == executors_and_keys->output_name_to_rendezvous_key.end()) {
+        return errors::Internal("'", output_name, "' is not a pre-defined fetch.");
+      }
+      const string& output_key = it->second;
+      Tensor output_tensor;
+      bool is_dead;
+      IntraProcessRendezvous* rendez = run_state->rendez;
+
+      s = Rendezvous::ParseKey(output_key, &parsed);
+      if (s.ok()) {
+        // Fetch data from the Rendezvous.
+        s = rendez->Recv(parsed, Rendezvous::Args(), &output_tensor, &is_dead, operation_timeout_in_ms_);
+        if (is_dead && s.ok()) {
+          s = errors::InvalidArgument("The tensor returned for ", output_name, " was not valid.");
+        }
+      }
+      if (!s.ok()) {
+        rendez->StartAbort(s);
+        outputs->clear();
+        return s;
+      }
+
+      (*outputs)[output_offset] = output_tensor;
+    }
+    return Status::OK();
+  }
+
+  Status NTSession::CheckFetch(const NamedTensorList& feeds,
+                               const std::vector<string>& fetches,
+                               const ExecutorsAndKeys* executors_and_keys,
+                               const RunState* run_state) {
+    const Graph* graph = executors_and_keys->graph.get();
+    const NameNodeMap* name_to_node = &executors_and_keys->name_to_node;
+
+    // Build the set of pending feeds that we haven't seen.
+    std::unordered_set<TensorId, TensorId::Hasher> pending_feeds;
     {
-      mutex_lock l(run_state->mu_);
-      run_state->status.Update(status);
+      mutex_lock l(executor_lock_);
+      for (const auto& input : run_state->pending_inputs) {
+        // Skip if the feed has already been fed.
+        if (input.second)
+          continue;
+        TensorId id(ParseTensorName(input.first));
+        auto it = name_to_node->find(id.first);
+        if (it == name_to_node->end()) {
+          return errors::NotFound("Feed ", input.first, ": not found");
+        }
+        pending_feeds.insert(id);
+      }
     }
-    cm->StartCancel();
-    // We must wait for the executors to complete, because they have borrowed
-    // references to `cm` and other per-step state. After this notification, it
-    // is safe to clean up the step.
-    run_state->executors_done.WaitForNotification();
-  }
-}
+    for (const auto& it : feeds) {
+      TensorId id(ParseTensorName(it.first));
+      pending_feeds.erase(id);
+    }
 
-::tensorflow::Status NTSession::WaitForNotification(
-    Notification* notification, int64 timeout_in_ms) {
-  if (timeout_in_ms > 0) {
-    const int64 timeout_in_us = timeout_in_ms * 1000;
-    const bool notified =
-        WaitForNotificationWithTimeout(notification, timeout_in_us);
-    if (!notified) {
-      return Status(error::DEADLINE_EXCEEDED,
-                    "Timed out waiting for notification");
+    // Initialize the stack with the fetch nodes.
+    std::vector<const Node*> stack;
+    for (const string& fetch : fetches) {
+      TensorId id(ParseTensorName(fetch));
+      auto it = name_to_node->find(id.first);
+      if (it == name_to_node->end()) {
+        return errors::NotFound("Fetch ", fetch, ": not found");
+      }
+      stack.push_back(it->second);
     }
-  } else {
-    notification->WaitForNotification();
+
+    // Any tensor needed for fetches can't be in pending_feeds.
+    std::vector<bool> visited(graph->num_node_ids(), false);
+    while (!stack.empty()) {
+      const Node* n = stack.back();
+      stack.pop_back();
+
+      for (const Edge* in_edge : n->in_edges()) {
+        const Node* in_node = in_edge->src();
+        if (pending_feeds.count({in_node->name(), in_edge->src_output()}) > 0) {
+          return errors::InvalidArgument("Fetch ",
+                                         in_node->name(),
+                                         ":",
+                                         in_edge->src_output(),
+                                         " can't be computed from the feeds"
+                                         " that have been fed so far.");
+        }
+        if (!visited[in_node->id()]) {
+          visited[in_node->id()] = true;
+          stack.push_back(in_node);
+        }
+      }
+    }
+    return Status::OK();
   }
-  return Status::OK();
-}
+
+  Status NTSession::GetOrCreateExecutors(gtl::ArraySlice<string> inputs,
+                                         gtl::ArraySlice<string> outputs,
+                                         gtl::ArraySlice<string> target_nodes,
+                                         ExecutorsAndKeys** executors_and_keys,
+                                         RunStateArgs* run_state_args) {
+    int64 handle_name_counter_value = -1;
+    if (LogMemory::IsEnabled() || run_state_args->is_partial_run) {
+      handle_name_counter_value = handle_name_counter_.fetch_add(1);
+    }
+
+    string debug_tensor_watches_summary;
+    if (!run_state_args->debug_options.debug_tensor_watch_opts().empty()) {
+      debug_tensor_watches_summary =
+          SummarizeDebugTensorWatches(run_state_args->debug_options.debug_tensor_watch_opts());
+    }
+
+    // Fast lookup path, no sorting.
+    const string key = strings::StrCat(str_util::Join(inputs, ","),
+                                       "->",
+                                       str_util::Join(outputs, ","),
+                                       "/",
+                                       str_util::Join(target_nodes, ","),
+                                       "/",
+                                       run_state_args->is_partial_run,
+                                       "/",
+                                       debug_tensor_watches_summary);
+    // Set the handle, if it's needed to log memory or for partial run.
+    if (handle_name_counter_value >= 0) {
+      run_state_args->handle = strings::StrCat(key, ";", handle_name_counter_value);
+    }
+
+    // See if we already have the executors for this run.
+    {
+      mutex_lock l(executor_lock_);  // could use reader lock
+      auto it = executors_.find(key);
+      if (it != executors_.end()) {
+        *executors_and_keys = it->second.get();
+        return Status::OK();
+      }
+    }
+
+    // Slow lookup path, the unsorted key missed the cache.
+    // Sort the inputs and outputs, and look up with the sorted key in case an
+    // earlier call used a different order of inputs and outputs.
+    //
+    // We could consider some other signature instead of sorting that
+    // preserves the same property to avoid the sort in the future.
+    std::vector<string> inputs_sorted(inputs.begin(), inputs.end());
+    std::sort(inputs_sorted.begin(), inputs_sorted.end());
+    std::vector<string> outputs_sorted(outputs.begin(), outputs.end());
+    std::sort(outputs_sorted.begin(), outputs_sorted.end());
+    std::vector<string> tn_sorted(target_nodes.begin(), target_nodes.end());
+    std::sort(tn_sorted.begin(), tn_sorted.end());
+
+    const string sorted_key = strings::StrCat(str_util::Join(inputs_sorted, ","),
+                                              "->",
+                                              str_util::Join(outputs_sorted, ","),
+                                              "/",
+                                              str_util::Join(tn_sorted, ","),
+                                              "/",
+                                              run_state_args->is_partial_run,
+                                              "/",
+                                              debug_tensor_watches_summary);
+    // Set the handle, if its needed to log memory or for partial run.
+    if (handle_name_counter_value >= 0) {
+      run_state_args->handle = strings::StrCat(sorted_key, ";", handle_name_counter_value);
+    }
+
+    // See if we already have the executors for this run.
+    {
+      mutex_lock l(executor_lock_);
+      auto it = executors_.find(sorted_key);
+      if (it != executors_.end()) {
+        *executors_and_keys = it->second.get();
+        // Insert this under the original key.
+        executors_.emplace(key, it->second);
+        return Status::OK();
+      }
+    }
+
+    // Nothing found, so create the executors and store in the cache.
+    BuildGraphOptions options;
+    options.feed_endpoints = inputs_sorted;
+    options.fetch_endpoints = outputs_sorted;
+    options.target_nodes = tn_sorted;
+    options.use_function_convention = !run_state_args->is_partial_run;
+    if (!run_state_args->debug_options.debug_tensor_watch_opts().empty()) {
+      options.debug_options = run_state_args->debug_options;
+    }
+
+    std::unique_ptr<FunctionInfo> func_info(new FunctionInfo);
+    std::shared_ptr<ExecutorsAndKeys> ek(new ExecutorsAndKeys);
+
+    // The executor_lock_ is intentionally released while executor is
+    // being created.
+    std::unordered_map<string, std::unique_ptr<Graph>> graphs;
+    TF_RETURN_IF_ERROR(
+        CreateGraphs(options, &graphs, &func_info->flib_def, run_state_args, &ek->input_types, &ek->output_types));
+
+    if (run_state_args->is_partial_run) {
+      ek->graph = std::move(run_state_args->graph);
+      std::unordered_set<StringPiece, StringPieceHasher> names;
+      for (const string& input : inputs) {
+        TensorId id(ParseTensorName(input));
+        names.emplace(id.first);
+      }
+      for (const string& output : outputs) {
+        TensorId id(ParseTensorName(output));
+        names.emplace(id.first);
+      }
+      for (Node* n : ek->graph->nodes()) {
+        if (names.count(n->name()) > 0) {
+          ek->name_to_node.insert({n->name(), n});
+        }
+      }
+    }
+    ek->items.reserve(graphs.size());
+    const auto& optimizer_opts = options_.config.graph_options().optimizer_options();
+
+    int graph_def_version;
+    {
+      mutex_lock l(graph_def_lock_);
+      graph_def_version = execution_state_->original_graph_def().versions().producer();
+    }
+    func_info->proc_flr.reset(new ProcessFunctionLibraryRuntime(
+        device_mgr_.get(), options_.env, graph_def_version, func_info->flib_def.get(), optimizer_opts));
+
+    GraphOptimizer optimizer(optimizer_opts);
+    for (auto iter = graphs.begin(); iter != graphs.end(); ++iter) {
+      const string& partition_name = iter->first;
+      std::unique_ptr<Graph>& partition_graph = iter->second;
+
+      Device* device;
+      TF_RETURN_IF_ERROR(device_mgr_->LookupDevice(partition_name, &device));
+
+      ek->items.resize(ek->items.size() + 1);
+      auto* item = &(ek->items.back());
+      auto lib = func_info->proc_flr->GetFLR(partition_name);
+      if (lib == nullptr) {
+        return errors::Internal("Could not find device: ", partition_name);
+      }
+      item->flib = lib;
+
+      LocalExecutorParams params;
+      params.device = device;
+      params.function_library = lib;
+      auto opseg = device->op_segment();
+      params.create_kernel = [this, lib, opseg](const NodeDef& ndef, OpKernel** kernel) {
+        // We do not share the kernel via the OpSegment if the node is
+        // stateless, or a function.
+        // NOTE(mrry): We must not share function kernels (implemented
+        // using `CallOp`) between subgraphs, because `CallOp::handle_`
+        // is tied to a particular subgraph. Even if the function itself
+        // is stateful, the `CallOp` that invokes it is not.
+        if (!lib->IsStateful(ndef.op()) || lib->GetFunctionLibraryDefinition()->Find(ndef.op()) != nullptr) {
+          return lib->CreateKernel(ndef, kernel);
+        }
+        auto create_fn = [lib, &ndef](OpKernel** kernel) { return lib->CreateKernel(ndef, kernel); };
+        // Kernels created for subgraph nodes need to be cached.  On
+        // cache miss, create_fn() is invoked to create a kernel based
+        // on the function library here + global op registry.
+        return opseg->FindOrCreate(session_handle_, ndef.name(), kernel, create_fn);
+      };
+      params.delete_kernel = [lib](OpKernel* kernel) {
+        // If the node is stateful, opseg owns it. Otherwise, delete it.
+        if (kernel && !lib->IsStateful(kernel->type_string())) {
+          delete kernel;
+        }
+      };
+      params.node_outputs_cb = node_outputs_callback_;
+
+      optimizer.Optimize(lib,
+                         options_.env,
+                         device,
+                         &iter->second,
+                         /*shape_map=*/nullptr);
+
+      // EXPERIMENTAL: tfdbg inserts debug nodes in the graph.
+      if (!options.debug_options.debug_tensor_watch_opts().empty()) {
+        TF_RETURN_IF_ERROR(
+            DecorateAndPublishGraphForDebug(options.debug_options, partition_graph.get(), params.device));
+      }
+
+      TF_RETURN_IF_ERROR(EnsureMemoryTypes(DeviceType(device->device_type()), device->name(), partition_graph.get()));
+      // NewLocalExecutor takes ownership of partition_graph.
+      item->graph = partition_graph.get();
+      item->executor = nullptr;
+      item->device = device;
+      Executor* executor;
+      TF_RETURN_IF_ERROR(NewLocalExecutor(params, partition_graph.release(), &executor));
+      item->executor.reset(executor);
+    }
+
+    // Cache the mapping from input/output names to graph elements to
+    // avoid recomputing it every time.
+    if (!run_state_args->is_partial_run) {
+      // For regular `Run()`, we use the function calling convention, and so
+      // maintain a mapping from input/output names to
+      // argument/return-value ordinal index.
+      for (size_t i = 0; i < inputs_sorted.size(); ++i) {
+        const string& input = inputs_sorted[i];
+        ek->input_name_to_index[input] = i;
+      }
+      for (size_t i = 0; i < outputs_sorted.size(); ++i) {
+        const string& output = outputs_sorted[i];
+        ek->output_name_to_index[output] = i;
+      }
+    } else {
+      // For `PRun()`, we use the rendezvous calling convention, and so
+      // maintain a mapping from input/output names to rendezvous keys.
+      //
+      // We always use the first device as the device name portion of the
+      // key, even if we're feeding another graph.
+      for (size_t i = 0; i < inputs_sorted.size(); ++i) {
+        const string& input = inputs_sorted[i];
+        ek->input_name_to_rendezvous_key[input] =
+            GetRendezvousKey(input, device_set_.client_device()->attributes(), FrameAndIter(0, 0));
+      }
+      for (size_t i = 0; i < outputs_sorted.size(); ++i) {
+        const string& output = outputs_sorted[i];
+        ek->output_name_to_rendezvous_key[output] =
+            GetRendezvousKey(output, device_set_.client_device()->attributes(), FrameAndIter(0, 0));
+      }
+    }
+
+    // Reacquire the lock, try to insert into the map.
+    mutex_lock l(executor_lock_);
+    functions_.push_back(std::move(func_info));
+
+    // Another thread may have created the entry before us, in which case we will
+    // reuse the already created one.
+    auto insert_result = executors_.emplace(sorted_key, ek);
+    // Insert the value under the original key, so the fast path lookup will work
+    // if the user uses the same order of inputs, outputs, and targets again.
+    executors_.emplace(key, insert_result.first->second);
+    *executors_and_keys = insert_result.first->second.get();
+
+    return Status::OK();
+  }
+
+  Status NTSession::CreateGraphs(const BuildGraphOptions& subgraph_options,
+                                 std::unordered_map<string, std::unique_ptr<Graph>>* outputs,
+                                 std::unique_ptr<FunctionLibraryDefinition>* flib_def,
+                                 RunStateArgs* run_state_args,
+                                 DataTypeVector* input_types,
+                                 DataTypeVector* output_types) {
+    mutex_lock l(graph_def_lock_);
+    std::unique_ptr<ClientGraph> client_graph;
+
+    std::unique_ptr<GraphExecutionState> temp_exec_state_holder;
+    GraphExecutionState* execution_state = nullptr;
+    if (options_.config.graph_options().place_pruned_graph()) {
+      // Because we are placing pruned graphs, we need to create a
+      // new GraphExecutionState for every new unseen graph,
+      // and then place it.
+      GraphExecutionStateOptions prune_options;
+      prune_options.device_set = &device_set_;
+      prune_options.session_options = &options_;
+      prune_options.stateful_placements = stateful_placements_;
+      TF_RETURN_IF_ERROR(GraphExecutionState::MakeForPrunedGraph(execution_state_->original_graph_def().library(),
+                                                                 prune_options,
+                                                                 execution_state_->original_graph_def(),
+                                                                 subgraph_options,
+                                                                 &temp_exec_state_holder,
+                                                                 &client_graph));
+      execution_state = temp_exec_state_holder.get();
+    } else {
+      execution_state = execution_state_.get();
+      TF_RETURN_IF_ERROR(execution_state->BuildGraph(subgraph_options, &client_graph));
+    }
+
+    if (subgraph_options.feed_endpoints.size() != client_graph->feed_types.size()) {
+      return errors::Internal("Graph pruning failed: requested number of feed endpoints = ",
+                              subgraph_options.feed_endpoints.size(),
+                              " versus number of pruned feed endpoints = ",
+                              client_graph->feed_types.size());
+    }
+    if (subgraph_options.fetch_endpoints.size() != client_graph->fetch_types.size()) {
+      return errors::Internal("Graph pruning failed: requested number of fetch endpoints = ",
+                              subgraph_options.fetch_endpoints.size(),
+                              " versus number of pruned fetch endpoints = ",
+                              client_graph->fetch_types.size());
+    }
+
+    auto current_stateful_placements = execution_state->GetStatefulPlacements();
+    // Update our current state based on the execution_state's
+    // placements.  If there are any mismatches for a node,
+    // we should fail, as this should never happen.
+    for (auto placement_pair : current_stateful_placements) {
+      const string& node_name = placement_pair.first;
+      const string& placement = placement_pair.second;
+      auto iter = stateful_placements_.find(node_name);
+      if (iter == stateful_placements_.end()) {
+        stateful_placements_.insert(std::make_pair(node_name, placement));
+      } else if (iter->second != placement) {
+        return errors::Internal(
+            "Stateful placement mismatch. "
+            "Current assignment of ",
+            node_name,
+            " to ",
+            iter->second,
+            " does not match ",
+            placement);
+      }
+    }
+
+    stateful_placements_ = execution_state->GetStatefulPlacements();
+
+    // Remember the graph in run state if this is a partial run.
+    if (run_state_args->is_partial_run) {
+      run_state_args->graph.reset(new Graph(flib_def_.get()));
+      CopyGraph(*execution_state->full_graph(), run_state_args->graph.get());
+    }
+
+    // Partition the graph across devices.
+    PartitionOptions popts;
+    popts.node_to_loc = [](const Node* node) {
+      assert(node != nullptr);
+      return node->assigned_device_name();
+    };
+    popts.new_name = [this](const string& prefix) {
+      return strings::StrCat(prefix, "/_", edge_name_counter_.fetch_add(1));
+    };
+    popts.get_incarnation = [](const string& name) {
+      // The direct session does not have changing incarnation numbers.
+      // Just return '1'.
+      return 1;
+    };
+    popts.flib_def = &client_graph->graph.flib_def();
+    popts.control_flow_added = false;
+
+    std::unordered_map<string, GraphDef> partitions;
+    TF_RETURN_IF_ERROR(Partition(popts, &client_graph->graph, &partitions));
+
+    std::vector<string> device_names;
+    for (auto device : devices_) {
+      // Extract the LocalName from the device.
+      device_names.push_back(DeviceNameUtils::LocalName(device->name()));
+    }
+
+    // Check for valid partitions.
+    for (const auto& partition : partitions) {
+      const string local_partition_name = DeviceNameUtils::LocalName(partition.first);
+      if (std::count(device_names.begin(), device_names.end(), local_partition_name) == 0) {
+        return errors::InvalidArgument("Creating a partition for ",
+                                       local_partition_name,
+                                       " which doesn't exist in the list of available devices. Available "
+                                       "devices: ",
+                                       str_util::Join(device_names, ","));
+      }
+    }
+
+    for (const auto& partition : partitions) {
+      std::unique_ptr<Graph> device_graph(new Graph(client_graph->flib_def.get()));
+      GraphConstructorOptions device_opts;
+      // There are internal operations (e.g., send/recv) that we now allow.
+      device_opts.allow_internal_ops = true;
+      device_opts.expect_device_spec = true;
+      TF_RETURN_IF_ERROR(ConvertGraphDefToGraph(device_opts, partition.second, device_graph.get()));
+      outputs->emplace(partition.first, std::move(device_graph));
+    }
+
+    GraphOptimizationPassOptions optimization_options;
+    optimization_options.session_options = &options_;
+    optimization_options.flib_def = client_graph->flib_def.get();
+    optimization_options.partition_graphs = outputs;
+    TF_RETURN_IF_ERROR(OptimizationPassRegistry::Global()->RunGrouping(OptimizationPassRegistry::POST_PARTITIONING,
+                                                                       optimization_options));
+
+    Status s;
+    for (auto& partition : *outputs) {
+      const string& partition_name = partition.first;
+      std::unique_ptr<Graph>* graph = &partition.second;
+
+      VLOG(2) << "Created " << DebugString(graph->get()) << " for " << partition_name;
+
+      // Give the device an opportunity to rewrite its subgraph.
+      Device* d;
+      s = device_mgr_->LookupDevice(partition_name, &d);
+      if (!s.ok())
+        break;
+      s = d->MaybeRewriteGraph(graph);
+      if (!s.ok()) {
+        break;
+      }
+    }
+    *flib_def = std::move(client_graph->flib_def);
+    std::swap(*input_types, client_graph->feed_types);
+    std::swap(*output_types, client_graph->fetch_types);
+    return s;
+  }
+
+  ::tensorflow::Status NTSession::ListDevices(std::vector<DeviceAttributes>* response) {
+    response->clear();
+    response->reserve(devices_.size());
+    for (Device* d : devices_) {
+      const DeviceAttributes& attrs = d->attributes();
+      response->emplace_back(attrs);
+    }
+    return ::tensorflow::Status::OK();
+  }
+
+  ::tensorflow::Status NTSession::Reset(const std::vector<string>& containers) {
+    device_mgr_->ClearContainers(containers);
+    return ::tensorflow::Status::OK();
+  }
+
+  ::tensorflow::Status NTSession::Close() {
+    cancellation_manager_->StartCancel();
+    {
+      mutex_lock l(closed_lock_);
+      if (closed_)
+        return ::tensorflow::Status::OK();
+      closed_ = true;
+    }
+    if (factory_ != nullptr)
+      factory_->Deregister(this);
+    return ::tensorflow::Status::OK();
+  }
+
+  NTSession::RunState::RunState(const std::vector<string>& pending_input_names,
+                                const std::vector<string>& pending_output_names,
+                                int64 step_id,
+                                const std::vector<Device*>* devices)
+      : step_container(step_id, [devices](const string& name) {
+          for (auto d : *devices) {
+            if (!d->resource_manager()->Cleanup(name).ok()) {
+              // Do nothing...
+            }
+          }
+        }) {
+    // Initially all the feeds and fetches are pending.
+    for (auto& name : pending_input_names) {
+      pending_inputs[name] = false;
+    }
+    for (auto& name : pending_output_names) {
+      pending_outputs[name] = false;
+    }
+  }
+
+  NTSession::RunState::RunState(int64 step_id, const std::vector<Device*>* devices)
+      : RunState({}, {}, step_id, devices) {}
+
+  NTSession::RunState::~RunState() {
+    if (rendez != nullptr) {
+      if (!executors_done.HasBeenNotified()) {
+        rendez->StartAbort(errors::Cancelled("PRun cancellation"));
+        executors_done.WaitForNotification();
+      }
+      rendez->Unref();
+    }
+  }
+
+  bool NTSession::RunState::PendingDone() const {
+    for (const auto& it : pending_inputs) {
+      if (!it.second)
+        return false;
+    }
+    for (const auto& it : pending_outputs) {
+      if (!it.second)
+        return false;
+    }
+    return true;
+  }
+
+  void NTSession::WaitForNotification(RunState* run_state, CancellationManager* cm, int64 timeout_in_ms) {
+    const Status status = WaitForNotification(&run_state->executors_done, timeout_in_ms);
+    if (!status.ok()) {
+      {
+        mutex_lock l(run_state->mu_);
+        run_state->status.Update(status);
+      }
+      cm->StartCancel();
+      // We must wait for the executors to complete, because they have borrowed
+      // references to `cm` and other per-step state. After this notification, it
+      // is safe to clean up the step.
+      run_state->executors_done.WaitForNotification();
+    }
+  }
+
+  ::tensorflow::Status NTSession::WaitForNotification(Notification* notification, int64 timeout_in_ms) {
+    if (timeout_in_ms > 0) {
+      const int64 timeout_in_us = timeout_in_ms * 1000;
+      const bool notified = WaitForNotificationWithTimeout(notification, timeout_in_us);
+      if (!notified) {
+        return Status(error::DEADLINE_EXCEEDED, "Timed out waiting for notification");
+      }
+    } else {
+      notification->WaitForNotification();
+    }
+    return Status::OK();
+  }
 
 }  // namespace tensorflow

--- a/PhysicsTools/TensorFlow/src/NTSession.h
+++ b/PhysicsTools/TensorFlow/src/NTSession.h
@@ -63,308 +63,301 @@ Changes:
 
 namespace tensorflow {
 
-class CostModel;
-class DebugGateway;
-class Device;
-class NTSessionFactory;
+  class CostModel;
+  class DebugGateway;
+  class Device;
+  class NTSessionFactory;
 
-class NTSession : public Session {
- public:
-  typedef std::function<void(Session*)> CloseCallback;
+  class NTSession : public Session {
+  public:
+    typedef std::function<void(Session*)> CloseCallback;
 
-  // Takes ownership of 'device_mgr'.
-  // 'factory' is used to unregister the NTSession with 'factory' when its
-  // closed. This ensures that Reset requests from the 'factory' don't get sent
-  // to sessions that are already closed.
-  NTSession(const SessionOptions& options, const DeviceMgr* device_mgr,
-            NTSessionFactory* factory);
-  ~NTSession() override;
+    // Takes ownership of 'device_mgr'.
+    // 'factory' is used to unregister the NTSession with 'factory' when its
+    // closed. This ensures that Reset requests from the 'factory' don't get sent
+    // to sessions that are already closed.
+    NTSession(const SessionOptions& options, const DeviceMgr* device_mgr, NTSessionFactory* factory);
+    ~NTSession() override;
 
-  typedef std::vector<std::pair<string, Tensor>> NamedTensorList;
-  typedef std::unordered_map<StringPiece, Node*, StringPieceHasher> NameNodeMap;
+    typedef std::vector<std::pair<string, Tensor>> NamedTensorList;
+    typedef std::unordered_map<StringPiece, Node*, StringPieceHasher> NameNodeMap;
 
-  ::tensorflow::Status Create(const GraphDef& graph) override;
-  ::tensorflow::Status Extend(const GraphDef& graph) override;
-  ::tensorflow::Status Run(const NamedTensorList& inputs,
-                           const std::vector<string>& output_names,
-                           const std::vector<string>& target_nodes,
-                           std::vector<Tensor>* outputs) override;
+    ::tensorflow::Status Create(const GraphDef& graph) override;
+    ::tensorflow::Status Extend(const GraphDef& graph) override;
+    ::tensorflow::Status Run(const NamedTensorList& inputs,
+                             const std::vector<string>& output_names,
+                             const std::vector<string>& target_nodes,
+                             std::vector<Tensor>* outputs) override;
 
-  // NOTE: Experimental and subject to change.
-  ::tensorflow::Status Run(const ::tensorflow::RunOptions& run_options,
-                           const NamedTensorList& inputs,
-                           const std::vector<string>& output_names,
-                           const std::vector<string>& target_nodes,
-                           std::vector<Tensor>* outputs,
-                           RunMetadata* run_metadata) override;
+    // NOTE: Experimental and subject to change.
+    ::tensorflow::Status Run(const ::tensorflow::RunOptions& run_options,
+                             const NamedTensorList& inputs,
+                             const std::vector<string>& output_names,
+                             const std::vector<string>& target_nodes,
+                             std::vector<Tensor>* outputs,
+                             RunMetadata* run_metadata) override;
 
-  // NOTE: PRunSetup and PRun are added to support partial execution. This
-  // feature is experimental and subject to change.
-  ::tensorflow::Status PRunSetup(const std::vector<string>& input_names,
-                                 const std::vector<string>& output_names,
-                                 const std::vector<string>& target_nodes,
-                                 string* handle) override;
-  ::tensorflow::Status PRun(const string& handle, const NamedTensorList& inputs,
-                            const std::vector<string>& output_names,
-                            std::vector<Tensor>* outputs) override;
+    // NOTE: PRunSetup and PRun are added to support partial execution. This
+    // feature is experimental and subject to change.
+    ::tensorflow::Status PRunSetup(const std::vector<string>& input_names,
+                                   const std::vector<string>& output_names,
+                                   const std::vector<string>& target_nodes,
+                                   string* handle) override;
+    ::tensorflow::Status PRun(const string& handle,
+                              const NamedTensorList& inputs,
+                              const std::vector<string>& output_names,
+                              std::vector<Tensor>* outputs) override;
 
-  // Reset clears 'containers' from the device_mgr of the NTSession.
-  // If 'containers' is empty, then Reset clears the default container.
-  ::tensorflow::Status Reset(const std::vector<string>& containers);
+    // Reset clears 'containers' from the device_mgr of the NTSession.
+    // If 'containers' is empty, then Reset clears the default container.
+    ::tensorflow::Status Reset(const std::vector<string>& containers);
 
-  ::tensorflow::Status ListDevices(
-      std::vector<DeviceAttributes>* response) override;
-  ::tensorflow::Status Close() override;
-  ::tensorflow::Status LocalDeviceManager(const DeviceMgr** output) override {
-    *output = device_mgr_.get();
-    return ::tensorflow::Status::OK();
-  }
+    ::tensorflow::Status ListDevices(std::vector<DeviceAttributes>* response) override;
+    ::tensorflow::Status Close() override;
+    ::tensorflow::Status LocalDeviceManager(const DeviceMgr** output) override {
+      *output = device_mgr_.get();
+      return ::tensorflow::Status::OK();
+    }
 
-  void ExportCostModels(CostModelManager::CostModelMap* cost_models) {
-    cost_model_manager_.ExportCostModels(cost_models);
-  }
+    void ExportCostModels(CostModelManager::CostModelMap* cost_models) {
+      cost_model_manager_.ExportCostModels(cost_models);
+    }
 
- private:
-  // We create one executor and its dependent library runtime for
-  // every partition.
-  struct PerPartitionExecutorsAndLib {
-    Graph* graph = nullptr;                  // not owned.
-    Device* device = nullptr;                // not owned.
-    FunctionLibraryRuntime* flib = nullptr;  // not owned.
-    std::unique_ptr<Executor> executor;
+  private:
+    // We create one executor and its dependent library runtime for
+    // every partition.
+    struct PerPartitionExecutorsAndLib {
+      Graph* graph = nullptr;                  // not owned.
+      Device* device = nullptr;                // not owned.
+      FunctionLibraryRuntime* flib = nullptr;  // not owned.
+      std::unique_ptr<Executor> executor;
+    };
+
+    // An ExecutorsAndKeys is created for a given set of feeds/fetches.
+    // 'step_count' is the number of times this graph is executed.
+    // 'graph' is the entire graph being executed. 'name_to_node'
+    // maps node name to node. We keep 'graph' and 'name_to_node' only in
+    // the case of partial runs. Each item in 'items' is the executor for
+    // a partition of the graph bundled with its dependent library runtime.
+    // 'input_keys' are the rendezvous keys for the feeds and 'output_keys'
+    // are rendezvous keys for the fetches.
+    struct ExecutorsAndKeys {
+      ExecutorsAndKeys() : step_count(0) {}
+
+      std::atomic_int_fast64_t step_count;
+      std::unique_ptr<Graph> graph;
+      NameNodeMap name_to_node;
+      std::vector<PerPartitionExecutorsAndLib> items;
+      std::unordered_map<string, size_t> input_name_to_index;
+      std::unordered_map<string, string> input_name_to_rendezvous_key;
+      std::unordered_map<string, size_t> output_name_to_index;
+      std::unordered_map<string, string> output_name_to_rendezvous_key;
+
+      DataTypeVector input_types;
+      DataTypeVector output_types;
+    };
+
+    // A FunctionInfo object is created for every unique set of feeds/fetches.
+    // This info could be folded into the ExecutorsAndKeys object but we would
+    // like to maintain a deletion order in which the OpKernels (owned by the
+    // executor) should be destroyed first, followed by the resources in the
+    // device and then followed by the function stuff.
+    // TODO(rohanj): Consolidate function library definitions so that we can
+    // instantiate only one ProcFLR and lib_def and make this just a member
+    // variable and not a vector.
+    // 'flib_def' is the function library used.
+    // 'proc_flr' is the collection of FunctionLibraryRuntime objects, one per
+    // device.
+    struct FunctionInfo {
+      std::unique_ptr<FunctionLibraryDefinition> flib_def;
+      std::unique_ptr<ProcessFunctionLibraryRuntime> proc_flr;
+    };
+
+    // For each live partial execution, the session maintains a RunState.
+    // 'status' is the current status of this partial execution. 'executor_done'
+    // is "notified" when all executors are done. 'pending_inputs' are the set
+    // of pending feeds and 'pending_outputs' are the set of pending fetches.
+    struct RunState {
+      mutex mu_;
+      Status status GUARDED_BY(mu_);
+      IntraProcessRendezvous* rendez = nullptr;
+      std::unique_ptr<StepStatsCollector> collector;
+      Notification executors_done;
+      std::unordered_map<string, bool> pending_inputs;   // true if fed
+      std::unordered_map<string, bool> pending_outputs;  // true if fetched
+      TensorStore tensor_store;
+      ScopedStepContainer step_container;
+
+      RunState(int64 step_id, const std::vector<Device*>* devices);
+
+      RunState(const std::vector<string>& pending_input_names,
+               const std::vector<string>& pending_output_names,
+               int64 step_id,
+               const std::vector<Device*>* devices);
+
+      // Returns true if all pending inputs and outputs have been completed.
+      bool PendingDone() const;
+
+      ~RunState();
+    };
+
+    struct RunStateArgs {
+      RunStateArgs(const DebugOptions& options) : debug_options(options) {}
+
+      bool is_partial_run = false;
+      string handle;
+      std::unique_ptr<Graph> graph;
+      const DebugOptions& debug_options;
+    };
+
+    // Initializes the base execution state given the 'graph',
+    // if not already initialized.
+    Status MaybeInitializeExecutionState(const GraphDef& graph, bool* out_already_initialized)
+        EXCLUSIVE_LOCKS_REQUIRED(graph_def_lock_);
+
+    // Retrieves an already existing set of executors to run 'inputs' and
+    // 'outputs', or creates and caches them for future use.
+    ::tensorflow::Status GetOrCreateExecutors(gtl::ArraySlice<string> inputs,
+                                              gtl::ArraySlice<string> outputs,
+                                              gtl::ArraySlice<string> target_nodes,
+                                              ExecutorsAndKeys** executors_and_keys,
+                                              RunStateArgs* run_state_args);
+
+    // Creates several graphs given the existing graph_def_ and the
+    // input feeds and fetches, given 'devices'. The graphs share a common
+    // function library 'flib_def'.
+    ::tensorflow::Status CreateGraphs(const BuildGraphOptions& options,
+                                      std::unordered_map<string, std::unique_ptr<Graph>>* outputs,
+                                      std::unique_ptr<FunctionLibraryDefinition>* flib_def,
+                                      RunStateArgs* run_state_args,
+                                      DataTypeVector* input_types,
+                                      DataTypeVector* output_types);
+
+    ::tensorflow::Status ExtendLocked(const GraphDef& graph) EXCLUSIVE_LOCKS_REQUIRED(graph_def_lock_);
+
+    ::tensorflow::Status ResourceHandleToInputTensor(const Tensor& resource_tensor, Tensor* retrieved_tensor);
+
+    // Feeds more inputs to the executors, triggering further execution.
+    ::tensorflow::Status SendPRunInputs(const std::vector<std::pair<string, Tensor>>& inputs,
+                                        const ExecutorsAndKeys* executors_and_keys,
+                                        IntraProcessRendezvous* rendez);
+
+    // Fetches more outputs from the executors. It waits until the output
+    // tensors are computed.
+    ::tensorflow::Status RecvPRunOutputs(const std::vector<string>& output_names,
+                                         const ExecutorsAndKeys* executors_and_keys,
+                                         RunState* run_state,
+                                         std::vector<Tensor>* outputs);
+
+    // Check if the specified fetches can be computed from the feeds
+    // that we have already provided.
+    ::tensorflow::Status CheckFetch(const std::vector<std::pair<string, Tensor>>& feeds,
+                                    const std::vector<string>& fetches,
+                                    const ExecutorsAndKeys* executors_and_keys,
+                                    const RunState* run_state);
+
+    // Use the appropriate WaitForNotification function based on whether
+    // operation_timeout_in_ms is greater than 0.
+    //
+    // If the timeout expires, the `cm->StartCancel()` will be called.
+    ::tensorflow::Status WaitForNotification(Notification* n, int64 timeout_in_ms);
+    void WaitForNotification(RunState* run_state, CancellationManager* cm, int64 timeout_in_ms);
+
+    ::tensorflow::Status CheckNotClosed() {
+      mutex_lock l(closed_lock_);
+      if (closed_)
+        return errors::Cancelled("Session has been closed.");
+      return ::tensorflow::Status::OK();
+    }
+
+    ::tensorflow::Status CreateDebuggerState(const DebugOptions& debug_options,
+                                             int64 session_run_index,
+                                             int64 executor_step_index,
+                                             const std::vector<string>& input_names,
+                                             const std::vector<string>& output_names,
+                                             const std::vector<string>& target_names,
+                                             std::unique_ptr<DebuggerStateInterface>* debugger_state);
+
+    ::tensorflow::Status DecorateAndPublishGraphForDebug(const DebugOptions& debug_options,
+                                                         Graph* graph,
+                                                         Device* device);
+
+    const SessionOptions options_;
+
+    // Device structures.
+    const std::unique_ptr<const DeviceMgr> device_mgr_;
+    std::vector<Device*> devices_;  // not owned
+    DeviceSet device_set_;
+
+    string session_handle_;
+    bool graph_created_ GUARDED_BY(graph_def_lock_) = false;
+
+    mutex graph_def_lock_;
+    GraphDef graph_def_ GUARDED_BY(graph_def_lock_);
+
+    Status init_error_;  // Set to an error if construction failed.
+
+    // If true, blocks until device has finished all queued operations in a step.
+    bool sync_on_finish_ = true;
+    void SchedClosure(std::function<void()> c);
+
+    std::vector<std::unique_ptr<FunctionInfo>> functions_ GUARDED_BY(executor_lock_);
+
+    mutex executor_lock_;  // protects executors_
+    // Holds mappings from signature to the executors that process
+    // it. The reason for a level of indirection around mapped_type is
+    // to guarantee address stability.
+    // The map value is a shared_ptr since multiple map keys can point to the
+    // same ExecutorsAndKey object.
+    std::unordered_map<string, std::shared_ptr<ExecutorsAndKeys>> executors_ GUARDED_BY(executor_lock_);
+
+    // Holds mappings from handle to partial run state.
+    std::unordered_map<string, std::unique_ptr<RunState>> partial_runs_ GUARDED_BY(executor_lock_);
+
+    // This holds all the tensors that are currently alive in the session.
+    SessionState session_state_;
+
+    NTSessionFactory* const factory_;  // not owned
+    CancellationManager* cancellation_manager_;
+
+    // Map of placed stateful nodes, i.e. nodes for which is_stateful()
+    // is true, such as "params" and "queue" nodes.  Once placed these
+    // nodes can not be moved to a different device.  Maps node names to
+    // device names.
+    std::unordered_map<string, string> stateful_placements_ GUARDED_BY(graph_def_lock_);
+
+    // Execution_state; used when placing the entire graph.
+    std::unique_ptr<GraphExecutionState> execution_state_ GUARDED_BY(graph_def_lock_);
+
+    // The function library, before any rewrites or optimizations have been
+    // performed. In particular, CreateGraphs() may need to modify the function
+    // library; it copies and modifies the function library.
+    std::unique_ptr<FunctionLibraryDefinition> flib_def_;
+
+    // true if the Session has been Closed.
+    mutex closed_lock_;
+    bool closed_ GUARDED_BY(closed_lock_) = false;
+
+    // For generating unique names for this session instance.
+    std::atomic<int64> edge_name_counter_ = {0};
+    std::atomic<int64> handle_name_counter_ = {0};
+
+    // For generating step ids that are unique across all sessions.
+    static std::atomic_int_fast64_t step_id_counter_;
+
+    // Global timeout for all blocking operations in this session.
+    const int64 operation_timeout_in_ms_ = 0;
+
+    // Manages all the cost models for the graphs executed in this session.
+    CostModelManager cost_model_manager_;
+
+    Executor::Args::NodeOutputsCallback node_outputs_callback_ = nullptr;
+
+    TF_DISALLOW_COPY_AND_ASSIGN(NTSession);
+
+    // EXPERIMENTAL: debugger (tfdbg) related
+    friend class DebugGateway;
   };
-
-  // An ExecutorsAndKeys is created for a given set of feeds/fetches.
-  // 'step_count' is the number of times this graph is executed.
-  // 'graph' is the entire graph being executed. 'name_to_node'
-  // maps node name to node. We keep 'graph' and 'name_to_node' only in
-  // the case of partial runs. Each item in 'items' is the executor for
-  // a partition of the graph bundled with its dependent library runtime.
-  // 'input_keys' are the rendezvous keys for the feeds and 'output_keys'
-  // are rendezvous keys for the fetches.
-  struct ExecutorsAndKeys {
-    ExecutorsAndKeys() : step_count(0) {}
-
-    std::atomic_int_fast64_t step_count;
-    std::unique_ptr<Graph> graph;
-    NameNodeMap name_to_node;
-    std::vector<PerPartitionExecutorsAndLib> items;
-    std::unordered_map<string, size_t> input_name_to_index;
-    std::unordered_map<string, string> input_name_to_rendezvous_key;
-    std::unordered_map<string, size_t> output_name_to_index;
-    std::unordered_map<string, string> output_name_to_rendezvous_key;
-
-    DataTypeVector input_types;
-    DataTypeVector output_types;
-  };
-
-  // A FunctionInfo object is created for every unique set of feeds/fetches.
-  // This info could be folded into the ExecutorsAndKeys object but we would
-  // like to maintain a deletion order in which the OpKernels (owned by the
-  // executor) should be destroyed first, followed by the resources in the
-  // device and then followed by the function stuff.
-  // TODO(rohanj): Consolidate function library definitions so that we can
-  // instantiate only one ProcFLR and lib_def and make this just a member
-  // variable and not a vector.
-  // 'flib_def' is the function library used.
-  // 'proc_flr' is the collection of FunctionLibraryRuntime objects, one per
-  // device.
-  struct FunctionInfo {
-    std::unique_ptr<FunctionLibraryDefinition> flib_def;
-    std::unique_ptr<ProcessFunctionLibraryRuntime> proc_flr;
-  };
-
-  // For each live partial execution, the session maintains a RunState.
-  // 'status' is the current status of this partial execution. 'executor_done'
-  // is "notified" when all executors are done. 'pending_inputs' are the set
-  // of pending feeds and 'pending_outputs' are the set of pending fetches.
-  struct RunState {
-    mutex mu_;
-    Status status GUARDED_BY(mu_);
-    IntraProcessRendezvous* rendez = nullptr;
-    std::unique_ptr<StepStatsCollector> collector;
-    Notification executors_done;
-    std::unordered_map<string, bool> pending_inputs;   // true if fed
-    std::unordered_map<string, bool> pending_outputs;  // true if fetched
-    TensorStore tensor_store;
-    ScopedStepContainer step_container;
-
-    RunState(int64 step_id, const std::vector<Device*>* devices);
-
-    RunState(const std::vector<string>& pending_input_names,
-             const std::vector<string>& pending_output_names, int64 step_id,
-             const std::vector<Device*>* devices);
-
-    // Returns true if all pending inputs and outputs have been completed.
-    bool PendingDone() const;
-
-    ~RunState();
-  };
-
-  struct RunStateArgs {
-    RunStateArgs(const DebugOptions& options) : debug_options(options) {}
-
-    bool is_partial_run = false;
-    string handle;
-    std::unique_ptr<Graph> graph;
-    const DebugOptions& debug_options;
-  };
-
-  // Initializes the base execution state given the 'graph',
-  // if not already initialized.
-  Status MaybeInitializeExecutionState(const GraphDef& graph,
-                                       bool* out_already_initialized)
-      EXCLUSIVE_LOCKS_REQUIRED(graph_def_lock_);
-
-  // Retrieves an already existing set of executors to run 'inputs' and
-  // 'outputs', or creates and caches them for future use.
-  ::tensorflow::Status GetOrCreateExecutors(
-      gtl::ArraySlice<string> inputs, gtl::ArraySlice<string> outputs,
-      gtl::ArraySlice<string> target_nodes,
-      ExecutorsAndKeys** executors_and_keys, RunStateArgs* run_state_args);
-
-  // Creates several graphs given the existing graph_def_ and the
-  // input feeds and fetches, given 'devices'. The graphs share a common
-  // function library 'flib_def'.
-  ::tensorflow::Status CreateGraphs(
-      const BuildGraphOptions& options,
-      std::unordered_map<string, std::unique_ptr<Graph>>* outputs,
-      std::unique_ptr<FunctionLibraryDefinition>* flib_def,
-      RunStateArgs* run_state_args, DataTypeVector* input_types,
-      DataTypeVector* output_types);
-
-  ::tensorflow::Status ExtendLocked(const GraphDef& graph)
-      EXCLUSIVE_LOCKS_REQUIRED(graph_def_lock_);
-
-  ::tensorflow::Status ResourceHandleToInputTensor(
-      const Tensor& resource_tensor, Tensor* retrieved_tensor);
-
-  // Feeds more inputs to the executors, triggering further execution.
-  ::tensorflow::Status SendPRunInputs(
-      const std::vector<std::pair<string, Tensor>>& inputs,
-      const ExecutorsAndKeys* executors_and_keys,
-      IntraProcessRendezvous* rendez);
-
-  // Fetches more outputs from the executors. It waits until the output
-  // tensors are computed.
-  ::tensorflow::Status RecvPRunOutputs(
-      const std::vector<string>& output_names,
-      const ExecutorsAndKeys* executors_and_keys, RunState* run_state,
-      std::vector<Tensor>* outputs);
-
-  // Check if the specified fetches can be computed from the feeds
-  // that we have already provided.
-  ::tensorflow::Status CheckFetch(
-      const std::vector<std::pair<string, Tensor>>& feeds,
-      const std::vector<string>& fetches,
-      const ExecutorsAndKeys* executors_and_keys, const RunState* run_state);
-
-  // Use the appropriate WaitForNotification function based on whether
-  // operation_timeout_in_ms is greater than 0.
-  //
-  // If the timeout expires, the `cm->StartCancel()` will be called.
-  ::tensorflow::Status WaitForNotification(Notification* n,
-                                           int64 timeout_in_ms);
-  void WaitForNotification(RunState* run_state, CancellationManager* cm,
-                           int64 timeout_in_ms);
-
-  ::tensorflow::Status CheckNotClosed() {
-    mutex_lock l(closed_lock_);
-    if (closed_) return errors::Cancelled("Session has been closed.");
-    return ::tensorflow::Status::OK();
-  }
-
-  ::tensorflow::Status CreateDebuggerState(
-      const DebugOptions& debug_options, int64 session_run_index,
-      int64 executor_step_index, const std::vector<string>& input_names,
-      const std::vector<string>& output_names,
-      const std::vector<string>& target_names,
-      std::unique_ptr<DebuggerStateInterface>* debugger_state);
-
-  ::tensorflow::Status DecorateAndPublishGraphForDebug(
-      const DebugOptions& debug_options, Graph* graph, Device* device);
-
-  const SessionOptions options_;
-
-  // Device structures.
-  const std::unique_ptr<const DeviceMgr> device_mgr_;
-  std::vector<Device*> devices_;  // not owned
-  DeviceSet device_set_;
-
-  string session_handle_;
-  bool graph_created_ GUARDED_BY(graph_def_lock_) = false;
-
-  mutex graph_def_lock_;
-  GraphDef graph_def_ GUARDED_BY(graph_def_lock_);
-
-  Status init_error_;  // Set to an error if construction failed.
-
-  // If true, blocks until device has finished all queued operations in a step.
-  bool sync_on_finish_ = true;
-  void SchedClosure(std::function<void()> c);
-
-  std::vector<std::unique_ptr<FunctionInfo>> functions_
-      GUARDED_BY(executor_lock_);
-
-  mutex executor_lock_;  // protects executors_
-  // Holds mappings from signature to the executors that process
-  // it. The reason for a level of indirection around mapped_type is
-  // to guarantee address stability.
-  // The map value is a shared_ptr since multiple map keys can point to the
-  // same ExecutorsAndKey object.
-  std::unordered_map<string, std::shared_ptr<ExecutorsAndKeys>> executors_
-      GUARDED_BY(executor_lock_);
-
-  // Holds mappings from handle to partial run state.
-  std::unordered_map<string, std::unique_ptr<RunState>> partial_runs_
-      GUARDED_BY(executor_lock_);
-
-  // This holds all the tensors that are currently alive in the session.
-  SessionState session_state_;
-
-  NTSessionFactory* const factory_;  // not owned
-  CancellationManager* cancellation_manager_;
-
-  // Map of placed stateful nodes, i.e. nodes for which is_stateful()
-  // is true, such as "params" and "queue" nodes.  Once placed these
-  // nodes can not be moved to a different device.  Maps node names to
-  // device names.
-  std::unordered_map<string, string> stateful_placements_
-      GUARDED_BY(graph_def_lock_);
-
-  // Execution_state; used when placing the entire graph.
-  std::unique_ptr<GraphExecutionState> execution_state_
-      GUARDED_BY(graph_def_lock_);
-
-  // The function library, before any rewrites or optimizations have been
-  // performed. In particular, CreateGraphs() may need to modify the function
-  // library; it copies and modifies the function library.
-  std::unique_ptr<FunctionLibraryDefinition> flib_def_;
-
-  // true if the Session has been Closed.
-  mutex closed_lock_;
-  bool closed_ GUARDED_BY(closed_lock_) = false;
-
-  // For generating unique names for this session instance.
-  std::atomic<int64> edge_name_counter_ = {0};
-  std::atomic<int64> handle_name_counter_ = {0};
-
-  // For generating step ids that are unique across all sessions.
-  static std::atomic_int_fast64_t step_id_counter_;
-
-  // Global timeout for all blocking operations in this session.
-  const int64 operation_timeout_in_ms_ = 0;
-
-  // Manages all the cost models for the graphs executed in this session.
-  CostModelManager cost_model_manager_;
-
-  Executor::Args::NodeOutputsCallback node_outputs_callback_ = nullptr;
-
-  TF_DISALLOW_COPY_AND_ASSIGN(NTSession);
-
-  // EXPERIMENTAL: debugger (tfdbg) related
-  friend class DebugGateway;
-};
 
 }  // end namespace tensorflow
 

--- a/PhysicsTools/TensorFlow/src/TBBSession.cc
+++ b/PhysicsTools/TensorFlow/src/TBBSession.cc
@@ -81,1092 +81,1058 @@ Changes with respect to the original code are documented in the TBBSession.h hea
 
 namespace tensorflow {
 
-namespace {
+  namespace {
 
-CMS_THREAD_SAFE auto* tbb_session_runs = monitoring::Counter<0>::New(
-    "/tensorflow/core/tbb_session_runs",
-    "The number of times TBBSession::Run() has been called.");
+    CMS_THREAD_SAFE auto* tbb_session_runs = monitoring::Counter<0>::New(
+        "/tensorflow/core/tbb_session_runs", "The number of times TBBSession::Run() has been called.");
 
-// TODO(vrv): Figure out how to unify the many different functions
-// that generate RendezvousKey, since many of them have to be
-// consistent with each other.
-string GetRendezvousKey(const string& tensor_name,
-                        const DeviceAttributes& device_info,
-                        const FrameAndIter& frame_iter) {
-  return strings::StrCat(device_info.name(), ";",
-                         strings::FpToString(device_info.incarnation()), ";",
-                         device_info.name(), ";", tensor_name, ";",
-                         frame_iter.frame_id, ":", frame_iter.iter_id);
-}
-
-}  // namespace
-
-class TBBSessionFactory : public SessionFactory {
- public:
-  TBBSessionFactory() {}
-
-  bool AcceptsOptions(const SessionOptions& options) override {
-    return options.target == "tbb";
-  }
-
-  Session* NewSession(const SessionOptions& options) override {
-    // Must do this before the CPU allocator is created.
-    if (options.config.graph_options().build_cost_model() > 0) {
-      EnableCPUAllocatorFullStats(true);
-    }
-    std::vector<Device*> devices;
-    const Status s = DeviceFactory::AddDevices(
-        options, "/job:localhost/replica:0/task:0", &devices);
-    if (!s.ok()) {
-      LOG(ERROR) << s;
-      return nullptr;
+    // TODO(vrv): Figure out how to unify the many different functions
+    // that generate RendezvousKey, since many of them have to be
+    // consistent with each other.
+    string GetRendezvousKey(const string& tensor_name,
+                            const DeviceAttributes& device_info,
+                            const FrameAndIter& frame_iter) {
+      return strings::StrCat(device_info.name(),
+                             ";",
+                             strings::FpToString(device_info.incarnation()),
+                             ";",
+                             device_info.name(),
+                             ";",
+                             tensor_name,
+                             ";",
+                             frame_iter.frame_id,
+                             ":",
+                             frame_iter.iter_id);
     }
 
-    TBBSession* session =
-        new TBBSession(options, new DeviceMgr(devices), this);
-    {
+  }  // namespace
+
+  class TBBSessionFactory : public SessionFactory {
+  public:
+    TBBSessionFactory() {}
+
+    bool AcceptsOptions(const SessionOptions& options) override { return options.target == "tbb"; }
+
+    Session* NewSession(const SessionOptions& options) override {
+      // Must do this before the CPU allocator is created.
+      if (options.config.graph_options().build_cost_model() > 0) {
+        EnableCPUAllocatorFullStats(true);
+      }
+      std::vector<Device*> devices;
+      const Status s = DeviceFactory::AddDevices(options, "/job:localhost/replica:0/task:0", &devices);
+      if (!s.ok()) {
+        LOG(ERROR) << s;
+        return nullptr;
+      }
+
+      TBBSession* session = new TBBSession(options, new DeviceMgr(devices), this);
+      {
+        mutex_lock l(sessions_lock_);
+        sessions_.push_back(session);
+      }
+      return session;
+    }
+
+    Status Reset(const SessionOptions& options, const std::vector<string>& containers) override {
+      std::vector<TBBSession*> sessions_to_reset;
+      {
+        mutex_lock l(sessions_lock_);
+        // We create a copy to ensure that we don't have a deadlock when
+        // session->Close calls the TBBSessionFactory.Deregister, which
+        // acquires sessions_lock_.
+        std::swap(sessions_to_reset, sessions_);
+      }
+      Status s;
+      for (auto session : sessions_to_reset) {
+        s.Update(session->Reset(containers));
+      }
+      // TODO(suharshs): Change the Reset behavior of all SessionFactories so that
+      // it doesn't close the sessions?
+      for (auto session : sessions_to_reset) {
+        s.Update(session->Close());
+      }
+      return s;
+    }
+
+    void Deregister(const TBBSession* session) {
       mutex_lock l(sessions_lock_);
-      sessions_.push_back(session);
+      sessions_.erase(std::remove(sessions_.begin(), sessions_.end(), session), sessions_.end());
     }
-    return session;
+
+  private:
+    mutex sessions_lock_;
+    std::vector<TBBSession*> sessions_ GUARDED_BY(sessions_lock_);
+  };
+
+  class TBBSessionRegistrar {
+  public:
+    TBBSessionRegistrar() { SessionFactory::Register("TBB_SESSION", new TBBSessionFactory()); }
+  };
+  static TBBSessionRegistrar registrar;
+
+  std::atomic_int_fast64_t TBBSession::step_id_counter_(1);
+
+  // NOTE: On Android with a single device, there is never
+  // a risk of an OpKernel blocking indefinitely:
+  //
+  // 1) No operations do I/O that depends on other simultaneous kernels,
+  //
+  // 2) Recv nodes always complete immediately: The inputs are sent into
+  //    the local rendezvous before we start the executor, so the
+  //    corresponding recvs will not block.
+  //
+  // Based on these assumptions, we can use the same thread pool for
+  // both "non-blocking" and "blocking" OpKernels on Android.
+  //
+  // This may change down the road when we add support for multiple
+  // devices that run concurrently, in which case we will need to
+  // revisit this decision.
+  // Override to allow CMSSW FWK to schedule
+  void TBBSession::SchedClosure(tbb::task_arena& arena, tbb::task_group& g, std::function<void()> c) {
+    arena.execute([&g, &c]() { g.run(c); });
   }
 
-  Status Reset(const SessionOptions& options,
-               const std::vector<string>& containers) override {
-    std::vector<TBBSession*> sessions_to_reset;
-    {
-      mutex_lock l(sessions_lock_);
-      // We create a copy to ensure that we don't have a deadlock when
-      // session->Close calls the TBBSessionFactory.Deregister, which
-      // acquires sessions_lock_.
-      std::swap(sessions_to_reset, sessions_);
+  TBBSession::TBBSession(const SessionOptions& options, const DeviceMgr* device_mgr, TBBSessionFactory* const factory)
+      : options_(options),
+        device_mgr_(device_mgr),
+        factory_(factory),
+        cancellation_manager_(new CancellationManager()),
+        operation_timeout_in_ms_(options_.config.operation_timeout_in_ms()) {
+    // The default value of sync_on_finish will be flipped soon and this
+    // environment variable will be removed as well.
+    const Status status = ReadBoolFromEnvVar("TF_SYNC_ON_FINISH", true, &sync_on_finish_);
+    if (!status.ok()) {
+      LOG(ERROR) << status.error_message();
     }
-    Status s;
-    for (auto session : sessions_to_reset) {
-      s.Update(session->Reset(containers));
+    // NOTE(mrry): We do not need to use a unique string for the session
+    // handle, because TBBSession owns its devices. This may change
+    // in future versions.
+    session_handle_ = "tbb";
+    int devices_added = 0;
+    if (options.config.log_device_placement()) {
+      const string mapping_str = device_mgr_->DeviceMappingString();
+      if (mapping_str.empty()) {
+        printf("Device mapping: no known devices.\n");
+      } else {
+        printf("Device mapping:\n%s", mapping_str.c_str());
+      }
+      LOG(INFO) << "Device mapping:\n" << mapping_str;
     }
-    // TODO(suharshs): Change the Reset behavior of all SessionFactories so that
-    // it doesn't close the sessions?
-    for (auto session : sessions_to_reset) {
-      s.Update(session->Close());
+    for (auto d : device_mgr_->ListDevices()) {
+      devices_.push_back(d);
+      device_set_.AddDevice(d);
+      d->op_segment()->AddHold(session_handle_);
+
+      // The first device added is special: it is the 'client device' (a
+      // CPU device) from which we feed and fetch Tensors.
+      if (devices_added == 0) {
+        device_set_.set_client_device(d);
+      }
+      ++devices_added;
     }
-    return s;
   }
 
-  void Deregister(const TBBSession* session) {
-    mutex_lock l(sessions_lock_);
-    sessions_.erase(std::remove(sessions_.begin(), sessions_.end(), session),
-                    sessions_.end());
-  }
-
- private:
-  mutex sessions_lock_;
-  std::vector<TBBSession*> sessions_ GUARDED_BY(sessions_lock_);
-};
-
-class TBBSessionRegistrar {
- public:
-  TBBSessionRegistrar() {
-    SessionFactory::Register("TBB_SESSION", new TBBSessionFactory());
-  }
-};
-static TBBSessionRegistrar registrar;
-
-std::atomic_int_fast64_t TBBSession::step_id_counter_(1);
-
-// NOTE: On Android with a single device, there is never
-// a risk of an OpKernel blocking indefinitely:
-//
-// 1) No operations do I/O that depends on other simultaneous kernels,
-//
-// 2) Recv nodes always complete immediately: The inputs are sent into
-//    the local rendezvous before we start the executor, so the
-//    corresponding recvs will not block.
-//
-// Based on these assumptions, we can use the same thread pool for
-// both "non-blocking" and "blocking" OpKernels on Android.
-//
-// This may change down the road when we add support for multiple
-// devices that run concurrently, in which case we will need to
-// revisit this decision.
-// Override to allow CMSSW FWK to schedule
-void TBBSession::SchedClosure(tbb::task_arena& arena, tbb::task_group& g, std::function<void()> c) {
-  arena.execute( [&g, &c] () {g.run( c ); } );
-}
-
-TBBSession::TBBSession(const SessionOptions& options,
-                       const DeviceMgr* device_mgr,
-                       TBBSessionFactory* const factory)
-    : options_(options),
-      device_mgr_(device_mgr),
-      factory_(factory),
-      cancellation_manager_(new CancellationManager()),
-      operation_timeout_in_ms_(options_.config.operation_timeout_in_ms()) {
-  // The default value of sync_on_finish will be flipped soon and this
-  // environment variable will be removed as well.
-  const Status status =
-      ReadBoolFromEnvVar("TF_SYNC_ON_FINISH", true, &sync_on_finish_);
-  if (!status.ok()) {
-    LOG(ERROR) << status.error_message();
-  }
-  // NOTE(mrry): We do not need to use a unique string for the session
-  // handle, because TBBSession owns its devices. This may change
-  // in future versions.
-  session_handle_ = "tbb";
-  int devices_added = 0;
-  if (options.config.log_device_placement()) {
-    const string mapping_str = device_mgr_->DeviceMappingString();
-    if (mapping_str.empty()) {
-      printf("Device mapping: no known devices.\n");
-    } else {
-      printf("Device mapping:\n%s", mapping_str.c_str());
+  TBBSession::~TBBSession() {
+    if (!closed_)
+      Close().IgnoreError();
+    for (auto& it : partial_runs_) {
+      it.second.reset(nullptr);
     }
-    LOG(INFO) << "Device mapping:\n" << mapping_str;
-  }
-  for (auto d : device_mgr_->ListDevices()) {
-    devices_.push_back(d);
-    device_set_.AddDevice(d);
-    d->op_segment()->AddHold(session_handle_);
-
-    // The first device added is special: it is the 'client device' (a
-    // CPU device) from which we feed and fetch Tensors.
-    if (devices_added == 0) {
-      device_set_.set_client_device(d);
+    for (auto& it : executors_) {
+      it.second.reset();
     }
-    ++devices_added;
-  }
-}
+    for (auto d : device_mgr_->ListDevices()) {
+      d->op_segment()->RemoveHold(session_handle_);
+    }
+    for (auto d : device_mgr_->ListDevices()) {
+      d->ClearResourceMgr();
+    }
+    functions_.clear();
+    delete cancellation_manager_;
 
-TBBSession::~TBBSession() {
-  if (!closed_) Close().IgnoreError();
-  for (auto& it : partial_runs_) {
-    it.second.reset(nullptr);
+    execution_state_.reset(nullptr);
+    flib_def_.reset(nullptr);
   }
-  for (auto& it : executors_) {
-    it.second.reset();
-  }
-  for (auto d : device_mgr_->ListDevices()) {
-    d->op_segment()->RemoveHold(session_handle_);
-  }
-  for (auto d : device_mgr_->ListDevices()) {
-    d->ClearResourceMgr();
-  }
-  functions_.clear();
-  delete cancellation_manager_;
 
-  execution_state_.reset(nullptr);
-  flib_def_.reset(nullptr);
-}
-
-Status TBBSession::MaybeInitializeExecutionState(
-    const GraphDef& graph, bool* out_already_initialized) {
-  // If already initialized, do nothing.
-  if (flib_def_ && execution_state_) {
-    *out_already_initialized = true;
+  Status TBBSession::MaybeInitializeExecutionState(const GraphDef& graph, bool* out_already_initialized) {
+    // If already initialized, do nothing.
+    if (flib_def_ && execution_state_) {
+      *out_already_initialized = true;
+      return Status::OK();
+    }
+    // Set up the per-session execution state.
+    // NOTE(mrry): The function library created here will be used for
+    // all subsequent extensions of the graph.
+    flib_def_.reset(new FunctionLibraryDefinition(OpRegistry::Global(), graph.library()));
+    GraphExecutionStateOptions options;
+    options.device_set = &device_set_;
+    options.session_options = &options_;
+    // TODO(mrry,suharshs): We explicitly copy `graph` so that
+    // `MakeForBaseGraph()` can take ownership of its
+    // contents. Previously this happened implicitly in calls to the
+    // `GraphExecutionState`. Other sessions call
+    // `MakeForBaseGraph` in such a way that we can destructively read
+    // the passed-in `GraphDef`. In principle we could do the same here,
+    // with a wider refactoring; we might revise the direct session so
+    // that it copies the graph fewer times.
+    GraphDef temp(graph);
+    TF_RETURN_IF_ERROR(GraphExecutionState::MakeForBaseGraph(&temp, options, &execution_state_));
+    graph_created_ = true;
+    *out_already_initialized = false;
     return Status::OK();
   }
-  // Set up the per-session execution state.
-  // NOTE(mrry): The function library created here will be used for
-  // all subsequent extensions of the graph.
-  flib_def_.reset(
-      new FunctionLibraryDefinition(OpRegistry::Global(), graph.library()));
-  GraphExecutionStateOptions options;
-  options.device_set = &device_set_;
-  options.session_options = &options_;
-  // TODO(mrry,suharshs): We explicitly copy `graph` so that
-  // `MakeForBaseGraph()` can take ownership of its
-  // contents. Previously this happened implicitly in calls to the
-  // `GraphExecutionState`. Other sessions call
-  // `MakeForBaseGraph` in such a way that we can destructively read
-  // the passed-in `GraphDef`. In principle we could do the same here,
-  // with a wider refactoring; we might revise the direct session so
-  // that it copies the graph fewer times.
-  GraphDef temp(graph);
-  TF_RETURN_IF_ERROR(
-      GraphExecutionState::MakeForBaseGraph(&temp, options, &execution_state_));
-  graph_created_ = true;
-  *out_already_initialized = false;
-  return Status::OK();
-}
 
-Status TBBSession::Create(const GraphDef& graph) {
-  TF_RETURN_IF_ERROR(init_error_);
-  if (graph.node_size() > 0) {
-    mutex_lock l(graph_def_lock_);
-    if (graph_created_) {
-      return errors::AlreadyExists(
-          "A Graph has already been created for this session.");
+  Status TBBSession::Create(const GraphDef& graph) {
+    TF_RETURN_IF_ERROR(init_error_);
+    if (graph.node_size() > 0) {
+      mutex_lock l(graph_def_lock_);
+      if (graph_created_) {
+        return errors::AlreadyExists("A Graph has already been created for this session.");
+      }
+      return ExtendLocked(graph);
     }
+    return Status::OK();
+  }
+
+  Status TBBSession::Extend(const GraphDef& graph) {
+    TF_RETURN_IF_ERROR(CheckNotClosed());
+    mutex_lock l(graph_def_lock_);
     return ExtendLocked(graph);
   }
-  return Status::OK();
-}
 
-Status TBBSession::Extend(const GraphDef& graph) {
-  TF_RETURN_IF_ERROR(CheckNotClosed());
-  mutex_lock l(graph_def_lock_);
-  return ExtendLocked(graph);
-}
-
-Status TBBSession::ExtendLocked(const GraphDef& graph) {
-  bool already_initialized;
-  // If this is the first call, we can initialize the execution state
-  // with `graph` and do not need to call `Extend()`.
-  TF_RETURN_IF_ERROR(
-      MaybeInitializeExecutionState(graph, &already_initialized));
-  if (already_initialized) {
-    TF_RETURN_IF_ERROR(flib_def_->AddLibrary(graph.library()));
-    std::unique_ptr<GraphExecutionState> state;
-    TF_RETURN_IF_ERROR(execution_state_->Extend(graph, &state));
-    execution_state_.swap(state);
-  }
-  return Status::OK();
-}
-
-Status TBBSession::Run(const NamedTensorList& inputs,
-                          const std::vector<string>& output_names,
-                          const std::vector<string>& target_nodes,
-                          std::vector<Tensor>* outputs) {
-  RunMetadata run_metadata;
-  return Run(RunOptions(), inputs, output_names, target_nodes, outputs,
-             &run_metadata);
-}
-
-Status TBBSession::CreateDebuggerState(
-    const DebugOptions& debug_options, int64 session_run_index,
-    int64 executor_step_index, const std::vector<string>& input_names,
-    const std::vector<string>& output_names,
-    const std::vector<string>& target_names,
-    std::unique_ptr<DebuggerStateInterface>* debugger_state) {
-  TF_RETURN_IF_ERROR(
-      DebuggerStateRegistry::CreateState(debug_options, debugger_state));
-  TF_RETURN_IF_ERROR(debugger_state->get()->PublishDebugMetadata(
-      debug_options.global_step(), session_run_index, executor_step_index,
-      input_names, output_names, target_names));
-  return Status::OK();
-}
-
-Status TBBSession::DecorateAndPublishGraphForDebug(
-    const DebugOptions& debug_options, Graph* graph, Device* device) {
-  std::unique_ptr<DebugGraphDecoratorInterface> decorator;
-  TF_RETURN_IF_ERROR(
-      DebugGraphDecoratorRegistry::CreateDecorator(debug_options, &decorator));
-
-  TF_RETURN_IF_ERROR(decorator->DecorateGraph(graph, device));
-  TF_RETURN_IF_ERROR(decorator->PublishGraph(*graph, device->name()));
-  return Status::OK();
-}
-
-Status TBBSession::Run(const RunOptions& run_options,
-                          const NamedTensorList& inputs,
-                          const std::vector<string>& output_names,
-                          const std::vector<string>& target_nodes,
-                          std::vector<Tensor>* outputs,
-                          RunMetadata* run_metadata) {
-  TF_RETURN_IF_ERROR(CheckNotClosed());
-  tbb_session_runs->GetCell()->IncrementBy(1);
-  {
-    mutex_lock l(graph_def_lock_);
-    if (!graph_created_) {
-      return errors::InvalidArgument(
-          "Session was not created with a graph before Run()!");
+  Status TBBSession::ExtendLocked(const GraphDef& graph) {
+    bool already_initialized;
+    // If this is the first call, we can initialize the execution state
+    // with `graph` and do not need to call `Extend()`.
+    TF_RETURN_IF_ERROR(MaybeInitializeExecutionState(graph, &already_initialized));
+    if (already_initialized) {
+      TF_RETURN_IF_ERROR(flib_def_->AddLibrary(graph.library()));
+      std::unique_ptr<GraphExecutionState> state;
+      TF_RETURN_IF_ERROR(execution_state_->Extend(graph, &state));
+      execution_state_.swap(state);
     }
+    return Status::OK();
   }
 
-  // Extract the inputs names for this run of the session.
-  std::vector<string> input_tensor_names;
-  input_tensor_names.reserve(inputs.size());
-  for (const auto& it : inputs) {
-    input_tensor_names.push_back(it.first);
+  Status TBBSession::Run(const NamedTensorList& inputs,
+                         const std::vector<string>& output_names,
+                         const std::vector<string>& target_nodes,
+                         std::vector<Tensor>* outputs) {
+    RunMetadata run_metadata;
+    return Run(RunOptions(), inputs, output_names, target_nodes, outputs, &run_metadata);
   }
 
-  // Check if we already have an executor for these arguments.
-  ExecutorsAndKeys* executors_and_keys;
-  RunStateArgs run_state_args(run_options.debug_options());
-
-  Executor::Args args;
-  args.step_id = step_id_counter_.fetch_add(1);
-
-  TF_RETURN_IF_ERROR(
-      GetOrCreateExecutors(input_tensor_names, output_names,
-                           target_nodes, &executors_and_keys,
-                           &run_state_args));
-  const int64 executor_step_count = executors_and_keys->step_count.fetch_add(1);
-
-  std::unique_ptr<DebuggerStateInterface> debugger_state;
-  if (!run_options.debug_options().debug_tensor_watch_opts().empty()) {
-    TF_RETURN_IF_ERROR(CreateDebuggerState(
-        run_options.debug_options(), args.step_id, executor_step_count,
-        input_tensor_names, output_names, target_nodes, &debugger_state));
+  Status TBBSession::CreateDebuggerState(const DebugOptions& debug_options,
+                                         int64 session_run_index,
+                                         int64 executor_step_index,
+                                         const std::vector<string>& input_names,
+                                         const std::vector<string>& output_names,
+                                         const std::vector<string>& target_names,
+                                         std::unique_ptr<DebuggerStateInterface>* debugger_state) {
+    TF_RETURN_IF_ERROR(DebuggerStateRegistry::CreateState(debug_options, debugger_state));
+    TF_RETURN_IF_ERROR(debugger_state->get()->PublishDebugMetadata(
+        debug_options.global_step(), session_run_index, executor_step_index, input_names, output_names, target_names));
+    return Status::OK();
   }
 
-  // Configure a call frame for the step, which we use to feed and
-  // fetch values to and from the executors.
-  FunctionCallFrame call_frame(executors_and_keys->input_types,
-                               executors_and_keys->output_types);
-  gtl::InlinedVector<Tensor, 4> feed_args(inputs.size());
-  for (const auto& it : inputs) {
-    if (it.second.dtype() == DT_RESOURCE) {
-      Tensor tensor_from_handle;
-      TF_RETURN_IF_ERROR(
-          ResourceHandleToInputTensor(it.second, &tensor_from_handle));
-      feed_args[executors_and_keys->input_name_to_index[it.first]] =
-          tensor_from_handle;
-    } else {
-      feed_args[executors_and_keys->input_name_to_index[it.first]] = it.second;
-    }
-  }
-  const Status s = call_frame.SetArgs(feed_args);
-  if (errors::IsInternal(s)) {
-    return errors::InvalidArgument(s.error_message());
-  } else if (!s.ok()) {
-    return s;
+  Status TBBSession::DecorateAndPublishGraphForDebug(const DebugOptions& debug_options, Graph* graph, Device* device) {
+    std::unique_ptr<DebugGraphDecoratorInterface> decorator;
+    TF_RETURN_IF_ERROR(DebugGraphDecoratorRegistry::CreateDecorator(debug_options, &decorator));
+
+    TF_RETURN_IF_ERROR(decorator->DecorateGraph(graph, device));
+    TF_RETURN_IF_ERROR(decorator->PublishGraph(*graph, device->name()));
+    return Status::OK();
   }
 
-  // Create a run state and start execution.
-  RunState run_state(args.step_id, &devices_);
-  run_state.rendez = new IntraProcessRendezvous(device_mgr_.get());
-  CancellationManager step_cancellation_manager;
-  args.call_frame = &call_frame;
-
-  // Use a task_arena to avoid having unrelated tasks start
-  // running on this thread (which could start deadlocks)
-  tbb::task_arena taskArena;
-  tbb::task_group taskGroup;
-  // we are required to always call wait before destructor
-  auto doneWithTaskGroup = [&taskArena, &taskGroup](void *) { taskArena.execute([&taskGroup]() { taskGroup.wait();}); };
-  std::unique_ptr<tbb::task_group, decltype(doneWithTaskGroup) > guard(&taskGroup, doneWithTaskGroup);
-
-  // Start parallel Executors.
-  const size_t num_executors = executors_and_keys->items.size();
-  ExecutorBarrier* barrier = new ExecutorBarrier(
-      num_executors, run_state.rendez, [&run_state](const Status& ret) {
-        {
-          mutex_lock l(run_state.mu_);
-          run_state.status.Update(ret);
-        }
-        run_state.executors_done.Notify();
-      });
-
-  args.rendezvous = run_state.rendez;
-  args.cancellation_manager = &step_cancellation_manager;
-
-  args.session_state = &session_state_;
-  args.tensor_store = &run_state.tensor_store;
-  args.step_container = &run_state.step_container;
-  if (LogMemory::IsEnabled()) {
-    LogMemory::RecordStep(args.step_id, run_state_args.handle);
-  }
-  args.sync_on_finish = sync_on_finish_;
-
-  const bool do_trace = (run_options.trace_level() > RunOptions::NO_TRACE);
-
-  bool update_cost_model = false;
-  if (options_.config.graph_options().build_cost_model() > 0) {
-    const int64 build_cost_model_every =
-        options_.config.graph_options().build_cost_model();
-    const int64 build_cost_model_after =
-        options_.config.graph_options().build_cost_model_after();
-    int64 measure_step_count = executor_step_count - build_cost_model_after;
-    if (measure_step_count >= 0) {
-      update_cost_model =
-          ((measure_step_count + 1) % build_cost_model_every == 0);
-    }
-  }
-  if (do_trace || update_cost_model ||
-      run_options.report_tensor_allocations_upon_oom()) {
-    run_state.collector.reset(
-        new StepStatsCollector(run_metadata->mutable_step_stats()));
-    args.stats_collector = run_state.collector.get();
-  }
-
-  std::unique_ptr<DeviceTracer> tracer;
-  if (run_options.trace_level() >= RunOptions::HARDWARE_TRACE) {
-    tracer = CreateDeviceTracer();
-    // tracer may be NULL on platforms without accelerators.
-    if (tracer) {
-      Status s = tracer->Start();
-      if (!s.ok()) {
-        run_state.executors_done.Notify();
-        delete barrier;
-        return s;
+  Status TBBSession::Run(const RunOptions& run_options,
+                         const NamedTensorList& inputs,
+                         const std::vector<string>& output_names,
+                         const std::vector<string>& target_nodes,
+                         std::vector<Tensor>* outputs,
+                         RunMetadata* run_metadata) {
+    TF_RETURN_IF_ERROR(CheckNotClosed());
+    tbb_session_runs->GetCell()->IncrementBy(1);
+    {
+      mutex_lock l(graph_def_lock_);
+      if (!graph_created_) {
+        return errors::InvalidArgument("Session was not created with a graph before Run()!");
       }
     }
-  }
 
-  // Register this step with session's cancellation manager, so that
-  // `Session::Close()` will cancel the step.
-  const CancellationToken cancellation_token =
-      cancellation_manager_->get_cancellation_token();
-  const bool already_cancelled = !cancellation_manager_->RegisterCallback(
-      cancellation_token, [&step_cancellation_manager]() {
-        step_cancellation_manager.StartCancel();
-      });
-  if (already_cancelled) {
-    // NOTE(mrry): If we don't explicitly notify
-    // `run_state.executors_done`, the RunState destructor would
-    // block on this notification.
-    run_state.executors_done.Notify();
-    delete barrier;
-    return errors::Cancelled("Run call was cancelled");
-  }
+    // Extract the inputs names for this run of the session.
+    std::vector<string> input_tensor_names;
+    input_tensor_names.reserve(inputs.size());
+    for (const auto& it : inputs) {
+      input_tensor_names.push_back(it.first);
+    }
 
-  // pass taskArena and taskGroup to SchedClosure
-  // consequently, disable TF's own thread logic inside the loop
-  Executor::Args::Runner default_runner = [this, &taskArena, &taskGroup](Executor::Args::Closure c) {
-    SchedClosure(taskArena, taskGroup, std::move(c));
-  };
-  for (const auto& item : executors_and_keys->items) {
-    // TODO(zhengxq): support partial run.
-    // TODO(zhengxq): if the device picks its own threadpool, we need to assign
-    //     less threads to the main compute pool by default.
-    // thread::ThreadPool* device_thread_pool =
-    //     item.device->tensorflow_device_thread_pool();
-    // if (!device_thread_pool) {
-    //   args.runner = default_runner;
-    // } else {
-    //   args.runner = [this, device_thread_pool](Executor::Args::Closure c) {
-    //     SchedClosure(device_thread_pool, std::move(c));
-    //   };
-    // }
-    args.runner = default_runner;
-    item.executor->RunAsync(args, barrier->Get());
-  }
+    // Check if we already have an executor for these arguments.
+    ExecutorsAndKeys* executors_and_keys;
+    RunStateArgs run_state_args(run_options.debug_options());
 
-  // WaitForNotification will handle calling wait on taskGroup
-  guard.release();
-  WaitForNotification(taskArena, taskGroup, &run_state, &step_cancellation_manager,
-                      run_options.timeout_in_ms() > 0
-                          ? run_options.timeout_in_ms()
-                          : operation_timeout_in_ms_);
+    Executor::Args args;
+    args.step_id = step_id_counter_.fetch_add(1);
 
-  if (!cancellation_manager_->DeregisterCallback(cancellation_token)) {
-    // The step has been cancelled: make sure we don't attempt to receive the
-    // outputs as this would make it block forever.
-    mutex_lock l(run_state.mu_);
-    run_state.status.Update(errors::Cancelled("Run call was cancelled"));
-  }
+    TF_RETURN_IF_ERROR(
+        GetOrCreateExecutors(input_tensor_names, output_names, target_nodes, &executors_and_keys, &run_state_args));
+    const int64 executor_step_count = executors_and_keys->step_count.fetch_add(1);
 
-  if (tracer) {
-    TF_RETURN_IF_ERROR(tracer->Stop());
-    TF_RETURN_IF_ERROR(tracer->Collect(args.stats_collector));
-  }
+    std::unique_ptr<DebuggerStateInterface> debugger_state;
+    if (!run_options.debug_options().debug_tensor_watch_opts().empty()) {
+      TF_RETURN_IF_ERROR(CreateDebuggerState(run_options.debug_options(),
+                                             args.step_id,
+                                             executor_step_count,
+                                             input_tensor_names,
+                                             output_names,
+                                             target_nodes,
+                                             &debugger_state));
+    }
 
-  {
-    mutex_lock l(run_state.mu_);
-    TF_RETURN_IF_ERROR(run_state.status);
-  }
-
-  // Receive outputs.
-  if (outputs) {
-    std::vector<Tensor> sorted_outputs;
-    const Status s = call_frame.ConsumeRetvals(&sorted_outputs);
+    // Configure a call frame for the step, which we use to feed and
+    // fetch values to and from the executors.
+    FunctionCallFrame call_frame(executors_and_keys->input_types, executors_and_keys->output_types);
+    gtl::InlinedVector<Tensor, 4> feed_args(inputs.size());
+    for (const auto& it : inputs) {
+      if (it.second.dtype() == DT_RESOURCE) {
+        Tensor tensor_from_handle;
+        TF_RETURN_IF_ERROR(ResourceHandleToInputTensor(it.second, &tensor_from_handle));
+        feed_args[executors_and_keys->input_name_to_index[it.first]] = tensor_from_handle;
+      } else {
+        feed_args[executors_and_keys->input_name_to_index[it.first]] = it.second;
+      }
+    }
+    const Status s = call_frame.SetArgs(feed_args);
     if (errors::IsInternal(s)) {
       return errors::InvalidArgument(s.error_message());
     } else if (!s.ok()) {
       return s;
     }
-    const bool unique_outputs =
-        output_names.size() == executors_and_keys->output_name_to_index.size();
-    // first_indices[i] = j implies that j is the smallest value for which
-    // output_names[i] == output_names[j].
-    std::vector<int> first_indices;
-    if (!unique_outputs) {
-      first_indices.resize(output_names.size());
-      for (int i = 0; i < static_cast<int>(output_names.size()); ++i) {
-        for (int j = 0; j <= i; ++j) {
-          if (output_names[i] == output_names[j]) {
-            first_indices[i] = j;
-            break;
-          }
+
+    // Create a run state and start execution.
+    RunState run_state(args.step_id, &devices_);
+    run_state.rendez = new IntraProcessRendezvous(device_mgr_.get());
+    CancellationManager step_cancellation_manager;
+    args.call_frame = &call_frame;
+
+    // Use a task_arena to avoid having unrelated tasks start
+    // running on this thread (which could start deadlocks)
+    tbb::task_arena taskArena;
+    tbb::task_group taskGroup;
+    // we are required to always call wait before destructor
+    auto doneWithTaskGroup = [&taskArena, &taskGroup](void*) {
+      taskArena.execute([&taskGroup]() { taskGroup.wait(); });
+    };
+    std::unique_ptr<tbb::task_group, decltype(doneWithTaskGroup)> guard(&taskGroup, doneWithTaskGroup);
+
+    // Start parallel Executors.
+    const size_t num_executors = executors_and_keys->items.size();
+    ExecutorBarrier* barrier = new ExecutorBarrier(num_executors, run_state.rendez, [&run_state](const Status& ret) {
+      {
+        mutex_lock l(run_state.mu_);
+        run_state.status.Update(ret);
+      }
+      run_state.executors_done.Notify();
+    });
+
+    args.rendezvous = run_state.rendez;
+    args.cancellation_manager = &step_cancellation_manager;
+
+    args.session_state = &session_state_;
+    args.tensor_store = &run_state.tensor_store;
+    args.step_container = &run_state.step_container;
+    if (LogMemory::IsEnabled()) {
+      LogMemory::RecordStep(args.step_id, run_state_args.handle);
+    }
+    args.sync_on_finish = sync_on_finish_;
+
+    const bool do_trace = (run_options.trace_level() > RunOptions::NO_TRACE);
+
+    bool update_cost_model = false;
+    if (options_.config.graph_options().build_cost_model() > 0) {
+      const int64 build_cost_model_every = options_.config.graph_options().build_cost_model();
+      const int64 build_cost_model_after = options_.config.graph_options().build_cost_model_after();
+      int64 measure_step_count = executor_step_count - build_cost_model_after;
+      if (measure_step_count >= 0) {
+        update_cost_model = ((measure_step_count + 1) % build_cost_model_every == 0);
+      }
+    }
+    if (do_trace || update_cost_model || run_options.report_tensor_allocations_upon_oom()) {
+      run_state.collector.reset(new StepStatsCollector(run_metadata->mutable_step_stats()));
+      args.stats_collector = run_state.collector.get();
+    }
+
+    std::unique_ptr<DeviceTracer> tracer;
+    if (run_options.trace_level() >= RunOptions::HARDWARE_TRACE) {
+      tracer = CreateDeviceTracer();
+      // tracer may be NULL on platforms without accelerators.
+      if (tracer) {
+        Status s = tracer->Start();
+        if (!s.ok()) {
+          run_state.executors_done.Notify();
+          delete barrier;
+          return s;
         }
       }
     }
-    outputs->clear();
-    outputs->reserve(sorted_outputs.size());
-    for (int i = 0; i < static_cast<int>(output_names.size()); ++i) {
-      const string& output_name = output_names[i];
-      if (first_indices.empty() || first_indices[i] == i) {
-        outputs->emplace_back(
-            std::move(sorted_outputs[executors_and_keys
-                                         ->output_name_to_index[output_name]]));
-      } else {
-        outputs->push_back((*outputs)[first_indices[i]]);
-      }
+
+    // Register this step with session's cancellation manager, so that
+    // `Session::Close()` will cancel the step.
+    const CancellationToken cancellation_token = cancellation_manager_->get_cancellation_token();
+    const bool already_cancelled = !cancellation_manager_->RegisterCallback(
+        cancellation_token, [&step_cancellation_manager]() { step_cancellation_manager.StartCancel(); });
+    if (already_cancelled) {
+      // NOTE(mrry): If we don't explicitly notify
+      // `run_state.executors_done`, the RunState destructor would
+      // block on this notification.
+      run_state.executors_done.Notify();
+      delete barrier;
+      return errors::Cancelled("Run call was cancelled");
     }
-  }
 
-  // Save the output tensors of this run we choose to keep.
-  TF_RETURN_IF_ERROR(
-      run_state.tensor_store.SaveTensors(output_names, &session_state_));
-  if (args.stats_collector) {
-    args.stats_collector->Finalize();
-  }
-
-  // Build and return the cost model as instructed.
-  mutex_lock l(executor_lock_);
-  if (update_cost_model) {
-    // Build the cost model
-    std::unordered_map<string, const Graph*> device_to_graph;
-    for (const PerPartitionExecutorsAndLib& partition :
-         executors_and_keys->items) {
-      const Graph* graph = partition.graph;
-      const string device = partition.flib->device()->name();
-      device_to_graph[device] = graph;
-    }
-    args.stats_collector->BuildCostModel(&cost_model_manager_, device_to_graph);
-
-    // annotate stats onto cost graph.
-    CostGraphDef* cost_graph = run_metadata->mutable_cost_graph();
+    // pass taskArena and taskGroup to SchedClosure
+    // consequently, disable TF's own thread logic inside the loop
+    Executor::Args::Runner default_runner = [this, &taskArena, &taskGroup](Executor::Args::Closure c) {
+      SchedClosure(taskArena, taskGroup, std::move(c));
+    };
     for (const auto& item : executors_and_keys->items) {
-      TF_RETURN_IF_ERROR(
-          cost_model_manager_.AddToCostGraphDef(item.graph, cost_graph));
+      // TODO(zhengxq): support partial run.
+      // TODO(zhengxq): if the device picks its own threadpool, we need to assign
+      //     less threads to the main compute pool by default.
+      // thread::ThreadPool* device_thread_pool =
+      //     item.device->tensorflow_device_thread_pool();
+      // if (!device_thread_pool) {
+      //   args.runner = default_runner;
+      // } else {
+      //   args.runner = [this, device_thread_pool](Executor::Args::Closure c) {
+      //     SchedClosure(device_thread_pool, std::move(c));
+      //   };
+      // }
+      args.runner = default_runner;
+      item.executor->RunAsync(args, barrier->Get());
     }
-  }
 
-  // If requested via RunOptions, output the partition graphs.
-  if (run_options.output_partition_graphs()) {
-    protobuf::RepeatedPtrField<GraphDef>* partition_graph_defs =
-        run_metadata->mutable_partition_graphs();
-    for (const PerPartitionExecutorsAndLib& exec_and_lib :
-         executors_and_keys->items) {
-      GraphDef* partition_graph_def = partition_graph_defs->Add();
-      exec_and_lib.graph->ToGraphDef(partition_graph_def);
+    // WaitForNotification will handle calling wait on taskGroup
+    guard.release();
+    WaitForNotification(taskArena,
+                        taskGroup,
+                        &run_state,
+                        &step_cancellation_manager,
+                        run_options.timeout_in_ms() > 0 ? run_options.timeout_in_ms() : operation_timeout_in_ms_);
+
+    if (!cancellation_manager_->DeregisterCallback(cancellation_token)) {
+      // The step has been cancelled: make sure we don't attempt to receive the
+      // outputs as this would make it block forever.
+      mutex_lock l(run_state.mu_);
+      run_state.status.Update(errors::Cancelled("Run call was cancelled"));
     }
-  }
 
-  return Status::OK();
-}
-
-Status TBBSession::ResourceHandleToInputTensor(const Tensor& resource_tensor,
-                                                  Tensor* retrieved_tensor) {
-  if (resource_tensor.dtype() != DT_RESOURCE) {
-    return errors::InvalidArgument(strings::StrCat(
-        "ResourceHandleToInputTensor() received non-DT_RESOURCE Tensor: ",
-        resource_tensor.dtype()));
-  }
-
-  const ResourceHandle& resource_handle =
-      resource_tensor.scalar<ResourceHandle>()();
-
-  if (resource_handle.container() ==
-      SessionState::kTensorHandleResourceTypeName) {
-    return session_state_.GetTensor(resource_handle.name(), retrieved_tensor);
-  } else {
-    return errors::InvalidArgument(strings::StrCat(
-        "Invalid resource type hash code: ", resource_handle.hash_code(),
-        "(name: ", resource_handle.name(),
-        " type: ", resource_handle.maybe_type_name(),
-        "). Perhaps a resource tensor was being provided as a feed? That is "
-        "not currently allowed. Please file an issue at "
-        "https://github.com/tensorflow/tensorflow/issues/new, ideally with a "
-        "short code snippet that leads to this error message."));
-  }
-}
-
-Status TBBSession::GetOrCreateExecutors(
-    gtl::ArraySlice<string> inputs, gtl::ArraySlice<string> outputs,
-    gtl::ArraySlice<string> target_nodes, ExecutorsAndKeys** executors_and_keys,
-    RunStateArgs* run_state_args) {
-  int64 handle_name_counter_value = -1;
-  if (LogMemory::IsEnabled() || run_state_args->is_partial_run) {
-    handle_name_counter_value = handle_name_counter_.fetch_add(1);
-  }
-
-  string debug_tensor_watches_summary;
-  if (!run_state_args->debug_options.debug_tensor_watch_opts().empty()) {
-    debug_tensor_watches_summary = SummarizeDebugTensorWatches(
-        run_state_args->debug_options.debug_tensor_watch_opts());
-  }
-
-  // Fast lookup path, no sorting.
-  const string key = strings::StrCat(
-      str_util::Join(inputs, ","), "->", str_util::Join(outputs, ","), "/",
-      str_util::Join(target_nodes, ","), "/", run_state_args->is_partial_run,
-      "/", debug_tensor_watches_summary);
-  // Set the handle, if it's needed to log memory or for partial run.
-  if (handle_name_counter_value >= 0) {
-    run_state_args->handle =
-        strings::StrCat(key, ";", handle_name_counter_value);
-  }
-
-  // See if we already have the executors for this run.
-  {
-    mutex_lock l(executor_lock_);  // could use reader lock
-    auto it = executors_.find(key);
-    if (it != executors_.end()) {
-      *executors_and_keys = it->second.get();
-      return Status::OK();
+    if (tracer) {
+      TF_RETURN_IF_ERROR(tracer->Stop());
+      TF_RETURN_IF_ERROR(tracer->Collect(args.stats_collector));
     }
-  }
 
-  // Slow lookup path, the unsorted key missed the cache.
-  // Sort the inputs and outputs, and look up with the sorted key in case an
-  // earlier call used a different order of inputs and outputs.
-  //
-  // We could consider some other signature instead of sorting that
-  // preserves the same property to avoid the sort in the future.
-  std::vector<string> inputs_sorted(inputs.begin(), inputs.end());
-  std::sort(inputs_sorted.begin(), inputs_sorted.end());
-  std::vector<string> outputs_sorted(outputs.begin(), outputs.end());
-  std::sort(outputs_sorted.begin(), outputs_sorted.end());
-  std::vector<string> tn_sorted(target_nodes.begin(), target_nodes.end());
-  std::sort(tn_sorted.begin(), tn_sorted.end());
-
-  const string sorted_key = strings::StrCat(
-      str_util::Join(inputs_sorted, ","), "->",
-      str_util::Join(outputs_sorted, ","), "/", str_util::Join(tn_sorted, ","),
-      "/", run_state_args->is_partial_run, "/", debug_tensor_watches_summary);
-  // Set the handle, if its needed to log memory or for partial run.
-  if (handle_name_counter_value >= 0) {
-    run_state_args->handle =
-        strings::StrCat(sorted_key, ";", handle_name_counter_value);
-  }
-
-  // See if we already have the executors for this run.
-  {
-    mutex_lock l(executor_lock_);
-    auto it = executors_.find(sorted_key);
-    if (it != executors_.end()) {
-      *executors_and_keys = it->second.get();
-      // Insert this under the original key.
-      executors_.emplace(key, it->second);
-      return Status::OK();
+    {
+      mutex_lock l(run_state.mu_);
+      TF_RETURN_IF_ERROR(run_state.status);
     }
-  }
 
-  // Nothing found, so create the executors and store in the cache.
-  BuildGraphOptions options;
-  options.feed_endpoints = inputs_sorted;
-  options.fetch_endpoints = outputs_sorted;
-  options.target_nodes = tn_sorted;
-  options.use_function_convention = !run_state_args->is_partial_run;
-  if (!run_state_args->debug_options.debug_tensor_watch_opts().empty()) {
-    options.debug_options = run_state_args->debug_options;
-  }
-
-  std::unique_ptr<FunctionInfo> func_info(new FunctionInfo);
-  std::shared_ptr<ExecutorsAndKeys> ek(new ExecutorsAndKeys);
-
-  // The executor_lock_ is intentionally released while executor is
-  // being created.
-  std::unordered_map<string, std::unique_ptr<Graph>> graphs;
-  TF_RETURN_IF_ERROR(CreateGraphs(options, &graphs, &func_info->flib_def,
-                                  run_state_args, &ek->input_types,
-                                  &ek->output_types));
-
-  if (run_state_args->is_partial_run) {
-    ek->graph = std::move(run_state_args->graph);
-    std::unordered_set<StringPiece, StringPieceHasher> names;
-    for (const string& input : inputs) {
-      TensorId id(ParseTensorName(input));
-      names.emplace(id.first);
-    }
-    for (const string& output : outputs) {
-      TensorId id(ParseTensorName(output));
-      names.emplace(id.first);
-    }
-    for (Node* n : ek->graph->nodes()) {
-      if (names.count(n->name()) > 0) {
-        ek->name_to_node.insert({n->name(), n});
+    // Receive outputs.
+    if (outputs) {
+      std::vector<Tensor> sorted_outputs;
+      const Status s = call_frame.ConsumeRetvals(&sorted_outputs);
+      if (errors::IsInternal(s)) {
+        return errors::InvalidArgument(s.error_message());
+      } else if (!s.ok()) {
+        return s;
       }
-    }
-  }
-  ek->items.reserve(graphs.size());
-  const auto& optimizer_opts =
-      options_.config.graph_options().optimizer_options();
-
-  int graph_def_version;
-  {
-    mutex_lock l(graph_def_lock_);
-    graph_def_version =
-        execution_state_->original_graph_def().versions().producer();
-  }
-  func_info->proc_flr.reset(new ProcessFunctionLibraryRuntime(
-      device_mgr_.get(), options_.env, graph_def_version,
-      func_info->flib_def.get(), optimizer_opts));
-
-  GraphOptimizer optimizer(optimizer_opts);
-  for (auto iter = graphs.begin(); iter != graphs.end(); ++iter) {
-    const string& partition_name = iter->first;
-    std::unique_ptr<Graph>& partition_graph = iter->second;
-
-    Device* device;
-    TF_RETURN_IF_ERROR(device_mgr_->LookupDevice(partition_name, &device));
-
-    ek->items.resize(ek->items.size() + 1);
-    auto* item = &(ek->items.back());
-    auto lib = func_info->proc_flr->GetFLR(partition_name);
-    if (lib == nullptr) {
-      return errors::Internal("Could not find device: ", partition_name);
-    }
-    item->flib = lib;
-
-    LocalExecutorParams params;
-    params.device = device;
-    params.function_library = lib;
-    auto opseg = device->op_segment();
-    params.create_kernel = [this, lib, opseg](const NodeDef& ndef,
-                                              OpKernel** kernel) {
-      // We do not share the kernel via the OpSegment if the node is
-      // stateless, or a function.
-      // NOTE(mrry): We must not share function kernels (implemented
-      // using `CallOp`) between subgraphs, because `CallOp::handle_`
-      // is tied to a particular subgraph. Even if the function itself
-      // is stateful, the `CallOp` that invokes it is not.
-      if (!lib->IsStateful(ndef.op()) ||
-          lib->GetFunctionLibraryDefinition()->Find(ndef.op()) != nullptr) {
-        return lib->CreateKernel(ndef, kernel);
-      }
-      auto create_fn = [lib, &ndef](OpKernel** kernel) {
-        return lib->CreateKernel(ndef, kernel);
-      };
-      // Kernels created for subgraph nodes need to be cached.  On
-      // cache miss, create_fn() is invoked to create a kernel based
-      // on the function library here + global op registry.
-      return opseg->FindOrCreate(session_handle_, ndef.name(), kernel,
-                                 create_fn);
-    };
-    params.delete_kernel = [lib](OpKernel* kernel) {
-      // If the node is stateful, opseg owns it. Otherwise, delete it.
-      if (kernel && !lib->IsStateful(kernel->type_string())) {
-        delete kernel;
-      }
-    };
-    params.node_outputs_cb = node_outputs_callback_;
-
-    optimizer.Optimize(lib, options_.env, device, &iter->second,
-                       /*shape_map=*/nullptr);
-
-    // EXPERIMENTAL: tfdbg inserts debug nodes in the graph.
-    if (!options.debug_options.debug_tensor_watch_opts().empty()) {
-      TF_RETURN_IF_ERROR(DecorateAndPublishGraphForDebug(
-          options.debug_options, partition_graph.get(), params.device));
-    }
-
-    TF_RETURN_IF_ERROR(EnsureMemoryTypes(DeviceType(device->device_type()),
-                                         device->name(),
-                                         partition_graph.get()));
-    // NewLocalExecutor takes ownership of partition_graph.
-    item->graph = partition_graph.get();
-    item->executor = nullptr;
-    item->device = device;
-    Executor* executor;
-    TF_RETURN_IF_ERROR(
-        NewLocalExecutor(params, partition_graph.release(), &executor));
-    item->executor.reset(executor);
-  }
-
-  // Cache the mapping from input/output names to graph elements to
-  // avoid recomputing it every time.
-  if (!run_state_args->is_partial_run) {
-    // For regular `Run()`, we use the function calling convention, and so
-    // maintain a mapping from input/output names to
-    // argument/return-value ordinal index.
-    for (size_t i = 0; i < inputs_sorted.size(); ++i) {
-      const string& input = inputs_sorted[i];
-      ek->input_name_to_index[input] = i;
-    }
-    for (size_t i = 0; i < outputs_sorted.size(); ++i) {
-      const string& output = outputs_sorted[i];
-      ek->output_name_to_index[output] = i;
-    }
-  } else {
-    // For `PRun()`, we use the rendezvous calling convention, and so
-    // maintain a mapping from input/output names to rendezvous keys.
-    //
-    // We always use the first device as the device name portion of the
-    // key, even if we're feeding another graph.
-    for (size_t i = 0; i < inputs_sorted.size(); ++i) {
-      const string& input = inputs_sorted[i];
-      ek->input_name_to_rendezvous_key[input] = GetRendezvousKey(
-          input, device_set_.client_device()->attributes(), FrameAndIter(0, 0));
-    }
-    for (size_t i = 0; i < outputs_sorted.size(); ++i) {
-      const string& output = outputs_sorted[i];
-      ek->output_name_to_rendezvous_key[output] =
-          GetRendezvousKey(output, device_set_.client_device()->attributes(),
-                           FrameAndIter(0, 0));
-    }
-  }
-
-  // Reacquire the lock, try to insert into the map.
-  mutex_lock l(executor_lock_);
-  functions_.push_back(std::move(func_info));
-
-  // Another thread may have created the entry before us, in which case we will
-  // reuse the already created one.
-  auto insert_result = executors_.emplace(sorted_key, ek);
-  // Insert the value under the original key, so the fast path lookup will work
-  // if the user uses the same order of inputs, outputs, and targets again.
-  executors_.emplace(key, insert_result.first->second);
-  *executors_and_keys = insert_result.first->second.get();
-
-  return Status::OK();
-}
-
-Status TBBSession::CreateGraphs(
-    const BuildGraphOptions& subgraph_options,
-    std::unordered_map<string, std::unique_ptr<Graph>>* outputs,
-    std::unique_ptr<FunctionLibraryDefinition>* flib_def,
-    RunStateArgs* run_state_args, DataTypeVector* input_types,
-    DataTypeVector* output_types) {
-  mutex_lock l(graph_def_lock_);
-  std::unique_ptr<ClientGraph> client_graph;
-
-  std::unique_ptr<GraphExecutionState> temp_exec_state_holder;
-  GraphExecutionState* execution_state = nullptr;
-  if (options_.config.graph_options().place_pruned_graph()) {
-    // Because we are placing pruned graphs, we need to create a
-    // new GraphExecutionState for every new unseen graph,
-    // and then place it.
-    GraphExecutionStateOptions prune_options;
-    prune_options.device_set = &device_set_;
-    prune_options.session_options = &options_;
-    prune_options.stateful_placements = stateful_placements_;
-    TF_RETURN_IF_ERROR(GraphExecutionState::MakeForPrunedGraph(
-        execution_state_->original_graph_def().library(), prune_options,
-        execution_state_->original_graph_def(), subgraph_options,
-        &temp_exec_state_holder, &client_graph));
-    execution_state = temp_exec_state_holder.get();
-  } else {
-    execution_state = execution_state_.get();
-    TF_RETURN_IF_ERROR(
-        execution_state->BuildGraph(subgraph_options, &client_graph));
-  }
-
-  if (subgraph_options.feed_endpoints.size() !=
-      client_graph->feed_types.size()) {
-    return errors::Internal(
-        "Graph pruning failed: requested number of feed endpoints = ",
-        subgraph_options.feed_endpoints.size(),
-        " versus number of pruned feed endpoints = ",
-        client_graph->feed_types.size());
-  }
-  if (subgraph_options.fetch_endpoints.size() !=
-      client_graph->fetch_types.size()) {
-    return errors::Internal(
-        "Graph pruning failed: requested number of fetch endpoints = ",
-        subgraph_options.fetch_endpoints.size(),
-        " versus number of pruned fetch endpoints = ",
-        client_graph->fetch_types.size());
-  }
-
-  auto current_stateful_placements = execution_state->GetStatefulPlacements();
-  // Update our current state based on the execution_state's
-  // placements.  If there are any mismatches for a node,
-  // we should fail, as this should never happen.
-  for (auto placement_pair : current_stateful_placements) {
-    const string& node_name = placement_pair.first;
-    const string& placement = placement_pair.second;
-    auto iter = stateful_placements_.find(node_name);
-    if (iter == stateful_placements_.end()) {
-      stateful_placements_.insert(std::make_pair(node_name, placement));
-    } else if (iter->second != placement) {
-      return errors::Internal(
-          "Stateful placement mismatch. "
-          "Current assignment of ",
-          node_name, " to ", iter->second, " does not match ", placement);
-    }
-  }
-
-  stateful_placements_ = execution_state->GetStatefulPlacements();
-
-  // Remember the graph in run state if this is a partial run.
-  if (run_state_args->is_partial_run) {
-    run_state_args->graph.reset(new Graph(flib_def_.get()));
-    CopyGraph(*execution_state->full_graph(), run_state_args->graph.get());
-  }
-
-  // Partition the graph across devices.
-  PartitionOptions popts;
-  popts.node_to_loc = [](const Node* node) {
-    assert(node != nullptr);
-    return node->assigned_device_name();
-  };
-  popts.new_name = [this](const string& prefix) {
-    return strings::StrCat(prefix, "/_", edge_name_counter_.fetch_add(1));
-  };
-  popts.get_incarnation = [](const string& name) {
-    // The direct session does not have changing incarnation numbers.
-    // Just return '1'.
-    return 1;
-  };
-  popts.flib_def = &client_graph->graph.flib_def();
-  popts.control_flow_added = false;
-
-  std::unordered_map<string, GraphDef> partitions;
-  TF_RETURN_IF_ERROR(Partition(popts, &client_graph->graph, &partitions));
-
-  std::vector<string> device_names;
-  for (auto device : devices_) {
-    // Extract the LocalName from the device.
-    device_names.push_back(DeviceNameUtils::LocalName(device->name()));
-  }
-
-  // Check for valid partitions.
-  for (const auto& partition : partitions) {
-    const string local_partition_name =
-        DeviceNameUtils::LocalName(partition.first);
-    if (std::count(device_names.begin(), device_names.end(),
-                   local_partition_name) == 0) {
-      return errors::InvalidArgument(
-          "Creating a partition for ", local_partition_name,
-          " which doesn't exist in the list of available devices. Available "
-          "devices: ",
-          str_util::Join(device_names, ","));
-    }
-  }
-
-  for (const auto& partition : partitions) {
-    std::unique_ptr<Graph> device_graph(
-        new Graph(client_graph->flib_def.get()));
-    GraphConstructorOptions device_opts;
-    // There are internal operations (e.g., send/recv) that we now allow.
-    device_opts.allow_internal_ops = true;
-    device_opts.expect_device_spec = true;
-    TF_RETURN_IF_ERROR(ConvertGraphDefToGraph(device_opts, partition.second,
-                                              device_graph.get()));
-    outputs->emplace(partition.first, std::move(device_graph));
-  }
-
-  GraphOptimizationPassOptions optimization_options;
-  optimization_options.session_options = &options_;
-  optimization_options.flib_def = client_graph->flib_def.get();
-  optimization_options.partition_graphs = outputs;
-  TF_RETURN_IF_ERROR(OptimizationPassRegistry::Global()->RunGrouping(
-      OptimizationPassRegistry::POST_PARTITIONING, optimization_options));
-
-  Status s;
-  for (auto& partition : *outputs) {
-    const string& partition_name = partition.first;
-    std::unique_ptr<Graph>* graph = &partition.second;
-
-    VLOG(2) << "Created " << DebugString(graph->get()) << " for "
-            << partition_name;
-
-    // Give the device an opportunity to rewrite its subgraph.
-    Device* d;
-    s = device_mgr_->LookupDevice(partition_name, &d);
-    if (!s.ok()) break;
-    s = d->MaybeRewriteGraph(graph);
-    if (!s.ok()) {
-      break;
-    }
-  }
-  *flib_def = std::move(client_graph->flib_def);
-  std::swap(*input_types, client_graph->feed_types);
-  std::swap(*output_types, client_graph->fetch_types);
-  return s;
-}
-
-::tensorflow::Status TBBSession::ListDevices(
-    std::vector<DeviceAttributes>* response) {
-  response->clear();
-  response->reserve(devices_.size());
-  for (Device* d : devices_) {
-    const DeviceAttributes& attrs = d->attributes();
-    response->emplace_back(attrs);
-  }
-  return ::tensorflow::Status::OK();
-}
-
-::tensorflow::Status TBBSession::Reset(
-    const std::vector<string>& containers) {
-  device_mgr_->ClearContainers(containers);
-  return ::tensorflow::Status::OK();
-}
-
-::tensorflow::Status TBBSession::Close() {
-  cancellation_manager_->StartCancel();
-  {
-    mutex_lock l(closed_lock_);
-    if (closed_) return ::tensorflow::Status::OK();
-    closed_ = true;
-  }
-  if (factory_ != nullptr) factory_->Deregister(this);
-  return ::tensorflow::Status::OK();
-}
-
-TBBSession::RunState::RunState(
-    const std::vector<string>& pending_input_names,
-    const std::vector<string>& pending_output_names, int64 step_id,
-    const std::vector<Device*>* devices)
-    : step_container(step_id, [devices](const string& name) {
-        for (auto d : *devices) {
-          if (!d->resource_manager()->Cleanup(name).ok()) {
-            // Do nothing...
+      const bool unique_outputs = output_names.size() == executors_and_keys->output_name_to_index.size();
+      // first_indices[i] = j implies that j is the smallest value for which
+      // output_names[i] == output_names[j].
+      std::vector<int> first_indices;
+      if (!unique_outputs) {
+        first_indices.resize(output_names.size());
+        for (int i = 0; i < static_cast<int>(output_names.size()); ++i) {
+          for (int j = 0; j <= i; ++j) {
+            if (output_names[i] == output_names[j]) {
+              first_indices[i] = j;
+              break;
+            }
           }
         }
-      }) {
-  // Initially all the feeds and fetches are pending.
-  for (auto& name : pending_input_names) {
-    pending_inputs[name] = false;
-  }
-  for (auto& name : pending_output_names) {
-    pending_outputs[name] = false;
-  }
-}
-
-TBBSession::RunState::RunState(int64 step_id,
-                                  const std::vector<Device*>* devices)
-    : RunState({}, {}, step_id, devices) {}
-
-TBBSession::RunState::~RunState() {
-  if (rendez != nullptr) {
-    if (!executors_done.HasBeenNotified()) {
-      rendez->StartAbort(errors::Cancelled("PRun cancellation"));
-      executors_done.WaitForNotification();
+      }
+      outputs->clear();
+      outputs->reserve(sorted_outputs.size());
+      for (int i = 0; i < static_cast<int>(output_names.size()); ++i) {
+        const string& output_name = output_names[i];
+        if (first_indices.empty() || first_indices[i] == i) {
+          outputs->emplace_back(std::move(sorted_outputs[executors_and_keys->output_name_to_index[output_name]]));
+        } else {
+          outputs->push_back((*outputs)[first_indices[i]]);
+        }
+      }
     }
-    rendez->Unref();
-  }
-}
 
-bool TBBSession::RunState::PendingDone() const {
-  for (const auto& it : pending_inputs) {
-    if (!it.second) return false;
-  }
-  for (const auto& it : pending_outputs) {
-    if (!it.second) return false;
-  }
-  return true;
-}
+    // Save the output tensors of this run we choose to keep.
+    TF_RETURN_IF_ERROR(run_state.tensor_store.SaveTensors(output_names, &session_state_));
+    if (args.stats_collector) {
+      args.stats_collector->Finalize();
+    }
 
-void TBBSession::WaitForNotification(tbb::task_arena& arena, tbb::task_group& taskGroup,
-    RunState* run_state, CancellationManager* cm, int64 timeout_in_ms) {
-  // Doing the wait in the arena adds this thread to the arena
-  // and therefore tasks associated to the group can run on this thread
-  arena.execute([&taskGroup]() { taskGroup.wait();} );
+    // Build and return the cost model as instructed.
+    mutex_lock l(executor_lock_);
+    if (update_cost_model) {
+      // Build the cost model
+      std::unordered_map<string, const Graph*> device_to_graph;
+      for (const PerPartitionExecutorsAndLib& partition : executors_and_keys->items) {
+        const Graph* graph = partition.graph;
+        const string device = partition.flib->device()->name();
+        device_to_graph[device] = graph;
+      }
+      args.stats_collector->BuildCostModel(&cost_model_manager_, device_to_graph);
 
-  const Status status =
-      WaitForNotification(&run_state->executors_done, timeout_in_ms);
-  if (!status.ok()) {
+      // annotate stats onto cost graph.
+      CostGraphDef* cost_graph = run_metadata->mutable_cost_graph();
+      for (const auto& item : executors_and_keys->items) {
+        TF_RETURN_IF_ERROR(cost_model_manager_.AddToCostGraphDef(item.graph, cost_graph));
+      }
+    }
+
+    // If requested via RunOptions, output the partition graphs.
+    if (run_options.output_partition_graphs()) {
+      protobuf::RepeatedPtrField<GraphDef>* partition_graph_defs = run_metadata->mutable_partition_graphs();
+      for (const PerPartitionExecutorsAndLib& exec_and_lib : executors_and_keys->items) {
+        GraphDef* partition_graph_def = partition_graph_defs->Add();
+        exec_and_lib.graph->ToGraphDef(partition_graph_def);
+      }
+    }
+
+    return Status::OK();
+  }
+
+  Status TBBSession::ResourceHandleToInputTensor(const Tensor& resource_tensor, Tensor* retrieved_tensor) {
+    if (resource_tensor.dtype() != DT_RESOURCE) {
+      return errors::InvalidArgument(
+          strings::StrCat("ResourceHandleToInputTensor() received non-DT_RESOURCE Tensor: ", resource_tensor.dtype()));
+    }
+
+    const ResourceHandle& resource_handle = resource_tensor.scalar<ResourceHandle>()();
+
+    if (resource_handle.container() == SessionState::kTensorHandleResourceTypeName) {
+      return session_state_.GetTensor(resource_handle.name(), retrieved_tensor);
+    } else {
+      return errors::InvalidArgument(
+          strings::StrCat("Invalid resource type hash code: ",
+                          resource_handle.hash_code(),
+                          "(name: ",
+                          resource_handle.name(),
+                          " type: ",
+                          resource_handle.maybe_type_name(),
+                          "). Perhaps a resource tensor was being provided as a feed? That is "
+                          "not currently allowed. Please file an issue at "
+                          "https://github.com/tensorflow/tensorflow/issues/new, ideally with a "
+                          "short code snippet that leads to this error message."));
+    }
+  }
+
+  Status TBBSession::GetOrCreateExecutors(gtl::ArraySlice<string> inputs,
+                                          gtl::ArraySlice<string> outputs,
+                                          gtl::ArraySlice<string> target_nodes,
+                                          ExecutorsAndKeys** executors_and_keys,
+                                          RunStateArgs* run_state_args) {
+    int64 handle_name_counter_value = -1;
+    if (LogMemory::IsEnabled() || run_state_args->is_partial_run) {
+      handle_name_counter_value = handle_name_counter_.fetch_add(1);
+    }
+
+    string debug_tensor_watches_summary;
+    if (!run_state_args->debug_options.debug_tensor_watch_opts().empty()) {
+      debug_tensor_watches_summary =
+          SummarizeDebugTensorWatches(run_state_args->debug_options.debug_tensor_watch_opts());
+    }
+
+    // Fast lookup path, no sorting.
+    const string key = strings::StrCat(str_util::Join(inputs, ","),
+                                       "->",
+                                       str_util::Join(outputs, ","),
+                                       "/",
+                                       str_util::Join(target_nodes, ","),
+                                       "/",
+                                       run_state_args->is_partial_run,
+                                       "/",
+                                       debug_tensor_watches_summary);
+    // Set the handle, if it's needed to log memory or for partial run.
+    if (handle_name_counter_value >= 0) {
+      run_state_args->handle = strings::StrCat(key, ";", handle_name_counter_value);
+    }
+
+    // See if we already have the executors for this run.
     {
-      mutex_lock l(run_state->mu_);
-      run_state->status.Update(status);
+      mutex_lock l(executor_lock_);  // could use reader lock
+      auto it = executors_.find(key);
+      if (it != executors_.end()) {
+        *executors_and_keys = it->second.get();
+        return Status::OK();
+      }
     }
-    cm->StartCancel();
-    // We must wait for the executors to complete, because they have borrowed
-    // references to `cm` and other per-step state. After this notification, it
-    // is safe to clean up the step.
-    run_state->executors_done.WaitForNotification();
-  }
-}
 
-::tensorflow::Status TBBSession::WaitForNotification(
-    Notification* notification, int64 timeout_in_ms) {
-  if (timeout_in_ms > 0) {
-    const int64 timeout_in_us = timeout_in_ms * 1000;
-    const bool notified =
-        WaitForNotificationWithTimeout(notification, timeout_in_us);
-    if (!notified) {
-      return Status(error::DEADLINE_EXCEEDED,
-                    "Timed out waiting for notification");
+    // Slow lookup path, the unsorted key missed the cache.
+    // Sort the inputs and outputs, and look up with the sorted key in case an
+    // earlier call used a different order of inputs and outputs.
+    //
+    // We could consider some other signature instead of sorting that
+    // preserves the same property to avoid the sort in the future.
+    std::vector<string> inputs_sorted(inputs.begin(), inputs.end());
+    std::sort(inputs_sorted.begin(), inputs_sorted.end());
+    std::vector<string> outputs_sorted(outputs.begin(), outputs.end());
+    std::sort(outputs_sorted.begin(), outputs_sorted.end());
+    std::vector<string> tn_sorted(target_nodes.begin(), target_nodes.end());
+    std::sort(tn_sorted.begin(), tn_sorted.end());
+
+    const string sorted_key = strings::StrCat(str_util::Join(inputs_sorted, ","),
+                                              "->",
+                                              str_util::Join(outputs_sorted, ","),
+                                              "/",
+                                              str_util::Join(tn_sorted, ","),
+                                              "/",
+                                              run_state_args->is_partial_run,
+                                              "/",
+                                              debug_tensor_watches_summary);
+    // Set the handle, if its needed to log memory or for partial run.
+    if (handle_name_counter_value >= 0) {
+      run_state_args->handle = strings::StrCat(sorted_key, ";", handle_name_counter_value);
     }
-  } else {
-    notification->WaitForNotification();
+
+    // See if we already have the executors for this run.
+    {
+      mutex_lock l(executor_lock_);
+      auto it = executors_.find(sorted_key);
+      if (it != executors_.end()) {
+        *executors_and_keys = it->second.get();
+        // Insert this under the original key.
+        executors_.emplace(key, it->second);
+        return Status::OK();
+      }
+    }
+
+    // Nothing found, so create the executors and store in the cache.
+    BuildGraphOptions options;
+    options.feed_endpoints = inputs_sorted;
+    options.fetch_endpoints = outputs_sorted;
+    options.target_nodes = tn_sorted;
+    options.use_function_convention = !run_state_args->is_partial_run;
+    if (!run_state_args->debug_options.debug_tensor_watch_opts().empty()) {
+      options.debug_options = run_state_args->debug_options;
+    }
+
+    std::unique_ptr<FunctionInfo> func_info(new FunctionInfo);
+    std::shared_ptr<ExecutorsAndKeys> ek(new ExecutorsAndKeys);
+
+    // The executor_lock_ is intentionally released while executor is
+    // being created.
+    std::unordered_map<string, std::unique_ptr<Graph>> graphs;
+    TF_RETURN_IF_ERROR(
+        CreateGraphs(options, &graphs, &func_info->flib_def, run_state_args, &ek->input_types, &ek->output_types));
+
+    if (run_state_args->is_partial_run) {
+      ek->graph = std::move(run_state_args->graph);
+      std::unordered_set<StringPiece, StringPieceHasher> names;
+      for (const string& input : inputs) {
+        TensorId id(ParseTensorName(input));
+        names.emplace(id.first);
+      }
+      for (const string& output : outputs) {
+        TensorId id(ParseTensorName(output));
+        names.emplace(id.first);
+      }
+      for (Node* n : ek->graph->nodes()) {
+        if (names.count(n->name()) > 0) {
+          ek->name_to_node.insert({n->name(), n});
+        }
+      }
+    }
+    ek->items.reserve(graphs.size());
+    const auto& optimizer_opts = options_.config.graph_options().optimizer_options();
+
+    int graph_def_version;
+    {
+      mutex_lock l(graph_def_lock_);
+      graph_def_version = execution_state_->original_graph_def().versions().producer();
+    }
+    func_info->proc_flr.reset(new ProcessFunctionLibraryRuntime(
+        device_mgr_.get(), options_.env, graph_def_version, func_info->flib_def.get(), optimizer_opts));
+
+    GraphOptimizer optimizer(optimizer_opts);
+    for (auto iter = graphs.begin(); iter != graphs.end(); ++iter) {
+      const string& partition_name = iter->first;
+      std::unique_ptr<Graph>& partition_graph = iter->second;
+
+      Device* device;
+      TF_RETURN_IF_ERROR(device_mgr_->LookupDevice(partition_name, &device));
+
+      ek->items.resize(ek->items.size() + 1);
+      auto* item = &(ek->items.back());
+      auto lib = func_info->proc_flr->GetFLR(partition_name);
+      if (lib == nullptr) {
+        return errors::Internal("Could not find device: ", partition_name);
+      }
+      item->flib = lib;
+
+      LocalExecutorParams params;
+      params.device = device;
+      params.function_library = lib;
+      auto opseg = device->op_segment();
+      params.create_kernel = [this, lib, opseg](const NodeDef& ndef, OpKernel** kernel) {
+        // We do not share the kernel via the OpSegment if the node is
+        // stateless, or a function.
+        // NOTE(mrry): We must not share function kernels (implemented
+        // using `CallOp`) between subgraphs, because `CallOp::handle_`
+        // is tied to a particular subgraph. Even if the function itself
+        // is stateful, the `CallOp` that invokes it is not.
+        if (!lib->IsStateful(ndef.op()) || lib->GetFunctionLibraryDefinition()->Find(ndef.op()) != nullptr) {
+          return lib->CreateKernel(ndef, kernel);
+        }
+        auto create_fn = [lib, &ndef](OpKernel** kernel) { return lib->CreateKernel(ndef, kernel); };
+        // Kernels created for subgraph nodes need to be cached.  On
+        // cache miss, create_fn() is invoked to create a kernel based
+        // on the function library here + global op registry.
+        return opseg->FindOrCreate(session_handle_, ndef.name(), kernel, create_fn);
+      };
+      params.delete_kernel = [lib](OpKernel* kernel) {
+        // If the node is stateful, opseg owns it. Otherwise, delete it.
+        if (kernel && !lib->IsStateful(kernel->type_string())) {
+          delete kernel;
+        }
+      };
+      params.node_outputs_cb = node_outputs_callback_;
+
+      optimizer.Optimize(lib,
+                         options_.env,
+                         device,
+                         &iter->second,
+                         /*shape_map=*/nullptr);
+
+      // EXPERIMENTAL: tfdbg inserts debug nodes in the graph.
+      if (!options.debug_options.debug_tensor_watch_opts().empty()) {
+        TF_RETURN_IF_ERROR(
+            DecorateAndPublishGraphForDebug(options.debug_options, partition_graph.get(), params.device));
+      }
+
+      TF_RETURN_IF_ERROR(EnsureMemoryTypes(DeviceType(device->device_type()), device->name(), partition_graph.get()));
+      // NewLocalExecutor takes ownership of partition_graph.
+      item->graph = partition_graph.get();
+      item->executor = nullptr;
+      item->device = device;
+      Executor* executor;
+      TF_RETURN_IF_ERROR(NewLocalExecutor(params, partition_graph.release(), &executor));
+      item->executor.reset(executor);
+    }
+
+    // Cache the mapping from input/output names to graph elements to
+    // avoid recomputing it every time.
+    if (!run_state_args->is_partial_run) {
+      // For regular `Run()`, we use the function calling convention, and so
+      // maintain a mapping from input/output names to
+      // argument/return-value ordinal index.
+      for (size_t i = 0; i < inputs_sorted.size(); ++i) {
+        const string& input = inputs_sorted[i];
+        ek->input_name_to_index[input] = i;
+      }
+      for (size_t i = 0; i < outputs_sorted.size(); ++i) {
+        const string& output = outputs_sorted[i];
+        ek->output_name_to_index[output] = i;
+      }
+    } else {
+      // For `PRun()`, we use the rendezvous calling convention, and so
+      // maintain a mapping from input/output names to rendezvous keys.
+      //
+      // We always use the first device as the device name portion of the
+      // key, even if we're feeding another graph.
+      for (size_t i = 0; i < inputs_sorted.size(); ++i) {
+        const string& input = inputs_sorted[i];
+        ek->input_name_to_rendezvous_key[input] =
+            GetRendezvousKey(input, device_set_.client_device()->attributes(), FrameAndIter(0, 0));
+      }
+      for (size_t i = 0; i < outputs_sorted.size(); ++i) {
+        const string& output = outputs_sorted[i];
+        ek->output_name_to_rendezvous_key[output] =
+            GetRendezvousKey(output, device_set_.client_device()->attributes(), FrameAndIter(0, 0));
+      }
+    }
+
+    // Reacquire the lock, try to insert into the map.
+    mutex_lock l(executor_lock_);
+    functions_.push_back(std::move(func_info));
+
+    // Another thread may have created the entry before us, in which case we will
+    // reuse the already created one.
+    auto insert_result = executors_.emplace(sorted_key, ek);
+    // Insert the value under the original key, so the fast path lookup will work
+    // if the user uses the same order of inputs, outputs, and targets again.
+    executors_.emplace(key, insert_result.first->second);
+    *executors_and_keys = insert_result.first->second.get();
+
+    return Status::OK();
   }
-  return Status::OK();
-}
+
+  Status TBBSession::CreateGraphs(const BuildGraphOptions& subgraph_options,
+                                  std::unordered_map<string, std::unique_ptr<Graph>>* outputs,
+                                  std::unique_ptr<FunctionLibraryDefinition>* flib_def,
+                                  RunStateArgs* run_state_args,
+                                  DataTypeVector* input_types,
+                                  DataTypeVector* output_types) {
+    mutex_lock l(graph_def_lock_);
+    std::unique_ptr<ClientGraph> client_graph;
+
+    std::unique_ptr<GraphExecutionState> temp_exec_state_holder;
+    GraphExecutionState* execution_state = nullptr;
+    if (options_.config.graph_options().place_pruned_graph()) {
+      // Because we are placing pruned graphs, we need to create a
+      // new GraphExecutionState for every new unseen graph,
+      // and then place it.
+      GraphExecutionStateOptions prune_options;
+      prune_options.device_set = &device_set_;
+      prune_options.session_options = &options_;
+      prune_options.stateful_placements = stateful_placements_;
+      TF_RETURN_IF_ERROR(GraphExecutionState::MakeForPrunedGraph(execution_state_->original_graph_def().library(),
+                                                                 prune_options,
+                                                                 execution_state_->original_graph_def(),
+                                                                 subgraph_options,
+                                                                 &temp_exec_state_holder,
+                                                                 &client_graph));
+      execution_state = temp_exec_state_holder.get();
+    } else {
+      execution_state = execution_state_.get();
+      TF_RETURN_IF_ERROR(execution_state->BuildGraph(subgraph_options, &client_graph));
+    }
+
+    if (subgraph_options.feed_endpoints.size() != client_graph->feed_types.size()) {
+      return errors::Internal("Graph pruning failed: requested number of feed endpoints = ",
+                              subgraph_options.feed_endpoints.size(),
+                              " versus number of pruned feed endpoints = ",
+                              client_graph->feed_types.size());
+    }
+    if (subgraph_options.fetch_endpoints.size() != client_graph->fetch_types.size()) {
+      return errors::Internal("Graph pruning failed: requested number of fetch endpoints = ",
+                              subgraph_options.fetch_endpoints.size(),
+                              " versus number of pruned fetch endpoints = ",
+                              client_graph->fetch_types.size());
+    }
+
+    auto current_stateful_placements = execution_state->GetStatefulPlacements();
+    // Update our current state based on the execution_state's
+    // placements.  If there are any mismatches for a node,
+    // we should fail, as this should never happen.
+    for (auto placement_pair : current_stateful_placements) {
+      const string& node_name = placement_pair.first;
+      const string& placement = placement_pair.second;
+      auto iter = stateful_placements_.find(node_name);
+      if (iter == stateful_placements_.end()) {
+        stateful_placements_.insert(std::make_pair(node_name, placement));
+      } else if (iter->second != placement) {
+        return errors::Internal(
+            "Stateful placement mismatch. "
+            "Current assignment of ",
+            node_name,
+            " to ",
+            iter->second,
+            " does not match ",
+            placement);
+      }
+    }
+
+    stateful_placements_ = execution_state->GetStatefulPlacements();
+
+    // Remember the graph in run state if this is a partial run.
+    if (run_state_args->is_partial_run) {
+      run_state_args->graph.reset(new Graph(flib_def_.get()));
+      CopyGraph(*execution_state->full_graph(), run_state_args->graph.get());
+    }
+
+    // Partition the graph across devices.
+    PartitionOptions popts;
+    popts.node_to_loc = [](const Node* node) {
+      assert(node != nullptr);
+      return node->assigned_device_name();
+    };
+    popts.new_name = [this](const string& prefix) {
+      return strings::StrCat(prefix, "/_", edge_name_counter_.fetch_add(1));
+    };
+    popts.get_incarnation = [](const string& name) {
+      // The direct session does not have changing incarnation numbers.
+      // Just return '1'.
+      return 1;
+    };
+    popts.flib_def = &client_graph->graph.flib_def();
+    popts.control_flow_added = false;
+
+    std::unordered_map<string, GraphDef> partitions;
+    TF_RETURN_IF_ERROR(Partition(popts, &client_graph->graph, &partitions));
+
+    std::vector<string> device_names;
+    for (auto device : devices_) {
+      // Extract the LocalName from the device.
+      device_names.push_back(DeviceNameUtils::LocalName(device->name()));
+    }
+
+    // Check for valid partitions.
+    for (const auto& partition : partitions) {
+      const string local_partition_name = DeviceNameUtils::LocalName(partition.first);
+      if (std::count(device_names.begin(), device_names.end(), local_partition_name) == 0) {
+        return errors::InvalidArgument("Creating a partition for ",
+                                       local_partition_name,
+                                       " which doesn't exist in the list of available devices. Available "
+                                       "devices: ",
+                                       str_util::Join(device_names, ","));
+      }
+    }
+
+    for (const auto& partition : partitions) {
+      std::unique_ptr<Graph> device_graph(new Graph(client_graph->flib_def.get()));
+      GraphConstructorOptions device_opts;
+      // There are internal operations (e.g., send/recv) that we now allow.
+      device_opts.allow_internal_ops = true;
+      device_opts.expect_device_spec = true;
+      TF_RETURN_IF_ERROR(ConvertGraphDefToGraph(device_opts, partition.second, device_graph.get()));
+      outputs->emplace(partition.first, std::move(device_graph));
+    }
+
+    GraphOptimizationPassOptions optimization_options;
+    optimization_options.session_options = &options_;
+    optimization_options.flib_def = client_graph->flib_def.get();
+    optimization_options.partition_graphs = outputs;
+    TF_RETURN_IF_ERROR(OptimizationPassRegistry::Global()->RunGrouping(OptimizationPassRegistry::POST_PARTITIONING,
+                                                                       optimization_options));
+
+    Status s;
+    for (auto& partition : *outputs) {
+      const string& partition_name = partition.first;
+      std::unique_ptr<Graph>* graph = &partition.second;
+
+      VLOG(2) << "Created " << DebugString(graph->get()) << " for " << partition_name;
+
+      // Give the device an opportunity to rewrite its subgraph.
+      Device* d;
+      s = device_mgr_->LookupDevice(partition_name, &d);
+      if (!s.ok())
+        break;
+      s = d->MaybeRewriteGraph(graph);
+      if (!s.ok()) {
+        break;
+      }
+    }
+    *flib_def = std::move(client_graph->flib_def);
+    std::swap(*input_types, client_graph->feed_types);
+    std::swap(*output_types, client_graph->fetch_types);
+    return s;
+  }
+
+  ::tensorflow::Status TBBSession::ListDevices(std::vector<DeviceAttributes>* response) {
+    response->clear();
+    response->reserve(devices_.size());
+    for (Device* d : devices_) {
+      const DeviceAttributes& attrs = d->attributes();
+      response->emplace_back(attrs);
+    }
+    return ::tensorflow::Status::OK();
+  }
+
+  ::tensorflow::Status TBBSession::Reset(const std::vector<string>& containers) {
+    device_mgr_->ClearContainers(containers);
+    return ::tensorflow::Status::OK();
+  }
+
+  ::tensorflow::Status TBBSession::Close() {
+    cancellation_manager_->StartCancel();
+    {
+      mutex_lock l(closed_lock_);
+      if (closed_)
+        return ::tensorflow::Status::OK();
+      closed_ = true;
+    }
+    if (factory_ != nullptr)
+      factory_->Deregister(this);
+    return ::tensorflow::Status::OK();
+  }
+
+  TBBSession::RunState::RunState(const std::vector<string>& pending_input_names,
+                                 const std::vector<string>& pending_output_names,
+                                 int64 step_id,
+                                 const std::vector<Device*>* devices)
+      : step_container(step_id, [devices](const string& name) {
+          for (auto d : *devices) {
+            if (!d->resource_manager()->Cleanup(name).ok()) {
+              // Do nothing...
+            }
+          }
+        }) {
+    // Initially all the feeds and fetches are pending.
+    for (auto& name : pending_input_names) {
+      pending_inputs[name] = false;
+    }
+    for (auto& name : pending_output_names) {
+      pending_outputs[name] = false;
+    }
+  }
+
+  TBBSession::RunState::RunState(int64 step_id, const std::vector<Device*>* devices)
+      : RunState({}, {}, step_id, devices) {}
+
+  TBBSession::RunState::~RunState() {
+    if (rendez != nullptr) {
+      if (!executors_done.HasBeenNotified()) {
+        rendez->StartAbort(errors::Cancelled("PRun cancellation"));
+        executors_done.WaitForNotification();
+      }
+      rendez->Unref();
+    }
+  }
+
+  bool TBBSession::RunState::PendingDone() const {
+    for (const auto& it : pending_inputs) {
+      if (!it.second)
+        return false;
+    }
+    for (const auto& it : pending_outputs) {
+      if (!it.second)
+        return false;
+    }
+    return true;
+  }
+
+  void TBBSession::WaitForNotification(tbb::task_arena& arena,
+                                       tbb::task_group& taskGroup,
+                                       RunState* run_state,
+                                       CancellationManager* cm,
+                                       int64 timeout_in_ms) {
+    // Doing the wait in the arena adds this thread to the arena
+    // and therefore tasks associated to the group can run on this thread
+    arena.execute([&taskGroup]() { taskGroup.wait(); });
+
+    const Status status = WaitForNotification(&run_state->executors_done, timeout_in_ms);
+    if (!status.ok()) {
+      {
+        mutex_lock l(run_state->mu_);
+        run_state->status.Update(status);
+      }
+      cm->StartCancel();
+      // We must wait for the executors to complete, because they have borrowed
+      // references to `cm` and other per-step state. After this notification, it
+      // is safe to clean up the step.
+      run_state->executors_done.WaitForNotification();
+    }
+  }
+
+  ::tensorflow::Status TBBSession::WaitForNotification(Notification* notification, int64 timeout_in_ms) {
+    if (timeout_in_ms > 0) {
+      const int64 timeout_in_us = timeout_in_ms * 1000;
+      const bool notified = WaitForNotificationWithTimeout(notification, timeout_in_us);
+      if (!notified) {
+        return Status(error::DEADLINE_EXCEEDED, "Timed out waiting for notification");
+      }
+    } else {
+      notification->WaitForNotification();
+    }
+    return Status::OK();
+  }
 
 }  // namespace tensorflow

--- a/PhysicsTools/TensorFlow/src/TBBSession.h
+++ b/PhysicsTools/TensorFlow/src/TBBSession.h
@@ -67,284 +67,281 @@ Changes:
 
 namespace tbb {
 
-class task_group;
+  class task_group;
 
 }  // end namespace tbb
 
 namespace tensorflow {
 
-class CostModel;
-class DebugGateway;
-class Device;
-class TBBSessionFactory;
+  class CostModel;
+  class DebugGateway;
+  class Device;
+  class TBBSessionFactory;
 
-class TBBSession : public Session {
- public:
-  typedef std::function<void(Session*)> CloseCallback;
+  class TBBSession : public Session {
+  public:
+    typedef std::function<void(Session*)> CloseCallback;
 
-  // Takes ownership of 'device_mgr'.
-  // 'factory' is used to unregister the TBBSession with 'factory' when its
-  // closed. This ensures that Reset requests from the 'factory' don't get sent
-  // to sessions that are already closed.
-  TBBSession(const SessionOptions& options, const DeviceMgr* device_mgr,
-                TBBSessionFactory* factory);
-  ~TBBSession() override;
+    // Takes ownership of 'device_mgr'.
+    // 'factory' is used to unregister the TBBSession with 'factory' when its
+    // closed. This ensures that Reset requests from the 'factory' don't get sent
+    // to sessions that are already closed.
+    TBBSession(const SessionOptions& options, const DeviceMgr* device_mgr, TBBSessionFactory* factory);
+    ~TBBSession() override;
 
-  typedef std::vector<std::pair<string, Tensor>> NamedTensorList;
-  typedef std::unordered_map<StringPiece, Node*, StringPieceHasher> NameNodeMap;
+    typedef std::vector<std::pair<string, Tensor>> NamedTensorList;
+    typedef std::unordered_map<StringPiece, Node*, StringPieceHasher> NameNodeMap;
 
-  ::tensorflow::Status Create(const GraphDef& graph) override;
-  ::tensorflow::Status Extend(const GraphDef& graph) override;
-  ::tensorflow::Status Run(const NamedTensorList& inputs,
-                           const std::vector<string>& output_names,
-                           const std::vector<string>& target_nodes,
-                           std::vector<Tensor>* outputs) override;
+    ::tensorflow::Status Create(const GraphDef& graph) override;
+    ::tensorflow::Status Extend(const GraphDef& graph) override;
+    ::tensorflow::Status Run(const NamedTensorList& inputs,
+                             const std::vector<string>& output_names,
+                             const std::vector<string>& target_nodes,
+                             std::vector<Tensor>* outputs) override;
 
-  // NOTE: Experimental and subject to change.
-  ::tensorflow::Status Run(const ::tensorflow::RunOptions& run_options,
-                           const NamedTensorList& inputs,
-                           const std::vector<string>& output_names,
-                           const std::vector<string>& target_nodes,
-                           std::vector<Tensor>* outputs,
-                           RunMetadata* run_metadata) override;
+    // NOTE: Experimental and subject to change.
+    ::tensorflow::Status Run(const ::tensorflow::RunOptions& run_options,
+                             const NamedTensorList& inputs,
+                             const std::vector<string>& output_names,
+                             const std::vector<string>& target_nodes,
+                             std::vector<Tensor>* outputs,
+                             RunMetadata* run_metadata) override;
 
-  // Reset clears 'containers' from the device_mgr of the TBBSession.
-  // If 'containers' is empty, then Reset clears the default container.
-  ::tensorflow::Status Reset(const std::vector<string>& containers);
+    // Reset clears 'containers' from the device_mgr of the TBBSession.
+    // If 'containers' is empty, then Reset clears the default container.
+    ::tensorflow::Status Reset(const std::vector<string>& containers);
 
-  ::tensorflow::Status ListDevices(
-      std::vector<DeviceAttributes>* response) override;
-  ::tensorflow::Status Close() override;
-  ::tensorflow::Status LocalDeviceManager(const DeviceMgr** output) override {
-    *output = device_mgr_.get();
-    return ::tensorflow::Status::OK();
-  }
+    ::tensorflow::Status ListDevices(std::vector<DeviceAttributes>* response) override;
+    ::tensorflow::Status Close() override;
+    ::tensorflow::Status LocalDeviceManager(const DeviceMgr** output) override {
+      *output = device_mgr_.get();
+      return ::tensorflow::Status::OK();
+    }
 
-  void ExportCostModels(CostModelManager::CostModelMap* cost_models) {
-    cost_model_manager_.ExportCostModels(cost_models);
-  }
+    void ExportCostModels(CostModelManager::CostModelMap* cost_models) {
+      cost_model_manager_.ExportCostModels(cost_models);
+    }
 
- private:
-  // We create one executor and its dependent library runtime for
-  // every partition.
-  struct PerPartitionExecutorsAndLib {
-    Graph* graph = nullptr;                  // not owned.
-    Device* device = nullptr;                // not owned.
-    FunctionLibraryRuntime* flib = nullptr;  // not owned.
-    std::unique_ptr<Executor> executor;
+  private:
+    // We create one executor and its dependent library runtime for
+    // every partition.
+    struct PerPartitionExecutorsAndLib {
+      Graph* graph = nullptr;                  // not owned.
+      Device* device = nullptr;                // not owned.
+      FunctionLibraryRuntime* flib = nullptr;  // not owned.
+      std::unique_ptr<Executor> executor;
+    };
+
+    // An ExecutorsAndKeys is created for a given set of feeds/fetches.
+    // 'step_count' is the number of times this graph is executed.
+    // 'graph' is the entire graph being executed. 'name_to_node'
+    // maps node name to node. We keep 'graph' and 'name_to_node' only in
+    // the case of partial runs. Each item in 'items' is the executor for
+    // a partition of the graph bundled with its dependent library runtime.
+    // 'input_keys' are the rendezvous keys for the feeds and 'output_keys'
+    // are rendezvous keys for the fetches.
+    struct ExecutorsAndKeys {
+      ExecutorsAndKeys() : step_count(0) {}
+
+      std::atomic_int_fast64_t step_count;
+      std::unique_ptr<Graph> graph;
+      NameNodeMap name_to_node;
+      std::vector<PerPartitionExecutorsAndLib> items;
+      std::unordered_map<string, size_t> input_name_to_index;
+      std::unordered_map<string, string> input_name_to_rendezvous_key;
+      std::unordered_map<string, size_t> output_name_to_index;
+      std::unordered_map<string, string> output_name_to_rendezvous_key;
+
+      DataTypeVector input_types;
+      DataTypeVector output_types;
+    };
+
+    // A FunctionInfo object is created for every unique set of feeds/fetches.
+    // This info could be folded into the ExecutorsAndKeys object but we would
+    // like to maintain a deletion order in which the OpKernels (owned by the
+    // executor) should be destroyed first, followed by the resources in the
+    // device and then followed by the function stuff.
+    // TODO(rohanj): Consolidate function library definitions so that we can
+    // instantiate only one ProcFLR and lib_def and make this just a member
+    // variable and not a vector.
+    // 'flib_def' is the function library used.
+    // 'proc_flr' is the collection of FunctionLibraryRuntime objects, one per
+    // device.
+    struct FunctionInfo {
+      std::unique_ptr<FunctionLibraryDefinition> flib_def;
+      std::unique_ptr<ProcessFunctionLibraryRuntime> proc_flr;
+    };
+
+    // For each live partial execution, the session maintains a RunState.
+    // 'status' is the current status of this partial execution. 'executor_done'
+    // is "notified" when all executors are done. 'pending_inputs' are the set
+    // of pending feeds and 'pending_outputs' are the set of pending fetches.
+    struct RunState {
+      mutex mu_;
+      Status status GUARDED_BY(mu_);
+      IntraProcessRendezvous* rendez = nullptr;
+      std::unique_ptr<StepStatsCollector> collector;
+      Notification executors_done;
+      std::unordered_map<string, bool> pending_inputs;   // true if fed
+      std::unordered_map<string, bool> pending_outputs;  // true if fetched
+      TensorStore tensor_store;
+      ScopedStepContainer step_container;
+
+      RunState(int64 step_id, const std::vector<Device*>* devices);
+
+      RunState(const std::vector<string>& pending_input_names,
+               const std::vector<string>& pending_output_names,
+               int64 step_id,
+               const std::vector<Device*>* devices);
+
+      // Returns true if all pending inputs and outputs have been completed.
+      bool PendingDone() const;
+
+      ~RunState();
+    };
+
+    struct RunStateArgs {
+      RunStateArgs(const DebugOptions& options) : debug_options(options) {}
+
+      bool is_partial_run = false;
+      string handle;
+      std::unique_ptr<Graph> graph;
+      const DebugOptions& debug_options;
+    };
+
+    // Initializes the base execution state given the 'graph',
+    // if not already initialized.
+    Status MaybeInitializeExecutionState(const GraphDef& graph, bool* out_already_initialized)
+        EXCLUSIVE_LOCKS_REQUIRED(graph_def_lock_);
+
+    // Retrieves an already existing set of executors to run 'inputs' and
+    // 'outputs', or creates and caches them for future use.
+    ::tensorflow::Status GetOrCreateExecutors(gtl::ArraySlice<string> inputs,
+                                              gtl::ArraySlice<string> outputs,
+                                              gtl::ArraySlice<string> target_nodes,
+                                              ExecutorsAndKeys** executors_and_keys,
+                                              RunStateArgs* run_state_args);
+
+    // Creates several graphs given the existing graph_def_ and the
+    // input feeds and fetches, given 'devices'. The graphs share a common
+    // function library 'flib_def'.
+    ::tensorflow::Status CreateGraphs(const BuildGraphOptions& options,
+                                      std::unordered_map<string, std::unique_ptr<Graph>>* outputs,
+                                      std::unique_ptr<FunctionLibraryDefinition>* flib_def,
+                                      RunStateArgs* run_state_args,
+                                      DataTypeVector* input_types,
+                                      DataTypeVector* output_types);
+
+    ::tensorflow::Status ExtendLocked(const GraphDef& graph) EXCLUSIVE_LOCKS_REQUIRED(graph_def_lock_);
+
+    ::tensorflow::Status ResourceHandleToInputTensor(const Tensor& resource_tensor, Tensor* retrieved_tensor);
+
+    // Use the appropriate WaitForNotification function based on whether
+    // operation_timeout_in_ms is greater than 0.
+    //
+    // If the timeout expires, the `cm->StartCancel()` will be called.
+    ::tensorflow::Status WaitForNotification(Notification* n, int64 timeout_in_ms);
+    void WaitForNotification(tbb::task_arena& arena,
+                             tbb::task_group& group,
+                             RunState* run_state,
+                             CancellationManager* cm,
+                             int64 timeout_in_ms);
+
+    ::tensorflow::Status CheckNotClosed() {
+      mutex_lock l(closed_lock_);
+      if (closed_)
+        return errors::Cancelled("Session has been closed.");
+      return ::tensorflow::Status::OK();
+    }
+
+    ::tensorflow::Status CreateDebuggerState(const DebugOptions& debug_options,
+                                             int64 session_run_index,
+                                             int64 executor_step_index,
+                                             const std::vector<string>& input_names,
+                                             const std::vector<string>& output_names,
+                                             const std::vector<string>& target_names,
+                                             std::unique_ptr<DebuggerStateInterface>* debugger_state);
+
+    ::tensorflow::Status DecorateAndPublishGraphForDebug(const DebugOptions& debug_options,
+                                                         Graph* graph,
+                                                         Device* device);
+
+    const SessionOptions options_;
+
+    // Device structures.
+    const std::unique_ptr<const DeviceMgr> device_mgr_;
+    std::vector<Device*> devices_;  // not owned
+    DeviceSet device_set_;
+
+    string session_handle_;
+    bool graph_created_ GUARDED_BY(graph_def_lock_) = false;
+
+    mutex graph_def_lock_;
+    GraphDef graph_def_ GUARDED_BY(graph_def_lock_);
+
+    Status init_error_;  // Set to an error if construction failed.
+
+    // If true, blocks until device has finished all queued operations in a step.
+    bool sync_on_finish_ = true;
+    void SchedClosure(tbb::task_arena& arena, tbb::task_group& g, std::function<void()> c);
+
+    std::vector<std::unique_ptr<FunctionInfo>> functions_ GUARDED_BY(executor_lock_);
+
+    mutex executor_lock_;  // protects executors_
+    // Holds mappings from signature to the executors that process
+    // it. The reason for a level of indirection around mapped_type is
+    // to guarantee address stability.
+    // The map value is a shared_ptr since multiple map keys can point to the
+    // same ExecutorsAndKey object.
+    std::unordered_map<string, std::shared_ptr<ExecutorsAndKeys>> executors_ GUARDED_BY(executor_lock_);
+
+    // Holds mappings from handle to partial run state.
+    std::unordered_map<string, std::unique_ptr<RunState>> partial_runs_ GUARDED_BY(executor_lock_);
+
+    // This holds all the tensors that are currently alive in the session.
+    SessionState session_state_;
+
+    TBBSessionFactory* const factory_;  // not owned
+    CancellationManager* cancellation_manager_;
+
+    // Map of placed stateful nodes, i.e. nodes for which is_stateful()
+    // is true, such as "params" and "queue" nodes.  Once placed these
+    // nodes can not be moved to a different device.  Maps node names to
+    // device names.
+    std::unordered_map<string, string> stateful_placements_ GUARDED_BY(graph_def_lock_);
+
+    // Execution_state; used when placing the entire graph.
+    std::unique_ptr<GraphExecutionState> execution_state_ GUARDED_BY(graph_def_lock_);
+
+    // The function library, before any rewrites or optimizations have been
+    // performed. In particular, CreateGraphs() may need to modify the function
+    // library; it copies and modifies the function library.
+    std::unique_ptr<FunctionLibraryDefinition> flib_def_;
+
+    // true if the Session has been Closed.
+    mutex closed_lock_;
+    bool closed_ GUARDED_BY(closed_lock_) = false;
+
+    // For generating unique names for this session instance.
+    std::atomic<int64> edge_name_counter_ = {0};
+    std::atomic<int64> handle_name_counter_ = {0};
+
+    // For generating step ids that are unique across all sessions.
+    static std::atomic_int_fast64_t step_id_counter_;
+
+    // Global timeout for all blocking operations in this session.
+    const int64 operation_timeout_in_ms_ = 0;
+
+    // Manages all the cost models for the graphs executed in this session.
+    CostModelManager cost_model_manager_;
+
+    Executor::Args::NodeOutputsCallback node_outputs_callback_ = nullptr;
+
+    TF_DISALLOW_COPY_AND_ASSIGN(TBBSession);
+
+    // EXPERIMENTAL: debugger (tfdbg) related
+    friend class DebugGateway;
   };
-
-  // An ExecutorsAndKeys is created for a given set of feeds/fetches.
-  // 'step_count' is the number of times this graph is executed.
-  // 'graph' is the entire graph being executed. 'name_to_node'
-  // maps node name to node. We keep 'graph' and 'name_to_node' only in
-  // the case of partial runs. Each item in 'items' is the executor for
-  // a partition of the graph bundled with its dependent library runtime.
-  // 'input_keys' are the rendezvous keys for the feeds and 'output_keys'
-  // are rendezvous keys for the fetches.
-  struct ExecutorsAndKeys {
-    ExecutorsAndKeys() : step_count(0) {}
-
-    std::atomic_int_fast64_t step_count;
-    std::unique_ptr<Graph> graph;
-    NameNodeMap name_to_node;
-    std::vector<PerPartitionExecutorsAndLib> items;
-    std::unordered_map<string, size_t> input_name_to_index;
-    std::unordered_map<string, string> input_name_to_rendezvous_key;
-    std::unordered_map<string, size_t> output_name_to_index;
-    std::unordered_map<string, string> output_name_to_rendezvous_key;
-
-    DataTypeVector input_types;
-    DataTypeVector output_types;
-  };
-
-  // A FunctionInfo object is created for every unique set of feeds/fetches.
-  // This info could be folded into the ExecutorsAndKeys object but we would
-  // like to maintain a deletion order in which the OpKernels (owned by the
-  // executor) should be destroyed first, followed by the resources in the
-  // device and then followed by the function stuff.
-  // TODO(rohanj): Consolidate function library definitions so that we can
-  // instantiate only one ProcFLR and lib_def and make this just a member
-  // variable and not a vector.
-  // 'flib_def' is the function library used.
-  // 'proc_flr' is the collection of FunctionLibraryRuntime objects, one per
-  // device.
-  struct FunctionInfo {
-    std::unique_ptr<FunctionLibraryDefinition> flib_def;
-    std::unique_ptr<ProcessFunctionLibraryRuntime> proc_flr;
-  };
-
-  // For each live partial execution, the session maintains a RunState.
-  // 'status' is the current status of this partial execution. 'executor_done'
-  // is "notified" when all executors are done. 'pending_inputs' are the set
-  // of pending feeds and 'pending_outputs' are the set of pending fetches.
-  struct RunState {
-    mutex mu_;
-    Status status GUARDED_BY(mu_);
-    IntraProcessRendezvous* rendez = nullptr;
-    std::unique_ptr<StepStatsCollector> collector;
-    Notification executors_done;
-    std::unordered_map<string, bool> pending_inputs;   // true if fed
-    std::unordered_map<string, bool> pending_outputs;  // true if fetched
-    TensorStore tensor_store;
-    ScopedStepContainer step_container;
-
-    RunState(int64 step_id, const std::vector<Device*>* devices);
-
-    RunState(const std::vector<string>& pending_input_names,
-             const std::vector<string>& pending_output_names, int64 step_id,
-             const std::vector<Device*>* devices);
-
-    // Returns true if all pending inputs and outputs have been completed.
-    bool PendingDone() const;
-
-    ~RunState();
-  };
-
-  struct RunStateArgs {
-    RunStateArgs(const DebugOptions& options) : debug_options(options) {}
-
-    bool is_partial_run = false;
-    string handle;
-    std::unique_ptr<Graph> graph;
-    const DebugOptions& debug_options;
-  };
-
-  // Initializes the base execution state given the 'graph',
-  // if not already initialized.
-  Status MaybeInitializeExecutionState(const GraphDef& graph,
-                                       bool* out_already_initialized)
-      EXCLUSIVE_LOCKS_REQUIRED(graph_def_lock_);
-
-  // Retrieves an already existing set of executors to run 'inputs' and
-  // 'outputs', or creates and caches them for future use.
-  ::tensorflow::Status GetOrCreateExecutors(
-      gtl::ArraySlice<string> inputs, gtl::ArraySlice<string> outputs,
-      gtl::ArraySlice<string> target_nodes,
-      ExecutorsAndKeys** executors_and_keys, RunStateArgs* run_state_args);
-
-  // Creates several graphs given the existing graph_def_ and the
-  // input feeds and fetches, given 'devices'. The graphs share a common
-  // function library 'flib_def'.
-  ::tensorflow::Status CreateGraphs(
-      const BuildGraphOptions& options,
-      std::unordered_map<string, std::unique_ptr<Graph>>* outputs,
-      std::unique_ptr<FunctionLibraryDefinition>* flib_def,
-      RunStateArgs* run_state_args, DataTypeVector* input_types,
-      DataTypeVector* output_types);
-
-  ::tensorflow::Status ExtendLocked(const GraphDef& graph)
-      EXCLUSIVE_LOCKS_REQUIRED(graph_def_lock_);
-
-  ::tensorflow::Status ResourceHandleToInputTensor(
-      const Tensor& resource_tensor, Tensor* retrieved_tensor);
-
-  // Use the appropriate WaitForNotification function based on whether
-  // operation_timeout_in_ms is greater than 0.
-  //
-  // If the timeout expires, the `cm->StartCancel()` will be called.
-  ::tensorflow::Status WaitForNotification(Notification* n,
-                                           int64 timeout_in_ms);
-  void WaitForNotification(tbb::task_arena& arena, tbb::task_group& group,
-      RunState* run_state, CancellationManager* cm, int64 timeout_in_ms);
-
-  ::tensorflow::Status CheckNotClosed() {
-    mutex_lock l(closed_lock_);
-    if (closed_) return errors::Cancelled("Session has been closed.");
-    return ::tensorflow::Status::OK();
-  }
-
-  ::tensorflow::Status CreateDebuggerState(
-      const DebugOptions& debug_options, int64 session_run_index,
-      int64 executor_step_index, const std::vector<string>& input_names,
-      const std::vector<string>& output_names,
-      const std::vector<string>& target_names,
-      std::unique_ptr<DebuggerStateInterface>* debugger_state);
-
-  ::tensorflow::Status DecorateAndPublishGraphForDebug(
-      const DebugOptions& debug_options, Graph* graph, Device* device);
-
-  const SessionOptions options_;
-
-  // Device structures.
-  const std::unique_ptr<const DeviceMgr> device_mgr_;
-  std::vector<Device*> devices_;  // not owned
-  DeviceSet device_set_;
-
-  string session_handle_;
-  bool graph_created_ GUARDED_BY(graph_def_lock_) = false;
-
-  mutex graph_def_lock_;
-  GraphDef graph_def_ GUARDED_BY(graph_def_lock_);
-
-  Status init_error_;  // Set to an error if construction failed.
-
-  // If true, blocks until device has finished all queued operations in a step.
-  bool sync_on_finish_ = true;
-  void SchedClosure(tbb::task_arena& arena, tbb::task_group& g, std::function<void()> c);
-
-  std::vector<std::unique_ptr<FunctionInfo>> functions_
-      GUARDED_BY(executor_lock_);
-
-  mutex executor_lock_;  // protects executors_
-  // Holds mappings from signature to the executors that process
-  // it. The reason for a level of indirection around mapped_type is
-  // to guarantee address stability.
-  // The map value is a shared_ptr since multiple map keys can point to the
-  // same ExecutorsAndKey object.
-  std::unordered_map<string, std::shared_ptr<ExecutorsAndKeys>> executors_
-      GUARDED_BY(executor_lock_);
-
-  // Holds mappings from handle to partial run state.
-  std::unordered_map<string, std::unique_ptr<RunState>> partial_runs_
-      GUARDED_BY(executor_lock_);
-
-  // This holds all the tensors that are currently alive in the session.
-  SessionState session_state_;
-
-  TBBSessionFactory* const factory_;  // not owned
-  CancellationManager* cancellation_manager_;
-
-  // Map of placed stateful nodes, i.e. nodes for which is_stateful()
-  // is true, such as "params" and "queue" nodes.  Once placed these
-  // nodes can not be moved to a different device.  Maps node names to
-  // device names.
-  std::unordered_map<string, string> stateful_placements_
-      GUARDED_BY(graph_def_lock_);
-
-  // Execution_state; used when placing the entire graph.
-  std::unique_ptr<GraphExecutionState> execution_state_
-      GUARDED_BY(graph_def_lock_);
-
-  // The function library, before any rewrites or optimizations have been
-  // performed. In particular, CreateGraphs() may need to modify the function
-  // library; it copies and modifies the function library.
-  std::unique_ptr<FunctionLibraryDefinition> flib_def_;
-
-  // true if the Session has been Closed.
-  mutex closed_lock_;
-  bool closed_ GUARDED_BY(closed_lock_) = false;
-
-  // For generating unique names for this session instance.
-  std::atomic<int64> edge_name_counter_ = {0};
-  std::atomic<int64> handle_name_counter_ = {0};
-
-  // For generating step ids that are unique across all sessions.
-  static std::atomic_int_fast64_t step_id_counter_;
-
-  // Global timeout for all blocking operations in this session.
-  const int64 operation_timeout_in_ms_ = 0;
-
-  // Manages all the cost models for the graphs executed in this session.
-  CostModelManager cost_model_manager_;
-
-  Executor::Args::NodeOutputsCallback node_outputs_callback_ = nullptr;
-
-  TF_DISALLOW_COPY_AND_ASSIGN(TBBSession);
-
-  // EXPERIMENTAL: debugger (tfdbg) related
-  friend class DebugGateway;
-};
 
 }  // end namespace tensorflow
 

--- a/PhysicsTools/TensorFlow/test/testGraphLoading.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoading.cc
@@ -12,119 +12,102 @@
 
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
-std::string cmsswPath(std::string path)
-{
-    if (path.size() > 0 && path.substr(0, 1) != "/")
-    {
-        path = "/" + path;
-    }
+std::string cmsswPath(std::string path) {
+  if (path.size() > 0 && path.substr(0, 1) != "/") {
+    path = "/" + path;
+  }
 
-    std::string base = std::string(std::getenv("CMSSW_BASE"));
-    std::string releaseBase = std::string(std::getenv("CMSSW_RELEASE_BASE"));
+  std::string base = std::string(std::getenv("CMSSW_BASE"));
+  std::string releaseBase = std::string(std::getenv("CMSSW_RELEASE_BASE"));
 
-    return (boost::filesystem::exists(base.c_str()) ? base : releaseBase) + path;
+  return (boost::filesystem::exists(base.c_str()) ? base : releaseBase) + path;
 }
 
-class testGraphLoading : public CppUnit::TestFixture
-{
-    CPPUNIT_TEST_SUITE(testGraphLoading);
-    CPPUNIT_TEST(checkAll);
-    CPPUNIT_TEST_SUITE_END();
+class testGraphLoading : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testGraphLoading);
+  CPPUNIT_TEST(checkAll);
+  CPPUNIT_TEST_SUITE_END();
 
 public:
-    std::string dataPath;
+  std::string dataPath;
 
-    void setUp();
-    void tearDown();
-    void checkAll();
-
+  void setUp();
+  void tearDown();
+  void checkAll();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoading);
 
-void testGraphLoading::setUp()
-{
-    dataPath = cmsswPath("/test/" + std::string(getenv("SCRAM_ARCH"))
-        + "/" + boost::filesystem::unique_path().string());
+void testGraphLoading::setUp() {
+  dataPath = cmsswPath("/test/" + std::string(getenv("SCRAM_ARCH")) + "/" + boost::filesystem::unique_path().string());
 
-    // create the graph
-    std::string testPath = cmsswPath("/src/PhysicsTools/TensorFlow/test");
-    std::string cmd = "python " + testPath + "/createconstantgraph.py " + dataPath;
-    std::array<char, 128> buffer;
-    std::string result;
-    std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
-    if (!pipe)
-    {
-        throw std::runtime_error("popen() failed!");
+  // create the graph
+  std::string testPath = cmsswPath("/src/PhysicsTools/TensorFlow/test");
+  std::string cmd = "python " + testPath + "/createconstantgraph.py " + dataPath;
+  std::array<char, 128> buffer;
+  std::string result;
+  std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
+  if (!pipe) {
+    throw std::runtime_error("popen() failed!");
+  }
+  while (!feof(pipe.get())) {
+    if (fgets(buffer.data(), 128, pipe.get()) != NULL) {
+      result += buffer.data();
     }
-    while (!feof(pipe.get()))
-    {
-        if (fgets(buffer.data(), 128, pipe.get()) != NULL)
-        {
-            result += buffer.data();
-        }
-    }
-    std::cout << std::endl
-              << result << std::endl;
+  }
+  std::cout << std::endl << result << std::endl;
 }
 
-void testGraphLoading::tearDown()
-{
-    if (boost::filesystem::exists(dataPath))
-    {
-        boost::filesystem::remove_all(dataPath);
-    }
+void testGraphLoading::tearDown() {
+  if (boost::filesystem::exists(dataPath)) {
+    boost::filesystem::remove_all(dataPath);
+  }
 }
 
-void testGraphLoading::checkAll()
-{
-    std::string pbFile = dataPath + "/constantgraph.pb";
+void testGraphLoading::checkAll() {
+  std::string pbFile = dataPath + "/constantgraph.pb";
 
-    // load the graph
-    tensorflow::setLogging();
-    tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
-    CPPUNIT_ASSERT(graphDef != nullptr);
+  // load the graph
+  tensorflow::setLogging();
+  tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
+  CPPUNIT_ASSERT(graphDef != nullptr);
 
-    // create a new session and add the graphDef
-    tensorflow::Session* session = tensorflow::createSession(graphDef);
-    CPPUNIT_ASSERT(session != nullptr);
+  // create a new session and add the graphDef
+  tensorflow::Session* session = tensorflow::createSession(graphDef);
+  CPPUNIT_ASSERT(session != nullptr);
 
-    // example evaluation
-    tensorflow::Tensor input(tensorflow::DT_FLOAT, { 1, 10 });
-    float* d = input.flat<float>().data();
-    for (size_t i = 0; i < 10; i++, d++)
-    {
-        *d = float(i);
-    }
-    tensorflow::Tensor scale(tensorflow::DT_FLOAT, {});
-    scale.scalar<float>()() = 1.0;
+  // example evaluation
+  tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 10});
+  float* d = input.flat<float>().data();
+  for (size_t i = 0; i < 10; i++, d++) {
+    *d = float(i);
+  }
+  tensorflow::Tensor scale(tensorflow::DT_FLOAT, {});
+  scale.scalar<float>()() = 1.0;
 
-    std::vector<tensorflow::Tensor> outputs;
-    tensorflow::Status status = session->Run({ { "input", input }, { "scale", scale } },
-        { "output" }, {}, &outputs);
-    if (!status.ok())
-    {
-        std::cout << status.ToString() << std::endl;
-        CPPUNIT_ASSERT(false);
-    }
+  std::vector<tensorflow::Tensor> outputs;
+  tensorflow::Status status = session->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
+  if (!status.ok()) {
+    std::cout << status.ToString() << std::endl;
+    CPPUNIT_ASSERT(false);
+  }
 
-    // check the output
-    CPPUNIT_ASSERT(outputs.size() == 1);
-    std::cout << outputs[0].DebugString() << std::endl;
-    CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
+  // check the output
+  CPPUNIT_ASSERT(outputs.size() == 1);
+  std::cout << outputs[0].DebugString() << std::endl;
+  CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
 
-    // run again using the convenience helper
-    outputs.clear();
-    tensorflow::run(session, { { "input", input }, { "scale", scale } }, { "output" }, &outputs);
-    CPPUNIT_ASSERT(outputs.size() == 1);
-    std::cout << outputs[0].DebugString() << std::endl;
-    CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
+  // run again using the convenience helper
+  outputs.clear();
+  tensorflow::run(session, {{"input", input}, {"scale", scale}}, {"output"}, &outputs);
+  CPPUNIT_ASSERT(outputs.size() == 1);
+  std::cout << outputs[0].DebugString() << std::endl;
+  CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
 
-    // check for exception
-    CPPUNIT_ASSERT_THROW(tensorflow::run(session, { { "foo", input } }, { "output" }, &outputs),
-        cms::Exception);
+  // check for exception
+  CPPUNIT_ASSERT_THROW(tensorflow::run(session, {{"foo", input}}, {"output"}, &outputs), cms::Exception);
 
-    // cleanup
-    CPPUNIT_ASSERT(tensorflow::closeSession(session));
-    delete graphDef;
+  // cleanup
+  CPPUNIT_ASSERT(tensorflow::closeSession(session));
+  delete graphDef;
 }

--- a/PhysicsTools/TensorFlow/test/testMetaGraphLoading.cc
+++ b/PhysicsTools/TensorFlow/test/testMetaGraphLoading.cc
@@ -12,124 +12,107 @@
 
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
-std::string cmsswPath(std::string path)
-{
-    if (path.size() > 0 && path.substr(0, 1) != "/")
-    {
-        path = "/" + path;
-    }
+std::string cmsswPath(std::string path) {
+  if (path.size() > 0 && path.substr(0, 1) != "/") {
+    path = "/" + path;
+  }
 
-    std::string base = std::string(std::getenv("CMSSW_BASE"));
-    std::string releaseBase = std::string(std::getenv("CMSSW_RELEASE_BASE"));
+  std::string base = std::string(std::getenv("CMSSW_BASE"));
+  std::string releaseBase = std::string(std::getenv("CMSSW_RELEASE_BASE"));
 
-    return (boost::filesystem::exists(base.c_str()) ? base : releaseBase) + path;
+  return (boost::filesystem::exists(base.c_str()) ? base : releaseBase) + path;
 }
 
-class testMetaGraphLoading : public CppUnit::TestFixture
-{
-    CPPUNIT_TEST_SUITE(testMetaGraphLoading);
-    CPPUNIT_TEST(checkAll);
-    CPPUNIT_TEST_SUITE_END();
+class testMetaGraphLoading : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testMetaGraphLoading);
+  CPPUNIT_TEST(checkAll);
+  CPPUNIT_TEST_SUITE_END();
 
 public:
-    std::string dataPath;
+  std::string dataPath;
 
-    void setUp();
-    void tearDown();
-    void checkAll();
-
+  void setUp();
+  void tearDown();
+  void checkAll();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testMetaGraphLoading);
 
-void testMetaGraphLoading::setUp()
-{
-    dataPath = cmsswPath("/test/" + std::string(getenv("SCRAM_ARCH"))
-        + "/" + boost::filesystem::unique_path().string());
+void testMetaGraphLoading::setUp() {
+  dataPath = cmsswPath("/test/" + std::string(getenv("SCRAM_ARCH")) + "/" + boost::filesystem::unique_path().string());
 
-    // create the graph
-    std::string testPath = cmsswPath("/src/PhysicsTools/TensorFlow/test");
-    std::string cmd = "python " + testPath + "/creategraph.py " + dataPath;
-    std::array<char, 128> buffer;
-    std::string result;
-    std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
-    if (!pipe)
-    {
-        throw std::runtime_error("popen() failed!");
+  // create the graph
+  std::string testPath = cmsswPath("/src/PhysicsTools/TensorFlow/test");
+  std::string cmd = "python " + testPath + "/creategraph.py " + dataPath;
+  std::array<char, 128> buffer;
+  std::string result;
+  std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
+  if (!pipe) {
+    throw std::runtime_error("popen() failed!");
+  }
+  while (!feof(pipe.get())) {
+    if (fgets(buffer.data(), 128, pipe.get()) != NULL) {
+      result += buffer.data();
     }
-    while (!feof(pipe.get()))
-    {
-        if (fgets(buffer.data(), 128, pipe.get()) != NULL)
-        {
-            result += buffer.data();
-        }
-    }
-    std::cout << std::endl
-              << result << std::endl;
+  }
+  std::cout << std::endl << result << std::endl;
 }
 
-void testMetaGraphLoading::tearDown()
-{
-    if (boost::filesystem::exists(dataPath))
-    {
-        boost::filesystem::remove_all(dataPath);
-    }
+void testMetaGraphLoading::tearDown() {
+  if (boost::filesystem::exists(dataPath)) {
+    boost::filesystem::remove_all(dataPath);
+  }
 }
 
-void testMetaGraphLoading::checkAll()
-{
-    std::string exportDir = dataPath + "/simplegraph";
+void testMetaGraphLoading::checkAll() {
+  std::string exportDir = dataPath + "/simplegraph";
 
-    // load the graph
-    tensorflow::setLogging();
-    tensorflow::MetaGraphDef* metaGraph = tensorflow::loadMetaGraph(exportDir);
-    CPPUNIT_ASSERT(metaGraph != nullptr);
+  // load the graph
+  tensorflow::setLogging();
+  tensorflow::MetaGraphDef* metaGraph = tensorflow::loadMetaGraph(exportDir);
+  CPPUNIT_ASSERT(metaGraph != nullptr);
 
-    // create a new, empty session
-    tensorflow::Session* session1 = tensorflow::createSession();
-    CPPUNIT_ASSERT(session1 != nullptr);
+  // create a new, empty session
+  tensorflow::Session* session1 = tensorflow::createSession();
+  CPPUNIT_ASSERT(session1 != nullptr);
 
-    // create a new session, using the meta graph
-    tensorflow::Session* session2 = tensorflow::createSession(metaGraph, exportDir);
-    CPPUNIT_ASSERT(session2 != nullptr);
+  // create a new session, using the meta graph
+  tensorflow::Session* session2 = tensorflow::createSession(metaGraph, exportDir);
+  CPPUNIT_ASSERT(session2 != nullptr);
 
-    // example evaluation
-    tensorflow::Tensor input(tensorflow::DT_FLOAT, { 1, 10 });
-    float* d = input.flat<float>().data();
-    for (size_t i = 0; i < 10; i++, d++)
-    {
-        *d = float(i);
-    }
-    tensorflow::Tensor scale(tensorflow::DT_FLOAT, {});
-    scale.scalar<float>()() = 1.0;
+  // example evaluation
+  tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 10});
+  float* d = input.flat<float>().data();
+  for (size_t i = 0; i < 10; i++, d++) {
+    *d = float(i);
+  }
+  tensorflow::Tensor scale(tensorflow::DT_FLOAT, {});
+  scale.scalar<float>()() = 1.0;
 
-    std::vector<tensorflow::Tensor> outputs;
-    tensorflow::Status status = session2->Run({ { "input", input }, { "scale", scale } },
-        { "output" }, {}, &outputs);
-    if (!status.ok())
-    {
-        std::cout << status.ToString() << std::endl;
-        CPPUNIT_ASSERT(false);
-    }
+  std::vector<tensorflow::Tensor> outputs;
+  tensorflow::Status status = session2->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
+  if (!status.ok()) {
+    std::cout << status.ToString() << std::endl;
+    CPPUNIT_ASSERT(false);
+  }
 
-    // check the output
-    CPPUNIT_ASSERT(outputs.size() == 1);
-    std::cout << outputs[0].DebugString() << std::endl;
-    CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
+  // check the output
+  CPPUNIT_ASSERT(outputs.size() == 1);
+  std::cout << outputs[0].DebugString() << std::endl;
+  CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
 
-    // run again using the convenience helper
-    outputs.clear();
-    tensorflow::run(session2, { { "input", input }, { "scale", scale } }, { "output" }, &outputs);
-    CPPUNIT_ASSERT(outputs.size() == 1);
-    std::cout << outputs[0].DebugString() << std::endl;
-    CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
+  // run again using the convenience helper
+  outputs.clear();
+  tensorflow::run(session2, {{"input", input}, {"scale", scale}}, {"output"}, &outputs);
+  CPPUNIT_ASSERT(outputs.size() == 1);
+  std::cout << outputs[0].DebugString() << std::endl;
+  CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
 
-    // check for exception
-    CPPUNIT_ASSERT_THROW(tensorflow::run(session2, { { "foo", input } }, { "output" }, &outputs),
-        cms::Exception);
+  // check for exception
+  CPPUNIT_ASSERT_THROW(tensorflow::run(session2, {{"foo", input}}, {"output"}, &outputs), cms::Exception);
 
-    // cleanup
-    CPPUNIT_ASSERT(tensorflow::closeSession(session1));
-    CPPUNIT_ASSERT(tensorflow::closeSession(session2));
-    delete metaGraph;
+  // cleanup
+  CPPUNIT_ASSERT(tensorflow::closeSession(session1));
+  CPPUNIT_ASSERT(tensorflow::closeSession(session2));
+  delete metaGraph;
 }


### PR DESCRIPTION

Applying code-format for CMSSW category analysis,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/399//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


