### PR TITLE
Running code-format for dqm

### DIFF
--- a/DQM/EcalMonitorTasks/src/RecoSummaryTask.cc
+++ b/DQM/EcalMonitorTasks/src/RecoSummaryTask.cc
@@ -50,7 +50,7 @@ namespace ecaldqm {
     MESet* meSwissCross(isBarrel ? &MEs_.at("SwissCross") : nullptr);
     MESet& meRecoFlag(MEs_.at("RecoFlagAll"));
 
-    double maxE[2] = {-1., - 1};
+    double maxE[2] = {-1., -1};
     int subdet(isBarrel ? EcalBarrel : EcalEndcap);
 
     for (EcalRecHitCollection::const_iterator hitItr(_hits.begin()); hitItr != _hits.end(); ++hitItr) {

--- a/DQM/HcalCommon/src/DetectorQuantity.cc
+++ b/DQM/HcalCommon/src/DetectorQuantity.cc
@@ -26,7 +26,7 @@ namespace hcaldqm {
 
     uint32_t getBin_ieta(HcalDetId const &did) { return (uint32_t)(getValue_ieta(did) + 1); }
 
-    uint32_t getBin_depth(HcalDetId const &did) { //return (uint32_t)(did.depth());}
+    uint32_t getBin_depth(HcalDetId const &did) {  //return (uint32_t)(did.depth());}
       return (uint32_t)(did.subdet() == HcalOuter ? 7 : did.depth());
     }
 

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayHit.cc
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayHit.cc
@@ -139,7 +139,8 @@ SiStripFineDelayHit::DeviceMask SiStripFineDelayHit::deviceMask(const StripSubde
       maskDetId = tkrTopo->tecDetId(3, 15, 0, 0, 0, 0, 0).rawId();
       break;
     }
-    default: break;
+    default:
+      break;
   }
   return std::make_pair(maskDetId, rootDetId);
 }

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -123,8 +123,8 @@ private:
                     const SiStripGain* stripGain,
                     const SiStripQuality* stripQuality,
                     const edm::DetSetVector<SiStripDigi>& digilist,
-		    float clustZ,
-		    float clustPhi);
+                    float clustZ,
+                    float clustPhi);
   template <class T>
   void RecHitInfo(const T* tkrecHit,
                   LocalVector LV,

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -23,7 +23,6 @@
 #include "DQM/SiStripCommon/interface/SiStripHistoId.h"
 #include "TMath.h"
 
-
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 #include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
 
@@ -541,46 +540,45 @@ void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker& ibooker, const uint32_
       (conf_.getParameter<edm::ParameterSet>(hpar.c_str())).getParameter<bool>(view.c_str()))
     theLayerMEs.ClusterPosOnTrack = ibooker.book1D(hname, hname, total_nr_strips, 0.5, total_nr_strips + 0.5);
 
-   
   //----------------------
   //add 2D z-phi map per layer
   hname = hidmanager.createHistoLayer("Summary_ClusterPosition2D", name, layer_id, "OnTrack");
   hpar = "TH2ClusterPosTOB";
-  if ( layer_id.find("TOB") != std::string::npos )  theLayerMEs.ClusterPosOnTrack2D = ibooker.book2D(hname, hname, 12, -110, 110, 300, -3.2, 3.2);
-  
+  if (layer_id.find("TOB") != std::string::npos)
+    theLayerMEs.ClusterPosOnTrack2D = ibooker.book2D(hname, hname, 12, -110, 110, 300, -3.2, 3.2);
+
   hname = hidmanager.createHistoLayer("Summary_ClusterPosition2D", name, layer_id, "OnTrack");
   hpar = "TH2ClusterPosTIB";
-  if ( layer_id.find("TIB") != std::string::npos )  theLayerMEs.ClusterPosOnTrack2D = ibooker.book2D(hname, hname, 12, -65, 65, 450, -3.2, 3.2);
- 
+  if (layer_id.find("TIB") != std::string::npos)
+    theLayerMEs.ClusterPosOnTrack2D = ibooker.book2D(hname, hname, 12, -65, 65, 450, -3.2, 3.2);
+
   hname = hidmanager.createHistoLayer("Summary_ClusterPosition2D", name, layer_id, "OnTrack");
   hpar = "TH2ClusterPosTEC";
-  if ( layer_id.find("TEC") != std::string::npos ){ 
-    
-    static constexpr int   nbinR = 8;
-    static constexpr float rval[9]= {0, 21.2, 30.8, 40.4, 50.0, 60.0, 75.0, 90.0, 110.0};
-    static constexpr int   nmodulesPhi = 40*6; //max number of APV  for a ring
+  if (layer_id.find("TEC") != std::string::npos) {
+    static constexpr int nbinR = 8;
+    static constexpr float rval[9] = {0, 21.2, 30.8, 40.4, 50.0, 60.0, 75.0, 90.0, 110.0};
+    static constexpr int nmodulesPhi = 40 * 6;  //max number of APV  for a ring
     float phival[nmodulesPhi];
-    for(int i=0; i<nmodulesPhi; i++) phival[i] = -3.2+2*i*3.2/nmodulesPhi;
-    
-    TH2F * temp = new TH2F("tmp", "tmp", nbinR, rval, nmodulesPhi-1, phival); 
+    for (int i = 0; i < nmodulesPhi; i++)
+      phival[i] = -3.2 + 2 * i * 3.2 / nmodulesPhi;
+
+    TH2F* temp = new TH2F("tmp", "tmp", nbinR, rval, nmodulesPhi - 1, phival);
     theLayerMEs.ClusterPosOnTrack2D = ibooker.book2D(hname, temp);
   }
- 
+
   hname = hidmanager.createHistoLayer("Summary_ClusterPosition2D", name, layer_id, "OnTrack");
   hpar = "TH2ClusterPosTID";
-  if ( layer_id.find("TID") != std::string::npos ){
-    static constexpr int   nbinR = 4;
-    static constexpr float rval[5]= {0, 21.2, 30.8, 40.4, 50.0};
-    static constexpr int   nmodulesPhi = 80*4;//max number of APV  for a ring
+  if (layer_id.find("TID") != std::string::npos) {
+    static constexpr int nbinR = 4;
+    static constexpr float rval[5] = {0, 21.2, 30.8, 40.4, 50.0};
+    static constexpr int nmodulesPhi = 80 * 4;  //max number of APV  for a ring
     float phival[nmodulesPhi];
-    for(int i=0; i<nmodulesPhi; i++) phival[i] = -3.2+i*2*3.2/nmodulesPhi;
-    
-    TH2F * temp = new TH2F("tmp", "tmp", nbinR, rval, nmodulesPhi-1, phival); 
+    for (int i = 0; i < nmodulesPhi; i++)
+      phival[i] = -3.2 + i * 2 * 3.2 / nmodulesPhi;
+
+    TH2F* temp = new TH2F("tmp", "tmp", nbinR, rval, nmodulesPhi - 1, phival);
     theLayerMEs.ClusterPosOnTrack2D = ibooker.book2D(hname, temp);
   }
- 
-
- 
 
   hname = hidmanager.createHistoLayer("Summary_ClusterPosition", name, layer_id, "OffTrack");
   hpar = "TH1ClusterPos";
@@ -1244,32 +1242,40 @@ void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit,
     const DetId detid = tkrecHit->geographicalId();
     int subDet = detid.subdetId();
     //std::cout << __LINE__ << std::endl;
-    float clust_Pos1  = -1000;
-    float clust_Pos2  = -1000;
-    
-    
-    GlobalPoint  theGlobalPos = tkgeom_->idToDet(tkrecHit->geographicalId())->surface().toGlobal(tkrecHit->localPosition());
-    if(subDet == SiStripDetId::TIB || subDet == SiStripDetId::TOB ){
-      clust_Pos1 =  theGlobalPos.z();
-      clust_Pos2 =  theGlobalPos.phi();
-    }else{
-      clust_Pos1 =  pow(theGlobalPos.x()*theGlobalPos.x() + theGlobalPos.y()*theGlobalPos.y(), 0.5);
-      clust_Pos2 =  theGlobalPos.phi();
+    float clust_Pos1 = -1000;
+    float clust_Pos2 = -1000;
+
+    GlobalPoint theGlobalPos =
+        tkgeom_->idToDet(tkrecHit->geographicalId())->surface().toGlobal(tkrecHit->localPosition());
+    if (subDet == SiStripDetId::TIB || subDet == SiStripDetId::TOB) {
+      clust_Pos1 = theGlobalPos.z();
+      clust_Pos2 = theGlobalPos.phi();
+    } else {
+      clust_Pos1 = pow(theGlobalPos.x() * theGlobalPos.x() + theGlobalPos.y() * theGlobalPos.y(), 0.5);
+      clust_Pos2 = theGlobalPos.phi();
     }
-    
+
     const SiStripCluster* SiStripCluster_ = &*(tkrecHit->cluster());
     SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_, es, detid);
 
-
     const Det2MEs MEs = findMEs(tTopo, detid);
-    if (clusterInfos(
-            &SiStripClusterInfo_, detid, OnTrack, track_ok, LV, MEs, tTopo, stripGain, stripQuality, digilist, clust_Pos1, clust_Pos2)) {
+    if (clusterInfos(&SiStripClusterInfo_,
+                     detid,
+                     OnTrack,
+                     track_ok,
+                     LV,
+                     MEs,
+                     tTopo,
+                     stripGain,
+                     stripQuality,
+                     digilist,
+                     clust_Pos1,
+                     clust_Pos2)) {
       vPSiStripCluster.insert(SiStripCluster_);
     }
   } else {
     edm::LogError("SiStripMonitorTrack") << "NULL hit" << std::endl;
   }
-  
 }
 
 //------------------------------------------------------------------------
@@ -1278,7 +1284,7 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
   edm::ESHandle<TrackerTopology> tTopoHandle;
   es.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
-  
+
   /*edm::ESHandle<TrackerGeometry> tracker;
   es.get<TrackerDigiGeometryRecord>().get(tracker);
   const TrackerGeometry *tkgeom = &(*tracker); */
@@ -1299,12 +1305,11 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
 
   edm::Handle<edmNew::DetSetVector<SiStripCluster>> siStripClusterHandle;
   ev.getByToken(clusterToken_, siStripClusterHandle);
-  
-  
+
   /*edm::ESHandle<StripClusterParameterEstimator> parameterestimator;
   es.get<TkStripCPERecord>().get("StripCPEfromTrackAngle", parameterestimator); 
   const StripClusterParameterEstimator &stripcpe(*parameterestimator);*/
-  
+
   if (siStripClusterHandle.isValid()) {
     //Loop on Dets
     for (edmNew::DetSetVector<SiStripCluster>::const_iterator DSViter = siStripClusterHandle->begin(),
@@ -1322,13 +1327,13 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
            ++ClusIter) {
         if (vPSiStripCluster.find(&*ClusIter) == vPSiStripCluster.end()) {
           SiStripClusterInfo SiStripClusterInfo_(*ClusIter, es, detid);
-	  
-	  /*const StripGeomDetUnit * stripdet = (const StripGeomDetUnit*) tkgeom->idToDetUnit(detid);
+
+          /*const StripGeomDetUnit * stripdet = (const StripGeomDetUnit*) tkgeom->idToDetUnit(detid);
     	  StripClusterParameterEstimator::LocalValues parameters=stripcpe.localParameters(*ClusIter, *stripdet);
     	  LocalPoint lp = parameters.first;
 	  const Surface& surface = tracker->idToDet(detid)->surface();
 	  GlobalPoint gp = surface.toGlobal(lp);*/
-	  
+
           clusterInfos(&SiStripClusterInfo_,
                        detid,
                        OffTrack,
@@ -1339,8 +1344,8 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
                        stripGain,
                        stripQuality,
                        digilist,
-		       0,
-		       0);
+                       0,
+                       0);
         }
       }
     }
@@ -1523,8 +1528,8 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster,
                                        const SiStripGain* stripGain,
                                        const SiStripQuality* stripQuality,
                                        const edm::DetSetVector<SiStripDigi>& digilist,
-				       float valX,
-				       float valY) {
+                                       float valX,
+                                       float valY) {
   if (cluster == nullptr)
     return false;
   // if one imposes a cut on the clusters, apply it
@@ -1542,14 +1547,12 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster,
     LogDebug("SiStripMonitorTrack") << "\n\t cosRZ " << cosRZ << std::endl;
   }
 
-
   // Filling SubDet/Layer Plots (on Track + off Track)
   float StoN = cluster->signalOverNoise();
   float noise = cluster->noiseRescaledByGain();
   uint16_t charge = cluster->charge();
   uint16_t width = cluster->width();
   float position = cluster->baryStrip();
-
 
   // Getting raw charge with strip gain.
   double chargeraw = 0;
@@ -1574,7 +1577,7 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster,
       }
     }
   }
-  
+
   clustergain /= double(cluster->stripCharges().size());  // calculating average gain inside cluster
 
   // new dE/dx (chargePerCM)
@@ -1615,10 +1618,9 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster,
       fillME(MEs.iLayer->ClusterWidthOnTrack, width);
       fillME(MEs.iLayer->ClusterPosOnTrack, position);
       //auto clustgp = cluster->globalPosition();
-      
-      fillME(MEs.iLayer->ClusterPosOnTrack2D, valX, valY );
-      
-      
+
+      fillME(MEs.iLayer->ClusterPosOnTrack2D, valX, valY);
+
       if (track_ok)
         fillME(MEs.iLayer->ClusterChargePerCMfromTrack, dQdx_fromTrack);
       if (track_ok)

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -69,7 +69,7 @@ void HcalRecHitsAnalyzer::dqmBeginRun(const edm::Run &run, const edm::EventSetup
   hcons = &(*pHRNDC);
   maxDepthHB_ = hcons->getMaxDepth(0);
   maxDepthHE_ = hcons->getMaxDepth(1);
-  maxDepthHF_ = std::max(hcons->getMaxDepth(2),1);
+  maxDepthHF_ = std::max(hcons->getMaxDepth(2), 1);
   maxDepthHO_ = hcons->getMaxDepth(3);
 
   edm::ESHandle<CaloGeometry> geometry;
@@ -83,7 +83,7 @@ void HcalRecHitsAnalyzer::dqmBeginRun(const edm::Run &run, const edm::EventSetup
   const HcalGeometry *gHF = static_cast<const HcalGeometry *>(geo->getSubdetectorGeometry(DetId::Hcal, HcalForward));
 
   nChannels_[1] = gHB->getHxSize(1);
-  nChannels_[2] = std::max(int(gHE->getHxSize(2)),1);
+  nChannels_[2] = std::max(int(gHE->getHxSize(2)), 1);
   nChannels_[3] = gHO->getHxSize(3);
   nChannels_[4] = gHF->getHxSize(4);
 

--- a/Validation/HcalHits/src/HcalSimHitStudy.cc
+++ b/Validation/HcalHits/src/HcalSimHitStudy.cc
@@ -48,7 +48,7 @@ void HcalSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run,
   iphi_bins = (int)(iphi_max - iphi_min);
 
   int iEtaHBMax = hcons->getEtaRange(0).second;
-  int iEtaHEMax = std::max(hcons->getEtaRange(1).second,1);
+  int iEtaHEMax = std::max(hcons->getEtaRange(1).second, 1);
   int iEtaHFMax = hcons->getEtaRange(2).second;
   int iEtaHOMax = hcons->getEtaRange(3).second;
 

--- a/Validation/HcalHits/src/HcalSimHitsValidation.cc
+++ b/Validation/HcalHits/src/HcalSimHitsValidation.cc
@@ -58,7 +58,7 @@ void HcalSimHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
   // int iphi_bins = (int) (iphi_max - iphi_min);
 
   int iEtaHBMax = hcons->getEtaRange(0).second;
-  int iEtaHEMax = std::max(hcons->getEtaRange(1).second,1);
+  int iEtaHEMax = std::max(hcons->getEtaRange(1).second, 1);
   int iEtaHFMax = hcons->getEtaRange(2).second;
   int iEtaHOMax = hcons->getEtaRange(3).second;
 

--- a/Validation/HcalHits/src/SimG4HcalValidation.cc
+++ b/Validation/HcalHits/src/SimG4HcalValidation.cc
@@ -58,26 +58,22 @@ SimG4HcalValidation::SimG4HcalValidation(const edm::ParameterSet &p)
   if (infolevel > 1)
     produces<PHcalValidInfoJets>(labelJets);
 
-  edm::LogVerbatim("ValidHcal") 
-    << "HcalTestAnalysis:: Initialised as observer of begin/end events and "
-    << "of G4step with Parameter values: \n\tInfoLevel     = " << infolevel 
-    << "\n\thcalOnly      = " << hcalOnly << "\n\tapplySampling = " 
-    << applySampling << "\n\tconeSize      = " << coneSize
-    << "\n\tehitThreshold = " << ehitThreshold << "\n\thhitThreshold = " 
-    << hhitThreshold  << "\n\tttimeLowlim   = " << timeLowlim 
-    << "\n\tttimeUplim    = " << timeUplim << "\n\teta0          = " << eta0
-    << "\n\tphi0          = " << phi0 << "\nLabels (Layer): " << labelLayer 
-    << " (NxN): " << labelNxN << " (Jets): " << labelJets;
+  edm::LogVerbatim("ValidHcal") << "HcalTestAnalysis:: Initialised as observer of begin/end events and "
+                                << "of G4step with Parameter values: \n\tInfoLevel     = " << infolevel
+                                << "\n\thcalOnly      = " << hcalOnly << "\n\tapplySampling = " << applySampling
+                                << "\n\tconeSize      = " << coneSize << "\n\tehitThreshold = " << ehitThreshold
+                                << "\n\thhitThreshold = " << hhitThreshold << "\n\tttimeLowlim   = " << timeLowlim
+                                << "\n\tttimeUplim    = " << timeUplim << "\n\teta0          = " << eta0
+                                << "\n\tphi0          = " << phi0 << "\nLabels (Layer): " << labelLayer
+                                << " (NxN): " << labelNxN << " (Jets): " << labelJets;
 
   init();
 }
 
 SimG4HcalValidation::~SimG4HcalValidation() {
-  edm::LogVerbatim("ValidHcal") 
-    << "\n -------->  Total number of selected entries"
-    << " : " << count << "\nPointers:: JettFinder " << jetf 
-    << ", Numbering Scheme " << org
-    << " and FromDDD " << numberingFromDDD;
+  edm::LogVerbatim("ValidHcal") << "\n -------->  Total number of selected entries"
+                                << " : " << count << "\nPointers:: JettFinder " << jetf << ", Numbering Scheme " << org
+                                << " and FromDDD " << numberingFromDDD;
   if (jetf) {
     edm::LogVerbatim("ValidHcal") << "Delete Jetfinder";
     delete jetf;
@@ -147,7 +143,7 @@ void SimG4HcalValidation::update(const BeginOfJob *job) {
   (*job)()->get<HcalSimNumberingRecord>().get(hdc);
   const HcalDDDSimConstants *hcons = hdc.product();
   edm::LogVerbatim("ValidHcal") << "HcalTestAnalysis:: Initialise "
-				<< "HcalNumberingFromDDD";
+                                << "HcalNumberingFromDDD";
   numberingFromDDD = new HcalNumberingFromDDD(hcons);
 
   // Numbering scheme
@@ -169,13 +165,11 @@ void SimG4HcalValidation::update(const BeginOfRun *run) {
                                    << "Setup";
     } else {
       HCalSD *theCaloSD = dynamic_cast<HCalSD *>(aSD);
-      edm::LogVerbatim("ValidHcal") 
-	<< "SimG4HcalValidation::beginOfRun: Finds SD with name " 
-	<< theCaloSD->GetName() << " in this Setup";
+      edm::LogVerbatim("ValidHcal") << "SimG4HcalValidation::beginOfRun: Finds SD with name " << theCaloSD->GetName()
+                                    << " in this Setup";
       if (org) {
         theCaloSD->setNumberingScheme(org);
-        edm::LogVerbatim("ValidHcal") 
-	  << "SimG4HcalValidation::beginOfRun: set a new numbering scheme";
+        edm::LogVerbatim("ValidHcal") << "SimG4HcalValidation::beginOfRun: set a new numbering scheme";
       }
     }
   } else {
@@ -312,11 +306,9 @@ void SimG4HcalValidation::fill(const EndOfEvent *evt) {
         else if (layer == 0)
           vhitec += e;
         else
-          edm::LogVerbatim("ValidHcal") 
-	    << "SimG4HcalValidation::HitPMT " << subdet << " " 
-	    << (2*zside-1)*etaIndex << " " << phiIndex << " " << layer + 1 
-	    << " R " << pos.rho() << " Phi " << convertRadToDeg(phi)
-	    << " Edep " << e << " Time " << time;
+          edm::LogVerbatim("ValidHcal") << "SimG4HcalValidation::HitPMT " << subdet << " " << (2 * zside - 1) * etaIndex
+                                        << " " << phiIndex << " " << layer + 1 << " R " << pos.rho() << " Phi "
+                                        << convertRadToDeg(phi) << " Edep " << e << " Time " << time;
       } else if (subdet == static_cast<int>(HcalEndcap)) {
         if (etaIndex <= 20) {
           det = "HES";

--- a/Validation/HcalHits/src/SimHitsValidationHcal.cc
+++ b/Validation/HcalHits/src/SimHitsValidationHcal.cc
@@ -13,9 +13,8 @@ SimHitsValidationHcal::SimHitsValidationHcal(const edm::ParameterSet &ps) {
 
   tok_hits_ = consumes<edm::PCaloHitContainer>(edm::InputTag(g4Label_, hcalHits_));
 
-  edm::LogVerbatim("HitsValidationHcal") 
-    << "Module Label: " << g4Label_ << "   Hits: " << hcalHits_ 
-    << " TestNumbering " << testNumber_;
+  edm::LogVerbatim("HitsValidationHcal") << "Module Label: " << g4Label_ << "   Hits: " << hcalHits_
+                                         << " TestNumbering " << testNumber_;
 }
 
 SimHitsValidationHcal::~SimHitsValidationHcal() {}
@@ -44,7 +43,7 @@ void SimHitsValidationHcal::bookHistograms(DQMStore::IBooker &ib, edm::Run const
   int iphi_bins = (int)(iphi_max - iphi_min);
 
   int iEtaHBMax = hcons->getEtaRange(0).second;
-  int iEtaHEMax = std::max(hcons->getEtaRange(1).second,1);
+  int iEtaHEMax = std::max(hcons->getEtaRange(1).second, 1);
   int iEtaHFMax = hcons->getEtaRange(2).second;
   int iEtaHOMax = hcons->getEtaRange(3).second;
 
@@ -78,9 +77,8 @@ void SimHitsValidationHcal::bookHistograms(DQMStore::IBooker &ib, edm::Run const
   // int ieta_bins_HO = (int) (ieta_max_HO - ieta_min_HO);
 
 #ifdef DebugLog
-  edm::LogVerbatim("HitsValidationHcal") 
-    << " Maximum Depths HB:" << maxDepthHB_ << " HE:" << maxDepthHE_
-    << " HO:" << maxDepthHO_ << " HF:" << maxDepthHF_;
+  edm::LogVerbatim("HitsValidationHcal") << " Maximum Depths HB:" << maxDepthHB_ << " HE:" << maxDepthHE_
+                                         << " HO:" << maxDepthHO_ << " HF:" << maxDepthHF_;
 #endif
   std::vector<std::pair<std::string, std::string>> divisions = getHistogramTypes();
 
@@ -151,8 +149,7 @@ void SimHitsValidationHcal::bookHistograms(DQMStore::IBooker &ib, edm::Run const
 
 void SimHitsValidationHcal::analyze(const edm::Event &e, const edm::EventSetup &) {
 #ifdef DebugLog
-  edm::LogVerbatim("HitsValidationHcal") 
-    << "Run = " << e.id().run() << " Event = " << e.id().event();
+  edm::LogVerbatim("HitsValidationHcal") << "Run = " << e.id().run() << " Event = " << e.id().event();
 #endif
   std::vector<PCaloHit> caloHits;
   edm::Handle<edm::PCaloHitContainer> hitsHcal;
@@ -162,8 +159,7 @@ void SimHitsValidationHcal::analyze(const edm::Event &e, const edm::EventSetup &
   if (hitsHcal.isValid())
     getHits = true;
 #ifdef DebugLog
-  edm::LogVerbatim("HitsValidationHcal") 
-    << "HitsValidationHcal.: Input flags Hits " << getHits;
+  edm::LogVerbatim("HitsValidationHcal") << "HitsValidationHcal.: Input flags Hits " << getHits;
 #endif
   if (getHits) {
     caloHits.insert(caloHits.end(), hitsHcal->begin(), hitsHcal->end());
@@ -181,8 +177,7 @@ void SimHitsValidationHcal::analyze(const edm::Event &e, const edm::EventSetup &
       }
     }
 #ifdef DebugLog
-    edm::LogVerbatim("HitsValidationHcal") 
-      << "HitsValidationHcal: Hit buffer " << caloHits.size();
+    edm::LogVerbatim("HitsValidationHcal") << "HitsValidationHcal: Hit buffer " << caloHits.size();
 #endif
     analyzeHits(caloHits);
   }
@@ -246,10 +241,9 @@ void SimHitsValidationHcal::analyzeHits(std::vector<PCaloHit> &hits) {
 
 #ifdef DebugLog
     edm::LogVerbatim("HitsValidationHcal")
-      << "Hit[" << i << "] ID " << std::dec << " " << id << std::dec << " Det "
-      << id.det() << " Sub " << subdet << " depth " << depth << " depthX " << dep
-      << " Eta " << eta << " Phi " << id.iphi() << " E " << energy << " time " << time
-      << " type " << types.first << " " << types.second;
+        << "Hit[" << i << "] ID " << std::dec << " " << id << std::dec << " Det " << id.det() << " Sub " << subdet
+        << " depth " << depth << " depthX " << dep << " Eta " << eta << " Phi " << id.iphi() << " E " << energy
+        << " time " << time << " type " << types.first << " " << types.second;
 #endif
 
     double etax = eta - 0.5;
@@ -302,12 +296,10 @@ void SimHitsValidationHcal::analyzeHits(std::vector<PCaloHit> &hits) {
     }
 
 #ifdef DebugLog
-    edm::LogVerbatim("HitsValidationHcal") 
-      << " energy of tower =" << (*itr).first.first
-      << " in time 25ns is == " << (*itr).second.e25
-      << " in time 25-50ns == " << (*itr).second.e50
-      << " in time 50-100ns == " << (*itr).second.e100
-      << " in time 100-250 ns == " << (*itr).second.e250;
+    edm::LogVerbatim("HitsValidationHcal")
+        << " energy of tower =" << (*itr).first.first << " in time 25ns is == " << (*itr).second.e25
+        << " in time 25-50ns == " << (*itr).second.e50 << " in time 50-100ns == " << (*itr).second.e100
+        << " in time 100-250 ns == " << (*itr).second.e250;
 #endif
   }
 }
@@ -353,11 +345,9 @@ SimHitsValidationHcal::etaRange SimHitsValidationHcal::getLimits(idType type) {
     high = 41;
   }
 #ifdef DebugLog
-  edm::LogVerbatim("HitsValidationHcal") 
-    << "Subdetector:" << type.subdet << " z:" << type.z
-    << " range.first:" << range.first << " and second:" << range.second;
-  edm::LogVerbatim("HitsValidationHcal")
-    << "bins: " << bins << " low:" << low << " high:" << high;
+  edm::LogVerbatim("HitsValidationHcal") << "Subdetector:" << type.subdet << " z:" << type.z
+                                         << " range.first:" << range.first << " and second:" << range.second;
+  edm::LogVerbatim("HitsValidationHcal") << "bins: " << bins << " low:" << low << " high:" << high;
 #endif
   return SimHitsValidationHcal::etaRange(bins, low, high);
 }

--- a/Validation/HcalHits/test/HcalGeomCheck.cc
+++ b/Validation/HcalHits/test/HcalGeomCheck.cc
@@ -38,14 +38,10 @@
 #include "TH1D.h"
 #include "TH2D.h"
 
-class HcalGeomCheck : public edm::one::EDAnalyzer<edm::one::WatchRuns,edm::one::SharedResources> {
-  
+class HcalGeomCheck : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
-  
-  struct hitsinfo{
-    hitsinfo() {
-      phi=eta=energy=time=0.0;
-    }
+  struct hitsinfo {
+    hitsinfo() { phi = eta = energy = time = 0.0; }
     double phi, eta, energy, time;
   };
 
@@ -54,196 +50,186 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-
   void beginJob() override;
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void endRun(edm::Run const&, edm::EventSetup const&) override {}
-  
-private:
 
-  void analyzeHits (int, const std::string&, const std::vector<PCaloHit>&);
-  
+private:
+  void analyzeHits(int, const std::string&, const std::vector<PCaloHit>&);
+
   // ----------member data ---------------------------
-  const std::string                     caloHitSource_;
-  const int                             ietaMin_, ietaMax_, depthMax_;
-  const double                          rmin_, rmax_, zmin_, zmax_;
-  const int                             nbinR_, nbinZ_, verbosity_;
-  const HcalDDDRecConstants*            hcons_;
+  const std::string caloHitSource_;
+  const int ietaMin_, ietaMax_, depthMax_;
+  const double rmin_, rmax_, zmin_, zmax_;
+  const int nbinR_, nbinZ_, verbosity_;
+  const HcalDDDRecConstants* hcons_;
   edm::EDGetTokenT<edm::PCaloHitContainer> tok_hits_;
-  
+
   //histogram related stuff
-  TH2D                                 *h_RZ_;
-  std::map<std::pair<int,int>,TH1D*>    h_phi_;
-  std::map<int,TH1D*>                   h_eta_;
-  std::vector<TH1D*>                    h_E_, h_T_;
+  TH2D* h_RZ_;
+  std::map<std::pair<int, int>, TH1D*> h_phi_;
+  std::map<int, TH1D*> h_eta_;
+  std::vector<TH1D*> h_E_, h_T_;
 };
 
-HcalGeomCheck::HcalGeomCheck(const edm::ParameterSet& iConfig) :
+HcalGeomCheck::HcalGeomCheck(const edm::ParameterSet& iConfig)
+    :
 
-  caloHitSource_(iConfig.getParameter<std::string>("caloHitSource")),
-  ietaMin_(iConfig.getUntrackedParameter<int>("ietaMin",-41)),
-  ietaMax_(iConfig.getUntrackedParameter<int>("ietaMax",41)),
-  depthMax_(iConfig.getUntrackedParameter<int>("depthMax",7)),
-  rmin_(iConfig.getUntrackedParameter<double>("rMin",0.0)),
-  rmax_(iConfig.getUntrackedParameter<double>("rMax",5500.0)),
-  zmin_(iConfig.getUntrackedParameter<double>("zMin",-12500.0)),
-  zmax_(iConfig.getUntrackedParameter<double>("zMax",12500.0)),
-  nbinR_(iConfig.getUntrackedParameter<int>("nBinR",550)),
-  nbinZ_(iConfig.getUntrackedParameter<int>("nBinZ",2500)),
-  verbosity_(iConfig.getUntrackedParameter<int>("verbosity",0)) {
-
+      caloHitSource_(iConfig.getParameter<std::string>("caloHitSource")),
+      ietaMin_(iConfig.getUntrackedParameter<int>("ietaMin", -41)),
+      ietaMax_(iConfig.getUntrackedParameter<int>("ietaMax", 41)),
+      depthMax_(iConfig.getUntrackedParameter<int>("depthMax", 7)),
+      rmin_(iConfig.getUntrackedParameter<double>("rMin", 0.0)),
+      rmax_(iConfig.getUntrackedParameter<double>("rMax", 5500.0)),
+      zmin_(iConfig.getUntrackedParameter<double>("zMin", -12500.0)),
+      zmax_(iConfig.getUntrackedParameter<double>("zMax", 12500.0)),
+      nbinR_(iConfig.getUntrackedParameter<int>("nBinR", 550)),
+      nbinZ_(iConfig.getUntrackedParameter<int>("nBinZ", 2500)),
+      verbosity_(iConfig.getUntrackedParameter<int>("verbosity", 0)) {
   usesResource(TFileService::kSharedResource);
-  tok_hits_ = consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits",caloHitSource_));
+  tok_hits_ = consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", caloHitSource_));
 }
 
 void HcalGeomCheck::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("caloHitSource","HcalHits");
-  desc.addUntracked<int>("ietaMin",-41);
-  desc.addUntracked<int>("ietaMax",41);
-  desc.addUntracked<int>("depthMax",7);
-  desc.addUntracked<double>("rMin",0.0);
-  desc.addUntracked<double>("rMax",5500.0);
-  desc.addUntracked<double>("zMin",-12500.0);
-  desc.addUntracked<double>("zMax",12500.0);
-  desc.addUntracked<int>("nBinR",550);
-  desc.addUntracked<int>("nBinZ",250);
-  desc.addUntracked<int>("verbosity",0);
-  descriptions.add("hcalGeomCheck",desc);
+  desc.add<std::string>("caloHitSource", "HcalHits");
+  desc.addUntracked<int>("ietaMin", -41);
+  desc.addUntracked<int>("ietaMax", 41);
+  desc.addUntracked<int>("depthMax", 7);
+  desc.addUntracked<double>("rMin", 0.0);
+  desc.addUntracked<double>("rMax", 5500.0);
+  desc.addUntracked<double>("zMin", -12500.0);
+  desc.addUntracked<double>("zMax", 12500.0);
+  desc.addUntracked<int>("nBinR", 550);
+  desc.addUntracked<int>("nBinZ", 250);
+  desc.addUntracked<int>("verbosity", 0);
+  descriptions.add("hcalGeomCheck", desc);
 }
 
-void HcalGeomCheck::analyze(const edm::Event& iEvent, 
-			    const edm::EventSetup& iSetup) {
-
-
+void HcalGeomCheck::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Now the hits
   edm::Handle<edm::PCaloHitContainer> theCaloHitContainer;
   iEvent.getByToken(tok_hits_, theCaloHitContainer);
   if (theCaloHitContainer.isValid()) {
-    if (verbosity_>0) 
-      edm::LogVerbatim("HcalValidation") << " PcalohitItr = " 
-					 << theCaloHitContainer->size();
-    
+    if (verbosity_ > 0)
+      edm::LogVerbatim("HcalValidation") << " PcalohitItr = " << theCaloHitContainer->size();
+
     //Merge hits for the same DetID
-    std::map<HcalDetId,hitsinfo> map_hits;
+    std::map<HcalDetId, hitsinfo> map_hits;
     unsigned int nused(0);
-    for (auto const& hit : *(theCaloHitContainer.product()) ) {
+    for (auto const& hit : *(theCaloHitContainer.product())) {
       unsigned int id = hit.id();
-      HcalDetId detId = HcalHitRelabeller::relabel(id,hcons_);
-      double energy   = hit.energy();
-      double time     = hit.time();
-      int subdet      = detId.subdet();
-      int ieta        = detId.ieta();
-      int iphi        = detId.iphi();
-      int depth       = detId.depth();
-      std::pair<double,double> etaphi = hcons_->getEtaPhi(subdet,ieta,iphi);
-      double                   rz = hcons_->getRZ(subdet,ieta,depth);
-      if (verbosity_>2) edm::LogVerbatim("HcalValidation") 
-			  << "i/p " << subdet << ":" << ieta << ":" << iphi 
-			  << ":" << depth <<" o/p " << etaphi.first << ":" 
-			  << etaphi.second << ":" << rz;
-      HepGeom::Point3D<float> gcoord = 
-	HepGeom::Point3D<float>(rz*cos(etaphi.second)/cosh(etaphi.first),
-				rz*sin(etaphi.second)/cosh(etaphi.first),
-				rz*tanh(etaphi.first));
+      HcalDetId detId = HcalHitRelabeller::relabel(id, hcons_);
+      double energy = hit.energy();
+      double time = hit.time();
+      int subdet = detId.subdet();
+      int ieta = detId.ieta();
+      int iphi = detId.iphi();
+      int depth = detId.depth();
+      std::pair<double, double> etaphi = hcons_->getEtaPhi(subdet, ieta, iphi);
+      double rz = hcons_->getRZ(subdet, ieta, depth);
+      if (verbosity_ > 2)
+        edm::LogVerbatim("HcalValidation") << "i/p " << subdet << ":" << ieta << ":" << iphi << ":" << depth << " o/p "
+                                           << etaphi.first << ":" << etaphi.second << ":" << rz;
+      HepGeom::Point3D<float> gcoord = HepGeom::Point3D<float>(rz * cos(etaphi.second) / cosh(etaphi.first),
+                                                               rz * sin(etaphi.second) / cosh(etaphi.first),
+                                                               rz * tanh(etaphi.first));
       nused++;
-      double tof = (gcoord.mag()*CLHEP::mm)/CLHEP::c_light; 
-      if (verbosity_>1) edm::LogVerbatim("HcalValidation") 
-			  << "Detector " << subdet << " ieta = " << ieta
-			  << " iphi = " << iphi << " depth = "  << depth
-			  << " positon = " << gcoord << " energy = "  << energy
-			  << " time = " << time << ":" << tof;
+      double tof = (gcoord.mag() * CLHEP::mm) / CLHEP::c_light;
+      if (verbosity_ > 1)
+        edm::LogVerbatim("HcalValidation")
+            << "Detector " << subdet << " ieta = " << ieta << " iphi = " << iphi << " depth = " << depth
+            << " positon = " << gcoord << " energy = " << energy << " time = " << time << ":" << tof;
       time -= tof;
-      if (time < 0) time = 0;
-      hitsinfo   hinfo;
+      if (time < 0)
+        time = 0;
+      hitsinfo hinfo;
       if (map_hits.count(detId) != 0) {
-	hinfo = map_hits[detId];
+        hinfo = map_hits[detId];
       } else {
-	hinfo.phi   = gcoord.getPhi();
-	hinfo.eta   = gcoord.getEta();
-	hinfo.time  = time;
+        hinfo.phi = gcoord.getPhi();
+        hinfo.eta = gcoord.getEta();
+        hinfo.time = time;
       }
       hinfo.energy += energy;
-      map_hits[detId]  = hinfo; 
+      map_hits[detId] = hinfo;
 
-      h_RZ_->Fill(gcoord.z(),gcoord.rho());
+      h_RZ_->Fill(gcoord.z(), gcoord.rho());
     }
 
     //Fill in histograms
     for (auto const& hit : map_hits) {
       hitsinfo hinfo = hit.second;
-      int subdet     = hit.first.subdet();
+      int subdet = hit.first.subdet();
       if (subdet > 0 && subdet < static_cast<int>(h_E_.size())) {
-	int depth = hit.first.depth();
-	int ieta  = hit.first.ieta();
-	int iphi  = hit.first.iphi();
-	if (verbosity_>1) edm::LogVerbatim("HGCalValidation") 
-			    << " ----------------------   eta = " << ieta 
-			    << ":" << hinfo.eta << " phi = " << iphi << ":"
-			    << hinfo.phi << " depth = " << depth << " E = "
-			    << hinfo.energy << " T = " << hinfo.time;
-	h_E_[subdet]->Fill(hinfo.energy);
-	h_T_[subdet]->Fill(hinfo.time);
-	auto itr1 = h_phi_.find(std::pair<int,int>(ieta,depth));
-	if (itr1 != h_phi_.end()) itr1->second->Fill(iphi);
-	auto itr2 = h_eta_.find(depth);
-	if (itr2 != h_eta_.end()) itr2->second->Fill(ieta);
+        int depth = hit.first.depth();
+        int ieta = hit.first.ieta();
+        int iphi = hit.first.iphi();
+        if (verbosity_ > 1)
+          edm::LogVerbatim("HGCalValidation")
+              << " ----------------------   eta = " << ieta << ":" << hinfo.eta << " phi = " << iphi << ":" << hinfo.phi
+              << " depth = " << depth << " E = " << hinfo.energy << " T = " << hinfo.time;
+        h_E_[subdet]->Fill(hinfo.energy);
+        h_T_[subdet]->Fill(hinfo.time);
+        auto itr1 = h_phi_.find(std::pair<int, int>(ieta, depth));
+        if (itr1 != h_phi_.end())
+          itr1->second->Fill(iphi);
+        auto itr2 = h_eta_.find(depth);
+        if (itr2 != h_eta_.end())
+          itr2->second->Fill(ieta);
       }
     }
-  } else if (verbosity_>0) {
+  } else if (verbosity_ > 0) {
     edm::LogVerbatim("HcalValidation") << "PCaloHitContainer does not "
-				       << "exist for HCAL";
+                                       << "exist for HCAL";
   }
 }
 
 // ------------ method called when starting to processes a run  ------------
-void HcalGeomCheck::beginRun(const edm::Run&, 
-			     const edm::EventSetup& iSetup) {
+void HcalGeomCheck::beginRun(const edm::Run&, const edm::EventSetup& iSetup) {
   edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-  iSetup.get<HcalRecNumberingRecord>().get( pHRNDC );
-  hcons_  = &(*pHRNDC);
-  if (verbosity_>0) edm::LogVerbatim("HcalValidation") 
-		      << "Obtain HcalDDDRecConstants from Event Setup";
+  iSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
+  hcons_ = &(*pHRNDC);
+  if (verbosity_ > 0)
+    edm::LogVerbatim("HcalValidation") << "Obtain HcalDDDRecConstants from Event Setup";
 }
 
 void HcalGeomCheck::beginJob() {
-
-  if (verbosity_>2) edm::LogVerbatim("HcalValidation") 
-		      << "HcalGeomCheck:: Enter beginJob";
+  if (verbosity_ > 2)
+    edm::LogVerbatim("HcalValidation") << "HcalGeomCheck:: Enter beginJob";
   edm::Service<TFileService> fs;
-  h_RZ_ = fs->make<TH2D>("RZ","R vs Z",nbinZ_,zmin_,zmax_,nbinR_,rmin_,rmax_);
-  if (verbosity_>2) edm::LogVerbatim("HcalValidation") 
-		      << "HcalGeomCheck: booked scatterplot RZ";
+  h_RZ_ = fs->make<TH2D>("RZ", "R vs Z", nbinZ_, zmin_, zmax_, nbinR_, rmin_, rmax_);
+  if (verbosity_ > 2)
+    edm::LogVerbatim("HcalValidation") << "HcalGeomCheck: booked scatterplot RZ";
   char name[20], title[100];
-  for (int depth=1; depth<depthMax_; ++depth) {
-    for (int ieta=ietaMin_; ieta <= ietaMax_; ++ieta) {
-      sprintf (name, "phi%d%d", ieta, depth);
-      sprintf (title, "i#phi (i#eta = %d, depth = %d)", ieta, depth);
-      h_phi_[std::pair<int,int>(ieta,depth)] = 
-	fs->make<TH1D>(name,title,400,-20,380);
-      if (verbosity_>2) edm::LogVerbatim("HcalValidation") 
-			  << "HcalGeomCheck: books " << title;
+  for (int depth = 1; depth < depthMax_; ++depth) {
+    for (int ieta = ietaMin_; ieta <= ietaMax_; ++ieta) {
+      sprintf(name, "phi%d%d", ieta, depth);
+      sprintf(title, "i#phi (i#eta = %d, depth = %d)", ieta, depth);
+      h_phi_[std::pair<int, int>(ieta, depth)] = fs->make<TH1D>(name, title, 400, -20, 380);
+      if (verbosity_ > 2)
+        edm::LogVerbatim("HcalValidation") << "HcalGeomCheck: books " << title;
     }
-    sprintf (name, "eta%d", depth);
-    sprintf (title, "i#eta (depth = %d)", depth);
-    h_eta_[depth] = fs->make<TH1D>(name,title,100,-50,50);
-    if (verbosity_>2) edm::LogVerbatim("HcalValidation") 
-			<< "HcalGeomCheck: books " << title;
+    sprintf(name, "eta%d", depth);
+    sprintf(title, "i#eta (depth = %d)", depth);
+    h_eta_[depth] = fs->make<TH1D>(name, title, 100, -50, 50);
+    if (verbosity_ > 2)
+      edm::LogVerbatim("HcalValidation") << "HcalGeomCheck: books " << title;
   }
 
-  std::vector<std::string> dets = {"HCAL","HB","HE","HF","HO"};
-  for (unsigned int ih=0; ih<dets.size(); ++ih) {
-    sprintf (name,  "E_%s", dets[ih].c_str());
-    sprintf (title, "Energy deposit in %s (MeV)", dets[ih].c_str());
-    h_E_.emplace_back(fs->make<TH1D>(name, title, 1000,0.0,1.0));
-    if (verbosity_>2) edm::LogVerbatim("HcalValidation") 
-			<< "HcalGeomCheck: books " << title;
-    sprintf (name,  "T_%s", dets[ih].c_str());
-    sprintf (title, "Time of hit in %s (ns)", dets[ih].c_str());
-    h_T_.emplace_back(fs->make<TH1D>(name, title,1000,0.0,200.0));
-    if (verbosity_>2) edm::LogVerbatim("HcalValidation") 
-			<< "HcalGeomCheck: books " << title;
+  std::vector<std::string> dets = {"HCAL", "HB", "HE", "HF", "HO"};
+  for (unsigned int ih = 0; ih < dets.size(); ++ih) {
+    sprintf(name, "E_%s", dets[ih].c_str());
+    sprintf(title, "Energy deposit in %s (MeV)", dets[ih].c_str());
+    h_E_.emplace_back(fs->make<TH1D>(name, title, 1000, 0.0, 1.0));
+    if (verbosity_ > 2)
+      edm::LogVerbatim("HcalValidation") << "HcalGeomCheck: books " << title;
+    sprintf(name, "T_%s", dets[ih].c_str());
+    sprintf(title, "Time of hit in %s (ns)", dets[ih].c_str());
+    h_T_.emplace_back(fs->make<TH1D>(name, title, 1000, 0.0, 200.0));
+    if (verbosity_ > 2)
+      edm::LogVerbatim("HcalValidation") << "HcalGeomCheck: books " << title;
   }
 }
 

--- a/Validation/HcalRecHits/test/HcalDumpHits.cc
+++ b/Validation/HcalRecHits/test/HcalDumpHits.cc
@@ -28,16 +28,13 @@
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 
 class HcalDumpHits : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
-
 public:
-
   explicit HcalDumpHits(const edm::ParameterSet&);
   ~HcalDumpHits() override {}
-  
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-
   void beginJob() override {}
   void endJob() override {}
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
@@ -46,115 +43,102 @@ private:
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<edm::PCaloHitContainer> simHitSource_;
-  const edm::EDGetTokenT<QIE11DigiCollection>    hbheDigiSource_; 
-  const edm::EDGetTokenT<QIE10DigiCollection>    hfDigiSource_; 
-  const edm::EDGetTokenT<HODigiCollection>       hoDigiSource_;
-  const edm::EDGetTokenT<HBHERecHitCollection>   hbheRecHitSource_;
-  const edm::EDGetTokenT<HFRecHitCollection>     hfRecHitSource_;
-  const edm::EDGetTokenT<HORecHitCollection>     hoRecHitSource_;
-  const HcalDDDRecConstants*                     hcons_;
+  const edm::EDGetTokenT<QIE11DigiCollection> hbheDigiSource_;
+  const edm::EDGetTokenT<QIE10DigiCollection> hfDigiSource_;
+  const edm::EDGetTokenT<HODigiCollection> hoDigiSource_;
+  const edm::EDGetTokenT<HBHERecHitCollection> hbheRecHitSource_;
+  const edm::EDGetTokenT<HFRecHitCollection> hfRecHitSource_;
+  const edm::EDGetTokenT<HORecHitCollection> hoRecHitSource_;
+  const HcalDDDRecConstants* hcons_;
 };
 
-HcalDumpHits::HcalDumpHits(const edm::ParameterSet& iConfig) :
-  simHitSource_(consumes<edm::PCaloHitContainer>(iConfig.getParameter<edm::InputTag>("simHitSource"))),
-  hbheDigiSource_(consumes<QIE11DigiCollection>(iConfig.getParameter<edm::InputTag>("hbheDigiSource"))),
-  hfDigiSource_(consumes<QIE10DigiCollection>(iConfig.getParameter<edm::InputTag>("hfDigiSource"))),
-  hoDigiSource_(consumes<HODigiCollection>(iConfig.getParameter<edm::InputTag>("hoDigiSource"))),
-  hbheRecHitSource_(consumes<HBHERecHitCollection>(iConfig.getParameter<edm::InputTag>("hbheRecHitSource"))),
-  hfRecHitSource_(consumes<HFRecHitCollection>(iConfig.getParameter<edm::InputTag>("hfRecHitSource"))),
-  hoRecHitSource_(consumes<HORecHitCollection>(iConfig.getParameter<edm::InputTag>("hoRecHitSource"))),
-  hcons_(nullptr) {
-}
+HcalDumpHits::HcalDumpHits(const edm::ParameterSet& iConfig)
+    : simHitSource_(consumes<edm::PCaloHitContainer>(iConfig.getParameter<edm::InputTag>("simHitSource"))),
+      hbheDigiSource_(consumes<QIE11DigiCollection>(iConfig.getParameter<edm::InputTag>("hbheDigiSource"))),
+      hfDigiSource_(consumes<QIE10DigiCollection>(iConfig.getParameter<edm::InputTag>("hfDigiSource"))),
+      hoDigiSource_(consumes<HODigiCollection>(iConfig.getParameter<edm::InputTag>("hoDigiSource"))),
+      hbheRecHitSource_(consumes<HBHERecHitCollection>(iConfig.getParameter<edm::InputTag>("hbheRecHitSource"))),
+      hfRecHitSource_(consumes<HFRecHitCollection>(iConfig.getParameter<edm::InputTag>("hfRecHitSource"))),
+      hoRecHitSource_(consumes<HORecHitCollection>(iConfig.getParameter<edm::InputTag>("hoRecHitSource"))),
+      hcons_(nullptr) {}
 
 void HcalDumpHits::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("simHitSource",edm::InputTag("g4SimHits","HcalHits"));
-  desc.add<edm::InputTag>("hbheDigiSource",edm::InputTag("hcalDigis"));
-  desc.add<edm::InputTag>("hfDigiSource",edm::InputTag("hcalDigis"));
-  desc.add<edm::InputTag>("hoDigiSource",edm::InputTag("hcalDigis"));
-  desc.add<edm::InputTag>("hbheRecHitSource",edm::InputTag("hbhereco"));
-  desc.add<edm::InputTag>("hfRecHitSource",edm::InputTag("hfreco"));
-  desc.add<edm::InputTag>("hoRecHitSource",edm::InputTag("horeco"));
-  descriptions.add("hcalDumpHits",desc);
+  desc.add<edm::InputTag>("simHitSource", edm::InputTag("g4SimHits", "HcalHits"));
+  desc.add<edm::InputTag>("hbheDigiSource", edm::InputTag("hcalDigis"));
+  desc.add<edm::InputTag>("hfDigiSource", edm::InputTag("hcalDigis"));
+  desc.add<edm::InputTag>("hoDigiSource", edm::InputTag("hcalDigis"));
+  desc.add<edm::InputTag>("hbheRecHitSource", edm::InputTag("hbhereco"));
+  desc.add<edm::InputTag>("hfRecHitSource", edm::InputTag("hfreco"));
+  desc.add<edm::InputTag>("hoRecHitSource", edm::InputTag("horeco"));
+  descriptions.add("hcalDumpHits", desc);
 }
 
 void HcalDumpHits::beginRun(const edm::Run&, const edm::EventSetup& iSetup) {
-  
   edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-  iSetup.get<HcalRecNumberingRecord>().get( pHRNDC );
-  hcons_  = &(*pHRNDC);
+  iSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
+  hcons_ = &(*pHRNDC);
 }
 
-void HcalDumpHits::analyze(const edm::Event& iEvent, const edm::EventSetup&) { 
-
+void HcalDumpHits::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
   // first SimHits
   edm::Handle<edm::PCaloHitContainer> theCaloHitContainer;
   iEvent.getByToken(simHitSource_, theCaloHitContainer);
   if (theCaloHitContainer.isValid()) {
-    edm::LogVerbatim("HcalValidation")
-      << theCaloHitContainer->size() << " SimHits in HCAL";
+    edm::LogVerbatim("HcalValidation") << theCaloHitContainer->size() << " SimHits in HCAL";
     unsigned int k(0);
-    for (auto const& hit : *(theCaloHitContainer.product()) ) {
+    for (auto const& hit : *(theCaloHitContainer.product())) {
       unsigned int id = hit.id();
-      HcalDetId hid = HcalHitRelabeller::relabel(id,hcons_);
-      edm::LogVerbatim("HcalValidation") 
-	<< "[" << k << "] " << hid << " E " << hit.energy() << " T " 
-	<< hit.time();
+      HcalDetId hid = HcalHitRelabeller::relabel(id, hcons_);
+      edm::LogVerbatim("HcalValidation") << "[" << k << "] " << hid << " E " << hit.energy() << " T " << hit.time();
       ++k;
     }
   }
 
   // Digis (HBHE/HF/HO)
-  edm::Handle<QIE11DigiCollection>  hbheDigiCollection;
+  edm::Handle<QIE11DigiCollection> hbheDigiCollection;
   iEvent.getByToken(hbheDigiSource_, hbheDigiCollection);
   if (hbheDigiCollection.isValid()) {
-    edm::LogVerbatim("HcalValidation")
-      << hbheDigiCollection->size() << " Digis for HB/HE";
+    edm::LogVerbatim("HcalValidation") << hbheDigiCollection->size() << " Digis for HB/HE";
     unsigned int k(0);
-    for (auto const& it : *(hbheDigiCollection.product()) ) {
+    for (auto const& it : *(hbheDigiCollection.product())) {
       QIE11DataFrame hit(it);
       std::ostringstream ost;
-      ost << "[" << k << "] " << HcalDetId(hit.detid()) << " with " 
-	  << hit.size() << " words:";
+      ost << "[" << k << "] " << HcalDetId(hit.detid()) << " with " << hit.size() << " words:";
       unsigned int k1(0);
-      for (auto itr = hit.begin(); itr !=hit.end(); ++itr, ++k1)
-	ost << " [" << k1 << "] " << (*itr);
-      edm::LogVerbatim("HcalValidation")  << ost.str();
-      ++k;
-    }
-  }
-  edm::Handle<QIE10DigiCollection>  hfDigiCollection;
-  iEvent.getByToken(hfDigiSource_, hfDigiCollection);
-  if (hfDigiCollection.isValid()) {
-    edm::LogVerbatim("HcalValidation")
-      << hfDigiCollection->size() << " Digis for HF";
-    unsigned int k(0);
-    for (auto const& it : *(hfDigiCollection.product()) ) {
-      QIE10DataFrame hit(it);
-      std::ostringstream ost;
-      ost << "[" << k << "] " << HcalDetId(hit.detid()) << " with " 
-	  << hit.size() << " words ";
-      unsigned int k1(0);
-      for (auto itr = hit.begin(); itr !=hit.end(); ++itr, ++k1)
-	ost << " [" << k1 << "] " << (*itr);
+      for (auto itr = hit.begin(); itr != hit.end(); ++itr, ++k1)
+        ost << " [" << k1 << "] " << (*itr);
       edm::LogVerbatim("HcalValidation") << ost.str();
       ++k;
     }
   }
-  edm::Handle<HODigiCollection>  hoDigiCollection;
+  edm::Handle<QIE10DigiCollection> hfDigiCollection;
+  iEvent.getByToken(hfDigiSource_, hfDigiCollection);
+  if (hfDigiCollection.isValid()) {
+    edm::LogVerbatim("HcalValidation") << hfDigiCollection->size() << " Digis for HF";
+    unsigned int k(0);
+    for (auto const& it : *(hfDigiCollection.product())) {
+      QIE10DataFrame hit(it);
+      std::ostringstream ost;
+      ost << "[" << k << "] " << HcalDetId(hit.detid()) << " with " << hit.size() << " words ";
+      unsigned int k1(0);
+      for (auto itr = hit.begin(); itr != hit.end(); ++itr, ++k1)
+        ost << " [" << k1 << "] " << (*itr);
+      edm::LogVerbatim("HcalValidation") << ost.str();
+      ++k;
+    }
+  }
+  edm::Handle<HODigiCollection> hoDigiCollection;
   iEvent.getByToken(hoDigiSource_, hoDigiCollection);
   if (hoDigiCollection.isValid()) {
-    edm::LogVerbatim("HcalValidation") 
-      << hoDigiCollection->size() << " Digis for HO";
+    edm::LogVerbatim("HcalValidation") << hoDigiCollection->size() << " Digis for HO";
     unsigned int k(0);
-    for (auto const& it : *(hoDigiCollection.product()) ) {
+    for (auto const& it : *(hoDigiCollection.product())) {
       HODataFrame hit(it);
       std::ostringstream ost;
-      ost << "[" << k << "] " << HcalDetId(hit.id()) << " with " 
-	  << hit.size() << " words ";
+      ost << "[" << k << "] " << HcalDetId(hit.id()) << " with " << hit.size() << " words ";
       for (int k1 = 0; k1 < hit.size(); ++k1)
-	ost << " [" << k1 << "] " << hit.sample(k1);
+        ost << " [" << k1 << "] " << hit.sample(k1);
       edm::LogVerbatim("HcalValidation") << ost.str();
       ++k;
     }
@@ -164,10 +148,9 @@ void HcalDumpHits::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
   edm::Handle<HBHERecHitCollection> hbhecoll;
   iEvent.getByToken(hbheRecHitSource_, hbhecoll);
   if (hbhecoll.isValid()) {
-    edm::LogVerbatim("HcalValidation") 
-      << hbhecoll->size() << " RecHits for HB/HE";
+    edm::LogVerbatim("HcalValidation") << hbhecoll->size() << " RecHits for HB/HE";
     unsigned int k(0);
-    for (const auto & it : *(hbhecoll.product())) {
+    for (const auto& it : *(hbhecoll.product())) {
       HBHERecHit hit(it);
       edm::LogVerbatim("HcalValidation") << "[" << k << "] = " << hit;
       ++k;
@@ -176,10 +159,9 @@ void HcalDumpHits::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
   edm::Handle<HFRecHitCollection> hfcoll;
   iEvent.getByToken(hfRecHitSource_, hfcoll);
   if (hfcoll.isValid()) {
-    edm::LogVerbatim("HcalValidation") 
-      << hfcoll->size() << " RecHits for HF";
+    edm::LogVerbatim("HcalValidation") << hfcoll->size() << " RecHits for HF";
     unsigned int k(0);
-    for (const auto & it : *(hfcoll.product())) {
+    for (const auto& it : *(hfcoll.product())) {
       HFRecHit hit(it);
       edm::LogVerbatim("HcalValidation") << "[" << k << "] = " << hit;
       ++k;
@@ -188,20 +170,18 @@ void HcalDumpHits::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
   edm::Handle<HORecHitCollection> hocoll;
   iEvent.getByToken(hoRecHitSource_, hocoll);
   if (hocoll.isValid()) {
-    edm::LogVerbatim("HcalValidation") 
-      << hocoll->size() << " RecHits for HO";
+    edm::LogVerbatim("HcalValidation") << hocoll->size() << " RecHits for HO";
     unsigned int k(0);
-    for (const auto & it : *(hocoll.product())) {
+    for (const auto& it : *(hocoll.product())) {
       HORecHit hit(it);
       edm::LogVerbatim("HcalValidation") << "[" << k << "] = " << hit;
       ++k;
     }
   }
- }
+}
 
 //define this as a plug-in
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 
 DEFINE_FWK_MODULE(HcalDumpHits);
-

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -1831,7 +1831,7 @@ void PhotonValidator::bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&
   p_eResVsNVtx_[2][1] =
       iBooker.bookProfile(histname + "unconvEndcap",
                           "Uncoverted photons  E/E_{true}  vs N_{vtx}: Endcap;  N_{vtx}; E}/E_{true} ",
-                         2080,
+                          2080,
                           -0.5,
                           199.5,
                           resBin,


### PR DESCRIPTION

Applying code-format for CMSSW category dqm.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/404//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


