### PR TITLE
Running code-format for dqm-generators

### DIFF
--- a/Validation/EventGenerator/plugins/TauValidation.cc
+++ b/Validation/EventGenerator/plugins/TauValidation.cc
@@ -680,14 +680,12 @@ void TauValidation::spinEffectsWHpm(
         TauSpinEffectsW_X->Fill(energy, weight);
       else if (abs(mother) == 37)
         TauSpinEffectsHpm_X->Fill(energy, weight);
-    }
-    else if (decay == TauDecay::MODE_MUON) {
+    } else if (decay == TauDecay::MODE_MUON) {
       if (abs(mother) == 24)
         TauSpinEffectsW_muX->Fill(energy, weight);
       else if (abs(mother) == 37)
         TauSpinEffectsHpm_muX->Fill(energy, weight);
-    }
-    else if (decay == TauDecay::MODE_ELECTRON) {
+    } else if (decay == TauDecay::MODE_ELECTRON) {
       if (abs(mother) == 24)
         TauSpinEffectsW_eX->Fill(energy, weight);
       else if (abs(mother) == 37)
@@ -700,8 +698,7 @@ void TauValidation::spinEffectsWHpm(
       if (abs(part.at(i)->pdgId()) == PdtPdgMini::pi_plus) {
         pi += LV;
         rho += LV;
-      }
-      else if (abs(part.at(i)->pdgId()) == PdtPdgMini::pi0) {
+      } else if (abs(part.at(i)->pdgId()) == PdtPdgMini::pi0) {
         rho += LV;
       }
     }
@@ -718,8 +715,7 @@ void TauValidation::spinEffectsWHpm(
         pi_p += LV;
         a1 += LV;
         nplus++;
-      }
-      else if (part.at(i)->pdgId() == PdtPdgMini::pi_minus) {
+      } else if (part.at(i)->pdgId() == PdtPdgMini::pi_minus) {
         pi_m += LV;
         a1 += LV;
         nminus++;

--- a/Validation/EventGenerator/src/HepMCValidationHelper.cc
+++ b/Validation/EventGenerator/src/HepMCValidationHelper.cc
@@ -220,9 +220,9 @@ namespace HepMCValidationHelper {
             marked = true;
             break;
           }
-	}
-	if (!marked)
-	  forIsolation.push_back(*iiso);
+        }
+        if (!marked)
+          forIsolation.push_back(*iiso);
       }
       //no compute isolation wrt the status 2 tau direction
       double sumIso = 0;


### PR DESCRIPTION

Applying code-format for CMSSW category dqm,generators.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/406//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


