### PR TITLE
Added missing library to JetMETCorrections/Type1MET

### DIFF
--- a/JetMETCorrections/Type1MET/plugins/BuildFile.xml
+++ b/JetMETCorrections/Type1MET/plugins/BuildFile.xml
@@ -16,4 +16,5 @@
   <use   name="DataFormats/VertexReco"/>
   <use   name="JetMETCorrections/Objects"/>
   <use   name="JetMETCorrections/Type1MET"/>
+  <use   name="JetMETCorrections/JetCorrector"/>
 </library>


### PR DESCRIPTION
#### PR description:
The plugins need to link to JetMETCorrections/JetCorrector inorder for UBSAN to work.


#### PR validation:

Compiles and links using CMSSW_11_0_UBSAN_X_2019-06-18-1100 IB.