### PR TITLE
Running code-format for alca-analysis-db

### DIFF
--- a/CondCore/ESSources/interface/DataProxy.h
+++ b/CondCore/ESSources/interface/DataProxy.h
@@ -11,29 +11,28 @@
 
 // expose a cond::PayloadProxy as a eventsetup::DataProxy
 namespace cond {
-  template< typename DataT> struct DefaultInitializer {
-    void operator()(DataT &){}
+  template <typename DataT>
+  struct DefaultInitializer {
+    void operator()(DataT&) {}
   };
-}
+}  // namespace cond
 
-template< class RecordT, class DataT , typename Initializer=cond::DefaultInitializer<DataT> >
-class DataProxy : public edm::eventsetup::DataProxyTemplate<RecordT, DataT >{
-  public:
-  typedef DataProxy<RecordT,DataT> self;
-    typedef std::shared_ptr<cond::persistency::PayloadProxy<DataT> > DataP;
+template <class RecordT, class DataT, typename Initializer = cond::DefaultInitializer<DataT> >
+class DataProxy : public edm::eventsetup::DataProxyTemplate<RecordT, DataT> {
+public:
+  typedef DataProxy<RecordT, DataT> self;
+  typedef std::shared_ptr<cond::persistency::PayloadProxy<DataT> > DataP;
 
-    explicit DataProxy(std::shared_ptr<cond::persistency::PayloadProxy<DataT> > pdata) : m_data(pdata) { 
- 
-  }
+  explicit DataProxy(std::shared_ptr<cond::persistency::PayloadProxy<DataT> > pdata) : m_data(pdata) {}
   //virtual ~DataProxy();
-  
+
   // ---------- const member functions ---------------------
-  
+
   // ---------- static member functions --------------------
-  
+
   // ---------- member functions ---------------------------
-  
-  protected:
+
+protected:
   const DataT* make(const RecordT&, const edm::eventsetup::DataKey&) override {
     m_data->make();
     m_initializer(const_cast<DataT&>((*m_data)()));
@@ -43,15 +42,14 @@ class DataProxy : public edm::eventsetup::DataProxyTemplate<RecordT, DataT >{
     // don't, preserve data for future access
     // m_data->invalidateCache();
   }
-  void invalidateTransientCache() override {
-    m_data->invalidateTransientCache();
-  }
-  private:
+  void invalidateTransientCache() override { m_data->invalidateTransientCache(); }
+
+private:
   //DataProxy(); // stop default
-  const DataProxy& operator=( const DataProxy& ) = delete; // stop default
+  const DataProxy& operator=(const DataProxy&) = delete;  // stop default
   // ---------- member data --------------------------------
 
-  std::shared_ptr<cond::persistency::PayloadProxy<DataT> >  m_data;
+  std::shared_ptr<cond::persistency::PayloadProxy<DataT> > m_data;
   Initializer m_initializer;
 };
 
@@ -64,89 +62,92 @@ namespace cond {
   public:
     typedef std::shared_ptr<cond::persistency::BasePayloadProxy> ProxyP;
     typedef std::shared_ptr<edm::eventsetup::DataProxy> edmProxyP;
-    
+
     // limitation of plugin manager...
-    typedef std::pair< std::string, std::string> Args;
+    typedef std::pair<std::string, std::string> Args;
 
-    virtual edm::eventsetup::TypeTag type() const=0;
-    virtual ProxyP proxy() const=0;
-    virtual edmProxyP edmProxy() const=0;
-
+    virtual edm::eventsetup::TypeTag type() const = 0;
+    virtual ProxyP proxy() const = 0;
+    virtual edmProxyP edmProxy() const = 0;
 
     DataProxyWrapperBase();
-    explicit DataProxyWrapperBase(std::string const & il);
+    explicit DataProxyWrapperBase(std::string const& il);
     // late initialize (to allow to load ALL library first)
-    virtual void lateInit(cond::persistency::Session& session, const std::string & tag, const boost::posix_time::ptime& snapshotTime,
-			  std::string const & il, std::string const & cs)=0;
+    virtual void lateInit(cond::persistency::Session& session,
+                          const std::string& tag,
+                          const boost::posix_time::ptime& snapshotTime,
+                          std::string const& il,
+                          std::string const& cs) = 0;
 
-    void addInfo(std::string const & il, std::string const & cs, std::string const & tag);
-    
+    void addInfo(std::string const& il, std::string const& cs, std::string const& tag);
 
     virtual ~DataProxyWrapperBase();
-    std::string const & label() const { return m_label;}
+    std::string const& label() const { return m_label; }
 
-    std::string const & connString() const { return m_connString;}
-    std::string const & tag() const { return m_tag;}
+    std::string const& connString() const { return m_connString; }
+    std::string const& tag() const { return m_tag; }
 
   private:
     std::string m_label;
     std::string m_connString;
     std::string m_tag;
-
   };
-}
+}  // namespace cond
 
 /* bridge between the cond world and eventsetup world
  * keep them separated!
  */
-template< class RecordT, class DataT, typename Initializer=cond::DefaultInitializer<DataT> >
-class DataProxyWrapper : public  cond::DataProxyWrapperBase {
+template <class RecordT, class DataT, typename Initializer = cond::DefaultInitializer<DataT> >
+class DataProxyWrapper : public cond::DataProxyWrapperBase {
 public:
-  typedef ::DataProxy<RecordT,DataT, Initializer> DataProxy;
+  typedef ::DataProxy<RecordT, DataT, Initializer> DataProxy;
   typedef cond::persistency::PayloadProxy<DataT> PayProxy;
   typedef std::shared_ptr<PayProxy> DataP;
-  
-  
+
   DataProxyWrapper(cond::persistency::Session& session,
-		   const std::string& tag, const std::string& ilabel, const char * source=nullptr) :
-    cond::DataProxyWrapperBase(ilabel),
-    m_source( source ? source : "" ),
-    m_proxy(new PayProxy( source)), //'errorPolicy set to true: PayloadProxy should catch and re-throw ORA exceptions' still needed?
-    m_edmProxy(new DataProxy(m_proxy)){
-    m_proxy->setUp( session );
+                   const std::string& tag,
+                   const std::string& ilabel,
+                   const char* source = nullptr)
+      : cond::DataProxyWrapperBase(ilabel),
+        m_source(source ? source : ""),
+        m_proxy(new PayProxy(
+            source)),  //'errorPolicy set to true: PayloadProxy should catch and re-throw ORA exceptions' still needed?
+        m_edmProxy(new DataProxy(m_proxy)) {
+    m_proxy->setUp(session);
     //NOTE: We do this so that the type 'DataT' will get registered
     // when the plugin is dynamically loaded
     m_type = edm::eventsetup::DataKey::makeTypeTag<DataT>();
   }
 
   // constructor from plugin...
-  explicit DataProxyWrapper(const char * source=nullptr) : m_source (source ? source : "") {
+  explicit DataProxyWrapper(const char* source = nullptr) : m_source(source ? source : "") {
     //NOTE: We do this so that the type 'DataT' will get registered
     // when the plugin is dynamically loaded
     m_type = edm::eventsetup::DataKey::makeTypeTag<DataT>();
   }
 
   // late initialize (to allow to load ALL library first)
-  void lateInit(cond::persistency::Session& session, const std::string & tag, const boost::posix_time::ptime& snapshotTime,
-			std::string const & il, std::string const & cs) override {
-    m_proxy.reset(new PayProxy(m_source.empty() ?  (const char *)nullptr : m_source.c_str() ) );
-    m_proxy->setUp( session );
-    m_proxy->loadTag( tag, snapshotTime );
+  void lateInit(cond::persistency::Session& session,
+                const std::string& tag,
+                const boost::posix_time::ptime& snapshotTime,
+                std::string const& il,
+                std::string const& cs) override {
+    m_proxy.reset(new PayProxy(m_source.empty() ? (const char*)nullptr : m_source.c_str()));
+    m_proxy->setUp(session);
+    m_proxy->loadTag(tag, snapshotTime);
     m_edmProxy.reset(new DataProxy(m_proxy));
     addInfo(il, cs, tag);
   }
-    
-  edm::eventsetup::TypeTag type() const override { return m_type;}
-  ProxyP proxy() const override { return m_proxy;}
-  edmProxyP edmProxy() const override { return m_edmProxy;}
- 
+
+  edm::eventsetup::TypeTag type() const override { return m_type; }
+  ProxyP proxy() const override { return m_proxy; }
+  edmProxyP edmProxy() const override { return m_edmProxy; }
+
 private:
   std::string m_source;
   edm::eventsetup::TypeTag m_type;
-  std::shared_ptr<cond::persistency::PayloadProxy<DataT> >  m_proxy;
+  std::shared_ptr<cond::persistency::PayloadProxy<DataT> > m_proxy;
   edmProxyP m_edmProxy;
-
 };
-
 
 #endif /* CONDCORE_PLUGINSYSTEM_DATAPROXY_H */

--- a/CondCore/ESSources/interface/ProxyFactory.h
+++ b/CondCore/ESSources/interface/ProxyFactory.h
@@ -4,7 +4,7 @@
 //
 // Package:     ESSources
 // Class  :     ProxyFactory
-// 
+//
 /**\class ProxyFactory ProxyFactory.h CondCore/ESSources/interface/ProxyFactory.h
    
 Description: <one line class summary>
@@ -18,7 +18,7 @@ Usage:
 //         Created:  Sat Jul 23 19:14:06 EDT 2005
 //
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-#include<string>
+#include <string>
 
 namespace cond {
   class DataProxyWrapperBase;
@@ -26,9 +26,9 @@ namespace cond {
     class Session;
   }
 
-  typedef edmplugin::PluginFactory< cond::DataProxyWrapperBase* ()  > ProxyFactory;
+  typedef edmplugin::PluginFactory<cond::DataProxyWrapperBase*()> ProxyFactory;
 
-   const char* pluginCategory();
-}
+  const char* pluginCategory();
+}  // namespace cond
 
 #endif /* CONDCORE_PLUGINSYSTEM_PROXYFACTORY_H */

--- a/CondCore/ESSources/interface/registration_macros.h
+++ b/CondCore/ESSources/interface/registration_macros.h
@@ -4,7 +4,7 @@
 //
 // Package:     ESSources
 // Class  :     registration_macros
-// 
+//
 /**\class registration_macros registration_macros.h TestCondDB/ESSources/interface/registration_macros.h
 
  Description: CPP macros used to simplify registration of plugins
@@ -29,33 +29,31 @@
 // macros
 #define INSTANTIATE_PROXY(record_, type_) template class DataProxyWrapper<record_, type_>;
 
+#define ONLY_REGISTER_PLUGIN(record_, type_)                                \
+  typedef DataProxyWrapper<record_, type_> EDM_PLUGIN_SYM(Proxy, __LINE__); \
+  DEFINE_EDM_PLUGIN(cond::ProxyFactory, EDM_PLUGIN_SYM(Proxy, __LINE__), #record_ "@NewProxy")
 
-#define ONLY_REGISTER_PLUGIN(record_,type_)\
-typedef DataProxyWrapper<record_, type_> EDM_PLUGIN_SYM(Proxy , __LINE__ ); \
-DEFINE_EDM_PLUGIN( cond::ProxyFactory, EDM_PLUGIN_SYM(Proxy , __LINE__ ), #record_ "@NewProxy")
+#define REGISTER_PLUGIN(record_, type_) \
+  INSTANTIATE_PROXY(record_, type_)     \
+  ONLY_REGISTER_PLUGIN(record_, type_)
 
-#define REGISTER_PLUGIN(record_, type_ ) \
-INSTANTIATE_PROXY(record_, type_ ) \
-ONLY_REGISTER_PLUGIN(record_, type_ )
+#define INSTANTIATE_PROXY_INIT(record_, type_, initializer_) \
+  template class DataProxyWrapper<record_, type_, initializer_>;
 
-#define INSTANTIATE_PROXY_INIT(record_, type_, initializer_) template class DataProxyWrapper<record_, type_, initializer_>;
-
-#define ONLY_REGISTER_PLUGIN_INIT(record_,type_, initializer_)\
-typedef DataProxyWrapper<record_, type_, initializer_> EDM_PLUGIN_SYM(Proxy , __LINE__ ); \
-DEFINE_EDM_PLUGIN( cond::ProxyFactory, EDM_PLUGIN_SYM(Proxy , __LINE__ ), #record_ "@NewProxy")
+#define ONLY_REGISTER_PLUGIN_INIT(record_, type_, initializer_)                           \
+  typedef DataProxyWrapper<record_, type_, initializer_> EDM_PLUGIN_SYM(Proxy, __LINE__); \
+  DEFINE_EDM_PLUGIN(cond::ProxyFactory, EDM_PLUGIN_SYM(Proxy, __LINE__), #record_ "@NewProxy")
 
 #define REGISTER_PLUGIN_INIT(record_, type_, initializer_) \
-INSTANTIATE_PROXY_INIT(record_, type_, initializer_ ) \
-ONLY_REGISTER_PLUGIN_INIT(record_, type_, initializer_ )
-
-
+  INSTANTIATE_PROXY_INIT(record_, type_, initializer_)     \
+  ONLY_REGISTER_PLUGIN_INIT(record_, type_, initializer_)
 
 // source_ is the record name of the keyed objects
-#define REGISTER_KEYLIST_PLUGIN(record_, type_, source_) \
-template class DataProxyWrapper<record_, type_>; \
- struct EDM_PLUGIN_SYM(Proxy , record_ ) : public  DataProxyWrapper<record_, type_> { EDM_PLUGIN_SYM(Proxy , record_ ) () :  DataProxyWrapper<record_, type_>(#source_){};}; \
-DEFINE_EDM_PLUGIN( cond::ProxyFactory, EDM_PLUGIN_SYM(Proxy , record_ ), #record_ "@NewProxy") 
-
-
+#define REGISTER_KEYLIST_PLUGIN(record_, type_, source_)                             \
+  template class DataProxyWrapper<record_, type_>;                                   \
+  struct EDM_PLUGIN_SYM(Proxy, record_) : public DataProxyWrapper<record_, type_> {  \
+    EDM_PLUGIN_SYM(Proxy, record_)() : DataProxyWrapper<record_, type_>(#source_){}; \
+  };                                                                                 \
+  DEFINE_EDM_PLUGIN(cond::ProxyFactory, EDM_PLUGIN_SYM(Proxy, record_), #record_ "@NewProxy")
 
 #endif /* PLUGINSYSTEM_REGISTRATION_MACROS_H */

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -32,13 +32,10 @@ namespace {
   /* utility ot build the name of the plugin corresponding to a given record
      se ESSources
    */
-  std::string
-  buildName( std::string const & iRecordName ) {
-    return iRecordName + std::string( "@NewProxy" );
-  }
-  
-  std::string joinRecordAndLabel( std::string const & iRecordName, std::string const & iLabelName ) {
-    return iRecordName + std::string( "@" ) + iLabelName;
+  std::string buildName(std::string const& iRecordName) { return iRecordName + std::string("@NewProxy"); }
+
+  std::string joinRecordAndLabel(std::string const& iRecordName, std::string const& iLabelName) {
+    return iRecordName + std::string("@") + iLabelName;
   }
 
   /* utility class to return a IOVs associated to a given "name"
@@ -49,45 +46,44 @@ namespace {
    */
   class CondGetterFromESSource : public cond::persistency::CondGetter {
   public:
-    CondGetterFromESSource(CondDBESSource::ProxyMap const & ip) : m_proxies(ip){}
-    ~CondGetterFromESSource() override{}
+    CondGetterFromESSource(CondDBESSource::ProxyMap const& ip) : m_proxies(ip) {}
+    ~CondGetterFromESSource() override {}
 
     cond::persistency::IOVProxy get(std::string name) const override {
       CondDBESSource::ProxyMap::const_iterator p = m_proxies.find(name);
-      if ( p != m_proxies.end())
-	return (*p).second->proxy()->iov();
+      if (p != m_proxies.end())
+        return (*p).second->proxy()->iov();
       return cond::persistency::IOVProxy();
     }
 
-    CondDBESSource::ProxyMap const & m_proxies;
+    CondDBESSource::ProxyMap const& m_proxies;
   };
 
   // This needs to be re-design and implemented...
   // dump the state of a DataProxy
-  void dumpInfo(std::ostream & out, std::string const & recName, cond::DataProxyWrapperBase const & proxy) {
+  void dumpInfo(std::ostream& out, std::string const& recName, cond::DataProxyWrapperBase const& proxy) {
     //cond::SequenceState state(proxy.proxy()->iov().state());
-    out << recName << " / " << proxy.label() << ": " 
-	<< proxy.connString() << ", " << proxy.tag()   << "\n  "
-      //	<< state.size() << ", " << state.revision()  << ", "
-      //	<< cond::time::to_boost(state.timestamp())     << "\n  "
-      //	<< state.comment()
-	<< "\n  "
-      //	<< "refresh " << proxy.proxy()->stats.nRefresh
-      //	<< "/" << proxy.proxy()->stats.nArefresh
-      //	<< ", reconnect " << proxy.proxy()->stats.nReconnect
-      //	<< "/" << proxy.proxy()->stats.nAreconnect
-      //	<< ", make " << proxy.proxy()->stats.nMake
-      //	<< ", load " << proxy.proxy()->stats.nLoad
-      ;
+    out << recName << " / " << proxy.label() << ": " << proxy.connString() << ", " << proxy.tag()
+        << "\n  "
+        //	<< state.size() << ", " << state.revision()  << ", "
+        //	<< cond::time::to_boost(state.timestamp())     << "\n  "
+        //	<< state.comment()
+        << "\n  "
+        //	<< "refresh " << proxy.proxy()->stats.nRefresh
+        //	<< "/" << proxy.proxy()->stats.nArefresh
+        //	<< ", reconnect " << proxy.proxy()->stats.nReconnect
+        //	<< "/" << proxy.proxy()->stats.nAreconnect
+        //	<< ", make " << proxy.proxy()->stats.nMake
+        //	<< ", load " << proxy.proxy()->stats.nLoad
+        ;
     //if ( proxy.proxy()->stats.nLoad>0) {
-    out << "Time look up, payloadIds:" <<std::endl;
-    const auto& pids =  proxy.proxy()->requests();
-    for (auto id: pids )
-      out << "   "<< id.since <<" - "<< id.till <<" : "<<id.payloadId<<std::endl; 
+    out << "Time look up, payloadIds:" << std::endl;
+    const auto& pids = proxy.proxy()->requests();
+    for (auto id : pids)
+      out << "   " << id.since << " - " << id.till << " : " << id.payloadId << std::endl;
   }
 
-}
-
+}  // namespace
 
 /*
  *  config Param
@@ -97,109 +93,109 @@ namespace {
  *  globaltag: The GlobalTag
  *  toGet: list of record label tag connection-string to add/overwrite the content of the global-tag
  */
-CondDBESSource::CondDBESSource( const edm::ParameterSet& iConfig ) :
-  m_connection(), 
-  m_connectionString(""),
-  m_lastRun(0),  // for the stat
-  m_lastLumi(0),  // for the stat
-  m_policy( NOREFRESH ),
-  m_doDump( iConfig.getUntrackedParameter<bool>( "DumpStat", false ) )
-{
-  if( iConfig.getUntrackedParameter<bool>( "RefreshAlways", false ) ) {
+CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
+    : m_connection(),
+      m_connectionString(""),
+      m_lastRun(0),   // for the stat
+      m_lastLumi(0),  // for the stat
+      m_policy(NOREFRESH),
+      m_doDump(iConfig.getUntrackedParameter<bool>("DumpStat", false)) {
+  if (iConfig.getUntrackedParameter<bool>("RefreshAlways", false)) {
     m_policy = REFRESH_ALWAYS;
   }
-  if( iConfig.getUntrackedParameter<bool>( "RefreshOpenIOVs", false ) ) {
+  if (iConfig.getUntrackedParameter<bool>("RefreshOpenIOVs", false)) {
     m_policy = REFRESH_OPEN_IOVS;
   }
-  if( iConfig.getUntrackedParameter<bool>( "RefreshEachRun", false ) ) {
+  if (iConfig.getUntrackedParameter<bool>("RefreshEachRun", false)) {
     m_policy = REFRESH_EACH_RUN;
   }
-  if( iConfig.getUntrackedParameter<bool>( "ReconnectEachRun", false ) ) {
+  if (iConfig.getUntrackedParameter<bool>("ReconnectEachRun", false)) {
     m_policy = RECONNECT_EACH_RUN;
   }
 
-  Stats s = {0,0,0,0,0,0,0,0};
-  m_stats = s;	
+  Stats s = {0, 0, 0, 0, 0, 0, 0, 0};
+  m_stats = s;
 
   /*parameter set parsing
-   */  
+   */
   std::string globaltag("");
-  if( iConfig.exists( "globaltag" ) ) {
-    globaltag = iConfig.getParameter<std::string>( "globaltag" );
-   // the global tag _requires_ a connection string
-   m_connectionString= iConfig.getParameter<std::string>("connect");
-  } else if( iConfig.exists("connect") ) // default connection string
-    m_connectionString= iConfig.getParameter<std::string>("connect");
+  if (iConfig.exists("globaltag")) {
+    globaltag = iConfig.getParameter<std::string>("globaltag");
+    // the global tag _requires_ a connection string
+    m_connectionString = iConfig.getParameter<std::string>("connect");
+  } else if (iConfig.exists("connect"))  // default connection string
+    m_connectionString = iConfig.getParameter<std::string>("connect");
 
   // snapshot
   boost::posix_time::ptime snapshotTime;
-  if( iConfig.exists( "snapshotTime" ) ){
-    std::string snapshotTimeString = iConfig.getParameter<std::string>("snapshotTime" );
-    if( !snapshotTimeString.empty() ) snapshotTime = boost::posix_time::time_from_string( snapshotTimeString );
+  if (iConfig.exists("snapshotTime")) {
+    std::string snapshotTimeString = iConfig.getParameter<std::string>("snapshotTime");
+    if (!snapshotTimeString.empty())
+      snapshotTime = boost::posix_time::time_from_string(snapshotTimeString);
   }
 
   // connection configuration
-  if( iConfig.exists("DBParameters") ) {
-    edm::ParameterSet connectionPset = iConfig.getParameter<edm::ParameterSet>( "DBParameters" );
-    m_connection.setParameters( connectionPset );
+  if (iConfig.exists("DBParameters")) {
+    edm::ParameterSet connectionPset = iConfig.getParameter<edm::ParameterSet>("DBParameters");
+    m_connection.setParameters(connectionPset);
   }
   m_connection.configure();
-  
+
   // load specific record/tag info - it will overwrite the global tag ( if any )
-  std::map<std::string,cond::GTEntry_t> replacements;
-  std::map<std::string,boost::posix_time::ptime> specialSnapshots;
-  if( iConfig.exists( "toGet" ) ) {
-    typedef std::vector< edm::ParameterSet > Parameters;
-    Parameters toGet = iConfig.getParameter<Parameters>( "toGet" );
-    for( Parameters::iterator itToGet = toGet.begin(); itToGet != toGet.end(); ++itToGet ) {
-      std::string recordname = itToGet->getParameter<std::string>( "record" );
-      if( recordname.empty() ) throw cond::Exception( "ESSource: The record name has not been provided in a \"toGet\" entry." );
-      std::string labelname = itToGet->getUntrackedParameter<std::string>( "label", "" );
+  std::map<std::string, cond::GTEntry_t> replacements;
+  std::map<std::string, boost::posix_time::ptime> specialSnapshots;
+  if (iConfig.exists("toGet")) {
+    typedef std::vector<edm::ParameterSet> Parameters;
+    Parameters toGet = iConfig.getParameter<Parameters>("toGet");
+    for (Parameters::iterator itToGet = toGet.begin(); itToGet != toGet.end(); ++itToGet) {
+      std::string recordname = itToGet->getParameter<std::string>("record");
+      if (recordname.empty())
+        throw cond::Exception("ESSource: The record name has not been provided in a \"toGet\" entry.");
+      std::string labelname = itToGet->getUntrackedParameter<std::string>("label", "");
       std::string pfn("");
-      if( m_connectionString.empty() || itToGet->exists("connect") ) pfn = itToGet->getParameter<std::string>( "connect" );
+      if (m_connectionString.empty() || itToGet->exists("connect"))
+        pfn = itToGet->getParameter<std::string>("connect");
       std::string tag("");
       std::string fqTag("");
-      if( itToGet->exists("tag") ) {
-	tag = itToGet->getParameter<std::string>( "tag" );
-	fqTag = cond::persistency::fullyQualifiedTag(tag,pfn);
+      if (itToGet->exists("tag")) {
+        tag = itToGet->getParameter<std::string>("tag");
+        fqTag = cond::persistency::fullyQualifiedTag(tag, pfn);
       }
-      boost::posix_time::ptime tagSnapshotTime = boost::posix_time::time_from_string(std::string(cond::time::MAX_TIMESTAMP) );
-      if( itToGet->exists("snapshotTime") ) tagSnapshotTime = boost::posix_time::time_from_string( itToGet->getParameter<std::string>("snapshotTime" ) );
-      std::string recordLabelKey = joinRecordAndLabel( recordname, labelname );
-      replacements.insert( std::make_pair( recordLabelKey, cond::GTEntry_t( std::make_tuple(recordname, labelname, fqTag )  ) ) );
-      specialSnapshots.insert( std::make_pair( recordLabelKey, tagSnapshotTime ) );
+      boost::posix_time::ptime tagSnapshotTime =
+          boost::posix_time::time_from_string(std::string(cond::time::MAX_TIMESTAMP));
+      if (itToGet->exists("snapshotTime"))
+        tagSnapshotTime = boost::posix_time::time_from_string(itToGet->getParameter<std::string>("snapshotTime"));
+      std::string recordLabelKey = joinRecordAndLabel(recordname, labelname);
+      replacements.insert(
+          std::make_pair(recordLabelKey, cond::GTEntry_t(std::make_tuple(recordname, labelname, fqTag))));
+      specialSnapshots.insert(std::make_pair(recordLabelKey, tagSnapshotTime));
     }
   }
-  
+
   // get the global tag, merge with "replacement" store in "tagCollection"
   std::vector<std::string> globaltagList;
   std::vector<std::string> connectList;
   std::vector<std::string> pfnPrefixList;
   std::vector<std::string> pfnPostfixList;
-  if( !globaltag.empty() ) {
-    std::string pfnPrefix(iConfig.getUntrackedParameter<std::string>( "pfnPrefix", "" ));
-    std::string pfnPostfix(iConfig.getUntrackedParameter<std::string>( "pfnPostfix", "" ));
-    boost::split( globaltagList, globaltag, boost::is_any_of("|"), boost::token_compress_off );
+  if (!globaltag.empty()) {
+    std::string pfnPrefix(iConfig.getUntrackedParameter<std::string>("pfnPrefix", ""));
+    std::string pfnPostfix(iConfig.getUntrackedParameter<std::string>("pfnPostfix", ""));
+    boost::split(globaltagList, globaltag, boost::is_any_of("|"), boost::token_compress_off);
     fillList(m_connectionString, connectList, globaltagList.size(), "connection");
     fillList(pfnPrefix, pfnPrefixList, globaltagList.size(), "pfnPrefix");
     fillList(pfnPostfix, pfnPostfixList, globaltagList.size(), "pfnPostfix");
   }
 
   cond::GTMetadata_t gtMetadata;
-  fillTagCollectionFromDB(connectList,
-			  pfnPrefixList,
-			  pfnPostfixList,
-			  globaltagList,
-			  replacements,
-			  gtMetadata);
+  fillTagCollectionFromDB(connectList, pfnPrefixList, pfnPostfixList, globaltagList, replacements, gtMetadata);
   // if no job specific setting has been found, use the GT timestamp
-  if(snapshotTime.is_not_a_date_time()) 
+  if (snapshotTime.is_not_a_date_time())
     snapshotTime = gtMetadata.snapshotTime;
-  
+
   TagCollection::iterator it;
   TagCollection::iterator itBeg = m_tagCollection.begin();
   TagCollection::iterator itEnd = m_tagCollection.end();
- 
+
   std::map<std::string, cond::persistency::Session> sessions;
 
   /* load DataProxy Plugin (it is strongly typed due to EventSetup ideosyncrasis)
@@ -211,84 +207,90 @@ CondDBESSource::CondDBESSource( const edm::ParameterSet& iConfig ) :
    * The real initialization of the Data-Proxies is done in the second loop 
    */
   std::vector<std::unique_ptr<cond::DataProxyWrapperBase>> proxyWrappers(m_tagCollection.size());
-  size_t ipb=0;
-  for(it=itBeg;it!=itEnd;++it){
+  size_t ipb = 0;
+  for (it = itBeg; it != itEnd; ++it) {
     proxyWrappers[ipb++] = std::unique_ptr<cond::DataProxyWrapperBase>{
-      cond::ProxyFactory::get()->create(buildName(it->second.recordName()))};
+        cond::ProxyFactory::get()->create(buildName(it->second.recordName()))};
   }
 
   // now all required libraries have been loaded
   // init sessions and DataProxies
-  ipb=0;
-  for(it=itBeg;it!=itEnd;++it){
+  ipb = 0;
+  for (it = itBeg; it != itEnd; ++it) {
     std::string connStr = m_connectionString;
     std::string tag = it->second.tagName();
-    std::pair<std::string,std::string> tagParams = cond::persistency::parseTag( it->second.tagName() );
-    if( !tagParams.second.empty() ) {
-      connStr =  tagParams.second;
+    std::pair<std::string, std::string> tagParams = cond::persistency::parseTag(it->second.tagName());
+    if (!tagParams.second.empty()) {
+      connStr = tagParams.second;
       tag = tagParams.first;
     }
-    std::map<std::string, cond::persistency::Session>::iterator p = sessions.find( connStr );
+    std::map<std::string, cond::persistency::Session>::iterator p = sessions.find(connStr);
     cond::persistency::Session nsess;
     if (p == sessions.end()) {
-      std::string oracleConnStr = cond::persistency::convertoToOracleConnection( connStr );
-      std::tuple<std::string,std::string,std::string> connPars = cond::persistency::parseConnectionString( oracleConnStr );
-      std::string dbService = std::get<1>( connPars );
-      std::string dbAccount = std::get<2>( connPars );
-      if( (dbService == "cms_orcon_prod" || dbService == "cms_orcon_adg") && dbAccount != "CMS_CONDITIONS" )
-	edm::LogWarning( "CondDBESSource" )<<"[WARNING] You are reading tag \""<<tag<<"\" from V1 account \""<<connStr<<"\". The concerned Conditions might be out of date."<<std::endl;
+      std::string oracleConnStr = cond::persistency::convertoToOracleConnection(connStr);
+      std::tuple<std::string, std::string, std::string> connPars =
+          cond::persistency::parseConnectionString(oracleConnStr);
+      std::string dbService = std::get<1>(connPars);
+      std::string dbAccount = std::get<2>(connPars);
+      if ((dbService == "cms_orcon_prod" || dbService == "cms_orcon_adg") && dbAccount != "CMS_CONDITIONS")
+        edm::LogWarning("CondDBESSource")
+            << "[WARNING] You are reading tag \"" << tag << "\" from V1 account \"" << connStr
+            << "\". The concerned Conditions might be out of date." << std::endl;
       //open db get tag info (i.e. the IOV token...)
-      nsess = m_connection.createReadOnlySession( connStr, "" );
-      sessions.insert(std::make_pair( connStr, nsess));
-    } else nsess = (*p).second;
+      nsess = m_connection.createReadOnlySession(connStr, "");
+      sessions.insert(std::make_pair(connStr, nsess));
+    } else
+      nsess = (*p).second;
 
     // ownership...
     ProxyP proxy(std::move(proxyWrappers[ipb++]));
-   //  instert in the map
+    //  instert in the map
     m_proxies.insert(std::make_pair(it->second.recordName(), proxy));
     // initialize
     boost::posix_time::ptime tagSnapshotTime = snapshotTime;
-    auto tagSnapshotIter = specialSnapshots.find( it->first );
-    if( tagSnapshotIter != specialSnapshots.end() ) tagSnapshotTime = tagSnapshotIter->second;
+    auto tagSnapshotIter = specialSnapshots.find(it->first);
+    if (tagSnapshotIter != specialSnapshots.end())
+      tagSnapshotTime = tagSnapshotIter->second;
     // finally, if the snapshot is set to infinity, reset the snapshot to null, to take the full iov set...
-    if(tagSnapshotTime == boost::posix_time::time_from_string(std::string(cond::time::MAX_TIMESTAMP) ) )
+    if (tagSnapshotTime == boost::posix_time::time_from_string(std::string(cond::time::MAX_TIMESTAMP)))
       tagSnapshotTime = boost::posix_time::ptime();
 
     proxy->lateInit(nsess, tag, tagSnapshotTime, it->second.recordLabel(), connStr);
   }
 
-  // one loaded expose all other tags to the Proxy! 
-  CondGetterFromESSource visitor( m_proxies );
+  // one loaded expose all other tags to the Proxy!
+  CondGetterFromESSource visitor(m_proxies);
   ProxyMap::iterator b = m_proxies.begin();
   ProxyMap::iterator e = m_proxies.end();
-  for ( ;b != e; b++ ) {
-
-    (*b).second->proxy()->loadMore( visitor );
+  for (; b != e; b++) {
+    (*b).second->proxy()->loadMore(visitor);
 
     /// required by eventsetup
-    edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType( (*b).first ) );
-    if( recordKey.type() != edm::eventsetup::EventSetupRecordKey::TypeTag() ) {
-      findingRecordWithKey( recordKey );
-      usingRecordWithKey( recordKey );
+    edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType((*b).first));
+    if (recordKey.type() != edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+      findingRecordWithKey(recordKey);
+      usingRecordWithKey(recordKey);
     }
   }
 
-  m_stats.nData=m_proxies.size();
-
+  m_stats.nData = m_proxies.size();
 }
 
-void CondDBESSource::fillList(const std::string & stringList, std::vector<std::string> & listToFill, const unsigned int listSize, const std::string & type)
-{
-  boost::split( listToFill, stringList, boost::is_any_of("|"), boost::token_compress_off );
+void CondDBESSource::fillList(const std::string& stringList,
+                              std::vector<std::string>& listToFill,
+                              const unsigned int listSize,
+                              const std::string& type) {
+  boost::split(listToFill, stringList, boost::is_any_of("|"), boost::token_compress_off);
   // If it is one clone it for each GT
-  if( listToFill.size() == 1 ) {
-    for( unsigned int i=1; i<listSize; ++i ) {
+  if (listToFill.size() == 1) {
+    for (unsigned int i = 1; i < listSize; ++i) {
       listToFill.push_back(stringList);
     }
   }
   // else if they don't match the number of GTs throw an exception
-  else if( listSize != listToFill.size() ) {
-    throw cond::Exception( std::string( "ESSource: number of global tag components does not match number of "+type+" strings" ) );
+  else if (listSize != listToFill.size()) {
+    throw cond::Exception(
+        std::string("ESSource: number of global tag components does not match number of " + type + " strings"));
   }
 }
 
@@ -296,21 +298,16 @@ CondDBESSource::~CondDBESSource() {
   //dump info FIXME: find a more suitable place...
   if (m_doDump) {
     std::cout << "CondDBESSource Statistics" << std::endl
-	      << "DataProxy " << m_stats.nData
-	      << " setInterval " << m_stats.nSet
-	      << " Runs " << m_stats.nRun
-	      << " Lumis " << m_stats.nLumi
-	      << " Refresh " << m_stats.nRefresh
-	      << " Actual Refresh " << m_stats.nActualRefresh
-	      << " Reconnect " << m_stats.nReconnect
-	      << " Actual Reconnect " << m_stats.nActualReconnect;
+              << "DataProxy " << m_stats.nData << " setInterval " << m_stats.nSet << " Runs " << m_stats.nRun
+              << " Lumis " << m_stats.nLumi << " Refresh " << m_stats.nRefresh << " Actual Refresh "
+              << m_stats.nActualRefresh << " Reconnect " << m_stats.nReconnect << " Actual Reconnect "
+              << m_stats.nActualReconnect;
     std::cout << std::endl;
 
-
-    ProxyMap::iterator b= m_proxies.begin();
-    ProxyMap::iterator e= m_proxies.end();
-    for ( ;b != e; b++ ) {
-      dumpInfo( std::cout, (*b).first, *(*b).second );
+    ProxyMap::iterator b = m_proxies.begin();
+    ProxyMap::iterator e = m_proxies.end();
+    for (; b != e; b++) {
+      dumpInfo(std::cout, (*b).first, *(*b).second);
       std::cout << "\n" << std::endl;
     }
 
@@ -319,164 +316,163 @@ CondDBESSource::~CondDBESSource() {
   }
 }
 
-
 //
 // invoked by EventSetUp: for a given record return the smallest IOV for which iTime is valid
 // limit to next run/lumisection of Refresh is required
 //
-void 
-CondDBESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey& iKey, const edm::IOVSyncValue& iTime, edm::ValidityInterval& oInterval ){
+void CondDBESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey,
+                                    const edm::IOVSyncValue& iTime,
+                                    edm::ValidityInterval& oInterval) {
+  std::string recordname = iKey.name();
 
-  std::string recordname=iKey.name();
-  
-  edm::LogInfo( "CondDBESSource" ) << "Getting data for record \""<< recordname
-				   << "\" to be consumed by "<< iTime.eventID() << ", timestamp: " << iTime.time().value()
-				   << "; from CondDBESSource::setIntervalFor";
-  
+  edm::LogInfo("CondDBESSource") << "Getting data for record \"" << recordname << "\" to be consumed by "
+                                 << iTime.eventID() << ", timestamp: " << iTime.time().value()
+                                 << "; from CondDBESSource::setIntervalFor";
+
   m_stats.nSet++;
   //{
-    // not really required, keep here for the time being
-    if(iTime.eventID().run()!=m_lastRun) {
-      m_lastRun=iTime.eventID().run();
-      m_stats.nRun++;
-    }
-    if(iTime.luminosityBlockNumber()!=m_lastLumi) {
-      m_lastLumi=iTime.luminosityBlockNumber();
-      m_stats.nLumi++;
-    }
-    //}
- 
+  // not really required, keep here for the time being
+  if (iTime.eventID().run() != m_lastRun) {
+    m_lastRun = iTime.eventID().run();
+    m_stats.nRun++;
+  }
+  if (iTime.luminosityBlockNumber() != m_lastLumi) {
+    m_lastLumi = iTime.luminosityBlockNumber();
+    m_stats.nLumi++;
+  }
+  //}
+
   bool doRefresh = false;
-  if( m_policy == REFRESH_EACH_RUN || m_policy == RECONNECT_EACH_RUN ) {
+  if (m_policy == REFRESH_EACH_RUN || m_policy == RECONNECT_EACH_RUN) {
     // find out the last run number for the proxy of the specified record
-    std::map<std::string,unsigned int>::iterator iRec = m_lastRecordRuns.find( recordname );
-    if( iRec != m_lastRecordRuns.end() ){
+    std::map<std::string, unsigned int>::iterator iRec = m_lastRecordRuns.find(recordname);
+    if (iRec != m_lastRecordRuns.end()) {
       unsigned int lastRecordRun = iRec->second;
-      if( lastRecordRun != m_lastRun ){
+      if (lastRecordRun != m_lastRun) {
         // a refresh is required!
         doRefresh = true;
         iRec->second = m_lastRun;
-	edm::LogInfo( "CondDBESSource" ) << "Preparing refresh for record \"" << recordname 
-					 << "\" since there has been a transition from run "
-					 << lastRecordRun << " to run " << m_lastRun
-					 << "; from CondDBESSource::setIntervalFor";
+        edm::LogInfo("CondDBESSource") << "Preparing refresh for record \"" << recordname
+                                       << "\" since there has been a transition from run " << lastRecordRun
+                                       << " to run " << m_lastRun << "; from CondDBESSource::setIntervalFor";
       }
     } else {
       doRefresh = true;
-      m_lastRecordRuns.insert( std::make_pair( recordname, m_lastRun ) );
-      edm::LogInfo( "CondDBESSource" ) << "Preparing refresh for record \"" << recordname 
-				       << "\" for " << iTime.eventID() << ", timestamp: " << iTime.time().value()
-				       << "; from CondDBESSource::setIntervalFor";
+      m_lastRecordRuns.insert(std::make_pair(recordname, m_lastRun));
+      edm::LogInfo("CondDBESSource") << "Preparing refresh for record \"" << recordname << "\" for " << iTime.eventID()
+                                     << ", timestamp: " << iTime.time().value()
+                                     << "; from CondDBESSource::setIntervalFor";
     }
-    if ( !doRefresh )
-      edm::LogInfo( "CondDBESSource" ) << "Though enabled, refresh not needed for record \"" << recordname 
-				       << "\" for " << iTime.eventID() << ", timestamp: " << iTime.time().value()
-				       << "; from CondDBESSource::setIntervalFor";
-  } else if( m_policy == REFRESH_ALWAYS || m_policy == REFRESH_OPEN_IOVS ) {
+    if (!doRefresh)
+      edm::LogInfo("CondDBESSource") << "Though enabled, refresh not needed for record \"" << recordname << "\" for "
+                                     << iTime.eventID() << ", timestamp: " << iTime.time().value()
+                                     << "; from CondDBESSource::setIntervalFor";
+  } else if (m_policy == REFRESH_ALWAYS || m_policy == REFRESH_OPEN_IOVS) {
     doRefresh = true;
-    edm::LogInfo( "CondDBESSource" ) << "Forcing refresh for record \"" << recordname 
-				     << "\" for " << iTime.eventID() << ", timestamp: " << iTime.time().value()
-				     << "; from CondDBESSource::setIntervalFor";
+    edm::LogInfo("CondDBESSource") << "Forcing refresh for record \"" << recordname << "\" for " << iTime.eventID()
+                                   << ", timestamp: " << iTime.time().value()
+                                   << "; from CondDBESSource::setIntervalFor";
   }
 
   oInterval = edm::ValidityInterval::invalidInterval();
 
-  // compute the smallest interval (assume all objects have the same timetype....)                                                                                                          
-  cond::ValidityInterval recordValidity(1,cond::TIMELIMIT);
+  // compute the smallest interval (assume all objects have the same timetype....)
+  cond::ValidityInterval recordValidity(1, cond::TIMELIMIT);
   cond::TimeType timetype = cond::TimeType::invalid;
-  bool userTime=true;
+  bool userTime = true;
 
- //FIXME use equal_range
+  //FIXME use equal_range
   ProxyMap::const_iterator pmBegin = m_proxies.lower_bound(recordname);
   ProxyMap::const_iterator pmEnd = m_proxies.upper_bound(recordname);
-  if ( pmBegin == pmEnd ) {
-    edm::LogInfo( "CondDBESSource" ) << "No DataProxy (Pluging) found for record \""<< recordname
-				     << "\"; from CondDBESSource::setIntervalFor";
+  if (pmBegin == pmEnd) {
+    edm::LogInfo("CondDBESSource") << "No DataProxy (Pluging) found for record \"" << recordname
+                                   << "\"; from CondDBESSource::setIntervalFor";
     return;
   }
-  
-  for ( ProxyMap::const_iterator pmIter = pmBegin; pmIter != pmEnd; ++pmIter ) {
 
-    edm::LogInfo( "CondDBESSource" ) << "Processing record \"" << recordname
-				     << "\" and label \""<< pmIter->second->label()
-				     << "\" for " << iTime.eventID() << ", timestamp: " << iTime.time().value()
-				     << "; from CondDBESSource::setIntervalFor";
+  for (ProxyMap::const_iterator pmIter = pmBegin; pmIter != pmEnd; ++pmIter) {
+    edm::LogInfo("CondDBESSource") << "Processing record \"" << recordname << "\" and label \""
+                                   << pmIter->second->label() << "\" for " << iTime.eventID()
+                                   << ", timestamp: " << iTime.time().value()
+                                   << "; from CondDBESSource::setIntervalFor";
 
     timetype = (*pmIter).second->proxy()->timeType();
-    
-    cond::Time_t abtime = cond::time::fromIOVSyncValue( iTime, timetype );
-    userTime = ( 0 == abtime );
-    
-    if (userTime) return; //  oInterval invalid to avoid that make is called...
-    
-    if( doRefresh ) {
 
-      std::string recKey = joinRecordAndLabel( recordname, pmIter->second->label() );
-      TagCollection::const_iterator tcIter = m_tagCollection.find( recKey ); 
-      if ( tcIter == m_tagCollection.end() ) {
-	edm::LogInfo( "CondDBESSource" ) << "No Tag found for record \""<< recordname
-					 << "\" and label \""<< pmIter->second->label()
-					 << "\"; from CondDBESSource::setIntervalFor";
-	return;
+    cond::Time_t abtime = cond::time::fromIOVSyncValue(iTime, timetype);
+    userTime = (0 == abtime);
+
+    if (userTime)
+      return;  //  oInterval invalid to avoid that make is called...
+
+    if (doRefresh) {
+      std::string recKey = joinRecordAndLabel(recordname, pmIter->second->label());
+      TagCollection::const_iterator tcIter = m_tagCollection.find(recKey);
+      if (tcIter == m_tagCollection.end()) {
+        edm::LogInfo("CondDBESSource") << "No Tag found for record \"" << recordname << "\" and label \""
+                                       << pmIter->second->label() << "\"; from CondDBESSource::setIntervalFor";
+        return;
       }
 
       // first reconnect if required
-      if( m_policy == RECONNECT_EACH_RUN ) {
-	edm::LogInfo( "CondDBESSource" ) << "Checking if the session must be closed and re-opened for getting correct conditions"
-					 << "; from CondDBESSource::setIntervalFor";
-	std::stringstream transId;
-	//transId << "long" << m_lastRun;
-	transId << m_lastRun;
-	std::string connStr = m_connectionString;
-	std::pair<std::string,std::string> tagParams = cond::persistency::parseTag( tcIter->second.tagName() );
-	if( !tagParams.second.empty() ) connStr =  tagParams.second;
-	std::map<std::string,std::pair<cond::persistency::Session,std::string> >::iterator iSess = m_sessionPool.find( connStr );
-	bool reopen = false;
-	if( iSess != m_sessionPool.end() ){
-	  if( iSess->second.second != transId.str() ) {
-	    // the available session is open for a different run: reopen
+      if (m_policy == RECONNECT_EACH_RUN) {
+        edm::LogInfo("CondDBESSource")
+            << "Checking if the session must be closed and re-opened for getting correct conditions"
+            << "; from CondDBESSource::setIntervalFor";
+        std::stringstream transId;
+        //transId << "long" << m_lastRun;
+        transId << m_lastRun;
+        std::string connStr = m_connectionString;
+        std::pair<std::string, std::string> tagParams = cond::persistency::parseTag(tcIter->second.tagName());
+        if (!tagParams.second.empty())
+          connStr = tagParams.second;
+        std::map<std::string, std::pair<cond::persistency::Session, std::string>>::iterator iSess =
+            m_sessionPool.find(connStr);
+        bool reopen = false;
+        if (iSess != m_sessionPool.end()) {
+          if (iSess->second.second != transId.str()) {
+            // the available session is open for a different run: reopen
             reopen = true;
-	    iSess->second.second = transId.str();
-	  }
-	} else {
-          // no available session: probably first run analysed... 
-	  iSess = m_sessionPool.insert(std::make_pair( connStr, std::make_pair( cond::persistency::Session(),transId.str()) )).first; 
-	  reopen = true;
-	} 
-	if( reopen ){
-	  iSess->second.first = m_connection.createReadOnlySession( connStr, transId.str() );
-	  edm::LogInfo( "CondDBESSource" ) << "Re-opening the session with connection string " << connStr
-					   << " and new transaction Id " <<  transId.str()
-					   << "; from CondDBESSource::setIntervalFor";
-	}
-	
-	edm::LogInfo( "CondDBESSource" ) << "Reconnecting to \"" << connStr
-					 << "\" for getting new payload for record \"" << recordname 
-					 << "\" and label \""<< pmIter->second->label()
-					 << "\" from IOV tag \"" << tcIter->second.tagName()
-					 << "\" to be consumed by " << iTime.eventID() << ", timestamp: " << iTime.time().value()
-					 << "; from CondDBESSource::setIntervalFor";
-        pmIter->second->proxy()->setUp( iSess->second.first ); 
-	pmIter->second->proxy()->reload();
-	//if( isSizeIncreased )
-	//edm::LogInfo( "CondDBESSource" ) << "After reconnecting, an increased size of the IOV sequence labeled by tag \"" << tcIter->second.tag
-	//				 << "\" was found; from CondDBESSource::setIntervalFor";
-	//m_stats.nActualReconnect += isSizeIncreased;
-	m_stats.nReconnect++;
-      } else {
-	edm::LogInfo( "CondDBESSource" ) << "Refreshing IOV sequence labeled by tag \"" << tcIter->second.tagName()
-					 << "\" for getting new payload for record \"" << recordname
-					 << "\" and label \""<< pmIter->second->label()
-					 << "\" to be consumed by " << iTime.eventID() << ", timestamp: " << iTime.time().value()
-					 << "; from CondDBESSource::setIntervalFor";
-	pmIter->second->proxy()->reload();
-	//if( isSizeIncreased )
-	//  edm::LogInfo( "CondDBESSource" ) << "After refreshing, an increased size of the IOV sequence labeled by tag \"" << tcIter->second.tag
-	//				   << "\" was found; from CondDBESSource::setIntervalFor";
-        //m_stats.nActualRefresh += isSizeIncreased;
-	m_stats.nRefresh++;
-      }
+            iSess->second.second = transId.str();
+          }
+        } else {
+          // no available session: probably first run analysed...
+          iSess =
+              m_sessionPool.insert(std::make_pair(connStr, std::make_pair(cond::persistency::Session(), transId.str())))
+                  .first;
+          reopen = true;
+        }
+        if (reopen) {
+          iSess->second.first = m_connection.createReadOnlySession(connStr, transId.str());
+          edm::LogInfo("CondDBESSource") << "Re-opening the session with connection string " << connStr
+                                         << " and new transaction Id " << transId.str()
+                                         << "; from CondDBESSource::setIntervalFor";
+        }
 
+        edm::LogInfo("CondDBESSource") << "Reconnecting to \"" << connStr << "\" for getting new payload for record \""
+                                       << recordname << "\" and label \"" << pmIter->second->label()
+                                       << "\" from IOV tag \"" << tcIter->second.tagName() << "\" to be consumed by "
+                                       << iTime.eventID() << ", timestamp: " << iTime.time().value()
+                                       << "; from CondDBESSource::setIntervalFor";
+        pmIter->second->proxy()->setUp(iSess->second.first);
+        pmIter->second->proxy()->reload();
+        //if( isSizeIncreased )
+        //edm::LogInfo( "CondDBESSource" ) << "After reconnecting, an increased size of the IOV sequence labeled by tag \"" << tcIter->second.tag
+        //				 << "\" was found; from CondDBESSource::setIntervalFor";
+        //m_stats.nActualReconnect += isSizeIncreased;
+        m_stats.nReconnect++;
+      } else {
+        edm::LogInfo("CondDBESSource") << "Refreshing IOV sequence labeled by tag \"" << tcIter->second.tagName()
+                                       << "\" for getting new payload for record \"" << recordname << "\" and label \""
+                                       << pmIter->second->label() << "\" to be consumed by " << iTime.eventID()
+                                       << ", timestamp: " << iTime.time().value()
+                                       << "; from CondDBESSource::setIntervalFor";
+        pmIter->second->proxy()->reload();
+        //if( isSizeIncreased )
+        //  edm::LogInfo( "CondDBESSource" ) << "After refreshing, an increased size of the IOV sequence labeled by tag \"" << tcIter->second.tag
+        //				   << "\" was found; from CondDBESSource::setIntervalFor";
+        //m_stats.nActualRefresh += isSizeIncreased;
+        m_stats.nRefresh++;
+      }
     }
 
     /*
@@ -489,100 +485,100 @@ CondDBESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey& iKey
     */
 
     //query the IOVSequence
-    cond::ValidityInterval validity = (*pmIter).second->proxy()->setIntervalFor( abtime );
-    
-    edm::LogInfo( "CondDBESSource" ) << "Validity coming from IOV sequence for record \"" << recordname
-				     << "\" and label \""<< pmIter->second->label()
-				     << "\": (" << validity.first << ", " << validity.second
-				     << ") for time (type: "<< cond::timeTypeNames( timetype ) << ") " << abtime
-				     << "; from CondDBESSource::setIntervalFor";
-    
-    recordValidity.first = std::max(recordValidity.first,validity.first);
-    recordValidity.second = std::min(recordValidity.second,validity.second);
-  }      
-  
-  if( m_policy == REFRESH_OPEN_IOVS ) {
-    doRefresh = ( recordValidity.second == cond::timeTypeSpecs[timetype].endValue );
-    edm::LogInfo( "CondDBESSource" ) << "Validity for record \"" << recordname
-				     << "\" and the corresponding label(s) coming from Condition DB: (" << recordValidity.first 
-				     << ", "<< recordValidity.first 
-				     << ") as the last IOV element in the IOV sequence is infinity"
-				     << "; from CondDBESSource::setIntervalFor";
+    cond::ValidityInterval validity = (*pmIter).second->proxy()->setIntervalFor(abtime);
+
+    edm::LogInfo("CondDBESSource") << "Validity coming from IOV sequence for record \"" << recordname
+                                   << "\" and label \"" << pmIter->second->label() << "\": (" << validity.first << ", "
+                                   << validity.second << ") for time (type: " << cond::timeTypeNames(timetype) << ") "
+                                   << abtime << "; from CondDBESSource::setIntervalFor";
+
+    recordValidity.first = std::max(recordValidity.first, validity.first);
+    recordValidity.second = std::min(recordValidity.second, validity.second);
   }
-  
+
+  if (m_policy == REFRESH_OPEN_IOVS) {
+    doRefresh = (recordValidity.second == cond::timeTypeSpecs[timetype].endValue);
+    edm::LogInfo("CondDBESSource") << "Validity for record \"" << recordname
+                                   << "\" and the corresponding label(s) coming from Condition DB: ("
+                                   << recordValidity.first << ", " << recordValidity.first
+                                   << ") as the last IOV element in the IOV sequence is infinity"
+                                   << "; from CondDBESSource::setIntervalFor";
+  }
+
   // to force refresh we set end-value to the minimum such an IOV can extend to: current run or lumiblock
-    
-  if ( (!userTime) && recordValidity.second !=0 ) {
+
+  if ((!userTime) && recordValidity.second != 0) {
     edm::IOVSyncValue start = cond::time::toIOVSyncValue(recordValidity.first, timetype, true);
-    edm::IOVSyncValue stop = doRefresh  ? cond::time::limitedIOVSyncValue (iTime, timetype)
-      : cond::time::toIOVSyncValue(recordValidity.second, timetype, false);
-       
-    oInterval = edm::ValidityInterval( start, stop );
-   }
-  
-  edm::LogInfo( "CondDBESSource" ) << "Setting validity for record \"" << recordname 
-				   << "\" and corresponding label(s): starting at " << oInterval.first().eventID() << ", timestamp: " << oInterval.first().time().value()
-				   << ", ending at "<< oInterval.last().eventID() << ", timestamp: " << oInterval.last().time().value()
-				   << ", for "<< iTime.eventID() << ", timestamp: " << iTime.time().value()
-				   << "; from CondDBESSource::setIntervalFor";
+    edm::IOVSyncValue stop = doRefresh ? cond::time::limitedIOVSyncValue(iTime, timetype)
+                                       : cond::time::toIOVSyncValue(recordValidity.second, timetype, false);
+
+    oInterval = edm::ValidityInterval(start, stop);
+  }
+
+  edm::LogInfo("CondDBESSource") << "Setting validity for record \"" << recordname
+                                 << "\" and corresponding label(s): starting at " << oInterval.first().eventID()
+                                 << ", timestamp: " << oInterval.first().time().value() << ", ending at "
+                                 << oInterval.last().eventID() << ", timestamp: " << oInterval.last().time().value()
+                                 << ", for " << iTime.eventID() << ", timestamp: " << iTime.time().value()
+                                 << "; from CondDBESSource::setIntervalFor";
 }
-  
 
 //required by EventSetup System
-void 
-CondDBESSource::registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey , KeyedProxies& aProxyList) {
-  std::string recordname=iRecordKey.name();
+void CondDBESSource::registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey, KeyedProxies& aProxyList) {
+  std::string recordname = iRecordKey.name();
 
   ProxyMap::const_iterator b = m_proxies.lower_bound(recordname);
   ProxyMap::const_iterator e = m_proxies.upper_bound(recordname);
-  if ( b == e) {
-    edm::LogInfo( "CondDBESSource" ) << "No DataProxy (Pluging) found for record \""<< recordname
-				     << "\"; from CondDBESSource::registerProxies";
+  if (b == e) {
+    edm::LogInfo("CondDBESSource") << "No DataProxy (Pluging) found for record \"" << recordname
+                                   << "\"; from CondDBESSource::registerProxies";
     return;
   }
 
-  for (ProxyMap::const_iterator p=b;p!=e;++p) {  
-    if(nullptr != (*p).second.get()) {
-      edm::eventsetup::TypeTag type =  (*p).second->type(); 
-      edm::eventsetup::DataKey key( type, edm::eventsetup::IdTags((*p).second->label().c_str()) );
-      aProxyList.push_back(KeyedProxies::value_type(key,(*p).second->edmProxy()));
+  for (ProxyMap::const_iterator p = b; p != e; ++p) {
+    if (nullptr != (*p).second.get()) {
+      edm::eventsetup::TypeTag type = (*p).second->type();
+      edm::eventsetup::DataKey key(type, edm::eventsetup::IdTags((*p).second->label().c_str()));
+      aProxyList.push_back(KeyedProxies::value_type(key, (*p).second->edmProxy()));
     }
   }
 }
 
 // required by the EventSetup System
-void 
-CondDBESSource::newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType,
-			    const edm::ValidityInterval&) 
-{
+void CondDBESSource::newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType,
+                                 const edm::ValidityInterval&) {
   //LogDebug ("CondDBESSource")<<"newInterval";
   invalidateProxies(iRecordType);
 }
 
-
 // Fills tag collection from the given globaltag
-void CondDBESSource::fillTagCollectionFromGT( const std::string & connectionString,
-                                              const std::string & prefix,
-                                              const std::string & postfix,
-                                              const std::string & roottag,
-                                              std::set< cond::GTEntry_t > & tagcoll,
-					      cond::GTMetadata_t& gtMetadata )
-{
-  if ( !roottag.empty() ) {
-    if ( connectionString.empty() )
-      throw cond::Exception( std::string( "ESSource: requested global tag ") + roottag + std::string( " but not connection string given" ) );
-    std::tuple<std::string,std::string,std::string> connPars = cond::persistency::parseConnectionString( connectionString );
-    if( std::get<2>( connPars ) == "CMS_COND_31X_GLOBALTAG" ){
-      edm::LogWarning( "CondDBESSource" )<<"[WARNING] You are reading Global Tag \""<<roottag<<"\" from V1 account \"CMS_COND_31X_GLOBALTAG\". The concerned Conditions might be out of date."<<std::endl;
-    } else if( roottag.rfind("::All")!=std::string::npos && std::get<2>( connPars ) == "CMS_CONDITIONS" ){
-      edm::LogWarning( "CondDBESSource" )<<"[WARNING] You are trying to read Global Tag \""<<roottag<<"\" - postfix \"::All\" should not be used for V2."<<std::endl;      
+void CondDBESSource::fillTagCollectionFromGT(const std::string& connectionString,
+                                             const std::string& prefix,
+                                             const std::string& postfix,
+                                             const std::string& roottag,
+                                             std::set<cond::GTEntry_t>& tagcoll,
+                                             cond::GTMetadata_t& gtMetadata) {
+  if (!roottag.empty()) {
+    if (connectionString.empty())
+      throw cond::Exception(std::string("ESSource: requested global tag ") + roottag +
+                            std::string(" but not connection string given"));
+    std::tuple<std::string, std::string, std::string> connPars =
+        cond::persistency::parseConnectionString(connectionString);
+    if (std::get<2>(connPars) == "CMS_COND_31X_GLOBALTAG") {
+      edm::LogWarning("CondDBESSource")
+          << "[WARNING] You are reading Global Tag \"" << roottag
+          << "\" from V1 account \"CMS_COND_31X_GLOBALTAG\". The concerned Conditions might be out of date."
+          << std::endl;
+    } else if (roottag.rfind("::All") != std::string::npos && std::get<2>(connPars) == "CMS_CONDITIONS") {
+      edm::LogWarning("CondDBESSource") << "[WARNING] You are trying to read Global Tag \"" << roottag
+                                        << "\" - postfix \"::All\" should not be used for V2." << std::endl;
     }
-    cond::persistency::Session session = m_connection.createSession( connectionString );
-    session.transaction().start( true );
-    cond::persistency::GTProxy gtp = session.readGlobalTag( roottag, prefix, postfix );
-    gtMetadata.snapshotTime = gtp.snapshotTime(); 
-    for( const auto& gte : gtp ){
-      tagcoll.insert( gte );
+    cond::persistency::Session session = m_connection.createSession(connectionString);
+    session.transaction().start(true);
+    cond::persistency::GTProxy gtp = session.readGlobalTag(roottag, prefix, postfix);
+    gtMetadata.snapshotTime = gtp.snapshotTime();
+    for (const auto& gte : gtp) {
+      tagcoll.insert(gte);
     }
     session.transaction().commit();
   }
@@ -590,19 +586,19 @@ void CondDBESSource::fillTagCollectionFromGT( const std::string & connectionStri
 
 // fills tagcollection merging with replacement
 // Note: it assumem the coraldbList and roottagList have the same length. This checked in the constructor that prepares the two lists before calling this method.
-void CondDBESSource::fillTagCollectionFromDB( const std::vector<std::string> & connectionStringList,
-                                              const std::vector<std::string> & prefixList,
-                                              const std::vector<std::string> & postfixList,
-                                              const std::vector<std::string> & roottagList,
-                                              std::map<std::string,cond::GTEntry_t>& replacement,
-					      cond::GTMetadata_t& gtMetadata )
-{
-  std::set< cond::GTEntry_t > tagcoll;
- 
+void CondDBESSource::fillTagCollectionFromDB(const std::vector<std::string>& connectionStringList,
+                                             const std::vector<std::string>& prefixList,
+                                             const std::vector<std::string>& postfixList,
+                                             const std::vector<std::string>& roottagList,
+                                             std::map<std::string, cond::GTEntry_t>& replacement,
+                                             cond::GTMetadata_t& gtMetadata) {
+  std::set<cond::GTEntry_t> tagcoll;
+
   auto connectionString = connectionStringList.begin();
   auto prefix = prefixList.begin();
   auto postfix = postfixList.begin();
-  for( auto roottag = roottagList.begin(); roottag != roottagList.end(); ++roottag, ++connectionString, ++prefix, ++postfix) {
+  for (auto roottag = roottagList.begin(); roottag != roottagList.end();
+       ++roottag, ++connectionString, ++prefix, ++postfix) {
     fillTagCollectionFromGT(*connectionString, *prefix, *postfix, *roottag, tagcoll, gtMetadata);
   }
 
@@ -611,49 +607,47 @@ void CondDBESSource::fillTagCollectionFromDB( const std::vector<std::string> & c
   std::set<cond::GTEntry_t>::iterator tagCollEnd = tagcoll.end();
 
   // FIXME the logic is a bit perverse: can be surely linearized (at least simplified!) ....
-  for( tagCollIter = tagCollBegin; tagCollIter != tagCollEnd; ++tagCollIter ) {
-    std::string recordLabelKey = joinRecordAndLabel( tagCollIter->recordName(), tagCollIter->recordLabel() );
-    std::map<std::string,cond::GTEntry_t>::iterator fid = replacement.find( recordLabelKey );
-    if( fid != replacement.end() ) {
-      if( !fid->second.tagName().empty() ){
-	cond::GTEntry_t tagMetadata( std::make_tuple( tagCollIter->recordName(), tagCollIter->recordLabel(), fid->second.tagName() ) );  
-	m_tagCollection.insert( std::make_pair( recordLabelKey, tagMetadata ) );
-	edm::LogInfo( "CondDBESSource" ) << "Replacing tag \"" << tagCollIter->tagName()
-					 << "\" for record \"" << tagMetadata.recordName()
-					 << "\" and label \"" << tagMetadata.recordLabel()
-					 << "\" with tag " << tagMetadata.tagName()
-					 << "\"; from CondDBESSource::fillTagCollectionFromDB";
+  for (tagCollIter = tagCollBegin; tagCollIter != tagCollEnd; ++tagCollIter) {
+    std::string recordLabelKey = joinRecordAndLabel(tagCollIter->recordName(), tagCollIter->recordLabel());
+    std::map<std::string, cond::GTEntry_t>::iterator fid = replacement.find(recordLabelKey);
+    if (fid != replacement.end()) {
+      if (!fid->second.tagName().empty()) {
+        cond::GTEntry_t tagMetadata(
+            std::make_tuple(tagCollIter->recordName(), tagCollIter->recordLabel(), fid->second.tagName()));
+        m_tagCollection.insert(std::make_pair(recordLabelKey, tagMetadata));
+        edm::LogInfo("CondDBESSource") << "Replacing tag \"" << tagCollIter->tagName() << "\" for record \""
+                                       << tagMetadata.recordName() << "\" and label \"" << tagMetadata.recordLabel()
+                                       << "\" with tag " << tagMetadata.tagName()
+                                       << "\"; from CondDBESSource::fillTagCollectionFromDB";
       } else {
-	m_tagCollection.insert( std::make_pair( recordLabelKey, *tagCollIter) );
+        m_tagCollection.insert(std::make_pair(recordLabelKey, *tagCollIter));
       }
-      replacement.erase( fid );
+      replacement.erase(fid);
     } else {
-      m_tagCollection.insert( std::make_pair( recordLabelKey, *tagCollIter) );
+      m_tagCollection.insert(std::make_pair(recordLabelKey, *tagCollIter));
     }
   }
-  std::map<std::string,cond::GTEntry_t>::iterator replacementIter;
-  std::map<std::string,cond::GTEntry_t>::iterator replacementBegin = replacement.begin();
-  std::map<std::string,cond::GTEntry_t>::iterator replacementEnd = replacement.end();
-  for( replacementIter = replacementBegin; replacementIter != replacementEnd; ++replacementIter ){
-    if( replacementIter->second.tagName().empty() ){
+  std::map<std::string, cond::GTEntry_t>::iterator replacementIter;
+  std::map<std::string, cond::GTEntry_t>::iterator replacementBegin = replacement.begin();
+  std::map<std::string, cond::GTEntry_t>::iterator replacementEnd = replacement.end();
+  for (replacementIter = replacementBegin; replacementIter != replacementEnd; ++replacementIter) {
+    if (replacementIter->second.tagName().empty()) {
       std::stringstream msg;
       msg << "ESSource: no tag provided for record " << replacementIter->second.recordName();
-      if( !replacementIter->second.recordLabel().empty() ) msg << " and label "<<replacementIter->second.recordLabel();
-      throw cond::Exception( msg.str() );
+      if (!replacementIter->second.recordLabel().empty())
+        msg << " and label " << replacementIter->second.recordLabel();
+      throw cond::Exception(msg.str());
     }
-    m_tagCollection.insert( *replacementIter );
+    m_tagCollection.insert(*replacementIter);
   }
 }
-
 
 // backward compatibility for configuration files
 class PoolDBESSource : public CondDBESSource {
 public:
-  explicit  PoolDBESSource( const edm::ParameterSet& ps) :
-    CondDBESSource(ps){}
+  explicit PoolDBESSource(const edm::ParameterSet& ps) : CondDBESSource(ps) {}
 };
 
 #include "FWCore/Framework/interface/SourceFactory.h"
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_SOURCE(PoolDBESSource);
-

--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -22,37 +22,35 @@
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 //#include "CondCore/DBCommon/interface/Time.h"
 
-namespace edm{
+namespace edm {
   class ParameterSet;
 }
 
-namespace cond{
+namespace cond {
   class DataProxyWrapperBase;
 }
 
-class CondDBESSource : public edm::eventsetup::DataProxyProvider,
-		       public edm::EventSetupRecordIntervalFinder{
- public:
-  typedef std::shared_ptr<cond::DataProxyWrapperBase > ProxyP;
-  typedef std::multimap< std::string,  ProxyP> ProxyMap;
+class CondDBESSource : public edm::eventsetup::DataProxyProvider, public edm::EventSetupRecordIntervalFinder {
+public:
+  typedef std::shared_ptr<cond::DataProxyWrapperBase> ProxyP;
+  typedef std::multimap<std::string, ProxyP> ProxyMap;
 
   typedef enum { NOREFRESH, REFRESH_ALWAYS, REFRESH_OPEN_IOVS, REFRESH_EACH_RUN, RECONNECT_EACH_RUN } RefreshPolicy;
-  
 
-  explicit CondDBESSource( const edm::ParameterSet& );
+  explicit CondDBESSource(const edm::ParameterSet&);
   ~CondDBESSource() override;
-  
- protected:
+
+protected:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-			      const edm::IOVSyncValue& , 
-			      edm::ValidityInterval&) override ;
+                      const edm::IOVSyncValue&,
+                      edm::ValidityInterval&) override;
 
-  void registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey, KeyedProxies& aProxyList) override ;
+  void registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey, KeyedProxies& aProxyList) override;
 
-  void newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType, const edm::ValidityInterval& iInterval) override ;
+  void newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType,
+                   const edm::ValidityInterval& iInterval) override;
 
- private:
-
+private:
   // ----------member data ---------------------------
 
   cond::persistency::ConnectionPool m_connection;
@@ -61,13 +59,12 @@ class CondDBESSource : public edm::eventsetup::DataProxyProvider,
   // Container of DataProxy, implemented as multi-map keyed by records
   ProxyMap m_proxies;
 
-
-  typedef std::map< std::string, cond::GTEntry_t > TagCollection;
+  typedef std::map<std::string, cond::GTEntry_t> TagCollection;
   // the collections of tag, record/label used in this ESSource
   TagCollection m_tagCollection;
-  std::map<std::string,std::pair<cond::persistency::Session,std::string> > m_sessionPool;
-  std::map<std::string,unsigned int> m_lastRecordRuns;
-  
+  std::map<std::string, std::pair<cond::persistency::Session, std::string> > m_sessionPool;
+  std::map<std::string, unsigned int> m_lastRecordRuns;
+
   struct Stats {
     int nData;
     int nSet;
@@ -84,25 +81,27 @@ class CondDBESSource : public edm::eventsetup::DataProxyProvider,
   unsigned int m_lastRun;
   unsigned int m_lastLumi;
   RefreshPolicy m_policy;
-  
+
   bool m_doDump;
 
- private:
+private:
+  void fillList(const std::string& pfn,
+                std::vector<std::string>& pfnList,
+                const unsigned int listSize,
+                const std::string& type);
 
-  void fillList(const std::string & pfn, std::vector<std::string> & pfnList, const unsigned int listSize, const std::string & type);
+  void fillTagCollectionFromGT(const std::string& connectionString,
+                               const std::string& prefix,
+                               const std::string& postfix,
+                               const std::string& roottag,
+                               std::set<cond::GTEntry_t>& tagcoll,
+                               cond::GTMetadata_t& gtMetadata);
 
-  void fillTagCollectionFromGT(const std::string & connectionString,
-                               const std::string & prefix,
-                               const std::string & postfix,
-                               const std::string & roottag,
-                               std::set< cond::GTEntry_t > & tagcoll,
-			       cond::GTMetadata_t& gtMetadata);
-
-  void fillTagCollectionFromDB( const std::vector<std::string> & connectionStringList,
-                                const std::vector<std::string> & prefixList,
-                                const std::vector<std::string> & postfixList,
-                                const std::vector<std::string> & roottagList,
-                                std::map<std::string,cond::GTEntry_t>& replacement,
-				cond::GTMetadata_t& gtMetadata);
+  void fillTagCollectionFromDB(const std::vector<std::string>& connectionStringList,
+                               const std::vector<std::string>& prefixList,
+                               const std::vector<std::string>& postfixList,
+                               const std::vector<std::string>& roottagList,
+                               std::map<std::string, cond::GTEntry_t>& replacement,
+                               cond::GTMetadata_t& gtMetadata);
 };
 #endif

--- a/CondCore/ESSources/src/ProxyFactory.cc
+++ b/CondCore/ESSources/src/ProxyFactory.cc
@@ -2,7 +2,7 @@
 //
 // Package:     ESSources
 // Class  :     ProxyFactory
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -16,23 +16,20 @@
 #include "CondCore/ESSources/interface/ProxyFactory.h"
 #include "CondCore/ESSources/interface/DataProxy.h"
 
-cond::DataProxyWrapperBase::DataProxyWrapperBase(){}
+cond::DataProxyWrapperBase::DataProxyWrapperBase() {}
 
-cond::DataProxyWrapperBase::DataProxyWrapperBase(std::string const & il) : m_label(il){}
+cond::DataProxyWrapperBase::DataProxyWrapperBase(std::string const& il) : m_label(il) {}
 
-cond::DataProxyWrapperBase::~DataProxyWrapperBase(){}
+cond::DataProxyWrapperBase::~DataProxyWrapperBase() {}
 
-void cond::DataProxyWrapperBase::addInfo(std::string const & il, std::string const & cs, std::string const & tag) { 
-  m_label=il; m_connString = cs; m_tag=tag;
+void cond::DataProxyWrapperBase::addInfo(std::string const& il, std::string const& cs, std::string const& tag) {
+  m_label = il;
+  m_connString = cs;
+  m_tag = tag;
 }
 
 EDM_REGISTER_PLUGINFACTORY(cond::ProxyFactory, cond::pluginCategory());
 
 namespace cond {
-  const char*
-  pluginCategory()
-  {
-    return  "CondProxyFactory";
-  }
-}
-
+  const char* pluginCategory() { return "CondProxyFactory"; }
+}  // namespace cond

--- a/CondCore/ESSources/test/SiStripTest/noiseanalyzer.cc
+++ b/CondCore/ESSources/test/SiStripTest/noiseanalyzer.cc
@@ -13,48 +13,42 @@
 
 using namespace std;
 
-namespace edmtest
-{
-  class NoisesAnalyzer : public edm::EDAnalyzer
-  {
+namespace edmtest {
+  class NoisesAnalyzer : public edm::EDAnalyzer {
   public:
-    explicit  NoisesAnalyzer(edm::ParameterSet const& p) 
-    { 
-      std::cout<<"NoisesAnalyzer"<<std::endl;
-    }
-    explicit  NoisesAnalyzer(int i) 
-    { std::cout<<"NoisesAnalyzer "<<i<<std::endl; }
-    virtual ~NoisesAnalyzer() {  
-      std::cout<<"~NoisesAnalyzer "<<std::endl;
-    }
+    explicit NoisesAnalyzer(edm::ParameterSet const& p) { std::cout << "NoisesAnalyzer" << std::endl; }
+    explicit NoisesAnalyzer(int i) { std::cout << "NoisesAnalyzer " << i << std::endl; }
+    virtual ~NoisesAnalyzer() { std::cout << "~NoisesAnalyzer " << std::endl; }
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+
   private:
   };
-  
-  void
-   NoisesAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context){
+
+  void NoisesAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.
-    std::cout <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
-    std::cout <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
-    edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("mySiStripNoisesRcd"));
-    if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::eventsetup::EventSetupRecordKey recordKey(
+        edm::eventsetup::EventSetupRecordKey::TypeTag::findType("mySiStripNoisesRcd"));
+    if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout <<"Record \"mySiStripNoisesRcd"<<"\" does not exist "<<std::endl;
+      std::cout << "Record \"mySiStripNoisesRcd"
+                << "\" does not exist " << std::endl;
     }
     edm::ESHandle<mySiStripNoises> pNoises;
-    std::cout<<"got eshandle"<<std::endl;
+    std::cout << "got eshandle" << std::endl;
     context.get<mySiStripNoisesRcd>().get(pNoises);
-    std::cout<<"got context"<<std::endl;
-    const mySiStripNoises* mynoise=pNoises.product();
-    std::cout<<"Noises* "<<mynoise<<std::endl;
-    unsigned int a=mynoise->v_noises.size();
-    std::cout<<"size a "<<a<<std::endl;
-    unsigned int b=mynoise->indexes.size();
-    std::cout<<"size b "<<b<<std::endl;
+    std::cout << "got context" << std::endl;
+    const mySiStripNoises* mynoise = pNoises.product();
+    std::cout << "Noises* " << mynoise << std::endl;
+    unsigned int a = mynoise->v_noises.size();
+    std::cout << "size a " << a << std::endl;
+    unsigned int b = mynoise->indexes.size();
+    std::cout << "size b " << b << std::endl;
     /*for(std::vector<mySiStripNoises::DetRegistry>::const_iterator it=mynoise->indexes.begin(); it!=mynoise->indexes.end(); ++it){
       std::cout << "  detid  " <<it->detid<< std::endl;
       }*/
   }
   DEFINE_FWK_MODULE(NoisesAnalyzer);
-}
+}  // namespace edmtest

--- a/CondCore/ESSources/test/stubs/EfficiencyByLabelAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/EfficiencyByLabelAnalyzer.cc
@@ -21,56 +21,50 @@ Toy EDProducers and EDProducts for testing purposes only.
 
 using namespace std;
 
-namespace edmtest
-{
-  class EfficiencyByLabelAnalyzer : public edm::EDAnalyzer
-  {
+namespace edmtest {
+  class EfficiencyByLabelAnalyzer : public edm::EDAnalyzer {
   public:
-    explicit  EfficiencyByLabelAnalyzer(edm::ParameterSet const& p) 
-    { 
-      std::cout<<"EfficiencyByLabelAnalyzer"<<std::endl;
+    explicit EfficiencyByLabelAnalyzer(edm::ParameterSet const& p) {
+      std::cout << "EfficiencyByLabelAnalyzer" << std::endl;
     }
-    explicit  EfficiencyByLabelAnalyzer(int i) 
-    { std::cout<<"EfficiencyByLabelAnalyzer "<<i<<std::endl; }
-    virtual ~EfficiencyByLabelAnalyzer() {  
-      std::cout<<"~EfficiencyByLabelAnalyzer "<<std::endl;
-    }
+    explicit EfficiencyByLabelAnalyzer(int i) { std::cout << "EfficiencyByLabelAnalyzer " << i << std::endl; }
+    virtual ~EfficiencyByLabelAnalyzer() { std::cout << "~EfficiencyByLabelAnalyzer " << std::endl; }
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+
   private:
   };
-  
-  void
-   EfficiencyByLabelAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context){
+
+  void EfficiencyByLabelAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.
-    std::cout <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
-    std::cout <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
-    edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("ExEfficiencyRcd"));
-    if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::eventsetup::EventSetupRecordKey recordKey(
+        edm::eventsetup::EventSetupRecordKey::TypeTag::findType("ExEfficiencyRcd"));
+    if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout <<"Record \"ExEfficiencyRcd"<<"\" does not exist "<<std::endl;
+      std::cout << "Record \"ExEfficiencyRcd"
+                << "\" does not exist " << std::endl;
     }
     edm::ESHandle<condex::Efficiency> hEff1;
     edm::ESHandle<condex::Efficiency> hEff2;
-    std::cout<<"got eshandle"<<std::endl;
-    context.get<ExEfficiencyRcd>().get("vinEff1",hEff1);
-    context.get<ExEfficiencyRcd>().get("vinEff2",hEff2);
-    std::cout<<"got context"<<std::endl;
+    std::cout << "got eshandle" << std::endl;
+    context.get<ExEfficiencyRcd>().get("vinEff1", hEff1);
+    context.get<ExEfficiencyRcd>().get("vinEff2", hEff2);
+    std::cout << "got context" << std::endl;
     {
-      condex::Efficiency const &  eff= *hEff2.product();
-      std::cout<<"Efficiency*, type (2) "<< (void*)(&eff) << " " << typeid(eff).name() <<std::endl;
+      condex::Efficiency const& eff = *hEff2.product();
+      std::cout << "Efficiency*, type (2) " << (void*)(&eff) << " " << typeid(eff).name() << std::endl;
     }
-    condex::Efficiency const &  eff= *hEff1.product();
-    std::cout<<"Efficiency*, type "<< (void*)(&eff) << " " << typeid(eff).name() <<std::endl;
-    for (float pt=0;pt<10; pt+=2) {
-     std::cout << "\npt="<<pt<<"    :";
-     for (float eta=-3;eta<3; eta+=1)
-       std::cout << eff(pt,eta) <<" ";    
-   }  
-   std::cout << std::endl;
+    condex::Efficiency const& eff = *hEff1.product();
+    std::cout << "Efficiency*, type " << (void*)(&eff) << " " << typeid(eff).name() << std::endl;
+    for (float pt = 0; pt < 10; pt += 2) {
+      std::cout << "\npt=" << pt << "    :";
+      for (float eta = -3; eta < 3; eta += 1)
+        std::cout << eff(pt, eta) << " ";
+    }
+    std::cout << std::endl;
   }
 
   DEFINE_FWK_MODULE(EfficiencyByLabelAnalyzer);
-}
-
-
+}  // namespace edmtest

--- a/CondCore/ESSources/test/stubs/PedestalsAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/PedestalsAnalyzer.cc
@@ -23,65 +23,57 @@ Toy EDProducers and EDProducts for testing purposes only.
 
 using namespace std;
 
-namespace edmtest
-{
-  class PedestalsAnalyzer : public edm::EDAnalyzer
-  {
+namespace edmtest {
+  class PedestalsAnalyzer : public edm::EDAnalyzer {
   public:
-    explicit  PedestalsAnalyzer(edm::ParameterSet const& p) 
-    { 
-      std::cout<<"PedestalsAnalyzer"<<std::endl;
-    }
-    explicit  PedestalsAnalyzer(int i) 
-    { std::cout<<"PedestalsAnalyzer "<<i<<std::endl; }
-    virtual ~PedestalsAnalyzer() {  
-      std::cout<<"~PedestalsAnalyzer "<<std::endl;
-    }
+    explicit PedestalsAnalyzer(edm::ParameterSet const& p) { std::cout << "PedestalsAnalyzer" << std::endl; }
+    explicit PedestalsAnalyzer(int i) { std::cout << "PedestalsAnalyzer " << i << std::endl; }
+    virtual ~PedestalsAnalyzer() { std::cout << "~PedestalsAnalyzer " << std::endl; }
     virtual void beginJob();
     virtual void beginRun(const edm::Run&, const edm::EventSetup& context);
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+
   private:
   };
-  void
-  PedestalsAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& context){
-    std::cout<<"###PedestalsAnalyzer::beginRun"<<std::endl;
+  void PedestalsAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& context) {
+    std::cout << "###PedestalsAnalyzer::beginRun" << std::endl;
     edm::ESHandle<Pedestals> pPeds;
-    std::cout<<"got eshandle"<<std::endl;
+    std::cout << "got eshandle" << std::endl;
     context.get<PedestalsRcd>().get(pPeds);
   }
-  void
-  PedestalsAnalyzer::beginJob(){
-    std::cout<<"###PedestalsAnalyzer::beginJob"<<std::endl;
+  void PedestalsAnalyzer::beginJob() {
+    std::cout << "###PedestalsAnalyzer::beginJob" << std::endl;
     /*edm::ESHandle<Pedestals> pPeds;
       std::cout<<"got eshandle"<<std::endl;
       context.get<PedestalsRcd>().get(pPeds);
     */
   }
-  void
-  PedestalsAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context){
+  void PedestalsAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.
-    std::cout <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
-    std::cout <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
-    edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("PedestalsRcd"));
-    if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::eventsetup::EventSetupRecordKey recordKey(
+        edm::eventsetup::EventSetupRecordKey::TypeTag::findType("PedestalsRcd"));
+    if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout <<"Record \"PedestalsRcd"<<"\" does not exist "<<std::endl;
+      std::cout << "Record \"PedestalsRcd"
+                << "\" does not exist " << std::endl;
     }
     edm::ESHandle<Pedestals> pPeds;
-    std::cout<<"got eshandle"<<std::endl;
+    std::cout << "got eshandle" << std::endl;
     context.get<PedestalsRcd>().get(pPeds);
-    std::cout<<"got context"<<std::endl;
-    const Pedestals* myped=pPeds.product();
-    std::cout<<"Pedestals* "<<myped<<std::endl;
-    for(std::vector<Pedestals::Item>::const_iterator it=myped->m_pedestals.begin(); it!=myped->m_pedestals.end(); ++it)
-      std::cout << " mean: " <<it->m_mean
-                << " variance: " <<it->m_variance;
-    std::cout  << std::endl;
+    std::cout << "got context" << std::endl;
+    const Pedestals* myped = pPeds.product();
+    std::cout << "Pedestals* " << myped << std::endl;
+    for (std::vector<Pedestals::Item>::const_iterator it = myped->m_pedestals.begin(); it != myped->m_pedestals.end();
+         ++it)
+      std::cout << " mean: " << it->m_mean << " variance: " << it->m_variance;
+    std::cout << std::endl;
 
-    TFile * f = TFile::Open("MyPedestal.xml","recreate");
-    f->WriteObjectAny(myped,"Pedestals","Pedestals");
+    TFile* f = TFile::Open("MyPedestal.xml", "recreate");
+    f->WriteObjectAny(myped, "Pedestals", "Pedestals");
     f->Close();
   }
   DEFINE_FWK_MODULE(PedestalsAnalyzer);
-}
+}  // namespace edmtest

--- a/CondCore/ESSources/test/stubs/PedestalsByLabelAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/PedestalsByLabelAnalyzer.cc
@@ -20,49 +20,41 @@ Toy EDProducers and EDProducts for testing purposes only.
 
 using namespace std;
 
-namespace edmtest
-{
-  class PedestalsByLabelAnalyzer : public edm::EDAnalyzer
-  {
+namespace edmtest {
+  class PedestalsByLabelAnalyzer : public edm::EDAnalyzer {
   public:
-    explicit  PedestalsByLabelAnalyzer(edm::ParameterSet const& p) 
-    { 
-      std::cout<<"PedestalsByLabelAnalyzer"<<std::endl;
+    explicit PedestalsByLabelAnalyzer(edm::ParameterSet const& p) {
+      std::cout << "PedestalsByLabelAnalyzer" << std::endl;
     }
-    explicit  PedestalsByLabelAnalyzer(int i) 
-    { std::cout<<"PedestalsByLabelAnalyzer "<<i<<std::endl; }
-    virtual ~PedestalsByLabelAnalyzer() {  
-      std::cout<<"~PedestalsByLabelAnalyzer "<<std::endl;
-    }
+    explicit PedestalsByLabelAnalyzer(int i) { std::cout << "PedestalsByLabelAnalyzer " << i << std::endl; }
+    virtual ~PedestalsByLabelAnalyzer() { std::cout << "~PedestalsByLabelAnalyzer " << std::endl; }
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+
   private:
   };
-  
-  void
-   PedestalsByLabelAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context){
+
+  void PedestalsByLabelAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.
-    std::cout <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
-    std::cout <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
-    edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("PedestalsRcd"));
-    if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::eventsetup::EventSetupRecordKey recordKey(
+        edm::eventsetup::EventSetupRecordKey::TypeTag::findType("PedestalsRcd"));
+    if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout <<"Record \"PedestalsRcd"<<"\" does not exist "<<std::endl;
+      std::cout << "Record \"PedestalsRcd"
+                << "\" does not exist " << std::endl;
     }
     edm::ESHandle<Pedestals> pPeds;
-    std::cout<<"got eshandle"<<std::endl;
-    context.get<PedestalsRcd>().get("lab3d",pPeds);
-    std::cout<<"got context"<<std::endl;
-    const Pedestals* myped=pPeds.product();
-    std::cout<<"Pedestals* "<<myped<<std::endl;
-    for(std::vector<Pedestals::Item>::const_iterator it=myped->m_pedestals.begin();
-	it!=myped->m_pedestals.end(); ++it)
-      std::cout << " mean: " <<it->m_mean
-                << " variance: " <<it->m_variance;
-    std::cout  << std::endl;
-    
+    std::cout << "got eshandle" << std::endl;
+    context.get<PedestalsRcd>().get("lab3d", pPeds);
+    std::cout << "got context" << std::endl;
+    const Pedestals* myped = pPeds.product();
+    std::cout << "Pedestals* " << myped << std::endl;
+    for (std::vector<Pedestals::Item>::const_iterator it = myped->m_pedestals.begin(); it != myped->m_pedestals.end();
+         ++it)
+      std::cout << " mean: " << it->m_mean << " variance: " << it->m_variance;
+    std::cout << std::endl;
   }
   DEFINE_FWK_MODULE(PedestalsByLabelAnalyzer);
-}
-
-
+}  // namespace edmtest

--- a/PhysicsTools/CondLiteIO/interface/RecordWriter.h
+++ b/PhysicsTools/CondLiteIO/interface/RecordWriter.h
@@ -4,7 +4,7 @@
 //
 // Package:     CondLiteIO
 // Class  :     RecordWriter
-// 
+//
 /**\class RecordWriter RecordWriter.h PhysicsTools/CondLiteIO/interface/RecordWriter.h
 
  Description: Used to write the contents of an EventSetup Record to a TFile
@@ -30,42 +30,40 @@ class TBranch;
 class TTree;
 
 namespace fwlite {
-class RecordWriter
-{
+  class RecordWriter {
+  public:
+    RecordWriter(const char* iName, TFile* iFile);
+    virtual ~RecordWriter();
 
-   public:
-      RecordWriter(const char* iName, TFile* iFile);
-      virtual ~RecordWriter();
+    struct DataBuffer {
+      const void* pBuffer_;
+      TBranch* branch_;
+      edm::TypeIDBase trueType_;
+    };
+    // ---------- const member functions ---------------------
 
-      struct DataBuffer {
-         const void* pBuffer_;
-         TBranch* branch_;
-         edm::TypeIDBase trueType_;
-      };
-      // ---------- const member functions ---------------------
+    // ---------- static member functions --------------------
 
-      // ---------- static member functions --------------------
+    // ---------- member functions ---------------------------
+    void update(const void* iData, const std::type_info& iType, const char* iLabel);
 
-      // ---------- member functions ---------------------------
-      void update(const void* iData, const std::type_info& iType, const char* iLabel);
-      
-      //call update before calling write
-      void fill(const edm::ESRecordAuxiliary&);
+    //call update before calling write
+    void fill(const edm::ESRecordAuxiliary&);
 
-      void write();
+    void write();
 
-   private:
-      RecordWriter(const RecordWriter&) = delete; // stop default
+  private:
+    RecordWriter(const RecordWriter&) = delete;  // stop default
 
-      const RecordWriter& operator=(const RecordWriter&) = delete; // stop default
+    const RecordWriter& operator=(const RecordWriter&) = delete;  // stop default
 
-      // ---------- member data --------------------------------
-      TTree* tree_;
-      edm::ESRecordAuxiliary aux_;
-      edm::ESRecordAuxiliary* pAux_;
-      TBranch* auxBranch_;
-      std::map<std::pair<edm::TypeIDBase,std::string>, DataBuffer> idToBuffer_;
-};
-}
+    // ---------- member data --------------------------------
+    TTree* tree_;
+    edm::ESRecordAuxiliary aux_;
+    edm::ESRecordAuxiliary* pAux_;
+    TBranch* auxBranch_;
+    std::map<std::pair<edm::TypeIDBase, std::string>, DataBuffer> idToBuffer_;
+  };
+}  // namespace fwlite
 
 #endif

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    FWLiteESRecordWriterAnalyzer
 // Class:      FWLiteESRecordWriterAnalyzer
-// 
+//
 /**\class FWLiteESRecordWriterAnalyzer FWLiteESRecordWriterAnalyzer.cc PhysicsTools/FWLiteESRecordWriterAnalyzer/src/FWLiteESRecordWriterAnalyzer.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Fri Jun 18 14:23:07 CDT 2010
 //
 //
-
 
 // system include files
 #include <memory>
@@ -40,134 +39,122 @@
 // class declaration
 //
 
-namespace  {
-   
-   struct DataInfo {
-      DataInfo( const edm::eventsetup::heterocontainer::HCTypeTag& iTag,
-               const std::string& iLabel) :
-      m_tag(iTag), m_label(iLabel) {}
-      edm::eventsetup::heterocontainer::HCTypeTag m_tag;
-      std::string m_label;
-   };
-}
+namespace {
+
+  struct DataInfo {
+    DataInfo(const edm::eventsetup::heterocontainer::HCTypeTag& iTag, const std::string& iLabel)
+        : m_tag(iTag), m_label(iLabel) {}
+    edm::eventsetup::heterocontainer::HCTypeTag m_tag;
+    std::string m_label;
+  };
+}  // namespace
 
 namespace fwliteeswriter {
-   struct DummyType {
-      const edm::eventsetup::heterocontainer::HCTypeTag* m_tag;
-      mutable const void* m_data;
-   };
-   struct Handle {
-      Handle(const DataInfo* iInfo): m_data(nullptr), m_info(iInfo) {}
-      const void* m_data;
-      const DataInfo* m_info;
-      const edm::eventsetup::ComponentDescription* m_desc;
-   };
-}
-
+  struct DummyType {
+    const edm::eventsetup::heterocontainer::HCTypeTag* m_tag;
+    mutable const void* m_data;
+  };
+  struct Handle {
+    Handle(const DataInfo* iInfo) : m_data(nullptr), m_info(iInfo) {}
+    const void* m_data;
+    const DataInfo* m_info;
+    const edm::eventsetup::ComponentDescription* m_desc;
+  };
+}  // namespace fwliteeswriter
 
 namespace edm {
-   namespace eventsetup {
-      
-      template <> 
-      void EventSetupRecordImpl::getImplementation<fwliteeswriter::DummyType>(fwliteeswriter::DummyType const *& iData ,
-                                                                              const char* iName,
-                                                                              const ComponentDescription*& iDesc,
-                                                                              bool iTransientAccessOnly,
-                                                                              std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory) const {
-         DataKey dataKey(*(iData->m_tag),
-                         iName,
-                         DataKey::kDoNotCopyMemory);
-         
-         const void* pValue = this->getFromProxy(dataKey,iDesc,iTransientAccessOnly);
-         if(nullptr==pValue) {
-	   throw cms::Exception("NoProxyException")<<"No data of type \""<<iData->m_tag->name()<<"\" with label \""<<
-	     iName<<"\" in record \""<<this->key().name()<<"\"";
-         }
-         iData->m_data = pValue;
-      }
-      
-      template<>
-      bool EventSetupRecord::get<fwliteeswriter::Handle>(const std::string& iName, fwliteeswriter::Handle& iHolder) const {
-         fwliteeswriter::DummyType t;
-         t.m_tag = &(iHolder.m_info->m_tag);
-         const fwliteeswriter::DummyType* value = &t;
-         const ComponentDescription* desc = nullptr;
-         std::shared_ptr<ESHandleExceptionFactory> dummy;
-         impl_->getImplementation(value, iName.c_str(),desc,true, dummy);
-         iHolder.m_data = t.m_data;
-         iHolder.m_desc = desc;
-         return true;
-      }
-      
-   }
-}
+  namespace eventsetup {
 
+    template <>
+    void EventSetupRecordImpl::getImplementation<fwliteeswriter::DummyType>(
+        fwliteeswriter::DummyType const*& iData,
+        const char* iName,
+        const ComponentDescription*& iDesc,
+        bool iTransientAccessOnly,
+        std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory) const {
+      DataKey dataKey(*(iData->m_tag), iName, DataKey::kDoNotCopyMemory);
 
-namespace  {
-
-   class RecordHandler {
-   public:
-      RecordHandler(const edm::eventsetup::EventSetupRecordKey& iRec,
-                    TFile* iFile,
-                    std::vector<DataInfo>& ioInfo):
-      m_key(iRec),
-      m_record(),
-      m_writer(m_key.name(),iFile),
-      m_cacheID(0) {
-         m_dataInfos.swap(ioInfo);
+      const void* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly);
+      if (nullptr == pValue) {
+        throw cms::Exception("NoProxyException") << "No data of type \"" << iData->m_tag->name() << "\" with label \""
+                                                 << iName << "\" in record \"" << this->key().name() << "\"";
       }
-      
-      void update(const edm::EventSetup& iSetup) {
-         if(not m_record) {
-            m_record = iSetup.find(m_key);
-            assert(m_record);
-         }
-         if(m_cacheID != m_record->cacheIdentifier()) {
-            m_cacheID = m_record->cacheIdentifier();
-         
-            for(std::vector<DataInfo>::const_iterator it = m_dataInfos.begin(),
-                itEnd = m_dataInfos.end();
-                it != itEnd;
-                ++it) {
-               fwliteeswriter::Handle h(&(*it));
-               m_record->get(it->m_label,h);
-               m_writer.update(h.m_data,(it->m_tag.value()),it->m_label.c_str());
-            }
-            edm::ValidityInterval const& iov= m_record->validityInterval();
-            m_writer.fill(edm::ESRecordAuxiliary(iov.first().eventID(),
-                                                 iov.first().time()) );
-         }
-      }
-   private:
-      edm::eventsetup::EventSetupRecordKey m_key;
-     std::optional<edm::eventsetup::EventSetupRecordGeneric> m_record;
-      fwlite::RecordWriter m_writer;
-      unsigned long long m_cacheID;
-      std::vector<DataInfo> m_dataInfos;
-   };
-}
+      iData->m_data = pValue;
+    }
 
-                        
+    template <>
+    bool EventSetupRecord::get<fwliteeswriter::Handle>(const std::string& iName,
+                                                       fwliteeswriter::Handle& iHolder) const {
+      fwliteeswriter::DummyType t;
+      t.m_tag = &(iHolder.m_info->m_tag);
+      const fwliteeswriter::DummyType* value = &t;
+      const ComponentDescription* desc = nullptr;
+      std::shared_ptr<ESHandleExceptionFactory> dummy;
+      impl_->getImplementation(value, iName.c_str(), desc, true, dummy);
+      iHolder.m_data = t.m_data;
+      iHolder.m_desc = desc;
+      return true;
+    }
+
+  }  // namespace eventsetup
+}  // namespace edm
+
+namespace {
+
+  class RecordHandler {
+  public:
+    RecordHandler(const edm::eventsetup::EventSetupRecordKey& iRec, TFile* iFile, std::vector<DataInfo>& ioInfo)
+        : m_key(iRec), m_record(), m_writer(m_key.name(), iFile), m_cacheID(0) {
+      m_dataInfos.swap(ioInfo);
+    }
+
+    void update(const edm::EventSetup& iSetup) {
+      if (not m_record) {
+        m_record = iSetup.find(m_key);
+        assert(m_record);
+      }
+      if (m_cacheID != m_record->cacheIdentifier()) {
+        m_cacheID = m_record->cacheIdentifier();
+
+        for (std::vector<DataInfo>::const_iterator it = m_dataInfos.begin(), itEnd = m_dataInfos.end(); it != itEnd;
+             ++it) {
+          fwliteeswriter::Handle h(&(*it));
+          m_record->get(it->m_label, h);
+          m_writer.update(h.m_data, (it->m_tag.value()), it->m_label.c_str());
+        }
+        edm::ValidityInterval const& iov = m_record->validityInterval();
+        m_writer.fill(edm::ESRecordAuxiliary(iov.first().eventID(), iov.first().time()));
+      }
+    }
+
+  private:
+    edm::eventsetup::EventSetupRecordKey m_key;
+    std::optional<edm::eventsetup::EventSetupRecordGeneric> m_record;
+    fwlite::RecordWriter m_writer;
+    unsigned long long m_cacheID;
+    std::vector<DataInfo> m_dataInfos;
+  };
+}  // namespace
+
 class FWLiteESRecordWriterAnalyzer : public edm::EDAnalyzer {
-   public:
-      explicit FWLiteESRecordWriterAnalyzer(const edm::ParameterSet&);
-      ~FWLiteESRecordWriterAnalyzer() override;
+public:
+  explicit FWLiteESRecordWriterAnalyzer(const edm::ParameterSet&);
+  ~FWLiteESRecordWriterAnalyzer() override;
 
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-   private:
-      void beginJob() override ;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
-      void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-   
-      void update(const edm::EventSetup&);
+  void update(const edm::EventSetup&);
 
-      // ----------member data ---------------------------
-   std::vector<std::shared_ptr<RecordHandler> > m_handlers;
-   
-   std::map<std::string, std::vector<std::pair<std::string,std::string> > > m_recordToDataNames;
-   TFile* m_file;
+  // ----------member data ---------------------------
+  std::vector<std::shared_ptr<RecordHandler> > m_handlers;
+
+  std::map<std::string, std::vector<std::pair<std::string, std::string> > > m_recordToDataNames;
+  TFile* m_file;
 };
 
 //
@@ -181,134 +168,119 @@ class FWLiteESRecordWriterAnalyzer : public edm::EDAnalyzer {
 //
 // constructors and destructor
 //
-FWLiteESRecordWriterAnalyzer::FWLiteESRecordWriterAnalyzer(const edm::ParameterSet& iConfig)
-{
-   std::vector<std::string> names = iConfig.getParameterNamesForType<std::vector<edm::ParameterSet> >(false);
-   if (names.empty()) {
-      throw edm::Exception(edm::errors::Configuration)<<"No VPSets were given in configuration";
-   }
-   for (std::vector<std::string>::const_iterator it = names.begin(), itEnd=names.end(); it != itEnd; ++it) {
-      const std::vector<edm::ParameterSet>& ps = iConfig.getUntrackedParameter<std::vector<edm::ParameterSet> >(*it);
-      std::vector<std::pair<std::string,std::string> >& data = m_recordToDataNames[*it];
-      for(std::vector<edm::ParameterSet>::const_iterator itPS = ps.begin(),itPSEnd = ps.end(); 
-          itPS != itPSEnd;
-          ++itPS){ 
-         std::string type = itPS->getUntrackedParameter<std::string>("type");
-         std::string label = itPS->getUntrackedParameter<std::string>("label",std::string());
-         data.push_back(std::make_pair(type,label) );
-      }
-   }
-   
-   m_file = TFile::Open(iConfig.getUntrackedParameter<std::string>("fileName").c_str(),"NEW");
+FWLiteESRecordWriterAnalyzer::FWLiteESRecordWriterAnalyzer(const edm::ParameterSet& iConfig) {
+  std::vector<std::string> names = iConfig.getParameterNamesForType<std::vector<edm::ParameterSet> >(false);
+  if (names.empty()) {
+    throw edm::Exception(edm::errors::Configuration) << "No VPSets were given in configuration";
+  }
+  for (std::vector<std::string>::const_iterator it = names.begin(), itEnd = names.end(); it != itEnd; ++it) {
+    const std::vector<edm::ParameterSet>& ps = iConfig.getUntrackedParameter<std::vector<edm::ParameterSet> >(*it);
+    std::vector<std::pair<std::string, std::string> >& data = m_recordToDataNames[*it];
+    for (std::vector<edm::ParameterSet>::const_iterator itPS = ps.begin(), itPSEnd = ps.end(); itPS != itPSEnd;
+         ++itPS) {
+      std::string type = itPS->getUntrackedParameter<std::string>("type");
+      std::string label = itPS->getUntrackedParameter<std::string>("label", std::string());
+      data.push_back(std::make_pair(type, label));
+    }
+  }
+
+  m_file = TFile::Open(iConfig.getUntrackedParameter<std::string>("fileName").c_str(), "NEW");
 }
 
-
-FWLiteESRecordWriterAnalyzer::~FWLiteESRecordWriterAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-   m_file->Close();
-   delete m_file;
+FWLiteESRecordWriterAnalyzer::~FWLiteESRecordWriterAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  m_file->Close();
+  delete m_file;
 }
-
 
 //
 // member functions
 //
-void
-FWLiteESRecordWriterAnalyzer::update(const edm::EventSetup& iSetup)
-{
-   using edm::eventsetup::heterocontainer::HCTypeTag;
-   if(m_handlers.empty()) {
-      //now we have access to the EventSetup so we can setup our data structure
-      for(std::map<std::string, std::vector<std::pair<std::string,std::string> > >::iterator it=m_recordToDataNames.begin(),
-          itEnd = m_recordToDataNames.end();
-          it != itEnd;
-          ++it) {
-         HCTypeTag tt = HCTypeTag::findType(it->first);
-         if(tt == HCTypeTag()) {
-            throw cms::Exception("UnknownESRecordType")<<"The name '"<<it->first<<"' is not associated with a known EventSetupRecord.\n"
-            "Please check spelling or load a module known to link with the package which declares that Record.";
-         }
-         edm::eventsetup::EventSetupRecordKey rKey(tt);
-         
-         auto rec = iSetup.find(tt);
-         if(not rec) {
-            throw cms::Exception("UnknownESRecordType")<<"The name '"<<it->first<<"' is not associated with a type which is not an EventSetupRecord.\n"
-            "Please check your spelling.";
-         }
-         
-         //now figure out what data
-         std::vector<std::pair<std::string,std::string> >& data = it->second;
-         if(data.empty()) {
-            //get everything from the record
-            std::vector<edm::eventsetup::DataKey> keys;
-            rec->fillRegisteredDataKeys(keys);
-            for(std::vector<edm::eventsetup::DataKey>::iterator itKey = keys.begin(), itKeyEnd = keys.end();
-                itKey != itKeyEnd;
-                ++itKey) {
-               data.push_back(std::make_pair(std::string(itKey->type().name()),
-                                             std::string(itKey->name().value())));
-            }
-         }
-         
-         std::vector<DataInfo> dataInfos;
-         for (std::vector<std::pair<std::string,std::string> >::iterator itData = data.begin(), itDataEnd = data.end(); 
-              itData != itDataEnd;              
-              ++itData) {
-            HCTypeTag tt = HCTypeTag::findType(itData->first);
-            if(tt == HCTypeTag()) {
-               throw cms::Exception("UnknownESDataType")<<"The name '"<<itData->first<<"' is not associated with a known type held in the "<<it->first<<" Record.\n"
-               "Please check spelling or load a module known to link with the package which declares that type.";
-            }
-            if(!bool(edm::TypeWithDict( tt.value() ))) {
-               throw cms::Exception("NoDictionary")<<"The type '"<<itData->first<<"' can not be retrieved from the Record "<<it->first<<" and stored \n"
-               "because no dictionary exists for the type.";
-            }
-            dataInfos.push_back(DataInfo(tt,itData->second));
-         }
-         m_handlers.push_back( std::make_shared<RecordHandler>(rKey,m_file,dataInfos) );
+void FWLiteESRecordWriterAnalyzer::update(const edm::EventSetup& iSetup) {
+  using edm::eventsetup::heterocontainer::HCTypeTag;
+  if (m_handlers.empty()) {
+    //now we have access to the EventSetup so we can setup our data structure
+    for (std::map<std::string, std::vector<std::pair<std::string, std::string> > >::iterator
+             it = m_recordToDataNames.begin(),
+             itEnd = m_recordToDataNames.end();
+         it != itEnd;
+         ++it) {
+      HCTypeTag tt = HCTypeTag::findType(it->first);
+      if (tt == HCTypeTag()) {
+        throw cms::Exception("UnknownESRecordType")
+            << "The name '" << it->first
+            << "' is not associated with a known EventSetupRecord.\n"
+               "Please check spelling or load a module known to link with the package which declares that Record.";
       }
-   }
-   
-   for(std::vector<std::shared_ptr<RecordHandler> >::iterator it = m_handlers.begin(),itEnd = m_handlers.end();
+      edm::eventsetup::EventSetupRecordKey rKey(tt);
+
+      auto rec = iSetup.find(tt);
+      if (not rec) {
+        throw cms::Exception("UnknownESRecordType")
+            << "The name '" << it->first
+            << "' is not associated with a type which is not an EventSetupRecord.\n"
+               "Please check your spelling.";
+      }
+
+      //now figure out what data
+      std::vector<std::pair<std::string, std::string> >& data = it->second;
+      if (data.empty()) {
+        //get everything from the record
+        std::vector<edm::eventsetup::DataKey> keys;
+        rec->fillRegisteredDataKeys(keys);
+        for (std::vector<edm::eventsetup::DataKey>::iterator itKey = keys.begin(), itKeyEnd = keys.end();
+             itKey != itKeyEnd;
+             ++itKey) {
+          data.push_back(std::make_pair(std::string(itKey->type().name()), std::string(itKey->name().value())));
+        }
+      }
+
+      std::vector<DataInfo> dataInfos;
+      for (std::vector<std::pair<std::string, std::string> >::iterator itData = data.begin(), itDataEnd = data.end();
+           itData != itDataEnd;
+           ++itData) {
+        HCTypeTag tt = HCTypeTag::findType(itData->first);
+        if (tt == HCTypeTag()) {
+          throw cms::Exception("UnknownESDataType")
+              << "The name '" << itData->first << "' is not associated with a known type held in the " << it->first
+              << " Record.\n"
+                 "Please check spelling or load a module known to link with the package which declares that type.";
+        }
+        if (!bool(edm::TypeWithDict(tt.value()))) {
+          throw cms::Exception("NoDictionary")
+              << "The type '" << itData->first << "' can not be retrieved from the Record " << it->first
+              << " and stored \n"
+                 "because no dictionary exists for the type.";
+        }
+        dataInfos.push_back(DataInfo(tt, itData->second));
+      }
+      m_handlers.push_back(std::make_shared<RecordHandler>(rKey, m_file, dataInfos));
+    }
+  }
+
+  for (std::vector<std::shared_ptr<RecordHandler> >::iterator it = m_handlers.begin(), itEnd = m_handlers.end();
        it != itEnd;
        ++it) {
-      (*it)->update(iSetup);
-   }
+    (*it)->update(iSetup);
+  }
 }
-
 
 // ------------ method called to for each event  ------------
-void
-FWLiteESRecordWriterAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup)
-{
-   update(iSetup);
+void FWLiteESRecordWriterAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
+  update(iSetup);
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-FWLiteESRecordWriterAnalyzer::beginJob()
-{
-}
+void FWLiteESRecordWriterAnalyzer::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-FWLiteESRecordWriterAnalyzer::endJob() {
-   m_file->Write();
-}
+void FWLiteESRecordWriterAnalyzer::endJob() { m_file->Write(); }
 
-void 
-FWLiteESRecordWriterAnalyzer::beginRun(edm::Run const&, edm::EventSetup const& iSetup){
-   update(iSetup);
+void FWLiteESRecordWriterAnalyzer::beginRun(edm::Run const&, edm::EventSetup const& iSetup) { update(iSetup); }
+void FWLiteESRecordWriterAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& iSetup) {
+  update(iSetup);
 }
-void 
-FWLiteESRecordWriterAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& iSetup){
-   update(iSetup);
-}
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(FWLiteESRecordWriterAnalyzer);

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESSource.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESSource.cc
@@ -2,7 +2,7 @@
 //
 // Package:     CondLiteIO
 // Class  :     FWLiteESSource
-// 
+//
 /**\class FWLiteESSource FWLiteESSource.h PhysicsTools/CondLiteIO/interface/FWLiteESSource.h
 
  Description: [one line class summary]
@@ -36,103 +36,82 @@
 
 #include "FWCore/Framework/interface/SourceFactory.h"
 
-
 // forward declarations
-namespace  {
-   struct TypeID : public edm::TypeIDBase {
-      explicit TypeID(const std::type_info& iInfo): edm::TypeIDBase(iInfo) {}
-      TypeID() {}
-      using TypeIDBase::typeInfo;
-   };
-   struct FWLiteESGenericHandle {
-      FWLiteESGenericHandle(const TypeID& iType):
-      m_type(iType),
-      m_data(nullptr),
-      m_exception(nullptr){}
-      
-      FWLiteESGenericHandle(const void* iData):
-      m_type(),
-      m_data(iData),
-      m_exception(nullptr) {}
+namespace {
+  struct TypeID : public edm::TypeIDBase {
+    explicit TypeID(const std::type_info& iInfo) : edm::TypeIDBase(iInfo) {}
+    TypeID() {}
+    using TypeIDBase::typeInfo;
+  };
+  struct FWLiteESGenericHandle {
+    FWLiteESGenericHandle(const TypeID& iType) : m_type(iType), m_data(nullptr), m_exception(nullptr) {}
 
-      FWLiteESGenericHandle(cms::Exception* iException):
-      m_type(),
-      m_data(nullptr),
-      m_exception(iException){}
-      
-      const std::type_info& typeInfo() const {
-         return m_type.typeInfo();
+    FWLiteESGenericHandle(const void* iData) : m_type(), m_data(iData), m_exception(nullptr) {}
+
+    FWLiteESGenericHandle(cms::Exception* iException) : m_type(), m_data(nullptr), m_exception(iException) {}
+
+    const std::type_info& typeInfo() const { return m_type.typeInfo(); }
+
+    TypeID m_type;
+    const void* m_data;
+    cms::Exception* m_exception;
+  };
+
+  class FWLiteProxy : public edm::eventsetup::DataProxy {
+  public:
+    FWLiteProxy(const TypeID& iTypeID, const fwlite::Record* iRecord) : m_type(iTypeID), m_record(iRecord) {}
+
+    const void* getImpl(const edm::eventsetup::EventSetupRecordImpl&, const edm::eventsetup::DataKey& iKey) override {
+      assert(iKey.type() == m_type);
+
+      FWLiteESGenericHandle h(m_type);
+      m_record->get(h, iKey.name().value());
+
+      if (nullptr != h.m_exception) {
+        throw *(h.m_exception);
       }
-      
-      TypeID m_type;
-      const void* m_data;
-      cms::Exception* m_exception;
-   };
-   
-   class FWLiteProxy : public edm::eventsetup::DataProxy {
-   public:
-      FWLiteProxy(const TypeID& iTypeID, const fwlite::Record* iRecord):
-      m_type(iTypeID),
-      m_record(iRecord){}
-      
-      const void* getImpl(const edm::eventsetup::EventSetupRecordImpl&, const edm::eventsetup::DataKey& iKey) override {
-         assert(iKey.type() == m_type);
-         
-         FWLiteESGenericHandle h(m_type);
-         m_record->get(h,iKey.name().value());
-         
-         if(nullptr!=h.m_exception) {
-            throw *(h.m_exception);
-         }
-         return h.m_data;
-      }
-      
-      void invalidateCache() override {
-      }
-      
-   private:
-      TypeID m_type;
-      const fwlite::Record* m_record;
-   };
-}
+      return h.m_data;
+    }
+
+    void invalidateCache() override {}
+
+  private:
+    TypeID m_type;
+    const fwlite::Record* m_record;
+  };
+}  // namespace
 
 class FWLiteESSource : public edm::eventsetup::DataProxyProvider, public edm::EventSetupRecordIntervalFinder {
-   
 public:
-   FWLiteESSource(edm::ParameterSet const& iPS);
-   ~FWLiteESSource() override;
-   
-   // ---------- const member functions ---------------------
-   
-   // ---------- static member functions --------------------
-   
-   // ---------- member functions ---------------------------
-   void newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType,
-                            const edm::ValidityInterval& iInterval) override;
-   
-   
-private:
-   FWLiteESSource(const FWLiteESSource&) = delete; // stop default
-   
-   const FWLiteESSource& operator=(const FWLiteESSource&) = delete; // stop default
-   
-   void registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey ,
-                                KeyedProxies& aProxyList) override;
-   
-   
-   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-                               const edm::IOVSyncValue& , 
-                               edm::ValidityInterval&) override;
-   
-   void delaySettingRecords() override;
-   
-   // ---------- member data --------------------------------
-   std::unique_ptr<TFile> m_file;
-   fwlite::EventSetup m_es;
-   std::map<edm::eventsetup::EventSetupRecordKey, fwlite::RecordID> m_keyToID;
-   
-};
+  FWLiteESSource(edm::ParameterSet const& iPS);
+  ~FWLiteESSource() override;
 
+  // ---------- const member functions ---------------------
+
+  // ---------- static member functions --------------------
+
+  // ---------- member functions ---------------------------
+  void newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType,
+                   const edm::ValidityInterval& iInterval) override;
+
+private:
+  FWLiteESSource(const FWLiteESSource&) = delete;  // stop default
+
+  const FWLiteESSource& operator=(const FWLiteESSource&) = delete;  // stop default
+
+  void registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey, KeyedProxies& aProxyList) override;
+
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                      const edm::IOVSyncValue&,
+                      edm::ValidityInterval&) override;
+
+  void delaySettingRecords() override;
+
+  // ---------- member data --------------------------------
+  std::unique_ptr<TFile> m_file;
+  fwlite::EventSetup m_es;
+  std::map<edm::eventsetup::EventSetupRecordKey, fwlite::RecordID> m_keyToID;
+};
 
 //
 // constants, enums and typedefs
@@ -145,20 +124,15 @@ private:
 //
 // constructors and destructor
 //
-FWLiteESSource::FWLiteESSource(edm::ParameterSet const& iPS):
-m_file( TFile::Open(iPS.getParameter<std::string>("fileName").c_str())),
-m_es( m_file.get())
-{
-}
+FWLiteESSource::FWLiteESSource(edm::ParameterSet const& iPS)
+    : m_file(TFile::Open(iPS.getParameter<std::string>("fileName").c_str())), m_es(m_file.get()) {}
 
 // FWLiteESSource::FWLiteESSource(const FWLiteESSource& rhs)
 // {
 //    // do actual copying here;
 // }
 
-FWLiteESSource::~FWLiteESSource()
-{
-}
+FWLiteESSource::~FWLiteESSource() {}
 
 //
 // assignment operators
@@ -175,86 +149,64 @@ FWLiteESSource::~FWLiteESSource()
 //
 // member functions
 //
-void 
-FWLiteESSource::newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType,
-                            const edm::ValidityInterval& /*iInterval*/)
-{
-   invalidateProxies(iRecordType);
+void FWLiteESSource::newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType,
+                                 const edm::ValidityInterval& /*iInterval*/) {
+  invalidateProxies(iRecordType);
 }
 
 //
 // const member functions
 //
-void 
-FWLiteESSource::registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey ,
-                                KeyedProxies& aProxyList)
-{
-   using edm::eventsetup::heterocontainer::HCTypeTag;
+void FWLiteESSource::registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey, KeyedProxies& aProxyList) {
+  using edm::eventsetup::heterocontainer::HCTypeTag;
 
-   fwlite::RecordID recID =  m_keyToID[iRecordKey];
-   const fwlite::Record& rec = m_es.get(recID);
-   typedef std::vector<std::pair<std::string,std::string> > TypesAndLabels;
-   TypesAndLabels typesAndLabels = rec.typeAndLabelOfAvailableData();
+  fwlite::RecordID recID = m_keyToID[iRecordKey];
+  const fwlite::Record& rec = m_es.get(recID);
+  typedef std::vector<std::pair<std::string, std::string> > TypesAndLabels;
+  TypesAndLabels typesAndLabels = rec.typeAndLabelOfAvailableData();
 
-   std::cout <<"Looking for data in record "<<iRecordKey.name()<<std::endl;
-   for(TypesAndLabels::const_iterator it = typesAndLabels.begin(), itEnd = typesAndLabels.end();
-       it != itEnd;
+  std::cout << "Looking for data in record " << iRecordKey.name() << std::endl;
+  for (TypesAndLabels::const_iterator it = typesAndLabels.begin(), itEnd = typesAndLabels.end(); it != itEnd; ++it) {
+    std::cout << " need type " << it->first << std::endl;
+    HCTypeTag tt = HCTypeTag::findType(it->first);
+    if (tt != HCTypeTag()) {
+      edm::eventsetup::DataKey dk(tt, edm::eventsetup::IdTags(it->second.c_str()));
+      aProxyList.push_back(std::make_pair(dk, std::make_shared<FWLiteProxy>(TypeID(tt.value()), &rec)));
+    } else {
+      LogDebug("UnknownESType") << "The type '" << it->first << "' is unknown in this job";
+      std::cout << "    *****FAILED*****" << std::endl;
+    }
+  }
+}
+
+void FWLiteESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey,
+                                    const edm::IOVSyncValue& iSync,
+                                    edm::ValidityInterval& oIOV) {
+  m_es.syncTo(iSync.eventID(), iSync.time());
+
+  const fwlite::Record& rec = m_es.get(m_keyToID[iKey]);
+  edm::IOVSyncValue endSync(rec.endSyncValue().eventID(), rec.endSyncValue().time());
+  if (rec.endSyncValue().eventID().run() == 0 && rec.endSyncValue().time().value() == 0ULL) {
+    endSync = edm::IOVSyncValue::endOfTime();
+  }
+  oIOV = edm::ValidityInterval(edm::IOVSyncValue(rec.startSyncValue().eventID(), rec.startSyncValue().time()), endSync);
+}
+
+void FWLiteESSource::delaySettingRecords() {
+  using edm::eventsetup::heterocontainer::HCTypeTag;
+  std::vector<std::string> recordNames = m_es.namesOfAvailableRecords();
+
+  for (std::vector<std::string>::const_iterator it = recordNames.begin(), itEnd = recordNames.end(); it != itEnd;
        ++it) {
-      std::cout <<" need type "<<it->first<<std::endl;
-      HCTypeTag tt = HCTypeTag::findType(it->first);
-      if(tt != HCTypeTag() ) {
-         edm::eventsetup::DataKey dk(tt,edm::eventsetup::IdTags(it->second.c_str()));
-         aProxyList.push_back(std::make_pair(dk,
-                                             std::make_shared<FWLiteProxy>(TypeID(tt.value()),&rec)));
-      } else {
-         LogDebug("UnknownESType")<<"The type '"<<it->first<<"' is unknown in this job";
-         std::cout <<"    *****FAILED*****"<<std::endl;
-      }
-   }
-   
+    HCTypeTag t = HCTypeTag::findType(*it);
+    if (t != HCTypeTag()) {
+      edm::eventsetup::EventSetupRecordKey key(t);
+      findingRecordWithKey(key);
+      usingRecordWithKey(key);
+      m_keyToID[key] = m_es.recordID(it->c_str());
+    }
+  }
 }
-
-
-void 
-FWLiteESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey,
-                               const edm::IOVSyncValue& iSync, 
-                               edm::ValidityInterval& oIOV)
-{
-   m_es.syncTo(iSync.eventID(), iSync.time());
-   
-   const fwlite::Record& rec = m_es.get(m_keyToID[iKey]);
-   edm::IOVSyncValue endSync(rec.endSyncValue().eventID(),
-                             rec.endSyncValue().time());
-   if(rec.endSyncValue().eventID().run()==0 &&
-      rec.endSyncValue().time().value() == 0ULL) {
-      endSync = edm::IOVSyncValue::endOfTime();
-   }
-   oIOV = edm::ValidityInterval(edm::IOVSyncValue(rec.startSyncValue().eventID(),
-                                                  rec.startSyncValue().time()),
-                                endSync);
-}
-
-void 
-FWLiteESSource::delaySettingRecords()
-{
-   using edm::eventsetup::heterocontainer::HCTypeTag;
-   std::vector<std::string> recordNames = m_es.namesOfAvailableRecords();
-   
-   for(std::vector<std::string>::const_iterator it = recordNames.begin(),
-       itEnd = recordNames.end();
-       it != itEnd;
-       ++it) {
-      HCTypeTag t = HCTypeTag::findType(*it);
-      if(t != HCTypeTag() ) {
-         edm::eventsetup::EventSetupRecordKey key(t);
-         findingRecordWithKey(key);
-         usingRecordWithKey(key);
-         m_keyToID[key]=m_es.recordID(it->c_str());
-      }
-   }
-}
-
-
 
 //
 // static member functions

--- a/PhysicsTools/CondLiteIO/src/RecordWriter.cc
+++ b/PhysicsTools/CondLiteIO/src/RecordWriter.cc
@@ -2,11 +2,11 @@
 //
 // Package:     FWCondLite
 // Class  :     RecordWriter
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
-// Original Author:  
+// Original Author:
 //         Created:  Wed Dec  9 17:01:03 CST 2009
 //
 
@@ -35,13 +35,11 @@ using namespace fwlite;
 //
 // constructors and destructor
 //
-RecordWriter::RecordWriter(const char* iName, TFile* iFile):
-pAux_(&aux_)
-{
-   tree_ = new TTree(fwlite::format_type_to_mangled(iName).c_str(),"Holds data for an EventSetup Record");
-   tree_->SetDirectory(iFile);
-   
-   auxBranch_ = tree_->Branch("ESRecordAuxiliary","edm::ESRecordAuxiliary",&pAux_);
+RecordWriter::RecordWriter(const char* iName, TFile* iFile) : pAux_(&aux_) {
+  tree_ = new TTree(fwlite::format_type_to_mangled(iName).c_str(), "Holds data for an EventSetup Record");
+  tree_->SetDirectory(iFile);
+
+  auxBranch_ = tree_->Branch("ESRecordAuxiliary", "edm::ESRecordAuxiliary", &pAux_);
 }
 
 // RecordWriter::RecordWriter(const RecordWriter& rhs)
@@ -49,9 +47,7 @@ pAux_(&aux_)
 //    // do actual copying here;
 // }
 
-RecordWriter::~RecordWriter()
-{
-}
+RecordWriter::~RecordWriter() {}
 
 //
 // assignment operators
@@ -68,69 +64,64 @@ RecordWriter::~RecordWriter()
 //
 // member functions
 //
-void 
-RecordWriter::update(const void* iData, const std::type_info& iType, const char* iLabel)
-{
-   const char* label = iLabel;
-   if(nullptr==iLabel) {
-      label = "";
-   }
-   std::map<std::pair<edm::TypeIDBase,std::string>, DataBuffer>::iterator itFound = idToBuffer_.find(std::make_pair(edm::TypeIDBase(iType),
-      std::string(iLabel)));
-   if(itFound == idToBuffer_.end()) {
-      //first request
-      DataBuffer buffer;
-      buffer.pBuffer_=iData;
-      edm::TypeWithDict t(iType);
-      assert(bool(t));
-      
-      std::string className = t.name();
-      
-      //now find actual type
-      edm::ObjectWithDict o(t,const_cast<void*>(iData));
-      edm::TypeWithDict trueType(o.dynamicType());
-      buffer.trueType_ = edm::TypeIDBase(trueType.typeInfo());
-      std::string trueClassName = trueType.name();
-      
-      buffer.branch_ = tree_->Branch((fwlite::format_type_to_mangled(className)+"__"+label).c_str(),
-                                     trueClassName.c_str(),
-                                     &buffer.pBuffer_);
-      idToBuffer_.insert(std::make_pair(std::make_pair(edm::TypeIDBase(iType),std::string(iLabel)),buffer));
-      itFound = idToBuffer_.find(std::make_pair(edm::TypeIDBase(iType),
-         std::string(iLabel)));
-   }
-   edm::TypeWithDict t(iType);
-   edm::ObjectWithDict o(t,const_cast<void*>(iData));
-   edm::TypeWithDict trueType(o.dynamicType());
-   assert(edm::TypeIDBase(trueType.typeInfo())==itFound->second.trueType_);
-   itFound->second.branch_->SetAddress(&(itFound->second.pBuffer_));
-   itFound->second.pBuffer_ = iData;
+void RecordWriter::update(const void* iData, const std::type_info& iType, const char* iLabel) {
+  const char* label = iLabel;
+  if (nullptr == iLabel) {
+    label = "";
+  }
+  std::map<std::pair<edm::TypeIDBase, std::string>, DataBuffer>::iterator itFound =
+      idToBuffer_.find(std::make_pair(edm::TypeIDBase(iType), std::string(iLabel)));
+  if (itFound == idToBuffer_.end()) {
+    //first request
+    DataBuffer buffer;
+    buffer.pBuffer_ = iData;
+    edm::TypeWithDict t(iType);
+    assert(bool(t));
+
+    std::string className = t.name();
+
+    //now find actual type
+    edm::ObjectWithDict o(t, const_cast<void*>(iData));
+    edm::TypeWithDict trueType(o.dynamicType());
+    buffer.trueType_ = edm::TypeIDBase(trueType.typeInfo());
+    std::string trueClassName = trueType.name();
+
+    buffer.branch_ = tree_->Branch(
+        (fwlite::format_type_to_mangled(className) + "__" + label).c_str(), trueClassName.c_str(), &buffer.pBuffer_);
+    idToBuffer_.insert(std::make_pair(std::make_pair(edm::TypeIDBase(iType), std::string(iLabel)), buffer));
+    itFound = idToBuffer_.find(std::make_pair(edm::TypeIDBase(iType), std::string(iLabel)));
+  }
+  edm::TypeWithDict t(iType);
+  edm::ObjectWithDict o(t, const_cast<void*>(iData));
+  edm::TypeWithDict trueType(o.dynamicType());
+  assert(edm::TypeIDBase(trueType.typeInfo()) == itFound->second.trueType_);
+  itFound->second.branch_->SetAddress(&(itFound->second.pBuffer_));
+  itFound->second.pBuffer_ = iData;
 }
 
 //call update before calling write
-void 
-RecordWriter::fill(const edm::ESRecordAuxiliary& iValue)
-{
-   for(std::map<std::pair<edm::TypeIDBase,std::string>, DataBuffer>::iterator it=idToBuffer_.begin(),itEnd=idToBuffer_.end();
-       it!=itEnd;++it) {
-      if(nullptr==it->second.pBuffer_) {
-         throw cms::Exception("MissingESData")<<"The EventSetup data "<<it->first.first.name()<<" '"<<it->first.second<<"' was not supplied";
-      }
-   }
-   
-   aux_ = iValue;
-   tree_->Fill();
-   for(std::map<std::pair<edm::TypeIDBase,std::string>, DataBuffer>::iterator it=idToBuffer_.begin(),itEnd=idToBuffer_.end();
-       it!=itEnd;++it) {
-          it->second.pBuffer_=nullptr;
-   }
+void RecordWriter::fill(const edm::ESRecordAuxiliary& iValue) {
+  for (std::map<std::pair<edm::TypeIDBase, std::string>, DataBuffer>::iterator it = idToBuffer_.begin(),
+                                                                               itEnd = idToBuffer_.end();
+       it != itEnd;
+       ++it) {
+    if (nullptr == it->second.pBuffer_) {
+      throw cms::Exception("MissingESData")
+          << "The EventSetup data " << it->first.first.name() << " '" << it->first.second << "' was not supplied";
+    }
+  }
+
+  aux_ = iValue;
+  tree_->Fill();
+  for (std::map<std::pair<edm::TypeIDBase, std::string>, DataBuffer>::iterator it = idToBuffer_.begin(),
+                                                                               itEnd = idToBuffer_.end();
+       it != itEnd;
+       ++it) {
+    it->second.pBuffer_ = nullptr;
+  }
 }
 
-void
-RecordWriter::write()
-{
-   tree_->Write();
-}
+void RecordWriter::write() { tree_->Write(); }
 //
 // const member functions
 //

--- a/PhysicsTools/CondLiteIO/test/EventSetupIntProductAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/test/EventSetupIntProductAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EventSetupIntProductAnalyzer
 // Class:      EventSetupIntProductAnalyzer
-// 
+//
 /**\class EventSetupIntProductAnalyzer EventSetupIntProductAnalyzer.cc test/EventSetupIntProductAnalyzer/src/EventSetupIntProductAnalyzer.cc
 
  Description: <one line class summary>
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <iostream>
@@ -26,7 +25,6 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "PhysicsTools/CondLiteIO/test/IntProductRecord.h"
@@ -41,71 +39,61 @@
 
 namespace edmtest {
 
-class EventSetupIntProductAnalyzer : public edm::EDAnalyzer {
-   public:
-      explicit EventSetupIntProductAnalyzer(const edm::ParameterSet&);
-      ~EventSetupIntProductAnalyzer();
+  class EventSetupIntProductAnalyzer : public edm::EDAnalyzer {
+  public:
+    explicit EventSetupIntProductAnalyzer(const edm::ParameterSet&);
+    ~EventSetupIntProductAnalyzer();
 
+    virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-   private:
-      // ----------member data ---------------------------
-      std::vector<int> expectedValues_;
-      unsigned int index_;
-};
+  private:
+    // ----------member data ---------------------------
+    std::vector<int> expectedValues_;
+    unsigned int index_;
+  };
 
-//
-// constants, enums and typedefs
-//
+  //
+  // constants, enums and typedefs
+  //
 
-//
-// static data member definitions
-//
+  //
+  // static data member definitions
+  //
 
-//
-// constructors and destructor
-//
-EventSetupIntProductAnalyzer::EventSetupIntProductAnalyzer(const edm::ParameterSet& iConfig):
-   expectedValues_(iConfig.getUntrackedParameter<std::vector<int> >("expectedValues",std::vector<int>())),
-   index_(0)
-{
-   //now do what ever initialization is needed
+  //
+  // constructors and destructor
+  //
+  EventSetupIntProductAnalyzer::EventSetupIntProductAnalyzer(const edm::ParameterSet& iConfig)
+      : expectedValues_(iConfig.getUntrackedParameter<std::vector<int> >("expectedValues", std::vector<int>())),
+        index_(0) {
+    //now do what ever initialization is needed
+  }
 
-}
+  EventSetupIntProductAnalyzer::~EventSetupIntProductAnalyzer() {
+    // do anything here that needs to be done at desctruction time
+    // (e.g. close files, deallocate resources etc.)
+  }
 
+  //
+  // member functions
+  //
 
-EventSetupIntProductAnalyzer::~EventSetupIntProductAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+  // ------------ method called to produce the data  ------------
+  void EventSetupIntProductAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
+    using namespace edm;
+    ESHandle<edmtest::IntProduct> pSetup;
+    iSetup.get<IntProductRecord>().get(pSetup);
 
-}
-
-
-//
-// member functions
-//
-
-// ------------ method called to produce the data  ------------
-void
-EventSetupIntProductAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   ESHandle<edmtest::IntProduct> pSetup;
-   iSetup.get<IntProductRecord>().get(pSetup);
-
-   std::cout <<"edmtest::IntProduct "<<pSetup->value<<std::endl;
-   if(!expectedValues_.empty()) {
-      if(expectedValues_.at(index_) != pSetup->value) {
-         throw cms::Exception("TestFail")<<"expected value "<<expectedValues_[index_]
-         <<" but was got "<<pSetup->value;
+    std::cout << "edmtest::IntProduct " << pSetup->value << std::endl;
+    if (!expectedValues_.empty()) {
+      if (expectedValues_.at(index_) != pSetup->value) {
+        throw cms::Exception("TestFail") << "expected value " << expectedValues_[index_] << " but was got "
+                                         << pSetup->value;
       }
       ++index_;
-   }
-   
-}
-}
+    }
+  }
+}  // namespace edmtest
 using namespace edmtest;
 //define this as a plug-in
 DEFINE_FWK_MODULE(EventSetupIntProductAnalyzer);

--- a/PhysicsTools/CondLiteIO/test/IntProductESSource.cc
+++ b/PhysicsTools/CondLiteIO/test/IntProductESSource.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Integration
 // Class  :     IntProductESSource
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -20,87 +20,75 @@
 #include "PhysicsTools/CondLiteIO/test/IntProductRecord.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 
-
 namespace edmtest {
-class IntProductESSource :
-   public edm::EventSetupRecordIntervalFinder, 
-   public edm::ESProducer
-{
-   
-public:
-   IntProductESSource(const edm::ParameterSet&);
-   
-   std::unique_ptr<edmtest::IntProduct> produce(const IntProductRecord&) ;
-   
-protected:
-   
-   virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-                                const edm::IOVSyncValue& iTime, 
+  class IntProductESSource : public edm::EventSetupRecordIntervalFinder, public edm::ESProducer {
+  public:
+    IntProductESSource(const edm::ParameterSet&);
+
+    std::unique_ptr<edmtest::IntProduct> produce(const IntProductRecord&);
+
+  protected:
+    virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                const edm::IOVSyncValue& iTime,
                                 edm::ValidityInterval& iInterval);
-   
-private:
-   IntProductESSource(const IntProductESSource&); // stop default
-   
-   const IntProductESSource& operator=(const IntProductESSource&); // stop default
-   
-   // ---------- member data --------------------------------
-   unsigned int nCalls_;
-};
 
-//
-// constants, enums and typedefs
-//
+  private:
+    IntProductESSource(const IntProductESSource&);  // stop default
 
-//
-// static data member definitions
-//
+    const IntProductESSource& operator=(const IntProductESSource&);  // stop default
 
-//
-// constructors and destructor
-//
-IntProductESSource::IntProductESSource(const edm::ParameterSet&)
-: nCalls_(0) {
-   this->findingRecord<IntProductRecord>();
-   setWhatProduced(this);
-}
+    // ---------- member data --------------------------------
+    unsigned int nCalls_;
+  };
 
-//IntProductESSource::~IntProductESSource()
-//{
-//}
+  //
+  // constants, enums and typedefs
+  //
 
-//
-// member functions
-//
+  //
+  // static data member definitions
+  //
 
-std::unique_ptr<edmtest::IntProduct> 
-IntProductESSource::produce(const IntProductRecord&) {
-   auto data = std::make_unique<edmtest::IntProduct>();
-   data->value = nCalls_;
-   ++nCalls_;
-   return data;
-}
+  //
+  // constructors and destructor
+  //
+  IntProductESSource::IntProductESSource(const edm::ParameterSet&) : nCalls_(0) {
+    this->findingRecord<IntProductRecord>();
+    setWhatProduced(this);
+  }
 
+  //IntProductESSource::~IntProductESSource()
+  //{
+  //}
 
-void 
-IntProductESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-                                const edm::IOVSyncValue& iTime, 
-                                edm::ValidityInterval& iInterval) {
-   //Be valid for 3 runs 
-   edm::EventID newTime = edm::EventID(1, 0, 0);
-   edm::EventID endTime = edm::EventID(4,0,0);
-   iInterval = edm::ValidityInterval(edm::IOVSyncValue(newTime),
-                                      edm::IOVSyncValue(endTime));
-}
+  //
+  // member functions
+  //
 
-//
-// const member functions
-//
+  std::unique_ptr<edmtest::IntProduct> IntProductESSource::produce(const IntProductRecord&) {
+    auto data = std::make_unique<edmtest::IntProduct>();
+    data->value = nCalls_;
+    ++nCalls_;
+    return data;
+  }
 
-//
-// static member functions
-//
-}
+  void IntProductESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                          const edm::IOVSyncValue& iTime,
+                                          edm::ValidityInterval& iInterval) {
+    //Be valid for 3 runs
+    edm::EventID newTime = edm::EventID(1, 0, 0);
+    edm::EventID endTime = edm::EventID(4, 0, 0);
+    iInterval = edm::ValidityInterval(edm::IOVSyncValue(newTime), edm::IOVSyncValue(endTime));
+  }
+
+  //
+  // const member functions
+  //
+
+  //
+  // static member functions
+  //
+}  // namespace edmtest
 using namespace edmtest;
 
 DEFINE_FWK_EVENTSETUP_SOURCE(IntProductESSource);
-

--- a/PhysicsTools/CondLiteIO/test/IntProductRecord.cc
+++ b/PhysicsTools/CondLiteIO/test/IntProductRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     CondLiteIO
 // Class  :     IntProductRecord
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -17,4 +17,3 @@
 EVENTSETUP_RECORD_REG(IntProductRecord);
 
 TYPELOOKUP_DATA_REG(edmtest::IntProduct);
-

--- a/PhysicsTools/CondLiteIO/test/IntProductRecord.h
+++ b/PhysicsTools/CondLiteIO/test/IntProductRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     CondLiteIO
 // Class  :     IntProductRecord
-// 
+//
 /**\class IntProductRecord IntProductRecord.h PhysicsTools/CondLiteIO/interface/IntProductRecord.h
 
  Description: [one line class summary]

--- a/PhysicsTools/CondLiteIO/test/recordwriter.cppunit.cpp
+++ b/PhysicsTools/CondLiteIO/test/recordwriter.cppunit.cpp
@@ -17,101 +17,97 @@
 #include "DataFormats/FWLite/interface/format_type_name.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 
-class testRecordWriter: public CppUnit::TestFixture
-{
-   CPPUNIT_TEST_SUITE(testRecordWriter);
-   
-   CPPUNIT_TEST(testNoInheritance);
-   CPPUNIT_TEST(testInheritance);
-   
-   CPPUNIT_TEST_SUITE_END();
+class testRecordWriter : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testRecordWriter);
+
+  CPPUNIT_TEST(testNoInheritance);
+  CPPUNIT_TEST(testInheritance);
+
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-   void setUp(){ }
-   void tearDown(){}
-   
-   void testNoInheritance();
-   void testInheritance();
+  void setUp() {}
+  void tearDown() {}
+
+  void testNoInheritance();
+  void testInheritance();
 };
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testRecordWriter);
 
+void testRecordWriter::testNoInheritance() {
+  {
+    TFile f("testRecordWriter.root", "RECREATE");
+    fwlite::RecordWriter w("TestRecord", &f);
 
-void testRecordWriter::testNoInheritance()
-{
-   {
-      TFile f("testRecordWriter.root","RECREATE");
-      fwlite::RecordWriter w("TestRecord", &f);
-      
-      std::vector<int> v;
-      for(int index=0; index<10; ++index) {
-         //std::cout <<" index "<<index<<std::endl;
-         v.push_back(index);
-         w.update(&v, typeid(v),"");
-         w.fill(edm::ESRecordAuxiliary(edm::EventID(index+1,0,0),edm::Timestamp()));
-      }
-      w.write();
-      f.Close();
-   }
-   
-   {
-      TFile f("testRecordWriter.root","READ");
-      TTree* recordTree = reinterpret_cast<TTree*>(f.Get("TestRecord"));
-      CPPUNIT_ASSERT(0!=recordTree);
-      
-      edm::ESRecordAuxiliary* aux=0;
-      recordTree->SetBranchAddress("ESRecordAuxiliary",&aux);
+    std::vector<int> v;
+    for (int index = 0; index < 10; ++index) {
+      //std::cout <<" index "<<index<<std::endl;
+      v.push_back(index);
+      w.update(&v, typeid(v), "");
+      w.fill(edm::ESRecordAuxiliary(edm::EventID(index + 1, 0, 0), edm::Timestamp()));
+    }
+    w.write();
+    f.Close();
+  }
 
-      std::vector<int>* pV=0;
-      recordTree->SetBranchAddress((fwlite::format_type_to_mangled("std::vector<int>")+"__").c_str(),&pV);
+  {
+    TFile f("testRecordWriter.root", "READ");
+    TTree* recordTree = reinterpret_cast<TTree*>(f.Get("TestRecord"));
+    CPPUNIT_ASSERT(0 != recordTree);
 
-      for(int index=0; index < recordTree->GetEntries(); ++index) {
-         recordTree->GetEntry(index);
-         CPPUNIT_ASSERT( aux->eventID().run()==static_cast<unsigned int>(index+1));
-         CPPUNIT_ASSERT( pV->size()==static_cast<size_t>(index+1));
-      }
-      
-   }
+    edm::ESRecordAuxiliary* aux = 0;
+    recordTree->SetBranchAddress("ESRecordAuxiliary", &aux);
+
+    std::vector<int>* pV = 0;
+    recordTree->SetBranchAddress((fwlite::format_type_to_mangled("std::vector<int>") + "__").c_str(), &pV);
+
+    for (int index = 0; index < recordTree->GetEntries(); ++index) {
+      recordTree->GetEntry(index);
+      CPPUNIT_ASSERT(aux->eventID().run() == static_cast<unsigned int>(index + 1));
+      CPPUNIT_ASSERT(pV->size() == static_cast<size_t>(index + 1));
+    }
+  }
 }
 
-void testRecordWriter::testInheritance()
-{
-   {
-      TFile f("testRecordWriter.root","RECREATE");
-      fwlite::RecordWriter w("TestRecord", &f);
-      
-      edmtest::SimpleDerived d;
-      for(int index=0; index<10; ++index) {
-         //std::cout <<" index "<<index<<std::endl;
-         d.key = index;
-         d.value = index;
-         d.dummy = index;
-         w.update(&d, typeid(edmtest::Simple),"");
-         w.fill(edm::ESRecordAuxiliary(edm::EventID(index+1,0,0),edm::Timestamp()));
-      }
-      w.write();
-      f.Close();
-   }
-   
-   {
-      TFile f("testRecordWriter.root","READ");
-      TTree* recordTree = reinterpret_cast<TTree*>(f.Get("TestRecord"));
-      CPPUNIT_ASSERT(0!=recordTree);
-      
-      edm::ESRecordAuxiliary* aux=0;
-      recordTree->SetBranchAddress("ESRecordAuxiliary",&aux);
+void testRecordWriter::testInheritance() {
+  {
+    TFile f("testRecordWriter.root", "RECREATE");
+    fwlite::RecordWriter w("TestRecord", &f);
 
-      edmtest::Simple* pS=0;
-      recordTree->SetBranchAddress((fwlite::format_type_to_mangled("edmtest::Simple")+"__").c_str(),&pS);
+    edmtest::SimpleDerived d;
+    for (int index = 0; index < 10; ++index) {
+      //std::cout <<" index "<<index<<std::endl;
+      d.key = index;
+      d.value = index;
+      d.dummy = index;
+      w.update(&d, typeid(edmtest::Simple), "");
+      w.fill(edm::ESRecordAuxiliary(edm::EventID(index + 1, 0, 0), edm::Timestamp()));
+    }
+    w.write();
+    f.Close();
+  }
 
-      for(int index=0; index < recordTree->GetEntries(); ++index) {
-         recordTree->GetEntry(index);
-         CPPUNIT_ASSERT( aux->eventID().run()==static_cast<unsigned int>(index+1));
-         CPPUNIT_ASSERT( pS->key==index);
-         CPPUNIT_ASSERT(0 != dynamic_cast<edmtest::SimpleDerived*>(pS));
-         CPPUNIT_ASSERT(index == dynamic_cast<edmtest::SimpleDerived*>(pS)->dummy);
-      }      
-   }
+  {
+    TFile f("testRecordWriter.root", "READ");
+    TTree* recordTree = reinterpret_cast<TTree*>(f.Get("TestRecord"));
+    CPPUNIT_ASSERT(0 != recordTree);
+
+    edm::ESRecordAuxiliary* aux = 0;
+    recordTree->SetBranchAddress("ESRecordAuxiliary", &aux);
+
+    edmtest::Simple* pS = 0;
+    recordTree->SetBranchAddress((fwlite::format_type_to_mangled("edmtest::Simple") + "__").c_str(), &pS);
+
+    for (int index = 0; index < recordTree->GetEntries(); ++index) {
+      recordTree->GetEntry(index);
+      CPPUNIT_ASSERT(aux->eventID().run() == static_cast<unsigned int>(index + 1));
+      CPPUNIT_ASSERT(pS->key == index);
+      CPPUNIT_ASSERT(0 != dynamic_cast<edmtest::SimpleDerived*>(pS));
+      CPPUNIT_ASSERT(index == dynamic_cast<edmtest::SimpleDerived*>(pS)->dummy);
+    }
+  }
 }
 
 #include <Utilities/Testing/interface/CppUnit_testdriver.icpp>


### PR DESCRIPTION

Applying code-format for CMSSW category alca,analysis,db.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/418//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


