### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/DataFormats/EgammaCandidates/interface/Conversion.h
+++ b/DataFormats/EgammaCandidates/interface/Conversion.h
@@ -11,7 +11,7 @@
 
 #include <bitset>
 #include "DataFormats/Math/interface/Point3D.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h" 
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1DFloat.h"
@@ -19,240 +19,230 @@
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 
-
 namespace reco {
-    class Conversion  {
+  class Conversion {
   public:
+    enum ConversionAlgorithm { undefined = 0, ecalSeeded = 1, trackerOnly = 2, mixed = 3, pflow = 4, algoSize = 5 };
 
-      enum ConversionAlgorithm {undefined=0, 
-				ecalSeeded=1, 
-				trackerOnly=2, 
-				mixed=3, 
-                                pflow=4,
-				algoSize=5}; 
+    enum ConversionQuality {
+      generalTracksOnly = 0,
+      arbitratedEcalSeeded = 1,
+      arbitratedMerged = 2,
+      arbitratedMergedEcalGeneral = 3,
+      gsfTracksOpenOnly = 4,
+      highPurity = 8,
+      highEfficiency = 9,
+      ecalMatched1Track = 10,
+      ecalMatched2Track = 11
+    };
 
-      enum ConversionQuality {generalTracksOnly=0, 
-			      arbitratedEcalSeeded=1, 
-			      arbitratedMerged=2,
-			      arbitratedMergedEcalGeneral=3,
-                              gsfTracksOpenOnly=4,
-			      highPurity=8, 
-			      highEfficiency=9,
-			      ecalMatched1Track=10,
-			      ecalMatched2Track=11};
+    static const std::string algoNames[];
 
-      static const std::string algoNames[];      
+    // Default constructor
+    Conversion();
 
-      // Default constructor
-      Conversion();
-      
-      Conversion( const reco::CaloClusterPtrVector& clu, 
-		  const std::vector<edm::RefToBase<reco::Track> >& tr,
-		  const std::vector<math::XYZPointF>& trackPositionAtEcal , 
-		  const reco::Vertex  &  convVtx,
-		  const std::vector<reco::CaloClusterPtr> & matchingBC,
-		  const float DCA,        
-		  const std::vector<math::XYZPointF> & innPoint,
-		  const std::vector<math::XYZVectorF> & trackPin ,
-		  const std::vector<math::XYZVectorF> & trackPout,
-                  const std::vector<uint8_t>& nHitsBeforeVtx,
-                  const std::vector<Measurement1DFloat> & dlClosestHitToVtx,
-                  uint8_t nSharedHits,
-                  const float mva,
-		  ConversionAlgorithm=undefined);
+    Conversion(const reco::CaloClusterPtrVector& clu,
+               const std::vector<edm::RefToBase<reco::Track> >& tr,
+               const std::vector<math::XYZPointF>& trackPositionAtEcal,
+               const reco::Vertex& convVtx,
+               const std::vector<reco::CaloClusterPtr>& matchingBC,
+               const float DCA,
+               const std::vector<math::XYZPointF>& innPoint,
+               const std::vector<math::XYZVectorF>& trackPin,
+               const std::vector<math::XYZVectorF>& trackPout,
+               const std::vector<uint8_t>& nHitsBeforeVtx,
+               const std::vector<Measurement1DFloat>& dlClosestHitToVtx,
+               uint8_t nSharedHits,
+               const float mva,
+               ConversionAlgorithm = undefined);
 
+    Conversion(const reco::CaloClusterPtrVector& clu,
+               const std::vector<reco::TrackRef>& tr,
+               const std::vector<math::XYZPointF>& trackPositionAtEcal,
+               const reco::Vertex& convVtx,
+               const std::vector<reco::CaloClusterPtr>& matchingBC,
+               const float DCA,
+               const std::vector<math::XYZPointF>& innPoint,
+               const std::vector<math::XYZVectorF>& trackPin,
+               const std::vector<math::XYZVectorF>& trackPout,
+               const float mva,
+               ConversionAlgorithm = undefined);
 
-      Conversion( const reco::CaloClusterPtrVector& clu, 
-		  const std::vector<reco::TrackRef>& tr,
-		  const std::vector<math::XYZPointF>& trackPositionAtEcal , 
-		  const reco::Vertex  &  convVtx,
-		  const std::vector<reco::CaloClusterPtr> & matchingBC,
-		  const float DCA,        
-		  const std::vector<math::XYZPointF> & innPoint,
-		  const std::vector<math::XYZVectorF> & trackPin ,
-		  const std::vector<math::XYZVectorF> & trackPout,
-                  const float mva,
-		  ConversionAlgorithm=undefined);
-      
+    Conversion(const reco::CaloClusterPtrVector& clu,
+               const std::vector<reco::TrackRef>& tr,
+               const reco::Vertex& convVtx,
+               ConversionAlgorithm = undefined);
 
+    Conversion(const reco::CaloClusterPtrVector& clu,
+               const std::vector<edm::RefToBase<reco::Track> >& tr,
+               const reco::Vertex& convVtx,
+               ConversionAlgorithm = undefined);
 
-      
-      Conversion( const reco::CaloClusterPtrVector& clu, 
-		  const std::vector<reco::TrackRef>& tr,
-		  const reco::Vertex  &  convVtx,
-		  ConversionAlgorithm=undefined);
-      
-      Conversion( const reco::CaloClusterPtrVector& clu, 
-		  const std::vector<edm::RefToBase<reco::Track> >& tr,
-		  const reco::Vertex  &  convVtx,
-		  ConversionAlgorithm=undefined);
-      
-      
-      /// returns a clone of the candidate
-      Conversion * clone() const;
-      /// Pointer to CaloCluster (foe Egamma Conversions it points to  a SuperCluster)
-      reco::CaloClusterPtrVector caloCluster() const {return caloCluster_ ;}
-      /// vector of track to base references 
-      std::vector<edm::RefToBase<reco::Track> > const& tracks() const ; 
-      /// returns  the reco conversion vertex
-      const reco::Vertex & conversionVertex() const  { return theConversionVertex_ ; }
-      /// Bool flagging objects having track size >0
-      bool isConverted() const;
-      /// Number of tracks= 0,1,2
-      unsigned int nTracks() const {return  tracks().size(); }
-      /// get the value  of the TMVA output
-      double MVAout() const { return theMVAout_;}
-      /// get the MVS output from PF for one leg conversions
-      std::vector<float> const oneLegMVA() {return theOneLegMVA_;}
-      /// if nTracks=2 returns the pair invariant mass. Original tracks are used here
-      double pairInvariantMass() const;
-      /// Delta cot(Theta) where Theta is the angle in the (y,z) plane between the two tracks. Original tracks are used
-      double pairCotThetaSeparation() const;
-      /// Conversion tracks momentum from the tracks inner momentum
-      math::XYZVectorF  pairMomentum() const;
-      /// Conversion track pair 4-momentum from the tracks refitted with vertex constraint
-      math::XYZTLorentzVectorF   refittedPair4Momentum() const;
-      /// Conversion tracks momentum from the tracks refitted with vertex constraint
-      math::XYZVectorF  refittedPairMomentum() const;
-      /// Super Cluster energy divided by track pair momentum if Standard seeding method. If a pointer to two (or more clusters)
-      /// is stored in the conversion, this method returns the energy sum of clusters divided by the track pair momentum
-      /// Track innermost momentum is used here
-      double EoverP() const;
-      /// Super Cluster energy divided by track pair momentum if Standard seeing method. If a pointer to two (or more clusters)
-      /// is stored in the conversion, this method returns the energy sum of clusters divided by the track pair momentum
-      ///  Track momentum refitted with vertex constraint is used
-      double EoverPrefittedTracks() const;
-      // Dist of minimum approach between tracks
-      double distOfMinimumApproach() const {return  theMinDistOfApproach_;}
-      // deltaPhi tracks at innermost point
-      double dPhiTracksAtVtx() const;
-      // deltaPhi tracks at ECAl
-      double dPhiTracksAtEcal() const;
-      // deltaEta tracks at ECAl
-      double dEtaTracksAtEcal() const;
+    /// returns a clone of the candidate
+    Conversion* clone() const;
+    /// Pointer to CaloCluster (foe Egamma Conversions it points to  a SuperCluster)
+    reco::CaloClusterPtrVector caloCluster() const { return caloCluster_; }
+    /// vector of track to base references
+    std::vector<edm::RefToBase<reco::Track> > const& tracks() const;
+    /// returns  the reco conversion vertex
+    const reco::Vertex& conversionVertex() const { return theConversionVertex_; }
+    /// Bool flagging objects having track size >0
+    bool isConverted() const;
+    /// Number of tracks= 0,1,2
+    unsigned int nTracks() const { return tracks().size(); }
+    /// get the value  of the TMVA output
+    double MVAout() const { return theMVAout_; }
+    /// get the MVS output from PF for one leg conversions
+    std::vector<float> const oneLegMVA() { return theOneLegMVA_; }
+    /// if nTracks=2 returns the pair invariant mass. Original tracks are used here
+    double pairInvariantMass() const;
+    /// Delta cot(Theta) where Theta is the angle in the (y,z) plane between the two tracks. Original tracks are used
+    double pairCotThetaSeparation() const;
+    /// Conversion tracks momentum from the tracks inner momentum
+    math::XYZVectorF pairMomentum() const;
+    /// Conversion track pair 4-momentum from the tracks refitted with vertex constraint
+    math::XYZTLorentzVectorF refittedPair4Momentum() const;
+    /// Conversion tracks momentum from the tracks refitted with vertex constraint
+    math::XYZVectorF refittedPairMomentum() const;
+    /// Super Cluster energy divided by track pair momentum if Standard seeding method. If a pointer to two (or more clusters)
+    /// is stored in the conversion, this method returns the energy sum of clusters divided by the track pair momentum
+    /// Track innermost momentum is used here
+    double EoverP() const;
+    /// Super Cluster energy divided by track pair momentum if Standard seeing method. If a pointer to two (or more clusters)
+    /// is stored in the conversion, this method returns the energy sum of clusters divided by the track pair momentum
+    ///  Track momentum refitted with vertex constraint is used
+    double EoverPrefittedTracks() const;
+    // Dist of minimum approach between tracks
+    double distOfMinimumApproach() const { return theMinDistOfApproach_; }
+    // deltaPhi tracks at innermost point
+    double dPhiTracksAtVtx() const;
+    // deltaPhi tracks at ECAl
+    double dPhiTracksAtEcal() const;
+    // deltaEta tracks at ECAl
+    double dEtaTracksAtEcal() const;
 
-      //impact parameter and decay length computed with respect to given beamspot or vertex
-      //computed from refittedPairMomentum
+    //impact parameter and decay length computed with respect to given beamspot or vertex
+    //computed from refittedPairMomentum
 
-      //transverse impact parameter
-      double dxy(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
-      //longitudinal impact parameter
-      double dz(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
-      //transverse decay length
-      double lxy(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
-      //longitudinal decay length
-      double lz(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
-      //z position of intersection with beamspot in rz plane (possible tilt of beamspot is neglected)
-      double zOfPrimaryVertexFromTracks(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const { return dz(myBeamSpot) + myBeamSpot.z(); }
+    //transverse impact parameter
+    double dxy(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
+    //longitudinal impact parameter
+    double dz(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
+    //transverse decay length
+    double lxy(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
+    //longitudinal decay length
+    double lz(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const;
+    //z position of intersection with beamspot in rz plane (possible tilt of beamspot is neglected)
+    double zOfPrimaryVertexFromTracks(const math::XYZPoint& myBeamSpot = math::XYZPoint()) const {
+      return dz(myBeamSpot) + myBeamSpot.z();
+    }
 
-      ///// The following are variables provided per each track
-      /// positions of the track extrapolation at the ECAL front face
-      const std::vector<math::XYZPointF> & ecalImpactPosition() const  {return thePositionAtEcal_;}
-      //  pair of BC matching a posteriori the tracks
-      const std::vector<reco::CaloClusterPtr>&  bcMatchingWithTracks() const { return theMatchingBCs_;}
-      /// signed transverse impact parameter for each track
-      std::vector<double> tracksSigned_d0() const ;
-      /// Vector containing the position of the innermost hit of each track
-      const std::vector<math::XYZPointF>& tracksInnerPosition() const {return theTrackInnerPosition_;}
-      /// Vector of track momentum measured at the outermost hit
-      const std::vector<math::XYZVectorF>& tracksPout() const {return theTrackPout_;}
-      /// Vector of track momentum measured at the innermost hit
-      const std::vector<math::XYZVectorF>& tracksPin() const  {return theTrackPin_;}
-      ///Vector of the number of hits before the vertex along each track trajector
-      const std::vector<uint8_t> &nHitsBeforeVtx() const { return nHitsBeforeVtx_; }
-      ///Vector of signed decay length with uncertainty from nearest hit on track to the conversion vtx positions
-      const std::vector<Measurement1DFloat> &dlClosestHitToVtx() const { return dlClosestHitToVtx_; }
-      ///number of shared hits btw the two track
-      uint8_t nSharedHits() const { return nSharedHits_; }
+    ///// The following are variables provided per each track
+    /// positions of the track extrapolation at the ECAL front face
+    const std::vector<math::XYZPointF>& ecalImpactPosition() const { return thePositionAtEcal_; }
+    //  pair of BC matching a posteriori the tracks
+    const std::vector<reco::CaloClusterPtr>& bcMatchingWithTracks() const { return theMatchingBCs_; }
+    /// signed transverse impact parameter for each track
+    std::vector<double> tracksSigned_d0() const;
+    /// Vector containing the position of the innermost hit of each track
+    const std::vector<math::XYZPointF>& tracksInnerPosition() const { return theTrackInnerPosition_; }
+    /// Vector of track momentum measured at the outermost hit
+    const std::vector<math::XYZVectorF>& tracksPout() const { return theTrackPout_; }
+    /// Vector of track momentum measured at the innermost hit
+    const std::vector<math::XYZVectorF>& tracksPin() const { return theTrackPin_; }
+    ///Vector of the number of hits before the vertex along each track trajector
+    const std::vector<uint8_t>& nHitsBeforeVtx() const { return nHitsBeforeVtx_; }
+    ///Vector of signed decay length with uncertainty from nearest hit on track to the conversion vtx positions
+    const std::vector<Measurement1DFloat>& dlClosestHitToVtx() const { return dlClosestHitToVtx_; }
+    ///number of shared hits btw the two track
+    uint8_t nSharedHits() const { return nSharedHits_; }
 
+    /// set the value  of the TMVA output
+    void setMVAout(const float& mva) { theMVAout_ = mva; }
+    /// set the MVS output from PF for one leg conversions
+    void setOneLegMVA(const std::vector<float>& mva) { theOneLegMVA_ = mva; }
+    // Set the ptr to the Super cluster if not set in the constructor
+    void setMatchingSuperCluster(const reco::CaloClusterPtrVector& sc) { caloCluster_ = sc; }
+    /// Conversion Track algorithm/provenance
+    void setConversionAlgorithm(const ConversionAlgorithm a, bool set = true) {
+      if (set)
+        algorithm_ = a;
+      else
+        algorithm_ = undefined;
+    }
+    ConversionAlgorithm algo() const;
+    std::string algoName() const;
+    static std::string algoName(ConversionAlgorithm);
+    static ConversionAlgorithm algoByName(const std::string& name);
 
-      /// set the value  of the TMVA output
-      void setMVAout(const float& mva) { theMVAout_=mva;}
-      /// set the MVS output from PF for one leg conversions
-      void setOneLegMVA(const std::vector<float>& mva) { theOneLegMVA_=mva;}
-      // Set the ptr to the Super cluster if not set in the constructor 
-      void setMatchingSuperCluster ( const  reco::CaloClusterPtrVector& sc) { caloCluster_= sc;}
-      /// Conversion Track algorithm/provenance
-      void setConversionAlgorithm(const ConversionAlgorithm a, bool set=true) { if (set) algorithm_=a; else algorithm_=undefined;}
-      ConversionAlgorithm algo() const ;
-      std::string algoName() const;
-      static std::string algoName(ConversionAlgorithm );
-      static ConversionAlgorithm  algoByName(const std::string &name);      
+    bool quality(ConversionQuality q) const { return (qualityMask_ & (1 << q)) >> q; }
+    void setQuality(ConversionQuality q, bool b);
 
-      bool quality(ConversionQuality q) const { return  (qualityMask_ & (1<<q))>>q; }
-      void setQuality(ConversionQuality q, bool b);
-
-
-      
-    private:
-      
-      /// vector pointer to a/multiple seed CaloCluster(s)
-      reco::CaloClusterPtrVector caloCluster_;
-      /// vector Track RefToBase
-      std::vector<edm::RefToBase<reco::Track> >  trackToBaseRefs_;
-      /// position at the ECAl surface of the track extrapolation
-      std::vector<math::XYZPointF>  thePositionAtEcal_;
-      /// Fitted Kalman conversion vertex
-      reco::Vertex theConversionVertex_;
-      /// Clusters mathing the tracks (these are not the seeds)
-      std::vector<reco::CaloClusterPtr> theMatchingBCs_;
-      /// P_in of tracks
-      std::vector<math::XYZPointF> theTrackInnerPosition_;    
-      /// P_in of tracks
-      std::vector<math::XYZVectorF> theTrackPin_;    
-      /// P_out of tracks
-      std::vector<math::XYZVectorF> theTrackPout_;    
-      ///number of hits before the vertex on each trackerOnly
-      std::vector<uint8_t> nHitsBeforeVtx_;
-      ///signed decay length and uncertainty from nearest hit on track to conversion vertex
-      std::vector<Measurement1DFloat> dlClosestHitToVtx_;
-      /// vectors of TMVA outputs from pflow for one leg conversions
-      std::vector<float>  theOneLegMVA_;
-      /// Distance of min approach of the two tracks
-      float theMinDistOfApproach_;
-      /// TMVA output
-      float theMVAout_;
-      uint16_t qualityMask_;
-      ///number of shared hits between tracks
-      uint8_t nSharedHits_;
-      /// conversion algorithm/provenance
-      uint8_t algorithm_;
-
-
+  private:
+    /// vector pointer to a/multiple seed CaloCluster(s)
+    reco::CaloClusterPtrVector caloCluster_;
+    /// vector Track RefToBase
+    std::vector<edm::RefToBase<reco::Track> > trackToBaseRefs_;
+    /// position at the ECAl surface of the track extrapolation
+    std::vector<math::XYZPointF> thePositionAtEcal_;
+    /// Fitted Kalman conversion vertex
+    reco::Vertex theConversionVertex_;
+    /// Clusters mathing the tracks (these are not the seeds)
+    std::vector<reco::CaloClusterPtr> theMatchingBCs_;
+    /// P_in of tracks
+    std::vector<math::XYZPointF> theTrackInnerPosition_;
+    /// P_in of tracks
+    std::vector<math::XYZVectorF> theTrackPin_;
+    /// P_out of tracks
+    std::vector<math::XYZVectorF> theTrackPout_;
+    ///number of hits before the vertex on each trackerOnly
+    std::vector<uint8_t> nHitsBeforeVtx_;
+    ///signed decay length and uncertainty from nearest hit on track to conversion vertex
+    std::vector<Measurement1DFloat> dlClosestHitToVtx_;
+    /// vectors of TMVA outputs from pflow for one leg conversions
+    std::vector<float> theOneLegMVA_;
+    /// Distance of min approach of the two tracks
+    float theMinDistOfApproach_;
+    /// TMVA output
+    float theMVAout_;
+    uint16_t qualityMask_;
+    ///number of shared hits between tracks
+    uint8_t nSharedHits_;
+    /// conversion algorithm/provenance
+    uint8_t algorithm_;
   };
 
-    inline Conversion::ConversionAlgorithm Conversion::algo() const {
-      return (ConversionAlgorithm) algorithm_;
-    }
-    
-    
-    inline std::string Conversion::algoName() const{
-            
-      switch(algorithm_)
-	{
-	case undefined: return "undefined";
-	case ecalSeeded: return "ecalSeeded";
-	case trackerOnly: return "trackerOnly";
-	case mixed: return "mixed";
-	case pflow: return "pflow";
+  inline Conversion::ConversionAlgorithm Conversion::algo() const { return (ConversionAlgorithm)algorithm_; }
 
-	}
-      return "undefined";
+  inline std::string Conversion::algoName() const {
+    switch (algorithm_) {
+      case undefined:
+        return "undefined";
+      case ecalSeeded:
+        return "ecalSeeded";
+      case trackerOnly:
+        return "trackerOnly";
+      case mixed:
+        return "mixed";
+      case pflow:
+        return "pflow";
     }
+    return "undefined";
+  }
 
-    inline std::string Conversion::algoName(ConversionAlgorithm a){
-      if(int(a) < int(algoSize) && int(a)>0) return algoNames[int(a)];
-      return "undefined";
-    }
+  inline std::string Conversion::algoName(ConversionAlgorithm a) {
+    if (int(a) < int(algoSize) && int(a) > 0)
+      return algoNames[int(a)];
+    return "undefined";
+  }
 
-    inline void Conversion::setQuality(ConversionQuality q, bool b){
-      if (b)//regular OR if setting value to true
-        qualityMask_ |= (1<<q) ;
-      else // doing "half-XOR" if unsetting value
-        qualityMask_ &= (~(1<<q));
+  inline void Conversion::setQuality(ConversionQuality q, bool b) {
+    if (b)  //regular OR if setting value to true
+      qualityMask_ |= (1 << q);
+    else  // doing "half-XOR" if unsetting value
+      qualityMask_ &= (~(1 << q));
+  }
 
-    }
-  
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/ConversionFwd.h
+++ b/DataFormats/EgammaCandidates/interface/ConversionFwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of reference to Conversion objects
   typedef ConversionRefVector::iterator c_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/Electron.h
+++ b/DataFormats/EgammaCandidates/interface/Electron.h
@@ -16,32 +16,33 @@ namespace reco {
   class Electron : public RecoCandidate {
   public:
     /// default constructor
-    Electron() : RecoCandidate() { }
+    Electron() : RecoCandidate() {}
     /// constructor from values
-    Electron( Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ) ) :
-      RecoCandidate( q, p4, vtx, -11 * q ) { }
+    Electron(Charge q, const LorentzVector& p4, const Point& vtx = Point(0, 0, 0))
+        : RecoCandidate(q, p4, vtx, -11 * q) {}
     /// destructor
     ~Electron() override;
     /// returns a clone of the candidate
-    Electron * clone() const override;
+    Electron* clone() const override;
     /// reference to a Track
-    using reco::RecoCandidate::track ; // avoid hiding the base
+    using reco::RecoCandidate::track;  // avoid hiding the base
     reco::TrackRef track() const override;
     /// reference to a SuperCluster
     reco::SuperClusterRef superCluster() const override;
     /// reference to a GsfTrack
     reco::GsfTrackRef gsfTrack() const override;
     /// set refrence to Photon component
-    void setSuperCluster( const reco::SuperClusterRef & r ) { superCluster_ = r; }
+    void setSuperCluster(const reco::SuperClusterRef& r) { superCluster_ = r; }
     /// set refrence to Track component
-    void setTrack( const reco::TrackRef & r ) { track_ = r; }
+    void setTrack(const reco::TrackRef& r) { track_ = r; }
     /// set reference to GsfTrack component
-    void setGsfTrack( const reco::GsfTrackRef & r ) { gsfTrack_ = r; }
+    void setGsfTrack(const reco::GsfTrackRef& r) { gsfTrack_ = r; }
 
     bool isElectron() const override;
+
   private:
     /// check overlap with another candidate
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate&) const override;
     /// reference to a SuperCluster
     reco::SuperClusterRef superCluster_;
     /// reference to a Track
@@ -50,6 +51,6 @@ namespace reco {
     reco::GsfTrackRef gsfTrack_;
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/ElectronFwd.h
+++ b/DataFormats/EgammaCandidates/interface/ElectronFwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of reference to Electron objects
   typedef ElectronRefVector::iterator electron_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/ElectronIsolationAssociation.h
+++ b/DataFormats/EgammaCandidates/interface/ElectronIsolationAssociation.h
@@ -1,15 +1,15 @@
 #ifndef EgammaCandidates_ElectronIsolationAssociation_h
 #define EgammaCandidates_ElectronIsolationAssociation_h
 // \class ElectronIsolationAssociation
-// 
+//
 // \short association of Isolation to an Electron
 //
 
 #include "DataFormats/Common/interface/AssociationMap.h"
-#include "DataFormats/EgammaCandidates/interface/ElectronFwd.h" 
+#include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
 #include <vector>
 
 namespace reco {
-  typedef edm::AssociationMap<edm::OneToValue<std::vector<reco::Electron>, float > > ElectronIsolationMap;
+  typedef edm::AssociationMap<edm::OneToValue<std::vector<reco::Electron>, float> > ElectronIsolationMap;
 }
 #endif

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -19,11 +19,9 @@
 #include <vector>
 #include <limits>
 
-namespace reco
- {
+namespace reco {
 
-
-/****************************************************************************
+  /****************************************************************************
  * \class reco::GsfElectron
  *
  * An Electron with a GsfTrack seeded from an ElectronSeed.
@@ -35,443 +33,418 @@ namespace reco
  *
  ****************************************************************************/
 
-class GsfElectron : public RecoCandidate
- {
-
-  //=======================================================
-  // Constructors
-  //
-  // The clone() method with arguments, and the copy
-  // constructor with edm references is designed for
-  // someone which want to duplicates all
-  // collections.
-  //=======================================================
-
-  public :
-
-    // some nested structures defined later on
-    struct ChargeInfo ;
-    struct TrackClusterMatching ;
-    struct TrackExtrapolations ;
-    struct ClosestCtfTrack ;
-    struct FiducialFlags ;
-    struct ShowerShape ;
-    struct IsolationVariables ;
-    struct ConversionRejection ;
-    struct ClassificationVariables ;
-    struct SaturationInfo ;
-
-    GsfElectron() ;
-    GsfElectron( const GsfElectronCoreRef & ) ;
-    GsfElectron
-     (
-      const GsfElectron &,
-      const GsfElectronCoreRef &
-     ) ;
-    GsfElectron
-     (
-      const GsfElectron & electron,
-      const GsfElectronCoreRef & core,
-      const CaloClusterPtr & electronCluster,
-      const TrackRef & closestCtfTrack,
-      const TrackBaseRef & conversionPartner,
-      const GsfTrackRefVector & ambiguousTracks
-     ) ;
-    GsfElectron
-     (
-      int charge,
-      const ChargeInfo &,
-      const GsfElectronCoreRef &,
-      const TrackClusterMatching &,
-      const TrackExtrapolations &,
-      const ClosestCtfTrack &,
-      const FiducialFlags &,
-      const ShowerShape &,
-      const ConversionRejection &
-     ) ;
-     GsfElectron
-     (
-      int charge,
-      const ChargeInfo &,
-      const GsfElectronCoreRef &,
-      const TrackClusterMatching &,
-      const TrackExtrapolations &,
-      const ClosestCtfTrack &,
-      const FiducialFlags &,
-      const ShowerShape &,
-      const ShowerShape &,
-      const ConversionRejection &,
-      const SaturationInfo &
-     ) ;
-    GsfElectron * clone() const override ;
-    GsfElectron * clone
-     (
-      const GsfElectronCoreRef & core,
-      const CaloClusterPtr & electronCluster,
-      const TrackRef & closestCtfTrack,
-      const TrackBaseRef & conversionPartner,
-      const GsfTrackRefVector & ambiguousTracks
-     ) const ;
-    ~GsfElectron() override {} ;
-
-  private:
-
-    void init() ;
-
-
-  //=======================================================
-  // Candidate methods and complementary information
-  //
-  // The gsf electron producer has tried to best evaluate
-  // the four momentum and charge and given those values to
-  // the GsfElectron constructor, which forwarded them to
-  // the Candidate constructor. Those values can be retreived
-  // with getters inherited from Candidate : p4() and charge().
-  //=======================================================
+  class GsfElectron : public RecoCandidate {
+    //=======================================================
+    // Constructors
+    //
+    // The clone() method with arguments, and the copy
+    // constructor with edm references is designed for
+    // someone which want to duplicates all
+    // collections.
+    //=======================================================
 
   public:
+    // some nested structures defined later on
+    struct ChargeInfo;
+    struct TrackClusterMatching;
+    struct TrackExtrapolations;
+    struct ClosestCtfTrack;
+    struct FiducialFlags;
+    struct ShowerShape;
+    struct IsolationVariables;
+    struct ConversionRejection;
+    struct ClassificationVariables;
+    struct SaturationInfo;
 
+    GsfElectron();
+    GsfElectron(const GsfElectronCoreRef &);
+    GsfElectron(const GsfElectron &, const GsfElectronCoreRef &);
+    GsfElectron(const GsfElectron &electron,
+                const GsfElectronCoreRef &core,
+                const CaloClusterPtr &electronCluster,
+                const TrackRef &closestCtfTrack,
+                const TrackBaseRef &conversionPartner,
+                const GsfTrackRefVector &ambiguousTracks);
+    GsfElectron(int charge,
+                const ChargeInfo &,
+                const GsfElectronCoreRef &,
+                const TrackClusterMatching &,
+                const TrackExtrapolations &,
+                const ClosestCtfTrack &,
+                const FiducialFlags &,
+                const ShowerShape &,
+                const ConversionRejection &);
+    GsfElectron(int charge,
+                const ChargeInfo &,
+                const GsfElectronCoreRef &,
+                const TrackClusterMatching &,
+                const TrackExtrapolations &,
+                const ClosestCtfTrack &,
+                const FiducialFlags &,
+                const ShowerShape &,
+                const ShowerShape &,
+                const ConversionRejection &,
+                const SaturationInfo &);
+    GsfElectron *clone() const override;
+    GsfElectron *clone(const GsfElectronCoreRef &core,
+                       const CaloClusterPtr &electronCluster,
+                       const TrackRef &closestCtfTrack,
+                       const TrackBaseRef &conversionPartner,
+                       const GsfTrackRefVector &ambiguousTracks) const;
+    ~GsfElectron() override{};
+
+  private:
+    void init();
+
+    //=======================================================
+    // Candidate methods and complementary information
+    //
+    // The gsf electron producer has tried to best evaluate
+    // the four momentum and charge and given those values to
+    // the GsfElectron constructor, which forwarded them to
+    // the Candidate constructor. Those values can be retreived
+    // with getters inherited from Candidate : p4() and charge().
+    //=======================================================
+
+  public:
     // Inherited from Candidate
     // const LorentzVector & charge() const ;
     // const LorentzVector & p4() const ;
 
     // Complementary struct
-    struct ChargeInfo
-     {
-      int scPixCharge ;
-      bool isGsfCtfScPixConsistent ;
-      bool isGsfScPixConsistent ;
-      bool isGsfCtfConsistent ;
+    struct ChargeInfo {
+      int scPixCharge;
+      bool isGsfCtfScPixConsistent;
+      bool isGsfScPixConsistent;
+      bool isGsfCtfConsistent;
       ChargeInfo()
-        : scPixCharge(0), isGsfCtfScPixConsistent(false),
-          isGsfScPixConsistent(false), isGsfCtfConsistent(false)
-        {}
-     } ;
+          : scPixCharge(0), isGsfCtfScPixConsistent(false), isGsfScPixConsistent(false), isGsfCtfConsistent(false) {}
+    };
 
     // Charge info accessors
     // to get gsf track charge: gsfTrack()->charge()
     // to get ctf track charge, if closestCtfTrackRef().isNonnull(): closestCtfTrackRef()->charge()
-    int scPixCharge() const { return chargeInfo_.scPixCharge ; }
-    bool isGsfCtfScPixChargeConsistent() const { return chargeInfo_.isGsfCtfScPixConsistent ; }
-    bool isGsfScPixChargeConsistent() const { return chargeInfo_.isGsfScPixConsistent ; }
-    bool isGsfCtfChargeConsistent() const { return chargeInfo_.isGsfCtfConsistent ; }
-    const ChargeInfo & chargeInfo() const { return chargeInfo_ ; }
+    int scPixCharge() const { return chargeInfo_.scPixCharge; }
+    bool isGsfCtfScPixChargeConsistent() const { return chargeInfo_.isGsfCtfScPixConsistent; }
+    bool isGsfScPixChargeConsistent() const { return chargeInfo_.isGsfScPixConsistent; }
+    bool isGsfCtfChargeConsistent() const { return chargeInfo_.isGsfCtfConsistent; }
+    const ChargeInfo &chargeInfo() const { return chargeInfo_; }
 
     // Candidate redefined methods
-    bool isElectron() const override { return true ; }
-    bool overlap( const Candidate & ) const override ;
+    bool isElectron() const override { return true; }
+    bool overlap(const Candidate &) const override;
 
   private:
-
     // Complementary attributes
-    ChargeInfo chargeInfo_ ;
+    ChargeInfo chargeInfo_;
 
-
-  //=======================================================
-  // Core Attributes
-  //
-  // They all have been computed before, when building the
-  // collection of GsfElectronCore instances. Each GsfElectron
-  // has a reference toward a GsfElectronCore.
-  //=======================================================
+    //=======================================================
+    // Core Attributes
+    //
+    // They all have been computed before, when building the
+    // collection of GsfElectronCore instances. Each GsfElectron
+    // has a reference toward a GsfElectronCore.
+    //=======================================================
 
   public:
-
     // accessors
-    virtual GsfElectronCoreRef core() const ;
+    virtual GsfElectronCoreRef core() const;
     void setCore(const reco::GsfElectronCoreRef &core) { core_ = core; }
 
     // forward core methods
-    SuperClusterRef superCluster() const override { return core()->superCluster() ; }
-    GsfTrackRef gsfTrack() const override { return core()->gsfTrack() ; }
-    float ctfGsfOverlap() const { return core()->ctfGsfOverlap() ; }
-    bool ecalDrivenSeed() const { return core()->ecalDrivenSeed() ; }
-    bool trackerDrivenSeed() const { return core()->trackerDrivenSeed() ; }
-    virtual SuperClusterRef parentSuperCluster() const { return core()->parentSuperCluster() ; }
-    bool closestCtfTrackRefValid() const { return closestCtfTrackRef().isAvailable() && closestCtfTrackRef().isNonnull() ; }
+    SuperClusterRef superCluster() const override { return core()->superCluster(); }
+    GsfTrackRef gsfTrack() const override { return core()->gsfTrack(); }
+    float ctfGsfOverlap() const { return core()->ctfGsfOverlap(); }
+    bool ecalDrivenSeed() const { return core()->ecalDrivenSeed(); }
+    bool trackerDrivenSeed() const { return core()->trackerDrivenSeed(); }
+    virtual SuperClusterRef parentSuperCluster() const { return core()->parentSuperCluster(); }
+    bool closestCtfTrackRefValid() const {
+      return closestCtfTrackRef().isAvailable() && closestCtfTrackRef().isNonnull();
+    }
     //methods used for MVA variables
-    float closestCtfTrackNormChi2() const { return closestCtfTrackRefValid() ? closestCtfTrackRef()->normalizedChi2() : 0; }
-    int closestCtfTrackNLayers() const { return closestCtfTrackRefValid() ? closestCtfTrackRef()->hitPattern().trackerLayersWithMeasurement() : -1; }
+    float closestCtfTrackNormChi2() const {
+      return closestCtfTrackRefValid() ? closestCtfTrackRef()->normalizedChi2() : 0;
+    }
+    int closestCtfTrackNLayers() const {
+      return closestCtfTrackRefValid() ? closestCtfTrackRef()->hitPattern().trackerLayersWithMeasurement() : -1;
+    }
 
     // backward compatibility
-    struct ClosestCtfTrack
-     {
-      TrackRef ctfTrack ; // best matching ctf track
-      float shFracInnerHits ; // fraction of common hits between the ctf and gsf tracks
+    struct ClosestCtfTrack {
+      TrackRef ctfTrack;      // best matching ctf track
+      float shFracInnerHits;  // fraction of common hits between the ctf and gsf tracks
       ClosestCtfTrack() : shFracInnerHits(0.) {}
-      ClosestCtfTrack( TrackRef track, float sh ) : ctfTrack(track), shFracInnerHits(sh) {}
-     } ;
-    float shFracInnerHits() const { return core()->ctfGsfOverlap() ; }
-    virtual TrackRef closestCtfTrackRef() const { return core()->ctfTrack() ; }
-    virtual ClosestCtfTrack closestCtfTrack() const { return ClosestCtfTrack(core()->ctfTrack(),core()->ctfGsfOverlap()) ; }
+      ClosestCtfTrack(TrackRef track, float sh) : ctfTrack(track), shFracInnerHits(sh) {}
+    };
+    float shFracInnerHits() const { return core()->ctfGsfOverlap(); }
+    virtual TrackRef closestCtfTrackRef() const { return core()->ctfTrack(); }
+    virtual ClosestCtfTrack closestCtfTrack() const {
+      return ClosestCtfTrack(core()->ctfTrack(), core()->ctfGsfOverlap());
+    }
 
   private:
-
     // attributes
-    GsfElectronCoreRef core_ ;
+    GsfElectronCoreRef core_;
 
-
-  //=======================================================
-  // Track-Cluster Matching Attributes
-  //=======================================================
+    //=======================================================
+    // Track-Cluster Matching Attributes
+    //=======================================================
 
   public:
-
-    struct TrackClusterMatching
-     {
-      CaloClusterPtr electronCluster ;  // basic cluster best matching gsf track
-      float eSuperClusterOverP ;        // the supercluster energy / track momentum at the PCA to the beam spot
-      float eSeedClusterOverP ;         // the seed cluster energy / track momentum at the PCA to the beam spot
-      float eSeedClusterOverPout ;      // the seed cluster energy / track momentum at calo extrapolated from the outermost track state
-      float eEleClusterOverPout ;       // the electron cluster energy / track momentum at calo extrapolated from the outermost track state
-      float deltaEtaSuperClusterAtVtx ; // the supercluster eta - track eta position at calo extrapolated from innermost track state
-      float deltaEtaSeedClusterAtCalo ; // the seed cluster eta - track eta position at calo extrapolated from the outermost track state
-      float deltaEtaEleClusterAtCalo ;  // the electron cluster eta - track eta position at calo extrapolated from the outermost state
-      float deltaPhiEleClusterAtCalo ;  // the electron cluster phi - track phi position at calo extrapolated from the outermost track state
-      float deltaPhiSuperClusterAtVtx ; // the supercluster phi - track phi position at calo extrapolated from the innermost track state
-      float deltaPhiSeedClusterAtCalo ; // the seed cluster phi - track phi position at calo extrapolated from the outermost track state
+    struct TrackClusterMatching {
+      CaloClusterPtr electronCluster;  // basic cluster best matching gsf track
+      float eSuperClusterOverP;        // the supercluster energy / track momentum at the PCA to the beam spot
+      float eSeedClusterOverP;         // the seed cluster energy / track momentum at the PCA to the beam spot
+      float eSeedClusterOverPout;  // the seed cluster energy / track momentum at calo extrapolated from the outermost track state
+      float eEleClusterOverPout;  // the electron cluster energy / track momentum at calo extrapolated from the outermost track state
+      float deltaEtaSuperClusterAtVtx;  // the supercluster eta - track eta position at calo extrapolated from innermost track state
+      float deltaEtaSeedClusterAtCalo;  // the seed cluster eta - track eta position at calo extrapolated from the outermost track state
+      float deltaEtaEleClusterAtCalo;  // the electron cluster eta - track eta position at calo extrapolated from the outermost state
+      float deltaPhiEleClusterAtCalo;  // the electron cluster phi - track phi position at calo extrapolated from the outermost track state
+      float deltaPhiSuperClusterAtVtx;  // the supercluster phi - track phi position at calo extrapolated from the innermost track state
+      float deltaPhiSeedClusterAtCalo;  // the seed cluster phi - track phi position at calo extrapolated from the outermost track state
       TrackClusterMatching()
-       : eSuperClusterOverP(0.),
-         eSeedClusterOverP(0.),
-         eSeedClusterOverPout(0.),
-         eEleClusterOverPout(0.),
-         deltaEtaSuperClusterAtVtx(std::numeric_limits<float>::max()),
-         deltaEtaSeedClusterAtCalo(std::numeric_limits<float>::max()),
-         deltaEtaEleClusterAtCalo(std::numeric_limits<float>::max()),
-         deltaPhiEleClusterAtCalo(std::numeric_limits<float>::max()),
-         deltaPhiSuperClusterAtVtx(std::numeric_limits<float>::max()),
-         deltaPhiSeedClusterAtCalo(std::numeric_limits<float>::max())
-        {}
-     } ;
+          : eSuperClusterOverP(0.),
+            eSeedClusterOverP(0.),
+            eSeedClusterOverPout(0.),
+            eEleClusterOverPout(0.),
+            deltaEtaSuperClusterAtVtx(std::numeric_limits<float>::max()),
+            deltaEtaSeedClusterAtCalo(std::numeric_limits<float>::max()),
+            deltaEtaEleClusterAtCalo(std::numeric_limits<float>::max()),
+            deltaPhiEleClusterAtCalo(std::numeric_limits<float>::max()),
+            deltaPhiSuperClusterAtVtx(std::numeric_limits<float>::max()),
+            deltaPhiSeedClusterAtCalo(std::numeric_limits<float>::max()) {}
+    };
 
     // accessors
-    CaloClusterPtr electronCluster() const { return trackClusterMatching_.electronCluster ; }
-    float eSuperClusterOverP() const { return trackClusterMatching_.eSuperClusterOverP ; }
-    float eSeedClusterOverP() const { return trackClusterMatching_.eSeedClusterOverP ; }
-    float eSeedClusterOverPout() const { return trackClusterMatching_.eSeedClusterOverPout ; }
-    float eEleClusterOverPout() const { return trackClusterMatching_.eEleClusterOverPout ; }
-    float deltaEtaSuperClusterTrackAtVtx() const { return trackClusterMatching_.deltaEtaSuperClusterAtVtx ; }
-    float deltaEtaSeedClusterTrackAtCalo() const { return trackClusterMatching_.deltaEtaSeedClusterAtCalo ; }
-    float deltaEtaEleClusterTrackAtCalo() const { return trackClusterMatching_.deltaEtaEleClusterAtCalo ; }
-    float deltaPhiSuperClusterTrackAtVtx() const { return trackClusterMatching_.deltaPhiSuperClusterAtVtx ; }
-    float deltaPhiSeedClusterTrackAtCalo() const { return trackClusterMatching_.deltaPhiSeedClusterAtCalo ; }
-    float deltaPhiEleClusterTrackAtCalo() const { return trackClusterMatching_.deltaPhiEleClusterAtCalo ; }
-    float deltaEtaSeedClusterTrackAtVtx() const { return superCluster().isNonnull() && superCluster()->seed().isNonnull() ? 
-	trackClusterMatching_.deltaEtaSuperClusterAtVtx - superCluster()->eta() + superCluster()->seed()->eta() : std::numeric_limits<float>::max();
+    CaloClusterPtr electronCluster() const { return trackClusterMatching_.electronCluster; }
+    float eSuperClusterOverP() const { return trackClusterMatching_.eSuperClusterOverP; }
+    float eSeedClusterOverP() const { return trackClusterMatching_.eSeedClusterOverP; }
+    float eSeedClusterOverPout() const { return trackClusterMatching_.eSeedClusterOverPout; }
+    float eEleClusterOverPout() const { return trackClusterMatching_.eEleClusterOverPout; }
+    float deltaEtaSuperClusterTrackAtVtx() const { return trackClusterMatching_.deltaEtaSuperClusterAtVtx; }
+    float deltaEtaSeedClusterTrackAtCalo() const { return trackClusterMatching_.deltaEtaSeedClusterAtCalo; }
+    float deltaEtaEleClusterTrackAtCalo() const { return trackClusterMatching_.deltaEtaEleClusterAtCalo; }
+    float deltaPhiSuperClusterTrackAtVtx() const { return trackClusterMatching_.deltaPhiSuperClusterAtVtx; }
+    float deltaPhiSeedClusterTrackAtCalo() const { return trackClusterMatching_.deltaPhiSeedClusterAtCalo; }
+    float deltaPhiEleClusterTrackAtCalo() const { return trackClusterMatching_.deltaPhiEleClusterAtCalo; }
+    float deltaEtaSeedClusterTrackAtVtx() const {
+      return superCluster().isNonnull() && superCluster()->seed().isNonnull()
+                 ? trackClusterMatching_.deltaEtaSuperClusterAtVtx - superCluster()->eta() +
+                       superCluster()->seed()->eta()
+                 : std::numeric_limits<float>::max();
     }
-    const TrackClusterMatching & trackClusterMatching() const { return trackClusterMatching_ ; }
+    const TrackClusterMatching &trackClusterMatching() const { return trackClusterMatching_; }
 
     // for backward compatibility, usefull ?
-    void setDeltaEtaSuperClusterAtVtx( float de ) { trackClusterMatching_.deltaEtaSuperClusterAtVtx = de ; }
-    void setDeltaPhiSuperClusterAtVtx( float dphi ) { trackClusterMatching_.deltaPhiSuperClusterAtVtx = dphi ; }
-
+    void setDeltaEtaSuperClusterAtVtx(float de) { trackClusterMatching_.deltaEtaSuperClusterAtVtx = de; }
+    void setDeltaPhiSuperClusterAtVtx(float dphi) { trackClusterMatching_.deltaPhiSuperClusterAtVtx = dphi; }
 
   private:
-
     // attributes
-    TrackClusterMatching trackClusterMatching_ ;
+    TrackClusterMatching trackClusterMatching_;
 
+    //=======================================================
+    // Track extrapolations
+    //=======================================================
 
-  //=======================================================
-  // Track extrapolations
-  //=======================================================
-
-  public :
-
-    struct TrackExtrapolations
-     {
-      math::XYZPointF  positionAtVtx ;     // the track PCA to the beam spot
-      math::XYZPointF  positionAtCalo ;    // the track PCA to the supercluster position
-      math::XYZVectorF momentumAtVtx ;     // the track momentum at the PCA to the beam spot
-      math::XYZVectorF momentumAtCalo ;    // the track momentum extrapolated at the supercluster position from the innermost track state
-      math::XYZVectorF momentumOut ;       // the track momentum extrapolated at the seed cluster position from the outermost track state
-      math::XYZVectorF momentumAtEleClus ; // the track momentum extrapolated at the ele cluster position from the outermost track state
-      math::XYZVectorF momentumAtVtxWithConstraint ;     // the track momentum at the PCA to the beam spot using bs constraint
-     } ;
+  public:
+    struct TrackExtrapolations {
+      math::XYZPointF positionAtVtx;   // the track PCA to the beam spot
+      math::XYZPointF positionAtCalo;  // the track PCA to the supercluster position
+      math::XYZVectorF momentumAtVtx;  // the track momentum at the PCA to the beam spot
+      math::XYZVectorF
+          momentumAtCalo;  // the track momentum extrapolated at the supercluster position from the innermost track state
+      math::XYZVectorF
+          momentumOut;  // the track momentum extrapolated at the seed cluster position from the outermost track state
+      math::XYZVectorF
+          momentumAtEleClus;  // the track momentum extrapolated at the ele cluster position from the outermost track state
+      math::XYZVectorF momentumAtVtxWithConstraint;  // the track momentum at the PCA to the beam spot using bs constraint
+    };
 
     // accessors
-    math::XYZPointF trackPositionAtVtx() const { return trackExtrapolations_.positionAtVtx ; }
-    math::XYZPointF trackPositionAtCalo() const { return trackExtrapolations_.positionAtCalo ; }
-    math::XYZVectorF trackMomentumAtVtx() const { return trackExtrapolations_.momentumAtVtx ; }
-    math::XYZVectorF trackMomentumAtCalo() const { return trackExtrapolations_.momentumAtCalo ; }
-    math::XYZVectorF trackMomentumOut() const { return trackExtrapolations_.momentumOut ; }
-    math::XYZVectorF trackMomentumAtEleClus() const { return trackExtrapolations_.momentumAtEleClus ; }
-    math::XYZVectorF trackMomentumAtVtxWithConstraint() const { return trackExtrapolations_.momentumAtVtxWithConstraint ; }
-    const TrackExtrapolations & trackExtrapolations() const { return trackExtrapolations_ ; }
+    math::XYZPointF trackPositionAtVtx() const { return trackExtrapolations_.positionAtVtx; }
+    math::XYZPointF trackPositionAtCalo() const { return trackExtrapolations_.positionAtCalo; }
+    math::XYZVectorF trackMomentumAtVtx() const { return trackExtrapolations_.momentumAtVtx; }
+    math::XYZVectorF trackMomentumAtCalo() const { return trackExtrapolations_.momentumAtCalo; }
+    math::XYZVectorF trackMomentumOut() const { return trackExtrapolations_.momentumOut; }
+    math::XYZVectorF trackMomentumAtEleClus() const { return trackExtrapolations_.momentumAtEleClus; }
+    math::XYZVectorF trackMomentumAtVtxWithConstraint() const {
+      return trackExtrapolations_.momentumAtVtxWithConstraint;
+    }
+    const TrackExtrapolations &trackExtrapolations() const { return trackExtrapolations_; }
 
     // setter (if you know what you're doing)
     void setTrackExtrapolations(const TrackExtrapolations &te) { trackExtrapolations_ = te; }
 
     // for backward compatibility
-    math::XYZPointF TrackPositionAtVtx() const { return trackPositionAtVtx() ; }
-    math::XYZPointF TrackPositionAtCalo() const { return trackPositionAtCalo() ; }
-
+    math::XYZPointF TrackPositionAtVtx() const { return trackPositionAtVtx(); }
+    math::XYZPointF TrackPositionAtCalo() const { return trackPositionAtCalo(); }
 
   private:
-
     // attributes
-    TrackExtrapolations trackExtrapolations_ ;
+    TrackExtrapolations trackExtrapolations_;
 
+    //=======================================================
+    // SuperCluster direct access
+    //=======================================================
 
-  //=======================================================
-  // SuperCluster direct access
-  //=======================================================
-
-  public :
-
+  public:
     // direct accessors
-    math::XYZPoint superClusterPosition() const { return superCluster()->position() ; } // the super cluster position
-    int basicClustersSize() const { return superCluster()->clustersSize() ; } // number of basic clusters inside the supercluster
-    CaloCluster_iterator basicClustersBegin() const { return superCluster()->clustersBegin() ; }
-    CaloCluster_iterator basicClustersEnd() const { return superCluster()->clustersEnd() ; }
+    math::XYZPoint superClusterPosition() const { return superCluster()->position(); }  // the super cluster position
+    int basicClustersSize() const {
+      return superCluster()->clustersSize();
+    }  // number of basic clusters inside the supercluster
+    CaloCluster_iterator basicClustersBegin() const { return superCluster()->clustersBegin(); }
+    CaloCluster_iterator basicClustersEnd() const { return superCluster()->clustersEnd(); }
 
     // for backward compatibility
-    math::XYZPoint caloPosition() const { return superCluster()->position() ; }
+    math::XYZPoint caloPosition() const { return superCluster()->position(); }
 
+    //=======================================================
+    // Fiducial Flags
+    //=======================================================
 
-
-  //=======================================================
-  // Fiducial Flags
-  //=======================================================
-
-  public :
-
-    struct FiducialFlags
-     {
-      bool isEB ;        // true if particle is in ECAL Barrel
-      bool isEE ;        // true if particle is in ECAL Endcaps
-      bool isEBEEGap ;   // true if particle is in the crack between EB and EE
-      bool isEBEtaGap ;  // true if particle is in EB, and inside the eta gaps between modules
-      bool isEBPhiGap ;  // true if particle is in EB, and inside the phi gaps between modules
-      bool isEEDeeGap ;  // true if particle is in EE, and inside the gaps between dees
-      bool isEERingGap ; // true if particle is in EE, and inside the gaps between rings
+  public:
+    struct FiducialFlags {
+      bool isEB;         // true if particle is in ECAL Barrel
+      bool isEE;         // true if particle is in ECAL Endcaps
+      bool isEBEEGap;    // true if particle is in the crack between EB and EE
+      bool isEBEtaGap;   // true if particle is in EB, and inside the eta gaps between modules
+      bool isEBPhiGap;   // true if particle is in EB, and inside the phi gaps between modules
+      bool isEEDeeGap;   // true if particle is in EE, and inside the gaps between dees
+      bool isEERingGap;  // true if particle is in EE, and inside the gaps between rings
       FiducialFlags()
-       : isEB(false), isEE(false), isEBEEGap(false),
-         isEBEtaGap(false), isEBPhiGap(false),
-	     isEEDeeGap(false), isEERingGap(false)
-	   {}
-     } ;
+          : isEB(false),
+            isEE(false),
+            isEBEEGap(false),
+            isEBEtaGap(false),
+            isEBPhiGap(false),
+            isEEDeeGap(false),
+            isEERingGap(false) {}
+    };
 
     // accessors
-    bool isEB() const { return fiducialFlags_.isEB ; }
-    bool isEE() const { return fiducialFlags_.isEE ; }
-    bool isGap() const { return ((isEBEEGap())||(isEBGap())||(isEEGap())) ; }
-    bool isEBEEGap() const { return fiducialFlags_.isEBEEGap ; }
-    bool isEBGap() const { return (isEBEtaGap()||isEBPhiGap()) ; }
-    bool isEBEtaGap() const { return fiducialFlags_.isEBEtaGap ; }
-    bool isEBPhiGap() const { return fiducialFlags_.isEBPhiGap ; }
-    bool isEEGap() const { return (isEEDeeGap()||isEERingGap()) ; }
-    bool isEEDeeGap() const { return fiducialFlags_.isEEDeeGap ; }
-    bool isEERingGap() const { return fiducialFlags_.isEERingGap ; }
-    const FiducialFlags & fiducialFlags() const { return fiducialFlags_ ; }
+    bool isEB() const { return fiducialFlags_.isEB; }
+    bool isEE() const { return fiducialFlags_.isEE; }
+    bool isGap() const { return ((isEBEEGap()) || (isEBGap()) || (isEEGap())); }
+    bool isEBEEGap() const { return fiducialFlags_.isEBEEGap; }
+    bool isEBGap() const { return (isEBEtaGap() || isEBPhiGap()); }
+    bool isEBEtaGap() const { return fiducialFlags_.isEBEtaGap; }
+    bool isEBPhiGap() const { return fiducialFlags_.isEBPhiGap; }
+    bool isEEGap() const { return (isEEDeeGap() || isEERingGap()); }
+    bool isEEDeeGap() const { return fiducialFlags_.isEEDeeGap; }
+    bool isEERingGap() const { return fiducialFlags_.isEERingGap; }
+    const FiducialFlags &fiducialFlags() const { return fiducialFlags_; }
     // setters... not necessary in regular situations
     // but handy for late stage modifications of electron objects
-    void setFFlagIsEB(const bool b)        { fiducialFlags_.isEB = b; }
-    void setFFlagIsEE(const bool b)        { fiducialFlags_.isEE = b; }
-    void setFFlagIsEBEEGap(const bool b)   { fiducialFlags_.isEBEEGap = b; }
-    void setFFlagIsEBEtaGap(const bool b)  { fiducialFlags_.isEBEtaGap = b; }
-    void setFFlagIsEBPhiGap(const bool b)  { fiducialFlags_.isEBPhiGap = b; }
-    void setFFlagIsEEDeeGap(const bool b)  { fiducialFlags_.isEEDeeGap = b; }
+    void setFFlagIsEB(const bool b) { fiducialFlags_.isEB = b; }
+    void setFFlagIsEE(const bool b) { fiducialFlags_.isEE = b; }
+    void setFFlagIsEBEEGap(const bool b) { fiducialFlags_.isEBEEGap = b; }
+    void setFFlagIsEBEtaGap(const bool b) { fiducialFlags_.isEBEtaGap = b; }
+    void setFFlagIsEBPhiGap(const bool b) { fiducialFlags_.isEBPhiGap = b; }
+    void setFFlagIsEEDeeGap(const bool b) { fiducialFlags_.isEEDeeGap = b; }
     void setFFlagIsEERingGap(const bool b) { fiducialFlags_.isEERingGap = b; }
 
   private:
-
     // attributes
-    FiducialFlags fiducialFlags_ ;
+    FiducialFlags fiducialFlags_;
 
+    //=======================================================
+    // Shower Shape Variables
+    //=======================================================
 
-  //=======================================================
-  // Shower Shape Variables
-  //=======================================================
-
-  public :
-
-    struct ShowerShape
-     {
-      float sigmaEtaEta ;        // weighted cluster rms along eta and inside 5x5 (absolute eta)
-      float sigmaIetaIeta ;      // weighted cluster rms along eta and inside 5x5 (Xtal eta)
-      float sigmaIphiIphi ;      // weighted cluster rms along phi and inside 5x5 (Xtal phi)
-      float e1x5 ;               // energy inside 1x5 in etaxphi around the seed Xtal
-      float e2x5Max ;            // energy inside 2x5 in etaxphi around the seed Xtal (max bwt the 2 possible sums)
-      float e5x5 ;               // energy inside 5x5 in etaxphi around the seed Xtal
-      float r9 ;                 // ratio of the 3x3 energy and supercluster energy
-      float hcalDepth1OverEcal ; // hcal over ecal seed cluster energy using 1st hcal depth (using hcal towers within a cone)
-      float hcalDepth2OverEcal ; // hcal over ecal seed cluster energy using 2nd hcal depth (using hcal towers within a cone)
-      std::vector<CaloTowerDetId> hcalTowersBehindClusters ; //
-      float hcalDepth1OverEcalBc ; // hcal over ecal seed cluster energy using 1st hcal depth (using hcal towers behind clusters)
-      float hcalDepth2OverEcalBc ; // hcal over ecal seed cluster energy using 2nd hcal depth (using hcal towers behind clusters)
-      bool  invalidHcal ;          // set to true if the hcal energy estimate is not valid (e.g. the corresponding tower was off or masked)
+  public:
+    struct ShowerShape {
+      float sigmaEtaEta;         // weighted cluster rms along eta and inside 5x5 (absolute eta)
+      float sigmaIetaIeta;       // weighted cluster rms along eta and inside 5x5 (Xtal eta)
+      float sigmaIphiIphi;       // weighted cluster rms along phi and inside 5x5 (Xtal phi)
+      float e1x5;                // energy inside 1x5 in etaxphi around the seed Xtal
+      float e2x5Max;             // energy inside 2x5 in etaxphi around the seed Xtal (max bwt the 2 possible sums)
+      float e5x5;                // energy inside 5x5 in etaxphi around the seed Xtal
+      float r9;                  // ratio of the 3x3 energy and supercluster energy
+      float hcalDepth1OverEcal;  // hcal over ecal seed cluster energy using 1st hcal depth (using hcal towers within a cone)
+      float hcalDepth2OverEcal;  // hcal over ecal seed cluster energy using 2nd hcal depth (using hcal towers within a cone)
+      std::vector<CaloTowerDetId> hcalTowersBehindClusters;  //
+      float hcalDepth1OverEcalBc;  // hcal over ecal seed cluster energy using 1st hcal depth (using hcal towers behind clusters)
+      float hcalDepth2OverEcalBc;  // hcal over ecal seed cluster energy using 2nd hcal depth (using hcal towers behind clusters)
+      bool invalidHcal;  // set to true if the hcal energy estimate is not valid (e.g. the corresponding tower was off or masked)
       float sigmaIetaIphi;
       float eMax;
       float e2nd;
       float eTop;
       float eLeft;
       float eRight;
-      float eBottom; 
+      float eBottom;
       float e2x5Top;
       float e2x5Left;
       float e2x5Right;
-      float e2x5Bottom; 
+      float e2x5Bottom;
       ShowerShape()
-       : sigmaEtaEta(std::numeric_limits<float>::max()),
-       sigmaIetaIeta(std::numeric_limits<float>::max()),
-       sigmaIphiIphi(std::numeric_limits<float>::max()),
-	     e1x5(0.), e2x5Max(0.), e5x5(0.),
-	     r9(-std::numeric_limits<float>::max()),
-       hcalDepth1OverEcal(0.), hcalDepth2OverEcal(0.),
-       hcalDepth1OverEcalBc(0.), hcalDepth2OverEcalBc(0.),
-       invalidHcal(false),
-       sigmaIetaIphi(0.f),
-       eMax(0.f),
-       e2nd(0.f),
-       eTop(0.f),
-       eLeft(0.f),
-       eRight(0.f),
-       eBottom(0.f),
-       e2x5Top(0.f),
-       e2x5Left(0.f),
-       e2x5Right(0.f),
-       e2x5Bottom(0.f)
-       {}
-     } ;
+          : sigmaEtaEta(std::numeric_limits<float>::max()),
+            sigmaIetaIeta(std::numeric_limits<float>::max()),
+            sigmaIphiIphi(std::numeric_limits<float>::max()),
+            e1x5(0.),
+            e2x5Max(0.),
+            e5x5(0.),
+            r9(-std::numeric_limits<float>::max()),
+            hcalDepth1OverEcal(0.),
+            hcalDepth2OverEcal(0.),
+            hcalDepth1OverEcalBc(0.),
+            hcalDepth2OverEcalBc(0.),
+            invalidHcal(false),
+            sigmaIetaIphi(0.f),
+            eMax(0.f),
+            e2nd(0.f),
+            eTop(0.f),
+            eLeft(0.f),
+            eRight(0.f),
+            eBottom(0.f),
+            e2x5Top(0.f),
+            e2x5Left(0.f),
+            e2x5Right(0.f),
+            e2x5Bottom(0.f) {}
+    };
 
     // accessors
-    float sigmaEtaEta() const { return showerShape_.sigmaEtaEta ; }
-    float sigmaIetaIeta() const { return showerShape_.sigmaIetaIeta ; }
-    float sigmaIphiIphi() const { return showerShape_.sigmaIphiIphi ; }
-    float e1x5() const { return showerShape_.e1x5 ; }
-    float e2x5Max() const { return showerShape_.e2x5Max ; }
-    float e5x5() const { return showerShape_.e5x5 ; }
-    float r9() const { return showerShape_.r9 ; }
-    float hcalDepth1OverEcal() const { return showerShape_.hcalDepth1OverEcal ; }
-    float hcalDepth2OverEcal() const { return showerShape_.hcalDepth2OverEcal ; }
-    float hcalOverEcal() const { return hcalDepth1OverEcal() + hcalDepth2OverEcal() ; }
-    const std::vector<CaloTowerDetId> & hcalTowersBehindClusters() const { return showerShape_.hcalTowersBehindClusters ; }
-    float hcalDepth1OverEcalBc() const { return showerShape_.hcalDepth1OverEcalBc ; }
-    float hcalDepth2OverEcalBc() const { return showerShape_.hcalDepth2OverEcalBc ; }
-    float hcalOverEcalBc() const { return hcalDepth1OverEcalBc() + hcalDepth2OverEcalBc() ; } 
-    float hcalOverEcalValid() const { return !showerShape_.invalidHcal; } 
+    float sigmaEtaEta() const { return showerShape_.sigmaEtaEta; }
+    float sigmaIetaIeta() const { return showerShape_.sigmaIetaIeta; }
+    float sigmaIphiIphi() const { return showerShape_.sigmaIphiIphi; }
+    float e1x5() const { return showerShape_.e1x5; }
+    float e2x5Max() const { return showerShape_.e2x5Max; }
+    float e5x5() const { return showerShape_.e5x5; }
+    float r9() const { return showerShape_.r9; }
+    float hcalDepth1OverEcal() const { return showerShape_.hcalDepth1OverEcal; }
+    float hcalDepth2OverEcal() const { return showerShape_.hcalDepth2OverEcal; }
+    float hcalOverEcal() const { return hcalDepth1OverEcal() + hcalDepth2OverEcal(); }
+    const std::vector<CaloTowerDetId> &hcalTowersBehindClusters() const {
+      return showerShape_.hcalTowersBehindClusters;
+    }
+    float hcalDepth1OverEcalBc() const { return showerShape_.hcalDepth1OverEcalBc; }
+    float hcalDepth2OverEcalBc() const { return showerShape_.hcalDepth2OverEcalBc; }
+    float hcalOverEcalBc() const { return hcalDepth1OverEcalBc() + hcalDepth2OverEcalBc(); }
+    float hcalOverEcalValid() const { return !showerShape_.invalidHcal; }
     float eLeft() const { return showerShape_.eLeft; }
     float eRight() const { return showerShape_.eRight; }
     float eTop() const { return showerShape_.eTop; }
     float eBottom() const { return showerShape_.eBottom; }
-    const ShowerShape & showerShape() const { return showerShape_ ; }
+    const ShowerShape &showerShape() const { return showerShape_; }
     // non-zero-suppressed and no-fractions shower shapes
-    // ecal energy is always that from the full 5x5 
-    float full5x5_sigmaEtaEta() const { return full5x5_showerShape_.sigmaEtaEta ; }
-    float full5x5_sigmaIetaIeta() const { return full5x5_showerShape_.sigmaIetaIeta ; }
-    float full5x5_sigmaIphiIphi() const { return full5x5_showerShape_.sigmaIphiIphi ; }
-    float full5x5_e1x5() const { return full5x5_showerShape_.e1x5 ; }
-    float full5x5_e2x5Max() const { return full5x5_showerShape_.e2x5Max ; }
-    float full5x5_e5x5() const { return full5x5_showerShape_.e5x5 ; }
-    float full5x5_r9() const { return full5x5_showerShape_.r9 ; }
-    float full5x5_hcalDepth1OverEcal() const { return full5x5_showerShape_.hcalDepth1OverEcal ; }
-    float full5x5_hcalDepth2OverEcal() const { return full5x5_showerShape_.hcalDepth2OverEcal ; }
-    float full5x5_hcalOverEcal() const { return full5x5_hcalDepth1OverEcal() + full5x5_hcalDepth2OverEcal() ; }    
-    float full5x5_hcalDepth1OverEcalBc() const { return full5x5_showerShape_.hcalDepth1OverEcalBc ; }
-    float full5x5_hcalDepth2OverEcalBc() const { return full5x5_showerShape_.hcalDepth2OverEcalBc ; }
-    float full5x5_hcalOverEcalBc() const { return full5x5_hcalDepth1OverEcalBc() + full5x5_hcalDepth2OverEcalBc() ; }
-    float full5x5_hcalOverEcalValid() const { return !full5x5_showerShape_.invalidHcal; } 
+    // ecal energy is always that from the full 5x5
+    float full5x5_sigmaEtaEta() const { return full5x5_showerShape_.sigmaEtaEta; }
+    float full5x5_sigmaIetaIeta() const { return full5x5_showerShape_.sigmaIetaIeta; }
+    float full5x5_sigmaIphiIphi() const { return full5x5_showerShape_.sigmaIphiIphi; }
+    float full5x5_e1x5() const { return full5x5_showerShape_.e1x5; }
+    float full5x5_e2x5Max() const { return full5x5_showerShape_.e2x5Max; }
+    float full5x5_e5x5() const { return full5x5_showerShape_.e5x5; }
+    float full5x5_r9() const { return full5x5_showerShape_.r9; }
+    float full5x5_hcalDepth1OverEcal() const { return full5x5_showerShape_.hcalDepth1OverEcal; }
+    float full5x5_hcalDepth2OverEcal() const { return full5x5_showerShape_.hcalDepth2OverEcal; }
+    float full5x5_hcalOverEcal() const { return full5x5_hcalDepth1OverEcal() + full5x5_hcalDepth2OverEcal(); }
+    float full5x5_hcalDepth1OverEcalBc() const { return full5x5_showerShape_.hcalDepth1OverEcalBc; }
+    float full5x5_hcalDepth2OverEcalBc() const { return full5x5_showerShape_.hcalDepth2OverEcalBc; }
+    float full5x5_hcalOverEcalBc() const { return full5x5_hcalDepth1OverEcalBc() + full5x5_hcalDepth2OverEcalBc(); }
+    float full5x5_hcalOverEcalValid() const { return !full5x5_showerShape_.invalidHcal; }
     float full5x5_e2x5Left() const { return full5x5_showerShape_.e2x5Left; }
     float full5x5_e2x5Right() const { return full5x5_showerShape_.e2x5Right; }
     float full5x5_e2x5Top() const { return full5x5_showerShape_.e2x5Top; }
@@ -480,438 +453,412 @@ class GsfElectron : public RecoCandidate
     float full5x5_eRight() const { return full5x5_showerShape_.eRight; }
     float full5x5_eTop() const { return full5x5_showerShape_.eTop; }
     float full5x5_eBottom() const { return full5x5_showerShape_.eBottom; }
-    const ShowerShape & full5x5_showerShape() const { return full5x5_showerShape_ ; }
+    const ShowerShape &full5x5_showerShape() const { return full5x5_showerShape_; }
 
     // setters (if you know what you're doing)
     void setShowerShape(const ShowerShape &s) { showerShape_ = s; }
     void full5x5_setShowerShape(const ShowerShape &s) { full5x5_showerShape_ = s; }
 
     // for backward compatibility (this will only ever be the ZS shapes!)
-    float scSigmaEtaEta() const { return sigmaEtaEta() ; }
-    float scSigmaIEtaIEta() const { return sigmaIetaIeta() ; }
-    float scE1x5() const { return e1x5() ; }
-    float scE2x5Max() const { return e2x5Max() ; }
-    float scE5x5() const { return e5x5() ; }
-    float hadronicOverEm() const {return hcalOverEcal();}
-    float hadronicOverEm1() const {return hcalDepth1OverEcal();}
-    float hadronicOverEm2() const {return hcalDepth2OverEcal();}
-
+    float scSigmaEtaEta() const { return sigmaEtaEta(); }
+    float scSigmaIEtaIEta() const { return sigmaIetaIeta(); }
+    float scE1x5() const { return e1x5(); }
+    float scE2x5Max() const { return e2x5Max(); }
+    float scE5x5() const { return e5x5(); }
+    float hadronicOverEm() const { return hcalOverEcal(); }
+    float hadronicOverEm1() const { return hcalDepth1OverEcal(); }
+    float hadronicOverEm2() const { return hcalDepth2OverEcal(); }
 
   private:
-
     // attributes
-    ShowerShape showerShape_ ;
-    ShowerShape full5x5_showerShape_ ;
+    ShowerShape showerShape_;
+    ShowerShape full5x5_showerShape_;
 
-  //=======================================================
-  // SaturationInfo
-  //=======================================================
+    //=======================================================
+    // SaturationInfo
+    //=======================================================
 
-  public :
-
+  public:
     struct SaturationInfo {
       int nSaturatedXtals;
       bool isSeedSaturated;
-      SaturationInfo() 
-      : nSaturatedXtals(0), isSeedSaturated(false) {};
-     } ;
+      SaturationInfo() : nSaturatedXtals(0), isSeedSaturated(false){};
+    };
 
     // accessors
     float nSaturatedXtals() const { return saturationInfo_.nSaturatedXtals; }
     float isSeedSaturated() const { return saturationInfo_.isSeedSaturated; }
-    const SaturationInfo& saturationInfo() const { return saturationInfo_; }
+    const SaturationInfo &saturationInfo() const { return saturationInfo_; }
     void setSaturationInfo(const SaturationInfo &s) { saturationInfo_ = s; }
 
   private:
-    
     SaturationInfo saturationInfo_;
 
-  //=======================================================
-  // Isolation Variables
-  //=======================================================
-
-  public :
-
-    struct IsolationVariables
-     {
-      float tkSumPt ;                // track iso with electron footprint removed
-      float tkSumPtHEEP ;            // track iso used for the HEEP ID
-      float ecalRecHitSumEt ;        // ecal iso deposit with electron footprint removed
-      float hcalDepth1TowerSumEt ;   // hcal depht 1 iso deposit with electron footprint removed
-      float hcalDepth2TowerSumEt ;   // hcal depht 2 iso deposit with electron footprint removed
-      float hcalDepth1TowerSumEtBc ; // hcal depht 1 iso deposit without towers behind clusters
-      float hcalDepth2TowerSumEtBc ; // hcal depht 2 iso deposit without towers behind clusters
-      IsolationVariables()
-       : tkSumPt(0.), tkSumPtHEEP(0.), ecalRecHitSumEt(0.),
-         hcalDepth1TowerSumEt(0.), hcalDepth2TowerSumEt(0.),
-         hcalDepth1TowerSumEtBc(0.), hcalDepth2TowerSumEtBc(0.)
-       {}
-     } ;
-
-    // 03 accessors
-    float dr03TkSumPt() const { return dr03_.tkSumPt ; }
-    float dr03TkSumPtHEEP() const { return dr03_.tkSumPtHEEP ; }
-    float dr03EcalRecHitSumEt() const { return dr03_.ecalRecHitSumEt ; }
-    float dr03HcalDepth1TowerSumEt() const { return dr03_.hcalDepth1TowerSumEt ; }
-    float dr03HcalDepth2TowerSumEt() const { return dr03_.hcalDepth2TowerSumEt ; }
-    float dr03HcalTowerSumEt() const { return dr03HcalDepth1TowerSumEt()+dr03HcalDepth2TowerSumEt() ; }
-    float dr03HcalDepth1TowerSumEtBc() const { return dr03_.hcalDepth1TowerSumEtBc ; }
-    float dr03HcalDepth2TowerSumEtBc() const { return dr03_.hcalDepth2TowerSumEtBc ; }
-    float dr03HcalTowerSumEtBc() const { return dr03HcalDepth1TowerSumEtBc()+dr03HcalDepth2TowerSumEtBc() ; }
-    const IsolationVariables & dr03IsolationVariables() const { return dr03_ ; }
-
-    // 04 accessors
-    float dr04TkSumPt() const { return dr04_.tkSumPt ; }
-    float dr04TkSumPtHEEP() const { return dr04_.tkSumPtHEEP ; }
-    float dr04EcalRecHitSumEt() const { return dr04_.ecalRecHitSumEt ; }
-    float dr04HcalDepth1TowerSumEt() const { return dr04_.hcalDepth1TowerSumEt ; }
-    float dr04HcalDepth2TowerSumEt() const { return dr04_.hcalDepth2TowerSumEt ; }
-    float dr04HcalTowerSumEt() const { return dr04HcalDepth1TowerSumEt()+dr04HcalDepth2TowerSumEt() ; }
-    float dr04HcalDepth1TowerSumEtBc() const { return dr04_.hcalDepth1TowerSumEtBc ; }
-    float dr04HcalDepth2TowerSumEtBc() const { return dr04_.hcalDepth2TowerSumEtBc ; }
-    float dr04HcalTowerSumEtBc() const { return dr04HcalDepth1TowerSumEtBc()+dr04HcalDepth2TowerSumEtBc() ; }
-    const IsolationVariables & dr04IsolationVariables() const { return dr04_ ; }
-
-    // setters ?!?
-    void setDr03Isolation( const IsolationVariables & dr03 ) { dr03_ = dr03 ; }
-    void setDr04Isolation( const IsolationVariables & dr04 ) { dr04_ = dr04 ; }
-
-    // for backward compatibility
-    void setIsolation03( const IsolationVariables & dr03 ) { dr03_ = dr03 ; }
-    void setIsolation04( const IsolationVariables & dr04 ) { dr04_ = dr04 ; }
-    const IsolationVariables & isolationVariables03() const { return dr03_ ; }
-    const IsolationVariables & isolationVariables04() const { return dr04_ ; }
-
-  private:
-
-    // attributes
-    IsolationVariables dr03_ ;
-    IsolationVariables dr04_ ;
-
-
-  //=======================================================
-  // Conversion Rejection Information
-  //=======================================================
-
-  public :
-
-    struct ConversionRejection
-     {
-      int flags ;  // -max:not-computed, other: as computed by Puneeth conversion code
-      TrackBaseRef partner ; // conversion partner
-      float dist ; // distance to the conversion partner
-      float dcot ; // difference of cot(angle) with the conversion partner track
-      float radius ; // signed conversion radius
-      float vtxFitProb ; //fit probablity (chi2/ndof) of the matched conversion vtx
-      ConversionRejection()
-       : flags(-1),
-         dist(std::numeric_limits<float>::max()),
-         dcot(std::numeric_limits<float>::max()),
-         radius(std::numeric_limits<float>::max()),
-	 vtxFitProb(std::numeric_limits<float>::max())
-       {}
-     } ;
-
-    // accessors
-    int convFlags() const { return conversionRejection_.flags ; }
-    TrackBaseRef convPartner() const { return conversionRejection_.partner ; }
-    float convDist() const { return conversionRejection_.dist ; }
-    float convDcot() const { return conversionRejection_.dcot ; }
-    float convRadius() const { return conversionRejection_.radius ; }
-    float convVtxFitProb() const { return conversionRejection_.vtxFitProb ; } 
-    const ConversionRejection & conversionRejectionVariables() const { return conversionRejection_ ; }
-    void setConversionRejectionVariables(const ConversionRejection& convRej) { conversionRejection_ = convRej ; }
-  private:
-
-    // attributes
-    ConversionRejection conversionRejection_ ;
-
-
-  //=======================================================
-  // Pflow Information
-  //=======================================================
+    //=======================================================
+    // Isolation Variables
+    //=======================================================
 
   public:
+    struct IsolationVariables {
+      float tkSumPt;                 // track iso with electron footprint removed
+      float tkSumPtHEEP;             // track iso used for the HEEP ID
+      float ecalRecHitSumEt;         // ecal iso deposit with electron footprint removed
+      float hcalDepth1TowerSumEt;    // hcal depht 1 iso deposit with electron footprint removed
+      float hcalDepth2TowerSumEt;    // hcal depht 2 iso deposit with electron footprint removed
+      float hcalDepth1TowerSumEtBc;  // hcal depht 1 iso deposit without towers behind clusters
+      float hcalDepth2TowerSumEtBc;  // hcal depht 2 iso deposit without towers behind clusters
+      IsolationVariables()
+          : tkSumPt(0.),
+            tkSumPtHEEP(0.),
+            ecalRecHitSumEt(0.),
+            hcalDepth1TowerSumEt(0.),
+            hcalDepth2TowerSumEt(0.),
+            hcalDepth1TowerSumEtBc(0.),
+            hcalDepth2TowerSumEtBc(0.) {}
+    };
 
-    struct PflowIsolationVariables
-      {
-       //first three data members that changed names, according to DataFormats/MuonReco/interface/MuonPFIsolation.h
-       float sumChargedHadronPt; //!< sum-pt of charged Hadron    // old float chargedHadronIso ;
-       float sumNeutralHadronEt;  //!< sum pt of neutral hadrons  // old float neutralHadronIso ;
-       float sumPhotonEt;  //!< sum pt of PF photons              // old float photonIso ;
-       //then four new data members, corresponding to DataFormats/MuonReco/interface/MuonPFIsolation.h
-       float sumChargedParticlePt; //!< sum-pt of charged Particles(inludes e/mu) 
-       float sumNeutralHadronEtHighThreshold;  //!< sum pt of neutral hadrons with a higher threshold
-       float sumPhotonEtHighThreshold;  //!< sum pt of PF photons with a higher threshold
-       float sumPUPt;  //!< sum pt of charged Particles not from PV  (for Pu corrections)
-       //new pf cluster based isolation values
-       float sumEcalClusterEt; //sum pt of ecal clusters, vetoing clusters part of electron
-       float sumHcalClusterEt; //sum pt of hcal clusters, vetoing clusters part of electron
-       PflowIsolationVariables() :
-        sumChargedHadronPt(0),sumNeutralHadronEt(0),sumPhotonEt(0),sumChargedParticlePt(0),
-        sumNeutralHadronEtHighThreshold(0),sumPhotonEtHighThreshold(0),sumPUPt(0),
-	sumEcalClusterEt(0),sumHcalClusterEt(0){}; 
-      } ;
+    // 03 accessors
+    float dr03TkSumPt() const { return dr03_.tkSumPt; }
+    float dr03TkSumPtHEEP() const { return dr03_.tkSumPtHEEP; }
+    float dr03EcalRecHitSumEt() const { return dr03_.ecalRecHitSumEt; }
+    float dr03HcalDepth1TowerSumEt() const { return dr03_.hcalDepth1TowerSumEt; }
+    float dr03HcalDepth2TowerSumEt() const { return dr03_.hcalDepth2TowerSumEt; }
+    float dr03HcalTowerSumEt() const { return dr03HcalDepth1TowerSumEt() + dr03HcalDepth2TowerSumEt(); }
+    float dr03HcalDepth1TowerSumEtBc() const { return dr03_.hcalDepth1TowerSumEtBc; }
+    float dr03HcalDepth2TowerSumEtBc() const { return dr03_.hcalDepth2TowerSumEtBc; }
+    float dr03HcalTowerSumEtBc() const { return dr03HcalDepth1TowerSumEtBc() + dr03HcalDepth2TowerSumEtBc(); }
+    const IsolationVariables &dr03IsolationVariables() const { return dr03_; }
 
-    struct MvaInput
-     {
-      int earlyBrem ; // Early Brem detected (-2=>unknown,-1=>could not be evaluated,0=>wrong,1=>true)
-      int lateBrem ; // Late Brem detected (-2=>unknown,-1=>could not be evaluated,0=>wrong,1=>true)
-      float sigmaEtaEta ; // Sigma-eta-eta with the PF cluster
-      float hadEnergy ; // Associated PF Had Cluster energy
-      float deltaEta ; // PF-cluster GSF track delta-eta
-      int nClusterOutsideMustache ; // -2 => unknown, -1 =>could not be evaluated, 0 and more => number of clusters
-      float etOutsideMustache ;
-      MvaInput()
-       : earlyBrem(-2), lateBrem(-2),
-         sigmaEtaEta(std::numeric_limits<float>::max()),
-         hadEnergy(0.),
-         deltaEta(std::numeric_limits<float>::max()),
-         nClusterOutsideMustache(-2),
-         etOutsideMustache(-std::numeric_limits<float>::max())
-       {}
-     } ;
+    // 04 accessors
+    float dr04TkSumPt() const { return dr04_.tkSumPt; }
+    float dr04TkSumPtHEEP() const { return dr04_.tkSumPtHEEP; }
+    float dr04EcalRecHitSumEt() const { return dr04_.ecalRecHitSumEt; }
+    float dr04HcalDepth1TowerSumEt() const { return dr04_.hcalDepth1TowerSumEt; }
+    float dr04HcalDepth2TowerSumEt() const { return dr04_.hcalDepth2TowerSumEt; }
+    float dr04HcalTowerSumEt() const { return dr04HcalDepth1TowerSumEt() + dr04HcalDepth2TowerSumEt(); }
+    float dr04HcalDepth1TowerSumEtBc() const { return dr04_.hcalDepth1TowerSumEtBc; }
+    float dr04HcalDepth2TowerSumEtBc() const { return dr04_.hcalDepth2TowerSumEtBc; }
+    float dr04HcalTowerSumEtBc() const { return dr04HcalDepth1TowerSumEtBc() + dr04HcalDepth2TowerSumEtBc(); }
+    const IsolationVariables &dr04IsolationVariables() const { return dr04_; }
 
-    struct MvaOutput
-     {
-      int status ; // see PFCandidateElectronExtra::StatusFlag
-      float mva_Isolated ;
-      float mva_e_pi ;
-      float mvaByPassForIsolated ; // complementary MVA used in preselection
-      MvaOutput()
-       : status(-1), mva_Isolated(-999999999.),mva_e_pi(-999999999.), mvaByPassForIsolated(-999999999.)
-       {}
-     } ;
+    // setters ?!?
+    void setDr03Isolation(const IsolationVariables &dr03) { dr03_ = dr03; }
+    void setDr04Isolation(const IsolationVariables &dr04) { dr04_ = dr04; }
+
+    // for backward compatibility
+    void setIsolation03(const IsolationVariables &dr03) { dr03_ = dr03; }
+    void setIsolation04(const IsolationVariables &dr04) { dr04_ = dr04; }
+    const IsolationVariables &isolationVariables03() const { return dr03_; }
+    const IsolationVariables &isolationVariables04() const { return dr04_; }
+
+  private:
+    // attributes
+    IsolationVariables dr03_;
+    IsolationVariables dr04_;
+
+    //=======================================================
+    // Conversion Rejection Information
+    //=======================================================
+
+  public:
+    struct ConversionRejection {
+      int flags;             // -max:not-computed, other: as computed by Puneeth conversion code
+      TrackBaseRef partner;  // conversion partner
+      float dist;            // distance to the conversion partner
+      float dcot;            // difference of cot(angle) with the conversion partner track
+      float radius;          // signed conversion radius
+      float vtxFitProb;      //fit probablity (chi2/ndof) of the matched conversion vtx
+      ConversionRejection()
+          : flags(-1),
+            dist(std::numeric_limits<float>::max()),
+            dcot(std::numeric_limits<float>::max()),
+            radius(std::numeric_limits<float>::max()),
+            vtxFitProb(std::numeric_limits<float>::max()) {}
+    };
 
     // accessors
-    const PflowIsolationVariables & pfIsolationVariables() const { return pfIso_ ; }
+    int convFlags() const { return conversionRejection_.flags; }
+    TrackBaseRef convPartner() const { return conversionRejection_.partner; }
+    float convDist() const { return conversionRejection_.dist; }
+    float convDcot() const { return conversionRejection_.dcot; }
+    float convRadius() const { return conversionRejection_.radius; }
+    float convVtxFitProb() const { return conversionRejection_.vtxFitProb; }
+    const ConversionRejection &conversionRejectionVariables() const { return conversionRejection_; }
+    void setConversionRejectionVariables(const ConversionRejection &convRej) { conversionRejection_ = convRej; }
+
+  private:
+    // attributes
+    ConversionRejection conversionRejection_;
+
+    //=======================================================
+    // Pflow Information
+    //=======================================================
+
+  public:
+    struct PflowIsolationVariables {
+      //first three data members that changed names, according to DataFormats/MuonReco/interface/MuonPFIsolation.h
+      float sumChargedHadronPt;  //!< sum-pt of charged Hadron    // old float chargedHadronIso ;
+      float sumNeutralHadronEt;  //!< sum pt of neutral hadrons  // old float neutralHadronIso ;
+      float sumPhotonEt;         //!< sum pt of PF photons              // old float photonIso ;
+      //then four new data members, corresponding to DataFormats/MuonReco/interface/MuonPFIsolation.h
+      float sumChargedParticlePt;             //!< sum-pt of charged Particles(inludes e/mu)
+      float sumNeutralHadronEtHighThreshold;  //!< sum pt of neutral hadrons with a higher threshold
+      float sumPhotonEtHighThreshold;         //!< sum pt of PF photons with a higher threshold
+      float sumPUPt;                          //!< sum pt of charged Particles not from PV  (for Pu corrections)
+      //new pf cluster based isolation values
+      float sumEcalClusterEt;  //sum pt of ecal clusters, vetoing clusters part of electron
+      float sumHcalClusterEt;  //sum pt of hcal clusters, vetoing clusters part of electron
+      PflowIsolationVariables()
+          : sumChargedHadronPt(0),
+            sumNeutralHadronEt(0),
+            sumPhotonEt(0),
+            sumChargedParticlePt(0),
+            sumNeutralHadronEtHighThreshold(0),
+            sumPhotonEtHighThreshold(0),
+            sumPUPt(0),
+            sumEcalClusterEt(0),
+            sumHcalClusterEt(0){};
+    };
+
+    struct MvaInput {
+      int earlyBrem;                // Early Brem detected (-2=>unknown,-1=>could not be evaluated,0=>wrong,1=>true)
+      int lateBrem;                 // Late Brem detected (-2=>unknown,-1=>could not be evaluated,0=>wrong,1=>true)
+      float sigmaEtaEta;            // Sigma-eta-eta with the PF cluster
+      float hadEnergy;              // Associated PF Had Cluster energy
+      float deltaEta;               // PF-cluster GSF track delta-eta
+      int nClusterOutsideMustache;  // -2 => unknown, -1 =>could not be evaluated, 0 and more => number of clusters
+      float etOutsideMustache;
+      MvaInput()
+          : earlyBrem(-2),
+            lateBrem(-2),
+            sigmaEtaEta(std::numeric_limits<float>::max()),
+            hadEnergy(0.),
+            deltaEta(std::numeric_limits<float>::max()),
+            nClusterOutsideMustache(-2),
+            etOutsideMustache(-std::numeric_limits<float>::max()) {}
+    };
+
+    struct MvaOutput {
+      int status;  // see PFCandidateElectronExtra::StatusFlag
+      float mva_Isolated;
+      float mva_e_pi;
+      float mvaByPassForIsolated;  // complementary MVA used in preselection
+      MvaOutput() : status(-1), mva_Isolated(-999999999.), mva_e_pi(-999999999.), mvaByPassForIsolated(-999999999.) {}
+    };
+
+    // accessors
+    const PflowIsolationVariables &pfIsolationVariables() const { return pfIso_; }
     //backwards compat functions for pat::Electron
     float ecalPFClusterIso() const { return pfIso_.sumEcalClusterEt; };
     float hcalPFClusterIso() const { return pfIso_.sumHcalClusterEt; };
-   
-    const MvaInput & mvaInput() const { return mvaInput_ ; }
-    const MvaOutput & mvaOutput() const { return mvaOutput_ ; }
+
+    const MvaInput &mvaInput() const { return mvaInput_; }
+    const MvaOutput &mvaOutput() const { return mvaOutput_; }
 
     // setters
-    void setPfIsolationVariables( const PflowIsolationVariables & iso ) { pfIso_ = iso ; }
-    void setMvaInput( const MvaInput & mi ) { mvaInput_ = mi ; }
-    void setMvaOutput( const MvaOutput & mo ) { mvaOutput_ = mo ; }
+    void setPfIsolationVariables(const PflowIsolationVariables &iso) { pfIso_ = iso; }
+    void setMvaInput(const MvaInput &mi) { mvaInput_ = mi; }
+    void setMvaOutput(const MvaOutput &mo) { mvaOutput_ = mo; }
 
     // for backward compatibility
-    float mva_Isolated() const { return mvaOutput_.mva_Isolated ; }
-    float mva_e_pi() const { return mvaOutput_.mva_e_pi ; }
+    float mva_Isolated() const { return mvaOutput_.mva_Isolated; }
+    float mva_e_pi() const { return mvaOutput_.mva_e_pi; }
 
   private:
+    PflowIsolationVariables pfIso_;
+    MvaInput mvaInput_;
+    MvaOutput mvaOutput_;
 
-    PflowIsolationVariables pfIso_ ;
-    MvaInput mvaInput_ ;
-    MvaOutput mvaOutput_ ;
+    //=======================================================
+    // Preselection and Ambiguity
+    //=======================================================
 
-
-  //=======================================================
-  // Preselection and Ambiguity
-  //=======================================================
-
-  public :
-
+  public:
     // accessors
-    bool ecalDriven() const ; // return true if ecalDrivenSeed() and passingCutBasedPreselection()
-    bool passingCutBasedPreselection() const { return passCutBasedPreselection_ ; }
-    bool passingPflowPreselection() const { return passPflowPreselection_ ; }
-    bool ambiguous() const { return ambiguous_ ; }
-    GsfTrackRefVector::size_type ambiguousGsfTracksSize() const { return ambiguousGsfTracks_.size() ; }
-    GsfTrackRefVector::const_iterator ambiguousGsfTracksBegin() const { return ambiguousGsfTracks_.begin() ; }
-    GsfTrackRefVector::const_iterator ambiguousGsfTracksEnd() const { return ambiguousGsfTracks_.end() ; }
+    bool ecalDriven() const;  // return true if ecalDrivenSeed() and passingCutBasedPreselection()
+    bool passingCutBasedPreselection() const { return passCutBasedPreselection_; }
+    bool passingPflowPreselection() const { return passPflowPreselection_; }
+    bool ambiguous() const { return ambiguous_; }
+    GsfTrackRefVector::size_type ambiguousGsfTracksSize() const { return ambiguousGsfTracks_.size(); }
+    GsfTrackRefVector::const_iterator ambiguousGsfTracksBegin() const { return ambiguousGsfTracks_.begin(); }
+    GsfTrackRefVector::const_iterator ambiguousGsfTracksEnd() const { return ambiguousGsfTracks_.end(); }
 
     // setters
-    void setPassCutBasedPreselection( bool flag ) { passCutBasedPreselection_ = flag ; }
-    void setPassPflowPreselection( bool flag ) { passPflowPreselection_ = flag ; }
-    void setAmbiguous( bool flag ) { ambiguous_ = flag ; }
-    void clearAmbiguousGsfTracks() { ambiguousGsfTracks_.clear() ; }
-    void addAmbiguousGsfTrack( const reco::GsfTrackRef & t ) { ambiguousGsfTracks_.push_back(t) ; }
+    void setPassCutBasedPreselection(bool flag) { passCutBasedPreselection_ = flag; }
+    void setPassPflowPreselection(bool flag) { passPflowPreselection_ = flag; }
+    void setAmbiguous(bool flag) { ambiguous_ = flag; }
+    void clearAmbiguousGsfTracks() { ambiguousGsfTracks_.clear(); }
+    void addAmbiguousGsfTrack(const reco::GsfTrackRef &t) { ambiguousGsfTracks_.push_back(t); }
 
     // backward compatibility
-    void setPassMvaPreselection( bool flag ) { passMvaPreslection_ = flag ; }
-    bool passingMvaPreselection() const { return passMvaPreslection_ ; }
+    void setPassMvaPreselection(bool flag) { passMvaPreslection_ = flag; }
+    bool passingMvaPreselection() const { return passMvaPreslection_; }
 
   private:
-
     // attributes
-    bool passCutBasedPreselection_ ;
-    bool passPflowPreselection_ ;
-    bool passMvaPreslection_ ; // to be removed : passPflowPreslection_
-    bool ambiguous_ ;
-    GsfTrackRefVector ambiguousGsfTracks_ ; // ambiguous gsf tracks
+    bool passCutBasedPreselection_;
+    bool passPflowPreselection_;
+    bool passMvaPreslection_;  // to be removed : passPflowPreslection_
+    bool ambiguous_;
+    GsfTrackRefVector ambiguousGsfTracks_;  // ambiguous gsf tracks
 
+    //=======================================================
+    // Brem Fractions and Classification
+    //=======================================================
 
-  //=======================================================
-  // Brem Fractions and Classification
-  //=======================================================
-
-  public :
-
-    struct ClassificationVariables
-      {
-       float trackFbrem  ;       // the brem fraction from gsf fit: (track momentum in - track momentum out) / track momentum in
-       float superClusterFbrem ; // the brem fraction from supercluster: (supercluster energy - electron cluster energy) / supercluster energy
-       constexpr static float kDefaultValue = -1.e30;
-       ClassificationVariables()
-        : trackFbrem(kDefaultValue), superClusterFbrem(kDefaultValue)
-        {}
-      } ;
-    enum Classification { UNKNOWN=-1, GOLDEN=0, BIGBREM=1, BADTRACK=2, SHOWERING=3, GAP=4 } ;
+  public:
+    struct ClassificationVariables {
+      float trackFbrem;  // the brem fraction from gsf fit: (track momentum in - track momentum out) / track momentum in
+      float superClusterFbrem;  // the brem fraction from supercluster: (supercluster energy - electron cluster energy) / supercluster energy
+      constexpr static float kDefaultValue = -1.e30;
+      ClassificationVariables() : trackFbrem(kDefaultValue), superClusterFbrem(kDefaultValue) {}
+    };
+    enum Classification { UNKNOWN = -1, GOLDEN = 0, BIGBREM = 1, BADTRACK = 2, SHOWERING = 3, GAP = 4 };
 
     // accessors
-    float trackFbrem() const { return classVariables_.trackFbrem ; }
-    float superClusterFbrem() const { return classVariables_.superClusterFbrem ; }
-    const ClassificationVariables & classificationVariables() const { return classVariables_ ; }
-    Classification classification() const { return class_ ; }
+    float trackFbrem() const { return classVariables_.trackFbrem; }
+    float superClusterFbrem() const { return classVariables_.superClusterFbrem; }
+    const ClassificationVariables &classificationVariables() const { return classVariables_; }
+    Classification classification() const { return class_; }
 
     // utilities
-    int numberOfBrems() const { return basicClustersSize()-1 ; }
-    float fbrem() const { return trackFbrem() ; }
+    int numberOfBrems() const { return basicClustersSize() - 1; }
+    float fbrem() const { return trackFbrem(); }
 
     // setters
-    void setTrackFbrem( float fbrem ) { classVariables_.trackFbrem = fbrem ; }
-    void setSuperClusterFbrem( float fbrem ) { classVariables_.superClusterFbrem = fbrem ; }
-    void setClassificationVariables( const ClassificationVariables & cv ) { classVariables_ = cv ; }
-    void setClassification( Classification myclass ) { class_ = myclass ; }
+    void setTrackFbrem(float fbrem) { classVariables_.trackFbrem = fbrem; }
+    void setSuperClusterFbrem(float fbrem) { classVariables_.superClusterFbrem = fbrem; }
+    void setClassificationVariables(const ClassificationVariables &cv) { classVariables_ = cv; }
+    void setClassification(Classification myclass) { class_ = myclass; }
 
   private:
-
     // attributes
-    ClassificationVariables classVariables_ ;
-    Classification class_ ; // fbrem and number of clusters based electron classification
+    ClassificationVariables classVariables_;
+    Classification class_;  // fbrem and number of clusters based electron classification
 
+    //=======================================================
+    // Corrections
+    //
+    // The only methods, with classification, which modify
+    // the electrons after they have been constructed.
+    // They change a given characteristic, such as the super-cluster
+    // energy, and propagate the change consistently
+    // to all the depending attributes.
+    // We expect the methods to be called in a given order
+    // and so to store specific kind of corrections
+    // 1) classify()
+    // 2) correctEcalEnergy() : depending on classification and eta
+    // 3) correctMomemtum() : depending on classification and ecal energy and tracker momentum errors
+    //
+    // Beware that correctEcalEnergy() is modifying few attributes which
+    // were potentially used for preselection, whose value used in
+    // preselection will not be available any more :
+    // hcalDepth1OverEcal, hcalDepth2OverEcal, eSuperClusterOverP,
+    // eSeedClusterOverP, eEleClusterOverPout.
+    //=======================================================
 
-  //=======================================================
-  // Corrections
-  //
-  // The only methods, with classification, which modify
-  // the electrons after they have been constructed.
-  // They change a given characteristic, such as the super-cluster
-  // energy, and propagate the change consistently
-  // to all the depending attributes.
-  // We expect the methods to be called in a given order
-  // and so to store specific kind of corrections
-  // 1) classify()
-  // 2) correctEcalEnergy() : depending on classification and eta
-  // 3) correctMomemtum() : depending on classification and ecal energy and tracker momentum errors
-  //
-  // Beware that correctEcalEnergy() is modifying few attributes which
-  // were potentially used for preselection, whose value used in
-  // preselection will not be available any more :
-  // hcalDepth1OverEcal, hcalDepth2OverEcal, eSuperClusterOverP,
-  // eSeedClusterOverP, eEleClusterOverPout.
-  //=======================================================
+  public:
+    enum P4Kind { P4_UNKNOWN = -1, P4_FROM_SUPER_CLUSTER = 0, P4_COMBINATION = 1, P4_PFLOW_COMBINATION = 2 };
 
-  public :
-
-    enum P4Kind { P4_UNKNOWN=-1, P4_FROM_SUPER_CLUSTER=0, P4_COMBINATION=1, P4_PFLOW_COMBINATION=2 } ;
-
-    struct Corrections
-     {
-      bool  isEcalEnergyCorrected ;    // true if ecal energy has been corrected
-      float correctedEcalEnergy ;      // corrected energy (if !isEcalEnergyCorrected this value is identical to the supercluster energy)
-      float correctedEcalEnergyError ; // error on energy
+    struct Corrections {
+      bool isEcalEnergyCorrected;  // true if ecal energy has been corrected
+      float correctedEcalEnergy;  // corrected energy (if !isEcalEnergyCorrected this value is identical to the supercluster energy)
+      float correctedEcalEnergyError;  // error on energy
       //bool isMomentumCorrected ;     // DEPRECATED
-      float trackMomentumError ;       // track momentum error from gsf fit
+      float trackMomentumError;  // track momentum error from gsf fit
       //
-      LorentzVector fromSuperClusterP4 ; // for P4_FROM_SUPER_CLUSTER
-      float fromSuperClusterP4Error ;    // for P4_FROM_SUPER_CLUSTER
-      LorentzVector combinedP4 ;    // for P4_COMBINATION
-      float combinedP4Error ;       // for P4_COMBINATION
-      LorentzVector pflowP4 ;       // for P4_PFLOW_COMBINATION
-      float pflowP4Error ;          // for P4_PFLOW_COMBINATION
-      P4Kind candidateP4Kind ;  // say which momentum has been stored in reco::Candidate
+      LorentzVector fromSuperClusterP4;  // for P4_FROM_SUPER_CLUSTER
+      float fromSuperClusterP4Error;     // for P4_FROM_SUPER_CLUSTER
+      LorentzVector combinedP4;          // for P4_COMBINATION
+      float combinedP4Error;             // for P4_COMBINATION
+      LorentzVector pflowP4;             // for P4_PFLOW_COMBINATION
+      float pflowP4Error;                // for P4_PFLOW_COMBINATION
+      P4Kind candidateP4Kind;            // say which momentum has been stored in reco::Candidate
       //
       Corrections()
-       : isEcalEnergyCorrected(false), correctedEcalEnergy(0.), correctedEcalEnergyError(999.),
-  	     /*isMomentumCorrected(false),*/ trackMomentumError(999.),
-  	     fromSuperClusterP4Error(999.), combinedP4Error(999.), pflowP4Error(999.),
-  	     candidateP4Kind(P4_UNKNOWN)
-       {}
-     } ;
+          : isEcalEnergyCorrected(false),
+            correctedEcalEnergy(0.),
+            correctedEcalEnergyError(999.),
+            /*isMomentumCorrected(false),*/ trackMomentumError(999.),
+            fromSuperClusterP4Error(999.),
+            combinedP4Error(999.),
+            pflowP4Error(999.),
+            candidateP4Kind(P4_UNKNOWN) {}
+    };
 
     // setters
-    void setCorrectedEcalEnergyError( float newEnergyError ) ;
-    void setCorrectedEcalEnergy( float newEnergy ) ;
-    void setTrackMomentumError( float trackMomentumError ) ;
-    void setP4( P4Kind kind, const LorentzVector & p4, float p4Error, bool setCandidate ) ;
-    using RecoCandidate::setP4 ;
+    void setCorrectedEcalEnergyError(float newEnergyError);
+    void setCorrectedEcalEnergy(float newEnergy);
+    void setTrackMomentumError(float trackMomentumError);
+    void setP4(P4Kind kind, const LorentzVector &p4, float p4Error, bool setCandidate);
+    using RecoCandidate::setP4;
 
     // accessors
-    bool isEcalEnergyCorrected() const { return corrections_.isEcalEnergyCorrected ; }
-    float correctedEcalEnergy() const { return corrections_.correctedEcalEnergy ; }
-    float correctedEcalEnergyError() const { return corrections_.correctedEcalEnergyError ; }
-    float trackMomentumError() const { return corrections_.trackMomentumError ; }
-    const LorentzVector & p4( P4Kind kind ) const ;
-    using RecoCandidate::p4 ;
-    float p4Error( P4Kind kind ) const ;
-    P4Kind candidateP4Kind() const { return corrections_.candidateP4Kind ; }
-    const Corrections & corrections() const { return corrections_ ; }
-    
+    bool isEcalEnergyCorrected() const { return corrections_.isEcalEnergyCorrected; }
+    float correctedEcalEnergy() const { return corrections_.correctedEcalEnergy; }
+    float correctedEcalEnergyError() const { return corrections_.correctedEcalEnergyError; }
+    float trackMomentumError() const { return corrections_.trackMomentumError; }
+    const LorentzVector &p4(P4Kind kind) const;
+    using RecoCandidate::p4;
+    float p4Error(P4Kind kind) const;
+    P4Kind candidateP4Kind() const { return corrections_.candidateP4Kind; }
+    const Corrections &corrections() const { return corrections_; }
+
     // bare setter (if you know what you're doing)
     void setCorrections(const Corrections &c) { corrections_ = c; }
 
     // for backward compatibility
-    void setEcalEnergyError( float energyError ) { setCorrectedEcalEnergyError(energyError) ; }
-    float ecalEnergy() const { return correctedEcalEnergy() ; }
-    float ecalEnergyError() const { return correctedEcalEnergyError() ; }
+    void setEcalEnergyError(float energyError) { setCorrectedEcalEnergyError(energyError); }
+    float ecalEnergy() const { return correctedEcalEnergy(); }
+    float ecalEnergyError() const { return correctedEcalEnergyError(); }
     //bool isMomentumCorrected() const { return corrections_.isMomentumCorrected ; }
-    float caloEnergy() const { return correctedEcalEnergy() ; }
-    bool isEnergyScaleCorrected() const { return isEcalEnergyCorrected() ; }
-    void correctEcalEnergy( float newEnergy, float newEnergyError )
-     {
-      setCorrectedEcalEnergy(newEnergy) ;
-      setEcalEnergyError(newEnergyError) ;
-     }
-    void correctMomentum( const LorentzVector & p4, float trackMomentumError, float p4Error )
-     { setTrackMomentumError(trackMomentumError) ; setP4(P4_COMBINATION,p4,p4Error,true) ; }
-
+    float caloEnergy() const { return correctedEcalEnergy(); }
+    bool isEnergyScaleCorrected() const { return isEcalEnergyCorrected(); }
+    void correctEcalEnergy(float newEnergy, float newEnergyError) {
+      setCorrectedEcalEnergy(newEnergy);
+      setEcalEnergyError(newEnergyError);
+    }
+    void correctMomentum(const LorentzVector &p4, float trackMomentumError, float p4Error) {
+      setTrackMomentumError(trackMomentumError);
+      setP4(P4_COMBINATION, p4, p4Error, true);
+    }
 
   private:
-
     // attributes
-    Corrections corrections_ ;
-  
-  public:
-    struct PixelMatchVariables{
-      //! Pixel match variable: deltaPhi for innermost hit
-      float dPhi1 ;
-      //! Pixel match variable: deltaPhi for second hit
-      float dPhi2 ;
-      //! Pixel match variable: deltaRz for innermost hit
-      float dRz1  ;
-      //! Pixel match variable: deltaRz for second hit
-      float dRz2  ;
-      //! Subdetectors for first and second pixel hit
-      unsigned char subdetectors ;
-      PixelMatchVariables():
-        dPhi1(-999),
-        dPhi2(-999),
-        dRz1(-999),
-        dRz2(-999),
-        subdetectors(0)
-      {}
-      ~PixelMatchVariables(){}
-    };
-  void setPixelMatchSubdetectors(int sd1, int sd2){ pixelMatchVariables_.subdetectors = 10*sd1+sd2 ; }
-  void setPixelMatchDPhi1(float dPhi1){ pixelMatchVariables_.dPhi1 = dPhi1 ; }
-  void setPixelMatchDPhi2(float dPhi2){ pixelMatchVariables_.dPhi2 = dPhi2 ; }
-  void setPixelMatchDRz1 (float dRz1 ){ pixelMatchVariables_.dRz1  = dRz1  ; }
-  void setPixelMatchDRz2 (float dRz2 ){ pixelMatchVariables_.dRz2  = dRz2  ; }
-  
-  int pixelMatchSubdetector1() const { return pixelMatchVariables_.subdetectors/10 ; }
-  int pixelMatchSubdetector2() const { return pixelMatchVariables_.subdetectors%10 ; }
-  float pixelMatchDPhi1() const { return pixelMatchVariables_.dPhi1 ; }
-  float pixelMatchDPhi2() const { return pixelMatchVariables_.dPhi2 ; }
-  float pixelMatchDRz1 () const { return pixelMatchVariables_.dRz1  ; }
-  float pixelMatchDRz2 () const { return pixelMatchVariables_.dRz2  ; }
-  private:
-    PixelMatchVariables pixelMatchVariables_ ;    
- } ;
+    Corrections corrections_;
 
- } // namespace reco
+  public:
+    struct PixelMatchVariables {
+      //! Pixel match variable: deltaPhi for innermost hit
+      float dPhi1;
+      //! Pixel match variable: deltaPhi for second hit
+      float dPhi2;
+      //! Pixel match variable: deltaRz for innermost hit
+      float dRz1;
+      //! Pixel match variable: deltaRz for second hit
+      float dRz2;
+      //! Subdetectors for first and second pixel hit
+      unsigned char subdetectors;
+      PixelMatchVariables() : dPhi1(-999), dPhi2(-999), dRz1(-999), dRz2(-999), subdetectors(0) {}
+      ~PixelMatchVariables() {}
+    };
+    void setPixelMatchSubdetectors(int sd1, int sd2) { pixelMatchVariables_.subdetectors = 10 * sd1 + sd2; }
+    void setPixelMatchDPhi1(float dPhi1) { pixelMatchVariables_.dPhi1 = dPhi1; }
+    void setPixelMatchDPhi2(float dPhi2) { pixelMatchVariables_.dPhi2 = dPhi2; }
+    void setPixelMatchDRz1(float dRz1) { pixelMatchVariables_.dRz1 = dRz1; }
+    void setPixelMatchDRz2(float dRz2) { pixelMatchVariables_.dRz2 = dRz2; }
+
+    int pixelMatchSubdetector1() const { return pixelMatchVariables_.subdetectors / 10; }
+    int pixelMatchSubdetector2() const { return pixelMatchVariables_.subdetectors % 10; }
+    float pixelMatchDPhi1() const { return pixelMatchVariables_.dPhi1; }
+    float pixelMatchDPhi2() const { return pixelMatchVariables_.dPhi2; }
+    float pixelMatchDRz1() const { return pixelMatchVariables_.dRz1; }
+    float pixelMatchDRz2() const { return pixelMatchVariables_.dRz2; }
+
+  private:
+    PixelMatchVariables pixelMatchVariables_;
+  };
+
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/GsfElectronCore.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectronCore.h
@@ -11,7 +11,6 @@
 
 #include <vector>
 
-
 /****************************************************************************
  * \class reco::GsfElectronCore
  *
@@ -22,67 +21,67 @@
  *
  ****************************************************************************/
 
+namespace reco {
 
-namespace reco
- {
+  class GsfElectronCore {
+  public:
+    // construction
+    GsfElectronCore();
+    GsfElectronCore(const GsfTrackRef&);
+    GsfElectronCore* clone() const;
+    ~GsfElectronCore() {}
 
-  class GsfElectronCore
-   {
+    // accessors
+    const GsfTrackRef& gsfTrack() const { return gsfTrack_; }
+    const SuperClusterRef& superCluster() const {
+      return (superCluster_.isNull() ? parentSuperCluster_ : superCluster_);
+    }
+    TrackRef ctfTrack() const {
+      return closestCtfTrack_;
+    }  // get the CTF track best matching the GTF associated to this electron
+    float ctfGsfOverlap() const {
+      return ctfGsfOverlap_;
+    }  // measure the fraction of common hits between the GSF and CTF tracks
+    bool ecalDrivenSeed() const { return isEcalDrivenSeed_; }
+    bool trackerDrivenSeed() const { return isTrackerDrivenSeed_; }
 
-    public :
+    /// get vector of references to  Conversion's
+    reco::ConversionRefVector conversions() const { return conversions_; }
+    /// get vector of references to one leg Conversion's
+    reco::ConversionRefVector conversionsOneLeg() const { return conversionsOneLeg_; }
 
-      // construction
-      GsfElectronCore() ;
-      GsfElectronCore( const GsfTrackRef & ) ;
-      GsfElectronCore * clone() const ;
-      ~GsfElectronCore() {}
+    // setters
+    void setGsfTrack(const GsfTrackRef& gsfTrack) { gsfTrack_ = gsfTrack; }
+    void setSuperCluster(const SuperClusterRef& scl) { superCluster_ = scl; }
+    void setCtfTrack(const TrackRef& closestCtfTrack, float ctfGsfOverlap) {
+      closestCtfTrack_ = closestCtfTrack;
+      ctfGsfOverlap_ = ctfGsfOverlap;
+    }
 
-      // accessors
-      const GsfTrackRef & gsfTrack() const { return gsfTrack_ ; }
-      const SuperClusterRef & superCluster() const
-       { return (superCluster_.isNull()?parentSuperCluster_:superCluster_) ; }
-      TrackRef ctfTrack() const { return closestCtfTrack_ ; } // get the CTF track best matching the GTF associated to this electron
-      float ctfGsfOverlap() const { return ctfGsfOverlap_ ; } // measure the fraction of common hits between the GSF and CTF tracks
-      bool ecalDrivenSeed() const { return isEcalDrivenSeed_ ; }
-      bool trackerDrivenSeed() const { return isTrackerDrivenSeed_ ; }
+    /// add  single ConversionRef to the vector of Refs
+    void addConversion(const reco::ConversionRef& r) { conversions_.push_back(r); }
+    /// add  single ConversionRef to the vector of Refs
+    void addOneLegConversion(const reco::ConversionRef& r) { conversionsOneLeg_.push_back(r); }
 
-      /// get vector of references to  Conversion's
-      reco::ConversionRefVector conversions() const {return conversions_;} 
-      /// get vector of references to one leg Conversion's
-      reco::ConversionRefVector conversionsOneLeg() const {return conversionsOneLeg_;}       
-      
-      // setters
-      void setGsfTrack( const GsfTrackRef & gsfTrack ) { gsfTrack_ = gsfTrack ; }
-      void setSuperCluster( const SuperClusterRef & scl ) { superCluster_ = scl ; }
-      void setCtfTrack( const TrackRef & closestCtfTrack, float ctfGsfOverlap )
-       { closestCtfTrack_ = closestCtfTrack ; ctfGsfOverlap_ = ctfGsfOverlap ; }
+    // pflow eventual additionnal info
+    const SuperClusterRef& parentSuperCluster() const { return parentSuperCluster_; }
+    void setParentSuperCluster(const SuperClusterRef& scl) { parentSuperCluster_ = scl; }
 
-      /// add  single ConversionRef to the vector of Refs
-      void addConversion( const reco::ConversionRef & r ) { conversions_.push_back(r); }
-      /// add  single ConversionRef to the vector of Refs
-      void addOneLegConversion( const reco::ConversionRef & r ) { conversionsOneLeg_.push_back(r); }       
-       
-      // pflow eventual additionnal info
-      const SuperClusterRef & parentSuperCluster() const { return parentSuperCluster_ ; }
-      void setParentSuperCluster( const SuperClusterRef & scl ) { parentSuperCluster_ = scl ; }
+  private:
+    GsfTrackRef gsfTrack_;
+    SuperClusterRef superCluster_;
+    SuperClusterRef parentSuperCluster_;
+    TrackRef closestCtfTrack_;  // best matching ctf track
+    // vector of references to Conversions
+    reco::ConversionRefVector conversions_;
+    //vector of references for 1-leg
+    reco::ConversionRefVector conversionsOneLeg_;
+    float ctfGsfOverlap_;  // fraction of common hits between the ctf and gsf tracks
+    bool isEcalDrivenSeed_;
+    bool isTrackerDrivenSeed_;
+  };
 
-    private :
-
-      GsfTrackRef gsfTrack_ ;
-      SuperClusterRef superCluster_ ;
-      SuperClusterRef parentSuperCluster_ ;
-      TrackRef closestCtfTrack_ ; // best matching ctf track
-      // vector of references to Conversions
-      reco::ConversionRefVector  conversions_;
-      //vector of references for 1-leg
-      reco::ConversionRefVector  conversionsOneLeg_;      
-      float ctfGsfOverlap_ ; // fraction of common hits between the ctf and gsf tracks
-      bool isEcalDrivenSeed_ ;
-      bool isTrackerDrivenSeed_ ;
-
-   } ;
-
- }
+}  // namespace reco
 
 //*****************************************************************************
 //

--- a/DataFormats/EgammaCandidates/interface/GsfElectronCoreFwd.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectronCoreFwd.h
@@ -9,13 +9,13 @@
 
 namespace reco {
 
-  class GsfElectronCore ;
-  typedef std::vector<GsfElectronCore> GsfElectronCoreCollection ;
-  typedef edm::Ref<GsfElectronCoreCollection> GsfElectronCoreRef ;
-  typedef edm::RefProd<GsfElectronCoreCollection> GsfElectronCoreRefProd ;
-  typedef edm::RefVector<GsfElectronCoreCollection> GsfElectronCoreRefVector ;
-  typedef GsfElectronCoreRefVector::iterator GsfElectronCore_iterator ;
+  class GsfElectronCore;
+  typedef std::vector<GsfElectronCore> GsfElectronCoreCollection;
+  typedef edm::Ref<GsfElectronCoreCollection> GsfElectronCoreRef;
+  typedef edm::RefProd<GsfElectronCoreCollection> GsfElectronCoreRefProd;
+  typedef edm::RefVector<GsfElectronCoreCollection> GsfElectronCoreRefVector;
+  typedef GsfElectronCoreRefVector::iterator GsfElectronCore_iterator;
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/GsfElectronFwd.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectronFwd.h
@@ -11,28 +11,28 @@
 
 namespace reco {
 
-  class GsfElectron ;
+  class GsfElectron;
 
   /// collection of GsfElectron objects
-  typedef std::vector<GsfElectron> GsfElectronCollection ;
+  typedef std::vector<GsfElectron> GsfElectronCollection;
   //typedef GsfElectronCollection PixelMatchGsfElectronCollection ;
 
   /// reference to an object in a collection of GsfElectron objects
-  typedef edm::Ref<GsfElectronCollection> GsfElectronRef ;
+  typedef edm::Ref<GsfElectronCollection> GsfElectronRef;
   //typedef GsfElectronRef PixelMatchGsfElectronRef ;
 
   /// reference to a collection of GsfElectron objects
-  typedef edm::RefProd<GsfElectronCollection> GsfElectronRefProd ;
+  typedef edm::RefProd<GsfElectronCollection> GsfElectronRefProd;
   //typedef GsfElectronRefProd PixelMatchGsfElectronRefProd ;
 
   /// vector of objects in the same collection of GsfElectron objects
-  typedef edm::RefVector<GsfElectronCollection> GsfElectronRefVector ;
+  typedef edm::RefVector<GsfElectronCollection> GsfElectronRefVector;
   //typedef GsfElectronRefVector PixelMatchGsfElectronRefVector ;
 
   /// iterator over a vector of reference to GsfElectron objects
-  typedef GsfElectronRefVector::iterator GsfElectron_iterator ;
+  typedef GsfElectronRefVector::iterator GsfElectron_iterator;
   //typedef GsfElectron_iterator PixelMatchGsfElectron_iterator ;
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/GsfElectronIsoCollection.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectronIsoCollection.h
@@ -1,21 +1,19 @@
 #ifndef EgammaCandidates_GsfElectronIsoCollection_h
 #define EgammaCandidates_GsfElectronIsoCollection_h
 
-
 #include "DataFormats/Common/interface/AssociationVector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include <vector>
 
-namespace reco{
+namespace reco {
 
-  typedef edm::AssociationVector<reco::GsfElectronRefProd,std::vector<double> > GsfElectronIsoCollection;
-  
+  typedef edm::AssociationVector<reco::GsfElectronRefProd, std::vector<double> > GsfElectronIsoCollection;
 
-  typedef  GsfElectronIsoCollection::value_type     GsfElectronIso;
-  typedef  edm::Ref<GsfElectronIsoCollection>       GsfElectronIsoCollectionRef;
-  typedef  edm::RefProd<GsfElectronIsoCollection>   GsfElectronIsoCollectionRefProd;
-  typedef  edm::RefVector<GsfElectronIsoCollection> GsfElectronIsoCollectionRefVector;
+  typedef GsfElectronIsoCollection::value_type GsfElectronIso;
+  typedef edm::Ref<GsfElectronIsoCollection> GsfElectronIsoCollectionRef;
+  typedef edm::RefProd<GsfElectronIsoCollection> GsfElectronIsoCollectionRefProd;
+  typedef edm::RefVector<GsfElectronIsoCollection> GsfElectronIsoCollectionRefVector;
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/GsfElectronIsoNumCollection.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectronIsoNumCollection.h
@@ -1,21 +1,19 @@
 #ifndef EgammaCandidates_GsfElectronIsoNumCollection_h
 #define EgammaCandidates_GsfElectronIsoNumCollection_h
 
-
 #include "DataFormats/Common/interface/AssociationVector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include <vector>
 
-namespace reco{
+namespace reco {
 
-  typedef edm::AssociationVector<reco::GsfElectronRefProd,std::vector<int> > GsfElectronIsoNumCollection;
-  
+  typedef edm::AssociationVector<reco::GsfElectronRefProd, std::vector<int> > GsfElectronIsoNumCollection;
 
-  typedef  GsfElectronIsoNumCollection::value_type     GsfElectronIsoNum;
-  typedef  edm::Ref<GsfElectronIsoNumCollection>       GsfElectronIsoNumCollectionRef;
-  typedef  edm::RefProd<GsfElectronIsoNumCollection>   GsfElectronIsoNumCollectionRefProd;
-  typedef  edm::RefVector<GsfElectronIsoNumCollection> GsfElectronIsoNumCollectionRefVector;
+  typedef GsfElectronIsoNumCollection::value_type GsfElectronIsoNum;
+  typedef edm::Ref<GsfElectronIsoNumCollection> GsfElectronIsoNumCollectionRef;
+  typedef edm::RefProd<GsfElectronIsoNumCollection> GsfElectronIsoNumCollectionRefProd;
+  typedef edm::RefVector<GsfElectronIsoNumCollection> GsfElectronIsoNumCollectionRefVector;
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/HIPhotonIsolation.h
+++ b/DataFormats/EgammaCandidates/interface/HIPhotonIsolation.h
@@ -3,115 +3,111 @@
 
 #include "DataFormats/Common/interface/ValueMap.h"
 
-namespace reco{
+namespace reco {
 
   class HIPhotonIsolation {
-
   public:
-
-  HIPhotonIsolation() : ecalClusterIsoR1_(0),
-      ecalClusterIsoR2_(0),
-      ecalClusterIsoR3_(0),
-      ecalClusterIsoR4_(0),
-      ecalClusterIsoR5_(0),
-      hcalRechitIsoR1_(0),
-      hcalRechitIsoR2_(0),
-      hcalRechitIsoR3_(0),
-      hcalRechitIsoR4_(0),
-      hcalRechitIsoR5_(0),
-      trackIsoR1PtCut20_(0),
-      trackIsoR2PtCut20_(0),
-      trackIsoR3PtCut20_(0),
-      trackIsoR4PtCut20_(0),
-      trackIsoR5PtCut20_(0),
-      swissCrx_(0),
-      seedTime_(0)
-      {}
+    HIPhotonIsolation()
+        : ecalClusterIsoR1_(0),
+          ecalClusterIsoR2_(0),
+          ecalClusterIsoR3_(0),
+          ecalClusterIsoR4_(0),
+          ecalClusterIsoR5_(0),
+          hcalRechitIsoR1_(0),
+          hcalRechitIsoR2_(0),
+          hcalRechitIsoR3_(0),
+          hcalRechitIsoR4_(0),
+          hcalRechitIsoR5_(0),
+          trackIsoR1PtCut20_(0),
+          trackIsoR2PtCut20_(0),
+          trackIsoR3PtCut20_(0),
+          trackIsoR4PtCut20_(0),
+          trackIsoR5PtCut20_(0),
+          swissCrx_(0),
+          seedTime_(0) {}
     virtual ~HIPhotonIsolation() {}
 
     //getters
 
     /// Cluster-based isolation (ECAL) R = 0.1
-    float ecalClusterIsoR1() const {return ecalClusterIsoR1_;}
+    float ecalClusterIsoR1() const { return ecalClusterIsoR1_; }
     /// Cluster-based isolation (ECAL) R = 0.2
-    float ecalClusterIsoR2() const {return ecalClusterIsoR2_;}
+    float ecalClusterIsoR2() const { return ecalClusterIsoR2_; }
     /// Cluster-based isolation (ECAL) R = 0.3
-    float ecalClusterIsoR3() const {return ecalClusterIsoR3_;}
+    float ecalClusterIsoR3() const { return ecalClusterIsoR3_; }
     /// Cluster-based isolation (ECAL) R = 0.4
-    float ecalClusterIsoR4() const {return ecalClusterIsoR4_;}
+    float ecalClusterIsoR4() const { return ecalClusterIsoR4_; }
     /// Cluster-based isolation (ECAL) R = 0.5
-    float ecalClusterIsoR5() const {return ecalClusterIsoR5_;}
+    float ecalClusterIsoR5() const { return ecalClusterIsoR5_; }
 
     /// Rechit-based isolation (HCAL) R = 0.1
-    float hcalRechitIsoR1() const {return hcalRechitIsoR1_;}
+    float hcalRechitIsoR1() const { return hcalRechitIsoR1_; }
     /// Rechit-based isolation (HCAL) R = 0.2
-    float hcalRechitIsoR2() const {return hcalRechitIsoR2_;}
+    float hcalRechitIsoR2() const { return hcalRechitIsoR2_; }
     /// Rechit-based isolation (HCAL) R = 0.3
-    float hcalRechitIsoR3() const {return hcalRechitIsoR3_;}
+    float hcalRechitIsoR3() const { return hcalRechitIsoR3_; }
     /// Rechit-based isolation (HCAL) R = 0.4
-    float hcalRechitIsoR4() const {return hcalRechitIsoR4_;}
+    float hcalRechitIsoR4() const { return hcalRechitIsoR4_; }
     /// Rechit-based isolation (HCAL) R = 0.5
-    float hcalRechitIsoR5() const {return hcalRechitIsoR5_;}
+    float hcalRechitIsoR5() const { return hcalRechitIsoR5_; }
 
     /// Track-based isolation, pt>2.0GeV, R = 0.1
-    float trackIsoR1PtCut20() const {return trackIsoR1PtCut20_;}
+    float trackIsoR1PtCut20() const { return trackIsoR1PtCut20_; }
     /// Track-based isolation, pt>2.0GeV, R = 0.2
-    float trackIsoR2PtCut20() const {return trackIsoR2PtCut20_;}
+    float trackIsoR2PtCut20() const { return trackIsoR2PtCut20_; }
     /// Track-based isolation, pt>2.0GeV, R = 0.3
-    float trackIsoR3PtCut20() const {return trackIsoR3PtCut20_;}
+    float trackIsoR3PtCut20() const { return trackIsoR3PtCut20_; }
     /// Track-based isolation, pt>2.0GeV, R = 0.4
-    float trackIsoR4PtCut20() const {return trackIsoR4PtCut20_;}
+    float trackIsoR4PtCut20() const { return trackIsoR4PtCut20_; }
     /// Track-based isolation, pt>2.0GeV, R = 0.5
-    float trackIsoR5PtCut20() const {return trackIsoR5PtCut20_;}
+    float trackIsoR5PtCut20() const { return trackIsoR5PtCut20_; }
 
     /// SwissCross crystal ratio
-    float swissCrx() const {return swissCrx_;}
+    float swissCrx() const { return swissCrx_; }
     /// Ecal rechit seed time
-    float seedTime() const {return seedTime_;}
+    float seedTime() const { return seedTime_; }
 
     // setters
 
     /// Cluster-based isolation (ECAL) R = 0.1
-    void ecalClusterIsoR1(float ecalClusterIsoR1)  {ecalClusterIsoR1_ = ecalClusterIsoR1;}
+    void ecalClusterIsoR1(float ecalClusterIsoR1) { ecalClusterIsoR1_ = ecalClusterIsoR1; }
     /// Cluster-based isolation (ECAL) R = 0.2
-    void ecalClusterIsoR2(float ecalClusterIsoR2)  {ecalClusterIsoR2_ = ecalClusterIsoR2;}
+    void ecalClusterIsoR2(float ecalClusterIsoR2) { ecalClusterIsoR2_ = ecalClusterIsoR2; }
     /// Cluster-based isolation (ECAL) R = 0.3
-    void ecalClusterIsoR3(float ecalClusterIsoR3)  {ecalClusterIsoR3_ = ecalClusterIsoR3;}
+    void ecalClusterIsoR3(float ecalClusterIsoR3) { ecalClusterIsoR3_ = ecalClusterIsoR3; }
     /// Cluster-based isolation (ECAL) R = 0.4
-    void ecalClusterIsoR4(float ecalClusterIsoR4)  {ecalClusterIsoR4_ = ecalClusterIsoR4;}
+    void ecalClusterIsoR4(float ecalClusterIsoR4) { ecalClusterIsoR4_ = ecalClusterIsoR4; }
     /// Cluster-based isolation (ECAL) R = 0.5
-    void ecalClusterIsoR5(float ecalClusterIsoR5)  {ecalClusterIsoR5_ = ecalClusterIsoR5;}
+    void ecalClusterIsoR5(float ecalClusterIsoR5) { ecalClusterIsoR5_ = ecalClusterIsoR5; }
 
     /// Rechit-based isolation (HCAL) R = 0.1
-    void hcalRechitIsoR1(float hcalRechitIsoR1)  {hcalRechitIsoR1_ = hcalRechitIsoR1;}
+    void hcalRechitIsoR1(float hcalRechitIsoR1) { hcalRechitIsoR1_ = hcalRechitIsoR1; }
     /// Rechit-based isolation (HCAL) R = 0.2
-    void hcalRechitIsoR2(float hcalRechitIsoR2)  {hcalRechitIsoR2_ = hcalRechitIsoR2;}
+    void hcalRechitIsoR2(float hcalRechitIsoR2) { hcalRechitIsoR2_ = hcalRechitIsoR2; }
     /// Rechit-based isolation (HCAL) R = 0.3
-    void hcalRechitIsoR3(float hcalRechitIsoR3)  {hcalRechitIsoR3_ = hcalRechitIsoR3;}
+    void hcalRechitIsoR3(float hcalRechitIsoR3) { hcalRechitIsoR3_ = hcalRechitIsoR3; }
     /// Rechit-based isolation (HCAL) R = 0.4
-    void hcalRechitIsoR4(float hcalRechitIsoR4)  {hcalRechitIsoR4_ = hcalRechitIsoR4;}
+    void hcalRechitIsoR4(float hcalRechitIsoR4) { hcalRechitIsoR4_ = hcalRechitIsoR4; }
     /// Rechit-based isolation (HCAL) R = 0.5
-    void hcalRechitIsoR5(float hcalRechitIsoR5)  {hcalRechitIsoR5_ = hcalRechitIsoR5;}
+    void hcalRechitIsoR5(float hcalRechitIsoR5) { hcalRechitIsoR5_ = hcalRechitIsoR5; }
 
     /// Track-based isolation, pt>2.0GeV, R = 0.1
-    void trackIsoR1PtCut20(float trackIsoR1PtCut20)  {trackIsoR1PtCut20_ = trackIsoR1PtCut20;}
+    void trackIsoR1PtCut20(float trackIsoR1PtCut20) { trackIsoR1PtCut20_ = trackIsoR1PtCut20; }
     /// Track-based isolation, pt>2.0GeV, R = 0.2
-    void trackIsoR2PtCut20(float trackIsoR2PtCut20)  {trackIsoR2PtCut20_ = trackIsoR2PtCut20;}
+    void trackIsoR2PtCut20(float trackIsoR2PtCut20) { trackIsoR2PtCut20_ = trackIsoR2PtCut20; }
     /// Track-based isolation, pt>2.0GeV, R = 0.3
-    void trackIsoR3PtCut20(float trackIsoR3PtCut20)  {trackIsoR3PtCut20_ = trackIsoR3PtCut20;}
+    void trackIsoR3PtCut20(float trackIsoR3PtCut20) { trackIsoR3PtCut20_ = trackIsoR3PtCut20; }
     /// Track-based isolation, pt>2.0GeV, R = 0.4
-    void trackIsoR4PtCut20(float trackIsoR4PtCut20)  {trackIsoR4PtCut20_ = trackIsoR4PtCut20;}
+    void trackIsoR4PtCut20(float trackIsoR4PtCut20) { trackIsoR4PtCut20_ = trackIsoR4PtCut20; }
     /// Track-based isolation, pt>2.0GeV, R = 0.5
-    void trackIsoR5PtCut20(float trackIsoR5PtCut20)  {trackIsoR5PtCut20_ = trackIsoR5PtCut20;}
+    void trackIsoR5PtCut20(float trackIsoR5PtCut20) { trackIsoR5PtCut20_ = trackIsoR5PtCut20; }
 
     /// SwissCross ecal crystal ratio
-    void swissCrx(float swissCrx)  {swissCrx_ = swissCrx;}
+    void swissCrx(float swissCrx) { swissCrx_ = swissCrx; }
     /// Ecal rechit seed time
-    void seedTime(float seedTime)  {seedTime_ = seedTime;}
-
+    void seedTime(float seedTime) { seedTime_ = seedTime; }
 
   private:
-
     float ecalClusterIsoR1_, ecalClusterIsoR2_, ecalClusterIsoR3_, ecalClusterIsoR4_, ecalClusterIsoR5_;
     float hcalRechitIsoR1_, hcalRechitIsoR2_, hcalRechitIsoR3_, hcalRechitIsoR4_, hcalRechitIsoR5_;
     float trackIsoR1PtCut20_, trackIsoR2PtCut20_, trackIsoR3PtCut20_, trackIsoR4PtCut20_, trackIsoR5PtCut20_;
@@ -121,5 +117,5 @@ namespace reco{
 
   typedef edm::ValueMap<reco::HIPhotonIsolation> HIPhotonIsolationMap;
 
-}
+}  // namespace reco
 #endif

--- a/DataFormats/EgammaCandidates/interface/Photon.h
+++ b/DataFormats/EgammaCandidates/interface/Photon.h
@@ -16,141 +16,138 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 
-
 namespace reco {
 
   class Photon : public RecoCandidate {
   public:
     /// Forward declaration of data structures included in the object
-    struct  FiducialFlags;
-    struct  IsolationVariables;
-    struct  ShowerShape;
-    struct  MIPVariables;  
-    struct  SaturationInfo;
-    
+    struct FiducialFlags;
+    struct IsolationVariables;
+    struct ShowerShape;
+    struct MIPVariables;
+    struct SaturationInfo;
+
     /// default constructor
-    Photon() : RecoCandidate() { pixelSeed_=false; }
+    Photon() : RecoCandidate() { pixelSeed_ = false; }
 
     /// copy constructor
-    Photon ( const Photon&); 
+    Photon(const Photon&);
 
     /// constructor from values
-    Photon( const LorentzVector & p4, 
-	    const Point& caloPos, 
-	    const PhotonCoreRef & core,  
-	    const Point & vtx = Point( 0, 0, 0 ) );
+    Photon(const LorentzVector& p4, const Point& caloPos, const PhotonCoreRef& core, const Point& vtx = Point(0, 0, 0));
 
     /// destructor
     ~Photon() override;
 
     /// returns a clone of the candidate
-    Photon * clone() const override;
+    Photon* clone() const override;
 
     /// returns a reference to the core photon object
-    reco::PhotonCoreRef photonCore() const { return photonCore_;}
-    void setPhotonCore(const reco::PhotonCoreRef &photonCore) { photonCore_ = photonCore; }
-    
+    reco::PhotonCoreRef photonCore() const { return photonCore_; }
+    void setPhotonCore(const reco::PhotonCoreRef& photonCore) { photonCore_ = photonCore; }
+
     //
     /// Retrieve photonCore attributes
     //
     // retrieve provenance
-    bool isPFlowPhoton() const {return this->photonCore()->isPFlowPhoton();}
-    bool isStandardPhoton() const {return this->photonCore()->isStandardPhoton();}
+    bool isPFlowPhoton() const { return this->photonCore()->isPFlowPhoton(); }
+    bool isStandardPhoton() const { return this->photonCore()->isStandardPhoton(); }
     /// Ref to SuperCluster
     reco::SuperClusterRef superCluster() const override;
     /// Ref to PFlow SuperCluster
-    reco::SuperClusterRef parentSuperCluster() const {return this->photonCore()->parentSuperCluster();}
+    reco::SuperClusterRef parentSuperCluster() const { return this->photonCore()->parentSuperCluster(); }
     /// vector of references to  Conversion's
-    reco::ConversionRefVector conversions() const {return this->photonCore()->conversions() ;}  
-    enum ConversionProvenance {egamma=0, 
-			       pflow=1, 
-			       both=2};
+    reco::ConversionRefVector conversions() const { return this->photonCore()->conversions(); }
+    enum ConversionProvenance { egamma = 0, pflow = 1, both = 2 };
 
     /// vector of references to  one leg Conversion's
-    reco::ConversionRefVector conversionsOneLeg() const {return this->photonCore()->conversionsOneLeg() ;} 
+    reco::ConversionRefVector conversionsOneLeg() const { return this->photonCore()->conversionsOneLeg(); }
     /// Bool flagging photons with a vector of refereces to conversions with size >0
-    bool hasConversionTracks() const { if (!this->photonCore()->conversions().empty() || !this->photonCore()->conversionsOneLeg().empty())  return true; else return false;}
-    /// reference to electron Pixel seed 
-    reco::ElectronSeedRefVector electronPixelSeeds() const {return this->photonCore()->electronPixelSeeds();}
+    bool hasConversionTracks() const {
+      if (!this->photonCore()->conversions().empty() || !this->photonCore()->conversionsOneLeg().empty())
+        return true;
+      else
+        return false;
+    }
+    /// reference to electron Pixel seed
+    reco::ElectronSeedRefVector electronPixelSeeds() const { return this->photonCore()->electronPixelSeeds(); }
     /// Bool flagging photons having a non-zero size vector of Ref to electornPixel seeds
-    bool hasPixelSeed() const { if (!(this->photonCore()->electronPixelSeeds()).empty() ) return true; else return false; }
+    bool hasPixelSeed() const {
+      if (!(this->photonCore()->electronPixelSeeds()).empty())
+        return true;
+      else
+        return false;
+    }
     int conversionTrackProvenance(const edm::RefToBase<reco::Track>& convTrack) const;
 
- 
     /// position in ECAL: this is th SC position if r9<0.93. If r8>0.93 is position of seed BasicCluster taking shower depth for unconverted photon
-    math::XYZPointF caloPosition() const {return caloPosition_;}
+    math::XYZPointF caloPosition() const { return caloPosition_; }
     /// set primary event vertex used to define photon direction
-    void setVertex(const Point & vertex) override;
+    void setVertex(const Point& vertex) override;
     /// Implement Candidate method for particle species
-    bool isPhoton() const override { return true ; }
- 
+    bool isPhoton() const override { return true; }
 
     //=======================================================
     // Fiducial Flags
     //=======================================================
-    struct  FiducialFlags
-    {
-      
+    struct FiducialFlags {
       //Fiducial flags
-      bool isEB;//Photon is in EB
-      bool isEE;//Photon is in EE
-      bool isEBEtaGap;//Photon is in supermodule/supercrystal eta gap in EB
-      bool isEBPhiGap;//Photon is in supermodule/supercrystal phi gap in EB
-      bool isEERingGap;//Photon is in crystal ring gap in EE
-      bool isEEDeeGap;//Photon is in crystal dee gap in EE
-      bool isEBEEGap;//Photon is in border between EB and EE.
-      
-      FiducialFlags():
-        isEB(false),
-           isEE(false),
-           isEBEtaGap(false),
-           isEBPhiGap(false),
-           isEERingGap(false),
-           isEEDeeGap(false),
-           isEBEEGap(false)
-           
+      bool isEB;         //Photon is in EB
+      bool isEE;         //Photon is in EE
+      bool isEBEtaGap;   //Photon is in supermodule/supercrystal eta gap in EB
+      bool isEBPhiGap;   //Photon is in supermodule/supercrystal phi gap in EB
+      bool isEERingGap;  //Photon is in crystal ring gap in EE
+      bool isEEDeeGap;   //Photon is in crystal dee gap in EE
+      bool isEBEEGap;    //Photon is in border between EB and EE.
+
+      FiducialFlags()
+          : isEB(false),
+            isEE(false),
+            isEBEtaGap(false),
+            isEBPhiGap(false),
+            isEERingGap(false),
+            isEEDeeGap(false),
+            isEBEEGap(false)
+
       {}
-      
-      
     };
 
     /// set flags for photons in the ECAL fiducial volume
-    void setFiducialVolumeFlags  ( const FiducialFlags&  a )  { fiducialFlagBlock_= a ;}
+    void setFiducialVolumeFlags(const FiducialFlags& a) { fiducialFlagBlock_ = a; }
     /// Ritrievs fiducial flags
     /// true if photon is in ECAL barrel
-    bool isEB() const{return  fiducialFlagBlock_.isEB;}
+    bool isEB() const { return fiducialFlagBlock_.isEB; }
     // true if photon is in ECAL endcap
-    bool isEE() const{return fiducialFlagBlock_.isEE;}
+    bool isEE() const { return fiducialFlagBlock_.isEE; }
     /// true if photon is in EB, and inside the boundaries in super crystals/modules
     bool isEBGap() const { return (isEBEtaGap() || isEBPhiGap()); }
-    bool isEBEtaGap() const{return fiducialFlagBlock_.isEBEtaGap;}
-    bool isEBPhiGap() const{return fiducialFlagBlock_.isEBPhiGap;}
+    bool isEBEtaGap() const { return fiducialFlagBlock_.isEBEtaGap; }
+    bool isEBPhiGap() const { return fiducialFlagBlock_.isEBPhiGap; }
     /// true if photon is in EE, and inside the boundaries in supercrystal/D
     bool isEEGap() const { return (isEERingGap() || isEEDeeGap()); }
-    bool isEERingGap() const{return fiducialFlagBlock_.isEERingGap;}
-    bool isEEDeeGap() const{return fiducialFlagBlock_.isEEDeeGap;}
+    bool isEERingGap() const { return fiducialFlagBlock_.isEERingGap; }
+    bool isEEDeeGap() const { return fiducialFlagBlock_.isEEDeeGap; }
     /// true if photon is in boundary between EB and EE
-    bool isEBEEGap() const{return fiducialFlagBlock_.isEBEEGap;}
+    bool isEBEEGap() const { return fiducialFlagBlock_.isEBEEGap; }
 
     //=======================================================
     // Shower Shape Variables
     //=======================================================
 
-    struct ShowerShape
-    {
-      float sigmaEtaEta ;
-      float sigmaIetaIeta ;
-      float e1x5 ;
-      float e2x5 ;
-      float e3x3 ;
-      float e5x5 ;
-      float maxEnergyXtal ;       
-      float hcalDepth1OverEcal ; // hcal over ecal energy using first hcal depth
-      float hcalDepth2OverEcal ; // hcal over ecal energy using 2nd hcal depth
+    struct ShowerShape {
+      float sigmaEtaEta;
+      float sigmaIetaIeta;
+      float e1x5;
+      float e2x5;
+      float e3x3;
+      float e5x5;
+      float maxEnergyXtal;
+      float hcalDepth1OverEcal;  // hcal over ecal energy using first hcal depth
+      float hcalDepth2OverEcal;  // hcal over ecal energy using 2nd hcal depth
       float hcalDepth1OverEcalBc;
       float hcalDepth2OverEcalBc;
       std::vector<CaloTowerDetId> hcalTowersBehindClusters;
-      bool  invalidHcal;
+      bool invalidHcal;
       float effSigmaRR;
       float sigmaIetaIphi;
       float sigmaIphiIphi;
@@ -170,108 +167,110 @@ namespace reco {
       float smMinor;
       float smAlpha;
       ShowerShape()
-	: sigmaEtaEta(std::numeric_limits<float>::max()),
-	   sigmaIetaIeta(std::numeric_limits<float>::max()),
-	   e1x5(0.f), 
-	   e2x5(0.f), 
-	   e3x3(0.f), 
-	   e5x5(0.f), 
-	   maxEnergyXtal(0.f),           
-	  hcalDepth1OverEcal(0),
-	  hcalDepth2OverEcal(0),
-	  hcalDepth1OverEcalBc(0),
-          hcalDepth2OverEcalBc(0),
-          invalidHcal(false),
-          effSigmaRR(std::numeric_limits<float>::max()),
-          sigmaIetaIphi(std::numeric_limits<float>::max()),
-          sigmaIphiIphi(std::numeric_limits<float>::max()),
-          e2nd(0.f),
-          eTop(0.f),
-          eLeft(0.f),
-          eRight(0.f),
-          eBottom(0.f),
-          e1x3(0.f),
-          e2x2(0.f),
-          e2x5Max(0.f),
-          e2x5Left(0.f),
-          e2x5Right(0.f),
-          e2x5Top(0.f),
-          e2x5Bottom(0.f),
-	  smMajor(0.f),
-	  smMinor(0.f),
-	  smAlpha(0.f)
-      {}
-    } ;
+          : sigmaEtaEta(std::numeric_limits<float>::max()),
+            sigmaIetaIeta(std::numeric_limits<float>::max()),
+            e1x5(0.f),
+            e2x5(0.f),
+            e3x3(0.f),
+            e5x5(0.f),
+            maxEnergyXtal(0.f),
+            hcalDepth1OverEcal(0),
+            hcalDepth2OverEcal(0),
+            hcalDepth1OverEcalBc(0),
+            hcalDepth2OverEcalBc(0),
+            invalidHcal(false),
+            effSigmaRR(std::numeric_limits<float>::max()),
+            sigmaIetaIphi(std::numeric_limits<float>::max()),
+            sigmaIphiIphi(std::numeric_limits<float>::max()),
+            e2nd(0.f),
+            eTop(0.f),
+            eLeft(0.f),
+            eRight(0.f),
+            eBottom(0.f),
+            e1x3(0.f),
+            e2x2(0.f),
+            e2x5Max(0.f),
+            e2x5Left(0.f),
+            e2x5Right(0.f),
+            e2x5Top(0.f),
+            e2x5Bottom(0.f),
+            smMajor(0.f),
+            smMinor(0.f),
+            smAlpha(0.f) {}
+    };
     const ShowerShape& showerShapeVariables() const { return showerShapeBlock_; }
     const ShowerShape& full5x5_showerShapeVariables() const { return full5x5_showerShapeBlock_; }
 
-    void setShowerShapeVariables ( const ShowerShape& a )     { showerShapeBlock_ = a ;}
-    void full5x5_setShowerShapeVariables ( const ShowerShape& a )     { full5x5_showerShapeBlock_ = a ;}
-    
-    /// the total hadronic over electromagnetic fraction
-    float hadronicOverEm() const {return   showerShapeBlock_.hcalDepth1OverEcal + showerShapeBlock_.hcalDepth2OverEcal  ;}
-    /// the  hadronic release in depth1 over electromagnetic fraction
-    float hadronicDepth1OverEm() const {return  showerShapeBlock_.hcalDepth1OverEcal  ;}
-    /// the  hadronic release in depth2 over electromagnetic fraction
-    float hadronicDepth2OverEm() const {return  showerShapeBlock_.hcalDepth2OverEcal  ;}
-    /// returns false if hadronicOverEm is not reliably estimated (e.g. because hcal was off or masked)
-    float hadronicOverEmValid() const {return !showerShapeBlock_.invalidHcal  ;}
+    void setShowerShapeVariables(const ShowerShape& a) { showerShapeBlock_ = a; }
+    void full5x5_setShowerShapeVariables(const ShowerShape& a) { full5x5_showerShapeBlock_ = a; }
 
-    /// the ration of hadronic energy in towers behind the BCs in the SC  and the SC energy 
-    float hadTowOverEm() const {return   showerShapeBlock_.hcalDepth1OverEcalBc + showerShapeBlock_.hcalDepth2OverEcalBc  ;}
-    /// the ration of hadronic energy in towers depth1 behind the BCs in the SC  and the SC energy 
-    float hadTowDepth1OverEm() const {return  showerShapeBlock_.hcalDepth1OverEcalBc  ;}
-    /// the ration of hadronic energy in towers depth2 behind the BCs in the SC  and the SC energy 
-    float hadTowDepth2OverEm() const {return  showerShapeBlock_.hcalDepth2OverEcalBc  ;}
-    const std::vector<CaloTowerDetId> & hcalTowersBehindClusters() const { return showerShapeBlock_.hcalTowersBehindClusters ; }
+    /// the total hadronic over electromagnetic fraction
+    float hadronicOverEm() const { return showerShapeBlock_.hcalDepth1OverEcal + showerShapeBlock_.hcalDepth2OverEcal; }
+    /// the  hadronic release in depth1 over electromagnetic fraction
+    float hadronicDepth1OverEm() const { return showerShapeBlock_.hcalDepth1OverEcal; }
+    /// the  hadronic release in depth2 over electromagnetic fraction
+    float hadronicDepth2OverEm() const { return showerShapeBlock_.hcalDepth2OverEcal; }
+    /// returns false if hadronicOverEm is not reliably estimated (e.g. because hcal was off or masked)
+    float hadronicOverEmValid() const { return !showerShapeBlock_.invalidHcal; }
+
+    /// the ration of hadronic energy in towers behind the BCs in the SC  and the SC energy
+    float hadTowOverEm() const {
+      return showerShapeBlock_.hcalDepth1OverEcalBc + showerShapeBlock_.hcalDepth2OverEcalBc;
+    }
+    /// the ration of hadronic energy in towers depth1 behind the BCs in the SC  and the SC energy
+    float hadTowDepth1OverEm() const { return showerShapeBlock_.hcalDepth1OverEcalBc; }
+    /// the ration of hadronic energy in towers depth2 behind the BCs in the SC  and the SC energy
+    float hadTowDepth2OverEm() const { return showerShapeBlock_.hcalDepth2OverEcalBc; }
+    const std::vector<CaloTowerDetId>& hcalTowersBehindClusters() const {
+      return showerShapeBlock_.hcalTowersBehindClusters;
+    }
     /// returns false if hadTowOverEm is not reliably estimated (e.g. because hcal was off or masked)
-    float hadTowOverEmValid() const {return !showerShapeBlock_.invalidHcal  ;}
+    float hadTowOverEmValid() const { return !showerShapeBlock_.invalidHcal; }
 
     ///  Shower shape variables
-    float e1x5()            const {return showerShapeBlock_.e1x5;}
-    float e2x5()            const {return showerShapeBlock_.e2x5;}
-    float e3x3()            const {return showerShapeBlock_.e3x3;}
-    float e5x5()            const {return showerShapeBlock_.e5x5;}
-    float maxEnergyXtal()   const {return showerShapeBlock_.maxEnergyXtal;}
-    float sigmaEtaEta()     const {return showerShapeBlock_.sigmaEtaEta;}
-    float sigmaIetaIeta()   const {return showerShapeBlock_.sigmaIetaIeta;}
-    float r1x5 ()           const {return showerShapeBlock_.e1x5/showerShapeBlock_.e5x5;}
-    float r2x5 ()           const {return showerShapeBlock_.e2x5/showerShapeBlock_.e5x5;}
-    float r9 ()             const {return showerShapeBlock_.e3x3/this->superCluster()->rawEnergy();}  
-    
-    ///full5x5 Shower shape variables
-    float full5x5_e1x5()            const {return full5x5_showerShapeBlock_.e1x5;}
-    float full5x5_e2x5()            const {return full5x5_showerShapeBlock_.e2x5;}
-    float full5x5_e3x3()            const {return full5x5_showerShapeBlock_.e3x3;}
-    float full5x5_e5x5()            const {return full5x5_showerShapeBlock_.e5x5;}
-    float full5x5_maxEnergyXtal()   const {return full5x5_showerShapeBlock_.maxEnergyXtal;}
-    float full5x5_sigmaEtaEta()     const {return full5x5_showerShapeBlock_.sigmaEtaEta;}
-    float full5x5_sigmaIetaIeta()   const {return full5x5_showerShapeBlock_.sigmaIetaIeta;}
-    float full5x5_r1x5 ()           const {return full5x5_showerShapeBlock_.e1x5/full5x5_showerShapeBlock_.e5x5;}
-    float full5x5_r2x5 ()           const {return full5x5_showerShapeBlock_.e2x5/full5x5_showerShapeBlock_.e5x5;}
-    float full5x5_r9 ()             const {return full5x5_showerShapeBlock_.e3x3/this->superCluster()->rawEnergy();}      
+    float e1x5() const { return showerShapeBlock_.e1x5; }
+    float e2x5() const { return showerShapeBlock_.e2x5; }
+    float e3x3() const { return showerShapeBlock_.e3x3; }
+    float e5x5() const { return showerShapeBlock_.e5x5; }
+    float maxEnergyXtal() const { return showerShapeBlock_.maxEnergyXtal; }
+    float sigmaEtaEta() const { return showerShapeBlock_.sigmaEtaEta; }
+    float sigmaIetaIeta() const { return showerShapeBlock_.sigmaIetaIeta; }
+    float r1x5() const { return showerShapeBlock_.e1x5 / showerShapeBlock_.e5x5; }
+    float r2x5() const { return showerShapeBlock_.e2x5 / showerShapeBlock_.e5x5; }
+    float r9() const { return showerShapeBlock_.e3x3 / this->superCluster()->rawEnergy(); }
 
-  //=======================================================
-  // SaturationInfo
-  //=======================================================
+    ///full5x5 Shower shape variables
+    float full5x5_e1x5() const { return full5x5_showerShapeBlock_.e1x5; }
+    float full5x5_e2x5() const { return full5x5_showerShapeBlock_.e2x5; }
+    float full5x5_e3x3() const { return full5x5_showerShapeBlock_.e3x3; }
+    float full5x5_e5x5() const { return full5x5_showerShapeBlock_.e5x5; }
+    float full5x5_maxEnergyXtal() const { return full5x5_showerShapeBlock_.maxEnergyXtal; }
+    float full5x5_sigmaEtaEta() const { return full5x5_showerShapeBlock_.sigmaEtaEta; }
+    float full5x5_sigmaIetaIeta() const { return full5x5_showerShapeBlock_.sigmaIetaIeta; }
+    float full5x5_r1x5() const { return full5x5_showerShapeBlock_.e1x5 / full5x5_showerShapeBlock_.e5x5; }
+    float full5x5_r2x5() const { return full5x5_showerShapeBlock_.e2x5 / full5x5_showerShapeBlock_.e5x5; }
+    float full5x5_r9() const { return full5x5_showerShapeBlock_.e3x3 / this->superCluster()->rawEnergy(); }
+
+    //=======================================================
+    // SaturationInfo
+    //=======================================================
 
     struct SaturationInfo {
       int nSaturatedXtals;
       bool isSeedSaturated;
-      SaturationInfo() 
-      : nSaturatedXtals(0), isSeedSaturated(false) {};
-     } ;
+      SaturationInfo() : nSaturatedXtals(0), isSeedSaturated(false){};
+    };
 
     // accessors
     float nSaturatedXtals() const { return saturationInfo_.nSaturatedXtals; }
     float isSeedSaturated() const { return saturationInfo_.isSeedSaturated; }
     const SaturationInfo& saturationInfo() const { return saturationInfo_; }
-    void setSaturationInfo(const SaturationInfo &s) { saturationInfo_ = s; }
+    void setSaturationInfo(const SaturationInfo& s) { saturationInfo_ = s; }
 
     //=======================================================
     // Energy Determinations
     //=======================================================
-    enum P4type { undefined=-1, ecal_standard=0, ecal_photons=1, regression1=2, regression2= 3 } ;
+    enum P4type { undefined = -1, ecal_standard = 0, ecal_photons = 1, regression1 = 2, regression2 = 3 };
 
     struct EnergyCorrections {
       float scEcalEnergy;
@@ -287,84 +286,78 @@ namespace reco {
       float regression2EnergyError;
       LorentzVector regression2P4;
       P4type candidateP4type;
-      EnergyCorrections() : 
-	scEcalEnergy(0.), 
-	scEcalEnergyError(999.),
-	scEcalP4(0., 0., 0., 0.),
-	phoEcalEnergy(0.), 
-	phoEcalEnergyError(999.),
-	phoEcalP4(0., 0., 0., 0.),
-	regression1Energy(0.), 
-	regression1EnergyError(999.),
-	regression1P4(0.,0.,0.,0.),  
-	regression2Energy(0.), 
-	regression2EnergyError(999.),
-	regression2P4(0.,0.,0.,0.),
-        candidateP4type(undefined) 
-      {}
+      EnergyCorrections()
+          : scEcalEnergy(0.),
+            scEcalEnergyError(999.),
+            scEcalP4(0., 0., 0., 0.),
+            phoEcalEnergy(0.),
+            phoEcalEnergyError(999.),
+            phoEcalP4(0., 0., 0., 0.),
+            regression1Energy(0.),
+            regression1EnergyError(999.),
+            regression1P4(0., 0., 0., 0.),
+            regression2Energy(0.),
+            regression2EnergyError(999.),
+            regression2P4(0., 0., 0., 0.),
+            candidateP4type(undefined) {}
     };
 
-    using RecoCandidate::setP4 ;
-    using RecoCandidate::p4 ;
+    using RecoCandidate::p4;
+    using RecoCandidate::setP4;
 
     //sets both energy and its uncertainty
-    void setCorrectedEnergy( P4type type, float E, float dE, bool toCand=true );        
-    void setP4( P4type type, const LorentzVector & p4, float p4Error, bool setToRecoCandidate ) ;
-    void setEnergyCorrections ( const EnergyCorrections& e) { eCorrections_=e;}
-    void setCandidateP4type(const  P4type type) { eCorrections_.candidateP4type = type; }
+    void setCorrectedEnergy(P4type type, float E, float dE, bool toCand = true);
+    void setP4(P4type type, const LorentzVector& p4, float p4Error, bool setToRecoCandidate);
+    void setEnergyCorrections(const EnergyCorrections& e) { eCorrections_ = e; }
+    void setCandidateP4type(const P4type type) { eCorrections_.candidateP4type = type; }
 
-    float getCorrectedEnergy( P4type type) const;
-    float getCorrectedEnergyError( P4type type) const ;
-    P4type getCandidateP4type() const {return eCorrections_.candidateP4type;}
-    const LorentzVector& p4( P4type type ) const ;
-    const EnergyCorrections & energyCorrections() const { return eCorrections_ ; }
+    float getCorrectedEnergy(P4type type) const;
+    float getCorrectedEnergyError(P4type type) const;
+    P4type getCandidateP4type() const { return eCorrections_.candidateP4type; }
+    const LorentzVector& p4(P4type type) const;
+    const EnergyCorrections& energyCorrections() const { return eCorrections_; }
 
     //=======================================================
     // MIP Variables
     //=======================================================
-    
-    struct MIPVariables
-    {       
+
+    struct MIPVariables {
       float mipChi2;
       float mipTotEnergy;
       float mipSlope;
       float mipIntercept;
-      int   mipNhitCone;
-      bool  mipIsHalo;
-      
-      MIPVariables():
-	
-	mipChi2(0), 
-	mipTotEnergy(0), 
-	mipSlope(0), 
-	mipIntercept(0), 
-	mipNhitCone(0),
-	mipIsHalo(false)        
-      {}    
-      
-    } ;  
-    
+      int mipNhitCone;
+      bool mipIsHalo;
+
+      MIPVariables()
+          :
+
+            mipChi2(0),
+            mipTotEnergy(0),
+            mipSlope(0),
+            mipIntercept(0),
+            mipNhitCone(0),
+            mipIsHalo(false) {}
+    };
+
     ///  MIP variables
-    float mipChi2()         const {return mipVariableBlock_.mipChi2;}
-    float mipTotEnergy()    const {return mipVariableBlock_.mipTotEnergy;}
-    float mipSlope()        const {return mipVariableBlock_.mipSlope;}
-    float mipIntercept()    const {return mipVariableBlock_.mipIntercept;}
-    int mipNhitCone()     const {return mipVariableBlock_.mipNhitCone;}
-    bool  mipIsHalo()       const {return mipVariableBlock_.mipIsHalo;}
-            
+    float mipChi2() const { return mipVariableBlock_.mipChi2; }
+    float mipTotEnergy() const { return mipVariableBlock_.mipTotEnergy; }
+    float mipSlope() const { return mipVariableBlock_.mipSlope; }
+    float mipIntercept() const { return mipVariableBlock_.mipIntercept; }
+    int mipNhitCone() const { return mipVariableBlock_.mipNhitCone; }
+    bool mipIsHalo() const { return mipVariableBlock_.mipIsHalo; }
+
     ///set mip Variables
-    void setMIPVariables ( const MIPVariables& mipVar) {mipVariableBlock_= mipVar;} 
-    
-    
+    void setMIPVariables(const MIPVariables& mipVar) { mipVariableBlock_ = mipVar; }
 
     //=======================================================
     // Isolation Variables
     //=======================================================
 
-    struct IsolationVariables
-    {
+    struct IsolationVariables {
       //These are analysis quantities calculated in the PhotonIDAlgo class
-      
+
       //EcalRecHit isolation
       float ecalRecHitSumEt;
       //HcalTower isolation
@@ -374,7 +367,7 @@ namespace reco {
       //HcalDepth2Tower isolation
       float hcalDepth2TowerSumEt;
       //HcalTower isolation subtracting the hadronic energy in towers behind the BCs in the SC
-      float hcalTowerSumEtBc; 
+      float hcalTowerSumEtBc;
       //HcalDepth1Tower isolation subtracting the hadronic energy in towers behind the BCs in the SC
       float hcalDepth1TowerSumEtBc;
       //HcalDepth2Tower isolation subtracting the hadronic energy in towers behind the BCs in the SC
@@ -387,117 +380,112 @@ namespace reco {
       int nTrkSolidCone;
       //Number of tracks in a hollow cone of outer radius, inner radius
       int nTrkHollowCone;
-      
-      IsolationVariables():
-	
-	ecalRecHitSumEt(0),
-	hcalTowerSumEt(0),
-	hcalDepth1TowerSumEt(0),
-	hcalDepth2TowerSumEt(0),
-	hcalTowerSumEtBc(0),
-	hcalDepth1TowerSumEtBc(0),
-	hcalDepth2TowerSumEtBc(0),
-	trkSumPtSolidCone(0),
-	trkSumPtHollowCone(0),
-	nTrkSolidCone(0),
-	nTrkHollowCone(0)
-	   
+
+      IsolationVariables()
+          :
+
+            ecalRecHitSumEt(0),
+            hcalTowerSumEt(0),
+            hcalDepth1TowerSumEt(0),
+            hcalDepth2TowerSumEt(0),
+            hcalTowerSumEtBc(0),
+            hcalDepth1TowerSumEtBc(0),
+            hcalDepth2TowerSumEtBc(0),
+            trkSumPtSolidCone(0),
+            trkSumPtHollowCone(0),
+            nTrkSolidCone(0),
+            nTrkHollowCone(0)
+
       {}
-      
-      
     };
 
-    
     /// set relevant isolation variables
-    void setIsolationVariables ( const IsolationVariables& isolInDr04, const IsolationVariables& isolInDr03) {  isolationR04_ = isolInDr04 ; isolationR03_ = isolInDr03 ;} 
+    void setIsolationVariables(const IsolationVariables& isolInDr04, const IsolationVariables& isolInDr03) {
+      isolationR04_ = isolInDr04;
+      isolationR03_ = isolInDr03;
+    }
 
     /// Egamma Isolation variables in cone dR=0.4
     ///Ecal isolation sum calculated from recHits
-    float ecalRecHitSumEtConeDR04()      const{return  isolationR04_.ecalRecHitSumEt;}
+    float ecalRecHitSumEtConeDR04() const { return isolationR04_.ecalRecHitSumEt; }
     /// Hcal isolation sum
-    float hcalTowerSumEtConeDR04()      const{return  isolationR04_.hcalTowerSumEt ;}
+    float hcalTowerSumEtConeDR04() const { return isolationR04_.hcalTowerSumEt; }
     /// Hcal-Depth1 isolation sum
-    float hcalDepth1TowerSumEtConeDR04()      const{return  isolationR04_.hcalDepth1TowerSumEt;}
+    float hcalDepth1TowerSumEtConeDR04() const { return isolationR04_.hcalDepth1TowerSumEt; }
     /// Hcal-Depth2 isolation sum
-    float hcalDepth2TowerSumEtConeDR04()      const{return  isolationR04_.hcalDepth2TowerSumEt;}
+    float hcalDepth2TowerSumEtConeDR04() const { return isolationR04_.hcalDepth2TowerSumEt; }
     /// Hcal isolation sum subtracting the hadronic energy in towers behind the BCs in the SC
-    float hcalTowerSumEtBcConeDR04()      const{return  isolationR04_.hcalTowerSumEtBc ;}
+    float hcalTowerSumEtBcConeDR04() const { return isolationR04_.hcalTowerSumEtBc; }
     /// Hcal-Depth1 isolation sum subtracting the hadronic energy in towers behind the BCs in the SC
-    float hcalDepth1TowerSumEtBcConeDR04()      const{return  isolationR04_.hcalDepth1TowerSumEtBc;}
+    float hcalDepth1TowerSumEtBcConeDR04() const { return isolationR04_.hcalDepth1TowerSumEtBc; }
     /// Hcal-Depth2 isolation sum subtracting the hadronic energy in towers behind the BCs in the SC
-    float hcalDepth2TowerSumEtBcConeDR04()      const{return  isolationR04_.hcalDepth2TowerSumEtBc;}
-    //  Track pT sum 
-    float trkSumPtSolidConeDR04()    const{return   isolationR04_.trkSumPtSolidCone;}
+    float hcalDepth2TowerSumEtBcConeDR04() const { return isolationR04_.hcalDepth2TowerSumEtBc; }
+    //  Track pT sum
+    float trkSumPtSolidConeDR04() const { return isolationR04_.trkSumPtSolidCone; }
     //As above, excluding the core at the center of the cone
-    float trkSumPtHollowConeDR04()   const{return   isolationR04_.trkSumPtHollowCone;}
+    float trkSumPtHollowConeDR04() const { return isolationR04_.trkSumPtHollowCone; }
     //Returns number of tracks in a cone of dR
-    int nTrkSolidConeDR04()              const{return   isolationR04_.nTrkSolidCone;}
+    int nTrkSolidConeDR04() const { return isolationR04_.nTrkSolidCone; }
     //As above, excluding the core at the center of the cone
-    int nTrkHollowConeDR04()            const{return   isolationR04_.nTrkHollowCone;}
+    int nTrkHollowConeDR04() const { return isolationR04_.nTrkHollowCone; }
     //
     /// Isolation variables in cone dR=0.3
-    float ecalRecHitSumEtConeDR03()      const{return  isolationR03_.ecalRecHitSumEt;}
+    float ecalRecHitSumEtConeDR03() const { return isolationR03_.ecalRecHitSumEt; }
     /// Hcal isolation sum
-    float hcalTowerSumEtConeDR03()      const{return isolationR03_.hcalTowerSumEt;}
+    float hcalTowerSumEtConeDR03() const { return isolationR03_.hcalTowerSumEt; }
     /// Hcal-Depth1 isolation sum
-    float hcalDepth1TowerSumEtConeDR03()      const{return isolationR03_.hcalDepth1TowerSumEt;}
+    float hcalDepth1TowerSumEtConeDR03() const { return isolationR03_.hcalDepth1TowerSumEt; }
     /// Hcal-Depth2 isolation sum
-    float hcalDepth2TowerSumEtConeDR03()      const{return isolationR03_.hcalDepth2TowerSumEt;}
+    float hcalDepth2TowerSumEtConeDR03() const { return isolationR03_.hcalDepth2TowerSumEt; }
     /// Hcal isolation sum subtracting the hadronic energy in towers behind the BCs in the SC
-    float hcalTowerSumEtBcConeDR03()      const{return  isolationR03_.hcalTowerSumEtBc ;}
+    float hcalTowerSumEtBcConeDR03() const { return isolationR03_.hcalTowerSumEtBc; }
     /// Hcal-Depth1 isolation sum subtracting the hadronic energy in towers behind the BCs in the SC
-    float hcalDepth1TowerSumEtBcConeDR03()      const{return  isolationR03_.hcalDepth1TowerSumEtBc;}
+    float hcalDepth1TowerSumEtBcConeDR03() const { return isolationR03_.hcalDepth1TowerSumEtBc; }
     /// Hcal-Depth2 isolation sum subtracting the hadronic energy in towers behind the BCs in the SC
-    float hcalDepth2TowerSumEtBcConeDR03()      const{return  isolationR03_.hcalDepth2TowerSumEtBc;}
+    float hcalDepth2TowerSumEtBcConeDR03() const { return isolationR03_.hcalDepth2TowerSumEtBc; }
     //  Track pT sum c
-    float trkSumPtSolidConeDR03()    const{return  isolationR03_.trkSumPtSolidCone;}
+    float trkSumPtSolidConeDR03() const { return isolationR03_.trkSumPtSolidCone; }
     //As above, excluding the core at the center of the cone
-    float trkSumPtHollowConeDR03()   const{return  isolationR03_.trkSumPtHollowCone;}
+    float trkSumPtHollowConeDR03() const { return isolationR03_.trkSumPtHollowCone; }
     //Returns number of tracks in a cone of dR
-    int nTrkSolidConeDR03()              const{return  isolationR03_.nTrkSolidCone;}
+    int nTrkSolidConeDR03() const { return isolationR03_.nTrkSolidCone; }
     //As above, excluding the core at the center of the cone
-    int nTrkHollowConeDR03()             const{return  isolationR03_.nTrkHollowCone;}
-
+    int nTrkHollowConeDR03() const { return isolationR03_.nTrkHollowCone; }
 
     //=======================================================
     // PFlow based Isolation Variables
     //=======================================================
 
-    struct PflowIsolationVariables
-    {
+    struct PflowIsolationVariables {
+      float chargedHadronIso;                  //charged hadron isolation with dxy,dz match to pv
+      float chargedHadronWorstVtxIso;          //max charged hadron isolation when dxy/dz matching to given vtx
+      float chargedHadronWorstVtxGeomVetoIso;  //as chargedHadronWorstVtxIso but an additional geometry based veto cone
+      float chargedHadronPFPVIso;  //only considers particles assigned to the primary vertex (PV) by particle flow, corresponds to <10_6 chargedHadronIso
+      float neutralHadronIso;
+      float photonIso;
+      float sumEcalClusterEt;  //sum pt of ecal clusters, vetoing clusters part of photon
+      float sumHcalClusterEt;  //sum pt of hcal clusters, vetoing clusters part of photon
+      PflowIsolationVariables()
+          :
 
-      float chargedHadronIso; //charged hadron isolation with dxy,dz match to pv
-      float chargedHadronWorstVtxIso;  //max charged hadron isolation when dxy/dz matching to given vtx
-      float chargedHadronWorstVtxGeomVetoIso; //as chargedHadronWorstVtxIso but an additional geometry based veto cone
-      float chargedHadronPFPVIso; //only considers particles assigned to the primary vertex (PV) by particle flow, corresponds to <10_6 chargedHadronIso
-      float neutralHadronIso; 
-      float photonIso;       
-      float sumEcalClusterEt; //sum pt of ecal clusters, vetoing clusters part of photon
-      float sumHcalClusterEt; //sum pt of hcal clusters, vetoing clusters part of photon
-      PflowIsolationVariables():
-	
-	chargedHadronIso(0.),
-	chargedHadronWorstVtxIso(0.),
-	chargedHadronWorstVtxGeomVetoIso(0.),
-	chargedHadronPFPVIso(0.),
-	neutralHadronIso(0.),
-	photonIso(0.),
-	sumEcalClusterEt(0.),
-	sumHcalClusterEt(0.)
-      {}
-      
-      
+            chargedHadronIso(0.),
+            chargedHadronWorstVtxIso(0.),
+            chargedHadronWorstVtxGeomVetoIso(0.),
+            chargedHadronPFPVIso(0.),
+            neutralHadronIso(0.),
+            photonIso(0.),
+            sumEcalClusterEt(0.),
+            sumHcalClusterEt(0.) {}
     };
 
-    /// Accessors for Particle Flow Isolation variables 
-    float chargedHadronIso() const {return  pfIsolation_.chargedHadronIso;}
-    float chargedHadronWorstVtxIso() const {return  pfIsolation_.chargedHadronWorstVtxIso;}
-    float chargedHadronWorstVtxGeomVetoIso() const {return  pfIsolation_.chargedHadronWorstVtxGeomVetoIso;}
-    float chargedHadronPFPVIso() const {return  pfIsolation_.chargedHadronPFPVIso;}
-    float neutralHadronIso() const {return  pfIsolation_.neutralHadronIso;}
-    float photonIso() const {return  pfIsolation_.photonIso;}
-    
-    
+    /// Accessors for Particle Flow Isolation variables
+    float chargedHadronIso() const { return pfIsolation_.chargedHadronIso; }
+    float chargedHadronWorstVtxIso() const { return pfIsolation_.chargedHadronWorstVtxIso; }
+    float chargedHadronWorstVtxGeomVetoIso() const { return pfIsolation_.chargedHadronWorstVtxGeomVetoIso; }
+    float chargedHadronPFPVIso() const { return pfIsolation_.chargedHadronPFPVIso; }
+    float neutralHadronIso() const { return pfIsolation_.neutralHadronIso; }
+    float photonIso() const { return pfIsolation_.photonIso; }
+
     //backwards compat functions for pat::Photon
     float ecalPFClusterIso() const { return pfIsolation_.sumEcalClusterEt; };
     float hcalPFClusterIso() const { return pfIsolation_.sumHcalClusterEt; };
@@ -506,34 +494,33 @@ namespace reco {
     const PflowIsolationVariables& getPflowIsolationVariables() const { return pfIsolation_; }
 
     /// Set Particle Flow Isolation variables
-    void setPflowIsolationVariables ( const PflowIsolationVariables& pfisol ) {  pfIsolation_ = pfisol;} 
+    void setPflowIsolationVariables(const PflowIsolationVariables& pfisol) { pfIsolation_ = pfisol; }
 
-    struct PflowIDVariables
-    {
-
+    struct PflowIDVariables {
       int nClusterOutsideMustache;
       float etOutsideMustache;
       float mva;
 
-      PflowIDVariables():
+      PflowIDVariables()
+          :
 
-        nClusterOutsideMustache(-1),
-        etOutsideMustache(-999999999.),
-        mva(-999999999.)
-      		   
+            nClusterOutsideMustache(-1),
+            etOutsideMustache(-999999999.),
+            mva(-999999999.)
+
       {}
     };
-    
+
     // getters
-    int nClusterOutsideMustache() const {return pfID_.nClusterOutsideMustache;}
-    float etOutsideMustache() const {return pfID_.etOutsideMustache;}
-    float pfMVA() const {return pfID_.mva;}
+    int nClusterOutsideMustache() const { return pfID_.nClusterOutsideMustache; }
+    float etOutsideMustache() const { return pfID_.etOutsideMustache; }
+    float pfMVA() const { return pfID_.mva; }
     // setters
-    void setPflowIDVariables ( const PflowIDVariables& pfid ) {  pfID_ = pfid;}         
-    
+    void setPflowIDVariables(const PflowIDVariables& pfid) { pfID_ = pfid; }
+
   private:
     /// check overlap with another candidate
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate&) const override;
     /// position of seed BasicCluster for shower depth of unconverted photon
     math::XYZPointF caloPosition_;
     /// reference to the PhotonCore
@@ -544,15 +531,15 @@ namespace reco {
     FiducialFlags fiducialFlagBlock_;
     IsolationVariables isolationR04_;
     IsolationVariables isolationR03_;
-    ShowerShape        showerShapeBlock_;
-    ShowerShape        full5x5_showerShapeBlock_;
+    ShowerShape showerShapeBlock_;
+    ShowerShape full5x5_showerShapeBlock_;
     SaturationInfo saturationInfo_;
-    EnergyCorrections eCorrections_; 
-    MIPVariables        mipVariableBlock_; 
+    EnergyCorrections eCorrections_;
+    MIPVariables mipVariableBlock_;
     PflowIsolationVariables pfIsolation_;
-    PflowIDVariables pfID_;    
+    PflowIDVariables pfID_;
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/PhotonCandidateAssociation.h
+++ b/DataFormats/EgammaCandidates/interface/PhotonCandidateAssociation.h
@@ -8,7 +8,8 @@
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 namespace reco {
-  typedef edm::AssociationMap<edm::OneToOne<reco::PhotonCollection, reco::CandidateCollection> > PhotonCandidateAssociation;
+  typedef edm::AssociationMap<edm::OneToOne<reco::PhotonCollection, reco::CandidateCollection> >
+      PhotonCandidateAssociation;
 }
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/PhotonCore.h
+++ b/DataFormats/EgammaCandidates/interface/PhotonCore.h
@@ -19,89 +19,83 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 
-
 namespace reco {
 
-  class PhotonCore  {
+  class PhotonCore {
   public:
     /// default constructor
     //    PhotonCore() { }
 
     /// To be deleted: Internal comment for Florian
     /// I would reserve this constructor to build the standard photons, as it was before, plus I add the initialization of the provenance
-    PhotonCore(const reco::SuperClusterRef & scl ):  superCluster_(scl), isPFlowPhoton_(false), isStandardPhoton_(true) { }
+    PhotonCore(const reco::SuperClusterRef &scl) : superCluster_(scl), isPFlowPhoton_(false), isStandardPhoton_(true) {}
 
-    // while for building photons from pf I would use the default constructor 
-    PhotonCore(): isPFlowPhoton_(false), isStandardPhoton_(false) { }
+    // while for building photons from pf I would use the default constructor
+    PhotonCore() : isPFlowPhoton_(false), isStandardPhoton_(false) {}
     // followed by the setters of the provenance and of the Ref to the wanted supercluster
-    // at that point if in PF you have found a photon which correspond to a standard SC yuo can 
+    // at that point if in PF you have found a photon which correspond to a standard SC yuo can
     // set both supercluster and the two flags to true
     // if you have found an object which does not have a standard SC associated you set only the
-    // one from pflow. 
-    // How does this sound ? 
-
+    // one from pflow.
+    // How does this sound ?
 
     /// destructor
-    virtual ~PhotonCore() { }
+    virtual ~PhotonCore() {}
 
-    PhotonCore* clone() const { return new PhotonCore( * this ); }
+    PhotonCore *clone() const { return new PhotonCore(*this); }
 
     /// set reference to SuperCluster
-    void setSuperCluster( const reco::SuperClusterRef & r ) { superCluster_ = r; }
+    void setSuperCluster(const reco::SuperClusterRef &r) { superCluster_ = r; }
     /// set reference to PFlow SuperCluster
-    void setParentSuperCluster( const reco::SuperClusterRef & r ) { parentSuperCluster_ = r; }
+    void setParentSuperCluster(const reco::SuperClusterRef &r) { parentSuperCluster_ = r; }
     /// add  single ConversionRef to the vector of Refs
-    void addConversion( const reco::ConversionRef & r ) { conversions_.push_back(r); }
+    void addConversion(const reco::ConversionRef &r) { conversions_.push_back(r); }
     /// add  single ConversionRef to the vector of Refs
-    void addOneLegConversion( const reco::ConversionRef & r ) { conversionsOneLeg_.push_back(r); }
+    void addOneLegConversion(const reco::ConversionRef &r) { conversionsOneLeg_.push_back(r); }
     /// set electron pixel seed ref
-    void addElectronPixelSeed( const reco::ElectronSeedRef & r ) { electronSeed_.push_back(r) ; }
+    void addElectronPixelSeed(const reco::ElectronSeedRef &r) { electronSeed_.push_back(r); }
     /// set the provenance
-    void setPFlowPhoton( const bool prov) {  isPFlowPhoton_ = prov; }
-    void setStandardPhoton( const bool prov) { isStandardPhoton_ = prov; }
-
+    void setPFlowPhoton(const bool prov) { isPFlowPhoton_ = prov; }
+    void setStandardPhoton(const bool prov) { isStandardPhoton_ = prov; }
 
     /// get reference to SuperCluster
-    reco::SuperClusterRef superCluster() const { return superCluster_;}
+    reco::SuperClusterRef superCluster() const { return superCluster_; }
     /// get reference to PFlow SuperCluster
-    reco::SuperClusterRef parentSuperCluster() const { return parentSuperCluster_;}
+    reco::SuperClusterRef parentSuperCluster() const { return parentSuperCluster_; }
 
     //// comment for Florian. I have seen that in GsfElectronCore they have a getter for the supercluster
     // which returns the pfSuperCluster only if the standard supeclsuter is not null
     // But I had udnerstood from you when we spke last time that we wish to be free
-    // to have both SCs available. Or not ? 
+    // to have both SCs available. Or not ?
 
     /// get vector of references to  Conversion's
-    reco::ConversionRefVector conversions() const {return conversions_;} 
+    reco::ConversionRefVector conversions() const { return conversions_; }
     /// get vector of references to one leg Conversion's
-    reco::ConversionRefVector conversionsOneLeg() const {return conversionsOneLeg_;} 
+    reco::ConversionRefVector conversionsOneLeg() const { return conversionsOneLeg_; }
 
     void setConversions(const reco::ConversionRefVector &conversions) { conversions_ = conversions; }
     void setConversionsOneLeg(const reco::ConversionRefVector &conversions) { conversionsOneLeg_ = conversions; }
-    
+
     /// get reference to electron seed if existing
-    reco::ElectronSeedRefVector electronPixelSeeds() const {return electronSeed_;}
-    bool isPFlowPhoton() const {return isPFlowPhoton_;} 
-    bool isStandardPhoton() const {return isStandardPhoton_;}
+    reco::ElectronSeedRefVector electronPixelSeeds() const { return electronSeed_; }
+    bool isPFlowPhoton() const { return isPFlowPhoton_; }
+    bool isStandardPhoton() const { return isStandardPhoton_; }
 
   private:
-
     /// reference to a SuperCluster
     reco::SuperClusterRef superCluster_;
     // vector of references to Conversions
-    reco::ConversionRefVector  conversions_;
+    reco::ConversionRefVector conversions_;
     //vector of references for 1-leg
-    reco::ConversionRefVector  conversionsOneLeg_;
+    reco::ConversionRefVector conversionsOneLeg_;
     // vector of references to ElectronPixelSeeds
-    reco::ElectronSeedRefVector  electronSeed_;
+    reco::ElectronSeedRefVector electronSeed_;
     /// reference to a Particle flow SuperCluster
     reco::SuperClusterRef parentSuperCluster_;
-    bool  isPFlowPhoton_;
-    bool  isStandardPhoton_;
-
+    bool isPFlowPhoton_;
+    bool isStandardPhoton_;
   };
 
-  
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/PhotonCoreFwd.h
+++ b/DataFormats/EgammaCandidates/interface/PhotonCoreFwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of reference to PhotonCore objects
   typedef PhotonCoreRefVector::iterator photonCore_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/PhotonFwd.h
+++ b/DataFormats/EgammaCandidates/interface/PhotonFwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of reference to Photon objects
   typedef PhotonRefVector::iterator photon_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/PhotonIsolationAssociation.h
+++ b/DataFormats/EgammaCandidates/interface/PhotonIsolationAssociation.h
@@ -1,15 +1,15 @@
 #ifndef EgammaCandidates_PhotonIsolationAssociation_h
 #define EgammaCandidates_PhotonIsolationAssociation_h
 // \class PhotonIsolationAssociation
-// 
+//
 // \short association of Isolation to a Photon
 //
 
 #include "DataFormats/Common/interface/AssociationMap.h"
-#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h" 
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include <vector>
 
 namespace reco {
-  typedef edm::AssociationMap<edm::OneToValue<std::vector<reco::Photon>, float > > PhotonIsolationMap;
+  typedef edm::AssociationMap<edm::OneToValue<std::vector<reco::Photon>, float> > PhotonIsolationMap;
 }
 #endif

--- a/DataFormats/EgammaCandidates/interface/PhotonPi0DiscriminatorAssociation.h
+++ b/DataFormats/EgammaCandidates/interface/PhotonPi0DiscriminatorAssociation.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 namespace reco {
-  typedef edm::AssociationMap<edm::OneToValue<std::vector<reco::Photon>, float > > PhotonPi0DiscriminatorAssociationMap;
+  typedef edm::AssociationMap<edm::OneToValue<std::vector<reco::Photon>, float> > PhotonPi0DiscriminatorAssociationMap;
 }
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/SiStripElectron.h
+++ b/DataFormats/EgammaCandidates/interface/SiStripElectron.h
@@ -4,7 +4,7 @@
 //
 // Package:     EgammaCandidates
 // Class  :     SiStripElectron
-// 
+//
 /**\class SiStripElectron SiStripElectron.h DataFormats/EgammaCandidates/interface/SiStripElectron.h
 
  Description: <one line class summary>
@@ -26,62 +26,61 @@
 
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
-#include "DataFormats/Common/interface/RefVector.h" 
+#include "DataFormats/Common/interface/RefVector.h"
 
 // forward declarations
 
 namespace reco {
-  
+
   class SiStripElectron : public RecoCandidate {
   public:
     /// default constructor
-    SiStripElectron() : RecoCandidate() { }
+    SiStripElectron() : RecoCandidate() {}
     /// constructor from band algorithm
     SiStripElectron(const reco::SuperClusterRef& superCluster,
-		    Charge q,
-		    const std::vector<SiStripRecHit2D>& rphiRecHits,
-		    const std::vector<SiStripRecHit2D>& stereoRecHits,
-		    double superClusterPhiVsRSlope,
-		    double phiVsRSlope,
-		    double phiAtOrigin,
-		    double chi2,
-		    int ndof,
-		    double pt,
-		    double pz,
-		    double zVsRSlope,
-		    unsigned int numberOfStereoHits,
-		    unsigned int numberOfBarrelRphiHits,
-		    unsigned int numberOfEndcapZphiHits)
-      : RecoCandidate(q, PtEtaPhiMass(pt,etaFromRZ(pt,pz), phiAtOrigin, 0.000510f), Point(0,0,0), -11 * q )
-	, superCluster_(superCluster)
-      , rphiRecHits_(rphiRecHits)
-      , stereoRecHits_(stereoRecHits)
-      , superClusterPhiVsRSlope_(superClusterPhiVsRSlope)
-      , phiVsRSlope_(phiVsRSlope)
-      , phiAtOrigin_(phiAtOrigin)
-      , chi2_(chi2)
-      , ndof_(ndof)
-      , zVsRSlope_(zVsRSlope)
-      , numberOfStereoHits_(numberOfStereoHits)
-      , numberOfBarrelRphiHits_(numberOfBarrelRphiHits)
-      , numberOfEndcapZphiHits_(numberOfEndcapZphiHits) { }
-        
+                    Charge q,
+                    const std::vector<SiStripRecHit2D>& rphiRecHits,
+                    const std::vector<SiStripRecHit2D>& stereoRecHits,
+                    double superClusterPhiVsRSlope,
+                    double phiVsRSlope,
+                    double phiAtOrigin,
+                    double chi2,
+                    int ndof,
+                    double pt,
+                    double pz,
+                    double zVsRSlope,
+                    unsigned int numberOfStereoHits,
+                    unsigned int numberOfBarrelRphiHits,
+                    unsigned int numberOfEndcapZphiHits)
+        : RecoCandidate(q, PtEtaPhiMass(pt, etaFromRZ(pt, pz), phiAtOrigin, 0.000510f), Point(0, 0, 0), -11 * q),
+          superCluster_(superCluster),
+          rphiRecHits_(rphiRecHits),
+          stereoRecHits_(stereoRecHits),
+          superClusterPhiVsRSlope_(superClusterPhiVsRSlope),
+          phiVsRSlope_(phiVsRSlope),
+          phiAtOrigin_(phiAtOrigin),
+          chi2_(chi2),
+          ndof_(ndof),
+          zVsRSlope_(zVsRSlope),
+          numberOfStereoHits_(numberOfStereoHits),
+          numberOfBarrelRphiHits_(numberOfBarrelRphiHits),
+          numberOfEndcapZphiHits_(numberOfEndcapZphiHits) {}
+
     /// constructor from RecoCandidate
-    template<typename P4>
-    SiStripElectron( Charge q, const P4 & p4, const Point & vtx = Point( 0, 0, 0 ) ) : 
-      RecoCandidate( q, p4, vtx, -11 * q ) { }
+    template <typename P4>
+    SiStripElectron(Charge q, const P4& p4, const Point& vtx = Point(0, 0, 0)) : RecoCandidate(q, p4, vtx, -11 * q) {}
     /// destructor
     ~SiStripElectron() override;
     /// returns a clone of the candidate
-    SiStripElectron * clone() const override;
+    SiStripElectron* clone() const override;
     /// reference to a SuperCluster
     reco::SuperClusterRef superCluster() const override;
-    
+
     /// reference to the rphiRecHits identified as belonging to an electron
     const std::vector<SiStripRecHit2D>& rphiRecHits() const { return rphiRecHits_; }
     /// reference to the stereoRecHits identified as belonging to an electron
     const std::vector<SiStripRecHit2D>& stereoRecHits() const { return stereoRecHits_; }
-    
+
     /// returns phi(r) projection from supercluster
     double superClusterPhiVsRSlope() const { return superClusterPhiVsRSlope_; }
     /// returns phi(r) slope from fit to tracker hits
@@ -92,10 +91,10 @@ namespace reco {
     double chi2() const { return chi2_; }
     /// returns number of degrees of freedom of fit to tracker hits
     int ndof() const { return ndof_; }
-        
+
     /// returns z(r) slope fit from stereo tracker hits (constrained to pass through supercluster)
     double zVsRSlope() const { return zVsRSlope_; }
-    
+
     /// returns number of stereo hits in phi band (barrel + endcap)
     unsigned int numberOfStereoHits() const { return numberOfStereoHits_; }
     /// returns number of barrel rphi hits in phi band
@@ -104,26 +103,27 @@ namespace reco {
     unsigned int numberOfEndcapZphiHits() const { return numberOfEndcapZphiHits_; }
 
     bool isElectron() const override;
+
   private:
     /// check overlap with another candidate
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate&) const override;
     /// reference to a SuperCluster
     reco::SuperClusterRef superCluster_;
     std::vector<SiStripRecHit2D> rphiRecHits_;
     std::vector<SiStripRecHit2D> stereoRecHits_;
-    
+
     double superClusterPhiVsRSlope_;
     double phiVsRSlope_;
     double phiAtOrigin_;
     double chi2_;
     int ndof_;
-    
+
     double zVsRSlope_;
-    
+
     unsigned int numberOfStereoHits_;
     unsigned int numberOfBarrelRphiHits_;
     unsigned int numberOfEndcapZphiHits_;
-   };
-}
+  };
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/interface/SiStripElectronFwd.h
+++ b/DataFormats/EgammaCandidates/interface/SiStripElectronFwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of reference to SiStripElectron objects
   typedef SiStripElectronRefVector::iterator siStripElectron_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/EgammaCandidates/src/Conversion.cc
+++ b/DataFormats/EgammaCandidates/src/Conversion.cc
@@ -1,417 +1,359 @@
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
-#include "DataFormats/TrackReco/interface/Track.h" 
-#include "DataFormats/CaloRecHit/interface/CaloCluster.h" 
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 
 using namespace reco;
 
+Conversion::Conversion(const reco::CaloClusterPtrVector& sc,
+                       const std::vector<reco::TrackRef>& tr,
+                       const std::vector<math::XYZPointF>& trackPositionAtEcal,
+                       const reco::Vertex& convVtx,
+                       const std::vector<reco::CaloClusterPtr>& matchingBC,
+                       const float DCA,
+                       const std::vector<math::XYZPointF>& innPoint,
+                       const std::vector<math::XYZVectorF>& trackPin,
+                       const std::vector<math::XYZVectorF>& trackPout,
+                       const float mva,
+                       ConversionAlgorithm algo)
+    :
 
-Conversion::Conversion(  const reco::CaloClusterPtrVector& sc, 
-			 const std::vector<reco::TrackRef>& tr, 
-			 const std::vector<math::XYZPointF>& trackPositionAtEcal, 
-			 const reco::Vertex  & convVtx,
-			 const std::vector<reco::CaloClusterPtr> & matchingBC,
-                         const float DCA,
-			 const std::vector<math::XYZPointF> & innPoint,
-			 const std::vector<math::XYZVectorF> & trackPin,
-			 const std::vector<math::XYZVectorF> & trackPout,
-                         const float mva,
-			 ConversionAlgorithm algo):  
-			 
+      caloCluster_(sc),
+      trackToBaseRefs_(),
+      thePositionAtEcal_(trackPositionAtEcal),
+      theConversionVertex_(convVtx),
+      theMatchingBCs_(matchingBC),
+      theTrackInnerPosition_(innPoint),
+      theTrackPin_(trackPin),
+      theTrackPout_(trackPout),
+      theMinDistOfApproach_(DCA),
+      theMVAout_(mva),
+      qualityMask_(0),
+      nSharedHits_(0),
+      algorithm_(algo) {
+  trackToBaseRefs_.reserve(tr.size());
+  for (auto const& track : tr) {
+    trackToBaseRefs_.emplace_back(track);
+  }
+}
 
-  caloCluster_(sc),
-  trackToBaseRefs_(),
-  thePositionAtEcal_(trackPositionAtEcal), 
-  theConversionVertex_(convVtx), 
-  theMatchingBCs_(matchingBC), 
-  theTrackInnerPosition_(innPoint),
-  theTrackPin_(trackPin),
-  theTrackPout_(trackPout),
-  theMinDistOfApproach_(DCA),
-  theMVAout_(mva),
-  qualityMask_(0),
-  nSharedHits_(0),  
-  algorithm_(algo)
- { 
-   trackToBaseRefs_.reserve(tr.size());
-   for( auto const& track: tr) {
-     trackToBaseRefs_.emplace_back(track);
-   }
- }
+Conversion::Conversion(const reco::CaloClusterPtrVector& sc,
+                       const std::vector<edm::RefToBase<reco::Track> >& tr,
+                       const std::vector<math::XYZPointF>& trackPositionAtEcal,
+                       const reco::Vertex& convVtx,
+                       const std::vector<reco::CaloClusterPtr>& matchingBC,
+                       const float DCA,
+                       const std::vector<math::XYZPointF>& innPoint,
+                       const std::vector<math::XYZVectorF>& trackPin,
+                       const std::vector<math::XYZVectorF>& trackPout,
+                       const std::vector<uint8_t>& nHitsBeforeVtx,
+                       const std::vector<Measurement1DFloat>& dlClosestHitToVtx,
+                       uint8_t nSharedHits,
+                       const float mva,
+                       ConversionAlgorithm algo)
+    :
 
+      caloCluster_(sc),
+      trackToBaseRefs_(tr),
+      thePositionAtEcal_(trackPositionAtEcal),
+      theConversionVertex_(convVtx),
+      theMatchingBCs_(matchingBC),
+      theTrackInnerPosition_(innPoint),
+      theTrackPin_(trackPin),
+      theTrackPout_(trackPout),
+      nHitsBeforeVtx_(nHitsBeforeVtx),
+      dlClosestHitToVtx_(dlClosestHitToVtx),
+      theMinDistOfApproach_(DCA),
+      theMVAout_(mva),
+      qualityMask_(0),
+      nSharedHits_(nSharedHits),
+      algorithm_(algo) {}
 
-
-
-Conversion::Conversion(  const reco::CaloClusterPtrVector& sc, 
-			 const std::vector<edm::RefToBase<reco::Track> >& tr, 
-			 const std::vector<math::XYZPointF>& trackPositionAtEcal, 
-			 const reco::Vertex  & convVtx,
-			 const std::vector<reco::CaloClusterPtr> & matchingBC,
-                         const float DCA,
-			 const std::vector<math::XYZPointF> & innPoint,
-			 const std::vector<math::XYZVectorF> & trackPin,
-			 const std::vector<math::XYZVectorF> & trackPout,
-                         const std::vector<uint8_t>& nHitsBeforeVtx,                  
-                         const std::vector<Measurement1DFloat> & dlClosestHitToVtx,
-                         uint8_t nSharedHits,
-                         const float mva,
-			 ConversionAlgorithm algo):  
-			 
-
-  caloCluster_(sc), trackToBaseRefs_(tr), 
-  thePositionAtEcal_(trackPositionAtEcal), 
-  theConversionVertex_(convVtx), 
-  theMatchingBCs_(matchingBC), 
-  theTrackInnerPosition_(innPoint),
-  theTrackPin_(trackPin),
-  theTrackPout_(trackPout),
-  nHitsBeforeVtx_(nHitsBeforeVtx),
-  dlClosestHitToVtx_(dlClosestHitToVtx),
-  theMinDistOfApproach_(DCA),
-  theMVAout_(mva),
-  qualityMask_(0),
-  nSharedHits_(nSharedHits),
-  algorithm_(algo)
- { 
-   
- }
-
-
-
-
-Conversion::Conversion(  const reco::CaloClusterPtrVector& sc, 
-			 const std::vector<reco::TrackRef>& tr, 
-			 const reco::Vertex  & convVtx,
-			 ConversionAlgorithm algo):  
-  caloCluster_(sc),
-  trackToBaseRefs_(),
-  theConversionVertex_(convVtx),
-  qualityMask_(0),
-  nSharedHits_(0),
-  algorithm_(algo)
- { 
-   trackToBaseRefs_.reserve(tr.size());
-   for( auto const& track: tr) {
-     trackToBaseRefs_.emplace_back(track);
-   }
-
+Conversion::Conversion(const reco::CaloClusterPtrVector& sc,
+                       const std::vector<reco::TrackRef>& tr,
+                       const reco::Vertex& convVtx,
+                       ConversionAlgorithm algo)
+    : caloCluster_(sc),
+      trackToBaseRefs_(),
+      theConversionVertex_(convVtx),
+      qualityMask_(0),
+      nSharedHits_(0),
+      algorithm_(algo) {
+  trackToBaseRefs_.reserve(tr.size());
+  for (auto const& track : tr) {
+    trackToBaseRefs_.emplace_back(track);
+  }
 
   theMinDistOfApproach_ = 9999.;
   theMVAout_ = 9999.;
-  thePositionAtEcal_.push_back(math::XYZPointF(0.,0.,0.));
-  thePositionAtEcal_.push_back(math::XYZPointF(0.,0.,0.));
-  theTrackInnerPosition_.push_back(math::XYZPointF(0.,0.,0.));
-  theTrackInnerPosition_.push_back(math::XYZPointF(0.,0.,0.));
-  theTrackPin_.push_back(math::XYZVectorF(0.,0.,0.));
-  theTrackPin_.push_back(math::XYZVectorF(0.,0.,0.));
-  theTrackPout_.push_back(math::XYZVectorF(0.,0.,0.));
-  theTrackPout_.push_back(math::XYZVectorF(0.,0.,0.));
+  thePositionAtEcal_.push_back(math::XYZPointF(0., 0., 0.));
+  thePositionAtEcal_.push_back(math::XYZPointF(0., 0., 0.));
+  theTrackInnerPosition_.push_back(math::XYZPointF(0., 0., 0.));
+  theTrackInnerPosition_.push_back(math::XYZPointF(0., 0., 0.));
+  theTrackPin_.push_back(math::XYZVectorF(0., 0., 0.));
+  theTrackPin_.push_back(math::XYZVectorF(0., 0., 0.));
+  theTrackPout_.push_back(math::XYZVectorF(0., 0., 0.));
+  theTrackPout_.push_back(math::XYZVectorF(0., 0., 0.));
+}
 
-   
- }
-
-
-Conversion::Conversion(  const reco::CaloClusterPtrVector& sc, 
-			 const std::vector<edm::RefToBase<reco::Track> >&  tr, 
-			 const reco::Vertex  & convVtx,
-			 ConversionAlgorithm algo):  
-  caloCluster_(sc), trackToBaseRefs_(tr), 
-  theConversionVertex_(convVtx), 
-  qualityMask_(0),
-  nSharedHits_(0),
-  algorithm_(algo)
- { 
-
-
+Conversion::Conversion(const reco::CaloClusterPtrVector& sc,
+                       const std::vector<edm::RefToBase<reco::Track> >& tr,
+                       const reco::Vertex& convVtx,
+                       ConversionAlgorithm algo)
+    : caloCluster_(sc),
+      trackToBaseRefs_(tr),
+      theConversionVertex_(convVtx),
+      qualityMask_(0),
+      nSharedHits_(0),
+      algorithm_(algo) {
   theMinDistOfApproach_ = 9999.;
   theMVAout_ = 9999.;
-  thePositionAtEcal_.push_back(math::XYZPointF(0.,0.,0.));
-  thePositionAtEcal_.push_back(math::XYZPointF(0.,0.,0.));
-  theTrackInnerPosition_.push_back(math::XYZPointF(0.,0.,0.));
-  theTrackInnerPosition_.push_back(math::XYZPointF(0.,0.,0.));
-  theTrackPin_.push_back(math::XYZVectorF(0.,0.,0.));
-  theTrackPin_.push_back(math::XYZVectorF(0.,0.,0.));
-  theTrackPout_.push_back(math::XYZVectorF(0.,0.,0.));
-  theTrackPout_.push_back(math::XYZVectorF(0.,0.,0.));
+  thePositionAtEcal_.push_back(math::XYZPointF(0., 0., 0.));
+  thePositionAtEcal_.push_back(math::XYZPointF(0., 0., 0.));
+  theTrackInnerPosition_.push_back(math::XYZPointF(0., 0., 0.));
+  theTrackInnerPosition_.push_back(math::XYZPointF(0., 0., 0.));
+  theTrackPin_.push_back(math::XYZVectorF(0., 0., 0.));
+  theTrackPin_.push_back(math::XYZVectorF(0., 0., 0.));
+  theTrackPout_.push_back(math::XYZVectorF(0., 0., 0.));
+  theTrackPout_.push_back(math::XYZVectorF(0., 0., 0.));
+}
 
-   
- }
-
-
-
-Conversion::Conversion() { 
-
-  algorithm_=0;
-  qualityMask_=0;
+Conversion::Conversion() {
+  algorithm_ = 0;
+  qualityMask_ = 0;
   theMinDistOfApproach_ = 9999.;
   nSharedHits_ = 0;
   theMVAout_ = 9999.;
-  thePositionAtEcal_.push_back(math::XYZPointF(0.,0.,0.));
-  thePositionAtEcal_.push_back(math::XYZPointF(0.,0.,0.));
-  theTrackInnerPosition_.push_back(math::XYZPointF(0.,0.,0.));
-  theTrackInnerPosition_.push_back(math::XYZPointF(0.,0.,0.));
-  theTrackPin_.push_back(math::XYZVectorF(0.,0.,0.));
-  theTrackPin_.push_back(math::XYZVectorF(0.,0.,0.));
-  theTrackPout_.push_back(math::XYZVectorF(0.,0.,0.));
-  theTrackPout_.push_back(math::XYZVectorF(0.,0.,0.));
-    
+  thePositionAtEcal_.push_back(math::XYZPointF(0., 0., 0.));
+  thePositionAtEcal_.push_back(math::XYZPointF(0., 0., 0.));
+  theTrackInnerPosition_.push_back(math::XYZPointF(0., 0., 0.));
+  theTrackInnerPosition_.push_back(math::XYZPointF(0., 0., 0.));
+  theTrackPin_.push_back(math::XYZVectorF(0., 0., 0.));
+  theTrackPin_.push_back(math::XYZVectorF(0., 0., 0.));
+  theTrackPout_.push_back(math::XYZVectorF(0., 0., 0.));
+  theTrackPout_.push_back(math::XYZVectorF(0., 0., 0.));
 }
 
+std::string const Conversion::algoNames[] = {"undefined", "ecalSeeded", "trackerOnly", "mixed", "pflow"};
 
-std::string const Conversion::algoNames[] = { "undefined","ecalSeeded","trackerOnly","mixed","pflow"};  
-
-Conversion::ConversionAlgorithm Conversion::algoByName(const std::string &name){
+Conversion::ConversionAlgorithm Conversion::algoByName(const std::string& name) {
   ConversionAlgorithm size = algoSize;
-  int index = std::find(algoNames, algoNames+size, name)-algoNames;
-  if(index == size) return undefined;
+  int index = std::find(algoNames, algoNames + size, name) - algoNames;
+  if (index == size)
+    return undefined;
 
   return ConversionAlgorithm(index);
 }
 
-Conversion * Conversion::clone() const { 
-  return new Conversion( * this ); 
-}
+Conversion* Conversion::clone() const { return new Conversion(*this); }
 
-
-std::vector<edm::RefToBase<reco::Track> > const&  Conversion::tracks() const { 
-  return trackToBaseRefs_;
-}
-
-
+std::vector<edm::RefToBase<reco::Track> > const& Conversion::tracks() const { return trackToBaseRefs_; }
 
 bool Conversion::isConverted() const {
-  
-  if ( this->nTracks() == 2 ) 
+  if (this->nTracks() == 2)
     return true;
   else
     return false;
 }
 
-double Conversion::pairInvariantMass() const{
-  double invMass=-99.;
-  const float mElec= 0.000511;
-  if ( nTracks()==2 ) {
-    double px= tracksPin()[0].x() +  tracksPin()[1].x();
-    double py= tracksPin()[0].y() +  tracksPin()[1].y();
-    double pz= tracksPin()[0].z() +  tracksPin()[1].z();
-    double mom1= tracksPin()[0].Mag2();
-    double mom2= tracksPin()[1].Mag2();
-    double e = sqrt( mom1+ mElec*mElec ) + sqrt( mom2 + mElec*mElec );
-    invMass= ( e*e - px*px -py*py - pz*pz);
-    if ( invMass>0) invMass = sqrt(invMass);
-    else 
+double Conversion::pairInvariantMass() const {
+  double invMass = -99.;
+  const float mElec = 0.000511;
+  if (nTracks() == 2) {
+    double px = tracksPin()[0].x() + tracksPin()[1].x();
+    double py = tracksPin()[0].y() + tracksPin()[1].y();
+    double pz = tracksPin()[0].z() + tracksPin()[1].z();
+    double mom1 = tracksPin()[0].Mag2();
+    double mom2 = tracksPin()[1].Mag2();
+    double e = sqrt(mom1 + mElec * mElec) + sqrt(mom2 + mElec * mElec);
+    invMass = (e * e - px * px - py * py - pz * pz);
+    if (invMass > 0)
+      invMass = sqrt(invMass);
+    else
       invMass = -1;
   }
-  
+
   return invMass;
 }
 
-double  Conversion::pairCotThetaSeparation() const  {
-  double dCotTheta=-99.;
-  
-  if ( nTracks()==2 ) {
-    double theta1=this->tracksPin()[0].Theta();
-    double theta2=this->tracksPin()[1].Theta();
-    dCotTheta =  1./tan(theta1) - 1./tan(theta2) ;
+double Conversion::pairCotThetaSeparation() const {
+  double dCotTheta = -99.;
+
+  if (nTracks() == 2) {
+    double theta1 = this->tracksPin()[0].Theta();
+    double theta2 = this->tracksPin()[1].Theta();
+    dCotTheta = 1. / tan(theta1) - 1. / tan(theta2);
   }
 
   return dCotTheta;
-
 }
 
-
-math::XYZVectorF  Conversion::pairMomentum() const  {
-  
-  if ( nTracks()==2 ) {
-    return this->tracksPin()[0] +  this->tracksPin()[1];
+math::XYZVectorF Conversion::pairMomentum() const {
+  if (nTracks() == 2) {
+    return this->tracksPin()[0] + this->tracksPin()[1];
   }
-  return math::XYZVectorF(0.,0.,0.);
-
-
-
+  return math::XYZVectorF(0., 0., 0.);
 }
 
-
-math::XYZTLorentzVectorF Conversion::refittedPair4Momentum() const  {
-
+math::XYZTLorentzVectorF Conversion::refittedPair4Momentum() const {
   math::XYZTLorentzVectorF p4;
-  if ( this->conversionVertex().isValid() ) 
-    p4 = this->conversionVertex().p4( 0.000511, 0.5);
+  if (this->conversionVertex().isValid())
+    p4 = this->conversionVertex().p4(0.000511, 0.5);
 
   return p4;
-
-
 }
 
-
-
-math::XYZVectorF  Conversion::refittedPairMomentum() const  {
-
-  if (  this->conversionVertex().isValid() ) {
+math::XYZVectorF Conversion::refittedPairMomentum() const {
+  if (this->conversionVertex().isValid()) {
     return this->refittedPair4Momentum().Vect();
   }
-  return math::XYZVectorF(0.,0.,0.);
-
+  return math::XYZVectorF(0., 0., 0.);
 }
 
+double Conversion::EoverP() const {
+  double ep = -99.;
 
-
-double  Conversion::EoverP() const  {
-
-
-  double ep=-99.;
-
-  if ( nTracks() > 0  ) {
-    unsigned int size= this->caloCluster().size();
-    float etot=0.;
-    for ( unsigned int i=0; i<size; i++) {
-      etot+= caloCluster()[i]->energy();
+  if (nTracks() > 0) {
+    unsigned int size = this->caloCluster().size();
+    float etot = 0.;
+    for (unsigned int i = 0; i < size; i++) {
+      etot += caloCluster()[i]->energy();
     }
-    if (this->pairMomentum().Mag2() !=0) ep= etot/sqrt(this->pairMomentum().Mag2());
+    if (this->pairMomentum().Mag2() != 0)
+      ep = etot / sqrt(this->pairMomentum().Mag2());
   }
 
-
-
-  return ep;  
-
+  return ep;
 }
 
+double Conversion::EoverPrefittedTracks() const {
+  double ep = -99.;
 
-
-double  Conversion::EoverPrefittedTracks() const  {
-
-
-  double ep=-99.;
- 
-  if ( nTracks() > 0  ) {
-    unsigned int size= this->caloCluster().size();
-    float etot=0.;
-    for ( unsigned int i=0; i<size; i++) {
-      etot+= caloCluster()[i]->energy();
+  if (nTracks() > 0) {
+    unsigned int size = this->caloCluster().size();
+    float etot = 0.;
+    for (unsigned int i = 0; i < size; i++) {
+      etot += caloCluster()[i]->energy();
     }
-    if (this->refittedPairMomentum().Mag2() !=0) ep= etot/sqrt(this->refittedPairMomentum().Mag2());
+    if (this->refittedPairMomentum().Mag2() != 0)
+      ep = etot / sqrt(this->refittedPairMomentum().Mag2());
   }
 
-
-
-  return ep;  
-
+  return ep;
 }
 
- 
-
-std::vector<double>  Conversion::tracksSigned_d0() const  {
+std::vector<double> Conversion::tracksSigned_d0() const {
   std::vector<double> result;
   result.reserve(tracks().size());
-  
-  for (auto const& track: tracks()) {
-    result.emplace_back(track->d0()* track->charge()) ;
+
+  for (auto const& track : tracks()) {
+    result.emplace_back(track->d0() * track->charge());
   }
   return result;
 }
 
-double  Conversion::dPhiTracksAtVtx() const  {
-  double result=-99;
-  if  ( nTracks()==2 ) {
+double Conversion::dPhiTracksAtVtx() const {
+  double result = -99;
+  if (nTracks() == 2) {
     result = tracksPin()[0].phi() - tracksPin()[1].phi();
-    if( result   > pi)  { result = result - twopi;}
-    if( result  < -pi)  { result = result + twopi;}
+    if (result > pi) {
+      result = result - twopi;
+    }
+    if (result < -pi) {
+      result = result + twopi;
+    }
   }
 
   return result;
-
-
 }
 
-double  Conversion::dPhiTracksAtEcal() const  {
-  double result =-99.;
-  
-  if (  nTracks()==2  && bcMatchingWithTracks()[0].isNonnull() && bcMatchingWithTracks()[1].isNonnull() ) {
-    
+double Conversion::dPhiTracksAtEcal() const {
+  double result = -99.;
+
+  if (nTracks() == 2 && bcMatchingWithTracks()[0].isNonnull() && bcMatchingWithTracks()[1].isNonnull()) {
     float recoPhi1 = ecalImpactPosition()[0].phi();
-    if( recoPhi1   > pi)  { recoPhi1 = recoPhi1 - twopi;}
-    if( recoPhi1  < -pi)  { recoPhi1 = recoPhi1 + twopi;}
+    if (recoPhi1 > pi) {
+      recoPhi1 = recoPhi1 - twopi;
+    }
+    if (recoPhi1 < -pi) {
+      recoPhi1 = recoPhi1 + twopi;
+    }
 
     float recoPhi2 = ecalImpactPosition()[1].phi();
-    if( recoPhi2   > pi)  { recoPhi2 = recoPhi2 - twopi;}
-    if( recoPhi2  < -pi)  { recoPhi2 = recoPhi2 + twopi;}
+    if (recoPhi2 > pi) {
+      recoPhi2 = recoPhi2 - twopi;
+    }
+    if (recoPhi2 < -pi) {
+      recoPhi2 = recoPhi2 + twopi;
+    }
 
-    result = recoPhi1 -recoPhi2;
+    result = recoPhi1 - recoPhi2;
 
-    if( result   > pi)  { result = result - twopi;}
-    if( result  < -pi)  { result = result + twopi;}
-
+    if (result > pi) {
+      result = result - twopi;
+    }
+    if (result < -pi) {
+      result = result + twopi;
+    }
   }
 
   return result;
-
-
 }
 
-double  Conversion::dEtaTracksAtEcal() const  {
-  double result=-99.;
+double Conversion::dEtaTracksAtEcal() const {
+  double result = -99.;
 
-
-  if ( nTracks()==2 && bcMatchingWithTracks()[0].isNonnull() && bcMatchingWithTracks()[1].isNonnull() ) {
-
-    result =ecalImpactPosition()[0].eta() - ecalImpactPosition()[1].eta();
-
+  if (nTracks() == 2 && bcMatchingWithTracks()[0].isNonnull() && bcMatchingWithTracks()[1].isNonnull()) {
+    result = ecalImpactPosition()[0].eta() - ecalImpactPosition()[1].eta();
   }
 
-
-
   return result;
-
-
 }
 
 double Conversion::dxy(const math::XYZPoint& myBeamSpot) const {
-
-  const reco::Vertex &vtx = conversionVertex();
-  if (!vtx.isValid()) return -9999.;
+  const reco::Vertex& vtx = conversionVertex();
+  if (!vtx.isValid())
+    return -9999.;
 
   math::XYZVectorF mom = refittedPairMomentum();
-  
-  double dxy = (-(vtx.x() - myBeamSpot.x())*mom.y() + (vtx.y() - myBeamSpot.y())*mom.x())/mom.rho();
-  return dxy;  
-  
+
+  double dxy = (-(vtx.x() - myBeamSpot.x()) * mom.y() + (vtx.y() - myBeamSpot.y()) * mom.x()) / mom.rho();
+  return dxy;
 }
 
 double Conversion::dz(const math::XYZPoint& myBeamSpot) const {
-
-  const reco::Vertex &vtx = conversionVertex();
-  if (!vtx.isValid()) return -9999.;
+  const reco::Vertex& vtx = conversionVertex();
+  if (!vtx.isValid())
+    return -9999.;
 
   math::XYZVectorF mom = refittedPairMomentum();
-  
-  double dz = (vtx.z()-myBeamSpot.z()) - ((vtx.x()-myBeamSpot.x())*mom.x()+(vtx.y()-myBeamSpot.y())*mom.y())/mom.rho() * mom.z()/mom.rho();
-  return dz;  
-  
+
+  double dz =
+      (vtx.z() - myBeamSpot.z()) -
+      ((vtx.x() - myBeamSpot.x()) * mom.x() + (vtx.y() - myBeamSpot.y()) * mom.y()) / mom.rho() * mom.z() / mom.rho();
+  return dz;
 }
 
 double Conversion::lxy(const math::XYZPoint& myBeamSpot) const {
-
-  const reco::Vertex &vtx = conversionVertex();
-  if (!vtx.isValid()) return -9999.;
+  const reco::Vertex& vtx = conversionVertex();
+  if (!vtx.isValid())
+    return -9999.;
 
   math::XYZVectorF mom = refittedPairMomentum();
-  
+
   double dbsx = vtx.x() - myBeamSpot.x();
   double dbsy = vtx.y() - myBeamSpot.y();
-  double lxy = (mom.x()*dbsx + mom.y()*dbsy)/mom.rho();
-  return lxy;  
-  
+  double lxy = (mom.x() * dbsx + mom.y() * dbsy) / mom.rho();
+  return lxy;
 }
 
 double Conversion::lz(const math::XYZPoint& myBeamSpot) const {
-
-  const reco::Vertex &vtx = conversionVertex();
-  if (!vtx.isValid()) return -9999.;
+  const reco::Vertex& vtx = conversionVertex();
+  if (!vtx.isValid())
+    return -9999.;
 
   math::XYZVectorF mom = refittedPairMomentum();
-  
-  double lz = (vtx.z() - myBeamSpot.z())*mom.z()/std::abs(mom.z());
-  return lz;  
-  
-}
 
+  double lz = (vtx.z() - myBeamSpot.z()) * mom.z() / std::abs(mom.z());
+  return lz;
+}

--- a/DataFormats/EgammaCandidates/src/Electron.cc
+++ b/DataFormats/EgammaCandidates/src/Electron.cc
@@ -2,33 +2,20 @@
 
 using namespace reco;
 
-Electron::~Electron() { }
+Electron::~Electron() {}
 
-Electron * Electron::clone() const { 
-  return new Electron( * this ); 
-}
+Electron *Electron::clone() const { return new Electron(*this); }
 
-TrackRef Electron::track() const {
-  return track_;
-}
+TrackRef Electron::track() const { return track_; }
 
-GsfTrackRef Electron::gsfTrack() const {
-  return gsfTrack_;
-}
+GsfTrackRef Electron::gsfTrack() const { return gsfTrack_; }
 
-SuperClusterRef Electron::superCluster() const {
-  return superCluster_;
-}
+SuperClusterRef Electron::superCluster() const { return superCluster_; }
 
-bool Electron::overlap( const Candidate & c ) const {
-  const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != nullptr && 
-	   ( checkOverlap( track(), o->track() ) ||
-	     checkOverlap( superCluster(), o->superCluster() ) ) 
-	   );
+bool Electron::overlap(const Candidate &c) const {
+  const RecoCandidate *o = dynamic_cast<const RecoCandidate *>(&c);
+  return (o != nullptr && (checkOverlap(track(), o->track()) || checkOverlap(superCluster(), o->superCluster())));
   return false;
 }
 
-bool Electron::isElectron() const {
-  return true;
-}
+bool Electron::isElectron() const { return true; }

--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -3,140 +3,140 @@
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
 
-using namespace reco ;
+using namespace reco;
 
-GsfElectronCoreRef GsfElectron::core() const { return core_ ; }
+GsfElectronCoreRef GsfElectron::core() const { return core_; }
 
-void GsfElectron::init()
- {
-  passCutBasedPreselection_ = false ;
-  passPflowPreselection_ = false ;
-  passMvaPreslection_ = false ;
-  ambiguous_ = true ;
-  class_ = UNKNOWN ;
- }
+void GsfElectron::init() {
+  passCutBasedPreselection_ = false;
+  passPflowPreselection_ = false;
+  passMvaPreslection_ = false;
+  ambiguous_ = true;
+  class_ = UNKNOWN;
+}
 
-GsfElectron::GsfElectron()
- { init() ; }
+GsfElectron::GsfElectron() { init(); }
 
-GsfElectron::GsfElectron( const GsfElectronCoreRef & core )
- : core_(core)
- { init() ; }
+GsfElectron::GsfElectron(const GsfElectronCoreRef& core) : core_(core) { init(); }
 
-GsfElectron::GsfElectron
- ( int charge, const ChargeInfo & chargeInfo,
-   const GsfElectronCoreRef & core,
-   const TrackClusterMatching & tcm, const TrackExtrapolations & te,
-   const ClosestCtfTrack & ctfInfo,
-   const FiducialFlags & ff, const ShowerShape & ss,
-   const ConversionRejection & crv
- )
- : chargeInfo_(chargeInfo),
-   core_(core),
-   trackClusterMatching_(tcm), trackExtrapolations_(te),
-   //closestCtfTrack_(ctfInfo),
-   fiducialFlags_(ff), showerShape_(ss), conversionRejection_(crv)
- {
-  init() ;
-  setCharge(charge) ;
-  setVertex(math::XYZPoint(te.positionAtVtx.x(),te.positionAtVtx.y(),te.positionAtVtx.z())) ;
-  setPdgId(-11*charge) ;
-  /*if (ecalDrivenSeed())*/ corrections_.correctedEcalEnergy = superCluster()->energy() ;
+GsfElectron::GsfElectron(int charge,
+                         const ChargeInfo& chargeInfo,
+                         const GsfElectronCoreRef& core,
+                         const TrackClusterMatching& tcm,
+                         const TrackExtrapolations& te,
+                         const ClosestCtfTrack& ctfInfo,
+                         const FiducialFlags& ff,
+                         const ShowerShape& ss,
+                         const ConversionRejection& crv)
+    : chargeInfo_(chargeInfo),
+      core_(core),
+      trackClusterMatching_(tcm),
+      trackExtrapolations_(te),
+      //closestCtfTrack_(ctfInfo),
+      fiducialFlags_(ff),
+      showerShape_(ss),
+      conversionRejection_(crv) {
+  init();
+  setCharge(charge);
+  setVertex(math::XYZPoint(te.positionAtVtx.x(), te.positionAtVtx.y(), te.positionAtVtx.z()));
+  setPdgId(-11 * charge);
+  /*if (ecalDrivenSeed())*/ corrections_.correctedEcalEnergy = superCluster()->energy();
   //  assert(ctfInfo.ctfTrack==(GsfElectron::core()->ctfTrack())) ;
   //  assert(ctfInfo.shFracInnerHits==(GsfElectron::core()->ctfGsfOverlap())) ;
- }
+}
 
-GsfElectron::GsfElectron
- ( int charge, const ChargeInfo & chargeInfo,
-   const GsfElectronCoreRef & core,
-   const TrackClusterMatching & tcm, const TrackExtrapolations & te,
-   const ClosestCtfTrack & ctfInfo,
-   const FiducialFlags & ff, const ShowerShape & ss,
-   const ShowerShape& full5x5_ss,
-   const ConversionRejection & crv, 
-   const SaturationInfo& si
- )
- : chargeInfo_(chargeInfo),
-   core_(core),
-   trackClusterMatching_(tcm), trackExtrapolations_(te),
-   fiducialFlags_(ff), showerShape_(ss), full5x5_showerShape_(full5x5_ss), saturationInfo_(si),
-   conversionRejection_(crv)
- {
-  init() ;
-  setCharge(charge) ;
-  setVertex(math::XYZPoint(te.positionAtVtx.x(),te.positionAtVtx.y(),te.positionAtVtx.z())) ;
-  setPdgId(-11*charge) ;
-  corrections_.correctedEcalEnergy = superCluster()->energy() ;
- }
+GsfElectron::GsfElectron(int charge,
+                         const ChargeInfo& chargeInfo,
+                         const GsfElectronCoreRef& core,
+                         const TrackClusterMatching& tcm,
+                         const TrackExtrapolations& te,
+                         const ClosestCtfTrack& ctfInfo,
+                         const FiducialFlags& ff,
+                         const ShowerShape& ss,
+                         const ShowerShape& full5x5_ss,
+                         const ConversionRejection& crv,
+                         const SaturationInfo& si)
+    : chargeInfo_(chargeInfo),
+      core_(core),
+      trackClusterMatching_(tcm),
+      trackExtrapolations_(te),
+      fiducialFlags_(ff),
+      showerShape_(ss),
+      full5x5_showerShape_(full5x5_ss),
+      saturationInfo_(si),
+      conversionRejection_(crv) {
+  init();
+  setCharge(charge);
+  setVertex(math::XYZPoint(te.positionAtVtx.x(), te.positionAtVtx.y(), te.positionAtVtx.z()));
+  setPdgId(-11 * charge);
+  corrections_.correctedEcalEnergy = superCluster()->energy();
+}
 
-GsfElectron::GsfElectron
- ( const GsfElectron & electron,
-   const GsfElectronCoreRef & core )
- : RecoCandidate(electron),
-   chargeInfo_(electron.chargeInfo_),
-   core_(core),
-   trackClusterMatching_(electron.trackClusterMatching_),
-   trackExtrapolations_(electron.trackExtrapolations_),
-   //closestCtfTrack_(electron.closestCtfTrack_),
-   fiducialFlags_(electron.fiducialFlags_),
-   showerShape_(electron.showerShape_),
-   full5x5_showerShape_(electron.full5x5_showerShape_),
-   saturationInfo_(electron.saturationInfo_),
-   dr03_(electron.dr03_), dr04_(electron.dr04_),
-   conversionRejection_(electron.conversionRejection_),
-   pfIso_(electron.pfIso_),
-   mvaInput_(electron.mvaInput_),
-   mvaOutput_(electron.mvaOutput_),
-   passCutBasedPreselection_(electron.passCutBasedPreselection_),
-   passPflowPreselection_(electron.passPflowPreselection_),
-   passMvaPreslection_(electron.passMvaPreslection_),
-   ambiguous_(electron.ambiguous_),
-   ambiguousGsfTracks_(electron.ambiguousGsfTracks_),
-   classVariables_(electron.classVariables_),
-   class_(electron.class_),
-   corrections_(electron.corrections_),
-   pixelMatchVariables_(electron.pixelMatchVariables_)
- {
-   //assert(electron.core()->ctfTrack()==core->ctfTrack()) ;
-   //assert(electron.core()->ctfGsfOverlap()==core->ctfGsfOverlap()) ;
- }
+GsfElectron::GsfElectron(const GsfElectron& electron, const GsfElectronCoreRef& core)
+    : RecoCandidate(electron),
+      chargeInfo_(electron.chargeInfo_),
+      core_(core),
+      trackClusterMatching_(electron.trackClusterMatching_),
+      trackExtrapolations_(electron.trackExtrapolations_),
+      //closestCtfTrack_(electron.closestCtfTrack_),
+      fiducialFlags_(electron.fiducialFlags_),
+      showerShape_(electron.showerShape_),
+      full5x5_showerShape_(electron.full5x5_showerShape_),
+      saturationInfo_(electron.saturationInfo_),
+      dr03_(electron.dr03_),
+      dr04_(electron.dr04_),
+      conversionRejection_(electron.conversionRejection_),
+      pfIso_(electron.pfIso_),
+      mvaInput_(electron.mvaInput_),
+      mvaOutput_(electron.mvaOutput_),
+      passCutBasedPreselection_(electron.passCutBasedPreselection_),
+      passPflowPreselection_(electron.passPflowPreselection_),
+      passMvaPreslection_(electron.passMvaPreslection_),
+      ambiguous_(electron.ambiguous_),
+      ambiguousGsfTracks_(electron.ambiguousGsfTracks_),
+      classVariables_(electron.classVariables_),
+      class_(electron.class_),
+      corrections_(electron.corrections_),
+      pixelMatchVariables_(electron.pixelMatchVariables_) {
+  //assert(electron.core()->ctfTrack()==core->ctfTrack()) ;
+  //assert(electron.core()->ctfGsfOverlap()==core->ctfGsfOverlap()) ;
+}
 
-GsfElectron::GsfElectron
- ( const GsfElectron & electron,
-   const GsfElectronCoreRef & core,
-   const CaloClusterPtr & electronCluster,
-   const TrackRef & closestCtfTrack,
-   const TrackBaseRef & conversionPartner,
-   const GsfTrackRefVector & ambiguousTracks )
- : RecoCandidate(electron),
-   chargeInfo_(electron.chargeInfo_),
-   core_(core),
-   trackClusterMatching_(electron.trackClusterMatching_),
-   trackExtrapolations_(electron.trackExtrapolations_),
-   //closestCtfTrack_(electron.closestCtfTrack_),
-   fiducialFlags_(electron.fiducialFlags_),
-   showerShape_(electron.showerShape_),
-   full5x5_showerShape_(electron.full5x5_showerShape_),
-   saturationInfo_(electron.saturationInfo_),
-   dr03_(electron.dr03_), dr04_(electron.dr04_),
-   conversionRejection_(electron.conversionRejection_),
-   pfIso_(electron.pfIso_),
-   mvaInput_(electron.mvaInput_),
-   mvaOutput_(electron.mvaOutput_),
-   passCutBasedPreselection_(electron.passCutBasedPreselection_),
-   passPflowPreselection_(electron.passPflowPreselection_),
-   passMvaPreslection_(electron.passMvaPreslection_),
-   ambiguous_(electron.ambiguous_),
-   ambiguousGsfTracks_(ambiguousTracks),
-   //mva_(electron.mva_),
-   classVariables_(electron.classVariables_),
-   class_(electron.class_),
-   corrections_(electron.corrections_),
-   pixelMatchVariables_(electron.pixelMatchVariables_)
- {
-  trackClusterMatching_.electronCluster = electronCluster ;
+GsfElectron::GsfElectron(const GsfElectron& electron,
+                         const GsfElectronCoreRef& core,
+                         const CaloClusterPtr& electronCluster,
+                         const TrackRef& closestCtfTrack,
+                         const TrackBaseRef& conversionPartner,
+                         const GsfTrackRefVector& ambiguousTracks)
+    : RecoCandidate(electron),
+      chargeInfo_(electron.chargeInfo_),
+      core_(core),
+      trackClusterMatching_(electron.trackClusterMatching_),
+      trackExtrapolations_(electron.trackExtrapolations_),
+      //closestCtfTrack_(electron.closestCtfTrack_),
+      fiducialFlags_(electron.fiducialFlags_),
+      showerShape_(electron.showerShape_),
+      full5x5_showerShape_(electron.full5x5_showerShape_),
+      saturationInfo_(electron.saturationInfo_),
+      dr03_(electron.dr03_),
+      dr04_(electron.dr04_),
+      conversionRejection_(electron.conversionRejection_),
+      pfIso_(electron.pfIso_),
+      mvaInput_(electron.mvaInput_),
+      mvaOutput_(electron.mvaOutput_),
+      passCutBasedPreselection_(electron.passCutBasedPreselection_),
+      passPflowPreselection_(electron.passPflowPreselection_),
+      passMvaPreslection_(electron.passMvaPreslection_),
+      ambiguous_(electron.ambiguous_),
+      ambiguousGsfTracks_(ambiguousTracks),
+      //mva_(electron.mva_),
+      classVariables_(electron.classVariables_),
+      class_(electron.class_),
+      corrections_(electron.corrections_),
+      pixelMatchVariables_(electron.pixelMatchVariables_) {
+  trackClusterMatching_.electronCluster = electronCluster;
   //closestCtfTrack_.ctfTrack = closestCtfTrack ;
-  conversionRejection_.partner = conversionPartner ;
+  conversionRejection_.partner = conversionPartner;
   //assert(closestCtfTrack==core->ctfTrack()) ;
   //assert(electron.core()->ctfGsfOverlap()==core->ctfGsfOverlap()) ;
   // TO BE DONE
@@ -147,100 +147,89 @@ GsfElectron::GsfElectron
   // * electron.trackClusterMatching_.electronCluster ~ electronCluster ?
   // * electron.closestCtfTrack_.ctfTrack ~ closestCtfTrack ?
   // * electron.ambiguousGsfTracks_ ~ ambiguousTracks ?
- }
+}
 
-bool GsfElectron::overlap( const Candidate & c ) const {
-  const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != nullptr &&
-	   ( checkOverlap( gsfTrack(), o->gsfTrack() ) ||
-	     checkOverlap( superCluster(), o->superCluster() ) )
-	   );
+bool GsfElectron::overlap(const Candidate& c) const {
+  const RecoCandidate* o = dynamic_cast<const RecoCandidate*>(&c);
+  return (o != nullptr && (checkOverlap(gsfTrack(), o->gsfTrack()) || checkOverlap(superCluster(), o->superCluster())));
   //?? return false;
 }
 
-GsfElectron * GsfElectron::clone() const
- { return new GsfElectron(*this) ; }
+GsfElectron* GsfElectron::clone() const { return new GsfElectron(*this); }
 
-GsfElectron * GsfElectron::clone
- (
-  const GsfElectronCoreRef & core,
-  const CaloClusterPtr & electronCluster,
-  const TrackRef & closestCtfTrack,
-  const TrackBaseRef & conversionPartner,
-  const GsfTrackRefVector & ambiguousTracks
- ) const
- { return new GsfElectron(*this,core,electronCluster,closestCtfTrack,conversionPartner,ambiguousTracks) ; }
+GsfElectron* GsfElectron::clone(const GsfElectronCoreRef& core,
+                                const CaloClusterPtr& electronCluster,
+                                const TrackRef& closestCtfTrack,
+                                const TrackBaseRef& conversionPartner,
+                                const GsfTrackRefVector& ambiguousTracks) const {
+  return new GsfElectron(*this, core, electronCluster, closestCtfTrack, conversionPartner, ambiguousTracks);
+}
 
-bool GsfElectron::ecalDriven() const
- {
-  return (ecalDrivenSeed()&&passingCutBasedPreselection()) ;
- }
+bool GsfElectron::ecalDriven() const { return (ecalDrivenSeed() && passingCutBasedPreselection()); }
 
-void GsfElectron::setCorrectedEcalEnergyError( float energyError )
- { corrections_.correctedEcalEnergyError = energyError ; }
+void GsfElectron::setCorrectedEcalEnergyError(float energyError) {
+  corrections_.correctedEcalEnergyError = energyError;
+}
 
-void GsfElectron::setCorrectedEcalEnergy( float newEnergy )
- {
-  math::XYZTLorentzVectorD momentum = p4() ;
-  momentum *= newEnergy/momentum.e() ;
-  setP4(momentum) ;
-  showerShape_.hcalDepth1OverEcal *= corrections_.correctedEcalEnergy/newEnergy ;
-  showerShape_.hcalDepth2OverEcal *= corrections_.correctedEcalEnergy/newEnergy ;
-  trackClusterMatching_.eSuperClusterOverP *= newEnergy/corrections_.correctedEcalEnergy ;
-  corrections_.correctedEcalEnergyError *= newEnergy/corrections_.correctedEcalEnergy ;
-  corrections_.correctedEcalEnergy = newEnergy ;
-  corrections_.isEcalEnergyCorrected = true ;
- }
+void GsfElectron::setCorrectedEcalEnergy(float newEnergy) {
+  math::XYZTLorentzVectorD momentum = p4();
+  momentum *= newEnergy / momentum.e();
+  setP4(momentum);
+  showerShape_.hcalDepth1OverEcal *= corrections_.correctedEcalEnergy / newEnergy;
+  showerShape_.hcalDepth2OverEcal *= corrections_.correctedEcalEnergy / newEnergy;
+  trackClusterMatching_.eSuperClusterOverP *= newEnergy / corrections_.correctedEcalEnergy;
+  corrections_.correctedEcalEnergyError *= newEnergy / corrections_.correctedEcalEnergy;
+  corrections_.correctedEcalEnergy = newEnergy;
+  corrections_.isEcalEnergyCorrected = true;
+}
 
-void GsfElectron::setTrackMomentumError( float trackErr )
- { corrections_.trackMomentumError = trackErr ; }
+void GsfElectron::setTrackMomentumError(float trackErr) { corrections_.trackMomentumError = trackErr; }
 
-void GsfElectron::setP4
- ( P4Kind kind, const reco::Candidate::LorentzVector & p4, float error, bool setCandidate )
- {
-  switch(kind)
-   {
+void GsfElectron::setP4(P4Kind kind, const reco::Candidate::LorentzVector& p4, float error, bool setCandidate) {
+  switch (kind) {
     case P4_FROM_SUPER_CLUSTER:
-      corrections_.fromSuperClusterP4 = p4 ;
-      corrections_.fromSuperClusterP4Error = error ;
-      break ;
+      corrections_.fromSuperClusterP4 = p4;
+      corrections_.fromSuperClusterP4Error = error;
+      break;
     case P4_COMBINATION:
-      corrections_.combinedP4 = p4 ;
-      corrections_.combinedP4Error = error ;
-      break ;
+      corrections_.combinedP4 = p4;
+      corrections_.combinedP4Error = error;
+      break;
     case P4_PFLOW_COMBINATION:
-      corrections_.pflowP4 = p4 ;
-      corrections_.pflowP4Error = error ;
-      break ;
+      corrections_.pflowP4 = p4;
+      corrections_.pflowP4Error = error;
+      break;
     default:
-      throw cms::Exception("GsfElectron")<<"unexpected p4 kind: "<<kind ;
-   }
-  if (setCandidate)
-   {
-    setP4(p4) ;
-    corrections_.candidateP4Kind = kind ;
-   }
- }
+      throw cms::Exception("GsfElectron") << "unexpected p4 kind: " << kind;
+  }
+  if (setCandidate) {
+    setP4(p4);
+    corrections_.candidateP4Kind = kind;
+  }
+}
 
-const Candidate::LorentzVector &  GsfElectron::p4( P4Kind kind ) const
- {
-  switch(kind)
-   {
-    case P4_FROM_SUPER_CLUSTER: return corrections_.fromSuperClusterP4 ;
-    case P4_COMBINATION: return corrections_.combinedP4 ;
-    case P4_PFLOW_COMBINATION: return corrections_.pflowP4 ;
-    default: throw cms::Exception("GsfElectron")<<"unexpected p4 kind: "<<kind ;
-   }
- }
+const Candidate::LorentzVector& GsfElectron::p4(P4Kind kind) const {
+  switch (kind) {
+    case P4_FROM_SUPER_CLUSTER:
+      return corrections_.fromSuperClusterP4;
+    case P4_COMBINATION:
+      return corrections_.combinedP4;
+    case P4_PFLOW_COMBINATION:
+      return corrections_.pflowP4;
+    default:
+      throw cms::Exception("GsfElectron") << "unexpected p4 kind: " << kind;
+  }
+}
 
-
-float GsfElectron::p4Error( P4Kind kind ) const
- {
-  switch(kind)
-   {
-    case P4_FROM_SUPER_CLUSTER: return corrections_.fromSuperClusterP4Error ;
-    case P4_COMBINATION: return corrections_.combinedP4Error ;
-    case P4_PFLOW_COMBINATION: return corrections_.pflowP4Error ;
-    default: throw cms::Exception("GsfElectron")<<"unexpected p4 kind: "<<kind ;
-   }
- }
+float GsfElectron::p4Error(P4Kind kind) const {
+  switch (kind) {
+    case P4_FROM_SUPER_CLUSTER:
+      return corrections_.fromSuperClusterP4Error;
+    case P4_COMBINATION:
+      return corrections_.combinedP4Error;
+    case P4_PFLOW_COMBINATION:
+      return corrections_.pflowP4Error;
+    default:
+      throw cms::Exception("GsfElectron") << "unexpected p4 kind: " << kind;
+  }
+}

--- a/DataFormats/EgammaCandidates/src/GsfElectronCore.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectronCore.cc
@@ -6,32 +6,26 @@
 
 #include <cmath>
 
-using namespace reco ;
+using namespace reco;
 
-GsfElectronCore::GsfElectronCore
- ()
- : ctfGsfOverlap_(0.), isEcalDrivenSeed_(false), isTrackerDrivenSeed_(false)
- {}
+GsfElectronCore::GsfElectronCore() : ctfGsfOverlap_(0.), isEcalDrivenSeed_(false), isTrackerDrivenSeed_(false) {}
 
- GsfElectronCore::GsfElectronCore
-  ( const GsfTrackRef & gsfTrack )
-  : gsfTrack_(gsfTrack), ctfGsfOverlap_(0.), isEcalDrivenSeed_(false), isTrackerDrivenSeed_(false)
-  {
-   edm::RefToBase<TrajectorySeed> seed = gsfTrack_->extra()->seedRef() ;
-   if (seed.isNull())
-    { edm::LogError("GsfElectronCore")<<"The GsfTrack has no seed ?!" ; }
-   else
-    {
-     ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>() ;
-     if (elseed.isNull())
-      { edm::LogError("GsfElectronCore")<<"The GsfTrack seed is not an ElectronSeed ?!" ; }
-     else
-      {
-       if (elseed->isEcalDriven()) isEcalDrivenSeed_ = true ;
-       if (elseed->isTrackerDriven()) isTrackerDrivenSeed_ = true ;
-      }
+GsfElectronCore::GsfElectronCore(const GsfTrackRef& gsfTrack)
+    : gsfTrack_(gsfTrack), ctfGsfOverlap_(0.), isEcalDrivenSeed_(false), isTrackerDrivenSeed_(false) {
+  edm::RefToBase<TrajectorySeed> seed = gsfTrack_->extra()->seedRef();
+  if (seed.isNull()) {
+    edm::LogError("GsfElectronCore") << "The GsfTrack has no seed ?!";
+  } else {
+    ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
+    if (elseed.isNull()) {
+      edm::LogError("GsfElectronCore") << "The GsfTrack seed is not an ElectronSeed ?!";
+    } else {
+      if (elseed->isEcalDriven())
+        isEcalDrivenSeed_ = true;
+      if (elseed->isTrackerDriven())
+        isTrackerDrivenSeed_ = true;
     }
   }
+}
 
-GsfElectronCore * GsfElectronCore::clone() const
- { return new GsfElectronCore(*this) ; }
+GsfElectronCore* GsfElectronCore::clone() const { return new GsfElectronCore(*this); }

--- a/DataFormats/EgammaCandidates/src/Photon.cc
+++ b/DataFormats/EgammaCandidates/src/Photon.cc
@@ -3,206 +3,177 @@
 
 using namespace reco;
 
-Photon::Photon( const LorentzVector & p4,
-		const Point& caloPos,
-    const PhotonCoreRef & core,
-		const Point & vtx) :
-    RecoCandidate( 0, p4, vtx, 22 ),
-    caloPosition_( caloPos ),
-    photonCore_(core),
-    pixelSeed_(false)
- {}
+Photon::Photon(const LorentzVector& p4, const Point& caloPos, const PhotonCoreRef& core, const Point& vtx)
+    : RecoCandidate(0, p4, vtx, 22), caloPosition_(caloPos), photonCore_(core), pixelSeed_(false) {}
 
+Photon::Photon(const Photon& rhs)
+    : RecoCandidate(rhs),
+      caloPosition_(rhs.caloPosition_),
+      photonCore_(rhs.photonCore_),
+      pixelSeed_(rhs.pixelSeed_),
+      fiducialFlagBlock_(rhs.fiducialFlagBlock_),
+      isolationR04_(rhs.isolationR04_),
+      isolationR03_(rhs.isolationR03_),
+      showerShapeBlock_(rhs.showerShapeBlock_),
+      full5x5_showerShapeBlock_(rhs.full5x5_showerShapeBlock_),
+      saturationInfo_(rhs.saturationInfo_),
+      eCorrections_(rhs.eCorrections_),
+      mipVariableBlock_(rhs.mipVariableBlock_),
+      pfIsolation_(rhs.pfIsolation_) {}
 
-Photon::Photon( const Photon& rhs ) :
-  RecoCandidate(rhs),
-  caloPosition_(rhs.caloPosition_),
-  photonCore_ ( rhs.photonCore_),
-  pixelSeed_  ( rhs.pixelSeed_ ),
-  fiducialFlagBlock_ ( rhs.fiducialFlagBlock_ ),
-  isolationR04_ ( rhs.isolationR04_),
-  isolationR03_ ( rhs.isolationR03_),
-  showerShapeBlock_ ( rhs.showerShapeBlock_),
-  full5x5_showerShapeBlock_ ( rhs.full5x5_showerShapeBlock_),
-  saturationInfo_ ( rhs.saturationInfo_ ),
-  eCorrections_(rhs.eCorrections_),
-  mipVariableBlock_ (rhs.mipVariableBlock_),
-  pfIsolation_ ( rhs.pfIsolation_ )
- {}
+Photon::~Photon() {}
 
+Photon* Photon::clone() const { return new Photon(*this); }
 
-
-
-Photon::~Photon() { }
-
-Photon * Photon::clone() const {
-  return new Photon( * this );
-}
-
-
-bool Photon::overlap( const Candidate & c ) const {
-  const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != nullptr &&
-	   ( checkOverlap( superCluster(), o->superCluster() ) )
-	   );
+bool Photon::overlap(const Candidate& c) const {
+  const RecoCandidate* o = dynamic_cast<const RecoCandidate*>(&c);
+  return (o != nullptr && (checkOverlap(superCluster(), o->superCluster())));
   return false;
 }
 
-void Photon::setVertex(const Point & vertex) {
+void Photon::setVertex(const Point& vertex) {
   math::XYZVectorF direction = caloPosition() - vertex;
   double energy = this->energy();
   math::XYZVectorF momentum = direction.unit() * energy;
-  math::XYZTLorentzVector lv(momentum.x(), momentum.y(), momentum.z(), energy );
+  math::XYZTLorentzVector lv(momentum.x(), momentum.y(), momentum.z(), energy);
   setP4(lv);
   LeafCandidate::setVertex(vertex);
 }
 
-reco::SuperClusterRef Photon::superCluster() const {
-  return this->photonCore()->superCluster();
-}
+reco::SuperClusterRef Photon::superCluster() const { return this->photonCore()->superCluster(); }
 
-int Photon::conversionTrackProvenance(const edm::RefToBase<reco::Track>& convTrack) const{
-
-  const reco::ConversionRefVector & conv2leg = this->photonCore()->conversions();
-  const reco::ConversionRefVector & conv1leg = this->photonCore()->conversionsOneLeg();
+int Photon::conversionTrackProvenance(const edm::RefToBase<reco::Track>& convTrack) const {
+  const reco::ConversionRefVector& conv2leg = this->photonCore()->conversions();
+  const reco::ConversionRefVector& conv1leg = this->photonCore()->conversionsOneLeg();
 
   int origin = -1;
-  bool isEg=false, isPf=false;
+  bool isEg = false, isPf = false;
 
-  for (unsigned iConv=0; iConv<conv2leg.size(); iConv++){
+  for (unsigned iConv = 0; iConv < conv2leg.size(); iConv++) {
     std::vector<edm::RefToBase<reco::Track> > convtracks = conv2leg[iConv]->tracks();
-    for (unsigned itk=0; itk<convtracks.size(); itk++){
-      if (convTrack==convtracks[itk]) isEg=true;
+    for (unsigned itk = 0; itk < convtracks.size(); itk++) {
+      if (convTrack == convtracks[itk])
+        isEg = true;
     }
   }
 
-  for (unsigned iConv=0; iConv<conv1leg.size(); iConv++){
+  for (unsigned iConv = 0; iConv < conv1leg.size(); iConv++) {
     std::vector<edm::RefToBase<reco::Track> > convtracks = conv1leg[iConv]->tracks();
-    for (unsigned itk=0; itk<convtracks.size(); itk++){
-      if (convTrack==convtracks[itk]) isPf=true;
+    for (unsigned itk = 0; itk < convtracks.size(); itk++) {
+      if (convTrack == convtracks[itk])
+        isPf = true;
     }
   }
 
-  if (isEg) origin=egamma;
-  if (isPf) origin=pflow;
-  if (isEg && isPf) origin=both;
+  if (isEg)
+    origin = egamma;
+  if (isPf)
+    origin = pflow;
+  if (isEg && isPf)
+    origin = both;
 
   return origin;
 }
 
-
-void Photon::setCorrectedEnergy( P4type type, float newEnergy, float delta_e,  bool setToRecoCandidate ) {
-
-  math::XYZTLorentzVectorD newP4 = p4() ;
-  newP4 *= newEnergy/newP4.e() ;
-  switch(type)
-    {
+void Photon::setCorrectedEnergy(P4type type, float newEnergy, float delta_e, bool setToRecoCandidate) {
+  math::XYZTLorentzVectorD newP4 = p4();
+  newP4 *= newEnergy / newP4.e();
+  switch (type) {
     case ecal_standard:
       eCorrections_.scEcalEnergy = newEnergy;
       eCorrections_.scEcalEnergyError = delta_e;
-      break ;
+      break;
     case ecal_photons:
       eCorrections_.phoEcalEnergy = newEnergy;
       eCorrections_.phoEcalEnergyError = delta_e;
-      break ;
-    case  regression1:
-      eCorrections_.regression1Energy = newEnergy ;
+      break;
+    case regression1:
+      eCorrections_.regression1Energy = newEnergy;
       eCorrections_.regression1EnergyError = delta_e;
-    case  regression2:
-      eCorrections_.regression2Energy = newEnergy ;
+    case regression2:
+      eCorrections_.regression2Energy = newEnergy;
       eCorrections_.regression2EnergyError = delta_e;
-      break ;
+      break;
     default:
-      throw cms::Exception("reco::Photon")<<"unexpected p4 type: "<< type ;
-    }
-  setP4(type, newP4,  delta_e,  setToRecoCandidate); 
-
+      throw cms::Exception("reco::Photon") << "unexpected p4 type: " << type;
+  }
+  setP4(type, newP4, delta_e, setToRecoCandidate);
 }
 
-
-
-
- float  Photon::getCorrectedEnergy( P4type type) const {
-  switch(type)
-    {
+float Photon::getCorrectedEnergy(P4type type) const {
+  switch (type) {
     case ecal_standard:
-      return      eCorrections_.scEcalEnergy;
-      break ;
+      return eCorrections_.scEcalEnergy;
+      break;
     case ecal_photons:
       return eCorrections_.phoEcalEnergy;
-      break ;
-    case  regression1:
+      break;
+    case regression1:
       return eCorrections_.regression1Energy;
-    case  regression2:
+    case regression2:
       return eCorrections_.regression2Energy;
-      break ;
+      break;
     default:
-      throw cms::Exception("reco::Photon")<<"unexpected p4 type " << type << " cannot return the energy value: " ;
-   }
- }
-
-
- float  Photon::getCorrectedEnergyError( P4type type) const {
-  switch(type)
-    {
-    case ecal_standard:
-      return      eCorrections_.scEcalEnergyError;
-      break ;
-    case ecal_photons:
-      return eCorrections_.phoEcalEnergyError;
-      break ;
-    case  regression1:
-      return eCorrections_.regression1EnergyError;
-    case  regression2:
-      return eCorrections_.regression2EnergyError;
-      break ;
-    default:
-      throw cms::Exception("reco::Photon")<<"unexpected p4 type " << type << " cannot return the uncertainty on the energy: " ;
-   }
- }
-
-
-
-void Photon::setP4(P4type type, const LorentzVector & p4, float error, bool setToRecoCandidate ) {
-
-
-  switch(type)
-   {
-    case ecal_standard:
-      eCorrections_.scEcalP4 = p4 ;
-      eCorrections_.scEcalEnergyError = error ;
-      break ;
-    case ecal_photons:
-      eCorrections_.phoEcalP4 = p4 ;
-      eCorrections_.phoEcalEnergyError = error ;
-      break ;
-    case  regression1:
-      eCorrections_.regression1P4 = p4 ;
-      eCorrections_.regression1EnergyError = error ;
-    case  regression2:
-      eCorrections_.regression2P4 = p4 ;
-      eCorrections_.regression2EnergyError = error ;
-      break ;
-    default:
-      throw cms::Exception("reco::Photon")<<"unexpected p4 type: "<< type ;
-   }
-  if (setToRecoCandidate)
-   {
-    setP4(p4) ;
-    eCorrections_.candidateP4type = type ;
-   }
-
-
+      throw cms::Exception("reco::Photon") << "unexpected p4 type " << type << " cannot return the energy value: ";
+  }
 }
 
-const Candidate::LorentzVector& Photon::p4( P4type type ) const
- {
-  switch(type)
-    {
-    case ecal_standard: return eCorrections_.scEcalP4 ;
-    case ecal_photons: return eCorrections_.phoEcalP4 ;
-    case regression1: return eCorrections_.regression1P4 ;
-    case regression2: return eCorrections_.regression2P4 ;
-    default: throw cms::Exception("reco::Photon")<<"unexpected p4 type: "<< type << " cannot return p4 ";
-   }
- }
+float Photon::getCorrectedEnergyError(P4type type) const {
+  switch (type) {
+    case ecal_standard:
+      return eCorrections_.scEcalEnergyError;
+      break;
+    case ecal_photons:
+      return eCorrections_.phoEcalEnergyError;
+      break;
+    case regression1:
+      return eCorrections_.regression1EnergyError;
+    case regression2:
+      return eCorrections_.regression2EnergyError;
+      break;
+    default:
+      throw cms::Exception("reco::Photon")
+          << "unexpected p4 type " << type << " cannot return the uncertainty on the energy: ";
+  }
+}
+
+void Photon::setP4(P4type type, const LorentzVector& p4, float error, bool setToRecoCandidate) {
+  switch (type) {
+    case ecal_standard:
+      eCorrections_.scEcalP4 = p4;
+      eCorrections_.scEcalEnergyError = error;
+      break;
+    case ecal_photons:
+      eCorrections_.phoEcalP4 = p4;
+      eCorrections_.phoEcalEnergyError = error;
+      break;
+    case regression1:
+      eCorrections_.regression1P4 = p4;
+      eCorrections_.regression1EnergyError = error;
+    case regression2:
+      eCorrections_.regression2P4 = p4;
+      eCorrections_.regression2EnergyError = error;
+      break;
+    default:
+      throw cms::Exception("reco::Photon") << "unexpected p4 type: " << type;
+  }
+  if (setToRecoCandidate) {
+    setP4(p4);
+    eCorrections_.candidateP4type = type;
+  }
+}
+
+const Candidate::LorentzVector& Photon::p4(P4type type) const {
+  switch (type) {
+    case ecal_standard:
+      return eCorrections_.scEcalP4;
+    case ecal_photons:
+      return eCorrections_.phoEcalP4;
+    case regression1:
+      return eCorrections_.regression1P4;
+    case regression2:
+      return eCorrections_.regression2P4;
+    default:
+      throw cms::Exception("reco::Photon") << "unexpected p4 type: " << type << " cannot return p4 ";
+  }
+}

--- a/DataFormats/EgammaCandidates/src/SiStripElectron.cc
+++ b/DataFormats/EgammaCandidates/src/SiStripElectron.cc
@@ -2,7 +2,7 @@
 //
 // Package:     EgammaCandidates
 // Class  :     SiStripElectron
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -14,7 +14,7 @@
 
 // user include files
 #include "DataFormats/EgammaCandidates/interface/SiStripElectron.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h" 
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 using namespace reco;
 
@@ -35,7 +35,7 @@ using namespace reco;
 //    // do actual copying here;
 // }
 
-SiStripElectron::~SiStripElectron() { }
+SiStripElectron::~SiStripElectron() {}
 
 //
 // assignment operators
@@ -49,31 +49,21 @@ SiStripElectron::~SiStripElectron() { }
 //   return *this;
 // }
 
-SiStripElectron * SiStripElectron::clone() const { 
-  return new SiStripElectron( * this ); 
-}
+SiStripElectron *SiStripElectron::clone() const { return new SiStripElectron(*this); }
 
 //
 // member functions
 //
 
-SuperClusterRef SiStripElectron::superCluster() const {
-  return superCluster_;
-}
+SuperClusterRef SiStripElectron::superCluster() const { return superCluster_; }
 
-bool SiStripElectron::overlap( const Candidate & c ) const {
-  const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != nullptr && ! 
-	   ( checkOverlap( track(), o->track() ) ||
-	     checkOverlap( superCluster(), o->superCluster() ) ) 
-	   );
+bool SiStripElectron::overlap(const Candidate &c) const {
+  const RecoCandidate *o = dynamic_cast<const RecoCandidate *>(&c);
+  return (o != nullptr && !(checkOverlap(track(), o->track()) || checkOverlap(superCluster(), o->superCluster())));
   return false;
 }
 
-bool SiStripElectron::isElectron() const {
-  return true;
-}
-
+bool SiStripElectron::isElectron() const { return true; }
 
 //
 // const member functions


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/402//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


