### PR TITLE
Fix BoostedDoubleSVProd crashing with nan/inf daughters

### DIFF
--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -653,8 +653,11 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
           if (constit) {
             // Check if any values were nan or inf
             float valcheck = constit->px() + constit->py() + constit->pz() + constit->energy();
-            if (edm::isNotFinite(valcheck))
+            if (edm::isNotFinite(valcheck)) {
+              edm::LogWarning("FaultyJetConstituent")
+                  << "Jet constituent required for N-subjettiness computation contains Nan/Inf values!";
               continue;
+            }
             fjParticles.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
           } else
             edm::LogWarning("MissingJetConstituent")
@@ -663,8 +666,11 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
       } else {
         // Check if any values were nan or inf
         float valcheck = daughter->px() + daughter->py() + daughter->pz() + daughter->energy();
-        if (edm::isNotFinite(valcheck))
+        if (edm::isNotFinite(valcheck)) {
+          edm::LogWarning("FaultyJetConstituent")
+              << "Jet constituent required for N-subjettiness computation contains Nan/Inf values!";
           continue;
+        }
         fjParticles.push_back(fastjet::PseudoJet(daughter->px(), daughter->py(), daughter->pz(), daughter->energy()));
       }
     } else

--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -656,7 +656,12 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
                 << "Jet constituent required for N-subjettiness computation is missing!";
         }
       } else
+	{
+        // Check if any values were nan or inf
+          float valcheck = daughter->px() + daughter->py() +  daughter->pz() + daughter->energy();
+          if (std::isnan(valcheck) || std::isinf(valcheck)) continue;
         fjParticles.push_back(fastjet::PseudoJet(daughter->px(), daughter->py(), daughter->pz(), daughter->energy()));
+        }
     } else
       edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
   }

--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -655,13 +655,13 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
             edm::LogWarning("MissingJetConstituent")
                 << "Jet constituent required for N-subjettiness computation is missing!";
         }
-      } else
-	{
+      } else {
         // Check if any values were nan or inf
-          float valcheck = daughter->px() + daughter->py() +  daughter->pz() + daughter->energy();
-          if (std::isnan(valcheck) || std::isinf(valcheck)) continue;
+        float valcheck = daughter->px() + daughter->py() + daughter->pz() + daughter->energy();
+        if (std::isnan(valcheck) || std::isinf(valcheck))
+          continue;
         fjParticles.push_back(fastjet::PseudoJet(daughter->px(), daughter->py(), daughter->pz(), daughter->energy()));
-        }
+      }
     } else
       edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
   }

--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -29,6 +29,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 #include "DataFormats/BTauReco/interface/CandIPTagInfo.h"
 #include "DataFormats/BTauReco/interface/CandSecondaryVertexTagInfo.h"
@@ -649,16 +650,20 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
         for (size_t i = 0; i < daughter->numberOfDaughters(); ++i) {
           const reco::Candidate* constit = daughter->daughter(i);
 
-          if (constit)
+          if (constit) {
+            // Check if any values were nan or inf
+            float valcheck = constit->px() + constit->py() + constit->pz() + constit->energy();
+            if (edm::isNotFinite(valcheck))
+              continue;
             fjParticles.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
-          else
+          } else
             edm::LogWarning("MissingJetConstituent")
                 << "Jet constituent required for N-subjettiness computation is missing!";
         }
       } else {
         // Check if any values were nan or inf
         float valcheck = daughter->px() + daughter->py() + daughter->pz() + daughter->energy();
-        if (std::isnan(valcheck) || std::isinf(valcheck))
+        if (edm::isNotFinite(valcheck))
           continue;
         fjParticles.push_back(fastjet::PseudoJet(daughter->px(), daughter->py(), daughter->pz(), daughter->energy()));
       }


### PR DESCRIPTION
#### PR description:

Fix for a problem reported in https://its.cern.ch/jira/browse/CMSCOMPPR-6445. Crashes caused by daughters with nan/inf values. Protection is added.

#### PR validation:

Local test, minor straightforward change