### PR TITLE
Running code-format for simulation-upgrade

### DIFF
--- a/DataFormats/ForwardDetId/interface/HFNoseDetId.h
+++ b/DataFormats/ForwardDetId/interface/HFNoseDetId.h
@@ -51,7 +51,7 @@ public:
   int zside() const { return (((id_ >> kHFNoseZsideOffset) & kHFNoseZsideMask) ? -1 : 1); }
 
   /// get the layer #
-  int layer() const { return ((id_ >> kHFNoseLayerOffset) & kHFNoseLayerMask)+1; }
+  int layer() const { return ((id_ >> kHFNoseLayerOffset) & kHFNoseLayerMask) + 1; }
 
   /// get the cell #'s in u,v or in x,y
   int cellU() const { return (id_ >> kHFNoseCellUOffset) & kHFNoseCellUMask; }

--- a/DataFormats/ForwardDetId/src/HFNoseDetId.cc
+++ b/DataFormats/ForwardDetId/src/HFNoseDetId.cc
@@ -15,7 +15,7 @@ HFNoseDetId::HFNoseDetId(int zp, int type, int layer, int waferU, int waferV, in
   int waferUsign = (waferU >= 0) ? 0 : 1;
   int waferVsign = (waferV >= 0) ? 0 : 1;
   int zside = (zp < 0) ? 1 : 0;
-  int lay   = std::max(layer-1, 0);
+  int lay = std::max(layer - 1, 0);
   id_ |= (((cellU & kHFNoseCellUMask) << kHFNoseCellUOffset) | ((cellV & kHFNoseCellVMask) << kHFNoseCellVOffset) |
           ((waferUabs & kHFNoseWaferUMask) << kHFNoseWaferUOffset) |
           ((waferUsign & kHFNoseWaferUSignMask) << kHFNoseWaferUSignOffset) |

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -33,7 +33,9 @@ namespace {
 
   float getPositionDistance(const HGCalGeometry* geom, const DetId& id) { return geom->getPosition(id).mag(); }
 
-  float getPositionDistance(const HcalGeometry* geom, const DetId& id) { return geom->getGeometry(id)->getPosition().mag(); }
+  float getPositionDistance(const HcalGeometry* geom, const DetId& id) {
+    return geom->getGeometry(id)->getPosition().mag();
+  }
 
   int getCellThickness(const HGCalGeometry* geom, const DetId& detid) {
     const auto& dddConst = geom->topology().dddConstants();
@@ -279,8 +281,8 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
     if (producesEEDigis()) {
       auto digiResult = std::make_unique<HGCalDigiCollection>();
       theHGCEEDigitizer_->run(digiResult, *simHitAccumulator_, theGeom, validIds_, digitizationType_, hre);
-      edm::LogVerbatim("HGCDigitizer")
-        << "HGCDigitizer:: finalize event - produced " << digiResult->size() << " EE hits";
+      edm::LogVerbatim("HGCDigitizer") << "HGCDigitizer:: finalize event - produced " << digiResult->size()
+                                       << " EE hits";
 #ifdef EDM_ML_DEBUG
       checkPosition(&(*digiResult));
 #endif
@@ -289,8 +291,8 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
     if (producesHEfrontDigis()) {
       auto digiResult = std::make_unique<HGCalDigiCollection>();
       theHGCHEfrontDigitizer_->run(digiResult, *simHitAccumulator_, theGeom, validIds_, digitizationType_, hre);
-      edm::LogVerbatim("HGCDigitizer")
-        << "HGCDigitizer:: finalize event - produced " << digiResult->size() <<	" HE silicon hits";
+      edm::LogVerbatim("HGCDigitizer") << "HGCDigitizer:: finalize event - produced " << digiResult->size()
+                                       << " HE silicon hits";
 #ifdef EDM_ML_DEBUG
       checkPosition(&(*digiResult));
 #endif
@@ -299,8 +301,8 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
     if (producesHEbackDigis()) {
       auto digiResult = std::make_unique<HGCalDigiCollection>();
       theHGCHEbackDigitizer_->run(digiResult, *simHitAccumulator_, theGeom, validIds_, digitizationType_, hre);
-      edm::LogVerbatim("HGCDigitizer")
-	<< "HGCDigitizer:: finalize event - produced " << digiResult->size() <<	" HE Scintillator hits";                                                      
+      edm::LogVerbatim("HGCDigitizer") << "HGCDigitizer:: finalize event - produced " << digiResult->size()
+                                       << " HE Scintillator hits";
 #ifdef EDM_ML_DEBUG
       checkPosition(&(*digiResult));
 #endif
@@ -309,8 +311,8 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
     if (producesHFNoseDigis()) {
       auto digiResult = std::make_unique<HGCalDigiCollection>();
       theHFNoseDigitizer_->run(digiResult, *simHitAccumulator_, theGeom, validIds_, digitizationType_, hre);
-      edm::LogVerbatim("HGCDigitizer")
-        << "HGCDigitizer:: finalize event - produced " << digiResult->size() <<	" HFNose hits";
+      edm::LogVerbatim("HGCDigitizer") << "HGCDigitizer:: finalize event - produced " << digiResult->size()
+                                       << " HFNose hits";
 #ifdef EDM_ML_DEBUG
       checkPosition(&(*digiResult));
 #endif
@@ -388,11 +390,11 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const& hits,
 
     if (verbosity_ > 0) {
       if (producesEEDigis())
-        edm::LogVerbatim("HGCDigitizer") 
-	  << "HGCDigitizer::i/p " << std::hex << the_hit.id() << " o/p " << id.rawId() << std::dec;
+        edm::LogVerbatim("HGCDigitizer") << "HGCDigitizer::i/p " << std::hex << the_hit.id() << " o/p " << id.rawId()
+                                         << std::dec;
       else
-        edm::LogVerbatim("HGCDigitizer") 
-	  << "HGCDigitizer::i/p " << std::hex << the_hit.id() << " o/p " << id.rawId() << std::dec;
+        edm::LogVerbatim("HGCDigitizer") << "HGCDigitizer::i/p " << std::hex << the_hit.id() << " o/p " << id.rawId()
+                                         << std::dec;
     }
 
     if (0 != id.rawId()) {
@@ -682,41 +684,22 @@ void HGCDigitizer::checkPosition(const HGCalDigiCollection* digis) const {
       bool val = gHGCal_->topology().valid(id);
       if ((!ok) || (!val)) {
         if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
-	  edm::LogVerbatim("HGCDigitizer") << "Check " << HGCSiliconDetId(id)
-                                           << " " << global << " R " << r
-                                           << ":" << rrange.first << ":"
-                                           << rrange.second << " Z " << z
-                                           << ":" << zrange.first << ":"
-                                           << zrange.second << " Flag "
-                                           << ok << ":" << val << " " << ck;
+          edm::LogVerbatim("HGCDigitizer") << "Check " << HGCSiliconDetId(id) << " " << global << " R " << r << ":"
+                                           << rrange.first << ":" << rrange.second << " Z " << z << ":" << zrange.first
+                                           << ":" << zrange.second << " Flag " << ok << ":" << val << " " << ck;
         } else if (id.det() == DetId::HGCalHSc) {
-	  edm::LogVerbatim("HGCDigitizer") << "Check " << HGCScintillatorDetId(id)
-                                           << " " << global << " R " << r
-                                           << ":"  << rrange.first << ":"
-                                           << rrange.second << " Z " << z
-                                           << ":" << zrange.first << ":"
-                                           << zrange.second << " Flag "
-                                           << ok << ":" << val << " " << ck;
-        } else if ((id.det() == DetId::Forward) &&
-                   (id.subdetId() == static_cast<int>(HFNose))) {
-	  edm::LogVerbatim("HGCDigitizer") << "Check " << HFNoseDetId(id)
-                                           << " " << global << " R " << r
-                                           << ":"  << rrange.first << ":"
-                                           << rrange.second << " Z " << z
-                                           << ":" << zrange.first << ":"
-                                           << zrange.second << " Flag "
-                                           << ok << ":" << val << " " << ck;
+          edm::LogVerbatim("HGCDigitizer") << "Check " << HGCScintillatorDetId(id) << " " << global << " R " << r << ":"
+                                           << rrange.first << ":" << rrange.second << " Z " << z << ":" << zrange.first
+                                           << ":" << zrange.second << " Flag " << ok << ":" << val << " " << ck;
+        } else if ((id.det() == DetId::Forward) && (id.subdetId() == static_cast<int>(HFNose))) {
+          edm::LogVerbatim("HGCDigitizer") << "Check " << HFNoseDetId(id) << " " << global << " R " << r << ":"
+                                           << rrange.first << ":" << rrange.second << " Z " << z << ":" << zrange.first
+                                           << ":" << zrange.second << " Flag " << ok << ":" << val << " " << ck;
         } else {
-	  edm::LogVerbatim("HGCDigitizer") << "Check " << std::hex
-                                           << id.rawId() << std::dec
-                                           << " " << id.det() << ":"
-                                           << id.subdetId()
-                                           << " " << global << " R " << r
-                                           << ":"  << rrange.first << ":"
-					   << rrange.second << " Z " << z
-                                           << ":" << zrange.first << ":"
-                                           << zrange.second << " Flag "
-                                           << ok << ":" << val << " " << ck;
+          edm::LogVerbatim("HGCDigitizer")
+              << "Check " << std::hex << id.rawId() << std::dec << " " << id.det() << ":" << id.subdetId() << " "
+              << global << " R " << r << ":" << rrange.first << ":" << rrange.second << " Z " << z << ":"
+              << zrange.first << ":" << zrange.second << " Flag " << ok << ":" << val << " " << ck;
         }
       }
     }

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -340,9 +340,9 @@ void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::unique_ptr<HGCalDigiCollect
       if (noise_MIP_ != 0)
         chargeColl[i] += std::max(CLHEP::RandGaussQ::shoot(engine, 0., noise_MIP_), 0.);
       if (debug && cell.hit_info[0][i] > 0)
-	edm::LogVerbatim("HGCDigitizer") 
-	  << "[runCaliceLikeDigitizer] xtalk=" << xtalk << " En=" << cell.hit_info[0][i] << " keV -> "
-	  << totalIniMIPs << " raw-MIPs -> " << chargeColl[i] << " digi-MIPs";
+        edm::LogVerbatim("HGCDigitizer") << "[runCaliceLikeDigitizer] xtalk=" << xtalk << " En=" << cell.hit_info[0][i]
+                                         << " keV -> " << totalIniMIPs << " raw-MIPs -> " << chargeColl[i]
+                                         << " digi-MIPs";
     }
 
     //init a new data frame and run shaper


### PR DESCRIPTION

Applying code-format for CMSSW category simulation,upgrade.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/415//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


