### PR TITLE
Add missing dependency in TopQuarkAnalysis/TopEventSelection

### DIFF
--- a/TopQuarkAnalysis/TopEventSelection/BuildFile.xml
+++ b/TopQuarkAnalysis/TopEventSelection/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="FWCore/Framework"/>
 <use   name="PhysicsTools/CandUtils"/>
+<use   name="PhysicsTools/MVATrainer"/>
 <use   name="TopQuarkAnalysis/TopTools"/>
 <use   name="DataFormats/PatCandidates"/>
 <use   name="AnalysisDataFormats/TopObjects"/>


### PR DESCRIPTION
#### PR description:

When testing the header consistency, the test found that the package needs to export its dependency on PhysicsTools/MVATrainer.

#### PR validation:

The code compiles.