### PR TITLE
Added missing library to RecoTracker/TrackProducer

### DIFF
--- a/RecoTracker/TrackProducer/BuildFile.xml
+++ b/RecoTracker/TrackProducer/BuildFile.xml
@@ -19,6 +19,7 @@
 <use   name="TrackingTools/GeomPropagators"/>
 <use   name="TrackingTools/PatternTools"/>
 <use   name="TrackingTools/Records"/>
+<use   name="RecoTracker/SiTrackerMRHTools"/>
 <use   name="RecoTracker/TransientTrackingRecHit"/>
 <use   name="TrackingTools/TrackFitters"/>
 <use   name="TrackingTools/TrajectoryState"/>


### PR DESCRIPTION

#### PR description:

Need to link with RecoTracker/SiTrackerMRHTools for UBSAN to work.

#### PR validation:

Now compiles and links with CMSSW_11_0_UBSAN_X_2019-06-21-2300 IB.
NOTE: I had to also temporarily add the changes in #27313 to make the plugins fully link.