### PR TITLE
Revert "Add some reset calls to TrackingMonitorClient."

### DIFF
--- a/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
@@ -363,17 +363,6 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker & ibooker, DQM
     }
   }
 
-  // After harvesting, all per-lumi MEs are reset, to make sure we only get
-  // events of the new lumisection next time.
-  for (std::map<std::string, TrackingMEs>::iterator it = TrackingMEsMap.begin();
-       it != TrackingMEsMap.end(); it++) {
-    std::string localMEdirpath = it->second.HistoDir;
-    std::vector<MonitorElement*> tmpMEvec = igetter.getContents(ibooker.pwd()+"/"+localMEdirpath);
-    for ( auto ime : tmpMEvec ) {
-      ime->Reset();
-    }
-  }
-
   if (verbose_) std::cout << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus << std::endl;  
   size_t nQT = TrackingMEsMap.size();
   if (gstatus < 1.) gstatus = -1.;


### PR DESCRIPTION
This reverts commit a0c43f3ea4e248d9b0b318bc1b566f1e8f36e5c0.

#### PR description:

@mmusich suspects that this is causing too many plots to be reset. So let's try without it.
This might cause double counting in other places, lets see.

#### PR validation:

none.

#### if this PR is a backport please specify the original PR:

Needs forward port if tests agree.