### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/CommonTools/RecoAlgos/interface/ClusterStorer.h
+++ b/CommonTools/RecoAlgos/interface/ClusterStorer.h
@@ -26,53 +26,53 @@ namespace helper {
 
   class ClusterStorer {
   public:
-    ClusterStorer () {}
+    ClusterStorer() {}
     /// add cluster of newHit to list (throws if hit is of unknown type)
     void addCluster(TrackingRecHitCollection &hits, size_t index);
     /// clear records
     void clear();
     //------------------------------------------------------------------
-    //!  Processes all the clusters of the tracks 
+    //!  Processes all the clusters of the tracks
     //!  (after the tracks have been dealt with),
     //!  need Refs to products (i.e. full collections) in the event.
     //------------------------------------------------------------------
-    void processAllClusters(edmNew::DetSetVector<SiPixelCluster> &pixelDsvToFill,		    
-			    edm::RefProd<edmNew::DetSetVector<SiPixelCluster> > refPixelClusters,
-			    edmNew::DetSetVector<SiStripCluster> &stripDsvToFill,
-			    edm::RefProd<edmNew::DetSetVector<SiStripCluster> > refStripClusters);
-   
-    private:
+    void processAllClusters(edmNew::DetSetVector<SiPixelCluster> &pixelDsvToFill,
+                            edm::RefProd<edmNew::DetSetVector<SiPixelCluster> > refPixelClusters,
+                            edmNew::DetSetVector<SiStripCluster> &stripDsvToFill,
+                            edm::RefProd<edmNew::DetSetVector<SiStripCluster> > refStripClusters);
+
+  private:
     /// A struct for clusters associated to hits
-    template<typename ClusterRefType>
+    template <typename ClusterRefType>
     class ClusterHitRecord {
     public:
       /// Create a record for a hit with a given index in the TrackingRecHitCollection.
       /// 'RecHitType' must have a method 'cluster()' that returns a 'ClusterRefType'.
-      template<typename RecHitType>
+      template <typename RecHitType>
       ClusterHitRecord(const RecHitType &hit, TrackingRecHitCollection &hits, size_t idx)
-        : detid_(hit.geographicalId().rawId()), hits_(&hits), index_(idx), ref_(hit.cluster()) {}
+          : detid_(hit.geographicalId().rawId()), hits_(&hits), index_(idx), ref_(hit.cluster()) {}
       /// returns the detid
       uint32_t detid() const { return detid_; }
       /// this method is to be able to compare and see if two refs are the same
-      const ClusterRefType & clusterRef() const { return ref_; }
+      const ClusterRefType &clusterRef() const { return ref_; }
       /// this one is to sort by detid and then by index of the rechit
-      bool operator<(const ClusterHitRecord<ClusterRefType> &other) const
-      {
-        return (detid_ != other.detid_) ? detid_ < other.detid_ : ref_  < other.ref_;
+      bool operator<(const ClusterHitRecord<ClusterRefType> &other) const {
+        return (detid_ != other.detid_) ? detid_ < other.detid_ : ref_ < other.ref_;
       }
       /// Set the reference of the hit of this record to 'newRef',
       /// will not modify the ref stored in this object.
       template <typename RecHitType>
       void rekey(const ClusterRefType &newRef) const;
+
     private:
-      ClusterHitRecord() {}/// private => unusable
+      ClusterHitRecord() {}  /// private => unusable
       uint32_t detid_;
       TrackingRecHitCollection *hits_;
-      size_t   index_;
+      size_t index_;
       ClusterRefType ref_;
     };
-    
-    typedef ClusterHitRecord<SiPixelRecHit::ClusterRef>   PixelClusterHitRecord;
+
+    typedef ClusterHitRecord<SiPixelRecHit::ClusterRef> PixelClusterHitRecord;
     /// Assuming that the ClusterRef is the same for all SiStripRecHit*:
     typedef ClusterHitRecord<SiStripRecHit2D::ClusterRef> StripClusterHitRecord;
     //FIXME:: this is just temporary solution for phase2,
@@ -83,18 +83,17 @@ namespace helper {
     //!  Processes all the clusters of a specific type
     //!  (after the tracks have been dealt with)
     //------------------------------------------------------------------
-    template<typename HitType, typename ClusterType>
-      void
-      processClusters(std::vector<ClusterHitRecord<typename HitType::ClusterRef> > &clusterRecords,
-		      edmNew::DetSetVector<ClusterType>                            &dsvToFill,
-		      edm::RefProd< edmNew::DetSetVector<ClusterType> >            &refprod);
+    template <typename HitType, typename ClusterType>
+    void processClusters(std::vector<ClusterHitRecord<typename HitType::ClusterRef> > &clusterRecords,
+                         edmNew::DetSetVector<ClusterType> &dsvToFill,
+                         edm::RefProd<edmNew::DetSetVector<ClusterType> > &refprod);
 
     //--- Information about the cloned clusters
-    std::vector<PixelClusterHitRecord>                  pixelClusterRecords_;
-    std::vector<StripClusterHitRecord>                  stripClusterRecords_;
-    std::vector<Phase2OTClusterHitRecord>               phase2OTClusterRecords_;
+    std::vector<PixelClusterHitRecord> pixelClusterRecords_;
+    std::vector<StripClusterHitRecord> stripClusterRecords_;
+    std::vector<Phase2OTClusterHitRecord> phase2OTClusterRecords_;
   };
 
-}
+}  // namespace helper
 
 #endif

--- a/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
+++ b/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
@@ -37,177 +37,188 @@
 class TrajectoryStateClosestToBeamLineBuilder;
 
 class CosmicTrackingParticleSelector {
-
 public:
   typedef TrackingParticleCollection collection;
-  typedef std::vector<const TrackingParticle *> container;
+  typedef std::vector<const TrackingParticle*> container;
   typedef container::const_iterator const_iterator;
 
-  CosmicTrackingParticleSelector(){}
+  CosmicTrackingParticleSelector() {}
 
-  CosmicTrackingParticleSelector ( double ptMin,double minRapidity,double maxRapidity,
-				   double tip,double lip,int minHit, bool chargedOnly,
-				   const std::vector<int>& pdgId = std::vector<int>()) :
-    ptMin_( ptMin ), minRapidity_( minRapidity ), maxRapidity_( maxRapidity ),
-    tip_( tip ), lip_( lip ), minHit_( minHit ), chargedOnly_(chargedOnly), pdgId_( pdgId ) { }
+  CosmicTrackingParticleSelector(double ptMin,
+                                 double minRapidity,
+                                 double maxRapidity,
+                                 double tip,
+                                 double lip,
+                                 int minHit,
+                                 bool chargedOnly,
+                                 const std::vector<int>& pdgId = std::vector<int>())
+      : ptMin_(ptMin),
+        minRapidity_(minRapidity),
+        maxRapidity_(maxRapidity),
+        tip_(tip),
+        lip_(lip),
+        minHit_(minHit),
+        chargedOnly_(chargedOnly),
+        pdgId_(pdgId) {}
 
+  CosmicTrackingParticleSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : ptMin_(cfg.getParameter<double>("ptMin")),
+        minRapidity_(cfg.getParameter<double>("minRapidity")),
+        maxRapidity_(cfg.getParameter<double>("maxRapidity")),
+        tip_(cfg.getParameter<double>("tip")),
+        lip_(cfg.getParameter<double>("lip")),
+        minHit_(cfg.getParameter<int>("minHit")),
+        chargedOnly_(cfg.getParameter<bool>("chargedOnly")),
+        pdgId_(cfg.getParameter<std::vector<int> >("pdgId")),
+        beamSpotToken_(iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))) {}
 
-    CosmicTrackingParticleSelector  ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-      ptMin_(cfg.getParameter<double>("ptMin")),
-      minRapidity_(cfg.getParameter<double>("minRapidity")),
-      maxRapidity_(cfg.getParameter<double>("maxRapidity")),
-      tip_(cfg.getParameter<double>("tip")),
-      lip_(cfg.getParameter<double>("lip")),
-      minHit_(cfg.getParameter<int>("minHit")),
-      chargedOnly_(cfg.getParameter<bool>("chargedOnly")),
-      pdgId_(cfg.getParameter<std::vector<int> >("pdgId")),
-      beamSpotToken_(iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))) { }
-
-
-      void select( const edm::Handle<collection>& c, const edm::Event & event, const edm::EventSetup& setup) {
-	selected_.clear();
-	edm::Handle<reco::BeamSpot> beamSpot;
-	event.getByToken(beamSpotToken_, beamSpot);
-	for( TrackingParticleCollection::const_iterator itp = c->begin();
-	     itp != c->end(); ++ itp )
-	  if ( operator()(TrackingParticleRef(c,itp-c->begin()),beamSpot.product(),event,setup) ) {
-	    selected_.push_back( & * itp );
-	  }
+  void select(const edm::Handle<collection>& c, const edm::Event& event, const edm::EventSetup& setup) {
+    selected_.clear();
+    edm::Handle<reco::BeamSpot> beamSpot;
+    event.getByToken(beamSpotToken_, beamSpot);
+    for (TrackingParticleCollection::const_iterator itp = c->begin(); itp != c->end(); ++itp)
+      if (operator()(TrackingParticleRef(c, itp - c->begin()), beamSpot.product(), event, setup)) {
+        selected_.push_back(&*itp);
       }
+  }
 
-    const_iterator begin() const { return selected_.begin(); }
-    const_iterator end() const { return selected_.end(); }
+  const_iterator begin() const { return selected_.begin(); }
+  const_iterator end() const { return selected_.end(); }
 
-    void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet) const {
-      simHitsTPAssoc = simHitsTPAssocToSet;
+  void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet) const {
+    simHitsTPAssoc = simHitsTPAssocToSet;
+  }
+
+  // Operator() performs the selection: e.g. if (tPSelector(tp, bs, event, evtsetup)) {...
+  bool operator()(const TrackingParticleRef tpr,
+                  const reco::BeamSpot* bs,
+                  const edm::Event& iEvent,
+                  const edm::EventSetup& iSetup) const {
+    if (chargedOnly_ && tpr->charge() == 0)
+      return false;  //select only if charge!=0
+    //bool testId = false;
+    //unsigned int idSize = pdgId_.size();
+    //if (idSize==0) testId = true;
+    //else for (unsigned int it=0;it!=idSize;++it){
+    //if (tpr->pdgId()==pdgId_[it]) testId = true;
+    //}
+
+    edm::ESHandle<TrackerGeometry> tracker;
+    iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+    edm::ESHandle<GlobalTrackingGeometry> theGeometry;
+    iSetup.get<GlobalTrackingGeometryRecord>().get(theGeometry);
+
+    edm::ESHandle<MagneticField> theMF;
+    iSetup.get<IdealMagneticFieldRecord>().get(theMF);
+
+    GlobalVector finalGV(0, 0, 0);
+    GlobalPoint finalGP(0, 0, 0);
+    GlobalVector momentum(0, 0, 0);  //At the PCA
+    GlobalPoint vertex(0, 0, 0);     //At the PCA
+    double radius(9999);
+    bool found(false);
+
+    int ii = 0;
+    DetId::Detector det;
+    int subdet;
+
+    edm::LogVerbatim("CosmicTrackingParticleSelector")
+        << "TOT Number of PSimHits = " << tpr->numberOfHits()
+        << ", Number of Tracker PSimHits = " << tpr->numberOfTrackerHits() << "\n";
+
+    if (simHitsTPAssoc.isValid() == 0) {
+      edm::LogError("CosmicTrackingParticleSelector") << "Invalid handle!";
+      return false;
     }
-
-    // Operator() performs the selection: e.g. if (tPSelector(tp, bs, event, evtsetup)) {...
-    bool operator()( const TrackingParticleRef tpr, const reco::BeamSpot* bs, const edm::Event &iEvent, const edm::EventSetup& iSetup ) const {
-      if (chargedOnly_ && tpr->charge()==0) return false;//select only if charge!=0
-      //bool testId = false;
-      //unsigned int idSize = pdgId_.size();
-      //if (idSize==0) testId = true;
-      //else for (unsigned int it=0;it!=idSize;++it){
-	//if (tpr->pdgId()==pdgId_[it]) testId = true;
-      //}
-
-      edm::ESHandle<TrackerGeometry> tracker;
-      iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
-      edm::ESHandle<GlobalTrackingGeometry> theGeometry;
-      iSetup.get<GlobalTrackingGeometryRecord>().get(theGeometry);
-
-      edm::ESHandle<MagneticField> theMF;
-      iSetup.get<IdealMagneticFieldRecord>().get(theMF);
-
-      GlobalVector finalGV (0,0,0);
-      GlobalPoint finalGP(0,0,0);
-      GlobalVector momentum(0,0,0);//At the PCA
-      GlobalPoint vertex(0,0,0);//At the PCA
-      double radius(9999);
-      bool found(false);
-
-      int ii=0;
-      DetId::Detector det;
-      int subdet;
-
-      edm::LogVerbatim("CosmicTrackingParticleSelector")
-	<<"TOT Number of PSimHits = "<< tpr->numberOfHits() << ", Number of Tracker PSimHits = "<< tpr->numberOfTrackerHits() <<"\n";
-
-      if (simHitsTPAssoc.isValid()==0) {
-	edm::LogError("CosmicTrackingParticleSelector") << "Invalid handle!";
-	return false;
+    std::pair<TrackingParticleRef, TrackPSimHitRef> clusterTPpairWithDummyTP(
+        tpr, TrackPSimHitRef());  //SimHit is dummy: for simHitTPAssociationListGreater
+                                  // sorting only the cluster is needed
+    auto range = std::equal_range(simHitsTPAssoc->begin(),
+                                  simHitsTPAssoc->end(),
+                                  clusterTPpairWithDummyTP,
+                                  SimHitTPAssociationProducer::simHitTPAssociationListGreater);
+    for (auto ip = range.first; ip != range.second; ++ip) {
+      TrackPSimHitRef it = ip->second;
+      ++ii;
+      const GeomDet* tmpDet = theGeometry->idToDet(DetId(it->detUnitId()));
+      if (!tmpDet) {
+        edm::LogVerbatim("CosmicTrackingParticleSelector")
+            << "***WARNING:  PSimHit " << ii << ", no GeomDet for: " << it->detUnitId() << ". Skipping it.";
+        continue;
+      } else {
+        det = DetId(it->detUnitId()).det();
+        subdet = DetId(it->detUnitId()).subdetId();
       }
-      std::pair<TrackingParticleRef, TrackPSimHitRef> clusterTPpairWithDummyTP(tpr,TrackPSimHitRef());//SimHit is dummy: for simHitTPAssociationListGreater
-                                                                                                      // sorting only the cluster is needed
-      auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(),
-				    clusterTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
-      for(auto ip = range.first; ip != range.second; ++ip) {
-	TrackPSimHitRef it = ip->second;
-	++ii;
-	const GeomDet* tmpDet  = theGeometry->idToDet( DetId(it->detUnitId()) ) ;
-	if (!tmpDet) {
-	  edm::LogVerbatim("CosmicTrackingParticleSelector")
-	    <<"***WARNING:  PSimHit "<<ii <<", no GeomDet for: "<<it->detUnitId()<<". Skipping it.";
-	  continue;
-	} else {
-	  det = DetId(it->detUnitId()).det();
-	  subdet = DetId(it->detUnitId()).subdetId();
-	}
 
-	LocalVector  lv = it->momentumAtEntry();
-	Local3DPoint lp = it->localPosition ();
-	GlobalVector gv = tmpDet->surface().toGlobal( lv );
-	GlobalPoint  gp = tmpDet->surface().toGlobal( lp );
-	edm::LogVerbatim("CosmicTrackingParticleSelector")
-	  <<"PSimHit "<<ii<<", Detector = "<<det<<", subdet = "<<subdet
-	  <<"\t Radius = "<< gp.perp() << ", z = "<< gp.z() 
-	  <<"\t     pt = "<< gv.perp() << ", pz = "<< gv.z();
-	edm::LogVerbatim("CosmicTrackingParticleSelector")
-	  <<"\t trackId = "<<it->trackId()<<", particleType = "<<it->particleType()<<", processType = "<<it->processType();
-
-	// discard hits related to low energy debris from the primary particle
-	if (it->processType()!=0) continue;
-
-	if(gp.perp()<radius){
-	  found=true;
-	  radius = gp.perp();
-	  finalGV = gv;
-	  finalGP = gp;
-	}
-      }
+      LocalVector lv = it->momentumAtEntry();
+      Local3DPoint lp = it->localPosition();
+      GlobalVector gv = tmpDet->surface().toGlobal(lv);
+      GlobalPoint gp = tmpDet->surface().toGlobal(lp);
       edm::LogVerbatim("CosmicTrackingParticleSelector")
-	<<"\n"<<"FINAL State at InnerMost Hit:        Radius = "<< finalGP.perp() << ", z = "<< finalGP.z() 
-	<<", pt = "<< finalGV.perp() << ", pz = "<< finalGV.z();
+          << "PSimHit " << ii << ", Detector = " << det << ", subdet = " << subdet << "\t Radius = " << gp.perp()
+          << ", z = " << gp.z() << "\t     pt = " << gv.perp() << ", pz = " << gv.z();
+      edm::LogVerbatim("CosmicTrackingParticleSelector")
+          << "\t trackId = " << it->trackId() << ", particleType = " << it->particleType()
+          << ", processType = " << it->processType();
 
-      if(!found) return false;
-      else
-	{
-	  FreeTrajectoryState ftsAtProduction(finalGP,finalGV,TrackCharge(tpr->charge()),theMF.product());
-	  TSCBLBuilderNoMaterial tscblBuilder;
-	  TrajectoryStateClosestToBeamLine tsAtClosestApproach = tscblBuilder(ftsAtProduction,*bs);//as in TrackProducerAlgorithm
-	  if(!tsAtClosestApproach.isValid()){
-	    edm::LogVerbatim("CosmicTrackingParticleSelector")
-	      <<"*** WARNING in CosmicTrackingParticleSelector: tsAtClosestApproach is not valid." <<"\n";
-	    return false;
-	  }
-	  else
-	    {
-	      momentum = tsAtClosestApproach.trackStateAtPCA().momentum();
-	      vertex = tsAtClosestApproach.trackStateAtPCA().position();
+      // discard hits related to low energy debris from the primary particle
+      if (it->processType() != 0)
+        continue;
 
-	      edm::LogVerbatim("CosmicTrackingParticleSelector")
-		<<"FINAL State extrapolated at PCA: Radius = "<< vertex.perp() << ", z = "<< vertex.z() 
-		<<", pt = "<< momentum.perp() << ", pz = "<< momentum.z() <<"\n";
-
-	      return (
-		      tpr->numberOfTrackerLayers() >= minHit_ &&
-		      sqrt(momentum.perp2()) >= ptMin_ &&
-		      momentum.eta() >= minRapidity_ && momentum.eta() <= maxRapidity_ &&
-		      sqrt(vertex.perp2()) <= tip_ &&
-		      fabs(vertex.z()) <= lip_
-		      );
-	    }
-	}
+      if (gp.perp() < radius) {
+        found = true;
+        radius = gp.perp();
+        finalGV = gv;
+        finalGP = gp;
+      }
     }
+    edm::LogVerbatim("CosmicTrackingParticleSelector")
+        << "\n"
+        << "FINAL State at InnerMost Hit:        Radius = " << finalGP.perp() << ", z = " << finalGP.z()
+        << ", pt = " << finalGV.perp() << ", pz = " << finalGV.z();
 
-    size_t size() const { return selected_.size(); }
+    if (!found)
+      return false;
+    else {
+      FreeTrajectoryState ftsAtProduction(finalGP, finalGV, TrackCharge(tpr->charge()), theMF.product());
+      TSCBLBuilderNoMaterial tscblBuilder;
+      TrajectoryStateClosestToBeamLine tsAtClosestApproach =
+          tscblBuilder(ftsAtProduction, *bs);  //as in TrackProducerAlgorithm
+      if (!tsAtClosestApproach.isValid()) {
+        edm::LogVerbatim("CosmicTrackingParticleSelector")
+            << "*** WARNING in CosmicTrackingParticleSelector: tsAtClosestApproach is not valid."
+            << "\n";
+        return false;
+      } else {
+        momentum = tsAtClosestApproach.trackStateAtPCA().momentum();
+        vertex = tsAtClosestApproach.trackStateAtPCA().position();
 
- private:
+        edm::LogVerbatim("CosmicTrackingParticleSelector")
+            << "FINAL State extrapolated at PCA: Radius = " << vertex.perp() << ", z = " << vertex.z()
+            << ", pt = " << momentum.perp() << ", pz = " << momentum.z() << "\n";
 
-    double ptMin_;
-    double minRapidity_;
-    double maxRapidity_;
-    double tip_;
-    double lip_;
-    int    minHit_;
-    bool chargedOnly_;
-      std::vector<int> pdgId_;
-      container selected_;
-    edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+        return (tpr->numberOfTrackerLayers() >= minHit_ && sqrt(momentum.perp2()) >= ptMin_ &&
+                momentum.eta() >= minRapidity_ && momentum.eta() <= maxRapidity_ && sqrt(vertex.perp2()) <= tip_ &&
+                fabs(vertex.z()) <= lip_);
+      }
+    }
+  }
 
-    mutable edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
+  size_t size() const { return selected_.size(); }
 
+private:
+  double ptMin_;
+  double minRapidity_;
+  double maxRapidity_;
+  double tip_;
+  double lip_;
+  int minHit_;
+  bool chargedOnly_;
+  std::vector<int> pdgId_;
+  container selected_;
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+
+  mutable edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
 };
 
 #endif

--- a/CommonTools/RecoAlgos/interface/FKDPoint.h
+++ b/CommonTools/RecoAlgos/interface/FKDPoint.h
@@ -4,74 +4,51 @@
 #include <utility>
 
 //a K-dimensional point to interface with the FKDTree class
-template<class TYPE, int numberOfDimensions>
-class FKDPoint
-{
+template <class TYPE, int numberOfDimensions>
+class FKDPoint {
+public:
+  FKDPoint() : theElements(), theId(0) {}
 
-    public:
-        FKDPoint() :
-                theElements(), theId(0)
-        {
-        }
+  FKDPoint(TYPE x, TYPE y, unsigned int id = 0) {
+    static_assert(numberOfDimensions == 2, "FKDPoint number of arguments does not match the number of dimensions");
 
-        FKDPoint(TYPE x, TYPE y, unsigned int id = 0)
-        {
-            static_assert(numberOfDimensions==2,"FKDPoint number of arguments does not match the number of dimensions");
+    theId = id;
+    theElements[0] = x;
+    theElements[1] = y;
+  }
 
-            theId = id;
-            theElements[0] = x;
-            theElements[1] = y;
-        }
+  FKDPoint(TYPE x, TYPE y, TYPE z, unsigned int id = 0) {
+    static_assert(numberOfDimensions == 3, "FKDPoint number of arguments does not match the number of dimensions");
 
-        FKDPoint(TYPE x, TYPE y, TYPE z, unsigned int id = 0)
-        {
-            static_assert(numberOfDimensions==3,"FKDPoint number of arguments does not match the number of dimensions");
+    theId = id;
+    theElements[0] = x;
+    theElements[1] = y;
+    theElements[2] = z;
+  }
 
-            theId = id;
-            theElements[0] = x;
-            theElements[1] = y;
-            theElements[2] = z;
-        }
+  FKDPoint(TYPE x, TYPE y, TYPE z, TYPE w, unsigned int id = 0) {
+    static_assert(numberOfDimensions == 4, "FKDPoint number of arguments does not match the number of dimensions");
+    theId = id;
+    theElements[0] = x;
+    theElements[1] = y;
+    theElements[2] = z;
+    theElements[3] = w;
+  }
 
-        FKDPoint(TYPE x, TYPE y, TYPE z, TYPE w, unsigned int id = 0)
-        {
-            static_assert(numberOfDimensions==4,"FKDPoint number of arguments does not match the number of dimensions");
-            theId = id;
-            theElements[0] = x;
-            theElements[1] = y;
-            theElements[2] = z;
-            theElements[3] = w;
-        }
+  // the user should check that i < numberOfDimensions
+  TYPE& operator[](unsigned int const i) { return theElements[i]; }
 
-        // the user should check that i < numberOfDimensions
-        TYPE& operator[](unsigned int const i)
-        {
-            return theElements[i];
-        }
+  TYPE const& operator[](unsigned int const i) const { return theElements[i]; }
 
-        TYPE const& operator[](unsigned int const i) const
-        {
-            return theElements[i];
-        }
+  void setDimension(unsigned int i, const TYPE& value) { theElements[i] = value; }
 
-        void setDimension(unsigned int i, const TYPE& value)
-        {
-            theElements[i] = value;
-        }
+  void setId(const unsigned int id) { theId = id; }
 
-        void setId(const unsigned int id)
-        {
-            theId = id;
-        }
+  unsigned int getId() const { return theId; }
 
-        unsigned int getId() const
-        {
-            return theId;
-        }
-
-    private:
-        std::array<TYPE, numberOfDimensions> theElements;
-        unsigned int theId;
+private:
+  std::array<TYPE, numberOfDimensions> theElements;
+  unsigned int theId;
 };
 
-#endif 
+#endif

--- a/CommonTools/RecoAlgos/interface/FKDTree.h
+++ b/CommonTools/RecoAlgos/interface/FKDTree.h
@@ -17,284 +17,230 @@
 // It produces a compact array of nodes in memory thanks to the different space partitioning method used.
 
 // Fast version of the integer logarithm
-namespace
-{
-const std::array<unsigned int, 32> MultiplyDeBruijnBitPosition
-{
-{ 0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30, 8, 12, 20, 28, 15, 17, 24, 7, 19, 27,
-        23, 6, 26, 5, 4, 31 } };
-unsigned int ilog2(unsigned int v)
-{
-    v |= v >> 1; // first round down to one less than a power of 2
+namespace {
+  const std::array<unsigned int, 32> MultiplyDeBruijnBitPosition{{0,  9,  1,  10, 13, 21, 2,  29, 11, 14, 16,
+                                                                  18, 22, 25, 3,  30, 8,  12, 20, 28, 15, 17,
+                                                                  24, 7,  19, 27, 23, 6,  26, 5,  4,  31}};
+  unsigned int ilog2(unsigned int v) {
+    v |= v >> 1;  // first round down to one less than a power of 2
     v |= v >> 2;
     v |= v >> 4;
     v |= v >> 8;
     v |= v >> 16;
-    return MultiplyDeBruijnBitPosition[(unsigned int) (v * 0x07C4ACDDU) >> 27];
-}
-}
+    return MultiplyDeBruijnBitPosition[(unsigned int)(v * 0x07C4ACDDU) >> 27];
+  }
+}  // namespace
 
-template<class TYPE, unsigned int numberOfDimensions>
-class FKDTree
-{
+template <class TYPE, unsigned int numberOfDimensions>
+class FKDTree {
+public:
+  FKDTree() {
+    theNumberOfPoints = 0;
+    theDepth = 0;
+  }
 
-    public:
+  bool empty() { return theNumberOfPoints == 0; }
 
-        FKDTree()
-        {
-            theNumberOfPoints = 0;
-            theDepth = 0;
+  // One can search for all the points which are contained in a k-dimensional box.
+  // Searching is done by providing the two k-dimensional points in the minimum and maximum corners.
+  // The vector that will contain the indices of the points that lay inside the box is also needed.
+  // Indices are pushed into foundPoints, which is not checked for emptiness at the beginning,
+  // nor memory is reserved for it.
+  // Searching is done using a Breadth-first search, level after level.
+  void search(const FKDPoint<TYPE, numberOfDimensions>& minPoint,
+              const FKDPoint<TYPE, numberOfDimensions>& maxPoint,
+              std::vector<unsigned int>& foundPoints) {
+    //going down the FKDTree, one needs track which indices have to be visited in the following level.
+    //a custom queue is created, since std::queue is based on lists which are sometimes not performing
+    // well on computing accelerators
+    // The initial size of the queue has to be a power of two for allowing fast modulo  % operation.
+    FQueue<unsigned int> indicesToVisit(16);
+
+    //The root element is pushed first
+    indicesToVisit.push_back(0);
+    unsigned int index;
+    bool intersection;
+    unsigned int dimension;
+    unsigned int numberOfindicesToVisitThisDepth;
+    unsigned int numberOfSonsToVisitNext;
+    unsigned int firstSonToVisitNext;
+
+    //The loop over levels of the FKDTree starts here
+    for (unsigned int depth = 0; depth < theDepth + 1; ++depth) {
+      // At each level, comparisons are performed for a different dimension in round robin.
+      dimension = depth % numberOfDimensions;
+      numberOfindicesToVisitThisDepth = indicesToVisit.size();
+      // Loop over the nodes to be visit at this level
+      for (unsigned int visitedindicesThisDepth = 0; visitedindicesThisDepth < numberOfindicesToVisitThisDepth;
+           visitedindicesThisDepth++) {
+        index = indicesToVisit[visitedindicesThisDepth];
+        // check if the element's dimension lays between the two box borders
+        intersection = intersects(index, minPoint, maxPoint, dimension);
+        firstSonToVisitNext = leftSonIndex(index);
+
+        if (intersection) {
+          // Check if the element is contained in the box and push it to the result
+          if (is_in_the_box(index, minPoint, maxPoint)) {
+            foundPoints.emplace_back(theIds[index]);
+          }
+          //if the element is between the box borders, both the its sons have to be visited
+          numberOfSonsToVisitNext =
+              (firstSonToVisitNext < theNumberOfPoints) + ((firstSonToVisitNext + 1) < theNumberOfPoints);
+        } else {
+          // depending on the position of the element wrt the box, one son will be visited (if it exists)
+          firstSonToVisitNext += (theDimensions[dimension][index] < minPoint[dimension]);
+
+          numberOfSonsToVisitNext =
+              std::min((firstSonToVisitNext < theNumberOfPoints) + ((firstSonToVisitNext + 1) < theNumberOfPoints), 1);
         }
 
-        bool empty()
-        {
-            return theNumberOfPoints == 0;
+        // the indices of the sons to be visited in the next iteration are pushed in the queue
+        for (unsigned int whichSon = 0; whichSon < numberOfSonsToVisitNext; ++whichSon) {
+          indicesToVisit.push_back(firstSonToVisitNext + whichSon);
+        }
+      }
+      // a new element is popped from the queue
+      indicesToVisit.pop_front(numberOfindicesToVisitThisDepth);
+    }
+  }
+
+  // A vector of K-dimensional points needs to be passed in order to build the kdtree.
+  // The order of the elements in the vector will be modified.
+  void build(std::vector<FKDPoint<TYPE, numberOfDimensions> >& points) {
+    // initialization of the data members
+    theNumberOfPoints = points.size();
+    theDepth = ilog2(theNumberOfPoints);
+    theIntervalLength.resize(theNumberOfPoints, 0);
+    theIntervalMin.resize(theNumberOfPoints, 0);
+    for (unsigned int i = 0; i < numberOfDimensions; ++i)
+      theDimensions[i].resize(theNumberOfPoints);
+    theIds.resize(theNumberOfPoints);
+
+    // building is done by reordering elements in a partition starting at theIntervalMin
+    // for a number of elements theIntervalLength
+    unsigned int dimension;
+    theIntervalMin[0] = 0;
+    theIntervalLength[0] = theNumberOfPoints;
+
+    // building for each level starts here
+    for (unsigned int depth = 0; depth < theDepth; ++depth) {
+      // A heapified left-balanced tree can be represented in memory as an array.
+      // Each level contains a power of two number of elements and starts from element 2^depth -1
+      dimension = depth % numberOfDimensions;
+      unsigned int firstIndexInDepth = (1 << depth) - 1;
+      unsigned int maxDepth = (1 << depth);
+      for (unsigned int indexInDepth = 0; indexInDepth < maxDepth; ++indexInDepth) {
+        unsigned int indexInArray = firstIndexInDepth + indexInDepth;
+        unsigned int leftSonIndexInArray = 2 * indexInArray + 1;
+        unsigned int rightSonIndexInArray = leftSonIndexInArray + 1;
+
+        // partitioning is done by choosing the pivotal element that keeps the tree heapified
+        // and left-balanced
+        unsigned int whichElementInInterval = partition_complete_kdtree(theIntervalLength[indexInArray]);
+        // the elements have been partitioned in two unsorted subspaces (one containing the elements
+        // smaller than the pivot, the other containing those greater than the pivot)
+        std::nth_element(points.begin() + theIntervalMin[indexInArray],
+                         points.begin() + theIntervalMin[indexInArray] + whichElementInInterval,
+                         points.begin() + theIntervalMin[indexInArray] + theIntervalLength[indexInArray],
+                         [dimension](const FKDPoint<TYPE, numberOfDimensions>& a,
+                                     const FKDPoint<TYPE, numberOfDimensions>& b) -> bool {
+                           if (a[dimension] == b[dimension])
+                             return a.getId() < b.getId();
+                           else
+                             return a[dimension] < b[dimension];
+                         });
+        // the element is placed in its final position in the internal array representation
+        // of the tree
+        add_at_position(points[theIntervalMin[indexInArray] + whichElementInInterval], indexInArray);
+        if (leftSonIndexInArray < theNumberOfPoints) {
+          theIntervalMin[leftSonIndexInArray] = theIntervalMin[indexInArray];
+          theIntervalLength[leftSonIndexInArray] = whichElementInInterval;
         }
 
-        // One can search for all the points which are contained in a k-dimensional box.
-        // Searching is done by providing the two k-dimensional points in the minimum and maximum corners.
-        // The vector that will contain the indices of the points that lay inside the box is also needed.
-        // Indices are pushed into foundPoints, which is not checked for emptiness at the beginning,
-        // nor memory is reserved for it.
-        // Searching is done using a Breadth-first search, level after level.
-        void search(const FKDPoint<TYPE, numberOfDimensions>& minPoint,
-                const FKDPoint<TYPE, numberOfDimensions>& maxPoint,
-                std::vector<unsigned int>& foundPoints)
-        {
-            //going down the FKDTree, one needs track which indices have to be visited in the following level.
-            //a custom queue is created, since std::queue is based on lists which are sometimes not performing
-            // well on computing accelerators
-            // The initial size of the queue has to be a power of two for allowing fast modulo  % operation.
-            FQueue<unsigned int> indicesToVisit(16);
-
-            //The root element is pushed first
-            indicesToVisit.push_back(0);
-            unsigned int index;
-            bool intersection;
-            unsigned int dimension;
-            unsigned int numberOfindicesToVisitThisDepth;
-            unsigned int numberOfSonsToVisitNext;
-            unsigned int firstSonToVisitNext;
-
-            //The loop over levels of the FKDTree starts here
-            for (unsigned int depth = 0; depth < theDepth + 1; ++depth)
-            {
-                // At each level, comparisons are performed for a different dimension in round robin.
-                dimension = depth % numberOfDimensions;
-                numberOfindicesToVisitThisDepth = indicesToVisit.size();
-                // Loop over the nodes to be visit at this level
-                for (unsigned int visitedindicesThisDepth = 0;
-                        visitedindicesThisDepth < numberOfindicesToVisitThisDepth;
-                        visitedindicesThisDepth++)
-                {
-
-                    index = indicesToVisit[visitedindicesThisDepth];
-                    // check if the element's dimension lays between the two box borders
-                    intersection = intersects(index, minPoint, maxPoint, dimension);
-                    firstSonToVisitNext = leftSonIndex(index);
-
-
-                    if (intersection)
-                    {
-                        // Check if the element is contained in the box and push it to the result
-                        if (is_in_the_box(index, minPoint, maxPoint))
-                        {
-                            foundPoints.emplace_back(theIds[index]);
-                        }
-                        //if the element is between the box borders, both the its sons have to be visited
-                        numberOfSonsToVisitNext = (firstSonToVisitNext < theNumberOfPoints)
-                                + ((firstSonToVisitNext + 1) < theNumberOfPoints);
-                    }
-                    else
-                    {
-                        // depending on the position of the element wrt the box, one son will be visited (if it exists)
-                        firstSonToVisitNext += (theDimensions[dimension][index]
-                                < minPoint[dimension]);
-
-                        numberOfSonsToVisitNext = std::min(
-                                (firstSonToVisitNext < theNumberOfPoints)
-                                        + ((firstSonToVisitNext + 1) < theNumberOfPoints), 1);
-                    }
-
-                    // the indices of the sons to be visited in the next iteration are pushed in the queue
-                    for (unsigned int whichSon = 0; whichSon < numberOfSonsToVisitNext; ++whichSon)
-                    {
-                        indicesToVisit.push_back(firstSonToVisitNext + whichSon);
-                    }
-                }
-                // a new element is popped from the queue
-                indicesToVisit.pop_front(numberOfindicesToVisitThisDepth);
-            }
-
+        if (rightSonIndexInArray < theNumberOfPoints) {
+          theIntervalMin[rightSonIndexInArray] = theIntervalMin[indexInArray] + whichElementInInterval + 1;
+          theIntervalLength[rightSonIndexInArray] = (theIntervalLength[indexInArray] - 1 - whichElementInInterval);
         }
+      }
+    }
+    // the last level of the tree may not be complete and needs special treatment
+    dimension = theDepth % numberOfDimensions;
+    unsigned int firstIndexInDepth = (1 << theDepth) - 1;
+    for (unsigned int indexInArray = firstIndexInDepth; indexInArray < theNumberOfPoints; ++indexInArray) {
+      add_at_position(points[theIntervalMin[indexInArray]], indexInArray);
+    }
+  }
+  // returns the number of points in the FKDTree
+  std::size_t size() const { return theNumberOfPoints; }
 
-        // A vector of K-dimensional points needs to be passed in order to build the kdtree.
-        // The order of the elements in the vector will be modified.
-        void build(std::vector<FKDPoint<TYPE, numberOfDimensions> >& points)
-        {
-            // initialization of the data members
-            theNumberOfPoints = points.size();
-            theDepth = ilog2(theNumberOfPoints);
-            theIntervalLength.resize(theNumberOfPoints, 0);
-            theIntervalMin.resize(theNumberOfPoints, 0);
-            for (unsigned int i = 0; i < numberOfDimensions; ++i)
-                theDimensions[i].resize(theNumberOfPoints);
-            theIds.resize(theNumberOfPoints);
+private:
+  // returns the index of the element which makes the FKDtree a left-complete heap
+  // e.g.: if we have 6 elements, the tree will be shaped like
+  //                 O
+  //                / '\'
+  //               O    O
+  //              /'\' /
+  //             O   OO
+  //
+  // This will return for a length of 6 the 4th element, which will partition the tree so that
+  // 3 elements are on its left and 2 elements are on its right
+  unsigned int partition_complete_kdtree(unsigned int length) {
+    if (length == 1)
+      return 0;
+    unsigned int index = 1 << (ilog2(length));
 
-            // building is done by reordering elements in a partition starting at theIntervalMin
-            // for a number of elements theIntervalLength
-            unsigned int dimension;
-            theIntervalMin[0] = 0;
-            theIntervalLength[0] = theNumberOfPoints;
+    if ((index / 2) - 1 <= length - index)
+      return index - 1;
+    else
+      return length - index / 2;
+  }
 
-            // building for each level starts here
-            for (unsigned int depth = 0; depth < theDepth; ++depth)
-            {
-                // A heapified left-balanced tree can be represented in memory as an array.
-                // Each level contains a power of two number of elements and starts from element 2^depth -1
-                dimension = depth % numberOfDimensions;
-                unsigned int firstIndexInDepth = (1 << depth) - 1;
-                unsigned int maxDepth = (1 << depth);
-                for (unsigned int indexInDepth = 0; indexInDepth < maxDepth; ++indexInDepth)
-                {
-                    unsigned int indexInArray = firstIndexInDepth + indexInDepth;
-                    unsigned int leftSonIndexInArray = 2 * indexInArray + 1;
-                    unsigned int rightSonIndexInArray = leftSonIndexInArray + 1;
+  // returns the index of an element left son in the array representation
+  unsigned int leftSonIndex(unsigned int index) const { return 2 * index + 1; }
+  // returns the index of an element right son in the array representation
+  unsigned int rightSonIndex(unsigned int index) const { return 2 * index + 2; }
 
-                    // partitioning is done by choosing the pivotal element that keeps the tree heapified
-                    // and left-balanced
-                    unsigned int whichElementInInterval = partition_complete_kdtree(
-                            theIntervalLength[indexInArray]);
-                    // the elements have been partitioned in two unsorted subspaces (one containing the elements
-                    // smaller than the pivot, the other containing those greater than the pivot)
-                    std::nth_element(points.begin() + theIntervalMin[indexInArray],
-                            points.begin() + theIntervalMin[indexInArray] + whichElementInInterval,
-                            points.begin() + theIntervalMin[indexInArray]
-                                    + theIntervalLength[indexInArray],
-                            [dimension](const FKDPoint<TYPE,numberOfDimensions> & a,
-                                    const FKDPoint<TYPE,numberOfDimensions> & b) -> bool
-                            {
-                                if(a[dimension] == b[dimension])
-                                return a.getId() < b.getId();
-                                else
-                                return a[dimension] < b[dimension];
-                            });
-                    // the element is placed in its final position in the internal array representation
-                    // of the tree
-                    add_at_position(points[theIntervalMin[indexInArray] + whichElementInInterval],
-                            indexInArray);
-                    if (leftSonIndexInArray < theNumberOfPoints)
-                    {
-                        theIntervalMin[leftSonIndexInArray] = theIntervalMin[indexInArray];
-                        theIntervalLength[leftSonIndexInArray] = whichElementInInterval;
-                    }
+  //check if one element's dimension is between minPoint's and maxPoint's dimension
+  bool intersects(unsigned int index,
+                  const FKDPoint<TYPE, numberOfDimensions>& minPoint,
+                  const FKDPoint<TYPE, numberOfDimensions>& maxPoint,
+                  int dimension) const {
+    return (theDimensions[dimension][index] <= maxPoint[dimension] &&
+            theDimensions[dimension][index] >= minPoint[dimension]);
+  }
 
-                    if (rightSonIndexInArray < theNumberOfPoints)
-                    {
-                        theIntervalMin[rightSonIndexInArray] = theIntervalMin[indexInArray]
-                                + whichElementInInterval + 1;
-                        theIntervalLength[rightSonIndexInArray] = (theIntervalLength[indexInArray]
-                                - 1 - whichElementInInterval);
-                    }
-                }
-            }
-            // the last level of the tree may not be complete and needs special treatment
-            dimension = theDepth % numberOfDimensions;
-            unsigned int firstIndexInDepth = (1 << theDepth) - 1;
-            for (unsigned int indexInArray = firstIndexInDepth; indexInArray < theNumberOfPoints;
-                    ++indexInArray)
-            {
-                add_at_position(points[theIntervalMin[indexInArray]], indexInArray);
-            }
+  // check if an element is completely in the box
+  bool is_in_the_box(unsigned int index,
+                     const FKDPoint<TYPE, numberOfDimensions>& minPoint,
+                     const FKDPoint<TYPE, numberOfDimensions>& maxPoint) const {
+    for (unsigned int i = 0; i < numberOfDimensions; ++i) {
+      if ((theDimensions[i][index] <= maxPoint[i] && theDimensions[i][index] >= minPoint[i]) == false)
+        return false;
+    }
+    return true;
+  }
 
-        }
-        // returns the number of points in the FKDTree
-        std::size_t size() const
-        {
-            return theNumberOfPoints;
-        }
+  // places an element at the specified position in the internal data structure
+  void add_at_position(const FKDPoint<TYPE, numberOfDimensions>& point, const unsigned int position) {
+    for (unsigned int i = 0; i < numberOfDimensions; ++i)
+      theDimensions[i][position] = point[i];
+    theIds[position] = point.getId();
+  }
 
-    private:
-        // returns the index of the element which makes the FKDtree a left-complete heap
-        // e.g.: if we have 6 elements, the tree will be shaped like
-        //                 O
-        //                / '\'
-        //               O    O
-        //              /'\' /
-        //             O   OO
-        //
-        // This will return for a length of 6 the 4th element, which will partition the tree so that
-        // 3 elements are on its left and 2 elements are on its right
-        unsigned int partition_complete_kdtree(unsigned int length)
-        {
-            if (length == 1)
-                return 0;
-            unsigned int index = 1 << (ilog2(length));
+  void add_at_position(FKDPoint<TYPE, numberOfDimensions>&& point, const unsigned int position) {
+    for (unsigned int i = 0; i < numberOfDimensions; ++i)
+      theDimensions[i][position] = point[i];
+    theIds[position] = point.getId();
+  }
 
-            if ((index / 2) - 1 <= length - index)
-                return index - 1;
-            else
-                return length - index / 2;
-        }
+  unsigned int theNumberOfPoints;
+  unsigned int theDepth;
 
-        // returns the index of an element left son in the array representation
-        unsigned int leftSonIndex(unsigned int index) const
-        {
-            return 2 * index + 1;
-        }
-        // returns the index of an element right son in the array representation
-        unsigned int rightSonIndex(unsigned int index) const
-        {
-            return 2 * index + 2;
-        }
-
-        //check if one element's dimension is between minPoint's and maxPoint's dimension
-        bool intersects(unsigned int index, const FKDPoint<TYPE, numberOfDimensions>& minPoint,
-                const FKDPoint<TYPE, numberOfDimensions>& maxPoint, int dimension) const
-        {
-            return (theDimensions[dimension][index] <= maxPoint[dimension]
-                    && theDimensions[dimension][index] >= minPoint[dimension]);
-        }
-
-        // check if an element is completely in the box
-        bool is_in_the_box(unsigned int index, const FKDPoint<TYPE, numberOfDimensions>& minPoint,
-                const FKDPoint<TYPE, numberOfDimensions>& maxPoint) const
-        {
-            for (unsigned int i = 0; i < numberOfDimensions; ++i)
-            {
-                if ((theDimensions[i][index] <= maxPoint[i]
-                        && theDimensions[i][index] >= minPoint[i]) == false)
-                    return false;
-            }
-            return true;
-        }
-
-        // places an element at the specified position in the internal data structure
-        void add_at_position(const FKDPoint<TYPE, numberOfDimensions>& point,
-                const unsigned int position)
-        {
-            for (unsigned int i = 0; i < numberOfDimensions; ++i)
-                theDimensions[i][position] = point[i];
-            theIds[position] = point.getId();
-        }
-
-        void add_at_position(FKDPoint<TYPE, numberOfDimensions> && point,
-                const unsigned int position)
-        {
-            for (unsigned int i = 0; i < numberOfDimensions; ++i)
-                theDimensions[i][position] = point[i];
-            theIds[position] = point.getId();
-        }
-
-        unsigned int theNumberOfPoints;
-        unsigned int theDepth;
-
-        // a SoA containing all the dimensions for each point
-        std::array<std::vector<TYPE>, numberOfDimensions> theDimensions;
-        std::vector<unsigned int> theIntervalLength;
-        std::vector<unsigned int> theIntervalMin;
-        std::vector<unsigned int> theIds;
-
+  // a SoA containing all the dimensions for each point
+  std::array<std::vector<TYPE>, numberOfDimensions> theDimensions;
+  std::vector<unsigned int> theIntervalLength;
+  std::vector<unsigned int> theIntervalMin;
+  std::vector<unsigned int> theIds;
 };
 
-#endif 
+#endif

--- a/CommonTools/RecoAlgos/interface/FQueue.h
+++ b/CommonTools/RecoAlgos/interface/FQueue.h
@@ -3,119 +3,82 @@
 
 #include <vector>
 
-template<class T>
-class FQueue
-{
-    public:
-        FQueue()
-        {
-            theSize = 0;
-            theFront = 0;
-            theTail = 0;
-            theCapacity = 0;
-        }
+template <class T>
+class FQueue {
+public:
+  FQueue() {
+    theSize = 0;
+    theFront = 0;
+    theTail = 0;
+    theCapacity = 0;
+  }
 
-        FQueue(unsigned int initialCapacity)
-        {
-            theBuffer.resize(initialCapacity);
-            theSize = 0;
-            theFront = 0;
-            theTail = 0;
-            theCapacity = initialCapacity;
-        }
+  FQueue(unsigned int initialCapacity) {
+    theBuffer.resize(initialCapacity);
+    theSize = 0;
+    theFront = 0;
+    theTail = 0;
+    theCapacity = initialCapacity;
+  }
 
-        unsigned int size() const
-        {
-            return theSize;
-        }
+  unsigned int size() const { return theSize; }
 
-        bool empty() const
-        {
-            return theSize == 0;
-        }
+  bool empty() const { return theSize == 0; }
 
-        T front() const
-        {
-            return theBuffer[theFront];
-        }
+  T front() const { return theBuffer[theFront]; }
 
-        T & tail()
-        {
-            return theBuffer[theTail];
-        }
+  T& tail() { return theBuffer[theTail]; }
 
-        constexpr unsigned int wrapIndex(unsigned int i)
-        {
-            return i & (theBuffer.size() - 1);
-        }
+  constexpr unsigned int wrapIndex(unsigned int i) { return i & (theBuffer.size() - 1); }
 
-        void push_back(const T & value)
-        {
-            if (theSize >= theCapacity)
-            {
-                theBuffer.resize(theCapacity * 2);
-                if (theFront != 0)
-                {
-                    std::copy(theBuffer.begin(), theBuffer.begin() + theTail,
-                            theBuffer.begin() + theCapacity);
+  void push_back(const T& value) {
+    if (theSize >= theCapacity) {
+      theBuffer.resize(theCapacity * 2);
+      if (theFront != 0) {
+        std::copy(theBuffer.begin(), theBuffer.begin() + theTail, theBuffer.begin() + theCapacity);
 
-                    theTail += theSize;
+        theTail += theSize;
 
-                }
-                else
-                {
-                    theTail += theCapacity;
-                }
-                theCapacity *= 2;
-            }
-            theBuffer[theTail] = value;
-            theTail = wrapIndex(theTail + 1);
-            theSize++;
+      } else {
+        theTail += theCapacity;
+      }
+      theCapacity *= 2;
+    }
+    theBuffer[theTail] = value;
+    theTail = wrapIndex(theTail + 1);
+    theSize++;
+  }
 
-        }
+  void pop_front() {
+    if (theSize > 0) {
+      theFront = wrapIndex(theFront + 1);
+      theSize--;
+    }
+  }
 
-        void pop_front()
-        {
-            if (theSize > 0)
-            {
-                theFront = wrapIndex(theFront + 1);
-                theSize--;
-            }
-        }
+  void pop_front(const unsigned int numberOfElementsToPop) {
+    unsigned int elementsToErase = theSize > numberOfElementsToPop ? numberOfElementsToPop : theSize;
+    theSize -= elementsToErase;
+    theFront = wrapIndex(theFront + elementsToErase);
+  }
 
-        void pop_front(const unsigned int numberOfElementsToPop)
-        {
-            unsigned int elementsToErase =
-                    theSize > numberOfElementsToPop ? numberOfElementsToPop : theSize;
-            theSize -= elementsToErase;
-            theFront = wrapIndex(theFront + elementsToErase);
-        }
+  void reserve(unsigned int capacity) { theBuffer.reserve(capacity); }
 
-        void reserve(unsigned int capacity)
-        {
-            theBuffer.reserve(capacity);
-        }
+  T& operator[](unsigned int index) { return theBuffer[wrapIndex(theFront + index)]; }
 
-        T & operator[](unsigned int index)
-        {
-            return theBuffer[wrapIndex(theFront + index)];
-        }
+  void clear() {
+    theBuffer.clear();
+    theSize = 0;
+    theFront = 0;
+    theTail = 0;
+  }
 
-        void clear()
-        {
-            theBuffer.clear();
-            theSize = 0;
-            theFront = 0;
-            theTail = 0;
-        }
-
-    private:
-        unsigned int theSize;
-        unsigned int theFront;
-        unsigned int theTail;
-        std::vector<T> theBuffer;
-        unsigned int theCapacity;
-
+private:
+  unsigned int theSize;
+  unsigned int theFront;
+  unsigned int theTail;
+  std::vector<T> theBuffer;
+  unsigned int theCapacity;
 };
 
 #endif

--- a/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
+++ b/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
@@ -24,68 +24,80 @@
 namespace helper {
   struct GsfElectronCollectionStoreManager {
     typedef reco::GsfElectronCollection collection;
-    GsfElectronCollectionStoreManager(const edm::Handle<reco::GsfElectronCollection>&) :
-      selElectrons_( new reco::GsfElectronCollection ),
-      selElectronCores_ (new reco::GsfElectronCoreCollection ) ,
-      selSuperClusters_( new reco::SuperClusterCollection ),
-      selTracks_( new reco::GsfTrackCollection ),
-      selTrackExtras_( new reco::TrackExtraCollection ),
-      selGsfTrackExtras_( new reco::GsfTrackExtraCollection ),
-      selHits_( new TrackingRecHitCollection ) {
-    }
-    template<typename I>
-    void cloneAndStore( const I & begin, const I & end, edm::Event & evt ) {
+    GsfElectronCollectionStoreManager(const edm::Handle<reco::GsfElectronCollection>&)
+        : selElectrons_(new reco::GsfElectronCollection),
+          selElectronCores_(new reco::GsfElectronCoreCollection),
+          selSuperClusters_(new reco::SuperClusterCollection),
+          selTracks_(new reco::GsfTrackCollection),
+          selTrackExtras_(new reco::TrackExtraCollection),
+          selGsfTrackExtras_(new reco::GsfTrackExtraCollection),
+          selHits_(new TrackingRecHitCollection) {}
+    template <typename I>
+    void cloneAndStore(const I& begin, const I& end, edm::Event& evt) {
       using namespace reco;
       TrackingRecHitRefProd rHits = evt.template getRefBeforePut<TrackingRecHitCollection>();
       TrackExtraRefProd rTrackExtras = evt.template getRefBeforePut<TrackExtraCollection>();
       GsfTrackExtraRefProd rGsfTrackExtras = evt.template getRefBeforePut<GsfTrackExtraCollection>();
-      GsfTrackRefProd rTracks = evt.template getRefBeforePut<GsfTrackCollection>();      
-      GsfElectronCoreRefProd rElectronCores = evt.template getRefBeforePut<GsfElectronCoreCollection>();      
-      GsfElectronRefProd rElectrons = evt.template getRefBeforePut<GsfElectronCollection>();      
-      SuperClusterRefProd rSuperClusters = evt.template getRefBeforePut<SuperClusterCollection>();      
+      GsfTrackRefProd rTracks = evt.template getRefBeforePut<GsfTrackCollection>();
+      GsfElectronCoreRefProd rElectronCores = evt.template getRefBeforePut<GsfElectronCoreCollection>();
+      GsfElectronRefProd rElectrons = evt.template getRefBeforePut<GsfElectronCollection>();
+      SuperClusterRefProd rSuperClusters = evt.template getRefBeforePut<SuperClusterCollection>();
       size_t idx = 0, tidx = 0, hidx = 0;
-      for( I i = begin; i != end; ++ i ) {
-	const GsfElectron & ele = * * i;
-	selElectronCores_->push_back( GsfElectronCore( *(ele.core()) ) );
-	selElectronCores_->back().setGsfTrack( GsfTrackRef( rTracks, idx ) );
-	selElectronCores_->back().setSuperCluster( SuperClusterRef( rSuperClusters, idx ) );
-	selSuperClusters_->push_back( SuperCluster( * ( ele.superCluster() ) ) );
-        selElectrons_->push_back(GsfElectron(ele,GsfElectronCoreRef(rElectronCores,idx++),CaloClusterPtr(),TrackRef(),TrackBaseRef(),GsfTrackRefVector()));
-	GsfTrackRef trkRef = ele.gsfTrack();
-	if ( trkRef.isNonnull() ) {
-	  selTracks_->push_back( GsfTrack( * trkRef ) );
-  	  GsfTrack & trk = selTracks_->back();
-	  selTrackExtras_->push_back( TrackExtra( trk.outerPosition(), trk.outerMomentum(), trk.outerOk(),
-						  trk.innerPosition(), trk.innerMomentum(), trk.innerOk(),
-						  trk.outerStateCovariance(), trk.outerDetId(),
-						  trk.innerStateCovariance(), trk.innerDetId(),
-						  trk.seedDirection() ) );
-	  selGsfTrackExtras_->push_back( GsfTrackExtra( *(trk.gsfExtra()) ) );
-	  TrackExtra & tx = selTrackExtras_->back();
-	  unsigned int nHitsToAdd = trk.recHitsSize();
-	  for(auto const& hit : trk.recHits()) selHits_->push_back( hit->clone() );
-	  tx.setHits( rHits, hidx, nHitsToAdd );
-	  tx.setTrajParams(trk.extra()->trajParams(),trk.extra()->chi2sX5());
-	  assert(tx.trajParams().size()==tx.recHitsSize());
-	  hidx += nHitsToAdd;
-	  trk.setGsfExtra( GsfTrackExtraRef( rGsfTrackExtras, tidx ) ); 
-	  trk.setExtra( TrackExtraRef( rTrackExtras, tidx ++ ) ); 
-	} 
+      for (I i = begin; i != end; ++i) {
+        const GsfElectron& ele = **i;
+        selElectronCores_->push_back(GsfElectronCore(*(ele.core())));
+        selElectronCores_->back().setGsfTrack(GsfTrackRef(rTracks, idx));
+        selElectronCores_->back().setSuperCluster(SuperClusterRef(rSuperClusters, idx));
+        selSuperClusters_->push_back(SuperCluster(*(ele.superCluster())));
+        selElectrons_->push_back(GsfElectron(ele,
+                                             GsfElectronCoreRef(rElectronCores, idx++),
+                                             CaloClusterPtr(),
+                                             TrackRef(),
+                                             TrackBaseRef(),
+                                             GsfTrackRefVector()));
+        GsfTrackRef trkRef = ele.gsfTrack();
+        if (trkRef.isNonnull()) {
+          selTracks_->push_back(GsfTrack(*trkRef));
+          GsfTrack& trk = selTracks_->back();
+          selTrackExtras_->push_back(TrackExtra(trk.outerPosition(),
+                                                trk.outerMomentum(),
+                                                trk.outerOk(),
+                                                trk.innerPosition(),
+                                                trk.innerMomentum(),
+                                                trk.innerOk(),
+                                                trk.outerStateCovariance(),
+                                                trk.outerDetId(),
+                                                trk.innerStateCovariance(),
+                                                trk.innerDetId(),
+                                                trk.seedDirection()));
+          selGsfTrackExtras_->push_back(GsfTrackExtra(*(trk.gsfExtra())));
+          TrackExtra& tx = selTrackExtras_->back();
+          unsigned int nHitsToAdd = trk.recHitsSize();
+          for (auto const& hit : trk.recHits())
+            selHits_->push_back(hit->clone());
+          tx.setHits(rHits, hidx, nHitsToAdd);
+          tx.setTrajParams(trk.extra()->trajParams(), trk.extra()->chi2sX5());
+          assert(tx.trajParams().size() == tx.recHitsSize());
+          hidx += nHitsToAdd;
+          trk.setGsfExtra(GsfTrackExtraRef(rGsfTrackExtras, tidx));
+          trk.setExtra(TrackExtraRef(rTrackExtras, tidx++));
+        }
       }
     }
 
-    edm::OrphanHandle<reco::GsfElectronCollection> put( edm::Event & evt ) {
+    edm::OrphanHandle<reco::GsfElectronCollection> put(edm::Event& evt) {
       edm::OrphanHandle<reco::GsfElectronCollection> h = evt.put(std::move(selElectrons_));
-      evt.put(std::move(selElectronCores_ ));
-      evt.put(std::move(selSuperClusters_ ));
-      evt.put(std::move(selTracks_ ));
-      evt.put(std::move(selTrackExtras_ ));
-      evt.put(std::move(selGsfTrackExtras_ ));
-      evt.put(std::move(selHits_ ));
+      evt.put(std::move(selElectronCores_));
+      evt.put(std::move(selSuperClusters_));
+      evt.put(std::move(selTracks_));
+      evt.put(std::move(selTrackExtras_));
+      evt.put(std::move(selGsfTrackExtras_));
+      evt.put(std::move(selHits_));
       return h;
     }
 
     size_t size() const { return selElectrons_->size(); }
+
   private:
     std::unique_ptr<reco::GsfElectronCollection> selElectrons_;
     std::unique_ptr<reco::GsfElectronCoreCollection> selElectronCores_;
@@ -98,23 +110,23 @@ namespace helper {
 
   class GsfElectronSelectorBase : public edm::EDFilter {
   public:
-    GsfElectronSelectorBase( const edm::ParameterSet & cfg ) {
-      std::string alias( cfg.getParameter<std::string>( "@module_label" ) );
-      produces<reco::GsfElectronCollection>().setBranchAlias( alias + "GsfElectrons" );
-      produces<reco::GsfElectronCoreCollection>().setBranchAlias( alias + "GsfElectronCores" );
-      produces<reco::SuperClusterCollection>().setBranchAlias( alias + "SuperClusters" );
-      produces<reco::GsfTrackCollection>().setBranchAlias( alias + "GsfTracks" );
-      produces<reco::GsfTrackExtraCollection>().setBranchAlias( alias + "GsfTrackExtras" );
-      produces<reco::TrackExtraCollection>().setBranchAlias( alias + "TrackExtras" );
-      produces<TrackingRecHitCollection>().setBranchAlias( alias + "RecHits" );
+    GsfElectronSelectorBase(const edm::ParameterSet& cfg) {
+      std::string alias(cfg.getParameter<std::string>("@module_label"));
+      produces<reco::GsfElectronCollection>().setBranchAlias(alias + "GsfElectrons");
+      produces<reco::GsfElectronCoreCollection>().setBranchAlias(alias + "GsfElectronCores");
+      produces<reco::SuperClusterCollection>().setBranchAlias(alias + "SuperClusters");
+      produces<reco::GsfTrackCollection>().setBranchAlias(alias + "GsfTracks");
+      produces<reco::GsfTrackExtraCollection>().setBranchAlias(alias + "GsfTrackExtras");
+      produces<reco::TrackExtraCollection>().setBranchAlias(alias + "TrackExtras");
+      produces<TrackingRecHitCollection>().setBranchAlias(alias + "RecHits");
     }
   };
-  
-  template<>
+
+  template <>
   struct StoreManagerTrait<reco::GsfElectronCollection> {
     typedef GsfElectronCollectionStoreManager type;
     typedef GsfElectronSelectorBase base;
   };
-}
+}  // namespace helper
 
 #endif

--- a/CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h
+++ b/CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h
@@ -123,7 +123,7 @@ public:
 
 private:
   // The node pool allow us to do just 1 call to new for each tree building.
-  KDTreeNodes<DATA,DIM> nodePool_;
+  KDTreeNodes<DATA, DIM> nodePool_;
 
   std::vector<DATA> *closestNeighbour;
   std::vector<KDTreeNodeInfo<DATA, DIM> > *initialEltList;

--- a/CommonTools/RecoAlgos/interface/MuonSelector.h
+++ b/CommonTools/RecoAlgos/interface/MuonSelector.h
@@ -27,41 +27,40 @@
 
 namespace helper {
   struct MuonCollectionStoreManager {
-   public:
+  public:
     typedef reco::MuonCollection collection;
 
-    MuonCollectionStoreManager(const edm::Handle<reco::MuonCollection>&) ;
-    
+    MuonCollectionStoreManager(const edm::Handle<reco::MuonCollection> &);
+
     //------------------------------------------------------------------
     //!  Use these to turn off/on the cloning of clusters.  The default
     //!  is to clone them.  To not clone (and save space in a quick local
-    //!  job, do:  
+    //!  job, do:
     //!              setCloneClusters(false);
     //------------------------------------------------------------------
-    inline bool cloneClusters() {return cloneClusters_ ; } 
+    inline bool cloneClusters() { return cloneClusters_; }
     inline void setCloneClusters(bool w) { cloneClusters_ = w; }
 
     //------------------------------------------------------------------
     //!  Put tracks, track extras and hits+clusters into the event.
     //------------------------------------------------------------------
-    edm::OrphanHandle<reco::MuonCollection> put( edm::Event & evt );
+    edm::OrphanHandle<reco::MuonCollection> put(edm::Event &evt);
 
     //------------------------------------------------------------------
     //!  Get the size.
     //------------------------------------------------------------------
     inline size_t size() const { return selMuons_->size(); }
-    
 
     //------------------------------------------------------------------
     //! \brief Method to clone tracks, track extras and their hits and clusters.
     //! typename I = this is an interator over a Muon collection, **I needs
     //! to dereference into a Muon.
     //------------------------------------------------------------------
-    template<typename I>
-    void cloneAndStore( const I & begin, const I & end, edm::Event & evt ) ;
-    
+    template <typename I>
+    void cloneAndStore(const I &begin, const I &end, edm::Event &evt);
+
   private:
-     //--- Collections to store:
+    //--- Collections to store:
     std::unique_ptr<reco::MuonCollection> selMuons_;
     std::unique_ptr<reco::TrackCollection> selTracks_;
     std::unique_ptr<reco::TrackExtraCollection> selTracksExtras_;
@@ -72,19 +71,19 @@ namespace helper {
     std::unique_ptr<reco::TrackCollection> selStandAloneTracks_;
     std::unique_ptr<reco::TrackExtraCollection> selStandAloneTracksExtras_;
     std::unique_ptr<TrackingRecHitCollection> selStandAloneTracksHits_;
-    std::unique_ptr< edmNew::DetSetVector<SiStripCluster> >  selStripClusters_;
-    std::unique_ptr< edmNew::DetSetVector<SiPixelCluster> >  selPixelClusters_;
+    std::unique_ptr<edmNew::DetSetVector<SiStripCluster> > selStripClusters_;
+    std::unique_ptr<edmNew::DetSetVector<SiPixelCluster> > selPixelClusters_;
 
-    reco::MuonRefProd rMuons_;      
-    reco::TrackRefProd rTracks_;      
+    reco::MuonRefProd rMuons_;
+    reco::TrackRefProd rTracks_;
     reco::TrackExtraRefProd rTrackExtras_;
     TrackingRecHitRefProd rHits_;
 
-    reco::TrackRefProd rGBTracks_;      
+    reco::TrackRefProd rGBTracks_;
     reco::TrackExtraRefProd rGBTrackExtras_;
     TrackingRecHitRefProd rGBHits_;
-    
-    reco::TrackRefProd rSATracks_;      
+
+    reco::TrackRefProd rSATracks_;
     reco::TrackExtraRefProd rSATrackExtras_;
     TrackingRecHitRefProd rSAHits_;
 
@@ -95,87 +94,87 @@ namespace helper {
     //--- Indices into collections handled with RefProd
     size_t id_, igbd_, isad_, idx_, igbdx_, isadx_, hidx_, higbdx_, hisadx_;
 
-    //--- Switches 
-    bool   cloneClusters_ ;  //!< Clone clusters, or not?  Default: true.
-    
+    //--- Switches
+    bool cloneClusters_;  //!< Clone clusters, or not?  Default: true.
+
     //--- Methods
     //------------------------------------------------------------------
-    //!  Process a single muon.  
+    //!  Process a single muon.
     //------------------------------------------------------------------
-    void processMuon( const reco::Muon & mu );
+    void processMuon(const reco::Muon &mu);
 
     bool clusterRefsOK(const reco::Track &track) const;
   };
   // (end of struct MuonCollectionStoreManager)
- 
-  template<typename I>
-  void 
-  MuonCollectionStoreManager::cloneAndStore( const I & begin, const I & end, edm::Event & evt ) 
-  {
-      using namespace reco;
-      rHits_ = evt.template getRefBeforePut<TrackingRecHitCollection>("TrackerOnly");
-      rGBHits_ = evt.template getRefBeforePut<TrackingRecHitCollection>("GlobalMuon");
-      rSAHits_ = evt.template getRefBeforePut<TrackingRecHitCollection>("StandAlone");
-      rTrackExtras_ = evt.template getRefBeforePut<TrackExtraCollection>("TrackerOnly");
-      rGBTrackExtras_ = evt.template getRefBeforePut<TrackExtraCollection>("GlobalMuon");
-      rSATrackExtras_ = evt.template getRefBeforePut<TrackExtraCollection>("StandAlone");
-      rTracks_ = evt.template getRefBeforePut<TrackCollection>("TrackerOnly");      
-      rGBTracks_ = evt.template getRefBeforePut<TrackCollection>("GlobalMuon");      
-      rSATracks_ = evt.template getRefBeforePut<TrackCollection>("StandAlone");      
-      rMuons_ = evt.template getRefBeforePut<MuonCollection>("SelectedMuons");      
-      //--- New: save clusters too
-      edm::RefProd<edmNew::DetSetVector<SiStripCluster> > rStripClusters
-	= evt.template getRefBeforePut<edmNew::DetSetVector<SiStripCluster> >();
 
-      edm::RefProd<edmNew::DetSetVector<SiPixelCluster> >  rPixelClusters 
-	= evt.template getRefBeforePut<edmNew::DetSetVector<SiPixelCluster> >();
+  template <typename I>
+  void MuonCollectionStoreManager::cloneAndStore(const I &begin, const I &end, edm::Event &evt) {
+    using namespace reco;
+    rHits_ = evt.template getRefBeforePut<TrackingRecHitCollection>("TrackerOnly");
+    rGBHits_ = evt.template getRefBeforePut<TrackingRecHitCollection>("GlobalMuon");
+    rSAHits_ = evt.template getRefBeforePut<TrackingRecHitCollection>("StandAlone");
+    rTrackExtras_ = evt.template getRefBeforePut<TrackExtraCollection>("TrackerOnly");
+    rGBTrackExtras_ = evt.template getRefBeforePut<TrackExtraCollection>("GlobalMuon");
+    rSATrackExtras_ = evt.template getRefBeforePut<TrackExtraCollection>("StandAlone");
+    rTracks_ = evt.template getRefBeforePut<TrackCollection>("TrackerOnly");
+    rGBTracks_ = evt.template getRefBeforePut<TrackCollection>("GlobalMuon");
+    rSATracks_ = evt.template getRefBeforePut<TrackCollection>("StandAlone");
+    rMuons_ = evt.template getRefBeforePut<MuonCollection>("SelectedMuons");
+    //--- New: save clusters too
+    edm::RefProd<edmNew::DetSetVector<SiStripCluster> > rStripClusters =
+        evt.template getRefBeforePut<edmNew::DetSetVector<SiStripCluster> >();
 
-      id_=0; igbd_=0; isad_=0; 
-      idx_ = 0; igbdx_=0; isadx_=0; 
-      hidx_=0; higbdx_=0; hisadx_=0;
-      clusterStorer_.clear();
+    edm::RefProd<edmNew::DetSetVector<SiPixelCluster> > rPixelClusters =
+        evt.template getRefBeforePut<edmNew::DetSetVector<SiPixelCluster> >();
 
-      for( I i = begin; i != end; ++ i ) {
-	const Muon & mu = * * i;
-          //--- Clone this track, and store references aside
-          processMuon( mu );
-      }
-      //--- Clone the clusters and fixup refs
-      clusterStorer_.processAllClusters(*selPixelClusters_, rPixelClusters,
-					*selStripClusters_, rStripClusters);
-   }
-    
+    id_ = 0;
+    igbd_ = 0;
+    isad_ = 0;
+    idx_ = 0;
+    igbdx_ = 0;
+    isadx_ = 0;
+    hidx_ = 0;
+    higbdx_ = 0;
+    hisadx_ = 0;
+    clusterStorer_.clear();
+
+    for (I i = begin; i != end; ++i) {
+      const Muon &mu = **i;
+      //--- Clone this track, and store references aside
+      processMuon(mu);
+    }
+    //--- Clone the clusters and fixup refs
+    clusterStorer_.processAllClusters(*selPixelClusters_, rPixelClusters, *selStripClusters_, rStripClusters);
+  }
+
   //----------------------------------------------------------------------
   class MuonSelectorBase : public edm::EDFilter {
   public:
-    MuonSelectorBase( const edm::ParameterSet & cfg ) {
-      std::string alias( cfg.getParameter<std::string>( "@module_label" ) );
+    MuonSelectorBase(const edm::ParameterSet &cfg) {
+      std::string alias(cfg.getParameter<std::string>("@module_label"));
 
-
-      produces<reco::MuonCollection>("SelectedMuons").setBranchAlias( alias + "SelectedMuons" );
-      produces<reco::TrackCollection>("TrackerOnly").setBranchAlias( alias + "TrackerOnlyTracks" );
-      produces<reco::TrackExtraCollection>("TrackerOnly").setBranchAlias( alias + "TrackerOnlyExtras" );
-      produces<TrackingRecHitCollection>("TrackerOnly").setBranchAlias( alias + "TrackerOnlyHits" );
+      produces<reco::MuonCollection>("SelectedMuons").setBranchAlias(alias + "SelectedMuons");
+      produces<reco::TrackCollection>("TrackerOnly").setBranchAlias(alias + "TrackerOnlyTracks");
+      produces<reco::TrackExtraCollection>("TrackerOnly").setBranchAlias(alias + "TrackerOnlyExtras");
+      produces<TrackingRecHitCollection>("TrackerOnly").setBranchAlias(alias + "TrackerOnlyHits");
       //--- New: save clusters too
-      produces< edmNew::DetSetVector<SiPixelCluster> >().setBranchAlias( alias + "PixelClusters" );
-      produces< edmNew::DetSetVector<SiStripCluster> >().setBranchAlias( alias + "StripClusters" );
-      produces<reco::TrackCollection>("GlobalMuon").setBranchAlias( alias + "GlobalMuonTracks" );
-      produces<reco::TrackExtraCollection>("GlobalMuon").setBranchAlias( alias + "GlobalMuonExtras" );
-      produces<TrackingRecHitCollection>("GlobalMuon").setBranchAlias( alias + "GlobalMuonHits" );
-      produces<reco::TrackCollection>("StandAlone").setBranchAlias( alias + "StandAloneTracks" );
-      produces<reco::TrackExtraCollection>("StandAlone").setBranchAlias( alias + "StandAloneExtras" );
-      produces<TrackingRecHitCollection>("StandAlone").setBranchAlias( alias + "StandAloneHits" );
-
+      produces<edmNew::DetSetVector<SiPixelCluster> >().setBranchAlias(alias + "PixelClusters");
+      produces<edmNew::DetSetVector<SiStripCluster> >().setBranchAlias(alias + "StripClusters");
+      produces<reco::TrackCollection>("GlobalMuon").setBranchAlias(alias + "GlobalMuonTracks");
+      produces<reco::TrackExtraCollection>("GlobalMuon").setBranchAlias(alias + "GlobalMuonExtras");
+      produces<TrackingRecHitCollection>("GlobalMuon").setBranchAlias(alias + "GlobalMuonHits");
+      produces<reco::TrackCollection>("StandAlone").setBranchAlias(alias + "StandAloneTracks");
+      produces<reco::TrackExtraCollection>("StandAlone").setBranchAlias(alias + "StandAloneExtras");
+      produces<TrackingRecHitCollection>("StandAlone").setBranchAlias(alias + "StandAloneHits");
     }
-   }; // (end of class MuonSelectorBase)
+  };  // (end of class MuonSelectorBase)
 
-
-  template<>
+  template <>
   struct StoreManagerTrait<reco::MuonCollection> {
     typedef MuonCollectionStoreManager type;
     typedef MuonSelectorBase base;
   };
 
-}
+}  // namespace helper
 
 #endif

--- a/CommonTools/RecoAlgos/interface/PrimaryVertexAssignment.h
+++ b/CommonTools/RecoAlgos/interface/PrimaryVertexAssignment.h
@@ -16,93 +16,102 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
 class PrimaryVertexAssignment {
- public:
-  enum Quality {UsedInFit=7,PrimaryDz=6,PrimaryV0=5,BTrack=4,Unused=3,OtherDz=2,NotReconstructedPrimary=1,Unassigned=0};
- 
-  PrimaryVertexAssignment(const edm::ParameterSet& iConfig):
-   maxDzSigForPrimaryAssignment_(iConfig.getParameter<double>("maxDzSigForPrimaryAssignment")),
-   maxDzForPrimaryAssignment_(iConfig.getParameter<double>("maxDzForPrimaryAssignment")),
-   maxDzErrorForPrimaryAssignment_(iConfig.getParameter<double>("maxDzErrorForPrimaryAssignment")),
-   maxDtSigForPrimaryAssignment_(iConfig.getParameter<double>("maxDtSigForPrimaryAssignment")),   
-   maxJetDeltaR_(iConfig.getParameter<double>("maxJetDeltaR")),
-   minJetPt_(iConfig.getParameter<double>("minJetPt")),
-   maxDistanceToJetAxis_(iConfig.getParameter<double>("maxDistanceToJetAxis")),
-   maxDzForJetAxisAssigment_(iConfig.getParameter<double>("maxDzForJetAxisAssigment")),
-   maxDxyForJetAxisAssigment_(iConfig.getParameter<double>("maxDxyForJetAxisAssigment")),
-   maxDxySigForNotReconstructedPrimary_(iConfig.getParameter<double>("maxDxySigForNotReconstructedPrimary")),
-   maxDxyForNotReconstructedPrimary_(iConfig.getParameter<double>("maxDxyForNotReconstructedPrimary")),
-   useTiming_(iConfig.getParameter<bool>("useTiming")),
-   preferHighRanked_(iConfig.getParameter<bool>("preferHighRanked"))
-  {}
+public:
+  enum Quality {
+    UsedInFit = 7,
+    PrimaryDz = 6,
+    PrimaryV0 = 5,
+    BTrack = 4,
+    Unused = 3,
+    OtherDz = 2,
+    NotReconstructedPrimary = 1,
+    Unassigned = 0
+  };
 
-  ~PrimaryVertexAssignment(){}
+  PrimaryVertexAssignment(const edm::ParameterSet& iConfig)
+      : maxDzSigForPrimaryAssignment_(iConfig.getParameter<double>("maxDzSigForPrimaryAssignment")),
+        maxDzForPrimaryAssignment_(iConfig.getParameter<double>("maxDzForPrimaryAssignment")),
+        maxDzErrorForPrimaryAssignment_(iConfig.getParameter<double>("maxDzErrorForPrimaryAssignment")),
+        maxDtSigForPrimaryAssignment_(iConfig.getParameter<double>("maxDtSigForPrimaryAssignment")),
+        maxJetDeltaR_(iConfig.getParameter<double>("maxJetDeltaR")),
+        minJetPt_(iConfig.getParameter<double>("minJetPt")),
+        maxDistanceToJetAxis_(iConfig.getParameter<double>("maxDistanceToJetAxis")),
+        maxDzForJetAxisAssigment_(iConfig.getParameter<double>("maxDzForJetAxisAssigment")),
+        maxDxyForJetAxisAssigment_(iConfig.getParameter<double>("maxDxyForJetAxisAssigment")),
+        maxDxySigForNotReconstructedPrimary_(iConfig.getParameter<double>("maxDxySigForNotReconstructedPrimary")),
+        maxDxyForNotReconstructedPrimary_(iConfig.getParameter<double>("maxDxyForNotReconstructedPrimary")),
+        useTiming_(iConfig.getParameter<bool>("useTiming")),
+        preferHighRanked_(iConfig.getParameter<bool>("preferHighRanked")) {}
 
-  std::pair<int,PrimaryVertexAssignment::Quality> chargedHadronVertex(const reco::VertexCollection& vertices, 
-               const reco::TrackRef& trackRef,
-               const reco::Track * track,
-               float trackTime, 
-               float trackTimeResolution, // <0 if timing not available for this object
-               const edm::View<reco::Candidate> & jets,
-              const TransientTrackBuilder & builder) const;
+  ~PrimaryVertexAssignment() {}
 
-  std::pair<int,PrimaryVertexAssignment::Quality> chargedHadronVertex(const reco::VertexCollection& vertices,
-               const reco::TrackRef& trackRef,
-               float trackTime, 
-               float trackTimeResolution, // <0 if timing not available for this object
-               const edm::View<reco::Candidate> & jets,
-              const TransientTrackBuilder & builder) const
- {
-	return chargedHadronVertex(vertices,trackRef,&(*trackRef),trackTime,trackTimeResolution,jets,builder);
- }
+  std::pair<int, PrimaryVertexAssignment::Quality> chargedHadronVertex(
+      const reco::VertexCollection& vertices,
+      const reco::TrackRef& trackRef,
+      const reco::Track* track,
+      float trackTime,
+      float trackTimeResolution,  // <0 if timing not available for this object
+      const edm::View<reco::Candidate>& jets,
+      const TransientTrackBuilder& builder) const;
 
-  std::pair<int,PrimaryVertexAssignment::Quality> chargedHadronVertex( const reco::VertexCollection& vertices,
-                                   const reco::PFCandidate& pfcand,
-                                   const edm::View<reco::Candidate>& jets,
-                                   const TransientTrackBuilder& builder) const {
-          float time = 0, timeResolution = -1;
-          if (useTiming_ && pfcand.isTimeValid()) { 
-              time = pfcand.time(); timeResolution = pfcand.timeError();
-          }
-	  if(pfcand.gsfTrackRef().isNull())
-	  {
-		  if(pfcand.trackRef().isNull())
-			  return std::pair<int,PrimaryVertexAssignment::Quality>(-1,PrimaryVertexAssignment::Unassigned);
-		  else 
-			  return chargedHadronVertex(vertices,pfcand.trackRef(),time,timeResolution,jets,builder);
-	  }
-	  return chargedHadronVertex(vertices,reco::TrackRef(),&(*pfcand.gsfTrackRef()),time,timeResolution,jets,builder);
-  }
-  std::pair<int,PrimaryVertexAssignment::Quality> chargedHadronVertex( const reco::VertexCollection& vertices,
-                                   const reco::RecoChargedRefCandidate& chcand,
-                                   const edm::ValueMap<float> *trackTimeTag,
-                                   const edm::ValueMap<float> *trackTimeResoTag,
-                                   const edm::View<reco::Candidate>& jets,
-                                   const TransientTrackBuilder& builder) const {
-      float time = 0, timeResolution = -1;
-      if (useTiming_) {
-        time = (*trackTimeTag)[chcand.track()];
-        timeResolution = (*trackTimeResoTag)[chcand.track()]; 
-      }
-      if(chcand.track().isNull())
-         return std::pair<int,PrimaryVertexAssignment::Quality>(-1,PrimaryVertexAssignment::Unassigned);
-      return chargedHadronVertex(vertices,chcand.track(),time,timeResolution,jets,builder);
+  std::pair<int, PrimaryVertexAssignment::Quality> chargedHadronVertex(
+      const reco::VertexCollection& vertices,
+      const reco::TrackRef& trackRef,
+      float trackTime,
+      float trackTimeResolution,  // <0 if timing not available for this object
+      const edm::View<reco::Candidate>& jets,
+      const TransientTrackBuilder& builder) const {
+    return chargedHadronVertex(vertices, trackRef, &(*trackRef), trackTime, trackTimeResolution, jets, builder);
   }
 
+  std::pair<int, PrimaryVertexAssignment::Quality> chargedHadronVertex(const reco::VertexCollection& vertices,
+                                                                       const reco::PFCandidate& pfcand,
+                                                                       const edm::View<reco::Candidate>& jets,
+                                                                       const TransientTrackBuilder& builder) const {
+    float time = 0, timeResolution = -1;
+    if (useTiming_ && pfcand.isTimeValid()) {
+      time = pfcand.time();
+      timeResolution = pfcand.timeError();
+    }
+    if (pfcand.gsfTrackRef().isNull()) {
+      if (pfcand.trackRef().isNull())
+        return std::pair<int, PrimaryVertexAssignment::Quality>(-1, PrimaryVertexAssignment::Unassigned);
+      else
+        return chargedHadronVertex(vertices, pfcand.trackRef(), time, timeResolution, jets, builder);
+    }
+    return chargedHadronVertex(
+        vertices, reco::TrackRef(), &(*pfcand.gsfTrackRef()), time, timeResolution, jets, builder);
+  }
+  std::pair<int, PrimaryVertexAssignment::Quality> chargedHadronVertex(const reco::VertexCollection& vertices,
+                                                                       const reco::RecoChargedRefCandidate& chcand,
+                                                                       const edm::ValueMap<float>* trackTimeTag,
+                                                                       const edm::ValueMap<float>* trackTimeResoTag,
+                                                                       const edm::View<reco::Candidate>& jets,
+                                                                       const TransientTrackBuilder& builder) const {
+    float time = 0, timeResolution = -1;
+    if (useTiming_) {
+      time = (*trackTimeTag)[chcand.track()];
+      timeResolution = (*trackTimeResoTag)[chcand.track()];
+    }
+    if (chcand.track().isNull())
+      return std::pair<int, PrimaryVertexAssignment::Quality>(-1, PrimaryVertexAssignment::Unassigned);
+    return chargedHadronVertex(vertices, chcand.track(), time, timeResolution, jets, builder);
+  }
 
- private  :
-    double    maxDzSigForPrimaryAssignment_;
-    double    maxDzForPrimaryAssignment_;
-    double    maxDzErrorForPrimaryAssignment_;
-    double    maxDtSigForPrimaryAssignment_;
-    double    maxJetDeltaR_;
-    double    minJetPt_;
-    double    maxDistanceToJetAxis_;
-    double    maxDzForJetAxisAssigment_;
-    double    maxDxyForJetAxisAssigment_;
-    double    maxDxySigForNotReconstructedPrimary_;
-    double    maxDxyForNotReconstructedPrimary_;
-    bool      useTiming_;
-    bool      preferHighRanked_;
+private:
+  double maxDzSigForPrimaryAssignment_;
+  double maxDzForPrimaryAssignment_;
+  double maxDzErrorForPrimaryAssignment_;
+  double maxDtSigForPrimaryAssignment_;
+  double maxJetDeltaR_;
+  double minJetPt_;
+  double maxDistanceToJetAxis_;
+  double maxDzForJetAxisAssigment_;
+  double maxDxyForJetAxisAssigment_;
+  double maxDxySigForNotReconstructedPrimary_;
+  double maxDxyForNotReconstructedPrimary_;
+  bool useTiming_;
+  bool preferHighRanked_;
 };
 
 #endif

--- a/CommonTools/RecoAlgos/interface/PrimaryVertexSorting.h
+++ b/CommonTools/RecoAlgos/interface/PrimaryVertexSorting.h
@@ -12,23 +12,18 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "CommonTools/RecoAlgos/interface/PrimaryVertexAssignment.h"
 
-
-
 class PrimaryVertexSorting {
- public:
-  enum Quality {UsedInFit=0,PrimaryDz,BTrack,OtherDz,NotReconstructedPrimary,Unassigned=99};
- 
+public:
+  enum Quality { UsedInFit = 0, PrimaryDz, BTrack, OtherDz, NotReconstructedPrimary, Unassigned = 99 };
+
   PrimaryVertexSorting(const edm::ParameterSet& iConfig)
-   //minJetPt_(iConfig.getParameter<double>("minJetPt")),
+  //minJetPt_(iConfig.getParameter<double>("minJetPt")),
   {}
 
-  ~PrimaryVertexSorting(){}
-  float score(const reco::Vertex & pv, const std::vector<const reco::Candidate *> & candidates , bool useMet) const ;
+  ~PrimaryVertexSorting() {}
+  float score(const reco::Vertex& pv, const std::vector<const reco::Candidate*>& candidates, bool useMet) const;
 
-
-
-
- private  :
+private:
 };
 
 #endif

--- a/CommonTools/RecoAlgos/interface/RecoTrackRefSelector.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackRefSelector.h
@@ -8,7 +8,7 @@
 #include "CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h"
 
 class RecoTrackRefSelector : public RecoTrackSelectorBase {
- public:
+public:
   typedef reco::TrackCollection collection;
   typedef reco::TrackRefVector ref_container;
   typedef ref_container::const_iterator const_ref_iterator;
@@ -16,25 +16,25 @@ class RecoTrackRefSelector : public RecoTrackSelectorBase {
   /// Constructors
   RecoTrackRefSelector() {}
 
-  RecoTrackRefSelector ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) : RecoTrackSelectorBase(cfg, iC) {}
+  RecoTrackRefSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) : RecoTrackSelectorBase(cfg, iC) {}
 
   const_ref_iterator begin() const { return ref_selected_.begin(); }
   const_ref_iterator end() const { return ref_selected_.end(); }
 
-  void select( const edm::Handle<collection>& c, const edm::Event & event, const edm::EventSetup&es) {
+  void select(const edm::Handle<collection>& c, const edm::Event& event, const edm::EventSetup& es) {
     init(event, es);
     ref_selected_.clear();
     for (unsigned int i = 0; i < c->size(); i++) {
       edm::Ref<collection> trk(c, i);
-      if ( operator()(*trk) ) {
-	ref_selected_.push_back( trk );
+      if (operator()(*trk)) {
+        ref_selected_.push_back(trk);
       }
     }
   }
 
   size_t size() const { return ref_selected_.size(); }
 
- private:
+private:
   ref_container ref_selected_;
 };
 

--- a/CommonTools/RecoAlgos/interface/RecoTrackSelector.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelector.h
@@ -7,36 +7,34 @@
  */
 #include "CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h"
 
-class RecoTrackSelector: public RecoTrackSelectorBase {
- public:
+class RecoTrackSelector : public RecoTrackSelectorBase {
+public:
   typedef reco::TrackRef reference_type;
   typedef reco::TrackCollection collection;
-  typedef std::vector<const reco::Track *> container;
+  typedef std::vector<const reco::Track*> container;
   typedef container::const_iterator const_iterator;
 
   /// Constructors
   RecoTrackSelector() {}
-  RecoTrackSelector ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-    RecoTrackSelectorBase( cfg, iC ) {}
+  RecoTrackSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) : RecoTrackSelectorBase(cfg, iC) {}
 
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
 
-  void select( const edm::Handle<collection>& c, const edm::Event & event, const edm::EventSetup&es) {
-    init(event,es);
+  void select(const edm::Handle<collection>& c, const edm::Event& event, const edm::EventSetup& es) {
+    init(event, es);
     selected_.clear();
-    for( reco::TrackCollection::const_iterator trk = c->begin();
-         trk != c->end(); ++ trk ) {
-      reference_type tkref(c,std::distance(c->begin(),trk));
-      if ( operator()(*tkref) ) {
-	selected_.push_back( & * trk );
+    for (reco::TrackCollection::const_iterator trk = c->begin(); trk != c->end(); ++trk) {
+      reference_type tkref(c, std::distance(c->begin(), trk));
+      if (operator()(*tkref)) {
+        selected_.push_back(&*trk);
       }
     }
   }
 
   size_t size() const { return selected_.size(); }
 
- private:
+private:
   container selected_;
 };
 

--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -16,44 +16,49 @@
 class RecoTrackSelectorBase {
 public:
   RecoTrackSelectorBase() {}
-  RecoTrackSelectorBase(const edm::ParameterSet & cfg):
-    ptMin_(cfg.getParameter<double>("ptMin")),
-    minRapidity_(cfg.getParameter<double>("minRapidity")),
-    maxRapidity_(cfg.getParameter<double>("maxRapidity")),
-    meanPhi_((cfg.getParameter<double>("minPhi")+cfg.getParameter<double>("maxPhi"))/2.),
-    rangePhi_((cfg.getParameter<double>("maxPhi")-cfg.getParameter<double>("minPhi"))/2.),
-    tip_(cfg.getParameter<double>("tip")),
-    lip_(cfg.getParameter<double>("lip")),
-    maxChi2_(cfg.getParameter<double>("maxChi2")),
-    minHit_(cfg.getParameter<int>("minHit")),
-    minPixelHit_(cfg.getParameter<int>("minPixelHit")),
-    minLayer_(cfg.getParameter<int>("minLayer")),
-    min3DLayer_(cfg.getParameter<int>("min3DLayer")),
-    usePV_(false) {
-      const auto minPhi = cfg.getParameter<double>("minPhi");
-      const auto maxPhi = cfg.getParameter<double>("maxPhi");
-      if(minPhi >= maxPhi) {
-        throw cms::Exception("Configuration") << "RecoTrackSelectorPhase: minPhi (" << minPhi << ") must be smaller than maxPhi (" << maxPhi << "). The range is constructed from minPhi to maxPhi around their average.";
-      }
-      if(minPhi >= M_PI) {
-        throw cms::Exception("Configuration") << "RecoTrackSelectorPhase: minPhi (" << minPhi << ") must be smaller than PI. The range is constructed from minPhi to maxPhi around their average.";
-      }
-      if(maxPhi <= -M_PI) {
-        throw cms::Exception("Configuration") << "RecoTrackSelectorPhase: maxPhi (" << maxPhi << ") must be larger than -PI. The range is constructed from minPhi to maxPhi around their average.";
-      }
-
-      for(const std::string& quality: cfg.getParameter<std::vector<std::string> >("quality"))
-        quality_.push_back(reco::TrackBase::qualityByName(quality));
-      for(const std::string& algorithm: cfg.getParameter<std::vector<std::string> >("algorithm"))
-        algorithm_.push_back(reco::TrackBase::algoByName(algorithm));
-      for(const std::string& algorithm: cfg.getParameter<std::vector<std::string> >("originalAlgorithm"))
-        originalAlgorithm_.push_back(reco::TrackBase::algoByName(algorithm));
-      for(const std::string& algorithm: cfg.getParameter<std::vector<std::string> >("algorithmMaskContains"))
-        algorithmMask_.push_back(reco::TrackBase::algoByName(algorithm));
+  RecoTrackSelectorBase(const edm::ParameterSet& cfg)
+      : ptMin_(cfg.getParameter<double>("ptMin")),
+        minRapidity_(cfg.getParameter<double>("minRapidity")),
+        maxRapidity_(cfg.getParameter<double>("maxRapidity")),
+        meanPhi_((cfg.getParameter<double>("minPhi") + cfg.getParameter<double>("maxPhi")) / 2.),
+        rangePhi_((cfg.getParameter<double>("maxPhi") - cfg.getParameter<double>("minPhi")) / 2.),
+        tip_(cfg.getParameter<double>("tip")),
+        lip_(cfg.getParameter<double>("lip")),
+        maxChi2_(cfg.getParameter<double>("maxChi2")),
+        minHit_(cfg.getParameter<int>("minHit")),
+        minPixelHit_(cfg.getParameter<int>("minPixelHit")),
+        minLayer_(cfg.getParameter<int>("minLayer")),
+        min3DLayer_(cfg.getParameter<int>("min3DLayer")),
+        usePV_(false) {
+    const auto minPhi = cfg.getParameter<double>("minPhi");
+    const auto maxPhi = cfg.getParameter<double>("maxPhi");
+    if (minPhi >= maxPhi) {
+      throw cms::Exception("Configuration")
+          << "RecoTrackSelectorPhase: minPhi (" << minPhi << ") must be smaller than maxPhi (" << maxPhi
+          << "). The range is constructed from minPhi to maxPhi around their average.";
+    }
+    if (minPhi >= M_PI) {
+      throw cms::Exception("Configuration")
+          << "RecoTrackSelectorPhase: minPhi (" << minPhi
+          << ") must be smaller than PI. The range is constructed from minPhi to maxPhi around their average.";
+    }
+    if (maxPhi <= -M_PI) {
+      throw cms::Exception("Configuration")
+          << "RecoTrackSelectorPhase: maxPhi (" << maxPhi
+          << ") must be larger than -PI. The range is constructed from minPhi to maxPhi around their average.";
     }
 
-  RecoTrackSelectorBase(const edm::ParameterSet & cfg, edm::ConsumesCollector & iC):
-    RecoTrackSelectorBase(cfg) {
+    for (const std::string& quality : cfg.getParameter<std::vector<std::string> >("quality"))
+      quality_.push_back(reco::TrackBase::qualityByName(quality));
+    for (const std::string& algorithm : cfg.getParameter<std::vector<std::string> >("algorithm"))
+      algorithm_.push_back(reco::TrackBase::algoByName(algorithm));
+    for (const std::string& algorithm : cfg.getParameter<std::vector<std::string> >("originalAlgorithm"))
+      originalAlgorithm_.push_back(reco::TrackBase::algoByName(algorithm));
+    for (const std::string& algorithm : cfg.getParameter<std::vector<std::string> >("algorithmMaskContains"))
+      algorithmMask_.push_back(reco::TrackBase::algoByName(algorithm));
+  }
+
+  RecoTrackSelectorBase(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) : RecoTrackSelectorBase(cfg) {
     usePV_ = cfg.getParameter<bool>("usePV");
     bsSrcToken_ = iC.consumes<reco::BeamSpot>(cfg.getParameter<edm::InputTag>("beamSpot"));
     if (usePV_)
@@ -61,69 +66,65 @@ public:
   }
 
   void init(const edm::Event& event, const edm::EventSetup& es) {
-     edm::Handle<reco::BeamSpot> beamSpot;
-     event.getByToken(bsSrcToken_,beamSpot);
-     vertex_ = beamSpot->position();
-     if (!usePV_) return;
-     edm::Handle<reco::VertexCollection> hVtx;
-     event.getByToken(vertexToken_, hVtx);
-     if (hVtx->empty()) return;
-     vertex_ = (*hVtx)[0].position();
+    edm::Handle<reco::BeamSpot> beamSpot;
+    event.getByToken(bsSrcToken_, beamSpot);
+    vertex_ = beamSpot->position();
+    if (!usePV_)
+      return;
+    edm::Handle<reco::VertexCollection> hVtx;
+    event.getByToken(vertexToken_, hVtx);
+    if (hVtx->empty())
+      return;
+    vertex_ = (*hVtx)[0].position();
   }
 
-  bool operator()( const reco::TrackRef& tref ) const {
-    return (*this)(*tref);
-  }
+  bool operator()(const reco::TrackRef& tref) const { return (*this)(*tref); }
 
-  bool operator()( const reco::Track & t) const {
-    return (*this)(t, vertex_);
-  }
+  bool operator()(const reco::Track& t) const { return (*this)(t, vertex_); }
 
   bool operator()(const reco::Track& t, const reco::Track::Point& vertex) const {
-
     bool quality_ok = true;
     if (!quality_.empty()) {
       quality_ok = false;
-      for (unsigned int i = 0; i<quality_.size();++i) {
-	if (t.quality(quality_[i])){
-	  quality_ok = true;
-	  break;
-	}
+      for (unsigned int i = 0; i < quality_.size(); ++i) {
+        if (t.quality(quality_[i])) {
+          quality_ok = true;
+          break;
+        }
       }
     }
 
     bool algo_ok = true;
     if (!algorithm_.empty()) {
-      if (std::find(algorithm_.begin(),algorithm_.end(),t.algo())==algorithm_.end()) algo_ok = false;
+      if (std::find(algorithm_.begin(), algorithm_.end(), t.algo()) == algorithm_.end())
+        algo_ok = false;
     }
     if (!originalAlgorithm_.empty() && algo_ok) {
-      if (std::find(originalAlgorithm_.begin(), originalAlgorithm_.end(), t.originalAlgo()) == originalAlgorithm_.end()) algo_ok = false;
+      if (std::find(originalAlgorithm_.begin(), originalAlgorithm_.end(), t.originalAlgo()) == originalAlgorithm_.end())
+        algo_ok = false;
     }
-    if(!algorithmMask_.empty() && algo_ok) {
-      if(std::find_if(algorithmMask_.begin(), algorithmMask_.end(), [&](reco::TrackBase::TrackAlgorithm algo) -> bool { // for some reason I have to either explicitly give the return type, or use static_cast<bool>()
-            return t.algoMask()[algo];
-          }) == algorithmMask_.end()) algo_ok = false;
+    if (!algorithmMask_.empty() && algo_ok) {
+      if (std::find_if(
+              algorithmMask_.begin(),
+              algorithmMask_.end(),
+              [&](reco::TrackBase::TrackAlgorithm algo)
+                  -> bool {  // for some reason I have to either explicitly give the return type, or use static_cast<bool>()
+                return t.algoMask()[algo];
+              }) == algorithmMask_.end())
+        algo_ok = false;
     }
 
     const auto dphi = deltaPhi(t.phi(), meanPhi_);
 
-    return
-      (
-       (algo_ok & quality_ok) &&
-       t.hitPattern().numberOfValidHits() >= minHit_ &&
-       t.hitPattern().numberOfValidPixelHits() >= minPixelHit_ &&
-       t.hitPattern().trackerLayersWithMeasurement() >= minLayer_ &&
-       t.hitPattern().pixelLayersWithMeasurement() +
-       t.hitPattern().numberOfValidStripLayersWithMonoAndStereo() >= min3DLayer_ &&
-       fabs(t.pt()) >= ptMin_ &&
-       t.eta() >= minRapidity_ && t.eta() <= maxRapidity_ &&
-       dphi >= -rangePhi_ && dphi <= rangePhi_ &&
-       fabs(t.dxy(vertex)) <= tip_ &&
-       fabs(t.dsz(vertex)) <= lip_  &&
-       t.normalizedChi2()<=maxChi2_
-      );
+    return ((algo_ok & quality_ok) && t.hitPattern().numberOfValidHits() >= minHit_ &&
+            t.hitPattern().numberOfValidPixelHits() >= minPixelHit_ &&
+            t.hitPattern().trackerLayersWithMeasurement() >= minLayer_ &&
+            t.hitPattern().pixelLayersWithMeasurement() + t.hitPattern().numberOfValidStripLayersWithMonoAndStereo() >=
+                min3DLayer_ &&
+            fabs(t.pt()) >= ptMin_ && t.eta() >= minRapidity_ && t.eta() <= maxRapidity_ && dphi >= -rangePhi_ &&
+            dphi <= rangePhi_ && fabs(t.dxy(vertex)) <= tip_ && fabs(t.dsz(vertex)) <= lip_ &&
+            t.normalizedChi2() <= maxChi2_);
   }
-
 
 private:
   double ptMin_;
@@ -134,10 +135,10 @@ private:
   double tip_;
   double lip_;
   double maxChi2_;
-  int    minHit_;
-  int    minPixelHit_;
-  int    minLayer_;
-  int    min3DLayer_;
+  int minHit_;
+  int minPixelHit_;
+  int minLayer_;
+  int min3DLayer_;
   bool usePV_;
 
   edm::EDGetTokenT<reco::BeamSpot> bsSrcToken_;

--- a/CommonTools/RecoAlgos/interface/RecoTrackViewRefSelector.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackViewRefSelector.h
@@ -5,7 +5,7 @@
 #include "DataFormats/Common/interface/RefToBaseVector.h"
 
 class RecoTrackViewRefSelector : public RecoTrackSelectorBase {
- public:
+public:
   typedef edm::View<reco::Track> collection;
   typedef edm::RefToBaseVector<reco::Track> ref_container;
   typedef ref_container::const_iterator const_ref_iterator;
@@ -13,25 +13,26 @@ class RecoTrackViewRefSelector : public RecoTrackSelectorBase {
   /// Constructors
   RecoTrackViewRefSelector() {}
 
-  RecoTrackViewRefSelector ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) : RecoTrackSelectorBase(cfg, iC) {}
+  RecoTrackViewRefSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : RecoTrackSelectorBase(cfg, iC) {}
 
   const_ref_iterator begin() const { return ref_selected_.begin(); }
   const_ref_iterator end() const { return ref_selected_.end(); }
 
-  void select( const edm::Handle<collection>& c, const edm::Event & event, const edm::EventSetup&es) {
+  void select(const edm::Handle<collection>& c, const edm::Event& event, const edm::EventSetup& es) {
     init(event, es);
     ref_selected_.clear();
     for (unsigned int i = 0; i < c->size(); i++) {
       auto trk = c->refAt(i);
-      if ( operator()(*trk) ) {
-	ref_selected_.push_back( trk );
+      if (operator()(*trk)) {
+        ref_selected_.push_back(trk);
       }
     }
   }
 
   size_t size() const { return ref_selected_.size(); }
 
- private:
+private:
   ref_container ref_selected_;
 };
 

--- a/CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h
@@ -29,139 +29,149 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
+namespace reco {
+  namespace modules {
 
-namespace reco { namespace modules {
-
-template<typename Selector>
-class TrackFullCloneSelectorBase : public edm::stream::EDProducer<> {
-public:
-  /// constructor
-  explicit TrackFullCloneSelectorBase( const edm::ParameterSet & cfg ) :
-    hSrcTrackToken_( consumes<reco::TrackCollection>( cfg.template getParameter<edm::InputTag>( "src" ) ) ),
-    hTrajToken_( mayConsume< std::vector<Trajectory> >( cfg.template getParameter<edm::InputTag>( "src" ) ) ),
-    hTTAssToken_( mayConsume< TrajTrackAssociationCollection >( cfg.template getParameter<edm::InputTag>( "src" ) ) ),
-    copyExtras_(cfg.template getUntrackedParameter<bool>("copyExtras", false)),
-    copyTrajectories_(cfg.template getUntrackedParameter<bool>("copyTrajectories", false)),
-    selector_( cfg, consumesCollector() ) {
-      std::string alias( cfg.getParameter<std::string>( "@module_label" ) );
-      produces<reco::TrackCollection>().setBranchAlias( alias + "Tracks" );
-      if (copyExtras_) {
-          produces<reco::TrackExtraCollection>().setBranchAlias( alias + "TrackExtras" );
-          produces<TrackingRecHitCollection>().setBranchAlias( alias + "RecHits" );
+    template <typename Selector>
+    class TrackFullCloneSelectorBase : public edm::stream::EDProducer<> {
+    public:
+      /// constructor
+      explicit TrackFullCloneSelectorBase(const edm::ParameterSet& cfg)
+          : hSrcTrackToken_(consumes<reco::TrackCollection>(cfg.template getParameter<edm::InputTag>("src"))),
+            hTrajToken_(mayConsume<std::vector<Trajectory> >(cfg.template getParameter<edm::InputTag>("src"))),
+            hTTAssToken_(mayConsume<TrajTrackAssociationCollection>(cfg.template getParameter<edm::InputTag>("src"))),
+            copyExtras_(cfg.template getUntrackedParameter<bool>("copyExtras", false)),
+            copyTrajectories_(cfg.template getUntrackedParameter<bool>("copyTrajectories", false)),
+            selector_(cfg, consumesCollector()) {
+        std::string alias(cfg.getParameter<std::string>("@module_label"));
+        produces<reco::TrackCollection>().setBranchAlias(alias + "Tracks");
+        if (copyExtras_) {
+          produces<reco::TrackExtraCollection>().setBranchAlias(alias + "TrackExtras");
+          produces<TrackingRecHitCollection>().setBranchAlias(alias + "RecHits");
           if (copyTrajectories_) {
-              produces< std::vector<Trajectory> >().setBranchAlias( alias + "Trajectories" );
-              produces< TrajTrackAssociationCollection >().setBranchAlias( alias + "TrajectoryTrackAssociations" );
+            produces<std::vector<Trajectory> >().setBranchAlias(alias + "Trajectories");
+            produces<TrajTrackAssociationCollection>().setBranchAlias(alias + "TrajectoryTrackAssociations");
           }
+        }
       }
-   }
-  /// destructor
-  ~TrackFullCloneSelectorBase() override { }
+      /// destructor
+      ~TrackFullCloneSelectorBase() override {}
 
-private:
-  /// process one event
-  void produce( edm::Event& evt, const edm::EventSetup& es) override {
-      edm::Handle<reco::TrackCollection> hSrcTrack;
-      evt.getByToken( hSrcTrackToken_, hSrcTrack );
+    private:
+      /// process one event
+      void produce(edm::Event& evt, const edm::EventSetup& es) override {
+        edm::Handle<reco::TrackCollection> hSrcTrack;
+        evt.getByToken(hSrcTrackToken_, hSrcTrack);
 
-      selTracks_ = std::unique_ptr<reco::TrackCollection>(new reco::TrackCollection());
-      if (copyExtras_) {
+        selTracks_ = std::unique_ptr<reco::TrackCollection>(new reco::TrackCollection());
+        if (copyExtras_) {
           selTrackExtras_ = std::unique_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection());
           selHits_ = std::unique_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
-      }
+        }
 
-      TrackRefProd rTracks = evt.template getRefBeforePut<TrackCollection>();
+        TrackRefProd rTracks = evt.template getRefBeforePut<TrackCollection>();
 
-      TrackingRecHitRefProd rHits;
-      TrackExtraRefProd rTrackExtras;
-      if (copyExtras_) {
+        TrackingRecHitRefProd rHits;
+        TrackExtraRefProd rTrackExtras;
+        if (copyExtras_) {
           rHits = evt.template getRefBeforePut<TrackingRecHitCollection>();
           rTrackExtras = evt.template getRefBeforePut<TrackExtraCollection>();
-      }
+        }
 
-      typedef reco::TrackRef::key_type TrackRefKey;
-      std::map<TrackRefKey, reco::TrackRef  > goodTracks;
-      TrackRefKey current = 0;
+        typedef reco::TrackRef::key_type TrackRefKey;
+        std::map<TrackRefKey, reco::TrackRef> goodTracks;
+        TrackRefKey current = 0;
 
-      selector_.init(evt,es);
-      auto tkBegin = hSrcTrack->begin();
-      for (reco::TrackCollection::const_iterator it = tkBegin, ed = hSrcTrack->end(); it != ed; ++it, ++current) {
-	  const reco::Track & trk = * it;
-	  const reco::TrackRef tkref(hSrcTrack,std::distance(tkBegin,it));
-          if (!selector_(tkref)) continue;
+        selector_.init(evt, es);
+        auto tkBegin = hSrcTrack->begin();
+        for (reco::TrackCollection::const_iterator it = tkBegin, ed = hSrcTrack->end(); it != ed; ++it, ++current) {
+          const reco::Track& trk = *it;
+          const reco::TrackRef tkref(hSrcTrack, std::distance(tkBegin, it));
+          if (!selector_(tkref))
+            continue;
 
-          selTracks_->push_back( Track( trk ) ); // clone and store
-          if (!copyExtras_) continue;
+          selTracks_->push_back(Track(trk));  // clone and store
+          if (!copyExtras_)
+            continue;
 
           // TrackExtras
-          selTrackExtras_->push_back( TrackExtra( trk.outerPosition(), trk.outerMomentum(), trk.outerOk(),
-                      trk.innerPosition(), trk.innerMomentum(), trk.innerOk(),
-                      trk.outerStateCovariance(), trk.outerDetId(),
-                      trk.innerStateCovariance(), trk.innerDetId(),
-                      trk.seedDirection() ) );
-          selTracks_->back().setExtra( TrackExtraRef( rTrackExtras, selTrackExtras_->size() - 1) );
-          TrackExtra & tx = selTrackExtras_->back();
+          selTrackExtras_->push_back(TrackExtra(trk.outerPosition(),
+                                                trk.outerMomentum(),
+                                                trk.outerOk(),
+                                                trk.innerPosition(),
+                                                trk.innerMomentum(),
+                                                trk.innerOk(),
+                                                trk.outerStateCovariance(),
+                                                trk.outerDetId(),
+                                                trk.innerStateCovariance(),
+                                                trk.innerDetId(),
+                                                trk.seedDirection()));
+          selTracks_->back().setExtra(TrackExtraRef(rTrackExtras, selTrackExtras_->size() - 1));
+          TrackExtra& tx = selTrackExtras_->back();
           // TrackingRecHits
           auto const firstHitIndex = selHits_->size();
-          for(auto const& hit : trk.recHits()) selHits_->push_back( hit->clone() );
-          tx.setHits( rHits, firstHitIndex, selHits_->size() - firstHitIndex );
-          tx.setTrajParams(trk.extra()->trajParams(),trk.extra()->chi2sX5());
-          assert(tx.trajParams().size()==tx.recHitsSize());
+          for (auto const& hit : trk.recHits())
+            selHits_->push_back(hit->clone());
+          tx.setHits(rHits, firstHitIndex, selHits_->size() - firstHitIndex);
+          tx.setTrajParams(trk.extra()->trajParams(), trk.extra()->chi2sX5());
+          assert(tx.trajParams().size() == tx.recHitsSize());
           if (copyTrajectories_) {
-              goodTracks[current] = reco::TrackRef(rTracks, selTracks_->size() - 1);
+            goodTracks[current] = reco::TrackRef(rTracks, selTracks_->size() - 1);
           }
-      }
-      if ( copyTrajectories_ ) {
-          edm::Handle< std::vector<Trajectory> > hTraj;
-          edm::Handle< TrajTrackAssociationCollection > hTTAss;
+        }
+        if (copyTrajectories_) {
+          edm::Handle<std::vector<Trajectory> > hTraj;
+          edm::Handle<TrajTrackAssociationCollection> hTTAss;
           evt.getByToken(hTTAssToken_, hTTAss);
           evt.getByToken(hTrajToken_, hTraj);
-          edm::RefProd< std::vector<Trajectory> > TrajRefProd = evt.template getRefBeforePut< std::vector<Trajectory> >();
-          selTrajs_ = std::unique_ptr< std::vector<Trajectory> >(new std::vector<Trajectory>());
-          selTTAss_ = std::unique_ptr< TrajTrackAssociationCollection >(new TrajTrackAssociationCollection());
+          edm::RefProd<std::vector<Trajectory> > TrajRefProd = evt.template getRefBeforePut<std::vector<Trajectory> >();
+          selTrajs_ = std::unique_ptr<std::vector<Trajectory> >(new std::vector<Trajectory>());
+          selTTAss_ = std::unique_ptr<TrajTrackAssociationCollection>(new TrajTrackAssociationCollection());
           for (size_t i = 0, n = hTraj->size(); i < n; ++i) {
-              edm::Ref< std::vector<Trajectory> > trajRef(hTraj, i);
-              TrajTrackAssociationCollection::const_iterator match = hTTAss->find(trajRef);
-              if (match != hTTAss->end()) {
-                  const edm::Ref<reco::TrackCollection> &trkRef = match->val;
-                  TrackRefKey oldKey = trkRef.key();
-                  std::map<TrackRefKey, reco::TrackRef>::iterator getref = goodTracks.find(oldKey);
-                  if (getref != goodTracks.end()) {
-                      // do the clone
-                      selTrajs_->push_back( Trajectory(*trajRef) );
-                      selTTAss_->insert ( edm::Ref< std::vector<Trajectory> >(TrajRefProd, selTrajs_->size() - 1),
-                                          getref->second );
-                  }
+            edm::Ref<std::vector<Trajectory> > trajRef(hTraj, i);
+            TrajTrackAssociationCollection::const_iterator match = hTTAss->find(trajRef);
+            if (match != hTTAss->end()) {
+              const edm::Ref<reco::TrackCollection>& trkRef = match->val;
+              TrackRefKey oldKey = trkRef.key();
+              std::map<TrackRefKey, reco::TrackRef>::iterator getref = goodTracks.find(oldKey);
+              if (getref != goodTracks.end()) {
+                // do the clone
+                selTrajs_->push_back(Trajectory(*trajRef));
+                selTTAss_->insert(edm::Ref<std::vector<Trajectory> >(TrajRefProd, selTrajs_->size() - 1),
+                                  getref->second);
               }
-          }
-      }
-
-      evt.put(std::move(selTracks_));
-      if (copyExtras_) {
-            evt.put(std::move(selTrackExtras_));
-            evt.put(std::move(selHits_));
-            if ( copyTrajectories_ ) {
-                evt.put(std::move(selTrajs_));
-                evt.put(std::move(selTTAss_));
             }
-      }
-  }
-  /// source collection label
-  edm::EDGetTokenT<reco::TrackCollection> hSrcTrackToken_;
-  edm::EDGetTokenT< std::vector<Trajectory> > hTrajToken_;
-  edm::EDGetTokenT< TrajTrackAssociationCollection > hTTAssToken_;
-  /// copy only the tracks, not extras and rechits (for AOD)
-  bool copyExtras_;
-  /// copy also trajectories and trajectory->track associations
-  bool copyTrajectories_;
-  /// filter event
-  Selector selector_;
-  // some space
-  std::unique_ptr<reco::TrackCollection> selTracks_;
-  std::unique_ptr<reco::TrackExtraCollection> selTrackExtras_;
-  std::unique_ptr<TrackingRecHitCollection> selHits_;
-  std::unique_ptr< std::vector<Trajectory> > selTrajs_;
-  std::unique_ptr< TrajTrackAssociationCollection > selTTAss_;
-};
+          }
+        }
 
-} }
+        evt.put(std::move(selTracks_));
+        if (copyExtras_) {
+          evt.put(std::move(selTrackExtras_));
+          evt.put(std::move(selHits_));
+          if (copyTrajectories_) {
+            evt.put(std::move(selTrajs_));
+            evt.put(std::move(selTTAss_));
+          }
+        }
+      }
+      /// source collection label
+      edm::EDGetTokenT<reco::TrackCollection> hSrcTrackToken_;
+      edm::EDGetTokenT<std::vector<Trajectory> > hTrajToken_;
+      edm::EDGetTokenT<TrajTrackAssociationCollection> hTTAssToken_;
+      /// copy only the tracks, not extras and rechits (for AOD)
+      bool copyExtras_;
+      /// copy also trajectories and trajectory->track associations
+      bool copyTrajectories_;
+      /// filter event
+      Selector selector_;
+      // some space
+      std::unique_ptr<reco::TrackCollection> selTracks_;
+      std::unique_ptr<reco::TrackExtraCollection> selTrackExtras_;
+      std::unique_ptr<TrackingRecHitCollection> selHits_;
+      std::unique_ptr<std::vector<Trajectory> > selTrajs_;
+      std::unique_ptr<TrajTrackAssociationCollection> selTTAss_;
+    };
+
+  }  // namespace modules
+}  // namespace reco
 #endif

--- a/CommonTools/RecoAlgos/interface/TrackWithVertexSelector.h
+++ b/CommonTools/RecoAlgos/interface/TrackWithVertexSelector.h
@@ -5,7 +5,6 @@
 //         Created:  Fri May 25 10:06:02 CEST 2007
 // $Id: TrackWithVertexSelector.h,v 1.4 2010/04/07 08:56:18 gpetrucc Exp $
 
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -16,49 +15,52 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 class TrackWithVertexSelector {
-   public:
-      explicit TrackWithVertexSelector(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) :
-        TrackWithVertexSelector(iConfig, iC) {}
-      explicit TrackWithVertexSelector(const edm::ParameterSet& iConfig, edm::ConsumesCollector & iC);
-      ~TrackWithVertexSelector();
+public:
+  explicit TrackWithVertexSelector(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iC)
+      : TrackWithVertexSelector(iConfig, iC) {}
+  explicit TrackWithVertexSelector(const edm::ParameterSet &iConfig, edm::ConsumesCollector &iC);
+  ~TrackWithVertexSelector();
 
-      void init(const edm::Event & event, const edm::EventSetup&) {init(event);}
-      void init(const edm::Event & event);
-      
-      bool operator()(const reco::Track &t) const ;
-      bool operator()(const reco::Track &t, const edm::Event &iEvent) {
-         init(iEvent); return (*this)(t);   
-      }
+  void init(const edm::Event &event, const edm::EventSetup &) { init(event); }
+  void init(const edm::Event &event);
 
-      bool operator()(const reco::TrackRef &t) const ;
-      bool operator()(const reco::TrackRef &t, const edm::Event &iEvent) {
-         init(iEvent); return (*this)(t);   
-      }
-      bool testTrack(const reco::Track &t) const ;
-      bool testVertices(const reco::Track &t, const reco::VertexCollection &vtxs) const ;
+  bool operator()(const reco::Track &t) const;
+  bool operator()(const reco::Track &t, const edm::Event &iEvent) {
+    init(iEvent);
+    return (*this)(t);
+  }
 
-      bool testTrack(const reco::TrackRef &t) const ;
-      bool testVertices(const reco::TrackRef &t, const reco::VertexCollection &vtxs) const ;
-   private:
-      uint32_t numberOfValidHits_;
-      uint32_t numberOfValidPixelHits_;
-      uint32_t numberOfLostHits_;
-      double   normalizedChi2_;
-      double   ptMin_, ptMax_, etaMin_, etaMax_;
-      double   dzMax_,   d0Max_;
-      double   ptErrorCut_;
-      std::string quality_;
+  bool operator()(const reco::TrackRef &t) const;
+  bool operator()(const reco::TrackRef &t, const edm::Event &iEvent) {
+    init(iEvent);
+    return (*this)(t);
+  }
+  bool testTrack(const reco::Track &t) const;
+  bool testVertices(const reco::Track &t, const reco::VertexCollection &vtxs) const;
 
-      uint32_t      nVertices_;
-      edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
-      edm::EDGetTokenT<edm::ValueMap<float> > timesToken_, timeResosToken_;
-      bool          vtxFallback_;
-      double        zetaVtx_, rhoVtx_, nSigmaDtVertex_;
+  bool testTrack(const reco::TrackRef &t) const;
+  bool testVertices(const reco::TrackRef &t, const reco::VertexCollection &vtxs) const;
 
-      reco::VertexCollection const * vcoll_ = nullptr;
-      edm::ValueMap<float> const * timescoll_ = nullptr;
-      edm::ValueMap<float> const * timeresoscoll_ = nullptr;
-      typedef math::XYZPoint Point;
+private:
+  uint32_t numberOfValidHits_;
+  uint32_t numberOfValidPixelHits_;
+  uint32_t numberOfLostHits_;
+  double normalizedChi2_;
+  double ptMin_, ptMax_, etaMin_, etaMax_;
+  double dzMax_, d0Max_;
+  double ptErrorCut_;
+  std::string quality_;
+
+  uint32_t nVertices_;
+  edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
+  edm::EDGetTokenT<edm::ValueMap<float> > timesToken_, timeResosToken_;
+  bool vtxFallback_;
+  double zetaVtx_, rhoVtx_, nSigmaDtVertex_;
+
+  reco::VertexCollection const *vcoll_ = nullptr;
+  edm::ValueMap<float> const *timescoll_ = nullptr;
+  edm::ValueMap<float> const *timeresoscoll_ = nullptr;
+  typedef math::XYZPoint Point;
 };
 
 #endif

--- a/CommonTools/RecoAlgos/plugins/BasicClusterMerger.cc
+++ b/CommonTools/RecoAlgos/plugins/BasicClusterMerger.cc
@@ -5,4 +5,4 @@
 
 typedef Merger<reco::BasicClusterCollection> BasicClusterMerger;
 
-DEFINE_FWK_MODULE( BasicClusterMerger );
+DEFINE_FWK_MODULE(BasicClusterMerger);

--- a/CommonTools/RecoAlgos/plugins/BooleanFlagFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/BooleanFlagFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CommonTools/RecoAlgos
 // Class:      BooleanFlagFilter
-// 
+//
 /**\class BooleanFlagFilter BooleanFlagFilter.cc CommonTools/RecoAlgos/plugins/BooleanFlagFilter.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Fri, 20 Mar 2015 08:05:20 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -34,23 +33,23 @@
 //
 
 class BooleanFlagFilter : public edm::global::EDFilter<> {
-   public:
-      explicit BooleanFlagFilter(const edm::ParameterSet&);
-      ~BooleanFlagFilter() override;
+public:
+  explicit BooleanFlagFilter(const edm::ParameterSet&);
+  ~BooleanFlagFilter() override;
 
-   private:
-      //virtual void beginJob() override;
-      bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-      //virtual void endJob() override;
-      
-      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+private:
+  //virtual void beginJob() override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  //virtual void endJob() override;
 
-      // ----------member data ---------------------------
-      edm::EDGetTokenT<bool> inputToken_;
-      bool reverse_;
+  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<bool> inputToken_;
+  bool reverse_;
 };
 
 //
@@ -64,46 +63,37 @@ class BooleanFlagFilter : public edm::global::EDFilter<> {
 //
 // constructors and destructor
 //
-BooleanFlagFilter::BooleanFlagFilter(const edm::ParameterSet& iConfig)
-{
-   //now do what ever initialization is needed
-   inputToken_ = consumes<bool>(iConfig.getParameter<edm::InputTag>("inputLabel"));
-   reverse_ = iConfig.getParameter<bool>("reverseDecision");
+BooleanFlagFilter::BooleanFlagFilter(const edm::ParameterSet& iConfig) {
+  //now do what ever initialization is needed
+  inputToken_ = consumes<bool>(iConfig.getParameter<edm::InputTag>("inputLabel"));
+  reverse_ = iConfig.getParameter<bool>("reverseDecision");
 }
 
-
-BooleanFlagFilter::~BooleanFlagFilter()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+BooleanFlagFilter::~BooleanFlagFilter() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool
-BooleanFlagFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-   using namespace edm;
+bool BooleanFlagFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  using namespace edm;
 
-   Handle<bool> pIn;
-   iEvent.getByToken(inputToken_, pIn);
-   if (!pIn.isValid())
-   {
-      throw edm::Exception(edm::errors::ProductNotFound) << " could not find requested flag\n";
-      return true;
-   }
+  Handle<bool> pIn;
+  iEvent.getByToken(inputToken_, pIn);
+  if (!pIn.isValid()) {
+    throw edm::Exception(edm::errors::ProductNotFound) << " could not find requested flag\n";
+    return true;
+  }
 
-   bool result = *pIn;
-   if (reverse_)
-      result = !result;
+  bool result = *pIn;
+  if (reverse_)
+    result = !result;
 
-   return result;
+  return result;
 }
 
 // ------------ method called once each job just before starting event loop  ------------
@@ -128,7 +118,7 @@ BooleanFlagFilter::beginRun(edm::Run const&, edm::EventSetup const&)
 { 
 }
 */
- 
+
 // ------------ method called when ending the processing of a run  ------------
 /*
 void
@@ -136,7 +126,7 @@ BooleanFlagFilter::endRun(edm::Run const&, edm::EventSetup const&)
 {
 }
 */
- 
+
 // ------------ method called when starting to processes a luminosity block  ------------
 /*
 void
@@ -144,7 +134,7 @@ BooleanFlagFilter::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventS
 {
 }
 */
- 
+
 // ------------ method called when ending the processing of a luminosity block  ------------
 /*
 void
@@ -152,6 +142,6 @@ BooleanFlagFilter::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSet
 {
 }
 */
- 
+
 //define this as a plug-in
 DEFINE_FWK_MODULE(BooleanFlagFilter);

--- a/CommonTools/RecoAlgos/plugins/CaloJetCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/CaloJetCountFilter.cc
@@ -9,8 +9,6 @@
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
 
- typedef ObjectCountFilter<
-           reco::CaloJetCollection
-         >::type CaloJetCountFilter;
+typedef ObjectCountFilter<reco::CaloJetCollection>::type CaloJetCountFilter;
 
-DEFINE_FWK_MODULE( CaloJetCountFilter );
+DEFINE_FWK_MODULE(CaloJetCountFilter);

--- a/CommonTools/RecoAlgos/plugins/CaloJetRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/CaloJetRefSelector.cc
@@ -26,10 +26,7 @@
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 
- typedef SingleObjectSelector<
-           reco::CaloJetCollection, 
-           StringCutObjectSelector<reco::CaloJet>,
-           reco::CaloJetRefVector
-         > CaloJetRefSelector;
+typedef SingleObjectSelector<reco::CaloJetCollection, StringCutObjectSelector<reco::CaloJet>, reco::CaloJetRefVector>
+    CaloJetRefSelector;
 
-DEFINE_FWK_MODULE( CaloJetRefSelector );
+DEFINE_FWK_MODULE(CaloJetRefSelector);

--- a/CommonTools/RecoAlgos/plugins/CaloJetSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/CaloJetSelector.cc
@@ -26,9 +26,6 @@
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 
- typedef SingleObjectSelector<
-           reco::CaloJetCollection, 
-           StringCutObjectSelector<reco::CaloJet> 
-         > CaloJetSelector;
+typedef SingleObjectSelector<reco::CaloJetCollection, StringCutObjectSelector<reco::CaloJet> > CaloJetSelector;
 
-DEFINE_FWK_MODULE( CaloJetSelector );
+DEFINE_FWK_MODULE(CaloJetSelector);

--- a/CommonTools/RecoAlgos/plugins/CaloJetShallowCloneProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/CaloJetShallowCloneProducer.cc
@@ -5,4 +5,4 @@ typedef ShallowCloneProducer<reco::CaloJetCollection> CaloJetShallowCloneProduce
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( CaloJetShallowCloneProducer );
+DEFINE_FWK_MODULE(CaloJetShallowCloneProducer);

--- a/CommonTools/RecoAlgos/plugins/CaloMETShallowCloneProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/CaloMETShallowCloneProducer.cc
@@ -7,4 +7,4 @@ typedef ShallowCloneProducer<reco::CaloMETCollection> CaloMETShallowCloneProduce
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( CaloMETShallowCloneProducer );
+DEFINE_FWK_MODULE(CaloMETShallowCloneProducer);

--- a/CommonTools/RecoAlgos/plugins/CaloRecHitCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/CaloRecHitCandidateProducer.cc
@@ -5,23 +5,23 @@
 namespace reco {
   namespace modules {
 
-    template<typename HitCollection>
+    template <typename HitCollection>
     class CaloRecHitCandidateProducer : public edm::EDProducer {
     public:
       /// constructor
-      CaloRecHitCandidateProducer( const edm::ParameterSet & cfg ) :
-	srcToken_( consumes<HitCollection>( cfg.template getParameter<edm::InputTag>( "src" ) ) ) { }
+      CaloRecHitCandidateProducer(const edm::ParameterSet &cfg)
+          : srcToken_(consumes<HitCollection>(cfg.template getParameter<edm::InputTag>("src"))) {}
       /// destructor
-      ~CaloRecHitCandidateProducer() override { }
+      ~CaloRecHitCandidateProducer() override {}
 
     private:
       /// process one event
-      void produce( edm::Event &, const edm::EventSetup&) override;
+      void produce(edm::Event &, const edm::EventSetup &) override;
       /// source collection tag
       edm::EDGetTokenT<HitCollection> srcToken_;
     };
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -30,31 +30,31 @@ namespace reco {
 namespace reco {
   namespace modules {
 
-    template<typename HitCollection>
-    void CaloRecHitCandidateProducer<HitCollection>::produce( edm::Event & evt, const edm::EventSetup & ) {
+    template <typename HitCollection>
+    void CaloRecHitCandidateProducer<HitCollection>::produce(edm::Event &evt, const edm::EventSetup &) {
       using namespace edm;
       using namespace reco;
       using namespace std;
       Handle<HitCollection> hits;
-      evt.getByToken( srcToken_, hits );
-      unique_ptr<CandidateCollection> cands( new CandidateCollection );
+      evt.getByToken(srcToken_, hits);
+      unique_ptr<CandidateCollection> cands(new CandidateCollection);
       size_t size = hits->size();
-      cands->reserve( size );
-      for( size_t idx = 0; idx != size; ++ idx ) {
-	const CaloRecHit & hit = (*hits)[ idx ];
-	/// don't know how to set eta and phi
-	double eta = 0, phi = 0, energy = hit.energy();
-	math::RhoEtaPhiVector p( 1, eta, phi );
-	p *= ( energy / p.r() );
-	CaloRecHitCandidate * c = new CaloRecHitCandidate( Candidate::LorentzVector( p.x(), p.y(), p.z(), energy ) );
-	c->setCaloRecHit( RefToBase<CaloRecHit>( Ref<HitCollection>( hits, idx ) ) );
-	cands->push_back( c );
+      cands->reserve(size);
+      for (size_t idx = 0; idx != size; ++idx) {
+        const CaloRecHit &hit = (*hits)[idx];
+        /// don't know how to set eta and phi
+        double eta = 0, phi = 0, energy = hit.energy();
+        math::RhoEtaPhiVector p(1, eta, phi);
+        p *= (energy / p.r());
+        CaloRecHitCandidate *c = new CaloRecHitCandidate(Candidate::LorentzVector(p.x(), p.y(), p.z(), energy));
+        c->setCaloRecHit(RefToBase<CaloRecHit>(Ref<HitCollection>(hits, idx)));
+        cands->push_back(c);
       }
       evt.put(std::move(cands));
     }
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
@@ -64,7 +64,7 @@ typedef reco::modules::CaloRecHitCandidateProducer<ZDCRecHitCollection> ZDCRecHi
 typedef reco::modules::CaloRecHitCandidateProducer<HBHERecHitCollection> HBHERecHitCandidateProducer;
 typedef reco::modules::CaloRecHitCandidateProducer<HORecHitCollection> HORecHitCandidateProducer;
 
-DEFINE_FWK_MODULE( HFRecHitCandidateProducer );
-DEFINE_FWK_MODULE( ZDCRecHitCandidateProducer );
-DEFINE_FWK_MODULE( HBHERecHitCandidateProducer );
-DEFINE_FWK_MODULE( HORecHitCandidateProducer );
+DEFINE_FWK_MODULE(HFRecHitCandidateProducer);
+DEFINE_FWK_MODULE(ZDCRecHitCandidateProducer);
+DEFINE_FWK_MODULE(HBHERecHitCandidateProducer);
+DEFINE_FWK_MODULE(HORecHitCandidateProducer);

--- a/CommonTools/RecoAlgos/plugins/ChargedCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/ChargedCandidateProducer.cc
@@ -12,11 +12,10 @@
 #include "CommonTools/RecoAlgos/src/TrackToCandidate.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef CandidateProducer<
-          edm::View<reco::Track>,
-          reco::RecoChargedCandidateCollection,
-          AnySelector,
-          converter::helper::CandConverter<reco::Track>::type
-        > ChargedCandidateProducer;
+typedef CandidateProducer<edm::View<reco::Track>,
+                          reco::RecoChargedCandidateCollection,
+                          AnySelector,
+                          converter::helper::CandConverter<reco::Track>::type>
+    ChargedCandidateProducer;
 
 DEFINE_FWK_MODULE(ChargedCandidateProducer);

--- a/CommonTools/RecoAlgos/plugins/ChargedRefCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/ChargedRefCandidateProducer.cc
@@ -12,11 +12,10 @@
 #include "CommonTools/RecoAlgos/src/TrackToRefCandidate.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef CandidateProducer<
-          edm::View<reco::Track>,
-          reco::RecoChargedRefCandidateCollection,
-          AnySelector,
-          converter::helper::CandConverter<reco::Track>::type
-        > ChargedRefCandidateProducer;
+typedef CandidateProducer<edm::View<reco::Track>,
+                          reco::RecoChargedRefCandidateCollection,
+                          AnySelector,
+                          converter::helper::CandConverter<reco::Track>::type>
+    ChargedRefCandidateProducer;
 
 DEFINE_FWK_MODULE(ChargedRefCandidateProducer);

--- a/CommonTools/RecoAlgos/plugins/CompositeDimuonAndSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/CompositeDimuonAndSelector.cc
@@ -7,14 +7,9 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 typedef SingleObjectSelector<
-          reco::CandidateView,
-          CompositeCandSelector<
-            AndPairSelector<
-              StringCutObjectSelector<reco::Muon>,
-              StringCutObjectSelector<reco::Muon> 
-            >,
-            reco::Muon
-          >
-        > CompositeDimuonAndSelector;
+    reco::CandidateView,
+    CompositeCandSelector<AndPairSelector<StringCutObjectSelector<reco::Muon>, StringCutObjectSelector<reco::Muon> >,
+                          reco::Muon> >
+    CompositeDimuonAndSelector;
 
 DEFINE_FWK_MODULE(CompositeDimuonAndSelector);

--- a/CommonTools/RecoAlgos/plugins/ConcreteChargedCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/ConcreteChargedCandidateProducer.cc
@@ -14,9 +14,6 @@
 #include "CommonTools/RecoAlgos/src/TrackToCandidate.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef CandidateProducer<
-          reco::TrackCollection, 
-          reco::RecoChargedCandidateCollection
-        > ConcreteChargedCandidateProducer;
+typedef CandidateProducer<reco::TrackCollection, reco::RecoChargedCandidateCollection> ConcreteChargedCandidateProducer;
 
 DEFINE_FWK_MODULE(ConcreteChargedCandidateProducer);

--- a/CommonTools/RecoAlgos/plugins/ConcreteChargedRefCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/ConcreteChargedRefCandidateProducer.cc
@@ -14,9 +14,7 @@
 #include "CommonTools/RecoAlgos/src/TrackToRefCandidate.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef CandidateProducer<
-          reco::TrackCollection, 
-          reco::RecoChargedRefCandidateCollection
-        > ConcreteChargedRefCandidateProducer;
+typedef CandidateProducer<reco::TrackCollection, reco::RecoChargedRefCandidateCollection>
+    ConcreteChargedRefCandidateProducer;
 
 DEFINE_FWK_MODULE(ConcreteChargedRefCandidateProducer);

--- a/CommonTools/RecoAlgos/plugins/ConcreteEcalCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/ConcreteEcalCandidateProducer.cc
@@ -14,9 +14,6 @@
 #include "CommonTools/RecoAlgos/src/SuperClusterToCandidate.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef CandidateProducer<
-          reco::SuperClusterCollection, 
-          reco::RecoEcalCandidateCollection
-        > ConcreteEcalCandidateProducer;
+typedef CandidateProducer<reco::SuperClusterCollection, reco::RecoEcalCandidateCollection> ConcreteEcalCandidateProducer;
 
-DEFINE_FWK_MODULE( ConcreteEcalCandidateProducer );
+DEFINE_FWK_MODULE(ConcreteEcalCandidateProducer);

--- a/CommonTools/RecoAlgos/plugins/ConcreteStandAloneMuonCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/ConcreteStandAloneMuonCandidateProducer.cc
@@ -14,9 +14,7 @@
 #include "CommonTools/RecoAlgos/src/StandAloneMuonTrackToCandidate.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef CandidateProducer<
-          reco::TrackCollection, 
-          reco::RecoStandAloneMuonCandidateCollection
-        > ConcreteStandAloneMuonCandidateProducer;
+typedef CandidateProducer<reco::TrackCollection, reco::RecoStandAloneMuonCandidateCollection>
+    ConcreteStandAloneMuonCandidateProducer;
 
 DEFINE_FWK_MODULE(ConcreteStandAloneMuonCandidateProducer);

--- a/CommonTools/RecoAlgos/plugins/CosmicTrackingParticleSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/CosmicTrackingParticleSelector.cc
@@ -14,5 +14,5 @@
 
 namespace reco {
   typedef ObjectSelector<CosmicTrackingParticleSelector> CosmicTrackingParticleSelector;
-    DEFINE_FWK_MODULE( CosmicTrackingParticleSelector );
-}
+  DEFINE_FWK_MODULE(CosmicTrackingParticleSelector);
+}  // namespace reco

--- a/CommonTools/RecoAlgos/plugins/ElectronShallowCloneProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/ElectronShallowCloneProducer.cc
@@ -6,4 +6,4 @@ typedef ShallowCloneProducer<reco::ElectronCollection> ElectronShallowCloneProdu
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( ElectronShallowCloneProducer );
+DEFINE_FWK_MODULE(ElectronShallowCloneProducer);

--- a/CommonTools/RecoAlgos/plugins/EtMinCaloJetCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/EtMinCaloJetCountFilter.cc
@@ -11,9 +11,6 @@
 #include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
 #include "CommonTools/UtilAlgos/interface/EtMinSelector.h"
 
-typedef ObjectCountFilter<
-          reco::CaloJetCollection, 
-          EtMinSelector
-        >::type EtMinCaloJetCountFilter;
+typedef ObjectCountFilter<reco::CaloJetCollection, EtMinSelector>::type EtMinCaloJetCountFilter;
 
-DEFINE_FWK_MODULE( EtMinCaloJetCountFilter );
+DEFINE_FWK_MODULE(EtMinCaloJetCountFilter);

--- a/CommonTools/RecoAlgos/plugins/EtMinCaloJetRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtMinCaloJetRefSelector.cc
@@ -11,10 +11,6 @@
 #include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 
- typedef SingleObjectSelector<
-           reco::CaloJetCollection,
-           EtMinSelector,
-           reco::CaloJetRefVector
-         > EtMinCaloJetRefSelector;
+typedef SingleObjectSelector<reco::CaloJetCollection, EtMinSelector, reco::CaloJetRefVector> EtMinCaloJetRefSelector;
 
-DEFINE_FWK_MODULE( EtMinCaloJetRefSelector );
+DEFINE_FWK_MODULE(EtMinCaloJetRefSelector);

--- a/CommonTools/RecoAlgos/plugins/EtMinCaloJetSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtMinCaloJetSelector.cc
@@ -10,9 +10,6 @@
 #include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 
- typedef SingleObjectSelector<
-           reco::CaloJetCollection, 
-           EtMinSelector
-         > EtMinCaloJetSelector;
+typedef SingleObjectSelector<reco::CaloJetCollection, EtMinSelector> EtMinCaloJetSelector;
 
-DEFINE_FWK_MODULE( EtMinCaloJetSelector );
+DEFINE_FWK_MODULE(EtMinCaloJetSelector);

--- a/CommonTools/RecoAlgos/plugins/EtMinPFJetSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtMinPFJetSelector.cc
@@ -10,9 +10,6 @@
 #include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 
- typedef SingleObjectSelector<
-           reco::PFJetCollection, 
-           EtMinSelector
-         > EtMinPFJetSelector;
+typedef SingleObjectSelector<reco::PFJetCollection, EtMinSelector> EtMinPFJetSelector;
 
-DEFINE_FWK_MODULE( EtMinPFJetSelector );
+DEFINE_FWK_MODULE(EtMinPFJetSelector);

--- a/CommonTools/RecoAlgos/plugins/EtMinPhotonCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/EtMinPhotonCountFilter.cc
@@ -12,9 +12,6 @@
 #include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
 #include "CommonTools/UtilAlgos/interface/EtMinSelector.h"
 
-typedef ObjectCountFilter<
-          reco::PhotonCollection, 
-          EtMinSelector
-        >::type EtMinPhotonCountFilter;
+typedef ObjectCountFilter<reco::PhotonCollection, EtMinSelector>::type EtMinPhotonCountFilter;
 
-DEFINE_FWK_MODULE( EtMinPhotonCountFilter );
+DEFINE_FWK_MODULE(EtMinPhotonCountFilter);

--- a/CommonTools/RecoAlgos/plugins/EtMinPhotonSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtMinPhotonSelector.cc
@@ -11,9 +11,6 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 
- typedef SingleObjectSelector<
-           reco::PhotonCollection, 
-           EtMinSelector
-         > EtMinPhotonSelector;
+typedef SingleObjectSelector<reco::PhotonCollection, EtMinSelector> EtMinPhotonSelector;
 
-DEFINE_FWK_MODULE( EtMinPhotonSelector );
+DEFINE_FWK_MODULE(EtMinPhotonSelector);

--- a/CommonTools/RecoAlgos/plugins/EtMinSuperClusterCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/EtMinSuperClusterCountFilter.cc
@@ -7,9 +7,7 @@
 #include "CommonTools/RecoAlgos/plugins/EtMinSuperClusterSelector.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 
-typedef ObjectCountFilter<
-          reco::SuperClusterCollection, 
-          reco::modules::EtMinSuperClusterSelector
-        >::type EtMinSuperClusterCountFilter;
+typedef ObjectCountFilter<reco::SuperClusterCollection, reco::modules::EtMinSuperClusterSelector>::type
+    EtMinSuperClusterCountFilter;
 
-DEFINE_FWK_MODULE( EtMinSuperClusterCountFilter );
+DEFINE_FWK_MODULE(EtMinSuperClusterCountFilter);

--- a/CommonTools/RecoAlgos/plugins/EtMinSuperClusterSelector.h
+++ b/CommonTools/RecoAlgos/plugins/EtMinSuperClusterSelector.h
@@ -8,22 +8,19 @@
 #include "CommonTools/RecoAlgos/plugins/SuperClusterEt.h"
 
 namespace reco {
-   namespace modules {
-     typedef FunctionMinSelector<SuperClusterEt> EtMinSuperClusterSelector;
+  namespace modules {
+    typedef FunctionMinSelector<SuperClusterEt> EtMinSuperClusterSelector;
 
-     template<>
-     struct ParameterAdapter<EtMinSuperClusterSelector> {
-       static EtMinSuperClusterSelector make(
-         const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	 return EtMinSuperClusterSelector( cfg.getParameter<double>( "etMin" ) );
-       }
+    template <>
+    struct ParameterAdapter<EtMinSuperClusterSelector> {
+      static EtMinSuperClusterSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return EtMinSuperClusterSelector(cfg.getParameter<double>("etMin"));
+      }
 
-       static void fillPSetDescription(edm::ParameterSetDescription& desc) {
-         desc.add<double>("etMin", 0);
-       }
-     };
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<double>("etMin", 0); }
+    };
 
-   }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif

--- a/CommonTools/RecoAlgos/plugins/EtaEtMinCaloJetCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/EtaEtMinCaloJetCountFilter.cc
@@ -13,12 +13,7 @@
 #include "CommonTools/UtilAlgos/interface/EtMinSelector.h"
 #include "CommonTools/UtilAlgos/interface/EtaRangeSelector.h"
 
- typedef ObjectCountFilter<
-           reco::CaloJetCollection, 
-	      AndSelector<
-               EtMinSelector,
-	       EtaRangeSelector
-           > 
-         >::type EtaEtMinCaloJetCountFilter;
+typedef ObjectCountFilter<reco::CaloJetCollection, AndSelector<EtMinSelector, EtaRangeSelector> >::type
+    EtaEtMinCaloJetCountFilter;
 
-DEFINE_FWK_MODULE( EtaEtMinCaloJetCountFilter );
+DEFINE_FWK_MODULE(EtaEtMinCaloJetCountFilter);

--- a/CommonTools/RecoAlgos/plugins/EtaPtMinGsfElectronFullCloneSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtaPtMinGsfElectronFullCloneSelector.cc
@@ -15,12 +15,7 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "CommonTools/RecoAlgos/interface/GsfElectronSelector.h"
 
- typedef SingleObjectSelector<
-           reco::GsfElectronCollection,
-           AndSelector<
-	     EtaRangeSelector,
-             PtMinSelector
-           >
-         > EtaPtMinGsfElectronFullCloneSelector;
+typedef SingleObjectSelector<reco::GsfElectronCollection, AndSelector<EtaRangeSelector, PtMinSelector> >
+    EtaPtMinGsfElectronFullCloneSelector;
 
-DEFINE_FWK_MODULE( EtaPtMinGsfElectronFullCloneSelector );
+DEFINE_FWK_MODULE(EtaPtMinGsfElectronFullCloneSelector);

--- a/CommonTools/RecoAlgos/plugins/EtaPtMinGsfElectronSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtaPtMinGsfElectronSelector.cc
@@ -13,12 +13,7 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 
- typedef SingleObjectSelector<
-           reco::GsfElectronCollection,
-           AndSelector<
-             EtaRangeSelector,
-             PtMinSelector
-           >
-         > EtaPtMinGsfElectronSelector;
+typedef SingleObjectSelector<reco::GsfElectronCollection, AndSelector<EtaRangeSelector, PtMinSelector> >
+    EtaPtMinGsfElectronSelector;
 
-DEFINE_FWK_MODULE( EtaPtMinGsfElectronSelector );
+DEFINE_FWK_MODULE(EtaPtMinGsfElectronSelector);

--- a/CommonTools/RecoAlgos/plugins/EtaPtMinPixelMatchGsfElectronFullCloneSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtaPtMinPixelMatchGsfElectronFullCloneSelector.cc
@@ -15,12 +15,7 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "CommonTools/RecoAlgos/interface/GsfElectronSelector.h"
 
- typedef SingleObjectSelector<
-           reco::GsfElectronCollection,
-           AndSelector<
-	     EtaRangeSelector,
-             PtMinSelector
-           >
-         > EtaPtMinPixelMatchGsfElectronFullCloneSelector;
+typedef SingleObjectSelector<reco::GsfElectronCollection, AndSelector<EtaRangeSelector, PtMinSelector> >
+    EtaPtMinPixelMatchGsfElectronFullCloneSelector;
 
-DEFINE_FWK_MODULE( EtaPtMinPixelMatchGsfElectronFullCloneSelector );
+DEFINE_FWK_MODULE(EtaPtMinPixelMatchGsfElectronFullCloneSelector);

--- a/CommonTools/RecoAlgos/plugins/EtaPtMinPixelMatchGsfElectronSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtaPtMinPixelMatchGsfElectronSelector.cc
@@ -13,12 +13,7 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 
- typedef SingleObjectSelector<
-           reco::GsfElectronCollection,
-           AndSelector<
-             EtaRangeSelector,
-             PtMinSelector
-           >
-         > EtaPtMinPixelMatchGsfElectronSelector;
+typedef SingleObjectSelector<reco::GsfElectronCollection, AndSelector<EtaRangeSelector, PtMinSelector> >
+    EtaPtMinPixelMatchGsfElectronSelector;
 
-DEFINE_FWK_MODULE( EtaPtMinPixelMatchGsfElectronSelector );
+DEFINE_FWK_MODULE(EtaPtMinPixelMatchGsfElectronSelector);

--- a/CommonTools/RecoAlgos/plugins/EtaRangeCaloJetSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtaRangeCaloJetSelector.cc
@@ -10,9 +10,6 @@
 #include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 
- typedef SingleObjectSelector<
-           reco::CaloJetCollection, 
-           EtaRangeSelector
-         > EtaRangeCaloJetSelector;
+typedef SingleObjectSelector<reco::CaloJetCollection, EtaRangeSelector> EtaRangeCaloJetSelector;
 
-DEFINE_FWK_MODULE( EtaRangeCaloJetSelector );
+DEFINE_FWK_MODULE(EtaRangeCaloJetSelector);

--- a/CommonTools/RecoAlgos/plugins/GenJetRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/GenJetRefSelector.cc
@@ -26,10 +26,7 @@
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
 
- typedef SingleObjectSelector<
-           reco::GenJetCollection, 
-           StringCutObjectSelector<reco::GenJet>,
-           reco::GenJetRefVector
-         > GenJetRefSelector;
+typedef SingleObjectSelector<reco::GenJetCollection, StringCutObjectSelector<reco::GenJet>, reco::GenJetRefVector>
+    GenJetRefSelector;
 
-DEFINE_FWK_MODULE( GenJetRefSelector );
+DEFINE_FWK_MODULE(GenJetRefSelector);

--- a/CommonTools/RecoAlgos/plugins/GenJetShallowCloneProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/GenJetShallowCloneProducer.cc
@@ -5,4 +5,4 @@ typedef ShallowCloneProducer<reco::GenJetCollection> GenJetShallowCloneProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( GenJetShallowCloneProducer );
+DEFINE_FWK_MODULE(GenJetShallowCloneProducer);

--- a/CommonTools/RecoAlgos/plugins/GenMETShallowCloneProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/GenMETShallowCloneProducer.cc
@@ -6,4 +6,4 @@ typedef ShallowCloneProducer<reco::GenMETCollection> GenMETShallowCloneProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( GenMETShallowCloneProducer );
+DEFINE_FWK_MODULE(GenMETShallowCloneProducer);

--- a/CommonTools/RecoAlgos/plugins/GsfElectronRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/GsfElectronRefSelector.cc
@@ -26,10 +26,9 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 
- typedef SingleObjectSelector<
-           reco::GsfElectronCollection, 
-           StringCutObjectSelector<reco::GsfElectron>,
-           reco::GsfElectronRefVector
-         > GsfElectronRefSelector;
+typedef SingleObjectSelector<reco::GsfElectronCollection,
+                             StringCutObjectSelector<reco::GsfElectron>,
+                             reco::GsfElectronRefVector>
+    GsfElectronRefSelector;
 
-DEFINE_FWK_MODULE( GsfElectronRefSelector );
+DEFINE_FWK_MODULE(GsfElectronRefSelector);

--- a/CommonTools/RecoAlgos/plugins/GsfElectronSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/GsfElectronSelector.cc
@@ -26,9 +26,7 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 
- typedef SingleObjectSelector<
-           reco::GsfElectronCollection, 
-           StringCutObjectSelector<reco::GsfElectron> 
-         > GsfElectronSelector;
+typedef SingleObjectSelector<reco::GsfElectronCollection, StringCutObjectSelector<reco::GsfElectron> >
+    GsfElectronSelector;
 
-DEFINE_FWK_MODULE( GsfElectronSelector );
+DEFINE_FWK_MODULE(GsfElectronSelector);

--- a/CommonTools/RecoAlgos/plugins/GsfElectronShallowCloneProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/GsfElectronShallowCloneProducer.cc
@@ -6,4 +6,4 @@ typedef ShallowCloneProducer<reco::GsfElectronCollection> PixelMatchGsfElectronS
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( PixelMatchGsfElectronShallowCloneProducer );
+DEFINE_FWK_MODULE(PixelMatchGsfElectronShallowCloneProducer);

--- a/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
@@ -28,31 +28,26 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-
-
-
 template <class T, typename C = std::vector<typename T::ConstituentTypeFwdPtr>>
 class JetConstituentSelector : public edm::stream::EDProducer<> {
 public:
-
   using JetsOutput = std::vector<T>;
   using ConstituentsOutput = C;
   using ValueType = typename C::value_type;
-  
-  JetConstituentSelector(edm::ParameterSet const& params) :
-    srcToken_{consumes<edm::View<T>>(params.getParameter<edm::InputTag>("src"))},
-    selector_{params.getParameter<std::string>("cut")}
-  {
+
+  JetConstituentSelector(edm::ParameterSet const& params)
+      : srcToken_{consumes<edm::View<T>>(params.getParameter<edm::InputTag>("src"))},
+        selector_{params.getParameter<std::string>("cut")} {
     produces<JetsOutput>();
     produces<ConstituentsOutput>("constituents");
   }
 
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-  {
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<edm::InputTag>("src")->setComment("InputTag used for retrieving jets in event.");
-    desc.add<std::string>("cut")->setComment("Cut used by which to select jets.  For example:\n"
-                                             "  \"pt > 100.0 && abs(rapidity()) < 2.4\".");
+    desc.add<std::string>("cut")->setComment(
+        "Cut used by which to select jets.  For example:\n"
+        "  \"pt > 100.0 && abs(rapidity()) < 2.4\".");
 
     // addDefault must be used here instead of add unless this function is specialized
     // for different sets of template parameter types. Each specialization would need
@@ -62,29 +57,27 @@ public:
   }
 
   // Default initialization is for edm::FwdPtr. Specialization (below) is for edm::Ptr.
-  typename  ConstituentsOutput::value_type const initptr( edm::Ptr<reco::Candidate> const & dau) const{
-    return typename ConstituentsOutput::value_type( dau, dau );
+  typename ConstituentsOutput::value_type const initptr(edm::Ptr<reco::Candidate> const& dau) const {
+    return typename ConstituentsOutput::value_type(dau, dau);
   }
 
-  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) override
-  {
+  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) override {
     auto jets = std::make_unique<JetsOutput>();
     auto candsOut = std::make_unique<ConstituentsOutput>();
 
     edm::Handle<edm::View<T>> h_jets;
     iEvent.getByToken(srcToken_, h_jets);
 
-    
     // Now set the Ptrs with the orphan handles.
     for (auto const& jet : *h_jets) {
       // Check the selection
       if (selector_(jet)) {
-	// Add the jets that pass to the output collection
-	jets->push_back(jet);
+        // Add the jets that pass to the output collection
+        jets->push_back(jet);
 
-	for (unsigned int ida {}; ida < jet.numberOfDaughters(); ++ida) {
-	    candsOut->emplace_back( initptr(jet.daughterPtr(ida)) );
-	}
+        for (unsigned int ida{}; ida < jet.numberOfDaughters(); ++ida) {
+          candsOut->emplace_back(initptr(jet.daughterPtr(ida)));
+        }
       }
     }
 
@@ -97,28 +90,34 @@ private:
   StringCutObjectSelector<T> const selector_;
 };
 
-template<>
- edm::Ptr<pat::PackedCandidate> const
-JetConstituentSelector< pat::Jet,std::vector<edm::Ptr<pat::PackedCandidate>>>::initptr( edm::Ptr<reco::Candidate> const & dau) const{
-  edm::Ptr<pat::PackedCandidate> retval( dau );
+template <>
+edm::Ptr<pat::PackedCandidate> const
+JetConstituentSelector<pat::Jet, std::vector<edm::Ptr<pat::PackedCandidate>>>::initptr(
+    edm::Ptr<reco::Candidate> const& dau) const {
+  edm::Ptr<pat::PackedCandidate> retval(dau);
   return retval;
 }
 
-template<>
- edm::Ptr<pat::PackedGenParticle> const
-JetConstituentSelector<reco::GenJet,std::vector<edm::Ptr<pat::PackedGenParticle>>>::initptr( edm::Ptr<reco::Candidate> const & dau) const{
-  edm::Ptr<pat::PackedGenParticle> retval( dau );
+template <>
+edm::Ptr<pat::PackedGenParticle> const
+JetConstituentSelector<reco::GenJet, std::vector<edm::Ptr<pat::PackedGenParticle>>>::initptr(
+    edm::Ptr<reco::Candidate> const& dau) const {
+  edm::Ptr<pat::PackedGenParticle> retval(dau);
   return retval;
 }
 
 using PFJetConstituentSelector = JetConstituentSelector<reco::PFJet>;
 using GenJetConstituentSelector = JetConstituentSelector<reco::GenJet, std::vector<edm::FwdPtr<reco::GenParticle>>>;
-using GenJetPackedConstituentSelector = JetConstituentSelector<reco::GenJet, std::vector<edm::FwdPtr<pat::PackedGenParticle>>>;
-using GenJetPackedConstituentPtrSelector = JetConstituentSelector<reco::GenJet, std::vector<edm::Ptr<pat::PackedGenParticle>>>;
+using GenJetPackedConstituentSelector =
+    JetConstituentSelector<reco::GenJet, std::vector<edm::FwdPtr<pat::PackedGenParticle>>>;
+using GenJetPackedConstituentPtrSelector =
+    JetConstituentSelector<reco::GenJet, std::vector<edm::Ptr<pat::PackedGenParticle>>>;
 using PatJetConstituentSelector = JetConstituentSelector<pat::Jet, std::vector<edm::FwdPtr<pat::PackedCandidate>>>;
 using PatJetConstituentPtrSelector = JetConstituentSelector<pat::Jet, std::vector<edm::Ptr<pat::PackedCandidate>>>;
-using MiniAODJetConstituentSelector = JetConstituentSelector<reco::PFJet, std::vector<edm::FwdPtr<pat::PackedCandidate>>>;
-using MiniAODJetConstituentPtrSelector = JetConstituentSelector<reco::PFJet, std::vector<edm::Ptr<pat::PackedCandidate>>>;
+using MiniAODJetConstituentSelector =
+    JetConstituentSelector<reco::PFJet, std::vector<edm::FwdPtr<pat::PackedCandidate>>>;
+using MiniAODJetConstituentPtrSelector =
+    JetConstituentSelector<reco::PFJet, std::vector<edm::Ptr<pat::PackedCandidate>>>;
 
 DEFINE_FWK_MODULE(PFJetConstituentSelector);
 DEFINE_FWK_MODULE(GenJetConstituentSelector);

--- a/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
@@ -20,7 +20,6 @@
  *
  */
 
-
 #include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "DataFormats/JetReco/interface/Jet.h"
@@ -33,106 +32,94 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-template < class T, class I >
+template <class T, class I>
 class JetDeltaRTagInfoValueMapProducer : public edm::global::EDProducer<> {
-
 public:
-
   typedef std::vector<T> JetsInput;
   typedef std::vector<I> TagInfosCollection;
 
-  JetDeltaRTagInfoValueMapProducer ( edm::ParameterSet const & params ) :
-      srcToken_( consumes< typename edm::View<T> >( params.getParameter<edm::InputTag>("src") ) ),
-      matchedToken_( consumes< typename edm::View<T> >( params.getParameter<edm::InputTag>( "matched" ) ) ),
-      matchedTagInfosToken_( consumes< typename edm::View<I> >( params.getParameter<edm::InputTag>( "matchedTagInfos" ) ) ),
-      distMax_( params.getParameter<double>( "distMax" ) )
-  {
-        produces< TagInfosCollection >();
+  JetDeltaRTagInfoValueMapProducer(edm::ParameterSet const& params)
+      : srcToken_(consumes<typename edm::View<T> >(params.getParameter<edm::InputTag>("src"))),
+        matchedToken_(consumes<typename edm::View<T> >(params.getParameter<edm::InputTag>("matched"))),
+        matchedTagInfosToken_(consumes<typename edm::View<I> >(params.getParameter<edm::InputTag>("matchedTagInfos"))),
+        distMax_(params.getParameter<double>("distMax")) {
+    produces<TagInfosCollection>();
   }
 
   ~JetDeltaRTagInfoValueMapProducer() override {}
 
 private:
-
   void beginJob() override {}
   void endJob() override {}
 
   void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {
+    std::unique_ptr<TagInfosCollection> mappedTagInfos(new TagInfosCollection());
 
-    std::unique_ptr< TagInfosCollection > mappedTagInfos ( new TagInfosCollection() );
+    edm::Handle<typename edm::View<T> > h_jets1;
+    iEvent.getByToken(srcToken_, h_jets1);
+    edm::Handle<typename edm::View<T> > h_jets2;
+    iEvent.getByToken(matchedToken_, h_jets2);
+    edm::Handle<typename edm::View<I> > h_tagInfos;
+    iEvent.getByToken(matchedTagInfosToken_, h_tagInfos);
 
+    const double distMax2 = distMax_ * distMax_;
 
-    edm::Handle< typename edm::View<T> > h_jets1;
-    iEvent.getByToken( srcToken_, h_jets1 );
-    edm::Handle< typename edm::View<T> > h_jets2;
-    iEvent.getByToken( matchedToken_, h_jets2 );
-    edm::Handle< typename edm::View<I> > h_tagInfos;
-    iEvent.getByToken( matchedTagInfosToken_, h_tagInfos );
+    std::vector<bool> jets2_locks(h_jets2->size(), false);
 
-    const double distMax2 = distMax_*distMax_;
-
-    std::vector<bool> jets2_locks( h_jets2->size(), false );
-
-    for ( typename edm::View<T>::const_iterator ibegin = h_jets1->begin(),
-          iend = h_jets1->end(), ijet = ibegin;
-          ijet != iend; ++ijet )
-    {
+    for (typename edm::View<T>::const_iterator ibegin = h_jets1->begin(), iend = h_jets1->end(), ijet = ibegin;
+         ijet != iend;
+         ++ijet) {
       float matched_dR2 = 1e9;
       int matched_index = -1;
 
       //std::cout << "Looking at jet " << ijet - ibegin << ", mass = " << ijet->mass() << std::endl;
-     
-      for ( typename edm::View<T>::const_iterator jbegin = h_jets2->begin(),
-            jend = h_jets2->end(), jjet = jbegin;
-            jjet != jend; ++jjet )
-      {
-        int index=jjet - jbegin;
 
-	//std::cout << "Checking jet " << index << ", mass = " << jjet->mass() << std::endl;
+      for (typename edm::View<T>::const_iterator jbegin = h_jets2->begin(), jend = h_jets2->end(), jjet = jbegin;
+           jjet != jend;
+           ++jjet) {
+        int index = jjet - jbegin;
 
-        if( jets2_locks.at(index) ) continue; // skip jets that have already been matched
+        //std::cout << "Checking jet " << index << ", mass = " << jjet->mass() << std::endl;
 
-        float temp_dR2 = reco::deltaR2(ijet->eta(),ijet->phi(),jjet->eta(),jjet->phi());
-        if ( temp_dR2 < matched_dR2 )
-        {
+        if (jets2_locks.at(index))
+          continue;  // skip jets that have already been matched
+
+        float temp_dR2 = reco::deltaR2(ijet->eta(), ijet->phi(), jjet->eta(), jjet->phi());
+        if (temp_dR2 < matched_dR2) {
           matched_dR2 = temp_dR2;
           matched_index = index;
         }
-      }// end loop over src jets
+      }  // end loop over src jets
 
-      I mappedTagInfo; 
+      I mappedTagInfo;
 
-      if( matched_index>=0 && static_cast<size_t>(matched_index) < h_tagInfos->size() )
-      {
-        if ( matched_dR2 > distMax2 )
+      if (matched_index >= 0 && static_cast<size_t>(matched_index) < h_tagInfos->size()) {
+        if (matched_dR2 > distMax2)
           LogDebug("MatchedJetsFarApart") << "Matched jets separated by dR greater than distMax=" << distMax_;
-        else
-        {
+        else {
           jets2_locks.at(matched_index) = true;
-	  
-          auto otherTagInfo = h_tagInfos->at( matched_index );
-	  otherTagInfo.setJetRef( h_jets1->refAt( ijet - ibegin) );
-	  mappedTagInfo = otherTagInfo;
-	  //std::cout << "Matched! : " << matched_index << ", mass = " << mappedTagInfo.properties().topMass << std::endl;
+
+          auto otherTagInfo = h_tagInfos->at(matched_index);
+          otherTagInfo.setJetRef(h_jets1->refAt(ijet - ibegin));
+          mappedTagInfo = otherTagInfo;
+          //std::cout << "Matched! : " << matched_index << ", mass = " << mappedTagInfo.properties().topMass << std::endl;
         }
       }
 
-      mappedTagInfos->push_back( mappedTagInfo );
+      mappedTagInfos->push_back(mappedTagInfo);
 
-    }// end loop over matched jets
-    
+    }  // end loop over matched jets
 
     // put  in Event
     iEvent.put(std::move(mappedTagInfos));
   }
 
-  const edm::EDGetTokenT< typename edm::View<T> >  srcToken_;
-  const edm::EDGetTokenT< typename edm::View<T> >  matchedToken_;
-  const edm::EDGetTokenT< typename edm::View<I> >  matchedTagInfosToken_;
-  const double                                     distMax_;
-
+  const edm::EDGetTokenT<typename edm::View<T> > srcToken_;
+  const edm::EDGetTokenT<typename edm::View<T> > matchedToken_;
+  const edm::EDGetTokenT<typename edm::View<I> > matchedTagInfosToken_;
+  const double distMax_;
 };
 
 typedef JetDeltaRTagInfoValueMapProducer<reco::Jet, reco::CATopJetTagInfo> RecoJetDeltaRTagInfoValueMapProducer;
 
-DEFINE_FWK_MODULE( RecoJetDeltaRTagInfoValueMapProducer );
+DEFINE_FWK_MODULE(RecoJetDeltaRTagInfoValueMapProducer);

--- a/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
@@ -15,7 +15,6 @@
  *
  */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/JetReco/interface/Jet.h"
@@ -28,109 +27,100 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-template < class T, class C=T >
+template <class T, class C = T>
 class JetDeltaRValueMapProducer : public edm::stream::EDProducer<> {
-
 public:
-
   typedef edm::ValueMap<float> JetValueMap;
 
-  JetDeltaRValueMapProducer ( edm::ParameterSet const & params ) :
-      srcToken_( consumes< typename edm::View<T> >( params.getParameter<edm::InputTag>("src") ) ),
-      matchedToken_( consumes< typename edm::View<C> >( params.getParameter<edm::InputTag>( "matched" ) ) ),
-      distMax_( params.getParameter<double>( "distMax" ) ),
-      value_( params.existsAs<std::string>("value") ? params.getParameter<std::string>("value") : "" ),
-      values_( params.existsAs<std::vector<std::string> >("values") ? params.getParameter<std::vector<std::string> >("values") : std::vector<std::string>() ),
-      valueLabels_( params.existsAs<std::vector<std::string> >("valueLabels") ? params.getParameter<std::vector<std::string> >("valueLabels") : std::vector<std::string>() ),
-      lazyParser_( params.existsAs<bool>("lazyParser") ? params.getParameter<bool>("lazyParser") : false ),
-      multiValue_(false)
-  {
-    if( !value_.empty() )
-    {
-      evaluationMap_.insert( std::make_pair( value_, std::unique_ptr<StringObjectFunction<C> >( new StringObjectFunction<C>( value_, lazyParser_ ) ) ) );
-      produces< JetValueMap >();
+  JetDeltaRValueMapProducer(edm::ParameterSet const& params)
+      : srcToken_(consumes<typename edm::View<T> >(params.getParameter<edm::InputTag>("src"))),
+        matchedToken_(consumes<typename edm::View<C> >(params.getParameter<edm::InputTag>("matched"))),
+        distMax_(params.getParameter<double>("distMax")),
+        value_(params.existsAs<std::string>("value") ? params.getParameter<std::string>("value") : ""),
+        values_(params.existsAs<std::vector<std::string> >("values")
+                    ? params.getParameter<std::vector<std::string> >("values")
+                    : std::vector<std::string>()),
+        valueLabels_(params.existsAs<std::vector<std::string> >("valueLabels")
+                         ? params.getParameter<std::vector<std::string> >("valueLabels")
+                         : std::vector<std::string>()),
+        lazyParser_(params.existsAs<bool>("lazyParser") ? params.getParameter<bool>("lazyParser") : false),
+        multiValue_(false) {
+    if (!value_.empty()) {
+      evaluationMap_.insert(std::make_pair(
+          value_, std::unique_ptr<StringObjectFunction<C> >(new StringObjectFunction<C>(value_, lazyParser_))));
+      produces<JetValueMap>();
     }
 
-    if( !valueLabels_.empty() || !values_.empty() )
-    {
-      if( valueLabels_.size()==values_.size() )
-      {
+    if (!valueLabels_.empty() || !values_.empty()) {
+      if (valueLabels_.size() == values_.size()) {
         multiValue_ = true;
-        for( size_t i=0; i<valueLabels_.size(); ++i)
-        {
-          evaluationMap_.insert( std::make_pair( valueLabels_[i], std::unique_ptr<StringObjectFunction<C> >( new StringObjectFunction<C>( values_[i], lazyParser_ ) ) ) );
-          produces< JetValueMap >(valueLabels_[i]);
+        for (size_t i = 0; i < valueLabels_.size(); ++i) {
+          evaluationMap_.insert(std::make_pair(
+              valueLabels_[i],
+              std::unique_ptr<StringObjectFunction<C> >(new StringObjectFunction<C>(values_[i], lazyParser_))));
+          produces<JetValueMap>(valueLabels_[i]);
         }
-      }
-      else
-        edm::LogWarning("ValueLabelMismatch") << "The number of value labels does not match the number of values. Values will not be evaluated.";
+      } else
+        edm::LogWarning("ValueLabelMismatch")
+            << "The number of value labels does not match the number of values. Values will not be evaluated.";
     }
   }
 
   ~JetDeltaRValueMapProducer() override {}
 
 private:
-  
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+    edm::Handle<typename edm::View<T> > h_jets1;
+    iEvent.getByToken(srcToken_, h_jets1);
+    edm::Handle<typename edm::View<C> > h_jets2;
+    iEvent.getByToken(matchedToken_, h_jets2);
 
-    edm::Handle< typename edm::View<T> > h_jets1;
-    iEvent.getByToken( srcToken_, h_jets1 );
-    edm::Handle< typename edm::View<C> > h_jets2;
-    iEvent.getByToken( matchedToken_, h_jets2 );
-
-    std::vector<float> values( h_jets1->size(), -99999 );
+    std::vector<float> values(h_jets1->size(), -99999);
     std::map<std::string, std::vector<float> > valuesMap;
-    if( multiValue_ )
-    {
-      for( size_t i=0; i<valueLabels_.size(); ++i)
-        valuesMap.insert( std::make_pair( valueLabels_[i], std::vector<float>( h_jets1->size(), -99999 ) ) );
+    if (multiValue_) {
+      for (size_t i = 0; i < valueLabels_.size(); ++i)
+        valuesMap.insert(std::make_pair(valueLabels_[i], std::vector<float>(h_jets1->size(), -99999)));
     }
-    std::vector<bool> jets1_locks( h_jets1->size(), false );
+    std::vector<bool> jets1_locks(h_jets1->size(), false);
 
-    for ( typename edm::View<C>::const_iterator ibegin = h_jets2->begin(),
-          iend = h_jets2->end(), ijet = ibegin;
-          ijet != iend; ++ijet )
-    {
+    for (typename edm::View<C>::const_iterator ibegin = h_jets2->begin(), iend = h_jets2->end(), ijet = ibegin;
+         ijet != iend;
+         ++ijet) {
       float matched_dR2 = 1e9;
       int matched_index = -1;
-     
-      for ( typename edm::View<T>::const_iterator jbegin = h_jets1->begin(),
-            jend = h_jets1->end(), jjet = jbegin;
-            jjet != jend; ++jjet )
-      {
-        int index=jjet - jbegin;
 
-        if( jets1_locks.at(index) ) continue; // skip jets that have already been matched
+      for (typename edm::View<T>::const_iterator jbegin = h_jets1->begin(), jend = h_jets1->end(), jjet = jbegin;
+           jjet != jend;
+           ++jjet) {
+        int index = jjet - jbegin;
 
-        float temp_dR2 = reco::deltaR2(ijet->eta(),ijet->phi(),jjet->eta(),jjet->phi());
-        if ( temp_dR2 < matched_dR2 )
-        {
+        if (jets1_locks.at(index))
+          continue;  // skip jets that have already been matched
+
+        float temp_dR2 = reco::deltaR2(ijet->eta(), ijet->phi(), jjet->eta(), jjet->phi());
+        if (temp_dR2 < matched_dR2) {
           matched_dR2 = temp_dR2;
           matched_index = index;
         }
-      }// end loop over src jets
+      }  // end loop over src jets
 
-      if( matched_index>=0 )
-      {
-        if ( matched_dR2 > distMax_*distMax_ )
+      if (matched_index >= 0) {
+        if (matched_dR2 > distMax_ * distMax_)
           edm::LogInfo("MatchedJetsFarApart") << "Matched jets separated by dR greater than distMax=" << distMax_;
-        else
-        {
+        else {
           jets1_locks.at(matched_index) = true;
-          if( !value_.empty() )
+          if (!value_.empty())
             values.at(matched_index) = (*(evaluationMap_.at(value_)))(*ijet);
-          if( multiValue_ )
-          {
-            for( size_t i=0; i<valueLabels_.size(); ++i)
+          if (multiValue_) {
+            for (size_t i = 0; i < valueLabels_.size(); ++i)
               valuesMap.at(valueLabels_[i]).at(matched_index) = (*(evaluationMap_.at(valueLabels_[i])))(*ijet);
           }
         }
       }
-    }// end loop over matched jets
+    }  // end loop over matched jets
 
-    if( !value_.empty() )
-    {
-      std::unique_ptr< JetValueMap > jetValueMap ( new JetValueMap() );
+    if (!value_.empty()) {
+      std::unique_ptr<JetValueMap> jetValueMap(new JetValueMap());
 
       JetValueMap::Filler filler(*jetValueMap);
       filler.insert(h_jets1, values.begin(), values.end());
@@ -139,11 +129,9 @@ private:
       // put in Event
       iEvent.put(std::move(jetValueMap));
     }
-    if( multiValue_ )
-    {
-      for( size_t i=0; i<valueLabels_.size(); ++i)
-      {
-        std::unique_ptr< JetValueMap > jetValueMap ( new JetValueMap() );
+    if (multiValue_) {
+      for (size_t i = 0; i < valueLabels_.size(); ++i) {
+        std::unique_ptr<JetValueMap> jetValueMap(new JetValueMap());
 
         JetValueMap::Filler filler(*jetValueMap);
         filler.insert(h_jets1, valuesMap.at(valueLabels_[i]).begin(), valuesMap.at(valueLabels_[i]).end());
@@ -155,21 +143,21 @@ private:
     }
   }
 
-  const edm::EDGetTokenT< typename edm::View<T> >  srcToken_;
-  const edm::EDGetTokenT< typename edm::View<C> >  matchedToken_;
-  const double                                     distMax_;
-  const std::string                                value_;
-  const std::vector<std::string>                   values_;
-  const std::vector<std::string>                   valueLabels_;
-  const bool                                       lazyParser_;
-  bool                                             multiValue_;
-  std::map<std::string, std::unique_ptr<const StringObjectFunction<C> > >  evaluationMap_;
+  const edm::EDGetTokenT<typename edm::View<T> > srcToken_;
+  const edm::EDGetTokenT<typename edm::View<C> > matchedToken_;
+  const double distMax_;
+  const std::string value_;
+  const std::vector<std::string> values_;
+  const std::vector<std::string> valueLabels_;
+  const bool lazyParser_;
+  bool multiValue_;
+  std::map<std::string, std::unique_ptr<const StringObjectFunction<C> > > evaluationMap_;
 };
 
 typedef JetDeltaRValueMapProducer<reco::Jet> RecoJetDeltaRValueMapProducer;
-typedef JetDeltaRValueMapProducer<reco::Jet,pat::Jet> RecoJetToPatJetDeltaRValueMapProducer;
+typedef JetDeltaRValueMapProducer<reco::Jet, pat::Jet> RecoJetToPatJetDeltaRValueMapProducer;
 typedef JetDeltaRValueMapProducer<pat::Jet> PatJetDeltaRValueMapProducer;
 
-DEFINE_FWK_MODULE( RecoJetDeltaRValueMapProducer );
-DEFINE_FWK_MODULE( RecoJetToPatJetDeltaRValueMapProducer );
-DEFINE_FWK_MODULE( PatJetDeltaRValueMapProducer );
+DEFINE_FWK_MODULE(RecoJetDeltaRValueMapProducer);
+DEFINE_FWK_MODULE(RecoJetToPatJetDeltaRValueMapProducer);
+DEFINE_FWK_MODULE(PatJetDeltaRValueMapProducer);

--- a/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
@@ -45,7 +45,7 @@ public:
       lazyParser_( params.existsAs<bool>("lazyParser") ? params.getParameter<bool>("lazyParser") : false ),
       multiValue_(false)
   {
-    if( value_!="" )
+    if( !value_.empty() )
     {
       evaluationMap_.insert( std::make_pair( value_, std::unique_ptr<StringObjectFunction<C> >( new StringObjectFunction<C>( value_, lazyParser_ ) ) ) );
       produces< JetValueMap >();
@@ -117,7 +117,7 @@ private:
         else
         {
           jets1_locks.at(matched_index) = true;
-          if( value_!="" )
+          if( !value_.empty() )
             values.at(matched_index) = (*(evaluationMap_.at(value_)))(*ijet);
           if( multiValue_ )
           {
@@ -128,7 +128,7 @@ private:
       }
     }// end loop over matched jets
 
-    if( value_!="" )
+    if( !value_.empty() )
     {
       std::unique_ptr< JetValueMap > jetValueMap ( new JetValueMap() );
 

--- a/CommonTools/RecoAlgos/plugins/JetTracksAssociationToTrackRefs.cc
+++ b/CommonTools/RecoAlgos/plugins/JetTracksAssociationToTrackRefs.cc
@@ -20,7 +20,7 @@
  * AssociationVector<JetRefBaseProd, vector<RefVector<Track> > to a
  * RefVector<Track> of the (unique) values.
  */
-class JetTracksAssociationToTrackRefs: public edm::global::EDProducer<> {
+class JetTracksAssociationToTrackRefs : public edm::global::EDProducer<> {
 public:
   JetTracksAssociationToTrackRefs(const edm::ParameterSet& iConfig);
 
@@ -30,19 +30,18 @@ public:
 
 private:
   edm::EDGetTokenT<reco::JetTracksAssociation::Container> associationToken_;
-  edm::EDGetTokenT<edm::View<reco::Jet> > jetToken_;
+  edm::EDGetTokenT<edm::View<reco::Jet>> jetToken_;
   edm::EDGetTokenT<reco::JetCorrector> correctorToken_;
   const double ptMin_;
 };
 
-
-JetTracksAssociationToTrackRefs::JetTracksAssociationToTrackRefs(const edm::ParameterSet& iConfig):
-  associationToken_(consumes<reco::JetTracksAssociation::Container>(iConfig.getParameter<edm::InputTag>("association"))),
-  jetToken_(consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
-  correctorToken_(consumes<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("corrector"))),
-  ptMin_(iConfig.getParameter<double>("correctedPtMin"))
-{
-  produces<reco::TrackRefVector> ();
+JetTracksAssociationToTrackRefs::JetTracksAssociationToTrackRefs(const edm::ParameterSet& iConfig)
+    : associationToken_(
+          consumes<reco::JetTracksAssociation::Container>(iConfig.getParameter<edm::InputTag>("association"))),
+      jetToken_(consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
+      correctorToken_(consumes<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("corrector"))),
+      ptMin_(iConfig.getParameter<double>("correctedPtMin")) {
+  produces<reco::TrackRefVector>();
 }
 
 void JetTracksAssociationToTrackRefs::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -72,32 +71,30 @@ void JetTracksAssociationToTrackRefs::produce(edm::StreamID, edm::Event& iEvent,
 
   // Exctract tracks only for jets passing certain pT threshold after
   // correction
-  for(size_t i=0; i<jets.size(); ++i) {
+  for (size_t i = 0; i < jets.size(); ++i) {
     edm::RefToBase<reco::Jet> jetRef = jets.refAt(i);
     const reco::Jet& jet = *jetRef;
 
     auto p4 = jet.p4();
 
     // Energy correction in the most general way
-    if(!corrector.vectorialCorrection()) {
+    if (!corrector.vectorialCorrection()) {
       double scale = 1;
-      if(!corrector.refRequired()) {
+      if (!corrector.refRequired()) {
         scale = corrector.correction(jet);
-      }
-      else {
+      } else {
         scale = corrector.correction(jet, jetRef);
       }
-      p4 = p4*scale;
-    }
-    else {
+      p4 = p4 * scale;
+    } else {
       corrector.correction(jet, jetRef, p4);
     }
 
-    if(p4.pt() <= ptMin_)
+    if (p4.pt() <= ptMin_)
       continue;
 
-    for(const auto& trackRef: association[jetRef]) {
-      if(alreadyAdded.find(trackRef.key()) == alreadyAdded.end()) {
+    for (const auto& trackRef : association[jetRef]) {
+      if (alreadyAdded.find(trackRef.key()) == alreadyAdded.end()) {
         ret->push_back(trackRef);
         alreadyAdded.insert(trackRef.key());
       }

--- a/CommonTools/RecoAlgos/plugins/LargestEtCaloJetSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/LargestEtCaloJetSelector.cc
@@ -11,11 +11,7 @@
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "CommonTools/Utils/interface/EtComparator.h"
 
-typedef ObjectSelectorStream<
-          SortCollectionSelector<
-            reco::CaloJetCollection, 
-              GreaterByEt<reco::CaloJet> 
-          > 
-        > LargestEtCaloJetSelector;
+typedef ObjectSelectorStream<SortCollectionSelector<reco::CaloJetCollection, GreaterByEt<reco::CaloJet> > >
+    LargestEtCaloJetSelector;
 
-DEFINE_FWK_MODULE( LargestEtCaloJetSelector );
+DEFINE_FWK_MODULE(LargestEtCaloJetSelector);

--- a/CommonTools/RecoAlgos/plugins/LargestEtPFJetSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/LargestEtPFJetSelector.cc
@@ -11,11 +11,7 @@
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "CommonTools/Utils/interface/EtComparator.h"
 
-typedef ObjectSelectorStream<
-          SortCollectionSelector<
-            reco::PFJetCollection, 
-              GreaterByEt<reco::PFJet> 
-          > 
-        > LargestEtPFJetSelector;
+typedef ObjectSelectorStream<SortCollectionSelector<reco::PFJetCollection, GreaterByEt<reco::PFJet> > >
+    LargestEtPFJetSelector;
 
-DEFINE_FWK_MODULE( LargestEtPFJetSelector );
+DEFINE_FWK_MODULE(LargestEtPFJetSelector);

--- a/CommonTools/RecoAlgos/plugins/LargestPtTrackSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/LargestPtTrackSelector.cc
@@ -12,11 +12,6 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "CommonTools/Utils/interface/PtComparator.h"
 
- typedef ObjectSelector<
-           SortCollectionSelector<
-             reco::TrackCollection, 
-             GreaterByPt<reco::Track> 
-           > 
-         > LargestPtTrackSelector;
+typedef ObjectSelector<SortCollectionSelector<reco::TrackCollection, GreaterByPt<reco::Track> > > LargestPtTrackSelector;
 
-DEFINE_FWK_MODULE( LargestPtTrackSelector );
+DEFINE_FWK_MODULE(LargestPtTrackSelector);

--- a/CommonTools/RecoAlgos/plugins/MassWindowTrackSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/MassWindowTrackSelector.cc
@@ -13,13 +13,8 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "CommonTools/UtilAlgos/interface/MasslessInvariantMass.h"
 
- typedef ObjectSelector<
-           ObjectPairCollectionSelector<
-             reco::TrackCollection, 
-             RangeObjectPairSelector<
-               MasslessInvariantMass
-             >
-           >
-         > MassWindowTrackSelector;
+typedef ObjectSelector<
+    ObjectPairCollectionSelector<reco::TrackCollection, RangeObjectPairSelector<MasslessInvariantMass> > >
+    MassWindowTrackSelector;
 
-DEFINE_FWK_MODULE( MassWindowTrackSelector );
+DEFINE_FWK_MODULE(MassWindowTrackSelector);

--- a/CommonTools/RecoAlgos/plugins/MuonCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/MuonCountFilter.cc
@@ -10,8 +10,6 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
 
- typedef ObjectCountFilter<
-           reco::MuonCollection
-         >::type MuonCountFilter;
+typedef ObjectCountFilter<reco::MuonCollection>::type MuonCountFilter;
 
-DEFINE_FWK_MODULE( MuonCountFilter );
+DEFINE_FWK_MODULE(MuonCountFilter);

--- a/CommonTools/RecoAlgos/plugins/MuonRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/MuonRefSelector.cc
@@ -26,10 +26,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
- typedef SingleObjectSelector<
-           reco::MuonCollection, 
-           StringCutObjectSelector<reco::Muon>,
-           reco::MuonRefVector
-         > MuonRefSelector;
+typedef SingleObjectSelector<reco::MuonCollection, StringCutObjectSelector<reco::Muon>, reco::MuonRefVector>
+    MuonRefSelector;
 
-DEFINE_FWK_MODULE( MuonRefSelector );
+DEFINE_FWK_MODULE(MuonRefSelector);

--- a/CommonTools/RecoAlgos/plugins/MuonSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/MuonSelector.cc
@@ -29,10 +29,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
- typedef SingleObjectSelector<
-           edm::View<reco::Muon>, 
-           StringCutObjectSelector<reco::Muon>,
-           reco::MuonCollection
-         > MuonSelector;
+typedef SingleObjectSelector<edm::View<reco::Muon>, StringCutObjectSelector<reco::Muon>, reco::MuonCollection>
+    MuonSelector;
 
-DEFINE_FWK_MODULE( MuonSelector );
+DEFINE_FWK_MODULE(MuonSelector);

--- a/CommonTools/RecoAlgos/plugins/MuonShallowCloneProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/MuonShallowCloneProducer.cc
@@ -6,4 +6,4 @@ typedef ShallowCloneProducer<reco::MuonCollection> MuonShallowCloneProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( MuonShallowCloneProducer );
+DEFINE_FWK_MODULE(MuonShallowCloneProducer);

--- a/CommonTools/RecoAlgos/plugins/MuonViewRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/MuonViewRefSelector.cc
@@ -28,10 +28,7 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Common/interface/RefToBaseVector.h"
 
-typedef SingleObjectSelector<
-       edm::View<reco::Muon>, 
-       StringCutObjectSelector<reco::Muon>,
-       edm::RefToBaseVector<reco::Muon>
-     > MuonViewRefSelector;
+typedef SingleObjectSelector<edm::View<reco::Muon>, StringCutObjectSelector<reco::Muon>, edm::RefToBaseVector<reco::Muon> >
+    MuonViewRefSelector;
 
-DEFINE_FWK_MODULE( MuonViewRefSelector );
+DEFINE_FWK_MODULE(MuonViewRefSelector);

--- a/CommonTools/RecoAlgos/plugins/PFClusterCandidateMerger.cc
+++ b/CommonTools/RecoAlgos/plugins/PFClusterCandidateMerger.cc
@@ -13,7 +13,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "CommonTools/UtilAlgos/interface/Merger.h"
 
-typedef Merger<reco::RecoPFClusterRefCandidateCollection>
-        PFClusterRefCandidateMerger;
+typedef Merger<reco::RecoPFClusterRefCandidateCollection> PFClusterRefCandidateMerger;
 
 DEFINE_FWK_MODULE(PFClusterRefCandidateMerger);

--- a/CommonTools/RecoAlgos/plugins/PFClusterCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/PFClusterCandidateProducer.cc
@@ -12,11 +12,10 @@
 #include "CommonTools/RecoAlgos/src/PFClusterToRefCandidate.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef CandidateProducer<
-          edm::View<reco::PFCluster>,
-          reco::RecoPFClusterRefCandidateCollection,
-          AnySelector,
-          converter::helper::CandConverter<reco::PFCluster>::type
-        > PFClusterRefCandidateProducer;
+typedef CandidateProducer<edm::View<reco::PFCluster>,
+                          reco::RecoPFClusterRefCandidateCollection,
+                          AnySelector,
+                          converter::helper::CandConverter<reco::PFCluster>::type>
+    PFClusterRefCandidateProducer;
 
 DEFINE_FWK_MODULE(PFClusterRefCandidateProducer);

--- a/CommonTools/RecoAlgos/plugins/PFJetSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/PFJetSelector.cc
@@ -26,9 +26,6 @@
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 
- typedef SingleObjectSelector<
-           reco::PFJetCollection, 
-           StringCutObjectSelector<reco::PFJet> 
-         > PFJetSelector;
+typedef SingleObjectSelector<reco::PFJetCollection, StringCutObjectSelector<reco::PFJet> > PFJetSelector;
 
-DEFINE_FWK_MODULE( PFJetSelector );
+DEFINE_FWK_MODULE(PFJetSelector);

--- a/CommonTools/RecoAlgos/plugins/PhotonCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PhotonCountFilter.cc
@@ -10,8 +10,6 @@
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
 
- typedef ObjectCountFilter<
-           reco::PhotonCollection
-         >::type PhotonCountFilter;
+typedef ObjectCountFilter<reco::PhotonCollection>::type PhotonCountFilter;
 
-DEFINE_FWK_MODULE( PhotonCountFilter );
+DEFINE_FWK_MODULE(PhotonCountFilter);

--- a/CommonTools/RecoAlgos/plugins/PhotonRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/PhotonRefSelector.cc
@@ -26,10 +26,7 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 
- typedef SingleObjectSelector<
-           reco::PhotonCollection, 
-           StringCutObjectSelector<reco::Photon>,
-           reco::PhotonRefVector
-         > PhotonRefSelector;
+typedef SingleObjectSelector<reco::PhotonCollection, StringCutObjectSelector<reco::Photon>, reco::PhotonRefVector>
+    PhotonRefSelector;
 
-DEFINE_FWK_MODULE( PhotonRefSelector );
+DEFINE_FWK_MODULE(PhotonRefSelector);

--- a/CommonTools/RecoAlgos/plugins/PhotonSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/PhotonSelector.cc
@@ -26,9 +26,6 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 
- typedef SingleObjectSelector<
-           reco::PhotonCollection, 
-           StringCutObjectSelector<reco::Photon>
-         > PhotonSelector;
+typedef SingleObjectSelector<reco::PhotonCollection, StringCutObjectSelector<reco::Photon> > PhotonSelector;
 
-DEFINE_FWK_MODULE( PhotonSelector );
+DEFINE_FWK_MODULE(PhotonSelector);

--- a/CommonTools/RecoAlgos/plugins/PrimaryVertexSorter.cc
+++ b/CommonTools/RecoAlgos/plugins/PrimaryVertexSorter.cc
@@ -2,7 +2,7 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedRefCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 
-typedef  PrimaryVertexSorter<std::vector<reco::RecoChargedRefCandidate> > RecoChargedRefCandidatePrimaryVertexSorter ;
+typedef PrimaryVertexSorter<std::vector<reco::RecoChargedRefCandidate> > RecoChargedRefCandidatePrimaryVertexSorter;
 DEFINE_FWK_MODULE(RecoChargedRefCandidatePrimaryVertexSorter);
-typedef  PrimaryVertexSorter<std::vector<reco::PFCandidate> > PFCandidatePrimaryVertexSorter;
+typedef PrimaryVertexSorter<std::vector<reco::PFCandidate> > PFCandidatePrimaryVertexSorter;
 DEFINE_FWK_MODULE(PFCandidatePrimaryVertexSorter);

--- a/CommonTools/RecoAlgos/plugins/PrimaryVertexSorter.h
+++ b/CommonTools/RecoAlgos/plugins/PrimaryVertexSorter.h
@@ -29,8 +29,7 @@
 template <class ParticlesCollection>
 
 class PrimaryVertexSorter : public edm::stream::EDProducer<> {
- public:
-
+public:
   typedef edm::Association<reco::VertexCollection> CandToVertex;
   typedef edm::ValueMap<int> CandToVertexQuality;
   typedef edm::ValueMap<float> VertexScore;
@@ -43,35 +42,36 @@ class PrimaryVertexSorter : public edm::stream::EDProducer<> {
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
- private:
-
-  PrimaryVertexAssignment    assignmentAlgo_;
-  PrimaryVertexSorting       sortingAlgo_;
+private:
+  PrimaryVertexAssignment assignmentAlgo_;
+  PrimaryVertexSorting sortingAlgo_;
 
   /// Candidates to be analyzed
-  edm::EDGetTokenT<PFCollection>   tokenCandidates_;
+  edm::EDGetTokenT<PFCollection> tokenCandidates_;
 
   /// vertices
-  edm::EDGetTokenT<reco::VertexCollection>   tokenVertices_;
-  edm::EDGetTokenT<edm::View<reco::Candidate> >   tokenJets_;
-  edm::EDGetTokenT<edm::ValueMap<float> >   tokenTrackTimeTag_;
-  edm::EDGetTokenT<edm::ValueMap<float> >   tokenTrackTimeResoTag_;
+  edm::EDGetTokenT<reco::VertexCollection> tokenVertices_;
+  edm::EDGetTokenT<edm::View<reco::Candidate>> tokenJets_;
+  edm::EDGetTokenT<edm::ValueMap<float>> tokenTrackTimeTag_;
+  edm::EDGetTokenT<edm::ValueMap<float>> tokenTrackTimeResoTag_;
 
   bool produceOriginalMapping_;
   bool produceSortedVertices_;
   bool producePFPileUp_;
   bool producePFNoPileUp_;
-  int  qualityCut_;
+  int qualityCut_;
   bool useMET_;
   bool useTiming_;
 
-  void doConsumesForTiming(const edm::ParameterSet &iConfig) ;
-  bool needsProductsForTiming() ;
-  std::pair<int,PrimaryVertexAssignment::Quality> runAlgo( const reco::VertexCollection& vertices, const typename ParticlesCollection::value_type & pf, const edm::ValueMap<float> *trackTimeTag,
-                                   const edm::ValueMap<float> *trackTimeResoTag, const edm::View<reco::Candidate>& jets, const TransientTrackBuilder& builder) ;
+  void doConsumesForTiming(const edm::ParameterSet& iConfig);
+  bool needsProductsForTiming();
+  std::pair<int, PrimaryVertexAssignment::Quality> runAlgo(const reco::VertexCollection& vertices,
+                                                           const typename ParticlesCollection::value_type& pf,
+                                                           const edm::ValueMap<float>* trackTimeTag,
+                                                           const edm::ValueMap<float>* trackTimeResoTag,
+                                                           const edm::View<reco::Candidate>& jets,
+                                                           const TransientTrackBuilder& builder);
 };
-
-
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
@@ -82,281 +82,264 @@ class PrimaryVertexSorter : public edm::stream::EDProducer<> {
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-
-
 template <class ParticlesCollection>
-PrimaryVertexSorter<ParticlesCollection>::PrimaryVertexSorter(const edm::ParameterSet& iConfig) :
-  assignmentAlgo_(iConfig.getParameterSet("assignment")),
-  sortingAlgo_(iConfig.getParameterSet("sorting")),
-  tokenCandidates_(consumes<ParticlesCollection>(iConfig.getParameter<edm::InputTag>("particles"))),
-  tokenVertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
-  tokenJets_(consumes<edm::View<reco::Candidate> > (iConfig.getParameter<edm::InputTag>("jets"))),
-  produceOriginalMapping_(iConfig.getParameter<bool>("produceAssociationToOriginalVertices")),
-  produceSortedVertices_(iConfig.getParameter<bool>("produceSortedVertices")),
-  producePFPileUp_(iConfig.getParameter<bool>("producePileUpCollection")),
-  producePFNoPileUp_(iConfig.getParameter<bool>("produceNoPileUpCollection")),
-  qualityCut_(iConfig.getParameter<int>("qualityForPrimary")),
-  useMET_(iConfig.getParameter<bool>("usePVMET")),
-  useTiming_(iConfig.getParameterSet("assignment").getParameter<bool>("useTiming"))
-{
+PrimaryVertexSorter<ParticlesCollection>::PrimaryVertexSorter(const edm::ParameterSet& iConfig)
+    : assignmentAlgo_(iConfig.getParameterSet("assignment")),
+      sortingAlgo_(iConfig.getParameterSet("sorting")),
+      tokenCandidates_(consumes<ParticlesCollection>(iConfig.getParameter<edm::InputTag>("particles"))),
+      tokenVertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
+      tokenJets_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("jets"))),
+      produceOriginalMapping_(iConfig.getParameter<bool>("produceAssociationToOriginalVertices")),
+      produceSortedVertices_(iConfig.getParameter<bool>("produceSortedVertices")),
+      producePFPileUp_(iConfig.getParameter<bool>("producePileUpCollection")),
+      producePFNoPileUp_(iConfig.getParameter<bool>("produceNoPileUpCollection")),
+      qualityCut_(iConfig.getParameter<int>("qualityForPrimary")),
+      useMET_(iConfig.getParameter<bool>("usePVMET")),
+      useTiming_(iConfig.getParameterSet("assignment").getParameter<bool>("useTiming")) {
+  using namespace std;
+  using namespace edm;
+  using namespace reco;
 
-using namespace std;
-using namespace edm;
-using namespace reco;
-
-  if(produceOriginalMapping_){
-      produces< CandToVertex> ("original");
-      produces< CandToVertexQuality> ("original");
-      produces< VertexScore> ("original");
+  if (produceOriginalMapping_) {
+    produces<CandToVertex>("original");
+    produces<CandToVertexQuality>("original");
+    produces<VertexScore>("original");
   }
-  if(produceSortedVertices_){
-      produces< reco::VertexCollection> ();
-      produces< CandToVertex> ();
-      produces< CandToVertexQuality> ();
-      produces< VertexScore> ();
+  if (produceSortedVertices_) {
+    produces<reco::VertexCollection>();
+    produces<CandToVertex>();
+    produces<CandToVertexQuality>();
+    produces<VertexScore>();
   }
 
-  if(producePFPileUp_){
-      if(produceOriginalMapping_)
-            produces< PFCollection> ("originalPileUp");
-      if(produceSortedVertices_)
-            produces< PFCollection> ("PileUp");
+  if (producePFPileUp_) {
+    if (produceOriginalMapping_)
+      produces<PFCollection>("originalPileUp");
+    if (produceSortedVertices_)
+      produces<PFCollection>("PileUp");
   }
 
-  if(producePFNoPileUp_){
-      if(produceOriginalMapping_)
-            produces< PFCollection> ("originalNoPileUp");
-      if(produceSortedVertices_)
-            produces< PFCollection> ("NoPileUp");
+  if (producePFNoPileUp_) {
+    if (produceOriginalMapping_)
+      produces<PFCollection>("originalNoPileUp");
+    if (produceSortedVertices_)
+      produces<PFCollection>("NoPileUp");
   }
 
-  if (useTiming_) doConsumesForTiming(iConfig);
-
+  if (useTiming_)
+    doConsumesForTiming(iConfig);
 }
 
-
-
-
-
 template <class ParticlesCollection>
-void PrimaryVertexSorter<ParticlesCollection>::produce(edm::Event& iEvent,  const edm::EventSetup& iSetup) {
+void PrimaryVertexSorter<ParticlesCollection>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace std;
+  using namespace edm;
+  using namespace reco;
 
-using namespace std;
-using namespace edm;
-using namespace reco;
-
-  Handle<edm::View<reco::Candidate> > jets;
-  iEvent.getByToken( tokenJets_, jets);
+  Handle<edm::View<reco::Candidate>> jets;
+  iEvent.getByToken(tokenJets_, jets);
 
   edm::ESHandle<TransientTrackBuilder> builder;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
 
-
   Handle<VertexCollection> vertices;
-  iEvent.getByToken( tokenVertices_, vertices);
+  iEvent.getByToken(tokenVertices_, vertices);
 
   Handle<ParticlesCollection> particlesHandle;
-  iEvent.getByToken( tokenCandidates_, particlesHandle);
-  
-  Handle<edm::ValueMap<float> > trackTimeTagHandle;
-  Handle<edm::ValueMap<float> > trackTimeResoTagHandle;
-  
-  const edm::ValueMap<float> *trackTimeTag = nullptr;
-  const edm::ValueMap<float> *trackTimeResoTag = nullptr;
+  iEvent.getByToken(tokenCandidates_, particlesHandle);
+
+  Handle<edm::ValueMap<float>> trackTimeTagHandle;
+  Handle<edm::ValueMap<float>> trackTimeResoTagHandle;
+
+  const edm::ValueMap<float>* trackTimeTag = nullptr;
+  const edm::ValueMap<float>* trackTimeResoTag = nullptr;
   if (useTiming_ && needsProductsForTiming()) {
     iEvent.getByToken(tokenTrackTimeTag_, trackTimeTagHandle);
     iEvent.getByToken(tokenTrackTimeResoTag_, trackTimeResoTagHandle);
-    
+
     trackTimeTag = trackTimeTagHandle.product();
     trackTimeResoTag = trackTimeResoTagHandle.product();
-  } 
-    
+  }
+
   ParticlesCollection particles = *particlesHandle.product();
   std::vector<int> pfToPVVector;
   std::vector<PrimaryVertexAssignment::Quality> pfToPVQualityVector;
   //reverse mapping
-  std::vector< std::vector<int> > pvToPFVector(vertices->size());
-  std::vector< std::vector<const reco::Candidate *> > pvToCandVector(vertices->size());
-  std::vector< std::vector<PrimaryVertexAssignment::Quality> > pvToPFQualityVector(vertices->size());
+  std::vector<std::vector<int>> pvToPFVector(vertices->size());
+  std::vector<std::vector<const reco::Candidate*>> pvToCandVector(vertices->size());
+  std::vector<std::vector<PrimaryVertexAssignment::Quality>> pvToPFQualityVector(vertices->size());
   std::vector<float> vertexScoreOriginal(vertices->size());
   std::vector<float> vertexScore(vertices->size());
 
-    for(auto const & pf : particles) {
-    std::pair<int,PrimaryVertexAssignment::Quality> vtxWithQuality = runAlgo(*vertices,pf,trackTimeTag,trackTimeResoTag,*jets,*builder);
-    pfToPVVector.push_back(vtxWithQuality.first); 
-    pfToPVQualityVector.push_back(vtxWithQuality.second); 
+  for (auto const& pf : particles) {
+    std::pair<int, PrimaryVertexAssignment::Quality> vtxWithQuality =
+        runAlgo(*vertices, pf, trackTimeTag, trackTimeResoTag, *jets, *builder);
+    pfToPVVector.push_back(vtxWithQuality.first);
+    pfToPVQualityVector.push_back(vtxWithQuality.second);
   }
 
   //Invert the mapping
-  for(size_t i = 0; i < pfToPVVector.size();i++)
-  {
+  for (size_t i = 0; i < pfToPVVector.size(); i++) {
     auto pv = pfToPVVector[i];
     auto qual = pfToPVQualityVector[i];
-    if(pv >=0 and qual >= qualityCut_){
-       pvToPFVector[pv].push_back(i);
-//    std::cout << i << std::endl;
-//     const typename  ParticlesCollection::value_type & cp = particles[i];
-//     std::cout << "CP " << &cp <<  std::endl;
-       pvToCandVector[pv].push_back( &particles[i] );
-       pvToPFQualityVector[pv].push_back(qual);
+    if (pv >= 0 and qual >= qualityCut_) {
+      pvToPFVector[pv].push_back(i);
+      //    std::cout << i << std::endl;
+      //     const typename  ParticlesCollection::value_type & cp = particles[i];
+      //     std::cout << "CP " << &cp <<  std::endl;
+      pvToCandVector[pv].push_back(&particles[i]);
+      pvToPFQualityVector[pv].push_back(qual);
     }
   }
 
   //Use multimap for sorting of indices
-  std::multimap<float,int> scores;
-  for(unsigned int i=0;i<vertices->size();i++){
-     float s=sortingAlgo_.score((*vertices)[i],pvToCandVector[i],useMET_);
-     vertexScoreOriginal[i]=s;
-     scores.insert(std::pair<float,int>(-s,i));    
+  std::multimap<float, int> scores;
+  for (unsigned int i = 0; i < vertices->size(); i++) {
+    float s = sortingAlgo_.score((*vertices)[i], pvToCandVector[i], useMET_);
+    vertexScoreOriginal[i] = s;
+    scores.insert(std::pair<float, int>(-s, i));
   }
 
   //create indices
-  std::vector<int> oldToNew(vertices->size()),  newToOld(vertices->size());
-  size_t newIdx=0;
-  for(auto const &  idx :  scores)
-  {
-//    std::cout << newIdx << " score: " << idx.first << " oldidx: " << idx.second << " "<< producePFPileUp_ << std::endl;
-    vertexScore[newIdx]=-idx.first;
-    oldToNew[idx.second]=newIdx;
-    newToOld[newIdx]=idx.second;
+  std::vector<int> oldToNew(vertices->size()), newToOld(vertices->size());
+  size_t newIdx = 0;
+  for (auto const& idx : scores) {
+    //    std::cout << newIdx << " score: " << idx.first << " oldidx: " << idx.second << " "<< producePFPileUp_ << std::endl;
+    vertexScore[newIdx] = -idx.first;
+    oldToNew[idx.second] = newIdx;
+    newToOld[newIdx] = idx.second;
     newIdx++;
   }
-  
 
-
-
-  if(produceOriginalMapping_){
-    unique_ptr< CandToVertex>  pfCandToOriginalVertexOutput( new CandToVertex(vertices) );
-    unique_ptr< CandToVertexQuality>  pfCandToOriginalVertexQualityOutput( new CandToVertexQuality() );
+  if (produceOriginalMapping_) {
+    unique_ptr<CandToVertex> pfCandToOriginalVertexOutput(new CandToVertex(vertices));
+    unique_ptr<CandToVertexQuality> pfCandToOriginalVertexQualityOutput(new CandToVertexQuality());
     CandToVertex::Filler cand2VertexFiller(*pfCandToOriginalVertexOutput);
     CandToVertexQuality::Filler cand2VertexQualityFiller(*pfCandToOriginalVertexQualityOutput);
 
-    cand2VertexFiller.insert(particlesHandle,pfToPVVector.begin(),pfToPVVector.end());
-    cand2VertexQualityFiller.insert(particlesHandle,pfToPVQualityVector.begin(),pfToPVQualityVector.end());
+    cand2VertexFiller.insert(particlesHandle, pfToPVVector.begin(), pfToPVVector.end());
+    cand2VertexQualityFiller.insert(particlesHandle, pfToPVQualityVector.begin(), pfToPVQualityVector.end());
 
     cand2VertexFiller.fill();
     cand2VertexQualityFiller.fill();
-    iEvent.put(std::move(pfCandToOriginalVertexOutput) ,"original");
-    iEvent.put(std::move(pfCandToOriginalVertexQualityOutput) ,"original");
+    iEvent.put(std::move(pfCandToOriginalVertexOutput), "original");
+    iEvent.put(std::move(pfCandToOriginalVertexQualityOutput), "original");
 
-    unique_ptr< VertexScore>  vertexScoreOriginalOutput( new VertexScore );
+    unique_ptr<VertexScore> vertexScoreOriginalOutput(new VertexScore);
     VertexScore::Filler vertexScoreOriginalFiller(*vertexScoreOriginalOutput);
-    vertexScoreOriginalFiller.insert(vertices,vertexScoreOriginal.begin(),vertexScoreOriginal.end());
+    vertexScoreOriginalFiller.insert(vertices, vertexScoreOriginal.begin(), vertexScoreOriginal.end());
     vertexScoreOriginalFiller.fill();
-    iEvent.put(std::move(vertexScoreOriginalOutput) ,"original");
- 
+    iEvent.put(std::move(vertexScoreOriginalOutput), "original");
   }
 
-  if(produceSortedVertices_){
-      std::vector<int> pfToSortedPVVector;
-//      std::vector<int> pfToSortedPVQualityVector;
-      for(size_t i=0;i<pfToPVVector.size();i++) {
-        pfToSortedPVVector.push_back(oldToNew[pfToPVVector[i]]);
-//        pfToSortedPVQualityVector.push_back(pfToPVQualityVector[i]); //same as old!
-      }
+  if (produceSortedVertices_) {
+    std::vector<int> pfToSortedPVVector;
+    //      std::vector<int> pfToSortedPVQualityVector;
+    for (size_t i = 0; i < pfToPVVector.size(); i++) {
+      pfToSortedPVVector.push_back(oldToNew[pfToPVVector[i]]);
+      //        pfToSortedPVQualityVector.push_back(pfToPVQualityVector[i]); //same as old!
+    }
 
-      unique_ptr< reco::VertexCollection>  sortedVerticesOutput( new reco::VertexCollection );
-      for(size_t i=0;i<vertices->size();i++){
-         sortedVerticesOutput->push_back((*vertices)[newToOld[i]]); 
-      }
+    unique_ptr<reco::VertexCollection> sortedVerticesOutput(new reco::VertexCollection);
+    for (size_t i = 0; i < vertices->size(); i++) {
+      sortedVerticesOutput->push_back((*vertices)[newToOld[i]]);
+    }
     edm::OrphanHandle<reco::VertexCollection> oh = iEvent.put(std::move(sortedVerticesOutput));
-    unique_ptr< CandToVertex>  pfCandToVertexOutput( new CandToVertex(oh) );
-    unique_ptr< CandToVertexQuality>  pfCandToVertexQualityOutput( new CandToVertexQuality() );
+    unique_ptr<CandToVertex> pfCandToVertexOutput(new CandToVertex(oh));
+    unique_ptr<CandToVertexQuality> pfCandToVertexQualityOutput(new CandToVertexQuality());
     CandToVertex::Filler cand2VertexFiller(*pfCandToVertexOutput);
     CandToVertexQuality::Filler cand2VertexQualityFiller(*pfCandToVertexQualityOutput);
 
-    cand2VertexFiller.insert(particlesHandle,pfToSortedPVVector.begin(),pfToSortedPVVector.end());
-    cand2VertexQualityFiller.insert(particlesHandle,pfToPVQualityVector.begin(),pfToPVQualityVector.end());
+    cand2VertexFiller.insert(particlesHandle, pfToSortedPVVector.begin(), pfToSortedPVVector.end());
+    cand2VertexQualityFiller.insert(particlesHandle, pfToPVQualityVector.begin(), pfToPVQualityVector.end());
 
     cand2VertexFiller.fill();
     cand2VertexQualityFiller.fill();
-    iEvent.put(std::move(pfCandToVertexOutput ));
-    iEvent.put(std::move(pfCandToVertexQualityOutput ));
+    iEvent.put(std::move(pfCandToVertexOutput));
+    iEvent.put(std::move(pfCandToVertexQualityOutput));
 
-    unique_ptr< VertexScore>  vertexScoreOutput( new VertexScore );
+    unique_ptr<VertexScore> vertexScoreOutput(new VertexScore);
     VertexScore::Filler vertexScoreFiller(*vertexScoreOutput);
-    vertexScoreFiller.insert(oh,vertexScore.begin(),vertexScore.end());
+    vertexScoreFiller.insert(oh, vertexScore.begin(), vertexScore.end());
     vertexScoreFiller.fill();
     iEvent.put(std::move(vertexScoreOutput));
-
-
   }
 
+  unique_ptr<PFCollection> pfCollectionNOPUOriginalOutput(new PFCollection);
+  unique_ptr<PFCollection> pfCollectionNOPUOutput(new PFCollection);
+  unique_ptr<PFCollection> pfCollectionPUOriginalOutput(new PFCollection);
+  unique_ptr<PFCollection> pfCollectionPUOutput(new PFCollection);
 
-  unique_ptr< PFCollection >  pfCollectionNOPUOriginalOutput( new PFCollection );
-  unique_ptr< PFCollection >  pfCollectionNOPUOutput( new PFCollection );
-  unique_ptr< PFCollection >  pfCollectionPUOriginalOutput( new PFCollection );
-  unique_ptr< PFCollection >  pfCollectionPUOutput( new PFCollection );
-
-  for(size_t i=0;i<particles.size();i++) {
+  for (size_t i = 0; i < particles.size(); i++) {
     auto pv = pfToPVVector[i];
     auto qual = pfToPVQualityVector[i];
 
+    if (producePFNoPileUp_ && produceSortedVertices_)
+      if (pv == newToOld[0] and qual >= qualityCut_)
+        pfCollectionNOPUOutput->push_back(particles[i]);
 
-     if(producePFNoPileUp_ && produceSortedVertices_) 
-         if(pv == newToOld[0] and qual >= qualityCut_) 
-                   pfCollectionNOPUOutput->push_back(particles[i]);
+    if (producePFPileUp_ && produceSortedVertices_)
+      if (pv != newToOld[0] and qual >= qualityCut_)
+        pfCollectionPUOutput->push_back(particles[i]);
 
-     if(producePFPileUp_ && produceSortedVertices_) 
-         if(pv != newToOld[0] and qual >= qualityCut_) 
-                   pfCollectionPUOutput->push_back(particles[i]);
+    if (producePFNoPileUp_ && produceOriginalMapping_)
+      if (pv == 0 and qual >= qualityCut_)
+        pfCollectionNOPUOriginalOutput->push_back(particles[i]);
 
-     if(producePFNoPileUp_ && produceOriginalMapping_) 
-         if(pv == 0 and qual >= qualityCut_) 
-                   pfCollectionNOPUOriginalOutput->push_back(particles[i]);
-
-     if(producePFPileUp_ && produceOriginalMapping_) 
-         if(pv != 0 and qual >= qualityCut_) 
-                   pfCollectionPUOriginalOutput->push_back(particles[i]);
-
-  }              
-  if(producePFNoPileUp_ && produceSortedVertices_) iEvent.put(std::move(pfCollectionNOPUOutput),"NoPileUp" );
-  if(producePFPileUp_ && produceSortedVertices_) iEvent.put(std::move(pfCollectionPUOutput), "PileUp");
-  if(producePFNoPileUp_ && produceOriginalMapping_) iEvent.put(std::move(pfCollectionNOPUOriginalOutput),"originalNoPileUp" );
-  if(producePFPileUp_ && produceOriginalMapping_) iEvent.put(std::move(pfCollectionPUOriginalOutput),"originalPileUp" );
-  
-
-} 
-
-
-template<>
-void PrimaryVertexSorter<std::vector<reco::RecoChargedRefCandidate>>::doConsumesForTiming(const edm::ParameterSet &iConfig) 
-{
-  tokenTrackTimeTag_ = consumes<edm::ValueMap<float> > (iConfig.getParameter<edm::InputTag>("trackTimeTag"));
-  tokenTrackTimeResoTag_ = consumes<edm::ValueMap<float> > (iConfig.getParameter<edm::InputTag>("trackTimeResoTag"));
+    if (producePFPileUp_ && produceOriginalMapping_)
+      if (pv != 0 and qual >= qualityCut_)
+        pfCollectionPUOriginalOutput->push_back(particles[i]);
+  }
+  if (producePFNoPileUp_ && produceSortedVertices_)
+    iEvent.put(std::move(pfCollectionNOPUOutput), "NoPileUp");
+  if (producePFPileUp_ && produceSortedVertices_)
+    iEvent.put(std::move(pfCollectionPUOutput), "PileUp");
+  if (producePFNoPileUp_ && produceOriginalMapping_)
+    iEvent.put(std::move(pfCollectionNOPUOriginalOutput), "originalNoPileUp");
+  if (producePFPileUp_ && produceOriginalMapping_)
+    iEvent.put(std::move(pfCollectionPUOriginalOutput), "originalPileUp");
 }
 
-template<>
-void PrimaryVertexSorter<std::vector<reco::PFCandidate>>::doConsumesForTiming(const edm::ParameterSet &iConfig)
-{
+template <>
+void PrimaryVertexSorter<std::vector<reco::RecoChargedRefCandidate>>::doConsumesForTiming(
+    const edm::ParameterSet& iConfig) {
+  tokenTrackTimeTag_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("trackTimeTag"));
+  tokenTrackTimeResoTag_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("trackTimeResoTag"));
 }
 
-template<>
-bool PrimaryVertexSorter<std::vector<reco::RecoChargedRefCandidate>>::needsProductsForTiming() 
-{ 
-   return true; 
+template <>
+void PrimaryVertexSorter<std::vector<reco::PFCandidate>>::doConsumesForTiming(const edm::ParameterSet& iConfig) {}
+
+template <>
+bool PrimaryVertexSorter<std::vector<reco::RecoChargedRefCandidate>>::needsProductsForTiming() {
+  return true;
 }
 
-template<>
-bool PrimaryVertexSorter<std::vector<reco::PFCandidate>>::needsProductsForTiming()
-{
-   return false;
+template <>
+bool PrimaryVertexSorter<std::vector<reco::PFCandidate>>::needsProductsForTiming() {
+  return false;
 }
 
-template<>
-std::pair<int,PrimaryVertexAssignment::Quality>
-PrimaryVertexSorter<std::vector<reco::RecoChargedRefCandidate>>::runAlgo( const reco::VertexCollection& vertices, const reco::RecoChargedRefCandidate & pf, const edm::ValueMap<float> *trackTimeTag,
-                                   const edm::ValueMap<float> *trackTimeResoTag, const edm::View<reco::Candidate>& jets, const TransientTrackBuilder& builder) 
-{
-    return assignmentAlgo_.chargedHadronVertex( vertices, pf, trackTimeTag, trackTimeResoTag, jets, builder);
+template <>
+std::pair<int, PrimaryVertexAssignment::Quality>
+PrimaryVertexSorter<std::vector<reco::RecoChargedRefCandidate>>::runAlgo(const reco::VertexCollection& vertices,
+                                                                         const reco::RecoChargedRefCandidate& pf,
+                                                                         const edm::ValueMap<float>* trackTimeTag,
+                                                                         const edm::ValueMap<float>* trackTimeResoTag,
+                                                                         const edm::View<reco::Candidate>& jets,
+                                                                         const TransientTrackBuilder& builder) {
+  return assignmentAlgo_.chargedHadronVertex(vertices, pf, trackTimeTag, trackTimeResoTag, jets, builder);
 }
 
-template<>
-std::pair<int,PrimaryVertexAssignment::Quality>
-PrimaryVertexSorter<std::vector<reco::PFCandidate>>::runAlgo( const reco::VertexCollection& vertices, const reco::PFCandidate & pf, const edm::ValueMap<float> *trackTimeTag,
-                                   const edm::ValueMap<float> *trackTimeResoTag, const edm::View<reco::Candidate>& jets, const TransientTrackBuilder& builder) 
-{
-    return assignmentAlgo_.chargedHadronVertex( vertices, pf, jets, builder);
+template <>
+std::pair<int, PrimaryVertexAssignment::Quality> PrimaryVertexSorter<std::vector<reco::PFCandidate>>::runAlgo(
+    const reco::VertexCollection& vertices,
+    const reco::PFCandidate& pf,
+    const edm::ValueMap<float>* trackTimeTag,
+    const edm::ValueMap<float>* trackTimeResoTag,
+    const edm::View<reco::Candidate>& jets,
+    const TransientTrackBuilder& builder) {
+  return assignmentAlgo_.chargedHadronVertex(vertices, pf, jets, builder);
 }
 
 #endif

--- a/CommonTools/RecoAlgos/plugins/PtMinElectronCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinElectronCountFilter.cc
@@ -12,9 +12,6 @@
 #include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
 #include "CommonTools/UtilAlgos/interface/PtMinSelector.h"
 
-typedef ObjectCountFilter<
-          reco::ElectronCollection, 
-          PtMinSelector
-        >::type PtMinElectronCountFilter;
+typedef ObjectCountFilter<reco::ElectronCollection, PtMinSelector>::type PtMinElectronCountFilter;
 
-DEFINE_FWK_MODULE( PtMinElectronCountFilter );
+DEFINE_FWK_MODULE(PtMinElectronCountFilter);

--- a/CommonTools/RecoAlgos/plugins/PtMinGsfElectronCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinGsfElectronCountFilter.cc
@@ -12,9 +12,6 @@
 #include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
 #include "CommonTools/UtilAlgos/interface/PtMinSelector.h"
 
-typedef ObjectCountFilter<
-          reco::GsfElectronCollection, 
-          PtMinSelector
-        >::type PtMinGsfElectronCountFilter;
+typedef ObjectCountFilter<reco::GsfElectronCollection, PtMinSelector>::type PtMinGsfElectronCountFilter;
 
-DEFINE_FWK_MODULE( PtMinGsfElectronCountFilter );
+DEFINE_FWK_MODULE(PtMinGsfElectronCountFilter);

--- a/CommonTools/RecoAlgos/plugins/PtMinMuonCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinMuonCountFilter.cc
@@ -12,9 +12,6 @@
 #include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
 #include "CommonTools/UtilAlgos/interface/PtMinSelector.h"
 
-typedef ObjectCountFilter<
-          reco::MuonCollection, 
-          PtMinSelector
-        >::type PtMinMuonCountFilter;
+typedef ObjectCountFilter<reco::MuonCollection, PtMinSelector>::type PtMinMuonCountFilter;
 
-DEFINE_FWK_MODULE( PtMinMuonCountFilter );
+DEFINE_FWK_MODULE(PtMinMuonCountFilter);

--- a/CommonTools/RecoAlgos/plugins/PtMinMuonSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinMuonSelector.cc
@@ -11,9 +11,6 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
- typedef SingleObjectSelector<
-           reco::MuonCollection, 
-           PtMinSelector
-         > PtMinMuonSelector;
+typedef SingleObjectSelector<reco::MuonCollection, PtMinSelector> PtMinMuonSelector;
 
-DEFINE_FWK_MODULE( PtMinMuonSelector );
+DEFINE_FWK_MODULE(PtMinMuonSelector);

--- a/CommonTools/RecoAlgos/plugins/PtMinTrackSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinTrackSelector.cc
@@ -11,9 +11,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
- typedef SingleObjectSelector<
-           reco::TrackCollection, 
-           PtMinSelector
-         > PtMinTrackSelector;
+typedef SingleObjectSelector<reco::TrackCollection, PtMinSelector> PtMinTrackSelector;
 
-DEFINE_FWK_MODULE( PtMinTrackSelector );
+DEFINE_FWK_MODULE(PtMinTrackSelector);

--- a/CommonTools/RecoAlgos/plugins/RecoCandViewRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/RecoCandViewRefSelector.cc
@@ -18,9 +18,7 @@
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 
-typedef SingleObjectSelector<
-          edm::View<reco::RecoCandidate>,
-          StringCutObjectSelector<reco::RecoCandidate>
-       > RecoCandViewRefSelector;
+typedef SingleObjectSelector<edm::View<reco::RecoCandidate>, StringCutObjectSelector<reco::RecoCandidate> >
+    RecoCandViewRefSelector;
 
 DEFINE_FWK_MODULE(RecoCandViewRefSelector);

--- a/CommonTools/RecoAlgos/plugins/RecoChargedRefCandidateToTrackRefProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/RecoChargedRefCandidateToTrackRefProducer.cc
@@ -3,11 +3,10 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef CandidateProducer<
-  edm::View<reco::RecoChargedRefCandidate>,
-  reco::TrackRefVector,
-  AnySelector,
-  converter::RecoChargedRefCandidateToTrackRef
-  > RecoChargedRefCandidateToTrackRefProducer;
+typedef CandidateProducer<edm::View<reco::RecoChargedRefCandidate>,
+                          reco::TrackRefVector,
+                          AnySelector,
+                          converter::RecoChargedRefCandidateToTrackRef>
+    RecoChargedRefCandidateToTrackRefProducer;
 
 DEFINE_FWK_MODULE(RecoChargedRefCandidateToTrackRefProducer);

--- a/CommonTools/RecoAlgos/plugins/RecoTrackRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/RecoTrackRefSelector.cc
@@ -16,6 +16,6 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace reco {
-  typedef ObjectSelectorStreamProducer<RecoTrackRefSelector,reco::TrackRefVector> RecoTrackRefSelector;
+  typedef ObjectSelectorStreamProducer<RecoTrackRefSelector, reco::TrackRefVector> RecoTrackRefSelector;
   DEFINE_FWK_MODULE(RecoTrackRefSelector);
-}
+}  // namespace reco

--- a/CommonTools/RecoAlgos/plugins/RecoTrackSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/RecoTrackSelector.cc
@@ -18,5 +18,5 @@ namespace reco {
     //typedef ObjectSelector<RecoTrackSelector> RecoTrackSelector;
     typedef TrackFullCloneSelectorBase<RecoTrackSelector> RecoTrackSelector;
     DEFINE_FWK_MODULE(RecoTrackSelector);
-  }
-}
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/RecoAlgos/plugins/RecoTrackViewRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/RecoTrackViewRefSelector.cc
@@ -3,6 +3,7 @@
 #include "CommonTools/RecoAlgos/interface/RecoTrackViewRefSelector.h"
 
 namespace reco {
-  typedef ObjectSelectorStreamProducer<RecoTrackViewRefSelector, edm::RefToBaseVector<reco::Track>> RecoTrackViewRefSelector;
+  typedef ObjectSelectorStreamProducer<RecoTrackViewRefSelector, edm::RefToBaseVector<reco::Track>>
+      RecoTrackViewRefSelector;
   DEFINE_FWK_MODULE(RecoTrackViewRefSelector);
-}
+}  // namespace reco

--- a/CommonTools/RecoAlgos/plugins/SuperClusterEt.h
+++ b/CommonTools/RecoAlgos/plugins/SuperClusterEt.h
@@ -3,13 +3,9 @@
 
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 
-   struct SuperClusterEt {
-     typedef reco::SuperCluster type;
-     double operator()( const reco::SuperCluster & c ) const {
-       return c.energy() * sin( c.position().theta() );
-     }
-   };
-
-
+struct SuperClusterEt {
+  typedef reco::SuperCluster type;
+  double operator()(const reco::SuperCluster& c) const { return c.energy() * sin(c.position().theta()); }
+};
 
 #endif

--- a/CommonTools/RecoAlgos/plugins/SuperClusterRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/SuperClusterRefSelector.cc
@@ -26,10 +26,9 @@
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 
- typedef SingleObjectSelector<
-           reco::SuperClusterCollection, 
-           StringCutObjectSelector<reco::SuperCluster>,
-           reco::SuperClusterRefVector
-         > SuperClusterRefSelector;
+typedef SingleObjectSelector<reco::SuperClusterCollection,
+                             StringCutObjectSelector<reco::SuperCluster>,
+                             reco::SuperClusterRefVector>
+    SuperClusterRefSelector;
 
-DEFINE_FWK_MODULE( SuperClusterRefSelector );
+DEFINE_FWK_MODULE(SuperClusterRefSelector);

--- a/CommonTools/RecoAlgos/plugins/SuperClusterSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/SuperClusterSelector.cc
@@ -26,9 +26,7 @@
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 
- typedef SingleObjectSelector<
-           reco::SuperClusterCollection, 
-           StringCutObjectSelector<reco::SuperCluster>
-         > SuperClusterSelector;
+typedef SingleObjectSelector<reco::SuperClusterCollection, StringCutObjectSelector<reco::SuperCluster> >
+    SuperClusterSelector;
 
-DEFINE_FWK_MODULE( SuperClusterSelector );
+DEFINE_FWK_MODULE(SuperClusterSelector);

--- a/CommonTools/RecoAlgos/plugins/TOFPIDProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/TOFPIDProducer.cc
@@ -18,34 +18,36 @@
 using namespace std;
 using namespace edm;
 
-class TOFPIDProducer : public edm::stream::EDProducer<> {  
- public:
-  
-  TOFPIDProducer(const ParameterSet& pset); 
+class TOFPIDProducer : public edm::stream::EDProducer<> {
+public:
+  TOFPIDProducer(const ParameterSet& pset);
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   template <class H, class T>
-  void fillValueMap(edm::Event& iEvent, const edm::Handle<H>& handle, const std::vector<T>& vec, const std::string& name) const;
-  
+  void fillValueMap(edm::Event& iEvent,
+                    const edm::Handle<H>& handle,
+                    const std::vector<T>& vec,
+                    const std::string& name) const;
+
   void produce(edm::Event& ev, const edm::EventSetup& es) final;
 
- private:
+private:
   static constexpr char t0Name[] = "t0";
   static constexpr char sigmat0Name[] = "sigmat0";
   static constexpr char t0safeName[] = "t0safe";
-  static constexpr char sigmat0safeName[] = "sigmat0safe";  
+  static constexpr char sigmat0safeName[] = "sigmat0safe";
   static constexpr char probPiName[] = "probPi";
   static constexpr char probKName[] = "probK";
   static constexpr char probPName[] = "probP";
-  
+
   edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
-  edm::EDGetTokenT<edm::ValueMap<float> > t0Token_;
-  edm::EDGetTokenT<edm::ValueMap<float> > tmtdToken_;
-  edm::EDGetTokenT<edm::ValueMap<float> > sigmat0Token_;
-  edm::EDGetTokenT<edm::ValueMap<float> > sigmatmtdToken_;
-  edm::EDGetTokenT<edm::ValueMap<float> > pathLengthToken_;
-  edm::EDGetTokenT<edm::ValueMap<float> > pToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> t0Token_;
+  edm::EDGetTokenT<edm::ValueMap<float>> tmtdToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> sigmat0Token_;
+  edm::EDGetTokenT<edm::ValueMap<float>> sigmatmtdToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> pToken_;
   edm::EDGetTokenT<reco::VertexCollection> vtxsToken_;
   double vtxMaxSigmaT_;
   double maxDz_;
@@ -53,107 +55,107 @@ class TOFPIDProducer : public edm::stream::EDProducer<> {
   double minProbHeavy_;
 };
 
-
-  
-TOFPIDProducer::TOFPIDProducer(const ParameterSet& iConfig) :
-  tracksToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
-  t0Token_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("t0Src"))),
-  tmtdToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("tmtdSrc"))),
-  sigmat0Token_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("sigmat0Src"))),
-  sigmatmtdToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("sigmatmtdSrc"))),
-  pathLengthToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("pathLengthSrc"))),
-  pToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("pSrc"))),
-  vtxsToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vtxsSrc"))),
-  vtxMaxSigmaT_(iConfig.getParameter<double>("vtxMaxSigmaT")),
-  maxDz_(iConfig.getParameter<double>("maxDz")),
-  maxDtSignificance_(iConfig.getParameter<double>("maxDtSignificance")),
-  minProbHeavy_(iConfig.getParameter<double>("minProbHeavy"))
-  {  
-  produces<edm::ValueMap<float> >(t0Name);
-  produces<edm::ValueMap<float> >(sigmat0Name);
-  produces<edm::ValueMap<float> >(t0safeName);
-  produces<edm::ValueMap<float> >(sigmat0safeName);
-  produces<edm::ValueMap<float> >(probPiName); 
-  produces<edm::ValueMap<float> >(probKName);
-  produces<edm::ValueMap<float> >(probPName);
+TOFPIDProducer::TOFPIDProducer(const ParameterSet& iConfig)
+    : tracksToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
+      t0Token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0Src"))),
+      tmtdToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tmtdSrc"))),
+      sigmat0Token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0Src"))),
+      sigmatmtdToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmatmtdSrc"))),
+      pathLengthToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"))),
+      pToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pSrc"))),
+      vtxsToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vtxsSrc"))),
+      vtxMaxSigmaT_(iConfig.getParameter<double>("vtxMaxSigmaT")),
+      maxDz_(iConfig.getParameter<double>("maxDz")),
+      maxDtSignificance_(iConfig.getParameter<double>("maxDtSignificance")),
+      minProbHeavy_(iConfig.getParameter<double>("minProbHeavy")) {
+  produces<edm::ValueMap<float>>(t0Name);
+  produces<edm::ValueMap<float>>(sigmat0Name);
+  produces<edm::ValueMap<float>>(t0safeName);
+  produces<edm::ValueMap<float>>(sigmat0safeName);
+  produces<edm::ValueMap<float>>(probPiName);
+  produces<edm::ValueMap<float>>(probKName);
+  produces<edm::ValueMap<float>>(probPName);
 }
 
 // Configuration descriptions
 void TOFPIDProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("tracksSrc", edm::InputTag("generalTracks"))->
-    setComment("Input tracks collection");
-  desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0"))->
-    setComment("Input ValueMap for track time at beamline");
-  desc.add<edm::InputTag>("tmtdSrc", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"))->
-    setComment("Input ValueMap for track time at MTD");
-  desc.add<edm::InputTag>("sigmat0Src", edm::InputTag("trackExtenderWithMTD:generalTracksigmat0"))->
-    setComment("Input ValueMap for track time uncertainty at beamline");
-  desc.add<edm::InputTag>("sigmatmtdSrc", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"))->
-    setComment("Input ValueMap for track time uncertainty at MTD");
-  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"))->
-    setComment("Input ValueMap for track path lengh from beamline to MTD");
-  desc.add<edm::InputTag>("pSrc", edm::InputTag("trackExtenderWithMTD:generalTrackp"))->
-    setComment("Input ValueMap for track momentum magnitude (normally from refit with MTD hits)");
-  desc.add<edm::InputTag>("vtxsSrc", edm::InputTag("unsortedOfflinePrimaryVertices4DnoPID"))->
-    setComment("Input primary vertex collection");
-  desc.add<double>("vtxMaxSigmaT", 0.025)->
-    setComment("Maximum primary vertex time uncertainty for use in particle id [ns]");
-  desc.add<double>("maxDz", 0.1)->
-    setComment("Maximum distance in z for track-primary vertex association for particle id [cm]");
-  desc.add<double>("maxDtSignificance", 5.0)->
-    setComment("Maximum distance in time (normalized by uncertainty) for track-primary vertex association for particle id");
-  desc.add<double>("minProbHeavy", 0.75)->
-    setComment("Minimum probability for a particle to be a kaon or proton before reassigning the timestamp");
-    
+  desc.add<edm::InputTag>("tracksSrc", edm::InputTag("generalTracks"))->setComment("Input tracks collection");
+  desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0"))
+      ->setComment("Input ValueMap for track time at beamline");
+  desc.add<edm::InputTag>("tmtdSrc", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"))
+      ->setComment("Input ValueMap for track time at MTD");
+  desc.add<edm::InputTag>("sigmat0Src", edm::InputTag("trackExtenderWithMTD:generalTracksigmat0"))
+      ->setComment("Input ValueMap for track time uncertainty at beamline");
+  desc.add<edm::InputTag>("sigmatmtdSrc", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"))
+      ->setComment("Input ValueMap for track time uncertainty at MTD");
+  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"))
+      ->setComment("Input ValueMap for track path lengh from beamline to MTD");
+  desc.add<edm::InputTag>("pSrc", edm::InputTag("trackExtenderWithMTD:generalTrackp"))
+      ->setComment("Input ValueMap for track momentum magnitude (normally from refit with MTD hits)");
+  desc.add<edm::InputTag>("vtxsSrc", edm::InputTag("unsortedOfflinePrimaryVertices4DnoPID"))
+      ->setComment("Input primary vertex collection");
+  desc.add<double>("vtxMaxSigmaT", 0.025)
+      ->setComment("Maximum primary vertex time uncertainty for use in particle id [ns]");
+  desc.add<double>("maxDz", 0.1)
+      ->setComment("Maximum distance in z for track-primary vertex association for particle id [cm]");
+  desc.add<double>("maxDtSignificance", 5.0)
+      ->setComment(
+          "Maximum distance in time (normalized by uncertainty) for track-primary vertex association for particle id");
+  desc.add<double>("minProbHeavy", 0.75)
+      ->setComment("Minimum probability for a particle to be a kaon or proton before reassigning the timestamp");
+
   descriptions.add("tofPIDProducer", desc);
 }
 
 template <class H, class T>
-void TOFPIDProducer::fillValueMap(edm::Event& iEvent, const edm::Handle<H>& handle, const std::vector<T>& vec, const std::string& name) const {
+void TOFPIDProducer::fillValueMap(edm::Event& iEvent,
+                                  const edm::Handle<H>& handle,
+                                  const std::vector<T>& vec,
+                                  const std::string& name) const {
   auto out = std::make_unique<edm::ValueMap<T>>();
   typename edm::ValueMap<T>::Filler filler(*out);
   filler.insert(handle, vec.begin(), vec.end());
   filler.fill();
-  iEvent.put(std::move(out),name);
+  iEvent.put(std::move(out), name);
 }
 
-void TOFPIDProducer::produce( edm::Event& ev, const edm::EventSetup& es ) {
-  constexpr double m_k = 0.493677; //[GeV]
-  constexpr double m_p = 0.9382720813; //[GeV]
-  constexpr double c_cm_ns = CLHEP::c_light*CLHEP::ns/CLHEP::cm; //[cm/ns]
-  constexpr double c_inv = 1.0/c_cm_ns;
-  
-  edm::Handle<reco::TrackCollection> tracksH;  
-  ev.getByToken(tracksToken_,tracksH);
+void TOFPIDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
+  constexpr double m_k = 0.493677;                                    //[GeV]
+  constexpr double m_p = 0.9382720813;                                //[GeV]
+  constexpr double c_cm_ns = CLHEP::c_light * CLHEP::ns / CLHEP::cm;  //[cm/ns]
+  constexpr double c_inv = 1.0 / c_cm_ns;
+
+  edm::Handle<reco::TrackCollection> tracksH;
+  ev.getByToken(tracksToken_, tracksH);
   const auto& tracks = *tracksH;
 
-  edm::Handle<edm::ValueMap<float> > t0H;
+  edm::Handle<edm::ValueMap<float>> t0H;
   ev.getByToken(t0Token_, t0H);
-  const auto &t0In = *t0H;
+  const auto& t0In = *t0H;
 
-  edm::Handle<edm::ValueMap<float> > tmtdH;
+  edm::Handle<edm::ValueMap<float>> tmtdH;
   ev.getByToken(tmtdToken_, tmtdH);
-  const auto &tmtdIn = *tmtdH;
-  
-  edm::Handle<edm::ValueMap<float> > sigmat0H;
-  ev.getByToken(sigmat0Token_, sigmat0H);
-  const auto &sigmat0In = *sigmat0H;
+  const auto& tmtdIn = *tmtdH;
 
-  edm::Handle<edm::ValueMap<float> > sigmatmtdH;
+  edm::Handle<edm::ValueMap<float>> sigmat0H;
+  ev.getByToken(sigmat0Token_, sigmat0H);
+  const auto& sigmat0In = *sigmat0H;
+
+  edm::Handle<edm::ValueMap<float>> sigmatmtdH;
   ev.getByToken(sigmatmtdToken_, sigmatmtdH);
-  const auto &sigmatmtdIn = *sigmatmtdH;
-  
-  edm::Handle<edm::ValueMap<float> > pathLengthH;
+  const auto& sigmatmtdIn = *sigmatmtdH;
+
+  edm::Handle<edm::ValueMap<float>> pathLengthH;
   ev.getByToken(pathLengthToken_, pathLengthH);
-  const auto &pathLengthIn = *pathLengthH;
-  
-  edm::Handle<edm::ValueMap<float> > pH;
+  const auto& pathLengthIn = *pathLengthH;
+
+  edm::Handle<edm::ValueMap<float>> pH;
   ev.getByToken(pToken_, pH);
-  const auto &pIn = *pH;
-  
-  edm::Handle<reco::VertexCollection> vtxsH;  
-  ev.getByToken(vtxsToken_,vtxsH);
+  const auto& pIn = *pH;
+
+  edm::Handle<reco::VertexCollection> vtxsH;
+  ev.getByToken(vtxsToken_, vtxsH);
   const auto& vtxs = *vtxsH;
 
   //output value maps (PID probabilities and recalculated time at beamline)
@@ -164,26 +166,25 @@ void TOFPIDProducer::produce( edm::Event& ev, const edm::EventSetup& es ) {
   std::vector<float> probPiOutRaw;
   std::vector<float> probKOutRaw;
   std::vector<float> probPOutRaw;
-  
+
   //Do work here
-  for (unsigned int itrack = 0; itrack<tracks.size(); ++itrack) {
-    const reco::Track &track = tracks[itrack];
-    const reco::TrackRef trackref(tracksH,itrack);
+  for (unsigned int itrack = 0; itrack < tracks.size(); ++itrack) {
+    const reco::Track& track = tracks[itrack];
+    const reco::TrackRef trackref(tracksH, itrack);
     float t0 = t0In[trackref];
     float t0safe = t0;
     float sigmat0safe = sigmat0In[trackref];
     float sigmatmtd = sigmatmtdIn[trackref];
     float sigmat0 = sigmatmtd;
-    
+
     float prob_pi = -1.;
     float prob_k = -1.;
     float prob_p = -1.;
-    
-    if (sigmat0>0.) {
-      
-      double rsigmazsq = 1./track.dzError()/track.dzError();
-      double rsigmat = 1./sigmatmtd;
-      
+
+    if (sigmat0 > 0.) {
+      double rsigmazsq = 1. / track.dzError() / track.dzError();
+      double rsigmat = 1. / sigmatmtd;
+
       //find associated vertex
       int vtxidx = -1;
       int vtxidxmindz = -1;
@@ -191,144 +192,139 @@ void TOFPIDProducer::produce( edm::Event& ev, const edm::EventSetup& es ) {
       double mindz = maxDz_;
       double minchisq = std::numeric_limits<double>::max();
       //first try based on association weights, but keep track of closest in z and z-t as well
-      for (unsigned int ivtx = 0; ivtx<vtxs.size(); ++ivtx) {
-        const reco::Vertex &vtx = vtxs[ivtx];
+      for (unsigned int ivtx = 0; ivtx < vtxs.size(); ++ivtx) {
+        const reco::Vertex& vtx = vtxs[ivtx];
         float w = vtx.trackWeight(trackref);
-        if (w>0.5) {
+        if (w > 0.5) {
           vtxidx = ivtx;
           break;
         }
         double dz = std::abs(track.dz(vtx.position()));
-        if (dz<mindz) {
+        if (dz < mindz) {
           mindz = dz;
           vtxidxmindz = ivtx;
         }
-        if (vtx.tError()>0. && vtx.tError()<vtxMaxSigmaT_) {
-          double dt = std::abs(t0-vtx.t());
-          double dtsig = dt*rsigmat;
-          double chisq = dz*dz*rsigmazsq + dtsig*dtsig;
-          if (dz<maxDz_ && dtsig<maxDtSignificance_ && chisq<minchisq) {
+        if (vtx.tError() > 0. && vtx.tError() < vtxMaxSigmaT_) {
+          double dt = std::abs(t0 - vtx.t());
+          double dtsig = dt * rsigmat;
+          double chisq = dz * dz * rsigmazsq + dtsig * dtsig;
+          if (dz < maxDz_ && dtsig < maxDtSignificance_ && chisq < minchisq) {
             minchisq = chisq;
             vtxidxminchisq = ivtx;
           }
         }
       }
-      
+
       //if no vertex found based on association weights, fall back to closest in z or z-t
-      if (vtxidx<0) {
-        //if closest vertex in z does not have valid time information, just use it, 
+      if (vtxidx < 0) {
+        //if closest vertex in z does not have valid time information, just use it,
         //otherwise use the closest vertex in z-t plane with timing info, with a fallback to the closest in z
-        if (vtxidxmindz>=0 && !(vtxs[vtxidxmindz].tError()>0. && vtxs[vtxidxmindz].tError()<vtxMaxSigmaT_)) {
+        if (vtxidxmindz >= 0 && !(vtxs[vtxidxmindz].tError() > 0. && vtxs[vtxidxmindz].tError() < vtxMaxSigmaT_)) {
           vtxidx = vtxidxmindz;
-        }
-        else if (vtxidxminchisq>=0) {
+        } else if (vtxidxminchisq >= 0) {
           vtxidx = vtxidxminchisq;
-        }
-        else if (vtxidxmindz>=0) {
+        } else if (vtxidxmindz >= 0) {
           vtxidx = vtxidxmindz;
         }
       }
-      
+
       //testing mass hypotheses only possible if there is an associated vertex with time information
-      if (vtxidx>=0 && vtxs[vtxidx].tError()>0. && vtxs[vtxidx].tError()<vtxMaxSigmaT_) {        
+      if (vtxidx >= 0 && vtxs[vtxidx].tError() > 0. && vtxs[vtxidx].tError() < vtxMaxSigmaT_) {
         //compute chisq in z-t plane for nominal vertex and mass hypothesis (pion)
-        const reco::Vertex &vtxnom = vtxs[vtxidx];
+        const reco::Vertex& vtxnom = vtxs[vtxidx];
         double dznom = std::abs(track.dz(vtxnom.position()));
         double dtnom = std::abs(t0 - vtxnom.t());
-        double dtsignom = dtnom*rsigmat;
-        double chisqnom = dznom*dznom*rsigmazsq + dtsignom*dtsignom;
-        
+        double dtsignom = dtnom * rsigmat;
+        double chisqnom = dznom * dznom * rsigmazsq + dtsignom * dtsignom;
+
         //recompute t0 for alternate mass hypotheses
         double t0_best = t0;
-        
+
         //reliable match, revert to raw mtd time uncertainty
         if (dtsignom < maxDtSignificance_) {
           sigmat0safe = sigmatmtd;
         }
-        
+
         double tmtd = tmtdIn[trackref];
         double pathlength = pathLengthIn[trackref];
         double magp = pIn[trackref];
-        
-        double gammasq_k = 1. + magp*magp/m_k/m_k;
-        double beta_k = std::sqrt(1.-1./gammasq_k);
-        double t0_k = tmtd - pathlength/beta_k*c_inv;
-        
-        double gammasq_p = 1. + magp*magp/m_p/m_p;
-        double beta_p = std::sqrt(1.-1./gammasq_p);
-        double t0_p = tmtd - pathlength/beta_p*c_inv;
-        
+
+        double gammasq_k = 1. + magp * magp / m_k / m_k;
+        double beta_k = std::sqrt(1. - 1. / gammasq_k);
+        double t0_k = tmtd - pathlength / beta_k * c_inv;
+
+        double gammasq_p = 1. + magp * magp / m_p / m_p;
+        double beta_p = std::sqrt(1. - 1. / gammasq_p);
+        double t0_p = tmtd - pathlength / beta_p * c_inv;
+
         double chisqmin = chisqnom;
-        
+
         double chisqmin_pi = chisqnom;
         double chisqmin_k = std::numeric_limits<double>::max();
         double chisqmin_p = std::numeric_limits<double>::max();
         //loop through vertices and check for better matches
-        for (const reco::Vertex &vtx : vtxs) {
-          if (!(vtx.tError()>0. && vtx.tError()<vtxMaxSigmaT_)) {
+        for (const reco::Vertex& vtx : vtxs) {
+          if (!(vtx.tError() > 0. && vtx.tError() < vtxMaxSigmaT_)) {
             continue;
           }
-          
+
           double dz = std::abs(track.dz(vtx.position()));
-          if (dz>=maxDz_) {
+          if (dz >= maxDz_) {
             continue;
           }
-          
-          double chisqdz = dz*dz*rsigmazsq;
-          
+
+          double chisqdz = dz * dz * rsigmazsq;
+
           double dt_k = std::abs(t0_k - vtx.t());
-          double dtsig_k = dt_k*rsigmat;
-          double chisq_k = chisqdz + dtsig_k*dtsig_k;
-          
-          if (dtsig_k < maxDtSignificance_ && chisq_k<chisqmin_k) {
+          double dtsig_k = dt_k * rsigmat;
+          double chisq_k = chisqdz + dtsig_k * dtsig_k;
+
+          if (dtsig_k < maxDtSignificance_ && chisq_k < chisqmin_k) {
             chisqmin_k = chisq_k;
           }
-          
+
           double dt_p = std::abs(t0_p - vtx.t());
-          double dtsig_p = dt_p*rsigmat;
-          double chisq_p = chisqdz + dtsig_p*dtsig_p;
-          
-          if (dtsig_p < maxDtSignificance_ && chisq_p<chisqmin_p) {
+          double dtsig_p = dt_p * rsigmat;
+          double chisq_p = chisqdz + dtsig_p * dtsig_p;
+
+          if (dtsig_p < maxDtSignificance_ && chisq_p < chisqmin_p) {
             chisqmin_p = chisq_p;
           }
-          
-          if (dtsig_k < maxDtSignificance_ && chisq_k<chisqmin) {
+
+          if (dtsig_k < maxDtSignificance_ && chisq_k < chisqmin) {
             chisqmin = chisq_k;
             t0_best = t0_k;
             t0safe = t0_k;
             sigmat0safe = sigmatmtd;
           }
-          if (dtsig_p < maxDtSignificance_ && chisq_p<chisqmin) {
+          if (dtsig_p < maxDtSignificance_ && chisq_p < chisqmin) {
             chisqmin = chisq_p;
             t0_best = t0_p;
             t0safe = t0_p;
             sigmat0safe = sigmatmtd;
           }
-          
         }
-        
+
         //compute PID probabilities
         //*TODO* deal with heavier nucleons and/or BSM case here?
-        double rawprob_pi = exp(-0.5*chisqmin_pi);
-        double rawprob_k = exp(-0.5*chisqmin_k);
-        double rawprob_p = exp(-0.5*chisqmin_p);
-        
-        double normprob = 1./(rawprob_pi + rawprob_k + rawprob_p);
-        
-        prob_pi = rawprob_pi*normprob;
-        prob_k = rawprob_k*normprob;
-        prob_p = rawprob_p*normprob;
+        double rawprob_pi = exp(-0.5 * chisqmin_pi);
+        double rawprob_k = exp(-0.5 * chisqmin_k);
+        double rawprob_p = exp(-0.5 * chisqmin_p);
 
-        double prob_heavy = 1.-prob_pi;
-        
-        if (prob_heavy>minProbHeavy_) {
+        double normprob = 1. / (rawprob_pi + rawprob_k + rawprob_p);
+
+        prob_pi = rawprob_pi * normprob;
+        prob_k = rawprob_k * normprob;
+        prob_p = rawprob_p * normprob;
+
+        double prob_heavy = 1. - prob_pi;
+
+        if (prob_heavy > minProbHeavy_) {
           t0 = t0_best;
         }
-
       }
-      
     }
-    
+
     t0OutRaw.push_back(t0);
     sigmat0OutRaw.push_back(sigmat0);
     t0safeOutRaw.push_back(t0safe);
@@ -345,7 +341,6 @@ void TOFPIDProducer::produce( edm::Event& ev, const edm::EventSetup& es ) {
   fillValueMap(ev, tracksH, probPiOutRaw, probPiName);
   fillValueMap(ev, tracksH, probKOutRaw, probKName);
   fillValueMap(ev, tracksH, probPOutRaw, probPName);
-  
 }
 
 //define this as a plug-in

--- a/CommonTools/RecoAlgos/plugins/TrackCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackCountFilter.cc
@@ -10,8 +10,6 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
 
- typedef ObjectCountFilter<
-           reco::TrackCollection
-         >::type TrackCountFilter;
+typedef ObjectCountFilter<reco::TrackCollection>::type TrackCountFilter;
 
-DEFINE_FWK_MODULE( TrackCountFilter );
+DEFINE_FWK_MODULE(TrackCountFilter);

--- a/CommonTools/RecoAlgos/plugins/TrackFullCloneSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackFullCloneSelector.cc
@@ -28,10 +28,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
- typedef SingleObjectSelector<
-           reco::TrackCollection, 
-           StringCutObjectSelector<reco::Track> 
-         > TrackFullCloneSelector;
+typedef SingleObjectSelector<reco::TrackCollection, StringCutObjectSelector<reco::Track> > TrackFullCloneSelector;
 
 DEFINE_FWK_MODULE(TrackFullCloneSelector);
-

--- a/CommonTools/RecoAlgos/plugins/TrackRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackRefSelector.cc
@@ -26,10 +26,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
- typedef SingleObjectSelector<
-           reco::TrackCollection, 
-           StringCutObjectSelector<reco::Track>,
-           reco::TrackRefVector
-         > TrackRefSelector;
+typedef SingleObjectSelector<reco::TrackCollection, StringCutObjectSelector<reco::Track>, reco::TrackRefVector>
+    TrackRefSelector;
 
-DEFINE_FWK_MODULE( TrackRefSelector );
+DEFINE_FWK_MODULE(TrackRefSelector);

--- a/CommonTools/RecoAlgos/plugins/TrackSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackSelector.cc
@@ -26,9 +26,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
- typedef SingleObjectSelector<
-           reco::TrackCollection, 
-           StringCutObjectSelector<reco::Track> 
-         > TrackSelector;
+typedef SingleObjectSelector<reco::TrackCollection, StringCutObjectSelector<reco::Track> > TrackSelector;
 
-DEFINE_FWK_MODULE( TrackSelector );
+DEFINE_FWK_MODULE(TrackSelector);

--- a/CommonTools/RecoAlgos/plugins/TrackViewCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackViewCandidateProducer.cc
@@ -17,10 +17,9 @@
 #include "DataFormats/Common/interface/View.h"
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 
-typedef CandidateProducer<
-          edm::View<reco::Track>,
-          reco::RecoChargedCandidateCollection,
-          StringCutObjectSelector<reco::Track>
-        > TrackViewCandidateProducer;
+typedef CandidateProducer<edm::View<reco::Track>,
+                          reco::RecoChargedCandidateCollection,
+                          StringCutObjectSelector<reco::Track> >
+    TrackViewCandidateProducer;
 
 DEFINE_FWK_MODULE(TrackViewCandidateProducer);

--- a/CommonTools/RecoAlgos/plugins/TrackWithVertexRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackWithVertexRefSelector.cc
@@ -4,17 +4,15 @@
 #include "CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h"
 #include "CommonTools/RecoAlgos/interface/TrackWithVertexSelector.h"
 
-namespace reco { 
+namespace reco {
   namespace modules {
 
-typedef ObjectSelectorStreamProducer<
-  SingleElementCollectionSelectorPlusEvent<
-          reco::TrackCollection,
-          ::TrackWithVertexSelector,
-          reco::TrackRefVector 
-          >,
-  reco::TrackRefVector > TrackWithVertexRefSelector;
+    typedef ObjectSelectorStreamProducer<
+        SingleElementCollectionSelectorPlusEvent<reco::TrackCollection, ::TrackWithVertexSelector, reco::TrackRefVector>,
+        reco::TrackRefVector>
+        TrackWithVertexRefSelector;
 
-DEFINE_FWK_MODULE(TrackWithVertexRefSelector);
+    DEFINE_FWK_MODULE(TrackWithVertexRefSelector);
 
-} }
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/RecoAlgos/plugins/TrackWithVertexSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackWithVertexSelector.cc
@@ -3,11 +3,12 @@
 #include "CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h"
 #include "CommonTools/RecoAlgos/interface/TrackWithVertexSelector.h"
 
-namespace reco { 
+namespace reco {
   namespace modules {
 
-    typedef TrackFullCloneSelectorBase< ::TrackWithVertexSelector > TrackWithVertexSelector;
+    typedef TrackFullCloneSelectorBase< ::TrackWithVertexSelector> TrackWithVertexSelector;
 
     DEFINE_FWK_MODULE(TrackWithVertexSelector);
 
-} }
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/RecoAlgos/plugins/TrackingParticleConversionRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackingParticleConversionRefSelector.cc
@@ -9,7 +9,7 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 
-class TrackingParticleConversionRefSelector: public edm::global::EDProducer<> {
+class TrackingParticleConversionRefSelector : public edm::global::EDProducer<> {
 public:
   TrackingParticleConversionRefSelector(const edm::ParameterSet& iConfig);
 
@@ -21,10 +21,8 @@ private:
   edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
 };
 
-
-TrackingParticleConversionRefSelector::TrackingParticleConversionRefSelector(const edm::ParameterSet& iConfig):
-  tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("src")))
-{
+TrackingParticleConversionRefSelector::TrackingParticleConversionRefSelector(const edm::ParameterSet& iConfig)
+    : tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("src"))) {
   produces<TrackingParticleRefVector>();
 }
 
@@ -34,7 +32,9 @@ void TrackingParticleConversionRefSelector::fillDescriptions(edm::ConfigurationD
   descriptions.add("trackingParticleConversionRefSelectorDefault", desc);
 }
 
-void TrackingParticleConversionRefSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void TrackingParticleConversionRefSelector::produce(edm::StreamID,
+                                                    edm::Event& iEvent,
+                                                    const edm::EventSetup& iSetup) const {
   edm::Handle<TrackingParticleCollection> h_tps;
   iEvent.getByToken(tpToken_, h_tps);
 
@@ -43,11 +43,11 @@ void TrackingParticleConversionRefSelector::produce(edm::StreamID, edm::Event& i
   // Logic is similar to Validation/RecoEgamma/plugins/PhotonValidator.cc
   // and RecoEgamma/EgammaMCTools/src/PhotonMCTruthFinder.cc,
   // but implemented purely in terms of TrackingParticles (simpler and works for pileup too)
-  for(const auto& tp: *h_tps) {
-    if(tp.pdgId() == 22) {
-      for(const auto& vertRef: tp.decayVertices()) {
-        for(const auto& tpRef: vertRef->daughterTracks()) {
-          if(std::abs(tpRef->pdgId()) == 11) {
+  for (const auto& tp : *h_tps) {
+    if (tp.pdgId() == 22) {
+      for (const auto& vertRef : tp.decayVertices()) {
+        for (const auto& tpRef : vertRef->daughterTracks()) {
+          if (std::abs(tpRef->pdgId()) == 11) {
             ret->push_back(tpRef);
           }
         }

--- a/CommonTools/RecoAlgos/plugins/TrackingParticleRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackingParticleRefSelector.cc
@@ -15,9 +15,9 @@
 
 namespace reco {
   namespace modules {
-    typedef SingleObjectSelector<TrackingParticleCollection,::TrackingParticleSelector,TrackingParticleRefVector> 
-    TrackingParticleRefSelector ;
+    typedef SingleObjectSelector<TrackingParticleCollection, ::TrackingParticleSelector, TrackingParticleRefVector>
+        TrackingParticleRefSelector;
 
-    DEFINE_FWK_MODULE( TrackingParticleRefSelector );
-  }
-}
+    DEFINE_FWK_MODULE(TrackingParticleRefSelector);
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/RecoAlgos/plugins/TrackingParticleSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackingParticleSelector.cc
@@ -14,9 +14,8 @@
 
 namespace reco {
   namespace modules {
-    typedef SingleObjectSelector<TrackingParticleCollection,::TrackingParticleSelector> 
-    TrackingParticleSelector ;
+    typedef SingleObjectSelector<TrackingParticleCollection, ::TrackingParticleSelector> TrackingParticleSelector;
 
-    DEFINE_FWK_MODULE( TrackingParticleSelector );
-  }
-}
+    DEFINE_FWK_MODULE(TrackingParticleSelector);
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/RecoAlgos/plugins/VertexCompositeCandidateCollectionSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/VertexCompositeCandidateCollectionSelector.cc
@@ -21,8 +21,8 @@
 //
 namespace {
   const float dummy = -9.;
-  const GlobalPoint dummyGP(dummy,dummy,0.);
-} //end anonymous namespace
+  const GlobalPoint dummyGP(dummy, dummy, 0.);
+}  //end anonymous namespace
 
 class VertexCompositeCandidateCollectionSelector : public edm::stream::EDProducer<> {
 public:
@@ -30,13 +30,13 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 
   edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> v0Token_;
-  edm::EDGetTokenT<reco::BeamSpot>         bsToken_;
+  edm::EDGetTokenT<reco::BeamSpot> bsToken_;
   edm::EDGetTokenT<reco::VertexCollection> pvToken_;
 
   int pvNDOF_;
@@ -46,13 +46,12 @@ public:
   // list of variables for the selection
   float lxyCUT_;
   float lxyWRTbsCUT_;
-  bool  debug_;
+  bool debug_;
 };
 
 //
 // constants, enums and typedefs
 //
-
 
 //
 // static data member definitions
@@ -62,92 +61,94 @@ public:
 // constructors and destructor
 //
 VertexCompositeCandidateCollectionSelector::VertexCompositeCandidateCollectionSelector(const edm::ParameterSet& iConfig)
-  : v0Token_ ( consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("v0") )            )
-  , bsToken_ ( consumes<reco::BeamSpot>                          (iConfig.getParameter<edm::InputTag>("beamSpot") )      )
-  , pvToken_ ( consumes<reco::VertexCollection>                  (iConfig.getParameter<edm::InputTag>("primaryVertex") ) )
-  , pvNDOF_ ( iConfig.getParameter<int> ("pvNDOF") )
-  , label_  ( iConfig.getParameter<edm::InputTag>("v0").instance() )
-  , lxyCUT_      ( iConfig.getParameter<double>("lxyCUT") )
-  , lxyWRTbsCUT_ ( iConfig.getParameter<double>("lxyWRTbsCUT") )
-  , debug_ ( iConfig.getUntrackedParameter<bool>("debug") )
-{
-  if (debug_) std::cout << "VertexCompositeCandidateCollectionSelector::VertexCompositeCandidateCollectionSelector" << std::endl;
+    : v0Token_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("v0"))),
+      bsToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+      pvToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertex"))),
+      pvNDOF_(iConfig.getParameter<int>("pvNDOF")),
+      label_(iConfig.getParameter<edm::InputTag>("v0").instance()),
+      lxyCUT_(iConfig.getParameter<double>("lxyCUT")),
+      lxyWRTbsCUT_(iConfig.getParameter<double>("lxyWRTbsCUT")),
+      debug_(iConfig.getUntrackedParameter<bool>("debug")) {
+  if (debug_)
+    std::cout << "VertexCompositeCandidateCollectionSelector::VertexCompositeCandidateCollectionSelector" << std::endl;
   // product
   produces<reco::VertexCompositeCandidateCollection>();
 
   //now do what ever other initialization is needed
-  
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-VertexCompositeCandidateCollectionSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   
-  if (debug_) std::cout << "VertexCompositeCandidateCollectionSelector::produce" << std::endl;
+void VertexCompositeCandidateCollectionSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   // Create auto_ptr for each collection to be stored in the Event
-   auto result = std::make_unique<reco::VertexCompositeCandidateCollection>();
+  if (debug_)
+    std::cout << "VertexCompositeCandidateCollectionSelector::produce" << std::endl;
 
-   edm::Handle<reco::BeamSpot> beamspotHandle;
-   iEvent.getByToken(bsToken_,beamspotHandle);
-   reco::BeamSpot const * bs = nullptr;
-   if (beamspotHandle.isValid())
-     bs = &(*beamspotHandle);
+  // Create auto_ptr for each collection to be stored in the Event
+  auto result = std::make_unique<reco::VertexCompositeCandidateCollection>();
 
+  edm::Handle<reco::BeamSpot> beamspotHandle;
+  iEvent.getByToken(bsToken_, beamspotHandle);
+  reco::BeamSpot const* bs = nullptr;
+  if (beamspotHandle.isValid())
+    bs = &(*beamspotHandle);
 
-   edm::Handle< reco::VertexCollection > pvHandle;
-   iEvent.getByToken(pvToken_, pvHandle );
-   reco::Vertex const * pv = nullptr;  
-   if (pvHandle.isValid()) {
-     pv = &pvHandle->front();
-     //--- pv fake (the pv collection should have size==1 and the pv==beam spot)
-     if (   pv->isFake() || pv->tracksSize()==0
-	    // definition of goodOfflinePrimaryVertex
-	    || pv->ndof() < pvNDOF_ || pv->z() > 24.)  pv = nullptr;
-   }
+  edm::Handle<reco::VertexCollection> pvHandle;
+  iEvent.getByToken(pvToken_, pvHandle);
+  reco::Vertex const* pv = nullptr;
+  if (pvHandle.isValid()) {
+    pv = &pvHandle->front();
+    //--- pv fake (the pv collection should have size==1 and the pv==beam spot)
+    if (pv->isFake() ||
+        pv->tracksSize() == 0
+        // definition of goodOfflinePrimaryVertex
+        || pv->ndof() < pvNDOF_ || pv->z() > 24.)
+      pv = nullptr;
+  }
 
-   edm::Handle<reco::VertexCompositeCandidateCollection> v0Handle;
-   iEvent.getByToken(v0Token_, v0Handle);
-   int n = ( v0Handle.isValid() ? v0Handle->size() : -1 );
-   if (debug_) std::cout << "n: " << n << std::endl;
-   if (n>0) {
-  
-     auto const& v0s = *v0Handle.product();    
-     for ( auto const& v0 : v0s ) {
-       GlobalPoint displacementFromPV2D = ( pv==nullptr ? dummyGP : GlobalPoint( (pv->x() - v0.vx()), 
-										 (pv->y() - v0.vy()), 
-										 0. ) );
-       GlobalPoint displacementFromBS2D = ( bs==nullptr ? dummyGP : GlobalPoint( v0.vx() - bs->x(v0.vz()),
-										 v0.vy() - bs->y(v0.vz()),
-										 0. ) );
-       float abslxy      = ( pv==nullptr ? dummy : displacementFromPV2D.perp() );
-       float abslxyWRTbs = ( bs==nullptr ? dummy : displacementFromBS2D.perp() );
+  edm::Handle<reco::VertexCompositeCandidateCollection> v0Handle;
+  iEvent.getByToken(v0Token_, v0Handle);
+  int n = (v0Handle.isValid() ? v0Handle->size() : -1);
+  if (debug_)
+    std::cout << "n: " << n << std::endl;
+  if (n > 0) {
+    auto const& v0s = *v0Handle.product();
+    for (auto const& v0 : v0s) {
+      GlobalPoint displacementFromPV2D =
+          (pv == nullptr ? dummyGP : GlobalPoint((pv->x() - v0.vx()), (pv->y() - v0.vy()), 0.));
+      GlobalPoint displacementFromBS2D =
+          (bs == nullptr ? dummyGP : GlobalPoint(v0.vx() - bs->x(v0.vz()), v0.vy() - bs->y(v0.vz()), 0.));
+      float abslxy = (pv == nullptr ? dummy : displacementFromPV2D.perp());
+      float abslxyWRTbs = (bs == nullptr ? dummy : displacementFromBS2D.perp());
 
-       if (debug_) std::cout << "abslxy: " << abslxy << " w.r.t. " << lxyCUT_ << " ==> " << ( abslxy >= lxyCUT_ ? "OK" : "KO" ) << std::endl;
-       if (debug_) std::cout << "abslxyWRTbs: " << abslxyWRTbs << " w.r.t. " << lxyWRTbsCUT_ << " ==> " << ( abslxyWRTbs >= lxyWRTbsCUT_ ? "OK" : "KO" ) << std::endl;       
-       if (abslxy      < lxyCUT_     ) continue;
-       if (abslxyWRTbs < lxyWRTbsCUT_) continue;
-       result->push_back(v0);
-     }
-   }
+      if (debug_)
+        std::cout << "abslxy: " << abslxy << " w.r.t. " << lxyCUT_ << " ==> " << (abslxy >= lxyCUT_ ? "OK" : "KO")
+                  << std::endl;
+      if (debug_)
+        std::cout << "abslxyWRTbs: " << abslxyWRTbs << " w.r.t. " << lxyWRTbsCUT_ << " ==> "
+                  << (abslxyWRTbs >= lxyWRTbsCUT_ ? "OK" : "KO") << std::endl;
+      if (abslxy < lxyCUT_)
+        continue;
+      if (abslxyWRTbs < lxyWRTbsCUT_)
+        continue;
+      result->push_back(v0);
+    }
+  }
 
-   if (debug_) std::cout << "result: " << result->size() << std::endl;
-   // put into the Event
-   // Write the collections to the Event
-   result->shrink_to_fit(); iEvent.put(std::move(result) );
- 
+  if (debug_)
+    std::cout << "result: " << result->size() << std::endl;
+  // put into the Event
+  // Write the collections to the Event
+  result->shrink_to_fit();
+  iEvent.put(std::move(result));
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-VertexCompositeCandidateCollectionSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void VertexCompositeCandidateCollectionSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
@@ -155,10 +156,10 @@ VertexCompositeCandidateCollectionSelector::fillDescriptions(edm::ConfigurationD
   desc.add<edm::InputTag>("beamSpot");
   desc.add<edm::InputTag>("primaryVertex");
   desc.add<int>("pvNDOF");
-  desc.add<double>("lxyCUT",      16.); // cm (2016 pixel layer3:10.2 cm ; 2017 pixel layer4: 16.0 cm)
-  desc.add<double>("lxyWRTbsCUT",  0.); // cm
-  desc.addUntracked<bool>("debug",false);
-  descriptions.add("VertexCompositeCandidateCollectionSelector",desc);
+  desc.add<double>("lxyCUT", 16.);      // cm (2016 pixel layer3:10.2 cm ; 2017 pixel layer4: 16.0 cm)
+  desc.add<double>("lxyWRTbsCUT", 0.);  // cm
+  desc.addUntracked<bool>("debug", false);
+  descriptions.add("VertexCompositeCandidateCollectionSelector", desc);
 }
 
 //define this as a plug-in

--- a/CommonTools/RecoAlgos/plugins/VertexCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/VertexCountFilter.cc
@@ -13,10 +13,7 @@
 #include "CommonTools/UtilAlgos/interface/MaxNumberSelector.h"
 #include "CommonTools/UtilAlgos/interface/AndSelector.h"
 
- typedef ObjectCountFilter<
-           reco::VertexCollection,
-           AnySelector,
-           AndSelector<MinNumberSelector, MaxNumberSelector>
-         >::type VertexCountFilter;
+typedef ObjectCountFilter<reco::VertexCollection, AnySelector, AndSelector<MinNumberSelector, MaxNumberSelector> >::type
+    VertexCountFilter;
 
-DEFINE_FWK_MODULE( VertexCountFilter );
+DEFINE_FWK_MODULE(VertexCountFilter);

--- a/CommonTools/RecoAlgos/plugins/VertexRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/VertexRefSelector.cc
@@ -26,10 +26,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
- typedef SingleObjectSelector<
-           reco::VertexCollection, 
-           StringCutObjectSelector<reco::Vertex>,
-           reco::VertexRefVector
-         > VertexRefSelector;
+typedef SingleObjectSelector<reco::VertexCollection, StringCutObjectSelector<reco::Vertex>, reco::VertexRefVector>
+    VertexRefSelector;
 
 DEFINE_FWK_MODULE(VertexRefSelector);

--- a/CommonTools/RecoAlgos/plugins/VertexSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/VertexSelector.cc
@@ -26,9 +26,6 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
- using VertexSelector = SingleObjectSelectorStream<
-           reco::VertexCollection, 
-           StringCutObjectSelector<reco::Vertex> 
-         >;
+using VertexSelector = SingleObjectSelectorStream<reco::VertexCollection, StringCutObjectSelector<reco::Vertex> >;
 
 DEFINE_FWK_MODULE(VertexSelector);

--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -14,79 +14,68 @@
 #include "DataFormats/TrackerRecHit2D/interface/FastProjectedTrackerRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/FastMatchedTrackerRecHit.h"
 
-
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 namespace helper {
 
   // -------------------------------------------------------------
   //FIXME (push cluster pointers...)
-  void ClusterStorer::addCluster(TrackingRecHitCollection &hits, size_t index)
-  {
+  void ClusterStorer::addCluster(TrackingRecHitCollection &hits, size_t index) {
     TrackingRecHit &newHit = hits[index];
     const std::type_info &hit_type = typeid(newHit);
     if (hit_type == typeid(SiPixelRecHit)) {
       //std::cout << "|  It is a Pixel hit !!" << std::endl;
-      pixelClusterRecords_.push_back(PixelClusterHitRecord(static_cast<SiPixelRecHit&>(newHit),
-							   hits, index));
+      pixelClusterRecords_.push_back(PixelClusterHitRecord(static_cast<SiPixelRecHit &>(newHit), hits, index));
     } else if (hit_type == typeid(SiStripRecHit1D)) {
       //std::cout << "|   It is a SiStripRecHit1D hit !!" << std::endl;
-      stripClusterRecords_.push_back(StripClusterHitRecord(static_cast<SiStripRecHit1D&>(newHit),
-							   hits, index));
+      stripClusterRecords_.push_back(StripClusterHitRecord(static_cast<SiStripRecHit1D &>(newHit), hits, index));
     } else if (hit_type == typeid(SiStripRecHit2D)) {
       //std::cout << "|   It is a SiStripRecHit2D hit !!" << std::endl;
-      stripClusterRecords_.push_back(StripClusterHitRecord(static_cast<SiStripRecHit2D&>(newHit),
-							   hits, index));
-    } else if (hit_type == typeid(SiStripMatchedRecHit2D)) {      
+      stripClusterRecords_.push_back(StripClusterHitRecord(static_cast<SiStripRecHit2D &>(newHit), hits, index));
+    } else if (hit_type == typeid(SiStripMatchedRecHit2D)) {
       //std::cout << "|   It is a SiStripMatchedRecHit2D hit !!" << std::endl;
-      SiStripMatchedRecHit2D &mhit = static_cast<SiStripMatchedRecHit2D&>(newHit);
+      SiStripMatchedRecHit2D &mhit = static_cast<SiStripMatchedRecHit2D &>(newHit);
       stripClusterRecords_.push_back(StripClusterHitRecord(mhit.monoHit(), hits, index));
       stripClusterRecords_.push_back(StripClusterHitRecord(mhit.stereoHit(), hits, index));
     } else if (hit_type == typeid(ProjectedSiStripRecHit2D)) {
       //std::cout << "|   It is a ProjectedSiStripRecHit2D hit !!" << std::endl;
-      ProjectedSiStripRecHit2D &phit = static_cast<ProjectedSiStripRecHit2D&>(newHit);
+      ProjectedSiStripRecHit2D &phit = static_cast<ProjectedSiStripRecHit2D &>(newHit);
       stripClusterRecords_.push_back(StripClusterHitRecord(phit.originalHit(), hits, index));
     } else if (hit_type == typeid(Phase2TrackerRecHit1D)) {
       //FIXME:: this is just temporary solution for phase2,
       //it is not really running in the phase2 tracking wf - yet...
       //std::cout << "|   It is a Phase2TrackerRecHit1D hit !!" << std::endl;
-      phase2OTClusterRecords_.push_back(Phase2OTClusterHitRecord(static_cast<Phase2TrackerRecHit1D&>(newHit), hits, index));
+      phase2OTClusterRecords_.push_back(
+          Phase2OTClusterHitRecord(static_cast<Phase2TrackerRecHit1D &>(newHit), hits, index));
     } else {
-      if (hit_type == typeid(FastTrackerRecHit)
- 	  || hit_type == typeid(FastProjectedTrackerRecHit)
-	  || hit_type == typeid(FastMatchedTrackerRecHit)) {
-	//std::cout << "|   It is a " << hit_type.name() << " hit !!" << std::endl;
-	// FastSim hits: Do nothing instead of caring about FastSim clusters, 
-	//               not even sure whether these really exist.
-	//               At least predecessor code in TrackSelector and MuonSelector
-	//               did not treat them.
+      if (hit_type == typeid(FastTrackerRecHit) || hit_type == typeid(FastProjectedTrackerRecHit) ||
+          hit_type == typeid(FastMatchedTrackerRecHit)) {
+        //std::cout << "|   It is a " << hit_type.name() << " hit !!" << std::endl;
+        // FastSim hits: Do nothing instead of caring about FastSim clusters,
+        //               not even sure whether these really exist.
+        //               At least predecessor code in TrackSelector and MuonSelector
+        //               did not treat them.
       } else {
-	// through for unknown types
-	throw cms::Exception("UnknownHitType") << "helper::ClusterStorer::addCluster: "
-					       << "Unknown hit type " << hit_type.name()
-					       << ".\n";
+        // through for unknown types
+        throw cms::Exception("UnknownHitType") << "helper::ClusterStorer::addCluster: "
+                                               << "Unknown hit type " << hit_type.name() << ".\n";
       }
-    } // end 'switch' on hit type
-    
+    }  // end 'switch' on hit type
   }
-  
+
   // -------------------------------------------------------------
-  void ClusterStorer::clear()
-  {
+  void ClusterStorer::clear() {
     pixelClusterRecords_.clear();
     stripClusterRecords_.clear();
   }
-  
+
   // -------------------------------------------------------------
-  void ClusterStorer::
-  processAllClusters(edmNew::DetSetVector<SiPixelCluster> &pixelDsvToFill,
-		     edm::RefProd<edmNew::DetSetVector<SiPixelCluster> > refPixelClusters,
-		     edmNew::DetSetVector<SiStripCluster> &stripDsvToFill,
-		     edm::RefProd<edmNew::DetSetVector<SiStripCluster> > refStripClusters)
-  {
+  void ClusterStorer::processAllClusters(edmNew::DetSetVector<SiPixelCluster> &pixelDsvToFill,
+                                         edm::RefProd<edmNew::DetSetVector<SiPixelCluster> > refPixelClusters,
+                                         edmNew::DetSetVector<SiStripCluster> &stripDsvToFill,
+                                         edm::RefProd<edmNew::DetSetVector<SiStripCluster> > refStripClusters) {
     if (!pixelClusterRecords_.empty()) {
-      this->processClusters<SiPixelRecHit, SiPixelCluster>
-	(pixelClusterRecords_, pixelDsvToFill, refPixelClusters);
+      this->processClusters<SiPixelRecHit, SiPixelCluster>(pixelClusterRecords_, pixelDsvToFill, refPixelClusters);
     }
     if (!stripClusterRecords_.empty()) {
       // All we need from the HitType 'SiStripRecHit2D' is the
@@ -94,97 +83,91 @@ namespace helper {
       // The fact that rekey<SiStripRecHit2D> is called is irrelevant since
       // ClusterHitRecord<typename SiStripRecHit2D::ClusterRef>::rekey<RecHitType>
       // is specialised such that 'RecHitType' is not used...
-      this->processClusters<SiStripRecHit2D, SiStripCluster>
-	(stripClusterRecords_, stripDsvToFill, refStripClusters);
+      this->processClusters<SiStripRecHit2D, SiStripCluster>(stripClusterRecords_, stripDsvToFill, refStripClusters);
     }
   }
-  
+
   //-------------------------------------------------------------
-  template<typename HitType, typename ClusterType>
-  void ClusterStorer::
-  processClusters(std::vector<ClusterHitRecord<typename HitType::ClusterRef> > &clusterRecords,
-		  edmNew::DetSetVector<ClusterType>                            &dsvToFill,
-		  edm::RefProd< edmNew::DetSetVector<ClusterType> >            &refprod)
-  {
-    std::sort(clusterRecords.begin(), clusterRecords.end()); // this sorts them by detid 
-    typedef
-      typename std::vector<ClusterHitRecord<typename HitType::ClusterRef> >::const_iterator
-      RIT;
+  template <typename HitType, typename ClusterType>
+  void ClusterStorer::processClusters(std::vector<ClusterHitRecord<typename HitType::ClusterRef> > &clusterRecords,
+                                      edmNew::DetSetVector<ClusterType> &dsvToFill,
+                                      edm::RefProd<edmNew::DetSetVector<ClusterType> > &refprod) {
+    std::sort(clusterRecords.begin(), clusterRecords.end());  // this sorts them by detid
+    typedef typename std::vector<ClusterHitRecord<typename HitType::ClusterRef> >::const_iterator RIT;
     RIT it = clusterRecords.begin(), end = clusterRecords.end();
     size_t clusters = 0;
     while (it != end) {
       RIT it2 = it;
       uint32_t detid = it->detid();
-      
+
       // first isolate all clusters on the same detid
-      while ( (it2 != end) && (it2->detid() == detid)) {  ++it2; }
+      while ((it2 != end) && (it2->detid() == detid)) {
+        ++it2;
+      }
       // now [it, it2] bracket one detid
-      
+
       // then prepare to copy the clusters
       typename edmNew::DetSetVector<ClusterType>::FastFiller filler(dsvToFill, detid);
       typename HitType::ClusterRef lastRef, newRef;
-      for ( ; it != it2; ++it) { // loop on the detid
-	// first check if we need to clone the hit
-	if (it->clusterRef() != lastRef) { 
-	  lastRef = it->clusterRef();
-	  // clone cluster
-	  filler.push_back( *lastRef );  
-	  // make new ref
-	  newRef = typename HitType::ClusterRef( refprod, clusters++ );
-	} 
-	it->template rekey<HitType>(newRef);
-      } // end of the loop on a single detid
-      
-    } // end of the loop on all clusters
+      for (; it != it2; ++it) {  // loop on the detid
+        // first check if we need to clone the hit
+        if (it->clusterRef() != lastRef) {
+          lastRef = it->clusterRef();
+          // clone cluster
+          filler.push_back(*lastRef);
+          // make new ref
+          newRef = typename HitType::ClusterRef(refprod, clusters++);
+        }
+        it->template rekey<HitType>(newRef);
+      }  // end of the loop on a single detid
+
+    }  // end of the loop on all clusters
   }
-  
+
   //-------------------------------------------------------------
-  // helper classes  
+  // helper classes
   //-------------------------------------------------------------
   // FIXME (migrate to new RTTI and interface)
   // generic rekey (in practise for pixel only...)
-  template<typename ClusterRefType> // template for class
-  template<typename RecHitType>     // template for member function
-  void ClusterStorer::ClusterHitRecord<ClusterRefType>::
-  rekey(const ClusterRefType &newRef) const
-  {
-    TrackingRecHit & genericHit = (*hits_)[index_]; 
+  template <typename ClusterRefType>  // template for class
+  template <typename RecHitType>      // template for member function
+  void ClusterStorer::ClusterHitRecord<ClusterRefType>::rekey(const ClusterRefType &newRef) const {
+    TrackingRecHit &genericHit = (*hits_)[index_];
     RecHitType *hit = nullptr;
-    if (genericHit.geographicalId().rawId() == detid_) { // a hit on this det, so it's simple
-      hit = dynamic_cast<RecHitType *>(&genericHit); //static_cast<RecHitType *>(&genericHit);
+    if (genericHit.geographicalId().rawId() == detid_) {  // a hit on this det, so it's simple
+      hit = dynamic_cast<RecHitType *>(&genericHit);      //static_cast<RecHitType *>(&genericHit);
     }
-    assert (hit != nullptr);
-    assert (hit->cluster() == ref_); // otherwise something went wrong
+    assert(hit != nullptr);
+    assert(hit->cluster() == ref_);  // otherwise something went wrong
     hit->setClusterRef(newRef);
   }
-  
+
   // -------------------------------------------------------------
   // Specific rekey for class template ClusterRefType = SiStripRecHit2D::ClusterRef,
   // RecHitType is not used.
-  template<>
-  template<typename RecHitType> // or template<> to specialise also here?
+  template <>
+  template <typename RecHitType>  // or template<> to specialise also here?
   void ClusterStorer::ClusterHitRecord<SiStripRecHit2D::ClusterRef>::
-  //  rekey<SiStripRecHit2D>(const SiStripRecHit2D::ClusterRef &newRef) const
-  rekey(const SiStripRecHit2D::ClusterRef &newRef) const
-  {
+      //  rekey<SiStripRecHit2D>(const SiStripRecHit2D::ClusterRef &newRef) const
+      rekey(const SiStripRecHit2D::ClusterRef &newRef) const {
     TrackingRecHit &genericHit = (*hits_)[index_];
     const std::type_info &hit_type = typeid(genericHit);
 
-    OmniClusterRef * cluRef=nullptr;
+    OmniClusterRef *cluRef = nullptr;
     if (typeid(SiStripRecHit1D) == hit_type) {
-      cluRef = &static_cast<SiStripRecHit1D&>(genericHit).omniCluster();
-     } else if (typeid(SiStripRecHit2D) == hit_type) {
-      cluRef = &static_cast<SiStripRecHit2D&>(genericHit).omniCluster();
+      cluRef = &static_cast<SiStripRecHit1D &>(genericHit).omniCluster();
+    } else if (typeid(SiStripRecHit2D) == hit_type) {
+      cluRef = &static_cast<SiStripRecHit2D &>(genericHit).omniCluster();
     } else if (typeid(SiStripMatchedRecHit2D) == hit_type) {
-	SiStripMatchedRecHit2D &mhit = static_cast<SiStripMatchedRecHit2D&>(genericHit);
-	 cluRef = (SiStripDetId(detid_).stereo() ? &mhit.stereoClusterRef() : &mhit.monoClusterRef());
+      SiStripMatchedRecHit2D &mhit = static_cast<SiStripMatchedRecHit2D &>(genericHit);
+      cluRef = (SiStripDetId(detid_).stereo() ? &mhit.stereoClusterRef() : &mhit.monoClusterRef());
     } else if (typeid(ProjectedSiStripRecHit2D) == hit_type) {
-      cluRef = &static_cast<ProjectedSiStripRecHit2D&>(genericHit).originalHit().omniCluster();
+      cluRef = &static_cast<ProjectedSiStripRecHit2D &>(genericHit).originalHit().omniCluster();
     }
-  
-    assert(cluRef != nullptr); // to catch missing RecHit types
-    assert(cluRef->key() == ref_.key()); // otherwise something went wrong
+
+    assert(cluRef != nullptr);            // to catch missing RecHit types
+    assert(cluRef->key() == ref_.key());  // otherwise something went wrong
     (*cluRef) = OmniClusterRef(newRef);
   }
-  
-} // end namespace 'helper'
+
+}  // namespace helper

--- a/CommonTools/RecoAlgos/src/MassiveCandidateConverter.cc
+++ b/CommonTools/RecoAlgos/src/MassiveCandidateConverter.cc
@@ -7,13 +7,11 @@ using namespace edm;
 using namespace std;
 using namespace converter;
 
-MassiveCandidateConverter::MassiveCandidateConverter( const edm::ParameterSet & cfg ) :
-  massSqr_(0), particle_( cfg.getParameter<PdtEntry>( "particleType" ) ) {
-}
+MassiveCandidateConverter::MassiveCandidateConverter(const edm::ParameterSet& cfg)
+    : massSqr_(0), particle_(cfg.getParameter<PdtEntry>("particleType")) {}
 
-void MassiveCandidateConverter::beginFirstRun( const EventSetup & es ) {
+void MassiveCandidateConverter::beginFirstRun(const EventSetup& es) {
   particle_.setup(es);
-  massSqr_ = particle_.data().mass(); 
+  massSqr_ = particle_.data().mass();
   massSqr_ *= massSqr_;
 }
-

--- a/CommonTools/RecoAlgos/src/MassiveCandidateConverter.h
+++ b/CommonTools/RecoAlgos/src/MassiveCandidateConverter.h
@@ -4,17 +4,19 @@
 #include "SimGeneral/HepPDTRecord/interface/PdtEntry.h"
 #include <string>
 
-namespace edm { class EventSetup; }
+namespace edm {
+  class EventSetup;
+}
 
 namespace converter {
   struct MassiveCandidateConverter {
-    MassiveCandidateConverter( const edm::ParameterSet & );
-    void beginFirstRun( const edm::EventSetup & );
+    MassiveCandidateConverter(const edm::ParameterSet&);
+    void beginFirstRun(const edm::EventSetup&);
 
   protected:
     double massSqr_;
     PdtEntry particle_;
   };
-}
+}  // namespace converter
 
 #endif

--- a/CommonTools/RecoAlgos/src/MuonSelector.cc
+++ b/CommonTools/RecoAlgos/src/MuonSelector.cc
@@ -12,183 +12,202 @@
 
 using namespace reco;
 
-namespace helper 
-{
-    MuonCollectionStoreManager::
-    MuonCollectionStoreManager(const edm::Handle<reco::MuonCollection>&) 
-      :
-      selMuons_( new reco::MuonCollection ),
-      selTracks_( new reco::TrackCollection ),
-      selTracksExtras_( new reco::TrackExtraCollection ),
-      selTracksHits_( new TrackingRecHitCollection ),
-      selGlobalMuonTracks_( new reco::TrackCollection ),
-      selGlobalMuonTracksExtras_( new reco::TrackExtraCollection ),    
-      selGlobalMuonTracksHits_( new TrackingRecHitCollection ),
-      selStandAloneTracks_( new reco::TrackCollection ),
-      selStandAloneTracksExtras_( new reco::TrackExtraCollection ),
-      selStandAloneTracksHits_( new TrackingRecHitCollection ),     
-      selStripClusters_( new edmNew::DetSetVector<SiStripCluster> ),
-      selPixelClusters_( new edmNew::DetSetVector<SiPixelCluster> ),
-      rMuons_(),
-      rTracks_(), rTrackExtras_(), rHits_(),
-      rGBTracks_(), rGBTrackExtras_(), rGBHits_(),
-      rSATracks_(), rSATrackExtras_(), rSAHits_(),
-      clusterStorer_(),
-      id_(0), igbd_(0), isad_(0), idx_(0), igbdx_(0),
-      isadx_(0), hidx_(0), higbdx_(0), hisadx_(0),
-      cloneClusters_ (true)
-    {
+namespace helper {
+  MuonCollectionStoreManager::MuonCollectionStoreManager(const edm::Handle<reco::MuonCollection> &)
+      : selMuons_(new reco::MuonCollection),
+        selTracks_(new reco::TrackCollection),
+        selTracksExtras_(new reco::TrackExtraCollection),
+        selTracksHits_(new TrackingRecHitCollection),
+        selGlobalMuonTracks_(new reco::TrackCollection),
+        selGlobalMuonTracksExtras_(new reco::TrackExtraCollection),
+        selGlobalMuonTracksHits_(new TrackingRecHitCollection),
+        selStandAloneTracks_(new reco::TrackCollection),
+        selStandAloneTracksExtras_(new reco::TrackExtraCollection),
+        selStandAloneTracksHits_(new TrackingRecHitCollection),
+        selStripClusters_(new edmNew::DetSetVector<SiStripCluster>),
+        selPixelClusters_(new edmNew::DetSetVector<SiPixelCluster>),
+        rMuons_(),
+        rTracks_(),
+        rTrackExtras_(),
+        rHits_(),
+        rGBTracks_(),
+        rGBTrackExtras_(),
+        rGBHits_(),
+        rSATracks_(),
+        rSATrackExtras_(),
+        rSAHits_(),
+        clusterStorer_(),
+        id_(0),
+        igbd_(0),
+        isad_(0),
+        idx_(0),
+        igbdx_(0),
+        isadx_(0),
+        hidx_(0),
+        higbdx_(0),
+        hisadx_(0),
+        cloneClusters_(true) {}
+
+  //------------------------------------------------------------------
+  //!  Process a single muon.
+  //------------------------------------------------------------------
+  void MuonCollectionStoreManager::processMuon(const Muon &mu) {
+    if (this->cloneClusters() && ((mu.globalTrack().isNonnull() && !this->clusterRefsOK(*mu.globalTrack())) ||
+                                  (mu.innerTrack().isNonnull() && !this->clusterRefsOK(*mu.innerTrack()))
+                                  // || (mu.outerTrack(). isNonnull() && !this->clusterRefsOK(*mu.outerTrack() ))
+                                  )) {  // outer track is muon only and has no strip clusters...
+      // At least until CMSSW_2_1_8, global muon track reconstruction assigns wrong hits in
+      // case of a track from iterative tracking. These hits are fetched from Trajectories
+      // instead of from Tracks and therefore reference temporary cluster collections.
+      // As a hack we skip these muons here - they can anyway not be refitted.
+      edm::LogError("BadRef") << "@SUB=MuonCollectionStoreManager::processMuon"
+                              << "Skip muon: One of its tracks references "
+                              << "non-available clusters!";
+      return;
     }
 
-  
-  //------------------------------------------------------------------
-  //!  Process a single muon.  
-  //------------------------------------------------------------------
-  void 
-  MuonCollectionStoreManager::
-  processMuon( const Muon & mu ) 
-  {
-        if (this->cloneClusters() 
-            && (   (mu.globalTrack().isNonnull() && !this->clusterRefsOK(*mu.globalTrack()))
-                || (mu.innerTrack() .isNonnull() && !this->clusterRefsOK(*mu.innerTrack() ))
-                   // || (mu.outerTrack(). isNonnull() && !this->clusterRefsOK(*mu.outerTrack() ))
-                   )) { // outer track is muon only and has no strip clusters...
-          // At least until CMSSW_2_1_8, global muon track reconstruction assigns wrong hits in
-          // case of a track from iterative tracking. These hits are fetched from Trajectories
-          // instead of from Tracks and therefore reference temporary cluster collections.
-          // As a hack we skip these muons here - they can anyway not be refitted. 
-          edm::LogError("BadRef") << "@SUB=MuonCollectionStoreManager::processMuon"
-                                  << "Skip muon: One of its tracks references "
-                                  << "non-available clusters!";
-          return;
+    selMuons_->push_back(Muon(mu));
+    // only tracker Muon Track
+    selMuons_->back().setInnerTrack(TrackRef(rTracks_, id_++));
+    TrackRef trkRef = mu.track();
+    if (trkRef.isNonnull()) {
+      selTracks_->push_back(Track(*trkRef));
+
+      Track &trk = selTracks_->back();
+
+      selTracksExtras_->push_back(TrackExtra(trk.outerPosition(),
+                                             trk.outerMomentum(),
+                                             trk.outerOk(),
+                                             trk.innerPosition(),
+                                             trk.innerMomentum(),
+                                             trk.innerOk(),
+                                             trk.outerStateCovariance(),
+                                             trk.outerDetId(),
+                                             trk.innerStateCovariance(),
+                                             trk.innerDetId(),
+                                             trk.seedDirection()));
+
+      TrackExtra &tx = selTracksExtras_->back();
+
+      auto const firstHitIndex = hidx_;
+      unsigned int nHitsAdded = 0;
+      for (trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++hit, ++hidx_) {
+        selTracksHits_->push_back((*hit)->clone());
+        TrackingRecHit *newHit = &(selTracksHits_->back());
+        ++nHitsAdded;
+        if (cloneClusters() && newHit->isValid() && ((*hit)->geographicalId().det() == DetId::Tracker)) {
+          clusterStorer_.addCluster(*selTracksHits_, hidx_);
         }
-        
-	selMuons_->push_back( Muon( mu ) );
-	// only tracker Muon Track	
-	selMuons_->back().setInnerTrack( TrackRef( rTracks_, id_ ++ ) );
-	TrackRef trkRef = mu.track();
-	if(trkRef.isNonnull()){
+      }  // end of for loop over tracking rec hits on this track
+      tx.setHits(rHits_, firstHitIndex, nHitsAdded);
 
-	selTracks_->push_back(Track( *trkRef) );
+      trk.setExtra(TrackExtraRef(rTrackExtras_, idx_++));
 
-	Track & trk= selTracks_->back();
+    }  // TO trkRef.isNonnull
 
-	selTracksExtras_->push_back( TrackExtra( trk.outerPosition(), trk.outerMomentum(), trk.outerOk(),
-						 trk.innerPosition(), trk.innerMomentum(), trk.innerOk(),
-						 trk.outerStateCovariance(), trk.outerDetId(),
-						 trk.innerStateCovariance(), trk.innerDetId(),
-						 trk.seedDirection() ) );
+    // global Muon Track
+    selMuons_->back().setGlobalTrack(TrackRef(rGBTracks_, igbd_++));
+    trkRef = mu.combinedMuon();
+    if (trkRef.isNonnull()) {
+      selGlobalMuonTracks_->push_back(Track(*trkRef));
+      Track &trk = selGlobalMuonTracks_->back();
 
-	TrackExtra & tx = selTracksExtras_->back();
+      selGlobalMuonTracksExtras_->push_back(TrackExtra(trk.outerPosition(),
+                                                       trk.outerMomentum(),
+                                                       trk.outerOk(),
+                                                       trk.innerPosition(),
+                                                       trk.innerMomentum(),
+                                                       trk.innerOk(),
+                                                       trk.outerStateCovariance(),
+                                                       trk.outerDetId(),
+                                                       trk.innerStateCovariance(),
+                                                       trk.innerDetId(),
+                                                       trk.seedDirection()));
+      TrackExtra &tx = selGlobalMuonTracksExtras_->back();
+      auto const firstHitIndex = higbdx_;
+      unsigned int nHitsAdded = 0;
+      for (trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++hit, ++higbdx_) {
+        selGlobalMuonTracksHits_->push_back((*hit)->clone());
+        TrackingRecHit *newHit = &(selGlobalMuonTracksHits_->back());
+        ++nHitsAdded;
+        if (cloneClusters() && newHit->isValid() && ((*hit)->geographicalId().det() == DetId::Tracker)) {
+          clusterStorer_.addCluster(*selGlobalMuonTracksHits_, higbdx_);
+        }
+      }
+      tx.setHits(rGBHits_, firstHitIndex, nHitsAdded);
 
-        auto const firstHitIndex = hidx_;
-        unsigned int nHitsAdded = 0;
-	for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd();
-	     ++ hit, ++ hidx_) {
-  	  selTracksHits_->push_back( (*hit)->clone() );
-          TrackingRecHit * newHit = & (selTracksHits_->back());
-          ++nHitsAdded;
-	  if (cloneClusters() && newHit->isValid()
-	      && ((*hit)->geographicalId().det() == DetId::Tracker)) {
-	    clusterStorer_.addCluster( *selTracksHits_, hidx_ );
-	  }
-	} // end of for loop over tracking rec hits on this track
-        tx.setHits( rHits_, firstHitIndex, nHitsAdded );
-	
-	trk.setExtra( TrackExtraRef( rTrackExtras_, idx_ ++ ) );
+      trk.setExtra(TrackExtraRef(rGBTrackExtras_, igbdx_++));
 
-	}// TO trkRef.isNonnull
+    }  // GB trkRef.isNonnull()
 
+    // stand alone Muon Track
+    selMuons_->back().setOuterTrack(TrackRef(rSATracks_, isad_++));
+    trkRef = mu.standAloneMuon();
+    if (trkRef.isNonnull()) {
+      selStandAloneTracks_->push_back(Track(*trkRef));
+      Track &trk = selStandAloneTracks_->back();
 
-	// global Muon Track	
-	selMuons_->back().setGlobalTrack( TrackRef( rGBTracks_, igbd_ ++ ) );
-	trkRef = mu.combinedMuon();
-	if(trkRef.isNonnull()){
-	selGlobalMuonTracks_->push_back(Track( *trkRef) );
-	Track & trk = selGlobalMuonTracks_->back();
-		
-	selGlobalMuonTracksExtras_->push_back( TrackExtra( trk.outerPosition(), trk.outerMomentum(), trk.outerOk(),
-						trk.innerPosition(), trk.innerMomentum(), trk.innerOk(),
-						trk.outerStateCovariance(), trk.outerDetId(),
-						trk.innerStateCovariance(), trk.innerDetId(), trk.seedDirection() ) );
-	TrackExtra & tx = selGlobalMuonTracksExtras_->back();
-        auto const firstHitIndex = higbdx_;
-        unsigned int nHitsAdded = 0;
-	for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd();
-	     ++ hit, ++ higbdx_) {
-            selGlobalMuonTracksHits_->push_back( (*hit)->clone() );
-            TrackingRecHit * newHit = & (selGlobalMuonTracksHits_->back()); 
-            ++nHitsAdded;
-	    if (cloneClusters() && newHit->isValid()
-		&& ((*hit)->geographicalId().det() == DetId::Tracker)) {
-	      clusterStorer_.addCluster( *selGlobalMuonTracksHits_, higbdx_ );
-	  }
+      selStandAloneTracksExtras_->push_back(TrackExtra(trk.outerPosition(),
+                                                       trk.outerMomentum(),
+                                                       trk.outerOk(),
+                                                       trk.innerPosition(),
+                                                       trk.innerMomentum(),
+                                                       trk.innerOk(),
+                                                       trk.outerStateCovariance(),
+                                                       trk.outerDetId(),
+                                                       trk.innerStateCovariance(),
+                                                       trk.innerDetId(),
+                                                       trk.seedDirection()));
+      TrackExtra &tx = selStandAloneTracksExtras_->back();
+      auto const firstHitIndex = hisadx_;
+      unsigned int nHitsAdded = 0;
+      for (trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++hit) {
+        selStandAloneTracksHits_->push_back((*hit)->clone());
+        ++nHitsAdded;
+        hisadx_++;
+      }
+      tx.setHits(rSAHits_, firstHitIndex, nHitsAdded);
+      trk.setExtra(TrackExtraRef(rSATrackExtras_, isadx_++));
 
-	}
-        tx.setHits( rGBHits_, firstHitIndex, nHitsAdded );
-
-	trk.setExtra( TrackExtraRef( rGBTrackExtras_, igbdx_ ++ ) );
-
-	} // GB trkRef.isNonnull()
-
-	// stand alone Muon Track	
-	selMuons_->back().setOuterTrack( TrackRef( rSATracks_, isad_ ++ ) );
-	trkRef = mu.standAloneMuon();
-	if(trkRef.isNonnull()){
-	selStandAloneTracks_->push_back(Track( *trkRef) );
-	Track & trk = selStandAloneTracks_->back();
-		
-	selStandAloneTracksExtras_->push_back( TrackExtra( trk.outerPosition(), trk.outerMomentum(), trk.outerOk(),
-						trk.innerPosition(), trk.innerMomentum(), trk.innerOk(),
-						trk.outerStateCovariance(), trk.outerDetId(),
-						trk.innerStateCovariance(), trk.innerDetId(), trk.seedDirection() ) );
-	TrackExtra & tx = selStandAloneTracksExtras_->back();
-        auto const firstHitIndex = hisadx_;
-        unsigned int nHitsAdded = 0;
-	for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit ) {
-	  selStandAloneTracksHits_->push_back( (*hit)->clone() );
-          ++nHitsAdded;
-          hisadx_ ++;
-	}
-        tx.setHits( rSAHits_, firstHitIndex, nHitsAdded );
-	trk.setExtra( TrackExtraRef( rSATrackExtras_, isadx_ ++ ) );
-
-	} // SA trkRef.isNonnull()
-  }// end of track, and function
+    }  // SA trkRef.isNonnull()
+  }    // end of track, and function
 
   //-------------------------------------------------------------------------
   //!  Check if all references to silicon strip/pixel clusters are available.
   //-------------------------------------------------------------------------
-  bool
-  MuonCollectionStoreManager::
-  clusterRefsOK(const reco::Track &track) const
-  {
-
+  bool MuonCollectionStoreManager::clusterRefsOK(const reco::Track &track) const {
     for (trackingRecHit_iterator hitIt = track.recHitsBegin(); hitIt != track.recHitsEnd(); ++hitIt) {
       const TrackingRecHit &hit = **hitIt;
-      if (!hit.isValid() || hit.geographicalId().det() != DetId::Tracker) continue;
+      if (!hit.isValid() || hit.geographicalId().det() != DetId::Tracker)
+        continue;
 
       // So we are in the tracker - now check hit types and availability of cluster refs:
       const std::type_info &hit_type = typeid(hit);
       if (hit_type == typeid(SiPixelRecHit)) {
-        if (!static_cast<const SiPixelRecHit &>(hit).cluster().isAvailable()) return false;
+        if (!static_cast<const SiPixelRecHit &>(hit).cluster().isAvailable())
+          return false;
       } else if (hit_type == typeid(SiStripRecHit2D)) {
-        if (!static_cast<const SiStripRecHit2D &>(hit).cluster().isAvailable()) return false;
+        if (!static_cast<const SiStripRecHit2D &>(hit).cluster().isAvailable())
+          return false;
       } else if (hit_type == typeid(SiStripRecHit1D)) {
-        if (!static_cast<const SiStripRecHit1D &>(hit).cluster().isAvailable()) return false;
-      } else if (hit_type == typeid(SiStripMatchedRecHit2D)) {      
+        if (!static_cast<const SiStripRecHit1D &>(hit).cluster().isAvailable())
+          return false;
+      } else if (hit_type == typeid(SiStripMatchedRecHit2D)) {
         const SiStripMatchedRecHit2D &mHit = static_cast<const SiStripMatchedRecHit2D &>(hit);
-        if (!mHit.monoHit().cluster().isAvailable()) return false;
-        if (!mHit.stereoHit().cluster().isAvailable()) return false;
+        if (!mHit.monoHit().cluster().isAvailable())
+          return false;
+        if (!mHit.stereoHit().cluster().isAvailable())
+          return false;
       } else if (hit_type == typeid(ProjectedSiStripRecHit2D)) {
         const ProjectedSiStripRecHit2D &pHit = static_cast<const ProjectedSiStripRecHit2D &>(hit);
-        if (!pHit.originalHit().cluster().isAvailable()) return false;
+        if (!pHit.originalHit().cluster().isAvailable())
+          return false;
       } else {
         // std::cout << "|   It is a " << hit_type.name() << " hit !?" << std::endl;
         // Do nothing. We might end up here for FastSim hits.
-      } // end 'switch' on hit type
+      }  // end 'switch' on hit type
     }
-	
+
     // No tracker hit with bad cluster found, so all fine:
     return true;
   }
@@ -196,27 +215,23 @@ namespace helper
   //------------------------------------------------------------------
   //!  Put Muons, tracks, track extras and hits+clusters into the event.
   //------------------------------------------------------------------
-    edm::OrphanHandle<reco::MuonCollection> 
-    MuonCollectionStoreManager::
-    put( edm::Event & evt ) {
-      edm::OrphanHandle<reco::MuonCollection> h;
-      h = evt.put(std::move(selMuons_), "SelectedMuons");
-      evt.put(std::move(selTracks_), "TrackerOnly");
-      evt.put(std::move(selTracksExtras_), "TrackerOnly");
-      evt.put(std::move(selTracksHits_),"TrackerOnly");
-      evt.put(std::move(selGlobalMuonTracks_),"GlobalMuon" );
-      evt.put(std::move(selGlobalMuonTracksExtras_),"GlobalMuon");
-      evt.put(std::move(selGlobalMuonTracksHits_),"GlobalMuon" );
-      evt.put(std::move(selStandAloneTracks_),"StandAlone");
-      evt.put(std::move(selStandAloneTracksExtras_),"StandAlone");
-      evt.put(std::move(selStandAloneTracksHits_),"StandAlone");
-      if (cloneClusters()) {
-          evt.put(std::move(selStripClusters_));
-          evt.put(std::move(selPixelClusters_));
-      }
-      return h; 
-     
+  edm::OrphanHandle<reco::MuonCollection> MuonCollectionStoreManager::put(edm::Event &evt) {
+    edm::OrphanHandle<reco::MuonCollection> h;
+    h = evt.put(std::move(selMuons_), "SelectedMuons");
+    evt.put(std::move(selTracks_), "TrackerOnly");
+    evt.put(std::move(selTracksExtras_), "TrackerOnly");
+    evt.put(std::move(selTracksHits_), "TrackerOnly");
+    evt.put(std::move(selGlobalMuonTracks_), "GlobalMuon");
+    evt.put(std::move(selGlobalMuonTracksExtras_), "GlobalMuon");
+    evt.put(std::move(selGlobalMuonTracksHits_), "GlobalMuon");
+    evt.put(std::move(selStandAloneTracks_), "StandAlone");
+    evt.put(std::move(selStandAloneTracksExtras_), "StandAlone");
+    evt.put(std::move(selStandAloneTracksHits_), "StandAlone");
+    if (cloneClusters()) {
+      evt.put(std::move(selStripClusters_));
+      evt.put(std::move(selPixelClusters_));
     }
+    return h;
+  }
 
-
-} // end of namespace helper
+}  // end of namespace helper

--- a/CommonTools/RecoAlgos/src/PFClusterToRefCandidate.h
+++ b/CommonTools/RecoAlgos/src/PFClusterToRefCandidate.h
@@ -13,21 +13,19 @@ namespace converter {
     typedef reco::PFCluster value_type;
     typedef reco::PFClusterCollection Components;
     typedef reco::RecoPFClusterRefCandidate Candidate;
-    PFClusterToRefCandidate(const edm::ParameterSet & cfg) : 
-      MassiveCandidateConverter(cfg) {
+    PFClusterToRefCandidate(const edm::ParameterSet& cfg) : MassiveCandidateConverter(cfg) {}
+    void convert(reco::PFClusterRef pfclusterRef, reco::RecoPFClusterRefCandidate& c) const {
+      c = reco::RecoPFClusterRefCandidate(pfclusterRef, sqrt(massSqr_));
     }
-    void convert(reco::PFClusterRef pfclusterRef, reco::RecoPFClusterRefCandidate & c) const {
-      c = reco::RecoPFClusterRefCandidate( pfclusterRef, sqrt(massSqr_) );
-    }  
   };
 
   namespace helper {
-    template<>
-    struct CandConverter<reco::PFCluster> { 
+    template <>
+    struct CandConverter<reco::PFCluster> {
       typedef PFClusterToRefCandidate type;
     };
-  }
+  }  // namespace helper
 
-}
+}  // namespace converter
 
 #endif

--- a/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
@@ -6,156 +6,151 @@
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
-
-std::pair<int,PrimaryVertexAssignment::Quality>
-PrimaryVertexAssignment::chargedHadronVertex( const reco::VertexCollection& vertices,
-                                   const reco::TrackRef& trackRef,
-                                   const reco::Track* track,
-                                   float time, 
-                                   float timeReso, // <0 if timing not available for this object
-                                   const edm::View<reco::Candidate>& jets,
-                                   const TransientTrackBuilder& builder) const {
-
+std::pair<int, PrimaryVertexAssignment::Quality> PrimaryVertexAssignment::chargedHadronVertex(
+    const reco::VertexCollection& vertices,
+    const reco::TrackRef& trackRef,
+    const reco::Track* track,
+    float time,
+    float timeReso,  // <0 if timing not available for this object
+    const edm::View<reco::Candidate>& jets,
+    const TransientTrackBuilder& builder) const {
   typedef reco::VertexCollection::const_iterator IV;
   typedef reco::Vertex::trackRef_iterator IT;
 
   int iVertex = -1;
-  size_t index=0;
-  float bestweight=0;
-  for( auto const & vtx : vertices) {
-      float w = vtx.trackWeight(trackRef);
-      if (w > bestweight){
-        bestweight=w;
-        iVertex=index;
-      }        
-      index++;
+  size_t index = 0;
+  float bestweight = 0;
+  for (auto const& vtx : vertices) {
+    float w = vtx.trackWeight(trackRef);
+    if (w > bestweight) {
+      bestweight = w;
+      iVertex = index;
+    }
+    index++;
   }
-  
+
   bool useTime = useTiming_;
-  if (edm::isNotFinite(time) || timeReso<1e-6) {
+  if (edm::isNotFinite(time) || timeReso < 1e-6) {
     useTime = false;
     time = 0.;
     timeReso = -1.;
   }
-  
+
   if (preferHighRanked_) {
-    for(IV iv=vertices.begin(); iv!=vertices.end(); ++iv) {
-        int ivtx = iv - vertices.begin();
-        if (iVertex == ivtx) return std::pair<int,PrimaryVertexAssignment::Quality>(ivtx,PrimaryVertexAssignment::UsedInFit);
-        
-        double dz = std::abs(track->dz(iv->position()));
-        double dt = std::abs(time-iv->t());
-        
-        bool useTimeVtx = useTime && iv->tError()>0.;
-        
-        if ((dz < maxDzForPrimaryAssignment_ or dz/track->dzError() < maxDzSigForPrimaryAssignment_ ) and (!useTimeVtx or dt/timeReso < maxDtSigForPrimaryAssignment_)) {
-          return std::pair<int,PrimaryVertexAssignment::Quality>(ivtx,PrimaryVertexAssignment::PrimaryDz);
-        }               
+    for (IV iv = vertices.begin(); iv != vertices.end(); ++iv) {
+      int ivtx = iv - vertices.begin();
+      if (iVertex == ivtx)
+        return std::pair<int, PrimaryVertexAssignment::Quality>(ivtx, PrimaryVertexAssignment::UsedInFit);
+
+      double dz = std::abs(track->dz(iv->position()));
+      double dt = std::abs(time - iv->t());
+
+      bool useTimeVtx = useTime && iv->tError() > 0.;
+
+      if ((dz < maxDzForPrimaryAssignment_ or dz / track->dzError() < maxDzSigForPrimaryAssignment_) and
+          (!useTimeVtx or dt / timeReso < maxDtSigForPrimaryAssignment_)) {
+        return std::pair<int, PrimaryVertexAssignment::Quality>(ivtx, PrimaryVertexAssignment::PrimaryDz);
+      }
     }
   }
 
-    
-  if(iVertex >= 0 ) return std::pair<int,PrimaryVertexAssignment::Quality>(iVertex,PrimaryVertexAssignment::UsedInFit);
-    
+  if (iVertex >= 0)
+    return std::pair<int, PrimaryVertexAssignment::Quality>(iVertex, PrimaryVertexAssignment::UsedInFit);
+
   double distmin = std::numeric_limits<double>::max();
   double dzmin = std::numeric_limits<double>::max();
   double dtmin = std::numeric_limits<double>::max();
   int vtxIdMinSignif = -1;
-  for(IV iv=vertices.begin(); iv!=vertices.end(); ++iv) {
+  for (IV iv = vertices.begin(); iv != vertices.end(); ++iv) {
     double dz = std::abs(track->dz(iv->position()));
-    double dt = std::abs(time-iv->t());
-    
-    double dzsig = dz/track->dzError();
-    double dist = dzsig*dzsig;
-    
-    bool useTimeVtx = useTime && iv->tError()>0.;
+    double dt = std::abs(time - iv->t());
+
+    double dzsig = dz / track->dzError();
+    double dist = dzsig * dzsig;
+
+    bool useTimeVtx = useTime && iv->tError() > 0.;
     if (useTime && !useTimeVtx) {
       dt = timeReso;
     }
-    
+
     if (useTime) {
-      double dtsig = dt/timeReso;
-              
-      dist += dtsig*dtsig;
+      double dtsig = dt / timeReso;
+
+      dist += dtsig * dtsig;
     }
-    if(dist<distmin) {
+    if (dist < distmin) {
       distmin = dist;
       dzmin = dz;
       dtmin = dt;
-      vtxIdMinSignif = iv-vertices.begin();
+      vtxIdMinSignif = iv - vertices.begin();
     }
   }
-      
+
   // first use "closest in Z" with tight cuts (targetting primary particles)
-    const float add_cov = vtxIdMinSignif >= 0 ? vertices[vtxIdMinSignif].covariance(2,2) : 0.f;
-    const float dzE=sqrt(track->dzError()*track->dzError()+add_cov);
-    if(vtxIdMinSignif>=0 and 
-       (dzmin < maxDzForPrimaryAssignment_ and dzmin/dzE < maxDzSigForPrimaryAssignment_  and track->dzError()<maxDzErrorForPrimaryAssignment_) and
-       (!useTime or dtmin/timeReso < maxDtSigForPrimaryAssignment_) )
-    {
-        iVertex=vtxIdMinSignif;
-    }
- 
-  if(iVertex >= 0 ) return std::pair<int,PrimaryVertexAssignment::Quality>(iVertex,PrimaryVertexAssignment::PrimaryDz);
+  const float add_cov = vtxIdMinSignif >= 0 ? vertices[vtxIdMinSignif].covariance(2, 2) : 0.f;
+  const float dzE = sqrt(track->dzError() * track->dzError() + add_cov);
+  if (vtxIdMinSignif >= 0 and
+      (dzmin < maxDzForPrimaryAssignment_ and dzmin / dzE < maxDzSigForPrimaryAssignment_ and
+       track->dzError() < maxDzErrorForPrimaryAssignment_) and
+      (!useTime or dtmin / timeReso < maxDtSigForPrimaryAssignment_)) {
+    iVertex = vtxIdMinSignif;
+  }
 
-  
-  
+  if (iVertex >= 0)
+    return std::pair<int, PrimaryVertexAssignment::Quality>(iVertex, PrimaryVertexAssignment::PrimaryDz);
+
   // if track not assigned yet, it could be a b-decay secondary , use jet axis dist criterion
-    // first find the closest jet within maxJetDeltaR_
-    int jetIdx = -1;
-    double minDeltaR = maxJetDeltaR_;
-    for(edm::View<reco::Candidate>::const_iterator ij=jets.begin(); ij!=jets.end(); ++ij)
-    {
-      if( ij->pt() < minJetPt_ ) continue; // skip jets below the jet Pt threshold
+  // first find the closest jet within maxJetDeltaR_
+  int jetIdx = -1;
+  double minDeltaR = maxJetDeltaR_;
+  for (edm::View<reco::Candidate>::const_iterator ij = jets.begin(); ij != jets.end(); ++ij) {
+    if (ij->pt() < minJetPt_)
+      continue;  // skip jets below the jet Pt threshold
 
-      double deltaR = reco::deltaR( *ij, *track );
-      if( deltaR < minDeltaR and track->dzError()<maxDzErrorForPrimaryAssignment_ )
-      {
-        minDeltaR = deltaR;
-        jetIdx = std::distance(jets.begin(), ij);
+    double deltaR = reco::deltaR(*ij, *track);
+    if (deltaR < minDeltaR and track->dzError() < maxDzErrorForPrimaryAssignment_) {
+      minDeltaR = deltaR;
+      jetIdx = std::distance(jets.begin(), ij);
+    }
+  }
+  // if jet found
+  if (jetIdx != -1) {
+    reco::TransientTrack transientTrack = builder.build(*track);
+    GlobalVector direction(jets.at(jetIdx).px(), jets.at(jetIdx).py(), jets.at(jetIdx).pz());
+    // find the vertex with the smallest distanceToJetAxis that is still within maxDistaneToJetAxis_
+    int vtxIdx = -1;
+    double minDistanceToJetAxis = maxDistanceToJetAxis_;
+    for (IV iv = vertices.begin(); iv != vertices.end(); ++iv) {
+      // only check for vertices that are close enough in Z and for tracks that have not too high dXY
+      if (std::abs(track->dz(iv->position())) > maxDzForJetAxisAssigment_ ||
+          std::abs(track->dxy(iv->position())) > maxDxyForJetAxisAssigment_)
+        continue;
+
+      double distanceToJetAxis = IPTools::jetTrackDistance(transientTrack, direction, *iv).second.value();
+      if (distanceToJetAxis < minDistanceToJetAxis) {
+        minDistanceToJetAxis = distanceToJetAxis;
+        vtxIdx = std::distance(vertices.begin(), iv);
       }
     }
-    // if jet found
-    if( jetIdx!=-1 )
-    {
-      reco::TransientTrack transientTrack = builder.build(*track);
-      GlobalVector direction(jets.at(jetIdx).px(), jets.at(jetIdx).py(), jets.at(jetIdx).pz());
-      // find the vertex with the smallest distanceToJetAxis that is still within maxDistaneToJetAxis_
-      int vtxIdx = -1;
-      double minDistanceToJetAxis = maxDistanceToJetAxis_;
-      for(IV iv=vertices.begin(); iv!=vertices.end(); ++iv)
-      {
-        // only check for vertices that are close enough in Z and for tracks that have not too high dXY
-        if(std::abs(track->dz(iv->position())) > maxDzForJetAxisAssigment_ || std::abs(track->dxy(iv->position())) > maxDxyForJetAxisAssigment_) 
-          continue;
-
-        double distanceToJetAxis = IPTools::jetTrackDistance(transientTrack, direction, *iv).second.value();
-        if( distanceToJetAxis < minDistanceToJetAxis )
-        {
-          minDistanceToJetAxis = distanceToJetAxis;
-          vtxIdx = std::distance(vertices.begin(), iv);
-        }
-      }
-      if( vtxIdx>=0 )
-      {
-        iVertex=vtxIdx;
-      }
+    if (vtxIdx >= 0) {
+      iVertex = vtxIdx;
     }
-  if(iVertex >= 0 )
-     return std::pair<int,PrimaryVertexAssignment::Quality>(iVertex,PrimaryVertexAssignment::BTrack);
+  }
+  if (iVertex >= 0)
+    return std::pair<int, PrimaryVertexAssignment::Quality>(iVertex, PrimaryVertexAssignment::BTrack);
 
   // if the track is not compatible with other PVs but is compatible with the BeamSpot, we may simply have not reco'ed the PV!
   //  we still point it to the closest in Z, but flag it as possible orphan-primary
-  if(!vertices.empty() && std::abs(track->dxy(vertices[0].position()))<maxDxyForNotReconstructedPrimary_ && std::abs(track->dxy(vertices[0].position())/track->dxyError())<maxDxySigForNotReconstructedPrimary_)
-     return std::pair<int,PrimaryVertexAssignment::Quality>(vtxIdMinSignif,PrimaryVertexAssignment::NotReconstructedPrimary);
- 
+  if (!vertices.empty() && std::abs(track->dxy(vertices[0].position())) < maxDxyForNotReconstructedPrimary_ &&
+      std::abs(track->dxy(vertices[0].position()) / track->dxyError()) < maxDxySigForNotReconstructedPrimary_)
+    return std::pair<int, PrimaryVertexAssignment::Quality>(vtxIdMinSignif,
+                                                            PrimaryVertexAssignment::NotReconstructedPrimary);
+
   //FIXME: here we could better handle V0s and NucInt
 
   // all other tracks could be non-B secondaries and we just attach them with closest Z
-  if(vtxIdMinSignif>=0)
-     return std::pair<int,PrimaryVertexAssignment::Quality>(vtxIdMinSignif,PrimaryVertexAssignment::OtherDz);
+  if (vtxIdMinSignif >= 0)
+    return std::pair<int, PrimaryVertexAssignment::Quality>(vtxIdMinSignif, PrimaryVertexAssignment::OtherDz);
   //If for some reason even the dz failed (when?) we consider the track not assigned
-  return std::pair<int,PrimaryVertexAssignment::Quality>(-1,PrimaryVertexAssignment::Unassigned);
+  return std::pair<int, PrimaryVertexAssignment::Quality>(-1, PrimaryVertexAssignment::Unassigned);
 }
-
-

--- a/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
@@ -14,60 +14,59 @@
 using namespace fastjet;
 using namespace std;
 
-
-float PrimaryVertexSorting::score(const reco::Vertex & pv,const  std::vector<const reco::Candidate *> & cands, bool useMet ) const {
+float PrimaryVertexSorting::score(const reco::Vertex &pv,
+                                  const std::vector<const reco::Candidate *> &cands,
+                                  bool useMet) const {
   typedef math::XYZTLorentzVector LorentzVector;
-  float sumPt2=0;
-  float sumEt=0;
+  float sumPt2 = 0;
+  float sumEt = 0;
   LorentzVector met;
-  std::vector<fastjet::PseudoJet> fjInputs_;  
+  std::vector<fastjet::PseudoJet> fjInputs_;
   fjInputs_.clear();
   size_t countScale0 = 0;
-  for (size_t i = 0 ; i < cands.size(); i++) {
-    const reco::Candidate * c= cands[i];
-    float scale=1.;
-    if(c->bestTrack() != nullptr)
-      {
-	if(c->pt()!=0) {
-       		 scale=(c->pt()-c->bestTrack()->ptError())/c->pt();
-	}
- 	if(edm::isNotFinite(scale)) { 
-		edm::LogWarning("PrimaryVertexSorting") << "Scaling is NAN ignoring this candidate/track" << std::endl;
-		scale=0; 
-        }
-        if(scale<0){ 
-	  scale=0; 
-	  countScale0++;
-	}
+  for (size_t i = 0; i < cands.size(); i++) {
+    const reco::Candidate *c = cands[i];
+    float scale = 1.;
+    if (c->bestTrack() != nullptr) {
+      if (c->pt() != 0) {
+        scale = (c->pt() - c->bestTrack()->ptError()) / c->pt();
       }
+      if (edm::isNotFinite(scale)) {
+        edm::LogWarning("PrimaryVertexSorting") << "Scaling is NAN ignoring this candidate/track" << std::endl;
+        scale = 0;
+      }
+      if (scale < 0) {
+        scale = 0;
+        countScale0++;
+      }
+    }
 
-    int absId=abs(c->pdgId());
-    if(absId==13 or absId == 11) {
-      float pt =c->pt()*scale;
-      sumPt2+=pt*pt;
-      met+=c->p4()*scale;
-      sumEt+=c->pt()*scale;
+    int absId = abs(c->pdgId());
+    if (absId == 13 or absId == 11) {
+      float pt = c->pt() * scale;
+      sumPt2 += pt * pt;
+      met += c->p4() * scale;
+      sumEt += c->pt() * scale;
     } else {
-      if (scale != 0){ // otherwise, what is the point to cluster zeroes
-	fjInputs_.push_back(fastjet::PseudoJet(c->px()*scale,c->py()*scale,c->pz()*scale,c->p4().E()*scale));
-	//      fjInputs_.back().set_user_index(i);
+      if (scale != 0) {  // otherwise, what is the point to cluster zeroes
+        fjInputs_.push_back(fastjet::PseudoJet(c->px() * scale, c->py() * scale, c->pz() * scale, c->p4().E() * scale));
+        //      fjInputs_.back().set_user_index(i);
       }
     }
   }
-  fastjet::ClusterSequence sequence( fjInputs_, JetDefinition(antikt_algorithm, 0.4));
+  fastjet::ClusterSequence sequence(fjInputs_, JetDefinition(antikt_algorithm, 0.4));
   auto jets = fastjet::sorted_by_pt(sequence.inclusive_jets(0));
-  for (const auto & pj : jets) {
-    auto p4 = LorentzVector( pj.px(), pj.py(), pj.pz(), pj.e() ) ;
-    sumPt2+=(p4.pt()*p4.pt())*0.8*0.8;
-    met+=p4;
-    sumEt+=p4.pt();
+  for (const auto &pj : jets) {
+    auto p4 = LorentzVector(pj.px(), pj.py(), pj.pz(), pj.e());
+    sumPt2 += (p4.pt() * p4.pt()) * 0.8 * 0.8;
+    met += p4;
+    sumEt += p4.pt();
   }
-  float metAbove = met.pt() - 2*sqrt(sumEt);
-  if(metAbove > 0 and useMet) {
-    sumPt2+=metAbove*metAbove;
+  float metAbove = met.pt() - 2 * sqrt(sumEt);
+  if (metAbove > 0 and useMet) {
+    sumPt2 += metAbove * metAbove;
   }
-  if (countScale0 == cands.size()) sumPt2 = countScale0*0.01; //leave some epsilon value to sort vertices with unknown pt
+  if (countScale0 == cands.size())
+    sumPt2 = countScale0 * 0.01;  //leave some epsilon value to sort vertices with unknown pt
   return sumPt2;
 }
-
-

--- a/CommonTools/RecoAlgos/src/RecoChargedRefCandidateToTrackRef.h
+++ b/CommonTools/RecoAlgos/src/RecoChargedRefCandidateToTrackRef.h
@@ -5,19 +5,20 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedRefCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedRefCandidateFwd.h"
 
-namespace edm { class EventSetup; class ParameterSet; }
+namespace edm {
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
 namespace converter {
   struct RecoChargedRefCandidateToTrackRef {
     typedef reco::RecoChargedRefCandidate value_type;
     typedef reco::RecoChargedRefCandidateCollection Components;
     typedef reco::TrackRef Candidate;
-    RecoChargedRefCandidateToTrackRef(const edm::ParameterSet & cfg) {}
+    RecoChargedRefCandidateToTrackRef(const edm::ParameterSet& cfg) {}
     void beginFirstRun(const edm::EventSetup&) {}
-    void convert(const reco::RecoChargedRefCandidateRef& c, reco::TrackRef& trkRef) const {
-      trkRef = c->track();
-    }  
+    void convert(const reco::RecoChargedRefCandidateRef& c, reco::TrackRef& trkRef) const { trkRef = c->track(); }
   };
-}
+}  // namespace converter
 
 #endif

--- a/CommonTools/RecoAlgos/src/StandAloneMuonTrackToCandidate.h
+++ b/CommonTools/RecoAlgos/src/StandAloneMuonTrackToCandidate.h
@@ -13,11 +13,9 @@ namespace converter {
     typedef reco::Track value_type;
     typedef reco::TrackCollection Components;
     typedef reco::RecoStandAloneMuonCandidate Candidate;
-    StandAloneMuonTrackToCandidate(const edm::ParameterSet & cfg) : 
-      MassiveCandidateConverter(cfg) {
-    }
-    void convert(reco::TrackRef trkRef, reco::RecoStandAloneMuonCandidate & c) const {
-      const reco::Track & trk = * trkRef;
+    StandAloneMuonTrackToCandidate(const edm::ParameterSet& cfg) : MassiveCandidateConverter(cfg) {}
+    void convert(reco::TrackRef trkRef, reco::RecoStandAloneMuonCandidate& c) const {
+      const reco::Track& trk = *trkRef;
       c.setCharge(trk.charge());
       c.setVertex(trk.vertex());
       const reco::Track::Vector& p = trk.momentum();
@@ -25,16 +23,16 @@ namespace converter {
       c.setP4(reco::Candidate::LorentzVector(p.x(), p.y(), p.z(), t));
       c.setTrack(trkRef);
       c.setPdgId(particle_.pdgId());
-    }  
+    }
   };
 
   namespace helper {
-    template<>
-    struct CandConverter<reco::Track> { 
+    template <>
+    struct CandConverter<reco::Track> {
       typedef StandAloneMuonTrackToCandidate type;
     };
-  }
+  }  // namespace helper
 
-}
+}  // namespace converter
 
 #endif

--- a/CommonTools/RecoAlgos/src/SuperClusterToCandidate.h
+++ b/CommonTools/RecoAlgos/src/SuperClusterToCandidate.h
@@ -12,12 +12,10 @@ namespace converter {
     typedef reco::SuperCluster value_type;
     typedef reco::SuperClusterCollection Components;
     typedef reco::RecoEcalCandidate Candidate;
-    SuperClusterToCandidate(const edm::ParameterSet & cfg) : 
-      MassiveCandidateConverter(cfg) {
-    }
-    void convert(reco::SuperClusterRef scRef, reco::RecoEcalCandidate & c) const {
-      const reco::SuperCluster & sc = * scRef;
-      math::XYZPoint v(0, 0, 0); // this should be taken from something else...
+    SuperClusterToCandidate(const edm::ParameterSet& cfg) : MassiveCandidateConverter(cfg) {}
+    void convert(reco::SuperClusterRef scRef, reco::RecoEcalCandidate& c) const {
+      const reco::SuperCluster& sc = *scRef;
+      math::XYZPoint v(0, 0, 0);  // this should be taken from something else...
       math::XYZVector p = sc.energy() * (sc.position() - v).unit();
       double t = sqrt(massSqr_ + p.mag2());
       c.setCharge(0);
@@ -29,11 +27,11 @@ namespace converter {
   };
 
   namespace helper {
-    template<>
-    struct CandConverter<reco::SuperCluster> { 
+    template <>
+    struct CandConverter<reco::SuperCluster> {
       typedef SuperClusterToCandidate type;
     };
-  }
-}
+  }  // namespace helper
+}  // namespace converter
 
 #endif

--- a/CommonTools/RecoAlgos/src/TrackSelector.cc
+++ b/CommonTools/RecoAlgos/src/TrackSelector.cc
@@ -2,75 +2,67 @@
 
 using namespace reco;
 
-namespace helper 
-{
+namespace helper {
 
-  TrackCollectionStoreManager::
-  TrackCollectionStoreManager(const edm::Handle<reco::TrackCollection> & ) 
-    :
-    selTracks_( new reco::TrackCollection ),
-    selTrackExtras_( new reco::TrackExtraCollection ),
-    selHits_( new TrackingRecHitCollection ),
-    selStripClusters_( new edmNew::DetSetVector<SiStripCluster> ),
-    selPixelClusters_( new edmNew::DetSetVector<SiPixelCluster> ),
-    rTracks_(), rTrackExtras_(), rHits_(),
-    clusterStorer_(),
-    idx_(0), hidx_(0),
-    cloneClusters_ (true)
-  {
-  }
-  
-  
+  TrackCollectionStoreManager::TrackCollectionStoreManager(const edm::Handle<reco::TrackCollection>&)
+      : selTracks_(new reco::TrackCollection),
+        selTrackExtras_(new reco::TrackExtraCollection),
+        selHits_(new TrackingRecHitCollection),
+        selStripClusters_(new edmNew::DetSetVector<SiStripCluster>),
+        selPixelClusters_(new edmNew::DetSetVector<SiPixelCluster>),
+        rTracks_(),
+        rTrackExtras_(),
+        rHits_(),
+        clusterStorer_(),
+        idx_(0),
+        hidx_(0),
+        cloneClusters_(true) {}
+
   //------------------------------------------------------------------
-  //!  Process a single track.  
+  //!  Process a single track.
   //------------------------------------------------------------------
-  void 
-  TrackCollectionStoreManager::
-  processTrack( const Track & trk ) 
-  {
-    selTracks_->push_back( Track( trk ) );
-    selTracks_->back().setExtra( TrackExtraRef( rTrackExtras_, idx_ ++ ) );
-    selTrackExtras_->push_back( TrackExtra( trk.outerPosition(), trk.outerMomentum(), trk.outerOk(),
-					    trk.innerPosition(), trk.innerMomentum(), trk.innerOk(),
-					    trk.outerStateCovariance(), trk.outerDetId(),
-					    trk.innerStateCovariance(), trk.innerDetId(),
-					    trk.seedDirection() ) );
-    TrackExtra & tx = selTrackExtras_->back();
+  void TrackCollectionStoreManager::processTrack(const Track& trk) {
+    selTracks_->push_back(Track(trk));
+    selTracks_->back().setExtra(TrackExtraRef(rTrackExtras_, idx_++));
+    selTrackExtras_->push_back(TrackExtra(trk.outerPosition(),
+                                          trk.outerMomentum(),
+                                          trk.outerOk(),
+                                          trk.innerPosition(),
+                                          trk.innerMomentum(),
+                                          trk.innerOk(),
+                                          trk.outerStateCovariance(),
+                                          trk.outerDetId(),
+                                          trk.innerStateCovariance(),
+                                          trk.innerDetId(),
+                                          trk.seedDirection()));
+    TrackExtra& tx = selTrackExtras_->back();
     auto const firstHitIndex = hidx_;
     unsigned int nHitsAdded = 0;
-    for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd();
-	 ++ hit, ++ hidx_ ) {
+    for (trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++hit, ++hidx_) {
+      selHits_->push_back((*hit)->clone());
+      TrackingRecHit* newHit = &(selHits_->back());
+      ++nHitsAdded;
 
-        selHits_->push_back( (*hit)->clone() );
-        TrackingRecHit * newHit = & (selHits_->back());
-        ++nHitsAdded;
+      //--- Skip the rest for this hit if we don't want to clone the cluster.
+      //--- The copy constructer in the rec hit will copy the link properly.
+      if (cloneClusters() && newHit->isValid() && ((*hit)->geographicalId().det() == DetId::Tracker)) {
+        clusterStorer_.addCluster(*selHits_, hidx_);
+      }
+    }  // end of for loop over tracking rec hits on this track
+    tx.setHits(rHits_, firstHitIndex, nHitsAdded);
 
-        //--- Skip the rest for this hit if we don't want to clone the cluster.
-        //--- The copy constructer in the rec hit will copy the link properly.
-        if (cloneClusters() && newHit->isValid()
-	    && ((*hit)->geographicalId().det() == DetId::Tracker)) {
-	  clusterStorer_.addCluster( *selHits_, hidx_ );
-        }
-    } // end of for loop over tracking rec hits on this track
-    tx.setHits( rHits_, firstHitIndex, nHitsAdded );
-
-  } // end of track, and function
-
+  }  // end of track, and function
 
   //------------------------------------------------------------------
   //!  Put tracks, track extras and hits+clusters into the event.
   //------------------------------------------------------------------
-  edm::OrphanHandle<reco::TrackCollection> 
-  TrackCollectionStoreManager::
-  put( edm::Event & evt ) {
-    edm::OrphanHandle<reco::TrackCollection> 
-      h = evt.put(std::move(selTracks_));
+  edm::OrphanHandle<reco::TrackCollection> TrackCollectionStoreManager::put(edm::Event& evt) {
+    edm::OrphanHandle<reco::TrackCollection> h = evt.put(std::move(selTracks_));
     evt.put(std::move(selTrackExtras_));
     evt.put(std::move(selHits_));
     evt.put(std::move(selStripClusters_));
     evt.put(std::move(selPixelClusters_));
-    return h; 
+    return h;
   }
-  
-} // end of namespace helper
 
+}  // end of namespace helper

--- a/CommonTools/RecoAlgos/src/TrackToCandidate.h
+++ b/CommonTools/RecoAlgos/src/TrackToCandidate.h
@@ -13,11 +13,9 @@ namespace converter {
     typedef reco::Track value_type;
     typedef reco::TrackCollection Components;
     typedef reco::RecoChargedCandidate Candidate;
-    TrackToCandidate(const edm::ParameterSet & cfg) :
-      MassiveCandidateConverter(cfg) {
-    }
-    void convert(reco::TrackRef trkRef, reco::RecoChargedCandidate & c) const {
-      const reco::Track & trk = * trkRef;
+    TrackToCandidate(const edm::ParameterSet& cfg) : MassiveCandidateConverter(cfg) {}
+    void convert(reco::TrackRef trkRef, reco::RecoChargedCandidate& c) const {
+      const reco::Track& trk = *trkRef;
       c.setCharge(trk.charge());
       c.setVertex(trk.vertex());
       const reco::Track::Vector& p = trk.momentum();
@@ -29,12 +27,12 @@ namespace converter {
   };
 
   namespace helper {
-    template<>
+    template <>
     struct CandConverter<reco::Track> {
       typedef TrackToCandidate type;
     };
-  }
+  }  // namespace helper
 
-}
+}  // namespace converter
 
 #endif

--- a/CommonTools/RecoAlgos/src/TrackToRefCandidate.h
+++ b/CommonTools/RecoAlgos/src/TrackToRefCandidate.h
@@ -13,21 +13,19 @@ namespace converter {
     typedef reco::Track value_type;
     typedef reco::TrackCollection Components;
     typedef reco::RecoChargedRefCandidate Candidate;
-    TrackToRefCandidate(const edm::ParameterSet & cfg) : 
-      MassiveCandidateConverter(cfg) {
+    TrackToRefCandidate(const edm::ParameterSet& cfg) : MassiveCandidateConverter(cfg) {}
+    void convert(reco::TrackRef trkRef, reco::RecoChargedRefCandidate& c) const {
+      c = reco::RecoChargedRefCandidate(trkRef, sqrt(massSqr_));
     }
-    void convert(reco::TrackRef trkRef, reco::RecoChargedRefCandidate & c) const {
-      c = reco::RecoChargedRefCandidate( trkRef, sqrt(massSqr_) );
-    }  
   };
 
   namespace helper {
-    template<>
-    struct CandConverter<reco::Track> { 
+    template <>
+    struct CandConverter<reco::Track> {
       typedef TrackToRefCandidate type;
     };
-  }
+  }  // namespace helper
 
-}
+}  // namespace converter
 
 #endif

--- a/CommonTools/RecoAlgos/src/TrackWithVertexSelector.cc
+++ b/CommonTools/RecoAlgos/src/TrackWithVertexSelector.cc
@@ -8,130 +8,123 @@ namespace {
   constexpr float fakeBeamSpotTimeWidth = 0.175f;
 }
 
-TrackWithVertexSelector::TrackWithVertexSelector(const edm::ParameterSet& iConfig, edm::ConsumesCollector & iC) :
-  numberOfValidHits_(iConfig.getParameter<uint32_t>("numberOfValidHits")),
-  numberOfValidPixelHits_(iConfig.getParameter<uint32_t>("numberOfValidPixelHits")),
-  numberOfLostHits_(iConfig.getParameter<uint32_t>("numberOfLostHits")),
-  normalizedChi2_(iConfig.getParameter<double>("normalizedChi2")),
-  ptMin_(iConfig.getParameter<double>("ptMin")),
-  ptMax_(iConfig.getParameter<double>("ptMax")),
-  etaMin_(iConfig.getParameter<double>("etaMin")),
-  etaMax_(iConfig.getParameter<double>("etaMax")),
-  dzMax_(iConfig.getParameter<double>("dzMax")),
-  d0Max_(iConfig.getParameter<double>("d0Max")),
-  ptErrorCut_(iConfig.getParameter<double>("ptErrorCut")),
-  quality_(iConfig.getParameter<std::string>("quality")),
-  nVertices_(iConfig.getParameter<bool>("useVtx") ? iConfig.getParameter<uint32_t>("nVertices") : 0),
-  vertexToken_(iC.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexTag"))),
-  timesToken_(iC.consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("timesTag"))),
-  timeResosToken_(iC.consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("timeResosTag"))),
-  vtxFallback_(iConfig.getParameter<bool>("vtxFallback")),
-  zetaVtx_(iConfig.getParameter<double>("zetaVtx")),
-  rhoVtx_(iConfig.getParameter<double>("rhoVtx")),
-  nSigmaDtVertex_(iConfig.getParameter<double>("nSigmaDtVertex")) {
-}
+TrackWithVertexSelector::TrackWithVertexSelector(const edm::ParameterSet &iConfig, edm::ConsumesCollector &iC)
+    : numberOfValidHits_(iConfig.getParameter<uint32_t>("numberOfValidHits")),
+      numberOfValidPixelHits_(iConfig.getParameter<uint32_t>("numberOfValidPixelHits")),
+      numberOfLostHits_(iConfig.getParameter<uint32_t>("numberOfLostHits")),
+      normalizedChi2_(iConfig.getParameter<double>("normalizedChi2")),
+      ptMin_(iConfig.getParameter<double>("ptMin")),
+      ptMax_(iConfig.getParameter<double>("ptMax")),
+      etaMin_(iConfig.getParameter<double>("etaMin")),
+      etaMax_(iConfig.getParameter<double>("etaMax")),
+      dzMax_(iConfig.getParameter<double>("dzMax")),
+      d0Max_(iConfig.getParameter<double>("d0Max")),
+      ptErrorCut_(iConfig.getParameter<double>("ptErrorCut")),
+      quality_(iConfig.getParameter<std::string>("quality")),
+      nVertices_(iConfig.getParameter<bool>("useVtx") ? iConfig.getParameter<uint32_t>("nVertices") : 0),
+      vertexToken_(iC.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexTag"))),
+      timesToken_(iC.consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("timesTag"))),
+      timeResosToken_(iC.consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("timeResosTag"))),
+      vtxFallback_(iConfig.getParameter<bool>("vtxFallback")),
+      zetaVtx_(iConfig.getParameter<double>("zetaVtx")),
+      rhoVtx_(iConfig.getParameter<double>("rhoVtx")),
+      nSigmaDtVertex_(iConfig.getParameter<double>("nSigmaDtVertex")) {}
 
-TrackWithVertexSelector::~TrackWithVertexSelector() {  }
+TrackWithVertexSelector::~TrackWithVertexSelector() {}
 
+void TrackWithVertexSelector::init(const edm::Event &event) {
+  edm::Handle<reco::VertexCollection> hVtx;
+  event.getByToken(vertexToken_, hVtx);
+  vcoll_ = hVtx.product();
 
-void TrackWithVertexSelector::init(const edm::Event & event) {
-    edm::Handle<reco::VertexCollection> hVtx;
-    event.getByToken(vertexToken_, hVtx);
-    vcoll_ = hVtx.product();
+  edm::Handle<edm::ValueMap<float> > hTimes;
+  event.getByToken(timesToken_, hTimes);
+  timescoll_ = hTimes.isValid() ? hTimes.product() : nullptr;
 
-    edm::Handle<edm::ValueMap<float> > hTimes;
-    event.getByToken(timesToken_, hTimes);
-    timescoll_ = hTimes.isValid() ? hTimes.product() : nullptr;
-
-    edm::Handle<edm::ValueMap<float> > hTimeResos;
-    event.getByToken(timeResosToken_, hTimeResos);
-    timeresoscoll_ = hTimeResos.isValid() ? hTimeResos.product() : nullptr;
+  edm::Handle<edm::ValueMap<float> > hTimeResos;
+  event.getByToken(timeResosToken_, hTimeResos);
+  timeresoscoll_ = hTimeResos.isValid() ? hTimeResos.product() : nullptr;
 }
 
 bool TrackWithVertexSelector::testTrack(const reco::Track &t) const {
   using std::abs;
   if ((t.numberOfValidHits() >= numberOfValidHits_) &&
       (static_cast<unsigned int>(t.hitPattern().numberOfValidPixelHits()) >= numberOfValidPixelHits_) &&
-      (t.numberOfLostHits() <= numberOfLostHits_) &&
-      (t.normalizedChi2()    <= normalizedChi2_) &&
-      (t.ptError()/t.pt()*std::max(1.,t.normalizedChi2()) <= ptErrorCut_) &&
-      (t.quality(t.qualityByName(quality_))) &&
-      (t.pt()              >= ptMin_)      &&
-      (t.pt()              <= ptMax_)      &&
-      (abs(t.eta())   <= etaMax_)     &&
-      (abs(t.eta())   >= etaMin_)     &&
-      (abs(t.dz())    <= dzMax_)      &&
-      (abs(t.d0())    <= d0Max_)  ) {
+      (t.numberOfLostHits() <= numberOfLostHits_) && (t.normalizedChi2() <= normalizedChi2_) &&
+      (t.ptError() / t.pt() * std::max(1., t.normalizedChi2()) <= ptErrorCut_) &&
+      (t.quality(t.qualityByName(quality_))) && (t.pt() >= ptMin_) && (t.pt() <= ptMax_) && (abs(t.eta()) <= etaMax_) &&
+      (abs(t.eta()) >= etaMin_) && (abs(t.dz()) <= dzMax_) && (abs(t.d0()) <= d0Max_)) {
     return true;
   }
   return false;
 }
 
-bool TrackWithVertexSelector::testTrack(const reco::TrackRef &tref) const {
-  return testTrack(*tref);
-}
+bool TrackWithVertexSelector::testTrack(const reco::TrackRef &tref) const { return testTrack(*tref); }
 
-bool TrackWithVertexSelector::testVertices(const reco::Track& t, const reco::VertexCollection &vtxs) const {
+bool TrackWithVertexSelector::testVertices(const reco::Track &t, const reco::VertexCollection &vtxs) const {
   bool ok = false;
   if (!vtxs.empty()) {
     unsigned int tested = 1;
-    for (reco::VertexCollection::const_iterator it = vtxs.begin(), ed = vtxs.end();
-	 it != ed; ++it) {
-      if ( (std::abs(t.dxy(it->position())) < rhoVtx_) &&
-           (std::abs(t.dz(it->position())) < zetaVtx_)  ) {
-        ok = true; break;
+    for (reco::VertexCollection::const_iterator it = vtxs.begin(), ed = vtxs.end(); it != ed; ++it) {
+      if ((std::abs(t.dxy(it->position())) < rhoVtx_) && (std::abs(t.dz(it->position())) < zetaVtx_)) {
+        ok = true;
+        break;
       }
-      if (tested++ >= nVertices_) break;
+      if (tested++ >= nVertices_)
+        break;
     }
   } else if (vtxFallback_) {
-    return ( (std::abs(t.vertex().z()) < 15.9) && (t.vertex().Rho() < 0.2) );
+    return ((std::abs(t.vertex().z()) < 15.9) && (t.vertex().Rho() < 0.2));
   }
   return ok;
 }
 
 bool TrackWithVertexSelector::testVertices(const reco::TrackRef &tref, const reco::VertexCollection &vtxs) const {
-  const auto& t = *tref;
+  const auto &t = *tref;
   const bool timeAvailable = timescoll_ != nullptr && timeresoscoll_ != nullptr;
   bool ok = false;
   if (!vtxs.empty()) {
     unsigned int tested = 1;
-    for (reco::VertexCollection::const_iterator it = vtxs.begin(), ed = vtxs.end();
-	 it != ed; ++it) {
+    for (reco::VertexCollection::const_iterator it = vtxs.begin(), ed = vtxs.end(); it != ed; ++it) {
       const bool useTime = timeAvailable && it->t() != 0.;
       float time = useTime ? (*timescoll_)[tref] : -1.f;
       float timeReso = useTime ? (*timeresoscoll_)[tref] : -1.f;
-      timeReso = ( timeReso > 1e-6 ? timeReso : fakeBeamSpotTimeWidth );
+      timeReso = (timeReso > 1e-6 ? timeReso : fakeBeamSpotTimeWidth);
 
-      if( edm::isNotFinite(time) ) {
-	time = 0.0;
-	timeReso = 2.0*fakeBeamSpotTimeWidth;
+      if (edm::isNotFinite(time)) {
+        time = 0.0;
+        timeReso = 2.0 * fakeBeamSpotTimeWidth;
       }
 
       const double vtxSigmaT2 = it->tError() * it->tError();
-      const double vtxTrackErr = std::sqrt( vtxSigmaT2 + timeReso*timeReso );
+      const double vtxTrackErr = std::sqrt(vtxSigmaT2 + timeReso * timeReso);
 
-      if ( (std::abs(t.dxy(it->position())) < rhoVtx_) &&
-           (std::abs(t.dz(it->position())) < zetaVtx_) &&
-	   ( !useTime || (std::abs(time - it->t())/vtxTrackErr < nSigmaDtVertex_) ) ) {
-        ok = true; break;
+      if ((std::abs(t.dxy(it->position())) < rhoVtx_) && (std::abs(t.dz(it->position())) < zetaVtx_) &&
+          (!useTime || (std::abs(time - it->t()) / vtxTrackErr < nSigmaDtVertex_))) {
+        ok = true;
+        break;
       }
-      if (tested++ >= nVertices_) break;
+      if (tested++ >= nVertices_)
+        break;
     }
   } else if (vtxFallback_) {
-    return ( (std::abs(t.vertex().z()) < 15.9) && (t.vertex().Rho() < 0.2) );
+    return ((std::abs(t.vertex().z()) < 15.9) && (t.vertex().Rho() < 0.2));
   }
   return ok;
 }
 
 bool TrackWithVertexSelector::operator()(const reco::Track &t) const {
-  if (!testTrack(t)) return false;
-  if (nVertices_ == 0) return true;
+  if (!testTrack(t))
+    return false;
+  if (nVertices_ == 0)
+    return true;
   return testVertices(t, *vcoll_);
 }
 
 bool TrackWithVertexSelector::operator()(const reco::TrackRef &tref) const {
-  if (!testTrack(tref)) return false;
-  if (nVertices_ == 0) return true;
+  if (!testTrack(tref))
+    return false;
+  if (nVertices_ == 0)
+    return true;
   return testVertices(tref, *vcoll_);
 }
-

--- a/CommonTools/RecoAlgos/test/FKDTree_t.cpp
+++ b/CommonTools/RecoAlgos/test/FKDTree_t.cpp
@@ -1,142 +1,113 @@
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 #include "cppunit/extensions/HelperMacros.h"
 
-class TestFKDTree: public CppUnit::TestFixture
-{
-        CPPUNIT_TEST_SUITE (TestFKDTree);
-        CPPUNIT_TEST (test2D);
-        CPPUNIT_TEST (test3D);
-        CPPUNIT_TEST_SUITE_END();
+class TestFKDTree : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(TestFKDTree);
+  CPPUNIT_TEST(test2D);
+  CPPUNIT_TEST(test3D);
+  CPPUNIT_TEST_SUITE_END();
 
-    public:
-        /// run all test tokenizer
-        void test2D();
-        void test3D();
+public:
+  /// run all test tokenizer
+  void test2D();
+  void test3D();
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION (TestFKDTree);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestFKDTree);
 
 #include "CommonTools/RecoAlgos/interface/FKDTree.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-void TestFKDTree::test2D()
-{
-    try
-    {
-        FKDTree<float, 2> tree;
-        float minX = 0.2;
-        float minY = 0.1;
-        float maxX = 0.7;
-        float maxY = 0.9;
-        unsigned int numberOfPointsInTheBox = 1000;
-        unsigned int numberOfPointsOutsideTheBox = 5000;
-        std::vector<FKDPoint<float, 2> > points;
-        std::vector<unsigned int> result;
+void TestFKDTree::test2D() {
+  try {
+    FKDTree<float, 2> tree;
+    float minX = 0.2;
+    float minY = 0.1;
+    float maxX = 0.7;
+    float maxY = 0.9;
+    unsigned int numberOfPointsInTheBox = 1000;
+    unsigned int numberOfPointsOutsideTheBox = 5000;
+    std::vector<FKDPoint<float, 2> > points;
+    std::vector<unsigned int> result;
 
-        FKDPoint<float, 2> minPoint(minX, minY);
-        FKDPoint<float, 2> maxPoint(maxX, maxY);
-        unsigned int id = 0;
+    FKDPoint<float, 2> minPoint(minX, minY);
+    FKDPoint<float, 2> maxPoint(maxX, maxY);
+    unsigned int id = 0;
 
-        for (unsigned int i = 0; i < numberOfPointsInTheBox; ++i)
-        {
-            float x = minX
-                    + static_cast<float>(rand())
-                            / (static_cast<float>(RAND_MAX / std::fabs(maxX - minX)));
+    for (unsigned int i = 0; i < numberOfPointsInTheBox; ++i) {
+      float x = minX + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxX - minX)));
 
-            float y = minY
-                    + static_cast<float>(rand())
-                            / (static_cast<float>(RAND_MAX / std::fabs(maxY - minY)));
+      float y = minY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxY - minY)));
 
-            points.emplace_back(x, y, id);
-            id++;
-        }
-
-        for (unsigned int i = 0; i < numberOfPointsOutsideTheBox; ++i)
-        {
-            float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
-            float y;
-            if (x <= maxX && x >= minX)
-                y = maxY
-                        + static_cast<float>(rand())
-                                / (static_cast<float>(RAND_MAX / std::fabs(1.f - maxY)));
-
-            points.emplace_back(x, y, id);
-            id++;
-
-        }
-        tree.build(points);
-        tree.search(minPoint,maxPoint,result);
-        CPPUNIT_ASSERT_EQUAL((unsigned int)tree.size(), numberOfPointsInTheBox+numberOfPointsOutsideTheBox);
-
-        CPPUNIT_ASSERT_EQUAL((unsigned int)result.size(), numberOfPointsInTheBox);
-    } catch (cms::Exception& e)
-    {
-        std::cerr << e.what() << std::endl;
-        CPPUNIT_ASSERT(false);
+      points.emplace_back(x, y, id);
+      id++;
     }
+
+    for (unsigned int i = 0; i < numberOfPointsOutsideTheBox; ++i) {
+      float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
+      float y;
+      if (x <= maxX && x >= minX)
+        y = maxY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(1.f - maxY)));
+
+      points.emplace_back(x, y, id);
+      id++;
+    }
+    tree.build(points);
+    tree.search(minPoint, maxPoint, result);
+    CPPUNIT_ASSERT_EQUAL((unsigned int)tree.size(), numberOfPointsInTheBox + numberOfPointsOutsideTheBox);
+
+    CPPUNIT_ASSERT_EQUAL((unsigned int)result.size(), numberOfPointsInTheBox);
+  } catch (cms::Exception& e) {
+    std::cerr << e.what() << std::endl;
+    CPPUNIT_ASSERT(false);
+  }
 }
-void TestFKDTree::test3D()
-{
-    try
-    {
-        FKDTree<float, 3> tree;
-        float minX = 0.2;
-        float minY = 0.1;
-        float minZ = 0.1;
-        float maxX = 0.7;
-        float maxY = 0.9;
-        float maxZ = 0.3;
+void TestFKDTree::test3D() {
+  try {
+    FKDTree<float, 3> tree;
+    float minX = 0.2;
+    float minY = 0.1;
+    float minZ = 0.1;
+    float maxX = 0.7;
+    float maxY = 0.9;
+    float maxZ = 0.3;
 
-        unsigned int numberOfPointsInTheBox = 1000;
-        unsigned int numberOfPointsOutsideTheBox = 5000;
-        std::vector<FKDPoint<float, 3> > points;
-        std::vector<unsigned int> result;
+    unsigned int numberOfPointsInTheBox = 1000;
+    unsigned int numberOfPointsOutsideTheBox = 5000;
+    std::vector<FKDPoint<float, 3> > points;
+    std::vector<unsigned int> result;
 
-        FKDPoint<float, 3> minPoint(minX, minY, minZ);
-        FKDPoint<float, 3> maxPoint(maxX, maxY, maxZ);
-        unsigned int id = 0;
+    FKDPoint<float, 3> minPoint(minX, minY, minZ);
+    FKDPoint<float, 3> maxPoint(maxX, maxY, maxZ);
+    unsigned int id = 0;
 
-        for (unsigned int i = 0; i < numberOfPointsInTheBox; ++i)
-        {
-            float x = minX
-                    + static_cast<float>(rand())
-                            / (static_cast<float>(RAND_MAX / std::fabs(maxX - minX)));
+    for (unsigned int i = 0; i < numberOfPointsInTheBox; ++i) {
+      float x = minX + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxX - minX)));
 
-            float y = minY
-                    + static_cast<float>(rand())
-                            / (static_cast<float>(RAND_MAX / std::fabs(maxY - minY)));
-            float z = minZ
-                    + static_cast<float>(rand())
-                            / (static_cast<float>(RAND_MAX / std::fabs(maxZ - minZ)));
+      float y = minY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxY - minY)));
+      float z = minZ + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxZ - minZ)));
 
-            points.emplace_back(x, y, z, id);
-            id++;
-        }
-
-        for (unsigned int i = 0; i < numberOfPointsOutsideTheBox; ++i)
-        {
-            float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
-            float y;
-            if (x <= maxX && x >= minX)
-                y = maxY
-                        + static_cast<float>(rand())
-                                / (static_cast<float>(RAND_MAX / std::fabs(1.f - maxY)));
-            float z = minZ
-                    + static_cast<float>(rand())
-                            / (static_cast<float>(RAND_MAX / std::fabs(maxZ - minZ)));
-
-            points.emplace_back(x, y, z, id);
-            id++;
-
-        }
-        tree.build(points);
-        tree.search(minPoint,maxPoint,result);
-        CPPUNIT_ASSERT_EQUAL((unsigned int)tree.size(), numberOfPointsInTheBox+numberOfPointsOutsideTheBox);
-        CPPUNIT_ASSERT_EQUAL((unsigned int)result.size(), numberOfPointsInTheBox);
-
-    } catch (cms::Exception& e)
-    {
-        std::cerr << e.what() << std::endl;
-        CPPUNIT_ASSERT(false);
+      points.emplace_back(x, y, z, id);
+      id++;
     }
+
+    for (unsigned int i = 0; i < numberOfPointsOutsideTheBox; ++i) {
+      float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
+      float y;
+      if (x <= maxX && x >= minX)
+        y = maxY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(1.f - maxY)));
+      float z = minZ + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / std::fabs(maxZ - minZ)));
+
+      points.emplace_back(x, y, z, id);
+      id++;
+    }
+    tree.build(points);
+    tree.search(minPoint, maxPoint, result);
+    CPPUNIT_ASSERT_EQUAL((unsigned int)tree.size(), numberOfPointsInTheBox + numberOfPointsOutsideTheBox);
+    CPPUNIT_ASSERT_EQUAL((unsigned int)result.size(), numberOfPointsInTheBox);
+
+  } catch (cms::Exception& e) {
+    std::cerr << e.what() << std::endl;
+    CPPUNIT_ASSERT(false);
+  }
 }

--- a/RecoEgamma/ElectronIdentification/interface/ClassBasedElectronID.h
+++ b/RecoEgamma/ElectronIdentification/interface/ClassBasedElectronID.h
@@ -4,9 +4,7 @@
 #include "RecoEgamma/ElectronIdentification/interface/ElectronIDAlgo.h"
 
 class ClassBasedElectronID : public ElectronIDAlgo {
-
 public:
-
   ClassBasedElectronID(){};
 
   ~ClassBasedElectronID() override{};
@@ -14,8 +12,7 @@ public:
   void setup(const edm::ParameterSet& conf) override;
   double result(const reco::GsfElectron*, const edm::Event&, const edm::EventSetup&) override;
 
- private:
-
+private:
   std::string quality_;
 
   /*  std::vector<int> useEoverPIn_; */
@@ -30,10 +27,10 @@ public:
   /*   std::vector<int> useSigmaEtaEta_; */
   /*   std::vector<int> useSigmaPhiPhi_; */
   /*   std::vector<int> acceptCracks_; */
-  
+
   edm::ParameterSet cuts_;
 
   //int variables_;
 };
 
-#endif // ClassBasedElectronID_H
+#endif  // ClassBasedElectronID_H

--- a/RecoEgamma/ElectronIdentification/interface/CutBasedElectronID.h
+++ b/RecoEgamma/ElectronIdentification/interface/CutBasedElectronID.h
@@ -8,21 +8,19 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 class CutBasedElectronID : public ElectronIDAlgo {
-
 public:
-  
-  CutBasedElectronID(const edm::ParameterSet& conf,edm::ConsumesCollector & iC);
+  CutBasedElectronID(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
 
-  ~CutBasedElectronID() override {};
+  ~CutBasedElectronID() override{};
 
   void setup(const edm::ParameterSet& conf) override;
   double result(const reco::GsfElectron*, const edm::Event&, const edm::EventSetup&) override;
   double cicSelection(const reco::GsfElectron*, const edm::Event&, const edm::EventSetup&);
   double robustSelection(const reco::GsfElectron*, const edm::Event&, const edm::EventSetup&);
   int classify(const reco::GsfElectron*);
-  bool compute_cut(double x, double et, double cut_min, double cut_max, bool gtn=false);
+  bool compute_cut(double x, double et, double cut_min, double cut_max, bool gtn = false);
 
- private:
+private:
   bool wantBinning_;
   bool newCategories_;
   std::string type_;
@@ -30,7 +28,6 @@ public:
   std::string version_;
   edm::EDGetTokenT<std::vector<reco::Vertex> > verticesCollection_;
   edm::ParameterSet cuts_;
-
 };
 
-#endif // CutBasedElectronID_H
+#endif  // CutBasedElectronID_H

--- a/RecoEgamma/ElectronIdentification/interface/EBEECutValues.h
+++ b/RecoEgamma/ElectronIdentification/interface/EBEECutValues.h
@@ -4,29 +4,30 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Ptr.h"
 
-template<typename T>
+template <typename T>
 class EBEECutValuesT {
 private:
   T barrel_;
   T endcap_;
-  const double barrelCutOff_=1.479; //this is currrently used to identify if object is barrel or endcap but may change
-  
+  const double barrelCutOff_ =
+      1.479;  //this is currrently used to identify if object is barrel or endcap but may change
+
 public:
-  EBEECutValuesT(const edm::ParameterSet& params,const std::string& name):
-    barrel_(params.getParameter<T>(name+"EB")),
-    endcap_(params.getParameter<T>(name+"EE")){}
-  template<typename CandType>
-  T operator()(const edm::Ptr<CandType>& cand)const{return isBarrel(cand) ? barrel_ : endcap_;}
+  EBEECutValuesT(const edm::ParameterSet& params, const std::string& name)
+      : barrel_(params.getParameter<T>(name + "EB")), endcap_(params.getParameter<T>(name + "EE")) {}
+  template <typename CandType>
+  T operator()(const edm::Ptr<CandType>& cand) const {
+    return isBarrel(cand) ? barrel_ : endcap_;
+  }
 
 private:
-  template<typename CandType>
-  const bool isBarrel(const edm::Ptr<CandType>& cand)const{return std::abs(cand->superCluster()->position().eta())<barrelCutOff_;}
-  
+  template <typename CandType>
+  const bool isBarrel(const edm::Ptr<CandType>& cand) const {
+    return std::abs(cand->superCluster()->position().eta()) < barrelCutOff_;
+  }
 };
 
 typedef EBEECutValuesT<double> EBEECutValues;
 typedef EBEECutValuesT<int> EBEECutValuesInt;
-
-
 
 #endif

--- a/RecoEgamma/ElectronIdentification/interface/ElectronIDAlgo.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronIDAlgo.h
@@ -17,25 +17,21 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 
-
 class ElectronIDAlgo {
-
 public:
-
   ElectronIDAlgo(){};
 
   virtual ~ElectronIDAlgo(){};
 
   //void baseSetup(const edm::ParameterSet& conf) ;
-  virtual void setup(const edm::ParameterSet& conf)  {};
-  virtual double result(const reco::GsfElectron*, const edm::Event&, const edm::EventSetup&) {return 0.;};
+  virtual void setup(const edm::ParameterSet& conf){};
+  virtual double result(const reco::GsfElectron*, const edm::Event&, const edm::EventSetup&) { return 0.; };
 
- protected:
-
+protected:
   //EcalClusterLazyTools getClusterShape(const edm::Event&, const edm::EventSetup&);
 
   edm::InputTag reducedBarrelRecHitCollection_;
   edm::InputTag reducedEndcapRecHitCollection_;
 };
 
-#endif // ElectronIDAlgo_H
+#endif  // ElectronIDAlgo_H

--- a/RecoEgamma/ElectronIdentification/interface/ElectronLikelihood.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronLikelihood.h
@@ -13,62 +13,55 @@
 #include <TDirectory.h>
 #include <vector>
 
-
 class ElectronLikelihood {
-
- public:
-  
+public:
   //! ctor, not used for this algo (need initialization from ES)
-  ElectronLikelihood () {} ;
+  ElectronLikelihood(){};
 
   //! ctor
-  ElectronLikelihood (const ElectronLikelihoodCalibration *calibration,
-		      LikelihoodSwitches eleIDSwitches,
-		      std::string signalWeightSplitting,
-		      std::string backgroundWeightSplitting,
-		      bool splitSignalPdfs,
-		      bool splitBackgroundPdfs) ;
+  ElectronLikelihood(const ElectronLikelihoodCalibration* calibration,
+                     LikelihoodSwitches eleIDSwitches,
+                     std::string signalWeightSplitting,
+                     std::string backgroundWeightSplitting,
+                     bool splitSignalPdfs,
+                     bool splitBackgroundPdfs);
 
   //! dtor
-  virtual ~ElectronLikelihood () ;
+  virtual ~ElectronLikelihood();
 
   //! not used for this algo
-  void setup (const edm::ParameterSet& conf) {} ;
+  void setup(const edm::ParameterSet& conf){};
 
   //! get the result of the algorithm
-  float result (const reco::GsfElectron &electron, 
-                const EcalClusterLazyTools&) const ;
+  float result(const reco::GsfElectron& electron, const EcalClusterLazyTools&) const;
   //! get the log-expanded result of the algorithm
-  float resultLog (const reco::GsfElectron &electron, 
-                   const EcalClusterLazyTools&) const ;
+  float resultLog(const reco::GsfElectron& electron, const EcalClusterLazyTools&) const;
 
- private:
-
-  //! build the likelihood model from histograms 
+private:
+  //! build the likelihood model from histograms
   //! in Barrel file and Endcap file
-  void Setup (const ElectronLikelihoodCalibration *calibration,
-	      std::string signalWeightSplitting,
-	      std::string backgroundWeightSplitting,
-	      bool splitSignalPdfs,
-	      bool splitBackgroundPdfs) ;
-
+  void Setup(const ElectronLikelihoodCalibration* calibration,
+             std::string signalWeightSplitting,
+             std::string backgroundWeightSplitting,
+             bool splitSignalPdfs,
+             bool splitBackgroundPdfs);
 
   //! get the input variables from the electron and the e-Setup
-  void getInputVar (const reco::GsfElectron &electron, 
-                    std::vector<float> &measuremnts, 
-                    const EcalClusterLazyTools&) const ;
+  void getInputVar(const reco::GsfElectron& electron,
+                   std::vector<float>& measuremnts,
+                   const EcalClusterLazyTools&) const;
 
   //Class to enforce that we only call const functions on LikelihoodPdfProduct
   // when we are in const functions of ElectronLikelihood
   class LikelihoodPdfProductPtr {
   public:
-    LikelihoodPdfProductPtr(): m_ptr(nullptr) {}
-    LikelihoodPdfProductPtr( LikelihoodPdfProduct* iPtr): m_ptr(iPtr) {}
+    LikelihoodPdfProductPtr() : m_ptr(nullptr) {}
+    LikelihoodPdfProductPtr(LikelihoodPdfProduct* iPtr) : m_ptr(iPtr) {}
 
-    LikelihoodPdfProduct* operator->() { return m_ptr;}
-    const LikelihoodPdfProduct* operator->() const { return m_ptr;}
+    LikelihoodPdfProduct* operator->() { return m_ptr; }
+    const LikelihoodPdfProduct* operator->() const { return m_ptr; }
 
-    LikelihoodPdfProduct* get() { return m_ptr;}
+    LikelihoodPdfProduct* get() { return m_ptr; }
 
   private:
     LikelihoodPdfProduct* m_ptr;
@@ -80,15 +73,14 @@ class ElectronLikelihood {
   LikelihoodPdfProductPtr _EB0gt15lh, _EB1gt15lh, _EEgt15lh;
 
   //! general parameters of all the ele id algorithms
-  LikelihoodSwitches m_eleIDSwitches ;
+  LikelihoodSwitches m_eleIDSwitches;
 
   //! splitting rule for PDF's
   std::string m_signalWeightSplitting;
   std::string m_backgroundWeightSplitting;
-
 };
 
 #include "FWCore/Framework/interface/data_default_record_trait.h"
-EVENTSETUP_DATA_DEFAULT_RECORD (ElectronLikelihood, ElectronLikelihoodRcd)
+EVENTSETUP_DATA_DEFAULT_RECORD(ElectronLikelihood, ElectronLikelihoodRcd)
 
-#endif // ElectronLikelihood_H
+#endif  // ElectronLikelihood_H

--- a/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimator.h
@@ -8,22 +8,21 @@
 #include <string>
 
 class ElectronMVAEstimator {
- public:
-  struct Configuration{
-         std::vector<std::string> vweightsfiles;
-   };
+public:
+  struct Configuration {
+    std::vector<std::string> vweightsfiles;
+  };
   ElectronMVAEstimator();
   ElectronMVAEstimator(const std::string& fileName);
-  ElectronMVAEstimator(const Configuration & );
-  ~ElectronMVAEstimator() {;}
-  double mva(const reco::GsfElectron& myElectron, int nvertices=0) const;
+  ElectronMVAEstimator(const Configuration&);
+  ~ElectronMVAEstimator() { ; }
+  double mva(const reco::GsfElectron& myElectron, int nvertices = 0) const;
 
- private:
+private:
   const Configuration cfg_;
   void bindVariables(float vars[18]) const;
-  
+
   std::vector<std::unique_ptr<const GBRForest> > gbr_;
-  
 };
 
 #endif

--- a/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2.h
@@ -14,34 +14,33 @@
 #include <TMath.h>
 
 class ElectronMVAEstimatorRun2 : public AnyMVAEstimatorRun2Base {
-
- public:
-
+public:
   // Constructor and destructor
   ElectronMVAEstimatorRun2(const edm::ParameterSet& conf);
-  ~ElectronMVAEstimatorRun2() override {};
+  ~ElectronMVAEstimatorRun2() override{};
   // For use with FWLite/Python
   ElectronMVAEstimatorRun2(const std::string& mvaTag,
                            const std::string& mvaName,
                            int nCategories,
                            const std::string& variableDefinition,
                            const std::vector<std::string>& categoryCutStrings,
-                           const std::vector<std::string> &weightFileNames,
-                           bool debug=false );
+                           const std::vector<std::string>& weightFileNames,
+                           bool debug = false);
 
   // Calculation of the MVA value
-  float mvaValue( const reco::Candidate* candidate, std::vector<float> const& auxVariables, int &iCategory) const override;
+  float mvaValue(const reco::Candidate* candidate,
+                 std::vector<float> const& auxVariables,
+                 int& iCategory) const override;
 
   // for FWLite just passing rho
-  float mvaValue( const reco::Candidate* candidate, float rho, int &iCategory) const {
+  float mvaValue(const reco::Candidate* candidate, float rho, int& iCategory) const {
     return mvaValue(candidate, std::vector<float>{rho}, iCategory);
   }
 
-  int findCategory( const reco::Candidate* candidate) const override;
+  int findCategory(const reco::Candidate* candidate) const override;
 
- private:
-
-  void init(const std::vector<std::string> &weightFileNames);
+private:
+  void init(const std::vector<std::string>& weightFileNames);
 
   int findCategory(reco::GsfElectron const& electron) const;
 
@@ -49,15 +48,13 @@ class ElectronMVAEstimatorRun2 : public AnyMVAEstimatorRun2Base {
   std::vector<int> nVariables_;
 
   // Data members
-  std::vector< std::unique_ptr<const GBRForest> > gbrForests_;
-
+  std::vector<std::unique_ptr<const GBRForest>> gbrForests_;
 
   // There might be different variables for each category, so the variables
   // names vector is itself a vector of length nCategories
   std::vector<std::vector<int>> variables_;
 
   MVAVariableManager<reco::GsfElectron> mvaVarMngr_;
-
 };
 
 #endif

--- a/RecoEgamma/ElectronIdentification/interface/LikelihoodPdf.h
+++ b/RecoEgamma/ElectronIdentification/interface/LikelihoodPdf.h
@@ -10,22 +10,21 @@
 #include <map>
 
 class LikelihoodPdf {
-
- public:
-  LikelihoodPdf() {};
-  LikelihoodPdf(const LikelihoodPdf& pdf) {}; 
+public:
+  LikelihoodPdf(){};
+  LikelihoodPdf(const LikelihoodPdf& pdf){};
   LikelihoodPdf(const char* name, const char* species, int ecalsubdet, int ptbin);
   virtual ~LikelihoodPdf();
-  
+
   //! initialize PDFs from CondDB
-  void initFromDB(const ElectronLikelihoodCalibration *calibration);
+  void initFromDB(const ElectronLikelihoodCalibration* calibration);
 
   //! split the pdf by category if splitPdf is true. split map is: <"class",classFraction>
   //! if splitPdf is false, pdf is splitted, but they are all equal (but allowing different priors)
-  void split(const std::map<std::string,float>& splitFractions, bool splitPdf = false);
+  void split(const std::map<std::string, float>& splitFractions, bool splitPdf = false);
 
   //! get Value of pdf at point x for class catName
-  float getVal(float x, std::string const& catName="NOSPLIT", bool normalized = true) const;
+  float getVal(float x, std::string const& catName = "NOSPLIT", bool normalized = true) const;
 
   //! get PDF name
   std::string const& getName() const { return _name; }
@@ -33,20 +32,16 @@ class LikelihoodPdf {
   //! get PDF species
   std::string const& getSpecies() const { return _species; }
 
+private:
+  float normalization(const PhysicsTools::Calibration::HistogramF* thePdf) const;
 
-
- private:
-
-  float normalization(const PhysicsTools::Calibration::HistogramF *thePdf) const;
-  
   std::string _name;
   std::string _species;
   int _ecalsubdet;
   int _ptbin;
 
-  std::map<std::string,const PhysicsTools::Calibration::HistogramF*> _splitPdf;
-  std::map<std::string,std::string> _splitRule;
-
+  std::map<std::string, const PhysicsTools::Calibration::HistogramF*> _splitPdf;
+  std::map<std::string, std::string> _splitRule;
 };
 
 #endif

--- a/RecoEgamma/ElectronIdentification/interface/LikelihoodPdfProduct.h
+++ b/RecoEgamma/ElectronIdentification/interface/LikelihoodPdfProduct.h
@@ -10,35 +10,32 @@
 #include <map>
 
 class LikelihoodPdfProduct {
- public:
+public:
   LikelihoodPdfProduct(const char* name, int ecalsubdet, int ptbin);
   ~LikelihoodPdfProduct();
-  
-  //! initialize the PDFs from CondDB  
-  void initFromDB(const ElectronLikelihoodCalibration *calibration);
 
-  //! add a species (hypothesis) to the likelihood, with a priori probability 
-  void addSpecies(const char* name, float priorWeight=1.);
+  //! initialize the PDFs from CondDB
+  void initFromDB(const ElectronLikelihoodCalibration* calibration);
+
+  //! add a species (hypothesis) to the likelihood, with a priori probability
+  void addSpecies(const char* name, float priorWeight = 1.);
 
   //! add a pdf for a species, splitted or not
-  void addPdf(const char* specname, const char* name, bool splitPdf=false);
+  void addPdf(const char* specname, const char* name, bool splitPdf = false);
 
   //! set the fraction of one category for a given species
-  void setSplitFrac(const char* specname, const char* catName, float frac=1.0);
+  void setSplitFrac(const char* specname, const char* catName, float frac = 1.0);
 
   //! get the likelihood ratio p(a priori) * L(specName) / L_tot
   float getRatio(const char* specName, const std::vector<float>& measurements, const std::string&) const;
 
- private:
-
+private:
   float getSpeciesProb(const char* specName, const std::vector<float>& measurements, const std::string& gsfClass) const;
   std::string _name;
-  const ElectronLikelihoodCalibration *_calibration;
+  const ElectronLikelihoodCalibration* _calibration;
   std::vector<LikelihoodSpecies*> _specList;
   std::vector<float> _priorList;
   int _ecalsubdet;
   int _ptbin;
-
 };
 #endif
-    

--- a/RecoEgamma/ElectronIdentification/interface/LikelihoodSpecies.h
+++ b/RecoEgamma/ElectronIdentification/interface/LikelihoodSpecies.h
@@ -7,8 +7,8 @@
 #include <map>
 
 class LikelihoodSpecies {
- public:
-  LikelihoodSpecies() {};
+public:
+  LikelihoodSpecies(){};
   LikelihoodSpecies(const char* name, float prior);
 
   virtual ~LikelihoodSpecies();
@@ -17,19 +17,18 @@ class LikelihoodSpecies {
   void setName(const char* name);
   void addPdf(const LikelihoodPdf* pdf);
   void setPrior(float prior);
-  void setSplitFraction(std::pair<std::string,float> splitfrac);
+  void setSplitFraction(std::pair<std::string, float> splitfrac);
 
   // methods
   std::vector<const LikelihoodPdf*> const& getListOfPdfs() const;
   const char* getName() const;
   float getPrior() const;
-  std::map<std::string,float> const& getSplitFractions() const;
+  std::map<std::string, float> const& getSplitFractions() const;
 
- private:
+private:
   std::vector<const LikelihoodPdf*> _pdfList;
   std::string _name;
   float _prior;
-  std::map<std::string,float> _splitFractions;
-
+  std::map<std::string, float> _splitFractions;
 };
 #endif

--- a/RecoEgamma/ElectronIdentification/interface/LikelihoodSwitches.h
+++ b/RecoEgamma/ElectronIdentification/interface/LikelihoodSwitches.h
@@ -2,26 +2,24 @@
 #define LikelihoodSwitches_H
 
 struct LikelihoodSwitches {
+  LikelihoodSwitches()
+      : m_useEoverP(false),
+        m_useOneOverEMinusOneOverP(true),
+        m_useDeltaEta(true),
+        m_useDeltaPhi(true),
+        m_useHoverE(false),
+        m_useFBrem(true),
+        m_useSigmaEtaEta(true),
+        m_useSigmaPhiPhi(true){};
 
-  LikelihoodSwitches () :
-    m_useEoverP (false) ,
-    m_useOneOverEMinusOneOverP (true) ,
-    m_useDeltaEta (true) ,
-    m_useDeltaPhi (true) ,
-    m_useHoverE (false) ,
-    m_useFBrem (true) ,
-    m_useSigmaEtaEta (true) ,
-    m_useSigmaPhiPhi (true) {} ;
-
-  bool m_useEoverP ;
-  bool m_useOneOverEMinusOneOverP ;
-  bool m_useDeltaEta ;
-  bool m_useDeltaPhi ;
-  bool m_useHoverE ;
-  bool m_useFBrem ;
-  bool m_useSigmaEtaEta ;
-  bool m_useSigmaPhiPhi ;
-
+  bool m_useEoverP;
+  bool m_useOneOverEMinusOneOverP;
+  bool m_useDeltaEta;
+  bool m_useDeltaPhi;
+  bool m_useHoverE;
+  bool m_useFBrem;
+  bool m_useSigmaEtaEta;
+  bool m_useSigmaPhiPhi;
 };
 
-#endif // LikelihoodSwitches_H
+#endif  // LikelihoodSwitches_H

--- a/RecoEgamma/ElectronIdentification/interface/PTDRElectronID.h
+++ b/RecoEgamma/ElectronIdentification/interface/PTDRElectronID.h
@@ -4,9 +4,7 @@
 #include "RecoEgamma/ElectronIdentification/interface/ElectronIDAlgo.h"
 
 class PTDRElectronID : public ElectronIDAlgo {
-
 public:
-
   PTDRElectronID(){};
 
   ~PTDRElectronID() override{};
@@ -14,8 +12,7 @@ public:
   void setup(const edm::ParameterSet& conf) override;
   double result(const reco::GsfElectron*, const edm::Event&, const edm::EventSetup&) override;
 
- private:
-
+private:
   std::string quality_;
 
   std::vector<int> useEoverPIn_;
@@ -30,10 +27,10 @@ public:
   std::vector<int> useSigmaEtaEta_;
   std::vector<int> useSigmaPhiPhi_;
   std::vector<int> acceptCracks_;
-  
+
   edm::ParameterSet cuts_;
 
   int variables_;
 };
 
-#endif // PTDRElectronID_H
+#endif  // PTDRElectronID_H

--- a/RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h
@@ -12,25 +12,23 @@
 #include <string>
 
 class SoftElectronMVAEstimator {
- public:
+public:
   constexpr static unsigned int ExpectedNBins = 1;
 
-  struct Configuration{
+  struct Configuration {
     std::vector<std::string> vweightsfiles;
   };
-  SoftElectronMVAEstimator(const Configuration & );
-  ~SoftElectronMVAEstimator() ;
-  double mva(const reco::GsfElectron& myElectron,
-             const reco::VertexCollection&) const;
+  SoftElectronMVAEstimator(const Configuration&);
+  ~SoftElectronMVAEstimator();
+  double mva(const reco::GsfElectron& myElectron, const reco::VertexCollection&) const;
 
- private:
-  void bindVariables(float vars[25]) const ;
+private:
+  void bindVariables(float vars[25]) const;
   void init();
 
- private:
-    const Configuration cfg_;
-    std::vector<std::unique_ptr<const GBRForest> > gbr_;
-    
+private:
+  const Configuration cfg_;
+  std::vector<std::unique_ptr<const GBRForest> > gbr_;
 };
 
 #endif

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronHEEPIDValueMapProducer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronHEEPIDValueMapProducer.cc
@@ -28,130 +28,155 @@
 
 //Heavily inspired from ElectronIDValueMapProducer
 
-
 class ElectronHEEPIDValueMapProducer : public edm::stream::EDProducer<> {
 private:
   //helper classes to handle AOD vs MiniAOD
-  template<typename T>
+  template <typename T>
   struct DualToken {
     edm::EDGetTokenT<T> aod;
     edm::EDGetTokenT<T> miniAOD;
   };
   class DataFormat {
   public:
-    enum Format{AUTO=0,AOD=1,MINIAOD=2};
+    enum Format { AUTO = 0, AOD = 1, MINIAOD = 2 };
+
   private:
     int data_;
+
   public:
-    DataFormat(int val):data_(val){}
-    bool tryAOD()const{return data_==AUTO || data_==AOD;}
-    bool tryMiniAOD()const{return data_==AUTO || data_==MINIAOD;}
-    int operator()()const{return data_;}
+    DataFormat(int val) : data_(val) {}
+    bool tryAOD() const { return data_ == AUTO || data_ == AOD; }
+    bool tryMiniAOD() const { return data_ == AUTO || data_ == MINIAOD; }
+    int operator()() const { return data_; }
   };
+
 public:
   explicit ElectronHEEPIDValueMapProducer(const edm::ParameterSet&);
   ~ElectronHEEPIDValueMapProducer() override;
-  
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  template<typename T>
-  static void writeValueMap(edm::Event &iEvent,
-			    const edm::Handle<edm::View<reco::GsfElectron> > & handle,
-			    const std::vector<T> & values,
-			    const std::string& label);
-  
-  static int nrSaturatedCrysIn5x5(const reco::GsfElectron& ele,
-				  edm::Handle<EcalRecHitCollection>& ebHits,
-				  edm::Handle<EcalRecHitCollection>& eeHits,
-				  edm::ESHandle<CaloTopology>& caloTopo);
+  template <typename T>
+  static void writeValueMap(edm::Event& iEvent,
+                            const edm::Handle<edm::View<reco::GsfElectron> >& handle,
+                            const std::vector<T>& values,
+                            const std::string& label);
 
-  static float calTrkIso(const reco::GsfElectron& ele,		  
-			 const edm::View<reco::GsfElectron>& eles,
-			 const std::vector<edm::Handle<pat::PackedCandidateCollection> >& handles,
-			 const std::vector<EleTkIsolFromCands::PIDVeto>& pidVetos,
-			 const EleTkIsolFromCands& trkIsoCalc);
-  
-  template <typename T> void setToken(edm::EDGetTokenT<T>& token,edm::InputTag tag){token=consumes<T>(tag);}
-  template <typename T> void setToken(edm::EDGetTokenT<T>& token,const edm::ParameterSet& iPara,const std::string& tag){token=consumes<T>(iPara.getParameter<edm::InputTag>(tag));}
-  template <typename T> void setToken(std::vector<edm::EDGetTokenT<T> >& tokens,const edm::ParameterSet& iPara,const std::string& tagName){
-    auto tags =iPara.getParameter<std::vector<edm::InputTag> >(tagName);
-    for(auto& tag : tags) {
+  static int nrSaturatedCrysIn5x5(const reco::GsfElectron& ele,
+                                  edm::Handle<EcalRecHitCollection>& ebHits,
+                                  edm::Handle<EcalRecHitCollection>& eeHits,
+                                  edm::ESHandle<CaloTopology>& caloTopo);
+
+  static float calTrkIso(const reco::GsfElectron& ele,
+                         const edm::View<reco::GsfElectron>& eles,
+                         const std::vector<edm::Handle<pat::PackedCandidateCollection> >& handles,
+                         const std::vector<EleTkIsolFromCands::PIDVeto>& pidVetos,
+                         const EleTkIsolFromCands& trkIsoCalc);
+
+  template <typename T>
+  void setToken(edm::EDGetTokenT<T>& token, edm::InputTag tag) {
+    token = consumes<T>(tag);
+  }
+  template <typename T>
+  void setToken(edm::EDGetTokenT<T>& token, const edm::ParameterSet& iPara, const std::string& tag) {
+    token = consumes<T>(iPara.getParameter<edm::InputTag>(tag));
+  }
+  template <typename T>
+  void setToken(std::vector<edm::EDGetTokenT<T> >& tokens, const edm::ParameterSet& iPara, const std::string& tagName) {
+    auto tags = iPara.getParameter<std::vector<edm::InputTag> >(tagName);
+    for (auto& tag : tags) {
       edm::EDGetTokenT<T> token;
-      setToken(token,tag);
+      setToken(token, tag);
       tokens.push_back(token);
     }
-  } 
-  template <typename T> void setToken(DualToken<T>& token,const edm::ParameterSet& iPara,const std::string& tagAOD,const std::string& tagMiniAOD,DataFormat format){
-    if(format.tryAOD()) token.aod=consumes<T>(iPara.getParameter<edm::InputTag>(tagAOD));
-    if(format.tryMiniAOD()) token.miniAOD=consumes<T>(iPara.getParameter<edm::InputTag>(tagMiniAOD));
   }
-  template <typename T> void setToken(std::vector<DualToken<T> >& tokens,const edm::ParameterSet& iPara,const std::string& tagAOD,const std::string& tagMiniAOD,DataFormat format){
-    auto tagsAOD =iPara.getParameter<std::vector<edm::InputTag> >(tagAOD);
-    auto tagsMiniAOD =iPara.getParameter<std::vector<edm::InputTag> >(tagMiniAOD);
-    size_t maxSize = std::max(tagsAOD.size(),tagsMiniAOD.size());
+  template <typename T>
+  void setToken(DualToken<T>& token,
+                const edm::ParameterSet& iPara,
+                const std::string& tagAOD,
+                const std::string& tagMiniAOD,
+                DataFormat format) {
+    if (format.tryAOD())
+      token.aod = consumes<T>(iPara.getParameter<edm::InputTag>(tagAOD));
+    if (format.tryMiniAOD())
+      token.miniAOD = consumes<T>(iPara.getParameter<edm::InputTag>(tagMiniAOD));
+  }
+  template <typename T>
+  void setToken(std::vector<DualToken<T> >& tokens,
+                const edm::ParameterSet& iPara,
+                const std::string& tagAOD,
+                const std::string& tagMiniAOD,
+                DataFormat format) {
+    auto tagsAOD = iPara.getParameter<std::vector<edm::InputTag> >(tagAOD);
+    auto tagsMiniAOD = iPara.getParameter<std::vector<edm::InputTag> >(tagMiniAOD);
+    size_t maxSize = std::max(tagsAOD.size(), tagsMiniAOD.size());
     tokens.clear();
-    tokens.resize(maxSize); 
-    if(format.tryAOD()){
-      for(size_t tagNr=0;tagNr<tagsAOD.size();tagNr++) {
-	setToken(tokens[tagNr].aod,tagsAOD[tagNr]);
+    tokens.resize(maxSize);
+    if (format.tryAOD()) {
+      for (size_t tagNr = 0; tagNr < tagsAOD.size(); tagNr++) {
+        setToken(tokens[tagNr].aod, tagsAOD[tagNr]);
       }
     }
-    if(format.tryMiniAOD()){
-      for(size_t tagNr=0;tagNr<tagsMiniAOD.size();tagNr++) {
-	setToken(tokens[tagNr].miniAOD,tagsMiniAOD[tagNr]);
+    if (format.tryMiniAOD()) {
+      for (size_t tagNr = 0; tagNr < tagsMiniAOD.size(); tagNr++) {
+        setToken(tokens[tagNr].miniAOD, tagsMiniAOD[tagNr]);
       }
     }
   }
-      
-  template<typename T>  
-  static edm::Handle<T> getHandle(const edm::Event& iEvent,
-				  const edm::EDGetTokenT<T>& token){
+
+  template <typename T>
+  static edm::Handle<T> getHandle(const edm::Event& iEvent, const edm::EDGetTokenT<T>& token) {
     edm::Handle<T> handle;
-    iEvent.getByToken(token,handle);
+    iEvent.getByToken(token, handle);
     return handle;
   }
-  template<typename T> 
-  static edm::Handle<T> getHandle(const edm::Event& iEvent,
-				  const DualToken<T>& token){
+  template <typename T>
+  static edm::Handle<T> getHandle(const edm::Event& iEvent, const DualToken<T>& token) {
     edm::Handle<T> handle;
-    if(!token.aod.isUninitialized()) iEvent.getByToken(token.aod,handle);
-    if(!handle.isValid() && !token.miniAOD.isUninitialized()) iEvent.getByToken(token.miniAOD,handle);
+    if (!token.aod.isUninitialized())
+      iEvent.getByToken(token.aod, handle);
+    if (!handle.isValid() && !token.miniAOD.isUninitialized())
+      iEvent.getByToken(token.miniAOD, handle);
     return handle;
   }
 
-  template<typename T> 
-  static std::vector<edm::Handle<T> > 
-  getHandles(const edm::Event& iEvent,const std::vector<DualToken<T> >& tokens){
+  template <typename T>
+  static std::vector<edm::Handle<T> > getHandles(const edm::Event& iEvent, const std::vector<DualToken<T> >& tokens) {
     std::vector<edm::Handle<T> > handles(tokens.size());
-    if(tokens.empty()) return handles;
-    if(!tokens[0].aod.isUninitialized()) iEvent.getByToken(tokens[0].aod,handles[0]);
+    if (tokens.empty())
+      return handles;
+    if (!tokens[0].aod.isUninitialized())
+      iEvent.getByToken(tokens[0].aod, handles[0]);
     bool isAOD = handles[0].isValid();
-    if(!isAOD && !tokens[0].miniAOD.isUninitialized() ) iEvent.getByToken(tokens[0].miniAOD,handles[0]);
-    
-    for(size_t tokenNr=1;tokenNr<tokens.size();tokenNr++){
+    if (!isAOD && !tokens[0].miniAOD.isUninitialized())
+      iEvent.getByToken(tokens[0].miniAOD, handles[0]);
+
+    for (size_t tokenNr = 1; tokenNr < tokens.size(); tokenNr++) {
       auto token = isAOD ? tokens[tokenNr].aod : tokens[tokenNr].miniAOD;
-      if(!token.isUninitialized()) iEvent.getByToken(token,handles[tokenNr]);
+      if (!token.isUninitialized())
+        iEvent.getByToken(token, handles[tokenNr]);
     }
     return handles;
   }
-  
-  template<typename T> 
-  static bool isEventAOD(const edm::Event& iEvent,const DualToken<T>& token){
+
+  template <typename T>
+  static bool isEventAOD(const edm::Event& iEvent, const DualToken<T>& token) {
     edm::Handle<T> handle;
-    if(!token.aod.isUninitialized()) iEvent.getByToken(token.aod,handle);
-    if(handle.isValid()) return true;
-    else return false;
+    if (!token.aod.isUninitialized())
+      iEvent.getByToken(token.aod, handle);
+    if (handle.isValid())
+      return true;
+    else
+      return false;
   }
 
-  
-  
   DualToken<EcalRecHitCollection> ebRecHitToken_;
   DualToken<EcalRecHitCollection> eeRecHitToken_;
   DualToken<edm::View<reco::GsfElectron> > eleToken_;
-  std::vector<DualToken<pat::PackedCandidateCollection> >candTokens_;
+  std::vector<DualToken<pat::PackedCandidateCollection> > candTokens_;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
 
   EleTkIsolFromCands trkIsoCalc_;
@@ -160,151 +185,144 @@ private:
   DataFormat dataFormat_;
   std::vector<EleTkIsolFromCands::PIDVeto> candVetosAOD_;
   std::vector<EleTkIsolFromCands::PIDVeto> candVetosMiniAOD_;
-  
+
   static const std::string eleTrkPtIsoLabel_;
   static const std::string eleTrkPtIso04Label_;
   static const std::string eleNrSaturateIn5x5Label_;
 };
 
-const std::string ElectronHEEPIDValueMapProducer::eleTrkPtIsoLabel_="eleTrkPtIso";
-const std::string ElectronHEEPIDValueMapProducer::eleTrkPtIso04Label_="eleTrkPtIso04";
-const std::string ElectronHEEPIDValueMapProducer::eleNrSaturateIn5x5Label_="eleNrSaturateIn5x5";
- 
+const std::string ElectronHEEPIDValueMapProducer::eleTrkPtIsoLabel_ = "eleTrkPtIso";
+const std::string ElectronHEEPIDValueMapProducer::eleTrkPtIso04Label_ = "eleTrkPtIso04";
+const std::string ElectronHEEPIDValueMapProducer::eleNrSaturateIn5x5Label_ = "eleNrSaturateIn5x5";
 
+ElectronHEEPIDValueMapProducer::ElectronHEEPIDValueMapProducer(const edm::ParameterSet& iConfig)
+    : trkIsoCalc_(iConfig.getParameter<edm::ParameterSet>("trkIsoConfig")),
+      trkIso04Calc_(iConfig.getParameter<edm::ParameterSet>("trkIso04Config")),
+      makeTrkIso04_(iConfig.getParameter<bool>("makeTrkIso04")),
+      dataFormat_(iConfig.getParameter<int>("dataFormat")) {
+  setToken(ebRecHitToken_, iConfig, "ebRecHitsAOD", "ebRecHitsMiniAOD", dataFormat_);
+  setToken(eeRecHitToken_, iConfig, "eeRecHitsAOD", "eeRecHitsMiniAOD", dataFormat_);
+  setToken(eleToken_, iConfig, "elesAOD", "elesMiniAOD", dataFormat_);
+  setToken(candTokens_, iConfig, "candsAOD", "candsMiniAOD", dataFormat_);
+  setToken(beamSpotToken_, iConfig, "beamSpot");
 
-ElectronHEEPIDValueMapProducer::ElectronHEEPIDValueMapProducer(const edm::ParameterSet& iConfig):
-  trkIsoCalc_(iConfig.getParameter<edm::ParameterSet>("trkIsoConfig")),
-  trkIso04Calc_(iConfig.getParameter<edm::ParameterSet>("trkIso04Config")),
-  makeTrkIso04_(iConfig.getParameter<bool>("makeTrkIso04")),
-  dataFormat_(iConfig.getParameter<int>("dataFormat"))
-{
-  setToken(ebRecHitToken_,iConfig,"ebRecHitsAOD","ebRecHitsMiniAOD",dataFormat_);
-  setToken(eeRecHitToken_,iConfig,"eeRecHitsAOD","eeRecHitsMiniAOD",dataFormat_);
-  setToken(eleToken_,iConfig,"elesAOD","elesMiniAOD",dataFormat_);
-  setToken(candTokens_,iConfig,"candsAOD","candsMiniAOD",dataFormat_);
-  setToken(beamSpotToken_,iConfig,"beamSpot");
-  
-  auto fillVetos=[](const auto& in,auto& out){
-    std::transform(in.begin(),in.end(),std::back_inserter(out),EleTkIsolFromCands::pidVetoFromStr);
+  auto fillVetos = [](const auto& in, auto& out) {
+    std::transform(in.begin(), in.end(), std::back_inserter(out), EleTkIsolFromCands::pidVetoFromStr);
   };
-  
-  fillVetos(iConfig.getParameter<std::vector<std::string> >("candVetosAOD"),candVetosAOD_);
-  if(candVetosAOD_.size()!=iConfig.getParameter<std::vector<edm::InputTag> >("candsAOD").size()){
-    throw cms::Exception("ConfigError") <<" Error candVetosAOD should be the same size as candsAOD "<<std::endl;
+
+  fillVetos(iConfig.getParameter<std::vector<std::string> >("candVetosAOD"), candVetosAOD_);
+  if (candVetosAOD_.size() != iConfig.getParameter<std::vector<edm::InputTag> >("candsAOD").size()) {
+    throw cms::Exception("ConfigError") << " Error candVetosAOD should be the same size as candsAOD " << std::endl;
   }
 
-  fillVetos(iConfig.getParameter<std::vector<std::string> >("candVetosMiniAOD"),candVetosMiniAOD_);
-  if(candVetosMiniAOD_.size()!=iConfig.getParameter<std::vector<edm::InputTag> >("candsMiniAOD").size()){
-    throw cms::Exception("ConfigError") <<" Error candVetosMiniAOD should be the same size as candsMiniAOD "<<std::endl;
+  fillVetos(iConfig.getParameter<std::vector<std::string> >("candVetosMiniAOD"), candVetosMiniAOD_);
+  if (candVetosMiniAOD_.size() != iConfig.getParameter<std::vector<edm::InputTag> >("candsMiniAOD").size()) {
+    throw cms::Exception("ConfigError") << " Error candVetosMiniAOD should be the same size as candsMiniAOD "
+                                        << std::endl;
   }
 
-  produces<edm::ValueMap<float> >(eleTrkPtIsoLabel_);  
-  if(makeTrkIso04_) produces<edm::ValueMap<float> >(eleTrkPtIso04Label_);  
-  produces<edm::ValueMap<int> >(eleNrSaturateIn5x5Label_);  
+  produces<edm::ValueMap<float> >(eleTrkPtIsoLabel_);
+  if (makeTrkIso04_)
+    produces<edm::ValueMap<float> >(eleTrkPtIso04Label_);
+  produces<edm::ValueMap<int> >(eleNrSaturateIn5x5Label_);
 }
 
-ElectronHEEPIDValueMapProducer::~ElectronHEEPIDValueMapProducer()
-{
+ElectronHEEPIDValueMapProducer::~ElectronHEEPIDValueMapProducer() {}
 
-}
+void ElectronHEEPIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto eleHandle = getHandle(iEvent, eleToken_);
+  auto ebRecHitHandle = getHandle(iEvent, ebRecHitToken_);
+  auto eeRecHitHandle = getHandle(iEvent, eeRecHitToken_);
+  auto beamSpotHandle = getHandle(iEvent, beamSpotToken_);
+  auto candHandles = getHandles(iEvent, candTokens_);
 
-void ElectronHEEPIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  auto eleHandle = getHandle(iEvent,eleToken_);
-  auto ebRecHitHandle = getHandle(iEvent,ebRecHitToken_);
-  auto eeRecHitHandle = getHandle(iEvent,eeRecHitToken_);
-  auto beamSpotHandle = getHandle(iEvent,beamSpotToken_);
-  auto candHandles = getHandles(iEvent,candTokens_);
-
-  bool isAOD = isEventAOD(iEvent,eleToken_);
+  bool isAOD = isEventAOD(iEvent, eleToken_);
   const auto& candVetos = isAOD ? candVetosAOD_ : candVetosMiniAOD_;
 
   edm::ESHandle<CaloTopology> caloTopoHandle;
   iSetup.get<CaloTopologyRecord>().get(caloTopoHandle);
-  
+
   std::vector<float> eleTrkPtIso;
   std::vector<float> eleTrkPtIso04;
   std::vector<int> eleNrSaturateIn5x5;
-  for(auto const& ele : *eleHandle) {
-    eleTrkPtIso.push_back(calTrkIso(ele,*eleHandle,candHandles,candVetos,trkIsoCalc_));
-    if(makeTrkIso04_){
-      eleTrkPtIso04.push_back(calTrkIso(ele,*eleHandle,candHandles,candVetos,trkIso04Calc_));
+  for (auto const& ele : *eleHandle) {
+    eleTrkPtIso.push_back(calTrkIso(ele, *eleHandle, candHandles, candVetos, trkIsoCalc_));
+    if (makeTrkIso04_) {
+      eleTrkPtIso04.push_back(calTrkIso(ele, *eleHandle, candHandles, candVetos, trkIso04Calc_));
     }
-    eleNrSaturateIn5x5.push_back(nrSaturatedCrysIn5x5(ele,ebRecHitHandle,eeRecHitHandle,caloTopoHandle));    
+    eleNrSaturateIn5x5.push_back(nrSaturatedCrysIn5x5(ele, ebRecHitHandle, eeRecHitHandle, caloTopoHandle));
   }
-  
-  writeValueMap(iEvent,eleHandle,eleTrkPtIso,eleTrkPtIsoLabel_);  
-  if(makeTrkIso04_) writeValueMap(iEvent,eleHandle,eleTrkPtIso04,eleTrkPtIso04Label_);  
-  writeValueMap(iEvent,eleHandle,eleNrSaturateIn5x5,eleNrSaturateIn5x5Label_);  
+
+  writeValueMap(iEvent, eleHandle, eleTrkPtIso, eleTrkPtIsoLabel_);
+  if (makeTrkIso04_)
+    writeValueMap(iEvent, eleHandle, eleTrkPtIso04, eleTrkPtIso04Label_);
+  writeValueMap(iEvent, eleHandle, eleNrSaturateIn5x5, eleNrSaturateIn5x5Label_);
 }
 
 int ElectronHEEPIDValueMapProducer::nrSaturatedCrysIn5x5(const reco::GsfElectron& ele,
-							 edm::Handle<EcalRecHitCollection>& ebHits,
-							 edm::Handle<EcalRecHitCollection>& eeHits,
-							 edm::ESHandle<CaloTopology>& caloTopo)
-{ 
+                                                         edm::Handle<EcalRecHitCollection>& ebHits,
+                                                         edm::Handle<EcalRecHitCollection>& eeHits,
+                                                         edm::ESHandle<CaloTopology>& caloTopo) {
   DetId id = ele.superCluster()->seed()->seed();
-  auto recHits = id.subdetId()==EcalBarrel ? ebHits.product() : eeHits.product();
-  return noZS::EcalClusterTools::nrSaturatedCrysIn5x5(id,recHits,caloTopo.product());
-
+  auto recHits = id.subdetId() == EcalBarrel ? ebHits.product() : eeHits.product();
+  return noZS::EcalClusterTools::nrSaturatedCrysIn5x5(id, recHits, caloTopo.product());
 }
 
-float ElectronHEEPIDValueMapProducer::
-calTrkIso(const reco::GsfElectron& ele,		  
-	  const edm::View<reco::GsfElectron>& eles,
-	  const std::vector<edm::Handle<pat::PackedCandidateCollection> >& handles,
-	  const std::vector<EleTkIsolFromCands::PIDVeto>& pidVetos,
-	  const EleTkIsolFromCands& trkIsoCalc)
-{
-  if(ele.gsfTrack().isNull()) return std::numeric_limits<float>::max();
-  else{
-    float trkIso=0.; 
-    for(size_t handleNr=0;handleNr<handles.size();handleNr++){
+float ElectronHEEPIDValueMapProducer::calTrkIso(const reco::GsfElectron& ele,
+                                                const edm::View<reco::GsfElectron>& eles,
+                                                const std::vector<edm::Handle<pat::PackedCandidateCollection> >& handles,
+                                                const std::vector<EleTkIsolFromCands::PIDVeto>& pidVetos,
+                                                const EleTkIsolFromCands& trkIsoCalc) {
+  if (ele.gsfTrack().isNull())
+    return std::numeric_limits<float>::max();
+  else {
+    float trkIso = 0.;
+    for (size_t handleNr = 0; handleNr < handles.size(); handleNr++) {
       auto& handle = handles[handleNr];
-      if(handle.isValid()){
-	if(handleNr<pidVetos.size()){
-	  trkIso+= trkIsoCalc.calIsolPt(*ele.gsfTrack(),*handle,pidVetos[handleNr]);
-	}else{
-	  throw cms::Exception("LogicError") <<" somehow the pidVetos and handles do not much, given this is checked at construction time, something has gone wrong in the code handle nr "<<handleNr<<" size of vetos "<<pidVetos.size();
-	}
+      if (handle.isValid()) {
+        if (handleNr < pidVetos.size()) {
+          trkIso += trkIsoCalc.calIsolPt(*ele.gsfTrack(), *handle, pidVetos[handleNr]);
+        } else {
+          throw cms::Exception("LogicError") << " somehow the pidVetos and handles do not much, given this is checked "
+                                                "at construction time, something has gone wrong in the code handle nr "
+                                             << handleNr << " size of vetos " << pidVetos.size();
+        }
       }
     }
     return trkIso;
   }
 }
 
-template<typename T>
-void ElectronHEEPIDValueMapProducer::writeValueMap(edm::Event &iEvent,
-						   const edm::Handle<edm::View<reco::GsfElectron> > & handle,
-						   const std::vector<T> & values,
-						   const std::string& label)
-{ 
+template <typename T>
+void ElectronHEEPIDValueMapProducer::writeValueMap(edm::Event& iEvent,
+                                                   const edm::Handle<edm::View<reco::GsfElectron> >& handle,
+                                                   const std::vector<T>& values,
+                                                   const std::string& label) {
   std::unique_ptr<edm::ValueMap<T> > valMap(new edm::ValueMap<T>());
   typename edm::ValueMap<T>::Filler filler(*valMap);
   filler.insert(handle, values.begin(), values.end());
   filler.fill();
-  iEvent.put(std::move(valMap),label);
+  iEvent.put(std::move(valMap), label);
 }
 
 void ElectronHEEPIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
- 
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("beamSpot",edm::InputTag("offlineBeamSpot"));
-  desc.add<edm::InputTag>("ebRecHitsAOD",edm::InputTag("reducedEcalRecHitsEB"));
-  desc.add<edm::InputTag>("eeRecHitsAOD",edm::InputTag("reducedEcalRecHitsEE"));
-  desc.add<std::vector<edm::InputTag> >("candsAOD",{edm::InputTag("packedCandidates")});
-  desc.add<std::vector<std::string> >("candVetosAOD",{"none"});
-  desc.add<edm::InputTag>("elesAOD",edm::InputTag("gedGsfElectrons"));
-  
-  desc.add<edm::InputTag>("ebRecHitsMiniAOD",edm::InputTag("reducedEcalRecHitsEB"));
-  desc.add<edm::InputTag>("eeRecHitsMiniAOD",edm::InputTag("reducedEcalRecHitsEE"));
-  desc.add<std::vector<edm::InputTag> >("candsMiniAOD",{edm::InputTag("packedCandidates")});
-  desc.add<std::vector<std::string> >("candVetosMiniAOD",{"none"});
-  desc.add<edm::InputTag>("elesMiniAOD",edm::InputTag("gedGsfElectrons"));
-  desc.add<int>("dataFormat",0);
-  desc.add<bool>("makeTrkIso04",false);
-  desc.add("trkIsoConfig",EleTkIsolFromCands::pSetDescript());
-  desc.add("trkIso04Config",EleTkIsolFromCands::pSetDescript());
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+  desc.add<edm::InputTag>("ebRecHitsAOD", edm::InputTag("reducedEcalRecHitsEB"));
+  desc.add<edm::InputTag>("eeRecHitsAOD", edm::InputTag("reducedEcalRecHitsEE"));
+  desc.add<std::vector<edm::InputTag> >("candsAOD", {edm::InputTag("packedCandidates")});
+  desc.add<std::vector<std::string> >("candVetosAOD", {"none"});
+  desc.add<edm::InputTag>("elesAOD", edm::InputTag("gedGsfElectrons"));
+
+  desc.add<edm::InputTag>("ebRecHitsMiniAOD", edm::InputTag("reducedEcalRecHitsEB"));
+  desc.add<edm::InputTag>("eeRecHitsMiniAOD", edm::InputTag("reducedEcalRecHitsEE"));
+  desc.add<std::vector<edm::InputTag> >("candsMiniAOD", {edm::InputTag("packedCandidates")});
+  desc.add<std::vector<std::string> >("candVetosMiniAOD", {"none"});
+  desc.add<edm::InputTag>("elesMiniAOD", edm::InputTag("gedGsfElectrons"));
+  desc.add<int>("dataFormat", 0);
+  desc.add<bool>("makeTrkIso04", false);
+  desc.add("trkIsoConfig", EleTkIsolFromCands::pSetDescript());
+  desc.add("trkIso04Config", EleTkIsolFromCands::pSetDescript());
 
   descriptions.addDefault(desc);
 }

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDExternalProducer.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDExternalProducer.h
@@ -14,50 +14,46 @@
 
 #include "DataFormats/Common/interface/ValueMap.h"
 
-template<class algo>
+template <class algo>
 class ElectronIDExternalProducer : public edm::stream::EDProducer<> {
- public:
-   explicit ElectronIDExternalProducer(const edm::ParameterSet& iConfig) :
-            srcToken_(consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-            select_(iConfig, consumesCollector())
-   {
-        produces<edm::ValueMap<float> >();
-   }
+public:
+  explicit ElectronIDExternalProducer(const edm::ParameterSet& iConfig)
+      : srcToken_(consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+        select_(iConfig, consumesCollector()) {
+    produces<edm::ValueMap<float>>();
+  }
 
-   ~ElectronIDExternalProducer() override {}
+  ~ElectronIDExternalProducer() override {}
 
-   void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override ;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
- private:
-   edm::EDGetTokenT<reco::GsfElectronCollection> srcToken_ ;
-   algo select_ ;
-
+private:
+  edm::EDGetTokenT<reco::GsfElectronCollection> srcToken_;
+  algo select_;
 };
 
-template<typename algo>
-void ElectronIDExternalProducer<algo>::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-     // read input collection
-     edm::Handle<reco::GsfElectronCollection> electrons;
-     iEvent.getByToken(srcToken_, electrons);
+template <typename algo>
+void ElectronIDExternalProducer<algo>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // read input collection
+  edm::Handle<reco::GsfElectronCollection> electrons;
+  iEvent.getByToken(srcToken_, electrons);
 
-     // initialize common selector
-     select_.newEvent(iEvent, iSetup);
+  // initialize common selector
+  select_.newEvent(iEvent, iSetup);
 
-     // prepare room for output
-     std::vector<float> values; values.reserve(electrons->size());
-     for ( reco::GsfElectronCollection::const_iterator eleIt = electrons->begin () ;
-             eleIt != electrons->end () ;
-             ++eleIt ) {
-         values.push_back( float( select_((*eleIt),iEvent,iSetup) ) );
-     }
+  // prepare room for output
+  std::vector<float> values;
+  values.reserve(electrons->size());
+  for (reco::GsfElectronCollection::const_iterator eleIt = electrons->begin(); eleIt != electrons->end(); ++eleIt) {
+    values.push_back(float(select_((*eleIt), iEvent, iSetup)));
+  }
 
-     // fill in the ValueMap
-     auto out = std::make_unique<edm::ValueMap<float>>();
-     edm::ValueMap<float>::Filler filler(*out);
-     filler.insert(electrons, values.begin(), values.end());
-     filler.fill();
-     // and put it into the event
-     iEvent.put(std::move(out));
-
+  // fill in the ValueMap
+  auto out = std::make_unique<edm::ValueMap<float>>();
+  edm::ValueMap<float>::Filler filler(*out);
+  filler.insert(electrons, values.begin(), values.end());
+  filler.fill();
+  // and put it into the event
+  iEvent.put(std::move(out));
 }
 #endif

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelector.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelector.h
@@ -11,53 +11,45 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 
-template<class algo>
-struct ElectronIDSelector{
- public:
-   explicit ElectronIDSelector(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) :
-            select_(iConfig, iC),
-	    threshold_(iConfig.getParameter<double>("threshold"))
-   {
-   }
+template <class algo>
+struct ElectronIDSelector {
+public:
+  explicit ElectronIDSelector(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
+      : select_(iConfig, iC), threshold_(iConfig.getParameter<double>("threshold")) {}
 
-   virtual ~ElectronIDSelector() {};
+  virtual ~ElectronIDSelector(){};
 
-   // Collections to be selected
-   typedef reco::GsfElectronCollection collection;
-   typedef std::vector<reco::GsfElectronRef> container ;
-   //typedef std::vector<reco::GsfElectron> container ;
-   typedef container::const_iterator const_iterator;
+  // Collections to be selected
+  typedef reco::GsfElectronCollection collection;
+  typedef std::vector<reco::GsfElectronRef> container;
+  //typedef std::vector<reco::GsfElectron> container ;
+  typedef container::const_iterator const_iterator;
 
-   //define iterators with above typedef
-   const_iterator begin () const { return selected_.begin () ; }
-   const_iterator end () const { return  selected_.end () ; }
+  //define iterators with above typedef
+  const_iterator begin() const { return selected_.begin(); }
+  const_iterator end() const { return selected_.end(); }
 
-   void select(const edm::Handle<reco::GsfElectronCollection>& _electrons,
-               const edm::Event& iEvent ,
-	       const edm::EventSetup& iEs)
-   {
-     const edm::Handle<reco::GsfElectronCollection>& electrons = _electrons;
-     selected_.clear();
-     select_.newEvent(iEvent, iEs);
-     // Loop over electrons
-     unsigned int i = 0 ;
-     for ( reco::GsfElectronCollection::const_iterator eleIt = electrons->begin () ;
-      	 			                       eleIt != electrons->end () ;
-   						       ++eleIt )
-	{
-	 edm::Ref<reco::GsfElectronCollection> electronRef(electrons,i);
-	 if (select_((*eleIt),iEvent,iEs) > threshold_)
-	     selected_.push_back (electronRef) ;
-	     //selected_.push_back ( & * eleIt) ;
-	 ++i;
-	}
-   }
+  void select(const edm::Handle<reco::GsfElectronCollection>& _electrons,
+              const edm::Event& iEvent,
+              const edm::EventSetup& iEs) {
+    const edm::Handle<reco::GsfElectronCollection>& electrons = _electrons;
+    selected_.clear();
+    select_.newEvent(iEvent, iEs);
+    // Loop over electrons
+    unsigned int i = 0;
+    for (reco::GsfElectronCollection::const_iterator eleIt = electrons->begin(); eleIt != electrons->end(); ++eleIt) {
+      edm::Ref<reco::GsfElectronCollection> electronRef(electrons, i);
+      if (select_((*eleIt), iEvent, iEs) > threshold_)
+        selected_.push_back(electronRef);
+      //selected_.push_back ( & * eleIt) ;
+      ++i;
+    }
+  }
 
- private:
-   container selected_ ;
-   algo select_ ;
-   double threshold_ ;
-
+private:
+  container selected_;
+  algo select_;
+  double threshold_;
 };
 
 #endif

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.cc
@@ -1,32 +1,29 @@
 #include "RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.h"
 
-ElectronIDSelectorCutBased::ElectronIDSelectorCutBased (const edm::ParameterSet& conf, edm::ConsumesCollector & iC) : conf_ (conf)
-{
-  std::string algorithm_ = conf.getParameter<std::string> ("algorithm") ;
+ElectronIDSelectorCutBased::ElectronIDSelectorCutBased(const edm::ParameterSet& conf, edm::ConsumesCollector& iC)
+    : conf_(conf) {
+  std::string algorithm_ = conf.getParameter<std::string>("algorithm");
 
-  if ( algorithm_ == "eIDClassBased" )
-     electronIDAlgo_ = new ClassBasedElectronID ();
-  else if ( algorithm_ == "eIDCBClasses" )
-     electronIDAlgo_ = new PTDRElectronID ();
-  else if ( algorithm_ == "eIDCB" )
-    electronIDAlgo_ = new CutBasedElectronID (conf,iC);
+  if (algorithm_ == "eIDClassBased")
+    electronIDAlgo_ = new ClassBasedElectronID();
+  else if (algorithm_ == "eIDCBClasses")
+    electronIDAlgo_ = new PTDRElectronID();
+  else if (algorithm_ == "eIDCB")
+    electronIDAlgo_ = new CutBasedElectronID(conf, iC);
   else {
     throw cms::Exception("Configuration")
-      << "Invalid algorithm parameter in ElectronIDSelectorCutBased: must be eIDCBClasses or eIDCB." ;
+        << "Invalid algorithm parameter in ElectronIDSelectorCutBased: must be eIDCBClasses or eIDCB.";
   }
 }
 
-ElectronIDSelectorCutBased::~ElectronIDSelectorCutBased ()
-{
-  delete electronIDAlgo_ ;
+ElectronIDSelectorCutBased::~ElectronIDSelectorCutBased() { delete electronIDAlgo_; }
+
+void ElectronIDSelectorCutBased::newEvent(const edm::Event& e, const edm::EventSetup& es) {
+  electronIDAlgo_->setup(conf_);
 }
 
-void ElectronIDSelectorCutBased::newEvent (const edm::Event& e, const edm::EventSetup& es)
-{
-  electronIDAlgo_->setup (conf_);
-}
-
-double ElectronIDSelectorCutBased::operator () (const reco::GsfElectron & ele, const edm::Event& e, const edm::EventSetup& es)
-{
-  return electronIDAlgo_->result (& (ele), e, es) ;
+double ElectronIDSelectorCutBased::operator()(const reco::GsfElectron& ele,
+                                              const edm::Event& e,
+                                              const edm::EventSetup& es) {
+  return electronIDAlgo_->result(&(ele), e, es);
 }

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.h
@@ -13,24 +13,20 @@
 #include "RecoEgamma/ElectronIdentification/interface/ClassBasedElectronID.h"
 #include "RecoEgamma/ElectronIdentification/interface/CutBasedElectronID.h"
 
-class ElectronIDSelectorCutBased
-{
- public:
+class ElectronIDSelectorCutBased {
+public:
+  explicit ElectronIDSelectorCutBased(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC)
+      : ElectronIDSelectorCutBased(conf, iC) {}
+  explicit ElectronIDSelectorCutBased(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
+  virtual ~ElectronIDSelectorCutBased();
 
-  explicit ElectronIDSelectorCutBased (const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
-    ElectronIDSelectorCutBased(conf, iC) {}
-  explicit ElectronIDSelectorCutBased (const edm::ParameterSet& conf, edm::ConsumesCollector & iC) ;
-  virtual ~ElectronIDSelectorCutBased () ;
+  void newEvent(const edm::Event&, const edm::EventSetup&);
+  double operator()(const reco::GsfElectron&, const edm::Event&, const edm::EventSetup&);
 
-  void newEvent (const edm::Event&, const edm::EventSetup&) ;
-  double operator() (const reco::GsfElectron& , const edm::Event& , const edm::EventSetup& ) ;
-
- private:
-
+private:
   ElectronIDAlgo* electronIDAlgo_;
   edm::ParameterSet conf_;
-  std::string algorithm_ ;
-
+  std::string algorithm_;
 };
 
 #endif

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorLikelihood.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorLikelihood.cc
@@ -1,39 +1,32 @@
 #include "RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorLikelihood.h"
 
-ElectronIDSelectorLikelihood::ElectronIDSelectorLikelihood (const edm::ParameterSet& conf, edm::ConsumesCollector & iC) : conf_ (conf)
-{
-  doLikelihood_ = conf_.getParameter<bool> ("doLikelihood");
+ElectronIDSelectorLikelihood::ElectronIDSelectorLikelihood(const edm::ParameterSet& conf, edm::ConsumesCollector& iC)
+    : conf_(conf) {
+  doLikelihood_ = conf_.getParameter<bool>("doLikelihood");
   reducedBarrelRecHitCollection_ = conf.getParameter<edm::InputTag>("reducedBarrelRecHitCollection");
   reducedEndcapRecHitCollection_ = conf.getParameter<edm::InputTag>("reducedEndcapRecHitCollection");
   reducedBarrelRecHitCollectionToken_ = iC.consumes<EcalRecHitCollection>(reducedBarrelRecHitCollection_);
   reducedEndcapRecHitCollectionToken_ = iC.consumes<EcalRecHitCollection>(reducedEndcapRecHitCollection_);
-
 }
 
-ElectronIDSelectorLikelihood::~ElectronIDSelectorLikelihood ()
-{
+ElectronIDSelectorLikelihood::~ElectronIDSelectorLikelihood() {}
+
+void ElectronIDSelectorLikelihood::newEvent(const edm::Event& e, const edm::EventSetup& es) {
+  es.getData(likelihoodAlgo_);
 }
 
-void ElectronIDSelectorLikelihood::newEvent (const edm::Event& e, const edm::EventSetup& es)
-{
-
-  es.getData(likelihoodAlgo_) ;
-
-}
-
-double ElectronIDSelectorLikelihood::operator () (const reco::GsfElectron & ele, const edm::Event& e, const edm::EventSetup& es)
-{
-
+double ElectronIDSelectorLikelihood::operator()(const reco::GsfElectron& ele,
+                                                const edm::Event& e,
+                                                const edm::EventSetup& es) {
   if (doLikelihood_) {
-    edm::Handle< EcalRecHitCollection > pEBRecHits;
-    e.getByToken( reducedBarrelRecHitCollectionToken_, pEBRecHits );
+    edm::Handle<EcalRecHitCollection> pEBRecHits;
+    e.getByToken(reducedBarrelRecHitCollectionToken_, pEBRecHits);
 
-    edm::Handle< EcalRecHitCollection > pEERecHits;
-    e.getByToken( reducedEndcapRecHitCollectionToken_, pEERecHits );
+    edm::Handle<EcalRecHitCollection> pEERecHits;
+    e.getByToken(reducedEndcapRecHitCollectionToken_, pEERecHits);
 
-    EcalClusterLazyTools lazyTools( e, es, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_ ) ;
-    return static_cast<double>(likelihoodAlgo_->resultLog (ele,lazyTools)) ;
+    EcalClusterLazyTools lazyTools(e, es, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
+    return static_cast<double>(likelihoodAlgo_->resultLog(ele, lazyTools));
   }
   return 0;
-
 }

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorLikelihood.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorLikelihood.h
@@ -17,21 +17,18 @@
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "RecoEgamma/ElectronIdentification/interface/ElectronLikelihood.h"
 
-class ElectronIDSelectorLikelihood
-{
- public:
+class ElectronIDSelectorLikelihood {
+public:
+  explicit ElectronIDSelectorLikelihood(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC)
+      : ElectronIDSelectorLikelihood(conf, iC) {}
+  explicit ElectronIDSelectorLikelihood(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
+  virtual ~ElectronIDSelectorLikelihood();
 
-  explicit ElectronIDSelectorLikelihood (const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
-    ElectronIDSelectorLikelihood(conf, iC) {}
-  explicit ElectronIDSelectorLikelihood (const edm::ParameterSet& conf, edm::ConsumesCollector & iC) ;
-  virtual ~ElectronIDSelectorLikelihood () ;
+  void newEvent(const edm::Event&, const edm::EventSetup&);
+  double operator()(const reco::GsfElectron&, const edm::Event&, const edm::EventSetup&);
 
-  void newEvent (const edm::Event&, const edm::EventSetup&) ;
-  double operator() (const reco::GsfElectron&, const edm::Event&, const edm::EventSetup&) ;
-
- private:
-
-  edm::ESHandle<ElectronLikelihood> likelihoodAlgo_ ;
+private:
+  edm::ESHandle<ElectronLikelihood> likelihoodAlgo_;
 
   edm::ParameterSet conf_;
 
@@ -41,6 +38,5 @@ class ElectronIDSelectorLikelihood
   edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
 
   bool doLikelihood_;
-
 };
 #endif

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronLikelihoodESSource.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronLikelihoodESSource.cc
@@ -1,72 +1,56 @@
 #include "RecoEgamma/ElectronIdentification/plugins/ElectronLikelihoodESSource.h"
 
-ElectronLikelihoodESSource::ElectronLikelihoodESSource (const edm::ParameterSet& cfg) :
-  m_signalWeightSplitting (cfg.getParameter<std::string> ("signalWeightSplitting")) ,
-  m_backgroundWeightSplitting (cfg.getParameter<std::string> ("backgroundWeightSplitting")) ,
-  m_splitSignalPdfs (cfg.getParameter<bool> ("splitSignalPdfs")) ,
-  m_splitBackgroundPdfs (cfg.getParameter<bool> ("splitBackgroundPdfs"))
-{
-  setWhatProduced (this) ;
-  findingRecord<ElectronLikelihoodRcd> () ;
+ElectronLikelihoodESSource::ElectronLikelihoodESSource(const edm::ParameterSet& cfg)
+    : m_signalWeightSplitting(cfg.getParameter<std::string>("signalWeightSplitting")),
+      m_backgroundWeightSplitting(cfg.getParameter<std::string>("backgroundWeightSplitting")),
+      m_splitSignalPdfs(cfg.getParameter<bool>("splitSignalPdfs")),
+      m_splitBackgroundPdfs(cfg.getParameter<bool>("splitBackgroundPdfs")) {
+  setWhatProduced(this);
+  findingRecord<ElectronLikelihoodRcd>();
 
-  m_eleIDSwitches.m_useDeltaEta     = cfg.getParameter<bool> ("useDeltaEta") ;
-  m_eleIDSwitches.m_useDeltaPhi     = cfg.getParameter<bool> ("useDeltaPhi") ;
-  m_eleIDSwitches.m_useHoverE       = cfg.getParameter<bool> ("useHoverE") ;
-  m_eleIDSwitches.m_useEoverP       = cfg.getParameter<bool> ("useEoverP") ;
-  m_eleIDSwitches.m_useSigmaEtaEta  = cfg.getParameter<bool> ("useSigmaEtaEta") ;
-  m_eleIDSwitches.m_useSigmaPhiPhi  = cfg.getParameter<bool> ("useSigmaPhiPhi") ;
-  m_eleIDSwitches.m_useFBrem        = cfg.getParameter<bool> ("useFBrem") ;
-  m_eleIDSwitches.m_useOneOverEMinusOneOverP = cfg.getParameter<bool> ("useOneOverEMinusOneOverP") ;
-
+  m_eleIDSwitches.m_useDeltaEta = cfg.getParameter<bool>("useDeltaEta");
+  m_eleIDSwitches.m_useDeltaPhi = cfg.getParameter<bool>("useDeltaPhi");
+  m_eleIDSwitches.m_useHoverE = cfg.getParameter<bool>("useHoverE");
+  m_eleIDSwitches.m_useEoverP = cfg.getParameter<bool>("useEoverP");
+  m_eleIDSwitches.m_useSigmaEtaEta = cfg.getParameter<bool>("useSigmaEtaEta");
+  m_eleIDSwitches.m_useSigmaPhiPhi = cfg.getParameter<bool>("useSigmaPhiPhi");
+  m_eleIDSwitches.m_useFBrem = cfg.getParameter<bool>("useFBrem");
+  m_eleIDSwitches.m_useOneOverEMinusOneOverP = cfg.getParameter<bool>("useOneOverEMinusOneOverP");
 }
-
 
 // ----------------------------------------------------
 
-
-ElectronLikelihoodESSource::~ElectronLikelihoodESSource() {
-}
-
+ElectronLikelihoodESSource::~ElectronLikelihoodESSource() {}
 
 // ----------------------------------------------------
 
+ElectronLikelihoodESSource::ReturnType ElectronLikelihoodESSource::produce(const ElectronLikelihoodRcd& iRecord) {
+  const ElectronLikelihoodCalibration* calibration = readPdfFromDB(iRecord);
 
-ElectronLikelihoodESSource::ReturnType
-ElectronLikelihoodESSource::produce (const ElectronLikelihoodRcd & iRecord) 
-{
-
-  const ElectronLikelihoodCalibration *calibration = readPdfFromDB (iRecord) ;
-
-  ReturnType LHAlgo (new ElectronLikelihood (&(*calibration), 
-					     m_eleIDSwitches,
-					     m_signalWeightSplitting, m_backgroundWeightSplitting,
-					     m_splitSignalPdfs, m_splitBackgroundPdfs
-					     ) ); 
+  ReturnType LHAlgo(new ElectronLikelihood(&(*calibration),
+                                           m_eleIDSwitches,
+                                           m_signalWeightSplitting,
+                                           m_backgroundWeightSplitting,
+                                           m_splitSignalPdfs,
+                                           m_splitBackgroundPdfs));
 
   return LHAlgo;
 }
 
-
 // ----------------------------------------------------
 
-
-void 
-ElectronLikelihoodESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-					   const edm::IOVSyncValue&,
-					   edm::ValidityInterval& oInterval ) {
+void ElectronLikelihoodESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                const edm::IOVSyncValue&,
+                                                edm::ValidityInterval& oInterval) {
   // the same PDF's is valid for any time
-  oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime (), 
-                                     edm::IOVSyncValue::endOfTime ()) ;
+  oInterval = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }
 
-
 // ----------------------------------------------------
 
-const ElectronLikelihoodCalibration*
-ElectronLikelihoodESSource::readPdfFromDB( const ElectronLikelihoodRcd & iRecord ) {
-
+const ElectronLikelihoodCalibration* ElectronLikelihoodESSource::readPdfFromDB(const ElectronLikelihoodRcd& iRecord) {
   // setup the PDF's from DB
-  const ElectronLikelihoodCalibration *calibration = nullptr;
+  const ElectronLikelihoodCalibration* calibration = nullptr;
   edm::ESHandle<ElectronLikelihoodCalibration> calibHandle;
   iRecord.getRecord<ElectronLikelihoodPdfsRcd>().get(calibHandle);
   calibration = calibHandle.product();

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronLikelihoodESSource.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronLikelihoodESSource.h
@@ -1,22 +1,21 @@
 // -*- C++ -*-
 //-----------------------------------------------------------------------
 //
-// Package:    
+// Package:
 //      EgammaAnalysis/ElectronIDESSource
 // Description:
 //      Class ElectronLikelihoodESSource
 //      class defining the Event Setup sources, where to take:
 //      PDFs, a priori probabilities, cluster shape Fisher setup
-//      
-// Original Authors:  Emanuele Di Marco, 
-//                    Chiara Ilaria Rovelli, 
+//
+// Original Authors:  Emanuele Di Marco,
+//                    Chiara Ilaria Rovelli,
 //                    Paolo Meridiani
 // Universita' di Roma "La Sapienza" and INFN Roma
 //
 // Created:  Fri Jun  25 11:25:36 CEST 2007
 //
 //-----------------------------------------------------------------------
-
 
 #ifndef ElectronLikelihoodESSource_h
 #define ElectronLikelihoodESSource_h
@@ -35,35 +34,33 @@
 #include <climits>
 #include <string>
 
-class ElectronLikelihoodESSource : public edm::ESProducer, public  edm::EventSetupRecordIntervalFinder {
- public:
+class ElectronLikelihoodESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
   /// constructor from parameter set
-  ElectronLikelihoodESSource( const edm::ParameterSet& );
+  ElectronLikelihoodESSource(const edm::ParameterSet &);
   /// destructor
   ~ElectronLikelihoodESSource() override;
   /// define the return type
   typedef std::unique_ptr<ElectronLikelihood> ReturnType;
   /// return the particle table
-  ReturnType produce( const ElectronLikelihoodRcd &);
+  ReturnType produce(const ElectronLikelihoodRcd &);
   /// set validity interval
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey &,
-		       const edm::IOVSyncValue &,
-		       edm::ValidityInterval & ) override;
-  
- private:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+private:
   //! read PDF's from CondDB
-  const ElectronLikelihoodCalibration* readPdfFromDB ( const ElectronLikelihoodRcd & );
+  const ElectronLikelihoodCalibration *readPdfFromDB(const ElectronLikelihoodRcd &);
 
- private:
-
+private:
   //! general parameters of the id algorithm
-  LikelihoodSwitches m_eleIDSwitches ;
-  
-  //! signal pdf splitting
-  std::string m_signalWeightSplitting ;
-  std::string m_backgroundWeightSplitting ;
-  bool m_splitSignalPdfs ;
-  bool m_splitBackgroundPdfs ;
+  LikelihoodSwitches m_eleIDSwitches;
 
+  //! signal pdf splitting
+  std::string m_signalWeightSplitting;
+  std::string m_backgroundWeightSplitting;
+  bool m_splitSignalPdfs;
+  bool m_splitBackgroundPdfs;
 };
 #endif

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVANtuplizer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVANtuplizer.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
@@ -43,95 +42,94 @@
 // class declaration
 //
 
-class ElectronMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
-   public:
-      explicit ElectronMVANtuplizer(const edm::ParameterSet&);
+class ElectronMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit ElectronMVANtuplizer(const edm::ParameterSet&);
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-      // method called once each job just before starting event loop
-      void beginJob() override {};
-      // method called once each job just after ending the event loop
-      void endJob() override {};
+  // method called once each job just before starting event loop
+  void beginJob() override{};
+  // method called once each job just after ending the event loop
+  void endJob() override{};
 
-      int matchToTruth(reco::GsfElectron const& electron,
-                       edm::View<reco::GenParticle> const& genParticles) const;
+  int matchToTruth(reco::GsfElectron const& electron, edm::View<reco::GenParticle> const& genParticles) const;
 
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 
-      //global variables
-      int nEvent_;
-      int nRun_;
-      int nLumi_;
-      int genNpu_;
-      int vtxN_;
+  //global variables
+  int nEvent_;
+  int nRun_;
+  int nLumi_;
+  int genNpu_;
+  int vtxN_;
 
-      // electron variables
-      float eleQ_;
-      int ele3Q_;
-      int matchedToGenEle_;
+  // electron variables
+  float eleQ_;
+  int ele3Q_;
+  int matchedToGenEle_;
 
-      std::vector<float> energyMatrix_;
+  std::vector<float> energyMatrix_;
 
-      // gap variables
-      bool eleIsEB_;
-      bool eleIsEE_;
-      bool eleIsEBEtaGap_;
-      bool eleIsEBPhiGap_;
-      bool eleIsEBEEGap_;
-      bool eleIsEEDeeGap_;
-      bool eleIsEERingGap_;
+  // gap variables
+  bool eleIsEB_;
+  bool eleIsEE_;
+  bool eleIsEBEtaGap_;
+  bool eleIsEBPhiGap_;
+  bool eleIsEBEEGap_;
+  bool eleIsEEDeeGap_;
+  bool eleIsEERingGap_;
 
-      // config
-      const bool isMC_;
-      const double deltaR_;
-      const double ptThreshold_;
+  // config
+  const bool isMC_;
+  const double deltaR_;
+  const double ptThreshold_;
 
-      // ID decisions objects
-      const std::vector< std::string > eleMapTags_;
-      std::vector< edm::EDGetTokenT< edm::ValueMap<bool> > > eleMapTokens_;
-      const std::vector< std::string > eleMapBranchNames_;
-      const size_t nEleMaps_;
+  // ID decisions objects
+  const std::vector<std::string> eleMapTags_;
+  std::vector<edm::EDGetTokenT<edm::ValueMap<bool>>> eleMapTokens_;
+  const std::vector<std::string> eleMapBranchNames_;
+  const size_t nEleMaps_;
 
-      // MVA values and categories (optional)
-      const std::vector< std::string > valMapTags_;
-      std::vector< edm::EDGetTokenT<edm::ValueMap<float> > > valMapTokens_;
-      const std::vector< std::string > valMapBranchNames_;
-      const size_t nValMaps_;
+  // MVA values and categories (optional)
+  const std::vector<std::string> valMapTags_;
+  std::vector<edm::EDGetTokenT<edm::ValueMap<float>>> valMapTokens_;
+  const std::vector<std::string> valMapBranchNames_;
+  const size_t nValMaps_;
 
-      const std::vector< std::string > mvaCatTags_;
-      std::vector< edm::EDGetTokenT<edm::ValueMap<int> > > mvaCatTokens_;
-      const std::vector< std::string > mvaCatBranchNames_;
-      const size_t nCats_;
+  const std::vector<std::string> mvaCatTags_;
+  std::vector<edm::EDGetTokenT<edm::ValueMap<int>>> mvaCatTokens_;
+  const std::vector<std::string> mvaCatBranchNames_;
+  const size_t nCats_;
 
-      // Tokens
-      const edm::EDGetTokenT<edm::View<reco::GsfElectron>>   src_;
-      const edm::EDGetTokenT<std::vector<reco::Vertex>>      vertices_;
-      const edm::EDGetTokenT<std::vector<PileupSummaryInfo>> pileup_;
-      const edm::EDGetTokenT<edm::View<reco::GenParticle>>   genParticles_;
-      const edm::EDGetTokenT<EcalRecHitCollection>           ebRecHits_;
-      const edm::EDGetTokenT<EcalRecHitCollection>           eeRecHits_;
+  // Tokens
+  const edm::EDGetTokenT<edm::View<reco::GsfElectron>> src_;
+  const edm::EDGetTokenT<std::vector<reco::Vertex>> vertices_;
+  const edm::EDGetTokenT<std::vector<PileupSummaryInfo>> pileup_;
+  const edm::EDGetTokenT<edm::View<reco::GenParticle>> genParticles_;
+  const edm::EDGetTokenT<EcalRecHitCollection> ebRecHits_;
+  const edm::EDGetTokenT<EcalRecHitCollection> eeRecHits_;
 
-      // to hold ID decisions and categories
-      std::vector<int> mvaPasses_;
-      std::vector<float> mvaValues_;
-      std::vector<int> mvaCats_;
+  // to hold ID decisions and categories
+  std::vector<int> mvaPasses_;
+  std::vector<float> mvaValues_;
+  std::vector<int> mvaCats_;
 
-      // To get the auxiliary MVA variables
-      const MVAVariableHelper variableHelper_;
+  // To get the auxiliary MVA variables
+  const MVAVariableHelper variableHelper_;
 
-      // other
-      TTree* tree_;
+  // other
+  TTree* tree_;
 
-      MVAVariableManager<reco::GsfElectron> mvaVarMngr_;
-      const int nVars_;
-      std::vector<float> vars_;
+  MVAVariableManager<reco::GsfElectron> mvaVarMngr_;
+  const int nVars_;
+  std::vector<float> vars_;
 
-      const bool doEnergyMatrix_;
-      const int energyMatrixSize_;
+  const bool doEnergyMatrix_;
+  const int energyMatrixSize_;
 };
 
 //
@@ -139,205 +137,204 @@ class ElectronMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResourc
 //
 
 enum ElectronMatchType {
-                        UNMATCHED,
-                        TRUE_PROMPT_ELECTRON,
-                        TRUE_ELECTRON_FROM_TAU,
-                        TRUE_NON_PROMPT_ELECTRON,
-                       }; // The last does not include tau parents
+  UNMATCHED,
+  TRUE_PROMPT_ELECTRON,
+  TRUE_ELECTRON_FROM_TAU,
+  TRUE_NON_PROMPT_ELECTRON,
+};  // The last does not include tau parents
 
 //
 // constructors and destructor
 //
 ElectronMVANtuplizer::ElectronMVANtuplizer(const edm::ParameterSet& iConfig)
-  : isMC_                  (iConfig.getParameter<bool>("isMC"))
-  , deltaR_                (iConfig.getParameter<double>("deltaR"))
-  , ptThreshold_           (iConfig.getParameter<double>("ptThreshold"))
-  , eleMapTags_            (iConfig.getParameter<std::vector<std::string>>("eleMVAs"))
-  , eleMapBranchNames_     (iConfig.getParameter<std::vector<std::string>>("eleMVALabels"))
-  , nEleMaps_              (eleMapBranchNames_.size())
-  , valMapTags_            (iConfig.getParameter<std::vector<std::string>>("eleMVAValMaps"))
-  , valMapBranchNames_     (iConfig.getParameter<std::vector<std::string>>("eleMVAValMapLabels"))
-  , nValMaps_              (valMapBranchNames_.size())
-  , mvaCatTags_            (iConfig.getParameter<std::vector<std::string>>("eleMVACats"))
-  , mvaCatBranchNames_     (iConfig.getParameter<std::vector<std::string>>("eleMVACatLabels"))
-  , nCats_                 (mvaCatBranchNames_.size())
-  , src_                   (consumes<edm::View<reco::GsfElectron>>(iConfig.getParameter<edm::InputTag>("src")))
-  , vertices_              (consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("vertices")))
-  , pileup_                (consumes<std::vector<PileupSummaryInfo>>(iConfig.getParameter<edm::InputTag>("pileup")))
-  , genParticles_          (consumes<edm::View<reco::GenParticle>>(iConfig.getParameter<edm::InputTag>("genParticles")))
-  , ebRecHits_             (consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ebReducedRecHitCollection")))
-  , eeRecHits_             (consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("eeReducedRecHitCollection")))
-  , mvaPasses_             (nEleMaps_)
-  , mvaValues_             (nValMaps_)
-  , mvaCats_               (nCats_)
-  , variableHelper_        (consumesCollector())
-  , mvaVarMngr_            (iConfig.getParameter<std::string>("variableDefinition"))
-  , nVars_                 (mvaVarMngr_.getNVars())
-  , vars_                  (nVars_)
-  , doEnergyMatrix_        (iConfig.getParameter<bool>("doEnergyMatrix"))
-  , energyMatrixSize_      (iConfig.getParameter<int>("energyMatrixSize"))
-{
-    // eleMaps
-    for (auto const& tag : eleMapTags_) {
-        eleMapTokens_.push_back(consumes<edm::ValueMap<bool> >(edm::InputTag(tag)));
-    }
-    // valMaps
-    for (auto const& tag : valMapTags_) {
-        valMapTokens_.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(tag)));
-    }
-    // categories
-    for (auto const& tag : mvaCatTags_) {
-        mvaCatTokens_.push_back(consumes<edm::ValueMap<int> >(edm::InputTag(tag)));
-    }
+    : isMC_(iConfig.getParameter<bool>("isMC")),
+      deltaR_(iConfig.getParameter<double>("deltaR")),
+      ptThreshold_(iConfig.getParameter<double>("ptThreshold")),
+      eleMapTags_(iConfig.getParameter<std::vector<std::string>>("eleMVAs")),
+      eleMapBranchNames_(iConfig.getParameter<std::vector<std::string>>("eleMVALabels")),
+      nEleMaps_(eleMapBranchNames_.size()),
+      valMapTags_(iConfig.getParameter<std::vector<std::string>>("eleMVAValMaps")),
+      valMapBranchNames_(iConfig.getParameter<std::vector<std::string>>("eleMVAValMapLabels")),
+      nValMaps_(valMapBranchNames_.size()),
+      mvaCatTags_(iConfig.getParameter<std::vector<std::string>>("eleMVACats")),
+      mvaCatBranchNames_(iConfig.getParameter<std::vector<std::string>>("eleMVACatLabels")),
+      nCats_(mvaCatBranchNames_.size()),
+      src_(consumes<edm::View<reco::GsfElectron>>(iConfig.getParameter<edm::InputTag>("src"))),
+      vertices_(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("vertices"))),
+      pileup_(consumes<std::vector<PileupSummaryInfo>>(iConfig.getParameter<edm::InputTag>("pileup"))),
+      genParticles_(consumes<edm::View<reco::GenParticle>>(iConfig.getParameter<edm::InputTag>("genParticles"))),
+      ebRecHits_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ebReducedRecHitCollection"))),
+      eeRecHits_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("eeReducedRecHitCollection"))),
+      mvaPasses_(nEleMaps_),
+      mvaValues_(nValMaps_),
+      mvaCats_(nCats_),
+      variableHelper_(consumesCollector()),
+      mvaVarMngr_(iConfig.getParameter<std::string>("variableDefinition")),
+      nVars_(mvaVarMngr_.getNVars()),
+      vars_(nVars_),
+      doEnergyMatrix_(iConfig.getParameter<bool>("doEnergyMatrix")),
+      energyMatrixSize_(iConfig.getParameter<int>("energyMatrixSize")) {
+  // eleMaps
+  for (auto const& tag : eleMapTags_) {
+    eleMapTokens_.push_back(consumes<edm::ValueMap<bool>>(edm::InputTag(tag)));
+  }
+  // valMaps
+  for (auto const& tag : valMapTags_) {
+    valMapTokens_.push_back(consumes<edm::ValueMap<float>>(edm::InputTag(tag)));
+  }
+  // categories
+  for (auto const& tag : mvaCatTags_) {
+    mvaCatTokens_.push_back(consumes<edm::ValueMap<int>>(edm::InputTag(tag)));
+  }
 
-   // Book tree
-   usesResource(TFileService::kSharedResource);
-   edm::Service<TFileService> fs ;
-   tree_  = fs->make<TTree>("tree","tree");
+  // Book tree
+  usesResource(TFileService::kSharedResource);
+  edm::Service<TFileService> fs;
+  tree_ = fs->make<TTree>("tree", "tree");
 
-   tree_->Branch("nEvent",  &nEvent_);
-   tree_->Branch("nRun",    &nRun_);
-   tree_->Branch("nLumi",   &nLumi_);
-   if (isMC_) tree_->Branch("genNpu", &genNpu_);
-   tree_->Branch("vtxN",   &vtxN_);
+  tree_->Branch("nEvent", &nEvent_);
+  tree_->Branch("nRun", &nRun_);
+  tree_->Branch("nLumi", &nLumi_);
+  if (isMC_)
+    tree_->Branch("genNpu", &genNpu_);
+  tree_->Branch("vtxN", &vtxN_);
 
-   tree_->Branch("ele_q",&eleQ_);
-   tree_->Branch("ele_3q",&ele3Q_);
+  tree_->Branch("ele_q", &eleQ_);
+  tree_->Branch("ele_3q", &ele3Q_);
 
-   if (doEnergyMatrix_) tree_->Branch("energyMatrix",&energyMatrix_);
+  if (doEnergyMatrix_)
+    tree_->Branch("energyMatrix", &energyMatrix_);
 
-   if (isMC_) tree_->Branch("matchedToGenEle",   &matchedToGenEle_);
+  if (isMC_)
+    tree_->Branch("matchedToGenEle", &matchedToGenEle_);
 
-   for (int i = 0; i < nVars_; ++i) tree_->Branch(mvaVarMngr_.getName(i).c_str(), &vars_[i]);
+  for (int i = 0; i < nVars_; ++i)
+    tree_->Branch(mvaVarMngr_.getName(i).c_str(), &vars_[i]);
 
-   tree_->Branch("ele_isEB",&eleIsEB_);
-   tree_->Branch("ele_isEE",&eleIsEE_);
-   tree_->Branch("ele_isEBEtaGap",&eleIsEBEtaGap_);
-   tree_->Branch("ele_isEBPhiGap",&eleIsEBPhiGap_);
-   tree_->Branch("ele_isEBEEGap", &eleIsEBEEGap_);
-   tree_->Branch("ele_isEEDeeGap",&eleIsEEDeeGap_);
-   tree_->Branch("ele_isEERingGap",&eleIsEERingGap_);
+  tree_->Branch("ele_isEB", &eleIsEB_);
+  tree_->Branch("ele_isEE", &eleIsEE_);
+  tree_->Branch("ele_isEBEtaGap", &eleIsEBEtaGap_);
+  tree_->Branch("ele_isEBPhiGap", &eleIsEBPhiGap_);
+  tree_->Branch("ele_isEBEEGap", &eleIsEBEEGap_);
+  tree_->Branch("ele_isEEDeeGap", &eleIsEEDeeGap_);
+  tree_->Branch("ele_isEERingGap", &eleIsEERingGap_);
 
-   // IDs
-   for (size_t k = 0; k < nValMaps_; ++k) {
-       tree_->Branch(valMapBranchNames_[k].c_str() ,  &mvaValues_[k]);
-   }
+  // IDs
+  for (size_t k = 0; k < nValMaps_; ++k) {
+    tree_->Branch(valMapBranchNames_[k].c_str(), &mvaValues_[k]);
+  }
 
-   for (size_t k = 0; k < nEleMaps_; ++k) {
-       tree_->Branch(eleMapBranchNames_[k].c_str() ,  &mvaPasses_[k]);
-   }
+  for (size_t k = 0; k < nEleMaps_; ++k) {
+    tree_->Branch(eleMapBranchNames_[k].c_str(), &mvaPasses_[k]);
+  }
 
-   for (size_t k = 0; k < nCats_; ++k) {
-       tree_->Branch(mvaCatBranchNames_[k].c_str() ,  &mvaCats_[k]);
-   }
+  for (size_t k = 0; k < nCats_; ++k) {
+    tree_->Branch(mvaCatBranchNames_[k].c_str(), &mvaCats_[k]);
+  }
 }
 
-
 // ------------ method called for each event  ------------
-void
-ElectronMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    // Fill global event info
-    nEvent_ = iEvent.id().event();
-    nRun_   = iEvent.id().run();
-    nLumi_  = iEvent.luminosityBlock();
+void ElectronMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // Fill global event info
+  nEvent_ = iEvent.id().event();
+  nRun_ = iEvent.id().run();
+  nLumi_ = iEvent.luminosityBlock();
 
-    // Get Handles
-    auto src      = iEvent.getHandle(src_);
-    auto vertices = iEvent.getHandle(vertices_);
+  // Get Handles
+  auto src = iEvent.getHandle(src_);
+  auto vertices = iEvent.getHandle(vertices_);
 
-    // initialize cluster tools
-    std::unique_ptr<noZS::EcalClusterLazyTools> lazyTools;
-    if(doEnergyMatrix_) {
-        // Configure Lazy Tools, which will compute 5x5 quantities
-        lazyTools = std::make_unique<noZS::EcalClusterLazyTools>(iEvent, iSetup, ebRecHits_, eeRecHits_);
+  // initialize cluster tools
+  std::unique_ptr<noZS::EcalClusterLazyTools> lazyTools;
+  if (doEnergyMatrix_) {
+    // Configure Lazy Tools, which will compute 5x5 quantities
+    lazyTools = std::make_unique<noZS::EcalClusterLazyTools>(iEvent, iSetup, ebRecHits_, eeRecHits_);
+  }
+
+  // Get MC only Handles, which are allowed to be non-valid
+  auto genParticles = iEvent.getHandle(genParticles_);
+  auto pileup = iEvent.getHandle(pileup_);
+
+  vtxN_ = vertices->size();
+
+  // Fill with true number of pileup
+  if (isMC_) {
+    for (const auto& pu : *pileup) {
+      int bx = pu.getBunchCrossing();
+      if (bx == 0) {
+        genNpu_ = pu.getPU_NumInteractions();
+        break;
+      }
+    }
+  }
+
+  // Get MVA decisions
+  edm::Handle<edm::ValueMap<bool>> decisions[nEleMaps_];
+  for (size_t k = 0; k < nEleMaps_; ++k) {
+    iEvent.getByToken(eleMapTokens_[k], decisions[k]);
+  }
+
+  // Get MVA values
+  edm::Handle<edm::ValueMap<float>> values[nValMaps_];
+  for (size_t k = 0; k < nValMaps_; ++k) {
+    iEvent.getByToken(valMapTokens_[k], values[k]);
+  }
+
+  // Get MVA categories
+  edm::Handle<edm::ValueMap<int>> mvaCats[nCats_];
+  for (size_t k = 0; k < nCats_; ++k) {
+    iEvent.getByToken(mvaCatTokens_[k], mvaCats[k]);
+  }
+
+  std::vector<float> extraVariables = variableHelper_.getAuxVariables(iEvent);
+
+  for (auto const& ele : src->ptrs()) {
+    if (ele->pt() < ptThreshold_)
+      continue;
+
+    // Fill the energy matrix around the seed
+    if (doEnergyMatrix_) {
+      const auto& seed = *(ele->superCluster()->seed());
+      energyMatrix_ = lazyTools->energyMatrix(seed, energyMatrixSize_);
     }
 
-    // Get MC only Handles, which are allowed to be non-valid
-    auto genParticles = iEvent.getHandle(genParticles_);
-    auto pileup       = iEvent.getHandle(pileup_);
+    // Fill various tree variable
+    eleQ_ = ele->charge();
+    ele3Q_ = ele->chargeInfo().isGsfCtfScPixConsistent;
 
-    vtxN_ = vertices->size();
-
-    // Fill with true number of pileup
-    if(isMC_) {
-       for(const auto& pu : *pileup)
-       {
-           int bx = pu.getBunchCrossing();
-           if(bx == 0)
-           {
-               genNpu_ = pu.getPU_NumInteractions();
-               break;
-           }
-       }
+    for (int iVar = 0; iVar < nVars_; ++iVar) {
+      vars_[iVar] = mvaVarMngr_.getValue(iVar, *ele, extraVariables);
     }
 
-    // Get MVA decisions
-    edm::Handle<edm::ValueMap<bool> > decisions[nEleMaps_];
-    for (size_t k = 0; k < nEleMaps_; ++k) {
-        iEvent.getByToken(eleMapTokens_[k],decisions[k]);
+    if (isMC_) {
+      matchedToGenEle_ = matchToTruth(*ele, *genParticles);
     }
 
-    // Get MVA values
-    edm::Handle<edm::ValueMap<float> > values[nValMaps_];
-    for (size_t k = 0; k < nValMaps_; ++k) {
-        iEvent.getByToken(valMapTokens_[k],values[k]);
-    }
+    // gap variables
+    eleIsEB_ = ele->isEB();
+    eleIsEE_ = ele->isEE();
+    eleIsEBEEGap_ = ele->isEBEEGap();
+    eleIsEBEtaGap_ = ele->isEBEtaGap();
+    eleIsEBPhiGap_ = ele->isEBPhiGap();
+    eleIsEEDeeGap_ = ele->isEEDeeGap();
+    eleIsEERingGap_ = ele->isEERingGap();
 
-    // Get MVA categories
-    edm::Handle<edm::ValueMap<int> > mvaCats[nCats_];
-    for (size_t k = 0; k < nCats_; ++k) {
-        iEvent.getByToken(mvaCatTokens_[k],mvaCats[k]);
-    }
+    //
+    // Look up and save the ID decisions
+    //
+    for (size_t k = 0; k < nEleMaps_; ++k)
+      mvaPasses_[k] = static_cast<int>((*decisions[k])[ele]);
+    for (size_t k = 0; k < nValMaps_; ++k)
+      mvaValues_[k] = (*values[k])[ele];
+    for (size_t k = 0; k < nCats_; ++k)
+      mvaCats_[k] = (*mvaCats[k])[ele];
 
-    std::vector<float> extraVariables = variableHelper_.getAuxVariables(iEvent);
-
-    for(auto const& ele : src->ptrs())
-    {
-        if (ele->pt() < ptThreshold_) continue;
-
-        // Fill the energy matrix around the seed
-        if(doEnergyMatrix_) {
-            const auto& seed = *(ele->superCluster()->seed());
-            energyMatrix_ = lazyTools->energyMatrix(seed, energyMatrixSize_);
-        }
-
-        // Fill various tree variable
-        eleQ_ = ele->charge();
-        ele3Q_ = ele->chargeInfo().isGsfCtfScPixConsistent;
-
-        for (int iVar = 0; iVar < nVars_; ++iVar) {
-            vars_[iVar] = mvaVarMngr_.getValue(iVar, *ele, extraVariables);
-        }
-
-        if (isMC_) {
-            matchedToGenEle_ = matchToTruth( *ele, *genParticles);
-        }
-
-        // gap variables
-        eleIsEB_ = ele->isEB();
-        eleIsEE_ = ele->isEE();
-        eleIsEBEEGap_ = ele->isEBEEGap();
-        eleIsEBEtaGap_ = ele->isEBEtaGap();
-        eleIsEBPhiGap_ = ele->isEBPhiGap();
-        eleIsEEDeeGap_ = ele->isEEDeeGap();
-        eleIsEERingGap_ = ele->isEERingGap();
-
-        //
-        // Look up and save the ID decisions
-        //
-        for (size_t k = 0; k < nEleMaps_; ++k) mvaPasses_[k] = static_cast<int>((*decisions[k])[ele]);
-        for (size_t k = 0; k < nValMaps_; ++k) mvaValues_[k] = (*values[k])[ele];
-        for (size_t k = 0; k < nCats_   ; ++k) mvaCats_[k]   = (*mvaCats[k])[ele];
-
-        tree_->Fill();
-    }
-
+    tree_->Fill();
+  }
 }
 
 int ElectronMVANtuplizer::matchToTruth(reco::GsfElectron const& electron,
-                                       edm::View<reco::GenParticle> const& genParticles) const
-{
+                                       edm::View<reco::GenParticle> const& genParticles) const {
   //
   // Explicit loop and geometric matching method (advised by Josh Bendavid)
   //
@@ -345,53 +342,53 @@ int ElectronMVANtuplizer::matchToTruth(reco::GsfElectron const& electron,
   // Find the closest status 1 gen electron to the reco electron
   double dR = 999;
   reco::GenParticle const* closestElectron = nullptr;
-  for(auto const& particle : genParticles) {
+  for (auto const& particle : genParticles) {
     // Drop everything that is not electron or not status 1
-    if( std::abs(particle.pdgId()) != 11 || particle.status() != 1 )
+    if (std::abs(particle.pdgId()) != 11 || particle.status() != 1)
       continue;
     //
-    double dRtmp = ROOT::Math::VectorUtil::DeltaR( electron.p4(), particle.p4() );
-    if( dRtmp < dR ){
+    double dRtmp = ROOT::Math::VectorUtil::DeltaR(electron.p4(), particle.p4());
+    if (dRtmp < dR) {
       dR = dRtmp;
       closestElectron = &particle;
     }
   }
   // See if the closest electron is close enough. If not, no match found.
-  if( closestElectron == nullptr || dR >= deltaR_ ) return UNMATCHED;
+  if (closestElectron == nullptr || dR >= deltaR_)
+    return UNMATCHED;
 
-  if( closestElectron->fromHardProcessFinalState() ) return TRUE_PROMPT_ELECTRON;
+  if (closestElectron->fromHardProcessFinalState())
+    return TRUE_PROMPT_ELECTRON;
 
-  if( closestElectron->isDirectHardProcessTauDecayProductFinalState() ) return TRUE_ELECTRON_FROM_TAU;
+  if (closestElectron->isDirectHardProcessTauDecayProductFinalState())
+    return TRUE_ELECTRON_FROM_TAU;
 
   // What remains is true non-prompt electrons
   return TRUE_NON_PROMPT_ELECTRON;
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-ElectronMVANtuplizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
-    edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("src",          edm::InputTag("slimmedElectrons"));
-    desc.add<edm::InputTag>("vertices",     edm::InputTag("offlineSlimmedPrimaryVertices"));
-    desc.add<edm::InputTag>("pileup",       edm::InputTag("slimmedAddPileupInfo"));
-    desc.add<edm::InputTag>("genParticles", edm::InputTag("prunedGenParticles"));
-    desc.add<edm::InputTag>("ebReducedRecHitCollection", edm::InputTag("reducedEgamma","reducedEBRecHits"));
-    desc.add<edm::InputTag>("eeReducedRecHitCollection", edm::InputTag("reducedEgamma","reducedEERecHits"));
-    desc.add<std::string>("variableDefinition");
-    desc.add<bool>("doEnergyMatrix", false);
-    desc.add<int>("energyMatrixSize", 2)->setComment("extension of crystals in each direction away from the seed");
-    desc.add<bool>("isMC", true);
-    desc.add<double>("deltaR", 0.1);
-    desc.add<double>("ptThreshold", 5.0);
-    desc.add<std::vector<std::string>>("eleMVAs", {});
-    desc.add<std::vector<std::string>>("eleMVALabels", {});
-    desc.add<std::vector<std::string>>("eleMVAValMaps", {});
-    desc.add<std::vector<std::string>>("eleMVAValMapLabels", {});
-    desc.add<std::vector<std::string>>("eleMVACats", {});
-    desc.add<std::vector<std::string>>("eleMVACatLabels", {});
-    descriptions.addDefault(desc);
-
+void ElectronMVANtuplizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("slimmedElectrons"));
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
+  desc.add<edm::InputTag>("pileup", edm::InputTag("slimmedAddPileupInfo"));
+  desc.add<edm::InputTag>("genParticles", edm::InputTag("prunedGenParticles"));
+  desc.add<edm::InputTag>("ebReducedRecHitCollection", edm::InputTag("reducedEgamma", "reducedEBRecHits"));
+  desc.add<edm::InputTag>("eeReducedRecHitCollection", edm::InputTag("reducedEgamma", "reducedEERecHits"));
+  desc.add<std::string>("variableDefinition");
+  desc.add<bool>("doEnergyMatrix", false);
+  desc.add<int>("energyMatrixSize", 2)->setComment("extension of crystals in each direction away from the seed");
+  desc.add<bool>("isMC", true);
+  desc.add<double>("deltaR", 0.1);
+  desc.add<double>("ptThreshold", 5.0);
+  desc.add<std::vector<std::string>>("eleMVAs", {});
+  desc.add<std::vector<std::string>>("eleMVALabels", {});
+  desc.add<std::vector<std::string>>("eleMVAValMaps", {});
+  desc.add<std::vector<std::string>>("eleMVAValMapLabels", {});
+  desc.add<std::vector<std::string>>("eleMVACats", {});
+  desc.add<std::vector<std::string>>("eleMVACatLabels", {});
+  descriptions.addDefault(desc);
 }
 
 //define this as a plug-in

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleCalPFClusterIsoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleCalPFClusterIsoCut.cc
@@ -2,14 +2,12 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
 
-
 class GsfEleCalPFClusterIsoCut : public CutApplicatorWithEventContentBase {
 public:
-
-  enum IsoType {UNDEF=-1, ISO_ECAL=0, ISO_HCAL=1};
+  enum IsoType { UNDEF = -1, ISO_ECAL = 0, ISO_HCAL = 1 };
 
   GsfEleCalPFClusterIsoCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -17,129 +15,117 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   // Cut values
-  const float isoCutEBLowPt_,isoCutEBHighPt_,isoCutEELowPt_,isoCutEEHighPt_;
+  const float isoCutEBLowPt_, isoCutEBHighPt_, isoCutEELowPt_, isoCutEEHighPt_;
   // Configuration
-  const int     isoType_;
-  const float   ptCutOff_;
-  const float   barrelCutOff_;
-  bool          isRelativeIso_;
+  const int isoType_;
+  const float ptCutOff_;
+  const float barrelCutOff_;
+  bool isRelativeIso_;
   // Effective area constants
   EffectiveAreas effectiveAreas_;
   // The rho
-  edm::Handle< double > rhoHandle_;
+  edm::Handle<double> rhoHandle_;
 
-  constexpr static char rhoString_     [] = "rho";
+  constexpr static char rhoString_[] = "rho";
 };
 
 constexpr char GsfEleCalPFClusterIsoCut::rhoString_[];
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleCalPFClusterIsoCut,
-		  "GsfEleCalPFClusterIsoCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleCalPFClusterIsoCut, "GsfEleCalPFClusterIsoCut");
 
-GsfEleCalPFClusterIsoCut::GsfEleCalPFClusterIsoCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  isoCutEBLowPt_(c.getParameter<double>("isoCutEBLowPt")),
-  isoCutEBHighPt_(c.getParameter<double>("isoCutEBHighPt")),
-  isoCutEELowPt_(c.getParameter<double>("isoCutEELowPt")),
-  isoCutEEHighPt_(c.getParameter<double>("isoCutEEHighPt")),
-  isoType_(c.getParameter<int>("isoType")),
-  ptCutOff_(c.getParameter<double>("ptCutOff")),
-   barrelCutOff_(c.getParameter<double>("barrelCutOff")),
-  isRelativeIso_(c.getParameter<bool>("isRelativeIso")),
-  effectiveAreas_( (c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath())
-{
-  
+GsfEleCalPFClusterIsoCut::GsfEleCalPFClusterIsoCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      isoCutEBLowPt_(c.getParameter<double>("isoCutEBLowPt")),
+      isoCutEBHighPt_(c.getParameter<double>("isoCutEBHighPt")),
+      isoCutEELowPt_(c.getParameter<double>("isoCutEELowPt")),
+      isoCutEEHighPt_(c.getParameter<double>("isoCutEEHighPt")),
+      isoType_(c.getParameter<int>("isoType")),
+      ptCutOff_(c.getParameter<double>("ptCutOff")),
+      barrelCutOff_(c.getParameter<double>("barrelCutOff")),
+      isRelativeIso_(c.getParameter<bool>("isRelativeIso")),
+      effectiveAreas_((c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath()) {
   edm::InputTag rhoTag = c.getParameter<edm::InputTag>("rho");
-  contentTags_.emplace(rhoString_,rhoTag);
-
+  contentTags_.emplace(rhoString_, rhoTag);
 }
 
 void GsfEleCalPFClusterIsoCut::setConsumes(edm::ConsumesCollector& cc) {
-
   auto rho = cc.consumes<double>(contentTags_[rhoString_]);
   contentTokens_.emplace(rhoString_, rho);
 }
 
-void GsfEleCalPFClusterIsoCut::getEventContent(const edm::EventBase& ev) {  
-
-  ev.getByLabel(contentTags_[rhoString_],rhoHandle_);
+void GsfEleCalPFClusterIsoCut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_[rhoString_], rhoHandle_);
 }
 
-CutApplicatorBase::result_type 
-GsfEleCalPFClusterIsoCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-
+CutApplicatorBase::result_type GsfEleCalPFClusterIsoCut::operator()(const reco::GsfElectronPtr& cand) const {
   // Establish the cut value
   double absEta = std::abs(cand->superCluster()->eta());
 
   const pat::Electron* elPat = dynamic_cast<const pat::Electron*>(cand.get());
-  if( !elPat ) {
+  if (!elPat) {
     throw cms::Exception("ERROR: this VID selection is meant to be run on miniAOD/PAT only")
-      << std::endl << "Change input format to PAT/miniAOD or contact Egamma experts" 
-      << std::endl << std::endl;
+        << std::endl
+        << "Change input format to PAT/miniAOD or contact Egamma experts" << std::endl
+        << std::endl;
   }
 
-  const float isoCut =
-    ( cand->pt() < ptCutOff_ ?
-      ( absEta < barrelCutOff_ ? isoCutEBLowPt_ : isoCutEELowPt_ ) 
-      :
-      ( absEta < barrelCutOff_ ? isoCutEBHighPt_ : isoCutEEHighPt_ ) );
+  const float isoCut = (cand->pt() < ptCutOff_ ? (absEta < barrelCutOff_ ? isoCutEBLowPt_ : isoCutEELowPt_)
+                                               : (absEta < barrelCutOff_ ? isoCutEBHighPt_ : isoCutEEHighPt_));
 
-  const float  eA = effectiveAreas_.getEffectiveArea( absEta );
-  const float rho = rhoHandle_.isValid() ? (float)(*rhoHandle_) : 0; // std::max likes float arguments
+  const float eA = effectiveAreas_.getEffectiveArea(absEta);
+  const float rho = rhoHandle_.isValid() ? (float)(*rhoHandle_) : 0;  // std::max likes float arguments
 
   float isoValue = -999;
-  if( isoType_ == ISO_ECAL ){
+  if (isoType_ == ISO_ECAL) {
     isoValue = elPat->ecalPFClusterIso();
-  }else if( isoType_ == ISO_HCAL ){
+  } else if (isoType_ == ISO_HCAL) {
     isoValue = elPat->hcalPFClusterIso();
-  }else{
+  } else {
     throw cms::Exception("ERROR: unknown type requested for PF cluster isolation.")
-      << std::endl << "Check VID configuration." << std::endl;
+        << std::endl
+        << "Check VID configuration." << std::endl;
   }
-  float isoValueCorr = std::max(0.0f, isoValue - rho*eA);
-  
+  float isoValueCorr = std::max(0.0f, isoValue - rho * eA);
+
   // Apply the cut and return the result
   // Scale by pT if the relative isolation is requested but avoid division by 0
-  return isoValueCorr < isoCut*(isRelativeIso_ ? cand->pt() : 1.);
+  return isoValueCorr < isoCut * (isRelativeIso_ ? cand->pt() : 1.);
 }
 
 double GsfEleCalPFClusterIsoCut::value(const reco::CandidatePtr& cand) const {
-
   reco::GsfElectronPtr ele(cand);
   // Establish the cut value
   double absEta = std::abs(ele->superCluster()->eta());
 
-  const pat::Electron *elPat = dynamic_cast<const pat::Electron*>(ele.get());
-  if( !elPat ){
+  const pat::Electron* elPat = dynamic_cast<const pat::Electron*>(ele.get());
+  if (!elPat) {
     throw cms::Exception("ERROR: this VID selection is meant to be run on miniAOD/PAT only")
-      << std::endl << "Change input format to PAT/miniAOD or contact Egamma experts" 
-      << std::endl << std::endl;
+        << std::endl
+        << "Change input format to PAT/miniAOD or contact Egamma experts" << std::endl
+        << std::endl;
   }
 
-  const float  eA = effectiveAreas_.getEffectiveArea( absEta );
-  const float rho = rhoHandle_.isValid() ? (float)(*rhoHandle_) : 0; // std::max likes float arguments
+  const float eA = effectiveAreas_.getEffectiveArea(absEta);
+  const float rho = rhoHandle_.isValid() ? (float)(*rhoHandle_) : 0;  // std::max likes float arguments
 
   float isoValue = -999;
-  if( isoType_ == ISO_ECAL ){
+  if (isoType_ == ISO_ECAL) {
     isoValue = elPat->ecalPFClusterIso();
-  }else if( isoType_ == ISO_HCAL ){
+  } else if (isoType_ == ISO_HCAL) {
     isoValue = elPat->hcalPFClusterIso();
-  }else{
+  } else {
     throw cms::Exception("ERROR: unknown type requested for PF cluster isolation.")
-      << std::endl << "Check VID configuration." << std::endl;
-  } 
-  float isoValueCorr = std::max(0.0f, isoValue - rho*eA);
-  
+        << std::endl
+        << "Check VID configuration." << std::endl;
+  }
+  float isoValueCorr = std::max(0.0f, isoValue - rho * eA);
+
   // Divide by pT if the relative isolation is requested
-  if( isRelativeIso_ )
+  if (isRelativeIso_)
     isoValueCorr /= ele->pt();
 
   // Apply the cut and return the result

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleConversionVetoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleConversionVetoCut.cc
@@ -4,11 +4,10 @@
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
 
-
 class GsfEleConversionVetoCut : public CutApplicatorWithEventContentBase {
 public:
   GsfEleConversionVetoCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -16,70 +15,59 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
-private:  
+private:
   edm::Handle<reco::ConversionCollection> _convs;
   edm::Handle<reco::BeamSpot> _thebs;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleConversionVetoCut,
-		  "GsfEleConversionVetoCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleConversionVetoCut, "GsfEleConversionVetoCut");
 
-GsfEleConversionVetoCut::GsfEleConversionVetoCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c) {
-
+GsfEleConversionVetoCut::GsfEleConversionVetoCut(const edm::ParameterSet& c) : CutApplicatorWithEventContentBase(c) {
   edm::InputTag conversiontag = c.getParameter<edm::InputTag>("conversionSrc");
-  contentTags_.emplace("conversions",conversiontag);
+  contentTags_.emplace("conversions", conversiontag);
 
   edm::InputTag conversiontagMiniAOD = c.getParameter<edm::InputTag>("conversionSrcMiniAOD");
-  contentTags_.emplace("conversionsMiniAOD",conversiontagMiniAOD);
+  contentTags_.emplace("conversionsMiniAOD", conversiontagMiniAOD);
 
   edm::InputTag beamspottag = c.getParameter<edm::InputTag>("beamspotSrc");
-  contentTags_.emplace("beamspot",beamspottag);
+  contentTags_.emplace("beamspot", beamspottag);
 }
 
 void GsfEleConversionVetoCut::setConsumes(edm::ConsumesCollector& cc) {
   auto convs = cc.mayConsume<reco::ConversionCollection>(contentTags_["conversions"]);
   auto convsMiniAOD = cc.mayConsume<reco::ConversionCollection>(contentTags_["conversionsMiniAOD"]);
   auto thebs = cc.consumes<reco::BeamSpot>(contentTags_["beamspot"]);
-  contentTokens_.emplace("conversions",convs);
-  contentTokens_.emplace("conversionsMiniAOD",convsMiniAOD);
-  contentTokens_.emplace("beamspot",thebs);
+  contentTokens_.emplace("conversions", convs);
+  contentTokens_.emplace("conversionsMiniAOD", convsMiniAOD);
+  contentTokens_.emplace("beamspot", thebs);
 }
 
-void GsfEleConversionVetoCut::getEventContent(const edm::EventBase& ev) {    
-
+void GsfEleConversionVetoCut::getEventContent(const edm::EventBase& ev) {
   // First try AOD, then go to miniAOD. Use the same Handle since collection class is the same.
-  ev.getByLabel(contentTags_["conversions"],_convs);
+  ev.getByLabel(contentTags_["conversions"], _convs);
   if (!_convs.isValid())
-    ev.getByLabel(contentTags_["conversionsMiniAOD"],_convs);
+    ev.getByLabel(contentTags_["conversionsMiniAOD"], _convs);
 
-  ev.getByLabel(contentTags_["beamspot"],_thebs);  
+  ev.getByLabel(contentTags_["beamspot"], _thebs);
 }
 
-CutApplicatorBase::result_type 
-GsfEleConversionVetoCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-  if( _thebs.isValid() && _convs.isValid() ) {
+CutApplicatorBase::result_type GsfEleConversionVetoCut::operator()(const reco::GsfElectronPtr& cand) const {
+  if (_thebs.isValid() && _convs.isValid()) {
     return !ConversionTools::hasMatchedConversion(*cand, *_convs, _thebs->position());
   } else {
-    edm::LogWarning("GsfEleConversionVetoCut")
-      << "Couldn't find a necessary collection, returning true!";
+    edm::LogWarning("GsfEleConversionVetoCut") << "Couldn't find a necessary collection, returning true!";
   }
   return true;
 }
 
 double GsfEleConversionVetoCut::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
-  if( _thebs.isValid() && _convs.isValid() ) {
+  if (_thebs.isValid() && _convs.isValid()) {
     return !ConversionTools::hasMatchedConversion(*ele, *_convs, _thebs->position());
   } else {
-    edm::LogWarning("GsfEleConversionVetoCut")
-      << "Couldn't find a necessary collection, returning true!";
+    edm::LogWarning("GsfEleConversionVetoCut") << "Couldn't find a necessary collection, returning true!";
     return true;
   }
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDEtaInCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDEtaInCut.cc
@@ -3,35 +3,27 @@
 
 class GsfEleDEtaInCut : public CutApplicatorBase {
 public:
-  GsfEleDEtaInCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _dEtaInCutValueEB(c.getParameter<double>("dEtaInCutValueEB")),
-    _dEtaInCutValueEE(c.getParameter<double>("dEtaInCutValueEE")),
-    _barrelCutOff(c.getParameter<double>("barrelCutOff")){    
-  }
-  
+  GsfEleDEtaInCut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+        _dEtaInCutValueEB(c.getParameter<double>("dEtaInCutValueEB")),
+        _dEtaInCutValueEE(c.getParameter<double>("dEtaInCutValueEE")),
+        _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-  const double _dEtaInCutValueEB,_dEtaInCutValueEE,_barrelCutOff;
+  const double _dEtaInCutValueEB, _dEtaInCutValueEE, _barrelCutOff;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleDEtaInCut,
-		  "GsfEleDEtaInCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleDEtaInCut, "GsfEleDEtaInCut");
 
-CutApplicatorBase::result_type 
-GsfEleDEtaInCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-  const float dEtaInCutValue = 
-    ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? 
-      _dEtaInCutValueEB : _dEtaInCutValueEE );
+CutApplicatorBase::result_type GsfEleDEtaInCut::operator()(const reco::GsfElectronPtr& cand) const {
+  const float dEtaInCutValue =
+      (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _dEtaInCutValueEB : _dEtaInCutValueEE);
   return std::abs(cand->deltaEtaSuperClusterTrackAtVtx()) < dEtaInCutValue;
 }
 

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDEtaInLinearCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDEtaInLinearCut.cc
@@ -4,21 +4,17 @@
 
 class GsfEleDEtaInLinearCut : public CutApplicatorBase {
 public:
-  GsfEleDEtaInLinearCut(const edm::ParameterSet& param) :
-    CutApplicatorBase(param),
-    slopeTerm_(param,"slopeTerm"),
-    constTerm_(param,"constTerm"),
-    minValue_(param,"minValue")
-  {
-  }
-  
+  GsfEleDEtaInLinearCut(const edm::ParameterSet& param)
+      : CutApplicatorBase(param),
+        slopeTerm_(param, "slopeTerm"),
+        constTerm_(param, "constTerm"),
+        minValue_(param, "minValue") {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   const EBEECutValues slopeTerm_;
@@ -26,18 +22,12 @@ private:
   const EBEECutValues minValue_;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleDEtaInLinearCut,
-		  "GsfEleDEtaInLinearCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleDEtaInLinearCut, "GsfEleDEtaInLinearCut");
 
-CutApplicatorBase::result_type 
-GsfEleDEtaInLinearCut::
-operator()(const reco::GsfElectronPtr& cand) const
-{  
-  float et = cand->energy()!=0. ? cand->et()/cand->energy()*cand->caloEnergy() : 0.;
-  double cutValue = std::max(constTerm_(cand)+slopeTerm_(cand)*et,minValue_(cand));
-  return std::abs(cand->deltaEtaSuperClusterTrackAtVtx())<cutValue;
- 
+CutApplicatorBase::result_type GsfEleDEtaInLinearCut::operator()(const reco::GsfElectronPtr& cand) const {
+  float et = cand->energy() != 0. ? cand->et() / cand->energy() * cand->caloEnergy() : 0.;
+  double cutValue = std::max(constTerm_(cand) + slopeTerm_(cand) * et, minValue_(cand));
+  return std::abs(cand->deltaEtaSuperClusterTrackAtVtx()) < cutValue;
 }
 
 double GsfEleDEtaInLinearCut::value(const reco::CandidatePtr& cand) const {

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDEtaInSeedCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDEtaInSeedCut.cc
@@ -3,46 +3,39 @@
 
 class GsfEleDEtaInSeedCut : public CutApplicatorBase {
 public:
-  GsfEleDEtaInSeedCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _dEtaInSeedCutValueEB(c.getParameter<double>("dEtaInSeedCutValueEB")),
-    _dEtaInSeedCutValueEE(c.getParameter<double>("dEtaInSeedCutValueEE")),
-    _barrelCutOff(c.getParameter<double>("barrelCutOff")){    
-  }
-  
+  GsfEleDEtaInSeedCut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+        _dEtaInSeedCutValueEB(c.getParameter<double>("dEtaInSeedCutValueEB")),
+        _dEtaInSeedCutValueEE(c.getParameter<double>("dEtaInSeedCutValueEE")),
+        _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-  const double _dEtaInSeedCutValueEB,_dEtaInSeedCutValueEE,_barrelCutOff;
+  const double _dEtaInSeedCutValueEB, _dEtaInSeedCutValueEE, _barrelCutOff;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleDEtaInSeedCut,
-		  "GsfEleDEtaInSeedCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleDEtaInSeedCut, "GsfEleDEtaInSeedCut");
 
 //a little temporary 72X fix
-float dEtaInSeed(const reco::GsfElectronPtr& ele){
-  return ele->superCluster().isNonnull() && ele->superCluster()->seed().isNonnull() ? 
-    ele->deltaEtaSuperClusterTrackAtVtx() - ele->superCluster()->eta() + ele->superCluster()->seed()->eta() : std::numeric_limits<float>::max();
+float dEtaInSeed(const reco::GsfElectronPtr& ele) {
+  return ele->superCluster().isNonnull() && ele->superCluster()->seed().isNonnull()
+             ? ele->deltaEtaSuperClusterTrackAtVtx() - ele->superCluster()->eta() + ele->superCluster()->seed()->eta()
+             : std::numeric_limits<float>::max();
 }
 
-CutApplicatorBase::result_type 
-GsfEleDEtaInSeedCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-  const float dEtaInSeedCutValue = 
-    ( std::abs(cand->superCluster()->eta()) < _barrelCutOff ? 
-      _dEtaInSeedCutValueEB : _dEtaInSeedCutValueEE );
+CutApplicatorBase::result_type GsfEleDEtaInSeedCut::operator()(const reco::GsfElectronPtr& cand) const {
+  const float dEtaInSeedCutValue =
+      (std::abs(cand->superCluster()->eta()) < _barrelCutOff ? _dEtaInSeedCutValueEB : _dEtaInSeedCutValueEE);
   // return std::abs(cand->deltaEtaSeedClusterTrackAtVtx()) < dEtaInSeedCutValue;
-  return std::abs(dEtaInSeed(cand))<dEtaInSeedCutValue;
+  return std::abs(dEtaInSeed(cand)) < dEtaInSeedCutValue;
 }
 
 double GsfEleDEtaInSeedCut::value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+  reco::GsfElectronPtr ele(cand);
   return std::abs(dEtaInSeed(ele));
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDPhiInCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDPhiInCut.cc
@@ -4,35 +4,27 @@
 
 class GsfEleDPhiInCut : public CutApplicatorBase {
 public:
-  GsfEleDPhiInCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _dPhiInCutValueEB(c.getParameter<double>("dPhiInCutValueEB")),
-    _dPhiInCutValueEE(c.getParameter<double>("dPhiInCutValueEE")),
-    _barrelCutOff(c.getParameter<double>("barrelCutOff")) {    
-  }
-  
+  GsfEleDPhiInCut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+        _dPhiInCutValueEB(c.getParameter<double>("dPhiInCutValueEB")),
+        _dPhiInCutValueEE(c.getParameter<double>("dPhiInCutValueEE")),
+        _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   const double _dPhiInCutValueEB, _dPhiInCutValueEE, _barrelCutOff;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleDPhiInCut,
-		  "GsfEleDPhiInCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleDPhiInCut, "GsfEleDPhiInCut");
 
-CutApplicatorBase::result_type 
-GsfEleDPhiInCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-  const float dPhiInCutValue = 
-    ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? 
-      _dPhiInCutValueEB : _dPhiInCutValueEE );
+CutApplicatorBase::result_type GsfEleDPhiInCut::operator()(const reco::GsfElectronPtr& cand) const {
+  const float dPhiInCutValue =
+      (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _dPhiInCutValueEB : _dPhiInCutValueEE);
   return std::abs(cand->deltaPhiSuperClusterTrackAtVtx()) < dPhiInCutValue;
 }
 

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDeltaBetaIsoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDeltaBetaIsoCut.cc
@@ -4,11 +4,10 @@
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
 
-
 class GsfEleDeltaBetaIsoCut : public CutApplicatorWithEventContentBase {
 public:
   GsfEleDeltaBetaIsoCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -16,157 +15,137 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-  const float _isoCutEBLowPt,_isoCutEBHighPt,_isoCutEELowPt,_isoCutEEHighPt;
-  const float _deltaBetaConstant,_ptCutOff,_barrelCutOff;
+  const float _isoCutEBLowPt, _isoCutEBHighPt, _isoCutEELowPt, _isoCutEEHighPt;
+  const float _deltaBetaConstant, _ptCutOff, _barrelCutOff;
   bool _relativeIso;
-  edm::Handle<edm::ValueMap<float> > _chad_iso,_nhad_iso,_ph_iso,_PUchad_iso;
+  edm::Handle<edm::ValueMap<float> > _chad_iso, _nhad_iso, _ph_iso, _PUchad_iso;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleDeltaBetaIsoCut,
-		  "GsfEleDeltaBetaIsoCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleDeltaBetaIsoCut, "GsfEleDeltaBetaIsoCut");
 
-GsfEleDeltaBetaIsoCut::GsfEleDeltaBetaIsoCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  _isoCutEBLowPt(c.getParameter<double>("isoCutEBLowPt")),
-  _isoCutEBHighPt(c.getParameter<double>("isoCutEBHighPt")),
-  _isoCutEELowPt(c.getParameter<double>("isoCutEELowPt")),
-  _isoCutEEHighPt(c.getParameter<double>("isoCutEEHighPt")),
-  _deltaBetaConstant(c.getParameter<double>("deltaBetaConstant")),
-  _ptCutOff(c.getParameter<double>("ptCutOff")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")),
-  _relativeIso(c.getParameter<bool>("isRelativeIso")) {  
+GsfEleDeltaBetaIsoCut::GsfEleDeltaBetaIsoCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      _isoCutEBLowPt(c.getParameter<double>("isoCutEBLowPt")),
+      _isoCutEBHighPt(c.getParameter<double>("isoCutEBHighPt")),
+      _isoCutEELowPt(c.getParameter<double>("isoCutEELowPt")),
+      _isoCutEEHighPt(c.getParameter<double>("isoCutEEHighPt")),
+      _deltaBetaConstant(c.getParameter<double>("deltaBetaConstant")),
+      _ptCutOff(c.getParameter<double>("ptCutOff")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")),
+      _relativeIso(c.getParameter<bool>("isRelativeIso")) {
   edm::InputTag chadtag = c.getParameter<edm::InputTag>("chargedHadronIsoDR03Src");
   edm::InputTag nhadtag = c.getParameter<edm::InputTag>("neutralHadronIsoDR03Src");
   edm::InputTag phtag = c.getParameter<edm::InputTag>("photonIsoDR03Src");
   edm::InputTag PUchadtag = c.getParameter<edm::InputTag>("puChargedHadronIsoDR03Src");
-  contentTags_.emplace("chad",chadtag);
-  contentTags_.emplace("nhad",nhadtag);
-  contentTags_.emplace("pho",phtag);
-  contentTags_.emplace("puchad",PUchadtag);
+  contentTags_.emplace("chad", chadtag);
+  contentTags_.emplace("nhad", nhadtag);
+  contentTags_.emplace("pho", phtag);
+  contentTags_.emplace("puchad", PUchadtag);
 }
 
 void GsfEleDeltaBetaIsoCut::setConsumes(edm::ConsumesCollector& cc) {
-  auto chad = 
-    cc.consumes<edm::ValueMap<float> >(contentTags_["chad"]);
-  contentTokens_.emplace("chad",chad);
-  auto nhad = 
-    cc.consumes<edm::ValueMap<float> >(contentTags_["nhad"]);
-  contentTokens_.emplace("nhad",nhad);
-  auto pho = 
-    cc.consumes<edm::ValueMap<float> >(contentTags_["pho"]);
-  contentTokens_.emplace("pho",pho);
-  auto puchad = 
-    cc.consumes<edm::ValueMap<float> >(contentTags_["puchad"]);
-  contentTokens_.emplace("puchad",puchad);
+  auto chad = cc.consumes<edm::ValueMap<float> >(contentTags_["chad"]);
+  contentTokens_.emplace("chad", chad);
+  auto nhad = cc.consumes<edm::ValueMap<float> >(contentTags_["nhad"]);
+  contentTokens_.emplace("nhad", nhad);
+  auto pho = cc.consumes<edm::ValueMap<float> >(contentTags_["pho"]);
+  contentTokens_.emplace("pho", pho);
+  auto puchad = cc.consumes<edm::ValueMap<float> >(contentTags_["puchad"]);
+  contentTokens_.emplace("puchad", puchad);
 }
 
-void GsfEleDeltaBetaIsoCut::getEventContent(const edm::EventBase& ev) {  
-  ev.getByLabel(contentTags_["chad"],_chad_iso);
-  ev.getByLabel(contentTags_["nhad"],_nhad_iso);
-  ev.getByLabel(contentTags_["pho"],_ph_iso);
-  ev.getByLabel(contentTags_["puchad"],_PUchad_iso);
+void GsfEleDeltaBetaIsoCut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_["chad"], _chad_iso);
+  ev.getByLabel(contentTags_["nhad"], _nhad_iso);
+  ev.getByLabel(contentTags_["pho"], _ph_iso);
+  ev.getByLabel(contentTags_["puchad"], _PUchad_iso);
 }
 
-CutApplicatorBase::result_type 
-GsfEleDeltaBetaIsoCut::
-operator()(const reco::GsfElectronPtr& cand) const{ 
-  const float isoCut = 
-    ( cand->p4().pt() < _ptCutOff ? 
-      ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ?
-	_isoCutEBLowPt : _isoCutEELowPt ) :
-      ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ?
-	_isoCutEBHighPt : _isoCutEEHighPt ) );
-  const reco::GsfElectron::PflowIsolationVariables& pfIso =
-    cand->pfIsolationVariables();
+CutApplicatorBase::result_type GsfEleDeltaBetaIsoCut::operator()(const reco::GsfElectronPtr& cand) const {
+  const float isoCut =
+      (cand->p4().pt() < _ptCutOff
+           ? (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _isoCutEBLowPt : _isoCutEELowPt)
+           : (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _isoCutEBHighPt : _isoCutEEHighPt));
+  const reco::GsfElectron::PflowIsolationVariables& pfIso = cand->pfIsolationVariables();
 
-  float chad_val   = 0.0;
-  float nhad_val   = 0.0;
-  float pho_val    = 0.0;
+  float chad_val = 0.0;
+  float nhad_val = 0.0;
+  float pho_val = 0.0;
   float puchad_val = 0.0;
 
-  if( _chad_iso.isValid()   && _chad_iso->contains( cand.id() )   &&
-      _nhad_iso.isValid()   && _nhad_iso->contains( cand.id() )   && 
-      _ph_iso.isValid()     && _ph_iso->contains( cand.id() )     && 
-      _PUchad_iso.isValid() && _PUchad_iso->contains( cand.id() )    ) {
-    chad_val   = (*_chad_iso)[cand];
-    nhad_val   = (*_nhad_iso)[cand];
-    pho_val    = (*_ph_iso)[cand];
+  if (_chad_iso.isValid() && _chad_iso->contains(cand.id()) && _nhad_iso.isValid() && _nhad_iso->contains(cand.id()) &&
+      _ph_iso.isValid() && _ph_iso->contains(cand.id()) && _PUchad_iso.isValid() && _PUchad_iso->contains(cand.id())) {
+    chad_val = (*_chad_iso)[cand];
+    nhad_val = (*_nhad_iso)[cand];
+    pho_val = (*_ph_iso)[cand];
     puchad_val = (*_PUchad_iso)[cand];
-  } else if ( _chad_iso.isValid()   && _chad_iso->idSize()   == 1 &&
-              _nhad_iso.isValid()   && _nhad_iso->idSize()   == 1 &&
-              _ph_iso.isValid()     && _ph_iso->idSize()     == 1 &&
-              _PUchad_iso.isValid() && _PUchad_iso->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_chad_iso.isValid() && _chad_iso->idSize() == 1 && _nhad_iso.isValid() && _nhad_iso->idSize() == 1 &&
+             _ph_iso.isValid() && _ph_iso->idSize() == 1 && _PUchad_iso.isValid() && _PUchad_iso->idSize() == 1 &&
+             cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
-    chad_val   = _chad_iso->begin()[cand.key()];
-    nhad_val   = _nhad_iso->begin()[cand.key()];
-    pho_val    = _ph_iso->begin()[cand.key()];
+    chad_val = _chad_iso->begin()[cand.key()];
+    nhad_val = _nhad_iso->begin()[cand.key()];
+    pho_val = _ph_iso->begin()[cand.key()];
     puchad_val = _PUchad_iso->begin()[cand.key()];
-  } else if ( _chad_iso.isValid()   && _nhad_iso.isValid()   && 
-              _ph_iso.isValid()     && _PUchad_iso.isValid()    ){ // throw an exception
-    chad_val   = (*_chad_iso)[cand];
-    nhad_val   = (*_nhad_iso)[cand];
-    pho_val    = (*_ph_iso)[cand];
+  } else if (_chad_iso.isValid() && _nhad_iso.isValid() && _ph_iso.isValid() &&
+             _PUchad_iso.isValid()) {  // throw an exception
+    chad_val = (*_chad_iso)[cand];
+    nhad_val = (*_nhad_iso)[cand];
+    pho_val = (*_ph_iso)[cand];
     puchad_val = (*_PUchad_iso)[cand];
   }
-  
-  const float chad   = _chad_iso.isValid()   ? chad_val   : pfIso.sumChargedHadronPt;
-  const float nhad   = _nhad_iso.isValid()   ? nhad_val   : pfIso.sumNeutralHadronEt;
-  const float pho    = _ph_iso.isValid()     ? pho_val    : pfIso.sumPhotonEt;
+
+  const float chad = _chad_iso.isValid() ? chad_val : pfIso.sumChargedHadronPt;
+  const float nhad = _nhad_iso.isValid() ? nhad_val : pfIso.sumNeutralHadronEt;
+  const float pho = _ph_iso.isValid() ? pho_val : pfIso.sumPhotonEt;
   const float puchad = _PUchad_iso.isValid() ? puchad_val : pfIso.sumPUPt;
-  float iso = chad + std::max(0.0f, nhad + pho - _deltaBetaConstant*puchad);
-  if( _relativeIso ) iso /= cand->p4().pt();
+  float iso = chad + std::max(0.0f, nhad + pho - _deltaBetaConstant * puchad);
+  if (_relativeIso)
+    iso /= cand->p4().pt();
   return iso < isoCut;
 }
 
 double GsfEleDeltaBetaIsoCut::value(const reco::CandidatePtr& cand) const {
   edm::Ptr<reco::GsfElectron> ele(cand);
-  const reco::GsfElectron::PflowIsolationVariables& pfIso =
-    ele->pfIsolationVariables();
-  float chad_val   = 0.0;
-  float nhad_val   = 0.0;
-  float pho_val    = 0.0;
+  const reco::GsfElectron::PflowIsolationVariables& pfIso = ele->pfIsolationVariables();
+  float chad_val = 0.0;
+  float nhad_val = 0.0;
+  float pho_val = 0.0;
   float puchad_val = 0.0;
 
-  if( _chad_iso.isValid()   && _chad_iso->contains( cand.id() )   &&
-      _nhad_iso.isValid()   && _nhad_iso->contains( cand.id() )   &&
-      _ph_iso.isValid()     && _ph_iso->contains( cand.id() )     &&
-      _PUchad_iso.isValid() && _PUchad_iso->contains( cand.id() )    ) {
-    chad_val   = (*_chad_iso)[cand];
-    nhad_val   = (*_nhad_iso)[cand];
-    pho_val    = (*_ph_iso)[cand];
+  if (_chad_iso.isValid() && _chad_iso->contains(cand.id()) && _nhad_iso.isValid() && _nhad_iso->contains(cand.id()) &&
+      _ph_iso.isValid() && _ph_iso->contains(cand.id()) && _PUchad_iso.isValid() && _PUchad_iso->contains(cand.id())) {
+    chad_val = (*_chad_iso)[cand];
+    nhad_val = (*_nhad_iso)[cand];
+    pho_val = (*_ph_iso)[cand];
     puchad_val = (*_PUchad_iso)[cand];
-  } else if ( _chad_iso.isValid()   && _chad_iso->idSize()   == 1 &&
-              _nhad_iso.isValid()   && _nhad_iso->idSize()   == 1 &&
-              _ph_iso.isValid()     && _ph_iso->idSize()     == 1 &&
-              _PUchad_iso.isValid() && _PUchad_iso->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_chad_iso.isValid() && _chad_iso->idSize() == 1 && _nhad_iso.isValid() && _nhad_iso->idSize() == 1 &&
+             _ph_iso.isValid() && _ph_iso->idSize() == 1 && _PUchad_iso.isValid() && _PUchad_iso->idSize() == 1 &&
+             cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
-    chad_val   = _chad_iso->begin()[cand.key()];
-    nhad_val   = _nhad_iso->begin()[cand.key()];
-    pho_val    = _ph_iso->begin()[cand.key()];
+    chad_val = _chad_iso->begin()[cand.key()];
+    nhad_val = _nhad_iso->begin()[cand.key()];
+    pho_val = _ph_iso->begin()[cand.key()];
     puchad_val = _PUchad_iso->begin()[cand.key()];
-  } else if ( _chad_iso.isValid()   && _nhad_iso.isValid()   &&
-              _ph_iso.isValid()     && _PUchad_iso.isValid()    ){ // throw an exception
-    chad_val   = (*_chad_iso)[cand];
-    nhad_val   = (*_nhad_iso)[cand];
-    pho_val    = (*_ph_iso)[cand];
+  } else if (_chad_iso.isValid() && _nhad_iso.isValid() && _ph_iso.isValid() &&
+             _PUchad_iso.isValid()) {  // throw an exception
+    chad_val = (*_chad_iso)[cand];
+    nhad_val = (*_nhad_iso)[cand];
+    pho_val = (*_ph_iso)[cand];
     puchad_val = (*_PUchad_iso)[cand];
   }
-  
-  const float chad   = _chad_iso.isValid()   ? chad_val    : pfIso.sumChargedHadronPt;
-  const float nhad   = _nhad_iso.isValid()   ? nhad_val    : pfIso.sumNeutralHadronEt;
-  const float pho    = _ph_iso.isValid()     ? pho_val     : pfIso.sumPhotonEt;
+
+  const float chad = _chad_iso.isValid() ? chad_val : pfIso.sumChargedHadronPt;
+  const float nhad = _nhad_iso.isValid() ? nhad_val : pfIso.sumNeutralHadronEt;
+  const float pho = _ph_iso.isValid() ? pho_val : pfIso.sumPhotonEt;
   const float puchad = _PUchad_iso.isValid() ? puchad_val : pfIso.sumPUPt;
-  float iso = chad + std::max(0.0f, nhad + pho - _deltaBetaConstant*puchad);
-  if( _relativeIso ) iso /= cand->p4().pt();
+  float iso = chad + std::max(0.0f, nhad + pho - _deltaBetaConstant * puchad);
+  if (_relativeIso)
+    iso /= cand->p4().pt();
   return iso;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDeltaBetaIsoCutStandalone.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDeltaBetaIsoCutStandalone.cc
@@ -4,72 +4,60 @@
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
 
-
 class GsfEleDeltaBetaIsoCutStandalone : public CutApplicatorBase {
 public:
   GsfEleDeltaBetaIsoCutStandalone(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
-  
+
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-  const float _isoCutEBLowPt,_isoCutEBHighPt,_isoCutEELowPt,_isoCutEEHighPt;
-  const float _deltaBetaConstant,_ptCutOff,_barrelCutOff;
+  const float _isoCutEBLowPt, _isoCutEBHighPt, _isoCutEELowPt, _isoCutEEHighPt;
+  const float _deltaBetaConstant, _ptCutOff, _barrelCutOff;
   const bool _relativeIso;
-  
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleDeltaBetaIsoCutStandalone,
-		  "GsfEleDeltaBetaIsoCutStandalone");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleDeltaBetaIsoCutStandalone, "GsfEleDeltaBetaIsoCutStandalone");
 
-GsfEleDeltaBetaIsoCutStandalone::GsfEleDeltaBetaIsoCutStandalone(const edm::ParameterSet& c) :
-  CutApplicatorBase(c),
-  _isoCutEBLowPt(c.getParameter<double>("isoCutEBLowPt")),
-  _isoCutEBHighPt(c.getParameter<double>("isoCutEBHighPt")),
-  _isoCutEELowPt(c.getParameter<double>("isoCutEELowPt")),
-  _isoCutEEHighPt(c.getParameter<double>("isoCutEEHighPt")),
-  _deltaBetaConstant(c.getParameter<double>("deltaBetaConstant")),
-  _ptCutOff(c.getParameter<double>("ptCutOff")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")),
-  _relativeIso(c.getParameter<bool>("isRelativeIso")) {  
-}
+GsfEleDeltaBetaIsoCutStandalone::GsfEleDeltaBetaIsoCutStandalone(const edm::ParameterSet& c)
+    : CutApplicatorBase(c),
+      _isoCutEBLowPt(c.getParameter<double>("isoCutEBLowPt")),
+      _isoCutEBHighPt(c.getParameter<double>("isoCutEBHighPt")),
+      _isoCutEELowPt(c.getParameter<double>("isoCutEELowPt")),
+      _isoCutEEHighPt(c.getParameter<double>("isoCutEEHighPt")),
+      _deltaBetaConstant(c.getParameter<double>("deltaBetaConstant")),
+      _ptCutOff(c.getParameter<double>("ptCutOff")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")),
+      _relativeIso(c.getParameter<bool>("isRelativeIso")) {}
 
-CutApplicatorBase::result_type 
-GsfEleDeltaBetaIsoCutStandalone::
-operator()(const reco::GsfElectronPtr& cand) const{
-  const float isoCut = 
-    ( cand->p4().pt() < _ptCutOff ? 
-      ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ?
-	_isoCutEBLowPt : _isoCutEELowPt ) :
-      ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ?
-	_isoCutEBHighPt : _isoCutEEHighPt ) );
-  const reco::GsfElectron::PflowIsolationVariables& pfIso = 
-    cand->pfIsolationVariables();
+CutApplicatorBase::result_type GsfEleDeltaBetaIsoCutStandalone::operator()(const reco::GsfElectronPtr& cand) const {
+  const float isoCut =
+      (cand->p4().pt() < _ptCutOff
+           ? (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _isoCutEBLowPt : _isoCutEELowPt)
+           : (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _isoCutEBHighPt : _isoCutEEHighPt));
+  const reco::GsfElectron::PflowIsolationVariables& pfIso = cand->pfIsolationVariables();
   const float chad = pfIso.sumChargedHadronPt;
   const float nhad = pfIso.sumNeutralHadronEt;
   const float pho = pfIso.sumPhotonEt;
   const float puchad = pfIso.sumPUPt;
-  float iso = chad + std::max(0.0f, nhad + pho - _deltaBetaConstant*puchad);
-  if( _relativeIso ) iso /= cand->p4().pt();
+  float iso = chad + std::max(0.0f, nhad + pho - _deltaBetaConstant * puchad);
+  if (_relativeIso)
+    iso /= cand->p4().pt();
   return iso < isoCut;
 }
 
-double GsfEleDeltaBetaIsoCutStandalone::
-value(const reco::CandidatePtr& cand) const {
+double GsfEleDeltaBetaIsoCutStandalone::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
-  const reco::GsfElectron::PflowIsolationVariables& pfIso = 
-    ele->pfIsolationVariables();
+  const reco::GsfElectron::PflowIsolationVariables& pfIso = ele->pfIsolationVariables();
   const float chad = pfIso.sumChargedHadronPt;
   const float nhad = pfIso.sumNeutralHadronEt;
   const float pho = pfIso.sumPhotonEt;
   const float puchad = pfIso.sumPUPt;
-  float iso = chad + std::max(0.0f, nhad + pho - _deltaBetaConstant*puchad);
-  if( _relativeIso ) iso /= cand->p4().pt();
+  float iso = chad + std::max(0.0f, nhad + pho - _deltaBetaConstant * puchad);
+  if (_relativeIso)
+    iso /= cand->p4().pt();
   return iso;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDxyCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDxyCut.cc
@@ -7,7 +7,7 @@
 class GsfEleDxyCut : public CutApplicatorWithEventContentBase {
 public:
   GsfEleDxyCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -15,63 +15,52 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
-private:  
-  const double _dxyCutValueEB, _dxyCutValueEE,_barrelCutOff;
+private:
+  const double _dxyCutValueEB, _dxyCutValueEE, _barrelCutOff;
   edm::Handle<reco::VertexCollection> _vtxs;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleDxyCut,
-		  "GsfEleDxyCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleDxyCut, "GsfEleDxyCut");
 
-GsfEleDxyCut::GsfEleDxyCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  _dxyCutValueEB(c.getParameter<double>("dxyCutValueEB")),
-  _dxyCutValueEE(c.getParameter<double>("dxyCutValueEE")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
+GsfEleDxyCut::GsfEleDxyCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      _dxyCutValueEB(c.getParameter<double>("dxyCutValueEB")),
+      _dxyCutValueEE(c.getParameter<double>("dxyCutValueEE")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
   edm::InputTag vertextag = c.getParameter<edm::InputTag>("vertexSrc");
-  edm::InputTag vertextagMiniAOD = c.getParameter<edm::InputTag>("vertexSrcMiniAOD"); 
-  contentTags_.emplace("vertices",vertextag);
-  contentTags_.emplace("verticesMiniAOD",vertextagMiniAOD);
+  edm::InputTag vertextagMiniAOD = c.getParameter<edm::InputTag>("vertexSrcMiniAOD");
+  contentTags_.emplace("vertices", vertextag);
+  contentTags_.emplace("verticesMiniAOD", vertextagMiniAOD);
 }
 
 void GsfEleDxyCut::setConsumes(edm::ConsumesCollector& cc) {
   auto vtcs = cc.mayConsume<reco::VertexCollection>(contentTags_["vertices"]);
   auto vtcsMiniAOD = cc.mayConsume<reco::VertexCollection>(contentTags_["verticesMiniAOD"]);
-  contentTokens_.emplace("vertices",vtcs);
-  contentTokens_.emplace("verticesMiniAOD",vtcsMiniAOD);
+  contentTokens_.emplace("vertices", vtcs);
+  contentTokens_.emplace("verticesMiniAOD", vtcsMiniAOD);
 }
 
-void GsfEleDxyCut::getEventContent(const edm::EventBase& ev) {    
+void GsfEleDxyCut::getEventContent(const edm::EventBase& ev) {
   // First try AOD, then go to miniAOD. Use the same Handle since collection class is the same.
-  ev.getByLabel(contentTags_["vertices"],_vtxs);
+  ev.getByLabel(contentTags_["vertices"], _vtxs);
   if (!_vtxs.isValid())
-    ev.getByLabel(contentTags_["verticesMiniAOD"],_vtxs);
+    ev.getByLabel(contentTags_["verticesMiniAOD"], _vtxs);
 }
 
-CutApplicatorBase::result_type 
-GsfEleDxyCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-  const float dxyCutValue = 
-    ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? 
-      _dxyCutValueEB : _dxyCutValueEE );
+CutApplicatorBase::result_type GsfEleDxyCut::operator()(const reco::GsfElectronPtr& cand) const {
+  const float dxyCutValue =
+      (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _dxyCutValueEB : _dxyCutValueEE);
 
   const reco::VertexCollection& vtxs = *_vtxs;
-  const double dxy = ( !vtxs.empty() ? 
-		       cand->gsfTrack()->dxy(vtxs[0].position()) : 
-		       cand->gsfTrack()->dxy() );
+  const double dxy = (!vtxs.empty() ? cand->gsfTrack()->dxy(vtxs[0].position()) : cand->gsfTrack()->dxy());
   return std::abs(dxy) < dxyCutValue;
 }
 
 double GsfEleDxyCut::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
   const reco::VertexCollection& vtxs = *_vtxs;
-  const double dxy = ( !vtxs.empty() ? 
-		       ele->gsfTrack()->dxy(vtxs[0].position()) : 
-		       ele->gsfTrack()->dxy() );
+  const double dxy = (!vtxs.empty() ? ele->gsfTrack()->dxy(vtxs[0].position()) : ele->gsfTrack()->dxy());
   return std::abs(dxy);
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDzCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDzCut.cc
@@ -7,7 +7,7 @@
 class GsfEleDzCut : public CutApplicatorWithEventContentBase {
 public:
   GsfEleDzCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -15,63 +15,52 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
-private:  
-  const double _dzCutValueEB,_dzCutValueEE,_barrelCutOff;
+private:
+  const double _dzCutValueEB, _dzCutValueEE, _barrelCutOff;
   edm::Handle<reco::VertexCollection> _vtxs;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleDzCut,
-		  "GsfEleDzCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleDzCut, "GsfEleDzCut");
 
-GsfEleDzCut::GsfEleDzCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  _dzCutValueEB(c.getParameter<double>("dzCutValueEB")),
-  _dzCutValueEE(c.getParameter<double>("dzCutValueEE")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
+GsfEleDzCut::GsfEleDzCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      _dzCutValueEB(c.getParameter<double>("dzCutValueEB")),
+      _dzCutValueEE(c.getParameter<double>("dzCutValueEE")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
   edm::InputTag vertextag = c.getParameter<edm::InputTag>("vertexSrc");
   edm::InputTag vertextagMiniAOD = c.getParameter<edm::InputTag>("vertexSrcMiniAOD");
-  contentTags_.emplace("vertices",vertextag);
-  contentTags_.emplace("verticesMiniAOD",vertextagMiniAOD);
+  contentTags_.emplace("vertices", vertextag);
+  contentTags_.emplace("verticesMiniAOD", vertextagMiniAOD);
 }
 
 void GsfEleDzCut::setConsumes(edm::ConsumesCollector& cc) {
   auto vtcs = cc.mayConsume<reco::VertexCollection>(contentTags_["vertices"]);
   auto vtcsMiniAOD = cc.mayConsume<reco::VertexCollection>(contentTags_["verticesMiniAOD"]);
-  contentTokens_.emplace("vertices",vtcs);
-  contentTokens_.emplace("verticesMiniAOD",vtcsMiniAOD);
+  contentTokens_.emplace("vertices", vtcs);
+  contentTokens_.emplace("verticesMiniAOD", vtcsMiniAOD);
 }
 
-void GsfEleDzCut::getEventContent(const edm::EventBase& ev) {    
+void GsfEleDzCut::getEventContent(const edm::EventBase& ev) {
   // First try AOD, then go to miniAOD. Use the same Handle since collection class is the same.
-  ev.getByLabel(contentTags_["vertices"],_vtxs);
+  ev.getByLabel(contentTags_["vertices"], _vtxs);
   if (!_vtxs.isValid())
-    ev.getByLabel(contentTags_["verticesMiniAOD"],_vtxs);
+    ev.getByLabel(contentTags_["verticesMiniAOD"], _vtxs);
 }
 
-CutApplicatorBase::result_type 
-GsfEleDzCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-  const float dzCutValue = 
-    ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? 
-      _dzCutValueEB : _dzCutValueEE );
-  
+CutApplicatorBase::result_type GsfEleDzCut::operator()(const reco::GsfElectronPtr& cand) const {
+  const float dzCutValue =
+      (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _dzCutValueEB : _dzCutValueEE);
+
   const reco::VertexCollection& vtxs = *_vtxs;
-  const double dz = ( !vtxs.empty() ? 
-		      cand->gsfTrack()->dz(vtxs[0].position()) : 
-		      cand->gsfTrack()->dz() );
+  const double dz = (!vtxs.empty() ? cand->gsfTrack()->dz(vtxs[0].position()) : cand->gsfTrack()->dz());
   return std::abs(dz) < dzCutValue;
 }
 
 double GsfEleDzCut::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
   const reco::VertexCollection& vtxs = *_vtxs;
-  const double dz = ( !vtxs.empty() ? 
-		      ele->gsfTrack()->dz(vtxs[0].position()) : 
-		      ele->gsfTrack()->dz() );
+  const double dz = (!vtxs.empty() ? ele->gsfTrack()->dz(vtxs[0].position()) : ele->gsfTrack()->dz());
   return std::abs(dz);
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleE2x5OverE5x5Cut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleE2x5OverE5x5Cut.cc
@@ -4,42 +4,32 @@
 
 class GsfEleE2x5OverE5x5Cut : public CutApplicatorBase {
 public:
-  GsfEleE2x5OverE5x5Cut(const edm::ParameterSet& params) :
-    CutApplicatorBase(params),
-    minE1x5OverE5x5_(params,"minE1x5OverE5x5"),
-    minE2x5OverE5x5_(params,"minE2x5OverE5x5"){}
-  
+  GsfEleE2x5OverE5x5Cut(const edm::ParameterSet& params)
+      : CutApplicatorBase(params),
+        minE1x5OverE5x5_(params, "minE1x5OverE5x5"),
+        minE2x5OverE5x5_(params, "minE2x5OverE5x5") {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
-  
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   EBEECutValues minE1x5OverE5x5_;
   EBEECutValues minE2x5OverE5x5_;
-  
-
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleE2x5OverE5x5Cut,
-		  "GsfEleE2x5OverE5x5Cut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleE2x5OverE5x5Cut, "GsfEleE2x5OverE5x5Cut");
 
-CutApplicatorBase::result_type 
-GsfEleE2x5OverE5x5Cut::
-operator()(const reco::GsfElectronPtr& cand) const{
-  
-  return cand->e2x5Max() > minE2x5OverE5x5_(cand)*cand->e5x5() || 
-         cand->e1x5()    > minE1x5OverE5x5_(cand)*cand->e5x5();
-  
+CutApplicatorBase::result_type GsfEleE2x5OverE5x5Cut::operator()(const reco::GsfElectronPtr& cand) const {
+  return cand->e2x5Max() > minE2x5OverE5x5_(cand) * cand->e5x5() ||
+         cand->e1x5() > minE1x5OverE5x5_(cand) * cand->e5x5();
 }
 
 double GsfEleE2x5OverE5x5Cut::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
   //btw we broke somebodies nice model of assuming every cut is 1D....
   //what this is returning is fairly meaningless...
-  return ele->e1x5() ? ele->e2x5Max()/ele->e1x5() : 0.;
+  return ele->e1x5() ? ele->e2x5Max() / ele->e1x5() : 0.;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEInverseMinusPInverseCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEInverseMinusPInverseCut.cc
@@ -1,46 +1,37 @@
 #include "PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
- 
+
 class GsfEleEInverseMinusPInverseCut : public CutApplicatorBase {
 public:
-  GsfEleEInverseMinusPInverseCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _ooemoopCutValueEB(c.getParameter<double>("eInverseMinusPInverseCutValueEB")),
-    _ooemoopCutValueEE(c.getParameter<double>("eInverseMinusPInverseCutValueEE")),
-    _barrelCutOff(c.getParameter<double>("barrelCutOff")){
-  }
-  
+  GsfEleEInverseMinusPInverseCut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+        _ooemoopCutValueEB(c.getParameter<double>("eInverseMinusPInverseCutValueEB")),
+        _ooemoopCutValueEE(c.getParameter<double>("eInverseMinusPInverseCutValueEE")),
+        _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-  const double _ooemoopCutValueEB,_ooemoopCutValueEE,_barrelCutOff;
+  const double _ooemoopCutValueEB, _ooemoopCutValueEE, _barrelCutOff;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleEInverseMinusPInverseCut,
-		  "GsfEleEInverseMinusPInverseCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleEInverseMinusPInverseCut, "GsfEleEInverseMinusPInverseCut");
 
-CutApplicatorBase::result_type 
-GsfEleEInverseMinusPInverseCut::
-operator()(const reco::GsfElectronPtr& cand) const{
-  const float ooemoopCutValue = 
-    ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? 
-      _ooemoopCutValueEB : _ooemoopCutValueEE );
-  const float ecal_energy_inverse = 1.0/cand->ecalEnergy();
+CutApplicatorBase::result_type GsfEleEInverseMinusPInverseCut::operator()(const reco::GsfElectronPtr& cand) const {
+  const float ooemoopCutValue =
+      (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _ooemoopCutValueEB : _ooemoopCutValueEE);
+  const float ecal_energy_inverse = 1.0 / cand->ecalEnergy();
   const float eSCoverP = cand->eSuperClusterOverP();
-  return std::abs(1.0 - eSCoverP)*ecal_energy_inverse < ooemoopCutValue;
+  return std::abs(1.0 - eSCoverP) * ecal_energy_inverse < ooemoopCutValue;
 }
 
-double GsfEleEInverseMinusPInverseCut::
-value(const reco::CandidatePtr& cand) const {
+double GsfEleEInverseMinusPInverseCut::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
-  const float ecal_energy_inverse = 1.0/ele->ecalEnergy();
+  const float ecal_energy_inverse = 1.0 / ele->ecalEnergy();
   const float eSCoverP = ele->eSuperClusterOverP();
-  return std::abs(1.0 - eSCoverP)*ecal_energy_inverse;
+  return std::abs(1.0 - eSCoverP) * ecal_energy_inverse;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEcalDrivenCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEcalDrivenCut.cc
@@ -5,57 +5,51 @@
 class GsfEleEcalDrivenCut : public CutApplicatorBase {
 public:
   GsfEleEcalDrivenCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   static bool isValidCutVal(int val);
 
 private:
-  enum EcalDrivenCode{IGNORE=-1,FAIL=0,PASS=1};
+  enum EcalDrivenCode { IGNORE = -1, FAIL = 0, PASS = 1 };
   const int ecalDrivenEB_, ecalDrivenEE_;
   const double barrelCutOff_;
-  
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleEcalDrivenCut,
-		  "GsfEleEcalDrivenCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleEcalDrivenCut, "GsfEleEcalDrivenCut");
 
-
- 
-GsfEleEcalDrivenCut::GsfEleEcalDrivenCut(const edm::ParameterSet& c) :
-  CutApplicatorBase(c),
-  ecalDrivenEB_(static_cast<EcalDrivenCode>(c.getParameter<int>("ecalDrivenEB"))),
-  ecalDrivenEE_(static_cast<EcalDrivenCode>(c.getParameter<int>("ecalDrivenEE"))),
-  barrelCutOff_(c.getParameter<double>("barrelCutOff"))
-{
-  if(!isValidCutVal(ecalDrivenEB_) || !isValidCutVal(ecalDrivenEE_)){
+GsfEleEcalDrivenCut::GsfEleEcalDrivenCut(const edm::ParameterSet& c)
+    : CutApplicatorBase(c),
+      ecalDrivenEB_(static_cast<EcalDrivenCode>(c.getParameter<int>("ecalDrivenEB"))),
+      ecalDrivenEE_(static_cast<EcalDrivenCode>(c.getParameter<int>("ecalDrivenEE"))),
+      barrelCutOff_(c.getParameter<double>("barrelCutOff")) {
+  if (!isValidCutVal(ecalDrivenEB_) || !isValidCutVal(ecalDrivenEE_)) {
     throw edm::Exception(edm::errors::Configuration)
-      <<"error in constructing GsfEleEcalDrivenCut"<<std::endl
-      <<"values of ecalDrivenEB: "<<ecalDrivenEB_<<" and/or ecalDrivenEE: "<<ecalDrivenEE_<<" are invalid "<<std::endl
-      <<"allowed values are IGNORE:"<<IGNORE<<" FAIL:"<<FAIL<<" PASS:"<<PASS;
+        << "error in constructing GsfEleEcalDrivenCut" << std::endl
+        << "values of ecalDrivenEB: " << ecalDrivenEB_ << " and/or ecalDrivenEE: " << ecalDrivenEE_ << " are invalid "
+        << std::endl
+        << "allowed values are IGNORE:" << IGNORE << " FAIL:" << FAIL << " PASS:" << PASS;
   }
 }
 
-CutApplicatorBase::result_type 
-GsfEleEcalDrivenCut::
-operator()(const reco::GsfElectronPtr& cand) const{ 
-  const auto ecalDrivenRequirement =  std::abs(cand->superCluster()->position().eta()) < barrelCutOff_ ? 
-    ecalDrivenEB_ : ecalDrivenEE_;
-  if(ecalDrivenRequirement==IGNORE) return true;
-  else if(ecalDrivenRequirement==FAIL) return !cand->ecalDriven();
-  else if(ecalDrivenRequirement==PASS) return cand->ecalDriven();
-  else{  
-    throw edm::Exception(edm::errors::LogicError)
-      <<"error in "<<__FILE__<<" line "<<__LINE__<<std::endl
-      <<"default option should not be reached, code has been updated without changing the logic, this needs to be fixed";
+CutApplicatorBase::result_type GsfEleEcalDrivenCut::operator()(const reco::GsfElectronPtr& cand) const {
+  const auto ecalDrivenRequirement =
+      std::abs(cand->superCluster()->position().eta()) < barrelCutOff_ ? ecalDrivenEB_ : ecalDrivenEE_;
+  if (ecalDrivenRequirement == IGNORE)
+    return true;
+  else if (ecalDrivenRequirement == FAIL)
+    return !cand->ecalDriven();
+  else if (ecalDrivenRequirement == PASS)
+    return cand->ecalDriven();
+  else {
+    throw edm::Exception(edm::errors::LogicError) << "error in " << __FILE__ << " line " << __LINE__ << std::endl
+                                                  << "default option should not be reached, code has been updated "
+                                                     "without changing the logic, this needs to be fixed";
   }
 }
 
@@ -64,10 +58,12 @@ double GsfEleEcalDrivenCut::value(const reco::CandidatePtr& cand) const {
   return ele->ecalDriven();
 }
 
-bool GsfEleEcalDrivenCut::isValidCutVal(int val)
-{
-  if(val==IGNORE) return true;
-  if(val==FAIL) return true;
-  if(val==PASS) return true;
+bool GsfEleEcalDrivenCut::isValidCutVal(int val) {
+  if (val == IGNORE)
+    return true;
+  if (val == FAIL)
+    return true;
+  if (val == PASS)
+    return true;
   return false;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEffAreaPFIsoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEffAreaPFIsoCut.cc
@@ -2,11 +2,10 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
 
-
 class GsfEleEffAreaPFIsoCut : public CutApplicatorWithEventContentBase {
 public:
   GsfEleEffAreaPFIsoCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -14,103 +13,86 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   // Cut values
-  const float _isoCutEBLowPt,_isoCutEBHighPt,_isoCutEELowPt,_isoCutEEHighPt;
+  const float _isoCutEBLowPt, _isoCutEBHighPt, _isoCutEELowPt, _isoCutEEHighPt;
   // Configuration
   const float _ptCutOff;
   const float _barrelCutOff;
-  bool  _isRelativeIso;
+  bool _isRelativeIso;
   // Effective area constants
   EffectiveAreas _effectiveAreas;
   // The rho
-  edm::Handle< double > _rhoHandle;
+  edm::Handle<double> _rhoHandle;
 
-  constexpr static char rhoString_     [] = "rho";
+  constexpr static char rhoString_[] = "rho";
 };
 
 constexpr char GsfEleEffAreaPFIsoCut::rhoString_[];
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleEffAreaPFIsoCut,
-		  "GsfEleEffAreaPFIsoCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleEffAreaPFIsoCut, "GsfEleEffAreaPFIsoCut");
 
-GsfEleEffAreaPFIsoCut::GsfEleEffAreaPFIsoCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  _isoCutEBLowPt(c.getParameter<double>("isoCutEBLowPt")),
-  _isoCutEBHighPt(c.getParameter<double>("isoCutEBHighPt")),
-  _isoCutEELowPt(c.getParameter<double>("isoCutEELowPt")),
-  _isoCutEEHighPt(c.getParameter<double>("isoCutEEHighPt")),
-  _ptCutOff(c.getParameter<double>("ptCutOff")),
-   _barrelCutOff(c.getParameter<double>("barrelCutOff")),
-  _isRelativeIso(c.getParameter<bool>("isRelativeIso")),
-  _effectiveAreas( (c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath())
-{
-  
+GsfEleEffAreaPFIsoCut::GsfEleEffAreaPFIsoCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      _isoCutEBLowPt(c.getParameter<double>("isoCutEBLowPt")),
+      _isoCutEBHighPt(c.getParameter<double>("isoCutEBHighPt")),
+      _isoCutEELowPt(c.getParameter<double>("isoCutEELowPt")),
+      _isoCutEEHighPt(c.getParameter<double>("isoCutEEHighPt")),
+      _ptCutOff(c.getParameter<double>("ptCutOff")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")),
+      _isRelativeIso(c.getParameter<bool>("isRelativeIso")),
+      _effectiveAreas((c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath()) {
   edm::InputTag rhoTag = c.getParameter<edm::InputTag>("rho");
-  contentTags_.emplace(rhoString_,rhoTag);
-
+  contentTags_.emplace(rhoString_, rhoTag);
 }
 
 void GsfEleEffAreaPFIsoCut::setConsumes(edm::ConsumesCollector& cc) {
-
   auto rho = cc.consumes<double>(contentTags_[rhoString_]);
   contentTokens_.emplace(rhoString_, rho);
 }
 
-void GsfEleEffAreaPFIsoCut::getEventContent(const edm::EventBase& ev) {  
-
-  ev.getByLabel(contentTags_[rhoString_],_rhoHandle);
+void GsfEleEffAreaPFIsoCut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_[rhoString_], _rhoHandle);
 }
 
-CutApplicatorBase::result_type 
-GsfEleEffAreaPFIsoCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-
+CutApplicatorBase::result_type GsfEleEffAreaPFIsoCut::operator()(const reco::GsfElectronPtr& cand) const {
   // Establish the cut value
   double absEta = std::abs(cand->superCluster()->eta());
-  const float isoCut =
-    ( cand->pt() < _ptCutOff ?
-      ( absEta < _barrelCutOff ? _isoCutEBLowPt : _isoCutEELowPt ) 
-      :
-      ( absEta < _barrelCutOff ? _isoCutEBHighPt : _isoCutEEHighPt ) );
+  const float isoCut = (cand->pt() < _ptCutOff ? (absEta < _barrelCutOff ? _isoCutEBLowPt : _isoCutEELowPt)
+                                               : (absEta < _barrelCutOff ? _isoCutEBHighPt : _isoCutEEHighPt));
 
   // Compute the combined isolation with effective area correction
-  const reco::GsfElectron::PflowIsolationVariables& pfIso =
-    cand->pfIsolationVariables();
+  const reco::GsfElectron::PflowIsolationVariables& pfIso = cand->pfIsolationVariables();
   const float chad = pfIso.sumChargedHadronPt;
   const float nhad = pfIso.sumNeutralHadronEt;
   const float pho = pfIso.sumPhotonEt;
-  const float  eA = _effectiveAreas.getEffectiveArea( absEta );
-  const float rho = _rhoHandle.isValid() ? (float)(*_rhoHandle) : 0; // std::max likes float arguments
-  const float iso = chad + std::max(0.0f, nhad + pho - rho*eA);
-  
+  const float eA = _effectiveAreas.getEffectiveArea(absEta);
+  const float rho = _rhoHandle.isValid() ? (float)(*_rhoHandle) : 0;  // std::max likes float arguments
+  const float iso = chad + std::max(0.0f, nhad + pho - rho * eA);
+
   // Apply the cut and return the result
   // Scale by pT if the relative isolation is requested but avoid division by 0
-  return iso < isoCut*(_isRelativeIso ? cand->pt() : 1.);
+  return iso < isoCut * (_isRelativeIso ? cand->pt() : 1.);
 }
 
 double GsfEleEffAreaPFIsoCut::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
   // Establish the cut value
   double absEta = std::abs(ele->superCluster()->eta());
-  
+
   // Compute the combined isolation with effective area correction
-  const reco::GsfElectron::PflowIsolationVariables& pfIso =
-    ele->pfIsolationVariables();
+  const reco::GsfElectron::PflowIsolationVariables& pfIso = ele->pfIsolationVariables();
   const float chad = pfIso.sumChargedHadronPt;
   const float nhad = pfIso.sumNeutralHadronEt;
   const float pho = pfIso.sumPhotonEt;
-  float  eA = _effectiveAreas.getEffectiveArea( absEta );
-  float rho = (float)(*_rhoHandle); // std::max likes float arguments
-  float iso = chad + std::max(0.0f, nhad + pho - rho*eA);
-  
+  float eA = _effectiveAreas.getEffectiveArea(absEta);
+  float rho = (float)(*_rhoHandle);  // std::max likes float arguments
+  float iso = chad + std::max(0.0f, nhad + pho - rho * eA);
+
   // Divide by pT if the relative isolation is requested
-  if( _isRelativeIso )
+  if (_isRelativeIso)
     iso /= ele->pt();
 
   // Apply the cut and return the result

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEmHadD1IsoRhoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEmHadD1IsoRhoCut.cc
@@ -7,7 +7,7 @@
 class GsfEleEmHadD1IsoRhoCut : public CutApplicatorWithEventContentBase {
 public:
   GsfEleEmHadD1IsoRhoCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -15,9 +15,7 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   float rhoConstant_;
@@ -25,49 +23,43 @@ private:
   EBEECutValues slopeStart_;
   EBEECutValues constTerm_;
   EleEnergyRetriever energyRetriever_;
-  
+
   edm::Handle<double> rhoHandle_;
-  
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleEmHadD1IsoRhoCut,
-		  "GsfEleEmHadD1IsoRhoCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleEmHadD1IsoRhoCut, "GsfEleEmHadD1IsoRhoCut");
 
-GsfEleEmHadD1IsoRhoCut::GsfEleEmHadD1IsoRhoCut(const edm::ParameterSet& params) :
-  CutApplicatorWithEventContentBase(params),
-  rhoConstant_(params.getParameter<double>("rhoConstant")),
-  slopeTerm_(params,"slopeTerm"),
-  slopeStart_(params,"slopeStart"),
-  constTerm_(params,"constTerm"),
-  energyRetriever_(params.getParameter<std::string>("energyType"))
-{
+GsfEleEmHadD1IsoRhoCut::GsfEleEmHadD1IsoRhoCut(const edm::ParameterSet& params)
+    : CutApplicatorWithEventContentBase(params),
+      rhoConstant_(params.getParameter<double>("rhoConstant")),
+      slopeTerm_(params, "slopeTerm"),
+      slopeStart_(params, "slopeStart"),
+      constTerm_(params, "constTerm"),
+      energyRetriever_(params.getParameter<std::string>("energyType")) {
   edm::InputTag rhoTag = params.getParameter<edm::InputTag>("rho");
-  contentTags_.emplace("rho",rhoTag);
- 
+  contentTags_.emplace("rho", rhoTag);
 }
 
 void GsfEleEmHadD1IsoRhoCut::setConsumes(edm::ConsumesCollector& cc) {
   auto rho = cc.consumes<double>(contentTags_["rho"]);
-  contentTokens_.emplace("rho",rho);
+  contentTokens_.emplace("rho", rho);
 }
 
-void GsfEleEmHadD1IsoRhoCut::getEventContent(const edm::EventBase& ev) {  
-  ev.getByLabel(contentTags_["rho"],rhoHandle_);
+void GsfEleEmHadD1IsoRhoCut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_["rho"], rhoHandle_);
 }
 
-CutApplicatorBase::result_type 
-GsfEleEmHadD1IsoRhoCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
+CutApplicatorBase::result_type GsfEleEmHadD1IsoRhoCut::operator()(const reco::GsfElectronPtr& cand) const {
   const double rho = (*rhoHandle_);
-  
+
   const float isolEmHadDepth1 = cand->dr03EcalRecHitSumEt() + cand->dr03HcalDepth1TowerSumEt();
 
-  const float sinTheta = cand->p()!=0. ? cand->pt()/cand->p() : 0.;
-  const float et = energyRetriever_(*cand)*sinTheta;
+  const float sinTheta = cand->p() != 0. ? cand->pt() / cand->p() : 0.;
+  const float et = energyRetriever_(*cand) * sinTheta;
 
-  const float cutValue = et > slopeStart_(cand)  ? slopeTerm_(cand)*(et-slopeStart_(cand)) + constTerm_(cand) : constTerm_(cand);
-  return isolEmHadDepth1 < cutValue + rhoConstant_*rho;
+  const float cutValue =
+      et > slopeStart_(cand) ? slopeTerm_(cand) * (et - slopeStart_(cand)) + constTerm_(cand) : constTerm_(cand);
+  return isolEmHadDepth1 < cutValue + rhoConstant_ * rho;
 }
 
 double GsfEleEmHadD1IsoRhoCut::value(const reco::CandidatePtr& cand) const {

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleFull5x5E2x5OverE5x5Cut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleFull5x5E2x5OverE5x5Cut.cc
@@ -6,50 +6,36 @@
 class GsfEleFull5x5E2x5OverE5x5Cut : public CutApplicatorBase {
 public:
   GsfEleFull5x5E2x5OverE5x5Cut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   EBEECutValues minE1x5OverE5x5Cut_;
   EBEECutValues minE2x5OverE5x5Cut_;
-  
-  
-  
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleFull5x5E2x5OverE5x5Cut,
-		  "GsfEleFull5x5E2x5OverE5x5Cut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleFull5x5E2x5OverE5x5Cut, "GsfEleFull5x5E2x5OverE5x5Cut");
 
-GsfEleFull5x5E2x5OverE5x5Cut::GsfEleFull5x5E2x5OverE5x5Cut(const edm::ParameterSet& params) :
-  CutApplicatorBase(params),
-  minE1x5OverE5x5Cut_(params,"minE1x5OverE5x5"),
-  minE2x5OverE5x5Cut_(params,"minE2x5OverE5x5"){
-}
+GsfEleFull5x5E2x5OverE5x5Cut::GsfEleFull5x5E2x5OverE5x5Cut(const edm::ParameterSet& params)
+    : CutApplicatorBase(params),
+      minE1x5OverE5x5Cut_(params, "minE1x5OverE5x5"),
+      minE2x5OverE5x5Cut_(params, "minE2x5OverE5x5") {}
 
-
-CutApplicatorBase::result_type 
-GsfEleFull5x5E2x5OverE5x5Cut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-
+CutApplicatorBase::result_type GsfEleFull5x5E2x5OverE5x5Cut::operator()(const reco::GsfElectronPtr& cand) const {
   const double e5x5 = cand->full5x5_e5x5();
-  const double e2x5OverE5x5 = e5x5!=0 ? cand->full5x5_e2x5Max()/e5x5 : 0; 
-  const double e1x5OverE5x5 = e5x5!=0 ? cand->full5x5_e1x5()/e5x5 : 0;
+  const double e2x5OverE5x5 = e5x5 != 0 ? cand->full5x5_e2x5Max() / e5x5 : 0;
+  const double e1x5OverE5x5 = e5x5 != 0 ? cand->full5x5_e1x5() / e5x5 : 0;
 
   return e1x5OverE5x5 > minE1x5OverE5x5Cut_(cand) || e2x5OverE5x5 > minE2x5OverE5x5Cut_(cand);
- 
 }
 
-double GsfEleFull5x5E2x5OverE5x5Cut::
-value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+double GsfEleFull5x5E2x5OverE5x5Cut::value(const reco::CandidatePtr& cand) const {
+  reco::GsfElectronPtr ele(cand);
   //btw we broke somebodies nice model of assuming every cut is 1D....
   //what this is returning is fairly meaningless...
-  return ele->full5x5_e1x5() ? ele->full5x5_e2x5Max()/ele->full5x5_e1x5() : 0.;
+  return ele->full5x5_e1x5() ? ele->full5x5_e2x5Max() / ele->full5x5_e1x5() : 0.;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleFull5x5E2x5OverE5x5WithSatCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleFull5x5E2x5OverE5x5WithSatCut.cc
@@ -6,55 +6,41 @@
 class GsfEleFull5x5E2x5OverE5x5WithSatCut : public CutApplicatorBase {
 public:
   GsfEleFull5x5E2x5OverE5x5WithSatCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
- 
+
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   EBEECutValues minE1x5OverE5x5Cut_;
   EBEECutValues minE2x5OverE5x5Cut_;
   EBEECutValuesInt maxNrSatCrysIn5x5Cut_;
-
-  
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleFull5x5E2x5OverE5x5WithSatCut,
-		  "GsfEleFull5x5E2x5OverE5x5WithSatCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleFull5x5E2x5OverE5x5WithSatCut, "GsfEleFull5x5E2x5OverE5x5WithSatCut");
 
-GsfEleFull5x5E2x5OverE5x5WithSatCut::GsfEleFull5x5E2x5OverE5x5WithSatCut(const edm::ParameterSet& params) :
-  CutApplicatorBase(params),
-  minE1x5OverE5x5Cut_(params,"minE1x5OverE5x5"),
-  minE2x5OverE5x5Cut_(params,"minE2x5OverE5x5"),
-  maxNrSatCrysIn5x5Cut_(params,"maxNrSatCrysIn5x5")
-{
+GsfEleFull5x5E2x5OverE5x5WithSatCut::GsfEleFull5x5E2x5OverE5x5WithSatCut(const edm::ParameterSet& params)
+    : CutApplicatorBase(params),
+      minE1x5OverE5x5Cut_(params, "minE1x5OverE5x5"),
+      minE2x5OverE5x5Cut_(params, "minE2x5OverE5x5"),
+      maxNrSatCrysIn5x5Cut_(params, "maxNrSatCrysIn5x5") {}
 
-}
-
-
-CutApplicatorBase::result_type 
-GsfEleFull5x5E2x5OverE5x5WithSatCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-
-  if(cand->nSaturatedXtals()>maxNrSatCrysIn5x5Cut_(cand)) return true;
+CutApplicatorBase::result_type GsfEleFull5x5E2x5OverE5x5WithSatCut::operator()(const reco::GsfElectronPtr& cand) const {
+  if (cand->nSaturatedXtals() > maxNrSatCrysIn5x5Cut_(cand))
+    return true;
 
   const double e5x5 = cand->full5x5_e5x5();
-  const double e2x5OverE5x5 = e5x5!=0 ? cand->full5x5_e2x5Max()/e5x5 : 0; 
-  const double e1x5OverE5x5 = e5x5!=0 ? cand->full5x5_e1x5()/e5x5 : 0;
+  const double e2x5OverE5x5 = e5x5 != 0 ? cand->full5x5_e2x5Max() / e5x5 : 0;
+  const double e1x5OverE5x5 = e5x5 != 0 ? cand->full5x5_e1x5() / e5x5 : 0;
 
   return e1x5OverE5x5 > minE1x5OverE5x5Cut_(cand) || e2x5OverE5x5 > minE2x5OverE5x5Cut_(cand);
- 
 }
 
-double GsfEleFull5x5E2x5OverE5x5WithSatCut::
-value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+double GsfEleFull5x5E2x5OverE5x5WithSatCut::value(const reco::CandidatePtr& cand) const {
+  reco::GsfElectronPtr ele(cand);
   //btw we broke somebodies nice model of assuming every cut is 1D....
   //what this is returning is fairly meaningless...
-  return ele->full5x5_e1x5() ? ele->full5x5_e2x5Max()/ele->full5x5_e1x5() : 0.;
+  return ele->full5x5_e1x5() ? ele->full5x5_e2x5Max() / ele->full5x5_e1x5() : 0.;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleFull5x5SigmaIEtaIEtaCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleFull5x5SigmaIEtaIEtaCut.cc
@@ -4,49 +4,38 @@
 class GsfEleFull5x5SigmaIEtaIEtaCut : public CutApplicatorBase {
 public:
   GsfEleFull5x5SigmaIEtaIEtaCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   float _full5x5SigmaIEtaIEtaCutValueEB;
   float _full5x5SigmaIEtaIEtaCutValueEE;
   float _barrelCutOff;
-
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleFull5x5SigmaIEtaIEtaCut,
-		  "GsfEleFull5x5SigmaIEtaIEtaCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleFull5x5SigmaIEtaIEtaCut, "GsfEleFull5x5SigmaIEtaIEtaCut");
 
-GsfEleFull5x5SigmaIEtaIEtaCut::GsfEleFull5x5SigmaIEtaIEtaCut(const edm::ParameterSet& c) :
-  CutApplicatorBase(c),
-  _full5x5SigmaIEtaIEtaCutValueEB(c.getParameter<double>("full5x5SigmaIEtaIEtaCutValueEB")),
-  _full5x5SigmaIEtaIEtaCutValueEE(c.getParameter<double>("full5x5SigmaIEtaIEtaCutValueEE")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
-  
-}
+GsfEleFull5x5SigmaIEtaIEtaCut::GsfEleFull5x5SigmaIEtaIEtaCut(const edm::ParameterSet& c)
+    : CutApplicatorBase(c),
+      _full5x5SigmaIEtaIEtaCutValueEB(c.getParameter<double>("full5x5SigmaIEtaIEtaCutValueEB")),
+      _full5x5SigmaIEtaIEtaCutValueEE(c.getParameter<double>("full5x5SigmaIEtaIEtaCutValueEE")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
 
-CutApplicatorBase::result_type 
-GsfEleFull5x5SigmaIEtaIEtaCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-
+CutApplicatorBase::result_type GsfEleFull5x5SigmaIEtaIEtaCut::operator()(const reco::GsfElectronPtr& cand) const {
   // Figure out the cut value
-  const float full5x5SigmaIEtaIEtaCutValue = 
-    ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? 
-      _full5x5SigmaIEtaIEtaCutValueEB : _full5x5SigmaIEtaIEtaCutValueEE );
-  
+  const float full5x5SigmaIEtaIEtaCutValue =
+      (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _full5x5SigmaIEtaIEtaCutValueEB
+                                                                        : _full5x5SigmaIEtaIEtaCutValueEE);
+
   // Apply the cut and return the result
   return cand->full5x5_sigmaIetaIeta() < full5x5SigmaIEtaIEtaCutValue;
 }
 
-double GsfEleFull5x5SigmaIEtaIEtaCut::
-value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+double GsfEleFull5x5SigmaIEtaIEtaCut::value(const reco::CandidatePtr& cand) const {
+  reco::GsfElectronPtr ele(cand);
   return ele->full5x5_sigmaIetaIeta();
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleFull5x5SigmaIEtaIEtaWithSatCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleFull5x5SigmaIEtaIEtaWithSatCut.cc
@@ -6,45 +6,33 @@
 class GsfEleFull5x5SigmaIEtaIEtaWithSatCut : public CutApplicatorBase {
 public:
   GsfEleFull5x5SigmaIEtaIEtaWithSatCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
-  
+
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   EBEECutValues maxSigmaIEtaIEtaCut_;
   EBEECutValuesInt maxNrSatCrysIn5x5Cut_;
-  
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleFull5x5SigmaIEtaIEtaWithSatCut,
-		  "GsfEleFull5x5SigmaIEtaIEtaWithSatCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleFull5x5SigmaIEtaIEtaWithSatCut, "GsfEleFull5x5SigmaIEtaIEtaWithSatCut");
 
-GsfEleFull5x5SigmaIEtaIEtaWithSatCut::GsfEleFull5x5SigmaIEtaIEtaWithSatCut(const edm::ParameterSet& params) :
-  CutApplicatorBase(params),
-  maxSigmaIEtaIEtaCut_(params,"maxSigmaIEtaIEta"),
-  maxNrSatCrysIn5x5Cut_(params,"maxNrSatCrysIn5x5")
-{
+GsfEleFull5x5SigmaIEtaIEtaWithSatCut::GsfEleFull5x5SigmaIEtaIEtaWithSatCut(const edm::ParameterSet& params)
+    : CutApplicatorBase(params),
+      maxSigmaIEtaIEtaCut_(params, "maxSigmaIEtaIEta"),
+      maxNrSatCrysIn5x5Cut_(params, "maxNrSatCrysIn5x5") {}
 
+CutApplicatorBase::result_type GsfEleFull5x5SigmaIEtaIEtaWithSatCut::operator()(const reco::GsfElectronPtr& cand) const {
+  if (cand->nSaturatedXtals() > maxNrSatCrysIn5x5Cut_(cand))
+    return true;
+  else
+    return cand->full5x5_sigmaIetaIeta() < maxSigmaIEtaIEtaCut_(cand);
 }
 
-
-CutApplicatorBase::result_type 
-GsfEleFull5x5SigmaIEtaIEtaWithSatCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-
-  if(cand->nSaturatedXtals()>maxNrSatCrysIn5x5Cut_(cand)) return true;
-  else return cand->full5x5_sigmaIetaIeta() < maxSigmaIEtaIEtaCut_(cand);
-
-}
-
-double GsfEleFull5x5SigmaIEtaIEtaWithSatCut::
-value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+double GsfEleFull5x5SigmaIEtaIEtaWithSatCut::value(const reco::CandidatePtr& cand) const {
+  reco::GsfElectronPtr ele(cand);
   return ele->full5x5_sigmaIetaIeta();
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleHadronicOverEMCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleHadronicOverEMCut.cc
@@ -3,39 +3,32 @@
 
 class GsfEleHadronicOverEMCut : public CutApplicatorBase {
 public:
-  GsfEleHadronicOverEMCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _hadronicOverEMCutValueEB(c.getParameter<double>("hadronicOverEMCutValueEB")),
-    _hadronicOverEMCutValueEE(c.getParameter<double>("hadronicOverEMCutValueEE")),
-    _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
-  }
-  
+  GsfEleHadronicOverEMCut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+        _hadronicOverEMCutValueEB(c.getParameter<double>("hadronicOverEMCutValueEB")),
+        _hadronicOverEMCutValueEE(c.getParameter<double>("hadronicOverEMCutValueEE")),
+        _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-  const float _hadronicOverEMCutValueEB, _hadronicOverEMCutValueEE, _barrelCutOff;  
+  const float _hadronicOverEMCutValueEB, _hadronicOverEMCutValueEE, _barrelCutOff;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleHadronicOverEMCut,
-		  "GsfEleHadronicOverEMCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleHadronicOverEMCut, "GsfEleHadronicOverEMCut");
 
-CutApplicatorBase::result_type 
-GsfEleHadronicOverEMCut::
-operator()(const reco::GsfElectronPtr& cand) const { 
-  const float hadronicOverEMCutValue = 
-    ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? 
-      _hadronicOverEMCutValueEB : _hadronicOverEMCutValueEE );
+CutApplicatorBase::result_type GsfEleHadronicOverEMCut::operator()(const reco::GsfElectronPtr& cand) const {
+  const float hadronicOverEMCutValue =
+      (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _hadronicOverEMCutValueEB
+                                                                        : _hadronicOverEMCutValueEE);
   return cand->hadronicOverEm() < hadronicOverEMCutValue;
 }
 
 double GsfEleHadronicOverEMCut::value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+  reco::GsfElectronPtr ele(cand);
   return ele->hadronicOverEm();
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleHadronicOverEMEnergyScaledCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleHadronicOverEMEnergyScaledCut.cc
@@ -3,21 +3,19 @@
 
 class GsfEleHadronicOverEMEnergyScaledCut : public CutApplicatorWithEventContentBase {
 public:
-  GsfEleHadronicOverEMEnergyScaledCut(const edm::ParameterSet& c) :
-    CutApplicatorWithEventContentBase(c),
-    barrelC0_(c.getParameter<double>("barrelC0")),
-    barrelCE_(c.getParameter<double>("barrelCE")),
-    barrelCr_(c.getParameter<double>("barrelCr")),
-    endcapC0_(c.getParameter<double>("endcapC0")),
-    endcapCE_(c.getParameter<double>("endcapCE")),
-    endcapCr_(c.getParameter<double>("endcapCr")),
-    barrelCutOff_(c.getParameter<double>("barrelCutOff")) 
-  {
-    edm::InputTag rhoTag = c.getParameter<edm::InputTag>("rho");    
-    contentTags_.emplace("rho",rhoTag);  
-    
+  GsfEleHadronicOverEMEnergyScaledCut(const edm::ParameterSet& c)
+      : CutApplicatorWithEventContentBase(c),
+        barrelC0_(c.getParameter<double>("barrelC0")),
+        barrelCE_(c.getParameter<double>("barrelCE")),
+        barrelCr_(c.getParameter<double>("barrelCr")),
+        endcapC0_(c.getParameter<double>("endcapC0")),
+        endcapCE_(c.getParameter<double>("endcapCE")),
+        endcapCr_(c.getParameter<double>("endcapCr")),
+        barrelCutOff_(c.getParameter<double>("barrelCutOff")) {
+    edm::InputTag rhoTag = c.getParameter<edm::InputTag>("rho");
+    contentTags_.emplace("rho", rhoTag);
   }
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -25,40 +23,34 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-  const float barrelC0_, barrelCE_, barrelCr_, endcapC0_, endcapCE_, endcapCr_, barrelCutOff_;  
+  const float barrelC0_, barrelCE_, barrelCr_, endcapC0_, endcapCE_, endcapCr_, barrelCutOff_;
   edm::Handle<double> rhoHandle_;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleHadronicOverEMEnergyScaledCut,
-		  "GsfEleHadronicOverEMEnergyScaledCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleHadronicOverEMEnergyScaledCut, "GsfEleHadronicOverEMEnergyScaledCut");
 
 void GsfEleHadronicOverEMEnergyScaledCut::setConsumes(edm::ConsumesCollector& cc) {
   auto rho = cc.consumes<double>(contentTags_["rho"]);
-  contentTokens_.emplace("rho",rho);
+  contentTokens_.emplace("rho", rho);
 }
 
-void GsfEleHadronicOverEMEnergyScaledCut::getEventContent(const edm::EventBase& ev) {  
-  ev.getByLabel(contentTags_["rho"],rhoHandle_);
+void GsfEleHadronicOverEMEnergyScaledCut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_["rho"], rhoHandle_);
 }
 
-
-CutApplicatorBase::result_type GsfEleHadronicOverEMEnergyScaledCut::operator()(const reco::GsfElectronPtr& cand) const { 
-
+CutApplicatorBase::result_type GsfEleHadronicOverEMEnergyScaledCut::operator()(const reco::GsfElectronPtr& cand) const {
   const double rho = rhoHandle_.isValid() ? (float)(*rhoHandle_) : 0;
   const float energy = cand->superCluster()->energy();
   const float c0 = (std::abs(cand->superCluster()->position().eta()) < barrelCutOff_ ? barrelC0_ : endcapC0_);
   const float cE = (std::abs(cand->superCluster()->position().eta()) < barrelCutOff_ ? barrelCE_ : endcapCE_);
   const float cR = (std::abs(cand->superCluster()->position().eta()) < barrelCutOff_ ? barrelCr_ : endcapCr_);
-  return cand->hadronicOverEm() < c0 + cE/energy + cR*rho/energy;
+  return cand->hadronicOverEm() < c0 + cE / energy + cR * rho / energy;
 }
 
 double GsfEleHadronicOverEMEnergyScaledCut::value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+  reco::GsfElectronPtr ele(cand);
   return ele->hadronicOverEm();
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleHadronicOverEMLinearCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleHadronicOverEMLinearCut.cc
@@ -3,44 +3,36 @@
 #include "RecoEgamma/ElectronIdentification/interface/EBEECutValues.h"
 class GsfEleHadronicOverEMLinearCut : public CutApplicatorBase {
 public:
-  GsfEleHadronicOverEMLinearCut(const edm::ParameterSet& params) : 
-    CutApplicatorBase(params),
-    slopeTerm_(params,"slopeTerm"),
-    slopeStart_(params,"slopeStart"),
-    constTerm_(params,"constTerm"){}
-  
+  GsfEleHadronicOverEMLinearCut(const edm::ParameterSet& params)
+      : CutApplicatorBase(params),
+        slopeTerm_(params, "slopeTerm"),
+        slopeStart_(params, "slopeStart"),
+        constTerm_(params, "constTerm") {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   EBEECutValues slopeTerm_;
   EBEECutValues slopeStart_;
   EBEECutValues constTerm_;
-   
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleHadronicOverEMLinearCut,
-		  "GsfEleHadronicOverEMLinearCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleHadronicOverEMLinearCut, "GsfEleHadronicOverEMLinearCut");
 
-CutApplicatorBase::result_type 
-GsfEleHadronicOverEMLinearCut::
-operator()(const reco::GsfElectronPtr& cand) const { 
-
+CutApplicatorBase::result_type GsfEleHadronicOverEMLinearCut::operator()(const reco::GsfElectronPtr& cand) const {
   const float energy = cand->superCluster()->energy();
-  const float cutValue = energy > slopeStart_(cand)  ? slopeTerm_(cand)*(energy-slopeStart_(cand)) + constTerm_(cand) : constTerm_(cand);
+  const float cutValue = energy > slopeStart_(cand) ? slopeTerm_(cand) * (energy - slopeStart_(cand)) + constTerm_(cand)
+                                                    : constTerm_(cand);
 
-  return cand->hadronicOverEm()*energy < cutValue;
+  return cand->hadronicOverEm() * energy < cutValue;
 }
 
-double GsfEleHadronicOverEMLinearCut::
-value(const reco::CandidatePtr& cand) const {
+double GsfEleHadronicOverEMLinearCut::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
   const float energy = ele->superCluster()->energy();
-  return ele->hadronicOverEm()*energy;
+  return ele->hadronicOverEm() * energy;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleMVACut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleMVACut.cc
@@ -2,7 +2,6 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 
-
 class GsfEleMVACut : public CutApplicatorWithEventContentBase {
 public:
   GsfEleMVACut(const edm::ParameterSet& c);
@@ -12,12 +11,9 @@ public:
   void setConsumes(edm::ConsumesCollector&) final;
   void getEventContent(const edm::EventBase&) final;
 
-  CandidateType candidateType() const final {
-    return ELECTRON;
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-
   double value(const reco::CandidatePtr& cand) const final;
 
   // Cut formulas
@@ -27,106 +23,92 @@ private:
   const int nCuts_;
 
   // Pre-computed MVA value map
-  edm::Handle<edm::ValueMap<float> > mvaValueMap_;
-  edm::Handle<edm::ValueMap<int> > mvaCategoriesMap_;
-
+  edm::Handle<edm::ValueMap<float>> mvaValueMap_;
+  edm::Handle<edm::ValueMap<int>> mvaCategoriesMap_;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-                  GsfEleMVACut,
-                  "GsfEleMVACut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleMVACut, "GsfEleMVACut");
 
-GsfEleMVACut::GsfEleMVACut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  mvaCutStrings_(c.getParameter<std::vector<std::string> >("mvaCuts")),
-  nCuts_(mvaCutStrings_.size())
-{
+GsfEleMVACut::GsfEleMVACut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      mvaCutStrings_(c.getParameter<std::vector<std::string>>("mvaCuts")),
+      nCuts_(mvaCutStrings_.size()) {
   edm::InputTag mvaValTag = c.getParameter<edm::InputTag>("mvaValueMapName");
-  contentTags_.emplace("mvaVal",mvaValTag);
+  contentTags_.emplace("mvaVal", mvaValTag);
 
   edm::InputTag mvaCatTag = c.getParameter<edm::InputTag>("mvaCategoriesMapName");
-  contentTags_.emplace("mvaCat",mvaCatTag);
+  contentTags_.emplace("mvaCat", mvaCatTag);
 
-  for (auto &cutString : mvaCutStrings_) {
-      cutFormula_.push_back(StringObjectFunction<reco::GsfElectron>(cutString));
+  for (auto& cutString : mvaCutStrings_) {
+    cutFormula_.push_back(StringObjectFunction<reco::GsfElectron>(cutString));
   }
 }
 
 void GsfEleMVACut::setConsumes(edm::ConsumesCollector& cc) {
+  auto mvaVal = cc.consumes<edm::ValueMap<float>>(contentTags_["mvaVal"]);
+  contentTokens_.emplace("mvaVal", mvaVal);
 
-  auto mvaVal =
-    cc.consumes<edm::ValueMap<float> >(contentTags_["mvaVal"]);
-  contentTokens_.emplace("mvaVal",mvaVal);
-
-  auto mvaCat =
-    cc.consumes<edm::ValueMap<int> >(contentTags_["mvaCat"]);
-  contentTokens_.emplace("mvaCat",mvaCat);
+  auto mvaCat = cc.consumes<edm::ValueMap<int>>(contentTags_["mvaCat"]);
+  contentTokens_.emplace("mvaCat", mvaCat);
 }
 
 void GsfEleMVACut::getEventContent(const edm::EventBase& ev) {
-
   ev.getByLabel(contentTags_["mvaVal"], mvaValueMap_);
   ev.getByLabel(contentTags_["mvaCat"], mvaCategoriesMap_);
 }
 
-CutApplicatorBase::result_type
-GsfEleMVACut::
-operator()(const reco::GsfElectronPtr& cand) const{
-
+CutApplicatorBase::result_type GsfEleMVACut::operator()(const reco::GsfElectronPtr& cand) const {
   // in case we are by-value
   const std::string& val_name = contentTags_.find("mvaVal")->second.instance();
   const std::string& cat_name = contentTags_.find("mvaCat")->second.instance();
   edm::Ptr<pat::Electron> pat(cand);
   float val = -1.0;
-  int   cat = -1;
-  if( mvaCategoriesMap_.isValid() && mvaCategoriesMap_->contains( cand.id() ) &&
-      mvaValueMap_.isValid() && mvaValueMap_->contains( cand.id() ) ) {
+  int cat = -1;
+  if (mvaCategoriesMap_.isValid() && mvaCategoriesMap_->contains(cand.id()) && mvaValueMap_.isValid() &&
+      mvaValueMap_->contains(cand.id())) {
     cat = (*mvaCategoriesMap_)[cand];
     val = (*mvaValueMap_)[cand];
-  } else if ( mvaCategoriesMap_.isValid() && mvaValueMap_.isValid() &&
-              mvaCategoriesMap_->idSize() == 1 && mvaValueMap_->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (mvaCategoriesMap_.isValid() && mvaValueMap_.isValid() && mvaCategoriesMap_->idSize() == 1 &&
+             mvaValueMap_->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     cat = mvaCategoriesMap_->begin()[cand.key()];
     val = mvaValueMap_->begin()[cand.key()];
-  } else if ( mvaCategoriesMap_.isValid() && mvaValueMap_.isValid() ){ // throw an exception
+  } else if (mvaCategoriesMap_.isValid() && mvaValueMap_.isValid()) {  // throw an exception
     cat = (*mvaCategoriesMap_)[cand];
     val = (*mvaValueMap_)[cand];
   }
 
   // Find the cut formula
-  const int iCategory = mvaCategoriesMap_.isValid() ? cat : pat->userInt( cat_name );
-  if( iCategory >= nCuts_ )
+  const int iCategory = mvaCategoriesMap_.isValid() ? cat : pat->userInt(cat_name);
+  if (iCategory >= nCuts_)
     throw cms::Exception(" Error in MVA categories: ")
-      << " found a particle with a category larger than max configured " << std::endl;
+        << " found a particle with a category larger than max configured " << std::endl;
 
   // Look up the MVA value for this particle
-  const float mvaValue = mvaValueMap_.isValid() ? val : pat->userFloat( val_name );
+  const float mvaValue = mvaValueMap_.isValid() ? val : pat->userFloat(val_name);
 
   // Apply the cut and return the result
   return mvaValue > cutFormula_[iCategory](*cand);
 }
 
 double GsfEleMVACut::value(const reco::CandidatePtr& cand) const {
-
   // in case we are by-value
-  const std::string& val_name =contentTags_.find("mvaVal")->second.instance();
+  const std::string& val_name = contentTags_.find("mvaVal")->second.instance();
   edm::Ptr<pat::Electron> pat(cand);
   float val = 0.0;
-  if( mvaCategoriesMap_.isValid() && mvaCategoriesMap_->contains( cand.id() ) &&
-      mvaValueMap_.isValid() && mvaValueMap_->contains( cand.id() ) ) {
+  if (mvaCategoriesMap_.isValid() && mvaCategoriesMap_->contains(cand.id()) && mvaValueMap_.isValid() &&
+      mvaValueMap_->contains(cand.id())) {
     val = (*mvaValueMap_)[cand];
-  } else if ( mvaCategoriesMap_.isValid() && mvaValueMap_.isValid() &&
-              mvaCategoriesMap_->idSize() == 1 && mvaValueMap_->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (mvaCategoriesMap_.isValid() && mvaValueMap_.isValid() && mvaCategoriesMap_->idSize() == 1 &&
+             mvaValueMap_->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     val = mvaValueMap_->begin()[cand.key()];
-  } else if ( mvaCategoriesMap_.isValid() && mvaValueMap_.isValid() ){ // throw an exception
+  } else if (mvaCategoriesMap_.isValid() && mvaValueMap_.isValid()) {  // throw an exception
     val = (*mvaValueMap_)[cand];
   }
 
-  const float mvaValue = mvaValueMap_.isValid() ? val : pat->userFloat( val_name );
+  const float mvaValue = mvaValueMap_.isValid() ? val : pat->userFloat(val_name);
   return mvaValue;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleMinEcalEtCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleMinEcalEtCut.cc
@@ -1,46 +1,36 @@
 #include "PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h" 
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
 class GsfEleMinEcalEtCut : public CutApplicatorBase {
 public:
   GsfEleMinEcalEtCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
-private:  
+private:
   const double minEt_;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleMinEcalEtCut,
-		  "GsfEleMinEcalEtCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleMinEcalEtCut, "GsfEleMinEcalEtCut");
 
-GsfEleMinEcalEtCut::GsfEleMinEcalEtCut(const edm::ParameterSet& c) :
-  CutApplicatorBase(c),
-  minEt_(c.getParameter<double>("minEt"))
-{
+GsfEleMinEcalEtCut::GsfEleMinEcalEtCut(const edm::ParameterSet& c)
+    : CutApplicatorBase(c), minEt_(c.getParameter<double>("minEt")) {}
 
-}
-
-CutApplicatorBase::result_type 
-GsfEleMinEcalEtCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
+CutApplicatorBase::result_type GsfEleMinEcalEtCut::operator()(const reco::GsfElectronPtr& cand) const {
   const reco::GsfElectron& ele = *cand;
-  const float sinTheta = ele.p()!=0 ? ele.pt()/ele.p() : 0.;
-  const float et = ele.ecalEnergy()*sinTheta;
-  return et>minEt_;
+  const float sinTheta = ele.p() != 0 ? ele.pt() / ele.p() : 0.;
+  const float et = ele.ecalEnergy() * sinTheta;
+  return et > minEt_;
 }
 
 double GsfEleMinEcalEtCut::value(const reco::CandidatePtr& cand) const {
   const reco::GsfElectronPtr elePtr(cand);
   const reco::GsfElectron& ele = *elePtr;
-  const float sinTheta = ele.p()!=0 ? ele.pt()/ele.p() : 0.;
-  const float et = ele.ecalEnergy()*sinTheta;
+  const float sinTheta = ele.p() != 0 ? ele.pt() / ele.p() : 0.;
+  const float et = ele.ecalEnergy() * sinTheta;
   return et;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleMissingHitsCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleMissingHitsCut.cc
@@ -4,48 +4,36 @@
 
 class GsfEleMissingHitsCut : public CutApplicatorBase {
 public:
-  GsfEleMissingHitsCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _maxMissingHitsEB(c.getParameter<unsigned>("maxMissingHitsEB")),
-    _maxMissingHitsEE(c.getParameter<unsigned>("maxMissingHitsEE")),
-    _barrelCutOff(c.getParameter<double>("barrelCutOff")){
-  }
-  
+  GsfEleMissingHitsCut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+        _maxMissingHitsEB(c.getParameter<unsigned>("maxMissingHitsEB")),
+        _maxMissingHitsEE(c.getParameter<unsigned>("maxMissingHitsEE")),
+        _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   const unsigned _maxMissingHitsEB, _maxMissingHitsEE;
   const double _barrelCutOff;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleMissingHitsCut,
-		  "GsfEleMissingHitsCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleMissingHitsCut, "GsfEleMissingHitsCut");
 
-CutApplicatorBase::result_type 
-GsfEleMissingHitsCut::
-operator()(const reco::GsfElectronPtr& cand) const{ 
-  constexpr auto missingHitType =
-    reco::HitPattern::MISSING_INNER_HITS;
-  const unsigned maxMissingHits = 
-    ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? 
-      _maxMissingHitsEB : _maxMissingHitsEE );
-  const unsigned mHits = 
-    cand->gsfTrack()->hitPattern().numberOfLostHits(missingHitType);
+CutApplicatorBase::result_type GsfEleMissingHitsCut::operator()(const reco::GsfElectronPtr& cand) const {
+  constexpr auto missingHitType = reco::HitPattern::MISSING_INNER_HITS;
+  const unsigned maxMissingHits =
+      (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _maxMissingHitsEB : _maxMissingHitsEE);
+  const unsigned mHits = cand->gsfTrack()->hitPattern().numberOfLostHits(missingHitType);
   return mHits <= maxMissingHits;
 }
 
 double GsfEleMissingHitsCut::value(const reco::CandidatePtr& cand) const {
-  constexpr auto missingHitType =
-    reco::HitPattern::MISSING_INNER_HITS;
+  constexpr auto missingHitType = reco::HitPattern::MISSING_INNER_HITS;
   reco::GsfElectronPtr ele(cand);
-  const unsigned mHits = 
-    ele->gsfTrack()->hitPattern().numberOfLostHits(missingHitType);
+  const unsigned mHits = ele->gsfTrack()->hitPattern().numberOfLostHits(missingHitType);
   return mHits;
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleNormalizedGsfChi2Cut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleNormalizedGsfChi2Cut.cc
@@ -3,44 +3,37 @@
 
 class GsfEleNormalizedGsfChi2Cut : public CutApplicatorBase {
 public:
-  GsfEleNormalizedGsfChi2Cut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    normalizedGsfChi2CutValueEB_(c.getParameter<double>("normalizedGsfChi2CutValueEB")),
-    normalizedGsfChi2CutValueEE_(c.getParameter<double>("normalizedGsfChi2CutValueEE")),
-    barrelCutOff_(c.getParameter<double>("barrelCutOff")){    
-  }
-  
+  GsfEleNormalizedGsfChi2Cut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+        normalizedGsfChi2CutValueEB_(c.getParameter<double>("normalizedGsfChi2CutValueEB")),
+        normalizedGsfChi2CutValueEE_(c.getParameter<double>("normalizedGsfChi2CutValueEE")),
+        barrelCutOff_(c.getParameter<double>("barrelCutOff")) {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-  const double normalizedGsfChi2CutValueEB_,normalizedGsfChi2CutValueEE_,barrelCutOff_;
+  const double normalizedGsfChi2CutValueEB_, normalizedGsfChi2CutValueEE_, barrelCutOff_;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleNormalizedGsfChi2Cut,
-		  "GsfEleNormalizedGsfChi2Cut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleNormalizedGsfChi2Cut, "GsfEleNormalizedGsfChi2Cut");
 
-float normalizedGsfChi2(const reco::GsfElectronPtr& ele){
+float normalizedGsfChi2(const reco::GsfElectronPtr& ele) {
   return ele->gsfTrack().isNonnull() ? ele->gsfTrack()->normalizedChi2() : std::numeric_limits<float>::max();
 }
 
-CutApplicatorBase::result_type 
-GsfEleNormalizedGsfChi2Cut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-  const float normalizedGsfChi2CutValue = 
-    ( std::abs(cand->superCluster()->eta()) < barrelCutOff_ ? 
-      normalizedGsfChi2CutValueEB_ : normalizedGsfChi2CutValueEE_ );
+CutApplicatorBase::result_type GsfEleNormalizedGsfChi2Cut::operator()(const reco::GsfElectronPtr& cand) const {
+  const float normalizedGsfChi2CutValue =
+      (std::abs(cand->superCluster()->eta()) < barrelCutOff_ ? normalizedGsfChi2CutValueEB_
+                                                             : normalizedGsfChi2CutValueEE_);
 
   return std::abs(normalizedGsfChi2(cand)) < normalizedGsfChi2CutValue;
 }
 
 double GsfEleNormalizedGsfChi2Cut::value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+  reco::GsfElectronPtr ele(cand);
   return std::abs(normalizedGsfChi2(ele));
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleRelPFIsoScaledCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleRelPFIsoScaledCut.cc
@@ -2,76 +2,71 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
 
-
 class GsfEleRelPFIsoScaledCut : public CutApplicatorWithEventContentBase {
-  public:
-    GsfEleRelPFIsoScaledCut(const edm::ParameterSet& c);
-    
-    result_type operator()(const reco::GsfElectronPtr&) const final;
+public:
+  GsfEleRelPFIsoScaledCut(const edm::ParameterSet& c);
 
-    void setConsumes(edm::ConsumesCollector&) final;
-    void getEventContent(const edm::EventBase&) final;
+  result_type operator()(const reco::GsfElectronPtr&) const final;
 
-    double value(const reco::CandidatePtr& cand) const final;
+  void setConsumes(edm::ConsumesCollector&) final;
+  void getEventContent(const edm::EventBase&) final;
 
-    CandidateType candidateType() const final { 
-      return ELECTRON; 
-    }
+  double value(const reco::CandidatePtr& cand) const final;
 
-  private:
-    const float barrelC0_, endcapC0_, barrelCpt_, endcapCpt_, barrelCutOff_;
-    EffectiveAreas effectiveAreas_;
-    edm::Handle<double> rhoHandle_;
+  CandidateType candidateType() const final { return ELECTRON; }
+
+private:
+  const float barrelC0_, endcapC0_, barrelCpt_, endcapCpt_, barrelCutOff_;
+  EffectiveAreas effectiveAreas_;
+  edm::Handle<double> rhoHandle_;
 };
 
 DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleRelPFIsoScaledCut, "GsfEleRelPFIsoScaledCut");
 
-GsfEleRelPFIsoScaledCut::GsfEleRelPFIsoScaledCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  barrelC0_(c.getParameter<double>("barrelC0")),
-  endcapC0_(c.getParameter<double>("endcapC0")),
-  barrelCpt_(c.getParameter<double>("barrelCpt")),
-  endcapCpt_(c.getParameter<double>("endcapCpt")),
-  barrelCutOff_(c.getParameter<double>("barrelCutOff")),
-  effectiveAreas_((c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath())
-{
-  edm::InputTag rhoTag = c.getParameter<edm::InputTag>("rho");    
-  contentTags_.emplace("rho",rhoTag);  
+GsfEleRelPFIsoScaledCut::GsfEleRelPFIsoScaledCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      barrelC0_(c.getParameter<double>("barrelC0")),
+      endcapC0_(c.getParameter<double>("endcapC0")),
+      barrelCpt_(c.getParameter<double>("barrelCpt")),
+      endcapCpt_(c.getParameter<double>("endcapCpt")),
+      barrelCutOff_(c.getParameter<double>("barrelCutOff")),
+      effectiveAreas_((c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath()) {
+  edm::InputTag rhoTag = c.getParameter<edm::InputTag>("rho");
+  contentTags_.emplace("rho", rhoTag);
 }
 
-void GsfEleRelPFIsoScaledCut::setConsumes(edm::ConsumesCollector& cc){
+void GsfEleRelPFIsoScaledCut::setConsumes(edm::ConsumesCollector& cc) {
   auto rho = cc.consumes<double>(contentTags_["rho"]);
   contentTokens_.emplace("rho", rho);
 }
 
-void GsfEleRelPFIsoScaledCut::getEventContent(const edm::EventBase& ev){
+void GsfEleRelPFIsoScaledCut::getEventContent(const edm::EventBase& ev) {
   ev.getByLabel(contentTags_["rho"], rhoHandle_);
 }
 
-CutApplicatorBase::result_type GsfEleRelPFIsoScaledCut::operator()(const reco::GsfElectronPtr& cand) const {  
+CutApplicatorBase::result_type GsfEleRelPFIsoScaledCut::operator()(const reco::GsfElectronPtr& cand) const {
   // Establish the cut value
   double absEta = std::abs(cand->superCluster()->eta());
 
-  const float C0     = (absEta < barrelCutOff_ ? barrelC0_  : endcapC0_);
-  const float Cpt    = (absEta < barrelCutOff_ ? barrelCpt_ : endcapCpt_);
-  const float isoCut = C0+Cpt/cand->pt();
+  const float C0 = (absEta < barrelCutOff_ ? barrelC0_ : endcapC0_);
+  const float Cpt = (absEta < barrelCutOff_ ? barrelCpt_ : endcapCpt_);
+  const float isoCut = C0 + Cpt / cand->pt();
 
   return value(cand) < isoCut;
 }
 
 double GsfEleRelPFIsoScaledCut::value(const reco::CandidatePtr& cand) const {
-
   // Establish the cut value
   reco::GsfElectronPtr ele(cand);
   double absEta = std::abs(ele->superCluster()->eta());
-  
+
   // Compute the combined isolation with effective area correction
   auto pfIso = ele->pfIsolationVariables();
   const float chad = pfIso.sumChargedHadronPt;
   const float nhad = pfIso.sumNeutralHadronEt;
-  const float pho  = pfIso.sumPhotonEt;
-  const float  eA  = effectiveAreas_.getEffectiveArea(absEta);
-  const float rho  = rhoHandle_.isValid() ? (float)(*rhoHandle_) : 0; // std::max likes float arguments
-  const float iso  = chad + std::max(0.0f, nhad + pho - rho*eA);
-  return iso/cand->pt();
+  const float pho = pfIso.sumPhotonEt;
+  const float eA = effectiveAreas_.getEffectiveArea(absEta);
+  const float rho = rhoHandle_.isValid() ? (float)(*rhoHandle_) : 0;  // std::max likes float arguments
+  const float iso = chad + std::max(0.0f, nhad + pho - rho * eA);
+  return iso / cand->pt();
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleSCEtaMultiRangeCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleSCEtaMultiRangeCut.cc
@@ -3,44 +3,37 @@
 
 class GsfEleSCEtaMultiRangeCut : public CutApplicatorBase {
 public:
-  GsfEleSCEtaMultiRangeCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _absEta(c.getParameter<bool>("useAbsEta")) {
-    const std::vector<edm::ParameterSet>& ranges =
-      c.getParameterSetVector("allowedEtaRanges");
-    for( const auto& range : ranges ) {
+  GsfEleSCEtaMultiRangeCut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c), _absEta(c.getParameter<bool>("useAbsEta")) {
+    const std::vector<edm::ParameterSet>& ranges = c.getParameterSetVector("allowedEtaRanges");
+    for (const auto& range : ranges) {
       const double min = range.getParameter<double>("minEta");
       const double max = range.getParameter<double>("maxEta");
-      _ranges.emplace_back(min,max);
+      _ranges.emplace_back(min, max);
     }
   }
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   const bool _absEta;
-  std::vector<std::pair<double,double> > _ranges; 
+  std::vector<std::pair<double, double> > _ranges;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleSCEtaMultiRangeCut,
-		  "GsfEleSCEtaMultiRangeCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleSCEtaMultiRangeCut, "GsfEleSCEtaMultiRangeCut");
 
-CutApplicatorBase::result_type 
-GsfEleSCEtaMultiRangeCut::
-operator()(const reco::GsfElectronPtr& cand) const{
+CutApplicatorBase::result_type GsfEleSCEtaMultiRangeCut::operator()(const reco::GsfElectronPtr& cand) const {
   const reco::SuperClusterRef& scref = cand->superCluster();
-  const double the_eta = ( _absEta ? std::abs(scref->eta()) : scref->eta() );
+  const double the_eta = (_absEta ? std::abs(scref->eta()) : scref->eta());
   bool result = false;
-  for(const auto& range : _ranges ) {
-    if( the_eta >= range.first && the_eta < range.second ) {
-      result = true; break;
+  for (const auto& range : _ranges) {
+    if (the_eta >= range.first && the_eta < range.second) {
+      result = true;
+      break;
     }
   }
   return result;
@@ -49,5 +42,5 @@ operator()(const reco::GsfElectronPtr& cand) const{
 double GsfEleSCEtaMultiRangeCut::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
   const reco::SuperClusterRef& scref = ele->superCluster();
-  return ( _absEta ? std::abs(scref->eta()) : scref->eta() );
+  return (_absEta ? std::abs(scref->eta()) : scref->eta());
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleSCMaxAbsEtaCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleSCMaxAbsEtaCut.cc
@@ -3,30 +3,23 @@
 
 class GsfEleSCMaxAbsEtaCut : public CutApplicatorBase {
 public:
-  GsfEleSCMaxAbsEtaCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _maxEta(c.getParameter<bool>("maxEta")) { }
-  
+  GsfEleSCMaxAbsEtaCut(const edm::ParameterSet& c) : CutApplicatorBase(c), _maxEta(c.getParameter<bool>("maxEta")) {}
+
   result_type operator()(const reco::GsfElectronPtr& cand) const final {
     const reco::SuperClusterRef& scref = cand->superCluster();
     return std::abs(scref->eta()) < _maxEta;
   }
-  
+
   double value(const reco::CandidatePtr& cand) const final {
     reco::GsfElectronPtr ele(cand);
     const reco::SuperClusterRef& scref = ele->superCluster();
     return std::abs(scref->eta());
   }
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
   const double _maxEta;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleSCMaxAbsEtaCut,
-		  "GsfEleSCMaxAbsEtaCut");
-
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleSCMaxAbsEtaCut, "GsfEleSCMaxAbsEtaCut");

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleSigmaIEtaIEtaCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleSigmaIEtaIEtaCut.cc
@@ -3,40 +3,32 @@
 
 class GsfEleSigmaIEtaIEtaCut : public CutApplicatorBase {
 public:
-  GsfEleSigmaIEtaIEtaCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _sigmaIEtaIEtaCutValueEB(c.getParameter<double>("sigmaIEtaIEtaCutValueEB")),
-    _sigmaIEtaIEtaCutValueEE(c.getParameter<double>("sigmaIEtaIEtaCutValueEE")),
-    _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
-  }
-  
+  GsfEleSigmaIEtaIEtaCut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+        _sigmaIEtaIEtaCutValueEB(c.getParameter<double>("sigmaIEtaIEtaCutValueEB")),
+        _sigmaIEtaIEtaCutValueEE(c.getParameter<double>("sigmaIEtaIEtaCutValueEE")),
+        _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-  const double _sigmaIEtaIEtaCutValueEB,_sigmaIEtaIEtaCutValueEE,_barrelCutOff;
+  const double _sigmaIEtaIEtaCutValueEB, _sigmaIEtaIEtaCutValueEE, _barrelCutOff;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleSigmaIEtaIEtaCut,
-		  "GsfEleSigmaIEtaIEtaCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleSigmaIEtaIEtaCut, "GsfEleSigmaIEtaIEtaCut");
 
-CutApplicatorBase::result_type 
-GsfEleSigmaIEtaIEtaCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-  const float sigmaIEtaIEtaCutValue = 
-    ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? 
-      _sigmaIEtaIEtaCutValueEB : _sigmaIEtaIEtaCutValueEE );
+CutApplicatorBase::result_type GsfEleSigmaIEtaIEtaCut::operator()(const reco::GsfElectronPtr& cand) const {
+  const float sigmaIEtaIEtaCutValue =
+      (std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? _sigmaIEtaIEtaCutValueEB
+                                                                        : _sigmaIEtaIEtaCutValueEE);
   return cand->sigmaIetaIeta() < sigmaIEtaIEtaCutValue;
 }
 
-double GsfEleSigmaIEtaIEtaCut::
-value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+double GsfEleSigmaIEtaIEtaCut::value(const reco::CandidatePtr& cand) const {
+  reco::GsfElectronPtr ele(cand);
   return ele->sigmaIetaIeta();
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleTrkPtIsoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleTrkPtIsoCut.cc
@@ -9,54 +9,41 @@
 class GsfEleTrkPtIsoCut : public CutApplicatorBase {
 public:
   GsfEleTrkPtIsoCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
- 
   EBEECutValues slopeTerm_;
   EBEECutValues slopeStart_;
   EBEECutValues constTerm_;
   bool useHEEPIso_;
-  
+
   edm::Handle<double> rhoHandle_;
-  
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleTrkPtIsoCut,
-		  "GsfEleTrkPtIsoCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleTrkPtIsoCut, "GsfEleTrkPtIsoCut");
 
-GsfEleTrkPtIsoCut::GsfEleTrkPtIsoCut(const edm::ParameterSet& params) :
-  CutApplicatorBase(params),
-  slopeTerm_(params,"slopeTerm"),
-  slopeStart_(params,"slopeStart"),
-  constTerm_(params,"constTerm"),
-  useHEEPIso_(params.getParameter<bool>("useHEEPIso"))
-{
+GsfEleTrkPtIsoCut::GsfEleTrkPtIsoCut(const edm::ParameterSet& params)
+    : CutApplicatorBase(params),
+      slopeTerm_(params, "slopeTerm"),
+      slopeStart_(params, "slopeStart"),
+      constTerm_(params, "constTerm"),
+      useHEEPIso_(params.getParameter<bool>("useHEEPIso")) {}
 
-}
-
-
-CutApplicatorBase::result_type 
-GsfEleTrkPtIsoCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-  
+CutApplicatorBase::result_type GsfEleTrkPtIsoCut::operator()(const reco::GsfElectronPtr& cand) const {
   const float isolTrkPt = useHEEPIso_ ? cand->dr03TkSumPtHEEP() : cand->dr03TkSumPt();
 
   const float et = cand->et();
-  const float cutValue = et > slopeStart_(cand)  ? slopeTerm_(cand)*(et-slopeStart_(cand)) + constTerm_(cand) : constTerm_(cand);
+  const float cutValue =
+      et > slopeStart_(cand) ? slopeTerm_(cand) * (et - slopeStart_(cand)) + constTerm_(cand) : constTerm_(cand);
   return isolTrkPt < cutValue;
 }
 
-double GsfEleTrkPtIsoCut::
-value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+double GsfEleTrkPtIsoCut::value(const reco::CandidatePtr& cand) const {
+  reco::GsfElectronPtr ele(cand);
   return ele->dr03TkSumPt();
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleTrkPtIsoRhoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleTrkPtIsoRhoCut.cc
@@ -9,72 +9,60 @@
 class GsfEleTrkPtIsoRhoCut : public CutApplicatorWithEventContentBase {
 public:
   GsfEleTrkPtIsoRhoCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
- 
+
   void setConsumes(edm::ConsumesCollector&) final;
   void getEventContent(const edm::EventBase&) final;
-  
+
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
- 
   EBEECutValues slopeTerm_;
   EBEECutValues slopeStart_;
   EBEECutValues constTerm_;
   EBEECutValues rhoEtStart_;
   EBEECutValues rhoEA_;
-  
-  
+
   edm::Handle<double> rhoHandle_;
-  
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleTrkPtIsoRhoCut,
-		  "GsfEleTrkPtIsoRhoCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleTrkPtIsoRhoCut, "GsfEleTrkPtIsoRhoCut");
 
-GsfEleTrkPtIsoRhoCut::GsfEleTrkPtIsoRhoCut(const edm::ParameterSet& params) :
-  CutApplicatorWithEventContentBase(params),
-  slopeTerm_(params,"slopeTerm"),
-  slopeStart_(params,"slopeStart"),
-  constTerm_(params,"constTerm"),
-  rhoEtStart_(params,"rhoEtStart"),
-  rhoEA_(params,"rhoEA")
-{
+GsfEleTrkPtIsoRhoCut::GsfEleTrkPtIsoRhoCut(const edm::ParameterSet& params)
+    : CutApplicatorWithEventContentBase(params),
+      slopeTerm_(params, "slopeTerm"),
+      slopeStart_(params, "slopeStart"),
+      constTerm_(params, "constTerm"),
+      rhoEtStart_(params, "rhoEtStart"),
+      rhoEA_(params, "rhoEA") {
   edm::InputTag rhoTag = params.getParameter<edm::InputTag>("rho");
-  contentTags_.emplace("rho",rhoTag);
+  contentTags_.emplace("rho", rhoTag);
 }
 
 void GsfEleTrkPtIsoRhoCut::setConsumes(edm::ConsumesCollector& cc) {
   auto rho = cc.consumes<double>(contentTags_["rho"]);
-  contentTokens_.emplace("rho",rho);
+  contentTokens_.emplace("rho", rho);
 }
 
-void GsfEleTrkPtIsoRhoCut::getEventContent(const edm::EventBase& ev) {  
-  ev.getByLabel(contentTags_["rho"],rhoHandle_);
-}
+void GsfEleTrkPtIsoRhoCut::getEventContent(const edm::EventBase& ev) { ev.getByLabel(contentTags_["rho"], rhoHandle_); }
 
-CutApplicatorBase::result_type 
-GsfEleTrkPtIsoRhoCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
+CutApplicatorBase::result_type GsfEleTrkPtIsoRhoCut::operator()(const reco::GsfElectronPtr& cand) const {
   const double rho = (*rhoHandle_);
   const float isolTrkPt = cand->dr03TkSumPt();
 
   const float et = cand->et();
-  const float cutValue = et > slopeStart_(cand)  ? slopeTerm_(cand)*(et-slopeStart_(cand)) + constTerm_(cand) : constTerm_(cand);
+  const float cutValue =
+      et > slopeStart_(cand) ? slopeTerm_(cand) * (et - slopeStart_(cand)) + constTerm_(cand) : constTerm_(cand);
 
-  const float rhoCutValue = et >= rhoEtStart_(cand) ? rhoEA_(cand)*rho : 0.;
+  const float rhoCutValue = et >= rhoEtStart_(cand) ? rhoEA_(cand) * rho : 0.;
 
-  return isolTrkPt < cutValue+rhoCutValue;
+  return isolTrkPt < cutValue + rhoCutValue;
 }
 
-double GsfEleTrkPtIsoRhoCut::
-value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+double GsfEleTrkPtIsoRhoCut::value(const reco::CandidatePtr& cand) const {
+  reco::GsfElectronPtr ele(cand);
   return ele->dr03TkSumPt();
 }

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleValueMapIsoRhoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleValueMapIsoRhoCut.cc
@@ -6,89 +6,83 @@
 class GsfEleValueMapIsoRhoCut : public CutApplicatorWithEventContentBase {
 public:
   GsfEleValueMapIsoRhoCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::GsfElectronPtr&) const final;
- 
+
   void setConsumes(edm::ConsumesCollector&) final;
   void getEventContent(const edm::EventBase&) final;
-  
+
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return ELECTRON; 
-  }
+  CandidateType candidateType() const final { return ELECTRON; }
 
 private:
-  float getRhoCorr(const reco::GsfElectronPtr& cand)const;
-   
+  float getRhoCorr(const reco::GsfElectronPtr& cand) const;
+
   EBEECutValues slopeTerm_;
   EBEECutValues slopeStart_;
   EBEECutValues constTerm_;
   EBEECutValues rhoEtStart_;
   EBEECutValues rhoEA_;
-  
+
   bool useRho_;
-  
+
   edm::Handle<double> rhoHandle_;
   edm::Handle<edm::ValueMap<float> > valueHandle_;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GsfEleValueMapIsoRhoCut,
-		  "GsfEleValueMapIsoRhoCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GsfEleValueMapIsoRhoCut, "GsfEleValueMapIsoRhoCut");
 
-GsfEleValueMapIsoRhoCut::GsfEleValueMapIsoRhoCut(const edm::ParameterSet& params) :
-  CutApplicatorWithEventContentBase(params),
-  slopeTerm_(params,"slopeTerm"),
-  slopeStart_(params,"slopeStart"),
-  constTerm_(params,"constTerm"),
-  rhoEtStart_(params,"rhoEtStart"),
-  rhoEA_(params,"rhoEA")
-{
+GsfEleValueMapIsoRhoCut::GsfEleValueMapIsoRhoCut(const edm::ParameterSet& params)
+    : CutApplicatorWithEventContentBase(params),
+      slopeTerm_(params, "slopeTerm"),
+      slopeStart_(params, "slopeStart"),
+      constTerm_(params, "constTerm"),
+      rhoEtStart_(params, "rhoEtStart"),
+      rhoEA_(params, "rhoEA") {
   auto rho = params.getParameter<edm::InputTag>("rho");
-  if(!rho.label().empty()){
-    useRho_=true;
-    contentTags_.emplace("rho",rho);
-  }else useRho_=false;
-  
-  contentTags_.emplace("value",params.getParameter<edm::InputTag>("value"));
+  if (!rho.label().empty()) {
+    useRho_ = true;
+    contentTags_.emplace("rho", rho);
+  } else
+    useRho_ = false;
 
+  contentTags_.emplace("value", params.getParameter<edm::InputTag>("value"));
 }
 
 void GsfEleValueMapIsoRhoCut::setConsumes(edm::ConsumesCollector& cc) {
-  if(useRho_) contentTokens_.emplace("rho",cc.consumes<double>(contentTags_["rho"]));
-  contentTokens_.emplace("value",cc.consumes<edm::ValueMap<float> >(contentTags_["value"]));
+  if (useRho_)
+    contentTokens_.emplace("rho", cc.consumes<double>(contentTags_["rho"]));
+  contentTokens_.emplace("value", cc.consumes<edm::ValueMap<float> >(contentTags_["value"]));
 }
 
-void GsfEleValueMapIsoRhoCut::getEventContent(const edm::EventBase& ev) {  
-  if(useRho_) ev.getByLabel(contentTags_["rho"],rhoHandle_);
-  ev.getByLabel(contentTags_["value"],valueHandle_);
+void GsfEleValueMapIsoRhoCut::getEventContent(const edm::EventBase& ev) {
+  if (useRho_)
+    ev.getByLabel(contentTags_["rho"], rhoHandle_);
+  ev.getByLabel(contentTags_["value"], valueHandle_);
 }
 
-CutApplicatorBase::result_type 
-GsfEleValueMapIsoRhoCut::
-operator()(const reco::GsfElectronPtr& cand) const{  
-
+CutApplicatorBase::result_type GsfEleValueMapIsoRhoCut::operator()(const reco::GsfElectronPtr& cand) const {
   const float val = (*valueHandle_)[cand];
 
   const float et = cand->et();
-  const float cutValue = et > slopeStart_(cand)  ? slopeTerm_(cand)*(et-slopeStart_(cand)) + constTerm_(cand) : constTerm_(cand);
+  const float cutValue =
+      et > slopeStart_(cand) ? slopeTerm_(cand) * (et - slopeStart_(cand)) + constTerm_(cand) : constTerm_(cand);
   const float rhoCutValue = getRhoCorr(cand);
 
-  return val < cutValue+rhoCutValue;
+  return val < cutValue + rhoCutValue;
 }
 
-
-double GsfEleValueMapIsoRhoCut::
-value(const reco::CandidatePtr& cand) const {
-  reco::GsfElectronPtr ele(cand);  
+double GsfEleValueMapIsoRhoCut::value(const reco::CandidatePtr& cand) const {
+  reco::GsfElectronPtr ele(cand);
   return (*valueHandle_)[cand];
 }
 
-float GsfEleValueMapIsoRhoCut::getRhoCorr(const reco::GsfElectronPtr& cand)const{
-  if(!useRho_) return 0.;
-  else{
+float GsfEleValueMapIsoRhoCut::getRhoCorr(const reco::GsfElectronPtr& cand) const {
+  if (!useRho_)
+    return 0.;
+  else {
     const double rho = (*rhoHandle_);
-    return cand->et() >= rhoEtStart_(cand) ? rhoEA_(cand)*rho : 0.;
+    return cand->et() >= rhoEtStart_(cand) ? rhoEA_(cand) * rho : 0.;
   }
 }

--- a/RecoEgamma/ElectronIdentification/plugins/plugins.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/plugins.cc
@@ -15,32 +15,25 @@
 typedef VersionedIdProducer<reco::GsfElectronPtr> VersionedGsfElectronIdProducer;
 DEFINE_FWK_MODULE(VersionedGsfElectronIdProducer);
 
-
 typedef VersionedIdProducer<pat::ElectronPtr> VersionedPatElectronIdProducer;
 DEFINE_FWK_MODULE(VersionedPatElectronIdProducer);
 
-typedef ElectronIDSelector<ElectronIDSelectorCutBased>   EleIdCutBasedSel;
+typedef ElectronIDSelector<ElectronIDSelectorCutBased> EleIdCutBasedSel;
 typedef ElectronIDSelector<ElectronIDSelectorLikelihood> EleIdLikelihoodSel;
-typedef ObjectSelector<
-          EleIdCutBasedSel, 
-          edm::RefVector<reco::GsfElectronCollection> 
-         > EleIdCutBasedRef ;
-typedef ObjectSelector<
-          EleIdLikelihoodSel, 
-          edm::RefVector<reco::GsfElectronCollection> 
-         > EleIdLikelihoodRef ;
+typedef ObjectSelector<EleIdCutBasedSel, edm::RefVector<reco::GsfElectronCollection> > EleIdCutBasedRef;
+typedef ObjectSelector<EleIdLikelihoodSel, edm::RefVector<reco::GsfElectronCollection> > EleIdLikelihoodRef;
 DEFINE_FWK_MODULE(EleIdCutBasedRef);
 DEFINE_FWK_MODULE(EleIdLikelihoodRef);
 
 #include "RecoEgamma/ElectronIdentification/plugins/ElectronIDExternalProducer.h"
-typedef ElectronIDExternalProducer<ElectronIDSelectorCutBased>   EleIdCutBasedExtProducer;
+typedef ElectronIDExternalProducer<ElectronIDSelectorCutBased> EleIdCutBasedExtProducer;
 typedef ElectronIDExternalProducer<ElectronIDSelectorLikelihood> EleIdLikelihoodExtProducer;
 DEFINE_FWK_MODULE(EleIdCutBasedExtProducer);
 DEFINE_FWK_MODULE(EleIdLikelihoodExtProducer);
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "RecoEgamma/ElectronIdentification/plugins/ElectronLikelihoodESSource.h"
-DEFINE_FWK_EVENTSETUP_MODULE( ElectronLikelihoodESSource );
+DEFINE_FWK_EVENTSETUP_MODULE(ElectronLikelihoodESSource);
 
 typedef ObjectSelector<EleIdCutBasedSel, reco::GsfElectronCollection> EleIdCutBased;
 DEFINE_FWK_MODULE(EleIdCutBased);

--- a/RecoEgamma/ElectronIdentification/src/ClassBasedElectronID.cc
+++ b/RecoEgamma/ElectronIdentification/src/ClassBasedElectronID.cc
@@ -1,106 +1,111 @@
 #include "RecoEgamma/ElectronIdentification/interface/ClassBasedElectronID.h"
 
 // ===========================================================================================================
-void ClassBasedElectronID::setup(const edm::ParameterSet& conf) 
+void ClassBasedElectronID::setup(const edm::ParameterSet& conf)
 // ===========================================================================================================
 {
-
-
   // Get all the parameters
   //baseSetup(conf);
-  
-  quality_ =  conf.getParameter<std::string>("electronQuality");
-  
-	if(quality_=="Eff95Cuts") {
-		cuts_ = conf.getParameter<edm::ParameterSet>("Eff95Cuts");
-	}
-	
-	else if(quality_=="Eff90Cuts") {
-		cuts_ = conf.getParameter<edm::ParameterSet>("Eff90Cuts");
-	}
-	
-	else {
-    edm::LogError("ClassBasedElectronID") << "Invalid electronQuality parameter: must be tight, medium or loose." ;
-    exit (1);
+
+  quality_ = conf.getParameter<std::string>("electronQuality");
+
+  if (quality_ == "Eff95Cuts") {
+    cuts_ = conf.getParameter<edm::ParameterSet>("Eff95Cuts");
   }
-  
-} // end of setup
 
-double ClassBasedElectronID::result(const reco::GsfElectron* electron,
-                                    const edm::Event& e ,
-									const edm::EventSetup& es) 
-{
+  else if (quality_ == "Eff90Cuts") {
+    cuts_ = conf.getParameter<edm::ParameterSet>("Eff90Cuts");
+  }
 
+  else {
+    edm::LogError("ClassBasedElectronID") << "Invalid electronQuality parameter: must be tight, medium or loose.";
+    exit(1);
+  }
+
+}  // end of setup
+
+double ClassBasedElectronID::result(const reco::GsfElectron* electron, const edm::Event& e, const edm::EventSetup& es) {
   //determine which element of the cut arrays in cfi file to read
   //depending on the electron classification
-  int icut=0;
-  int elClass = electron->classification() ;
-  if (electron->isEB()) //barrel
-     {
-       if (elClass == reco::GsfElectron::GOLDEN)    icut=0;
-       if (elClass == reco::GsfElectron::BIGBREM)   icut=1;
-       if (elClass == reco::GsfElectron::SHOWERING) icut=2;
-       if (elClass == reco::GsfElectron::GAP)       icut=6;
-     }
-  if (electron->isEE()) //endcap
-     {
-       if (elClass == reco::GsfElectron::GOLDEN)    icut=3;
-       if (elClass == reco::GsfElectron::BIGBREM)   icut=4;
-       if (elClass == reco::GsfElectron::SHOWERING) icut=5;
-       if (elClass == reco::GsfElectron::GAP)       icut=7;
-     }
-  if (elClass == reco::GsfElectron::UNKNOWN) 
-     {
-       edm::LogError("ClassBasedElectronID") << "Error: unrecognized electron classification ";
-       return 1.;
-     }
+  int icut = 0;
+  int elClass = electron->classification();
+  if (electron->isEB())  //barrel
+  {
+    if (elClass == reco::GsfElectron::GOLDEN)
+      icut = 0;
+    if (elClass == reco::GsfElectron::BIGBREM)
+      icut = 1;
+    if (elClass == reco::GsfElectron::SHOWERING)
+      icut = 2;
+    if (elClass == reco::GsfElectron::GAP)
+      icut = 6;
+  }
+  if (electron->isEE())  //endcap
+  {
+    if (elClass == reco::GsfElectron::GOLDEN)
+      icut = 3;
+    if (elClass == reco::GsfElectron::BIGBREM)
+      icut = 4;
+    if (elClass == reco::GsfElectron::SHOWERING)
+      icut = 5;
+    if (elClass == reco::GsfElectron::GAP)
+      icut = 7;
+  }
+  if (elClass == reco::GsfElectron::UNKNOWN) {
+    edm::LogError("ClassBasedElectronID") << "Error: unrecognized electron classification ";
+    return 1.;
+  }
 
-  bool useDeltaEtaIn       = true;
-  bool useSigmaIetaIeta    = true;
-  bool useHoverE           = true;
-  bool useEoverPOut        = true;
+  bool useDeltaEtaIn = true;
+  bool useSigmaIetaIeta = true;
+  bool useHoverE = true;
+  bool useEoverPOut = true;
   bool useDeltaPhiInCharge = true;
 
   // DeltaEtaIn
-  if (useDeltaEtaIn) { 
+  if (useDeltaEtaIn) {
     double value = electron->deltaEtaSuperClusterTrackAtVtx();
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("deltaEtaIn");
-    if (fabs(value)>maxcut[icut]) return 0.;
-  } 
+    if (fabs(value) > maxcut[icut])
+      return 0.;
+  }
 
   // SigmaIetaIeta
-  if(useSigmaIetaIeta) {
-    double value = electron->sigmaIetaIeta() ; 
+  if (useSigmaIetaIeta) {
+    double value = electron->sigmaIetaIeta();
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("sigmaIetaIetaMax");
     std::vector<double> mincut = cuts_.getParameter<std::vector<double> >("sigmaIetaIetaMin");
-    if(value<mincut[icut] || value>maxcut[icut]) return 0.;   
-  } 
+    if (value < mincut[icut] || value > maxcut[icut])
+      return 0.;
+  }
 
   // H/E
-  if (useHoverE) { //_[variables_]) {
+  if (useHoverE) {  //_[variables_]) {
     double value = electron->hadronicOverEm();
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("HoverE");
-    if (value>maxcut[icut]) return 0.;
-  } // if use
- 
+    if (value > maxcut[icut])
+      return 0.;
+  }  // if use
+
   // Eseed/Pout
-  if (useEoverPOut) { 
-	double value = electron->eSeedClusterOverPout();
+  if (useEoverPOut) {
+    double value = electron->eSeedClusterOverPout();
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("EoverPOutMax");
     std::vector<double> mincut = cuts_.getParameter<std::vector<double> >("EoverPOutMin");
-    if (value<mincut[icut] || value>maxcut[icut]) return 0.;
-  } 
+    if (value < mincut[icut] || value > maxcut[icut])
+      return 0.;
+  }
 
   // DeltaPhiIn*Charge
-  if (useDeltaPhiInCharge) { 
+  if (useDeltaPhiInCharge) {
     double value1 = electron->deltaPhiSuperClusterTrackAtVtx();
     double value2 = electron->charge();
-    double value  = value1*value2;
+    double value = value1 * value2;
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("deltaPhiInChargeMax");
     std::vector<double> mincut = cuts_.getParameter<std::vector<double> >("deltaPhiInChargeMin");
-    if (value<mincut[icut] || value>maxcut[icut]) return 0.;
-  } 
-  
-  return 1.;
+    if (value < mincut[icut] || value > maxcut[icut])
+      return 0.;
+  }
 
+  return 1.;
 }

--- a/RecoEgamma/ElectronIdentification/src/CutBasedElectronID.cc
+++ b/RecoEgamma/ElectronIdentification/src/CutBasedElectronID.cc
@@ -5,14 +5,11 @@
 
 #include <algorithm>
 
-CutBasedElectronID::CutBasedElectronID(const edm::ParameterSet& conf,edm::ConsumesCollector & iC)
-{
+CutBasedElectronID::CutBasedElectronID(const edm::ParameterSet& conf, edm::ConsumesCollector& iC) {
   verticesCollection_ = iC.consumes<std::vector<reco::Vertex> >(conf.getParameter<edm::InputTag>("verticesCollection"));
-
 }
 
 void CutBasedElectronID::setup(const edm::ParameterSet& conf) {
-
   // Get all the parameters
   //baseSetup(conf);
 
@@ -20,7 +17,7 @@ void CutBasedElectronID::setup(const edm::ParameterSet& conf) {
   quality_ = conf.getParameter<std::string>("electronQuality");
   version_ = conf.getParameter<std::string>("electronVersion");
   //verticesCollection_ = conf.getParameter<edm::InputTag>("verticesCollection");
-  
+
   if (type_ == "classbased" and (version_ == "V06")) {
     newCategories_ = conf.getParameter<bool>("additionalCategories");
   }
@@ -31,60 +28,54 @@ void CutBasedElectronID::setup(const edm::ParameterSet& conf) {
   }
 
   if (type_ == "robust" || type_ == "classbased") {
-    std::string stringCut = type_+quality_+"EleIDCuts"+version_;
+    std::string stringCut = type_ + quality_ + "EleIDCuts" + version_;
     cuts_ = conf.getParameter<edm::ParameterSet>(stringCut);
-  }
-  else {
+  } else {
     throw cms::Exception("Configuration")
-      << "Invalid electronType parameter in CutBasedElectronID: must be robust or classbased\n";
+        << "Invalid electronType parameter in CutBasedElectronID: must be robust or classbased\n";
   }
 }
 
-double CutBasedElectronID::result(const reco::GsfElectron* electron ,
-                                  const edm::Event& e ,
-                                  const edm::EventSetup& es) {
-
+double CutBasedElectronID::result(const reco::GsfElectron* electron, const edm::Event& e, const edm::EventSetup& es) {
   if (type_ == "classbased")
     return cicSelection(electron, e, es);
   else if (type_ == "robust")
     return robustSelection(electron, e, es);
 
   return 0;
-
 }
 
 int CutBasedElectronID::classify(const reco::GsfElectron* electron) {
-
   double eta = fabs(electron->superCluster()->eta());
   double eOverP = electron->eSuperClusterOverP();
   double fBrem = electron->fbrem();
 
   int cat = -1;
   if (version_ == "V00" || version_ == "V01") {
-    if((electron->isEB() && fBrem<0.06) || (electron->isEE() && fBrem<0.1))
-      cat=1;
+    if ((electron->isEB() && fBrem < 0.06) || (electron->isEE() && fBrem < 0.1))
+      cat = 1;
     else if (eOverP < 1.2 && eOverP > 0.8)
-      cat=0;
+      cat = 0;
     else
-      cat=2;
+      cat = 2;
 
     return cat;
 
   } else if (version_ == "V02") {
-    if (electron->isEB()) {       // BARREL
-      if(fBrem < 0.12)
-        cat=1;
+    if (electron->isEB()) {  // BARREL
+      if (fBrem < 0.12)
+        cat = 1;
       else if (eOverP < 1.2 && eOverP > 0.9)
-        cat=0;
+        cat = 0;
       else
-        cat=2;
-    } else {                     // ENDCAP
-      if(fBrem < 0.2)
-        cat=1;
+        cat = 2;
+    } else {  // ENDCAP
+      if (fBrem < 0.2)
+        cat = 1;
       else if (eOverP < 1.22 && eOverP > 0.82)
-        cat=0;
+        cat = 0;
       else
-        cat=2;
+        cat = 2;
     }
 
     return cat;
@@ -93,10 +84,9 @@ int CutBasedElectronID::classify(const reco::GsfElectron* electron) {
     if (electron->isEB()) {
       if ((fBrem >= 0.12) and (eOverP > 0.9) and (eOverP < 1.2))
         cat = 0;
-      else if (((eta >  .445   and eta <  .45  ) or
-                (eta >  .79    and eta <  .81  ) or
-                (eta > 1.137   and eta < 1.157 ) or
-                (eta > 1.47285 and eta < 1.4744)) and newCategories_)
+      else if (((eta > .445 and eta < .45) or (eta > .79 and eta < .81) or (eta > 1.137 and eta < 1.157) or
+                (eta > 1.47285 and eta < 1.4744)) and
+               newCategories_)
         cat = 6;
       else if (electron->trackerDrivenSeed() and !electron->ecalDrivenSeed() and newCategories_)
         cat = 8;
@@ -107,7 +97,7 @@ int CutBasedElectronID::classify(const reco::GsfElectron* electron) {
     } else {
       if ((fBrem >= 0.2) and (eOverP > 0.82) and (eOverP < 1.22))
         cat = 3;
-      else if (eta > 1.5 and eta <  1.58 and newCategories_)
+      else if (eta > 1.5 and eta < 1.58 and newCategories_)
         cat = 7;
       else if (electron->trackerDrivenSeed() and !electron->ecalDrivenSeed() and newCategories_)
         cat = 8;
@@ -126,9 +116,8 @@ int CutBasedElectronID::classify(const reco::GsfElectron* electron) {
 double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
                                         const edm::Event& e,
                                         const edm::EventSetup& es) {
-
-  double scTheta = (2*atan(exp(-electron->superCluster()->eta())));
-  double scEt = electron->superCluster()->energy()*sin(scTheta);
+  double scTheta = (2 * atan(exp(-electron->superCluster()->eta())));
+  double scEt = electron->superCluster()->energy() * sin(scTheta);
 
   double eta = fabs(electron->superCluster()->eta());
 
@@ -136,7 +125,7 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
   double eSeedOverPin = electron->eSeedClusterOverP();
   double fBrem = electron->fbrem();
   double hOverE = electron->hadronicOverEm();
-  double sigmaee = electron->sigmaIetaIeta(); //sqrt(vLocCov[0]);
+  double sigmaee = electron->sigmaIetaIeta();  //sqrt(vLocCov[0]);
   double deltaPhiIn = electron->deltaPhiSuperClusterTrackAtVtx();
   double deltaEtaIn = electron->deltaEtaSuperClusterTrackAtVtx();
 
@@ -147,9 +136,9 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
   double hcalIso = electron->dr04HcalTowerSumEt();
 
   if (version_ == "V00") {
-    sigmaee = electron->sigmaEtaEta();//sqrt(vCov[0]);
+    sigmaee = electron->sigmaEtaEta();  //sqrt(vCov[0]);
     if (electron->isEE())
-      sigmaee = sigmaee - 0.02*(fabs(eta) - 2.3);   //correct sigmaetaeta dependence on eta in endcap
+      sigmaee = sigmaee - 0.02 * (fabs(eta) - 2.3);  //correct sigmaetaeta dependence on eta in endcap
   }
 
   if (version_ != "V01" or version_ != "V00") {
@@ -157,12 +146,12 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
     e.getByToken(verticesCollection_, vtxH);
     if (!vtxH->empty()) {
       reco::VertexRef vtx(vtxH, 0);
-      ip = fabs(electron->gsfTrack()->dxy(math::XYZPoint(vtx->x(),vtx->y(),vtx->z())));
+      ip = fabs(electron->gsfTrack()->dxy(math::XYZPoint(vtx->x(), vtx->y(), vtx->z())));
     } else
       ip = fabs(electron->gsfTrack()->dxy());
 
     if (electron->isEB()) {
-      sigmaee = electron->sigmaIetaIeta(); //sqrt(vCov[0]);
+      sigmaee = electron->sigmaIetaIeta();  //sqrt(vCov[0]);
     }
   }
 
@@ -178,37 +167,36 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
 
   // LOOSE and TIGHT Selections
   if (type_ == "classbased" && (version_ == "V01" || version_ == "V00")) {
-
     if ((eOverP < 0.8) && (fBrem < 0.2))
       return 0.;
 
     cut = cuts_.getParameter<std::vector<double> >("hOverE");
-    if (hOverE > cut[cat+4*eb])
+    if (hOverE > cut[cat + 4 * eb])
       return 0.;
 
     cut = cuts_.getParameter<std::vector<double> >("sigmaEtaEta");
-    if (sigmaee > cut[cat+4*eb])
+    if (sigmaee > cut[cat + 4 * eb])
       return 0.;
 
     cut = cuts_.getParameter<std::vector<double> >("deltaPhiIn");
     if (eOverP < 1.5) {
-      if (fabs(deltaPhiIn) > cut[cat+4*eb])
+      if (fabs(deltaPhiIn) > cut[cat + 4 * eb])
         return 0.;
     } else {
-      if (fabs(deltaPhiIn) > cut[3+4*eb])
+      if (fabs(deltaPhiIn) > cut[3 + 4 * eb])
         return 0.;
     }
 
     cut = cuts_.getParameter<std::vector<double> >("deltaEtaIn");
-    if (fabs(deltaEtaIn) > cut[cat+4*eb])
+    if (fabs(deltaEtaIn) > cut[cat + 4 * eb])
       return 0.;
 
     cut = cuts_.getParameter<std::vector<double> >("eSeedOverPin");
-    if (eSeedOverPin < cut[cat+4*eb])
+    if (eSeedOverPin < cut[cat + 4 * eb])
       return 0.;
 
     if (quality_ == "tight")
-      if (eOverP < 0.9*(1-fBrem))
+      if (eOverP < 0.9 * (1 - fBrem))
         return 0.;
 
     return 1.;
@@ -230,17 +218,16 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
       eSeedOverPin = eSeedOverPin + fBrem;
 
     if (bin != 2) {
-      tkIso = tkIso*pow(40./scEt, 2);
-      ecalIso = ecalIso*pow(40./scEt, 2);
-      hcalIso = hcalIso*pow(40./scEt, 2);
+      tkIso = tkIso * pow(40. / scEt, 2);
+      ecalIso = ecalIso * pow(40. / scEt, 2);
+      hcalIso = hcalIso * pow(40. / scEt, 2);
     }
 
     std::vector<double> cutTk = cuts_.getParameter<std::vector<double> >("cutisotk");
     std::vector<double> cutEcal = cuts_.getParameter<std::vector<double> >("cutisoecal");
     std::vector<double> cutHcal = cuts_.getParameter<std::vector<double> >("cutisohcal");
-    if ((tkIso > cutTk[cat+3*eb+bin*6]) ||
-        (ecalIso > cutEcal[cat+3*eb+bin*6]) ||
-        (hcalIso > cutHcal[cat+3*eb+bin*6]))
+    if ((tkIso > cutTk[cat + 3 * eb + bin * 6]) || (ecalIso > cutEcal[cat + 3 * eb + bin * 6]) ||
+        (hcalIso > cutHcal[cat + 3 * eb + bin * 6]))
       result = 0.;
     else
       result = 2.;
@@ -254,13 +241,10 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
       std::vector<double> cutet = cuts_.getParameter<std::vector<double> >("cutet");
       std::vector<double> cutip = cuts_.getParameter<std::vector<double> >("cutip");
       std::vector<double> cutmishits = cuts_.getParameter<std::vector<double> >("cutmishits");
-      if ((hOverE < cuthoe[cat+3*eb+bin*6]) and
-          (sigmaee < cutsee[cat+3*eb+bin*6]) and
-          (fabs(deltaPhiIn) < cutdphi[cat+3*eb+bin*6]) and
-          (fabs(deltaEtaIn) < cutdeta[cat+3*eb+bin*6]) and
-          (eSeedOverPin > cuteopin[cat+3*eb+bin*6]) and
-          (ip < cutip[cat+3*eb+bin*6]) and
-          (mishits < cutmishits[cat+3*eb+bin*6]))
+      if ((hOverE < cuthoe[cat + 3 * eb + bin * 6]) and (sigmaee < cutsee[cat + 3 * eb + bin * 6]) and
+          (fabs(deltaPhiIn) < cutdphi[cat + 3 * eb + bin * 6]) and
+          (fabs(deltaEtaIn) < cutdeta[cat + 3 * eb + bin * 6]) and (eSeedOverPin > cuteopin[cat + 3 * eb + bin * 6]) and
+          (ip < cutip[cat + 3 * eb + bin * 6]) and (mishits < cutmishits[cat + 3 * eb + bin * 6]))
         result = result + 1.;
     }
     return result;
@@ -284,12 +268,11 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
       eSeedOverPin = eSeedOverPin + fBrem;
 
     float iso_sum = tkIso + ecalIso + hcalIso;
-    float iso_sum_corrected = iso_sum*pow(40./scEt, 2);
+    float iso_sum_corrected = iso_sum * pow(40. / scEt, 2);
 
     std::vector<double> cutIsoSum = cuts_.getParameter<std::vector<double> >("cutiso_sum");
     std::vector<double> cutIsoSumCorr = cuts_.getParameter<std::vector<double> >("cutiso_sumoet");
-    if ((iso_sum < cutIsoSum[cat+bin*9]) and
-        (iso_sum_corrected < cutIsoSumCorr[cat+bin*9]))
+    if ((iso_sum < cutIsoSum[cat + bin * 9]) and (iso_sum_corrected < cutIsoSumCorr[cat + bin * 9]))
       result += 2.;
 
     if (fBrem > -2) {
@@ -300,120 +283,118 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
       std::vector<double> cuteopin = cuts_.getParameter<std::vector<double> >("cuteseedopcor");
       std::vector<double> cutet = cuts_.getParameter<std::vector<double> >("cutet");
 
-      if ((hOverE < cuthoe[cat+bin*9]) and
-          (sigmaee < cutsee[cat+bin*9]) and
-          (fabs(deltaPhiIn) < cutdphi[cat+bin*9]) and
-          (fabs(deltaEtaIn) < cutdeta[cat+bin*9]) and
-          (eSeedOverPin > cuteopin[cat+bin*9]) and
-          (scEt > cutet[cat+bin*9]))
+      if ((hOverE < cuthoe[cat + bin * 9]) and (sigmaee < cutsee[cat + bin * 9]) and
+          (fabs(deltaPhiIn) < cutdphi[cat + bin * 9]) and (fabs(deltaEtaIn) < cutdeta[cat + bin * 9]) and
+          (eSeedOverPin > cuteopin[cat + bin * 9]) and (scEt > cutet[cat + bin * 9]))
         result += 1.;
     }
 
     std::vector<double> cutip = cuts_.getParameter<std::vector<double> >("cutip_gsf");
-    if (ip < cutip[cat+bin*9])
+    if (ip < cutip[cat + bin * 9])
       result += 8;
-    
+
     std::vector<double> cutmishits = cuts_.getParameter<std::vector<double> >("cutfmishits");
     std::vector<double> cutdcotdist = cuts_.getParameter<std::vector<double> >("cutdcotdist");
-    
-    float dist = (electron->convDist() == -9999.? 9999:electron->convDist());
-    float dcot = (electron->convDcot() == -9999.? 9999:electron->convDcot());
 
-    float dcotdistcomb = ((0.04 - std::max(fabs(dist), fabs(dcot))) > 0?(0.04 - std::max(fabs(dist), fabs(dcot))):0);
+    float dist = (electron->convDist() == -9999. ? 9999 : electron->convDist());
+    float dcot = (electron->convDcot() == -9999. ? 9999 : electron->convDcot());
 
-    if ((mishits < cutmishits[cat+bin*9]) and
-        (dcotdistcomb < cutdcotdist[cat+bin*9]))
+    float dcotdistcomb =
+        ((0.04 - std::max(fabs(dist), fabs(dcot))) > 0 ? (0.04 - std::max(fabs(dist), fabs(dcot))) : 0);
+
+    if ((mishits < cutmishits[cat + bin * 9]) and (dcotdistcomb < cutdcotdist[cat + bin * 9]))
       result += 4;
 
     return result;
   }
 
-  if (type_ == "classbased" && (version_ == "V06" || version_.empty())) { 
-    std::vector<double> cutIsoSum      = cuts_.getParameter<std::vector<double> >("cutiso_sum");
-    std::vector<double> cutIsoSumCorr  = cuts_.getParameter<std::vector<double> >("cutiso_sumoet");
-    std::vector<double> cuthoe         = cuts_.getParameter<std::vector<double> >("cuthoe");
-    std::vector<double> cutsee         = cuts_.getParameter<std::vector<double> >("cutsee");
-    std::vector<double> cutdphi        = cuts_.getParameter<std::vector<double> >("cutdphiin");
-    std::vector<double> cutdeta        = cuts_.getParameter<std::vector<double> >("cutdetain");
-    std::vector<double> cuteopin       = cuts_.getParameter<std::vector<double> >("cuteseedopcor");
-    std::vector<double> cutmishits     = cuts_.getParameter<std::vector<double> >("cutfmishits");
-    std::vector<double> cutdcotdist    = cuts_.getParameter<std::vector<double> >("cutdcotdist");
-    std::vector<double> cutip          = cuts_.getParameter<std::vector<double> >("cutip_gsf");
+  if (type_ == "classbased" && (version_ == "V06" || version_.empty())) {
+    std::vector<double> cutIsoSum = cuts_.getParameter<std::vector<double> >("cutiso_sum");
+    std::vector<double> cutIsoSumCorr = cuts_.getParameter<std::vector<double> >("cutiso_sumoet");
+    std::vector<double> cuthoe = cuts_.getParameter<std::vector<double> >("cuthoe");
+    std::vector<double> cutsee = cuts_.getParameter<std::vector<double> >("cutsee");
+    std::vector<double> cutdphi = cuts_.getParameter<std::vector<double> >("cutdphiin");
+    std::vector<double> cutdeta = cuts_.getParameter<std::vector<double> >("cutdetain");
+    std::vector<double> cuteopin = cuts_.getParameter<std::vector<double> >("cuteseedopcor");
+    std::vector<double> cutmishits = cuts_.getParameter<std::vector<double> >("cutfmishits");
+    std::vector<double> cutdcotdist = cuts_.getParameter<std::vector<double> >("cutdcotdist");
+    std::vector<double> cutip = cuts_.getParameter<std::vector<double> >("cutip_gsf");
     std::vector<double> cutIsoSumCorrl = cuts_.getParameter<std::vector<double> >("cutiso_sumoetl");
-    std::vector<double> cuthoel        = cuts_.getParameter<std::vector<double> >("cuthoel");
-    std::vector<double> cutseel        = cuts_.getParameter<std::vector<double> >("cutseel");
-    std::vector<double> cutdphil       = cuts_.getParameter<std::vector<double> >("cutdphiinl");
-    std::vector<double> cutdetal       = cuts_.getParameter<std::vector<double> >("cutdetainl");
-    std::vector<double> cutipl         = cuts_.getParameter<std::vector<double> >("cutip_gsfl");
-    
+    std::vector<double> cuthoel = cuts_.getParameter<std::vector<double> >("cuthoel");
+    std::vector<double> cutseel = cuts_.getParameter<std::vector<double> >("cutseel");
+    std::vector<double> cutdphil = cuts_.getParameter<std::vector<double> >("cutdphiinl");
+    std::vector<double> cutdetal = cuts_.getParameter<std::vector<double> >("cutdetainl");
+    std::vector<double> cutipl = cuts_.getParameter<std::vector<double> >("cutip_gsfl");
+
     int result = 0;
-    
+
     const int ncuts = 10;
     std::vector<bool> cut_results(ncuts, false);
-    
+
     float iso_sum = tkIso + ecalIso + hcalIso;
     float scEta = electron->superCluster()->eta();
-    if(fabs(scEta)>1.5) 
-      iso_sum += (fabs(scEta)-1.5)*1.09;
-    
-    float iso_sumoet = iso_sum*(40./scEt);
-    
+    if (fabs(scEta) > 1.5)
+      iso_sum += (fabs(scEta) - 1.5) * 1.09;
+
+    float iso_sumoet = iso_sum * (40. / scEt);
+
     float eseedopincor = eSeedOverPin + fBrem;
-    if(fBrem < 0)
+    if (fBrem < 0)
       eseedopincor = eSeedOverPin;
 
-    float dist = (electron->convDist() == -9999.? 9999:electron->convDist());
-    float dcot = (electron->convDcot() == -9999.? 9999:electron->convDcot());
+    float dist = (electron->convDist() == -9999. ? 9999 : electron->convDist());
+    float dcot = (electron->convDcot() == -9999. ? 9999 : electron->convDcot());
 
-    float dcotdistcomb = ((0.04 - std::max(fabs(dist), fabs(dcot))) > 0?(0.04 - std::max(fabs(dist), fabs(dcot))):0);
+    float dcotdistcomb =
+        ((0.04 - std::max(fabs(dist), fabs(dcot))) > 0 ? (0.04 - std::max(fabs(dist), fabs(dcot))) : 0);
 
-    for (int cut=0; cut<ncuts; cut++) {
+    for (int cut = 0; cut < ncuts; cut++) {
       switch (cut) {
-      case 0:
-        cut_results[cut] = compute_cut(fabs(deltaEtaIn), scEt, cutdetal[cat], cutdeta[cat]);
-        break;
-      case 1:
-        cut_results[cut] = compute_cut(fabs(deltaPhiIn), scEt, cutdphil[cat], cutdphi[cat]);
-        break;
-      case 2:
-        cut_results[cut] = (eseedopincor > cuteopin[cat]);
-        break;
-      case 3:
-        cut_results[cut] = compute_cut(hOverE, scEt, cuthoel[cat], cuthoe[cat]);
-        break;
-      case 4:
-        cut_results[cut] = compute_cut(sigmaee, scEt, cutseel[cat], cutsee[cat]);
-        break;
-      case 5:
-        cut_results[cut] = compute_cut(iso_sumoet, scEt, cutIsoSumCorrl[cat], cutIsoSumCorr[cat]);
-        break;
-      case 6:
-        cut_results[cut] = (iso_sum < cutIsoSum[cat]);
-        break;
-      case 7:
-        cut_results[cut] = compute_cut(fabs(ip), scEt, cutipl[cat], cutip[cat]);
-        break;
-      case 8:
-        cut_results[cut] = (mishits < cutmishits[cat]);
-        break;
-      case 9:
-        cut_results[cut] = (dcotdistcomb < cutdcotdist[cat]);
-        break;
+        case 0:
+          cut_results[cut] = compute_cut(fabs(deltaEtaIn), scEt, cutdetal[cat], cutdeta[cat]);
+          break;
+        case 1:
+          cut_results[cut] = compute_cut(fabs(deltaPhiIn), scEt, cutdphil[cat], cutdphi[cat]);
+          break;
+        case 2:
+          cut_results[cut] = (eseedopincor > cuteopin[cat]);
+          break;
+        case 3:
+          cut_results[cut] = compute_cut(hOverE, scEt, cuthoel[cat], cuthoe[cat]);
+          break;
+        case 4:
+          cut_results[cut] = compute_cut(sigmaee, scEt, cutseel[cat], cutsee[cat]);
+          break;
+        case 5:
+          cut_results[cut] = compute_cut(iso_sumoet, scEt, cutIsoSumCorrl[cat], cutIsoSumCorr[cat]);
+          break;
+        case 6:
+          cut_results[cut] = (iso_sum < cutIsoSum[cat]);
+          break;
+        case 7:
+          cut_results[cut] = compute_cut(fabs(ip), scEt, cutipl[cat], cutip[cat]);
+          break;
+        case 8:
+          cut_results[cut] = (mishits < cutmishits[cat]);
+          break;
+        case 9:
+          cut_results[cut] = (dcotdistcomb < cutdcotdist[cat]);
+          break;
       }
     }
-    
+
     // ID part
     if (cut_results[0] & cut_results[1] & cut_results[2] & cut_results[3] & cut_results[4])
       result = result + 1;
-    
+
     // ISO part
     if (cut_results[5] & cut_results[6])
       result = result + 2;
-    
+
     // IP part
     if (cut_results[7])
       result = result + 8;
-    
+
     // Conversion part
     if (cut_results[8] & cut_results[9])
       result = result + 4;
@@ -424,27 +405,24 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
   return -1.;
 }
 
-
 bool CutBasedElectronID::compute_cut(double x, double et, double cut_min, double cut_max, bool gtn) {
-
   float et_min = 10;
   float et_max = 40;
 
   bool accept = false;
-  float cut = cut_max; //  the cut at et=40 GeV
+  float cut = cut_max;  //  the cut at et=40 GeV
 
-  if(et < et_max) {
-    cut = cut_min + (1/et_min - 1/et)*(cut_max - cut_min)/(1/et_min - 1/et_max);
-  } 
-  
-  if(et < et_min) {
+  if (et < et_max) {
+    cut = cut_min + (1 / et_min - 1 / et) * (cut_max - cut_min) / (1 / et_min - 1 / et_max);
+  }
+
+  if (et < et_min) {
     cut = cut_min;
-  } 
+  }
 
-  if(gtn) {   // useful for e/p cut which is gt
+  if (gtn) {  // useful for e/p cut which is gt
     accept = (x >= cut);
-  } 
-  else {
+  } else {
     accept = (x <= cut);
   }
 
@@ -452,12 +430,11 @@ bool CutBasedElectronID::compute_cut(double x, double et, double cut_min, double
   return accept;
 }
 
-double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron ,
-                                           const edm::Event& e ,
+double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron,
+                                           const edm::Event& e,
                                            const edm::EventSetup& es) {
-
-  double scTheta = (2*atan(exp(-electron->superCluster()->eta())));
-  double scEt = electron->superCluster()->energy()*sin(scTheta);
+  double scTheta = (2 * atan(exp(-electron->superCluster()->eta())));
+  double scEt = electron->superCluster()->energy() * sin(scTheta);
   double eta = electron->p4().Eta();
   double eOverP = electron->eSuperClusterOverP();
   double hOverE = electron->hadronicOverEm();
@@ -465,8 +442,8 @@ double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron ,
   double e25Max = electron->e2x5Max();
   double e15 = electron->e1x5();
   double e55 = electron->e5x5();
-  double e25Maxoe55 = e25Max/e55;
-  double e15oe55 = e15/e55 ;
+  double e25Maxoe55 = e25Max / e55;
+  double e15oe55 = e15 / e55;
   double deltaPhiIn = electron->deltaPhiSuperClusterTrackAtVtx();
   double deltaEtaIn = electron->deltaEtaSuperClusterTrackAtVtx();
 
@@ -474,15 +451,15 @@ double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron ,
   int mishits = electron->gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
   double tkIso = electron->dr03TkSumPt();
   double ecalIso = electron->dr04EcalRecHitSumEt();
-  double ecalIsoPed = (electron->isEB())?std::max(0.,ecalIso-1.):ecalIso;
+  double ecalIsoPed = (electron->isEB()) ? std::max(0., ecalIso - 1.) : ecalIso;
   double hcalIso = electron->dr04HcalTowerSumEt();
   double hcalIso1 = electron->dr04HcalDepth1TowerSumEt();
   double hcalIso2 = electron->dr04HcalDepth2TowerSumEt();
 
   if (version_ == "V00") {
     sigmaee = electron->sigmaEtaEta();
-     if (electron->isEE())
-       sigmaee = sigmaee - 0.02*(fabs(eta) - 2.3);   //correct sigmaetaeta dependence on eta in endcap
+    if (electron->isEE())
+      sigmaee = sigmaee - 0.02 * (fabs(eta) - 2.3);  //correct sigmaetaeta dependence on eta in endcap
   }
 
   if (version_ == "V03" or version_ == "V04") {
@@ -490,7 +467,7 @@ double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron ,
     // uses the same name for the vertex collection to avoid adding more new names
     e.getByToken(verticesCollection_, pBeamSpot);
     if (pBeamSpot.isValid()) {
-      const reco::BeamSpot *bspot = pBeamSpot.product();
+      const reco::BeamSpot* bspot = pBeamSpot.product();
       const math::XYZPoint& bspotPosition = bspot->position();
       ip = fabs(electron->gsfTrack()->dxy(bspotPosition));
     } else
@@ -499,7 +476,7 @@ double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron ,
 
   if (version_ == "V04" or version_ == "V05") {
     ecalIso = electron->dr03EcalRecHitSumEt();
-    ecalIsoPed = (electron->isEB())?std::max(0.,ecalIso-1.):ecalIso;
+    ecalIsoPed = (electron->isEB()) ? std::max(0., ecalIso - 1.) : ecalIso;
     hcalIso = electron->dr03HcalTowerSumEt();
     hcalIso1 = electron->dr03HcalDepth1TowerSumEt();
     hcalIso2 = electron->dr03HcalDepth2TowerSumEt();
@@ -510,7 +487,7 @@ double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron ,
     e.getByToken(verticesCollection_, vtxH);
     if (!vtxH->empty()) {
       reco::VertexRef vtx(vtxH, 0);
-      ip = fabs(electron->gsfTrack()->dxy(math::XYZPoint(vtx->x(),vtx->y(),vtx->z())));
+      ip = fabs(electron->gsfTrack()->dxy(math::XYZPoint(vtx->x(), vtx->y(), vtx->z())));
     } else
       ip = fabs(electron->gsfTrack()->dxy());
   }
@@ -519,7 +496,6 @@ double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron ,
   std::vector<double> cut;
   // ROBUST Selection
   if (type_ == "robust") {
-
     double result = 0;
 
     // hoe, sigmaEtaEta, dPhiIn, dEtaIn
@@ -530,46 +506,49 @@ double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron ,
     // check isolations: if only isolation passes result = 2
     if (quality_ == "highenergy") {
       if ((tkIso > cut[6] || hcalIso2 > cut[11]) ||
-          (electron->isEB() && ((ecalIso + hcalIso1) > cut[7]+cut[8]*scEt)) ||
-          (electron->isEE() && (scEt >= 50.) && ((ecalIso + hcalIso1) > cut[7]+cut[8]*(scEt-50))) ||
-          (electron->isEE() && (scEt < 50.) && ((ecalIso + hcalIso1) > cut[9]+cut[10]*(scEt-50))))
+          (electron->isEB() && ((ecalIso + hcalIso1) > cut[7] + cut[8] * scEt)) ||
+          (electron->isEE() && (scEt >= 50.) && ((ecalIso + hcalIso1) > cut[7] + cut[8] * (scEt - 50))) ||
+          (electron->isEE() && (scEt < 50.) && ((ecalIso + hcalIso1) > cut[9] + cut[10] * (scEt - 50))))
         result = 0;
       else
         result = 2;
     } else {
       if ((tkIso > cut[6]) || (ecalIso > cut[7]) || (hcalIso > cut[8]) || (hcalIso1 > cut[9]) || (hcalIso2 > cut[10]) ||
-          (tkIso/electron->p4().Pt() > cut[11]) || (ecalIso/electron->p4().Pt() > cut[12]) || (hcalIso/electron->p4().Pt() > cut[13]) ||
-          ((tkIso+ecalIso+hcalIso)>cut[14]) || (((tkIso+ecalIso+hcalIso)/ electron->p4().Pt()) > cut[15]) ||
-          ((tkIso+ecalIsoPed+hcalIso)>cut[16]) || (((tkIso+ecalIsoPed+hcalIso)/ electron->p4().Pt()) > cut[17])  )
+          (tkIso / electron->p4().Pt() > cut[11]) || (ecalIso / electron->p4().Pt() > cut[12]) ||
+          (hcalIso / electron->p4().Pt() > cut[13]) || ((tkIso + ecalIso + hcalIso) > cut[14]) ||
+          (((tkIso + ecalIso + hcalIso) / electron->p4().Pt()) > cut[15]) ||
+          ((tkIso + ecalIsoPed + hcalIso) > cut[16]) ||
+          (((tkIso + ecalIsoPed + hcalIso) / electron->p4().Pt()) > cut[17]))
         result = 0.;
       else
         result = 2.;
     }
 
-    if ((hOverE < cut[0]) && (sigmaee < cut[1]) && (fabs(deltaPhiIn) < cut[2]) &&
-        (fabs(deltaEtaIn) < cut[3]) && (e25Maxoe55 > cut[4] && e15oe55 > cut[5]) &&
-        (sigmaee >= cut[18]) && (eOverP > cut[19] &&  eOverP < cut[20]) )
-     { result = result + 1 ; }
+    if ((hOverE < cut[0]) && (sigmaee < cut[1]) && (fabs(deltaPhiIn) < cut[2]) && (fabs(deltaEtaIn) < cut[3]) &&
+        (e25Maxoe55 > cut[4] && e15oe55 > cut[5]) && (sigmaee >= cut[18]) && (eOverP > cut[19] && eOverP < cut[20])) {
+      result = result + 1;
+    }
 
     if (ip > cut[21])
       return result;
-    if (mishits > cut[22]) // expected missing hits
+    if (mishits > cut[22])  // expected missing hits
       return result;
     // positive cut[23] means to demand a valid hit in 1st layer PXB
-    if (cut[23] > 0 && !electron->gsfTrack()->hitPattern().hasValidHitInPixelLayer(PixelSubdetector::SubDetector::PixelBarrel, 1))
+    if (cut[23] > 0 &&
+        !electron->gsfTrack()->hitPattern().hasValidHitInPixelLayer(PixelSubdetector::SubDetector::PixelBarrel, 1))
       return result;
 
     // cut[24]: Dist cut[25]: dcot
     float dist = fabs(electron->convDist());
     float dcot = fabs(electron->convDcot());
-    bool isConversion = (cut[24]>99. || cut[25]>99.)?false:(dist < cut[24] && dcot < cut[25]);
+    bool isConversion = (cut[24] > 99. || cut[25] > 99.) ? false : (dist < cut[24] && dcot < cut[25]);
     if (isConversion)
-      return result ;
-    
-    result += 4 ;
+      return result;
 
-    return result ;
-   }
+    result += 4;
 
-  return -1. ;
- }
+    return result;
+  }
+
+  return -1.;
+}

--- a/RecoEgamma/ElectronIdentification/src/ElectronIDAlgo.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronIDAlgo.cc
@@ -7,8 +7,8 @@
 //  reducedEndcapRecHitCollection_ = conf.getParameter<edm::InputTag>("reducedEndcapRecHitCollection");
 //}
 //
-//EcalClusterLazyTools ElectronIDAlgo::getClusterShape(const edm::Event& ev, 
-//                                                     const edm::EventSetup& es) 
+//EcalClusterLazyTools ElectronIDAlgo::getClusterShape(const edm::Event& ev,
+//                                                     const edm::EventSetup& es)
 //{
 //
 //  edm::Handle< EcalRecHitCollection > pEBRecHits;

--- a/RecoEgamma/ElectronIdentification/src/ElectronLikelihood.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronLikelihood.cc
@@ -6,438 +6,500 @@
 #include "RecoEgamma/ElectronIdentification/interface/ElectronLikelihood.h"
 #include <iostream>
 
-
-ElectronLikelihood::ElectronLikelihood (const ElectronLikelihoodCalibration *calibration,
-					LikelihoodSwitches eleIDSwitches,
-					std::string signalWeightSplitting,
-					std::string backgroundWeightSplitting,
-					bool splitSignalPdfs,
-					bool splitBackgroundPdfs) :
-  _EB0lt15lh (new LikelihoodPdfProduct ("electronID_EB0_ptLt15_likelihood",0,0)) ,
-  _EB1lt15lh (new LikelihoodPdfProduct ("electronID_EB1_ptLt15_likelihood",1,0)) ,
-  _EElt15lh (new LikelihoodPdfProduct ("electronID_EE_ptLt15_likelihood",2,0)) ,
-  _EB0gt15lh (new LikelihoodPdfProduct ("electronID_EB0_ptGt15_likelihood",0,1)) ,
-  _EB1gt15lh (new LikelihoodPdfProduct ("electronID_EB1_ptGt15_likelihood",1,1)) ,
-  _EEgt15lh (new LikelihoodPdfProduct ("electronID_EE_ptGt15_likelihood",2,1)) ,
-  m_eleIDSwitches (eleIDSwitches) ,
-  m_signalWeightSplitting (signalWeightSplitting), 
-  m_backgroundWeightSplitting (backgroundWeightSplitting)
-{
-  Setup (calibration,
-	 signalWeightSplitting, backgroundWeightSplitting,
-	 splitSignalPdfs, splitBackgroundPdfs) ;
+ElectronLikelihood::ElectronLikelihood(const ElectronLikelihoodCalibration *calibration,
+                                       LikelihoodSwitches eleIDSwitches,
+                                       std::string signalWeightSplitting,
+                                       std::string backgroundWeightSplitting,
+                                       bool splitSignalPdfs,
+                                       bool splitBackgroundPdfs)
+    : _EB0lt15lh(new LikelihoodPdfProduct("electronID_EB0_ptLt15_likelihood", 0, 0)),
+      _EB1lt15lh(new LikelihoodPdfProduct("electronID_EB1_ptLt15_likelihood", 1, 0)),
+      _EElt15lh(new LikelihoodPdfProduct("electronID_EE_ptLt15_likelihood", 2, 0)),
+      _EB0gt15lh(new LikelihoodPdfProduct("electronID_EB0_ptGt15_likelihood", 0, 1)),
+      _EB1gt15lh(new LikelihoodPdfProduct("electronID_EB1_ptGt15_likelihood", 1, 1)),
+      _EEgt15lh(new LikelihoodPdfProduct("electronID_EE_ptGt15_likelihood", 2, 1)),
+      m_eleIDSwitches(eleIDSwitches),
+      m_signalWeightSplitting(signalWeightSplitting),
+      m_backgroundWeightSplitting(backgroundWeightSplitting) {
+  Setup(calibration, signalWeightSplitting, backgroundWeightSplitting, splitSignalPdfs, splitBackgroundPdfs);
 }
-
-
 
 // --------------------------------------------------------
 
-
-
-ElectronLikelihood::~ElectronLikelihood () {
-  delete _EB0lt15lh.get() ;
-  delete _EB1lt15lh.get() ;
-  delete _EElt15lh.get() ;
-  delete _EB0gt15lh.get() ;
-  delete _EB1gt15lh.get() ;
-  delete _EEgt15lh.get() ;
+ElectronLikelihood::~ElectronLikelihood() {
+  delete _EB0lt15lh.get();
+  delete _EB1lt15lh.get();
+  delete _EElt15lh.get();
+  delete _EB0gt15lh.get();
+  delete _EB1gt15lh.get();
+  delete _EEgt15lh.get();
 }
-
-
 
 // --------------------------------------------------------
 
-
-void 
-ElectronLikelihood::Setup (const ElectronLikelihoodCalibration *calibration,
-			   std::string signalWeightSplitting,
-			   std::string backgroundWeightSplitting,
-			   bool splitSignalPdfs,
-			   bool splitBackgroundPdfs) 
-{
-
+void ElectronLikelihood::Setup(const ElectronLikelihoodCalibration *calibration,
+                               std::string signalWeightSplitting,
+                               std::string backgroundWeightSplitting,
+                               bool splitSignalPdfs,
+                               bool splitBackgroundPdfs) {
   // ECAL BARREL0 (|eta|<1.0) LIKELIHOOD - Pt < 15 GeV region
-  _EB0lt15lh->initFromDB (calibration) ;
+  _EB0lt15lh->initFromDB(calibration);
 
-  _EB0lt15lh->addSpecies ("electrons") ;
-  _EB0lt15lh->addSpecies ("hadrons") ;
+  _EB0lt15lh->addSpecies("electrons");
+  _EB0lt15lh->addSpecies("hadrons");
 
-  if(signalWeightSplitting=="class") {
-    _EB0lt15lh->setSplitFrac ("electrons", "class0") ;
-    _EB0lt15lh->setSplitFrac ("electrons", "class1") ;
-  }
-  else {
+  if (signalWeightSplitting == "class") {
+    _EB0lt15lh->setSplitFrac("electrons", "class0");
+    _EB0lt15lh->setSplitFrac("electrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (non-showering / showering)"
-				      << " and fullclass (golden / bigbrem / narrow / showering)" 
-				      << " splitting is implemented right now";
+                                      << " and fullclass (golden / bigbrem / narrow / showering)"
+                                      << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EB0lt15lh->addPdf ("electrons", "dPhi",          splitSignalPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EB0lt15lh->addPdf ("electrons", "dEta",          splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EB0lt15lh->addPdf ("electrons", "EoP",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EB0lt15lh->addPdf ("electrons", "HoE",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EB0lt15lh->addPdf ("electrons", "sigmaIEtaIEta", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EB0lt15lh->addPdf ("electrons", "sigmaIPhiIPhi", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EB0lt15lh->addPdf ("electrons", "fBrem",         splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EB0lt15lh->addPdf ("electrons", "OneOverEMinusOneOverP",         splitSignalPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EB0lt15lh->addPdf("electrons", "dPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EB0lt15lh->addPdf("electrons", "dEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EB0lt15lh->addPdf("electrons", "EoP", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EB0lt15lh->addPdf("electrons", "HoE", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EB0lt15lh->addPdf("electrons", "sigmaIEtaIEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EB0lt15lh->addPdf("electrons", "sigmaIPhiIPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EB0lt15lh->addPdf("electrons", "fBrem", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EB0lt15lh->addPdf("electrons", "OneOverEMinusOneOverP", splitSignalPdfs);
 
-  if(backgroundWeightSplitting=="class") {
-    _EB0lt15lh->setSplitFrac ("hadrons", "class0") ;
-    _EB0lt15lh->setSplitFrac ("hadrons", "class1") ;
-  }
-  else {
+  if (backgroundWeightSplitting == "class") {
+    _EB0lt15lh->setSplitFrac("hadrons", "class0");
+    _EB0lt15lh->setSplitFrac("hadrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
-				      << " splitting is implemented right now";
+                                      << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EB0lt15lh->addPdf ("hadrons", "dPhi",          splitBackgroundPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EB0lt15lh->addPdf ("hadrons", "dEta",          splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EB0lt15lh->addPdf ("hadrons", "EoP",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EB0lt15lh->addPdf ("hadrons", "HoE",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EB0lt15lh->addPdf ("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EB0lt15lh->addPdf ("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EB0lt15lh->addPdf ("hadrons", "fBrem",         splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EB0lt15lh->addPdf ("hadrons", "OneOverEMinusOneOverP",         splitBackgroundPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EB0lt15lh->addPdf("hadrons", "dPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EB0lt15lh->addPdf("hadrons", "dEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EB0lt15lh->addPdf("hadrons", "EoP", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EB0lt15lh->addPdf("hadrons", "HoE", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EB0lt15lh->addPdf("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EB0lt15lh->addPdf("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EB0lt15lh->addPdf("hadrons", "fBrem", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EB0lt15lh->addPdf("hadrons", "OneOverEMinusOneOverP", splitBackgroundPdfs);
 
   // ECAL BARREL0 (|eta|<1.0) LIKELIHOOD - Pt >= 15 GeV region
-  _EB0gt15lh->initFromDB (calibration) ;
+  _EB0gt15lh->initFromDB(calibration);
 
-  _EB0gt15lh->addSpecies ("electrons") ;  
-  _EB0gt15lh->addSpecies ("hadrons") ;
+  _EB0gt15lh->addSpecies("electrons");
+  _EB0gt15lh->addSpecies("hadrons");
 
-  if(signalWeightSplitting=="class") {
-    _EB0gt15lh->setSplitFrac ("electrons", "class0") ;
-    _EB0gt15lh->setSplitFrac ("electrons", "class1") ;
-  }
-  else {
+  if (signalWeightSplitting == "class") {
+    _EB0gt15lh->setSplitFrac("electrons", "class0");
+    _EB0gt15lh->setSplitFrac("electrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
                                       << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EB0gt15lh->addPdf ("electrons", "dPhi",          splitSignalPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EB0gt15lh->addPdf ("electrons", "dEta",          splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EB0gt15lh->addPdf ("electrons", "EoP",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EB0gt15lh->addPdf ("electrons", "HoE",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EB0gt15lh->addPdf ("electrons", "sigmaIEtaIEta", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EB0gt15lh->addPdf ("electrons", "sigmaIPhiIPhi", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EB0gt15lh->addPdf ("electrons", "fBrem",         splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EB0gt15lh->addPdf ("electrons", "OneOverEMinusOneOverP",         splitSignalPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EB0gt15lh->addPdf("electrons", "dPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EB0gt15lh->addPdf("electrons", "dEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EB0gt15lh->addPdf("electrons", "EoP", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EB0gt15lh->addPdf("electrons", "HoE", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EB0gt15lh->addPdf("electrons", "sigmaIEtaIEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EB0gt15lh->addPdf("electrons", "sigmaIPhiIPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EB0gt15lh->addPdf("electrons", "fBrem", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EB0gt15lh->addPdf("electrons", "OneOverEMinusOneOverP", splitSignalPdfs);
 
-  if(backgroundWeightSplitting=="class") {
-    _EB0gt15lh->setSplitFrac ("hadrons", "class0") ;
-    _EB0gt15lh->setSplitFrac ("hadrons", "class1") ;
-  }
-  else {
+  if (backgroundWeightSplitting == "class") {
+    _EB0gt15lh->setSplitFrac("hadrons", "class0");
+    _EB0gt15lh->setSplitFrac("hadrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
                                       << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EB0gt15lh->addPdf ("hadrons", "dPhi",          splitBackgroundPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EB0gt15lh->addPdf ("hadrons", "dEta",          splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EB0gt15lh->addPdf ("hadrons", "EoP",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EB0gt15lh->addPdf ("hadrons", "HoE",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EB0gt15lh->addPdf ("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EB0gt15lh->addPdf ("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EB0gt15lh->addPdf ("hadrons", "fBrem",         splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EB0gt15lh->addPdf ("hadrons", "OneOverEMinusOneOverP",         splitBackgroundPdfs) ;
-
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EB0gt15lh->addPdf("hadrons", "dPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EB0gt15lh->addPdf("hadrons", "dEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EB0gt15lh->addPdf("hadrons", "EoP", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EB0gt15lh->addPdf("hadrons", "HoE", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EB0gt15lh->addPdf("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EB0gt15lh->addPdf("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EB0gt15lh->addPdf("hadrons", "fBrem", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EB0gt15lh->addPdf("hadrons", "OneOverEMinusOneOverP", splitBackgroundPdfs);
 
   // ECAL BARREL1 (|eta|>1.0) LIKELIHOOD - Pt < 15 GeV region
-  _EB1lt15lh->initFromDB (calibration) ;
+  _EB1lt15lh->initFromDB(calibration);
 
-  _EB1lt15lh->addSpecies ("electrons") ;
-  _EB1lt15lh->addSpecies ("hadrons") ;
+  _EB1lt15lh->addSpecies("electrons");
+  _EB1lt15lh->addSpecies("hadrons");
 
-  if(signalWeightSplitting=="class") {
-    _EB1lt15lh->setSplitFrac ("electrons", "class0") ;
-    _EB1lt15lh->setSplitFrac ("electrons", "class1") ;
-  }
-  else {
+  if (signalWeightSplitting == "class") {
+    _EB1lt15lh->setSplitFrac("electrons", "class0");
+    _EB1lt15lh->setSplitFrac("electrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (non-showering / showering)"
-				      << " and fullclass (golden / bigbrem / narrow / showering)" 
-				      << " splitting is implemented right now";
+                                      << " and fullclass (golden / bigbrem / narrow / showering)"
+                                      << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EB1lt15lh->addPdf ("electrons", "dPhi",          splitSignalPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EB1lt15lh->addPdf ("electrons", "dEta",          splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EB1lt15lh->addPdf ("electrons", "EoP",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EB1lt15lh->addPdf ("electrons", "HoE",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EB1lt15lh->addPdf ("electrons", "sigmaIEtaIEta", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EB1lt15lh->addPdf ("electrons", "sigmaIPhiIPhi", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EB1lt15lh->addPdf ("electrons", "fBrem",         splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EB1lt15lh->addPdf ("electrons", "OneOverEMinusOneOverP",         splitSignalPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EB1lt15lh->addPdf("electrons", "dPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EB1lt15lh->addPdf("electrons", "dEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EB1lt15lh->addPdf("electrons", "EoP", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EB1lt15lh->addPdf("electrons", "HoE", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EB1lt15lh->addPdf("electrons", "sigmaIEtaIEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EB1lt15lh->addPdf("electrons", "sigmaIPhiIPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EB1lt15lh->addPdf("electrons", "fBrem", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EB1lt15lh->addPdf("electrons", "OneOverEMinusOneOverP", splitSignalPdfs);
 
-  if(backgroundWeightSplitting=="class") {
-    _EB1lt15lh->setSplitFrac ("hadrons", "class0") ;
-    _EB1lt15lh->setSplitFrac ("hadrons", "class1") ;
-  }
-  else {
+  if (backgroundWeightSplitting == "class") {
+    _EB1lt15lh->setSplitFrac("hadrons", "class0");
+    _EB1lt15lh->setSplitFrac("hadrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
-				      << " splitting is implemented right now";
+                                      << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EB1lt15lh->addPdf ("hadrons", "dPhi",          splitBackgroundPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EB1lt15lh->addPdf ("hadrons", "dEta",          splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EB1lt15lh->addPdf ("hadrons", "EoP",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EB1lt15lh->addPdf ("hadrons", "HoE",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EB1lt15lh->addPdf ("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EB1lt15lh->addPdf ("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EB1lt15lh->addPdf ("hadrons", "fBrem",         splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EB1lt15lh->addPdf ("hadrons", "OneOverEMinusOneOverP",         splitBackgroundPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EB1lt15lh->addPdf("hadrons", "dPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EB1lt15lh->addPdf("hadrons", "dEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EB1lt15lh->addPdf("hadrons", "EoP", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EB1lt15lh->addPdf("hadrons", "HoE", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EB1lt15lh->addPdf("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EB1lt15lh->addPdf("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EB1lt15lh->addPdf("hadrons", "fBrem", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EB1lt15lh->addPdf("hadrons", "OneOverEMinusOneOverP", splitBackgroundPdfs);
 
   // ECAL BARREL1 (|eta|>1.0) LIKELIHOOD - Pt >= 15 GeV region
-  _EB1gt15lh->initFromDB (calibration) ;
+  _EB1gt15lh->initFromDB(calibration);
 
-  _EB1gt15lh->addSpecies ("electrons") ;  
-  _EB1gt15lh->addSpecies ("hadrons") ;
+  _EB1gt15lh->addSpecies("electrons");
+  _EB1gt15lh->addSpecies("hadrons");
 
-  if(signalWeightSplitting=="class") {
-    _EB1gt15lh->setSplitFrac ("electrons", "class0") ;
-    _EB1gt15lh->setSplitFrac ("electrons", "class1") ;
-  }
-  else {
+  if (signalWeightSplitting == "class") {
+    _EB1gt15lh->setSplitFrac("electrons", "class0");
+    _EB1gt15lh->setSplitFrac("electrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
                                       << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EB1gt15lh->addPdf ("electrons", "dPhi",          splitSignalPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EB1gt15lh->addPdf ("electrons", "dEta",          splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EB1gt15lh->addPdf ("electrons", "EoP",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EB1gt15lh->addPdf ("electrons", "HoE",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EB1gt15lh->addPdf ("electrons", "sigmaIEtaIEta", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EB1gt15lh->addPdf ("electrons", "sigmaIPhiIPhi", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EB1gt15lh->addPdf ("electrons", "fBrem",         splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EB1gt15lh->addPdf ("electrons", "OneOverEMinusOneOverP",         splitSignalPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EB1gt15lh->addPdf("electrons", "dPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EB1gt15lh->addPdf("electrons", "dEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EB1gt15lh->addPdf("electrons", "EoP", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EB1gt15lh->addPdf("electrons", "HoE", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EB1gt15lh->addPdf("electrons", "sigmaIEtaIEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EB1gt15lh->addPdf("electrons", "sigmaIPhiIPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EB1gt15lh->addPdf("electrons", "fBrem", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EB1gt15lh->addPdf("electrons", "OneOverEMinusOneOverP", splitSignalPdfs);
 
-  if(backgroundWeightSplitting=="class") {
-    _EB1gt15lh->setSplitFrac ("hadrons", "class0") ;
-    _EB1gt15lh->setSplitFrac ("hadrons", "class1") ;
-  }
-  else {
+  if (backgroundWeightSplitting == "class") {
+    _EB1gt15lh->setSplitFrac("hadrons", "class0");
+    _EB1gt15lh->setSplitFrac("hadrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
                                       << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EB1gt15lh->addPdf ("hadrons", "dPhi",          splitBackgroundPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EB1gt15lh->addPdf ("hadrons", "dEta",          splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EB1gt15lh->addPdf ("hadrons", "EoP",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EB1gt15lh->addPdf ("hadrons", "HoE",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EB1gt15lh->addPdf ("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EB1gt15lh->addPdf ("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EB1gt15lh->addPdf ("hadrons", "fBrem",         splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EB1gt15lh->addPdf ("hadrons", "OneOverEMinusOneOverP",         splitBackgroundPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EB1gt15lh->addPdf("hadrons", "dPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EB1gt15lh->addPdf("hadrons", "dEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EB1gt15lh->addPdf("hadrons", "EoP", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EB1gt15lh->addPdf("hadrons", "HoE", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EB1gt15lh->addPdf("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EB1gt15lh->addPdf("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EB1gt15lh->addPdf("hadrons", "fBrem", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EB1gt15lh->addPdf("hadrons", "OneOverEMinusOneOverP", splitBackgroundPdfs);
 
   // ECAL ENDCAP LIKELIHOOD - Pt < 15 GeV
-  _EElt15lh->initFromDB (calibration) ;
+  _EElt15lh->initFromDB(calibration);
 
-  _EElt15lh->addSpecies ("electrons") ;
-  _EElt15lh->addSpecies ("hadrons") ;
+  _EElt15lh->addSpecies("electrons");
+  _EElt15lh->addSpecies("hadrons");
 
-  if(signalWeightSplitting=="class") {
-    _EElt15lh->setSplitFrac ("electrons", "class0") ;
-    _EElt15lh->setSplitFrac ("electrons", "class1") ;
-  }
-  else {
+  if (signalWeightSplitting == "class") {
+    _EElt15lh->setSplitFrac("electrons", "class0");
+    _EElt15lh->setSplitFrac("electrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
                                       << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EElt15lh->addPdf ("electrons", "dPhi",          splitSignalPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EElt15lh->addPdf ("electrons", "dEta",          splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EElt15lh->addPdf ("electrons", "EoP",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EElt15lh->addPdf ("electrons", "HoE",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EElt15lh->addPdf ("electrons", "sigmaIEtaIEta", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EElt15lh->addPdf ("electrons", "sigmaIPhiIPhi", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EElt15lh->addPdf ("electrons", "fBrem",         splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EElt15lh->addPdf ("electrons", "OneOverEMinusOneOverP",         splitSignalPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EElt15lh->addPdf("electrons", "dPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EElt15lh->addPdf("electrons", "dEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EElt15lh->addPdf("electrons", "EoP", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EElt15lh->addPdf("electrons", "HoE", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EElt15lh->addPdf("electrons", "sigmaIEtaIEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EElt15lh->addPdf("electrons", "sigmaIPhiIPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EElt15lh->addPdf("electrons", "fBrem", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EElt15lh->addPdf("electrons", "OneOverEMinusOneOverP", splitSignalPdfs);
 
-  if(backgroundWeightSplitting=="class") {
-    _EElt15lh->setSplitFrac ("hadrons", "class0") ;
-    _EElt15lh->setSplitFrac ("hadrons", "class1") ;
-  }
-  else {
+  if (backgroundWeightSplitting == "class") {
+    _EElt15lh->setSplitFrac("hadrons", "class0");
+    _EElt15lh->setSplitFrac("hadrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
                                       << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EElt15lh->addPdf ("hadrons", "dPhi",          splitBackgroundPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EElt15lh->addPdf ("hadrons", "dEta",          splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EElt15lh->addPdf ("hadrons", "EoP",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EElt15lh->addPdf ("hadrons", "HoE",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EElt15lh->addPdf ("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EElt15lh->addPdf ("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EElt15lh->addPdf ("hadrons", "fBrem",         splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EElt15lh->addPdf ("hadrons", "OneOverEMinusOneOverP",         splitBackgroundPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EElt15lh->addPdf("hadrons", "dPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EElt15lh->addPdf("hadrons", "dEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EElt15lh->addPdf("hadrons", "EoP", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EElt15lh->addPdf("hadrons", "HoE", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EElt15lh->addPdf("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EElt15lh->addPdf("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EElt15lh->addPdf("hadrons", "fBrem", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EElt15lh->addPdf("hadrons", "OneOverEMinusOneOverP", splitBackgroundPdfs);
 
   // ECAL ENDCAP LIKELIHOOD - Pt >= 15 GeV
-  _EEgt15lh->initFromDB (calibration) ;
+  _EEgt15lh->initFromDB(calibration);
 
-  _EEgt15lh->addSpecies ("electrons") ;
-  _EEgt15lh->addSpecies ("hadrons") ;
+  _EEgt15lh->addSpecies("electrons");
+  _EEgt15lh->addSpecies("hadrons");
 
-  if(signalWeightSplitting=="class") {
-    _EEgt15lh->setSplitFrac ("electrons", "class0") ;
-    _EEgt15lh->setSplitFrac ("electrons", "class1") ;
-  }
-  else {
+  if (signalWeightSplitting == "class") {
+    _EEgt15lh->setSplitFrac("electrons", "class0");
+    _EEgt15lh->setSplitFrac("electrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
                                       << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EEgt15lh->addPdf ("electrons", "dPhi",          splitSignalPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EEgt15lh->addPdf ("electrons", "dEta",          splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EEgt15lh->addPdf ("electrons", "EoP",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EEgt15lh->addPdf ("electrons", "HoE",           splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EEgt15lh->addPdf ("electrons", "sigmaIEtaIEta", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EEgt15lh->addPdf ("electrons", "sigmaIPhiIPhi", splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EEgt15lh->addPdf ("electrons", "fBrem",         splitSignalPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EEgt15lh->addPdf ("electrons", "OneOverEMinusOneOverP",         splitSignalPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EEgt15lh->addPdf("electrons", "dPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EEgt15lh->addPdf("electrons", "dEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EEgt15lh->addPdf("electrons", "EoP", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EEgt15lh->addPdf("electrons", "HoE", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EEgt15lh->addPdf("electrons", "sigmaIEtaIEta", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EEgt15lh->addPdf("electrons", "sigmaIPhiIPhi", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EEgt15lh->addPdf("electrons", "fBrem", splitSignalPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EEgt15lh->addPdf("electrons", "OneOverEMinusOneOverP", splitSignalPdfs);
 
-  if(backgroundWeightSplitting=="class") {
-    _EEgt15lh->setSplitFrac ("hadrons", "class0") ;
-    _EEgt15lh->setSplitFrac ("hadrons", "class1") ;
-  }
-  else {
+  if (backgroundWeightSplitting == "class") {
+    _EEgt15lh->setSplitFrac("hadrons", "class0");
+    _EEgt15lh->setSplitFrac("hadrons", "class1");
+  } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
                                       << " splitting is implemented right now";
   }
 
-  if (m_eleIDSwitches.m_useDeltaPhi)     _EEgt15lh->addPdf ("hadrons", "dPhi",          splitBackgroundPdfs) ;   
-  if (m_eleIDSwitches.m_useDeltaEta)     _EEgt15lh->addPdf ("hadrons", "dEta",          splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useEoverP)       _EEgt15lh->addPdf ("hadrons", "EoP",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useHoverE)       _EEgt15lh->addPdf ("hadrons", "HoE",           splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta)  _EEgt15lh->addPdf ("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useSigmaPhiPhi)  _EEgt15lh->addPdf ("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useFBrem)        _EEgt15lh->addPdf ("hadrons", "fBrem",         splitBackgroundPdfs) ;
-  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)        _EEgt15lh->addPdf ("hadrons", "OneOverEMinusOneOverP",         splitBackgroundPdfs) ;
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    _EEgt15lh->addPdf("hadrons", "dPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useDeltaEta)
+    _EEgt15lh->addPdf("hadrons", "dEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useEoverP)
+    _EEgt15lh->addPdf("hadrons", "EoP", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useHoverE)
+    _EEgt15lh->addPdf("hadrons", "HoE", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    _EEgt15lh->addPdf("hadrons", "sigmaIEtaIEta", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    _EEgt15lh->addPdf("hadrons", "sigmaIPhiIPhi", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useFBrem)
+    _EEgt15lh->addPdf("hadrons", "fBrem", splitBackgroundPdfs);
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    _EEgt15lh->addPdf("hadrons", "OneOverEMinusOneOverP", splitBackgroundPdfs);
 }
-
-
 
 // --------------------------------------------------------
 
-
-
-void 
-ElectronLikelihood::getInputVar (const reco::GsfElectron &electron, 
-                                 std::vector<float> &measurements, 
-                                 const EcalClusterLazyTools& _myEcalCluster) const 
-{
+void ElectronLikelihood::getInputVar(const reco::GsfElectron &electron,
+                                     std::vector<float> &measurements,
+                                     const EcalClusterLazyTools &_myEcalCluster) const {
   EcalClusterLazyTools myEcalCluster = _myEcalCluster;
   // the variables entering the likelihood
-  if (m_eleIDSwitches.m_useDeltaPhi) measurements.push_back ( electron.deltaPhiSuperClusterTrackAtVtx () ) ;
-  if (m_eleIDSwitches.m_useDeltaEta) measurements.push_back ( electron.deltaEtaSuperClusterTrackAtVtx () ) ;
-  if (m_eleIDSwitches.m_useEoverP) measurements.push_back ( electron.eSuperClusterOverP () ) ;
-  if (m_eleIDSwitches.m_useHoverE) measurements.push_back ( electron.hadronicOverEm () ) ;
-  std::vector<float> vCov = myEcalCluster.localCovariances(*(electron.superCluster()->seed())) ;
-  if (m_eleIDSwitches.m_useSigmaEtaEta) measurements.push_back ( sqrt (vCov[0]) );
-  if (m_eleIDSwitches.m_useSigmaPhiPhi) measurements.push_back ( sqrt (vCov[2]) );
-  if(m_eleIDSwitches.m_useFBrem) measurements.push_back( electron.fbrem() );
+  if (m_eleIDSwitches.m_useDeltaPhi)
+    measurements.push_back(electron.deltaPhiSuperClusterTrackAtVtx());
+  if (m_eleIDSwitches.m_useDeltaEta)
+    measurements.push_back(electron.deltaEtaSuperClusterTrackAtVtx());
+  if (m_eleIDSwitches.m_useEoverP)
+    measurements.push_back(electron.eSuperClusterOverP());
+  if (m_eleIDSwitches.m_useHoverE)
+    measurements.push_back(electron.hadronicOverEm());
+  std::vector<float> vCov = myEcalCluster.localCovariances(*(electron.superCluster()->seed()));
+  if (m_eleIDSwitches.m_useSigmaEtaEta)
+    measurements.push_back(sqrt(vCov[0]));
+  if (m_eleIDSwitches.m_useSigmaPhiPhi)
+    measurements.push_back(sqrt(vCov[2]));
+  if (m_eleIDSwitches.m_useFBrem)
+    measurements.push_back(electron.fbrem());
   // 1/E - 1/P calculated consistently with the variables used to make the PDFs
   reco::GsfTrackRef trkRef = electron.get<reco::GsfTrackRef>();
-  float OneOverEMinusOneOverP = 1.0/(electron.eSuperClusterOverP() * trkRef->p()) - 1.0/trkRef->p();
-  if(m_eleIDSwitches.m_useOneOverEMinusOneOverP) measurements.push_back( OneOverEMinusOneOverP );
-
+  float OneOverEMinusOneOverP = 1.0 / (electron.eSuperClusterOverP() * trkRef->p()) - 1.0 / trkRef->p();
+  if (m_eleIDSwitches.m_useOneOverEMinusOneOverP)
+    measurements.push_back(OneOverEMinusOneOverP);
 }
-
-
 
 // --------------------------------------------------------
 
-
-
-float 
-ElectronLikelihood::result (const reco::GsfElectron &electron, 
-                            const EcalClusterLazyTools& myEcalCluster) const 
-{
-
+float ElectronLikelihood::result(const reco::GsfElectron &electron, const EcalClusterLazyTools &myEcalCluster) const {
   //=======================================================
   // used classification:
   // nbrem clusters = 0         =>  0
   // nbrem clusters >= 1        =>  1
   //=======================================================
 
-  std::vector<float> measurements ;
-  getInputVar (electron, measurements, myEcalCluster) ;
+  std::vector<float> measurements;
+  getInputVar(electron, measurements, myEcalCluster);
 
   // Split using only the number of brem clusters
-  int bitVal=(electron.numberOfBrems()==0) ? 0 : 1 ;
-  
+  int bitVal = (electron.numberOfBrems() == 0) ? 0 : 1;
+
   char className[20];
-  if(m_signalWeightSplitting=="class") {
+  if (m_signalWeightSplitting == "class") {
     snprintf(className, 20, "class%d", bitVal);
   } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
-				      << " splitting is implemented right now";
+                                      << " splitting is implemented right now";
   }
 
-  reco::SuperClusterRef sclusRef = electron.superCluster() ;
-  EcalSubdetector subdet = EcalSubdetector (sclusRef->hitsAndFractions()[0].first.subdetId ()) ;
-  float thisPt =  electron.pt();
+  reco::SuperClusterRef sclusRef = electron.superCluster();
+  EcalSubdetector subdet = EcalSubdetector(sclusRef->hitsAndFractions()[0].first.subdetId());
+  float thisPt = electron.pt();
 
-  if (subdet==EcalBarrel && fabs(electron.eta())<=1.0 && thisPt<15.)
-    return _EB0lt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else if (subdet==EcalBarrel && fabs(electron.eta())<=1.0 && thisPt>=15.)
-    return _EB0gt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else if (subdet==EcalBarrel && fabs(electron.eta())>1.0 && thisPt<15.)
-    return _EB1lt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else if (subdet==EcalBarrel && fabs(electron.eta())>1.0 && thisPt>=15.)
-    return _EB1gt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else if (subdet==EcalEndcap && thisPt<15.)
-    return _EElt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else if (subdet==EcalEndcap && thisPt>=15.)
-    return _EEgt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else return -999. ;
+  if (subdet == EcalBarrel && fabs(electron.eta()) <= 1.0 && thisPt < 15.)
+    return _EB0lt15lh->getRatio("electrons", measurements, std::string(className));
+  else if (subdet == EcalBarrel && fabs(electron.eta()) <= 1.0 && thisPt >= 15.)
+    return _EB0gt15lh->getRatio("electrons", measurements, std::string(className));
+  else if (subdet == EcalBarrel && fabs(electron.eta()) > 1.0 && thisPt < 15.)
+    return _EB1lt15lh->getRatio("electrons", measurements, std::string(className));
+  else if (subdet == EcalBarrel && fabs(electron.eta()) > 1.0 && thisPt >= 15.)
+    return _EB1gt15lh->getRatio("electrons", measurements, std::string(className));
+  else if (subdet == EcalEndcap && thisPt < 15.)
+    return _EElt15lh->getRatio("electrons", measurements, std::string(className));
+  else if (subdet == EcalEndcap && thisPt >= 15.)
+    return _EEgt15lh->getRatio("electrons", measurements, std::string(className));
+  else
+    return -999.;
 }
 
-float 
-ElectronLikelihood::resultLog (const reco::GsfElectron &electron, 
-                               const EcalClusterLazyTools& myEcalCluster) const 
-{
-
+float ElectronLikelihood::resultLog(const reco::GsfElectron &electron,
+                                    const EcalClusterLazyTools &myEcalCluster) const {
   //=======================================================
   // used classification:
   // nbrem clusters = 0         =>  0
   // nbrem clusters >= 1        =>  1
   //=======================================================
 
-  std::vector<float> measurements ;
-  getInputVar (electron, measurements, myEcalCluster) ;
+  std::vector<float> measurements;
+  getInputVar(electron, measurements, myEcalCluster);
 
   // Split using only the number of brem clusters
-  int bitVal=(electron.numberOfBrems()==0) ? 0 : 1 ;
-  
+  int bitVal = (electron.numberOfBrems() == 0) ? 0 : 1;
+
   char className[20];
-  if(m_signalWeightSplitting=="class") {
+  if (m_signalWeightSplitting == "class") {
     snprintf(className, 20, "class%d", bitVal);
   } else {
     throw cms::Exception("BadConfig") << "Only class (0 brem clusters / >=1 brem clusters)"
-				      << " splitting is implemented right now";
+                                      << " splitting is implemented right now";
   }
 
-  reco::SuperClusterRef sclusRef = electron.superCluster() ;
-  EcalSubdetector subdet = EcalSubdetector (sclusRef->hitsAndFractions()[0].first.subdetId ()) ;
-  float thisPt =  electron.pt();
+  reco::SuperClusterRef sclusRef = electron.superCluster();
+  EcalSubdetector subdet = EcalSubdetector(sclusRef->hitsAndFractions()[0].first.subdetId());
+  float thisPt = electron.pt();
 
-  float lh=-999.;
+  float lh = -999.;
 
-  if (subdet==EcalBarrel && fabs(electron.eta())<=1.0 && thisPt<15.)
-    lh = _EB0lt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else if (subdet==EcalBarrel && fabs(electron.eta())<=1.0 && thisPt>=15.)
-    lh = _EB0gt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else if (subdet==EcalBarrel && fabs(electron.eta())>1.0 && thisPt<15.)
-    lh = _EB1lt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else if (subdet==EcalBarrel && fabs(electron.eta())>1.0 && thisPt>=15.)
-    lh = _EB1gt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else if (subdet==EcalEndcap && thisPt<15.)
-    lh = _EElt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else if (subdet==EcalEndcap && thisPt>=15.)
-    lh = _EEgt15lh->getRatio ("electrons",measurements,std::string (className)) ;
-  else lh = -999. ;
+  if (subdet == EcalBarrel && fabs(electron.eta()) <= 1.0 && thisPt < 15.)
+    lh = _EB0lt15lh->getRatio("electrons", measurements, std::string(className));
+  else if (subdet == EcalBarrel && fabs(electron.eta()) <= 1.0 && thisPt >= 15.)
+    lh = _EB0gt15lh->getRatio("electrons", measurements, std::string(className));
+  else if (subdet == EcalBarrel && fabs(electron.eta()) > 1.0 && thisPt < 15.)
+    lh = _EB1lt15lh->getRatio("electrons", measurements, std::string(className));
+  else if (subdet == EcalBarrel && fabs(electron.eta()) > 1.0 && thisPt >= 15.)
+    lh = _EB1gt15lh->getRatio("electrons", measurements, std::string(className));
+  else if (subdet == EcalEndcap && thisPt < 15.)
+    lh = _EElt15lh->getRatio("electrons", measurements, std::string(className));
+  else if (subdet == EcalEndcap && thisPt >= 15.)
+    lh = _EEgt15lh->getRatio("electrons", measurements, std::string(className));
+  else
+    lh = -999.;
 
-  if(lh<=0) return -20.;
-  else if(lh==1) return 20.;
-  else return log(lh/(1.0-lh));
-
+  if (lh <= 0)
+    return -20.;
+  else if (lh == 1)
+    return 20.;
+  else
+    return log(lh / (1.0 - lh));
 }
-

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
@@ -5,27 +5,22 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "CommonTools/MVAUtils/interface/GBRForestTools.h"
 
-ElectronMVAEstimator::ElectronMVAEstimator():
-  cfg_{}
-{}
+ElectronMVAEstimator::ElectronMVAEstimator() : cfg_{} {}
 
-ElectronMVAEstimator::ElectronMVAEstimator(const std::string& fileName):
-  cfg_{} 
-{
+ElectronMVAEstimator::ElectronMVAEstimator(const std::string& fileName) : cfg_{} {
   // Taken from Daniele (his mail from the 30/11)
   //  tmvaReader.BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
   // training of the 7/12 with Nvtx added
-  gbr_.push_back( createGBRForest(fileName) );
+  gbr_.push_back(createGBRForest(fileName));
 }
 
-ElectronMVAEstimator::ElectronMVAEstimator(const Configuration & cfg):cfg_(cfg)
-{
-  for(const auto& weightsfile : cfg_.vweightsfiles) {
-    gbr_.push_back( createGBRForest(weightsfile) );
+ElectronMVAEstimator::ElectronMVAEstimator(const Configuration& cfg) : cfg_(cfg) {
+  for (const auto& weightsfile : cfg_.vweightsfiles) {
+    gbr_.push_back(createGBRForest(weightsfile));
   }
 }
 
-double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nvertices ) const {
+double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nvertices) const {
   float vars[18];
 
   vars[0] = myElectron.fbrem();
@@ -34,17 +29,17 @@ double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nverti
   vars[3] = myElectron.sigmaIetaIeta();
   vars[4] = myElectron.hcalOverEcal();
   vars[5] = myElectron.eSuperClusterOverP();
-  vars[6] = (myElectron.e5x5()) !=0. ? 1.-(myElectron.e1x5()/myElectron.e5x5()) : -1. ;
+  vars[6] = (myElectron.e5x5()) != 0. ? 1. - (myElectron.e1x5() / myElectron.e5x5()) : -1.;
   vars[7] = myElectron.eEleClusterOverPout();
   vars[8] = std::abs(myElectron.deltaEtaEleClusterTrackAtCalo());
-  
-  bool validKF= false;
+
+  bool validKF = false;
 
   reco::TrackRef myTrackRef = myElectron.closestCtfTrackRef();
-  validKF = (myTrackRef.isNonnull() && myTrackRef.isAvailable());   
+  validKF = (myTrackRef.isNonnull() && myTrackRef.isAvailable());
 
-  vars[9] = (validKF) ? myTrackRef->normalizedChi2() : 0 ;
-  vars[10] = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1.; 
+  vars[9] = (validKF) ? myTrackRef->normalizedChi2() : 0;
+  vars[10] = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1.;
   vars[11] = myElectron.gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
   vars[12] = std::abs(myElectron.convDist());
   vars[13] = std::abs(myElectron.convDcot());
@@ -52,7 +47,7 @@ double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nverti
   vars[15] = myElectron.eta();
   vars[16] = myElectron.pt();
   vars[17] = myElectron.ecalDrivenSeed();
-  
+
   bindVariables(vars);
 
   //0 pt &lt; 10 &amp;&amp; abs(eta)&lt;=1.485
@@ -60,68 +55,67 @@ double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nverti
   //2 pt &lt; 10 &amp;&amp; abs(eta)&gt; 1.485
   //3 pt &gt;= 10 &amp;&amp;  abs(eta)&gt; 1.485
 
-  const unsigned index = (unsigned)(myElectron.pt() >= 10) + 2*(unsigned)(std::abs(myElectron.eta()) > 1.485);
+  const unsigned index = (unsigned)(myElectron.pt() >= 10) + 2 * (unsigned)(std::abs(myElectron.eta()) > 1.485);
 
-  double result =  gbr_[index]->GetAdaBoostClassifier(vars);
-//  
-//  std::cout << "fbrem" << vars[0] << std::endl;
-//  std::cout << "detain"<< vars[1] << std::endl;
-//  std::cout << "dphiin"<< vars[2] << std::endl;
-//  std::cout << "sieie"<< vars[3] << std::endl;
-//  std::cout << "hoe"<< vars[4] << std::endl;
-//  std::cout << "eop"<< vars[5] << std::endl;
-//  std::cout << "e1x5e5x5"<< vars[6] << std::endl;
-//  std::cout << "eleopout"<< vars[7] << std::endl;
-//  std::cout << "detaeleout"<< vars[8] << std::endl;
-//  std::cout << "kfchi2"<< vars[9] << std::endl;
-//  std::cout << "kfhits"<< vars[10] << std::endl;
-//  std::cout << "mishits"<<vars[11] << std::endl;
-//  std::cout << "dist"<< vars[12] << std::endl;
-//  std::cout << "dcot"<< vars[13] << std::endl;
-//  std::cout << "nvtx"<< vars[14] << std::endl;
-//  std::cout << "eta"<< vars[15] << std::endl;
-//  std::cout << "pt"<< vars[16] << std::endl;
-//  std::cout << "ecalseed"<< vars[17] << std::endl;
-//
-//  std::cout << " MVA " << result << std::endl;
+  double result = gbr_[index]->GetAdaBoostClassifier(vars);
+  //
+  //  std::cout << "fbrem" << vars[0] << std::endl;
+  //  std::cout << "detain"<< vars[1] << std::endl;
+  //  std::cout << "dphiin"<< vars[2] << std::endl;
+  //  std::cout << "sieie"<< vars[3] << std::endl;
+  //  std::cout << "hoe"<< vars[4] << std::endl;
+  //  std::cout << "eop"<< vars[5] << std::endl;
+  //  std::cout << "e1x5e5x5"<< vars[6] << std::endl;
+  //  std::cout << "eleopout"<< vars[7] << std::endl;
+  //  std::cout << "detaeleout"<< vars[8] << std::endl;
+  //  std::cout << "kfchi2"<< vars[9] << std::endl;
+  //  std::cout << "kfhits"<< vars[10] << std::endl;
+  //  std::cout << "mishits"<<vars[11] << std::endl;
+  //  std::cout << "dist"<< vars[12] << std::endl;
+  //  std::cout << "dcot"<< vars[13] << std::endl;
+  //  std::cout << "nvtx"<< vars[14] << std::endl;
+  //  std::cout << "eta"<< vars[15] << std::endl;
+  //  std::cout << "pt"<< vars[16] << std::endl;
+  //  std::cout << "ecalseed"<< vars[17] << std::endl;
+  //
+  //  std::cout << " MVA " << result << std::endl;
   return result;
 }
 
-
 void ElectronMVAEstimator::bindVariables(float vars[18]) const {
-  if(vars[0] < -1.)
-    vars[1] = -1.;  
-  
-  if(vars[1] > 0.06)
+  if (vars[0] < -1.)
+    vars[1] = -1.;
+
+  if (vars[1] > 0.06)
     vars[1] = 0.06;
-    
-  if(vars[2] > 0.6)
+
+  if (vars[2] > 0.6)
     vars[2] = 0.6;
-  
-  if(vars[5] > 20.)
+
+  if (vars[5] > 20.)
     vars[5] = 20.;
-    
-  if(vars[7] > 20.)
+
+  if (vars[7] > 20.)
     vars[7] = 20;
-  
-  if(vars[8] > 0.2)
+
+  if (vars[8] > 0.2)
     vars[8] = 0.2;
-  
-  if(vars[9] < 0.)
+
+  if (vars[9] < 0.)
     vars[9] = 0.;
-  
-  if(vars[9] > 15.)
+
+  if (vars[9] > 15.)
     vars[9] = 15.;
-    
-  if(vars[6] < -1.)
+
+  if (vars[6] < -1.)
     vars[6] = -1;
 
-  if(vars[6] > 2.)
-    vars[6] = 2.; 
-    
-  if(vars[12] > 15.)
+  if (vars[6] > 2.)
+    vars[6] = 2.;
+
+  if (vars[12] > 15.)
     vars[12] = 15.;
-    
-  if(vars[13] > 3.)
+
+  if (vars[13] > 3.)
     vars[13] = 3.;
 }

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2.cc
@@ -1,59 +1,52 @@
 #include "RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2.h"
 
-ElectronMVAEstimatorRun2::ElectronMVAEstimatorRun2(const edm::ParameterSet& conf):
-  AnyMVAEstimatorRun2Base(conf),
-  mvaVarMngr_(conf.getParameter<std::string>("variableDefinition"))
-{
-
+ElectronMVAEstimatorRun2::ElectronMVAEstimatorRun2(const edm::ParameterSet& conf)
+    : AnyMVAEstimatorRun2Base(conf), mvaVarMngr_(conf.getParameter<std::string>("variableDefinition")) {
   const auto weightFileNames = conf.getParameter<std::vector<std::string> >("weightFileNames");
   const auto categoryCutStrings = conf.getParameter<std::vector<std::string> >("categoryCuts");
 
-  if( (int)(categoryCutStrings.size()) != getNCategories() )
+  if ((int)(categoryCutStrings.size()) != getNCategories())
     throw cms::Exception("MVA config failure: ")
-      << "wrong number of category cuts in ElectronMVAEstimatorRun2" << getTag() << std::endl;
+        << "wrong number of category cuts in ElectronMVAEstimatorRun2" << getTag() << std::endl;
 
   for (int i = 0; i < getNCategories(); ++i) {
-      categoryFunctions_.emplace_back(categoryCutStrings[i]);
+    categoryFunctions_.emplace_back(categoryCutStrings[i]);
   }
 
   // Initialize GBRForests from weight files
   init(weightFileNames);
 }
 
-ElectronMVAEstimatorRun2::ElectronMVAEstimatorRun2( const std::string& mvaTag,
-                                                    const std::string& mvaName,
-                                                    int nCategories,
-                                                    const std::string& variableDefinition,
-                                                    const std::vector<std::string>& categoryCutStrings,
-                                                    const std::vector<std::string> &weightFileNames,
-                                                    bool debug)
-  : AnyMVAEstimatorRun2Base( mvaName, mvaTag, nCategories, debug )
-  , mvaVarMngr_            (variableDefinition)
-{
-  
-  if( (int)(categoryCutStrings.size()) != getNCategories() )
+ElectronMVAEstimatorRun2::ElectronMVAEstimatorRun2(const std::string& mvaTag,
+                                                   const std::string& mvaName,
+                                                   int nCategories,
+                                                   const std::string& variableDefinition,
+                                                   const std::vector<std::string>& categoryCutStrings,
+                                                   const std::vector<std::string>& weightFileNames,
+                                                   bool debug)
+    : AnyMVAEstimatorRun2Base(mvaName, mvaTag, nCategories, debug), mvaVarMngr_(variableDefinition) {
+  if ((int)(categoryCutStrings.size()) != getNCategories())
     throw cms::Exception("MVA config failure: ")
-      << "wrong number of category cuts in " << getName() << getTag() << std::endl;
-  
-  for (auto const& cut : categoryCutStrings) categoryFunctions_.emplace_back(cut);
+        << "wrong number of category cuts in " << getName() << getTag() << std::endl;
+
+  for (auto const& cut : categoryCutStrings)
+    categoryFunctions_.emplace_back(cut);
   init(weightFileNames);
 }
 
-void ElectronMVAEstimatorRun2::init(const std::vector<std::string> &weightFileNames) {
-
-  if(isDebug()) {
+void ElectronMVAEstimatorRun2::init(const std::vector<std::string>& weightFileNames) {
+  if (isDebug()) {
     std::cout << " *** Inside ElectronMVAEstimatorRun2" << getTag() << std::endl;
   }
 
   // Initialize GBRForests
-  if( (int)(weightFileNames.size()) != getNCategories() )
+  if ((int)(weightFileNames.size()) != getNCategories())
     throw cms::Exception("MVA config failure: ")
-      << "wrong number of weightfiles in ElectronMVAEstimatorRun2" << getTag() << std::endl;
+        << "wrong number of weightfiles in ElectronMVAEstimatorRun2" << getTag() << std::endl;
 
   gbrForests_.clear();
   // Create a TMVA reader object for each category
-  for(int i=0; i<getNCategories(); i++){
-
+  for (int i = 0; i < getNCategories(); i++) {
     std::vector<int> variablesInCategory;
 
     // Use unique_ptr so that all readers are properly cleaned up
@@ -66,86 +59,81 @@ void ElectronMVAEstimatorRun2::init(const std::vector<std::string> &weightFileNa
 
     variables_.push_back(variablesInCategory);
 
-    if(isDebug()) {
+    if (isDebug()) {
       std::cout << " *** Inside ElectronMVAEstimatorRun2" << getTag() << std::endl;
       std::cout << " category " << i << " with nVariables " << nVariables_[i] << std::endl;
     }
 
-    for (int j=0; j<nVariables_[i];++j) {
-        int index = mvaVarMngr_.getVarIndex(variableNamesInCategory[j]);
-        if(index == -1) {
-            throw cms::Exception("MVA config failure: ")
-               << "Concerning ElectronMVAEstimatorRun2" << getTag() << std::endl
-               << "Variable " << variableNamesInCategory[j]
-               << " not found in variable definition file!" << std::endl;
-        }
-        variables_[i].push_back(index);
-
+    for (int j = 0; j < nVariables_[i]; ++j) {
+      int index = mvaVarMngr_.getVarIndex(variableNamesInCategory[j]);
+      if (index == -1) {
+        throw cms::Exception("MVA config failure: ")
+            << "Concerning ElectronMVAEstimatorRun2" << getTag() << std::endl
+            << "Variable " << variableNamesInCategory[j] << " not found in variable definition file!" << std::endl;
+      }
+      variables_[i].push_back(index);
     }
   }
 }
 
-float ElectronMVAEstimatorRun2::
-mvaValue( const reco::Candidate* candidate, const std::vector<float>& auxVariables, int &iCategory) const {
-
+float ElectronMVAEstimatorRun2::mvaValue(const reco::Candidate* candidate,
+                                         const std::vector<float>& auxVariables,
+                                         int& iCategory) const {
   const reco::GsfElectron* electron = dynamic_cast<const reco::GsfElectron*>(candidate);
 
-  if( electron == nullptr ) {
+  if (electron == nullptr) {
     throw cms::Exception("MVA failure: ")
-      << " given particle is expected to be reco::GsfElectron or pat::Electron," << std::endl
-      << " but appears to be neither" << std::endl;
+        << " given particle is expected to be reco::GsfElectron or pat::Electron," << std::endl
+        << " but appears to be neither" << std::endl;
   }
 
-  iCategory = findCategory( electron );
+  iCategory = findCategory(electron);
 
-  if (iCategory < 0) return -999;
+  if (iCategory < 0)
+    return -999;
 
   std::vector<float> vars;
 
   for (int i = 0; i < nVariables_[iCategory]; ++i) {
-      vars.push_back(mvaVarMngr_.getValue(variables_[iCategory][i], *electron, auxVariables));
+    vars.push_back(mvaVarMngr_.getValue(variables_[iCategory][i], *electron, auxVariables));
   }
 
-  if(isDebug()) {
+  if (isDebug()) {
     std::cout << " *** Inside ElectronMVAEstimatorRun2" << getTag() << std::endl;
     std::cout << " category " << iCategory << std::endl;
     for (int i = 0; i < nVariables_[iCategory]; ++i) {
-        std::cout << " " << mvaVarMngr_.getName(variables_[iCategory][i]) << " " << vars[i] << std::endl;
+      std::cout << " " << mvaVarMngr_.getName(variables_[iCategory][i]) << " " << vars[i] << std::endl;
     }
   }
-  const float response = gbrForests_.at(iCategory)->GetResponse(vars.data()); // The BDT score
+  const float response = gbrForests_.at(iCategory)->GetResponse(vars.data());  // The BDT score
 
-  if(isDebug()) {
+  if (isDebug()) {
     std::cout << " ### MVA " << response << std::endl << std::endl;
   }
 
   return response;
 }
 
-int ElectronMVAEstimatorRun2::findCategory( const reco::Candidate* candidate) const {
-
+int ElectronMVAEstimatorRun2::findCategory(const reco::Candidate* candidate) const {
   const reco::GsfElectron* electron = dynamic_cast<reco::GsfElectron const*>(candidate);
 
-  if( electron == nullptr ) {
+  if (electron == nullptr) {
     throw cms::Exception("MVA failure: ")
-      << " given particle is expected to be reco::GsfElectron or pat::Electron," << std::endl
-      << " but appears to be neither" << std::endl;
+        << " given particle is expected to be reco::GsfElectron or pat::Electron," << std::endl
+        << " but appears to be neither" << std::endl;
   }
 
   return findCategory(*electron);
-
 }
 
 int ElectronMVAEstimatorRun2::findCategory(reco::GsfElectron const& electron) const {
-
   for (int i = 0; i < getNCategories(); ++i) {
-      if (categoryFunctions_[i](electron)) return i;
+    if (categoryFunctions_[i](electron))
+      return i;
   }
 
-  edm::LogWarning  ("MVA warning") <<
-      "category not defined for particle with pt " << electron.pt() << " GeV, eta " <<
-          electron.superCluster()->eta() << " in ElectronMVAEstimatorRun2" << getTag();
+  edm::LogWarning("MVA warning") << "category not defined for particle with pt " << electron.pt() << " GeV, eta "
+                                 << electron.superCluster()->eta() << " in ElectronMVAEstimatorRun2" << getTag();
 
   return -1;
-
 }

--- a/RecoEgamma/ElectronIdentification/src/LikelihoodPdf.cc
+++ b/RecoEgamma/ElectronIdentification/src/LikelihoodPdf.cc
@@ -3,9 +3,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include <iostream>
 
-
-
-
 LikelihoodPdf::LikelihoodPdf(const char* name, const char* species, int ecalsubdet, int ptbin) {
   _name = std::string(name);
   _species = std::string(species);
@@ -13,118 +10,101 @@ LikelihoodPdf::LikelihoodPdf(const char* name, const char* species, int ecalsubd
   _ptbin = ptbin;
 }
 
+LikelihoodPdf::~LikelihoodPdf() {}
 
-
-LikelihoodPdf::~LikelihoodPdf() {
-}
-
-
-
-void 
-LikelihoodPdf::split(const std::map<std::string,float>& splitFractions, 
-		     bool splitPdf) {
-//  std::map<std::string,float>splitFractions = _splitFractions;
+void LikelihoodPdf::split(const std::map<std::string, float>& splitFractions, bool splitPdf) {
+  //  std::map<std::string,float>splitFractions = _splitFractions;
   char buffer[100];
-  //! use different a-priori probabilities and different PDFs 
+  //! use different a-priori probabilities and different PDFs
   //! depending by category
-  if(!splitFractions.empty() && splitPdf) {
-    std::map<std::string,float>::const_iterator splitCatItr;
-    for(splitCatItr=splitFractions.begin();splitCatItr!=splitFractions.end();splitCatItr++) {
-      snprintf(buffer, 100, "%s_%s_subdet%d_ptbin%d_%s",_name.c_str(),_species.c_str(),_ecalsubdet,_ptbin,splitCatItr->first.c_str());
+  if (!splitFractions.empty() && splitPdf) {
+    std::map<std::string, float>::const_iterator splitCatItr;
+    for (splitCatItr = splitFractions.begin(); splitCatItr != splitFractions.end(); splitCatItr++) {
+      snprintf(buffer,
+               100,
+               "%s_%s_subdet%d_ptbin%d_%s",
+               _name.c_str(),
+               _species.c_str(),
+               _ecalsubdet,
+               _ptbin,
+               splitCatItr->first.c_str());
       std::string totPdfName = std::string(buffer);
-      _splitRule.insert( std::make_pair(splitCatItr->first,totPdfName) );
+      _splitRule.insert(std::make_pair(splitCatItr->first, totPdfName));
     }
   }
 
   //! use different a-priori, but same PDFs for all categories
-  else if(!splitFractions.empty()) {
-    std::map<std::string,float>::const_iterator splitCatItr;
-    for(splitCatItr=splitFractions.begin();splitCatItr!=splitFractions.end();splitCatItr++) {
-      snprintf(buffer, 100, "%s_%s_subdet%d_ptbin%d",_name.c_str(),_species.c_str(),_ecalsubdet,_ptbin);
+  else if (!splitFractions.empty()) {
+    std::map<std::string, float>::const_iterator splitCatItr;
+    for (splitCatItr = splitFractions.begin(); splitCatItr != splitFractions.end(); splitCatItr++) {
+      snprintf(buffer, 100, "%s_%s_subdet%d_ptbin%d", _name.c_str(), _species.c_str(), _ecalsubdet, _ptbin);
       std::string totPdfName = std::string(buffer);
-      _splitRule.insert( std::make_pair(splitCatItr->first,totPdfName) );
+      _splitRule.insert(std::make_pair(splitCatItr->first, totPdfName));
     }
   }
-  
+
   //! do not split at all (same PDF's, same a-priori for all categories)
   else {
-    snprintf(buffer, 100, "%s_%s_subdet%d_ptbin%d",_name.c_str(),_species.c_str(),_ecalsubdet,_ptbin);
+    snprintf(buffer, 100, "%s_%s_subdet%d_ptbin%d", _name.c_str(), _species.c_str(), _ecalsubdet, _ptbin);
     std::string totPdfName = std::string(buffer);
-    _splitRule.insert( std::make_pair("NOSPLIT",totPdfName) );
+    _splitRule.insert(std::make_pair("NOSPLIT", totPdfName));
   }
 }
 
-
-
-void 
-LikelihoodPdf::initFromDB(const ElectronLikelihoodCalibration *calibration) {
-
-  std::map<std::string,std::string>::const_iterator ruleItr;
-  for(ruleItr=_splitRule.begin();ruleItr!=_splitRule.end();ruleItr++) {
+void LikelihoodPdf::initFromDB(const ElectronLikelihoodCalibration* calibration) {
+  std::map<std::string, std::string>::const_iterator ruleItr;
+  for (ruleItr = _splitRule.begin(); ruleItr != _splitRule.end(); ruleItr++) {
     // look for the requested PDF in the CondDB
     std::vector<ElectronLikelihoodCalibration::Entry>::const_iterator entryItr;
-    bool foundPdf=false;
-    for(entryItr=calibration->data.begin(); entryItr!=calibration->data.end(); entryItr++) {
-      if(entryItr->category.label==ruleItr->second) { 
-	const PhysicsTools::Calibration::HistogramF *histo = &(entryItr->histogram);
-	_splitPdf.insert( std::make_pair(ruleItr->first,histo) );
-	foundPdf=true;
+    bool foundPdf = false;
+    for (entryItr = calibration->data.begin(); entryItr != calibration->data.end(); entryItr++) {
+      if (entryItr->category.label == ruleItr->second) {
+        const PhysicsTools::Calibration::HistogramF* histo = &(entryItr->histogram);
+        _splitPdf.insert(std::make_pair(ruleItr->first, histo));
+        foundPdf = true;
       }
     }
-    if(!foundPdf) {
-      throw cms::Exception("LikelihoodPdf") << "The pdf requested: " << _name
-					    << " for species: " << _species
-					    << " is not present in the Conditions DB!";
+    if (!foundPdf) {
+      throw cms::Exception("LikelihoodPdf")
+          << "The pdf requested: " << _name << " for species: " << _species << " is not present in the Conditions DB!";
     }
   }
 }
 
-
-
-float 
-LikelihoodPdf::getVal(float x, std::string const& gsfClass, 
-		      bool normalized) const {
-  const PhysicsTools::Calibration::HistogramF *thePdf=nullptr;
-  if(_splitPdf.size()>1) {
-    edm::LogInfo("LikelihoodPdf") << "The PDF " << _name
-				  << " is SPLITTED by category " << gsfClass;
-    thePdf=_splitPdf.find(gsfClass)->second;
+float LikelihoodPdf::getVal(float x, std::string const& gsfClass, bool normalized) const {
+  const PhysicsTools::Calibration::HistogramF* thePdf = nullptr;
+  if (_splitPdf.size() > 1) {
+    edm::LogInfo("LikelihoodPdf") << "The PDF " << _name << " is SPLITTED by category " << gsfClass;
+    thePdf = _splitPdf.find(gsfClass)->second;
+  } else {
+    edm::LogInfo("LikelihoodPdf") << "The PDF " << _name << " is UNSPLITTED";
+    thePdf = _splitPdf.find("NOSPLIT")->second;
   }
-  else {
-    edm::LogInfo("LikelihoodPdf") << "The PDF " << _name
-				  << " is UNSPLITTED";
-    thePdf=_splitPdf.find("NOSPLIT")->second;
-  }
-  
-  float prob=-1;
 
-  if(normalized)
+  float prob = -1;
+
+  if (normalized)
     // using thePdf->normalization() neglects the overflows... calculating it manually.
     // prob=thePdf->value(x)/thePdf->normalization();
-    prob=thePdf->value(x)/normalization(thePdf);
+    prob = thePdf->value(x) / normalization(thePdf);
   else
-    prob=thePdf->value(x);
+    prob = thePdf->value(x);
 
-  edm::LogInfo("LikelihoodPdf") << "sanity check: PDF name = " << _name
-                                << " for species = " << _species
-                                << " for class = " << gsfClass 
+  edm::LogInfo("LikelihoodPdf") << "sanity check: PDF name = " << _name << " for species = " << _species
+                                << " for class = " << gsfClass
                                 << " bin content = " << thePdf->binContent(thePdf->findBin(x))
                                 << " normalization (std) = " << thePdf->normalization()
-                                << " normalization (manual) = " << normalization(thePdf)
-                                << " prob = " << prob;
-  edm::LogInfo("LikelihoodPdf") << "From likelihood with ecalsubdet = " << _ecalsubdet
-                                << " ptbin = " << _ptbin;
- 
+                                << " normalization (manual) = " << normalization(thePdf) << " prob = " << prob;
+  edm::LogInfo("LikelihoodPdf") << "From likelihood with ecalsubdet = " << _ecalsubdet << " ptbin = " << _ptbin;
 
   return prob;
 }
 
 // Histogram::normalization() gives the integral excluding the over-underflow...
-float
-LikelihoodPdf::normalization(const PhysicsTools::Calibration::HistogramF *thePdf) const {
+float LikelihoodPdf::normalization(const PhysicsTools::Calibration::HistogramF* thePdf) const {
   int nBins = thePdf->numberOfBins();
-  float sum=0.;
-  for(int i=0; i<=nBins+1; i++) {
+  float sum = 0.;
+  for (int i = 0; i <= nBins + 1; i++) {
     sum += thePdf->binContent(i);
   }
   return sum;

--- a/RecoEgamma/ElectronIdentification/src/LikelihoodPdfProduct.cc
+++ b/RecoEgamma/ElectronIdentification/src/LikelihoodPdfProduct.cc
@@ -2,128 +2,91 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-
-
-LikelihoodPdfProduct::LikelihoodPdfProduct(const char* name, 
-					   int ecalsubdet, int ptbin) 
-{
-  _name=std::string(name);
+LikelihoodPdfProduct::LikelihoodPdfProduct(const char* name, int ecalsubdet, int ptbin) {
+  _name = std::string(name);
   _ecalsubdet = ecalsubdet;
   _ptbin = ptbin;
 }
 
-
-
-LikelihoodPdfProduct::~LikelihoodPdfProduct() 
-{
-  // do the delete's 
+LikelihoodPdfProduct::~LikelihoodPdfProduct() {
+  // do the delete's
   std::vector<LikelihoodSpecies*>::iterator specItr;
-  for(specItr=_specList.begin(); specItr!=_specList.end(); specItr++) {
+  for (specItr = _specList.begin(); specItr != _specList.end(); specItr++) {
     delete *specItr;
   }
 }
 
+void LikelihoodPdfProduct::initFromDB(const ElectronLikelihoodCalibration* calibration) { _calibration = calibration; }
 
-
-void 
-LikelihoodPdfProduct::initFromDB(const ElectronLikelihoodCalibration *calibration) 
-{
-  _calibration=calibration;
-}
-
-
-
-void 
-LikelihoodPdfProduct::addSpecies(const char* name, float priorWeight) 
-{
-  LikelihoodSpecies* species = new LikelihoodSpecies(name,priorWeight);
+void LikelihoodPdfProduct::addSpecies(const char* name, float priorWeight) {
+  LikelihoodSpecies* species = new LikelihoodSpecies(name, priorWeight);
   _specList.push_back(species);
 }
 
-
-
-void 
-LikelihoodPdfProduct::addPdf(const char* specname, 
-			     const char* name, 
-			     bool splitPdf) 
-{
+void LikelihoodPdfProduct::addPdf(const char* specname, const char* name, bool splitPdf) {
   std::vector<LikelihoodSpecies*>::const_iterator specItr;
-  for(specItr=_specList.begin();specItr!=_specList.end();specItr++) {
+  for (specItr = _specList.begin(); specItr != _specList.end(); specItr++) {
     LikelihoodSpecies* species = *specItr;
-    if(strcmp(species->getName(),specname)==0) {
-      LikelihoodPdf *pdf = new LikelihoodPdf(name,species->getName(),_ecalsubdet,_ptbin);
-      pdf->split(species->getSplitFractions(),splitPdf);
+    if (strcmp(species->getName(), specname) == 0) {
+      LikelihoodPdf* pdf = new LikelihoodPdf(name, species->getName(), _ecalsubdet, _ptbin);
+      pdf->split(species->getSplitFractions(), splitPdf);
       pdf->initFromDB(_calibration);
       species->addPdf(pdf);
     }
   }
 }
 
-
-
-void 
-LikelihoodPdfProduct::setSplitFrac(const char* specname, 
-				   const char* catName, float frac) {
+void LikelihoodPdfProduct::setSplitFrac(const char* specname, const char* catName, float frac) {
   std::vector<LikelihoodSpecies*>::const_iterator specItr;
-  for(specItr=_specList.begin();specItr!=_specList.end();specItr++) {
+  for (specItr = _specList.begin(); specItr != _specList.end(); specItr++) {
     LikelihoodSpecies* species = *specItr;
-    if(strcmp(species->getName(),specname)==0) {
-      species->setSplitFraction( make_pair(std::string(catName), frac) );
+    if (strcmp(species->getName(), specname) == 0) {
+      species->setSplitFraction(make_pair(std::string(catName), frac));
       break;
     }
   }
 }
 
-
-
-float 
-LikelihoodPdfProduct::getRatio(const char* specname, 
-			       const std::vector<float>& measurements, 
-			       const std::string& gsfClass) const
-{
-  float sigProb=0, bkgProb=0;
+float LikelihoodPdfProduct::getRatio(const char* specname,
+                                     const std::vector<float>& measurements,
+                                     const std::string& gsfClass) const {
+  float sigProb = 0, bkgProb = 0;
   std::vector<LikelihoodSpecies*>::const_iterator specItr;
-  for(specItr=_specList.begin();specItr!=_specList.end();specItr++) {
+  for (specItr = _specList.begin(); specItr != _specList.end(); specItr++) {
     const LikelihoodSpecies* species = *specItr;
-    std::map<std::string,float> const& splitFractions = species->getSplitFractions();
-    std::map<std::string,float>::const_iterator iter = splitFractions.find(gsfClass);
+    std::map<std::string, float> const& splitFractions = species->getSplitFractions();
+    std::map<std::string, float>::const_iterator iter = splitFractions.find(gsfClass);
     //! if the pdf is not splitted, assign the split fraction = 1
-    float splitFr= (splitFractions.empty()) ? 1. : iter->second;
-    if(strcmp(species->getName(),specname)==0) {
-      sigProb=splitFr*getSpeciesProb(specname,measurements,gsfClass);
+    float splitFr = (splitFractions.empty()) ? 1. : iter->second;
+    if (strcmp(species->getName(), specname) == 0) {
+      sigProb = splitFr * getSpeciesProb(specname, measurements, gsfClass);
+    } else {
+      bkgProb += splitFr * getSpeciesProb(species->getName(), measurements, gsfClass);
     }
-    else {
-      bkgProb+=splitFr*getSpeciesProb(species->getName(),measurements,gsfClass);
-    } 
   }
-  if(sigProb+bkgProb>0)
-    return sigProb/(sigProb+bkgProb);
+  if (sigProb + bkgProb > 0)
+    return sigProb / (sigProb + bkgProb);
   else
     return -1.;
 }
 
-
-
-float 
-LikelihoodPdfProduct::getSpeciesProb(const char* specName, 
-				     const std::vector<float>& measurements, 
-				     const std::string& gsfClass)  const
-{
-  float bareProb=1.;
-  float priorWeight=1.;
+float LikelihoodPdfProduct::getSpeciesProb(const char* specName,
+                                           const std::vector<float>& measurements,
+                                           const std::string& gsfClass) const {
+  float bareProb = 1.;
+  float priorWeight = 1.;
   std::vector<LikelihoodSpecies*>::const_iterator specItr;
-  for(specItr=_specList.begin();specItr!=_specList.end();specItr++) {
+  for (specItr = _specList.begin(); specItr != _specList.end(); specItr++) {
     const LikelihoodSpecies* species = *specItr;
-    if(strcmp(species->getName(),specName)==0) {
-      for(unsigned int ipdf=0; ipdf< species->getListOfPdfs().size(); ipdf++) {
-        bareProb*=species->getListOfPdfs()[ipdf]->getVal(measurements.at(ipdf),gsfClass);
+    if (strcmp(species->getName(), specName) == 0) {
+      for (unsigned int ipdf = 0; ipdf < species->getListOfPdfs().size(); ipdf++) {
+        bareProb *= species->getListOfPdfs()[ipdf]->getVal(measurements.at(ipdf), gsfClass);
       }
-      priorWeight=species->getPrior();
+      priorWeight = species->getPrior();
       break;
     }
   }
-  edm::LogInfo("LikelihoodPdfProduct") << "Species: " << specName
-				       << " bare probability = " << bareProb
-				       << " with a priori probability = " << priorWeight;
-  return priorWeight*bareProb;
+  edm::LogInfo("LikelihoodPdfProduct") << "Species: " << specName << " bare probability = " << bareProb
+                                       << " with a priori probability = " << priorWeight;
+  return priorWeight * bareProb;
 }

--- a/RecoEgamma/ElectronIdentification/src/LikelihoodSpecies.cc
+++ b/RecoEgamma/ElectronIdentification/src/LikelihoodSpecies.cc
@@ -1,46 +1,29 @@
 #include "RecoEgamma/ElectronIdentification/interface/LikelihoodSpecies.h"
 
 LikelihoodSpecies::LikelihoodSpecies(const char* name, float prior) {
-  _name=std::string(name);
-  _prior=prior;
+  _name = std::string(name);
+  _prior = prior;
 }
 
 LikelihoodSpecies::~LikelihoodSpecies() {
   std::vector<const LikelihoodPdf*>::iterator pdfItr;
-  for(pdfItr=_pdfList.begin(); pdfItr!=_pdfList.end(); pdfItr++) {
+  for (pdfItr = _pdfList.begin(); pdfItr != _pdfList.end(); pdfItr++) {
     delete *pdfItr;
   }
 }
 
-void LikelihoodSpecies::setName(const char* name) {
-  _name = std::string(name);
-}
+void LikelihoodSpecies::setName(const char* name) { _name = std::string(name); }
 
-void LikelihoodSpecies::addPdf(const LikelihoodPdf* pdf) {
-  _pdfList.push_back(pdf);
-}
+void LikelihoodSpecies::addPdf(const LikelihoodPdf* pdf) { _pdfList.push_back(pdf); }
 
-void LikelihoodSpecies::setPrior(float prior) {
-  _prior=prior;
-}
+void LikelihoodSpecies::setPrior(float prior) { _prior = prior; }
 
-void LikelihoodSpecies::setSplitFraction(std::pair<std::string,float> splitfrac) {
-  _splitFractions.insert(splitfrac);
-}
+void LikelihoodSpecies::setSplitFraction(std::pair<std::string, float> splitfrac) { _splitFractions.insert(splitfrac); }
 
-std::vector<const LikelihoodPdf*> const& LikelihoodSpecies::getListOfPdfs() const {
-  return _pdfList;
-}
+std::vector<const LikelihoodPdf*> const& LikelihoodSpecies::getListOfPdfs() const { return _pdfList; }
 
-const char* LikelihoodSpecies::getName() const {
-  return _name.c_str();
-}
+const char* LikelihoodSpecies::getName() const { return _name.c_str(); }
 
-float LikelihoodSpecies::getPrior() const {
-  return _prior;
-}
+float LikelihoodSpecies::getPrior() const { return _prior; }
 
-std::map<std::string,float> const& LikelihoodSpecies::getSplitFractions() const {
-  return _splitFractions;
-}
-
+std::map<std::string, float> const& LikelihoodSpecies::getSplitFractions() const { return _splitFractions; }

--- a/RecoEgamma/ElectronIdentification/src/PTDRElectronID.cc
+++ b/RecoEgamma/ElectronIdentification/src/PTDRElectronID.cc
@@ -1,12 +1,11 @@
 #include "RecoEgamma/ElectronIdentification/interface/PTDRElectronID.h"
 
 void PTDRElectronID::setup(const edm::ParameterSet& conf) {
-
   // Get all the parameters
   //baseSetup(conf);
-  
-  quality_ =  conf.getParameter<std::string>("electronQuality");
-  
+
+  quality_ = conf.getParameter<std::string>("electronQuality");
+
   useEoverPIn_ = conf.getParameter<std::vector<int> >("useEoverPIn");
   useDeltaEtaIn_ = conf.getParameter<std::vector<int> >("useDeltaEtaIn");
   useDeltaPhiIn_ = conf.getParameter<std::vector<int> >("useDeltaPhiIn");
@@ -19,126 +18,142 @@ void PTDRElectronID::setup(const edm::ParameterSet& conf) {
   useSigmaEtaEta_ = conf.getParameter<std::vector<int> >("useSigmaEtaEta");
   useSigmaPhiPhi_ = conf.getParameter<std::vector<int> >("useSigmaPhiPhi");
   acceptCracks_ = conf.getParameter<std::vector<int> >("acceptCracks");
-  
-  if (quality_=="tight") {
+
+  if (quality_ == "tight") {
     cuts_ = conf.getParameter<edm::ParameterSet>("tightEleIDCuts");
-    variables_ = 2 ;
-  } else if (quality_=="medium") {
+    variables_ = 2;
+  } else if (quality_ == "medium") {
     cuts_ = conf.getParameter<edm::ParameterSet>("mediumEleIDCuts");
-    variables_ = 1 ;
-  } else if (quality_=="loose") {
+    variables_ = 1;
+  } else if (quality_ == "loose") {
     cuts_ = conf.getParameter<edm::ParameterSet>("looseEleIDCuts");
-    variables_ = 0 ;
+    variables_ = 0;
   } else {
-     throw cms::Exception("Configuration") << "Invalid electronQuality parameter in PTDElectronID: must be tight, medium or loose." ;
-  }  
+    throw cms::Exception("Configuration")
+        << "Invalid electronQuality parameter in PTDElectronID: must be tight, medium or loose.";
+  }
 }
 
-double PTDRElectronID::result(const reco::GsfElectron* electron,
-                              const edm::Event& e ,
-                              const edm::EventSetup& es) {
-
+double PTDRElectronID::result(const reco::GsfElectron* electron, const edm::Event& e, const edm::EventSetup& es) {
   //determine which element of the cut arrays in cfi file to read
   //depending on the electron classification
-  int icut=0;
-  int elClass = electron->classification() ;
-  if (electron->isEB()) //barrel
-     {
-       if (elClass == reco::GsfElectron::GOLDEN)    icut=0;
-       if (elClass == reco::GsfElectron::BIGBREM)   icut=1;
-       //if (elClass == reco::GsfElectron::NARROW)    icut=2;
-       if (elClass == reco::GsfElectron::SHOWERING) icut=3;
-       if (elClass == reco::GsfElectron::GAP)       icut=8;
-     }
-  if (electron->isEE()) //endcap
-     {
-       if (elClass == reco::GsfElectron::GOLDEN)    icut=4;
-       if (elClass == reco::GsfElectron::BIGBREM)   icut=5;
-       //if (elClass == reco::GsfElectron::NARROW)    icut=6;
-       if (elClass == reco::GsfElectron::SHOWERING) icut=7;
-       if (elClass == reco::GsfElectron::GAP)       icut=8;
-     }
-  if (elClass == reco::GsfElectron::UNKNOWN) 
-     {
-       edm::LogError("PTDRElectronID") << "Error: unrecognized electron classification ";
-       return 1.;
-     }
+  int icut = 0;
+  int elClass = electron->classification();
+  if (electron->isEB())  //barrel
+  {
+    if (elClass == reco::GsfElectron::GOLDEN)
+      icut = 0;
+    if (elClass == reco::GsfElectron::BIGBREM)
+      icut = 1;
+    //if (elClass == reco::GsfElectron::NARROW)    icut=2;
+    if (elClass == reco::GsfElectron::SHOWERING)
+      icut = 3;
+    if (elClass == reco::GsfElectron::GAP)
+      icut = 8;
+  }
+  if (electron->isEE())  //endcap
+  {
+    if (elClass == reco::GsfElectron::GOLDEN)
+      icut = 4;
+    if (elClass == reco::GsfElectron::BIGBREM)
+      icut = 5;
+    //if (elClass == reco::GsfElectron::NARROW)    icut=6;
+    if (elClass == reco::GsfElectron::SHOWERING)
+      icut = 7;
+    if (elClass == reco::GsfElectron::GAP)
+      icut = 8;
+  }
+  if (elClass == reco::GsfElectron::UNKNOWN) {
+    edm::LogError("PTDRElectronID") << "Error: unrecognized electron classification ";
+    return 1.;
+  }
 
   if (acceptCracks_[variables_])
-    if (elClass == reco::GsfElectron::GAP) return 1.;
-  
+    if (elClass == reco::GsfElectron::GAP)
+      return 1.;
+
   if (useEoverPIn_[variables_]) {
     double value = electron->eSuperClusterOverP();
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("EoverPInMax");
     std::vector<double> mincut = cuts_.getParameter<std::vector<double> >("EoverPInMin");
-    if (value<mincut[icut] || value>maxcut[icut]) return 0.;
+    if (value < mincut[icut] || value > maxcut[icut])
+      return 0.;
   }
 
   if (useDeltaEtaIn_[variables_]) {
     double value = electron->deltaEtaSuperClusterTrackAtVtx();
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("deltaEtaIn");
-    if (fabs(value)>maxcut[icut]) return 0.;
+    if (fabs(value) > maxcut[icut])
+      return 0.;
   }
 
   if (useDeltaPhiIn_[variables_]) {
     double value = electron->deltaPhiSuperClusterTrackAtVtx();
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("deltaPhiIn");
-    if (fabs(value)>maxcut[icut]) return 0.;
+    if (fabs(value) > maxcut[icut])
+      return 0.;
   }
 
   if (useHoverE_[variables_]) {
     double value = electron->hadronicOverEm();
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("HoverE");
-    if (value>maxcut[icut]) return 0.;
+    if (value > maxcut[icut])
+      return 0.;
   }
 
   if (useEoverPOut_[variables_]) {
     double value = electron->eSeedClusterOverPout();
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("EoverPOutMax");
     std::vector<double> mincut = cuts_.getParameter<std::vector<double> >("EoverPOutMin");
-    if (value<mincut[icut] || value>maxcut[icut]) return 0.;
+    if (value < mincut[icut] || value > maxcut[icut])
+      return 0.;
   }
 
   if (useDeltaPhiOut_[variables_]) {
     double value = electron->deltaPhiSeedClusterTrackAtCalo();
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("deltaPhiOut");
-    if (fabs(value)>maxcut[icut]) return 0.;
+    if (fabs(value) > maxcut[icut])
+      return 0.;
   }
 
   if (useInvEMinusInvP_[variables_]) {
-    double value = (1./electron->caloEnergy())-(1./electron->trackMomentumAtVtx().R());
+    double value = (1. / electron->caloEnergy()) - (1. / electron->trackMomentumAtVtx().R());
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("invEMinusInvP");
-    if (value>maxcut[icut]) return 0.;
+    if (value > maxcut[icut])
+      return 0.;
   }
 
   if (useBremFraction_[variables_]) {
-    double value = electron->trackMomentumAtVtx().R()-electron->trackMomentumOut().R();
+    double value = electron->trackMomentumAtVtx().R() - electron->trackMomentumOut().R();
     std::vector<double> mincut = cuts_.getParameter<std::vector<double> >("bremFraction");
-    if (value<mincut[icut]) return 0.;
+    if (value < mincut[icut])
+      return 0.;
   }
 
   //EcalClusterLazyTools lazyTools = getClusterShape(e,es);
   //std::vector<float> vCov = lazyTools.localCovariances(*(electron->superCluster()->seed())) ;
   //std::vector<float> vCov = lazyTools.covariances(*(electron->superCluster()->seed())) ;
-    
+
   if (useE9overE25_[variables_]) {
-    double value = electron->r9()*electron->superCluster()->energy()/electron->e5x5();
+    double value = electron->r9() * electron->superCluster()->energy() / electron->e5x5();
     std::vector<double> mincut = cuts_.getParameter<std::vector<double> >("E9overE25");
-    if (fabs(value)<mincut[icut]) return 0.;
+    if (fabs(value) < mincut[icut])
+      return 0.;
   }
 
   if (useSigmaEtaEta_[variables_]) {
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("sigmaEtaEtaMax");
     std::vector<double> mincut = cuts_.getParameter<std::vector<double> >("sigmaEtaEtaMin");
-    if (electron->sigmaIetaIeta()<mincut[icut] || electron->sigmaIetaIeta()>maxcut[icut]) return 0.;
+    if (electron->sigmaIetaIeta() < mincut[icut] || electron->sigmaIetaIeta() > maxcut[icut])
+      return 0.;
   }
 
   if (useSigmaPhiPhi_[variables_]) {
     std::vector<double> mincut = cuts_.getParameter<std::vector<double> >("sigmaPhiPhiMin");
     std::vector<double> maxcut = cuts_.getParameter<std::vector<double> >("sigmaPhiPhiMax");
-    if (electron->sigmaIphiIphi()<mincut[icut] || electron->sigmaIphiIphi()>maxcut[icut]) return 0.;
+    if (electron->sigmaIphiIphi() < mincut[icut] || electron->sigmaIphiIphi() > maxcut[icut])
+      return 0.;
   }
 
   return 1.;
-
 }

--- a/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
@@ -5,67 +5,62 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "CommonTools/MVAUtils/interface/GBRForestTools.h"
 
-SoftElectronMVAEstimator::SoftElectronMVAEstimator(const Configuration & cfg):cfg_(cfg)
-{
+SoftElectronMVAEstimator::SoftElectronMVAEstimator(const Configuration& cfg) : cfg_(cfg) {
   //Check number of weight files given
-  if (ExpectedNBins != cfg_.vweightsfiles.size() ) {
-    edm::LogError  ("Soft Electron MVA Error") <<
-        "Expected Number of bins = " << ExpectedNBins <<
-        " does not equal to weightsfiles.size() = " << 
-        cfg_.vweightsfiles.size() << std::endl;
+  if (ExpectedNBins != cfg_.vweightsfiles.size()) {
+    edm::LogError("Soft Electron MVA Error")
+        << "Expected Number of bins = " << ExpectedNBins
+        << " does not equal to weightsfiles.size() = " << cfg_.vweightsfiles.size() << std::endl;
   }
 
-  for(auto& weightsfile : cfg_.vweightsfiles) {
-    // Taken from Daniele (his mail from the 30/11)    
+  for (auto& weightsfile : cfg_.vweightsfiles) {
+    // Taken from Daniele (his mail from the 30/11)
     // training of the 7/12 with Nvtx added
-    gbr_.push_back(createGBRForest( weightsfile ));
+    gbr_.push_back(createGBRForest(weightsfile));
   }
 }
 
+SoftElectronMVAEstimator::~SoftElectronMVAEstimator() {}
 
-SoftElectronMVAEstimator::~SoftElectronMVAEstimator()
-{ }
-
-double SoftElectronMVAEstimator::mva(const reco::GsfElectron& myElectron,
-                                     const reco::VertexCollection& pvc) const {
+double SoftElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, const reco::VertexCollection& pvc) const {
   float vars[25];
 
-  vars[0]  = myElectron.fbrem();// fbrem
-  vars[1]  = myElectron.eSuperClusterOverP(); //EtotOvePin
-  vars[2]   = myElectron.eEleClusterOverPout(); //eleEoPout 
-  
-  float etot  = myElectron.eSuperClusterOverP()*myElectron.trackMomentumAtVtx().R();
-  float eEcal = myElectron.eEleClusterOverPout()*myElectron.trackMomentumAtEleClus().R();
-  float dP    = myElectron.trackMomentumAtVtx().R()-myElectron.trackMomentumAtEleClus().R();
-  vars[3]  = (etot-eEcal)/dP; //EBremOverDeltaP
-  vars[4]  = std::log(myElectron.sigmaEtaEta()); //logSigmaEtaEta
-  vars[5]  = myElectron.deltaEtaEleClusterTrackAtCalo(); //DeltaEtaTrackEcalSeed
-  vars[6]  = myElectron.hcalOverEcalBc(); //HoE  
+  vars[0] = myElectron.fbrem();                // fbrem
+  vars[1] = myElectron.eSuperClusterOverP();   //EtotOvePin
+  vars[2] = myElectron.eEleClusterOverPout();  //eleEoPout
 
-  bool validKF= false;
-  reco::TrackRef myTrackRef     = myElectron.closestCtfTrackRef();
-  validKF                       = (myTrackRef.isAvailable() && myTrackRef.isNonnull());
-  vars[7]  = myElectron.gsfTrack()->normalizedChi2(); //gsfchi2
-  vars[8]  = (validKF) ? myTrackRef->normalizedChi2() : 0 ; //kfchi2
-  vars[9]  = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1. ; //kfhits
-  
-  vars[10] = myElectron.gsfTrack().get()->ptModeError()/myElectron.gsfTrack().get()->ptMode() ; //SigmaPtOverPt 
-  vars[11]  = myElectron.deltaEtaSuperClusterTrackAtVtx(); //deta
-  vars[12]  = myElectron.deltaPhiSuperClusterTrackAtVtx(); //dphi
-  vars[13]  = myElectron.deltaEtaSeedClusterTrackAtCalo(); //detacalo 
-  vars[14]  = myElectron.sigmaIetaIeta(); //see
-  vars[15]  = myElectron.sigmaIphiIphi(); //spp
-  vars[16]  = myElectron.r9(); //R9
-  vars[17]  = myElectron.superCluster()->etaWidth(); //etawidth
-  vars[18]  = myElectron.superCluster()->phiWidth(); //phiwidth
-  vars[19]  = (myElectron.e5x5()) !=0. ? 1.-(myElectron.e1x5()/myElectron.e5x5()) : -1. ; //OneMinusE1x5E5x5
-  vars[20]  = (1.0/myElectron.ecalEnergy()) - (1.0 / myElectron.p()); // IoEmIoP
-  vars[21]  = myElectron.superCluster()->preshowerEnergy() / myElectron.superCluster()->rawEnergy(); //PreShowerOverRaw
-  vars[22]  = pvc.size(); // nPV
-  vars[23]  = myElectron.pt(); //pt
-  vars[24]  = myElectron.eta(); //eta
-  
-/*
+  float etot = myElectron.eSuperClusterOverP() * myElectron.trackMomentumAtVtx().R();
+  float eEcal = myElectron.eEleClusterOverPout() * myElectron.trackMomentumAtEleClus().R();
+  float dP = myElectron.trackMomentumAtVtx().R() - myElectron.trackMomentumAtEleClus().R();
+  vars[3] = (etot - eEcal) / dP;                         //EBremOverDeltaP
+  vars[4] = std::log(myElectron.sigmaEtaEta());          //logSigmaEtaEta
+  vars[5] = myElectron.deltaEtaEleClusterTrackAtCalo();  //DeltaEtaTrackEcalSeed
+  vars[6] = myElectron.hcalOverEcalBc();                 //HoE
+
+  bool validKF = false;
+  reco::TrackRef myTrackRef = myElectron.closestCtfTrackRef();
+  validKF = (myTrackRef.isAvailable() && myTrackRef.isNonnull());
+  vars[7] = myElectron.gsfTrack()->normalizedChi2();                                    //gsfchi2
+  vars[8] = (validKF) ? myTrackRef->normalizedChi2() : 0;                               //kfchi2
+  vars[9] = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1.;  //kfhits
+
+  vars[10] = myElectron.gsfTrack().get()->ptModeError() / myElectron.gsfTrack().get()->ptMode();     //SigmaPtOverPt
+  vars[11] = myElectron.deltaEtaSuperClusterTrackAtVtx();                                            //deta
+  vars[12] = myElectron.deltaPhiSuperClusterTrackAtVtx();                                            //dphi
+  vars[13] = myElectron.deltaEtaSeedClusterTrackAtCalo();                                            //detacalo
+  vars[14] = myElectron.sigmaIetaIeta();                                                             //see
+  vars[15] = myElectron.sigmaIphiIphi();                                                             //spp
+  vars[16] = myElectron.r9();                                                                        //R9
+  vars[17] = myElectron.superCluster()->etaWidth();                                                  //etawidth
+  vars[18] = myElectron.superCluster()->phiWidth();                                                  //phiwidth
+  vars[19] = (myElectron.e5x5()) != 0. ? 1. - (myElectron.e1x5() / myElectron.e5x5()) : -1.;         //OneMinusE1x5E5x5
+  vars[20] = (1.0 / myElectron.ecalEnergy()) - (1.0 / myElectron.p());                               // IoEmIoP
+  vars[21] = myElectron.superCluster()->preshowerEnergy() / myElectron.superCluster()->rawEnergy();  //PreShowerOverRaw
+  vars[22] = pvc.size();                                                                             // nPV
+  vars[23] = myElectron.pt();                                                                        //pt
+  vars[24] = myElectron.eta();                                                                       //eta
+
+  /*
   std::cout<<"fbrem "<<fbrem<<std::endl;
   std::cout<<"EtotOvePin "<<EtotOvePin<<std::endl;
   std::cout<<"eleEoPout "<<eleEoPout<<std::endl;
@@ -91,44 +86,42 @@ double SoftElectronMVAEstimator::mva(const reco::GsfElectron& myElectron,
 */
   bindVariables(vars);
 
-  double result= gbr_[0]->GetClassifier(vars);
+  double result = gbr_[0]->GetClassifier(vars);
 
   return result;
 }
 
-
 void SoftElectronMVAEstimator::bindVariables(float vars[25]) const {
-  if( vars[0] < -1.) //fbrem
+  if (vars[0] < -1.)  //fbrem
     vars[0] = -1.;
 
-  vars[11] = std::abs(vars[11]); // deta
-  if(vars[11] > 0.06)
+  vars[11] = std::abs(vars[11]);  // deta
+  if (vars[11] > 0.06)
     vars[11] = 0.06;
 
   vars[12] = std::abs(vars[12]);
-  if(vars[12] > 0.6)
+  if (vars[12] > 0.6)
     vars[12] = 0.6;
 
   //if(EoP > 20.)
   //  EoP = 20.;
 
-  if(vars[2] > 20.) //eleEoPout
+  if (vars[2] > 20.)  //eleEoPout
     vars[2] = 20.;
-  
-  vars[13] = std::abs(vars[13]); //detacalo
-  if(vars[13] > 0.2)
+
+  vars[13] = std::abs(vars[13]);  //detacalo
+  if (vars[13] > 0.2)
     vars[13] = 0.2;
 
-  if( vars[19] < -1.) //OneMinusE1x5E5x5
+  if (vars[19] < -1.)  //OneMinusE1x5E5x5
     vars[19] = -1;
 
-  if( vars[19] > 2.) //OneMinusE1x5E5x5
+  if (vars[19] > 2.)  //OneMinusE1x5E5x5
     vars[19] = 2.;
 
-  if( vars[7] > 200.) //gsfchi2
+  if (vars[7] > 200.)  //gsfchi2
     vars[7] = 200;
-  
-  if( vars[8] > 10.) //kfchi2
-    vars[8]  = 10.;
 
+  if (vars[8] > 10.)  //kfchi2
+    vars[8] = 10.;
 }

--- a/RecoEgamma/ElectronIdentification/src/T_ElectronLikelihood.cc
+++ b/RecoEgamma/ElectronIdentification/src/T_ElectronLikelihood.cc
@@ -1,4 +1,4 @@
 
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "RecoEgamma/ElectronIdentification/interface/ElectronLikelihood.h"
-TYPELOOKUP_DATA_REG( ElectronLikelihood );
+TYPELOOKUP_DATA_REG(ElectronLikelihood);

--- a/RecoEgamma/ElectronIdentification/src/classes.h
+++ b/RecoEgamma/ElectronIdentification/src/classes.h
@@ -13,7 +13,7 @@
 #include "RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2.h"
 
 namespace RecoEgamma_ElectronIdentification {
-  struct dictionary {    
+  struct dictionary {
     typedef MakeVersionedSelector<reco::GsfElectron> MakeVersionedGsfElectronSelector;
     typedef MakePtrFromCollection<reco::GsfElectronCollection> MakeGsfPtrFromCollection;
     typedef PrintVIDToString<reco::GsfElectron> PrintGsfElectronVIDToString;
@@ -23,18 +23,16 @@ namespace RecoEgamma_ElectronIdentification {
     typedef PrintVIDToString<pat::Electron> PrintPatElectronVIDToString;
 
     //for using the selectors in python
-    VersionedGsfElectronSelector vGsfElectronSelector;    
+    VersionedGsfElectronSelector vGsfElectronSelector;
     MakeVersionedGsfElectronSelector vMakeGsfElectronVersionedSelector;
     PrintGsfElectronVIDToString vGsfPrintVIDToString;
-    MakeGsfPtrFromCollection vGsfMakePtrFromCollection;  
-    
-    VersionedPatElectronSelector vPatElectronSelector; 
+    MakeGsfPtrFromCollection vGsfMakePtrFromCollection;
+
+    VersionedPatElectronSelector vPatElectronSelector;
     MakeVersionedPatElectronSelector vMakePatElectronVersionedSelector;
     PrintPatElectronVIDToString vPatPrintVIDToString;
     MakePatPtrFromCollection vPatMakePtrFromCollection;
-    MakePtrFromCollection<std::vector<pat::Electron>, pat::Electron, reco::GsfElectron > vPatToGsfMakePtrFromCollection;;
-    
+    MakePtrFromCollection<std::vector<pat::Electron>, pat::Electron, reco::GsfElectron> vPatToGsfMakePtrFromCollection;
+    ;
   };
-}
-
-
+}  // namespace RecoEgamma_ElectronIdentification

--- a/RecoEgamma/ElectronIdentification/test/VIDUsageExample.cc
+++ b/RecoEgamma/ElectronIdentification/test/VIDUsageExample.cc
@@ -7,7 +7,6 @@
 **
 */
 
-
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -21,103 +20,97 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 
-
-
 class VIDUsageExample : public edm::stream::EDAnalyzer<> {
-
 private:
   //we want this to work on mini-aod and aod, this means we dont know if we are getting
   //GsfElectrons or PAT electrons
   //so we try both (this could be a bit more sophosticated but lets keep things simple)
   edm::EDGetTokenT<reco::GsfElectronCollection> gsfEleToken_;
   edm::EDGetTokenT<edm::View<pat::Electron> > patEleToken_;
-  edm::EDGetTokenT<edm::ValueMap<bool> > idDecisionMapToken_; //a bool true=passed ID, false = failed ID
-  edm::EDGetTokenT<edm::ValueMap<unsigned> > firstIdCutFailedMapToken_; //the number of the first cut failed in the order they are defined in the PSet starting at zero (ie if you et,dEtaIn,dPhiIn,hadem cuts defined and it passed et,dEtaIn but failed dPhiIn, this number would be 2, in the case of no cuts failed it is #cuts
-  edm::EDGetTokenT<std::string> idMD5NameToken_; //the md5sum of the ID you are using (E/gamma might ask you for this to verify you are running the right ID) 
-  
+  edm::EDGetTokenT<edm::ValueMap<bool> > idDecisionMapToken_;  //a bool true=passed ID, false = failed ID
+  edm::EDGetTokenT<edm::ValueMap<unsigned> >
+      firstIdCutFailedMapToken_;  //the number of the first cut failed in the order they are defined in the PSet starting at zero (ie if you et,dEtaIn,dPhiIn,hadem cuts defined and it passed et,dEtaIn but failed dPhiIn, this number would be 2, in the case of no cuts failed it is #cuts
+  edm::EDGetTokenT<std::string>
+      idMD5NameToken_;  //the md5sum of the ID you are using (E/gamma might ask you for this to verify you are running the right ID)
+
   size_t nrPassID_;
   size_t nrFailID_;
 
 public:
   explicit VIDUsageExample(const edm::ParameterSet& para);
-  ~VIDUsageExample(){}
-  
-  virtual void analyze(const edm::Event& event,const edm::EventSetup& setup) override;
- 
-  void endStream() override {std::cout <<"nrPass "<<nrPassID_<<" nrFail "<<nrFailID_<<" (note this is all \"electrons\" so is not the ID efficiency)"<<std::endl;}
- 
+  ~VIDUsageExample() {}
+
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
+
+  void endStream() override {
+    std::cout << "nrPass " << nrPassID_ << " nrFail " << nrFailID_
+              << " (note this is all \"electrons\" so is not the ID efficiency)" << std::endl;
+  }
 };
 
-VIDUsageExample::VIDUsageExample(const edm::ParameterSet& para):
-  gsfEleToken_(consumes<reco::GsfElectronCollection>(para.getParameter<edm::InputTag>("eles"))),
-  patEleToken_(consumes<edm::View<pat::Electron> >(para.getParameter<edm::InputTag>("eles"))),
-   
-  idDecisionMapToken_(consumes<edm::ValueMap<bool> >(para.getParameter<edm::InputTag>("id"))),
-  firstIdCutFailedMapToken_(consumes<edm::ValueMap<unsigned> >(para.getParameter<edm::InputTag>("id"))),
-  idMD5NameToken_(consumes<std::string>(para.getParameter<edm::InputTag>("id"))),
-  nrPassID_(0),
-  nrFailID_(0)
+VIDUsageExample::VIDUsageExample(const edm::ParameterSet& para)
+    : gsfEleToken_(consumes<reco::GsfElectronCollection>(para.getParameter<edm::InputTag>("eles"))),
+      patEleToken_(consumes<edm::View<pat::Electron> >(para.getParameter<edm::InputTag>("eles"))),
 
-{
-  
-}
+      idDecisionMapToken_(consumes<edm::ValueMap<bool> >(para.getParameter<edm::InputTag>("id"))),
+      firstIdCutFailedMapToken_(consumes<edm::ValueMap<unsigned> >(para.getParameter<edm::InputTag>("id"))),
+      idMD5NameToken_(consumes<std::string>(para.getParameter<edm::InputTag>("id"))),
+      nrPassID_(0),
+      nrFailID_(0)
 
+{}
 
-void VIDUsageExample::analyze(const edm::Event& iEvent,const edm::EventSetup& iSetup)
-{ 
+void VIDUsageExample::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<edm::View<pat::Electron> > patEles;
-  iEvent.getByToken(patEleToken_,patEles);
-  
+  iEvent.getByToken(patEleToken_, patEles);
+
   edm::Handle<reco::GsfElectronCollection> gsfEles;
-  iEvent.getByToken(gsfEleToken_,gsfEles);
+  iEvent.getByToken(gsfEleToken_, gsfEles);
 
   edm::Handle<edm::ValueMap<bool> > idDecisionMap;
-  iEvent.getByToken(idDecisionMapToken_,idDecisionMap);
+  iEvent.getByToken(idDecisionMapToken_, idDecisionMap);
 
   edm::Handle<edm::ValueMap<unsigned> > firstIdCutFailedMap;
-  iEvent.getByToken(firstIdCutFailedMapToken_,firstIdCutFailedMap);
+  iEvent.getByToken(firstIdCutFailedMapToken_, firstIdCutFailedMap);
 
   edm::Handle<std::string> idMD5Name;
-  iEvent.getByToken(idMD5NameToken_,idMD5Name);
+  iEvent.getByToken(idMD5NameToken_, idMD5Name);
 
-  std::cout <<"md5sum of the ID "<<*idMD5Name<<std::endl;
+  std::cout << "md5sum of the ID " << *idMD5Name << std::endl;
 
   //note the copy/paste is only to make things clearer, its not a great way of solving this issue
 
-  if(patEles.isValid()){ //we have pat electrons availible use them
-    for(auto ele=patEles->begin();ele!=patEles->end();++ele){
-      const edm::Ptr<pat::Electron> elePtr(patEles,ele-patEles->begin()); //value map is keyed of edm::Ptrs so we need to make one
-      bool passID = (*idDecisionMap)[elePtr]; //a bool, true if it passed the ID, false if it didnt
-      if(passID) {
-	std::cout <<"pat ele passed ID"<<std::endl;
-	nrPassID_++;
-      }else{
-	int firstCutFailedNr = (*firstIdCutFailedMap)[elePtr];
-	std::cout <<"pat ele failed ID at cut #"<<firstCutFailedNr<<std::endl;
-	nrFailID_++;
+  if (patEles.isValid()) {  //we have pat electrons availible use them
+    for (auto ele = patEles->begin(); ele != patEles->end(); ++ele) {
+      const edm::Ptr<pat::Electron> elePtr(
+          patEles, ele - patEles->begin());    //value map is keyed of edm::Ptrs so we need to make one
+      bool passID = (*idDecisionMap)[elePtr];  //a bool, true if it passed the ID, false if it didnt
+      if (passID) {
+        std::cout << "pat ele passed ID" << std::endl;
+        nrPassID_++;
+      } else {
+        int firstCutFailedNr = (*firstIdCutFailedMap)[elePtr];
+        std::cout << "pat ele failed ID at cut #" << firstCutFailedNr << std::endl;
+        nrFailID_++;
       }
     }
-  }else if(gsfEles.isValid()){ //no pat electrons availible, fall back to GsfElectrons
-    for(auto ele=gsfEles->begin();ele!=gsfEles->end();++ele){
-      const edm::Ptr<reco::GsfElectron> elePtr(gsfEles,ele-gsfEles->begin()); //value map is keyed of edm::Ptrs so we need to make one
-      bool passID = (*idDecisionMap)[elePtr]; //a bool, true if it passed the ID, false if it didnt
-      if(passID){
-	std::cout <<"gsf ele passed ID"<<std::endl;
-	nrPassID_++;
-      }else{
-	int firstCutFailedNr = (*firstIdCutFailedMap)[elePtr];
-	std::cout <<"gsf ele failed ID at cut #"<<firstCutFailedNr<<std::endl;
-	nrFailID_++;
+  } else if (gsfEles.isValid()) {  //no pat electrons availible, fall back to GsfElectrons
+    for (auto ele = gsfEles->begin(); ele != gsfEles->end(); ++ele) {
+      const edm::Ptr<reco::GsfElectron> elePtr(
+          gsfEles, ele - gsfEles->begin());    //value map is keyed of edm::Ptrs so we need to make one
+      bool passID = (*idDecisionMap)[elePtr];  //a bool, true if it passed the ID, false if it didnt
+      if (passID) {
+        std::cout << "gsf ele passed ID" << std::endl;
+        nrPassID_++;
+      } else {
+        int firstCutFailedNr = (*firstIdCutFailedMap)[elePtr];
+        std::cout << "gsf ele failed ID at cut #" << firstCutFailedNr << std::endl;
+        nrFailID_++;
       }
     }
-  }else{
-    std::cout <<"no Gsf or PAT electrons found"<<std::endl;
+  } else {
+    std::cout << "no Gsf or PAT electrons found" << std::endl;
   }
-
 }
-
- 
-
-
 
 DEFINE_FWK_MODULE(VIDUsageExample);

--- a/RecoEgamma/PhotonIdentification/interface/CutBasedPhotonIDAlgo.h
+++ b/RecoEgamma/PhotonIdentification/interface/CutBasedPhotonIDAlgo.h
@@ -6,27 +6,17 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
-class CutBasedPhotonIDAlgo  {
-
+class CutBasedPhotonIDAlgo {
 public:
-
   CutBasedPhotonIDAlgo(){};
 
   virtual ~CutBasedPhotonIDAlgo(){};
 
-  void setup(const edm::ParameterSet& conf);
-  void decideEB(const reco::Photon* pho,
-		bool &LooseEM,
-		bool &LoosePhoton, 
-		bool &TightPhoton 
-		);
-  void decideEE(const reco::Photon* pho,
-		bool &LooseEM,
-		bool &LoosePhoton,
-		bool &TightPhoton);
- private:
-  
+  void setup(const edm::ParameterSet &conf);
+  void decideEB(const reco::Photon *pho, bool &LooseEM, bool &LoosePhoton, bool &TightPhoton);
+  void decideEE(const reco::Photon *pho, bool &LooseEM, bool &LoosePhoton, bool &TightPhoton);
+
+private:
   //Which cuts to do?
 
   bool dophotonEcalRecHitIsolationCut_;
@@ -129,8 +119,6 @@ public:
   double tightphotonEtaWidthCutEE_;
   double tightphotonHadOverEMCutEE_;
   double tightphotonR9CutEE_;
-
- 
 };
 
-#endif // CutBasedPhotonIDAlgo_H
+#endif  // CutBasedPhotonIDAlgo_H

--- a/RecoEgamma/PhotonIdentification/interface/PFPhotonIsolationCalculator.h
+++ b/RecoEgamma/PhotonIdentification/interface/PFPhotonIsolationCalculator.h
@@ -8,14 +8,12 @@
 // PF Particle collection and the reconstructed vertex collection as input.
 //
 // Authors: Vasundhara Chetluru
-// Modified specifically for Photons, to be used as configurable plug-in 
+// Modified specifically for Photons, to be used as configurable plug-in
 // algorithm in the gedPhotonProducer, by N. Marinelli
 //--------------------------------------------------------------------------------------------------
 
-
 #ifndef PFPhotonIsolationCalculator_H
 #define PFPhotonIsolationCalculator_H
-
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -31,79 +29,79 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 
-
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-
-
-class PFPhotonIsolationCalculator{
- public:
+class PFPhotonIsolationCalculator {
+public:
   PFPhotonIsolationCalculator();
   ~PFPhotonIsolationCalculator();
 
-
   void setup(const edm::ParameterSet& conf);
-  
 
+public:
+  void calculate(const reco::Photon*,
+                 const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle,
+                 edm::Handle<reco::VertexCollection>& vertices,
+                 const edm::Event& e,
+                 const edm::EventSetup& es,
+                 reco::Photon::PflowIsolationVariables& phoisol03);
 
- public:
-
-  
-
-  void calculate(const reco::Photon*, 
-		 const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle,
-		 edm::Handle< reco::VertexCollection >& vertices,
-		 const edm::Event& e, const edm::EventSetup& es,
-		 reco::Photon::PflowIsolationVariables& phoisol03) ;
-
-
-  
- 
- private:
-
-
- enum VetoType {
-    kElectron = -1, // MVA for non-triggering electrons
-    kPhoton = 1 // MVA for triggering electrons
+private:
+  enum VetoType {
+    kElectron = -1,  // MVA for non-triggering electrons
+    kPhoton = 1      // MVA for triggering electrons
   };
- 
 
- void initializeRings(int iNumberOfRings, float fRingSize);
- 
- 
- float getIsolationPhoton(){ fIsolationPhoton_ =  fIsolationInRingsPhoton_[0]; return fIsolationPhoton_; };
- float getIsolationNeutral(){ fIsolationNeutral_ = fIsolationInRingsNeutral_[0]; return fIsolationNeutral_; };
- float getIsolationCharged(){ fIsolationCharged_ = fIsolationInRingsCharged_[0]; return fIsolationCharged_; };
- float getIsolationChargedAll(){ return fIsolationChargedAll_; };
- 
- std::vector<float > getIsolationInRingsPhoton(){ return fIsolationInRingsPhoton_; };
- std::vector<float > getIsolationInRingsNeutral(){ return fIsolationInRingsNeutral_; };
- std::vector<float > getIsolationInRingsCharged(){ return fIsolationInRingsCharged_; };
- std::vector<float > getIsolationInRingsChargedAll(){ return fIsolationInRingsChargedAll_; };
+  void initializeRings(int iNumberOfRings, float fRingSize);
 
+  float getIsolationPhoton() {
+    fIsolationPhoton_ = fIsolationInRingsPhoton_[0];
+    return fIsolationPhoton_;
+  };
+  float getIsolationNeutral() {
+    fIsolationNeutral_ = fIsolationInRingsNeutral_[0];
+    return fIsolationNeutral_;
+  };
+  float getIsolationCharged() {
+    fIsolationCharged_ = fIsolationInRingsCharged_[0];
+    return fIsolationCharged_;
+  };
+  float getIsolationChargedAll() { return fIsolationChargedAll_; };
+
+  std::vector<float> getIsolationInRingsPhoton() { return fIsolationInRingsPhoton_; };
+  std::vector<float> getIsolationInRingsNeutral() { return fIsolationInRingsNeutral_; };
+  std::vector<float> getIsolationInRingsCharged() { return fIsolationInRingsCharged_; };
+  std::vector<float> getIsolationInRingsChargedAll() { return fIsolationInRingsChargedAll_; };
 
   //Veto implementation
-  float isPhotonParticleVetoed( const  reco::PFCandidateRef pfIsoCand );
-  float isPhotonParticleVetoed( const reco::PFCandidate* pfIsoCand );
+  float isPhotonParticleVetoed(const reco::PFCandidateRef pfIsoCand);
+  float isPhotonParticleVetoed(const reco::PFCandidate* pfIsoCand);
   //
-  float isNeutralParticleVetoed( const reco::PFCandidate* pfIsoCand );
-  float isNeutralParticleVetoed( const reco::PFCandidateRef pfIsoCand );
+  float isNeutralParticleVetoed(const reco::PFCandidate* pfIsoCand);
+  float isNeutralParticleVetoed(const reco::PFCandidateRef pfIsoCand);
   //
-  float isChargedParticleVetoed( const reco::PFCandidate* pfIsoCand, edm::Handle< reco::VertexCollection > vertices);
-  float isChargedParticleVetoed( const reco::PFCandidate* pfIsoCand,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices );
-  float isChargedParticleVetoed( const reco::PFCandidateRef pfIsoCand,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices );
- 
+  float isChargedParticleVetoed(const reco::PFCandidate* pfIsoCand, edm::Handle<reco::VertexCollection> vertices);
+  float isChargedParticleVetoed(const reco::PFCandidate* pfIsoCand,
+                                reco::VertexRef vtx,
+                                edm::Handle<reco::VertexCollection> vertices);
+  float isChargedParticleVetoed(const reco::PFCandidateRef pfIsoCand,
+                                reco::VertexRef vtx,
+                                edm::Handle<reco::VertexCollection> vertices);
 
+  reco::VertexRef chargedHadronVertex(edm::Handle<reco::VertexCollection> verticies, const reco::PFCandidate& pfcand);
 
-  reco::VertexRef chargedHadronVertex(edm::Handle< reco::VertexCollection > verticies, const reco::PFCandidate& pfcand );
+  int matchPFObject(const reco::Photon* photon, const reco::PFCandidateCollection* pfParticlesColl);
+  int matchPFObject(const reco::GsfElectron* photon, const reco::PFCandidateCollection* pfParticlesColl);
 
-  int matchPFObject(const reco::Photon* photon, const reco::PFCandidateCollection* pfParticlesColl );
-  int matchPFObject(const reco::GsfElectron* photon, const reco::PFCandidateCollection* pfParticlesColl );
-
-  float fGetIsolation(const reco::Photon* photon, const  edm::Handle<reco::PFCandidateCollection> pfCandidateHandle ,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices );
-  std::vector<float > fGetIsolationInRings(const reco::Photon* photon,  edm::Handle<reco::PFCandidateCollection> pfCandidateHandle, reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
-    
+  float fGetIsolation(const reco::Photon* photon,
+                      const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle,
+                      reco::VertexRef vtx,
+                      edm::Handle<reco::VertexCollection> vertices);
+  std::vector<float> fGetIsolationInRings(const reco::Photon* photon,
+                                          edm::Handle<reco::PFCandidateCollection> pfCandidateHandle,
+                                          reco::VertexRef vtx,
+                                          edm::Handle<reco::VertexCollection> vertices);
 
   int iParticleType_;
 
@@ -113,15 +111,15 @@ class PFPhotonIsolationCalculator{
   float fIsolationNeutral_;
   float fIsolationCharged_;
   float fIsolationChargedAll_;
-  
-  std::vector<float > fIsolationInRings_;
-  std::vector<float > fIsolationInRingsPhoton_;
-  std::vector<float > fIsolationInRingsNeutral_;
-  std::vector<float > fIsolationInRingsCharged_;
-  std::vector<float > fIsolationInRingsChargedAll_;
+
+  std::vector<float> fIsolationInRings_;
+  std::vector<float> fIsolationInRingsPhoton_;
+  std::vector<float> fIsolationInRingsNeutral_;
+  std::vector<float> fIsolationInRingsCharged_;
+  std::vector<float> fIsolationInRingsChargedAll_;
 
   Bool_t bCheckClosestZVertex_;
-  float  fConeSize_;
+  float fConeSize_;
   Bool_t bApplyVeto_;
   Bool_t bApplyDzDxyVeto_;
   Bool_t bApplyPFPUVeto_;
@@ -130,10 +128,10 @@ class PFPhotonIsolationCalculator{
 
   Bool_t bDeltaRVetoBarrel_;
   Bool_t bDeltaRVetoEndcap_;
-  
+
   Bool_t bRectangleVetoBarrel_;
   Bool_t bRectangleVetoEndcap_;
-  
+
   float fDeltaRVetoBarrelPhotons_;
   float fDeltaRVetoBarrelNeutrals_;
   float fDeltaRVetoBarrelCharged_;
@@ -151,7 +149,7 @@ class PFPhotonIsolationCalculator{
   float fRectangleDeltaPhiVetoEndcapPhotons_;
   float fRectangleDeltaPhiVetoEndcapNeutrals_;
   float fRectangleDeltaPhiVetoEndcapCharged_;
-  
+
   float fRectangleDeltaEtaVetoBarrelPhotons_;
   float fRectangleDeltaEtaVetoBarrelNeutrals_;
   float fRectangleDeltaEtaVetoBarrelCharged_;
@@ -172,17 +170,14 @@ class PFPhotonIsolationCalculator{
   float fPhi_;
   float fEtaSC_;
   float fPhiSC_;
-  
+
   float fPt_;
   float fVx_;
   float fVy_;
   float fVz_;
-  
+
   reco::SuperClusterRef refSC;
   bool pivotInBarrel;
-
-     
-
 };
 
 #endif

--- a/RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h
@@ -15,86 +15,73 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class PhotonIsolationCalculator {
-
 public:
+  PhotonIsolationCalculator() {}
 
-  PhotonIsolationCalculator(){}
-
-  ~PhotonIsolationCalculator(){}
+  ~PhotonIsolationCalculator() {}
 
   void setup(const edm::ParameterSet& conf,
-	     std::vector<int> const & flagsEB_,
-	     std::vector<int> const & flagsEE_,
-	     std::vector<int> const & severitiesEB_,
-	     std::vector<int> const & severitiesEE_,
-	     edm::ConsumesCollector && iC);
+             std::vector<int> const& flagsEB_,
+             std::vector<int> const& flagsEE_,
+             std::vector<int> const& severitiesEB_,
+             std::vector<int> const& severitiesEE_,
+             edm::ConsumesCollector&& iC);
 
-  void calculate(const reco::Photon*, 
-		 const edm::Event&, const edm::EventSetup& es,
-		 reco::Photon::FiducialFlags& phofid, 
-		 reco::Photon::IsolationVariables& phoisolR03, 
-		 reco::Photon::IsolationVariables& phoisolR04 ) const;
-
-
+  void calculate(const reco::Photon*,
+                 const edm::Event&,
+                 const edm::EventSetup& es,
+                 reco::Photon::FiducialFlags& phofid,
+                 reco::Photon::IsolationVariables& phoisolR03,
+                 reco::Photon::IsolationVariables& phoisolR04) const;
 
 private:
-
-  static void classify(const reco::Photon* photon, 
-		bool &isEBPho,
-		bool &isEEPho,
-		bool &isEBEtaGap,
-		bool &isEBPhiGap,
-		bool &isEERingGap,
-		bool &isEEDeeGap,
-		bool &isEBEEGap) dso_internal;
-
-
+  static void classify(const reco::Photon* photon,
+                       bool& isEBPho,
+                       bool& isEEPho,
+                       bool& isEBEtaGap,
+                       bool& isEBPhiGap,
+                       bool& isEERingGap,
+                       bool& isEEDeeGap,
+                       bool& isEBEEGap) dso_internal;
 
   void calculateTrackIso(const reco::Photon* photon,
-			 const edm::Event &e,
-			 double &trkCone,
-			 int &ntrkCone,
-			 double pTThresh=0,
-			 double RCone=.4,
-			 double RinnerCone=.1,
-                         double etaSlice=0.015,
-                         double lip=0.2,
-                         double d0=0.1) const dso_internal;
-
-
+                         const edm::Event& e,
+                         double& trkCone,
+                         int& ntrkCone,
+                         double pTThresh = 0,
+                         double RCone = .4,
+                         double RinnerCone = .1,
+                         double etaSlice = 0.015,
+                         double lip = 0.2,
+                         double d0 = 0.1) const dso_internal;
 
   double calculateEcalRecHitIso(const reco::Photon* photon,
-				const edm::Event& iEvent,
-				const edm::EventSetup& iSetup,
-				double RCone,
-				double RConeInner,
+                                const edm::Event& iEvent,
+                                const edm::EventSetup& iSetup,
+                                double RCone,
+                                double RConeInner,
                                 double etaSlice,
-				double eMin,
-				double etMin, 
-				bool vetoClusteredHits, 
-				bool useNumCrystals) const dso_internal;
+                                double eMin,
+                                double etMin,
+                                bool vetoClusteredHits,
+                                bool useNumCrystals) const dso_internal;
 
   double calculateHcalTowerIso(const reco::Photon* photon,
-			       const edm::Event& iEvent,
-			       const edm::EventSetup& iSetup,
-			       double RCone,
-			       double RConeInner,
-			       double eMin,
+                               const edm::Event& iEvent,
+                               const edm::EventSetup& iSetup,
+                               double RCone,
+                               double RConeInner,
+                               double eMin,
                                signed int depth) const dso_internal;
-
 
   double calculateHcalTowerIso(const reco::Photon* photon,
-			       const edm::Event& iEvent,
-			       const edm::EventSetup& iSetup,
-			       double RCone,
-			       double eMin,
+                               const edm::Event& iEvent,
+                               const edm::EventSetup& iSetup,
+                               double RCone,
+                               double eMin,
                                signed int depth) const dso_internal;
 
-
-
-  
- private:
-
+private:
   edm::EDGetToken barrelecalCollection_;
   edm::EDGetToken endcapecalCollection_;
   edm::EDGetToken hcalCollection_;
@@ -120,13 +107,10 @@ private:
   double ecalIsoEndcapRadiusB_[5];
   double hcalIsoEndcapRadiusB_[9];
 
-
   std::vector<int> flagsEB_;
   std::vector<int> flagsEE_;
   std::vector<int> severityExclEB_;
   std::vector<int> severityExclEE_;
-
-
 };
 
-#endif // PhotonIsolationCalculator_H
+#endif  // PhotonIsolationCalculator_H

--- a/RecoEgamma/PhotonIdentification/interface/PhotonMIPHaloTagger.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonMIPHaloTagger.h
@@ -9,67 +9,54 @@
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h" 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
 class PhotonMIPHaloTagger {
-
 public:
-
   PhotonMIPHaloTagger(){};
 
   virtual ~PhotonMIPHaloTagger(){};
 
-  void setup(const edm::ParameterSet& conf,edm::ConsumesCollector&& iC);
+  void setup(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC);
 
-  void MIPcalculate(const reco::Photon*, 
-		    const edm::Event&, 
+  void MIPcalculate(const reco::Photon*,
+                    const edm::Event&,
                     const edm::EventSetup& es,
                     reco::Photon::MIPVariables& mipId);
 
-
   //get the seed crystal index
- void GetSeedHighestE(const reco::Photon* photon,
+  void GetSeedHighestE(const reco::Photon* photon,
                        const edm::Event& iEvent,
                        const edm::EventSetup& iSetup,
                        edm::Handle<EcalRecHitCollection> Brechit,
-                       int &seedIEta,
-                       int &seedIPhi,
-                       double &seedE);
+                       int& seedIEta,
+                       int& seedIPhi,
+                       double& seedE);
 
-
-  //get the MIP  Fit Trail results 
- std::vector<double>  GetMipTrailFit(const reco::Photon* photon,
-		         	     const edm::Event& iEvent,
-			             const edm::EventSetup& iSetup,
+  //get the MIP  Fit Trail results
+  std::vector<double> GetMipTrailFit(const reco::Photon* photon,
+                                     const edm::Event& iEvent,
+                                     const edm::EventSetup& iSetup,
                                      edm::Handle<EcalRecHitCollection> ecalhitsCollEB,
-                                     double inputRangeY,    
-                                     double inputRangeX,    
-                                     double inputResWidth,  
+                                     double inputRangeY,
+                                     double inputRangeX,
+                                     double inputResWidth,
                                      double inputHaloDiscCut,
-                                     int & NhitCone_,
-                                     bool & ismipHalo_ );
+                                     int& NhitCone_,
+                                     bool& ismipHalo_);
 
-
- 
-
-
- 
- protected:
-
+protected:
   edm::EDGetToken EBecalCollection_;
   edm::EDGetToken EEecalCollection_;
 
-
-
- //used inside main methhod
- double inputRangeY;
- double inputRangeX;
- double inputResWidth;
- double inputHaloDiscCut;
- 
+  //used inside main methhod
+  double inputRangeY;
+  double inputRangeX;
+  double inputResWidth;
+  double inputHaloDiscCut;
 
   //Isolation parameters variables as input
   double yRangeFit_;
@@ -77,12 +64,10 @@ public:
   double residualWidthEnergy_;
   double haloDiscThreshold_;
 
- //Local Vector for results
- std::vector<double> mipFitResults_;
- int  nhitCone_;
- bool ismipHalo_; 
+  //Local Vector for results
+  std::vector<double> mipFitResults_;
+  int nhitCone_;
+  bool ismipHalo_;
+};
 
-
-  };
-
-#endif // PhotonMIPHaloTagger_H
+#endif  // PhotonMIPHaloTagger_H

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDProducer.cc
@@ -2,12 +2,10 @@
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
-
-
 PhotonIDProducer::PhotonIDProducer(const edm::ParameterSet& conf) : conf_(conf) {
-  photonToken_ = consumes<reco::PhotonCollection>(edm::InputTag(conf_.getParameter<std::string>("photonProducer"),
-								conf_.getParameter<std::string>("photonLabel")));
- 
+  photonToken_ = consumes<reco::PhotonCollection>(
+      edm::InputTag(conf_.getParameter<std::string>("photonProducer"), conf_.getParameter<std::string>("photonLabel")));
+
   photonCutBasedIDLooseLabel_ = conf.getParameter<std::string>("photonCutBasedIDLooseLabel");
   photonCutBasedIDTightLabel_ = conf.getParameter<std::string>("photonCutBasedIDTightLabel");
   photonCutBasedIDLooseEMLabel_ = conf.getParameter<std::string>("photonCutBasedIDLooseEMLabel");
@@ -15,46 +13,38 @@ PhotonIDProducer::PhotonIDProducer(const edm::ParameterSet& conf) : conf_(conf) 
   doCutBased_ = conf_.getParameter<bool>("doCutBased");
   cutBasedAlgo_ = new CutBasedPhotonIDAlgo();
   cutBasedAlgo_->setup(conf);
-  produces<edm::ValueMap<Bool_t> > (photonCutBasedIDLooseLabel_);
-  produces<edm::ValueMap<Bool_t> > (photonCutBasedIDTightLabel_);
-  produces<edm::ValueMap<Bool_t> > (photonCutBasedIDLooseEMLabel_);
-
+  produces<edm::ValueMap<Bool_t>>(photonCutBasedIDLooseLabel_);
+  produces<edm::ValueMap<Bool_t>>(photonCutBasedIDTightLabel_);
+  produces<edm::ValueMap<Bool_t>>(photonCutBasedIDLooseEMLabel_);
 }
 
 PhotonIDProducer::~PhotonIDProducer() {
-
   //if (doCutBased_)
   delete cutBasedAlgo_;
-
 }
 
 void PhotonIDProducer::produce(edm::Event& e, const edm::EventSetup& c) {
-
-   // Read in photons
+  // Read in photons
   edm::Handle<reco::PhotonCollection> photons;
-  e.getByToken(photonToken_,photons);
-
+  e.getByToken(photonToken_, photons);
 
   // Loop over photons and calculate photon ID using specified technique(s)
   reco::PhotonCollection::const_iterator photon;
-  std::vector <Bool_t> Loose;
-  std::vector <Bool_t> Tight;
-  std::vector <Bool_t> LooseEM;
-  for (photon = (*photons).begin();
-       photon != (*photons).end(); ++photon) {
+  std::vector<Bool_t> Loose;
+  std::vector<Bool_t> Tight;
+  std::vector<Bool_t> LooseEM;
+  for (photon = (*photons).begin(); photon != (*photons).end(); ++photon) {
     bool LooseQual;
     bool TightQual;
     bool LooseEMQual;
     if (photon->isEB())
-      cutBasedAlgo_->decideEB(&(*photon),LooseEMQual,LooseQual, TightQual);
+      cutBasedAlgo_->decideEB(&(*photon), LooseEMQual, LooseQual, TightQual);
     else
-      cutBasedAlgo_->decideEE(&(*photon),LooseEMQual,LooseQual, TightQual);
+      cutBasedAlgo_->decideEE(&(*photon), LooseEMQual, LooseQual, TightQual);
     LooseEM.push_back(LooseEMQual);
     Loose.push_back(LooseQual);
     Tight.push_back(TightQual);
-    
   }
-  
 
   auto outlooseEM = std::make_unique<edm::ValueMap<Bool_t>>();
   edm::ValueMap<Bool_t>::Filler fillerlooseEM(*outlooseEM);
@@ -69,13 +59,11 @@ void PhotonIDProducer::produce(edm::Event& e, const edm::EventSetup& c) {
   fillerloose.fill();
   // and put it into the event
   e.put(std::move(outloose), photonCutBasedIDLooseLabel_);
-  
+
   auto outtight = std::make_unique<edm::ValueMap<Bool_t>>();
   edm::ValueMap<Bool_t>::Filler fillertight(*outtight);
   fillertight.insert(photons, Tight.begin(), Tight.end());
   fillertight.fill();
   // and put it into the event
   e.put(std::move(outtight), photonCutBasedIDTightLabel_);
-  
-  
 }

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDProducer.h
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDProducer.h
@@ -12,19 +12,15 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 
-
-class PhotonIDProducer : public edm::stream::EDProducer<>
-{
- public:
-
+class PhotonIDProducer : public edm::stream::EDProducer<> {
+public:
   explicit PhotonIDProducer(const edm::ParameterSet& conf);
   ~PhotonIDProducer() override;
 
   void produce(edm::Event& e, const edm::EventSetup& c) override;
-   
- private:
 
-  CutBasedPhotonIDAlgo* cutBasedAlgo_; 	   
+private:
+  CutBasedPhotonIDAlgo* cutBasedAlgo_;
 
   edm::ParameterSet conf_;
   edm::EDGetTokenT<reco::PhotonCollection> photonToken_;
@@ -34,7 +30,6 @@ class PhotonIDProducer : public edm::stream::EDProducer<>
   std::string photonCutBasedIDTightLabel_;
 
   bool doCutBased_;
-
 };
 
 #endif

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDSimpleAnalyzer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDSimpleAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    PhotonIDSimpleAnalyzer
 // Class:      PhotonIDSimpleAnalyzer
-// 
+//
 /**\class PhotonIDSimpleAnalyzer PhotonIDSimpleAnalyzer.cc RecoEgamma/PhotonIdentification/test/PhotonIDSimpleAnalyzer.cc
 
  Description: Generate various histograms for cuts and important 
@@ -65,113 +65,109 @@
 #include "TH1.h"
 #include "TTree.h"
 
-
 class TFile;
 
 //
 // class declaration
 //
 class PhotonIDSimpleAnalyzer : public edm::one::EDAnalyzer<> {
-   public:
-      explicit PhotonIDSimpleAnalyzer( const edm::ParameterSet& );
-      ~PhotonIDSimpleAnalyzer() override;
+public:
+  explicit PhotonIDSimpleAnalyzer(const edm::ParameterSet&);
+  ~PhotonIDSimpleAnalyzer() override;
 
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void beginJob() override;
+  void endJob() override;
 
-      void analyze( const edm::Event&, const edm::EventSetup& ) override;
-      void beginJob() override;
-      void endJob() override;
- private:
+private:
+  std::string outputFile_;  // output file
+  double minPhotonEt_;      // minimum photon Et
+  double minPhotonAbsEta_;  // min and
+  double maxPhotonAbsEta_;  // max abs(eta)
+  double minPhotonR9_;      // minimum R9 = E(3x3)/E(SuperCluster)
+  double maxPhotonHoverE_;  // maximum HCAL / ECAL
+  bool createPhotonTTree_;  // Create a TTree of photon variables
 
-      std::string outputFile_;   // output file
-      double minPhotonEt_;       // minimum photon Et
-      double minPhotonAbsEta_;   // min and
-      double maxPhotonAbsEta_;   // max abs(eta)
-      double minPhotonR9_;       // minimum R9 = E(3x3)/E(SuperCluster)
-      double maxPhotonHoverE_;   // maximum HCAL / ECAL 
-      bool   createPhotonTTree_; // Create a TTree of photon variables
+  // Will be used for creating TTree of photons.
+  // These names did not have to match those from a phtn->...
+  // but do match for clarity.
+  struct struct_recPhoton {
+    float isolationEcalRecHit;
+    float isolationHcalRecHit;
+    float isolationSolidTrkCone;
+    float isolationHollowTrkCone;
+    float nTrkSolidCone;
+    float nTrkHollowCone;
+    float isEBEtaGap;
+    float isEBPhiGap;
+    float isEERingGap;
+    float isEEDeeGap;
+    float isEBEEGap;
+    float r9;
+    float et;
+    float eta;
+    float phi;
+    float hadronicOverEm;
+  };
+  struct_recPhoton recPhoton;
 
-      // Will be used for creating TTree of photons.
-      // These names did not have to match those from a phtn->...
-      // but do match for clarity.
-      struct struct_recPhoton {
-        float isolationEcalRecHit;
-	float isolationHcalRecHit;
-	float isolationSolidTrkCone;
-	float isolationHollowTrkCone;
-	float nTrkSolidCone;
-	float nTrkHollowCone;
-        float isEBEtaGap;
-        float isEBPhiGap;
-	float isEERingGap;
-	float isEEDeeGap;
-	float isEBEEGap;
-	float r9;
-	float et;
-	float eta;
-	float phi;
-        float hadronicOverEm;
-      } ;
-      struct_recPhoton recPhoton;
+  // root file to store histograms
+  TFile* rootFile_;
 
-      // root file to store histograms
-      TFile*  rootFile_;
+  // data members for histograms to be filled
 
-      // data members for histograms to be filled
+  // PhotonID Histograms
+  TH1F* h_isoEcalRecHit_;
+  TH1F* h_isoHcalRecHit_;
+  TH1F* h_trk_pt_solid_;
+  TH1F* h_trk_pt_hollow_;
+  TH1F* h_ntrk_solid_;
+  TH1F* h_ntrk_hollow_;
+  TH1F* h_ebetagap_;
+  TH1F* h_ebphigap_;
+  TH1F* h_eeringGap_;
+  TH1F* h_eedeeGap_;
+  TH1F* h_ebeeGap_;
+  TH1F* h_r9_;
 
-      // PhotonID Histograms
-      TH1F* h_isoEcalRecHit_;
-      TH1F* h_isoHcalRecHit_;
-      TH1F* h_trk_pt_solid_;
-      TH1F* h_trk_pt_hollow_;
-      TH1F* h_ntrk_solid_;
-      TH1F* h_ntrk_hollow_;
-      TH1F* h_ebetagap_;
-      TH1F* h_ebphigap_;
-      TH1F* h_eeringGap_;
-      TH1F* h_eedeeGap_;
-      TH1F* h_ebeeGap_;
-      TH1F* h_r9_;
+  // Photon Histograms
+  TH1F* h_photonEt_;
+  TH1F* h_photonEta_;
+  TH1F* h_photonPhi_;
+  TH1F* h_hadoverem_;
 
-      // Photon Histograms
-      TH1F* h_photonEt_;
-      TH1F* h_photonEta_;
-      TH1F* h_photonPhi_;
-      TH1F* h_hadoverem_;
+  // Photon's SuperCluster Histograms
+  TH1F* h_photonScEt_;
+  TH1F* h_photonScEta_;
+  TH1F* h_photonScPhi_;
+  TH1F* h_photonScEtaWidth_;
 
-      // Photon's SuperCluster Histograms
-      TH1F* h_photonScEt_;       
-      TH1F* h_photonScEta_;      
-      TH1F* h_photonScPhi_;
-      TH1F* h_photonScEtaWidth_;
+  // Composite or Other Histograms
+  TH1F* h_photonInAnyGap_;
+  TH1F* h_nPassingPho_;
+  TH1F* h_nPassEM_;
+  TH1F* h_nPho_;
 
-      // Composite or Other Histograms
-      TH1F* h_photonInAnyGap_;
-      TH1F* h_nPassingPho_;
-      TH1F* h_nPassEM_;
-      TH1F* h_nPho_;
-
-      // TTree
-      TTree* tree_PhotonAll_;
+  // TTree
+  TTree* tree_PhotonAll_;
 };
-
 
 using namespace std;
 
 ///////////////////////////////////////////////////////////////////////
 //                           Constructor                             //
 ///////////////////////////////////////////////////////////////////////
-PhotonIDSimpleAnalyzer::PhotonIDSimpleAnalyzer(const edm::ParameterSet& ps)
-{
+PhotonIDSimpleAnalyzer::PhotonIDSimpleAnalyzer(const edm::ParameterSet& ps) {
   // Read Parameters from configuration file
 
   // output filename
-  outputFile_   = ps.getParameter<std::string>("outputFile");
-  // Read variables that must be passed to allow a 
+  outputFile_ = ps.getParameter<std::string>("outputFile");
+  // Read variables that must be passed to allow a
   //  supercluster to be placed in histograms as a photon.
-  minPhotonEt_     = ps.getParameter<double>("minPhotonEt");
+  minPhotonEt_ = ps.getParameter<double>("minPhotonEt");
   minPhotonAbsEta_ = ps.getParameter<double>("minPhotonAbsEta");
   maxPhotonAbsEta_ = ps.getParameter<double>("maxPhotonAbsEta");
-  minPhotonR9_     = ps.getParameter<double>("minPhotonR9");
+  minPhotonR9_ = ps.getParameter<double>("minPhotonR9");
   maxPhotonHoverE_ = ps.getParameter<double>("maxPhotonHoverE");
 
   // Read variable to that decidedes whether
@@ -179,82 +175,77 @@ PhotonIDSimpleAnalyzer::PhotonIDSimpleAnalyzer(const edm::ParameterSet& ps)
   createPhotonTTree_ = ps.getParameter<bool>("createPhotonTTree");
 
   // open output file to store histograms
-  rootFile_ = TFile::Open(outputFile_.c_str(),"RECREATE");
+  rootFile_ = TFile::Open(outputFile_.c_str(), "RECREATE");
 }
 
 ///////////////////////////////////////////////////////////////////////
 //                            Destructor                             //
 ///////////////////////////////////////////////////////////////////////
-PhotonIDSimpleAnalyzer::~PhotonIDSimpleAnalyzer()
-{
-
-// do anything here that needs to be done at desctruction time
-// (e.g. close files, deallocate resources etc.)
+PhotonIDSimpleAnalyzer::~PhotonIDSimpleAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 
   delete rootFile_;
-
 }
 
 ///////////////////////////////////////////////////////////////////////
 //    method called once each job just before starting event loop    //
 ///////////////////////////////////////////////////////////////////////
-void 
-PhotonIDSimpleAnalyzer::beginJob()
-{
-
+void PhotonIDSimpleAnalyzer::beginJob() {
   // go to *OUR* rootfile
   rootFile_->cd();
 
   // Book Histograms
   // PhotonID Histograms
-  h_isoEcalRecHit_ = new TH1F("photonEcalIso",          "Ecal Rec Hit Isolation", 300, 0, 300);
-  h_isoHcalRecHit_ = new TH1F("photonHcalIso",          "Hcal Rec Hit Isolation", 300, 0, 300);
-  h_trk_pt_solid_  = new TH1F("photonTrackSolidIso",    "Sum of track pT in a cone of #DeltaR" , 300, 0, 300);
-  h_trk_pt_hollow_ = new TH1F("photonTrackHollowIso",   "Sum of track pT in a hollow cone" ,     300, 0, 300);
-  h_ntrk_solid_    = new TH1F("photonTrackCountSolid",  "Number of tracks in a cone of #DeltaR", 100, 0, 100);
-  h_ntrk_hollow_   = new TH1F("photonTrackCountHollow", "Number of tracks in a hollow cone",     100, 0, 100);
-  h_ebetagap_         = new TH1F("photonInEBEtagap",          "Ecal Barrel eta gap flag",  2, -0.5, 1.5);
-  h_ebphigap_         = new TH1F("photonInEBEtagap",          "Ecal Barrel phi gap flag",  2, -0.5, 1.5);
-  h_eeringGap_         = new TH1F("photonInEERinggap",          "Ecal Endcap ring gap flag",  2, -0.5, 1.5);
-  h_eedeeGap_         = new TH1F("photonInEEDeegap",          "Ecal Endcap dee gap flag",  2, -0.5, 1.5);
-  h_ebeeGap_       = new TH1F("photonInEEgap",          "Ecal Barrel/Endcap gap flag",  2, -0.5, 1.5);
-  h_r9_            = new TH1F("photonR9",               "R9 = E(3x3) / E(SuperCluster)", 300, 0, 3);
+  h_isoEcalRecHit_ = new TH1F("photonEcalIso", "Ecal Rec Hit Isolation", 300, 0, 300);
+  h_isoHcalRecHit_ = new TH1F("photonHcalIso", "Hcal Rec Hit Isolation", 300, 0, 300);
+  h_trk_pt_solid_ = new TH1F("photonTrackSolidIso", "Sum of track pT in a cone of #DeltaR", 300, 0, 300);
+  h_trk_pt_hollow_ = new TH1F("photonTrackHollowIso", "Sum of track pT in a hollow cone", 300, 0, 300);
+  h_ntrk_solid_ = new TH1F("photonTrackCountSolid", "Number of tracks in a cone of #DeltaR", 100, 0, 100);
+  h_ntrk_hollow_ = new TH1F("photonTrackCountHollow", "Number of tracks in a hollow cone", 100, 0, 100);
+  h_ebetagap_ = new TH1F("photonInEBEtagap", "Ecal Barrel eta gap flag", 2, -0.5, 1.5);
+  h_ebphigap_ = new TH1F("photonInEBEtagap", "Ecal Barrel phi gap flag", 2, -0.5, 1.5);
+  h_eeringGap_ = new TH1F("photonInEERinggap", "Ecal Endcap ring gap flag", 2, -0.5, 1.5);
+  h_eedeeGap_ = new TH1F("photonInEEDeegap", "Ecal Endcap dee gap flag", 2, -0.5, 1.5);
+  h_ebeeGap_ = new TH1F("photonInEEgap", "Ecal Barrel/Endcap gap flag", 2, -0.5, 1.5);
+  h_r9_ = new TH1F("photonR9", "R9 = E(3x3) / E(SuperCluster)", 300, 0, 3);
 
   // Photon Histograms
-  h_photonEt_      = new TH1F("photonEt",     "Photon E_{T}",  200,  0, 200);
-  h_photonEta_     = new TH1F("photonEta",    "Photon #eta",   800, -4,   4);
-  h_photonPhi_     = new TH1F("photonPhi",    "Photon #phi",   628, -1.*TMath::Pi(), TMath::Pi());
-  h_hadoverem_     = new TH1F("photonHoverE", "Hadronic over EM", 200, 0, 1);
+  h_photonEt_ = new TH1F("photonEt", "Photon E_{T}", 200, 0, 200);
+  h_photonEta_ = new TH1F("photonEta", "Photon #eta", 800, -4, 4);
+  h_photonPhi_ = new TH1F("photonPhi", "Photon #phi", 628, -1. * TMath::Pi(), TMath::Pi());
+  h_hadoverem_ = new TH1F("photonHoverE", "Hadronic over EM", 200, 0, 1);
 
   // Photon's SuperCluster Histograms
-  h_photonScEt_       = new TH1F("photonScEt",  "Photon SuperCluster E_{T}", 200,  0, 200);
-  h_photonScEta_      = new TH1F("photonScEta", "Photon #eta",               800, -4,   4);
-  h_photonScPhi_      = new TH1F("photonScPhi", "Photon #phi",628, -1.*TMath::Pi(), TMath::Pi());
-  h_photonScEtaWidth_ = new TH1F("photonScEtaWidth","#eta-width",            100,  0,  .1);
+  h_photonScEt_ = new TH1F("photonScEt", "Photon SuperCluster E_{T}", 200, 0, 200);
+  h_photonScEta_ = new TH1F("photonScEta", "Photon #eta", 800, -4, 4);
+  h_photonScPhi_ = new TH1F("photonScPhi", "Photon #phi", 628, -1. * TMath::Pi(), TMath::Pi());
+  h_photonScEtaWidth_ = new TH1F("photonScEtaWidth", "#eta-width", 100, 0, .1);
 
   // Composite or Other Histograms
-  h_photonInAnyGap_   = new TH1F("photonInAnyGap",     "Photon in any gap flag",  2, -0.5, 1.5);
-  h_nPassingPho_      = new TH1F("photonLoosePhoton", "Total number photons (0=NotPassing, 1=Passing)", 2, -0.5, 1.5);
-  h_nPassEM_          = new TH1F("photonLooseEM", "Total number photons (0=NotPassing, 1=Passing)", 2, -0.5, 1.5);
-  h_nPho_             = new TH1F("photonCount",        "Number of photons passing cuts in event",  10,  0,  10);
+  h_photonInAnyGap_ = new TH1F("photonInAnyGap", "Photon in any gap flag", 2, -0.5, 1.5);
+  h_nPassingPho_ = new TH1F("photonLoosePhoton", "Total number photons (0=NotPassing, 1=Passing)", 2, -0.5, 1.5);
+  h_nPassEM_ = new TH1F("photonLooseEM", "Total number photons (0=NotPassing, 1=Passing)", 2, -0.5, 1.5);
+  h_nPho_ = new TH1F("photonCount", "Number of photons passing cuts in event", 10, 0, 10);
 
   // Create a TTree of photons if set to 'True' in config file
-  if ( createPhotonTTree_ ) {
-    tree_PhotonAll_     = new TTree("TreePhotonAll", "Reconstructed Photon");
-    tree_PhotonAll_->Branch("recPhoton", &recPhoton.isolationEcalRecHit, "isolationEcalRecHit/F:isolationHcalRecHit:isolationSolidTrkCone:isolationHollowTrkCone:nTrkSolidCone:nTrkHollowCone:isEBGap:isEEGap:isEBEEGap:r9:et:eta:phi:hadronicOverEm");
+  if (createPhotonTTree_) {
+    tree_PhotonAll_ = new TTree("TreePhotonAll", "Reconstructed Photon");
+    tree_PhotonAll_->Branch("recPhoton",
+                            &recPhoton.isolationEcalRecHit,
+                            "isolationEcalRecHit/"
+                            "F:isolationHcalRecHit:isolationSolidTrkCone:isolationHollowTrkCone:nTrkSolidCone:"
+                            "nTrkHollowCone:isEBGap:isEEGap:isEBEEGap:r9:et:eta:phi:hadronicOverEm");
   }
 }
 
 ///////////////////////////////////////////////////////////////////////
 //                method called to for each event                    //
 ///////////////////////////////////////////////////////////////////////
-void
-PhotonIDSimpleAnalyzer::analyze(const edm::Event& evt, const edm::EventSetup& es)
-{
-  
+void PhotonIDSimpleAnalyzer::analyze(const edm::Event& evt, const edm::EventSetup& es) {
   using namespace std;
   using namespace edm;
-  
+
   // grab photons
   Handle<reco::PhotonCollection> photonColl;
   evt.getByLabel("photons", "", photonColl);
@@ -262,93 +253,89 @@ PhotonIDSimpleAnalyzer::analyze(const edm::Event& evt, const edm::EventSetup& es
   Handle<edm::ValueMap<Bool_t> > loosePhotonQual;
   evt.getByLabel("PhotonIDProd", "PhotonCutBasedIDLoose", loosePhotonQual);
   Handle<edm::ValueMap<Bool_t> > looseEMQual;
-  evt.getByLabel("PhotonIDProd","PhotonCutBasedIDLooseEM",looseEMQual);
-  // grab PhotonId objects  
-//   Handle<reco::PhotonIDAssociationCollection> photonIDMapColl;
-//   evt.getByLabel("PhotonIDProd", "PhotonAssociatedID", photonIDMapColl);
-  
+  evt.getByLabel("PhotonIDProd", "PhotonCutBasedIDLooseEM", looseEMQual);
+  // grab PhotonId objects
+  //   Handle<reco::PhotonIDAssociationCollection> photonIDMapColl;
+  //   evt.getByLabel("PhotonIDProd", "PhotonAssociatedID", photonIDMapColl);
+
   // create reference to the object types we are interested in
-  const reco::PhotonCollection *photons = photonColl.product();  
-  const edm::ValueMap<Bool_t> *phoMap = loosePhotonQual.product();
-  const edm::ValueMap<Bool_t> *lEMMap = looseEMQual.product();
+  const reco::PhotonCollection* photons = photonColl.product();
+  const edm::ValueMap<Bool_t>* phoMap = loosePhotonQual.product();
+  const edm::ValueMap<Bool_t>* lEMMap = looseEMQual.product();
   int photonCounter = 0;
-  int idxpho=0;
+  int idxpho = 0;
   reco::PhotonCollection::const_iterator pho;
-  for (pho = (*photons).begin(); pho!= (*photons).end(); pho++){   
-    
+  for (pho = (*photons).begin(); pho != (*photons).end(); pho++) {
     edm::Ref<reco::PhotonCollection> photonref(photonColl, idxpho);
     //reco::PhotonIDAssociationCollection::const_iterator photonIter = phoMap->find(photonref);
     //const reco::PhotonIDRef &phtn = photonIter->val;
     //const reco::PhotonRef &pho = photonIter->key;
 
-    float photonEt       = pho->et();
-    float superClusterEt = (pho->superCluster()->energy())/(cosh(pho->superCluster()->position().eta()));
+    float photonEt = pho->et();
+    float superClusterEt = (pho->superCluster()->energy()) / (cosh(pho->superCluster()->position().eta()));
     Bool_t LoosePhotonQu = (*phoMap)[photonref];
     h_nPassingPho_->Fill(LoosePhotonQu);
     Bool_t LooseEMQu = (*lEMMap)[photonref];
     h_nPassEM_->Fill(LooseEMQu);
     // Only store photon candidates (SuperClusters) that pass some simple cuts
-    bool passCuts = (              photonEt > minPhotonEt_     ) &&
-                    (      fabs(pho->eta()) > minPhotonAbsEta_ ) &&
-                    (      fabs(pho->eta()) < maxPhotonAbsEta_ ) &&
-                    (             pho->r9() > minPhotonR9_     ) &&
-                    ( pho->hadronicOverEm() < maxPhotonHoverE_ ) ;
+    bool passCuts = (photonEt > minPhotonEt_) && (fabs(pho->eta()) > minPhotonAbsEta_) &&
+                    (fabs(pho->eta()) < maxPhotonAbsEta_) && (pho->r9() > minPhotonR9_) &&
+                    (pho->hadronicOverEm() < maxPhotonHoverE_);
 
-    if ( passCuts )
-    {
+    if (passCuts) {
       ///////////////////////////////////////////////////////
       //                fill histograms                    //
       ///////////////////////////////////////////////////////
       // PhotonID Variables
       h_isoEcalRecHit_->Fill(pho->ecalRecHitSumEtConeDR04());
       h_isoHcalRecHit_->Fill(pho->hcalTowerSumEtConeDR04());
-      h_trk_pt_solid_ ->Fill(pho->trkSumPtSolidConeDR04());
+      h_trk_pt_solid_->Fill(pho->trkSumPtSolidConeDR04());
       h_trk_pt_hollow_->Fill(pho->trkSumPtHollowConeDR04());
-      h_ntrk_solid_->   Fill(pho->nTrkSolidConeDR04());
-      h_ntrk_hollow_->  Fill(pho->nTrkHollowConeDR04());
-      h_ebetagap_->        Fill(pho->isEBEtaGap());
-      h_ebphigap_->        Fill(pho->isEBPhiGap());
-      h_eeringGap_->        Fill(pho->isEERingGap()); 
-      h_eedeeGap_->        Fill(pho->isEEDeeGap()); 
-      h_ebeeGap_->      Fill(pho->isEBEEGap());
-      h_r9_->           Fill(pho->r9());
+      h_ntrk_solid_->Fill(pho->nTrkSolidConeDR04());
+      h_ntrk_hollow_->Fill(pho->nTrkHollowConeDR04());
+      h_ebetagap_->Fill(pho->isEBEtaGap());
+      h_ebphigap_->Fill(pho->isEBPhiGap());
+      h_eeringGap_->Fill(pho->isEERingGap());
+      h_eedeeGap_->Fill(pho->isEEDeeGap());
+      h_ebeeGap_->Fill(pho->isEBEEGap());
+      h_r9_->Fill(pho->r9());
 
       // Photon Variables
-      h_photonEt_->  Fill(photonEt);
-      h_photonEta_-> Fill(pho->eta());
-      h_photonPhi_-> Fill(pho->phi());
-      h_hadoverem_-> Fill(pho->hadronicOverEm());
+      h_photonEt_->Fill(photonEt);
+      h_photonEta_->Fill(pho->eta());
+      h_photonPhi_->Fill(pho->phi());
+      h_hadoverem_->Fill(pho->hadronicOverEm());
 
       // Photon's SuperCluster Variables
       // eta is with respect to detector (not physics) vertex,
       // thus Et and eta are different from photon.
-      h_photonScEt_->      Fill(superClusterEt);
-      h_photonScEta_->     Fill(pho->superCluster()->position().eta());
-      h_photonScPhi_->     Fill(pho->superCluster()->position().phi());
+      h_photonScEt_->Fill(superClusterEt);
+      h_photonScEta_->Fill(pho->superCluster()->position().eta());
+      h_photonScPhi_->Fill(pho->superCluster()->position().phi());
       h_photonScEtaWidth_->Fill(pho->superCluster()->etaWidth());
-      
+
       // It passed photon cuts, mark it
 
       ///////////////////////////////////////////////////////
       //                fill TTree (optional)              //
       ///////////////////////////////////////////////////////
-      if ( createPhotonTTree_ ) {
-	recPhoton.isolationEcalRecHit    = pho->ecalRecHitSumEtConeDR04();
-	recPhoton.isolationHcalRecHit    = pho->hcalTowerSumEtConeDR04();
-	recPhoton.isolationSolidTrkCone  = pho->trkSumPtSolidConeDR04();
-	recPhoton.isolationHollowTrkCone = pho->trkSumPtHollowConeDR04();
-	recPhoton.nTrkSolidCone          = pho->nTrkSolidConeDR04();
-	recPhoton.nTrkHollowCone         = pho->nTrkHollowConeDR04();
-	recPhoton.isEBEtaGap                = pho->isEBEtaGap();
-	recPhoton.isEBPhiGap                = pho->isEBPhiGap();
-	recPhoton.isEERingGap                = pho->isEERingGap();
-	recPhoton.isEEDeeGap                = pho->isEEDeeGap();
-	recPhoton.isEBEEGap              = pho->isEBEEGap();
-        recPhoton.r9                     = pho->r9();
-        recPhoton.et                     = pho->et();
-        recPhoton.eta                    = pho->eta();
-        recPhoton.phi                    = pho->phi();
-        recPhoton.hadronicOverEm         = pho->hadronicOverEm();
+      if (createPhotonTTree_) {
+        recPhoton.isolationEcalRecHit = pho->ecalRecHitSumEtConeDR04();
+        recPhoton.isolationHcalRecHit = pho->hcalTowerSumEtConeDR04();
+        recPhoton.isolationSolidTrkCone = pho->trkSumPtSolidConeDR04();
+        recPhoton.isolationHollowTrkCone = pho->trkSumPtHollowConeDR04();
+        recPhoton.nTrkSolidCone = pho->nTrkSolidConeDR04();
+        recPhoton.nTrkHollowCone = pho->nTrkHollowConeDR04();
+        recPhoton.isEBEtaGap = pho->isEBEtaGap();
+        recPhoton.isEBPhiGap = pho->isEBPhiGap();
+        recPhoton.isEERingGap = pho->isEERingGap();
+        recPhoton.isEEDeeGap = pho->isEEDeeGap();
+        recPhoton.isEBEEGap = pho->isEBEEGap();
+        recPhoton.r9 = pho->r9();
+        recPhoton.et = pho->et();
+        recPhoton.eta = pho->eta();
+        recPhoton.phi = pho->phi();
+        recPhoton.hadronicOverEm = pho->hadronicOverEm();
 
         // Fill the tree (this records all the recPhoton.* since
         // tree_PhotonAll_ was set to point at that.
@@ -357,7 +344,8 @@ PhotonIDSimpleAnalyzer::analyze(const edm::Event& evt, const edm::EventSetup& es
 
       // Record whether it was near any module gap.
       // Very convoluted at the moment.
-      bool inAnyGap = pho->isEBEEGap() || (pho->isEB()&&pho->isEBEtaGap()) ||(pho->isEB()&&pho->isEBPhiGap())  || (pho->isEE()&&pho->isEERingGap()) || (pho->isEE()&&pho->isEEDeeGap()) ;
+      bool inAnyGap = pho->isEBEEGap() || (pho->isEB() && pho->isEBEtaGap()) || (pho->isEB() && pho->isEBPhiGap()) ||
+                      (pho->isEE() && pho->isEERingGap()) || (pho->isEE() && pho->isEEDeeGap());
       if (inAnyGap) {
         h_photonInAnyGap_->Fill(1.0);
       } else {
@@ -365,64 +353,56 @@ PhotonIDSimpleAnalyzer::analyze(const edm::Event& evt, const edm::EventSetup& es
       }
 
       photonCounter++;
-    } 
-    else
-    {
+    } else {
       // This didn't pass photon cuts, mark it
-   
     }
     idxpho++;
-  } // End Loop over photons
+  }  // End Loop over photons
   h_nPho_->Fill(photonCounter);
- 
 }
 
 ///////////////////////////////////////////////////////////////////////
 //    method called once each job just after ending the event loop   //
 ///////////////////////////////////////////////////////////////////////
-void 
-PhotonIDSimpleAnalyzer::endJob()
-{
-
+void PhotonIDSimpleAnalyzer::endJob() {
   // go to *OUR* root file and store histograms
   rootFile_->cd();
 
   // PhotonID Histograms
   h_isoEcalRecHit_->Write();
   h_isoHcalRecHit_->Write();
-  h_trk_pt_solid_-> Write();
+  h_trk_pt_solid_->Write();
   h_trk_pt_hollow_->Write();
-  h_ntrk_solid_->   Write();
-  h_ntrk_hollow_->  Write();
-  h_ebetagap_->     Write();
-  h_ebphigap_->     Write();
-  h_eeringGap_->     Write();
-  h_eedeeGap_->     Write();
-  h_ebeeGap_->   Write();
-  h_r9_->        Write();
+  h_ntrk_solid_->Write();
+  h_ntrk_hollow_->Write();
+  h_ebetagap_->Write();
+  h_ebphigap_->Write();
+  h_eeringGap_->Write();
+  h_eedeeGap_->Write();
+  h_ebeeGap_->Write();
+  h_r9_->Write();
 
   // Photon Histograms
-  h_photonEt_->  Write();
-  h_photonEta_-> Write();
-  h_photonPhi_-> Write();
-  h_hadoverem_-> Write();
+  h_photonEt_->Write();
+  h_photonEta_->Write();
+  h_photonPhi_->Write();
+  h_hadoverem_->Write();
 
   // Photon's SuperCluster Histograms
-  h_photonScEt_->      Write();
-  h_photonScEta_->     Write();
-  h_photonScPhi_->     Write();
+  h_photonScEt_->Write();
+  h_photonScEta_->Write();
+  h_photonScPhi_->Write();
   h_photonScEtaWidth_->Write();
 
   // Composite or Other Histograms
   h_photonInAnyGap_->Write();
-  h_nPassingPho_->   Write();
-  h_nPassEM_->       Write();
-  h_nPho_->          Write();
+  h_nPassingPho_->Write();
+  h_nPassEM_->Write();
+  h_nPho_->Write();
 
   // Write the root file (really writes the TTree)
   rootFile_->Write();
   rootFile_->Close();
-
 }
 
 //define this as a plug-in

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -29,30 +29,26 @@ namespace {
   // collection. It is templated to be able to handle both reco and pat
   // photons (from AOD and miniAOD, respectively).
   template <class T>
-  bool isInFootprint(const T& footprint,
-                     const edm::Ptr<reco::Candidate>& candidate)
-  {
-      for (auto& it : footprint) {
-          if (it.key() == candidate.key())
-              return true;
-      }
-      return false;
+  bool isInFootprint(const T& footprint, const edm::Ptr<reco::Candidate>& candidate) {
+    for (auto& it : footprint) {
+      if (it.key() == candidate.key())
+        return true;
+    }
+    return false;
   }
 
   struct CachingPtrCandidate {
-    CachingPtrCandidate(const reco::Candidate* cPtr, bool isAOD) : 
-      candidate(cPtr), 
-      track(isAOD? &*static_cast<const reco::PFCandidate* >(cPtr)->trackRef() : nullptr),
-      packed(isAOD? nullptr : static_cast<const pat::PackedCandidate*>(cPtr))
-    {}
-    
+    CachingPtrCandidate(const reco::Candidate* cPtr, bool isAOD)
+        : candidate(cPtr),
+          track(isAOD ? &*static_cast<const reco::PFCandidate*>(cPtr)->trackRef() : nullptr),
+          packed(isAOD ? nullptr : static_cast<const pat::PackedCandidate*>(cPtr)) {}
+
     const reco::Candidate* candidate;
     const reco::Track* track;
     const pat::PackedCandidate* packed;
   };
 
-  void getImpactParameters(const CachingPtrCandidate& candidate, const reco::Vertex& pv, float& dxy, float& dz)
-  {
+  void getImpactParameters(const CachingPtrCandidate& candidate, const reco::Vertex& pv, float& dxy, float& dz) {
     if (candidate.track != nullptr) {
       dxy = candidate.track->dxy(pv.position());
       dz = candidate.track->dz(pv.position());
@@ -64,367 +60,358 @@ namespace {
 
   // Some helper functions that are needed to access info in
   // AOD vs miniAOD
-  reco::PFCandidate::ParticleType getCandidatePdgId(const reco::Candidate* candidate, bool isAOD)
-  {
-      if (isAOD)
-        return static_cast<const reco::PFCandidate*>(candidate)->particleId();
+  reco::PFCandidate::ParticleType getCandidatePdgId(const reco::Candidate* candidate, bool isAOD) {
+    if (isAOD)
+      return static_cast<const reco::PFCandidate*>(candidate)->particleId();
 
-      // the neutral hadrons and charged hadrons can be of pdgId types
-      // only 130 (K0L) and +-211 (pi+-) in packed candidates
-      const int pdgId = static_cast<const pat::PackedCandidate*>(candidate)->pdgId();
-      if (pdgId == 22)
-          return reco::PFCandidate::gamma;
-      else if (abs(pdgId) == 130) // PDG ID for K0L
-          return reco::PFCandidate::h0;
-      else if (abs(pdgId) == 211) // PDG ID for pi+-
-          return reco::PFCandidate::h;
-      else
-          return reco::PFCandidate::X;
+    // the neutral hadrons and charged hadrons can be of pdgId types
+    // only 130 (K0L) and +-211 (pi+-) in packed candidates
+    const int pdgId = static_cast<const pat::PackedCandidate*>(candidate)->pdgId();
+    if (pdgId == 22)
+      return reco::PFCandidate::gamma;
+    else if (abs(pdgId) == 130)  // PDG ID for K0L
+      return reco::PFCandidate::h0;
+    else if (abs(pdgId) == 211)  // PDG ID for pi+-
+      return reco::PFCandidate::h;
+    else
+      return reco::PFCandidate::X;
   }
 
-};
+};  // namespace
 
 class PhotonIDValueMapProducer : public edm::global::EDProducer<> {
-
 public:
-    explicit PhotonIDValueMapProducer(const edm::ParameterSet&);
-    ~PhotonIDValueMapProducer() override {}
+  explicit PhotonIDValueMapProducer(const edm::ParameterSet&);
+  ~PhotonIDValueMapProducer() override {}
 
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-    void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-    // This function computes charged hadron isolation with respect to multiple
-    // PVs and returns the worst of the found isolation values. The function
-    // implements the computation method taken directly from Run 1 code of
-    // H->gamma gamma, specifically from the class CiCPhotonID of the
-    // HiggsTo2photons anaysis code. Template is introduced to handle reco/pat
-    // photons and aod/miniAOD PF candidates collections
-    float computeWorstPFChargedIsolation(
-            const reco::Photon& photon,
-            const edm::View<reco::Candidate>& pfCands,
-            const reco::VertexCollection& vertices,
-            const reco::Vertex& pv,
-            unsigned char options, bool isAOD) const;
+  // This function computes charged hadron isolation with respect to multiple
+  // PVs and returns the worst of the found isolation values. The function
+  // implements the computation method taken directly from Run 1 code of
+  // H->gamma gamma, specifically from the class CiCPhotonID of the
+  // HiggsTo2photons anaysis code. Template is introduced to handle reco/pat
+  // photons and aod/miniAOD PF candidates collections
+  float computeWorstPFChargedIsolation(const reco::Photon& photon,
+                                       const edm::View<reco::Candidate>& pfCands,
+                                       const reco::VertexCollection& vertices,
+                                       const reco::Vertex& pv,
+                                       unsigned char options,
+                                       bool isAOD) const;
 
-    // check whether a non-null preshower is there
-    const bool usesES_;
+  // check whether a non-null preshower is there
+  const bool usesES_;
 
-    // Tokens
-    const edm::EDGetTokenT<edm::View<reco::Photon>>    src_;
-    const edm::EDGetTokenT<EcalRecHitCollection>       ebRecHits_;
-    const edm::EDGetTokenT<EcalRecHitCollection>       eeRecHits_;
-    const edm::EDGetTokenT<EcalRecHitCollection>       esRecHits_;
-    const edm::EDGetTokenT<reco::VertexCollection>     vtxToken_;
-    const edm::EDGetTokenT<edm::View<reco::Candidate>> pfCandsToken_;
-    const edm::EDGetToken                         particleBasedIsolationToken_;
+  // Tokens
+  const edm::EDGetTokenT<edm::View<reco::Photon>> src_;
+  const edm::EDGetTokenT<EcalRecHitCollection> ebRecHits_;
+  const edm::EDGetTokenT<EcalRecHitCollection> eeRecHits_;
+  const edm::EDGetTokenT<EcalRecHitCollection> esRecHits_;
+  const edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+  const edm::EDGetTokenT<edm::View<reco::Candidate>> pfCandsToken_;
+  const edm::EDGetToken particleBasedIsolationToken_;
 
-    const bool isAOD_;
+  const bool isAOD_;
 };
 
 constexpr int nVars_ = 19;
 
 const std::string names[nVars_] = {
     // Cluster shapes
-    "phoFull5x5SigmaIEtaIEta", // 0
+    "phoFull5x5SigmaIEtaIEta",  // 0
     "phoFull5x5SigmaIEtaIPhi",
     "phoFull5x5E1x3",
     "phoFull5x5E2x2",
     "phoFull5x5E2x5Max",
-    "phoFull5x5E5x5", // 5
+    "phoFull5x5E5x5",  // 5
     "phoESEffSigmaRR",
     // Cluster shape ratios
     "phoFull5x5E1x3byE5x5",
     "phoFull5x5E2x2byE5x5",
     "phoFull5x5E2x5byE5x5",
     // Isolations
-    "phoChargedIsolation", // 10
+    "phoChargedIsolation",  // 10
     "phoNeutralHadronIsolation",
     "phoPhotonIsolation",
     "phoWorstChargedIsolation",
     "phoWorstChargedIsolationConeVeto",
-    "phoWorstChargedIsolationConeVetoPVConstr", // 15
+    "phoWorstChargedIsolationConeVetoPVConstr",  // 15
     // PFCluster Isolation
     "phoTrkIsolation",
     "phoHcalPFClIsolation",
-    "phoEcalPFClIsolation"
-};
+    "phoEcalPFClIsolation"};
 
 // options and bitflags
-constexpr float coneSizeDR2 = 0.3*0.3;
+constexpr float coneSizeDR2 = 0.3 * 0.3;
 constexpr float dxyMax = 0.1;
 constexpr float dzMax = 0.2;
-constexpr float dRveto2Barrel = 0.02*0.02;
-constexpr float dRveto2Endcap = 0.02*0.02;
+constexpr float dRveto2Barrel = 0.02 * 0.02;
+constexpr float dRveto2Endcap = 0.02 * 0.02;
 constexpr float ptMin = 0.1;
 
-const unsigned char PV_CONSTRAINT  = 0x1;
+const unsigned char PV_CONSTRAINT = 0x1;
 const unsigned char DR_VETO = 0x2;
 const unsigned char PT_MIN_THRESH = 0x8;
 
 PhotonIDValueMapProducer::PhotonIDValueMapProducer(const edm::ParameterSet& cfg)
-    : usesES_(!cfg.getParameter<edm::InputTag>("esReducedRecHitCollection").label().empty())
-    , src_(consumes<edm::View<reco::Photon>>(cfg.getParameter<edm::InputTag>("src")))
-    , ebRecHits_(consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("ebReducedRecHitCollection")))
-    , eeRecHits_(consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("eeReducedRecHitCollection")))
-    , esRecHits_(consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("esReducedRecHitCollection")))
-    , vtxToken_(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices")))
-    , pfCandsToken_(consumes<edm::View<reco::Candidate>>(cfg.getParameter<edm::InputTag>("pfCandidates")))
-    , particleBasedIsolationToken_(mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
-          cfg.getParameter<edm::InputTag>("particleBasedIsolation")) /* ...only for AOD... */ )
-    , isAOD_(cfg.getParameter<bool>("isAOD"))
-{
-    // Declare producibles
-    for (int i = 0; i < nVars_; ++i)
-        produces<edm::ValueMap<float>>(names[i]);
+    : usesES_(!cfg.getParameter<edm::InputTag>("esReducedRecHitCollection").label().empty()),
+      src_(consumes<edm::View<reco::Photon>>(cfg.getParameter<edm::InputTag>("src"))),
+      ebRecHits_(consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("ebReducedRecHitCollection"))),
+      eeRecHits_(consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("eeReducedRecHitCollection"))),
+      esRecHits_(consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("esReducedRecHitCollection"))),
+      vtxToken_(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
+      pfCandsToken_(consumes<edm::View<reco::Candidate>>(cfg.getParameter<edm::InputTag>("pfCandidates"))),
+      particleBasedIsolationToken_(mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
+          cfg.getParameter<edm::InputTag>("particleBasedIsolation")) /* ...only for AOD... */),
+      isAOD_(cfg.getParameter<bool>("isAOD")) {
+  // Declare producibles
+  for (int i = 0; i < nVars_; ++i)
+    produces<edm::ValueMap<float>>(names[i]);
 }
 
-void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-    // Get the handles
-    auto src           = iEvent.getHandle(src_);
-    auto vertices      = iEvent.getHandle(vtxToken_);
-    auto pfCandsHandle = iEvent.getHandle(pfCandsToken_);
+void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  // Get the handles
+  auto src = iEvent.getHandle(src_);
+  auto vertices = iEvent.getHandle(vtxToken_);
+  auto pfCandsHandle = iEvent.getHandle(pfCandsToken_);
 
-    edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> particleBasedIsolationMap;
-    if (isAOD_) { // this exists only in AOD
-        iEvent.getByToken(particleBasedIsolationToken_, particleBasedIsolationMap);
-    } else if (!src->empty()) {
-        edm::Ptr<pat::Photon> test(src->ptrAt(0));
-        if (test.isNull() || !test.isAvailable()) {
-            throw cms::Exception("InvalidConfiguration")
-                << "DataFormat is detected as miniAOD but cannot cast to pat::Photon!";
-        }
+  edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> particleBasedIsolationMap;
+  if (isAOD_) {  // this exists only in AOD
+    iEvent.getByToken(particleBasedIsolationToken_, particleBasedIsolationMap);
+  } else if (!src->empty()) {
+    edm::Ptr<pat::Photon> test(src->ptrAt(0));
+    if (test.isNull() || !test.isAvailable()) {
+      throw cms::Exception("InvalidConfiguration")
+          << "DataFormat is detected as miniAOD but cannot cast to pat::Photon!";
+    }
+  }
+
+  // Configure Lazy Tools, which will compute 5x5 quantities
+  auto lazyToolnoZS = usesES_ ? noZS::EcalClusterLazyTools(iEvent, iSetup, ebRecHits_, eeRecHits_, esRecHits_)
+                              : noZS::EcalClusterLazyTools(iEvent, iSetup, ebRecHits_, eeRecHits_);
+
+  // Get PV
+  if (vertices->empty())
+    return;  // skip the event if no PV found
+  const reco::Vertex& pv = vertices->front();
+
+  std::vector<float> vars[nVars_];
+
+  // reco::Photon::superCluster() is virtual so we can exploit polymorphism
+  for (auto const& iPho : src->ptrs()) {
+    //
+    // Compute full 5x5 quantities
+    //
+    const auto& seed = *(iPho->superCluster()->seed());
+
+    // For full5x5_sigmaIetaIeta, for 720 we use: lazy tools for AOD,
+    // and userFloats or lazy tools for miniAOD. From some point in 72X and on, one can
+    // retrieve the full5x5 directly from the object with ->full5x5_sigmaIetaIeta()
+    // for both formats.
+    std::vector<float> vCov = lazyToolnoZS.localCovariances(seed);
+    vars[0].push_back(edm::isNotFinite(vCov[0]) ? 0. : sqrt(vCov[0]));
+    vars[1].push_back(vCov[1]);
+    vars[2].push_back(lazyToolnoZS.e1x3(seed));
+    vars[3].push_back(lazyToolnoZS.e2x2(seed));
+    vars[4].push_back(lazyToolnoZS.e2x5Max(seed));
+    vars[5].push_back(lazyToolnoZS.e5x5(seed));
+    vars[6].push_back(lazyToolnoZS.eseffsirir(*(iPho->superCluster())));
+    vars[7].push_back(vars[2].back() / vars[5].back());
+    vars[8].push_back(vars[3].back() / vars[5].back());
+    vars[9].push_back(vars[4].back() / vars[5].back());
+
+    //
+    // Compute absolute uncorrected isolations with footprint removal
+    //
+
+    // First, find photon direction with respect to the good PV
+    math::XYZVector phoWrtVtx(
+        iPho->superCluster()->x() - pv.x(), iPho->superCluster()->y() - pv.y(), iPho->superCluster()->z() - pv.z());
+
+    // isolation sums
+    float chargedIsoSum = 0.;
+    float neutralHadronIsoSum = 0.;
+    float photonIsoSum = 0.;
+
+    // Loop over all PF candidates
+    for (auto const& iCand : pfCandsHandle->ptrs()) {
+      // Here, the type will be a simple reco::Candidate. We cast it
+      // for full PFCandidate or PackedCandidate below as necessary
+
+      // One would think that we should check that this iCand from the
+      // generic PF collection is not identical to the iPho photon for
+      // which we are computing the isolations. However, it turns out to
+      // be unnecessary. Below, in the function isInFootprint(), we drop
+      // this iCand if it is in the footprint, and this always removes
+      // the iCand if it matches the iPho. The explicit check at this
+      // point is not totally trivial because of non-triviality of
+      // implementation of this check for miniAOD (PackedCandidates of
+      // the PF collection do not contain the supercluser link, so can't
+      // use that).
+      //
+      // if( isAOD_ ) {
+      //     if( ((const edm::Ptr<reco::PFCandidate>)iCand)->superClusterRef() == iPho->superCluster() )
+      //     continue;
+      // }
+
+      // Check if this candidate is within the isolation cone
+      float dR2 = deltaR2(phoWrtVtx.Eta(), phoWrtVtx.Phi(), iCand->eta(), iCand->phi());
+      if (dR2 > coneSizeDR2)
+        continue;
+
+      // Check if this candidate is not in the footprint
+      if (isAOD_) {
+        if (isInFootprint((*particleBasedIsolationMap)[iPho], iCand))
+          continue;
+      } else {
+        edm::Ptr<pat::Photon> patPhotonPtr(iPho);
+        if (isInFootprint(patPhotonPtr->associatedPackedPFCandidates(), iCand))
+          continue;
+      }
+
+      // Find candidate type
+      reco::PFCandidate::ParticleType thisCandidateType = getCandidatePdgId(&*iCand, isAOD_);
+
+      // Increment the appropriate isolation sum
+      if (thisCandidateType == reco::PFCandidate::h) {
+        // for charged hadrons, additionally check consistency
+        // with the PV
+        float dxy = -999;
+        float dz = -999;
+
+        getImpactParameters(CachingPtrCandidate(&*iCand, isAOD_), pv, dxy, dz);
+
+        if (fabs(dxy) > dxyMax || fabs(dz) > dzMax)
+          continue;
+
+        // The candidate is eligible, increment the isolaiton
+        chargedIsoSum += iCand->pt();
+      }
+
+      if (thisCandidateType == reco::PFCandidate::h0)
+        neutralHadronIsoSum += iCand->pt();
+
+      if (thisCandidateType == reco::PFCandidate::gamma)
+        photonIsoSum += iCand->pt();
     }
 
-    // Configure Lazy Tools, which will compute 5x5 quantities
-    auto lazyToolnoZS = usesES_ ? noZS::EcalClusterLazyTools(iEvent, iSetup, ebRecHits_, eeRecHits_, esRecHits_)
-                                : noZS::EcalClusterLazyTools(iEvent, iSetup, ebRecHits_, eeRecHits_);
+    vars[10].push_back(chargedIsoSum);
+    vars[11].push_back(neutralHadronIsoSum);
+    vars[12].push_back(photonIsoSum);
 
-    // Get PV
-    if (vertices->empty())
-        return; // skip the event if no PV found
-    const reco::Vertex& pv = vertices->front();
+    // Worst isolation computed with no vetos or ptMin cut, as in Run 1 Hgg code.
+    unsigned char options = 0;
+    vars[13].push_back(computeWorstPFChargedIsolation(*iPho, *pfCandsHandle, *vertices, pv, options, isAOD_));
 
-    std::vector<float> vars[nVars_];
+    // Worst isolation computed with cone vetos and a ptMin cut, as in Run 2 Hgg code.
+    options |= PT_MIN_THRESH | DR_VETO;
+    vars[14].push_back(computeWorstPFChargedIsolation(*iPho, *pfCandsHandle, *vertices, pv, options, isAOD_));
 
-    // reco::Photon::superCluster() is virtual so we can exploit polymorphism
-    for(auto const& iPho : src->ptrs())
-    {
-        //
-        // Compute full 5x5 quantities
-        //
-        const auto& seed = *(iPho->superCluster()->seed());
+    // Like before, but adding primary vertex constraint
+    options |= PV_CONSTRAINT;
+    vars[15].push_back(computeWorstPFChargedIsolation(*iPho, *pfCandsHandle, *vertices, pv, options, isAOD_));
 
-        // For full5x5_sigmaIetaIeta, for 720 we use: lazy tools for AOD,
-        // and userFloats or lazy tools for miniAOD. From some point in 72X and on, one can
-        // retrieve the full5x5 directly from the object with ->full5x5_sigmaIetaIeta()
-        // for both formats.
-        std::vector<float> vCov = lazyToolnoZS.localCovariances(seed);
-        vars[0].push_back(edm::isNotFinite(vCov[0]) ? 0. : sqrt(vCov[0]));
-        vars[1].push_back(vCov[1]);
-        vars[2].push_back(lazyToolnoZS.e1x3(seed));
-        vars[3].push_back(lazyToolnoZS.e2x2(seed));
-        vars[4].push_back(lazyToolnoZS.e2x5Max(seed));
-        vars[5].push_back(lazyToolnoZS.e5x5(seed));
-        vars[6].push_back(lazyToolnoZS.eseffsirir(*(iPho->superCluster())));
-        vars[7].push_back(vars[2].back() / vars[5].back());
-        vars[8].push_back(vars[3].back() / vars[5].back());
-        vars[9].push_back(vars[4].back() / vars[5].back());
-
-        //
-        // Compute absolute uncorrected isolations with footprint removal
-        //
-
-        // First, find photon direction with respect to the good PV
-        math::XYZVector phoWrtVtx(
-            iPho->superCluster()->x() - pv.x(), iPho->superCluster()->y() - pv.y(), iPho->superCluster()->z() - pv.z());
-
-        // isolation sums
-        float chargedIsoSum = 0.;
-        float neutralHadronIsoSum = 0.;
-        float photonIsoSum = 0.;
-
-        // Loop over all PF candidates
-        for(auto const& iCand : pfCandsHandle->ptrs())
-        {
-            // Here, the type will be a simple reco::Candidate. We cast it
-            // for full PFCandidate or PackedCandidate below as necessary
-
-            // One would think that we should check that this iCand from the
-            // generic PF collection is not identical to the iPho photon for
-            // which we are computing the isolations. However, it turns out to
-            // be unnecessary. Below, in the function isInFootprint(), we drop
-            // this iCand if it is in the footprint, and this always removes
-            // the iCand if it matches the iPho. The explicit check at this
-            // point is not totally trivial because of non-triviality of
-            // implementation of this check for miniAOD (PackedCandidates of
-            // the PF collection do not contain the supercluser link, so can't
-            // use that).
-            //
-            // if( isAOD_ ) {
-            //     if( ((const edm::Ptr<reco::PFCandidate>)iCand)->superClusterRef() == iPho->superCluster() )
-            //     continue;
-            // }
-
-            // Check if this candidate is within the isolation cone
-            float dR2 = deltaR2(phoWrtVtx.Eta(), phoWrtVtx.Phi(), iCand->eta(), iCand->phi());
-            if (dR2 > coneSizeDR2)
-                continue;
-
-            // Check if this candidate is not in the footprint
-            if (isAOD_) {
-                if(isInFootprint((*particleBasedIsolationMap)[iPho], iCand))
-                    continue;
-            } else {
-                edm::Ptr<pat::Photon> patPhotonPtr(iPho);
-                if(isInFootprint(patPhotonPtr->associatedPackedPFCandidates(), iCand))
-                    continue;
-            }
-
-            // Find candidate type
-            reco::PFCandidate::ParticleType thisCandidateType = getCandidatePdgId(&*iCand, isAOD_);
-
-            // Increment the appropriate isolation sum
-            if (thisCandidateType == reco::PFCandidate::h) {
-                // for charged hadrons, additionally check consistency
-                // with the PV
-                float dxy = -999;
-                float dz = -999;
-
-                getImpactParameters(CachingPtrCandidate(&*iCand, isAOD_), pv, dxy, dz);
-
-                if (fabs(dxy) > dxyMax || fabs(dz) > dzMax)
-                    continue;
-
-                // The candidate is eligible, increment the isolaiton
-                chargedIsoSum += iCand->pt();
-            }
-
-            if (thisCandidateType == reco::PFCandidate::h0)
-                neutralHadronIsoSum += iCand->pt();
-
-            if (thisCandidateType == reco::PFCandidate::gamma)
-                photonIsoSum += iCand->pt();
-        }
-
-        vars[10].push_back(chargedIsoSum);
-        vars[11].push_back(neutralHadronIsoSum);
-        vars[12].push_back(photonIsoSum);
-
-        // Worst isolation computed with no vetos or ptMin cut, as in Run 1 Hgg code.
-        unsigned char options = 0;
-        vars[13].push_back(computeWorstPFChargedIsolation(*iPho, *pfCandsHandle, *vertices, pv, options, isAOD_));
-
-        // Worst isolation computed with cone vetos and a ptMin cut, as in Run 2 Hgg code.
-        options |= PT_MIN_THRESH | DR_VETO;
-        vars[14].push_back(computeWorstPFChargedIsolation(*iPho, *pfCandsHandle, *vertices, pv, options, isAOD_));
-
-        // Like before, but adding primary vertex constraint
-        options |= PV_CONSTRAINT;
-        vars[15].push_back(computeWorstPFChargedIsolation(*iPho, *pfCandsHandle, *vertices, pv, options, isAOD_));
-
-        // PFCluster Isolations
-        vars[16].push_back(iPho->trkSumPtSolidConeDR04());
-        if (isAOD_) {
-            vars[17].push_back(0.f);
-            vars[18].push_back(0.f);
-        } else {
-            edm::Ptr<pat::Photon> patPhotonPtr{ iPho };
-            vars[17].push_back(patPhotonPtr->hcalPFClusterIso());
-            vars[18].push_back(patPhotonPtr->ecalPFClusterIso());
-        }
+    // PFCluster Isolations
+    vars[16].push_back(iPho->trkSumPtSolidConeDR04());
+    if (isAOD_) {
+      vars[17].push_back(0.f);
+      vars[18].push_back(0.f);
+    } else {
+      edm::Ptr<pat::Photon> patPhotonPtr{iPho};
+      vars[17].push_back(patPhotonPtr->hcalPFClusterIso());
+      vars[18].push_back(patPhotonPtr->ecalPFClusterIso());
     }
+  }
 
-    // write the value maps
-    for (int i = 0; i < nVars_; ++i) {
-        auto valMap = std::make_unique<edm::ValueMap<float>>();
-        typename edm::ValueMap<float>::Filler filler(*valMap);
-        filler.insert(src, vars[i].begin(), vars[i].end());
-        filler.fill();
-        iEvent.put(std::move(valMap),names[i]);
-    }
+  // write the value maps
+  for (int i = 0; i < nVars_; ++i) {
+    auto valMap = std::make_unique<edm::ValueMap<float>>();
+    typename edm::ValueMap<float>::Filler filler(*valMap);
+    filler.insert(src, vars[i].begin(), vars[i].end());
+    filler.fill();
+    iEvent.put(std::move(valMap), names[i]);
+  }
 }
 
 void PhotonIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // photonIDValueMapProducer
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("particleBasedIsolation",    edm::InputTag("particleBasedIsolation","gedPhotons"));
-  desc.add<edm::InputTag>("src",                       edm::InputTag("slimmedPhotons","","@skipCurrentProcess"));
-  desc.add<edm::InputTag>("esReducedRecHitCollection", edm::InputTag("reducedEgamma","reducedESRecHits"));
-  desc.add<edm::InputTag>("ebReducedRecHitCollection", edm::InputTag("reducedEgamma","reducedEBRecHits"));
-  desc.add<edm::InputTag>("eeReducedRecHitCollection", edm::InputTag("reducedEgamma","reducedEERecHits"));
-  desc.add<edm::InputTag>("pfCandidates",              edm::InputTag("packedPFCandidates"));
-  desc.add<edm::InputTag>("vertices",                  edm::InputTag("offlineSlimmedPrimaryVertices"));
+  desc.add<edm::InputTag>("particleBasedIsolation", edm::InputTag("particleBasedIsolation", "gedPhotons"));
+  desc.add<edm::InputTag>("src", edm::InputTag("slimmedPhotons", "", "@skipCurrentProcess"));
+  desc.add<edm::InputTag>("esReducedRecHitCollection", edm::InputTag("reducedEgamma", "reducedESRecHits"));
+  desc.add<edm::InputTag>("ebReducedRecHitCollection", edm::InputTag("reducedEgamma", "reducedEBRecHits"));
+  desc.add<edm::InputTag>("eeReducedRecHitCollection", edm::InputTag("reducedEgamma", "reducedEERecHits"));
+  desc.add<edm::InputTag>("pfCandidates", edm::InputTag("packedPFCandidates"));
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
   desc.add<bool>("isAOD", false);
   descriptions.add("photonIDValueMapProducer", desc);
 }
 
-
 // Charged isolation with respect to the worst vertex. See more
 // comments above at the function declaration.
-float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photon& photon, const edm::View<reco::Candidate>& pfCands,
-    const reco::VertexCollection& vertices, const reco::Vertex& pv, unsigned char options, bool isAOD) const
-{
-    float worstIsolation = 0.0;
+float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photon& photon,
+                                                               const edm::View<reco::Candidate>& pfCands,
+                                                               const reco::VertexCollection& vertices,
+                                                               const reco::Vertex& pv,
+                                                               unsigned char options,
+                                                               bool isAOD) const {
+  float worstIsolation = 0.0;
 
-    const float dRveto2 = photon.isEB() ? dRveto2Barrel : dRveto2Endcap;
+  const float dRveto2 = photon.isEB() ? dRveto2Barrel : dRveto2Endcap;
 
-    std::vector<CachingPtrCandidate> chargedCands;
-    chargedCands.reserve(pfCands.size());
-    for (auto const& aCand : pfCands){
-      
-      // require that PFCandidate is a charged hadron
-      reco::PFCandidate::ParticleType thisCandidateType = getCandidatePdgId(&aCand, isAOD);
-      if (thisCandidateType != reco::PFCandidate::h)
+  std::vector<CachingPtrCandidate> chargedCands;
+  chargedCands.reserve(pfCands.size());
+  for (auto const& aCand : pfCands) {
+    // require that PFCandidate is a charged hadron
+    reco::PFCandidate::ParticleType thisCandidateType = getCandidatePdgId(&aCand, isAOD);
+    if (thisCandidateType != reco::PFCandidate::h)
+      continue;
+
+    if ((options & PT_MIN_THRESH) && aCand.pt() < ptMin)
+      continue;
+
+    chargedCands.emplace_back(&aCand, isAOD);
+  }
+
+  // Calculate isolation sum separately for each vertex
+  for (unsigned int ivtx = 0; ivtx < vertices.size(); ++ivtx) {
+    // Shift the photon according to the vertex
+    const reco::VertexRef vtx(&vertices, ivtx);
+    math::XYZVector phoWrtVtx(photon.superCluster()->x() - vtx->x(),
+                              photon.superCluster()->y() - vtx->y(),
+                              photon.superCluster()->z() - vtx->z());
+
+    const float phoWrtVtxPhi = phoWrtVtx.phi();
+    const float phoWrtVtxEta = phoWrtVtx.eta();
+
+    float sum = 0;
+    // Loop over the PFCandidates
+    for (auto const& aCCand : chargedCands) {
+      auto iCand = aCCand.candidate;
+      float dR2 = deltaR2(phoWrtVtxEta, phoWrtVtxPhi, iCand->eta(), iCand->phi());
+      if (dR2 > coneSizeDR2 || (options & DR_VETO && dR2 < dRveto2))
         continue;
-      
-      if ((options & PT_MIN_THRESH) && aCand.pt() < ptMin)
+
+      float dxy = -999;
+      float dz = -999;
+      if (options & PV_CONSTRAINT)
+        getImpactParameters(aCCand, pv, dxy, dz);
+      else
+        getImpactParameters(aCCand, *vtx, dxy, dz);
+
+      if (fabs(dxy) > dxyMax || fabs(dz) > dzMax)
         continue;
 
-      chargedCands.emplace_back(&aCand, isAOD);
+      sum += iCand->pt();
     }
 
-    // Calculate isolation sum separately for each vertex
-    for (unsigned int ivtx = 0; ivtx < vertices.size(); ++ivtx) {
+    worstIsolation = std::max(sum, worstIsolation);
+  }
 
-        // Shift the photon according to the vertex
-        const reco::VertexRef vtx(&vertices, ivtx);
-        math::XYZVector phoWrtVtx(photon.superCluster()->x() - vtx->x(),
-            photon.superCluster()->y() - vtx->y(), photon.superCluster()->z() - vtx->z());
-
-	const float phoWrtVtxPhi = phoWrtVtx.phi();
-	const float phoWrtVtxEta = phoWrtVtx.eta();
-
-        float sum = 0;
-        // Loop over the PFCandidates
-        for (auto const& aCCand : chargedCands) {
-
-            auto iCand = aCCand.candidate;
-            float dR2 = deltaR2(phoWrtVtxEta, phoWrtVtxPhi, iCand->eta(), iCand->phi());
-            if (dR2 > coneSizeDR2  ||
-                    (options & DR_VETO && dR2 < dRveto2))
-                continue;
-
-	    float dxy = -999;
-            float dz = -999;
-            if (options & PV_CONSTRAINT)
-                getImpactParameters(aCCand, pv, dxy, dz);
-            else
-                getImpactParameters(aCCand, *vtx, dxy, dz);
-
-            if (fabs(dxy) > dxyMax || fabs(dz) > dzMax)
-                continue;
-
-
-            sum += iCand->pt();
-        }
-
-        worstIsolation = std::max(sum, worstIsolation);
-    }
-
-    return worstIsolation;
+  return worstIsolation;
 }
 
 DEFINE_FWK_MODULE(PhotonIDValueMapProducer);

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimator.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimator.cc
@@ -10,32 +10,29 @@
 #include "RecoEgamma/EgammaTools/interface/MVAVariableManager.h"
 #include "RecoEgamma/EgammaTools/interface/ThreadSafeStringCut.h"
 
-class PhotonMVAEstimator : public AnyMVAEstimatorRun2Base{
-  
- public:
-
+class PhotonMVAEstimator : public AnyMVAEstimatorRun2Base {
+public:
   // Constructor and destructor
   PhotonMVAEstimator(const edm::ParameterSet& conf);
-  ~PhotonMVAEstimator() override {};
+  ~PhotonMVAEstimator() override{};
 
   // Calculation of the MVA value
-  float mvaValue( const reco::Candidate* candPtr, std::vector<float> const& auxVars, int &iCategory) const override;
-  
-  int findCategory( const reco::Candidate* candPtr) const override;
+  float mvaValue(const reco::Candidate* candPtr, std::vector<float> const& auxVars, int& iCategory) const override;
+
+  int findCategory(const reco::Candidate* candPtr) const override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
-
+private:
   int findCategory(reco::Photon const& photon) const;
 
   // The number of categories and number of variables per category
   int nCategories_;
-  std::vector<ThreadSafeStringCut<StringCutObjectSelector<reco::Photon>,reco::Photon>> categoryFunctions_;
+  std::vector<ThreadSafeStringCut<StringCutObjectSelector<reco::Photon>, reco::Photon>> categoryFunctions_;
   std::vector<int> nVariables_;
 
   // Data members
-  std::vector< std::unique_ptr<const GBRForest> > gbrForests_;
+  std::vector<std::unique_ptr<const GBRForest>> gbrForests_;
 
   // There might be different variables for each category, so the variables
   // names vector is itself a vector of length nCategories
@@ -48,41 +45,38 @@ class PhotonMVAEstimator : public AnyMVAEstimatorRun2Base{
   std::unique_ptr<EffectiveAreas> effectiveAreas_;
   std::vector<double> phoIsoPtScalingCoeff_;
   double phoIsoCutoff_;
-
 };
 
 PhotonMVAEstimator::PhotonMVAEstimator(const edm::ParameterSet& conf)
-  : AnyMVAEstimatorRun2Base(conf)
-  , mvaVarMngr_ (conf.getParameter<std::string>("variableDefinition"))
-{
-
+    : AnyMVAEstimatorRun2Base(conf), mvaVarMngr_(conf.getParameter<std::string>("variableDefinition")) {
   //
   // Construct the MVA estimators
   //
   if (getTag() == "Run2Spring16NonTrigV1") {
-      effectiveAreas_ = std::make_unique<EffectiveAreas>((conf.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath());
-      phoIsoPtScalingCoeff_ = conf.getParameter<std::vector<double >>("phoIsoPtScalingCoeff");
-      phoIsoCutoff_ = conf.getParameter<double>("phoIsoCutoff");
+    effectiveAreas_ =
+        std::make_unique<EffectiveAreas>((conf.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath());
+    phoIsoPtScalingCoeff_ = conf.getParameter<std::vector<double>>("phoIsoPtScalingCoeff");
+    phoIsoCutoff_ = conf.getParameter<double>("phoIsoCutoff");
   }
 
-  const auto weightFileNames = conf.getParameter<std::vector<std::string> >("weightFileNames");
-  const auto categoryCutStrings = conf.getParameter<std::vector<std::string> >("categoryCuts");
+  const auto weightFileNames = conf.getParameter<std::vector<std::string>>("weightFileNames");
+  const auto categoryCutStrings = conf.getParameter<std::vector<std::string>>("categoryCuts");
 
-  if( (int)(categoryCutStrings.size()) != getNCategories() )
+  if ((int)(categoryCutStrings.size()) != getNCategories())
     throw cms::Exception("MVA config failure: ")
-      << "wrong number of category cuts in PhotonMVAEstimator" << getTag() << std::endl;
+        << "wrong number of category cuts in PhotonMVAEstimator" << getTag() << std::endl;
 
-  for (auto const& cut : categoryCutStrings) categoryFunctions_.emplace_back(cut);
+  for (auto const& cut : categoryCutStrings)
+    categoryFunctions_.emplace_back(cut);
 
   // Initialize GBRForests
-  if( static_cast<int>(weightFileNames.size()) != getNCategories() )
+  if (static_cast<int>(weightFileNames.size()) != getNCategories())
     throw cms::Exception("MVA config failure: ")
-      << "wrong number of weightfiles in PhotonMVAEstimator" << getTag() << std::endl;
+        << "wrong number of weightfiles in PhotonMVAEstimator" << getTag() << std::endl;
 
   gbrForests_.clear();
   // Create a TMVA reader object for each category
-  for(int i=0; i<getNCategories(); i++){
-
+  for (int i = 0; i < getNCategories(); i++) {
     std::vector<int> variablesInCategory;
 
     std::vector<std::string> variableNamesInCategory;
@@ -92,91 +86,83 @@ PhotonMVAEstimator::PhotonMVAEstimator(const edm::ParameterSet& conf)
 
     variables_.push_back(variablesInCategory);
 
-    for (int j=0; j<nVariables_[i];++j) {
-        int index = mvaVarMngr_.getVarIndex(variableNamesInCategory[j]);
-        if(index == -1) {
-            throw cms::Exception("MVA config failure: ")
-               << "Concerning PhotonMVAEstimator" << getTag() << std::endl
-               << "Variable " << variableNamesInCategory[j]
-               << " not found in variable definition file!" << std::endl;
-        }
-        variables_[i].push_back(index);
-
+    for (int j = 0; j < nVariables_[i]; ++j) {
+      int index = mvaVarMngr_.getVarIndex(variableNamesInCategory[j]);
+      if (index == -1) {
+        throw cms::Exception("MVA config failure: ")
+            << "Concerning PhotonMVAEstimator" << getTag() << std::endl
+            << "Variable " << variableNamesInCategory[j] << " not found in variable definition file!" << std::endl;
+      }
+      variables_[i].push_back(index);
     }
   }
 }
 
-float PhotonMVAEstimator::
-mvaValue(const reco::Candidate* candPtr, std::vector<float> const& auxVars, int &iCategory) const {
-
+float PhotonMVAEstimator::mvaValue(const reco::Candidate* candPtr,
+                                   std::vector<float> const& auxVars,
+                                   int& iCategory) const {
   const reco::Photon* phoPtr = dynamic_cast<const reco::Photon*>(candPtr);
-  if( phoPtr == nullptr) {
+  if (phoPtr == nullptr) {
     throw cms::Exception("MVA failure: ")
-      << " given particle is expected to be reco::Photon or pat::Photon," << std::endl
-      << " but appears to be neither" << std::endl;
+        << " given particle is expected to be reco::Photon or pat::Photon," << std::endl
+        << " but appears to be neither" << std::endl;
   }
 
-  iCategory = findCategory( phoPtr );
+  iCategory = findCategory(phoPtr);
 
   std::vector<float> vars;
 
   for (int i = 0; i < nVariables_[iCategory]; ++i) {
-      vars.push_back(mvaVarMngr_.getValue(variables_[iCategory][i], *phoPtr, auxVars));
+    vars.push_back(mvaVarMngr_.getValue(variables_[iCategory][i], *phoPtr, auxVars));
   }
 
   // Special case for Spring16!
-  if (getTag() == "Run2Spring16NonTrigV1" and iCategory == 1) { // Endcap category
-      // Raw value for EB only, because of loss of transparency in EE
-      // for endcap MVA only in 2016
-      double eA = effectiveAreas_->getEffectiveArea( std::abs(phoPtr->superCluster()->eta()) );
-      double phoIsoCorr = vars[10] - eA*(double)vars[9] - phoIsoPtScalingCoeff_.at(1) * phoPtr->pt();
-      vars[10] = TMath::Max( phoIsoCorr, phoIsoCutoff_);
+  if (getTag() == "Run2Spring16NonTrigV1" and iCategory == 1) {  // Endcap category
+    // Raw value for EB only, because of loss of transparency in EE
+    // for endcap MVA only in 2016
+    double eA = effectiveAreas_->getEffectiveArea(std::abs(phoPtr->superCluster()->eta()));
+    double phoIsoCorr = vars[10] - eA * (double)vars[9] - phoIsoPtScalingCoeff_.at(1) * phoPtr->pt();
+    vars[10] = TMath::Max(phoIsoCorr, phoIsoCutoff_);
   }
 
-  if(isDebug()) {
+  if (isDebug()) {
     std::cout << " *** Inside PhotonMVAEstimator" << getTag() << std::endl;
     std::cout << " category " << iCategory << std::endl;
     for (int i = 0; i < nVariables_[iCategory]; ++i) {
-        std::cout << " " << mvaVarMngr_.getName(variables_[iCategory][i]) << " " << vars[i] << std::endl;
+      std::cout << " " << mvaVarMngr_.getName(variables_[iCategory][i]) << " " << vars[i] << std::endl;
     }
   }
 
   const float response = gbrForests_.at(iCategory)->GetResponse(vars.data());
 
-  if(isDebug()) {
+  if (isDebug()) {
     std::cout << " ### MVA " << response << std::endl << std::endl;
   }
 
   return response;
 }
 
-int PhotonMVAEstimator::findCategory( const reco::Candidate* candPtr) const {
-
+int PhotonMVAEstimator::findCategory(const reco::Candidate* candPtr) const {
   const reco::Photon* phoPtr = dynamic_cast<const reco::Photon*>(candPtr);
-  if( phoPtr == nullptr ) {
+  if (phoPtr == nullptr) {
     throw cms::Exception("MVA failure: ")
-      << " given particle is expected to be reco::Photon or pat::Photon," << std::endl
-      << " but appears to be neither" << std::endl;
+        << " given particle is expected to be reco::Photon or pat::Photon," << std::endl
+        << " but appears to be neither" << std::endl;
   }
 
   return findCategory(*phoPtr);
-
 }
 
 int PhotonMVAEstimator::findCategory(reco::Photon const& photon) const {
-
   for (int i = 0; i < getNCategories(); ++i) {
-      if (categoryFunctions_[i](photon)) return i;
+    if (categoryFunctions_[i](photon))
+      return i;
   }
 
-  edm::LogWarning  ("MVA warning") <<
-      "category not defined for particle with pt " << photon.pt() << " GeV, eta " <<
-          photon.superCluster()->eta() << " in PhotonMVAEstimator" << getTag();
+  edm::LogWarning("MVA warning") << "category not defined for particle with pt " << photon.pt() << " GeV, eta "
+                                 << photon.superCluster()->eta() << " in PhotonMVAEstimator" << getTag();
 
   return -1;
-
 }
 
-DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,
-          PhotonMVAEstimator,
-          "PhotonMVAEstimator");
+DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory, PhotonMVAEstimator, "PhotonMVAEstimator");

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -42,81 +41,79 @@
 // class declaration
 //
 
-class PhotonMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
+class PhotonMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit PhotonMVANtuplizer(const edm::ParameterSet&);
 
-   public:
-      explicit PhotonMVANtuplizer(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
+  // ----------member data ---------------------------
 
-   private:
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
+  // other
+  TTree* tree_;
 
-      // ----------member data ---------------------------
+  // global variables
+  int nEvent_, nRun_, nLumi_;
+  int genNpu_;
+  int vtxN_;
 
-      // other
-      TTree* tree_;
+  // photon variables
+  double pT_, eta_;
+  std::vector<float> energyMatrix_;
 
-      // global variables
-      int nEvent_, nRun_, nLumi_;
-      int genNpu_;
-      int vtxN_;
+  // photon genMatch variable
+  int matchedToGenPh_;
+  int matchedGenIdx_;
 
-      // photon variables
-      double pT_, eta_;
-      std::vector<float> energyMatrix_;
+  // ID decisions objects
+  const std::vector<std::string> phoMapTags_;
+  std::vector<edm::EDGetTokenT<edm::ValueMap<bool>>> phoMapTokens_;
+  const std::vector<std::string> phoMapBranchNames_;
+  const size_t nPhoMaps_;
 
-      // photon genMatch variable
-      int matchedToGenPh_;
-      int matchedGenIdx_;
+  // MVA values and categories (optional)
+  const std::vector<std::string> valMapTags_;
+  std::vector<edm::EDGetTokenT<edm::ValueMap<float>>> valMapTokens_;
+  const std::vector<std::string> valMapBranchNames_;
+  const size_t nValMaps_;
 
-      // ID decisions objects
-      const std::vector< std::string > phoMapTags_;
-      std::vector< edm::EDGetTokenT< edm::ValueMap<bool> > > phoMapTokens_;
-      const std::vector< std::string > phoMapBranchNames_;
-      const size_t nPhoMaps_;
+  const std::vector<std::string> mvaCatTags_;
+  std::vector<edm::EDGetTokenT<edm::ValueMap<int>>> mvaCatTokens_;
+  const std::vector<std::string> mvaCatBranchNames_;
+  const size_t nCats_;
 
-      // MVA values and categories (optional)
-      const std::vector< std::string > valMapTags_;
-      std::vector< edm::EDGetTokenT<edm::ValueMap<float> > > valMapTokens_;
-      const std::vector< std::string > valMapBranchNames_;
-      const size_t nValMaps_;
+  // config
+  const bool isMC_;
+  const double ptThreshold_;
+  const double deltaR_;
 
-      const std::vector< std::string > mvaCatTags_;
-      std::vector< edm::EDGetTokenT<edm::ValueMap<int> > > mvaCatTokens_;
-      const std::vector< std::string > mvaCatBranchNames_;
-      const size_t nCats_;
+  // Tokens
+  const edm::EDGetTokenT<edm::View<reco::Photon>> src_;
+  const edm::EDGetTokenT<std::vector<reco::Vertex>> vertices_;
+  const edm::EDGetTokenT<std::vector<PileupSummaryInfo>> pileup_;
+  const edm::EDGetTokenT<edm::View<reco::GenParticle>> genParticles_;
+  const edm::EDGetTokenT<EcalRecHitCollection> ebRecHits_;
+  const edm::EDGetTokenT<EcalRecHitCollection> eeRecHits_;
 
-      // config
-      const bool isMC_;
-      const double ptThreshold_;
-      const double deltaR_;
+  // to hold ID decisions and categories
+  std::vector<int> mvaPasses_;
+  std::vector<float> mvaValues_;
+  std::vector<int> mvaCats_;
 
-      // Tokens
-      const edm::EDGetTokenT<edm::View<reco::Photon>>        src_;
-      const edm::EDGetTokenT<std::vector<reco::Vertex>>      vertices_;
-      const edm::EDGetTokenT<std::vector<PileupSummaryInfo>> pileup_;
-      const edm::EDGetTokenT<edm::View<reco::GenParticle>>   genParticles_;
-      const edm::EDGetTokenT<EcalRecHitCollection>           ebRecHits_;
-      const edm::EDGetTokenT<EcalRecHitCollection>           eeRecHits_;
+  // To get the auxiliary MVA variables
+  const MVAVariableHelper variableHelper_;
 
-      // to hold ID decisions and categories
-      std::vector<int> mvaPasses_;
-      std::vector<float> mvaValues_;
-      std::vector<int> mvaCats_;
+  // To manage the variables which are parsed from the text file
+  MVAVariableManager<reco::Photon> mvaVarMngr_;
 
-      // To get the auxiliary MVA variables
-      const MVAVariableHelper variableHelper_;
+  const int nVars_;
+  std::vector<float> vars_;
 
-      // To manage the variables which are parsed from the text file
-      MVAVariableManager<reco::Photon> mvaVarMngr_;
-
-      const int nVars_;
-      std::vector<float> vars_;
-
-      const bool doEnergyMatrix_;
-      const int energyMatrixSize_;
+  const bool doEnergyMatrix_;
+  const int energyMatrixSize_;
 };
 
 enum PhotonMatchType {
@@ -127,226 +124,223 @@ enum PhotonMatchType {
 
 namespace {
 
-    int matchToTruth( const reco::Photon& ph,
-                      const edm::View<reco::GenParticle>& genParticles,
-                      double deltaR)
-    {
-      // Find the closest status 1 gen photon to the reco photon
-      double dR = 999;
-      reco::GenParticle const * closestPhoton = &genParticles[0];
-      for (auto & particle : genParticles) {
-        // Drop everything that is not photon or not status 1
-        if( abs(particle.pdgId()) != 22 || particle.status() != 1 ) continue;
+  int matchToTruth(const reco::Photon& ph, const edm::View<reco::GenParticle>& genParticles, double deltaR) {
+    // Find the closest status 1 gen photon to the reco photon
+    double dR = 999;
+    reco::GenParticle const* closestPhoton = &genParticles[0];
+    for (auto& particle : genParticles) {
+      // Drop everything that is not photon or not status 1
+      if (abs(particle.pdgId()) != 22 || particle.status() != 1)
+        continue;
 
-        double dRtmp = ROOT::Math::VectorUtil::DeltaR( ph.p4(), particle.p4() );
-        if( dRtmp < dR ) {
-          dR = dRtmp;
-          closestPhoton = &particle;
-        }
+      double dRtmp = ROOT::Math::VectorUtil::DeltaR(ph.p4(), particle.p4());
+      if (dRtmp < dR) {
+        dR = dRtmp;
+        closestPhoton = &particle;
       }
-      // See if the closest photon (if it exists) is close enough.
-      // If not, no match found.
-      if(dR < deltaR) {
-          if( closestPhoton->isPromptFinalState() ) return TRUE_PROMPT_PHOTON;
-          else return TRUE_NON_PROMPT_PHOTON;
-      }
-      return FAKE_PHOTON;
     }
+    // See if the closest photon (if it exists) is close enough.
+    // If not, no match found.
+    if (dR < deltaR) {
+      if (closestPhoton->isPromptFinalState())
+        return TRUE_PROMPT_PHOTON;
+      else
+        return TRUE_NON_PROMPT_PHOTON;
+    }
+    return FAKE_PHOTON;
+  }
 
-};
+};  // namespace
 
 // constructor
 PhotonMVANtuplizer::PhotonMVANtuplizer(const edm::ParameterSet& iConfig)
- : phoMapTags_            (iConfig.getParameter<std::vector<std::string>>("phoMVAs"))
- , phoMapBranchNames_     (iConfig.getParameter<std::vector<std::string>>("phoMVALabels"))
- , nPhoMaps_              (phoMapBranchNames_.size())
- , valMapTags_            (iConfig.getParameter<std::vector<std::string>>("phoMVAValMaps"))
- , valMapBranchNames_     (iConfig.getParameter<std::vector<std::string>>("phoMVAValMapLabels"))
- , nValMaps_              (valMapBranchNames_.size())
- , mvaCatTags_            (iConfig.getParameter<std::vector<std::string>>("phoMVACats"))
- , mvaCatBranchNames_     (iConfig.getParameter<std::vector<std::string>>("phoMVACatLabels"))
- , nCats_                 (mvaCatBranchNames_.size())
- , isMC_                  (iConfig.getParameter<bool>("isMC"))
- , ptThreshold_           (iConfig.getParameter<double>("ptThreshold"))
- , deltaR_                (iConfig.getParameter<double>("deltaR"))
- , src_                   (consumes<edm::View<reco::Photon>>(iConfig.getParameter<edm::InputTag>("src")))
- , vertices_              (consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("vertices")))
- , pileup_                (consumes<std::vector<PileupSummaryInfo>>(iConfig.getParameter<edm::InputTag>("pileup")))
- , genParticles_          (consumes<edm::View<reco::GenParticle>>(iConfig.getParameter<edm::InputTag>("genParticles")))
- , ebRecHits_             (consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ebReducedRecHitCollection")))
- , eeRecHits_             (consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("eeReducedRecHitCollection")))
- , mvaPasses_             (nPhoMaps_)
- , mvaValues_             (nValMaps_)
- , mvaCats_               (nCats_)
- , variableHelper_        (consumesCollector())
- , mvaVarMngr_            (iConfig.getParameter<std::string>("variableDefinition"))
- , nVars_                 (mvaVarMngr_.getNVars())
- , vars_                  (nVars_)
- , doEnergyMatrix_        (iConfig.getParameter<bool>("doEnergyMatrix"))
- , energyMatrixSize_      (iConfig.getParameter<int>("energyMatrixSize"))
-{
-    // phoMaps
-    for (auto const& tag : phoMapTags_) {
-        phoMapTokens_.push_back(consumes<edm::ValueMap<bool> >(edm::InputTag(tag)));
-    }
-    // valMaps
-    for (auto const& tag : valMapTags_) {
-        valMapTokens_.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(tag)));
-    }
-    // categories
-    for (auto const& tag : mvaCatTags_) {
-        mvaCatTokens_.push_back(consumes<edm::ValueMap<int> >(edm::InputTag(tag)));
-    }
+    : phoMapTags_(iConfig.getParameter<std::vector<std::string>>("phoMVAs")),
+      phoMapBranchNames_(iConfig.getParameter<std::vector<std::string>>("phoMVALabels")),
+      nPhoMaps_(phoMapBranchNames_.size()),
+      valMapTags_(iConfig.getParameter<std::vector<std::string>>("phoMVAValMaps")),
+      valMapBranchNames_(iConfig.getParameter<std::vector<std::string>>("phoMVAValMapLabels")),
+      nValMaps_(valMapBranchNames_.size()),
+      mvaCatTags_(iConfig.getParameter<std::vector<std::string>>("phoMVACats")),
+      mvaCatBranchNames_(iConfig.getParameter<std::vector<std::string>>("phoMVACatLabels")),
+      nCats_(mvaCatBranchNames_.size()),
+      isMC_(iConfig.getParameter<bool>("isMC")),
+      ptThreshold_(iConfig.getParameter<double>("ptThreshold")),
+      deltaR_(iConfig.getParameter<double>("deltaR")),
+      src_(consumes<edm::View<reco::Photon>>(iConfig.getParameter<edm::InputTag>("src"))),
+      vertices_(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("vertices"))),
+      pileup_(consumes<std::vector<PileupSummaryInfo>>(iConfig.getParameter<edm::InputTag>("pileup"))),
+      genParticles_(consumes<edm::View<reco::GenParticle>>(iConfig.getParameter<edm::InputTag>("genParticles"))),
+      ebRecHits_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ebReducedRecHitCollection"))),
+      eeRecHits_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("eeReducedRecHitCollection"))),
+      mvaPasses_(nPhoMaps_),
+      mvaValues_(nValMaps_),
+      mvaCats_(nCats_),
+      variableHelper_(consumesCollector()),
+      mvaVarMngr_(iConfig.getParameter<std::string>("variableDefinition")),
+      nVars_(mvaVarMngr_.getNVars()),
+      vars_(nVars_),
+      doEnergyMatrix_(iConfig.getParameter<bool>("doEnergyMatrix")),
+      energyMatrixSize_(iConfig.getParameter<int>("energyMatrixSize")) {
+  // phoMaps
+  for (auto const& tag : phoMapTags_) {
+    phoMapTokens_.push_back(consumes<edm::ValueMap<bool>>(edm::InputTag(tag)));
+  }
+  // valMaps
+  for (auto const& tag : valMapTags_) {
+    valMapTokens_.push_back(consumes<edm::ValueMap<float>>(edm::InputTag(tag)));
+  }
+  // categories
+  for (auto const& tag : mvaCatTags_) {
+    mvaCatTokens_.push_back(consumes<edm::ValueMap<int>>(edm::InputTag(tag)));
+  }
 
-    // Book tree
-    usesResource(TFileService::kSharedResource);
-    edm::Service<TFileService> fs ;
-    tree_  = fs->make<TTree>("tree","tree");
+  // Book tree
+  usesResource(TFileService::kSharedResource);
+  edm::Service<TFileService> fs;
+  tree_ = fs->make<TTree>("tree", "tree");
 
-    tree_->Branch("nEvent", &nEvent_);
-    tree_->Branch("nRun", &nRun_);
-    tree_->Branch("nLumi", &nLumi_);
-    if (isMC_) {
-        tree_->Branch("genNpu", &genNpu_);
-        tree_->Branch("matchedToGenPh", &matchedToGenPh_);
-    }
-    tree_->Branch("vtxN", &vtxN_);
-    tree_->Branch("pT", &pT_);
-    tree_->Branch("eta", &eta_);
+  tree_->Branch("nEvent", &nEvent_);
+  tree_->Branch("nRun", &nRun_);
+  tree_->Branch("nLumi", &nLumi_);
+  if (isMC_) {
+    tree_->Branch("genNpu", &genNpu_);
+    tree_->Branch("matchedToGenPh", &matchedToGenPh_);
+  }
+  tree_->Branch("vtxN", &vtxN_);
+  tree_->Branch("pT", &pT_);
+  tree_->Branch("eta", &eta_);
 
-    if (doEnergyMatrix_) tree_->Branch("energyMatrix",&energyMatrix_);
+  if (doEnergyMatrix_)
+    tree_->Branch("energyMatrix", &energyMatrix_);
 
-    for (int i = 0; i < nVars_; ++i) {
-        tree_->Branch(mvaVarMngr_.getName(i).c_str(), &vars_[i]);
-    }
+  for (int i = 0; i < nVars_; ++i) {
+    tree_->Branch(mvaVarMngr_.getName(i).c_str(), &vars_[i]);
+  }
 
-    // IDs
-    for (size_t k = 0; k < nValMaps_; ++k) {
-        tree_->Branch(valMapBranchNames_[k].c_str() ,  &mvaValues_[k]);
-    }
+  // IDs
+  for (size_t k = 0; k < nValMaps_; ++k) {
+    tree_->Branch(valMapBranchNames_[k].c_str(), &mvaValues_[k]);
+  }
 
-    for (size_t k = 0; k < nPhoMaps_; ++k) {
-        tree_->Branch(phoMapBranchNames_[k].c_str() ,  &mvaPasses_[k]);
-    }
+  for (size_t k = 0; k < nPhoMaps_; ++k) {
+    tree_->Branch(phoMapBranchNames_[k].c_str(), &mvaPasses_[k]);
+  }
 
-    for (size_t k = 0; k < nCats_; ++k) {
-        tree_->Branch(mvaCatBranchNames_[k].c_str() ,  &mvaCats_[k]);
-    }
+  for (size_t k = 0; k < nCats_; ++k) {
+    tree_->Branch(mvaCatBranchNames_[k].c_str(), &mvaCats_[k]);
+  }
 }
 
 // ------------ method called for each event  ------------
-void
-PhotonMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    // Fill global event info
-    nEvent_ = iEvent.id().event();
-    nRun_   = iEvent.id().run();
-    nLumi_  = iEvent.luminosityBlock();
+void PhotonMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // Fill global event info
+  nEvent_ = iEvent.id().event();
+  nRun_ = iEvent.id().run();
+  nLumi_ = iEvent.luminosityBlock();
 
-    // Get Handles
-    auto src          = iEvent.getHandle(src_);
-    auto vertices     = iEvent.getHandle(vertices_);
-    auto pileup       = iEvent.getHandle(pileup_);
-    auto genParticles = iEvent.getHandle(genParticles_);
+  // Get Handles
+  auto src = iEvent.getHandle(src_);
+  auto vertices = iEvent.getHandle(vertices_);
+  auto pileup = iEvent.getHandle(pileup_);
+  auto genParticles = iEvent.getHandle(genParticles_);
 
-    vtxN_ = vertices->size();
+  vtxN_ = vertices->size();
 
-    // initialize cluster tools
-    std::unique_ptr<noZS::EcalClusterLazyTools> lazyTools;
-    if(doEnergyMatrix_) {
-        // Configure Lazy Tools, which will compute 5x5 quantities
-        lazyTools = std::make_unique<noZS::EcalClusterLazyTools>(iEvent, iSetup, ebRecHits_, eeRecHits_);
+  // initialize cluster tools
+  std::unique_ptr<noZS::EcalClusterLazyTools> lazyTools;
+  if (doEnergyMatrix_) {
+    // Configure Lazy Tools, which will compute 5x5 quantities
+    lazyTools = std::make_unique<noZS::EcalClusterLazyTools>(iEvent, iSetup, ebRecHits_, eeRecHits_);
+  }
+
+  // Fill with true number of pileup
+  if (isMC_) {
+    for (const auto& pu : *pileup) {
+      int bx = pu.getBunchCrossing();
+      if (bx == 0) {
+        genNpu_ = pu.getPU_NumInteractions();
+        break;
+      }
+    }
+  }
+
+  // Get MVA decisions
+  edm::Handle<edm::ValueMap<bool>> decisions[nPhoMaps_];
+  for (size_t k = 0; k < nPhoMaps_; ++k) {
+    iEvent.getByToken(phoMapTokens_[k], decisions[k]);
+  }
+
+  // Get MVA values
+  edm::Handle<edm::ValueMap<float>> values[nValMaps_];
+  for (size_t k = 0; k < nValMaps_; ++k) {
+    iEvent.getByToken(valMapTokens_[k], values[k]);
+  }
+
+  // Get MVA categories
+  edm::Handle<edm::ValueMap<int>> mvaCats[nCats_];
+  for (size_t k = 0; k < nCats_; ++k) {
+    iEvent.getByToken(mvaCatTokens_[k], mvaCats[k]);
+  }
+
+  std::vector<float> extraVariables = variableHelper_.getAuxVariables(iEvent);
+
+  for (auto const& pho : src->ptrs()) {
+    if (pho->pt() < ptThreshold_)
+      continue;
+
+    pT_ = pho->pt();
+    eta_ = pho->eta();
+
+    // Fill the energy matrix around the seed
+    if (doEnergyMatrix_) {
+      const auto& seed = *(pho->superCluster()->seed());
+      energyMatrix_ = lazyTools->energyMatrix(seed, energyMatrixSize_);
     }
 
-    // Fill with true number of pileup
-    if(isMC_) {
-       for(const auto& pu : *pileup)
-       {
-           int bx = pu.getBunchCrossing();
-           if(bx == 0)
-           {
-               genNpu_ = pu.getPU_NumInteractions();
-               break;
-           }
-       }
+    // variables from the text file
+    for (int iVar = 0; iVar < nVars_; ++iVar) {
+      vars_[iVar] = mvaVarMngr_.getValue(iVar, *pho, extraVariables);
     }
 
-    // Get MVA decisions
-    edm::Handle<edm::ValueMap<bool> > decisions[nPhoMaps_];
-    for (size_t k = 0; k < nPhoMaps_; ++k) {
-        iEvent.getByToken(phoMapTokens_[k],decisions[k]);
-    }
+    if (isMC_)
+      matchedToGenPh_ = matchToTruth(*pho, *genParticles, deltaR_);
 
-    // Get MVA values
-    edm::Handle<edm::ValueMap<float> > values[nValMaps_];
-    for (size_t k = 0; k < nValMaps_; ++k) {
-        iEvent.getByToken(valMapTokens_[k],values[k]);
-    }
+    //
+    // Look up and save the ID decisions
+    //
+    for (size_t k = 0; k < nPhoMaps_; ++k)
+      mvaPasses_[k] = static_cast<int>((*decisions[k])[pho]);
+    for (size_t k = 0; k < nValMaps_; ++k)
+      mvaValues_[k] = (*values[k])[pho];
+    for (size_t k = 0; k < nCats_; ++k)
+      mvaCats_[k] = (*mvaCats[k])[pho];
 
-    // Get MVA categories
-    edm::Handle<edm::ValueMap<int> > mvaCats[nCats_];
-    for (size_t k = 0; k < nCats_; ++k) {
-        iEvent.getByToken(mvaCatTokens_[k],mvaCats[k]);
-    }
-
-    std::vector<float> extraVariables = variableHelper_.getAuxVariables(iEvent);
-
-    for(auto const& pho : src->ptrs())
-    {
-        if (pho->pt() < ptThreshold_) continue;
-
-        pT_ = pho->pt();
-        eta_ = pho->eta();
-
-        // Fill the energy matrix around the seed
-        if(doEnergyMatrix_) {
-            const auto& seed = *(pho->superCluster()->seed());
-            energyMatrix_ = lazyTools->energyMatrix(seed, energyMatrixSize_);
-        }
-
-        // variables from the text file
-        for (int iVar = 0; iVar < nVars_; ++iVar) {
-            vars_[iVar] = mvaVarMngr_.getValue(iVar, *pho, extraVariables);
-        }
-
-        if (isMC_) matchedToGenPh_ = matchToTruth( *pho, *genParticles, deltaR_);
-
-        //
-        // Look up and save the ID decisions
-        //
-        for (size_t k = 0; k < nPhoMaps_; ++k) mvaPasses_[k] = static_cast<int>((*decisions[k])[pho]);
-        for (size_t k = 0; k < nValMaps_; ++k) mvaValues_[k] = (*values[k])[pho];
-        for (size_t k = 0; k < nCats_   ; ++k) mvaCats_[k]   = (*mvaCats[k])[pho];
-
-        tree_->Fill();
-    }
-
+    tree_->Fill();
+  }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-PhotonMVANtuplizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
-    edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("src",          edm::InputTag("slimmedPhotons"));
-    desc.add<edm::InputTag>("vertices",     edm::InputTag("offlineSlimmedPrimaryVertices"));
-    desc.add<edm::InputTag>("pileup",       edm::InputTag("slimmedAddPileupInfo"));
-    desc.add<edm::InputTag>("genParticles", edm::InputTag("prunedGenParticles"));
-    desc.add<edm::InputTag>("ebReducedRecHitCollection", edm::InputTag("reducedEgamma","reducedEBRecHits"));
-    desc.add<edm::InputTag>("eeReducedRecHitCollection", edm::InputTag("reducedEgamma","reducedEERecHits"));
-    desc.add<std::vector<std::string>>("phoMVAs", {});
-    desc.add<std::vector<std::string>>("phoMVALabels", {});
-    desc.add<std::vector<std::string>>("phoMVAValMaps", {});
-    desc.add<std::vector<std::string>>("phoMVAValMapLabels", {});
-    desc.add<std::vector<std::string>>("phoMVACats", {});
-    desc.add<std::vector<std::string>>("phoMVACatLabels", {});
-    desc.add<bool>("doEnergyMatrix", false);
-    desc.add<int>("energyMatrixSize", 2)->setComment("extension of crystals in each direction away from the seed");
-    desc.add<bool>("isMC", true);
-    desc.add<double>("ptThreshold", 15.0);
-    desc.add<double>("deltaR", 0.1);
-    desc.add<std::string>("variableDefinition");
-    descriptions.addDefault(desc);
+void PhotonMVANtuplizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("slimmedPhotons"));
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
+  desc.add<edm::InputTag>("pileup", edm::InputTag("slimmedAddPileupInfo"));
+  desc.add<edm::InputTag>("genParticles", edm::InputTag("prunedGenParticles"));
+  desc.add<edm::InputTag>("ebReducedRecHitCollection", edm::InputTag("reducedEgamma", "reducedEBRecHits"));
+  desc.add<edm::InputTag>("eeReducedRecHitCollection", edm::InputTag("reducedEgamma", "reducedEERecHits"));
+  desc.add<std::vector<std::string>>("phoMVAs", {});
+  desc.add<std::vector<std::string>>("phoMVALabels", {});
+  desc.add<std::vector<std::string>>("phoMVAValMaps", {});
+  desc.add<std::vector<std::string>>("phoMVAValMapLabels", {});
+  desc.add<std::vector<std::string>>("phoMVACats", {});
+  desc.add<std::vector<std::string>>("phoMVACatLabels", {});
+  desc.add<bool>("doEnergyMatrix", false);
+  desc.add<int>("energyMatrixSize", 2)->setComment("extension of crystals in each direction away from the seed");
+  desc.add<bool>("isMC", true);
+  desc.add<double>("ptThreshold", 15.0);
+  desc.add<double>("deltaR", 0.1);
+  desc.add<std::string>("variableDefinition");
+  descriptions.addDefault(desc);
 }
 
 //define this as a plug-in

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoAnyPFIsoWithEAAndExpoScalingCut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoAnyPFIsoWithEAAndExpoScalingCut.cc
@@ -2,21 +2,18 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
 
-
 class PhoAnyPFIsoWithEAAndExpoScalingCut : public CutApplicatorWithEventContentBase {
 public:
   PhoAnyPFIsoWithEAAndExpoScalingCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
   void getEventContent(const edm::EventBase&) final;
 
   double value(const reco::CandidatePtr& cand) const final;
-  
-  CandidateType candidateType() const final { 
-    return PHOTON; 
-  }
+
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
   // Cut values
@@ -28,76 +25,66 @@ private:
   float _C3_EE;
   // Configuration
   float _barrelCutOff;
-  bool  _useRelativeIso;
+  bool _useRelativeIso;
   // Effective area constants
   EffectiveAreas _effectiveAreas;
   // The isolations computed upstream
   edm::Handle<edm::ValueMap<float> > _anyPFIsoMap;
   // The rho
-  edm::Handle< double > _rhoHandle;
+  edm::Handle<double> _rhoHandle;
 
   constexpr static char anyPFIsoWithEA_[] = "anyPFIsoWithEA";
-  constexpr static char rhoString_     [] = "rho";
+  constexpr static char rhoString_[] = "rho";
 };
 
 constexpr char PhoAnyPFIsoWithEAAndExpoScalingCut::anyPFIsoWithEA_[];
 constexpr char PhoAnyPFIsoWithEAAndExpoScalingCut::rhoString_[];
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoAnyPFIsoWithEAAndExpoScalingCut,
-		  "PhoAnyPFIsoWithEAAndExpoScalingCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoAnyPFIsoWithEAAndExpoScalingCut, "PhoAnyPFIsoWithEAAndExpoScalingCut");
 
-PhoAnyPFIsoWithEAAndExpoScalingCut::PhoAnyPFIsoWithEAAndExpoScalingCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  _C1_EB(c.getParameter<double>("C1_EB")),
-  _C2_EB(c.getParameter<double>("C2_EB")),
-  _C3_EB(c.getParameter<double>("C3_EB")),
-  _C1_EE(c.getParameter<double>("C1_EE")),
-  _C2_EE(c.getParameter<double>("C2_EE")),
-  _C3_EE(c.getParameter<double>("C3_EE")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")),
-  _useRelativeIso(c.getParameter<bool>("useRelativeIso")),
-  _effectiveAreas( (c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath())
-{
-  
+PhoAnyPFIsoWithEAAndExpoScalingCut::PhoAnyPFIsoWithEAAndExpoScalingCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      _C1_EB(c.getParameter<double>("C1_EB")),
+      _C2_EB(c.getParameter<double>("C2_EB")),
+      _C3_EB(c.getParameter<double>("C3_EB")),
+      _C1_EE(c.getParameter<double>("C1_EE")),
+      _C2_EE(c.getParameter<double>("C2_EE")),
+      _C3_EE(c.getParameter<double>("C3_EE")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")),
+      _useRelativeIso(c.getParameter<bool>("useRelativeIso")),
+      _effectiveAreas((c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath()) {
   edm::InputTag maptag = c.getParameter<edm::InputTag>("anyPFIsoMap");
-  contentTags_.emplace(anyPFIsoWithEA_,maptag);
+  contentTags_.emplace(anyPFIsoWithEA_, maptag);
 
   edm::InputTag rhoTag = c.getParameter<edm::InputTag>("rho");
-  contentTags_.emplace(rhoString_,rhoTag);
-
+  contentTags_.emplace(rhoString_, rhoTag);
 }
 
 void PhoAnyPFIsoWithEAAndExpoScalingCut::setConsumes(edm::ConsumesCollector& cc) {
-  auto anyPFIsoWithEA = 
-    cc.consumes<edm::ValueMap<float> >(contentTags_[anyPFIsoWithEA_]);
-  contentTokens_.emplace(anyPFIsoWithEA_,anyPFIsoWithEA);
+  auto anyPFIsoWithEA = cc.consumes<edm::ValueMap<float> >(contentTags_[anyPFIsoWithEA_]);
+  contentTokens_.emplace(anyPFIsoWithEA_, anyPFIsoWithEA);
 
   auto rho = cc.consumes<double>(contentTags_[rhoString_]);
   contentTokens_.emplace(rhoString_, rho);
 }
 
-void PhoAnyPFIsoWithEAAndExpoScalingCut::getEventContent(const edm::EventBase& ev) {  
-  ev.getByLabel(contentTags_[anyPFIsoWithEA_],_anyPFIsoMap);
-  ev.getByLabel(contentTags_[rhoString_],_rhoHandle);
+void PhoAnyPFIsoWithEAAndExpoScalingCut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_[anyPFIsoWithEA_], _anyPFIsoMap);
+  ev.getByLabel(contentTags_[rhoString_], _rhoHandle);
 }
 
-CutApplicatorBase::result_type 
-PhoAnyPFIsoWithEAAndExpoScalingCut::
-operator()(const reco::PhotonPtr& cand) const{  
-
+CutApplicatorBase::result_type PhoAnyPFIsoWithEAAndExpoScalingCut::operator()(const reco::PhotonPtr& cand) const {
   // in case we are by-value
   const std::string& inst_name = contentTags_.find(anyPFIsoWithEA_)->second.instance();
   edm::Ptr<pat::Photon> pat(cand);
   float anyisoval = -1.0;
-  if( _anyPFIsoMap.isValid() && _anyPFIsoMap->contains( cand.id() ) ) {
+  if (_anyPFIsoMap.isValid() && _anyPFIsoMap->contains(cand.id())) {
     anyisoval = (*_anyPFIsoMap)[cand];
-  } else if ( _anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     anyisoval = _anyPFIsoMap->begin()[cand.key()];
-  } else if ( _anyPFIsoMap.isValid() ){ // throw an exception
+  } else if (_anyPFIsoMap.isValid()) {  // throw an exception
     anyisoval = (*_anyPFIsoMap)[cand];
   }
 
@@ -109,43 +96,39 @@ operator()(const reco::PhotonPtr& cand) const{
   // exponential pt scaling to the barrel isolation cut,
   // and linear pt scaling to the endcap isolation cut.
   double absEta = std::abs(cand->superCluster()->eta());
-  const float isolationCutValue = 
-    ( absEta < _barrelCutOff ? 
-      _C1_EB + exp( pt*_C2_EB + _C3_EB)
-      : _C1_EE + exp( pt*_C2_EE + _C3_EE) );
-  
+  const float isolationCutValue =
+      (absEta < _barrelCutOff ? _C1_EB + exp(pt * _C2_EB + _C3_EB) : _C1_EE + exp(pt * _C2_EE + _C3_EE));
+
   // Retrieve the variable value for this particle
   float anyPFIso = _anyPFIsoMap.isValid() ? anyisoval : pat->userFloat(inst_name);
 
   // Apply pile-up correction
-  double eA = _effectiveAreas.getEffectiveArea( absEta );
+  double eA = _effectiveAreas.getEffectiveArea(absEta);
   double rho = *_rhoHandle;
   float anyPFIsoWithEA = std::max(0.0, anyPFIso - rho * eA);
 
   // Divide by pT if the relative isolation is requested
-  if( _useRelativeIso )
+  if (_useRelativeIso)
     anyPFIsoWithEA /= pt;
 
   // Apply the cut and return the result
   return anyPFIsoWithEA < isolationCutValue;
 }
 
-double PhoAnyPFIsoWithEAAndExpoScalingCut::
-value(const reco::CandidatePtr& cand) const {
+double PhoAnyPFIsoWithEAAndExpoScalingCut::value(const reco::CandidatePtr& cand) const {
   reco::PhotonPtr pho(cand);
 
   // in case we are by-value
   const std::string& inst_name = contentTags_.find(anyPFIsoWithEA_)->second.instance();
   edm::Ptr<pat::Photon> pat(cand);
   float anyisoval = -1.0;
-  if( _anyPFIsoMap.isValid() && _anyPFIsoMap->contains( cand.id() ) ) {
+  if (_anyPFIsoMap.isValid() && _anyPFIsoMap->contains(cand.id())) {
     anyisoval = (*_anyPFIsoMap)[cand];
-  } else if ( _anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     anyisoval = _anyPFIsoMap->begin()[cand.key()];
-  } else if ( _anyPFIsoMap.isValid() ){ // throw an exception
+  } else if (_anyPFIsoMap.isValid()) {  // throw an exception
     anyisoval = (*_anyPFIsoMap)[cand];
   }
 
@@ -157,17 +140,17 @@ value(const reco::CandidatePtr& cand) const {
   // exponential pt scaling to the barrel isolation cut,
   // and linear pt scaling to the endcap isolation cut.
   double absEta = std::abs(pho->superCluster()->eta());
-  
+
   // Retrieve the variable value for this particle
   float anyPFIso = _anyPFIsoMap.isValid() ? anyisoval : pat->userFloat(inst_name);
 
   // Apply pile-up correction
-  double eA = _effectiveAreas.getEffectiveArea( absEta );
+  double eA = _effectiveAreas.getEffectiveArea(absEta);
   double rho = *_rhoHandle;
   float anyPFIsoWithEA = std::max(0.0, anyPFIso - rho * eA);
 
   // Divide by pT if the relative isolation is requested
-  if( _useRelativeIso )
+  if (_useRelativeIso)
     anyPFIsoWithEA /= pt;
 
   // Apply the cut and return the result

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoAnyPFIsoWithEAAndExpoScalingEBCut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoAnyPFIsoWithEAAndExpoScalingEBCut.cc
@@ -2,21 +2,18 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
 
-
 class PhoAnyPFIsoWithEAAndExpoScalingEBCut : public CutApplicatorWithEventContentBase {
 public:
   PhoAnyPFIsoWithEAAndExpoScalingEBCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
   void getEventContent(const edm::EventBase&) final;
 
   double value(const reco::CandidatePtr& cand) const final;
-  
-  CandidateType candidateType() const final { 
-    return PHOTON; 
-  }
+
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
   // Cut values
@@ -27,75 +24,65 @@ private:
   float _C2_EE;
   // Configuration
   float _barrelCutOff;
-  bool  _useRelativeIso;
+  bool _useRelativeIso;
   // Effective area constants
   EffectiveAreas _effectiveAreas;
   // The isolations computed upstream
   edm::Handle<edm::ValueMap<float> > _anyPFIsoMap;
   // The rho
-  edm::Handle< double > _rhoHandle;
+  edm::Handle<double> _rhoHandle;
 
   constexpr static char anyPFIsoWithEA_[] = "anyPFIsoWithEA";
-  constexpr static char rhoString_     [] = "rho";
+  constexpr static char rhoString_[] = "rho";
 };
 
 constexpr char PhoAnyPFIsoWithEAAndExpoScalingEBCut::anyPFIsoWithEA_[];
 constexpr char PhoAnyPFIsoWithEAAndExpoScalingEBCut::rhoString_[];
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoAnyPFIsoWithEAAndExpoScalingEBCut,
-		  "PhoAnyPFIsoWithEAAndExpoScalingEBCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoAnyPFIsoWithEAAndExpoScalingEBCut, "PhoAnyPFIsoWithEAAndExpoScalingEBCut");
 
-PhoAnyPFIsoWithEAAndExpoScalingEBCut::PhoAnyPFIsoWithEAAndExpoScalingEBCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  _C1_EB(c.getParameter<double>("C1_EB")),
-  _C2_EB(c.getParameter<double>("C2_EB")),
-  _C3_EB(c.getParameter<double>("C3_EB")),
-  _C1_EE(c.getParameter<double>("C1_EE")),
-  _C2_EE(c.getParameter<double>("C2_EE")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")),
-  _useRelativeIso(c.getParameter<bool>("useRelativeIso")),
-  _effectiveAreas( (c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath())
-{
-  
+PhoAnyPFIsoWithEAAndExpoScalingEBCut::PhoAnyPFIsoWithEAAndExpoScalingEBCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      _C1_EB(c.getParameter<double>("C1_EB")),
+      _C2_EB(c.getParameter<double>("C2_EB")),
+      _C3_EB(c.getParameter<double>("C3_EB")),
+      _C1_EE(c.getParameter<double>("C1_EE")),
+      _C2_EE(c.getParameter<double>("C2_EE")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")),
+      _useRelativeIso(c.getParameter<bool>("useRelativeIso")),
+      _effectiveAreas((c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath()) {
   edm::InputTag maptag = c.getParameter<edm::InputTag>("anyPFIsoMap");
-  contentTags_.emplace(anyPFIsoWithEA_,maptag);
+  contentTags_.emplace(anyPFIsoWithEA_, maptag);
 
   edm::InputTag rhoTag = c.getParameter<edm::InputTag>("rho");
-  contentTags_.emplace(rhoString_,rhoTag);
-
+  contentTags_.emplace(rhoString_, rhoTag);
 }
 
 void PhoAnyPFIsoWithEAAndExpoScalingEBCut::setConsumes(edm::ConsumesCollector& cc) {
-  auto anyPFIsoWithEA = 
-    cc.consumes<edm::ValueMap<float> >(contentTags_[anyPFIsoWithEA_]);
-  contentTokens_.emplace(anyPFIsoWithEA_,anyPFIsoWithEA);
+  auto anyPFIsoWithEA = cc.consumes<edm::ValueMap<float> >(contentTags_[anyPFIsoWithEA_]);
+  contentTokens_.emplace(anyPFIsoWithEA_, anyPFIsoWithEA);
 
   auto rho = cc.consumes<double>(contentTags_[rhoString_]);
   contentTokens_.emplace(rhoString_, rho);
 }
 
-void PhoAnyPFIsoWithEAAndExpoScalingEBCut::getEventContent(const edm::EventBase& ev) {  
-  ev.getByLabel(contentTags_[anyPFIsoWithEA_],_anyPFIsoMap);
-  ev.getByLabel(contentTags_[rhoString_],_rhoHandle);
+void PhoAnyPFIsoWithEAAndExpoScalingEBCut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_[anyPFIsoWithEA_], _anyPFIsoMap);
+  ev.getByLabel(contentTags_[rhoString_], _rhoHandle);
 }
 
-CutApplicatorBase::result_type 
-PhoAnyPFIsoWithEAAndExpoScalingEBCut::
-operator()(const reco::PhotonPtr& cand) const{  
-
+CutApplicatorBase::result_type PhoAnyPFIsoWithEAAndExpoScalingEBCut::operator()(const reco::PhotonPtr& cand) const {
   // in case we are by-value
   const std::string& inst_name = contentTags_.find(anyPFIsoWithEA_)->second.instance();
   edm::Ptr<pat::Photon> pat(cand);
   float anyisoval = -1.0;
-  if( _anyPFIsoMap.isValid() && _anyPFIsoMap->contains( cand.id() ) ) {
+  if (_anyPFIsoMap.isValid() && _anyPFIsoMap->contains(cand.id())) {
     anyisoval = (*_anyPFIsoMap)[cand];
-  } else if ( _anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     anyisoval = _anyPFIsoMap->begin()[cand.key()];
-  } else if ( _anyPFIsoMap.isValid() ){ // throw an exception
+  } else if (_anyPFIsoMap.isValid()) {  // throw an exception
     anyisoval = (*_anyPFIsoMap)[cand];
   }
 
@@ -107,43 +94,38 @@ operator()(const reco::PhotonPtr& cand) const{
   // exponential pt scaling to the barrel isolation cut,
   // and linear pt scaling to the endcap isolation cut.
   double absEta = std::abs(cand->superCluster()->eta());
-  const float isolationCutValue = 
-    ( absEta < _barrelCutOff ? 
-      _C1_EB + exp( pt*_C2_EB + _C3_EB)
-      : _C1_EE + pt * _C2_EE);
-  
+  const float isolationCutValue = (absEta < _barrelCutOff ? _C1_EB + exp(pt * _C2_EB + _C3_EB) : _C1_EE + pt * _C2_EE);
+
   // Retrieve the variable value for this particle
   float anyPFIso = _anyPFIsoMap.isValid() ? anyisoval : pat->userFloat(inst_name);
 
   // Apply pile-up correction
-  double eA = _effectiveAreas.getEffectiveArea( absEta );
+  double eA = _effectiveAreas.getEffectiveArea(absEta);
   double rho = *_rhoHandle;
   float anyPFIsoWithEA = std::max(0.0, anyPFIso - rho * eA);
 
   // Divide by pT if the relative isolation is requested
-  if( _useRelativeIso )
+  if (_useRelativeIso)
     anyPFIsoWithEA /= pt;
 
   // Apply the cut and return the result
   return anyPFIsoWithEA < isolationCutValue;
 }
 
-double PhoAnyPFIsoWithEAAndExpoScalingEBCut::
-value(const reco::CandidatePtr& cand) const {
+double PhoAnyPFIsoWithEAAndExpoScalingEBCut::value(const reco::CandidatePtr& cand) const {
   reco::PhotonPtr pho(cand);
 
   // in case we are by-value
   const std::string& inst_name = contentTags_.find(anyPFIsoWithEA_)->second.instance();
   edm::Ptr<pat::Photon> pat(cand);
   float anyisoval = -1.0;
-  if( _anyPFIsoMap.isValid() && _anyPFIsoMap->contains( cand.id() ) ) {
+  if (_anyPFIsoMap.isValid() && _anyPFIsoMap->contains(cand.id())) {
     anyisoval = (*_anyPFIsoMap)[cand];
-  } else if ( _anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     anyisoval = _anyPFIsoMap->begin()[cand.key()];
-  } else if ( _anyPFIsoMap.isValid() ){ // throw an exception
+  } else if (_anyPFIsoMap.isValid()) {  // throw an exception
     anyisoval = (*_anyPFIsoMap)[cand];
   }
 
@@ -155,17 +137,17 @@ value(const reco::CandidatePtr& cand) const {
   // exponential pt scaling to the barrel isolation cut,
   // and linear pt scaling to the endcap isolation cut.
   double absEta = std::abs(pho->superCluster()->eta());
-  
+
   // Retrieve the variable value for this particle
   float anyPFIso = _anyPFIsoMap.isValid() ? anyisoval : pat->userFloat(inst_name);
 
   // Apply pile-up correction
-  double eA = _effectiveAreas.getEffectiveArea( absEta );
+  double eA = _effectiveAreas.getEffectiveArea(absEta);
   double rho = *_rhoHandle;
   float anyPFIsoWithEA = std::max(0.0, anyPFIso - rho * eA);
 
   // Divide by pT if the relative isolation is requested
-  if( _useRelativeIso )
+  if (_useRelativeIso)
     anyPFIsoWithEA /= pt;
 
   // Apply the cut and return the result

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoAnyPFIsoWithEAAndQuadScalingCut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoAnyPFIsoWithEAAndQuadScalingCut.cc
@@ -2,21 +2,18 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
 
-
 class PhoAnyPFIsoWithEAAndQuadScalingCut : public CutApplicatorWithEventContentBase {
 public:
   PhoAnyPFIsoWithEAAndQuadScalingCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
   void getEventContent(const edm::EventBase&) final;
 
   double value(const reco::CandidatePtr& cand) const final;
-  
-  CandidateType candidateType() const final { 
-    return PHOTON; 
-  }
+
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
   // Cut values
@@ -28,76 +25,66 @@ private:
   float _C3_EE;
   // Configuration
   float _barrelCutOff;
-  bool  _useRelativeIso;
+  bool _useRelativeIso;
   // Effective area constants
   EffectiveAreas _effectiveAreas;
   // The isolations computed upstream
   edm::Handle<edm::ValueMap<float> > _anyPFIsoMap;
   // The rho
-  edm::Handle< double > _rhoHandle;
+  edm::Handle<double> _rhoHandle;
 
   constexpr static char anyPFIsoWithEA_[] = "anyPFIsoWithEA";
-  constexpr static char rhoString_     [] = "rho";
+  constexpr static char rhoString_[] = "rho";
 };
 
 constexpr char PhoAnyPFIsoWithEAAndQuadScalingCut::anyPFIsoWithEA_[];
 constexpr char PhoAnyPFIsoWithEAAndQuadScalingCut::rhoString_[];
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoAnyPFIsoWithEAAndQuadScalingCut,
-		  "PhoAnyPFIsoWithEAAndQuadScalingCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoAnyPFIsoWithEAAndQuadScalingCut, "PhoAnyPFIsoWithEAAndQuadScalingCut");
 
-PhoAnyPFIsoWithEAAndQuadScalingCut::PhoAnyPFIsoWithEAAndQuadScalingCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  _C1_EB(c.getParameter<double>("C1_EB")),
-  _C2_EB(c.getParameter<double>("C2_EB")),
-  _C3_EB(c.getParameter<double>("C3_EB")),
-  _C1_EE(c.getParameter<double>("C1_EE")),
-  _C2_EE(c.getParameter<double>("C2_EE")),
-  _C3_EE(c.getParameter<double>("C3_EE")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")),
-  _useRelativeIso(c.getParameter<bool>("useRelativeIso")),
-  _effectiveAreas( (c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath())
-{
-  
+PhoAnyPFIsoWithEAAndQuadScalingCut::PhoAnyPFIsoWithEAAndQuadScalingCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      _C1_EB(c.getParameter<double>("C1_EB")),
+      _C2_EB(c.getParameter<double>("C2_EB")),
+      _C3_EB(c.getParameter<double>("C3_EB")),
+      _C1_EE(c.getParameter<double>("C1_EE")),
+      _C2_EE(c.getParameter<double>("C2_EE")),
+      _C3_EE(c.getParameter<double>("C3_EE")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")),
+      _useRelativeIso(c.getParameter<bool>("useRelativeIso")),
+      _effectiveAreas((c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath()) {
   edm::InputTag maptag = c.getParameter<edm::InputTag>("anyPFIsoMap");
-  contentTags_.emplace(anyPFIsoWithEA_,maptag);
+  contentTags_.emplace(anyPFIsoWithEA_, maptag);
 
   edm::InputTag rhoTag = c.getParameter<edm::InputTag>("rho");
-  contentTags_.emplace(rhoString_,rhoTag);
-
+  contentTags_.emplace(rhoString_, rhoTag);
 }
 
 void PhoAnyPFIsoWithEAAndQuadScalingCut::setConsumes(edm::ConsumesCollector& cc) {
-  auto anyPFIsoWithEA = 
-    cc.consumes<edm::ValueMap<float> >(contentTags_[anyPFIsoWithEA_]);
-  contentTokens_.emplace(anyPFIsoWithEA_,anyPFIsoWithEA);
+  auto anyPFIsoWithEA = cc.consumes<edm::ValueMap<float> >(contentTags_[anyPFIsoWithEA_]);
+  contentTokens_.emplace(anyPFIsoWithEA_, anyPFIsoWithEA);
 
   auto rho = cc.consumes<double>(contentTags_[rhoString_]);
   contentTokens_.emplace(rhoString_, rho);
 }
 
-void PhoAnyPFIsoWithEAAndQuadScalingCut::getEventContent(const edm::EventBase& ev) {  
-  ev.getByLabel(contentTags_[anyPFIsoWithEA_],_anyPFIsoMap);
-  ev.getByLabel(contentTags_[rhoString_],_rhoHandle);
+void PhoAnyPFIsoWithEAAndQuadScalingCut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_[anyPFIsoWithEA_], _anyPFIsoMap);
+  ev.getByLabel(contentTags_[rhoString_], _rhoHandle);
 }
 
-CutApplicatorBase::result_type 
-PhoAnyPFIsoWithEAAndQuadScalingCut::
-operator()(const reco::PhotonPtr& cand) const{  
-
+CutApplicatorBase::result_type PhoAnyPFIsoWithEAAndQuadScalingCut::operator()(const reco::PhotonPtr& cand) const {
   // in case we are by-value
   const std::string& inst_name = contentTags_.find(anyPFIsoWithEA_)->second.instance();
   edm::Ptr<pat::Photon> pat(cand);
   float anyisoval = -1.0;
-  if( _anyPFIsoMap.isValid() && _anyPFIsoMap->contains( cand.id() ) ) {
+  if (_anyPFIsoMap.isValid() && _anyPFIsoMap->contains(cand.id())) {
     anyisoval = (*_anyPFIsoMap)[cand];
-  } else if ( _anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     anyisoval = _anyPFIsoMap->begin()[cand.key()];
-  } else if ( _anyPFIsoMap.isValid() ){ // throw an exception
+  } else if (_anyPFIsoMap.isValid()) {  // throw an exception
     anyisoval = (*_anyPFIsoMap)[cand];
   }
 
@@ -109,43 +96,39 @@ operator()(const reco::PhotonPtr& cand) const{
   // exponential pt scaling to the barrel isolation cut,
   // and linear pt scaling to the endcap isolation cut.
   double absEta = std::abs(cand->superCluster()->eta());
-  const float isolationCutValue = 
-    ( absEta < _barrelCutOff ? 
-      _C1_EB + pt*_C2_EB + pt*pt*_C3_EB
-      : _C1_EE + pt*_C2_EE + pt*pt*_C3_EE );
-  
+  const float isolationCutValue =
+      (absEta < _barrelCutOff ? _C1_EB + pt * _C2_EB + pt * pt * _C3_EB : _C1_EE + pt * _C2_EE + pt * pt * _C3_EE);
+
   // Retrieve the variable value for this particle
   float anyPFIso = _anyPFIsoMap.isValid() ? anyisoval : pat->userFloat(inst_name);
 
   // Apply pile-up correction
-  double eA = _effectiveAreas.getEffectiveArea( absEta );
+  double eA = _effectiveAreas.getEffectiveArea(absEta);
   double rho = *_rhoHandle;
   float anyPFIsoWithEA = std::max(0.0, anyPFIso - rho * eA);
 
   // Divide by pT if the relative isolation is requested
-  if( _useRelativeIso )
+  if (_useRelativeIso)
     anyPFIsoWithEA /= pt;
 
   // Apply the cut and return the result
   return anyPFIsoWithEA < isolationCutValue;
 }
 
-double PhoAnyPFIsoWithEAAndQuadScalingCut::
-value(const reco::CandidatePtr& cand) const {
+double PhoAnyPFIsoWithEAAndQuadScalingCut::value(const reco::CandidatePtr& cand) const {
   reco::PhotonPtr pho(cand);
 
   // in case we are by-value
   const std::string& inst_name = contentTags_.find(anyPFIsoWithEA_)->second.instance();
   edm::Ptr<pat::Photon> pat(cand);
   float anyisoval = -1.0;
-  if( _anyPFIsoMap.isValid() && _anyPFIsoMap->contains( cand.id() ) ) {
+  if (_anyPFIsoMap.isValid() && _anyPFIsoMap->contains(cand.id())) {
     anyisoval = (*_anyPFIsoMap)[cand];
-  } else if ( _anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     anyisoval = _anyPFIsoMap->begin()[cand.key()];
-  } else if ( _anyPFIsoMap.isValid() ){ // throw an exception
+  } else if (_anyPFIsoMap.isValid()) {  // throw an exception
     anyisoval = (*_anyPFIsoMap)[cand];
   }
 
@@ -157,17 +140,17 @@ value(const reco::CandidatePtr& cand) const {
   // exponential pt scaling to the barrel isolation cut,
   // and linear pt scaling to the endcap isolation cut.
   double absEta = std::abs(pho->superCluster()->eta());
-  
+
   // Retrieve the variable value for this particle
   float anyPFIso = _anyPFIsoMap.isValid() ? anyisoval : pat->userFloat(inst_name);
 
   // Apply pile-up correction
-  double eA = _effectiveAreas.getEffectiveArea( absEta );
+  double eA = _effectiveAreas.getEffectiveArea(absEta);
   double rho = *_rhoHandle;
   float anyPFIsoWithEA = std::max(0.0, anyPFIso - rho * eA);
 
   // Divide by pT if the relative isolation is requested
-  if( _useRelativeIso )
+  if (_useRelativeIso)
     anyPFIsoWithEA /= pt;
 
   // Apply the cut and return the result

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoAnyPFIsoWithEACut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoAnyPFIsoWithEACut.cc
@@ -2,11 +2,10 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
 
-
 class PhoAnyPFIsoWithEACut : public CutApplicatorWithEventContentBase {
 public:
   PhoAnyPFIsoWithEACut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -14,9 +13,7 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return PHOTON; 
-  }
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
   // Cut values
@@ -26,133 +23,117 @@ private:
   float _C2_EE;
   // Configuration
   float _barrelCutOff;
-  bool  _useRelativeIso;
+  bool _useRelativeIso;
   // Effective area constants
   EffectiveAreas _effectiveAreas;
   // The isolations computed upstream
   edm::Handle<edm::ValueMap<float> > _anyPFIsoMap;
   // The rho
-  edm::Handle< double > _rhoHandle;
+  edm::Handle<double> _rhoHandle;
 
   constexpr static char anyPFIsoWithEA_[] = "anyPFIsoWithEA";
-  constexpr static char rhoString_     [] = "rho";
+  constexpr static char rhoString_[] = "rho";
 };
 
 constexpr char PhoAnyPFIsoWithEACut::anyPFIsoWithEA_[];
 constexpr char PhoAnyPFIsoWithEACut::rhoString_[];
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoAnyPFIsoWithEACut,
-		  "PhoAnyPFIsoWithEACut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoAnyPFIsoWithEACut, "PhoAnyPFIsoWithEACut");
 
-PhoAnyPFIsoWithEACut::PhoAnyPFIsoWithEACut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  _C1_EB(c.getParameter<double>("C1_EB")),
-  _C2_EB(c.getParameter<double>("C2_EB")),
-  _C1_EE(c.getParameter<double>("C1_EE")),
-  _C2_EE(c.getParameter<double>("C2_EE")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")),
-  _useRelativeIso(c.getParameter<bool>("useRelativeIso")),
-  _effectiveAreas( (c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath())
-{
-  
+PhoAnyPFIsoWithEACut::PhoAnyPFIsoWithEACut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      _C1_EB(c.getParameter<double>("C1_EB")),
+      _C2_EB(c.getParameter<double>("C2_EB")),
+      _C1_EE(c.getParameter<double>("C1_EE")),
+      _C2_EE(c.getParameter<double>("C2_EE")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")),
+      _useRelativeIso(c.getParameter<bool>("useRelativeIso")),
+      _effectiveAreas((c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath()) {
   edm::InputTag maptag = c.getParameter<edm::InputTag>("anyPFIsoMap");
-  contentTags_.emplace(anyPFIsoWithEA_,maptag);
+  contentTags_.emplace(anyPFIsoWithEA_, maptag);
 
   edm::InputTag rhoTag = c.getParameter<edm::InputTag>("rho");
-  contentTags_.emplace(rhoString_,rhoTag);
-
+  contentTags_.emplace(rhoString_, rhoTag);
 }
 
 void PhoAnyPFIsoWithEACut::setConsumes(edm::ConsumesCollector& cc) {
-  auto anyPFIsoWithEA = 
-    cc.consumes<edm::ValueMap<float> >(contentTags_[anyPFIsoWithEA_]);
-  contentTokens_.emplace(anyPFIsoWithEA_,anyPFIsoWithEA);
+  auto anyPFIsoWithEA = cc.consumes<edm::ValueMap<float> >(contentTags_[anyPFIsoWithEA_]);
+  contentTokens_.emplace(anyPFIsoWithEA_, anyPFIsoWithEA);
 
   auto rho = cc.consumes<double>(contentTags_[rhoString_]);
   contentTokens_.emplace(rhoString_, rho);
 }
 
-void PhoAnyPFIsoWithEACut::getEventContent(const edm::EventBase& ev) {  
-  ev.getByLabel(contentTags_[anyPFIsoWithEA_],_anyPFIsoMap);
-  ev.getByLabel(contentTags_[rhoString_],_rhoHandle);
+void PhoAnyPFIsoWithEACut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_[anyPFIsoWithEA_], _anyPFIsoMap);
+  ev.getByLabel(contentTags_[rhoString_], _rhoHandle);
 }
 
-CutApplicatorBase::result_type 
-PhoAnyPFIsoWithEACut::
-operator()(const reco::PhotonPtr& cand) const{  
-
+CutApplicatorBase::result_type PhoAnyPFIsoWithEACut::operator()(const reco::PhotonPtr& cand) const {
   // in case we are by-value
   const std::string& inst_name = contentTags_.find(anyPFIsoWithEA_)->second.instance();
   edm::Ptr<pat::Photon> pat(cand);
   float anyisoval = -1.0;
-  if( _anyPFIsoMap.isValid() && _anyPFIsoMap->contains( cand.id() ) ) {
+  if (_anyPFIsoMap.isValid() && _anyPFIsoMap->contains(cand.id())) {
     anyisoval = (*_anyPFIsoMap)[cand];
-  } else if ( _anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     anyisoval = _anyPFIsoMap->begin()[cand.key()];
-  } else if ( _anyPFIsoMap.isValid() ){ // throw an exception
+  } else if (_anyPFIsoMap.isValid()) {  // throw an exception
     anyisoval = (*_anyPFIsoMap)[cand];
   }
 
   // Figure out the cut value
   // The value is generally pt-dependent: C1 + pt * C2
   const double absEta = std::abs(cand->superCluster()->eta());
-  const float anyPFIsoWithEACutValue = 
-    ( absEta < _barrelCutOff ? 
-      _C1_EB + cand->pt() * _C2_EB
-      : 
-      _C1_EE + cand->pt() * _C2_EE
-      );
-  
+  const float anyPFIsoWithEACutValue =
+      (absEta < _barrelCutOff ? _C1_EB + cand->pt() * _C2_EB : _C1_EE + cand->pt() * _C2_EE);
+
   // Retrieve the variable value for this particle
   float anyPFIso = _anyPFIsoMap.isValid() ? anyisoval : pat->userFloat(inst_name);
 
   // Apply pile-up correction
-  const double eA = _effectiveAreas.getEffectiveArea( absEta );
+  const double eA = _effectiveAreas.getEffectiveArea(absEta);
   const double rho = _rhoHandle.isValid() ? *_rhoHandle : 0;
   const float anyPFIsoWithEA = std::max(0.0, anyPFIso - rho * eA);
 
   // Apply the cut and return the result
   // Scale by pT if the relative isolation is requested but avoid division by 0
-  return anyPFIsoWithEA < anyPFIsoWithEACutValue*(_useRelativeIso ? cand->pt() : 1.);
+  return anyPFIsoWithEA < anyPFIsoWithEACutValue * (_useRelativeIso ? cand->pt() : 1.);
 }
 
-double PhoAnyPFIsoWithEACut::
-value(const reco::CandidatePtr& cand) const {
+double PhoAnyPFIsoWithEACut::value(const reco::CandidatePtr& cand) const {
   reco::PhotonPtr pho(cand);
 
   // in case we are by-value
   const std::string& inst_name = contentTags_.find(anyPFIsoWithEA_)->second.instance();
   edm::Ptr<pat::Photon> pat(cand);
   float anyisoval = -1.0;
-  if( _anyPFIsoMap.isValid() && _anyPFIsoMap->contains( cand.id() ) ) {
+  if (_anyPFIsoMap.isValid() && _anyPFIsoMap->contains(cand.id())) {
     anyisoval = (*_anyPFIsoMap)[cand];
-  } else if ( _anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_anyPFIsoMap.isValid() && _anyPFIsoMap->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     anyisoval = _anyPFIsoMap->begin()[cand.key()];
-  } else if ( _anyPFIsoMap.isValid() ){ // throw an exception
+  } else if (_anyPFIsoMap.isValid()) {  // throw an exception
     anyisoval = (*_anyPFIsoMap)[cand];
   }
 
   // Figure out the cut value
   // The value is generally pt-dependent: C1 + pt * C2
-  double absEta = std::abs(pho->superCluster()->eta());  
-  
+  double absEta = std::abs(pho->superCluster()->eta());
+
   // Retrieve the variable value for this particle
   float anyPFIso = _anyPFIsoMap.isValid() ? anyisoval : pat->userFloat(inst_name);
 
   // Apply pile-up correction
-  double eA = _effectiveAreas.getEffectiveArea( absEta );
+  double eA = _effectiveAreas.getEffectiveArea(absEta);
   double rho = *_rhoHandle;
   float anyPFIsoWithEA = std::max(0.0, anyPFIso - rho * eA);
 
   // Divide by pT if the relative isolation is requested
-  if( _useRelativeIso )
+  if (_useRelativeIso)
     anyPFIsoWithEA /= pho->pt();
 
   // Apply the cut and return the result

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoFull5x5SigmaIEtaIEtaCut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoFull5x5SigmaIEtaIEtaCut.cc
@@ -4,14 +4,12 @@
 class PhoFull5x5SigmaIEtaIEtaCut : public CutApplicatorBase {
 public:
   PhoFull5x5SigmaIEtaIEtaCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return PHOTON; 
-  }
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
   float _cutValueEB;
@@ -19,32 +17,24 @@ private:
   float _barrelCutOff;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoFull5x5SigmaIEtaIEtaCut,
-		  "PhoFull5x5SigmaIEtaIEtaCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoFull5x5SigmaIEtaIEtaCut, "PhoFull5x5SigmaIEtaIEtaCut");
 
-PhoFull5x5SigmaIEtaIEtaCut::PhoFull5x5SigmaIEtaIEtaCut(const edm::ParameterSet& c) :
-  CutApplicatorBase(c),
-  _cutValueEB(c.getParameter<double>("cutValueEB")),
-  _cutValueEE(c.getParameter<double>("cutValueEE")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
-}
+PhoFull5x5SigmaIEtaIEtaCut::PhoFull5x5SigmaIEtaIEtaCut(const edm::ParameterSet& c)
+    : CutApplicatorBase(c),
+      _cutValueEB(c.getParameter<double>("cutValueEB")),
+      _cutValueEE(c.getParameter<double>("cutValueEE")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
 
-CutApplicatorBase::result_type 
-PhoFull5x5SigmaIEtaIEtaCut::
-operator()(const reco::PhotonPtr& cand) const{  
-
+CutApplicatorBase::result_type PhoFull5x5SigmaIEtaIEtaCut::operator()(const reco::PhotonPtr& cand) const {
   // Figure out the cut value
-  const float full5x5SigmaIEtaIEtaCutValue = 
-    ( std::abs(cand->superCluster()->eta()) < _barrelCutOff ? 
-      _cutValueEB : _cutValueEE );
-  
+  const float full5x5SigmaIEtaIEtaCutValue =
+      (std::abs(cand->superCluster()->eta()) < _barrelCutOff ? _cutValueEB : _cutValueEE);
+
   // Apply the cut and return the result
   return cand->full5x5_sigmaIetaIeta() < full5x5SigmaIEtaIEtaCutValue;
 }
 
-double PhoFull5x5SigmaIEtaIEtaCut::
-value(const reco::CandidatePtr& cand) const {
+double PhoFull5x5SigmaIEtaIEtaCut::value(const reco::CandidatePtr& cand) const {
   reco::PhotonPtr pho(cand);
   return pho->full5x5_sigmaIetaIeta();
 }

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoFull5x5SigmaIEtaIEtaValueMapCut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoFull5x5SigmaIEtaIEtaValueMapCut.cc
@@ -4,7 +4,7 @@
 class PhoFull5x5SigmaIEtaIEtaValueMapCut : public CutApplicatorWithEventContentBase {
 public:
   PhoFull5x5SigmaIEtaIEtaValueMapCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -12,9 +12,7 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return PHOTON; 
-  }
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
   const float _cutValueEB;
@@ -27,69 +25,59 @@ private:
 
 constexpr char PhoFull5x5SigmaIEtaIEtaValueMapCut::full5x5SigmaIEtaIEta_[];
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoFull5x5SigmaIEtaIEtaValueMapCut,
-		  "PhoFull5x5SigmaIEtaIEtaValueMapCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoFull5x5SigmaIEtaIEtaValueMapCut, "PhoFull5x5SigmaIEtaIEtaValueMapCut");
 
-PhoFull5x5SigmaIEtaIEtaValueMapCut::PhoFull5x5SigmaIEtaIEtaValueMapCut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  _cutValueEB(c.getParameter<double>("cutValueEB")),
-  _cutValueEE(c.getParameter<double>("cutValueEE")),
-  _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
-
+PhoFull5x5SigmaIEtaIEtaValueMapCut::PhoFull5x5SigmaIEtaIEtaValueMapCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c),
+      _cutValueEB(c.getParameter<double>("cutValueEB")),
+      _cutValueEE(c.getParameter<double>("cutValueEE")),
+      _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
   edm::InputTag maptag = c.getParameter<edm::InputTag>("full5x5SigmaIEtaIEtaMap");
-  contentTags_.emplace(full5x5SigmaIEtaIEta_,maptag);
+  contentTags_.emplace(full5x5SigmaIEtaIEta_, maptag);
 }
 
 void PhoFull5x5SigmaIEtaIEtaValueMapCut::setConsumes(edm::ConsumesCollector& cc) {
-  auto full5x5SigmaIEtaIEta = 
-    cc.consumes<edm::ValueMap<float> >(contentTags_[full5x5SigmaIEtaIEta_]);
-  contentTokens_.emplace(full5x5SigmaIEtaIEta_,full5x5SigmaIEtaIEta);
+  auto full5x5SigmaIEtaIEta = cc.consumes<edm::ValueMap<float> >(contentTags_[full5x5SigmaIEtaIEta_]);
+  contentTokens_.emplace(full5x5SigmaIEtaIEta_, full5x5SigmaIEtaIEta);
 }
 
-void PhoFull5x5SigmaIEtaIEtaValueMapCut::getEventContent(const edm::EventBase& ev) {  
-  ev.getByLabel(contentTags_[full5x5SigmaIEtaIEta_],_full5x5SigmaIEtaIEtaMap);
+void PhoFull5x5SigmaIEtaIEtaValueMapCut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_[full5x5SigmaIEtaIEta_], _full5x5SigmaIEtaIEtaMap);
 }
 
-CutApplicatorBase::result_type 
-PhoFull5x5SigmaIEtaIEtaValueMapCut::
-operator()(const reco::PhotonPtr& cand) const{  
-
+CutApplicatorBase::result_type PhoFull5x5SigmaIEtaIEtaValueMapCut::operator()(const reco::PhotonPtr& cand) const {
   // Figure out the cut value
-  const float cutValue = 
-    ( std::abs(cand->superCluster()->eta()) < _barrelCutOff ? 
-      _cutValueEB : _cutValueEE );
+  const float cutValue = (std::abs(cand->superCluster()->eta()) < _barrelCutOff ? _cutValueEB : _cutValueEE);
   float sihihval = -1.0;
-  if( _full5x5SigmaIEtaIEtaMap.isValid() && _full5x5SigmaIEtaIEtaMap->contains( cand.id() ) ) {
+  if (_full5x5SigmaIEtaIEtaMap.isValid() && _full5x5SigmaIEtaIEtaMap->contains(cand.id())) {
     sihihval = (*_full5x5SigmaIEtaIEtaMap)[cand];
-  } else if ( _full5x5SigmaIEtaIEtaMap.isValid() && _full5x5SigmaIEtaIEtaMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_full5x5SigmaIEtaIEtaMap.isValid() && _full5x5SigmaIEtaIEtaMap->idSize() == 1 &&
+             cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     sihihval = _full5x5SigmaIEtaIEtaMap->begin()[cand.key()];
-  } else if ( _full5x5SigmaIEtaIEtaMap.isValid() ){ // throw an exception
+  } else if (_full5x5SigmaIEtaIEtaMap.isValid()) {  // throw an exception
     sihihval = (*_full5x5SigmaIEtaIEtaMap)[cand];
   }
-  
+
   // Retrieve the variable value for this particle
   const float full5x5SigmaIEtaIEta = _full5x5SigmaIEtaIEtaMap.isValid() ? sihihval : cand->full5x5_sigmaIetaIeta();
-  
+
   // Apply the cut and return the result
   return full5x5SigmaIEtaIEta < cutValue;
 }
 
-double PhoFull5x5SigmaIEtaIEtaValueMapCut::
-value(const reco::CandidatePtr& cand) const {
+double PhoFull5x5SigmaIEtaIEtaValueMapCut::value(const reco::CandidatePtr& cand) const {
   reco::PhotonPtr pho(cand);
   float sihihval = -1.0;
-  if( _full5x5SigmaIEtaIEtaMap.isValid() && _full5x5SigmaIEtaIEtaMap->contains( cand.id() ) ) {
+  if (_full5x5SigmaIEtaIEtaMap.isValid() && _full5x5SigmaIEtaIEtaMap->contains(cand.id())) {
     sihihval = (*_full5x5SigmaIEtaIEtaMap)[cand];
-  } else if ( _full5x5SigmaIEtaIEtaMap.isValid() && _full5x5SigmaIEtaIEtaMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_full5x5SigmaIEtaIEtaMap.isValid() && _full5x5SigmaIEtaIEtaMap->idSize() == 1 &&
+             cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     sihihval = _full5x5SigmaIEtaIEtaMap->begin()[cand.key()];
-  } else if ( _full5x5SigmaIEtaIEtaMap.isValid() ){ // throw an exception
+  } else if (_full5x5SigmaIEtaIEtaMap.isValid()) {  // throw an exception
     sihihval = (*_full5x5SigmaIEtaIEtaMap)[cand];
   }
 

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoGenericRhoPtScaledCut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoGenericRhoPtScaledCut.cc
@@ -7,7 +7,7 @@
 class PhoGenericRhoPtScaledCut : public CutApplicatorWithEventContentBase {
 public:
   PhoGenericRhoPtScaledCut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -15,15 +15,13 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return PHOTON;
-  }
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
-  ThreadSafeStringCut<StringObjectFunction<reco::Photon>,reco::Photon> varFunc_;
+  ThreadSafeStringCut<StringObjectFunction<reco::Photon>, reco::Photon> varFunc_;
   bool lessThan_;
   //cut value is constTerm + linearRhoTerm_*rho + linearPtTerm*pt + quadraticPtTerm*pt*pt
-  //note EBEECutValues & Effective areas are conceptually the same thing, both are eta 
+  //note EBEECutValues & Effective areas are conceptually the same thing, both are eta
   //binned constants, just Effective areas have arbitary rather than barrel/endcap binnng
   EBEECutValues constTerm_;
   EffectiveAreas linearRhoTerm_;
@@ -33,46 +31,42 @@ private:
   edm::Handle<double> rhoHandle_;
 };
 
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoGenericRhoPtScaledCut, "PhoGenericRhoPtScaledCut");
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoGenericRhoPtScaledCut,
-		  "PhoGenericRhoPtScaledCut");
-
-PhoGenericRhoPtScaledCut::PhoGenericRhoPtScaledCut(const edm::ParameterSet& params) :
-  CutApplicatorWithEventContentBase(params),
-  varFunc_(params.getParameter<std::string>("cutVariable")),
-  lessThan_(params.getParameter<bool>("lessThan")),
-  constTerm_(params,"constTerm"),
-  linearRhoTerm_(params.getParameter<edm::FileInPath>("effAreasConfigFile").fullPath()),
-  linearPtTerm_(params,"linearPtTerm"),
-  quadraticPtTerm_(params,"quadPtTerm")
-{
+PhoGenericRhoPtScaledCut::PhoGenericRhoPtScaledCut(const edm::ParameterSet& params)
+    : CutApplicatorWithEventContentBase(params),
+      varFunc_(params.getParameter<std::string>("cutVariable")),
+      lessThan_(params.getParameter<bool>("lessThan")),
+      constTerm_(params, "constTerm"),
+      linearRhoTerm_(params.getParameter<edm::FileInPath>("effAreasConfigFile").fullPath()),
+      linearPtTerm_(params, "linearPtTerm"),
+      quadraticPtTerm_(params, "quadPtTerm") {
   edm::InputTag rhoTag = params.getParameter<edm::InputTag>("rho");
-  contentTags_.emplace("rho",rhoTag);
+  contentTags_.emplace("rho", rhoTag);
 }
 
 void PhoGenericRhoPtScaledCut::setConsumes(edm::ConsumesCollector& cc) {
   auto rho = cc.consumes<double>(contentTags_["rho"]);
-  contentTokens_.emplace("rho",rho);
+  contentTokens_.emplace("rho", rho);
 }
 
-void PhoGenericRhoPtScaledCut::getEventContent(const edm::EventBase& ev) {  
-  ev.getByLabel(contentTags_["rho"],rhoHandle_);
+void PhoGenericRhoPtScaledCut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_["rho"], rhoHandle_);
 }
 
-CutApplicatorBase::result_type 
-PhoGenericRhoPtScaledCut::
-operator()(const reco::PhotonPtr& pho) const{  
+CutApplicatorBase::result_type PhoGenericRhoPtScaledCut::operator()(const reco::PhotonPtr& pho) const {
   const double rho = (*rhoHandle_);
-  
+
   const float var = varFunc_(*pho);
 
   const float et = pho->et();
   const float absEta = std::abs(pho->superCluster()->eta());
-  const float cutValue = constTerm_(pho) + linearRhoTerm_.getEffectiveArea(absEta)*rho + 
-                         linearPtTerm_(pho)*et + quadraticPtTerm_(pho)*et*et;
-  if(lessThan_) return var < cutValue;
-  else return var>=cutValue;
+  const float cutValue = constTerm_(pho) + linearRhoTerm_.getEffectiveArea(absEta) * rho + linearPtTerm_(pho) * et +
+                         quadraticPtTerm_(pho) * et * et;
+  if (lessThan_)
+    return var < cutValue;
+  else
+    return var >= cutValue;
 }
 
 double PhoGenericRhoPtScaledCut::value(const reco::CandidatePtr& cand) const {

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoHadronicOverEMCut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoHadronicOverEMCut.cc
@@ -3,41 +3,32 @@
 
 class PhoHadronicOverEMCut : public CutApplicatorBase {
 public:
-  PhoHadronicOverEMCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _hadronicOverEMCutValueEB(c.getParameter<double>("hadronicOverEMCutValueEB")),
-    _hadronicOverEMCutValueEE(c.getParameter<double>("hadronicOverEMCutValueEE")),
-    _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
-  }
-  
+  PhoHadronicOverEMCut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+        _hadronicOverEMCutValueEB(c.getParameter<double>("hadronicOverEMCutValueEB")),
+        _hadronicOverEMCutValueEE(c.getParameter<double>("hadronicOverEMCutValueEE")),
+        _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return PHOTON; 
-  }
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
-  const float _hadronicOverEMCutValueEB, _hadronicOverEMCutValueEE, _barrelCutOff;  
+  const float _hadronicOverEMCutValueEB, _hadronicOverEMCutValueEE, _barrelCutOff;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoHadronicOverEMCut,
-		  "PhoHadronicOverEMCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoHadronicOverEMCut, "PhoHadronicOverEMCut");
 
-CutApplicatorBase::result_type 
-PhoHadronicOverEMCut::
-operator()(const reco::PhotonPtr& cand) const { 
-  const float hadronicOverEMCutValue = 
-    ( std::abs(cand->superCluster()->eta()) < _barrelCutOff ? 
-      _hadronicOverEMCutValueEB : _hadronicOverEMCutValueEE );
+CutApplicatorBase::result_type PhoHadronicOverEMCut::operator()(const reco::PhotonPtr& cand) const {
+  const float hadronicOverEMCutValue =
+      (std::abs(cand->superCluster()->eta()) < _barrelCutOff ? _hadronicOverEMCutValueEB : _hadronicOverEMCutValueEE);
 
   return cand->hadronicOverEm() < hadronicOverEMCutValue;
 }
 
-double PhoHadronicOverEMCut::
-value(const reco::CandidatePtr& cand) const {
+double PhoHadronicOverEMCut::value(const reco::CandidatePtr& cand) const {
   reco::PhotonPtr pho(cand);
   return pho->hadronicOverEm();
 }

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoMVACut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoMVACut.cc
@@ -1,11 +1,10 @@
 #include "PhysicsTools/SelectorUtils/interface/CutApplicatorWithEventContentBase.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
-
 class PhoMVACut : public CutApplicatorWithEventContentBase {
 public:
   PhoMVACut(const edm::ParameterSet& c);
-  
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   void setConsumes(edm::ConsumesCollector&) final;
@@ -13,112 +12,93 @@ public:
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return PHOTON; 
-  }
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
-
   // Cut values
   const std::vector<double> _mvaCutValues;
 
   // Pre-computed MVA value map
   edm::Handle<edm::ValueMap<float> > _mvaValueMap;
   edm::Handle<edm::ValueMap<int> > _mvaCategoriesMap;
-
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoMVACut,
-		  "PhoMVACut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoMVACut, "PhoMVACut");
 
-PhoMVACut::PhoMVACut(const edm::ParameterSet& c) :
-  CutApplicatorWithEventContentBase(c),
-  _mvaCutValues(c.getParameter<std::vector<double> >("mvaCuts"))
-{
+PhoMVACut::PhoMVACut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c), _mvaCutValues(c.getParameter<std::vector<double> >("mvaCuts")) {
   edm::InputTag mvaValTag = c.getParameter<edm::InputTag>("mvaValueMapName");
-  contentTags_.emplace("mvaVal",mvaValTag);
-  
+  contentTags_.emplace("mvaVal", mvaValTag);
+
   edm::InputTag mvaCatTag = c.getParameter<edm::InputTag>("mvaCategoriesMapName");
-  contentTags_.emplace("mvaCat",mvaCatTag);
-  
+  contentTags_.emplace("mvaCat", mvaCatTag);
 }
 
 void PhoMVACut::setConsumes(edm::ConsumesCollector& cc) {
+  auto mvaVal = cc.consumes<edm::ValueMap<float> >(contentTags_["mvaVal"]);
+  contentTokens_.emplace("mvaVal", mvaVal);
 
-  auto mvaVal = 
-    cc.consumes<edm::ValueMap<float> >(contentTags_["mvaVal"]);
-  contentTokens_.emplace("mvaVal",mvaVal);
-
-  auto mvaCat = 
-    cc.consumes<edm::ValueMap<int> >(contentTags_["mvaCat"]);
-  contentTokens_.emplace("mvaCat",mvaCat);
+  auto mvaCat = cc.consumes<edm::ValueMap<int> >(contentTags_["mvaCat"]);
+  contentTokens_.emplace("mvaCat", mvaCat);
 }
 
-void PhoMVACut::getEventContent(const edm::EventBase& ev) {  
-
-  ev.getByLabel(contentTags_["mvaVal"],_mvaValueMap);
-  ev.getByLabel(contentTags_["mvaCat"],_mvaCategoriesMap);
+void PhoMVACut::getEventContent(const edm::EventBase& ev) {
+  ev.getByLabel(contentTags_["mvaVal"], _mvaValueMap);
+  ev.getByLabel(contentTags_["mvaCat"], _mvaCategoriesMap);
 }
 
-CutApplicatorBase::result_type 
-PhoMVACut::
-operator()(const reco::PhotonPtr& cand) const{  
-
+CutApplicatorBase::result_type PhoMVACut::operator()(const reco::PhotonPtr& cand) const {
   // in case we are by-value
   const std::string& val_name = contentTags_.find("mvaVal")->second.instance();
   const std::string& cat_name = contentTags_.find("mvaCat")->second.instance();
   edm::Ptr<pat::Photon> pat(cand);
   float val = -1.0;
-  int   cat = -1;
-  if( _mvaCategoriesMap.isValid() && _mvaCategoriesMap->contains( cand.id() ) &&
-      _mvaValueMap.isValid() && _mvaValueMap->contains( cand.id() ) ) {
+  int cat = -1;
+  if (_mvaCategoriesMap.isValid() && _mvaCategoriesMap->contains(cand.id()) && _mvaValueMap.isValid() &&
+      _mvaValueMap->contains(cand.id())) {
     cat = (*_mvaCategoriesMap)[cand];
     val = (*_mvaValueMap)[cand];
-  } else if ( _mvaCategoriesMap.isValid() && _mvaValueMap.isValid() &&
-              _mvaCategoriesMap->idSize() == 1 && _mvaValueMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_mvaCategoriesMap.isValid() && _mvaValueMap.isValid() && _mvaCategoriesMap->idSize() == 1 &&
+             _mvaValueMap->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     cat = _mvaCategoriesMap->begin()[cand.key()];
     val = _mvaValueMap->begin()[cand.key()];
-  } else if ( _mvaCategoriesMap.isValid() && _mvaValueMap.isValid() ){ // throw an exception
+  } else if (_mvaCategoriesMap.isValid() && _mvaValueMap.isValid()) {  // throw an exception
     cat = (*_mvaCategoriesMap)[cand];
     val = (*_mvaValueMap)[cand];
   }
 
   // Find the cut value
-  const int iCategory = _mvaCategoriesMap.isValid() ? cat : pat->userInt( cat_name );
-  if( iCategory >= (int)(_mvaCutValues.size()) )
+  const int iCategory = _mvaCategoriesMap.isValid() ? cat : pat->userInt(cat_name);
+  if (iCategory >= (int)(_mvaCutValues.size()))
     throw cms::Exception(" Error in MVA categories: ")
-      << " found a particle with a category larger than max configured " << std::endl;
+        << " found a particle with a category larger than max configured " << std::endl;
   const float cutValue = _mvaCutValues[iCategory];
 
   // Look up the MVA value for this particle
-  const float mvaValue = _mvaValueMap.isValid() ? val : pat->userFloat( val_name );
+  const float mvaValue = _mvaValueMap.isValid() ? val : pat->userFloat(val_name);
 
   // Apply the cut and return the result
   return mvaValue > cutValue;
 }
 
 double PhoMVACut::value(const reco::CandidatePtr& cand) const {
-  
   // in case we are by-value
-  const std::string& val_name =contentTags_.find("mvaVal")->second.instance();
+  const std::string& val_name = contentTags_.find("mvaVal")->second.instance();
   edm::Ptr<pat::Photon> pat(cand);
   float val = 0.0;
-  if( _mvaCategoriesMap.isValid() && _mvaCategoriesMap->contains( cand.id() ) &&
-      _mvaValueMap.isValid() && _mvaValueMap->contains( cand.id() ) ) {
+  if (_mvaCategoriesMap.isValid() && _mvaCategoriesMap->contains(cand.id()) && _mvaValueMap.isValid() &&
+      _mvaValueMap->contains(cand.id())) {
     val = (*_mvaValueMap)[cand];
-  } else if ( _mvaCategoriesMap.isValid() && _mvaValueMap.isValid() &&
-              _mvaCategoriesMap->idSize() == 1 && _mvaValueMap->idSize() == 1 &&
-              cand.id() == edm::ProductID() ) {
+  } else if (_mvaCategoriesMap.isValid() && _mvaValueMap.isValid() && _mvaCategoriesMap->idSize() == 1 &&
+             _mvaValueMap->idSize() == 1 && cand.id() == edm::ProductID()) {
     // in case we have spoofed a ptr
     //note this must be a 1:1 valuemap (only one product input)
     val = _mvaValueMap->begin()[cand.key()];
-  } else if ( _mvaCategoriesMap.isValid() && _mvaValueMap.isValid() ) {
+  } else if (_mvaCategoriesMap.isValid() && _mvaValueMap.isValid()) {
     val = (*_mvaValueMap)[cand];
   }
-  const float mvaValue = _mvaValueMap.isValid() ? val : pat->userFloat( val_name );
+  const float mvaValue = _mvaValueMap.isValid() ? val : pat->userFloat(val_name);
   return mvaValue;
 }

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoSCEtaMultiRangeCut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoSCEtaMultiRangeCut.cc
@@ -3,52 +3,43 @@
 
 class PhoSCEtaMultiRangeCut : public CutApplicatorBase {
 public:
-  PhoSCEtaMultiRangeCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _absEta(c.getParameter<bool>("useAbsEta")) {
-    const std::vector<edm::ParameterSet>& ranges =
-      c.getParameterSetVector("allowedEtaRanges");
-    for( const auto& range : ranges ) {
+  PhoSCEtaMultiRangeCut(const edm::ParameterSet& c) : CutApplicatorBase(c), _absEta(c.getParameter<bool>("useAbsEta")) {
+    const std::vector<edm::ParameterSet>& ranges = c.getParameterSetVector("allowedEtaRanges");
+    for (const auto& range : ranges) {
       const double min = range.getParameter<double>("minEta");
       const double max = range.getParameter<double>("maxEta");
-      _ranges.emplace_back(min,max);
+      _ranges.emplace_back(min, max);
     }
   }
-  
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return PHOTON; 
-  }
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
   const bool _absEta;
-  std::vector<std::pair<double,double> > _ranges; 
+  std::vector<std::pair<double, double> > _ranges;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoSCEtaMultiRangeCut,
-		  "PhoSCEtaMultiRangeCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoSCEtaMultiRangeCut, "PhoSCEtaMultiRangeCut");
 
-CutApplicatorBase::result_type 
-PhoSCEtaMultiRangeCut::
-operator()(const reco::PhotonPtr& cand) const{
+CutApplicatorBase::result_type PhoSCEtaMultiRangeCut::operator()(const reco::PhotonPtr& cand) const {
   const reco::SuperClusterRef& scref = cand->superCluster();
-  const double the_eta = ( _absEta ? std::abs(scref->eta()) : scref->eta() );
+  const double the_eta = (_absEta ? std::abs(scref->eta()) : scref->eta());
   bool result = false;
-  for(const auto& range : _ranges ) {
-    if( the_eta >= range.first && the_eta < range.second ) {
-      result = true; break;
+  for (const auto& range : _ranges) {
+    if (the_eta >= range.first && the_eta < range.second) {
+      result = true;
+      break;
     }
   }
   return result;
 }
 
-double PhoSCEtaMultiRangeCut::
-value(const reco::CandidatePtr& cand) const {
+double PhoSCEtaMultiRangeCut::value(const reco::CandidatePtr& cand) const {
   reco::PhotonPtr pho(cand);
   const reco::SuperClusterRef& scref = pho->superCluster();
-  return ( _absEta ? std::abs(scref->eta()) : scref->eta() );
+  return (_absEta ? std::abs(scref->eta()) : scref->eta());
 }

--- a/RecoEgamma/PhotonIdentification/plugins/cuts/PhoSingleTowerHadOverEmCut.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/cuts/PhoSingleTowerHadOverEmCut.cc
@@ -3,41 +3,32 @@
 
 class PhoSingleTowerHadOverEmCut : public CutApplicatorBase {
 public:
-  PhoSingleTowerHadOverEmCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _hadronicOverEMCutValueEB(c.getParameter<double>("hadronicOverEMCutValueEB")),
-    _hadronicOverEMCutValueEE(c.getParameter<double>("hadronicOverEMCutValueEE")),
-    _barrelCutOff(c.getParameter<double>("barrelCutOff")) {
-  }
-  
+  PhoSingleTowerHadOverEmCut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+        _hadronicOverEMCutValueEB(c.getParameter<double>("hadronicOverEMCutValueEB")),
+        _hadronicOverEMCutValueEE(c.getParameter<double>("hadronicOverEMCutValueEE")),
+        _barrelCutOff(c.getParameter<double>("barrelCutOff")) {}
+
   result_type operator()(const reco::PhotonPtr&) const final;
 
   double value(const reco::CandidatePtr& cand) const final;
 
-  CandidateType candidateType() const final { 
-    return PHOTON; 
-  }
+  CandidateType candidateType() const final { return PHOTON; }
 
 private:
-  const float _hadronicOverEMCutValueEB, _hadronicOverEMCutValueEE, _barrelCutOff;  
+  const float _hadronicOverEMCutValueEB, _hadronicOverEMCutValueEE, _barrelCutOff;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  PhoSingleTowerHadOverEmCut,
-		  "PhoSingleTowerHadOverEmCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PhoSingleTowerHadOverEmCut, "PhoSingleTowerHadOverEmCut");
 
-CutApplicatorBase::result_type 
-PhoSingleTowerHadOverEmCut::
-operator()(const reco::PhotonPtr& cand) const { 
-  const float hadronicOverEMCutValue = 
-    ( std::abs(cand->superCluster()->eta()) < _barrelCutOff ? 
-      _hadronicOverEMCutValueEB : _hadronicOverEMCutValueEE );
+CutApplicatorBase::result_type PhoSingleTowerHadOverEmCut::operator()(const reco::PhotonPtr& cand) const {
+  const float hadronicOverEMCutValue =
+      (std::abs(cand->superCluster()->eta()) < _barrelCutOff ? _hadronicOverEMCutValueEB : _hadronicOverEMCutValueEE);
 
   return cand->hadTowOverEm() < hadronicOverEMCutValue;
 }
 
-double PhoSingleTowerHadOverEmCut::
-value(const reco::CandidatePtr& cand) const {
+double PhoSingleTowerHadOverEmCut::value(const reco::CandidatePtr& cand) const {
   reco::PhotonPtr pho(cand);
   return pho->hadTowOverEm();
 }

--- a/RecoEgamma/PhotonIdentification/src/CutBasedPhotonIDAlgo.cc
+++ b/RecoEgamma/PhotonIdentification/src/CutBasedPhotonIDAlgo.cc
@@ -2,11 +2,7 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 
-
-
-void CutBasedPhotonIDAlgo::setup(const edm::ParameterSet& conf) {
-  
-
+void CutBasedPhotonIDAlgo::setup(const edm::ParameterSet &conf) {
   //Decision cuts
   dophotonEcalRecHitIsolationCut_ = conf.getParameter<bool>("DoEcalRecHitIsolationCut");
   dophotonHcalTowerIsolationCut_ = conf.getParameter<bool>("DoHcalTowerIsolationCut");
@@ -48,7 +44,6 @@ void CutBasedPhotonIDAlgo::setup(const edm::ParameterSet& conf) {
   loosephotonEtaWidthCutEB_ = conf.getParameter<double>("LoosePhotonEtaWidthEB");
   loosephotonHadOverEMCutEB_ = conf.getParameter<double>("LoosePhotonHadOverEMEB");
   loosephotonR9CutEB_ = conf.getParameter<double>("LoosePhotonR9CutEB");
-
 
   tightphotonEcalIsoRelativeCutSlopeEB_ = conf.getParameter<double>("TightPhotonEcalIsoRelativeCutSlopeEB");
   tightphotonEcalIsoRelativeCutOffsetEB_ = conf.getParameter<double>("TightPhotonEcalIsoRelativeCutOffsetEB");
@@ -109,34 +104,31 @@ void CutBasedPhotonIDAlgo::setup(const edm::ParameterSet& conf) {
   tightphotonEtaWidthCutEE_ = conf.getParameter<double>("TightPhotonEtaWidthEE");
   tightphotonHadOverEMCutEE_ = conf.getParameter<double>("TightPhotonHadOverEMEE");
   tightphotonR9CutEE_ = conf.getParameter<double>("TightPhotonR9CutEE");
-
 }
 
-void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool &LoosePhoton, bool &TightPhoton){
-
-
+void CutBasedPhotonIDAlgo::decideEB(const reco::Photon *pho, bool &LooseEM, bool &LoosePhoton, bool &TightPhoton) {
   ////////////
   //If one has selected to apply fiducial cuts, they will be
   //applied for all loosePhoton, tightPhoton.
   //Consider yourself warned!
   ///////////
-  
+
   //Require supercluster is within fiducial volume.
-  if(dorequireFiducial_){
+  if (dorequireFiducial_) {
     if (pho->isEBEEGap()) {
-      LooseEM     = false;
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
     }
-    if ( pho->isEBEtaGap() || pho->isEBPhiGap() ){
-      LooseEM     = false;
+    if (pho->isEBEtaGap() || pho->isEBPhiGap()) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
     }
-    if ( pho->isEERingGap() || pho->isEEDeeGap()  ){
-      LooseEM     = false;
+    if (pho->isEERingGap() || pho->isEEDeeGap()) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -150,21 +142,21 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   //by definition it is also not LoosePhoton or TightPhoton
 
   //Cut on the sum of ecal rec hits in a cone
-  if(dophotonEcalRecHitIsolationCut_){
-    double cutvalue = looseEMEcalIsoRelativeCutSlopeEB_*pho->pt() + looseEMEcalIsoRelativeCutOffsetEB_;
-    if(pho->ecalRecHitSumEtConeDR04() > cutvalue){
-      LooseEM     = false;
+  if (dophotonEcalRecHitIsolationCut_) {
+    double cutvalue = looseEMEcalIsoRelativeCutSlopeEB_ * pho->pt() + looseEMEcalIsoRelativeCutOffsetEB_;
+    if (pho->ecalRecHitSumEtConeDR04() > cutvalue) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
     }
   }
-  
+
   //Cut on the sum of hcal rec hits in a cone (HBHE)
-  if(dophotonHcalTowerIsolationCut_){
-    double cutvalue = looseEMHcalTowerIsolationCutSlopeEB_*pho->pt() + looseEMHcalTowerIsolationCutOffsetEB_;
-    if(pho->hcalTowerSumEtConeDR04() > cutvalue){
-      LooseEM     = false;
+  if (dophotonHcalTowerIsolationCut_) {
+    double cutvalue = looseEMHcalTowerIsolationCutSlopeEB_ * pho->pt() + looseEMHcalTowerIsolationCutOffsetEB_;
+    if (pho->hcalTowerSumEtConeDR04() > cutvalue) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -172,9 +164,9 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on number of tracks within the solid cone.
-  if (dophotonSCNTrkCut_){
-    if (pho->nTrkSolidConeDR04() > looseEMSolidConeNTrkCutEB_){
-      LooseEM     = false;
+  if (dophotonSCNTrkCut_) {
+    if (pho->nTrkSolidConeDR04() > looseEMSolidConeNTrkCutEB_) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -182,20 +174,20 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on number of tracks within the hollow cone.
-  if (dophotonHCNTrkCut_){
-    if (pho->nTrkHollowConeDR04() > looseEMHollowConeNTrkCutEB_){
-      LooseEM     = false;
+  if (dophotonHCNTrkCut_) {
+    if (pho->nTrkHollowConeDR04() > looseEMHollowConeNTrkCutEB_) {
+      LooseEM = false;
       LoosePhoton = false;
-      TightPhoton = false;    
+      TightPhoton = false;
       return;
     }
   }
- 
+
   //Cut on the sum of tracks within a solid cone
-  if (dophotonSCTrkIsolationCut_){
-    double cutvalue = looseEMSolidConeTrkIsolationSlopeEB_*pho->pt() + looseEMSolidConeTrkIsolationOffsetEB_;
-    if (pho->trkSumPtSolidConeDR04() > cutvalue){
-      LooseEM     = false;
+  if (dophotonSCTrkIsolationCut_) {
+    double cutvalue = looseEMSolidConeTrkIsolationSlopeEB_ * pho->pt() + looseEMSolidConeTrkIsolationOffsetEB_;
+    if (pho->trkSumPtSolidConeDR04() > cutvalue) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -203,21 +195,21 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on the sum of tracks within a hollow cone
-  if (dophotonHCTrkIsolationCut_){
-    double cutvalue = looseEMHollowConeTrkIsolationSlopeEB_*pho->pt() + looseEMHollowConeTrkIsolationOffsetEB_;
-    if (pho->trkSumPtHollowConeDR04() > cutvalue){
-      LooseEM     = false;
+  if (dophotonHCTrkIsolationCut_) {
+    double cutvalue = looseEMHollowConeTrkIsolationSlopeEB_ * pho->pt() + looseEMHollowConeTrkIsolationOffsetEB_;
+    if (pho->trkSumPtHollowConeDR04() > cutvalue) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
-    }  
+    }
   }
 
   //HadoverEM cut
-  if (dophotonHadOverEMCut_){
+  if (dophotonHadOverEMCut_) {
     float hadoverE = pho->hadronicOverEm();
-    if (hadoverE > looseEMHadOverEMCutEB_){
-      LooseEM     = false;
+    if (hadoverE > looseEMHadOverEMCutEB_) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -226,22 +218,21 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
 
   //eta width
 
-  if (dophotonsigmaeeCut_){
- 
+  if (dophotonsigmaeeCut_) {
     double sigmaee = pho->sigmaIetaIeta();
-    if (sigmaee > looseEMEtaWidthCutEB_){
-      LooseEM     = false;
+    if (sigmaee > looseEMEtaWidthCutEB_) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
     }
   }
   //R9 cut
-  if (dophotonR9Cut_){
-    if (pho->r9() < looseEMR9CutEB_){
-      LooseEM     = false;
+  if (dophotonR9Cut_) {
+    if (pho->r9() < looseEMR9CutEB_) {
+      LooseEM = false;
       LoosePhoton = false;
-      TightPhoton = false;      
+      TightPhoton = false;
       return;
     }
   }
@@ -253,19 +244,19 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   //TightPhoton!
   //////////////
   //Cut on the sum of ecal rec hits in a cone
-  if(dophotonEcalRecHitIsolationCut_){
-    double cutvalue = loosephotonEcalIsoRelativeCutSlopeEB_*pho->pt() + loosephotonEcalIsoRelativeCutOffsetEB_;
-    if(pho->ecalRecHitSumEtConeDR04() > cutvalue){
+  if (dophotonEcalRecHitIsolationCut_) {
+    double cutvalue = loosephotonEcalIsoRelativeCutSlopeEB_ * pho->pt() + loosephotonEcalIsoRelativeCutOffsetEB_;
+    if (pho->ecalRecHitSumEtConeDR04() > cutvalue) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
     }
   }
-  
+
   //Cut on the sum of hcal rec hits in a cone (HBHE)
-  if(dophotonHcalTowerIsolationCut_){
-    double cutvalue = loosephotonHcalTowerIsolationCutSlopeEB_*pho->pt() + loosephotonHcalTowerIsolationCutOffsetEB_;
-    if(pho->hcalTowerSumEtConeDR04() > cutvalue){
+  if (dophotonHcalTowerIsolationCut_) {
+    double cutvalue = loosephotonHcalTowerIsolationCutSlopeEB_ * pho->pt() + loosephotonHcalTowerIsolationCutOffsetEB_;
+    if (pho->hcalTowerSumEtConeDR04() > cutvalue) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -273,8 +264,8 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on number of tracks within the solid cone.
-  if (dophotonSCNTrkCut_){
-    if (pho->nTrkSolidConeDR04() > loosephotonSolidConeNTrkCutEB_){
+  if (dophotonSCNTrkCut_) {
+    if (pho->nTrkSolidConeDR04() > loosephotonSolidConeNTrkCutEB_) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -282,18 +273,18 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on number of tracks within the hollow cone.
-  if (dophotonHCNTrkCut_){
-    if (pho->nTrkHollowConeDR04() > loosephotonHollowConeNTrkCutEB_){
+  if (dophotonHCNTrkCut_) {
+    if (pho->nTrkHollowConeDR04() > loosephotonHollowConeNTrkCutEB_) {
       LoosePhoton = false;
-      TightPhoton = false;    
+      TightPhoton = false;
       return;
     }
   }
- 
+
   //Cut on the sum of tracks within a solid cone
-  if (dophotonSCTrkIsolationCut_){
-    double cutvalue = loosephotonSolidConeTrkIsolationSlopeEB_*pho->pt() + loosephotonSolidConeTrkIsolationOffsetEB_;
-    if (pho->trkSumPtSolidConeDR04() > cutvalue){
+  if (dophotonSCTrkIsolationCut_) {
+    double cutvalue = loosephotonSolidConeTrkIsolationSlopeEB_ * pho->pt() + loosephotonSolidConeTrkIsolationOffsetEB_;
+    if (pho->trkSumPtSolidConeDR04() > cutvalue) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -301,19 +292,20 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on the sum of tracks within a hollow cone
-  if (dophotonHCTrkIsolationCut_){
-    double cutvalue = loosephotonHollowConeTrkIsolationSlopeEB_*pho->pt() + loosephotonHollowConeTrkIsolationOffsetEB_;
-    if (pho->trkSumPtHollowConeDR04() > cutvalue){
+  if (dophotonHCTrkIsolationCut_) {
+    double cutvalue =
+        loosephotonHollowConeTrkIsolationSlopeEB_ * pho->pt() + loosephotonHollowConeTrkIsolationOffsetEB_;
+    if (pho->trkSumPtHollowConeDR04() > cutvalue) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
-    }  
+    }
   }
 
   //HadoverEM cut
-  if (dophotonHadOverEMCut_){
+  if (dophotonHadOverEMCut_) {
     float hadoverE = pho->hadronicOverEm();
-    if (hadoverE > loosephotonHadOverEMCutEB_){
+    if (hadoverE > loosephotonHadOverEMCutEB_) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -322,20 +314,19 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
 
   //eta width
 
-  if (dophotonsigmaeeCut_){
- 
+  if (dophotonsigmaeeCut_) {
     double sigmaee = pho->sigmaIetaIeta();
-    if (sigmaee > loosephotonEtaWidthCutEB_){
+    if (sigmaee > loosephotonEtaWidthCutEB_) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
     }
   }
   //R9 cut
-  if (dophotonR9Cut_){
-    if (pho->r9() < loosephotonR9CutEB_){
+  if (dophotonR9Cut_) {
+    if (pho->r9() < loosephotonR9CutEB_) {
       LoosePhoton = false;
-      TightPhoton = false;      
+      TightPhoton = false;
       return;
     }
   }
@@ -349,10 +340,10 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   //and once more one assumes that these criteria are
   //tighter than loose.
   //////////////
-    //Cut on the sum of ecal rec hits in a cone
-  if(dophotonEcalRecHitIsolationCut_){
-    double cutvalue = tightphotonEcalIsoRelativeCutSlopeEB_*pho->pt() + tightphotonEcalIsoRelativeCutOffsetEB_;
-    if(pho->ecalRecHitSumEtConeDR04() > cutvalue){
+  //Cut on the sum of ecal rec hits in a cone
+  if (dophotonEcalRecHitIsolationCut_) {
+    double cutvalue = tightphotonEcalIsoRelativeCutSlopeEB_ * pho->pt() + tightphotonEcalIsoRelativeCutOffsetEB_;
+    if (pho->ecalRecHitSumEtConeDR04() > cutvalue) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
@@ -360,9 +351,9 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on the sum of hcal rec hits in a cone (HBHE)
-  if(dophotonHcalTowerIsolationCut_){
-    double cutvalue = tightphotonHcalTowerIsolationCutSlopeEB_*pho->pt() + tightphotonHcalTowerIsolationCutOffsetEB_;
-    if(pho->hcalTowerSumEtConeDR04() > cutvalue){
+  if (dophotonHcalTowerIsolationCut_) {
+    double cutvalue = tightphotonHcalTowerIsolationCutSlopeEB_ * pho->pt() + tightphotonHcalTowerIsolationCutOffsetEB_;
+    if (pho->hcalTowerSumEtConeDR04() > cutvalue) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
@@ -370,8 +361,8 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on number of tracks within the solid cone.
-  if (dophotonSCNTrkCut_){
-    if (pho->nTrkSolidConeDR04() > tightphotonSolidConeNTrkCutEB_){
+  if (dophotonSCNTrkCut_) {
+    if (pho->nTrkSolidConeDR04() > tightphotonSolidConeNTrkCutEB_) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
@@ -379,18 +370,18 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on number of tracks within the hollow cone.
-  if (dophotonHCNTrkCut_){
-    if (pho->nTrkHollowConeDR04() > tightphotonHollowConeNTrkCutEB_){
+  if (dophotonHCNTrkCut_) {
+    if (pho->nTrkHollowConeDR04() > tightphotonHollowConeNTrkCutEB_) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
     }
   }
-  
+
   //Cut on the sum of tracks within a solid cone
-  if (dophotonSCTrkIsolationCut_){
-    double cutvalue = tightphotonSolidConeTrkIsolationSlopeEB_*pho->pt() + tightphotonSolidConeTrkIsolationOffsetEB_;
-    if (pho->trkSumPtSolidConeDR04() > cutvalue){
+  if (dophotonSCTrkIsolationCut_) {
+    double cutvalue = tightphotonSolidConeTrkIsolationSlopeEB_ * pho->pt() + tightphotonSolidConeTrkIsolationOffsetEB_;
+    if (pho->trkSumPtSolidConeDR04() > cutvalue) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
@@ -398,19 +389,20 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on the sum of tracks within a hollow cone
-  if (dophotonHCTrkIsolationCut_){
-    double cutvalue = tightphotonHollowConeTrkIsolationSlopeEB_*pho->pt() + tightphotonHollowConeTrkIsolationOffsetEB_;
-    if (pho->trkSumPtHollowConeDR04() > cutvalue){
+  if (dophotonHCTrkIsolationCut_) {
+    double cutvalue =
+        tightphotonHollowConeTrkIsolationSlopeEB_ * pho->pt() + tightphotonHollowConeTrkIsolationOffsetEB_;
+    if (pho->trkSumPtHollowConeDR04() > cutvalue) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
-    }  
+    }
   }
 
   //HadoverEM cut
-  if (dophotonHadOverEMCut_){
+  if (dophotonHadOverEMCut_) {
     float hadoverE = pho->hadronicOverEm();
-    if (hadoverE > tightphotonHadOverEMCutEB_){
+    if (hadoverE > tightphotonHadOverEMCutEB_) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
@@ -419,17 +411,17 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
 
   //eta width
 
-  if (dophotonsigmaeeCut_){
+  if (dophotonsigmaeeCut_) {
     double sigmaee = pho->sigmaIetaIeta();
-    if (sigmaee > tightphotonEtaWidthCutEB_){
+    if (sigmaee > tightphotonEtaWidthCutEB_) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
     }
   }
   //R9 cut
-  if (dophotonR9Cut_){
-    if (pho->r9() < tightphotonR9CutEB_){
+  if (dophotonR9Cut_) {
+    if (pho->r9() < tightphotonR9CutEB_) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
@@ -438,13 +430,9 @@ void CutBasedPhotonIDAlgo::decideEB(const reco::Photon* pho, bool &LooseEM, bool
 
   //if you got here, you must have passed all cuts!
   TightPhoton = true;
-  
 }
 
-
-
-void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool &LoosePhoton, bool &TightPhoton){
-  
+void CutBasedPhotonIDAlgo::decideEE(const reco::Photon *pho, bool &LooseEM, bool &LoosePhoton, bool &TightPhoton) {
   ////////////
   //If one has selected to apply fiducial cuts, they will be
   //applied for all , loosePhoton, tightPhoton.
@@ -452,22 +440,22 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   ///////////
 
   //Require supercluster is within fiducial volume.
-  if(dorequireFiducial_){
+  if (dorequireFiducial_) {
     if (pho->isEBEEGap()) {
-      LooseEM     = false;
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
-      
+
       return;
     }
-    if ( pho->isEBEtaGap() ||  pho->isEBPhiGap() ){
-      LooseEM     = false;
+    if (pho->isEBEtaGap() || pho->isEBPhiGap()) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
     }
-    if (pho->isEERingGap() || pho->isEEDeeGap() ){
-      LooseEM     = false;
+    if (pho->isEERingGap() || pho->isEEDeeGap()) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -477,21 +465,21 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   //Done with fiducial cuts.
   //////////////
   //Do LooseEM selection.  By definition, if a photon does not pass LooseEM, it does not pass LoosePhoton or TightPhoton!
-  if(dophotonEcalRecHitIsolationCut_){
-    double cutvalue = looseEMEcalIsoRelativeCutSlopeEE_*pho->pt() + looseEMEcalIsoRelativeCutOffsetEE_;
-    if(pho->ecalRecHitSumEtConeDR04() > cutvalue){
-      LooseEM     = false;
+  if (dophotonEcalRecHitIsolationCut_) {
+    double cutvalue = looseEMEcalIsoRelativeCutSlopeEE_ * pho->pt() + looseEMEcalIsoRelativeCutOffsetEE_;
+    if (pho->ecalRecHitSumEtConeDR04() > cutvalue) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
     }
   }
-  
+
   //Cut on the sum of hcal towers in a cone (HBHE)
-  if(dophotonHcalTowerIsolationCut_){
-    double cutvalue = looseEMHcalTowerIsolationCutSlopeEE_*pho->pt() + looseEMHcalTowerIsolationCutOffsetEE_;
-    if(pho->hcalTowerSumEtConeDR04() > cutvalue){
-      LooseEM     = false;
+  if (dophotonHcalTowerIsolationCut_) {
+    double cutvalue = looseEMHcalTowerIsolationCutSlopeEE_ * pho->pt() + looseEMHcalTowerIsolationCutOffsetEE_;
+    if (pho->hcalTowerSumEtConeDR04() > cutvalue) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -499,31 +487,30 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on number of tracks within the solid cone.
-  if (dophotonSCNTrkCut_){
-    if (pho->nTrkSolidConeDR04() > looseEMSolidConeNTrkCutEE_){
-      LooseEM     = false;
+  if (dophotonSCNTrkCut_) {
+    if (pho->nTrkSolidConeDR04() > looseEMSolidConeNTrkCutEE_) {
+      LooseEM = false;
       LoosePhoton = false;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
 
   //Cut on number of tracks within the hollow cone.
-  if (dophotonHCNTrkCut_){
-    if (pho->nTrkHollowConeDR04() > looseEMHollowConeNTrkCutEE_){
-      LooseEM     = false;
+  if (dophotonHCNTrkCut_) {
+    if (pho->nTrkHollowConeDR04() > looseEMHollowConeNTrkCutEE_) {
+      LooseEM = false;
       LoosePhoton = false;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
-  
 
   //Cut on the sum of tracks within a solid cone
-  if (dophotonSCTrkIsolationCut_){
-    double cutvalue = looseEMSolidConeTrkIsolationSlopeEE_*pho->pt() + looseEMSolidConeTrkIsolationOffsetEE_;
-    if (pho->trkSumPtSolidConeDR04() > cutvalue){
-      LooseEM     = false;
+  if (dophotonSCTrkIsolationCut_) {
+    double cutvalue = looseEMSolidConeTrkIsolationSlopeEE_ * pho->pt() + looseEMSolidConeTrkIsolationOffsetEE_;
+    if (pho->trkSumPtSolidConeDR04() > cutvalue) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -531,46 +518,45 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on the sum of tracks within a hollow cone
-  if (dophotonHCTrkIsolationCut_){
-    double cutvalue = looseEMHollowConeTrkIsolationSlopeEE_*pho->pt() + looseEMHollowConeTrkIsolationOffsetEE_;
-    if (pho->trkSumPtHollowConeDR04() > cutvalue){
-      LooseEM     = false;
+  if (dophotonHCTrkIsolationCut_) {
+    double cutvalue = looseEMHollowConeTrkIsolationSlopeEE_ * pho->pt() + looseEMHollowConeTrkIsolationOffsetEE_;
+    if (pho->trkSumPtHollowConeDR04() > cutvalue) {
+      LooseEM = false;
       LoosePhoton = false;
       TightPhoton = false;
       return;
-    }  
+    }
   }
 
   //HadoverEM cut
-  if (dophotonHadOverEMCut_){
+  if (dophotonHadOverEMCut_) {
     float hadoverE = pho->hadronicOverEm();
-    if (hadoverE > looseEMHadOverEMCutEE_){
-      LooseEM     = false;
+    if (hadoverE > looseEMHadOverEMCutEE_) {
+      LooseEM = false;
       LoosePhoton = false;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
 
   //eta width
 
-  if (dophotonsigmaeeCut_){
-    
+  if (dophotonsigmaeeCut_) {
     double sigmaee = pho->sigmaIetaIeta();
-  
-    if (sigmaee > looseEMEtaWidthCutEE_){
-      LooseEM     = false;
+
+    if (sigmaee > looseEMEtaWidthCutEE_) {
+      LooseEM = false;
       LoosePhoton = false;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
   //R9 cut
-  if (dophotonR9Cut_){
-    if (pho->r9() < looseEMR9CutEE_){
-      LooseEM     = false;
+  if (dophotonR9Cut_) {
+    if (pho->r9() < looseEMR9CutEE_) {
+      LooseEM = false;
       LoosePhoton = false;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
@@ -581,19 +567,19 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   //TightPhoton!
   //////////////
 
-  if(dophotonEcalRecHitIsolationCut_){
-    double cutvalue = loosephotonEcalIsoRelativeCutSlopeEE_*pho->pt() + loosephotonEcalIsoRelativeCutOffsetEE_;
-    if(pho->ecalRecHitSumEtConeDR04() > cutvalue){
+  if (dophotonEcalRecHitIsolationCut_) {
+    double cutvalue = loosephotonEcalIsoRelativeCutSlopeEE_ * pho->pt() + loosephotonEcalIsoRelativeCutOffsetEE_;
+    if (pho->ecalRecHitSumEtConeDR04() > cutvalue) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
     }
   }
-  
+
   //Cut on the sum of hcal rec hits in a cone (HBHE)
-  if(dophotonHcalTowerIsolationCut_){
-    double cutvalue = loosephotonHcalTowerIsolationCutSlopeEE_*pho->pt() + loosephotonHcalTowerIsolationCutOffsetEE_;
-    if(pho->hcalTowerSumEtConeDR04() > cutvalue){
+  if (dophotonHcalTowerIsolationCut_) {
+    double cutvalue = loosephotonHcalTowerIsolationCutSlopeEE_ * pho->pt() + loosephotonHcalTowerIsolationCutOffsetEE_;
+    if (pho->hcalTowerSumEtConeDR04() > cutvalue) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -601,28 +587,27 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on number of tracks within the solid cone.
-  if (dophotonSCNTrkCut_){
-    if (pho->nTrkSolidConeDR04() > loosephotonSolidConeNTrkCutEE_){
+  if (dophotonSCNTrkCut_) {
+    if (pho->nTrkSolidConeDR04() > loosephotonSolidConeNTrkCutEE_) {
       LoosePhoton = false;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
 
   //Cut on number of tracks within the hollow cone.
-  if (dophotonHCNTrkCut_){
-    if (pho->nTrkHollowConeDR04() > loosephotonHollowConeNTrkCutEE_){
+  if (dophotonHCNTrkCut_) {
+    if (pho->nTrkHollowConeDR04() > loosephotonHollowConeNTrkCutEE_) {
       LoosePhoton = false;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
-  
 
   //Cut on the sum of tracks within a solid cone
-  if (dophotonSCTrkIsolationCut_){
-    double cutvalue = loosephotonSolidConeTrkIsolationSlopeEE_*pho->pt() + loosephotonSolidConeTrkIsolationOffsetEE_;
-    if (pho->trkSumPtSolidConeDR04() > cutvalue){
+  if (dophotonSCTrkIsolationCut_) {
+    double cutvalue = loosephotonSolidConeTrkIsolationSlopeEE_ * pho->pt() + loosephotonSolidConeTrkIsolationOffsetEE_;
+    if (pho->trkSumPtSolidConeDR04() > cutvalue) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
@@ -630,42 +615,42 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on the sum of tracks within a hollow cone
-  if (dophotonHCTrkIsolationCut_){
-    double cutvalue = loosephotonHollowConeTrkIsolationSlopeEE_*pho->pt() + loosephotonHollowConeTrkIsolationOffsetEE_;
-    if (pho->trkSumPtHollowConeDR04() > cutvalue){
+  if (dophotonHCTrkIsolationCut_) {
+    double cutvalue =
+        loosephotonHollowConeTrkIsolationSlopeEE_ * pho->pt() + loosephotonHollowConeTrkIsolationOffsetEE_;
+    if (pho->trkSumPtHollowConeDR04() > cutvalue) {
       LoosePhoton = false;
       TightPhoton = false;
       return;
-    }  
+    }
   }
 
   //HadoverEM cut
-  if (dophotonHadOverEMCut_){
+  if (dophotonHadOverEMCut_) {
     float hadoverE = pho->hadronicOverEm();
-    if (hadoverE > loosephotonHadOverEMCutEE_){
+    if (hadoverE > loosephotonHadOverEMCutEE_) {
       LoosePhoton = false;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
 
   //eta width
 
-  if (dophotonsigmaeeCut_){
-    
+  if (dophotonsigmaeeCut_) {
     double sigmaee = pho->sigmaIetaIeta();
-  
-    if (sigmaee > loosephotonEtaWidthCutEE_){
+
+    if (sigmaee > loosephotonEtaWidthCutEE_) {
       LoosePhoton = false;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
   //R9 cut
-  if (dophotonR9Cut_){
-    if (pho->r9() < loosephotonR9CutEE_){
+  if (dophotonR9Cut_) {
+    if (pho->r9() < loosephotonR9CutEE_) {
       LoosePhoton = false;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
@@ -678,9 +663,9 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   //and once more one assumes that these criteria are
   //tighter than loose.
   //////////////
-  if(dophotonEcalRecHitIsolationCut_){
-    double cutvalue = tightphotonEcalIsoRelativeCutSlopeEE_*pho->pt() + tightphotonEcalIsoRelativeCutOffsetEE_;
-    if(pho->ecalRecHitSumEtConeDR04() > cutvalue){
+  if (dophotonEcalRecHitIsolationCut_) {
+    double cutvalue = tightphotonEcalIsoRelativeCutSlopeEE_ * pho->pt() + tightphotonEcalIsoRelativeCutOffsetEE_;
+    if (pho->ecalRecHitSumEtConeDR04() > cutvalue) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
@@ -688,9 +673,9 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on the sum of hcal rec hits in a cone (HBHE)
-  if(dophotonHcalTowerIsolationCut_){
-    double cutvalue = tightphotonHcalTowerIsolationCutSlopeEE_*pho->pt() + tightphotonHcalTowerIsolationCutOffsetEE_;
-    if(pho->hcalTowerSumEtConeDR04() > cutvalue){
+  if (dophotonHcalTowerIsolationCut_) {
+    double cutvalue = tightphotonHcalTowerIsolationCutSlopeEE_ * pho->pt() + tightphotonHcalTowerIsolationCutOffsetEE_;
+    if (pho->hcalTowerSumEtConeDR04() > cutvalue) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
@@ -698,28 +683,27 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on number of tracks within the solid cone.
-  if (dophotonSCNTrkCut_){
-    if (pho->nTrkSolidConeDR04() > tightphotonSolidConeNTrkCutEE_){
+  if (dophotonSCNTrkCut_) {
+    if (pho->nTrkSolidConeDR04() > tightphotonSolidConeNTrkCutEE_) {
       LoosePhoton = true;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
 
   //Cut on number of tracks within the hollow cone.
-  if (dophotonHCNTrkCut_){
-    if (pho->nTrkHollowConeDR04() > tightphotonHollowConeNTrkCutEE_){
+  if (dophotonHCNTrkCut_) {
+    if (pho->nTrkHollowConeDR04() > tightphotonHollowConeNTrkCutEE_) {
       LoosePhoton = true;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
-  
 
   //Cut on the sum of tracks within a solid cone
-  if (dophotonSCTrkIsolationCut_){
-    double cutvalue = tightphotonSolidConeTrkIsolationSlopeEE_*pho->pt() + tightphotonSolidConeTrkIsolationOffsetEE_;
-    if (pho->trkSumPtSolidConeDR04() > cutvalue){
+  if (dophotonSCTrkIsolationCut_) {
+    double cutvalue = tightphotonSolidConeTrkIsolationSlopeEE_ * pho->pt() + tightphotonSolidConeTrkIsolationOffsetEE_;
+    if (pho->trkSumPtSolidConeDR04() > cutvalue) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
@@ -727,48 +711,46 @@ void CutBasedPhotonIDAlgo::decideEE(const reco::Photon* pho, bool &LooseEM, bool
   }
 
   //Cut on the sum of tracks within a hollow cone
-  if (dophotonHCTrkIsolationCut_){
-    double cutvalue = tightphotonHollowConeTrkIsolationSlopeEE_*pho->pt() + tightphotonHollowConeTrkIsolationOffsetEE_;
-    if (pho->trkSumPtHollowConeDR04() > cutvalue){
+  if (dophotonHCTrkIsolationCut_) {
+    double cutvalue =
+        tightphotonHollowConeTrkIsolationSlopeEE_ * pho->pt() + tightphotonHollowConeTrkIsolationOffsetEE_;
+    if (pho->trkSumPtHollowConeDR04() > cutvalue) {
       LoosePhoton = true;
       TightPhoton = false;
       return;
-    }  
+    }
   }
 
-
   //HadoverEM cut
-  if (dophotonHadOverEMCut_){
+  if (dophotonHadOverEMCut_) {
     float hadoverE = pho->hadronicOverEm();
-    if (hadoverE > tightphotonHadOverEMCutEE_){
+    if (hadoverE > tightphotonHadOverEMCutEE_) {
       LoosePhoton = true;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
 
   //eta width
 
-  if (dophotonsigmaeeCut_){
-   
+  if (dophotonsigmaeeCut_) {
     double sigmaee = pho->sigmaIetaIeta();
-        
-    if (sigmaee > tightphotonEtaWidthCutEE_){
+
+    if (sigmaee > tightphotonEtaWidthCutEE_) {
       LoosePhoton = true;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
   //R9 cut
-  if (dophotonR9Cut_){
-    if (pho->r9() < tightphotonR9CutEE_){
+  if (dophotonR9Cut_) {
+    if (pho->r9() < tightphotonR9CutEE_) {
       LoosePhoton = true;
-      TightPhoton = false;  
+      TightPhoton = false;
       return;
     }
   }
 
   //if you got here, you must have passed all cuts!
-  TightPhoton = true;   
-  
+  TightPhoton = true;
 }

--- a/RecoEgamma/PhotonIdentification/src/PFPhotonIsolationCalculator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PFPhotonIsolationCalculator.cc
@@ -2,8 +2,6 @@
 #include <cmath>
 #include "DataFormats/Math/interface/deltaR.h"
 
-
-
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
@@ -15,61 +13,49 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 
-
-
 void PFPhotonIsolationCalculator::setup(const edm::ParameterSet& conf) {
- 
-
- iParticleType_ = conf.getParameter<int>("particleType");
-  if (  iParticleType_ ==1 ) { 
-
-    fConeSize_     = conf.getParameter<double>("coneDR");
+  iParticleType_ = conf.getParameter<int>("particleType");
+  if (iParticleType_ == 1) {
+    fConeSize_ = conf.getParameter<double>("coneDR");
     iNumberOfRings_ = conf.getParameter<int>("numberOfRings");
-    fRingSize_     = conf.getParameter<double>("ringSize");
+    fRingSize_ = conf.getParameter<double>("ringSize");
     //
-    bApplyVeto_    = conf.getParameter<bool>("applyVeto");
-    bApplyPFPUVeto_    = conf.getParameter<bool>("applyPFPUVeto");
-    bApplyDzDxyVeto_    = conf.getParameter<bool>("applyDzDxyVeto");
-    bApplyMissHitPhVeto_    = conf.getParameter<bool>("applyMissHitPhVeto");
-    bDeltaRVetoBarrel_    = conf.getParameter<bool>("deltaRVetoBarrel");
-    bDeltaRVetoEndcap_    = conf.getParameter<bool>("deltaRVetoEndcap");
-    bRectangleVetoBarrel_    = conf.getParameter<bool>("rectangleVetoBarrel");
-    bRectangleVetoEndcap_    = conf.getParameter<bool>("rectangleVetoEndcap");
-    bUseCrystalSize_    = conf.getParameter<bool>("useCrystalSize");
+    bApplyVeto_ = conf.getParameter<bool>("applyVeto");
+    bApplyPFPUVeto_ = conf.getParameter<bool>("applyPFPUVeto");
+    bApplyDzDxyVeto_ = conf.getParameter<bool>("applyDzDxyVeto");
+    bApplyMissHitPhVeto_ = conf.getParameter<bool>("applyMissHitPhVeto");
+    bDeltaRVetoBarrel_ = conf.getParameter<bool>("deltaRVetoBarrel");
+    bDeltaRVetoEndcap_ = conf.getParameter<bool>("deltaRVetoEndcap");
+    bRectangleVetoBarrel_ = conf.getParameter<bool>("rectangleVetoBarrel");
+    bRectangleVetoEndcap_ = conf.getParameter<bool>("rectangleVetoEndcap");
+    bUseCrystalSize_ = conf.getParameter<bool>("useCrystalSize");
     //
-    fDeltaRVetoBarrelPhotons_    = conf.getParameter<double>("deltaRVetoBarrelPhotons");   
-    fDeltaRVetoBarrelNeutrals_    = conf.getParameter<double>("deltaRVetoBarrelNeutrals");   
-    fDeltaRVetoBarrelCharged_    = conf.getParameter<double>("deltaRVetoBarrelCharged");   
-    fDeltaRVetoEndcapPhotons_    = conf.getParameter<double>("deltaRVetoEndcapPhotons");   
-    fDeltaRVetoEndcapNeutrals_    = conf.getParameter<double>("deltaRVetoEndcapNeutrals");   
-    fDeltaRVetoEndcapCharged_    = conf.getParameter<double>("deltaRVetoEndcapCharged");   
-    fNumberOfCrystalEndcapPhotons_ = conf.getParameter<double>("numberOfCrystalEndcapPhotons");  
+    fDeltaRVetoBarrelPhotons_ = conf.getParameter<double>("deltaRVetoBarrelPhotons");
+    fDeltaRVetoBarrelNeutrals_ = conf.getParameter<double>("deltaRVetoBarrelNeutrals");
+    fDeltaRVetoBarrelCharged_ = conf.getParameter<double>("deltaRVetoBarrelCharged");
+    fDeltaRVetoEndcapPhotons_ = conf.getParameter<double>("deltaRVetoEndcapPhotons");
+    fDeltaRVetoEndcapNeutrals_ = conf.getParameter<double>("deltaRVetoEndcapNeutrals");
+    fDeltaRVetoEndcapCharged_ = conf.getParameter<double>("deltaRVetoEndcapCharged");
+    fNumberOfCrystalEndcapPhotons_ = conf.getParameter<double>("numberOfCrystalEndcapPhotons");
     //
-    fRectangleDeltaPhiVetoBarrelPhotons_    = conf.getParameter<double>("rectangleDeltaPhiVetoBarrelPhotons");
-    fRectangleDeltaPhiVetoBarrelNeutrals_   = conf.getParameter<double>("rectangleDeltaPhiVetoBarrelNeutrals");
-    fRectangleDeltaPhiVetoBarrelCharged_    = conf.getParameter<double>("rectangleDeltaPhiVetoBarrelCharged");
-    fRectangleDeltaPhiVetoEndcapPhotons_    = conf.getParameter<double>("rectangleDeltaPhiVetoEndcapPhotons");
-    fRectangleDeltaPhiVetoEndcapNeutrals_   = conf.getParameter<double>("rectangleDeltaPhiVetoEndcapNeutrals");
-    fRectangleDeltaPhiVetoEndcapCharged_    = conf.getParameter<double>("rectangleDeltaPhiVetoEndcapCharged");
+    fRectangleDeltaPhiVetoBarrelPhotons_ = conf.getParameter<double>("rectangleDeltaPhiVetoBarrelPhotons");
+    fRectangleDeltaPhiVetoBarrelNeutrals_ = conf.getParameter<double>("rectangleDeltaPhiVetoBarrelNeutrals");
+    fRectangleDeltaPhiVetoBarrelCharged_ = conf.getParameter<double>("rectangleDeltaPhiVetoBarrelCharged");
+    fRectangleDeltaPhiVetoEndcapPhotons_ = conf.getParameter<double>("rectangleDeltaPhiVetoEndcapPhotons");
+    fRectangleDeltaPhiVetoEndcapNeutrals_ = conf.getParameter<double>("rectangleDeltaPhiVetoEndcapNeutrals");
+    fRectangleDeltaPhiVetoEndcapCharged_ = conf.getParameter<double>("rectangleDeltaPhiVetoEndcapCharged");
     //
-    fRectangleDeltaEtaVetoBarrelPhotons_    = conf.getParameter<double>("rectangleDeltaEtaVetoBarrelPhotons");
-    fRectangleDeltaEtaVetoBarrelNeutrals_   = conf.getParameter<double>("rectangleDeltaEtaVetoBarrelNeutrals");
-    fRectangleDeltaEtaVetoBarrelCharged_    = conf.getParameter<double>("rectangleDeltaEtaVetoBarrelCharged");
-    fRectangleDeltaEtaVetoEndcapPhotons_    = conf.getParameter<double>("rectangleDeltaEtaVetoEndcapPhotons");
-    fRectangleDeltaEtaVetoEndcapNeutrals_   = conf.getParameter<double>("rectangleDeltaEtaVetoEndcapNeutrals");
-    fRectangleDeltaEtaVetoEndcapCharged_    = conf.getParameter<double>("rectangleDeltaEtaVetoEndcapCharged");
+    fRectangleDeltaEtaVetoBarrelPhotons_ = conf.getParameter<double>("rectangleDeltaEtaVetoBarrelPhotons");
+    fRectangleDeltaEtaVetoBarrelNeutrals_ = conf.getParameter<double>("rectangleDeltaEtaVetoBarrelNeutrals");
+    fRectangleDeltaEtaVetoBarrelCharged_ = conf.getParameter<double>("rectangleDeltaEtaVetoBarrelCharged");
+    fRectangleDeltaEtaVetoEndcapPhotons_ = conf.getParameter<double>("rectangleDeltaEtaVetoEndcapPhotons");
+    fRectangleDeltaEtaVetoEndcapNeutrals_ = conf.getParameter<double>("rectangleDeltaEtaVetoEndcapNeutrals");
+    fRectangleDeltaEtaVetoEndcapCharged_ = conf.getParameter<double>("rectangleDeltaEtaVetoEndcapCharged");
     //
-    bCheckClosestZVertex_    = conf.getParameter<bool>("checkClosestZVertex");
+    bCheckClosestZVertex_ = conf.getParameter<bool>("checkClosestZVertex");
     initializeRings(iNumberOfRings_, fConeSize_);
-    
-  }  
- 
-
-
-
+  }
 }
-
-
 
 //--------------------------------------------------------------------------------------------------
 
@@ -77,43 +63,30 @@ PFPhotonIsolationCalculator::PFPhotonIsolationCalculator() {
   // Constructor.
 }
 
-
-
 //--------------------------------------------------------------------------------------------------
-PFPhotonIsolationCalculator::~PFPhotonIsolationCalculator()
-{
+PFPhotonIsolationCalculator::~PFPhotonIsolationCalculator() {}
 
+void PFPhotonIsolationCalculator::calculate(const reco::Photon* aPho,
+                                            const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle,
+                                            //					    reco::VertexRef vtx,
+                                            edm::Handle<reco::VertexCollection>& vertices,
+                                            const edm::Event& e,
+                                            const edm::EventSetup& es,
+                                            reco::Photon::PflowIsolationVariables& phoisol03) {
+  reco::VertexRef vtx(vertices, 0);
+  this->fGetIsolation(&*aPho, pfCandidateHandle, vtx, vertices);
+  phoisol03.chargedHadronIso = this->getIsolationCharged();
+  phoisol03.neutralHadronIso = this->getIsolationNeutral();
+  phoisol03.photonIso = this->getIsolationPhoton();
 }
 
-
-void PFPhotonIsolationCalculator::calculate(const reco::Photon* aPho, 
-					    const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle,
-					    //					    reco::VertexRef vtx,
-					    edm::Handle< reco::VertexCollection >& vertices,
-					    const edm::Event& e , const edm::EventSetup& es,
-					    reco::Photon::PflowIsolationVariables& phoisol03) {
-
-  reco::VertexRef vtx(vertices, 0);
-  this->fGetIsolation(&*aPho,  pfCandidateHandle, vtx, vertices);
-  phoisol03.chargedHadronIso = this->getIsolationCharged() ;
-  phoisol03.neutralHadronIso = this->getIsolationNeutral();
-  phoisol03.photonIso        = this->getIsolationPhoton();
-
-
-  
- }
-
-
-
-
 //--------------------------------------------------------------------------------------------------
-void PFPhotonIsolationCalculator::initializeRings(int iNumberOfRings, float fRingSize){
- 
+void PFPhotonIsolationCalculator::initializeRings(int iNumberOfRings, float fRingSize) {
   fIsolationInRings_.clear();
-  for(int isoBin =0;isoBin<iNumberOfRings;isoBin++){
+  for (int isoBin = 0; isoBin < iNumberOfRings; isoBin++) {
     float fTemp = 0.0;
     fIsolationInRings_.push_back(fTemp);
-    
+
     float fTempPhoton = 0.0;
     fIsolationInRingsPhoton_.push_back(fTempPhoton);
 
@@ -125,75 +98,50 @@ void PFPhotonIsolationCalculator::initializeRings(int iNumberOfRings, float fRin
 
     float fTempChargedAll = 0.0;
     fIsolationInRingsChargedAll_.push_back(fTempChargedAll);
-
   }
 
   fConeSize_ = fRingSize * (float)iNumberOfRings;
-
 }
-  
- 
-
 
 //--------------------------------------------------------------------------------------------------
-float PFPhotonIsolationCalculator::fGetIsolation(const reco::Photon * photon, const  edm::Handle<reco::PFCandidateCollection> pfCandidateHandle ,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices) {
- 
-  fGetIsolationInRings( photon, pfCandidateHandle, vtx, vertices);
+float PFPhotonIsolationCalculator::fGetIsolation(const reco::Photon* photon,
+                                                 const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle,
+                                                 reco::VertexRef vtx,
+                                                 edm::Handle<reco::VertexCollection> vertices) {
+  fGetIsolationInRings(photon, pfCandidateHandle, vtx, vertices);
   fIsolation_ = fIsolationInRings_[0];
   return fIsolation_;
 }
 
-
-
 //--------------------------------------------------------------------------------------------------
-std::vector<float > PFPhotonIsolationCalculator::fGetIsolationInRings(const reco::Photon * photon, const  edm::Handle<reco::PFCandidateCollection> pfCandidateHandle, reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices) {
-
-
+std::vector<float> PFPhotonIsolationCalculator::fGetIsolationInRings(
+    const reco::Photon* photon,
+    const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle,
+    reco::VertexRef vtx,
+    edm::Handle<reco::VertexCollection> vertices) {
   int isoBin;
-  
-  for(isoBin =0;isoBin<iNumberOfRings_;isoBin++){
-    fIsolationInRings_[isoBin]=0.;
-    fIsolationInRingsPhoton_[isoBin]=0.;
-    fIsolationInRingsNeutral_[isoBin]=0.;
-    fIsolationInRingsCharged_[isoBin]=0.;
-    fIsolationInRingsChargedAll_[isoBin]=0.;
+
+  for (isoBin = 0; isoBin < iNumberOfRings_; isoBin++) {
+    fIsolationInRings_[isoBin] = 0.;
+    fIsolationInRingsPhoton_[isoBin] = 0.;
+    fIsolationInRingsNeutral_[isoBin] = 0.;
+    fIsolationInRingsCharged_[isoBin] = 0.;
+    fIsolationInRingsChargedAll_[isoBin] = 0.;
   }
-  
+
   iMissHits_ = 0;
 
   refSC = photon->superCluster();
-  pivotInBarrel = std::fabs((refSC->position().eta()))<1.479;
+  pivotInBarrel = std::fabs((refSC->position().eta())) < 1.479;
 
-  for(unsigned iPF=0; iPF< pfCandidateHandle->size(); iPF++) {
-
+  for (unsigned iPF = 0; iPF < pfCandidateHandle->size(); iPF++) {
     reco::PFCandidateRef pfParticle(reco::PFCandidateRef(pfCandidateHandle, iPF));
 
-    if (pfParticle->superClusterRef().isNonnull() &&
-        photon->superCluster().isNonnull() &&
-        pfParticle->superClusterRef() == photon->superCluster()) 
+    if (pfParticle->superClusterRef().isNonnull() && photon->superCluster().isNonnull() &&
+        pfParticle->superClusterRef() == photon->superCluster())
       continue;
-    
 
-  
-    if(pfParticle->pdgId()==22){
-      // Set the vertex of reco::Photon to the first PV
-      math::XYZVector direction = math::XYZVector(photon->superCluster()->x() - pfParticle->vx(),
-						  photon->superCluster()->y() - pfParticle->vy(),
-                                                  photon->superCluster()->z() - pfParticle->vz());
-      
-      fEta_ = direction.Eta();
-      fPhi_ = direction.Phi();
-      fVx_ = pfParticle->vx();
-      fVy_ = pfParticle->vy();
-      fVz_ = pfParticle->vz();
-
-      float fDeltaR =isPhotonParticleVetoed(pfParticle); 
-      if( fDeltaR >=0.){
-        isoBin = (int)(fDeltaR/fRingSize_);
-        fIsolationInRingsPhoton_[isoBin] = fIsolationInRingsPhoton_[isoBin] + pfParticle->pt();
-      }
-      
-    }else if(std::abs(pfParticle->pdgId())==130){
+    if (pfParticle->pdgId() == 22) {
       // Set the vertex of reco::Photon to the first PV
       math::XYZVector direction = math::XYZVector(photon->superCluster()->x() - pfParticle->vx(),
                                                   photon->superCluster()->y() - pfParticle->vy(),
@@ -204,14 +152,32 @@ std::vector<float > PFPhotonIsolationCalculator::fGetIsolationInRings(const reco
       fVx_ = pfParticle->vx();
       fVy_ = pfParticle->vy();
       fVz_ = pfParticle->vz();
-      float fDeltaR =  isNeutralParticleVetoed( pfParticle); 
-      if( fDeltaR>=0.){
-	isoBin = (int)(fDeltaR/fRingSize_);
+
+      float fDeltaR = isPhotonParticleVetoed(pfParticle);
+      if (fDeltaR >= 0.) {
+        isoBin = (int)(fDeltaR / fRingSize_);
+        fIsolationInRingsPhoton_[isoBin] = fIsolationInRingsPhoton_[isoBin] + pfParticle->pt();
+      }
+
+    } else if (std::abs(pfParticle->pdgId()) == 130) {
+      // Set the vertex of reco::Photon to the first PV
+      math::XYZVector direction = math::XYZVector(photon->superCluster()->x() - pfParticle->vx(),
+                                                  photon->superCluster()->y() - pfParticle->vy(),
+                                                  photon->superCluster()->z() - pfParticle->vz());
+
+      fEta_ = direction.Eta();
+      fPhi_ = direction.Phi();
+      fVx_ = pfParticle->vx();
+      fVy_ = pfParticle->vy();
+      fVz_ = pfParticle->vz();
+      float fDeltaR = isNeutralParticleVetoed(pfParticle);
+      if (fDeltaR >= 0.) {
+        isoBin = (int)(fDeltaR / fRingSize_);
         fIsolationInRingsNeutral_[isoBin] = fIsolationInRingsNeutral_[isoBin] + pfParticle->pt();
       }
 
       //}else if(abs(pfParticle.pdgId()) == 11 ||abs(pfParticle.pdgId()) == 13 || abs(pfParticle.pdgId()) == 211){
-    }else if(std::abs(pfParticle->pdgId()) == 211){
+    } else if (std::abs(pfParticle->pdgId()) == 211) {
       // Set the vertex of reco::Photon to the first PV
       math::XYZVector direction = math::XYZVector(photon->superCluster()->x() - (*vtx).x(),
                                                   photon->superCluster()->y() - (*vtx).y(),
@@ -222,77 +188,74 @@ std::vector<float > PFPhotonIsolationCalculator::fGetIsolationInRings(const reco
       fVx_ = (*vtx).x();
       fVy_ = (*vtx).y();
       fVz_ = (*vtx).z();
-      float fDeltaR = isChargedParticleVetoed( pfParticle, vtx, vertices);
-      if( fDeltaR >=0.){
-        isoBin = (int)(fDeltaR/fRingSize_);
+      float fDeltaR = isChargedParticleVetoed(pfParticle, vtx, vertices);
+      if (fDeltaR >= 0.) {
+        isoBin = (int)(fDeltaR / fRingSize_);
         fIsolationInRingsCharged_[isoBin] = fIsolationInRingsCharged_[isoBin] + pfParticle->pt();
       }
-
     }
   }
 
- 
-  for(int isoBin =0;isoBin<iNumberOfRings_;isoBin++){
-    fIsolationInRings_[isoBin]= fIsolationInRingsPhoton_[isoBin]+ fIsolationInRingsNeutral_[isoBin] + fIsolationInRingsCharged_[isoBin];
+  for (int isoBin = 0; isoBin < iNumberOfRings_; isoBin++) {
+    fIsolationInRings_[isoBin] =
+        fIsolationInRingsPhoton_[isoBin] + fIsolationInRingsNeutral_[isoBin] + fIsolationInRingsCharged_[isoBin];
   }
-  
+
   return fIsolationInRings_;
 }
 
-
-
-
 //--------------------------------------------------------------------------------------------------
-float PFPhotonIsolationCalculator::isPhotonParticleVetoed( const reco::PFCandidate* pfIsoCand ){
-  
-  
-  float fDeltaR = deltaR(fEta_,fPhi_,pfIsoCand->eta(),pfIsoCand->phi());
+float PFPhotonIsolationCalculator::isPhotonParticleVetoed(const reco::PFCandidate* pfIsoCand) {
+  float fDeltaR = deltaR(fEta_, fPhi_, pfIsoCand->eta(), pfIsoCand->phi());
 
-  if(fDeltaR > fConeSize_)
+  if (fDeltaR > fConeSize_)
     return -999.;
-  
-  float fDeltaPhi = deltaPhi(fPhi_,pfIsoCand->phi());
-  float fDeltaEta = fEta_-pfIsoCand->eta();
 
-  if(!bApplyVeto_)
+  float fDeltaPhi = deltaPhi(fPhi_, pfIsoCand->phi());
+  float fDeltaEta = fEta_ - pfIsoCand->eta();
+
+  if (!bApplyVeto_)
     return fDeltaR;
- 
+
   //NOTE: get the direction for the EB/EE transition region from the deposit just to be in synch with the isoDep
   // this will be changed in the future
-  
-  if(bApplyMissHitPhVeto_) {
-    if(iMissHits_ > 0)
-      if(pfIsoCand->mva_nothing_gamma() > 0.99) {
-        if(pfIsoCand->superClusterRef().isNonnull() && refSC.isNonnull()) {
-         if(pfIsoCand->superClusterRef() == refSC)
-         return -999.;
+
+  if (bApplyMissHitPhVeto_) {
+    if (iMissHits_ > 0)
+      if (pfIsoCand->mva_nothing_gamma() > 0.99) {
+        if (pfIsoCand->superClusterRef().isNonnull() && refSC.isNonnull()) {
+          if (pfIsoCand->superClusterRef() == refSC)
+            return -999.;
         }
       }
   }
 
-  if(pivotInBarrel){
-    if(bDeltaRVetoBarrel_){
-      if(fDeltaR < fDeltaRVetoBarrelPhotons_)
+  if (pivotInBarrel) {
+    if (bDeltaRVetoBarrel_) {
+      if (fDeltaR < fDeltaRVetoBarrelPhotons_)
         return -999.;
     }
-    
-    if(bRectangleVetoBarrel_){
-      if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelPhotons_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelPhotons_ ){
+
+    if (bRectangleVetoBarrel_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelPhotons_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelPhotons_) {
         return -999.;
       }
     }
-  }else{
+  } else {
     if (bUseCrystalSize_ == true) {
-      fDeltaRVetoEndcapPhotons_ = 0.00864*std::fabs(refSC->position().z()/sqrt(refSC->position().perp2()))*fNumberOfCrystalEndcapPhotons_;
+      fDeltaRVetoEndcapPhotons_ =
+          0.00864 * std::fabs(refSC->position().z() / sqrt(refSC->position().perp2())) * fNumberOfCrystalEndcapPhotons_;
     }
 
-    if(bDeltaRVetoEndcap_){
-      if(fDeltaR < fDeltaRVetoEndcapPhotons_)
+    if (bDeltaRVetoEndcap_) {
+      if (fDeltaR < fDeltaRVetoEndcapPhotons_)
         return -999.;
     }
-    if(bRectangleVetoEndcap_){
-      if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapPhotons_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapPhotons_ ){
-         return -999.;
+    if (bRectangleVetoEndcap_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapPhotons_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapPhotons_) {
+        return -999.;
       }
     }
   }
@@ -300,59 +263,58 @@ float PFPhotonIsolationCalculator::isPhotonParticleVetoed( const reco::PFCandida
   return fDeltaR;
 }
 
-
-
 //--------------------------------------------------------------------------------------------------
-float PFPhotonIsolationCalculator::isPhotonParticleVetoed( const reco::PFCandidateRef pfIsoCand ){
-  
-  
-  float fDeltaR = deltaR(fEta_,fPhi_,pfIsoCand->eta(),pfIsoCand->phi());
+float PFPhotonIsolationCalculator::isPhotonParticleVetoed(const reco::PFCandidateRef pfIsoCand) {
+  float fDeltaR = deltaR(fEta_, fPhi_, pfIsoCand->eta(), pfIsoCand->phi());
 
-  if(fDeltaR > fConeSize_)
+  if (fDeltaR > fConeSize_)
     return -999.;
-  
-  float fDeltaPhi = deltaPhi(fPhi_,pfIsoCand->phi());
-  float fDeltaEta = fEta_-pfIsoCand->eta();
 
-  if(!bApplyVeto_)
+  float fDeltaPhi = deltaPhi(fPhi_, pfIsoCand->phi());
+  float fDeltaEta = fEta_ - pfIsoCand->eta();
+
+  if (!bApplyVeto_)
     return fDeltaR;
- 
+
   //NOTE: get the direction for the EB/EE transition region from the deposit just to be in synch with the isoDep
   // this will be changed in the future
-  
-  if(bApplyMissHitPhVeto_) {
-    if(iMissHits_ > 0)
-      if(pfIsoCand->mva_nothing_gamma() > 0.99) {
-        if(pfIsoCand->superClusterRef().isNonnull() && refSC.isNonnull()) {
-         if(pfIsoCand->superClusterRef() == refSC)
-         return -999.;
+
+  if (bApplyMissHitPhVeto_) {
+    if (iMissHits_ > 0)
+      if (pfIsoCand->mva_nothing_gamma() > 0.99) {
+        if (pfIsoCand->superClusterRef().isNonnull() && refSC.isNonnull()) {
+          if (pfIsoCand->superClusterRef() == refSC)
+            return -999.;
         }
       }
   }
 
-  if(pivotInBarrel){
-    if(bDeltaRVetoBarrel_){
-      if(fDeltaR < fDeltaRVetoBarrelPhotons_)
+  if (pivotInBarrel) {
+    if (bDeltaRVetoBarrel_) {
+      if (fDeltaR < fDeltaRVetoBarrelPhotons_)
         return -999.;
     }
-    
-    if(bRectangleVetoBarrel_){
-      if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelPhotons_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelPhotons_){
+
+    if (bRectangleVetoBarrel_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelPhotons_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelPhotons_) {
         return -999.;
       }
     }
-  }else{
+  } else {
     if (bUseCrystalSize_ == true) {
-      fDeltaRVetoEndcapPhotons_ = 0.00864*std::fabs(refSC->position().z()/sqrt(refSC->position().perp2()))*fNumberOfCrystalEndcapPhotons_;
+      fDeltaRVetoEndcapPhotons_ =
+          0.00864 * std::fabs(refSC->position().z() / sqrt(refSC->position().perp2())) * fNumberOfCrystalEndcapPhotons_;
     }
 
-    if(bDeltaRVetoEndcap_){
-      if(fDeltaR < fDeltaRVetoEndcapPhotons_)
+    if (bDeltaRVetoEndcap_) {
+      if (fDeltaR < fDeltaRVetoEndcapPhotons_)
         return -999.;
     }
-    if(bRectangleVetoEndcap_){
-      if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapPhotons_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapPhotons_){
-         return -999.;
+    if (bRectangleVetoEndcap_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapPhotons_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapPhotons_) {
+        return -999.;
       }
     }
   }
@@ -360,144 +322,141 @@ float PFPhotonIsolationCalculator::isPhotonParticleVetoed( const reco::PFCandida
   return fDeltaR;
 }
 
-
 //--------------------------------------------------------------------------------------------------
-float PFPhotonIsolationCalculator::isNeutralParticleVetoed( const reco::PFCandidate* pfIsoCand ){
+float PFPhotonIsolationCalculator::isNeutralParticleVetoed(const reco::PFCandidate* pfIsoCand) {
+  float fDeltaR = deltaR(fEta_, fPhi_, pfIsoCand->eta(), pfIsoCand->phi());
 
-  float fDeltaR = deltaR(fEta_,fPhi_,pfIsoCand->eta(),pfIsoCand->phi());
-  
-  if(fDeltaR > fConeSize_)
+  if (fDeltaR > fConeSize_)
     return -999;
-  
-  float fDeltaPhi = deltaPhi(fPhi_,pfIsoCand->phi());
-  float fDeltaEta = fEta_-pfIsoCand->eta();
 
-  if(!bApplyVeto_)
+  float fDeltaPhi = deltaPhi(fPhi_, pfIsoCand->phi());
+  float fDeltaEta = fEta_ - pfIsoCand->eta();
+
+  if (!bApplyVeto_)
     return fDeltaR;
 
   //NOTE: get the direction for the EB/EE transition region from the deposit just to be in synch with the isoDep
   // this will be changed in the future
-  if(pivotInBarrel){
-    if(!bDeltaRVetoBarrel_ && !bRectangleVetoBarrel_){
+  if (pivotInBarrel) {
+    if (!bDeltaRVetoBarrel_ && !bRectangleVetoBarrel_) {
       return fDeltaR;
     }
-    
-    if(bDeltaRVetoBarrel_ ){
-        if(fDeltaR < fDeltaRVetoBarrelNeutrals_)
-         return -999.;
+
+    if (bDeltaRVetoBarrel_) {
+      if (fDeltaR < fDeltaRVetoBarrelNeutrals_)
+        return -999.;
+    }
+    if (bRectangleVetoBarrel_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelNeutrals_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelNeutrals_) {
+        return -999.;
       }
-      if(bRectangleVetoBarrel_){
-        if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelNeutrals_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelNeutrals_){
-         return -999.;
-        }
+    }
+
+  } else {
+    if (!bDeltaRVetoEndcap_ && !bRectangleVetoEndcap_) {
+      return fDeltaR;
+    }
+    if (bDeltaRVetoEndcap_) {
+      if (fDeltaR < fDeltaRVetoEndcapNeutrals_)
+        return -999.;
+    }
+    if (bRectangleVetoEndcap_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapNeutrals_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapNeutrals_) {
+        return -999.;
       }
-      
-    }else{
-     if(!bDeltaRVetoEndcap_  &&!  bRectangleVetoEndcap_){
-       return fDeltaR;
-     }
-      if(bDeltaRVetoEndcap_){
-        if(fDeltaR < fDeltaRVetoEndcapNeutrals_)
-         return -999.;
-      }
-      if(bRectangleVetoEndcap_){
-        if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapNeutrals_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapNeutrals_){
-         return -999.;
-        }
-      }
+    }
   }
 
   return fDeltaR;
 }
 
-
 //--------------------------------------------------------------------------------------------------
-float PFPhotonIsolationCalculator::isNeutralParticleVetoed( const reco::PFCandidateRef pfIsoCand ){
+float PFPhotonIsolationCalculator::isNeutralParticleVetoed(const reco::PFCandidateRef pfIsoCand) {
+  float fDeltaR = deltaR(fEta_, fPhi_, pfIsoCand->eta(), pfIsoCand->phi());
 
-  float fDeltaR = deltaR(fEta_,fPhi_,pfIsoCand->eta(),pfIsoCand->phi());
-  
-  if(fDeltaR > fConeSize_)
+  if (fDeltaR > fConeSize_)
     return -999;
-  
-  float fDeltaPhi = deltaPhi(fPhi_,pfIsoCand->phi());
-  float fDeltaEta = fEta_-pfIsoCand->eta();
 
-  if(!bApplyVeto_)
+  float fDeltaPhi = deltaPhi(fPhi_, pfIsoCand->phi());
+  float fDeltaEta = fEta_ - pfIsoCand->eta();
+
+  if (!bApplyVeto_)
     return fDeltaR;
 
   //NOTE: get the direction for the EB/EE transition region from the deposit just to be in synch with the isoDep
   // this will be changed in the future
-  if(pivotInBarrel){
-    if(!bDeltaRVetoBarrel_  && !bRectangleVetoBarrel_ ){
+  if (pivotInBarrel) {
+    if (!bDeltaRVetoBarrel_ && !bRectangleVetoBarrel_) {
       return fDeltaR;
     }
-    
-    if(bDeltaRVetoBarrel_){
-        if(fDeltaR < fDeltaRVetoBarrelNeutrals_)
-         return -999.;
+
+    if (bDeltaRVetoBarrel_) {
+      if (fDeltaR < fDeltaRVetoBarrelNeutrals_)
+        return -999.;
+    }
+    if (bRectangleVetoBarrel_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelNeutrals_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelNeutrals_) {
+        return -999.;
       }
-      if(bRectangleVetoBarrel_){
-        if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelNeutrals_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelNeutrals_){
-         return -999.;
-        }
+    }
+
+  } else {
+    if (!bDeltaRVetoEndcap_ && !bRectangleVetoEndcap_) {
+      return fDeltaR;
+    }
+    if (bDeltaRVetoEndcap_) {
+      if (fDeltaR < fDeltaRVetoEndcapNeutrals_)
+        return -999.;
+    }
+    if (bRectangleVetoEndcap_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapNeutrals_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapNeutrals_) {
+        return -999.;
       }
-      
-    }else{
-     if(!bDeltaRVetoEndcap_ && !bRectangleVetoEndcap_ ){
-       return fDeltaR;
-     }
-      if(bDeltaRVetoEndcap_ ){
-        if(fDeltaR < fDeltaRVetoEndcapNeutrals_ )
-         return -999.;
-      }
-      if(bRectangleVetoEndcap_){
-        if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapNeutrals_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapNeutrals_){
-         return -999.;
-        }
-      }
+    }
   }
 
   return fDeltaR;
 }
-
-
-
 
 //----------------------------------------------------------------------------------------------------
-float PFPhotonIsolationCalculator::isChargedParticleVetoed(const reco::PFCandidate* pfIsoCand, edm::Handle< reco::VertexCollection > vertices ){
+float PFPhotonIsolationCalculator::isChargedParticleVetoed(const reco::PFCandidate* pfIsoCand,
+                                                           edm::Handle<reco::VertexCollection> vertices) {
   //need code to handle special conditions
-  
+
   return -999;
 }
 
 //-----------------------------------------------------------------------------------------------------
-float PFPhotonIsolationCalculator::isChargedParticleVetoed(const reco::PFCandidate* pfIsoCand,reco::VertexRef vtxMain, edm::Handle< reco::VertexCollection > vertices ){
-  
-  reco::VertexRef vtx = chargedHadronVertex(vertices, *pfIsoCand );
-  if(vtx.isNull())
+float PFPhotonIsolationCalculator::isChargedParticleVetoed(const reco::PFCandidate* pfIsoCand,
+                                                           reco::VertexRef vtxMain,
+                                                           edm::Handle<reco::VertexCollection> vertices) {
+  reco::VertexRef vtx = chargedHadronVertex(vertices, *pfIsoCand);
+  if (vtx.isNull())
     return -999.;
-  
-// float fVtxMainX = (*vtxMain).x();
-// float fVtxMainY = (*vtxMain).y();
+
+  // float fVtxMainX = (*vtxMain).x();
+  // float fVtxMainY = (*vtxMain).y();
   float fVtxMainZ = (*vtxMain).z();
 
-  if(bApplyPFPUVeto_) {
-    if(vtx != vtxMain)
+  if (bApplyPFPUVeto_) {
+    if (vtx != vtxMain)
       return -999.;
   }
-    
 
-  if(bApplyDzDxyVeto_) {
-    if(iParticleType_==kPhoton){
-      
-      float dz = std::fabs( pfIsoCand->trackRef()->dz( (*vtxMain).position() ) );
+  if (bApplyDzDxyVeto_) {
+    if (iParticleType_ == kPhoton) {
+      float dz = std::fabs(pfIsoCand->trackRef()->dz((*vtxMain).position()));
       if (dz > 0.2)
         return -999.;
-        
-      double dxy = pfIsoCand->trackRef()->dxy( (*vtxMain).position() );
+
+      double dxy = pfIsoCand->trackRef()->dxy((*vtxMain).position());
       if (std::fabs(dxy) > 0.1)
         return -999.;
-      
+
       /*
 float dz = fabs(vtx->z() - fVtxMainZ);
 if (dz > 1.)
@@ -506,103 +465,96 @@ double dxy = ( -(vtx->x() - fVtxMainX)*pfIsoCand->py() + (vtx->y() - fVtxMainY)*
 if(fabs(dxy) > 0.2)
         return -999.;
 */
-    }else{
-      
-      
+    } else {
       float dz = std::fabs(vtx->z() - fVtxMainZ);
       if (dz > 1.)
         return -999.;
-      
-      double dxy = ( -(vtx->x() - fVx_)*pfIsoCand->py() + (vtx->y() - fVy_)*pfIsoCand->px()) / pfIsoCand->pt();
-      if(std::fabs(dxy) > 0.1)
+
+      double dxy = (-(vtx->x() - fVx_) * pfIsoCand->py() + (vtx->y() - fVy_) * pfIsoCand->px()) / pfIsoCand->pt();
+      if (std::fabs(dxy) > 0.1)
         return -999.;
     }
   }
 
-  float fDeltaR = deltaR(pfIsoCand->eta(),pfIsoCand->phi(),fEta_,fPhi_);
+  float fDeltaR = deltaR(pfIsoCand->eta(), pfIsoCand->phi(), fEta_, fPhi_);
 
-  if(fDeltaR > fConeSize_)
+  if (fDeltaR > fConeSize_)
     return -999.;
 
-  float fDeltaPhi = deltaPhi(fPhi_,pfIsoCand->phi());
-  float fDeltaEta = fEta_-pfIsoCand->eta();
-  
+  float fDeltaPhi = deltaPhi(fPhi_, pfIsoCand->phi());
+  float fDeltaEta = fEta_ - pfIsoCand->eta();
 
-// std::abscout << " charged hadron: DR " << fDeltaR
-//          << " pt " << pfIsoCand->pt() << " eta,phi " << pfIsoCand->eta() << ", " << pfIsoCand->phi()
-//          << " fVtxMainZ " << (*vtxMain).z() << " cand z " << vtx->z() << std::endl;
-  
+  // std::abscout << " charged hadron: DR " << fDeltaR
+  //          << " pt " << pfIsoCand->pt() << " eta,phi " << pfIsoCand->eta() << ", " << pfIsoCand->phi()
+  //          << " fVtxMainZ " << (*vtxMain).z() << " cand z " << vtx->z() << std::endl;
 
-  if(!bApplyVeto_)
+  if (!bApplyVeto_)
     return fDeltaR;
-  
+
   //NOTE: get the direction for the EB/EE transition region from the deposit just to be in synch with the isoDep
   // this will be changed in the future
-  if(pivotInBarrel){
-    if(!bDeltaRVetoBarrel_ &&!bRectangleVetoBarrel_ ){
+  if (pivotInBarrel) {
+    if (!bDeltaRVetoBarrel_ && !bRectangleVetoBarrel_) {
       return fDeltaR;
     }
-    
-    if(bDeltaRVetoBarrel_){
-        if(fDeltaR < fDeltaRVetoBarrelCharged_)
-         return -999.;
-      }
-      if(bRectangleVetoBarrel_){
-        if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelCharged_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelCharged_){
-         return -999.;
-        }
-      }
-      
-    }else{
-     if(!bDeltaRVetoEndcap_  && !bRectangleVetoEndcap_){
-       return fDeltaR;
-     }
-      if(bDeltaRVetoEndcap_){
-        if(fDeltaR < fDeltaRVetoEndcapCharged_)
-         return -999.;
-      }
-      if(bRectangleVetoEndcap_){
-        if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapCharged_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapCharged_){
-         return -999.;
-        }
-      }
-  }
-                
-  
 
+    if (bDeltaRVetoBarrel_) {
+      if (fDeltaR < fDeltaRVetoBarrelCharged_)
+        return -999.;
+    }
+    if (bRectangleVetoBarrel_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelCharged_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelCharged_) {
+        return -999.;
+      }
+    }
+
+  } else {
+    if (!bDeltaRVetoEndcap_ && !bRectangleVetoEndcap_) {
+      return fDeltaR;
+    }
+    if (bDeltaRVetoEndcap_) {
+      if (fDeltaR < fDeltaRVetoEndcapCharged_)
+        return -999.;
+    }
+    if (bRectangleVetoEndcap_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapCharged_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapCharged_) {
+        return -999.;
+      }
+    }
+  }
 
   return fDeltaR;
 }
-
 
 //-----------------------------------------------------------------------------------------------------
-float PFPhotonIsolationCalculator::isChargedParticleVetoed(const reco::PFCandidateRef pfIsoCand,reco::VertexRef vtxMain, edm::Handle< reco::VertexCollection > vertices ){
-  
-  reco::VertexRef vtx = chargedHadronVertex(vertices, *pfIsoCand );
-  if(vtx.isNull())
+float PFPhotonIsolationCalculator::isChargedParticleVetoed(const reco::PFCandidateRef pfIsoCand,
+                                                           reco::VertexRef vtxMain,
+                                                           edm::Handle<reco::VertexCollection> vertices) {
+  reco::VertexRef vtx = chargedHadronVertex(vertices, *pfIsoCand);
+  if (vtx.isNull())
     return -999.;
-  
-// float fVtxMainX = (*vtxMain).x();
-// float fVtxMainY = (*vtxMain).y();
+
+  // float fVtxMainX = (*vtxMain).x();
+  // float fVtxMainY = (*vtxMain).y();
   float fVtxMainZ = (*vtxMain).z();
 
-  if(bApplyPFPUVeto_) {
-    if(vtx != vtxMain)
+  if (bApplyPFPUVeto_) {
+    if (vtx != vtxMain)
       return -999.;
   }
-    
 
-  if(bApplyDzDxyVeto_) {
-    if(iParticleType_==kPhoton){
-      
-      float dz = std::fabs( pfIsoCand->trackRef()->dz( (*vtxMain).position() ) );
+  if (bApplyDzDxyVeto_) {
+    if (iParticleType_ == kPhoton) {
+      float dz = std::fabs(pfIsoCand->trackRef()->dz((*vtxMain).position()));
       if (dz > 0.2)
         return -999.;
-        
-      double dxy = pfIsoCand->trackRef()->dxy( (*vtxMain).position() );
+
+      double dxy = pfIsoCand->trackRef()->dxy((*vtxMain).position());
       if (std::fabs(dxy) > 0.1)
         return -999.;
-      
+
       /*
 float dz = fabs(vtx->z() - fVtxMainZ);
 if (dz > 1.)
@@ -611,156 +563,140 @@ double dxy = ( -(vtx->x() - fVtxMainX)*pfIsoCand->py() + (vtx->y() - fVtxMainY)*
 if(fabs(dxy) > 0.2)
         return -999.;
 */
-    }else{
-      
-      
+    } else {
       float dz = std::fabs(vtx->z() - fVtxMainZ);
       if (dz > 1.)
         return -999.;
-      
-      double dxy = ( -(vtx->x() - fVx_)*pfIsoCand->py() + (vtx->y() - fVy_)*pfIsoCand->px()) / pfIsoCand->pt();
-      if(std::fabs(dxy) > 0.1)
+
+      double dxy = (-(vtx->x() - fVx_) * pfIsoCand->py() + (vtx->y() - fVy_) * pfIsoCand->px()) / pfIsoCand->pt();
+      if (std::fabs(dxy) > 0.1)
         return -999.;
     }
   }
 
-  float fDeltaR = deltaR(pfIsoCand->eta(),pfIsoCand->phi(),fEta_,fPhi_);
+  float fDeltaR = deltaR(pfIsoCand->eta(), pfIsoCand->phi(), fEta_, fPhi_);
 
-  if(fDeltaR > fConeSize_)
+  if (fDeltaR > fConeSize_)
     return -999.;
 
-  float fDeltaPhi = deltaPhi(fPhi_,pfIsoCand->phi());
-  float fDeltaEta = fEta_-pfIsoCand->eta();
-  
+  float fDeltaPhi = deltaPhi(fPhi_, pfIsoCand->phi());
+  float fDeltaEta = fEta_ - pfIsoCand->eta();
 
-// std::cout << " charged hadron: DR " << fDeltaR
-//          << " pt " << pfIsoCand->pt() << " eta,phi " << pfIsoCand->eta() << ", " << pfIsoCand->phi()
-//          << " fVtxMainZ " << (*vtxMain).z() << " cand z " << vtx->z() << std::endl;
-  
+  // std::cout << " charged hadron: DR " << fDeltaR
+  //          << " pt " << pfIsoCand->pt() << " eta,phi " << pfIsoCand->eta() << ", " << pfIsoCand->phi()
+  //          << " fVtxMainZ " << (*vtxMain).z() << " cand z " << vtx->z() << std::endl;
 
-  if(!bApplyVeto_)
+  if (!bApplyVeto_)
     return fDeltaR;
-  
+
   //NOTE: get the direction for the EB/EE transition region from the deposit just to be in synch with the isoDep
   // this will be changed in the future
-  if(pivotInBarrel){
-    if(!bDeltaRVetoBarrel_ && !bRectangleVetoBarrel_) {
+  if (pivotInBarrel) {
+    if (!bDeltaRVetoBarrel_ && !bRectangleVetoBarrel_) {
       return fDeltaR;
     }
-    
-    if(bDeltaRVetoBarrel_){
-        if(fDeltaR < fDeltaRVetoBarrelCharged_)
-         return -999.;
-      }
-      if(bRectangleVetoBarrel_){
-        if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelCharged_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelCharged_){
-         return -999.;
-        }
-      }
-      
-    }else{
-     if(!bDeltaRVetoEndcap_ &&!bRectangleVetoEndcap_ ){
-       return fDeltaR;
-     }
-      if(bDeltaRVetoEndcap_){
-        if(fDeltaR < fDeltaRVetoEndcapCharged_)
-         return -999.;
-      }
-      if(bRectangleVetoEndcap_){
-        if(std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapCharged_ && std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapCharged_){
-         return -999.;
-        }
-      }
-  }
-                
-  
 
+    if (bDeltaRVetoBarrel_) {
+      if (fDeltaR < fDeltaRVetoBarrelCharged_)
+        return -999.;
+    }
+    if (bRectangleVetoBarrel_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoBarrelCharged_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoBarrelCharged_) {
+        return -999.;
+      }
+    }
+
+  } else {
+    if (!bDeltaRVetoEndcap_ && !bRectangleVetoEndcap_) {
+      return fDeltaR;
+    }
+    if (bDeltaRVetoEndcap_) {
+      if (fDeltaR < fDeltaRVetoEndcapCharged_)
+        return -999.;
+    }
+    if (bRectangleVetoEndcap_) {
+      if (std::abs(fDeltaEta) < fRectangleDeltaEtaVetoEndcapCharged_ &&
+          std::abs(fDeltaPhi) < fRectangleDeltaPhiVetoEndcapCharged_) {
+        return -999.;
+      }
+    }
+  }
 
   return fDeltaR;
 }
 
-
-
 //--------------------------------------------------------------------------------------------------
-reco::VertexRef PFPhotonIsolationCalculator::chargedHadronVertex( edm::Handle< reco::VertexCollection > verticesColl, const reco::PFCandidate& pfcand ){
-
+reco::VertexRef PFPhotonIsolationCalculator::chargedHadronVertex(edm::Handle<reco::VertexCollection> verticesColl,
+                                                                 const reco::PFCandidate& pfcand) {
   //code copied from Florian's PFNoPU class (corrected removing the double loop....)
-    
-  auto const & track = pfcand.trackRef();
+
+  auto const& track = pfcand.trackRef();
 
   size_t iVertex = 0;
-  unsigned int index=0;
+  unsigned int index = 0;
   unsigned int nFoundVertex = 0;
 
-  float bestweight=0;
-  
+  float bestweight = 0;
+
   const reco::VertexCollection& vertices = *(verticesColl.product());
 
-  for( auto const & vtx :  vertices) {
-    float w = vtx.trackWeight(track); // 0 if does not belong here
+  for (auto const& vtx : vertices) {
+    float w = vtx.trackWeight(track);  // 0 if does not belong here
     //select the vertex for which the track has the highest weight
-    if (w > bestweight){ // should we break here?
-        bestweight=w;
-	iVertex=index;
-	nFoundVertex++;
+    if (w > bestweight) {  // should we break here?
+      bestweight = w;
+      iVertex = index;
+      nFoundVertex++;
     }
-    ++index; 
+    ++index;
   }
- 
- 
-  
-  if (nFoundVertex>0){
-    if (nFoundVertex!=1)
-      edm::LogWarning("TrackOnTwoVertex")<<"a track is shared by at least two verteces. Used to be an assert";
-    return reco::VertexRef( verticesColl, iVertex);
+
+  if (nFoundVertex > 0) {
+    if (nFoundVertex != 1)
+      edm::LogWarning("TrackOnTwoVertex") << "a track is shared by at least two verteces. Used to be an assert";
+    return reco::VertexRef(verticesColl, iVertex);
   }
   // no vertex found with this track.
 
   // optional: as a secondary solution, associate the closest vertex in z
-  if (  bCheckClosestZVertex_ ) {
-
+  if (bCheckClosestZVertex_) {
     double dzmin = 10000.;
     double ztrack = pfcand.vertex().z();
     bool foundVertex = false;
     index = 0;
-    for( reco::VertexCollection::const_iterator iv=vertices.begin(); iv!=vertices.end(); ++iv, ++index) {
-
+    for (reco::VertexCollection::const_iterator iv = vertices.begin(); iv != vertices.end(); ++iv, ++index) {
       double dz = std::fabs(ztrack - iv->z());
-      if(dz<dzmin) {
+      if (dz < dzmin) {
         dzmin = dz;
         iVertex = index;
         foundVertex = true;
       }
     }
 
-    if( foundVertex )
-      return reco::VertexRef( verticesColl, iVertex);
-  
+    if (foundVertex)
+      return reco::VertexRef(verticesColl, iVertex);
   }
-   
-  return reco::VertexRef( );
+
+  return reco::VertexRef();
 }
 
-
-
-int PFPhotonIsolationCalculator::matchPFObject(const reco::Photon* photon, const reco::PFCandidateCollection* Candidates ){
-  
+int PFPhotonIsolationCalculator::matchPFObject(const reco::Photon* photon,
+                                               const reco::PFCandidateCollection* Candidates) {
   Int_t iMatch = -1;
 
-  int i=0;
-  for(reco::PFCandidateCollection::const_iterator iPF=Candidates->begin();iPF !=Candidates->end();iPF++){
+  int i = 0;
+  for (reco::PFCandidateCollection::const_iterator iPF = Candidates->begin(); iPF != Candidates->end(); iPF++) {
     const reco::PFCandidate& pfParticle = (*iPF);
-    if((((pfParticle.pdgId()==22 ) || std::abs(pfParticle.pdgId())==11) )){
-     
-      if(pfParticle.superClusterRef()==photon->superCluster())
-        iMatch= i;
-     
+    if ((((pfParticle.pdgId() == 22) || std::abs(pfParticle.pdgId()) == 11))) {
+      if (pfParticle.superClusterRef() == photon->superCluster())
+        iMatch = i;
     }
-    
+
     i++;
   }
-  
-/*
+
+  /*
 if(iMatch == -1){
 i=0;
 float fPt = -1;
@@ -781,49 +717,40 @@ i++;
 */
 
   return iMatch;
-
 }
 
-
-
-
-
-int PFPhotonIsolationCalculator::matchPFObject(const reco::GsfElectron* electron, const reco::PFCandidateCollection* Candidates ){
-  
+int PFPhotonIsolationCalculator::matchPFObject(const reco::GsfElectron* electron,
+                                               const reco::PFCandidateCollection* Candidates) {
   Int_t iMatch = -1;
 
-  int i=0;
-  for(reco::PFCandidateCollection::const_iterator iPF=Candidates->begin();iPF !=Candidates->end();iPF++){
+  int i = 0;
+  for (reco::PFCandidateCollection::const_iterator iPF = Candidates->begin(); iPF != Candidates->end(); iPF++) {
     const reco::PFCandidate& pfParticle = (*iPF);
-    if((((pfParticle.pdgId()==22 ) || std::abs(pfParticle.pdgId())==11) )){
-     
-      if(pfParticle.superClusterRef()==electron->superCluster())
-        iMatch= i;
-     
+    if ((((pfParticle.pdgId() == 22) || std::abs(pfParticle.pdgId()) == 11))) {
+      if (pfParticle.superClusterRef() == electron->superCluster())
+        iMatch = i;
     }
-    
+
     i++;
   }
-  
-  if(iMatch == -1){
-    i=0;
+
+  if (iMatch == -1) {
+    i = 0;
     float fPt = -1;
-    for(reco::PFCandidateCollection::const_iterator iPF=Candidates->begin();iPF !=Candidates->end();iPF++){
+    for (reco::PFCandidateCollection::const_iterator iPF = Candidates->begin(); iPF != Candidates->end(); iPF++) {
       const reco::PFCandidate& pfParticle = (*iPF);
-      if((((pfParticle.pdgId()==22 ) || std::abs(pfParticle.pdgId())==11) )){
-        if(pfParticle.pt()>fPt){
-         float fDeltaR = deltaR(pfParticle.eta(),pfParticle.phi(),electron->eta(),electron->phi());
-         if(fDeltaR<0.1){
-         iMatch = i;
-         fPt = pfParticle.pt();
-         }
+      if ((((pfParticle.pdgId() == 22) || std::abs(pfParticle.pdgId()) == 11))) {
+        if (pfParticle.pt() > fPt) {
+          float fDeltaR = deltaR(pfParticle.eta(), pfParticle.phi(), electron->eta(), electron->phi());
+          if (fDeltaR < 0.1) {
+            iMatch = i;
+            fPt = pfParticle.pt();
+          }
         }
       }
       i++;
     }
   }
-  
+
   return iMatch;
-
 }
-

--- a/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
@@ -41,17 +41,18 @@
 #include <string>
 #include <TMath.h>
 
-
-void PhotonIsolationCalculator::setup(const edm::ParameterSet& conf, 
-				      std::vector<int> const & flagsEB, std::vector<int> const & flagsEE, 
-				      std::vector<int> const & severitiesEB, std::vector<int> const & severitiesEE,
-				      edm::ConsumesCollector && iC) {
-
-
+void PhotonIsolationCalculator::setup(const edm::ParameterSet& conf,
+                                      std::vector<int> const& flagsEB,
+                                      std::vector<int> const& flagsEE,
+                                      std::vector<int> const& severitiesEB,
+                                      std::vector<int> const& severitiesEE,
+                                      edm::ConsumesCollector&& iC) {
   trackInputTag_ = iC.consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("trackProducer"));
   beamSpotProducerTag_ = iC.consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpotProducer"));
-  barrelecalCollection_ = iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("barrelEcalRecHitCollection"));
-  endcapecalCollection_ = iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("endcapEcalRecHitCollection"));
+  barrelecalCollection_ =
+      iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("barrelEcalRecHitCollection"));
+  endcapecalCollection_ =
+      iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("endcapEcalRecHitCollection"));
   auto hcRHC = conf.getParameter<edm::InputTag>("HcalRecHitCollection");
   if (not hcRHC.label().empty())
     hcalCollection_ = iC.consumes<CaloTowerCollection>(hcRHC);
@@ -64,153 +65,148 @@ void PhotonIsolationCalculator::setup(const edm::ParameterSet& conf,
   useNumCrystals_ = conf.getParameter<bool>("useNumCrystals");
 
   /// Isolation parameters for barrel and for two different cone sizes
-  int i=0;
-  trkIsoBarrelRadiusA_[i++] = (  conf.getParameter<double>("TrackConeOuterRadiusA_Barrel") );
-  trkIsoBarrelRadiusA_[i++] = (  conf.getParameter<double>("TrackConeInnerRadiusA_Barrel") ) ;
-  trkIsoBarrelRadiusA_[i++] = (  conf.getParameter<double>("isolationtrackThresholdA_Barrel") );
-  trkIsoBarrelRadiusA_[i++] = (  conf.getParameter<double>("longImpactParameterA_Barrel") );
-  trkIsoBarrelRadiusA_[i++] = (  conf.getParameter<double>("transImpactParameterA_Barrel") );
-  trkIsoBarrelRadiusA_[i++] = (  conf.getParameter<double>("isolationtrackEtaSliceA_Barrel") );
+  int i = 0;
+  trkIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("TrackConeOuterRadiusA_Barrel"));
+  trkIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("TrackConeInnerRadiusA_Barrel"));
+  trkIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("isolationtrackThresholdA_Barrel"));
+  trkIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("longImpactParameterA_Barrel"));
+  trkIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("transImpactParameterA_Barrel"));
+  trkIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("isolationtrackEtaSliceA_Barrel"));
 
-  i=0;
-  ecalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("EcalRecHitInnerRadiusA_Barrel") );
-  ecalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("EcalRecHitOuterRadiusA_Barrel") );
-  ecalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("EcalRecHitEtaSliceA_Barrel") );
-  ecalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("EcalRecHitThreshEA_Barrel") );
-  ecalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("EcalRecHitThreshEtA_Barrel") );
+  i = 0;
+  ecalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("EcalRecHitInnerRadiusA_Barrel"));
+  ecalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("EcalRecHitOuterRadiusA_Barrel"));
+  ecalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("EcalRecHitEtaSliceA_Barrel"));
+  ecalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("EcalRecHitThreshEA_Barrel"));
+  ecalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("EcalRecHitThreshEtA_Barrel"));
 
-  i=0;
-  hcalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("HcalTowerInnerRadiusA_Barrel") );
-  hcalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("HcalTowerOuterRadiusA_Barrel") );
-  hcalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("HcalTowerThreshEA_Barrel") );
-  hcalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth1TowerInnerRadiusA_Barrel") );
-  hcalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth1TowerOuterRadiusA_Barrel") );
-  hcalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth1TowerThreshEA_Barrel") );
-  hcalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth2TowerInnerRadiusA_Barrel") );
-  hcalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth2TowerOuterRadiusA_Barrel") );
-  hcalIsoBarrelRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth2TowerThreshEA_Barrel") );
+  i = 0;
+  hcalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("HcalTowerInnerRadiusA_Barrel"));
+  hcalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("HcalTowerOuterRadiusA_Barrel"));
+  hcalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("HcalTowerThreshEA_Barrel"));
+  hcalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("HcalDepth1TowerInnerRadiusA_Barrel"));
+  hcalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("HcalDepth1TowerOuterRadiusA_Barrel"));
+  hcalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("HcalDepth1TowerThreshEA_Barrel"));
+  hcalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("HcalDepth2TowerInnerRadiusA_Barrel"));
+  hcalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("HcalDepth2TowerOuterRadiusA_Barrel"));
+  hcalIsoBarrelRadiusA_[i++] = (conf.getParameter<double>("HcalDepth2TowerThreshEA_Barrel"));
 
-  i=0;
-  trkIsoBarrelRadiusB_[i++] = (  conf.getParameter<double>("TrackConeOuterRadiusB_Barrel") );
-  trkIsoBarrelRadiusB_[i++] = (  conf.getParameter<double>("TrackConeInnerRadiusB_Barrel") ) ;
-  trkIsoBarrelRadiusB_[i++] = (  conf.getParameter<double>("isolationtrackThresholdB_Barrel") );
-  trkIsoBarrelRadiusB_[i++] = (  conf.getParameter<double>("longImpactParameterB_Barrel") );
-  trkIsoBarrelRadiusB_[i++] = (  conf.getParameter<double>("transImpactParameterB_Barrel") );
-  trkIsoBarrelRadiusB_[i++] = (  conf.getParameter<double>("isolationtrackEtaSliceB_Barrel") );
+  i = 0;
+  trkIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("TrackConeOuterRadiusB_Barrel"));
+  trkIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("TrackConeInnerRadiusB_Barrel"));
+  trkIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("isolationtrackThresholdB_Barrel"));
+  trkIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("longImpactParameterB_Barrel"));
+  trkIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("transImpactParameterB_Barrel"));
+  trkIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("isolationtrackEtaSliceB_Barrel"));
 
-  i=0;
-  ecalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("EcalRecHitInnerRadiusB_Barrel") );
-  ecalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("EcalRecHitOuterRadiusB_Barrel") );
-  ecalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("EcalRecHitEtaSliceB_Barrel") );
-  ecalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("EcalRecHitThreshEB_Barrel") );
-  ecalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("EcalRecHitThreshEtB_Barrel") );
+  i = 0;
+  ecalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("EcalRecHitInnerRadiusB_Barrel"));
+  ecalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("EcalRecHitOuterRadiusB_Barrel"));
+  ecalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("EcalRecHitEtaSliceB_Barrel"));
+  ecalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("EcalRecHitThreshEB_Barrel"));
+  ecalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("EcalRecHitThreshEtB_Barrel"));
 
-  i=0;
-  hcalIsoBarrelRadiusB_[i++] = (  conf.getParameter<double>("HcalTowerInnerRadiusB_Barrel") );
-  hcalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("HcalTowerOuterRadiusB_Barrel") );
-  hcalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("HcalTowerThreshEB_Barrel") );
-  hcalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth1TowerInnerRadiusB_Barrel") );
-  hcalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth1TowerOuterRadiusB_Barrel") );
-  hcalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth1TowerThreshEB_Barrel") );
-  hcalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth2TowerInnerRadiusB_Barrel") );
-  hcalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth2TowerOuterRadiusB_Barrel") );
-  hcalIsoBarrelRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth2TowerThreshEB_Barrel") );
+  i = 0;
+  hcalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("HcalTowerInnerRadiusB_Barrel"));
+  hcalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("HcalTowerOuterRadiusB_Barrel"));
+  hcalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("HcalTowerThreshEB_Barrel"));
+  hcalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("HcalDepth1TowerInnerRadiusB_Barrel"));
+  hcalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("HcalDepth1TowerOuterRadiusB_Barrel"));
+  hcalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("HcalDepth1TowerThreshEB_Barrel"));
+  hcalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("HcalDepth2TowerInnerRadiusB_Barrel"));
+  hcalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("HcalDepth2TowerOuterRadiusB_Barrel"));
+  hcalIsoBarrelRadiusB_[i++] = (conf.getParameter<double>("HcalDepth2TowerThreshEB_Barrel"));
 
   /// Isolation parameters for Endcap and for two different cone sizes
-  i=0;
-  trkIsoEndcapRadiusA_[i++] = (  conf.getParameter<double>("TrackConeOuterRadiusA_Endcap") );
-  trkIsoEndcapRadiusA_[i++] = (  conf.getParameter<double>("TrackConeInnerRadiusA_Endcap") ) ;
-  trkIsoEndcapRadiusA_[i++] = (  conf.getParameter<double>("isolationtrackThresholdA_Endcap") );
-  trkIsoEndcapRadiusA_[i++] = (  conf.getParameter<double>("longImpactParameterA_Endcap") );
-  trkIsoEndcapRadiusA_[i++] = (  conf.getParameter<double>("transImpactParameterA_Endcap") );
-  trkIsoEndcapRadiusA_[i++] = (  conf.getParameter<double>("isolationtrackEtaSliceA_Endcap") );
+  i = 0;
+  trkIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("TrackConeOuterRadiusA_Endcap"));
+  trkIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("TrackConeInnerRadiusA_Endcap"));
+  trkIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("isolationtrackThresholdA_Endcap"));
+  trkIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("longImpactParameterA_Endcap"));
+  trkIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("transImpactParameterA_Endcap"));
+  trkIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("isolationtrackEtaSliceA_Endcap"));
 
-  i=0;
-  ecalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("EcalRecHitInnerRadiusA_Endcap") );
-  ecalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("EcalRecHitOuterRadiusA_Endcap") );
-  ecalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("EcalRecHitEtaSliceA_Endcap") );
-  ecalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("EcalRecHitThreshEA_Endcap") );
-  ecalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("EcalRecHitThreshEtA_Endcap") );
+  i = 0;
+  ecalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("EcalRecHitInnerRadiusA_Endcap"));
+  ecalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("EcalRecHitOuterRadiusA_Endcap"));
+  ecalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("EcalRecHitEtaSliceA_Endcap"));
+  ecalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("EcalRecHitThreshEA_Endcap"));
+  ecalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("EcalRecHitThreshEtA_Endcap"));
 
-  i=0;
-  hcalIsoEndcapRadiusA_[i++] = (  conf.getParameter<double>("HcalTowerInnerRadiusA_Endcap") );
-  hcalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("HcalTowerOuterRadiusA_Endcap") );
-  hcalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("HcalTowerThreshEA_Endcap") );
-  hcalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth1TowerInnerRadiusA_Endcap") );
-  hcalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth1TowerOuterRadiusA_Endcap") );
-  hcalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth1TowerThreshEA_Endcap") );
-  hcalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth2TowerInnerRadiusA_Endcap") );
-  hcalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth2TowerOuterRadiusA_Endcap") );
-  hcalIsoEndcapRadiusA_[i++] = ( conf.getParameter<double>("HcalDepth2TowerThreshEA_Endcap") );
+  i = 0;
+  hcalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("HcalTowerInnerRadiusA_Endcap"));
+  hcalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("HcalTowerOuterRadiusA_Endcap"));
+  hcalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("HcalTowerThreshEA_Endcap"));
+  hcalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("HcalDepth1TowerInnerRadiusA_Endcap"));
+  hcalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("HcalDepth1TowerOuterRadiusA_Endcap"));
+  hcalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("HcalDepth1TowerThreshEA_Endcap"));
+  hcalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("HcalDepth2TowerInnerRadiusA_Endcap"));
+  hcalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("HcalDepth2TowerOuterRadiusA_Endcap"));
+  hcalIsoEndcapRadiusA_[i++] = (conf.getParameter<double>("HcalDepth2TowerThreshEA_Endcap"));
 
-  i=0;
-  trkIsoEndcapRadiusB_[i++] = (  conf.getParameter<double>("TrackConeOuterRadiusB_Endcap") );
-  trkIsoEndcapRadiusB_[i++] = (  conf.getParameter<double>("TrackConeInnerRadiusB_Endcap") ) ;
-  trkIsoEndcapRadiusB_[i++] = (  conf.getParameter<double>("isolationtrackThresholdB_Endcap") );
-  trkIsoEndcapRadiusB_[i++] = (  conf.getParameter<double>("longImpactParameterB_Endcap") );
-  trkIsoEndcapRadiusB_[i++] = (  conf.getParameter<double>("transImpactParameterB_Endcap") );
-  trkIsoEndcapRadiusB_[i++] = (  conf.getParameter<double>("isolationtrackEtaSliceB_Endcap") );
+  i = 0;
+  trkIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("TrackConeOuterRadiusB_Endcap"));
+  trkIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("TrackConeInnerRadiusB_Endcap"));
+  trkIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("isolationtrackThresholdB_Endcap"));
+  trkIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("longImpactParameterB_Endcap"));
+  trkIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("transImpactParameterB_Endcap"));
+  trkIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("isolationtrackEtaSliceB_Endcap"));
 
-  i=0;
-  ecalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("EcalRecHitInnerRadiusB_Endcap") );
-  ecalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("EcalRecHitOuterRadiusB_Endcap") );
-  ecalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("EcalRecHitEtaSliceB_Endcap") );
-  ecalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("EcalRecHitThreshEB_Endcap") );
-  ecalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("EcalRecHitThreshEtB_Endcap") );
+  i = 0;
+  ecalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("EcalRecHitInnerRadiusB_Endcap"));
+  ecalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("EcalRecHitOuterRadiusB_Endcap"));
+  ecalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("EcalRecHitEtaSliceB_Endcap"));
+  ecalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("EcalRecHitThreshEB_Endcap"));
+  ecalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("EcalRecHitThreshEtB_Endcap"));
 
-  i=0;
-  hcalIsoEndcapRadiusB_[i++] = (  conf.getParameter<double>("HcalTowerInnerRadiusB_Endcap") );
-  hcalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("HcalTowerOuterRadiusB_Endcap") );
-  hcalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("HcalTowerThreshEB_Endcap") );
-  hcalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth1TowerInnerRadiusB_Endcap") );
-  hcalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth1TowerOuterRadiusB_Endcap") );
-  hcalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth1TowerThreshEB_Endcap") );
-  hcalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth2TowerInnerRadiusB_Endcap") );
-  hcalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth2TowerOuterRadiusB_Endcap") );
-  hcalIsoEndcapRadiusB_[i++] = ( conf.getParameter<double>("HcalDepth2TowerThreshEB_Endcap") );
+  i = 0;
+  hcalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("HcalTowerInnerRadiusB_Endcap"));
+  hcalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("HcalTowerOuterRadiusB_Endcap"));
+  hcalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("HcalTowerThreshEB_Endcap"));
+  hcalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("HcalDepth1TowerInnerRadiusB_Endcap"));
+  hcalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("HcalDepth1TowerOuterRadiusB_Endcap"));
+  hcalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("HcalDepth1TowerThreshEB_Endcap"));
+  hcalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("HcalDepth2TowerInnerRadiusB_Endcap"));
+  hcalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("HcalDepth2TowerOuterRadiusB_Endcap"));
+  hcalIsoEndcapRadiusB_[i++] = (conf.getParameter<double>("HcalDepth2TowerThreshEB_Endcap"));
 
   //Pick up the variables for the spike removal
   flagsEB_ = flagsEB;
   flagsEE_ = flagsEE;
   severityExclEB_ = severitiesEB;
   severityExclEE_ = severitiesEE;
-
-
 }
 
-
 void PhotonIsolationCalculator::calculate(const reco::Photon* pho,
-					  const edm::Event& e,
-					  const edm::EventSetup& es,
-					  reco::Photon::FiducialFlags& phofid, 
-					  reco::Photon::IsolationVariables& phoisolR1, 
-					  reco::Photon::IsolationVariables& phoisolR2) const {
-
+                                          const edm::Event& e,
+                                          const edm::EventSetup& es,
+                                          reco::Photon::FiducialFlags& phofid,
+                                          reco::Photon::IsolationVariables& phoisolR1,
+                                          reco::Photon::IsolationVariables& phoisolR2) const {
   //Get fiducial flags. This does not really belong here
-  bool isEBPho     = false;
-  bool isEEPho     = false;
-  bool isEBEtaGap  = false;
-  bool isEBPhiGap  = false;
+  bool isEBPho = false;
+  bool isEEPho = false;
+  bool isEBEtaGap = false;
+  bool isEBPhiGap = false;
   bool isEERingGap = false;
-  bool isEEDeeGap  = false;
-  bool isEBEEGap   = false;
+  bool isEEDeeGap = false;
+  bool isEBEEGap = false;
   classify(pho, isEBPho, isEEPho, isEBEtaGap, isEBPhiGap, isEERingGap, isEEDeeGap, isEBEEGap);
   phofid.isEB = isEBPho;
   phofid.isEE = isEEPho;
-  phofid.isEBEtaGap  = isEBEtaGap;
-  phofid.isEBPhiGap  = isEBPhiGap;
+  phofid.isEBEtaGap = isEBEtaGap;
+  phofid.isEBPhiGap = isEBPhiGap;
   phofid.isEERingGap = isEERingGap;
-  phofid.isEEDeeGap  = isEEDeeGap;
-  phofid.isEBEEGap   = isEBEEGap;
-  
+  phofid.isEEDeeGap = isEEDeeGap;
+  phofid.isEBEEGap = isEBEEGap;
+
   // Calculate isolation variables. cone sizes and thresholds
-  // are set for Barrel and endcap separately 
+  // are set for Barrel and endcap separately
 
-  reco::SuperClusterRef scRef=pho->superCluster();
-  const reco::BasicCluster & seedCluster = *(scRef->seed()) ;
-  DetId seedXtalId = seedCluster.hitsAndFractions()[0].first ;
-  int detector = seedXtalId.subdetId() ;
-
+  reco::SuperClusterRef scRef = pho->superCluster();
+  const reco::BasicCluster& seedCluster = *(scRef->seed());
+  DetId seedXtalId = seedCluster.hitsAndFractions()[0].first;
+  int detector = seedXtalId.subdetId();
 
   //Isolation parameters variables
   double photonEcalRecHitConeInnerRadiusA_;
@@ -254,120 +250,130 @@ void PhotonIsolationCalculator::calculate(const reco::Photon* pho,
   double trackLipRadiusB_;
   double trackD0RadiusB_;
 
-  if (detector==EcalBarrel) {
-
-    trackConeOuterRadiusA_    = trkIsoBarrelRadiusA_[0];
-    trackConeInnerRadiusA_    = trkIsoBarrelRadiusA_[1];
+  if (detector == EcalBarrel) {
+    trackConeOuterRadiusA_ = trkIsoBarrelRadiusA_[0];
+    trackConeInnerRadiusA_ = trkIsoBarrelRadiusA_[1];
     isolationtrackThresholdA_ = trkIsoBarrelRadiusA_[2];
-    trackLipRadiusA_          = trkIsoBarrelRadiusA_[3];
-    trackD0RadiusA_           = trkIsoBarrelRadiusA_[4];
-    isolationtrackEtaSliceA_  = trkIsoBarrelRadiusA_[5];
+    trackLipRadiusA_ = trkIsoBarrelRadiusA_[3];
+    trackD0RadiusA_ = trkIsoBarrelRadiusA_[4];
+    isolationtrackEtaSliceA_ = trkIsoBarrelRadiusA_[5];
 
-    photonEcalRecHitConeInnerRadiusA_  = ecalIsoBarrelRadiusA_[0];
-    photonEcalRecHitConeOuterRadiusA_  = ecalIsoBarrelRadiusA_[1];
-    photonEcalRecHitEtaSliceA_         = ecalIsoBarrelRadiusA_[2];
-    photonEcalRecHitThreshEA_          = ecalIsoBarrelRadiusA_[3];
-    photonEcalRecHitThreshEtA_         = ecalIsoBarrelRadiusA_[4];
+    photonEcalRecHitConeInnerRadiusA_ = ecalIsoBarrelRadiusA_[0];
+    photonEcalRecHitConeOuterRadiusA_ = ecalIsoBarrelRadiusA_[1];
+    photonEcalRecHitEtaSliceA_ = ecalIsoBarrelRadiusA_[2];
+    photonEcalRecHitThreshEA_ = ecalIsoBarrelRadiusA_[3];
+    photonEcalRecHitThreshEtA_ = ecalIsoBarrelRadiusA_[4];
 
-    photonHcalTowerConeInnerRadiusA_       = hcalIsoBarrelRadiusA_[0];
-    photonHcalTowerConeOuterRadiusA_       = hcalIsoBarrelRadiusA_[1];
-    photonHcalTowerThreshEA_               = hcalIsoBarrelRadiusA_[2];
+    photonHcalTowerConeInnerRadiusA_ = hcalIsoBarrelRadiusA_[0];
+    photonHcalTowerConeOuterRadiusA_ = hcalIsoBarrelRadiusA_[1];
+    photonHcalTowerThreshEA_ = hcalIsoBarrelRadiusA_[2];
     photonHcalDepth1TowerConeInnerRadiusA_ = hcalIsoBarrelRadiusA_[3];
     photonHcalDepth1TowerConeOuterRadiusA_ = hcalIsoBarrelRadiusA_[4];
-    photonHcalDepth1TowerThreshEA_         = hcalIsoBarrelRadiusA_[5];
+    photonHcalDepth1TowerThreshEA_ = hcalIsoBarrelRadiusA_[5];
     photonHcalDepth2TowerConeInnerRadiusA_ = hcalIsoBarrelRadiusA_[6];
     photonHcalDepth2TowerConeOuterRadiusA_ = hcalIsoBarrelRadiusA_[7];
-    photonHcalDepth2TowerThreshEA_         = hcalIsoBarrelRadiusA_[8];
+    photonHcalDepth2TowerThreshEA_ = hcalIsoBarrelRadiusA_[8];
 
-
-    trackConeOuterRadiusB_    = trkIsoBarrelRadiusB_[0];
-    trackConeInnerRadiusB_    = trkIsoBarrelRadiusB_[1];
+    trackConeOuterRadiusB_ = trkIsoBarrelRadiusB_[0];
+    trackConeInnerRadiusB_ = trkIsoBarrelRadiusB_[1];
     isolationtrackThresholdB_ = trkIsoBarrelRadiusB_[2];
-    trackLipRadiusB_          = trkIsoBarrelRadiusB_[3];
-    trackD0RadiusB_           = trkIsoBarrelRadiusB_[4];
-    isolationtrackEtaSliceB_  = trkIsoBarrelRadiusB_[5];
+    trackLipRadiusB_ = trkIsoBarrelRadiusB_[3];
+    trackD0RadiusB_ = trkIsoBarrelRadiusB_[4];
+    isolationtrackEtaSliceB_ = trkIsoBarrelRadiusB_[5];
 
-    photonEcalRecHitConeInnerRadiusB_  = ecalIsoBarrelRadiusB_[0];
-    photonEcalRecHitConeOuterRadiusB_  = ecalIsoBarrelRadiusB_[1];
-    photonEcalRecHitEtaSliceB_         = ecalIsoBarrelRadiusB_[2];
-    photonEcalRecHitThreshEB_          = ecalIsoBarrelRadiusB_[3];
-    photonEcalRecHitThreshEtB_         = ecalIsoBarrelRadiusB_[4];
+    photonEcalRecHitConeInnerRadiusB_ = ecalIsoBarrelRadiusB_[0];
+    photonEcalRecHitConeOuterRadiusB_ = ecalIsoBarrelRadiusB_[1];
+    photonEcalRecHitEtaSliceB_ = ecalIsoBarrelRadiusB_[2];
+    photonEcalRecHitThreshEB_ = ecalIsoBarrelRadiusB_[3];
+    photonEcalRecHitThreshEtB_ = ecalIsoBarrelRadiusB_[4];
 
-    photonHcalTowerConeInnerRadiusB_       = hcalIsoBarrelRadiusB_[0];
-    photonHcalTowerConeOuterRadiusB_       = hcalIsoBarrelRadiusB_[1];
-    photonHcalTowerThreshEB_               = hcalIsoBarrelRadiusB_[2];
+    photonHcalTowerConeInnerRadiusB_ = hcalIsoBarrelRadiusB_[0];
+    photonHcalTowerConeOuterRadiusB_ = hcalIsoBarrelRadiusB_[1];
+    photonHcalTowerThreshEB_ = hcalIsoBarrelRadiusB_[2];
     photonHcalDepth1TowerConeInnerRadiusB_ = hcalIsoBarrelRadiusB_[3];
     photonHcalDepth1TowerConeOuterRadiusB_ = hcalIsoBarrelRadiusB_[4];
-    photonHcalDepth1TowerThreshEB_         = hcalIsoBarrelRadiusB_[5];
+    photonHcalDepth1TowerThreshEB_ = hcalIsoBarrelRadiusB_[5];
     photonHcalDepth2TowerConeInnerRadiusB_ = hcalIsoBarrelRadiusB_[6];
     photonHcalDepth2TowerConeOuterRadiusB_ = hcalIsoBarrelRadiusB_[7];
-    photonHcalDepth2TowerThreshEB_         = hcalIsoBarrelRadiusB_[8];
+    photonHcalDepth2TowerThreshEB_ = hcalIsoBarrelRadiusB_[8];
 
   } else {
     // detector==EcalEndcap
 
-    trackConeOuterRadiusA_    = trkIsoEndcapRadiusA_[0];
-    trackConeInnerRadiusA_    = trkIsoEndcapRadiusA_[1];
+    trackConeOuterRadiusA_ = trkIsoEndcapRadiusA_[0];
+    trackConeInnerRadiusA_ = trkIsoEndcapRadiusA_[1];
     isolationtrackThresholdA_ = trkIsoEndcapRadiusA_[2];
-    trackLipRadiusA_          = trkIsoEndcapRadiusA_[3];
-    trackD0RadiusA_           = trkIsoEndcapRadiusA_[4];
-    isolationtrackEtaSliceA_  = trkIsoEndcapRadiusA_[5];
+    trackLipRadiusA_ = trkIsoEndcapRadiusA_[3];
+    trackD0RadiusA_ = trkIsoEndcapRadiusA_[4];
+    isolationtrackEtaSliceA_ = trkIsoEndcapRadiusA_[5];
 
-    photonEcalRecHitConeInnerRadiusA_  = ecalIsoEndcapRadiusA_[0];
-    photonEcalRecHitConeOuterRadiusA_  = ecalIsoEndcapRadiusA_[1];
-    photonEcalRecHitEtaSliceA_         = ecalIsoEndcapRadiusA_[2];
-    photonEcalRecHitThreshEA_          = ecalIsoEndcapRadiusA_[3];
-    photonEcalRecHitThreshEtA_         = ecalIsoEndcapRadiusA_[4];
+    photonEcalRecHitConeInnerRadiusA_ = ecalIsoEndcapRadiusA_[0];
+    photonEcalRecHitConeOuterRadiusA_ = ecalIsoEndcapRadiusA_[1];
+    photonEcalRecHitEtaSliceA_ = ecalIsoEndcapRadiusA_[2];
+    photonEcalRecHitThreshEA_ = ecalIsoEndcapRadiusA_[3];
+    photonEcalRecHitThreshEtA_ = ecalIsoEndcapRadiusA_[4];
 
-    photonHcalTowerConeInnerRadiusA_       = hcalIsoEndcapRadiusA_[0];
-    photonHcalTowerConeOuterRadiusA_       = hcalIsoEndcapRadiusA_[1];
-    photonHcalTowerThreshEA_               = hcalIsoEndcapRadiusA_[2];
+    photonHcalTowerConeInnerRadiusA_ = hcalIsoEndcapRadiusA_[0];
+    photonHcalTowerConeOuterRadiusA_ = hcalIsoEndcapRadiusA_[1];
+    photonHcalTowerThreshEA_ = hcalIsoEndcapRadiusA_[2];
     photonHcalDepth1TowerConeInnerRadiusA_ = hcalIsoEndcapRadiusA_[3];
     photonHcalDepth1TowerConeOuterRadiusA_ = hcalIsoEndcapRadiusA_[4];
-    photonHcalDepth1TowerThreshEA_         = hcalIsoEndcapRadiusA_[5];
+    photonHcalDepth1TowerThreshEA_ = hcalIsoEndcapRadiusA_[5];
     photonHcalDepth2TowerConeInnerRadiusA_ = hcalIsoEndcapRadiusA_[6];
     photonHcalDepth2TowerConeOuterRadiusA_ = hcalIsoEndcapRadiusA_[7];
-    photonHcalDepth2TowerThreshEA_         = hcalIsoEndcapRadiusA_[8];
+    photonHcalDepth2TowerThreshEA_ = hcalIsoEndcapRadiusA_[8];
 
-
-    trackConeOuterRadiusB_    = trkIsoEndcapRadiusB_[0];
-    trackConeInnerRadiusB_    = trkIsoEndcapRadiusB_[1];
+    trackConeOuterRadiusB_ = trkIsoEndcapRadiusB_[0];
+    trackConeInnerRadiusB_ = trkIsoEndcapRadiusB_[1];
     isolationtrackThresholdB_ = trkIsoEndcapRadiusB_[2];
-    trackLipRadiusB_          = trkIsoEndcapRadiusB_[3];
-    trackD0RadiusB_           = trkIsoEndcapRadiusB_[4];
-    isolationtrackEtaSliceB_  = trkIsoEndcapRadiusB_[5];
+    trackLipRadiusB_ = trkIsoEndcapRadiusB_[3];
+    trackD0RadiusB_ = trkIsoEndcapRadiusB_[4];
+    isolationtrackEtaSliceB_ = trkIsoEndcapRadiusB_[5];
 
+    photonEcalRecHitConeInnerRadiusB_ = ecalIsoEndcapRadiusB_[0];
+    photonEcalRecHitConeOuterRadiusB_ = ecalIsoEndcapRadiusB_[1];
+    photonEcalRecHitEtaSliceB_ = ecalIsoEndcapRadiusB_[2];
+    photonEcalRecHitThreshEB_ = ecalIsoEndcapRadiusB_[3];
+    photonEcalRecHitThreshEtB_ = ecalIsoEndcapRadiusB_[4];
 
-    photonEcalRecHitConeInnerRadiusB_  = ecalIsoEndcapRadiusB_[0];
-    photonEcalRecHitConeOuterRadiusB_  = ecalIsoEndcapRadiusB_[1];
-    photonEcalRecHitEtaSliceB_         = ecalIsoEndcapRadiusB_[2];
-    photonEcalRecHitThreshEB_          = ecalIsoEndcapRadiusB_[3];
-    photonEcalRecHitThreshEtB_         = ecalIsoEndcapRadiusB_[4];
-
-    photonHcalTowerConeInnerRadiusB_       = hcalIsoEndcapRadiusB_[0];
-    photonHcalTowerConeOuterRadiusB_       = hcalIsoEndcapRadiusB_[1];
-    photonHcalTowerThreshEB_               = hcalIsoEndcapRadiusB_[2];
+    photonHcalTowerConeInnerRadiusB_ = hcalIsoEndcapRadiusB_[0];
+    photonHcalTowerConeOuterRadiusB_ = hcalIsoEndcapRadiusB_[1];
+    photonHcalTowerThreshEB_ = hcalIsoEndcapRadiusB_[2];
     photonHcalDepth1TowerConeInnerRadiusB_ = hcalIsoEndcapRadiusB_[3];
     photonHcalDepth1TowerConeOuterRadiusB_ = hcalIsoEndcapRadiusB_[4];
-    photonHcalDepth1TowerThreshEB_         = hcalIsoEndcapRadiusB_[5];
+    photonHcalDepth1TowerThreshEB_ = hcalIsoEndcapRadiusB_[5];
     photonHcalDepth2TowerConeInnerRadiusB_ = hcalIsoEndcapRadiusB_[6];
     photonHcalDepth2TowerConeOuterRadiusB_ = hcalIsoEndcapRadiusB_[7];
-    photonHcalDepth2TowerThreshEB_         = hcalIsoEndcapRadiusB_[8];
-
+    photonHcalDepth2TowerThreshEB_ = hcalIsoEndcapRadiusB_[8];
   }
 
- 
   //Calculate hollow cone track isolation, CONE A
-  int ntrkA=0;
-  double trkisoA=0;
-  calculateTrackIso(pho, e, trkisoA, ntrkA, isolationtrackThresholdA_,    
-		    trackConeOuterRadiusA_, trackConeInnerRadiusA_, isolationtrackEtaSliceA_, trackLipRadiusA_, trackD0RadiusA_);
+  int ntrkA = 0;
+  double trkisoA = 0;
+  calculateTrackIso(pho,
+                    e,
+                    trkisoA,
+                    ntrkA,
+                    isolationtrackThresholdA_,
+                    trackConeOuterRadiusA_,
+                    trackConeInnerRadiusA_,
+                    isolationtrackEtaSliceA_,
+                    trackLipRadiusA_,
+                    trackD0RadiusA_);
 
   //Calculate solid cone track isolation, CONE A
-  int sntrkA=0;
-  double strkisoA=0;
-  calculateTrackIso(pho, e, strkisoA, sntrkA, isolationtrackThresholdA_,    
-		    trackConeOuterRadiusA_, 0., isolationtrackEtaSliceA_, trackLipRadiusA_, trackD0RadiusA_ );
+  int sntrkA = 0;
+  double strkisoA = 0;
+  calculateTrackIso(pho,
+                    e,
+                    strkisoA,
+                    sntrkA,
+                    isolationtrackThresholdA_,
+                    trackConeOuterRadiusA_,
+                    0.,
+                    isolationtrackEtaSliceA_,
+                    trackLipRadiusA_,
+                    trackD0RadiusA_);
 
   phoisolR1.nTrkHollowCone = ntrkA;
   phoisolR1.trkSumPtHollowCone = trkisoA;
@@ -375,217 +381,226 @@ void PhotonIsolationCalculator::calculate(const reco::Photon* pho,
   phoisolR1.trkSumPtSolidCone = strkisoA;
 
   //Calculate hollow cone track isolation, CONE B
-  int ntrkB=0;
-  double trkisoB=0;
-  calculateTrackIso(pho, e, trkisoB, ntrkB, isolationtrackThresholdB_,    
-		    trackConeOuterRadiusB_, trackConeInnerRadiusB_,  isolationtrackEtaSliceB_, trackLipRadiusB_, trackD0RadiusB_ );
+  int ntrkB = 0;
+  double trkisoB = 0;
+  calculateTrackIso(pho,
+                    e,
+                    trkisoB,
+                    ntrkB,
+                    isolationtrackThresholdB_,
+                    trackConeOuterRadiusB_,
+                    trackConeInnerRadiusB_,
+                    isolationtrackEtaSliceB_,
+                    trackLipRadiusB_,
+                    trackD0RadiusB_);
 
   //Calculate solid cone track isolation, CONE B
-  int sntrkB=0;
-  double strkisoB=0;
-  calculateTrackIso(pho, e, strkisoB, sntrkB, isolationtrackThresholdB_,    
-		    trackConeOuterRadiusB_, 0., isolationtrackEtaSliceB_, trackLipRadiusB_, trackD0RadiusB_);
+  int sntrkB = 0;
+  double strkisoB = 0;
+  calculateTrackIso(pho,
+                    e,
+                    strkisoB,
+                    sntrkB,
+                    isolationtrackThresholdB_,
+                    trackConeOuterRadiusB_,
+                    0.,
+                    isolationtrackEtaSliceB_,
+                    trackLipRadiusB_,
+                    trackD0RadiusB_);
 
   phoisolR2.nTrkHollowCone = ntrkB;
   phoisolR2.trkSumPtHollowCone = trkisoB;
   phoisolR2.nTrkSolidCone = sntrkB;
   phoisolR2.trkSumPtSolidCone = strkisoB;
 
-//   std::cout << "Output from solid cone track isolation: ";
-//   std::cout << " Sum pT: " << strkiso << " ntrk: " << sntrk << std::endl;
-  
-  double EcalRecHitIsoA = calculateEcalRecHitIso(pho, e, es,
-						 photonEcalRecHitConeOuterRadiusA_,
-						 photonEcalRecHitConeInnerRadiusA_,
-						 photonEcalRecHitEtaSliceA_,
-						 photonEcalRecHitThreshEA_,
-						 photonEcalRecHitThreshEtA_,
-						 vetoClusteredEcalHits_,
-						 useNumCrystals_);
+  //   std::cout << "Output from solid cone track isolation: ";
+  //   std::cout << " Sum pT: " << strkiso << " ntrk: " << sntrk << std::endl;
+
+  double EcalRecHitIsoA = calculateEcalRecHitIso(pho,
+                                                 e,
+                                                 es,
+                                                 photonEcalRecHitConeOuterRadiusA_,
+                                                 photonEcalRecHitConeInnerRadiusA_,
+                                                 photonEcalRecHitEtaSliceA_,
+                                                 photonEcalRecHitThreshEA_,
+                                                 photonEcalRecHitThreshEtA_,
+                                                 vetoClusteredEcalHits_,
+                                                 useNumCrystals_);
   phoisolR1.ecalRecHitSumEt = EcalRecHitIsoA;
 
-  double EcalRecHitIsoB = calculateEcalRecHitIso(pho, e, es,
-						 photonEcalRecHitConeOuterRadiusB_,
-						 photonEcalRecHitConeInnerRadiusB_,
-						 photonEcalRecHitEtaSliceB_,
-						 photonEcalRecHitThreshEB_,
-						 photonEcalRecHitThreshEtB_,
-						 vetoClusteredEcalHits_,
-						 useNumCrystals_);
+  double EcalRecHitIsoB = calculateEcalRecHitIso(pho,
+                                                 e,
+                                                 es,
+                                                 photonEcalRecHitConeOuterRadiusB_,
+                                                 photonEcalRecHitConeInnerRadiusB_,
+                                                 photonEcalRecHitEtaSliceB_,
+                                                 photonEcalRecHitThreshEB_,
+                                                 photonEcalRecHitThreshEtB_,
+                                                 vetoClusteredEcalHits_,
+                                                 useNumCrystals_);
   phoisolR2.ecalRecHitSumEt = EcalRecHitIsoB;
 
-
-  double HcalTowerIsoA = calculateHcalTowerIso(pho, e, es, photonHcalTowerConeOuterRadiusA_,
-					      photonHcalTowerConeInnerRadiusA_,
-					      photonHcalTowerThreshEA_, -1 );
+  double HcalTowerIsoA = calculateHcalTowerIso(
+      pho, e, es, photonHcalTowerConeOuterRadiusA_, photonHcalTowerConeInnerRadiusA_, photonHcalTowerThreshEA_, -1);
   phoisolR1.hcalTowerSumEt = HcalTowerIsoA;
 
-
-  double HcalTowerIsoB = calculateHcalTowerIso(pho, e, es, photonHcalTowerConeOuterRadiusB_,
-					      photonHcalTowerConeInnerRadiusB_,
-					      photonHcalTowerThreshEB_, -1 );
+  double HcalTowerIsoB = calculateHcalTowerIso(
+      pho, e, es, photonHcalTowerConeOuterRadiusB_, photonHcalTowerConeInnerRadiusB_, photonHcalTowerThreshEB_, -1);
   phoisolR2.hcalTowerSumEt = HcalTowerIsoB;
 
   //// Hcal depth1
 
-  double HcalDepth1TowerIsoA = calculateHcalTowerIso(pho, e, es, photonHcalDepth1TowerConeOuterRadiusA_,
-					      photonHcalDepth1TowerConeInnerRadiusA_,
-					      photonHcalDepth1TowerThreshEA_, 1 );
+  double HcalDepth1TowerIsoA = calculateHcalTowerIso(pho,
+                                                     e,
+                                                     es,
+                                                     photonHcalDepth1TowerConeOuterRadiusA_,
+                                                     photonHcalDepth1TowerConeInnerRadiusA_,
+                                                     photonHcalDepth1TowerThreshEA_,
+                                                     1);
   phoisolR1.hcalDepth1TowerSumEt = HcalDepth1TowerIsoA;
 
-
-  double HcalDepth1TowerIsoB = calculateHcalTowerIso(pho, e, es, photonHcalDepth1TowerConeOuterRadiusB_,
-					      photonHcalDepth1TowerConeInnerRadiusB_,
-					      photonHcalDepth1TowerThreshEB_, 1 );
+  double HcalDepth1TowerIsoB = calculateHcalTowerIso(pho,
+                                                     e,
+                                                     es,
+                                                     photonHcalDepth1TowerConeOuterRadiusB_,
+                                                     photonHcalDepth1TowerConeInnerRadiusB_,
+                                                     photonHcalDepth1TowerThreshEB_,
+                                                     1);
   phoisolR2.hcalDepth1TowerSumEt = HcalDepth1TowerIsoB;
-
-
 
   //// Hcal depth2
 
-  double HcalDepth2TowerIsoA = calculateHcalTowerIso(pho, e, es, photonHcalDepth2TowerConeOuterRadiusA_,
-						       photonHcalDepth2TowerConeInnerRadiusA_,
-						       photonHcalDepth2TowerThreshEA_, 2 );
+  double HcalDepth2TowerIsoA = calculateHcalTowerIso(pho,
+                                                     e,
+                                                     es,
+                                                     photonHcalDepth2TowerConeOuterRadiusA_,
+                                                     photonHcalDepth2TowerConeInnerRadiusA_,
+                                                     photonHcalDepth2TowerThreshEA_,
+                                                     2);
   phoisolR1.hcalDepth2TowerSumEt = HcalDepth2TowerIsoA;
 
-
-  double HcalDepth2TowerIsoB = calculateHcalTowerIso(pho, e, es, photonHcalDepth2TowerConeOuterRadiusB_,
-					      photonHcalDepth2TowerConeInnerRadiusB_,
-					      photonHcalDepth2TowerThreshEB_, 2 );
+  double HcalDepth2TowerIsoB = calculateHcalTowerIso(pho,
+                                                     e,
+                                                     es,
+                                                     photonHcalDepth2TowerConeOuterRadiusB_,
+                                                     photonHcalDepth2TowerConeInnerRadiusB_,
+                                                     photonHcalDepth2TowerThreshEB_,
+                                                     2);
   phoisolR2.hcalDepth2TowerSumEt = HcalDepth2TowerIsoB;
 
-
   // New Hcal isolation based on the new H/E definition (towers behind the BCs in the SC are used to evaluated H)
-  double HcalTowerBcIsoA = calculateHcalTowerIso(pho, e, es, photonHcalTowerConeOuterRadiusA_,
-						 photonHcalTowerThreshEA_, -1 );
+  double HcalTowerBcIsoA =
+      calculateHcalTowerIso(pho, e, es, photonHcalTowerConeOuterRadiusA_, photonHcalTowerThreshEA_, -1);
   phoisolR1.hcalTowerSumEtBc = HcalTowerBcIsoA;
 
-
-  double HcalTowerBcIsoB = calculateHcalTowerIso(pho, e, es, photonHcalTowerConeOuterRadiusB_,
-						 photonHcalTowerThreshEB_, -1 );
+  double HcalTowerBcIsoB =
+      calculateHcalTowerIso(pho, e, es, photonHcalTowerConeOuterRadiusB_, photonHcalTowerThreshEB_, -1);
   phoisolR2.hcalTowerSumEtBc = HcalTowerBcIsoB;
 
   //// Hcal depth1
 
-  double HcalDepth1TowerBcIsoA = calculateHcalTowerIso(pho, e, es, photonHcalDepth1TowerConeOuterRadiusA_,
-						       photonHcalDepth1TowerThreshEA_, 1 );
+  double HcalDepth1TowerBcIsoA =
+      calculateHcalTowerIso(pho, e, es, photonHcalDepth1TowerConeOuterRadiusA_, photonHcalDepth1TowerThreshEA_, 1);
   phoisolR1.hcalDepth1TowerSumEtBc = HcalDepth1TowerBcIsoA;
 
-
-  double HcalDepth1TowerBcIsoB = calculateHcalTowerIso(pho, e, es, photonHcalDepth1TowerConeOuterRadiusB_,
-						       photonHcalDepth1TowerThreshEB_, 1 );
+  double HcalDepth1TowerBcIsoB =
+      calculateHcalTowerIso(pho, e, es, photonHcalDepth1TowerConeOuterRadiusB_, photonHcalDepth1TowerThreshEB_, 1);
   phoisolR2.hcalDepth1TowerSumEtBc = HcalDepth1TowerBcIsoB;
-
-
 
   //// Hcal depth2
 
-  double HcalDepth2TowerBcIsoA = calculateHcalTowerIso(pho, e, es, photonHcalDepth2TowerConeOuterRadiusA_,
-						       photonHcalDepth2TowerThreshEA_, 2 );
+  double HcalDepth2TowerBcIsoA =
+      calculateHcalTowerIso(pho, e, es, photonHcalDepth2TowerConeOuterRadiusA_, photonHcalDepth2TowerThreshEA_, 2);
   phoisolR1.hcalDepth2TowerSumEtBc = HcalDepth2TowerBcIsoA;
 
-
-  double HcalDepth2TowerBcIsoB = calculateHcalTowerIso(pho, e, es, photonHcalDepth2TowerConeOuterRadiusB_,
-						       photonHcalDepth2TowerThreshEB_, 2 );
+  double HcalDepth2TowerBcIsoB =
+      calculateHcalTowerIso(pho, e, es, photonHcalDepth2TowerConeOuterRadiusB_, photonHcalDepth2TowerThreshEB_, 2);
   phoisolR2.hcalDepth2TowerSumEtBc = HcalDepth2TowerBcIsoB;
-
-
-
 }
 
-
-void PhotonIsolationCalculator::classify(const reco::Photon* photon, 
-					 bool &isEBPho,
-					 bool &isEEPho,
-					 bool &isEBEtaGap,
-					 bool &isEBPhiGap,
-					 bool &isEERingGap,
-					 bool &isEEDeeGap,
-					 bool &isEBEEGap){
-
-
-  const reco::CaloCluster & seedCluster = *(photon->superCluster()->seed()) ;
-  // following line is temporary until the D. Evans or F. Ferri submit the new tag for ClusterAlgos 
-  // DEfinitive will be 
+void PhotonIsolationCalculator::classify(const reco::Photon* photon,
+                                         bool& isEBPho,
+                                         bool& isEEPho,
+                                         bool& isEBEtaGap,
+                                         bool& isEBPhiGap,
+                                         bool& isEERingGap,
+                                         bool& isEEDeeGap,
+                                         bool& isEBEEGap) {
+  const reco::CaloCluster& seedCluster = *(photon->superCluster()->seed());
+  // following line is temporary until the D. Evans or F. Ferri submit the new tag for ClusterAlgos
+  // DEfinitive will be
   // DetId seedXtalId = scRef->seed()->seed();
-  DetId seedXtalId = seedCluster.hitsAndFractions()[0].first ;
-  int detector = seedXtalId.subdetId() ;
+  DetId seedXtalId = seedCluster.hitsAndFractions()[0].first;
+  int detector = seedXtalId.subdetId();
 
   //Set fiducial flags for this photon.
   double eta = photon->superCluster()->position().eta();
   double feta = fabs(eta);
 
-  if (detector==EcalBarrel) {
-
-
+  if (detector == EcalBarrel) {
     isEBPho = true;
     if (EBDetId::isNextToEtaBoundary(EBDetId(seedXtalId))) {
-      if (fabs(feta-1.479)<.1) isEBEEGap = true ; 
+      if (fabs(feta - 1.479) < .1)
+        isEBEEGap = true;
       else
-	isEBEtaGap = true ; 
+        isEBEtaGap = true;
     }
 
     if (EBDetId::isNextToPhiBoundary(EBDetId(seedXtalId)))
-      isEBPhiGap = true ; 
+      isEBPhiGap = true;
 
-
-
-  } else if (detector==EcalEndcap) {
-
+  } else if (detector == EcalEndcap) {
     isEEPho = true;
     if (EEDetId::isNextToRingBoundary(EEDetId(seedXtalId))) {
-      if (fabs(feta-1.479)<.1) isEBEEGap = true ; 
+      if (fabs(feta - 1.479) < .1)
+        isEBEEGap = true;
       else
-	isEERingGap = true ; 
+        isEERingGap = true;
     }
 
     if (EEDetId::isNextToDBoundary(EEDetId(seedXtalId)))
-      isEEDeeGap = true ; 
+      isEEDeeGap = true;
   }
-
-
 }
 
 void PhotonIsolationCalculator::calculateTrackIso(const reco::Photon* photon,
                                                   const edm::Event& e,
-                                                  double &trkCone,
-                                                  int &ntrkCone,
+                                                  double& trkCone,
+                                                  int& ntrkCone,
                                                   double pTThresh,
                                                   double RCone,
                                                   double RinnerCone,
-                                                  double etaSlice, 
-                                                  double lip, 
-                                                  double d0)  const {
-  
-  ntrkCone =0;trkCone=0;
+                                                  double etaSlice,
+                                                  double lip,
+                                                  double d0) const {
+  ntrkCone = 0;
+  trkCone = 0;
   //get the tracks
   edm::Handle<reco::TrackCollection> tracks;
-  e.getByToken(trackInputTag_,tracks);
-  if(!tracks.isValid()) {
+  e.getByToken(trackInputTag_, tracks);
+  if (!tracks.isValid()) {
     return;
   }
   const reco::TrackCollection* trackCollection = tracks.product();
   //Photon Eta and Phi.  Hope these are correct.
   reco::BeamSpot vertexBeamSpot;
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  e.getByToken(beamSpotProducerTag_,recoBeamSpotHandle);
+  e.getByToken(beamSpotProducerTag_, recoBeamSpotHandle);
   vertexBeamSpot = *recoBeamSpotHandle;
-  
-  PhotonTkIsolation phoIso(RCone, 
-			   RinnerCone, 
-			   etaSlice,  
-			   pTThresh, 
-			   lip , 
-			   d0, 
-			   trackCollection, 
-			   math::XYZPoint(vertexBeamSpot.x0(),vertexBeamSpot.y0(),vertexBeamSpot.z0()));
 
-  std::pair<int,double> res = phoIso.getIso(photon);
+  PhotonTkIsolation phoIso(RCone,
+                           RinnerCone,
+                           etaSlice,
+                           pTThresh,
+                           lip,
+                           d0,
+                           trackCollection,
+                           math::XYZPoint(vertexBeamSpot.x0(), vertexBeamSpot.y0(), vertexBeamSpot.z0()));
+
+  std::pair<int, double> res = phoIso.getIso(photon);
   ntrkCone = res.first;
   trkCone = res.second;
 }
-
-
 
 double PhotonIsolationCalculator::calculateEcalRecHitIso(const reco::Photon* photon,
                                                          const edm::Event& iEvent,
@@ -596,15 +611,13 @@ double PhotonIsolationCalculator::calculateEcalRecHitIso(const reco::Photon* pho
                                                          double eMin,
                                                          double etMin,
                                                          bool vetoClusteredHits,
-                                                         bool useNumXtals)  const
-{
-  
+                                                         bool useNumXtals) const {
   edm::Handle<EcalRecHitCollection> ecalhitsCollEB;
   edm::Handle<EcalRecHitCollection> ecalhitsCollEE;
   iEvent.getByToken(endcapecalCollection_, ecalhitsCollEE);
- 
+
   iEvent.getByToken(barrelecalCollection_, ecalhitsCollEB);
- 
+
   const EcalRecHitCollection* rechitsCollectionEE_ = ecalhitsCollEE.product();
   const EcalRecHitCollection* rechitsCollectionEB_ = ecalhitsCollEB.product();
 
@@ -615,65 +628,47 @@ double PhotonIsolationCalculator::calculateEcalRecHitIso(const reco::Photon* pho
   edm::ESHandle<CaloGeometry> geoHandle;
   iSetup.get<CaloGeometryRecord>().get(geoHandle);
 
-  EgammaRecHitIsolation phoIsoEB(RCone,
-                                 RConeInner,
-                                 etaSlice,
-                                 etMin,
-                                 eMin,
-                                 geoHandle,
-                                 *rechitsCollectionEB_,
-                                 sevLevel,
-                                 DetId::Ecal);
+  EgammaRecHitIsolation phoIsoEB(
+      RCone, RConeInner, etaSlice, etMin, eMin, geoHandle, *rechitsCollectionEB_, sevLevel, DetId::Ecal);
 
   phoIsoEB.setVetoClustered(vetoClusteredHits);
   phoIsoEB.setUseNumCrystals(useNumXtals);
   phoIsoEB.doSeverityChecks(ecalhitsCollEB.product(), severityExclEB_);
   phoIsoEB.doFlagChecks(flagsEB_);
   double ecalIsolEB = phoIsoEB.getEtSum(photon);
-  
-  EgammaRecHitIsolation phoIsoEE(RCone,
-                                 RConeInner,
-                                 etaSlice,
-                                 etMin,
-                                 eMin,
-                                 geoHandle,
-                                 *rechitsCollectionEE_,
-                                 sevLevel,
-                                 DetId::Ecal);
-  
+
+  EgammaRecHitIsolation phoIsoEE(
+      RCone, RConeInner, etaSlice, etMin, eMin, geoHandle, *rechitsCollectionEE_, sevLevel, DetId::Ecal);
+
   phoIsoEE.setVetoClustered(vetoClusteredHits);
   phoIsoEE.setUseNumCrystals(useNumXtals);
-  phoIsoEE.doSeverityChecks(ecalhitsCollEE.product(), severityExclEE_); 
+  phoIsoEE.doSeverityChecks(ecalhitsCollEE.product(), severityExclEE_);
   phoIsoEE.doFlagChecks(flagsEE_);
 
   double ecalIsolEE = phoIsoEE.getEtSum(photon);
   //  delete phoIso;
   double ecalIsol = ecalIsolEB + ecalIsolEE;
-  
+
   return ecalIsol;
 }
 
 double PhotonIsolationCalculator::calculateHcalTowerIso(const reco::Photon* photon,
-							const edm::Event& iEvent,
-							const edm::EventSetup& iSetup,
-							double RCone,
-							double RConeInner,
-							double eMin,
-							signed int depth )  const
-{
-  double hcalIsol=0.;
- 
+                                                        const edm::Event& iEvent,
+                                                        const edm::EventSetup& iSetup,
+                                                        double RCone,
+                                                        double RConeInner,
+                                                        double eMin,
+                                                        signed int depth) const {
+  double hcalIsol = 0.;
+
   if (not hcalCollection_.isUninitialized()) {
     edm::Handle<CaloTowerCollection> hcalhitsCollH;
     iEvent.getByToken(hcalCollection_, hcalhitsCollH);
 
-    const CaloTowerCollection *toww = hcalhitsCollH.product();
+    const CaloTowerCollection* toww = hcalhitsCollH.product();
 
     //std::cout << "before iso call" << std::endl;
-    EgammaTowerIsolation phoIso(RCone,
-				RConeInner,
-				eMin,depth,
-				toww);
+    EgammaTowerIsolation phoIso(RCone, RConeInner, eMin, depth, toww);
     hcalIsol = phoIso.getTowerEtSum(photon);
     //  delete phoIso;
     //std::cout << "after call" << std::endl;
@@ -682,29 +677,23 @@ double PhotonIsolationCalculator::calculateHcalTowerIso(const reco::Photon* phot
   return hcalIsol;
 }
 
-
-
 double PhotonIsolationCalculator::calculateHcalTowerIso(const reco::Photon* photon,
-							const edm::Event& iEvent,
-							const edm::EventSetup& iSetup,
-							double RCone,
-							double eMin,
-							signed int depth )  const
-{
-  double hcalIsol=0.;
+                                                        const edm::Event& iEvent,
+                                                        const edm::EventSetup& iSetup,
+                                                        double RCone,
+                                                        double eMin,
+                                                        signed int depth) const {
+  double hcalIsol = 0.;
 
   if (not hcalCollection_.isUninitialized()) {
     edm::Handle<CaloTowerCollection> hcalhitsCollH;
     iEvent.getByToken(hcalCollection_, hcalhitsCollH);
-  
-    const CaloTowerCollection *toww = hcalhitsCollH.product();
+
+    const CaloTowerCollection* toww = hcalhitsCollH.product();
 
     //std::cout << "before iso call" << std::endl;
-    EgammaTowerIsolation phoIso(RCone,
-				0.,
-				eMin,depth,
-				toww);
-    hcalIsol = phoIso.getTowerEtSum(photon, &(photon->hcalTowersBehindClusters()) );
+    EgammaTowerIsolation phoIso(RCone, 0., eMin, depth, toww);
+    hcalIsol = phoIso.getTowerEtSum(photon, &(photon->hcalTowersBehindClusters()));
     //  delete phoIso;
     //std::cout << "after call" << std::endl;
   }

--- a/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
@@ -44,144 +44,109 @@
 #include <string>
 #include <TMath.h>
 
-
-void PhotonMIPHaloTagger::setup(const edm::ParameterSet& conf,edm::ConsumesCollector && iC) {
-
-
+void PhotonMIPHaloTagger::setup(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC) {
   EBecalCollection_ = iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("barrelEcalRecHitCollection"));
   EEecalCollection_ = iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("endcapEcalRecHitCollection"));
 
-
-  yRangeFit_             = conf.getParameter<double>("YRangeFit");
-  xRangeFit_             = conf.getParameter<double>("XRangeFit");
-  residualWidthEnergy_   = conf.getParameter<double>("ResidualWidth");
-  haloDiscThreshold_     = conf.getParameter<double>("HaloDiscThreshold");
-
-
+  yRangeFit_ = conf.getParameter<double>("YRangeFit");
+  xRangeFit_ = conf.getParameter<double>("XRangeFit");
+  residualWidthEnergy_ = conf.getParameter<double>("ResidualWidth");
+  haloDiscThreshold_ = conf.getParameter<double>("HaloDiscThreshold");
 }
 
-
-
-
-
 void PhotonMIPHaloTagger::MIPcalculate(const reco::Photon* pho,
-				     const edm::Event& e,
-				     const edm::EventSetup& es,
-                                     reco::Photon::MIPVariables& mipId){
-
+                                       const edm::Event& e,
+                                       const edm::EventSetup& es,
+                                       reco::Photon::MIPVariables& mipId) {
   //get the predefined variables
-  inputRangeY      = yRangeFit_; 
-  inputRangeX      = xRangeFit_;
-  inputResWidth    = residualWidthEnergy_;
+  inputRangeY = yRangeFit_;
+  inputRangeX = xRangeFit_;
+  inputResWidth = residualWidthEnergy_;
   inputHaloDiscCut = haloDiscThreshold_;
-
-
 
   //First store in local variables
   mipFitResults_.clear();
 
-  nhitCone_  = -99;       //hit inside the cone
-  ismipHalo_ = false;     // halo?
-
-
+  nhitCone_ = -99;     //hit inside the cone
+  ismipHalo_ = false;  // halo?
 
   // Get EcalRecHits
-  bool validEcalRecHits=true;
+  bool validEcalRecHits = true;
 
   edm::Handle<EcalRecHitCollection> barrelHitHandle;
   e.getByToken(EBecalCollection_, barrelHitHandle);
 
   if (!barrelHitHandle.isValid()) {
-    edm::LogError("MIPcalculate") << "Error! Can't get the barrel hits product ";//<<EBecalCollection_.label(); (cant be bothered tracking the input tag just for this error message)
-    validEcalRecHits=false;
+    edm::LogError("MIPcalculate")
+        << "Error! Can't get the barrel hits product ";  //<<EBecalCollection_.label(); (cant be bothered tracking the input tag just for this error message)
+    validEcalRecHits = false;
   }
 
+  if (validEcalRecHits) {
+    // GetMIPTrailFit
+    mipFitResults_ = GetMipTrailFit(
+        pho, e, es, barrelHitHandle, inputRangeY, inputRangeX, inputResWidth, inputHaloDiscCut, nhitCone_, ismipHalo_);
 
-  if(validEcalRecHits){ 
-          // GetMIPTrailFit
-          mipFitResults_ = GetMipTrailFit(pho, e, es,
-                                          barrelHitHandle,
-                                          inputRangeY, inputRangeX, inputResWidth, inputHaloDiscCut,
-                                          nhitCone_,
-                                          ismipHalo_ );
-
-
-
-  //Now set the variable in "MIPVaraible"
-  mipId.mipChi2         = mipFitResults_[0];
-  mipId.mipTotEnergy    = mipFitResults_[1];
-  mipId.mipSlope        = mipFitResults_[2]; 
-  mipId.mipIntercept    = mipFitResults_[3];
-  mipId.mipNhitCone     = nhitCone_;
-  mipId.mipIsHalo       = ismipHalo_;
+    //Now set the variable in "MIPVaraible"
+    mipId.mipChi2 = mipFitResults_[0];
+    mipId.mipTotEnergy = mipFitResults_[1];
+    mipId.mipSlope = mipFitResults_[2];
+    mipId.mipIntercept = mipFitResults_[3];
+    mipId.mipNhitCone = nhitCone_;
+    mipId.mipIsHalo = ismipHalo_;
+  } else {
+    std::cout << "MIPCalculate::Ecal Collection is not there hence set some default values" << std::endl;
+    mipId.mipChi2 = -999.;
+    mipId.mipTotEnergy = -999.;
+    mipId.mipSlope = -999.;
+    mipId.mipIntercept = -999.;
+    mipId.mipNhitCone = 0;
+    mipId.mipIsHalo = false;
   }
-  else{ std::cout<<"MIPCalculate::Ecal Collection is not there hence set some default values"<<std::endl;
-       mipId.mipChi2         = -999.;                     
-       mipId.mipTotEnergy    = -999.;                     
-       mipId.mipSlope        = -999.;                     
-       mipId.mipIntercept    = -999.;                     
-       mipId.mipNhitCone     =    0;                             
-       mipId.mipIsHalo       = false;    
-        }
 
-  // std::cout<<"Setting: isHalo = "<<ismipHalo_<<"    nhitcone=  "<<nhitCone_<<std::endl; 
+  // std::cout<<"Setting: isHalo = "<<ismipHalo_<<"    nhitcone=  "<<nhitCone_<<std::endl;
   // std::cout<<"Setting: Chi2  = "<<mipFitResults_[0]<<"  eT= "<<mipFitResults_[1]<<" slope = "<<mipFitResults_[2]<<"  Intercept ="<<mipFitResults_[3]<<std::endl;
 }
 
-
-
-
-
 // Get the MIP Variable NCone, Energy etc here
 std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* photon,
-                                           const edm::Event& iEvent,
-                                           const edm::EventSetup& iSetup,
-                                           edm::Handle<EcalRecHitCollection> ecalhitsCollEB,
-                                           double inputRangeY,
-                                           double inputRangeX,
-                                           double inputResWidth,
-                                           double inputHaloDiscCut,
-                                           int  &NhitCone_,                
-                                           bool &ismipHalo_)
-{
-  bool debug_= false;
+                                                        const edm::Event& iEvent,
+                                                        const edm::EventSetup& iSetup,
+                                                        edm::Handle<EcalRecHitCollection> ecalhitsCollEB,
+                                                        double inputRangeY,
+                                                        double inputRangeX,
+                                                        double inputResWidth,
+                                                        double inputHaloDiscCut,
+                                                        int& NhitCone_,
+                                                        bool& ismipHalo_) {
+  bool debug_ = false;
 
- if(debug_)std::cout<<" inside MipFitTrail "<<std::endl;
+  if (debug_)
+    std::cout << " inside MipFitTrail " << std::endl;
   //getting them from cfi config
-  double yrange        = inputRangeY;
-  double xrange        = inputRangeX;
-  double res_width     = inputResWidth;       //width of the residual distribution 
-  double halo_disc_cut = inputHaloDiscCut;    //cut based on  Shower,Angle and MIP
-
+  double yrange = inputRangeY;
+  double xrange = inputRangeX;
+  double res_width = inputResWidth;         //width of the residual distribution
+  double halo_disc_cut = inputHaloDiscCut;  //cut based on  Shower,Angle and MIP
 
   //initilize them here
-  double m       = 0.;
-         m       = yrange/xrange;            //slope of the lines which form the cone around the trail
- 
- 
+  double m = 0.;
+  m = yrange / xrange;  //slope of the lines which form the cone around the trail
 
-
- //first get the seed cell index
+  //first get the seed cell index
   int seedIEta = -999;
   int seedIPhi = -999;
-  double seedE = -999.; 
+  double seedE = -999.;
 
+  //get seed propert.
+  GetSeedHighestE(photon, iEvent, iSetup, ecalhitsCollEB, seedIEta, seedIPhi, seedE);
 
-               //get seed propert.
-                GetSeedHighestE(photon,
-                                iEvent,
-                                iSetup,
-                                ecalhitsCollEB,
-                                seedIEta,
-                                seedIPhi,
-                                seedE);
+  if (debug_)
+    std::cout << "Seed E =" << seedE << "  Seed ieta = " << seedIEta << "   Seed iphi =" << seedIPhi << std::endl;
 
-     if(debug_)std::cout<<"Seed E ="<<seedE<<"  Seed ieta = "<<seedIEta<<"   Seed iphi ="<< seedIPhi<<std::endl;
-
- //to store results 
- std::vector<double> FitResults_;
- FitResults_.clear();
-  
+  //to store results
+  std::vector<double> FitResults_;
+  FitResults_.clear();
 
   //create some vector and clear them
   std::vector<int> ieta_cell;
@@ -192,257 +157,230 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
   iphi_cell.clear();
   energy_cell.clear();
 
+  int ietacell = 0;
+  int iphicell = 0;
+  int kArray = 0;
 
-  int ietacell =    0;
-  int iphicell =    0;
-  int kArray   =    0;
-  
   double energy_total = 0.;
-  int delt_ieta    =0;
-  int delt_iphi    =0;
+  int delt_ieta = 0;
+  int delt_iphi = 0;
 
+  for (EcalRecHitCollection::const_iterator it = ecalhitsCollEB->begin(); it != ecalhitsCollEB->end(); ++it) {
+    EBDetId dit = it->detid();
 
- for(EcalRecHitCollection::const_iterator it = ecalhitsCollEB->begin();it!=ecalhitsCollEB->end();++it)
-    {
-       EBDetId dit = it->detid();
+    iphicell = dit.iphi();
+    ietacell = dit.ieta();
 
+    if (ietacell < 0)
+      ietacell++;
 
-        iphicell = dit.iphi();
-        ietacell = dit.ieta();
-    
-        if(ietacell < 0)ietacell++;
+    //Exclude all cells within +/- 5 ieta of seed cell
+    if (TMath::Abs(ietacell - seedIEta) >= 5 && it->energy() > 0.) {
+      delt_ieta = ietacell - seedIEta;
+      delt_iphi = iphicell - seedIPhi;
 
-        //Exclude all cells within +/- 5 ieta of seed cell 
-       if(TMath::Abs(ietacell - seedIEta) >= 5  &&  it->energy() > 0.)
-        {
+      //Phi wrapping inclusion
+      if (delt_iphi > 180) {
+        delt_iphi = delt_iphi - 360;
+      }
+      if (delt_iphi < -180) {
+        delt_iphi = delt_iphi + 360;
+      }
 
-          delt_ieta = ietacell - seedIEta;
-          delt_iphi = iphicell - seedIPhi;
+      //Condition to be within the cones
+      if (((delt_iphi >= (m * delt_ieta)) && (delt_iphi <= (-m * delt_ieta))) ||
+          ((delt_iphi <= (m * delt_ieta)) && (delt_iphi >= (-m * delt_ieta)))) {
+        ieta_cell.push_back(delt_ieta);
+        iphi_cell.push_back(delt_iphi);
+        energy_cell.push_back(it->energy());
+        energy_total += it->energy();
+        kArray++;
+      }
 
-          //Phi wrapping inclusion
-          if(delt_iphi > 180){ delt_iphi = delt_iphi - 360; }
-          if(delt_iphi < -180){ delt_iphi = delt_iphi + 360; }
+    }  //within cerntain range of seed cell
 
-          //Condition to be within the cones
-          if( ( (delt_iphi >= (m*delt_ieta)) && (delt_iphi <= (-m*delt_ieta)) ) ||
-              ( (delt_iphi <= (m*delt_ieta)) && (delt_iphi >= (-m*delt_ieta)) ) 
-            )
-            {
-              ieta_cell.push_back(delt_ieta);
-              iphi_cell.push_back(delt_iphi);
-              energy_cell.push_back(it->energy());
-              energy_total += it->energy();
-              kArray++;
-            }
+  }  //loop voer hits
 
-        }//within cerntain range of seed cell
+  //Iterations for imporovements
 
-    }//loop voer hits
+  int Npoints = 0;
+  int throwaway_index = -1;
+  double chi2;
+  double eT = 0.;
+  double hres = 99999.;
 
+  //some tmp local variale
+  double Roundness_ = 999.;
+  double Angle_ = 999.;
+  double halo_disc_ = 0.;
 
+  Npoints = kArray;
 
-//Iterations for imporovements
+  if (debug_)
+    std::cout << " starting npoing = " << Npoints << std::endl;
 
-      int Npoints         =  0; 
-      int throwaway_index = -1;
-      double chi2;
-      double eT          = 0.;         
-      double hres        = 99999.;
+  //defined some variable for iterative fitting the mip trail line
+  double sx = 0.0;
+  double sy = 0.0;
+  double ss = 0.0;
+  double sxx = 0.0;
+  double sxy = 0.0;
+  double a1 = 0.0;
+  double b1 = 0.0;
+  double m_chi2 = 0.0;
+  double etot_cell = 0.0;
 
-      //some tmp local variale
-      double Roundness_ =999.;
-      double Angle_     =999.;
-      double halo_disc_ =0.;
+  //start Iterations
+  for (int it = 0; it < 200 && hres > (5.0 * res_width); it++) {  //Max iter. is 200
 
-      Npoints = kArray;
+    //Throw away previous highest residual, if not first loop
+    if (throwaway_index != -1) {
+      ieta_cell.erase(ieta_cell.begin() + throwaway_index);
+      iphi_cell.erase(iphi_cell.begin() + throwaway_index);
+      energy_cell.erase(energy_cell.begin() + throwaway_index);
+      Npoints--;
+    }
 
-     if(debug_)std::cout<<" starting npoing = "<<Npoints<<std::endl;
+    //Lets Initialize them first for each iteration
+    sx = 0.0;
+    sy = 0.0;
+    ss = 0.0;
+    sxx = 0.0;
+    sxy = 0.0;
+    m_chi2 = 0.0;
+    etot_cell = 0.0;
 
-     //defined some variable for iterative fitting the mip trail line  
-        double  sx     = 0.0;    
-        double  sy     = 0.0;                                   
-        double  ss     = 0.0;                            
-        double  sxx    = 0.0;                            
-        double  sxy    = 0.0;
-        double  a1     = 0.0;
-        double  b1     = 0.0;                             
-        double  m_chi2 = 0.0;                            
-        double  etot_cell=0.0;   
+    //Fit the line to trail
+    for (int j = 0; j < Npoints; j++) {
+      double wt = 1.0;
+      ss += wt;
+      sx += ieta_cell[j] * wt;
+      sy += iphi_cell[j];
+      sxx += ieta_cell[j] * ieta_cell[j] * wt;
+      sxy += ieta_cell[j] * iphi_cell[j] * wt;
+    }
 
+    double delt = ss * sxx - (sx * sx);
+    a1 = ((sxx * sy) - (sx * sxy)) / delt;  // INTERCEPT
+    b1 = ((ss * sxy) - (sx * sy)) / delt;   // SLOPE
 
-      //start Iterations
-     for(int it=0; it < 200 && hres >(5.0*res_width); it++)
-    {  //Max iter. is 200
+    double highest_res = 0.;
+    int highres_index = 0;
 
+    for (int j = 0; j < Npoints; j++) {
+      double res = 1.0 * iphi_cell[j] - a1 - b1 * ieta_cell[j];
+      double res_sq = res * res;
 
-        //Throw away previous highest residual, if not first loop
-        if (throwaway_index!=-1)
-           {
-            ieta_cell.erase(ieta_cell.begin()+throwaway_index);
-            iphi_cell.erase(iphi_cell.begin()+throwaway_index);
-            energy_cell.erase(energy_cell.begin()+throwaway_index);
-            Npoints--;
-           }
-           
+      if (TMath::Abs(res) > highest_res) {
+        highest_res = TMath::Abs(res);
+        highres_index = j;
+      }
 
-        //Lets Initialize them first for each iteration 
-        sx     = 0.0;
-        sy     = 0.0; 
-        ss     = 0.0;
-        sxx    = 0.0;
-        sxy    = 0.0;
-        m_chi2 = 0.0;
-        etot_cell=0.0;
-     
- 
-            //Fit the line to trail 
-           for(int j=0; j<Npoints; j++)
-            {  
-               double wt = 1.0;
-               ss += wt;
-               sx += ieta_cell[j]*wt;                               
-               sy += iphi_cell[j]; 
-               sxx += ieta_cell[j]*ieta_cell[j]*wt;
-               sxy += ieta_cell[j]*iphi_cell[j]*wt;
-            }
-       
-            double delt =  ss*sxx - (sx*sx);
-            a1 = ((sxx*sy)-(sx*sxy))/delt;   // INTERCEPT
-            b1 = ((ss*sxy)-(sx*sy))/delt;    // SLOPE
+      m_chi2 += res_sq;
+      etot_cell += energy_cell[j];
+    }
 
+    throwaway_index = highres_index;
+    hres = highest_res;
 
-          double highest_res   = 0.;
-          int    highres_index = 0;
-                         
+    chi2 = m_chi2 / ((Npoints - 2));
+    chi2 = chi2 / (res_width * res_width);
+    eT = etot_cell;
 
-            for(int j=0; j<Npoints; j++)
-               {                
-                    double res = 1.0*iphi_cell[j] - a1 - b1*ieta_cell[j];
-                    double res_sq = res*res;
+  }  //for loop for iterations
 
-                    if(TMath::Abs(res) > highest_res)
-                       {             
-                        highest_res = TMath::Abs(res);
-                        highres_index = j;
-                       }             
+  if (debug_)
+    std::cout << "hres = " << hres << std::endl;
 
-                    m_chi2 += res_sq;
-                   etot_cell += energy_cell[j];
+  //get roundness and angle for this photon candidate form EcalClusterTool
+  std::vector<float> showershapes_barrel =
+      EcalClusterTools::roundnessBarrelSuperClusters(*(photon->superCluster()), (*ecalhitsCollEB.product()));
 
-               }                
-           
-              
-                     throwaway_index = highres_index;
-                     hres            = highest_res;
+  Roundness_ = showershapes_barrel[0];
+  Angle_ = showershapes_barrel[1];
 
-                     chi2 = m_chi2 /((Npoints-2));
-                     chi2 = chi2/(res_width*res_width);
-                     eT   = etot_cell;  
+  if (debug_)
+    std::cout << " eTot =" << eT << "     Rounness = " << Roundness_ << "    Angle_  " << Angle_ << std::endl;
 
-      }//for loop for iterations
+  //get the halo disc variable
+  halo_disc_ = eT / (Roundness_ * Angle_);
 
-     if(debug_)std::cout<<"hres = "<<hres<<std::endl;
+  ///Now Filll the FitResults vector
+  FitResults_.push_back(chi2);  //chi2
+  FitResults_.push_back(eT);    //total energy
+  FitResults_.push_back(b1);    //slope
+  FitResults_.push_back(a1);    //intercept
+  NhitCone_ = Npoints;          //nhit in cone
+  if (halo_disc_ > halo_disc_cut)
+    ismipHalo_ = true;  //is halo?, yes if halo_disc > 70 by default
+                        // based on 2010 study
 
-     //get roundness and angle for this photon candidate form EcalClusterTool
-     std::vector<float> showershapes_barrel = EcalClusterTools::roundnessBarrelSuperClusters(*(photon->superCluster()), (*ecalhitsCollEB.product()));
+  if (debug_)
+    std::cout << "Endof MIP Trail: halo_dic= " << halo_disc_ << "   nhitcone =" << NhitCone_
+              << "  isHalo= " << ismipHalo_ << std::endl;
+  if (debug_)
+    std::cout << "Endof MIP Trail: Chi2  = " << chi2 << "  eT= " << eT << " slope = " << b1 << "  Intercept =" << a1
+              << std::endl;
 
-     Roundness_ = showershapes_barrel[0];
-     Angle_     = showershapes_barrel[1];
-
-   if(debug_)std::cout<<" eTot ="<<eT<<"     Rounness = "<<Roundness_<<"    Angle_  "<<Angle_ <<std::endl; 
-
-     //get the halo disc variable
-     halo_disc_ = eT/(Roundness_* Angle_);
-
-
-      ///Now Filll the FitResults vector
-      FitResults_.push_back(chi2); //chi2
-      FitResults_.push_back(eT);   //total energy
-      FitResults_.push_back(b1);   //slope
-      FitResults_.push_back(a1);   //intercept
-      NhitCone_  = Npoints;        //nhit in cone
-      if(halo_disc_ > halo_disc_cut)ismipHalo_ = true;            //is halo?, yes if halo_disc > 70 by default
-                                                                  // based on 2010 study
-
-
-     if(debug_)std::cout<<"Endof MIP Trail: halo_dic= "<<halo_disc_<<"   nhitcone ="<<NhitCone_<<"  isHalo= "<<ismipHalo_<<std::endl;
-     if(debug_)std::cout<<"Endof MIP Trail: Chi2  = "<<chi2<<"  eT= "<<eT<<" slope = "<<b1<<"  Intercept ="<<a1<<std::endl;
-  
-    return FitResults_;
-
+  return FitResults_;
 }
-
-
-
-
 
 //get the seed crystal index
 void PhotonMIPHaloTagger::GetSeedHighestE(const reco::Photon* photon,
-                                           const edm::Event& iEvent,
-                                           const edm::EventSetup& iSetup,
-                                           edm::Handle<EcalRecHitCollection> Brechit,
-                                           int &seedIeta,
-                                           int &seedIphi,
-                                           double &seedEnergy)
-{
+                                          const edm::Event& iEvent,
+                                          const edm::EventSetup& iSetup,
+                                          edm::Handle<EcalRecHitCollection> Brechit,
+                                          int& seedIeta,
+                                          int& seedIphi,
+                                          double& seedEnergy) {
+  bool debug_ = false;
 
-   bool debug_= false;
+  if (debug_)
+    std::cout << "Inside GetSeed" << std::endl;
+  //Get the Seed
+  double SeedE = -999.;
 
-       if(debug_)std::cout<<"Inside GetSeed"<<std::endl;
-        //Get the Seed
-        double SeedE    = -999.;
+  //initilaze them here
+  seedIeta = -999;
+  seedIphi = -999;
+  seedEnergy = -999.;
 
-        //initilaze them here
-        seedIeta   = -999;
-        seedIphi   = -999;
-        seedEnergy = -999.;
+  std::vector<std::pair<DetId, float> > PhotonHit_DetIds = photon->superCluster()->hitsAndFractions();
+  int ncrys = 0;
 
+  std::vector<std::pair<DetId, float> >::const_iterator detitr;
+  for (detitr = PhotonHit_DetIds.begin(); detitr != PhotonHit_DetIds.end(); ++detitr) {
+    if (((*detitr).first).det() == DetId::Ecal && ((*detitr).first).subdetId() == EcalBarrel) {
+      EcalRecHitCollection::const_iterator j = Brechit->find(((*detitr).first));
+      EcalRecHitCollection::const_iterator thishit;
 
+      if (j != Brechit->end())
+        thishit = j;
+      if (j == Brechit->end()) {
+        continue;
+      }
 
+      EBDetId detId = (EBDetId)((*detitr).first);
 
-       std::vector< std::pair<DetId, float> >  PhotonHit_DetIds = photon->superCluster()->hitsAndFractions();
-       int ncrys   = 0;
+      double crysE = thishit->energy();
 
-	std::vector< std::pair<DetId, float> >::const_iterator detitr;
-	for(detitr = PhotonHit_DetIds.begin(); detitr != PhotonHit_DetIds.end(); ++detitr)
-       {
+      if (crysE > SeedE) {
+        SeedE = crysE;
+        seedIeta = detId.ieta();
+        seedIphi = (detId.iphi());
+        seedEnergy = SeedE;
 
-	 if (((*detitr).first).det() == DetId::Ecal && ((*detitr).first).subdetId() == EcalBarrel) 
-          {
-	       EcalRecHitCollection::const_iterator j= Brechit->find(((*detitr).first));
-	       EcalRecHitCollection::const_iterator thishit;
+        if (debug_)
+          std::cout << "Current max Seed = " << SeedE << "   seedIphi = " << seedIphi << "  ieta= " << seedIeta
+                    << std::endl;
+      }
 
-	       if ( j!= Brechit->end())  thishit = j;
-	       if ( j== Brechit->end()){ continue;}
-	      
+      ncrys++;
 
-            EBDetId detId  = (EBDetId)((*detitr).first);
+    }  //check if in Barrel
 
-            double crysE = thishit->energy();
+  }  //loop over EBrechits cells
 
-             if (crysE > SeedE)
-             {SeedE = crysE;                     
-              seedIeta    = detId.ieta();
-              seedIphi    = (detId.iphi());
-              seedEnergy  = SeedE;
-
-             if(debug_)std::cout<<"Current max Seed = "<<SeedE<<"   seedIphi = "<<seedIphi<<"  ieta= "<<seedIeta<<std::endl;
-
-             }
-
-            ncrys++;
-
-
-          }//check if in Barrel
-        
-        }//loop over EBrechits cells
-
-
-   
-    if(debug_)std::cout<<"End of  GetSeed"<<std::endl;
-
-} 
-
- 
-
-
+  if (debug_)
+    std::cout << "End of  GetSeed" << std::endl;
+}

--- a/RecoEgamma/PhotonIdentification/src/classes.h
+++ b/RecoEgamma/PhotonIdentification/src/classes.h
@@ -10,7 +10,7 @@
 #include "PhysicsTools/SelectorUtils/interface/PrintVIDToString.h"
 
 namespace RecoEgamma_PhotonIdentification {
-  struct dictionary {    
+  struct dictionary {
     typedef VersionedSelector<edm::Ptr<reco::Photon> > VersionedPhotonSelector;
     typedef MakeVersionedSelector<reco::Photon> MakeVersionedPhotonSelector;
     typedef MakePtrFromCollection<reco::PhotonCollection> MakePhoPtrFromCollection;
@@ -22,16 +22,15 @@ namespace RecoEgamma_PhotonIdentification {
     typedef PrintVIDToString<pat::Photon> PrintPatPhotonVIDToString;
 
     //for using the selectors in python
-    VersionedPhotonSelector vGsfElectronSelector;    
+    VersionedPhotonSelector vGsfElectronSelector;
     MakeVersionedPhotonSelector vMakePhotonVersionedSelector;
     PrintPhotonVIDToString vPhoPrintVIDToString;
-    MakePhoPtrFromCollection vPhoMakePtrFromCollection;  
-    
-    VersionedPatPhotonSelector vPatPhotonSelector; 
+    MakePhoPtrFromCollection vPhoMakePtrFromCollection;
+
+    VersionedPatPhotonSelector vPatPhotonSelector;
     MakeVersionedPatPhotonSelector vMakePatPhotonVersionedSelector;
     PrintPatPhotonVIDToString vPatPrintVIDToString;
     MakePatPtrFromCollection vPatMakePtrFromCollection;
     MakePtrFromCollection<std::vector<pat::Photon>, pat::Photon, reco::Photon> vPatToPhoMakePtrFromCollection;
-    
   };
-}
+}  // namespace RecoEgamma_PhotonIdentification


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/421//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


