### PR TITLE
Added missing library to L1Trigger/L1TCommon

### DIFF
--- a/L1Trigger/L1TCommon/plugins/BuildFile.xml
+++ b/L1Trigger/L1TCommon/plugins/BuildFile.xml
@@ -6,4 +6,5 @@
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/L1TCalorimeter"/>
 <use name="DataFormats/L1TMuon"/>
+<use name="DataFormats/L1TGlobal"/>
 <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
#### PR description:

The plugins need to link with DataFormats/L1TGlobal in order to work with UBSAN.

#### PR validation:

This compiles and links with CMSSW_11_0_UBSAN_X_2019-06-18-1100 IB.