### PR TITLE
Add missing library in CalibTracker/SiStripCommon

### DIFF
--- a/CalibTracker/SiStripCommon/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="CondFormats/SiStripObjects"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/SiStripDetId"/>
+<use   name="DataFormats/Scalers"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ServiceRegistry"/>


### PR DESCRIPTION
#### PR description:

Need to link with DataFormats/Scalers in order for UBSAN to work.

#### PR validation:

Compiles and links with CMSSW_11_0_UBSAN_X_2019-06-18-1100 IB.