### PR TITLE
Added missing link to rootmlp in PhysicsTools/PatUtils

### DIFF
--- a/PhysicsTools/PatUtils/BuildFile.xml
+++ b/PhysicsTools/PatUtils/BuildFile.xml
@@ -11,6 +11,7 @@
 <use   name="Utilities/General"/>
 <use   name="PhysicsTools/UtilAlgos"/>
 <use   name="root"/>
+<use   name="rootmlp"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION

#### PR description:

The link is needed to make UBSAN work as it needs to access the virtual table for any class used which has a virtual function.

#### PR validation:

The code compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-21-2300 IB.