### PR TITLE
Running code-format for alca

### DIFF
--- a/CalibMuon/DTCalibration/interface/DTCalibDBUtils.h
+++ b/CalibMuon/DTCalibration/interface/DTCalibDBUtils.h
@@ -24,37 +24,32 @@ public:
 
   /// Write the payload to the DB using PoolDBOutputService.
   /// New payload are created in the DB, existing payload are appended.
-  template<typename T>
+  template <typename T>
   static void writeToDB(std::string record, T* payload) {
     // Write the ttrig object to DB
     edm::Service<cond::service::PoolDBOutputService> dbOutputSvc;
-      if(dbOutputSvc.isAvailable()){
-	try{
-	  if(dbOutputSvc->isNewTagRequest(record)){
-	    //create mode
-	    dbOutputSvc->writeOne<T>(payload, dbOutputSvc->beginOfTime(),record);
-	  }else{
-	    //append mode. Note: correct PoolDBESSource must be loaded
-	    dbOutputSvc->writeOne<T>(payload, dbOutputSvc->currentTime(),record);
-	  }
-	}catch(const cond::Exception& er){
-	  std::cout << er.what() << std::endl;
-	}catch(const std::exception& er){
-	  std::cout << "[DTCalibDBUtils] caught std::exception " << er.what() << std::endl;
-	}catch(...){
-	  std::cout << "[DTCalibDBUtils] Funny error" << std::endl;
-	}
-      }else{
-	std::cout << "Service PoolDBOutputService is unavailable" << std::endl;
+    if (dbOutputSvc.isAvailable()) {
+      try {
+        if (dbOutputSvc->isNewTagRequest(record)) {
+          //create mode
+          dbOutputSvc->writeOne<T>(payload, dbOutputSvc->beginOfTime(), record);
+        } else {
+          //append mode. Note: correct PoolDBESSource must be loaded
+          dbOutputSvc->writeOne<T>(payload, dbOutputSvc->currentTime(), record);
+        }
+      } catch (const cond::Exception& er) {
+        std::cout << er.what() << std::endl;
+      } catch (const std::exception& er) {
+        std::cout << "[DTCalibDBUtils] caught std::exception " << er.what() << std::endl;
+      } catch (...) {
+        std::cout << "[DTCalibDBUtils] Funny error" << std::endl;
       }
-    
+    } else {
+      std::cout << "Service PoolDBOutputService is unavailable" << std::endl;
+    }
   }
 
-
 protected:
-
 private:
-
 };
 #endif
-

--- a/CalibMuon/DTCalibration/interface/DTCalibMuonSelection.h
+++ b/CalibMuon/DTCalibration/interface/DTCalibMuonSelection.h
@@ -2,7 +2,6 @@
 // Original Author:  Mario Pelliccioni, Gianluca Cerminara
 //         Created:  Tue Sep  9 15:56:24 CEST 2008
 
-
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDFilter.h"
@@ -15,22 +14,20 @@
 
 class DTCalibMuonSelection : public edm::EDFilter {
 public:
-
   explicit DTCalibMuonSelection(const edm::ParameterSet&);
 
   ~DTCalibMuonSelection() override;
-  
+
 private:
-  void beginJob() override ;
+  void beginJob() override;
 
   bool filter(edm::Event&, const edm::EventSetup&) override;
 
-  void endJob() override ;
-  
+  void endJob() override;
+
   edm::EDGetTokenT<reco::MuonCollection> muonList;
 
   double etaMin;
   double etaMax;
   double ptMin;
-
 };

--- a/CalibMuon/DTCalibration/interface/DTMeanTimerFitter.h
+++ b/CalibMuon/DTCalibration/interface/DTMeanTimerFitter.h
@@ -7,42 +7,36 @@
  *
  *  \author S. Bolognesi - INFN Torino
  */
-#include <vector> 
+#include <vector>
 #include "TString.h"
 
 class TH1F;
 class TFile;
 class TF1;
 
-
-
 class DTMeanTimerFitter {
 public:
   /// Constructor
-  DTMeanTimerFitter(TFile *file);
+  DTMeanTimerFitter(TFile* file);
 
   /// Destructor
   virtual ~DTMeanTimerFitter();
 
   /// Fit the TMax histos and evaluate VDrift and resolution
-  std::vector<float> evaluateVDriftAndReso (const TString& N);
+  std::vector<float> evaluateVDriftAndReso(const TString& N);
 
   /// Set the verbosity of the output: 0 = silent, 1 = info, 2 = debug
-  void setVerbosity(unsigned int lvl) {
-    theVerbosityLevel = lvl;
-  }
+  void setVerbosity(unsigned int lvl) { theVerbosityLevel = lvl; }
 
   /// Really do the fit
   TF1* fitTMax(TH1F* histo);
+
 protected:
-
 private:
-
-  TFile *hDebugFile;
-  TFile *hInputFile;
+  TFile* hDebugFile;
+  TFile* hInputFile;
 
   unsigned int theVerbosityLevel;
 };
 
 #endif
-

--- a/CalibMuon/DTCalibration/interface/DTRecHitSegmentResidual.h
+++ b/CalibMuon/DTCalibration/interface/DTRecHitSegmentResidual.h
@@ -10,13 +10,12 @@ class DTRecSegment4D;
 class DTRecHit1D;
 
 class DTRecHitSegmentResidual {
-   public:
-      DTRecHitSegmentResidual() {}
-      ~DTRecHitSegmentResidual() {}
-      float compute(const DTGeometry*, const DTRecHit1D&, const DTRecSegment4D&);
-    
-   private:
+public:
+  DTRecHitSegmentResidual() {}
+  ~DTRecHitSegmentResidual() {}
+  float compute(const DTGeometry*, const DTRecHit1D&, const DTRecSegment4D&);
+
+private:
 };
 
 #endif
-

--- a/CalibMuon/DTCalibration/interface/DTResidualFitter.h
+++ b/CalibMuon/DTCalibration/interface/DTResidualFitter.h
@@ -9,25 +9,23 @@ class TH1F;
 
 struct DTResidualFitResult {
 public:
-   DTResidualFitResult(double mean, double meanErr, double sigma, double sigmaErr): fitMean(mean), 
-                                                                                    fitMeanError(meanErr),
-                                                                                    fitSigma(sigma),
-                                                                                    fitSigmaError(sigmaErr) {} 
+  DTResidualFitResult(double mean, double meanErr, double sigma, double sigmaErr)
+      : fitMean(mean), fitMeanError(meanErr), fitSigma(sigma), fitSigmaError(sigmaErr) {}
 
-   double fitMean;
-   double fitMeanError;
-   double fitSigma;
-   double fitSigmaError;
+  double fitMean;
+  double fitMeanError;
+  double fitSigma;
+  double fitSigmaError;
 };
 
 class DTResidualFitter {
 public:
-   DTResidualFitter(bool debug = false);
-   ~DTResidualFitter();
+  DTResidualFitter(bool debug = false);
+  ~DTResidualFitter();
 
-   DTResidualFitResult fitResiduals(TH1F& histo, int nSigmas = 1);
+  DTResidualFitResult fitResiduals(TH1F& histo, int nSigmas = 1);
 
 private:
-   bool debug_;
+  bool debug_;
 };
 #endif

--- a/CalibMuon/DTCalibration/interface/DTSegmentSelector.h
+++ b/CalibMuon/DTCalibration/interface/DTSegmentSelector.h
@@ -22,22 +22,22 @@ class DTRecHit1D;
 class DTStatusFlag;
 
 class DTSegmentSelector {
-   public:
-      DTSegmentSelector(edm::ParameterSet const& pset, edm::ConsumesCollector& iC);
-      ~DTSegmentSelector() {}
-      bool operator() (DTRecSegment4D const&, edm::Event const&, edm::EventSetup const&);
-    
-   private:
-      bool checkNoisySegment(edm::ESHandle<DTStatusFlag> const&, std::vector<DTRecHit1D> const&);
+public:
+  DTSegmentSelector(edm::ParameterSet const& pset, edm::ConsumesCollector& iC);
+  ~DTSegmentSelector() {}
+  bool operator()(DTRecSegment4D const&, edm::Event const&, edm::EventSetup const&);
 
-      edm::InputTag muonTags_; 
-      edm::EDGetTokenT<reco::MuonCollection> muonToken_;
-      bool checkNoisyChannels_;
-      int minHitsPhi_;
-      int minHitsZ_;
-      double maxChi2_;
-      double maxAnglePhi_;
-      double maxAngleZ_;
+private:
+  bool checkNoisySegment(edm::ESHandle<DTStatusFlag> const&, std::vector<DTRecHit1D> const&);
+
+  edm::InputTag muonTags_;
+  edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+  bool checkNoisyChannels_;
+  int minHitsPhi_;
+  int minHitsZ_;
+  double maxChi2_;
+  double maxAnglePhi_;
+  double maxAngleZ_;
 };
 
 #endif

--- a/CalibMuon/DTCalibration/interface/DTT0BaseCorrection.h
+++ b/CalibMuon/DTCalibration/interface/DTT0BaseCorrection.h
@@ -9,32 +9,31 @@
 namespace edm {
   class EventSetup;
   class ParameterSet;
-}
+}  // namespace edm
 
 class DTWireId;
 
 namespace dtCalibration {
 
-struct DTT0Data {
-public:
-   // Constructor
-  DTT0Data(double t0_mean, double t0_rms) : mean(t0_mean),
-	                   		    rms(t0_rms) {}
+  struct DTT0Data {
+  public:
+    // Constructor
+    DTT0Data(double t0_mean, double t0_rms) : mean(t0_mean), rms(t0_rms) {}
 
-  double mean;
-  double rms;
-}; 
+    double mean;
+    double rms;
+  };
 
-class DTT0BaseCorrection {
-public:
-   // Constructor
-   DTT0BaseCorrection();
-   // Destructor
-   virtual ~DTT0BaseCorrection();
-   
-   virtual void setES(const edm::EventSetup& setup) = 0;
-   virtual DTT0Data correction(const DTWireId&) = 0;
-}; 
+  class DTT0BaseCorrection {
+  public:
+    // Constructor
+    DTT0BaseCorrection();
+    // Destructor
+    virtual ~DTT0BaseCorrection();
 
-} // namespace
+    virtual void setES(const edm::EventSetup& setup) = 0;
+    virtual DTT0Data correction(const DTWireId&) = 0;
+  };
+
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/interface/DTTMax.h
+++ b/CalibMuon/DTCalibration/interface/DTTMax.h
@@ -22,45 +22,46 @@ class DTSuperLayer;
 class DTSuperLayerId;
 class DTTTrigBaseSync;
 
-namespace dttmaxenums{
-  enum TMaxCells {c123, c124, c134, c234, notInit};
-  enum SigmaFactor{r32, r72, r78, noR};
-  enum SegDir {L, R};
-}
-
+namespace dttmaxenums {
+  enum TMaxCells { c123, c124, c134, c234, notInit };
+  enum SigmaFactor { r32, r72, r78, noR };
+  enum SegDir { L, R };
+}  // namespace dttmaxenums
 
 class DTTMax {
- public:
+public:
   typedef dttmaxenums::TMaxCells TMaxCells;
   typedef dttmaxenums::SegDir SegDir;
   typedef dttmaxenums::SigmaFactor SigmaFactor;
-  
+
   /// Constructor
-  DTTMax(const std::vector<DTRecHit1D> & hits, const DTSuperLayer & isl, GlobalVector dir, 
-	 GlobalPoint pos, const DTTTrigBaseSync& sync);
-  
+  DTTMax(const std::vector<DTRecHit1D>& hits,
+         const DTSuperLayer& isl,
+         GlobalVector dir,
+         GlobalPoint pos,
+         const DTTTrigBaseSync& sync);
+
   /// Destructor
   virtual ~DTTMax();
-  
+
   /// Information on each of the four TMax values in a SL
-  struct TMax{
-    TMax(float t_, TMaxCells cells_, std::string type_, SigmaFactor sigma_, 
-	 unsigned t0Factor_,unsigned hSubGroup_) :
-    t(t_), cells(cells_), type(type_), sigma(sigma_), t0Factor(t0Factor_), hSubGroup(hSubGroup_) {}
-    
+  struct TMax {
+    TMax(float t_, TMaxCells cells_, std::string type_, SigmaFactor sigma_, unsigned t0Factor_, unsigned hSubGroup_)
+        : t(t_), cells(cells_), type(type_), sigma(sigma_), t0Factor(t0Factor_), hSubGroup(hSubGroup_) {}
+
     float t;
     TMaxCells cells;
-    std::string type;       // LLR, LRL,...
-    SigmaFactor sigma; // factor relating the width of the Tmax distribution 
-                       // and the cell resolution
-    unsigned t0Factor; // "quantity" of Delta(t0) included in the tmax formula
-    unsigned hSubGroup;//different t0 hists (one hit within a given distance from the wire)
+    std::string type;    // LLR, LRL,...
+    SigmaFactor sigma;   // factor relating the width of the Tmax distribution
+                         // and the cell resolution
+    unsigned t0Factor;   // "quantity" of Delta(t0) included in the tmax formula
+    unsigned hSubGroup;  //different t0 hists (one hit within a given distance from the wire)
   };
 
   // All information on one of the layers crossed by the segment
   struct InfoLayer {
-    InfoLayer(const DTRecHit1D& rh_, const DTSuperLayer & isl, GlobalVector dir, 
-	      GlobalPoint pos, const DTTTrigBaseSync& sync);
+    InfoLayer(
+        const DTRecHit1D& rh_, const DTSuperLayer& isl, GlobalVector dir, GlobalPoint pos, const DTTTrigBaseSync& sync);
     DTRecHit1D rh;
     DTWireId idWire;
     DTEnums::DTCellSide lr;
@@ -69,28 +70,26 @@ class DTTMax {
   };
 
   // Return the three TMax for a given cell
-  std::vector<const TMax*> getTMax(const DTWireId & idWire);
+  std::vector<const TMax*> getTMax(const DTWireId& idWire);
 
   // Return the four TMaxes of the SL
-  std::vector<const TMax*> getTMax(const DTSuperLayerId & isl);
+  std::vector<const TMax*> getTMax(const DTSuperLayerId& isl);
 
   // Return one of the four TMaxes of the SL
   const TMax* getTMax(TMaxCells cCase);
 
   // Get InfoLayer (r/w) from layer number
-  InfoLayer*& getInfoLayer(int layer) {return theInfoLayers[layer-1];}
+  InfoLayer*& getInfoLayer(int layer) { return theInfoLayers[layer - 1]; }
 
- private:
-  DTTMax(){}; // Hide default constructor
+private:
+  DTTMax(){};  // Hide default constructor
 
-  //debug flag 
+  //debug flag
   bool debug;
 
   std::vector<InfoLayer*> theInfoLayers;
   std::vector<TMax*> theTMaxes;
   SegDir theSegDir;
-  std::string theSegType; // LRLR, LRLL, ....
-
+  std::string theSegType;  // LRLR, LRLL, ....
 };
 #endif
-

--- a/CalibMuon/DTCalibration/interface/DTTTrigBaseCorrection.h
+++ b/CalibMuon/DTCalibration/interface/DTTTrigBaseCorrection.h
@@ -10,34 +10,33 @@
 namespace edm {
   class EventSetup;
   class ParameterSet;
-}
+}  // namespace edm
 
 class DTSuperLayerId;
 
 namespace dtCalibration {
 
-struct DTTTrigData {
-public:
-   // Constructor
-  DTTTrigData(double ttrig_mean, double ttrig_sigma, double kFact) : mean(ttrig_mean),
-								     sigma(ttrig_sigma),
-								     kFactor(kFact) {}
+  struct DTTTrigData {
+  public:
+    // Constructor
+    DTTTrigData(double ttrig_mean, double ttrig_sigma, double kFact)
+        : mean(ttrig_mean), sigma(ttrig_sigma), kFactor(kFact) {}
 
-  double mean;
-  double sigma;
-  double kFactor;
-}; 
+    double mean;
+    double sigma;
+    double kFactor;
+  };
 
-class DTTTrigBaseCorrection {
-public:
-   // Constructor
-   DTTTrigBaseCorrection();
-   // Destructor
-   virtual ~DTTTrigBaseCorrection();
-   
-   virtual void setES(const edm::EventSetup& setup) = 0;
-   virtual DTTTrigData correction(const DTSuperLayerId&) = 0;
-};
- 
-} // namespace
+  class DTTTrigBaseCorrection {
+  public:
+    // Constructor
+    DTTTrigBaseCorrection();
+    // Destructor
+    virtual ~DTTTrigBaseCorrection();
+
+    virtual void setES(const edm::EventSetup& setup) = 0;
+    virtual DTTTrigData correction(const DTSuperLayerId&) = 0;
+  };
+
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/interface/DTTTrigCorrectionFactory.h
+++ b/CalibMuon/DTCalibration/interface/DTTTrigCorrectionFactory.h
@@ -16,5 +16,6 @@ namespace dtCalibration {
   class DTTTrigBaseCorrection;
 }
 
-typedef edmplugin::PluginFactory<dtCalibration::DTTTrigBaseCorrection *(const edm::ParameterSet &)> DTTTrigCorrectionFactory;
+typedef edmplugin::PluginFactory<dtCalibration::DTTTrigBaseCorrection *(const edm::ParameterSet &)>
+    DTTTrigCorrectionFactory;
 #endif

--- a/CalibMuon/DTCalibration/interface/DTTimeBoxFitter.h
+++ b/CalibMuon/DTCalibration/interface/DTTimeBoxFitter.h
@@ -10,7 +10,6 @@
 
 #include <utility>
 
-
 class TH1F;
 class TFile;
 #include "TString.h"
@@ -26,51 +25,37 @@ public:
   // Operations
 
   /// Fit the rising edge of the time box returning mean value and sigma (first and second respectively)
-  std::pair<double, double> fitTimeBox(TH1F *hTimeBox);
+  std::pair<double, double> fitTimeBox(TH1F* hTimeBox);
 
-  
   /// Automatically compute the seeds the range to be used for time box fit
-  void getFitSeeds(TH1F *hTBox, double& mean, double& sigma, double& tBoxMax, double& xFitMin,
-		   double& xFitMax);
+  void getFitSeeds(TH1F* hTBox, double& mean, double& sigma, double& tBoxMax, double& xFitMin, double& xFitMax);
 
   /// Ask the user to provide the seeds
-  void getInteractiveFitSeeds(TH1F *hTBox, double& mean, double& sigma, double& tBoxMax,
-			      double& xFitMin, double& xFitMax);
-
+  void getInteractiveFitSeeds(
+      TH1F* hTBox, double& mean, double& sigma, double& tBoxMax, double& xFitMin, double& xFitMax);
 
   /// Set the verbosity of the output: 0 = silent, 1 = info, 2 = debug
-  void setVerbosity(unsigned int lvl) {
-    theVerbosityLevel = lvl;
-  }
+  void setVerbosity(unsigned int lvl) { theVerbosityLevel = lvl; }
 
   /// Switch to interactive fit
-  void setInteractiveFit(bool isInteractive) {
-    interactiveFit = isInteractive;
-  }
+  void setInteractiveFit(bool isInteractive) { interactiveFit = isInteractive; }
 
- /// Set the rebin
-  void setRebinning(int reb) {
-    rebin = reb;
-  }
+  /// Set the rebin
+  void setRebinning(int reb) { rebin = reb; }
 
-  void setFitSigma(double sigma) {
-    theSigma = sigma;
-  }
+  void setFitSigma(double sigma) { theSigma = sigma; }
 
 protected:
-
 private:
-
-  TFile *hDebugFile;
+  TFile* hDebugFile;
 
   unsigned int theVerbosityLevel;
   bool interactiveFit;
   int rebin;
   double theSigma;
-
 };
 
 // Define the integral of the gaussian to be used in the fit
-double intGauss(double *x, double *par);
+double intGauss(double* x, double* par);
 
 #endif

--- a/CalibMuon/DTCalibration/interface/DTVDriftBaseAlgo.h
+++ b/CalibMuon/DTCalibration/interface/DTVDriftBaseAlgo.h
@@ -10,30 +10,28 @@
 namespace edm {
   class EventSetup;
   class ParameterSet;
-}
+}  // namespace edm
 
 class DTSuperLayerId;
 
 namespace dtCalibration {
 
-struct DTVDriftData {
-public:
-  DTVDriftData(double vdrift_mean, double vdrift_resolution):
-     vdrift(vdrift_mean),
-     resolution(vdrift_resolution) {}
+  struct DTVDriftData {
+  public:
+    DTVDriftData(double vdrift_mean, double vdrift_resolution) : vdrift(vdrift_mean), resolution(vdrift_resolution) {}
 
-  double vdrift;
-  double resolution;
-}; 
+    double vdrift;
+    double resolution;
+  };
 
-class DTVDriftBaseAlgo {
-public:
-   DTVDriftBaseAlgo();
-   virtual ~DTVDriftBaseAlgo();
-   
-   virtual void setES(const edm::EventSetup& setup) = 0;
-   virtual DTVDriftData compute(const DTSuperLayerId&) = 0;
-}; 
+  class DTVDriftBaseAlgo {
+  public:
+    DTVDriftBaseAlgo();
+    virtual ~DTVDriftBaseAlgo();
 
-} // namespace
+    virtual void setES(const edm::EventSetup& setup) = 0;
+    virtual DTVDriftData compute(const DTSuperLayerId&) = 0;
+  };
+
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/interface/Histogram.h
+++ b/CalibMuon/DTCalibration/interface/Histogram.h
@@ -5,36 +5,36 @@
 #include "TH2.h"
 #include "TString.h"
 
-TH1F * hT123Bad;
-TH1F * hT123LRL;
-TH1F * hT123LLR;
-TH1F * hT123LRR;
-TH1F * hT124Bad;
-TH1F * hT124LRR1gt4;
-TH1F * hT124LRR1lt4;
-TH1F * hT124LLR;
-TH1F * hT124LLLR;
-TH1F * hT124LLLL;
-TH1F * hT124LRLL;
-TH1F * hT124LRLR;
-TH1F * hT134Bad;
-TH1F * hT134LLR1gt4;
-TH1F * hT134LLR1lt4;
-TH1F * hT134LRR;
-TH1F * hT134LRLR;
-TH1F * hT134LRLL;
-TH1F * hT134LLLL;
-TH1F * hT134LLLR;
-TH1F * hT234Bad;
-TH1F * hT234LRL;
-TH1F * hT234LLR;
-TH1F * hT234LRR;
+TH1F* hT123Bad;
+TH1F* hT123LRL;
+TH1F* hT123LLR;
+TH1F* hT123LRR;
+TH1F* hT124Bad;
+TH1F* hT124LRR1gt4;
+TH1F* hT124LRR1lt4;
+TH1F* hT124LLR;
+TH1F* hT124LLLR;
+TH1F* hT124LLLL;
+TH1F* hT124LRLL;
+TH1F* hT124LRLR;
+TH1F* hT134Bad;
+TH1F* hT134LLR1gt4;
+TH1F* hT134LLR1lt4;
+TH1F* hT134LRR;
+TH1F* hT134LRLR;
+TH1F* hT134LRLL;
+TH1F* hT134LLLL;
+TH1F* hT134LLLR;
+TH1F* hT234Bad;
+TH1F* hT234LRL;
+TH1F* hT234LLR;
+TH1F* hT234LRR;
 
 void bookHistos() {
-  hT123LRL = new TH1F("hT123LRL", "Tmax123 LRL", 2000, -1000., 1000.); 
+  hT123LRL = new TH1F("hT123LRL", "Tmax123 LRL", 2000, -1000., 1000.);
   hT123LLR = new TH1F("hT123LLR", "Tmax123 LLR", 2000, -1000., 1000.);
   hT123LRR = new TH1F("hT123LRR", "Tmax123 LRR", 2000, -1000., 1000.);
-  hT123Bad = new TH1F("hT123Bad", "Bad Tmax123", 10, -5., 5.); 
+  hT123Bad = new TH1F("hT123Bad", "Bad Tmax123", 10, -5., 5.);
   hT124LRR1gt4 = new TH1F("hT124LRR1gt4", "Tmax124 LRR x1>x4", 2000, -1000., 1000.);
   hT124LRR1lt4 = new TH1F("hT124LRR1lt4", "Tmax124 LRR x1<x4", 2000, -1000., 1000.);
   hT124LLR = new TH1F("hT124LLR", "Tmax124 LLR", 2000, -1000., 1000.);
@@ -42,7 +42,7 @@ void bookHistos() {
   hT124LLLL = new TH1F("hT124LLLL", "Tmax124 LLL Dir.L", 2000, -1000., 1000.);
   hT124LRLL = new TH1F("hT124LRLL", "Tmax124 LRL Dir.L", 2000, -1000., 1000.);
   hT124LRLR = new TH1F("hT124LRLR", "Tmax124 LRL Dir.R", 2000, -1000., 1000.);
-  hT124Bad = new TH1F("hT124Bad", "Bad Tmax124", 10, -5., 5.); 
+  hT124Bad = new TH1F("hT124Bad", "Bad Tmax124", 10, -5., 5.);
   hT134LLR1gt4 = new TH1F("hT134LLR1gt4", "Tmax134 LLR x1>x4", 2000, -1000., 1000.);
   hT134LLR1lt4 = new TH1F("hT134LLR1lt4", "Tmax134 LLR x1<x4", 2000, -1000., 1000.);
   hT134LRR = new TH1F("hT134LRR", "Tmax134", 2000, -1000., 1000.);
@@ -50,11 +50,11 @@ void bookHistos() {
   hT134LRLL = new TH1F("hT134LRLL", "Tmax134 LRL Dir.L", 2000, -1000., 1000.);
   hT134LLLL = new TH1F("hT134LLLL", "Tmax134 LLL Dir.L", 2000, -1000., 1000.);
   hT134LLLR = new TH1F("hT134LLLR", "Tmax134 LLL Dir.R", 2000, -1000., 1000.);
-  hT134Bad = new TH1F("hT134Bad", "Bad Tmax134", 10, -5., 5.); 
+  hT134Bad = new TH1F("hT134Bad", "Bad Tmax134", 10, -5., 5.);
   hT234LRL = new TH1F("hT234LRL", "Tmax234 LRL", 2000, -1000., 1000.);
   hT234LLR = new TH1F("hT234LLR", "Tmax234 LLR", 2000, -1000., 1000.);
   hT234LRR = new TH1F("hT234LRR", "Tmax234 LRR", 2000, -1000., 1000.);
-  hT234Bad = new TH1F("hT234Bad", "Bad Tmax234", 10, -5., 5.); 
+  hT234Bad = new TH1F("hT234Bad", "Bad Tmax234", 10, -5., 5.);
 }
 
 #endif

--- a/CalibMuon/DTCalibration/interface/vDriftHistos.h
+++ b/CalibMuon/DTCalibration/interface/vDriftHistos.h
@@ -8,184 +8,174 @@
 #include <string>
 
 // A set of histograms on chamber angle and position
-class h4DSegm{
- public:
-  h4DSegm(std::string name_){
+class h4DSegm {
+public:
+  h4DSegm(std::string name_) {
     TString N = name_.c_str();
-    name=name_.c_str();
-    h4DSegmXPosInCham     = new TH1F(N+"_h4DSegmXPosInCham", 
-				    "4D Segment x position (cm) in Chamber RF", 200, -200, 200); 
-    h4DSegmYPosInCham     = new TH1F(N+"_h4DSegmYPosInCham", 
-				    "4D Segment y position (cm) in Chamber RF", 200, -200, 200); 
-    h4DSegmPhiAngleInCham   = new TH1F(N+"_h4DSegmPhiAngleInCham",  
- 				    "4D Segment phi angle (rad) in Chamber RF", 180, -180, 180); 
-    h4DSegmThetaAngleInCham   = new TH1F(N+"_h4DSegmThetaAngleInCham",  
- 				    "4D Segment theta angle (rad) in Chamber RF", 180, -180, 180); 
-    h4DSegmImpactAngleInCham   = new TH1F(N+"_h4DSegmImpactAngleInCham",  
- 				    "4D Segment impact angle (rad) in Chamber RF", 180, -180, 180); 
+    name = name_.c_str();
+    h4DSegmXPosInCham = new TH1F(N + "_h4DSegmXPosInCham", "4D Segment x position (cm) in Chamber RF", 200, -200, 200);
+    h4DSegmYPosInCham = new TH1F(N + "_h4DSegmYPosInCham", "4D Segment y position (cm) in Chamber RF", 200, -200, 200);
+    h4DSegmPhiAngleInCham =
+        new TH1F(N + "_h4DSegmPhiAngleInCham", "4D Segment phi angle (rad) in Chamber RF", 180, -180, 180);
+    h4DSegmThetaAngleInCham =
+        new TH1F(N + "_h4DSegmThetaAngleInCham", "4D Segment theta angle (rad) in Chamber RF", 180, -180, 180);
+    h4DSegmImpactAngleInCham =
+        new TH1F(N + "_h4DSegmImpactAngleInCham", "4D Segment impact angle (rad) in Chamber RF", 180, -180, 180);
   }
- h4DSegm(const TString& name_, TFile* file){
-    name=name_;
-    h4DSegmXPosInCham  = (TH1F *) file->Get(name+"_h4DSegmXPosInCham"); 
-    h4DSegmYPosInCham  = (TH1F *) file->Get(name+"_h4DSegmYPosInCham"); 
-    h4DSegmPhiAngleInCham  = (TH1F *) file->Get(name+"_h4DSegmPhiAngleInCham"); 
-    h4DSegmThetaAngleInCham  = (TH1F *) file->Get(name+"_h4DSegmThetaAngleInCham"); 
-    h4DSegmImpactAngleInCham  = (TH1F *) file->Get(name+"_h4DSegmImpactAngleInCham"); 
- }
- ~h4DSegm(){
-    delete h4DSegmXPosInCham;     
-    delete h4DSegmYPosInCham;     
-    delete h4DSegmPhiAngleInCham;   
-    delete h4DSegmThetaAngleInCham;   
-    delete h4DSegmImpactAngleInCham;   
- } 
-void Fill(float x, float y, float phi, float theta, float impact) {
-    h4DSegmXPosInCham->Fill(x); 
-    h4DSegmYPosInCham->Fill(y); 
-    h4DSegmPhiAngleInCham->Fill(phi);   
-    h4DSegmThetaAngleInCham->Fill(theta);   
-    h4DSegmImpactAngleInCham->Fill(impact);   
-} 
-void Fill(float x, float phi) {
-    h4DSegmXPosInCham->Fill(x); 
-    h4DSegmPhiAngleInCham->Fill(phi);   
-} 
- void Write() {
-    h4DSegmXPosInCham->Write();     
-    h4DSegmYPosInCham->Write();     
-    h4DSegmPhiAngleInCham->Write();   
-    h4DSegmThetaAngleInCham->Write();   
-    h4DSegmImpactAngleInCham->Write();   
+  h4DSegm(const TString &name_, TFile *file) {
+    name = name_;
+    h4DSegmXPosInCham = (TH1F *)file->Get(name + "_h4DSegmXPosInCham");
+    h4DSegmYPosInCham = (TH1F *)file->Get(name + "_h4DSegmYPosInCham");
+    h4DSegmPhiAngleInCham = (TH1F *)file->Get(name + "_h4DSegmPhiAngleInCham");
+    h4DSegmThetaAngleInCham = (TH1F *)file->Get(name + "_h4DSegmThetaAngleInCham");
+    h4DSegmImpactAngleInCham = (TH1F *)file->Get(name + "_h4DSegmImpactAngleInCham");
   }
- public:
+  ~h4DSegm() {
+    delete h4DSegmXPosInCham;
+    delete h4DSegmYPosInCham;
+    delete h4DSegmPhiAngleInCham;
+    delete h4DSegmThetaAngleInCham;
+    delete h4DSegmImpactAngleInCham;
+  }
+  void Fill(float x, float y, float phi, float theta, float impact) {
+    h4DSegmXPosInCham->Fill(x);
+    h4DSegmYPosInCham->Fill(y);
+    h4DSegmPhiAngleInCham->Fill(phi);
+    h4DSegmThetaAngleInCham->Fill(theta);
+    h4DSegmImpactAngleInCham->Fill(impact);
+  }
+  void Fill(float x, float phi) {
+    h4DSegmXPosInCham->Fill(x);
+    h4DSegmPhiAngleInCham->Fill(phi);
+  }
+  void Write() {
+    h4DSegmXPosInCham->Write();
+    h4DSegmYPosInCham->Write();
+    h4DSegmPhiAngleInCham->Write();
+    h4DSegmThetaAngleInCham->Write();
+    h4DSegmImpactAngleInCham->Write();
+  }
 
-  TH1F *h4DSegmXPosInCham;     
-  TH1F *h4DSegmYPosInCham;     
-  TH1F *h4DSegmPhiAngleInCham;   
-  TH1F *h4DSegmThetaAngleInCham;   
-  TH1F *h4DSegmImpactAngleInCham;   
+public:
+  TH1F *h4DSegmXPosInCham;
+  TH1F *h4DSegmYPosInCham;
+  TH1F *h4DSegmPhiAngleInCham;
+  TH1F *h4DSegmThetaAngleInCham;
+  TH1F *h4DSegmImpactAngleInCham;
 
   TString name;
 };
 
-
 // A set of histograms on SL angle and position
-class h2DSegm{
- public:
-  h2DSegm(std::string name_){
+class h2DSegm {
+public:
+  h2DSegm(std::string name_) {
     TString N = name_.c_str();
-    name=name_.c_str();
-    h2DSegmPosInCham     = new TH1F(N+"_h2DSegmPosInCham", 
-				    "2D Segment position (cm) in Chamber RF", 200, -200, 200); 
-    h2DSegmAngleInCham   = new TH1F(N+"_h2DSegmAngleInCham",  
- 				    "2D Segment angle (rad) in Chamber RF", 200, -2, 2); 
-    h2DSegmCosAngleInCham   = new TH1F(N+"_h2DSegmCosAngleInCham",  
- 				       "2D Segment cos(angle) in Chamber RF", 200, -2, 2); 
+    name = name_.c_str();
+    h2DSegmPosInCham = new TH1F(N + "_h2DSegmPosInCham", "2D Segment position (cm) in Chamber RF", 200, -200, 200);
+    h2DSegmAngleInCham = new TH1F(N + "_h2DSegmAngleInCham", "2D Segment angle (rad) in Chamber RF", 200, -2, 2);
+    h2DSegmCosAngleInCham = new TH1F(N + "_h2DSegmCosAngleInCham", "2D Segment cos(angle) in Chamber RF", 200, -2, 2);
   }
-  h2DSegm(const TString& name_, TFile* file){
-    name=name_;
+  h2DSegm(const TString &name_, TFile *file) {
+    name = name_;
 
-    h2DSegmPosInCham  = (TH1F *) file->Get(name+"_h2DSegmPosInCham"); 
-    h2DSegmAngleInCham  = (TH1F *) file->Get(name+"_h2DSegmAngleInCham"); 
-    h2DSegmCosAngleInCham  = (TH1F *) file->Get(name+"_h2DSegmCosAngleInCham"); 
+    h2DSegmPosInCham = (TH1F *)file->Get(name + "_h2DSegmPosInCham");
+    h2DSegmAngleInCham = (TH1F *)file->Get(name + "_h2DSegmAngleInCham");
+    h2DSegmCosAngleInCham = (TH1F *)file->Get(name + "_h2DSegmCosAngleInCham");
   }
-  ~h2DSegm(){
-    delete h2DSegmPosInCham;     
-    delete h2DSegmAngleInCham;   
-    delete h2DSegmCosAngleInCham;   
+  ~h2DSegm() {
+    delete h2DSegmPosInCham;
+    delete h2DSegmAngleInCham;
+    delete h2DSegmCosAngleInCham;
   }
   void Fill(float pos, float localAngle) {
-
-    h2DSegmPosInCham->Fill(pos); 
-    h2DSegmAngleInCham->Fill(atan(localAngle));   
-    h2DSegmCosAngleInCham->Fill(cos(atan(localAngle)));   
+    h2DSegmPosInCham->Fill(pos);
+    h2DSegmAngleInCham->Fill(atan(localAngle));
+    h2DSegmCosAngleInCham->Fill(cos(atan(localAngle)));
   }
   void Write() {
-    h2DSegmPosInCham->Write();     
-    h2DSegmAngleInCham->Write();   
-    h2DSegmCosAngleInCham->Write();   
+    h2DSegmPosInCham->Write();
+    h2DSegmAngleInCham->Write();
+    h2DSegmCosAngleInCham->Write();
   }
- public:
 
-  TH1F *h2DSegmPosInCham;     
-  TH1F *h2DSegmAngleInCham;   
-  TH1F *h2DSegmCosAngleInCham;   
+public:
+  TH1F *h2DSegmPosInCham;
+  TH1F *h2DSegmAngleInCham;
+  TH1F *h2DSegmCosAngleInCham;
 
   TString name;
 };
 
 // A set of histograms on SL Tmax
-class hTMaxCell{
- public:
-  hTMaxCell(const TString& name_){
+class hTMaxCell {
+public:
+  hTMaxCell(const TString &name_) {
     name = name_;
 
-    // book TMax histograms 
-    hTmax123      = new TH1F (name+"_Tmax123", "Tmax123 value", 2000, -1000., 1000.);
-    hTmax124s72   = new TH1F (name+"_Tmax124_s72", "Tmax124 sigma=sqrt(7/2) value", 2000, -1000., 1000.);
-    hTmax124s78   = new TH1F (name+"_Tmax124_s78", "Tmax124 sigma=sqrt(7/8) value", 2000, -1000., 1000.);
-    hTmax134s72   = new TH1F (name+"_Tmax134_s72", "Tmax134 sigma=sqrt(7/2) value", 2000, -1000., 1000.);
-    hTmax134s78   = new TH1F (name+"_Tmax134_s78", "Tmax134 sigma=sqrt(7/8) value", 2000, -1000., 1000.);
-    hTmax234      = new TH1F (name+"_Tmax234", "Tmax234 value", 2000, -1000., 1000.);
-    hTmax_3t0  = new TH1F (name+"_3t0", "Tmax+3*Delta(t0)", 2000, -1000., 1000.); 
-    hTmax_3t0_0  = new TH1F (name+"_3t0_0", "Tmax+3*Delta(t0); 3 hits", 2000, -1000., 1000.); 
-    hTmax_3t0_1  = new TH1F (name+"_3t0_1", "Tmax+3*Delta(t0); one t<5ns", 2000, -1000., 1000.); 
-    hTmax_3t0_2  = new TH1F (name+"_3t0_2", "Tmax+3*Delta(t0); one t<10ns", 2000, -1000., 1000.); 
-    hTmax_3t0_3  = new TH1F (name+"_3t0_3", "Tmax+3*Delta(t0); one t<20ns", 2000, -1000., 1000.); 
-    hTmax_3t0_4  = new TH1F (name+"_3t0_4", "Tmax+3*Delta(t0); one t<50ns", 2000, -1000., 1000.); 
-    hTmax_3t0_5  = new TH1F (name+"_3t0_5", "Tmax+3*Delta(t0); all t>50ns", 2000, -1000., 1000.); 
-    hTmax_2t0  = new TH1F (name+"_2t0", "Tmax+2*Delta(t0)", 2000, -1000., 1000.);
-    hTmax_2t0_0  = new TH1F (name+"_2t0_0", "Tmax+2*Delta(t0); 3 hits", 2000, -1000., 1000.); 
-    hTmax_2t0_1  = new TH1F (name+"_2t0_1", "Tmax+2*Delta(t0); one t<5ns", 2000, -1000., 1000.); 
-    hTmax_2t0_2  = new TH1F (name+"_2t0_2", "Tmax+2*Delta(t0); one t<10ns", 2000, -1000., 1000.); 
-    hTmax_2t0_3  = new TH1F (name+"_2t0_3", "Tmax+2*Delta(t0); one t<20ns", 2000, -1000., 1000.); 
-    hTmax_2t0_4  = new TH1F (name+"_2t0_4", "Tmax+2*Delta(t0); one t<50ns", 2000, -1000., 1000.); 
-    hTmax_2t0_5  = new TH1F (name+"_2t0_5", "Tmax+2*Delta(t0); all t>50ns", 2000, -1000., 1000.); 
-    hTmax_t0   = new TH1F (name+"_t0", "Tmax+Delta(t0)", 2000, -1000., 1000.);
-    hTmax_t0_0  = new TH1F (name+"_t0_0", "Tmax+Delta(t0); 3 hits", 2000, -1000., 1000.); 
-    hTmax_t0_1  = new TH1F (name+"_t0_1", "Tmax+Delta(t0); one t<5ns", 2000, -1000., 1000.); 
-    hTmax_t0_2  = new TH1F (name+"_t0_2", "Tmax+Delta(t0); one t<10ns", 2000, -1000., 1000.); 
-    hTmax_t0_3  = new TH1F (name+"_t0_3", "Tmax+Delta(t0); one t<20ns", 2000, -1000., 1000.); 
-    hTmax_t0_4  = new TH1F (name+"_t0_4", "Tmax+Delta(t0); one t<50ns", 2000, -1000., 1000.); 
-    hTmax_t0_5  = new TH1F (name+"_t0_5", "Tmax+Delta(t0); all t>50ns", 2000, -1000., 1000.); 
-    hTmax_0    = new TH1F (name+"_0", "Tmax", 2000, -1000., 1000.);
+    // book TMax histograms
+    hTmax123 = new TH1F(name + "_Tmax123", "Tmax123 value", 2000, -1000., 1000.);
+    hTmax124s72 = new TH1F(name + "_Tmax124_s72", "Tmax124 sigma=sqrt(7/2) value", 2000, -1000., 1000.);
+    hTmax124s78 = new TH1F(name + "_Tmax124_s78", "Tmax124 sigma=sqrt(7/8) value", 2000, -1000., 1000.);
+    hTmax134s72 = new TH1F(name + "_Tmax134_s72", "Tmax134 sigma=sqrt(7/2) value", 2000, -1000., 1000.);
+    hTmax134s78 = new TH1F(name + "_Tmax134_s78", "Tmax134 sigma=sqrt(7/8) value", 2000, -1000., 1000.);
+    hTmax234 = new TH1F(name + "_Tmax234", "Tmax234 value", 2000, -1000., 1000.);
+    hTmax_3t0 = new TH1F(name + "_3t0", "Tmax+3*Delta(t0)", 2000, -1000., 1000.);
+    hTmax_3t0_0 = new TH1F(name + "_3t0_0", "Tmax+3*Delta(t0); 3 hits", 2000, -1000., 1000.);
+    hTmax_3t0_1 = new TH1F(name + "_3t0_1", "Tmax+3*Delta(t0); one t<5ns", 2000, -1000., 1000.);
+    hTmax_3t0_2 = new TH1F(name + "_3t0_2", "Tmax+3*Delta(t0); one t<10ns", 2000, -1000., 1000.);
+    hTmax_3t0_3 = new TH1F(name + "_3t0_3", "Tmax+3*Delta(t0); one t<20ns", 2000, -1000., 1000.);
+    hTmax_3t0_4 = new TH1F(name + "_3t0_4", "Tmax+3*Delta(t0); one t<50ns", 2000, -1000., 1000.);
+    hTmax_3t0_5 = new TH1F(name + "_3t0_5", "Tmax+3*Delta(t0); all t>50ns", 2000, -1000., 1000.);
+    hTmax_2t0 = new TH1F(name + "_2t0", "Tmax+2*Delta(t0)", 2000, -1000., 1000.);
+    hTmax_2t0_0 = new TH1F(name + "_2t0_0", "Tmax+2*Delta(t0); 3 hits", 2000, -1000., 1000.);
+    hTmax_2t0_1 = new TH1F(name + "_2t0_1", "Tmax+2*Delta(t0); one t<5ns", 2000, -1000., 1000.);
+    hTmax_2t0_2 = new TH1F(name + "_2t0_2", "Tmax+2*Delta(t0); one t<10ns", 2000, -1000., 1000.);
+    hTmax_2t0_3 = new TH1F(name + "_2t0_3", "Tmax+2*Delta(t0); one t<20ns", 2000, -1000., 1000.);
+    hTmax_2t0_4 = new TH1F(name + "_2t0_4", "Tmax+2*Delta(t0); one t<50ns", 2000, -1000., 1000.);
+    hTmax_2t0_5 = new TH1F(name + "_2t0_5", "Tmax+2*Delta(t0); all t>50ns", 2000, -1000., 1000.);
+    hTmax_t0 = new TH1F(name + "_t0", "Tmax+Delta(t0)", 2000, -1000., 1000.);
+    hTmax_t0_0 = new TH1F(name + "_t0_0", "Tmax+Delta(t0); 3 hits", 2000, -1000., 1000.);
+    hTmax_t0_1 = new TH1F(name + "_t0_1", "Tmax+Delta(t0); one t<5ns", 2000, -1000., 1000.);
+    hTmax_t0_2 = new TH1F(name + "_t0_2", "Tmax+Delta(t0); one t<10ns", 2000, -1000., 1000.);
+    hTmax_t0_3 = new TH1F(name + "_t0_3", "Tmax+Delta(t0); one t<20ns", 2000, -1000., 1000.);
+    hTmax_t0_4 = new TH1F(name + "_t0_4", "Tmax+Delta(t0); one t<50ns", 2000, -1000., 1000.);
+    hTmax_t0_5 = new TH1F(name + "_t0_5", "Tmax+Delta(t0); all t>50ns", 2000, -1000., 1000.);
+    hTmax_0 = new TH1F(name + "_0", "Tmax", 2000, -1000., 1000.);
   }
 
-
-  hTMaxCell (const TString& name_, TFile* file){
-    name=name_;
-    hTmax123      = (TH1F *) file->Get(name+"_Tmax123");
-    hTmax124s72   = (TH1F *) file->Get(name+"_Tmax124_s72");
-    hTmax124s78   = (TH1F *) file->Get(name+"_Tmax124_s78");
-    hTmax134s72   = (TH1F *) file->Get(name+"_Tmax134_s72");
-    hTmax134s78   = (TH1F *) file->Get(name+"_Tmax134_s78");
-    hTmax234      = (TH1F *) file->Get(name+"_Tmax234");
-    hTmax_3t0  = (TH1F *) file->Get(name+"_3t0");
-    hTmax_3t0_0  = (TH1F *) file->Get(name+"_3t0_0");
-    hTmax_3t0_1  = (TH1F *) file->Get(name+"_3t0_1");
-    hTmax_3t0_2  = (TH1F *) file->Get(name+"_3t0_2");
-    hTmax_3t0_3  = (TH1F *) file->Get(name+"_3t0_3");
-    hTmax_3t0_4  = (TH1F *) file->Get(name+"_3t0_4");
-    hTmax_3t0_5  = (TH1F *) file->Get(name+"_3t0_5");
-    hTmax_2t0  = (TH1F *) file->Get(name+"_2t0");
-    hTmax_2t0_0  = (TH1F *) file->Get(name+"_2t0_0");
-    hTmax_2t0_1  = (TH1F *) file->Get(name+"_2t0_1");
-    hTmax_2t0_2  = (TH1F *) file->Get(name+"_2t0_2");
-    hTmax_2t0_3  = (TH1F *) file->Get(name+"_2t0_3");
-    hTmax_2t0_4  = (TH1F *) file->Get(name+"_2t0_4");
-    hTmax_2t0_5  = (TH1F *) file->Get(name+"_2t0_5");
-    hTmax_t0  = (TH1F *) file->Get(name+"_t0");
-    hTmax_t0_1  = (TH1F *) file->Get(name+"_t0_1");
-    hTmax_t0_2  = (TH1F *) file->Get(name+"_t0_2");
-    hTmax_t0_3  = (TH1F *) file->Get(name+"_t0_3");
-    hTmax_t0_4  = (TH1F *) file->Get(name+"_t0_4");
-    hTmax_t0_5  = (TH1F *) file->Get(name+"_t0_5");
-    hTmax_0  = (TH1F *) file->Get(name+"_0");
-
+  hTMaxCell(const TString &name_, TFile *file) {
+    name = name_;
+    hTmax123 = (TH1F *)file->Get(name + "_Tmax123");
+    hTmax124s72 = (TH1F *)file->Get(name + "_Tmax124_s72");
+    hTmax124s78 = (TH1F *)file->Get(name + "_Tmax124_s78");
+    hTmax134s72 = (TH1F *)file->Get(name + "_Tmax134_s72");
+    hTmax134s78 = (TH1F *)file->Get(name + "_Tmax134_s78");
+    hTmax234 = (TH1F *)file->Get(name + "_Tmax234");
+    hTmax_3t0 = (TH1F *)file->Get(name + "_3t0");
+    hTmax_3t0_0 = (TH1F *)file->Get(name + "_3t0_0");
+    hTmax_3t0_1 = (TH1F *)file->Get(name + "_3t0_1");
+    hTmax_3t0_2 = (TH1F *)file->Get(name + "_3t0_2");
+    hTmax_3t0_3 = (TH1F *)file->Get(name + "_3t0_3");
+    hTmax_3t0_4 = (TH1F *)file->Get(name + "_3t0_4");
+    hTmax_3t0_5 = (TH1F *)file->Get(name + "_3t0_5");
+    hTmax_2t0 = (TH1F *)file->Get(name + "_2t0");
+    hTmax_2t0_0 = (TH1F *)file->Get(name + "_2t0_0");
+    hTmax_2t0_1 = (TH1F *)file->Get(name + "_2t0_1");
+    hTmax_2t0_2 = (TH1F *)file->Get(name + "_2t0_2");
+    hTmax_2t0_3 = (TH1F *)file->Get(name + "_2t0_3");
+    hTmax_2t0_4 = (TH1F *)file->Get(name + "_2t0_4");
+    hTmax_2t0_5 = (TH1F *)file->Get(name + "_2t0_5");
+    hTmax_t0 = (TH1F *)file->Get(name + "_t0");
+    hTmax_t0_1 = (TH1F *)file->Get(name + "_t0_1");
+    hTmax_t0_2 = (TH1F *)file->Get(name + "_t0_2");
+    hTmax_t0_3 = (TH1F *)file->Get(name + "_t0_3");
+    hTmax_t0_4 = (TH1F *)file->Get(name + "_t0_4");
+    hTmax_t0_5 = (TH1F *)file->Get(name + "_t0_5");
+    hTmax_0 = (TH1F *)file->Get(name + "_0");
   }
 
- 
-  ~hTMaxCell(){
+  ~hTMaxCell() {
     delete hTmax123;
     delete hTmax124s72;
     delete hTmax124s78;
@@ -214,155 +204,270 @@ class hTMaxCell{
     delete hTmax_t0_4;
     delete hTmax_t0_5;
     delete hTmax_0;
-
   }
 
-  void Fill(float tmax123, float tmax124, float tmax134, float tmax234,
-	    dttmaxenums::SigmaFactor s124,// Give the factor relating the width of the TMax distribution
-	    dttmaxenums::SigmaFactor s134,// and the cell resolution (for tmax123 and tmax234 is always= sqrt(3/2)).
-	    unsigned t0_123, // Give the "quantity" of Delta(t0) included in the tmax 
-	    unsigned t0_124, // formula used for Tmax123 or Tma124 or Tma134 or Tma234
-	    unsigned t0_134,
-	    unsigned t0_234,
-	    unsigned hSubGroup//different t0 hists(at least one hit within a given distance from the wire)
-	    ) {
- 
-    if(tmax123 > 0.) {
+  void Fill(float tmax123,
+            float tmax124,
+            float tmax134,
+            float tmax234,
+            dttmaxenums::SigmaFactor s124,  // Give the factor relating the width of the TMax distribution
+            dttmaxenums::SigmaFactor s134,  // and the cell resolution (for tmax123 and tmax234 is always= sqrt(3/2)).
+            unsigned t0_123,                // Give the "quantity" of Delta(t0) included in the tmax
+            unsigned t0_124,                // formula used for Tmax123 or Tma124 or Tma134 or Tma234
+            unsigned t0_134,
+            unsigned t0_234,
+            unsigned hSubGroup  //different t0 hists(at least one hit within a given distance from the wire)
+  ) {
+    if (tmax123 > 0.) {
       hTmax123->Fill(tmax123);
-      if(t0_123==1) {
-	hTmax_t0->Fill(tmax123);
-	switch(hSubGroup) {
-	case 0: hTmax_t0_0->Fill(tmax123); break;
-	case 1: hTmax_t0_1->Fill(tmax123); break;
-	case 2: hTmax_t0_2->Fill(tmax123); break;
-	case 3: hTmax_t0_3->Fill(tmax123); break;
-	case 4: hTmax_t0_4->Fill(tmax123); break;
-	case 99: hTmax_t0_5->Fill(tmax123); break;
-	}
-      }
-      else {
-	hTmax_2t0->Fill(tmax123);
-	switch(hSubGroup) {
-	case 0: hTmax_2t0_0->Fill(tmax123); break;
-	case 1: hTmax_2t0_1->Fill(tmax123); break;
-	case 2: hTmax_2t0_2->Fill(tmax123); break;
-	case 3: hTmax_2t0_3->Fill(tmax123); break;
-	case 4: hTmax_2t0_4->Fill(tmax123); break;
-	case 99: hTmax_2t0_5->Fill(tmax123); break;
-	}
-      }
-    }
-    if(tmax124 > 0.) {
-      (s124==dttmaxenums::r72)? hTmax124s72->Fill(tmax124):hTmax124s78->Fill(tmax124);
-      if(t0_124==0)  
-	hTmax_0->Fill(tmax124);
-      else if(t0_124==1) {
-	hTmax_t0->Fill(tmax124); 
-	switch(hSubGroup) {
-	case 0: hTmax_t0_0->Fill(tmax124); break;
-	case 1: hTmax_t0_1->Fill(tmax124); break;
-	case 2: hTmax_t0_2->Fill(tmax124); break;
-	case 3: hTmax_t0_3->Fill(tmax124); break;
-	case 4: hTmax_t0_4->Fill(tmax124); break;
-	case 99: hTmax_t0_5->Fill(tmax124); break;
-	}
-      }
-      else if(t0_124== 2) {
-	hTmax_2t0->Fill(tmax124);
-	switch(hSubGroup) {
-	case 0: hTmax_2t0_0->Fill(tmax124); break;
-	case 1: hTmax_2t0_1->Fill(tmax124); break;
-	case 2: hTmax_2t0_2->Fill(tmax124); break;
-	case 3: hTmax_2t0_3->Fill(tmax124); break;
-	case 4: hTmax_2t0_4->Fill(tmax124); break;
-	case 99: hTmax_2t0_5->Fill(tmax124); break;
-	}
-      }
-      else if(t0_124==3) {
-	hTmax_3t0->Fill(tmax124); 
-	switch(hSubGroup) {
-	case 0: hTmax_3t0_0->Fill(tmax124); break;
-	case 1: hTmax_3t0_1->Fill(tmax124); break;
-	case 2: hTmax_3t0_2->Fill(tmax124); break;
-	case 3: hTmax_3t0_3->Fill(tmax124); break;
-	case 4: hTmax_3t0_4->Fill(tmax124); break;
-	case 99: hTmax_3t0_5->Fill(tmax124);break;
-	}      
+      if (t0_123 == 1) {
+        hTmax_t0->Fill(tmax123);
+        switch (hSubGroup) {
+          case 0:
+            hTmax_t0_0->Fill(tmax123);
+            break;
+          case 1:
+            hTmax_t0_1->Fill(tmax123);
+            break;
+          case 2:
+            hTmax_t0_2->Fill(tmax123);
+            break;
+          case 3:
+            hTmax_t0_3->Fill(tmax123);
+            break;
+          case 4:
+            hTmax_t0_4->Fill(tmax123);
+            break;
+          case 99:
+            hTmax_t0_5->Fill(tmax123);
+            break;
+        }
+      } else {
+        hTmax_2t0->Fill(tmax123);
+        switch (hSubGroup) {
+          case 0:
+            hTmax_2t0_0->Fill(tmax123);
+            break;
+          case 1:
+            hTmax_2t0_1->Fill(tmax123);
+            break;
+          case 2:
+            hTmax_2t0_2->Fill(tmax123);
+            break;
+          case 3:
+            hTmax_2t0_3->Fill(tmax123);
+            break;
+          case 4:
+            hTmax_2t0_4->Fill(tmax123);
+            break;
+          case 99:
+            hTmax_2t0_5->Fill(tmax123);
+            break;
+        }
       }
     }
-    if(tmax134 > 0.) {
-      (s134==dttmaxenums::r72)? hTmax134s72->Fill(tmax134):hTmax134s78->Fill(tmax134);
-      if(t0_134==0)  
-	hTmax_0->Fill(tmax134);
-      else if(t0_134==1) {
-	hTmax_t0->Fill(tmax134); 
-	switch(hSubGroup) {
-	case 0: hTmax_t0_0->Fill(tmax134); break;
-	case 1: hTmax_t0_1->Fill(tmax134); break;
-	case 2: hTmax_t0_2->Fill(tmax134); break;
-	case 3: hTmax_t0_3->Fill(tmax134); break;
-	case 4: hTmax_t0_4->Fill(tmax134); break;
-	case 99: hTmax_t0_5->Fill(tmax134); break;
-	}
-      }
-      else if(t0_134== 2) {
-	hTmax_2t0->Fill(tmax134);
-	switch(hSubGroup) {
-	case 0: hTmax_2t0_0->Fill(tmax134); break;
-	case 1: hTmax_2t0_1->Fill(tmax134); break;
-	case 2: hTmax_2t0_2->Fill(tmax134); break;
-	case 3: hTmax_2t0_3->Fill(tmax134); break;
-	case 4: hTmax_2t0_4->Fill(tmax134); break;
-	case 99: hTmax_2t0_5->Fill(tmax134); break;
-	}
-      }
-      else if(t0_134==3) {
-	hTmax_3t0->Fill(tmax134); 
-	switch(hSubGroup) {
-	case 0: hTmax_3t0_0->Fill(tmax134); break;
-	case 1: hTmax_3t0_1->Fill(tmax134); break;
-	case 2: hTmax_3t0_2->Fill(tmax134); break;
-	case 3: hTmax_3t0_3->Fill(tmax134); break;
-	case 4: hTmax_3t0_4->Fill(tmax134); break;
-	case 99: hTmax_3t0_5->Fill(tmax134); break;
-	}      
+    if (tmax124 > 0.) {
+      (s124 == dttmaxenums::r72) ? hTmax124s72->Fill(tmax124) : hTmax124s78->Fill(tmax124);
+      if (t0_124 == 0)
+        hTmax_0->Fill(tmax124);
+      else if (t0_124 == 1) {
+        hTmax_t0->Fill(tmax124);
+        switch (hSubGroup) {
+          case 0:
+            hTmax_t0_0->Fill(tmax124);
+            break;
+          case 1:
+            hTmax_t0_1->Fill(tmax124);
+            break;
+          case 2:
+            hTmax_t0_2->Fill(tmax124);
+            break;
+          case 3:
+            hTmax_t0_3->Fill(tmax124);
+            break;
+          case 4:
+            hTmax_t0_4->Fill(tmax124);
+            break;
+          case 99:
+            hTmax_t0_5->Fill(tmax124);
+            break;
+        }
+      } else if (t0_124 == 2) {
+        hTmax_2t0->Fill(tmax124);
+        switch (hSubGroup) {
+          case 0:
+            hTmax_2t0_0->Fill(tmax124);
+            break;
+          case 1:
+            hTmax_2t0_1->Fill(tmax124);
+            break;
+          case 2:
+            hTmax_2t0_2->Fill(tmax124);
+            break;
+          case 3:
+            hTmax_2t0_3->Fill(tmax124);
+            break;
+          case 4:
+            hTmax_2t0_4->Fill(tmax124);
+            break;
+          case 99:
+            hTmax_2t0_5->Fill(tmax124);
+            break;
+        }
+      } else if (t0_124 == 3) {
+        hTmax_3t0->Fill(tmax124);
+        switch (hSubGroup) {
+          case 0:
+            hTmax_3t0_0->Fill(tmax124);
+            break;
+          case 1:
+            hTmax_3t0_1->Fill(tmax124);
+            break;
+          case 2:
+            hTmax_3t0_2->Fill(tmax124);
+            break;
+          case 3:
+            hTmax_3t0_3->Fill(tmax124);
+            break;
+          case 4:
+            hTmax_3t0_4->Fill(tmax124);
+            break;
+          case 99:
+            hTmax_3t0_5->Fill(tmax124);
+            break;
+        }
       }
     }
-    if(tmax234 > 0.) {
+    if (tmax134 > 0.) {
+      (s134 == dttmaxenums::r72) ? hTmax134s72->Fill(tmax134) : hTmax134s78->Fill(tmax134);
+      if (t0_134 == 0)
+        hTmax_0->Fill(tmax134);
+      else if (t0_134 == 1) {
+        hTmax_t0->Fill(tmax134);
+        switch (hSubGroup) {
+          case 0:
+            hTmax_t0_0->Fill(tmax134);
+            break;
+          case 1:
+            hTmax_t0_1->Fill(tmax134);
+            break;
+          case 2:
+            hTmax_t0_2->Fill(tmax134);
+            break;
+          case 3:
+            hTmax_t0_3->Fill(tmax134);
+            break;
+          case 4:
+            hTmax_t0_4->Fill(tmax134);
+            break;
+          case 99:
+            hTmax_t0_5->Fill(tmax134);
+            break;
+        }
+      } else if (t0_134 == 2) {
+        hTmax_2t0->Fill(tmax134);
+        switch (hSubGroup) {
+          case 0:
+            hTmax_2t0_0->Fill(tmax134);
+            break;
+          case 1:
+            hTmax_2t0_1->Fill(tmax134);
+            break;
+          case 2:
+            hTmax_2t0_2->Fill(tmax134);
+            break;
+          case 3:
+            hTmax_2t0_3->Fill(tmax134);
+            break;
+          case 4:
+            hTmax_2t0_4->Fill(tmax134);
+            break;
+          case 99:
+            hTmax_2t0_5->Fill(tmax134);
+            break;
+        }
+      } else if (t0_134 == 3) {
+        hTmax_3t0->Fill(tmax134);
+        switch (hSubGroup) {
+          case 0:
+            hTmax_3t0_0->Fill(tmax134);
+            break;
+          case 1:
+            hTmax_3t0_1->Fill(tmax134);
+            break;
+          case 2:
+            hTmax_3t0_2->Fill(tmax134);
+            break;
+          case 3:
+            hTmax_3t0_3->Fill(tmax134);
+            break;
+          case 4:
+            hTmax_3t0_4->Fill(tmax134);
+            break;
+          case 99:
+            hTmax_3t0_5->Fill(tmax134);
+            break;
+        }
+      }
+    }
+    if (tmax234 > 0.) {
       hTmax234->Fill(tmax234);
-      if(t0_234==1) {
-	hTmax_t0->Fill(tmax234);
-	switch(hSubGroup) {
-	case 0: hTmax_t0_0->Fill(tmax234); break;
-	case 1: hTmax_t0_1->Fill(tmax234); break;
-	case 2: hTmax_t0_2->Fill(tmax234); break;
-	case 3: hTmax_t0_3->Fill(tmax234); break;
-	case 4: hTmax_t0_4->Fill(tmax234); break;
-	case 99: hTmax_t0_5->Fill(tmax234);break;
-	}
+      if (t0_234 == 1) {
+        hTmax_t0->Fill(tmax234);
+        switch (hSubGroup) {
+          case 0:
+            hTmax_t0_0->Fill(tmax234);
+            break;
+          case 1:
+            hTmax_t0_1->Fill(tmax234);
+            break;
+          case 2:
+            hTmax_t0_2->Fill(tmax234);
+            break;
+          case 3:
+            hTmax_t0_3->Fill(tmax234);
+            break;
+          case 4:
+            hTmax_t0_4->Fill(tmax234);
+            break;
+          case 99:
+            hTmax_t0_5->Fill(tmax234);
+            break;
+        }
+      } else {
+        hTmax_2t0->Fill(tmax234);
+        switch (hSubGroup) {
+          case 0:
+            hTmax_2t0_0->Fill(tmax234);
+            break;
+          case 1:
+            hTmax_2t0_1->Fill(tmax234);
+            break;
+          case 2:
+            hTmax_2t0_2->Fill(tmax234);
+            break;
+          case 3:
+            hTmax_2t0_3->Fill(tmax234);
+            break;
+          case 4:
+            hTmax_2t0_4->Fill(tmax234);
+            break;
+          case 99:
+            hTmax_2t0_5->Fill(tmax234);
+            break;
+        }
       }
-      else {
-	hTmax_2t0->Fill(tmax234);
-	switch(hSubGroup) {
-	case 0: hTmax_2t0_0->Fill(tmax234); break;
-	case 1: hTmax_2t0_1->Fill(tmax234); break;
-	case 2: hTmax_2t0_2->Fill(tmax234); break;
-	case 3: hTmax_2t0_3->Fill(tmax234); break;
-	case 4: hTmax_2t0_4->Fill(tmax234); break;
-	case 99: hTmax_2t0_5->Fill(tmax234); break;
-	}
-      }
-    }      
+    }
   }
 
-  void Write() { 
-    // write the Tmax histograms 
+  void Write() {
+    // write the Tmax histograms
     hTmax123->Write();
     hTmax124s72->Write();
     hTmax124s78->Write();
     hTmax134s72->Write();
     hTmax134s78->Write();
-    hTmax234->Write(); 
+    hTmax234->Write();
     hTmax_3t0->Write();
     hTmax_3t0_0->Write();
     hTmax_3t0_1->Write();
@@ -385,54 +490,53 @@ class hTMaxCell{
     hTmax_t0_4->Write();
     hTmax_t0_5->Write();
     hTmax_0->Write();
-
   }
 
-  int GetT0Factor(TH1F* hist) {
+  int GetT0Factor(TH1F *hist) {
     unsigned t0 = 999;
 
     if (hist == hTmax_3t0)
       t0 = 3;
-    else if(hist == hTmax_2t0)
+    else if (hist == hTmax_2t0)
       t0 = 2;
-    else if(hist ==  hTmax_t0)
-      t0 = 1;    
+    else if (hist == hTmax_t0)
+      t0 = 1;
     else if (hist == hTmax_0)
       t0 = 0;
-       
+
     return t0;
   }
- 
-  TH1F* hTmax123;
-  TH1F* hTmax124s72;
-  TH1F* hTmax124s78;
-  TH1F* hTmax134s72;
-  TH1F* hTmax134s78;
-  TH1F* hTmax234;
-  TH1F* hTmax_3t0;
-  TH1F* hTmax_3t0_0;
-  TH1F* hTmax_3t0_1;
-  TH1F* hTmax_3t0_2;
-  TH1F* hTmax_3t0_3;
-  TH1F* hTmax_3t0_4;
-  TH1F* hTmax_3t0_5;
-  TH1F* hTmax_2t0;
-  TH1F* hTmax_2t0_0;
-  TH1F* hTmax_2t0_1;
-  TH1F* hTmax_2t0_2;
-  TH1F* hTmax_2t0_3;
-  TH1F* hTmax_2t0_4;
-  TH1F* hTmax_2t0_5;
-  TH1F* hTmax_t0;
-  TH1F* hTmax_t0_0;
-  TH1F* hTmax_t0_1;
-  TH1F* hTmax_t0_2;
-  TH1F* hTmax_t0_3;
-  TH1F* hTmax_t0_4;
-  TH1F* hTmax_t0_5;
-  TH1F* hTmax_0;
 
-  TString name;  
+  TH1F *hTmax123;
+  TH1F *hTmax124s72;
+  TH1F *hTmax124s78;
+  TH1F *hTmax134s72;
+  TH1F *hTmax134s78;
+  TH1F *hTmax234;
+  TH1F *hTmax_3t0;
+  TH1F *hTmax_3t0_0;
+  TH1F *hTmax_3t0_1;
+  TH1F *hTmax_3t0_2;
+  TH1F *hTmax_3t0_3;
+  TH1F *hTmax_3t0_4;
+  TH1F *hTmax_3t0_5;
+  TH1F *hTmax_2t0;
+  TH1F *hTmax_2t0_0;
+  TH1F *hTmax_2t0_1;
+  TH1F *hTmax_2t0_2;
+  TH1F *hTmax_2t0_3;
+  TH1F *hTmax_2t0_4;
+  TH1F *hTmax_2t0_5;
+  TH1F *hTmax_t0;
+  TH1F *hTmax_t0_0;
+  TH1F *hTmax_t0_1;
+  TH1F *hTmax_t0_2;
+  TH1F *hTmax_t0_3;
+  TH1F *hTmax_t0_4;
+  TH1F *hTmax_t0_5;
+  TH1F *hTmax_0;
+
+  TString name;
 };
 
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTCalibrationMap.cc
+++ b/CalibMuon/DTCalibration/plugins/DTCalibrationMap.cc
@@ -21,83 +21,57 @@ using namespace std;
 using namespace edm;
 
 DTCalibrationMap::DTCalibrationMap(const ParameterSet& pset) {
-  nFields =  pset.getUntrackedParameter<int>("nFields", 5);
+  nFields = pset.getUntrackedParameter<int>("nFields", 5);
   calibConstFileName = pset.getUntrackedParameter<string>("calibConstFileName", "dummy.txt");
-  calibConstGranularity = pset.getUntrackedParameter<string>("calibConstGranularity","bySL");
+  calibConstGranularity = pset.getUntrackedParameter<string>("calibConstGranularity", "bySL");
 
   // Initialize correctly the enum which specify the granularity for the calibration
-  if(calibConstGranularity == "byWire") {
+  if (calibConstGranularity == "byWire") {
     theGranularity = byWire;
-  } else if(calibConstGranularity == "byLayer"){
+  } else if (calibConstGranularity == "byLayer") {
     theGranularity = byLayer;
-  } else if(calibConstGranularity == "bySL") {
+  } else if (calibConstGranularity == "bySL") {
     theGranularity = bySL;
   } else {
     theGranularity = byChamber;
-    if(!(calibConstGranularity == "byChamber")) {
-      cout << "[DTCalibrationMap]###Warning: Check parameter calibConstGranularity: "
-	   << calibConstGranularity << " options not available!" << endl;
+    if (!(calibConstGranularity == "byChamber")) {
+      cout << "[DTCalibrationMap]###Warning: Check parameter calibConstGranularity: " << calibConstGranularity
+           << " options not available!" << endl;
     }
   }
   readConsts(calibConstFileName);
 }
 
-
-
-DTCalibrationMap::~DTCalibrationMap(){}
-
-
+DTCalibrationMap::~DTCalibrationMap() {}
 
 // Return the t_trig (ns) for a particular wire
-float DTCalibrationMap::tTrig(DTWireId wireId) const {
- return getField(wireId, 0);
-}
-
-
+float DTCalibrationMap::tTrig(DTWireId wireId) const { return getField(wireId, 0); }
 
 // Return the sigma of the t_trig (ns) for a particular wire
-float DTCalibrationMap::sigma_tTrig(DTWireId wireId) const {
- return getField(wireId, 1);
-}
-
-
+float DTCalibrationMap::sigma_tTrig(DTWireId wireId) const { return getField(wireId, 1); }
 
 // Return the kfactor for a particular wire
-float DTCalibrationMap::kFactor(DTWireId wireId) const {
-  return getField(wireId, 2);
-}
-
- 
+float DTCalibrationMap::kFactor(DTWireId wireId) const { return getField(wireId, 2); }
 
 // Return the mean drift velocity for a particular wire (cm/ns)
-float DTCalibrationMap::meanVDrift(DTWireId wireId) const {
- return getField(wireId, 3);
-}
-
-
+float DTCalibrationMap::meanVDrift(DTWireId wireId) const { return getField(wireId, 3); }
 
 // Return the sigma of the mean drift velocity for a particular wire (cm/ns)
-float DTCalibrationMap::sigma_meanVDrift(DTWireId wireId) const {
- return getField(wireId, 4);
-}
-
-
+float DTCalibrationMap::sigma_meanVDrift(DTWireId wireId) const { return getField(wireId, 4); }
 
 // Get a key to read calibration constants for a particular wire
 // with the given granularity
 DTCalibrationMap::Key DTCalibrationMap::getKey(DTWireId wireId) const {
-  if (theGranularity == byChamber){
+  if (theGranularity == byChamber) {
     return Key(wireId.chamberId(), 0, 0, 0);
   } else if (theGranularity == bySL) {
-    return Key(wireId.superlayerId(), 0, 0); 
+    return Key(wireId.superlayerId(), 0, 0);
   } else if (theGranularity == byLayer) {
-    return Key(wireId.layerId(), 0);  
+    return Key(wireId.layerId(), 0);
   } else {
     return Key(wireId);
   }
 }
-
-
 
 // Get from the map the calibration constants for a particular key
 const DTCalibrationMap::CalibConsts* DTCalibrationMap::getConsts(DTWireId wireId) const {
@@ -108,7 +82,7 @@ const DTCalibrationMap::CalibConsts* DTCalibrationMap::getConsts(DTWireId wireId
   Key theKey = getKey(wireId);
 
   // Check if the result is already cached
-  if ( theKey == cache.first ) {
+  if (theKey == cache.first) {
     return &(cache.second);
   }
 
@@ -121,8 +95,6 @@ const DTCalibrationMap::CalibConsts* DTCalibrationMap::getConsts(DTWireId wireId
     return nullptr;
   }
 }
-  
-
 
 // Get a particular number (field) between all the calibration
 // constants available for a particluar wire
@@ -130,24 +102,20 @@ float DTCalibrationMap::getField(DTWireId wireId, int field) const {
   const CalibConsts* cals = getConsts(wireId);
   if (cals == nullptr) {
     throw cms::Exception("NoCalibConsts") << "DTCalibrationMap:" << endl
-						<< "No parameters for wire: " << wireId << endl
-						<< "Check the " << calibConstFileName << " file!" << endl;
+                                          << "No parameters for wire: " << wireId << endl
+                                          << "Check the " << calibConstFileName << " file!" << endl;
   } else {
     return (*(cals))[field];
   }
 }
 
-
-
-
-// Read the calibration consts from a file 
+// Read the calibration consts from a file
 void DTCalibrationMap::readConsts(const string& inputFileName) {
-   ifstream file(inputFileName.c_str());
-   // Check if the file exists
-   if(!file) {
-    cout << "[DTCalibrationMap]***Warning: File: " << inputFileName 
-	 << " not found in current directory!!!" << endl; 
-   }
+  ifstream file(inputFileName.c_str());
+  // Check if the file exists
+  if (!file) {
+    cout << "[DTCalibrationMap]***Warning: File: " << inputFileName << " not found in current directory!!!" << endl;
+  }
 
   string line;
 
@@ -160,95 +128,75 @@ void DTCalibrationMap::readConsts(const string& inputFileName) {
   int wire_id = 0;
 
   // Read all the lines
-  while (getline(file,line)) {
-    if( line.empty() || line[0] == '#' ) continue; // Skip comments and empty lines
+  while (getline(file, line)) {
+    if (line.empty() || line[0] == '#')
+      continue;  // Skip comments and empty lines
     stringstream linestr;
     linestr << line;
 
     pair<Key, CalibConsts> wireCalib;
 
-    linestr >> wheel_id
-	    >> station_id
-	    >> sector_id
-	    >> superlayer_id
-	    >> layer_id
-	    >> wire_id;
-    
+    linestr >> wheel_id >> station_id >> sector_id >> superlayer_id >> layer_id >> wire_id;
+
     // Build the key
-    wireCalib.first =  Key( wheel_id, 
-			    station_id, 
-			    sector_id, 
-			    superlayer_id, 
-			    layer_id, 
-			    wire_id);
+    wireCalib.first = Key(wheel_id, station_id, sector_id, superlayer_id, layer_id, wire_id);
 
-    if(!checkGranularity(wireCalib.first))
-       cout << "[DTCalibrationMap]***Warning: the CalibConstFile is not consistent with the selected granularity!" << endl;
-
+    if (!checkGranularity(wireCalib.first))
+      cout << "[DTCalibrationMap]***Warning: the CalibConstFile is not consistent with the selected granularity!"
+           << endl;
 
     // Read the calibration constants
-    copy(istream_iterator<float>(linestr),
-	 istream_iterator<float>(),
-	 back_inserter(wireCalib.second));
-    
-    if(wireCalib.second.size() <  nFields){
+    copy(istream_iterator<float>(linestr), istream_iterator<float>(), back_inserter(wireCalib.second));
+
+    if (wireCalib.second.size() < nFields) {
       cout << "[DTCalibrationMap]***Warning: the CalibConstFile is not consistent with the number of fields!" << endl;
     }
-    
+
     theMap.insert(wireCalib);
   }
 }
 
-// Add to the map the calibration consts for a given key 
+// Add to the map the calibration consts for a given key
 void DTCalibrationMap::addCell(Key theKey, const CalibConsts& calibConst) {
-  if(!checkGranularity(theKey))
+  if (!checkGranularity(theKey))
     throw cms::Exception("addCell") << "DTCalibrationMap:" << endl
-				    << "The added key is not compatible with the selected granularity"
-				    << endl;
+                                    << "The added key is not compatible with the selected granularity" << endl;
 
   theMap[theKey] = calibConst;
 }
 
-// Write the calibration consts to a file 
+// Write the calibration consts to a file
 void DTCalibrationMap::writeConsts(const string& outputFileName) const {
   ofstream out(outputFileName.c_str());
-  for(map<Key,CalibConsts>::const_iterator iter = theMap.begin();
-      iter != theMap.end() ; ++iter) {
-    
-    out << (*iter).first.wheel() << ' '
-      << (*iter).first.station() << ' '
-      << (*iter).first.sector() << ' '
-      << (*iter).first.superlayer() << ' '
-      << (*iter).first.layer() << ' '
-      << (*iter).first.wire() << ' ';
-    copy((*iter).second.begin(), (*iter).second.end(),
-	 ostream_iterator<float>(out, " "));
+  for (map<Key, CalibConsts>::const_iterator iter = theMap.begin(); iter != theMap.end(); ++iter) {
+    out << (*iter).first.wheel() << ' ' << (*iter).first.station() << ' ' << (*iter).first.sector() << ' '
+        << (*iter).first.superlayer() << ' ' << (*iter).first.layer() << ' ' << (*iter).first.wire() << ' ';
+    copy((*iter).second.begin(), (*iter).second.end(), ostream_iterator<float>(out, " "));
     out << endl;
   }
 }
 
-
-  // Check the consistency of a given key with the selected granularity
+// Check the consistency of a given key with the selected granularity
 bool DTCalibrationMap::checkGranularity(Key aKey) const {
   bool ret = true;
 
   // Check that the key is consistent with the given granularity
-  if(theGranularity == byChamber) {
-    if(aKey.superlayer() || aKey.layer() || aKey.wire()) {
+  if (theGranularity == byChamber) {
+    if (aKey.superlayer() || aKey.layer() || aKey.wire()) {
       ret = false;
     }
-  } else if(theGranularity == bySL) {
-    if(aKey.layer() || aKey.wire()) {
+  } else if (theGranularity == bySL) {
+    if (aKey.layer() || aKey.wire()) {
       ret = false;
     }
-  } else if(theGranularity == byLayer) {
-    if(aKey.wire()) {
+  } else if (theGranularity == byLayer) {
+    if (aKey.wire()) {
       ret = false;
     }
-  } else if(theGranularity == byWire) {
-    if(aKey.wire() == 0) {
+  } else if (theGranularity == byWire) {
+    if (aKey.wire() == 0) {
       ret = false;
     }
-  } 
+  }
   return ret;
 }

--- a/CalibMuon/DTCalibration/plugins/DTCalibrationMap.cc
+++ b/CalibMuon/DTCalibration/plugins/DTCalibrationMap.cc
@@ -161,7 +161,7 @@ void DTCalibrationMap::readConsts(const string& inputFileName) {
 
   // Read all the lines
   while (getline(file,line)) {
-    if( line == "" || line[0] == '#' ) continue; // Skip comments and empty lines
+    if( line.empty() || line[0] == '#' ) continue; // Skip comments and empty lines
     stringstream linestr;
     linestr << line;
 

--- a/CalibMuon/DTCalibration/plugins/DTCalibrationMap.h
+++ b/CalibMuon/DTCalibration/plugins/DTCalibrationMap.h
@@ -26,12 +26,9 @@
 
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 
-
 #include <string>
 #include <map>
 #include <vector>
-
-
 
 namespace edm {
   class ParameterSet;
@@ -46,7 +43,7 @@ public:
   virtual ~DTCalibrationMap();
 
   // Operations
-  
+
   /// Return the t_trig (ns) for a particular wire
   float tTrig(DTWireId wireId) const;
 
@@ -67,9 +64,7 @@ public:
   typedef std::map<Key, CalibConsts>::const_iterator const_iterator;
 
   // Clean the map
-  void cleanTheConsts() {
-    theMap.clear();
-  }
+  void cleanTheConsts() { theMap.clear(); }
 
   // Get a particular number (field) between all the calibration
   // constants available for a particluar wire
@@ -78,42 +73,31 @@ public:
   // Get from the map the calibration constants for a particular wire
   const CalibConsts* getConsts(DTWireId wireId) const;
 
-
-  // Add to the map the calibration consts for a given key 
+  // Add to the map the calibration consts for a given key
   void addCell(Key wireId, const CalibConsts& calibConst);
-  
-  // Write the calibration consts to a file 
+
+  // Write the calibration consts to a file
   void writeConsts(const std::string& outputFileName) const;
 
   // Get a key to read calibration constants for a particular wire
   // with the given granularity
   Key getKey(DTWireId wireId) const;
 
-  const_iterator keyAndConsts_begin() const {
-    return theMap.begin();
-  }
+  const_iterator keyAndConsts_begin() const { return theMap.begin(); }
 
-  const_iterator keyAndConsts_end() const {
-    return theMap.end();
-  }
-
+  const_iterator keyAndConsts_end() const { return theMap.end(); }
 
 protected:
-
 private:
-
   // Specify the granularity for the calibration constants
-  enum CalibGranularity {byChamber,bySL,byLayer,byWire};
+  enum CalibGranularity { byChamber, bySL, byLayer, byWire };
   CalibGranularity theGranularity;
 
-
-  // Read the calibration consts from a file 
+  // Read the calibration consts from a file
   void readConsts(const std::string& inputFileName);
-
 
   // Check the consistency of a given key with the selected granularity
   bool checkGranularity(Key aKey) const;
-
 
   // The number of fields (calibration numbers) to be read from file
   unsigned int nFields;
@@ -126,8 +110,6 @@ private:
 
   // The map between the Key and the calibration constants
   std::map<Key, CalibConsts> theMap;
-  
 };
 
 #endif
-

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
@@ -25,46 +25,40 @@
 
 using namespace std;
 
-DTFakeT0ESProducer::DTFakeT0ESProducer(const edm::ParameterSet& pset)
-{
+DTFakeT0ESProducer::DTFakeT0ESProducer(const edm::ParameterSet& pset) {
   //framework
-  setWhatProduced(this,&DTFakeT0ESProducer::produce);
+  setWhatProduced(this, &DTFakeT0ESProducer::produce);
   //  setWhatProduced(this,dependsOn(& DTGeometryESModule::parseDDD()));
   findingRecord<DTT0Rcd>();
-  
+
   //read constant value for t0 from cfg
   t0Mean = pset.getParameter<double>("t0Mean");
   t0Sigma = pset.getParameter<double>("t0Sigma");
 }
 
-
-DTFakeT0ESProducer::~DTFakeT0ESProducer(){
-}
-
+DTFakeT0ESProducer::~DTFakeT0ESProducer() {}
 
 // ------------ method called to produce the data  ------------
-std::unique_ptr<DTT0> DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord){
-  
+std::unique_ptr<DTT0> DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord) {
   parseDDD(iRecord);
   auto t0Map = std::make_unique<DTT0>();
-  
+
   //Loop on layerId-nwires map
- for(map<DTLayerId, pair <unsigned int,unsigned int> >::const_iterator lIdWire = theLayerIdWiresMap.begin();
-     lIdWire != theLayerIdWiresMap.end();
-     ++lIdWire){
-   int firstWire = ((*lIdWire).second).first;
-   int nWires = ((*lIdWire).second).second;
-   //Loop on wires of each layer
-   for(int wire=0; wire < nWires; wire++){
-     t0Map->set(DTWireId((*lIdWire).first, wire + firstWire), t0Mean, t0Sigma, DTTimeUnits::counts);
-   }
- }
+  for (map<DTLayerId, pair<unsigned int, unsigned int> >::const_iterator lIdWire = theLayerIdWiresMap.begin();
+       lIdWire != theLayerIdWiresMap.end();
+       ++lIdWire) {
+    int firstWire = ((*lIdWire).second).first;
+    int nWires = ((*lIdWire).second).second;
+    //Loop on wires of each layer
+    for (int wire = 0; wire < nWires; wire++) {
+      t0Map->set(DTWireId((*lIdWire).first, wire + firstWire), t0Mean, t0Sigma, DTTimeUnits::counts);
+    }
+  }
 
   return t0Map;
 }
 
-void DTFakeT0ESProducer::parseDDD(const DTT0Rcd& iRecord){
-
+void DTFakeT0ESProducer::parseDDD(const DTT0Rcd& iRecord) {
   edm::ESTransientHandle<DDCompactView> cpv;
   edm::ESHandle<MuonDDDConstants> mdc;
 
@@ -74,9 +68,8 @@ void DTFakeT0ESProducer::parseDDD(const DTT0Rcd& iRecord){
   DTGeometryParserFromDDD parser(&(*cpv), *mdc, theLayerIdWiresMap);
 }
 
- void DTFakeT0ESProducer::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&,
- edm::ValidityInterval & oValidity){
-   oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),edm::IOVSyncValue::endOfTime());
-  }
-
-
+void DTFakeT0ESProducer::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                        const edm::IOVSyncValue&,
+                                        edm::ValidityInterval& oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
+}

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
@@ -28,10 +28,8 @@ class DTT0;
 class DTT0Rcd;
 class DTLayerId;
 
-class DTFakeT0ESProducer : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-
+class DTFakeT0ESProducer : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
-
   DTFakeT0ESProducer(const edm::ParameterSet& pset);
 
   ~DTFakeT0ESProducer() override;
@@ -39,13 +37,13 @@ public:
   std::unique_ptr<DTT0> produce(const DTT0Rcd& iRecord);
 
 private:
-
   void parseDDD(const DTT0Rcd& iRecord);
 
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&,
-		      edm::ValidityInterval & oValidity) override;
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                      const edm::IOVSyncValue&,
+                      edm::ValidityInterval& oValidity) override;
 
-  std::map<DTLayerId,std::pair<unsigned int,unsigned int> > theLayerIdWiresMap;
+  std::map<DTLayerId, std::pair<unsigned int, unsigned int> > theLayerIdWiresMap;
 
   //t0 mean and sigma values read from cfg
   double t0Mean;

--- a/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
+++ b/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
@@ -8,79 +8,77 @@
 
 using namespace std;
 
-
-DTGeometryParserFromDDD::DTGeometryParserFromDDD(const DDCompactView* cview, const MuonDDDConstants& muonConstants, map<DTLayerId,std::pair<unsigned int,unsigned int> > &theLayerIdWiresMap ){
-
+DTGeometryParserFromDDD::DTGeometryParserFromDDD(
+    const DDCompactView* cview,
+    const MuonDDDConstants& muonConstants,
+    map<DTLayerId, std::pair<unsigned int, unsigned int> >& theLayerIdWiresMap) {
   try {
-    std::string attribute = "MuStructure"; 
-    std::string value     = "MuonBarrelDT";
+    std::string attribute = "MuStructure";
+    std::string value = "MuonBarrelDT";
 
     // Asking only for the Muon DTs
     DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
-    DDFilteredView fview(*cview,filter);
+    DDFilteredView fview(*cview, filter);
 
     parseGeometry(fview, muonConstants, theLayerIdWiresMap);
-  }
-  catch (const cms::Exception & e ) {
-    std::cerr << "DTGeometryParserFromDDD::build() : DDD Exception: something went wrong during XML parsing!" << std::endl
-	      << "  Message: " << e << std::endl
-	      << "  Terminating execution ... " << std::endl;
+  } catch (const cms::Exception& e) {
+    std::cerr << "DTGeometryParserFromDDD::build() : DDD Exception: something went wrong during XML parsing!"
+              << std::endl
+              << "  Message: " << e << std::endl
+              << "  Terminating execution ... " << std::endl;
     throw;
-  }
-  catch (const exception & e) {
-    std::cerr << "DTGeometryParserFromDDD::build() : an unexpected exception occured: " << e.what() << std::endl; 
+  } catch (const exception& e) {
+    std::cerr << "DTGeometryParserFromDDD::build() : an unexpected exception occured: " << e.what() << std::endl;
     throw;
-  }
-  catch (...) {
+  } catch (...) {
     std::cerr << "DTGeometryParserFromDDD::build() : An unexpected exception occured!" << std::endl
-	      << "  Terminating execution ... " << std::endl;
-    std::unexpected();           
+              << "  Terminating execution ... " << std::endl;
+    std::unexpected();
   }
 }
 
-DTGeometryParserFromDDD::~DTGeometryParserFromDDD(){
-}
- 
-void DTGeometryParserFromDDD::parseGeometry(DDFilteredView& fv, const MuonDDDConstants& muonConstants, map<DTLayerId,std::pair<unsigned int,unsigned int> > &theLayerIdWiresMap ) {
+DTGeometryParserFromDDD::~DTGeometryParserFromDDD() {}
 
+void DTGeometryParserFromDDD::parseGeometry(DDFilteredView& fv,
+                                            const MuonDDDConstants& muonConstants,
+                                            map<DTLayerId, std::pair<unsigned int, unsigned int> >& theLayerIdWiresMap) {
   bool doChamber = fv.firstChild();
 
   // Loop on chambers
-  int ChamCounter=0;
-  while (doChamber){
+  int ChamCounter = 0;
+  while (doChamber) {
     ChamCounter++;
-  
+
     // Loop on SLs
     bool doSL = fv.firstChild();
-    int SLCounter=0;
+    int SLCounter = 0;
     while (doSL) {
       SLCounter++;
-    
+
       bool doL = fv.firstChild();
-      int LCounter=0;
+      int LCounter = 0;
       // Loop on SLs
       while (doL) {
         LCounter++;
-        //DTLayer* layer = 
-	buildLayer(fv, muonConstants, theLayerIdWiresMap);
+        //DTLayer* layer =
+        buildLayer(fv, muonConstants, theLayerIdWiresMap);
 
         fv.parent();
-        doL = fv.nextSibling(); // go to next layer
-      } // layers
+        doL = fv.nextSibling();  // go to next layer
+      }                          // layers
 
       fv.parent();
-      doSL = fv.nextSibling(); // go to next SL
-    } // sls
+      doSL = fv.nextSibling();  // go to next SL
+    }                           // sls
 
     fv.parent();
-    doChamber = fv.nextSibling(); // go to next chamber
-  } // chambers
-
+    doChamber = fv.nextSibling();  // go to next chamber
+  }                                // chambers
 }
 
-
-void DTGeometryParserFromDDD::buildLayer(DDFilteredView& fv, const MuonDDDConstants& muonConstants, 
-					 map<DTLayerId,std::pair<unsigned int,unsigned int> > &theLayerIdWiresMap ) {
+void DTGeometryParserFromDDD::buildLayer(DDFilteredView& fv,
+                                         const MuonDDDConstants& muonConstants,
+                                         map<DTLayerId, std::pair<unsigned int, unsigned int> >& theLayerIdWiresMap) {
   MuonDDDNumbering mdddnum(muonConstants);
   DTNumberingScheme dtnum(muonConstants);
   int rawid = dtnum.getDetId(mdddnum.geoHistoryToBaseNumber(fv.geoHistory()));
@@ -88,12 +86,11 @@ void DTGeometryParserFromDDD::buildLayer(DDFilteredView& fv, const MuonDDDConsta
 
   // Loop on wires
   bool doWire = fv.firstChild();
-  int WCounter=0;
-  int firstWire=fv.copyno();
+  int WCounter = 0;
+  int firstWire = fv.copyno();
   while (doWire) {
     WCounter++;
-    doWire = fv.nextSibling(); // next wire
+    doWire = fv.nextSibling();  // next wire
   }
-  theLayerIdWiresMap[layId] = (make_pair(firstWire,WCounter));
+  theLayerIdWiresMap[layId] = (make_pair(firstWire, WCounter));
 }
-

--- a/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.h
+++ b/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.h
@@ -18,25 +18,25 @@
 
 class DTLayerId;
 
-class  DTGeometryParserFromDDD {
-
+class DTGeometryParserFromDDD {
 public:
-  
- /// Constructor
-  DTGeometryParserFromDDD(const DDCompactView* cview, const MuonDDDConstants& muonConstants,
-			  std::map<DTLayerId,std::pair<unsigned int,unsigned int> > &theLayerIdWiresMap);
+  /// Constructor
+  DTGeometryParserFromDDD(const DDCompactView* cview,
+                          const MuonDDDConstants& muonConstants,
+                          std::map<DTLayerId, std::pair<unsigned int, unsigned int> >& theLayerIdWiresMap);
 
-  /// Destructor 
+  /// Destructor
   ~DTGeometryParserFromDDD();
 
 protected:
-
 private:
   //Parse the DDD
-  void parseGeometry(DDFilteredView& fv, const MuonDDDConstants& muonConstants,
-		     std::map<DTLayerId,std::pair<unsigned int,unsigned int> >  &theLayerIdWiresMap );
+  void parseGeometry(DDFilteredView& fv,
+                     const MuonDDDConstants& muonConstants,
+                     std::map<DTLayerId, std::pair<unsigned int, unsigned int> >& theLayerIdWiresMap);
   //Fill the map
-  void buildLayer(DDFilteredView& fv, const MuonDDDConstants& muonConstants,
-		  std::map<DTLayerId,std::pair<unsigned int,unsigned int> > &theLayerIdWiresMap );
-  };
+  void buildLayer(DDFilteredView& fv,
+                  const MuonDDDConstants& muonConstants,
+                  std::map<DTLayerId, std::pair<unsigned int, unsigned int> >& theLayerIdWiresMap);
+};
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTMapGenerator.cc
+++ b/CalibMuon/DTCalibration/plugins/DTMapGenerator.cc
@@ -42,7 +42,7 @@ void DTMapGenerator::endJob() {
   // Read the map between DDU - ROS and Chambers
   string lineMap;
   while (getline(existingChannels,lineMap)) {
-    if( lineMap == "" || lineMap[0] == '#' ) continue; // Skip comments and empty lines
+    if( lineMap.empty() || lineMap[0] == '#' ) continue; // Skip comments and empty lines
     stringstream linestr;
     linestr << lineMap;
     int wheelEx, stationEx, sectorEx, slEx, layerEx, wireEx;
@@ -61,7 +61,7 @@ void DTMapGenerator::endJob() {
   // Read the map between DDU - ROS and Chambers
   string line;
   while (getline(skeletonMap,line)) {
-    if( line == "" || line[0] == '#' ) continue; // Skip comments and empty lines
+    if( line.empty() || line[0] == '#' ) continue; // Skip comments and empty lines
     stringstream linestr;
     linestr << line;
     int ddu, ros, wheel, station, sector;
@@ -81,7 +81,7 @@ void DTMapGenerator::endJob() {
 
     string lineChamberMap;
     while (getline(chamberMap,lineChamberMap)) {
-      if( lineChamberMap == "" || lineChamberMap[0] == '#' ) continue; // Skip comments and empty lines
+      if( lineChamberMap.empty() || lineChamberMap[0] == '#' ) continue; // Skip comments and empty lines
       stringstream chamberMapStr;
       chamberMapStr << lineChamberMap;
       

--- a/CalibMuon/DTCalibration/plugins/DTMapGenerator.cc
+++ b/CalibMuon/DTCalibration/plugins/DTMapGenerator.cc
@@ -17,32 +17,32 @@ using namespace std;
 
 DTMapGenerator::DTMapGenerator(const ParameterSet& pset) {
   // The output file with the map
-  outputMapName = pset.getUntrackedParameter<string>("outputFileName","output.map");
+  outputMapName = pset.getUntrackedParameter<string>("outputFileName", "output.map");
   // The input file with the base map (DDU ROS -> Wheel, Station, Sector)
-  inputMapName = pset.getUntrackedParameter<string>("inputFileName","basemap.txt");
+  inputMapName = pset.getUntrackedParameter<string>("inputFileName", "basemap.txt");
   //The ros type: ROS8 for commissioning, ROS25 otherwise
-  rosType =  pset.getUntrackedParameter<int>("rosType",25);
-  if(rosType != 8 && rosType != 25){
-    cout<<"[DTMapGenerator]: wrong ros type (8 for commissioning, 25 otherwise)"<<endl;
+  rosType = pset.getUntrackedParameter<int>("rosType", 25);
+  if (rosType != 8 && rosType != 25) {
+    cout << "[DTMapGenerator]: wrong ros type (8 for commissioning, 25 otherwise)" << endl;
     abort();
   }
 }
 
-DTMapGenerator::~DTMapGenerator(){}
+DTMapGenerator::~DTMapGenerator() {}
 
 void DTMapGenerator::endJob() {
-
   cout << "DTMapGenerator: Output Map: " << outputMapName << " ROS Type: " << rosType << endl;
 
   // Read the existing wires
   ifstream existingChannels("/afs/cern.ch/cms/Physics/muon/CMSSW/DT/channelsMaps/existing_channels.txt");
-  
-  set<DTWireId> wireMap; //FIXME:MAYBE YOU NEED THE > and == operators to use set?
+
+  set<DTWireId> wireMap;  //FIXME:MAYBE YOU NEED THE > and == operators to use set?
 
   // Read the map between DDU - ROS and Chambers
   string lineMap;
-  while (getline(existingChannels,lineMap)) {
-    if( lineMap.empty() || lineMap[0] == '#' ) continue; // Skip comments and empty lines
+  while (getline(existingChannels, lineMap)) {
+    if (lineMap.empty() || lineMap[0] == '#')
+      continue;  // Skip comments and empty lines
     stringstream linestr;
     linestr << lineMap;
     int wheelEx, stationEx, sectorEx, slEx, layerEx, wireEx;
@@ -54,136 +54,124 @@ void DTMapGenerator::endJob() {
 
   // The map between DDU - ROS and Chambers
   ifstream skeletonMap(inputMapName.c_str());
-  
+
   // The output map in the CMSSW format
   ofstream outputMap(outputMapName.c_str());
 
   // Read the map between DDU - ROS and Chambers
   string line;
-  while (getline(skeletonMap,line)) {
-    if( line.empty() || line[0] == '#' ) continue; // Skip comments and empty lines
+  while (getline(skeletonMap, line)) {
+    if (line.empty() || line[0] == '#')
+      continue;  // Skip comments and empty lines
     stringstream linestr;
     linestr << line;
     int ddu, ros, wheel, station, sector;
     linestr >> ddu >> ros >> wheel >> station >> sector;
     cout << "DDU: " << ddu << endl
-	 << "ROS: " << ros << endl
-	 << "Connected to chamber in Wh: " << wheel << " St: " << station << " Sec: " << sector << endl;
+         << "ROS: " << ros << endl
+         << "Connected to chamber in Wh: " << wheel << " St: " << station << " Sec: " << sector << endl;
 
     int previousROB = -1;
     int robCounter = -1;
-    // The chamber map in ORCA commissioning format    
+    // The chamber map in ORCA commissioning format
     string fileName;
     stringstream nameTmp;
-    nameTmp << "/afs/cern.ch/cms/Physics/muon/CMSSW/DT/channelsMaps/templates/MB" << station << "_" <<  sector << ".map";
+    nameTmp << "/afs/cern.ch/cms/Physics/muon/CMSSW/DT/channelsMaps/templates/MB" << station << "_" << sector << ".map";
     nameTmp >> fileName;
     ifstream chamberMap(fileName.c_str());
 
     string lineChamberMap;
-    while (getline(chamberMap,lineChamberMap)) {
-      if( lineChamberMap.empty() || lineChamberMap[0] == '#' ) continue; // Skip comments and empty lines
+    while (getline(chamberMap, lineChamberMap)) {
+      if (lineChamberMap.empty() || lineChamberMap[0] == '#')
+        continue;  // Skip comments and empty lines
       stringstream chamberMapStr;
       chamberMapStr << lineChamberMap;
-      
+
       int rob, tdc, tdcChannel, sl, layer, wire;
       int unusedRos, unusedChamberCode;
       int outRob = -1;
-      chamberMapStr >> unusedRos  >> rob >> tdc >> tdcChannel >> unusedChamberCode >> sl >> layer >> wire;
-      
-      // Check if the channel really exists
-      if(!checkWireExist(wireMap, wheel, station, sector, sl, layer, wire))
-	continue;
+      chamberMapStr >> unusedRos >> rob >> tdc >> tdcChannel >> unusedChamberCode >> sl >> layer >> wire;
 
-      if(rob > previousROB) {
-	previousROB = rob;
-	robCounter++;
-      } else if(rob < previousROB) {
-	cout << "Error: ROB number is not uniformly increasing!" << endl;
-	abort();
+      // Check if the channel really exists
+      if (!checkWireExist(wireMap, wheel, station, sector, sl, layer, wire))
+        continue;
+
+      if (rob > previousROB) {
+        previousROB = rob;
+        robCounter++;
+      } else if (rob < previousROB) {
+        cout << "Error: ROB number is not uniformly increasing!" << endl;
+        abort();
       }
       // Set the ROB id within the ros
-      if(rosType == 25) {
-	if(station == 1) {//MB1
-	  outRob = robCounter;
-	} else if(station == 2) {//MB2
-	  outRob = robCounter + 6;
-	} else if(station == 3) {//MB3
-	  if(robCounter < 3) 
-	    outRob = robCounter + 12;
-	  else if(robCounter == 3)
-	    outRob = 24;
-	  else if(robCounter > 3)
-	    outRob = robCounter + 11;
-	} else if(station == 4) {//MB4
-	  if(sector == 14)  {
-	    if(robCounter == 3) {
-	      continue;
-	    }
-	    outRob = robCounter + 18;
-	  } else if(sector == 10) {
-	    if(robCounter == 3) {
-	      continue;
-	    } else if(robCounter == 0) {
-	      outRob = 21;
-	    } else {
-	      outRob = robCounter + 21;
-	    }
-	  }
-	  if(sector == 4 )  {
-	    if(robCounter == 3 || robCounter == 4 ) {
-	      continue;
-	    }
-	    outRob = robCounter + 18;
-	  } else if(sector == 13) {
-	    if(robCounter == 3 || robCounter == 4) {
-	      continue;
-	    } else if(robCounter == 0) {
-	      outRob = 21;
-	    } else {
-	      outRob = robCounter + 21;
-	    }
-	  } else if(sector == 11 || sector == 9) {
-	    outRob = robCounter + 18;
-	    if(robCounter == 3) {
-	      continue;
-	    }
-	  }
-	  //else if(sector==12 || sector == 8 || sector == 7 || sector == 6 || sector == 5 ||  sector == 3 || sector == 2 ||sector == 1 ){
-	  else{
-	    outRob = robCounter + 18;
-	  }
-	}
+      if (rosType == 25) {
+        if (station == 1) {  //MB1
+          outRob = robCounter;
+        } else if (station == 2) {  //MB2
+          outRob = robCounter + 6;
+        } else if (station == 3) {  //MB3
+          if (robCounter < 3)
+            outRob = robCounter + 12;
+          else if (robCounter == 3)
+            outRob = 24;
+          else if (robCounter > 3)
+            outRob = robCounter + 11;
+        } else if (station == 4) {  //MB4
+          if (sector == 14) {
+            if (robCounter == 3) {
+              continue;
+            }
+            outRob = robCounter + 18;
+          } else if (sector == 10) {
+            if (robCounter == 3) {
+              continue;
+            } else if (robCounter == 0) {
+              outRob = 21;
+            } else {
+              outRob = robCounter + 21;
+            }
+          }
+          if (sector == 4) {
+            if (robCounter == 3 || robCounter == 4) {
+              continue;
+            }
+            outRob = robCounter + 18;
+          } else if (sector == 13) {
+            if (robCounter == 3 || robCounter == 4) {
+              continue;
+            } else if (robCounter == 0) {
+              outRob = 21;
+            } else {
+              outRob = robCounter + 21;
+            }
+          } else if (sector == 11 || sector == 9) {
+            outRob = robCounter + 18;
+            if (robCounter == 3) {
+              continue;
+            }
+          }
+          //else if(sector==12 || sector == 8 || sector == 7 || sector == 6 || sector == 5 ||  sector == 3 || sector == 2 ||sector == 1 ){
+          else {
+            outRob = robCounter + 18;
+          }
+        }
       } else {
-	outRob = rob;
+        outRob = rob;
       }
-      outputMap << ddu << " "
-		<< ros << " "
-		<< outRob << " "
-		<< tdc << " "
-		<< tdcChannel << " "
-		<< wheel << " "
-		<< station << " "
-		<< sector << " "
-		<< sl << " "
-		<< layer << " "
-		<< wire << endl;
+      outputMap << ddu << " " << ros << " " << outRob << " " << tdc << " " << tdcChannel << " " << wheel << " "
+                << station << " " << sector << " " << sl << " " << layer << " " << wire << endl;
     }
   }
 }
 
-bool DTMapGenerator::checkWireExist(const set<DTWireId>& wireMap, int wheel, int station, int sector, int sl, int layer, int wire) {
+bool DTMapGenerator::checkWireExist(
+    const set<DTWireId>& wireMap, int wheel, int station, int sector, int sl, int layer, int wire) {
   DTWireId wireId(wheel, station, sector, sl, layer, wire);
-  if(wireMap.find(wireId) == wireMap.end()) {
-    cout << "Skipping channel: Wh: " << wheel
-	 << ", st: " << station
-	 << ", sec: " << sector
-	 << ", sl: " << sl
-	 << ", lay: " << layer
-	 << ", wire: " << wire << endl;
+  if (wireMap.find(wireId) == wireMap.end()) {
+    cout << "Skipping channel: Wh: " << wheel << ", st: " << station << ", sec: " << sector << ", sl: " << sl
+         << ", lay: " << layer << ", wire: " << wire << endl;
     return false;
   }
-  
+
   return true;
 }
-
-

--- a/CalibMuon/DTCalibration/plugins/DTMapGenerator.h
+++ b/CalibMuon/DTCalibration/plugins/DTMapGenerator.h
@@ -11,14 +11,11 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 
-
 #include <string>
 #include <set>
 
 class DTMapGenerator : public edm::EDAnalyzer {
-
 public:
-
   /// Constructor
   DTMapGenerator(const edm::ParameterSet& pset);
 
@@ -27,18 +24,18 @@ public:
 
   // Operations
 
-  void beginJob() override{}
+  void beginJob() override {}
 
-  void analyze(const edm::Event& event, const edm::EventSetup& setup) override{}
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
 
   void endJob() override;
 
 protected:
-
 private:
   //Check if the wire exists in the channels list :
   //(/afs/cern.ch/cms/Physics/muon/CMSSW/DT/channelsMaps/existing_channels.txt)
-  bool checkWireExist(const std::set<DTWireId>& wireMap, int wheel, int station, int sector, int sl, int layer, int wire);
+  bool checkWireExist(
+      const std::set<DTWireId>& wireMap, int wheel, int station, int sector, int sl, int layer, int wire);
 
   //file name with the output map
   std::string outputMapName;

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
@@ -68,7 +68,7 @@ DTNoiseCalibration::DTNoiseCalibration(const edm::ParameterSet& pset)
     vector<string> cellsWithHisto = pset.getParameter<vector<string> >("cellsWithHisto");
     for (vector<string>::const_iterator cell = cellsWithHisto.begin(); cell != cellsWithHisto.end(); ++cell) {
       //FIXME: Use regex to check whether format is right
-      if (cell->empty() && (*cell) != "None") {
+      if ((!cell->empty()) && (*cell) != "None") {
         stringstream linestr;
         int wheel, station, sector, sl, layer, wire;
         linestr << (*cell);

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
@@ -69,7 +69,7 @@ DTNoiseCalibration::DTNoiseCalibration(const edm::ParameterSet& pset):
      vector<string> cellsWithHisto = pset.getParameter<vector<string> >("cellsWithHisto");
      for(vector<string>::const_iterator cell = cellsWithHisto.begin(); cell != cellsWithHisto.end(); ++cell){
         //FIXME: Use regex to check whether format is right
-        if( (*cell) != "" && (*cell) != "None"){
+        if( cell->empty() && (*cell) != "None"){
            stringstream linestr;
            int wheel,station,sector,sl,layer,wire;
            linestr << (*cell);

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
@@ -10,7 +10,7 @@
 // Framework
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
-#include "FWCore/Framework/interface/EventSetup.h" 
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -39,20 +39,19 @@
 using namespace edm;
 using namespace std;
 
-DTNoiseCalibration::DTNoiseCalibration(const edm::ParameterSet& pset):
-  digiLabel_( pset.getParameter<InputTag>("digiLabel") ),
-  useTimeWindow_( pset.getParameter<bool>("useTimeWindow") ),
-  triggerWidth_( pset.getParameter<double>("triggerWidth") ),
-  timeWindowOffset_( pset.getParameter<int>("timeWindowOffset") ),
-  maximumNoiseRate_( pset.getParameter<double>("maximumNoiseRate") ),
-  useAbsoluteRate_( pset.getParameter<bool>("useAbsoluteRate") ), 
-  readDB_(true), defaultTtrig_(0), 
-  dbLabel_( pset.getUntrackedParameter<string>("dbLabel", "") ),
-  //fastAnalysis_( pset.getParameter<bool>("fastAnalysis", true) ),
-  wireIdWithHisto_( std::vector<DTWireId>() ),
-  lumiMax_(3000)
-  {
-
+DTNoiseCalibration::DTNoiseCalibration(const edm::ParameterSet& pset)
+    : digiLabel_(pset.getParameter<InputTag>("digiLabel")),
+      useTimeWindow_(pset.getParameter<bool>("useTimeWindow")),
+      triggerWidth_(pset.getParameter<double>("triggerWidth")),
+      timeWindowOffset_(pset.getParameter<int>("timeWindowOffset")),
+      maximumNoiseRate_(pset.getParameter<double>("maximumNoiseRate")),
+      useAbsoluteRate_(pset.getParameter<bool>("useAbsoluteRate")),
+      readDB_(true),
+      defaultTtrig_(0),
+      dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")),
+      //fastAnalysis_( pset.getParameter<bool>("fastAnalysis", true) ),
+      wireIdWithHisto_(std::vector<DTWireId>()),
+      lumiMax_(3000) {
   // Get the debug parameter for verbose output
   //debug = ps.getUntrackedParameter<bool>("debug");
   /*// The analysis type
@@ -60,51 +59,51 @@ DTNoiseCalibration::DTNoiseCalibration(const edm::ParameterSet& pset):
   wh = ps.getUntrackedParameter<int>("wheel", 0);
   sect = ps.getUntrackedParameter<int>("sector", 6);*/
 
-  if( pset.exists("defaultTtrig") ){
-     readDB_ = false;
-     defaultTtrig_ = pset.getParameter<int>("defaultTtrig");
+  if (pset.exists("defaultTtrig")) {
+    readDB_ = false;
+    defaultTtrig_ = pset.getParameter<int>("defaultTtrig");
   }
 
-  if( pset.exists("cellsWithHisto") ){
-     vector<string> cellsWithHisto = pset.getParameter<vector<string> >("cellsWithHisto");
-     for(vector<string>::const_iterator cell = cellsWithHisto.begin(); cell != cellsWithHisto.end(); ++cell){
-        //FIXME: Use regex to check whether format is right
-        if( cell->empty() && (*cell) != "None"){
-           stringstream linestr;
-           int wheel,station,sector,sl,layer,wire;
-           linestr << (*cell);
-           linestr >> wheel >> station >> sector >> sl >> layer >> wire;
-           wireIdWithHisto_.push_back(DTWireId(wheel,station,sector,sl,layer,wire));
-        }
-     }
+  if (pset.exists("cellsWithHisto")) {
+    vector<string> cellsWithHisto = pset.getParameter<vector<string> >("cellsWithHisto");
+    for (vector<string>::const_iterator cell = cellsWithHisto.begin(); cell != cellsWithHisto.end(); ++cell) {
+      //FIXME: Use regex to check whether format is right
+      if (cell->empty() && (*cell) != "None") {
+        stringstream linestr;
+        int wheel, station, sector, sl, layer, wire;
+        linestr << (*cell);
+        linestr >> wheel >> station >> sector >> sl >> layer >> wire;
+        wireIdWithHisto_.push_back(DTWireId(wheel, station, sector, sl, layer, wire));
+      }
+    }
   }
 
   // The root file which will contain the histos
-  string rootFileName = pset.getUntrackedParameter<string>("rootFileName","noise.root");
+  string rootFileName = pset.getUntrackedParameter<string>("rootFileName", "noise.root");
   rootFile_ = new TFile(rootFileName.c_str(), "RECREATE");
   rootFile_->cd();
 }
 
 void DTNoiseCalibration::beginJob() {
   LogVerbatim("Calibration") << "[DTNoiseCalibration]: Begin job";
-  
+
   nevents_ = 0;
-  
+
   TH1::SetDefaultSumw2(true);
-  int numBin = (triggerWidth_*32/25)/50;
-  hTDCTriggerWidth_ = new TH1F("TDC_Time_Distribution", "TDC_Time_Distribution", numBin, 0, triggerWidth_*32/25);
+  int numBin = (triggerWidth_ * 32 / 25) / 50;
+  hTDCTriggerWidth_ = new TH1F("TDC_Time_Distribution", "TDC_Time_Distribution", numBin, 0, triggerWidth_ * 32 / 25);
 }
 
-void DTNoiseCalibration::beginRun(const edm::Run& run, const edm::EventSetup& setup ) {
-
+void DTNoiseCalibration::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   // Get the DT Geometry
   setup.get<MuonGeometryRecord>().get(dtGeom_);
 
-  // tTrig 
-  if( readDB_ ) setup.get<DTTtrigRcd>().get(dbLabel_,tTrigMap_);
+  // tTrig
+  if (readDB_)
+    setup.get<DTTtrigRcd>().get(dbLabel_, tTrigMap_);
 
-  runBeginTime_ = time_t(run.beginTime().value()>>32);
-  runEndTime_ = time_t(run.endTime().value()>>32);
+  runBeginTime_ = time_t(run.beginTime().value() >> 32);
+  runEndTime_ = time_t(run.endTime().value() >> 32);
   /*
   nevents = 0;
   counter = 0;
@@ -112,12 +111,11 @@ void DTNoiseCalibration::beginRun(const edm::Run& run, const edm::EventSetup& se
   // TDC time distribution
   int numBin = (triggerWidth_*(32/25))/50;
   hTDCTriggerWidth = new TH1F("TDC_Time_Distribution", "TDC_Time_Distribution", numBin, 0, triggerWidth_*(32/25));*/
-
 }
 
-void DTNoiseCalibration::analyze(const edm::Event& event, const edm::EventSetup& setup){
+void DTNoiseCalibration::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   ++nevents_;
-  
+
   // Get the digis from the event
   Handle<DTDigiCollection> dtdigis;
   event.getByLabel(digiLabel_, dtdigis);
@@ -126,119 +124,123 @@ void DTNoiseCalibration::analyze(const edm::Event& event, const edm::EventSetup&
   TH2F *hEvtPerWireH;
   string Histo2Name;*/
 
-  //RunNumber_t runNumber = event.id().run(); 
-  time_t eventTime = time_t(event.time().value()>>32);
+  //RunNumber_t runNumber = event.id().run();
+  time_t eventTime = time_t(event.time().value() >> 32);
   unsigned int lumiSection = event.luminosityBlock();
 
   // Loop over digis
   DTDigiCollection::DigiRangeIterator dtLayerId_It;
-  for (dtLayerId_It=dtdigis->begin(); dtLayerId_It!=dtdigis->end(); ++dtLayerId_It){
-     // Define time window
-     float upperLimit = 0.;
-     if(useTimeWindow_){
-        if( readDB_ ){
-           float tTrig,tTrigRMS,kFactor;
-           DTSuperLayerId slId = ((*dtLayerId_It).first).superlayerId();
-           int status = tTrigMap_->get( slId, tTrig, tTrigRMS, kFactor, DTTimeUnits::counts );
-           if(status != 0) throw cms::Exception("DTNoiseCalibration") << "Could not find tTrig entry in DB for" << slId << endl;
-           upperLimit = tTrig - timeWindowOffset_;
-        } else {
-           upperLimit = defaultTtrig_ - timeWindowOffset_;
+  for (dtLayerId_It = dtdigis->begin(); dtLayerId_It != dtdigis->end(); ++dtLayerId_It) {
+    // Define time window
+    float upperLimit = 0.;
+    if (useTimeWindow_) {
+      if (readDB_) {
+        float tTrig, tTrigRMS, kFactor;
+        DTSuperLayerId slId = ((*dtLayerId_It).first).superlayerId();
+        int status = tTrigMap_->get(slId, tTrig, tTrigRMS, kFactor, DTTimeUnits::counts);
+        if (status != 0)
+          throw cms::Exception("DTNoiseCalibration") << "Could not find tTrig entry in DB for" << slId << endl;
+        upperLimit = tTrig - timeWindowOffset_;
+      } else {
+        upperLimit = defaultTtrig_ - timeWindowOffset_;
+      }
+    }
+
+    double triggerWidth_s = 0.;
+    if (useTimeWindow_)
+      triggerWidth_s = ((upperLimit * 25) / 32) / 1e9;
+    else
+      triggerWidth_s = double(triggerWidth_ / 1e9);
+    LogTrace("Calibration") << ((*dtLayerId_It).first).superlayerId() << " Trigger width (s): " << triggerWidth_s;
+
+    for (DTDigiCollection::const_iterator digiIt = ((*dtLayerId_It).second).first;
+         digiIt != ((*dtLayerId_It).second).second;
+         ++digiIt) {
+      //Check the TDC trigger width
+      int tdcTime = (*digiIt).countsTDC();
+      if (!useTimeWindow_) {
+        if ((((float)tdcTime * 25) / 32) > triggerWidth_) {
+          LogError("Calibration") << "Digi has a TDC time (ns) higher than the pre-defined TDC trigger width: "
+                                  << ((float)tdcTime * 25) / 32;
+          continue;
         }
-     }
+      }
 
-     double triggerWidth_s = 0.;
-     if(useTimeWindow_) triggerWidth_s = ( (upperLimit*25)/32 )/1e9;
-     else               triggerWidth_s = double(triggerWidth_/1e9);
-     LogTrace("Calibration") << ((*dtLayerId_It).first).superlayerId() << " Trigger width (s): " << triggerWidth_s;
+      hTDCTriggerWidth_->Fill(tdcTime);
 
-     for (DTDigiCollection::const_iterator digiIt = ((*dtLayerId_It).second).first;
-	 digiIt!=((*dtLayerId_It).second).second; ++digiIt){
+      if (useTimeWindow_ && tdcTime > upperLimit)
+        continue;
 
-        //Check the TDC trigger width
-        int tdcTime = (*digiIt).countsTDC();
-        if( !useTimeWindow_ ){
-	   if( ( ((float)tdcTime*25)/32 ) > triggerWidth_ ){
-              LogError("Calibration") << "Digi has a TDC time (ns) higher than the pre-defined TDC trigger width: " << ((float)tdcTime*25)/32;
-              continue;
-           }
-        }	
-
-        hTDCTriggerWidth_->Fill(tdcTime);
-
-        if( useTimeWindow_ && tdcTime > upperLimit) continue;
-
-        /*LogTrace("Calibration") << "TDC time (ns): " << ((float)tdcTime*25)/32
+      /*LogTrace("Calibration") << "TDC time (ns): " << ((float)tdcTime*25)/32
                                 <<" --- trigger width (ns): " << ((float)upperLimit*25)/32;*/
 
-        const DTLayerId dtLId = (*dtLayerId_It).first;
-        const DTTopology& dtTopo = dtGeom_->layer(dtLId)->specificTopology();
-        const int firstWire = dtTopo.firstChannel();
-        const int lastWire = dtTopo.lastChannel();
-        //const int nWires = dtTopo.channels();
-        const int nWires = lastWire - firstWire + 1;
+      const DTLayerId dtLId = (*dtLayerId_It).first;
+      const DTTopology& dtTopo = dtGeom_->layer(dtLId)->specificTopology();
+      const int firstWire = dtTopo.firstChannel();
+      const int lastWire = dtTopo.lastChannel();
+      //const int nWires = dtTopo.channels();
+      const int nWires = lastWire - firstWire + 1;
 
-        // Book the occupancy histos
-        if( theHistoOccupancyMap_.find(dtLId) == theHistoOccupancyMap_.end() ){
-           string histoName = "DigiOccupancy_" + getLayerName(dtLId);
-	   rootFile_->cd();
-	   TH1F* hOccupancyHisto = new TH1F(histoName.c_str(), histoName.c_str(), nWires, firstWire, lastWire+1);
-	   LogTrace("Calibration") << "  Created occupancy Histo: " << hOccupancyHisto->GetName();
-	   theHistoOccupancyMap_[dtLId] = hOccupancyHisto;
+      // Book the occupancy histos
+      if (theHistoOccupancyMap_.find(dtLId) == theHistoOccupancyMap_.end()) {
+        string histoName = "DigiOccupancy_" + getLayerName(dtLId);
+        rootFile_->cd();
+        TH1F* hOccupancyHisto = new TH1F(histoName.c_str(), histoName.c_str(), nWires, firstWire, lastWire + 1);
+        LogTrace("Calibration") << "  Created occupancy Histo: " << hOccupancyHisto->GetName();
+        theHistoOccupancyMap_[dtLId] = hOccupancyHisto;
+      }
+      theHistoOccupancyMap_[dtLId]->Fill((*digiIt).wire(), 1. / triggerWidth_s);
+
+      // Histos vs lumi section
+      const DTChamberId dtChId = dtLId.chamberId();
+      if (chamberOccupancyVsLumiMap_.find(dtChId) == chamberOccupancyVsLumiMap_.end()) {
+        string histoName = "OccupancyVsLumi_" + getChamberName(dtChId);
+        rootFile_->cd();
+        TH1F* hOccupancyVsLumiHisto = new TH1F(histoName.c_str(), histoName.c_str(), lumiMax_, 0, lumiMax_);
+        LogTrace("Calibration") << "  Created occupancy histo: " << hOccupancyVsLumiHisto->GetName();
+        chamberOccupancyVsLumiMap_[dtChId] = hOccupancyVsLumiHisto;
+      }
+      chamberOccupancyVsLumiMap_[dtChId]->Fill(lumiSection, 1. / triggerWidth_s);
+
+      const DTWireId wireId(dtLId, (*digiIt).wire());
+      if (find(wireIdWithHisto_.begin(), wireIdWithHisto_.end(), wireId) != wireIdWithHisto_.end()) {
+        if (theHistoOccupancyVsLumiMap_.find(wireId) == theHistoOccupancyVsLumiMap_.end()) {
+          string histoName = "OccupancyVsLumi_" + getChannelName(wireId);
+          rootFile_->cd();
+          TH1F* hOccupancyVsLumiHisto = new TH1F(histoName.c_str(), histoName.c_str(), lumiMax_, 0, lumiMax_);
+          LogTrace("Calibration") << "  Created occupancy histo: " << hOccupancyVsLumiHisto->GetName();
+          theHistoOccupancyVsLumiMap_[wireId] = hOccupancyVsLumiHisto;
         }
-        theHistoOccupancyMap_[dtLId]->Fill( (*digiIt).wire(), 1./triggerWidth_s );
+        theHistoOccupancyVsLumiMap_[wireId]->Fill(lumiSection, 1. / triggerWidth_s);
+      }
 
-        // Histos vs lumi section
-        const DTChamberId dtChId = dtLId.chamberId();
-        if( chamberOccupancyVsLumiMap_.find(dtChId) == chamberOccupancyVsLumiMap_.end() ){
-           string histoName = "OccupancyVsLumi_" + getChamberName(dtChId);
-           rootFile_->cd();
-           TH1F* hOccupancyVsLumiHisto = new TH1F(histoName.c_str(), histoName.c_str(), lumiMax_, 0, lumiMax_);
-           LogTrace("Calibration") << "  Created occupancy histo: " << hOccupancyVsLumiHisto->GetName();
-           chamberOccupancyVsLumiMap_[dtChId] = hOccupancyVsLumiHisto;
+      // Histos vs time
+      if (chamberOccupancyVsTimeMap_.find(dtChId) == chamberOccupancyVsTimeMap_.end()) {
+        string histoName = "OccupancyVsTime_" + getChamberName(dtChId);
+        float secPerBin = 20.0;
+        unsigned int nBins = ((unsigned int)(runEndTime_ - runBeginTime_)) / secPerBin;
+        rootFile_->cd();
+        TH1F* hOccupancyVsTimeHisto = new TH1F(
+            histoName.c_str(), histoName.c_str(), nBins, (unsigned int)runBeginTime_, (unsigned int)runEndTime_);
+        for (int k = 0; k < hOccupancyVsTimeHisto->GetNbinsX(); ++k) {
+          if (k % 10 == 0) {
+            unsigned int binLowEdge = hOccupancyVsTimeHisto->GetBinLowEdge(k + 1);
+            time_t timeValue = time_t(binLowEdge);
+            hOccupancyVsTimeHisto->GetXaxis()->SetBinLabel((k + 1), ctime(&timeValue));
+          }
         }
-        chamberOccupancyVsLumiMap_[dtChId]->Fill( lumiSection, 1./triggerWidth_s );
+        size_t lastBin = hOccupancyVsTimeHisto->GetNbinsX();
+        unsigned int binUpperEdge =
+            hOccupancyVsTimeHisto->GetBinLowEdge(lastBin) + hOccupancyVsTimeHisto->GetBinWidth(lastBin);
+        time_t timeValue = time_t(binUpperEdge);
+        hOccupancyVsTimeHisto->GetXaxis()->SetBinLabel((lastBin), ctime(&timeValue));
 
-        const DTWireId wireId(dtLId, (*digiIt).wire());
-        if( find(wireIdWithHisto_.begin(),wireIdWithHisto_.end(),wireId) != wireIdWithHisto_.end() ){
-           if( theHistoOccupancyVsLumiMap_.find(wireId) == theHistoOccupancyVsLumiMap_.end() ){
-              string histoName = "OccupancyVsLumi_" + getChannelName(wireId);
-              rootFile_->cd();
-              TH1F* hOccupancyVsLumiHisto = new TH1F(histoName.c_str(), histoName.c_str(), lumiMax_, 0, lumiMax_);
-              LogTrace("Calibration") << "  Created occupancy histo: " << hOccupancyVsLumiHisto->GetName();
-              theHistoOccupancyVsLumiMap_[wireId] = hOccupancyVsLumiHisto;
-           }
-           theHistoOccupancyVsLumiMap_[wireId]->Fill( lumiSection, 1./triggerWidth_s );
-        }
+        LogTrace("Calibration") << "  Created occupancy histo: " << hOccupancyVsTimeHisto->GetName();
+        chamberOccupancyVsTimeMap_[dtChId] = hOccupancyVsTimeHisto;
+      }
+      chamberOccupancyVsTimeMap_[dtChId]->Fill((unsigned int)eventTime, 1. / triggerWidth_s);
 
-        // Histos vs time
-        if( chamberOccupancyVsTimeMap_.find(dtChId) == chamberOccupancyVsTimeMap_.end() ){
-           string histoName = "OccupancyVsTime_" + getChamberName(dtChId);
-           float secPerBin = 20.0; 
-           unsigned int nBins = ( (unsigned int)(runEndTime_ - runBeginTime_) )/secPerBin;
-           rootFile_->cd(); 
-           TH1F* hOccupancyVsTimeHisto = new TH1F(histoName.c_str(), histoName.c_str(),
-                                                                     nBins, (unsigned int)runBeginTime_,
-                                                                            (unsigned int)runEndTime_);
-           for(int k = 0; k < hOccupancyVsTimeHisto->GetNbinsX(); ++k){
-              if( k%10 == 0 ){
-                 unsigned int binLowEdge = hOccupancyVsTimeHisto->GetBinLowEdge(k+1);
-                 time_t timeValue = time_t(binLowEdge); 
-                 hOccupancyVsTimeHisto->GetXaxis()->SetBinLabel( (k+1),ctime(&timeValue) );
-              }
-           }
-           size_t lastBin = hOccupancyVsTimeHisto->GetNbinsX();
-           unsigned int binUpperEdge = hOccupancyVsTimeHisto->GetBinLowEdge(lastBin) +
-                                       hOccupancyVsTimeHisto->GetBinWidth(lastBin);
-           time_t timeValue = time_t(binUpperEdge);
-           hOccupancyVsTimeHisto->GetXaxis()->SetBinLabel( (lastBin),ctime(&timeValue) ); 
-
-           LogTrace("Calibration") << "  Created occupancy histo: " << hOccupancyVsTimeHisto->GetName();
-           chamberOccupancyVsTimeMap_[dtChId] = hOccupancyVsTimeHisto; 
-        }
-        chamberOccupancyVsTimeMap_[dtChId]->Fill( (unsigned int)eventTime, 1./triggerWidth_s );               
-
-        /*// Book the digi event plot every 1000 events if the analysis is not "fast" and if is the correct sector
+      /*// Book the digi event plot every 1000 events if the analysis is not "fast" and if is the correct sector
 	if(!fastAnalysis &&
 	   dtLId.superlayerId().chamberId().wheel()==wh &&
 	   dtLId.superlayerId().chamberId().sector()==sect) {
@@ -256,9 +258,9 @@ void DTNoiseCalibration::analyze(const edm::Event& event, const edm::EventSetup&
 	    }
 	  }
 	}*/
-     }
+    }
   }
-    
+
   /*//Fill the plot of the number of digi per event per wire
   std::map<int,int > DigiPerWirePerEvent;
   // LOOP OVER ALL THE CHAMBERS
@@ -320,11 +322,9 @@ void DTNoiseCalibration::analyze(const edm::Event& event, const edm::EventSetup&
     }
     theHistoEvtPerWireMap.clear();
   }*/
-  
 }
 
-void DTNoiseCalibration::endJob(){
-
+void DTNoiseCalibration::endJob() {
   //LogVerbatim("Calibration") << "[DTNoiseCalibration] endjob called!";
   LogVerbatim("Calibration") << "[DTNoiseCalibration] Total number of events analyzed: " << nevents_;
 
@@ -332,32 +332,35 @@ void DTNoiseCalibration::endJob(){
   rootFile_->cd();
   hTDCTriggerWidth_->Write();
 
-  double normalization = 1./double(nevents_);
+  double normalization = 1. / double(nevents_);
 
-  for(map<DTWireId, TH1F*>::const_iterator wHisto = theHistoOccupancyVsLumiMap_.begin();
-                                           wHisto != theHistoOccupancyVsLumiMap_.end(); ++wHisto){
-     (*wHisto).second->Scale(normalization);
-     (*wHisto).second->Write();
-  }
-  
-  for(map<DTChamberId, TH1F*>::const_iterator chHisto = chamberOccupancyVsLumiMap_.begin();
-                                              chHisto != chamberOccupancyVsLumiMap_.end(); ++chHisto){
-     (*chHisto).second->Scale(normalization);
-     (*chHisto).second->Write();
+  for (map<DTWireId, TH1F*>::const_iterator wHisto = theHistoOccupancyVsLumiMap_.begin();
+       wHisto != theHistoOccupancyVsLumiMap_.end();
+       ++wHisto) {
+    (*wHisto).second->Scale(normalization);
+    (*wHisto).second->Write();
   }
 
-  for(map<DTChamberId, TH1F*>::const_iterator chHisto = chamberOccupancyVsTimeMap_.begin();
-                                              chHisto != chamberOccupancyVsTimeMap_.end(); ++chHisto){
-     (*chHisto).second->Scale(normalization);
-     (*chHisto).second->Write();
+  for (map<DTChamberId, TH1F*>::const_iterator chHisto = chamberOccupancyVsLumiMap_.begin();
+       chHisto != chamberOccupancyVsLumiMap_.end();
+       ++chHisto) {
+    (*chHisto).second->Scale(normalization);
+    (*chHisto).second->Write();
+  }
+
+  for (map<DTChamberId, TH1F*>::const_iterator chHisto = chamberOccupancyVsTimeMap_.begin();
+       chHisto != chamberOccupancyVsTimeMap_.end();
+       ++chHisto) {
+    (*chHisto).second->Scale(normalization);
+    (*chHisto).second->Write();
   }
 
   // Save on file the occupancy histos and write the list of noisy cells
-  DTStatusFlag *statusMap = new DTStatusFlag();
-  for(map<DTLayerId, TH1F*>::const_iterator lHisto = theHistoOccupancyMap_.begin();
-      lHisto != theHistoOccupancyMap_.end();
-      ++lHisto){
-     /*double triggerWidth_s = 0.;
+  DTStatusFlag* statusMap = new DTStatusFlag();
+  for (map<DTLayerId, TH1F*>::const_iterator lHisto = theHistoOccupancyMap_.begin();
+       lHisto != theHistoOccupancyMap_.end();
+       ++lHisto) {
+    /*double triggerWidth_s = 0.;
      if( useTimeWindow_ ){
         double triggerWidth_ns = 0.;
         if( readDB_ ){
@@ -376,86 +379,74 @@ void DTNoiseCalibration::endJob(){
      }
      LogTrace("Calibration") << (*lHisto).second->GetName() << " trigger width (s): " << triggerWidth_s;*/
 
-     //double normalization = 1./(nevents_*triggerWidth_s);
-     if((*lHisto).second){
-        (*lHisto).second->Scale(normalization);
-        rootFile_->cd();
-        (*lHisto).second->Write();
-        const DTTopology& dtTopo = dtGeom_->layer((*lHisto).first)->specificTopology();
-        const int firstWire = dtTopo.firstChannel();
-        const int lastWire = dtTopo.lastChannel();
-        //const int nWires = dtTopo.channels();
-        const int nWires = lastWire - firstWire + 1;
-        // Find average in layer
-        double averageRate = 0.;  
-        for(int bin = 1; bin <= (*lHisto).second->GetNbinsX(); ++bin)
-           averageRate += (*lHisto).second->GetBinContent(bin);
+    //double normalization = 1./(nevents_*triggerWidth_s);
+    if ((*lHisto).second) {
+      (*lHisto).second->Scale(normalization);
+      rootFile_->cd();
+      (*lHisto).second->Write();
+      const DTTopology& dtTopo = dtGeom_->layer((*lHisto).first)->specificTopology();
+      const int firstWire = dtTopo.firstChannel();
+      const int lastWire = dtTopo.lastChannel();
+      //const int nWires = dtTopo.channels();
+      const int nWires = lastWire - firstWire + 1;
+      // Find average in layer
+      double averageRate = 0.;
+      for (int bin = 1; bin <= (*lHisto).second->GetNbinsX(); ++bin)
+        averageRate += (*lHisto).second->GetBinContent(bin);
 
-        if(nWires) averageRate /= nWires;  
-        LogTrace("Calibration") << "  Average rate = " << averageRate;
+      if (nWires)
+        averageRate /= nWires;
+      LogTrace("Calibration") << "  Average rate = " << averageRate;
 
-        for(int i_wire = firstWire; i_wire <= lastWire; ++i_wire){
-	   // From definition of "noisy cell"
-           int bin = i_wire - firstWire + 1;
-           double channelRate = (*lHisto).second->GetBinContent(bin);
-           double rateOffset = (useAbsoluteRate_) ? 0. : averageRate;
-	   if( (channelRate - rateOffset) > maximumNoiseRate_ ){
-	      DTWireId wireID((*lHisto).first, i_wire);
-	      statusMap->setCellNoise(wireID,true);
-              LogVerbatim("Calibration") << ">>> Channel noisy: " << wireID;
-	   }
+      for (int i_wire = firstWire; i_wire <= lastWire; ++i_wire) {
+        // From definition of "noisy cell"
+        int bin = i_wire - firstWire + 1;
+        double channelRate = (*lHisto).second->GetBinContent(bin);
+        double rateOffset = (useAbsoluteRate_) ? 0. : averageRate;
+        if ((channelRate - rateOffset) > maximumNoiseRate_) {
+          DTWireId wireID((*lHisto).first, i_wire);
+          statusMap->setCellNoise(wireID, true);
+          LogVerbatim("Calibration") << ">>> Channel noisy: " << wireID;
         }
-     }
+      }
+    }
   }
   LogVerbatim("Calibration") << "Writing noise map object to DB";
   string record = "DTStatusFlagRcd";
   DTCalibDBUtils::writeToDB<DTStatusFlag>(record, statusMap);
 }
 
-DTNoiseCalibration::~DTNoiseCalibration(){
-  rootFile_->Close();
-}
+DTNoiseCalibration::~DTNoiseCalibration() { rootFile_->Close(); }
 
-string DTNoiseCalibration::getChannelName(const DTWireId& wId) const{
-  string channelName = "Wh" + std::to_string(wId.wheel()) + "_St" + std::to_string(wId.station())
-                     + "_Sec" + std::to_string(wId.sector()) + "_SL" + std::to_string(wId.superlayer())
-                     + "_L" + std::to_string(wId.layer()) + "_W" + std::to_string(wId.wire());
+string DTNoiseCalibration::getChannelName(const DTWireId& wId) const {
+  string channelName = "Wh" + std::to_string(wId.wheel()) + "_St" + std::to_string(wId.station()) + "_Sec" +
+                       std::to_string(wId.sector()) + "_SL" + std::to_string(wId.superlayer()) + "_L" +
+                       std::to_string(wId.layer()) + "_W" + std::to_string(wId.wire());
   return channelName;
 }
 
-string DTNoiseCalibration::getLayerName(const DTLayerId& lId) const{
+string DTNoiseCalibration::getLayerName(const DTLayerId& lId) const {
+  const DTSuperLayerId dtSLId = lId.superlayerId();
+  const DTChamberId dtChId = dtSLId.chamberId();
+  string layerName = "W" + std::to_string(dtChId.wheel()) + "_St" + std::to_string(dtChId.station()) + "_Sec" +
+                     std::to_string(dtChId.sector()) + "_SL" + std::to_string(dtSLId.superlayer()) + "_L" +
+                     std::to_string(lId.layer());
 
-  const  DTSuperLayerId dtSLId = lId.superlayerId();
-  const  DTChamberId dtChId = dtSLId.chamberId(); 
-  string layerName = 
-    "W" + std::to_string(dtChId.wheel())
-    + "_St" + std::to_string(dtChId.station())
-    + "_Sec" + std::to_string(dtChId.sector())
-    + "_SL" + std::to_string(dtSLId.superlayer())
-    + "_L" + std::to_string(lId.layer());
-  
   return layerName;
 }
 
-string DTNoiseCalibration::getSuperLayerName(const DTSuperLayerId& dtSLId) const{
+string DTNoiseCalibration::getSuperLayerName(const DTSuperLayerId& dtSLId) const {
+  const DTChamberId dtChId = dtSLId.chamberId();
 
-  const  DTChamberId dtChId = dtSLId.chamberId(); 
-
-  string superLayerName = 
-    "W" + std::to_string(dtChId.wheel())
-    + "_St" + std::to_string(dtChId.station())
-    + "_Sec" + std::to_string(dtChId.sector())
-    + "_SL" + std::to_string(dtSLId.superlayer());
+  string superLayerName = "W" + std::to_string(dtChId.wheel()) + "_St" + std::to_string(dtChId.station()) + "_Sec" +
+                          std::to_string(dtChId.sector()) + "_SL" + std::to_string(dtSLId.superlayer());
 
   return superLayerName;
 }
 
-string DTNoiseCalibration::getChamberName(const DTChamberId& dtChId) const{
-
-  string chamberName =
-    "W" + std::to_string(dtChId.wheel())
-    + "_St" + std::to_string(dtChId.station())
-    + "_Sec" + std::to_string(dtChId.sector());
+string DTNoiseCalibration::getChamberName(const DTChamberId& dtChId) const {
+  string chamberName = "W" + std::to_string(dtChId.wheel()) + "_St" + std::to_string(dtChId.station()) + "_Sec" +
+                       std::to_string(dtChId.sector());
 
   return chamberName;
 }

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
@@ -21,23 +21,22 @@
 class DTGeometry;
 class DTChamberId;
 class DTSuperLayerId;
-class DTLayerId; 
+class DTLayerId;
 class DTWireId;
 class DTTtrig;
 class TFile;
 class TH2F;
 class TH1F;
 
-class DTNoiseCalibration: public edm::EDAnalyzer{
-
- public:
+class DTNoiseCalibration : public edm::EDAnalyzer {
+public:
   /// Constructor
   DTNoiseCalibration(const edm::ParameterSet& ps);
   /// Destructor
   ~DTNoiseCalibration() override;
 
   void beginJob() override;
-  void beginRun(const edm::Run& run, const edm::EventSetup& setup ) override;
+  void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void endJob() override;
 
@@ -55,7 +54,7 @@ private:
   double triggerWidth_;
   int timeWindowOffset_;
   double maximumNoiseRate_;
-  bool useAbsoluteRate_; 
+  bool useAbsoluteRate_;
 
   /*bool fastAnalysis;
   int wh;
@@ -88,7 +87,7 @@ private:
   // Map of occupancy by lumi by chamber
   std::map<DTChamberId, TH1F*> chamberOccupancyVsLumiMap_;
   // Map of occupancy by time by chamber
-  std::map<DTChamberId, TH1F*> chamberOccupancyVsTimeMap_; 
+  std::map<DTChamberId, TH1F*> chamberOccupancyVsTimeMap_;
   // Map of the histograms with the number of events per evt per wire
   //std::map<DTLayerId, TH2F*> theHistoEvtPerWireMap_;
   // Map of skipped histograms

--- a/CalibMuon/DTCalibration/plugins/DTNoiseComputation.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseComputation.cc
@@ -4,7 +4,6 @@
  *  \author G. Mila - INFN Torino
  */
 
-
 #include "CalibMuon/DTCalibration/plugins/DTNoiseComputation.h"
 #include "CalibMuon/DTCalibration/interface/DTCalibDBUtils.h"
 
@@ -39,10 +38,8 @@
 using namespace edm;
 using namespace std;
 
-
-DTNoiseComputation::DTNoiseComputation(const edm::ParameterSet& ps){
-
-  cout << "[DTNoiseComputation]: Constructor" <<endl;
+DTNoiseComputation::DTNoiseComputation(const edm::ParameterSet &ps) {
+  cout << "[DTNoiseComputation]: Constructor" << endl;
 
   // Get the debug parameter for verbose output
   debug = ps.getUntrackedParameter<bool>("debug");
@@ -60,19 +57,17 @@ DTNoiseComputation::DTNoiseComputation(const edm::ParameterSet& ps){
 
   // The maximum number of events to analyze
   MaxEvents = ps.getUntrackedParameter<int>("MaxEvents");
-
 }
 
-void DTNoiseComputation::beginRun(const edm::Run&, const EventSetup& setup)
-{
+void DTNoiseComputation::beginRun(const edm::Run &, const EventSetup &setup) {
   // Get the DT Geometry
   setup.get<MuonGeometryRecord>().get(dtGeom);
 
   static int count = 0;
 
-  if(count == 0){
+  if (count == 0) {
     string CheckHistoName;
-  
+
     TH1F *hOccHisto;
     TH1F *hAverageNoiseHisto;
     TH1F *hAverageNoiseIntegratedHisto;
@@ -87,392 +82,363 @@ void DTNoiseComputation::beginRun(const edm::Run&, const EventSetup& setup)
     string AverageNoiseIntegratedNamePerCh;
     TH1F *hnoisyC;
     TH1F *hsomeHowNoisyC;
-  
-    // Loop over all the chambers 	 
-    vector<const DTChamber*>::const_iterator ch_it = dtGeom->chambers().begin(); 	 
-    vector<const DTChamber*>::const_iterator ch_end = dtGeom->chambers().end(); 	 
-    // Loop over the SLs 	 
-    for (; ch_it != ch_end; ++ch_it) { 	 
-      DTChamberId ch = (*ch_it)->id(); 	 
-      vector<const DTSuperLayer*>::const_iterator sl_it = (*ch_it)->superLayers().begin(); 	 
-      vector<const DTSuperLayer*>::const_iterator sl_end = (*ch_it)->superLayers().end(); 	 
-      // Loop over the SLs 	 
-      for(; sl_it != sl_end; ++sl_it) { 	 
-	//      DTSuperLayerId sl = (*sl_it)->id(); 	 
-	vector<const DTLayer*>::const_iterator l_it = (*sl_it)->layers().begin(); 	 
-	vector<const DTLayer*>::const_iterator l_end = (*sl_it)->layers().end(); 	 
-	// Loop over the Ls 	 
-	for(; l_it != l_end; ++l_it) { 	 
-	  DTLayerId dtLId = (*l_it)->id();
-	
-	  //check if the layer has digi
-	  theFile->cd();
-	  CheckHistoName =  "DigiOccupancy_" + getLayerName(dtLId);
-	  TH1F *hCheckHisto = (TH1F *) theFile->Get(CheckHistoName.c_str());
-	  if(hCheckHisto){  
-	    delete hCheckHisto;
-	    string wheel = std::to_string(ch.wheel());
-	    string station = std::to_string(ch.station());
-	  
-	    if(someHowNoisyC.find(make_pair(ch.wheel(),ch.station())) == someHowNoisyC.end()) {
-	      TString histoName_someHowNoisy = "somehowNoisyCell_W"+wheel+"_St"+station;
-	      hsomeHowNoisyC = new TH1F(histoName_someHowNoisy,histoName_someHowNoisy,getMaxNumBins(ch),1,getMaxNumBins(ch)+1);
-	      someHowNoisyC[make_pair(ch.wheel(),ch.station())]=hsomeHowNoisyC;
-	    }
-	  
-	    if(noisyC.find(make_pair(ch.wheel(),ch.station())) == noisyC.end()) {
-	      TString histoName_noisy = "noisyCell_W"+wheel+"_St"+station;
-	      hnoisyC = new TH1F(histoName_noisy,histoName_noisy,getMaxNumBins(ch),1,getMaxNumBins(ch)+1);
-	      noisyC[make_pair(ch.wheel(),ch.station())]=hnoisyC;
-	    }
-	  
-	    //to fill a map with the average noise per wire and fill new noise histo	  
-	    if(AvNoisePerSuperLayer.find(dtLId.superlayerId()) == AvNoisePerSuperLayer.end()) {
-	      AverageNoiseName = "AverageNoise_" + getSuperLayerName(dtLId.superlayerId());
-	      hAverageNoiseHisto = new TH1F(AverageNoiseName.c_str(), AverageNoiseName.c_str(), 200, 0, 10000);
-	      AverageNoiseIntegratedName = "AverageNoiseIntegrated_" + getSuperLayerName(dtLId.superlayerId());
-	      hAverageNoiseIntegratedHisto = new TH1F(AverageNoiseIntegratedName.c_str(), AverageNoiseIntegratedName.c_str(), 200, 0, 10000);
-	      AvNoisePerSuperLayer[dtLId.superlayerId()] = hAverageNoiseHisto;
-	      AvNoiseIntegratedPerSuperLayer[dtLId.superlayerId()] = hAverageNoiseIntegratedHisto;
-	      if(debug){
-		cout << "  New Average Noise Histo per SuperLayer : " << hAverageNoiseHisto->GetName() << endl;
-		cout << "  New Average Noise Integrated Histo per SuperLayer : " << hAverageNoiseHisto->GetName() << endl;
-	      }
-	    }
-	    if(AvNoisePerChamber.find(dtLId.superlayerId().chamberId()) == AvNoisePerChamber.end()) {
-	      AverageNoiseNamePerCh = "AverageNoise_" + getChamberName(dtLId);
-	      hAverageNoiseHistoPerCh = new TH1F(AverageNoiseNamePerCh.c_str(), AverageNoiseNamePerCh.c_str(), 200, 0, 10000);
-	      AverageNoiseIntegratedNamePerCh = "AverageNoiseIntegrated_" + getChamberName(dtLId);
-	      hAverageNoiseIntegratedHistoPerCh = new TH1F(AverageNoiseIntegratedNamePerCh.c_str(), AverageNoiseIntegratedNamePerCh.c_str(), 200, 0, 10000);
-	      AvNoisePerChamber[dtLId.superlayerId().chamberId()] = hAverageNoiseHistoPerCh;
-	      AvNoiseIntegratedPerChamber[dtLId.superlayerId().chamberId()] = hAverageNoiseIntegratedHistoPerCh;
-	      if(debug)
-		cout << "  New Average Noise Histo per chamber : " << hAverageNoiseHistoPerCh->GetName() << endl;
-	    }
-	  
-	    HistoName = "DigiOccupancy_" + getLayerName(dtLId);
-	    theFile->cd();
-	    hOccHisto = (TH1F *) theFile->Get(HistoName.c_str());
-	    int numBin = hOccHisto->GetXaxis()->GetNbins(); 
-	    for (int bin=1; bin<=numBin; bin++) {
-	      DTWireId wireID(dtLId, bin);
-	      theAverageNoise[wireID]= hOccHisto->GetBinContent(bin);
-	      if(theAverageNoise[wireID] != 0) {
-		AvNoisePerSuperLayer[dtLId.superlayerId()]->Fill(theAverageNoise[wireID]);
-		AvNoisePerChamber[dtLId.superlayerId().chamberId()]->Fill(theAverageNoise[wireID]);
-	      }
-	    }	      
-	  
-	    //to compute the average noise per layer (excluding the noisy cells)
-	    double numCell=0;
-	    double AvNoise=0;	     
-	    HistoName = "DigiOccupancy_" + getLayerName(dtLId);
-	    theFile->cd();
-	    hOccHisto = (TH1F *) theFile->Get(HistoName.c_str());
-	    numBin = hOccHisto->GetXaxis()->GetNbins(); 
-	    for (int bin=1; bin<=numBin; bin++) {
-	      DTWireId wireID(dtLId, bin);
-	      theAverageNoise[wireID]= hOccHisto->GetBinContent(bin);
-	      if(hOccHisto->GetBinContent(bin)<100){
-		numCell++;
-		AvNoise += hOccHisto->GetBinContent(bin);
-	      }
-	      if(hOccHisto->GetBinContent(bin)>100 && hOccHisto->GetBinContent(bin)<500){
-		someHowNoisyC[make_pair(ch.wheel(),ch.station())]->Fill(bin);
-		cout<<"filling somehow noisy cell"<<endl;
-	      }
-	      if(hOccHisto->GetBinContent(bin)>500){
-		noisyC[make_pair(ch.wheel(),ch.station())]->Fill(bin);
-		cout<<"filling noisy cell"<<endl;
-	      }
-	    }
-	    AvNoise = AvNoise/numCell;
-	    cout<<"theAverageNoise for layer "<<getLayerName(dtLId)<<" is : "<<AvNoise << endl;
 
-	  
-	    // book the digi event plots every 1000 events
-	    int updates = MaxEvents/1000; 
-	    for(int evt=0; evt<updates; evt++){
-	      Histo2Name = "DigiPerWirePerEvent_" + getLayerName(dtLId) + "_" + std::to_string(evt);
-	      theFile->cd();
-	      hEvtHisto = (TH2F *) theFile->Get(Histo2Name.c_str());
-	      if(hEvtHisto){
-		if(debug)
-		  cout << "  New Histo with the number of events per evt per wire: " << hEvtHisto->GetName() << endl;
-		theEvtMap[dtLId].push_back(hEvtHisto);
-	      }
-	    }
-	  
-	  }// done if the layer has digi
-	}// loop over layers
-      }// loop over superlayers
-    }// loop over chambers
+    // Loop over all the chambers
+    vector<const DTChamber *>::const_iterator ch_it = dtGeom->chambers().begin();
+    vector<const DTChamber *>::const_iterator ch_end = dtGeom->chambers().end();
+    // Loop over the SLs
+    for (; ch_it != ch_end; ++ch_it) {
+      DTChamberId ch = (*ch_it)->id();
+      vector<const DTSuperLayer *>::const_iterator sl_it = (*ch_it)->superLayers().begin();
+      vector<const DTSuperLayer *>::const_iterator sl_end = (*ch_it)->superLayers().end();
+      // Loop over the SLs
+      for (; sl_it != sl_end; ++sl_it) {
+        //      DTSuperLayerId sl = (*sl_it)->id();
+        vector<const DTLayer *>::const_iterator l_it = (*sl_it)->layers().begin();
+        vector<const DTLayer *>::const_iterator l_end = (*sl_it)->layers().end();
+        // Loop over the Ls
+        for (; l_it != l_end; ++l_it) {
+          DTLayerId dtLId = (*l_it)->id();
+
+          //check if the layer has digi
+          theFile->cd();
+          CheckHistoName = "DigiOccupancy_" + getLayerName(dtLId);
+          TH1F *hCheckHisto = (TH1F *)theFile->Get(CheckHistoName.c_str());
+          if (hCheckHisto) {
+            delete hCheckHisto;
+            string wheel = std::to_string(ch.wheel());
+            string station = std::to_string(ch.station());
+
+            if (someHowNoisyC.find(make_pair(ch.wheel(), ch.station())) == someHowNoisyC.end()) {
+              TString histoName_someHowNoisy = "somehowNoisyCell_W" + wheel + "_St" + station;
+              hsomeHowNoisyC =
+                  new TH1F(histoName_someHowNoisy, histoName_someHowNoisy, getMaxNumBins(ch), 1, getMaxNumBins(ch) + 1);
+              someHowNoisyC[make_pair(ch.wheel(), ch.station())] = hsomeHowNoisyC;
+            }
+
+            if (noisyC.find(make_pair(ch.wheel(), ch.station())) == noisyC.end()) {
+              TString histoName_noisy = "noisyCell_W" + wheel + "_St" + station;
+              hnoisyC = new TH1F(histoName_noisy, histoName_noisy, getMaxNumBins(ch), 1, getMaxNumBins(ch) + 1);
+              noisyC[make_pair(ch.wheel(), ch.station())] = hnoisyC;
+            }
+
+            //to fill a map with the average noise per wire and fill new noise histo
+            if (AvNoisePerSuperLayer.find(dtLId.superlayerId()) == AvNoisePerSuperLayer.end()) {
+              AverageNoiseName = "AverageNoise_" + getSuperLayerName(dtLId.superlayerId());
+              hAverageNoiseHisto = new TH1F(AverageNoiseName.c_str(), AverageNoiseName.c_str(), 200, 0, 10000);
+              AverageNoiseIntegratedName = "AverageNoiseIntegrated_" + getSuperLayerName(dtLId.superlayerId());
+              hAverageNoiseIntegratedHisto =
+                  new TH1F(AverageNoiseIntegratedName.c_str(), AverageNoiseIntegratedName.c_str(), 200, 0, 10000);
+              AvNoisePerSuperLayer[dtLId.superlayerId()] = hAverageNoiseHisto;
+              AvNoiseIntegratedPerSuperLayer[dtLId.superlayerId()] = hAverageNoiseIntegratedHisto;
+              if (debug) {
+                cout << "  New Average Noise Histo per SuperLayer : " << hAverageNoiseHisto->GetName() << endl;
+                cout << "  New Average Noise Integrated Histo per SuperLayer : " << hAverageNoiseHisto->GetName()
+                     << endl;
+              }
+            }
+            if (AvNoisePerChamber.find(dtLId.superlayerId().chamberId()) == AvNoisePerChamber.end()) {
+              AverageNoiseNamePerCh = "AverageNoise_" + getChamberName(dtLId);
+              hAverageNoiseHistoPerCh =
+                  new TH1F(AverageNoiseNamePerCh.c_str(), AverageNoiseNamePerCh.c_str(), 200, 0, 10000);
+              AverageNoiseIntegratedNamePerCh = "AverageNoiseIntegrated_" + getChamberName(dtLId);
+              hAverageNoiseIntegratedHistoPerCh = new TH1F(
+                  AverageNoiseIntegratedNamePerCh.c_str(), AverageNoiseIntegratedNamePerCh.c_str(), 200, 0, 10000);
+              AvNoisePerChamber[dtLId.superlayerId().chamberId()] = hAverageNoiseHistoPerCh;
+              AvNoiseIntegratedPerChamber[dtLId.superlayerId().chamberId()] = hAverageNoiseIntegratedHistoPerCh;
+              if (debug)
+                cout << "  New Average Noise Histo per chamber : " << hAverageNoiseHistoPerCh->GetName() << endl;
+            }
+
+            HistoName = "DigiOccupancy_" + getLayerName(dtLId);
+            theFile->cd();
+            hOccHisto = (TH1F *)theFile->Get(HistoName.c_str());
+            int numBin = hOccHisto->GetXaxis()->GetNbins();
+            for (int bin = 1; bin <= numBin; bin++) {
+              DTWireId wireID(dtLId, bin);
+              theAverageNoise[wireID] = hOccHisto->GetBinContent(bin);
+              if (theAverageNoise[wireID] != 0) {
+                AvNoisePerSuperLayer[dtLId.superlayerId()]->Fill(theAverageNoise[wireID]);
+                AvNoisePerChamber[dtLId.superlayerId().chamberId()]->Fill(theAverageNoise[wireID]);
+              }
+            }
+
+            //to compute the average noise per layer (excluding the noisy cells)
+            double numCell = 0;
+            double AvNoise = 0;
+            HistoName = "DigiOccupancy_" + getLayerName(dtLId);
+            theFile->cd();
+            hOccHisto = (TH1F *)theFile->Get(HistoName.c_str());
+            numBin = hOccHisto->GetXaxis()->GetNbins();
+            for (int bin = 1; bin <= numBin; bin++) {
+              DTWireId wireID(dtLId, bin);
+              theAverageNoise[wireID] = hOccHisto->GetBinContent(bin);
+              if (hOccHisto->GetBinContent(bin) < 100) {
+                numCell++;
+                AvNoise += hOccHisto->GetBinContent(bin);
+              }
+              if (hOccHisto->GetBinContent(bin) > 100 && hOccHisto->GetBinContent(bin) < 500) {
+                someHowNoisyC[make_pair(ch.wheel(), ch.station())]->Fill(bin);
+                cout << "filling somehow noisy cell" << endl;
+              }
+              if (hOccHisto->GetBinContent(bin) > 500) {
+                noisyC[make_pair(ch.wheel(), ch.station())]->Fill(bin);
+                cout << "filling noisy cell" << endl;
+              }
+            }
+            AvNoise = AvNoise / numCell;
+            cout << "theAverageNoise for layer " << getLayerName(dtLId) << " is : " << AvNoise << endl;
+
+            // book the digi event plots every 1000 events
+            int updates = MaxEvents / 1000;
+            for (int evt = 0; evt < updates; evt++) {
+              Histo2Name = "DigiPerWirePerEvent_" + getLayerName(dtLId) + "_" + std::to_string(evt);
+              theFile->cd();
+              hEvtHisto = (TH2F *)theFile->Get(Histo2Name.c_str());
+              if (hEvtHisto) {
+                if (debug)
+                  cout << "  New Histo with the number of events per evt per wire: " << hEvtHisto->GetName() << endl;
+                theEvtMap[dtLId].push_back(hEvtHisto);
+              }
+            }
+
+          }  // done if the layer has digi
+        }    // loop over layers
+      }      // loop over superlayers
+    }        // loop over chambers
 
     count++;
   }
-
 }
-    
-void DTNoiseComputation::endJob(){
 
-  cout << "[DTNoiseComputation] endjob called!" <<endl;
-  TH1F *hEvtDistance=nullptr;
-  TF1 *ExpoFit = new TF1("ExpoFit","expo", 0.5, 1000.5);
-  ExpoFit->SetMarkerColor();//just silence gcc complaining about unused vars
-  TProfile *theNoiseHisto = new TProfile("theNoiseHisto","Time Constant versus Average Noise",100000,0,100000);
-  
+void DTNoiseComputation::endJob() {
+  cout << "[DTNoiseComputation] endjob called!" << endl;
+  TH1F *hEvtDistance = nullptr;
+  TF1 *ExpoFit = new TF1("ExpoFit", "expo", 0.5, 1000.5);
+  ExpoFit->SetMarkerColor();  //just silence gcc complaining about unused vars
+  TProfile *theNoiseHisto = new TProfile("theNoiseHisto", "Time Constant versus Average Noise", 100000, 0, 100000);
 
   //compute the time constant
-  for(map<DTLayerId, vector<TH2F*> >::const_iterator lHisto = theEvtMap.begin();
-      lHisto != theEvtMap.end();
-      ++lHisto) {
-    for(int bin=1; bin<(*lHisto).second[0]->GetYaxis()->GetNbins(); bin++){
+  for (map<DTLayerId, vector<TH2F *> >::const_iterator lHisto = theEvtMap.begin(); lHisto != theEvtMap.end();
+       ++lHisto) {
+    for (int bin = 1; bin < (*lHisto).second[0]->GetYaxis()->GetNbins(); bin++) {
       int distanceEvt = 1;
       DTWireId wire((*lHisto).first, bin);
-      for(int i=0; i<int((*lHisto).second.size()); i++){
-	for(int evt=1; evt<=(*lHisto).second[i]->GetXaxis()->GetNbins(); evt++){
-	  if((*lHisto).second[i]->GetBinContent(evt,bin) == 0) distanceEvt++;
-	  else { 
-	    if(toDel.find(wire) == toDel.end()) {
-	      toDel[wire] = false;
-	      string Histo = "EvtDistancePerWire_" + getLayerName((*lHisto).first) + "_" + std::to_string(bin);
-	      hEvtDistance = new TH1F(Histo.c_str(),Histo.c_str(), 50000,0.5,50000.5);
-	    }
-	    hEvtDistance->Fill(distanceEvt); 
-	    distanceEvt=1;
-	  }
-	}
+      for (int i = 0; i < int((*lHisto).second.size()); i++) {
+        for (int evt = 1; evt <= (*lHisto).second[i]->GetXaxis()->GetNbins(); evt++) {
+          if ((*lHisto).second[i]->GetBinContent(evt, bin) == 0)
+            distanceEvt++;
+          else {
+            if (toDel.find(wire) == toDel.end()) {
+              toDel[wire] = false;
+              string Histo = "EvtDistancePerWire_" + getLayerName((*lHisto).first) + "_" + std::to_string(bin);
+              hEvtDistance = new TH1F(Histo.c_str(), Histo.c_str(), 50000, 0.5, 50000.5);
+            }
+            hEvtDistance->Fill(distanceEvt);
+            distanceEvt = 1;
+          }
+        }
       }
-      if(toDel.find(wire) != toDel.end()){
-	theHistoEvtDistancePerWire[wire] =  hEvtDistance;
-	theNewFile->cd();
-	theHistoEvtDistancePerWire[wire]->Fit("ExpoFit","R");
-	TF1* funct = theHistoEvtDistancePerWire[wire]->GetFunction("ExpoFit");
-	double par0 = funct->GetParameter(0);
-	double par1 = funct->GetParameter(1);
-	cout<<"par0: "<<par0<<"  par1: "<<par1<<endl;
-	double chi2rid = funct->GetChisquare()/funct->GetNDF();
-	if(chi2rid>10)
-	  theTimeConstant[wire]=1;
-	else
-	  theTimeConstant[wire]=par1;
-	toDel[wire] = true;
-	theHistoEvtDistancePerWire[wire]->Write();
-	delete hEvtDistance;
+      if (toDel.find(wire) != toDel.end()) {
+        theHistoEvtDistancePerWire[wire] = hEvtDistance;
+        theNewFile->cd();
+        theHistoEvtDistancePerWire[wire]->Fit("ExpoFit", "R");
+        TF1 *funct = theHistoEvtDistancePerWire[wire]->GetFunction("ExpoFit");
+        double par0 = funct->GetParameter(0);
+        double par1 = funct->GetParameter(1);
+        cout << "par0: " << par0 << "  par1: " << par1 << endl;
+        double chi2rid = funct->GetChisquare() / funct->GetNDF();
+        if (chi2rid > 10)
+          theTimeConstant[wire] = 1;
+        else
+          theTimeConstant[wire] = par1;
+        toDel[wire] = true;
+        theHistoEvtDistancePerWire[wire]->Write();
+        delete hEvtDistance;
       }
     }
   }
 
-  if(!fastAnalysis){
+  if (!fastAnalysis) {
     //fill the histo with the time constant as a function of the average noise
-    for(map<DTWireId, double>::const_iterator AvNoise = theAverageNoise.begin();
-	AvNoise != theAverageNoise.end();
-	++AvNoise) {
+    for (map<DTWireId, double>::const_iterator AvNoise = theAverageNoise.begin(); AvNoise != theAverageNoise.end();
+         ++AvNoise) {
       DTWireId wire = (*AvNoise).first;
       theNoiseHisto->Fill((*AvNoise).second, theTimeConstant[wire]);
-      cout<<"Layer: "<<getLayerName(wire.layerId())<<"  wire: "<<wire.wire()<<endl;
-      cout<<"The Average noise: "<<(*AvNoise).second<<endl;
-      cout<<"The time constant: "<<theTimeConstant[wire]<<endl;
+      cout << "Layer: " << getLayerName(wire.layerId()) << "  wire: " << wire.wire() << endl;
+      cout << "The Average noise: " << (*AvNoise).second << endl;
+      cout << "The time constant: " << theTimeConstant[wire] << endl;
     }
     theNewFile->cd();
     theNoiseHisto->Write();
-  }  
-
+  }
 
   // histos with the integrated noise per layer
   int numBin;
   double integratedNoise, bin, halfBin, maxBin;
-  for(map<DTSuperLayerId, TH1F*>::const_iterator AvNoiseHisto = AvNoisePerSuperLayer.begin();
-      AvNoiseHisto != AvNoisePerSuperLayer.end();
-      ++AvNoiseHisto) {
-    integratedNoise=0;
+  for (map<DTSuperLayerId, TH1F *>::const_iterator AvNoiseHisto = AvNoisePerSuperLayer.begin();
+       AvNoiseHisto != AvNoisePerSuperLayer.end();
+       ++AvNoiseHisto) {
+    integratedNoise = 0;
     numBin = (*AvNoiseHisto).second->GetXaxis()->GetNbins();
     maxBin = (*AvNoiseHisto).second->GetXaxis()->GetXmax();
-    bin= double(maxBin/numBin);
-    halfBin=double(bin/2);
+    bin = double(maxBin / numBin);
+    halfBin = double(bin / 2);
     theNewFile->cd();
     (*AvNoiseHisto).second->Write();
-    for(int i=1; i<numBin; i++){
-      integratedNoise+=(*AvNoiseHisto).second->GetBinContent(i);
-      AvNoiseIntegratedPerSuperLayer[(*AvNoiseHisto).first]->Fill(halfBin,integratedNoise);
-      halfBin+=bin;
+    for (int i = 1; i < numBin; i++) {
+      integratedNoise += (*AvNoiseHisto).second->GetBinContent(i);
+      AvNoiseIntegratedPerSuperLayer[(*AvNoiseHisto).first]->Fill(halfBin, integratedNoise);
+      halfBin += bin;
     }
     theNewFile->cd();
-    AvNoiseIntegratedPerSuperLayer[(*AvNoiseHisto).first]->Write(); 
+    AvNoiseIntegratedPerSuperLayer[(*AvNoiseHisto).first]->Write();
   }
   // histos with the integrated noise per chamber
-  for(map<DTChamberId, TH1F*>::const_iterator AvNoiseHisto = AvNoisePerChamber.begin();
-      AvNoiseHisto != AvNoisePerChamber.end();
-      ++AvNoiseHisto) {
-    integratedNoise=0;
+  for (map<DTChamberId, TH1F *>::const_iterator AvNoiseHisto = AvNoisePerChamber.begin();
+       AvNoiseHisto != AvNoisePerChamber.end();
+       ++AvNoiseHisto) {
+    integratedNoise = 0;
     numBin = (*AvNoiseHisto).second->GetXaxis()->GetNbins();
     maxBin = (*AvNoiseHisto).second->GetXaxis()->GetXmax();
-    bin= maxBin/numBin;
-    halfBin=bin/2;
+    bin = maxBin / numBin;
+    halfBin = bin / 2;
     theNewFile->cd();
     (*AvNoiseHisto).second->Write();
-    for(int i=1; i<numBin; i++){
-      integratedNoise+=(*AvNoiseHisto).second->GetBinContent(i);
-      AvNoiseIntegratedPerChamber[(*AvNoiseHisto).first]->Fill(halfBin,integratedNoise);
-      halfBin+=bin;
-    } 
+    for (int i = 1; i < numBin; i++) {
+      integratedNoise += (*AvNoiseHisto).second->GetBinContent(i);
+      AvNoiseIntegratedPerChamber[(*AvNoiseHisto).first]->Fill(halfBin, integratedNoise);
+      halfBin += bin;
+    }
     theNewFile->cd();
-    AvNoiseIntegratedPerChamber[(*AvNoiseHisto).first]->Write(); 
+    AvNoiseIntegratedPerChamber[(*AvNoiseHisto).first]->Write();
   }
 
-  
   //overimpose the average noise histo
-  bool histo=false;
-  vector<const DTChamber*>::const_iterator chamber_it = dtGeom->chambers().begin();
-  vector<const DTChamber*>::const_iterator chamber_end = dtGeom->chambers().end();
+  bool histo = false;
+  vector<const DTChamber *>::const_iterator chamber_it = dtGeom->chambers().begin();
+  vector<const DTChamber *>::const_iterator chamber_end = dtGeom->chambers().end();
   // Loop over the chambers
   for (; chamber_it != chamber_end; ++chamber_it) {
-    vector<const DTSuperLayer*>::const_iterator sl_it = (*chamber_it)->superLayers().begin(); 
-    vector<const DTSuperLayer*>::const_iterator sl_end = (*chamber_it)->superLayers().end();
+    vector<const DTSuperLayer *>::const_iterator sl_it = (*chamber_it)->superLayers().begin();
+    vector<const DTSuperLayer *>::const_iterator sl_end = (*chamber_it)->superLayers().end();
     // Loop over the SLs
-    for(; sl_it != sl_end; ++sl_it) {
+    for (; sl_it != sl_end; ++sl_it) {
       DTSuperLayerId sl = (*sl_it)->id();
-      vector<const DTLayer*>::const_iterator l_it = (*sl_it)->layers().begin(); 
-      vector<const DTLayer*>::const_iterator l_end = (*sl_it)->layers().end();
+      vector<const DTLayer *>::const_iterator l_it = (*sl_it)->layers().begin();
+      vector<const DTLayer *>::const_iterator l_end = (*sl_it)->layers().end();
 
-      string canvasName = "c" + getSuperLayerName(sl); 
-      TCanvas c1(canvasName.c_str(),canvasName.c_str(),600,780);
-      TLegend *leg=new TLegend(0.5,0.6,0.7,0.8);
-      for(; l_it != l_end; ++l_it) {
-	DTLayerId layerId = (*l_it)->id();
-	string HistoName = "DigiOccupancy_" + getLayerName(layerId);
-	theFile->cd();
-	TH1F *hOccHisto = (TH1F *) theFile->Get(HistoName.c_str());
-	if(hOccHisto){
-	  string TitleHisto = "AverageNoise_" + getSuperLayerName(sl);
-	  cout<<"TitleHisto : "<<TitleHisto<<endl;
-	  hOccHisto->SetTitle(TitleHisto.c_str());
-	  string legendHisto = "layer " + std::to_string(layerId.layer());
-	  leg->AddEntry(hOccHisto,legendHisto.c_str(),"L");
-	  hOccHisto->SetMaximum(getYMaximum(sl));
-	  histo=true;
-	  if(layerId.layer() == 1)
-	    hOccHisto->Draw();
-	  else
-	    hOccHisto->Draw("same");
-	  hOccHisto->SetLineColor(layerId.layer());
-	}
+      string canvasName = "c" + getSuperLayerName(sl);
+      TCanvas c1(canvasName.c_str(), canvasName.c_str(), 600, 780);
+      TLegend *leg = new TLegend(0.5, 0.6, 0.7, 0.8);
+      for (; l_it != l_end; ++l_it) {
+        DTLayerId layerId = (*l_it)->id();
+        string HistoName = "DigiOccupancy_" + getLayerName(layerId);
+        theFile->cd();
+        TH1F *hOccHisto = (TH1F *)theFile->Get(HistoName.c_str());
+        if (hOccHisto) {
+          string TitleHisto = "AverageNoise_" + getSuperLayerName(sl);
+          cout << "TitleHisto : " << TitleHisto << endl;
+          hOccHisto->SetTitle(TitleHisto.c_str());
+          string legendHisto = "layer " + std::to_string(layerId.layer());
+          leg->AddEntry(hOccHisto, legendHisto.c_str(), "L");
+          hOccHisto->SetMaximum(getYMaximum(sl));
+          histo = true;
+          if (layerId.layer() == 1)
+            hOccHisto->Draw();
+          else
+            hOccHisto->Draw("same");
+          hOccHisto->SetLineColor(layerId.layer());
+        }
       }
-      if(histo){
-	leg->Draw("same");
-	theNewFile->cd();
-	c1.Write();
+      if (histo) {
+        leg->Draw("same");
+        theNewFile->cd();
+        c1.Write();
       }
     }
-    histo=false;   
+    histo = false;
   }
 
   //write on file the noisy plots
-  for(map<pair<int,int>, TH1F*>::const_iterator nCell = noisyC.begin();
-      nCell != noisyC.end();
-      ++nCell) {
+  for (map<pair<int, int>, TH1F *>::const_iterator nCell = noisyC.begin(); nCell != noisyC.end(); ++nCell) {
     theNewFile->cd();
     (*nCell).second->Write();
   }
-  for(map<pair<int,int>, TH1F*>::const_iterator somehownCell = someHowNoisyC.begin();
-      somehownCell != someHowNoisyC.end();
-      ++somehownCell) {
+  for (map<pair<int, int>, TH1F *>::const_iterator somehownCell = someHowNoisyC.begin();
+       somehownCell != someHowNoisyC.end();
+       ++somehownCell) {
     theNewFile->cd();
     (*somehownCell).second->Write();
   }
-    
 }
 
-
-DTNoiseComputation::~DTNoiseComputation(){
-
+DTNoiseComputation::~DTNoiseComputation() {
   theFile->Close();
   theNewFile->Close();
-
 }
 
-
-string DTNoiseComputation::getLayerName(const DTLayerId& lId) const {
-
-  const  DTSuperLayerId dtSLId = lId.superlayerId();
-  const  DTChamberId dtChId = dtSLId.chamberId(); 
-  string layerName = 
-    "W" + std::to_string(dtChId.wheel())
-    + "_St" + std::to_string(dtChId.station())
-    + "_Sec" + std::to_string(dtChId.sector())
-    + "_SL" + std::to_string(dtSLId.superlayer())
-    + "_L" + std::to_string(lId.layer());
+string DTNoiseComputation::getLayerName(const DTLayerId &lId) const {
+  const DTSuperLayerId dtSLId = lId.superlayerId();
+  const DTChamberId dtChId = dtSLId.chamberId();
+  string layerName = "W" + std::to_string(dtChId.wheel()) + "_St" + std::to_string(dtChId.station()) + "_Sec" +
+                     std::to_string(dtChId.sector()) + "_SL" + std::to_string(dtSLId.superlayer()) + "_L" +
+                     std::to_string(lId.layer());
 
   return layerName;
 }
 
+string DTNoiseComputation::getSuperLayerName(const DTSuperLayerId &dtSLId) const {
+  const DTChamberId dtChId = dtSLId.chamberId();
 
-string DTNoiseComputation::getSuperLayerName(const DTSuperLayerId& dtSLId) const {
-
-  const  DTChamberId dtChId = dtSLId.chamberId(); 
-
-  string superLayerName = 
-    "W" + std::to_string(dtChId.wheel())
-    + "_St" + std::to_string(dtChId.station())
-    + "_Sec" + std::to_string(dtChId.sector())
-    + "_SL" + std::to_string(dtSLId.superlayer());
+  string superLayerName = "W" + std::to_string(dtChId.wheel()) + "_St" + std::to_string(dtChId.station()) + "_Sec" +
+                          std::to_string(dtChId.sector()) + "_SL" + std::to_string(dtSLId.superlayer());
 
   return superLayerName;
 }
 
-
-string DTNoiseComputation::getChamberName(const DTLayerId& lId) const {
-
-  const  DTSuperLayerId dtSLId = lId.superlayerId();
-  const  DTChamberId dtChId = dtSLId.chamberId(); 
-  string chamberName =
-    "W" + std::to_string(dtChId.wheel())
-    + "_St" + std::to_string(dtChId.station())
-    + "_Sec" + std::to_string(dtChId.sector());
+string DTNoiseComputation::getChamberName(const DTLayerId &lId) const {
+  const DTSuperLayerId dtSLId = lId.superlayerId();
+  const DTChamberId dtChId = dtSLId.chamberId();
+  string chamberName = "W" + std::to_string(dtChId.wheel()) + "_St" + std::to_string(dtChId.station()) + "_Sec" +
+                       std::to_string(dtChId.sector());
 
   return chamberName;
 }
 
+int DTNoiseComputation::getMaxNumBins(const DTChamberId &chId) const {
+  int maximum = 0;
 
-int DTNoiseComputation::getMaxNumBins(const DTChamberId& chId) const {
-  
-  int maximum=0;
-  
-  for(int SL=1; SL<=3; SL++){
-    if(!(chId.station()==4 && SL==2)){
-      for (int L=1; L<=4; L++){	
-	DTLayerId layerId = DTLayerId(chId, SL, L);
-	string HistoName = "DigiOccupancy_" + getLayerName(layerId);
-	theFile->cd();
-	TH1F *hOccHisto = (TH1F *) theFile->Get(HistoName.c_str());
-	if(hOccHisto){
-	  if (hOccHisto->GetXaxis()->GetXmax()>maximum) 
-	    maximum = hOccHisto->GetXaxis()->GetNbins();
-	}
+  for (int SL = 1; SL <= 3; SL++) {
+    if (!(chId.station() == 4 && SL == 2)) {
+      for (int L = 1; L <= 4; L++) {
+        DTLayerId layerId = DTLayerId(chId, SL, L);
+        string HistoName = "DigiOccupancy_" + getLayerName(layerId);
+        theFile->cd();
+        TH1F *hOccHisto = (TH1F *)theFile->Get(HistoName.c_str());
+        if (hOccHisto) {
+          if (hOccHisto->GetXaxis()->GetXmax() > maximum)
+            maximum = hOccHisto->GetXaxis()->GetNbins();
+        }
       }
     }
   }
   return maximum;
 }
 
+double DTNoiseComputation::getYMaximum(const DTSuperLayerId &slId) const {
+  double maximum = 0;
+  double dummy = pow(10., 10.);
 
-double DTNoiseComputation::getYMaximum(const DTSuperLayerId& slId) const {
-  
-  double maximum=0;
-  double dummy = pow(10.,10.);
-
-  for (int L=1; L<=4; L++){
+  for (int L = 1; L <= 4; L++) {
     DTLayerId layerId = DTLayerId(slId, L);
     string HistoName = "DigiOccupancy_" + getLayerName(layerId);
     theFile->cd();
-    TH1F *hOccHisto = (TH1F *) theFile->Get(HistoName.c_str());
-    if(hOccHisto){
-      if (hOccHisto->GetMaximum(dummy)>maximum)
+    TH1F *hOccHisto = (TH1F *)theFile->Get(HistoName.c_str());
+    if (hOccHisto) {
+      if (hOccHisto->GetMaximum(dummy) > maximum)
         maximum = hOccHisto->GetMaximum(dummy);
     }
   }
   return maximum;
 }
-
-
-

--- a/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
@@ -15,8 +15,6 @@
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-
-
 #include <string>
 #include <map>
 #include <vector>
@@ -25,20 +23,18 @@ namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 class DTGeometry;
 class TFile;
 class TH2F;
 class TH1F;
 
-class DTNoiseComputation: public edm::EDAnalyzer{
-  
- public:
-  
+class DTNoiseComputation : public edm::EDAnalyzer {
+public:
   /// Constructor
   DTNoiseComputation(const edm::ParameterSet& ps);
-  
+
   /// Destructor
   ~DTNoiseComputation() override;
 
@@ -52,42 +48,39 @@ class DTNoiseComputation: public edm::EDAnalyzer{
   /// Endjob
   void endJob() override;
 
-
 protected:
-
 private:
-
   bool debug;
   int counter;
   int MaxEvents;
   bool fastAnalysis;
-  
+
   // Get the DT Geometry
   edm::ESHandle<DTGeometry> dtGeom;
 
   // The file which contain the occupancy plot and the digi event plot
-  TFile *theFile;
-  
+  TFile* theFile;
+
   // The file which will contain the occupancy plot and the digi event plot
-  TFile *theNewFile;
+  TFile* theNewFile;
 
   // Map of label to compute the average noise per layer
-  std::map<DTLayerId , bool> toComputeNoiseAverage;
+  std::map<DTLayerId, bool> toComputeNoiseAverage;
 
   // Map of the average noise per layer
-  std::map<DTWireId , double>  theAverageNoise;
+  std::map<DTWireId, double> theAverageNoise;
 
-   // Map of the histograms with the number of events per evt per wire
+  // Map of the histograms with the number of events per evt per wire
   std::map<DTLayerId, std::vector<TH2F*> > theEvtMap;
 
   // map of histos with the distance of event per wire
   std::map<DTWireId, TH1F*> theHistoEvtDistancePerWire;
-  
+
   // Map of label for analysis histos
-  std::map<DTWireId , bool> toDel;
+  std::map<DTWireId, bool> toDel;
 
   // Map of the Time Constants per wire
-  std::map<DTWireId , double> theTimeConstant;
+  std::map<DTWireId, double> theTimeConstant;
 
   /// Get the name of the layer
   std::string getLayerName(const DTLayerId& lId) const;
@@ -97,7 +90,7 @@ private:
 
   /// Get the name of the chamber
   std::string getChamberName(const DTLayerId& lId) const;
-  
+
   // map of histos with the average noise per chamber
   std::map<DTChamberId, TH1F*> AvNoisePerChamber;
 
@@ -112,15 +105,14 @@ private:
 
   // get the maximum bin number
   int getMaxNumBins(const DTChamberId& chId) const;
-  
+
   // get the Y axis maximum
   double getYMaximum(const DTSuperLayerId& slId) const;
 
   // map of noisy cell occupancy
-  std::map< std::pair<int,int> , TH1F*> noisyC;
+  std::map<std::pair<int, int>, TH1F*> noisyC;
 
   // map of somehow noisy cell occupancy
-  std::map< std::pair<int,int> , TH1F*> someHowNoisyC;
-
+  std::map<std::pair<int, int>, TH1F*> someHowNoisyC;
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTResidualCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTResidualCalibration.cc
@@ -31,24 +31,23 @@
 
 #include <algorithm>
 
-DTResidualCalibration::DTResidualCalibration(const edm::ParameterSet& pset):
-  histRange_(pset.getParameter<double>("histogramRange")),
-  segment4DLabel_(pset.getParameter<edm::InputTag>("segment4DLabel")),
-  rootBaseDir_(pset.getUntrackedParameter<std::string>("rootBaseDir","DT/Residuals")),
-  detailedAnalysis_(pset.getUntrackedParameter<bool>("detailedAnalysis",false)) {
-
+DTResidualCalibration::DTResidualCalibration(const edm::ParameterSet& pset)
+    : histRange_(pset.getParameter<double>("histogramRange")),
+      segment4DLabel_(pset.getParameter<edm::InputTag>("segment4DLabel")),
+      rootBaseDir_(pset.getUntrackedParameter<std::string>("rootBaseDir", "DT/Residuals")),
+      detailedAnalysis_(pset.getUntrackedParameter<bool>("detailedAnalysis", false)) {
   edm::ConsumesCollector collector(consumesCollector());
-  select_ = new DTSegmentSelector(pset,collector);
+  select_ = new DTSegmentSelector(pset, collector);
 
   LogDebug("Calibration") << "[DTResidualCalibration] Constructor called.";
-  consumes< DTRecSegment4DCollection >(edm::InputTag(segment4DLabel_));
-  std::string rootFileName = pset.getUntrackedParameter<std::string>("rootFileName","residuals.root");
+  consumes<DTRecSegment4DCollection>(edm::InputTag(segment4DLabel_));
+  std::string rootFileName = pset.getUntrackedParameter<std::string>("rootFileName", "residuals.root");
   rootFile_ = new TFile(rootFileName.c_str(), "RECREATE");
   rootFile_->cd();
 
-  segmok=0;
-  segmbad=0;
-  nevent=0;
+  segmok = 0;
+  segmbad = 0;
+  nevent = 0;
 }
 
 DTResidualCalibration::~DTResidualCalibration() {
@@ -59,25 +58,22 @@ DTResidualCalibration::~DTResidualCalibration() {
   edm::LogVerbatim("Calibration") << "[DTResidualCalibration] Bad segments: " << segmbad;
 }
 
-void DTResidualCalibration::beginJob() {
-  TH1::SetDefaultSumw2(true);
-}
+void DTResidualCalibration::beginJob() { TH1::SetDefaultSumw2(true); }
 
 void DTResidualCalibration::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
-
   // get the geometry
-  edm::ESHandle<DTGeometry> dtGeomH; 
+  edm::ESHandle<DTGeometry> dtGeomH;
   setup.get<MuonGeometryRecord>().get(dtGeomH);
   dtGeom_ = dtGeomH.product();
 
   // Loop over all the chambers
-  if(histoMapTH1F_.empty()) {
+  if (histoMapTH1F_.empty()) {
     for (auto ch_it : dtGeom_->chambers()) {
       // Loop over the SLs
       for (auto sl_it : ch_it->superLayers()) {
         DTSuperLayerId slId = (sl_it)->id();
         bookHistos(slId);
-        if(detailedAnalysis_) {
+        if (detailedAnalysis_) {
           for (auto layer_it : (sl_it)->layers()) {
             DTLayerId layerId = (layer_it)->id();
             bookHistos(layerId);
@@ -89,7 +85,6 @@ void DTResidualCalibration::beginRun(const edm::Run& run, const edm::EventSetup&
 }
 
 void DTResidualCalibration::analyze(const edm::Event& event, const edm::EventSetup& setup) {
-
   rootFile_->cd();
   ++nevent;
 
@@ -99,58 +94,60 @@ void DTResidualCalibration::analyze(const edm::Event& event, const edm::EventSet
 
   // Loop over segments by chamber
   DTRecSegment4DCollection::id_iterator chamberIdIt;
-  for(chamberIdIt = segments4D->id_begin(); chamberIdIt != segments4D->id_end(); ++chamberIdIt){
+  for (chamberIdIt = segments4D->id_begin(); chamberIdIt != segments4D->id_end(); ++chamberIdIt) {
+    const DTChamber* chamber = dtGeom_->chamber(*chamberIdIt);
 
-     const DTChamber* chamber = dtGeom_->chamber(*chamberIdIt);
+    // Get the range for the corresponding ChamberId
+    DTRecSegment4DCollection::range range = segments4D->get((*chamberIdIt));
+    // Loop over the rechits of this DetUnit
+    for (DTRecSegment4DCollection::const_iterator segment = range.first; segment != range.second; ++segment) {
+      LogTrace("Calibration") << "Segment local pos (in chamber RF): " << (*segment).localPosition()
+                              << "\nSegment global pos: " << chamber->toGlobal((*segment).localPosition());
 
-     // Get the range for the corresponding ChamberId
-     DTRecSegment4DCollection::range range = segments4D->get((*chamberIdIt));
-     // Loop over the rechits of this DetUnit
-     for(DTRecSegment4DCollection::const_iterator segment  = range.first;
-                                                  segment != range.second; ++segment){
+      if (!(*select_)(*segment, event, setup)) {
+        segmbad++;
+        continue;
+      }
+      segmok++;
 
-        LogTrace("Calibration") << "Segment local pos (in chamber RF): " << (*segment).localPosition()
-                                << "\nSegment global pos: " << chamber->toGlobal((*segment).localPosition());
+      // Get all 1D RecHits at step 3 within the 4D segment
+      std::vector<DTRecHit1D> recHits1D_S3;
 
-        if( !(*select_)(*segment, event, setup) ) { segmbad++; continue; }
-        segmok++;
+      if ((*segment).hasPhi()) {
+        const DTChamberRecSegment2D* phiSeg = (*segment).phiSegment();
+        const std::vector<DTRecHit1D>& phiRecHits = phiSeg->specificRecHits();
+        std::copy(phiRecHits.begin(), phiRecHits.end(), back_inserter(recHits1D_S3));
+      }
 
-        // Get all 1D RecHits at step 3 within the 4D segment
-        std::vector<DTRecHit1D> recHits1D_S3;
+      if ((*segment).hasZed()) {
+        const DTSLRecSegment2D* zSeg = (*segment).zSegment();
+        const std::vector<DTRecHit1D>& zRecHits = zSeg->specificRecHits();
+        std::copy(zRecHits.begin(), zRecHits.end(), back_inserter(recHits1D_S3));
+      }
 
-        if( (*segment).hasPhi() ){
-           const DTChamberRecSegment2D* phiSeg = (*segment).phiSegment();
-           const std::vector<DTRecHit1D>& phiRecHits = phiSeg->specificRecHits();
-           std::copy(phiRecHits.begin(), phiRecHits.end(), back_inserter(recHits1D_S3));
-        }
+      // Loop over 1D RecHit inside 4D segment
+      for (std::vector<DTRecHit1D>::const_iterator recHit1D = recHits1D_S3.begin(); recHit1D != recHits1D_S3.end();
+           ++recHit1D) {
+        const DTWireId wireId = recHit1D->wireId();
 
-        if( (*segment).hasZed() ){
-           const DTSLRecSegment2D* zSeg = (*segment).zSegment();
-           const std::vector<DTRecHit1D>& zRecHits = zSeg->specificRecHits();
-           std::copy(zRecHits.begin(), zRecHits.end(), back_inserter(recHits1D_S3));
-        }
+        float segmDistance = segmentToWireDistance(*recHit1D, *segment);
+        if (segmDistance > 2.1)
+          LogTrace("Calibration") << "WARNING: segment-wire distance: " << segmDistance;
+        else
+          LogTrace("Calibration") << "segment-wire distance: " << segmDistance;
 
-        // Loop over 1D RecHit inside 4D segment
-        for(std::vector<DTRecHit1D>::const_iterator recHit1D = recHits1D_S3.begin();
-                                                    recHit1D != recHits1D_S3.end(); ++recHit1D) {
-           const DTWireId wireId = recHit1D->wireId();
+        float residualOnDistance = DTRecHitSegmentResidual().compute(dtGeom_, *recHit1D, *segment);
+        LogTrace("Calibration") << "Wire Id " << wireId << " residual on distance: " << residualOnDistance;
 
-           float segmDistance = segmentToWireDistance(*recHit1D,*segment);
-           if(segmDistance > 2.1) LogTrace("Calibration") << "WARNING: segment-wire distance: " << segmDistance;
-           else                   LogTrace("Calibration") << "segment-wire distance: " << segmDistance;
-
-           float residualOnDistance = DTRecHitSegmentResidual().compute(dtGeom_,*recHit1D,*segment);
-           LogTrace("Calibration") << "Wire Id " << wireId << " residual on distance: " << residualOnDistance;
-
-           fillHistos(wireId.superlayerId(), segmDistance, residualOnDistance);
-           if(detailedAnalysis_) fillHistos(wireId.layerId(), segmDistance, residualOnDistance);
-        }
-     }
+        fillHistos(wireId.superlayerId(), segmDistance, residualOnDistance);
+        if (detailedAnalysis_)
+          fillHistos(wireId.layerId(), segmDistance, residualOnDistance);
+      }
+    }
   }
 }
 
-float DTResidualCalibration::segmentToWireDistance(const DTRecHit1D& recHit1D, const DTRecSegment4D& segment){
-
+float DTResidualCalibration::segmentToWireDistance(const DTRecHit1D& recHit1D, const DTRecSegment4D& segment) {
   // Get the layer and the wire position
   const DTWireId wireId = recHit1D.wireId();
   const DTLayer* layer = dtGeom_->layer(wireId);
@@ -159,25 +156,27 @@ float DTResidualCalibration::segmentToWireDistance(const DTRecHit1D& recHit1D, c
   // Extrapolate the segment to the z of the wire
   // Get wire position in chamber RF
   // (y and z must be those of the hit to be coherent in the transf. of RF in case of rotations of the layer alignment)
-  LocalPoint wirePosInLay(wireX,recHit1D.localPosition().y(),recHit1D.localPosition().z());
+  LocalPoint wirePosInLay(wireX, recHit1D.localPosition().y(), recHit1D.localPosition().z());
   GlobalPoint wirePosGlob = layer->toGlobal(wirePosInLay);
   const DTChamber* chamber = dtGeom_->chamber(wireId.layerId().chamberId());
   LocalPoint wirePosInChamber = chamber->toLocal(wirePosGlob);
 
   // Segment position at Wire z in chamber local frame
-  LocalPoint segPosAtZWire = segment.localPosition() + segment.localDirection()*wirePosInChamber.z()/cos(segment.localDirection().theta());
+  LocalPoint segPosAtZWire =
+      segment.localPosition() + segment.localDirection() * wirePosInChamber.z() / cos(segment.localDirection().theta());
 
   // Compute the distance of the segment from the wire
   int sl = wireId.superlayer();
   float segmDistance = -1;
-  if(sl == 1 || sl == 3) segmDistance = fabs(wirePosInChamber.x() - segPosAtZWire.x());
-  else if(sl == 2)       segmDistance =  fabs(segPosAtZWire.y() - wirePosInChamber.y());
+  if (sl == 1 || sl == 3)
+    segmDistance = fabs(wirePosInChamber.x() - segPosAtZWire.x());
+  else if (sl == 2)
+    segmDistance = fabs(segPosAtZWire.y() - wirePosInChamber.y());
 
   return segmDistance;
 }
 
-void DTResidualCalibration::endJob(){
-  
+void DTResidualCalibration::endJob() {
   LogDebug("Calibration") << "[DTResidualCalibration] Writing histos to file.";
   rootFile_->cd();
   rootFile_->Write();
@@ -194,7 +193,6 @@ void DTResidualCalibration::endJob(){
      std::vector<TH2F*>::const_iterator itHistTH2F_end = histoMapTH2F_[(*itSlHistos).first].end();
      for(; itHistTH2F != itHistTH2F_end; ++itHistTH2F) (*itHistTH2F)->Write();
   }*/
-
 }
 
 void DTResidualCalibration::bookHistos(DTSuperLayerId slId) {
@@ -211,35 +209,42 @@ void DTResidualCalibration::bookHistos(DTSuperLayerId slId) {
   std::string stationStr = std::to_string(slId.station());
   std::string sectorStr = std::to_string(slId.sector());
 
-  std::string slHistoName =
-    "_STEP" + std::to_string(step) +
-    "_W" + wheelStr +
-    "_St" + stationStr +
-    "_Sec" +  sectorStr +
-    "_SL" + std::to_string(slId.superlayer());
+  std::string slHistoName = "_STEP" + std::to_string(step) + "_W" + wheelStr + "_St" + stationStr + "_Sec" + sectorStr +
+                            "_SL" + std::to_string(slId.superlayer());
 
   LogDebug("Calibration") << "Accessing " << rootBaseDir_;
   TDirectory* baseDir = rootFile_->GetDirectory(rootBaseDir_.c_str());
-  if(!baseDir) baseDir = rootFile_->mkdir(rootBaseDir_.c_str());
+  if (!baseDir)
+    baseDir = rootFile_->mkdir(rootBaseDir_.c_str());
   LogDebug("Calibration") << "Accessing " << ("Wheel" + wheelStr);
   TDirectory* wheelDir = baseDir->GetDirectory(("Wheel" + wheelStr).c_str());
-  if(!wheelDir) wheelDir = baseDir->mkdir(("Wheel" + wheelStr).c_str());
+  if (!wheelDir)
+    wheelDir = baseDir->mkdir(("Wheel" + wheelStr).c_str());
   LogDebug("Calibration") << "Accessing " << ("Station" + stationStr);
   TDirectory* stationDir = wheelDir->GetDirectory(("Station" + stationStr).c_str());
-  if(!stationDir) stationDir = wheelDir->mkdir(("Station" + stationStr).c_str());
+  if (!stationDir)
+    stationDir = wheelDir->mkdir(("Station" + stationStr).c_str());
   LogDebug("Calibration") << "Accessing " << ("Sector" + sectorStr);
   TDirectory* sectorDir = stationDir->GetDirectory(("Sector" + sectorStr).c_str());
-  if(!sectorDir) sectorDir = stationDir->mkdir(("Sector" + sectorStr).c_str()); 
+  if (!sectorDir)
+    sectorDir = stationDir->mkdir(("Sector" + sectorStr).c_str());
 
   sectorDir->cd();
 
   // Create the monitor elements
-  TH1F* histosTH1F =  new TH1F(("hResDist"+slHistoName).c_str(),
-                                 "Residuals on the distance from wire (rec_hit - segm_extr) (cm)",
-                                 200, -histRange_, histRange_);
-  TH2F* histosTH2F = new TH2F(("hResDistVsDist"+slHistoName).c_str(),
-                                 "Residuals on the dist. (cm) from wire (rec_hit - segm_extr) vs dist. (cm)",
-                                 100, 0, 2.5, 200, -histRange_, histRange_);
+  TH1F* histosTH1F = new TH1F(("hResDist" + slHistoName).c_str(),
+                              "Residuals on the distance from wire (rec_hit - segm_extr) (cm)",
+                              200,
+                              -histRange_,
+                              histRange_);
+  TH2F* histosTH2F = new TH2F(("hResDistVsDist" + slHistoName).c_str(),
+                              "Residuals on the dist. (cm) from wire (rec_hit - segm_extr) vs dist. (cm)",
+                              100,
+                              0,
+                              2.5,
+                              200,
+                              -histRange_,
+                              histRange_);
   histoMapTH1F_[slId] = histosTH1F;
   histoMapTH2F_[slId] = histosTH2F;
 }
@@ -259,55 +264,57 @@ void DTResidualCalibration::bookHistos(DTLayerId layerId) {
   // Define the step
   int step = 3;
 
-  std::string layerHistoName =
-    "_STEP" + std::to_string(step) +
-    "_W" + wheelStr +
-    "_St" + stationStr +
-    "_Sec" + sectorStr +
-    "_SL" + superLayerStr + 
-    "_Layer" + layerStr;
-  
+  std::string layerHistoName = "_STEP" + std::to_string(step) + "_W" + wheelStr + "_St" + stationStr + "_Sec" +
+                               sectorStr + "_SL" + superLayerStr + "_Layer" + layerStr;
+
   LogDebug("Calibration") << "Accessing " << rootBaseDir_;
   TDirectory* baseDir = rootFile_->GetDirectory(rootBaseDir_.c_str());
-  if(!baseDir) baseDir = rootFile_->mkdir(rootBaseDir_.c_str());
+  if (!baseDir)
+    baseDir = rootFile_->mkdir(rootBaseDir_.c_str());
   LogDebug("Calibration") << "Accessing " << ("Wheel" + wheelStr);
   TDirectory* wheelDir = baseDir->GetDirectory(("Wheel" + wheelStr).c_str());
-  if(!wheelDir) wheelDir = baseDir->mkdir(("Wheel" + wheelStr).c_str());
+  if (!wheelDir)
+    wheelDir = baseDir->mkdir(("Wheel" + wheelStr).c_str());
   LogDebug("Calibration") << "Accessing " << ("Station" + stationStr);
   TDirectory* stationDir = wheelDir->GetDirectory(("Station" + stationStr).c_str());
-  if(!stationDir) stationDir = wheelDir->mkdir(("Station" + stationStr).c_str());
+  if (!stationDir)
+    stationDir = wheelDir->mkdir(("Station" + stationStr).c_str());
   LogDebug("Calibration") << "Accessing " << ("Sector" + sectorStr);
   TDirectory* sectorDir = stationDir->GetDirectory(("Sector" + sectorStr).c_str());
-  if(!sectorDir) sectorDir = stationDir->mkdir(("Sector" + sectorStr).c_str()); 
+  if (!sectorDir)
+    sectorDir = stationDir->mkdir(("Sector" + sectorStr).c_str());
   LogDebug("Calibration") << "Accessing " << ("SL" + superLayerStr);
   TDirectory* superLayerDir = sectorDir->GetDirectory(("SL" + superLayerStr).c_str());
-  if(!superLayerDir) superLayerDir = sectorDir->mkdir(("SL" + superLayerStr).c_str()); 
+  if (!superLayerDir)
+    superLayerDir = sectorDir->mkdir(("SL" + superLayerStr).c_str());
 
   superLayerDir->cd();
   // Create histograms
-  TH1F* histosTH1F = new TH1F(("hResDist"+layerHistoName).c_str(),
-                                 "Residuals on the distance from wire (rec_hit - segm_extr) (cm)",
-                                 200, -histRange_, histRange_);
-  TH2F* histosTH2F = new TH2F(("hResDistVsDist"+layerHistoName).c_str(),
-                                 "Residuals on the dist. (cm) from wire (rec_hit - segm_extr) vs dist. (cm)",
-                                 100, 0, 2.5, 200, -histRange_, histRange_);
+  TH1F* histosTH1F = new TH1F(("hResDist" + layerHistoName).c_str(),
+                              "Residuals on the distance from wire (rec_hit - segm_extr) (cm)",
+                              200,
+                              -histRange_,
+                              histRange_);
+  TH2F* histosTH2F = new TH2F(("hResDistVsDist" + layerHistoName).c_str(),
+                              "Residuals on the dist. (cm) from wire (rec_hit - segm_extr) vs dist. (cm)",
+                              100,
+                              0,
+                              2.5,
+                              200,
+                              -histRange_,
+                              histRange_);
   histoMapPerLayerTH1F_[layerId] = histosTH1F;
   histoMapPerLayerTH2F_[layerId] = histosTH2F;
 }
 
-// Fill a set of histograms for a given SL 
-void DTResidualCalibration::fillHistos(DTSuperLayerId slId,
-                                       float distance,
-                                       float residualOnDistance) {
+// Fill a set of histograms for a given SL
+void DTResidualCalibration::fillHistos(DTSuperLayerId slId, float distance, float residualOnDistance) {
   histoMapTH1F_[slId]->Fill(residualOnDistance);
   histoMapTH2F_[slId]->Fill(distance, residualOnDistance);
 }
 
-// Fill a set of histograms for a given layer 
-void DTResidualCalibration::fillHistos(DTLayerId layerId,
-                                       float distance,
-                                       float residualOnDistance) {
+// Fill a set of histograms for a given layer
+void DTResidualCalibration::fillHistos(DTLayerId layerId, float distance, float residualOnDistance) {
   histoMapPerLayerTH1F_[layerId]->Fill(residualOnDistance);
   histoMapPerLayerTH2F_[layerId]->Fill(distance, residualOnDistance);
 }
-

--- a/CalibMuon/DTCalibration/plugins/DTResidualCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTResidualCalibration.h
@@ -25,8 +25,8 @@ class DTGeometry;
 class DTSuperLayerId;
 class DTLayerId;
 
-class DTResidualCalibration: public edm::EDAnalyzer{
- public:
+class DTResidualCalibration : public edm::EDAnalyzer {
+public:
   /// Constructor
   DTResidualCalibration(const edm::ParameterSet& pset);
   /// Destructor
@@ -37,22 +37,20 @@ class DTResidualCalibration: public edm::EDAnalyzer{
   void endJob() override;
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
 
- protected:
-
- private:
-
+protected:
+private:
   unsigned int nevent;
-  unsigned int segmok,segmbad;
+  unsigned int segmok, segmbad;
 
-  float segmentToWireDistance(const DTRecHit1D& recHit1D, const DTRecSegment4D& segment); 
+  float segmentToWireDistance(const DTRecHit1D& recHit1D, const DTRecSegment4D& segment);
   // Book a set of histograms for a given super-layer/layer
   void bookHistos(DTSuperLayerId slId);
   void bookHistos(DTLayerId slId);
-  // Fill a set of histograms for a given super-layer/layer 
+  // Fill a set of histograms for a given super-layer/layer
   void fillHistos(DTSuperLayerId slId, float distance, float residualOnDistance);
   void fillHistos(DTLayerId slId, float distance, float residualOnDistance);
 
-  DTSegmentSelector *select_;
+  DTSegmentSelector* select_;
   double histRange_;
   edm::InputTag segment4DLabel_;
   std::string rootBaseDir_;
@@ -62,10 +60,10 @@ class DTResidualCalibration: public edm::EDAnalyzer{
   // Geometry
   const DTGeometry* dtGeom_;
   // Histograms per super-layer
-  std::map<DTSuperLayerId, TH1F* > histoMapTH1F_;
-  std::map<DTSuperLayerId, TH2F* > histoMapTH2F_;
+  std::map<DTSuperLayerId, TH1F*> histoMapTH1F_;
+  std::map<DTSuperLayerId, TH2F*> histoMapTH2F_;
   // Histograms per layer
-  std::map<DTLayerId, TH1F* > histoMapPerLayerTH1F_;
-  std::map<DTLayerId, TH2F* > histoMapPerLayerTH2F_;
+  std::map<DTLayerId, TH1F*> histoMapPerLayerTH1F_;
+  std::map<DTLayerId, TH2F*> histoMapPerLayerTH2F_;
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.cc
@@ -24,64 +24,63 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTT0AbsoluteReferenceCorrection::DTT0AbsoluteReferenceCorrection(const ParameterSet& pset):
-   calibChamber_( pset.getParameter<string>("calibChamber") ),
-   reference_( pset.getParameter<double>("reference") ) {
-
-   //DTChamberId chosenChamberId;
-   if( !calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All" ){
+  DTT0AbsoluteReferenceCorrection::DTT0AbsoluteReferenceCorrection(const ParameterSet& pset)
+      : calibChamber_(pset.getParameter<string>("calibChamber")), reference_(pset.getParameter<double>("reference")) {
+    //DTChamberId chosenChamberId;
+    if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
       stringstream linestr;
       int selWheel, selStation, selSector;
       linestr << calibChamber_;
       linestr >> selWheel >> selStation >> selSector;
       chosenChamberId_ = DTChamberId(selWheel, selStation, selSector);
       LogVerbatim("Calibration") << "[DTT0AbsoluteReferenceCorrection] Chosen chamber: " << chosenChamberId_ << endl;
-   }
-   //FIXME: Check if chosen chamber is valid.
-}
+    }
+    //FIXME: Check if chosen chamber is valid.
+  }
 
-DTT0AbsoluteReferenceCorrection::~DTT0AbsoluteReferenceCorrection() {
-}
+  DTT0AbsoluteReferenceCorrection::~DTT0AbsoluteReferenceCorrection() {}
 
-void DTT0AbsoluteReferenceCorrection::setES(const EventSetup& setup) {
-   // Get t0 record from DB
-   ESHandle<DTT0> t0H;
-   setup.get<DTT0Rcd>().get(t0H);
-   t0Map_ = &*t0H;
-   LogVerbatim("Calibration") << "[DTT0AbsoluteReferenceCorrection] T0 version: " << t0H->version();
-}
+  void DTT0AbsoluteReferenceCorrection::setES(const EventSetup& setup) {
+    // Get t0 record from DB
+    ESHandle<DTT0> t0H;
+    setup.get<DTT0Rcd>().get(t0H);
+    t0Map_ = &*t0H;
+    LogVerbatim("Calibration") << "[DTT0AbsoluteReferenceCorrection] T0 version: " << t0H->version();
+  }
 
-DTT0Data DTT0AbsoluteReferenceCorrection::correction(const DTWireId& wireId) {
-   // Compute for selected chamber (or All) correction using as reference chamber mean
+  DTT0Data DTT0AbsoluteReferenceCorrection::correction(const DTWireId& wireId) {
+    // Compute for selected chamber (or All) correction using as reference chamber mean
 
-   DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
+    DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
 
-   if( calibChamber_.empty() || calibChamber_ == "None" )          return defaultT0(wireId);
-   if( calibChamber_ != "All" && chamberId != chosenChamberId_ ) return defaultT0(wireId);
+    if (calibChamber_.empty() || calibChamber_ == "None")
+      return defaultT0(wireId);
+    if (calibChamber_ != "All" && chamberId != chosenChamberId_)
+      return defaultT0(wireId);
 
-   // Access DB
-   float t0Mean,t0RMS;
-   int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-   if(status != 0) 
-      throw cms::Exception("[DTT0AbsoluteReferenceCorrection]") << "Could not find t0 entry in DB for" 
-                                                                << wireId << endl;
+    // Access DB
+    float t0Mean, t0RMS;
+    int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+    if (status != 0)
+      throw cms::Exception("[DTT0AbsoluteReferenceCorrection]")
+          << "Could not find t0 entry in DB for" << wireId << endl;
 
-   float t0MeanNew = t0Mean - reference_;
-   float t0RMSNew = t0RMS;
-   return DTT0Data(t0MeanNew,t0RMSNew);
-}
+    float t0MeanNew = t0Mean - reference_;
+    float t0RMSNew = t0RMS;
+    return DTT0Data(t0MeanNew, t0RMSNew);
+  }
 
-DTT0Data DTT0AbsoluteReferenceCorrection::defaultT0(const DTWireId& wireId) {
-   // Access default DB
-   float t0Mean,t0RMS;
-   int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-   if(!status){
-      return DTT0Data(t0Mean,t0RMS);
-   } else{
-      //... 
-      throw cms::Exception("[DTT0AbsoluteReferenceCorrection]") << "Could not find t0 entry in DB for"
-	 << wireId << endl;
-   }
-}
+  DTT0Data DTT0AbsoluteReferenceCorrection::defaultT0(const DTWireId& wireId) {
+    // Access default DB
+    float t0Mean, t0RMS;
+    int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+    if (!status) {
+      return DTT0Data(t0Mean, t0RMS);
+    } else {
+      //...
+      throw cms::Exception("[DTT0AbsoluteReferenceCorrection]")
+          << "Could not find t0 entry in DB for" << wireId << endl;
+    }
+  }
 
-} // namespace
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.cc
@@ -29,7 +29,7 @@ DTT0AbsoluteReferenceCorrection::DTT0AbsoluteReferenceCorrection(const Parameter
    reference_( pset.getParameter<double>("reference") ) {
 
    //DTChamberId chosenChamberId;
-   if( calibChamber_ != "" && calibChamber_ != "None" && calibChamber_ != "All" ){
+   if( !calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All" ){
       stringstream linestr;
       int selWheel, selStation, selSector;
       linestr << calibChamber_;
@@ -56,7 +56,7 @@ DTT0Data DTT0AbsoluteReferenceCorrection::correction(const DTWireId& wireId) {
 
    DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
 
-   if( calibChamber_ == "" || calibChamber_ == "None" )          return defaultT0(wireId);
+   if( calibChamber_.empty() || calibChamber_ == "None" )          return defaultT0(wireId);
    if( calibChamber_ != "All" && chamberId != chosenChamberId_ ) return defaultT0(wireId);
 
    // Access DB

--- a/CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.h
@@ -22,26 +22,26 @@ class DTT0;
 
 namespace dtCalibration {
 
-class DTT0AbsoluteReferenceCorrection: public DTT0BaseCorrection {
-public:
-  // Constructor
-  DTT0AbsoluteReferenceCorrection(const edm::ParameterSet&);
+  class DTT0AbsoluteReferenceCorrection : public DTT0BaseCorrection {
+  public:
+    // Constructor
+    DTT0AbsoluteReferenceCorrection(const edm::ParameterSet&);
 
-  // Destructor
-  ~DTT0AbsoluteReferenceCorrection() override;
+    // Destructor
+    ~DTT0AbsoluteReferenceCorrection() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTT0Data correction(const DTWireId&) override;
+    void setES(const edm::EventSetup& setup) override;
+    DTT0Data correction(const DTWireId&) override;
 
-private:
-  DTT0Data defaultT0(const DTWireId&);
+  private:
+    DTT0Data defaultT0(const DTWireId&);
 
-  std::string calibChamber_;
-  double reference_;
+    std::string calibChamber_;
+    double reference_;
 
-  DTChamberId chosenChamberId_;
-  const DTT0 *t0Map_;
-};
+    DTChamberId chosenChamberId_;
+    const DTT0* t0Map_;
+  };
 
-} // namespace
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTT0Calibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0Calibration.cc
@@ -31,471 +31,438 @@ using namespace std;
 using namespace edm;
 
 // Constructor
-DTT0Calibration::DTT0Calibration(const edm::ParameterSet& pset) :
-   debug(pset.getUntrackedParameter<bool>("debug")),
-   digiToken(consumes<DTDigiCollection>(pset.getUntrackedParameter<string>("digiLabel"))),
-   theFile(pset.getUntrackedParameter<string>("rootFileName", "DTT0PerLayer.root").c_str(), "RECREATE"),
-   nevents(0),
-   eventsForLayerT0(pset.getParameter<unsigned int>("eventsForLayerT0")),
-   eventsForWireT0(pset.getParameter<unsigned int>("eventsForWireT0")),
-   tpPeakWidth(pset.getParameter<double>("tpPeakWidth")),
-   tpPeakWidthPerLayer(pset.getParameter<double>("tpPeakWidthPerLayer")),
-   rejectDigiFromPeak(pset.getParameter<unsigned int>("rejectDigiFromPeak")), 
-   hLayerPeaks("hLayerPeaks", "", 3000, 0, 3000),
-   spectrum(20)
+DTT0Calibration::DTT0Calibration(const edm::ParameterSet& pset)
+    : debug(pset.getUntrackedParameter<bool>("debug")),
+      digiToken(consumes<DTDigiCollection>(pset.getUntrackedParameter<string>("digiLabel"))),
+      theFile(pset.getUntrackedParameter<string>("rootFileName", "DTT0PerLayer.root").c_str(), "RECREATE"),
+      nevents(0),
+      eventsForLayerT0(pset.getParameter<unsigned int>("eventsForLayerT0")),
+      eventsForWireT0(pset.getParameter<unsigned int>("eventsForWireT0")),
+      tpPeakWidth(pset.getParameter<double>("tpPeakWidth")),
+      tpPeakWidthPerLayer(pset.getParameter<double>("tpPeakWidthPerLayer")),
+      rejectDigiFromPeak(pset.getParameter<unsigned int>("rejectDigiFromPeak")),
+      hLayerPeaks("hLayerPeaks", "", 3000, 0, 3000),
+      spectrum(20)
 
 {
-   // Get the debug parameter for verbose output
-   if(debug) 
-      cout << "[DTT0Calibration]Constructor called!" << endl;
+  // Get the debug parameter for verbose output
+  if (debug)
+    cout << "[DTT0Calibration]Constructor called!" << endl;
 
-   theCalibWheel =  pset.getUntrackedParameter<string>("calibWheel", "All"); //FIXME amke a vector of integer instead of a string
-   if(theCalibWheel != "All") {
-      stringstream linestr;
-      int selWheel;
-      linestr << theCalibWheel;
-      linestr >> selWheel;
-      cout << "[DTT0CalibrationPerLayer] chosen wheel " << selWheel << endl;
-   }
+  theCalibWheel =
+      pset.getUntrackedParameter<string>("calibWheel", "All");  //FIXME amke a vector of integer instead of a string
+  if (theCalibWheel != "All") {
+    stringstream linestr;
+    int selWheel;
+    linestr << theCalibWheel;
+    linestr >> selWheel;
+    cout << "[DTT0CalibrationPerLayer] chosen wheel " << selWheel << endl;
+  }
 
-   // Sector/s to calibrate
-   theCalibSector =  pset.getUntrackedParameter<string>("calibSector", "All"); //FIXME amke a vector of integer instead of a string
-   if(theCalibSector != "All") {
-      stringstream linestr;
-      int selSector;
-      linestr << theCalibSector;
-      linestr >> selSector;
-      cout << "[DTT0CalibrationPerLayer] chosen sector " << selSector << endl;
-   }
+  // Sector/s to calibrate
+  theCalibSector =
+      pset.getUntrackedParameter<string>("calibSector", "All");  //FIXME amke a vector of integer instead of a string
+  if (theCalibSector != "All") {
+    stringstream linestr;
+    int selSector;
+    linestr << theCalibSector;
+    linestr >> selSector;
+    cout << "[DTT0CalibrationPerLayer] chosen sector " << selSector << endl;
+  }
 
-   vector<string> defaultCell;
-   const auto& cellsWithHistos = pset.getUntrackedParameter<vector<string> >("cellsWithHisto", defaultCell);
-   for(const auto& cell : cellsWithHistos){
-      stringstream linestr;
-      int wheel, sector, station, sl, layer, wire;
-      linestr << cell;
-      linestr >> wheel >> sector >> station >> sl >> layer >> wire;
-      wireIdWithHistos.push_back(DTWireId(wheel, station, sector, sl, layer, wire));
-   }
+  vector<string> defaultCell;
+  const auto& cellsWithHistos = pset.getUntrackedParameter<vector<string> >("cellsWithHisto", defaultCell);
+  for (const auto& cell : cellsWithHistos) {
+    stringstream linestr;
+    int wheel, sector, station, sl, layer, wire;
+    linestr << cell;
+    linestr >> wheel >> sector >> station >> sl >> layer >> wire;
+    wireIdWithHistos.push_back(DTWireId(wheel, station, sector, sl, layer, wire));
+  }
 }
 
 // Destructor
-DTT0Calibration::~DTT0Calibration(){
-   if(debug) 
-      cout << "[DTT0Calibration]Destructor called!" << endl;
+DTT0Calibration::~DTT0Calibration() {
+  if (debug)
+    cout << "[DTT0Calibration]Destructor called!" << endl;
 
-   theFile.Close();
+  theFile.Close();
 }
 
 /// Perform the real analysis
-void DTT0Calibration::analyze(const edm::Event & event, const edm::EventSetup& eventSetup) {
-   nevents++;
+void DTT0Calibration::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
+  nevents++;
 
-   // Get the digis from the event
-   Handle<DTDigiCollection> digis; 
-   event.getByToken(digiToken, digis);
+  // Get the digis from the event
+  Handle<DTDigiCollection> digis;
+  event.getByToken(digiToken, digis);
 
-   // Get the DT Geometry
-   if (nevents == 1)
-      eventSetup.get<MuonGeometryRecord>().get(dtGeom);
+  // Get the DT Geometry
+  if (nevents == 1)
+    eventSetup.get<MuonGeometryRecord>().get(dtGeom);
 
-   // Iterate through all digi collections ordered by LayerId   
-   for (const auto& digis_per_layer : *digis)
-   {
-      //std::cout << __LINE__ << std::endl;
-      // Get the iterators over the digis associated with this LayerId
-      const DTDigiCollection::Range& digiRange = digis_per_layer.second;
+  // Iterate through all digi collections ordered by LayerId
+  for (const auto& digis_per_layer : *digis) {
+    //std::cout << __LINE__ << std::endl;
+    // Get the iterators over the digis associated with this LayerId
+    const DTDigiCollection::Range& digiRange = digis_per_layer.second;
 
-      // Get the layerId
-      const DTLayerId layerId = digis_per_layer.first;
-      //const DTChamberId chamberId = layerId.superlayerId().chamberId();
+    // Get the layerId
+    const DTLayerId layerId = digis_per_layer.first;
+    //const DTChamberId chamberId = layerId.superlayerId().chamberId();
 
-      if((theCalibWheel != "All") && (layerId.superlayerId().chamberId().wheel() != selWheel))
-         continue;
-      if((theCalibSector != "All") && (layerId.superlayerId().chamberId().sector() != selSector))
-         continue;
+    if ((theCalibWheel != "All") && (layerId.superlayerId().chamberId().wheel() != selWheel))
+      continue;
+    if ((theCalibSector != "All") && (layerId.superlayerId().chamberId().sector() != selSector))
+      continue;
 
-      // Loop over all digis in the given layer
-      for (DTDigiCollection::const_iterator digi = digiRange.first;
-            digi != digiRange.second;
-            ++digi)
-      {
-         const double t0 = digi->countsTDC();
-         const DTWireId wireIdtmp(layerId, (*digi).wire());
+    // Loop over all digis in the given layer
+    for (DTDigiCollection::const_iterator digi = digiRange.first; digi != digiRange.second; ++digi) {
+      const double t0 = digi->countsTDC();
+      const DTWireId wireIdtmp(layerId, (*digi).wire());
 
-         // Use first bunch of events to fill t0 per layer
-         if(nevents <= eventsForLayerT0){
-            // If it doesn't exist, book it
-            if(not theHistoLayerMap.count(layerId)){
-               theHistoLayerMap[layerId] = TH1I(getHistoName(layerId).c_str(),
-                     "T0 from pulses by layer (TDC counts, 1 TDC count = 0.781 ns)",
-                     3000,
-                     0,
-                     3000
-                     );
-               if(debug)
-                  cout << "  New T0 per Layer Histo: " << theHistoLayerMap[layerId].GetName() << endl;
-            }
-            theHistoLayerMap[layerId].Fill(t0);
-         }
-
-         // Use all the remaining events to compute t0 per wire
-         if(nevents>eventsForLayerT0){
-            // Get the wireId
-            const DTWireId wireId(layerId, (*digi).wire());
-            if(debug) {
-               cout << "   Wire: " << wireId << endl
-                  << "       time (TDC counts): " << (*digi).countsTDC()<< endl;
-            }   
-
-            //Fill the histos per wire for the chosen cells
-            if (std::find(layerIdWithWireHistos.begin(), layerIdWithWireHistos.end(), layerId) != layerIdWithWireHistos.end() or
-                std::find(wireIdWithHistos.begin(),wireIdWithHistos.end(),wireId) != wireIdWithHistos.end())
-            {
-               //If it doesn't exist, book it
-               if(theHistoWireMap.count(wireId) == 0){
-                  theHistoWireMap[wireId] = TH1I(getHistoName(wireId).c_str(),
-                        "T0 from pulses by wire (TDC counts, 1 TDC count = 0.781 ns)",
-                        7000,
-                        0,
-                        7000
-                        );
-                  if(debug)
-                     cout << "  New T0 per wire Histo: " << theHistoWireMap[wireId].GetName() << endl;
-               }
-               theHistoWireMap[wireId].Fill(t0);
-            }
-
-            //Select per layer
-            if(fabs(theTPPeakMap[layerId] - t0) > rejectDigiFromPeak){
-               if(debug)
-                  cout<<"digi skipped because t0 too far from peak " << theTPPeakMap[layerId] << endl;
-               continue;     
-            }
-
-            //Use second bunch of events to compute a t0 reference per wire
-            if(nevents <= (eventsForLayerT0 + eventsForWireT0)){
-               if(!nDigiPerWire_ref[wireId]){
-                  mK_ref[wireId] = 0;
-               }
-               nDigiPerWire_ref[wireId] = nDigiPerWire_ref[wireId] + 1;
-               mK_ref[wireId] = mK_ref[wireId] + (t0-mK_ref[wireId])/nDigiPerWire_ref[wireId];
-            }
-            //Use last all the remaining events to compute the mean and sigma t0 per wire
-            else if(nevents > (eventsForLayerT0 + eventsForWireT0)){
-               if(abs(t0-mK_ref[wireId]) > tpPeakWidth)
-                  continue;
-               if(!nDigiPerWire[wireId]){
-                  theAbsoluteT0PerWire[wireId] = 0;
-                  qK[wireId] = 0;
-                  mK[wireId] = 0;
-               }
-               nDigiPerWire[wireId] = nDigiPerWire[wireId] + 1;
-               theAbsoluteT0PerWire[wireId] = theAbsoluteT0PerWire[wireId] + t0;
-               qK[wireId] = qK[wireId] + ((nDigiPerWire[wireId]-1)*(t0-mK[wireId])*(t0-mK[wireId])/nDigiPerWire[wireId]);
-               mK[wireId] = mK[wireId] + (t0-mK[wireId])/nDigiPerWire[wireId];
-            }
-         }//end if(nevents>1000)
-      }//end loop on digi
-   }//end loop on layer
-
-   //Use the t0 per layer histos to have an indication about the t0 position 
-   if(nevents == eventsForLayerT0){
-      for(const auto& lHisto : theHistoLayerMap)
-      {
-         const auto& layerId = lHisto.first;
-         const auto& hist = lHisto.second;
-         if(debug)
-            cout << "Reading histogram " << hist.GetName() << " with mean " << hist.GetMean() << " and RMS " << hist.GetRMS() << endl;
-
-         //Find peaks
-         int npeaks = spectrum.Search(&hist, (tpPeakWidthPerLayer / 2.), "", 0.3);
-
-         double *peaks = spectrum.GetPositionX();
-         //Put in a std::vector<float>
-         vector<double> peakMeans(peaks, peaks + npeaks);
-         //Sort the peaks in ascending order
-         sort(peakMeans.begin(), peakMeans.end());
-
-         if (peakMeans.empty())
-         {
-            theTPPeakMap[layerId] = hist.GetMaximumBin();
-            std::cout << "No peaks found by peakfinder in layer " << layerId << ". Taking maximum bin at " << theTPPeakMap[layerId] << ". Please check!" << std::endl;
-            layerIdWithWireHistos.push_back(layerId);
-         }
-         else if (fabs(hist.GetXaxis()->FindBin(peakMeans.front()) - hist.GetXaxis()->FindBin(peakMeans.back())) < rejectDigiFromPeak)
-         {
-            theTPPeakMap[layerId] = peakMeans[peakMeans.size() / 2];
-         }
-         else
-         {
-            bool peak_set = false;
-            for (const auto& peak : peakMeans)
-            {
-               // Skip if at low edge
-               if (peak - tpPeakWidthPerLayer <= 0)
-                  continue;
-               // Get integral of peak
-               double sum = 0;
-               for (int ibin=peak - tpPeakWidthPerLayer; ibin<peak + tpPeakWidthPerLayer; ibin++)
-               {
-                  sum += hist.GetBinContent(ibin);
-               }
-               // Skip if peak too small
-               if (sum < hist.GetMaximum() / 2)
-                  continue;
-
-               // Passed all cuts
-               theTPPeakMap[layerId] = peak;
-               peak_set = true;
-               break;
-            }
-            if (peak_set)
-            {
-               std::cout << "Peaks to far away from each other in layer " << layerId << ". Maybe cross talk? Taking first good peak at " << theTPPeakMap[layerId] << ". Please check!" << std::endl;
-               layerIdWithWireHistos.push_back(layerId);
-            }
-            else
-            {
-               theTPPeakMap[layerId] = hist.GetMaximumBin();
-               std::cout << "Peaks to far away from each other in layer " << layerId << " and no good peak found. Taking maximum bin at " << theTPPeakMap[layerId] << ". Please check!" << std::endl;
-               layerIdWithWireHistos.push_back(layerId);
-            }
-         }
-         if (peakMeans.size() > 5)
-         {
-            std::cout << "Found more than 5 peaks in layer " << layerId << ". Please check!" << std::endl;
-            if (std::find(layerIdWithWireHistos.begin(), layerIdWithWireHistos.end(), layerId) == layerIdWithWireHistos.end())
-               layerIdWithWireHistos.push_back(layerId);
-         }
-         // Check for noise
-         int nspikes = 0;
-         for (int ibin=0; ibin<hist.GetNbinsX(); ibin++)
-         {
-            if (hist.GetBinContent(ibin + 1) > hist.GetMaximum() * 0.001)
-               nspikes++;
-         }
-         if (nspikes > 50)
-         {
-            std::cout << "Found a lot of (>50) small spikes in layer " << layerId << ". Please check if all wires are functioning as expected!" << std::endl;
-            if (std::find(layerIdWithWireHistos.begin(), layerIdWithWireHistos.end(), layerId) == layerIdWithWireHistos.end())
-               layerIdWithWireHistos.push_back(layerId);
-         }
-         hLayerPeaks.Fill(theTPPeakMap[layerId]);
+      // Use first bunch of events to fill t0 per layer
+      if (nevents <= eventsForLayerT0) {
+        // If it doesn't exist, book it
+        if (not theHistoLayerMap.count(layerId)) {
+          theHistoLayerMap[layerId] = TH1I(getHistoName(layerId).c_str(),
+                                           "T0 from pulses by layer (TDC counts, 1 TDC count = 0.781 ns)",
+                                           3000,
+                                           0,
+                                           3000);
+          if (debug)
+            cout << "  New T0 per Layer Histo: " << theHistoLayerMap[layerId].GetName() << endl;
+        }
+        theHistoLayerMap[layerId].Fill(t0);
       }
-   }
+
+      // Use all the remaining events to compute t0 per wire
+      if (nevents > eventsForLayerT0) {
+        // Get the wireId
+        const DTWireId wireId(layerId, (*digi).wire());
+        if (debug) {
+          cout << "   Wire: " << wireId << endl << "       time (TDC counts): " << (*digi).countsTDC() << endl;
+        }
+
+        //Fill the histos per wire for the chosen cells
+        if (std::find(layerIdWithWireHistos.begin(), layerIdWithWireHistos.end(), layerId) !=
+                layerIdWithWireHistos.end() or
+            std::find(wireIdWithHistos.begin(), wireIdWithHistos.end(), wireId) != wireIdWithHistos.end()) {
+          //If it doesn't exist, book it
+          if (theHistoWireMap.count(wireId) == 0) {
+            theHistoWireMap[wireId] = TH1I(getHistoName(wireId).c_str(),
+                                           "T0 from pulses by wire (TDC counts, 1 TDC count = 0.781 ns)",
+                                           7000,
+                                           0,
+                                           7000);
+            if (debug)
+              cout << "  New T0 per wire Histo: " << theHistoWireMap[wireId].GetName() << endl;
+          }
+          theHistoWireMap[wireId].Fill(t0);
+        }
+
+        //Select per layer
+        if (fabs(theTPPeakMap[layerId] - t0) > rejectDigiFromPeak) {
+          if (debug)
+            cout << "digi skipped because t0 too far from peak " << theTPPeakMap[layerId] << endl;
+          continue;
+        }
+
+        //Use second bunch of events to compute a t0 reference per wire
+        if (nevents <= (eventsForLayerT0 + eventsForWireT0)) {
+          if (!nDigiPerWire_ref[wireId]) {
+            mK_ref[wireId] = 0;
+          }
+          nDigiPerWire_ref[wireId] = nDigiPerWire_ref[wireId] + 1;
+          mK_ref[wireId] = mK_ref[wireId] + (t0 - mK_ref[wireId]) / nDigiPerWire_ref[wireId];
+        }
+        //Use last all the remaining events to compute the mean and sigma t0 per wire
+        else if (nevents > (eventsForLayerT0 + eventsForWireT0)) {
+          if (abs(t0 - mK_ref[wireId]) > tpPeakWidth)
+            continue;
+          if (!nDigiPerWire[wireId]) {
+            theAbsoluteT0PerWire[wireId] = 0;
+            qK[wireId] = 0;
+            mK[wireId] = 0;
+          }
+          nDigiPerWire[wireId] = nDigiPerWire[wireId] + 1;
+          theAbsoluteT0PerWire[wireId] = theAbsoluteT0PerWire[wireId] + t0;
+          qK[wireId] =
+              qK[wireId] + ((nDigiPerWire[wireId] - 1) * (t0 - mK[wireId]) * (t0 - mK[wireId]) / nDigiPerWire[wireId]);
+          mK[wireId] = mK[wireId] + (t0 - mK[wireId]) / nDigiPerWire[wireId];
+        }
+      }  //end if(nevents>1000)
+    }    //end loop on digi
+  }      //end loop on layer
+
+  //Use the t0 per layer histos to have an indication about the t0 position
+  if (nevents == eventsForLayerT0) {
+    for (const auto& lHisto : theHistoLayerMap) {
+      const auto& layerId = lHisto.first;
+      const auto& hist = lHisto.second;
+      if (debug)
+        cout << "Reading histogram " << hist.GetName() << " with mean " << hist.GetMean() << " and RMS "
+             << hist.GetRMS() << endl;
+
+      //Find peaks
+      int npeaks = spectrum.Search(&hist, (tpPeakWidthPerLayer / 2.), "", 0.3);
+
+      double* peaks = spectrum.GetPositionX();
+      //Put in a std::vector<float>
+      vector<double> peakMeans(peaks, peaks + npeaks);
+      //Sort the peaks in ascending order
+      sort(peakMeans.begin(), peakMeans.end());
+
+      if (peakMeans.empty()) {
+        theTPPeakMap[layerId] = hist.GetMaximumBin();
+        std::cout << "No peaks found by peakfinder in layer " << layerId << ". Taking maximum bin at "
+                  << theTPPeakMap[layerId] << ". Please check!" << std::endl;
+        layerIdWithWireHistos.push_back(layerId);
+      } else if (fabs(hist.GetXaxis()->FindBin(peakMeans.front()) - hist.GetXaxis()->FindBin(peakMeans.back())) <
+                 rejectDigiFromPeak) {
+        theTPPeakMap[layerId] = peakMeans[peakMeans.size() / 2];
+      } else {
+        bool peak_set = false;
+        for (const auto& peak : peakMeans) {
+          // Skip if at low edge
+          if (peak - tpPeakWidthPerLayer <= 0)
+            continue;
+          // Get integral of peak
+          double sum = 0;
+          for (int ibin = peak - tpPeakWidthPerLayer; ibin < peak + tpPeakWidthPerLayer; ibin++) {
+            sum += hist.GetBinContent(ibin);
+          }
+          // Skip if peak too small
+          if (sum < hist.GetMaximum() / 2)
+            continue;
+
+          // Passed all cuts
+          theTPPeakMap[layerId] = peak;
+          peak_set = true;
+          break;
+        }
+        if (peak_set) {
+          std::cout << "Peaks to far away from each other in layer " << layerId
+                    << ". Maybe cross talk? Taking first good peak at " << theTPPeakMap[layerId] << ". Please check!"
+                    << std::endl;
+          layerIdWithWireHistos.push_back(layerId);
+        } else {
+          theTPPeakMap[layerId] = hist.GetMaximumBin();
+          std::cout << "Peaks to far away from each other in layer " << layerId
+                    << " and no good peak found. Taking maximum bin at " << theTPPeakMap[layerId] << ". Please check!"
+                    << std::endl;
+          layerIdWithWireHistos.push_back(layerId);
+        }
+      }
+      if (peakMeans.size() > 5) {
+        std::cout << "Found more than 5 peaks in layer " << layerId << ". Please check!" << std::endl;
+        if (std::find(layerIdWithWireHistos.begin(), layerIdWithWireHistos.end(), layerId) ==
+            layerIdWithWireHistos.end())
+          layerIdWithWireHistos.push_back(layerId);
+      }
+      // Check for noise
+      int nspikes = 0;
+      for (int ibin = 0; ibin < hist.GetNbinsX(); ibin++) {
+        if (hist.GetBinContent(ibin + 1) > hist.GetMaximum() * 0.001)
+          nspikes++;
+      }
+      if (nspikes > 50) {
+        std::cout << "Found a lot of (>50) small spikes in layer " << layerId
+                  << ". Please check if all wires are functioning as expected!" << std::endl;
+        if (std::find(layerIdWithWireHistos.begin(), layerIdWithWireHistos.end(), layerId) ==
+            layerIdWithWireHistos.end())
+          layerIdWithWireHistos.push_back(layerId);
+      }
+      hLayerPeaks.Fill(theTPPeakMap[layerId]);
+    }
+  }
 }
 
 void DTT0Calibration::endJob() {
+  std::cout << "Analyzed " << nevents << " events" << std::endl;
 
-   std::cout << "Analyzed " << nevents << " events" << std::endl;
+  DTT0* t0sWRTChamber = new DTT0();
 
-   DTT0* t0sWRTChamber = new DTT0();
+  if (debug)
+    cout << "[DTT0CalibrationPerLayer]Writing histos to file!" << endl;
 
-   if(debug) 
-      cout << "[DTT0CalibrationPerLayer]Writing histos to file!" << endl;
+  theFile.cd();
+  //hT0SectorHisto->Write();
+  hLayerPeaks.Write();
+  for (const auto& wHisto : theHistoWireMap) {
+    wHisto.second.Write();
+  }
+  for (const auto& lHisto : theHistoLayerMap) {
+    lHisto.second.Write();
+  }
 
-   theFile.cd();
-   //hT0SectorHisto->Write();
-   hLayerPeaks.Write();
-   for(const auto& wHisto : theHistoWireMap){
-      wHisto.second.Write(); 
-   }
-   for(const auto& lHisto : theHistoLayerMap ) {
-      lHisto.second.Write(); 
-   }  
+  if (debug)
+    cout << "[DTT0Calibration] Compute and store t0 and sigma per wire" << endl;
 
-   if(debug) 
-      cout << "[DTT0Calibration] Compute and store t0 and sigma per wire" << endl;
+  // Calculate uncertainties per wire (counting experiment)
+  for (auto& wiret0 : theAbsoluteT0PerWire) {
+    auto& wireId = wiret0.first;
+    if (nDigiPerWire[wireId] > 1)
+      theSigmaT0PerWire[wireId] = qK[wireId] / (nDigiPerWire[wireId] - 1);
+    else
+      theSigmaT0PerWire[wireId] = 999.;  // Only one measurement: uncertainty -> infinity
+    // syst uncert
+    //theSigmaT0PerWire[wireId] += pow(0.5, 2));
+    // Every time the same measurement. Use Laplace estimator as estimation how propable it is to measure another value due to limited size of sample
+    if (theSigmaT0PerWire[wireId] == 0) {
+      theSigmaT0PerWire[wireId] += pow(1. / (nDigiPerWire[wireId] + 1), 2);
+    }
+  }
 
-   // Calculate uncertainties per wire (counting experiment)
-   for (auto& wiret0 : theAbsoluteT0PerWire)
-   {
-      auto& wireId = wiret0.first;
-      if (nDigiPerWire[wireId] > 1 )
-         theSigmaT0PerWire[wireId] = qK[wireId] / (nDigiPerWire[wireId] - 1);
-      else
-         theSigmaT0PerWire[wireId] = 999.; // Only one measurement: uncertainty -> infinity
-      // syst uncert
-      //theSigmaT0PerWire[wireId] += pow(0.5, 2));
-      // Every time the same measurement. Use Laplace estimator as estimation how propable it is to measure another value due to limited size of sample
-      if (theSigmaT0PerWire[wireId] == 0)
-      {
-         theSigmaT0PerWire[wireId] += pow(1. / (nDigiPerWire[wireId] + 1), 2);
+  // function to calculate unweighted means
+  auto unweighted_mean_function = [](const std::list<double>& values, const std::list<double>& sigmas) {
+    double mean = 0;
+    for (auto& value : values) {
+      mean += value;
+    }
+    mean /= values.size();
+
+    double uncertainty = 0;
+    for (auto& value : values) {
+      uncertainty += pow(value - mean, 2);
+    }
+    uncertainty /= values.size();
+    uncertainty = sqrt(uncertainty);
+    return std::make_pair(mean, uncertainty);
+  };
+
+  // correct for odd-even effect in each super layer
+  std::map<DTSuperLayerId, std::pair<double, double> > mean_sigma_even;
+  std::map<DTSuperLayerId, std::pair<double, double> > mean_sigma_odd;
+  for (const auto& superlayer : dtGeom->superLayers()) {
+    const auto superlayer_id = superlayer->id();
+    std::list<double> values_even;
+    std::list<double> sigmas_even;
+    std::list<double> values_odd;
+    std::list<double> sigmas_odd;
+
+    for (const auto& wiret0 : theAbsoluteT0PerWire) {
+      const auto& wireId = wiret0.first;
+      if (wireId.layerId().superlayerId() == superlayer_id) {
+        const auto& t0 = wiret0.second / nDigiPerWire[wireId];
+        if (wireId.layerId().layer() % 2) {
+          values_odd.push_back(t0);
+          sigmas_odd.push_back(sqrt(theSigmaT0PerWire[wireId]));
+        } else {
+          values_even.push_back(t0);
+          sigmas_even.push_back(sqrt(theSigmaT0PerWire[wireId]));
+        }
       }
-   }
+    }
+    // get mean and uncertainty
+    mean_sigma_even.emplace(superlayer_id, unweighted_mean_function(values_even, sigmas_even));
+    mean_sigma_odd.emplace(superlayer_id, unweighted_mean_function(values_odd, sigmas_odd));
+  }
 
-   // function to calculate unweighted means
-   auto unweighted_mean_function = [] (const std::list<double>& values, const std::list<double>& sigmas)
-   {
-      double mean = 0;
-      for (auto& value : values)
-      {
-         mean += value;
+  // filter outliers
+  for (const auto& superlayer : dtGeom->superLayers()) {
+    const auto superlayer_id = superlayer->id();
+    std::list<double> values_even;
+    std::list<double> sigmas_even;
+    std::list<double> values_odd;
+    std::list<double> sigmas_odd;
+
+    for (const auto& wiret0 : theAbsoluteT0PerWire) {
+      const auto& wireId = wiret0.first;
+      if (wireId.layerId().superlayerId() == superlayer_id) {
+        const auto& t0 = wiret0.second / nDigiPerWire[wireId];
+        if (wireId.layerId().layer() % 2 and
+            abs(t0 - mean_sigma_odd[superlayer_id].first) < 2 * mean_sigma_odd[superlayer_id].second) {
+          values_odd.push_back(t0);
+          sigmas_odd.push_back(sqrt(theSigmaT0PerWire[wireId]));
+        } else {
+          if (abs(t0 - mean_sigma_even[superlayer_id].first) < 2 * mean_sigma_even[superlayer_id].second) {
+            values_even.push_back(t0);
+            sigmas_even.push_back(sqrt(theSigmaT0PerWire[wireId]));
+          }
+        }
       }
-      mean /= values.size();
+    }
+    // get mean and uncertainty
+    mean_sigma_even[superlayer_id] = unweighted_mean_function(values_even, sigmas_even);
+    mean_sigma_odd[superlayer_id] = unweighted_mean_function(values_odd, sigmas_odd);
+  }
 
-      double uncertainty = 0;
-      for (auto& value : values)
-      {
-         uncertainty += pow(value - mean, 2);
-      }
-      uncertainty /= values.size();
-      uncertainty = sqrt(uncertainty);
-      return std::make_pair(mean, uncertainty);
-   };
+  // apply correction
+  for (auto& wiret0 : theAbsoluteT0PerWire) {
+    const auto& wire_id = wiret0.first;
+    const auto& superlayer_id = wiret0.first.layerId().superlayerId();
+    const auto& layer = wiret0.first.layerId().layer();
+    auto& t0 = wiret0.second;
+    t0 /= nDigiPerWire[wire_id];
+    if (not layer % 2)
+      continue;
+    // t0 is reference. Changing it changes the map
+    t0 += mean_sigma_even[superlayer_id].first - mean_sigma_odd[superlayer_id].first;
+    theSigmaT0PerWire[wire_id] +=
+        pow(mean_sigma_odd[superlayer_id].second, 2) + pow(mean_sigma_even[superlayer_id].second, 2);
+  }
 
-   // correct for odd-even effect in each super layer
-   std::map<DTSuperLayerId, std::pair<double, double> > mean_sigma_even;
-   std::map<DTSuperLayerId, std::pair<double, double> > mean_sigma_odd;
-   for (const auto& superlayer : dtGeom->superLayers())
-   {
-      const auto superlayer_id = superlayer->id();
-      std::list<double> values_even;
-      std::list<double> sigmas_even;
-      std::list<double> values_odd;
-      std::list<double> sigmas_odd;
+  // get chamber mean
+  std::map<DTChamberId, std::list<double> > values_per_chamber;
+  std::map<DTChamberId, std::list<double> > sigmas_per_chamber;
+  for (const auto& wire_t0 : theAbsoluteT0PerWire) {
+    const auto& wire_id = wire_t0.first;
+    const auto& chamber_id = wire_id.chamberId();
+    const auto& t0 = wire_t0.second;
+    values_per_chamber[chamber_id].push_back(t0);
+    sigmas_per_chamber[chamber_id].push_back(sqrt(theSigmaT0PerWire[wire_id]));
+  }
 
-      for (const auto& wiret0 : theAbsoluteT0PerWire)
-      {
-         const auto& wireId = wiret0.first;
-         if (wireId.layerId().superlayerId() == superlayer_id)
-         {
-            const auto& t0 = wiret0.second / nDigiPerWire[wireId];
-            if (wireId.layerId().layer() % 2)
-            {
-               values_odd.push_back(t0);
-               sigmas_odd.push_back(sqrt(theSigmaT0PerWire[wireId]));
-            }
-            else
-            {
-               values_even.push_back(t0);
-               sigmas_even.push_back(sqrt(theSigmaT0PerWire[wireId]));
-            }
-         }
-      }
-      // get mean and uncertainty
-      mean_sigma_even.emplace(superlayer_id, unweighted_mean_function(values_even, sigmas_even));
-      mean_sigma_odd.emplace(superlayer_id, unweighted_mean_function(values_odd, sigmas_odd));
-   }
+  std::map<DTChamberId, std::pair<double, double> > mean_per_chamber;
+  for (const auto& chamber_mean : values_per_chamber) {
+    const auto& chamber_id = chamber_mean.first;
+    const auto& means = chamber_mean.second;
+    const auto& sigmas = sigmas_per_chamber[chamber_id];
+    mean_per_chamber.emplace(chamber_id, unweighted_mean_function(means, sigmas));
+  }
 
-   // filter outliers
-   for (const auto& superlayer : dtGeom->superLayers())
-   {
-      const auto superlayer_id = superlayer->id();
-      std::list<double> values_even;
-      std::list<double> sigmas_even;
-      std::list<double> values_odd;
-      std::list<double> sigmas_odd;
+  // calculate relative values
+  for (const auto& wire_t0 : theAbsoluteT0PerWire) {
+    const auto& wire_id = wire_t0.first;
+    const auto& chamber_id = wire_id.chamberId();
+    const auto& t0 = wire_t0.second;
+    theRelativeT0PerWire.emplace(wire_id, t0 - mean_per_chamber[chamber_id].first);
+    cout << "[DTT0Calibration] Wire " << wire_id << " has    t0 " << theRelativeT0PerWire[wire_id]
+         << " (relative, after even-odd layer corrections)  "
+         << "    sigma " << sqrt(theSigmaT0PerWire[wire_id]) << endl;
+  }
 
-      for (const auto& wiret0 : theAbsoluteT0PerWire)
-      {
-         const auto& wireId = wiret0.first;
-         if (wireId.layerId().superlayerId() == superlayer_id)
-         {
-            const auto& t0 = wiret0.second / nDigiPerWire[wireId];
-            if (wireId.layerId().layer() % 2 and abs(t0 - mean_sigma_odd[superlayer_id].first) < 2 * mean_sigma_odd[superlayer_id].second)
-            {
-               values_odd.push_back(t0);
-               sigmas_odd.push_back(sqrt(theSigmaT0PerWire[wireId]));
-            }
-            else 
-            {
-               if (abs(t0 - mean_sigma_even[superlayer_id].first) < 2 * mean_sigma_even[superlayer_id].second)
-               {
-                  values_even.push_back(t0);
-                  sigmas_even.push_back(sqrt(theSigmaT0PerWire[wireId]));
-               }
-            }
-         }
-      }
-      // get mean and uncertainty
-      mean_sigma_even[superlayer_id] = unweighted_mean_function(values_even, sigmas_even);
-      mean_sigma_odd[superlayer_id] = unweighted_mean_function(values_odd, sigmas_odd);
-   }
+  for (const auto& wire_t0 : theRelativeT0PerWire) {
+    const auto& wire_id = wire_t0.first;
+    const auto& t0 = wire_t0.second;
+    t0sWRTChamber->set(wire_id, t0, sqrt(theSigmaT0PerWire[wire_id]), DTTimeUnits::counts);
+  }
 
-   // apply correction
-   for (auto& wiret0 : theAbsoluteT0PerWire)
-   {
-      const auto& wire_id = wiret0.first;
-      const auto& superlayer_id = wiret0.first.layerId().superlayerId();
-      const auto& layer = wiret0.first.layerId().layer();
-      auto& t0 = wiret0.second;
-      t0 /= nDigiPerWire[wire_id];
-      if (not layer % 2)
-         continue;
-      // t0 is reference. Changing it changes the map
-      t0 += mean_sigma_even[superlayer_id].first - mean_sigma_odd[superlayer_id].first;
-      theSigmaT0PerWire[wire_id] += pow(mean_sigma_odd[superlayer_id].second, 2) + pow(mean_sigma_even[superlayer_id].second, 2);
-   }
-
-   // get chamber mean
-   std::map<DTChamberId, std::list<double> > values_per_chamber;
-   std::map<DTChamberId, std::list<double> > sigmas_per_chamber;
-   for (const auto& wire_t0 : theAbsoluteT0PerWire)
-   {
-      const auto& wire_id = wire_t0.first;
-      const auto& chamber_id = wire_id.chamberId();
-      const auto& t0 = wire_t0.second;
-      values_per_chamber[chamber_id].push_back(t0);
-      sigmas_per_chamber[chamber_id].push_back(sqrt(theSigmaT0PerWire[wire_id]));
-   }
-
-   std::map<DTChamberId, std::pair<double, double> > mean_per_chamber;
-   for (const auto& chamber_mean : values_per_chamber)
-   {
-      const auto& chamber_id = chamber_mean.first;
-      const auto& means = chamber_mean.second;
-      const auto& sigmas = sigmas_per_chamber[chamber_id];
-      mean_per_chamber.emplace(chamber_id, unweighted_mean_function(means, sigmas));
-   }
-
-   // calculate relative values
-   for (const auto& wire_t0 : theAbsoluteT0PerWire)
-   {
-      const auto& wire_id = wire_t0.first;
-      const auto& chamber_id = wire_id.chamberId();
-      const auto& t0 = wire_t0.second;
-      theRelativeT0PerWire.emplace(wire_id, t0 - mean_per_chamber[chamber_id].first);
-      cout << "[DTT0Calibration] Wire " << wire_id << " has    t0 "<< theRelativeT0PerWire[wire_id] << " (relative, after even-odd layer corrections)  "
-         << "    sigma "<< sqrt(theSigmaT0PerWire[wire_id]) <<endl;
-   }
-
-   for(const auto& wire_t0 : theRelativeT0PerWire)
-   {
-      const auto& wire_id = wire_t0.first;
-      const auto& t0 = wire_t0.second;
-      t0sWRTChamber->set(wire_id,
-            t0,
-            sqrt(theSigmaT0PerWire[wire_id]),
-            DTTimeUnits::counts
-            );
-   }
-
-   ///Write the t0 map into DB
-   if(debug) 
-      cout << "[DTT0Calibration]Writing values in DB!" << endl;
-   // FIXME: to be read from cfg?
-   string t0Record = "DTT0Rcd";
-   // Write the t0 map to DB
-   DTCalibDBUtils::writeToDB(t0Record, t0sWRTChamber);
-   delete t0sWRTChamber;
+  ///Write the t0 map into DB
+  if (debug)
+    cout << "[DTT0Calibration]Writing values in DB!" << endl;
+  // FIXME: to be read from cfg?
+  string t0Record = "DTT0Rcd";
+  // Write the t0 map to DB
+  DTCalibDBUtils::writeToDB(t0Record, t0sWRTChamber);
+  delete t0sWRTChamber;
 }
 
 string DTT0Calibration::getHistoName(const DTWireId& wId) const {
-   string histoName;
-   stringstream theStream;
-   theStream << "Ch_" << wId.wheel() << "_" << wId.station() << "_" << wId.sector()
-      << "_SL" << wId.superlayer() << "_L" << wId.layer() << "_W"<< wId.wire() <<"_hT0Histo";
-   theStream >> histoName;
-   return histoName;
+  string histoName;
+  stringstream theStream;
+  theStream << "Ch_" << wId.wheel() << "_" << wId.station() << "_" << wId.sector() << "_SL" << wId.superlayer() << "_L"
+            << wId.layer() << "_W" << wId.wire() << "_hT0Histo";
+  theStream >> histoName;
+  return histoName;
 }
 
 string DTT0Calibration::getHistoName(const DTLayerId& lId) const {
-   string histoName;
-   stringstream theStream;
-   theStream << "Ch_" << lId.wheel() << "_" << lId.station() << "_" << lId.sector()
-      << "_SL" << lId.superlayer() << "_L" << lId.layer() <<"_hT0Histo";
-   theStream >> histoName;
-   return histoName;
+  string histoName;
+  stringstream theStream;
+  theStream << "Ch_" << lId.wheel() << "_" << lId.station() << "_" << lId.sector() << "_SL" << lId.superlayer() << "_L"
+            << lId.layer() << "_hT0Histo";
+  theStream >> histoName;
+  return histoName;
 }

--- a/CalibMuon/DTCalibration/plugins/DTT0Calibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0Calibration.h
@@ -44,14 +44,12 @@ public:
   // Operations
 
   /// Fill the maps with t0 (by channel)
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
   /// Compute the mean and the RMS of the t0 from the maps and write them to the DB with channel granularity
   void endJob() override;
 
-
 protected:
-
 private:
   // Generate the histo name
   std::string getHistoName(const DTWireId& wId) const;
@@ -79,7 +77,7 @@ private:
   //Acceptance of t0 w.r.t. reference peak
   double tpPeakWidthPerLayer;
 
-  //Digi's will be rejected if too far from TP peak 
+  //Digi's will be rejected if too far from TP peak
   unsigned int rejectDigiFromPeak;
 
   //The wheels,sector to be calibrated (default All)
@@ -93,7 +91,7 @@ private:
 
   // Histogram containing position of all peaks
   TH1D hLayerPeaks;
-  
+
   TSpectrum spectrum;
 
   //Layer with histos for each wire
@@ -101,29 +99,28 @@ private:
   std::vector<DTLayerId> layerIdWithWireHistos;
 
   //Maps with t0, sigma, number of digi per wire
-  std::map<DTWireId,double> theAbsoluteT0PerWire;
-  std::map<DTWireId,double> theRelativeT0PerWire;
-  std::map<DTWireId,double> theSigmaT0PerWire;
-  std::map<DTWireId,int> nDigiPerWire;
-  std::map<DTWireId,int> nDigiPerWire_ref;
-  std::map<DTWireId,double> mK;
-  std::map<DTWireId,double> mK_ref;
-  std::map<DTWireId,double> qK;
+  std::map<DTWireId, double> theAbsoluteT0PerWire;
+  std::map<DTWireId, double> theRelativeT0PerWire;
+  std::map<DTWireId, double> theSigmaT0PerWire;
+  std::map<DTWireId, int> nDigiPerWire;
+  std::map<DTWireId, int> nDigiPerWire_ref;
+  std::map<DTWireId, double> mK;
+  std::map<DTWireId, double> mK_ref;
+  std::map<DTWireId, double> qK;
   //Map with histo per wire for the chosen layer
-  std::map<DTWireId,TH1I> theHistoWireMap;
+  std::map<DTWireId, TH1I> theHistoWireMap;
   //Map with mean and RMS of t0 per layer
-  std::map<std::string,double> theT0LayerMap;
-  std::map<std::string,double> theSigmaT0LayerMap;
-  std::map<DTLayerId,double> theTPPeakMap;
+  std::map<std::string, double> theT0LayerMap;
+  std::map<std::string, double> theSigmaT0LayerMap;
+  std::map<DTLayerId, double> theTPPeakMap;
   //Ref. t0 per chamber
-  std::map<DTChamberId,double> theSumT0ByChamber;
-  std::map<DTChamberId,int> theCountT0ByChamber;
-  std::map<DTChamberId,double> theSigmaT0ByChamber;
-  std::map<DTChamberId,double> theMeanT0ByChamber;
-  std::map<DTChamberId,double> theRefT0ByChamber;
+  std::map<DTChamberId, double> theSumT0ByChamber;
+  std::map<DTChamberId, int> theCountT0ByChamber;
+  std::map<DTChamberId, double> theSigmaT0ByChamber;
+  std::map<DTChamberId, double> theMeanT0ByChamber;
+  std::map<DTChamberId, double> theRefT0ByChamber;
 
   //DTGeometry used to loop on the SL in the endJob
   edm::ESHandle<DTGeometry> dtGeom;
 };
 #endif
-

--- a/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.cc
@@ -27,18 +27,19 @@ using namespace edm;
 DTT0CalibrationRMS::DTT0CalibrationRMS(const edm::ParameterSet& pset) {
   // Get the debug parameter for verbose output
   debug = pset.getUntrackedParameter<bool>("debug");
-  if(debug)
+  if (debug)
     cout << "[DTT0CalibrationRMS]Constructor called!" << endl;
 
   // Get the label to retrieve digis from the event
   digiLabel = pset.getUntrackedParameter<string>("digiLabel");
 
   // The root file which contain the histos per layer
-  string rootFileName = pset.getUntrackedParameter<string>("rootFileName","DTT0PerLayer.root");
+  string rootFileName = pset.getUntrackedParameter<string>("rootFileName", "DTT0PerLayer.root");
   theFile = new TFile(rootFileName.c_str(), "RECREATE");
 
-  theCalibWheel =  pset.getUntrackedParameter<string>("calibWheel", "All"); //FIXME amke a vector of integer instead of a string
-  if(theCalibWheel != "All") {
+  theCalibWheel =
+      pset.getUntrackedParameter<string>("calibWheel", "All");  //FIXME amke a vector of integer instead of a string
+  if (theCalibWheel != "All") {
     stringstream linestr;
     int selWheel;
     linestr << theCalibWheel;
@@ -47,8 +48,9 @@ DTT0CalibrationRMS::DTT0CalibrationRMS(const edm::ParameterSet& pset) {
   }
 
   // Sector/s to calibrate
-  theCalibSector =  pset.getUntrackedParameter<string>("calibSector", "All"); //FIXME amke a vector of integer instead of a string
-  if(theCalibSector != "All") {
+  theCalibSector =
+      pset.getUntrackedParameter<string>("calibSector", "All");  //FIXME amke a vector of integer instead of a string
+  if (theCalibSector != "All") {
     stringstream linestr;
     int selSector;
     linestr << theCalibSector;
@@ -59,19 +61,19 @@ DTT0CalibrationRMS::DTT0CalibrationRMS(const edm::ParameterSet& pset) {
   vector<string> defaultCell;
   defaultCell.push_back("None");
   cellsWithHistos = pset.getUntrackedParameter<vector<string> >("cellsWithHisto", defaultCell);
-  for(vector<string>::const_iterator cell = cellsWithHistos.begin(); cell != cellsWithHistos.end(); ++cell){
-    if((*cell) != "None"){
+  for (vector<string>::const_iterator cell = cellsWithHistos.begin(); cell != cellsWithHistos.end(); ++cell) {
+    if ((*cell) != "None") {
       stringstream linestr;
-      int wheel,sector,station,sl,layer,wire;
+      int wheel, sector, station, sl, layer, wire;
       linestr << (*cell);
       linestr >> wheel >> sector >> station >> sl >> layer >> wire;
-      wireIdWithHistos.push_back(DTWireId(wheel,station,sector,sl,layer,wire));
+      wireIdWithHistos.push_back(DTWireId(wheel, station, sector, sl, layer, wire));
     }
   }
 
-  hT0SectorHisto=nullptr;
+  hT0SectorHisto = nullptr;
 
-  nevents=0;
+  nevents = 0;
   eventsForLayerT0 = pset.getParameter<unsigned int>("eventsForLayerT0");
   eventsForWireT0 = pset.getParameter<unsigned int>("eventsForWireT0");
   rejectDigiFromPeak = pset.getParameter<unsigned int>("rejectDigiFromPeak");
@@ -81,417 +83,422 @@ DTT0CalibrationRMS::DTT0CalibrationRMS(const edm::ParameterSet& pset) {
 }
 
 // Destructor
-DTT0CalibrationRMS::~DTT0CalibrationRMS(){
-  if(debug)
+DTT0CalibrationRMS::~DTT0CalibrationRMS() {
+  if (debug)
     cout << "[DTT0CalibrationRMS]Destructor called!" << endl;
 
   theFile->Close();
 }
 
- /// Perform the real analysis
-void DTT0CalibrationRMS::analyze(const edm::Event & event, const edm::EventSetup& eventSetup) {
-  if(debug || event.id().event() % 500==0)
-    cout << "--- [DTT0CalibrationRMS] Analysing Event: #Run: " << event.id().run()
-	 << " #Event: " << event.id().event() << endl;
+/// Perform the real analysis
+void DTT0CalibrationRMS::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
+  if (debug || event.id().event() % 500 == 0)
+    cout << "--- [DTT0CalibrationRMS] Analysing Event: #Run: " << event.id().run() << " #Event: " << event.id().event()
+         << endl;
   nevents++;
 
   // Get the digis from the event
-  Handle<DTDigiCollection> digis; 
+  Handle<DTDigiCollection> digis;
   event.getByLabel(digiLabel, digis);
 
   // Get the DT Geometry
   eventSetup.get<MuonGeometryRecord>().get(dtGeom);
 
-  // Iterate through all digi collections ordered by LayerId   
+  // Iterate through all digi collections ordered by LayerId
   DTDigiCollection::DigiRangeIterator dtLayerIt;
-  for (dtLayerIt = digis->begin();
-       dtLayerIt != digis->end();
-       ++dtLayerIt){
+  for (dtLayerIt = digis->begin(); dtLayerIt != digis->end(); ++dtLayerIt) {
     // Get the iterators over the digis associated with this LayerId
     const DTDigiCollection::Range& digiRange = (*dtLayerIt).second;
-  
-    // Get the layerId
-    const DTLayerId layerId = (*dtLayerIt).first; //FIXME: check to be in the right sector
 
-    if((theCalibWheel != "All") && (layerId.superlayerId().chamberId().wheel() != selWheel))
+    // Get the layerId
+    const DTLayerId layerId = (*dtLayerIt).first;  //FIXME: check to be in the right sector
+
+    if ((theCalibWheel != "All") && (layerId.superlayerId().chamberId().wheel() != selWheel))
       continue;
-    if((theCalibSector != "All") && (layerId.superlayerId().chamberId().sector() != selSector))
+    if ((theCalibSector != "All") && (layerId.superlayerId().chamberId().sector() != selSector))
       continue;
- 
+
     //if(debug) {
     //  cout << "Layer " << layerId<<" with "<<distance(digiRange.first, digiRange.second)<<" digi"<<endl;
     //}
 
     // Loop over all digis in the given layer
-    for (DTDigiCollection::const_iterator digi = digiRange.first;
-	 digi != digiRange.second;
-	 ++digi) {
+    for (DTDigiCollection::const_iterator digi = digiRange.first; digi != digiRange.second; ++digi) {
       double t0 = (*digi).countsTDC();
 
       //Use first bunch of events to fill t0 per layer
-      if(nevents < eventsForLayerT0){
-	//Get the per-layer histo from the map
-	TH1I *hT0LayerHisto = theHistoLayerMap[layerId];
-	//If it doesn't exist, book it
-	if(hT0LayerHisto == nullptr){
-	  theFile->cd();
-	  hT0LayerHisto = new TH1I(getHistoName(layerId).c_str(),
-				   "T0 from pulses by layer (TDC counts, 1 TDC count = 0.781 ns)",
-				   200, t0-100, t0+100);
-	  if(debug)
-	    cout << "  New T0 per Layer Histo: " << hT0LayerHisto->GetName() << endl;
-	  theHistoLayerMap[layerId] = hT0LayerHisto;
-	}
-    
-	//Fill the histos
-	theFile->cd();
-	if(hT0LayerHisto != nullptr) {
-	  //  if(debug)
-	  // cout<<"Filling histo "<<hT0LayerHisto->GetName()<<" with digi "<<t0<<" TDC counts"<<endl;
-	  hT0LayerHisto->Fill(t0);
-	}
+      if (nevents < eventsForLayerT0) {
+        //Get the per-layer histo from the map
+        TH1I* hT0LayerHisto = theHistoLayerMap[layerId];
+        //If it doesn't exist, book it
+        if (hT0LayerHisto == nullptr) {
+          theFile->cd();
+          hT0LayerHisto = new TH1I(getHistoName(layerId).c_str(),
+                                   "T0 from pulses by layer (TDC counts, 1 TDC count = 0.781 ns)",
+                                   200,
+                                   t0 - 100,
+                                   t0 + 100);
+          if (debug)
+            cout << "  New T0 per Layer Histo: " << hT0LayerHisto->GetName() << endl;
+          theHistoLayerMap[layerId] = hT0LayerHisto;
+        }
+
+        //Fill the histos
+        theFile->cd();
+        if (hT0LayerHisto != nullptr) {
+          //  if(debug)
+          // cout<<"Filling histo "<<hT0LayerHisto->GetName()<<" with digi "<<t0<<" TDC counts"<<endl;
+          hT0LayerHisto->Fill(t0);
+        }
       }
 
       //Use all the remaining events to compute t0 per wire
-      if(nevents>eventsForLayerT0){
-	// Get the wireId
-	const DTWireId wireId(layerId, (*digi).wire());
-	if(debug) {
-	  cout << "   Wire: " << wireId << endl
-	       << "       time (TDC counts): " << (*digi).countsTDC()<< endl;
-	}   
+      if (nevents > eventsForLayerT0) {
+        // Get the wireId
+        const DTWireId wireId(layerId, (*digi).wire());
+        if (debug) {
+          cout << "   Wire: " << wireId << endl << "       time (TDC counts): " << (*digi).countsTDC() << endl;
+        }
 
-	//Fill the histos per wire for the chosen cells
-	vector<DTWireId>::iterator it_wire = find(wireIdWithHistos.begin(),wireIdWithHistos.end(),wireId);
-	if(it_wire != wireIdWithHistos.end()){
-          if(theHistoWireMap.find(wireId) == theHistoWireMap.end()){
-            theHistoWireMap[wireId] = new TH1I(getHistoName(wireId).c_str(),"T0 from pulses by wire (TDC counts, 1 TDC count = 0.781 ns)",7000,0,7000);
-            if(debug) cout << "  New T0 per wire Histo: " << (theHistoWireMap[wireId])->GetName() << endl;
+        //Fill the histos per wire for the chosen cells
+        vector<DTWireId>::iterator it_wire = find(wireIdWithHistos.begin(), wireIdWithHistos.end(), wireId);
+        if (it_wire != wireIdWithHistos.end()) {
+          if (theHistoWireMap.find(wireId) == theHistoWireMap.end()) {
+            theHistoWireMap[wireId] = new TH1I(getHistoName(wireId).c_str(),
+                                               "T0 from pulses by wire (TDC counts, 1 TDC count = 0.781 ns)",
+                                               7000,
+                                               0,
+                                               7000);
+            if (debug)
+              cout << "  New T0 per wire Histo: " << (theHistoWireMap[wireId])->GetName() << endl;
           }
-          if(theHistoWireMap_ref.find(wireId) == theHistoWireMap_ref.end()){
-            theHistoWireMap_ref[wireId] = new TH1I((getHistoName(wireId) + "_ref").c_str(),"T0 from pulses by wire (TDC counts, 1 TDC count = 0.781 ns)",7000,0,7000);
-            if(debug) cout << "  New T0 per wire Histo: " << (theHistoWireMap_ref[wireId])->GetName() << endl;
+          if (theHistoWireMap_ref.find(wireId) == theHistoWireMap_ref.end()) {
+            theHistoWireMap_ref[wireId] = new TH1I((getHistoName(wireId) + "_ref").c_str(),
+                                                   "T0 from pulses by wire (TDC counts, 1 TDC count = 0.781 ns)",
+                                                   7000,
+                                                   0,
+                                                   7000);
+            if (debug)
+              cout << "  New T0 per wire Histo: " << (theHistoWireMap_ref[wireId])->GetName() << endl;
           }
 
           TH1I* hT0WireHisto = theHistoWireMap[wireId];
-	  //Fill the histos
-	  theFile->cd();
-	  if(hT0WireHisto) hT0WireHisto->Fill(t0);
-	}
+          //Fill the histos
+          theFile->cd();
+          if (hT0WireHisto)
+            hT0WireHisto->Fill(t0);
+        }
 
-	//Check the tzero has reasonable value
-	if(abs(hT0SectorHisto->GetBinCenter(hT0SectorHisto->GetMaximumBin()) - t0) > rejectDigiFromPeak){
-	  if(debug)
-	    cout<<"digi skipped because t0 per sector "<<hT0SectorHisto->GetBinCenter(hT0SectorHisto->GetMaximumBin())<<endl;
-	  continue;
-	}
+        //Check the tzero has reasonable value
+        if (abs(hT0SectorHisto->GetBinCenter(hT0SectorHisto->GetMaximumBin()) - t0) > rejectDigiFromPeak) {
+          if (debug)
+            cout << "digi skipped because t0 per sector "
+                 << hT0SectorHisto->GetBinCenter(hT0SectorHisto->GetMaximumBin()) << endl;
+          continue;
+        }
 
-	//Use second bunch of events to compute a t0 reference per wire
-	if(nevents< (eventsForLayerT0 + eventsForWireT0)){
+        //Use second bunch of events to compute a t0 reference per wire
+        if (nevents < (eventsForLayerT0 + eventsForWireT0)) {
           //Fill reference wire histos
-          if(it_wire != wireIdWithHistos.end()){
+          if (it_wire != wireIdWithHistos.end()) {
             TH1I* hT0WireHisto_ref = theHistoWireMap_ref[wireId];
             theFile->cd();
-            if(hT0WireHisto_ref) hT0WireHisto_ref->Fill(t0); 
-          } 
-	  if(!nDigiPerWire_ref[wireId]){
-	    mK_ref[wireId] = 0;
-	  }
-	  nDigiPerWire_ref[wireId] = nDigiPerWire_ref[wireId] + 1;
-	  mK_ref[wireId] = mK_ref[wireId] + (t0-mK_ref[wireId])/nDigiPerWire_ref[wireId];
-	}
-	//Use last all the remaining events to compute the mean and sigma t0 per wire
-	else if(nevents>(eventsForLayerT0 + eventsForWireT0)){
-	  if(abs(t0-mK_ref[wireId]) > tpPeakWidth)
-	    continue;
-	  if(!nDigiPerWire[wireId]){
-	    theAbsoluteT0PerWire[wireId] = 0;
-	    qK[wireId] = 0;
-	    mK[wireId] = 0;
-	  }
-	  nDigiPerWire[wireId] = nDigiPerWire[wireId] + 1;
-	  theAbsoluteT0PerWire[wireId] = theAbsoluteT0PerWire[wireId] + t0;
-	  //theSigmaT0PerWire[wireId] = theSigmaT0PerWire[wireId] + (t0*t0);
-	  qK[wireId] = qK[wireId] + ((nDigiPerWire[wireId]-1)*(t0-mK[wireId])*(t0-mK[wireId])/nDigiPerWire[wireId]);
-	  mK[wireId] = mK[wireId] + (t0-mK[wireId])/nDigiPerWire[wireId];
-	}
-      }//end if(nevents>1000)
-    }//end loop on digi
-  }//end loop on layer
+            if (hT0WireHisto_ref)
+              hT0WireHisto_ref->Fill(t0);
+          }
+          if (!nDigiPerWire_ref[wireId]) {
+            mK_ref[wireId] = 0;
+          }
+          nDigiPerWire_ref[wireId] = nDigiPerWire_ref[wireId] + 1;
+          mK_ref[wireId] = mK_ref[wireId] + (t0 - mK_ref[wireId]) / nDigiPerWire_ref[wireId];
+        }
+        //Use last all the remaining events to compute the mean and sigma t0 per wire
+        else if (nevents > (eventsForLayerT0 + eventsForWireT0)) {
+          if (abs(t0 - mK_ref[wireId]) > tpPeakWidth)
+            continue;
+          if (!nDigiPerWire[wireId]) {
+            theAbsoluteT0PerWire[wireId] = 0;
+            qK[wireId] = 0;
+            mK[wireId] = 0;
+          }
+          nDigiPerWire[wireId] = nDigiPerWire[wireId] + 1;
+          theAbsoluteT0PerWire[wireId] = theAbsoluteT0PerWire[wireId] + t0;
+          //theSigmaT0PerWire[wireId] = theSigmaT0PerWire[wireId] + (t0*t0);
+          qK[wireId] =
+              qK[wireId] + ((nDigiPerWire[wireId] - 1) * (t0 - mK[wireId]) * (t0 - mK[wireId]) / nDigiPerWire[wireId]);
+          mK[wireId] = mK[wireId] + (t0 - mK[wireId]) / nDigiPerWire[wireId];
+        }
+      }  //end if(nevents>1000)
+    }    //end loop on digi
+  }      //end loop on layer
 
-  //Use the t0 per layer histos to have an indication about the t0 position 
-  if(nevents == eventsForLayerT0){
-    for(map<DTLayerId, TH1I*>::const_iterator lHisto = theHistoLayerMap.begin();
-	lHisto != theHistoLayerMap.end();
-	++lHisto){
-      if(debug)
-	cout<<"Reading histogram "<<(*lHisto).second->GetName()<<" with mean "<<(*lHisto).second->GetMean()<<" and RMS "<<(*lHisto).second->GetRMS();
+  //Use the t0 per layer histos to have an indication about the t0 position
+  if (nevents == eventsForLayerT0) {
+    for (map<DTLayerId, TH1I*>::const_iterator lHisto = theHistoLayerMap.begin(); lHisto != theHistoLayerMap.end();
+         ++lHisto) {
+      if (debug)
+        cout << "Reading histogram " << (*lHisto).second->GetName() << " with mean " << (*lHisto).second->GetMean()
+             << " and RMS " << (*lHisto).second->GetRMS();
 
       //Take the mean as a first t0 estimation
-      if((*lHisto).second->GetRMS()<5.0){
-	if(hT0SectorHisto == nullptr){
-	  hT0SectorHisto = new TH1D("hT0AllLayerOfSector","T0 from pulses per layer in sector", 
-				    //20, (*lHisto).second->GetMean()-100, (*lHisto).second->GetMean()+100);
-				    700, 0, 7000);
-	}
-	if(debug)
-	  cout<<" accepted"<<endl;
-	hT0SectorHisto->Fill((*lHisto).second->GetMean());
+      if ((*lHisto).second->GetRMS() < 5.0) {
+        if (hT0SectorHisto == nullptr) {
+          hT0SectorHisto = new TH1D("hT0AllLayerOfSector",
+                                    "T0 from pulses per layer in sector",
+                                    //20, (*lHisto).second->GetMean()-100, (*lHisto).second->GetMean()+100);
+                                    700,
+                                    0,
+                                    7000);
+        }
+        if (debug)
+          cout << " accepted" << endl;
+        hT0SectorHisto->Fill((*lHisto).second->GetMean());
       }
       //Take the mean of noise + 400ns as a first t0 estimation
       // if((*lHisto).second->GetRMS()>10.0 && ((*lHisto).second->GetRMS()<15.0)){
-// 	double t0_estim = (*lHisto).second->GetMean() + 400;
-// 	if(hT0SectorHisto == 0){
-// 	  hT0SectorHisto = new TH1D("hT0AllLayerOfSector","T0 from pulses per layer in sector", 
-// 				    //20, t0_estim-100, t0_estim+100);
-// 				    700, 0, 7000);
-// 	}
-// 	if(debug)
-// 	  cout<<" accepted + 400ns"<<endl;
-// 	hT0SectorHisto->Fill((*lHisto).second->GetMean() + 400);
-//       }
-      if(debug)
-	cout<<endl;
+      // 	double t0_estim = (*lHisto).second->GetMean() + 400;
+      // 	if(hT0SectorHisto == 0){
+      // 	  hT0SectorHisto = new TH1D("hT0AllLayerOfSector","T0 from pulses per layer in sector",
+      // 				    //20, t0_estim-100, t0_estim+100);
+      // 				    700, 0, 7000);
+      // 	}
+      // 	if(debug)
+      // 	  cout<<" accepted + 400ns"<<endl;
+      // 	hT0SectorHisto->Fill((*lHisto).second->GetMean() + 400);
+      //       }
+      if (debug)
+        cout << endl;
 
       theT0LayerMap[(*lHisto).second->GetName()] = (*lHisto).second->GetMean();
       theSigmaT0LayerMap[(*lHisto).second->GetName()] = (*lHisto).second->GetRMS();
     }
-    if(!hT0SectorHisto){
-      cout<<"[DTT0CalibrationRMS]: All the t0 per layer are still uncorrect: trying with greater number of events"<<endl;
-      eventsForLayerT0 = eventsForLayerT0*2;
+    if (!hT0SectorHisto) {
+      cout << "[DTT0CalibrationRMS]: All the t0 per layer are still uncorrect: trying with greater number of events"
+           << endl;
+      eventsForLayerT0 = eventsForLayerT0 * 2;
       return;
     }
-    if(debug)
-      cout<<"[DTT0CalibrationRMS] t0 reference for this sector "<<
-	hT0SectorHisto->GetBinCenter(hT0SectorHisto->GetMaximumBin())<<endl;
-  } 
+    if (debug)
+      cout << "[DTT0CalibrationRMS] t0 reference for this sector "
+           << hT0SectorHisto->GetBinCenter(hT0SectorHisto->GetMaximumBin()) << endl;
+  }
 }
 
-
 void DTT0CalibrationRMS::endJob() {
-
   DTT0* t0sAbsolute = new DTT0();
   DTT0* t0sRelative = new DTT0();
   DTT0* t0sWRTChamber = new DTT0();
 
   //if(debug)
-    cout << "[DTT0CalibrationRMSPerLayer]Writing histos to file!" << endl;
+  cout << "[DTT0CalibrationRMSPerLayer]Writing histos to file!" << endl;
 
   theFile->cd();
   theFile->WriteTObject(hT0SectorHisto);
   //hT0SectorHisto->Write();
-  for(map<DTWireId, TH1I*>::const_iterator wHisto = theHistoWireMap.begin();
-      wHisto != theHistoWireMap.end();
-      ++wHisto) {
-    (*wHisto).second->Write(); 
-  }
-  for(map<DTWireId, TH1I*>::const_iterator wHisto = theHistoWireMap_ref.begin();
-      wHisto != theHistoWireMap_ref.end();
-      ++wHisto) {
+  for (map<DTWireId, TH1I*>::const_iterator wHisto = theHistoWireMap.begin(); wHisto != theHistoWireMap.end();
+       ++wHisto) {
     (*wHisto).second->Write();
   }
-  for(map<DTLayerId, TH1I*>::const_iterator lHisto = theHistoLayerMap.begin();
-      lHisto != theHistoLayerMap.end();
-      ++lHisto) {
-    (*lHisto).second->Write(); 
-  }  
+  for (map<DTWireId, TH1I*>::const_iterator wHisto = theHistoWireMap_ref.begin(); wHisto != theHistoWireMap_ref.end();
+       ++wHisto) {
+    (*wHisto).second->Write();
+  }
+  for (map<DTLayerId, TH1I*>::const_iterator lHisto = theHistoLayerMap.begin(); lHisto != theHistoLayerMap.end();
+       ++lHisto) {
+    (*lHisto).second->Write();
+  }
 
   //if(debug)
-    cout << "[DTT0CalibrationRMS] Compute and store t0 and sigma per wire" << endl;
+  cout << "[DTT0CalibrationRMS] Compute and store t0 and sigma per wire" << endl;
 
-  for(map<DTWireId, double>::const_iterator wiret0 = theAbsoluteT0PerWire.begin();
-      wiret0 != theAbsoluteT0PerWire.end();
-      ++wiret0){
-    if(nDigiPerWire[(*wiret0).first]){
-      double t0 = (*wiret0).second/nDigiPerWire[(*wiret0).first];
+  for (map<DTWireId, double>::const_iterator wiret0 = theAbsoluteT0PerWire.begin();
+       wiret0 != theAbsoluteT0PerWire.end();
+       ++wiret0) {
+    if (nDigiPerWire[(*wiret0).first]) {
+      double t0 = (*wiret0).second / nDigiPerWire[(*wiret0).first];
 
       theRelativeT0PerWire[(*wiret0).first] = t0 - hT0SectorHisto->GetBinCenter(hT0SectorHisto->GetMaximumBin());
 
       //theSigmaT0PerWire[(*wiret0).first] = sqrt((theSigmaT0PerWire[(*wiret0).first] / nDigiPerWire[(*wiret0).first]) - t0*t0);
-      theSigmaT0PerWire[(*wiret0).first] = sqrt(qK[(*wiret0).first]/nDigiPerWire[(*wiret0).first]);
+      theSigmaT0PerWire[(*wiret0).first] = sqrt(qK[(*wiret0).first] / nDigiPerWire[(*wiret0).first]);
 
-      cout << "Wire " << (*wiret0).first << " has t0 " << t0 << "(absolute) "
-                                                       << theRelativeT0PerWire[(*wiret0).first] << "(relative)"
-                                         << "    sigma " << theSigmaT0PerWire[(*wiret0).first] << endl;
+      cout << "Wire " << (*wiret0).first << " has t0 " << t0 << "(absolute) " << theRelativeT0PerWire[(*wiret0).first]
+           << "(relative)"
+           << "    sigma " << theSigmaT0PerWire[(*wiret0).first] << endl;
 
-      t0sAbsolute->set((*wiret0).first, t0, theSigmaT0PerWire[(*wiret0).first],DTTimeUnits::counts); 
-    }
-    else{
-      cout<<"[DTT0CalibrationRMS] ERROR: no digis in wire "<<(*wiret0).first<<endl;
+      t0sAbsolute->set((*wiret0).first, t0, theSigmaT0PerWire[(*wiret0).first], DTTimeUnits::counts);
+    } else {
+      cout << "[DTT0CalibrationRMS] ERROR: no digis in wire " << (*wiret0).first << endl;
       abort();
     }
   }
 
-  if(correctByChamberMean_){
-     ///Loop on superlayer to correct between even-odd layers (2 different test pulse lines!)
-     // Get all the sls from the setup
-     const vector<const DTSuperLayer*> superLayers = dtGeom->superLayers();     
-     // Loop over all SLs
-     for(vector<const DTSuperLayer*>::const_iterator  sl = superLayers.begin();
-	   sl != superLayers.end(); sl++) {
+  if (correctByChamberMean_) {
+    ///Loop on superlayer to correct between even-odd layers (2 different test pulse lines!)
+    // Get all the sls from the setup
+    const vector<const DTSuperLayer*> superLayers = dtGeom->superLayers();
+    // Loop over all SLs
+    for (vector<const DTSuperLayer*>::const_iterator sl = superLayers.begin(); sl != superLayers.end(); sl++) {
+      //Compute mean for odd and even superlayers
+      double oddLayersMean = 0;
+      double evenLayersMean = 0;
+      double oddLayersDen = 0;
+      double evenLayersDen = 0;
+      for (map<DTWireId, double>::const_iterator wiret0 = theRelativeT0PerWire.begin();
+           wiret0 != theRelativeT0PerWire.end();
+           ++wiret0) {
+        if ((*wiret0).first.layerId().superlayerId() == (*sl)->id()) {
+          if (debug)
+            cout << "[DTT0CalibrationRMS] Superlayer " << (*sl)->id() << "layer " << (*wiret0).first.layerId().layer()
+                 << " with " << (*wiret0).second << endl;
+          if (((*wiret0).first.layerId().layer()) % 2) {
+            oddLayersMean = oddLayersMean + (*wiret0).second;
+            oddLayersDen++;
+          } else {
+            evenLayersMean = evenLayersMean + (*wiret0).second;
+            evenLayersDen++;
+          }
+        }
+      }
+      oddLayersMean = oddLayersMean / oddLayersDen;
+      evenLayersMean = evenLayersMean / evenLayersDen;
+      //if(debug && oddLayersMean)
+      cout << "[DTT0CalibrationRMS] Relative T0 mean for  odd layers " << oddLayersMean << "  even layers"
+           << evenLayersMean << endl;
 
+      //Compute sigma for odd and even superlayers
+      double oddLayersSigma = 0;
+      double evenLayersSigma = 0;
+      for (map<DTWireId, double>::const_iterator wiret0 = theRelativeT0PerWire.begin();
+           wiret0 != theRelativeT0PerWire.end();
+           ++wiret0) {
+        if ((*wiret0).first.layerId().superlayerId() == (*sl)->id()) {
+          if (((*wiret0).first.layerId().layer()) % 2) {
+            oddLayersSigma = oddLayersSigma + ((*wiret0).second - oddLayersMean) * ((*wiret0).second - oddLayersMean);
+          } else {
+            evenLayersSigma =
+                evenLayersSigma + ((*wiret0).second - evenLayersMean) * ((*wiret0).second - evenLayersMean);
+          }
+        }
+      }
+      oddLayersSigma = oddLayersSigma / oddLayersDen;
+      evenLayersSigma = evenLayersSigma / evenLayersDen;
+      oddLayersSigma = sqrt(oddLayersSigma);
+      evenLayersSigma = sqrt(evenLayersSigma);
 
-	//Compute mean for odd and even superlayers
-	double oddLayersMean=0;
-	double evenLayersMean=0; 
-	double oddLayersDen=0;
-	double evenLayersDen=0;
-	for(map<DTWireId, double>::const_iterator wiret0 = theRelativeT0PerWire.begin();
-	      wiret0 != theRelativeT0PerWire.end();
-	      ++wiret0){
-	   if((*wiret0).first.layerId().superlayerId() == (*sl)->id()){
-	      if(debug)
-		 cout<<"[DTT0CalibrationRMS] Superlayer "<<(*sl)->id()
-		    <<"layer " <<(*wiret0).first.layerId().layer()<<" with "<<(*wiret0).second<<endl;
-	      if(((*wiret0).first.layerId().layer()) % 2){
-		 oddLayersMean = oddLayersMean + (*wiret0).second;
-		 oddLayersDen++;
-	      }
-	      else{
-		 evenLayersMean = evenLayersMean + (*wiret0).second;
-		 evenLayersDen++;
-	      }
-	   }
-	}
-	oddLayersMean = oddLayersMean/oddLayersDen;
-	evenLayersMean = evenLayersMean/evenLayersDen;
-	//if(debug && oddLayersMean)
-	cout<<"[DTT0CalibrationRMS] Relative T0 mean for  odd layers "<<oddLayersMean<<"  even layers"<<evenLayersMean<<endl;
+      //if(debug && oddLayersMean)
+      cout << "[DTT0CalibrationRMS] Relative T0 sigma for  odd layers " << oddLayersSigma << "  even layers"
+           << evenLayersSigma << endl;
 
-	//Compute sigma for odd and even superlayers
-	double oddLayersSigma=0;
-	double evenLayersSigma=0;
-	for(map<DTWireId, double>::const_iterator wiret0 = theRelativeT0PerWire.begin();
-	      wiret0 != theRelativeT0PerWire.end();
-	      ++wiret0){
-	   if((*wiret0).first.layerId().superlayerId() == (*sl)->id()){
-	      if(((*wiret0).first.layerId().layer()) % 2){
-		 oddLayersSigma = oddLayersSigma + ((*wiret0).second - oddLayersMean) * ((*wiret0).second - oddLayersMean);
-	      }
-	      else{
-		 evenLayersSigma = evenLayersSigma + ((*wiret0).second - evenLayersMean) * ((*wiret0).second - evenLayersMean);
-	      }
-	   }
-	}
-	oddLayersSigma = oddLayersSigma/oddLayersDen;
-	evenLayersSigma = evenLayersSigma/evenLayersDen;
-	oddLayersSigma = sqrt(oddLayersSigma);
-	evenLayersSigma = sqrt(evenLayersSigma);
+      //Recompute the mean for odd and even superlayers discarding fluctations
+      double oddLayersFinalMean = 0;
+      double evenLayersFinalMean = 0;
+      for (map<DTWireId, double>::const_iterator wiret0 = theRelativeT0PerWire.begin();
+           wiret0 != theRelativeT0PerWire.end();
+           ++wiret0) {
+        if ((*wiret0).first.layerId().superlayerId() == (*sl)->id()) {
+          if (((*wiret0).first.layerId().layer()) % 2) {
+            if (abs((*wiret0).second - oddLayersMean) < (2 * oddLayersSigma))
+              oddLayersFinalMean = oddLayersFinalMean + (*wiret0).second;
+          } else {
+            if (abs((*wiret0).second - evenLayersMean) < (2 * evenLayersSigma))
+              evenLayersFinalMean = evenLayersFinalMean + (*wiret0).second;
+          }
+        }
+      }
+      oddLayersFinalMean = oddLayersFinalMean / oddLayersDen;
+      evenLayersFinalMean = evenLayersFinalMean / evenLayersDen;
+      //if(debug && oddLayersMean)
+      cout << "[DTT0CalibrationRMS] Final relative T0 mean for  odd layers " << oddLayersFinalMean << "  even layers"
+           << evenLayersFinalMean << endl;
 
-	//if(debug && oddLayersMean)
-	cout<<"[DTT0CalibrationRMS] Relative T0 sigma for  odd layers "<<oddLayersSigma<<"  even layers"<<evenLayersSigma<<endl;
+      for (map<DTWireId, double>::const_iterator wiret0 = theRelativeT0PerWire.begin();
+           wiret0 != theRelativeT0PerWire.end();
+           ++wiret0) {
+        if ((*wiret0).first.layerId().superlayerId() == (*sl)->id()) {
+          double t0 = -999;
+          if (((*wiret0).first.layerId().layer()) % 2)
+            t0 = (*wiret0).second + (evenLayersFinalMean - oddLayersFinalMean);
+          else
+            t0 = (*wiret0).second;
 
-	//Recompute the mean for odd and even superlayers discarding fluctations
-	double oddLayersFinalMean=0;
-	double evenLayersFinalMean=0;
-	for(map<DTWireId, double>::const_iterator wiret0 = theRelativeT0PerWire.begin();
-	      wiret0 != theRelativeT0PerWire.end();
-	      ++wiret0){
-	   if((*wiret0).first.layerId().superlayerId() == (*sl)->id()){
-	      if(((*wiret0).first.layerId().layer()) % 2){
-		 if(abs((*wiret0).second - oddLayersMean) < (2*oddLayersSigma))
-		    oddLayersFinalMean = oddLayersFinalMean + (*wiret0).second;
-	      }
-	      else{
-		 if(abs((*wiret0).second - evenLayersMean) < (2*evenLayersSigma))
-		    evenLayersFinalMean = evenLayersFinalMean + (*wiret0).second;
-	      }
-	   }
-	}
-	oddLayersFinalMean = oddLayersFinalMean/oddLayersDen;
-	evenLayersFinalMean = evenLayersFinalMean/evenLayersDen;
-	//if(debug && oddLayersMean)
-	cout<<"[DTT0CalibrationRMS] Final relative T0 mean for  odd layers "<<oddLayersFinalMean<<"  even layers"<<evenLayersFinalMean<<endl;
+          cout << "[DTT0CalibrationRMS] Wire " << (*wiret0).first << " has t0 " << (*wiret0).second
+               << " (relative, after even-odd layer corrections)  "
+               << "    sigma " << theSigmaT0PerWire[(*wiret0).first] << endl;
 
-	for(map<DTWireId, double>::const_iterator wiret0 = theRelativeT0PerWire.begin();
-	      wiret0 != theRelativeT0PerWire.end();
-	      ++wiret0){
-	   if((*wiret0).first.layerId().superlayerId() == (*sl)->id()){
-	      double t0=-999;
-	      if(((*wiret0).first.layerId().layer()) % 2)
-		 t0 = (*wiret0).second + (evenLayersFinalMean - oddLayersFinalMean);
-	      else
-		 t0 = (*wiret0).second;
+          //Store the results into DB
+          t0sRelative->set((*wiret0).first, t0, theSigmaT0PerWire[(*wiret0).first], DTTimeUnits::counts);
+        }
+      }
+    }
 
-	      cout << "[DTT0CalibrationRMS] Wire " << (*wiret0).first << " has t0 " << (*wiret0).second
-                   << " (relative, after even-odd layer corrections)  "
-		   << "    sigma " << theSigmaT0PerWire[(*wiret0).first] << endl;
+    ///Change t0 absolute reference -> from sector peak to chamber average
+    //if(debug)
+    cout << "[DTT0CalibrationRMS]Computing relative t0 wrt to chamber average" << endl;
+    //Compute the reference for each chamber
+    map<DTChamberId, double> sumT0ByChamber;
+    map<DTChamberId, int> countT0ByChamber;
+    for (DTT0::const_iterator tzero = t0sRelative->begin(); tzero != t0sRelative->end(); ++tzero) {
+      int channelId = tzero->channelId;
+      if (channelId == 0)
+        continue;
+      DTWireId wireId(channelId);
+      DTChamberId chamberId(wireId.chamberId());
+      //sumT0ByChamber[chamberId] = sumT0ByChamber[chamberId] + tzero->t0mean;
+      // @@@ better DTT0 usage
+      float t0mean_f;
+      float t0rms_f;
+      t0sRelative->get(wireId, t0mean_f, t0rms_f, DTTimeUnits::counts);
+      sumT0ByChamber[chamberId] = sumT0ByChamber[chamberId] + t0mean_f;
+      // @@@ NEW DTT0 END
+      countT0ByChamber[chamberId]++;
+    }
 
-	      //Store the results into DB
-	      t0sRelative->set((*wiret0).first, t0, theSigmaT0PerWire[(*wiret0).first],DTTimeUnits::counts); 
-	   }
-	}
-     }
-
-     ///Change t0 absolute reference -> from sector peak to chamber average
-     //if(debug)
-     cout << "[DTT0CalibrationRMS]Computing relative t0 wrt to chamber average" << endl;
-     //Compute the reference for each chamber
-     map<DTChamberId,double> sumT0ByChamber;
-     map<DTChamberId,int> countT0ByChamber;
-     for(DTT0::const_iterator tzero = t0sRelative->begin();
-	   tzero != t0sRelative->end(); ++tzero) {
-        int channelId = tzero->channelId;
-        if ( channelId == 0 ) continue;
-        DTWireId wireId(channelId);
-        DTChamberId chamberId(wireId.chamberId());
-        //sumT0ByChamber[chamberId] = sumT0ByChamber[chamberId] + tzero->t0mean;
-        // @@@ better DTT0 usage
-        float t0mean_f;
-        float t0rms_f;
-        t0sRelative->get(wireId,t0mean_f,t0rms_f,DTTimeUnits::counts);
-        sumT0ByChamber[chamberId] = sumT0ByChamber[chamberId] + t0mean_f;
-        // @@@ NEW DTT0 END
-	countT0ByChamber[chamberId]++;
-     }
-
-     //Change reference for each wire and store the new t0s in the new map
-     for(DTT0::const_iterator tzero = t0sRelative->begin();
-	   tzero != t0sRelative->end(); ++tzero) {
-	int channelId = tzero->channelId;
-	if ( channelId == 0 ) continue;
-	DTWireId wireId(channelId);
-	DTChamberId chamberId(wireId.chamberId());
-	//double t0mean = (tzero->t0mean) - (sumT0ByChamber[chamberId]/countT0ByChamber[chamberId]);
-	//double t0rms = tzero->t0rms;
-	// @@@ better DTT0 usage
-	float t0mean_f;
-	float t0rms_f;
-	t0sRelative->get(wireId,t0mean_f,t0rms_f,DTTimeUnits::counts);
-	double t0mean = t0mean_f - (sumT0ByChamber[chamberId]/countT0ByChamber[chamberId]);
-	double t0rms = t0rms_f;
-	// @@@ NEW DTT0 END
-	t0sWRTChamber->set(wireId,
-	      t0mean,
-	      t0rms,
-	      DTTimeUnits::counts);
-	//if(debug)
-	//cout<<"Chamber "<<chamberId<<" has reference "<<(sumT0ByChamber[chamberId]/countT0ByChamber[chamberId]);
-	cout << "Changing t0 of wire " << wireId << " from " << t0mean_f
-	     << " to " << t0mean << endl;
-     }
+    //Change reference for each wire and store the new t0s in the new map
+    for (DTT0::const_iterator tzero = t0sRelative->begin(); tzero != t0sRelative->end(); ++tzero) {
+      int channelId = tzero->channelId;
+      if (channelId == 0)
+        continue;
+      DTWireId wireId(channelId);
+      DTChamberId chamberId(wireId.chamberId());
+      //double t0mean = (tzero->t0mean) - (sumT0ByChamber[chamberId]/countT0ByChamber[chamberId]);
+      //double t0rms = tzero->t0rms;
+      // @@@ better DTT0 usage
+      float t0mean_f;
+      float t0rms_f;
+      t0sRelative->get(wireId, t0mean_f, t0rms_f, DTTimeUnits::counts);
+      double t0mean = t0mean_f - (sumT0ByChamber[chamberId] / countT0ByChamber[chamberId]);
+      double t0rms = t0rms_f;
+      // @@@ NEW DTT0 END
+      t0sWRTChamber->set(wireId, t0mean, t0rms, DTTimeUnits::counts);
+      //if(debug)
+      //cout<<"Chamber "<<chamberId<<" has reference "<<(sumT0ByChamber[chamberId]/countT0ByChamber[chamberId]);
+      cout << "Changing t0 of wire " << wireId << " from " << t0mean_f << " to " << t0mean << endl;
+    }
   }
 
   ///Write the t0 map into DB
-  if(debug)
-   cout << "[DTT0CalibrationRMS]Writing values in DB!" << endl;
+  if (debug)
+    cout << "[DTT0CalibrationRMS]Writing values in DB!" << endl;
   // FIXME: to be read from cfg?
   string t0Record = "DTT0Rcd";
   // Write the t0 map to DB
-  if( correctByChamberMean_ ) DTCalibDBUtils::writeToDB(t0Record, t0sWRTChamber);
-  else                        DTCalibDBUtils::writeToDB(t0Record, t0sAbsolute);
+  if (correctByChamberMean_)
+    DTCalibDBUtils::writeToDB(t0Record, t0sWRTChamber);
+  else
+    DTCalibDBUtils::writeToDB(t0Record, t0sAbsolute);
 }
 
 string DTT0CalibrationRMS::getHistoName(const DTWireId& wId) const {
-  string histoName = "Ch_" + std::to_string(wId.wheel()) + "_" + std::to_string(wId.station())
-                     + "_" + std::to_string(wId.sector()) + "_SL" + std::to_string(wId.superlayer())
-                     + "_L" + std::to_string(wId.layer()) + "_W" + std::to_string(wId.wire()) + "_hT0Histo";
+  string histoName = "Ch_" + std::to_string(wId.wheel()) + "_" + std::to_string(wId.station()) + "_" +
+                     std::to_string(wId.sector()) + "_SL" + std::to_string(wId.superlayer()) + "_L" +
+                     std::to_string(wId.layer()) + "_W" + std::to_string(wId.wire()) + "_hT0Histo";
   return histoName;
 }
 
 string DTT0CalibrationRMS::getHistoName(const DTLayerId& lId) const {
-  string histoName = "Ch_" + std::to_string(lId.wheel()) + "_" + std::to_string(lId.station())
-                     + "_" + std::to_string(lId.sector()) + "_SL" + std::to_string(lId.superlayer())
-                     + "_L" + std::to_string(lId.layer()) + "_hT0Histo";
+  string histoName = "Ch_" + std::to_string(lId.wheel()) + "_" + std::to_string(lId.station()) + "_" +
+                     std::to_string(lId.sector()) + "_SL" + std::to_string(lId.superlayer()) + "_L" +
+                     std::to_string(lId.layer()) + "_hT0Histo";
   return histoName;
 }

--- a/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.h
@@ -34,14 +34,12 @@ public:
   // Operations
 
   /// Fill the maps with t0 (by channel)
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
   /// Compute the mean and the RMS of the t0 from the maps and write them to the DB with channel granularity
   void endJob() override;
 
-
 protected:
-
 private:
   // Generate the histo name
   std::string getHistoName(const DTWireId& wId) const;
@@ -54,9 +52,9 @@ private:
   std::string digiLabel;
 
   // The root file which contain the histos per layer
-  TFile *theFile;
+  TFile* theFile;
   // The root file which will contain the histos per wire (for the given layer)
-  TFile *theOutputFile;
+  TFile* theOutputFile;
 
   //The event counter
   unsigned int nevents;
@@ -84,26 +82,26 @@ private:
   std::map<DTLayerId, TH1I*> theHistoLayerMap;
   //Histo with t0 mean per layer for all the sector
   TH1D* hT0SectorHisto;
-  
+
   //Layer with histos for each wire
   std::vector<DTWireId> wireIdWithHistos;
   std::vector<std::string> cellsWithHistos;
 
   //Maps with t0, sigma, number of digi per wire
-  std::map<DTWireId,double> theAbsoluteT0PerWire;
-  std::map<DTWireId,double> theRelativeT0PerWire;
-  std::map<DTWireId,double> theSigmaT0PerWire;
-  std::map<DTWireId,int> nDigiPerWire;
-  std::map<DTWireId,int> nDigiPerWire_ref;
-  std::map<DTWireId,double> mK;
-  std::map<DTWireId,double> mK_ref;
-  std::map<DTWireId,double> qK;
+  std::map<DTWireId, double> theAbsoluteT0PerWire;
+  std::map<DTWireId, double> theRelativeT0PerWire;
+  std::map<DTWireId, double> theSigmaT0PerWire;
+  std::map<DTWireId, int> nDigiPerWire;
+  std::map<DTWireId, int> nDigiPerWire_ref;
+  std::map<DTWireId, double> mK;
+  std::map<DTWireId, double> mK_ref;
+  std::map<DTWireId, double> qK;
   //Map with histo per wire for the chosen layer
-  std::map<DTWireId,TH1I*> theHistoWireMap;
-  std::map<DTWireId,TH1I*> theHistoWireMap_ref;
+  std::map<DTWireId, TH1I*> theHistoWireMap;
+  std::map<DTWireId, TH1I*> theHistoWireMap_ref;
   //Map with mean and RMS of t0 per layer
-  std::map<std::string,double> theT0LayerMap;
-  std::map<std::string,double> theSigmaT0LayerMap;
+  std::map<std::string, double> theT0LayerMap;
+  std::map<std::string, double> theSigmaT0LayerMap;
 
   //DTGeometry used to loop on the SL in the endJob
   edm::ESHandle<DTGeometry> dtGeom;

--- a/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.cc
@@ -21,66 +21,63 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTT0ChamberReferenceCorrection::DTT0ChamberReferenceCorrection(const ParameterSet& pset):
-  calibChamber_( pset.getParameter<string>("calibChamber") ) {
-
-  //DTChamberId chosenChamberId;
-  if( !calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All" ){
-    stringstream linestr;
-    int selWheel, selStation, selSector;
-    linestr << calibChamber_;
-    linestr >> selWheel >> selStation >> selSector;
-    chosenChamberId_ = DTChamberId(selWheel, selStation, selSector);
-    LogVerbatim("Calibration") << "[DTT0ChamberReferenceCorrection] Chosen chamber: " << chosenChamberId_ << endl;
+  DTT0ChamberReferenceCorrection::DTT0ChamberReferenceCorrection(const ParameterSet& pset)
+      : calibChamber_(pset.getParameter<string>("calibChamber")) {
+    //DTChamberId chosenChamberId;
+    if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
+      stringstream linestr;
+      int selWheel, selStation, selSector;
+      linestr << calibChamber_;
+      linestr >> selWheel >> selStation >> selSector;
+      chosenChamberId_ = DTChamberId(selWheel, selStation, selSector);
+      LogVerbatim("Calibration") << "[DTT0ChamberReferenceCorrection] Chosen chamber: " << chosenChamberId_ << endl;
+    }
+    //FIXME: Check if chosen chamber is valid.
   }
-  //FIXME: Check if chosen chamber is valid.
 
-}
+  DTT0ChamberReferenceCorrection::~DTT0ChamberReferenceCorrection() {}
 
-DTT0ChamberReferenceCorrection::~DTT0ChamberReferenceCorrection() {
-}
+  void DTT0ChamberReferenceCorrection::setES(const EventSetup& setup) {
+    // Get t0 record from DB
+    ESHandle<DTT0> t0H;
+    setup.get<DTT0Rcd>().get(t0H);
+    t0Map_ = &*t0H;
+    LogVerbatim("Calibration") << "[DTT0ChamberReferenceCorrection] T0 version: " << t0H->version();
+  }
 
-void DTT0ChamberReferenceCorrection::setES(const EventSetup& setup) {
-  // Get t0 record from DB
-  ESHandle<DTT0> t0H;
-  setup.get<DTT0Rcd>().get(t0H);
-  t0Map_ = &*t0H;
-  LogVerbatim("Calibration") << "[DTT0ChamberReferenceCorrection] T0 version: " << t0H->version();
-}
+  DTT0Data DTT0ChamberReferenceCorrection::correction(const DTWireId& wireId) {
+    // Compute for selected chamber (or All) correction using as reference chamber mean
 
-DTT0Data DTT0ChamberReferenceCorrection::correction(const DTWireId& wireId) {
-  // Compute for selected chamber (or All) correction using as reference chamber mean
- 
-  DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
+    DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
 
-  if( calibChamber_.empty() || calibChamber_ == "None" )          return defaultT0(wireId);
-  if( calibChamber_ != "All" && chamberId != chosenChamberId_ ) return defaultT0(wireId);
+    if (calibChamber_.empty() || calibChamber_ == "None")
+      return defaultT0(wireId);
+    if (calibChamber_ != "All" && chamberId != chosenChamberId_)
+      return defaultT0(wireId);
 
-  // Access DB
-  float t0Mean,t0RMS;
-  int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-  if(status != 0) 
-     throw cms::Exception("[DTT0ChamberReferenceCorrection]") << "Could not find t0 entry in DB for" 
-                                                              << wireId << endl;
-  /*
+    // Access DB
+    float t0Mean, t0RMS;
+    int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+    if (status != 0)
+      throw cms::Exception("[DTT0ChamberReferenceCorrection]") << "Could not find t0 entry in DB for" << wireId << endl;
+    /*
     Leaving just the structure for future implementation
     ...
     ...
   */
-  return DTT0Data(t0Mean,t0RMS);
-}
-
-DTT0Data DTT0ChamberReferenceCorrection::defaultT0(const DTWireId& wireId) {
-  // Access default DB
-  float t0Mean,t0RMS;
-  int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-  if(!status){
-     return DTT0Data(t0Mean,t0RMS);
-  } else{
-     //... 
-     throw cms::Exception("[DTT0ChamberReferenceCorrection]") << "Could not find t0 entry in DB for"
-		                                              << wireId << endl;
+    return DTT0Data(t0Mean, t0RMS);
   }
-}
 
-} // namespace
+  DTT0Data DTT0ChamberReferenceCorrection::defaultT0(const DTWireId& wireId) {
+    // Access default DB
+    float t0Mean, t0RMS;
+    int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+    if (!status) {
+      return DTT0Data(t0Mean, t0RMS);
+    } else {
+      //...
+      throw cms::Exception("[DTT0ChamberReferenceCorrection]") << "Could not find t0 entry in DB for" << wireId << endl;
+    }
+  }
+
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.cc
@@ -25,7 +25,7 @@ DTT0ChamberReferenceCorrection::DTT0ChamberReferenceCorrection(const ParameterSe
   calibChamber_( pset.getParameter<string>("calibChamber") ) {
 
   //DTChamberId chosenChamberId;
-  if( calibChamber_ != "" && calibChamber_ != "None" && calibChamber_ != "All" ){
+  if( !calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All" ){
     stringstream linestr;
     int selWheel, selStation, selSector;
     linestr << calibChamber_;
@@ -53,7 +53,7 @@ DTT0Data DTT0ChamberReferenceCorrection::correction(const DTWireId& wireId) {
  
   DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
 
-  if( calibChamber_ == "" || calibChamber_ == "None" )          return defaultT0(wireId);
+  if( calibChamber_.empty() || calibChamber_ == "None" )          return defaultT0(wireId);
   if( calibChamber_ != "All" && chamberId != chosenChamberId_ ) return defaultT0(wireId);
 
   // Access DB

--- a/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.h
@@ -22,25 +22,25 @@ class DTT0;
 
 namespace dtCalibration {
 
-class DTT0ChamberReferenceCorrection: public DTT0BaseCorrection {
-public:
-  // Constructor
-  DTT0ChamberReferenceCorrection(const edm::ParameterSet&);
+  class DTT0ChamberReferenceCorrection : public DTT0BaseCorrection {
+  public:
+    // Constructor
+    DTT0ChamberReferenceCorrection(const edm::ParameterSet&);
 
-  // Destructor
-  ~DTT0ChamberReferenceCorrection() override;
+    // Destructor
+    ~DTT0ChamberReferenceCorrection() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTT0Data correction(const DTWireId&) override;
+    void setES(const edm::EventSetup& setup) override;
+    DTT0Data correction(const DTWireId&) override;
 
-private:
-  DTT0Data defaultT0(const DTWireId&);
+  private:
+    DTT0Data defaultT0(const DTWireId&);
 
-  std::string calibChamber_;
+    std::string calibChamber_;
 
-  DTChamberId chosenChamberId_;
-  const DTT0 *t0Map_;
-};
+    DTChamberId chosenChamberId_;
+    const DTT0* t0Map_;
+  };
 
-} // namespace
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
@@ -27,18 +27,15 @@
 using namespace edm;
 using namespace std;
 
-DTT0Correction::DTT0Correction(const ParameterSet& pset):
-  correctionAlgo_{DTT0CorrectionFactory::get()->create(pset.getParameter<string>("correctionAlgo"),
-                                                       pset.getParameter<ParameterSet>("correctionAlgoConfig"))}
-{
+DTT0Correction::DTT0Correction(const ParameterSet& pset)
+    : correctionAlgo_{DTT0CorrectionFactory::get()->create(pset.getParameter<string>("correctionAlgo"),
+                                                           pset.getParameter<ParameterSet>("correctionAlgoConfig"))} {
   LogVerbatim("Calibration") << "[DTT0Correction] Constructor called" << endl;
 }
 
-DTT0Correction::~DTT0Correction(){
-  LogVerbatim("Calibration") << "[DTT0Correction] Destructor called" << endl;
-}
+DTT0Correction::~DTT0Correction() { LogVerbatim("Calibration") << "[DTT0Correction] Destructor called" << endl; }
 
-void DTT0Correction::beginRun( const edm::Run& run, const edm::EventSetup& setup ) {
+void DTT0Correction::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   // Get t0 record from DB
   ESHandle<DTT0> t0H;
   setup.get<DTT0Rcd>().get(t0H);
@@ -54,54 +51,53 @@ void DTT0Correction::beginRun( const edm::Run& run, const edm::EventSetup& setup
 
 void DTT0Correction::endJob() {
   // Create the object to be written to DB
-  DTT0* t0NewMap = new DTT0();  
+  DTT0* t0NewMap = new DTT0();
 
   // Loop over all channels
-  for(vector<const DTSuperLayer*>::const_iterator sl = muonGeom_->superLayers().begin();
-	                                    sl != muonGeom_->superLayers().end(); ++sl) {
-     for(vector<const DTLayer*>::const_iterator layer = (*sl)->layers().begin();
-	                                        layer != (*sl)->layers().end(); ++layer) {
-	// Access layer topology
-	const DTTopology& dtTopo = (*layer)->specificTopology();
-	const int firstWire = dtTopo.firstChannel();
-	const int lastWire = dtTopo.lastChannel();
-	//const int nWires = dtTopo.channels();
+  for (vector<const DTSuperLayer*>::const_iterator sl = muonGeom_->superLayers().begin();
+       sl != muonGeom_->superLayers().end();
+       ++sl) {
+    for (vector<const DTLayer*>::const_iterator layer = (*sl)->layers().begin(); layer != (*sl)->layers().end();
+         ++layer) {
+      // Access layer topology
+      const DTTopology& dtTopo = (*layer)->specificTopology();
+      const int firstWire = dtTopo.firstChannel();
+      const int lastWire = dtTopo.lastChannel();
+      //const int nWires = dtTopo.channels();
 
-	//Loop on wires
-	for(int wire = firstWire; wire <= lastWire; ++wire){
-	   DTWireId wireId((*layer)->id(),wire);
+      //Loop on wires
+      for (int wire = firstWire; wire <= lastWire; ++wire) {
+        DTWireId wireId((*layer)->id(), wire);
 
-	   // Get old value from DB
-	   float t0Mean,t0RMS;
-	   int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
+        // Get old value from DB
+        float t0Mean, t0RMS;
+        int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
 
-	   // Compute new t0 for this wire
-	   try{
-	      dtCalibration::DTT0Data t0Corr = correctionAlgo_->correction( wireId );
-	      float t0MeanNew = t0Corr.mean;
-	      float t0RMSNew = t0Corr.rms; 
-	      t0NewMap->set(wireId,t0MeanNew,t0RMSNew,DTTimeUnits::counts);
+        // Compute new t0 for this wire
+        try {
+          dtCalibration::DTT0Data t0Corr = correctionAlgo_->correction(wireId);
+          float t0MeanNew = t0Corr.mean;
+          float t0RMSNew = t0Corr.rms;
+          t0NewMap->set(wireId, t0MeanNew, t0RMSNew, DTTimeUnits::counts);
 
-	      LogVerbatim("Calibration") << "New t0 for: " << wireId
-		                         << " mean from " << t0Mean << " to " << t0MeanNew
-		                         << " rms from " << t0RMS << " to " << t0RMSNew << endl;
-	   } catch(cms::Exception& e){
-	      LogError("Calibration") << e.explainSelf();
-	      // Set db to the old value, if it was there in the first place
-	      if(!status){
-		 t0NewMap->set(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-		 LogVerbatim("Calibration") << "Keep old t0 for: " << wireId
-	                                    << " mean " << t0Mean
-		                            << " rms " << t0RMS << endl;
-	      } 
-	      continue;
-	   }
-	} // End of loop on wires 
-     } // End of loop on layers 
-  } // End of loop on superlayers 
-  
+          LogVerbatim("Calibration") << "New t0 for: " << wireId << " mean from " << t0Mean << " to " << t0MeanNew
+                                     << " rms from " << t0RMS << " to " << t0RMSNew << endl;
+        } catch (cms::Exception& e) {
+          LogError("Calibration") << e.explainSelf();
+          // Set db to the old value, if it was there in the first place
+          if (!status) {
+            t0NewMap->set(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+            LogVerbatim("Calibration") << "Keep old t0 for: " << wireId << " mean " << t0Mean << " rms " << t0RMS
+                                       << endl;
+          }
+          continue;
+        }
+      }  // End of loop on wires
+    }    // End of loop on layers
+  }      // End of loop on superlayers
+
   //Write object to DB
   LogVerbatim("Calibration") << "[DTT0Correction]: Writing t0 object to DB!" << endl;
   string record = "DTT0Rcd";
   DTCalibDBUtils::writeToDB<DTT0>(record, t0NewMap);
-} 
+}

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.h
@@ -28,14 +28,12 @@ public:
   // Operations
 
   void beginJob() override {}
-  void beginRun( const edm::Run& run, const edm::EventSetup& setup ) override;
-  void analyze(const edm::Event& event, const edm::EventSetup& setup) override{}
+  void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
   void endJob() override;
 
 protected:
-
 private:
-
   const DTT0* t0Map_;
   edm::ESHandle<DTGeometry> muonGeom_;
 

--- a/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
@@ -24,71 +24,69 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTT0FEBPathCorrection::DTT0FEBPathCorrection(const ParameterSet& pset):
-   calibChamber_( pset.getParameter<string>("calibChamber") ) {
-
-   //DTChamberId chosenChamberId;
-   if( !calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All" ){
+  DTT0FEBPathCorrection::DTT0FEBPathCorrection(const ParameterSet& pset)
+      : calibChamber_(pset.getParameter<string>("calibChamber")) {
+    //DTChamberId chosenChamberId;
+    if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
       stringstream linestr;
       int selWheel, selStation, selSector;
       linestr << calibChamber_;
       linestr >> selWheel >> selStation >> selSector;
       chosenChamberId_ = DTChamberId(selWheel, selStation, selSector);
       LogVerbatim("Calibration") << "[DTT0FEBPathCorrection] Chosen chamber: " << chosenChamberId_ << endl;
-   }
-   //FIXME: Check if chosen chamber is valid.
-}
+    }
+    //FIXME: Check if chosen chamber is valid.
+  }
 
-DTT0FEBPathCorrection::~DTT0FEBPathCorrection() {
-}
+  DTT0FEBPathCorrection::~DTT0FEBPathCorrection() {}
 
-void DTT0FEBPathCorrection::setES(const EventSetup& setup) {
-   // Get t0 record from DB
-   ESHandle<DTT0> t0H;
-   setup.get<DTT0Rcd>().get(t0H);
-   t0Map_ = &*t0H;
-   LogVerbatim("Calibration") << "[DTT0FEBPathCorrection] T0 version: " << t0H->version();
-}
+  void DTT0FEBPathCorrection::setES(const EventSetup& setup) {
+    // Get t0 record from DB
+    ESHandle<DTT0> t0H;
+    setup.get<DTT0Rcd>().get(t0H);
+    t0Map_ = &*t0H;
+    LogVerbatim("Calibration") << "[DTT0FEBPathCorrection] T0 version: " << t0H->version();
+  }
 
-DTT0Data DTT0FEBPathCorrection::correction(const DTWireId& wireId) {
-   // Compute for selected chamber (or All) correction using as reference chamber mean
+  DTT0Data DTT0FEBPathCorrection::correction(const DTWireId& wireId) {
+    // Compute for selected chamber (or All) correction using as reference chamber mean
 
-   DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
+    DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
 
-   if( calibChamber_.empty() || calibChamber_ == "None" )          return defaultT0(wireId);
-   if( calibChamber_ != "All" && chamberId != chosenChamberId_ ) return defaultT0(wireId);
+    if (calibChamber_.empty() || calibChamber_ == "None")
+      return defaultT0(wireId);
+    if (calibChamber_ != "All" && chamberId != chosenChamberId_)
+      return defaultT0(wireId);
 
-   // Access DB
-   float t0Mean,t0RMS;
-   int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-   if(status != 0) 
-      throw cms::Exception("[DTT0FEBPathCorrection]") << "Could not find t0 entry in DB for" 
-                                                                << wireId << endl;
-   int wheel = chamberId.wheel();
-   int station = chamberId.station();
-   int sector = chamberId.sector();
-   int sl = wireId.layerId().superlayerId().superlayer();
-   int l = wireId.layerId().layer();
-   int wire = wireId.wire();
-   float t0MeanNew = t0Mean - t0FEBPathCorrection(wheel, station, sector, sl, l, wire);
-   float t0RMSNew = t0RMS;
-   return DTT0Data(t0MeanNew,t0RMSNew);
-}
+    // Access DB
+    float t0Mean, t0RMS;
+    int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+    if (status != 0)
+      throw cms::Exception("[DTT0FEBPathCorrection]") << "Could not find t0 entry in DB for" << wireId << endl;
+    int wheel = chamberId.wheel();
+    int station = chamberId.station();
+    int sector = chamberId.sector();
+    int sl = wireId.layerId().superlayerId().superlayer();
+    int l = wireId.layerId().layer();
+    int wire = wireId.wire();
+    float t0MeanNew = t0Mean - t0FEBPathCorrection(wheel, station, sector, sl, l, wire);
+    float t0RMSNew = t0RMS;
+    return DTT0Data(t0MeanNew, t0RMSNew);
+  }
 
-DTT0Data DTT0FEBPathCorrection::defaultT0(const DTWireId& wireId) {
-   // Access default DB
-   float t0Mean,t0RMS;
-   int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-   if(!status){
-      return DTT0Data(t0Mean,t0RMS);
-   } else{
-      //... 
-      throw cms::Exception("[DTT0FEBPathCorrection]") << "Could not find t0 entry in DB for"
-	 << wireId << endl;
-   }
-}
+  DTT0Data DTT0FEBPathCorrection::defaultT0(const DTWireId& wireId) {
+    // Access default DB
+    float t0Mean, t0RMS;
+    int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+    if (!status) {
+      return DTT0Data(t0Mean, t0RMS);
+    } else {
+      //...
+      throw cms::Exception("[DTT0FEBPathCorrection]") << "Could not find t0 entry in DB for" << wireId << endl;
+    }
+  }
 
-/**
+  /**
 
   Return the value to be subtracted to t0s to correct for the difference of 
   path lenght for TP signals within the FEB, from the TP input connector 
@@ -136,65 +134,55 @@ DTT0Data DTT0FEBPathCorrection::defaultT0(const DTWireId& wireId) {
 
 */
 
-float DTT0FEBPathCorrection::t0FEBPathCorrection(int wheel, int st, int sec, int sl, int l, int w) {
+  float DTT0FEBPathCorrection::t0FEBPathCorrection(int wheel, int st, int sec, int sl, int l, int w) {
+    // Skip correction for the last row of cells of FEB20 (see above)
+    if ((st == 1 && ((sl != 2 && w == 49) || (sl == 2 && w == 57))) || ((st == 2 || st == 3) && (sl == 2 && w == 57)))
+      return 0.;
 
-  // Skip correction for the last row of cells of FEB20 (see above)
-  if( (st==1 && ((sl!=2 && w ==49) || (sl==2 && w ==57))) || 
-      ((st==2||st==3)&& (sl==2 && w ==57)) ) return 0.;
+    float dist[8] = {};
 
-  
-  float dist[8]={};
+    // Path lenght differences for L1 and L3 (cm)
+    if (l == 1 || l == 3) {
+      dist[0] = +4.45;
+      dist[1] = +2.45;
+      dist[2] = -3.45;
+      dist[3] = -5.45;
+      dist[4] = -4.45;
+      dist[5] = -2.45;
+      dist[6] = +3.45;
+      dist[7] = +5.45;
+    }
 
-  // Path lenght differences for L1 and L3 (cm)
-  if(l==1 || l ==3){
-   
-    dist[0] = +4.45;
-    dist[1] = +2.45;
-    dist[2] = -3.45;
-    dist[3] = -5.45;
-    dist[4] = -4.45;
-    dist[5] = -2.45;
-    dist[6] = +3.45;
-    dist[7] = +5.45;
+    // Path lenght differences for L2 and L4 (cm)
+    else {
+      dist[0] = +5.45;
+      dist[1] = +3.45;
+      dist[2] = -2.45;
+      dist[3] = -4.45;
+      dist[4] = -5.45;
+      dist[5] = -3.45;
+      dist[6] = +2.45;
+      dist[7] = +4.45;
+    }
+
+    // Wire position within the 8-cell period (2 FEBs).
+    // Note that wire numbers start from 1.
+    int pos = (w - 1) % 8;
+
+    // Special case: in MB2 phi and MB4-10, the periodicity is broken at cell 49, as there is
+    // an odd number of FEDs (15): the 13th FEB is connected on the left,
+    // and not on the right; i.e. one FEB (4 colums of cells) is skipped from what would
+    // be the regular structure.
+    // The same happens in MB4-8/12 at cell 81.
+    if ((st == 2 && sl != 2 && w >= 49) || (st == 4 && sec == 10 && w >= 49) ||
+        (st == 4 && (sec == 8 || sec == 12) && w >= 81))
+      pos = (w - 1 + 4) % 8;
+
+    // Inverse of the signal propagation speed, determined from the
+    // observed amplitude of the modulation. This matches what is found
+    // with CAD simulation using reasonable assumptions on the PCB specs.
+
+    return dist[pos] * 0.075;
   }
 
-  // Path lenght differences for L2 and L4 (cm)
-  else {
-    
-    dist[0] = +5.45;
-    dist[1] = +3.45;
-    dist[2] = -2.45;
-    dist[3] = -4.45;
-    dist[4] = -5.45;
-    dist[5] = -3.45;
-    dist[6] = +2.45;
-    dist[7] = +4.45;
-  }
-  
-  
-  // Wire position within the 8-cell period (2 FEBs). 
-  // Note that wire numbers start from 1.
-  int pos = (w-1)%8;
-
-  // Special case: in MB2 phi and MB4-10, the periodicity is broken at cell 49, as there is 
-  // an odd number of FEDs (15): the 13th FEB is connected on the left, 
-  // and not on the right; i.e. one FEB (4 colums of cells) is skipped from what would 
-  // be the regular structure.
-  // The same happens in MB4-8/12 at cell 81.
-  if ((st==2 && sl!=2 && w>=49) || 
-      (st==4 && sec==10 && w>=49) || 
-      (st==4 && (sec==8||sec==12) && w>=81) ) pos =(w-1+4)%8;
-
-  // Inverse of the signal propagation speed, determined from the 
-  // observed amplitude of the modulation. This matches what is found 
-  // with CAD simulation using reasonable assumptions on the PCB specs.
-
-  return dist[pos]*0.075;
-  
-}
-
-
-
-
-
-} // namespace
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
@@ -28,7 +28,7 @@ DTT0FEBPathCorrection::DTT0FEBPathCorrection(const ParameterSet& pset):
    calibChamber_( pset.getParameter<string>("calibChamber") ) {
 
    //DTChamberId chosenChamberId;
-   if( calibChamber_ != "" && calibChamber_ != "None" && calibChamber_ != "All" ){
+   if( !calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All" ){
       stringstream linestr;
       int selWheel, selStation, selSector;
       linestr << calibChamber_;
@@ -55,7 +55,7 @@ DTT0Data DTT0FEBPathCorrection::correction(const DTWireId& wireId) {
 
    DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
 
-   if( calibChamber_ == "" || calibChamber_ == "None" )          return defaultT0(wireId);
+   if( calibChamber_.empty() || calibChamber_ == "None" )          return defaultT0(wireId);
    if( calibChamber_ != "All" && chamberId != chosenChamberId_ ) return defaultT0(wireId);
 
    // Access DB

--- a/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.h
@@ -22,26 +22,27 @@ class DTT0;
 
 namespace dtCalibration {
 
-class DTT0FEBPathCorrection: public DTT0BaseCorrection {
-public:
-  // Constructor
-  DTT0FEBPathCorrection(const edm::ParameterSet&);
+  class DTT0FEBPathCorrection : public DTT0BaseCorrection {
+  public:
+    // Constructor
+    DTT0FEBPathCorrection(const edm::ParameterSet&);
 
-  // Destructor
-  ~DTT0FEBPathCorrection() override;
+    // Destructor
+    ~DTT0FEBPathCorrection() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTT0Data correction(const DTWireId&) override;
+    void setES(const edm::EventSetup& setup) override;
+    DTT0Data correction(const DTWireId&) override;
 
-  float t0FEBPathCorrection(int wheel, int st, int sec, int sl, int l, int w);
-private:
-  DTT0Data defaultT0(const DTWireId&);
+    float t0FEBPathCorrection(int wheel, int st, int sec, int sl, int l, int w);
 
-  std::string calibChamber_;
+  private:
+    DTT0Data defaultT0(const DTWireId&);
 
-  DTChamberId chosenChamberId_;
-  const DTT0 *t0Map_;
-};
+    std::string calibChamber_;
 
-} // namespace
+    DTChamberId chosenChamberId_;
+    const DTT0* t0Map_;
+  };
+
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.cc
@@ -29,7 +29,7 @@ DTT0FillChamberFromDB::DTT0FillChamberFromDB(const ParameterSet& pset):
   chamberRef_( pset.getParameter<string>("chamberId") ) {
 
   //DTChamberId chosenChamberId;
-  if( chamberRef_ != "" && chamberRef_ != "None" ){
+  if( !chamberRef_.empty() && chamberRef_ != "None" ){
     stringstream linestr;
     int selWheel, selStation, selSector;
     linestr << chamberRef_;
@@ -65,7 +65,7 @@ DTT0Data DTT0FillChamberFromDB::correction(const DTWireId& wireId) {
  
   DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
 
-  if( chamberRef_ != "" && chamberRef_ != "None" && chamberId == chosenChamberId_ ){
+  if( !chamberRef_.empty() && chamberRef_ != "None" && chamberId == chosenChamberId_ ){
      // Access reference DB
      float t0MeanRef,t0RMSRef;
      int statusRef = t0MapRef_->get(wireId,t0MeanRef,t0RMSRef,DTTimeUnits::counts);

--- a/CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.cc
@@ -24,70 +24,64 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTT0FillChamberFromDB::DTT0FillChamberFromDB(const ParameterSet& pset):
-  dbLabelRef_( pset.getParameter<string>("dbLabelRef") ),
-  chamberRef_( pset.getParameter<string>("chamberId") ) {
-
-  //DTChamberId chosenChamberId;
-  if( !chamberRef_.empty() && chamberRef_ != "None" ){
-    stringstream linestr;
-    int selWheel, selStation, selSector;
-    linestr << chamberRef_;
-    linestr >> selWheel >> selStation >> selSector;
-    chosenChamberId_ = DTChamberId(selWheel, selStation, selSector);
-    LogVerbatim("Calibration") << "[DTT0FillChamberFromDB] Chosen chamber: " << chosenChamberId_ << endl;
+  DTT0FillChamberFromDB::DTT0FillChamberFromDB(const ParameterSet& pset)
+      : dbLabelRef_(pset.getParameter<string>("dbLabelRef")), chamberRef_(pset.getParameter<string>("chamberId")) {
+    //DTChamberId chosenChamberId;
+    if (!chamberRef_.empty() && chamberRef_ != "None") {
+      stringstream linestr;
+      int selWheel, selStation, selSector;
+      linestr << chamberRef_;
+      linestr >> selWheel >> selStation >> selSector;
+      chosenChamberId_ = DTChamberId(selWheel, selStation, selSector);
+      LogVerbatim("Calibration") << "[DTT0FillChamberFromDB] Chosen chamber: " << chosenChamberId_ << endl;
+    }
+    //FIXME: Check if chosen chamber is valid.
   }
-  //FIXME: Check if chosen chamber is valid.
 
-}
+  DTT0FillChamberFromDB::~DTT0FillChamberFromDB() {}
 
-DTT0FillChamberFromDB::~DTT0FillChamberFromDB() {
-}
+  void DTT0FillChamberFromDB::setES(const EventSetup& setup) {
+    // Get t0 record from DB
+    ESHandle<DTT0> t0H;
+    setup.get<DTT0Rcd>().get(t0H);
+    t0Map_ = &*t0H;
+    LogVerbatim("Calibration") << "[DTT0FillChamberFromDB] T0 version: " << t0H->version();
 
-void DTT0FillChamberFromDB::setES(const EventSetup& setup) {
-  // Get t0 record from DB
-  ESHandle<DTT0> t0H;
-  setup.get<DTT0Rcd>().get(t0H);
-  t0Map_ = &*t0H;
-  LogVerbatim("Calibration") << "[DTT0FillChamberFromDB] T0 version: " << t0H->version();
-
-  // Get reference t0 DB 
-  ESHandle<DTT0> t0RefH;
-  setup.get<DTT0Rcd>().get(dbLabelRef_,t0RefH);
-  t0MapRef_ = &*t0RefH;
-  LogVerbatim("Calibration") << "[DTT0FillChamberFromDB] Reference T0 version: " << t0RefH->version();
-
-}
-
-DTT0Data DTT0FillChamberFromDB::correction(const DTWireId& wireId) {
-  // If wire belongs to chosen chamber, use t0 value from reference DB
-  // Otherwise use value from default DB
- 
-  DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
-
-  if( !chamberRef_.empty() && chamberRef_ != "None" && chamberId == chosenChamberId_ ){
-     // Access reference DB
-     float t0MeanRef,t0RMSRef;
-     int statusRef = t0MapRef_->get(wireId,t0MeanRef,t0RMSRef,DTTimeUnits::counts);
-     if(!statusRef){
-        return DTT0Data(t0MeanRef,t0RMSRef);
-     } else{
-        //... 
-        throw cms::Exception("[DTT0FillChamberFromDB]") << "Could not find t0 entry in reference DB for"
-                                                        << wireId << endl;
-     }
-  } else{
-     // Access default DB
-     float t0Mean,t0RMS;
-     int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-     if(!status){
-	return DTT0Data(t0Mean,t0RMS);
-     } else{
-        //... 
-        throw cms::Exception("[DTT0FillChamberFromDB]") << "Could not find t0 entry in DB for"
-                                                        << wireId << endl;
-     }
+    // Get reference t0 DB
+    ESHandle<DTT0> t0RefH;
+    setup.get<DTT0Rcd>().get(dbLabelRef_, t0RefH);
+    t0MapRef_ = &*t0RefH;
+    LogVerbatim("Calibration") << "[DTT0FillChamberFromDB] Reference T0 version: " << t0RefH->version();
   }
-}
 
-} // namespace
+  DTT0Data DTT0FillChamberFromDB::correction(const DTWireId& wireId) {
+    // If wire belongs to chosen chamber, use t0 value from reference DB
+    // Otherwise use value from default DB
+
+    DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
+
+    if (!chamberRef_.empty() && chamberRef_ != "None" && chamberId == chosenChamberId_) {
+      // Access reference DB
+      float t0MeanRef, t0RMSRef;
+      int statusRef = t0MapRef_->get(wireId, t0MeanRef, t0RMSRef, DTTimeUnits::counts);
+      if (!statusRef) {
+        return DTT0Data(t0MeanRef, t0RMSRef);
+      } else {
+        //...
+        throw cms::Exception("[DTT0FillChamberFromDB]")
+            << "Could not find t0 entry in reference DB for" << wireId << endl;
+      }
+    } else {
+      // Access default DB
+      float t0Mean, t0RMS;
+      int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+      if (!status) {
+        return DTT0Data(t0Mean, t0RMS);
+      } else {
+        //...
+        throw cms::Exception("[DTT0FillChamberFromDB]") << "Could not find t0 entry in DB for" << wireId << endl;
+      }
+    }
+  }
+
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.h
@@ -22,26 +22,26 @@ class DTT0;
 
 namespace dtCalibration {
 
-class DTT0FillChamberFromDB: public DTT0BaseCorrection {
-public:
-  // Constructor
-  DTT0FillChamberFromDB(const edm::ParameterSet&);
+  class DTT0FillChamberFromDB : public DTT0BaseCorrection {
+  public:
+    // Constructor
+    DTT0FillChamberFromDB(const edm::ParameterSet &);
 
-  // Destructor
-  ~DTT0FillChamberFromDB() override;
+    // Destructor
+    ~DTT0FillChamberFromDB() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTT0Data correction(const DTWireId&) override;
+    void setES(const edm::EventSetup &setup) override;
+    DTT0Data correction(const DTWireId &) override;
 
-private:
-  std::string dbLabelRef_;
-  std::string chamberRef_;
+  private:
+    std::string dbLabelRef_;
+    std::string chamberRef_;
 
-  DTChamberId chosenChamberId_;
+    DTChamberId chosenChamberId_;
 
-  const DTT0 *t0MapRef_;
-  const DTT0 *t0Map_;
-};
+    const DTT0 *t0MapRef_;
+    const DTT0 *t0Map_;
+  };
 
-} // namespace
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTT0FillDefaultFromDB.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FillDefaultFromDB.cc
@@ -19,49 +19,46 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTT0FillDefaultFromDB::DTT0FillDefaultFromDB(const ParameterSet& pset):
-  dbLabelRef_( pset.getParameter<string>("dbLabelRef") ) {
-}
+  DTT0FillDefaultFromDB::DTT0FillDefaultFromDB(const ParameterSet& pset)
+      : dbLabelRef_(pset.getParameter<string>("dbLabelRef")) {}
 
-DTT0FillDefaultFromDB::~DTT0FillDefaultFromDB() {
-}
+  DTT0FillDefaultFromDB::~DTT0FillDefaultFromDB() {}
 
-void DTT0FillDefaultFromDB::setES(const EventSetup& setup) {
-  // Get t0 record from DB
-  ESHandle<DTT0> t0H;
-  setup.get<DTT0Rcd>().get(t0H);
-  t0Map_ = &*t0H;
-  LogVerbatim("Calibration") << "[DTT0FillDefaultFromDB] T0 version: " << t0H->version();
+  void DTT0FillDefaultFromDB::setES(const EventSetup& setup) {
+    // Get t0 record from DB
+    ESHandle<DTT0> t0H;
+    setup.get<DTT0Rcd>().get(t0H);
+    t0Map_ = &*t0H;
+    LogVerbatim("Calibration") << "[DTT0FillDefaultFromDB] T0 version: " << t0H->version();
 
-  // Get reference t0 DB 
-  ESHandle<DTT0> t0RefH;
-  setup.get<DTT0Rcd>().get(dbLabelRef_,t0RefH);
-  t0MapRef_ = &*t0RefH;
-  LogVerbatim("Calibration") << "[DTT0FillDefaultFromDB] Reference T0 version: " << t0RefH->version();
-
-}
-
-DTT0Data DTT0FillDefaultFromDB::correction(const DTWireId& wireId) {
-  // Try to access value in default DB
-  // If it does not exist return value from reference DB
-  // If it does not exist in reference DB, throw exception
-  // Could also set to default zero value
-  float t0Mean,t0RMS;
-  int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-  if(!status){
-     return DTT0Data(t0Mean,t0RMS);
-  } else{
-     // Now access reference DB
-     float t0MeanRef,t0RMSRef;
-     int statusRef = t0MapRef_->get(wireId,t0MeanRef,t0RMSRef,DTTimeUnits::counts);
-     if(!statusRef){
-        return DTT0Data(t0MeanRef,t0RMSRef);
-     } else{
-        //... 
-        throw cms::Exception("[DTT0FillDefaultFromDB]") << "Could not find t0 entry in reference DB for"
-                                                        << wireId << endl;
-     }
+    // Get reference t0 DB
+    ESHandle<DTT0> t0RefH;
+    setup.get<DTT0Rcd>().get(dbLabelRef_, t0RefH);
+    t0MapRef_ = &*t0RefH;
+    LogVerbatim("Calibration") << "[DTT0FillDefaultFromDB] Reference T0 version: " << t0RefH->version();
   }
-}
 
-} // namespace
+  DTT0Data DTT0FillDefaultFromDB::correction(const DTWireId& wireId) {
+    // Try to access value in default DB
+    // If it does not exist return value from reference DB
+    // If it does not exist in reference DB, throw exception
+    // Could also set to default zero value
+    float t0Mean, t0RMS;
+    int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+    if (!status) {
+      return DTT0Data(t0Mean, t0RMS);
+    } else {
+      // Now access reference DB
+      float t0MeanRef, t0RMSRef;
+      int statusRef = t0MapRef_->get(wireId, t0MeanRef, t0RMSRef, DTTimeUnits::counts);
+      if (!statusRef) {
+        return DTT0Data(t0MeanRef, t0RMSRef);
+      } else {
+        //...
+        throw cms::Exception("[DTT0FillDefaultFromDB]")
+            << "Could not find t0 entry in reference DB for" << wireId << endl;
+      }
+    }
+  }
+
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0FillDefaultFromDB.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0FillDefaultFromDB.h
@@ -21,23 +21,23 @@ class DTT0;
 
 namespace dtCalibration {
 
-class DTT0FillDefaultFromDB: public DTT0BaseCorrection {
-public:
-  // Constructor
-  DTT0FillDefaultFromDB(const edm::ParameterSet&);
+  class DTT0FillDefaultFromDB : public DTT0BaseCorrection {
+  public:
+    // Constructor
+    DTT0FillDefaultFromDB(const edm::ParameterSet &);
 
-  // Destructor
-  ~DTT0FillDefaultFromDB() override;
+    // Destructor
+    ~DTT0FillDefaultFromDB() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTT0Data correction(const DTWireId&) override;
+    void setES(const edm::EventSetup &setup) override;
+    DTT0Data correction(const DTWireId &) override;
 
-private:
-  std::string dbLabelRef_;
+  private:
+    std::string dbLabelRef_;
 
-  const DTT0 *t0MapRef_;
-  const DTT0 *t0Map_;
-};
+    const DTT0 *t0MapRef_;
+    const DTT0 *t0Map_;
+  };
 
-} // namespace
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTT0WireInChamberReferenceCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0WireInChamberReferenceCorrection.cc
@@ -29,7 +29,7 @@ DTT0WireInChamberReferenceCorrection::DTT0WireInChamberReferenceCorrection(const
    calibChamber_( pset.getParameter<string>("calibChamber") ) {
 
    //DTChamberId chosenChamberId;
-   if( calibChamber_ != "" && calibChamber_ != "None" && calibChamber_ != "All" ){
+   if( !calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All" ){
       stringstream linestr;
       int selWheel, selStation, selSector;
       linestr << calibChamber_;
@@ -59,7 +59,7 @@ DTT0Data DTT0WireInChamberReferenceCorrection::correction(const DTWireId& wireId
 
    DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
 
-   if( calibChamber_ == "" || calibChamber_ == "None" )          return defaultT0(wireId);
+   if( calibChamber_.empty() || calibChamber_ == "None" )          return defaultT0(wireId);
    if( calibChamber_ != "All" && chamberId != chosenChamberId_ ) return defaultT0(wireId);
 
    // Access DB

--- a/CalibMuon/DTCalibration/plugins/DTT0WireInChamberReferenceCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0WireInChamberReferenceCorrection.cc
@@ -25,88 +25,89 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTT0WireInChamberReferenceCorrection::DTT0WireInChamberReferenceCorrection(const ParameterSet& pset):
-   calibChamber_( pset.getParameter<string>("calibChamber") ) {
-
-   //DTChamberId chosenChamberId;
-   if( !calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All" ){
+  DTT0WireInChamberReferenceCorrection::DTT0WireInChamberReferenceCorrection(const ParameterSet& pset)
+      : calibChamber_(pset.getParameter<string>("calibChamber")) {
+    //DTChamberId chosenChamberId;
+    if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
       stringstream linestr;
       int selWheel, selStation, selSector;
       linestr << calibChamber_;
       linestr >> selWheel >> selStation >> selSector;
       chosenChamberId_ = DTChamberId(selWheel, selStation, selSector);
-      LogVerbatim("Calibration") << "[DTT0WireInChamberReferenceCorrection] Chosen chamber: " << chosenChamberId_ << endl;
-   }
-   //FIXME: Check if chosen chamber is valid.
-}
+      LogVerbatim("Calibration") << "[DTT0WireInChamberReferenceCorrection] Chosen chamber: " << chosenChamberId_
+                                 << endl;
+    }
+    //FIXME: Check if chosen chamber is valid.
+  }
 
-DTT0WireInChamberReferenceCorrection::~DTT0WireInChamberReferenceCorrection() {
-}
+  DTT0WireInChamberReferenceCorrection::~DTT0WireInChamberReferenceCorrection() {}
 
-void DTT0WireInChamberReferenceCorrection::setES(const EventSetup& setup) {
-   // Get t0 record from DB
-   ESHandle<DTT0> t0H;
-   setup.get<DTT0Rcd>().get(t0H);
-   t0Map_ = &*t0H;
-   LogVerbatim("Calibration") << "[DTT0WireInChamberReferenceCorrection] T0 version: " << t0H->version();
+  void DTT0WireInChamberReferenceCorrection::setES(const EventSetup& setup) {
+    // Get t0 record from DB
+    ESHandle<DTT0> t0H;
+    setup.get<DTT0Rcd>().get(t0H);
+    t0Map_ = &*t0H;
+    LogVerbatim("Calibration") << "[DTT0WireInChamberReferenceCorrection] T0 version: " << t0H->version();
 
-   // Get geometry from Event Setup
-   setup.get<MuonGeometryRecord>().get(dtGeom_);
-}
+    // Get geometry from Event Setup
+    setup.get<MuonGeometryRecord>().get(dtGeom_);
+  }
 
-DTT0Data DTT0WireInChamberReferenceCorrection::correction(const DTWireId& wireId) {
-   // Compute for selected chamber (or All) correction using as reference chamber mean
+  DTT0Data DTT0WireInChamberReferenceCorrection::correction(const DTWireId& wireId) {
+    // Compute for selected chamber (or All) correction using as reference chamber mean
 
-   DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
+    DTChamberId chamberId = wireId.layerId().superlayerId().chamberId();
 
-   if( calibChamber_.empty() || calibChamber_ == "None" )          return defaultT0(wireId);
-   if( calibChamber_ != "All" && chamberId != chosenChamberId_ ) return defaultT0(wireId);
+    if (calibChamber_.empty() || calibChamber_ == "None")
+      return defaultT0(wireId);
+    if (calibChamber_ != "All" && chamberId != chosenChamberId_)
+      return defaultT0(wireId);
 
-   // Access DB
-   float t0Mean,t0RMS;
-   int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-   if(status != 0) 
-      throw cms::Exception("[DTT0WireInChamberReferenceCorrection]") << "Could not find t0 entry in DB for" 
-                                                                     << wireId << endl;
+    // Access DB
+    float t0Mean, t0RMS;
+    int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+    if (status != 0)
+      throw cms::Exception("[DTT0WireInChamberReferenceCorrection]")
+          << "Could not find t0 entry in DB for" << wireId << endl;
 
-   // Try to find t0 for reference wire in layer
-   DTSuperLayerId slId = wireId.layerId().superlayerId();
-   // Layers 1 and 2
-   DTLayerId layerRef1( slId,1 );
-   //DTLayerId layerRef2( slId,2 );
+    // Try to find t0 for reference wire in layer
+    DTSuperLayerId slId = wireId.layerId().superlayerId();
+    // Layers 1 and 2
+    DTLayerId layerRef1(slId, 1);
+    //DTLayerId layerRef2( slId,2 );
 
-   const DTTopology& dtTopoLayerRef1 = dtGeom_->layer( layerRef1 )->specificTopology();
-   const int firstWireLayerRef1 = dtTopoLayerRef1.firstChannel();
-   const int refWireLayerRef1 = firstWireLayerRef1;
-   DTWireId wireIdRefLayerRef1( layerRef1,refWireLayerRef1 );
+    const DTTopology& dtTopoLayerRef1 = dtGeom_->layer(layerRef1)->specificTopology();
+    const int firstWireLayerRef1 = dtTopoLayerRef1.firstChannel();
+    const int refWireLayerRef1 = firstWireLayerRef1;
+    DTWireId wireIdRefLayerRef1(layerRef1, refWireLayerRef1);
 
-   float t0MeanRef1,t0RMSRef1;
-   int statusRef1 = t0Map_->get(wireIdRefLayerRef1,t0MeanRef1,t0RMSRef1,DTTimeUnits::counts);
+    float t0MeanRef1, t0RMSRef1;
+    int statusRef1 = t0Map_->get(wireIdRefLayerRef1, t0MeanRef1, t0RMSRef1, DTTimeUnits::counts);
 
-   // Correct channels in a superlayer wrt t0 from first wire in first layer
-   if(!statusRef1){
+    // Correct channels in a superlayer wrt t0 from first wire in first layer
+    if (!statusRef1) {
       float t0MeanNew = t0Mean - t0MeanRef1;
       float t0RMSNew = t0RMS;
-      return DTT0Data(t0MeanNew,t0RMSNew);
-   } else{
+      return DTT0Data(t0MeanNew, t0RMSNew);
+    } else {
       // If reference wire not active could choose adjacent wire instead
       //...
-      throw cms::Exception("[DTT0WireInChamberReferenceCorrection]") << "Could not find t0 entry in DB for" 
-                                                                     << wireIdRefLayerRef1 << endl;
-   }
-}
+      throw cms::Exception("[DTT0WireInChamberReferenceCorrection]")
+          << "Could not find t0 entry in DB for" << wireIdRefLayerRef1 << endl;
+    }
+  }
 
-DTT0Data DTT0WireInChamberReferenceCorrection::defaultT0(const DTWireId& wireId) {
-   // Access default DB
-   float t0Mean,t0RMS;
-   int status = t0Map_->get(wireId,t0Mean,t0RMS,DTTimeUnits::counts);
-   if(!status){
-      return DTT0Data(t0Mean,t0RMS);
-   } else{
-      //... 
-      throw cms::Exception("[DTT0WireInChamberReferenceCorrection]") << "Could not find t0 entry in DB for"
-	 << wireId << endl;
-   }
-}
+  DTT0Data DTT0WireInChamberReferenceCorrection::defaultT0(const DTWireId& wireId) {
+    // Access default DB
+    float t0Mean, t0RMS;
+    int status = t0Map_->get(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+    if (!status) {
+      return DTT0Data(t0Mean, t0RMS);
+    } else {
+      //...
+      throw cms::Exception("[DTT0WireInChamberReferenceCorrection]")
+          << "Could not find t0 entry in DB for" << wireId << endl;
+    }
+  }
 
-} // namespace
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0WireInChamberReferenceCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0WireInChamberReferenceCorrection.h
@@ -24,26 +24,26 @@ class DTGeometry;
 
 namespace dtCalibration {
 
-class DTT0WireInChamberReferenceCorrection: public DTT0BaseCorrection {
-public:
-  // Constructor
-  DTT0WireInChamberReferenceCorrection(const edm::ParameterSet&);
+  class DTT0WireInChamberReferenceCorrection : public DTT0BaseCorrection {
+  public:
+    // Constructor
+    DTT0WireInChamberReferenceCorrection(const edm::ParameterSet&);
 
-  // Destructor
-  ~DTT0WireInChamberReferenceCorrection() override;
+    // Destructor
+    ~DTT0WireInChamberReferenceCorrection() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTT0Data correction(const DTWireId&) override;
+    void setES(const edm::EventSetup& setup) override;
+    DTT0Data correction(const DTWireId&) override;
 
-private:
-  DTT0Data defaultT0(const DTWireId&);
+  private:
+    DTT0Data defaultT0(const DTWireId&);
 
-  std::string calibChamber_;
+    std::string calibChamber_;
 
-  DTChamberId chosenChamberId_;
-  const DTT0 *t0Map_;
-  edm::ESHandle<DTGeometry> dtGeom_;
-};
+    DTChamberId chosenChamberId_;
+    const DTT0* t0Map_;
+    edm::ESHandle<DTGeometry> dtGeom_;
+  };
 
-} // namespace
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTPAnalyzer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTPAnalyzer.cc
@@ -19,16 +19,16 @@ class TFile;
 
 class DTTPAnalyzer : public edm::EDAnalyzer {
 public:
-  DTTPAnalyzer( const edm::ParameterSet& );
+  DTTPAnalyzer(const edm::ParameterSet&);
   ~DTTPAnalyzer() override;
 
   //void beginJob();
-  void beginRun( const edm::Run& , const edm::EventSetup& ) override;
-  void analyze( const edm::Event& , const edm::EventSetup& ) override;
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
-  
+
 private:
-  std::string getHistoName( const DTLayerId& ); 
+  std::string getHistoName(const DTLayerId&);
 
   bool subtractT0_;
   edm::InputTag digiLabel_;
@@ -65,131 +65,124 @@ private:
 #include "TH1F.h"
 #include "TFile.h"
 
-DTTPAnalyzer::DTTPAnalyzer(const edm::ParameterSet& pset):
-  subtractT0_(pset.getParameter<bool>("subtractT0")),
-  digiLabel_(pset.getParameter<edm::InputTag>("digiLabel")) {
-
+DTTPAnalyzer::DTTPAnalyzer(const edm::ParameterSet& pset)
+    : subtractT0_(pset.getParameter<bool>("subtractT0")), digiLabel_(pset.getParameter<edm::InputTag>("digiLabel")) {
   std::string rootFileName = pset.getUntrackedParameter<std::string>("rootFileName");
   rootFile_ = new TFile(rootFileName.c_str(), "RECREATE");
   rootFile_->cd();
 
-  if(subtractT0_) 
+  if (subtractT0_)
     tTrigSync_ = DTTTrigSyncFactory::get()->create(pset.getParameter<std::string>("tTrigMode"),
                                                    pset.getParameter<edm::ParameterSet>("tTrigModeConfig"));
+}
 
-}
- 
-DTTPAnalyzer::~DTTPAnalyzer(){  
-  rootFile_->Close();
-}
+DTTPAnalyzer::~DTTPAnalyzer() { rootFile_->Close(); }
 
 void DTTPAnalyzer::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   // Get the t0 map from the DB
-  if(subtractT0_){ 
-     /*ESHandle<DTT0> t0;
+  if (subtractT0_) {
+    /*ESHandle<DTT0> t0;
      setup.get<DTT0Rcd>().get(t0);
      tZeroMap_ = &*t0;*/
-     tTrigSync_->setES(setup);
+    tTrigSync_->setES(setup);
   }
-  // Get the DT Geometry  
+  // Get the DT Geometry
   setup.get<MuonGeometryRecord>().get(dtGeom_);
 }
 
-void DTTPAnalyzer::analyze(const edm::Event & event, const edm::EventSetup& setup) {
-
+void DTTPAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   // Get the digis from the event
-  edm::Handle<DTDigiCollection> digis; 
+  edm::Handle<DTDigiCollection> digis;
   event.getByLabel(digiLabel_, digis);
 
-  // Iterate through all digi collections ordered by LayerId   
+  // Iterate through all digi collections ordered by LayerId
   DTDigiCollection::DigiRangeIterator dtLayerIt;
-  for (dtLayerIt = digis->begin();
-       dtLayerIt != digis->end();
-       ++dtLayerIt){
+  for (dtLayerIt = digis->begin(); dtLayerIt != digis->end(); ++dtLayerIt) {
     // Get the iterators over the digis associated with this LayerId
     const DTDigiCollection::Range& digiRange = (*dtLayerIt).second;
-  
+
     // Get the layerId
-    const DTLayerId layerId = (*dtLayerIt).first; //FIXME: check to be in the right sector
+    const DTLayerId layerId = (*dtLayerIt).first;  //FIXME: check to be in the right sector
 
     // Loop over all digis in the given layer
-    for (DTDigiCollection::const_iterator digi = digiRange.first;
-	 digi != digiRange.second;
-	 ++digi) {
-       const DTWireId wireId( layerId, (*digi).wire() );
+    for (DTDigiCollection::const_iterator digi = digiRange.first; digi != digiRange.second; ++digi) {
+      const DTWireId wireId(layerId, (*digi).wire());
 
-       double t0 = (*digi).countsTDC();
+      double t0 = (*digi).countsTDC();
 
-       //FIXME: Reject digis not coming from TP
+      //FIXME: Reject digis not coming from TP
 
-       if(subtractT0_) {
-          const DTLayer* layer = nullptr; //fake
-	  const GlobalPoint glPt; //fake
-	  double offset = tTrigSync_->offset(layer, wireId, glPt);
-          t0 -= offset;
-       }
+      if (subtractT0_) {
+        const DTLayer* layer = nullptr;  //fake
+        const GlobalPoint glPt;          //fake
+        double offset = tTrigSync_->offset(layer, wireId, glPt);
+        t0 -= offset;
+      }
 
-       if(nDigisPerWire_.find(wireId) == nDigisPerWire_.end()){
-          nDigisPerWire_[wireId] = 0;
-          sumWPerWire_[wireId] = 0.;
-          sumW2PerWire_[wireId] = 0.;  
-       }
+      if (nDigisPerWire_.find(wireId) == nDigisPerWire_.end()) {
+        nDigisPerWire_[wireId] = 0;
+        sumWPerWire_[wireId] = 0.;
+        sumW2PerWire_[wireId] = 0.;
+      }
 
-       ++nDigisPerWire_[wireId]; 
-       sumWPerWire_[wireId] += t0;
-       sumW2PerWire_[wireId] += t0*t0;
+      ++nDigisPerWire_[wireId];
+      sumWPerWire_[wireId] += t0;
+      sumW2PerWire_[wireId] += t0 * t0;
     }
-
   }
 }
 
 void DTTPAnalyzer::endJob() {
   rootFile_->cd();
   std::map<DTLayerId, TH1F*> meanHistoMap;
-  std::map<DTLayerId, TH1F*> sigmaHistoMap; 
-  for(std::map<DTWireId, int>::const_iterator wireIdIt = nDigisPerWire_.begin();
-                                              wireIdIt != nDigisPerWire_.end(); ++wireIdIt){
-     DTWireId wireId((*wireIdIt).first);
+  std::map<DTLayerId, TH1F*> sigmaHistoMap;
+  for (std::map<DTWireId, int>::const_iterator wireIdIt = nDigisPerWire_.begin(); wireIdIt != nDigisPerWire_.end();
+       ++wireIdIt) {
+    DTWireId wireId((*wireIdIt).first);
 
-     int nDigis = nDigisPerWire_[wireId];
-     double sumW = sumWPerWire_[wireId];
-     double sumW2 = sumW2PerWire_[wireId]; 
+    int nDigis = nDigisPerWire_[wireId];
+    double sumW = sumWPerWire_[wireId];
+    double sumW2 = sumW2PerWire_[wireId];
 
-     double mean = sumW/nDigis;
-     double rms = sumW2/nDigis - mean*mean;
-     rms = sqrt(rms);
+    double mean = sumW / nDigis;
+    double rms = sumW2 / nDigis - mean * mean;
+    rms = sqrt(rms);
 
-     DTLayerId layerId = wireId.layerId();
-     if(meanHistoMap.find(layerId) == meanHistoMap.end()) {
-        std::string histoName = getHistoName(layerId);
-        const int firstChannel = dtGeom_->layer(layerId)->specificTopology().firstChannel();
-        const int nWires = dtGeom_->layer(layerId)->specificTopology().channels();
-        TH1F* meanHistoTP = new TH1F((histoName + "_tpMean").c_str(),"mean from test pulses by channel", 
-                                      nWires,firstChannel,(firstChannel + nWires));
-        TH1F* sigmaHistoTP = new TH1F((histoName + "_tpSigma").c_str(),"sigma from test pulses by channel",
-                                      nWires,firstChannel,(firstChannel + nWires));
-        meanHistoMap[layerId] = meanHistoTP;
-        sigmaHistoMap[layerId] = sigmaHistoTP;
-     }
-     // Fill the histograms
-     int nBin = meanHistoMap[layerId]->GetXaxis()->FindFixBin(wireId.wire());
-     meanHistoMap[layerId]->SetBinContent(nBin,mean);
-     sigmaHistoMap[layerId]->SetBinContent(nBin,rms);
+    DTLayerId layerId = wireId.layerId();
+    if (meanHistoMap.find(layerId) == meanHistoMap.end()) {
+      std::string histoName = getHistoName(layerId);
+      const int firstChannel = dtGeom_->layer(layerId)->specificTopology().firstChannel();
+      const int nWires = dtGeom_->layer(layerId)->specificTopology().channels();
+      TH1F* meanHistoTP = new TH1F((histoName + "_tpMean").c_str(),
+                                   "mean from test pulses by channel",
+                                   nWires,
+                                   firstChannel,
+                                   (firstChannel + nWires));
+      TH1F* sigmaHistoTP = new TH1F((histoName + "_tpSigma").c_str(),
+                                    "sigma from test pulses by channel",
+                                    nWires,
+                                    firstChannel,
+                                    (firstChannel + nWires));
+      meanHistoMap[layerId] = meanHistoTP;
+      sigmaHistoMap[layerId] = sigmaHistoTP;
+    }
+    // Fill the histograms
+    int nBin = meanHistoMap[layerId]->GetXaxis()->FindFixBin(wireId.wire());
+    meanHistoMap[layerId]->SetBinContent(nBin, mean);
+    sigmaHistoMap[layerId]->SetBinContent(nBin, rms);
   }
 
-  for(std::map<DTLayerId, TH1F*>::const_iterator key = meanHistoMap.begin();
-                                                 key != meanHistoMap.end(); ++key){
-     meanHistoMap[(*key).first]->Write();
-     sigmaHistoMap[(*key).first]->Write(); 
-  } 
-
+  for (std::map<DTLayerId, TH1F*>::const_iterator key = meanHistoMap.begin(); key != meanHistoMap.end(); ++key) {
+    meanHistoMap[(*key).first]->Write();
+    sigmaHistoMap[(*key).first]->Write();
+  }
 }
 
 std::string DTTPAnalyzer::getHistoName(const DTLayerId& lId) {
   std::string histoName;
   std::stringstream theStream;
-  theStream << "Ch_" << lId.wheel() << "_" << lId.station() << "_" << lId.sector()
-	    << "_SL" << lId.superlayer() << "_L" << lId.layer();
+  theStream << "Ch_" << lId.wheel() << "_" << lId.station() << "_" << lId.sector() << "_SL" << lId.superlayer() << "_L"
+            << lId.layer();
   theStream >> histoName;
   return histoName;
 }

--- a/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.h
@@ -17,7 +17,7 @@ namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 class DTT0;
 class DTDeadFlag;
@@ -36,14 +36,12 @@ public:
   void beginRun(const edm::Run&, const edm::EventSetup& setup) override;
 
   /// Compute the ttrig by fiting the TB rising edge
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
   /// Write ttrig in the DB
   void endJob() override;
 
- 
 protected:
-
 private:
   // Debug flag
   bool debug;
@@ -53,7 +51,7 @@ private:
 
   // The object to be written to DB
   DTDeadFlag* tpDeadList;
- 
+
   //The DTGeometry
   edm::ESHandle<DTGeometry> muonGeom;
 };

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.cc
@@ -22,10 +22,8 @@
 
 #include "CalibMuon/DTCalibration/interface/DTCalibDBUtils.h"
 
-
 #include "CondFormats/DataRecord/interface/DTStatusFlagRcd.h"
 #include "CondFormats/DTObjects/interface/DTStatusFlag.h"
-
 
 #include "TFile.h"
 #include "TH1F.h"
@@ -37,8 +35,6 @@ using namespace std;
 using namespace edm;
 // using namespace cond;
 
-
-
 // Constructor
 DTTTrigCalibration::DTTTrigCalibration(const edm::ParameterSet& pset) {
   // Get the debug parameter for verbose output
@@ -46,7 +42,7 @@ DTTTrigCalibration::DTTTrigCalibration(const edm::ParameterSet& pset) {
 
   // Get the label to retrieve digis from the event
   digiLabel = pset.getUntrackedParameter<string>("digiLabel");
-  consumes< DTDigiCollection >(edm::InputTag(digiLabel));
+  consumes<DTDigiCollection>(edm::InputTag(digiLabel));
 
   // Switch on/off the DB writing
   findTMeanAndSigma = pset.getUntrackedParameter<bool>("fitAndWrite", false);
@@ -61,33 +57,31 @@ DTTTrigCalibration::DTTTrigCalibration(const edm::ParameterSet& pset) {
   theFile = new TFile(rootFileName.c_str(), "RECREATE");
   theFile->cd();
   theFitter = std::make_unique<DTTimeBoxFitter>();
-  if(debug)
+  if (debug)
     theFitter->setVerbosity(1);
 
-  double sigmaFit = pset.getUntrackedParameter<double>("sigmaTTrigFit",10.);
+  double sigmaFit = pset.getUntrackedParameter<double>("sigmaTTrigFit", 10.);
   theFitter->setFitSigma(sigmaFit);
 
-  doSubtractT0 = pset.getUntrackedParameter<bool>("doSubtractT0","false");
+  doSubtractT0 = pset.getUntrackedParameter<bool>("doSubtractT0", "false");
   // Get the synchronizer
-  if(doSubtractT0) {
+  if (doSubtractT0) {
     theSync = DTTTrigSyncFactory::get()->create(pset.getUntrackedParameter<string>("tTrigMode"),
                                                 pset.getUntrackedParameter<ParameterSet>("tTrigModeConfig"));
   }
 
-  checkNoisyChannels = pset.getUntrackedParameter<bool>("checkNoisyChannels","false");
+  checkNoisyChannels = pset.getUntrackedParameter<bool>("checkNoisyChannels", "false");
 
   // the kfactor to be uploaded in the ttrig DB
-  kFactor =  pset.getUntrackedParameter<double>("kFactor",-0.7);
+  kFactor = pset.getUntrackedParameter<double>("kFactor", -0.7);
 
-  if(debug) 
+  if (debug)
     cout << "[DTTTrigCalibration]Constructor called!" << endl;
 }
 
-
-
 // Destructor
-DTTTrigCalibration::~DTTTrigCalibration(){
-  if(debug) 
+DTTTrigCalibration::~DTTTrigCalibration() {
+  if (debug)
     cout << "[DTTTrigCalibration]Destructor called!" << endl;
 
   //   // Delete all histos
@@ -100,189 +94,170 @@ DTTTrigCalibration::~DTTTrigCalibration(){
   theFile->Close();
 }
 
-
-
 /// Perform the real analysis
-void DTTTrigCalibration::analyze(const edm::Event & event, const edm::EventSetup& eventSetup) {
-
-  if(debug) 
+void DTTTrigCalibration::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
+  if (debug)
     cout << "[DTTTrigCalibration] #Event: " << event.id().event() << endl;
-  
+
   // Get the digis from the event
-  Handle<DTDigiCollection> digis; 
+  Handle<DTDigiCollection> digis;
   event.getByLabel(digiLabel, digis);
 
   ESHandle<DTStatusFlag> statusMap;
-  if(checkNoisyChannels) {
+  if (checkNoisyChannels) {
     // Get the map of noisy channels
     eventSetup.get<DTStatusFlagRcd>().get(statusMap);
   }
 
-  if(doSubtractT0)
+  if (doSubtractT0)
     theSync->setES(eventSetup);
- 
+
   //The chambers too noisy in this event
   vector<DTChamberId> badChambers;
 
-  // Iterate through all digi collections ordered by LayerId   
+  // Iterate through all digi collections ordered by LayerId
   DTDigiCollection::DigiRangeIterator dtLayerIt;
-  for (dtLayerIt = digis->begin();
-       dtLayerIt != digis->end();
-       ++dtLayerIt){
+  for (dtLayerIt = digis->begin(); dtLayerIt != digis->end(); ++dtLayerIt) {
     // Get the iterators over the digis associated with this LayerId
-    const DTDigiCollection::Range& digiRange = (*dtLayerIt).second; 
-    
+    const DTDigiCollection::Range& digiRange = (*dtLayerIt).second;
+
     const DTLayerId layerId = (*dtLayerIt).first;
     const DTSuperLayerId slId = layerId.superlayerId();
     const DTChamberId chId = slId.chamberId();
-    bool badChamber=false;
+    bool badChamber = false;
 
-    if(debug)
-      cout<<"----------- Layer "<<layerId<<" -------------"<<endl;
+    if (debug)
+      cout << "----------- Layer " << layerId << " -------------" << endl;
 
     //Check if the layer is inside a noisy chamber
-    for(vector<DTChamberId>::const_iterator chamber = badChambers.begin(); chamber != badChambers.end(); ++chamber){
-      if((*chamber) == chId){
-	badChamber=true;
-	break;
+    for (vector<DTChamberId>::const_iterator chamber = badChambers.begin(); chamber != badChambers.end(); ++chamber) {
+      if ((*chamber) == chId) {
+        badChamber = true;
+        break;
       }
     }
-    if(badChamber) continue;
+    if (badChamber)
+      continue;
 
     //Check if the layer has too many digis
-    if((digiRange.second - digiRange.first) > maxDigiPerLayer){
-      if(debug)
-	cout<<"Layer "<<layerId<<"has too many digis ("<<(digiRange.second - digiRange.first)<<")"<<endl;
+    if ((digiRange.second - digiRange.first) > maxDigiPerLayer) {
+      if (debug)
+        cout << "Layer " << layerId << "has too many digis (" << (digiRange.second - digiRange.first) << ")" << endl;
       badChambers.push_back(chId);
       continue;
     }
 
     // Get the histo from the map
-    TH1F *hTBox = theHistoMap[slId];
-    if(hTBox == nullptr) {
+    TH1F* hTBox = theHistoMap[slId];
+    if (hTBox == nullptr) {
       // Book the histogram
       theFile->cd();
-      hTBox = new TH1F(getTBoxName(slId).c_str(), "Time box (ns)", int(0.25*32.0*maxTDCCounts/25.0), 0, maxTDCCounts);
-      if(debug)
-	cout << "  New Time Box: " << hTBox->GetName() << endl;
+      hTBox =
+          new TH1F(getTBoxName(slId).c_str(), "Time box (ns)", int(0.25 * 32.0 * maxTDCCounts / 25.0), 0, maxTDCCounts);
+      if (debug)
+        cout << "  New Time Box: " << hTBox->GetName() << endl;
       theHistoMap[slId] = hTBox;
     }
-    TH1F *hO = theOccupancyMap[layerId];
-    if(hO == nullptr) {
+    TH1F* hO = theOccupancyMap[layerId];
+    if (hO == nullptr) {
       // Book the histogram
       theFile->cd();
       hO = new TH1F(getOccupancyName(layerId).c_str(), "Occupancy", 100, 0, 100);
-      if(debug)
-	cout << "  New Time Box: " << hO->GetName() << endl;
+      if (debug)
+        cout << "  New Time Box: " << hO->GetName() << endl;
       theOccupancyMap[layerId] = hO;
     }
 
     // Loop over all digis in the given range
-    for (DTDigiCollection::const_iterator digi = digiRange.first;
-	 digi != digiRange.second;
-	 ++digi) {
+    for (DTDigiCollection::const_iterator digi = digiRange.first; digi != digiRange.second; ++digi) {
       const DTWireId wireId(layerId, (*digi).wire());
 
       // Check for noisy channels and skip them
-      if(checkNoisyChannels) {
-	bool isNoisy = false;
-	bool isFEMasked = false;
-	bool isTDCMasked = false;
-	bool isTrigMask = false;
-	bool isDead = false;
-	bool isNohv = false;
-	statusMap->cellStatus(wireId, isNoisy, isFEMasked, isTDCMasked, isTrigMask, isDead, isNohv);
-	if(isNoisy) {
-	  if(debug)
-	    cout << "Wire: " << wireId << " is noisy, skipping!" << endl;
-	  continue;
-	}      
+      if (checkNoisyChannels) {
+        bool isNoisy = false;
+        bool isFEMasked = false;
+        bool isTDCMasked = false;
+        bool isTrigMask = false;
+        bool isDead = false;
+        bool isNohv = false;
+        statusMap->cellStatus(wireId, isNoisy, isFEMasked, isTDCMasked, isTrigMask, isDead, isNohv);
+        if (isNoisy) {
+          if (debug)
+            cout << "Wire: " << wireId << " is noisy, skipping!" << endl;
+          continue;
+        }
       }
       theFile->cd();
       double offset = 0;
-      if(doSubtractT0) {
-	const DTLayer* layer = nullptr;//fake
-	const GlobalPoint glPt;//fake
-	offset = theSync->offset(layer, wireId, glPt);
+      if (doSubtractT0) {
+        const DTLayer* layer = nullptr;  //fake
+        const GlobalPoint glPt;          //fake
+        offset = theSync->offset(layer, wireId, glPt);
       }
-      hTBox->Fill((*digi).time()-offset);
-      if(debug) {
-	cout << "   Filling Time Box:   " << hTBox->GetName() << endl;
-	cout << "           offset (ns): " << offset << endl;
-	cout << "           time(ns):   " << (*digi).time()-offset<< endl;
+      hTBox->Fill((*digi).time() - offset);
+      if (debug) {
+        cout << "   Filling Time Box:   " << hTBox->GetName() << endl;
+        cout << "           offset (ns): " << offset << endl;
+        cout << "           time(ns):   " << (*digi).time() - offset << endl;
       }
       hO->Fill((*digi).wire());
     }
   }
 }
 
-
 void DTTTrigCalibration::endJob() {
-  if(debug) 
+  if (debug)
     cout << "[DTTTrigCalibration]Writing histos to file!" << endl;
-  
+
   // Write all time boxes to file
   theFile->cd();
-  for(map<DTSuperLayerId, TH1F*>::const_iterator slHisto = theHistoMap.begin();
-      slHisto != theHistoMap.end();
-      ++slHisto) {
+  for (map<DTSuperLayerId, TH1F*>::const_iterator slHisto = theHistoMap.begin(); slHisto != theHistoMap.end();
+       ++slHisto) {
     (*slHisto).second->Write();
   }
-  for(map<DTLayerId, TH1F*>::const_iterator slHisto = theOccupancyMap.begin();
-      slHisto != theOccupancyMap.end();
-      ++slHisto) {
+  for (map<DTLayerId, TH1F*>::const_iterator slHisto = theOccupancyMap.begin(); slHisto != theOccupancyMap.end();
+       ++slHisto) {
     (*slHisto).second->Write();
   }
 
-  if(findTMeanAndSigma) {
-      // Create the object to be written to DB
-      DTTtrig* tTrig = new DTTtrig();
+  if (findTMeanAndSigma) {
+    // Create the object to be written to DB
+    DTTtrig* tTrig = new DTTtrig();
 
-      // Loop over the map, fit the histos and write the resulting values to the DB
-      for(map<DTSuperLayerId, TH1F*>::const_iterator slHisto = theHistoMap.begin();
-	  slHisto != theHistoMap.end();
-	  ++slHisto) {
-	pair<double, double> meanAndSigma = theFitter->fitTimeBox((*slHisto).second);
-	tTrig->set((*slHisto).first,
-		   meanAndSigma.first,
-		   meanAndSigma.second,
-                   kFactor,
-		   DTTimeUnits::ns);
-    
-	if(debug) {
-	  cout << " SL: " << (*slHisto).first
-	       << " mean = " << meanAndSigma.first
-	       << " sigma = " << meanAndSigma.second << endl;
-	}
+    // Loop over the map, fit the histos and write the resulting values to the DB
+    for (map<DTSuperLayerId, TH1F*>::const_iterator slHisto = theHistoMap.begin(); slHisto != theHistoMap.end();
+         ++slHisto) {
+      pair<double, double> meanAndSigma = theFitter->fitTimeBox((*slHisto).second);
+      tTrig->set((*slHisto).first, meanAndSigma.first, meanAndSigma.second, kFactor, DTTimeUnits::ns);
+
+      if (debug) {
+        cout << " SL: " << (*slHisto).first << " mean = " << meanAndSigma.first << " sigma = " << meanAndSigma.second
+             << endl;
       }
+    }
 
-      // Print the ttrig map
-      dumpTTrigMap(tTrig);
-  
-      // Plot the tTrig
-      plotTTrig(tTrig);
+    // Print the ttrig map
+    dumpTTrigMap(tTrig);
 
-      if(debug) 
-	cout << "[DTTTrigCalibration]Writing ttrig object to DB!" << endl;
+    // Plot the tTrig
+    plotTTrig(tTrig);
 
+    if (debug)
+      cout << "[DTTTrigCalibration]Writing ttrig object to DB!" << endl;
 
-      // FIXME: to be read from cfg?
-      string tTrigRecord = "DTTtrigRcd";
-      
-      // Write the object to DB
-      DTCalibDBUtils::writeToDB(tTrigRecord, tTrig);
-    }  
+    // FIXME: to be read from cfg?
+    string tTrigRecord = "DTTtrigRcd";
 
+    // Write the object to DB
+    DTCalibDBUtils::writeToDB(tTrigRecord, tTrig);
+  }
 }
-
-
-
 
 string DTTTrigCalibration::getTBoxName(const DTSuperLayerId& slId) const {
   string histoName;
   stringstream theStream;
-  theStream << "Ch_" << slId.wheel() << "_" << slId.station() << "_" << slId.sector()
-	    << "_SL" << slId.superlayer() << "_hTimeBox";
+  theStream << "Ch_" << slId.wheel() << "_" << slId.station() << "_" << slId.sector() << "_SL" << slId.superlayer()
+            << "_hTimeBox";
   theStream >> histoName;
   return histoName;
 }
@@ -290,42 +265,33 @@ string DTTTrigCalibration::getTBoxName(const DTSuperLayerId& slId) const {
 string DTTTrigCalibration::getOccupancyName(const DTLayerId& slId) const {
   string histoName;
   stringstream theStream;
-  theStream << "Ch_" << slId.wheel() << "_" << slId.station() << "_" << slId.sector()
-	    << "_SL" << slId.superlayer() << "_L"<< slId.layer() <<"_Occupancy";
+  theStream << "Ch_" << slId.wheel() << "_" << slId.station() << "_" << slId.sector() << "_SL" << slId.superlayer()
+            << "_L" << slId.layer() << "_Occupancy";
   theStream >> histoName;
   return histoName;
 }
 
-
 void DTTTrigCalibration::dumpTTrigMap(const DTTtrig* tTrig) const {
-  static const double convToNs = 25./32.;
-  for(DTTtrig::const_iterator ttrig = tTrig->begin();
-      ttrig != tTrig->end(); ++ttrig) {
-    cout << "Wh: " << (*ttrig).first.wheelId
-	 << " St: " << (*ttrig).first.stationId
-	 << " Sc: " << (*ttrig).first.sectorId
-	 << " Sl: " << (*ttrig).first.slId
-	 << " TTrig mean (ns): " << (*ttrig).second.tTrig * convToNs
-	 << " TTrig sigma (ns): " << (*ttrig).second.tTrms * convToNs<< endl;
+  static const double convToNs = 25. / 32.;
+  for (DTTtrig::const_iterator ttrig = tTrig->begin(); ttrig != tTrig->end(); ++ttrig) {
+    cout << "Wh: " << (*ttrig).first.wheelId << " St: " << (*ttrig).first.stationId
+         << " Sc: " << (*ttrig).first.sectorId << " Sl: " << (*ttrig).first.slId
+         << " TTrig mean (ns): " << (*ttrig).second.tTrig * convToNs
+         << " TTrig sigma (ns): " << (*ttrig).second.tTrms * convToNs << endl;
   }
 }
 
-
 void DTTTrigCalibration::plotTTrig(const DTTtrig* tTrig) const {
+  TH1F* tTrig_YB1_Se10 = new TH1F("tTrig_YB1_Se10", "tTrig YB1_Se10", 15, 1, 16);
+  TH1F* tTrig_YB2_Se10 = new TH1F("tTrig_YB2_Se10", "tTrig YB2_Se10", 15, 1, 16);
+  TH1F* tTrig_YB2_Se11 = new TH1F("tTrig_YB2_Se11", "tTrig YB2_Se11", 12, 1, 13);
 
-  TH1F* tTrig_YB1_Se10 = new TH1F("tTrig_YB1_Se10","tTrig YB1_Se10",15,1,16);
-  TH1F* tTrig_YB2_Se10 = new TH1F("tTrig_YB2_Se10","tTrig YB2_Se10",15,1,16);
-  TH1F* tTrig_YB2_Se11 = new TH1F("tTrig_YB2_Se11","tTrig YB2_Se11",12,1,13);
-
-  static const double convToNs = 25./32.;
-  for(DTTtrig::const_iterator ttrig = tTrig->begin();
-      ttrig != tTrig->end(); ++ttrig) {
-
+  static const double convToNs = 25. / 32.;
+  for (DTTtrig::const_iterator ttrig = tTrig->begin(); ttrig != tTrig->end(); ++ttrig) {
     // avoid to have wired numbers in the plot
-    float tTrigValue=0;
-    float tTrmsValue=0;
-    if ((*ttrig).second.tTrig * convToNs > 0 &&
-	(*ttrig).second.tTrig * convToNs < 32000 ) {
+    float tTrigValue = 0;
+    float tTrmsValue = 0;
+    if ((*ttrig).second.tTrig * convToNs > 0 && (*ttrig).second.tTrig * convToNs < 32000) {
       tTrigValue = (*ttrig).second.tTrig * convToNs;
       tTrmsValue = (*ttrig).second.tTrms * convToNs;
     }
@@ -334,33 +300,30 @@ void DTTTrigCalibration::plotTTrig(const DTTtrig* tTrig) const {
     string binLabel;
     stringstream binLabelStream;
     if ((*ttrig).first.sectorId != 14) {
-      binx = ((*ttrig).first.stationId-1)*3  + (*ttrig).first.slId;
-      binLabelStream << "MB"<<(*ttrig).first.stationId<<"_SL"<<(*ttrig).first.slId;
-    }
-    else {
-      binx = 12  + (*ttrig).first.slId;
-      binLabelStream << "MB14_SL"<<(*ttrig).first.slId;
+      binx = ((*ttrig).first.stationId - 1) * 3 + (*ttrig).first.slId;
+      binLabelStream << "MB" << (*ttrig).first.stationId << "_SL" << (*ttrig).first.slId;
+    } else {
+      binx = 12 + (*ttrig).first.slId;
+      binLabelStream << "MB14_SL" << (*ttrig).first.slId;
     }
     binLabelStream >> binLabel;
 
     if ((*ttrig).first.wheelId == 2) {
       if ((*ttrig).first.sectorId == 10 || (*ttrig).first.sectorId == 14) {
-	tTrig_YB2_Se10->Fill( binx,tTrigValue);
-	tTrig_YB2_Se10->SetBinError( binx, tTrmsValue);
-	tTrig_YB2_Se10->GetXaxis()->SetBinLabel(binx,binLabel.c_str());
-	tTrig_YB2_Se10->GetYaxis()->SetTitle("ns");
+        tTrig_YB2_Se10->Fill(binx, tTrigValue);
+        tTrig_YB2_Se10->SetBinError(binx, tTrmsValue);
+        tTrig_YB2_Se10->GetXaxis()->SetBinLabel(binx, binLabel.c_str());
+        tTrig_YB2_Se10->GetYaxis()->SetTitle("ns");
+      } else {
+        tTrig_YB2_Se11->Fill(binx, tTrigValue);
+        tTrig_YB2_Se11->SetBinError(binx, tTrmsValue);
+        tTrig_YB2_Se11->GetXaxis()->SetBinLabel(binx, binLabel.c_str());
+        tTrig_YB2_Se11->GetYaxis()->SetTitle("ns");
       }
-      else {
-	tTrig_YB2_Se11->Fill( binx,tTrigValue);
-	tTrig_YB2_Se11->SetBinError( binx,tTrmsValue);
-	tTrig_YB2_Se11->GetXaxis()->SetBinLabel(binx,binLabel.c_str());
-	tTrig_YB2_Se11->GetYaxis()->SetTitle("ns");
-      }
-    }
-    else {
-      tTrig_YB1_Se10->Fill( binx,tTrigValue);
-      tTrig_YB1_Se10->SetBinError( binx,tTrmsValue);
-      tTrig_YB1_Se10->GetXaxis()->SetBinLabel(binx,binLabel.c_str());
+    } else {
+      tTrig_YB1_Se10->Fill(binx, tTrigValue);
+      tTrig_YB1_Se10->SetBinError(binx, tTrmsValue);
+      tTrig_YB1_Se10->GetXaxis()->SetBinLabel(binx, binLabel.c_str());
       tTrig_YB1_Se10->GetYaxis()->SetTitle("ns");
     }
   }
@@ -368,5 +331,4 @@ void DTTTrigCalibration::plotTTrig(const DTTtrig* tTrig) const {
   tTrig_YB1_Se10->Write();
   tTrig_YB2_Se10->Write();
   tTrig_YB2_Se11->Write();
-
 }

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.h
@@ -16,12 +16,11 @@
 #include <string>
 #include <map>
 
-
 namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 class TFile;
 class TH1F;
@@ -40,14 +39,12 @@ public:
   // Operations
 
   /// Fill the time boxes
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
   /// Fit the time box rising edge and write the resulting ttrig to the DB
   void endJob() override;
 
-
 protected:
-
 private:
   // Generate the time box name
   std::string getTBoxName(const DTSuperLayerId& slId) const;
@@ -72,8 +69,8 @@ private:
   int maxDigiPerLayer;
 
   // The file which will contain the time boxes
-  TFile *theFile;
-  
+  TFile* theFile;
+
   // Map of the histograms by SL
   std::map<DTSuperLayerId, TH1F*> theHistoMap;
   std::map<DTLayerId, TH1F*> theOccupancyMap;
@@ -82,16 +79,14 @@ private:
   bool doSubtractT0;
   // Switch for checking of noisy channels
   bool checkNoisyChannels;
-   //card to switch on/off the DB writing
-  bool findTMeanAndSigma; 
+  //card to switch on/off the DB writing
+  bool findTMeanAndSigma;
   // the kfactor to be uploaded in the ttrig DB
   double kFactor;
 
   // The fitter
   std::unique_ptr<DTTimeBoxFitter> theFitter;
   // The module for t0 subtraction
-  std::unique_ptr<DTTTrigBaseSync> theSync;//FIXME: should be const
-
+  std::unique_ptr<DTTTrigBaseSync> theSync;  //FIXME: should be const
 };
 #endif
-

--- a/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.cc
@@ -20,49 +20,46 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTTTrigConstantShift::DTTTrigConstantShift(const ParameterSet& pset):
-  dbLabel_( pset.getUntrackedParameter<string>("dbLabel", "") ),
-  calibChamber_( pset.getParameter<string>("calibChamber") ),
-  value_( pset.getParameter<double>("value") ) {
+  DTTTrigConstantShift::DTTTrigConstantShift(const ParameterSet& pset)
+      : dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")),
+        calibChamber_(pset.getParameter<string>("calibChamber")),
+        value_(pset.getParameter<double>("value")) {
+    LogVerbatim("Calibration") << "[DTTTrigConstantShift] Applying constant correction value: " << value_ << endl;
 
-  LogVerbatim("Calibration") << "[DTTTrigConstantShift] Applying constant correction value: " << value_ << endl;
-
-  if( !calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All" ){
-    stringstream linestr;
-    int selWheel, selStation, selSector;
-    linestr << calibChamber_;
-    linestr >> selWheel >> selStation >> selSector;
-    chosenChamberId_ = DTChamberId(selWheel, selStation, selSector);
-    LogVerbatim("Calibration") << "[DTTTrigConstantShift] Chosen chamber: " << chosenChamberId_ << endl;
-  }
-  //FIXME: Check if chosen chamber is valid.
-}
-
-DTTTrigConstantShift::~DTTTrigConstantShift() {}
-
-void DTTTrigConstantShift::setES(const EventSetup& setup) {
-  // Get tTrig record from DB
-  ESHandle<DTTtrig> tTrig;
-  setup.get<DTTtrigRcd>().get(dbLabel_,tTrig);
-  tTrigMap_ = &*tTrig;
-}
-
-DTTTrigData DTTTrigConstantShift::correction(const DTSuperLayerId& slId) {
-  
-  float tTrigMean,tTrigSigma,kFactor;
-  int status = tTrigMap_->get(slId,tTrigMean,tTrigSigma,kFactor,DTTimeUnits::ns);
-  if(status != 0) throw cms::Exception("[DTTTrigConstantShift]") << "Could not find tTrig entry in DB for"
-                                                                 << slId << endl;
-
-  float tTrigMeanNew = tTrigMean;
-  if( !calibChamber_.empty() && calibChamber_ != "None"){
-     if( ( calibChamber_ == "All" ) ||
-         ( calibChamber_ != "All" && slId.chamberId() == chosenChamberId_ ) ) {
-        tTrigMeanNew = tTrigMean + value_; 
-     }
+    if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
+      stringstream linestr;
+      int selWheel, selStation, selSector;
+      linestr << calibChamber_;
+      linestr >> selWheel >> selStation >> selSector;
+      chosenChamberId_ = DTChamberId(selWheel, selStation, selSector);
+      LogVerbatim("Calibration") << "[DTTTrigConstantShift] Chosen chamber: " << chosenChamberId_ << endl;
+    }
+    //FIXME: Check if chosen chamber is valid.
   }
 
-  return DTTTrigData(tTrigMeanNew,tTrigSigma,kFactor);
-}
+  DTTTrigConstantShift::~DTTTrigConstantShift() {}
 
-} // namespace
+  void DTTTrigConstantShift::setES(const EventSetup& setup) {
+    // Get tTrig record from DB
+    ESHandle<DTTtrig> tTrig;
+    setup.get<DTTtrigRcd>().get(dbLabel_, tTrig);
+    tTrigMap_ = &*tTrig;
+  }
+
+  DTTTrigData DTTTrigConstantShift::correction(const DTSuperLayerId& slId) {
+    float tTrigMean, tTrigSigma, kFactor;
+    int status = tTrigMap_->get(slId, tTrigMean, tTrigSigma, kFactor, DTTimeUnits::ns);
+    if (status != 0)
+      throw cms::Exception("[DTTTrigConstantShift]") << "Could not find tTrig entry in DB for" << slId << endl;
+
+    float tTrigMeanNew = tTrigMean;
+    if (!calibChamber_.empty() && calibChamber_ != "None") {
+      if ((calibChamber_ == "All") || (calibChamber_ != "All" && slId.chamberId() == chosenChamberId_)) {
+        tTrigMeanNew = tTrigMean + value_;
+      }
+    }
+
+    return DTTTrigData(tTrigMeanNew, tTrigSigma, kFactor);
+  }
+
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.cc
@@ -27,7 +27,7 @@ DTTTrigConstantShift::DTTTrigConstantShift(const ParameterSet& pset):
 
   LogVerbatim("Calibration") << "[DTTTrigConstantShift] Applying constant correction value: " << value_ << endl;
 
-  if( calibChamber_ != "" && calibChamber_ != "None" && calibChamber_ != "All" ){
+  if( !calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All" ){
     stringstream linestr;
     int selWheel, selStation, selSector;
     linestr << calibChamber_;
@@ -55,7 +55,7 @@ DTTTrigData DTTTrigConstantShift::correction(const DTSuperLayerId& slId) {
                                                                  << slId << endl;
 
   float tTrigMeanNew = tTrigMean;
-  if( calibChamber_ != "" && calibChamber_ != "None"){
+  if( !calibChamber_.empty() && calibChamber_ != "None"){
      if( ( calibChamber_ == "All" ) ||
          ( calibChamber_ != "All" && slId.chamberId() == chosenChamberId_ ) ) {
         tTrigMeanNew = tTrigMean + value_; 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.h
@@ -22,25 +22,25 @@ class DTTtrig;
 
 namespace dtCalibration {
 
-class DTTTrigConstantShift: public DTTTrigBaseCorrection {
-public:
-  // Constructor
-  DTTTrigConstantShift(const edm::ParameterSet&);
+  class DTTTrigConstantShift : public DTTTrigBaseCorrection {
+  public:
+    // Constructor
+    DTTTrigConstantShift(const edm::ParameterSet&);
 
-  // Destructor
-  ~DTTTrigConstantShift() override;
+    // Destructor
+    ~DTTTrigConstantShift() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTTTrigData correction(const DTSuperLayerId&) override;
+    void setES(const edm::EventSetup& setup) override;
+    DTTTrigData correction(const DTSuperLayerId&) override;
 
-private:
-  std::string dbLabel_;
-  std::string calibChamber_;
-  double value_;
+  private:
+    std::string dbLabel_;
+    std::string calibChamber_;
+    double value_;
 
-  const DTTtrig *tTrigMap_;
-  DTChamberId chosenChamberId_;
-};
+    const DTTtrig* tTrigMap_;
+    DTChamberId chosenChamberId_;
+  };
 
-} // namespace
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.cc
@@ -32,22 +32,21 @@
 using namespace edm;
 using namespace std;
 
-DTTTrigCorrection::DTTTrigCorrection(const ParameterSet& pset): 
-  dbLabel_( pset.getUntrackedParameter<string>("dbLabel", "") ),
-  correctionAlgo_{DTTTrigCorrectionFactory::get()->create(pset.getParameter<string>("correctionAlgo"),
-                                                          pset.getParameter<ParameterSet>("correctionAlgoConfig"))}
-{
+DTTTrigCorrection::DTTTrigCorrection(const ParameterSet& pset)
+    : dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")),
+      correctionAlgo_{DTTTrigCorrectionFactory::get()->create(
+          pset.getParameter<string>("correctionAlgo"), pset.getParameter<ParameterSet>("correctionAlgoConfig"))} {
   LogVerbatim("Calibration") << "[DTTTrigCorrection] Constructor called" << endl;
 }
 
-DTTTrigCorrection::~DTTTrigCorrection(){
+DTTTrigCorrection::~DTTTrigCorrection() {
   LogVerbatim("Calibration") << "[DTTTrigCorrection] Destructor called" << endl;
 }
 
-void DTTTrigCorrection::beginRun( const edm::Run& run, const edm::EventSetup& setup ) {
+void DTTTrigCorrection::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   // Get tTrig record from DB
   ESHandle<DTTtrig> tTrig;
-  setup.get<DTTtrigRcd>().get(dbLabel_,tTrig);
+  setup.get<DTTtrigRcd>().get(dbLabel_, tTrig);
   tTrigMap_ = &*tTrig;
   LogVerbatim("Calibration") << "[DTTTrigCorrection]: TTrig version: " << tTrig->version() << endl;
 
@@ -60,42 +59,40 @@ void DTTTrigCorrection::beginRun( const edm::Run& run, const edm::EventSetup& se
 
 void DTTTrigCorrection::endJob() {
   // Create the object to be written to DB
-  DTTtrig* tTrigNewMap = new DTTtrig();  
+  DTTtrig* tTrigNewMap = new DTTtrig();
 
-  for(vector<const DTSuperLayer*>::const_iterator sl = muonGeom_->superLayers().begin();
-                                            sl != muonGeom_->superLayers().end(); ++sl) {
+  for (vector<const DTSuperLayer*>::const_iterator sl = muonGeom_->superLayers().begin();
+       sl != muonGeom_->superLayers().end();
+       ++sl) {
     // Get old value from DB
-    float tTrigMean,tTrigSigma,kFactor;
-    int status = tTrigMap_->get((*sl)->id(),tTrigMean,tTrigSigma,kFactor,DTTimeUnits::ns);
+    float tTrigMean, tTrigSigma, kFactor;
+    int status = tTrigMap_->get((*sl)->id(), tTrigMean, tTrigSigma, kFactor, DTTimeUnits::ns);
 
     //Compute new ttrig
-    try{
+    try {
       dtCalibration::DTTTrigData tTrigCorr = correctionAlgo_->correction((*sl)->id());
       float tTrigMeanNew = tTrigCorr.mean;
-      float tTrigSigmaNew = tTrigCorr.sigma; 
+      float tTrigSigmaNew = tTrigCorr.sigma;
       float kFactorNew = tTrigCorr.kFactor;
-      tTrigNewMap->set((*sl)->id(),tTrigMeanNew,tTrigSigmaNew,kFactorNew,DTTimeUnits::ns);
+      tTrigNewMap->set((*sl)->id(), tTrigMeanNew, tTrigSigmaNew, kFactorNew, DTTimeUnits::ns);
 
-      LogVerbatim("Calibration") << "New tTrig for: " << (*sl)->id()
-				 << " mean from " << tTrigMean << " to " << tTrigMeanNew
-				 << " sigma from " << tTrigSigma << " to " << tTrigSigmaNew
-				 << " kFactor from " << kFactor << " to " << kFactorNew << endl;
-    } catch(cms::Exception& e){
+      LogVerbatim("Calibration") << "New tTrig for: " << (*sl)->id() << " mean from " << tTrigMean << " to "
+                                 << tTrigMeanNew << " sigma from " << tTrigSigma << " to " << tTrigSigmaNew
+                                 << " kFactor from " << kFactor << " to " << kFactorNew << endl;
+    } catch (cms::Exception& e) {
       LogError("Calibration") << e.explainSelf();
       // Set db to the old value, if it was there in the first place
-      if(!status){
-         tTrigNewMap->set((*sl)->id(),tTrigMean,tTrigSigma,kFactor,DTTimeUnits::ns);
-         LogVerbatim("Calibration") << "Keep old tTrig for: " << (*sl)->id()
-                                    << " mean " << tTrigMean
-                                    << " sigma " << tTrigSigma
-                                    << " kFactor " << kFactor << endl;
-      } 
+      if (!status) {
+        tTrigNewMap->set((*sl)->id(), tTrigMean, tTrigSigma, kFactor, DTTimeUnits::ns);
+        LogVerbatim("Calibration") << "Keep old tTrig for: " << (*sl)->id() << " mean " << tTrigMean << " sigma "
+                                   << tTrigSigma << " kFactor " << kFactor << endl;
+      }
       continue;
     }
-  }//End of loop on superlayers 
+  }  //End of loop on superlayers
 
   //Write object to DB
   LogVerbatim("Calibration") << "[DTTTrigCorrection]: Writing ttrig object to DB!" << endl;
   string record = "DTTtrigRcd";
   DTCalibDBUtils::writeToDB<DTTtrig>(record, tTrigNewMap);
-} 
+}

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
@@ -31,12 +31,11 @@ public:
   // Operations
 
   void beginJob() override {}
-  void beginRun( const edm::Run& run, const edm::EventSetup& setup ) override;
-  void analyze(const edm::Event& event, const edm::EventSetup& setup) override{}
+  void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
   void endJob() override;
 
 protected:
-
 private:
   std::string dbLabel_;
 
@@ -46,4 +45,3 @@ private:
   std::unique_ptr<dtCalibration::DTTTrigBaseCorrection> correctionAlgo_;
 };
 #endif
-

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
@@ -26,20 +26,19 @@ using namespace edm;
 using namespace std;
 
 DTTTrigCorrectionFirst::DTTTrigCorrectionFirst(const ParameterSet& pset) {
- 
-  debug = pset.getUntrackedParameter<bool>("debug",false);
-  ttrigMin = pset.getUntrackedParameter<double>("ttrigMin",0);
-  ttrigMax = pset.getUntrackedParameter<double>("ttrigMax",5000);
-  rmsLimit = pset.getUntrackedParameter<double>("rmsLimit",5.);
+  debug = pset.getUntrackedParameter<bool>("debug", false);
+  ttrigMin = pset.getUntrackedParameter<double>("ttrigMin", 0);
+  ttrigMax = pset.getUntrackedParameter<double>("ttrigMax", 5000);
+  rmsLimit = pset.getUntrackedParameter<double>("rmsLimit", 5.);
 
-  dbLabel  = pset.getUntrackedParameter<string>("dbLabel", "");
+  dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
 }
 
-DTTTrigCorrectionFirst::~DTTTrigCorrectionFirst(){}
+DTTTrigCorrectionFirst::~DTTTrigCorrectionFirst() {}
 
-void DTTTrigCorrectionFirst::beginRun( const edm::Run& run, const edm::EventSetup& setup ) {
+void DTTTrigCorrectionFirst::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   ESHandle<DTTtrig> tTrig;
-  setup.get<DTTtrigRcd>().get(dbLabel,tTrig);
+  setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
   tTrigMap = &*tTrig;
   cout << "[DTTTrigCorrection]: TTrig version: " << tTrig->version() << endl;
 
@@ -48,11 +47,11 @@ void DTTTrigCorrectionFirst::beginRun( const edm::Run& run, const edm::EventSetu
 
 void DTTTrigCorrectionFirst::endJob() {
   // Create the object to be written to DB
-  DTTtrig* tTrigNewMap = new DTTtrig();  
+  DTTtrig* tTrigNewMap = new DTTtrig();
   //Get the superlayers list
   vector<const DTSuperLayer*> dtSupLylist = muonGeom->superLayers();
 
-  //Loop on all superlayers to compute the mean 
+  //Loop on all superlayers to compute the mean
   double average = 0.;
   double average2 = 0.;
   double rms = 0.;
@@ -63,227 +62,178 @@ void DTTTrigCorrectionFirst::endJob() {
   double averagekfactor = 0;
   float kfactor = 0;
 
-  for (auto sl = dtSupLylist.begin();
-       sl != dtSupLylist.end(); sl++) {
+  for (auto sl = dtSupLylist.begin(); sl != dtSupLylist.end(); sl++) {
     float ttrigMean = 0;
-    float ttrigSigma = 0;   
-    tTrigMap->get((*sl)->id(),
-		  ttrigMean,
-		  ttrigSigma,
-                  kfactor,
-		  DTTimeUnits::ns);
-    if( ttrigMean < ttrigMax && ttrigMean > ttrigMin ) {
+    float ttrigSigma = 0;
+    tTrigMap->get((*sl)->id(), ttrigMean, ttrigSigma, kfactor, DTTimeUnits::ns);
+    if (ttrigMean < ttrigMax && ttrigMean > ttrigMin) {
       average += ttrigMean;
       averageSigma += ttrigSigma;
-      if(ttrigMean > 0)
-	counter +=  1.;
+      if (ttrigMean > 0)
+        counter += 1.;
     }
-  }//End of loop on superlayers 
+  }  //End of loop on superlayers
 
-  average =  average/ counter;
-  averageSigma = averageSigma/counter;
+  average = average / counter;
+  averageSigma = averageSigma / counter;
   averagekfactor = kfactor;
 
   //  cout << " average counter "<< average << " "<< counter <<endl;
 
-  for (auto sl = dtSupLylist.begin();
-       sl != dtSupLylist.end(); sl++) {
+  for (auto sl = dtSupLylist.begin(); sl != dtSupLylist.end(); sl++) {
     float ttrigMean = 0;
     float ttrigSigma = 0;
     float kfactor = 0;
-    tTrigMap->get((*sl)->id(),
-		  ttrigMean,
-		  ttrigSigma,
-                  kfactor,
-		  DTTimeUnits::ns);
-    if( ttrigMean < ttrigMax && ttrigMean > ttrigMin ) {
-      average2 += (ttrigMean-average)*(ttrigMean-average);
-      average2Sigma += (ttrigSigma-averageSigma)*(ttrigSigma-averageSigma);
+    tTrigMap->get((*sl)->id(), ttrigMean, ttrigSigma, kfactor, DTTimeUnits::ns);
+    if (ttrigMean < ttrigMax && ttrigMean > ttrigMin) {
+      average2 += (ttrigMean - average) * (ttrigMean - average);
+      average2Sigma += (ttrigSigma - averageSigma) * (ttrigSigma - averageSigma);
     }
-  }//End of loop on superlayers 
+  }  //End of loop on superlayers
 
-     rms = average2 /(counter-1);
-     rmsSigma = average2Sigma /(counter-1);
-     rms = sqrt(rms);
-     rmsSigma = sqrt(rmsSigma);
-  cout << "average averageSigma counter rms "<< average <<" " << averageSigma << " " << counter << " " << rms  <<endl;
+  rms = average2 / (counter - 1);
+  rmsSigma = average2Sigma / (counter - 1);
+  rms = sqrt(rms);
+  rmsSigma = sqrt(rmsSigma);
+  cout << "average averageSigma counter rms " << average << " " << averageSigma << " " << counter << " " << rms << endl;
 
-
-  for (auto sl = dtSupLylist.begin();
-       sl != dtSupLylist.end(); sl++) {
+  for (auto sl = dtSupLylist.begin(); sl != dtSupLylist.end(); sl++) {
     //Compute new ttrig
-    double newTTrigMean =  0;
-    double newTTrigSigma =  0;
-    double newkfactor =0;
+    double newTTrigMean = 0;
+    double newTTrigSigma = 0;
+    double newkfactor = 0;
     float tempttrigMean = 0;
     float tempttrigSigma = 0;
     float tempkfactor = 0;
     float ttrigMean = 0;
     float ttrigSigma = 0;
     float kfactor = 0;
-    tTrigMap->get((*sl)->id(),
-		  ttrigMean,
-		  ttrigSigma,
-                  kfactor,
-		  DTTimeUnits::ns);
+    tTrigMap->get((*sl)->id(), ttrigMean, ttrigSigma, kfactor, DTTimeUnits::ns);
     int chamber = (*sl)->id().chamberId().station();
 
     //check if ttrigMean is similar to the mean
-    if (abs(ttrigMean - average) < rmsLimit*rms ){
+    if (abs(ttrigMean - average) < rmsLimit * rms) {
       newTTrigMean = ttrigMean;
       newTTrigSigma = ttrigSigma;
       newkfactor = kfactor;
     } else {
       // do not consider if ttrig == 0
-      if(ttrigMean > 0) {
-	//cout << "ttrig chamber " << ttrigMean <<" "<<chamber<<endl;
-	if(((*sl)->id().superlayer()) == 1){
-	  //cout << " superlayer " << ((*sl)->id().superlayer()) <<endl; 
-	  DTSuperLayerId slId((*sl)->id().chamberId(),3);
-	  tTrigMap->get(slId,
-			tempttrigMean,
-			tempttrigSigma,
-                        tempkfactor,
-			DTTimeUnits::ns);
-	  if (abs(tempttrigMean - average) < rmsLimit*rms) {
-	    newTTrigMean = tempttrigMean;
-	    newTTrigSigma = tempttrigSigma;
+      if (ttrigMean > 0) {
+        //cout << "ttrig chamber " << ttrigMean <<" "<<chamber<<endl;
+        if (((*sl)->id().superlayer()) == 1) {
+          //cout << " superlayer " << ((*sl)->id().superlayer()) <<endl;
+          DTSuperLayerId slId((*sl)->id().chamberId(), 3);
+          tTrigMap->get(slId, tempttrigMean, tempttrigSigma, tempkfactor, DTTimeUnits::ns);
+          if (abs(tempttrigMean - average) < rmsLimit * rms) {
+            newTTrigMean = tempttrigMean;
+            newTTrigSigma = tempttrigSigma;
             newkfactor = tempkfactor;
-	    cout <<"Chamber "<< chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig "<< ttrigMean  
-		 << " -> takes value of sl 3 " <<  newTTrigMean <<endl;
-	  } else if(chamber == 4){
-	    cout << "No correction possible within same chamber (sl1) "  <<endl; 
-	    newTTrigMean = average;
-	    newTTrigSigma = averageSigma;
+            cout << "Chamber " << chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig " << ttrigMean
+                 << " -> takes value of sl 3 " << newTTrigMean << endl;
+          } else if (chamber == 4) {
+            cout << "No correction possible within same chamber (sl1) " << endl;
+            newTTrigMean = average;
+            newTTrigSigma = averageSigma;
             newkfactor = averagekfactor;
-	    cout<<"####### Bad SL: " << (*sl)->id() << " from "<< ttrigMean <<" to "<< newTTrigMean <<endl;
-	  } else if(chamber != 4){	  
-	    DTSuperLayerId slId((*sl)->id().chamberId(),2);
-	    tTrigMap->get(slId,
-			  tempttrigMean,
-			  tempttrigSigma,
-                          tempkfactor,
-			  DTTimeUnits::ns);
-	    if (abs(tempttrigMean - average) < rmsLimit*rms) {
-	      newTTrigMean = tempttrigMean;
-	      newTTrigSigma = tempttrigSigma;
+            cout << "####### Bad SL: " << (*sl)->id() << " from " << ttrigMean << " to " << newTTrigMean << endl;
+          } else if (chamber != 4) {
+            DTSuperLayerId slId((*sl)->id().chamberId(), 2);
+            tTrigMap->get(slId, tempttrigMean, tempttrigSigma, tempkfactor, DTTimeUnits::ns);
+            if (abs(tempttrigMean - average) < rmsLimit * rms) {
+              newTTrigMean = tempttrigMean;
+              newTTrigSigma = tempttrigSigma;
               newkfactor = tempkfactor;
-	      cout <<"Chamber "<< chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig "<< ttrigMean  
-		   <<" -> takes value of sl 2 " <<  newTTrigMean <<endl;
-	    } else {
-	      cout << "No correction possible within same chamber (sl1) "  <<endl;
-	      newTTrigMean = average;
-	      newTTrigSigma = averageSigma;
+              cout << "Chamber " << chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig " << ttrigMean
+                   << " -> takes value of sl 2 " << newTTrigMean << endl;
+            } else {
+              cout << "No correction possible within same chamber (sl1) " << endl;
+              newTTrigMean = average;
+              newTTrigSigma = averageSigma;
               newkfactor = averagekfactor;
-	      cout<<"####### Bad SL: " << (*sl)->id() << " from "<< ttrigMean <<" to "<< newTTrigMean <<endl;
-	    }
-	  }
-	} else if (((*sl)->id().superlayer()) == 2) {
-	  //cout << " superlayer " << ((*sl)->id().superlayer()) <<endl; 
-	  DTSuperLayerId slId((*sl)->id().chamberId(),1);
-	  tTrigMap->get(slId,
-			tempttrigMean,
-			tempttrigSigma,
-                        tempkfactor,
-			DTTimeUnits::ns);
-	  if (abs(tempttrigMean - average) < rmsLimit*rms) {
-	    newTTrigMean = tempttrigMean;
-	    newTTrigSigma = tempttrigSigma;
+              cout << "####### Bad SL: " << (*sl)->id() << " from " << ttrigMean << " to " << newTTrigMean << endl;
+            }
+          }
+        } else if (((*sl)->id().superlayer()) == 2) {
+          //cout << " superlayer " << ((*sl)->id().superlayer()) <<endl;
+          DTSuperLayerId slId((*sl)->id().chamberId(), 1);
+          tTrigMap->get(slId, tempttrigMean, tempttrigSigma, tempkfactor, DTTimeUnits::ns);
+          if (abs(tempttrigMean - average) < rmsLimit * rms) {
+            newTTrigMean = tempttrigMean;
+            newTTrigSigma = tempttrigSigma;
             newkfactor = tempkfactor;
-	    cout <<"Chamber "<< chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig "<< ttrigMean  
-		 << " -> takes value of sl 1 " <<  newTTrigMean <<endl;
-	  } else {
-	    DTSuperLayerId slId((*sl)->id().chamberId(),3);
-	    tTrigMap->get(slId,
-			  tempttrigMean,
-			  tempttrigSigma,
-                          tempkfactor,
-			  DTTimeUnits::ns);
-	    if (abs(tempttrigMean - average) < rmsLimit*rms) {
-	      newTTrigMean = tempttrigMean;
-	      newTTrigSigma = tempttrigSigma;
+            cout << "Chamber " << chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig " << ttrigMean
+                 << " -> takes value of sl 1 " << newTTrigMean << endl;
+          } else {
+            DTSuperLayerId slId((*sl)->id().chamberId(), 3);
+            tTrigMap->get(slId, tempttrigMean, tempttrigSigma, tempkfactor, DTTimeUnits::ns);
+            if (abs(tempttrigMean - average) < rmsLimit * rms) {
+              newTTrigMean = tempttrigMean;
+              newTTrigSigma = tempttrigSigma;
               newkfactor = tempkfactor;
-	      cout <<"Chamber "<< chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig "<< ttrigMean  
-		   << "-> takes value of sl 3 " <<  newTTrigMean <<endl;
-	      } else {
-	      cout << "No correction possible within same chamber (sl2)  "  <<endl;
-	      newTTrigMean = average;
-	      newTTrigSigma = averageSigma;
+              cout << "Chamber " << chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig " << ttrigMean
+                   << "-> takes value of sl 3 " << newTTrigMean << endl;
+            } else {
+              cout << "No correction possible within same chamber (sl2)  " << endl;
+              newTTrigMean = average;
+              newTTrigSigma = averageSigma;
               newkfactor = averagekfactor;
-	      cout<<"####### Bad SL: " << (*sl)->id() << " from "<< ttrigMean <<" to "<< newTTrigMean <<endl;
-	    }
-	  } 
-	  
-	  
-	} else if (((*sl)->id().superlayer()) == 3) {
-	  //cout << " superlayer " << ((*sl)->id().superlayer()) <<endl; 
-	  DTSuperLayerId slId((*sl)->id().chamberId(),1);
-	  tTrigMap->get(slId,
-			tempttrigMean,
-			tempttrigSigma,
-                        tempkfactor,
-			DTTimeUnits::ns);
-	  if (abs(tempttrigMean - average) < rmsLimit*rms) {
-	    newTTrigMean = tempttrigMean;
-	    newTTrigSigma = tempttrigSigma;
+              cout << "####### Bad SL: " << (*sl)->id() << " from " << ttrigMean << " to " << newTTrigMean << endl;
+            }
+          }
+
+        } else if (((*sl)->id().superlayer()) == 3) {
+          //cout << " superlayer " << ((*sl)->id().superlayer()) <<endl;
+          DTSuperLayerId slId((*sl)->id().chamberId(), 1);
+          tTrigMap->get(slId, tempttrigMean, tempttrigSigma, tempkfactor, DTTimeUnits::ns);
+          if (abs(tempttrigMean - average) < rmsLimit * rms) {
+            newTTrigMean = tempttrigMean;
+            newTTrigSigma = tempttrigSigma;
             newkfactor = tempkfactor;
-	    cout <<"Chamber "<< chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig "<< ttrigMean  
-		 << " -> takes value of sl 1 " <<  newTTrigMean <<endl;
-	  } else if(chamber == 4) {
-	    cout << "No correction possible within same chamber (sl3)"  <<endl;
-	    newTTrigMean = average;
-	    newTTrigSigma = averageSigma;
+            cout << "Chamber " << chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig " << ttrigMean
+                 << " -> takes value of sl 1 " << newTTrigMean << endl;
+          } else if (chamber == 4) {
+            cout << "No correction possible within same chamber (sl3)" << endl;
+            newTTrigMean = average;
+            newTTrigSigma = averageSigma;
             newkfactor = averagekfactor;
-	    cout<<"####### Bad SL: " << (*sl)->id() << " from "<< ttrigMean <<" to "<< newTTrigMean <<endl;
-	  } else if(chamber != 4){
-	    DTSuperLayerId slId((*sl)->id().chamberId(),2);
-	    tTrigMap->get(slId,
-			  tempttrigMean,
-			  tempttrigSigma,
-                          tempkfactor,
-			  DTTimeUnits::ns);
-	    if (abs(tempttrigMean - average) < rmsLimit*rms) {
-	      newTTrigMean = tempttrigMean;
-	      newTTrigSigma = tempttrigSigma;
+            cout << "####### Bad SL: " << (*sl)->id() << " from " << ttrigMean << " to " << newTTrigMean << endl;
+          } else if (chamber != 4) {
+            DTSuperLayerId slId((*sl)->id().chamberId(), 2);
+            tTrigMap->get(slId, tempttrigMean, tempttrigSigma, tempkfactor, DTTimeUnits::ns);
+            if (abs(tempttrigMean - average) < rmsLimit * rms) {
+              newTTrigMean = tempttrigMean;
+              newTTrigSigma = tempttrigSigma;
               newkfactor = tempkfactor;
-	      cout <<"Chamber "<< chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig "<< ttrigMean  
-		   << " -> takes value of sl 2 " <<  newTTrigMean <<endl;
-	    } else {
-	      cout << "No correction possible within same chamber (sl3) "  <<endl;
-	      newTTrigMean = average;
-	      newTTrigSigma = averageSigma;
+              cout << "Chamber " << chamber << " sl " << ((*sl)->id().superlayer()) << "has ttrig " << ttrigMean
+                   << " -> takes value of sl 2 " << newTTrigMean << endl;
+            } else {
+              cout << "No correction possible within same chamber (sl3) " << endl;
+              newTTrigMean = average;
+              newTTrigSigma = averageSigma;
               newkfactor = averagekfactor;
-	      cout<<"####### Bad SL: " << (*sl)->id() << " from "<< ttrigMean <<" to "<< newTTrigMean <<endl;
-	    }
-	  } 
-	  
-	}
+              cout << "####### Bad SL: " << (*sl)->id() << " from " << ttrigMean << " to " << newTTrigMean << endl;
+            }
+          }
+        }
       } else {
-	//	cout << "SL not present " << ttrigMean << " " <<((*sl)->id().superlayer()) <<endl;
-	newTTrigMean = average;
-	newTTrigSigma = averageSigma;
+        //	cout << "SL not present " << ttrigMean << " " <<((*sl)->id().superlayer()) <<endl;
+        newTTrigMean = average;
+        newTTrigSigma = averageSigma;
         newkfactor = averagekfactor;
-	cout<<"####### NotPresent SL: " << (*sl)->id() << " from "<< ttrigMean <<" to "<< newTTrigMean <<endl;
+        cout << "####### NotPresent SL: " << (*sl)->id() << " from " << ttrigMean << " to " << newTTrigMean << endl;
       }
     }
 
     //Store new ttrig in the new map
     tTrigNewMap->set((*sl)->id(), newTTrigMean, newTTrigSigma, newkfactor, DTTimeUnits::ns);
-    if(debug){
-      cout<<"New tTrig: " << (*sl)->id()
-    	  << " from "<< ttrigMean <<" to "<< newTTrigMean <<endl;
-      cout<<"New tTrigSigma: " << (*sl)->id()
-    	  << " from "<<ttrigSigma  <<" to "<< newTTrigSigma <<endl;
-
+    if (debug) {
+      cout << "New tTrig: " << (*sl)->id() << " from " << ttrigMean << " to " << newTTrigMean << endl;
+      cout << "New tTrigSigma: " << (*sl)->id() << " from " << ttrigSigma << " to " << newTTrigSigma << endl;
     }
-  }//End of loop on superlayers 
+  }  //End of loop on superlayers
 
-  
   //Write object to DB
   cout << "[DTTTrigCorrection]: Writing ttrig object to DB!" << endl;
   string record = "DTTtrigRcd";
-   DTCalibDBUtils::writeToDB<DTTtrig>(record, tTrigNewMap);
-} 
-
-
-
+  DTCalibDBUtils::writeToDB<DTTtrig>(record, tTrigNewMap);
+}

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
@@ -28,21 +28,19 @@ public:
   // Operations
 
   void beginJob() override {}
-  void beginRun( const edm::Run& run, const edm::EventSetup& setup ) override;
-  void analyze(const edm::Event& event, const edm::EventSetup& setup) override{}
+  void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
 
   void endJob() override;
 
 protected:
-
 private:
-  const DTTtrig *tTrigMap;
+  const DTTtrig* tTrigMap;
   edm::ESHandle<DTGeometry> muonGeom;
 
   std::string dbLabel;
 
   bool debug;
-  double ttrigMin,ttrigMax,rmsLimit; 
+  double ttrigMin, ttrigMax, rmsLimit;
 };
 #endif
-

--- a/CalibMuon/DTCalibration/plugins/DTTTrigFillWithAverage.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigFillWithAverage.cc
@@ -18,83 +18,83 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTTTrigFillWithAverage::DTTTrigFillWithAverage(const ParameterSet& pset):foundAverage_(false) {
-  dbLabel  = pset.getUntrackedParameter<string>("dbLabel", "");
-}
+  DTTTrigFillWithAverage::DTTTrigFillWithAverage(const ParameterSet& pset) : foundAverage_(false) {
+    dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
+  }
 
-DTTTrigFillWithAverage::~DTTTrigFillWithAverage() {}
+  DTTTrigFillWithAverage::~DTTTrigFillWithAverage() {}
 
-void DTTTrigFillWithAverage::setES(const EventSetup& setup) {
-  // Get tTrig record from DB
-  ESHandle<DTTtrig> tTrig;
-  setup.get<DTTtrigRcd>().get(dbLabel,tTrig);
-  tTrigMap_ = &*tTrig;
+  void DTTTrigFillWithAverage::setES(const EventSetup& setup) {
+    // Get tTrig record from DB
+    ESHandle<DTTtrig> tTrig;
+    setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
+    tTrigMap_ = &*tTrig;
 
-  // Get geometry from Event Setup
-  setup.get<MuonGeometryRecord>().get(muonGeom_);
-}
+    // Get geometry from Event Setup
+    setup.get<MuonGeometryRecord>().get(muonGeom_);
+  }
 
-DTTTrigData DTTTrigFillWithAverage::correction(const DTSuperLayerId& slId) {
-  float tTrigMean,tTrigSigma, kFactor;
-  int status = tTrigMap_->get(slId,tTrigMean,tTrigSigma,kFactor,DTTimeUnits::ns);
-  if(!status){
-    return DTTTrigData(tTrigMean,tTrigSigma,kFactor);
-  } else {
-    if(!foundAverage_) getAverage();
-    float corrMean = initialTTrig_.aveMean;
-    float corrSigma = initialTTrig_.aveSigma;
-    float corrKFactor = initialTTrig_.aveKFactor; 
-    return DTTTrigData(corrMean,corrSigma,corrKFactor); //FIXME: kFactor is not anymore a unique one
-  } 
-}
-
-void DTTTrigFillWithAverage::getAverage() {
-  //Get the superlayers list
-  vector<const DTSuperLayer*> dtSupLylist = muonGeom_->superLayers();
-
-  float aveMean = 0.;
-  float ave2Mean = 0.;
-  float aveSigma = 0.;
-  float ave2Sigma = 0.;
-  float aveKFactor = 0.;
-  int nIter = 0;
-  
-  for(auto sl = muonGeom_->superLayers().begin();
-          sl != muonGeom_->superLayers().end(); ++sl) {
-    float tTrigMean,tTrigSigma,kFactor;
-    int status = tTrigMap_->get((*sl)->id(),tTrigMean,tTrigSigma,kFactor,DTTimeUnits::ns);
-    if(!status){
-      ++nIter;
-      aveMean += tTrigMean;
-      ave2Mean += tTrigMean*tTrigMean;
-      aveSigma += tTrigSigma;
-      ave2Sigma += tTrigSigma*tTrigSigma;
-      aveKFactor += kFactor;
+  DTTTrigData DTTTrigFillWithAverage::correction(const DTSuperLayerId& slId) {
+    float tTrigMean, tTrigSigma, kFactor;
+    int status = tTrigMap_->get(slId, tTrigMean, tTrigSigma, kFactor, DTTimeUnits::ns);
+    if (!status) {
+      return DTTTrigData(tTrigMean, tTrigSigma, kFactor);
+    } else {
+      if (!foundAverage_)
+        getAverage();
+      float corrMean = initialTTrig_.aveMean;
+      float corrSigma = initialTTrig_.aveSigma;
+      float corrKFactor = initialTTrig_.aveKFactor;
+      return DTTTrigData(corrMean, corrSigma, corrKFactor);  //FIXME: kFactor is not anymore a unique one
     }
   }
 
-  // Compute average
-  aveMean /= nIter;
-  float rmsMean = ave2Mean/(nIter - 1) - aveMean*aveMean;
-  rmsMean = sqrt(rmsMean);
-  aveSigma /= nIter;
-  float rmsSigma = ave2Sigma/(nIter - 1) - aveSigma*aveSigma;
-  rmsSigma = sqrt(rmsSigma);
-  aveKFactor /= nIter;  
+  void DTTTrigFillWithAverage::getAverage() {
+    //Get the superlayers list
+    vector<const DTSuperLayer*> dtSupLylist = muonGeom_->superLayers();
 
-  initialTTrig_.aveMean = aveMean;
-  initialTTrig_.rmsMean = rmsMean;
-  initialTTrig_.aveSigma = aveSigma;
-  initialTTrig_.rmsSigma = rmsSigma;
-  initialTTrig_.aveKFactor = aveKFactor;
+    float aveMean = 0.;
+    float ave2Mean = 0.;
+    float aveSigma = 0.;
+    float ave2Sigma = 0.;
+    float aveKFactor = 0.;
+    int nIter = 0;
 
-  LogVerbatim("Calibration") << "[DTTTrigFillWithAverage] Found from " << nIter << " SL's\n"
-                             << "                               average tTrig mean: " << aveMean << "\n"
-                             << "                               tTrig mean RMS: " << rmsMean << "\n"
-                             << "                               average tTrig sigma: " << aveSigma << "\n"
-                             << "                               tTrig sigma RMS: " << rmsSigma << "\n" 
-                             << "                               kFactor mean: " << aveKFactor;
-  foundAverage_ = true;
-}
+    for (auto sl = muonGeom_->superLayers().begin(); sl != muonGeom_->superLayers().end(); ++sl) {
+      float tTrigMean, tTrigSigma, kFactor;
+      int status = tTrigMap_->get((*sl)->id(), tTrigMean, tTrigSigma, kFactor, DTTimeUnits::ns);
+      if (!status) {
+        ++nIter;
+        aveMean += tTrigMean;
+        ave2Mean += tTrigMean * tTrigMean;
+        aveSigma += tTrigSigma;
+        ave2Sigma += tTrigSigma * tTrigSigma;
+        aveKFactor += kFactor;
+      }
+    }
 
-} // namespace
+    // Compute average
+    aveMean /= nIter;
+    float rmsMean = ave2Mean / (nIter - 1) - aveMean * aveMean;
+    rmsMean = sqrt(rmsMean);
+    aveSigma /= nIter;
+    float rmsSigma = ave2Sigma / (nIter - 1) - aveSigma * aveSigma;
+    rmsSigma = sqrt(rmsSigma);
+    aveKFactor /= nIter;
+
+    initialTTrig_.aveMean = aveMean;
+    initialTTrig_.rmsMean = rmsMean;
+    initialTTrig_.aveSigma = aveSigma;
+    initialTTrig_.rmsSigma = rmsSigma;
+    initialTTrig_.aveKFactor = aveKFactor;
+
+    LogVerbatim("Calibration") << "[DTTTrigFillWithAverage] Found from " << nIter << " SL's\n"
+                               << "                               average tTrig mean: " << aveMean << "\n"
+                               << "                               tTrig mean RMS: " << rmsMean << "\n"
+                               << "                               average tTrig sigma: " << aveSigma << "\n"
+                               << "                               tTrig sigma RMS: " << rmsSigma << "\n"
+                               << "                               kFactor mean: " << aveKFactor;
+    foundAverage_ = true;
+  }
+
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTTTrigFillWithAverage.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigFillWithAverage.h
@@ -20,35 +20,35 @@ class DTGeometry;
 
 namespace dtCalibration {
 
-class DTTTrigFillWithAverage: public DTTTrigBaseCorrection {
-public:
-  // Constructor
-  DTTTrigFillWithAverage(const edm::ParameterSet&);
+  class DTTTrigFillWithAverage : public DTTTrigBaseCorrection {
+  public:
+    // Constructor
+    DTTTrigFillWithAverage(const edm::ParameterSet&);
 
-  // Destructor
-  ~DTTTrigFillWithAverage() override;
+    // Destructor
+    ~DTTTrigFillWithAverage() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTTTrigData correction(const DTSuperLayerId&) override;
+    void setES(const edm::EventSetup& setup) override;
+    DTTTrigData correction(const DTSuperLayerId&) override;
 
-private:
-  void getAverage();
+  private:
+    void getAverage();
 
-  const DTTtrig *tTrigMap_;
-  edm::ESHandle<DTGeometry> muonGeom_;
+    const DTTtrig* tTrigMap_;
+    edm::ESHandle<DTGeometry> muonGeom_;
 
-  std::string dbLabel;
+    std::string dbLabel;
 
-  struct {
-    float aveMean;
-    float rmsMean;
-    float aveSigma;
-    float rmsSigma;
-    float aveKFactor;
-  } initialTTrig_;
+    struct {
+      float aveMean;
+      float rmsMean;
+      float aveSigma;
+      float rmsSigma;
+      float aveKFactor;
+    } initialTTrig_;
 
-  bool foundAverage_; 
-};
+    bool foundAverage_;
+  };
 
-} // namespace
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.cc
@@ -19,49 +19,49 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTTTrigMatchRPhi::DTTTrigMatchRPhi(const ParameterSet& pset) {
-  dbLabel  = pset.getUntrackedParameter<string>("dbLabel", "");
-}
+  DTTTrigMatchRPhi::DTTTrigMatchRPhi(const ParameterSet& pset) {
+    dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
+  }
 
-DTTTrigMatchRPhi::~DTTTrigMatchRPhi() {}
+  DTTTrigMatchRPhi::~DTTTrigMatchRPhi() {}
 
-void DTTTrigMatchRPhi::setES(const EventSetup& setup) {
-  // Get tTrig record from DB
-  ESHandle<DTTtrig> tTrig;
-  setup.get<DTTtrigRcd>().get(dbLabel,tTrig);
-  tTrigMap_ = &*tTrig;
-}
+  void DTTTrigMatchRPhi::setES(const EventSetup& setup) {
+    // Get tTrig record from DB
+    ESHandle<DTTtrig> tTrig;
+    setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
+    tTrigMap_ = &*tTrig;
+  }
 
-DTTTrigData DTTTrigMatchRPhi::correction(const DTSuperLayerId& slId) {
-  
-  float tTrigMean,tTrigSigma,kFactor;
-  int status = tTrigMap_->get(slId,tTrigMean,tTrigSigma,kFactor,DTTimeUnits::ns);
-  // RZ superlayers return the current value
-  if(slId.superLayer() == 2){
-    if(status != 0) throw cms::Exception("[DTTTrigMatchRPhi]") << "Could not find tTrig entry in DB for"
-                                                               << slId << endl;
-    return DTTTrigData(tTrigMean,tTrigSigma,kFactor);
-  } else{
-    DTSuperLayerId partnerSLId(slId.chamberId(),(slId.superLayer() == 1)?3:1);
-    float tTrigMeanNew,tTrigSigmaNew,kFactorNew;
-    if(!status){ // Gets average of both SuperLayer's
-      if(!tTrigMap_->get(partnerSLId,tTrigMeanNew,tTrigSigmaNew,kFactorNew,DTTimeUnits::ns)){
-        tTrigMeanNew = (tTrigMean + tTrigMeanNew)/2.;
-//         tTrigSigmaNew = sqrt(tTrigSigmaNew*tTrigSigmaNew + tTrigSigma*tTrigSigma)/2.;
-        tTrigSigmaNew = (tTrigSigmaNew + tTrigSigma)/2.;
+  DTTTrigData DTTTrigMatchRPhi::correction(const DTSuperLayerId& slId) {
+    float tTrigMean, tTrigSigma, kFactor;
+    int status = tTrigMap_->get(slId, tTrigMean, tTrigSigma, kFactor, DTTimeUnits::ns);
+    // RZ superlayers return the current value
+    if (slId.superLayer() == 2) {
+      if (status != 0)
+        throw cms::Exception("[DTTTrigMatchRPhi]") << "Could not find tTrig entry in DB for" << slId << endl;
+      return DTTTrigData(tTrigMean, tTrigSigma, kFactor);
+    } else {
+      DTSuperLayerId partnerSLId(slId.chamberId(), (slId.superLayer() == 1) ? 3 : 1);
+      float tTrigMeanNew, tTrigSigmaNew, kFactorNew;
+      if (!status) {  // Gets average of both SuperLayer's
+        if (!tTrigMap_->get(partnerSLId, tTrigMeanNew, tTrigSigmaNew, kFactorNew, DTTimeUnits::ns)) {
+          tTrigMeanNew = (tTrigMean + tTrigMeanNew) / 2.;
+          //         tTrigSigmaNew = sqrt(tTrigSigmaNew*tTrigSigmaNew + tTrigSigma*tTrigSigma)/2.;
+          tTrigSigmaNew = (tTrigSigmaNew + tTrigSigma) / 2.;
 
-	kFactorNew = kFactor;
-        return DTTTrigData(tTrigMeanNew,tTrigSigmaNew,kFactorNew);
-      } else return DTTTrigData(tTrigMean,tTrigSigma,kFactor); 
-    } else{ // If there is no entry tries to find partner SL and retrieves its value
-      if(!tTrigMap_->get(partnerSLId,tTrigMeanNew,tTrigSigmaNew,kFactorNew,DTTimeUnits::ns))
-	return DTTTrigData(tTrigMeanNew,tTrigSigmaNew,kFactorNew);
-      else { // Both RPhi SL's not present in DB
-        throw cms::Exception("[DTTTrigMatchRPhi]") << "Could not find tTrig entry in DB for"
-                                                   << slId << "\n" << partnerSLId << endl;
+          kFactorNew = kFactor;
+          return DTTTrigData(tTrigMeanNew, tTrigSigmaNew, kFactorNew);
+        } else
+          return DTTTrigData(tTrigMean, tTrigSigma, kFactor);
+      } else {  // If there is no entry tries to find partner SL and retrieves its value
+        if (!tTrigMap_->get(partnerSLId, tTrigMeanNew, tTrigSigmaNew, kFactorNew, DTTimeUnits::ns))
+          return DTTTrigData(tTrigMeanNew, tTrigSigmaNew, kFactorNew);
+        else {  // Both RPhi SL's not present in DB
+          throw cms::Exception("[DTTTrigMatchRPhi]") << "Could not find tTrig entry in DB for" << slId << "\n"
+                                                     << partnerSLId << endl;
+        }
       }
     }
   }
-}
 
-} // namespace
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.h
@@ -20,22 +20,22 @@ class DTTtrig;
 
 namespace dtCalibration {
 
-class DTTTrigMatchRPhi: public DTTTrigBaseCorrection {
-public:
-  // Constructor
-  DTTTrigMatchRPhi(const edm::ParameterSet&);
+  class DTTTrigMatchRPhi : public DTTTrigBaseCorrection {
+  public:
+    // Constructor
+    DTTTrigMatchRPhi(const edm::ParameterSet&);
 
-  // Destructor
-  ~DTTTrigMatchRPhi() override;
+    // Destructor
+    ~DTTTrigMatchRPhi() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTTTrigData correction(const DTSuperLayerId&) override;
+    void setES(const edm::EventSetup& setup) override;
+    DTTTrigData correction(const DTSuperLayerId&) override;
 
-private:
-  const DTTtrig *tTrigMap_;
+  private:
+    const DTTtrig* tTrigMap_;
 
-  std::string dbLabel;
-};
+    std::string dbLabel;
+  };
 
-} // namespace
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.cc
@@ -34,42 +34,41 @@
 using namespace std;
 using namespace edm;
 
-DTTTrigOffsetCalibration::DTTTrigOffsetCalibration(const ParameterSet& pset):
-  theRecHits4DLabel_(pset.getParameter<InputTag>("recHits4DLabel")),
-  doTTrigCorrection_(pset.getUntrackedParameter<bool>("doT0SegCorrection", false)),
-  theCalibChamber_(pset.getUntrackedParameter<string>("calibChamber", "All")),
-  dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")) {
-
+DTTTrigOffsetCalibration::DTTTrigOffsetCalibration(const ParameterSet& pset)
+    : theRecHits4DLabel_(pset.getParameter<InputTag>("recHits4DLabel")),
+      doTTrigCorrection_(pset.getUntrackedParameter<bool>("doT0SegCorrection", false)),
+      theCalibChamber_(pset.getUntrackedParameter<string>("calibChamber", "All")),
+      dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")) {
   LogVerbatim("Calibration") << "[DTTTrigOffsetCalibration] Constructor called!";
 
   edm::ConsumesCollector collector(consumesCollector());
-  select_ = new DTSegmentSelector(pset,collector);
+  select_ = new DTSegmentSelector(pset, collector);
 
   // the root file which will contain the histos
-  string rootFileName = pset.getUntrackedParameter<string>("rootFileName","DTT0SegHistos.root");
+  string rootFileName = pset.getUntrackedParameter<string>("rootFileName", "DTT0SegHistos.root");
   rootFile_ = new TFile(rootFileName.c_str(), "RECREATE");
   rootFile_->cd();
 }
 
 void DTTTrigOffsetCalibration::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
-  if(doTTrigCorrection_){
+  if (doTTrigCorrection_) {
     ESHandle<DTTtrig> tTrig;
-    setup.get<DTTtrigRcd>().get(dbLabel_,tTrig);
+    setup.get<DTTtrigRcd>().get(dbLabel_, tTrig);
     tTrigMap_ = &*tTrig;
-    LogVerbatim("Calibration") << "[DTTTrigOffsetCalibration]: TTrig version: " << tTrig->version() << endl; 
+    LogVerbatim("Calibration") << "[DTTTrigOffsetCalibration]: TTrig version: " << tTrig->version() << endl;
   }
 }
 
-DTTTrigOffsetCalibration::~DTTTrigOffsetCalibration(){
+DTTTrigOffsetCalibration::~DTTTrigOffsetCalibration() {
   rootFile_->Close();
   LogVerbatim("Calibration") << "[DTTTrigOffsetCalibration] Destructor called!";
 }
 
-void DTTTrigOffsetCalibration::analyze(const Event & event, const EventSetup& eventSetup) {
+void DTTTrigOffsetCalibration::analyze(const Event& event, const EventSetup& eventSetup) {
   rootFile_->cd();
   DTChamberId chosenChamberId;
 
-  if(theCalibChamber_ != "All") {
+  if (theCalibChamber_ != "All") {
     stringstream linestr;
     int selWheel, selStation, selSector;
     linestr << theCalibChamber_;
@@ -84,102 +83,105 @@ void DTTTrigOffsetCalibration::analyze(const Event & event, const EventSetup& ev
 
   // Get the rechit collection from the event
   Handle<DTRecSegment4DCollection> all4DSegments;
-  event.getByLabel(theRecHits4DLabel_, all4DSegments); 
+  event.getByLabel(theRecHits4DLabel_, all4DSegments);
 
   // Loop over segments by chamber
   DTRecSegment4DCollection::id_iterator chamberIdIt;
-  for(chamberIdIt = all4DSegments->id_begin(); chamberIdIt != all4DSegments->id_end(); ++chamberIdIt){
-
+  for (chamberIdIt = all4DSegments->id_begin(); chamberIdIt != all4DSegments->id_end(); ++chamberIdIt) {
     // Get the chamber from the setup
     const DTChamber* chamber = dtGeom->chamber(*chamberIdIt);
     LogTrace("Calibration") << "Chamber Id: " << *chamberIdIt;
 
     // Book histos
-    if(theT0SegHistoMap_.find(*chamberIdIt) == theT0SegHistoMap_.end()){
+    if (theT0SegHistoMap_.find(*chamberIdIt) == theT0SegHistoMap_.end()) {
       bookHistos(*chamberIdIt);
     }
-   
-    // Calibrate just the chosen chamber/s    
-    if((theCalibChamber_ != "All") && ((*chamberIdIt) != chosenChamberId)) continue;
+
+    // Calibrate just the chosen chamber/s
+    if ((theCalibChamber_ != "All") && ((*chamberIdIt) != chosenChamberId))
+      continue;
 
     // Get the range for the corresponding ChamberId
     DTRecSegment4DCollection::range range = all4DSegments->get((*chamberIdIt));
 
     // Loop over the rechits of this DetUnit
-    for(DTRecSegment4DCollection::const_iterator segment  = range.first;
-                                                 segment != range.second; ++segment){
-
+    for (DTRecSegment4DCollection::const_iterator segment = range.first; segment != range.second; ++segment) {
       LogTrace("Calibration") << "Segment local pos (in chamber RF): " << (*segment).localPosition()
                               << "\nSegment global pos: " << chamber->toGlobal((*segment).localPosition());
-      
-      if( !(*select_)(*segment, event, eventSetup) ) continue;
+
+      if (!(*select_)(*segment, event, eventSetup))
+        continue;
 
       // Fill t0-seg values
-      if( (*segment).hasPhi() ) {
-        //if( segment->phiSegment()->ist0Valid() ){ 
-	if( (segment->phiSegment()->t0()) != 0.00 ){
-	  (theT0SegHistoMap_[*chamberIdIt])[0]->Fill(segment->phiSegment()->t0());
-	}
+      if ((*segment).hasPhi()) {
+        //if( segment->phiSegment()->ist0Valid() ){
+        if ((segment->phiSegment()->t0()) != 0.00) {
+          (theT0SegHistoMap_[*chamberIdIt])[0]->Fill(segment->phiSegment()->t0());
+        }
       }
-      if( (*segment).hasZed() ){
-        //if( segment->zSegment()->ist0Valid() ){ 
-    	if( (segment->zSegment()->t0()) != 0.00 ){
-	  (theT0SegHistoMap_[*chamberIdIt])[1]->Fill(segment->zSegment()->t0());
-	}
+      if ((*segment).hasZed()) {
+        //if( segment->zSegment()->ist0Valid() ){
+        if ((segment->zSegment()->t0()) != 0.00) {
+          (theT0SegHistoMap_[*chamberIdIt])[1]->Fill(segment->zSegment()->t0());
+        }
       }
-    } // DTRecSegment4DCollection::const_iterator segment
-  } // DTRecSegment4DCollection::id_iterator chamberIdIt
-} // DTTTrigOffsetCalibration::analyze
+    }  // DTRecSegment4DCollection::const_iterator segment
+  }    // DTRecSegment4DCollection::id_iterator chamberIdIt
+}  // DTTTrigOffsetCalibration::analyze
 
 void DTTTrigOffsetCalibration::endJob() {
   rootFile_->cd();
-  
+
   LogVerbatim("Calibration") << "[DTTTrigOffsetCalibration] Writing histos to file!" << endl;
 
-  for(ChamberHistosMap::const_iterator itChHistos = theT0SegHistoMap_.begin(); itChHistos != theT0SegHistoMap_.end(); ++itChHistos){
-    for(vector<TH1F*>::const_iterator itHist = (*itChHistos).second.begin();
-                                      itHist != (*itChHistos).second.end(); ++itHist) (*itHist)->Write();
+  for (ChamberHistosMap::const_iterator itChHistos = theT0SegHistoMap_.begin(); itChHistos != theT0SegHistoMap_.end();
+       ++itChHistos) {
+    for (vector<TH1F*>::const_iterator itHist = (*itChHistos).second.begin(); itHist != (*itChHistos).second.end();
+         ++itHist)
+      (*itHist)->Write();
   }
 
-  if(doTTrigCorrection_){
+  if (doTTrigCorrection_) {
     // Create the object to be written to DB
     DTTtrig* tTrig = new DTTtrig();
 
-    for(ChamberHistosMap::const_iterator itChHistos = theT0SegHistoMap_.begin(); itChHistos != theT0SegHistoMap_.end(); ++itChHistos){
+    for (ChamberHistosMap::const_iterator itChHistos = theT0SegHistoMap_.begin(); itChHistos != theT0SegHistoMap_.end();
+         ++itChHistos) {
       DTChamberId chId = itChHistos->first;
       // Get SuperLayerId's for each ChamberId
       vector<DTSuperLayerId> slIds;
-      slIds.push_back(DTSuperLayerId(chId,1));
-      slIds.push_back(DTSuperLayerId(chId,3));
-      if(chId.station() != 4) slIds.push_back(DTSuperLayerId(chId,2));
+      slIds.push_back(DTSuperLayerId(chId, 1));
+      slIds.push_back(DTSuperLayerId(chId, 3));
+      if (chId.station() != 4)
+        slIds.push_back(DTSuperLayerId(chId, 2));
 
-      for(vector<DTSuperLayerId>::const_iterator itSl = slIds.begin(); itSl != slIds.end(); ++itSl){      
+      for (vector<DTSuperLayerId>::const_iterator itSl = slIds.begin(); itSl != slIds.end(); ++itSl) {
         // Get old values from DB
         float ttrigMean = 0;
         float ttrigSigma = 0;
-	float kFactor = 0;
-        tTrigMap_->get(*itSl,ttrigMean,ttrigSigma,kFactor,DTTimeUnits::ns);
+        float kFactor = 0;
+        tTrigMap_->get(*itSl, ttrigMean, ttrigSigma, kFactor, DTTimeUnits::ns);
         //FIXME: verify if values make sense
         // Set new values
         float ttrigMeanNew = ttrigMean;
         float ttrigSigmaNew = ttrigSigma;
-	float t0SegMean = (itSl->superLayer() != 2)?itChHistos->second[0]->GetMean():itChHistos->second[1]->GetMean();
+        float t0SegMean =
+            (itSl->superLayer() != 2) ? itChHistos->second[0]->GetMean() : itChHistos->second[1]->GetMean();
 
-	float kFactorNew = (kFactor*ttrigSigma+t0SegMean)/ttrigSigma;
+        float kFactorNew = (kFactor * ttrigSigma + t0SegMean) / ttrigSigma;
 
-        tTrig->set(*itSl,ttrigMeanNew,ttrigSigmaNew,kFactorNew,DTTimeUnits::ns);
+        tTrig->set(*itSl, ttrigMeanNew, ttrigSigmaNew, kFactorNew, DTTimeUnits::ns);
       }
     }
-    LogVerbatim("Calibration")<< "[DTTTrigOffsetCalibration] Writing ttrig object to DB!" << endl;
+    LogVerbatim("Calibration") << "[DTTTrigOffsetCalibration] Writing ttrig object to DB!" << endl;
     // Write the object to DB
     string tTrigRecord = "DTTtrigRcd";
     DTCalibDBUtils::writeToDB(tTrigRecord, tTrig);
-  } 
+  }
 }
 
 // Book a set of histograms for a given Chamber
 void DTTTrigOffsetCalibration::bookHistos(DTChamberId chId) {
-
   LogTrace("Calibration") << "   Booking histos for Chamber: " << chId;
 
   // Compose the chamber name
@@ -187,15 +189,13 @@ void DTTTrigOffsetCalibration::bookHistos(DTChamberId chId) {
   std::string station = std::to_string(chId.station());
   std::string sector = std::to_string(chId.sector());
 
-  string chHistoName =
-    "_W" + wheel +
-    "_St" + station +
-    "_Sec" +  sector;
+  string chHistoName = "_W" + wheel + "_St" + station + "_Sec" + sector;
 
   vector<TH1F*> histos;
   // Note the order matters
-  histos.push_back(new TH1F(("hRPhiSegT0"+chHistoName).c_str(), "t0 from Phi segments", 500, -60., 60.));
-  if(chId.station() != 4) histos.push_back(new TH1F(("hRZSegT0"+chHistoName).c_str(), "t0 from Z segments", 500, -60., 60.));
+  histos.push_back(new TH1F(("hRPhiSegT0" + chHistoName).c_str(), "t0 from Phi segments", 500, -60., 60.));
+  if (chId.station() != 4)
+    histos.push_back(new TH1F(("hRZSegT0" + chHistoName).c_str(), "t0 from Z segments", 500, -60., 60.));
 
   theT0SegHistoMap_[chId] = histos;
 }

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
@@ -17,7 +17,7 @@ namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 class DTChamberId;
 class DTTtrig;
@@ -34,14 +34,14 @@ public:
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
   void endJob() override;
-  
+
 private:
   typedef std::map<DTChamberId, std::vector<TH1F*> > ChamberHistosMap;
   void bookHistos(DTChamberId);
 
-  DTSegmentSelector *select_;
+  DTSegmentSelector* select_;
 
-  edm::InputTag  theRecHits4DLabel_;
+  edm::InputTag theRecHits4DLabel_;
   bool doTTrigCorrection_;
   std::string theCalibChamber_;
   std::string dbLabel_;
@@ -51,4 +51,3 @@ private:
   ChamberHistosMap theT0SegHistoMap_;
 };
 #endif
-

--- a/CalibMuon/DTCalibration/plugins/DTTTrigResidualCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigResidualCorrection.cc
@@ -40,136 +40,136 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTTTrigResidualCorrection::DTTTrigResidualCorrection(const ParameterSet& pset) {
-  string residualsRootFile = pset.getParameter<string>("residualsRootFile");
-  rootFile_ = new TFile(residualsRootFile.c_str(),"READ");
-  rootBaseDir_ = pset.getUntrackedParameter<string>("rootBaseDir","/DQMData/DT/DTCalibValidation"); 
-  useFit_ = pset.getParameter<bool>("useFitToResiduals");
-  //useConstantvDrift_ = pset.getParameter<bool>("useConstantDriftVelocity");
-  dbLabel_  = pset.getUntrackedParameter<string>("dbLabel", "");
-  useSlopesCalib_ = pset.getUntrackedParameter<bool>("useSlopesCalib",false);
+  DTTTrigResidualCorrection::DTTTrigResidualCorrection(const ParameterSet& pset) {
+    string residualsRootFile = pset.getParameter<string>("residualsRootFile");
+    rootFile_ = new TFile(residualsRootFile.c_str(), "READ");
+    rootBaseDir_ = pset.getUntrackedParameter<string>("rootBaseDir", "/DQMData/DT/DTCalibValidation");
+    useFit_ = pset.getParameter<bool>("useFitToResiduals");
+    //useConstantvDrift_ = pset.getParameter<bool>("useConstantDriftVelocity");
+    dbLabel_ = pset.getUntrackedParameter<string>("dbLabel", "");
+    useSlopesCalib_ = pset.getUntrackedParameter<bool>("useSlopesCalib", false);
 
-  // Load external slopes
-  if(useSlopesCalib_){ 
-     ifstream fileSlopes; 
-     fileSlopes.open( pset.getParameter<FileInPath>("slopesFileName").fullPath().c_str() );
+    // Load external slopes
+    if (useSlopesCalib_) {
+      ifstream fileSlopes;
+      fileSlopes.open(pset.getParameter<FileInPath>("slopesFileName").fullPath().c_str());
 
-     int tmp_wheel = 0, tmp_sector = 0, tmp_station = 0, tmp_SL = 0;
-     double tmp_ttrig = 0., tmp_t0 = 0., tmp_kfact = 0.;
-     int tmp_a = 0, tmp_b = 0, tmp_c = 0, tmp_d = 0;
-     double tmp_v_eff = 0.;
-     while(!fileSlopes.eof()){
-        fileSlopes >> tmp_wheel >> tmp_sector >> tmp_station >> tmp_SL  >> tmp_a >> tmp_b >>
-                      tmp_ttrig >> tmp_t0 >> tmp_kfact >> tmp_c >> tmp_d >> tmp_v_eff;
-        vDriftEff_[tmp_wheel+2][tmp_sector-1][tmp_station-1][tmp_SL-1] = -tmp_v_eff;
-     }
-     fileSlopes.close();
-  } 
+      int tmp_wheel = 0, tmp_sector = 0, tmp_station = 0, tmp_SL = 0;
+      double tmp_ttrig = 0., tmp_t0 = 0., tmp_kfact = 0.;
+      int tmp_a = 0, tmp_b = 0, tmp_c = 0, tmp_d = 0;
+      double tmp_v_eff = 0.;
+      while (!fileSlopes.eof()) {
+        fileSlopes >> tmp_wheel >> tmp_sector >> tmp_station >> tmp_SL >> tmp_a >> tmp_b >> tmp_ttrig >> tmp_t0 >>
+            tmp_kfact >> tmp_c >> tmp_d >> tmp_v_eff;
+        vDriftEff_[tmp_wheel + 2][tmp_sector - 1][tmp_station - 1][tmp_SL - 1] = -tmp_v_eff;
+      }
+      fileSlopes.close();
+    }
 
-  bool debug = pset.getUntrackedParameter<bool>("debug",false);
-  fitter_ = new DTResidualFitter(debug);
-}
+    bool debug = pset.getUntrackedParameter<bool>("debug", false);
+    fitter_ = new DTResidualFitter(debug);
+  }
 
-DTTTrigResidualCorrection::~DTTTrigResidualCorrection() {
-  delete rootFile_;
-  delete fitter_;
-}
+  DTTTrigResidualCorrection::~DTTTrigResidualCorrection() {
+    delete rootFile_;
+    delete fitter_;
+  }
 
-void DTTTrigResidualCorrection::setES(const EventSetup& setup) {
-  // Get tTrig record from DB
-  ESHandle<DTTtrig> tTrig;
-  //setup.get<DTTtrigRcd>().get(tTrig);
-  setup.get<DTTtrigRcd>().get(dbLabel_,tTrig);
-  tTrigMap_ = &*tTrig;
+  void DTTTrigResidualCorrection::setES(const EventSetup& setup) {
+    // Get tTrig record from DB
+    ESHandle<DTTtrig> tTrig;
+    //setup.get<DTTtrigRcd>().get(tTrig);
+    setup.get<DTTtrigRcd>().get(dbLabel_, tTrig);
+    tTrigMap_ = &*tTrig;
 
-  // Get vDrift record
-  ESHandle<DTMtime> mTimeHandle;
-  setup.get<DTMtimeRcd>().get(mTimeHandle);
-  mTimeMap_ = &*mTimeHandle;
-}
+    // Get vDrift record
+    ESHandle<DTMtime> mTimeHandle;
+    setup.get<DTMtimeRcd>().get(mTimeHandle);
+    mTimeMap_ = &*mTimeHandle;
+  }
 
-DTTTrigData DTTTrigResidualCorrection::correction(const DTSuperLayerId& slId) {
+  DTTTrigData DTTTrigResidualCorrection::correction(const DTSuperLayerId& slId) {
+    float tTrigMean, tTrigSigma, kFactor;
+    int status = tTrigMap_->get(slId, tTrigMean, tTrigSigma, kFactor, DTTimeUnits::ns);
+    if (status != 0)
+      throw cms::Exception("[DTTTrigResidualCorrection]") << "Could not find tTrig entry in DB for" << slId << endl;
 
-  float tTrigMean,tTrigSigma,kFactor;
-  int status = tTrigMap_->get(slId,tTrigMean,tTrigSigma,kFactor,DTTimeUnits::ns);
-  if(status != 0) throw cms::Exception("[DTTTrigResidualCorrection]") << "Could not find tTrig entry in DB for"
-                                                                      << slId << endl;
-
-  float vDrift,hitResolution;
-  status = mTimeMap_->get(slId,vDrift,hitResolution,DTVelocityUnits::cm_per_ns);
-  if(status != 0) throw cms::Exception("[DTTTrigResidualCorrection]") << "Could not find vDrift entry in DB for"
-                                                                      << slId << endl;
-  TH1F residualHisto = *(getHisto(slId));
-  LogTrace("Calibration") << "[DTTTrigResidualCorrection]: \n"
-                          << "   Mean, RMS     = " << residualHisto.GetMean() << ", " << residualHisto.GetRMS();
-
-  double fitMean = -1.;
-  double fitSigma = -1.;
-  if(useFit_){
-    LogTrace("Calibration") << "[DTTTrigResidualCorrection]: Fitting histogram " << residualHisto.GetName(); 
-    int nSigmas = 2;
-
-    DTResidualFitResult fitResult = fitter_->fitResiduals(residualHisto,nSigmas);
-    fitMean = fitResult.fitMean;
-    fitSigma = fitResult.fitSigma;
-
+    float vDrift, hitResolution;
+    status = mTimeMap_->get(slId, vDrift, hitResolution, DTVelocityUnits::cm_per_ns);
+    if (status != 0)
+      throw cms::Exception("[DTTTrigResidualCorrection]") << "Could not find vDrift entry in DB for" << slId << endl;
+    TH1F residualHisto = *(getHisto(slId));
     LogTrace("Calibration") << "[DTTTrigResidualCorrection]: \n"
-                            << "   Fit Mean      = " << fitMean << "\n"
-                            << "   Fit Sigma     = " << fitSigma;
+                            << "   Mean, RMS     = " << residualHisto.GetMean() << ", " << residualHisto.GetRMS();
+
+    double fitMean = -1.;
+    double fitSigma = -1.;
+    if (useFit_) {
+      LogTrace("Calibration") << "[DTTTrigResidualCorrection]: Fitting histogram " << residualHisto.GetName();
+      int nSigmas = 2;
+
+      DTResidualFitResult fitResult = fitter_->fitResiduals(residualHisto, nSigmas);
+      fitMean = fitResult.fitMean;
+      fitSigma = fitResult.fitSigma;
+
+      LogTrace("Calibration") << "[DTTTrigResidualCorrection]: \n"
+                              << "   Fit Mean      = " << fitMean << "\n"
+                              << "   Fit Sigma     = " << fitSigma;
+    }
+    double resMean = (useFit_) ? fitMean : residualHisto.GetMean();
+
+    int wheel = slId.wheel();
+    int sector = slId.sector();
+    int station = slId.station();
+    int superLayer = slId.superLayer();
+    double resTime = 0.;
+    if (useSlopesCalib_) {
+      double vdrift_eff = vDriftEff_[wheel + 2][sector - 1][station - 1][superLayer - 1];
+      if (vdrift_eff == 0)
+        vdrift_eff = vDrift;
+
+      if (vdrift_eff)
+        resTime = resMean / vdrift_eff;
+
+      LogTrace("Calibration") << "[DTTTrigResidualCorrection]: Effective vDrift, correction to tTrig = " << vdrift_eff
+                              << ", " << resTime;
+    } else {
+      if (vDrift)
+        resTime = resMean / vDrift;
+
+      LogTrace("Calibration") << "[DTTTrigResidualCorrection]: vDrift from DB, correction to tTrig = " << vDrift << ", "
+                              << resTime;
+    }
+
+    double corrMean = tTrigMean;
+    double corrSigma = (tTrigSigma != 0.) ? tTrigSigma : 1.;
+    double corrKFact = (tTrigSigma != 0.) ? (kFactor + resTime / tTrigSigma) : resTime;
+
+    return DTTTrigData(corrMean, corrSigma, corrKFact);
   }
-  double resMean = (useFit_) ? fitMean : residualHisto.GetMean();
 
-  int wheel = slId.wheel();
-  int sector = slId.sector();
-  int station = slId.station();
-  int superLayer = slId.superLayer();
-  double resTime = 0.;
-  if(useSlopesCalib_){
-     double vdrift_eff = vDriftEff_[wheel+2][sector-1][station-1][superLayer-1];
-     if(vdrift_eff == 0) vdrift_eff = vDrift;
-
-     if(vdrift_eff) resTime = resMean/vdrift_eff;
-
-     LogTrace("Calibration") << "[DTTTrigResidualCorrection]: Effective vDrift, correction to tTrig = "
-                             << vdrift_eff << ", " << resTime;
-  } else{
-     if(vDrift) resTime = resMean/vDrift;
-
-     LogTrace("Calibration") << "[DTTTrigResidualCorrection]: vDrift from DB, correction to tTrig = "
-                             << vDrift << ", " << resTime;
+  const TH1F* DTTTrigResidualCorrection::getHisto(const DTSuperLayerId& slId) {
+    string histoName = getHistoName(slId);
+    LogTrace("Calibration") << "[DTTTrigResidualCorrection]: Accessing histogram " << histoName.c_str();
+    TH1F* histo = static_cast<TH1F*>(rootFile_->Get(histoName.c_str()));
+    if (!histo)
+      throw cms::Exception("[DTTTrigResidualCorrection]") << "residual histogram not found:" << histoName << endl;
+    return histo;
   }
- 
-  double corrMean = tTrigMean;
-  double corrSigma = (tTrigSigma != 0.) ? tTrigSigma : 1.;
-  double corrKFact = (tTrigSigma != 0.) ? (kFactor + resTime/tTrigSigma) : resTime;
 
-  return DTTTrigData(corrMean,corrSigma,corrKFact);  
-}
+  string DTTTrigResidualCorrection::getHistoName(const DTSuperLayerId& slId) {
+    int step = 3;
 
-const TH1F* DTTTrigResidualCorrection::getHisto(const DTSuperLayerId& slId) {
-  string histoName = getHistoName(slId);
-  LogTrace("Calibration") << "[DTTTrigResidualCorrection]: Accessing histogram " << histoName.c_str();
-  TH1F* histo = static_cast<TH1F*>(rootFile_->Get(histoName.c_str()));
-  if(!histo) throw cms::Exception("[DTTTrigResidualCorrection]") << "residual histogram not found:"
-                                                                 << histoName << endl; 
-  return histo;
-}
+    std::string wheel = std::to_string(slId.wheel());
+    std::string station = std::to_string(slId.station());
+    std::string sector = std::to_string(slId.sector());
+    std::string superLayer = std::to_string(slId.superlayer());
+    std::string Step = std::to_string(step);
 
-string DTTTrigResidualCorrection::getHistoName(const DTSuperLayerId& slId) {
+    string histoName = rootBaseDir_ + "/Wheel" + wheel + "/Station" + station + "/Sector" + sector + "/hResDist_STEP" +
+                       Step + "_W" + wheel + "_St" + station + "_Sec" + sector + "_SL" + superLayer;
 
-  int step = 3;
+    return histoName;
+  }
 
-  std::string wheel = std::to_string(slId.wheel());
-  std::string station = std::to_string(slId.station());
-  std::string sector = std::to_string(slId.sector());
-  std::string superLayer = std::to_string(slId.superlayer());
-  std::string Step = std::to_string(step);
-
-  string histoName =
-    rootBaseDir_ + "/Wheel" + wheel + "/Station" + station + "/Sector" + sector + 
-    "/hResDist_STEP" + Step + "_W" + wheel + "_St" + station + "_Sec" + sector + "_SL" + superLayer;
-
-  return histoName;
-}
-
-} // namespace
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTTTrigResidualCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigResidualCorrection.h
@@ -25,34 +25,34 @@ class TFile;
 
 namespace dtCalibration {
 
-class DTTTrigResidualCorrection: public DTTTrigBaseCorrection {
-public:
-  // Constructor
-  DTTTrigResidualCorrection(const edm::ParameterSet&);
+  class DTTTrigResidualCorrection : public DTTTrigBaseCorrection {
+  public:
+    // Constructor
+    DTTTrigResidualCorrection(const edm::ParameterSet&);
 
-  // Destructor
-  ~DTTTrigResidualCorrection() override;
+    // Destructor
+    ~DTTTrigResidualCorrection() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTTTrigData correction(const DTSuperLayerId&) override;
+    void setES(const edm::EventSetup& setup) override;
+    DTTTrigData correction(const DTSuperLayerId&) override;
 
-private:
-  const TH1F* getHisto(const DTSuperLayerId&);
-  std::string getHistoName(const DTSuperLayerId& slID);
+  private:
+    const TH1F* getHisto(const DTSuperLayerId&);
+    std::string getHistoName(const DTSuperLayerId& slID);
 
-  TFile* rootFile_;  
+    TFile* rootFile_;
 
-  std::string rootBaseDir_;
-  bool useFit_;
-  std::string dbLabel_;
-  bool useSlopesCalib_;
+    std::string rootBaseDir_;
+    bool useFit_;
+    std::string dbLabel_;
+    bool useSlopesCalib_;
 
-  double vDriftEff_[5][14][4][3];
+    double vDriftEff_[5][14][4][3];
 
-  const DTTtrig *tTrigMap_;
-  const DTMtime *mTimeMap_;
-  DTResidualFitter* fitter_;
-};
+    const DTTtrig* tTrigMap_;
+    const DTMtime* mTimeMap_;
+    DTResidualFitter* fitter_;
+  };
 
-} // namespace
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTTrigT0SegCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigT0SegCorrection.cc
@@ -23,59 +23,54 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTTTrigT0SegCorrection::DTTTrigT0SegCorrection(const ParameterSet& pset) {
-  string t0SegRootFile = pset.getParameter<string>("t0SegRootFile");
-  rootFile_ = new TFile(t0SegRootFile.c_str(),"READ");
-  dbLabel  = pset.getUntrackedParameter<string>("dbLabel", "");
-}
+  DTTTrigT0SegCorrection::DTTTrigT0SegCorrection(const ParameterSet& pset) {
+    string t0SegRootFile = pset.getParameter<string>("t0SegRootFile");
+    rootFile_ = new TFile(t0SegRootFile.c_str(), "READ");
+    dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
+  }
 
-DTTTrigT0SegCorrection::~DTTTrigT0SegCorrection() {
-  delete rootFile_;
-}
+  DTTTrigT0SegCorrection::~DTTTrigT0SegCorrection() { delete rootFile_; }
 
-void DTTTrigT0SegCorrection::setES(const EventSetup& setup) {
-  // Get tTrig record from DB
-  ESHandle<DTTtrig> tTrig;
-  setup.get<DTTtrigRcd>().get(dbLabel,tTrig);
-  tTrigMap_ = &*tTrig;
-}
+  void DTTTrigT0SegCorrection::setES(const EventSetup& setup) {
+    // Get tTrig record from DB
+    ESHandle<DTTtrig> tTrig;
+    setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
+    tTrigMap_ = &*tTrig;
+  }
 
-DTTTrigData DTTTrigT0SegCorrection::correction(const DTSuperLayerId& slId) {
-  float tTrigMean,tTrigSigma,kFactor;
-  int status = tTrigMap_->get(slId,tTrigMean,tTrigSigma,kFactor,DTTimeUnits::ns);
-  if(status != 0) throw cms::Exception("[DTTTrigT0SegCorrection]") << "Could not find tTrig entry in DB for"
-                                                                   << slId << endl;
+  DTTTrigData DTTTrigT0SegCorrection::correction(const DTSuperLayerId& slId) {
+    float tTrigMean, tTrigSigma, kFactor;
+    int status = tTrigMap_->get(slId, tTrigMean, tTrigSigma, kFactor, DTTimeUnits::ns);
+    if (status != 0)
+      throw cms::Exception("[DTTTrigT0SegCorrection]") << "Could not find tTrig entry in DB for" << slId << endl;
 
-  const TH1F* t0SegHisto = getHisto(slId);
-  double corrMean = tTrigMean;
-  double corrSigma = tTrigSigma;
-  //FIXME: can we fit the t0seg histo? How do we remove the peak at 0?;
-  double corrKFact = (kFactor*tTrigSigma + t0SegHisto->GetMean())/tTrigSigma;
-  return DTTTrigData(corrMean,corrSigma,corrKFact);  
-}
+    const TH1F* t0SegHisto = getHisto(slId);
+    double corrMean = tTrigMean;
+    double corrSigma = tTrigSigma;
+    //FIXME: can we fit the t0seg histo? How do we remove the peak at 0?;
+    double corrKFact = (kFactor * tTrigSigma + t0SegHisto->GetMean()) / tTrigSigma;
+    return DTTTrigData(corrMean, corrSigma, corrKFact);
+  }
 
-const TH1F* DTTTrigT0SegCorrection::getHisto(const DTSuperLayerId& slId) {
-  string histoName = getHistoName(slId);
-  TH1F* histo = static_cast<TH1F*>(rootFile_->Get(histoName.c_str()));
-  if(!histo) throw cms::Exception("[DTTTrigT0SegCorrection]") << "t0-seg histogram not found:"
-                                                              << histoName << endl; 
-  return histo;
-}
+  const TH1F* DTTTrigT0SegCorrection::getHisto(const DTSuperLayerId& slId) {
+    string histoName = getHistoName(slId);
+    TH1F* histo = static_cast<TH1F*>(rootFile_->Get(histoName.c_str()));
+    if (!histo)
+      throw cms::Exception("[DTTTrigT0SegCorrection]") << "t0-seg histogram not found:" << histoName << endl;
+    return histo;
+  }
 
-string DTTTrigT0SegCorrection::getHistoName(const DTSuperLayerId& slId) {
-  DTChamberId chId = slId.chamberId();
+  string DTTTrigT0SegCorrection::getHistoName(const DTSuperLayerId& slId) {
+    DTChamberId chId = slId.chamberId();
 
-  // Compose the chamber name
-  std::string wheel = std::to_string(chId.wheel());
-  std::string station = std::to_string(chId.station());
-  std::string sector = std::to_string(chId.sector());
+    // Compose the chamber name
+    std::string wheel = std::to_string(chId.wheel());
+    std::string station = std::to_string(chId.station());
+    std::string sector = std::to_string(chId.sector());
 
-  string chHistoName =
-    "_W" + wheel +
-    "_St" + station +
-    "_Sec" +  sector;
+    string chHistoName = "_W" + wheel + "_St" + station + "_Sec" + sector;
 
-  return (slId.superLayer() != 2)?("hRPhiSegT0"+chHistoName):("hRZSegT0"+chHistoName);
-}
+    return (slId.superLayer() != 2) ? ("hRPhiSegT0" + chHistoName) : ("hRZSegT0" + chHistoName);
+  }
 
-} // namespace
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTTTrigT0SegCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigT0SegCorrection.h
@@ -23,27 +23,27 @@ class TFile;
 
 namespace dtCalibration {
 
-class DTTTrigT0SegCorrection: public DTTTrigBaseCorrection {
-public:
-  // Constructor
-  DTTTrigT0SegCorrection(const edm::ParameterSet&);
+  class DTTTrigT0SegCorrection : public DTTTrigBaseCorrection {
+  public:
+    // Constructor
+    DTTTrigT0SegCorrection(const edm::ParameterSet&);
 
-  // Destructor
-  ~DTTTrigT0SegCorrection() override;
+    // Destructor
+    ~DTTTrigT0SegCorrection() override;
 
-  void setES(const edm::EventSetup& setup) override;
-  DTTTrigData correction(const DTSuperLayerId&) override;
+    void setES(const edm::EventSetup& setup) override;
+    DTTTrigData correction(const DTSuperLayerId&) override;
 
-private:
-  const TH1F* getHisto(const DTSuperLayerId&);
-  std::string getHistoName(const DTSuperLayerId& slID);
+  private:
+    const TH1F* getHisto(const DTSuperLayerId&);
+    std::string getHistoName(const DTSuperLayerId& slID);
 
-  TFile* rootFile_;
+    TFile* rootFile_;
 
-  std::string dbLabel;
+    std::string dbLabel;
 
-  const DTTtrig *tTrigMap_;
-};
+    const DTTtrig* tTrigMap_;
+  };
 
-} // namespace
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTTrigWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigWriter.h
@@ -16,13 +16,12 @@ namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 class TFile;
 class DTTimeBoxFitter;
 class DTSuperLayerId;
 class DTTtrig;
-
 
 class DTTTrigWriter : public edm::EDAnalyzer {
 public:
@@ -35,14 +34,12 @@ public:
   // Operations
 
   /// Compute the ttrig by fiting the TB rising edge
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
   /// Write ttrig in the DB
   void endJob() override;
 
- 
 protected:
-
 private:
   // Generate the time box name
   std::string getTBoxName(const DTSuperLayerId& slId) const;
@@ -53,16 +50,15 @@ private:
   double kFactor;
 
   // The file which contains the tMax histograms
-  TFile *theFile;
+  TFile* theFile;
 
   // The name of the input root file which contains the tMax histograms
   std::string theRootInputFile;
 
   // The fitter
-  DTTimeBoxFitter *theFitter;
+  DTTimeBoxFitter* theFitter;
 
   // The object to be written to DB
-  DTTtrig* tTrig; 
-
+  DTTtrig* tTrig;
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.cc
@@ -33,26 +33,24 @@
 #include "TFile.h"
 #include "TH1.h"
 #include "TF1.h"
-#include "TROOT.h" 
+#include "TROOT.h"
 
 // Declare histograms.
-TH1F * hChi2;
+TH1F* hChi2;
 extern void bookHistos();
 
 using namespace std;
 using namespace edm;
 using namespace dttmaxenums;
 
-
-DTVDriftCalibration::DTVDriftCalibration(const ParameterSet& pset) :
-  // Get the synchronizer
-  theSync{DTTTrigSyncFactory::get()->create(pset.getParameter<string>("tTrigMode"),
-                                            pset.getParameter<ParameterSet>("tTrigModeConfig"))}
+DTVDriftCalibration::DTVDriftCalibration(const ParameterSet& pset)
+    :  // Get the synchronizer
+      theSync{DTTTrigSyncFactory::get()->create(pset.getParameter<string>("tTrigMode"),
+                                                pset.getParameter<ParameterSet>("tTrigModeConfig"))}
 
 {
-
   edm::ConsumesCollector collector(consumesCollector());
-  select_ = std::make_unique<DTSegmentSelector>(pset,collector);
+  select_ = std::make_unique<DTSegmentSelector>(pset, collector);
 
   // The name of the 4D rec hits collection
   theRecHits4DToken = (consumes<DTRecSegment4DCollection>(pset.getParameter<InputTag>("recHits4DLabel")));
@@ -65,10 +63,10 @@ DTVDriftCalibration::DTVDriftCalibration(const ParameterSet& pset) :
   debug = pset.getUntrackedParameter<bool>("debug", false);
 
   theFitter = std::make_unique<DTMeanTimerFitter>(theFile);
-  if(debug)
+  if (debug)
     theFitter->setVerbosity(1);
 
-  hChi2 = new TH1F("hChi2","Chi squared tracks",100,0,100);
+  hChi2 = new TH1F("hChi2", "Chi squared tracks", 100, 0, 100);
   h2DSegmRPhi = new h2DSegm("SLRPhi");
   h2DSegmRZ = new h2DSegm("SLRZ");
   h4DSegmAllCh = new h4DSegm("AllCh");
@@ -77,48 +75,48 @@ DTVDriftCalibration::DTVDriftCalibration(const ParameterSet& pset) :
   findVDriftAndT0 = pset.getUntrackedParameter<bool>("fitAndWrite", false);
 
   // Chamber/s to calibrate
-  theCalibChamber =  pset.getUntrackedParameter<string>("calibChamber", "All");
+  theCalibChamber = pset.getUntrackedParameter<string>("calibChamber", "All");
 
   // the txt file which will contain the calibrated constants
   theVDriftOutputFile = pset.getUntrackedParameter<string>("vDriftFileName");
 
   // get parameter set for DTCalibrationMap constructor
-  theCalibFilePar =  pset.getUntrackedParameter<ParameterSet>("calibFileConfig");
+  theCalibFilePar = pset.getUntrackedParameter<ParameterSet>("calibFileConfig");
 
   // the granularity to be used for tMax
-  string tMaxGranularity = pset.getUntrackedParameter<string>("tMaxGranularity","bySL");
+  string tMaxGranularity = pset.getUntrackedParameter<string>("tMaxGranularity", "bySL");
 
   // Enforce it to be by SL since rest is not implemented
-  if(tMaxGranularity != "bySL"){
-     LogError("Calibration") << "[DTVDriftCalibration] tMaxGranularity will be fixed to bySL.";
-     tMaxGranularity = "bySL";
+  if (tMaxGranularity != "bySL") {
+    LogError("Calibration") << "[DTVDriftCalibration] tMaxGranularity will be fixed to bySL.";
+    tMaxGranularity = "bySL";
   }
   // Initialize correctly the enum which specify the granularity for the calibration
-  if(tMaxGranularity == "bySL") {
+  if (tMaxGranularity == "bySL") {
     theGranularity = bySL;
-  } else if(tMaxGranularity == "byChamber"){
+  } else if (tMaxGranularity == "byChamber") {
     theGranularity = byChamber;
-  } else if(tMaxGranularity== "byPartition") {
+  } else if (tMaxGranularity == "byPartition") {
     theGranularity = byPartition;
-  } else throw cms::Exception("Configuration") << "[DTVDriftCalibration] Check parameter tMaxGranularity: "
-	                                       << tMaxGranularity << " option not available";
-  
+  } else
+    throw cms::Exception("Configuration")
+        << "[DTVDriftCalibration] Check parameter tMaxGranularity: " << tMaxGranularity << " option not available";
 
   LogVerbatim("Calibration") << "[DTVDriftCalibration]Constructor called!";
 }
 
-DTVDriftCalibration::~DTVDriftCalibration(){
+DTVDriftCalibration::~DTVDriftCalibration() {
   theFile->Close();
   LogVerbatim("Calibration") << "[DTVDriftCalibration]Destructor called!";
 }
 
-void DTVDriftCalibration::analyze(const Event & event, const EventSetup& eventSetup) {
+void DTVDriftCalibration::analyze(const Event& event, const EventSetup& eventSetup) {
   LogTrace("Calibration") << "--- [DTVDriftCalibration] Event analysed #Run: " << event.id().run()
                           << " #Event: " << event.id().event();
   theFile->cd();
   DTChamberId chosenChamberId;
 
-  if(theCalibChamber != "All") {
+  if (theCalibChamber != "All") {
     stringstream linestr;
     int selWheel, selStation, selSector;
     linestr << theCalibChamber;
@@ -141,124 +139,126 @@ void DTVDriftCalibration::analyze(const Event & event, const EventSetup& eventSe
     eventSetup.get<DTStatusFlagRcd>().get(statusMap);
   }*/
 
-  // Set the event setup in the Synchronizer 
+  // Set the event setup in the Synchronizer
   theSync->setES(eventSetup);
 
   // Loop over segments by chamber
   DTRecSegment4DCollection::id_iterator chamberIdIt;
-  for (chamberIdIt = all4DSegments->id_begin();
-       chamberIdIt != all4DSegments->id_end();
-       ++chamberIdIt){
-
+  for (chamberIdIt = all4DSegments->id_begin(); chamberIdIt != all4DSegments->id_end(); ++chamberIdIt) {
     // Get the chamber from the setup
     const DTChamber* chamber = dtGeom->chamber(*chamberIdIt);
     LogTrace("Calibration") << "Chamber Id: " << *chamberIdIt;
 
-    // Calibrate just the chosen chamber/s    
-    if((theCalibChamber != "All") && ((*chamberIdIt) != chosenChamberId)) 
+    // Calibrate just the chosen chamber/s
+    if ((theCalibChamber != "All") && ((*chamberIdIt) != chosenChamberId))
       continue;
 
     // Get the range for the corresponding ChamberId
-    DTRecSegment4DCollection::range  range = all4DSegments->get((*chamberIdIt));
+    DTRecSegment4DCollection::range range = all4DSegments->get((*chamberIdIt));
 
     // Loop over the rechits of this DetUnit
-    for (DTRecSegment4DCollection::const_iterator segment = range.first;
-         segment!=range.second; ++segment){
-
-      if( !(*segment).hasZed() && !(*segment).hasPhi() ){
-         LogError("Calibration") << "4D segment without Z and Phi segments";
-         continue;   
-      } 
+    for (DTRecSegment4DCollection::const_iterator segment = range.first; segment != range.second; ++segment) {
+      if (!(*segment).hasZed() && !(*segment).hasPhi()) {
+        LogError("Calibration") << "4D segment without Z and Phi segments";
+        continue;
+      }
 
       LogTrace("Calibration") << "Segment local pos (in chamber RF): " << (*segment).localPosition()
                               << "\nSegment global pos: " << chamber->toGlobal((*segment).localPosition());
 
-      if( !((*select_)(*segment, event, eventSetup)) ) continue;
+      if (!((*select_)(*segment, event, eventSetup)))
+        continue;
 
-      LocalPoint phiSeg2DPosInCham;  
+      LocalPoint phiSeg2DPosInCham;
       LocalVector phiSeg2DDirInCham;
-      map<DTSuperLayerId,vector<DTRecHit1D> > hitsBySLMap; 
-      if((*segment).hasPhi()){
+      map<DTSuperLayerId, vector<DTRecHit1D> > hitsBySLMap;
+      if ((*segment).hasPhi()) {
         const DTChamberRecSegment2D* phiSeg = (*segment).phiSegment();  // phiSeg lives in the chamber RF
-        phiSeg2DPosInCham = phiSeg->localPosition();  
+        phiSeg2DPosInCham = phiSeg->localPosition();
         phiSeg2DDirInCham = phiSeg->localDirection();
         vector<DTRecHit1D> phiHits = phiSeg->specificRecHits();
-        for(vector<DTRecHit1D>::const_iterator hit = phiHits.begin();
-            hit != phiHits.end(); ++hit) {
+        for (vector<DTRecHit1D>::const_iterator hit = phiHits.begin(); hit != phiHits.end(); ++hit) {
           DTWireId wireId = (*hit).wireId();
-          DTSuperLayerId slId =  wireId.superlayerId();
-          hitsBySLMap[slId].push_back(*hit); 
+          DTSuperLayerId slId = wireId.superlayerId();
+          hitsBySLMap[slId].push_back(*hit);
         }
       }
       // Get the Theta 2D segment and plot the angle in the chamber RF
       LocalVector zSeg2DDirInCham;
       LocalPoint zSeg2DPosInCham;
-      if((*segment).hasZed()) {
+      if ((*segment).hasZed()) {
         const DTSLRecSegment2D* zSeg = (*segment).zSegment();  // zSeg lives in the SL RF
         const DTSuperLayer* sl = chamber->superLayer(zSeg->superLayerId());
-        zSeg2DPosInCham = chamber->toLocal(sl->toGlobal((*zSeg).localPosition())); 
+        zSeg2DPosInCham = chamber->toLocal(sl->toGlobal((*zSeg).localPosition()));
         zSeg2DDirInCham = chamber->toLocal(sl->toGlobal((*zSeg).localDirection()));
         hitsBySLMap[zSeg->superLayerId()] = zSeg->specificRecHits();
-      } 
+      }
 
       LocalPoint segment4DLocalPos = (*segment).localPosition();
       LocalVector segment4DLocalDir = (*segment).localDirection();
-      double chiSquare = ((*segment).chi2()/(*segment).degreesOfFreedom());
+      double chiSquare = ((*segment).chi2() / (*segment).degreesOfFreedom());
 
       hChi2->Fill(chiSquare);
-      if((*segment).hasPhi())
-        h2DSegmRPhi->Fill(phiSeg2DPosInCham.x(), phiSeg2DDirInCham.x()/phiSeg2DDirInCham.z());
-      if((*segment).hasZed())
-        h2DSegmRZ->Fill(zSeg2DPosInCham.y(), zSeg2DDirInCham.y()/zSeg2DDirInCham.z());
+      if ((*segment).hasPhi())
+        h2DSegmRPhi->Fill(phiSeg2DPosInCham.x(), phiSeg2DDirInCham.x() / phiSeg2DDirInCham.z());
+      if ((*segment).hasZed())
+        h2DSegmRZ->Fill(zSeg2DPosInCham.y(), zSeg2DDirInCham.y() / zSeg2DDirInCham.z());
 
-      if((*segment).hasZed() && (*segment).hasPhi()) 
-        h4DSegmAllCh->Fill(segment4DLocalPos.x(), 
+      if ((*segment).hasZed() && (*segment).hasPhi())
+        h4DSegmAllCh->Fill(segment4DLocalPos.x(),
                            segment4DLocalPos.y(),
-                           atan(segment4DLocalDir.x()/segment4DLocalDir.z())*180./Geom::pi(),
-                           atan(segment4DLocalDir.y()/segment4DLocalDir.z())*180./Geom::pi(),
-                           180 - segment4DLocalDir.theta()*180./Geom::pi());
-      else if((*segment).hasPhi())
-        h4DSegmAllCh->Fill(segment4DLocalPos.x(), 
-                           atan(segment4DLocalDir.x()/segment4DLocalDir.z())*180./Geom::pi());
-      else if((*segment).hasZed())
+                           atan(segment4DLocalDir.x() / segment4DLocalDir.z()) * 180. / Geom::pi(),
+                           atan(segment4DLocalDir.y() / segment4DLocalDir.z()) * 180. / Geom::pi(),
+                           180 - segment4DLocalDir.theta() * 180. / Geom::pi());
+      else if ((*segment).hasPhi())
+        h4DSegmAllCh->Fill(segment4DLocalPos.x(),
+                           atan(segment4DLocalDir.x() / segment4DLocalDir.z()) * 180. / Geom::pi());
+      else if ((*segment).hasZed())
         LogWarning("Calibration") << "4d segment with only Z";
 
-      //loop over the segments 
-      for(map<DTSuperLayerId,vector<DTRecHit1D> >::const_iterator slIdAndHits = hitsBySLMap.begin(); slIdAndHits != hitsBySLMap.end();  ++slIdAndHits) {
-        if (slIdAndHits->second.size() < 3) continue;
+      //loop over the segments
+      for (map<DTSuperLayerId, vector<DTRecHit1D> >::const_iterator slIdAndHits = hitsBySLMap.begin();
+           slIdAndHits != hitsBySLMap.end();
+           ++slIdAndHits) {
+        if (slIdAndHits->second.size() < 3)
+          continue;
         DTSuperLayerId slId = slIdAndHits->first;
 
         // Create the DTTMax, that computes the 4 TMax
-        DTTMax slSeg(slIdAndHits->second, *(chamber->superLayer(slIdAndHits->first)),chamber->toGlobal((*segment).localDirection()), chamber->toGlobal((*segment).localPosition()), *theSync);
+        DTTMax slSeg(slIdAndHits->second,
+                     *(chamber->superLayer(slIdAndHits->first)),
+                     chamber->toGlobal((*segment).localDirection()),
+                     chamber->toGlobal((*segment).localPosition()),
+                     *theSync);
 
-        if(theGranularity == bySL) {
+        if (theGranularity == bySL) {
           vector<const TMax*> tMaxes = slSeg.getTMax(slId);
           DTWireId wireId(slId, 0, 0);
           theFile->cd();
           cellInfo* cell = theWireIdAndCellMap[wireId];
-          if (cell==nullptr) {
-            TString name = (((((TString) "TMax"+(long) slId.wheel()) +(long) slId.station())
-                             +(long) slId.sector())+(long) slId.superLayer());
+          if (cell == nullptr) {
+            TString name = (((((TString) "TMax" + (long)slId.wheel()) + (long)slId.station()) + (long)slId.sector()) +
+                            (long)slId.superLayer());
             cell = new cellInfo(name);
             theWireIdAndCellMap[wireId] = cell;
           }
           cell->add(tMaxes);
-          cell->update(); // FIXME to reset the counter to avoid triple counting, which actually is not used...
-        }
-        else {
-          LogWarning("Calibration") << "[DTVDriftCalibration] ###Warning: the chosen granularity is not implemented yet, only bySL available!";
+          cell->update();  // FIXME to reset the counter to avoid triple counting, which actually is not used...
+        } else {
+          LogWarning("Calibration") << "[DTVDriftCalibration] ###Warning: the chosen granularity is not implemented "
+                                       "yet, only bySL available!";
         }
         // to be implemented: granularity different from bySL
 
         //       else if (theGranularity == byPartition) {
-        // 	// Use the custom granularity defined by partition(); 
-        // 	// in this case, add() should be called once for each Tmax of each layer 
+        // 	// Use the custom granularity defined by partition();
+        // 	// in this case, add() should be called once for each Tmax of each layer
         // 	// and triple counting should be avoided within add()
         // 	vector<cellInfo*> cells;
         // 	for (int i=1; i<=4; i++) {
         // 	  const DTTMax::InfoLayer* iLayer = slSeg.getInfoLayer(i);
         // 	  if(iLayer == 0) continue;
-        // 	  cellInfo * cell = partition(iLayer->idWire); 
+        // 	  cellInfo * cell = partition(iLayer->idWire);
         // 	  cells.push_back(cell);
         // 	  vector<const TMax*> tMaxes = slSeg.getTMax(iLayer->idWire);
         // 	  cell->add(tMaxes);
@@ -268,7 +268,7 @@ void DTVDriftCalibration::analyze(const Event & event, const EventSetup& eventSe
         // 	     i!= cells.end(); i++) {
         // 	  (*i)->update();
         // 	}
-        //       } 
+        //       }
       }
     }
   }
@@ -282,55 +282,52 @@ void DTVDriftCalibration::endJob() {
   h4DSegmAllCh->Write();
   hChi2->Write();
   // Instantiate a DTCalibrationMap object if you want to calculate the calibration constants
-  DTCalibrationMap calibValuesFile(theCalibFilePar);  
+  DTCalibrationMap calibValuesFile(theCalibFilePar);
   // Create the object to be written to DB
   DTMtime* mTime = new DTMtime();
 
   // write the TMax histograms of each SL to the root file
-  if(theGranularity == bySL) {
-    for(map<DTWireId, cellInfo*>::const_iterator  wireCell = theWireIdAndCellMap.begin();
-        wireCell != theWireIdAndCellMap.end(); ++wireCell) {
-      cellInfo* cell= theWireIdAndCellMap[(*wireCell).first];
+  if (theGranularity == bySL) {
+    for (map<DTWireId, cellInfo*>::const_iterator wireCell = theWireIdAndCellMap.begin();
+         wireCell != theWireIdAndCellMap.end();
+         ++wireCell) {
+      cellInfo* cell = theWireIdAndCellMap[(*wireCell).first];
       hTMaxCell* cellHists = cell->getHists();
       theFile->cd();
       cellHists->Write();
-      if(findVDriftAndT0) {  // if TRUE: evaluate calibration constants from TMax hists filled in this job  
-	// evaluate v_drift and sigma from the TMax histograms
-	DTWireId wireId = (*wireCell).first;
-	vector<float> newConstants;
-	TString N=(((((TString) "TMax"+(long) wireId.wheel()) +(long) wireId.station())
-		    +(long) wireId.sector())+(long) wireId.superLayer());
-	vector<float> vDriftAndReso = theFitter->evaluateVDriftAndReso(N);
+      if (findVDriftAndT0) {  // if TRUE: evaluate calibration constants from TMax hists filled in this job
+        // evaluate v_drift and sigma from the TMax histograms
+        DTWireId wireId = (*wireCell).first;
+        vector<float> newConstants;
+        TString N = (((((TString) "TMax" + (long)wireId.wheel()) + (long)wireId.station()) + (long)wireId.sector()) +
+                     (long)wireId.superLayer());
+        vector<float> vDriftAndReso = theFitter->evaluateVDriftAndReso(N);
 
-	// Don't write the constants for the SL if the vdrift was not computed
-	if(vDriftAndReso.front() == -1)
-	  continue;
-	const DTCalibrationMap::CalibConsts* oldConstants = calibValuesFile.getConsts(wireId);
-	if(oldConstants != nullptr) {
-	  newConstants.push_back((*oldConstants)[0]);
-	  newConstants.push_back((*oldConstants)[1]);
-	  newConstants.push_back((*oldConstants)[2]);
-	} else {
-	  newConstants.push_back(-1);
-	  newConstants.push_back(-1);
-	  newConstants.push_back(-1);
-	}
-	for(int ivd=0; ivd<=5;ivd++) { 
-	  // 0=vdrift, 1=reso, 2=(3deltat0-2deltat0), 3=(2deltat0-1deltat0),
-	  //  4=(1deltat0-0deltat0), 5=deltat0 from hists with max entries,
-	  newConstants.push_back(vDriftAndReso[ivd]); 
-	}
+        // Don't write the constants for the SL if the vdrift was not computed
+        if (vDriftAndReso.front() == -1)
+          continue;
+        const DTCalibrationMap::CalibConsts* oldConstants = calibValuesFile.getConsts(wireId);
+        if (oldConstants != nullptr) {
+          newConstants.push_back((*oldConstants)[0]);
+          newConstants.push_back((*oldConstants)[1]);
+          newConstants.push_back((*oldConstants)[2]);
+        } else {
+          newConstants.push_back(-1);
+          newConstants.push_back(-1);
+          newConstants.push_back(-1);
+        }
+        for (int ivd = 0; ivd <= 5; ivd++) {
+          // 0=vdrift, 1=reso, 2=(3deltat0-2deltat0), 3=(2deltat0-1deltat0),
+          //  4=(1deltat0-0deltat0), 5=deltat0 from hists with max entries,
+          newConstants.push_back(vDriftAndReso[ivd]);
+        }
 
-	calibValuesFile.addCell(calibValuesFile.getKey(wireId), newConstants);
+        calibValuesFile.addCell(calibValuesFile.getKey(wireId), newConstants);
 
         // vdrift is cm/ns , resolution is cm
-	mTime->set((wireId.layerId()).superlayerId(),
-		   vDriftAndReso[0],
-		   vDriftAndReso[1],
-		   DTVelocityUnits::cm_per_ns);
-    	LogTrace("Calibration") << " SL: " << (wireId.layerId()).superlayerId()
-	                        << " vDrift = " << vDriftAndReso[0]
-	                        << " reso = " << vDriftAndReso[1];
+        mTime->set((wireId.layerId()).superlayerId(), vDriftAndReso[0], vDriftAndReso[1], DTVelocityUnits::cm_per_ns);
+        LogTrace("Calibration") << " SL: " << (wireId.layerId()).superlayerId() << " vDrift = " << vDriftAndReso[0]
+                                << " reso = " << vDriftAndReso[1];
       }
     }
   }
@@ -366,7 +363,7 @@ void DTVDriftCalibration::endJob() {
   //     }
   //   }
 
-  // Write values to a table  
+  // Write values to a table
   calibValuesFile.writeConsts(theVDriftOutputFile);
 
   LogVerbatim("Calibration") << "[DTVDriftCalibration]Writing vdrift object to DB!";
@@ -378,7 +375,7 @@ void DTVDriftCalibration::endJob() {
 
 // to be implemented: granularity different from bySL
 
-// // Create partitions 
+// // Create partitions
 // DTVDriftCalibration::cellInfo* DTVDriftCalibration::partition(const DTWireId& wireId) {
 //   for( map<MuBarWireId, cellInfo*>::const_iterator iter =
 // 	 mapCellTmaxPart.begin(); iter != mapCellTmaxPart.end(); iter++) {
@@ -395,12 +392,11 @@ void DTVDriftCalibration::endJob() {
 //   return result;
 //}
 
-
 void DTVDriftCalibration::cellInfo::add(const vector<const TMax*>& _tMaxes) {
   vector<const TMax*> tMaxes = _tMaxes;
   float tmax123 = -1.;
   float tmax124 = -1.;
-  float tmax134 = -1.;  
+  float tmax134 = -1.;
   float tmax234 = -1.;
   SigmaFactor s124 = noR;
   SigmaFactor s134 = noR;
@@ -409,35 +405,47 @@ void DTVDriftCalibration::cellInfo::add(const vector<const TMax*>& _tMaxes) {
   unsigned t0_134 = 0;
   unsigned t0_234 = 0;
   unsigned hSubGroup = 0;
-  for (vector<const TMax*>::const_iterator it=tMaxes.begin(); it!=tMaxes.end();
-       ++it) {
-    if(*it == nullptr) {
-      continue;  
-    }
-    else { 
+  for (vector<const TMax*>::const_iterator it = tMaxes.begin(); it != tMaxes.end(); ++it) {
+    if (*it == nullptr) {
+      continue;
+    } else {
       //FIXME check cached,
-      if (addedCells.size()==4 || 
-          find(addedCells.begin(), addedCells.end(), (*it)->cells) 
-          != addedCells.end()) {
+      if (addedCells.size() == 4 || find(addedCells.begin(), addedCells.end(), (*it)->cells) != addedCells.end()) {
         continue;
       }
-      addedCells.push_back((*it)->cells);    
+      addedCells.push_back((*it)->cells);
       SigmaFactor sigma = (*it)->sigma;
       float t = (*it)->t;
       TMaxCells cells = (*it)->cells;
       unsigned t0Factor = (*it)->t0Factor;
       hSubGroup = (*it)->hSubGroup;
-      if(t < 0.) continue;
-      switch(cells) {
-      case notInit : cout << "Error: no cell type assigned to TMax" << endl; break;
-      case c123 : tmax123 =t; t0_123 = t0Factor; break;
-      case c124 : tmax124 =t; s124 = sigma; t0_124 = t0Factor; break;
-      case c134 : tmax134 =t; s134 = sigma; t0_134 = t0Factor; break;
-      case c234 : tmax234 =t; t0_234 = t0Factor; break;
-      } 
+      if (t < 0.)
+        continue;
+      switch (cells) {
+        case notInit:
+          cout << "Error: no cell type assigned to TMax" << endl;
+          break;
+        case c123:
+          tmax123 = t;
+          t0_123 = t0Factor;
+          break;
+        case c124:
+          tmax124 = t;
+          s124 = sigma;
+          t0_124 = t0Factor;
+          break;
+        case c134:
+          tmax134 = t;
+          s134 = sigma;
+          t0_134 = t0Factor;
+          break;
+        case c234:
+          tmax234 = t;
+          t0_234 = t0Factor;
+          break;
+      }
     }
   }
   //add entries to the TMax histograms
-  histos->Fill(tmax123, tmax124, tmax134, tmax234, s124, s134, t0_123, 
-               t0_124, t0_134, t0_234, hSubGroup); 
+  histos->Fill(tmax123, tmax124, tmax134, tmax234, s124, s134, t0_123, t0_124, t0_134, t0_234, hSubGroup);
 }

--- a/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.h
@@ -7,7 +7,6 @@
  *  \author M. Giunta
  */
 
-
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
@@ -26,7 +25,7 @@ namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 class TFile;
 class DTMeanTimerFitter;
@@ -41,64 +40,58 @@ public:
 
   // Operations
 
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
   void endJob() override;
-  
+
 protected:
-
 private:
-
   std::unique_ptr<DTSegmentSelector> select_;
 
   // The class containing TMax information
   typedef DTTMax::TMax TMax;
- 
-  // class to create/manage histos for each partition (SL) 
-  class cellInfo{
+
+  // class to create/manage histos for each partition (SL)
+  class cellInfo {
   public:
-    cellInfo(const TString& name) {
-      histos = new hTMaxCell(name);
-    }  
-   
-    ~cellInfo() {
-      delete histos;
-    }
+    cellInfo(const TString& name) { histos = new hTMaxCell(name); }
+
+    ~cellInfo() { delete histos; }
 
     void add(const std::vector<const TMax*>& tMaxes);
-    void update() {addedCells.clear();}
-    hTMaxCell* getHists() {return histos;}
-    
-  private: 
+    void update() { addedCells.clear(); }
+    hTMaxCell* getHists() { return histos; }
+
+  private:
     cellInfo(){};
     cellInfo(const cellInfo&){};
-    
+
     std::vector<dttmaxenums::TMaxCells> addedCells;
     hTMaxCell* histos;
   };
 
-  h2DSegm *h2DSegmRZ;
-  h2DSegm *h2DSegmRPhi;
-  h4DSegm *h4DSegmAllCh;
+  h2DSegm* h2DSegmRZ;
+  h2DSegm* h2DSegmRPhi;
+  h4DSegm* h4DSegmAllCh;
 
   // Divide cellInfo by given granularity (to be implemented)
-  // DTVDriftCalibration::cellInfo* partition(const DTWireId& wireId); 
+  // DTVDriftCalibration::cellInfo* partition(const DTWireId& wireId);
 
   // Specify the granularity for the TMax histograms
-  enum TMaxGranularity {byChamber, bySL, byPartition};
+  enum TMaxGranularity { byChamber, bySL, byPartition };
   TMaxGranularity theGranularity;
- 
+
   // The label used to retrieve 4D segments from the event
   edm::EDGetTokenT<DTRecSegment4DCollection> theRecHits4DToken;
 
   // Debug flag
   bool debug;
-  
+
   // The label used to retrieve digis from the event
   std::string digiLabel;
-  
+
   // The file which will contain the tMax histograms
-  TFile *theFile;
+  TFile* theFile;
 
   // The fitter
   std::unique_ptr<DTMeanTimerFitter> theFitter;
@@ -117,7 +110,7 @@ private:
   //bool checkNoisyChannels;
 
   // The module for t0 subtraction
-  std::unique_ptr<DTTTrigBaseSync> theSync;//FIXME: should be const
+  std::unique_ptr<DTTTrigBaseSync> theSync;  //FIXME: should be const
 
   // parameter set for DTCalibrationMap constructor
   edm::ParameterSet theCalibFilePar;
@@ -125,7 +118,7 @@ private:
   // Maximum value for the 4D Segment chi2
   //double theMaxChi2;
 
-  // Maximum incident angle for Phi Seg 
+  // Maximum incident angle for Phi Seg
   //double theMaxPhiAngle;
 
   // Maximum incident angle for Theta Seg
@@ -133,7 +126,5 @@ private:
 
   // Choose the chamber you want to calibrate
   std::string theCalibChamber;
-
 };
 #endif
-

--- a/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.cc
@@ -29,35 +29,34 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTVDriftMeanTimer::DTVDriftMeanTimer(const ParameterSet& pset) {
-  string rootFileName = pset.getParameter<string>("rootFileName");
-  rootFile_ = new TFile(rootFileName.c_str(), "READ");
-  fitter_ = new DTMeanTimerFitter(rootFile_);
-  bool debug = pset.getUntrackedParameter<bool>("debug", false);
-  if(debug) fitter_->setVerbosity(1);
-}
+  DTVDriftMeanTimer::DTVDriftMeanTimer(const ParameterSet& pset) {
+    string rootFileName = pset.getParameter<string>("rootFileName");
+    rootFile_ = new TFile(rootFileName.c_str(), "READ");
+    fitter_ = new DTMeanTimerFitter(rootFile_);
+    bool debug = pset.getUntrackedParameter<bool>("debug", false);
+    if (debug)
+      fitter_->setVerbosity(1);
+  }
 
-DTVDriftMeanTimer::~DTVDriftMeanTimer() {
-  rootFile_->Close();
-  delete fitter_;
-}
+  DTVDriftMeanTimer::~DTVDriftMeanTimer() {
+    rootFile_->Close();
+    delete fitter_;
+  }
 
-void DTVDriftMeanTimer::setES(const edm::EventSetup& setup) {}
+  void DTVDriftMeanTimer::setES(const edm::EventSetup& setup) {}
 
-DTVDriftData DTVDriftMeanTimer::compute(DTSuperLayerId const& slId) {
+  DTVDriftData DTVDriftMeanTimer::compute(DTSuperLayerId const& slId) {
+    // Evaluate v_drift and sigma from the TMax histograms
+    DTWireId wireId(slId, 0, 0);
+    TString N = (((((TString) "TMax" + (long)wireId.wheel()) + (long)wireId.station()) + (long)wireId.sector()) +
+                 (long)wireId.superLayer());
+    vector<float> vDriftAndReso = fitter_->evaluateVDriftAndReso(N);
 
-  // Evaluate v_drift and sigma from the TMax histograms
-  DTWireId wireId(slId, 0, 0);
-  TString N = ( ( ( ( (TString)"TMax" + (long)wireId.wheel() )
-                                      + (long)wireId.station() )
-		                      + (long)wireId.sector() ) + (long)wireId.superLayer() );
-  vector<float> vDriftAndReso = fitter_->evaluateVDriftAndReso(N);
+    // Don't write the constants for the SL if the vdrift was not computed
+    if (vDriftAndReso.front() == -1)
+      throw cms::Exception("DTCalibration") << "Could not compute valid vDrift value for SL " << slId << endl;
 
-  // Don't write the constants for the SL if the vdrift was not computed
-  if(vDriftAndReso.front() == -1)
-     throw cms::Exception("DTCalibration") << "Could not compute valid vDrift value for SL " << slId << endl;
+    return DTVDriftData(vDriftAndReso[0], vDriftAndReso[1]);
+  }
 
-  return DTVDriftData(vDriftAndReso[0],vDriftAndReso[1]);
-}
-
-} // namespace
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.h
@@ -16,17 +16,18 @@ class DTMeanTimerFitter;
 
 namespace dtCalibration {
 
-class DTVDriftMeanTimer: public DTVDriftBaseAlgo {
-public:
-   DTVDriftMeanTimer(edm::ParameterSet const&);
-   ~DTVDriftMeanTimer() override;
+  class DTVDriftMeanTimer : public DTVDriftBaseAlgo {
+  public:
+    DTVDriftMeanTimer(edm::ParameterSet const&);
+    ~DTVDriftMeanTimer() override;
 
-   void setES(const edm::EventSetup& setup) override;
-   DTVDriftData compute(const DTSuperLayerId&) override;
-private:
-   TFile* rootFile_;
-   DTMeanTimerFitter* fitter_;
-};
+    void setES(const edm::EventSetup& setup) override;
+    DTVDriftData compute(const DTSuperLayerId&) override;
 
-} // namespace
+  private:
+    TFile* rootFile_;
+    DTMeanTimerFitter* fitter_;
+  };
+
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegment.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegment.cc
@@ -31,90 +31,83 @@ using namespace edm;
 
 namespace dtCalibration {
 
-DTVDriftSegment::DTVDriftSegment(const ParameterSet& pset):
-  nSigmas_( pset.getUntrackedParameter<unsigned int>("nSigmasFitRange", 1) ) {
+  DTVDriftSegment::DTVDriftSegment(const ParameterSet& pset)
+      : nSigmas_(pset.getUntrackedParameter<unsigned int>("nSigmasFitRange", 1)) {
+    string rootFileName = pset.getParameter<string>("rootFileName");
+    rootFile_ = new TFile(rootFileName.c_str(), "READ");
 
-  string rootFileName = pset.getParameter<string>("rootFileName");
-  rootFile_ = new TFile(rootFileName.c_str(), "READ");
+    bool debug = pset.getUntrackedParameter<bool>("debug", false);
+    fitter_ = new DTResidualFitter(debug);
+    //bool debug = pset.getUntrackedParameter<bool>("debug", false);
+    //if(debug) fitter_->setVerbosity(1);
+  }
 
-  bool debug = pset.getUntrackedParameter<bool>("debug",false);
-  fitter_ = new DTResidualFitter(debug);
-  //bool debug = pset.getUntrackedParameter<bool>("debug", false);
-  //if(debug) fitter_->setVerbosity(1);
-}
+  DTVDriftSegment::~DTVDriftSegment() {
+    rootFile_->Close();
+    delete fitter_;
+  }
 
-DTVDriftSegment::~DTVDriftSegment() {
-  rootFile_->Close();
-  delete fitter_;
-}
+  void DTVDriftSegment::setES(const edm::EventSetup& setup) {
+    // Get the map of vdrift from the setup
+    ESHandle<DTMtime> mTime;
+    setup.get<DTMtimeRcd>().get(mTime);
+    mTimeMap_ = &*mTime;
+  }
 
-void DTVDriftSegment::setES(const edm::EventSetup& setup) {
-  // Get the map of vdrift from the setup
-  ESHandle<DTMtime> mTime;
-  setup.get<DTMtimeRcd>().get(mTime);
-  mTimeMap_ = &*mTime;
-}
+  DTVDriftData DTVDriftSegment::compute(DTSuperLayerId const& slId) {
+    // Get original value from DB; vdrift is cm/ns , resolution is cm
+    float vDrift = 0., resolution = 0.;
+    int status = mTimeMap_->get(slId, vDrift, resolution, DTVelocityUnits::cm_per_ns);
 
-DTVDriftData DTVDriftSegment::compute(DTSuperLayerId const& slId) {
+    if (status != 0)
+      throw cms::Exception("DTCalibration") << "Could not find vDrift entry in DB for" << slId << endl;
 
-  // Get original value from DB; vdrift is cm/ns , resolution is cm
-  float vDrift = 0., resolution = 0.;
-  int status = mTimeMap_->get(slId,vDrift,resolution,DTVelocityUnits::cm_per_ns);
-
-  if(status != 0) throw cms::Exception("DTCalibration") << "Could not find vDrift entry in DB for"
-                                                        << slId << endl;
-
-  // For RZ superlayers use original value
-  if(slId.superLayer() == 2){
-     LogTrace("Calibration") << "[DTVDriftSegment]: RZ superlayer\n"
-                             << "                   Will use original vDrift and resolution.";
-     return DTVDriftData(vDrift,resolution);
-  } else{
-     TH1F* vDriftCorrHisto = getHisto(slId);
-     // If empty histogram 
-     if(vDriftCorrHisto->GetEntries() == 0){
+    // For RZ superlayers use original value
+    if (slId.superLayer() == 2) {
+      LogTrace("Calibration") << "[DTVDriftSegment]: RZ superlayer\n"
+                              << "                   Will use original vDrift and resolution.";
+      return DTVDriftData(vDrift, resolution);
+    } else {
+      TH1F* vDriftCorrHisto = getHisto(slId);
+      // If empty histogram
+      if (vDriftCorrHisto->GetEntries() == 0) {
         LogError("Calibration") << "[DTVDriftSegment]: Histogram " << vDriftCorrHisto->GetName() << " is empty.\n"
                                 << "                   Will use original vDrift and resolution.";
-        return DTVDriftData(vDrift,resolution);                              
-     }
-   
-     LogTrace("Calibration") << "[DTVDriftSegment]: Fitting histogram " << vDriftCorrHisto->GetName(); 
-     DTResidualFitResult fitResult = fitter_->fitResiduals(*vDriftCorrHisto,nSigmas_);
-     LogTrace("Calibration") << "[DTVDriftSegment]: \n"
-                             << "   Fit Mean  = " << fitResult.fitMean << " +/- "
-                                                  << fitResult.fitMeanError << "\n"
-                             << "   Fit Sigma = " << fitResult.fitSigma << " +/- "
-                                                  << fitResult.fitSigmaError;
+        return DTVDriftData(vDrift, resolution);
+      }
 
-     float vDriftCorr = fitResult.fitMean;
-     float vDriftNew = vDrift*(1. - vDriftCorr); 
-     float resolutionNew = resolution;
-     return DTVDriftData(vDriftNew,resolutionNew);
+      LogTrace("Calibration") << "[DTVDriftSegment]: Fitting histogram " << vDriftCorrHisto->GetName();
+      DTResidualFitResult fitResult = fitter_->fitResiduals(*vDriftCorrHisto, nSigmas_);
+      LogTrace("Calibration") << "[DTVDriftSegment]: \n"
+                              << "   Fit Mean  = " << fitResult.fitMean << " +/- " << fitResult.fitMeanError << "\n"
+                              << "   Fit Sigma = " << fitResult.fitSigma << " +/- " << fitResult.fitSigmaError;
+
+      float vDriftCorr = fitResult.fitMean;
+      float vDriftNew = vDrift * (1. - vDriftCorr);
+      float resolutionNew = resolution;
+      return DTVDriftData(vDriftNew, resolutionNew);
+    }
   }
-}
 
-TH1F* DTVDriftSegment::getHisto(const DTSuperLayerId& slId) {
-  string histoName = getHistoName(slId);
-  TH1F* histo = static_cast<TH1F*>(rootFile_->Get(histoName.c_str()));
-  if(!histo) throw cms::Exception("DTCalibration") << "v-drift correction histogram not found:"
-                                                   << histoName << endl; 
-  return histo;
-}
+  TH1F* DTVDriftSegment::getHisto(const DTSuperLayerId& slId) {
+    string histoName = getHistoName(slId);
+    TH1F* histo = static_cast<TH1F*>(rootFile_->Get(histoName.c_str()));
+    if (!histo)
+      throw cms::Exception("DTCalibration") << "v-drift correction histogram not found:" << histoName << endl;
+    return histo;
+  }
 
-string DTVDriftSegment::getHistoName(const DTSuperLayerId& slId) {
-  DTChamberId chId = slId.chamberId();
+  string DTVDriftSegment::getHistoName(const DTSuperLayerId& slId) {
+    DTChamberId chId = slId.chamberId();
 
-  // Compose the chamber name
-  std::string wheel = std::to_string(chId.wheel());
-  std::string station = std::to_string(chId.station());
-  std::string sector = std::to_string(chId.sector());
+    // Compose the chamber name
+    std::string wheel = std::to_string(chId.wheel());
+    std::string station = std::to_string(chId.station());
+    std::string sector = std::to_string(chId.sector());
 
-  string chHistoName =
-    "_W" + wheel +
-    "_St" + station +
-    "_Sec" +  sector;
+    string chHistoName = "_W" + wheel + "_St" + station + "_Sec" + sector;
 
-  return (slId.superLayer() != 2)?("hRPhiVDriftCorr" + chHistoName):("hRZVDriftCorr" + chHistoName);
-}
+    return (slId.superLayer() != 2) ? ("hRPhiVDriftCorr" + chHistoName) : ("hRZVDriftCorr" + chHistoName);
+  }
 
-} // namespace
+}  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegment.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegment.h
@@ -20,23 +20,24 @@ class TFile;
 
 namespace dtCalibration {
 
-class DTVDriftSegment: public DTVDriftBaseAlgo {
-public:
-   DTVDriftSegment(edm::ParameterSet const&);
-   ~DTVDriftSegment() override;
+  class DTVDriftSegment : public DTVDriftBaseAlgo {
+  public:
+    DTVDriftSegment(edm::ParameterSet const&);
+    ~DTVDriftSegment() override;
 
-   void setES(const edm::EventSetup& setup) override;
-   DTVDriftData compute(const DTSuperLayerId&) override;
-private:
-   TH1F* getHisto(const DTSuperLayerId&);
-   std::string getHistoName(const DTSuperLayerId&);
+    void setES(const edm::EventSetup& setup) override;
+    DTVDriftData compute(const DTSuperLayerId&) override;
 
-   unsigned int nSigmas_;
+  private:
+    TH1F* getHisto(const DTSuperLayerId&);
+    std::string getHistoName(const DTSuperLayerId&);
 
-   const DTMtime* mTimeMap_;
-   TFile* rootFile_;
-   DTResidualFitter* fitter_;
-};
+    unsigned int nSigmas_;
 
-} // namespace
+    const DTMtime* mTimeMap_;
+    TFile* rootFile_;
+    DTResidualFitter* fitter_;
+  };
+
+}  // namespace dtCalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.cc
@@ -31,34 +31,31 @@
 using namespace std;
 using namespace edm;
 
-DTVDriftSegmentCalibration::DTVDriftSegmentCalibration(const ParameterSet& pset):
-  theRecHits4DLabel_(pset.getParameter<InputTag>("recHits4DLabel")),
-  //writeVDriftDB_(pset.getUntrackedParameter<bool>("writeVDriftDB", false)),
-  theCalibChamber_(pset.getUntrackedParameter<string>("calibChamber", "All")) {
-
+DTVDriftSegmentCalibration::DTVDriftSegmentCalibration(const ParameterSet& pset)
+    : theRecHits4DLabel_(pset.getParameter<InputTag>("recHits4DLabel")),
+      //writeVDriftDB_(pset.getUntrackedParameter<bool>("writeVDriftDB", false)),
+      theCalibChamber_(pset.getUntrackedParameter<string>("calibChamber", "All")) {
   LogVerbatim("Calibration") << "[DTVDriftSegmentCalibration] Constructor called!";
 
   edm::ConsumesCollector collector(consumesCollector());
-  select_ = new DTSegmentSelector(pset,collector);
-  consumes< DTRecSegment4DCollection >(edm::InputTag(theRecHits4DLabel_));
+  select_ = new DTSegmentSelector(pset, collector);
+  consumes<DTRecSegment4DCollection>(edm::InputTag(theRecHits4DLabel_));
   // the root file which will contain the histos
-  string rootFileName = pset.getUntrackedParameter<string>("rootFileName","DTVDriftHistos.root");
+  string rootFileName = pset.getUntrackedParameter<string>("rootFileName", "DTVDriftHistos.root");
   rootFile_ = new TFile(rootFileName.c_str(), "RECREATE");
   rootFile_->cd();
 }
 
-void DTVDriftSegmentCalibration::beginJob(){
-  TH1::SetDefaultSumw2(true);
-}
+void DTVDriftSegmentCalibration::beginJob() { TH1::SetDefaultSumw2(true); }
 
 void DTVDriftSegmentCalibration::beginRun(const edm::Run& run, const edm::EventSetup& setup) {}
 
-DTVDriftSegmentCalibration::~DTVDriftSegmentCalibration(){
+DTVDriftSegmentCalibration::~DTVDriftSegmentCalibration() {
   rootFile_->Close();
   LogVerbatim("Calibration") << "[DTVDriftSegmentCalibration] Destructor called!";
 }
 
-void DTVDriftSegmentCalibration::analyze(const Event & event, const EventSetup& eventSetup) {
+void DTVDriftSegmentCalibration::analyze(const Event& event, const EventSetup& eventSetup) {
   rootFile_->cd();
 
   // Get the DT Geometry
@@ -67,10 +64,10 @@ void DTVDriftSegmentCalibration::analyze(const Event & event, const EventSetup& 
 
   // Get the rechit collection from the event
   Handle<DTRecSegment4DCollection> all4DSegments;
-  event.getByLabel(theRecHits4DLabel_, all4DSegments); 
+  event.getByLabel(theRecHits4DLabel_, all4DSegments);
 
   DTChamberId chosenChamberId;
-  if(theCalibChamber_ != "All") {
+  if (theCalibChamber_ != "All") {
     stringstream linestr;
     int selWheel, selStation, selSector;
     linestr << theCalibChamber_;
@@ -80,93 +77,108 @@ void DTVDriftSegmentCalibration::analyze(const Event & event, const EventSetup& 
   }
   // Loop over segments by chamber
   DTRecSegment4DCollection::id_iterator chamberIdIt;
-  for(chamberIdIt = all4DSegments->id_begin(); chamberIdIt != all4DSegments->id_end(); ++chamberIdIt){
-
-    // Calibrate just the chosen chamber/s    
-    if((theCalibChamber_ != "All") && ((*chamberIdIt) != chosenChamberId)) continue;
+  for (chamberIdIt = all4DSegments->id_begin(); chamberIdIt != all4DSegments->id_end(); ++chamberIdIt) {
+    // Calibrate just the chosen chamber/s
+    if ((theCalibChamber_ != "All") && ((*chamberIdIt) != chosenChamberId))
+      continue;
 
     // Book histos
-    if(theVDriftHistoMapTH1F_.find(*chamberIdIt) == theVDriftHistoMapTH1F_.end()){
+    if (theVDriftHistoMapTH1F_.find(*chamberIdIt) == theVDriftHistoMapTH1F_.end()) {
       LogTrace("Calibration") << "   Booking histos for Chamber: " << *chamberIdIt;
       bookHistos(*chamberIdIt);
     }
-   
+
     // Get the chamber from the setup
     const DTChamber* chamber = dtGeom->chamber(*chamberIdIt);
     // Get the range for the corresponding ChamberId
     DTRecSegment4DCollection::range range = all4DSegments->get((*chamberIdIt));
     // Loop over the rechits of this DetUnit
-    for(DTRecSegment4DCollection::const_iterator segment  = range.first;
-                                                 segment != range.second; ++segment){
-
-      
+    for (DTRecSegment4DCollection::const_iterator segment = range.first; segment != range.second; ++segment) {
       LogTrace("Calibration") << "Segment local pos (in chamber RF): " << (*segment).localPosition()
                               << "\nSegment global pos: " << chamber->toGlobal((*segment).localPosition());
-      
-      if( !(*select_)(*segment, event, eventSetup) ) continue;
+
+      if (!(*select_)(*segment, event, eventSetup))
+        continue;
 
       // Fill v-drift values
-      if( (*segment).hasPhi() ) {
-         //if( segment->phiSegment()->ist0Valid() ){
-         double segmentVDrift = segment->phiSegment()->vDrift();
-         if( segmentVDrift != 0.00 ){   
-	    (theVDriftHistoMapTH1F_[*chamberIdIt])[0]->Fill(segmentVDrift);
-            (theVDriftHistoMapTH2F_[*chamberIdIt])[0]->Fill(segment->localPosition().x(),segmentVDrift);
-            (theVDriftHistoMapTH2F_[*chamberIdIt])[1]->Fill(segment->localPosition().y(),segmentVDrift);
-	}
+      if ((*segment).hasPhi()) {
+        //if( segment->phiSegment()->ist0Valid() ){
+        double segmentVDrift = segment->phiSegment()->vDrift();
+        if (segmentVDrift != 0.00) {
+          (theVDriftHistoMapTH1F_[*chamberIdIt])[0]->Fill(segmentVDrift);
+          (theVDriftHistoMapTH2F_[*chamberIdIt])[0]->Fill(segment->localPosition().x(), segmentVDrift);
+          (theVDriftHistoMapTH2F_[*chamberIdIt])[1]->Fill(segment->localPosition().y(), segmentVDrift);
+        }
       }
-      // Probably not meaningful 
-      if( (*segment).hasZed() ){
-         //if( segment->zSegment()->ist0Valid() ){
-         double segmentVDrift = segment->zSegment()->vDrift();
-         if( segmentVDrift != 0.00 ){
-	    (theVDriftHistoMapTH1F_[*chamberIdIt])[1]->Fill(segmentVDrift);
-	}
+      // Probably not meaningful
+      if ((*segment).hasZed()) {
+        //if( segment->zSegment()->ist0Valid() ){
+        double segmentVDrift = segment->zSegment()->vDrift();
+        if (segmentVDrift != 0.00) {
+          (theVDriftHistoMapTH1F_[*chamberIdIt])[1]->Fill(segmentVDrift);
+        }
       }
-    } // DTRecSegment4DCollection::const_iterator segment
-  } // DTRecSegment4DCollection::id_iterator chamberIdIt
-} // DTVDriftSegmentCalibration::analyze
+    }  // DTRecSegment4DCollection::const_iterator segment
+  }    // DTRecSegment4DCollection::id_iterator chamberIdIt
+}  // DTVDriftSegmentCalibration::analyze
 
 void DTVDriftSegmentCalibration::endJob() {
   rootFile_->cd();
-  
+
   LogVerbatim("Calibration") << "[DTVDriftSegmentCalibration] Writing histos to file!" << endl;
 
-  for(ChamberHistosMapTH1F::const_iterator itChHistos = theVDriftHistoMapTH1F_.begin(); itChHistos != theVDriftHistoMapTH1F_.end(); ++itChHistos){
-     vector<TH1F*>::const_iterator itHistTH1F = (*itChHistos).second.begin();
-     vector<TH1F*>::const_iterator itHistTH1F_end = (*itChHistos).second.end();
-     for(; itHistTH1F != itHistTH1F_end; ++itHistTH1F) (*itHistTH1F)->Write();
+  for (ChamberHistosMapTH1F::const_iterator itChHistos = theVDriftHistoMapTH1F_.begin();
+       itChHistos != theVDriftHistoMapTH1F_.end();
+       ++itChHistos) {
+    vector<TH1F*>::const_iterator itHistTH1F = (*itChHistos).second.begin();
+    vector<TH1F*>::const_iterator itHistTH1F_end = (*itChHistos).second.end();
+    for (; itHistTH1F != itHistTH1F_end; ++itHistTH1F)
+      (*itHistTH1F)->Write();
 
-     vector<TH2F*>::const_iterator itHistTH2F = theVDriftHistoMapTH2F_[(*itChHistos).first].begin();
-     vector<TH2F*>::const_iterator itHistTH2F_end = theVDriftHistoMapTH2F_[(*itChHistos).first].end();
-     for(; itHistTH2F != itHistTH2F_end; ++itHistTH2F) (*itHistTH2F)->Write();
+    vector<TH2F*>::const_iterator itHistTH2F = theVDriftHistoMapTH2F_[(*itChHistos).first].begin();
+    vector<TH2F*>::const_iterator itHistTH2F_end = theVDriftHistoMapTH2F_[(*itChHistos).first].end();
+    for (; itHistTH2F != itHistTH2F_end; ++itHistTH2F)
+      (*itHistTH2F)->Write();
   }
 
   /*if(writeVDriftDB_){
      // ...
-  }*/ 
+  }*/
 }
 
 // Book a set of histograms for a given Chamber
 void DTVDriftSegmentCalibration::bookHistos(DTChamberId chId) {
-
   // Compose the chamber name
   std::string wheel = std::to_string(chId.wheel());
   std::string station = std::to_string(chId.station());
   std::string sector = std::to_string(chId.sector());
 
-  string chHistoName =
-    "_W" + wheel +
-    "_St" + station +
-    "_Sec" +  sector;
+  string chHistoName = "_W" + wheel + "_St" + station + "_Sec" + sector;
 
   vector<TH1F*> histosTH1F;
-  histosTH1F.push_back(new TH1F(("hRPhiVDriftCorr" + chHistoName).c_str(), "v-drift corr. from Phi segments", 200, -0.4, 0.4));
-  if(chId.station() != 4) histosTH1F.push_back(new TH1F(("hRZVDriftCorr" + chHistoName).c_str(), "v-drift corr. from Z segments", 200, -0.4, 0.4));
-  
+  histosTH1F.push_back(
+      new TH1F(("hRPhiVDriftCorr" + chHistoName).c_str(), "v-drift corr. from Phi segments", 200, -0.4, 0.4));
+  if (chId.station() != 4)
+    histosTH1F.push_back(
+        new TH1F(("hRZVDriftCorr" + chHistoName).c_str(), "v-drift corr. from Z segments", 200, -0.4, 0.4));
+
   vector<TH2F*> histosTH2F;
-  histosTH2F.push_back(new TH2F(("hRPhiVDriftCorrVsSegmPosX" + chHistoName).c_str(), "v-drift corr. vs. segment x position", 250, -125., 125., 200, -0.4, 0.4));
-  histosTH2F.push_back(new TH2F(("hRPhiVDriftCorrVsSegmPosY" + chHistoName).c_str(), "v-drift corr. vs. segment y position", 250, -125., 125., 200, -0.4, 0.4));
+  histosTH2F.push_back(new TH2F(("hRPhiVDriftCorrVsSegmPosX" + chHistoName).c_str(),
+                                "v-drift corr. vs. segment x position",
+                                250,
+                                -125.,
+                                125.,
+                                200,
+                                -0.4,
+                                0.4));
+  histosTH2F.push_back(new TH2F(("hRPhiVDriftCorrVsSegmPosY" + chHistoName).c_str(),
+                                "v-drift corr. vs. segment y position",
+                                250,
+                                -125.,
+                                125.,
+                                200,
+                                -0.4,
+                                0.4));
   //if(chId.station() != 4) ...
 
   theVDriftHistoMapTH1F_[chId] = histosTH1F;

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
@@ -30,15 +30,15 @@ public:
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
   void endJob() override;
-  
+
 private:
   typedef std::map<DTChamberId, std::vector<TH1F*> > ChamberHistosMapTH1F;
   typedef std::map<DTChamberId, std::vector<TH2F*> > ChamberHistosMapTH2F;
   void bookHistos(DTChamberId);
 
-  DTSegmentSelector *select_;
+  DTSegmentSelector* select_;
 
-  edm::InputTag  theRecHits4DLabel_;
+  edm::InputTag theRecHits4DLabel_;
   //bool writeVDriftDB_;
   std::string theCalibChamber_;
 
@@ -47,4 +47,3 @@ private:
   ChamberHistosMapTH2F theVDriftHistoMapTH2F_;
 };
 #endif
-

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
@@ -30,21 +30,18 @@
 using namespace std;
 using namespace edm;
 
-DTVDriftWriter::DTVDriftWriter(const ParameterSet& pset):
-  granularity_( pset.getUntrackedParameter<string>("calibGranularity","bySL") ),
-  vDriftAlgo_{DTVDriftPluginFactory::get()->create(pset.getParameter<string>("vDriftAlgo"),
-                                                   pset.getParameter<ParameterSet>("vDriftAlgoConfig"))}
- {
-
+DTVDriftWriter::DTVDriftWriter(const ParameterSet& pset)
+    : granularity_(pset.getUntrackedParameter<string>("calibGranularity", "bySL")),
+      vDriftAlgo_{DTVDriftPluginFactory::get()->create(pset.getParameter<string>("vDriftAlgo"),
+                                                       pset.getParameter<ParameterSet>("vDriftAlgoConfig"))} {
   LogVerbatim("Calibration") << "[DTVDriftWriter]Constructor called!";
 
-  if(granularity_ != "bySL")
-     throw cms::Exception("Configuration") << "[DTVDriftWriter] Check parameter calibGranularity: " << granularity_ << " option not available.";
+  if (granularity_ != "bySL")
+    throw cms::Exception("Configuration")
+        << "[DTVDriftWriter] Check parameter calibGranularity: " << granularity_ << " option not available.";
 }
 
-DTVDriftWriter::~DTVDriftWriter(){
-  LogVerbatim("Calibration") << "[DTVDriftWriter]Destructor called!";
-}
+DTVDriftWriter::~DTVDriftWriter() { LogVerbatim("Calibration") << "[DTVDriftWriter]Destructor called!"; }
 
 void DTVDriftWriter::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   // Get the map of ttrig from the Setup
@@ -55,52 +52,44 @@ void DTVDriftWriter::beginRun(const edm::Run& run, const edm::EventSetup& setup)
   // Get geometry from Event Setup
   setup.get<MuonGeometryRecord>().get(dtGeom_);
   // Pass EventSetup to concrete implementation
-  vDriftAlgo_->setES(setup); 
+  vDriftAlgo_->setES(setup);
 }
 
 void DTVDriftWriter::endJob() {
   // Create the object to be written to DB
   DTMtime* mTimeNewMap = new DTMtime();
 
-  if(granularity_ == "bySL") {    
-     // Get all the sls from the geometry
-     const vector<const DTSuperLayer*>& superLayers = dtGeom_->superLayers(); 
-     auto sl = superLayers.begin();
-     auto sl_end = superLayers.end();
-     for(; sl != sl_end; ++sl){
-        DTSuperLayerId slId = (*sl)->id();
-        // Get original value from DB
-        float vDrift = 0., resolution = 0.;
-        // vdrift is cm/ns , resolution is cm
-        int status = mTimeMap_->get(slId,vDrift,resolution,DTVelocityUnits::cm_per_ns);
+  if (granularity_ == "bySL") {
+    // Get all the sls from the geometry
+    const vector<const DTSuperLayer*>& superLayers = dtGeom_->superLayers();
+    auto sl = superLayers.begin();
+    auto sl_end = superLayers.end();
+    for (; sl != sl_end; ++sl) {
+      DTSuperLayerId slId = (*sl)->id();
+      // Get original value from DB
+      float vDrift = 0., resolution = 0.;
+      // vdrift is cm/ns , resolution is cm
+      int status = mTimeMap_->get(slId, vDrift, resolution, DTVelocityUnits::cm_per_ns);
 
-        // Compute vDrift
-        try{
-           dtCalibration::DTVDriftData vDriftData = vDriftAlgo_->compute(slId);
-           float vDriftNew = vDriftData.vdrift;
-           float resolutionNew = vDriftData.resolution; 
-           // vdrift is cm/ns , resolution is cm
-           mTimeNewMap->set(slId,
-                            vDriftNew,
-		            resolutionNew,
-		            DTVelocityUnits::cm_per_ns);
-           LogVerbatim("Calibration") << "vDrift for: " << slId
-                                      << " Mean " << vDriftNew
-                                      << " Resolution " << resolutionNew;
-        } catch(cms::Exception& e){
-           LogError("Calibration") << e.explainSelf();
-           // Go back to original value in case of error
-           if(!status){  
-              mTimeNewMap->set(slId,
-                               vDrift,
-                               resolution,
-                               DTVelocityUnits::cm_per_ns);
-              LogVerbatim("Calibration") << "Keep original vDrift for: " << slId
-                                         << " Mean " << vDrift
-                                         << " Resolution " << resolution;
-           }
+      // Compute vDrift
+      try {
+        dtCalibration::DTVDriftData vDriftData = vDriftAlgo_->compute(slId);
+        float vDriftNew = vDriftData.vdrift;
+        float resolutionNew = vDriftData.resolution;
+        // vdrift is cm/ns , resolution is cm
+        mTimeNewMap->set(slId, vDriftNew, resolutionNew, DTVelocityUnits::cm_per_ns);
+        LogVerbatim("Calibration") << "vDrift for: " << slId << " Mean " << vDriftNew << " Resolution "
+                                   << resolutionNew;
+      } catch (cms::Exception& e) {
+        LogError("Calibration") << e.explainSelf();
+        // Go back to original value in case of error
+        if (!status) {
+          mTimeNewMap->set(slId, vDrift, resolution, DTVelocityUnits::cm_per_ns);
+          LogVerbatim("Calibration") << "Keep original vDrift for: " << slId << " Mean " << vDrift << " Resolution "
+                                     << resolution;
         }
-     } // End of loop on superlayers
+      }
+    }  // End of loop on superlayers
   }
 
   // Write the vDrift object to DB

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
@@ -28,11 +28,11 @@ public:
 
   // Operations
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override {}
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override {}
   void endJob() override;
- 
+
 private:
-  std::string granularity_; // enforced by SL
+  std::string granularity_;  // enforced by SL
 
   const DTMtime* mTimeMap_;
   edm::ESHandle<DTGeometry> dtGeom_;
@@ -40,4 +40,3 @@ private:
   std::unique_ptr<dtCalibration::DTVDriftBaseAlgo> vDriftAlgo_;
 };
 #endif
-

--- a/CalibMuon/DTCalibration/plugins/SealModule.cc
+++ b/CalibMuon/DTCalibration/plugins/SealModule.cc
@@ -22,7 +22,7 @@
 #include "CalibMuon/DTCalibration/plugins/DTResidualCalibration.h"
 
 // #include "CalibMuon/DTCalibration/plugins/DTFakeTTrigESProducer.h"
- #include "CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h"
+#include "CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h"
 // #include "CalibMuon/DTCalibration/plugins/DTFakeVDriftESProducer.h"
 
 #include "CalibMuon/DTCalibration/interface/DTTTrigCorrectionFactory.h"
@@ -64,16 +64,20 @@ DEFINE_FWK_MODULE(DTResidualCalibration);
 DEFINE_FWK_EVENTSETUP_SOURCE(DTFakeT0ESProducer);
 // DEFINE_FWK_EVENTSETUP_SOURCE(DTFakeVDriftESProducer);
 
-DEFINE_EDM_PLUGIN(DTTTrigCorrectionFactory,dtCalibration::DTTTrigT0SegCorrection,"DTTTrigT0SegCorrection");
-DEFINE_EDM_PLUGIN(DTTTrigCorrectionFactory,dtCalibration::DTTTrigResidualCorrection,"DTTTrigResidualCorrection");
-DEFINE_EDM_PLUGIN(DTTTrigCorrectionFactory,dtCalibration::DTTTrigMatchRPhi,"DTTTrigMatchRPhi");
-DEFINE_EDM_PLUGIN(DTTTrigCorrectionFactory,dtCalibration::DTTTrigFillWithAverage,"DTTTrigFillWithAverage");
-DEFINE_EDM_PLUGIN(DTTTrigCorrectionFactory,dtCalibration::DTTTrigConstantShift,"DTTTrigConstantShift");
+DEFINE_EDM_PLUGIN(DTTTrigCorrectionFactory, dtCalibration::DTTTrigT0SegCorrection, "DTTTrigT0SegCorrection");
+DEFINE_EDM_PLUGIN(DTTTrigCorrectionFactory, dtCalibration::DTTTrigResidualCorrection, "DTTTrigResidualCorrection");
+DEFINE_EDM_PLUGIN(DTTTrigCorrectionFactory, dtCalibration::DTTTrigMatchRPhi, "DTTTrigMatchRPhi");
+DEFINE_EDM_PLUGIN(DTTTrigCorrectionFactory, dtCalibration::DTTTrigFillWithAverage, "DTTTrigFillWithAverage");
+DEFINE_EDM_PLUGIN(DTTTrigCorrectionFactory, dtCalibration::DTTTrigConstantShift, "DTTTrigConstantShift");
 
-DEFINE_EDM_PLUGIN(DTT0CorrectionFactory,dtCalibration::DTT0FillDefaultFromDB,"DTT0FillDefaultFromDB");
-DEFINE_EDM_PLUGIN(DTT0CorrectionFactory,dtCalibration::DTT0FillChamberFromDB,"DTT0FillChamberFromDB");
-DEFINE_EDM_PLUGIN(DTT0CorrectionFactory,dtCalibration::DTT0WireInChamberReferenceCorrection,"DTT0WireInChamberReferenceCorrection");
-DEFINE_EDM_PLUGIN(DTT0CorrectionFactory,dtCalibration::DTT0AbsoluteReferenceCorrection,"DTT0AbsoluteReferenceCorrection");
+DEFINE_EDM_PLUGIN(DTT0CorrectionFactory, dtCalibration::DTT0FillDefaultFromDB, "DTT0FillDefaultFromDB");
+DEFINE_EDM_PLUGIN(DTT0CorrectionFactory, dtCalibration::DTT0FillChamberFromDB, "DTT0FillChamberFromDB");
+DEFINE_EDM_PLUGIN(DTT0CorrectionFactory,
+                  dtCalibration::DTT0WireInChamberReferenceCorrection,
+                  "DTT0WireInChamberReferenceCorrection");
+DEFINE_EDM_PLUGIN(DTT0CorrectionFactory,
+                  dtCalibration::DTT0AbsoluteReferenceCorrection,
+                  "DTT0AbsoluteReferenceCorrection");
 
-DEFINE_EDM_PLUGIN(DTVDriftPluginFactory,dtCalibration::DTVDriftMeanTimer,"DTVDriftMeanTimer");
-DEFINE_EDM_PLUGIN(DTVDriftPluginFactory,dtCalibration::DTVDriftSegment,"DTVDriftSegment");
+DEFINE_EDM_PLUGIN(DTVDriftPluginFactory, dtCalibration::DTVDriftMeanTimer, "DTVDriftMeanTimer");
+DEFINE_EDM_PLUGIN(DTVDriftPluginFactory, dtCalibration::DTVDriftSegment, "DTVDriftSegment");

--- a/CalibMuon/DTCalibration/src/DTCalibMuonSelection.cc
+++ b/CalibMuon/DTCalibration/src/DTCalibMuonSelection.cc
@@ -2,8 +2,6 @@
 // Original Author:  Marco Zanetti
 //         Created:  Tue Sep  9 15:56:24 CEST 2008
 
-
-
 // user include files
 #include "CalibMuon/DTCalibration/interface/DTCalibMuonSelection.h"
 
@@ -19,56 +17,43 @@
 using namespace edm;
 using namespace reco;
 
-DTCalibMuonSelection::DTCalibMuonSelection(const edm::ParameterSet& iConfig)
-{
+DTCalibMuonSelection::DTCalibMuonSelection(const edm::ParameterSet& iConfig) {
   muonList = consumes<MuonCollection>(iConfig.getParameter<edm::InputTag>("src"));
   etaMin = iConfig.getParameter<double>("etaMin");
   etaMax = iConfig.getParameter<double>("etaMax");
   ptMin = iConfig.getParameter<double>("ptMin");
 }
 
+DTCalibMuonSelection::~DTCalibMuonSelection() {}
 
-DTCalibMuonSelection::~DTCalibMuonSelection() { }
-
-
-bool DTCalibMuonSelection::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+bool DTCalibMuonSelection::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   bool result = false;
 
   //Retrieve the muons list
   Handle<MuonCollection> MuHandle;
-  iEvent.getByToken(muonList,MuHandle);
+  iEvent.getByToken(muonList, MuHandle);
 
   for (MuonCollection::const_iterator nmuon = MuHandle->begin(); nmuon != MuHandle->end(); ++nmuon) {
-
     double ptMuon(0.);
     double etaMuon(-999.);
 
-    if(nmuon->isGlobalMuon()){
+    if (nmuon->isGlobalMuon()) {
       ptMuon = nmuon->globalTrack()->pt();
       etaMuon = nmuon->globalTrack()->eta();
-    }
-    else continue;
+    } else
+      continue;
 
-    if(ptMuon > ptMin &&etaMuon > etaMin && etaMuon < etaMax){
+    if (ptMuon > ptMin && etaMuon > etaMin && etaMuon < etaMax) {
       result = true;
       break;
     }
-
   }
 
   return result;
 }
 
-
-
 // ------------ method called once each job just before starting event loop  ------------
-void  DTCalibMuonSelection::beginJob() {
-}
-
-
+void DTCalibMuonSelection::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void  DTCalibMuonSelection::endJob() {
-}
-
+void DTCalibMuonSelection::endJob() {}

--- a/CalibMuon/DTCalibration/src/DTMeanTimerFitter.cc
+++ b/CalibMuon/DTCalibration/src/DTMeanTimerFitter.cc
@@ -23,21 +23,18 @@ DTMeanTimerFitter::DTMeanTimerFitter(TFile *file) : hInputFile(file), theVerbosi
   hDebugFile = new TFile("DTMeanTimerFitter.root", "RECREATE");
 }
 
-DTMeanTimerFitter::~DTMeanTimerFitter() {
-  hDebugFile->Close();
-}
+DTMeanTimerFitter::~DTMeanTimerFitter() { hDebugFile->Close(); }
 
-vector<float> DTMeanTimerFitter::evaluateVDriftAndReso (const TString& N) {
-  
+vector<float> DTMeanTimerFitter::evaluateVDriftAndReso(const TString &N) {
   // Retrieve histogram sets
-  hTMaxCell * histos   = new hTMaxCell(N, hInputFile);
+  hTMaxCell *histos = new hTMaxCell(N, hInputFile);
   vector<float> vDriftAndReso;
 
   // Check that the histo for this cell exists
-  if(histos->hTmax123 != nullptr) {
-    vector<TH1F*> hTMax;  // histograms for <T_max> calculation
-    vector <TH1F*> hT0;   // histograms for T0 evaluation
-    hTMax.push_back(histos->hTmax123); 
+  if (histos->hTmax123 != nullptr) {
+    vector<TH1F *> hTMax;  // histograms for <T_max> calculation
+    vector<TH1F *> hT0;    // histograms for T0 evaluation
+    hTMax.push_back(histos->hTmax123);
     hTMax.push_back(histos->hTmax124s72);
     hTMax.push_back(histos->hTmax124s78);
     hTMax.push_back(histos->hTmax134s72);
@@ -49,104 +46,104 @@ vector<float> DTMeanTimerFitter::evaluateVDriftAndReso (const TString& N) {
     hT0.push_back(histos->hTmax_t0);
     hT0.push_back(histos->hTmax_0);
 
-    vector<Double_t> factor; // factor relating the width of the Tmax distribution 
-                             // and the cell resolution 
-    factor.push_back(sqrt(2./3.)); // hTmax123
-    factor.push_back(sqrt(2./7.)); // hTmax124s72
-    factor.push_back(sqrt(8./7.)); // hTmax124s78
-    factor.push_back(sqrt(2./7.)); // hTmax134s72
-    factor.push_back(sqrt(8./7.)); // hTmax134s78
-    factor.push_back(sqrt(2./3.)); // hTmax234
+    vector<Double_t> factor;          // factor relating the width of the Tmax distribution
+                                      // and the cell resolution
+    factor.push_back(sqrt(2. / 3.));  // hTmax123
+    factor.push_back(sqrt(2. / 7.));  // hTmax124s72
+    factor.push_back(sqrt(8. / 7.));  // hTmax124s78
+    factor.push_back(sqrt(2. / 7.));  // hTmax134s72
+    factor.push_back(sqrt(8. / 7.));  // hTmax134s78
+    factor.push_back(sqrt(2. / 3.));  // hTmax234
 
-
-    // Retrieve the gaussian mean and sigma for each TMax histogram    
+    // Retrieve the gaussian mean and sigma for each TMax histogram
     vector<Double_t> mean;
-    vector<Double_t> sigma; 
+    vector<Double_t> sigma;
     vector<Double_t> count;  //number of entries
 
-    for(vector<TH1F*>::const_iterator ith = hTMax.begin();
-	ith != hTMax.end(); ++ith) {
+    for (vector<TH1F *>::const_iterator ith = hTMax.begin(); ith != hTMax.end(); ++ith) {
       TF1 *funct = fitTMax(*ith);
-      if(!funct){
-	edm::LogError("DTMeanTimerFitter") << "Error when fitting TMax..histogram name" << (*ith)->GetName();
+      if (!funct) {
+        edm::LogError("DTMeanTimerFitter") << "Error when fitting TMax..histogram name" << (*ith)->GetName();
         // return empty or -1 filled vector?
-        vector<float> defvec(6,-1);
+        vector<float> defvec(6, -1);
         return defvec;
-      }			
+      }
       hDebugFile->cd();
       (*ith)->Write();
 
-    // Get mean, sigma and number of entries of each histogram
+      // Get mean, sigma and number of entries of each histogram
       mean.push_back(funct->GetParameter(1));
-      sigma.push_back(funct->GetParameter(2)); 
-      count.push_back((*ith)->GetEntries());  
-    } 
-  	  
-    Double_t tMaxMean=0.;
-    Double_t wTMaxSum=0.;
-    Double_t sigmaT=0.;
-    Double_t wSigmaSum = 0.;
-  
-    //calculate total mean and sigma
-    for(int i=0; i<=5; i++) {
-      if(count[i]<200) continue;
-      tMaxMean  += mean[i]*(count[i]/(sigma[i]*sigma[i]));
-      wTMaxSum  += count[i]/(sigma[i]*sigma[i]);
-      sigmaT    += count[i]*factor[i]*sigma[i];
-      wSigmaSum += count[i];
-      // cout << "TMaxMean "<<i<<": "<< mean[i] << " entries: " << count[i] 
-      // << " sigma: " << sigma[i] 
-      // << " weight: " << (count[i]/(sigma[i]*sigma[i])) << endl; 
+      sigma.push_back(funct->GetParameter(2));
+      count.push_back((*ith)->GetEntries());
     }
-    if((!wTMaxSum)||(!wSigmaSum)){
+
+    Double_t tMaxMean = 0.;
+    Double_t wTMaxSum = 0.;
+    Double_t sigmaT = 0.;
+    Double_t wSigmaSum = 0.;
+
+    //calculate total mean and sigma
+    for (int i = 0; i <= 5; i++) {
+      if (count[i] < 200)
+        continue;
+      tMaxMean += mean[i] * (count[i] / (sigma[i] * sigma[i]));
+      wTMaxSum += count[i] / (sigma[i] * sigma[i]);
+      sigmaT += count[i] * factor[i] * sigma[i];
+      wSigmaSum += count[i];
+      // cout << "TMaxMean "<<i<<": "<< mean[i] << " entries: " << count[i]
+      // << " sigma: " << sigma[i]
+      // << " weight: " << (count[i]/(sigma[i]*sigma[i])) << endl;
+    }
+    if ((!wTMaxSum) || (!wSigmaSum)) {
       edm::LogError("DTMeanTimerFitter") << "Error zero sum of weights..returning default";
-      vector<float> defvec(6,-1);
-      return defvec;	
+      vector<float> defvec(6, -1);
+      return defvec;
     }
 
     tMaxMean /= wTMaxSum;
     sigmaT /= wSigmaSum;
 
     //calculate v_drift and resolution
-    Double_t vDrift = 2.1 / tMaxMean; //2.1 is the half cell length in cm
+    Double_t vDrift = 2.1 / tMaxMean;  //2.1 is the half cell length in cm
     Double_t reso = vDrift * sigmaT;
     vDriftAndReso.push_back(vDrift);
     vDriftAndReso.push_back(reso);
     //if(theVerbosityLevel >= 1)
-    edm::LogVerbatim("DTMeanTimerFitter") << " final TMaxMean=" << tMaxMean << " sigma= "  << sigmaT 
-	   << " v_d and reso: " << vDrift << " " << reso << endl;
+    edm::LogVerbatim("DTMeanTimerFitter")
+        << " final TMaxMean=" << tMaxMean << " sigma= " << sigmaT << " v_d and reso: " << vDrift << " " << reso << endl;
 
     // Order t0 histogram by number of entries (choose histograms with higher nr. of entries)
-    map<Double_t,TH1F*> hEntries;    
-    for(vector<TH1F*>::const_iterator ith = hT0.begin();
-	ith != hT0.end(); ++ith) {
+    map<Double_t, TH1F *> hEntries;
+    for (vector<TH1F *>::const_iterator ith = hT0.begin(); ith != hT0.end(); ++ith) {
       hEntries[(*ith)->GetEntries()] = (*ith);
-    } 
-
-    // add at the end of hT0 the two hists with the higher number of entries 
-    int counter = 0;
-    for(map<Double_t,TH1F*>::reverse_iterator iter = hEntries.rbegin();
- 	iter != hEntries.rend(); ++iter) {
-      counter++;
-      if (counter==1) hT0.push_back(iter->second); 
-      else if (counter==2) {hT0.push_back(iter->second); break;} 
     }
-    
-    // Retrieve the gaussian mean and sigma of histograms for Delta(t0) evaluation   
+
+    // add at the end of hT0 the two hists with the higher number of entries
+    int counter = 0;
+    for (map<Double_t, TH1F *>::reverse_iterator iter = hEntries.rbegin(); iter != hEntries.rend(); ++iter) {
+      counter++;
+      if (counter == 1)
+        hT0.push_back(iter->second);
+      else if (counter == 2) {
+        hT0.push_back(iter->second);
+        break;
+      }
+    }
+
+    // Retrieve the gaussian mean and sigma of histograms for Delta(t0) evaluation
     vector<Double_t> meanT0;
-    vector<Double_t> sigmaT0; 
+    vector<Double_t> sigmaT0;
     vector<Double_t> countT0;
 
-    for(vector<TH1F*>::const_iterator ith = hT0.begin();
-	ith != hT0.end(); ++ith) {
-      try{
+    for (vector<TH1F *>::const_iterator ith = hT0.begin(); ith != hT0.end(); ++ith) {
+      try {
         (*ith)->Fit("gaus");
-      } catch(std::exception const&){
-        edm::LogError("DTMeanTimerFitter") << "Exception when fitting T0..histogram " << (*ith)->GetName();    
+      } catch (std::exception const &) {
+        edm::LogError("DTMeanTimerFitter") << "Exception when fitting T0..histogram " << (*ith)->GetName();
         // return empty or -1 filled vector?
-        vector<float> defvec(6,-1);
+        vector<float> defvec(6, -1);
         return defvec;
-      }	
+      }
       TF1 *f1 = (*ith)->GetFunction("gaus");
       // Get mean, sigma and number of entries of the  histograms
       meanT0.push_back(f1->GetParameter(1));
@@ -154,34 +151,31 @@ vector<float> DTMeanTimerFitter::evaluateVDriftAndReso (const TString& N) {
       countT0.push_back((*ith)->GetEntries());
     }
     //calculate Delta(t0)
-    if(hT0.size() != 6) { // check if you have all the t0 hists
+    if (hT0.size() != 6) {  // check if you have all the t0 hists
       edm::LogVerbatim("DTMeanTimerFitter") << "t0 histograms = " << hT0.size();
-      for(int i=1; i<=4;i++) {
-	vDriftAndReso.push_back(-1);
+      for (int i = 1; i <= 4; i++) {
+        vDriftAndReso.push_back(-1);
       }
       return vDriftAndReso;
     }
-    
-    for(int it0=0; it0<=2; it0++) {      
-      if((countT0[it0] > 200) && (countT0[it0+1] > 200)) {
-	Double_t deltaT0 = meanT0[it0] - meanT0[it0+1];	
-	vDriftAndReso.push_back(deltaT0);
-      }  
-      else
- 	vDriftAndReso.push_back(999.);
+
+    for (int it0 = 0; it0 <= 2; it0++) {
+      if ((countT0[it0] > 200) && (countT0[it0 + 1] > 200)) {
+        Double_t deltaT0 = meanT0[it0] - meanT0[it0 + 1];
+        vDriftAndReso.push_back(deltaT0);
+      } else
+        vDriftAndReso.push_back(999.);
     }
     //deltat0 using hists with max nr. of entries
-    if((countT0[4] > 200) && (countT0[5] > 200)) {
+    if ((countT0[4] > 200) && (countT0[5] > 200)) {
       Double_t t0Diff = histos->GetT0Factor(hT0[4]) - histos->GetT0Factor(hT0[5]);
-      Double_t deltaT0MaxEntries =  (meanT0[4] - meanT0[5])/ t0Diff;
+      Double_t deltaT0MaxEntries = (meanT0[4] - meanT0[5]) / t0Diff;
       vDriftAndReso.push_back(deltaT0MaxEntries);
-    }
-    else
+    } else
       vDriftAndReso.push_back(999.);
-  }
-  else {
-    for(int i=1; i<=6; i++) { 
-      // 0=vdrift, 1=reso,  2=(3deltat0-2deltat0), 3=(2deltat0-1deltat0), 
+  } else {
+    for (int i = 1; i <= 6; i++) {
+      // 0=vdrift, 1=reso,  2=(3deltat0-2deltat0), 3=(2deltat0-1deltat0),
       // 4=(1deltat0-0deltat0), 5=deltat0 from hists with max entries,
       vDriftAndReso.push_back(-1);
     }
@@ -189,29 +183,28 @@ vector<float> DTMeanTimerFitter::evaluateVDriftAndReso (const TString& N) {
   return vDriftAndReso;
 }
 
+TF1 *DTMeanTimerFitter::fitTMax(TH1F *histo) {
+  // Find distribution peak and fit range
+  Double_t peak = (((((histo->GetXaxis())->GetXmax()) - ((histo->GetXaxis())->GetXmin())) / histo->GetNbinsX()) *
+                   (histo->GetMaximumBin())) +
+                  ((histo->GetXaxis())->GetXmin());
+  //if(theVerbosityLevel >= 1)
+  LogDebug("DTMeanTimerFitter") << "Peak " << peak << " : "
+                                << "xmax " << ((histo->GetXaxis())->GetXmax()) << "            xmin "
+                                << ((histo->GetXaxis())->GetXmin()) << "            nbin " << histo->GetNbinsX()
+                                << "            bin with max " << (histo->GetMaximumBin());
+  Double_t range = 2. * histo->GetRMS();
 
-
-TF1* DTMeanTimerFitter::fitTMax(TH1F* histo){
- // Find distribution peak and fit range
-      Double_t peak = (((((histo->GetXaxis())->GetXmax())-((histo->GetXaxis())->GetXmin()))/histo->GetNbinsX())*
-		       (histo->GetMaximumBin()))+((histo->GetXaxis())->GetXmin());
-      //if(theVerbosityLevel >= 1)
-      LogDebug("DTMeanTimerFitter") <<"Peak "<<peak<<" : "<<"xmax "<<((histo->GetXaxis())->GetXmax())
-	    <<"            xmin "<<((histo->GetXaxis())->GetXmin())
-	    <<"            nbin "<<histo->GetNbinsX()
-	    <<"            bin with max "<<(histo->GetMaximumBin());
-      Double_t range = 2.*histo->GetRMS(); 
-
-      // Fit each Tmax histogram with a Gaussian in a restricted interval
-      TF1 *rGaus = new TF1("rGaus","gaus",peak-range,peak+range);
-      rGaus->SetMarkerSize();// just silence gcc complainining about unused var
-      try{	
-        histo->Fit("rGaus","R");
-      } catch(std::exception const&){
-	edm::LogError("DTMeanTimerFitter") << "Exception when fitting TMax..histogram " << histo->GetName()
-	     << "   setting return function pointer to zero";   
-	return nullptr;
-      }	
-      TF1 *f1 = histo->GetFunction("rGaus");
-      return f1;
- }
+  // Fit each Tmax histogram with a Gaussian in a restricted interval
+  TF1 *rGaus = new TF1("rGaus", "gaus", peak - range, peak + range);
+  rGaus->SetMarkerSize();  // just silence gcc complainining about unused var
+  try {
+    histo->Fit("rGaus", "R");
+  } catch (std::exception const &) {
+    edm::LogError("DTMeanTimerFitter") << "Exception when fitting TMax..histogram " << histo->GetName()
+                                       << "   setting return function pointer to zero";
+    return nullptr;
+  }
+  TF1 *f1 = histo->GetFunction("rGaus");
+  return f1;
+}

--- a/CalibMuon/DTCalibration/src/DTRecHitSegmentResidual.cc
+++ b/CalibMuon/DTCalibration/src/DTRecHitSegmentResidual.cc
@@ -14,36 +14,40 @@
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
 #include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
 
-float DTRecHitSegmentResidual::compute(const DTGeometry* dtGeom, const DTRecHit1D& recHit1D, const DTRecSegment4D& segment) {
-
+float DTRecHitSegmentResidual::compute(const DTGeometry* dtGeom,
+                                       const DTRecHit1D& recHit1D,
+                                       const DTRecSegment4D& segment) {
   const DTWireId wireId = recHit1D.wireId();
-      
+
   // Get the layer and the wire position
   const DTLayer* layer = dtGeom->layer(wireId);
   float wireX = layer->specificTopology().wirePosition(wireId.wire());
-      
+
   // Extrapolate the segment to the z of the wire
   // Get wire position in chamber RF
   // (y and z must be those of the hit to be coherent in the transf. of RF in case of rotations of the layer alignment)
-  LocalPoint wirePosInLay(wireX,recHit1D.localPosition().y(),recHit1D.localPosition().z());
+  LocalPoint wirePosInLay(wireX, recHit1D.localPosition().y(), recHit1D.localPosition().z());
   GlobalPoint wirePosGlob = layer->toGlobal(wirePosInLay);
   const DTChamber* chamber = dtGeom->chamber(wireId.layerId().chamberId());
   LocalPoint wirePosInChamber = chamber->toLocal(wirePosGlob);
-      
+
   // Segment position at Wire z in chamber local frame
-  LocalPoint segPosAtZWire = segment.localPosition() + segment.localDirection()*wirePosInChamber.z()/cos(segment.localDirection().theta());
-      
+  LocalPoint segPosAtZWire =
+      segment.localPosition() + segment.localDirection() * wirePosInChamber.z() / cos(segment.localDirection().theta());
+
   // Compute the distance of the segment from the wire
   int sl = wireId.superlayer();
   float segmDistance = -1;
-  if(sl == 1 || sl == 3) segmDistance = fabs(wirePosInChamber.x() - segPosAtZWire.x());
-  else if(sl == 2) segmDistance =  fabs(segPosAtZWire.y() - wirePosInChamber.y());
+  if (sl == 1 || sl == 3)
+    segmDistance = fabs(wirePosInChamber.x() - segPosAtZWire.x());
+  else if (sl == 2)
+    segmDistance = fabs(segPosAtZWire.y() - wirePosInChamber.y());
 
   // Compute the distance of the recHit from the wire
-  float recHitWireDist = fabs( recHit1D.localPosition().x() - wireX );
- 
-  // Compute the residuals 
+  float recHitWireDist = fabs(recHit1D.localPosition().x() - wireX);
+
+  // Compute the residuals
   float residualOnDistance = recHitWireDist - segmDistance;
 
-  return residualOnDistance; 
+  return residualOnDistance;
 }

--- a/CalibMuon/DTCalibration/src/DTResidualFitter.cc
+++ b/CalibMuon/DTCalibration/src/DTResidualFitter.cc
@@ -12,38 +12,36 @@
 #include "TF1.h"
 #include "TString.h"
 
-DTResidualFitter::DTResidualFitter(bool debug):debug_(debug) {}
+DTResidualFitter::DTResidualFitter(bool debug) : debug_(debug) {}
 
 DTResidualFitter::~DTResidualFitter() {}
 
-DTResidualFitResult DTResidualFitter::fitResiduals(TH1F& histo, int nSigmas){
-  
-   TString option("R");
-   if(!debug_) option += "Q";
- 
-   float under = histo.GetBinContent(0)/histo.GetEntries();
-   float over = histo.GetBinContent(histo.GetNbinsX()+1)/histo.GetEntries();
-   float minFit = histo.GetMean() - histo.GetRMS();
-   float maxFit = histo.GetMean() + histo.GetRMS();
+DTResidualFitResult DTResidualFitter::fitResiduals(TH1F& histo, int nSigmas) {
+  TString option("R");
+  if (!debug_)
+    option += "Q";
 
-   if ((under>0.1) || (over>0.1))
-     edm::LogError("DTResidualFitter") << "WARNING in histogram: " << histo.GetName() << "\n" 
-                                       << "             entries: " << histo.GetEntries() << "\n"
-                                       << "           underflow: " << under*100. << "% \n"
-                                       << "            overflow: " << over*100. << "%";
+  float under = histo.GetBinContent(0) / histo.GetEntries();
+  float over = histo.GetBinContent(histo.GetNbinsX() + 1) / histo.GetEntries();
+  float minFit = histo.GetMean() - histo.GetRMS();
+  float maxFit = histo.GetMean() + histo.GetRMS();
 
-   TString funcName = TString(histo.GetName()) + "_gaus";
-   TF1* fitFunc = new TF1(funcName,"gaus",minFit,maxFit);
+  if ((under > 0.1) || (over > 0.1))
+    edm::LogError("DTResidualFitter") << "WARNING in histogram: " << histo.GetName() << "\n"
+                                      << "             entries: " << histo.GetEntries() << "\n"
+                                      << "           underflow: " << under * 100. << "% \n"
+                                      << "            overflow: " << over * 100. << "%";
 
-   histo.Fit(fitFunc,option);
+  TString funcName = TString(histo.GetName()) + "_gaus";
+  TF1* fitFunc = new TF1(funcName, "gaus", minFit, maxFit);
 
-   minFit = fitFunc->GetParameter(1) - nSigmas*fitFunc->GetParameter(2);
-   maxFit = fitFunc->GetParameter(1) + nSigmas*fitFunc->GetParameter(2);
-   fitFunc->SetRange(minFit,maxFit);
-   histo.Fit(fitFunc,option);
+  histo.Fit(fitFunc, option);
 
-   return DTResidualFitResult( fitFunc->GetParameter(1),
-                               fitFunc->GetParError(1),
-                               fitFunc->GetParameter(2),
-                               fitFunc->GetParError(2) );
-} 
+  minFit = fitFunc->GetParameter(1) - nSigmas * fitFunc->GetParameter(2);
+  maxFit = fitFunc->GetParameter(1) + nSigmas * fitFunc->GetParameter(2);
+  fitFunc->SetRange(minFit, maxFit);
+  histo.Fit(fitFunc, option);
+
+  return DTResidualFitResult(
+      fitFunc->GetParameter(1), fitFunc->GetParError(1), fitFunc->GetParameter(2), fitFunc->GetParError(2));
+}

--- a/CalibMuon/DTCalibration/src/DTSegmentSelector.cc
+++ b/CalibMuon/DTCalibration/src/DTSegmentSelector.cc
@@ -13,125 +13,131 @@
 #include "CondFormats/DataRecord/interface/DTStatusFlagRcd.h"
 #include "CondFormats/DTObjects/interface/DTStatusFlag.h"
 
-DTSegmentSelector::DTSegmentSelector(edm::ParameterSet const& pset, edm::ConsumesCollector& iC):
-         muonTags_(pset.getParameter<edm::InputTag>("Muons")),
-         checkNoisyChannels_(pset.getParameter<bool>("checkNoisyChannels")),
-         minHitsPhi_(pset.getParameter<int>("minHitsPhi")),
-         minHitsZ_(pset.getParameter<int>("minHitsZ")),
-         maxChi2_(pset.getParameter<double>("maxChi2")),
-         maxAnglePhi_(pset.getParameter<double>("maxAnglePhi")),
-         maxAngleZ_(pset.getParameter<double>("maxAngleZ"))
-{
+DTSegmentSelector::DTSegmentSelector(edm::ParameterSet const& pset, edm::ConsumesCollector& iC)
+    : muonTags_(pset.getParameter<edm::InputTag>("Muons")),
+      checkNoisyChannels_(pset.getParameter<bool>("checkNoisyChannels")),
+      minHitsPhi_(pset.getParameter<int>("minHitsPhi")),
+      minHitsZ_(pset.getParameter<int>("minHitsZ")),
+      maxChi2_(pset.getParameter<double>("maxChi2")),
+      maxAnglePhi_(pset.getParameter<double>("maxAnglePhi")),
+      maxAngleZ_(pset.getParameter<double>("maxAngleZ")) {
   muonToken_ = iC.consumes<reco::MuonCollection>(muonTags_);
 }
 
-
-bool DTSegmentSelector::operator() (DTRecSegment4D const& segment, edm::Event const& event, edm::EventSetup const& setup){
-
+bool DTSegmentSelector::operator()(DTRecSegment4D const& segment,
+                                   edm::Event const& event,
+                                   edm::EventSetup const& setup) {
   bool result = true;
 
   /* get the muon collection if one is specified
     (not specifying a muon collection switches off muon matching */
   if (!muonTags_.label().empty()) {
     edm::Handle<reco::MuonCollection> muonH;
-    event.getByToken(muonToken_,muonH);
+    event.getByToken(muonToken_, muonH);
     const std::vector<reco::Muon>* muons = muonH.product();
     //std::cout << " Muon collection size: " << muons->size() << std::endl;
-    if (muons->empty()) return false;
+    if (muons->empty())
+      return false;
 
     DTChamberId segId(segment.rawId());
 
     bool matched = false;
-    for (auto &imuon : *muons) 
-      for (const auto &ch : imuon.matches()) {
+    for (auto& imuon : *muons)
+      for (const auto& ch : imuon.matches()) {
         DetId chId(ch.id.rawId());
-        if (chId!=segId) continue;
-        if ( imuon.pt()<15 || !imuon.isGlobalMuon()) continue;
+        if (chId != segId)
+          continue;
+        if (imuon.pt() < 15 || !imuon.isGlobalMuon())
+          continue;
 
-        int nsegs=ch.segmentMatches.size();
-        if (!nsegs) continue;
+        int nsegs = ch.segmentMatches.size();
+        if (!nsegs)
+          continue;
 
         LocalPoint posHit = segment.localPosition();
-        float dx = (posHit.x() ? posHit.x()-ch.x : 0 );
-        float dy = (posHit.y() ? posHit.y()-ch.y : 0 );
-        float dr = sqrt(dx*dx+dy*dy);
-        if (dr<5) matched=true;
+        float dx = (posHit.x() ? posHit.x() - ch.x : 0);
+        float dy = (posHit.y() ? posHit.y() - ch.y : 0);
+        float dr = sqrt(dx * dx + dy * dy);
+        if (dr < 5)
+          matched = true;
       }
 
-    if (!matched) result=false;
+    if (!matched)
+      result = false;
   }
 
-
-
   edm::ESHandle<DTStatusFlag> statusMap;
-  if(checkNoisyChannels_) setup.get<DTStatusFlagRcd>().get(statusMap);
+  if (checkNoisyChannels_)
+    setup.get<DTStatusFlagRcd>().get(statusMap);
 
   // Get the Phi 2D segment
   int nPhiHits = -1;
   bool segmentNoisyPhi = false;
-  if( segment.hasPhi() ){
-     const DTChamberRecSegment2D* phiSeg = segment.phiSegment();  // phiSeg lives in the chamber RF
-     std::vector<DTRecHit1D> phiRecHits = phiSeg->specificRecHits();
-     nPhiHits = phiRecHits.size(); 
-     if(checkNoisyChannels_) segmentNoisyPhi = checkNoisySegment(statusMap,phiRecHits);
-  //} else result = false;
+  if (segment.hasPhi()) {
+    const DTChamberRecSegment2D* phiSeg = segment.phiSegment();  // phiSeg lives in the chamber RF
+    std::vector<DTRecHit1D> phiRecHits = phiSeg->specificRecHits();
+    nPhiHits = phiRecHits.size();
+    if (checkNoisyChannels_)
+      segmentNoisyPhi = checkNoisySegment(statusMap, phiRecHits);
+    //} else result = false;
   }
   // Get the Theta 2D segment
   int nZHits = -1;
   bool segmentNoisyZ = false;
-  if( segment.hasZed() ){
-     const DTSLRecSegment2D* zSeg = segment.zSegment();  // zSeg lives in the SL RF
-     std::vector<DTRecHit1D> zRecHits = zSeg->specificRecHits();
-     nZHits = zRecHits.size();
-     if(checkNoisyChannels_) segmentNoisyZ = checkNoisySegment(statusMap,zRecHits);
-  } 
+  if (segment.hasZed()) {
+    const DTSLRecSegment2D* zSeg = segment.zSegment();  // zSeg lives in the SL RF
+    std::vector<DTRecHit1D> zRecHits = zSeg->specificRecHits();
+    nZHits = zRecHits.size();
+    if (checkNoisyChannels_)
+      segmentNoisyZ = checkNoisySegment(statusMap, zRecHits);
+  }
 
-  // Segment selection 
+  // Segment selection
   // Discard segment if it has a noisy cell
-  if(segmentNoisyPhi || segmentNoisyZ)
+  if (segmentNoisyPhi || segmentNoisyZ)
     result = false;
 
   // 2D-segment number of hits
-  if(segment.hasPhi() && nPhiHits < minHitsPhi_)
+  if (segment.hasPhi() && nPhiHits < minHitsPhi_)
     result = false;
 
-  if(segment.hasZed() && nZHits < minHitsZ_)
+  if (segment.hasZed() && nZHits < minHitsZ_)
     result = false;
 
   // Segment chi2
-  double chiSquare = segment.chi2()/segment.degreesOfFreedom();
-  if(chiSquare > maxChi2_)
+  double chiSquare = segment.chi2() / segment.degreesOfFreedom();
+  if (chiSquare > maxChi2_)
     result = false;
 
   // Segment angle
   LocalVector segment4DLocalDir = segment.localDirection();
-  double angleZ = fabs( atan(segment4DLocalDir.y()/segment4DLocalDir.z())*180./Geom::pi() ); 
-  if( angleZ > maxAngleZ_)
+  double angleZ = fabs(atan(segment4DLocalDir.y() / segment4DLocalDir.z()) * 180. / Geom::pi());
+  if (angleZ > maxAngleZ_)
     result = false;
 
-  double anglePhi = fabs( atan(segment4DLocalDir.x()/segment4DLocalDir.z())*180./Geom::pi() );
-  if( anglePhi > maxAnglePhi_)
+  double anglePhi = fabs(atan(segment4DLocalDir.x() / segment4DLocalDir.z()) * 180. / Geom::pi());
+  if (anglePhi > maxAnglePhi_)
     result = false;
 
   return result;
 }
 
-bool DTSegmentSelector::checkNoisySegment(edm::ESHandle<DTStatusFlag> const& statusMap, std::vector<DTRecHit1D> const& dtHits){
-
+bool DTSegmentSelector::checkNoisySegment(edm::ESHandle<DTStatusFlag> const& statusMap,
+                                          std::vector<DTRecHit1D> const& dtHits) {
   bool segmentNoisy = false;
 
   std::vector<DTRecHit1D>::const_iterator dtHit = dtHits.begin();
   std::vector<DTRecHit1D>::const_iterator dtHits_end = dtHits.end();
-  for(; dtHit != dtHits_end; ++dtHit){
-     DTWireId wireId = dtHit->wireId();
-     // Check for noisy channels to skip them
-     bool isNoisy = false, isFEMasked = false, isTDCMasked = false, isTrigMask = false,
-          isDead = false, isNohv = false;
-     statusMap->cellStatus(wireId, isNoisy, isFEMasked, isTDCMasked, isTrigMask, isDead, isNohv);
-     if(isNoisy) {
-        LogTrace("Calibration") << "Wire: " << wireId << " is noisy, skipping!";
-        segmentNoisy = true; break;
-     }
+  for (; dtHit != dtHits_end; ++dtHit) {
+    DTWireId wireId = dtHit->wireId();
+    // Check for noisy channels to skip them
+    bool isNoisy = false, isFEMasked = false, isTDCMasked = false, isTrigMask = false, isDead = false, isNohv = false;
+    statusMap->cellStatus(wireId, isNoisy, isFEMasked, isTDCMasked, isTrigMask, isDead, isNohv);
+    if (isNoisy) {
+      LogTrace("Calibration") << "Wire: " << wireId << " is noisy, skipping!";
+      segmentNoisy = true;
+      break;
+    }
   }
   return segmentNoisy;
 }

--- a/CalibMuon/DTCalibration/src/DTT0BaseCorrection.cc
+++ b/CalibMuon/DTCalibration/src/DTT0BaseCorrection.cc
@@ -9,6 +9,6 @@
 
 using dtCalibration::DTT0BaseCorrection;
 
-DTT0BaseCorrection::DTT0BaseCorrection(){}
+DTT0BaseCorrection::DTT0BaseCorrection() {}
 
-DTT0BaseCorrection::~DTT0BaseCorrection(){}
+DTT0BaseCorrection::~DTT0BaseCorrection() {}

--- a/CalibMuon/DTCalibration/src/DTT0CorrectionFactory.cc
+++ b/CalibMuon/DTCalibration/src/DTT0CorrectionFactory.cc
@@ -6,4 +6,4 @@
 
 #include "CalibMuon/DTCalibration/interface/DTT0CorrectionFactory.h"
 
-EDM_REGISTER_PLUGINFACTORY(DTT0CorrectionFactory,"DTT0CorrectionFactory");
+EDM_REGISTER_PLUGINFACTORY(DTT0CorrectionFactory, "DTT0CorrectionFactory");

--- a/CalibMuon/DTCalibration/src/DTTMax.cc
+++ b/CalibMuon/DTCalibration/src/DTTMax.cc
@@ -18,44 +18,44 @@ using namespace std;
 using namespace dttmaxenums;
 using namespace DTEnums;
 
-DTTMax::InfoLayer::InfoLayer(const DTRecHit1D& rh_, const DTSuperLayer & isl, GlobalVector dir,
-			     GlobalPoint pos, const DTTTrigBaseSync& sync):
-  rh(rh_), idWire(rh.wireId()), lr(rh.lrSide()) {
-    const DTLayer*  layer = isl.layer(idWire.layerId());
-    LocalPoint wirePosInLayer(layer->specificTopology().wirePosition(idWire.wire()), 0, 0);
-    LocalPoint wirePosInSL=isl.toLocal(layer->toGlobal(wirePosInLayer));
-    wireX = wirePosInSL.x();
-    
-    //-- Correction for signal propagation along wire, t0 subtraction,
-    LocalVector segDir =  layer->toLocal(dir);
-    LocalPoint segPos = layer->toLocal(pos);
-    LocalPoint segPosAtLayer = segPos + segDir*(-segPos.z())/cos(segDir.theta());
-    LocalPoint hitPos(rh.localPosition().x() ,segPosAtLayer.y(),0.);
-    time = rh.digiTime() - sync.offset(layer, idWire, layer->toGlobal(hitPos));
- 
-    if (time < 0. || time > 415.) {
-      // FIXME introduce time window to reject "out-of-time" digis
-      cout << " *** WARNING time = " << time << endl;
-    }
+DTTMax::InfoLayer::InfoLayer(
+    const DTRecHit1D& rh_, const DTSuperLayer& isl, GlobalVector dir, GlobalPoint pos, const DTTTrigBaseSync& sync)
+    : rh(rh_), idWire(rh.wireId()), lr(rh.lrSide()) {
+  const DTLayer* layer = isl.layer(idWire.layerId());
+  LocalPoint wirePosInLayer(layer->specificTopology().wirePosition(idWire.wire()), 0, 0);
+  LocalPoint wirePosInSL = isl.toLocal(layer->toGlobal(wirePosInLayer));
+  wireX = wirePosInSL.x();
+
+  //-- Correction for signal propagation along wire, t0 subtraction,
+  LocalVector segDir = layer->toLocal(dir);
+  LocalPoint segPos = layer->toLocal(pos);
+  LocalPoint segPosAtLayer = segPos + segDir * (-segPos.z()) / cos(segDir.theta());
+  LocalPoint hitPos(rh.localPosition().x(), segPosAtLayer.y(), 0.);
+  time = rh.digiTime() - sync.offset(layer, idWire, layer->toGlobal(hitPos));
+
+  if (time < 0. || time > 415.) {
+    // FIXME introduce time window to reject "out-of-time" digis
+    cout << " *** WARNING time = " << time << endl;
   }
+}
 
-
-DTTMax::DTTMax(const vector<DTRecHit1D>& hits, const DTSuperLayer & isl, GlobalVector dir, 
-	       GlobalPoint pos, const DTTTrigBaseSync& sync):
-  theInfoLayers(4,(InfoLayer*)nullptr), //FIXME
-  theTMaxes(4,(TMax*)nullptr) 
-{
+DTTMax::DTTMax(const vector<DTRecHit1D>& hits,
+               const DTSuperLayer& isl,
+               GlobalVector dir,
+               GlobalPoint pos,
+               const DTTTrigBaseSync& sync)
+    : theInfoLayers(4, (InfoLayer*)nullptr),  //FIXME
+      theTMaxes(4, (TMax*)nullptr) {
   // debug parameter for verbose output
   debug = "true";
 
   // Collect all information using InfoLayer
-  for (vector<DTRecHit1D>::const_iterator hit=hits.begin(); hit!=hits.end();
-       ++hit) {
+  for (vector<DTRecHit1D>::const_iterator hit = hits.begin(); hit != hits.end(); ++hit) {
     //     cout << "Hit Pos " << (*hit).localPosition() << endl;
-    
+
     InfoLayer* layInfo = new InfoLayer((*hit), isl, dir, pos, sync);
     int ilay = layInfo->idWire.layer();
-    if (getInfoLayer(ilay)==nullptr) {
+    if (getInfoLayer(ilay) == nullptr) {
       getInfoLayer(ilay) = layInfo;
     } else {
       // FIXME: in case there is > 1 hit/layer, the first is taken and the others are IGNORED.
@@ -64,31 +64,33 @@ DTTMax::DTTMax(const vector<DTRecHit1D>& hits, const DTSuperLayer & isl, GlobalV
   }
 
   // Get the segment direction
-  theSegDir = ((isl.toLocal(dir).x() < 0)? L : R);
+  theSegDir = ((isl.toLocal(dir).x() < 0) ? L : R);
 
-  int layersIn = 0; 
-  int nGoodHits=0;
-  for(vector<InfoLayer*>::const_iterator ilay =  theInfoLayers.begin();
-      ilay != theInfoLayers.end(); ++ilay) {
-    if ((*ilay) == nullptr ) {
-      theSegType+= "X";
+  int layersIn = 0;
+  int nGoodHits = 0;
+  for (vector<InfoLayer*>::const_iterator ilay = theInfoLayers.begin(); ilay != theInfoLayers.end(); ++ilay) {
+    if ((*ilay) == nullptr) {
+      theSegType += "X";
       continue;
     }
-    DTEnums::DTCellSide lOrR =(*ilay)->lr;
-    if(lOrR == Left) theSegType+= "L";
-    else if (lOrR == Right) theSegType+="R"; 
-    else theSegType+= "X";
-    
+    DTEnums::DTCellSide lOrR = (*ilay)->lr;
+    if (lOrR == Left)
+      theSegType += "L";
+    else if (lOrR == Right)
+      theSegType += "R";
+    else
+      theSegType += "X";
+
     // layersIn : 6 =  layers 1,2,3
     //            7 =         1,2,4
     //            8 =         1,3,4
     //            9 =         2,3,4
-    //            10=         1,2,3,4  
+    //            10=         1,2,3,4
     layersIn += (*ilay)->idWire.layer();
     nGoodHits++;
   }
 
-  if(nGoodHits >=3 && (theSegType != "RRRR" && theSegType != "LLLL")) {
+  if (nGoodHits >= 3 && (theSegType != "RRRR" && theSegType != "LLLL")) {
     float t1 = 0.;
     float t2 = 0.;
     float t3 = 0.;
@@ -98,30 +100,30 @@ DTTMax::DTTMax(const vector<DTRecHit1D>& hits, const DTSuperLayer & isl, GlobalV
     float x3 = 0.;
     float x4 = 0.;
 
-    if(layersIn <= 8  || layersIn == 10) {
-      t1 = getInfoLayer(1)->time; 	
-      x1 = getInfoLayer(1)->wireX;      
+    if (layersIn <= 8 || layersIn == 10) {
+      t1 = getInfoLayer(1)->time;
+      x1 = getInfoLayer(1)->wireX;
     }
-    if(layersIn <= 7  || layersIn >= 9) {
-      t2 = getInfoLayer(2)->time; 
-      x2 = getInfoLayer(2)->wireX;	      
+    if (layersIn <= 7 || layersIn >= 9) {
+      t2 = getInfoLayer(2)->time;
+      x2 = getInfoLayer(2)->wireX;
     }
-    if(layersIn == 6  || layersIn >= 8) {
-      t3 = getInfoLayer(3)->time; 
-      x3 = getInfoLayer(3)->wireX;	      
+    if (layersIn == 6 || layersIn >= 8) {
+      t3 = getInfoLayer(3)->time;
+      x3 = getInfoLayer(3)->wireX;
     }
-    if( layersIn >= 7) {
+    if (layersIn >= 7) {
       t4 = getInfoLayer(4)->time;
       x4 = getInfoLayer(4)->wireX;
     }
-    
+
     float t = 0.;
     TMaxCells cGroup = notInit;
     string type;
-    SigmaFactor sigma = noR; // Return the factor relating the width of the TMax distribution and the cell resolution
-    float halfCell = 2.1;    // 2.1 is the half cell length in cm
-    float delta = 0.5;       // (diff. wire pos.) < delta, halfCell+delta, .....
-    unsigned t0Factor = 99;  // "quantity" of Delta(t0) included in the tmax formula
+    SigmaFactor sigma = noR;  // Return the factor relating the width of the TMax distribution and the cell resolution
+    float halfCell = 2.1;     // 2.1 is the half cell length in cm
+    float delta = 0.5;        // (diff. wire pos.) < delta, halfCell+delta, .....
+    unsigned t0Factor = 99;   // "quantity" of Delta(t0) included in the tmax formula
 
     //Debug
     if (debug) {
@@ -129,217 +131,189 @@ DTTMax::DTTMax(const vector<DTRecHit1D>& hits, const DTSuperLayer & isl, GlobalV
       cout << "t1, t2, t3, t4: " << t1 << " " << t2 << " " << t3 << " " << t4 << endl;
       cout << "x1, x2, x3, x4: " << x1 << " " << x2 << " " << x3 << " " << x4 << endl;
     }
-    
+
     //different t0 hists (if you have at least one hit within a certain distance from the wire)
-    unsigned hSubGroup = 99; //
-    if(t1 == 0. || t2 == 0. || t3 == 0. || t4 == 0.)
-      hSubGroup = 0; //if only 3 hits
-    else if(t1<=5. || t2<=5. || t3<=5. || t4<=5.)
-      hSubGroup = 1; //if distance of one hit from wire < 275um (v_drift=55um/ns) 
-    else if(t1<=10. || t2<=10. || t3<=10. || t4<=10.)
+    unsigned hSubGroup = 99;  //
+    if (t1 == 0. || t2 == 0. || t3 == 0. || t4 == 0.)
+      hSubGroup = 0;  //if only 3 hits
+    else if (t1 <= 5. || t2 <= 5. || t3 <= 5. || t4 <= 5.)
+      hSubGroup = 1;  //if distance of one hit from wire < 275um (v_drift=55um/ns)
+    else if (t1 <= 10. || t2 <= 10. || t3 <= 10. || t4 <= 10.)
       hSubGroup = 2;
-    else if(t1<=20. || t2<=20. || t3<=20. || t4<=20.)
+    else if (t1 <= 20. || t2 <= 20. || t3 <= 20. || t4 <= 20.)
       hSubGroup = 3;
-    else if(t1<=50. || t2<=50. || t3<=50. || t4<=50.)
+    else if (t1 <= 50. || t2 <= 50. || t3 <= 50. || t4 <= 50.)
       hSubGroup = 4;
 
-    if((layersIn == 6 || layersIn == 10) && (fabs(x1-x3)<delta)) {
+    if ((layersIn == 6 || layersIn == 10) && (fabs(x1 - x3) < delta)) {
       cGroup = c123;
-      ((type+=theSegType[0])+=theSegType[1])+=theSegType[2];
+      ((type += theSegType[0]) += theSegType[1]) += theSegType[2];
       sigma = r32;
-      if(type == "LRL" || type == "RLR") {
-	t0Factor = 2;
-	t = (t1+t3)/2.+t2;
-	hT123LRL->Fill(t);
+      if (type == "LRL" || type == "RLR") {
+        t0Factor = 2;
+        t = (t1 + t3) / 2. + t2;
+        hT123LRL->Fill(t);
+      } else if ((type == "LLR" && theSegDir == R) || (type == "RRL" && theSegDir == L)) {
+        t0Factor = 1;
+        t = (t3 - t1) / 2. + t2;
+        hT123LLR->Fill(t);
+      } else if ((type == "LRR" && theSegDir == R) || (type == "RLL" && theSegDir == L)) {
+        t0Factor = 1;
+        t = (t1 - t3) / 2. + t2;
+        hT123LRR->Fill(t);
+      } else {
+        t = -1.;
+        sigma = noR;
+        hT123Bad->Fill(t);
       }
-      else if((type == "LLR" && theSegDir == R) ||
-	      (type == "RRL" && theSegDir == L)) {
-	t0Factor = 1;
-	t = (t3-t1)/2.+t2;
-	hT123LLR->Fill(t);
-      }
-      else if((type == "LRR" && theSegDir == R) ||
-	      (type == "RLL" && theSegDir == L)) {
-	t0Factor = 1;
-	t = (t1-t3)/2.+t2;
-	hT123LRR->Fill(t);
-      }
-      else {
-	t = -1.;
-	sigma = noR;
-	hT123Bad->Fill(t);
-      }
-      theTMaxes[cGroup] = new TMax(t,cGroup,type,sigma,t0Factor,hSubGroup);
-      if(debug) cout << "tmax123 " << t << " " << type << endl;
+      theTMaxes[cGroup] = new TMax(t, cGroup, type, sigma, t0Factor, hSubGroup);
+      if (debug)
+        cout << "tmax123 " << t << " " << type << endl;
     }
-    if(layersIn == 7 || layersIn == 10) {
+    if (layersIn == 7 || layersIn == 10) {
       cGroup = c124;
       type.clear();
       sigma = r72;
-      ((type+=theSegType[0])+=theSegType[1])+=theSegType[3];
-      if((theSegType == "LRLR" && type == "LRR" && x1 > x4) ||
-	 (theSegType == "RLRL" && type == "RLL" && x1 < x4)) {
-	t0Factor = 2;
-	t = 1.5*t2+t1-t4/2.;
-	hT124LRR1gt4->Fill(t);
+      ((type += theSegType[0]) += theSegType[1]) += theSegType[3];
+      if ((theSegType == "LRLR" && type == "LRR" && x1 > x4) || (theSegType == "RLRL" && type == "RLL" && x1 < x4)) {
+        t0Factor = 2;
+        t = 1.5 * t2 + t1 - t4 / 2.;
+        hT124LRR1gt4->Fill(t);
+      } else if ((type == "LLR" && theSegDir == R && (fabs(x2 - x4) < delta) && x1 < x2) ||
+                 (type == "RRL" && theSegDir == L && (fabs(x2 - x4) < delta) && x1 > x2)) {
+        t0Factor = 1;
+        t = 1.5 * t2 - t1 + t4 / 2.;
+        hT124LLR->Fill(t);
+      } else if ((type == "LLL" && theSegDir == R && (fabs(x2 - x4) < delta) && x1 < x2) ||
+                 (type == "RRR" && theSegDir == L && (fabs(x2 - x4) < delta) && x1 > x2)) {
+        t0Factor = 0;
+        t = 1.5 * t2 - t1 - t4 / 2.;
+        hT124LLLR->Fill(t);
+      } else if ((type == "LLL" && theSegDir == L && (fabs(x2 - x4) < delta)) ||
+                 (type == "RRR" && theSegDir == R && (fabs(x2 - x4) < delta))) {
+        t0Factor = 0;
+        t = -1.5 * t2 + t1 + t4 / 2.;
+        hT124LLLL->Fill(t);
+      } else if ((type == "LRL" && theSegDir == L && (fabs(x2 - x4) < delta)) ||
+                 (type == "RLR" && theSegDir == R && (fabs(x2 - x4) < delta))) {
+        t0Factor = 3;
+        t = 1.5 * t2 + t1 + t4 / 2.;
+        hT124LRLL->Fill(t);
+      } else if ((type == "LRL" && theSegDir == R && (fabs(x1 - x4) < (halfCell + delta))) ||
+                 (type == "RLR" && theSegDir == L && (fabs(x1 - x4) < (halfCell + delta)))) {
+        t0Factor = 99;  // it's actually 1.5, but this value it's not used
+        t = 3. / 4. * t2 + t1 / 2. + t4 / 4.;
+        sigma = r78;
+        hT124LRLR->Fill(t);
+      } else if ((type == "LRR" && theSegDir == R && x1 < x4 && (fabs(x1 - x4) < (halfCell + delta))) ||
+                 (type == "RLL" && theSegDir == L && x1 > x4 && (fabs(x1 - x4) < (halfCell + delta)))) {
+        t0Factor = 1;
+        t = 3. / 4. * t2 + t1 / 2. - t4 / 4.;
+        sigma = r78;
+        hT124LRR1lt4->Fill(t);
+      } else {
+        t = -1.;
+        sigma = noR;
+        hT124Bad->Fill(t);
       }
-      else if((type == "LLR" && theSegDir == R && (fabs(x2-x4)<delta) && x1 < x2) ||
-	      (type == "RRL" && theSegDir == L && (fabs(x2-x4)<delta) && x1 > x2)) {
-	t0Factor = 1;
-	t = 1.5*t2-t1+t4/2.;
-	hT124LLR->Fill(t);
-      }
-      else if((type == "LLL" && theSegDir == R && (fabs(x2-x4)<delta) && x1 < x2) ||
-	      (type == "RRR" && theSegDir == L && (fabs(x2-x4)<delta) && x1 > x2)) {
-	t0Factor = 0;
-	t = 1.5*t2-t1-t4/2.;
-	hT124LLLR->Fill(t);
-      }
-      else if((type == "LLL" && theSegDir == L && (fabs(x2-x4)<delta)) ||
-	      (type == "RRR" && theSegDir == R && (fabs(x2-x4)<delta))) {
-	t0Factor = 0;
-	t = -1.5*t2+t1+t4/2.;
-	hT124LLLL->Fill(t);
-      } 
-      else if((type == "LRL" && theSegDir == L && (fabs(x2-x4)<delta)) ||
-	      (type == "RLR" && theSegDir == R && (fabs(x2-x4)<delta))) {
-	t0Factor = 3;
-	t = 1.5*t2+t1+t4/2.;
-	hT124LRLL->Fill(t);
-      }
-      else if((type == "LRL" && theSegDir == R && (fabs(x1-x4)<(halfCell+delta))) ||
-	      (type == "RLR" && theSegDir == L && (fabs(x1-x4)<(halfCell+delta)))) {
-	t0Factor = 99;  // it's actually 1.5, but this value it's not used  
-	t = 3./4.*t2+t1/2.+t4/4.;
-	sigma = r78;
-	hT124LRLR->Fill(t);
-      }
-      else if((type == "LRR" && theSegDir == R && x1 < x4 && (fabs(x1-x4)<(halfCell+delta)))||
-	       (type == "RLL" && theSegDir == L && x1 > x4 && (fabs(x1-x4)<(halfCell+delta)))) {
-	t0Factor = 1;
-	t = 3./4.*t2+t1/2.-t4/4.;
-	sigma = r78;
-	hT124LRR1lt4->Fill(t);
-      }
-      else {
-	t = -1.; 
-	sigma = noR;
-	hT124Bad->Fill(t);
-      }
-      theTMaxes[cGroup] = new TMax(t,cGroup,type,sigma,t0Factor,hSubGroup);
-      if(debug) cout << "tmax124 " << t << " " << t0Factor << " "  << type << endl;
+      theTMaxes[cGroup] = new TMax(t, cGroup, type, sigma, t0Factor, hSubGroup);
+      if (debug)
+        cout << "tmax124 " << t << " " << t0Factor << " " << type << endl;
     }
-    if(layersIn == 8 || layersIn == 10) {
+    if (layersIn == 8 || layersIn == 10) {
       cGroup = c134;
       type.clear();
-      ((type+=theSegType[0])+=theSegType[2])+=theSegType[3];
+      ((type += theSegType[0]) += theSegType[2]) += theSegType[3];
       sigma = r72;
-      if((type == "LLR" && x1 > x4 && theSegType == "LRLR") ||
-	 (type == "RRL" && x1 < x4 && theSegType == "RLRL")) {
-	t0Factor = 2;
-	t = 1.5*t3+t4-t1/2.;
-	hT134LLR1gt4->Fill(t);
+      if ((type == "LLR" && x1 > x4 && theSegType == "LRLR") || (type == "RRL" && x1 < x4 && theSegType == "RLRL")) {
+        t0Factor = 2;
+        t = 1.5 * t3 + t4 - t1 / 2.;
+        hT134LLR1gt4->Fill(t);
+      } else if ((type == "LLR" && x1 < x4 && (fabs(x1 - x4) < (halfCell + delta))) ||
+                 (type == "RRL" && x1 > x4 && (fabs(x1 - x4) < (halfCell + delta)))) {
+        t0Factor = 1;
+        t = 3. / 4. * t3 + t4 / 2. - t1 / 4.;
+        sigma = r78;
+        hT134LLR1lt4->Fill(t);
+      } else if ((type == "LRR" && theSegDir == R && x1 < x4 && (fabs(x1 - x3) < delta)) ||
+                 (type == "RLL" && theSegDir == L && x1 > x4 && (fabs(x1 - x3) < delta))) {
+        t0Factor = 1;
+        t = 1.5 * t3 - t4 + t1 / 2.;
+        hT134LRR->Fill(t);
+      } else if ((type == "LRL" && theSegDir == R && (fabs(x1 - x3) < delta)) ||
+                 (type == "RLR" && theSegDir == L && (fabs(x1 - x3) < delta))) {
+        t0Factor = 3;
+        t = 1.5 * t3 + t4 + t1 / 2.;
+        hT134LRLR->Fill(t);
+      } else if ((type == "LRL" && theSegDir == L && (fabs(x1 - x3) < (2. * halfCell + delta))) ||
+                 (type == "RLR" && theSegDir == R && (fabs(x1 - x3) < (2. * halfCell + delta)))) {
+        t0Factor = 99;  // it's actually 1.5, but this value it's not used
+        t = 3. / 4. * t3 + t4 / 2. + t1 / 4.;
+        sigma = r78;
+        hT134LRLL->Fill(t);
+      } else if ((type == "LLL" && theSegDir == L && x1 > x4 && (fabs(x1 - x3) < delta)) ||
+                 (type == "RRR" && theSegDir == R && x1 < x4 && (fabs(x1 - x3) < delta))) {
+        t0Factor = 0;
+        t = 1.5 * t3 - t4 - t1 / 2.;
+        hT134LLLL->Fill(t);
+      } else if ((type == "LLL" && theSegDir == R && (fabs(x1 - x3) < delta)) ||
+                 (type == "RRR" && theSegDir == L && (fabs(x1 - x3) < delta))) {
+        t0Factor = 0;
+        t = -1.5 * t3 + t4 + t1 / 2.;
+        hT134LLLR->Fill(t);
+      } else {
+        t = -1;
+        sigma = noR;
+        hT134Bad->Fill(t);
       }
-      else if((type == "LLR"  && x1 < x4 && (fabs(x1-x4)<(halfCell+delta))) ||
-	       (type == "RRL"  && x1 > x4 && (fabs(x1-x4)<(halfCell+delta)))) {
-	t0Factor = 1;
-	t = 3./4.*t3+t4/2.-t1/4.; 
-	sigma = r78;
-	hT134LLR1lt4->Fill(t);
-      }
-      else if((type == "LRR"  && theSegDir == R && x1 < x4 && (fabs(x1-x3)<delta)) ||
-	       (type == "RLL"  && theSegDir == L && x1 > x4 &&(fabs(x1-x3)<delta))) {
-	t0Factor = 1;
-	t = 1.5*t3-t4+t1/2.;
-	hT134LRR->Fill(t);
-      }
-      else if((type == "LRL"  && theSegDir == R && (fabs(x1-x3)<delta)) ||
-	      (type == "RLR"  && theSegDir == L && (fabs(x1-x3)<delta))) {
-	t0Factor = 3;
-	t = 1.5*t3+t4+t1/2.;
-	hT134LRLR->Fill(t);
-      }
-      else if((type == "LRL"  && theSegDir == L && (fabs(x1-x3)<(2.*halfCell+delta))) ||
-	      (type == "RLR"  && theSegDir == R && (fabs(x1-x3)<(2.*halfCell+delta)))) {
-	t0Factor = 99; // it's actually 1.5, but this value it's not used  
-	t = 3./4.*t3+t4/2.+t1/4.;
-	sigma = r78;
-	hT134LRLL->Fill(t);
-      }
-      else if((type == "LLL"  && theSegDir == L && x1 > x4 && (fabs(x1-x3)<delta)) ||
-	      (type == "RRR"  && theSegDir == R && x1 < x4 && (fabs(x1-x3)<delta))) {
-	t0Factor = 0;
-	t = 1.5*t3-t4-t1/2.;
-	hT134LLLL->Fill(t);	
-      }
-      else if((type == "LLL"  && theSegDir == R && (fabs(x1-x3)<delta)) ||
-	      (type == "RRR"  && theSegDir == L && (fabs(x1-x3)<delta))) {
-	t0Factor = 0;
-	t = -1.5*t3+t4+t1/2.;
-	hT134LLLR->Fill(t);
-      }
-      else {
-	t = -1;
-	sigma = noR;
-	hT134Bad->Fill(t);
-      }
-      theTMaxes[cGroup] = new TMax(t,cGroup,type,sigma,t0Factor,hSubGroup);
-      if(debug) cout << "tmax134 " << t << " " << t0Factor << " "  << type << endl;
+      theTMaxes[cGroup] = new TMax(t, cGroup, type, sigma, t0Factor, hSubGroup);
+      if (debug)
+        cout << "tmax134 " << t << " " << t0Factor << " " << type << endl;
     }
-    if((layersIn == 9 || layersIn == 10) && (fabs(x2-x4)<delta)) {
+    if ((layersIn == 9 || layersIn == 10) && (fabs(x2 - x4) < delta)) {
       cGroup = c234;
       type.clear();
-      ((type+=theSegType[1])+=theSegType[2])+=theSegType[3];
+      ((type += theSegType[1]) += theSegType[2]) += theSegType[3];
       sigma = r32;
-      if((type == "LRL" ) ||
-	 (type == "RLR" )) {
-	t0Factor = 2;
-	t = (t2+t4)/2.+t3;
-	hT234LRL->Fill(t);
+      if ((type == "LRL") || (type == "RLR")) {
+        t0Factor = 2;
+        t = (t2 + t4) / 2. + t3;
+        hT234LRL->Fill(t);
+      } else if ((type == "LRR" && theSegDir == R) || (type == "RLL" && theSegDir == L)) {
+        t0Factor = 1;
+        t = (t2 - t4) / 2. + t3;
+        hT234LRR->Fill(t);
+      } else if ((type == "LLR" && theSegDir == R) || (type == "RRL" && theSegDir == L)) {
+        t0Factor = 1;
+        t = (t4 - t2) / 2. + t3;
+        hT234LLR->Fill(t);
+      } else {
+        t = -1;
+        sigma = noR;
+        hT234Bad->Fill(t);
       }
-      else if((type == "LRR" && theSegDir == R) ||
-	      (type == "RLL" && theSegDir == L)) {
-	t0Factor = 1;
-	t = (t2-t4)/2.+t3;
-	hT234LRR->Fill(t);
-      }
-      else if((type == "LLR" && theSegDir == R) ||
-	      (type == "RRL" && theSegDir == L)) {
-	t0Factor = 1;
-	t = (t4-t2)/2.+t3;
-	hT234LLR->Fill(t);
-      }
-      else {
-	t = -1;
-	sigma = noR;
-	hT234Bad->Fill(t);
-      }
-      theTMaxes[cGroup] = new TMax(t,cGroup,type,sigma,t0Factor,hSubGroup);
-      if(debug) cout << "tmax234 " << t << " " << type << endl;
+      theTMaxes[cGroup] = new TMax(t, cGroup, type, sigma, t0Factor, hSubGroup);
+      if (debug)
+        cout << "tmax234 " << t << " " << type << endl;
     }
-  }      
-  
+  }
 }
 
-
-vector<const DTTMax::TMax*> DTTMax::getTMax(const DTWireId & idWire) {
+vector<const DTTMax::TMax*> DTTMax::getTMax(const DTWireId& idWire) {
   vector<const TMax*> v;
-  if(idWire.layer()==1) {
-    v.push_back(getTMax(c123)); //FIXME: needs pointer
+  if (idWire.layer() == 1) {
+    v.push_back(getTMax(c123));  //FIXME: needs pointer
     v.push_back(getTMax(c124));
     v.push_back(getTMax(c134));
-  }
-  else if(idWire.layer()==2) {
+  } else if (idWire.layer() == 2) {
     v.push_back(getTMax(c123));
     v.push_back(getTMax(c124));
     v.push_back(getTMax(c234));
-  }
-  else if(idWire.layer()==3) {
+  } else if (idWire.layer() == 3) {
     v.push_back(getTMax(c123));
     v.push_back(getTMax(c134));
     v.push_back(getTMax(c234));
-  }
-  else {
+  } else {
     v.push_back(getTMax(c124));
     v.push_back(getTMax(c134));
     v.push_back(getTMax(c234));
@@ -347,32 +321,29 @@ vector<const DTTMax::TMax*> DTTMax::getTMax(const DTWireId & idWire) {
   return v;
 }
 
-
-
-vector<const DTTMax::TMax*> DTTMax::getTMax(const DTSuperLayerId & isl) {
+vector<const DTTMax::TMax*> DTTMax::getTMax(const DTSuperLayerId& isl) {
   vector<const TMax*> v;
-  // add TMax* to the vector only if it really exists 
-  if(getTMax(c123)) v.push_back(getTMax(c123)); 
-  if(getTMax(c124)) v.push_back(getTMax(c124));
-  if(getTMax(c134)) v.push_back(getTMax(c134));
-  if(getTMax(c234)) v.push_back(getTMax(c234));  
+  // add TMax* to the vector only if it really exists
+  if (getTMax(c123))
+    v.push_back(getTMax(c123));
+  if (getTMax(c124))
+    v.push_back(getTMax(c124));
+  if (getTMax(c134))
+    v.push_back(getTMax(c134));
+  if (getTMax(c234))
+    v.push_back(getTMax(c234));
   return v;
 }
 
+const DTTMax::TMax* DTTMax::getTMax(TMaxCells cCase) { return theTMaxes[cCase]; }
 
-const DTTMax::TMax* DTTMax::getTMax(TMaxCells cCase){
-  return theTMaxes[cCase];
-}
-
-/* Destructor */ 
-DTTMax::~DTTMax(){
-  for (vector<InfoLayer*>::const_iterator ilay = theInfoLayers.begin();
-       ilay != theInfoLayers.end(); ++ilay) {
+/* Destructor */
+DTTMax::~DTTMax() {
+  for (vector<InfoLayer*>::const_iterator ilay = theInfoLayers.begin(); ilay != theInfoLayers.end(); ++ilay) {
     delete (*ilay);
   }
 
-  for (vector<TMax*>::const_iterator iTmax = theTMaxes.begin();
-       iTmax != theTMaxes.end(); ++iTmax) {
+  for (vector<TMax*>::const_iterator iTmax = theTMaxes.begin(); iTmax != theTMaxes.end(); ++iTmax) {
     delete (*iTmax);
   }
 }

--- a/CalibMuon/DTCalibration/src/DTTTrigBaseCorrection.cc
+++ b/CalibMuon/DTCalibration/src/DTTTrigBaseCorrection.cc
@@ -9,6 +9,6 @@
 
 using dtCalibration::DTTTrigBaseCorrection;
 
-DTTTrigBaseCorrection::DTTTrigBaseCorrection(){}
+DTTTrigBaseCorrection::DTTTrigBaseCorrection() {}
 
-DTTTrigBaseCorrection::~DTTTrigBaseCorrection(){}
+DTTTrigBaseCorrection::~DTTTrigBaseCorrection() {}

--- a/CalibMuon/DTCalibration/src/DTTTrigCorrectionFactory.cc
+++ b/CalibMuon/DTCalibration/src/DTTTrigCorrectionFactory.cc
@@ -6,4 +6,4 @@
 
 #include "CalibMuon/DTCalibration/interface/DTTTrigCorrectionFactory.h"
 
-EDM_REGISTER_PLUGINFACTORY(DTTTrigCorrectionFactory,"DTTTrigCorrectionFactory");
+EDM_REGISTER_PLUGINFACTORY(DTTTrigCorrectionFactory, "DTTTrigCorrectionFactory");

--- a/CalibMuon/DTCalibration/src/DTTimeBoxFitter.cc
+++ b/CalibMuon/DTCalibration/src/DTTimeBoxFitter.cc
@@ -18,58 +18,53 @@
 
 using namespace std;
 
-DTTimeBoxFitter::DTTimeBoxFitter(const TString& debugFileName) : hDebugFile(nullptr),
-								 theVerbosityLevel(0),
-								 theSigma(10.) {
+DTTimeBoxFitter::DTTimeBoxFitter(const TString& debugFileName)
+    : hDebugFile(nullptr), theVerbosityLevel(0), theSigma(10.) {
   // Create a root file for debug output only if needed
-  if(debugFileName != "") hDebugFile = new TFile(debugFileName.Data(), "RECREATE");
+  if (debugFileName != "")
+    hDebugFile = new TFile(debugFileName.Data(), "RECREATE");
   interactiveFit = false;
   rebin = 1;
 }
 
-
-
 DTTimeBoxFitter::~DTTimeBoxFitter() {
-  if(hDebugFile != nullptr) hDebugFile->Close();
+  if (hDebugFile != nullptr)
+    hDebugFile->Close();
 }
 
-
-
-
 /// Compute the ttrig (in ns) from the Time Box
-pair<double, double> DTTimeBoxFitter::fitTimeBox(TH1F *hTimeBox) {
+pair<double, double> DTTimeBoxFitter::fitTimeBox(TH1F* hTimeBox) {
+  hTimeBox->Rebin(rebin);
 
-    hTimeBox->Rebin(rebin);
-  
   // Check if the histo contains any entry
-  if(hTimeBox->GetEntries() == 0) {
+  if (hTimeBox->GetEntries() == 0) {
     cout << "[DTTimeBoxFitter]***Error: the time box contains no entry!" << endl;
     return make_pair(-1, -1);
   }
 
-  if(hTimeBox->GetEntries() < 50000) {
+  if (hTimeBox->GetEntries() < 50000) {
     hTimeBox->Rebin(2);
   }
 
   // Get seeds for the fit
   // The TimeBox range to be fitted (the rising edge)
-  double xFitMin=0;     // Min value for the fit
-  double xFitMax=0;     // Max value for the fit 
-  double xValue=0;      // The mean value of the gaussian
-  double xFitSigma=0;   // The sigma of the gaussian
-  double tBoxMax=0;     // The max of the time box, it is used as seed for gaussian integral
+  double xFitMin = 0;    // Min value for the fit
+  double xFitMax = 0;    // Max value for the fit
+  double xValue = 0;     // The mean value of the gaussian
+  double xFitSigma = 0;  // The sigma of the gaussian
+  double tBoxMax = 0;    // The max of the time box, it is used as seed for gaussian integral
 
   //hTimeBox->Rebin(2); //FIXME: Temporary for low statistics
 
-  TH1F *hTimeBoxForSeed = (TH1F*) hTimeBox->Clone(); //FIXME: test
-  if(!interactiveFit) {
-  getFitSeeds(hTimeBoxForSeed, xValue, xFitSigma, tBoxMax, xFitMin, xFitMax);
+  TH1F* hTimeBoxForSeed = (TH1F*)hTimeBox->Clone();  //FIXME: test
+  if (!interactiveFit) {
+    getFitSeeds(hTimeBoxForSeed, xValue, xFitSigma, tBoxMax, xFitMin, xFitMax);
   } else {
     getInteractiveFitSeeds(hTimeBoxForSeed, xValue, xFitSigma, tBoxMax, xFitMin, xFitMax);
   }
 
   // Define the fitting function and use fit seeds
-  TF1 *fIntGaus = new TF1("IntGauss", intGauss, xFitMin, xFitMax, 3); 
+  TF1* fIntGaus = new TF1("IntGauss", intGauss, xFitMin, xFitMax, 3);
   fIntGaus->SetParName(0, "Constant");
   fIntGaus->SetParameter(0, tBoxMax);
   fIntGaus->SetParName(1, "Mean");
@@ -78,21 +73,20 @@ pair<double, double> DTTimeBoxFitter::fitTimeBox(TH1F *hTimeBox) {
   fIntGaus->SetParameter(2, xFitSigma);
   fIntGaus->SetLineColor(kRed);
 
-
   // Fit the histo
   string option = "Q";
-  if(theVerbosityLevel >= 2)
+  if (theVerbosityLevel >= 2)
     option = "";
 
-  hTimeBox->Fit(fIntGaus, option.c_str(), "",xFitMin, xFitMax);
+  hTimeBox->Fit(fIntGaus, option.c_str(), "", xFitMin, xFitMax);
 
   // Get fitted parameters
-  double mean =  fIntGaus->GetParameter("Mean");
+  double mean = fIntGaus->GetParameter("Mean");
   double sigma = fIntGaus->GetParameter("Sigma");
   //   double constant = fIntGaus->GetParameter("Constant");
-  double chiSquare = fIntGaus->GetChisquare()/fIntGaus->GetNDF();
-  
-  if(theVerbosityLevel >= 1) {
+  double chiSquare = fIntGaus->GetChisquare() / fIntGaus->GetNDF();
+
+  if (theVerbosityLevel >= 1) {
     cout << " === Fit Results: " << endl;
     cout << "     Fitted mean = " << mean << endl;
     cout << "     Fitted sigma = " << sigma << endl;
@@ -101,26 +95,24 @@ pair<double, double> DTTimeBoxFitter::fitTimeBox(TH1F *hTimeBox) {
   return make_pair(mean, sigma);
 }
 
-
-
 // Get the seeds for the fit as input from user!It is used if interactiveFit == true
-void DTTimeBoxFitter::getInteractiveFitSeeds(TH1F *hTBox, double& mean, double& sigma, double& tBoxMax,
-				    double& xFitMin, double& xFitMax) {
-  if(theVerbosityLevel >= 1)
+void DTTimeBoxFitter::getInteractiveFitSeeds(
+    TH1F* hTBox, double& mean, double& sigma, double& tBoxMax, double& xFitMin, double& xFitMax) {
+  if (theVerbosityLevel >= 1)
     cout << " === Insert seeds for the Time Box fit:" << endl;
-  
+
   cout << "Inser the fit mean:" << endl;
   cin >> mean;
 
-  sigma = theSigma; //FIXME: estimate it!
+  sigma = theSigma;  //FIXME: estimate it!
 
   tBoxMax = hTBox->GetMaximum();
 
   // Define the fit range
-  xFitMin = mean-5.*sigma;
-  xFitMax = mean+5.*sigma;
+  xFitMin = mean - 5. * sigma;
+  xFitMax = mean + 5. * sigma;
 
-  if(theVerbosityLevel >= 1) {
+  if (theVerbosityLevel >= 1) {
     cout << "      Time Box Rising edge: " << mean << endl;
     cout << "    = Seeds and range for fit:" << endl;
     cout << "       Seed mean = " << mean << endl;
@@ -129,98 +121,96 @@ void DTTimeBoxFitter::getInteractiveFitSeeds(TH1F *hTBox, double& mean, double& 
   }
 }
 
-
 // Automatically compute the seeds the range to be used for time box fit
-void DTTimeBoxFitter::getFitSeeds(TH1F *hTBox, double& mean, double& sigma, double& tBoxMax,
-				    double& xFitMin, double& xFitMax) {
-  if(theVerbosityLevel >= 1)
+void DTTimeBoxFitter::getFitSeeds(
+    TH1F* hTBox, double& mean, double& sigma, double& tBoxMax, double& xFitMin, double& xFitMax) {
+  if (theVerbosityLevel >= 1)
     cout << " === Looking for fit seeds in Time Box:" << endl;
 
-
   // The approximate width of the time box
-  static const int tBoxWidth = 400; //FIXE: tune it
+  static const int tBoxWidth = 400;  //FIXE: tune it
 
   int nBins = hTBox->GetNbinsX();
   const int xMin = (int)hTBox->GetXaxis()->GetXmin();
   const int xMax = (int)hTBox->GetXaxis()->GetXmax();
-  const int nEntries =  (int)hTBox->GetEntries();
+  const int nEntries = (int)hTBox->GetEntries();
 
-  double binValue = (double)(xMax-xMin)/(double)nBins;
+  double binValue = (double)(xMax - xMin) / (double)nBins;
 
   // Compute a threshold for TimeBox discrimination
-  const double threshold = binValue*nEntries/(double)(tBoxWidth*3.);
-  if(theVerbosityLevel >= 2)
-    cout << "   Threshold for logic time box is (# entries): " <<  threshold << endl;
-    
-  int nRebins = 0; // protection for infinite loop
-  while(threshold > hTBox->GetMaximum()/2. && nRebins < 5) {
+  const double threshold = binValue * nEntries / (double)(tBoxWidth * 3.);
+  if (theVerbosityLevel >= 2)
+    cout << "   Threshold for logic time box is (# entries): " << threshold << endl;
+
+  int nRebins = 0;  // protection for infinite loop
+  while (threshold > hTBox->GetMaximum() / 2. && nRebins < 5) {
     cout << " Rebinning!" << endl;
     hTBox->Rebin(2);
     nBins = hTBox->GetNbinsX();
-    binValue = (double)(xMax-xMin)/(double)nBins;
+    binValue = (double)(xMax - xMin) / (double)nBins;
     nRebins++;
   }
 
-  if(hDebugFile != nullptr) hDebugFile->cd();
-  TString hLName = TString(hTBox->GetName())+"L";
+  if (hDebugFile != nullptr)
+    hDebugFile->cd();
+  TString hLName = TString(hTBox->GetName()) + "L";
   TH1F hLTB(hLName.Data(), "Logic Time Box", nBins, xMin, xMax);
   // Loop over all time box bins and discriminate them accordigly to the threshold
-  for(int i = 1; i <= nBins; i++) {
-    if(hTBox->GetBinContent(i) > threshold)
+  for (int i = 1; i <= nBins; i++) {
+    if (hTBox->GetBinContent(i) > threshold)
       hLTB.SetBinContent(i, 1);
   }
-  if(hDebugFile != nullptr) hLTB.Write();
-  
+  if (hDebugFile != nullptr)
+    hLTB.Write();
+
   // Look for the time box in the "logic histo" and save beginning and lenght of each plateau
-  vector< pair<int, int> > startAndLenght;
-  if(theVerbosityLevel >= 2)
+  vector<pair<int, int> > startAndLenght;
+  if (theVerbosityLevel >= 2)
     cout << "   Look for rising and folling edges of logic time box: " << endl;
   int start = -1;
   int lenght = -1;
-  for(int j = 1; j < nBins;j++) {
-    int diff = (int)hLTB.GetBinContent(j+1)-(int)hLTB.GetBinContent(j);
-    if(diff == 1) { // This is a rising edge
+  for (int j = 1; j < nBins; j++) {
+    int diff = (int)hLTB.GetBinContent(j + 1) - (int)hLTB.GetBinContent(j);
+    if (diff == 1) {  // This is a rising edge
       start = j;
       lenght = 1;
-      if(theVerbosityLevel >= 2) {
-	cout << "     >>>----" << endl;
-	cout << "      bin: " << j << " is a rising edge" << endl;
+      if (theVerbosityLevel >= 2) {
+        cout << "     >>>----" << endl;
+        cout << "      bin: " << j << " is a rising edge" << endl;
       }
-    } else if(diff == -1) { // This is a falling edge
+    } else if (diff == -1) {  // This is a falling edge
       startAndLenght.push_back(make_pair(start, lenght));
-      if(theVerbosityLevel >= 2) {
-	cout << "      bin: " << j << " is a falling edge, lenght is: " << lenght << endl;
-	cout << "     <<<----" << endl;
+      if (theVerbosityLevel >= 2) {
+        cout << "      bin: " << j << " is a falling edge, lenght is: " << lenght << endl;
+        cout << "     <<<----" << endl;
       }
       start = -1;
       lenght = -1;
-    } else if(diff == 0 && (int)hLTB.GetBinContent(j) == 1) { // This is a bin within the plateau
-      lenght ++;
+    } else if (diff == 0 && (int)hLTB.GetBinContent(j) == 1) {  // This is a bin within the plateau
+      lenght++;
     }
   }
 
-  if(theVerbosityLevel >= 2)
+  if (theVerbosityLevel >= 2)
     cout << "   Add macro intervals: " << endl;
   // Look for consecutive plateau: 2 plateau are consecutive if the gap is < 5 ns
-  vector<  pair<int, int> > superIntervals;
-  for(vector< pair<int, int> >::const_iterator interval = startAndLenght.begin();
-      interval != startAndLenght.end();
-      ++interval) {
+  vector<pair<int, int> > superIntervals;
+  for (vector<pair<int, int> >::const_iterator interval = startAndLenght.begin(); interval != startAndLenght.end();
+       ++interval) {
     pair<int, int> theInterval = (*interval);
-    vector< pair<int, int> >::const_iterator next = interval;
-    while(++next != startAndLenght.end()) {
-      int gap = (*next).first - (theInterval.first+theInterval.second);
-      double gabInNs = binValue*gap;
-      if(theVerbosityLevel >= 2)
-	cout << "      gap: " << gabInNs << "(ns)" << endl;
-      if(gabInNs > 20) {
-	break;
+    vector<pair<int, int> >::const_iterator next = interval;
+    while (++next != startAndLenght.end()) {
+      int gap = (*next).first - (theInterval.first + theInterval.second);
+      double gabInNs = binValue * gap;
+      if (theVerbosityLevel >= 2)
+        cout << "      gap: " << gabInNs << "(ns)" << endl;
+      if (gabInNs > 20) {
+        break;
       } else {
-	theInterval = make_pair(theInterval.first, theInterval.second+gap+(*next).second);
-	superIntervals.push_back(theInterval);
-	if(theVerbosityLevel >= 2)
-	  cout << "          Add interval, start: " << theInterval.first
-	       << " width: " << theInterval.second << endl;
+        theInterval = make_pair(theInterval.first, theInterval.second + gap + (*next).second);
+        superIntervals.push_back(theInterval);
+        if (theVerbosityLevel >= 2)
+          cout << "          Add interval, start: " << theInterval.first << " width: " << theInterval.second << endl;
       }
     }
   }
@@ -229,37 +219,34 @@ void DTTimeBoxFitter::getFitSeeds(TH1F *hTBox, double& mean, double& sigma, doub
   copy(superIntervals.begin(), superIntervals.end(), back_inserter(startAndLenght));
 
   // Look for the plateau of the right lenght
-  if(theVerbosityLevel >= 2)
+  if (theVerbosityLevel >= 2)
     cout << "    Look for the best interval:" << endl;
   int delta = 999999;
   int beginning = -1;
   int tbWidth = -1;
-  for(vector< pair<int, int> >::const_iterator stAndL = startAndLenght.begin();
-      stAndL != startAndLenght.end();
-      ++stAndL) {
-    if(abs((*stAndL).second - tBoxWidth) < delta) {
+  for (vector<pair<int, int> >::const_iterator stAndL = startAndLenght.begin(); stAndL != startAndLenght.end();
+       ++stAndL) {
+    if (abs((*stAndL).second - tBoxWidth) < delta) {
       delta = abs((*stAndL).second - tBoxWidth);
       beginning = (*stAndL).first;
       tbWidth = (*stAndL).second;
-      if(theVerbosityLevel >= 2)
-	cout << "   Candidate: First: " <<  beginning
-	     << ", width: " << tbWidth
-	     << ", delta: " << delta << endl;
+      if (theVerbosityLevel >= 2)
+        cout << "   Candidate: First: " << beginning << ", width: " << tbWidth << ", delta: " << delta << endl;
     }
   }
 
-  mean = xMin + beginning*binValue;
-  sigma = theSigma; //FIXME: estimate it!
+  mean = xMin + beginning * binValue;
+  sigma = theSigma;  //FIXME: estimate it!
 
   tBoxMax = hTBox->GetMaximum();
 
   // Define the fit range
-  xFitMin = mean-5.*sigma;
-  xFitMax = mean+5.*sigma;
+  xFitMin = mean - 5. * sigma;
+  xFitMax = mean + 5. * sigma;
 
-  if(theVerbosityLevel >= 1) {
+  if (theVerbosityLevel >= 1) {
     cout << "      Time Box Rising edge: " << mean << endl;
-    cout << "      Time Box Width: " << tbWidth*binValue << endl;
+    cout << "      Time Box Width: " << tbWidth * binValue << endl;
     cout << "    = Seeds and range for fit:" << endl;
     cout << "       Seed mean = " << mean << endl;
     cout << "       Seed sigma = " << sigma << endl;
@@ -267,13 +254,10 @@ void DTTimeBoxFitter::getFitSeeds(TH1F *hTBox, double& mean, double& sigma, doub
   }
 }
 
-
-
-double intGauss(double *x, double *par) {
+double intGauss(double* x, double* par) {
   double media = par[1];
   double sigma = par[2];
-  double var = (x[0]-media)/(sigma*sqrt(2.));
+  double var = (x[0] - media) / (sigma * sqrt(2.));
 
-  return 0.5*par[0]*(1+TMath::Erf(var));
-
+  return 0.5 * par[0] * (1 + TMath::Erf(var));
 }

--- a/CalibMuon/DTCalibration/src/DTVDriftBaseAlgo.cc
+++ b/CalibMuon/DTCalibration/src/DTVDriftBaseAlgo.cc
@@ -9,6 +9,6 @@
 
 using dtCalibration::DTVDriftBaseAlgo;
 
-DTVDriftBaseAlgo::DTVDriftBaseAlgo(){}
+DTVDriftBaseAlgo::DTVDriftBaseAlgo() {}
 
-DTVDriftBaseAlgo::~DTVDriftBaseAlgo(){}
+DTVDriftBaseAlgo::~DTVDriftBaseAlgo() {}

--- a/CalibMuon/DTCalibration/src/DTVDriftPluginFactory.cc
+++ b/CalibMuon/DTCalibration/src/DTVDriftPluginFactory.cc
@@ -6,4 +6,4 @@
 
 #include "CalibMuon/DTCalibration/interface/DTVDriftPluginFactory.h"
 
-EDM_REGISTER_PLUGINFACTORY(DTVDriftPluginFactory,"DTVDriftPluginFactory");
+EDM_REGISTER_PLUGINFACTORY(DTVDriftPluginFactory, "DTVDriftPluginFactory");

--- a/CalibMuon/DTCalibration/test/DBTools/DTCalibrationMap.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DTCalibrationMap.cc
@@ -6,4 +6,3 @@
  */
 
 #include "CalibMuon/DTCalibration/plugins/DTCalibrationMap.cc"
-

--- a/CalibMuon/DTCalibration/test/DBTools/DTT0Analyzer.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DTT0Analyzer.cc
@@ -25,12 +25,9 @@ DTT0Analyzer::DTT0Analyzer(const ParameterSet& pset) {
   string rootFileName = pset.getUntrackedParameter<string>("rootFileName");
   theFile = new TFile(rootFileName.c_str(), "RECREATE");
   theFile->cd();
- 
 }
- 
-DTT0Analyzer::~DTT0Analyzer(){  
-  theFile->Close();
-}
+
+DTT0Analyzer::~DTT0Analyzer() { theFile->Close(); }
 
 void DTT0Analyzer::beginRun(const edm::Run&, const edm::EventSetup& eventSetup) {
   //Get the t0 map from the DB
@@ -38,85 +35,84 @@ void DTT0Analyzer::beginRun(const edm::Run&, const edm::EventSetup& eventSetup) 
   eventSetup.get<DTT0Rcd>().get(t0);
   tZeroMap = &*t0;
 
-  // Get the DT Geometry  
+  // Get the DT Geometry
   eventSetup.get<MuonGeometryRecord>().get(dtGeom);
 }
 
 void DTT0Analyzer::endJob() {
   // Loop over DB entries
-  for(DTT0::const_iterator tzero = tZeroMap->begin();
-      tzero != tZeroMap->end(); ++tzero) {
-// @@@ NEW DTT0 FORMAT
-//    DTWireId wireId((*tzero).first.wheelId,
-//		    (*tzero).first.stationId,
-//		    (*tzero).first.sectorId,
-//		    (*tzero).first.slId,
-//		    (*tzero).first.layerId,
-//		    (*tzero).first.cellId);
+  for (DTT0::const_iterator tzero = tZeroMap->begin(); tzero != tZeroMap->end(); ++tzero) {
+    // @@@ NEW DTT0 FORMAT
+    //    DTWireId wireId((*tzero).first.wheelId,
+    //		    (*tzero).first.stationId,
+    //		    (*tzero).first.sectorId,
+    //		    (*tzero).first.slId,
+    //		    (*tzero).first.layerId,
+    //		    (*tzero).first.cellId);
     int channelId = tzero->channelId;
-    if ( channelId == 0 ) continue;
-    DTWireId wireId( channelId );
-// @@@ NEW DTT0 END
+    if (channelId == 0)
+      continue;
+    DTWireId wireId(channelId);
+    // @@@ NEW DTT0 END
     float t0mean;
     float t0rms;
     // t0s and rms are TDC counts
     tZeroMap->get(wireId, t0mean, t0rms, DTTimeUnits::counts);
-    cout << "Wire: " <<  wireId <<endl
-	 << " T0 mean (TDC counts): " << t0mean
-	 << " T0_rms (TDC counts): " << t0rms << endl;
+    cout << "Wire: " << wireId << endl
+         << " T0 mean (TDC counts): " << t0mean << " T0_rms (TDC counts): " << t0rms << endl;
 
     DTLayerId layerId = wireId.layerId();
     const int nWires = dtGeom->layer(layerId)->specificTopology().channels();
 
-
     //Define an histo for means and an histo for sigmas for each layer
-    TH1D *hT0Histo = theMeanHistoMap[layerId];
-    if(hT0Histo == 0) {
+    TH1D* hT0Histo = theMeanHistoMap[layerId];
+    if (hT0Histo == 0) {
       theFile->cd();
       TString name = getHistoName(layerId).c_str();
-      hT0Histo = new TH1D(name+"_t0Mean",
-			  "mean T0 from pulses by Channel", nWires,dtGeom->layer(layerId)->specificTopology().firstChannel(),
-			  dtGeom->layer(layerId)->specificTopology().firstChannel()+nWires);
+      hT0Histo = new TH1D(name + "_t0Mean",
+                          "mean T0 from pulses by Channel",
+                          nWires,
+                          dtGeom->layer(layerId)->specificTopology().firstChannel(),
+                          dtGeom->layer(layerId)->specificTopology().firstChannel() + nWires);
       theMeanHistoMap[layerId] = hT0Histo;
-     }
+    }
 
-    TH1D *hSigmaT0Histo = theSigmaHistoMap[layerId];
-    if(hSigmaT0Histo == 0) {
+    TH1D* hSigmaT0Histo = theSigmaHistoMap[layerId];
+    if (hSigmaT0Histo == 0) {
       theFile->cd();
       TString name = getHistoName(layerId).c_str();
-      hSigmaT0Histo = new TH1D(name+"_t0Sigma",
-			  "sigma T0 from pulses by Channel", nWires,dtGeom->layer(layerId)->specificTopology().firstChannel(),
-			  dtGeom->layer(layerId)->specificTopology().firstChannel()+nWires);
+      hSigmaT0Histo = new TH1D(name + "_t0Sigma",
+                               "sigma T0 from pulses by Channel",
+                               nWires,
+                               dtGeom->layer(layerId)->specificTopology().firstChannel(),
+                               dtGeom->layer(layerId)->specificTopology().firstChannel() + nWires);
       theSigmaHistoMap[layerId] = hSigmaT0Histo;
-     }
+    }
 
     //Fill the histos
-    int nBin= hT0Histo->GetXaxis()->FindFixBin(wireId.wire());
-    hT0Histo->SetBinContent(nBin,t0mean);  
-    hSigmaT0Histo->SetBinContent(nBin,t0rms);  
+    int nBin = hT0Histo->GetXaxis()->FindFixBin(wireId.wire());
+    hT0Histo->SetBinContent(nBin, t0mean);
+    hSigmaT0Histo->SetBinContent(nBin, t0rms);
   }
 
   //Write histos in a .root file
   theFile->cd();
-  for(map<DTLayerId, TH1D*>::const_iterator lHisto = theMeanHistoMap.begin();
-      lHisto != theMeanHistoMap.end();
-      ++lHisto) {
-    (*lHisto).second->Write(); 
-  }    
+  for (map<DTLayerId, TH1D*>::const_iterator lHisto = theMeanHistoMap.begin(); lHisto != theMeanHistoMap.end();
+       ++lHisto) {
+    (*lHisto).second->Write();
+  }
 
-  for(map<DTLayerId, TH1D*>::const_iterator lHisto = theSigmaHistoMap.begin();
-      lHisto != theSigmaHistoMap.end();
-      ++lHisto) {
-    (*lHisto).second->Write(); 
- }
-
+  for (map<DTLayerId, TH1D*>::const_iterator lHisto = theSigmaHistoMap.begin(); lHisto != theSigmaHistoMap.end();
+       ++lHisto) {
+    (*lHisto).second->Write();
+  }
 }
 
 string DTT0Analyzer::getHistoName(const DTLayerId& lId) const {
   string histoName;
   stringstream theStream;
-  theStream << "Ch_" << lId.wheel() << "_" << lId.station() << "_" << lId.sector()
-	    << "_SL" << lId.superlayer() << "_L" << lId.layer();
+  theStream << "Ch_" << lId.wheel() << "_" << lId.station() << "_" << lId.sector() << "_SL" << lId.superlayer() << "_L"
+            << lId.layer();
   theStream >> histoName;
   return histoName;
 }

--- a/CalibMuon/DTCalibration/test/DBTools/DTT0Analyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTT0Analyzer.h
@@ -38,23 +38,20 @@ public:
   void endJob();
 
 protected:
-
 private:
- std::string getHistoName(const DTLayerId& lId) const;
+  std::string getHistoName(const DTLayerId& lId) const;
 
   //The DTGeometry
   edm::ESHandle<DTGeometry> dtGeom;
 
   // The file which will contain the histos
-  TFile *theFile;
+  TFile* theFile;
 
   //The t0 map
-  const DTT0 *tZeroMap;
- 
+  const DTT0* tZeroMap;
+
   // Map of the t0 and sigma histos by layer
   std::map<DTLayerId, TH1D*> theMeanHistoMap;
   std::map<DTLayerId, TH1D*> theSigmaHistoMap;
-
 };
 #endif
-

--- a/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.cc
@@ -19,104 +19,88 @@
 using namespace edm;
 using namespace std;
 
-DTTTrigAnalyzer::DTTTrigAnalyzer(const ParameterSet& pset) {
+DTTTrigAnalyzer::DTTTrigAnalyzer(const ParameterSet &pset) {
   // The root file which will contain the histos
   string rootFileName = pset.getUntrackedParameter<string>("rootFileName");
   theFile = new TFile(rootFileName.c_str(), "RECREATE");
   theFile->cd();
   //The k factor to compute ttrig
   //kfactor = pset.getUntrackedParameter<double>("kfactor",0);
-  dbLabel  = pset.getUntrackedParameter<string>("dbLabel", "");
-
-}
- 
-DTTTrigAnalyzer::~DTTTrigAnalyzer(){  
-  theFile->Close();
+  dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
 }
 
-void DTTTrigAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& eventSetup) {
+DTTTrigAnalyzer::~DTTTrigAnalyzer() { theFile->Close(); }
+
+void DTTTrigAnalyzer::beginRun(const edm::Run &, const edm::EventSetup &eventSetup) {
   ESHandle<DTTtrig> tTrig;
-  eventSetup.get<DTTtrigRcd>().get(dbLabel,tTrig);
+  eventSetup.get<DTTtrigRcd>().get(dbLabel, tTrig);
   tTrigMap = &*tTrig;
   cout << "[DTTTrigAnalyzer] TTrig version: " << tTrig->version() << endl;
 }
 
 void DTTTrigAnalyzer::endJob() {
-//   static const double convToNs = 25./32.;
-   // Loop over DB entries
-  for(DTTtrig::const_iterator ttrig = tTrigMap->begin();
-	  ttrig != tTrigMap->end(); ++ttrig) {
-    DTWireId wireId((*ttrig).first.wheelId,
-		    (*ttrig).first.stationId,
-		    (*ttrig).first.sectorId,
-		    (*ttrig).first.slId, 0, 0);
+  //   static const double convToNs = 25./32.;
+  // Loop over DB entries
+  for (DTTtrig::const_iterator ttrig = tTrigMap->begin(); ttrig != tTrigMap->end(); ++ttrig) {
+    DTWireId wireId(
+        (*ttrig).first.wheelId, (*ttrig).first.stationId, (*ttrig).first.sectorId, (*ttrig).first.slId, 0, 0);
     float tmean;
     float sigma;
     float kFactor;
 
-    DetId detId( wireId.rawId() );
+    DetId detId(wireId.rawId());
     // ttrig and rms are ns
     tTrigMap->get(detId, tmean, sigma, kFactor, DTTimeUnits::ns);
-    float ttcor = tmean + kFactor * sigma; 
-    cout << "Wire: " <<  wireId <<endl
-	 << " Ttrig (ns): " << ttcor << endl
-	 << " tmean (ns): " << tmean << endl
-	 << " sigma (ns): " << sigma << endl
+    float ttcor = tmean + kFactor * sigma;
+    cout << "Wire: " << wireId << endl
+         << " Ttrig (ns): " << ttcor << endl
+         << " tmean (ns): " << tmean << endl
+         << " sigma (ns): " << sigma << endl
          << " kfactor: " << kFactor << endl;
 
-
     //Define an histo for each wheel and each superlayer type
-    TH1D *hTTrigHisto = theTTrigHistoMap[make_pair(wireId.wheel(),wireId.superlayer())];
-    TH1D *hTMeanHisto = theTMeanHistoMap[make_pair(wireId.wheel(),wireId.superlayer())];
-    TH1D *hSigmaHisto = theSigmaHistoMap[make_pair(wireId.wheel(),wireId.superlayer())];
-    TH1D *hKFactorHisto = theKFactorHistoMap[make_pair(wireId.wheel(),wireId.superlayer())];
-    if(hTTrigHisto == 0) {
+    TH1D *hTTrigHisto = theTTrigHistoMap[make_pair(wireId.wheel(), wireId.superlayer())];
+    TH1D *hTMeanHisto = theTMeanHistoMap[make_pair(wireId.wheel(), wireId.superlayer())];
+    TH1D *hSigmaHisto = theSigmaHistoMap[make_pair(wireId.wheel(), wireId.superlayer())];
+    TH1D *hKFactorHisto = theKFactorHistoMap[make_pair(wireId.wheel(), wireId.superlayer())];
+    if (hTTrigHisto == 0) {
       theFile->cd();
       TString name = getHistoName(wireId).c_str();
-      if(wireId.superlayer() != 2){
-	hTTrigHisto = new TH1D(name+"_TTrig",
-			       "TTrig calibrated from TB per superlayer", 50, 0, 50);
- 	hTMeanHisto = new TH1D(name+"_TMean",
-			       "TMean calibrated from TB per superlayer", 50, 0, 50);
-  	hSigmaHisto = new TH1D(name+"_Sigma",
-			       "Sigma calibrated from TB per superlayer", 50, 0, 50);
-        hKFactorHisto = new TH1D(name+"_KFactor",
-                               "KFactor calibrated from TB per superlayer", 50, 0, 50); 
+      if (wireId.superlayer() != 2) {
+        hTTrigHisto = new TH1D(name + "_TTrig", "TTrig calibrated from TB per superlayer", 50, 0, 50);
+        hTMeanHisto = new TH1D(name + "_TMean", "TMean calibrated from TB per superlayer", 50, 0, 50);
+        hSigmaHisto = new TH1D(name + "_Sigma", "Sigma calibrated from TB per superlayer", 50, 0, 50);
+        hKFactorHisto = new TH1D(name + "_KFactor", "KFactor calibrated from TB per superlayer", 50, 0, 50);
+      } else {
+        hTTrigHisto = new TH1D(name + "_TTrig", "TTrig calibrated from TB per superlayer", 36, 0, 36);
+        hTMeanHisto = new TH1D(name + "_TMean", "TMean calibrated from TB per superlayer", 36, 0, 36);
+        hSigmaHisto = new TH1D(name + "_Sigma", "Sigma calibrated from TB per superlayer", 36, 0, 36);
+        hKFactorHisto = new TH1D(name + "_KFactor", "KFactor calibrated from TB per superlayer", 36, 0, 36);
       }
-      else{
- 	hTTrigHisto = new TH1D(name+"_TTrig",
-			       "TTrig calibrated from TB per superlayer", 36, 0, 36);
- 	hTMeanHisto = new TH1D(name+"_TMean",
-			       "TMean calibrated from TB per superlayer", 36, 0, 36);
-  	hSigmaHisto = new TH1D(name+"_Sigma",
-			       "Sigma calibrated from TB per superlayer", 36, 0, 36);
-        hKFactorHisto = new TH1D(name+"_KFactor",
-                               "KFactor calibrated from TB per superlayer", 36, 0, 36);
-      }
-      theTTrigHistoMap[make_pair(wireId.wheel(),wireId.superlayer())] = hTTrigHisto;
-      theTMeanHistoMap[make_pair(wireId.wheel(),wireId.superlayer())] = hTMeanHisto;
-      theSigmaHistoMap[make_pair(wireId.wheel(),wireId.superlayer())] = hSigmaHisto;
-      theKFactorHistoMap[make_pair(wireId.wheel(),wireId.superlayer())] = hKFactorHisto;
+      theTTrigHistoMap[make_pair(wireId.wheel(), wireId.superlayer())] = hTTrigHisto;
+      theTMeanHistoMap[make_pair(wireId.wheel(), wireId.superlayer())] = hTMeanHisto;
+      theSigmaHistoMap[make_pair(wireId.wheel(), wireId.superlayer())] = hSigmaHisto;
+      theKFactorHistoMap[make_pair(wireId.wheel(), wireId.superlayer())] = hKFactorHisto;
     }
 
     //Fill the histos and set the bin label
     int binNumber = wireId.sector() + 12 * (wireId.station() - 1);
-//    hTTrigHisto->SetBinContent(binNumber,ttrig);  
-    hTTrigHisto->SetBinContent(binNumber,ttcor);  
-    hTMeanHisto->SetBinContent(binNumber,tmean);  
-    hSigmaHisto->SetBinContent(binNumber,sigma);  
-    hKFactorHisto->SetBinContent(binNumber,kFactor);
+    //    hTTrigHisto->SetBinContent(binNumber,ttrig);
+    hTTrigHisto->SetBinContent(binNumber, ttcor);
+    hTMeanHisto->SetBinContent(binNumber, tmean);
+    hSigmaHisto->SetBinContent(binNumber, sigma);
+    hKFactorHisto->SetBinContent(binNumber, kFactor);
     string labelName;
     stringstream theStream;
-    if(wireId.sector() == 1)
-      theStream << "MB" << wireId.station() << "_Sec" << wireId.sector(); 
+    if (wireId.sector() == 1)
+      theStream << "MB" << wireId.station() << "_Sec" << wireId.sector();
     else
-      theStream << "Sec" << wireId.sector(); 
+      theStream << "Sec" << wireId.sector();
     theStream >> labelName;
-    hTTrigHisto->GetXaxis()->SetBinLabel(binNumber,labelName.c_str());  
-    hTMeanHisto->GetXaxis()->SetBinLabel(binNumber,labelName.c_str());  
-    hSigmaHisto->GetXaxis()->SetBinLabel(binNumber,labelName.c_str());
-    hKFactorHisto->GetXaxis()->SetBinLabel(binNumber,labelName.c_str());  
+    hTTrigHisto->GetXaxis()->SetBinLabel(binNumber, labelName.c_str());
+    hTMeanHisto->GetXaxis()->SetBinLabel(binNumber, labelName.c_str());
+    hSigmaHisto->GetXaxis()->SetBinLabel(binNumber, labelName.c_str());
+    hKFactorHisto->GetXaxis()->SetBinLabel(binNumber, labelName.c_str());
 
     //Define a distribution for each wheel,station and each superlayer type
     vector<int> Wh_St_SL;
@@ -127,24 +111,20 @@ void DTTTrigAnalyzer::endJob() {
     TH1D *hTMeanDistrib = theTMeanDistribMap[Wh_St_SL];
     TH1D *hSigmaDistrib = theSigmaDistribMap[Wh_St_SL];
     TH1D *hKFactorDistrib = theKFactorDistribMap[Wh_St_SL];
-    if(hTTrigDistrib == 0) {
+    if (hTTrigDistrib == 0) {
       theFile->cd();
       TString name = getDistribName(wireId).c_str();
-      hTTrigDistrib = new TH1D(name+"_TTrig",
-			       "TTrig calibrated from TB per superlayer",  500, 100, 600);
-      hTMeanDistrib = new TH1D(name+"_TMean",
-			       "TMean calibrated from TB per superlayer", 500, 100, 600);
-      hSigmaDistrib = new TH1D(name+"_Sigma",
-			       "Sigma calibrated from TB per superlayer", 50, 0, 50);
-      hKFactorDistrib = new TH1D(name+"_KFactor",
-                               "KFactor calibrated from TB per superlayer", 200, -10.0, 10.0);
+      hTTrigDistrib = new TH1D(name + "_TTrig", "TTrig calibrated from TB per superlayer", 500, 100, 600);
+      hTMeanDistrib = new TH1D(name + "_TMean", "TMean calibrated from TB per superlayer", 500, 100, 600);
+      hSigmaDistrib = new TH1D(name + "_Sigma", "Sigma calibrated from TB per superlayer", 50, 0, 50);
+      hKFactorDistrib = new TH1D(name + "_KFactor", "KFactor calibrated from TB per superlayer", 200, -10.0, 10.0);
       theTTrigDistribMap[Wh_St_SL] = hTTrigDistrib;
       theTMeanDistribMap[Wh_St_SL] = hTMeanDistrib;
       theSigmaDistribMap[Wh_St_SL] = hSigmaDistrib;
       theKFactorDistribMap[Wh_St_SL] = hKFactorDistrib;
     }
     //Fill the distributions
-//    hTTrigDistrib->Fill(ttrig);
+    //    hTTrigDistrib->Fill(ttrig);
     hTTrigDistrib->Fill(ttcor);
     hTMeanDistrib->Fill(tmean);
     hSigmaDistrib->Fill(sigma);
@@ -153,65 +133,61 @@ void DTTTrigAnalyzer::endJob() {
 
   //Write histos in a .root file
   theFile->cd();
-  for(map<pair<int,int>, TH1D*>::const_iterator lHisto = theTTrigHistoMap.begin();
-      lHisto != theTTrigHistoMap.end();
-      ++lHisto) {
-    (*lHisto).second->GetXaxis()->LabelsOption("v");
-    (*lHisto).second->Write(); 
-  }    
-  for(map<pair<int,int>, TH1D*>::const_iterator lHisto = theTMeanHistoMap.begin();
-      lHisto != theTMeanHistoMap.end();
-      ++lHisto) {
-    (*lHisto).second->GetXaxis()->LabelsOption("v");
-    (*lHisto).second->Write(); 
-  }    
-  for(map<pair<int,int>, TH1D*>::const_iterator lHisto = theSigmaHistoMap.begin();
-      lHisto != theSigmaHistoMap.end();
-      ++lHisto) {
-    (*lHisto).second->GetXaxis()->LabelsOption("v");
-    (*lHisto).second->Write(); 
-  }
-  for(map<pair<int,int>, TH1D*>::const_iterator lHisto = theKFactorHistoMap.begin();
-      lHisto != theKFactorHistoMap.end();
-      ++lHisto) {
+  for (map<pair<int, int>, TH1D *>::const_iterator lHisto = theTTrigHistoMap.begin(); lHisto != theTTrigHistoMap.end();
+       ++lHisto) {
     (*lHisto).second->GetXaxis()->LabelsOption("v");
     (*lHisto).second->Write();
-  } 
-  for(map<vector<int>, TH1D*>::const_iterator lDistrib = theTTrigDistribMap.begin();
-      lDistrib != theTTrigDistribMap.end();
-      ++lDistrib) {
-    (*lDistrib).second->Write(); 
-  }    
-  for(map<vector<int>, TH1D*>::const_iterator lDistrib = theTMeanDistribMap.begin();
-      lDistrib != theTMeanDistribMap.end();
-      ++lDistrib) {
-    (*lDistrib).second->Write(); 
-  }    
-  for(map<vector<int>, TH1D*>::const_iterator lDistrib = theSigmaDistribMap.begin();
-      lDistrib != theSigmaDistribMap.end();
-      ++lDistrib) {
-    (*lDistrib).second->Write(); 
   }
-  for(map<vector<int>, TH1D*>::const_iterator lDistrib = theKFactorDistribMap.begin();
-      lDistrib != theKFactorDistribMap.end();
-      ++lDistrib) {
+  for (map<pair<int, int>, TH1D *>::const_iterator lHisto = theTMeanHistoMap.begin(); lHisto != theTMeanHistoMap.end();
+       ++lHisto) {
+    (*lHisto).second->GetXaxis()->LabelsOption("v");
+    (*lHisto).second->Write();
+  }
+  for (map<pair<int, int>, TH1D *>::const_iterator lHisto = theSigmaHistoMap.begin(); lHisto != theSigmaHistoMap.end();
+       ++lHisto) {
+    (*lHisto).second->GetXaxis()->LabelsOption("v");
+    (*lHisto).second->Write();
+  }
+  for (map<pair<int, int>, TH1D *>::const_iterator lHisto = theKFactorHistoMap.begin();
+       lHisto != theKFactorHistoMap.end();
+       ++lHisto) {
+    (*lHisto).second->GetXaxis()->LabelsOption("v");
+    (*lHisto).second->Write();
+  }
+  for (map<vector<int>, TH1D *>::const_iterator lDistrib = theTTrigDistribMap.begin();
+       lDistrib != theTTrigDistribMap.end();
+       ++lDistrib) {
     (*lDistrib).second->Write();
-  }  
-
+  }
+  for (map<vector<int>, TH1D *>::const_iterator lDistrib = theTMeanDistribMap.begin();
+       lDistrib != theTMeanDistribMap.end();
+       ++lDistrib) {
+    (*lDistrib).second->Write();
+  }
+  for (map<vector<int>, TH1D *>::const_iterator lDistrib = theSigmaDistribMap.begin();
+       lDistrib != theSigmaDistribMap.end();
+       ++lDistrib) {
+    (*lDistrib).second->Write();
+  }
+  for (map<vector<int>, TH1D *>::const_iterator lDistrib = theKFactorDistribMap.begin();
+       lDistrib != theKFactorDistribMap.end();
+       ++lDistrib) {
+    (*lDistrib).second->Write();
+  }
 }
 
-string DTTTrigAnalyzer::getHistoName(const DTWireId& wId) const {
+string DTTTrigAnalyzer::getHistoName(const DTWireId &wId) const {
   string histoName;
   stringstream theStream;
-  theStream << "Wheel" << wId.wheel() << "_SL" << wId.superlayer(); 
+  theStream << "Wheel" << wId.wheel() << "_SL" << wId.superlayer();
   theStream >> histoName;
   return histoName;
 }
 
-string DTTTrigAnalyzer::getDistribName(const DTWireId& wId) const {
+string DTTTrigAnalyzer::getDistribName(const DTWireId &wId) const {
   string histoName;
   stringstream theStream;
-  theStream << "Wheel" << wId.wheel() <<"_Station"<< wId.station() << "_SL" << wId.superlayer(); 
+  theStream << "Wheel" << wId.wheel() << "_Station" << wId.station() << "_SL" << wId.superlayer();
   theStream >> histoName;
   return histoName;
 }

--- a/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.h
@@ -31,39 +31,36 @@ public:
 
   /// Operations
   //Read the DTGeometry and teh t0 DB
-  virtual void beginRun(const edm::Run&,const edm::EventSetup& setup);
+  virtual void beginRun(const edm::Run&, const edm::EventSetup& setup);
   void analyze(const edm::Event& event, const edm::EventSetup& setup) {}
   //Do the real work
   void endJob();
 
 protected:
-
 private:
   std::string getHistoName(const DTWireId& lId) const;
   std::string getDistribName(const DTWireId& wId) const;
 
   // The file which will contain the histos
-  TFile *theFile;
+  TFile* theFile;
 
   //The t0 map
-  const DTTtrig *tTrigMap;
+  const DTTtrig* tTrigMap;
 
   std::string dbLabel;
- 
+
   //The k factor
   //double kfactor;
-  
+
   // Map of the ttrig, tmean, sigma histos by wheel/sector/SL
-  std::map<std::pair<int,int>, TH1D*> theTTrigHistoMap;
-  std::map<std::pair<int,int>, TH1D*> theTMeanHistoMap;
-  std::map<std::pair<int,int>, TH1D*> theSigmaHistoMap;
-  std::map<std::pair<int,int>, TH1D*> theKFactorHistoMap;
- // Map of the ttrig, tmean, sigma distributions by wheel/station/SL
+  std::map<std::pair<int, int>, TH1D*> theTTrigHistoMap;
+  std::map<std::pair<int, int>, TH1D*> theTMeanHistoMap;
+  std::map<std::pair<int, int>, TH1D*> theSigmaHistoMap;
+  std::map<std::pair<int, int>, TH1D*> theKFactorHistoMap;
+  // Map of the ttrig, tmean, sigma distributions by wheel/station/SL
   std::map<std::vector<int>, TH1D*> theTTrigDistribMap;
   std::map<std::vector<int>, TH1D*> theTMeanDistribMap;
   std::map<std::vector<int>, TH1D*> theSigmaDistribMap;
   std::map<std::vector<int>, TH1D*> theKFactorDistribMap;
-
 };
 #endif
-

--- a/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.cc
@@ -25,86 +25,71 @@ DTVDriftAnalyzer::DTVDriftAnalyzer(const ParameterSet& pset) {
   theFile = new TFile(rootFileName.c_str(), "RECREATE");
   theFile->cd();
 }
- 
-DTVDriftAnalyzer::~DTVDriftAnalyzer(){  
-  theFile->Close();
-}
+
+DTVDriftAnalyzer::~DTVDriftAnalyzer() { theFile->Close(); }
 
 void DTVDriftAnalyzer::beginRun(const edm::Run& run, const edm::EventSetup& eventSetup) {
   ESHandle<DTMtime> mTime;
   eventSetup.get<DTMtimeRcd>().get(mTime);
   mTimeMap = &*mTime;
   cout << "[DTVDriftAnalyzer] MTime version: " << mTime->version() << endl;
- 
 }
 
 void DTVDriftAnalyzer::endJob() {
-   // Loop over DB entries
-   for(DTMtime::const_iterator mtime = mTimeMap->begin();
-       mtime != mTimeMap->end(); ++mtime) {
-     DTWireId wireId((*mtime).first.wheelId,
-		     (*mtime).first.stationId,
-		     (*mtime).first.sectorId,
-		     (*mtime).first.slId, 0, 0);
+  // Loop over DB entries
+  for (DTMtime::const_iterator mtime = mTimeMap->begin(); mtime != mTimeMap->end(); ++mtime) {
+    DTWireId wireId(
+        (*mtime).first.wheelId, (*mtime).first.stationId, (*mtime).first.sectorId, (*mtime).first.slId, 0, 0);
     float vdrift;
     float reso;
-    DetId detId( wireId.rawId() );
+    DetId detId(wireId.rawId());
     // vdrift is cm/ns , resolution is cm
     mTimeMap->get(detId, vdrift, reso, DTVelocityUnits::cm_per_ns);
-    cout << "Wire: " <<  wireId <<endl
-	 << " vdrift (cm/ns): " << vdrift<<endl
-	 << " reso (cm): " << reso<<endl;
+    cout << "Wire: " << wireId << endl << " vdrift (cm/ns): " << vdrift << endl << " reso (cm): " << reso << endl;
 
     //Define an histo for each wheel and each superlayer type
-    TH1D *hVDriftHisto = theVDriftHistoMap[make_pair(wireId.wheel(),wireId.superlayer())];
-    TH1D *hResoHisto = theResoHistoMap[make_pair(wireId.wheel(),wireId.superlayer())];
-    if(hVDriftHisto == 0) {
+    TH1D* hVDriftHisto = theVDriftHistoMap[make_pair(wireId.wheel(), wireId.superlayer())];
+    TH1D* hResoHisto = theResoHistoMap[make_pair(wireId.wheel(), wireId.superlayer())];
+    if (hVDriftHisto == 0) {
       theFile->cd();
       TString name = getHistoName(wireId).c_str();
-      if(wireId.superlayer() != 2){
-	hVDriftHisto = new TH1D(name+"_VDrift",
-			       "VDrift calibrated from MT per superlayer", 50, 0, 50);
-  	hResoHisto = new TH1D(name+"_Reso",
-			       "Reso calibrated from MT per superlayer", 50, 0, 50);
+      if (wireId.superlayer() != 2) {
+        hVDriftHisto = new TH1D(name + "_VDrift", "VDrift calibrated from MT per superlayer", 50, 0, 50);
+        hResoHisto = new TH1D(name + "_Reso", "Reso calibrated from MT per superlayer", 50, 0, 50);
+      } else {
+        hVDriftHisto = new TH1D(name + "_VDrift", "VDrift calibrated from MT per superlayer", 36, 0, 36);
+        hResoHisto = new TH1D(name + "_Reso", "Reso calibrated from MT per superlayer", 36, 0, 36);
       }
-      else{
- 	hVDriftHisto = new TH1D(name+"_VDrift",
-			       "VDrift calibrated from MT per superlayer", 36, 0, 36);
-  	hResoHisto = new TH1D(name+"_Reso",
-			       "Reso calibrated from MT per superlayer", 36, 0, 36);
-      }
-      theVDriftHistoMap[make_pair(wireId.wheel(),wireId.superlayer())] = hVDriftHisto;
-      theResoHistoMap[make_pair(wireId.wheel(),wireId.superlayer())] = hResoHisto;
+      theVDriftHistoMap[make_pair(wireId.wheel(), wireId.superlayer())] = hVDriftHisto;
+      theResoHistoMap[make_pair(wireId.wheel(), wireId.superlayer())] = hResoHisto;
     }
 
     //Fill the histos and set the bin label
     int binNumber = wireId.sector() + 12 * (wireId.station() - 1);
-    hVDriftHisto->SetBinContent(binNumber,vdrift);  
-    hResoHisto->SetBinContent(binNumber,reso);  
+    hVDriftHisto->SetBinContent(binNumber, vdrift);
+    hResoHisto->SetBinContent(binNumber, reso);
     string labelName;
     stringstream theStream;
-    if(wireId.sector() == 1)
-      theStream << "MB" << wireId.station() << "_Sec" << wireId.sector(); 
+    if (wireId.sector() == 1)
+      theStream << "MB" << wireId.station() << "_Sec" << wireId.sector();
     else
-      theStream << "Sec" << wireId.sector(); 
+      theStream << "Sec" << wireId.sector();
     theStream >> labelName;
-    hVDriftHisto->GetXaxis()->SetBinLabel(binNumber,labelName.c_str());  
-    hResoHisto->GetXaxis()->SetBinLabel(binNumber,labelName.c_str());  
+    hVDriftHisto->GetXaxis()->SetBinLabel(binNumber, labelName.c_str());
+    hResoHisto->GetXaxis()->SetBinLabel(binNumber, labelName.c_str());
 
     //Define a distribution for each wheel,station and each superlayer type
     vector<int> Wh_St_SL;
     Wh_St_SL.push_back(wireId.wheel());
     Wh_St_SL.push_back(wireId.station());
     Wh_St_SL.push_back(wireId.superlayer());
-    TH1D *hVDriftDistrib = theVDriftDistribMap[Wh_St_SL];
-    TH1D *hResoDistrib = theResoDistribMap[Wh_St_SL];
-    if(hVDriftDistrib == 0) {
+    TH1D* hVDriftDistrib = theVDriftDistribMap[Wh_St_SL];
+    TH1D* hResoDistrib = theResoDistribMap[Wh_St_SL];
+    if (hVDriftDistrib == 0) {
       theFile->cd();
       TString name = getDistribName(wireId).c_str();
-      hVDriftDistrib = new TH1D(name+"_VDrift",
-			       "VDrift calibrated from MT per superlayer", 100, 0.00530, 0.00580);
-      hResoDistrib = new TH1D(name+"_Reso",
-			       "Reso calibrated from MT per superlayer", 300, 0.015, 0.045);
+      hVDriftDistrib = new TH1D(name + "_VDrift", "VDrift calibrated from MT per superlayer", 100, 0.00530, 0.00580);
+      hResoDistrib = new TH1D(name + "_Reso", "Reso calibrated from MT per superlayer", 300, 0.015, 0.045);
       theVDriftDistribMap[Wh_St_SL] = hVDriftDistrib;
       theResoDistribMap[Wh_St_SL] = hResoDistrib;
     }
@@ -115,35 +100,32 @@ void DTVDriftAnalyzer::endJob() {
 
   //Write histos in a .root file
   theFile->cd();
-  for(map<pair<int,int>, TH1D*>::const_iterator lHisto = theVDriftHistoMap.begin();
-      lHisto != theVDriftHistoMap.end();
-      ++lHisto) {
+  for (map<pair<int, int>, TH1D*>::const_iterator lHisto = theVDriftHistoMap.begin(); lHisto != theVDriftHistoMap.end();
+       ++lHisto) {
     (*lHisto).second->GetXaxis()->LabelsOption("v");
-    (*lHisto).second->Write(); 
-  }    
-  for(map<pair<int,int>, TH1D*>::const_iterator lHisto = theResoHistoMap.begin();
-      lHisto != theResoHistoMap.end();
-      ++lHisto) {
+    (*lHisto).second->Write();
+  }
+  for (map<pair<int, int>, TH1D*>::const_iterator lHisto = theResoHistoMap.begin(); lHisto != theResoHistoMap.end();
+       ++lHisto) {
     (*lHisto).second->GetXaxis()->LabelsOption("v");
-    (*lHisto).second->Write(); 
-  } 
-   for(map<vector<int>, TH1D*>::const_iterator lDistrib = theVDriftDistribMap.begin();
-      lDistrib != theVDriftDistribMap.end();
-      ++lDistrib) {
-    (*lDistrib).second->Write(); 
-  }    
-  for(map<vector<int>, TH1D*>::const_iterator lDistrib = theResoDistribMap.begin();
-      lDistrib != theResoDistribMap.end();
-      ++lDistrib) {
-    (*lDistrib).second->Write(); 
-  }  
-
+    (*lHisto).second->Write();
+  }
+  for (map<vector<int>, TH1D*>::const_iterator lDistrib = theVDriftDistribMap.begin();
+       lDistrib != theVDriftDistribMap.end();
+       ++lDistrib) {
+    (*lDistrib).second->Write();
+  }
+  for (map<vector<int>, TH1D*>::const_iterator lDistrib = theResoDistribMap.begin();
+       lDistrib != theResoDistribMap.end();
+       ++lDistrib) {
+    (*lDistrib).second->Write();
+  }
 }
 
 string DTVDriftAnalyzer::getHistoName(const DTWireId& wId) const {
   string histoName;
   stringstream theStream;
-  theStream << "Wheel" << wId.wheel() << "_SL" << wId.superlayer(); 
+  theStream << "Wheel" << wId.wheel() << "_SL" << wId.superlayer();
   theStream >> histoName;
   return histoName;
 }
@@ -151,7 +133,7 @@ string DTVDriftAnalyzer::getHistoName(const DTWireId& wId) const {
 string DTVDriftAnalyzer::getDistribName(const DTWireId& wId) const {
   string histoName;
   stringstream theStream;
-  theStream << "Wheel" << wId.wheel() <<"_Station"<< wId.station() << "_SL" << wId.superlayer(); 
+  theStream << "Wheel" << wId.wheel() << "_Station" << wId.station() << "_SL" << wId.superlayer();
   theStream >> histoName;
   return histoName;
 }

--- a/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.h
@@ -31,30 +31,27 @@ public:
 
   /// Operations
   //Read the DTGeometry and the vdrift DB
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup );
+  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup);
   void analyze(const edm::Event& event, const edm::EventSetup& setup) {}
   //Do the real work
   void endJob();
 
 protected:
-
 private:
   std::string getHistoName(const DTWireId& lId) const;
   std::string getDistribName(const DTWireId& wId) const;
 
   // The file which will contain the histos
-  TFile *theFile;
+  TFile* theFile;
 
   //The t0 map
-  const DTMtime *mTimeMap;
-  
+  const DTMtime* mTimeMap;
+
   // Map of the vdrift, reso histos by wheel/sector/SL
-  std::map<std::pair<int,int>, TH1D*> theVDriftHistoMap;
-  std::map<std::pair<int,int>, TH1D*> theResoHistoMap;
- // Map of the vdrift, reso distributions by wheel/station/SL
+  std::map<std::pair<int, int>, TH1D*> theVDriftHistoMap;
+  std::map<std::pair<int, int>, TH1D*> theResoHistoMap;
+  // Map of the vdrift, reso distributions by wheel/station/SL
   std::map<std::vector<int>, TH1D*> theVDriftDistribMap;
   std::map<std::vector<int>, TH1D*> theResoDistribMap;
-
 };
 #endif
-

--- a/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.cc
@@ -8,7 +8,6 @@
 #include "DumpDBToFile.h"
 #include "DTCalibrationMap.h"
 
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -47,53 +46,50 @@ DumpDBToFile::DumpDBToFile(const ParameterSet& pset) {
   theOutputFileName = pset.getUntrackedParameter<string>("outputFileName");
 
   dbToDump = pset.getUntrackedParameter<string>("dbToDump", "TTrigDB");
-  dbLabel  = pset.getUntrackedParameter<string>("dbLabel", "");
+  dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
   format = pset.getUntrackedParameter<string>("dbFormat", "Legacy");
 
-  if(dbToDump != "VDriftDB" && dbToDump != "TTrigDB" && dbToDump != "TZeroDB" 
-     && dbToDump != "NoiseDB" && dbToDump != "DeadDB" && dbToDump != "ChannelsDB" && dbToDump != "RecoUncertDB")
+  if (dbToDump != "VDriftDB" && dbToDump != "TTrigDB" && dbToDump != "TZeroDB" && dbToDump != "NoiseDB" &&
+      dbToDump != "DeadDB" && dbToDump != "ChannelsDB" && dbToDump != "RecoUncertDB")
     throw cms::Exception("IncorrectSetup") << "Parameter dbToDump is not valid, check the cfg file" << endl;
 
-  if (format != "Legacy" &&
-      format != "DTRecoConditions")
+  if (format != "Legacy" && format != "DTRecoConditions")
     throw cms::Exception("IncorrectSetup") << "Parameter format is not valid, check the cfg file" << endl;
-
 }
 
-DumpDBToFile::~DumpDBToFile(){}
-
+DumpDBToFile::~DumpDBToFile() {}
 
 void DumpDBToFile::beginRun(const edm::Run&, const EventSetup& setup) {
   // Read the right DB accordingly to the parameter dbToDump
-  if(dbToDump == "VDriftDB") {
-    if (format=="Legacy") {
+  if (dbToDump == "VDriftDB") {
+    if (format == "Legacy") {
       ESHandle<DTMtime> mTime;
       setup.get<DTMtimeRcd>().get(mTime);
       mTimeMap = &*mTime;
-    } else if (format=="DTRecoConditions"){
+    } else if (format == "DTRecoConditions") {
       ESHandle<DTRecoConditions> h_rconds;
       setup.get<DTRecoConditionsVdriftRcd>().get(h_rconds);
       rconds = &*h_rconds;
     }
-  } else if(dbToDump == "TTrigDB") {
-    if (format=="Legacy") {
+  } else if (dbToDump == "TTrigDB") {
+    if (format == "Legacy") {
       ESHandle<DTTtrig> tTrig;
-      setup.get<DTTtrigRcd>().get(dbLabel,tTrig);
+      setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
       tTrigMap = &*tTrig;
-    } else if (format=="DTRecoConditions"){
+    } else if (format == "DTRecoConditions") {
       ESHandle<DTRecoConditions> h_rconds;
       setup.get<DTRecoConditionsTtrigRcd>().get(h_rconds);
       rconds = &*h_rconds;
     }
-  } else if(dbToDump == "TZeroDB") {
+  } else if (dbToDump == "TZeroDB") {
     ESHandle<DTT0> t0;
     setup.get<DTT0Rcd>().get(t0);
     tZeroMap = &*t0;
-  } else if(dbToDump == "NoiseDB") {
+  } else if (dbToDump == "NoiseDB") {
     ESHandle<DTStatusFlag> status;
     setup.get<DTStatusFlagRcd>().get(status);
     statusMap = &*status;
-  } else if(dbToDump == "DeadDB") {
+  } else if (dbToDump == "DeadDB") {
     ESHandle<DTDeadFlag> dead;
     setup.get<DTDeadFlagRcd>().get(dead);
     deadMap = &*dead;
@@ -102,11 +98,11 @@ void DumpDBToFile::beginRun(const edm::Run&, const EventSetup& setup) {
     setup.get<DTReadOutMappingRcd>().get(channels);
     channelsMap = &*channels;
   } else if (dbToDump == "RecoUncertDB") {
-    if (format=="Legacy") {
+    if (format == "Legacy") {
       ESHandle<DTRecoUncertainties> uncerts;
       setup.get<DTRecoUncertaintiesRcd>().get(uncerts);
       uncertMap = &*uncerts;
-    } else if (format=="DTRecoConditions"){
+    } else if (format == "DTRecoConditions") {
       ESHandle<DTRecoConditions> h_rconds;
       setup.get<DTRecoConditionsUncertRcd>().get(h_rconds);
       rconds = &*h_rconds;
@@ -114,271 +110,252 @@ void DumpDBToFile::beginRun(const edm::Run&, const EventSetup& setup) {
   }
 }
 
-
 void DumpDBToFile::endJob() {
-  
   if (dbToDump != "ChannelsDB") {
-
     //---------- VDrifts
-    if(dbToDump == "VDriftDB") {
-      if (format=="Legacy") {
-	int version = 1;
-	int type =1; //ie constant
-	int nfields=1;
-	cout << "[DumpDBToFile] MTime version: " << mTimeMap->version() << endl;
-	for(DTMtime::const_iterator mtime = mTimeMap->begin();
-	    mtime != mTimeMap->end(); ++mtime) {
-	  DTWireId wireId((*mtime).first.wheelId,
-			  (*mtime).first.stationId,
-			  (*mtime).first.sectorId,
-			  (*mtime).first.slId, 0, 0);
-	  float vdrift;
-	  float reso;
-	  DetId detId( wireId.rawId() );
-	  // vdrift is cm/ns , resolution is cm
-	  mTimeMap->get(detId, vdrift, reso, DTVelocityUnits::cm_per_ns);
-// 	  cout << "Wh: " << (*mtime).first.wheelId
-// 	       << " St: " << (*mtime).first.stationId
-// 	       << " Sc: " << (*mtime).first.sectorId
-// 	       << " Sl: " << (*mtime).first.slId
-// 	       << " VDrift (cm/ns): " << vdrift
-// 	       << " Hit reso (cm): " << reso << endl;
-	  vector<float> consts = {-1, -1, -1, vdrift, reso, -1, -1, -1, -1, -1, float(version*1000+type*100+nfields), vdrift};
-	  theCalibFile->addCell(wireId, consts);
-	}
-      }	else if (format=="DTRecoConditions") {
-	int version = rconds->version() ;
-	int type =1; // i.e. expr = "[0]"
-	string expr = rconds->getFormulaExpr();
-	cout << "[DumpDBToFile] DTRecoConditions (vdrift) version: " << version
-	     << " expression: " << expr << endl;
-	if (version!=1 || expr!="[0]") throw cms::Exception("Configuration") << "only version 1, type 1 is presently supported for VDriftDB";
-	for(DTRecoConditions::const_iterator irc = rconds->begin(); irc != rconds->end(); ++irc) {
-	  DTWireId wireId(irc->first);
-	  const vector<double>& data = irc->second;
-	  int nfields = data.size(); // FIXME check size
-	  float vdrift = data[0];
-	  float reso = 0;
-	  vector<float> consts(11+nfields,-1);
-	  consts[3] = vdrift;
-	  consts[4] = reso;
-	  consts[10] = float(version*1000+type*100+nfields);
-	  std::copy(data.begin(),data.end(),consts.begin()+11);
-	  theCalibFile->addCell(wireId, consts);
-	}
+    if (dbToDump == "VDriftDB") {
+      if (format == "Legacy") {
+        int version = 1;
+        int type = 1;  //ie constant
+        int nfields = 1;
+        cout << "[DumpDBToFile] MTime version: " << mTimeMap->version() << endl;
+        for (DTMtime::const_iterator mtime = mTimeMap->begin(); mtime != mTimeMap->end(); ++mtime) {
+          DTWireId wireId(
+              (*mtime).first.wheelId, (*mtime).first.stationId, (*mtime).first.sectorId, (*mtime).first.slId, 0, 0);
+          float vdrift;
+          float reso;
+          DetId detId(wireId.rawId());
+          // vdrift is cm/ns , resolution is cm
+          mTimeMap->get(detId, vdrift, reso, DTVelocityUnits::cm_per_ns);
+          // 	  cout << "Wh: " << (*mtime).first.wheelId
+          // 	       << " St: " << (*mtime).first.stationId
+          // 	       << " Sc: " << (*mtime).first.sectorId
+          // 	       << " Sl: " << (*mtime).first.slId
+          // 	       << " VDrift (cm/ns): " << vdrift
+          // 	       << " Hit reso (cm): " << reso << endl;
+          vector<float> consts = {
+              -1, -1, -1, vdrift, reso, -1, -1, -1, -1, -1, float(version * 1000 + type * 100 + nfields), vdrift};
+          theCalibFile->addCell(wireId, consts);
+        }
+      } else if (format == "DTRecoConditions") {
+        int version = rconds->version();
+        int type = 1;  // i.e. expr = "[0]"
+        string expr = rconds->getFormulaExpr();
+        cout << "[DumpDBToFile] DTRecoConditions (vdrift) version: " << version << " expression: " << expr << endl;
+        if (version != 1 || expr != "[0]")
+          throw cms::Exception("Configuration") << "only version 1, type 1 is presently supported for VDriftDB";
+        for (DTRecoConditions::const_iterator irc = rconds->begin(); irc != rconds->end(); ++irc) {
+          DTWireId wireId(irc->first);
+          const vector<double>& data = irc->second;
+          int nfields = data.size();  // FIXME check size
+          float vdrift = data[0];
+          float reso = 0;
+          vector<float> consts(11 + nfields, -1);
+          consts[3] = vdrift;
+          consts[4] = reso;
+          consts[10] = float(version * 1000 + type * 100 + nfields);
+          std::copy(data.begin(), data.end(), consts.begin() + 11);
+          theCalibFile->addCell(wireId, consts);
+        }
       }
 
-    //---------- TTrigs
-    } else if(dbToDump == "TTrigDB") {
-      if (format=="Legacy") {
-	int version = 1;
-	int type = 1; //ie constant
-	int nfields =1;
-	cout << "[DumpDBToFile] TTrig version: " << tTrigMap->version() << endl;
-	for(DTTtrig::const_iterator ttrig = tTrigMap->begin();
-	    ttrig != tTrigMap->end(); ++ttrig) {
-	  DTWireId wireId((*ttrig).first.wheelId,
-			  (*ttrig).first.stationId,
-			  (*ttrig).first.sectorId,
-			  (*ttrig).first.slId, 0, 0);
-	  DetId detId(wireId.rawId());
-	  float tmea;
-	  float trms;
-	  float kFactor;
-	  // ttrig and rms are ns
-	  tTrigMap->get(detId, tmea, trms, kFactor, DTTimeUnits::ns);
-// 	  cout << "Wh: " << (*ttrig).first.wheelId
-// 	       << " St: " << (*ttrig).first.stationId
-// 	       << " Sc: " << (*ttrig).first.sectorId
-// 	       << " Sl: " << (*ttrig).first.slId
-// 	       << " TTrig mean (ns): " << tmea
-// 	       << " TTrig sigma (ns): " << trms << endl;
+      //---------- TTrigs
+    } else if (dbToDump == "TTrigDB") {
+      if (format == "Legacy") {
+        int version = 1;
+        int type = 1;  //ie constant
+        int nfields = 1;
+        cout << "[DumpDBToFile] TTrig version: " << tTrigMap->version() << endl;
+        for (DTTtrig::const_iterator ttrig = tTrigMap->begin(); ttrig != tTrigMap->end(); ++ttrig) {
+          DTWireId wireId(
+              (*ttrig).first.wheelId, (*ttrig).first.stationId, (*ttrig).first.sectorId, (*ttrig).first.slId, 0, 0);
+          DetId detId(wireId.rawId());
+          float tmea;
+          float trms;
+          float kFactor;
+          // ttrig and rms are ns
+          tTrigMap->get(detId, tmea, trms, kFactor, DTTimeUnits::ns);
+          // 	  cout << "Wh: " << (*ttrig).first.wheelId
+          // 	       << " St: " << (*ttrig).first.stationId
+          // 	       << " Sc: " << (*ttrig).first.sectorId
+          // 	       << " Sl: " << (*ttrig).first.slId
+          // 	       << " TTrig mean (ns): " << tmea
+          // 	       << " TTrig sigma (ns): " << trms << endl;
 
-	  // note that in the free fields we write one single time = tmea+trms*kFactor, as per current use:
-	  // https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc#L197
-	  vector<float> consts = {tmea, trms, kFactor, -1, -1, -1, -1, -1, -1, -1, float(version*1000+type*100+nfields), tmea+ trms*kFactor}; 
-	  theCalibFile->addCell(wireId, consts);
-	}
-      }	else if (format=="DTRecoConditions") {
-	int version = rconds->version();
-	int type = 1; // i.e. expr = "[0]"
-	string expr = rconds->getFormulaExpr();
-	if (version!=1||expr!="[0]") throw cms::Exception("Configuration") << "only version 1, type 1 is presently supported for TTrigDB";
+          // note that in the free fields we write one single time = tmea+trms*kFactor, as per current use:
+          // https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc#L197
+          vector<float> consts = {tmea,
+                                  trms,
+                                  kFactor,
+                                  -1,
+                                  -1,
+                                  -1,
+                                  -1,
+                                  -1,
+                                  -1,
+                                  -1,
+                                  float(version * 1000 + type * 100 + nfields),
+                                  tmea + trms * kFactor};
+          theCalibFile->addCell(wireId, consts);
+        }
+      } else if (format == "DTRecoConditions") {
+        int version = rconds->version();
+        int type = 1;  // i.e. expr = "[0]"
+        string expr = rconds->getFormulaExpr();
+        if (version != 1 || expr != "[0]")
+          throw cms::Exception("Configuration") << "only version 1, type 1 is presently supported for TTrigDB";
 
-	cout << "[DumpDBToFile] DTRecoConditions (ttrig) version: " << rconds->version() 
-	     << " expression: " << expr << endl;
-	for(DTRecoConditions::const_iterator irc = rconds->begin(); irc != rconds->end(); ++irc) {
-	  DTWireId wireId(irc->first);
-	  const vector<double>& data = irc->second;
-	  int nfields = data.size(); // FIXME check size (should be 1)
-	  float ttrig = data[0];
-	  float sigma = 0; // Unused in DTRecoConditions
-	  float kappa = 0;
+        cout << "[DumpDBToFile] DTRecoConditions (ttrig) version: " << rconds->version() << " expression: " << expr
+             << endl;
+        for (DTRecoConditions::const_iterator irc = rconds->begin(); irc != rconds->end(); ++irc) {
+          DTWireId wireId(irc->first);
+          const vector<double>& data = irc->second;
+          int nfields = data.size();  // FIXME check size (should be 1)
+          float ttrig = data[0];
+          float sigma = 0;  // Unused in DTRecoConditions
+          float kappa = 0;
 
-	  vector<float> consts(11+nfields,-1);
-	  consts[0]=ttrig;
-	  consts[1]=sigma;
-	  consts[2]=kappa;
-	  consts[10] = float(version*1000+type*100+nfields);
-	  std::copy(data.begin(),data.end(),consts.begin()+11);
-	  theCalibFile->addCell(wireId, consts);	  
-	}
+          vector<float> consts(11 + nfields, -1);
+          consts[0] = ttrig;
+          consts[1] = sigma;
+          consts[2] = kappa;
+          consts[10] = float(version * 1000 + type * 100 + nfields);
+          std::copy(data.begin(), data.end(), consts.begin() + 11);
+          theCalibFile->addCell(wireId, consts);
+        }
       }
 
-
-    //---------- T0, noise, dead
-    } else if(dbToDump == "TZeroDB") {
+      //---------- T0, noise, dead
+    } else if (dbToDump == "TZeroDB") {
       cout << "[DumpDBToFile] T0 version: " << tZeroMap->version() << endl;
-      for(DTT0::const_iterator tzero = tZeroMap->begin();
-	  tzero != tZeroMap->end(); ++tzero) {
-// @@@ NEW DTT0 FORMAT
-//	DTWireId wireId((*tzero).first.wheelId,
-//			(*tzero).first.stationId,
-//			(*tzero).first.sectorId,
-//			(*tzero).first.slId,
-//			(*tzero).first.layerId,
-//			(*tzero).first.cellId);
+      for (DTT0::const_iterator tzero = tZeroMap->begin(); tzero != tZeroMap->end(); ++tzero) {
+        // @@@ NEW DTT0 FORMAT
+        //	DTWireId wireId((*tzero).first.wheelId,
+        //			(*tzero).first.stationId,
+        //			(*tzero).first.sectorId,
+        //			(*tzero).first.slId,
+        //			(*tzero).first.layerId,
+        //			(*tzero).first.cellId);
         int channelId = tzero->channelId;
-        if ( channelId == 0 ) continue;
+        if (channelId == 0)
+          continue;
         DTWireId wireId(channelId);
-// @@@ NEW DTT0 END
+        // @@@ NEW DTT0 END
         float t0mean;
         float t0rms;
         // t0s and rms are TDC counts
         tZeroMap->get(wireId, t0mean, t0rms, DTTimeUnits::counts);
-	cout << wireId
-	     << " TZero mean (TDC counts): " << t0mean
-	     << " TZero RMS (TDC counts): " << t0rms << endl;
-	vector<float> consts;
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(t0mean);      
-	consts.push_back(t0rms);
+        cout << wireId << " TZero mean (TDC counts): " << t0mean << " TZero RMS (TDC counts): " << t0rms << endl;
+        vector<float> consts;
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(t0mean);
+        consts.push_back(t0rms);
 
-	theCalibFile->addCell(wireId, consts);
+        theCalibFile->addCell(wireId, consts);
       }
-    } else if(dbToDump == "NoiseDB") {
-      for(DTStatusFlag::const_iterator statusFlag = statusMap->begin();
-	  statusFlag != statusMap->end(); ++statusFlag) {
-	DTWireId wireId((*statusFlag).first.wheelId,
-			(*statusFlag).first.stationId,
-			(*statusFlag).first.sectorId,
-			(*statusFlag).first.slId,
-			(*statusFlag).first.layerId,
-			(*statusFlag).first.cellId);
-	cout << wireId
-	     << " Noisy Flag: " << (*statusFlag).second.noiseFlag << endl;
-	vector<float> consts;
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-9999999);      
-	consts.push_back(-9999999);
-	consts.push_back((*statusFlag).second.noiseFlag);
+    } else if (dbToDump == "NoiseDB") {
+      for (DTStatusFlag::const_iterator statusFlag = statusMap->begin(); statusFlag != statusMap->end(); ++statusFlag) {
+        DTWireId wireId((*statusFlag).first.wheelId,
+                        (*statusFlag).first.stationId,
+                        (*statusFlag).first.sectorId,
+                        (*statusFlag).first.slId,
+                        (*statusFlag).first.layerId,
+                        (*statusFlag).first.cellId);
+        cout << wireId << " Noisy Flag: " << (*statusFlag).second.noiseFlag << endl;
+        vector<float> consts;
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-9999999);
+        consts.push_back(-9999999);
+        consts.push_back((*statusFlag).second.noiseFlag);
 
-	theCalibFile->addCell(wireId, consts);
+        theCalibFile->addCell(wireId, consts);
       }
-    }  else if(dbToDump == "DeadDB") {
-      for(DTDeadFlag::const_iterator deadFlag = deadMap->begin();
-	  deadFlag != deadMap->end(); ++deadFlag) {
-	DTWireId wireId((*deadFlag).first.wheelId,
-			(*deadFlag).first.stationId,
-			(*deadFlag).first.sectorId,
-			(*deadFlag).first.slId,
-			(*deadFlag).first.layerId,
-			(*deadFlag).first.cellId);
-	cout << wireId
-	     << " Dead Flag: " << (*deadFlag).second.dead_TP << endl;
-	vector<float> consts;
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-9999999);      
-	consts.push_back(-9999999);
-	consts.push_back((*deadFlag).second.dead_TP);
+    } else if (dbToDump == "DeadDB") {
+      for (DTDeadFlag::const_iterator deadFlag = deadMap->begin(); deadFlag != deadMap->end(); ++deadFlag) {
+        DTWireId wireId((*deadFlag).first.wheelId,
+                        (*deadFlag).first.stationId,
+                        (*deadFlag).first.sectorId,
+                        (*deadFlag).first.slId,
+                        (*deadFlag).first.layerId,
+                        (*deadFlag).first.cellId);
+        cout << wireId << " Dead Flag: " << (*deadFlag).second.dead_TP << endl;
+        vector<float> consts;
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-1);
+        consts.push_back(-9999999);
+        consts.push_back(-9999999);
+        consts.push_back((*deadFlag).second.dead_TP);
 
-	theCalibFile->addCell(wireId, consts);
+        theCalibFile->addCell(wireId, consts);
       }
 
-    //---------- Uncertainties
-    } else if(dbToDump == "RecoUncertDB") {
-      if (format=="Legacy") {
-	int version = 1;
-	int type =2; // par[step]
-	cout << "RecoUncertDB version: " << uncertMap->version() << endl;
-	for(DTRecoUncertainties::const_iterator wireAndUncerts = uncertMap->begin();
-	    wireAndUncerts != uncertMap->end(); ++wireAndUncerts) {
-	  DTWireId wireId((*wireAndUncerts).first);
-	  vector<float> values = (*wireAndUncerts).second;	
-// 	  cout << wireId;
-// 	  copy(values.begin(), values.end(), ostream_iterator<float>(cout, " cm, "));
-// 	  cout << endl;
-	  int nfields=values.size();
-	  vector<float> consts = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, float(version*1000+type*100+nfields)};	  
-	  consts.insert(consts.end(), values.begin(), values.end());
-	  theCalibFile->addCell(wireId, consts);
-	}
-      }	else if (format=="DTRecoConditions") {
-	int version = rconds->version();
-	string expr = rconds->getFormulaExpr();
-	int type = 2; // par[step]
-	if (version!=1||expr!="par[step]") throw cms::Exception("Configuration") << "only version 1, type 2 is presently supported for RecoUncertDB";
+      //---------- Uncertainties
+    } else if (dbToDump == "RecoUncertDB") {
+      if (format == "Legacy") {
+        int version = 1;
+        int type = 2;  // par[step]
+        cout << "RecoUncertDB version: " << uncertMap->version() << endl;
+        for (DTRecoUncertainties::const_iterator wireAndUncerts = uncertMap->begin();
+             wireAndUncerts != uncertMap->end();
+             ++wireAndUncerts) {
+          DTWireId wireId((*wireAndUncerts).first);
+          vector<float> values = (*wireAndUncerts).second;
+          // 	  cout << wireId;
+          // 	  copy(values.begin(), values.end(), ostream_iterator<float>(cout, " cm, "));
+          // 	  cout << endl;
+          int nfields = values.size();
+          vector<float> consts = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, float(version * 1000 + type * 100 + nfields)};
+          consts.insert(consts.end(), values.begin(), values.end());
+          theCalibFile->addCell(wireId, consts);
+        }
+      } else if (format == "DTRecoConditions") {
+        int version = rconds->version();
+        string expr = rconds->getFormulaExpr();
+        int type = 2;  // par[step]
+        if (version != 1 || expr != "par[step]")
+          throw cms::Exception("Configuration") << "only version 1, type 2 is presently supported for RecoUncertDB";
 
-	cout << "[DumpDBToFile] DTRecoConditions (uncerts) version: " << rconds->version() 
-	     << " expression: " << expr << endl;
+        cout << "[DumpDBToFile] DTRecoConditions (uncerts) version: " << rconds->version() << " expression: " << expr
+             << endl;
 
-	for(DTRecoConditions::const_iterator irc = rconds->begin(); irc != rconds->end(); ++irc) {
-	  DTWireId wireId(irc->first);
-	  const vector<double>& data = irc->second;
-	  int nfields = data.size();
-	  vector<float> consts(11+nfields,-1);
-	  consts[10] = float(version*1000+type*100+nfields);
-	  std::copy(data.begin(),data.end(),consts.begin()+11);	  
-	  theCalibFile->addCell(wireId, consts);
-	}
+        for (DTRecoConditions::const_iterator irc = rconds->begin(); irc != rconds->end(); ++irc) {
+          DTWireId wireId(irc->first);
+          const vector<double>& data = irc->second;
+          int nfields = data.size();
+          vector<float> consts(11 + nfields, -1);
+          consts[10] = float(version * 1000 + type * 100 + nfields);
+          std::copy(data.begin(), data.end(), consts.begin() + 11);
+          theCalibFile->addCell(wireId, consts);
+        }
       }
     }
     //Write constants into file
     theCalibFile->writeConsts(theOutputFileName);
   }
 
-  else if (dbToDump == "ChannelsDB"){
+  else if (dbToDump == "ChannelsDB") {
     ofstream out(theOutputFileName.c_str());
-    for(DTReadOutMapping::const_iterator roLink = channelsMap->begin();
-	roLink != channelsMap->end(); ++roLink) {
-      out << roLink->dduId << ' ' 
-	  << roLink->rosId << ' ' 
-	  << roLink->robId << ' ' 
-	  << roLink->tdcId << ' ' 
-	  << roLink->channelId << ' ' 
-	  << roLink->wheelId << ' ' 
-	  << roLink->stationId << ' ' 
-	  << roLink->sectorId << ' ' 
-	  << roLink->slId << ' ' 
-	  << roLink->layerId << ' ' 
-	  << roLink->cellId <<endl;
-       
-      cout << "ddu " <<roLink->dduId << ' ' 
-	   << "ros " <<roLink->rosId << ' ' 
-	   << "rob " <<roLink->robId << ' ' 
-	   << "tdc " <<roLink->tdcId << ' ' 
-	   << "channel " <<roLink->channelId << ' ' << "->" << ' '
-	   << "wheel "   <<roLink->wheelId << ' ' 
-	   << "station " <<roLink->stationId << ' ' 
-	   << "sector "  <<roLink->sectorId << ' ' 
-	   << "superlayer " << roLink->slId << ' ' 
-	   << "layer "   << roLink->layerId << ' ' 
-	   << "wire "    << roLink->cellId << ' '<<endl;
+    for (DTReadOutMapping::const_iterator roLink = channelsMap->begin(); roLink != channelsMap->end(); ++roLink) {
+      out << roLink->dduId << ' ' << roLink->rosId << ' ' << roLink->robId << ' ' << roLink->tdcId << ' '
+          << roLink->channelId << ' ' << roLink->wheelId << ' ' << roLink->stationId << ' ' << roLink->sectorId << ' '
+          << roLink->slId << ' ' << roLink->layerId << ' ' << roLink->cellId << endl;
+
+      cout << "ddu " << roLink->dduId << ' ' << "ros " << roLink->rosId << ' ' << "rob " << roLink->robId << ' '
+           << "tdc " << roLink->tdcId << ' ' << "channel " << roLink->channelId << ' ' << "->" << ' ' << "wheel "
+           << roLink->wheelId << ' ' << "station " << roLink->stationId << ' ' << "sector " << roLink->sectorId << ' '
+           << "superlayer " << roLink->slId << ' ' << "layer " << roLink->layerId << ' ' << "wire " << roLink->cellId
+           << ' ' << endl;
     }
   }
-
-
 }
-

--- a/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.h
@@ -27,20 +27,19 @@ class DTRecoConditions;
 class DumpDBToFile : public edm::EDAnalyzer {
 public:
   /// Constructor
-  DumpDBToFile(const edm::ParameterSet& pset);
+  DumpDBToFile(const edm::ParameterSet &pset);
 
   /// Destructor
   virtual ~DumpDBToFile();
 
   // Operations
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup );
+  virtual void beginRun(const edm::Run &run, const edm::EventSetup &setup);
 
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){}
+  virtual void analyze(const edm::Event &event, const edm::EventSetup &setup) {}
 
   virtual void endJob();
 
 protected:
-
 private:
   const DTMtime *mTimeMap;
   const DTTtrig *tTrigMap;
@@ -58,7 +57,5 @@ private:
   std::string dbToDump;
   std::string dbLabel;
   std::string format;
-
 };
 #endif
-

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
@@ -10,7 +10,6 @@
 #include "DumpFileToDB.h"
 #include "DTCalibrationMap.h"
 
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -36,300 +35,282 @@ using namespace edm;
 using namespace std;
 
 DumpFileToDB::DumpFileToDB(const ParameterSet& pset) {
-
   dbToDump = pset.getUntrackedParameter<string>("dbToDump", "TTrigDB");
   format = pset.getUntrackedParameter<string>("dbFormat", "Legacy");
 
   cout << "Writing DB: " << dbToDump << " with format: " << format << endl;
 
+  if (dbToDump != "ChannelsDB")
+    theCalibFile = new DTCalibrationMap(pset.getUntrackedParameter<ParameterSet>("calibFileConfig"));
 
-  if(dbToDump != "ChannelsDB") theCalibFile = new DTCalibrationMap(pset.getUntrackedParameter<ParameterSet>("calibFileConfig"));
+  mapFileName = pset.getUntrackedParameter<ParameterSet>("calibFileConfig")
+                    .getUntrackedParameter<string>("calibConstFileName", "dummy.txt");
 
-  mapFileName = pset.getUntrackedParameter<ParameterSet>("calibFileConfig").getUntrackedParameter<string>("calibConstFileName", "dummy.txt");
-
-  if(dbToDump != "VDriftDB" &&
-     dbToDump != "TTrigDB" &&
-     dbToDump != "TZeroDB" && 
-     dbToDump != "NoiseDB" &&
-     dbToDump != "DeadDB" &&
-     dbToDump != "ChannelsDB" &&
-     dbToDump != "RecoUncertDB")
+  if (dbToDump != "VDriftDB" && dbToDump != "TTrigDB" && dbToDump != "TZeroDB" && dbToDump != "NoiseDB" &&
+      dbToDump != "DeadDB" && dbToDump != "ChannelsDB" && dbToDump != "RecoUncertDB")
     throw cms::Exception("IncorrectSetup") << "Parameter dbToDump is not valid";
 
-  if (format != "Legacy" &&
-      format != "DTRecoConditions")
+  if (format != "Legacy" && format != "DTRecoConditions")
     throw cms::Exception("IncorrectSetup") << "Parameter format is not valid";
 
-  if (format == "DTRecoConditions" &&
-      (dbToDump != "VDriftDB" && 
-       dbToDump != "TTrigDB" &&
-       dbToDump != "RecoUncertDB"))
-    throw cms::Exception("IncorrectSetup") << "DTRecoConditions currently implemented only for TTrigDB, VDriftDB, RecoUncertDB";
+  if (format == "DTRecoConditions" && (dbToDump != "VDriftDB" && dbToDump != "TTrigDB" && dbToDump != "RecoUncertDB"))
+    throw cms::Exception("IncorrectSetup")
+        << "DTRecoConditions currently implemented only for TTrigDB, VDriftDB, RecoUncertDB";
 
   diffMode = pset.getUntrackedParameter<bool>("differentialMode", false);
-  if(diffMode) {
-    if(dbToDump != "TTrigDB") {
+  if (diffMode) {
+    if (dbToDump != "TTrigDB") {
       throw cms::Exception("IncorrectSetup") << "Differential mode currently implemented for ttrig only";
     }
     cout << "Using differential mode: mean value of txt table will be added to the current DB value" << endl;
   }
-
 }
- 
-DumpFileToDB::~DumpFileToDB(){}
 
+DumpFileToDB::~DumpFileToDB() {}
 
 void DumpFileToDB::endJob() {
-
   //---------- VDrift
-  if(dbToDump == "VDriftDB") {
-    if (format=="Legacy") {
+  if (dbToDump == "VDriftDB") {
+    if (format == "Legacy") {
       DTMtime* mtime = new DTMtime();
-      for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-	  keyAndCalibs != theCalibFile->keyAndConsts_end();
-	  ++keyAndCalibs) {
-	// 	cout << "key: " << (*keyAndCalibs).first
-	// 	     << " vdrift (cm/ns): " << theCalibFile->meanVDrift((*keyAndCalibs).first)
-	// 	     << " hit reso (cm): " << theCalibFile->sigma_meanVDrift((*keyAndCalibs).first) << endl;
-	// vdrift is cm/ns , resolution is cm
-	mtime->set((*keyAndCalibs).first.superlayerId(),
-		   theCalibFile->meanVDrift((*keyAndCalibs).first), 
-		   theCalibFile->sigma_meanVDrift((*keyAndCalibs).first),
-		   DTVelocityUnits::cm_per_ns);
+      for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+           keyAndCalibs != theCalibFile->keyAndConsts_end();
+           ++keyAndCalibs) {
+        // 	cout << "key: " << (*keyAndCalibs).first
+        // 	     << " vdrift (cm/ns): " << theCalibFile->meanVDrift((*keyAndCalibs).first)
+        // 	     << " hit reso (cm): " << theCalibFile->sigma_meanVDrift((*keyAndCalibs).first) << endl;
+        // vdrift is cm/ns , resolution is cm
+        mtime->set((*keyAndCalibs).first.superlayerId(),
+                   theCalibFile->meanVDrift((*keyAndCalibs).first),
+                   theCalibFile->sigma_meanVDrift((*keyAndCalibs).first),
+                   DTVelocityUnits::cm_per_ns);
       }
       DTCalibDBUtils::writeToDB<DTMtime>("DTMtimeRcd", mtime);
-    } else if (format=="DTRecoConditions") {
+    } else if (format == "DTRecoConditions") {
       DTRecoConditions* conds = new DTRecoConditions();
       conds->setFormulaExpr("[0]");
       //      conds->setFormulaExpr("[0]*(1-[1]*x)");
       int version = 1;
       conds->setVersion(version);
-      for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-	  keyAndCalibs != theCalibFile->keyAndConsts_end();
-	  ++keyAndCalibs) {
+      for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+           keyAndCalibs != theCalibFile->keyAndConsts_end();
+           ++keyAndCalibs) {
+        vector<float> values = (*keyAndCalibs).second;
+        int fversion = int(values[10] / 1000);
+        int type = (int(values[10]) % 1000) / 100;
+        int nfields = int(values[10]) % 100;
+        if (type != 1)
+          throw cms::Exception("IncorrectSetup") << "Input file is not for VDriftDB";
+        if (values.size() != unsigned(nfields + 11))
+          throw cms::Exception("IncorrectSetup") << "Inconsistent number of fields";
+        if (fversion != version)
+          throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
 
-	vector<float> values = (*keyAndCalibs).second;
-	int fversion = int(values[10]/1000);
-	int type = (int(values[10])%1000)/100;
-	int nfields = int(values[10])%100;
-	if (type !=1) throw cms::Exception("IncorrectSetup") << "Input file is not for VDriftDB";
-	if (values.size()!=unsigned(nfields+11)) throw cms::Exception("IncorrectSetup") << "Inconsistent number of fields";
-	if (fversion!=version) throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
-	
-	vector<double> params(values.begin()+11, values.begin()+11+nfields);
-	conds->set((*keyAndCalibs).first, params);
+        vector<double> params(values.begin() + 11, values.begin() + 11 + nfields);
+        conds->set((*keyAndCalibs).first, params);
       }
-      DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsVdriftRcd", conds);      
+      DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsVdriftRcd", conds);
     }
-  
-  //---------- TTrig
-  } else if(dbToDump == "TTrigDB") {
-    if (format=="Legacy") {
-      DTTtrig* tTrig = new DTTtrig();
-      for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-	  keyAndCalibs != theCalibFile->keyAndConsts_end();
-	  ++keyAndCalibs) {
-      
-	if(diffMode) { // sum the correction in the txt file (for the mean value) to what is input DB	  
-	  // retrieve the previous value from the DB
-	  float tmean;
-	  float trms;
-	  float kFactor;
-	  // ttrig and rms are ns
-	  tTrigMapOrig->get((*keyAndCalibs).first.rawId(), tmean, trms, kFactor, DTTimeUnits::ns);	
-	  if(theCalibFile->kFactor((*keyAndCalibs).first) != 0 || kFactor != 0) {
-	    throw cms::Exception("IncorrectSetup") << "The differentialMode can only be used with kFactor = 0, old: " << kFactor
-						   << " new: " << theCalibFile->kFactor((*keyAndCalibs).first);
-	  }
-	  tTrig->set((*keyAndCalibs).first.superlayerId(),
-		     theCalibFile->tTrig((*keyAndCalibs).first) + tmean, 
-		     theCalibFile->sigma_tTrig((*keyAndCalibs).first),
-		     theCalibFile->kFactor((*keyAndCalibs).first),
-		     DTTimeUnits::ns);
-// 	  cout << "key: " << (*keyAndCalibs).first
-// 	       << " ttrig_mean (ns): " << theCalibFile->tTrig((*keyAndCalibs).first) + tmean
-// 	       << " ttrig_sigma(ns): " << theCalibFile->sigma_tTrig((*keyAndCalibs).first)
-// 	       << " kFactor: " << theCalibFile->kFactor((*keyAndCalibs).first) << endl;
 
-	} else { // Normal mode
-// 	  cout << "key: " << (*keyAndCalibs).first
-// 	       << " ttrig_mean (ns): " << theCalibFile->tTrig((*keyAndCalibs).first)
-// 	       << " ttrig_sigma(ns): " << theCalibFile->sigma_tTrig((*keyAndCalibs).first)
-// 	       << " kFactor: " << theCalibFile->kFactor((*keyAndCalibs).first) << endl;
-	  tTrig->set((*keyAndCalibs).first.superlayerId(),
-		     theCalibFile->tTrig((*keyAndCalibs).first), 
-		     theCalibFile->sigma_tTrig((*keyAndCalibs).first),
-		     theCalibFile->kFactor((*keyAndCalibs).first),
-		     DTTimeUnits::ns);
-	}
+    //---------- TTrig
+  } else if (dbToDump == "TTrigDB") {
+    if (format == "Legacy") {
+      DTTtrig* tTrig = new DTTtrig();
+      for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+           keyAndCalibs != theCalibFile->keyAndConsts_end();
+           ++keyAndCalibs) {
+        if (diffMode) {  // sum the correction in the txt file (for the mean value) to what is input DB
+          // retrieve the previous value from the DB
+          float tmean;
+          float trms;
+          float kFactor;
+          // ttrig and rms are ns
+          tTrigMapOrig->get((*keyAndCalibs).first.rawId(), tmean, trms, kFactor, DTTimeUnits::ns);
+          if (theCalibFile->kFactor((*keyAndCalibs).first) != 0 || kFactor != 0) {
+            throw cms::Exception("IncorrectSetup")
+                << "The differentialMode can only be used with kFactor = 0, old: " << kFactor
+                << " new: " << theCalibFile->kFactor((*keyAndCalibs).first);
+          }
+          tTrig->set((*keyAndCalibs).first.superlayerId(),
+                     theCalibFile->tTrig((*keyAndCalibs).first) + tmean,
+                     theCalibFile->sigma_tTrig((*keyAndCalibs).first),
+                     theCalibFile->kFactor((*keyAndCalibs).first),
+                     DTTimeUnits::ns);
+          // 	  cout << "key: " << (*keyAndCalibs).first
+          // 	       << " ttrig_mean (ns): " << theCalibFile->tTrig((*keyAndCalibs).first) + tmean
+          // 	       << " ttrig_sigma(ns): " << theCalibFile->sigma_tTrig((*keyAndCalibs).first)
+          // 	       << " kFactor: " << theCalibFile->kFactor((*keyAndCalibs).first) << endl;
+
+        } else {  // Normal mode
+                  // 	  cout << "key: " << (*keyAndCalibs).first
+                  // 	       << " ttrig_mean (ns): " << theCalibFile->tTrig((*keyAndCalibs).first)
+                  // 	       << " ttrig_sigma(ns): " << theCalibFile->sigma_tTrig((*keyAndCalibs).first)
+                  // 	       << " kFactor: " << theCalibFile->kFactor((*keyAndCalibs).first) << endl;
+          tTrig->set((*keyAndCalibs).first.superlayerId(),
+                     theCalibFile->tTrig((*keyAndCalibs).first),
+                     theCalibFile->sigma_tTrig((*keyAndCalibs).first),
+                     theCalibFile->kFactor((*keyAndCalibs).first),
+                     DTTimeUnits::ns);
+        }
       }
       DTCalibDBUtils::writeToDB<DTTtrig>("DTTtrigRcd", tTrig);
 
-    } else if (format=="DTRecoConditions") {
+    } else if (format == "DTRecoConditions") {
       DTRecoConditions* conds = new DTRecoConditions();
       conds->setFormulaExpr("[0]");
       int version = 1;
       conds->setVersion(version);
 
-      for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-	  keyAndCalibs != theCalibFile->keyAndConsts_end();
-	  ++keyAndCalibs) {
+      for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+           keyAndCalibs != theCalibFile->keyAndConsts_end();
+           ++keyAndCalibs) {
+        vector<float> values = (*keyAndCalibs).second;
+        int fversion = int(values[10] / 1000);
+        int type = (int(values[10]) % 1000) / 100;
+        int nfields = int(values[10]) % 100;
 
-	vector<float> values = (*keyAndCalibs).second;
-	int fversion = int(values[10]/1000);
-	int type = (int(values[10])%1000)/100;
-	int nfields = int(values[10])%100;
+        if (type != 1)
+          throw cms::Exception("IncorrectSetup") << "Only type==1 currently supported for TTrigDB";
+        if (values.size() != unsigned(nfields + 11))
+          throw cms::Exception("IncorrectSetup") << "Inconsistent number of fields";
+        if (fversion != version)
+          throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
 
-	if (type!=1) throw cms::Exception("IncorrectSetup") << "Only type==1 currently supported for TTrigDB";
-	if (values.size()!=unsigned(nfields+11)) throw cms::Exception("IncorrectSetup") << "Inconsistent number of fields";
-	if (fversion!=version) throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
-
-	vector<double> params(values.begin()+11, values.begin()+11+nfields);
-	conds->set((*keyAndCalibs).first, params);
+        vector<double> params(values.begin() + 11, values.begin() + 11 + nfields);
+        conds->set((*keyAndCalibs).first, params);
       }
       DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsTtrigRcd", conds);
     }
-    
-  } else if(dbToDump == "TZeroDB") { // Write the T0
+
+  } else if (dbToDump == "TZeroDB") {  // Write the T0
 
     // Create the object to be written to DB
     DTT0* tZeroMap = new DTT0();
 
     // Loop over file entries
-    for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-	keyAndCalibs != theCalibFile->keyAndConsts_end();
-	++keyAndCalibs) {
+    for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+         keyAndCalibs != theCalibFile->keyAndConsts_end();
+         ++keyAndCalibs) {
       float t0mean = (*keyAndCalibs).second[5];
       float t0rms = (*keyAndCalibs).second[6];
-      cout << "key: " << (*keyAndCalibs).first
-	   << " T0 mean (TDC counts): " << t0mean
-	   << " T0_rms (TDC counts): " << t0rms << endl;
-      tZeroMap->set((*keyAndCalibs).first,
-		    t0mean,
-		    t0rms,
-		    DTTimeUnits::counts);
+      cout << "key: " << (*keyAndCalibs).first << " T0 mean (TDC counts): " << t0mean
+           << " T0_rms (TDC counts): " << t0rms << endl;
+      tZeroMap->set((*keyAndCalibs).first, t0mean, t0rms, DTTimeUnits::counts);
     }
 
     DTCalibDBUtils::writeToDB<DTT0>("DTT0Rcd", tZeroMap);
 
-  } else if(dbToDump == "NoiseDB") { // Write the Noise
-    DTStatusFlag *statusMap = new DTStatusFlag();
-    
+  } else if (dbToDump == "NoiseDB") {  // Write the Noise
+    DTStatusFlag* statusMap = new DTStatusFlag();
+
     // Loop over file entries
-    for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-	keyAndCalibs != theCalibFile->keyAndConsts_end();
-	++keyAndCalibs) {
-      cout << "key: " << (*keyAndCalibs).first
-	   << " Noisy flag: " << (*keyAndCalibs).second[7] << endl;
-      statusMap->setCellNoise((*keyAndCalibs).first,
-			      (*keyAndCalibs).second[7]);
+    for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+         keyAndCalibs != theCalibFile->keyAndConsts_end();
+         ++keyAndCalibs) {
+      cout << "key: " << (*keyAndCalibs).first << " Noisy flag: " << (*keyAndCalibs).second[7] << endl;
+      statusMap->setCellNoise((*keyAndCalibs).first, (*keyAndCalibs).second[7]);
     }
 
     DTCalibDBUtils::writeToDB<DTStatusFlag>("DTStatusFlagRcd", statusMap);
-  
-  } else if(dbToDump == "DeadDB") { // Write the tp-dead
-    DTDeadFlag *deadMap = new DTDeadFlag();
-    
+
+  } else if (dbToDump == "DeadDB") {  // Write the tp-dead
+    DTDeadFlag* deadMap = new DTDeadFlag();
+
     // Loop over file entries
-    for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-	keyAndCalibs != theCalibFile->keyAndConsts_end();
-	++keyAndCalibs) {
-      cout << "key: " << (*keyAndCalibs).first
-	   << " dead flag: " << (*keyAndCalibs).second[7] << endl;
-      deadMap->setCellDead_TP((*keyAndCalibs).first,
-			      (*keyAndCalibs).second[7]);
+    for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+         keyAndCalibs != theCalibFile->keyAndConsts_end();
+         ++keyAndCalibs) {
+      cout << "key: " << (*keyAndCalibs).first << " dead flag: " << (*keyAndCalibs).second[7] << endl;
+      deadMap->setCellDead_TP((*keyAndCalibs).first, (*keyAndCalibs).second[7]);
     }
 
     DTCalibDBUtils::writeToDB<DTDeadFlag>("DTDeadFlagRcd", deadMap);
-  
-  } else if (dbToDump == "ChannelsDB") { //Write channels map
-    
-    DTReadOutMapping* ro_map = new DTReadOutMapping( "cmssw_ROB",
-                                                     "cmssw_ROS" );
+
+  } else if (dbToDump == "ChannelsDB") {  //Write channels map
+
+    DTReadOutMapping* ro_map = new DTReadOutMapping("cmssw_ROB", "cmssw_ROS");
     //Loop over file entries
     string line;
     ifstream file(mapFileName.c_str());
-    while (getline(file,line)) {
-      if( line == "" || line[0] == '#' ) continue; // Skip comments and empty lines
+    while (getline(file, line)) {
+      if (line == "" || line[0] == '#')
+        continue;  // Skip comments and empty lines
       stringstream linestr;
       linestr << line;
-      vector <int> channelMap = readChannelsMap(linestr);
+      vector<int> channelMap = readChannelsMap(linestr);
       int status = ro_map->insertReadOutGeometryLink(channelMap[0],
-						     channelMap[1],
-						     channelMap[2],
-						     channelMap[3],
-						     channelMap[4],
-						     channelMap[5],
-						     channelMap[6],
-						     channelMap[7],
-						     channelMap[8],
-						     channelMap[9],
-						     channelMap[10]);
+                                                     channelMap[1],
+                                                     channelMap[2],
+                                                     channelMap[3],
+                                                     channelMap[4],
+                                                     channelMap[5],
+                                                     channelMap[6],
+                                                     channelMap[7],
+                                                     channelMap[8],
+                                                     channelMap[9],
+                                                     channelMap[10]);
       cout << "ddu " << channelMap[0] << " "
-	   << "ros " << channelMap[1] << " "
-	   << "rob " << channelMap[2] << " "
-	   << "tdc " << channelMap[3] << " "
-	   << "channel " << channelMap[4] << " "
-	   << "wheel " << channelMap[5] << " "
-	   << "station " << channelMap[6] << " "
-	   << "sector " << channelMap[7] << " "
-	   << "superlayer " << channelMap[8] << " "
-	   << "layer " << channelMap[9] << " "
-	   << "wire " << channelMap[10] << " " << "  -> ";                
+           << "ros " << channelMap[1] << " "
+           << "rob " << channelMap[2] << " "
+           << "tdc " << channelMap[3] << " "
+           << "channel " << channelMap[4] << " "
+           << "wheel " << channelMap[5] << " "
+           << "station " << channelMap[6] << " "
+           << "sector " << channelMap[7] << " "
+           << "superlayer " << channelMap[8] << " "
+           << "layer " << channelMap[9] << " "
+           << "wire " << channelMap[10] << " "
+           << "  -> ";
       cout << "insert status: " << status << std::endl;
     }
     DTCalibDBUtils::writeToDB<DTReadOutMapping>("DTReadOutMappingRcd", ro_map);
 
+    //---------- Uncertainties
+  } else if (dbToDump == "RecoUncertDB") {  // Write the Uncertainties
 
-  //---------- Uncertainties
-  } else if(dbToDump == "RecoUncertDB") { // Write the Uncertainties
-
-    if (format=="Legacy") {
+    if (format == "Legacy") {
       DTRecoUncertainties* uncert = new DTRecoUncertainties();
-      int version = 1; // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
+      int version = 1;  // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
       uncert->setVersion(version);
       // Loop over file entries
-      for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-	  keyAndCalibs != theCalibFile->keyAndConsts_end();
-	  ++keyAndCalibs) {
-	vector<float> values = (*keyAndCalibs).second;
-	vector<float> uncerts(values.begin()+11, values.end());
-	uncert->set((*keyAndCalibs).first, uncerts);
+      for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+           keyAndCalibs != theCalibFile->keyAndConsts_end();
+           ++keyAndCalibs) {
+        vector<float> values = (*keyAndCalibs).second;
+        vector<float> uncerts(values.begin() + 11, values.end());
+        uncert->set((*keyAndCalibs).first, uncerts);
       }
       DTCalibDBUtils::writeToDB<DTRecoUncertainties>("DTRecoUncertaintiesRcd", uncert);
 
-    } else if (format=="DTRecoConditions") {
+    } else if (format == "DTRecoConditions") {
       DTRecoConditions* conds = new DTRecoConditions();
       conds->setFormulaExpr("par[step]");
-      int version = 1; // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
+      int version = 1;  // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
       conds->setVersion(version);
 
-      for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-	  keyAndCalibs != theCalibFile->keyAndConsts_end();
-	  ++keyAndCalibs) {
+      for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+           keyAndCalibs != theCalibFile->keyAndConsts_end();
+           ++keyAndCalibs) {
+        vector<float> values = (*keyAndCalibs).second;
+        int fversion = int(values[10] / 1000);
+        int type = (int(values[10]) % 1000) / 100;
+        int nfields = int(values[10]) % 100;
+        if (type != 2)
+          throw cms::Exception("IncorrectSetup") << "Only type==2 supported for uncertainties DB";
+        if (values.size() != unsigned(nfields + 11))
+          throw cms::Exception("IncorrectSetup") << "Inconsistent number of fields";
+        if (fversion != version)
+          throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
 
-	vector<float> values = (*keyAndCalibs).second;
-	int fversion = int(values[10]/1000);
-	int type = (int(values[10])%1000)/100;
-	int nfields = int(values[10])%100;
-	if (type !=2) throw cms::Exception("IncorrectSetup") << "Only type==2 supported for uncertainties DB";
-	if(values.size()!=unsigned(nfields+11)) throw cms::Exception("IncorrectSetup") << "Inconsistent number of fields";
-	if (fversion!=version) throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
-
-	vector<double> params(values.begin()+11, values.begin()+11+nfields);
-	conds->set((*keyAndCalibs).first, params);
+        vector<double> params(values.begin() + 11, values.begin() + 11 + nfields);
+        conds->set((*keyAndCalibs).first, params);
       }
       DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsUncertRcd", conds);
     }
   }
 }
 
-
-
-
-
-  
-vector <int> DumpFileToDB::readChannelsMap (stringstream &linestr) {
+vector<int> DumpFileToDB::readChannelsMap(stringstream& linestr) {
   //The hardware channel
   int ddu_id = 0;
   int ros_id = 0;
@@ -344,18 +325,9 @@ vector <int> DumpFileToDB::readChannelsMap (stringstream &linestr) {
   int layer_id = 0;
   int wire_id = 0;
 
-  linestr  >> ddu_id
-	   >> ros_id
-	   >> rob_id
-	   >> tdc_id
-	   >> channel_id
-	   >> wheel_id
-	   >> station_id
-	   >> sector_id
-	   >> superlayer_id
-	   >> layer_id
-	   >> wire_id;
-    
+  linestr >> ddu_id >> ros_id >> rob_id >> tdc_id >> channel_id >> wheel_id >> station_id >> sector_id >>
+      superlayer_id >> layer_id >> wire_id;
+
   vector<int> channelMap;
   channelMap.push_back(ddu_id);
   channelMap.push_back(ros_id);
@@ -371,11 +343,9 @@ vector <int> DumpFileToDB::readChannelsMap (stringstream &linestr) {
   return channelMap;
 }
 
-
-void DumpFileToDB::beginRun(const edm::Run& run, const edm::EventSetup& setup ) {
-
-  if(diffMode) {
-    if(dbToDump == "TTrigDB") { // read the original DB
+void DumpFileToDB::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
+  if (diffMode) {
+    if (dbToDump == "TTrigDB") {  // read the original DB
       ESHandle<DTTtrig> tTrig;
       setup.get<DTTtrigRcd>().get(tTrig);
       tTrigMapOrig = &*tTrig;

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.h
@@ -28,29 +28,25 @@ public:
   virtual ~DumpFileToDB();
 
   // Operations
- // Operations
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup );
+  // Operations
+  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup);
 
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){}
- 
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) {}
+
   virtual void endJob();
 
 protected:
-
 private:
-  std::vector<int> readChannelsMap (std::stringstream &linestr);
+  std::vector<int> readChannelsMap(std::stringstream& linestr);
 
-  const DTCalibrationMap *theCalibFile;
+  const DTCalibrationMap* theCalibFile;
   std::string mapFileName;
 
   std::string dbToDump;
   std::string format;
 
-  // sum the correction in the txt file (for the mean value) to what is input DB 
+  // sum the correction in the txt file (for the mean value) to what is input DB
   bool diffMode;
-  const DTTtrig *tTrigMapOrig;
-
-
+  const DTTtrig* tTrigMapOrig;
 };
 #endif
-

--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
@@ -30,9 +30,9 @@ public:
   virtual ~FakeTTrig();
 
   // Operations
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup ) override;
+  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup)override {}
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
   virtual void endJob() override;
 
   // TOF computation
@@ -41,7 +41,6 @@ public:
   double wirePropComputation(const DTSuperLayer* superlayer);
 
 protected:
-
 private:
   edm::ESHandle<DTGeometry> muonGeom;
   edm::ParameterSet ps;

--- a/CalibMuon/DTCalibration/test/DBTools/SealModule.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/SealModule.cc
@@ -10,7 +10,6 @@
 #include "ShiftTTrigDB.h"
 #include "FakeTTrig.h"
 
-
 DEFINE_FWK_MODULE(DumpDBToFile);
 DEFINE_FWK_MODULE(DumpFileToDB);
 DEFINE_FWK_MODULE(DTT0Analyzer);
@@ -18,4 +17,3 @@ DEFINE_FWK_MODULE(DTTTrigAnalyzer);
 DEFINE_FWK_MODULE(DTVDriftAnalyzer);
 DEFINE_FWK_MODULE(ShiftTTrigDB);
 DEFINE_FWK_MODULE(FakeTTrig);
-

--- a/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.cc
@@ -29,11 +29,11 @@ ShiftTTrigDB::ShiftTTrigDB(const ParameterSet& pset) {
   //Read the ttrig shifts
   shifts = pset.getParameter<vector<double> >("shifts");
   //Read the chambers to be shifted
-  vector<ParameterSet> parameters =  pset.getParameter <vector<ParameterSet> > ("chambers");
-  dbLabel  = pset.getUntrackedParameter<string>("dbLabel", "");
+  vector<ParameterSet> parameters = pset.getParameter<vector<ParameterSet> >("chambers");
+  dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
 
-  int counter=0;
-  for(vector<ParameterSet>::iterator parameter = parameters.begin(); parameter != parameters.end(); ++parameter ) {
+  int counter = 0;
+  for (vector<ParameterSet>::iterator parameter = parameters.begin(); parameter != parameters.end(); ++parameter) {
     vector<int> chAddress;
     chAddress.push_back(parameter->getParameter<int>("wheel"));
     chAddress.push_back(parameter->getParameter<int>("sector"));
@@ -44,83 +44,71 @@ ShiftTTrigDB::ShiftTTrigDB(const ParameterSet& pset) {
     counter++;
   }
 
-  debug = pset.getUntrackedParameter<bool>("debug",false);
-  if (chambers.size() != shifts.size()){
-    cout<<"[ShiftTTrigDB]: Wrong configuration: number of chambers different from number of shifts!! Aborting."<<endl;
+  debug = pset.getUntrackedParameter<bool>("debug", false);
+  if (chambers.size() != shifts.size()) {
+    cout << "[ShiftTTrigDB]: Wrong configuration: number of chambers different from number of shifts!! Aborting."
+         << endl;
     abort();
   }
 }
 
-ShiftTTrigDB::~ShiftTTrigDB(){}
+ShiftTTrigDB::~ShiftTTrigDB() {}
 
 void ShiftTTrigDB::beginRun(const edm::Run&, const EventSetup& setup) {
   ESHandle<DTTtrig> tTrig;
-  setup.get<DTTtrigRcd>().get(dbLabel,tTrig);
+  setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
   tTrigMap = &*tTrig;
   cout << "[ShiftTTrigDB]: TTrig version: " << tTrig->version() << endl;
 
   setup.get<MuonGeometryRecord>().get(muonGeom);
 }
 
-
 void ShiftTTrigDB::endJob() {
   // Create the object to be written to DB
-  DTTtrig* tTrigNewMap = new DTTtrig();  
+  DTTtrig* tTrigNewMap = new DTTtrig();
   //Get the superlayers list
   vector<const DTSuperLayer*> dtSupLylist = muonGeom->superLayers();
 
   //Loop on all superlayers
-  for (auto sl = dtSupLylist.begin();
-       sl != dtSupLylist.end(); sl++) {
+  for (auto sl = dtSupLylist.begin(); sl != dtSupLylist.end(); sl++) {
     float ttrigMean = 0;
     float ttrigSigma = 0;
     float kFactor = 0;
-    tTrigMap->get((*sl)->id(),
-		  ttrigMean,
-		  ttrigSigma,
-                  kFactor,
-		  DTTimeUnits::ns);
+    tTrigMap->get((*sl)->id(), ttrigMean, ttrigSigma, kFactor, DTTimeUnits::ns);
     bool ttrigShifted = false;
     //Loop on the chambers with ttrig to be shifted
-    for(vector<vector<int> >::const_iterator ch =chambers.begin();
-	ch != chambers.end(); ++ch){
+    for (vector<vector<int> >::const_iterator ch = chambers.begin(); ch != chambers.end(); ++ch) {
       //Check the chamber address format
-      if((*ch).size()!=3){
-	cout<<"[ShiftTTrigDB]: Wrong configuration: use three integer to indicate each chamber. Aborting."<<endl;
-	abort();
+      if ((*ch).size() != 3) {
+        cout << "[ShiftTTrigDB]: Wrong configuration: use three integer to indicate each chamber. Aborting." << endl;
+        abort();
       }
-      if(((*sl)->id().wheel() == (*ch)[0]) ||  (*ch)[0] == 999){
-	if(((*sl)->id().sector() == (*ch)[1]) ||  (*ch)[1] == 999){
-	  if(((*sl)->id().station() == (*ch)[2]) ||  (*ch)[2] == 999){
-
-	    //Compute new ttrig
-	    double newTTrigMean =  ttrigMean + mapShiftsByChamber[(*ch)]; 
-	    //Store new ttrig in the new map
-	    tTrigNewMap->set((*sl)->id(), newTTrigMean, ttrigSigma, kFactor, DTTimeUnits::ns);
-	    ttrigShifted = true;
-	    if(debug){
-	      cout<<"Shifting SL: " << (*sl)->id()
-		  << " from "<< ttrigMean <<" to "<< newTTrigMean <<endl;
-	    }
-	  }
-	}
+      if (((*sl)->id().wheel() == (*ch)[0]) || (*ch)[0] == 999) {
+        if (((*sl)->id().sector() == (*ch)[1]) || (*ch)[1] == 999) {
+          if (((*sl)->id().station() == (*ch)[2]) || (*ch)[2] == 999) {
+            //Compute new ttrig
+            double newTTrigMean = ttrigMean + mapShiftsByChamber[(*ch)];
+            //Store new ttrig in the new map
+            tTrigNewMap->set((*sl)->id(), newTTrigMean, ttrigSigma, kFactor, DTTimeUnits::ns);
+            ttrigShifted = true;
+            if (debug) {
+              cout << "Shifting SL: " << (*sl)->id() << " from " << ttrigMean << " to " << newTTrigMean << endl;
+            }
+          }
+        }
       }
-    }//End loop on chambers to be shifted
-    if(!ttrigShifted){
+    }  //End loop on chambers to be shifted
+    if (!ttrigShifted) {
       //Store old ttrig in the new map
       tTrigNewMap->set((*sl)->id(), ttrigMean, ttrigSigma, kFactor, DTTimeUnits::ns);
-      if(debug){
-	cout<<"Copying  SL: " << (*sl)->id()
-	    << " ttrig "<< ttrigMean <<endl;
+      if (debug) {
+        cout << "Copying  SL: " << (*sl)->id() << " ttrig " << ttrigMean << endl;
       }
     }
-  }//End of loop on superlayers 
+  }  //End of loop on superlayers
 
   //Write object to DB
- cout << "[ShiftTTrigDB]: Writing ttrig object to DB!" << endl;
-    string record = "DTTtrigRcd";
-    DTCalibDBUtils::writeToDB<DTTtrig>(record, tTrigNewMap);
-} 
-
-
-
+  cout << "[ShiftTTrigDB]: Writing ttrig object to DB!" << endl;
+  string record = "DTTtrigRcd";
+  DTCalibDBUtils::writeToDB<DTTtrig>(record, tTrigNewMap);
+}

--- a/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.h
+++ b/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.h
@@ -29,25 +29,22 @@ public:
 
   // Operations
 
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup );
+  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup);
 
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){}
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) {}
 
   virtual void endJob();
 
 protected:
-
 private:
-  const DTTtrig *tTrigMap;
+  const DTTtrig* tTrigMap;
   edm::ESHandle<DTGeometry> muonGeom;
 
   std::string dbLabel;
 
   std::vector<std::vector<int> > chambers;
   std::vector<double> shifts;
-  std::map<std::vector <int>, double> mapShiftsByChamber;
+  std::map<std::vector<int>, double> mapShiftsByChamber;
   bool debug;
-
 };
 #endif
-

--- a/CalibMuon/DTCalibration/test/stubs/DTMeanTimerPlotter.cc
+++ b/CalibMuon/DTCalibration/test/stubs/DTMeanTimerPlotter.cc
@@ -25,162 +25,150 @@
 using namespace std;
 
 // Constructor
-DTMeanTimerPlotter::DTMeanTimerPlotter(TFile *file) : theFile(file), theVerbosityLevel(1), theRebinning(1), color(0){
-}
+DTMeanTimerPlotter::DTMeanTimerPlotter(TFile* file) : theFile(file), theVerbosityLevel(1), theRebinning(1), color(0) {}
 
 // Destructor
-DTMeanTimerPlotter::~DTMeanTimerPlotter(){}
-
+DTMeanTimerPlotter::~DTMeanTimerPlotter() {}
 
 void DTMeanTimerPlotter::plotMeanTimer(int wheel, int station, int sector, int sl, const TString& drawOptions) {
   TString histoName = getHistoNameSuffix(wheel, station, sector, sl);
 
-  if(drawOptions.Contains("SingleDeltaT0"))
-    plotHistos(plotSingleTMaxDeltaT0(histoName),histoName,drawOptions);
-  else if(drawOptions.Contains("SingleFormula")) 
-    plotHistos(plotSingleTMaxFormula(histoName),histoName,drawOptions);
+  if (drawOptions.Contains("SingleDeltaT0"))
+    plotHistos(plotSingleTMaxDeltaT0(histoName), histoName, drawOptions);
+  else if (drawOptions.Contains("SingleFormula"))
+    plotHistos(plotSingleTMaxFormula(histoName), histoName, drawOptions);
   else {
-     plotHistos(plotTotalTMax(histoName),histoName,drawOptions) ;
-    cout<<"use '(fit)SingleDeltaT0' or '(fit)SingleFormula' as option to fit each TMax histo separately"<<endl;
+    plotHistos(plotTotalTMax(histoName), histoName, drawOptions);
+    cout << "use '(fit)SingleDeltaT0' or '(fit)SingleFormula' as option to fit each TMax histo separately" << endl;
   }
 }
 
 // Set the verbosity of the output: 0 = silent, 1 = info, 2 = debug
-void DTMeanTimerPlotter::setVerbosity(unsigned int lvl) {
-  theVerbosityLevel = lvl;
-}
+void DTMeanTimerPlotter::setVerbosity(unsigned int lvl) { theVerbosityLevel = lvl; }
 
-void DTMeanTimerPlotter::setRebinning(unsigned int rebin) {
-  theRebinning = rebin;
-}
+void DTMeanTimerPlotter::setRebinning(unsigned int rebin) { theRebinning = rebin; }
 
-void DTMeanTimerPlotter::resetColor() {
-  color = 0;
-}
+void DTMeanTimerPlotter::resetColor() { color = 0; }
 
 TString DTMeanTimerPlotter::getHistoNameSuffix(int wheel, int station, int sector, int sl) {
- TString N=(((((TString) "TMax"+(long) wheel) +(long) station)
-		  +(long) sector)+(long) sl);
+  TString N = (((((TString) "TMax" + (long)wheel) + (long)station) + (long)sector) + (long)sl);
   return N;
 }
 
-void DTMeanTimerPlotter::plotHistos(vector<TH1D*> hTMaxes, TString& name, const TString& drawOptions){
+void DTMeanTimerPlotter::plotHistos(vector<TH1D*> hTMaxes, TString& name, const TString& drawOptions) {
+  TLegend* leg = new TLegend(0.5, 0.6, 0.7, 0.8);
+  ;
+  if (!drawOptions.Contains("same")) {
+    new TCanvas(name, "Fit of Tmax histo");
+    hTMaxes[0]->Draw();
+  }
 
-  TLegend *leg = new TLegend(0.5,0.6,0.7,0.8);;
-  if(!drawOptions.Contains("same")){
-     new TCanvas(name,"Fit of Tmax histo");
-     hTMaxes[0]->Draw();
-   }
+  for (vector<TH1D*>::const_iterator ith = hTMaxes.begin(); ith != hTMaxes.end(); ++ith) {
+    color++;
 
-  for(vector<TH1D*>::const_iterator ith = hTMaxes.begin();
-      ith != hTMaxes.end(); ++ith) {
-   color++;     
+    (*ith)->Rebin(theRebinning);
+    (*ith)->SetLineColor(color);
+    ((*ith)->GetXaxis())->SetRangeUser(200, 600);
+    (*ith)->Draw("same");
 
-   (*ith)->Rebin(theRebinning);
-   (*ith)->SetLineColor(color);
-   ((*ith)->GetXaxis())->SetRangeUser(200,600);
-   (*ith)->Draw("same");
+    leg->AddEntry((*ith), (*ith)->GetName(), "L");
+  }
 
-   leg->AddEntry((*ith),(*ith)->GetName(),"L");
- }
-
- if(drawOptions.Contains("fit")){
-   int i=0;
-   vector<TF1*> functions = fitTMaxes(hTMaxes);
-   for(vector<TF1*>::const_iterator funct = functions.begin();
-       funct != functions.end(); ++funct) {
-     //     color++;     
-     (*funct)->SetLineColor(hTMaxes[i]->GetLineColor());
-     (*funct)->Draw("same");
-     i++;
-   }
- }
- leg->SetFillColor(0);;
- leg->Draw("same");
- hTMaxes[0]->SetMaximum(getMaximum(hTMaxes));
- setRebinning(1);
+  if (drawOptions.Contains("fit")) {
+    int i = 0;
+    vector<TF1*> functions = fitTMaxes(hTMaxes);
+    for (vector<TF1*>::const_iterator funct = functions.begin(); funct != functions.end(); ++funct) {
+      //     color++;
+      (*funct)->SetLineColor(hTMaxes[i]->GetLineColor());
+      (*funct)->Draw("same");
+      i++;
+    }
+  }
+  leg->SetFillColor(0);
+  ;
+  leg->Draw("same");
+  hTMaxes[0]->SetMaximum(getMaximum(hTMaxes));
+  setRebinning(1);
 }
 
-vector<TH1D*> DTMeanTimerPlotter::plotSingleTMaxDeltaT0 (TString& name) {
- // Retrieve histogram sets
-   vector <TH1D*> hTMaxes;
-  hTMaxes.push_back((TH1D*)theFile->Get(name+"_0"));
-  hTMaxes.push_back((TH1D*)theFile->Get(name+"_t0"));
-  hTMaxes.push_back((TH1D*)theFile->Get(name+"_2t0"));
-  hTMaxes.push_back((TH1D*)theFile->Get(name+"_3t0"));
-  if(theVerbosityLevel >= 1){
-    cout<<"NOTE: these histos are not directly used to calibrate vdrift"<<endl;
+vector<TH1D*> DTMeanTimerPlotter::plotSingleTMaxDeltaT0(TString& name) {
+  // Retrieve histogram sets
+  vector<TH1D*> hTMaxes;
+  hTMaxes.push_back((TH1D*)theFile->Get(name + "_0"));
+  hTMaxes.push_back((TH1D*)theFile->Get(name + "_t0"));
+  hTMaxes.push_back((TH1D*)theFile->Get(name + "_2t0"));
+  hTMaxes.push_back((TH1D*)theFile->Get(name + "_3t0"));
+  if (theVerbosityLevel >= 1) {
+    cout << "NOTE: these histos are not directly used to calibrate vdrift" << endl;
   }
   return hTMaxes;
 }
 
-vector<TH1D*>  DTMeanTimerPlotter::plotSingleTMaxFormula (TString& name) {
- // Retrieve histogram sets
-   vector <TH1D*> hTMaxes;
-  hTMaxes.push_back((TH1D*)theFile->Get(name+"_Tmax123"));
-  hTMaxes.push_back((TH1D*)theFile->Get(name+"_Tmax124_s72"));
-  hTMaxes.push_back((TH1D*)theFile->Get(name+"_Tmax124_s78"));
-  hTMaxes.push_back((TH1D*)theFile->Get(name+"_Tmax134_s72"));
-  hTMaxes.push_back((TH1D*)theFile->Get(name+"_Tmax134_s78"));
-  hTMaxes.push_back((TH1D*)theFile->Get(name+"_Tmax234"));
-  return hTMaxes;
-}  
-
-vector<TH1D*>  DTMeanTimerPlotter::plotTotalTMax (TString& name) {
-
-  TH1D* hTMax;  // histograms for <T_max> calculation
-  hTMax = ((TH1D*)theFile->Get(name+"_Tmax123"));
-  hTMax->Add((TH1D*)theFile->Get(name+"_Tmax124_s72"));
-  hTMax->Add((TH1D*)theFile->Get(name+"_Tmax124_s78"));
-  hTMax->Add((TH1D*)theFile->Get(name+"_Tmax134_s72"));
-  hTMax->Add((TH1D*)theFile->Get(name+"_Tmax134_s78"));
-  hTMax->Add((TH1D*)theFile->Get(name+"_Tmax234"));
-  hTMax->SetName(name);
-  hTMax->SetTitle(name);
-
-  vector <TH1D*> hTMaxes;
-  hTMaxes.push_back(hTMax);
-  if(theVerbosityLevel >= 1){
-    cout<<"NOTE: this histo is not directly used to calibrate vdrift"<<endl;
- }
+vector<TH1D*> DTMeanTimerPlotter::plotSingleTMaxFormula(TString& name) {
+  // Retrieve histogram sets
+  vector<TH1D*> hTMaxes;
+  hTMaxes.push_back((TH1D*)theFile->Get(name + "_Tmax123"));
+  hTMaxes.push_back((TH1D*)theFile->Get(name + "_Tmax124_s72"));
+  hTMaxes.push_back((TH1D*)theFile->Get(name + "_Tmax124_s78"));
+  hTMaxes.push_back((TH1D*)theFile->Get(name + "_Tmax134_s72"));
+  hTMaxes.push_back((TH1D*)theFile->Get(name + "_Tmax134_s78"));
+  hTMaxes.push_back((TH1D*)theFile->Get(name + "_Tmax234"));
   return hTMaxes;
 }
 
-vector<TF1*>  DTMeanTimerPlotter::fitTMaxes(vector<TH1D*> hTMaxes){
-  vector <TF1*> functions;
-   for(vector<TH1D*>::const_iterator ith = hTMaxes.begin();
-      ith != hTMaxes.end(); ++ith) {
-     // Find distribution peak and fit range
-      Double_t peak = ((((((*ith)->GetXaxis())->GetXmax())-(((*ith)->GetXaxis())->GetXmin()))/(*ith)->GetNbinsX())*
-		       ((*ith)->GetMaximumBin()))+(((*ith)->GetXaxis())->GetXmin());
-      if(theVerbosityLevel >= 1)
-	cout<<"Peak "<<peak<<" : "<<"xmax "<<(((*ith)->GetXaxis())->GetXmax())
-	    <<"            xmin "<<(((*ith)->GetXaxis())->GetXmin())
-	    <<"            nbin "<<(*ith)->GetNbinsX()
-	    <<"            bin with max "<<((*ith)->GetMaximumBin())<<endl;
-      Double_t range = 2.*(*ith)->GetRMS(); 
+vector<TH1D*> DTMeanTimerPlotter::plotTotalTMax(TString& name) {
+  TH1D* hTMax;  // histograms for <T_max> calculation
+  hTMax = ((TH1D*)theFile->Get(name + "_Tmax123"));
+  hTMax->Add((TH1D*)theFile->Get(name + "_Tmax124_s72"));
+  hTMax->Add((TH1D*)theFile->Get(name + "_Tmax124_s78"));
+  hTMax->Add((TH1D*)theFile->Get(name + "_Tmax134_s72"));
+  hTMax->Add((TH1D*)theFile->Get(name + "_Tmax134_s78"));
+  hTMax->Add((TH1D*)theFile->Get(name + "_Tmax234"));
+  hTMax->SetName(name);
+  hTMax->SetTitle(name);
 
-      // Fit each Tmax (*ith)gram with a Gaussian in a restricted interval
-      TF1 *rGaus = new TF1("rGaus","gaus",peak-range,peak+range);
-      rGaus->SetMarkerSize(); //to stop gcc complain about unused var
-      (*ith)->Fit("rGaus","R0");
-      functions.push_back((*ith)->GetFunction("rGaus"));
-      
-      // Get mean, sigma and number of entries of each histogram
-      cout<<"Histo name "<<(*ith)->GetName()<<": "<<endl;
-      cout<<"mean  "<<(((*ith)->GetFunction("rGaus"))->GetParameter(1))<<endl;
-      cout<<"sigma "<<(((*ith)->GetFunction("rGaus"))->GetParameter(2))<<endl; 
-      cout<<"count "<<((*ith)->GetEntries())<<endl<<endl;  
-   }
-   return functions;
- }
+  vector<TH1D*> hTMaxes;
+  hTMaxes.push_back(hTMax);
+  if (theVerbosityLevel >= 1) {
+    cout << "NOTE: this histo is not directly used to calibrate vdrift" << endl;
+  }
+  return hTMaxes;
+}
 
-double DTMeanTimerPlotter::getMaximum(vector<TH1D*> hTMaxes){
-  double max = -pow(10.0,10);
-  for(vector<TH1D*>::const_iterator ith = hTMaxes.begin();
-      ith != hTMaxes.end(); ++ith) {
-    double m =(*ith)->GetMaximum(pow(10.0,10));
-    if(m>max)
+vector<TF1*> DTMeanTimerPlotter::fitTMaxes(vector<TH1D*> hTMaxes) {
+  vector<TF1*> functions;
+  for (vector<TH1D*>::const_iterator ith = hTMaxes.begin(); ith != hTMaxes.end(); ++ith) {
+    // Find distribution peak and fit range
+    Double_t peak = ((((((*ith)->GetXaxis())->GetXmax()) - (((*ith)->GetXaxis())->GetXmin())) / (*ith)->GetNbinsX()) *
+                     ((*ith)->GetMaximumBin())) +
+                    (((*ith)->GetXaxis())->GetXmin());
+    if (theVerbosityLevel >= 1)
+      cout << "Peak " << peak << " : "
+           << "xmax " << (((*ith)->GetXaxis())->GetXmax()) << "            xmin " << (((*ith)->GetXaxis())->GetXmin())
+           << "            nbin " << (*ith)->GetNbinsX() << "            bin with max " << ((*ith)->GetMaximumBin())
+           << endl;
+    Double_t range = 2. * (*ith)->GetRMS();
+
+    // Fit each Tmax (*ith)gram with a Gaussian in a restricted interval
+    TF1* rGaus = new TF1("rGaus", "gaus", peak - range, peak + range);
+    rGaus->SetMarkerSize();  //to stop gcc complain about unused var
+    (*ith)->Fit("rGaus", "R0");
+    functions.push_back((*ith)->GetFunction("rGaus"));
+
+    // Get mean, sigma and number of entries of each histogram
+    cout << "Histo name " << (*ith)->GetName() << ": " << endl;
+    cout << "mean  " << (((*ith)->GetFunction("rGaus"))->GetParameter(1)) << endl;
+    cout << "sigma " << (((*ith)->GetFunction("rGaus"))->GetParameter(2)) << endl;
+    cout << "count " << ((*ith)->GetEntries()) << endl << endl;
+  }
+  return functions;
+}
+
+double DTMeanTimerPlotter::getMaximum(vector<TH1D*> hTMaxes) {
+  double max = -pow(10.0, 10);
+  for (vector<TH1D*>::const_iterator ith = hTMaxes.begin(); ith != hTMaxes.end(); ++ith) {
+    double m = (*ith)->GetMaximum(pow(10.0, 10));
+    if (m > max)
       max = m;
   }
   return max;

--- a/CalibMuon/DTCalibration/test/stubs/DTMeanTimerPlotter.h
+++ b/CalibMuon/DTCalibration/test/stubs/DTMeanTimerPlotter.h
@@ -12,7 +12,6 @@
 #include "TString.h"
 #include <vector>
 
-
 class TFile;
 class TCanvas;
 class TH1D;
@@ -21,8 +20,7 @@ class TF1;
 class DTMeanTimerPlotter {
 public:
   /// Constructor
-  DTMeanTimerPlotter(TFile *file);
-
+  DTMeanTimerPlotter(TFile* file);
 
   /// Destructor
   virtual ~DTMeanTimerPlotter();
@@ -30,14 +28,13 @@ public:
   // Operations
 
   /// Plot the time box of a given superlayer.
-  /// Options: <br> 
+  /// Options: <br>
   /// "same" -> histo drawn in the active canvas, <br>
   /// "SingleDeltaT0" or "SingleFormula" -> fit and draw each TMax histo separately (in the same canvas) <br>
   /// "fit" -> draw and fit the histos <br>
-  void plotMeanTimer(int wheel, int station, int sector, int sl,
-		    const TString& drawOptions = "");
- 
-   /// Set the verbosity of the output: 0 = silent, 1 = info, 2 = debug
+  void plotMeanTimer(int wheel, int station, int sector, int sl, const TString& drawOptions = "");
+
+  /// Set the verbosity of the output: 0 = silent, 1 = info, 2 = debug
   void setVerbosity(unsigned int lvl);
 
   /// Set rebin number
@@ -47,22 +44,20 @@ public:
   void resetColor();
 
 protected:
-
 private:
-
   //Plot the TMax histogram for each deltaT0: THESE ARE NOT USED TO COMPUTE VDRIFT
-  std::vector<TH1D*>  plotSingleTMaxDeltaT0 (TString& name);
+  std::vector<TH1D*> plotSingleTMaxDeltaT0(TString& name);
   //Plot the TMax histogram for each formula
-  std::vector<TH1D*> plotSingleTMaxFormula (TString& name);
+  std::vector<TH1D*> plotSingleTMaxFormula(TString& name);
   //Plot the total TMax histograms: THIS IS NOT USED TO COMPUTE VDRIFT
-  std::vector<TH1D*> plotTotalTMax (TString& name);
+  std::vector<TH1D*> plotTotalTMax(TString& name);
 
   void plotHistos(std::vector<TH1D*> hTMaxes, TString& name, const TString& drawOptions);
   TString getHistoNameSuffix(int wheel, int station, int sector, int sl);
   std::vector<TF1*> fitTMaxes(std::vector<TH1D*> histo);
   double getMaximum(std::vector<TH1D*> hTMaxes);
 
-  TFile *theFile;
+  TFile* theFile;
   unsigned int theVerbosityLevel;
   unsigned int theRebinning;
   unsigned int color;

--- a/CalibMuon/DTCalibration/test/stubs/DTTimeBoxFitter.cc
+++ b/CalibMuon/DTCalibration/test/stubs/DTTimeBoxFitter.cc
@@ -7,5 +7,3 @@
 
 #include "DTTimeBoxFitter.h"
 #include "CalibMuon/DTCalibration/src/DTTimeBoxFitter.cc"
-
-

--- a/CalibMuon/DTCalibration/test/stubs/DTTimeBoxFitter.h
+++ b/CalibMuon/DTCalibration/test/stubs/DTTimeBoxFitter.h
@@ -10,4 +10,3 @@
 #include "CalibMuon/DTCalibration/interface/DTTimeBoxFitter.h"
 
 #endif
-

--- a/CalibMuon/DTCalibration/test/stubs/DTTimeBoxPlotter.cc
+++ b/CalibMuon/DTCalibration/test/stubs/DTTimeBoxPlotter.cc
@@ -7,8 +7,6 @@
 #include "DTTimeBoxPlotter.h"
 #include "DTTimeBoxFitter.h"
 
-
-
 #include <iostream>
 #include <cstdio>
 #include <sstream>
@@ -25,17 +23,13 @@
 using namespace std;
 
 // Constructor
-DTTimeBoxPlotter::DTTimeBoxPlotter( TFile *file) : theFile(file), theVerbosityLevel(0) {
+DTTimeBoxPlotter::DTTimeBoxPlotter(TFile* file) : theFile(file), theVerbosityLevel(0) {
   theFitter = new DTTimeBoxFitter();
   theFitter->setVerbosity(1);
 }
 
-
 // Destructor
-DTTimeBoxPlotter::~DTTimeBoxPlotter(){}
-
-
-
+DTTimeBoxPlotter::~DTTimeBoxPlotter() {}
 
 TH1F* DTTimeBoxPlotter::plotTimeBox(int wheel, int station, int sector, const TString& drawOptions) {
   TString histoName = getHistoNameSuffix(wheel, station, sector) + "_hTimeBox";
@@ -47,160 +41,134 @@ TH1F* DTTimeBoxPlotter::plotTimeBox(int wheel, int station, int sector, int sl, 
   return plotHisto(histoName, drawOptions);
 }
 
-TH1F* DTTimeBoxPlotter::plotTimeBox(int wheel, int station, int sector, int sl, int layer,
-				const TString& drawOptions) {
+TH1F* DTTimeBoxPlotter::plotTimeBox(int wheel, int station, int sector, int sl, int layer, const TString& drawOptions) {
   TString histoName = getHistoNameSuffix(wheel, station, sector, sl, layer) + "_hTimeBox";
   return plotHisto(histoName, drawOptions);
 }
 
-TH1F* DTTimeBoxPlotter::plotTimeBox(int wheel, int station, int sector, int sl, int layer, int wire,
-				const TString& drawOptions) {
+TH1F* DTTimeBoxPlotter::plotTimeBox(
+    int wheel, int station, int sector, int sl, int layer, int wire, const TString& drawOptions) {
   TString histoName = getHistoNameSuffix(wheel, station, sector, sl, layer, wire) + "_hTimeBox";
   return plotHisto(histoName, drawOptions);
 }
 
-
 void DTTimeBoxPlotter::printPDF() {
   TIter iter(gROOT->GetListOfCanvases());
-  TCanvas *c;
-  while( (c = (TCanvas *)iter()) ) {
-    c->Print(0,"ps");
+  TCanvas* c;
+  while ((c = (TCanvas*)iter())) {
+    c->Print(0, "ps");
   }
   gSystem->Exec("ps2pdf *.ps");
 }
 
-
-
 TString DTTimeBoxPlotter::getHistoNameSuffix(int wheel, int station, int sector) {
   string histoName;
   stringstream theStream;
-  theStream << "Ch_" <<wheel << "_" << station << "_" << sector << "_SLall_Lall_Wall";
+  theStream << "Ch_" << wheel << "_" << station << "_" << sector << "_SLall_Lall_Wall";
   theStream >> histoName;
   return TString(histoName.c_str());
 }
-
-
 
 TString DTTimeBoxPlotter::getHistoNameSuffix(int wheel, int station, int sector, int sl) {
   string histoName;
   stringstream theStream;
-  theStream << "Ch_" <<wheel << "_" << station << "_" << sector << "_SL" << sl;
+  theStream << "Ch_" << wheel << "_" << station << "_" << sector << "_SL" << sl;
   theStream >> histoName;
   return TString(histoName.c_str());
 }
-
-
 
 TString DTTimeBoxPlotter::getHistoNameSuffix(int wheel, int station, int sector, int sl, int layer) {
   string histoName;
   stringstream theStream;
-  theStream << "Ch_" <<wheel << "_" << station << "_" << sector << "_SL" << sl << "_L" << layer << "_Wall";
+  theStream << "Ch_" << wheel << "_" << station << "_" << sector << "_SL" << sl << "_L" << layer << "_Wall";
   theStream >> histoName;
   return TString(histoName.c_str());
 }
-
-
 
 TString DTTimeBoxPlotter::getHistoNameSuffix(int wheel, int station, int sector, int sl, int layer, int wire) {
   string histoName;
   stringstream theStream;
-  theStream << "Ch_" <<wheel << "_" << station << "_" << sector << "_SL" << sl << "_L" << layer << "_W" << wire;
+  theStream << "Ch_" << wheel << "_" << station << "_" << sector << "_SL" << sl << "_L" << layer << "_W" << wire;
   theStream >> histoName;
   return TString(histoName.c_str());
 }
 
-
-
 TH1F* DTTimeBoxPlotter::plotHisto(const TString& histoName, const TString& drawOptions) {
-  TH1F *histo = (TH1F *) theFile->Get(histoName.Data());
-  if(histo == 0) {
+  TH1F* histo = (TH1F*)theFile->Get(histoName.Data());
+  if (histo == 0) {
     cout << "***Error: Histogram: " << histoName << " doesn't exist!" << endl;
     return 0;
   }
   static int color;
-  
-  TCanvas *c;
-  if(!drawOptions.Contains("same")) {
+
+  TCanvas* c;
+  if (!drawOptions.Contains("same")) {
     color = 1;
-    c = newCanvas("c_"+histoName);
+    c = newCanvas("c_" + histoName);
     c->cd();
     histo->SetLineColor(color);
   } else {
-    color ++;
+    color++;
     histo->SetLineColor(color);
   }
-  histo->Draw(TString("h"+drawOptions).Data());
+  histo->Draw(TString("h" + drawOptions).Data());
 
-  if(drawOptions.Contains("fit")) {
+  if (drawOptions.Contains("fit")) {
     theFitter->fitTimeBox(histo);
   }
 
-
   return histo;
 }
 
-
-
-
 TH2F* DTTimeBoxPlotter::plotHisto2D(const TString& histoName, const TString& drawOptions) {
-  TH2F *histo = (TH2F *) theFile->Get(histoName.Data());
-  if(histo == 0) {
+  TH2F* histo = (TH2F*)theFile->Get(histoName.Data());
+  if (histo == 0) {
     cout << "***Error: Histogram: " << histoName << " doesn't exist!" << endl;
     return 0;
   }
   static int color;
 
-  TCanvas *c;
-  if(!drawOptions.Contains("same")) {
+  TCanvas* c;
+  if (!drawOptions.Contains("same")) {
     color = 1;
-    c = newCanvas("c_"+histoName);
+    c = newCanvas("c_" + histoName);
     c->cd();
     histo->SetLineColor(color);
   } else {
-    color ++;
+    color++;
     histo->SetLineColor(color);
-  } 
-  histo->Draw(TString("h"+drawOptions).Data());
+  }
+  histo->Draw(TString("h" + drawOptions).Data());
   return histo;
 }
 
-
-
-TCanvas * DTTimeBoxPlotter::newCanvas(TString name, TString title,
-				    int xdiv, int ydiv, int form, int w){
+TCanvas* DTTimeBoxPlotter::newCanvas(TString name, TString title, int xdiv, int ydiv, int form, int w) {
   static int i = 1;
   if (name == "") {
     name = TString("Canvas ") + TString(i);
     i++;
   }
-  TCanvas *c = 0;
-  if (title == "") title = name;
-  if (w<0) {
-    c = new TCanvas(name,title, form);
+  TCanvas* c = 0;
+  if (title == "")
+    title = name;
+  if (w < 0) {
+    c = new TCanvas(name, title, form);
   } else {
-    c = new TCanvas(name,title,form,w);
+    c = new TCanvas(name, title, form, w);
   }
-  if (xdiv*ydiv!=0) c->Divide(xdiv,ydiv);
+  if (xdiv * ydiv != 0)
+    c->Divide(xdiv, ydiv);
   c->cd(1);
   return c;
 }
 
-TCanvas * DTTimeBoxPlotter::newCanvas(TString name, int xdiv, int ydiv, int form, int w) {
-  return newCanvas(name, name,xdiv,ydiv,form,w);
+TCanvas* DTTimeBoxPlotter::newCanvas(TString name, int xdiv, int ydiv, int form, int w) {
+  return newCanvas(name, name, xdiv, ydiv, form, w);
 }
-TCanvas * DTTimeBoxPlotter::newCanvas(int xdiv, int ydiv, int form) {
-  return newCanvas("","",xdiv,ydiv,form);
-}
-TCanvas * DTTimeBoxPlotter::newCanvas(int form)
-{
-  return newCanvas(0,0,form);
-}
+TCanvas* DTTimeBoxPlotter::newCanvas(int xdiv, int ydiv, int form) { return newCanvas("", "", xdiv, ydiv, form); }
+TCanvas* DTTimeBoxPlotter::newCanvas(int form) { return newCanvas(0, 0, form); }
 
-TCanvas * DTTimeBoxPlotter::newCanvas(TString name, int form, int w)
-{
-  return newCanvas(name, name, 0,0,form,w);
-}
-
+TCanvas* DTTimeBoxPlotter::newCanvas(TString name, int form, int w) { return newCanvas(name, name, 0, 0, form, w); }
 
 // Set the verbosity of the output: 0 = silent, 1 = info, 2 = debug
 void DTTimeBoxPlotter::setVerbosity(unsigned int lvl) {
@@ -208,11 +176,6 @@ void DTTimeBoxPlotter::setVerbosity(unsigned int lvl) {
   theFitter->setVerbosity(lvl);
 }
 
-void DTTimeBoxPlotter::setInteractiveFit(bool isInteractive) {
-  theFitter->setInteractiveFit(isInteractive);
-}
+void DTTimeBoxPlotter::setInteractiveFit(bool isInteractive) { theFitter->setInteractiveFit(isInteractive); }
 
-void DTTimeBoxPlotter::setRebinning(int rebin) {
-  theFitter->setRebinning(rebin);
-}
-
+void DTTimeBoxPlotter::setRebinning(int rebin) { theFitter->setRebinning(rebin); }

--- a/CalibMuon/DTCalibration/test/stubs/DTTimeBoxPlotter.h
+++ b/CalibMuon/DTCalibration/test/stubs/DTTimeBoxPlotter.h
@@ -11,7 +11,6 @@
 
 #include "TString.h"
 
-
 class TFile;
 class TCanvas;
 class TH1F;
@@ -21,8 +20,7 @@ class DTTimeBoxFitter;
 class DTTimeBoxPlotter {
 public:
   /// Constructor
-  DTTimeBoxPlotter(TFile *file);
-
+  DTTimeBoxPlotter(TFile* file);
 
   /// Destructor
   virtual ~DTTimeBoxPlotter();
@@ -31,20 +29,16 @@ public:
 
   /// Plot the time box of a given chamber.
   /// Options: "same" -> histo drawn in the active canvas, "fit" -> fit the rising edge of the time box
-  TH1F* plotTimeBox(int wheel, int station, int sector,
-		    const TString& drawOptions = "");
+  TH1F* plotTimeBox(int wheel, int station, int sector, const TString& drawOptions = "");
   /// Plot the time box of a given superlayer.
   /// Options: "same" -> histo drawn in the active canvas, "fit" -> fit the rising edge of the time box
-  TH1F* plotTimeBox(int wheel, int station, int sector, int sl,
-		    const TString& drawOptions = "");
+  TH1F* plotTimeBox(int wheel, int station, int sector, int sl, const TString& drawOptions = "");
   /// Plot the time box of a given layer.
   /// Options: "same" -> histo drawn in the active canvas, "fit" -> fit the rising edge of the time box
-  TH1F* plotTimeBox(int wheel, int station, int sector, int sl, int layer,
-		    const TString& drawOptions = "");
+  TH1F* plotTimeBox(int wheel, int station, int sector, int sl, int layer, const TString& drawOptions = "");
   /// Plot the time box of a given wire.
   /// Options: "same" -> histo drawn in the active canvas, "fit" -> fit the rising edge of the time box
-  TH1F* plotTimeBox(int wheel, int station, int sector, int sl, int layer, int wire,
-		    const TString& drawOptions = "");
+  TH1F* plotTimeBox(int wheel, int station, int sector, int sl, int layer, int wire, const TString& drawOptions = "");
 
   /// Print all canvases in a pdf file.
   void printPDF();
@@ -55,7 +49,6 @@ public:
   void setRebinning(int rebin);
 
 protected:
-
 private:
   TString getHistoNameSuffix(int wheel, int station, int sector);
   TString getHistoNameSuffix(int wheel, int station, int sector, int sl);
@@ -65,20 +58,15 @@ private:
   TH1F* plotHisto(const TString& histoName, const TString& drawOptions = "");
   TH2F* plotHisto2D(const TString& histoName, const TString& drawOptions = "");
 
-  TCanvas * newCanvas(TString name="",
-		      TString title="",
-		      int xdiv=0,
-		      int ydiv=0,
-		      int form = 1,
-		      int w=-1);
+  TCanvas* newCanvas(TString name = "", TString title = "", int xdiv = 0, int ydiv = 0, int form = 1, int w = -1);
 
-  TCanvas * newCanvas(TString name, int xdiv, int ydiv, int form, int w);
-  TCanvas * newCanvas(int xdiv, int ydiv, int form = 1);
-  TCanvas * newCanvas(int form = 1);
-  TCanvas * newCanvas(TString name, int form, int w=-1);
+  TCanvas* newCanvas(TString name, int xdiv, int ydiv, int form, int w);
+  TCanvas* newCanvas(int xdiv, int ydiv, int form = 1);
+  TCanvas* newCanvas(int form = 1);
+  TCanvas* newCanvas(TString name, int form, int w = -1);
 
-  DTTimeBoxFitter *theFitter;
-  TFile *theFile;
+  DTTimeBoxFitter* theFitter;
+  TFile* theFile;
   unsigned int theVerbosityLevel;
 };
 #endif

--- a/CalibMuon/DTCalibration/test/stubs/classes.h
+++ b/CalibMuon/DTCalibration/test/stubs/classes.h
@@ -3,6 +3,5 @@
 #include "CalibMuon/DTCalibration/test/stubs/DTMeanTimerPlotter.h"
 
 namespace CalibMuon_DTCalibration_test {
-  struct dictionary {
-  };
-}
+  struct dictionary {};
+}  // namespace CalibMuon_DTCalibration_test


### PR DESCRIPTION

Applying code-format for CMSSW category alca.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/422//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


