### PR TITLE
Running code-format for generators

### DIFF
--- a/GeneratorInterface/GenFilters/interface/HTXSFilter.h
+++ b/GeneratorInterface/GenFilters/interface/HTXSFilter.h
@@ -4,7 +4,7 @@
 //
 // Package:    HTXSFilter
 // Class:      HTXSFilter
-// 
+//
 /**\class HTXSFilter HTXSFilter.cc user/HTXSFilter/plugins/HTXSFilter.cc
 
  Description: [one line class summary]
@@ -17,7 +17,6 @@
 //         Created:  Fri, 10 May 2019 14:30:15 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -41,16 +40,16 @@ namespace edm {
 }
 
 class HTXSFilter : public edm::global::EDFilter<> {
-   public:
-      explicit HTXSFilter(const edm::ParameterSet&);
-      ~HTXSFilter() override;
+public:
+  explicit HTXSFilter(const edm::ParameterSet&);
+  ~HTXSFilter() override;
 
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-      bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-   private:
-      // ----------member data ---------------------------
-      
-       const edm::EDGetTokenT<HTXS::HiggsClassification> token_;
-       const std::vector<int> htxs_flags;
+private:
+  // ----------member data ---------------------------
+
+  const edm::EDGetTokenT<HTXS::HiggsClassification> token_;
+  const std::vector<int> htxs_flags;
 };
 #endif

--- a/GeneratorInterface/GenFilters/src/HTXSFilter.cc
+++ b/GeneratorInterface/GenFilters/src/HTXSFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HTXSFilter
 // Class:      HTXSFilter
-// 
+//
 /**\class HTXSFilter HTXSFilter.cc user/HTXSFilter/plugins/HTXSFilter.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Fri, 10 May 2019 14:30:15 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -32,43 +31,34 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
 
+HTXSFilter::HTXSFilter(const edm::ParameterSet& iConfig)
+    : token_(consumes<HTXS::HiggsClassification>(edm::InputTag("rivetProducerHTXS", "HiggsClassification"))),
+      htxs_flags(iConfig.getUntrackedParameter("htxs_flags", std::vector<int>())) {}
 
-HTXSFilter::HTXSFilter(const edm::ParameterSet& iConfig) :
-token_(consumes<HTXS::HiggsClassification>(edm::InputTag("rivetProducerHTXS", "HiggsClassification"))),
-htxs_flags(iConfig.getUntrackedParameter("htxs_flags",std::vector <int> ()))
-{
-
+HTXSFilter::~HTXSFilter() {
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
-
-HTXSFilter::~HTXSFilter()
-{
- 
-   // do anything here that needs to be done at destruction time
-   // (e.g. close files, deallocate resources etc.)
-
-}
-
 
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool HTXSFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-   using namespace edm;
-   Handle<HTXS::HiggsClassification> cat;
-   iEvent.getByToken(token_, cat);
-   if(htxs_flags.empty()){
-      edm::LogInfo ("HTXSFilter") << "Selection of HTXS flags to filter is empty. Filtering will not be applied." << std::endl;
-      return true;
-   }
-   if(std::find(htxs_flags.begin(), htxs_flags.end(), cat->stage1_1_cat_pTjet30GeV) != htxs_flags.end()) {
-      return true;
-   } else {
-      return false;
-   }
+bool HTXSFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  using namespace edm;
+  Handle<HTXS::HiggsClassification> cat;
+  iEvent.getByToken(token_, cat);
+  if (htxs_flags.empty()) {
+    edm::LogInfo("HTXSFilter") << "Selection of HTXS flags to filter is empty. Filtering will not be applied."
+                               << std::endl;
+    return true;
+  }
+  if (std::find(htxs_flags.begin(), htxs_flags.end(), cat->stage1_1_cat_pTjet30GeV) != htxs_flags.end()) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 //define this as a plug-in

--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -2,11 +2,8 @@
 Marco A. Harrendorf
 **/
 
-
 #ifndef GeneratorInterface_Herwig7Interface_Herwig7Interface_h
 #define GeneratorInterface_Herwig7Interface_Herwig7Interface_h
-
-
 
 #include <memory>
 #include <string>
@@ -28,76 +25,60 @@ Marco A. Harrendorf
 
 namespace ThePEG {
 
-  template<> struct HepMCTraits<HepMC::GenEvent> :
-                public HepMCTraitsBase<
-    HepMC::GenEvent, HepMC::GenParticle,
-    HepMC::GenVertex, HepMC::Polarization,
-    HepMC::PdfInfo> {};
+  template <>
+  struct HepMCTraits<HepMC::GenEvent>
+      : public HepMCTraitsBase<HepMC::GenEvent, HepMC::GenParticle, HepMC::GenVertex, HepMC::Polarization, HepMC::PdfInfo> {
+  };
 
-}
+}  // namespace ThePEG
 
 namespace CLHEP {
   class HepRandomEngine;
 }
 
 class Herwig7Interface {
-    public:
-	Herwig7Interface(const edm::ParameterSet &params);
-	~Herwig7Interface() noexcept;
+public:
+  Herwig7Interface(const edm::ParameterSet &params);
+  ~Herwig7Interface() noexcept;
 
-        void setPEGRandomEngine(CLHEP::HepRandomEngine*);
+  void setPEGRandomEngine(CLHEP::HepRandomEngine *);
 
-	ThePEG::EGPtr				eg_;
+  ThePEG::EGPtr eg_;
 
+protected:
+  void initRepository(const edm::ParameterSet &params);
+  bool initGenerator();
+  void flushRandomNumberGenerator();
 
+  static std::auto_ptr<HepMC::GenEvent> convert(const ThePEG::EventPtr &event);
 
-    protected:
-	void initRepository(const edm::ParameterSet &params);
-	bool initGenerator();
-	void flushRandomNumberGenerator();
+  static double pthat(const ThePEG::EventPtr &event);
 
-	static std::auto_ptr<HepMC::GenEvent>
-				convert(const ThePEG::EventPtr &event);
+  std::auto_ptr<HepMC::IO_BaseClass> iobc_;
 
-	static double pthat(const ThePEG::EventPtr &event);
+  // HerwigUi contains settings piped to Herwig7
+  std::shared_ptr<Herwig::HerwigUIProvider> HwUI_;
 
-	
-
-	std::auto_ptr<HepMC::IO_BaseClass>	iobc_;
-
-	// HerwigUi contains settings piped to Herwig7
-	std::shared_ptr<Herwig::HerwigUIProvider> HwUI_;
-
-	/**
+  /**
         * Function calls Herwig event generator via API
 	*
 	* According to the run mode different steps of event generation are done
 	**/
-	void callHerwigGenerator();
+  void callHerwigGenerator();
 
+  // The Inputfile ist created according to the parameter set
+  void createInputFile(const edm::ParameterSet &params);
 
-	// The Inputfile ist created according to the parameter set
-	void createInputFile(const edm::ParameterSet &params);
+private:
+  boost::shared_ptr<ThePEG::RandomEngineGlue::Proxy> randomEngineGlueProxy_;
 
-
-
-    private:
-	boost::shared_ptr<ThePEG::RandomEngineGlue::Proxy>
-						randomEngineGlueProxy_;
-
-	const std::string			dataLocation_;
-	const std::string			generator_;
-	const std::string			run_;
-	// File name containing Herwig input config 
-	std::string				dumpConfig_;
-	const unsigned int			skipEvents_;
-    CLHEP::HepRandomEngine* randomEngine;
+  const std::string dataLocation_;
+  const std::string generator_;
+  const std::string run_;
+  // File name containing Herwig input config
+  std::string dumpConfig_;
+  const unsigned int skipEvents_;
+  CLHEP::HepRandomEngine *randomEngine;
 };
 
-
-
-
-
-
-
-#endif // GeneratorInterface_Herwig7Interface_Herwig7Interface_h
+#endif  // GeneratorInterface_Herwig7Interface_Herwig7Interface_h

--- a/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
+++ b/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
@@ -34,194 +34,164 @@ namespace CLHEP {
 }
 
 class Herwig7Hadronizer : public Herwig7Interface, public gen::BaseHadronizer {
-    public:
-	Herwig7Hadronizer(const edm::ParameterSet &params);
-	~Herwig7Hadronizer() override;
+public:
+  Herwig7Hadronizer(const edm::ParameterSet& params);
+  ~Herwig7Hadronizer() override;
 
-	bool readSettings( int ) { return true; }
-	bool initializeForInternalPartons();
-	bool initializeForExternalPartons();
-	bool declareStableParticles(const std::vector<int> &pdgIds);
-	bool declareSpecialSettings( const std::vector<std::string> ) { return true; }
+  bool readSettings(int) { return true; }
+  bool initializeForInternalPartons();
+  bool initializeForExternalPartons();
+  bool declareStableParticles(const std::vector<int>& pdgIds);
+  bool declareSpecialSettings(const std::vector<std::string>) { return true; }
 
-	void statistics();
+  void statistics();
 
-	bool generatePartonsAndHadronize();
-	bool hadronize();
-	bool decay();
-	bool residualDecay();
-	void finalizeEvent();
+  bool generatePartonsAndHadronize();
+  bool hadronize();
+  bool decay();
+  bool residualDecay();
+  void finalizeEvent();
 
-	const char *classname() const { return "Herwig7Hadronizer"; }
-	std::unique_ptr<GenLumiInfoHeader> getGenLumiInfoHeader() const override;
- 	void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
- 	void randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine);
+  const char* classname() const { return "Herwig7Hadronizer"; }
+  std::unique_ptr<GenLumiInfoHeader> getGenLumiInfoHeader() const override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  void randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine);
 
+private:
+  void doSetRandomEngine(CLHEP::HepRandomEngine* v) override { setPEGRandomEngine(v); }
 
-    private:
+  unsigned int eventsToPrint;
 
-        void doSetRandomEngine(CLHEP::HepRandomEngine* v) override { setPEGRandomEngine(v); }
+  ThePEG::EventPtr thepegEvent;
 
-	unsigned int			eventsToPrint;
+  std::shared_ptr<lhef::LHEProxy> proxy_;
+  const std::string handlerDirectory_;
+  edm::ParameterSet paramSettings;
+  const std::string runFileName;
 
-	ThePEG::EventPtr		thepegEvent;
-	
-	std::shared_ptr<lhef::LHEProxy> proxy_;
-	const std::string		handlerDirectory_;
-	edm::ParameterSet 	paramSettings;
-	const std::string runFileName;
-
-	unsigned int firstLumiBlock=0;
-	unsigned int currentLumiBlock=0;
+  unsigned int firstLumiBlock = 0;
+  unsigned int currentLumiBlock = 0;
 };
 
-Herwig7Hadronizer::Herwig7Hadronizer(const edm::ParameterSet &pset) :
-	Herwig7Interface(pset),
-	BaseHadronizer(pset),
-	eventsToPrint(pset.getUntrackedParameter<unsigned int>("eventsToPrint", 0)),
-	handlerDirectory_(pset.getParameter<std::string>("eventHandlers")),
-	runFileName(pset.getParameter<std::string>("run"))
-{  
-	initRepository(pset);
-	paramSettings = pset;
+Herwig7Hadronizer::Herwig7Hadronizer(const edm::ParameterSet& pset)
+    : Herwig7Interface(pset),
+      BaseHadronizer(pset),
+      eventsToPrint(pset.getUntrackedParameter<unsigned int>("eventsToPrint", 0)),
+      handlerDirectory_(pset.getParameter<std::string>("eventHandlers")),
+      runFileName(pset.getParameter<std::string>("run")) {
+  initRepository(pset);
+  paramSettings = pset;
 }
 
-Herwig7Hadronizer::~Herwig7Hadronizer()
-{
+Herwig7Hadronizer::~Herwig7Hadronizer() {}
+
+bool Herwig7Hadronizer::initializeForInternalPartons() {
+  if (currentLumiBlock == firstLumiBlock) {
+    std::ifstream runFile(runFileName + ".run");
+    if (runFile.fail())  //required for showering of LHE files
+    {
+      initRepository(paramSettings);
+    }
+    if (!initGenerator()) {
+      edm::LogInfo("Generator|Herwig7Hadronizer") << "No run step for Herwig chosen. Program will be aborted.";
+      exit(0);
+    }
+  }
+  return true;
 }
 
-bool Herwig7Hadronizer::initializeForInternalPartons()
-{
-
-	if (currentLumiBlock==firstLumiBlock)
-	{
-		std::ifstream runFile(runFileName+".run");
-		if (runFile.fail()) //required for showering of LHE files
-		{
-			initRepository(paramSettings);
-		}
-		if (!initGenerator())
-		{
-			edm::LogInfo("Generator|Herwig7Hadronizer") << "No run step for Herwig chosen. Program will be aborted.";
-			exit(0);
-		}
-	}
-	return true;
+bool Herwig7Hadronizer::initializeForExternalPartons() {
+  edm::LogError("Herwig7 interface")
+      << "Read in of LHE files is not supported in this way. You can read them manually if necessary.";
+  return false;
 }
 
-bool Herwig7Hadronizer::initializeForExternalPartons()
-{
-	edm::LogError("Herwig7 interface") << "Read in of LHE files is not supported in this way. You can read them manually if necessary.";
-	return false;
+bool Herwig7Hadronizer::declareStableParticles(const std::vector<int>& pdgIds) { return false; }
+
+void Herwig7Hadronizer::statistics() {
+  if (eg_) {
+    runInfo().setInternalXSec(
+        GenRunInfoProduct::XSec(eg_->integratedXSec() / ThePEG::picobarn, eg_->integratedXSecErr() / ThePEG::picobarn));
+  }
 }
 
-bool Herwig7Hadronizer::declareStableParticles(const std::vector<int> &pdgIds)
-{
-	return false;
+bool Herwig7Hadronizer::generatePartonsAndHadronize() {
+  edm::LogInfo("Generator|Herwig7Hadronizer") << "Start production";
+
+  try {
+    thepegEvent = eg_->shoot();
+  } catch (std::exception& exc) {
+    edm::LogWarning("Generator|Herwig7Hadronizer")
+        << "EGPtr::shoot() thrown an exception, event skipped: " << exc.what();
+    return false;
+  }
+
+  if (!thepegEvent) {
+    edm::LogWarning("Generator|Herwig7Hadronizer") << "thepegEvent not initialized";
+    return false;
+  }
+
+  event() = convert(thepegEvent);
+  if (!event().get()) {
+    edm::LogWarning("Generator|Herwig7Hadronizer") << "genEvent not initialized";
+    return false;
+  }
+
+  return true;
 }
 
-void Herwig7Hadronizer::statistics()
-{
-	if(eg_){
-		runInfo().setInternalXSec(GenRunInfoProduct::XSec(
-			eg_->integratedXSec() / ThePEG::picobarn,
-			eg_->integratedXSecErr() / ThePEG::picobarn));
-	}
+bool Herwig7Hadronizer::hadronize() {
+  edm::LogError("Herwig7 interface")
+      << "Read in of LHE files is not supported in this way. You can read them manually if necessary.";
+  return false;
 }
 
-bool Herwig7Hadronizer::generatePartonsAndHadronize()
-{
-	edm::LogInfo("Generator|Herwig7Hadronizer") << "Start production";
+void Herwig7Hadronizer::finalizeEvent() {
+  eventInfo().reset(new GenEventInfoProduct(event().get()));
+  eventInfo()->setBinningValues(std::vector<double>(1, pthat(thepegEvent)));
 
+  if (eventsToPrint) {
+    eventsToPrint--;
+    event()->print();
+  }
 
-        try {
-                thepegEvent = eg_->shoot();
-        } catch (std::exception& exc) {
-                edm::LogWarning("Generator|Herwig7Hadronizer") << "EGPtr::shoot() thrown an exception, event skipped: " << exc.what();
-                return false;
-        }
+  if (iobc_.get())
+    iobc_->write_event(event().get());
 
-        if (!thepegEvent) {
-                edm::LogWarning("Generator|Herwig7Hadronizer") << "thepegEvent not initialized";
-                return false;
-        }
-
-        event() = convert(thepegEvent);
-        if (!event().get()) {
-                edm::LogWarning("Generator|Herwig7Hadronizer") << "genEvent not initialized";
-                return false;
-        }
-
-        return true;
+  edm::LogInfo("Generator|Herwig7Hadronizer") << "Event produced";
 }
 
-bool Herwig7Hadronizer::hadronize()
-{
+bool Herwig7Hadronizer::decay() { return true; }
 
-	edm::LogError("Herwig7 interface") << "Read in of LHE files is not supported in this way. You can read them manually if necessary.";
-	return false;
-}
-
-void Herwig7Hadronizer::finalizeEvent()
-{
-	eventInfo().reset(new GenEventInfoProduct(event().get()));
-	eventInfo()->setBinningValues(
-			std::vector<double>(1, pthat(thepegEvent)));
-
-	if (eventsToPrint) {
-		eventsToPrint--;
-		event()->print();
-	}
-
-	if (iobc_.get())
-		iobc_->write_event(event().get());
-
-	edm::LogInfo("Generator|Herwig7Hadronizer") << "Event produced";
-}
-
-bool Herwig7Hadronizer::decay()
-{
-	return true;
-}
-
-bool Herwig7Hadronizer::residualDecay()
-{
-	return true;
-}
+bool Herwig7Hadronizer::residualDecay() { return true; }
 
 std::unique_ptr<GenLumiInfoHeader> Herwig7Hadronizer::getGenLumiInfoHeader() const {
   auto genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
 
-  if (thepegEvent)
-  {
-  	int weights_number = thepegEvent->optionalWeights().size();
+  if (thepegEvent) {
+    int weights_number = thepegEvent->optionalWeights().size();
 
-	  if(weights_number > 1){
-	    genLumiInfoHeader->weightNames().reserve(weights_number + 1);
-	    genLumiInfoHeader->weightNames().push_back("nominal");
-	    std::map<std::string,double> weights_map = thepegEvent->optionalWeights();
-		for (std::map<std::string,double>::iterator it = weights_map.begin(); it != weights_map.end(); it++)
-		{
-		  	genLumiInfoHeader->weightNames().push_back(it->first);
-		}
- 	 }
+    if (weights_number > 1) {
+      genLumiInfoHeader->weightNames().reserve(weights_number + 1);
+      genLumiInfoHeader->weightNames().push_back("nominal");
+      std::map<std::string, double> weights_map = thepegEvent->optionalWeights();
+      for (std::map<std::string, double>::iterator it = weights_map.begin(); it != weights_map.end(); it++) {
+        genLumiInfoHeader->weightNames().push_back(it->first);
+      }
+    }
   }
 
   return genLumiInfoHeader;
 }
 
-void Herwig7Hadronizer::randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine)
-{
-	BaseHadronizer::randomizeIndex(lumi, rengine);
-	
-	if (firstLumiBlock==0)
-	{
-		firstLumiBlock=lumi.id().luminosityBlock();
-	}
-	currentLumiBlock=lumi.id().luminosityBlock();
+void Herwig7Hadronizer::randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine) {
+  BaseHadronizer::randomizeIndex(lumi, rengine);
 
+  if (firstLumiBlock == 0) {
+    firstLumiBlock = lumi.id().luminosityBlock();
+  }
+  currentLumiBlock = lumi.id().luminosityBlock();
 }
-
 
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
 

--- a/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
@@ -28,7 +28,7 @@
 #include <ThePEG/Handlers/EventHandler.h>
 #include <ThePEG/Handlers/XComb.h>
 #include <ThePEG/EventRecord/Event.h>
-#include <ThePEG/EventRecord/Particle.h> 
+#include <ThePEG/EventRecord/Particle.h>
 #include <ThePEG/EventRecord/Collision.h>
 #include <ThePEG/EventRecord/TmpTransform.h>
 #include <ThePEG/Config/ThePEG.h>
@@ -36,7 +36,6 @@
 #include <ThePEG/PDF/PDFBase.h>
 #include <ThePEG/Utilities/UtilityBase.h>
 #include <ThePEG/Vectors/HepMCConverter.h>
-
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -51,188 +50,173 @@
 using namespace std;
 using namespace gen;
 
-Herwig7Interface::Herwig7Interface(const edm::ParameterSet &pset) :
-	randomEngineGlueProxy_(ThePEG::RandomEngineGlue::Proxy::create()),
-	dataLocation_(ParameterCollector::resolve(pset.getParameter<string>("dataLocation"))),
-	generator_(pset.getParameter<string>("generatorModule")),
-	run_(pset.getParameter<string>("run")),
-	dumpConfig_(pset.getUntrackedParameter<string>("dumpConfig", "HerwigConfig.in")),
-	skipEvents_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0))
-{
-	// Write events in hepmc ascii format for debugging purposes
-	string dumpEvents = pset.getUntrackedParameter<string>("dumpEvents", "");
-	if (!dumpEvents.empty()) {
-		iobc_.reset(new HepMC::IO_GenEvent(dumpEvents, ios::out));
-		edm::LogInfo("ThePEGSource") << "Event logging switched on (=> " << dumpEvents << ")";
-	}
-	// Clear dumpConfig target
-	if (!dumpConfig_.empty())
-		ofstream cfgDump(dumpConfig_.c_str(), ios_base::trunc);
+Herwig7Interface::Herwig7Interface(const edm::ParameterSet &pset)
+    : randomEngineGlueProxy_(ThePEG::RandomEngineGlue::Proxy::create()),
+      dataLocation_(ParameterCollector::resolve(pset.getParameter<string>("dataLocation"))),
+      generator_(pset.getParameter<string>("generatorModule")),
+      run_(pset.getParameter<string>("run")),
+      dumpConfig_(pset.getUntrackedParameter<string>("dumpConfig", "HerwigConfig.in")),
+      skipEvents_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0)) {
+  // Write events in hepmc ascii format for debugging purposes
+  string dumpEvents = pset.getUntrackedParameter<string>("dumpEvents", "");
+  if (!dumpEvents.empty()) {
+    iobc_.reset(new HepMC::IO_GenEvent(dumpEvents, ios::out));
+    edm::LogInfo("ThePEGSource") << "Event logging switched on (=> " << dumpEvents << ")";
+  }
+  // Clear dumpConfig target
+  if (!dumpConfig_.empty())
+    ofstream cfgDump(dumpConfig_.c_str(), ios_base::trunc);
 }
 
-Herwig7Interface::~Herwig7Interface () noexcept
-{
-	if (eg_)
-		eg_->finalize();
-	edm::LogInfo("Herwig7Interface") << "Event generator finalized";
+Herwig7Interface::~Herwig7Interface() noexcept {
+  if (eg_)
+    eg_->finalize();
+  edm::LogInfo("Herwig7Interface") << "Event generator finalized";
 }
 
-void Herwig7Interface::setPEGRandomEngine(CLHEP::HepRandomEngine* v) {
-    
-        randomEngineGlueProxy_->setRandomEngine(v);
-        randomEngine = v;
-        ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
-        if(rnd) {
-            rnd->setRandomEngine(v);
-        }
+void Herwig7Interface::setPEGRandomEngine(CLHEP::HepRandomEngine *v) {
+  randomEngineGlueProxy_->setRandomEngine(v);
+  randomEngine = v;
+  ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
+  if (rnd) {
+    rnd->setRandomEngine(v);
+  }
 }
 
+void Herwig7Interface::initRepository(const edm::ParameterSet &pset) {
+  std::string runModeTemp = pset.getUntrackedParameter<string>("runModeList", "read,run");
 
-void Herwig7Interface::initRepository(const edm::ParameterSet &pset)
-{
-	std::string runModeTemp = pset.getUntrackedParameter<string>("runModeList","read,run");
+  // To Lower
+  std::transform(runModeTemp.begin(), runModeTemp.end(), runModeTemp.begin(), ::tolower);
 
-	// To Lower
-	std::transform(runModeTemp.begin(), runModeTemp.end(), runModeTemp.begin(), ::tolower);
+  while (!runModeTemp.empty()) {
+    // Split first part of List
+    std::string choice;
+    size_t pos = runModeTemp.find(",");
+    if (std::string::npos == pos)
+      choice = runModeTemp;
+    else
+      choice = runModeTemp.substr(0, pos);
 
+    if (pos == std::string::npos)
+      runModeTemp.erase();
+    else
+      runModeTemp.erase(0, pos + 1);
 
+    HwUI_.reset(new Herwig::HerwigUIProvider(pset, dumpConfig_, Herwig::RunMode::READ));
+    edm::LogInfo("Herwig7Interface") << "HerwigUIProvider object with run mode " << HwUI_->runMode() << " created.\n";
 
-	while(!runModeTemp.empty())
-	{
-		// Split first part of List
-		std::string choice;
-		size_t pos = runModeTemp.find(",");
-        if (std::string::npos == pos)
-            choice=runModeTemp;
-        else
-		    choice = runModeTemp.substr(0, pos);
-        
-		if (pos == std::string::npos)
-			runModeTemp.erase();
-        else
-            runModeTemp.erase(0, pos+1);
+    // Chose run mode
+    if (choice == "read") {
+      createInputFile(pset);
+      HwUI_->setRunMode(Herwig::RunMode::READ, pset, dumpConfig_);
+      edm::LogInfo("Herwig7Interface") << "Input file " << dumpConfig_
+                                       << " will be passed to Herwig for the read step.\n";
+      callHerwigGenerator();
+    } else if (choice == "build") {
+      createInputFile(pset);
+      HwUI_->setRunMode(Herwig::RunMode::BUILD, pset, dumpConfig_);
+      edm::LogInfo("Herwig7Interface") << "Input file " << dumpConfig_
+                                       << " will be passed to Herwig for the build step.\n";
+      callHerwigGenerator();
 
-		HwUI_.reset(new Herwig::HerwigUIProvider(pset, dumpConfig_, Herwig::RunMode::READ));
-		edm::LogInfo("Herwig7Interface") << "HerwigUIProvider object with run mode " << HwUI_->runMode() << " created.\n";
+    } else if (choice == "integrate") {
+      std::string runFileName = run_ + ".run";
+      edm::LogInfo("Herwig7Interface") << "Run file " << runFileName
+                                       << " will be passed to Herwig for the integrate step.\n";
+      HwUI_->setRunMode(Herwig::RunMode::INTEGRATE, pset, runFileName);
+      callHerwigGenerator();
 
-
-		// Chose run mode
-		if	( choice == "read" )
-		{
-			createInputFile(pset);
-			HwUI_->setRunMode(Herwig::RunMode::READ, pset, dumpConfig_);
-			edm::LogInfo("Herwig7Interface") << "Input file " << dumpConfig_ << " will be passed to Herwig for the read step.\n";
-			callHerwigGenerator();
-		}
-		else if	( choice == "build" )
-		{
-			createInputFile(pset);
-			HwUI_->setRunMode(Herwig::RunMode::BUILD, pset, dumpConfig_);
-			edm::LogInfo("Herwig7Interface") << "Input file " << dumpConfig_ << " will be passed to Herwig for the build step.\n";
-			callHerwigGenerator();
-
-		}
-		else if	( choice == "integrate" )
-		{
-			std::string runFileName = run_ + ".run";
-			edm::LogInfo("Herwig7Interface") << "Run file " << runFileName << " will be passed to Herwig for the integrate step.\n";
-			HwUI_->setRunMode(Herwig::RunMode::INTEGRATE, pset, runFileName);
-			callHerwigGenerator();
-
-		}
-		else if	( choice == "run" )
-		{
-			std::string runFileName = run_ + ".run";
-			edm::LogInfo("Herwig7Interface") << "Run file " << runFileName << " will be passed to Herwig for the run step.\n";
-			HwUI_->setRunMode(Herwig::RunMode::RUN, pset, runFileName);
-		}
-		else
-		{
-			edm::LogInfo("Herwig7Interface") << "Cannot recognize \"" << choice << "\".\n"
-							 << "Trying to skip step.\n";
-			continue;
-		}
-
-	}
-
+    } else if (choice == "run") {
+      std::string runFileName = run_ + ".run";
+      edm::LogInfo("Herwig7Interface") << "Run file " << runFileName << " will be passed to Herwig for the run step.\n";
+      HwUI_->setRunMode(Herwig::RunMode::RUN, pset, runFileName);
+    } else {
+      edm::LogInfo("Herwig7Interface") << "Cannot recognize \"" << choice << "\".\n"
+                                       << "Trying to skip step.\n";
+      continue;
+    }
+  }
 }
 
-void Herwig7Interface::callHerwigGenerator()
-{
+void Herwig7Interface::callHerwigGenerator() {
   try {
-
-    edm::LogInfo("Herwig7Interface") << "callHerwigGenerator function invoked with run mode " << HwUI_->runMode() << ".\n";
+    edm::LogInfo("Herwig7Interface") << "callHerwigGenerator function invoked with run mode " << HwUI_->runMode()
+                                     << ".\n";
 
     // Call program switches according to runMode
-    switch ( HwUI_->runMode() ) {
-    case Herwig::RunMode::INIT:        Herwig::API::init(*HwUI_);       break;
-    case Herwig::RunMode::READ:        Herwig::API::read(*HwUI_);       break;
-    case Herwig::RunMode::BUILD:       Herwig::API::build(*HwUI_);      break;
-    case Herwig::RunMode::INTEGRATE:   Herwig::API::integrate(*HwUI_);  break;
-    case Herwig::RunMode::MERGEGRIDS:  Herwig::API::mergegrids(*HwUI_); break;
-    case Herwig::RunMode::RUN:         {    
-                                            HwUI_->setSeed(randomEngine->getSeed());
-                                            eg_ =  Herwig::API::prepareRun(*HwUI_); break;}
-    case Herwig::RunMode::ERROR:       
-      edm::LogError("Herwig7Interface") << "Error during read in of command line parameters.\n"
-                << "Program execution will stop now."; 
-      return;
-    default:          		     
-      HwUI_->quitWithHelp();
+    switch (HwUI_->runMode()) {
+      case Herwig::RunMode::INIT:
+        Herwig::API::init(*HwUI_);
+        break;
+      case Herwig::RunMode::READ:
+        Herwig::API::read(*HwUI_);
+        break;
+      case Herwig::RunMode::BUILD:
+        Herwig::API::build(*HwUI_);
+        break;
+      case Herwig::RunMode::INTEGRATE:
+        Herwig::API::integrate(*HwUI_);
+        break;
+      case Herwig::RunMode::MERGEGRIDS:
+        Herwig::API::mergegrids(*HwUI_);
+        break;
+      case Herwig::RunMode::RUN: {
+        HwUI_->setSeed(randomEngine->getSeed());
+        eg_ = Herwig::API::prepareRun(*HwUI_);
+        break;
+      }
+      case Herwig::RunMode::ERROR:
+        edm::LogError("Herwig7Interface") << "Error during read in of command line parameters.\n"
+                                          << "Program execution will stop now.";
+        return;
+      default:
+        HwUI_->quitWithHelp();
     }
 
     return;
 
-  }
-  catch ( ThePEG::Exception & e ) {
+  } catch (ThePEG::Exception &e) {
     edm::LogError("Herwig7Interface") << ": ThePEG::Exception caught.\n"
-              << e.what() << '\n'
-      	      << "See logfile for details.\n";
+                                      << e.what() << '\n'
+                                      << "See logfile for details.\n";
     return;
-  }
-  catch ( std::exception & e ) {
+  } catch (std::exception &e) {
     edm::LogError("Herwig7Interface") << ": " << e.what() << '\n';
     return;
-  }
-  catch ( const char* what ) {
-    edm::LogError("Herwig7Interface") << ": caught exception: "
-	      << what << "\n";
+  } catch (const char *what) {
+    edm::LogError("Herwig7Interface") << ": caught exception: " << what << "\n";
     return;
   }
-
 }
 
+bool Herwig7Interface::initGenerator() {
+  if (HwUI_->runMode() == Herwig::RunMode::RUN) {
+    edm::LogInfo("Herwig7Interface") << "Starting EventGenerator initialization";
+    callHerwigGenerator();
+    edm::LogInfo("Herwig7Interface") << "EventGenerator initialized";
 
-bool Herwig7Interface::initGenerator()
-{
-	if ( HwUI_->runMode() == Herwig::RunMode::RUN) {
-		edm::LogInfo("Herwig7Interface") << "Starting EventGenerator initialization";
-		callHerwigGenerator();
-		edm::LogInfo("Herwig7Interface") << "EventGenerator initialized";
+    // Skip events
+    for (unsigned int i = 0; i < skipEvents_; i++) {
+      flushRandomNumberGenerator();
+      eg_->shoot();
+      edm::LogInfo("Herwig7Interface") << "Event discarded";
+    }
 
-		// Skip events
-		for (unsigned int i = 0; i < skipEvents_; i++) {
-			flushRandomNumberGenerator();
-			eg_->shoot();
-			edm::LogInfo("Herwig7Interface") << "Event discarded";
-		}
+    return true;
 
-		return true;
-
-	} else {
-		edm::LogInfo("Herwig7Interface") << "Stopped EventGenerator due to missing run mode.";
-		return false;
-/*
+  } else {
+    edm::LogInfo("Herwig7Interface") << "Stopped EventGenerator due to missing run mode.";
+    return false;
+    /*
 		throw cms::Exception("Herwig7Interface")
 			<< "EventGenerator could not be initialized due to wrong run mode!" << endl;
 */
-	}
-
+  }
 }
 
-void Herwig7Interface::flushRandomNumberGenerator()
-{
-	/*ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
+void Herwig7Interface::flushRandomNumberGenerator() {
+  /*ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
 
 	if (!rnd)
 		edm::LogWarning("ProxyMissing")
@@ -242,105 +226,89 @@ void Herwig7Interface::flushRandomNumberGenerator()
       */
 }
 
-auto_ptr<HepMC::GenEvent> Herwig7Interface::convert(
-					const ThePEG::EventPtr &event)
-{
-	return std::auto_ptr<HepMC::GenEvent>(
-		ThePEG::HepMCConverter<HepMC::GenEvent>::convert(*event));
+auto_ptr<HepMC::GenEvent> Herwig7Interface::convert(const ThePEG::EventPtr &event) {
+  return std::auto_ptr<HepMC::GenEvent>(ThePEG::HepMCConverter<HepMC::GenEvent>::convert(*event));
 }
 
+double Herwig7Interface::pthat(const ThePEG::EventPtr &event) {
+  using namespace ThePEG;
 
+  if (!event->primaryCollision())
+    return -1.0;
 
+  tSubProPtr sub = event->primaryCollision()->primarySubProcess();
+  TmpTransform<tSubProPtr> tmp(sub, Utilities::getBoostToCM(sub->incoming()));
 
-double Herwig7Interface::pthat(const ThePEG::EventPtr &event)
-{
-	using namespace ThePEG;
+  double pthat = (*sub->outgoing().begin())->momentum().perp() / ThePEG::GeV;
+  for (PVector::const_iterator it = sub->outgoing().begin(); it != sub->outgoing().end(); ++it)
+    pthat = std::min<double>(pthat, (*it)->momentum().perp() / ThePEG::GeV);
 
-	if (!event->primaryCollision())
-		return -1.0;
-
-	tSubProPtr sub = event->primaryCollision()->primarySubProcess();
-	TmpTransform<tSubProPtr> tmp(sub, Utilities::getBoostToCM(
-							sub->incoming()));
-
-	double pthat = (*sub->outgoing().begin())->momentum().perp() / ThePEG::GeV;
-	for(PVector::const_iterator it = sub->outgoing().begin();
-	    it != sub->outgoing().end(); ++it)
-		pthat = std::min<double>(pthat, (*it)->momentum().perp() / ThePEG::GeV);
-
-	return pthat;
+  return pthat;
 }
 
-
-
-
-void Herwig7Interface::createInputFile(const edm::ParameterSet &pset)
-{
-	/* Initialize the input config for Herwig from
+void Herwig7Interface::createInputFile(const edm::ParameterSet &pset) {
+  /* Initialize the input config for Herwig from
 	 * 1. the Herwig7 config files
 	 * 2. the CMSSW config blocks
 	 * Writes them to an output file which is read by Herwig
 	*/
 
-	stringstream logstream;
+  stringstream logstream;
 
+  // Contains input config passed to Herwig
+  stringstream herwiginputconfig;
 
-	// Contains input config passed to Herwig
-	stringstream herwiginputconfig;
+  // Define output file to which input config is written, too, if dumpConfig parameter is set.
+  // Otherwise use default file HerwigConfig.in which is read in by Herwig
+  ofstream cfgDump;
+  cfgDump.open(dumpConfig_.c_str(), ios_base::app);
 
-	// Define output file to which input config is written, too, if dumpConfig parameter is set. 
-	// Otherwise use default file HerwigConfig.in which is read in by Herwig
-	ofstream cfgDump;
-	cfgDump.open(dumpConfig_.c_str(), ios_base::app);
-	
+  // Read Herwig config files as input
+  vector<string> configFiles = pset.getParameter<vector<string> >("configFiles");
+  // Loop over the config files
+  for (const auto &iter : configFiles) {
+    // Open external config file
+    ifstream externalConfigFile(iter);
+    if (externalConfigFile.is_open()) {
+      edm::LogInfo("Herwig7Interface") << "Reading config file (" << iter << ")" << endl;
+      stringstream configFileStream;
+      configFileStream << externalConfigFile.rdbuf();
+      string configFileContent = configFileStream.str();
 
+      // Comment out occurence of saverun in config file since it is set later considering run and generator option
+      string searchKeyword("saverun");
+      if (configFileContent.find(searchKeyword) != std::string::npos) {
+        edm::LogInfo("Herwig7Interface") << "Commented out saverun command in external input config file(" << iter
+                                         << ")" << endl;
+        configFileContent.insert(configFileContent.find(searchKeyword), "#");
+      }
+      herwiginputconfig << "# Begin Config file input" << endl
+                        << configFileContent << endl
+                        << "# End Config file input";
+      edm::LogInfo("Herwig7Interface") << "Finished reading config file (" << iter << ")" << endl;
+    } else {
+      edm::LogWarning("Herwig7Interface") << "Could not read config file (" << iter << ")" << endl;
+    }
+  }
 
-	// Read Herwig config files as input
-	vector<string> configFiles = pset.getParameter<vector<string> >("configFiles");
-	// Loop over the config files
-	for ( const auto & iter : configFiles ) {
-		// Open external config file
-		ifstream externalConfigFile (iter);
-		if (externalConfigFile.is_open()) {
-			edm::LogInfo("Herwig7Interface") << "Reading config file (" << iter << ")" << endl;
-			stringstream configFileStream;
-			configFileStream << externalConfigFile.rdbuf();
-			string configFileContent = configFileStream.str();
-			
-			// Comment out occurence of saverun in config file since it is set later considering run and generator option
-			string searchKeyword("saverun");
-   			if(configFileContent.find(searchKeyword) !=std::string::npos) {
-				edm::LogInfo("Herwig7Interface") << "Commented out saverun command in external input config file(" << iter << ")" << endl;
-				configFileContent.insert(configFileContent.find(searchKeyword),"#");
-			}
-			herwiginputconfig << "# Begin Config file input" << endl  << configFileContent << endl << "# End Config file input";
-			edm::LogInfo("Herwig7Interface") << "Finished reading config file (" << iter << ")" << endl;
-		}
-		else {
-			edm::LogWarning("Herwig7Interface") << "Could not read config file (" << iter << ")" << endl;
-		}
-	}
+  edm::LogInfo("Herwig7Interface") << "Start with processing CMSSW config" << endl;
+  // Read CMSSW config file parameter sets starting from "parameterSets"
+  ParameterCollector collector(pset);
+  ParameterCollector::const_iterator iter;
+  iter = collector.begin();
+  herwiginputconfig << endl << "# Begin Parameter set input\n" << endl;
+  for (; iter != collector.end(); ++iter) {
+    herwiginputconfig << *iter << endl;
+  }
 
-	edm::LogInfo("Herwig7Interface") << "Start with processing CMSSW config" << endl;
-	// Read CMSSW config file parameter sets starting from "parameterSets"
-	ParameterCollector collector(pset);
-	ParameterCollector::const_iterator iter;
-	iter = collector.begin();
-	herwiginputconfig << endl << "# Begin Parameter set input\n" << endl;
-	for(; iter != collector.end(); ++iter) {
-		herwiginputconfig << *iter << endl;
-	}
+  // Add some additional necessary lines to the Herwig input config
+  herwiginputconfig << "saverun " << run_ << " " << generator_ << endl;
+  // write the ProxyID for the RandomEngineGlue to fill its pointer in
+  ostringstream ss;
+  ss << randomEngineGlueProxy_->getID();
+  //herwiginputconfig << "set " << generator_ << ":RandomNumberGenerator:ProxyID " << ss.str() << endl;
 
-	// Add some additional necessary lines to the Herwig input config
-	herwiginputconfig << "saverun " << run_ << " " << generator_ << endl;
-	// write the ProxyID for the RandomEngineGlue to fill its pointer in
-	ostringstream ss;
-	ss << randomEngineGlueProxy_->getID();
-	//herwiginputconfig << "set " << generator_ << ":RandomNumberGenerator:ProxyID " << ss.str() << endl;
-
-
-	// Dump Herwig input config to file, so that it can be read by Herwig
-	cfgDump << herwiginputconfig.str() << endl;
-	cfgDump.close();
+  // Dump Herwig input config to file, so that it can be read by Herwig
+  cfgDump << herwiginputconfig.str() << endl;
+  cfgDump.close();
 }
-

--- a/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
+++ b/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
@@ -91,11 +91,11 @@ void PhotosppInterface::init() {
     if (curSet == "suppressAll")
       if (fPSet->getParameter<bool>(curSet) == true)
         Photospp::Photos::suppressAll();
-    if(curSet=="setPairEmission")
+    if (curSet == "setPairEmission")
       Photospp::Photos::setPairEmission(fPSet->getParameter<bool>(curSet));
-    if(curSet=="setPhotonEmission")
+    if (curSet == "setPhotonEmission")
       Photospp::Photos::setPhotonEmission(fPSet->getParameter<bool>(curSet));
-    if(curSet=="setStopAtCriticalError")
+    if (curSet == "setStopAtCriticalError")
       Photospp::Photos::setStopAtCriticalError(fPSet->getParameter<bool>(curSet));
 
     // Now setup more complicated radiation/mass supression and forcing.


### PR DESCRIPTION

Applying code-format for CMSSW category generators.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/407//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


