### PR TITLE
[PPS][util] Enable/disable calibration for PPS timing detector

### DIFF
--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondRecHitProducerAlgorithm.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondRecHitProducerAlgorithm.h
@@ -34,6 +34,8 @@ private:
   static constexpr unsigned short MAX_CHANNEL = 20;
   /// Conversion constant between HPTDC time slice and absolute time (in ns)
   double ts_to_ns_;
+  /// Switch on/off the timing calibration
+  bool apply_calib_;
   PPSTimingCalibration calib_;
   std::unique_ptr<reco::FormulaEvaluator> calib_fct_;
 };

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
@@ -54,6 +54,7 @@ private:
 CTPPSDiamondRecHitProducer::CTPPSDiamondRecHitProducer(const edm::ParameterSet& iConfig)
     : digiToken_(consumes<edm::DetSetVector<CTPPSDiamondDigi> >(iConfig.getParameter<edm::InputTag>("digiTag"))),
       timingCalibrationTag_(iConfig.getParameter<std::string>("timingCalibrationTag")),
+      applyCalib_(iConfig.getParameter<bool>("applyCalibration")),
       algo_(iConfig) {
   produces<edm::DetSetVector<CTPPSDiamondRecHit> >();
 }
@@ -66,7 +67,7 @@ void CTPPSDiamondRecHitProducer::produce(edm::Event& iEvent, const edm::EventSet
   iEvent.getByToken(digiToken_, digis);
 
   if (!digis->empty()) {
-    if (calibWatcher_.check(iSetup)) {
+    if (applyCalib_ && calibWatcher_.check(iSetup)) {
       edm::ESHandle<PPSTimingCalibration> hTimingCalib;
       iSetup.get<PPSTimingCalibrationRcd>().get(timingCalibrationTag_, hTimingCalib);
       algo_.setCalibration(*hTimingCalib);

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
@@ -47,6 +47,7 @@ private:
   /// A watcher to detect timing calibration changes.
   edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
 
+  bool applyCalib_;
   CTPPSDiamondRecHitProducerAlgorithm algo_;
 };
 
@@ -90,9 +91,8 @@ void CTPPSDiamondRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions
       ->setComment("input tag for timing calibrations retrieval");
   desc.add<double>("timeSliceNs", 25.0 / 1024.0)
       ->setComment("conversion constant between HPTDC timing bin size and nanoseconds");
-  desc.add<int>("timeShift",
-                0)  // to be determined at calibration level, will be replaced by a map channel id -> time shift
-      ->setComment("overall time offset to apply on all hits in all channels");
+  desc.add<bool>("applyCalibration", true)
+      ->setComment("switch on/off the timing calibration");
 
   descr.add("ctppsDiamondRecHits", desc);
 }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
@@ -92,8 +92,7 @@ void CTPPSDiamondRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions
       ->setComment("input tag for timing calibrations retrieval");
   desc.add<double>("timeSliceNs", 25.0 / 1024.0)
       ->setComment("conversion constant between HPTDC timing bin size and nanoseconds");
-  desc.add<bool>("applyCalibration", true)
-      ->setComment("switch on/off the timing calibration");
+  desc.add<bool>("applyCalibration", true)->setComment("switch on/off the timing calibration");
 
   descr.add("ctppsDiamondRecHits", desc);
 }

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -67,9 +67,8 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
         }
       }
 
-      const int time_slice = (t_lead != 0)
-        ? (t_lead - ch_t_offset / ts_to_ns_) / 1024
-        : CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING;
+      const int time_slice =
+          (t_lead != 0) ? (t_lead - ch_t_offset / ts_to_ns_) / 1024 : CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING;
 
       // calibrated time of arrival
       const double t0 = (t_lead % 1024) * ts_to_ns_ - ch_t_twc;

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -43,7 +43,7 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
 
     // retrieve the timing calibration part for this channel
     const int sector = detid.arm(), station = detid.station(), plane = detid.plane(), channel = detid.channel();
-    const auto ch_params = (apply_calib_) ? calib_.parameters(sector, station, plane, channel) : {};
+    const auto& ch_params = (apply_calib_) ? calib_.parameters(sector, station, plane, channel) : std::vector<double>{};
     // default values for offset + time precision if calibration object not found
     const double ch_t_offset = (apply_calib_) ? calib_.timeOffset(sector, station, plane, channel) : 0.;
     const double ch_t_precis = (apply_calib_) ? calib_.timePrecision(sector, station, plane, channel) : 0.;


### PR DESCRIPTION
#### PR description:

This PR allows to manually disable the timing calibration procedure for the rechits producer. This is not meant to be used in any T0 operations, but provides a useful tool for our AlCaDB testing purposes.
Additionally, the unused `timeShift` parameter description is dropped from the producer's `fillDescriptions`.

#### PR validation:

Compiles and runs smoothly.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- [x] verify that the PR is really intended for the chosen branch
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
