### PR TITLE
Add a script to split a CMSSW configuration into individual cfi files

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -827,7 +827,10 @@ class Process(object):
                 if options.useSubdirectories and module_subfolder:
                     module = module_subfolder + '.' + module
                 if options.targetDirectory is not None:
-                    module = options.targetDirectory + '.' + module
+                    if options.useSubdirectories and subfolder:
+                      module = '..' + module
+                    else:
+                      module = '.' + module
                 code += 'from ' + module + ' import *\n'
             if dependencies:
                 code += '\n'

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1010,15 +1010,16 @@ class Process(object):
         for (name, (subfolder, code)) in six.iteritems(parts):
             filename = name + '_cfi'
             if options.useSubdirectories and subfolder:
-              filename = subfolder + '/' + filename
+                filename = subfolder + '/' + filename
             if options.targetDirectory is not None:
-              filename = options.targetDirectory + '/' + filename
+                filename = options.targetDirectory + '/' + filename
             result += 'process.load("%s")\n' % filename
             with open('%s.py' % filename, 'w') as f:
               f.write(header + '\n\n')
               f.write(code)
 
         if self.schedule_() is not None:
+            options.isCfg = True
             result += 'process.schedule = ' + self.schedule.dumpPython(options)
 
         imports = specialImportRegistry.getSpecialImports()

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -9,10 +9,12 @@ class _ConfigureComponent(object):
         return False
 
 class PrintOptions(object):
-    def __init__(self, indent = 0, deltaIndent = 4, process = True):
+    def __init__(self, indent = 0, deltaIndent = 4, process = True, targetDirectory = None, useSubdirectories = False):
         self.indent_= indent
         self.deltaIndent_ = deltaIndent
         self.isCfg = process
+        self.targetDirectory = targetDirectory
+        self.useSubdirectories = useSubdirectories
     def indentation(self):
         return ' '*self.indent_
     def indent(self):

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -452,6 +452,9 @@ class _TypedParameterizable(_Parameterizable):
                             params[name] = getattr(default,name)
                         return params
         return None
+
+    def directDependencies(self):
+        return []
     
     def dumpConfig(self, options=PrintOptions()):
         config = self.__type +' { \n'
@@ -534,7 +537,10 @@ class _Labelable(object):
     def dumpSequenceConfig(self):
         return str(self.__label)
     def dumpSequencePython(self, options=PrintOptions()):
-        return 'process.'+str(self.__label)
+        if options.isCfg:
+            return 'process.'+str(self.__label)
+        else:
+            return str(self.__label)
     def _findDependencies(self,knownDeps,presentDeps):
         #print 'in labelled'
         myDeps=knownDeps.get(self.label_(),None)

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -673,6 +673,8 @@ class _ValidatingParameterListBase(_ValidatingListBase,_ParameterTypeBase):
             result +=' ) '
         result += ')'
         return result            
+    def directDependencies(self):
+        return []
     @staticmethod
     def _itemsFromStrings(strings,converter):
         return (converter(x).value() for x in strings)

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -359,6 +359,10 @@ class SwitchProducer(EDProducer):
         result += "\n)\n"
         return result
 
+    def directDependencies(self):
+        # XXX FIXME handle SwitchProducer dependencies
+        return []
+
     def nameInProcessDesc_(self, myname):
         return myname
     def moduleLabel_(self, myname):

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -178,10 +178,18 @@ class _SequenceCollection(_Sequenceable):
         return returnValue
 
     def directDependencies(self):
-        return [ item.label() for item in self._collection ]
-        #options = PrintOptions()
-        #options.isCfg = False
-        #return [ name for name in (item.dumpSequencePython(options) for item in self._collection) if name ]
+        dependencies = []
+        for item in self._collection:
+            if type(item).__name__ in ("EDFilter", "EDProducer", "EDAnalyzer", "OutputModule"):
+                t = 'modules'
+            elif type(item).__name__ in ("_SequenceIgnore", "_SequenceNegation"):
+                t = 'modules'
+            elif type(item).__name__ in ("Sequence"):
+                t = 'sequences'
+            else:
+                t = ''
+            dependencies.append((t, item.label()))
+        return dependencies
 
     def visitNode(self,visitor):
         for m in self._collection:
@@ -335,7 +343,7 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
         if self._seq:
           result += self._seq.directDependencies()
         if self._tasks:
-          result += [ task.label() for task in self._tasks ]
+          result += [ ('tasks', task.label()) for task in self._tasks ]
         return result
 
     def moduleNames(self):

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -226,6 +226,10 @@ def findDirectDependencies(element, collection):
                 dependencies += item.directDependencies()
                 continue
             t = 'modules'
+        # _SequenceCollection
+        elif isinstance(item, _SequenceCollection):
+            dependencies += item.directDependencies()
+            continue
         # cms.Sequence
         elif isinstance(item, Sequence):
             if not item.hasLabel_():

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1144,6 +1144,9 @@ class VPSet(_ValidatingParameterListBase,_ConfigureComponent,_Labelable):
             pset.insertContentsInto(newparameterset)
             parametersets.append(newparameterset)
         parameterSet.addVPSet(self.isTracked(), myname, parametersets)
+    # XXX FIXME handle refToPSet
+    def directDependencies(self):
+        return []
     def __repr__(self):
         return self.dumpPython()
 

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -827,6 +827,9 @@ class PSet(_ParameterTypeBase,_Parameterizable,_ConfigureComponent,_Labelable):
         return config
     def dumpPython(self, options=PrintOptions()):
         return self.pythonTypeName()+"(\n"+_Parameterizable.dumpPython(self, options)+options.indentation()+")"
+    # XXX FIXME handle refToPSet
+    def directDependencies(self):
+        return []
     def clone(self, **params):
         myparams = self.parameters_()
         _modifyParametersFromDict(myparams, params, self._Parameterizable__raiseBadSetAttr)

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1356,6 +1356,10 @@ class EDAlias(_ConfigureComponent,_Labelable,_Parameterizable):
             options.unindent()
         return '\n'.join(resultList)+'\n)'
 
+    # an EDAlias only references other modules by label, so it does not need their definition
+    def directDependencies(self):
+        return []
+
 if __name__ == "__main__":
 
     import unittest

--- a/FWCore/ParameterSet/scripts/edmConfigSplit
+++ b/FWCore/ParameterSet/scripts/edmConfigSplit
@@ -51,5 +51,16 @@ args.file.close()
 options = PrintOptions()
 options.useSubdirectories = args.subdirectories
 options.targetDirectory = args.output_directory
-args.output.write(process.splitPython(options))
+
+files = process.splitPython(options)
+for fn, c in files.iteritems():
+  if fn == '-':
+    continue
+  d = os.path.dirname(fn)
+  if d and not os.path.isdir(d):
+    os.makedirs(d)
+  with open(fn, 'w') as f:
+    f.write(c)
+
+args.output.write(files['-'])
 args.output.close()

--- a/FWCore/ParameterSet/scripts/edmConfigSplit
+++ b/FWCore/ParameterSet/scripts/edmConfigSplit
@@ -1,0 +1,26 @@
+#! /usr/bin/env python
+
+from optparse import OptionParser
+import sys
+import os
+import imp
+
+# make the behaviour of 'cmsRun file.py' and 'edmConfigDump file.py' more consistent
+sys.path.append(os.getcwd())
+
+parser = OptionParser()
+parser.usage = "%prog <file> : expand this python configuration"
+
+(options,args) = parser.parse_args()
+
+if len(args)!=1:
+    parser.print_help()
+    sys.exit(1)
+
+filename = args[0]
+handle = open(filename, 'r')
+cfo = imp.load_source("pycfg", filename, handle)
+cmsProcess = cfo.process
+handle.close()
+
+print cmsProcess.splitPython()

--- a/FWCore/ParameterSet/scripts/edmConfigSplit
+++ b/FWCore/ParameterSet/scripts/edmConfigSplit
@@ -1,26 +1,55 @@
 #! /usr/bin/env python
 
-from optparse import OptionParser
 import sys
 import os
 import imp
+import argparse
 
-# make the behaviour of 'cmsRun file.py' and 'edmConfigDump file.py' more consistent
+from FWCore.ParameterSet.Mixins import PrintOptions
+
+# customise the HelpFormatter to show additional parameters in the usage line
+class PartialHelpFormatter(argparse.HelpFormatter):
+  def _format_usage(self, usage, actions, groups, prefix):
+    partial = super(PartialHelpFormatter, self)._format_usage(usage, actions, groups, prefix).strip()
+    return partial + ' [--] [OPTIONS ...]\n\n'
+
+
+parser = argparse.ArgumentParser(formatter_class = PartialHelpFormatter,
+  description = '%(prog)s splits the given CMSSW configuration file into one file per top-level object, and outputs the configuration for the main process object.',
+  epilog = 'Additional options and arguments are passed to the configuration file unchanged (e.g. for use by VarParsing.py).')
+parser.add_argument('file', metavar = 'FILE', type = argparse.FileType('r'))
+
+parser.add_argument('-o', '--output',
+  metavar = 'OUT',
+  type = argparse.FileType('w'),
+  default = sys.stdout,
+  help = 'write the process configuration to %(metavar)s instead of standard output')
+parser.add_argument('-d', '--output-directory',
+  metavar = 'DIR',
+  type = str,
+  default = None,
+  help = 'create the individual files and subdirectories under %(metavar)s instead of the current directory; if %(metavar)s does not exist it will be created first')
+parser.add_argument('-s', '--subdirectories',
+  action = "store_true",
+  default = False,
+  help = 'create subdirectories for different modules categories')
+
+args, other = parser.parse_known_args()
+
+# delete all arguments, so they are not "seen" by the confguration file being split
+del sys.argv[1:]
+sys.argv.append(args.file.name)
+sys.argv.extend(other)
+
+# make the behaviour of 'cmsRun file.py' and 'edmConfigSplit file.py' more consistent
 sys.path.append(os.getcwd())
 
-parser = OptionParser()
-parser.usage = "%prog <file> : expand this python configuration"
+cfo = imp.load_source("pycfg", args.file.name, args.file)
+process = cfo.process
+args.file.close()
 
-(options,args) = parser.parse_args()
-
-if len(args)!=1:
-    parser.print_help()
-    sys.exit(1)
-
-filename = args[0]
-handle = open(filename, 'r')
-cfo = imp.load_source("pycfg", filename, handle)
-cmsProcess = cfo.process
-handle.close()
-
-print cmsProcess.splitPython()
+options = PrintOptions()
+options.useSubdirectories = args.subdirectories
+options.targetDirectory = args.output_directory
+args.output.write(process.splitPython(options))
+args.output.close()


### PR DESCRIPTION
#### PR description:

This PR adds the necessary hooks under `FWCore/ParameterSet/python`, and a script under `FWCore/ParameterSet/scripts`, to split a CMSSW python configuration into individual *_cfi.py files.

Missing features
  - `SwitchProducer` and `Subprocess` are not supported;
  - `refToPSet`, `SequencePlaceholder` and `TaskPlaceholder` are not handled specifically, but that is probably the correct approach.

#### PR validation:

As a validation, the latest HLT menu has been split into individual modules with `edmConfigSplit`, and combined back together with `edmConfigDump`; the resulting configuration was identical.
