### PR TITLE
Remove UBSAN flags from CondFormats/HcalObjects

### DIFF
--- a/CondFormats/HcalObjects/BuildFile.xml
+++ b/CondFormats/HcalObjects/BuildFile.xml
@@ -1,4 +1,7 @@
 <flags   GENREFLEX_ARGS="--"/>
+<ifrelease name="_UBSAN_">
+  <flags   REM_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=undefined"/>
+</ifrelease>
 <use   name="CondFormats/Common"/>
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/HcalDetId"/>


### PR DESCRIPTION
#### PR description:

CondFormats/HcalObjects directly uses boost serialization which is known to cause problems when compiled with UBSAN.

#### PR validation:

The code now compiles and links using CMSSW_11_0_UBSAN_X_2019-06-21-2300 IB. Previously we were getting a segmentation fault during the edmCheckClassVersion call.