### PR TITLE
Added missing library to DQM/DataScouting

### DIFF
--- a/DQM/DataScouting/plugins/BuildFile.xml
+++ b/DQM/DataScouting/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="DataFormats/TrackingRecHit"/>
 <use name="DataFormats/CSCRecHit"/>
 <use name="DataFormats/TrackReco"/>
+<use name="DataFormats/JetReco"/>
 <library name="DQMDataScoutingPlugins" file="*.cc">
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

Need to link with DataFormats/JetReco in order for UBSAN to work.

#### PR validation:

Compiles and links using CMSSW_11_0_UBSAN_X_2019-06-18-1100 IB.