### PR TITLE
Running code-format for reconstruction-upgrade

### DIFF
--- a/DataFormats/HGCRecHit/interface/HGCRecHit.h
+++ b/DataFormats/HGCRecHit/interface/HGCRecHit.h
@@ -39,8 +39,20 @@ public:
   enum HGCbheFlags { kHGCbheGood, kHGCbheDead, kHGCbheHot, kHGCbhePassBX, kHGCbheSaturated };
 
   //   HFnose rechit flags
-  enum HFNoseFlags { kHFNoseGood, kHFNosePoorReco, kHFNoseOutOfTime, kHFNoseFaultyHardware, kHFNoseNoisy, kHFNosePoorCalib, kHFNoseSaturated, kHFNoseDead, kHFNoseKilled, kHFNoseWeird, kHFNoseDiWeird, kHFNoseUnknown };
-
+  enum HFNoseFlags {
+    kHFNoseGood,
+    kHFNosePoorReco,
+    kHFNoseOutOfTime,
+    kHFNoseFaultyHardware,
+    kHFNoseNoisy,
+    kHFNosePoorCalib,
+    kHFNoseSaturated,
+    kHFNoseDead,
+    kHFNoseKilled,
+    kHFNoseWeird,
+    kHFNoseDiWeird,
+    kHFNoseUnknown
+  };
 
   /** bit structure of CaloRecHit::flags_ used in EcalRecHit:
    *

--- a/DataFormats/HGCRecHit/src/HGCRecHit.cc
+++ b/DataFormats/HGCRecHit/src/HGCRecHit.cc
@@ -127,7 +127,7 @@ std::ostream& operator<<(std::ostream& s, const HGCRecHit& hit) {
     return s << HGCSiliconDetId(hit.detid()) << ": " << hit.energy() << " GeV, " << hit.time() << " ns";
   else if (hit.detid().det() == DetId::HGCalHSc)
     return s << HGCScintillatorDetId(hit.detid()) << ": " << hit.energy() << " GeV, " << hit.time() << " ns";
-  else if (hit.detid().det() == DetId::Forward && hit.detid().subdetId() == HFNose) 
+  else if (hit.detid().det() == DetId::Forward && hit.detid().subdetId() == HFNose)
     return s << HFNoseDetId(hit.detid()) << ": " << hit.energy() << " GeV, " << hit.time() << " ns";
   else
     return s << "HGCRecHit undefined subdetector";


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction,upgrade.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/413//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


