### PR TITLE
Fix boosted double s vmodule master

### DIFF
--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -674,12 +674,13 @@ BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef & jet, float &
             edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
         }
       }
-      else{
+      else
+	{
 	// Check if any values were nan or inf
 	float valcheck = daughter->px() + daughter->py() +  daughter->pz() + daughter->energy();
 	if (std::isnan(valcheck) || std::isinf(valcheck)) continue;
         fjParticles.push_back( fastjet::PseudoJet( daughter->px(), daughter->py(), daughter->pz(), daughter->energy() ) );
-      }
+	}
     }
     else
       edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";

--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -674,8 +674,12 @@ BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef & jet, float &
             edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
         }
       }
-      else
+      else{
+	// Check if any values were nan or inf
+	float valcheck = daughter->px() + daughter->py() +  daughter->pz() + daughter->energy();
+	if (std::isnan(valcheck) || std::isinf(valcheck)) continue;
         fjParticles.push_back( fastjet::PseudoJet( daughter->px(), daughter->py(), daughter->pz(), daughter->energy() ) );
+      }
     }
     else
       edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";


### PR DESCRIPTION
#### PR description:

Fix for a problem reported in https://its.cern.ch/jira/browse/CMSCOMPPR-6445. Crashes caused by daughters with nan/inf values. Protection is added.

#### PR validation:

Local test, minor straightforward change
