### PR TITLE
Running code-format for geometry-upgrade

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalGeomTools.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomTools.h
@@ -10,12 +10,26 @@ public:
   HGCalGeomTools();
   ~HGCalGeomTools() {}
 
-  enum WaferType {WaferFull = 0, WaferFive=1, WaferChoptwo=2, WaferChopTwom=3, 
-		  WaferHalf=4, WaferSemi=5, WaferSemi2=6, WaferThree=7};
-  
-  enum WaferPosition {UnknownPosition=-1, WaferCenter=0, CornerCenterYp=1,
-		      CornerCenterYm=2, CornerCenterXp=3, CornerCenterXm=4};
-      
+  enum WaferType {
+    WaferFull = 0,
+    WaferFive = 1,
+    WaferChoptwo = 2,
+    WaferChopTwom = 3,
+    WaferHalf = 4,
+    WaferSemi = 5,
+    WaferSemi2 = 6,
+    WaferThree = 7
+  };
+
+  enum WaferPosition {
+    UnknownPosition = -1,
+    WaferCenter = 0,
+    CornerCenterYp = 1,
+    CornerCenterYm = 2,
+    CornerCenterXp = 3,
+    CornerCenterXm = 4
+  };
+
   static void radius(double zf,
                      double zb,
                      std::vector<double> const& zFront1,
@@ -34,7 +48,7 @@ public:
                        std::vector<double> const& slope);
   static double radius(
       double z, int layer0, int layerf, std::vector<double> const& zFront, std::vector<double> const& rFront);
-  std::pair<double,double> shiftXY(int waferPosition, double waferSize);
+  std::pair<double, double> shiftXY(int waferPosition, double waferSize);
   static double slope(double z, std::vector<double> const& zFront, std::vector<double> const& slope);
   static std::pair<double, double> zradius(double z1,
                                            double z2,
@@ -45,7 +59,7 @@ public:
 
 private:
   static constexpr double tol_ = 0.0001;
-  double  factor_;
+  double factor_;
 };
 
 #endif

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -215,7 +215,7 @@ double HGCalDDDConstants::cellThickness(int layer, int waferU, int waferV) const
     if ((mode_ == HGCalGeometryMode::Hexagon8) || (mode_ == HGCalGeometryMode::Hexagon8Full)) {
       thick = 10000.0 * hgpar_->cellThickness_[type];  // cm to micron
     } else if ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull)) {
-      thick = 100.0 * (type+1);  // type = 1,2,3 for 100,200,300 micron
+      thick = 100.0 * (type + 1);  // type = 1,2,3 for 100,200,300 micron
     }
   }
   return thick;
@@ -484,9 +484,8 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, int cellU, in
   int indx = HGCalWaferIndex::waferIndex(layer, modU, modV);
   auto itr = hgpar_->typesInLayers_.find(indx);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") 
-    << "HGCalDDDConstants::isValidHex8:WaferType " << layer << ":" << modU << ":" << modV
-    << ":" << indx << " Test " << (itr != hgpar_->typesInLayers_.end());
+  edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants::isValidHex8:WaferType " << layer << ":" << modU << ":" << modV
+                                << ":" << indx << " Test " << (itr != hgpar_->typesInLayers_.end());
 #endif
   if (itr == hgpar_->typesInLayers_.end())
     return false;
@@ -503,7 +502,7 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, int cellU, in
                                 << " Tests " << (cellU >= 0) << ":" << (cellU < 2 * N) << ":" << (cellV >= 0) << ":"
                                 << (cellV < 2 * N) << ":" << ((cellV - cellU) < N) << ":" << ((cellU - cellV) <= N);
 #endif
-  if ((cellU < 0) || (cellU >= 2 * N) || (cellV < 0) || (cellV >= 2 * N)) 
+  if ((cellU < 0) || (cellU >= 2 * N) || (cellV < 0) || (cellV >= 2 * N))
     return false;
   if (((cellV - cellU) >= N) || ((cellU - cellV) > N))
     return false;
@@ -1240,11 +1239,11 @@ int HGCalDDDConstants::waferType(int layer, int waferU, int waferV) const {
   int type(-1);
   if ((mode_ == HGCalGeometryMode::Hexagon8) || (mode_ == HGCalGeometryMode::Hexagon8Full)) {
     auto itr = hgpar_->typesInLayers_.find(HGCalWaferIndex::waferIndex(layer, waferU, waferV));
-    if (itr != hgpar_->typesInLayers_.end()) 
+    if (itr != hgpar_->typesInLayers_.end())
       type = hgpar_->waferTypeL_[itr->second];
   } else if ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull)) {
     if ((waferU >= 0) && (waferU < (int)(hgpar_->waferTypeL_.size())))
-      type = (hgpar_->waferTypeL_[waferU]-1);
+      type = (hgpar_->waferTypeL_[waferU] - 1);
   }
   return type;
 }
@@ -1416,10 +1415,7 @@ bool HGCalDDDConstants::isValidCell(int lay, int wafer, int cell) const {
   return result;
 }
 
-
-bool HGCalDDDConstants::isValidCell8(int lay, int waferU, int waferV, 
-				     int cellU, int cellV, int type) const {
-
+bool HGCalDDDConstants::isValidCell8(int lay, int waferU, int waferV, int cellU, int cellV, int type) const {
   float x(0), y(0);
   int kndx = cellV * 100 + cellU;
   if (type == 0) {
@@ -1430,7 +1426,7 @@ bool HGCalDDDConstants::isValidCell8(int lay, int waferU, int waferV,
     }
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "Fine " << cellU << ":" << cellV << ":" << kndx << ":" << x << ":" << y << ":"
-				  << (ktr != hgpar_->cellFineIndex_.end());
+                                  << (ktr != hgpar_->cellFineIndex_.end());
 #endif
   } else {
     auto ktr = hgpar_->cellCoarseIndex_.find(kndx);
@@ -1440,7 +1436,7 @@ bool HGCalDDDConstants::isValidCell8(int lay, int waferU, int waferV,
     }
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "Coarse " << cellU << ":" << cellV << ":" << kndx << ":" << x << ":" << y << ":"
-				  << (ktr != hgpar_->cellCoarseIndex_.end());
+                                  << (ktr != hgpar_->cellCoarseIndex_.end());
 #endif
   }
   int indx = HGCalWaferIndex::waferIndex(0, waferU, waferV);
@@ -1450,16 +1446,15 @@ bool HGCalDDDConstants::isValidCell8(int lay, int waferU, int waferV,
     y += hgpar_->waferPosY_[itr->second];
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "With wafer (" << waferU << "," << waferV <<") " << x << ":" << y;
+  edm::LogVerbatim("HGCalGeom") << "With wafer (" << waferU << "," << waferV << ") " << x << ":" << y;
 #endif
   double rr = sqrt(x * x + y * y);
-  bool result = ((rr >= hgpar_->rMinLayHex_[lay - 1]) && 
-		 (rr <= hgpar_->rMaxLayHex_[lay - 1]));
+  bool result = ((rr >= hgpar_->rMinLayHex_[lay - 1]) && (rr <= hgpar_->rMaxLayHex_[lay - 1]));
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") 
-    << "Input " << lay << ":" << waferU << ":" << waferV  << ":" << cellU << ":" << cellV << " Position " 
-    << x << ":" << y << ":" << rr << " Compare Limits " << hgpar_->rMinLayHex_[lay - 1] << ":"
-    << hgpar_->rMaxLayHex_[lay - 1] << " Flag " << result;
+  edm::LogVerbatim("HGCalGeom") << "Input " << lay << ":" << waferU << ":" << waferV << ":" << cellU << ":" << cellV
+                                << " Position " << x << ":" << y << ":" << rr << " Compare Limits "
+                                << hgpar_->rMinLayHex_[lay - 1] << ":" << hgpar_->rMaxLayHex_[lay - 1] << " Flag "
+                                << result;
 #endif
   return result;
 }

--- a/Geometry/HGCalCommonData/src/HGCalGeomTools.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomTools.cc
@@ -5,7 +5,7 @@
 #include <string>
 
 //#define EDM_ML_DEBUG
-HGCalGeomTools::HGCalGeomTools() : factor_(1.0/std::sqrt(3.0)) {}
+HGCalGeomTools::HGCalGeomTools() : factor_(1.0 / std::sqrt(3.0)) {}
 
 void HGCalGeomTools::radius(double zf,
                             double zb,
@@ -162,21 +162,30 @@ double HGCalGeomTools::radius(
   return r;
 }
 
-std::pair<double,double> HGCalGeomTools::shiftXY(int waferPosition, 
-						 double waferSize) {
-
+std::pair<double, double> HGCalGeomTools::shiftXY(int waferPosition, double waferSize) {
   double dx(0), dy(0);
   switch (waferPosition) {
-  case (CornerCenterYp): { dy = factor_*waferSize; break;}
-  case (CornerCenterYm): { dy =-factor_*waferSize; break;}
-  case (CornerCenterXp): { dx = factor_*waferSize; break;}
-  case (CornerCenterXm): { dx =-factor_*waferSize; break;}
+    case (CornerCenterYp): {
+      dy = factor_ * waferSize;
+      break;
+    }
+    case (CornerCenterYm): {
+      dy = -factor_ * waferSize;
+      break;
+    }
+    case (CornerCenterXp): {
+      dx = factor_ * waferSize;
+      break;
+    }
+    case (CornerCenterXm): {
+      dx = -factor_ * waferSize;
+      break;
+    }
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") 
-    << "Shift for " << waferPosition << " is (" << dx << ":" << dy << ")";
+  edm::LogVerbatim("HGCalGeom") << "Shift for " << waferPosition << " is (" << dx << ":" << dy << ")";
 #endif
-  return std::make_pair(dx,dy);
+  return std::make_pair(dx, dy);
 }
 
 double HGCalGeomTools::slope(double z, std::vector<double> const& zFront, std::vector<double> const& slope) {

--- a/Geometry/HGCalGeometry/test/CaloCellGeometryTester.cc
+++ b/Geometry/HGCalGeometry/test/CaloCellGeometryTester.cc
@@ -29,11 +29,10 @@ void CaloCellGeometryTester::analyze(const edm::Event& /*iEvent*/, const edm::Ev
   const auto& pG = iSetup.getData(caloToken_);
   const CaloGeometry* geo = &pG;
 
-  const int ncalo=11;
-  int dets[ncalo] = {3, 3, 3, 4, 4, 4, 4, 8, 9,10, 6};
+  const int ncalo = 11;
+  int dets[ncalo] = {3, 3, 3, 4, 4, 4, 4, 8, 9, 10, 6};
   int subd[ncalo] = {1, 2, 3, 1, 2, 4, 3, 0, 0, 0, 6};
-  std::string name[ncalo] = {"EB", "EE", "ES", "HB", "HE", "HF", "HO", 
-			     "HGCEE", "HGCHESil", "HGCHESci", "HFNose"};
+  std::string name[ncalo] = {"EB", "EE", "ES", "HB", "HE", "HF", "HO", "HGCEE", "HGCHESil", "HGCHESci", "HFNose"};
   for (unsigned int k = 0; k < ncalo; ++k) {
     const CaloSubdetectorGeometry* geom = geo->getSubdetectorGeometry((DetId::Detector)(dets[k]), subd[k]);
     if (geom) {

--- a/Geometry/HGCalGeometry/test/HGCalTestRecHitTool.cc
+++ b/Geometry/HGCalGeometry/test/HGCalTestRecHitTool.cc
@@ -56,8 +56,8 @@ HGCalTestRecHitTool::HGCalTestRecHitTool(const edm::ParameterSet& iC)
     : geomToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})},
       geom_(nullptr),
       mode_(iC.getParameter<int>("Mode")) {
-   layerEE_     = layerFH_     = layerBH_     = 0;
-   layerEE1000_ = layerFH1000_ = layerBH1000_ = 0;
+  layerEE_ = layerFH_ = layerBH_ = 0;
+  layerEE1000_ = layerFH1000_ = layerBH1000_ = 0;
 }
 
 HGCalTestRecHitTool::~HGCalTestRecHitTool() {}
@@ -87,10 +87,9 @@ void HGCalTestRecHitTool::analyze(const edm::Event&, const edm::EventSetup& iSet
       layerBH_ = (geomBH->topology().dddConstants()).layers(true);
       layerBH1000_ = (geomBH->topology().dddConstants()).getLayer(10000., true);
     }
-    edm::LogVerbatim("HGCalGeom") 
-      << "Layers " << layerEE_ << ":" << layerFH_ << ":" << layerBH_ 
-      << "\nLayer # at 1000 cm " << layerEE1000_ << ":" << layerFH1000_ << ":"
-      << layerBH1000_;
+    edm::LogVerbatim("HGCalGeom") << "Layers " << layerEE_ << ":" << layerFH_ << ":" << layerBH_
+                                  << "\nLayer # at 1000 cm " << layerEE1000_ << ":" << layerFH1000_ << ":"
+                                  << layerBH1000_;
     for (int layer = 1; layer <= layerEE_; ++layer)
       edm::LogVerbatim("HGCalGeom") << "EE Layer " << layer << " Wafers "
                                     << (geomEE->topology().dddConstants()).wafers(layer, 0) << ":"


### PR DESCRIPTION

Applying code-format for CMSSW category geometry,upgrade.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/410//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


