### PR TITLE
Running code-format for visualization

### DIFF
--- a/Fireworks/Calo/interface/FWHeatmapProxyBuilderTemplate.h
+++ b/Fireworks/Calo/interface/FWHeatmapProxyBuilderTemplate.h
@@ -90,45 +90,43 @@ protected:
       iItem->getConfig()->assertParam("Z-", true);
     }
   }
-  
-  void build(const FWEventItem *iItem, TEveElementList *product, const FWViewContext *vc) override
-  {
-      if (item()->getConfig()->template value<bool>("Heatmap"))
-      {
-         hitmap.clear();
 
-         edm::Handle<HGCRecHitCollection> recHitHandleEE;
-         edm::Handle<HGCRecHitCollection> recHitHandleFH;
-         edm::Handle<HGCRecHitCollection> recHitHandleBH;   
+  void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext* vc) override {
+    if (item()->getConfig()->template value<bool>("Heatmap")) {
+      hitmap.clear();
 
-         const edm::EventBase *event = iItem->getEvent();
-         event->getByLabel( edm::InputTag( "HGCalRecHit", "HGCEERecHits" ), recHitHandleEE );
-         event->getByLabel( edm::InputTag( "HGCalRecHit", "HGCHEFRecHits" ), recHitHandleFH );
-         event->getByLabel( edm::InputTag( "HGCalRecHit", "HGCHEBRecHits" ), recHitHandleBH );
+      edm::Handle<HGCRecHitCollection> recHitHandleEE;
+      edm::Handle<HGCRecHitCollection> recHitHandleFH;
+      edm::Handle<HGCRecHitCollection> recHitHandleBH;
 
-         if(recHitHandleEE.isValid()){
-            const auto& rechitsEE = *recHitHandleEE;
+      const edm::EventBase* event = iItem->getEvent();
+      event->getByLabel(edm::InputTag("HGCalRecHit", "HGCEERecHits"), recHitHandleEE);
+      event->getByLabel(edm::InputTag("HGCalRecHit", "HGCHEFRecHits"), recHitHandleFH);
+      event->getByLabel(edm::InputTag("HGCalRecHit", "HGCHEBRecHits"), recHitHandleBH);
 
-            for (unsigned int i = 0; i < rechitsEE.size(); ++i) {
-               hitmap[rechitsEE[i].detid().rawId()] = &rechitsEE[i];
-            }
-         }
+      if (recHitHandleEE.isValid()) {
+        const auto& rechitsEE = *recHitHandleEE;
 
-         if(recHitHandleFH.isValid()){
-            const auto& rechitsFH = *recHitHandleFH;
+        for (unsigned int i = 0; i < rechitsEE.size(); ++i) {
+          hitmap[rechitsEE[i].detid().rawId()] = &rechitsEE[i];
+        }
+      }
 
-            for (unsigned int i = 0; i < rechitsFH.size(); ++i) {
-               hitmap[rechitsFH[i].detid().rawId()] = &rechitsFH[i];
-            }
-         }
+      if (recHitHandleFH.isValid()) {
+        const auto& rechitsFH = *recHitHandleFH;
 
-         if(recHitHandleBH.isValid()){
-            const auto& rechitsBH = *recHitHandleBH;
+        for (unsigned int i = 0; i < rechitsFH.size(); ++i) {
+          hitmap[rechitsFH[i].detid().rawId()] = &rechitsFH[i];
+        }
+      }
 
-            for (unsigned int i = 0; i < rechitsBH.size(); ++i) {
-               hitmap[rechitsBH[i].detid().rawId()] = &rechitsBH[i];
-            }
-         }
+      if (recHitHandleBH.isValid()) {
+        const auto& rechitsBH = *recHitHandleBH;
+
+        for (unsigned int i = 0; i < rechitsBH.size(); ++i) {
+          hitmap[rechitsBH[i].detid().rawId()] = &rechitsBH[i];
+        }
+      }
     }
 
     FWSimpleProxyBuilder::build(iItem, product, vc);

--- a/Fireworks/SimData/plugins/FWECaloParticleProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWECaloParticleProxyBuilder.cc
@@ -7,55 +7,57 @@
 
 #include "TEveBoxSet.h"
 
-class FWECaloParticleProxyBuilder : public FWSimpleProxyBuilderTemplate<CaloParticle>
-{
- public:
-   FWECaloParticleProxyBuilder(void) {}
-   ~FWECaloParticleProxyBuilder(void) override {}
+class FWECaloParticleProxyBuilder : public FWSimpleProxyBuilderTemplate<CaloParticle> {
+public:
+  FWECaloParticleProxyBuilder(void) {}
+  ~FWECaloParticleProxyBuilder(void) override {}
 
-   REGISTER_PROXYBUILDER_METHODS();
+  REGISTER_PROXYBUILDER_METHODS();
 
- private:
-   // Disable default copy constructor
-   FWECaloParticleProxyBuilder(const FWECaloParticleProxyBuilder &) = delete;
-   // Disable default assignment operator
-   const FWECaloParticleProxyBuilder &operator=(const FWECaloParticleProxyBuilder &) = delete;
+private:
+  // Disable default copy constructor
+  FWECaloParticleProxyBuilder(const FWECaloParticleProxyBuilder &) = delete;
+  // Disable default assignment operator
+  const FWECaloParticleProxyBuilder &operator=(const FWECaloParticleProxyBuilder &) = delete;
 
-   void build(const CaloParticle &iData, unsigned int iIndex, TEveElement &oItemHolder, const FWViewContext *) override;
+  void build(const CaloParticle &iData, unsigned int iIndex, TEveElement &oItemHolder, const FWViewContext *) override;
 };
 
-void FWECaloParticleProxyBuilder::build(const CaloParticle &iData, unsigned int iIndex, TEveElement &oItemHolder, const FWViewContext *)
-{
-   TEveBoxSet *boxset = new TEveBoxSet();
-   boxset->UseSingleColor();
-   boxset->SetPickable(true);
-   boxset->Reset(TEveBoxSet::kBT_FreeBox, true, 64);
-   boxset->SetAntiFlick(true);
+void FWECaloParticleProxyBuilder::build(const CaloParticle &iData,
+                                        unsigned int iIndex,
+                                        TEveElement &oItemHolder,
+                                        const FWViewContext *) {
+  TEveBoxSet *boxset = new TEveBoxSet();
+  boxset->UseSingleColor();
+  boxset->SetPickable(true);
+  boxset->Reset(TEveBoxSet::kBT_FreeBox, true, 64);
+  boxset->SetAntiFlick(true);
 
-   for (const auto &c : iData.simClusters())
-   {
-      for (const auto &it : (*c).hits_and_fractions())
-      {
-         if(DetId(it.first).det() != DetId::Detector::Ecal){
-            std::cerr << "this proxy should be used only for ECAL";
-            return;
-         }
-
-         const float *corners = item()->getGeom()->getCorners(it.first);
-         if (corners == nullptr)
-            continue;
-
-         boxset->AddBox(corners);
+  for (const auto &c : iData.simClusters()) {
+    for (const auto &it : (*c).hits_and_fractions()) {
+      if (DetId(it.first).det() != DetId::Detector::Ecal) {
+        std::cerr << "this proxy should be used only for ECAL";
+        return;
       }
-   }
 
-   boxset->RefitPlex();
-   boxset->CSCTakeAnyParentAsMaster();
-   boxset->CSCApplyMainColorToMatchingChildren();
-   boxset->CSCApplyMainTransparencyToMatchingChildren();
-   boxset->SetMainColor(item()->modelInfo(iIndex).displayProperties().color());
-   boxset->SetMainTransparency(item()->defaultDisplayProperties().transparency());
-   oItemHolder.AddElement(boxset);
+      const float *corners = item()->getGeom()->getCorners(it.first);
+      if (corners == nullptr)
+        continue;
+
+      boxset->AddBox(corners);
+    }
+  }
+
+  boxset->RefitPlex();
+  boxset->CSCTakeAnyParentAsMaster();
+  boxset->CSCApplyMainColorToMatchingChildren();
+  boxset->CSCApplyMainTransparencyToMatchingChildren();
+  boxset->SetMainColor(item()->modelInfo(iIndex).displayProperties().color());
+  boxset->SetMainTransparency(item()->defaultDisplayProperties().transparency());
+  oItemHolder.AddElement(boxset);
 }
 
-REGISTER_FWPROXYBUILDER(FWECaloParticleProxyBuilder, CaloParticle, "ECaloParticle", FWViewType::kAll3DBits | FWViewType::kAllRPZBits);
+REGISTER_FWPROXYBUILDER(FWECaloParticleProxyBuilder,
+                        CaloParticle,
+                        "ECaloParticle",
+                        FWViewType::kAll3DBits | FWViewType::kAllRPZBits);


### PR DESCRIPTION

Applying code-format for CMSSW category visualization.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/417//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


