### PR TITLE
Running code-format for geometry

### DIFF
--- a/Geometry/MuonCommonData/plugins/DDGEMAngular.cc
+++ b/Geometry/MuonCommonData/plugins/DDGEMAngular.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // File: DDGEMAngular.cc
-// Description: Position inside the mother according to (eta,phi) 
+// Description: Position inside the mother according to (eta,phi)
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <cmath>
@@ -25,82 +25,75 @@ DDGEMAngular::DDGEMAngular() {
 
 DDGEMAngular::~DDGEMAngular() {}
 
-void DDGEMAngular::initialize(const DDNumericArguments & nArgs,
-			      const DDVectorArguments & ,
-			      const DDMapArguments & ,
-			      const DDStringArguments & sArgs,
-			      const DDStringVectorArguments & ) {
-
-  startAngle  = nArgs["startAngle"];
-  stepAngle   = nArgs["stepAngle"];
-  invert      = int (nArgs["invert"]);
-  rPos        = nArgs["rPosition"];
-  zoffset     = nArgs["zoffset"];
-  n           = int (nArgs["n"]);
-  startCopyNo = int (nArgs["startCopyNo"]);
-  incrCopyNo  = int (nArgs["incrCopyNo"]);
+void DDGEMAngular::initialize(const DDNumericArguments& nArgs,
+                              const DDVectorArguments&,
+                              const DDMapArguments&,
+                              const DDStringArguments& sArgs,
+                              const DDStringVectorArguments&) {
+  startAngle = nArgs["startAngle"];
+  stepAngle = nArgs["stepAngle"];
+  invert = int(nArgs["invert"]);
+  rPos = nArgs["rPosition"];
+  zoffset = nArgs["zoffset"];
+  n = int(nArgs["n"]);
+  startCopyNo = int(nArgs["startCopyNo"]);
+  incrCopyNo = int(nArgs["incrCopyNo"]);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("MuonGeom") 
-    << "DDGEMAngular: Parameters for positioning-- " << n 
-    << " copies in steps of " << convertRadToDeg( stepAngle )
-    << " from " << convertRadToDeg( startAngle )
-    << " (inversion flag " << invert << ") \trPos " << rPos
-    << " Zoffest " << zoffset << "\tStart and inremental "
-    << "copy nos " << startCopyNo << ", " << incrCopyNo;
+  edm::LogVerbatim("MuonGeom") << "DDGEMAngular: Parameters for positioning-- " << n << " copies in steps of "
+                               << convertRadToDeg(stepAngle) << " from " << convertRadToDeg(startAngle)
+                               << " (inversion flag " << invert << ") \trPos " << rPos << " Zoffest " << zoffset
+                               << "\tStart and inremental "
+                               << "copy nos " << startCopyNo << ", " << incrCopyNo;
 #endif
 
-  rotns       = sArgs["RotNameSpace"];
+  rotns = sArgs["RotNameSpace"];
   idNameSpace = DDCurrentNamespace::ns();
-  childName   = sArgs["ChildName"]; 
+  childName = sArgs["ChildName"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("MuonGeom") 
-    << "DDGEMAngular: Parent " << parent().name() << "\tChild " << childName 
-    << "\tNameSpace " << idNameSpace << "\tRotation Namespace " << rotns;
+  edm::LogVerbatim("MuonGeom") << "DDGEMAngular: Parent " << parent().name() << "\tChild " << childName
+                               << "\tNameSpace " << idNameSpace << "\tRotation Namespace " << rotns;
 #endif
 }
 
 void DDGEMAngular::execute(DDCompactView& cpv) {
+  double phi = startAngle;
+  int copyNo = startCopyNo;
 
-  double phi    = startAngle;
-  int    copyNo = startCopyNo;
-
-  for (int ii=0; ii<n; ii++) {
-
+  for (int ii = 0; ii < n; ii++) {
     double phitmp = phi;
-    if (phitmp >= 2._pi) phitmp -= 2._pi;
+    if (phitmp >= 2._pi)
+      phitmp -= 2._pi;
     DDRotation rotation;
     std::string rotstr("RG");
 
-    if (invert > 0) rotstr += "I";
-    rotstr  += formatAsDegrees(phitmp);
-    rotation = DDRotation(DDName(rotstr, rotns)); 
+    if (invert > 0)
+      rotstr += "I";
+    rotstr += formatAsDegrees(phitmp);
+    rotation = DDRotation(DDName(rotstr, rotns));
     if (!rotation) {
       double thetax = 90.0_deg;
-      double phix   = invert==0 ? (90.0_deg + phitmp) : (-90.0_deg + phitmp);
-      double thetay = invert==0 ? 0.0 : 180.0_deg;
-      double phiz   = phitmp;
+      double phix = invert == 0 ? (90.0_deg + phitmp) : (-90.0_deg + phitmp);
+      double thetay = invert == 0 ? 0.0 : 180.0_deg;
+      double phiz = phitmp;
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("MuonGeom") 
-	<< "DDGEMAngular: Creating a new rotation "
-	<< DDName(rotstr, idNameSpace) << "\t " 
-	<< convertRadToDeg( thetax ) << ", " << convertRadToDeg(  phix ) <<", "
-	<< convertRadToDeg(  thetay ) << ", 0, " << convertRadToDeg( thetax )
-	<< ", " << convertRadToDeg(  phiz );
+      edm::LogVerbatim("MuonGeom") << "DDGEMAngular: Creating a new rotation " << DDName(rotstr, idNameSpace) << "\t "
+                                   << convertRadToDeg(thetax) << ", " << convertRadToDeg(phix) << ", "
+                                   << convertRadToDeg(thetay) << ", 0, " << convertRadToDeg(thetax) << ", "
+                                   << convertRadToDeg(phiz);
 #endif
       rotation = DDrot(DDName(rotstr, rotns), thetax, phix, thetay, 0., thetax, phiz);
-    } 
-    
-    DDTranslation tran(rPos*cos(phitmp), rPos*sin(phitmp), zoffset);
-  
-    DDName parentName = parent().name(); 
-    cpv.position(DDName(childName,idNameSpace), parentName, copyNo, tran, rotation);
+    }
+
+    DDTranslation tran(rPos * cos(phitmp), rPos * sin(phitmp), zoffset);
+
+    DDName parentName = parent().name();
+    cpv.position(DDName(childName, idNameSpace), parentName, copyNo, tran, rotation);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("MuonGeom") 
-      << "DDGEMAngular: " << DDName(childName, idNameSpace) << " number " 
-      << copyNo << " positioned in " << parentName 
-      << " at " << tran << " with " << rotstr << " " << rotation;
+    edm::LogVerbatim("MuonGeom") << "DDGEMAngular: " << DDName(childName, idNameSpace) << " number " << copyNo
+                                 << " positioned in " << parentName << " at " << tran << " with " << rotstr << " "
+                                 << rotation;
 #endif
-    phi    += stepAngle;
+    phi += stepAngle;
     copyNo += incrCopyNo;
   }
 }

--- a/Geometry/MuonCommonData/plugins/DDGEMAngular.h
+++ b/Geometry/MuonCommonData/plugins/DDGEMAngular.h
@@ -8,33 +8,32 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDGEMAngular : public DDAlgorithm {
- public:
+public:
   //Constructor and Destructor
-  DDGEMAngular(); 
+  DDGEMAngular();
   ~DDGEMAngular() override;
-  
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 private:
+  double startAngle;  //Start angle
+  double stepAngle;   //Step  angle
+  int invert;         //inverted or forward
+  double rPos;        //Radial position of center
+  double zoffset;     //Offset in z
+  int n;              //Mumber of copies
+  int startCopyNo;    //Start copy Number
+  int incrCopyNo;     //Increment copy Number
 
-  double        startAngle;   //Start angle 
-  double        stepAngle;    //Step  angle
-  int           invert;       //inverted or forward
-  double        rPos;         //Radial position of center
-  double        zoffset;      //Offset in z
-  int           n;            //Mumber of copies
-  int           startCopyNo;  //Start copy Number
-  int           incrCopyNo;   //Increment copy Number
-
-  std::string   rotns;        //Namespace for rotation matrix
-  std::string   idNameSpace;  //Namespace of this and ALL sub-parts
-  std::string   childName;    //Children name
+  std::string rotns;        //Namespace for rotation matrix
+  std::string idNameSpace;  //Namespace of this and ALL sub-parts
+  std::string childName;    //Children name
 };
 
 #endif

--- a/Geometry/MuonCommonData/plugins/DDMuonAngular.cc
+++ b/Geometry/MuonCommonData/plugins/DDMuonAngular.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // File: DDMuonAngular.cc
-// Description: Position inside the mother according to (eta,phi) 
+// Description: Position inside the mother according to (eta,phi)
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <cmath>
@@ -24,75 +24,65 @@ DDMuonAngular::DDMuonAngular() {
 
 DDMuonAngular::~DDMuonAngular() {}
 
-void DDMuonAngular::initialize(const DDNumericArguments & nArgs,
-			       const DDVectorArguments & ,
-			       const DDMapArguments & ,
-			       const DDStringArguments & sArgs,
-			       const DDStringVectorArguments & ) {
-
-  startAngle  = nArgs["startAngle"];
-  stepAngle   = nArgs["stepAngle"];
-  zoffset     = nArgs["zoffset"];
-  n           = int (nArgs["n"]);
-  startCopyNo = int (nArgs["startCopyNo"]);
-  incrCopyNo  = int (nArgs["incrCopyNo"]);
+void DDMuonAngular::initialize(const DDNumericArguments& nArgs,
+                               const DDVectorArguments&,
+                               const DDMapArguments&,
+                               const DDStringArguments& sArgs,
+                               const DDStringVectorArguments&) {
+  startAngle = nArgs["startAngle"];
+  stepAngle = nArgs["stepAngle"];
+  zoffset = nArgs["zoffset"];
+  n = int(nArgs["n"]);
+  startCopyNo = int(nArgs["startCopyNo"]);
+  incrCopyNo = int(nArgs["incrCopyNo"]);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("MuonGeom") 
-    << "DDMuonAngular: Parameters for positioning-- "  << n 
-    << " copies in steps of " << convertRadToDeg( stepAngle )
-    << " from " << convertRadToDeg( startAngle ) << " \tZoffest "
-    << zoffset << "\tStart and inremental copy nos " 
-    << startCopyNo << ", " << incrCopyNo;
+  edm::LogVerbatim("MuonGeom") << "DDMuonAngular: Parameters for positioning-- " << n << " copies in steps of "
+                               << convertRadToDeg(stepAngle) << " from " << convertRadToDeg(startAngle) << " \tZoffest "
+                               << zoffset << "\tStart and inremental copy nos " << startCopyNo << ", " << incrCopyNo;
 #endif
-  rotns       = sArgs["RotNameSpace"];
+  rotns = sArgs["RotNameSpace"];
   idNameSpace = DDCurrentNamespace::ns();
-  childName   = sArgs["ChildName"]; 
+  childName = sArgs["ChildName"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("MuonGeom") 
-    << "DDMuonAngular debug: Parent " << parent().name()
-    << "\tChild " << childName << "\tNameSpace "
-    << idNameSpace << "\tRotation Namespace " << rotns;
+  edm::LogVerbatim("MuonGeom") << "DDMuonAngular debug: Parent " << parent().name() << "\tChild " << childName
+                               << "\tNameSpace " << idNameSpace << "\tRotation Namespace " << rotns;
 #endif
 }
 
 void DDMuonAngular::execute(DDCompactView& cpv) {
+  double phi = startAngle;
+  int copyNo = startCopyNo;
 
-  double phi    = startAngle;
-  int    copyNo = startCopyNo;
-
-  for (int ii=0; ii<n; ii++) {
-
+  for (int ii = 0; ii < n; ii++) {
     double phitmp = phi;
-    if (phitmp >= 2._pi) phitmp -= 2._pi;
+    if (phitmp >= 2._pi)
+      phitmp -= 2._pi;
     DDRotation rotation;
     std::string rotstr("NULL");
 
     if (std::abs(phitmp) >= 1.0_deg) {
       rotstr = "R" + formatAsDegrees(phitmp);
-      rotation = DDRotation(DDName(rotstr, rotns)); 
+      rotation = DDRotation(DDName(rotstr, rotns));
       if (!rotation) {
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("MuonGeom") 
-	  << "DDMuonAngular: Creating a new rotation "
-	  << DDName(rotstr, idNameSpace) << "\t90, " 
-	  << convertRadToDeg( phitmp ) << ", 90, "
-	  << convertRadToDeg( phitmp + 90._deg ) << ", 0, 0";
+        edm::LogVerbatim("MuonGeom") << "DDMuonAngular: Creating a new rotation " << DDName(rotstr, idNameSpace)
+                                     << "\t90, " << convertRadToDeg(phitmp) << ", 90, "
+                                     << convertRadToDeg(phitmp + 90._deg) << ", 0, 0";
 #endif
         rotation = DDrot(DDName(rotstr, rotns), 90._deg, phitmp, 90._deg, 90._deg + phitmp, 0., 0.);
-      } 
+      }
     }
-    
+
     DDTranslation tran(0, 0, zoffset);
-  
-    DDName parentName = parent().name(); 
-    cpv.position(DDName(childName,idNameSpace), parentName, copyNo, tran, rotation);
+
+    DDName parentName = parent().name();
+    cpv.position(DDName(childName, idNameSpace), parentName, copyNo, tran, rotation);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("MuonGeom") 
-      << "DDMuonAngular: " << DDName(childName, idNameSpace) << " number " 
-      << copyNo << " positioned in " << parentName 
-      << " at " << tran << " with " << rotstr << " " << rotation;
+    edm::LogVerbatim("MuonGeom") << "DDMuonAngular: " << DDName(childName, idNameSpace) << " number " << copyNo
+                                 << " positioned in " << parentName << " at " << tran << " with " << rotstr << " "
+                                 << rotation;
 #endif
-    phi    += stepAngle;
+    phi += stepAngle;
     copyNo += incrCopyNo;
   }
 }

--- a/Geometry/MuonCommonData/plugins/DDMuonAngular.h
+++ b/Geometry/MuonCommonData/plugins/DDMuonAngular.h
@@ -8,31 +8,30 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDMuonAngular : public DDAlgorithm {
- public:
+public:
   //Constructor and Destructor
-  DDMuonAngular(); 
+  DDMuonAngular();
   ~DDMuonAngular() override;
-  
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 private:
+  double startAngle;  //Start angle
+  double stepAngle;   //Step  angle
+  double zoffset;     //Offset in z
+  int n;              //Mumber of copies
+  int startCopyNo;    //Start copy Number
+  int incrCopyNo;     //Increment copy Number
 
-  double        startAngle;   //Start angle 
-  double        stepAngle;    //Step  angle
-  double        zoffset;      //Offset in z
-  int           n;            //Mumber of copies
-  int           startCopyNo;  //Start copy Number
-  int           incrCopyNo;   //Increment copy Number
-
-  std::string   rotns;        //Namespace for rotation matrix
-  std::string   idNameSpace;  //Namespace of this and ALL sub-parts
-  std::string   childName;    //Children name
+  std::string rotns;        //Namespace for rotation matrix
+  std::string idNameSpace;  //Namespace of this and ALL sub-parts
+  std::string childName;    //Children name
 };
 
 #endif

--- a/Geometry/MuonCommonData/plugins/module.cc
+++ b/Geometry/MuonCommonData/plugins/module.cc
@@ -5,5 +5,5 @@
 #include "DetectorDescription/Core/interface/DDAlgorithmFactory.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDMuonAngular,      "muon:DDMuonAngular");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDGEMAngular,       "muon:DDGEMAngular");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDMuonAngular, "muon:DDMuonAngular");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDGEMAngular, "muon:DDGEMAngular");


### PR DESCRIPTION

Applying code-format for CMSSW category geometry.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/409//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


