### PR TITLE
Added missing library to DQMOffline/RecoB

### DIFF
--- a/DQMOffline/RecoB/BuildFile.xml
+++ b/DQMOffline/RecoB/BuildFile.xml
@@ -11,6 +11,7 @@
 <use name="DQMServices/Core"/>
 <use name="rootgpad"/>
 <use name="JetMETCorrections/Objects"/>
+<use name="JetMETCorrections/JetCorrector"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
#### PR description:

Need to link with JetMETCorrections/JetCorrector in order to allow UBSAN to work.

#### PR validation:

Compiles and links with CMSSW_11_0_UBSAN_X_2019-06-18-1100 IB.