### PR TITLE
Running code-format for l1

### DIFF
--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h
@@ -30,17 +30,14 @@
 //              -- Class Interface --
 //              ---------------------
 
-
 class L1MuDTChambPhContainer {
-
- public:
-
-  typedef std::vector<L1MuDTChambPhDigi>  Phi_Container;
-  typedef Phi_Container::const_iterator   Phi_iterator;
+public:
+  typedef std::vector<L1MuDTChambPhDigi> Phi_Container;
+  typedef Phi_Container::const_iterator Phi_iterator;
 
   //  Constructors
   L1MuDTChambPhContainer() = default;
-  explicit L1MuDTChambPhContainer(Phi_Container );
+  explicit L1MuDTChambPhContainer(Phi_Container);
 
   //  Destructor
   ~L1MuDTChambPhContainer() = default;
@@ -57,10 +54,8 @@ class L1MuDTChambPhContainer {
 
   L1MuDTChambPhDigi const* chPhiSegm2(int wheel, int stat, int sect, int bx) const;
 
- private:
-
-  Phi_Container phiSegments; 
-
+private:
+  Phi_Container phiSegments;
 };
 
 #endif

--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhDigi.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhDigi.h
@@ -1,6 +1,6 @@
 //-------------------------------------------------
 //
-//   Class L1MuDTChambPhDigi	
+//   Class L1MuDTChambPhDigi
 //
 //   Description: input data for PHTF trigger
 //
@@ -16,49 +16,43 @@
 // Collaborating Class Declarations --
 //------------------------------------
 
-
 //----------------------
 // Base Class Headers --
 //----------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
-
 
 //              ---------------------
 //              -- Class Interface --
 //              ---------------------
 
 class L1MuDTChambPhDigi {
-
- public:
-
+public:
   //  Constructors
   L1MuDTChambPhDigi();
 
-  L1MuDTChambPhDigi( int ubx, int uwh, int usc, int ust,
-        int uphr, int uphb, int uqua, int utag, int ucnt, int urpc=-10);
+  L1MuDTChambPhDigi(
+      int ubx, int uwh, int usc, int ust, int uphr, int uphb, int uqua, int utag, int ucnt, int urpc = -10);
 
   //  Destructor
   ~L1MuDTChambPhDigi();
 
   // Operations
-  int bxNum()       const;
-  int whNum()       const;
-  int scNum()       const;
-  int stNum()       const;
-  int phi()         const;
-  int phiB()        const;
-  int code()        const;
-  int Ts2Tag()      const;
-  int BxCnt()       const;
-  int RpcBit()      const;
-  int UpDownTag()	const;
+  int bxNum() const;
+  int whNum() const;
+  int scNum() const;
+  int stNum() const;
+  int phi() const;
+  int phiB() const;
+  int code() const;
+  int Ts2Tag() const;
+  int BxCnt() const;
+  int RpcBit() const;
+  int UpDownTag() const;
 
- private:
-
+private:
   int bx;
   int wheel;
   int sector;

--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h
@@ -26,17 +26,14 @@
 // C++ Headers --
 //---------------
 
-
 //              ---------------------
 //              -- Class Interface --
 //              ---------------------
 
 class L1MuDTChambThContainer {
-
- public:
-
-  typedef std::vector<L1MuDTChambThDigi>  The_Container;
-  typedef The_Container::const_iterator   The_iterator;
+public:
+  typedef std::vector<L1MuDTChambThDigi> The_Container;
+  typedef The_Container::const_iterator The_iterator;
 
   //  Constructors
   L1MuDTChambThContainer() = default;
@@ -55,10 +52,8 @@ class L1MuDTChambThContainer {
 
   L1MuDTChambThDigi const* chThetaSegm(int wheel, int stat, int sect, int bx) const;
 
- private:
-
-  The_Container theSegments; 
-
+private:
+  The_Container theSegments;
 };
 
 #endif

--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTChambThDigi.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTChambThDigi.h
@@ -1,6 +1,6 @@
 //-------------------------------------------------
 //
-//   Class L1MuDTChambThDigi	
+//   Class L1MuDTChambThDigi
 //
 //   Description: input data for ETTF trigger
 //
@@ -16,16 +16,13 @@
 // Collaborating Class Declarations --
 //------------------------------------
 
-
 //----------------------
 // Base Class Headers --
 //----------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
-
 
 //              ---------------------
 //              -- Class Interface --
@@ -34,33 +31,28 @@
 typedef unsigned char myint8;
 
 class L1MuDTChambThDigi {
-
- public:
-
+public:
   //  Constructors
   L1MuDTChambThDigi();
 
-  L1MuDTChambThDigi( int ubx, int uwh, int usc, int ust,
-	             int* uos, int* uqual );
+  L1MuDTChambThDigi(int ubx, int uwh, int usc, int ust, int* uos, int* uqual);
 
-  L1MuDTChambThDigi( int ubx, int uwh, int usc, int ust,
-	             int* uos );
+  L1MuDTChambThDigi(int ubx, int uwh, int usc, int ust, int* uos);
 
   //  Destructor
   ~L1MuDTChambThDigi();
 
   // Operations
-  int bxNum()       const;
-  int whNum()       const;
-  int scNum()       const;
-  int stNum()       const;
+  int bxNum() const;
+  int whNum() const;
+  int scNum() const;
+  int stNum() const;
 
   int code(const int i) const;
   int position(const int i) const;
   int quality(const int i) const;
 
- private:
-
+private:
   int bx;
   int wheel;
   int sector;

--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTTrackCand.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTTrackCand.h
@@ -1,6 +1,6 @@
 //-------------------------------------------------
 //
-//   Class L1MuDTTrackCand	
+//   Class L1MuDTTrackCand
 //
 //   Description: output data for DTTF trigger
 //
@@ -16,7 +16,6 @@
 // Collaborating Class Declarations --
 //------------------------------------
 
-
 //----------------------
 // Base Class Headers --
 //----------------------
@@ -31,41 +30,50 @@
 //              -- Class Interface --
 //              ---------------------
 
-class L1MuDTTrackCand: public L1MuRegionalCand {
-
- public:
-
+class L1MuDTTrackCand : public L1MuRegionalCand {
+public:
   //  Constructors
   L1MuDTTrackCand();
 
-  L1MuDTTrackCand( unsigned dataword, int bx, int uwh, int usc, int utag,
-                   int adr1, int adr2, int adr3, int adr4, int utc );
+  L1MuDTTrackCand(
+      unsigned dataword, int bx, int uwh, int usc, int utag, int adr1, int adr2, int adr3, int adr4, int utc);
 
-  L1MuDTTrackCand( unsigned type_idx, unsigned phi, unsigned eta, unsigned pt, unsigned charge,
-		   unsigned ch_valid, unsigned finehalo, unsigned quality, int bx,
-                   int uwh, int usc, int utag, int adr1, int adr2, int adr3, int adr4 );
+  L1MuDTTrackCand(unsigned type_idx,
+                  unsigned phi,
+                  unsigned eta,
+                  unsigned pt,
+                  unsigned charge,
+                  unsigned ch_valid,
+                  unsigned finehalo,
+                  unsigned quality,
+                  int bx,
+                  int uwh,
+                  int usc,
+                  int utag,
+                  int adr1,
+                  int adr2,
+                  int adr3,
+                  int adr4);
 
   //  Destructor
   ~L1MuDTTrackCand() override;
 
   // Operations
-  int whNum()        const;
-  int scNum()        const;
+  int whNum() const;
+  int scNum() const;
   int stNum(int ust) const;
-  int TCNum()        const;
-  int TrkTag()       const;
+  int TCNum() const;
+  int TrkTag() const;
 
   void setTC();
   void setAdd(int ust);
 
- private:
-
+private:
   int wheel;
   int sector;
   int TrkTagCode;
   int TClassCode;
   int TrkAdd[4];
-
 };
 
 #endif

--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTTrackContainer.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTTrackContainer.h
@@ -30,14 +30,11 @@
 //              -- Class Interface --
 //              ---------------------
 
-
 class L1MuDTTrackContainer {
-
- public:
-
-  typedef std::vector<L1MuDTTrackCand>    TrackContainer;
-  typedef TrackContainer::const_iterator  Trackiterator;
-  typedef TrackContainer::iterator        TrackIterator;
+public:
+  typedef std::vector<L1MuDTTrackCand> TrackContainer;
+  typedef TrackContainer::const_iterator Trackiterator;
+  typedef TrackContainer::iterator TrackIterator;
 
   //  Constructors
   L1MuDTTrackContainer();
@@ -57,11 +54,8 @@ class L1MuDTTrackContainer {
 
   L1MuDTTrackCand const* dtTrackCand2(int wheel, int sect, int bx) const;
 
-
- private:
-
-  TrackContainer dtTracks; 
-
+private:
+  TrackContainer dtTracks;
 };
 
 #endif

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h
@@ -31,13 +31,10 @@
 //              -- Class Interface --
 //              ---------------------
 
-
 class L1Phase2MuDTPhContainer {
-
- public:
-
-  typedef std::vector<L1Phase2MuDTPhDigi>  Segment_Container;
-  typedef Segment_Container::const_iterator   Segment_iterator;
+public:
+  typedef std::vector<L1Phase2MuDTPhDigi> Segment_Container;
+  typedef Segment_Container::const_iterator Segment_iterator;
 
   //  Constructor
   L1Phase2MuDTPhContainer();
@@ -46,12 +43,8 @@ class L1Phase2MuDTPhContainer {
 
   Segment_Container const* getContainer() const;
 
-    
- private:
-
-  Segment_Container m_segments; 
-
+private:
+  Segment_Container m_segments;
 };
 
 #endif
-

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h
@@ -1,6 +1,6 @@
 //-------------------------------------------------
 //
-//   Class L1Phase2MuDTPhDigi	
+//   Class L1Phase2MuDTPhDigi
 //
 //   Description: trigger primtive data for the
 //                muon barrel Phase2 trigger
@@ -17,54 +17,46 @@
 // Collaborating Class Declarations --
 //------------------------------------
 
-
 //----------------------
 // Base Class Headers --
 //----------------------
-
 
 //---------------
 // C++ Headers --
 //---------------
 
-
 //              ---------------------
 //              -- Class Interface --
 //              ---------------------
 
-class L1Phase2MuDTPhDigi 
-{
-
- public:
-
+class L1Phase2MuDTPhDigi {
+public:
   //  Constructors
   L1Phase2MuDTPhDigi();
-  
-  L1Phase2MuDTPhDigi( int bx, int wh, int sc, int st, int sl, int phi, int phib,
-		      int qual, int idx, int t0, int chi2, int rpc=-10);
-  
+
+  L1Phase2MuDTPhDigi(
+      int bx, int wh, int sc, int st, int sl, int phi, int phib, int qual, int idx, int t0, int chi2, int rpc = -10);
+
   // Operations
-  int bxNum()       const;
+  int bxNum() const;
 
-  int whNum()       const;
-  int scNum()       const;
-  int stNum()       const;
-  int slNum()       const;
+  int whNum() const;
+  int scNum() const;
+  int stNum() const;
+  int slNum() const;
 
-  int phi()         const;
-  int phiBend()     const;
+  int phi() const;
+  int phiBend() const;
 
-  int quality()     const;
-  int index()       const;
-   
-  int t0()          const;
-  int chi2()        const;
+  int quality() const;
+  int index() const;
 
-  int rpcFlag()      const;
-  
+  int t0() const;
+  int chi2() const;
 
- private:
+  int rpcFlag() const;
 
+private:
   int m_bx;
   int m_wheel;
   int m_sector;
@@ -76,10 +68,10 @@ class L1Phase2MuDTPhDigi
 
   int m_qualityCode;
   int m_index;
-  
+
   int m_t0;
   int m_chi2;
-  
+
   int m_rpcFlag;
 };
 

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTChambPhContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTChambPhContainer.cc
@@ -19,7 +19,6 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
@@ -29,79 +28,60 @@ using namespace std;
 // Initializations --
 //-------------------
 
-
 //----------------
 // Constructors --
 //----------------
-L1MuDTChambPhContainer::L1MuDTChambPhContainer(Phi_Container c): phiSegments(std::move(c)) {}
+L1MuDTChambPhContainer::L1MuDTChambPhContainer(Phi_Container c) : phiSegments(std::move(c)) {}
 
 //--------------
 // Operations --
 //--------------
-void L1MuDTChambPhContainer::setContainer(Phi_Container inputSegments) {
+void L1MuDTChambPhContainer::setContainer(Phi_Container inputSegments) { phiSegments = std::move(inputSegments); }
 
-  phiSegments = std::move(inputSegments);
-}
-
-L1MuDTChambPhContainer::Phi_Container const* L1MuDTChambPhContainer::getContainer() const {
-  return &phiSegments;
-}
+L1MuDTChambPhContainer::Phi_Container const* L1MuDTChambPhContainer::getContainer() const { return &phiSegments; }
 
 bool L1MuDTChambPhContainer::bxEmpty(int step) const {
-
   bool empty = true;
 
-  for ( Phi_iterator i  = phiSegments.begin();
-                     i != phiSegments.end();
-                     i++ ) {
-    if  (step == i->bxNum()) empty = false;
+  for (Phi_iterator i = phiSegments.begin(); i != phiSegments.end(); i++) {
+    if (step == i->bxNum())
+      empty = false;
   }
 
-  return(empty);
+  return (empty);
 }
 
 int L1MuDTChambPhContainer::bxSize(int step1, int step2) const {
-
   int size = 0;
 
-  for ( Phi_iterator i  = phiSegments.begin();
-                     i != phiSegments.end();
-                     i++ ) {
-    if  (step1 <= i->bxNum() && step2 >= i->bxNum() 
-      && i->Ts2Tag() == 0 && i->code() != 7) size++;
-    if  (step1 <= i->bxNum()-1 && step2 >= i->bxNum()-1 
-      && i->Ts2Tag() == 1 && i->code() != 7) size++;
+  for (Phi_iterator i = phiSegments.begin(); i != phiSegments.end(); i++) {
+    if (step1 <= i->bxNum() && step2 >= i->bxNum() && i->Ts2Tag() == 0 && i->code() != 7)
+      size++;
+    if (step1 <= i->bxNum() - 1 && step2 >= i->bxNum() - 1 && i->Ts2Tag() == 1 && i->code() != 7)
+      size++;
   }
 
-  return(size);
+  return (size);
 }
 
 L1MuDTChambPhDigi const* L1MuDTChambPhContainer::chPhiSegm1(int wheel, int stat, int sect, int step) const {
+  L1MuDTChambPhDigi const* rT = nullptr;
 
-  L1MuDTChambPhDigi const* rT=nullptr;
-
-  for ( Phi_iterator i  = phiSegments.begin();
-                     i != phiSegments.end();
-                     i++ ) {
-    if  (step == i->bxNum() && wheel == i->whNum() && sect == i->scNum()
-      && stat == i->stNum() && i->Ts2Tag() == 0)
+  for (Phi_iterator i = phiSegments.begin(); i != phiSegments.end(); i++) {
+    if (step == i->bxNum() && wheel == i->whNum() && sect == i->scNum() && stat == i->stNum() && i->Ts2Tag() == 0)
       rT = &(*i);
   }
 
-  return(rT);
+  return (rT);
 }
 
 L1MuDTChambPhDigi const* L1MuDTChambPhContainer::chPhiSegm2(int wheel, int stat, int sect, int step) const {
+  L1MuDTChambPhDigi const* rT = nullptr;
 
-  L1MuDTChambPhDigi const* rT=nullptr;
-
-  for ( Phi_iterator i  = phiSegments.begin();
-                     i != phiSegments.end();
-                     i++ ) {
-    if  (step == i->bxNum()-1 && wheel == i->whNum() && sect == i->scNum()
-      && stat == i->stNum() && i->Ts2Tag() == 1)
+  for (Phi_iterator i = phiSegments.begin(); i != phiSegments.end(); i++) {
+    if (step == i->bxNum() - 1 && wheel == i->whNum() && sect == i->scNum() && stat == i->stNum() && i->Ts2Tag() == 1)
       rT = &(*i);
   }
 
-  return(rT);
+  return (rT);
 }

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTChambPhDigi.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTChambPhDigi.cc
@@ -19,7 +19,6 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
@@ -28,88 +27,60 @@
 // Initializations --
 //-------------------
 
-
 //----------------
 // Constructors --
 //----------------
 L1MuDTChambPhDigi::L1MuDTChambPhDigi() {
-
-  bx              = -100;
-  wheel           = 0;
-  sector          = 0;
-  station         = 0;
-  radialAngle     = 0;
-  bendingAngle    = 0;
-  qualityCode     = 7;
-  Ts2TagCode      = 0;
-  BxCntCode       = 0;
-  rpcBit          = -10;
+  bx = -100;
+  wheel = 0;
+  sector = 0;
+  station = 0;
+  radialAngle = 0;
+  bendingAngle = 0;
+  qualityCode = 7;
+  Ts2TagCode = 0;
+  BxCntCode = 0;
+  rpcBit = -10;
 }
 
-L1MuDTChambPhDigi::L1MuDTChambPhDigi( int ubx, int uwh, int usc, int ust,
-                         int uphr, int uphb, int uqua, int utag, int ucnt, int urpc ) {
-
-  bx              = ubx;
-  wheel           = uwh;
-  sector          = usc;
-  station         = ust;
-  radialAngle     = uphr;
-  bendingAngle    = uphb;
-  qualityCode     = uqua;
-  Ts2TagCode      = utag;
-  BxCntCode       = ucnt;
-  rpcBit          = urpc;
+L1MuDTChambPhDigi::L1MuDTChambPhDigi(
+    int ubx, int uwh, int usc, int ust, int uphr, int uphb, int uqua, int utag, int ucnt, int urpc) {
+  bx = ubx;
+  wheel = uwh;
+  sector = usc;
+  station = ust;
+  radialAngle = uphr;
+  bendingAngle = uphb;
+  qualityCode = uqua;
+  Ts2TagCode = utag;
+  BxCntCode = ucnt;
+  rpcBit = urpc;
 }
-
-
 
 //--------------
 // Destructor --
 //--------------
-L1MuDTChambPhDigi::~L1MuDTChambPhDigi() {
-}
+L1MuDTChambPhDigi::~L1MuDTChambPhDigi() {}
 
 //--------------
 // Operations --
 //--------------
-int L1MuDTChambPhDigi::bxNum() const {
-  return bx;
-}
+int L1MuDTChambPhDigi::bxNum() const { return bx; }
 
-int L1MuDTChambPhDigi::whNum() const {
-  return wheel;
-}
-int L1MuDTChambPhDigi::scNum() const {
-  return sector;
-}
-int L1MuDTChambPhDigi::stNum() const {
-  return station;
-}
+int L1MuDTChambPhDigi::whNum() const { return wheel; }
+int L1MuDTChambPhDigi::scNum() const { return sector; }
+int L1MuDTChambPhDigi::stNum() const { return station; }
 
-int L1MuDTChambPhDigi::phi() const {
-  return radialAngle;
-}
+int L1MuDTChambPhDigi::phi() const { return radialAngle; }
 
-int L1MuDTChambPhDigi::phiB() const {
-  return bendingAngle;
-}
+int L1MuDTChambPhDigi::phiB() const { return bendingAngle; }
 
-int L1MuDTChambPhDigi::code() const {
-  return qualityCode;
-}
+int L1MuDTChambPhDigi::code() const { return qualityCode; }
 
-int L1MuDTChambPhDigi::Ts2Tag() const {
-  return Ts2TagCode%2;
-}
+int L1MuDTChambPhDigi::Ts2Tag() const { return Ts2TagCode % 2; }
 
-int L1MuDTChambPhDigi::BxCnt() const {
-  return BxCntCode;
-}
+int L1MuDTChambPhDigi::BxCnt() const { return BxCntCode; }
 
-int L1MuDTChambPhDigi::RpcBit() const {
-  return rpcBit;
-}
+int L1MuDTChambPhDigi::RpcBit() const { return rpcBit; }
 
-int L1MuDTChambPhDigi::UpDownTag()	const{
-  return Ts2TagCode/2 ;
-}
+int L1MuDTChambPhDigi::UpDownTag() const { return Ts2TagCode / 2; }

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTChambThContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTChambThContainer.cc
@@ -19,7 +19,6 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
@@ -29,63 +28,47 @@ using namespace std;
 // Initializations --
 //-------------------
 
-
 //----------------
 // Constructors --
 //----------------
-L1MuDTChambThContainer::L1MuDTChambThContainer(The_Container c):
- theSegments{std::move(c)} {}
+L1MuDTChambThContainer::L1MuDTChambThContainer(The_Container c) : theSegments{std::move(c)} {}
 
 //--------------
 // Operations --
 //--------------
-void L1MuDTChambThContainer::setContainer(The_Container inputSegments) {
+void L1MuDTChambThContainer::setContainer(The_Container inputSegments) { theSegments = std::move(inputSegments); }
 
-  theSegments = std::move(inputSegments);
-}
-
-L1MuDTChambThContainer::The_Container const* L1MuDTChambThContainer::getContainer() const {
-  return &theSegments;
-}
+L1MuDTChambThContainer::The_Container const* L1MuDTChambThContainer::getContainer() const { return &theSegments; }
 
 bool L1MuDTChambThContainer::bxEmpty(int step) const {
-
   bool empty = true;
 
-  for ( The_iterator i  = theSegments.begin();
-                     i != theSegments.end();
-                     i++ ) {
-    if  (step == i->bxNum()) empty = false;
+  for (The_iterator i = theSegments.begin(); i != theSegments.end(); i++) {
+    if (step == i->bxNum())
+      empty = false;
   }
 
-  return(empty);
+  return (empty);
 }
 
 int L1MuDTChambThContainer::bxSize(int step1, int step2) const {
-
   int size = 0;
 
-  for ( The_iterator i  = theSegments.begin();
-                     i != theSegments.end();
-                     i++ ) {
-    if  (step1 <= i->bxNum() && step2 >= i->bxNum()) size++;
+  for (The_iterator i = theSegments.begin(); i != theSegments.end(); i++) {
+    if (step1 <= i->bxNum() && step2 >= i->bxNum())
+      size++;
   }
 
-  return(size);
+  return (size);
 }
 
 L1MuDTChambThDigi const* L1MuDTChambThContainer::chThetaSegm(int wheel, int stat, int sect, int step) const {
+  L1MuDTChambThDigi const* rT = nullptr;
 
-  L1MuDTChambThDigi const* rT=nullptr;
-
-  for ( The_iterator i  = theSegments.begin();
-                     i != theSegments.end();
-                     i++ ) {
-    if  (step == i->bxNum() && wheel == i->whNum() && sect == i->scNum()
-      && stat == i->stNum() )
+  for (The_iterator i = theSegments.begin(); i != theSegments.end(); i++) {
+    if (step == i->bxNum() && wheel == i->whNum() && sect == i->scNum() && stat == i->stNum())
       rT = &(*i);
   }
 
-  return(rT);
+  return (rT);
 }
-

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTChambThDigi.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTChambThDigi.cc
@@ -19,7 +19,6 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
@@ -28,46 +27,40 @@
 // Initializations --
 //-------------------
 
-
 //----------------
 // Constructors --
 //----------------
 L1MuDTChambThDigi::L1MuDTChambThDigi() {
+  bx = -100;
+  wheel = 0;
+  sector = 0;
+  station = 0;
 
-  bx              = -100;
-  wheel           = 0;
-  sector          = 0;
-  station         = 0;
-
-  for(int i=0;i<7;i++) {
+  for (int i = 0; i < 7; i++) {
     m_outPos[i] = 0;
     m_outQual[i] = 0;
   }
 }
 
-L1MuDTChambThDigi::L1MuDTChambThDigi( int ubx, int uwh, int usc, int ust,
-                                      int* upos, int* uqual ) {
+L1MuDTChambThDigi::L1MuDTChambThDigi(int ubx, int uwh, int usc, int ust, int* upos, int* uqual) {
+  bx = ubx;
+  wheel = uwh;
+  sector = usc;
+  station = ust;
 
-  bx              = ubx;
-  wheel           = uwh;
-  sector          = usc;
-  station         = ust;
-
-  for(int i=0;i<7;i++) {
+  for (int i = 0; i < 7; i++) {
     m_outPos[i] = upos[i];
     m_outQual[i] = uqual[i];
   }
 }
 
-L1MuDTChambThDigi::L1MuDTChambThDigi( int ubx, int uwh, int usc, int ust,
-                                      int* upos ) {
+L1MuDTChambThDigi::L1MuDTChambThDigi(int ubx, int uwh, int usc, int ust, int* upos) {
+  bx = ubx;
+  wheel = uwh;
+  sector = usc;
+  station = ust;
 
-  bx              = ubx;
-  wheel           = uwh;
-  sector          = usc;
-  station         = ust;
-
-  for(int i=0;i<7;i++) {
+  for (int i = 0; i < 7; i++) {
     m_outPos[i] = upos[i];
     m_outQual[i] = 0;
   }
@@ -76,40 +69,34 @@ L1MuDTChambThDigi::L1MuDTChambThDigi( int ubx, int uwh, int usc, int ust,
 //--------------
 // Destructor --
 //--------------
-L1MuDTChambThDigi::~L1MuDTChambThDigi() {
-}
+L1MuDTChambThDigi::~L1MuDTChambThDigi() {}
 
 //--------------
 // Operations --
 //--------------
-int L1MuDTChambThDigi::bxNum() const {
-  return bx;
-}
+int L1MuDTChambThDigi::bxNum() const { return bx; }
 
-int L1MuDTChambThDigi::whNum() const {
-  return wheel;
-}
-int L1MuDTChambThDigi::scNum() const {
-  return sector;
-}
-int L1MuDTChambThDigi::stNum() const {
-  return station;
-}
+int L1MuDTChambThDigi::whNum() const { return wheel; }
+int L1MuDTChambThDigi::scNum() const { return sector; }
+int L1MuDTChambThDigi::stNum() const { return station; }
 
 int L1MuDTChambThDigi::code(const int i) const {
-  if (i<0||i>=7) return 0;
+  if (i < 0 || i >= 7)
+    return 0;
 
-  return (int)(m_outPos[i]+m_outQual[i]);
+  return (int)(m_outPos[i] + m_outQual[i]);
 }
 
 int L1MuDTChambThDigi::position(const int i) const {
-  if (i<0||i>=7) return 0;
+  if (i < 0 || i >= 7)
+    return 0;
 
   return (int)m_outPos[i];
 }
 
 int L1MuDTChambThDigi::quality(const int i) const {
-  if (i<0||i>=7) return 0;
+  if (i < 0 || i >= 7)
+    return 0;
 
   return (int)m_outQual[i];
 }

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTTrackCand.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTTrackCand.cc
@@ -19,7 +19,6 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
@@ -28,34 +27,31 @@
 // Initializations --
 //-------------------
 
-
 //----------------
 // Constructors --
 //----------------
-L1MuDTTrackCand::L1MuDTTrackCand() : L1MuRegionalCand(0,0) {
-
-  wheel           = 0;
-  sector          = 0;
-  TrkTagCode      = -1;
-  TrkAdd[0]       =  3;
-  TrkAdd[1]       = 15;
-  TrkAdd[2]       = 15;
-  TrkAdd[3]       = 15;
-  TClassCode      = 11;
+L1MuDTTrackCand::L1MuDTTrackCand() : L1MuRegionalCand(0, 0) {
+  wheel = 0;
+  sector = 0;
+  TrkTagCode = -1;
+  TrkAdd[0] = 3;
+  TrkAdd[1] = 15;
+  TrkAdd[2] = 15;
+  TrkAdd[3] = 15;
+  TClassCode = 11;
 }
 
-L1MuDTTrackCand::L1MuDTTrackCand( unsigned dataword, int bx, int uwh, int usc,
-                       int utag, int adr1, int adr2, int adr3, int adr4, int utc ) :
-                   L1MuRegionalCand(dataword, bx) {
-
-  wheel           = uwh;
-  sector          = usc;
-  TrkTagCode      = utag;
-  TrkAdd[0]       = adr1&0x03;
-  TrkAdd[1]       = adr2;
-  TrkAdd[2]       = adr3;
-  TrkAdd[3]       = adr4;
-  TClassCode      = utc;
+L1MuDTTrackCand::L1MuDTTrackCand(
+    unsigned dataword, int bx, int uwh, int usc, int utag, int adr1, int adr2, int adr3, int adr4, int utc)
+    : L1MuRegionalCand(dataword, bx) {
+  wheel = uwh;
+  sector = usc;
+  TrkTagCode = utag;
+  TrkAdd[0] = adr1 & 0x03;
+  TrkAdd[1] = adr2;
+  TrkAdd[2] = adr3;
+  TrkAdd[3] = adr4;
+  TClassCode = utc;
 
   setAdd(1);
   setAdd(2);
@@ -63,12 +59,23 @@ L1MuDTTrackCand::L1MuDTTrackCand( unsigned dataword, int bx, int uwh, int usc,
   setAdd(4);
 }
 
-L1MuDTTrackCand::L1MuDTTrackCand( unsigned type_idx, unsigned phi, unsigned eta,
-                       unsigned pt, unsigned charge, unsigned ch_valid, unsigned finehalo,
-                       unsigned quality, int bx, int uwh, int usc, int utag,
-                       int adr1, int adr2, int adr3, int adr4 ) :
-                   L1MuRegionalCand(0, bx) {
-
+L1MuDTTrackCand::L1MuDTTrackCand(unsigned type_idx,
+                                 unsigned phi,
+                                 unsigned eta,
+                                 unsigned pt,
+                                 unsigned charge,
+                                 unsigned ch_valid,
+                                 unsigned finehalo,
+                                 unsigned quality,
+                                 int bx,
+                                 int uwh,
+                                 int usc,
+                                 int utag,
+                                 int adr1,
+                                 int adr2,
+                                 int adr3,
+                                 int adr4)
+    : L1MuRegionalCand(0, bx) {
   setType(type_idx);
   setPhiPacked(phi);
   setEtaPacked(eta);
@@ -76,15 +83,15 @@ L1MuDTTrackCand::L1MuDTTrackCand( unsigned type_idx, unsigned phi, unsigned eta,
   setChargePacked(charge);
   setChargeValidPacked(ch_valid);
   setFineHaloPacked(finehalo);
-  setQualityPacked(quality); 
+  setQualityPacked(quality);
 
-  wheel           = uwh;
-  sector          = usc;
-  TrkTagCode      = utag;
-  TrkAdd[0]       = adr1;
-  TrkAdd[1]       = adr2;
-  TrkAdd[2]       = adr3;
-  TrkAdd[3]       = adr4;
+  wheel = uwh;
+  sector = usc;
+  TrkTagCode = utag;
+  TrkAdd[0] = adr1;
+  TrkAdd[1] = adr2;
+  TrkAdd[2] = adr3;
+  TrkAdd[3] = adr4;
 
   setTC();
 }
@@ -92,51 +99,65 @@ L1MuDTTrackCand::L1MuDTTrackCand( unsigned type_idx, unsigned phi, unsigned eta,
 //--------------
 // Destructor --
 //--------------
-L1MuDTTrackCand::~L1MuDTTrackCand() {
-}
+L1MuDTTrackCand::~L1MuDTTrackCand() {}
 
 //--------------
 // Operations --
 //--------------
-int L1MuDTTrackCand::whNum() const {
-  return wheel;
-}
+int L1MuDTTrackCand::whNum() const { return wheel; }
 
-int L1MuDTTrackCand::scNum() const {
-  return sector;
-}
+int L1MuDTTrackCand::scNum() const { return sector; }
 
-int L1MuDTTrackCand::stNum(int ust) const {
-  return TrkAdd[ust-1];
-}
+int L1MuDTTrackCand::stNum(int ust) const { return TrkAdd[ust - 1]; }
 
-int L1MuDTTrackCand::TCNum() const {
-  return TClassCode;
-}
+int L1MuDTTrackCand::TCNum() const { return TClassCode; }
 
-int L1MuDTTrackCand::TrkTag() const {
-  return TrkTagCode;
-}
+int L1MuDTTrackCand::TrkTag() const { return TrkTagCode; }
 
 void L1MuDTTrackCand::setTC() {
   unsigned int uqua = quality_packed();
 
   switch (uqua) {
-    case 7:  { TClassCode =  0; break; }
-    case 6:  { TClassCode =  1;
-               if ( TrkAdd[3] != 15 ) TClassCode = 2;
-               break; }
-    case 5:  { TClassCode =  3; break; }
-    case 4:  { TClassCode =  4; break; }
-    case 3:  { TClassCode =  5;
-               if ( TrkAdd[3] != 15 ) TClassCode = 6;
-               if ( TrkAdd[2] != 15 ) TClassCode = 7;
-               break; }
-    case 2:  { TClassCode =  8;
-               if ( TrkAdd[2] != 15 ) TClassCode = 9;
-               break; }
-    case 1:  { TClassCode = 10; break; }
-    default: { TClassCode = 11; break; }
+    case 7: {
+      TClassCode = 0;
+      break;
+    }
+    case 6: {
+      TClassCode = 1;
+      if (TrkAdd[3] != 15)
+        TClassCode = 2;
+      break;
+    }
+    case 5: {
+      TClassCode = 3;
+      break;
+    }
+    case 4: {
+      TClassCode = 4;
+      break;
+    }
+    case 3: {
+      TClassCode = 5;
+      if (TrkAdd[3] != 15)
+        TClassCode = 6;
+      if (TrkAdd[2] != 15)
+        TClassCode = 7;
+      break;
+    }
+    case 2: {
+      TClassCode = 8;
+      if (TrkAdd[2] != 15)
+        TClassCode = 9;
+      break;
+    }
+    case 1: {
+      TClassCode = 10;
+      break;
+    }
+    default: {
+      TClassCode = 11;
+      break;
+    }
   }
 }
 
@@ -144,28 +165,83 @@ void L1MuDTTrackCand::setAdd(int ust) {
   unsigned int uadd = stNum(ust);
 
   switch (uadd) {
-    case  0:  { TrkAdd[ust-1] =   8; break; }
-    case  1:  { TrkAdd[ust-1] =   9; break; }
-    case  2:  { TrkAdd[ust-1] =   0; break; }
-    case  3:  { TrkAdd[ust-1] =   1; break; }
-    case  4:  { TrkAdd[ust-1] =  10; break; }
-    case  5:  { TrkAdd[ust-1] =  11; break; }
-    case  6:  { TrkAdd[ust-1] =   2; break; }
-    case  7:  { TrkAdd[ust-1] =   3; break; }
-    case  8:  { TrkAdd[ust-1] =  12; break; }
-    case  9:  { TrkAdd[ust-1] =  13; break; }
-    case 10:  { TrkAdd[ust-1] =   4; break; }
-    case 11:  { TrkAdd[ust-1] =   5; break; }
-    case 15:  { TrkAdd[ust-1] =  15; break; }
-    default:  { TrkAdd[ust-1] =  15; break; }
+    case 0: {
+      TrkAdd[ust - 1] = 8;
+      break;
+    }
+    case 1: {
+      TrkAdd[ust - 1] = 9;
+      break;
+    }
+    case 2: {
+      TrkAdd[ust - 1] = 0;
+      break;
+    }
+    case 3: {
+      TrkAdd[ust - 1] = 1;
+      break;
+    }
+    case 4: {
+      TrkAdd[ust - 1] = 10;
+      break;
+    }
+    case 5: {
+      TrkAdd[ust - 1] = 11;
+      break;
+    }
+    case 6: {
+      TrkAdd[ust - 1] = 2;
+      break;
+    }
+    case 7: {
+      TrkAdd[ust - 1] = 3;
+      break;
+    }
+    case 8: {
+      TrkAdd[ust - 1] = 12;
+      break;
+    }
+    case 9: {
+      TrkAdd[ust - 1] = 13;
+      break;
+    }
+    case 10: {
+      TrkAdd[ust - 1] = 4;
+      break;
+    }
+    case 11: {
+      TrkAdd[ust - 1] = 5;
+      break;
+    }
+    case 15: {
+      TrkAdd[ust - 1] = 15;
+      break;
+    }
+    default: {
+      TrkAdd[ust - 1] = 15;
+      break;
+    }
   }
 
-  if (ust!=1) return;
-    
+  if (ust != 1)
+    return;
+
   switch (uadd) {
-    case  0:  { TrkAdd[0] =  2; break; }
-    case  1:  { TrkAdd[0] =  1; break; }
-    case 15:  { TrkAdd[0] =  3; break; }
-    default:  { TrkAdd[0] =  3; break; }
+    case 0: {
+      TrkAdd[0] = 2;
+      break;
+    }
+    case 1: {
+      TrkAdd[0] = 1;
+      break;
+    }
+    case 15: {
+      TrkAdd[0] = 3;
+      break;
+    }
+    default: {
+      TrkAdd[0] = 3;
+      break;
+    }
   }
 }

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTTrackContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTTrackContainer.cc
@@ -19,7 +19,6 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
@@ -28,7 +27,6 @@ using namespace std;
 //-------------------
 // Initializations --
 //-------------------
-
 
 //----------------
 // Constructors --
@@ -43,68 +41,50 @@ L1MuDTTrackContainer::~L1MuDTTrackContainer() {}
 //--------------
 // Operations --
 //--------------
-void L1MuDTTrackContainer::setContainer(const TrackContainer& inputTracks) {
+void L1MuDTTrackContainer::setContainer(const TrackContainer& inputTracks) { dtTracks = inputTracks; }
 
-  dtTracks = inputTracks;
-}
-
-L1MuDTTrackContainer::TrackContainer const* L1MuDTTrackContainer::getContainer() const {
-  return &dtTracks;
-}
+L1MuDTTrackContainer::TrackContainer const* L1MuDTTrackContainer::getContainer() const { return &dtTracks; }
 
 bool L1MuDTTrackContainer::bxEmpty(int step) const {
-
   bool empty = true;
 
-  for ( Trackiterator i  = dtTracks.begin();
-                      i != dtTracks.end();
-                      i++ ) {
-    if  (step == i->bx()) empty = false;
+  for (Trackiterator i = dtTracks.begin(); i != dtTracks.end(); i++) {
+    if (step == i->bx())
+      empty = false;
   }
 
-  return(empty);
+  return (empty);
 }
 
 int L1MuDTTrackContainer::bxSize(int step1, int step2) const {
-
   int size = 0;
 
-  for ( Trackiterator i  = dtTracks.begin();
-                      i != dtTracks.end();
-                      i++ ) {
-    if  (step1 <= i->bx() && step2 >= i->bx() 
-      && i->quality_packed() != 0) size++;
+  for (Trackiterator i = dtTracks.begin(); i != dtTracks.end(); i++) {
+    if (step1 <= i->bx() && step2 >= i->bx() && i->quality_packed() != 0)
+      size++;
   }
 
-  return(size);
+  return (size);
 }
 
 L1MuDTTrackCand const* L1MuDTTrackContainer::dtTrackCand1(int wheel, int sect, int step) const {
+  L1MuDTTrackCand const* rT = nullptr;
 
-  L1MuDTTrackCand const* rT=nullptr;
-
-  for ( Trackiterator i  = dtTracks.begin();
-                      i != dtTracks.end();
-                      i++ ) {
-    if  (step == i->bx() && wheel == i->whNum() && sect == i->scNum()
-      && i->TrkTag() == 0)
+  for (Trackiterator i = dtTracks.begin(); i != dtTracks.end(); i++) {
+    if (step == i->bx() && wheel == i->whNum() && sect == i->scNum() && i->TrkTag() == 0)
       rT = &(*i);
   }
 
-  return(rT);
+  return (rT);
 }
 
 L1MuDTTrackCand const* L1MuDTTrackContainer::dtTrackCand2(int wheel, int sect, int step) const {
+  L1MuDTTrackCand const* rT = nullptr;
 
-  L1MuDTTrackCand const* rT=nullptr;
-
-  for ( Trackiterator i  = dtTracks.begin();
-                      i != dtTracks.end();
-                      i++ ) {
-    if  (step == i->bx() && wheel == i->whNum() && sect == i->scNum()
-      && i->TrkTag() == 1)
+  for (Trackiterator i = dtTracks.begin(); i != dtTracks.end(); i++) {
+    if (step == i->bx() && wheel == i->whNum() && sect == i->scNum() && i->TrkTag() == 1)
       rT = &(*i);
   }
 
-  return(rT);
+  return (rT);
 }

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTPhContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTPhContainer.cc
@@ -20,7 +20,6 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
@@ -28,7 +27,6 @@
 //-------------------
 // Initializations --
 //-------------------
-
 
 //----------------
 // Constructors --
@@ -38,11 +36,6 @@ L1Phase2MuDTPhContainer::L1Phase2MuDTPhContainer() {}
 //--------------
 // Operations --
 //--------------
-void L1Phase2MuDTPhContainer::setContainer(const Segment_Container& inputSegments) {
+void L1Phase2MuDTPhContainer::setContainer(const Segment_Container& inputSegments) { m_segments = inputSegments; }
 
-  m_segments = inputSegments;
-}
-
-L1Phase2MuDTPhContainer::Segment_Container const* L1Phase2MuDTPhContainer::getContainer() const {
-  return &m_segments;
-}
+L1Phase2MuDTPhContainer::Segment_Container const* L1Phase2MuDTPhContainer::getContainer() const { return &m_segments; }

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTPhDigi.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTPhDigi.cc
@@ -20,7 +20,6 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
@@ -29,86 +28,61 @@
 // Initializations --
 //-------------------
 
-
 //----------------
 // Constructors --
 //----------------
-L1Phase2MuDTPhDigi::L1Phase2MuDTPhDigi() :
-  m_bx(-100), m_wheel(0), m_sector(0), m_station(0), m_superlayer(0), m_phiAngle(0), 
-  m_phiBending(0), m_qualityCode(-1), m_index(0), m_t0(0), m_chi2(0), m_rpcFlag(-10)
-{
+L1Phase2MuDTPhDigi::L1Phase2MuDTPhDigi()
+    : m_bx(-100),
+      m_wheel(0),
+      m_sector(0),
+      m_station(0),
+      m_superlayer(0),
+      m_phiAngle(0),
+      m_phiBending(0),
+      m_qualityCode(-1),
+      m_index(0),
+      m_t0(0),
+      m_chi2(0),
+      m_rpcFlag(-10) {}
 
-}
-
-
-L1Phase2MuDTPhDigi::L1Phase2MuDTPhDigi( int bx, int wh, int sc, int st, int sl, int phi, int phib,
-					int qual, int idx, int t0, int chi2, int rpc) :
-  m_bx(bx), m_wheel(wh), m_sector(sc), m_station(st), m_superlayer(sl), m_phiAngle(phi), 
-  m_phiBending(phib), m_qualityCode(qual), m_index(idx), m_t0(t0), m_chi2(chi2), m_rpcFlag(rpc)
-{
- 
-}
-
+L1Phase2MuDTPhDigi::L1Phase2MuDTPhDigi(
+    int bx, int wh, int sc, int st, int sl, int phi, int phib, int qual, int idx, int t0, int chi2, int rpc)
+    : m_bx(bx),
+      m_wheel(wh),
+      m_sector(sc),
+      m_station(st),
+      m_superlayer(sl),
+      m_phiAngle(phi),
+      m_phiBending(phib),
+      m_qualityCode(qual),
+      m_index(idx),
+      m_t0(t0),
+      m_chi2(chi2),
+      m_rpcFlag(rpc) {}
 
 //--------------
 // Operations --
 //--------------
-int L1Phase2MuDTPhDigi::bxNum() const 
-{
-  return m_bx;
-}
+int L1Phase2MuDTPhDigi::bxNum() const { return m_bx; }
 
-int L1Phase2MuDTPhDigi::whNum() const 
-{
-  return m_wheel;
-}
+int L1Phase2MuDTPhDigi::whNum() const { return m_wheel; }
 
-int L1Phase2MuDTPhDigi::scNum() const 
-{
-  return m_sector;
-}
+int L1Phase2MuDTPhDigi::scNum() const { return m_sector; }
 
-int L1Phase2MuDTPhDigi::stNum() const 
-{
-  return m_station;
-}
+int L1Phase2MuDTPhDigi::stNum() const { return m_station; }
 
-int L1Phase2MuDTPhDigi::slNum() const 
-{
-  return m_superlayer;
-}
+int L1Phase2MuDTPhDigi::slNum() const { return m_superlayer; }
 
-int L1Phase2MuDTPhDigi::phi() const 
-{
-  return m_phiAngle;
-}
+int L1Phase2MuDTPhDigi::phi() const { return m_phiAngle; }
 
-int L1Phase2MuDTPhDigi::phiBend() const 
-{
-  return m_phiBending;
-}
+int L1Phase2MuDTPhDigi::phiBend() const { return m_phiBending; }
 
-int L1Phase2MuDTPhDigi::quality() const 
-{
-  return m_qualityCode;
-}
+int L1Phase2MuDTPhDigi::quality() const { return m_qualityCode; }
 
-int L1Phase2MuDTPhDigi::index() const
-{
-  return m_index;
-}
+int L1Phase2MuDTPhDigi::index() const { return m_index; }
 
-int L1Phase2MuDTPhDigi::t0() const 
-{
-  return m_t0;
-}
+int L1Phase2MuDTPhDigi::t0() const { return m_t0; }
 
-int L1Phase2MuDTPhDigi::chi2() const 
-{
-  return m_chi2;
-}
+int L1Phase2MuDTPhDigi::chi2() const { return m_chi2; }
 
-int L1Phase2MuDTPhDigi::rpcFlag() const 
-{
-  return m_rpcFlag;
-}
+int L1Phase2MuDTPhDigi::rpcFlag() const { return m_rpcFlag; }

--- a/DataFormats/L1DTTrackFinder/src/classes.h
+++ b/DataFormats/L1DTTrackFinder/src/classes.h
@@ -7,4 +7,3 @@
 #include <DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h>
 #include <DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h>
 #include <DataFormats/Common/interface/Wrapper.h>
-

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
@@ -115,7 +115,6 @@ private:
   DTKeyedConfigCache cfgCache;
 };
 
-
 //
 // constructors and destructor
 //
@@ -142,9 +141,9 @@ DTConfigDBProducer::DTConfigDBProducer(const edm::ParameterSet &p) {
 
   m_UseT0 = p.getParameter<bool>("UseT0");  // CB check for a better way to do it
 
-  if(not cfgConfig) {
+  if (not cfgConfig) {
     cc.setConsumes(m_dttpgParamsToken).setConsumes(m_ccb_confToken);
-    if(m_UseT0) {
+    if (m_UseT0) {
       cc.setConsumes(m_t0iToken);
     }
   }
@@ -204,7 +203,7 @@ std::unique_ptr<DTConfigManager> DTConfigDBProducer::produce(const DTConfigManag
 }
 
 void DTConfigDBProducer::readDBPedestalsConfig(const DTConfigManagerRcd &iRecord, DTConfigManager &dttpgConfig) {
-  const auto& dttpgParams = iRecord.get(m_dttpgParamsToken);
+  const auto &dttpgParams = iRecord.get(m_dttpgParamsToken);
 
   DTConfigPedestals pedestals;
   pedestals.setDebug(m_debugPed);
@@ -339,7 +338,7 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord, DTCon
   dttpgConfig.setCCBConfigValidity(true);
 
   // get DTCCBConfigRcd from DTConfigManagerRcd (they are dependent records)
-  const auto& ccb_conf = iRecord.get(m_ccb_confToken);
+  const auto &ccb_conf = iRecord.get(m_ccb_confToken);
   int ndata = std::distance(ccb_conf.begin(), ccb_conf.end());
 
   const DTKeyedConfigListRcd &keyRecord = iRecord.getRecord<DTKeyedConfigListRcd>();


### PR DESCRIPTION

Applying code-format for CMSSW category l1.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/411//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


