### PR TITLE
Prevent pLHE workflows to start from input files 

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_pileup.py
+++ b/Configuration/PyReleaseValidation/python/relval_pileup.py
@@ -62,7 +62,7 @@ workflows[25213.18]=['',['VBFHToBB_M125_Pow_py8_Evt_13UP18','DIGIUP18_PU25','REC
 # pLHE-based fullSim PU  workflows
 workflows[25215]   =['',['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_2p_HToGG_M125_13','DIGIUP15_PU25','RECOUP15_PU25','HARVESTUP15_PU25']]
 workflows[25215.17]=['',['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP17','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_2p_HToGG_M125_13UP17','DIGIUP17_PU25','RECOUP17_PU25','HARVESTUP17_PU25']]
-workflows[25215.18]=['',['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP18','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_2p_HToGG_M125_13','DIGIUP18_PU25','RECOUP18_PU25','HARVESTUP18_PU25']]
+workflows[25215.18]=['',['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP18','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_2p_HToGG_M125_13UP18','DIGIUP18_PU25','RECOUP18_PU25','HARVESTUP18_PU25']]
 
 workflows[11024.2]=['',['TTbar_13UP18HEfailINPUT','DigiFullHEfail','RecoFullHEfail','HARVESTFullHEfail','NanoFullHEfail']]
 workflows[11024.3]=['',['TTbar_13UP18BadHcalMitigINPUT','DigiFullBadHcalMitig','RecoFullBadHcalMitig','HARVESTFullBadHcalMitig','NanoFullBadHcalMitig']]

--- a/Configuration/PyReleaseValidation/python/relval_pileup.py
+++ b/Configuration/PyReleaseValidation/python/relval_pileup.py
@@ -60,9 +60,9 @@ workflows[25212.18]=['',['VBFHToZZTo4Nu_M125_Pow_py8_Evt_13UP18','DIGIUP18_PU25'
 workflows[25213.18]=['',['VBFHToBB_M125_Pow_py8_Evt_13UP18','DIGIUP18_PU25','RECOUP18_PU25','HARVESTUP18_PU25']]
 
 # pLHE-based fullSim PU  workflows
-workflows[25215]   =['',['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13INPUT','DIGIUP15_PU25','RECOUP15_PU25','HARVESTUP15_PU25']]
-workflows[25215.17]=['',['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP17INPUT','DIGIUP17_PU25','RECOUP17_PU25','HARVESTUP17_PU25']]
-workflows[25215.18]=['',['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP18INPUT','DIGIUP18_PU25','RECOUP18_PU25','HARVESTUP18_PU25']]
+workflows[25215]   =['',['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_2p_HToGG_M125_13','DIGIUP15_PU25','RECOUP15_PU25','HARVESTUP15_PU25']]
+workflows[25215.17]=['',['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP17','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_2p_HToGG_M125_13UP17','DIGIUP17_PU25','RECOUP17_PU25','HARVESTUP17_PU25']]
+workflows[25215.18]=['',['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP18','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_2p_HToGG_M125_13','DIGIUP18_PU25','RECOUP18_PU25','HARVESTUP18_PU25']]
 
 workflows[11024.2]=['',['TTbar_13UP18HEfailINPUT','DigiFullHEfail','RecoFullHEfail','HARVESTFullHEfail','NanoFullHEfail']]
 workflows[11024.3]=['',['TTbar_13UP18BadHcalMitigINPUT','DigiFullBadHcalMitig','RecoFullBadHcalMitig','HARVESTFullBadHcalMitig','NanoFullBadHcalMitig']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1431,7 +1431,7 @@ step1LHENormal = {'--relval'     : '10000,50',
                  '--datatier'    : 'LHE',
                  '--eventcontent': 'LHE',
                  '--era'         : 'Run2_2016',
-                 '-n'            : 100,
+                 '-n'            : 10,
                  }
 # followed by GEN-SIM step
 step1GENNormal = {'--relval'     : '10000,50',

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1464,9 +1464,9 @@ steps['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP18']=merge ([{'--filein':'lhe:1
 steps['Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_2p_HToGG_M125_13UP18']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_2p_HToGG_M125_LHE_py8_cff',step1GENNormal2018Default)
 
 #GEN-SIM inputs for pLHE-GEN-SIM workflows 2016,2017,2018
-steps['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13INPUT']={'INPUT':InputInfo(dataSet='/RelValGluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13/%s/GEN-SIM'%(baseDataSetRelease[3],),location='STD')}
-steps['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP17INPUT']={'INPUT':InputInfo(dataSet='/RelValGluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP17/%s/GEN-SIM'%(baseDataSetRelease[21],),location='STD')}
-steps['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP18INPUT']={'INPUT':InputInfo(dataSet='/RelValGluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP18/%s/GEN-SIM'%(baseDataSetRelease[22],),location='STD')}
+#steps['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13INPUT']={'INPUT':InputInfo(dataSet='/RelValGluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13/%s/GEN-SIM'%(baseDataSetRelease[3],),location='STD')}
+#steps['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP17INPUT']={'INPUT':InputInfo(dataSet='/RelValGluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP17/%s/GEN-SIM'%(baseDataSetRelease[21],),location='STD')}
+#steps['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP18INPUT']={'INPUT':InputInfo(dataSet='/RelValGluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13UP18/%s/GEN-SIM'%(baseDataSetRelease[22],),location='STD')}
 
 
 #Sherpa


### PR DESCRIPTION
#### PR description:

PR #26875 has added 6 new test workflows based on pLHE input to GEN-SIM. Although the basic workflows run smoothly, when the ```-i all``` is used for runTheMatrix.py in IB , 1370.0,1370.17 and 1370.18 fail due to the fact that the generator part is split in two, and the standard logic of PyReleaseValidation fail, see issue #27248. A simple workaround is to force these workflows to be always fully executed, regardless of the input option (to be verified the possible impact on resources). 

#### PR validation:

All the pLHE workflows have been verified to pass the first two steps both with and without the ```-i all``` option of runTheMatrix.py.