### PR TITLE
Added missing library to TrackingTools/GsfTracking

### DIFF
--- a/TrackingTools/GsfTracking/BuildFile.xml
+++ b/TrackingTools/GsfTracking/BuildFile.xml
@@ -12,6 +12,7 @@
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="TrackingTools/GeomPropagators"/>
 <use   name="TrackingTools/GsfTools"/>
+<use   name="TrackingTools/MaterialEffects"/>
 <use   name="TrackingTools/KalmanUpdators"/>
 <use   name="TrackingTools/PatternTools"/>
 <use   name="TrackingTools/Records"/>


### PR DESCRIPTION

#### PR description:

Need to link to TrackingTools/MaterialEffects in order for UBSAN to work.

#### PR validation:

Now compiles and links using CMSSW_11_0_UBSAN_X_2019-06-21-2300 IB.