### PR TITLE
Added missing package dependency for DataFormats/MuonDetId

### DIFF
--- a/DataFormats/MuonDetId/test/BuildFile.xml
+++ b/DataFormats/MuonDetId/test/BuildFile.xml
@@ -19,5 +19,6 @@
   <flags   EDM_PLUGIN="1"/>
 </library>
 <library   file="GEMDetIdAnalyzer.cc" name="GEMDetIdAnalyzer">
+  <use name="DataFormats/GEMRecHit"/>
   <flags   EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

The analyzer in the test directory needs to be linked with DataFormats/GEMRecHit for UBSAN to work.

#### PR validation:

Compiles and links successfully using the CMSSW_11_0_UBSAN_X_2019-06-18-1100 IB.