### PR TITLE
LZMA and ZSTD support for Streamer format

### DIFF
--- a/EventFilter/Utilities/interface/json_batchallocator.h
+++ b/EventFilter/Utilities/interface/json_batchallocator.h
@@ -76,6 +76,10 @@ namespace Json {
       freeHead_ = object;
     }
 
+    // disabled copy constructor and assignement operator.
+    BatchAllocator(const BatchAllocator &) = delete;
+    void operator=(const BatchAllocator &) = delete;
+
   private:
     struct BatchInfo {
       BatchInfo *next_;
@@ -83,10 +87,6 @@ namespace Json {
       AllocatedType *end_;
       AllocatedType buffer_[objectPerAllocation];
     };
-
-    // disabled copy constructor and assignement operator.
-    BatchAllocator(const BatchAllocator &) = delete;
-    void operator=(const BatchAllocator &) = delete;
 
     static BatchInfo *allocateBatch(unsigned int objectsPerPage) {
       const unsigned int mallocSize = sizeof(BatchInfo) - sizeof(AllocatedType) * objectPerAllocation +

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -154,7 +154,8 @@ namespace evf {
     edm::BranchIDLists const* bidlPtr = branchIDLists();
 
     std::unique_ptr<InitMsgBuilder> init_message =
-        jsonWriter_->streamerCommon_.serializeRegistry(*bidlPtr,
+        jsonWriter_->streamerCommon_.serializeRegistry(*jsonWriter_->streamerCommon_.getSerializerBuffer(),
+                                                       *bidlPtr,
                                                        *thinnedAssociationsHelper(),
                                                        OutputModule::processName(),
                                                        description().moduleLabel(),
@@ -186,7 +187,7 @@ namespace evf {
     fclose(src);
 
     //clear serialization buffers
-    jsonWriter_->streamerCommon_.clearSerializeDataBuffer();
+    jsonWriter_->streamerCommon_.getSerializerBuffer()->clearHeaderBuffer();
 
     //free output buffer needed only for the file write
     delete[] outBuf;
@@ -221,9 +222,8 @@ namespace evf {
 
     //auto lumiWriter = const_cast<EvFOutputEventWriter*>(luminosityBlockCache(e.getLuminosityBlock().index() ));
     auto lumiWriter = luminosityBlockCache(e.getLuminosityBlock().index());
-
-    std::unique_ptr<EventMsgBuilder> msg =
-        jsonWriter_->streamerCommon_.serializeEvent(e, triggerResults, selectorConfig());
+    std::unique_ptr<EventMsgBuilder> msg = jsonWriter_->streamerCommon_.serializeEvent(
+        *jsonWriter_->streamerCommon_.getSerializerBuffer(), e, triggerResults, selectorConfig());
     lumiWriter->incAccepted();
     lumiWriter->doOutputEvent(*msg);  //msg is written and discarded at this point
   }

--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -139,10 +139,14 @@ process.streamC = cms.OutputModule("ShmStreamConsumer",
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
 )
 
-#process.streamD = cms.OutputModule("EventStreamFileWriter",
-#    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
-#)
-
-process.ep = cms.EndPath(process.streamA+process.streamB+process.streamC
-  #+process.streamD
+process.streamD = cms.OutputModule("EventStreamFileWriter",
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
 )
+
+process.ep = cms.EndPath(
+  process.streamA
+  + process.streamB
+  + process.streamC
+# + process.streamD
+)
+

--- a/EventFilter/Utilities/test/testGlobalNumbers.cc
+++ b/EventFilter/Utilities/test/testGlobalNumbers.cc
@@ -22,10 +22,10 @@
 
 #include "boost/date_time/posix_time/posix_time.hpp"
 
+#include <ctime>
 #include <iomanip>
 #include <sstream>
 #include <string>
-#include <time.h>
 
 namespace test {
 
@@ -40,7 +40,7 @@ namespace test {
         : m_fedRawDataCollectionToken(consumes<FEDRawDataCollection>(
               pset.getUntrackedParameter<edm::InputTag>("inputTag", edm::InputTag("source")))) {}
 
-    void analyze(const edm::Event& e, const edm::EventSetup& c) {
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override {
       boost::posix_time::ptime event_timestamp;
       event_timestamp = boost::posix_time::from_time_t((time_t)e.time().unixTime());
       event_timestamp += boost::posix_time::microseconds(e.time().microsecondOffset());

--- a/IOPool/Streamer/BuildFile.xml
+++ b/IOPool/Streamer/BuildFile.xml
@@ -12,6 +12,8 @@
 <use   name="Utilities/StorageFactory"/>
 <use   name="rootcore"/>
 <use   name="zlib"/>
+<use   name="xz"/>
+<use   name="zstd"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/IOPool/Streamer/interface/EventMsgBuilder.h
+++ b/IOPool/Streamer/interface/EventMsgBuilder.h
@@ -23,6 +23,8 @@ public:
   void setOrigDataSize(uint32);
   uint8* startAddress() const { return buf_; }
   void setEventLength(uint32 len);
+  void setBufAddr(uint8* buf_addr) { buf_ = buf_addr; }
+  void setEventAddr(uint8* event_addr) { event_addr_ = event_addr; }
   uint8* eventAddr() const { return event_addr_; }
   uint32 headerSize() const { return event_addr_ - buf_; }
   uint32 size() const;

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -18,7 +18,6 @@
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
-
 // Data structure to be shared by all output modules for event serialization
 struct SerializeDataBuffer {
   typedef std::vector<char> SBuffer;

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -18,12 +18,12 @@
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
-const int init_size = 0;  //will be allocated on first event
-const unsigned int reserve_size = 50000;
 
 // Data structure to be shared by all output modules for event serialization
 struct SerializeDataBuffer {
   typedef std::vector<char> SBuffer;
+  static constexpr int init_size = 0;  //will be allocated on first event
+  static constexpr unsigned int reserve_size = 50000;
 
   SerializeDataBuffer()
       : comp_buf_(reserve_size + init_size),

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -18,45 +18,52 @@
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
-const int init_size = 1024 * 1024;
+const int init_size = 0;  //will be allocated on first event
+const unsigned int reserve_size = 50000;
 
 // Data structure to be shared by all output modules for event serialization
 struct SerializeDataBuffer {
   typedef std::vector<char> SBuffer;
 
   SerializeDataBuffer()
-      : comp_buf_(init_size),
+      : comp_buf_(reserve_size + init_size),
         curr_event_size_(),
         curr_space_used_(),
         rootbuf_(TBuffer::kWrite, init_size),
-        ptr_((unsigned char*)rootbuf_.Buffer()),
+        ptr_((unsigned char *)rootbuf_.Buffer()),
         header_buf_(),
-        bufs_(),
         adler32_chksum_(0) {}
 
   // This object caches the results of the last INIT or event
   // serialization operation.  You get access to the data using the
   // following member functions.
 
-  unsigned char const* bufferPointer() const { return get_underlying_safe(ptr_); }
-  unsigned char*& bufferPointer() { return get_underlying_safe(ptr_); }
+  unsigned char const *bufferPointer() const { return get_underlying_safe(ptr_); }
+  unsigned char *&bufferPointer() { return get_underlying_safe(ptr_); }
   unsigned int currentSpaceUsed() const { return curr_space_used_; }
   unsigned int currentEventSize() const { return curr_event_size_; }
   uint32_t adler32_chksum() const { return adler32_chksum_; }
+
+  void clearHeaderBuffer() {
+    header_buf_.clear();
+    header_buf_.shrink_to_fit();
+    rootbuf_.Reset();
+    rootbuf_.Expand(init_size);  //shrink TBuffer to size 0 after resetting TBuffer length
+  }
 
   std::vector<unsigned char> comp_buf_;  // space for compressed data
   unsigned int curr_event_size_;
   unsigned int curr_space_used_;  // less than curr_event_size_ if compressed
   TBufferFile rootbuf_;
-  edm::propagate_const<unsigned char*> ptr_;  // set to the place where the last event stored
-  SBuffer header_buf_;                        // place for INIT message creation
-  SBuffer bufs_;                              // place for EVENT message creation
-  uint32_t adler32_chksum_;                   // adler32 check sum for the (compressed) data
+  edm::propagate_const<unsigned char *> ptr_;  // set to the place where the last event stored
+  SBuffer header_buf_;                         // place for INIT message creation and streamer event header
+  uint32_t adler32_chksum_;                    // adler32 check sum for the (compressed) data
 };
 
 class EventMsgBuilder;
 class InitMsgBuilder;
 namespace edm {
+  enum StreamerCompressionAlgo { UNCOMPRESSED = 0, ZLIB = 1, LZMA = 2, ZSTD = 4 };
 
   class EventForOutput;
   class ModuleCallingContext;
@@ -64,31 +71,47 @@ namespace edm {
 
   class StreamSerializer {
   public:
-    StreamSerializer(SelectedProducts const* selections);
+    StreamSerializer(SelectedProducts const *selections);
 
-    int serializeRegistry(SerializeDataBuffer& data_buffer,
-                          const BranchIDLists& branchIDLists,
-                          ThinnedAssociationsHelper const& thinnedAssociationsHelper);
+    int serializeRegistry(SerializeDataBuffer &data_buffer,
+                          const BranchIDLists &branchIDLists,
+                          ThinnedAssociationsHelper const &thinnedAssociationsHelper);
 
-    int serializeEvent(EventForOutput const& event,
-                       ParameterSetID const& selectorConfig,
-                       bool use_compression,
+    int serializeEvent(SerializeDataBuffer &data_buffer,
+                       EventForOutput const &event,
+                       ParameterSetID const &selectorConfig,
+                       StreamerCompressionAlgo compressionAlgo,
                        int compression_level,
-                       SerializeDataBuffer& data_buffer) const;
+                       unsigned int reserveSize) const;
 
     /**
      * Compresses the data in the specified input buffer into the
      * specified output buffer.  Returns the size of the compressed data
      * or zero if compression failed.
      */
-    static unsigned int compressBuffer(unsigned char* inputBuffer,
+    static unsigned int compressBuffer(unsigned char *inputBuffer,
                                        unsigned int inputSize,
-                                       std::vector<unsigned char>& outputBuffer,
-                                       int compressionLevel);
+                                       std::vector<unsigned char> &outputBuffer,
+                                       int compressionLevel,
+                                       unsigned int reserveSize);
+
+    static unsigned int compressBufferLZMA(unsigned char *inputBuffer,
+                                           unsigned int inputSize,
+                                           std::vector<unsigned char> &outputBuffer,
+                                           int compressionLevel,
+                                           unsigned int reserveSize,
+                                           bool addHeader = true);
+
+    static unsigned int compressBufferZSTD(unsigned char *inputBuffer,
+                                           unsigned int inputSize,
+                                           std::vector<unsigned char> &outputBuffer,
+                                           int compressionLevel,
+                                           unsigned int reserveSize,
+                                           bool addHeader = true);
 
   private:
-    SelectedProducts const* selections_;
-    edm::propagate_const<TClass*> tc_;
+    SelectedProducts const *selections_;
+    edm::propagate_const<TClass *> tc_;
   };
 
 }  // namespace edm

--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -47,6 +47,16 @@ namespace edm {
                                   bool subsequent);
 
     /**
+     * Detect if buffer starts with "XZ\0" which means it is compressed in LZMA format
+     */
+    bool isBufferLZMA(unsigned char const* inputBuffer, unsigned int inputSize);
+
+    /**
+     * Detect if buffer starts with "Z\0" which means it is compressed in ZStandard format
+     */
+    bool isBufferZSTD(unsigned char const* inputBuffer, unsigned int inputSize);
+
+    /**
      * Uncompresses the data in the specified input buffer into the
      * specified output buffer.  The inputSize should be set to the size
      * of the compressed data in the inputBuffer.  The expectedFullSize should
@@ -58,6 +68,18 @@ namespace edm {
                                          unsigned int inputSize,
                                          std::vector<unsigned char>& outputBuffer,
                                          unsigned int expectedFullSize);
+
+    static unsigned int uncompressBufferLZMA(unsigned char* inputBuffer,
+                                             unsigned int inputSize,
+                                             std::vector<unsigned char>& outputBuffer,
+                                             unsigned int expectedFullSize,
+                                             bool hasHeader = true);
+
+    static unsigned int uncompressBufferZSTD(unsigned char* inputBuffer,
+                                             unsigned int inputSize,
+                                             std::vector<unsigned char>& outputBuffer,
+                                             unsigned int expectedFullSize,
+                                             bool hasHeader = true);
 
   protected:
     static void declareStreamers(SendDescs const& descs);

--- a/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
@@ -23,20 +23,22 @@ namespace edm {
     ~StreamerOutputModuleCommon();
     static void fillDescription(ParameterSetDescription& desc);
 
-    std::unique_ptr<InitMsgBuilder> serializeRegistry(BranchIDLists const& branchLists,
+    std::unique_ptr<InitMsgBuilder> serializeRegistry(SerializeDataBuffer& sbuf,
+                                                      BranchIDLists const& branchLists,
                                                       ThinnedAssociationsHelper const& helper,
                                                       std::string const& processName,
                                                       std::string const& moduleLabel,
                                                       ParameterSetID const& toplevel);
 
-    std::unique_ptr<EventMsgBuilder> serializeEvent(EventForOutput const& e,
+    std::unique_ptr<EventMsgBuilder> serializeEvent(SerializeDataBuffer& sbuf,
+                                                    EventForOutput const& e,
                                                     Handle<TriggerResults> const& triggerResults,
                                                     ParameterSetID const& selectorCfg);
 
-    void clearSerializeDataBuffer() {
-      serializeDataBuffer_.header_buf_.clear();
-      serializeDataBuffer_.header_buf_.shrink_to_fit();
-    }
+    SerializeDataBuffer* getSerializerBuffer();
+
+  protected:
+    std::unique_ptr<SerializeDataBuffer> serializerBuffer_;
 
   private:
     void setHltMask(EventForOutput const& e,
@@ -47,16 +49,16 @@ namespace edm {
 
     int maxEventSize_;
     bool useCompression_;
+    std::string compressionAlgoStr_;
     int compressionLevel_;
+
+    StreamerCompressionAlgo compressionAlgo_;
 
     // test luminosity sections
     int lumiSectionInterval_;
     double timeInSecSinceUTC;
 
-    SerializeDataBuffer serializeDataBuffer_;
-
     unsigned int hltsize_;
-    uint32 origSize_;
     char host_name_[255];
 
     Strings hltTriggerSelections_;

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -312,7 +312,7 @@ namespace edm {
     lzma_options_lzma opt_lzma2;
     lzma_filter filters[] = {
         {.id = LZMA_FILTER_LZMA2, .options = &opt_lzma2},
-        {.id = LZMA_VLI_UNKNOWN, .options = NULL},
+        {.id = LZMA_VLI_UNKNOWN, .options = nullptr},
     };
     lzma_ret returnStatus;
 

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -243,7 +243,7 @@ namespace edm {
           data_buffer.comp_buf_.resize(dest_size + reserveSize);
         std::copy((char *)data_buffer.rootbuf_.Buffer(),
                   (char *)data_buffer.rootbuf_.Buffer() + dest_size,
-                  (char *)(&data_buffer.comp_buf_[reserve_size]));
+                  (char *)(&data_buffer.comp_buf_[SerializeDataBuffer::reserve_size]));
         break;
     };
 

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -20,8 +20,11 @@
 #include "FWCore/Utilities/interface/Adler32Calculator.h"
 #include "DataFormats/Streamer/interface/StreamedProducts.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "zlib.h"
+#include "lzma.h"
+#include "zstd.h"
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
@@ -32,7 +35,7 @@ namespace edm {
   /**
    * Creates a translator instance for the specified product registry.
    */
-  StreamSerializer::StreamSerializer(SelectedProducts const* selections)
+  StreamSerializer::StreamSerializer(SelectedProducts const *selections)
       : selections_(selections), tc_(getTClass(typeid(SendEvent))) {}
 
   /**
@@ -40,15 +43,15 @@ namespace edm {
    * into the specified InitMessage.
    */
 
-  int StreamSerializer::serializeRegistry(SerializeDataBuffer& data_buffer,
-                                          const BranchIDLists& branchIDLists,
-                                          ThinnedAssociationsHelper const& thinnedAssociationsHelper) {
+  int StreamSerializer::serializeRegistry(SerializeDataBuffer &data_buffer,
+                                          const BranchIDLists &branchIDLists,
+                                          ThinnedAssociationsHelper const &thinnedAssociationsHelper) {
     FDEBUG(6) << "StreamSerializer::serializeRegistry" << std::endl;
     SendJobHeader sd;
 
     FDEBUG(9) << "Product List: " << std::endl;
 
-    for (auto const& selection : *selections_) {
+    for (auto const &selection : *selections_) {
       sd.push_back(*selection.first);
       FDEBUG(9) << "StreamOutput got product = " << selection.first->className() << std::endl;
     }
@@ -64,8 +67,8 @@ namespace edm {
 
     RootDebug tracer(10, 10);
 
-    TClass* tc = getTClass(typeid(SendJobHeader));
-    int bres = data_buffer.rootbuf_.WriteObjectAny((char*)&sd, tc);
+    TClass *tc = getTClass(typeid(SendJobHeader));
+    int bres = data_buffer.rootbuf_.WriteObjectAny((char *)&sd, tc);
 
     switch (bres) {
       case 0:  // failure
@@ -94,9 +97,9 @@ namespace edm {
 
     data_buffer.curr_event_size_ = data_buffer.rootbuf_.Length();
     data_buffer.curr_space_used_ = data_buffer.curr_event_size_;
-    data_buffer.ptr_ = (unsigned char*)data_buffer.rootbuf_.Buffer();
+    data_buffer.ptr_ = (unsigned char *)data_buffer.rootbuf_.Buffer();
     // calculate the adler32 checksum and fill it into the struct
-    data_buffer.adler32_chksum_ = cms::Adler32((char*)data_buffer.bufferPointer(), data_buffer.curr_space_used_);
+    data_buffer.adler32_chksum_ = cms::Adler32((char *)data_buffer.bufferPointer(), data_buffer.curr_space_used_);
     //std::cout << "Adler32 checksum of init message = " << data_buffer.adler32_chksum_ << std::endl;
     return data_buffer.curr_space_used_;
   }
@@ -121,11 +124,12 @@ namespace edm {
 
 
    */
-  int StreamSerializer::serializeEvent(EventForOutput const& event,
-                                       ParameterSetID const& selectorConfig,
-                                       bool use_compression,
+  int StreamSerializer::serializeEvent(SerializeDataBuffer &data_buffer,
+                                       EventForOutput const &event,
+                                       ParameterSetID const &selectorConfig,
+                                       StreamerCompressionAlgo compressionAlgo,
                                        int compression_level,
-                                       SerializeDataBuffer& data_buffer) const {
+                                       unsigned int reserveSize) const {
     EventSelectionIDVector selectionIDs = event.eventSelectionIDs();
     selectionIDs.push_back(selectorConfig);
     SendEvent se(event.eventAuxiliary(), event.processHistory(), selectionIDs, event.branchListIndexes());
@@ -144,8 +148,8 @@ namespace edm {
     // the PoolOutputModule. That information is currently
     // lost when the streamer output module is used.
 
-    for (auto const& selection : *selections_) {
-      BranchDescription const& desc = *selection.first;
+    for (auto const &selection : *selections_) {
+      BranchDescription const &desc = *selection.first;
       BasicHandle result = event.getByToken(selection.second, desc.unwrappedTypeID());
       if (!result.isValid()) {
         // No product with this ID was put in the event.
@@ -153,7 +157,7 @@ namespace edm {
         se.products().push_back(StreamedProduct(desc));
       } else {
         if (result.provenance()->productProvenance()) {
-          Parentage const* parentage =
+          Parentage const *parentage =
               ParentageRegistry::instance()->getMapped(result.provenance()->productProvenance()->parentageID());
           assert(parentage);
           se.products().push_back(
@@ -195,8 +199,8 @@ namespace edm {
     }
 
     data_buffer.curr_event_size_ = data_buffer.rootbuf_.Length();
-    data_buffer.curr_space_used_ = data_buffer.curr_event_size_;
-    data_buffer.ptr_ = (unsigned char*)data_buffer.rootbuf_.Buffer();
+    data_buffer.ptr_ = (unsigned char *)data_buffer.rootbuf_.Buffer();
+
 #if 0
    if(data_buffer.ptr_ != data_.ptr_) {
         std::cerr << "ROOT reset the buffer!!!!\n";
@@ -210,16 +214,44 @@ namespace edm {
     // compress before return if we need to
     // should test if compressed already - should never be?
     //   as double compression can have problems
-    if (use_compression) {
-      unsigned int dest_size =
-          compressBuffer(data_buffer.ptr_, data_buffer.curr_event_size_, data_buffer.comp_buf_, compression_level);
-      if (dest_size != 0) {
-        data_buffer.ptr_ = &data_buffer.comp_buf_[0];  // reset to point at compressed area
-        data_buffer.curr_space_used_ = dest_size;
-      }
-    }
+    unsigned int dest_size = 0;
+    switch (compressionAlgo) {
+      case ZLIB:
+        dest_size = compressBuffer((unsigned char *)data_buffer.rootbuf_.Buffer(),
+                                   data_buffer.curr_event_size_,
+                                   data_buffer.comp_buf_,
+                                   compression_level,
+                                   reserveSize);
+        break;
+      case LZMA:
+        dest_size = compressBufferLZMA((unsigned char *)data_buffer.rootbuf_.Buffer(),
+                                       data_buffer.curr_event_size_,
+                                       data_buffer.comp_buf_,
+                                       compression_level,
+                                       reserveSize);
+        break;
+      case ZSTD:
+        dest_size = compressBufferZSTD((unsigned char *)data_buffer.rootbuf_.Buffer(),
+                                       data_buffer.curr_event_size_,
+                                       data_buffer.comp_buf_,
+                                       compression_level,
+                                       reserveSize);
+        break;
+      default:
+        dest_size = data_buffer.rootbuf_.Length();
+        if (data_buffer.comp_buf_.size() < dest_size + reserveSize)
+          data_buffer.comp_buf_.resize(dest_size + reserveSize);
+        std::copy((char *)data_buffer.rootbuf_.Buffer(),
+                  (char *)data_buffer.rootbuf_.Buffer() + dest_size,
+                  (char *)(&data_buffer.comp_buf_[reserve_size]));
+        break;
+    };
+
+    data_buffer.ptr_ = &data_buffer.comp_buf_[reserveSize];  // reset to point at compressed area
+    data_buffer.curr_space_used_ = dest_size;
+
     // calculate the adler32 checksum and fill it into the struct
-    data_buffer.adler32_chksum_ = cms::Adler32((char*)data_buffer.bufferPointer(), data_buffer.curr_space_used_);
+    data_buffer.adler32_chksum_ = cms::Adler32((char *)data_buffer.bufferPointer(), data_buffer.curr_space_used_);
     //std::cout << "Adler32 checksum of event = " << data_buffer.adler32_chksum_ << std::endl;
 
     return data_buffer.curr_space_used_;
@@ -230,19 +262,21 @@ namespace edm {
    * specified output buffer.  Returns the size of the compressed data
    * or zero if compression failed.
    */
-  unsigned int StreamSerializer::compressBuffer(unsigned char* inputBuffer,
+  unsigned int StreamSerializer::compressBuffer(unsigned char *inputBuffer,
                                                 unsigned int inputSize,
-                                                std::vector<unsigned char>& outputBuffer,
-                                                int compressionLevel) {
+                                                std::vector<unsigned char> &outputBuffer,
+                                                int compressionLevel,
+                                                unsigned int reserveSize) {
     unsigned int resultSize = 0;
 
-    // what are these magic numbers? (jbk)
+    // what are these magic numbers? (jbk) -> LSB 3.0 buffer size reccommendation
     unsigned long dest_size = (unsigned long)(double(inputSize) * 1.002 + 1.0) + 12;
-    if (outputBuffer.size() < dest_size)
-      outputBuffer.resize(dest_size);
+    //this can has some overhead in memory usage (capacity > size) due to the way std::vector allocator works
+    if (outputBuffer.size() < dest_size + reserveSize)
+      outputBuffer.resize(dest_size + reserveSize);
 
     // compression 1-9, 6 is zlib default, 0 none
-    int ret = compress2(&outputBuffer[0], &dest_size, inputBuffer, inputSize, compressionLevel);
+    int ret = compress2(&outputBuffer[reserveSize], &dest_size, inputBuffer, inputSize, compressionLevel);
 
     // check status
     if (ret == Z_OK) {
@@ -252,12 +286,139 @@ namespace edm {
       FDEBUG(1) << " original size = " << inputSize << " final size = " << dest_size
                 << " ratio = " << double(dest_size) / double(inputSize) << std::endl;
     } else {
-      // compression failed, return a size of zero
-      FDEBUG(9) << "Compression Return value: " << ret << " Okay = " << Z_OK << std::endl;
-      // do we throw an exception here?
-      std::cerr << "Compression Return value: " << ret << " Okay = " << Z_OK << std::endl;
+      throw cms::Exception("StreamSerializer", "compressBuffer")
+          << "Compression Return value: " << ret << " Okay = " << Z_OK << std::endl;
     }
 
     return resultSize;
   }
+
+  //this is based on ROOT R__zipLZMA
+  unsigned int StreamSerializer::compressBufferLZMA(unsigned char *inputBuffer,
+                                                    unsigned int inputSize,
+                                                    std::vector<unsigned char> &outputBuffer,
+                                                    int compressionLevel,
+                                                    unsigned int reserveSize,
+                                                    bool addHeader) {
+    // what are these magic numbers? (jbk)
+    unsigned int hdr_size = addHeader ? 4 : 0;
+    unsigned long dest_size = (unsigned long)(double(inputSize) * 1.01 + 1.0) + 12;
+    if (outputBuffer.size() < dest_size + reserveSize)
+      outputBuffer.resize(dest_size + reserveSize);
+
+    // compression 1-9
+    uint32_t dict_size_est = inputSize / 4;
+    lzma_stream stream = LZMA_STREAM_INIT;
+    lzma_options_lzma opt_lzma2;
+    lzma_filter filters[] = {
+        {.id = LZMA_FILTER_LZMA2, .options = &opt_lzma2},
+        {.id = LZMA_VLI_UNKNOWN, .options = NULL},
+    };
+    lzma_ret returnStatus;
+
+    unsigned char *tgt = &outputBuffer[reserveSize];
+
+    //if (*srcsize > 0xffffff || *srcsize < 0) { //16 MB limit ?
+    //   return;
+    //}
+
+    if (compressionLevel > 9)
+      compressionLevel = 9;
+
+    lzma_bool presetStatus = lzma_lzma_preset(&opt_lzma2, compressionLevel);
+    if (presetStatus) {
+      throw cms::Exception("StreamSerializer", "compressBufferLZMA") << "LZMA preset return status: " << presetStatus;
+    }
+
+    if (LZMA_DICT_SIZE_MIN > dict_size_est) {
+      dict_size_est = LZMA_DICT_SIZE_MIN;
+    }
+    if (opt_lzma2.dict_size > dict_size_est) {
+      /* reduce the dictionary size if larger than 1/4 the input size, preset
+         dictionaries size can be expensively large
+       */
+      opt_lzma2.dict_size = dict_size_est;
+    }
+
+    returnStatus =
+        lzma_stream_encoder(&stream,
+                            filters,
+                            LZMA_CHECK_NONE);  //CRC32 and CRC64 are available, but we already calculate adler32
+    if (returnStatus != LZMA_OK) {
+      throw cms::Exception("StreamSerializer", "compressBufferLZMA")
+          << "LZMA compression encoder return value: " << returnStatus;
+    }
+
+    stream.next_in = (const uint8_t *)inputBuffer;
+    stream.avail_in = (size_t)(inputSize);
+
+    stream.next_out = (uint8_t *)(&tgt[hdr_size]);
+    stream.avail_out = (size_t)(dest_size - hdr_size);
+
+    returnStatus = lzma_code(&stream, LZMA_FINISH);
+
+    if (returnStatus != LZMA_STREAM_END) {
+      lzma_end(&stream);
+      throw cms::Exception("StreamSerializer", "compressBufferLZMA")
+          << "LZMA compression return value: " << returnStatus;
+    }
+    lzma_end(&stream);
+
+    //Add compression-specific header at the buffer start. This will be used to detect LZMA(2) format after streamer header
+    if (addHeader) {
+      tgt[0] = 'X'; /* Signature of LZMA from XZ Utils */
+      tgt[1] = 'Z';
+      tgt[2] = 0;
+      tgt[3] = 0;  //let's put offset to 4, not 3
+    }
+
+    FDEBUG(1) << " LZMA original size = " << inputSize << " final size = " << stream.total_out
+              << " ratio = " << double(stream.total_out) / double(inputSize) << std::endl;
+
+    return stream.total_out + hdr_size;
+  }
+
+  unsigned int StreamSerializer::compressBufferZSTD(unsigned char *inputBuffer,
+                                                    unsigned int inputSize,
+                                                    std::vector<unsigned char> &outputBuffer,
+                                                    int compressionLevel,
+                                                    unsigned int reserveSize,
+                                                    bool addHeader) {
+    unsigned int hdr_size = addHeader ? 4 : 0;
+    unsigned int resultSize = 0;
+
+    // what are these magic numbers? (jbk) -> LSB 3.0 buffer size reccommendation
+    size_t worst_size = ZSTD_compressBound(inputSize);
+    //this can has some overhead in memory usage (capacity > size) due to the way std::vector allocator works
+    if (outputBuffer.size() < worst_size + reserveSize + hdr_size)
+      outputBuffer.resize(worst_size + reserveSize + hdr_size);
+
+    //Add compression-specific header at the buffer start. This will be used to detect ZSTD format after streamer header
+    unsigned char *tgt = &outputBuffer[reserveSize];
+    if (addHeader) {
+      tgt[0] = 'Z'; /* Pre */
+      tgt[1] = 'S';
+      tgt[2] = 0;
+      tgt[3] = 0;
+    }
+
+    // compression 1-20
+    size_t dest_size = ZSTD_compress(
+        (void *)&outputBuffer[reserveSize + hdr_size], worst_size, (void *)inputBuffer, inputSize, compressionLevel);
+
+    // check status
+    if (!ZSTD_isError(dest_size)) {
+      // return the correct length
+      resultSize = (unsigned int)dest_size + hdr_size;
+
+      FDEBUG(1) << " original size = " << inputSize << " final size = " << dest_size
+                << " ratio = " << double(dest_size) / double(inputSize) << std::endl;
+    } else {
+      throw cms::Exception("StreamSerializer", "compressBuffer")
+          << "Compression (ZSTD) Error: " << ZSTD_getErrorName(dest_size);
+    }
+
+    return resultSize;
+  }
+
 }  // namespace edm

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -17,6 +17,8 @@
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 
 #include "zlib.h"
+#include "lzma.h"
+#include "zstd.h"
 
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
@@ -207,10 +209,21 @@ namespace edm {
     }
     if (origsize != 78 && origsize != 0) {
       // compressed
-      dest_size = uncompressBuffer(const_cast<unsigned char*>((unsigned char const*)eventView.eventData()),
-                                   eventView.eventLength(),
-                                   dest_,
-                                   origsize);
+      if (isBufferLZMA((unsigned char const*)eventView.eventData(), eventView.eventLength())) {
+        dest_size = uncompressBufferLZMA(const_cast<unsigned char*>((unsigned char const*)eventView.eventData()),
+                                         eventView.eventLength(),
+                                         dest_,
+                                         origsize);
+      } else if (isBufferZSTD((unsigned char const*)eventView.eventData(), eventView.eventLength())) {
+        dest_size = uncompressBufferZSTD(const_cast<unsigned char*>((unsigned char const*)eventView.eventData()),
+                                         eventView.eventLength(),
+                                         dest_,
+                                         origsize);
+      } else
+        dest_size = uncompressBuffer(const_cast<unsigned char*>((unsigned char const*)eventView.eventData()),
+                                     eventView.eventLength(),
+                                     dest_,
+                                     origsize);
     } else {  // not compressed
       // we need to copy anyway the buffer as we are using dest in xbuf
       dest_size = eventView.eventLength();
@@ -360,6 +373,85 @@ namespace edm {
       throw cms::Exception("StreamDeserialization", "Uncompression error") << "Error code = " << ret << "\n ";
     }
     return (unsigned int)uncompressedSize;
+  }
+
+  bool StreamerInputSource::isBufferLZMA(unsigned char const* inputBuffer, unsigned int inputSize) {
+    if (inputSize >= 4 && !strcmp((const char*)inputBuffer, "XZ"))
+      return true;
+    else
+      return false;
+  }
+
+  unsigned int StreamerInputSource::uncompressBufferLZMA(unsigned char* inputBuffer,
+                                                         unsigned int inputSize,
+                                                         std::vector<unsigned char>& outputBuffer,
+                                                         unsigned int expectedFullSize,
+                                                         bool hasHeader) {
+    unsigned long origSize = expectedFullSize;
+    unsigned long uncompressedSize = expectedFullSize * 1.1;
+    FDEBUG(1) << "Uncompress: original size = " << origSize << ", compressed size = " << inputSize << std::endl;
+    outputBuffer.resize(uncompressedSize);
+
+    lzma_stream stream = LZMA_STREAM_INIT;
+    lzma_ret returnStatus;
+
+    returnStatus = lzma_stream_decoder(&stream, UINT64_MAX, 0U);
+    if (returnStatus != LZMA_OK) {
+      throw cms::Exception("StreamDeserializationLZM", "LZMA stream decoder error")
+          << "Error code = " << returnStatus << "\n ";
+    }
+
+    size_t hdrSize = hasHeader ? 4 : 0;
+    stream.next_in = (const uint8_t*)(inputBuffer + hdrSize);
+    stream.avail_in = (size_t)(inputSize - hdrSize);
+    stream.next_out = (uint8_t*)&outputBuffer[0];
+    stream.avail_out = (size_t)uncompressedSize;
+
+    returnStatus = lzma_code(&stream, LZMA_FINISH);
+    if (returnStatus != LZMA_STREAM_END) {
+      lzma_end(&stream);
+      throw cms::Exception("StreamDeserializationLZM", "LZMA uncompression error")
+          << "Error code = " << returnStatus << "\n ";
+    }
+    lzma_end(&stream);
+
+    uncompressedSize = (unsigned int)stream.total_out;
+
+    FDEBUG(10) << " original size = " << origSize << " final size = " << uncompressedSize << std::endl;
+    if (origSize != uncompressedSize) {
+      // we throw an error and return without event! null pointer
+      throw cms::Exception("StreamDeserialization", "LZMA uncompression error")
+          << "mismatch event lengths should be" << origSize << " got " << uncompressedSize << "\n";
+    }
+
+    return uncompressedSize;
+  }
+
+  bool StreamerInputSource::isBufferZSTD(unsigned char const* inputBuffer, unsigned int inputSize) {
+    if (inputSize >= 4 && !strcmp((const char*)inputBuffer, "ZS"))
+      return true;
+    else
+      return false;
+  }
+
+  unsigned int StreamerInputSource::uncompressBufferZSTD(unsigned char* inputBuffer,
+                                                         unsigned int inputSize,
+                                                         std::vector<unsigned char>& outputBuffer,
+                                                         unsigned int expectedFullSize,
+                                                         bool hasHeader) {
+    unsigned long uncompressedSize = expectedFullSize * 1.1;
+    FDEBUG(1) << "Uncompress: original size = " << expectedFullSize << ", compressed size = " << inputSize << std::endl;
+    outputBuffer.resize(uncompressedSize);
+
+    size_t hdrSize = hasHeader ? 4 : 0;
+    size_t ret = ZSTD_decompress(
+        (void*)&(outputBuffer[0]), uncompressedSize, (const void*)(inputBuffer + hdrSize), inputSize - hdrSize);
+
+    if (ZSTD_isError(ret)) {
+      throw cms::Exception("StreamDeserializationZSTD", "ZSTD uncompression error")
+          << "Error core " << ret << ", message:" << ZSTD_getErrorName(ret);
+    }
+    return (unsigned int)ret;
   }
 
   void StreamerInputSource::resetAfterEndRun() {

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -24,14 +24,15 @@ namespace edm {
   void StreamerOutputModuleBase::beginRun(RunForOutput const&) {
     start();
 
-    std::unique_ptr<InitMsgBuilder> init_message = serializeRegistry(*branchIDLists(),
+    std::unique_ptr<InitMsgBuilder> init_message = serializeRegistry(*getSerializerBuffer(),
+                                                                     *branchIDLists(),
                                                                      *thinnedAssociationsHelper(),
                                                                      OutputModule::processName(),
                                                                      description().moduleLabel(),
                                                                      moduleDescription().mainParameterSetID());
 
     doOutputHeader(*init_message);
-    clearSerializeDataBuffer();
+    serializerBuffer_->clearHeaderBuffer();
   }
 
   void StreamerOutputModuleBase::endRun(RunForOutput const&) { stop(); }
@@ -46,7 +47,8 @@ namespace edm {
 
   void StreamerOutputModuleBase::write(EventForOutput const& e) {
     Handle<TriggerResults> const& triggerResults = getTriggerResults(trToken_, e);
-    std::unique_ptr<EventMsgBuilder> msg = serializeEvent(e, triggerResults, selectorConfig());
+
+    std::unique_ptr<EventMsgBuilder> msg = serializeEvent(*getSerializerBuffer(), e, triggerResults, selectorConfig());
     doOutputEvent(*msg);  // You can't use msg in StreamerOutputModuleBase after this point
   }
 

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -196,7 +196,6 @@ namespace edm {
       EventForOutput const& e,
       Handle<TriggerResults> const& triggerResults,
       ParameterSetID const& selectorCfg) {
-
     constexpr unsigned int reserve_size = SerializeDataBuffer::reserve_size;
     //Lets Build the Event Message first
 

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -27,17 +27,17 @@ namespace edm {
       :
 
         serializer_(selections),
-        maxEventSize_(ps.getUntrackedParameter<int>("max_event_size")),
         useCompression_(ps.getUntrackedParameter<bool>("use_compression")),
+        compressionAlgoStr_(ps.getUntrackedParameter<std::string>("compression_algorithm")),
         compressionLevel_(ps.getUntrackedParameter<int>("compression_level")),
         lumiSectionInterval_(ps.getUntrackedParameter<int>("lumiSection_interval")),
-        serializeDataBuffer_(),
         hltsize_(0),
-        origSize_(0),
         host_name_(),
         hltTriggerSelections_(),
         outputModuleId_(0) {
-    // no compression as default value - we need this!
+    //limits initially set for default ZLIB option
+    int minCompressionLevel = 1;
+    int maxCompressionLevel = 9;
 
     // test luminosity sections
     struct timeval now;
@@ -46,16 +46,36 @@ namespace edm {
     timeInSecSinceUTC = static_cast<double>(now.tv_sec) + (static_cast<double>(now.tv_usec) / 1000000.0);
 
     if (useCompression_ == true) {
-      if (compressionLevel_ <= 0) {
+      if (compressionAlgoStr_ == "ZLIB") {
+        compressionAlgo_ = ZLIB;
+      } else if (compressionAlgoStr_ == "LZMA") {
+        compressionAlgo_ = LZMA;
+        minCompressionLevel = 0;
+      } else if (compressionAlgoStr_ == "ZSTD") {
+        compressionAlgo_ = ZSTD;
+        maxCompressionLevel = 20;
+      } else if (compressionAlgoStr_ == "UNCOMPRESSED") {
+        compressionLevel_ = 0;
+        useCompression_ = false;
+        compressionAlgo_ = UNCOMPRESSED;
+      } else
+        throw cms::Exception("StreamerOutputModuleCommon", "Compression type unknown")
+            << "Unknown compression algorithm " << compressionAlgoStr_;
+
+      if (compressionLevel_ < minCompressionLevel) {
         FDEBUG(9) << "Compression Level = " << compressionLevel_ << " no compression" << std::endl;
         compressionLevel_ = 0;
         useCompression_ = false;
-      } else if (compressionLevel_ > 9) {
-        FDEBUG(9) << "Compression Level = " << compressionLevel_ << " using max compression level 9" << std::endl;
-        compressionLevel_ = 9;
+        compressionAlgo_ = UNCOMPRESSED;
+      } else if (compressionLevel_ > maxCompressionLevel) {
+        FDEBUG(9) << "Compression Level = " << compressionLevel_ << " using max compression level "
+                  << maxCompressionLevel << std::endl;
+        compressionLevel_ = maxCompressionLevel;
+        compressionAlgo_ = UNCOMPRESSED;
       }
-    }
-    serializeDataBuffer_.bufs_.resize(maxEventSize_);
+    } else
+      compressionAlgo_ = UNCOMPRESSED;
+
     int got_host = gethostname(host_name_, 255);
     if (got_host != 0)
       strncpy(host_name_, "noHostNameFoundOrTooLong", sizeof(host_name_));
@@ -68,19 +88,20 @@ namespace edm {
 
   StreamerOutputModuleCommon::~StreamerOutputModuleCommon() {}
 
-  std::unique_ptr<InitMsgBuilder> StreamerOutputModuleCommon::serializeRegistry(const BranchIDLists& branchLists,
+  std::unique_ptr<InitMsgBuilder> StreamerOutputModuleCommon::serializeRegistry(SerializeDataBuffer& sbuf,
+                                                                                const BranchIDLists& branchLists,
                                                                                 ThinnedAssociationsHelper const& helper,
                                                                                 std::string const& processName,
                                                                                 std::string const& moduleLabel,
                                                                                 ParameterSetID const& toplevel) {
-    serializer_.serializeRegistry(serializeDataBuffer_, branchLists, helper);
+    serializer_.serializeRegistry(sbuf, branchLists, helper);
 
-    // resize bufs_ to reflect space used in serializer_ + header
+    // resize header_buf_ to reflect space used in serializer_ + header
     // I just added an overhead for header of 50000 for now
-    unsigned int src_size = serializeDataBuffer_.currentSpaceUsed();
+    unsigned int src_size = sbuf.currentSpaceUsed();
     unsigned int new_size = src_size + 50000;
-    if (serializeDataBuffer_.header_buf_.size() < new_size)
-      serializeDataBuffer_.header_buf_.resize(new_size);
+    if (sbuf.header_buf_.size() < new_size)
+      sbuf.header_buf_.resize(new_size);
 
     //Build the INIT Message
     //Following values are strictly DUMMY and will be replaced
@@ -109,8 +130,8 @@ namespace edm {
     crc = crc32(crc, buf, moduleLabel.length());
     outputModuleId_ = static_cast<uint32>(crc);
 
-    auto init_message = std::make_unique<InitMsgBuilder>(&serializeDataBuffer_.header_buf_[0],
-                                                         serializeDataBuffer_.header_buf_.size(),
+    auto init_message = std::make_unique<InitMsgBuilder>(&sbuf.header_buf_[0],
+                                                         sbuf.header_buf_.size(),
                                                          run,
                                                          Version((uint8 const*)toplevel.compactForm().c_str()),
                                                          getReleaseVersion().c_str(),
@@ -120,10 +141,10 @@ namespace edm {
                                                          hltTriggerNames,
                                                          hltTriggerSelections_,
                                                          l1_names,
-                                                         (uint32)serializeDataBuffer_.adler32_chksum());
+                                                         (uint32)sbuf.adler32_chksum());
 
     // copy data into the destination message
-    unsigned char* src = serializeDataBuffer_.bufferPointer();
+    unsigned char* src = sbuf.bufferPointer();
     std::copy(src, src + src_size, init_message->dataAddress());
     init_message->setDataLength(src_size);
     return init_message;
@@ -171,7 +192,10 @@ namespace edm {
   }
 
   std::unique_ptr<EventMsgBuilder> StreamerOutputModuleCommon::serializeEvent(
-      EventForOutput const& e, Handle<TriggerResults> const& triggerResults, ParameterSetID const& selectorCfg) {
+      SerializeDataBuffer& sbuf,
+      EventForOutput const& e,
+      Handle<TriggerResults> const& triggerResults,
+      ParameterSetID const& selectorCfg) {
     //Lets Build the Event Message first
 
     //Following is strictly DUMMY Data for L! Trig and will be replaced with actual
@@ -196,17 +220,14 @@ namespace edm {
         lumi = static_cast<uint32>(timeInSec / lumiSectionInterval_) + 1;
     }
 
-    serializer_.serializeEvent(e, selectorCfg, useCompression_, compressionLevel_, serializeDataBuffer_);
+    serializer_.serializeEvent(sbuf, e, selectorCfg, compressionAlgo_, compressionLevel_, reserve_size);
 
-    // resize bufs_ to reflect space used in serializer_ + header
-    // I just added an overhead for header of 50000 for now
-    unsigned int src_size = serializeDataBuffer_.currentSpaceUsed();
-    unsigned int new_size = src_size + 50000;
-    if (serializeDataBuffer_.bufs_.size() < new_size)
-      serializeDataBuffer_.bufs_.resize(new_size);
+    // resize header_buf_ to reserved size on first written event
+    if (sbuf.header_buf_.size() < reserve_size)
+      sbuf.header_buf_.resize(reserve_size);
 
-    auto msg = std::make_unique<EventMsgBuilder>(&serializeDataBuffer_.bufs_[0],
-                                                 serializeDataBuffer_.bufs_.size(),
+    auto msg = std::make_unique<EventMsgBuilder>(&sbuf.header_buf_[0],
+                                                 sbuf.comp_buf_.size(),
                                                  e.id().run(),
                                                  e.id().event(),
                                                  lumi,
@@ -215,37 +236,50 @@ namespace edm {
                                                  l1bit,
                                                  (uint8*)&hltbits[0],
                                                  hltsize_,
-                                                 (uint32)serializeDataBuffer_.adler32_chksum(),
+                                                 (uint32)sbuf.adler32_chksum(),
                                                  host_name_);
-    msg->setOrigDataSize(origSize_);  // we need this set to zero
 
-    // copy data into the destination message
-    // an alternative is to have serializer only to the serialization
-    // in serializeEvent, and then call a new member "getEventData" that
-    // takes the compression arguments and a place to put the data.
-    // This will require one less copy.  The only catch is that the
-    // space provided in bufs_ should be at least the uncompressed
-    // size + overhead for header because we will not know the actual
-    // compressed size.
+    // 50000 bytes is reserved for header as has been the case with previous version which did one extra copy of event data
+    uint32 headerSize = msg->headerSize();
+    if (headerSize > reserve_size)
+      throw cms::Exception("StreamerOutputModuleCommon", "Header Overflow")
+          << " header of size " << headerSize << "bytes is too big to fit into the reserved buffer space";
 
-    unsigned char* src = serializeDataBuffer_.bufferPointer();
-    std::copy(src, src + src_size, msg->eventAddr());
-    msg->setEventLength(src_size);
+    //set addresses to other buffer and copy constructed header there
+    msg->setBufAddr(&sbuf.comp_buf_[reserve_size - headerSize]);
+    msg->setEventAddr(sbuf.bufferPointer());
+    std::copy(&sbuf.header_buf_[0], &sbuf.header_buf_[headerSize], (char*)(&sbuf.comp_buf_[reserve_size - headerSize]));
+
+    unsigned int src_size = sbuf.currentSpaceUsed();
+    msg->setEventLength(src_size);  //compressed size
     if (useCompression_)
-      msg->setOrigDataSize(serializeDataBuffer_.currentEventSize());
+      msg->setOrigDataSize(
+          sbuf.currentEventSize());  //uncompressed size (or 0 if no compression -> streamer input source requires this)
+    else
+      msg->setOrigDataSize(0);
 
     return msg;
   }
 
   void StreamerOutputModuleCommon::fillDescription(ParameterSetDescription& desc) {
-    desc.addUntracked<int>("max_event_size", 7000000)
-        ->setComment("Starting size in bytes of the serialized event buffer.");
+    desc.addUntracked<int>("max_event_size", 7000000)->setComment("Obsolete parameter.");
     desc.addUntracked<bool>("use_compression", true)
         ->setComment("If True, compression will be used to write streamer file.");
-    desc.addUntracked<int>("compression_level", 1)->setComment("ROOT compression level to use.");
+    desc.addUntracked<std::string>("compression_algorithm", "ZLIB")
+        ->setComment("Compression algorithm to use: UNCOMPRESSED, ZLIB, LZMA or ZSTD");
+    desc.addUntracked<int>("compression_level", 1)->setComment("Compression level to use on serialized ROOT events");
     desc.addUntracked<int>("lumiSection_interval", 0)
         ->setComment(
             "If 0, use lumi section number from event.\n"
             "If not 0, the interval in seconds between fake lumi sections.");
+  }
+
+  SerializeDataBuffer* StreamerOutputModuleCommon::getSerializerBuffer() {
+    auto* ptr = serializerBuffer_.get();
+    if (!ptr) {
+      serializerBuffer_.reset(new SerializeDataBuffer);
+      ptr = serializerBuffer_.get();
+    }
+    return ptr;
   }
 }  // namespace edm

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -196,6 +196,8 @@ namespace edm {
       EventForOutput const& e,
       Handle<TriggerResults> const& triggerResults,
       ParameterSetID const& selectorCfg) {
+
+    constexpr unsigned int reserve_size = SerializeDataBuffer::reserve_size;
     //Lets Build the Event Message first
 
     //Following is strictly DUMMY Data for L! Trig and will be replaced with actual

--- a/IOPool/Streamer/test/BuildFile.xml
+++ b/IOPool/Streamer/test/BuildFile.xml
@@ -10,8 +10,17 @@
   <bin   file="WriteStreamerFile.cpp">
     <use   name="IOPool/Streamer"/>
   </bin>
-  <bin   file="RunThis_t.cpp">
-    <flags   TEST_RUNNER_ARGS=" /bin/bash IOPool/Streamer/test RunSimple_NewStreamer.sh"/>
+  <bin   file="RunThis_t.cpp" name="NewStreamerUNCOMPRESSED">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash IOPool/Streamer/test RunUNCOMPRESSED.sh"/>
+  </bin>
+  <bin   file="RunThis_t.cpp" name="NewStreamerZLIB">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash IOPool/Streamer/test RunZLIB.sh"/>
+  </bin>
+  <bin   file="RunThis_t.cpp" name="NewStreamerLZMA">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash IOPool/Streamer/test RunLZMA.sh"/>
+  </bin>
+  <bin   file="RunThis_t.cpp" name="NewStreamerZSTD">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash IOPool/Streamer/test RunZSTD.sh"/>
   </bin>
   <library   file="StreamThingProducer.cc" name="StreamThingProducer">
     <flags   EDM_PLUGIN="1"/>

--- a/IOPool/Streamer/test/NewStreamOut_cfg.py
+++ b/IOPool/Streamer/test/NewStreamOut_cfg.py
@@ -1,4 +1,16 @@
 import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing('analysis')
+
+options.register ('compAlgo',
+                  'ZLIB', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "Compression Algorithm")
+
+options.parseArguments()
+
 
 process = cms.Process("HLT")
 
@@ -30,6 +42,7 @@ process.out = cms.OutputModule("EventStreamFileWriter",
     fileName = cms.untracked.string('teststreamfile.dat'),
     compression_level = cms.untracked.int32(1),
     use_compression = cms.untracked.bool(True),
+    compression_algorithm = cms.untracked.string(options.compAlgo),
     max_event_size = cms.untracked.int32(7000000)
 )
 

--- a/IOPool/Streamer/test/RunLZMA.sh
+++ b/IOPool/Streamer/test/RunLZMA.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export TEST_COMPRESSION_ALGO="LZMA" 
+exec ${SCRIPTDIR}/RunSimple_NewStreamer.sh

--- a/IOPool/Streamer/test/RunSimple_NewStreamer.sh
+++ b/IOPool/Streamer/test/RunSimple_NewStreamer.sh
@@ -2,8 +2,20 @@
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
+if [ -z  $LOCAL_TEST_DIR ]; then
+LOCAL_TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+fi
 echo "LOCAL_TEST_DIR = $LOCAL_TEST_DIR"
+
+if [ -z  $LOCAL_TMP_DIR ]; then
+LOCAL_TMP_DIR="/tmp"
+fi
 echo "LOCAL_TMP_DIR = $LOCAL_TMP_DIR"
+
+if [ -z  $TEST_COMPRESSION_ALGO ]; then
+TEST_COMPRESSION_ALGO="ZLIB"
+fi
+echo "TEST_COMPRESSION_ALGO = $TEST_COMPRESSION_ALGO"
 
 cd $LOCAL_TEST_DIR
 
@@ -16,7 +28,8 @@ mkdir ${OUTDIR}
 cp *_cfg.py ${OUTDIR}
 cd ${OUTDIR}
 
-cmsRun --parameter-set NewStreamOut_cfg.py > out 2>&1 || die "cmsRun NewStreamOut_cfg.py" $?
+#cmsRun --parameter-set NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > out 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > out 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun --parameter-set NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
 cmsRun --parameter-set NewStreamIn2_cfg.py  > in2  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?
 cmsRun --parameter-set NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?

--- a/IOPool/Streamer/test/RunSimple_NewStreamer.sh
+++ b/IOPool/Streamer/test/RunSimple_NewStreamer.sh
@@ -28,7 +28,6 @@ mkdir ${OUTDIR}
 cp *_cfg.py ${OUTDIR}
 cd ${OUTDIR}
 
-#cmsRun --parameter-set NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > out 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > out 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun --parameter-set NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
 cmsRun --parameter-set NewStreamIn2_cfg.py  > in2  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?

--- a/IOPool/Streamer/test/RunUNCOMPRESSED.sh
+++ b/IOPool/Streamer/test/RunUNCOMPRESSED.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export TEST_COMPRESSION_ALGO="UNCOMPRESSED" 
+exec ${SCRIPTDIR}/RunSimple_NewStreamer.sh

--- a/IOPool/Streamer/test/RunZLIB.sh
+++ b/IOPool/Streamer/test/RunZLIB.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export TEST_COMPRESSION_ALGO="ZLIB" 
+exec ${SCRIPTDIR}/RunSimple_NewStreamer.sh

--- a/IOPool/Streamer/test/RunZSTD.sh
+++ b/IOPool/Streamer/test/RunZSTD.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export TEST_COMPRESSION_ALGO="ZSTD" 
+exec ${SCRIPTDIR}/RunSimple_NewStreamer.sh

--- a/IOPool/Streamer/test/StreamThingAnalyzer.h
+++ b/IOPool/Streamer/test/StreamThingAnalyzer.h
@@ -22,9 +22,9 @@ namespace edmtest_thing {
   public:
     explicit StreamThingAnalyzer(edm::ParameterSet const&);
 
-    virtual ~StreamThingAnalyzer();
+    ~StreamThingAnalyzer() override;
 
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
+    void analyze(edm::Event const& e, edm::EventSetup const& c) override;
 
   private:
     std::string name_;

--- a/IOPool/Streamer/test/StreamThingProducer.h
+++ b/IOPool/Streamer/test/StreamThingProducer.h
@@ -19,9 +19,9 @@ namespace edmtest_thing {
   public:
     explicit StreamThingProducer(edm::ParameterSet const& ps);
 
-    virtual ~StreamThingProducer();
+    ~StreamThingProducer() override;
 
-    virtual void produce(edm::Event& e, edm::EventSetup const& c);
+    void produce(edm::Event& e, edm::EventSetup const& c) override;
 
   private:
     int size_;


### PR DESCRIPTION
#### PR description:
PR adds new compression formats and also optimizes buffer usage in Streamer event writing.

Output buffering changes:
- Output buffering changed to reduce extra copy of the payload. Instead, small header is copied to the front of the payload after compression. Initial default of 7 MB is not needed and can be sized dynamically (usually to much less). New initial size is 50 kb to reserve for event header.

- Reduced ROOT TBuffer (TBufferFile object) size after serialization of the INI file, which, due to typically large INI payloads in HLT, results in significant reduction in memory usage of the process during event processing.

- In testing with the realistic 2018 HLT payload and data with the 4-thread HLT (pp Physics) CMSSW job, these two changes reduced total memory footprint from 2.7 GB to 2 GB (per process).

Compression changes:
- LZMA compression algorithm added. To facilitate automatic detection in reader, a
4-byte header is present at the beginning of LZMA content (this does not
conflict with zlib header which starts with a different sequence). Compression
/decompression functions are based on ROOT implementation, but we turn off
calculation of CRC32/64 checksum (adler32 is already used to checksum whole payload). Error handling is also improved and 16 MB buffer size limitation in ROOT routine is removed.

- Zstandard compression is added. Compression factor is comparable to zlib, but is performing faster at lower compression levels making it potentially interesting for HLT in situations where CPU usage is tight. Similar 4-byte header ("ZS") is added to the payload.

- "compression_algorithm" parameter was added to the output module allowing to choose between algorithms.

- Decompression for both new algorithms with format autodetection is added to the StreamerInputSource.

- several "scram b code-checks-all" changes to Streamer and Utililities modules has also been included with the PR.

#### PR validation:

Buffering and compression changes have been verified to produce correct files by producing output files  with different algorithms (DAQ and Streamer output module) and reading them with Streamer input source to verify integrity.