### PR TITLE
Adjust clang-format after CMSSW_11_0_X_2019-06-21-1100

### DIFF
--- a/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
@@ -54,9 +54,8 @@ bool SiPixelStatusManager::rankByLumi(SiPixelDetectorStatus status1, SiPixelDete
 }
 
 void SiPixelStatusManager::createPayloads() {
-  if (!siPixelStatusVtr_
-           .empty()) {  //only create std::map payloads when the number of non-zero DIGI lumi sections is greater than ZERO otherwise segmentation fault
-
+  //only create std::map payloads when the number of non-zero DIGI lumi sections is greater than ZERO otherwise segmentation fault
+  if (!siPixelStatusVtr_.empty()) {
     // sort the vector according to lumi
     std::sort(siPixelStatusVtr_.begin(), siPixelStatusVtr_.end(), SiPixelStatusManager::rankByLumi);
 
@@ -92,9 +91,8 @@ void SiPixelStatusManager::createBadComponents() {
 
   siPixelStatusMap_.clear();
 
-  if (outputBase_ == "nLumibased" &&
-      nLumi_ > 1) {  // doesn't work for nLumi_=1 cos any integer can be completely divided by 1
-
+  // doesn't work for nLumi_=1 cos any integer can be completely divided by 1
+  if (outputBase_ == "nLumibased" && nLumi_ > 1) {
     // if the total number of Lumi Blocks can't be completely divided by nLumi_,
     // the residual Lumi Blocks will be as the last IOV
     int iterationLumi = 0;

--- a/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
+++ b/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
@@ -182,8 +182,8 @@ public:
     else {
       FreeTrajectoryState ftsAtProduction(finalGP, finalGV, TrackCharge(tpr->charge()), theMF.product());
       TSCBLBuilderNoMaterial tscblBuilder;
-      TrajectoryStateClosestToBeamLine tsAtClosestApproach =
-          tscblBuilder(ftsAtProduction, *bs);  //as in TrackProducerAlgorithm
+      //as in TrackProducerAlgorithm
+      TrajectoryStateClosestToBeamLine tsAtClosestApproach = tscblBuilder(ftsAtProduction, *bs);
       if (!tsAtClosestApproach.isValid()) {
         edm::LogVerbatim("CosmicTrackingParticleSelector")
             << "*** WARNING in CosmicTrackingParticleSelector: tsAtClosestApproach is not valid."

--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -104,13 +104,11 @@ public:
         algo_ok = false;
     }
     if (!algorithmMask_.empty() && algo_ok) {
-      if (std::find_if(
-              algorithmMask_.begin(),
-              algorithmMask_.end(),
-              [&](reco::TrackBase::TrackAlgorithm algo)
-                  -> bool {  // for some reason I have to either explicitly give the return type, or use static_cast<bool>()
-                return t.algoMask()[algo];
-              }) == algorithmMask_.end())
+      if (std::find_if(algorithmMask_.begin(),
+                       algorithmMask_.end(),
+                       // for some reason I have to either explicitly give the return type, or use static_cast<bool>()
+                       [&](reco::TrackBase::TrackAlgorithm algo) -> bool { return t.algoMask()[algo]; }) ==
+          algorithmMask_.end())
         algo_ok = false;
     }
 

--- a/CondCore/ESSources/interface/DataProxy.h
+++ b/CondCore/ESSources/interface/DataProxy.h
@@ -110,8 +110,8 @@ public:
                    const char* source = nullptr)
       : cond::DataProxyWrapperBase(ilabel),
         m_source(source ? source : ""),
-        m_proxy(new PayProxy(
-            source)),  //'errorPolicy set to true: PayloadProxy should catch and re-throw ORA exceptions' still needed?
+        //'errorPolicy set to true: PayloadProxy should catch and re-throw ORA exceptions' still needed?
+        m_proxy(new PayProxy(source)),
         m_edmProxy(new DataProxy(m_proxy)) {
     m_proxy->setUp(session);
     //NOTE: We do this so that the type 'DataT' will get registered

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h
@@ -92,8 +92,9 @@ private:
   std::vector<DetRegistry> indexes;
   float minPed_, maxPed_, minGain_, maxGain_;
 
-  unsigned int
-      numberOfRowsToAverageOver_;  //THIS WILL BE HARDCODED TO 1 (no averaging) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING!
+  //THIS WILL BE HARDCODED TO 1 (no averaging) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING!
+  unsigned int numberOfRowsToAverageOver_;
+
   unsigned int nBinsToUseForEncoding_;
   unsigned int deadFlag_;
   unsigned int noisyFlag_;

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h
@@ -116,8 +116,9 @@ private:
 
   float pedPrecision, gainPrecision;
 
-  unsigned int
-      numberOfRowsToAverageOver_;  //THIS WILL BE HARDCODED TO 80 (all rows in a ROC) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING!
+  //THIS WILL BE HARDCODED TO 80 (all rows in a ROC) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING!
+  unsigned int numberOfRowsToAverageOver_;
+
   unsigned int nBinsToUseForEncoding_;
   unsigned int deadFlag_;
   unsigned int noisyFlag_;

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h
@@ -112,8 +112,9 @@ private:
   std::vector<DetRegistry> indexes;
   float minPed_, maxPed_, minGain_, maxGain_;
 
-  unsigned int
-      numberOfRowsToAverageOver_;  //THIS WILL BE HARDCODED TO 80 (all rows in a ROC) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING!
+  //THIS WILL BE HARDCODED TO 80 (all rows in a ROC) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING!
+  unsigned int numberOfRowsToAverageOver_;
+
   unsigned int nBinsToUseForEncoding_;
   unsigned int deadFlag_;
   unsigned int noisyFlag_;

--- a/CondFormats/SiPixelObjects/src/SiPixelQuality.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelQuality.cc
@@ -101,8 +101,8 @@ bool SiPixelQuality::IsModuleBad(const uint32_t& detid) const {
   std::sort(disabledModules.begin(), disabledModules.end(), SiPixelQuality::BadComponentStrictWeakOrdering());
   std::vector<disabledModuleType>::const_iterator iter = std::lower_bound(
       disabledModules.begin(), disabledModules.end(), detid, SiPixelQuality::BadComponentStrictWeakOrdering());
-  if (iter != disabledModules.end() && iter->DetID == detid &&
-      iter->errorType == 0)  //errorType 0 corresponds to "whole" dead module
+  //errorType 0 corresponds to "whole" dead module
+  if (iter != disabledModules.end() && iter->DetID == detid && iter->errorType == 0)
     return true;
   return false;
 }

--- a/DQMServices/Core/src/QTest.cc
+++ b/DQMServices/Core/src/QTest.cc
@@ -1061,20 +1061,18 @@ float ContentSigma::runTest(const MonitorElement* me) {
     neighborsY = 0;
   }
 
-  if (xMin_ != 0 &&
-      xMax_ !=
-          0) {  //give users option for automatic mininum and maximum selection by inputting 0 to any of the parameters
-                // check that user's parameters are completely in agreement with histogram
-                // for instance, if inputted xMax is out of range xMin will automatically be ignored
+  //give users option for automatic mininum and maximum selection by inputting 0 to any of the parameters
+  // check that user's parameters are completely in agreement with histogram
+  // for instance, if inputted xMax is out of range xMin will automatically be ignored
+  if (xMin_ != 0 && xMax_ != 0) {
     if ((xMax_ <= nbinsX) && (xMin_ <= xMax_)) {  // rescale area of histogram being analyzed
       nbinsX = xMax_ - xMin_ + 1;
       xMax = xMax_;  // do NOT use overflow bin
       xMin = xMin_;  // do NOT use underflow bin
     }
   }
-  if (yMin_ != 0 &&
-      yMax_ !=
-          0) {  //give users option for automatic mininum and maximum selection by inputting 0 to any of the parameters
+  //give users option for automatic mininum and maximum selection by inputting 0 to any of the parameters
+  if (yMin_ != 0 && yMax_ != 0) {
     if ((yMax_ <= nbinsY) && (yMin_ <= yMax_)) {
       nbinsY = yMax_ - yMin_ + 1;
       yMax = yMax_;
@@ -1138,8 +1136,8 @@ float ContentSigma::runTest(const MonitorElement* me) {
 
       double average = sum / (XWidth * YWidth - 1);
       double sigma = getNeighborSigma(average, groupx, groupy, XBlocks, YBlocks, neighborsX, neighborsY, h);
-      sigma -= (average - blocksum) *
-               (average - blocksum);  //get rid of block being tested just like we did with the average
+      //get rid of block being tested just like we did with the average
+      sigma -= (average - blocksum) * (average - blocksum);
       double sigma_2 = sqrt(sigma) / sqrt(XWidth * YWidth - 2);  //N-1 where N=XWidth*YWidth - 1
       double sigma_real = sigma_2 / (XWidth * YWidth - 1);
       //double avg_uncrt = average*sqrt(sum)/sum;//Obsolete now(Chad Freer)
@@ -1205,11 +1203,10 @@ double ContentSigma::getNeighborSum(unsigned groupx,
   unsigned Xbinnum = 1;
   unsigned Ybinnum = 1;
 
-  if (xMin_ != 0 &&
-      xMax_ !=
-          0) {  //give users option for automatic mininum and maximum selection by inputting 0 to any of the parameters
-                // check that user's parameters are completely in agreement with histogram
-                // for instance, if inputted xMax is out of range xMin will automatically be ignored
+  //give users option for automatic mininum and maximum selection by inputting 0 to any of the parameters
+  // check that user's parameters are completely in agreement with histogram
+  // for instance, if inputted xMax is out of range xMin will automatically be ignored
+  if (xMin_ != 0 && xMax_ != 0) {
     if ((xMax_ <= nbinsX) && (xMin_ <= xMax_)) {
       nbinsX = xMax_ - xMin_ + 1;
       xMax = xMax_;  // do NOT use overflow bin

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -253,12 +253,12 @@ namespace reco {
       math::XYZPointF positionAtVtx;   // the track PCA to the beam spot
       math::XYZPointF positionAtCalo;  // the track PCA to the supercluster position
       math::XYZVectorF momentumAtVtx;  // the track momentum at the PCA to the beam spot
-      math::XYZVectorF
-          momentumAtCalo;  // the track momentum extrapolated at the supercluster position from the innermost track state
-      math::XYZVectorF
-          momentumOut;  // the track momentum extrapolated at the seed cluster position from the outermost track state
-      math::XYZVectorF
-          momentumAtEleClus;  // the track momentum extrapolated at the ele cluster position from the outermost track state
+      // the track momentum extrapolated at the supercluster position from the innermost track state
+      math::XYZVectorF momentumAtCalo;
+      // the track momentum extrapolated at the seed cluster position from the outermost track state
+      math::XYZVectorF momentumOut;
+      // the track momentum extrapolated at the ele cluster position from the outermost track state
+      math::XYZVectorF momentumAtEleClus;
       math::XYZVectorF momentumAtVtxWithConstraint;  // the track momentum at the PCA to the beam spot using bs constraint
     };
 

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.cc
@@ -115,19 +115,13 @@ void CSCGeometryBuilder::build(CSCGeometry& theGeometry,
   }
 }
 
-void CSCGeometryBuilder::buildChamber(CSCGeometry& theGeometry  // the geometry container
-                                      ,
-                                      CSCDetId chamberId  // the DetId for this chamber
-                                      ,
-                                      const std::vector<float>& fpar  // volume parameters hB, hT. hD, hH
-                                      ,
-                                      const std::vector<float>& fupar  // user parameters
-                                      ,
-                                      const std::vector<float>& gtran  // translation vector
-                                      ,
-                                      const std::vector<float>& grmat  // rotation matrix
-                                      ,
-                                      const CSCWireGroupPackage& wg  // wire group info
+void CSCGeometryBuilder::buildChamber(CSCGeometry& theGeometry,         // the geometry container
+                                      CSCDetId chamberId,               // the DetId for this chamber
+                                      const std::vector<float>& fpar,   // volume parameters hB, hT. hD, hH
+                                      const std::vector<float>& fupar,  // user parameters
+                                      const std::vector<float>& gtran,  // translation vector
+                                      const std::vector<float>& grmat,  // rotation matrix
+                                      const CSCWireGroupPackage& wg     // wire group info
 ) {
   LogTrace(myName) << myName << ": entering buildChamber";
 

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.h
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.h
@@ -30,19 +30,13 @@ public:
 
 private:
   /// Build one CSC chamber, and its component layers, and add them to the geometry
-  void buildChamber(CSCGeometry& theGeometry  // the geometry container
-                    ,
-                    CSCDetId chamberId  // the DetId of this chamber
-                    ,
-                    const std::vector<float>& fpar  // volume parameters
-                    ,
-                    const std::vector<float>& fupar  // user parameters
-                    ,
-                    const std::vector<float>& gtran  // translation vector
-                    ,
-                    const std::vector<float>& grmat  // rotation matrix
-                    ,
-                    const CSCWireGroupPackage& wg  // wire group info
+  void buildChamber(CSCGeometry& theGeometry,         // the geometry container
+                    CSCDetId chamberId,               // the DetId of this chamber
+                    const std::vector<float>& fpar,   // volume parameters
+                    const std::vector<float>& fupar,  // user parameters
+                    const std::vector<float>& gtran,  // translation vector
+                    const std::vector<float>& grmat,  // rotation matrix
+                    const CSCWireGroupPackage& wg     // wire group info
   );
 
   const std::string myName;

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -258,9 +258,9 @@ bool CSCGeometryParsFromDD::build(const DDCompactView* cview,
           noOfAnonParams = kNoOfAnonParams;
         }  // in case it wasn't seen
 
-        std::copy(uparvals.begin() + noOfAnonParams + 1,
-                  uparvals.begin() + (2 * noOfAnonParams) + 2,
-                  uparvals.begin() + 1);  // copy ME1a params from back to the front
+        // copy ME1a params from back to the front
+        std::copy(
+            uparvals.begin() + noOfAnonParams + 1, uparvals.begin() + (2 * noOfAnonParams) + 2, uparvals.begin() + 1);
 
         CSCDetId detid1a = CSCDetId(jendcap, 1, 4, jchamber, 0);  // reset to ME1A
         rig.insert(detid1a.rawId(), gtran, grmat, fpar);

--- a/Geometry/CommonTopologies/src/TwoBowedSurfacesDeformation.cc
+++ b/Geometry/CommonTopologies/src/TwoBowedSurfacesDeformation.cc
@@ -99,9 +99,9 @@ bool TwoBowedSurfacesDeformation::add(const SurfaceDeformation &other) {
   if (this->type() == other.type()) {
     const std::vector<double> otherParameters(other.parameters());
     if (otherParameters.size() == parameterSize()) {
+      // Second check in case it is really adding, either way DO NOT check equality directly
       if (fabs(theParameters[k_ySplit()] - otherParameters[k_ySplit()]) < 1e-5 ||
-          fabs(otherParameters[k_ySplit()]) <
-              1e-5) {  // Second check in case it is really adding, either way DO NOT check equality directly
+          fabs(otherParameters[k_ySplit()]) < 1e-5) {
         for (unsigned int i = 0; i != parameterSize() - 1; ++i) {  // -1 for ySplit
           // mean bows, delta shifts, delta angles and delta bows can simply be added up
           theParameters[i] += otherParameters[i];

--- a/Geometry/TrackerNumberingBuilder/test/ModuleNumbering.cc
+++ b/Geometry/TrackerNumberingBuilder/test/ModuleNumbering.cc
@@ -240,8 +240,8 @@ void ModuleNumbering::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         // TIB
       case 3: {
         // TIB loop
-        unsigned int string_int_ext_TIB[8] = {
-            26, 30, 34, 38, 44, 46, 52, 56};                      // number of strings per layer 1/4 int/ext
+        // number of strings per layer 1/4 int/ext
+        unsigned int string_int_ext_TIB[8] = {26, 30, 34, 38, 44, 46, 52, 56};
         unsigned int mod_type_TIB[8] = {1, 2, 1, 2, 0, 0, 0, 0};  // first and last type for module type loop
         unsigned int nLayers = 4;
         unsigned int nModules = 3;

--- a/RecoEgamma/ElectronIdentification/interface/EBEECutValues.h
+++ b/RecoEgamma/ElectronIdentification/interface/EBEECutValues.h
@@ -9,8 +9,8 @@ class EBEECutValuesT {
 private:
   T barrel_;
   T endcap_;
-  const double barrelCutOff_ =
-      1.479;  //this is currrently used to identify if object is barrel or endcap but may change
+  //this is currrently used to identify if object is barrel or endcap but may change
+  const double barrelCutOff_ = 1.479;
 
 public:
   EBEECutValuesT(const edm::ParameterSet& params, const std::string& name)

--- a/RecoEgamma/ElectronIdentification/test/VIDUsageExample.cc
+++ b/RecoEgamma/ElectronIdentification/test/VIDUsageExample.cc
@@ -28,10 +28,10 @@ private:
   edm::EDGetTokenT<reco::GsfElectronCollection> gsfEleToken_;
   edm::EDGetTokenT<edm::View<pat::Electron> > patEleToken_;
   edm::EDGetTokenT<edm::ValueMap<bool> > idDecisionMapToken_;  //a bool true=passed ID, false = failed ID
-  edm::EDGetTokenT<edm::ValueMap<unsigned> >
-      firstIdCutFailedMapToken_;  //the number of the first cut failed in the order they are defined in the PSet starting at zero (ie if you et,dEtaIn,dPhiIn,hadem cuts defined and it passed et,dEtaIn but failed dPhiIn, this number would be 2, in the case of no cuts failed it is #cuts
-  edm::EDGetTokenT<std::string>
-      idMD5NameToken_;  //the md5sum of the ID you are using (E/gamma might ask you for this to verify you are running the right ID)
+  //the number of the first cut failed in the order they are defined in the PSet starting at zero (ie if you et,dEtaIn,dPhiIn,hadem cuts defined and it passed et,dEtaIn but failed dPhiIn, this number would be 2, in the case of no cuts failed it is #cuts
+  edm::EDGetTokenT<edm::ValueMap<unsigned> > firstIdCutFailedMapToken_;
+  //the md5sum of the ID you are using (E/gamma might ask you for this to verify you are running the right ID)
+  edm::EDGetTokenT<std::string> idMD5NameToken_;
 
   size_t nrPassID_;
   size_t nrFailID_;
@@ -82,8 +82,8 @@ void VIDUsageExample::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
   if (patEles.isValid()) {  //we have pat electrons availible use them
     for (auto ele = patEles->begin(); ele != patEles->end(); ++ele) {
-      const edm::Ptr<pat::Electron> elePtr(
-          patEles, ele - patEles->begin());    //value map is keyed of edm::Ptrs so we need to make one
+      //value map is keyed of edm::Ptrs so we need to make one
+      const edm::Ptr<pat::Electron> elePtr(patEles, ele - patEles->begin());
       bool passID = (*idDecisionMap)[elePtr];  //a bool, true if it passed the ID, false if it didnt
       if (passID) {
         std::cout << "pat ele passed ID" << std::endl;
@@ -96,8 +96,8 @@ void VIDUsageExample::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     }
   } else if (gsfEles.isValid()) {  //no pat electrons availible, fall back to GsfElectrons
     for (auto ele = gsfEles->begin(); ele != gsfEles->end(); ++ele) {
-      const edm::Ptr<reco::GsfElectron> elePtr(
-          gsfEles, ele - gsfEles->begin());    //value map is keyed of edm::Ptrs so we need to make one
+      //value map is keyed of edm::Ptrs so we need to make one
+      const edm::Ptr<reco::GsfElectron> elePtr(gsfEles, ele - gsfEles->begin());
       bool passID = (*idDecisionMap)[elePtr];  //a bool, true if it passed the ID, false if it didnt
       if (passID) {
         std::cout << "gsf ele passed ID" << std::endl;

--- a/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
@@ -77,8 +77,8 @@ void PhotonMIPHaloTagger::MIPcalculate(const reco::Photon* pho,
   e.getByToken(EBecalCollection_, barrelHitHandle);
 
   if (!barrelHitHandle.isValid()) {
-    edm::LogError("MIPcalculate")
-        << "Error! Can't get the barrel hits product ";  //<<EBecalCollection_.label(); (cant be bothered tracking the input tag just for this error message)
+    edm::LogError("MIPcalculate") << "Error! Can't get the barrel hits product ";
+    //<<EBecalCollection_.label(); (cant be bothered tracking the input tag just for this error message)
     validEcalRecHits = false;
   }
 

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
@@ -52,8 +52,8 @@ OuterTrackerMonitorTrackingParticles::OuterTrackerMonitorTrackingParticles(const
   L1Tk_maxChi2 = conf_.getParameter<double>("L1Tk_maxChi2");        // maximum chi2 of the track
   L1Tk_maxChi2dof = conf_.getParameter<double>("L1Tk_maxChi2dof");  // maximum chi2/dof of the track
   TP_minNStub = conf_.getParameter<int>("TP_minNStub");             // min number of stubs in the tracking particle to
-  TP_minNLayersStub = conf_.getParameter<int>(
-      "TP_minNLayersStub");  //min number of layers with stubs in the tracking particle to consider matching                                                                  // consider matching
+  //min number of layers with stubs in the tracking particle to consider matching
+  TP_minNLayersStub = conf_.getParameter<int>("TP_minNLayersStub");
   TP_minPt = conf_.getParameter<double>("TP_minPt");                 // min pT to consider matching
   TP_maxPt = conf_.getParameter<double>("TP_maxPt");                 // max pT to consider matching
   TP_maxEta = conf_.getParameter<double>("TP_maxEta");               // max eta to consider matching


### PR DESCRIPTION
#### PR description:

Manual adjustments of comments after clang-format cleaning up to CMSSW_11_0_X_2019-06-21-1100.
In some cases the proposal by clang has been left untouched, as the fixed version looks to me more ugly.

#### PR validation:

Code compiles.