### PR TITLE
New Plots for the New Quick Collection in the Tracikng workspace

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -209,6 +209,21 @@ class TrackAnalyzer
 	  MonitorElement* TrackPy;
 	  MonitorElement* TrackPz;
 	  MonitorElement* TrackPt;
+	  MonitorElement* TrackPtZone1;
+	  MonitorElement* TrackPtZone2;
+	  MonitorElement* TrackPtZone3;
+	  MonitorElement* TrackPtZone4;
+	  MonitorElement* TrackPtZone5;
+	  MonitorElement* TrackPtZone6;
+	  MonitorElement* TrackPtZone7;
+	  MonitorElement* TrackPtZone8;
+	  MonitorElement* Ratio_byFolding;
+	  MonitorElement* Ratio_byFolding2;
+	  MonitorElement* TrackPtHighPurity;
+	  MonitorElement* TrackPtTight;
+	  MonitorElement* TrackPtLoose;
+	  MonitorElement* Quality;	
+
 	  
 	  MonitorElement* TrackPxErr;
 	  MonitorElement* TrackPyErr;
@@ -219,10 +234,21 @@ class TrackAnalyzer
 	  MonitorElement* TrackPtErrVsEta;
 	  
 	  MonitorElement* TrackQ;
+	  MonitorElement* TrackQoverP;
+
 	  
 	  MonitorElement* TrackPhi;
 	  MonitorElement* TrackEta;
+	  MonitorElement* TrackEtaHighPurity;
+	  MonitorElement* TrackEtaTight;
+	  MonitorElement* TrackEtaLoose;
           MonitorElement* TrackEtaPhi=nullptr;
+          MonitorElement* TrackEtaPhiInverted=nullptr;
+          MonitorElement* TrackEtaPhiInvertedoutofphase=nullptr;
+          MonitorElement* TkEtaPhi_Ratio_byFoldingmap=nullptr;
+          MonitorElement* TkEtaPhi_Ratio_byFoldingmap_op=nullptr;
+          MonitorElement* TkEtaPhi_RelativeDifference_byFoldingmap=nullptr;
+          MonitorElement* TkEtaPhi_RelativeDifference_byFoldingmap_op=nullptr;
           MonitorElement* TrackEtaPhiInner=nullptr;
           MonitorElement* TrackEtaPhiOuter=nullptr;
 
@@ -357,6 +383,7 @@ class TrackAnalyzer
 	MonitorElement* DistanceOfClosestApproachErrorVsPhi;
 	MonitorElement* DistanceOfClosestApproachErrorVsDxy;
 	MonitorElement* DistanceOfClosestApproachToBS;
+	MonitorElement* DistanceOfClosestApproachToBSdz;
 	MonitorElement* AbsDistanceOfClosestApproachToBS;
 	MonitorElement* DistanceOfClosestApproachToPV;
         MonitorElement* DistanceOfClosestApproachToPVZoom;
@@ -365,6 +392,7 @@ class TrackAnalyzer
 	MonitorElement* DistanceOfClosestApproachVsTheta;
 	MonitorElement* DistanceOfClosestApproachVsPhi;
 	MonitorElement* DistanceOfClosestApproachToBSVsPhi;
+	MonitorElement* DistanceOfClosestApproachToBSVsEta;
 	MonitorElement* DistanceOfClosestApproachToPVVsPhi;
 	MonitorElement* DistanceOfClosestApproachVsEta;
 	MonitorElement* xPointOfClosestApproach;

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -125,6 +125,9 @@ class TrackingMonitor : public one::DQMEDAnalyzer<one::DQMLuminosityBlockElement
 
         // Tracks 
         MonitorElement * NumberOfTracks;
+        MonitorElement * NumberOfTracks_PUvtx;
+        MonitorElement * NumberofTracks_Hardvtx;
+        MonitorElement * NumberofTracks_Hardvtx_PUvtx;
         MonitorElement * NumberOfMeanRecHitsPerTrack;
         MonitorElement * NumberOfMeanLayersPerTrack;  
 

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -1,6 +1,6 @@
 /*
  *  See header file for a description of this class.
- *
+ **
  *  \author Suchandra Dutta , Giorgia Mila
  */
 
@@ -290,7 +290,24 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
      NumberOfTracks = ibooker.book1D(histname, histname, 3*TKNoBin, TKNoMin, (TKNoMax+0.5)*3.-0.5);
      NumberOfTracks->setAxisTitle("Number of Tracks per Event", 1);
      NumberOfTracks->setAxisTitle("Number of Events", 2);
-  
+
+     histname = "NumberOfTracks_PUvtx_" + CategoryName;
+     NumberOfTracks_PUvtx = ibooker.book1D(histname, histname, 3*TKNoBin, TKNoMin, (TKNoMax+0.5)*3.-0.5);
+     NumberOfTracks_PUvtx->setAxisTitle("Number of Tracks per Event (matched a PU vertex)", 1);
+     NumberOfTracks_PUvtx->setAxisTitle("Number of Events", 2);
+
+     histname = "NumberofTracks_Hardvtx_" + CategoryName;
+     NumberofTracks_Hardvtx = ibooker.book1D(histname, histname, TKNoBin/10, TKNoMin, (TKNoMax/10+0.5)*3.-0.5);
+     NumberofTracks_Hardvtx->setAxisTitle("Number of Tracks per Event (matched main vertex)", 1);
+     NumberofTracks_Hardvtx->setAxisTitle("Number of Events", 2);
+
+     histname = "NumberofTracks_Hardvtx_PUvtx_" + CategoryName;
+     NumberofTracks_Hardvtx_PUvtx = ibooker.book1D(histname, histname, 2, 0., 2.);
+     NumberofTracks_Hardvtx_PUvtx->setAxisTitle("Number of Tracks per PU/Hard vertex", 1);
+     NumberofTracks_Hardvtx_PUvtx->setAxisTitle("Number of Tracks", 2);
+     NumberofTracks_Hardvtx_PUvtx->setBinLabel(1,"PU_Vertex");
+     NumberofTracks_Hardvtx_PUvtx->setBinLabel(2,"Hard_Vertex");
+
      histname = "NumberOfMeanRecHitsPerTrack_" + CategoryName;
      NumberOfMeanRecHitsPerTrack = ibooker.book1D(histname, histname, MeanHitBin, MeanHitMin, MeanHitMax);
      NumberOfMeanRecHitsPerTrack->setAxisTitle("Mean number of valid RecHits per Track", 1);
@@ -821,7 +838,11 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       if (numberOfTracks_den > 0) frac = static_cast<double>(numberOfTracks_num)/static_cast<double>(numberOfTracks_den);
       
       if (doGeneralPropertiesPlots_ || doAllPlots){
-	NumberOfTracks       -> Fill(numberOfTracks);
+	NumberOfTracks       -> Fill(double(numberOfTracks));
+	NumberofTracks_Hardvtx->Fill(double(numberOfTracks_pv0));
+	NumberOfTracks_PUvtx->Fill(double(numberOfTracks - numberOfTracks_pv0));
+	NumberofTracks_Hardvtx_PUvtx->Fill(0.5,double(numberOfTracks_pv0));
+	NumberofTracks_Hardvtx_PUvtx->Fill(1.5,double(numberOfTracks-numberOfTracks_pv0));
 	if ( doPlotsVsBX_ || doAllPlots )
 	  NumberOfTracksVsBX   -> Fill(bx,numberOfTracks);
 	if (doPlotsVsLUMI_ || doAllPlots) 


### PR DESCRIPTION
PR description:

Add new plots in the Tracking Workspace

dz with respect to BS
dxy with respect to the BS vs eta and phi,
q over p
track quality (isLoose, isTight, isHighQuality),
"inclusively" but also vs pT and eta
number of tracks per vertex, for the hard vertex and
for the other (PU) vertices
tracking efficiency plots from the folding method, for the
"eta vs phi map"
tracking efficiency vs pT of the tracks