### PR TITLE
Modernize HGCalTriggerGeometryESProducer

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -8,7 +8,6 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/CaloTopology/interface/HGCalTopology.h"
@@ -28,30 +27,30 @@ public:
 
   const std::string& name() const { return name_; }
 
-  bool isV9Geometry() const { return !calo_geometry_.isValid(); }
-  const edm::ESHandle<CaloGeometry>& caloGeometry() const { return calo_geometry_; }
+  bool isV9Geometry() const { return !calo_geometry_; }
+  const CaloGeometry* caloGeometry() const { return calo_geometry_; }
   const HGCalGeometry* eeGeometry() const {
-    return (hgc_ee_geometry_.isValid()
-                ? hgc_ee_geometry_.product()
+    return (hgc_ee_geometry_
+                ? hgc_ee_geometry_
                 : (static_cast<const HGCalGeometry*>(calo_geometry_->getSubdetectorGeometry(DetId::Forward, HGCEE))));
   }
   const HGCalGeometry* fhGeometry() const {
-    return (hgc_hsi_geometry_.isValid()
-                ? hgc_hsi_geometry_.product()
+    return (hgc_hsi_geometry_
+                ? hgc_hsi_geometry_
                 : (static_cast<const HGCalGeometry*>(calo_geometry_->getSubdetectorGeometry(DetId::Forward, HGCHEF))));
   }
   const HcalGeometry* bhGeometry() const {
-    if (hgc_hsc_geometry_.isValid()) {
+    if (hgc_hsc_geometry_) {
       throw cms::Exception("HGCalTriggerGeometry") << "bhGeometry cannot be used with the V9 geometry";
     }
     return (static_cast<const HcalGeometry*>(calo_geometry_->getSubdetectorGeometry(DetId::Hcal, HcalEndcap)));
   }
   const HGCalGeometry* hsiGeometry() const { return fhGeometry(); }
   const HGCalGeometry* hscGeometry() const {
-    if (!hgc_hsc_geometry_.isValid()) {
+    if (!hgc_hsc_geometry_) {
       throw cms::Exception("HGCalTriggerGeometry") << "hscGeometry cannot be used with the V7 and V8 geometries";
     }
-    return hgc_hsc_geometry_.product();
+    return hgc_hsc_geometry_;
   }
   const HGCalTopology& eeTopology() const { return eeGeometry()->topology(); }
   const HGCalTopology& fhTopology() const { return fhGeometry()->topology(); }
@@ -60,10 +59,8 @@ public:
   const HGCalTopology& hscTopology() const { return hscGeometry()->topology(); }
 
   // non-const access to the geometry class
-  virtual void initialize(const edm::ESHandle<CaloGeometry>&) = 0;
-  virtual void initialize(const edm::ESHandle<HGCalGeometry>&,
-                          const edm::ESHandle<HGCalGeometry>&,
-                          const edm::ESHandle<HGCalGeometry>&) = 0;
+  virtual void initialize(const CaloGeometry*) = 0;
+  virtual void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) = 0;
   virtual void reset();
 
   // const access to the geometry class
@@ -92,18 +89,18 @@ public:
   virtual unsigned triggerLayer(const unsigned id) const = 0;
 
 protected:
-  void setCaloGeometry(const edm::ESHandle<CaloGeometry>& geom) { calo_geometry_ = geom; }
-  void setEEGeometry(const edm::ESHandle<HGCalGeometry>& geom) { hgc_ee_geometry_ = geom; }
-  void setHSiGeometry(const edm::ESHandle<HGCalGeometry>& geom) { hgc_hsi_geometry_ = geom; }
-  void setHScGeometry(const edm::ESHandle<HGCalGeometry>& geom) { hgc_hsc_geometry_ = geom; }
+  void setCaloGeometry(const CaloGeometry* geom) { calo_geometry_ = geom; }
+  void setEEGeometry(const HGCalGeometry* geom) { hgc_ee_geometry_ = geom; }
+  void setHSiGeometry(const HGCalGeometry* geom) { hgc_hsi_geometry_ = geom; }
+  void setHScGeometry(const HGCalGeometry* geom) { hgc_hsc_geometry_ = geom; }
 
 private:
   const std::string name_;
 
-  edm::ESHandle<CaloGeometry> calo_geometry_;
-  edm::ESHandle<HGCalGeometry> hgc_ee_geometry_;
-  edm::ESHandle<HGCalGeometry> hgc_hsi_geometry_;
-  edm::ESHandle<HGCalGeometry> hgc_hsc_geometry_;
+  const CaloGeometry* calo_geometry_ = nullptr;
+  const HGCalGeometry* hgc_ee_geometry_ = nullptr;
+  const HGCalGeometry* hgc_hsi_geometry_ = nullptr;
+  const HGCalGeometry* hgc_hsc_geometry_ = nullptr;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerGeometryESProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerGeometryESProducer.cc
@@ -3,7 +3,6 @@
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESProducts.h"
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
@@ -22,12 +21,20 @@ public:
 private:
   edm::ParameterSet geometry_config_;
   std::string geometry_name_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> calo_geometry_token_;
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> ee_geometry_token_;
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> hsi_geometry_token_;
+  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> hsc_geometry_token_;
 };
 
 HGCalTriggerGeometryESProducer::HGCalTriggerGeometryESProducer(const edm::ParameterSet& iConfig)
     : geometry_config_(iConfig.getParameterSet("TriggerGeometry")),
       geometry_name_(geometry_config_.getParameter<std::string>("TriggerGeometryName")) {
-  setWhatProduced(this);
+  setWhatProduced(this)
+      .setConsumes(calo_geometry_token_)
+      .setConsumes(ee_geometry_token_, edm::ESInputTag{"", "HGCalEESensitive"})
+      .setConsumes(hsi_geometry_token_, edm::ESInputTag{"", "HGCalHESiliconSensitive"})
+      .setConsumes(hsc_geometry_token_, edm::ESInputTag{"", "HGCalHEScintillatorSensitive"});
 }
 
 HGCalTriggerGeometryESProducer::~HGCalTriggerGeometryESProducer() {
@@ -39,8 +46,7 @@ HGCalTriggerGeometryESProducer::ReturnType HGCalTriggerGeometryESProducer::produ
   //using namespace edm::es;
   ReturnType geometry(HGCalTriggerGeometryFactory::get()->create(geometry_name_, geometry_config_));
   geometry->reset();
-  edm::ESHandle<CaloGeometry> calo_geometry;
-  iRecord.get(calo_geometry);
+  auto calo_geometry = iRecord.getHandle(calo_geometry_token_);
   // Initialize trigger geometry for V7/V8 HGCAL geometry
   if (calo_geometry.isValid() && calo_geometry->getSubdetectorGeometry(DetId::Forward, HGCEE) &&
       calo_geometry->getSubdetectorGeometry(DetId::Forward, HGCHEF) &&
@@ -49,13 +55,8 @@ HGCalTriggerGeometryESProducer::ReturnType HGCalTriggerGeometryESProducer::produ
   }
   // Initialize trigger geometry for V9 HGCAL geometry
   else {
-    edm::ESHandle<HGCalGeometry> ee_geometry;
-    edm::ESHandle<HGCalGeometry> hsi_geometry;
-    edm::ESHandle<HGCalGeometry> hsc_geometry;
-    iRecord.getRecord<IdealGeometryRecord>().get("HGCalEESensitive", ee_geometry);
-    iRecord.getRecord<IdealGeometryRecord>().get("HGCalHESiliconSensitive", hsi_geometry);
-    iRecord.getRecord<IdealGeometryRecord>().get("HGCalHEScintillatorSensitive", hsc_geometry);
-    geometry->initialize(ee_geometry.product(), hsi_geometry.product(), hsc_geometry.product());
+    geometry->initialize(
+        &iRecord.get(ee_geometry_token_), &iRecord.get(hsi_geometry_token_), &iRecord.get(hsc_geometry_token_));
   }
   return geometry;
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerGeometryESProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerGeometryESProducer.cc
@@ -45,7 +45,7 @@ HGCalTriggerGeometryESProducer::ReturnType HGCalTriggerGeometryESProducer::produ
   if (calo_geometry.isValid() && calo_geometry->getSubdetectorGeometry(DetId::Forward, HGCEE) &&
       calo_geometry->getSubdetectorGeometry(DetId::Forward, HGCHEF) &&
       calo_geometry->getSubdetectorGeometry(DetId::Hcal, HcalEndcap)) {
-    geometry->initialize(calo_geometry);
+    geometry->initialize(calo_geometry.product());
   }
   // Initialize trigger geometry for V9 HGCAL geometry
   else {
@@ -55,7 +55,7 @@ HGCalTriggerGeometryESProducer::ReturnType HGCalTriggerGeometryESProducer::produ
     iRecord.getRecord<IdealGeometryRecord>().get("HGCalEESensitive", ee_geometry);
     iRecord.getRecord<IdealGeometryRecord>().get("HGCalHESiliconSensitive", hsi_geometry);
     iRecord.getRecord<IdealGeometryRecord>().get("HGCalHEScintillatorSensitive", hsc_geometry);
-    geometry->initialize(ee_geometry, hsi_geometry, hsc_geometry);
+    geometry->initialize(ee_geometry.product(), hsi_geometry.product(), hsc_geometry.product());
   }
   return geometry;
 }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp1.cc
@@ -13,10 +13,8 @@ class HGCalTriggerGeometryHexImp1 : public HGCalTriggerGeometryGenericMapping {
 public:
   HGCalTriggerGeometryHexImp1(const edm::ParameterSet& conf);
 
-  void initialize(const edm::ESHandle<CaloGeometry>&) final;
-  void initialize(const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&) final;
+  void initialize(const CaloGeometry*) final;
+  void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final;
 
 private:
   edm::FileInPath l1tCellsMapping_;
@@ -35,7 +33,7 @@ HGCalTriggerGeometryHexImp1::HGCalTriggerGeometryHexImp1(const edm::ParameterSet
 {}
 
 /*****************************************************************/
-void HGCalTriggerGeometryHexImp1::initialize(const edm::ESHandle<CaloGeometry>& calo_geometry)
+void HGCalTriggerGeometryHexImp1::initialize(const CaloGeometry* calo_geometry)
 /*****************************************************************/
 {
   edm::LogWarning("HGCalTriggerGeometry") << "WARNING: This HGCal trigger geometry is incomplete.\n"
@@ -47,9 +45,9 @@ void HGCalTriggerGeometryHexImp1::initialize(const edm::ESHandle<CaloGeometry>& 
 }
 
 /*****************************************************************/
-void HGCalTriggerGeometryHexImp1::initialize(const edm::ESHandle<HGCalGeometry>& hgc_ee_geometry,
-                                             const edm::ESHandle<HGCalGeometry>& hgc_hsi_geometry,
-                                             const edm::ESHandle<HGCalGeometry>& hgc_hsc_geometry)
+void HGCalTriggerGeometryHexImp1::initialize(const HGCalGeometry* hgc_ee_geometry,
+                                             const HGCalGeometry* hgc_hsi_geometry,
+                                             const HGCalGeometry* hgc_hsc_geometry)
 /*****************************************************************/
 {
   throw cms::Exception("BadGeometry")

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexImp2.cc
@@ -13,10 +13,8 @@ class HGCalTriggerGeometryHexImp2 : public HGCalTriggerGeometryBase {
 public:
   HGCalTriggerGeometryHexImp2(const edm::ParameterSet& conf);
 
-  void initialize(const edm::ESHandle<CaloGeometry>&) final;
-  void initialize(const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&) final;
+  void initialize(const CaloGeometry*) final;
+  void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final;
   void reset() final;
 
   unsigned getTriggerCellFromCell(const unsigned) const final;
@@ -105,16 +103,16 @@ void HGCalTriggerGeometryHexImp2::reset() {
   number_cells_in_wafers_.clear();
 }
 
-void HGCalTriggerGeometryHexImp2::initialize(const edm::ESHandle<CaloGeometry>& calo_geometry) {
+void HGCalTriggerGeometryHexImp2::initialize(const CaloGeometry* calo_geometry) {
   setCaloGeometry(calo_geometry);
   fillMaps();
   fillNeighborMaps();
   fillInvalidTriggerCells();
 }
 
-void HGCalTriggerGeometryHexImp2::initialize(const edm::ESHandle<HGCalGeometry>& hgc_ee_geometry,
-                                             const edm::ESHandle<HGCalGeometry>& hgc_hsi_geometry,
-                                             const edm::ESHandle<HGCalGeometry>& hgc_hsc_geometry) {
+void HGCalTriggerGeometryHexImp2::initialize(const HGCalGeometry* hgc_ee_geometry,
+                                             const HGCalGeometry* hgc_hsi_geometry,
+                                             const HGCalGeometry* hgc_hsc_geometry) {
   throw cms::Exception("BadGeometry")
       << "HGCalTriggerGeometryHexImp2 geometry cannot be initialized with the V9 HGCAL geometry";
 }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -14,10 +14,8 @@ class HGCalTriggerGeometryHexLayerBasedImp1 : public HGCalTriggerGeometryBase {
 public:
   HGCalTriggerGeometryHexLayerBasedImp1(const edm::ParameterSet& conf);
 
-  void initialize(const edm::ESHandle<CaloGeometry>&) final;
-  void initialize(const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&) final;
+  void initialize(const CaloGeometry*) final;
+  void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final;
   void reset() final;
 
   unsigned getTriggerCellFromCell(const unsigned) const final;
@@ -125,7 +123,7 @@ void HGCalTriggerGeometryHexLayerBasedImp1::reset() {
   trigger_cell_neighbors_bh_.clear();
 }
 
-void HGCalTriggerGeometryHexLayerBasedImp1::initialize(const edm::ESHandle<CaloGeometry>& calo_geometry) {
+void HGCalTriggerGeometryHexLayerBasedImp1::initialize(const CaloGeometry* calo_geometry) {
   setCaloGeometry(calo_geometry);
   fhOffset_ = eeTopology().dddConstants().layers(true);
   bhOffset_ = fhOffset_ + fhTopology().dddConstants().layers(true);
@@ -149,9 +147,9 @@ void HGCalTriggerGeometryHexLayerBasedImp1::initialize(const edm::ESHandle<CaloG
   fillInvalidTriggerCells();
 }
 
-void HGCalTriggerGeometryHexLayerBasedImp1::initialize(const edm::ESHandle<HGCalGeometry>& hgc_ee_geometry,
-                                                       const edm::ESHandle<HGCalGeometry>& hgc_hsi_geometry,
-                                                       const edm::ESHandle<HGCalGeometry>& hgc_hsc_geometry) {
+void HGCalTriggerGeometryHexLayerBasedImp1::initialize(const HGCalGeometry* hgc_ee_geometry,
+                                                       const HGCalGeometry* hgc_hsi_geometry,
+                                                       const HGCalGeometry* hgc_hsc_geometry) {
   throw cms::Exception("BadGeometry")
       << "HGCalTriggerGeometryHexLayerBasedImp1 geometry cannot be initialized with the V9 HGCAL geometry";
 }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryImp1.cc
@@ -12,10 +12,8 @@ class HGCalTriggerGeometryImp1 : public HGCalTriggerGeometryGenericMapping {
 public:
   HGCalTriggerGeometryImp1(const edm::ParameterSet& conf);
 
-  void initialize(const edm::ESHandle<CaloGeometry>&) final;
-  void initialize(const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&) final;
+  void initialize(const CaloGeometry*) final;
+  void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final;
 
 private:
   edm::FileInPath l1tCellsMapping_;
@@ -31,7 +29,7 @@ HGCalTriggerGeometryImp1::HGCalTriggerGeometryImp1(const edm::ParameterSet& conf
 {}
 
 /*****************************************************************/
-void HGCalTriggerGeometryImp1::initialize(const edm::ESHandle<CaloGeometry>& calo_geometry)
+void HGCalTriggerGeometryImp1::initialize(const CaloGeometry* calo_geometry)
 /*****************************************************************/
 {
   // FIXME: !!!Only for HGCEE for the moment!!!
@@ -42,9 +40,9 @@ void HGCalTriggerGeometryImp1::initialize(const edm::ESHandle<CaloGeometry>& cal
 }
 
 /*****************************************************************/
-void HGCalTriggerGeometryImp1::initialize(const edm::ESHandle<HGCalGeometry>& hgc_ee_geometry,
-                                          const edm::ESHandle<HGCalGeometry>& hgc_hsi_geometry,
-                                          const edm::ESHandle<HGCalGeometry>& hgc_hsc_geometry)
+void HGCalTriggerGeometryImp1::initialize(const HGCalGeometry* hgc_ee_geometry,
+                                          const HGCalGeometry* hgc_hsi_geometry,
+                                          const HGCalGeometry* hgc_hsc_geometry)
 /*****************************************************************/
 {
   throw cms::Exception("BadGeometry")

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp1.cc
@@ -14,10 +14,8 @@ class HGCalTriggerGeometryV9Imp1 : public HGCalTriggerGeometryBase {
 public:
   HGCalTriggerGeometryV9Imp1(const edm::ParameterSet& conf);
 
-  void initialize(const edm::ESHandle<CaloGeometry>&) final;
-  void initialize(const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&) final;
+  void initialize(const CaloGeometry*) final;
+  void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final;
   void reset() final;
 
   unsigned getTriggerCellFromCell(const unsigned) const final;
@@ -141,14 +139,14 @@ void HGCalTriggerGeometryV9Imp1::reset() {
   trigger_cell_neighbors_sci_.clear();
 }
 
-void HGCalTriggerGeometryV9Imp1::initialize(const edm::ESHandle<CaloGeometry>& calo_geometry) {
+void HGCalTriggerGeometryV9Imp1::initialize(const CaloGeometry* calo_geometry) {
   throw cms::Exception("BadGeometry")
       << "HGCalTriggerGeometryV9Imp1 geometry cannot be initialized with the V7/V8 HGCAL geometry";
 }
 
-void HGCalTriggerGeometryV9Imp1::initialize(const edm::ESHandle<HGCalGeometry>& hgc_ee_geometry,
-                                            const edm::ESHandle<HGCalGeometry>& hgc_hsi_geometry,
-                                            const edm::ESHandle<HGCalGeometry>& hgc_hsc_geometry) {
+void HGCalTriggerGeometryV9Imp1::initialize(const HGCalGeometry* hgc_ee_geometry,
+                                            const HGCalGeometry* hgc_hsi_geometry,
+                                            const HGCalGeometry* hgc_hsc_geometry) {
   setEEGeometry(hgc_ee_geometry);
   setHSiGeometry(hgc_hsi_geometry);
   setHScGeometry(hgc_hsc_geometry);

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
@@ -17,10 +17,8 @@ class HGCalTriggerGeometryV9Imp2 : public HGCalTriggerGeometryBase {
 public:
   HGCalTriggerGeometryV9Imp2(const edm::ParameterSet& conf);
 
-  void initialize(const edm::ESHandle<CaloGeometry>&) final;
-  void initialize(const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&) final;
+  void initialize(const CaloGeometry*) final;
+  void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final;
   void reset() final;
 
   unsigned getTriggerCellFromCell(const unsigned) const final;
@@ -100,14 +98,14 @@ void HGCalTriggerGeometryV9Imp2::reset() {
   module_to_wafers_.clear();
 }
 
-void HGCalTriggerGeometryV9Imp2::initialize(const edm::ESHandle<CaloGeometry>& calo_geometry) {
+void HGCalTriggerGeometryV9Imp2::initialize(const CaloGeometry* calo_geometry) {
   throw cms::Exception("BadGeometry")
       << "HGCalTriggerGeometryV9Imp2 geometry cannot be initialized with the V7/V8 HGCAL geometry";
 }
 
-void HGCalTriggerGeometryV9Imp2::initialize(const edm::ESHandle<HGCalGeometry>& hgc_ee_geometry,
-                                            const edm::ESHandle<HGCalGeometry>& hgc_hsi_geometry,
-                                            const edm::ESHandle<HGCalGeometry>& hgc_hsc_geometry) {
+void HGCalTriggerGeometryV9Imp2::initialize(const HGCalGeometry* hgc_ee_geometry,
+                                            const HGCalGeometry* hgc_hsi_geometry,
+                                            const HGCalGeometry* hgc_hsc_geometry) {
   setEEGeometry(hgc_ee_geometry);
   setHSiGeometry(hgc_hsi_geometry);
   setHScGeometry(hgc_hsc_geometry);

--- a/L1Trigger/L1THGCal/plugins/geometries/NullGeometry.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/NullGeometry.cc
@@ -4,10 +4,8 @@ class NullGeometry : public HGCalTriggerGeometryGenericMapping {
 public:
   NullGeometry(const edm::ParameterSet& conf) : HGCalTriggerGeometryGenericMapping(conf) {}
 
-  void initialize(const edm::ESHandle<CaloGeometry>&) final {}
-  void initialize(const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&) final {}
+  void initialize(const CaloGeometry*) final {}
+  void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final {}
 };
 
 DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory, NullGeometry, "NullGeometry");

--- a/L1Trigger/L1THGCal/plugins/geometries/TrivialGeometry.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/TrivialGeometry.cc
@@ -4,23 +4,21 @@ class TrivialGeometry : public HGCalTriggerGeometryGenericMapping {
 public:
   TrivialGeometry(const edm::ParameterSet& conf) : HGCalTriggerGeometryGenericMapping(conf) {}
 
-  void initialize(const edm::ESHandle<CaloGeometry>&) final {
+  void initialize(const CaloGeometry*) final {
     constexpr unsigned nmodules = 6;
     for (unsigned i = 0; i < nmodules; ++i) {
       trigger_cells_to_modules_[i] = i;
 
       HGCalTriggerGeometry::TriggerCell::list_type tc_empty;
-      trigger_cells_[i].reset(new HGCalTriggerGeometry::TriggerCell(i, i, GlobalPoint(), tc_empty, tc_empty));
+      trigger_cells_[i] = std::make_unique<HGCalTriggerGeometry::TriggerCell>(i, i, GlobalPoint(), tc_empty, tc_empty);
 
       HGCalTriggerGeometry::Module::list_type mod_empty;
       HGCalTriggerGeometry::Module::list_type mod_comps = {i};
       HGCalTriggerGeometry::Module::tc_map_type map_empty;
-      modules_[i].reset(new HGCalTriggerGeometry::Module(i, GlobalPoint(), mod_empty, mod_comps, map_empty));
+      modules_[i] = std::make_unique<HGCalTriggerGeometry::Module>(i, GlobalPoint(), mod_empty, mod_comps, map_empty);
     }
   }
-  void initialize(const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&,
-                  const edm::ESHandle<HGCalGeometry>&) final {}
+  void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final {}
 };
 
 DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory, TrivialGeometry, "TrivialGeometry");


### PR DESCRIPTION
#### PR description:

In addition of using ESGetToken in HGCalTriggerGeometryESProducer (as part of #26748), this PR suggests to use raw pointers instead of `ESHandle` for the contained products in HGCalTriggerGeometryBase and derived classes.

This change does alter the behavior, as now the existence of the input products is always checked in the ESProducer (earlier it was checked at the first time when the HGCalTriggerGeometryBase or -derived class accessed the input products).

There is one caveat though. Currently the ESProducer tries to read CaloGeometry, and if either CaloGeometry is not available or does not have the expected content, the ESProducer reads 3 HGCalGeometry products. With the solution in this PR, all 4 objects would get produced in the (eventual) prefetching, which is not necessarily what we want. On the other hand, (based on my understanding of the code) memory-wise this issue would only affect HGCal < V9 geometries, but I don't know how relevant those workflows still are. In addition, in principle the `phase2_hgcalV9` modifier could be used to control the behavior of this ESProducer.

#### PR validation:

Code compiles.