### PR TITLE
HCAL: making ped.width ADC2fC ped.-aware

### DIFF
--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -139,6 +139,7 @@ private:
   bool convertPedestals(const HcalGenericDetId& fId, const HcalPedestal* pedestal, float* pedTrue, bool inADC) const;
   bool convertPedestalWidths(const HcalGenericDetId& fId,
                              const HcalPedestalWidth* pedestalwidth,
+                             const HcalPedestal* pedestal,
                              float* pedTrueWidth,
                              bool inADC) const;
   const HcalPedestals* mPedestals;

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -205,6 +205,7 @@ bool HcalDbService::makeHcalCalibration(const HcalGenericDetId& fId,
 
 bool HcalDbService::convertPedestalWidths(const HcalGenericDetId& fId,
                                           const HcalPedestalWidth* pedestalwidth,
+                                          const HcalPedestal* pedestal,
                                           float* pedTrueWidth,
                                           bool inADC) const {
   if (!pedestalwidth)
@@ -223,10 +224,11 @@ bool HcalDbService::convertPedestalWidths(const HcalGenericDetId& fId,
       pedTrueWidth[i] = x;
       continue;
     }
-    // assume QIE is linear in low range and use x1=0 and x2=1
-    // y = (y2-y1) * (x) [do not add any constant, only scale!]
-    float y2 = coder->charge(*shape, 1, i);
-    float y1 = coder->charge(*shape, 0, i);
+    float  y = pedestal->getValues()[i];
+    int   x1 = (int)std::floor(y);
+    int   x2 = (int)std::floor(y + 1.);
+    float y1 = coder->charge(*shape, x1, i);
+    float y2 = coder->charge(*shape, x2, i);
     pedTrueWidth[i] = (y2 - y1) * x;
   }
   return true;
@@ -237,15 +239,18 @@ bool HcalDbService::makeHcalCalibrationWidth(const HcalGenericDetId& fId,
                                              bool pedestalInADC,
                                              bool effPedestalInADC) const {
   if (fObject) {
+    const HcalPedestal* pedestal = getPedestal(fId);
+    const HcalPedestal* effpedestal = getEffectivePedestal(fId);
+
     const HcalPedestalWidth* pedestalwidth = getPedestalWidth(fId);
     const HcalPedestalWidth* effpedestalwidth = getEffectivePedestalWidth(fId);
     const HcalGainWidth* gainwidth = getGainWidth(fId);
 
     float pedTrueWidth[4];
-    bool converted = convertPedestalWidths(fId, pedestalwidth, pedTrueWidth, pedestalInADC);
+    bool converted = convertPedestalWidths(fId, pedestalwidth, pedestal, pedTrueWidth, pedestalInADC);
 
     float effPedTrueWidth[4];
-    bool effconverted = convertPedestalWidths(fId, effpedestalwidth, effPedTrueWidth, effPedestalInADC);
+    bool effconverted = convertPedestalWidths(fId, effpedestalwidth, effpedestal, effPedTrueWidth, effPedestalInADC);
     if (pedestalwidth && effpedestalwidth && gainwidth && converted && effconverted) {
       *fObject = HcalCalibrationWidths(gainwidth->getValues(), pedTrueWidth, effPedTrueWidth);
       return true;

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -224,9 +224,9 @@ bool HcalDbService::convertPedestalWidths(const HcalGenericDetId& fId,
       pedTrueWidth[i] = x;
       continue;
     }
-    float  y = pedestal->getValues()[i];
-    int   x1 = (int)std::floor(y);
-    int   x2 = (int)std::floor(y + 1.);
+    float y = pedestal->getValues()[i];
+    int x1 = (int)std::floor(y);
+    int x2 = (int)std::floor(y + 1.);
     float y1 = coder->charge(*shape, x1, i);
     float y2 = coder->charge(*shape, x2, i);
     pedTrueWidth[i] = (y2 - y1) * x;

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -225,10 +225,11 @@ bool HcalDbService::convertPedestalWidths(const HcalGenericDetId& fId,
       continue;
     }
     float y = pedestal->getValues()[i];
-    int x1 = (int)std::floor(y);
-    int x2 = (int)std::floor(y + 1.);
-    float y1 = coder->charge(*shape, x1, i);
-    float y2 = coder->charge(*shape, x2, i);
+    unsigned x1 = static_cast<unsigned>(std::floor(y));
+    unsigned x2 = static_cast<unsigned>(std::floor(y + 1.));
+    unsigned iun = static_cast<unsigned>(i);
+    float y1 = coder->charge(*shape, x1, iun);
+    float y2 = coder->charge(*shape, x2, iun);
     pedTrueWidth[i] = (y2 - y1) * x;
   }
   return true;


### PR DESCRIPTION
#### PR description:

Old pedestal width conversion from ADC to fC assumed the values are small and lie within (linear) 1st sub-range of 1st range of QIE calibration. This assumption is no more valid for high HB/HE (SiPMs-dark-current-related) effective pedestals and ped.widths at the end of Run3.  
An issue has been observed in Run3 2023/2024 MC tests and is fixed by this PR. 

#### PR validation:

runTheMatris -s  is OK

Private sanity check test with pion gun "CaloScan" for Run3 2021 shows no difference  (modulo Digi rndm sequence change)

https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/11_X/11_0_X_run3_pedfix_vs_11_0_0_pre2_run3_SinglePi/

#### if this PR is a backport please specify the original PR:

This PR affects(fixes) solely end-of-Run3 MC. 
Eras <=2018, regular Run3_2021 and Phase2 are OK without it.
May *not need* back-porting, if HCAL will submit updated end-of-Run3 ("2023,2024") pedestals & ped.widths in fC.

