### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h
+++ b/DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h
@@ -52,7 +52,7 @@ namespace reco {
       HOLayer = 8,
       /// VFcal(HF) front face
       VFcalEntrance = 9,
-      
+
       NLayers = 10
     };
 

--- a/DataFormats/ParticleFlowReco/src/PFTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/PFTrack.cc
@@ -58,7 +58,6 @@ void PFTrack::calculatePositionREP() {
 const reco::PFTrajectoryPoint& PFTrack::extrapolatedPoint(unsigned layerid) const {
   const unsigned offset_layerid = nTrajectoryMeasurements() + layerid;
   if (layerid >= reco::PFTrajectoryPoint::NLayers || offset_layerid >= trajectoryPoints_.size()) {
-
     throw cms::Exception("SizeError") << "PFRecTrack::extrapolatedPoint: cannot access " << layerid
                                       << " #traj meas = " << nTrajectoryMeasurements()
                                       << " #traj points = " << trajectoryPoints_.size() << endl

--- a/TrackingTools/Producers/src/TrajectoryCleanerESProducer.cc
+++ b/TrackingTools/Producers/src/TrajectoryCleanerESProducer.cc
@@ -6,7 +6,6 @@
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleaner.h"
 
-
 #include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleanerFactory.h"
 
 class TrajectoryCleanerESProducer : public edm::ESProducer {


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/412//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


