### PR TITLE
DQM/Tracking: Improve the per-lumi fix

### DIFF
--- a/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
@@ -441,7 +441,9 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
     std::string localMEdirpath = it->second.HistoDir;
     std::vector<MonitorElement*> tmpMEvec = igetter.getContents(ibooker.pwd() + "/" + localMEdirpath);
     for (auto ime : tmpMEvec) {
-      ime->Reset();
+      if (ime->getLumiFlag()) {
+        ime->Reset();
+      }
     }
   }
 


### PR DESCRIPTION
#### PR description:

The fix for double counting in a0c43f3ea4e248d seems to be a bit aggressive. It seems to have reset some MEs that are not per-lumi, so check for that.

#### PR validation:

After the tests of #27239 and #27237, it looks like this should bring back the missing plots, while not risking to bring back bugs due to double-counting.

Old test comparison: http://tinyurl.com/yyanjesa