### PR TITLE
Running code-format for alca

### DIFF
--- a/CalibCalorimetry/HcalPlugins/test/HBHEDarkeningAnalyzer.cc
+++ b/CalibCalorimetry/HcalPlugins/test/HBHEDarkeningAnalyzer.cc
@@ -96,10 +96,8 @@ void HBHEDarkeningAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup
   for (int i = 0; i < maxEta; i++) {
     theTopology->getDepthSegmentation(i + 1, m_segmentation[i]);
   }
-  std::cout << "HB: Eta " << theTopology->firstHBRing() 
-	    << ":" << theTopology->lastHBRing() << " HE: Eta "
-	    << theTopology->firstHERing() << ":" << theTopology->lastHERing()
-	    << std::endl;
+  std::cout << "HB: Eta " << theTopology->firstHBRing() << ":" << theTopology->lastHBRing() << " HE: Eta "
+            << theTopology->firstHERing() << ":" << theTopology->lastHERing() << std::endl;
   hb_recalibration.setup(m_segmentation, hb_darkening);
   he_recalibration.setup(m_segmentation, he_darkening);
 }
@@ -133,8 +131,7 @@ void HBHEDarkeningAnalyzer::print(int ieta_min,
                                   int lay_max,
                                   const HBHEDarkening* darkening,
                                   const HBHERecalibration& recalibration) {
-  std::cout << "Darkening: ieta " << ieta_min << ":" << ieta_max << " layer "
-	    << lay_min << ":" << lay_max << std::endl;
+  std::cout << "Darkening: ieta " << ieta_min << ":" << ieta_max << " layer " << lay_min << ":" << lay_max << std::endl;
   for (int ieta = ieta_min; ieta <= ieta_max; ++ieta) {
     std::cout << "Tower " << ieta << ": ";
     for (int lay = lay_min; lay <= lay_max; ++lay) {
@@ -143,8 +140,8 @@ void HBHEDarkeningAnalyzer::print(int ieta_min,
     std::cout << std::endl;
   }
 
-  std::cout << "Recalibration: ieta " << ieta_min << ":" << ieta_max 
-	    << " layer " << lay_min << ":" << lay_max << std::endl;
+  std::cout << "Recalibration: ieta " << ieta_min << ":" << ieta_max << " layer " << lay_min << ":" << lay_max
+            << std::endl;
   for (int ieta = ieta_min; ieta <= ieta_max; ++ieta) {
     std::cout << "Tower " << ieta << ": ";
     for (int depth = 1; depth <= recalibration.maxDepth(); ++depth) {

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelCPEGenericDBErrorParametrization.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelCPEGenericDBErrorParametrization.h
@@ -8,66 +8,64 @@
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelCPEGenericErrorParm.h"
 
-class SiPixelCPEGenericDBErrorParametrization
-{
-  public:
-	
-	SiPixelCPEGenericDBErrorParametrization();
-	 ~SiPixelCPEGenericDBErrorParametrization();
+class SiPixelCPEGenericDBErrorParametrization {
+public:
+  SiPixelCPEGenericDBErrorParametrization();
+  ~SiPixelCPEGenericDBErrorParametrization();
 
-	 void setDBAccess(const edm::EventSetup& es);
-	 
-	 std::pair<float,float>
-		 getError(const SiPixelCPEGenericErrorParm* parmErrors,
-			        GeomDetType::SubDetector pixelPart,
-			        int sizex, int sizey,
-			        float alpha, float beta,
-			        bool bigInX = false,
-			        bool bigInY = false);
+  void setDBAccess(const edm::EventSetup& es);
 
-	 std::pair<float,float>
-		 getError(GeomDetType::SubDetector pixelPart,
-			        int sizex, int sizey,
-			        float alpha, float beta,
-			        bool bigInX = false,
-			        bool bigInY = false);
+  std::pair<float, float> getError(const SiPixelCPEGenericErrorParm* parmErrors,
+                                   GeomDetType::SubDetector pixelPart,
+                                   int sizex,
+                                   int sizey,
+                                   float alpha,
+                                   float beta,
+                                   bool bigInX = false,
+                                   bool bigInY = false);
 
-	 float index(int ind_subpart, int size, float alpha, float beta, bool big);
-	 
-  private:
+  std::pair<float, float> getError(GeomDetType::SubDetector pixelPart,
+                                   int sizex,
+                                   int sizey,
+                                   float alpha,
+                                   float beta,
+                                   bool bigInX = false,
+                                   bool bigInY = false);
 
-	 edm::ESHandle<SiPixelCPEGenericErrorParm> errorsH;
-	 
-	 static const float bx_a_min[3];
-	 static const float bx_a_max[3];
-	 
-	 static const float fx_a_min[2];
-	 static const float fx_a_max[2];
-	 static const float fx_b_min[2];
-	 static const float fx_b_max[2];
-	 
-	 static const float by_a_min[6];
-	 static const float by_a_max[6];
-	 static const float by_b_min[6];
-	 static const float by_b_max[6];
-	 
-	 static const float fy_a_min[2];
-	 static const float fy_a_max[2];
-	 static const float fy_b_min[2];
-	 static const float fy_b_max[2];
+  float index(int ind_subpart, int size, float alpha, float beta, bool big);
 
-	 static const float errors_big_pix[4];
-	 static const int   size_max[4];
-	 
-	 static const int part_bin_size[4];
-	 static const int size_bin_size[4];
-	 static const int alpha_bin_size[4];
-	 static const int beta_bin_size[4];
+private:
+  edm::ESHandle<SiPixelCPEGenericErrorParm> errorsH;
 
-	 static const float* a_min[4];
-	 static const float* a_max[4];
-	 static const float* b_min[4];
-	 static const float* b_max[4];
+  static const float bx_a_min[3];
+  static const float bx_a_max[3];
 
+  static const float fx_a_min[2];
+  static const float fx_a_max[2];
+  static const float fx_b_min[2];
+  static const float fx_b_max[2];
+
+  static const float by_a_min[6];
+  static const float by_a_max[6];
+  static const float by_b_min[6];
+  static const float by_b_max[6];
+
+  static const float fy_a_min[2];
+  static const float fy_a_max[2];
+  static const float fy_b_min[2];
+  static const float fy_b_max[2];
+
+  static const float errors_big_pix[4];
+  static const int size_max[4];
+
+  static const int part_bin_size[4];
+  static const int size_bin_size[4];
+  static const int alpha_bin_size[4];
+  static const int beta_bin_size[4];
+
+  static const float* a_min[4];
+  static const float* a_max[4];
+  static const float* b_min[4];
+  static const float* b_max[4];
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelDetInfoFileReader
 // Class:      SiPixelDetInfoFileReader
-// 
+//
 /**\class SiPixelDetInfoFileReader SiPixelDetInfoFileReader.cc CalibTracker/SiPixelCommon/src/SiPixelDetInfoFileReader.cc
 
  Description: <one line class summary>
@@ -25,23 +25,19 @@
 #include <fstream>
 #include <boost/cstdint.hpp>
 
-class SiPixelDetInfoFileReader  {
-
+class SiPixelDetInfoFileReader {
 public:
-
   explicit SiPixelDetInfoFileReader(std::string filePath);
   ~SiPixelDetInfoFileReader();
 
-  const std::vector<uint32_t> & getAllDetIds() const;
-  const std::pair<int, int> & getDetUnitDimensions(uint32_t detId) const;
+  const std::vector<uint32_t>& getAllDetIds() const;
+  const std::pair<int, int>& getDetUnitDimensions(uint32_t detId) const;
 
 private:
-
-  std::ifstream inputFile_; 
+  std::ifstream inputFile_;
   //  std::string filePath_;
 
   std::map<uint32_t, std::pair<int, int> > detData_;
   std::vector<uint32_t> detIds_;
-
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileWriter.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileWriter.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelDetInfoFileWriter
 // Class:      SiPixelDetInfoFileWriter
-// 
+//
 /**\class SiPixelDetInfoFileWriter SiPixelDetInfoFileWriter.cc CalibTracker/SiPixelCommon/src/SiPixelDetInfoFileWriter.cc
 
  Description: <one line class summary>
@@ -24,24 +24,17 @@
 #include <fstream>
 
 class SiPixelDetInfoFileWriter : public edm::EDAnalyzer {
-
 public:
-
-  explicit SiPixelDetInfoFileWriter(const edm::ParameterSet&);
+  explicit SiPixelDetInfoFileWriter(const edm::ParameterSet &);
   ~SiPixelDetInfoFileWriter() override;
 
 private:
-
   void beginJob() override;
   void beginRun(const edm::Run &, const edm::EventSetup &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:
-
-
-  std::ofstream outputFile_; 
+  std::ofstream outputFile_;
   std::string filePath_;
-
-
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeCPEGenericErrorParmESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeCPEGenericErrorParmESSource.h
@@ -9,24 +9,20 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelCPEGenericErrorParm.h"
 #include "CondFormats/DataRecord/interface/SiPixelCPEGenericErrorParmRcd.h"
 
-class SiPixelFakeCPEGenericErrorParmESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-
- public:
+class SiPixelFakeCPEGenericErrorParmESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
   SiPixelFakeCPEGenericErrorParmESSource(const edm::ParameterSet &);
   ~SiPixelFakeCPEGenericErrorParmESSource() override;
-  
-   virtual std::unique_ptr<SiPixelCPEGenericErrorParm>  produce(const SiPixelCPEGenericErrorParmRcd &);
-  
- protected:
-  
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
-			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& ) override;
-  
- private:
-  
-  edm::FileInPath fp_;
-	double version_;
 
+  virtual std::unique_ptr<SiPixelCPEGenericErrorParm> produce(const SiPixelCPEGenericErrorParmRcd &);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+private:
+  edm::FileInPath fp_;
+  double version_;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainESSource.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelFakeGainESSource
 // Class:      SiPixelFakeGainESSource
-// 
+//
 /**\class SiPixelFakeGainESSource SiPixelFakeGainESSource.h CalibTracker/SiPixelGainESProducer/src/SiPixelFakeGainESSource.cc
 
  Description: <one line class summary>
@@ -17,7 +17,6 @@
 //         Created:  Tue 8 12:31:25 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -32,26 +31,21 @@
 // class decleration
 //
 
-class SiPixelFakeGainESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-
- public:
+class SiPixelFakeGainESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
   SiPixelFakeGainESSource(const edm::ParameterSet &);
   ~SiPixelFakeGainESSource() override;
-  
-  //      typedef edm::ESProducts<> ReturnType;
-  
-  virtual std::unique_ptr<SiPixelGainCalibration>  produce(const SiPixelGainCalibrationRcd &);
-  
- protected:
-  
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
-			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& ) override;
-  
-  
- private:
-  
-  edm::FileInPath fp_;
 
+  //      typedef edm::ESProducts<> ReturnType;
+
+  virtual std::unique_ptr<SiPixelGainCalibration> produce(const SiPixelGainCalibrationRcd &);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+private:
+  edm::FileInPath fp_;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainForHLTESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainForHLTESSource.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelFakeGainForHLTESSource
 // Class:      SiPixelFakeGainForHLTESSource
-// 
+//
 /**\class SiPixelFakeGainForHLTESSource SiPixelFakeGainForHLTESSource.h CalibTracker/SiPixelGainForHLTESProducer/src/SiPixelFakeGainForHLTESSource.cc
 
  Description: <one line class summary>
@@ -17,7 +17,6 @@
 //         Created:  Tue 8 12:31:25 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -32,26 +31,21 @@
 // class decleration
 //
 
-class SiPixelFakeGainForHLTESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-
- public:
+class SiPixelFakeGainForHLTESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
   SiPixelFakeGainForHLTESSource(const edm::ParameterSet &);
   ~SiPixelFakeGainForHLTESSource() override;
-  
-  //      typedef edm::ESProducts<> ReturnType;
-  
-  virtual std::unique_ptr<SiPixelGainCalibrationForHLT>  produce(const SiPixelGainCalibrationForHLTRcd &);
-  
- protected:
-  
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
-			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& ) override;
-  
-  
- private:
-  
-  edm::FileInPath fp_;
 
+  //      typedef edm::ESProducts<> ReturnType;
+
+  virtual std::unique_ptr<SiPixelGainCalibrationForHLT> produce(const SiPixelGainCalibrationForHLTRcd &);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+private:
+  edm::FileInPath fp_;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainOfflineESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainOfflineESSource.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelFakeGainESSource
 // Class:      SiPixelFakeGainOfflineESSource
-// 
+//
 /**\class SiPixelFakeGainOfflineESSource SiPixelFakeGainOfflineESSource.h CalibTracker/SiPixelGainESProducer/src/SiPixelFakeGainOfflineESSource.cc
 
  Description: <one line class summary>
@@ -17,7 +17,6 @@
 //         Created:  Tue 8 12:31:25 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -32,26 +31,21 @@
 // class decleration
 //
 
-class SiPixelFakeGainOfflineESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-
- public:
+class SiPixelFakeGainOfflineESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
   SiPixelFakeGainOfflineESSource(const edm::ParameterSet &);
   ~SiPixelFakeGainOfflineESSource() override;
-  
-  //      typedef edm::ESProducts<> ReturnType;
-  
-  virtual std::unique_ptr<SiPixelGainCalibrationOffline>  produce(const SiPixelGainCalibrationOfflineRcd &);
-  
- protected:
-  
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
-			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& ) override;
-  
-  
- private:
-  
-  edm::FileInPath fp_;
 
+  //      typedef edm::ESProducts<> ReturnType;
+
+  virtual std::unique_ptr<SiPixelGainCalibrationOffline> produce(const SiPixelGainCalibrationOfflineRcd &);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+private:
+  edm::FileInPath fp_;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGenErrorDBObjectESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGenErrorDBObjectESSource.h
@@ -9,26 +9,22 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h"
 #include "CondFormats/DataRecord/interface/SiPixelGenErrorDBObjectRcd.h"
 
-class SiPixelFakeGenErrorDBObjectESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-
- public:
+class SiPixelFakeGenErrorDBObjectESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
   SiPixelFakeGenErrorDBObjectESSource(const edm::ParameterSet &);
   ~SiPixelFakeGenErrorDBObjectESSource() override;
-  
-  typedef std::vector<std::string> vstring;
-  
-  virtual std::unique_ptr<SiPixelGenErrorDBObject>  produce(const SiPixelGenErrorDBObjectRcd &);
-  
- protected:
-  
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
-			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& ) override;
-  
- private:
-  
- 	vstring GenErrorCalibrations_;
-	float version_;
 
+  typedef std::vector<std::string> vstring;
+
+  virtual std::unique_ptr<SiPixelGenErrorDBObject> produce(const SiPixelGenErrorDBObjectRcd &);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+private:
+  vstring GenErrorCalibrations_;
+  float version_;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelFakeLorentzAngleESSource
 // Class:      SiPixelFakeLorentzAngleESSource
-// 
+//
 /**\class SiPixelFakeLorentzAngleESSource SiPixelFakeLorentzAngleESSource.h CalibTracker/SiPixelGainESProducer/src/SiPixelFakeLorentzAngleESSource.cc
 
  Description: <one line class summary>
@@ -17,7 +17,6 @@
 //         Created:  Jan. 31st, 2008
 //
 //
-
 
 // system include files
 #include <memory>
@@ -33,26 +32,21 @@
 // class decleration
 //
 
-class SiPixelFakeLorentzAngleESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-
- public:
+class SiPixelFakeLorentzAngleESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
   SiPixelFakeLorentzAngleESSource(const edm::ParameterSet &);
   ~SiPixelFakeLorentzAngleESSource() override;
-  
-  //      typedef edm::ESProducts<> ReturnType;
-  
-  virtual std::unique_ptr<SiPixelLorentzAngle>  produce(const SiPixelLorentzAngleRcd &);
-  
- protected:
-  
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
-			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& ) override;
-  
-  
- private:
-  
-  edm::FileInPath fp_;
 
+  //      typedef edm::ESProducts<> ReturnType;
+
+  virtual std::unique_ptr<SiPixelLorentzAngle> produce(const SiPixelLorentzAngleRcd &);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+private:
+  edm::FileInPath fp_;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeQualityESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeQualityESSource.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelFakeQualityESSource
 // Class:      SiPixelFakeQualityESSource
-// 
+//
 /**\class SiPixelFakeQualityESSource SiPixelFakeQualityESSource.h CalibTracker/SiPixelGainESProducer/src/SiPixelFakeQualityESSource.cc
 
  Description: <one line class summary>
@@ -17,7 +17,6 @@
 //         Created:  Oct. 21st, 2008
 //
 //
-
 
 // system include files
 #include <memory>
@@ -33,26 +32,21 @@
 // class decleration
 //
 
-class SiPixelFakeQualityESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-
- public:
+class SiPixelFakeQualityESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
   SiPixelFakeQualityESSource(const edm::ParameterSet &);
   ~SiPixelFakeQualityESSource() override;
-  
-  //      typedef edm::ESProducts<> ReturnType;
-  
-  virtual std::unique_ptr<SiPixelQuality>  produce(const SiPixelQualityFromDbRcd &);
-  
- protected:
-  
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
-			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& ) override;
-  
-  
- private:
-  
-  edm::FileInPath fp_;
 
+  //      typedef edm::ESProducts<> ReturnType;
+
+  virtual std::unique_ptr<SiPixelQuality> produce(const SiPixelQualityFromDbRcd &);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+private:
+  edm::FileInPath fp_;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeTemplateDBObjectESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeTemplateDBObjectESSource.h
@@ -9,26 +9,22 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h"
 #include "CondFormats/DataRecord/interface/SiPixelTemplateDBObjectRcd.h"
 
-class SiPixelFakeTemplateDBObjectESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-
- public:
+class SiPixelFakeTemplateDBObjectESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
   SiPixelFakeTemplateDBObjectESSource(const edm::ParameterSet &);
   ~SiPixelFakeTemplateDBObjectESSource() override;
-  
-  typedef std::vector<std::string> vstring;
-  
-  virtual std::unique_ptr<SiPixelTemplateDBObject>  produce(const SiPixelTemplateDBObjectRcd &);
-  
- protected:
-  
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
-			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& ) override;
-  
- private:
-  
- 	vstring templateCalibrations_;
-	float version_;
 
+  typedef std::vector<std::string> vstring;
+
+  virtual std::unique_ptr<SiPixelTemplateDBObject> produce(const SiPixelTemplateDBObjectRcd &);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+private:
+  vstring templateCalibrations_;
+  float version_;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h
@@ -15,26 +15,26 @@
 // Gain Calibration base class
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h"
 
-#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h" 
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h"
 #include "CondFormats/DataRecord/interface/SiPixelGainCalibrationForHLTRcd.h"
 
-class SiPixelGainCalibrationForHLTService final : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,SiPixelGainCalibrationForHLTRcd>
-{
-
- public:
-  explicit SiPixelGainCalibrationForHLTService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,SiPixelGainCalibrationForHLTRcd>(conf){};
+class SiPixelGainCalibrationForHLTService final
+    : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT, SiPixelGainCalibrationForHLTRcd> {
+public:
+  explicit SiPixelGainCalibrationForHLTService(const edm::ParameterSet& conf)
+      : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT, SiPixelGainCalibrationForHLTRcd>(
+            conf){};
   ~SiPixelGainCalibrationForHLTService() override{};
 
-  void calibrate(uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int * electron) override;
-
+  void calibrate(
+      uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int* electron) override;
 
   // column granularity
-  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row) override;
-  float   getGain      ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isDead       ( const uint32_t& detID,const int& col, const int& row) override; //also return dead by column.
-  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row) override;
-
+  float getPedestal(const uint32_t& detID, const int& col, const int& row) override;
+  float getGain(const uint32_t& detID, const int& col, const int& row) override;
+  bool isDead(const uint32_t& detID, const int& col, const int& row) override;  //also return dead by column.
+  bool isDeadColumn(const uint32_t& detID, const int& col, const int& row) override;
+  bool isNoisy(const uint32_t& detID, const int& col, const int& row) override;
+  bool isNoisyColumn(const uint32_t& detID, const int& col, const int& row) override;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTSimService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTSimService.h
@@ -16,23 +16,24 @@
 // Gain Calibration base class
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h"
 
-#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h" 
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h"
 #include "CondFormats/DataRecord/interface/SiPixelGainCalibrationForHLTSimRcd.h"
 
-class SiPixelGainCalibrationForHLTSimService : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,SiPixelGainCalibrationForHLTSimRcd>
-{
-
- public:
-  explicit SiPixelGainCalibrationForHLTSimService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,SiPixelGainCalibrationForHLTSimRcd>(conf){};
+class SiPixelGainCalibrationForHLTSimService
+    : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,
+                                                        SiPixelGainCalibrationForHLTSimRcd> {
+public:
+  explicit SiPixelGainCalibrationForHLTSimService(const edm::ParameterSet& conf)
+      : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT, SiPixelGainCalibrationForHLTSimRcd>(
+            conf){};
   ~SiPixelGainCalibrationForHLTSimService() override{};
 
   // column granularity
-  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row) override;
-  float   getGain      ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isDead       ( const uint32_t& detID,const int& col, const int& row) override; //also return dead by column.
-  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row) override;
-
+  float getPedestal(const uint32_t& detID, const int& col, const int& row) override;
+  float getGain(const uint32_t& detID, const int& col, const int& row) override;
+  bool isDead(const uint32_t& detID, const int& col, const int& row) override;  //also return dead by column.
+  bool isDeadColumn(const uint32_t& detID, const int& col, const int& row) override;
+  bool isNoisy(const uint32_t& detID, const int& col, const int& row) override;
+  bool isNoisyColumn(const uint32_t& detID, const int& col, const int& row) override;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h
@@ -15,22 +15,23 @@
 // Gain CalibrationOffline base class
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h"
 
-#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h" 
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h"
 #include "CondFormats/DataRecord/interface/SiPixelGainCalibrationOfflineRcd.h"
 
-class SiPixelGainCalibrationOfflineService : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline,SiPixelGainCalibrationOfflineRcd>
-{
-
- public:
-  explicit SiPixelGainCalibrationOfflineService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline,SiPixelGainCalibrationOfflineRcd>(conf){};
+class SiPixelGainCalibrationOfflineService
+    : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline, SiPixelGainCalibrationOfflineRcd> {
+public:
+  explicit SiPixelGainCalibrationOfflineService(const edm::ParameterSet& conf)
+      : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline, SiPixelGainCalibrationOfflineRcd>(
+            conf){};
   ~SiPixelGainCalibrationOfflineService() override{};
 
   // pixel granularity
-  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row) override;
-  float   getGain      ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isDead       ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row) override;
+  float getPedestal(const uint32_t& detID, const int& col, const int& row) override;
+  float getGain(const uint32_t& detID, const int& col, const int& row) override;
+  bool isDead(const uint32_t& detID, const int& col, const int& row) override;
+  bool isDeadColumn(const uint32_t& detID, const int& col, const int& row) override;
+  bool isNoisy(const uint32_t& detID, const int& col, const int& row) override;
+  bool isNoisyColumn(const uint32_t& detID, const int& col, const int& row) override;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h
@@ -16,22 +16,24 @@
 // Gain CalibrationOffline base class
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h"
 
-#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h" 
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h"
 #include "CondFormats/DataRecord/interface/SiPixelGainCalibrationOfflineSimRcd.h"
 
-class SiPixelGainCalibrationOfflineSimService : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline,SiPixelGainCalibrationOfflineSimRcd>
-{
-
- public:
-  explicit SiPixelGainCalibrationOfflineSimService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline,SiPixelGainCalibrationOfflineSimRcd>(conf){};
+class SiPixelGainCalibrationOfflineSimService
+    : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline,
+                                                        SiPixelGainCalibrationOfflineSimRcd> {
+public:
+  explicit SiPixelGainCalibrationOfflineSimService(const edm::ParameterSet& conf)
+      : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline, SiPixelGainCalibrationOfflineSimRcd>(
+            conf){};
   ~SiPixelGainCalibrationOfflineSimService() override{};
 
   // pixel granularity
-  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row) override;
-  float   getGain      ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isDead       ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row) override;
+  float getPedestal(const uint32_t& detID, const int& col, const int& row) override;
+  float getGain(const uint32_t& detID, const int& col, const int& row) override;
+  bool isDead(const uint32_t& detID, const int& col, const int& row) override;
+  bool isDeadColumn(const uint32_t& detID, const int& col, const int& row) override;
+  bool isNoisy(const uint32_t& detID, const int& col, const int& row) override;
+  bool isNoisyColumn(const uint32_t& detID, const int& col, const int& row) override;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h
@@ -15,24 +15,22 @@
 // Gain Calibration base class
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h"
 
-#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h" 
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h"
 #include "CondFormats/DataRecord/interface/SiPixelGainCalibrationRcd.h"
 
-class SiPixelGainCalibrationService : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibration,SiPixelGainCalibrationRcd>
-{
-
- public:
-  explicit SiPixelGainCalibrationService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibration,SiPixelGainCalibrationRcd>(conf){};
+class SiPixelGainCalibrationService
+    : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibration, SiPixelGainCalibrationRcd> {
+public:
+  explicit SiPixelGainCalibrationService(const edm::ParameterSet& conf)
+      : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibration, SiPixelGainCalibrationRcd>(conf){};
   ~SiPixelGainCalibrationService() override{};
 
   // pixel granularity
-  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row) override;
-  float   getGain      ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isDead       ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row) override; //throws exception!
-  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row) override;
-  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row) override;
-
-
+  float getPedestal(const uint32_t& detID, const int& col, const int& row) override;
+  float getGain(const uint32_t& detID, const int& col, const int& row) override;
+  bool isDead(const uint32_t& detID, const int& col, const int& row) override;
+  bool isDeadColumn(const uint32_t& detID, const int& col, const int& row) override;  //throws exception!
+  bool isNoisy(const uint32_t& detID, const int& col, const int& row) override;
+  bool isNoisyColumn(const uint32_t& detID, const int& col, const int& row) override;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
@@ -25,58 +25,54 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-// Abstract base class provides common interface to different payload getters 
+// Abstract base class provides common interface to different payload getters
 class SiPixelGainCalibrationServiceBase {
-   public:
-
-  typedef edm::DetSet<PixelDigi>::const_iterator    DigiIterator;
-
+public:
+  typedef edm::DetSet<PixelDigi>::const_iterator DigiIterator;
 
   SiPixelGainCalibrationServiceBase(){};
   virtual ~SiPixelGainCalibrationServiceBase(){};
 
   static void fillPSetDescription(edm::ParameterSetDescription& desc) {}
-  
-  // default inplementation from PixelThresholdClusterizer 
-  virtual void calibrate(uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int * electron);
-  
-  virtual float getGain      ( const uint32_t& detID , const int& col , const int& row)=0;
-  virtual float getPedestal  ( const uint32_t& detID , const int& col , const int& row)=0;
-  virtual bool  isDead       ( const uint32_t& detID , const int& col , const int& row)=0;
-  virtual bool  isDeadColumn ( const uint32_t& detID , const int& col , const int& row)=0;
-  virtual bool  isNoisy       ( const uint32_t& detID , const int& col , const int& row)=0;
-  virtual bool  isNoisyColumn ( const uint32_t& detID , const int& col , const int& row)=0;
-  virtual void  setESObjects(const edm::EventSetup& es )=0;
-  virtual std::vector<uint32_t> getDetIds()=0;
-  virtual double getGainLow()=0;
-  virtual double getGainHigh()=0;
-  virtual double getPedLow()=0;
-  virtual double getPedHigh()=0;
 
+  // default inplementation from PixelThresholdClusterizer
+  virtual void calibrate(
+      uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int* electron);
+
+  virtual float getGain(const uint32_t& detID, const int& col, const int& row) = 0;
+  virtual float getPedestal(const uint32_t& detID, const int& col, const int& row) = 0;
+  virtual bool isDead(const uint32_t& detID, const int& col, const int& row) = 0;
+  virtual bool isDeadColumn(const uint32_t& detID, const int& col, const int& row) = 0;
+  virtual bool isNoisy(const uint32_t& detID, const int& col, const int& row) = 0;
+  virtual bool isNoisyColumn(const uint32_t& detID, const int& col, const int& row) = 0;
+  virtual void setESObjects(const edm::EventSetup& es) = 0;
+  virtual std::vector<uint32_t> getDetIds() = 0;
+  virtual double getGainLow() = 0;
+  virtual double getGainHigh() = 0;
+  virtual double getPedLow() = 0;
+  virtual double getPedHigh() = 0;
 };
 
-
 // Abstract template class that defines DB access types and payload specific getters
-template<class thePayloadObject, class theDBRecordType>
+template <class thePayloadObject, class theDBRecordType>
 class SiPixelGainCalibrationServicePayloadGetter : public SiPixelGainCalibrationServiceBase {
-
- public:
+public:
   explicit SiPixelGainCalibrationServicePayloadGetter(const edm::ParameterSet& conf);
   ~SiPixelGainCalibrationServicePayloadGetter() override{};
 
   //Abstract methods
-  float getGain(const uint32_t& detID, const int& col, const int& row) override =0;
-  float getPedestal(const uint32_t& detID, const int& col, const int& row) override =0;
+  float getGain(const uint32_t& detID, const int& col, const int& row) override = 0;
+  float getPedestal(const uint32_t& detID, const int& col, const int& row) override = 0;
 
-  bool isDead       ( const uint32_t& detID, const int& col, const int& row ) override =0;
-  bool isDeadColumn ( const uint32_t& detID, const int& col, const int& row ) override =0;
+  bool isDead(const uint32_t& detID, const int& col, const int& row) override = 0;
+  bool isDeadColumn(const uint32_t& detID, const int& col, const int& row) override = 0;
 
-  bool isNoisy       ( const uint32_t& detID, const int& col, const int& row ) override =0;
-  bool isNoisyColumn ( const uint32_t& detID, const int& col, const int& row ) override =0;
+  bool isNoisy(const uint32_t& detID, const int& col, const int& row) override = 0;
+  bool isNoisyColumn(const uint32_t& detID, const int& col, const int& row) override = 0;
 
-  void    setESObjects(const edm::EventSetup& es ) override;
+  void setESObjects(const edm::EventSetup& es) override;
 
-  thePayloadObject const & payload() const { return *ped; }
+  thePayloadObject const& payload() const { return *ped; }
 
   std::vector<uint32_t> getDetIds() override;
   double getGainLow() override;
@@ -84,17 +80,17 @@ class SiPixelGainCalibrationServicePayloadGetter : public SiPixelGainCalibration
   double getPedLow() override;
   double getPedHigh() override;
 
- protected:
-
-  float   getPedestalByPixel(const uint32_t& detID,const int& col, const int& row, bool& isDeadPixel, bool& isNoisyPixel) ;
-  float   getGainByPixel(const uint32_t& detID,const int& col, const int& row, bool& isDeadPixel, bool& isNoisyPixel) ;
+protected:
+  float getPedestalByPixel(const uint32_t& detID, const int& col, const int& row, bool& isDeadPixel, bool& isNoisyPixel);
+  float getGainByPixel(const uint32_t& detID, const int& col, const int& row, bool& isDeadPixel, bool& isNoisyPixel);
 
   // the getByColumn functions caches the data to prevent multiple lookups on averaged quanitities
-  float   getPedestalByColumn(const uint32_t& detID,const int& col, const int& row, bool& isDeadColumn, bool& isNoisyColumn) ;
-  float   getGainByColumn(const uint32_t& detID,const int& col, const int& row, bool& isDeadColumn, bool& isNoisyColumn) ;
+  float getPedestalByColumn(
+      const uint32_t& detID, const int& col, const int& row, bool& isDeadColumn, bool& isNoisyColumn);
+  float getGainByColumn(const uint32_t& detID, const int& col, const int& row, bool& isDeadColumn, bool& isNoisyColumn);
 
-  void    throwExepctionForBadRead(std::string payload, const uint32_t& detID, const int& col, const int& row, double value = -1) const;
-
+  void throwExepctionForBadRead(
+      std::string payload, const uint32_t& detID, const int& col, const int& row, double value = -1) const;
 
   edm::ParameterSet conf_;
   bool ESetupInit_;
@@ -106,217 +102,223 @@ class SiPixelGainCalibrationServicePayloadGetter : public SiPixelGainCalibration
   double pedHigh_;
 
   uint32_t old_detID;
-  int      old_cols;
+  int old_cols;
   // Cache data for payloads that average over columns
-  
+
   // these two quantities determine what column averaged block we are in - i.e. ROC 1 or ROC 2
-  int      oldAveragedBlockDataGain_;
-  int      oldAveragedBlockDataPed_;
-  
-  bool     oldThisColumnIsDeadGain_;
-  bool     oldThisColumnIsDeadPed_;
-  bool     oldThisColumnIsNoisyGain_;
-  bool     oldThisColumnIsNoisyPed_;
-  int      oldColumnIndexGain_;
-  int      oldColumnIndexPed_;
-  float    oldColumnValueGain_;
-  float    oldColumnValuePed_;
+  int oldAveragedBlockDataGain_;
+  int oldAveragedBlockDataPed_;
+
+  bool oldThisColumnIsDeadGain_;
+  bool oldThisColumnIsDeadPed_;
+  bool oldThisColumnIsNoisyGain_;
+  bool oldThisColumnIsNoisyPed_;
+  int oldColumnIndexGain_;
+  int oldColumnIndexPed_;
+  float oldColumnValueGain_;
+  float oldColumnValuePed_;
 
   typename thePayloadObject::Range old_range;
 };
 
-template<class thePayloadObject, class theDBRecordType>
-SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::SiPixelGainCalibrationServicePayloadGetter(const edm::ParameterSet& conf):
-  conf_(conf),
-  ESetupInit_(false)
-{
-
-  edm::LogInfo("SiPixelGainCalibrationServicePayloadGetter")  << "[SiPixelGainCalibrationServicePayloadGetter::SiPixelGainCalibrationServicePayloadGetter]";
+template <class thePayloadObject, class theDBRecordType>
+SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::SiPixelGainCalibrationServicePayloadGetter(
+    const edm::ParameterSet& conf)
+    : conf_(conf), ESetupInit_(false) {
+  edm::LogInfo("SiPixelGainCalibrationServicePayloadGetter")
+      << "[SiPixelGainCalibrationServicePayloadGetter::SiPixelGainCalibrationServicePayloadGetter]";
   // Initialize cache variables
-  old_detID             = 0;
-  oldColumnIndexGain_   = -1;
-  oldColumnIndexPed_    = -1;
-  oldColumnValueGain_   = 0.;
-  oldColumnValuePed_    = 0.; 
+  old_detID = 0;
+  oldColumnIndexGain_ = -1;
+  oldColumnIndexPed_ = -1;
+  oldColumnValueGain_ = 0.;
+  oldColumnValuePed_ = 0.;
 
   oldAveragedBlockDataGain_ = -1;
-  oldAveragedBlockDataPed_  = -1;
+  oldAveragedBlockDataPed_ = -1;
   oldThisColumnIsDeadGain_ = false;
-  oldThisColumnIsDeadPed_  = false;
+  oldThisColumnIsDeadPed_ = false;
   oldThisColumnIsNoisyGain_ = false;
-  oldThisColumnIsNoisyPed_  = false;
-
+  oldThisColumnIsNoisyPed_ = false;
 }
 
-template<class thePayloadObject, class theDBRecordType>
-void SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::setESObjects( const edm::EventSetup& es ) {
-
-    es.get<theDBRecordType>().get(ped);
-    // ped->initialize();  moved to cond infrastructure
-    numberOfRowsAveragedOver_ = ped->getNumberOfRowsToAverageOver();
-    ESetupInit_ = true;
-
+template <class thePayloadObject, class theDBRecordType>
+void SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::setESObjects(
+    const edm::EventSetup& es) {
+  es.get<theDBRecordType>().get(ped);
+  // ped->initialize();  moved to cond infrastructure
+  numberOfRowsAveragedOver_ = ped->getNumberOfRowsToAverageOver();
+  ESetupInit_ = true;
 }
 
-template<class thePayloadObject, class theDBRecordType>
-std::vector<uint32_t> SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::getDetIds() {
-
-  std::vector<uint32_t> vdetId_;  
+template <class thePayloadObject, class theDBRecordType>
+std::vector<uint32_t> SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::getDetIds() {
+  std::vector<uint32_t> vdetId_;
   ped->getDetIds(vdetId_);
   return vdetId_;
-
 }
 
-template<class thePayloadObject, class theDBRecordType>
-double SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::getGainLow() {
+template <class thePayloadObject, class theDBRecordType>
+double SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::getGainLow() {
   double gainLow_ = ped->getGainLow();
   return gainLow_;
 }
 
-template<class thePayloadObject, class theDBRecordType>
-double SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::getGainHigh() {
+template <class thePayloadObject, class theDBRecordType>
+double SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::getGainHigh() {
   double gainHigh_ = ped->getGainHigh();
   return gainHigh_;
 }
 
-template<class thePayloadObject, class theDBRecordType>
-double SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::getPedLow() {
+template <class thePayloadObject, class theDBRecordType>
+double SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::getPedLow() {
   double pedLow_ = ped->getPedLow();
   return pedLow_;
 }
 
-template<class thePayloadObject, class theDBRecordType>
-double SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::getPedHigh() {
+template <class thePayloadObject, class theDBRecordType>
+double SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::getPedHigh() {
   double pedHigh_ = ped->getPedHigh();
   return pedHigh_;
 }
 
-template<class thePayloadObject, class theDBRecordType>
-float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::getPedestalByPixel(const uint32_t& detID,const int& col, const int& row, bool& isDead, bool& isNoisy) { 
-  if(ESetupInit_) {
+template <class thePayloadObject, class theDBRecordType>
+float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::getPedestalByPixel(
+    const uint32_t& detID, const int& col, const int& row, bool& isDead, bool& isNoisy) {
+  if (ESetupInit_) {
     //&&&&&&&&&&&&&&&&&&&&
     //Access from DB
     //&&&&&&&&&&&&&&&&&&&&
-      if (detID != old_detID){
-	old_detID=detID;
-        std::pair<const typename thePayloadObject::Range, const int> rangeAndNCols = ped->getRangeAndNCols(detID);
-	old_range = rangeAndNCols.first;
-	old_cols  = rangeAndNCols.second;
-	oldColumnIndexGain_ = -1;
-      }
-      //std::cout<<" Pedestal "<<ped->getPed(col, row, old_range, old_cols)<<std::endl;
-      return  ped->getPed(col, row, old_range, old_cols, isDead, isNoisy);
-  } else throw cms::Exception("NullPointer")
-    << "[SiPixelGainCalibrationServicePayloadGetter::getPedestalByPixel] SiPixelGainCalibrationRcd not initialized ";
-}
-
-
-template<class thePayloadObject, class theDBRecordType>
-float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::getGainByPixel(const uint32_t& detID,const int& col, const int& row, bool& isDead, bool& isNoisy) {
-  if(ESetupInit_) {
-    //&&&&&&&&&&&&&&&&&&&&
-    //Access from DB
-    //&&&&&&&&&&&&&&&&&&&&
-    if (detID != old_detID){
-      old_detID=detID;
+    if (detID != old_detID) {
+      old_detID = detID;
       std::pair<const typename thePayloadObject::Range, const int> rangeAndNCols = ped->getRangeAndNCols(detID);
       old_range = rangeAndNCols.first;
-      old_cols  = rangeAndNCols.second;
+      old_cols = rangeAndNCols.second;
+      oldColumnIndexGain_ = -1;
+    }
+    //std::cout<<" Pedestal "<<ped->getPed(col, row, old_range, old_cols)<<std::endl;
+    return ped->getPed(col, row, old_range, old_cols, isDead, isNoisy);
+  } else
+    throw cms::Exception("NullPointer") << "[SiPixelGainCalibrationServicePayloadGetter::getPedestalByPixel] "
+                                           "SiPixelGainCalibrationRcd not initialized ";
+}
+
+template <class thePayloadObject, class theDBRecordType>
+float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::getGainByPixel(
+    const uint32_t& detID, const int& col, const int& row, bool& isDead, bool& isNoisy) {
+  if (ESetupInit_) {
+    //&&&&&&&&&&&&&&&&&&&&
+    //Access from DB
+    //&&&&&&&&&&&&&&&&&&&&
+    if (detID != old_detID) {
+      old_detID = detID;
+      std::pair<const typename thePayloadObject::Range, const int> rangeAndNCols = ped->getRangeAndNCols(detID);
+      old_range = rangeAndNCols.first;
+      old_cols = rangeAndNCols.second;
       return oldColumnValuePed_;
     }
     return ped->getGain(col, row, old_range, old_cols, isDead, isNoisy);
-  } else throw cms::Exception("NullPointer")
-    << "[SiPixelGainCalibrationServicePayloadGetter::getGainByPixel] SiPixelGainCalibrationRcd not initialized ";
+  } else
+    throw cms::Exception("NullPointer")
+        << "[SiPixelGainCalibrationServicePayloadGetter::getGainByPixel] SiPixelGainCalibrationRcd not initialized ";
 }
 
-
-template<class thePayloadObject, class theDBRecordType>
-float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::getPedestalByColumn(const uint32_t& detID,const int& col, const int& row, bool& isDeadColumn, bool& isNoisyColumn) { 
-  if(ESetupInit_) {
+template <class thePayloadObject, class theDBRecordType>
+float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::getPedestalByColumn(
+    const uint32_t& detID, const int& col, const int& row, bool& isDeadColumn, bool& isNoisyColumn) {
+  if (ESetupInit_) {
     //&&&&&&&&&&&&&&&&&&&&
     //Access from DB
     //&&&&&&&&&&&&&&&&&&&&
-      // see if we are in the same averaged data block
-      bool inTheSameAveragedDataBlock = false;
-      if ( row / numberOfRowsAveragedOver_ == oldAveragedBlockDataPed_ )
-         inTheSameAveragedDataBlock = true;
+    // see if we are in the same averaged data block
+    bool inTheSameAveragedDataBlock = false;
+    if (row / numberOfRowsAveragedOver_ == oldAveragedBlockDataPed_)
+      inTheSameAveragedDataBlock = true;
 
-      if (detID != old_detID){
-	old_detID=detID;
-        std::pair<const typename thePayloadObject::Range, const int> rangeAndNCols = ped->getRangeAndNCols(detID);
-	old_range = rangeAndNCols.first;
-	old_cols  = rangeAndNCols.second;
-	oldColumnIndexGain_ = -1;
-      } 
-      else if (col == oldColumnIndexPed_ && inTheSameAveragedDataBlock) // same DetID, same column, same data block
-      {
-         isDeadColumn = oldThisColumnIsDeadPed_;
-         isNoisyColumn = oldThisColumnIsNoisyPed_;
-         return oldColumnValuePed_;
-      } 
-
-      oldColumnIndexPed_       = col;
-      oldAveragedBlockDataPed_ = row / numberOfRowsAveragedOver_;
-      oldColumnValuePed_       = ped->getPed(col, row, old_range, old_cols, isDeadColumn, isNoisyColumn);
-      oldThisColumnIsDeadPed_  = isDeadColumn;
-      oldThisColumnIsNoisyPed_  = isNoisyColumn;
-
+    if (detID != old_detID) {
+      old_detID = detID;
+      std::pair<const typename thePayloadObject::Range, const int> rangeAndNCols = ped->getRangeAndNCols(detID);
+      old_range = rangeAndNCols.first;
+      old_cols = rangeAndNCols.second;
+      oldColumnIndexGain_ = -1;
+    } else if (col == oldColumnIndexPed_ && inTheSameAveragedDataBlock)  // same DetID, same column, same data block
+    {
+      isDeadColumn = oldThisColumnIsDeadPed_;
+      isNoisyColumn = oldThisColumnIsNoisyPed_;
       return oldColumnValuePed_;
+    }
 
-  } else throw cms::Exception("NullPointer")
-    << "[SiPixelGainCalibrationServicePayloadGetter::getPedestalByColumn] SiPixelGainCalibrationRcd not initialized ";
+    oldColumnIndexPed_ = col;
+    oldAveragedBlockDataPed_ = row / numberOfRowsAveragedOver_;
+    oldColumnValuePed_ = ped->getPed(col, row, old_range, old_cols, isDeadColumn, isNoisyColumn);
+    oldThisColumnIsDeadPed_ = isDeadColumn;
+    oldThisColumnIsNoisyPed_ = isNoisyColumn;
+
+    return oldColumnValuePed_;
+
+  } else
+    throw cms::Exception("NullPointer") << "[SiPixelGainCalibrationServicePayloadGetter::getPedestalByColumn] "
+                                           "SiPixelGainCalibrationRcd not initialized ";
 }
 
-
-template<class thePayloadObject, class theDBRecordType>
-float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::getGainByColumn(const uint32_t& detID,const int& col, const int& row, bool& isDeadColumn, bool& isNoisyColumn) {
-  if(ESetupInit_) {
+template <class thePayloadObject, class theDBRecordType>
+float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::getGainByColumn(
+    const uint32_t& detID, const int& col, const int& row, bool& isDeadColumn, bool& isNoisyColumn) {
+  if (ESetupInit_) {
     //&&&&&&&&&&&&&&&&&&&&
     //Access from DB
     //&&&&&&&&&&&&&&&&&&&&
     bool inTheSameAveragedDataBlock = false;
-    if ( row / numberOfRowsAveragedOver_ == oldAveragedBlockDataGain_ )
-       inTheSameAveragedDataBlock = true;
+    if (row / numberOfRowsAveragedOver_ == oldAveragedBlockDataGain_)
+      inTheSameAveragedDataBlock = true;
 
-    if (detID != old_detID){
-      old_detID=detID;
+    if (detID != old_detID) {
+      old_detID = detID;
       std::pair<const typename thePayloadObject::Range, const int> rangeAndNCols = ped->getRangeAndNCols(detID);
       old_range = rangeAndNCols.first;
-      old_cols  = rangeAndNCols.second;
+      old_cols = rangeAndNCols.second;
       oldColumnIndexPed_ = -1;
-    }
-    else if (col == oldColumnIndexGain_ && inTheSameAveragedDataBlock) // same DetID, same column
+    } else if (col == oldColumnIndexGain_ && inTheSameAveragedDataBlock)  // same DetID, same column
     {
-       isDeadColumn = oldThisColumnIsDeadGain_;
-       isDeadColumn = oldThisColumnIsNoisyGain_;
-       return oldColumnValueGain_;
+      isDeadColumn = oldThisColumnIsDeadGain_;
+      isDeadColumn = oldThisColumnIsNoisyGain_;
+      return oldColumnValueGain_;
     }
 
-    oldColumnIndexGain_       = col;
+    oldColumnIndexGain_ = col;
     oldAveragedBlockDataGain_ = row / numberOfRowsAveragedOver_;
-    oldColumnValueGain_       = ped->getGain(col, row, old_range, old_cols, isDeadColumn, isNoisyColumn);
-    oldThisColumnIsDeadGain_  = isDeadColumn;
-    oldThisColumnIsNoisyGain_  = isNoisyColumn;
+    oldColumnValueGain_ = ped->getGain(col, row, old_range, old_cols, isDeadColumn, isNoisyColumn);
+    oldThisColumnIsDeadGain_ = isDeadColumn;
+    oldThisColumnIsNoisyGain_ = isNoisyColumn;
 
     return oldColumnValueGain_;
 
-  } else throw cms::Exception("NullPointer")
-    << "[SiPixelGainCalibrationServicePayloadGetter::getGainByColumn] SiPixelGainCalibrationRcd not initialized ";
+  } else
+    throw cms::Exception("NullPointer")
+        << "[SiPixelGainCalibrationServicePayloadGetter::getGainByColumn] SiPixelGainCalibrationRcd not initialized ";
 }
 
-template<class thePayloadObject, class theDBRecordType>
-void SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::throwExepctionForBadRead(std::string payload, const uint32_t& detID, const int& col, const int& row, const double value) const
-{
-   std::cerr << "[SiPixelGainCalibrationServicePayloadGetter::SiPixelGainCalibrationServicePayloadGetter]"
-      << "[SiPixelGainCalibrationServicePayloadGetter] ERROR - Slow down, speed racer! You have tried to read the ped/gain on a pixel that is flagged as dead/noisy. For payload: " << payload << "  DETID: " 
-      << detID << " col: " << col << " row: " << row << ". You must check if the pixel is dead/noisy before asking for the ped/gain value, otherwise you will get corrupt data! value: " << value << std::endl;
+template <class thePayloadObject, class theDBRecordType>
+void SiPixelGainCalibrationServicePayloadGetter<thePayloadObject, theDBRecordType>::throwExepctionForBadRead(
+    std::string payload, const uint32_t& detID, const int& col, const int& row, const double value) const {
+  std::cerr << "[SiPixelGainCalibrationServicePayloadGetter::SiPixelGainCalibrationServicePayloadGetter]"
+            << "[SiPixelGainCalibrationServicePayloadGetter] ERROR - Slow down, speed racer! You have tried to read "
+               "the ped/gain on a pixel that is flagged as dead/noisy. For payload: "
+            << payload << "  DETID: " << detID << " col: " << col << " row: " << row
+            << ". You must check if the pixel is dead/noisy before asking for the ped/gain value, otherwise you will "
+               "get corrupt data! value: "
+            << value << std::endl;
 
-   // really yell if this occurs
+  // really yell if this occurs
 
-   edm::LogError("SiPixelGainCalibrationService") << "[SiPixelGainCalibrationServicePayloadGetter::SiPixelGainCalibrationServicePayloadGetter]"
-      << "[SiPixelGainCalibrationServicePayloadGetter] ERROR - Slow down, speed racer! You have tried to read the ped/gain on a pixel that is flagged as dead/noisy. For payload: " << payload << "  DETID: " 
-      << detID << " col: " << col << " row: " << row << ". You must check if the pixel is dead/noisy before asking for the ped/gain value, otherwise you will get corrupt data! value: " << value << std::endl;
+  edm::LogError("SiPixelGainCalibrationService")
+      << "[SiPixelGainCalibrationServicePayloadGetter::SiPixelGainCalibrationServicePayloadGetter]"
+      << "[SiPixelGainCalibrationServicePayloadGetter] ERROR - Slow down, speed racer! You have tried to read the "
+         "ped/gain on a pixel that is flagged as dead/noisy. For payload: "
+      << payload << "  DETID: " << detID << " col: " << col << " row: " << row
+      << ". You must check if the pixel is dead/noisy before asking for the ped/gain value, otherwise you will get "
+         "corrupt data! value: "
+      << value << std::endl;
 }
-
 
 #endif

--- a/CalibTracker/SiPixelESProducers/plugins/PixelFEDChannelCollectionProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/PixelFEDChannelCollectionProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CalibTracker/PixelFEDChannelCollectionProducer
 // Class:      PixelFEDChannelCollectionProducer
-// 
+//
 /**\class PixelFEDChannelCollectionProducer
 
  Description: [one line class summary]
@@ -24,7 +24,7 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "CondFormats/DataRecord/interface/SiPixelStatusScenariosRcd.h" 
+#include "CondFormats/DataRecord/interface/SiPixelStatusScenariosRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFEDChannelContainer.h"
 #include "CalibTracker/Records/interface/SiPixelFEDChannelContainerESProducerRcd.h"
 
@@ -36,36 +36,31 @@
 //
 
 class PixelFEDChannelCollectionProducer : public edm::ESProducer {
-   public:
-      PixelFEDChannelCollectionProducer(const edm::ParameterSet&);
-      ~PixelFEDChannelCollectionProducer() override;
+public:
+  PixelFEDChannelCollectionProducer(const edm::ParameterSet&);
+  ~PixelFEDChannelCollectionProducer() override;
 
-      typedef std::unordered_map<std::string,PixelFEDChannelCollection> PixelFEDChannelCollectionMap;
-      using ReturnType = std::unique_ptr<PixelFEDChannelCollectionMap>;
+  typedef std::unordered_map<std::string, PixelFEDChannelCollection> PixelFEDChannelCollectionMap;
+  using ReturnType = std::unique_ptr<PixelFEDChannelCollectionMap>;
 
-      ReturnType produce(const SiPixelFEDChannelContainerESProducerRcd &);
-   private:
-      // ----------member data ---------------------------
+  ReturnType produce(const SiPixelFEDChannelContainerESProducerRcd&);
+
+private:
+  // ----------member data ---------------------------
   edm::ESGetToken<SiPixelFEDChannelContainer, SiPixelStatusScenariosRcd> qualityToken_;
 };
 
+PixelFEDChannelCollectionProducer::PixelFEDChannelCollectionProducer(const edm::ParameterSet& iConfig) {
+  //the following line is needed to tell the framework what
+  // data is being produced
+  setWhatProduced(this).setConsumes(qualityToken_);
 
-PixelFEDChannelCollectionProducer::PixelFEDChannelCollectionProducer(const edm::ParameterSet& iConfig)
-{
-   //the following line is needed to tell the framework what
-   // data is being produced
-   setWhatProduced(this).setConsumes(qualityToken_);
-
-   //now do what ever other initialization is needed
+  //now do what ever other initialization is needed
 }
 
-
-PixelFEDChannelCollectionProducer::~PixelFEDChannelCollectionProducer()
-{
- 
-   // do anything here that needs to be done at destruction time
-   // (e.g. close files, deallocate resources etc.)
-
+PixelFEDChannelCollectionProducer::~PixelFEDChannelCollectionProducer() {
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -73,25 +68,23 @@ PixelFEDChannelCollectionProducer::~PixelFEDChannelCollectionProducer()
 //
 
 // ------------ method called to produce the data  ------------
-PixelFEDChannelCollectionProducer::ReturnType
-PixelFEDChannelCollectionProducer::produce(const SiPixelFEDChannelContainerESProducerRcd& iRecord)
-{
+PixelFEDChannelCollectionProducer::ReturnType PixelFEDChannelCollectionProducer::produce(
+    const SiPixelFEDChannelContainerESProducerRcd& iRecord) {
   const auto& qualityCollection = iRecord.get(qualityToken_);
 
   auto out = std::make_unique<PixelFEDChannelCollectionMap>();
 
-  for(const auto& it : qualityCollection.getScenarioMap()){
- 
+  for (const auto& it : qualityCollection.getScenarioMap()) {
     const std::string& scenario = it.first;
     // getScenarioMap() is an unordered_map<string, ...>, so each scenario appears exactly once
     PixelFEDChannelCollection& disabled_channelcollection = (*out)[scenario];
 
     const auto& SiPixelBadFedChannels = it.second;
-    for(const auto &entry : SiPixelBadFedChannels){
+    for (const auto& entry : SiPixelBadFedChannels) {
       disabled_channelcollection.insert(entry.first, entry.second.data(), entry.second.size());
     }
   }
-  
+
   return out;
 }
 

--- a/CalibTracker/SiPixelESProducers/plugins/SealModules.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SealModules.cc
@@ -14,7 +14,6 @@
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelFakeTemplateDBObjectESSource.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelFakeQualityESSource.h"
 
-
 DEFINE_FWK_EVENTSETUP_SOURCE(SiPixelFakeGainESSource);
 DEFINE_FWK_EVENTSETUP_SOURCE(SiPixelFakeGainForHLTESSource);
 DEFINE_FWK_EVENTSETUP_SOURCE(SiPixelFakeGainOfflineESSource);

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelDetInfoFileWriter.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelDetInfoFileWriter.cc
@@ -9,84 +9,63 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 
-
 using namespace cms;
 using namespace std;
 
-
-SiPixelDetInfoFileWriter::SiPixelDetInfoFileWriter(const edm::ParameterSet& iConfig) {
-
-  
+SiPixelDetInfoFileWriter::SiPixelDetInfoFileWriter(const edm::ParameterSet &iConfig) {
   edm::LogInfo("SiPixelDetInfoFileWriter::SiPixelDetInfoFileWriter");
 
-  filePath_ = iConfig.getUntrackedParameter<std::string>("FilePath",std::string("SiPixelDetInfo.dat"));
-
+  filePath_ = iConfig.getUntrackedParameter<std::string>("FilePath", std::string("SiPixelDetInfo.dat"));
 }
 
-
-SiPixelDetInfoFileWriter::~SiPixelDetInfoFileWriter(){
-
-   edm::LogInfo("SiPixelDetInfoFileWriter::~SiPixelDetInfoFileWriter");
+SiPixelDetInfoFileWriter::~SiPixelDetInfoFileWriter() {
+  edm::LogInfo("SiPixelDetInfoFileWriter::~SiPixelDetInfoFileWriter");
 }
 
-
-
-void SiPixelDetInfoFileWriter::beginRun(const edm::Run &run , const edm::EventSetup &iSetup){
-
+void SiPixelDetInfoFileWriter::beginRun(const edm::Run &run, const edm::EventSetup &iSetup) {
   outputFile_.open(filePath_.c_str());
 
-  if (outputFile_.is_open()){
-
+  if (outputFile_.is_open()) {
     edm::ESHandle<TrackerGeometry> pDD;
 
-    iSetup.get<TrackerDigiGeometryRecord>().get( pDD );
+    iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
 
-    edm::LogInfo("SiPixelDetInfoFileWriter::beginJob - got geometry  ")<<std::endl;    
-    edm::LogInfo("SiPixelDetInfoFileWriter") <<" There are "<<pDD->detUnits().size() <<" detectors"<<std::endl;
-    
+    edm::LogInfo("SiPixelDetInfoFileWriter::beginJob - got geometry  ") << std::endl;
+    edm::LogInfo("SiPixelDetInfoFileWriter") << " There are " << pDD->detUnits().size() << " detectors" << std::endl;
+
     int nPixelDets = 0;
 
-    for( const auto& it : pDD->detUnits()) {
-  
-      const PixelGeomDetUnit* mit = dynamic_cast<PixelGeomDetUnit const *>(it);
+    for (const auto &it : pDD->detUnits()) {
+      const PixelGeomDetUnit *mit = dynamic_cast<PixelGeomDetUnit const *>(it);
 
-      if(mit!=nullptr){
-	nPixelDets++;
-      const PixelTopology & topol = mit->specificTopology();       
-      // Get the module sizes.
-      int nrows = topol.nrows();      // rows in x
-      int ncols = topol.ncolumns();   // cols in y      
-      uint32_t detid=(mit->geographicalId()).rawId();
-      
-      
-      outputFile_ << detid << " "<< ncols << " " << nrows << "\n";
-      
+      if (mit != nullptr) {
+        nPixelDets++;
+        const PixelTopology &topol = mit->specificTopology();
+        // Get the module sizes.
+        int nrows = topol.nrows();     // rows in x
+        int ncols = topol.ncolumns();  // cols in y
+        uint32_t detid = (mit->geographicalId()).rawId();
+
+        outputFile_ << detid << " " << ncols << " " << nrows << "\n";
       }
-    }    
+    }
     outputFile_.close();
-    edm::LogInfo("SiPixelDetInfoFileWriter::beginJob - Loop finished. ")<< nPixelDets << " Pixel DetUnits found " << std::endl;
+    edm::LogInfo("SiPixelDetInfoFileWriter::beginJob - Loop finished. ")
+        << nPixelDets << " Pixel DetUnits found " << std::endl;
   }
-  
+
   else {
-
-    edm::LogError("SiPixelDetInfoFileWriter::beginJob - Unable to open file")<<endl;
+    edm::LogError("SiPixelDetInfoFileWriter::beginJob - Unable to open file") << endl;
     return;
-  
   }
-
 }
 
+void SiPixelDetInfoFileWriter::beginJob() {}
 
-void SiPixelDetInfoFileWriter::beginJob() {
-
-}
-
-void SiPixelDetInfoFileWriter::analyze(const edm::Event &, const edm::EventSetup &) {
-
-}
+void SiPixelDetInfoFileWriter::analyze(const edm::Event &, const edm::EventSetup &) {}

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeCPEGenericErrorParmESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeCPEGenericErrorParmESSource.cc
@@ -1,32 +1,30 @@
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelFakeCPEGenericErrorParmESSource.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-SiPixelFakeCPEGenericErrorParmESSource::SiPixelFakeCPEGenericErrorParmESSource(const edm::ParameterSet& conf_) : fp_(conf_.getParameter<edm::FileInPath>("file")), version_(conf_.getParameter<double>("version"))
-{
-	edm::LogInfo("SiPixelFakeCPEGenericErrorParmESSource::SiPixelFakeCPEGenericErrorParmESSource");
-	//the following line is needed to tell the framework what
-	// data is being produced
-	setWhatProduced(this);
-	findingRecord<SiPixelCPEGenericErrorParmRcd>();
+SiPixelFakeCPEGenericErrorParmESSource::SiPixelFakeCPEGenericErrorParmESSource(const edm::ParameterSet& conf_)
+    : fp_(conf_.getParameter<edm::FileInPath>("file")), version_(conf_.getParameter<double>("version")) {
+  edm::LogInfo("SiPixelFakeCPEGenericErrorParmESSource::SiPixelFakeCPEGenericErrorParmESSource");
+  //the following line is needed to tell the framework what
+  // data is being produced
+  setWhatProduced(this);
+  findingRecord<SiPixelCPEGenericErrorParmRcd>();
 }
 
-SiPixelFakeCPEGenericErrorParmESSource::~SiPixelFakeCPEGenericErrorParmESSource()
-{
+SiPixelFakeCPEGenericErrorParmESSource::~SiPixelFakeCPEGenericErrorParmESSource() {}
+
+std::unique_ptr<SiPixelCPEGenericErrorParm> SiPixelFakeCPEGenericErrorParmESSource::produce(
+    const SiPixelCPEGenericErrorParmRcd&) {
+  using namespace edm::es;
+  SiPixelCPEGenericErrorParm* obj = new SiPixelCPEGenericErrorParm();
+  obj->fillCPEGenericErrorParm(version_, fp_.fullPath());
+  //std::cout << *obj << std::endl;
+
+  return std::unique_ptr<SiPixelCPEGenericErrorParm>(obj);
 }
 
-std::unique_ptr<SiPixelCPEGenericErrorParm> SiPixelFakeCPEGenericErrorParmESSource::produce(const SiPixelCPEGenericErrorParmRcd & )
-{
-	using namespace edm::es;
-	SiPixelCPEGenericErrorParm * obj = new SiPixelCPEGenericErrorParm();
-	obj->fillCPEGenericErrorParm(version_, fp_.fullPath());
-	//std::cout << *obj << std::endl;
-
-	return std::unique_ptr<SiPixelCPEGenericErrorParm>(obj);
-}
-
-void SiPixelFakeCPEGenericErrorParmESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-						const edm::IOVSyncValue& iosv, 
-						edm::ValidityInterval& oValidity ) {
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
-  oValidity = infinity;  
+void SiPixelFakeCPEGenericErrorParmESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                            const edm::IOVSyncValue& iosv,
+                                                            edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
+  oValidity = infinity;
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainESSource.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SiPixelFakeGainESSource
 // Class:      SiPixelFakeGainESSource
-// 
+//
 /**\class SiPixelFakeGainESSource SiPixelFakeGainESSource.h CalibTracker/SiPixelESProducer/src/SiPixelFakeGainESSource.cc
 
  Description: <one line class summary>
@@ -26,69 +26,61 @@
 //
 // constructors and destructor
 //
-SiPixelFakeGainESSource::SiPixelFakeGainESSource(const edm::ParameterSet& conf_) :
-  fp_(conf_.getParameter<edm::FileInPath>("file"))
-{
- edm::LogInfo("SiPixelFakeGainESSource::SiPixelFakeGainESSource");
+SiPixelFakeGainESSource::SiPixelFakeGainESSource(const edm::ParameterSet& conf_)
+    : fp_(conf_.getParameter<edm::FileInPath>("file")) {
+  edm::LogInfo("SiPixelFakeGainESSource::SiPixelFakeGainESSource");
   //the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this);
   findingRecord<SiPixelGainCalibrationRcd>();
 }
 
-SiPixelFakeGainESSource::~SiPixelFakeGainESSource()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+SiPixelFakeGainESSource::~SiPixelFakeGainESSource() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
 
-std::unique_ptr<SiPixelGainCalibration> SiPixelFakeGainESSource::produce(const SiPixelGainCalibrationRcd & )
-{
+std::unique_ptr<SiPixelGainCalibration> SiPixelFakeGainESSource::produce(const SiPixelGainCalibrationRcd&) {
+  using namespace edm::es;
+  unsigned int nmodules = 0;
+  uint32_t nchannels = 0;
+  SiPixelGainCalibration* obj = new SiPixelGainCalibration(25., 30., 2., 3.);
+  SiPixelDetInfoFileReader reader(fp_.fullPath());
+  const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
-   using namespace edm::es;
-   unsigned int nmodules = 0;
-   uint32_t nchannels = 0;
-   SiPixelGainCalibration * obj = new SiPixelGainCalibration(25.,30., 2.,3.);
-   SiPixelDetInfoFileReader reader(fp_.fullPath());
-   const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
+  // Loop over detectors
+  for (std::vector<uint32_t>::const_iterator detit = DetIds.begin(); detit != DetIds.end(); detit++) {
+    nmodules++;
+    std::vector<char> theSiPixelGainCalibration;
+    const std::pair<int, int>& detUnitDimensions = reader.getDetUnitDimensions(*detit);
 
-   // Loop over detectors
-   for(std::vector<uint32_t>::const_iterator detit=DetIds.begin(); detit!=DetIds.end(); detit++) {
-     nmodules++;
-     std::vector<char> theSiPixelGainCalibration;
-     const std::pair<int, int> & detUnitDimensions = reader.getDetUnitDimensions(*detit);
+    // Loop over columns and rows
+    for (int i = 0; i < detUnitDimensions.first; i++) {
+      for (int j = 0; j < detUnitDimensions.second; j++) {
+        nchannels++;
+        float gain = 2.8;
+        float ped = 28.2;
+        obj->setData(ped, gain, theSiPixelGainCalibration);
+      }
+    }
 
-     // Loop over columns and rows
-     for(int i=0; i<detUnitDimensions.first; i++) {
-       for(int j=0; j<detUnitDimensions.second; j++) {
-	 nchannels++;
-	 float gain =  2.8;
-	 float ped  = 28.2;	 
-	 obj->setData(ped, gain , theSiPixelGainCalibration);	 
-       }
-     }
+    //std::cout << "detid " << (*detit) << std::endl;
 
-     //std::cout << "detid " << (*detit) << std::endl;
+    SiPixelGainCalibration::Range range(theSiPixelGainCalibration.begin(), theSiPixelGainCalibration.end());
+    if (!obj->put(*detit, range, detUnitDimensions.first))
+      edm::LogError("SiPixelFakeGainESSource")
+          << "[SiPixelFakeGainESSource::produce] detid already exists" << std::endl;
+  }
 
-     SiPixelGainCalibration::Range range(theSiPixelGainCalibration.begin(),theSiPixelGainCalibration.end());
-     if( !obj->put(*detit,range,detUnitDimensions.first) )
-       edm::LogError("SiPixelFakeGainESSource")<<"[SiPixelFakeGainESSource::produce] detid already exists"<<std::endl;
-   }
+  //std::cout << "Modules = " << nmodules << " Channels " << nchannels << std::endl;
 
-   //std::cout << "Modules = " << nmodules << " Channels " << nchannels << std::endl;
-   
-
-   // 
-   return std::unique_ptr<SiPixelGainCalibration>(obj);
-
-
+  //
+  return std::unique_ptr<SiPixelGainCalibration>(obj);
 }
 
-void SiPixelFakeGainESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-						const edm::IOVSyncValue& iosv, 
-						edm::ValidityInterval& oValidity ) {
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
-  oValidity = infinity;  
+void SiPixelFakeGainESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                             const edm::IOVSyncValue& iosv,
+                                             edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
+  oValidity = infinity;
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainForHLTESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainForHLTESSource.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SiPixelFakeGainForHLTESSource
 // Class:      SiPixelFakeGainForHLTESSource
-// 
+//
 /**\class SiPixelFakeGainForHLTESSource SiPixelFakeGainForHLTESSource.h CalibTracker/SiPixelESProducer/src/SiPixelFakeGainForHLTESSource.cc
 
  Description: <one line class summary>
@@ -26,83 +26,76 @@
 //
 // constructors and destructor
 //
-SiPixelFakeGainForHLTESSource::SiPixelFakeGainForHLTESSource(const edm::ParameterSet& conf_) :
-  fp_(conf_.getParameter<edm::FileInPath>("file"))
-{
- edm::LogInfo("SiPixelFakeGainForHLTESSource::SiPixelFakeGainForHLTESSource");
+SiPixelFakeGainForHLTESSource::SiPixelFakeGainForHLTESSource(const edm::ParameterSet& conf_)
+    : fp_(conf_.getParameter<edm::FileInPath>("file")) {
+  edm::LogInfo("SiPixelFakeGainForHLTESSource::SiPixelFakeGainForHLTESSource");
   //the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this);
   findingRecord<SiPixelGainCalibrationForHLTRcd>();
 }
 
-SiPixelFakeGainForHLTESSource::~SiPixelFakeGainForHLTESSource()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+SiPixelFakeGainForHLTESSource::~SiPixelFakeGainForHLTESSource() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
 
-std::unique_ptr<SiPixelGainCalibrationForHLT> SiPixelFakeGainForHLTESSource::produce(const SiPixelGainCalibrationForHLTRcd & )
-{
+std::unique_ptr<SiPixelGainCalibrationForHLT> SiPixelFakeGainForHLTESSource::produce(
+    const SiPixelGainCalibrationForHLTRcd&) {
+  using namespace edm::es;
+  unsigned int nmodules = 0;
+  uint32_t nchannels = 0;
+  SiPixelGainCalibrationForHLT* obj = new SiPixelGainCalibrationForHLT(25., 30., 2., 3.);
+  SiPixelDetInfoFileReader reader(fp_.fullPath());
+  const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
-   using namespace edm::es;
-   unsigned int nmodules = 0;
-   uint32_t nchannels = 0;
-   SiPixelGainCalibrationForHLT * obj = new SiPixelGainCalibrationForHLT(25.,30., 2.,3.);
-   SiPixelDetInfoFileReader reader(fp_.fullPath());
-   const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
+  // Loop over detectors
+  for (std::vector<uint32_t>::const_iterator detit = DetIds.begin(); detit != DetIds.end(); detit++) {
+    nmodules++;
+    std::vector<char> theSiPixelGainCalibration;
+    const std::pair<int, int>& detUnitDimensions = reader.getDetUnitDimensions(*detit);
 
-   // Loop over detectors
-   for(std::vector<uint32_t>::const_iterator detit=DetIds.begin(); detit!=DetIds.end(); detit++) {
-     nmodules++;
-     std::vector<char> theSiPixelGainCalibration;
-     const std::pair<int, int> & detUnitDimensions = reader.getDetUnitDimensions(*detit);
+    // Loop over columns and rows
 
-     // Loop over columns and rows
- 
-     for(int i=0; i<detUnitDimensions.first; i++) {
-       float totalGain  = 0.0;
-       float totalPed   = 0.0; 
-       float totalEntries=0.0;
-       for(int j=0; j<detUnitDimensions.second; j++) {
-	 nchannels++;
-         totalGain      += 2.8;
-         totalPed       += 28.2;
-	 totalEntries   ++;
-	 if((j+1)%80==0){
-	   float gain       = totalGain/totalEntries;
-	   float ped        = totalPed/totalEntries;
-	   
-	   obj->setData(ped,gain, theSiPixelGainCalibration);	 
-	   totalGain=0.;
-	   totalPed=0.;
-	   totalEntries=0.;
-	 }
-       }
-     }
+    for (int i = 0; i < detUnitDimensions.first; i++) {
+      float totalGain = 0.0;
+      float totalPed = 0.0;
+      float totalEntries = 0.0;
+      for (int j = 0; j < detUnitDimensions.second; j++) {
+        nchannels++;
+        totalGain += 2.8;
+        totalPed += 28.2;
+        totalEntries++;
+        if ((j + 1) % 80 == 0) {
+          float gain = totalGain / totalEntries;
+          float ped = totalPed / totalEntries;
 
-     //std::cout << "detid " << (*detit) << std::endl;
+          obj->setData(ped, gain, theSiPixelGainCalibration);
+          totalGain = 0.;
+          totalPed = 0.;
+          totalEntries = 0.;
+        }
+      }
+    }
 
-     SiPixelGainCalibrationForHLT::Range range(theSiPixelGainCalibration.begin(),theSiPixelGainCalibration.end());
-     int nCols = detUnitDimensions.first;
-     if( !obj->put(*detit,range,nCols) )
-       edm::LogError("SiPixelFakeGainForHLTESSource")<<"[SiPixelFakeGainForHLTESSource::produce] detid already exists"<<std::endl;
-   }
+    //std::cout << "detid " << (*detit) << std::endl;
 
-   //std::cout << "Modules = " << nmodules << " Channels " << nchannels << std::endl;
-   
+    SiPixelGainCalibrationForHLT::Range range(theSiPixelGainCalibration.begin(), theSiPixelGainCalibration.end());
+    int nCols = detUnitDimensions.first;
+    if (!obj->put(*detit, range, nCols))
+      edm::LogError("SiPixelFakeGainForHLTESSource")
+          << "[SiPixelFakeGainForHLTESSource::produce] detid already exists" << std::endl;
+  }
 
-   // 
-   return std::unique_ptr<SiPixelGainCalibrationForHLT>(obj);
+  //std::cout << "Modules = " << nmodules << " Channels " << nchannels << std::endl;
 
-
+  //
+  return std::unique_ptr<SiPixelGainCalibrationForHLT>(obj);
 }
 
-void SiPixelFakeGainForHLTESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-						    const edm::IOVSyncValue& iosv, 
-						    edm::ValidityInterval& oValidity ) {
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
-  oValidity = infinity;  
+void SiPixelFakeGainForHLTESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                   const edm::IOVSyncValue& iosv,
+                                                   edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
+  oValidity = infinity;
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainOfflineESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainOfflineESSource.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SiPixelFakeGainOfflineESSource
 // Class:      SiPixelFakeGainOfflineESSource
-// 
+//
 /**\class SiPixelFakeGainOfflineESSource SiPixelFakeGainOfflineESSource.h CalibTracker/SiPixelESProducer/src/SiPixelFakeGainOfflineESSource.cc
 
  Description: <one line class summary>
@@ -26,80 +26,74 @@
 //
 // constructors and destructor
 //
-SiPixelFakeGainOfflineESSource::SiPixelFakeGainOfflineESSource(const edm::ParameterSet& conf_) :
-  fp_(conf_.getParameter<edm::FileInPath>("file"))
-{
- edm::LogInfo("SiPixelFakeGainOfflineESSource::SiPixelFakeGainOfflineESSource");
+SiPixelFakeGainOfflineESSource::SiPixelFakeGainOfflineESSource(const edm::ParameterSet& conf_)
+    : fp_(conf_.getParameter<edm::FileInPath>("file")) {
+  edm::LogInfo("SiPixelFakeGainOfflineESSource::SiPixelFakeGainOfflineESSource");
   //the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this);
   findingRecord<SiPixelGainCalibrationOfflineRcd>();
 }
 
-SiPixelFakeGainOfflineESSource::~SiPixelFakeGainOfflineESSource()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+SiPixelFakeGainOfflineESSource::~SiPixelFakeGainOfflineESSource() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
 
-std::unique_ptr<SiPixelGainCalibrationOffline> SiPixelFakeGainOfflineESSource::produce(const SiPixelGainCalibrationOfflineRcd & )
-{
+std::unique_ptr<SiPixelGainCalibrationOffline> SiPixelFakeGainOfflineESSource::produce(
+    const SiPixelGainCalibrationOfflineRcd&) {
+  using namespace edm::es;
+  unsigned int nmodules = 0;
+  uint32_t nchannels = 0;
+  SiPixelGainCalibrationOffline* obj = new SiPixelGainCalibrationOffline(25., 30., 2., 3.);
+  SiPixelDetInfoFileReader reader(fp_.fullPath());
+  const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
-   using namespace edm::es;
-   unsigned int nmodules = 0;
-   uint32_t nchannels = 0;
-   SiPixelGainCalibrationOffline * obj = new SiPixelGainCalibrationOffline(25.,30., 2.,3.);
-   SiPixelDetInfoFileReader reader(fp_.fullPath());
-   const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
+  // Loop over detectors
+  for (std::vector<uint32_t>::const_iterator detit = DetIds.begin(); detit != DetIds.end(); detit++) {
+    nmodules++;
+    std::vector<char> theSiPixelGainCalibrationOffline;
+    const std::pair<int, int>& detUnitDimensions = reader.getDetUnitDimensions(*detit);
 
-   // Loop over detectors
-   for(std::vector<uint32_t>::const_iterator detit=DetIds.begin(); detit!=DetIds.end(); detit++) {
-     nmodules++;
-     std::vector<char> theSiPixelGainCalibrationOffline;
-     const std::pair<int, int> & detUnitDimensions = reader.getDetUnitDimensions(*detit);
+    // Loop over columns and rows
+    for (int i = 0; i < detUnitDimensions.first; i++) {
+      float totalGain = 0.0;
+      float totalEntries = 0.0;
+      for (int j = 0; j < detUnitDimensions.second; j++) {
+        nchannels++;
+        totalGain += 2.8;
+        float ped = 28.2;
+        totalEntries += 1.0;
+        obj->setDataPedestal(ped, theSiPixelGainCalibrationOffline);
+        if ((j + 1) % 80 == 0)  //compute the gain average after each ROC
+        {
+          float gain = totalGain / totalEntries;
+          obj->setDataGain(gain, 80, theSiPixelGainCalibrationOffline);
+          totalGain = 0;
+          totalEntries = 0.0;
+        }
+      }
+    }
 
-     // Loop over columns and rows
-     for(int i=0; i<detUnitDimensions.first; i++) {
-       float totalGain    = 0.0;
-       float totalEntries = 0.0;
-       for(int j=0; j<detUnitDimensions.second; j++) {
-	 nchannels++;
-         totalGain  += 2.8;
-	 float ped  = 28.2;	 
-         totalEntries += 1.0;
-	 obj->setDataPedestal(ped, theSiPixelGainCalibrationOffline);	 
-         if ((j + 1) % 80 == 0) //compute the gain average after each ROC
-         {
-            float gain = totalGain/totalEntries;
-            obj->setDataGain(gain, 80, theSiPixelGainCalibrationOffline);
-            totalGain    = 0;
-            totalEntries = 0.0;
-         }
-       }
-     }
+    //std::cout << "detid " << (*detit) << std::endl;
 
-     //std::cout << "detid " << (*detit) << std::endl;
+    SiPixelGainCalibrationOffline::Range range(theSiPixelGainCalibrationOffline.begin(),
+                                               theSiPixelGainCalibrationOffline.end());
+    // the 80 in the line below represents the number of columns averaged over.
+    if (!obj->put(*detit, range, detUnitDimensions.first))
+      edm::LogError("SiPixelFakeGainOfflineESSource")
+          << "[SiPixelFakeGainOfflineESSource::produce] detid already exists" << std::endl;
+  }
 
-     SiPixelGainCalibrationOffline::Range range(theSiPixelGainCalibrationOffline.begin(),theSiPixelGainCalibrationOffline.end());
-     // the 80 in the line below represents the number of columns averaged over.  
-     if( !obj->put(*detit,range,detUnitDimensions.first) )
-       edm::LogError("SiPixelFakeGainOfflineESSource")<<"[SiPixelFakeGainOfflineESSource::produce] detid already exists"<<std::endl;
-   }
+  //std::cout << "Modules = " << nmodules << " Channels " << nchannels << std::endl;
 
-   //std::cout << "Modules = " << nmodules << " Channels " << nchannels << std::endl;
-   
-
-   // 
-   return std::unique_ptr<SiPixelGainCalibrationOffline>(obj);
-
-
+  //
+  return std::unique_ptr<SiPixelGainCalibrationOffline>(obj);
 }
 
-void SiPixelFakeGainOfflineESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-						const edm::IOVSyncValue& iosv, 
-						edm::ValidityInterval& oValidity ) {
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
-  oValidity = infinity;  
+void SiPixelFakeGainOfflineESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                    const edm::IOVSyncValue& iosv,
+                                                    edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
+  oValidity = infinity;
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
@@ -2,103 +2,99 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <fstream>
 
-SiPixelFakeGenErrorDBObjectESSource::SiPixelFakeGenErrorDBObjectESSource(const edm::ParameterSet& conf_) : GenErrorCalibrations_(conf_.getParameter<vstring>("siPixelGenErrorCalibrations")),
-																																																					 version_(conf_.getParameter<double>("Version"))
-{
-	edm::LogInfo("SiPixelFakeGenErrorDBObjectESSource::SiPixelFakeGenErrorDBObjectESSource");
-	//the following line is needed to tell the framework what
-	// data is being produced
-	setWhatProduced(this);
-	findingRecord<SiPixelGenErrorDBObjectRcd>();
+SiPixelFakeGenErrorDBObjectESSource::SiPixelFakeGenErrorDBObjectESSource(const edm::ParameterSet& conf_)
+    : GenErrorCalibrations_(conf_.getParameter<vstring>("siPixelGenErrorCalibrations")),
+      version_(conf_.getParameter<double>("Version")) {
+  edm::LogInfo("SiPixelFakeGenErrorDBObjectESSource::SiPixelFakeGenErrorDBObjectESSource");
+  //the following line is needed to tell the framework what
+  // data is being produced
+  setWhatProduced(this);
+  findingRecord<SiPixelGenErrorDBObjectRcd>();
 }
 
-SiPixelFakeGenErrorDBObjectESSource::~SiPixelFakeGenErrorDBObjectESSource()
-{
+SiPixelFakeGenErrorDBObjectESSource::~SiPixelFakeGenErrorDBObjectESSource() {}
+
+std::unique_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::produce(
+    const SiPixelGenErrorDBObjectRcd&) {
+  using namespace edm::es;
+
+  //Mostly copied from CondTools/SiPixel/test/SiPixelGenErrorDBObjectUploader.cc
+  //--- Make the POOL-ORA object to store the database object
+  SiPixelGenErrorDBObject* obj = new SiPixelGenErrorDBObject;
+
+  // Local variables
+  const char* tempfile;
+  int m;
+
+  // Set the number of GenErrors to be passed to the dbobject
+  obj->setNumOfTempl(GenErrorCalibrations_.size());
+
+  // Set the version of the GenError dbobject - this is an external parameter
+  obj->setVersion(version_);
+
+  //  open the GenError file(s)
+  for (m = 0; m < obj->numOfTempl(); ++m) {
+    edm::FileInPath file(GenErrorCalibrations_[m].c_str());
+    tempfile = (file.fullPath()).c_str();
+
+    std::ifstream in_file(tempfile, std::ios::in);
+
+    if (in_file.is_open()) {
+      edm::LogInfo("SiPixelFakeGenErrorDBObjectESSource")
+          << "Opened GenError File: " << file.fullPath().c_str() << std::endl;
+
+      // Local variables
+      char title_char[80], c;
+      SiPixelGenErrorDBObject::char2float temp;
+      float tempstore;
+      unsigned int iter;
+
+      // GenErrors contain a header char - we must be clever about storing this
+      for (iter = 0; (c = in_file.get()) != '\n' && iter < 79; ++iter) {
+        title_char[iter] = c;
+      }
+      if (iter == 79) {
+        title_char[iter] = '\n';
+      } else {
+        unsigned int ilast = 3 - (iter % 4);
+        for (unsigned int it = 0; it != ilast; it++) {
+          title_char[iter] = ' ';
+          iter++;
+        }
+        title_char[iter] = '\n';
+      }
+
+      for (unsigned int j = 0; j <= iter; j += 4) {
+        temp.c[0] = title_char[j];
+        temp.c[1] = title_char[j + 1];
+        temp.c[2] = title_char[j + 2];
+        temp.c[3] = title_char[j + 3];
+        obj->push_back(temp.f);
+        obj->setMaxIndex(obj->maxIndex() + 1);
+      }
+
+      // Fill the dbobject
+      in_file >> tempstore;
+      while (!in_file.eof()) {
+        obj->setMaxIndex(obj->maxIndex() + 1);
+        obj->push_back(tempstore);
+        in_file >> tempstore;
+      }
+
+      in_file.close();
+    } else {
+      // If file didn't open, report this
+      edm::LogError("SiPixeFakelGenErrorDBObjectESSource") << "Error opening File" << tempfile << std::endl;
+    }
+  }
+
+  //std::cout << *obj << std::endl;
+  return std::unique_ptr<SiPixelGenErrorDBObject>(obj);
 }
 
-std::unique_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::produce(const SiPixelGenErrorDBObjectRcd & )
-{
-	using namespace edm::es;
-
-	//Mostly copied from CondTools/SiPixel/test/SiPixelGenErrorDBObjectUploader.cc
-	//--- Make the POOL-ORA object to store the database object
-	SiPixelGenErrorDBObject* obj = new SiPixelGenErrorDBObject;
-
-	// Local variables 
-	const char *tempfile;
-	int m;
-	
-	// Set the number of GenErrors to be passed to the dbobject
-	obj->setNumOfTempl(GenErrorCalibrations_.size());
-
-	// Set the version of the GenError dbobject - this is an external parameter
-	obj->setVersion(version_);
-
-	//  open the GenError file(s) 
-	for(m=0; m< obj->numOfTempl(); ++m){
-
-		edm::FileInPath file( GenErrorCalibrations_[m].c_str() );
-		tempfile = (file.fullPath()).c_str();
-
-		std::ifstream in_file(tempfile, std::ios::in);
-			
-		if(in_file.is_open()){
-			edm::LogInfo("SiPixelFakeGenErrorDBObjectESSource") << "Opened GenError File: " << file.fullPath().c_str() << std::endl;
-
-			// Local variables 
-			char title_char[80], c;
-			SiPixelGenErrorDBObject::char2float temp;
-			float tempstore;
-			unsigned int iter;
-			
-			// GenErrors contain a header char - we must be clever about storing this
-			for (iter = 0; (c=in_file.get()) != '\n' && iter<79; ++iter) {
-			  title_char[iter] = c;
-			}
-			if(iter == 79) {
-			  title_char[iter] ='\n';
-			} else  {
-			  unsigned int ilast = 3-(iter%4);
-			  for (unsigned int it=0; it!=ilast; it++) {
-			    title_char[iter] =' ';
-			    iter++;
-			  }
-			  title_char[iter] ='\n';
-			}
-			
-			for(unsigned int j=0; j<=iter; j+=4) {
-				temp.c[0] = title_char[j];
-				temp.c[1] = title_char[j+1];
-				temp.c[2] = title_char[j+2];
-				temp.c[3] = title_char[j+3];
-				obj->push_back(temp.f);
-				obj->setMaxIndex(obj->maxIndex()+1);
-			}
-			
-			// Fill the dbobject
-			in_file >> tempstore;
-			while(!in_file.eof()) {
-				obj->setMaxIndex(obj->maxIndex()+1);
-				obj->push_back(tempstore);
-				in_file >> tempstore;
-			}
-	
-			in_file.close();
-		}
-		else {
-			// If file didn't open, report this
-			edm::LogError("SiPixeFakelGenErrorDBObjectESSource") << "Error opening File" << tempfile << std::endl;
-		}
-	}
-
-	//std::cout << *obj << std::endl;
-	return std::unique_ptr<SiPixelGenErrorDBObject>(obj);
+void SiPixelFakeGenErrorDBObjectESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                         const edm::IOVSyncValue& iosv,
+                                                         edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
+  oValidity = infinity;
 }
-
-void SiPixelFakeGenErrorDBObjectESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-	const edm::IOVSyncValue& iosv, 
-	edm::ValidityInterval& oValidity ) {
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
-  oValidity = infinity;  
-}
-

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SiPixelFakeLorentzAngleESSource
 // Class:      SiPixelFakeLorentzAngleESSource
-// 
+//
 /**\class SiPixelFakeLorentzAngleESSource SiPixelFakeLorentzAngleESSource.h CalibTracker/SiPixelESProducer/src/SiPixelFakeLorentzAngleESSource.cc
 
  Description: <one line class summary>
@@ -26,51 +26,46 @@
 //
 // constructors and destructor
 //
-SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource(const edm::ParameterSet& conf_) : fp_(conf_.getParameter<edm::FileInPath>("file"))
-{
-	edm::LogInfo("SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource");
-	//the following line is needed to tell the framework what
-	// data is being produced
-	setWhatProduced(this);
-	findingRecord<SiPixelLorentzAngleRcd>();
+SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource(const edm::ParameterSet& conf_)
+    : fp_(conf_.getParameter<edm::FileInPath>("file")) {
+  edm::LogInfo("SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource");
+  //the following line is needed to tell the framework what
+  // data is being produced
+  setWhatProduced(this);
+  findingRecord<SiPixelLorentzAngleRcd>();
 }
 
-SiPixelFakeLorentzAngleESSource::~SiPixelFakeLorentzAngleESSource()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+SiPixelFakeLorentzAngleESSource::~SiPixelFakeLorentzAngleESSource() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
 
-std::unique_ptr<SiPixelLorentzAngle> SiPixelFakeLorentzAngleESSource::produce(const SiPixelLorentzAngleRcd & )
-{
+std::unique_ptr<SiPixelLorentzAngle> SiPixelFakeLorentzAngleESSource::produce(const SiPixelLorentzAngleRcd&) {
+  using namespace edm::es;
+  unsigned int nmodules = 0;
+  SiPixelLorentzAngle* obj = new SiPixelLorentzAngle();
+  SiPixelDetInfoFileReader reader(fp_.fullPath());
+  const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
-	using namespace edm::es;
-	unsigned int nmodules = 0;
-	SiPixelLorentzAngle * obj = new SiPixelLorentzAngle();
-	SiPixelDetInfoFileReader reader(fp_.fullPath());
-	const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
-	
-	// Loop over detectors
-	for(std::vector<uint32_t>::const_iterator detit = DetIds.begin(); detit!=DetIds.end(); detit++) {
-		nmodules++;
-		float langle =  0.106;	 
-		//std::cout << "detid " << (*detit) << std::endl;
-	
-		if( !obj->putLorentzAngle(*detit,langle) ) edm::LogError("SiPixelFakeLorentzAngleESSource")<<"[SiPixelFakeLorentzAngleESSource::produce] detid already exists"<<std::endl;
-	}
-	
-	//std::cout << "Modules = " << nmodules << std::endl;
+  // Loop over detectors
+  for (std::vector<uint32_t>::const_iterator detit = DetIds.begin(); detit != DetIds.end(); detit++) {
+    nmodules++;
+    float langle = 0.106;
+    //std::cout << "detid " << (*detit) << std::endl;
 
-	return std::unique_ptr<SiPixelLorentzAngle>(obj);
-	
+    if (!obj->putLorentzAngle(*detit, langle))
+      edm::LogError("SiPixelFakeLorentzAngleESSource")
+          << "[SiPixelFakeLorentzAngleESSource::produce] detid already exists" << std::endl;
+  }
 
+  //std::cout << "Modules = " << nmodules << std::endl;
+
+  return std::unique_ptr<SiPixelLorentzAngle>(obj);
 }
 
-void SiPixelFakeLorentzAngleESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-						const edm::IOVSyncValue& iosv, 
-						edm::ValidityInterval& oValidity ) {
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
-  oValidity = infinity;  
+void SiPixelFakeLorentzAngleESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                     const edm::IOVSyncValue& iosv,
+                                                     edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
+  oValidity = infinity;
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeQualityESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeQualityESSource.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SiPixelFakeQualityESSource
 // Class:      SiPixelFakeQualityESSource
-// 
+//
 /**\class SiPixelFakeQualityESSource SiPixelFakeQualityESSource.h CalibTracker/SiPixelESProducer/src/SiPixelFakeQualityESSource.cc
 
  Description: <one line class summary>
@@ -26,46 +26,42 @@
 //
 // constructors and destructor
 //
-SiPixelFakeQualityESSource::SiPixelFakeQualityESSource(const edm::ParameterSet& conf_) : fp_(conf_.getParameter<edm::FileInPath>("file"))
-{
-	edm::LogInfo("SiPixelFakeQualityESSource::SiPixelFakeQualityESSource");
-	//the following line is needed to tell the framework what
-	// data is being produced
-	setWhatProduced(this);
-	findingRecord<SiPixelQualityFromDbRcd>();
+SiPixelFakeQualityESSource::SiPixelFakeQualityESSource(const edm::ParameterSet& conf_)
+    : fp_(conf_.getParameter<edm::FileInPath>("file")) {
+  edm::LogInfo("SiPixelFakeQualityESSource::SiPixelFakeQualityESSource");
+  //the following line is needed to tell the framework what
+  // data is being produced
+  setWhatProduced(this);
+  findingRecord<SiPixelQualityFromDbRcd>();
 }
 
-SiPixelFakeQualityESSource::~SiPixelFakeQualityESSource()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+SiPixelFakeQualityESSource::~SiPixelFakeQualityESSource() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
 
-std::unique_ptr<SiPixelQuality> SiPixelFakeQualityESSource::produce(const SiPixelQualityFromDbRcd & )
-{
+std::unique_ptr<SiPixelQuality> SiPixelFakeQualityESSource::produce(const SiPixelQualityFromDbRcd&) {
+  ///////////////////////////////////////////////////////
+  //  errortype "whole" = int 0 in DB  BadRocs = 65535 //
+  //  errortype "tbmA" = int 1 in DB  BadRocs = 255    //
+  //  errortype "tbmB" = int 2 in DB  Bad Rocs = 65280 //
+  //  errortype "none" = int 3 in DB                   //
+  ///////////////////////////////////////////////////////
 
+  SiPixelQuality* obj = new SiPixelQuality();
 
-      ///////////////////////////////////////////////////////
-      //  errortype "whole" = int 0 in DB  BadRocs = 65535 //
-      //  errortype "tbmA" = int 1 in DB  BadRocs = 255    //
-      //  errortype "tbmB" = int 2 in DB  Bad Rocs = 65280 //
-      //  errortype "none" = int 3 in DB                   //
-      ///////////////////////////////////////////////////////
-  
-    SiPixelQuality * obj = new SiPixelQuality();
+  SiPixelQuality::disabledModuleType BadModule;
+  BadModule.DetID = 1;
+  BadModule.errorType = 0;
+  BadModule.BadRocs = 65535;
+  obj->addDisabledModule(BadModule);
 
-    SiPixelQuality::disabledModuleType BadModule;
-    BadModule.DetID = 1; BadModule.errorType = 0; BadModule.BadRocs = 65535; obj->addDisabledModule(BadModule);
-
-    return std::unique_ptr<SiPixelQuality>(obj);
-
+  return std::unique_ptr<SiPixelQuality>(obj);
 }
 
-void SiPixelFakeQualityESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-						const edm::IOVSyncValue& iosv, 
-						edm::ValidityInterval& oValidity ) {
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
-  oValidity = infinity;  
+void SiPixelFakeQualityESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                const edm::IOVSyncValue& iosv,
+                                                edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
+  oValidity = infinity;
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeTemplateDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeTemplateDBObjectESSource.cc
@@ -2,103 +2,99 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <fstream>
 
-SiPixelFakeTemplateDBObjectESSource::SiPixelFakeTemplateDBObjectESSource(const edm::ParameterSet& conf_) : templateCalibrations_(conf_.getParameter<vstring>("siPixelTemplateCalibrations")),
-																																																					 version_(conf_.getParameter<double>("Version"))
-{
-	edm::LogInfo("SiPixelFakeTemplateDBObjectESSource::SiPixelFakeTemplateDBObjectESSource");
-	//the following line is needed to tell the framework what
-	// data is being produced
-	setWhatProduced(this);
-	findingRecord<SiPixelTemplateDBObjectRcd>();
+SiPixelFakeTemplateDBObjectESSource::SiPixelFakeTemplateDBObjectESSource(const edm::ParameterSet& conf_)
+    : templateCalibrations_(conf_.getParameter<vstring>("siPixelTemplateCalibrations")),
+      version_(conf_.getParameter<double>("Version")) {
+  edm::LogInfo("SiPixelFakeTemplateDBObjectESSource::SiPixelFakeTemplateDBObjectESSource");
+  //the following line is needed to tell the framework what
+  // data is being produced
+  setWhatProduced(this);
+  findingRecord<SiPixelTemplateDBObjectRcd>();
 }
 
-SiPixelFakeTemplateDBObjectESSource::~SiPixelFakeTemplateDBObjectESSource()
-{
+SiPixelFakeTemplateDBObjectESSource::~SiPixelFakeTemplateDBObjectESSource() {}
+
+std::unique_ptr<SiPixelTemplateDBObject> SiPixelFakeTemplateDBObjectESSource::produce(
+    const SiPixelTemplateDBObjectRcd&) {
+  using namespace edm::es;
+
+  //Mostly copied from CondTools/SiPixel/test/SiPixelTemplateDBObjectUploader.cc
+  //--- Make the POOL-ORA object to store the database object
+  SiPixelTemplateDBObject* obj = new SiPixelTemplateDBObject;
+
+  // Local variables
+  const char* tempfile;
+  int m;
+
+  // Set the number of templates to be passed to the dbobject
+  obj->setNumOfTempl(templateCalibrations_.size());
+
+  // Set the version of the template dbobject - this is an external parameter
+  obj->setVersion(version_);
+
+  //  open the template file(s)
+  for (m = 0; m < obj->numOfTempl(); ++m) {
+    edm::FileInPath file(templateCalibrations_[m].c_str());
+    tempfile = (file.fullPath()).c_str();
+
+    std::ifstream in_file(tempfile, std::ios::in);
+
+    if (in_file.is_open()) {
+      edm::LogInfo("SiPixelFakeTemplateDBObjectESSource")
+          << "Opened Template File: " << file.fullPath().c_str() << std::endl;
+
+      // Local variables
+      char title_char[80], c;
+      SiPixelTemplateDBObject::char2float temp;
+      float tempstore;
+      unsigned int iter;
+
+      // Templates contain a header char - we must be clever about storing this
+      for (iter = 0; (c = in_file.get()) != '\n' && iter < 79; ++iter) {
+        title_char[iter] = c;
+      }
+      if (iter == 79) {
+        title_char[iter] = '\n';
+      } else {
+        unsigned int ilast = 3 - (iter % 4);
+        for (unsigned int it = 0; it != ilast; it++) {
+          title_char[iter] = ' ';
+          iter++;
+        }
+        title_char[iter] = '\n';
+      }
+
+      for (unsigned int j = 0; j <= iter; j += 4) {
+        temp.c[0] = title_char[j];
+        temp.c[1] = title_char[j + 1];
+        temp.c[2] = title_char[j + 2];
+        temp.c[3] = title_char[j + 3];
+        obj->push_back(temp.f);
+        obj->setMaxIndex(obj->maxIndex() + 1);
+      }
+
+      // Fill the dbobject
+      in_file >> tempstore;
+      while (!in_file.eof()) {
+        obj->setMaxIndex(obj->maxIndex() + 1);
+        obj->push_back(tempstore);
+        in_file >> tempstore;
+      }
+
+      in_file.close();
+    } else {
+      // If file didn't open, report this
+      edm::LogError("SiPixeFakelTemplateDBObjectESSource") << "Error opening File" << tempfile << std::endl;
+    }
+  }
+
+  //std::cout << *obj << std::endl;
+  return std::unique_ptr<SiPixelTemplateDBObject>(obj);
 }
 
-std::unique_ptr<SiPixelTemplateDBObject> SiPixelFakeTemplateDBObjectESSource::produce(const SiPixelTemplateDBObjectRcd & )
-{
-	using namespace edm::es;
-
-	//Mostly copied from CondTools/SiPixel/test/SiPixelTemplateDBObjectUploader.cc
-	//--- Make the POOL-ORA object to store the database object
-	SiPixelTemplateDBObject* obj = new SiPixelTemplateDBObject;
-
-	// Local variables 
-	const char *tempfile;
-	int m;
-	
-	// Set the number of templates to be passed to the dbobject
-	obj->setNumOfTempl(templateCalibrations_.size());
-
-	// Set the version of the template dbobject - this is an external parameter
-	obj->setVersion(version_);
-
-	//  open the template file(s) 
-	for(m=0; m< obj->numOfTempl(); ++m){
-
-		edm::FileInPath file( templateCalibrations_[m].c_str() );
-		tempfile = (file.fullPath()).c_str();
-
-		std::ifstream in_file(tempfile, std::ios::in);
-			
-		if(in_file.is_open()){
-			edm::LogInfo("SiPixelFakeTemplateDBObjectESSource") << "Opened Template File: " << file.fullPath().c_str() << std::endl;
-
-			// Local variables 
-			char title_char[80], c;
-			SiPixelTemplateDBObject::char2float temp;
-			float tempstore;
-			unsigned int iter;
-			
-			// Templates contain a header char - we must be clever about storing this
-			for (iter = 0; (c=in_file.get()) != '\n' && iter<79; ++iter) {
-			  title_char[iter] = c;
-			}
-			if(iter == 79) {
-			  title_char[iter] ='\n';
-			} else  {
-			  unsigned int ilast =  3-(iter%4);
-			  for (unsigned int it=0; it!=ilast; it++) {
-			    title_char[iter] =' ';
-			    iter++;
-			  }
-			  title_char[iter] ='\n';
-			}
-			
-			for(unsigned int j=0; j<=iter; j+=4) {
-				temp.c[0] = title_char[j];
-				temp.c[1] = title_char[j+1];
-				temp.c[2] = title_char[j+2];
-				temp.c[3] = title_char[j+3];
-				obj->push_back(temp.f);
-				obj->setMaxIndex(obj->maxIndex()+1);
-			}
-			
-			// Fill the dbobject
-			in_file >> tempstore;
-			while(!in_file.eof()) {
-				obj->setMaxIndex(obj->maxIndex()+1);
-				obj->push_back(tempstore);
-				in_file >> tempstore;
-			}
-	
-			in_file.close();
-		}
-		else {
-			// If file didn't open, report this
-			edm::LogError("SiPixeFakelTemplateDBObjectESSource") << "Error opening File" << tempfile << std::endl;
-		}
-	}
-
-	//std::cout << *obj << std::endl;
-	return std::unique_ptr<SiPixelTemplateDBObject>(obj);
+void SiPixelFakeTemplateDBObjectESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                         const edm::IOVSyncValue& iosv,
+                                                         edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
+  oValidity = infinity;
 }
-
-void SiPixelFakeTemplateDBObjectESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-	const edm::IOVSyncValue& iosv, 
-	edm::ValidityInterval& oValidity ) {
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
-  oValidity = infinity;  
-}
-

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SiPixelQualityESProducer
 // Class:      SiPixelQualityESProducer
-// 
+//
 /**\class SiPixelQualityESProducer SiPixelQualityESProducer.h CalibTracker/SiPixelESProducer/src/SiPixelQualityESProducer.cc
 
  Description: <one line class summary>
@@ -39,25 +39,25 @@
 
 using namespace edm;
 
-class SiPixelQualityESProducer : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
- public:
-  SiPixelQualityESProducer(const edm::ParameterSet & iConfig);
+class SiPixelQualityESProducer : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
+  SiPixelQualityESProducer(const edm::ParameterSet& iConfig);
   ~SiPixelQualityESProducer() override;
-  
-  std::unique_ptr<SiPixelQuality> produce(const SiPixelQualityRcd & iRecord) ;
-  std::unique_ptr<SiPixelQuality> produceWithLabel(const SiPixelQualityRcd & iRecord);
-  
- private:
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
-			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& ) override;
-  
+
+  std::unique_ptr<SiPixelQuality> produce(const SiPixelQualityRcd& iRecord);
+  std::unique_ptr<SiPixelQuality> produceWithLabel(const SiPixelQualityRcd& iRecord);
+
+private:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                      const edm::IOVSyncValue&,
+                      edm::ValidityInterval&) override;
+
   struct Tokens {
     edm::ESGetToken<SiStripDetVOff, SiPixelDetVOffRcd> voffToken_;
     edm::ESGetToken<SiPixelQuality, SiPixelQualityFromDbRcd> dbobjectToken_;
   };
 
-  std::unique_ptr<SiPixelQuality> get_pointer(const SiPixelQualityRcd & iRecord, const Tokens& tokens);
+  std::unique_ptr<SiPixelQuality> get_pointer(const SiPixelQualityRcd& iRecord, const Tokens& tokens);
 
   Tokens defaultTokens_;
   Tokens labelTokens_;
@@ -67,11 +67,11 @@ class SiPixelQualityESProducer : public edm::ESProducer, public edm::EventSetupR
 // constructors and destructor
 //
 
-SiPixelQualityESProducer::SiPixelQualityESProducer(const edm::ParameterSet& conf_) 
-{
+SiPixelQualityESProducer::SiPixelQualityESProducer(const edm::ParameterSet& conf_) {
   edm::LogInfo("SiPixelQualityESProducer::SiPixelQualityESProducer");
 
-  auto label = conf_.exists("siPixelQualityLabel")?conf_.getParameter<std::string>("siPixelQualityLabel"):std::string{};
+  auto label =
+      conf_.exists("siPixelQualityLabel") ? conf_.getParameter<std::string>("siPixelQualityLabel") : std::string{};
   auto setConsumes = [](edm::ESConsumesCollector&& cc, Tokens& tokens, const std::string& label) {
     cc.setConsumes(tokens.voffToken_).setConsumes(tokens.dbobjectToken_, edm::ESInputTag{"", label});
   };
@@ -79,33 +79,32 @@ SiPixelQualityESProducer::SiPixelQualityESProducer(const edm::ParameterSet& conf
   //the following line is needed to tell the framework what
   // data is being produced
   setConsumes(setWhatProduced(this), defaultTokens_, "");
-  if (label == "forDigitizer"){
-    setConsumes(setWhatProduced(this, &SiPixelQualityESProducer::produceWithLabel, edm::es::Label(label)), labelTokens_, label);
+  if (label == "forDigitizer") {
+    setConsumes(
+        setWhatProduced(this, &SiPixelQualityESProducer::produceWithLabel, edm::es::Label(label)), labelTokens_, label);
   }
-  findingRecord<SiPixelQualityRcd>();  
+  findingRecord<SiPixelQualityRcd>();
 }
 
-SiPixelQualityESProducer::~SiPixelQualityESProducer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+SiPixelQualityESProducer::~SiPixelQualityESProducer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
 
-std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::get_pointer(const SiPixelQualityRcd & iRecord, const Tokens& tokens) {
+std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::get_pointer(const SiPixelQualityRcd& iRecord,
+                                                                      const Tokens& tokens) {
   ///////////////////////////////////////////////////////
   //  errortype "whole" = int 0 in DB  BadRocs = 65535 //
   //  errortype "tbmA" = int 1 in DB  BadRocs = 255    //
   //  errortype "tbmB" = int 2 in DB  Bad Rocs = 65280 //
   //  errortype "none" = int 3 in DB                   //
   ///////////////////////////////////////////////////////
-  
+
   //if I have understood this is the one got from the DB or file, but in any case the ORIGINAL(maybe i need to get the record for it)
   //SiPixelQuality * obj = new SiPixelQuality();
   //SiPixelQuality::disabledModuleType BadModule;
   //BadModule.DetID = 1; BadModule.errorType = 0; BadModule.BadRocs = 65535; obj->addDisabledModule(BadModule);
-  
+
   //now the dbobject is the one copied from the db
   auto dbptr = std::make_unique<SiPixelQuality>(iRecord.get(tokens.dbobjectToken_));
 
@@ -114,21 +113,18 @@ std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::get_pointer(const SiPi
   return dbptr;
 }
 
-
-std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::produce(const SiPixelQualityRcd & iRecord)
-{
+std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::produce(const SiPixelQualityRcd& iRecord) {
   return get_pointer(iRecord, defaultTokens_);
 }
-std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::produceWithLabel(const SiPixelQualityRcd & iRecord)
-{
+std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::produceWithLabel(const SiPixelQualityRcd& iRecord) {
   return get_pointer(iRecord, labelTokens_);
 }
 
-void SiPixelQualityESProducer::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-						const edm::IOVSyncValue& iosv, 
-						edm::ValidityInterval& oValidity ) {
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
-  oValidity = infinity;  
+void SiPixelQualityESProducer::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                              const edm::IOVSyncValue& iosv,
+                                              edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
+  oValidity = infinity;
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(SiPixelQualityESProducer);

--- a/CalibTracker/SiPixelESProducers/src/SiPixelCPEGenericDBErrorParametrization.cc
+++ b/CalibTracker/SiPixelESProducers/src/SiPixelCPEGenericDBErrorParametrization.cc
@@ -15,162 +15,172 @@ const float SiPixelCPEGenericDBErrorParametrization::fx_a_max[2] = {0.285, 0.465
 const float SiPixelCPEGenericDBErrorParametrization::fx_b_min[2] = {998, 998};
 const float SiPixelCPEGenericDBErrorParametrization::fx_b_max[2] = {999, 999};
 
-const float SiPixelCPEGenericDBErrorParametrization::by_a_min[6] = {1.47078, 1.47078, 1.47078, 1.47078, 1.47078, 1.47078};
-const float SiPixelCPEGenericDBErrorParametrization::by_a_max[6] = {1.67078, 1.67078, 1.67078, 1.67078, 1.67078, 1.67078};
+const float SiPixelCPEGenericDBErrorParametrization::by_a_min[6] = {
+    1.47078, 1.47078, 1.47078, 1.47078, 1.47078, 1.47078};
+const float SiPixelCPEGenericDBErrorParametrization::by_a_max[6] = {
+    1.67078, 1.67078, 1.67078, 1.67078, 1.67078, 1.67078};
 const float SiPixelCPEGenericDBErrorParametrization::by_b_min[6] = {0.05, 0.15, 0.70, 0.95, 1.15, 1.20};
 const float SiPixelCPEGenericDBErrorParametrization::by_b_max[6] = {0.50, 0.90, 1.05, 1.15, 1.20, 1.40};
-	
+
 const float SiPixelCPEGenericDBErrorParametrization::fy_a_min[2] = {998, 998};
 const float SiPixelCPEGenericDBErrorParametrization::fy_a_max[2] = {999, 999};
 const float SiPixelCPEGenericDBErrorParametrization::fy_b_min[2] = {0.31, 0.31};
 const float SiPixelCPEGenericDBErrorParametrization::fy_b_max[2] = {0.39, 0.39};
 
-//Constants based on subpart 
+//Constants based on subpart
 const float SiPixelCPEGenericDBErrorParametrization::errors_big_pix[4] = {0.0070, 0.0030, 0.0068, 0.0040};
-const int   SiPixelCPEGenericDBErrorParametrization::size_max[4]       = {5, 2, 0, 0};
+const int SiPixelCPEGenericDBErrorParametrization::size_max[4] = {5, 2, 0, 0};
 
 //Garbage is set to hold a place for bx_b, though we don't parametrize it the same way
 const float garbage[1] = {-9999.99};
 
 const float* SiPixelCPEGenericDBErrorParametrization::a_min[4] = {by_a_min, bx_a_min, fy_a_min, fx_a_min};
 const float* SiPixelCPEGenericDBErrorParametrization::a_max[4] = {by_a_max, bx_a_max, fy_a_max, fx_a_max};
-const float* SiPixelCPEGenericDBErrorParametrization::b_min[4] = {by_b_min, garbage,  fy_b_min, fx_b_min};
-const float* SiPixelCPEGenericDBErrorParametrization::b_max[4] = {by_b_max, garbage,  fy_b_max, fx_b_max};
+const float* SiPixelCPEGenericDBErrorParametrization::b_min[4] = {by_b_min, garbage, fy_b_min, fx_b_min};
+const float* SiPixelCPEGenericDBErrorParametrization::b_max[4] = {by_b_max, garbage, fy_b_max, fx_b_max};
 
 //Bin Sizes
-const int SiPixelCPEGenericDBErrorParametrization::part_bin_size[4]  = { 0, 240, 360, 380};
-const int SiPixelCPEGenericDBErrorParametrization::size_bin_size[4]  = {40,  40,  40,  40};
-const int SiPixelCPEGenericDBErrorParametrization::alpha_bin_size[4] = {10,   1,  10,   1};
-const int SiPixelCPEGenericDBErrorParametrization::beta_bin_size[4]  = { 1,  10,   1,  10};
+const int SiPixelCPEGenericDBErrorParametrization::part_bin_size[4] = {0, 240, 360, 380};
+const int SiPixelCPEGenericDBErrorParametrization::size_bin_size[4] = {40, 40, 40, 40};
+const int SiPixelCPEGenericDBErrorParametrization::alpha_bin_size[4] = {10, 1, 10, 1};
+const int SiPixelCPEGenericDBErrorParametrization::beta_bin_size[4] = {1, 10, 1, 10};
 
-SiPixelCPEGenericDBErrorParametrization::SiPixelCPEGenericDBErrorParametrization(){}
+SiPixelCPEGenericDBErrorParametrization::SiPixelCPEGenericDBErrorParametrization() {}
 
-SiPixelCPEGenericDBErrorParametrization::~SiPixelCPEGenericDBErrorParametrization(){}
+SiPixelCPEGenericDBErrorParametrization::~SiPixelCPEGenericDBErrorParametrization() {}
 
-void SiPixelCPEGenericDBErrorParametrization::setDBAccess(const edm::EventSetup& es)
-{
-	es.get<SiPixelCPEGenericErrorParmRcd>().get(errorsH);
+void SiPixelCPEGenericDBErrorParametrization::setDBAccess(const edm::EventSetup& es) {
+  es.get<SiPixelCPEGenericErrorParmRcd>().get(errorsH);
 }
 
 //The function which is called to return errX and errY. Used in CPEs.
-std::pair<float,float> SiPixelCPEGenericDBErrorParametrization::getError(const SiPixelCPEGenericErrorParm* parmErrors,
-	                                                      GeomDetType::SubDetector pixelPart,
-	                                                      int sizex, int sizey,
-	                                                      float alpha, float beta,
-	                                                      bool bigInX, bool bigInY)
-{
-	std::pair<float,float> element;
-  std::pair<float,float> errors;
-	
-	if(!GeomDetEnumerators::isTrackerPixel(pixelPart))
-		throw cms::Exception("PixelCPEGenericDBErrorParametrization::getError")
-			<< "Non-pixel detector type !!!" ;
-	if(GeomDetEnumerators::isBarrel(pixelPart)) {
-		element = std::pair<float,float>(index(1, sizex, alpha, beta, bigInX),  //1 -- Bx
-                          		       index(0, sizey, alpha, beta, bigInY)); //0 -- By
-	}
-	else {
-		element = std::pair<float,float>(index(3, sizex, alpha, beta, bigInX),  //3 -- Fx
-                          			     index(2, sizey, alpha, beta, bigInY)); //2 -- Fy
-	}
-	
-	if (bigInX && sizex == 1) errors.first  = element.first;
-	else                      errors.first  = parmErrors->errors()[(int)element.first].sigma;
-	if (bigInY && sizey == 1) errors.second = element.second;
-	else                      errors.second = parmErrors->errors()[(int)element.second].sigma;
+std::pair<float, float> SiPixelCPEGenericDBErrorParametrization::getError(const SiPixelCPEGenericErrorParm* parmErrors,
+                                                                          GeomDetType::SubDetector pixelPart,
+                                                                          int sizex,
+                                                                          int sizey,
+                                                                          float alpha,
+                                                                          float beta,
+                                                                          bool bigInX,
+                                                                          bool bigInY) {
+  std::pair<float, float> element;
+  std::pair<float, float> errors;
 
-	return errors;
+  if (!GeomDetEnumerators::isTrackerPixel(pixelPart))
+    throw cms::Exception("PixelCPEGenericDBErrorParametrization::getError") << "Non-pixel detector type !!!";
+  if (GeomDetEnumerators::isBarrel(pixelPart)) {
+    element = std::pair<float, float>(index(1, sizex, alpha, beta, bigInX),   //1 -- Bx
+                                      index(0, sizey, alpha, beta, bigInY));  //0 -- By
+  } else {
+    element = std::pair<float, float>(index(3, sizex, alpha, beta, bigInX),   //3 -- Fx
+                                      index(2, sizey, alpha, beta, bigInY));  //2 -- Fy
+  }
+
+  if (bigInX && sizex == 1)
+    errors.first = element.first;
+  else
+    errors.first = parmErrors->errors()[(int)element.first].sigma;
+  if (bigInY && sizey == 1)
+    errors.second = element.second;
+  else
+    errors.second = parmErrors->errors()[(int)element.second].sigma;
+
+  return errors;
 }
 
 //The function which is called to return errX and errY. Used outside CPEs with access to ES.
-std::pair<float,float> SiPixelCPEGenericDBErrorParametrization::getError(GeomDetType::SubDetector pixelPart,
-	                                                      int sizex, int sizey,
-	                                                      float alpha, float beta,
-	                                                      bool bigInX, bool bigInY)
-{
-	std::pair<float,float> element;
-  std::pair<float,float> errors;
-	
-	if(!GeomDetEnumerators::isTrackerPixel(pixelPart))
-		throw cms::Exception("PixelCPEGenericDBErrorParametrization::getError")
-			<< "Non-pixel detector type !!!" ;
-	if(GeomDetEnumerators::isBarrel(pixelPart)) {
-		element = std::pair<float,float>(index(1, sizex, alpha, beta, bigInX),  //1 -- Bx
-                          		       index(0, sizey, alpha, beta, bigInY)); //0 -- By
-	}
-	else {
-		element = std::pair<float,float>(index(3, sizex, alpha, beta, bigInX),  //3 -- Fx
-                          			     index(2, sizey, alpha, beta, bigInY)); //2 -- Fy
-	}
-	
-	if (bigInX && sizex == 1) errors.first  = element.first;
-	else                      errors.first  = errorsH->errors()[(int)element.first].sigma;
-	if (bigInY && sizey == 1) errors.second = element.second;
-	else                      errors.second = errorsH->errors()[(int)element.second].sigma;
+std::pair<float, float> SiPixelCPEGenericDBErrorParametrization::getError(
+    GeomDetType::SubDetector pixelPart, int sizex, int sizey, float alpha, float beta, bool bigInX, bool bigInY) {
+  std::pair<float, float> element;
+  std::pair<float, float> errors;
 
-	return errors;
+  if (!GeomDetEnumerators::isTrackerPixel(pixelPart))
+    throw cms::Exception("PixelCPEGenericDBErrorParametrization::getError") << "Non-pixel detector type !!!";
+  if (GeomDetEnumerators::isBarrel(pixelPart)) {
+    element = std::pair<float, float>(index(1, sizex, alpha, beta, bigInX),   //1 -- Bx
+                                      index(0, sizey, alpha, beta, bigInY));  //0 -- By
+  } else {
+    element = std::pair<float, float>(index(3, sizex, alpha, beta, bigInX),   //3 -- Fx
+                                      index(2, sizey, alpha, beta, bigInY));  //2 -- Fy
+  }
+
+  if (bigInX && sizex == 1)
+    errors.first = element.first;
+  else
+    errors.first = errorsH->errors()[(int)element.first].sigma;
+  if (bigInY && sizey == 1)
+    errors.second = element.second;
+  else
+    errors.second = errorsH->errors()[(int)element.second].sigma;
+
+  return errors;
 }
 
+float SiPixelCPEGenericDBErrorParametrization::index(int ind_subpart, int size, float alpha, float beta, bool big) {
+  //This is a check for big pixels. If it passes, the code returns a given error and the function ends.
+  if (big && size == 1)
+    return errors_big_pix[ind_subpart];
 
+  int ind_size = std::min(size - 1, size_max[ind_subpart]);
 
-float SiPixelCPEGenericDBErrorParametrization::index(int ind_subpart, int size, float alpha, float beta, bool big)
-{
-	//This is a check for big pixels. If it passes, the code returns a given error and the function ends.
-	if ( big && size == 1) return errors_big_pix[ind_subpart];
-	
-	int ind_size = std::min(size - 1, size_max[ind_subpart]);
+  float alpha_rad = -999.9;
+  float betap_rad = -999.9;
 
-	float alpha_rad = -999.9;
-	float betap_rad = -999.9;
+  int ind_alpha = -99;
+  int ind_beta = -99;
 
-	int ind_alpha = -99;
-	int ind_beta  = -99;
+  float binw_a = -999.9;
+  float binw_b = -999.9;
+  int maxbin_a = -99;
+  int maxbin_b = -99;
 
-	float binw_a = -999.9;
-	float binw_b = -999.9;
-	int maxbin_a = -99;
-	int maxbin_b = -99;
+  betap_rad = fabs(math_pi / 2.0 - beta);
+  //We must take into account that Fx(subpart=3) has different alpha parametrization
+  if (ind_subpart == 3)
+    alpha_rad = fabs(math_pi / 2.0 - alpha);
+  else
+    alpha_rad = fabs(alpha);
 
-	betap_rad = fabs(math_pi/2.0 - beta);
-	//We must take into account that Fx(subpart=3) has different alpha parametrization
-	if(ind_subpart == 3) alpha_rad = fabs(math_pi/2.0 - alpha);
-	else                 alpha_rad = fabs(alpha);
+  //Sets the correct binning for alpha and beta based on whether in x or y
+  if (ind_subpart == 0 || ind_subpart == 2) {
+    binw_a = (a_max[ind_subpart][ind_size] - a_min[ind_subpart][ind_size]) / 2.0;
+    binw_b = (b_max[ind_subpart][ind_size] - b_min[ind_subpart][ind_size]) / 8.0;
+    maxbin_a = 3;
+    maxbin_b = 9;
+  } else {
+    binw_a = (a_max[ind_subpart][ind_size] - a_min[ind_subpart][ind_size]) / 8.0;
+    binw_b = (b_max[ind_subpart][ind_size] - b_min[ind_subpart][ind_size]) / 2.0;
+    maxbin_a = 3;
+    maxbin_b = 9;
+  }
 
-	//Sets the correct binning for alpha and beta based on whether in x or y
-	if(ind_subpart == 0||ind_subpart == 2)
-	{
-		binw_a = (a_max[ind_subpart][ind_size] - a_min[ind_subpart][ind_size])/2.0;
-		binw_b = (b_max[ind_subpart][ind_size] - b_min[ind_subpart][ind_size])/8.0;
-		maxbin_a = 3;
-		maxbin_b = 9;
-	}
-	else
-	{
-		binw_a = (a_max[ind_subpart][ind_size] - a_min[ind_subpart][ind_size])/8.0;
-		binw_b = (b_max[ind_subpart][ind_size] - b_min[ind_subpart][ind_size])/2.0;
-		maxbin_a = 3;
-		maxbin_b = 9;
-	}
+  //Binning for alpha
+  if (alpha_rad < a_min[ind_subpart][ind_size])
+    ind_alpha = 0;
+  else if (alpha_rad >= a_max[ind_subpart][ind_size])
+    ind_alpha = maxbin_a;
+  else
+    ind_alpha = 1 + (int)((alpha_rad - a_min[ind_subpart][ind_size]) / binw_a);
 
-	//Binning for alpha
-	if      ( alpha_rad <  a_min[ind_subpart][ind_size]) ind_alpha = 0;
-	else if ( alpha_rad >= a_max[ind_subpart][ind_size]) ind_alpha = maxbin_a;
-	else      ind_alpha  = 1 + (int)((alpha_rad - a_min[ind_subpart][ind_size])/binw_a);
+  //Binning for beta -- we need to account for Bx(subpart=1) having uneven binning
+  if (ind_subpart == 1) {
+    if (betap_rad <= 0.7)
+      ind_beta = 0;
+    else if (0.7 < betap_rad && betap_rad <= 1.0)
+      ind_beta = 1;
+    else if (1.0 < betap_rad && betap_rad <= 1.2)
+      ind_beta = 2;
+    else if (1.2 <= betap_rad)
+      ind_beta = 3;
+  } else if (betap_rad < b_min[ind_subpart][ind_size])
+    ind_beta = 0;
+  else if (betap_rad >= b_max[ind_subpart][ind_size])
+    ind_beta = maxbin_b;
+  else
+    ind_beta = 1 + (int)((betap_rad - b_min[ind_subpart][ind_size]) / binw_b);
 
-	//Binning for beta -- we need to account for Bx(subpart=1) having uneven binning
-	if(ind_subpart == 1)
-	{
-		if      (                     betap_rad <= 0.7 ) ind_beta = 0;
-		else if ( 0.7 <  betap_rad && betap_rad <= 1.0 ) ind_beta = 1;
-		else if ( 1.0 <  betap_rad && betap_rad <= 1.2 ) ind_beta = 2;
-		else if ( 1.2 <= betap_rad                     ) ind_beta = 3;
-	}
-	else if ( betap_rad <  b_min[ind_subpart][ind_size]) ind_beta = 0;
-	else if ( betap_rad >= b_max[ind_subpart][ind_size]) ind_beta = maxbin_b;
-	else      ind_beta   = 1 + (int)((betap_rad - b_min[ind_subpart][ind_size])/binw_b);
+  //Index to be used to find error in database
+  int index = part_bin_size[ind_subpart] + size_bin_size[ind_subpart] * ind_size +
+              alpha_bin_size[ind_subpart] * ind_alpha + beta_bin_size[ind_subpart] * ind_beta;
 
-	//Index to be used to find error in database
-	int index = part_bin_size[ind_subpart] + size_bin_size[ind_subpart] * ind_size + alpha_bin_size[ind_subpart] * ind_alpha + beta_bin_size[ind_subpart] * ind_beta;
-	
-	return index;
+  return index;
 }

--- a/CalibTracker/SiPixelESProducers/src/SiPixelDetInfoFileReader.cc
+++ b/CalibTracker/SiPixelESProducers/src/SiPixelDetInfoFileReader.cc
@@ -12,117 +12,91 @@
 using namespace cms;
 using namespace std;
 
-
 SiPixelDetInfoFileReader::SiPixelDetInfoFileReader(std::string filePath) {
-
-//   if(filePath==std::string("")){
-//     filePath = edm::FileInPath(std::string("CalibTracker/SiPixelCommon/data/SiPixelDetInfo.dat") ).fullPath();
-//   }
+  //   if(filePath==std::string("")){
+  //     filePath = edm::FileInPath(std::string("CalibTracker/SiPixelCommon/data/SiPixelDetInfo.dat") ).fullPath();
+  //   }
 
   detData_.clear();
   detIds_.clear();
 
   inputFile_.open(filePath.c_str());
 
-  if (inputFile_.is_open()){
-
-    for(;;) {
-
+  if (inputFile_.is_open()) {
+    for (;;) {
       uint32_t detid;
       int ncols;
       int nrows;
 
-      inputFile_ >> detid >> ncols  >> nrows ;
+      inputFile_ >> detid >> ncols >> nrows;
 
-      if (!(inputFile_.eof() || inputFile_.fail())){
+      if (!(inputFile_.eof() || inputFile_.fail())) {
+        detIds_.push_back(detid);
 
-	detIds_.push_back(detid);
+        //inputFile_ >> numberOfAPVs;
+        //inputFile_ >> stripLength;
 
-	//inputFile_ >> numberOfAPVs;
-	//inputFile_ >> stripLength;
-	
-	//       edm::LogInfo("SiPixelDetInfoFileReader::SiPixelDetInfoFileReader") << detid <<" " <<numberOfAPVs <<" " <<stripLength << " "<< thickness<< endl;
-	
-	std::map<uint32_t, std::pair<int, int> >::const_iterator it = detData_.find(detid);
-	
-	if( it==detData_.end() ){
-	  
-	  detData_[detid]=pair<int, int>(ncols,nrows);
-	  
-	}
-	else{	  
-	  edm::LogError("SiPixelDetInfoFileReader::SiPixelDetInfoFileReader") <<"DetId " << detid << " already found on file. Ignoring new data"<<endl;
-	  detIds_.pop_back();
-	  continue;
-	}
-      }
-      else if (inputFile_.eof()){
-	
-	edm::LogInfo("SiPixelDetInfoFileReader::SiPixelDetInfoFileReader - END of file reached")<<endl;
-	break;
-	
-      }
-      else if (inputFile_.fail()) {
-	
-	edm::LogError("SiPixelDetInfoFileReader::SiPixelDetInfoFileReader - ERROR while reading file")<<endl;     
-	break;
+        //       edm::LogInfo("SiPixelDetInfoFileReader::SiPixelDetInfoFileReader") << detid <<" " <<numberOfAPVs <<" " <<stripLength << " "<< thickness<< endl;
+
+        std::map<uint32_t, std::pair<int, int> >::const_iterator it = detData_.find(detid);
+
+        if (it == detData_.end()) {
+          detData_[detid] = pair<int, int>(ncols, nrows);
+
+        } else {
+          edm::LogError("SiPixelDetInfoFileReader::SiPixelDetInfoFileReader")
+              << "DetId " << detid << " already found on file. Ignoring new data" << endl;
+          detIds_.pop_back();
+          continue;
+        }
+      } else if (inputFile_.eof()) {
+        edm::LogInfo("SiPixelDetInfoFileReader::SiPixelDetInfoFileReader - END of file reached") << endl;
+        break;
+
+      } else if (inputFile_.fail()) {
+        edm::LogError("SiPixelDetInfoFileReader::SiPixelDetInfoFileReader - ERROR while reading file") << endl;
+        break;
       }
     }
-    
+
     inputFile_.close();
-    
-  }  
-  else {
-    
-    edm::LogError("SiPixelDetInfoFileReader::SiPixelDetInfoFileReader - Unable to open file")<<endl;
+
+  } else {
+    edm::LogError("SiPixelDetInfoFileReader::SiPixelDetInfoFileReader - Unable to open file") << endl;
     return;
-    
   }
-  
 
-//   int i=0;
-//   for(std::map<uint32_t, std::pair<unsigned short, double> >::iterator it =detData_.begin(); it!=detData_.end(); it++ ) {
-//     std::cout<< it->first << " " << (it->second).first << " " << (it->second).second<<endl;
-//     i++;
-//   }
-//   std::cout<<i;
-
-
+  //   int i=0;
+  //   for(std::map<uint32_t, std::pair<unsigned short, double> >::iterator it =detData_.begin(); it!=detData_.end(); it++ ) {
+  //     std::cout<< it->first << " " << (it->second).first << " " << (it->second).second<<endl;
+  //     i++;
+  //   }
+  //   std::cout<<i;
 }
 //
 // Destructor
 //
-SiPixelDetInfoFileReader::~SiPixelDetInfoFileReader(){
-
-   edm::LogInfo("SiPixelDetInfoFileReader::~SiPixelDetInfoFileReader");
+SiPixelDetInfoFileReader::~SiPixelDetInfoFileReader() {
+  edm::LogInfo("SiPixelDetInfoFileReader::~SiPixelDetInfoFileReader");
 }
 //
 // get DetId's
 //
-const std::vector<uint32_t> & SiPixelDetInfoFileReader::getAllDetIds() const{
-
-  return detIds_;
-
-}
+const std::vector<uint32_t>& SiPixelDetInfoFileReader::getAllDetIds() const { return detIds_; }
 //
 // get method
 //
-const std::pair<int, int> & SiPixelDetInfoFileReader::getDetUnitDimensions(uint32_t detId) const{
-
+const std::pair<int, int>& SiPixelDetInfoFileReader::getDetUnitDimensions(uint32_t detId) const {
   std::map<uint32_t, std::pair<int, int> >::const_iterator it = detData_.find(detId);
 
-  if(it!=detData_.end()){
-    
-    return (*it).second; 
+  if (it != detData_.end()) {
+    return (*it).second;
 
-  }
-  else{
-
-    static const std::pair< int, int> defaultValue(0,0);
-    edm::LogWarning("SiPixelDetInfoFileReader::getDetUnitDimensions - Unable to find requested detid. Returning invalid data ")<<endl; 
+  } else {
+    static const std::pair<int, int> defaultValue(0, 0);
+    edm::LogWarning(
+        "SiPixelDetInfoFileReader::getDetUnitDimensions - Unable to find requested detid. Returning invalid data ")
+        << endl;
     return defaultValue;
-
   }
-
 }
-

--- a/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationForHLTService.cc
+++ b/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationForHLTService.cc
@@ -15,128 +15,111 @@
  */
 
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h"
-#include<tuple>
+#include <tuple>
 
-void SiPixelGainCalibrationForHLTService::calibrate(uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int * electron) {
+void SiPixelGainCalibrationForHLTService::calibrate(
+    uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int* electron) {
   SiPixelGainCalibrationForHLT::Range range;
   int cols;
-  std::tie(range,cols) = ped->getRangeAndNCols(detID);
-  float pedestal=0,gain=0;
-  int i=0;
-  bool isDeadColumn=false, isNoisyColumn=false;
-  int oldCol=-1, oldAveragedBlock=-1;
-  for(DigiIterator di = b; di != e; ++di)  {
+  std::tie(range, cols) = ped->getRangeAndNCols(detID);
+  float pedestal = 0, gain = 0;
+  int i = 0;
+  bool isDeadColumn = false, isNoisyColumn = false;
+  int oldCol = -1, oldAveragedBlock = -1;
+  for (DigiIterator di = b; di != e; ++di) {
     int row = di->row();
     int col = di->column();
     int averagedBlock = row / numberOfRowsAveragedOver_;
-    if ( (col!=oldCol) | ( averagedBlock != oldAveragedBlock) ) {
-      oldCol=col; oldAveragedBlock= averagedBlock;
-      std::tie(pedestal,gain) = ped->getPedAndGain(col, row, range, cols, isDeadColumn, isNoisyColumn);
+    if ((col != oldCol) | (averagedBlock != oldAveragedBlock)) {
+      oldCol = col;
+      oldAveragedBlock = averagedBlock;
+      std::tie(pedestal, gain) = ped->getPedAndGain(col, row, range, cols, isDeadColumn, isNoisyColumn);
     }
-    if ( isDeadColumn | isNoisyColumn ) electron[i++] =0;
+    if (isDeadColumn | isNoisyColumn)
+      electron[i++] = 0;
     else {
-      float vcal = di->adc() * gain  - pedestal*gain;
+      float vcal = di->adc() * gain - pedestal * gain;
       //    float vcal = (di->adc()  - DBpedestal) * DBgain;
-      electron[i++] = int( vcal * conversionFactor + offset); 
+      electron[i++] = int(vcal * conversionFactor + offset);
     }
   }
-  assert(i==(e-b));
+  assert(i == (e - b));
 }
 
-
-
-
-float SiPixelGainCalibrationForHLTService::getPedestal( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   float pedestalValue = this->getPedestalByColumn(detID, col, row, isDead, isNoisy);
-   if (isDead || isNoisy)
-   {
-      this->throwExepctionForBadRead("HLT getPedestal()", detID, col, row, pedestalValue);
-      return 0.0;
-   }
-   return pedestalValue;
+float SiPixelGainCalibrationForHLTService::getPedestal(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  float pedestalValue = this->getPedestalByColumn(detID, col, row, isDead, isNoisy);
+  if (isDead || isNoisy) {
+    this->throwExepctionForBadRead("HLT getPedestal()", detID, col, row, pedestalValue);
+    return 0.0;
+  }
+  return pedestalValue;
 }
 
-float SiPixelGainCalibrationForHLTService::getGain( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   float gainValue = this->getGainByColumn(detID, col, row, isDead, isNoisy);
-   if (isDead || isNoisy)
-   {
-      this->throwExepctionForBadRead("HLT getGain()", detID, col, row, gainValue);
-      return 0.0;
-   }
-   return gainValue;
+float SiPixelGainCalibrationForHLTService::getGain(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  float gainValue = this->getGainByColumn(detID, col, row, isDead, isNoisy);
+  if (isDead || isNoisy) {
+    this->throwExepctionForBadRead("HLT getGain()", detID, col, row, gainValue);
+    return 0.0;
+  }
+  return gainValue;
 }
 
-bool SiPixelGainCalibrationForHLTService::isDead( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getPedestalByColumn(detID, col, row, isDead, isNoisy); //pedestal stores dead column value as well
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationForHLTService") << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
-      isDead = false; 
-   }
-   return isDead;
+bool SiPixelGainCalibrationForHLTService::isDead(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getPedestalByColumn(detID, col, row, isDead, isNoisy);  //pedestal stores dead column value as well
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationForHLTService")
+        << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
+    isDead = false;
+  }
+  return isDead;
 }
 
-bool SiPixelGainCalibrationForHLTService::isNoisy( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getPedestalByColumn(detID, col, row, isDead, isNoisy); //pedestal stores noisy column value as well
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is noisy
-      edm::LogInfo("SiPixelGainCalibrationForHLTService") << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
-      isNoisy = false; 
-   }
-   return isNoisy;
-}
-   
-bool SiPixelGainCalibrationForHLTService::isDeadColumn( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getGainByColumn(detID, col, row, isDead, isNoisy);
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationForHLTService") << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
-      isDead = false; 
-   }
-   return isDead;
-}
-  
-bool SiPixelGainCalibrationForHLTService::isNoisyColumn( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getGainByColumn(detID, col, row, isDead, isNoisy);
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is noisy
-      edm::LogInfo("SiPixelGainCalibrationForHLTService") << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
-      isNoisy = false; 
-   }
-   return isNoisy;
+bool SiPixelGainCalibrationForHLTService::isNoisy(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getPedestalByColumn(detID, col, row, isDead, isNoisy);  //pedestal stores noisy column value as well
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is noisy
+    edm::LogInfo("SiPixelGainCalibrationForHLTService")
+        << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
+    isNoisy = false;
+  }
+  return isNoisy;
 }
 
+bool SiPixelGainCalibrationForHLTService::isDeadColumn(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getGainByColumn(detID, col, row, isDead, isNoisy);
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationForHLTService")
+        << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
+    isDead = false;
+  }
+  return isDead;
+}
+
+bool SiPixelGainCalibrationForHLTService::isNoisyColumn(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getGainByColumn(detID, col, row, isDead, isNoisy);
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is noisy
+    edm::LogInfo("SiPixelGainCalibrationForHLTService")
+        << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
+    isNoisy = false;
+  }
+  return isNoisy;
+}

--- a/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationForHLTSimService.cc
+++ b/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationForHLTSimService.cc
@@ -16,97 +16,80 @@
 
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTSimService.h"
 
-float SiPixelGainCalibrationForHLTSimService::getPedestal( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   float pedestalValue = this->getPedestalByColumn(detID, col, row, isDead, isNoisy);
-   if (isDead || isNoisy)
-   {
-      this->throwExepctionForBadRead("HLT getPedestal()", detID, col, row, pedestalValue);
-      return 0.0;
-   }
-   return pedestalValue;
+float SiPixelGainCalibrationForHLTSimService::getPedestal(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  float pedestalValue = this->getPedestalByColumn(detID, col, row, isDead, isNoisy);
+  if (isDead || isNoisy) {
+    this->throwExepctionForBadRead("HLT getPedestal()", detID, col, row, pedestalValue);
+    return 0.0;
+  }
+  return pedestalValue;
 }
 
-float SiPixelGainCalibrationForHLTSimService::getGain( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   float gainValue = this->getGainByColumn(detID, col, row, isDead, isNoisy);
-   if (isDead || isNoisy)
-   {
-      this->throwExepctionForBadRead("HLT getGain()", detID, col, row, gainValue);
-      return 0.0;
-   }
-   return gainValue;
+float SiPixelGainCalibrationForHLTSimService::getGain(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  float gainValue = this->getGainByColumn(detID, col, row, isDead, isNoisy);
+  if (isDead || isNoisy) {
+    this->throwExepctionForBadRead("HLT getGain()", detID, col, row, gainValue);
+    return 0.0;
+  }
+  return gainValue;
 }
 
-bool SiPixelGainCalibrationForHLTSimService::isDead( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getPedestalByColumn(detID, col, row, isDead, isNoisy); //pedestal stores dead column value as well
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationForHLTSimService") << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
-      isDead = false; 
-   }
-   return isDead;
+bool SiPixelGainCalibrationForHLTSimService::isDead(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getPedestalByColumn(detID, col, row, isDead, isNoisy);  //pedestal stores dead column value as well
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationForHLTSimService")
+        << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
+    isDead = false;
+  }
+  return isDead;
 }
 
-bool SiPixelGainCalibrationForHLTSimService::isNoisy( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getPedestalByColumn(detID, col, row, isDead, isNoisy); //pedestal stores noisy column value as well
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is noisy
-      edm::LogInfo("SiPixelGainCalibrationForHLTSimService") << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
-      isNoisy = false; 
-   }
-   return isNoisy;
-}
-   
-bool SiPixelGainCalibrationForHLTSimService::isDeadColumn( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getGainByColumn(detID, col, row, isDead, isNoisy);
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationForHLTSimService") << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
-      isDead = false; 
-   }
-   return isDead;
-}
-  
-bool SiPixelGainCalibrationForHLTSimService::isNoisyColumn( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getGainByColumn(detID, col, row, isDead, isNoisy);
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is noisy
-      edm::LogInfo("SiPixelGainCalibrationForHLTSimService") << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
-      isNoisy = false; 
-   }
-   return isNoisy;
+bool SiPixelGainCalibrationForHLTSimService::isNoisy(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getPedestalByColumn(detID, col, row, isDead, isNoisy);  //pedestal stores noisy column value as well
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is noisy
+    edm::LogInfo("SiPixelGainCalibrationForHLTSimService")
+        << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
+    isNoisy = false;
+  }
+  return isNoisy;
 }
 
+bool SiPixelGainCalibrationForHLTSimService::isDeadColumn(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getGainByColumn(detID, col, row, isDead, isNoisy);
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationForHLTSimService")
+        << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
+    isDead = false;
+  }
+  return isDead;
+}
+
+bool SiPixelGainCalibrationForHLTSimService::isNoisyColumn(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getGainByColumn(detID, col, row, isDead, isNoisy);
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is noisy
+    edm::LogInfo("SiPixelGainCalibrationForHLTSimService")
+        << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
+    isNoisy = false;
+  }
+  return isNoisy;
+}

--- a/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationOfflineService.cc
+++ b/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationOfflineService.cc
@@ -16,96 +16,80 @@
 
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h"
 
-float SiPixelGainCalibrationOfflineService::getPedestal( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   float pedestalValue = this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
-   if (isDead || isNoisy)
-   {
-      this->throwExepctionForBadRead("Offline getPedestal()", detID, col, row, pedestalValue);
-      return 0.0;
-   }
-   return pedestalValue;
+float SiPixelGainCalibrationOfflineService::getPedestal(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  float pedestalValue = this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
+  if (isDead || isNoisy) {
+    this->throwExepctionForBadRead("Offline getPedestal()", detID, col, row, pedestalValue);
+    return 0.0;
+  }
+  return pedestalValue;
 }
 
-float SiPixelGainCalibrationOfflineService::getGain( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   float gainValue = this->getGainByColumn(detID, col, row, isDead, isNoisy);
-   if (isDead || isNoisy)
-   {
-      this->throwExepctionForBadRead("Offline getGain()", detID, col, row, gainValue);
-      return 0.0;
-   }
-   return gainValue;
+float SiPixelGainCalibrationOfflineService::getGain(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  float gainValue = this->getGainByColumn(detID, col, row, isDead, isNoisy);
+  if (isDead || isNoisy) {
+    this->throwExepctionForBadRead("Offline getGain()", detID, col, row, gainValue);
+    return 0.0;
+  }
+  return gainValue;
 }
 
-bool SiPixelGainCalibrationOfflineService::isDead( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getPedestalByPixel(detID, col, row, isDead, isNoisy); 
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationOfflineService") << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
-      isDead = false; 
-   }
-   return isDead;
+bool SiPixelGainCalibrationOfflineService::isDead(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationOfflineService")
+        << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
+    isDead = false;
+  }
+  return isDead;
 }
 
-bool SiPixelGainCalibrationOfflineService::isNoisy( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getPedestalByPixel(detID, col, row, isDead, isNoisy); 
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationOfflineService") << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
-      isNoisy = false; 
-   }
-   return isNoisy;
-}
-   
-bool SiPixelGainCalibrationOfflineService::isDeadColumn( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getGainByColumn(detID, col, row, isDead, isNoisy); // the gain column average can flag a whole column as bad
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationOfflineService") << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
-      isDead = false; 
-   }
-   return isDead;
+bool SiPixelGainCalibrationOfflineService::isNoisy(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationOfflineService")
+        << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
+    isNoisy = false;
+  }
+  return isNoisy;
 }
 
-bool SiPixelGainCalibrationOfflineService::isNoisyColumn( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getGainByColumn(detID, col, row, isDead, isNoisy); // the gain column average can flag a whole column as bad
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationOfflineService") << "Attempting to check if nonexistant pixel is Noisy.  Exception message: " << e.what();
-      isNoisy = false; 
-   }
-   return isNoisy;
+bool SiPixelGainCalibrationOfflineService::isDeadColumn(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getGainByColumn(detID, col, row, isDead, isNoisy);  // the gain column average can flag a whole column as bad
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationOfflineService")
+        << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
+    isDead = false;
+  }
+  return isDead;
+}
+
+bool SiPixelGainCalibrationOfflineService::isNoisyColumn(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getGainByColumn(detID, col, row, isDead, isNoisy);  // the gain column average can flag a whole column as bad
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationOfflineService")
+        << "Attempting to check if nonexistant pixel is Noisy.  Exception message: " << e.what();
+    isNoisy = false;
+  }
+  return isNoisy;
 }

--- a/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationOfflineSimService.cc
+++ b/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationOfflineSimService.cc
@@ -16,96 +16,80 @@
 
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h"
 
-float SiPixelGainCalibrationOfflineSimService::getPedestal( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   float pedestalValue = this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
-   if (isDead || isNoisy)
-   {
-      this->throwExepctionForBadRead("Offline getPedestal()", detID, col, row, pedestalValue);
-      return 0.0;
-   }
-   return pedestalValue;
+float SiPixelGainCalibrationOfflineSimService::getPedestal(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  float pedestalValue = this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
+  if (isDead || isNoisy) {
+    this->throwExepctionForBadRead("Offline getPedestal()", detID, col, row, pedestalValue);
+    return 0.0;
+  }
+  return pedestalValue;
 }
 
-float SiPixelGainCalibrationOfflineSimService::getGain( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   float gainValue = this->getGainByColumn(detID, col, row, isDead, isNoisy);
-   if (isDead || isNoisy)
-   {
-      this->throwExepctionForBadRead("Offline getGain()", detID, col, row, gainValue);
-      return 0.0;
-   }
-   return gainValue;
+float SiPixelGainCalibrationOfflineSimService::getGain(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  float gainValue = this->getGainByColumn(detID, col, row, isDead, isNoisy);
+  if (isDead || isNoisy) {
+    this->throwExepctionForBadRead("Offline getGain()", detID, col, row, gainValue);
+    return 0.0;
+  }
+  return gainValue;
 }
 
-bool SiPixelGainCalibrationOfflineSimService::isDead( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getPedestalByPixel(detID, col, row, isDead, isNoisy); 
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationOfflineSimService") << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
-      isDead = false; 
-   }
-   return isDead;
+bool SiPixelGainCalibrationOfflineSimService::isDead(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationOfflineSimService")
+        << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
+    isDead = false;
+  }
+  return isDead;
 }
 
-bool SiPixelGainCalibrationOfflineSimService::isNoisy( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getPedestalByPixel(detID, col, row, isDead, isNoisy); 
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationOfflineSimService") << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
-      isNoisy = false; 
-   }
-   return isNoisy;
-}
-   
-bool SiPixelGainCalibrationOfflineSimService::isDeadColumn( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getGainByColumn(detID, col, row, isDead, isNoisy); // the gain column average can flag a whole column as bad
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationOfflineSimService") << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
-      isDead = false; 
-   }
-   return isDead;
+bool SiPixelGainCalibrationOfflineSimService::isNoisy(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationOfflineSimService")
+        << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
+    isNoisy = false;
+  }
+  return isNoisy;
 }
 
-bool SiPixelGainCalibrationOfflineSimService::isNoisyColumn( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getGainByColumn(detID, col, row, isDead, isNoisy); // the gain column average can flag a whole column as bad
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationOfflineSimService") << "Attempting to check if nonexistant pixel is Noisy.  Exception message: " << e.what();
-      isNoisy = false; 
-   }
-   return isNoisy;
+bool SiPixelGainCalibrationOfflineSimService::isDeadColumn(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getGainByColumn(detID, col, row, isDead, isNoisy);  // the gain column average can flag a whole column as bad
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationOfflineSimService")
+        << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
+    isDead = false;
+  }
+  return isDead;
+}
+
+bool SiPixelGainCalibrationOfflineSimService::isNoisyColumn(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getGainByColumn(detID, col, row, isDead, isNoisy);  // the gain column average can flag a whole column as bad
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationOfflineSimService")
+        << "Attempting to check if nonexistant pixel is Noisy.  Exception message: " << e.what();
+    isNoisy = false;
+  }
+  return isNoisy;
 }

--- a/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationService.cc
+++ b/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationService.cc
@@ -16,96 +16,86 @@
 
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h"
 
-
-
-void SiPixelGainCalibrationServiceBase::calibrate(uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int * electron) {
-  int i=0;
-  for(DigiIterator di = b; di != e; ++di)  {
+void SiPixelGainCalibrationServiceBase::calibrate(
+    uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int* electron) {
+  int i = 0;
+  for (DigiIterator di = b; di != e; ++di) {
     int row = di->row();
     int col = di->column();
-    
-    if ( isDead(detID,col,row) || isNoisy(detID,col,row) ) electron[i++] =0;
+
+    if (isDead(detID, col, row) || isNoisy(detID, col, row))
+      electron[i++] = 0;
     else {
-      float DBgain     = getGain(detID, col, row);
+      float DBgain = getGain(detID, col, row);
       float DBpedestal = getPedestal(detID, col, row) * DBgain;
-      float vcal = di->adc() * DBgain  - DBpedestal;
+      float vcal = di->adc() * DBgain - DBpedestal;
       //    float vcal = (di->adc()  - DBpedestal) * DBgain;
-      electron[i++] = int( vcal * conversionFactor + offset); 
+      electron[i++] = int(vcal * conversionFactor + offset);
     }
   }
-  assert(i==(e-b));
+  assert(i == (e - b));
 }
 
-
-
-float SiPixelGainCalibrationService::getPedestal( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   float pedestalValue = this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
-   if (isDead || isNoisy)
-   {
-      this->throwExepctionForBadRead("FullCalibration getPedestal()",detID, col, row, pedestalValue);
-      return 0.0;
-   }
-   return pedestalValue;
+float SiPixelGainCalibrationService::getPedestal(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  float pedestalValue = this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
+  if (isDead || isNoisy) {
+    this->throwExepctionForBadRead("FullCalibration getPedestal()", detID, col, row, pedestalValue);
+    return 0.0;
+  }
+  return pedestalValue;
 }
 
-float SiPixelGainCalibrationService::getGain( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   float gainValue = this->getGainByColumn(detID, col, row, isDead, isNoisy);
-   if (isDead || isNoisy)
-   {
-      this->throwExepctionForBadRead("FullCalibration getGain()",detID, col, row, gainValue);
-      return 0.0;
-   }
-   return gainValue;
+float SiPixelGainCalibrationService::getGain(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  float gainValue = this->getGainByColumn(detID, col, row, isDead, isNoisy);
+  if (isDead || isNoisy) {
+    this->throwExepctionForBadRead("FullCalibration getGain()", detID, col, row, gainValue);
+    return 0.0;
+  }
+  return gainValue;
 }
 
-bool SiPixelGainCalibrationService::isDead( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getPedestalByPixel(detID, col, row, isDead, isNoisy); 
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is dead
-      edm::LogInfo("SiPixelGainCalibrationService") << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
-      isDead = false; 
-   }
-   return isDead;
+bool SiPixelGainCalibrationService::isDead(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is dead
+    edm::LogInfo("SiPixelGainCalibrationService")
+        << "Attempting to check if nonexistant pixel is dead.  Exception message: " << e.what();
+    isDead = false;
+  }
+  return isDead;
 }
 
-bool SiPixelGainCalibrationService::isNoisy( const uint32_t& detID,const int& col, const int& row)
-{
-   bool isDead = false;
-   bool isNoisy = false;
-   try  
-   {
-      this->getPedestalByPixel(detID, col, row, isDead, isNoisy); 
-   }
-   catch (cms::Exception& e) 
-   {
-      // Do not stop processing if you check if a nonexistant pixel is noisy
-      edm::LogInfo("SiPixelGainCalibrationService") << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
-      isNoisy = false; 
-   }
-   return isNoisy;
+bool SiPixelGainCalibrationService::isNoisy(const uint32_t& detID, const int& col, const int& row) {
+  bool isDead = false;
+  bool isNoisy = false;
+  try {
+    this->getPedestalByPixel(detID, col, row, isDead, isNoisy);
+  } catch (cms::Exception& e) {
+    // Do not stop processing if you check if a nonexistant pixel is noisy
+    edm::LogInfo("SiPixelGainCalibrationService")
+        << "Attempting to check if nonexistant pixel is noisy.  Exception message: " << e.what();
+    isNoisy = false;
+  }
+  return isNoisy;
 }
-   
-bool SiPixelGainCalibrationService::isDeadColumn( const uint32_t& detID,const int& col, const int& row)
-{
-   edm::LogError("SiPixelGainCalibrationService") << "You attempted to check if an entire column was dead with a payload that stores information at pixel granularity.  Please check by pixel. THANKS!";
-   return false;
+
+bool SiPixelGainCalibrationService::isDeadColumn(const uint32_t& detID, const int& col, const int& row) {
+  edm::LogError("SiPixelGainCalibrationService")
+      << "You attempted to check if an entire column was dead with a payload that stores information at pixel "
+         "granularity.  Please check by pixel. THANKS!";
+  return false;
 }
-   
-bool SiPixelGainCalibrationService::isNoisyColumn( const uint32_t& detID,const int& col, const int& row)
-{
-   edm::LogError("SiPixelGainCalibrationService") << "You attempted to check if an entire column was noisy with a payload that stores information at pixel granularity.  Please check by pixel. THANKS!";
-   return false;
+
+bool SiPixelGainCalibrationService::isNoisyColumn(const uint32_t& detID, const int& col, const int& row) {
+  edm::LogError("SiPixelGainCalibrationService")
+      << "You attempted to check if an entire column was noisy with a payload that stores information at pixel "
+         "granularity.  Please check by pixel. THANKS!";
+  return false;
 }

--- a/CalibTracker/SiPixelESProducers/test/PixelFEDChannelCollectionMapTestReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/PixelFEDChannelCollectionMapTestReader.cc
@@ -13,71 +13,74 @@
 
 class PixelFEDChannelCollectionMapTestReader : public edm::one::EDAnalyzer<> {
 public:
-
-  typedef std::unordered_map<std::string,PixelFEDChannelCollection> PixelFEDChannelCollectionMap;
-  explicit PixelFEDChannelCollectionMapTestReader(edm::ParameterSet const& p); 
-  ~PixelFEDChannelCollectionMapTestReader(); 
+  typedef std::unordered_map<std::string, PixelFEDChannelCollection> PixelFEDChannelCollectionMap;
+  explicit PixelFEDChannelCollectionMapTestReader(edm::ParameterSet const& p);
+  ~PixelFEDChannelCollectionMapTestReader();
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
 private:
-    
   virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   // ----------member data ---------------------------
   const bool printdebug_;
   const std::string formatedOutput_;
-  
 };
-  
-PixelFEDChannelCollectionMapTestReader::PixelFEDChannelCollectionMapTestReader(edm::ParameterSet const& p):
-  printdebug_(p.getUntrackedParameter<bool>("printDebug",true)),
-  formatedOutput_(p.getUntrackedParameter<std::string>("outputFile",""))
-{ 
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader")<<"PixelFEDChannelCollectionMapTestReader"<<std::endl;
+
+PixelFEDChannelCollectionMapTestReader::PixelFEDChannelCollectionMapTestReader(edm::ParameterSet const& p)
+    : printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
+      formatedOutput_(p.getUntrackedParameter<std::string>("outputFile", "")) {
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "PixelFEDChannelCollectionMapTestReader" << std::endl;
 }
 
-PixelFEDChannelCollectionMapTestReader::~PixelFEDChannelCollectionMapTestReader() {  
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader")<<"~PixelFEDChannelCollectionMapTestReader "<<std::endl;
+PixelFEDChannelCollectionMapTestReader::~PixelFEDChannelCollectionMapTestReader() {
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "~PixelFEDChannelCollectionMapTestReader " << std::endl;
 }
 
-void
-PixelFEDChannelCollectionMapTestReader::analyze(const edm::Event& e, const edm::EventSetup& context){
-  
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") <<"### PixelFEDChannelCollectionMapTestReader::analyze  ###"<<std::endl;
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
-  
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("'SiPixelFEDChannelContainerESProducerRcd"));
-    
-  if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+void PixelFEDChannelCollectionMapTestReader::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader")
+      << "### PixelFEDChannelCollectionMapTestReader::analyze  ###" << std::endl;
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+  edm::eventsetup::EventSetupRecordKey recordKey(
+      edm::eventsetup::EventSetupRecordKey::TypeTag::findType("'SiPixelFEDChannelContainerESProducerRcd"));
+
+  if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
     //record not found
-    edm::LogInfo("PixelFEDChannelCollectionMapTestReader") <<"Record \"SiPixelFEDChannelContainerESProducerRcd"<<"\" does not exist "<<std::endl;
+    edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "Record \"SiPixelFEDChannelContainerESProducerRcd"
+                                                           << "\" does not exist " << std::endl;
   }
-  
+
   //this part gets the handle of the event source and the record (i.e. the Database)
   edm::ESHandle<PixelFEDChannelCollectionMap> PixelFEDChannelCollectionMapHandle;
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") <<"got eshandle"<<std::endl;
-  
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "got eshandle" << std::endl;
+
   context.get<SiPixelFEDChannelContainerESProducerRcd>().get(PixelFEDChannelCollectionMapHandle);
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") <<"got context"<<std::endl;
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "got context" << std::endl;
 
-  const PixelFEDChannelCollectionMap* thePixelFEDChannelCollectionMap=PixelFEDChannelCollectionMapHandle.product();
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") <<"got SiPixelFEDChannelContainer* "<< std::endl;
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "print  pointer address : " << thePixelFEDChannelCollectionMap << std::endl;  
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "Size: "  << thePixelFEDChannelCollectionMap->size() << std::endl;
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "Content of my PixelFEDChanneCollectionlMap: "<<std::endl;
+  const PixelFEDChannelCollectionMap* thePixelFEDChannelCollectionMap = PixelFEDChannelCollectionMapHandle.product();
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "got SiPixelFEDChannelContainer* " << std::endl;
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader")
+      << "print  pointer address : " << thePixelFEDChannelCollectionMap << std::endl;
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader")
+      << "Size: " << thePixelFEDChannelCollectionMap->size() << std::endl;
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "Content of my PixelFEDChanneCollectionlMap: " << std::endl;
 
-  FILE* pFile=NULL;
-  if(formatedOutput_!="")pFile=fopen(formatedOutput_.c_str(), "w");
-  if(pFile){
-    
-    fprintf(pFile,"PixelFEDChannelCollectionMap::printAll() \n");
-    fprintf(pFile," =================================================================================================================== \n"); 
-      
-    for(auto it = thePixelFEDChannelCollectionMap->begin(); it != thePixelFEDChannelCollectionMap->end() ; ++it){
-      fprintf(pFile," =================================================================================================================== \n");
-      fprintf(pFile,"run : %s \n ",(it->first).c_str());
+  FILE* pFile = NULL;
+  if (formatedOutput_ != "")
+    pFile = fopen(formatedOutput_.c_str(), "w");
+  if (pFile) {
+    fprintf(pFile, "PixelFEDChannelCollectionMap::printAll() \n");
+    fprintf(pFile,
+            " ========================================================================================================="
+            "========== \n");
+
+    for (auto it = thePixelFEDChannelCollectionMap->begin(); it != thePixelFEDChannelCollectionMap->end(); ++it) {
+      fprintf(pFile,
+              " ======================================================================================================="
+              "============ \n");
+      fprintf(pFile, "run : %s \n ", (it->first).c_str());
       const auto& thePixelFEDChannels = it->second;
 
       //std:: cout << thePixelFEDChannels.size() << std::endl;
@@ -86,26 +89,29 @@ PixelFEDChannelCollectionMapTestReader::analyze(const edm::Event& e, const edm::
       //       std:: cout << theDetId << std::endl;
       // }
 
-      for (const auto& disabledChannels: thePixelFEDChannels) {
-	//loop over different PixelFED in a PixelFED vector (module)
-       fprintf(pFile,"DetId : %i \n",disabledChannels.detId());
-       for(const auto& ch: disabledChannels) {
-         fprintf(pFile,"fed : %i | link : %2i | roc_first : %2i | roc_last: %2i \n",ch.fed, ch.link,  ch.roc_first, ch.roc_last);       
-         //std::cout <<  disabledChannels.detId() << " "<< ch.fed << " " << ch.link << " " << ch.roc_first << " " << ch.roc_last << std::endl;
-       } // loop over disable channels
-      } // loop over the detSetVector
-    } // main loop on the map
-  } // if file exists
-
+      for (const auto& disabledChannels : thePixelFEDChannels) {
+        //loop over different PixelFED in a PixelFED vector (module)
+        fprintf(pFile, "DetId : %i \n", disabledChannels.detId());
+        for (const auto& ch : disabledChannels) {
+          fprintf(pFile,
+                  "fed : %i | link : %2i | roc_first : %2i | roc_last: %2i \n",
+                  ch.fed,
+                  ch.link,
+                  ch.roc_first,
+                  ch.roc_last);
+          //std::cout <<  disabledChannels.detId() << " "<< ch.fed << " " << ch.link << " " << ch.roc_first << " " << ch.roc_last << std::endl;
+        }  // loop over disable channels
+      }    // loop over the detSetVector
+    }      // main loop on the map
+  }        // if file exists
 }
 
-void
-PixelFEDChannelCollectionMapTestReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PixelFEDChannelCollectionMapTestReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Reads payloads of type SiPixelFEDChannelContainer");
-  desc.addUntracked<bool>("printDebug",true);
-  desc.addUntracked<std::string>("outputFile","");
-  descriptions.add("PixelFEDChannelCollectionMapTestReader",desc);
+  desc.addUntracked<bool>("printDebug", true);
+  desc.addUntracked<std::string>("outputFile", "");
+  descriptions.add("PixelFEDChannelCollectionMapTestReader", desc);
 }
 
 DEFINE_FWK_MODULE(PixelFEDChannelCollectionMapTestReader);

--- a/CalibTracker/SiPixelESProducers/test/SealModules.cc
+++ b/CalibTracker/SiPixelESProducers/test/SealModules.cc
@@ -4,10 +4,9 @@
 #include "CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.h"
 #include "CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.h"
 
-using cms::SiPixelFakeGainReader;
 using cms::SiPixelFakeGainForHLTReader;
 using cms::SiPixelFakeGainOfflineReader;
-
+using cms::SiPixelFakeGainReader;
 
 DEFINE_FWK_MODULE(SiPixelFakeGainReader);
 DEFINE_FWK_MODULE(SiPixelFakeGainForHLTReader);

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.cc
@@ -5,122 +5,122 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-namespace cms{
-SiPixelFakeGainForHLTReader::SiPixelFakeGainForHLTReader(const edm::ParameterSet& conf): 
-    conf_(conf),
-    SiPixelGainCalibrationForHLTService_(conf),
-    filename_(conf.getParameter<std::string>("fileName"))
-{
-}
+namespace cms {
+  SiPixelFakeGainForHLTReader::SiPixelFakeGainForHLTReader(const edm::ParameterSet& conf)
+      : conf_(conf),
+        SiPixelGainCalibrationForHLTService_(conf),
+        filename_(conf.getParameter<std::string>("fileName")) {}
 
-void
-SiPixelFakeGainForHLTReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  
-  unsigned int nmodules = 0;
-  uint32_t nchannels = 0;
-  fFile->cd();
+  void SiPixelFakeGainForHLTReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    unsigned int nmodules = 0;
+    uint32_t nchannels = 0;
+    fFile->cd();
 
-  // Get the Geometry
-  iSetup.get<TrackerDigiGeometryRecord>().get( tkgeom );     
-  edm::LogInfo("SiPixelFakeGainForHLTReader") <<" There are "<<tkgeom->dets().size() <<" detectors"<<std::endl;
-  
-  // Get the calibrationForHLT data
-  //iSetup.get<SiPixelGainCalibrationForHLTRcd>().get(SiPixelGainCalibrationForHLT_);
-  //edm::LogInfo("SiPixelFakeGainForHLTReader") << "[SiPixelFakeGainForHLTReader::analyze] End Reading FakeGainForHLTects" << std::endl;
-  //SiPixelGainCalibrationForHLTService_.setESObjects(iSetup);
+    // Get the Geometry
+    iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+    edm::LogInfo("SiPixelFakeGainForHLTReader") << " There are " << tkgeom->dets().size() << " detectors" << std::endl;
 
-  //  for(TrackerGeometry::DetContainer::const_iterator it = tkgeom->dets().begin(); it != tkgeom->dets().end(); it++){
-  //   if( dynamic_cast<PixelGeomDetUnit*>((*it))!=0){
-  //     uint32_t detid=((*it)->geographicalId()).rawId();
-  // Get the list of DetId's
-  
-  std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationForHLTService_.getDetIds();
-  // Loop over DetId's
-  for (std::vector<uint32_t>::const_iterator detid_iter=vdetId_.begin();detid_iter!=vdetId_.end();detid_iter++){
-    uint32_t detid = *detid_iter;
+    // Get the calibrationForHLT data
+    //iSetup.get<SiPixelGainCalibrationForHLTRcd>().get(SiPixelGainCalibrationForHLT_);
+    //edm::LogInfo("SiPixelFakeGainForHLTReader") << "[SiPixelFakeGainForHLTReader::analyze] End Reading FakeGainForHLTects" << std::endl;
+    //SiPixelGainCalibrationForHLTService_.setESObjects(iSetup);
 
-    DetId detIdObject(detid);
-    nmodules++;
-    //if(nmodules>3) break;
+    //  for(TrackerGeometry::DetContainer::const_iterator it = tkgeom->dets().begin(); it != tkgeom->dets().end(); it++){
+    //   if( dynamic_cast<PixelGeomDetUnit*>((*it))!=0){
+    //     uint32_t detid=((*it)->geographicalId()).rawId();
+    // Get the list of DetId's
 
-    std::map<uint32_t,TH1F*>::iterator p_iter =  _TH1F_Pedestals_m.find(detid);
-    std::map<uint32_t,TH1F*>::iterator g_iter =  _TH1F_Gains_m.find(detid);
-    
-    const GeomDetUnit      * geoUnit = tkgeom->idToDetUnit( detIdObject );
-    const PixelGeomDetUnit * pixDet  = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
-    const PixelTopology & topol = pixDet->specificTopology();       
+    std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationForHLTService_.getDetIds();
+    // Loop over DetId's
+    for (std::vector<uint32_t>::const_iterator detid_iter = vdetId_.begin(); detid_iter != vdetId_.end();
+         detid_iter++) {
+      uint32_t detid = *detid_iter;
 
-    // Get the module sizes.
-    int nrows = topol.nrows();      // rows in x
-    int ncols = topol.ncolumns();   // cols in y
-    
-    for(int col_iter=0; col_iter<ncols; col_iter++) {
-      for(int row_iter=0; row_iter<nrows; row_iter++){
-         nchannels++;
-         float ped  = SiPixelGainCalibrationForHLTService_.getPedestal(detid, col_iter, row_iter);
-         float gain  = SiPixelGainCalibrationForHLTService_.getGain(detid, col_iter, row_iter);
-         p_iter->second->Fill( ped );
-         g_iter->second->Fill( gain );
+      DetId detIdObject(detid);
+      nmodules++;
+      //if(nmodules>3) break;
+
+      std::map<uint32_t, TH1F*>::iterator p_iter = _TH1F_Pedestals_m.find(detid);
+      std::map<uint32_t, TH1F*>::iterator g_iter = _TH1F_Gains_m.find(detid);
+
+      const GeomDetUnit* geoUnit = tkgeom->idToDetUnit(detIdObject);
+      const PixelGeomDetUnit* pixDet = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
+      const PixelTopology& topol = pixDet->specificTopology();
+
+      // Get the module sizes.
+      int nrows = topol.nrows();     // rows in x
+      int ncols = topol.ncolumns();  // cols in y
+
+      for (int col_iter = 0; col_iter < ncols; col_iter++) {
+        for (int row_iter = 0; row_iter < nrows; row_iter++) {
+          nchannels++;
+          float ped = SiPixelGainCalibrationForHLTService_.getPedestal(detid, col_iter, row_iter);
+          float gain = SiPixelGainCalibrationForHLTService_.getGain(detid, col_iter, row_iter);
+          p_iter->second->Fill(ped);
+          g_iter->second->Fill(gain);
+        }
+      }
+    }
+
+    edm::LogInfo("SiPixelFakeGainForHLTReader")
+        << "[SiPixelFakeGainForHLTReader::analyze] ---> PIXEL Modules  " << nmodules << std::endl;
+    edm::LogInfo("SiPixelFakeGainForHLTReader")
+        << "[SiPixelFakeGainForHLTReader::analyze] ---> PIXEL Channels " << nchannels << std::endl;
+    fFile->ls();
+    fFile->Write();
+    fFile->Close();
+  }
+
+  // ----------------------------------------------------------------------
+  void SiPixelFakeGainForHLTReader::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
+    static int first(1);
+    if (1 == first) {
+      first = 0;
+      edm::LogInfo("SiPixelFakeGainForHLTReader")
+          << "[SiPixelFakeGainForHLTReader::beginJob] Opening ROOT file  " << std::endl;
+      fFile = new TFile(filename_.c_str(), "RECREATE");
+      fFile->mkdir("Pedestals");
+      fFile->mkdir("Gains");
+      fFile->cd();
+      char name[128];
+
+      // Get Geometry
+      iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+
+      // Get the calibrationForHLT data
+      //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
+      //iSetup.get<SiPixelGainCalibrationRcd>().get(SiPixelGainCalibration_);
+      SiPixelGainCalibrationForHLTService_.setESObjects(iSetup);
+      edm::LogInfo("SiPixelFakeGainForHLTReader")
+          << "[SiPixelFakeGainForHLTReader::beginJob] End Reading FakeGainForHLTects" << std::endl;
+      // Get the list of DetId's
+      std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationForHLTService_.getDetIds();
+      //SiPixelGainCalibrationForHLT_->getDetIds(vdetId_);
+      // Loop over DetId's
+      for (std::vector<uint32_t>::const_iterator detid_iter = vdetId_.begin(); detid_iter != vdetId_.end();
+           detid_iter++) {
+        uint32_t detid = *detid_iter;
+
+        const PixelGeomDetUnit* _PixelGeomDetUnit =
+            dynamic_cast<const PixelGeomDetUnit*>(tkgeom->idToDetUnit(DetId(detid)));
+        if (_PixelGeomDetUnit == 0) {
+          edm::LogError("SiPixelFakeGainForHLTDisplay") << "[SiPixelFakeGainForHLTReader::beginJob] the detID " << detid
+                                                        << " doesn't seem to belong to Tracker" << std::endl;
+          continue;
+        }
+        // Book histograms
+        sprintf(name, "Pedestals_%d", detid);
+        fFile->cd();
+        fFile->cd("Pedestals");
+        _TH1F_Pedestals_m[detid] = new TH1F(name, name, 50, 0., 50.);
+        sprintf(name, "Gains_%d", detid);
+        fFile->cd();
+        fFile->cd("Gains");
+        _TH1F_Gains_m[detid] = new TH1F(name, name, 100, 0., 10.);
       }
     }
   }
-  
-  edm::LogInfo("SiPixelFakeGainForHLTReader") <<"[SiPixelFakeGainForHLTReader::analyze] ---> PIXEL Modules  " << nmodules  << std::endl;
-  edm::LogInfo("SiPixelFakeGainForHLTReader") <<"[SiPixelFakeGainForHLTReader::analyze] ---> PIXEL Channels " << nchannels << std::endl;
-  fFile->ls();
-  fFile->Write();
-  fFile->Close();    
-}
-  
-  
-// ----------------------------------------------------------------------
-void SiPixelFakeGainForHLTReader::beginRun(const edm::Run &run , const edm::EventSetup &iSetup) {
-  static int first(1); 
-  if (1 == first) {
-    first = 0; 
-    edm::LogInfo("SiPixelFakeGainForHLTReader") <<"[SiPixelFakeGainForHLTReader::beginJob] Opening ROOT file  " <<std::endl;
-    fFile = new TFile(filename_.c_str(),"RECREATE");
-    fFile->mkdir("Pedestals");
-    fFile->mkdir("Gains");
-    fFile->cd();
-    char name[128];
-    
-    // Get Geometry
-    iSetup.get<TrackerDigiGeometryRecord>().get( tkgeom );
-    
-    // Get the calibrationForHLT data
-    //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
-    //iSetup.get<SiPixelGainCalibrationRcd>().get(SiPixelGainCalibration_);
-    SiPixelGainCalibrationForHLTService_.setESObjects(iSetup);
-    edm::LogInfo("SiPixelFakeGainForHLTReader") << "[SiPixelFakeGainForHLTReader::beginJob] End Reading FakeGainForHLTects" << std::endl;
-    // Get the list of DetId's
-    std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationForHLTService_.getDetIds();
-    //SiPixelGainCalibrationForHLT_->getDetIds(vdetId_);
-    // Loop over DetId's
-    for (std::vector<uint32_t>::const_iterator detid_iter=vdetId_.begin();detid_iter!=vdetId_.end();detid_iter++){
-      uint32_t detid = *detid_iter;
-      
-      const PixelGeomDetUnit* _PixelGeomDetUnit = dynamic_cast<const PixelGeomDetUnit*>(tkgeom->idToDetUnit(DetId(detid)));
-      if (_PixelGeomDetUnit==0){
-	edm::LogError("SiPixelFakeGainForHLTDisplay")<<"[SiPixelFakeGainForHLTReader::beginJob] the detID "<<detid<<" doesn't seem to belong to Tracker"<<std::endl; 
-	continue;
-      }     
-      // Book histograms
-      sprintf(name,"Pedestals_%d",detid);
-      fFile->cd();fFile->cd("Pedestals");
-      _TH1F_Pedestals_m[detid] = new TH1F(name,name,50,0.,50.);    
-      sprintf(name,"Gains_%d",detid);
-      fFile->cd();fFile->cd("Gains");
-      _TH1F_Gains_m[detid] = new TH1F(name,name,100,0.,10.);    
-    }
-  }
-}
 
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-SiPixelFakeGainForHLTReader::endJob() {
-  std::cout<<" ---> End job "<<std::endl;
-}
-}
+  // ------------ method called once each job just after ending the event loop  ------------
+  void SiPixelFakeGainForHLTReader::endJob() { std::cout << " ---> End job " << std::endl; }
+}  // namespace cms

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.h
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelFakeGainForHLTReader
 // Class:      SiPixelFakeGainForHLTReader
-// 
+//
 /**\class SiPixelFakeGainForHLTReader SiPixelFakeGainForHLTReader.h SiPixelESProducers/test/SiPixelFakeGainForHLTReader.h
 
  Description: Test analyzer for fake pixel calibrationForHLT
@@ -34,31 +34,27 @@
 #include "TBranch.h"
 #include "TH1F.h"
 
-namespace cms{
-class SiPixelFakeGainForHLTReader : public edm::EDAnalyzer {
+namespace cms {
+  class SiPixelFakeGainForHLTReader : public edm::EDAnalyzer {
+  public:
+    explicit SiPixelFakeGainForHLTReader(const edm::ParameterSet& iConfig);
 
-public:
+    ~SiPixelFakeGainForHLTReader(){};
+    virtual void beginJob() { ; }
+    virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    virtual void endJob();
 
-  explicit SiPixelFakeGainForHLTReader( const edm::ParameterSet& iConfig);
+  private:
+    edm::ParameterSet conf_;
+    edm::ESHandle<TrackerGeometry> tkgeom;
+    //edm::ESHandle<SiPixelGainCalibrationForHLT> SiPixelGainCalibrationForHLT_;
+    SiPixelGainCalibrationForHLTService SiPixelGainCalibrationForHLTService_;
 
-  ~SiPixelFakeGainForHLTReader(){};
-  virtual void beginJob() {;}
-  virtual void beginRun(const edm::Run& , const edm::EventSetup& );
-  virtual void analyze(const edm::Event& , const edm::EventSetup& );
-  virtual void endJob() ;
-
-private:
-
-  edm::ParameterSet conf_;
-  edm::ESHandle<TrackerGeometry> tkgeom;
-  //edm::ESHandle<SiPixelGainCalibrationForHLT> SiPixelGainCalibrationForHLT_;
-  SiPixelGainCalibrationForHLTService SiPixelGainCalibrationForHLTService_;
-
-  std::map< uint32_t, TH1F* >  _TH1F_Pedestals_m;
-  std::map< uint32_t, TH1F* >  _TH1F_Gains_m;
-  std::string filename_;
-  TFile* fFile;
-
-};
-}
+    std::map<uint32_t, TH1F*> _TH1F_Pedestals_m;
+    std::map<uint32_t, TH1F*> _TH1F_Gains_m;
+    std::string filename_;
+    TFile* fFile;
+  };
+}  // namespace cms
 #endif

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.cc
@@ -5,135 +5,128 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-namespace cms{
-SiPixelFakeGainOfflineReader::SiPixelFakeGainOfflineReader(const edm::ParameterSet& conf): 
-    conf_(conf),
-    SiPixelGainCalibrationOfflineService_(conf),
-    filename_(conf.getParameter<std::string>("fileName"))
-{
-}
+namespace cms {
+  SiPixelFakeGainOfflineReader::SiPixelFakeGainOfflineReader(const edm::ParameterSet& conf)
+      : conf_(conf),
+        SiPixelGainCalibrationOfflineService_(conf),
+        filename_(conf.getParameter<std::string>("fileName")) {}
 
-void
-SiPixelFakeGainOfflineReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  unsigned int nmodules = 0;
-  uint32_t nchannels = 0;
-  fFile->cd();
+  void SiPixelFakeGainOfflineReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    unsigned int nmodules = 0;
+    uint32_t nchannels = 0;
+    fFile->cd();
 
-  // Get the Geometry
-  iSetup.get<TrackerDigiGeometryRecord>().get( tkgeom );     
-  edm::LogInfo("SiPixelFakeGainOfflineReader") <<" There are "<<tkgeom->dets().size() <<" detectors"<<std::endl;
-  
-  // Get the calibrationOffline data
-  //iSetup.get<SiPixelGainCalibrationOfflineRcd>().get(SiPixelGainCalibrationOffline_);
-  //edm::LogInfo("SiPixelFakeGainOfflineReader") << "[SiPixelFakeGainOfflineReader::analyze] End Reading FakeGainOfflineects" << std::endl;
-  //SiPixelGainCalibrationOfflineService_.setESObjects(iSetup);
+    // Get the Geometry
+    iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+    edm::LogInfo("SiPixelFakeGainOfflineReader") << " There are " << tkgeom->dets().size() << " detectors" << std::endl;
 
-  //  for(TrackerGeometry::DetContainer::const_iterator it = tkgeom->dets().begin(); it != tkgeom->dets().end(); it++){
-  //   if( dynamic_cast<PixelGeomDetUnit*>((*it))!=0){
-  //     uint32_t detid=((*it)->geographicalId()).rawId();
-  // Get the list of DetId's
-  
-  std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationOfflineService_.getDetIds();
-  // Loop over DetId's
-  for (std::vector<uint32_t>::const_iterator detid_iter=vdetId_.begin();detid_iter!=vdetId_.end();detid_iter++){
-    uint32_t detid = *detid_iter;
+    // Get the calibrationOffline data
+    //iSetup.get<SiPixelGainCalibrationOfflineRcd>().get(SiPixelGainCalibrationOffline_);
+    //edm::LogInfo("SiPixelFakeGainOfflineReader") << "[SiPixelFakeGainOfflineReader::analyze] End Reading FakeGainOfflineects" << std::endl;
+    //SiPixelGainCalibrationOfflineService_.setESObjects(iSetup);
 
-    DetId detIdObject(detid);
-    nmodules++;
-    //if(nmodules>3) break;
+    //  for(TrackerGeometry::DetContainer::const_iterator it = tkgeom->dets().begin(); it != tkgeom->dets().end(); it++){
+    //   if( dynamic_cast<PixelGeomDetUnit*>((*it))!=0){
+    //     uint32_t detid=((*it)->geographicalId()).rawId();
+    // Get the list of DetId's
 
-    std::map<uint32_t,TH1F*>::iterator p_iter =  _TH1F_Pedestals_m.find(detid);
-    std::map<uint32_t,TH1F*>::iterator g_iter =  _TH1F_Gains_m.find(detid);
-    
-    const GeomDetUnit      * geoUnit = tkgeom->idToDetUnit( detIdObject );
-    const PixelGeomDetUnit * pixDet  = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
-    const PixelTopology & topol = pixDet->specificTopology();       
+    std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationOfflineService_.getDetIds();
+    // Loop over DetId's
+    for (std::vector<uint32_t>::const_iterator detid_iter = vdetId_.begin(); detid_iter != vdetId_.end();
+         detid_iter++) {
+      uint32_t detid = *detid_iter;
 
-    // Get the module sizes.
-    int nrows = topol.nrows();      // rows in x
-    int ncols = topol.ncolumns();   // cols in y
-    
-    for(int col_iter=0; col_iter<ncols; col_iter++) {
-      for(int row_iter=0; row_iter<nrows; row_iter++) {
-	nchannels++;
-	
-	float gain  = SiPixelGainCalibrationOfflineService_.getGain(detid, col_iter, row_iter);
-	g_iter->second->Fill( gain );
-	float ped  = SiPixelGainCalibrationOfflineService_.getPedestal(detid, col_iter, row_iter);
-	p_iter->second->Fill( ped );
+      DetId detIdObject(detid);
+      nmodules++;
+      //if(nmodules>3) break;
 
+      std::map<uint32_t, TH1F*>::iterator p_iter = _TH1F_Pedestals_m.find(detid);
+      std::map<uint32_t, TH1F*>::iterator g_iter = _TH1F_Gains_m.find(detid);
 
-	//std::cout << "       Col "<<col_iter<<" Row "<<row_iter<<" Ped "<<ped<<" Gain "<<gain<<std::endl;
-	
+      const GeomDetUnit* geoUnit = tkgeom->idToDetUnit(detIdObject);
+      const PixelGeomDetUnit* pixDet = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
+      const PixelTopology& topol = pixDet->specificTopology();
+
+      // Get the module sizes.
+      int nrows = topol.nrows();     // rows in x
+      int ncols = topol.ncolumns();  // cols in y
+
+      for (int col_iter = 0; col_iter < ncols; col_iter++) {
+        for (int row_iter = 0; row_iter < nrows; row_iter++) {
+          nchannels++;
+
+          float gain = SiPixelGainCalibrationOfflineService_.getGain(detid, col_iter, row_iter);
+          g_iter->second->Fill(gain);
+          float ped = SiPixelGainCalibrationOfflineService_.getPedestal(detid, col_iter, row_iter);
+          p_iter->second->Fill(ped);
+
+          //std::cout << "       Col "<<col_iter<<" Row "<<row_iter<<" Ped "<<ped<<" Gain "<<gain<<std::endl;
+        }
+      }
+    }
+
+    edm::LogInfo("SiPixelFakeGainOfflineReader")
+        << "[SiPixelFakeGainOfflineReader::analyze] ---> PIXEL Modules  " << nmodules << std::endl;
+    edm::LogInfo("SiPixelFakeGainOfflineReader")
+        << "[SiPixelFakeGainOfflineReader::analyze] ---> PIXEL Channels " << nchannels << std::endl;
+    fFile->ls();
+    fFile->Write();
+    fFile->Close();
+  }
+
+  // ------------ method called once each job just before starting event loop  ------------
+  void SiPixelFakeGainOfflineReader::beginJob() {}
+
+  // ------------ method called once each job just before starting event loop  ------------
+  void SiPixelFakeGainOfflineReader::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
+    static int first(1);
+    if (1 == first) {
+      first = 0;
+      edm::LogInfo("SiPixelFakeGainOfflineReader")
+          << "[SiPixelFakeGainOfflineReader::beginJob] Opening ROOT file  " << std::endl;
+      fFile = new TFile(filename_.c_str(), "RECREATE");
+      fFile->mkdir("Pedestals");
+      fFile->mkdir("Gains");
+      fFile->cd();
+      char name[128];
+
+      // Get Geometry
+      iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+
+      // Get the calibrationOffline data
+      //edm::ESHandle<SiPixelGainCalibrationOffline> SiPixelGainCalibrationOffline_;
+      //iSetup.get<SiPixelGainCalibrationOfflineRcd>().get(SiPixelGainCalibrationOffline_);
+      SiPixelGainCalibrationOfflineService_.setESObjects(iSetup);
+      edm::LogInfo("SiPixelFakeGainOfflineReader")
+          << "[SiPixelFakeGainOfflineReader::beginJob] End Reading FakeGainOfflineects" << std::endl;
+      // Get the list of DetId's
+      std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationOfflineService_.getDetIds();
+      //SiPixelGainCalibrationOffline_->getDetIds(vdetId_);
+      // Loop over DetId's
+      for (std::vector<uint32_t>::const_iterator detid_iter = vdetId_.begin(); detid_iter != vdetId_.end();
+           detid_iter++) {
+        uint32_t detid = *detid_iter;
+
+        const PixelGeomDetUnit* _PixelGeomDetUnit =
+            dynamic_cast<const PixelGeomDetUnit*>(tkgeom->idToDetUnit(DetId(detid)));
+        if (_PixelGeomDetUnit == 0) {
+          edm::LogError("SiPixelFakeGainOfflineDisplay") << "[SiPixelFakeGainOfflineReader::beginJob] the detID "
+                                                         << detid << " doesn't seem to belong to Tracker" << std::endl;
+          continue;
+        }
+        // Book histograms
+        sprintf(name, "Pedestals_%d", detid);
+        fFile->cd();
+        fFile->cd("Pedestals");
+        _TH1F_Pedestals_m[detid] = new TH1F(name, name, 50, 0., 50.);
+        sprintf(name, "Gains_%d", detid);
+        fFile->cd();
+        fFile->cd("Gains");
+        _TH1F_Gains_m[detid] = new TH1F(name, name, 100, 0., 10.);
       }
     }
   }
-  
-  edm::LogInfo("SiPixelFakeGainOfflineReader") <<"[SiPixelFakeGainOfflineReader::analyze] ---> PIXEL Modules  " << nmodules  << std::endl;
-  edm::LogInfo("SiPixelFakeGainOfflineReader") <<"[SiPixelFakeGainOfflineReader::analyze] ---> PIXEL Channels " << nchannels << std::endl;
-  fFile->ls();
-  fFile->Write();
-  fFile->Close();    
-}
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-SiPixelFakeGainOfflineReader::beginJob()
-{
-}
-
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-SiPixelFakeGainOfflineReader::beginRun(const edm::Run &run , const edm::EventSetup &iSetup)
-{
-
-  static int first(1); 
-  if (1 == first) {
-    first = 0; 
-    edm::LogInfo("SiPixelFakeGainOfflineReader") <<"[SiPixelFakeGainOfflineReader::beginJob] Opening ROOT file  " <<std::endl;
-    fFile = new TFile(filename_.c_str(),"RECREATE");
-    fFile->mkdir("Pedestals");
-    fFile->mkdir("Gains");
-    fFile->cd();
-    char name[128];
-    
-    // Get Geometry
-    iSetup.get<TrackerDigiGeometryRecord>().get( tkgeom );
-    
-    // Get the calibrationOffline data
-    //edm::ESHandle<SiPixelGainCalibrationOffline> SiPixelGainCalibrationOffline_;
-    //iSetup.get<SiPixelGainCalibrationOfflineRcd>().get(SiPixelGainCalibrationOffline_);
-    SiPixelGainCalibrationOfflineService_.setESObjects(iSetup);
-    edm::LogInfo("SiPixelFakeGainOfflineReader") << "[SiPixelFakeGainOfflineReader::beginJob] End Reading FakeGainOfflineects" << std::endl;
-    // Get the list of DetId's
-    std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationOfflineService_.getDetIds();
-    //SiPixelGainCalibrationOffline_->getDetIds(vdetId_);
-    // Loop over DetId's
-    for (std::vector<uint32_t>::const_iterator detid_iter=vdetId_.begin();detid_iter!=vdetId_.end();detid_iter++){
-      uint32_t detid = *detid_iter;
-      
-      const PixelGeomDetUnit* _PixelGeomDetUnit = dynamic_cast<const PixelGeomDetUnit*>(tkgeom->idToDetUnit(DetId(detid)));
-      if (_PixelGeomDetUnit==0){
-	edm::LogError("SiPixelFakeGainOfflineDisplay")<<"[SiPixelFakeGainOfflineReader::beginJob] the detID "<<detid<<" doesn't seem to belong to Tracker"<<std::endl; 
-	continue;
-      }     
-      // Book histograms
-      sprintf(name,"Pedestals_%d",detid);
-      fFile->cd();fFile->cd("Pedestals");
-      _TH1F_Pedestals_m[detid] = new TH1F(name,name,50,0.,50.);    
-      sprintf(name,"Gains_%d",detid);
-      fFile->cd();fFile->cd("Gains");
-      _TH1F_Gains_m[detid] = new TH1F(name,name,100,0.,10.);    
-    }
-  }
-}
-
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-SiPixelFakeGainOfflineReader::endJob() {
-  std::cout<<" ---> End job "<<std::endl;
-}
-}
+  // ------------ method called once each job just after ending the event loop  ------------
+  void SiPixelFakeGainOfflineReader::endJob() { std::cout << " ---> End job " << std::endl; }
+}  // namespace cms

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.h
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelFakeGainOfflineReader
 // Class:      SiPixelFakeGainOfflineReader
-// 
+//
 /**\class SiPixelFakeGainOfflineReader SiPixelFakeGainOfflineReader.h SiPixelESProducers/test/SiPixelFakeGainOfflineReader.h
 
  Description: Test analyzer for fake pixel calibrationOffline
@@ -34,31 +34,27 @@
 #include "TBranch.h"
 #include "TH1F.h"
 
-namespace cms{
-class SiPixelFakeGainOfflineReader : public edm::EDAnalyzer {
+namespace cms {
+  class SiPixelFakeGainOfflineReader : public edm::EDAnalyzer {
+  public:
+    explicit SiPixelFakeGainOfflineReader(const edm::ParameterSet& iConfig);
 
-public:
+    ~SiPixelFakeGainOfflineReader(){};
+    virtual void beginJob();
+    virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    virtual void endJob();
 
-  explicit SiPixelFakeGainOfflineReader( const edm::ParameterSet& iConfig);
+  private:
+    edm::ParameterSet conf_;
+    edm::ESHandle<TrackerGeometry> tkgeom;
+    //edm::ESHandle<SiPixelGainCalibrationOffline> SiPixelGainCalibrationOffline_;
+    SiPixelGainCalibrationOfflineService SiPixelGainCalibrationOfflineService_;
 
-  ~SiPixelFakeGainOfflineReader(){};
-  virtual void beginJob( );
-  virtual void beginRun(const edm::Run& , const edm::EventSetup& );
-  virtual void analyze(const edm::Event& , const edm::EventSetup& );
-  virtual void endJob() ;
-
-private:
-
-  edm::ParameterSet conf_;
-  edm::ESHandle<TrackerGeometry> tkgeom;
-  //edm::ESHandle<SiPixelGainCalibrationOffline> SiPixelGainCalibrationOffline_;
-  SiPixelGainCalibrationOfflineService SiPixelGainCalibrationOfflineService_;
-
-  std::map< uint32_t, TH1F* >  _TH1F_Pedestals_m;
-  std::map< uint32_t, TH1F* >  _TH1F_Gains_m;
-  std::string filename_;
-  TFile* fFile;
-
-};
-}
+    std::map<uint32_t, TH1F*> _TH1F_Pedestals_m;
+    std::map<uint32_t, TH1F*> _TH1F_Gains_m;
+    std::string filename_;
+    TFile* fFile;
+  };
+}  // namespace cms
 #endif

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.cc
@@ -5,134 +5,126 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-namespace cms{
-SiPixelFakeGainReader::SiPixelFakeGainReader(const edm::ParameterSet& conf): 
-    conf_(conf),
-    SiPixelGainCalibrationService_(conf),
-    filename_(conf.getParameter<std::string>("fileName"))
-{
-}
+namespace cms {
+  SiPixelFakeGainReader::SiPixelFakeGainReader(const edm::ParameterSet& conf)
+      : conf_(conf), SiPixelGainCalibrationService_(conf), filename_(conf.getParameter<std::string>("fileName")) {}
 
-void
-SiPixelFakeGainReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  unsigned int nmodules = 0;
-  uint32_t nchannels = 0;
-  fFile->cd();
+  void SiPixelFakeGainReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    unsigned int nmodules = 0;
+    uint32_t nchannels = 0;
+    fFile->cd();
 
-  // Get the Geometry
-  iSetup.get<TrackerDigiGeometryRecord>().get( tkgeom );     
-  edm::LogInfo("SiPixelFakeGainReader") <<" There are "<<tkgeom->dets().size() <<" detectors"<<std::endl;
-  
-  // Get the calibration data
-  //iSetup.get<SiPixelGainCalibrationRcd>().get(SiPixelGainCalibration_);
-  //edm::LogInfo("SiPixelFakeGainReader") << "[SiPixelFakeGainReader::analyze] End Reading FakeGainects" << std::endl;
-  //SiPixelGainCalibrationService_.setESObjects(iSetup);
+    // Get the Geometry
+    iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+    edm::LogInfo("SiPixelFakeGainReader") << " There are " << tkgeom->dets().size() << " detectors" << std::endl;
 
-  //  for(TrackerGeometry::DetContainer::const_iterator it = tkgeom->dets().begin(); it != tkgeom->dets().end(); it++){
-  //   if( dynamic_cast<PixelGeomDetUnit*>((*it))!=0){
-  //     uint32_t detid=((*it)->geographicalId()).rawId();
-  // Get the list of DetId's
-  
-  std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationService_.getDetIds();
-  // Loop over DetId's
-  for (std::vector<uint32_t>::const_iterator detid_iter=vdetId_.begin();detid_iter!=vdetId_.end();detid_iter++){
-    uint32_t detid = *detid_iter;
+    // Get the calibration data
+    //iSetup.get<SiPixelGainCalibrationRcd>().get(SiPixelGainCalibration_);
+    //edm::LogInfo("SiPixelFakeGainReader") << "[SiPixelFakeGainReader::analyze] End Reading FakeGainects" << std::endl;
+    //SiPixelGainCalibrationService_.setESObjects(iSetup);
 
-    DetId detIdObject(detid);
-    nmodules++;
-    //if(nmodules>3) break;
+    //  for(TrackerGeometry::DetContainer::const_iterator it = tkgeom->dets().begin(); it != tkgeom->dets().end(); it++){
+    //   if( dynamic_cast<PixelGeomDetUnit*>((*it))!=0){
+    //     uint32_t detid=((*it)->geographicalId()).rawId();
+    // Get the list of DetId's
 
-    std::map<uint32_t,TH1F*>::iterator p_iter =  _TH1F_Pedestals_m.find(detid);
-    std::map<uint32_t,TH1F*>::iterator g_iter =  _TH1F_Gains_m.find(detid);
-    
-    const GeomDetUnit      * geoUnit = tkgeom->idToDetUnit( detIdObject );
-    const PixelGeomDetUnit * pixDet  = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
-    const PixelTopology & topol = pixDet->specificTopology();       
+    std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationService_.getDetIds();
+    // Loop over DetId's
+    for (std::vector<uint32_t>::const_iterator detid_iter = vdetId_.begin(); detid_iter != vdetId_.end();
+         detid_iter++) {
+      uint32_t detid = *detid_iter;
 
-    // Get the module sizes.
-    int nrows = topol.nrows();      // rows in x
-    int ncols = topol.ncolumns();   // cols in y
-    
-    for(int col_iter=0; col_iter<ncols; col_iter++) {
-      for(int row_iter=0; row_iter<nrows; row_iter++) {
-         nchannels++;
+      DetId detIdObject(detid);
+      nmodules++;
+      //if(nmodules>3) break;
 
-         float ped  = SiPixelGainCalibrationService_.getPedestal(detid, col_iter, row_iter);
-         p_iter->second->Fill( ped );
+      std::map<uint32_t, TH1F*>::iterator p_iter = _TH1F_Pedestals_m.find(detid);
+      std::map<uint32_t, TH1F*>::iterator g_iter = _TH1F_Gains_m.find(detid);
 
-         float gain  = SiPixelGainCalibrationService_.getGain(detid, col_iter, row_iter);
-         g_iter->second->Fill( gain );
+      const GeomDetUnit* geoUnit = tkgeom->idToDetUnit(detIdObject);
+      const PixelGeomDetUnit* pixDet = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
+      const PixelTopology& topol = pixDet->specificTopology();
 
-//std::cout << "       Col "<<col_iter<<" Row "<<row_iter<<" Ped "<<ped<<" Gain "<<gain<<std::endl;
-   
+      // Get the module sizes.
+      int nrows = topol.nrows();     // rows in x
+      int ncols = topol.ncolumns();  // cols in y
+
+      for (int col_iter = 0; col_iter < ncols; col_iter++) {
+        for (int row_iter = 0; row_iter < nrows; row_iter++) {
+          nchannels++;
+
+          float ped = SiPixelGainCalibrationService_.getPedestal(detid, col_iter, row_iter);
+          p_iter->second->Fill(ped);
+
+          float gain = SiPixelGainCalibrationService_.getGain(detid, col_iter, row_iter);
+          g_iter->second->Fill(gain);
+
+          //std::cout << "       Col "<<col_iter<<" Row "<<row_iter<<" Ped "<<ped<<" Gain "<<gain<<std::endl;
+        }
+      }
+    }
+
+    edm::LogInfo("SiPixelFakeGainReader")
+        << "[SiPixelFakeGainReader::analyze] ---> PIXEL Modules  " << nmodules << std::endl;
+    edm::LogInfo("SiPixelFakeGainReader")
+        << "[SiPixelFakeGainReader::analyze] ---> PIXEL Channels " << nchannels << std::endl;
+    fFile->ls();
+    fFile->Write();
+    fFile->Close();
+  }
+
+  // ------------ method called once each job just before starting event loop  ------------
+  void SiPixelFakeGainReader::beginJob() {}
+
+  // ------------ method called once each job just before starting event loop  ------------
+  void SiPixelFakeGainReader::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
+    static int first(1);
+    if (1 == first) {
+      first = 0;
+      edm::LogInfo("SiPixelFakeGainReader") << "[SiPixelFakeGainReader::beginJob] Opening ROOT file  " << std::endl;
+      fFile = new TFile(filename_.c_str(), "RECREATE");
+      fFile->mkdir("Pedestals");
+      fFile->mkdir("Gains");
+      fFile->cd();
+      char name[128];
+
+      // Get Geometry
+      iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+
+      // Get the calibration data
+      //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
+      //iSetup.get<SiPixelGainCalibrationRcd>().get(SiPixelGainCalibration_);
+      SiPixelGainCalibrationService_.setESObjects(iSetup);
+      edm::LogInfo("SiPixelFakeGainReader")
+          << "[SiPixelFakeGainReader::beginJob] End Reading FakeGainects" << std::endl;
+      // Get the list of DetId's
+      std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationService_.getDetIds();
+      //SiPixelGainCalibration_->getDetIds(vdetId_);
+      // Loop over DetId's
+      for (std::vector<uint32_t>::const_iterator detid_iter = vdetId_.begin(); detid_iter != vdetId_.end();
+           detid_iter++) {
+        uint32_t detid = *detid_iter;
+
+        const PixelGeomDetUnit* _PixelGeomDetUnit =
+            dynamic_cast<const PixelGeomDetUnit*>(tkgeom->idToDetUnit(DetId(detid)));
+        if (_PixelGeomDetUnit == 0) {
+          edm::LogError("SiPixelFakeGainDisplay") << "[SiPixelFakeGainReader::beginJob] the detID " << detid
+                                                  << " doesn't seem to belong to Tracker" << std::endl;
+          continue;
+        }
+        // Book histograms
+        sprintf(name, "Pedestals_%d", detid);
+        fFile->cd();
+        fFile->cd("Pedestals");
+        _TH1F_Pedestals_m[detid] = new TH1F(name, name, 50, 0., 50.);
+        sprintf(name, "Gains_%d", detid);
+        fFile->cd();
+        fFile->cd("Gains");
+        _TH1F_Gains_m[detid] = new TH1F(name, name, 100, 0., 10.);
       }
     }
   }
-  
-  edm::LogInfo("SiPixelFakeGainReader") <<"[SiPixelFakeGainReader::analyze] ---> PIXEL Modules  " << nmodules  << std::endl;
-  edm::LogInfo("SiPixelFakeGainReader") <<"[SiPixelFakeGainReader::analyze] ---> PIXEL Channels " << nchannels << std::endl;
-  fFile->ls();
-  fFile->Write();
-  fFile->Close();    
-}
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-SiPixelFakeGainReader::beginJob()
-{
-}
-
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-SiPixelFakeGainReader::beginRun(const edm::Run &run , const edm::EventSetup &iSetup)
-{
-
-  static int first(1); 
-  if (1 == first) {
-    first = 0; 
-    edm::LogInfo("SiPixelFakeGainReader") <<"[SiPixelFakeGainReader::beginJob] Opening ROOT file  " <<std::endl;
-    fFile = new TFile(filename_.c_str(),"RECREATE");
-    fFile->mkdir("Pedestals");
-    fFile->mkdir("Gains");
-    fFile->cd();
-    char name[128];
-    
-    // Get Geometry
-    iSetup.get<TrackerDigiGeometryRecord>().get( tkgeom );
-    
-    // Get the calibration data
-    //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
-    //iSetup.get<SiPixelGainCalibrationRcd>().get(SiPixelGainCalibration_);
-    SiPixelGainCalibrationService_.setESObjects(iSetup);
-    edm::LogInfo("SiPixelFakeGainReader") << "[SiPixelFakeGainReader::beginJob] End Reading FakeGainects" << std::endl;
-    // Get the list of DetId's
-    std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationService_.getDetIds();
-    //SiPixelGainCalibration_->getDetIds(vdetId_);
-    // Loop over DetId's
-    for (std::vector<uint32_t>::const_iterator detid_iter=vdetId_.begin();detid_iter!=vdetId_.end();detid_iter++){
-      uint32_t detid = *detid_iter;
-      
-      const PixelGeomDetUnit* _PixelGeomDetUnit = dynamic_cast<const PixelGeomDetUnit*>(tkgeom->idToDetUnit(DetId(detid)));
-      if (_PixelGeomDetUnit==0){
-	edm::LogError("SiPixelFakeGainDisplay")<<"[SiPixelFakeGainReader::beginJob] the detID "<<detid<<" doesn't seem to belong to Tracker"<<std::endl; 
-	continue;
-      }     
-      // Book histograms
-      sprintf(name,"Pedestals_%d",detid);
-      fFile->cd();fFile->cd("Pedestals");
-      _TH1F_Pedestals_m[detid] = new TH1F(name,name,50,0.,50.);    
-      sprintf(name,"Gains_%d",detid);
-      fFile->cd();fFile->cd("Gains");
-      _TH1F_Gains_m[detid] = new TH1F(name,name,100,0.,10.);    
-    }
-  }
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-SiPixelFakeGainReader::endJob() {
-  std::cout<<" ---> End job "<<std::endl;
-}
-}
+  // ------------ method called once each job just after ending the event loop  ------------
+  void SiPixelFakeGainReader::endJob() { std::cout << " ---> End job " << std::endl; }
+}  // namespace cms

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.h
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelFakeGainReader
 // Class:      SiPixelFakeGainReader
-// 
+//
 /**\class SiPixelFakeGainReader SiPixelFakeGainReader.h SiPixelESProducers/test/SiPixelFakeGainReader.h
 
  Description: Test analyzer for fake pixel calibration
@@ -34,31 +34,27 @@
 #include "TBranch.h"
 #include "TH1F.h"
 
-namespace cms{
-class SiPixelFakeGainReader : public edm::EDAnalyzer {
+namespace cms {
+  class SiPixelFakeGainReader : public edm::EDAnalyzer {
+  public:
+    explicit SiPixelFakeGainReader(const edm::ParameterSet& iConfig);
 
-public:
+    ~SiPixelFakeGainReader(){};
+    virtual void beginJob();
+    virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    virtual void endJob();
 
-  explicit SiPixelFakeGainReader( const edm::ParameterSet& iConfig);
+  private:
+    edm::ParameterSet conf_;
+    edm::ESHandle<TrackerGeometry> tkgeom;
+    //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
+    SiPixelGainCalibrationService SiPixelGainCalibrationService_;
 
-  ~SiPixelFakeGainReader(){};
-  virtual void beginJob();
-  virtual void beginRun(const edm::Run& , const edm::EventSetup& );
-  virtual void analyze(const edm::Event& , const edm::EventSetup& );
-  virtual void endJob() ;
-
-private:
-
-  edm::ParameterSet conf_;
-  edm::ESHandle<TrackerGeometry> tkgeom;
-  //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
-  SiPixelGainCalibrationService SiPixelGainCalibrationService_;
-
-  std::map< uint32_t, TH1F* >  _TH1F_Pedestals_m;
-  std::map< uint32_t, TH1F* >  _TH1F_Gains_m;
-  std::string filename_;
-  TFile* fFile;
-
-};
-}
+    std::map<uint32_t, TH1F*> _TH1F_Pedestals_m;
+    std::map<uint32_t, TH1F*> _TH1F_Gains_m;
+    std::string filename_;
+    TFile* fFile;
+  };
+}  // namespace cms
 #endif

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
@@ -49,67 +49,73 @@
 #include "TTree.h"
 #include "TString.h"
 
-#include <iostream> 
+#include <iostream>
 #include <cstring>
 
 using namespace edm;
 //class MonitorElement;
 
 //--------------------------------------------------------------------------------------------------
-SiPixelStatusHarvester::SiPixelStatusHarvester(const edm::ParameterSet& iConfig) :
-  HistogramManagerHolder(iConfig),
-  thresholdL1_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<double>("thresholdL1")),
-  thresholdL2_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<double>("thresholdL2")),
-  thresholdL3_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<double>("thresholdL3")),
-  thresholdL4_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<double>("thresholdL4")),
-  thresholdRNG1_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<double>("thresholdRNG1")),
-  thresholdRNG2_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<double>("thresholdRNG2")),
-  outputBase_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<std::string>("outputBase")),
-  aveDigiOcc_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<int>("aveDigiOcc")),
-  nLumi_(iConfig.getParameter<edm::ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<int>("resetEveryNLumi")),
-  moduleName_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<std::string>("moduleName")),
-  label_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<std::string>("label")){  
-
+SiPixelStatusHarvester::SiPixelStatusHarvester(const edm::ParameterSet& iConfig)
+    : HistogramManagerHolder(iConfig),
+      thresholdL1_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                       .getUntrackedParameter<double>("thresholdL1")),
+      thresholdL2_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                       .getUntrackedParameter<double>("thresholdL2")),
+      thresholdL3_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                       .getUntrackedParameter<double>("thresholdL3")),
+      thresholdL4_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                       .getUntrackedParameter<double>("thresholdL4")),
+      thresholdRNG1_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                         .getUntrackedParameter<double>("thresholdRNG1")),
+      thresholdRNG2_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                         .getUntrackedParameter<double>("thresholdRNG2")),
+      outputBase_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                      .getUntrackedParameter<std::string>("outputBase")),
+      aveDigiOcc_(
+          iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<int>("aveDigiOcc")),
+      nLumi_(iConfig.getParameter<edm::ParameterSet>("SiPixelStatusManagerParameters")
+                 .getUntrackedParameter<int>("resetEveryNLumi")),
+      moduleName_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                      .getUntrackedParameter<std::string>("moduleName")),
+      label_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                 .getUntrackedParameter<std::string>("label")) {
   SiPixelStatusManager* siPixelStatusManager = new SiPixelStatusManager(iConfig, consumesCollector());
   siPixelStatusManager_ = *siPixelStatusManager;
   debug_ = iConfig.getUntrackedParameter<bool>("debug");
   recordName_ = iConfig.getUntrackedParameter<std::string>("recordName", "SiPixelQualityFromDbRcd");
-  
+
   sensorSize_.clear();
   pixelO2O_.clear();
 
   siPixelStatusManager_.reset();
   endLumiBlock_ = 0;
   countLumi_ = 0;
-
 }
 
 //--------------------------------------------------------------------------------------------------
-SiPixelStatusHarvester::~SiPixelStatusHarvester(){}
+SiPixelStatusHarvester::~SiPixelStatusHarvester() {}
 
 //--------------------------------------------------------------------------------------------------
-void SiPixelStatusHarvester::beginJob() {
-}
+void SiPixelStatusHarvester::beginJob() {}
 
 //--------------------------------------------------------------------------------------------------
-void SiPixelStatusHarvester::endJob() {
-}  
+void SiPixelStatusHarvester::endJob() {}
 
 //--------------------------------------------------------------------------------------------------
-void SiPixelStatusHarvester::bookHistograms( DQMStore::IBooker& iBooker, edm::Run const&, edm::EventSetup const& iSetup ){
-
-     for( auto& histoman : histo ){
-       histoman.book( iBooker, iSetup );
-     }
-
+void SiPixelStatusHarvester::bookHistograms(DQMStore::IBooker& iBooker,
+                                            edm::Run const&,
+                                            edm::EventSetup const& iSetup) {
+  for (auto& histoman : histo) {
+    histoman.book(iBooker, iSetup);
+  }
 }
 
 //--------------------------------------------------------------------------------------------------
 void SiPixelStatusHarvester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {}
 
 //--------------------------------------------------------------------------------------------------
-void SiPixelStatusHarvester::endRunProduce(edm::Run& iRun, const edm::EventSetup& iSetup){
-
+void SiPixelStatusHarvester::endRunProduce(edm::Run& iRun, const edm::EventSetup& iSetup) {
   // tracker geometry and cabling map to convert offline row/column (module) to online row/column
   edm::ESHandle<TrackerGeometry> tmpTkGeometry;
   iSetup.get<TrackerDigiGeometryRecord>().get(tmpTkGeometry);
@@ -122,82 +128,83 @@ void SiPixelStatusHarvester::endRunProduce(edm::Run& iRun, const edm::EventSetup
   // Pixel Phase-1 helper class
   coord_.init(iSetup);
 
-  for (TrackerGeometry::DetContainer::const_iterator it = trackerGeometry_->dets().begin(); it != trackerGeometry_->dets().end(); it++){
+  for (TrackerGeometry::DetContainer::const_iterator it = trackerGeometry_->dets().begin();
+       it != trackerGeometry_->dets().end();
+       it++) {
+    const PixelGeomDetUnit* pgdu = dynamic_cast<const PixelGeomDetUnit*>((*it));
+    if (pgdu == nullptr)
+      continue;
+    DetId detId = (*it)->geographicalId();
+    int detid = detId.rawId();
 
-       const PixelGeomDetUnit *pgdu = dynamic_cast<const PixelGeomDetUnit*>((*it));
-       if (pgdu == nullptr) continue;
-       DetId detId = (*it)->geographicalId();
-       int detid = detId.rawId();
+    const PixelTopology* topo = static_cast<const PixelTopology*>(&pgdu->specificTopology());
+    // number of row/columns for a given module
+    int rowsperroc = topo->rowsperroc();
+    int colsperroc = topo->colsperroc();
 
-       const PixelTopology* topo = static_cast<const PixelTopology*>(&pgdu->specificTopology());
-       // number of row/columns for a given module
-       int rowsperroc = topo->rowsperroc();
-       int colsperroc = topo->colsperroc();
+    int nROCrows = pgdu->specificTopology().nrows() / rowsperroc;
+    int nROCcolumns = pgdu->specificTopology().ncolumns() / colsperroc;
+    unsigned int nrocs = nROCrows * nROCcolumns;
+    sensorSize_[detid] = nrocs;
 
-       int nROCrows = pgdu->specificTopology().nrows()/rowsperroc;
-       int nROCcolumns = pgdu->specificTopology().ncolumns()/colsperroc;
-       unsigned int nrocs = nROCrows*nROCcolumns;
-       sensorSize_[detid] = nrocs;
+    std::map<int, std::pair<int, int>> rocToOfflinePixel;
 
-       std::map<int, std::pair<int,int> > rocToOfflinePixel;
+    std::vector<sipixelobjects::CablingPathToDetUnit> path = (cablingMap_->det2PathMap()).find(detId.rawId())->second;
+    typedef std::vector<sipixelobjects::CablingPathToDetUnit>::const_iterator IT;
+    for (IT it = path.begin(); it != path.end(); ++it) {
+      // Pixel ROC building from path in cabling map
+      const sipixelobjects::PixelROC* roc = cablingMap_->findItem(*it);
+      int idInDetUnit = (int)roc->idInDetUnit();
 
-       std::vector<sipixelobjects::CablingPathToDetUnit> path = (cablingMap_->det2PathMap()).find(detId.rawId())->second;
-       typedef std::vector<sipixelobjects::CablingPathToDetUnit>::const_iterator IT;
-       for(IT it = path.begin(); it != path.end(); ++it) {
-           // Pixel ROC building from path in cabling map
-           const sipixelobjects::PixelROC *roc = cablingMap_->findItem(*it);
-           int idInDetUnit = (int) roc->idInDetUnit();
+      // local to global conversion
+      sipixelobjects::LocalPixel::RocRowCol local = {rowsperroc / 2, colsperroc / 2};
+      sipixelobjects::GlobalPixel global = roc->toGlobal(sipixelobjects::LocalPixel(local));
 
-           // local to global conversion
-           sipixelobjects::LocalPixel::RocRowCol local = {rowsperroc/2, colsperroc/2};
-           sipixelobjects::GlobalPixel global = roc->toGlobal(sipixelobjects::LocalPixel(local));
- 
-           rocToOfflinePixel[idInDetUnit] = std::pair<int,int>(global.row, global.col);
+      rocToOfflinePixel[idInDetUnit] = std::pair<int, int>(global.row, global.col);
+    }
 
-       }
-
-       pixelO2O_[detid] = rocToOfflinePixel;
+    pixelO2O_[detid] = rocToOfflinePixel;
   }
 
   // Permananent bad components
   edm::ESHandle<SiPixelQuality> qualityInfo;
-  iSetup.get<SiPixelQualityFromDbRcd>().get( qualityInfo );
+  iSetup.get<SiPixelQualityFromDbRcd>().get(qualityInfo);
   badPixelInfo_ = qualityInfo.product();
 
   // read in SiPixel occupancy data in ALCARECO/ALCAPROMPT
   siPixelStatusManager_.createPayloads();
-  std::map<edm::LuminosityBlockNumber_t,std::map<int,std::vector<int>> > FEDerror25Map = siPixelStatusManager_.getFEDerror25Rocs();
-  std::map<edm::LuminosityBlockNumber_t,SiPixelDetectorStatus> siPixelStatusMap = siPixelStatusManager_.getBadComponents();
+  std::map<edm::LuminosityBlockNumber_t, std::map<int, std::vector<int>>> FEDerror25Map =
+      siPixelStatusManager_.getFEDerror25Rocs();
+  std::map<edm::LuminosityBlockNumber_t, SiPixelDetectorStatus> siPixelStatusMap =
+      siPixelStatusManager_.getBadComponents();
 
   // DB service
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
-  if(poolDbService.isAvailable() ) {// if(poolDbService.isAvailable() )
+  if (poolDbService.isAvailable()) {  // if(poolDbService.isAvailable() )
 
     // start producing tag for permanent component removed
-    SiPixelQuality *siPixelQualityPermBad = new SiPixelQuality();
+    SiPixelQuality* siPixelQualityPermBad = new SiPixelQuality();
     const std::vector<SiPixelQuality::disabledModuleType> badComponentList = badPixelInfo_->getBadComponentList();
-    for(unsigned int i = 0; i<badComponentList.size();i++){
+    for (unsigned int i = 0; i < badComponentList.size(); i++) {
+      siPixelQualityPermBad->addDisabledModule(badComponentList[i]);
 
-        siPixelQualityPermBad->addDisabledModule(badComponentList[i]);
+      uint32_t detId = badComponentList[i].DetID;
+      int detid = int(detId);
+      unsigned int nroc = sensorSize_[detid];
 
-        uint32_t detId = badComponentList[i].DetID;
-        int detid = int(detId);
-        unsigned int nroc = sensorSize_[detid];
-
-        for(int iroc = 0; iroc<int(nroc); iroc++){
-            if(badPixelInfo_->IsRocBad(detId, short(iroc)) ){
-                 std::map<int, std::pair<int,int> > rocToOfflinePixel = pixelO2O_[detid];
-                 int row = rocToOfflinePixel[iroc].first;
-                 int column = rocToOfflinePixel[iroc].second;
-                 histo[PERMANENTBADROC].fill(detId, nullptr, column, row);
-            }
+      for (int iroc = 0; iroc < int(nroc); iroc++) {
+        if (badPixelInfo_->IsRocBad(detId, short(iroc))) {
+          std::map<int, std::pair<int, int>> rocToOfflinePixel = pixelO2O_[detid];
+          int row = rocToOfflinePixel[iroc].first;
+          int column = rocToOfflinePixel[iroc].second;
+          histo[PERMANENTBADROC].fill(detId, nullptr, column, row);
         }
-
+      }
     }
-    if(debug_==true){ // only produced for debugging reason
-        cond::Time_t thisIOV = (cond::Time_t) iRun.id().run();
-        poolDbService->writeOne<SiPixelQuality>(siPixelQualityPermBad, thisIOV, recordName_+"_permanentBad");
+    if (debug_ == true) {  // only produced for debugging reason
+      cond::Time_t thisIOV = (cond::Time_t)iRun.id().run();
+      poolDbService->writeOne<SiPixelQuality>(siPixelQualityPermBad, thisIOV, recordName_ + "_permanentBad");
     }
 
     // IOV for final payloads. FEDerror25 and pcl
@@ -209,104 +216,108 @@ void SiPixelStatusHarvester::endRunProduce(edm::Run& iRun, const edm::EventSetup
     std::map<int, SiPixelQuality*> siPixelQualityStuckTBM_Tag;
 
     // stuckTBM tag from FED error 25 with permanent component removed
-    for(SiPixelStatusManager::FEDerror25Map_iterator it=FEDerror25Map.begin(); it!=FEDerror25Map.end();it++){
+    for (SiPixelStatusManager::FEDerror25Map_iterator it = FEDerror25Map.begin(); it != FEDerror25Map.end(); it++) {
+      cond::Time_t thisIOV = 1;
+      edm::LuminosityBlockID lu(iRun.id().run(), it->first);
+      thisIOV = (cond::Time_t)(lu.value());
 
-          cond::Time_t thisIOV = 1;
-          edm::LuminosityBlockID lu(iRun.id().run(),it->first);
-          thisIOV = (cond::Time_t)(lu.value());
+      int interval = 0;
+      // interval is the number of lumi sections in the IOV
+      SiPixelStatusManager::FEDerror25Map_iterator nextIt = std::next(it);
+      if (nextIt != FEDerror25Map.end())
+        interval = int(nextIt->first - it->first);
+      else
+        interval = int(endLumiBlock_ - it->first + 1);  // +1 because need to include the last lumi section
 
-          int interval = 0;
-          // interval is the number of lumi sections in the IOV
-          SiPixelStatusManager::FEDerror25Map_iterator nextIt = std::next(it);
-          if(nextIt!=FEDerror25Map.end()) interval = int(nextIt->first - it->first);
-          else interval = int(endLumiBlock_ - it->first + 1); // +1 because need to include the last lumi section
+      SiPixelQuality* siPixelQuality_stuckTBM = new SiPixelQuality();
+      SiPixelQuality* siPixelQuality_FEDerror25 = new SiPixelQuality();
 
-          SiPixelQuality *siPixelQuality_stuckTBM = new SiPixelQuality();
-          SiPixelQuality *siPixelQuality_FEDerror25 = new SiPixelQuality();
+      std::map<int, std::vector<int>> tmpFEDerror25 = it->second;
+      for (std::map<int, std::vector<int>>::iterator ilist = tmpFEDerror25.begin(); ilist != tmpFEDerror25.end();
+           ilist++) {
+        int detid = ilist->first;
+        uint32_t detId = uint32_t(detid);
 
-          std::map<int, std::vector<int> > tmpFEDerror25 = it->second;
-          for(std::map<int, std::vector<int> >::iterator ilist = tmpFEDerror25.begin(); ilist!=tmpFEDerror25.end();ilist++){
+        SiPixelQuality::disabledModuleType BadModule_stuckTBM, BadModule_FEDerror25;
 
-             int detid = ilist->first;
-             uint32_t detId = uint32_t(detid);
+        BadModule_stuckTBM.DetID = uint32_t(detid);
+        BadModule_FEDerror25.DetID = uint32_t(detid);
+        BadModule_stuckTBM.errorType = 3;
+        BadModule_FEDerror25.errorType = 3;
 
-             SiPixelQuality::disabledModuleType BadModule_stuckTBM, BadModule_FEDerror25;
+        BadModule_stuckTBM.BadRocs = 0;
+        BadModule_FEDerror25.BadRocs = 0;
+        std::vector<uint32_t> BadRocList_stuckTBM, BadRocList_FEDerror25;
+        std::vector<int> list = ilist->second;
 
-             BadModule_stuckTBM.DetID = uint32_t(detid); BadModule_FEDerror25.DetID = uint32_t(detid);
-             BadModule_stuckTBM.errorType = 3;           BadModule_FEDerror25.errorType = 3;
+        for (unsigned int i = 0; i < list.size(); i++) {
+          int iroc = list[i];
+          std::map<int, std::pair<int, int>> rocToOfflinePixel = pixelO2O_[detid];
+          int row = rocToOfflinePixel[iroc].first;
+          int column = rocToOfflinePixel[iroc].second;
 
-             BadModule_stuckTBM.BadRocs = 0;             BadModule_FEDerror25.BadRocs = 0;
-             std::vector<uint32_t> BadRocList_stuckTBM, BadRocList_FEDerror25;
-             std::vector<int> list = ilist->second;
+          BadRocList_FEDerror25.push_back(uint32_t(iroc));
+          for (int iLumi = 0; iLumi < interval; iLumi++) {
+            histo[FEDERRORROC].fill(detId, nullptr, column, row);  // 1.0/nLumiBlock_);
+          }
 
-             for(unsigned int i=0; i<list.size();i++){
+          // only include rocs that are not permanent known bad
+          if (!badPixelInfo_->IsRocBad(detId, short(iroc))) {  // stuckTBM = FEDerror25 - permanent bad
+            BadRocList_stuckTBM.push_back(uint32_t(iroc));
+            for (int iLumi = 0; iLumi < interval; iLumi++) {
+              histo[STUCKTBMROC].fill(detId, nullptr, column, row);  //, 1.0/nLumiBlock_);
+            }
+          }
+        }
 
-                 int iroc =  list[i];
-                 std::map<int, std::pair<int,int> > rocToOfflinePixel = pixelO2O_[detid];
-                 int row = rocToOfflinePixel[iroc].first;
-                 int column = rocToOfflinePixel[iroc].second;
+        // change module error type if all ROCs are bad
+        if (BadRocList_stuckTBM.size() == sensorSize_[detid])
+          BadModule_stuckTBM.errorType = 0;
 
-                 BadRocList_FEDerror25.push_back(uint32_t(iroc));
-                 for (int iLumi = 0; iLumi<interval;iLumi++){
-                      histo[FEDERRORROC].fill(detId, nullptr, column, row);// 1.0/nLumiBlock_);
-                 }
+        short badrocs_stuckTBM = 0;
+        for (std::vector<uint32_t>::iterator iter = BadRocList_stuckTBM.begin(); iter != BadRocList_stuckTBM.end();
+             ++iter) {
+          badrocs_stuckTBM += 1 << *iter;  // 1 << *iter = 2^{*iter} using bitwise shift
+        }
+        // fill the badmodule only if there is(are) bad ROC(s) in it
+        if (badrocs_stuckTBM != 0) {
+          BadModule_stuckTBM.BadRocs = badrocs_stuckTBM;
+          siPixelQuality_stuckTBM->addDisabledModule(BadModule_stuckTBM);
+        }
 
-                 // only include rocs that are not permanent known bad
-                 if(!badPixelInfo_->IsRocBad(detId, short(iroc))){ // stuckTBM = FEDerror25 - permanent bad
-                    BadRocList_stuckTBM.push_back(uint32_t(iroc));
-                    for (int iLumi = 0; iLumi<interval;iLumi++){
-                         histo[STUCKTBMROC].fill(detId, nullptr, column, row);//, 1.0/nLumiBlock_);
-                    }
-                 }
+        // change module error type if all ROCs are bad
+        if (BadRocList_FEDerror25.size() == sensorSize_[detid])
+          BadModule_FEDerror25.errorType = 0;
 
-             }
+        short badrocs_FEDerror25 = 0;
+        for (std::vector<uint32_t>::iterator iter = BadRocList_FEDerror25.begin(); iter != BadRocList_FEDerror25.end();
+             ++iter) {
+          badrocs_FEDerror25 += 1 << *iter;  // 1 << *iter = 2^{*iter} using bitwise shift
+        }
+        // fill the badmodule only if there is(are) bad ROC(s) in it
+        if (badrocs_FEDerror25 != 0) {
+          BadModule_FEDerror25.BadRocs = badrocs_FEDerror25;
+          siPixelQuality_FEDerror25->addDisabledModule(BadModule_FEDerror25);
+        }
 
-             // change module error type if all ROCs are bad
-             if(BadRocList_stuckTBM.size()==sensorSize_[detid]) 
-                BadModule_stuckTBM.errorType = 0;
+      }  // loop over modules
 
-             short badrocs_stuckTBM = 0;
-             for(std::vector<uint32_t>::iterator iter = BadRocList_stuckTBM.begin(); iter != BadRocList_stuckTBM.end(); ++iter){
-                   badrocs_stuckTBM +=  1 << *iter; // 1 << *iter = 2^{*iter} using bitwise shift
-             }
-             // fill the badmodule only if there is(are) bad ROC(s) in it
-             if(badrocs_stuckTBM!=0){
-               BadModule_stuckTBM.BadRocs = badrocs_stuckTBM;
-               siPixelQuality_stuckTBM->addDisabledModule(BadModule_stuckTBM);
-             }
+      siPixelQualityStuckTBM_Tag[it->first] = siPixelQuality_stuckTBM;
 
-             // change module error type if all ROCs are bad
-             if(BadRocList_FEDerror25.size()==sensorSize_[detid])
-                BadModule_FEDerror25.errorType = 0;
+      finalIOV[it->first] = it->first;
+      fedError25IOV[it->first] = it->first;
 
-             short badrocs_FEDerror25 = 0;
-             for(std::vector<uint32_t>::iterator iter = BadRocList_FEDerror25.begin(); iter != BadRocList_FEDerror25.end(); ++iter){
-                   badrocs_FEDerror25 +=  1 << *iter; // 1 << *iter = 2^{*iter} using bitwise shift
-             }
-             // fill the badmodule only if there is(are) bad ROC(s) in it
-             if(badrocs_FEDerror25!=0){
-                BadModule_FEDerror25.BadRocs = badrocs_FEDerror25;
-                siPixelQuality_FEDerror25->addDisabledModule(BadModule_FEDerror25);
-             }
+      if (debug_ == true)  // only produced for debugging reason
+        poolDbService->writeOne<SiPixelQuality>(siPixelQuality_FEDerror25, thisIOV, recordName_ + "_FEDerror25");
 
-          } // loop over modules
-
-          siPixelQualityStuckTBM_Tag[it->first] = siPixelQuality_stuckTBM;
-
-          finalIOV[it->first] = it->first;
-          fedError25IOV[it->first] = it->first;
-
-          if(debug_==true) // only produced for debugging reason
-             poolDbService->writeOne<SiPixelQuality>(siPixelQuality_FEDerror25, thisIOV, recordName_+"_FEDerror25");
-
-          delete siPixelQuality_FEDerror25;         
-
+      delete siPixelQuality_FEDerror25;
     }
 
     // IOV for PCL output tags that "combines" permanent bad/stuckTBM/other
-    for(SiPixelStatusManager::siPixelStatusMap_iterator it=siPixelStatusMap.begin(); it!=siPixelStatusMap.end();it++){
-        finalIOV[it->first] = it->first;
-        pclIOV[it->first] = it->first;
+    for (SiPixelStatusManager::siPixelStatusMap_iterator it = siPixelStatusMap.begin(); it != siPixelStatusMap.end();
+         it++) {
+      finalIOV[it->first] = it->first;
+      pclIOV[it->first] = it->first;
     }
 
     // loop over final IOV
@@ -317,398 +328,398 @@ void SiPixelStatusHarvester::endRunProduce(edm::Run& iRun, const edm::EventSetup
     std::map<int, SiPixelQuality*> siPixelQualityPrompt_Tag;
     std::map<int, SiPixelQuality*> siPixelQualityOther_Tag;
 
-    for(itIOV=finalIOV.begin();itIOV!=finalIOV.end();itIOV++){
+    for (itIOV = finalIOV.begin(); itIOV != finalIOV.end(); itIOV++) {
+      int interval = 0;
+      std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t>::iterator nextItIOV = std::next(itIOV);
+      if (nextItIOV != finalIOV.end())
+        interval = int(nextItIOV->first - itIOV->first);
+      else
+        interval = int(endLumiBlock_ - itIOV->first + 1);
 
-          int interval = 0;
-          std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t>::iterator nextItIOV = std::next(itIOV);
-          if(nextItIOV!=finalIOV.end()) interval = int(nextItIOV->first - itIOV->first);
-          else interval = int(endLumiBlock_ - itIOV->first + 1);
+      edm::LuminosityBlockNumber_t lumiFEDerror25 = SiPixelStatusHarvester::stepIOV(itIOV->first, fedError25IOV);
+      edm::LuminosityBlockNumber_t lumiPCL = SiPixelStatusHarvester::stepIOV(itIOV->first, pclIOV);
 
-          edm::LuminosityBlockNumber_t lumiFEDerror25 = SiPixelStatusHarvester::stepIOV(itIOV->first,fedError25IOV);
-          edm::LuminosityBlockNumber_t lumiPCL = SiPixelStatusHarvester::stepIOV(itIOV->first,pclIOV);
+      // get badROC list due to FEDerror25 = stuckTBM + permanent bad components
+      std::map<int, std::vector<int>> tmpFEDerror25 = FEDerror25Map[lumiFEDerror25];
+      // get SiPixelDetectorStatus
+      SiPixelDetectorStatus tmpSiPixelStatus = siPixelStatusMap[lumiPCL];
+      double DetAverage = tmpSiPixelStatus.perRocDigiOcc();
 
-          // get badROC list due to FEDerror25 = stuckTBM + permanent bad components
-          std::map<int, std::vector<int> > tmpFEDerror25 = FEDerror25Map[lumiFEDerror25];
-          // get SiPixelDetectorStatus
-          SiPixelDetectorStatus tmpSiPixelStatus = siPixelStatusMap[lumiPCL];
-          double DetAverage = tmpSiPixelStatus.perRocDigiOcc();
+      // For the IOV of which the statistics is too low, for e.g., a cosmic run
+      // When using dynamicLumibased harvester or runbased harvester
+      // this only happens when the full run is lack of statistics
+      if (DetAverage < aveDigiOcc_) {
+        edm::LogInfo("SiPixelStatusHarvester")
+            << "Tag requested for prompt in low statistics IOV in the " << outputBase_ << " harvester" << std::endl;
+        siPixelQualityPCL_Tag[itIOV->first] = siPixelQualityPermBad;
+        siPixelQualityPrompt_Tag[itIOV->first] = siPixelQualityPermBad;
 
-          // For the IOV of which the statistics is too low, for e.g., a cosmic run
-          // When using dynamicLumibased harvester or runbased harvester
-          // this only happens when the full run is lack of statistics 
-          if(DetAverage<aveDigiOcc_) {
+        // loop over modules to fill the PROMPT DQM plots with permanent bad components
+        std::map<int, SiPixelModuleStatus> detectorStatus = tmpSiPixelStatus.getDetectorStatus();
+        std::map<int, SiPixelModuleStatus>::iterator itModEnd = detectorStatus.end();
+        for (std::map<int, SiPixelModuleStatus>::iterator itMod = detectorStatus.begin(); itMod != itModEnd; ++itMod) {
+          int detid = itMod->first;
+          uint32_t detId = uint32_t(detid);
+          SiPixelModuleStatus modStatus = itMod->second;
 
-            edm::LogInfo("SiPixelStatusHarvester")
-                 << "Tag requested for prompt in low statistics IOV in the "<<outputBase_<<" harvester"<< std::endl;
-            siPixelQualityPCL_Tag[itIOV->first] = siPixelQualityPermBad;
-            siPixelQualityPrompt_Tag[itIOV->first] = siPixelQualityPermBad;            
+          for (int iroc = 0; iroc < modStatus.nrocs(); ++iroc) {
+            if (badPixelInfo_->IsRocBad(detId, short(iroc))) {
+              std::map<int, std::pair<int, int>> rocToOfflinePixel = pixelO2O_[detid];
+              int row = rocToOfflinePixel[iroc].first;
+              int column = rocToOfflinePixel[iroc].second;
+              for (int iLumi = 0; iLumi < interval; iLumi++) {
+                histo[PROMPTBADROC].fill(detId, nullptr, column, row);     //, 1.0/nLumiBlock_);
+                histo[PERMANENTBADROC].fill(detId, nullptr, column, row);  //, 1.0/nLumiBlock_);
+              }
 
-            // loop over modules to fill the PROMPT DQM plots with permanent bad components
-            std::map<int, SiPixelModuleStatus> detectorStatus = tmpSiPixelStatus.getDetectorStatus();
-            std::map<int, SiPixelModuleStatus>::iterator itModEnd = detectorStatus.end();
-            for (std::map<int, SiPixelModuleStatus>::iterator itMod = detectorStatus.begin(); itMod != itModEnd; ++itMod) {
-            
-                 int detid = itMod->first;
-                 uint32_t detId = uint32_t(detid);
-                 SiPixelModuleStatus modStatus = itMod->second;
+            }  // if permanent BAD
 
-                 for (int iroc = 0; iroc < modStatus.nrocs(); ++iroc) {
+          }  // loop over ROCs
 
-                       if(badPixelInfo_->IsRocBad(detId, short(iroc))){
-                         std::map<int, std::pair<int,int> > rocToOfflinePixel = pixelO2O_[detid];
-                         int row = rocToOfflinePixel[iroc].first;
-                         int column = rocToOfflinePixel[iroc].second;
-                         for (int iLumi = 0; iLumi<interval;iLumi++){
-                           histo[PROMPTBADROC].fill(detId, nullptr, column, row);//, 1.0/nLumiBlock_);
-                           histo[PERMANENTBADROC].fill(detId, nullptr, column, row);//, 1.0/nLumiBlock_);
-                         }
+        }  // loop over modules
 
-                       } // if permanent BAD
+        // add empty bad components to "other" tag
+        edm::LogInfo("SiPixelStatusHarvester")
+            << "Tag requested for other in low statistics IOV in the " << outputBase_ << " harvester" << std::endl;
+        siPixelQualityOther_Tag[itIOV->first] = new SiPixelQuality();
 
-                 } // loop over ROCs
+        continue;
+      }
 
-            } // loop over modules
+      // create the DB object
+      // payload including all : PCL = permanent bad (low DIGI ROC) + other + stuckTBM
+      SiPixelQuality* siPixelQualityPCL = new SiPixelQuality();
+      SiPixelQuality* siPixelQualityOther = new SiPixelQuality();
+      // Prompt = permanent bad(low DIGI + low eff/damaged ROCs + other)
+      SiPixelQuality* siPixelQualityPrompt = new SiPixelQuality();
 
-            // add empty bad components to "other" tag
-            edm::LogInfo("SiPixelStatusHarvester")
-                 << "Tag requested for other in low statistics IOV in the "<<outputBase_<<" harvester"<< std::endl;
-            siPixelQualityOther_Tag[itIOV->first] = new SiPixelQuality();
+      // loop over modules
+      std::map<int, SiPixelModuleStatus> detectorStatus = tmpSiPixelStatus.getDetectorStatus();
+      std::map<int, SiPixelModuleStatus>::iterator itModEnd = detectorStatus.end();
+      for (std::map<int, SiPixelModuleStatus>::iterator itMod = detectorStatus.begin(); itMod != itModEnd; ++itMod) {
+        // create the bad module list for PCL and other
+        SiPixelQuality::disabledModuleType BadModulePCL, BadModuleOther;
 
-            continue;
+        int detid = itMod->first;
+        uint32_t detId = uint32_t(detid);
 
-          } 
+        double DetAverage_local = SiPixelStatusHarvester::perLayerRingAverage(detid, tmpSiPixelStatus);
+        double local_threshold = 0.0;
 
-          // create the DB object
-          // payload including all : PCL = permanent bad (low DIGI ROC) + other + stuckTBM
-          SiPixelQuality *siPixelQualityPCL = new SiPixelQuality();
-          SiPixelQuality *siPixelQualityOther = new SiPixelQuality();
-          // Prompt = permanent bad(low DIGI + low eff/damaged ROCs + other)     
-          SiPixelQuality *siPixelQualityPrompt = new SiPixelQuality();
+        int layer = coord_.layer(DetId(detid));
+        int ring = coord_.ring(DetId(detid));
 
-          // loop over modules
-          std::map<int, SiPixelModuleStatus> detectorStatus = tmpSiPixelStatus.getDetectorStatus();
-          std::map<int, SiPixelModuleStatus>::iterator itModEnd = detectorStatus.end();
-          for (std::map<int, SiPixelModuleStatus>::iterator itMod = detectorStatus.begin(); itMod != itModEnd; ++itMod) {
+        if (layer == 1)
+          local_threshold = thresholdL1_;
+        if (layer == 2)
+          local_threshold = thresholdL2_;
+        if (layer == 3)
+          local_threshold = thresholdL3_;
+        if (layer == 4)
+          local_threshold = thresholdL4_;
 
-               // create the bad module list for PCL and other
-               SiPixelQuality::disabledModuleType BadModulePCL, BadModuleOther;
+        if (ring == 1)
+          local_threshold = thresholdRNG1_;
+        if (ring == 2)
+          local_threshold = thresholdRNG2_;
 
-               int detid = itMod->first; 
-               uint32_t detId = uint32_t(detid);
+        BadModulePCL.DetID = uint32_t(detid);
+        BadModuleOther.DetID = uint32_t(detid);
+        BadModulePCL.errorType = 3;
+        BadModuleOther.errorType = 3;
+        BadModulePCL.BadRocs = 0;
+        BadModuleOther.BadRocs = 0;
 
-               double DetAverage_local = SiPixelStatusHarvester::perLayerRingAverage(detid,tmpSiPixelStatus);
-               double local_threshold = 0.0;
-               
-               int layer  = coord_.layer(DetId(detid));
-               int ring   = coord_.ring(DetId(detid));
+        std::vector<uint32_t> BadRocListPCL, BadRocListOther;
 
-               if(layer==1) local_threshold = thresholdL1_;
-               if(layer==2) local_threshold = thresholdL2_;
-               if(layer==3) local_threshold = thresholdL3_;
-               if(layer==4) local_threshold = thresholdL4_;
+        // module status and FEDerror25 status for module with DetId detId
+        SiPixelModuleStatus modStatus = itMod->second;
+        std::vector<int> listFEDerror25 = tmpFEDerror25[detid];
 
-               if(ring==1) local_threshold = thresholdRNG1_;
-               if(ring==2) local_threshold = thresholdRNG2_;
+        std::map<int, std::pair<int, int>> rocToOfflinePixel = pixelO2O_[detid];
+        for (int iroc = 0; iroc < modStatus.nrocs(); ++iroc) {
+          unsigned int rocOccupancy = modStatus.digiOccROC(iroc);
 
-               BadModulePCL.DetID = uint32_t(detid); BadModuleOther.DetID = uint32_t(detid);
-               BadModulePCL.errorType = 3; BadModuleOther.errorType = 3;
-               BadModulePCL.BadRocs = 0; BadModuleOther.BadRocs = 0;
+          int row = rocToOfflinePixel[iroc].first;
+          int column = rocToOfflinePixel[iroc].second;
 
-               std::vector<uint32_t> BadRocListPCL, BadRocListOther;
+          // Bad ROC are from low DIGI Occ ROCs
+          if (rocOccupancy < local_threshold * DetAverage_local) {  // if BAD
 
-               // module status and FEDerror25 status for module with DetId detId
-               SiPixelModuleStatus modStatus = itMod->second;
-               std::vector<int> listFEDerror25 = tmpFEDerror25[detid];
+            //PCL bad roc list
+            BadRocListPCL.push_back(uint32_t(iroc));
+            for (int iLumi = 0; iLumi < interval; iLumi++) {
+              histo[BADROC].fill(detId, nullptr, column, row);  //, 1.0/nLumiBlock_);
+            }
 
-               std::map<int, std::pair<int,int> > rocToOfflinePixel = pixelO2O_[detid];
-               for (int iroc = 0; iroc < modStatus.nrocs(); ++iroc) {
+            //FEDerror25 list
+            std::vector<int>::iterator it = std::find(listFEDerror25.begin(), listFEDerror25.end(), iroc);
 
-                   unsigned int rocOccupancy = modStatus.digiOccROC(iroc);
+            // other source of bad components = PCL bad - FEDerror25 - permanent bad
+            if (it == listFEDerror25.end() && !(badPixelInfo_->IsRocBad(detId, short(iroc)))) {
+              // if neither permanent nor FEDerror25
+              BadRocListOther.push_back(uint32_t(iroc));
+              for (int iLumi = 0; iLumi < interval; iLumi++) {
+                histo[OTHERBADROC].fill(detId, nullptr, column, row);  //, 1.0/nLumiBlock_);
+              }
+            }
 
-                   int row = rocToOfflinePixel[iroc].first;
-                   int column = rocToOfflinePixel[iroc].second;
+          }  // if BAD
 
-                   // Bad ROC are from low DIGI Occ ROCs
-                   if(rocOccupancy<local_threshold*DetAverage_local){ // if BAD
+        }  // loop over ROCs
 
-                     //PCL bad roc list
-                     BadRocListPCL.push_back(uint32_t(iroc));
-                     for (int iLumi = 0; iLumi<interval;iLumi++){
-                         histo[BADROC].fill(detId, nullptr, column, row);//, 1.0/nLumiBlock_);
-                     }
+        // errorType 0 means the full module is bad
+        if (BadRocListPCL.size() == sensorSize_[detid])
+          BadModulePCL.errorType = 0;
+        if (BadRocListOther.size() == sensorSize_[detid])
+          BadModuleOther.errorType = 0;
 
-                     //FEDerror25 list
-                     std::vector<int>::iterator it = std::find(listFEDerror25.begin(), listFEDerror25.end(),iroc);
+        // PCL
+        short badrocsPCL = 0;
+        for (std::vector<uint32_t>::iterator iterPCL = BadRocListPCL.begin(); iterPCL != BadRocListPCL.end();
+             ++iterPCL) {
+          badrocsPCL += 1 << *iterPCL;  // 1 << *iter = 2^{*iter} using bitwise shift
+        }
+        if (badrocsPCL != 0) {
+          BadModulePCL.BadRocs = badrocsPCL;
+          siPixelQualityPCL->addDisabledModule(BadModulePCL);
+        }
 
-                     // other source of bad components = PCL bad - FEDerror25 - permanent bad
-                     if(it==listFEDerror25.end() && !(badPixelInfo_->IsRocBad(detId, short(iroc)))){
-                        // if neither permanent nor FEDerror25
-                        BadRocListOther.push_back(uint32_t(iroc)); 
-                        for (int iLumi = 0; iLumi<interval;iLumi++){
-                            histo[OTHERBADROC].fill(detId, nullptr, column, row);//, 1.0/nLumiBlock_);
-                        }
-                     }
+        // Other
+        short badrocsOther = 0;
+        for (std::vector<uint32_t>::iterator iterOther = BadRocListOther.begin(); iterOther != BadRocListOther.end();
+             ++iterOther) {
+          badrocsOther += 1 << *iterOther;  // 1 << *iter = 2^{*iter} using bitwise shift
+        }
+        if (badrocsOther != 0) {
+          BadModuleOther.BadRocs = badrocsOther;
+          siPixelQualityOther->addDisabledModule(BadModuleOther);
+        }
 
-                   }// if BAD
+        // start constructing bad components for prompt = "other" + permanent
+        SiPixelQuality::disabledModuleType BadModulePrompt;
+        BadModulePrompt.DetID = uint32_t(detid);
+        BadModulePrompt.errorType = 3;
+        BadModulePrompt.BadRocs = 0;
 
-               } // loop over ROCs
+        std::vector<uint32_t> BadRocListPrompt;
+        for (int iroc = 0; iroc < modStatus.nrocs(); ++iroc) {
+          // if in permannet bad tag or is in other tag
+          if (badPixelInfo_->IsRocBad(detId, short(iroc)) || ((badrocsOther >> short(iroc)) & 0x1)) {
+            BadRocListPrompt.push_back(uint32_t(iroc));
 
-               // errorType 0 means the full module is bad
-               if(BadRocListPCL.size()==sensorSize_[detid]) BadModulePCL.errorType = 0;
-               if(BadRocListOther.size()==sensorSize_[detid]) BadModuleOther.errorType = 0;
+            std::map<int, std::pair<int, int>> rocToOfflinePixel = pixelO2O_[detid];
+            int row = rocToOfflinePixel[iroc].first;
+            int column = rocToOfflinePixel[iroc].second;
+            for (int iLumi = 0; iLumi < interval; iLumi++) {
+              histo[PROMPTBADROC].fill(detId, nullptr, column, row);  //, 1.0/nLumiBlock_);
+            }
+          }  // if bad
+        }    // loop over all ROCs
 
-               // PCL
-               short badrocsPCL = 0;
-               for(std::vector<uint32_t>::iterator iterPCL = BadRocListPCL.begin(); iterPCL != BadRocListPCL.end(); ++iterPCL){
-                   badrocsPCL +=  1 << *iterPCL; // 1 << *iter = 2^{*iter} using bitwise shift 
-               } 
-               if(badrocsPCL!=0){
-                 BadModulePCL.BadRocs = badrocsPCL;
-                 siPixelQualityPCL->addDisabledModule(BadModulePCL);
-               }
+        // errorType 0 means the full module is bad
+        if (BadRocListPrompt.size() == sensorSize_[detid])
+          BadModulePrompt.errorType = 0;
 
-               // Other
-               short badrocsOther = 0;
-               for(std::vector<uint32_t>::iterator iterOther = BadRocListOther.begin(); iterOther != BadRocListOther.end(); ++iterOther){
-                   badrocsOther +=  1 << *iterOther; // 1 << *iter = 2^{*iter} using bitwise shift
-               }
-               if(badrocsOther!=0){
-                 BadModuleOther.BadRocs = badrocsOther;
-                 siPixelQualityOther->addDisabledModule(BadModuleOther);
-               }
+        short badrocsPrompt = 0;
+        for (std::vector<uint32_t>::iterator iterPrompt = BadRocListPrompt.begin();
+             iterPrompt != BadRocListPrompt.end();
+             ++iterPrompt) {
+          badrocsPrompt += 1 << *iterPrompt;  // 1 << *iter = 2^{*iter} using bitwise shift
+        }
+        if (badrocsPrompt != 0) {
+          BadModulePrompt.BadRocs = badrocsPrompt;
+          siPixelQualityPrompt->addDisabledModule(BadModulePrompt);
+        }
 
-               // start constructing bad components for prompt = "other" + permanent
-               SiPixelQuality::disabledModuleType BadModulePrompt;
-               BadModulePrompt.DetID = uint32_t(detid);
-               BadModulePrompt.errorType = 3;
-               BadModulePrompt.BadRocs = 0;
+      }  // end module loop
 
-               std::vector<uint32_t> BadRocListPrompt;
-               for (int iroc = 0; iroc < modStatus.nrocs(); ++iroc) {
-                   // if in permannet bad tag or is in other tag 
-                   if(badPixelInfo_->IsRocBad(detId, short(iroc))|| ((badrocsOther >> short(iroc))&0x1)){
-                      BadRocListPrompt.push_back(uint32_t(iroc));
+      // PCL
+      siPixelQualityPCL_Tag[itIOV->first] = siPixelQualityPCL;
+      // Prompt
+      siPixelQualityPrompt_Tag[itIOV->first] = siPixelQualityPrompt;
+      // Other
+      siPixelQualityOther_Tag[itIOV->first] = siPixelQualityOther;
 
-                      std::map<int, std::pair<int,int> > rocToOfflinePixel = pixelO2O_[detid];
-                      int row = rocToOfflinePixel[iroc].first;
-                      int column = rocToOfflinePixel[iroc].second;
-                      for (int iLumi = 0; iLumi<interval;iLumi++){
-                           histo[PROMPTBADROC].fill(detId, nullptr, column, row);//, 1.0/nLumiBlock_);
-                      }
-                   } // if bad
-               } // loop over all ROCs
+    }  // loop over IOV
 
-               // errorType 0 means the full module is bad
-               if(BadRocListPrompt.size()==sensorSize_[detid]) BadModulePrompt.errorType = 0;
+    // Now construct the tags made of payloads
+    // and only append newIOV if this payload differs wrt last
 
-               short badrocsPrompt = 0;
-               for(std::vector<uint32_t>::iterator iterPrompt = BadRocListPrompt.begin(); iterPrompt != BadRocListPrompt.end(); ++iterPrompt)
-               {
-                   badrocsPrompt +=  1 << *iterPrompt; // 1 << *iter = 2^{*iter} using bitwise shift
-               }
-               if(badrocsPrompt!=0){
-                 BadModulePrompt.BadRocs = badrocsPrompt;
-                 siPixelQualityPrompt->addDisabledModule(BadModulePrompt);
-               }
+    //PCL
+    if (debug_ == true)  // only produced for debugging reason
+      SiPixelStatusHarvester::constructTag(siPixelQualityPCL_Tag, poolDbService, "PCL", iRun);
+    // other
+    SiPixelStatusHarvester::constructTag(siPixelQualityOther_Tag, poolDbService, "other", iRun);
+    // prompt
+    SiPixelStatusHarvester::constructTag(siPixelQualityPrompt_Tag, poolDbService, "prompt", iRun);
+    // stuckTBM
+    SiPixelStatusHarvester::constructTag(siPixelQualityStuckTBM_Tag, poolDbService, "stuckTBM", iRun);
 
-         } // end module loop
- 
-         // PCL
-         siPixelQualityPCL_Tag[itIOV->first] = siPixelQualityPCL;
-         // Prompt
-         siPixelQualityPrompt_Tag[itIOV->first] = siPixelQualityPrompt;
-         // Other
-         siPixelQualityOther_Tag[itIOV->first] = siPixelQualityOther;
+    // Add a dummy IOV starting from last lumisection+1 to close the tag for the run
+    if ((outputBase_ == "nLumibased" || outputBase_ == "dynamicLumibased") && !finalIOV.empty()) {
+      itIOV = std::prev(finalIOV.end());  // go to last element in the pixel quality tag
+      SiPixelQuality* lastPrompt = siPixelQualityPrompt_Tag[itIOV->first];
+      SiPixelQuality* lastOther = siPixelQualityOther_Tag[itIOV->first];
 
-     }// loop over IOV
+      // add permanent bad components to last lumi+1 IF AND ONLY IF the last payload of prompt is not equal to permanent bad components
+      edm::LuminosityBlockID lu(iRun.id().run(), endLumiBlock_ + 1);
+      cond::Time_t thisIOV = (cond::Time_t)(lu.value());
+      if (!SiPixelStatusHarvester::equal(lastPrompt, siPixelQualityPermBad))
+        poolDbService->writeOne<SiPixelQuality>(siPixelQualityPermBad, thisIOV, recordName_ + "_prompt");
 
-     // Now construct the tags made of payloads 
-     // and only append newIOV if this payload differs wrt last
+      // add empty bad components to last lumi+1 IF AND ONLY IF the last payload of other is not equal to empty
+      SiPixelQuality* siPixelQualityDummy = new SiPixelQuality();
+      if (!SiPixelStatusHarvester::equal(lastOther, siPixelQualityDummy))
+        poolDbService->writeOne<SiPixelQuality>(siPixelQualityDummy, thisIOV, recordName_ + "_other");
 
-     //PCL
-     if(debug_==true)// only produced for debugging reason
-       SiPixelStatusHarvester::constructTag(siPixelQualityPCL_Tag, poolDbService, "PCL", iRun);
-     // other
-     SiPixelStatusHarvester::constructTag(siPixelQualityOther_Tag, poolDbService, "other", iRun);
-     // prompt
-     SiPixelStatusHarvester::constructTag(siPixelQualityPrompt_Tag, poolDbService, "prompt", iRun);
-     // stuckTBM
-     SiPixelStatusHarvester::constructTag(siPixelQualityStuckTBM_Tag, poolDbService, "stuckTBM", iRun);
+      delete siPixelQualityDummy;
+    }
 
-     // Add a dummy IOV starting from last lumisection+1 to close the tag for the run
-     if((outputBase_ == "nLumibased" || outputBase_ == "dynamicLumibased") && !finalIOV.empty()){
+    delete siPixelQualityPermBad;
 
-        itIOV=std::prev(finalIOV.end()); // go to last element in the pixel quality tag  
-        SiPixelQuality* lastPrompt = siPixelQualityPrompt_Tag[itIOV->first];
-        SiPixelQuality* lastOther  = siPixelQualityOther_Tag[itIOV->first];
-
-        // add permanent bad components to last lumi+1 IF AND ONLY IF the last payload of prompt is not equal to permanent bad components
-        edm::LuminosityBlockID lu(iRun.id().run(),endLumiBlock_+1);
-        cond::Time_t thisIOV = (cond::Time_t)(lu.value());
-        if(!SiPixelStatusHarvester::equal(lastPrompt,siPixelQualityPermBad))
-           poolDbService->writeOne<SiPixelQuality>(siPixelQualityPermBad, thisIOV, recordName_+"_prompt");
-
-        // add empty bad components to last lumi+1 IF AND ONLY IF the last payload of other is not equal to empty
-        SiPixelQuality* siPixelQualityDummy = new SiPixelQuality();
-        if(!SiPixelStatusHarvester::equal(lastOther,siPixelQualityDummy))
-           poolDbService->writeOne<SiPixelQuality>(siPixelQualityDummy, thisIOV, recordName_+"_other");
-
-        delete siPixelQualityDummy;
-     }
-
-     delete siPixelQualityPermBad;
-
-
-  } // end of if(poolDbService.isAvailable() )
-
+  }  // end of if(poolDbService.isAvailable() )
 }
 
 //--------------------------------------------------------------------------------------------------
-void SiPixelStatusHarvester::beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iEventSetup) { 
-     countLumi_++;
+void SiPixelStatusHarvester::beginLuminosityBlock(const edm::LuminosityBlock& iLumi,
+                                                  const edm::EventSetup& iEventSetup) {
+  countLumi_++;
 }
-
 
 //--------------------------------------------------------------------------------------------------
 void SiPixelStatusHarvester::endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iEventSetup) {
-
-     siPixelStatusManager_.readLumi(iLumi);
-     // update endLumiBlock_ by current lumi block
-     if(endLumiBlock_<iLumi.luminosityBlock())
-       endLumiBlock_ = iLumi.luminosityBlock();
-
+  siPixelStatusManager_.readLumi(iLumi);
+  // update endLumiBlock_ by current lumi block
+  if (endLumiBlock_ < iLumi.luminosityBlock())
+    endLumiBlock_ = iLumi.luminosityBlock();
 }
 
 // step function for IOV
-edm::LuminosityBlockNumber_t SiPixelStatusHarvester::stepIOV(edm::LuminosityBlockNumber_t pin, std::map<edm::LuminosityBlockNumber_t,edm::LuminosityBlockNumber_t> IOV){
+edm::LuminosityBlockNumber_t SiPixelStatusHarvester::stepIOV(
+    edm::LuminosityBlockNumber_t pin, std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t> IOV) {
+  std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t>::iterator itIOV;
+  for (itIOV = IOV.begin(); itIOV != IOV.end(); itIOV++) {
+    std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t>::iterator nextItIOV;
+    nextItIOV = itIOV;
+    nextItIOV++;
 
-   std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t>::iterator itIOV;
-   for(itIOV=IOV.begin();itIOV!=IOV.end();itIOV++){
-       std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t>::iterator nextItIOV;
-       nextItIOV = itIOV; nextItIOV++;
+    if (nextItIOV != IOV.end()) {
+      if (pin >= itIOV->first && pin < nextItIOV->first) {
+        return itIOV->first;
+      }
+    } else {
+      if (pin >= itIOV->first) {
+        return itIOV->first;
+      }
+    }
+  }
 
-       if(nextItIOV!=IOV.end()){ 
-          if(pin>=itIOV->first && pin<nextItIOV->first){
-             return itIOV->first;
-          }
-       }
-       else{
-          if(pin>=itIOV->first){
-             return itIOV->first;
-          }
-       }
-
-   }
-
-   // return the firstIOV in case all above fail
-   return (IOV.begin())->first;
-   
+  // return the firstIOV in case all above fail
+  return (IOV.begin())->first;
 }
 
 //--------------------------------------------------------------------------------------------------
-bool SiPixelStatusHarvester::equal(SiPixelQuality* a, SiPixelQuality* b){
-
+bool SiPixelStatusHarvester::equal(SiPixelQuality* a, SiPixelQuality* b) {
   std::vector<SiPixelQuality::disabledModuleType> badRocListA;
   std::vector<SiPixelQuality::disabledModuleType> badRocListB;
 
-  for(unsigned int ia = 0; ia < (a->getBadComponentList()).size();ia++){
-        badRocListA.push_back((a->getBadComponentList())[ia]); 
+  for (unsigned int ia = 0; ia < (a->getBadComponentList()).size(); ia++) {
+    badRocListA.push_back((a->getBadComponentList())[ia]);
   }
-  for(unsigned int ib = 0; ib < (b->getBadComponentList()).size();ib++){
-        badRocListB.push_back((b->getBadComponentList())[ib]);
+  for (unsigned int ib = 0; ib < (b->getBadComponentList()).size(); ib++) {
+    badRocListB.push_back((b->getBadComponentList())[ib]);
   }
 
-  if(badRocListA.size()!=badRocListB.size()) return false;
+  if (badRocListA.size() != badRocListB.size())
+    return false;
 
   // ordering ROCs by DetId
-  std::sort(badRocListA.begin(),badRocListA.end(),SiPixelQuality::BadComponentStrictWeakOrdering());
-  std::sort(badRocListB.begin(),badRocListB.end(),SiPixelQuality::BadComponentStrictWeakOrdering());
+  std::sort(badRocListA.begin(), badRocListA.end(), SiPixelQuality::BadComponentStrictWeakOrdering());
+  std::sort(badRocListB.begin(), badRocListB.end(), SiPixelQuality::BadComponentStrictWeakOrdering());
 
-  for(unsigned int i = 0; i<badRocListA.size();i++){
-
-        uint32_t detIdA = badRocListA[i].DetID;
-        uint32_t detIdB = badRocListB[i].DetID;
-        if(detIdA!=detIdB) return false;
-        else{
-           unsigned short BadRocsA = badRocListA[i].BadRocs;
-           unsigned short BadRocsB = badRocListB[i].BadRocs;
-           if(BadRocsA!=BadRocsB) return false;
-        }
-
+  for (unsigned int i = 0; i < badRocListA.size(); i++) {
+    uint32_t detIdA = badRocListA[i].DetID;
+    uint32_t detIdB = badRocListB[i].DetID;
+    if (detIdA != detIdB)
+      return false;
+    else {
+      unsigned short BadRocsA = badRocListA[i].BadRocs;
+      unsigned short BadRocsB = badRocListB[i].BadRocs;
+      if (BadRocsA != BadRocsB)
+        return false;
+    }
   }
 
   //if the module list is the same, and for each module, roc list is the same
   //the two SiPixelQualitys are equal
   return true;
-
-
 }
 
 //--------------------------------------------------------------------------------------------------
-void SiPixelStatusHarvester::constructTag(std::map<int,SiPixelQuality*>siPixelQualityTag, edm::Service<cond::service::PoolDBOutputService>& poolDbService, std::string tagName,edm::Run& iRun){
+void SiPixelStatusHarvester::constructTag(std::map<int, SiPixelQuality*> siPixelQualityTag,
+                                          edm::Service<cond::service::PoolDBOutputService>& poolDbService,
+                                          std::string tagName,
+                                          edm::Run& iRun) {
+  for (std::map<int, SiPixelQuality*>::iterator qIt = siPixelQualityTag.begin(); qIt != siPixelQualityTag.end();
+       ++qIt) {
+    edm::LuminosityBlockID lu(iRun.id().run(), qIt->first);
+    cond::Time_t thisIOV = (cond::Time_t)(lu.value());
 
-     for (std::map<int, SiPixelQuality*>::iterator qIt = siPixelQualityTag.begin(); qIt != siPixelQualityTag.end(); ++qIt) {
-
-            edm::LuminosityBlockID lu(iRun.id().run(),qIt->first);
-            cond::Time_t thisIOV = (cond::Time_t)(lu.value());
-
-            SiPixelQuality* thisPayload = qIt->second;
-            if(qIt==siPixelQualityTag.begin())
-                poolDbService->writeOne<SiPixelQuality>(thisPayload, thisIOV, recordName_+"_"+tagName);
-            else{
-                SiPixelQuality* prevPayload = (std::prev(qIt))->second;
-                if(!SiPixelStatusHarvester::equal(thisPayload,prevPayload)) // only append newIOV if this payload differs wrt last
-                  poolDbService->writeOne<SiPixelQuality>(thisPayload, thisIOV, recordName_+"_"+tagName);
-            }
-     }
-
+    SiPixelQuality* thisPayload = qIt->second;
+    if (qIt == siPixelQualityTag.begin())
+      poolDbService->writeOne<SiPixelQuality>(thisPayload, thisIOV, recordName_ + "_" + tagName);
+    else {
+      SiPixelQuality* prevPayload = (std::prev(qIt))->second;
+      if (!SiPixelStatusHarvester::equal(thisPayload,
+                                         prevPayload))  // only append newIOV if this payload differs wrt last
+        poolDbService->writeOne<SiPixelQuality>(thisPayload, thisIOV, recordName_ + "_" + tagName);
+    }
+  }
 }
 
 //--------------------------------------------------------------------------------------------------------
 double SiPixelStatusHarvester::perLayerRingAverage(int detid, SiPixelDetectorStatus tmpSiPixelStatus) {
+  unsigned long int ave(0);
+  int nrocs(0);
 
-          unsigned long int ave(0);
-          int nrocs(0);
+  int layer = coord_.layer(DetId(detid));
+  int ring = coord_.ring(DetId(detid));
 
-          int layer  = coord_.layer(DetId(detid));
-          int ring   = coord_.ring(DetId(detid));
+  std::map<int, SiPixelModuleStatus> detectorStatus = tmpSiPixelStatus.getDetectorStatus();
+  std::map<int, SiPixelModuleStatus>::iterator itModEnd = detectorStatus.end();
+  for (std::map<int, SiPixelModuleStatus>::iterator itMod = detectorStatus.begin(); itMod != itModEnd; ++itMod) {
+    if (layer != coord_.layer(DetId(itMod->first)))
+      continue;
+    if (ring != coord_.ring(DetId(itMod->first)))
+      continue;
+    unsigned long int inc = itMod->second.digiOccMOD();
+    ave += inc;
+    nrocs += itMod->second.nrocs();
+  }
 
-          std::map<int, SiPixelModuleStatus> detectorStatus = tmpSiPixelStatus.getDetectorStatus();
-          std::map<int, SiPixelModuleStatus>::iterator itModEnd = detectorStatus.end();
-          for (std::map<int, SiPixelModuleStatus>::iterator itMod = detectorStatus.begin(); itMod != itModEnd; ++itMod) {
-
-               if( layer != coord_.layer(DetId(itMod->first)) ) continue;
-               if( ring != coord_.ring(DetId(itMod->first)) ) continue;
-               unsigned long int inc = itMod->second.digiOccMOD();
-               ave += inc;
-               nrocs += itMod->second.nrocs();
-          }
-
-          if(nrocs>0)
-            return ave*1.0/nrocs;
-          else return 0.0;
-
-}     
-
-std::string SiPixelStatusHarvester::substructure(int detid){     
-     
-       std::string substructure = "";
-       int layer = coord_.layer(DetId(detid));
-
-       if(layer>0){
-         std::string L = std::to_string(layer);
-         substructure = "BpixLYR";
-         substructure += L;
-       }  
-       else{
-         substructure = "FpixRNG";
-         int ring  = coord_.ring(DetId(detid));
-         std::string R = std::to_string(ring);
-         substructure += R; 
-       }
-
-       return substructure;
+  if (nrocs > 0)
+    return ave * 1.0 / nrocs;
+  else
+    return 0.0;
 }
 
+std::string SiPixelStatusHarvester::substructure(int detid) {
+  std::string substructure = "";
+  int layer = coord_.layer(DetId(detid));
+
+  if (layer > 0) {
+    std::string L = std::to_string(layer);
+    substructure = "BpixLYR";
+    substructure += L;
+  } else {
+    substructure = "FpixRNG";
+    int ring = coord_.ring(DetId(detid));
+    std::string R = std::to_string(ring);
+    substructure += R;
+  }
+
+  return substructure;
+}
 
 DEFINE_FWK_MODULE(SiPixelStatusHarvester);

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
@@ -20,18 +20,11 @@
 #include "TH1.h"
 #include "TFile.h"
 
-class SiPixelStatusHarvester : public one::DQMEDAnalyzer<edm::one::WatchLuminosityBlocks>, private HistogramManagerHolder {
-    enum {
-      BADROC,
-      PERMANENTBADROC,
-      FEDERRORROC,
-      STUCKTBMROC,
-      OTHERBADROC,
-      PROMPTBADROC
-    };
+class SiPixelStatusHarvester : public one::DQMEDAnalyzer<edm::one::WatchLuminosityBlocks>,
+                               private HistogramManagerHolder {
+  enum { BADROC, PERMANENTBADROC, FEDERRORROC, STUCKTBMROC, OTHERBADROC, PROMPTBADROC };
 
- public:
-
+public:
   // Constructor
   SiPixelStatusHarvester(const edm::ParameterSet&);
 
@@ -97,7 +90,6 @@ private:
                     edm::Service<cond::service::PoolDBOutputService>& poolDbService,
                     std::string tagName,
                     edm::Run& iRun);
-
 };
 
 #endif

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
@@ -387,17 +387,16 @@ void SiPixelStatusProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   // siPixelStatusProducer
   edm::ParameterSetDescription desc;
   {
-       edm::ParameterSetDescription psd0;
-       psd0.addUntracked<int>("resetEveryNLumi", 1);
-       psd0.addUntracked<edm::InputTag>("pixelClusterLabel", edm::InputTag("siPixelClusters","","RECO"));
-       psd0.add<std::vector<edm::InputTag>>("badPixelFEDChannelCollections", {
-                    edm::InputTag("siPixelDigis"),
-       });
-       desc.add<edm::ParameterSetDescription>("SiPixelStatusProducerParameters", psd0);
+    edm::ParameterSetDescription psd0;
+    psd0.addUntracked<int>("resetEveryNLumi", 1);
+    psd0.addUntracked<edm::InputTag>("pixelClusterLabel", edm::InputTag("siPixelClusters", "", "RECO"));
+    psd0.add<std::vector<edm::InputTag>>("badPixelFEDChannelCollections",
+                                         {
+                                             edm::InputTag("siPixelDigis"),
+                                         });
+    desc.add<edm::ParameterSetDescription>("SiPixelStatusProducerParameters", psd0);
   }
   descriptions.add("siPixelStatusProducer", desc);
-
 }
-
 
 DEFINE_FWK_MODULE(SiPixelStatusProducer);

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
@@ -36,10 +36,9 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
-
-  void beginLuminosityBlock     (edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) final;
-  void endLuminosityBlock       (edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) final;
+private:
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) final;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) final;
   void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) final;
   void accumulate(edm::Event const&, const edm::EventSetup& iSetup) final;
 

--- a/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
@@ -18,86 +18,82 @@ using namespace edm;
 using namespace std;
 
 //--------------------------------------------------------------------------------------------------
-SiPixelStatusManager::SiPixelStatusManager(){
-}
+SiPixelStatusManager::SiPixelStatusManager() {}
 
 //--------------------------------------------------------------------------------------------------
-SiPixelStatusManager::SiPixelStatusManager(const ParameterSet& iConfig, edm::ConsumesCollector&& iC) :
-  outputBase_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<std::string>("outputBase")),
-  aveDigiOcc_(iConfig.getParameter<edm::ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<int>("aveDigiOcc")),
-  nLumi_(iConfig.getParameter<edm::ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<int>("resetEveryNLumi")),
-  moduleName_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<std::string>("moduleName")),
-  label_     (iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<std::string>("label"))
-{
-
+SiPixelStatusManager::SiPixelStatusManager(const ParameterSet& iConfig, edm::ConsumesCollector&& iC)
+    : outputBase_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                      .getUntrackedParameter<std::string>("outputBase")),
+      aveDigiOcc_(iConfig.getParameter<edm::ParameterSet>("SiPixelStatusManagerParameters")
+                      .getUntrackedParameter<int>("aveDigiOcc")),
+      nLumi_(iConfig.getParameter<edm::ParameterSet>("SiPixelStatusManagerParameters")
+                 .getUntrackedParameter<int>("resetEveryNLumi")),
+      moduleName_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                      .getUntrackedParameter<std::string>("moduleName")),
+      label_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters")
+                 .getUntrackedParameter<std::string>("label")) {
   edm::InputTag siPixelStatusTag_(moduleName_, label_);
-  siPixelStatusToken_ = iC.consumes<SiPixelDetectorStatus,edm::InLumi>(siPixelStatusTag_);
+  siPixelStatusToken_ = iC.consumes<SiPixelDetectorStatus, edm::InLumi>(siPixelStatusTag_);
 
-  LogInfo("SiPixelStatusManager") 
-    << "Output base: " << outputBase_ 
-    << std::endl;
+  LogInfo("SiPixelStatusManager") << "Output base: " << outputBase_ << std::endl;
   reset();
 }
 
 //--------------------------------------------------------------------------------------------------
-SiPixelStatusManager::~SiPixelStatusManager(){
+SiPixelStatusManager::~SiPixelStatusManager() {}
+
+//--------------------------------------------------------------------------------------------------
+void SiPixelStatusManager::reset() {
+  siPixelStatusMap_.clear();
+  siPixelStatusVtr_.clear();
 }
 
 //--------------------------------------------------------------------------------------------------
-void SiPixelStatusManager::reset(){
-     siPixelStatusMap_.clear();
-     siPixelStatusVtr_.clear();
+bool SiPixelStatusManager::rankByLumi(SiPixelDetectorStatus status1, SiPixelDetectorStatus status2) {
+  return (status1.getLSRange().first < status2.getLSRange().first);
 }
 
-//--------------------------------------------------------------------------------------------------
-bool SiPixelStatusManager::rankByLumi(SiPixelDetectorStatus status1,SiPixelDetectorStatus status2) 
-{ return (status1.getLSRange().first < status2.getLSRange().first); }
+void SiPixelStatusManager::createPayloads() {
+  if (!siPixelStatusVtr_
+           .empty()) {  //only create std::map payloads when the number of non-zero DIGI lumi sections is greater than ZERO otherwise segmentation fault
 
-void SiPixelStatusManager::createPayloads(){
-  if(!siPixelStatusVtr_.empty()){ //only create std::map payloads when the number of non-zero DIGI lumi sections is greater than ZERO otherwise segmentation fault
+    // sort the vector according to lumi
+    std::sort(siPixelStatusVtr_.begin(), siPixelStatusVtr_.end(), SiPixelStatusManager::rankByLumi);
 
-   // sort the vector according to lumi
-   std::sort(siPixelStatusVtr_.begin(), siPixelStatusVtr_.end(), SiPixelStatusManager::rankByLumi);
-   
-   // create FEDerror25 ROCs and bad ROCs from PCL
-   SiPixelStatusManager::createFEDerror25();
-   SiPixelStatusManager::createBadComponents();
-     
-   // realse the cost of siPixelStatusVtr_ since it is not needed anymore
-   siPixelStatusVtr_.clear();
+    // create FEDerror25 ROCs and bad ROCs from PCL
+    SiPixelStatusManager::createFEDerror25();
+    SiPixelStatusManager::createBadComponents();
 
+    // realse the cost of siPixelStatusVtr_ since it is not needed anymore
+    siPixelStatusVtr_.clear();
   }
-
 }
 
 //--------------------------------------------------------------------------------------------------
-void SiPixelStatusManager::readLumi(const LuminosityBlock& iLumi){
-
+void SiPixelStatusManager::readLumi(const LuminosityBlock& iLumi) {
   edm::Handle<SiPixelDetectorStatus> siPixelStatusHandle;
   iLumi.getByToken(siPixelStatusToken_, siPixelStatusHandle);
 
-  if(siPixelStatusHandle.isValid()) { // check the product
+  if (siPixelStatusHandle.isValid()) {  // check the product
     SiPixelDetectorStatus tmpStatus = (*siPixelStatusHandle);
-    if(tmpStatus.digiOccDET()>0){ // only put in SiPixelDetectorStatus with non zero digi (pixel hit)
+    if (tmpStatus.digiOccDET() > 0) {  // only put in SiPixelDetectorStatus with non zero digi (pixel hit)
       siPixelStatusVtr_.push_back(tmpStatus);
     }
+  } else {
+    edm::LogWarning("SiPixelStatusManager") << " SiPixelDetectorStatus is not valid for run " << iLumi.run() << " lumi "
+                                            << iLumi.luminosityBlock() << std::endl;
   }
-  else {
-       edm::LogWarning("SiPixelStatusManager")
-        << " SiPixelDetectorStatus is not valid for run "<<iLumi.run()<<" lumi "<<iLumi.luminosityBlock()<< std::endl;
-  }
-
 }
 
 //--------------------------------------------------------------------------------------------------
-void SiPixelStatusManager::createBadComponents(){
-
-  siPixelStatusVtr_iterator firstStatus    = siPixelStatusVtr_.begin();
-  siPixelStatusVtr_iterator lastStatus     = siPixelStatusVtr_.end();
+void SiPixelStatusManager::createBadComponents() {
+  siPixelStatusVtr_iterator firstStatus = siPixelStatusVtr_.begin();
+  siPixelStatusVtr_iterator lastStatus = siPixelStatusVtr_.end();
 
   siPixelStatusMap_.clear();
 
-  if(outputBase_ == "nLumibased" && nLumi_>1){ // doesn't work for nLumi_=1 cos any integer can be completely divided by 1
+  if (outputBase_ == "nLumibased" &&
+      nLumi_ > 1) {  // doesn't work for nLumi_=1 cos any integer can be completely divided by 1
 
     // if the total number of Lumi Blocks can't be completely divided by nLumi_,
     // the residual Lumi Blocks will be as the last IOV
@@ -106,29 +102,27 @@ void SiPixelStatusManager::createBadComponents(){
     LuminosityBlockNumber_t tmpLumi;
     SiPixelDetectorStatus tmpSiPixelStatus;
     for (siPixelStatusVtr_iterator it = firstStatus; it != lastStatus; it++) {
+      // this is the begining of an IOV
+      if (iterationLumi % nLumi_ == 0) {
+        tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);
+        tmpSiPixelStatus = (*it);
+      }
 
-        // this is the begining of an IOV
-        if(iterationLumi%nLumi_==0){
-           tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);
-           tmpSiPixelStatus = (*it); 
-	}
+      // keep update detector status up to nLumi_ lumi sections
+      if (iterationLumi % nLumi_ > 0) {
+        tmpSiPixelStatus.updateDetectorStatus((*it));
+        tmpSiPixelStatus.setLSRange(int(tmpLumi), (*it).getLSRange().second);
+      }
 
-        // keep update detector status up to nLumi_ lumi sections
-        if(iterationLumi%nLumi_>0){
-          tmpSiPixelStatus.updateDetectorStatus((*it));
-          tmpSiPixelStatus.setLSRange(int(tmpLumi), (*it).getLSRange().second);
-        }
+      siPixelStatusVtr_iterator currentIt = it;
+      siPixelStatusVtr_iterator nextIt = std::next(currentIt);
+      // wirte out if current lumi is the last lumi-section in the IOV
+      if (iterationLumi % nLumi_ == nLumi_ - 1 || nextIt == lastStatus) {
+        // fill it into a new map (with IOV structured)
+        siPixelStatusMap_[tmpLumi] = tmpSiPixelStatus;
+      }
 
-        siPixelStatusVtr_iterator currentIt = it;
-        siPixelStatusVtr_iterator nextIt = std::next(currentIt);
-        // wirte out if current lumi is the last lumi-section in the IOV
-        if(iterationLumi%nLumi_==nLumi_-1 || nextIt==lastStatus) 
-        {
-             // fill it into a new map (with IOV structured)
-             siPixelStatusMap_[tmpLumi] = tmpSiPixelStatus;
-        }
-
-        iterationLumi=iterationLumi+1;
+      iterationLumi = iterationLumi + 1;
     }
 
     // check whether there is not enough number of Lumi in the last IOV
@@ -137,149 +131,129 @@ void SiPixelStatusManager::createBadComponents(){
     //            and the number of lumi can not be completely divided by the nLumi_.
     //                (then the number of lumis in the last IOV is equal to the residual, which is less than nLumi_)
     // if it is, combine last IOV with the IOV before it
-    if(siPixelStatusVtr_.size()%nLumi_!=0 && siPixelStatusMap_.size()>1){
+    if (siPixelStatusVtr_.size() % nLumi_ != 0 && siPixelStatusMap_.size() > 1) {
+      // start from the iterator of the end of std::map
+      siPixelStatusMap_iterator iterEnd = siPixelStatusMap_.end();
+      // the last IOV
+      siPixelStatusMap_iterator iterLastIOV = std::prev(iterEnd);
+      // the IOV before the last IOV
+      siPixelStatusMap_iterator iterBeforeLastIOV = std::prev(iterLastIOV);
 
-       // start from the iterator of the end of std::map
-       siPixelStatusMap_iterator iterEnd = siPixelStatusMap_.end();
-       // the last IOV
-       siPixelStatusMap_iterator iterLastIOV = std::prev(iterEnd);
-       // the IOV before the last IOV
-       siPixelStatusMap_iterator iterBeforeLastIOV = std::prev(iterLastIOV);
+      // combine the last IOV data to the IOV before the last IOV
+      (iterBeforeLastIOV->second).updateDetectorStatus(iterLastIOV->second);
+      (iterBeforeLastIOV->second)
+          .setLSRange((iterBeforeLastIOV->second).getLSRange().first, (iterLastIOV->second).getLSRange().second);
 
-       // combine the last IOV data to the IOV before the last IOV
-       (iterBeforeLastIOV->second).updateDetectorStatus(iterLastIOV->second);
-       (iterBeforeLastIOV->second).setLSRange((iterBeforeLastIOV->second).getLSRange().first, (iterLastIOV->second).getLSRange().second);
-
-       // delete the last IOV, so the IOV before the last IOV becomes the new last IOV
-       siPixelStatusMap_.erase(iterLastIOV);
-
+      // delete the last IOV, so the IOV before the last IOV becomes the new last IOV
+      siPixelStatusMap_.erase(iterLastIOV);
     }
 
-  }
-  else if(outputBase_ == "dynamicLumibased"){
+  } else if (outputBase_ == "dynamicLumibased") {
+    double aveDigiOcc = 1.0 * aveDigiOcc_;
 
-    double aveDigiOcc = 1.0*aveDigiOcc_;
-  
     edm::LuminosityBlockNumber_t tmpLumi;
     SiPixelDetectorStatus tmpSiPixelStatus;
     bool isNewIOV = true;
 
     int counter = 0;
     for (siPixelStatusVtr_iterator it = firstStatus; it != lastStatus; it++) {
+      if (isNewIOV) {  // if it is new IOV, init with the current data
+        tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);
+        tmpSiPixelStatus = (*it);
+      } else {  // if it is not new IOV, append current data
+        tmpSiPixelStatus.updateDetectorStatus((*it));
+        tmpSiPixelStatus.setLSRange(int(tmpLumi), (*it).getLSRange().second);
+      }
 
-         if(isNewIOV){ // if it is new IOV, init with the current data
-               tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);
-               tmpSiPixelStatus = (*it);
-         }
-         else{ // if it is not new IOV, append current data
-               tmpSiPixelStatus.updateDetectorStatus((*it));
-               tmpSiPixelStatus.setLSRange(int(tmpLumi),(*it).getLSRange().second);
-         }
+      // if reaching the end of data, write the last IOV to the map whatsoevec
+      siPixelStatusVtr_iterator currentIt = it;
+      siPixelStatusVtr_iterator nextIt = std::next(currentIt);
+      if (tmpSiPixelStatus.perRocDigiOcc() < aveDigiOcc && nextIt != lastStatus) {
+        isNewIOV = false;  // if digi occ is not enough, next data will not belong to new IOV
+      } else {             // if (accunumated) digi occ is enough, write the data to the map
+        isNewIOV = true;
+        siPixelStatusMap_[tmpLumi] = tmpSiPixelStatus;
+        // so next loop is the begining of a new IOV
+      }
+      counter++;
 
-         // if reaching the end of data, write the last IOV to the map whatsoevec
-         siPixelStatusVtr_iterator currentIt = it;
-         siPixelStatusVtr_iterator nextIt = std::next(currentIt);
-         if(tmpSiPixelStatus.perRocDigiOcc()<aveDigiOcc && nextIt!=lastStatus){
-            isNewIOV = false; // if digi occ is not enough, next data will not belong to new IOV
-         }
-         else{ // if (accunumated) digi occ is enough, write the data to the map
-           isNewIOV = true;
-           siPixelStatusMap_[tmpLumi]=tmpSiPixelStatus;
-           // so next loop is the begining of a new IOV
-         }
-         counter++;
+    }  // end of siPixelStatusMap
 
-   } // end of siPixelStatusMap
-
-   // check whether last IOV has enough statistics
-   // (ONLY when there are more than oneIOV(otherwise there is NO previous IOV before the last IOV) )
-   // if not, combine with previous IOV
-   if(siPixelStatusMap_.size()>1){
-
+    // check whether last IOV has enough statistics
+    // (ONLY when there are more than oneIOV(otherwise there is NO previous IOV before the last IOV) )
+    // if not, combine with previous IOV
+    if (siPixelStatusMap_.size() > 1) {
       // start from the end iterator of the std::map
       siPixelStatusMap_iterator iterEnd = siPixelStatusMap_.end();
       // the last IOV
       siPixelStatusMap_iterator iterLastIOV = std::prev(iterEnd);
       // if the statistics of the last IOV is not enough
-      if((iterLastIOV->second).perRocDigiOcc()<aveDigiOcc){
-         // the IOV before the last IOV of the map
-         siPixelStatusMap_iterator iterBeforeLastIOV = std::prev(iterLastIOV);
-         // combine the last IOV data to the IOV before the last IOV
-         (iterBeforeLastIOV->second).updateDetectorStatus(iterLastIOV->second);
-         (iterBeforeLastIOV->second).setLSRange((iterBeforeLastIOV->second).getLSRange().first, (iterLastIOV->second).getLSRange().second);
-         // erase the last IOV, so the IOV before the last IOV becomes the new last IOV
-         siPixelStatusMap_.erase(iterLastIOV);
+      if ((iterLastIOV->second).perRocDigiOcc() < aveDigiOcc) {
+        // the IOV before the last IOV of the map
+        siPixelStatusMap_iterator iterBeforeLastIOV = std::prev(iterLastIOV);
+        // combine the last IOV data to the IOV before the last IOV
+        (iterBeforeLastIOV->second).updateDetectorStatus(iterLastIOV->second);
+        (iterBeforeLastIOV->second)
+            .setLSRange((iterBeforeLastIOV->second).getLSRange().first, (iterLastIOV->second).getLSRange().second);
+        // erase the last IOV, so the IOV before the last IOV becomes the new last IOV
+        siPixelStatusMap_.erase(iterLastIOV);
       }
- 
-   }
+    }
 
-  }
-  else if(outputBase_ == "runbased" || ( (int(siPixelStatusVtr_.size()) <= nLumi_ && outputBase_ == "nLumibased")) ){
-
+  } else if (outputBase_ == "runbased" || ((int(siPixelStatusVtr_.size()) <= nLumi_ && outputBase_ == "nLumibased"))) {
     edm::LuminosityBlockNumber_t tmpLumi = edm::LuminosityBlockNumber_t(firstStatus->getLSRange().first);
     SiPixelDetectorStatus tmpSiPixelStatus = (*firstStatus);
 
     siPixelStatusVtr_iterator nextStatus = ++siPixelStatusVtr_.begin();
     for (siPixelStatusVtr_iterator it = nextStatus; it != lastStatus; it++) {
-          tmpSiPixelStatus.updateDetectorStatus((*it));
-          tmpSiPixelStatus.setLSRange(int(tmpLumi),(*it).getLSRange().second); 
+      tmpSiPixelStatus.updateDetectorStatus((*it));
+      tmpSiPixelStatus.setLSRange(int(tmpLumi), (*it).getLSRange().second);
     }
 
     siPixelStatusMap_[tmpLumi] = tmpSiPixelStatus;
 
+  } else {
+    LogInfo("SiPixelStatusManager") << "Unrecognized payload outputBase parameter: " << outputBase_ << endl;
   }
-  else{
-    LogInfo("SiPixelStatusManager")
-      << "Unrecognized payload outputBase parameter: " << outputBase_
-      << endl;    
-  }
-
-
 }
 
+void SiPixelStatusManager::createFEDerror25() {
+  // initialize the first IOV and SiPixelDetector status (in the first IOV)
+  siPixelStatusVtr_iterator firstStatus = siPixelStatusVtr_.begin();
+  edm::LuminosityBlockNumber_t firstLumi = edm::LuminosityBlockNumber_t(firstStatus->getLSRange().first);
+  SiPixelDetectorStatus firstFEDerror25 = (*firstStatus);
+  FEDerror25Map_[firstLumi] = firstFEDerror25.getFEDerror25Rocs();
 
-void SiPixelStatusManager::createFEDerror25(){
+  siPixelStatusVtr_iterator lastStatus = siPixelStatusVtr_.end();
 
-    // initialize the first IOV and SiPixelDetector status (in the first IOV)
-    siPixelStatusVtr_iterator firstStatus = siPixelStatusVtr_.begin();
-    edm::LuminosityBlockNumber_t  firstLumi = edm::LuminosityBlockNumber_t(firstStatus->getLSRange().first);
-    SiPixelDetectorStatus  firstFEDerror25 = (*firstStatus);
-    FEDerror25Map_[firstLumi] = firstFEDerror25.getFEDerror25Rocs();   
+  ///////////
+  bool sameAsLastIOV = true;
+  edm::LuminosityBlockNumber_t previousLumi = firstLumi;
 
-    siPixelStatusVtr_iterator lastStatus = siPixelStatusVtr_.end();
+  siPixelStatusVtr_iterator secondStatus = std::next(siPixelStatusVtr_.begin());
+  for (siPixelStatusVtr_iterator it = secondStatus; it != lastStatus; it++) {
+    // init for each lumi section (iterator)
+    edm::LuminosityBlockNumber_t tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);
+    SiPixelDetectorStatus tmpFEDerror25 = (*it);
 
-    ///////////
-    bool sameAsLastIOV = true;
-    edm::LuminosityBlockNumber_t previousLumi = firstLumi;
+    std::map<int, std::vector<int> > tmpBadRocLists = tmpFEDerror25.getFEDerror25Rocs();
 
-    siPixelStatusVtr_iterator secondStatus = std::next(siPixelStatusVtr_.begin());
-    for (siPixelStatusVtr_iterator it = secondStatus; it != lastStatus; it++) {
-        // init for each lumi section (iterator)
-        edm::LuminosityBlockNumber_t tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);
-        SiPixelDetectorStatus tmpFEDerror25 = (*it);
-
-        std::map<int,std::vector<int> >tmpBadRocLists = tmpFEDerror25.getFEDerror25Rocs();
-
-        std::map<int, SiPixelModuleStatus>::iterator itModEnd = tmpFEDerror25.end();
-        for (std::map<int, SiPixelModuleStatus>::iterator itMod = tmpFEDerror25.begin(); itMod != itModEnd; ++itMod) 
-        {
-            int detid = itMod->first;
-            // if the badroc list differs for any detid, update the payload
-            if(tmpBadRocLists[detid]!=(FEDerror25Map_[previousLumi])[detid]){
-               sameAsLastIOV = false;
-               break; // jump out of the loop once a new payload is found
-            }       
-        }
-
-        if(sameAsLastIOV==false){
-            //only write new IOV when this Lumi's FEDerror25 ROC list is not equal to the previous one
-            FEDerror25Map_[tmpLumi] = tmpBadRocLists; 
-            // and reset
-            previousLumi = tmpLumi;
-            sameAsLastIOV = true;
-
-        }
-
+    std::map<int, SiPixelModuleStatus>::iterator itModEnd = tmpFEDerror25.end();
+    for (std::map<int, SiPixelModuleStatus>::iterator itMod = tmpFEDerror25.begin(); itMod != itModEnd; ++itMod) {
+      int detid = itMod->first;
+      // if the badroc list differs for any detid, update the payload
+      if (tmpBadRocLists[detid] != (FEDerror25Map_[previousLumi])[detid]) {
+        sameAsLastIOV = false;
+        break;  // jump out of the loop once a new payload is found
+      }
     }
 
+    if (sameAsLastIOV == false) {
+      //only write new IOV when this Lumi's FEDerror25 ROC list is not equal to the previous one
+      FEDerror25Map_[tmpLumi] = tmpBadRocLists;
+      // and reset
+      previousLumi = tmpLumi;
+      sameAsLastIOV = true;
+    }
+  }
 }


### PR DESCRIPTION

Applying code-format for CMSSW category alca.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/403//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


