### PR TITLE
DQM/Tracking: Improve the per-lumi fix [10_6_X]

### DIFF
--- a/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
@@ -370,7 +370,9 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker & ibooker, DQM
     std::string localMEdirpath = it->second.HistoDir;
     std::vector<MonitorElement*> tmpMEvec = igetter.getContents(ibooker.pwd()+"/"+localMEdirpath);
     for ( auto ime : tmpMEvec ) {
-      ime->Reset();
+      if (ime->getLumiFlag()) {
+        ime->Reset();
+      }
     }
   }
 


### PR DESCRIPTION

#### PR description:

The fix for double counting in a0c43f3ea4e248d seems to be a bit aggressive. It seems to have reset some MEs that are not per-lumi, so check for that.


#### PR validation:
Bin-to-bin comparison shows the plots in question re-populated.

#### if this PR is a backport please specify the original PR:

This is used instead of #27237, and a backport of #27246. 