### PR TITLE
add TkAlMinBias producer to JetHT dataset [10.6.x]

### DIFF
--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -7,7 +7,7 @@ AlCaRecoMatrix = {"AlCaLumiPixels" : "AlCaPCCZeroBias+AlCaPCCRandom",
                   # New PD in 2018 to replace SinglePhoton SingleElectron and DoubleEG in 2017
                   "EGamma"         : "EcalESAlign+EcalUncalWElectron+EcalUncalZElectron+HcalCalIsoTrkFilter+HcalCalIterativePhiSym",
                   "HLTPhysics"     : "TkAlMinBias",
-                  "JetHT"          : "HcalCalIsoTrkFilter+HcalCalIsolatedBunchFilter",
+                  "JetHT"          : "HcalCalIsoTrkFilter+HcalCalIsolatedBunchFilter+TkAlMinBias",
                   "MinimumBias"    : "SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias",
                   "MuOnia"         : "TkAlUpsilonMuMu",
                   "NoBPTX"         : "TkAlCosmicsInCollisions",


### PR DESCRIPTION
#### PR description:

Add `TkAlMinBias` to `JetHT` dataset in the `autoAlCa` file, as discussed here in this JIRA ticket https://its.cern.ch/jira/browse/PDMVRERECO-18. It is a preparatory move to have this change integrated in @ Tier-0 during Run3. 
Moreover, we'd like to have the `TkAlMinBias` produced over the `JetHT` PD for the UltraLegacy re-reco for the same reasons.  

#### PR validation:
Trivial configuration change, as the `TkAlMinBias` producer is already included in the `@allForPrompt` AlCaReco sequence no changes are expected in the relval workflows run in the PR tests.

#### if this PR is a backport please specify the original PR:

backport of https://github.com/cms-sw/cmssw/pull/27307

CC: @prebello @connorpa @adewit 
