### PR TITLE
Added missing library to CommonTools/RecoAlgos

### DIFF
--- a/CommonTools/RecoAlgos/plugins/BuildFile.xml
+++ b/CommonTools/RecoAlgos/plugins/BuildFile.xml
@@ -20,4 +20,5 @@
   <use   name="MagneticField/Records"/>
   <use   name="Geometry/Records"/>
   <use   name="Geometry/TrackerGeometryBuilder"/>
+  <use   name="JetMETCorrections/JetCorrector"/>
 </library>


### PR DESCRIPTION
#### PR description:
Need to link to JetMETCorrections/JetCorrector. This is necessary for UBSAN.


#### PR validation:

This compiles and links with CMSSW_11_0_UBSAN_X_2019-06-18-1100 IB.