### PR TITLE
Added missing links to CalibMuon/DTCalibration

### DIFF
--- a/CalibMuon/DTCalibration/BuildFile.xml
+++ b/CalibMuon/DTCalibration/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="DataFormats/DTRecHit"/>
 <use   name="DataFormats/CSCRecHit"/>
 <use   name="DataFormats/TrackReco"/>
+<use   name="DataFormats/MuonReco"/>
 <use   name="Geometry/DTGeometry"/>
 <use   name="Geometry/Records"/>
 <use   name="CondFormats/DTObjects"/>

--- a/CalibMuon/DTCalibration/plugins/BuildFile.xml
+++ b/CalibMuon/DTCalibration/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="DataFormats/DTDigi"/>
 <use   name="DataFormats/DTRecHit"/>
+<use   name="DataFormats/MuonReco"/>
 <use   name="Geometry/DTGeometry"/>
 <use   name="Geometry/Records"/>
 <use   name="Geometry/MuonNumbering"/>


### PR DESCRIPTION
#### PR description:

Need to link with DataFormats/MuonReco to make UBSAN work.


#### PR validation:

Compiles and links using CMSSW_11_0_UBSAN_X_2019-06-18-1100 IB.