### PR TITLE
[HGCAL trigger] Updates (mainly) in Super/Coarse trigger cells and cluster seeding

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
@@ -82,7 +82,6 @@ public:
 
   static const HGCalTriggerDetId Undefined;
 
-private:
   static const int kHGCalCellUOffset = 0;
   static const int kHGCalCellUMask = 0xF;
   static const int kHGCalCellVOffset = 4;

--- a/DataFormats/L1THGCal/interface/HGCalClusterT.h
+++ b/DataFormats/L1THGCal/interface/HGCalClusterT.h
@@ -217,7 +217,7 @@ namespace l1t {
         centre_ = GlobalPoint(clusterCentre);
 
         if (clusterCentre.z() != 0) {
-          centreProj_ = GlobalPoint(clusterCentre / clusterCentre.z());
+          centreProj_ = GlobalPoint(clusterCentre / std::abs(clusterCentre.z()));
         }
       }
 

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -1,0 +1,66 @@
+#ifndef __L1Trigger_L1THGCal_HGCalCoarseTriggerCellMapping_h__
+#define __L1Trigger_L1THGCal_HGCalCoarseTriggerCellMapping_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalCoarseTriggerCellMapping {
+public:
+  HGCalCoarseTriggerCellMapping(const std::vector<unsigned>& ctcSize);
+  uint32_t getRepresentativeDetId(uint32_t tcid) const;
+  std::vector<uint32_t> getConstituentTriggerCells(uint32_t ctcId) const;
+  GlobalPoint getCoarseTriggerCellPosition(uint32_t ctcId) const;
+  uint32_t getCoarseTriggerCellId(uint32_t detid) const;
+  void checkSizeValidity(int ctcSize) const;
+  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+
+  static constexpr int kCTCsizeCoarse_ = 16;
+  static constexpr int kCTCsizeMid_ = 8;
+  static constexpr int kCTCsizeFine_ = 4;
+  static constexpr int kCTCsizeVeryFine_ = 2;
+  static constexpr int kCTCsizeIndividual_ = 1;
+
+private:
+  static const std::map<int, int> kSplit_;
+  static const std::map<int, int> kSplit_v9_;
+  static const std::map<int, int> kSplit_v9_Scin_;
+  static constexpr int kSTCidMaskInv_ = ~0x3f;
+  static constexpr int kSTCidMaskInv_v9_ = ~0xf;
+  static constexpr int kSplit_v8_Coarse_ = 0x30;
+  static constexpr int kSplit_v8_Mid_ = 0x38;
+  static constexpr int kSplit_v8_Fine_ = 0x3a;
+  static constexpr int kSplit_v8_VeryFine_ = 0x3e;
+  static constexpr int kSplit_v8_Individual_ = 0x3f;
+  static constexpr int kNLayers_ = 4;
+  static constexpr int kSplit_v9_Coarse_ = 0;
+  static constexpr int kSplit_v9_Mid_ = 0x2;
+  static constexpr int kSplit_v9_Fine_ = 0xa;
+  static constexpr int kSplit_v9_VeryFine_ = 0xb;
+  static constexpr int kSplit_v9_Individual_ = 0xf;
+
+  static constexpr int kSplit_v9_Scin_Coarse_ = 0x1f9fc;
+  static constexpr int kSplit_v9_Scin_Mid_ = 0x1fdfc;
+  static constexpr int kSplit_v9_Scin_Fine_ = 0x1fdfe;
+  static constexpr int kSplit_v9_Scin_VeryFine_ = 0x1fffe;
+  static constexpr int kSplit_v9_Scin_Individual_ = 0x1ffff;
+
+  //For coarse TCs
+  static constexpr int kRocShift_ = 4;
+  static constexpr int kRocMask_ = 0xf;
+  static constexpr int kRotate4_ = 4;
+  static constexpr int kRotate7_ = 7;
+  static constexpr int kUShift_ = 2;
+  static constexpr int kVShift_ = 0;
+  static constexpr int kUMask_ = 0x3;
+  static constexpr int kVMask_ = 0x3;
+  static constexpr int kHGCalCellMaskV9Inv_ = ~0xff;
+  static constexpr int kHGCalScinCellMaskInv_ = ~0x1ffff;
+
+  HGCalTriggerTools triggerTools_;
+  HGCSiliconDetIdToROC detIdToROC_;
+  std::vector<unsigned> ctcSize_;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -58,6 +58,10 @@ private:
   static constexpr int kHGCalCellMaskV9Inv_ = ~0xff;
   static constexpr int kHGCalScinCellMaskInv_ = ~0x1ffff;
 
+  static constexpr int kRoc0deg_ = 1;
+  static constexpr int kRoc120deg_ = 2;
+  static constexpr int kRoc240deg_ = 3;
+
   HGCalTriggerTools triggerTools_;
   HGCSiliconDetIdToROC detIdToROC_;
   std::vector<unsigned> ctcSize_;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -22,9 +22,7 @@
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
-
-class HGCalTriggerGeometryBase;
-class DetId;
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 
 namespace edm {
   class Event;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -80,6 +80,8 @@ public:
   DetId simToReco(const DetId&, const HGCalTopology&) const;
   DetId simToReco(const DetId&, const HcalTopology&) const;
 
+  static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 3;
+
 private:
   const HGCalTriggerGeometryBase* geom_;
   unsigned eeLayers_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -93,7 +93,7 @@ private:
   SeedingType seedingType_;
   SeedingPosition seedingPosition_;
 
-  unsigned nBinsRHisto_ = 41;
+  unsigned nBinsRHisto_ = 42;
   unsigned nBinsPhiHisto_ = 216;
   std::vector<unsigned> binsSumsHisto_;
   double histoThreshold_ = 20.;
@@ -102,7 +102,7 @@ private:
   HGCalTriggerTools triggerTools_;
 
   static constexpr unsigned neighbour_weights_size_ = 9;
-  static constexpr double kROverZMin_ = 0.09;
+  static constexpr double kROverZMin_ = 0.076;
   static constexpr double kROverZMax_ = 0.58;
 };
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -45,7 +45,13 @@ private:
     unsigned bins_ = 0;
     Data histogram_;
 
-    unsigned index(int zside, unsigned x1, unsigned x2) const { return x2 + bins2_ * x1 + bins_ * (zside > 0 ? 1 : 0); }
+    unsigned index(int zside, unsigned x1, unsigned x2) const {
+      if (x1 >= bins1_ || x2 >= bins2_) {
+        throw cms::Exception("OutOfBound") << "Trying to access bin (" << x1 << "," << x2
+                                           << ") in seeding histogram of size (" << bins1_ << "," << bins2_ << ")";
+      }
+      return x2 + bins2_ * x1 + bins_ * (zside > 0 ? 1 : 0);
+    }
   };
   using Histogram = HistogramT<Bin>;
 
@@ -87,7 +93,7 @@ private:
   SeedingType seedingType_;
   SeedingPosition seedingPosition_;
 
-  unsigned nBinsRHisto_ = 36;
+  unsigned nBinsRHisto_ = 41;
   unsigned nBinsPhiHisto_ = 216;
   std::vector<unsigned> binsSumsHisto_;
   double histoThreshold_ = 20.;
@@ -97,7 +103,7 @@ private:
 
   static constexpr unsigned neighbour_weights_size_ = 9;
   static constexpr double kROverZMin_ = 0.09;
-  static constexpr double kROverZMax_ = 0.52;
+  static constexpr double kROverZMax_ = 0.58;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -24,14 +24,27 @@ public:
 
 private:
   enum SeedingType { HistoMaxC3d, HistoSecondaryMaxC3d, HistoThresholdC3d, HistoInterpolatedMaxC3d };
+  enum SeedingPosition { BinCentre, TCWeighted };
 
-  typedef std::map<std::array<int, 3>, float> Histogram;
+  struct Bin {
+    float sumMipPt;
+    float weighted_x;
+    float weighted_y;
+  };
+
+  typedef std::map<std::array<int, 3>, Bin> Histogram;
 
   Histogram fillHistoClusters(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs);
 
   Histogram fillSmoothPhiHistoClusters(const Histogram& histoClusters, const vector<unsigned>& binSums);
 
   Histogram fillSmoothRPhiHistoClusters(const Histogram& histoClusters);
+
+  void setSeedEnergyAndPosition(std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy,
+                                int z_side,
+                                int bin_R,
+                                int bin_phi,
+                                const Bin& histBin);
 
   std::vector<std::pair<GlobalPoint, double>> computeMaxSeeds(const Histogram& histoClusters);
 
@@ -43,6 +56,7 @@ private:
 
   std::string seedingAlgoType_;
   SeedingType seedingType_;
+  SeedingPosition seedingPosition_;
 
   unsigned nBinsRHisto_ = 36;
   unsigned nBinsPhiHisto_ = 216;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -31,7 +31,7 @@ private:
 
     T& at(int zside, unsigned x1, unsigned x2) { return histogram_[index(zside, x1, x2)]; }
 
-    const T& at(int zside, unsigned x1, unsigned x2) const { return histogram_.at(index(zside, x1, x2)); }
+    const T& at(int zside, unsigned x1, unsigned x2) const { return histogram_[index(zside, x1, x2)]; }
 
     iterator begin() { return histogram_.begin(); }
     const_iterator begin() const { return histogram_.begin(); }

--- a/L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h
@@ -13,7 +13,8 @@ class HGCalShowerShape {
 public:
   typedef math::XYZTLorentzVector LorentzVector;
 
-  HGCalShowerShape() {}
+  HGCalShowerShape() : threshold_(0.) {}
+  HGCalShowerShape(const edm::ParameterSet& conf);
 
   ~HGCalShowerShape() {}
 
@@ -74,8 +75,13 @@ private:
   float sigmaPhiPhi(const std::vector<pair<float, float>>& energy_phi_tc, const float phi_cluster) const {
     return sigmaXX<DeltaPhi<float>>(energy_phi_tc, phi_cluster);
   }
+  template <typename T>
+  bool pass(const T& obj) const {
+    return obj.mipPt() > threshold_;
+  }
 
   HGCalTriggerTools triggerTools_;
+  double threshold_ = 0.;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -1,0 +1,39 @@
+#ifndef __L1Trigger_L1THGCal_HGCalConcentratorCoarsenerImpl_h__
+#define __L1Trigger_L1THGCal_HGCalConcentratorCoarsenerImpl_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+#include "L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h"
+
+class HGCalConcentratorCoarsenerImpl {
+public:
+  HGCalConcentratorCoarsenerImpl(const edm::ParameterSet& conf);
+
+  void coarsen(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
+               std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
+  void eventSetup(const edm::EventSetup& es) {
+    triggerTools_.eventSetup(es);
+    coarseTCmapping_.eventSetup(es);
+  }
+
+private:
+  HGCalTriggerTools triggerTools_;
+  bool fixedDataSizePerHGCROC_;
+  HGCalCoarseTriggerCellMapping coarseTCmapping_;
+  static constexpr int kHighDensityThickness_ = 0;
+
+  struct CoarseTC {
+    float sumPt;
+    float maxMipPt;
+    int sumHwPt;
+    float sumMipPt;
+    unsigned maxId;
+  };
+
+  std::unordered_map<uint32_t, CoarseTC> coarseTCs_;
+
+  void updateCoarseTriggerCellMaps(const l1t::HGCalTriggerCell& tc, uint32_t ctcid);
+  void assignCoarseTriggerCellEnergy(l1t::HGCalTriggerCell& c, const CoarseTC& ctc) const;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -21,6 +21,7 @@ private:
   bool fixedDataSizePerHGCROC_;
   HGCalCoarseTriggerCellMapping coarseTCmapping_;
   static constexpr int kHighDensityThickness_ = 0;
+  static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 3;
 
   struct CoarseTC {
     float sumPt;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -21,7 +21,6 @@ private:
   bool fixedDataSizePerHGCROC_;
   HGCalCoarseTriggerCellMapping coarseTCmapping_;
   static constexpr int kHighDensityThickness_ = 0;
-  static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 3;
 
   struct CoarseTC {
     float sumPt;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -5,6 +5,7 @@
 #include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorThresholdImpl.h"
 #include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorBestChoiceImpl.h"
 #include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h"
+#include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h"
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
@@ -23,10 +24,14 @@ public:
 
 private:
   SelectionType selectionType_;
+  bool fixedDataSizePerHGCROC_;
+  bool coarsenTriggerCells_;
+  static constexpr int kHighDensityThickness_ = 0;
 
   std::unique_ptr<HGCalConcentratorThresholdImpl> thresholdImpl_;
   std::unique_ptr<HGCalConcentratorBestChoiceImpl> bestChoiceImpl_;
   std::unique_ptr<HGCalConcentratorSuperTriggerCellImpl> superTriggerCellImpl_;
+  std::unique_ptr<HGCalConcentratorCoarsenerImpl> coarsenerImpl_;
 
   HGCalTriggerTools triggerTools_;
 };

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -2,62 +2,94 @@
 #define __L1Trigger_L1THGCal_HGCalConcentratorSuperTriggerCellImpl_h__
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
-#include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+#include "L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h"
+
+#include <array>
 #include <vector>
 
 class HGCalConcentratorSuperTriggerCellImpl {
 public:
   HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf);
 
-  void superTriggerCellSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
-                                  std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void select(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
+              std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
+  void eventSetup(const edm::EventSetup& es) {
+    triggerTools_.eventSetup(es);
+    coarseTCmapping_.eventSetup(es);
+    superTCmapping_.eventSetup(es);
+  }
 
 private:
-  int getSuperTriggerCellId(int detid) const;
-  static const std::map<int, int> kSplit_;
-  static constexpr int kWafer_offset_ = 6;
-  static constexpr int kSTCsizeCoarse_ = 16;
-  static constexpr int kSTCsizeFine_ = 4;
-  static constexpr int kSplit_v8_Coarse_ = 0x30;
-  static constexpr int kSplit_v8_Fine_ = 0x3a;
-  static constexpr int kNLayers_ = 3;
-  static constexpr int kSplit_v9_ = 0x36;
-
-  static constexpr int kRocShift_ = 6;
-  static constexpr int kRotate4_ = 4;
-  static constexpr int kUShift_ = 3;
+  enum EnergyDivisionType {
+    superTriggerCell,
+    oneBitFraction,
+    equalShare,
+  };
+  EnergyDivisionType energyDivisionType_;
+  static constexpr int kHighDensityThickness_ = 0;
+  static constexpr int kOddNumberMask_ = 1;
 
   HGCalTriggerTools triggerTools_;
-  HGCSiliconDetIdToROC detIdToROC_;
-  std::vector<unsigned> stcSize_;
+  bool fixedDataSizePerHGCROC_;
+  HGCalCoarseTriggerCellMapping coarseTCmapping_;
+  HGCalCoarseTriggerCellMapping superTCmapping_;
+
+  //Parameters for energyDivisionType_ = oneBitFraction
+  double oneBitFractionThreshold_;
+  double oneBitFractionLowValue_;
+  double oneBitFractionHighValue_;
+
+  //Parameters for energyDivisionType_ = equalShare
+  static constexpr int kTriggerCellsForDivision_ = 4;
 
   class SuperTriggerCell {
   private:
-    float sumPt_, sumMipPt_;
-    int sumHwPt_, maxHwPt_;
-    unsigned maxId_;
+    float sumPt_, sumMipPt_, maxMipPt_, fracsum_;
+    int sumHwPt_;
+    uint32_t maxId_, stcId_;
+    std::map<uint32_t, float> tc_pts_;
 
   public:
-    SuperTriggerCell() { sumPt_ = 0, sumMipPt_ = 0, sumHwPt_ = 0, maxHwPt_ = 0, maxId_ = 0; }
-    void add(const l1t::HGCalTriggerCell& c) {
+    SuperTriggerCell() : sumPt_(0), sumMipPt_(0), maxMipPt_(0), fracsum_(0), sumHwPt_(0), maxId_(0), stcId_(0){};
+
+    void add(const l1t::HGCalTriggerCell& c, uint32_t stcId) {
       sumPt_ += c.pt();
       sumMipPt_ += c.mipPt();
       sumHwPt_ += c.hwPt();
-      if (maxId_ == 0 || c.hwPt() > maxHwPt_) {
-        maxHwPt_ = c.hwPt();
+      if (maxId_ == 0 || c.mipPt() > maxMipPt_) {
+        maxMipPt_ = c.mipPt();
         maxId_ = c.detId();
       }
+
+      if (stcId_ == 0) {
+        stcId_ = stcId;
+      }
+      tc_pts_[c.detId()] = c.mipPt();
     }
-    void assignEnergy(l1t::HGCalTriggerCell& c) const {
-      c.setHwPt(sumHwPt_);
-      c.setMipPt(sumMipPt_);
-      c.setPt(sumPt_);
+    void addToFractionSum(float frac) {
+      fracsum_ += frac;
+      if (fracsum_ > 1) {
+        throw cms::Exception("HGCalConcentratorSuperTriggerCellError")
+            << "Sum of Trigger Cell fractions should not be greater than 1";
+      }
     }
-    unsigned GetMaxId() const { return maxId_; }
+    uint32_t getMaxId() const { return maxId_; }
+    uint32_t getSTCId() const { return stcId_; }
+    float getSumMipPt() const { return sumMipPt_; }
+    int getSumHwPt() const { return sumHwPt_; }
+    float getSumPt() const { return sumPt_; }
+    float getFractionSum() const { return fracsum_; }
+    float getTCpt(uint32_t tcid) const {
+      const auto pt = tc_pts_.find(tcid);
+      return (pt == tc_pts_.end() ? 0 : pt->second);
+    }
+    int size() const { return tc_pts_.size(); }
   };
+  void createAllTriggerCells(std::unordered_map<unsigned, SuperTriggerCell>& STCs,
+                             std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const;
+  void assignSuperTriggerCellEnergyAndPosition(l1t::HGCalTriggerCell& c, const SuperTriggerCell& stc) const;
+  float getTriggerCellOneBitFraction(float tcPt, float sumPt) const;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -42,7 +42,7 @@ private:
 
   //Parameters for energyDivisionType_ = equalShare
   static constexpr int kTriggerCellsForDivision_ = 4;
-
+  static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 3;
   class SuperTriggerCell {
   private:
     float sumPt_, sumMipPt_, maxMipPt_, fracsum_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -42,7 +42,7 @@ private:
 
   //Parameters for energyDivisionType_ = equalShare
   static constexpr int kTriggerCellsForDivision_ = 4;
-  static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 3;
+
   class SuperTriggerCell {
   private:
     float sumPt_, sumMipPt_, maxMipPt_, fracsum_;

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -6,7 +6,9 @@
 DEFINE_EDM_PLUGIN(HGCalConcentratorFactory, HGCalConcentratorProcessorSelection, "HGCalConcentratorProcessorSelection");
 
 HGCalConcentratorProcessorSelection::HGCalConcentratorProcessorSelection(const edm::ParameterSet& conf)
-    : HGCalConcentratorProcessorBase(conf) {
+    : HGCalConcentratorProcessorBase(conf),
+      fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC")),
+      coarsenTriggerCells_(conf.getParameter<bool>("coarsenTriggerCells")) {
   std::string selectionType(conf.getParameter<std::string>("Method"));
   if (selectionType == "thresholdSelect") {
     selectionType_ = thresholdSelect;
@@ -21,6 +23,10 @@ HGCalConcentratorProcessorSelection::HGCalConcentratorProcessorSelection(const e
     throw cms::Exception("HGCTriggerParameterError")
         << "Unknown type of concentrator selection '" << selectionType << "'";
   }
+
+  if (coarsenTriggerCells_ || fixedDataSizePerHGCROC_) {
+    coarsenerImpl_ = std::make_unique<HGCalConcentratorCoarsenerImpl>(conf);
+  }
 }
 
 void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& triggerCellCollInput,
@@ -32,6 +38,10 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
     bestChoiceImpl_->eventSetup(es);
   if (superTriggerCellImpl_)
     superTriggerCellImpl_->eventSetup(es);
+  if (coarsenerImpl_)
+    coarsenerImpl_->eventSetup(es);
+  triggerTools_.eventSetup(es);
+
   const l1t::HGCalTriggerCellBxCollection& collInput = *triggerCellCollInput;
 
   std::unordered_map<uint32_t, std::vector<l1t::HGCalTriggerCell>> tc_modules;
@@ -42,23 +52,56 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
 
   for (const auto& module_trigcell : tc_modules) {
     std::vector<l1t::HGCalTriggerCell> trigCellVecOutput;
-    switch (selectionType_) {
-      case thresholdSelect:
-        thresholdImpl_->select(module_trigcell.second, trigCellVecOutput);
-        break;
-      case bestChoiceSelect:
-        bestChoiceImpl_->select(geometry_->getLinksInModule(module_trigcell.first),
-                                geometry_->getModuleSize(module_trigcell.first),
-                                module_trigcell.second,
-                                trigCellVecOutput);
-        break;
-      case superTriggerCellSelect:
-        superTriggerCellImpl_->superTriggerCellSelectImpl(module_trigcell.second, trigCellVecOutput);
-        break;
-      default:
-        // Should not happen, selection type checked in constructor
-        break;
+    std::vector<l1t::HGCalTriggerCell> trigCellVecCoarsened;
+
+    int thickness = 0;
+    if (triggerTools_.isSilicon(module_trigcell.second.at(0).detId())) {
+      thickness = triggerTools_.thicknessIndex(module_trigcell.second.at(0).detId(), true);
+    } else if (triggerTools_.isScintillator(module_trigcell.second.at(0).detId())) {
+      thickness = 3;
     }
+
+    if (coarsenTriggerCells_ || (fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_)) {
+      coarsenerImpl_->coarsen(module_trigcell.second, trigCellVecCoarsened);
+
+      switch (selectionType_) {
+        case thresholdSelect:
+          thresholdImpl_->select(trigCellVecCoarsened, trigCellVecOutput);
+          break;
+        case bestChoiceSelect:
+          bestChoiceImpl_->select(geometry_->getLinksInModule(module_trigcell.first),
+                                  geometry_->getModuleSize(module_trigcell.first),
+                                  trigCellVecCoarsened,
+                                  trigCellVecOutput);
+          break;
+        case superTriggerCellSelect:
+          superTriggerCellImpl_->select(trigCellVecCoarsened, trigCellVecOutput);
+          break;
+        default:
+          // Should not happen, selection type checked in constructor
+          break;
+      }
+
+    } else {
+      switch (selectionType_) {
+        case thresholdSelect:
+          thresholdImpl_->select(module_trigcell.second, trigCellVecOutput);
+          break;
+        case bestChoiceSelect:
+          bestChoiceImpl_->select(geometry_->getLinksInModule(module_trigcell.first),
+                                  geometry_->getModuleSize(module_trigcell.first),
+                                  module_trigcell.second,
+                                  trigCellVecOutput);
+          break;
+        case superTriggerCellSelect:
+          superTriggerCellImpl_->select(module_trigcell.second, trigCellVecOutput);
+          break;
+        default:
+          // Should not happen, selection type checked in constructor
+          break;
+      }
+    }
+
     for (const auto& trigCell : trigCellVecOutput) {
       triggerCellCollOutput.push_back(0, trigCell);
     }

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -58,7 +58,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
     if (triggerTools_.isSilicon(module_trigcell.second.at(0).detId())) {
       thickness = triggerTools_.thicknessIndex(module_trigcell.second.at(0).detId(), true);
     } else if (triggerTools_.isScintillator(module_trigcell.second.at(0).detId())) {
-      thickness = 3;
+      thickness = HGCalTriggerTools::kScintillatorPseudoThicknessIndex_;
     }
 
     if (coarsenTriggerCells_ || (fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_)) {

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
@@ -377,9 +377,7 @@ HGCalTriggerGeometryBase::geom_ordered_set HGCalTriggerGeometryV9Imp2::getOrdere
 
 HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getNeighborsFromTriggerCell(
     const unsigned trigger_cell_id) const {
-  HGCalDetId trigger_cell_det_id(trigger_cell_id);
-  geom_set neighbor_detids;
-  return neighbor_detids;
+  throw cms::Exception("FeatureNotImplemented") << "Neighbor search is not implemented in HGCalTriggerGeometryV9Imp2";
 }
 
 unsigned HGCalTriggerGeometryV9Imp2::getLinksInModule(const unsigned module_id) const {

--- a/L1Trigger/L1THGCal/python/customClustering.py
+++ b/L1Trigger/L1THGCal/python/customClustering.py
@@ -133,6 +133,7 @@ def custom_3dclustering_histoMax_variableDr(process,
                                             nBins_Phi=histoMaxVariableDR_C3d_params.nBins_Phi_histo_multicluster,
                                             binSumsHisto=histoMaxVariableDR_C3d_params.binSumsHisto,
                                             seed_threshold=histoMaxVariableDR_C3d_params.threshold_histo_multicluster,
+                                            seed_position=histoMaxVariableDR_C3d_params.seed_position,
                                             shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
                                             ):
     parameters_c3d = histoMaxVariableDR_C3d_params.clone(

--- a/L1Trigger/L1THGCal/python/customClustering.py
+++ b/L1Trigger/L1THGCal/python/customClustering.py
@@ -81,12 +81,20 @@ def custom_3dclustering_dbscan(process,
     return process
 
 
-def set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold):
+def set_histomax_params(parameters_c3d,
+                        distance,
+                        nBins_R,
+                        nBins_Phi,
+                        binSumsHisto,
+                        seed_threshold,
+                        shape_threshold
+                        ):
     parameters_c3d.dR_multicluster = distance
     parameters_c3d.nBins_R_histo_multicluster = nBins_R
     parameters_c3d.nBins_Phi_histo_multicluster = nBins_Phi
     parameters_c3d.binSumsHisto = binSumsHisto
     parameters_c3d.threshold_histo_multicluster = seed_threshold
+    parameters_c3d.shape_threshold = shape_threshold
 
 
 def custom_3dclustering_histoMax(process,
@@ -95,9 +103,11 @@ def custom_3dclustering_histoMax(process,
                                  nBins_Phi=histoMax_C3d_params.nBins_Phi_histo_multicluster,
                                  binSumsHisto=histoMax_C3d_params.binSumsHisto,
                                  seed_threshold=histoMax_C3d_params.threshold_histo_multicluster,
+                                 shape_threshold=histoMax_C3d_params.shape_threshold,
                                  ):
     parameters_c3d = histoMax_C3d_params.clone()
-    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto,
+                        seed_threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
@@ -108,9 +118,11 @@ def custom_3dclustering_histoSecondaryMax(process,
                                           nBins_R=histoSecondaryMax_C3d_params.nBins_R_histo_multicluster,
                                           nBins_Phi=histoSecondaryMax_C3d_params.nBins_Phi_histo_multicluster,
                                           binSumsHisto=histoSecondaryMax_C3d_params.binSumsHisto,
+                                          shape_threshold=histoSecondaryMax_C3d_params.shape_threshold,
                                           ):
     parameters_c3d = histoSecondaryMax_C3d_params.clone()
-    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, threshold)
+    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto,
+                        threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
@@ -121,11 +133,13 @@ def custom_3dclustering_histoMax_variableDr(process,
                                             nBins_Phi=histoMaxVariableDR_C3d_params.nBins_Phi_histo_multicluster,
                                             binSumsHisto=histoMaxVariableDR_C3d_params.binSumsHisto,
                                             seed_threshold=histoMaxVariableDR_C3d_params.threshold_histo_multicluster,
+                                            shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
                                             ):
     parameters_c3d = histoMaxVariableDR_C3d_params.clone(
             dR_multicluster_byLayer_coefficientA = cms.vdouble(distances)
             )
-    set_histomax_params(parameters_c3d, 0, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(parameters_c3d, 0, nBins_R, nBins_Phi, binSumsHisto,
+                        seed_threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
@@ -135,12 +149,14 @@ def custom_3dclustering_histoInterpolatedMax1stOrder(process,
                                                      nBins_R=histoInterpolatedMax_C3d_params.nBins_R_histo_multicluster,
                                                      nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
                                                      binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
-                                                     seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster
+                                                     seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+                                                     shape_threshold=histoInterpolatedMax_C3d_params.shape_threshold,
                                                      ):
     parameters_c3d = histoInterpolatedMax_C3d_params.clone(
             neighbour_weights = neighbour_weights_1stOrder
             )
-    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto,
+                        seed_threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
@@ -150,11 +166,14 @@ def custom_3dclustering_histoInterpolatedMax2ndOrder(process,
                                                      nBins_R=histoInterpolatedMax_C3d_params.nBins_R_histo_multicluster,
                                                      nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
                                                      binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
-                                                     seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster):
+                                                     seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+                                                     shape_threshold=histoInterpolatedMax_C3d_params.shape_threshold,
+                                                     ):
     parameters_c3d = histoInterpolatedMax_C3d_params.clone(
             neighbour_weights = neighbour_weights_2ndOrder
             )
-    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto,
+                        seed_threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 
@@ -164,10 +183,12 @@ def custom_3dclustering_histoThreshold(process,
                                        nBins_R=histoThreshold_C3d_params.nBins_R_histo_multicluster,
                                        nBins_Phi=histoThreshold_C3d_params.nBins_Phi_histo_multicluster,
                                        binSumsHisto=histoThreshold_C3d_params.binSumsHisto,
-                                       seed_threshold=histoThreshold_C3d_params.threshold_histo_multicluster
+                                       seed_threshold=histoThreshold_C3d_params.threshold_histo_multicluster,
+                                       shape_threshold=histoThreshold_C3d_params.shape_threshold,
                                        ):
     parameters_c3d = histoThreshold_C3d_params.clone()
-    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(parameters_c3d, distance, nBins_R, nBins_Phi, binSumsHisto,
+                        seed_threshold, shape_threshold)
     process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters = parameters_c3d
     return process
 

--- a/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
+++ b/L1Trigger/L1THGCal/python/customTriggerCellSelect.py
@@ -1,23 +1,29 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
-from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc
-
+from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, coarsetc_equalshare_proc
 
 def custom_triggercellselect_supertriggercell(process,
-                                              stcSize=supertc_conc_proc.stcSize
+                                              stcSize=supertc_conc_proc.stcSize,
+                                              type_energy_division=supertc_conc_proc.type_energy_division,
+                                              fixedDataSizePerHGCROC=supertc_conc_proc.fixedDataSizePerHGCROC
                                               ):
-    parameters = supertc_conc_proc.clone(stcSize = stcSize)
+    parameters = supertc_conc_proc.clone(stcSize = stcSize,
+                                         type_energy_division = type_energy_division,
+                                         fixedDataSizePerHGCROC = fixedDataSizePerHGCROC  
+                                         )
     process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process
 
 
 def custom_triggercellselect_threshold(process,
                                        threshold_silicon=threshold_conc_proc.threshold_silicon,  # in mipT
-                                       threshold_scintillator=threshold_conc_proc.threshold_scintillator  # in mipT
+                                       threshold_scintillator=threshold_conc_proc.threshold_scintillator,  # in mipT
+                                       coarsenTriggerCells=threshold_conc_proc.coarsenTriggerCells  
                                        ):
     parameters = threshold_conc_proc.clone(
             threshold_silicon = threshold_silicon,
-            threshold_scintillator = threshold_scintillator
+            threshold_scintillator = threshold_scintillator,
+            coarsenTriggerCells = coarsenTriggerCells  
             )
     process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process
@@ -29,3 +35,36 @@ def custom_triggercellselect_bestchoice(process,
     parameters = best_conc_proc.clone(NData = triggercells)
     process.hgcalConcentratorProducer.ProcessorParameters = parameters
     return process
+
+
+def custom_coarsetc_onebitfraction(process,
+                                   stcSize=coarsetc_onebitfraction_proc.stcSize,
+                                   fixedDataSizePerHGCROC=coarsetc_onebitfraction_proc.fixedDataSizePerHGCROC,
+                                   oneBitFractionThreshold = coarsetc_onebitfraction_proc.oneBitFractionThreshold,
+                                   oneBitFractionLowValue = coarsetc_onebitfraction_proc.oneBitFractionLowValue,
+                                   oneBitFractionHighValue = coarsetc_onebitfraction_proc.oneBitFractionHighValue,
+                                   ):
+    parameters = coarsetc_onebitfraction_proc.clone(
+        stcSize = stcSize,    
+        fixedDataSizePerHGCROC = fixedDataSizePerHGCROC, 
+        oneBitFractionThreshold = oneBitFractionThreshold,
+        oneBitFractionLowValue = oneBitFractionLowValue,
+        oneBitFractionHighValue = oneBitFractionHighValue,
+    )
+    process.hgcalConcentratorProducer.ProcessorParameters = parameters
+    return process
+
+
+
+
+def custom_coarsetc_equalshare(process,
+                               stcSize=coarsetc_equalshare_proc.stcSize,
+                               fixedDataSizePerHGCROC=coarsetc_equalshare_proc.fixedDataSizePerHGCROC,
+                               ):
+    parameters = coarsetc_equalshare_proc.clone(
+        stcSize = stcSize,    
+        fixedDataSizePerHGCROC = fixedDataSizePerHGCROC, 
+    )
+    process.hgcalConcentratorProducer.ProcessorParameters = parameters
+    return process
+    

--- a/L1Trigger/L1THGCal/python/customTriggerGeometry.py
+++ b/L1Trigger/L1THGCal/python/customTriggerGeometry.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 
 
 
-def custom_geometry_V9(process, implementation=1):
+def custom_geometry_V9(process, implementation=2):
     if implementation==1:
         process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp1')
         process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping_8inch_aligned_192_432_V9_1.txt")

--- a/L1Trigger/L1THGCal/python/egammaIdentification.py
+++ b/L1Trigger/L1THGCal/python/egammaIdentification.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+
 
 class Category:
     def __init__(self, eta_min, eta_max, pt_min, pt_max):
@@ -67,30 +69,84 @@ working_points_drnn_dbscan = [
         },
         ]
 
-# Identification for 3D HistoMax clustering (as in 3.5.2)
-bdt_weights_histomax = [
-        # Low eta
-        'L1Trigger/L1THGCal/data/egamma_id_histomax_352_loweta_v0.xml',
-        # High eta
-        'L1Trigger/L1THGCal/data/egamma_id_histomax_352_higheta_v0.xml',
-        ]
+# Identification for 3D HistoMax clustering: switch between configurations for v8 and v9 geometry
+input_features_histomax = {
+        "v8_352":['cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean'],
+        "v9_370":['cl3d_coreshowerlength', 'cl3d_showerlength', 'cl3d_firstlayer', 'cl3d_maxlayer', 'cl3d_szz', 'cl3d_srrmean', 'cl3d_srrtot', 'cl3d_seetot', 'cl3d_spptot'],
+        "v9_394":['cl3d_coreshowerlength', 'cl3d_showerlength', 'cl3d_firstlayer', 'cl3d_maxlayer', 'cl3d_szz', 'cl3d_srrmean', 'cl3d_srrtot', 'cl3d_seetot', 'cl3d_spptot']
+        }
 
-working_points_histomax = [
-        # Low eta
-        {
-        '900':0.19146989,
-        '950':0.1379665 ,
-        '975':0.03496629,
-        '995':-0.24383164,
-        },
-        # High eta
-        {
-        '900':0.13347613,
-        '950':0.04267797,
-        '975':-0.03698097,
-        '995':-0.23077505,
-        },
-        ]
+bdt_weights_histomax = {
+        "v8_352":[ #trained using TPG software version 3.5.2
+                # Low eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_352_loweta_v0.xml',
+                # High eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_352_higheta_v0.xml'
+                ],
+        "v9_370":[ #trained using TPG software version 3.7.0
+                # Low eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_370_loweta_v0.xml',
+                # High eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_370_higheta_v0.xml'
+                ],
+        "v9_394":[ #trained using TPG software version 3.9.4
+                # Low eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_394_loweta_v0.xml',
+                # High eta
+                'L1Trigger/L1THGCal/data/egamma_id_histomax_394_higheta_v0.xml'
+                ]
+        }
+
+working_points_histomax = {
+        "v8_352":[
+                # Low eta
+                {
+                '900':0.19146989,
+                '950':0.1379665,
+                '975':0.03496629,
+                '995':-0.24383164,
+                },
+                # High eta
+                {
+                '900':0.13347613,
+                '950':0.04267797,
+                '975':-0.03698097,
+                '995':-0.23077505,
+                }
+             ],
+        "v9_370":[
+                # Low eta
+                {
+                '900':0.8815851, # epsilon_b = 2.5%
+                '950':0.5587649, # epsilon_b = 4.0%
+                '975':-0.1937952, # epsilon_b = 5.5%
+                '995':-0.9394884, # epsilon_b = 10.1%
+                },
+                # High eta
+                {
+                '900':0.7078400, #epsilon_b = 3.5%
+                '950':-0.0239623, #epsilon_b = 6.9%
+                '975':-0.7045071, #epsilon_b = 11.6% 
+                '995':-0.9811426, #epsilon_b = 26.1%
+                }
+             ],
+        "v9_394":[
+                # Low eta
+                {
+                '900':0.9794103, # epsilon_b = 1.9%
+                '950':0.9052764, # epsilon_b = 3.9%
+                '975':0.5276631, # epsilon_b = 6.6%
+                '995':-0.9153535, # epsilon_b = 20.4%
+                },
+                # High eta
+                {
+                '900':0.8825340, #epsilon_b = 1.0%
+                '950':0.2856039, #epsilon_b = 1.7%
+                '975':-0.5274948, #epsilon_b = 2.8% 
+                '995':-0.9864445, #epsilon_b = 7.6%
+                }
+             ]
+        }
 
 tight_wp = ['975', '900']
 loose_wp = ['995', '950']
@@ -117,11 +173,20 @@ egamma_identification_drnn_dbscan = cms.PSet(
         )
 
 egamma_identification_histomax = cms.PSet(
-        Inputs=cms.vstring('cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean'),
+        Inputs=cms.vstring(input_features_histomax['v8_352']),
         CategoriesEtaMin=cms.vdouble([cat.eta_min for cat in categories]),
         CategoriesEtaMax=cms.vdouble([cat.eta_max for cat in categories]),
         CategoriesPtMin=cms.vdouble([cat.pt_min for cat in categories]),
         CategoriesPtMax=cms.vdouble([cat.pt_max for cat in categories]),
-        Weights=cms.vstring(bdt_weights_histomax),
-        WorkingPoints=cms.vdouble([wps[eff] for wps,eff in zip(working_points_histomax,tight_wp)]),
+        Weights=cms.vstring(bdt_weights_histomax['v8_352']),
+        WorkingPoints=cms.vdouble([wps[eff] for wps,eff in zip(working_points_histomax['v8_352'],tight_wp)]),
+        )
+
+# Era Modification for HGCal v9: use correct training and WPs
+phase2_hgcalV9.toModify(egamma_identification_histomax,
+        Inputs=cms.vstring(input_features_histomax['v9_394']),
+        Weights=cms.vstring(bdt_weights_histomax['v9_394']),
+        WorkingPoints=cms.vdouble(
+                [wps[eff] for wps,eff in zip(working_points_histomax['v9_394'],tight_wp)]
+                )
         )

--- a/L1Trigger/L1THGCal/python/egammaIdentification.py
+++ b/L1Trigger/L1THGCal/python/egammaIdentification.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 
+inputs_small = ['cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean']
+inputs_large = ['cl3d_coreshowerlength', 'cl3d_showerlength', 'cl3d_firstlayer', 'cl3d_maxlayer', 'cl3d_szz', 'cl3d_srrmean', 'cl3d_srrtot', 'cl3d_seetot', 'cl3d_spptot']
 
 class Category:
     def __init__(self, eta_min, eta_max, pt_min, pt_max):
@@ -71,9 +73,9 @@ working_points_drnn_dbscan = [
 
 # Identification for 3D HistoMax clustering: switch between configurations for v8 and v9 geometry
 input_features_histomax = {
-        "v8_352":['cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean'],
-        "v9_370":['cl3d_coreshowerlength', 'cl3d_showerlength', 'cl3d_firstlayer', 'cl3d_maxlayer', 'cl3d_szz', 'cl3d_srrmean', 'cl3d_srrtot', 'cl3d_seetot', 'cl3d_spptot'],
-        "v9_394":['cl3d_coreshowerlength', 'cl3d_showerlength', 'cl3d_firstlayer', 'cl3d_maxlayer', 'cl3d_szz', 'cl3d_srrmean', 'cl3d_srrtot', 'cl3d_seetot', 'cl3d_spptot']
+        "v8_352":inputs_small,
+        "v9_370":inputs_large,
+        "v9_394":inputs_large
         }
 
 bdt_weights_histomax = {
@@ -153,7 +155,7 @@ loose_wp = ['995', '950']
 
 
 egamma_identification_drnn_cone = cms.PSet(
-        Inputs=cms.vstring('cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean'),
+        Inputs=cms.vstring(inputs_small),
         CategoriesEtaMin=cms.vdouble([cat.eta_min for cat in categories]),
         CategoriesEtaMax=cms.vdouble([cat.eta_max for cat in categories]),
         CategoriesPtMin=cms.vdouble([cat.pt_min for cat in categories]),
@@ -163,7 +165,7 @@ egamma_identification_drnn_cone = cms.PSet(
         )
 
 egamma_identification_drnn_dbscan = cms.PSet(
-        Inputs=cms.vstring('cl3d_firstlayer', 'cl3d_coreshowerlength', 'cl3d_maxlayer', 'cl3d_srrmean'),
+        Inputs=cms.vstring(inputs_small),
         CategoriesEtaMin=cms.vdouble([cat.eta_min for cat in categories]),
         CategoriesEtaMax=cms.vdouble([cat.eta_max for cat in categories]),
         CategoriesPtMin=cms.vdouble([cat.pt_min for cat in categories]),

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -16,7 +16,7 @@ binSums = cms.vuint32(13,               # 0
                       9, 9, 9,          # 4 - 6
                       7, 7, 7, 7, 7, 7,  # 7 - 12
                       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,  # 13 - 27
-                      3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3  # 28 - 40
+                      3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3  # 28 - 41
                       )
 
 EE_DR_GROUP = 7
@@ -69,7 +69,7 @@ histoMax_C3d_params = cms.PSet(type_multicluster=cms.string('HistoMaxC3d'),
                                dR_multicluster_byLayer_coefficientB=cms.vdouble(),
                                shape_threshold=cms.double(1.),
                                minPt_multicluster=cms.double(0.5),  # minimum pt of the multicluster (GeV)
-                               nBins_R_histo_multicluster=cms.uint32(41), # bin size of about 0.012
+                               nBins_R_histo_multicluster=cms.uint32(42), # bin size of about 0.012
                                nBins_Phi_histo_multicluster=cms.uint32(216), # bin size of about 0.029
                                binSumsHisto=binSums,
                                threshold_histo_multicluster=cms.double(10.),

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -74,7 +74,8 @@ histoMax_C3d_params = cms.PSet(type_multicluster=cms.string('HistoMaxC3d'),
                                threshold_histo_multicluster=cms.double(10.),
                                cluster_association=cms.string("NearestNeighbour"),
                                EGIdentification=egamma_identification_histomax.clone(),
-                               neighbour_weights=neighbour_weights_1stOrder
+                               neighbour_weights=neighbour_weights_1stOrder,
+                               seed_position=cms.string("BinCentre"),#BinCentre, TCWeighted
                                )
 # V9 samples have a different defintiion of the dEdx calibrations. To account for it
 # we reascale the thresholds of the clustering seeds

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -16,7 +16,7 @@ binSums = cms.vuint32(13,               # 0
                       9, 9, 9,          # 4 - 6
                       7, 7, 7, 7, 7, 7,  # 7 - 12
                       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,  # 13 - 27
-                      3, 3, 3, 3, 3, 3, 3, 3  # 28 - 35
+                      3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3  # 28 - 40
                       )
 
 EE_DR_GROUP = 7
@@ -69,8 +69,8 @@ histoMax_C3d_params = cms.PSet(type_multicluster=cms.string('HistoMaxC3d'),
                                dR_multicluster_byLayer_coefficientB=cms.vdouble(),
                                shape_threshold=cms.double(1.),
                                minPt_multicluster=cms.double(0.5),  # minimum pt of the multicluster (GeV)
-                               nBins_R_histo_multicluster=cms.uint32(36),
-                               nBins_Phi_histo_multicluster=cms.uint32(216),
+                               nBins_R_histo_multicluster=cms.uint32(41), # bin size of about 0.012
+                               nBins_Phi_histo_multicluster=cms.uint32(216), # bin size of about 0.029
                                binSumsHisto=binSums,
                                threshold_histo_multicluster=cms.double(10.),
                                cluster_association=cms.string("NearestNeighbour"),

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -67,6 +67,7 @@ histoMax_C3d_params = cms.PSet(type_multicluster=cms.string('HistoMaxC3d'),
                                dR_multicluster=cms.double(0.03),
                                dR_multicluster_byLayer_coefficientA=cms.vdouble(),
                                dR_multicluster_byLayer_coefficientB=cms.vdouble(),
+                               shape_threshold=cms.double(1.),
                                minPt_multicluster=cms.double(0.5),  # minimum pt of the multicluster (GeV)
                                nBins_R_histo_multicluster=cms.uint32(36),
                                nBins_Phi_histo_multicluster=cms.uint32(216),

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -44,8 +44,8 @@ from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 # (see https://indico.cern.ch/event/806845/contributions/3359859/attachments/1815187/2966402/19-03-20_EGPerf_HGCBE.pdf
 # for more details)
 phase2_hgcalV9.toModify(threshold_conc_proc,
-                        threshold_silicon=1.5,  # MipT
-                        threshold_scintillator=1.5,  # MipT
+                        threshold_silicon=1.35,  # MipT
+                        threshold_scintillator=1.35,  # MipT
                         )
 
 

--- a/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalConcentratorProducer_cfi.py
@@ -10,6 +10,8 @@ threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorPro
                                Method = cms.string('thresholdSelect'),
                                threshold_silicon = cms.double(2.), # MipT
                                threshold_scintillator = cms.double(2.), # MipT
+                               coarsenTriggerCells = cms.bool(False),
+                               fixedDataSizePerHGCROC = cms.bool(False),
                                )
 
 
@@ -29,13 +31,41 @@ best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcesso
                                0,  0,  0,  0,   0,   0, 0, 0,
                                0,  0,  0,  0,   0,   0, 0, 0,
                               ),
+                          coarsenTriggerCells = cms.bool(False),
+                          fixedDataSizePerHGCROC = cms.bool(False),
                           )
 
 
 supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                              Method = cms.string('superTriggerCellSelect'),
-                             stcSize = cms.vuint32(4,4,4)
+                             type_energy_division = cms.string('superTriggerCell'),# superTriggerCell,oneBitFraction,equalShare
+                             stcSize = cms.vuint32(4,16,16,16),
+                             fixedDataSizePerHGCROC = cms.bool(False),
+                             coarsenTriggerCells = cms.bool(False),
                              )
+
+coarsetc_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
+                             Method = cms.string('superTriggerCellSelect'),
+                             type_energy_division = cms.string('oneBitFraction'),
+                             stcSize = cms.vuint32(4,8,8,8),
+                             fixedDataSizePerHGCROC = cms.bool(True),
+                             coarsenTriggerCells = cms.bool(False),
+                             oneBitFractionThreshold = cms.double(0.125),
+                             oneBitFractionLowValue = cms.double(0.0625),
+                             oneBitFractionHighValue = cms.double(0.25)
+                             )
+
+
+coarsetc_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
+                             Method = cms.string('superTriggerCellSelect'),
+                             type_energy_division = cms.string('equalShare'),
+                             stcSize = cms.vuint32(4,8,8,8),
+                             fixedDataSizePerHGCROC = cms.bool(True),
+                             coarsenTriggerCells = cms.bool(False),
+)
+
+
+
 
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -1,0 +1,243 @@
+#include "L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+
+HGCalCoarseTriggerCellMapping::HGCalCoarseTriggerCellMapping(const std::vector<unsigned>& ctcSize)
+    : ctcSize_(!ctcSize.empty() ? ctcSize : std::vector<unsigned>{2, 2, 2, 2}) {
+  if (ctcSize_.size() != kNLayers_) {
+    throw cms::Exception("HGCTriggerParameterError")
+        << "Inconsistent size of coarse trigger cell size vector" << ctcSize_.size();
+  }
+
+  for (auto ctc : ctcSize_)
+    checkSizeValidity(ctc);
+}
+
+const std::map<int, int> HGCalCoarseTriggerCellMapping::kSplit_ = {{kCTCsizeIndividual_, kSplit_v8_Individual_},
+                                                                   {kCTCsizeVeryFine_, kSplit_v8_VeryFine_},
+                                                                   {kCTCsizeFine_, kSplit_v8_Fine_},
+                                                                   {kCTCsizeMid_, kSplit_v8_Mid_},
+                                                                   {kCTCsizeCoarse_, kSplit_v8_Coarse_}};
+
+const std::map<int, int> HGCalCoarseTriggerCellMapping::kSplit_v9_ = {
+    {kCTCsizeIndividual_, kSplit_v9_Individual_},
+    {kCTCsizeVeryFine_, kSplit_v9_VeryFine_},
+    {kCTCsizeFine_, kSplit_v9_Fine_},
+    {kCTCsizeMid_, kSplit_v9_Mid_},
+    {kCTCsizeCoarse_, kSplit_v9_Coarse_},
+};
+
+const std::map<int, int> HGCalCoarseTriggerCellMapping::kSplit_v9_Scin_ = {
+    {kCTCsizeIndividual_, kSplit_v9_Scin_Individual_},
+    {kCTCsizeVeryFine_, kSplit_v9_Scin_VeryFine_},
+    {kCTCsizeFine_, kSplit_v9_Scin_Fine_},
+    {kCTCsizeMid_, kSplit_v9_Scin_Mid_},
+    {kCTCsizeCoarse_, kSplit_v9_Scin_Coarse_},
+};
+
+void HGCalCoarseTriggerCellMapping::checkSizeValidity(int ctcSize) const {
+  if (ctcSize != kCTCsizeFine_ && ctcSize != kCTCsizeCoarse_ && ctcSize != kCTCsizeMid_ &&
+      ctcSize != kCTCsizeVeryFine_ && ctcSize != kCTCsizeIndividual_) {
+    throw cms::Exception("HGCTriggerParameterError")
+        << "Coarse Trigger Cell should be of size " << kCTCsizeIndividual_ << " or " << kCTCsizeVeryFine_ << " or "
+        << kCTCsizeFine_ << " or " << kCTCsizeMid_ << " or " << kCTCsizeCoarse_;
+  }
+}
+
+uint32_t HGCalCoarseTriggerCellMapping::getRepresentativeDetId(uint32_t tcid) const {
+  uint32_t representativeid = 0;
+  DetId tc_Id(tcid);
+  if (tc_Id.det() == DetId::Forward) {  //V8
+    if (triggerTools_.isScintillator(tcid)) {
+      representativeid = tcid;  //stc not available in scintillator for v8
+    } else {
+      representativeid = tcid & ~1;
+    }
+  } else if (tc_Id.det() == DetId::HGCalTrigger || tc_Id.det() == DetId::HGCalHSc) {  //V9
+
+    if (triggerTools_.isScintillator(tcid)) {
+      HGCScintillatorDetId tc_IdV9(tcid);
+      uint32_t newPhi = tc_IdV9.iphi() & ~1;
+      representativeid = tcid & kHGCalScinCellMaskInv_;
+      representativeid |=
+          (((tc_IdV9.ietaAbs() & HGCScintillatorDetId::kHGCalRadiusMask) << HGCScintillatorDetId::kHGCalRadiusOffset) |
+           ((newPhi & HGCScintillatorDetId::kHGCalPhiMask) << HGCScintillatorDetId::kHGCalPhiOffset));
+
+    } else {
+      int uPrime = 0;
+      int newU = 0;
+      int newV = 0;
+      HGCalTriggerDetId tc_IdV9(tcid);
+      int rocnum = detIdToROC_.getROCNumber(tc_IdV9.triggerCellU(), tc_IdV9.triggerCellV(), 1);
+      if (rocnum == 1) {
+        uPrime = tc_IdV9.triggerCellU();
+        newU = (uPrime & ~1);
+        newV = tc_IdV9.triggerCellV() - tc_IdV9.triggerCellU() + newU;
+      } else if (rocnum == 2) {
+        uPrime = tc_IdV9.triggerCellU() - tc_IdV9.triggerCellV() - 1;
+        newU = (uPrime & ~1) + tc_IdV9.triggerCellV() + 1;
+        newV = tc_IdV9.triggerCellV();
+      } else if (rocnum == 3) {
+        uPrime = tc_IdV9.triggerCellV() - kRotate4_;
+        newU = tc_IdV9.triggerCellU();
+        newV = (uPrime & ~1) + kRotate4_;
+      }
+
+      representativeid = tcid & kHGCalCellMaskV9Inv_;
+      representativeid |= (((newU & HGCalTriggerDetId::kHGCalCellUMask) << HGCalTriggerDetId::kHGCalCellUOffset) |
+                           ((newV & HGCalTriggerDetId::kHGCalCellVMask) << HGCalTriggerDetId::kHGCalCellVOffset));
+    }
+  }
+
+  if (triggerTools_.getTriggerGeometry()->validTriggerCell(representativeid)) {
+    return representativeid;
+  } else {
+    return tcid;
+  }
+}
+
+uint32_t HGCalCoarseTriggerCellMapping::getCoarseTriggerCellId(uint32_t detid) const {
+  int thickness = 0;
+  if (triggerTools_.isSilicon(detid)) {
+    thickness = triggerTools_.thicknessIndex(detid, true);
+  } else if (triggerTools_.isScintillator(detid)) {
+    thickness = 3;
+  }
+  int ctcSize = ctcSize_.at(thickness);
+
+  DetId tc_Id(detid);
+  if (tc_Id.det() == DetId::Forward) {  //V8
+
+    HGCalDetId tc_IdV8(detid);
+
+    if (triggerTools_.isScintillator(detid)) {
+      return detid;  //stc not available in scintillator for v8
+    } else {
+      int tcSplit = (tc_IdV8.cell() & kSplit_.at(ctcSize));
+      detid = (detid & ~(HGCalDetId::kHGCalCellMask)) | tcSplit;
+      return detid;
+    }
+
+  }
+
+  else if (tc_Id.det() == DetId::HGCalTrigger || tc_Id.det() == DetId::HGCalHSc) {  //V9
+    if (triggerTools_.isScintillator(detid)) {
+      HGCScintillatorDetId tc_IdV9(detid);
+
+      int tcSplit = ((tc_IdV9.ietaAbs() << HGCScintillatorDetId::kHGCalRadiusOffset) | tc_IdV9.iphi()) &
+                    kSplit_v9_Scin_.at(ctcSize);
+      detid = (detid & kHGCalScinCellMaskInv_) | tcSplit;
+
+      return detid;
+
+    } else {
+      HGCalTriggerDetId tc_IdV9(detid);
+
+      int uPrime = 0;
+      int vPrime = 0;
+      int rocnum = detIdToROC_.getROCNumber(tc_IdV9.triggerCellU(), tc_IdV9.triggerCellV(), 1);
+
+      if (rocnum == 1) {
+        uPrime = tc_IdV9.triggerCellU();
+        vPrime = tc_IdV9.triggerCellV() - tc_IdV9.triggerCellU();
+
+      } else if (rocnum == 2) {
+        uPrime = tc_IdV9.triggerCellU() - tc_IdV9.triggerCellV() - 1;
+        vPrime = tc_IdV9.triggerCellV();
+
+      } else if (rocnum == 3) {
+        uPrime = tc_IdV9.triggerCellV() - kRotate4_;
+        vPrime = kRotate7_ - tc_IdV9.triggerCellU();
+      }
+
+      int tcSplit = (rocnum << kRocShift_) | ((uPrime << kUShift_ | vPrime) & kSplit_v9_.at(ctcSize));
+      detid = (detid & kHGCalCellMaskV9Inv_) | tcSplit;
+      return detid;
+    }
+
+  } else {
+    return 0;
+  }
+}
+
+std::vector<uint32_t> HGCalCoarseTriggerCellMapping::getConstituentTriggerCells(uint32_t ctcId) const {
+  int thickness = 0;
+  if (triggerTools_.isSilicon(ctcId)) {
+    thickness = triggerTools_.thicknessIndex(ctcId, true);
+  } else if (triggerTools_.isScintillator(ctcId)) {
+    thickness = 3;
+  }
+  int ctcSize = ctcSize_.at(thickness);
+
+  std::vector<uint32_t> output_ids;
+  DetId tc_Id(ctcId);
+
+  if (tc_Id.det() == DetId::Forward) {  //V8
+
+    if (triggerTools_.isScintillator(ctcId)) {
+      output_ids.emplace_back(ctcId);  //stc not available in scintillator for v8
+    } else {
+      int splitInv = ~(kSTCidMaskInv_ | kSplit_.at(ctcSize));
+      for (int i = 0; i < splitInv + 1; i++) {
+        if ((i & splitInv) != i)
+          continue;
+
+        output_ids.emplace_back(ctcId | i);
+      }
+    }
+  } else if (tc_Id.det() == DetId::HGCalTrigger || tc_Id.det() == DetId::HGCalHSc) {  //V9
+
+    if (triggerTools_.isScintillator(ctcId)) {
+      int splitInv = ~(kHGCalScinCellMaskInv_ | kSplit_v9_Scin_.at(ctcSize));
+      for (int i = 0; i < splitInv + 1; i++) {
+        if ((i & splitInv) != i)
+          continue;
+
+        output_ids.emplace_back(ctcId | i);
+      }
+
+    } else {
+      int splitInv = ~(kSTCidMaskInv_v9_ | kSplit_v9_.at(ctcSize));
+      for (int i = 0; i < splitInv + 1; i++) {
+        if ((i & splitInv) != i)
+          continue;
+        int uPrime = ((ctcId | i) >> kUShift_) & kUMask_;
+        int vPrime = ((ctcId | i) >> kVShift_) & kVMask_;
+        int rocnum = (ctcId >> kRocShift_) & kRocMask_;
+
+        int u = 0;
+        int v = 0;
+
+        if (rocnum == 1) {
+          u = uPrime;
+          v = vPrime + u;
+        } else if (rocnum == 2) {
+          u = uPrime + vPrime + 1;
+          v = vPrime;
+        } else if (rocnum == 3) {
+          u = kRotate7_ - vPrime;
+          v = uPrime + kRotate4_;
+        }
+
+        uint32_t outid = ctcId & kHGCalCellMaskV9Inv_;
+        outid |= (((u & HGCalTriggerDetId::kHGCalCellUMask) << HGCalTriggerDetId::kHGCalCellUOffset) |
+                  ((v & HGCalTriggerDetId::kHGCalCellVMask) << HGCalTriggerDetId::kHGCalCellVOffset));
+
+        output_ids.emplace_back(outid);
+      }
+    }
+  }
+  return output_ids;
+}
+
+GlobalPoint HGCalCoarseTriggerCellMapping::getCoarseTriggerCellPosition(uint32_t ctcId) const {
+  std::vector<uint32_t> constituentTCs = getConstituentTriggerCells(ctcId);
+  Basic3DVector<float> average_vector(0., 0., 0.);
+
+  for (const auto constituent : constituentTCs) {
+    average_vector += triggerTools_.getTCPosition(constituent).basicVector();
+  }
+
+  GlobalPoint average_point(average_vector / constituentTCs.size());
+
+  return average_point;
+}

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -100,7 +100,7 @@ uint32_t HGCalCoarseTriggerCellMapping::getCoarseTriggerCellId(uint32_t detid) c
   if (triggerTools_.isSilicon(detid)) {
     thickness = triggerTools_.thicknessIndex(detid, true);
   } else if (triggerTools_.isScintillator(detid)) {
-    thickness = 3;
+    thickness = HGCalTriggerTools::kScintillatorPseudoThicknessIndex_;
   }
   int ctcSize = ctcSize_.at(thickness);
 
@@ -164,7 +164,7 @@ std::vector<uint32_t> HGCalCoarseTriggerCellMapping::getConstituentTriggerCells(
   if (triggerTools_.isSilicon(ctcId)) {
     thickness = triggerTools_.thicknessIndex(ctcId, true);
   } else if (triggerTools_.isScintillator(ctcId)) {
-    thickness = 3;
+    thickness = HGCalTriggerTools::kScintillatorPseudoThicknessIndex_;
   }
   int ctcSize = ctcSize_.at(thickness);
 

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -68,15 +68,15 @@ uint32_t HGCalCoarseTriggerCellMapping::getRepresentativeDetId(uint32_t tcid) co
       int newV = 0;
       HGCalTriggerDetId tc_IdV9(tcid);
       int rocnum = detIdToROC_.getROCNumber(tc_IdV9.triggerCellU(), tc_IdV9.triggerCellV(), 1);
-      if (rocnum == 1) {
+      if (rocnum == kRoc0deg_) {
         uPrime = tc_IdV9.triggerCellU();
         newU = (uPrime & ~1);
         newV = tc_IdV9.triggerCellV() - tc_IdV9.triggerCellU() + newU;
-      } else if (rocnum == 2) {
+      } else if (rocnum == kRoc120deg_) {
         uPrime = tc_IdV9.triggerCellU() - tc_IdV9.triggerCellV() - 1;
         newU = (uPrime & ~1) + tc_IdV9.triggerCellV() + 1;
         newV = tc_IdV9.triggerCellV();
-      } else if (rocnum == 3) {
+      } else if (rocnum == kRoc240deg_) {
         uPrime = tc_IdV9.triggerCellV() - kRotate4_;
         newU = tc_IdV9.triggerCellU();
         newV = (uPrime & ~1) + kRotate4_;
@@ -136,15 +136,15 @@ uint32_t HGCalCoarseTriggerCellMapping::getCoarseTriggerCellId(uint32_t detid) c
       int vPrime = 0;
       int rocnum = detIdToROC_.getROCNumber(tc_IdV9.triggerCellU(), tc_IdV9.triggerCellV(), 1);
 
-      if (rocnum == 1) {
+      if (rocnum == kRoc0deg_) {
         uPrime = tc_IdV9.triggerCellU();
         vPrime = tc_IdV9.triggerCellV() - tc_IdV9.triggerCellU();
 
-      } else if (rocnum == 2) {
+      } else if (rocnum == kRoc120deg_) {
         uPrime = tc_IdV9.triggerCellU() - tc_IdV9.triggerCellV() - 1;
         vPrime = tc_IdV9.triggerCellV();
 
-      } else if (rocnum == 3) {
+      } else if (rocnum == kRoc240deg_) {
         uPrime = tc_IdV9.triggerCellV() - kRotate4_;
         vPrime = kRotate7_ - tc_IdV9.triggerCellU();
       }
@@ -207,13 +207,13 @@ std::vector<uint32_t> HGCalCoarseTriggerCellMapping::getConstituentTriggerCells(
         int u = 0;
         int v = 0;
 
-        if (rocnum == 1) {
+        if (rocnum == kRoc0deg_) {
           u = uPrime;
           v = vPrime + u;
-        } else if (rocnum == 2) {
+        } else if (rocnum == kRoc120deg_) {
           u = uPrime + vPrime + 1;
           v = vPrime;
-        } else if (rocnum == 3) {
+        } else if (rocnum == kRoc240deg_) {
           u = kRotate7_ - vPrime;
           v = uPrime + kRotate4_;
         }

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
@@ -12,7 +12,8 @@ HGCalHistoClusteringImpl::HGCalHistoClusteringImpl(const edm::ParameterSet& conf
                                    ? conf.getParameter<std::vector<double>>("dR_multicluster_byLayer_coefficientB")
                                    : std::vector<double>()),
       ptC3dThreshold_(conf.getParameter<double>("minPt_multicluster")),
-      cluster_association_input_(conf.getParameter<string>("cluster_association")) {
+      cluster_association_input_(conf.getParameter<string>("cluster_association")),
+      shape_(conf) {
   if (cluster_association_input_ == "NearestNeighbour") {
     cluster_association_strategy_ = NearestNeighbour;
   } else if (cluster_association_input_ == "EnergySplit") {

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
@@ -32,9 +32,7 @@ HGCalHistoClusteringImpl::HGCalHistoClusteringImpl(const edm::ParameterSet& conf
 }
 
 float HGCalHistoClusteringImpl::dR(const l1t::HGCalCluster& clu, const GlobalPoint& seed) const {
-  Basic3DVector<float> seed_3dv(seed);
-  GlobalPoint seed_proj(seed_3dv / seed.z());
-  return (seed_proj - clu.centreProj()).mag();
+  return (seed - clu.centreProj()).mag();
 }
 
 std::vector<l1t::HGCalMulticluster> HGCalHistoClusteringImpl::clusterSeedMulticluster(

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -56,6 +56,10 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillHistoClusters(
 
   for (auto& clu : clustersPtrs) {
     float ROverZ = sqrt(pow(clu->centreProj().x(), 2) + pow(clu->centreProj().y(), 2));
+    if (ROverZ < kROverZMin_ || ROverZ >= kROverZMax_) {
+      throw cms::Exception("OutOfBound") << "TC R/Z = " << ROverZ << " out of the seeding histogram bounds "
+                                         << kROverZMin_ << " - " << kROverZMax_;
+    }
     unsigned bin_R = unsigned((ROverZ - kROverZMin_) * nBinsRHisto_ / (kROverZMax_ - kROverZMin_));
     unsigned bin_phi = unsigned((reco::reduceRange(clu->phi()) + M_PI) * nBinsPhiHisto_ / (2 * M_PI));
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -52,33 +52,22 @@ HGCalHistoSeedingImpl::HGCalHistoSeedingImpl(const edm::ParameterSet& conf)
 
 HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillHistoClusters(
     const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs) {
-  Histogram histoClusters;  //key[0] = z.side(), key[1] = bin_R, key[2] = bin_phi
-
-  for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        auto& bin = histoClusters[{{z_side, bin_R, bin_phi}}];
-        bin.sumMipPt = 0;
-        bin.weighted_x = 0;
-        bin.weighted_y = 0;
-      }
-    }
-  }
+  Histogram histoClusters(nBinsRHisto_, nBinsPhiHisto_);
 
   for (auto& clu : clustersPtrs) {
     float ROverZ = sqrt(pow(clu->centreProj().x(), 2) + pow(clu->centreProj().y(), 2));
-    int bin_R = int((ROverZ - kROverZMin_) * nBinsRHisto_ / (kROverZMax_ - kROverZMin_));
-    int bin_phi = int((reco::reduceRange(clu->phi()) + M_PI) * nBinsPhiHisto_ / (2 * M_PI));
+    unsigned bin_R = unsigned((ROverZ - kROverZMin_) * nBinsRHisto_ / (kROverZMax_ - kROverZMin_));
+    unsigned bin_phi = unsigned((reco::reduceRange(clu->phi()) + M_PI) * nBinsPhiHisto_ / (2 * M_PI));
 
-    auto& bin = histoClusters[{{triggerTools_.zside(clu->detId()), bin_R, bin_phi}}];
+    auto& bin = histoClusters.at(triggerTools_.zside(clu->detId()), bin_R, bin_phi);
     bin.sumMipPt += clu->mipPt();
     bin.weighted_x += (clu->centreProj().x()) * clu->mipPt();
     bin.weighted_y += (clu->centreProj().y()) * clu->mipPt();
   }
 
   for (auto& bin : histoClusters) {
-    bin.second.weighted_x /= bin.second.sumMipPt;
-    bin.second.weighted_y /= bin.second.sumMipPt;
+    bin.weighted_x /= bin.sumMipPt;
+    bin.weighted_y /= bin.sumMipPt;
   }
 
   return histoClusters;
@@ -86,10 +75,10 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillHistoClusters(
 
 HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoClusters(const Histogram& histoClusters,
                                                                                    const vector<unsigned>& binSums) {
-  Histogram histoSumPhiClusters;  //key[0] = z.side(), key[1] = bin_R, key[2] = bin_phi
+  Histogram histoSumPhiClusters(nBinsRHisto_, nBinsPhiHisto_);
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
       int nBinsSide = (binSums[bin_R] - 1) / 2;
       float R1 = kROverZMin_ + bin_R * (kROverZMax_ - kROverZMin_);
       float R2 = R1 + (kROverZMax_ - kROverZMin_);
@@ -101,24 +90,24 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
                 pow(0.5,
                     nBinsSide)));  // Takes into account different area of bins in different R-rings + sum of quadratic weights used
 
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        auto& bin_orig = histoClusters.at({{z_side, bin_R, bin_phi}});
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        const auto& bin_orig = histoClusters.at(z_side, bin_R, bin_phi);
         float content = bin_orig.sumMipPt;
 
         for (int bin_phi2 = 1; bin_phi2 <= nBinsSide; bin_phi2++) {
           int binToSumLeft = bin_phi - bin_phi2;
           if (binToSumLeft < 0)
             binToSumLeft += nBinsPhiHisto_;
-          int binToSumRight = bin_phi + bin_phi2;
-          if (binToSumRight >= int(nBinsPhiHisto_))
+          unsigned binToSumRight = bin_phi + bin_phi2;
+          if (binToSumRight >= nBinsPhiHisto_)
             binToSumRight -= nBinsPhiHisto_;
 
-          content += histoClusters.at({{z_side, bin_R, binToSumLeft}}).sumMipPt / pow(2, bin_phi2);  // quadratic kernel
-          content +=
-              histoClusters.at({{z_side, bin_R, binToSumRight}}).sumMipPt / pow(2, bin_phi2);  // quadratic kernel
+          content += histoClusters.at(z_side, bin_R, binToSumLeft).sumMipPt / pow(2, bin_phi2);  // quadratic kernel
+
+          content += histoClusters.at(z_side, bin_R, binToSumRight).sumMipPt / pow(2, bin_phi2);  // quadratic kernel
         }
 
-        auto& bin = histoSumPhiClusters[{{z_side, bin_R, bin_phi}}];
+        auto& bin = histoSumPhiClusters.at(z_side, bin_R, bin_phi);
         bin.sumMipPt = content / area;
         bin.weighted_x = bin_orig.weighted_x;
         bin.weighted_y = bin_orig.weighted_y;
@@ -130,22 +119,20 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
 }
 
 HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothRPhiHistoClusters(const Histogram& histoClusters) {
-  Histogram histoSumRPhiClusters;  //key[0] = z.side(), key[1] = bin_R, key[2] = bin_phi
+  Histogram histoSumRPhiClusters(nBinsRHisto_, nBinsPhiHisto_);
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      float weight = (bin_R == 0 || bin_R == int(nBinsRHisto_) - 1)
-                         ? 1.5
-                         : 2.;  //Take into account edges with only one side up or down
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      float weight =
+          (bin_R == 0 || bin_R == nBinsRHisto_ - 1) ? 1.5 : 2.;  //Take into account edges with only one side up or down
 
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        auto& bin_orig = histoClusters.at({{z_side, bin_R, bin_phi}});
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        const auto& bin_orig = histoClusters.at(z_side, bin_R, bin_phi);
         float content = bin_orig.sumMipPt;
-        float contentDown = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, bin_phi}}).sumMipPt : 0;
-        float contentUp =
-            bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, bin_phi}}).sumMipPt : 0;
+        float contentDown = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
+        float contentUp = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
 
-        auto& bin = histoSumRPhiClusters[{{z_side, bin_R, bin_phi}}];
+        auto& bin = histoSumRPhiClusters.at(z_side, bin_R, bin_phi);
         bin.sumMipPt = (content + 0.5 * contentDown + 0.5 * contentUp) / weight;
         bin.weighted_x = bin_orig.weighted_x;
         bin.weighted_y = bin_orig.weighted_y;
@@ -158,8 +145,8 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothRPhiHistoClust
 
 void HGCalHistoSeedingImpl::setSeedEnergyAndPosition(std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy,
                                                      int z_side,
-                                                     int bin_R,
-                                                     int bin_phi,
+                                                     unsigned bin_R,
+                                                     unsigned bin_phi,
                                                      const Bin& histBin) {
   float x_seed = 0;
   float y_seed = 0;
@@ -181,37 +168,36 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeMaxSee
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        float MIPT_seed = histoClusters.at({{z_side, bin_R, bin_phi}}).sumMipPt;
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
         bool isMax = MIPT_seed > histoThreshold_;
         if (!isMax)
           continue;
 
-        float MIPT_S = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, bin_phi}}).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, bin_phi}}).sumMipPt : 0;
+        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
+        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
 
         int binLeft = bin_phi - 1;
         if (binLeft < 0)
           binLeft += nBinsPhiHisto_;
-        int binRight = bin_phi + 1;
-        if (binRight >= int(nBinsPhiHisto_))
+        unsigned binRight = bin_phi + 1;
+        if (binRight >= nBinsPhiHisto_)
           binRight -= nBinsPhiHisto_;
 
-        float MIPT_W = histoClusters.at({{z_side, bin_R, binLeft}}).sumMipPt;
-        float MIPT_E = histoClusters.at({{z_side, bin_R, binRight}}).sumMipPt;
-        float MIPT_NW = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binLeft}}).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binRight}}).sumMipPt : 0;
-        float MIPT_SW = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binLeft}}).sumMipPt : 0;
-        float MIPT_SE =
-            bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binRight}}).sumMipPt : 0;
+        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
+        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
+        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
+        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
+        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
+        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
 
         isMax &= MIPT_seed >= MIPT_S && MIPT_seed > MIPT_N && MIPT_seed >= MIPT_E && MIPT_seed >= MIPT_SE &&
                  MIPT_seed >= MIPT_NE && MIPT_seed > MIPT_W && MIPT_seed > MIPT_SW && MIPT_seed > MIPT_NW;
 
         if (isMax) {
           setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at({{z_side, bin_R, bin_phi}}));
+              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
         }
       }
     }
@@ -225,27 +211,26 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeInterp
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        float MIPT_seed = histoClusters.at({{z_side, bin_R, bin_phi}}).sumMipPt;
-        float MIPT_S = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, bin_phi}}).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, bin_phi}}).sumMipPt : 0;
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
+        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
+        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
 
         int binLeft = bin_phi - 1;
         if (binLeft < 0)
           binLeft += nBinsPhiHisto_;
-        int binRight = bin_phi + 1;
-        if (binRight >= int(nBinsPhiHisto_))
+        unsigned binRight = bin_phi + 1;
+        if (binRight >= nBinsPhiHisto_)
           binRight -= nBinsPhiHisto_;
 
-        float MIPT_W = histoClusters.at({{z_side, bin_R, binLeft}}).sumMipPt;
-        float MIPT_E = histoClusters.at({{z_side, bin_R, binRight}}).sumMipPt;
+        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
+        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
 
-        float MIPT_NW = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binLeft}}).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binRight}}).sumMipPt : 0;
-        float MIPT_SW = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binLeft}}).sumMipPt : 0;
-        float MIPT_SE =
-            bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binRight}}).sumMipPt : 0;
+        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
+        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
+        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
+        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
 
         float MIPT_pred = neighbour_weights_.at(0) * MIPT_NW + neighbour_weights_.at(1) * MIPT_N +
                           neighbour_weights_.at(2) * MIPT_NE + neighbour_weights_.at(3) * MIPT_W +
@@ -256,7 +241,7 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeInterp
 
         if (isMax) {
           setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at({{z_side, bin_R, bin_phi}}));
+              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
         }
       }
     }
@@ -270,14 +255,14 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeThresh
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        float MIPT_seed = histoClusters.at({{z_side, bin_R, bin_phi}}).sumMipPt;
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
         bool isSeed = MIPT_seed > histoThreshold_;
 
         if (isSeed) {
           setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at({{z_side, bin_R, bin_phi}}));
+              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
         }
       }
     }
@@ -290,57 +275,56 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeSecond
     const Histogram& histoClusters) {
   std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
 
-  std::map<std::tuple<int, int, int>, bool> primarySeedPositions;
-  std::map<std::tuple<int, int, int>, bool> vetoPositions;
+  HistogramT<uint8_t> primarySeedPositions(nBinsRHisto_, nBinsPhiHisto_);
+  HistogramT<uint8_t> vetoPositions(nBinsRHisto_, nBinsPhiHisto_);
 
   //Search for primary seeds
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
-        float MIPT_seed = histoClusters.at({{z_side, bin_R, bin_phi}}).sumMipPt;
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
+        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
         bool isMax = MIPT_seed > histoThreshold_;
 
         if (!isMax)
           continue;
 
-        float MIPT_S = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, bin_phi}}).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, bin_phi}}).sumMipPt : 0;
+        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
+        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
 
         int binLeft = bin_phi - 1;
         if (binLeft < 0)
           binLeft += nBinsPhiHisto_;
-        int binRight = bin_phi + 1;
-        if (binRight >= int(nBinsPhiHisto_))
+        unsigned binRight = bin_phi + 1;
+        if (binRight >= nBinsPhiHisto_)
           binRight -= nBinsPhiHisto_;
 
-        float MIPT_W = histoClusters.at({{z_side, bin_R, binLeft}}).sumMipPt;
-        float MIPT_E = histoClusters.at({{z_side, bin_R, binRight}}).sumMipPt;
-        float MIPT_NW = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binLeft}}).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binRight}}).sumMipPt : 0;
-        float MIPT_SW = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binLeft}}).sumMipPt : 0;
-        float MIPT_SE =
-            bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binRight}}).sumMipPt : 0;
+        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
+        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
+        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
+        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
+        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
+        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
 
         isMax &= MIPT_seed >= MIPT_S && MIPT_seed > MIPT_N && MIPT_seed >= MIPT_E && MIPT_seed >= MIPT_SE &&
                  MIPT_seed >= MIPT_NE && MIPT_seed > MIPT_W && MIPT_seed > MIPT_SW && MIPT_seed > MIPT_NW;
 
         if (isMax) {
           setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at({{z_side, bin_R, bin_phi}}));
+              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
 
-          primarySeedPositions[std::make_tuple(bin_R, bin_phi, z_side)] = true;
+          primarySeedPositions.at(z_side, bin_R, bin_phi) = true;
 
-          vetoPositions[std::make_tuple(bin_R, binLeft, z_side)] = true;
-          vetoPositions[std::make_tuple(bin_R, binRight, z_side)] = true;
+          vetoPositions.at(z_side, bin_R, binLeft) = true;
+          vetoPositions.at(z_side, bin_R, binRight) = true;
           if (bin_R > 0) {
-            vetoPositions[std::make_tuple(bin_R - 1, bin_phi, z_side)] = true;
-            vetoPositions[std::make_tuple(bin_R - 1, binRight, z_side)] = true;
-            vetoPositions[std::make_tuple(bin_R - 1, binLeft, z_side)] = true;
+            vetoPositions.at(z_side, bin_R - 1, bin_phi) = true;
+            vetoPositions.at(z_side, bin_R - 1, binRight) = true;
+            vetoPositions.at(z_side, bin_R - 1, binLeft) = true;
           }
-          if (bin_R < (int(nBinsRHisto_) - 1)) {
-            vetoPositions[std::make_tuple(bin_R + 1, bin_phi, z_side)] = true;
-            vetoPositions[std::make_tuple(bin_R + 1, binRight, z_side)] = true;
-            vetoPositions[std::make_tuple(bin_R + 1, binLeft, z_side)] = true;
+          if (bin_R < (nBinsRHisto_ - 1)) {
+            vetoPositions.at(z_side, bin_R + 1, bin_phi) = true;
+            vetoPositions.at(z_side, bin_R + 1, binRight) = true;
+            vetoPositions.at(z_side, bin_R + 1, binLeft) = true;
           }
         }
       }
@@ -350,46 +334,45 @@ std::vector<std::pair<GlobalPoint, double>> HGCalHistoSeedingImpl::computeSecond
   //Search for secondary seeds
 
   for (int z_side : {-1, 1}) {
-    for (int bin_R = 0; bin_R < int(nBinsRHisto_); bin_R++) {
-      for (int bin_phi = 0; bin_phi < int(nBinsPhiHisto_); bin_phi++) {
+    for (unsigned bin_R = 0; bin_R < nBinsRHisto_; bin_R++) {
+      for (unsigned bin_phi = 0; bin_phi < nBinsPhiHisto_; bin_phi++) {
         //Cannot be a secondary seed if already a primary seed, or adjacent to primary seed
-        if (primarySeedPositions[std::make_tuple(bin_R, bin_phi, z_side)] ||
-            vetoPositions[std::make_tuple(bin_R, bin_phi, z_side)])
+        if (primarySeedPositions.at(z_side, bin_R, bin_phi) || vetoPositions.at(z_side, bin_R, bin_phi))
           continue;
 
-        float MIPT_seed = histoClusters.at({{z_side, bin_R, bin_phi}}).sumMipPt;
+        float MIPT_seed = histoClusters.at(z_side, bin_R, bin_phi).sumMipPt;
         bool isMax = MIPT_seed > histoThreshold_;
 
-        float MIPT_S = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, bin_phi}}).sumMipPt : 0;
-        float MIPT_N = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, bin_phi}}).sumMipPt : 0;
+        float MIPT_S = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, bin_phi).sumMipPt : 0;
+        float MIPT_N = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, bin_phi).sumMipPt : 0;
 
         int binLeft = bin_phi - 1;
         if (binLeft < 0)
           binLeft += nBinsPhiHisto_;
-        int binRight = bin_phi + 1;
-        if (binRight >= int(nBinsPhiHisto_))
+        unsigned binRight = bin_phi + 1;
+        if (binRight >= nBinsPhiHisto_)
           binRight -= nBinsPhiHisto_;
 
-        float MIPT_W = histoClusters.at({{z_side, bin_R, binLeft}}).sumMipPt;
-        float MIPT_E = histoClusters.at({{z_side, bin_R, binRight}}).sumMipPt;
-        float MIPT_NW = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binLeft}}).sumMipPt : 0;
-        float MIPT_NE = bin_R > 0 ? histoClusters.at({{z_side, bin_R - 1, binRight}}).sumMipPt : 0;
-        float MIPT_SW = bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binLeft}}).sumMipPt : 0;
-        float MIPT_SE =
-            bin_R < (int(nBinsRHisto_) - 1) ? histoClusters.at({{z_side, bin_R + 1, binRight}}).sumMipPt : 0;
+        float MIPT_W = histoClusters.at(z_side, bin_R, binLeft).sumMipPt;
+        float MIPT_E = histoClusters.at(z_side, bin_R, binRight).sumMipPt;
+        float MIPT_NW = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binLeft).sumMipPt : 0;
+        float MIPT_NE = bin_R > 0 ? histoClusters.at(z_side, bin_R - 1, binRight).sumMipPt : 0;
+        float MIPT_SW = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binLeft).sumMipPt : 0;
+        float MIPT_SE = bin_R < (nBinsRHisto_ - 1) ? histoClusters.at(z_side, bin_R + 1, binRight).sumMipPt : 0;
 
-        isMax &= (vetoPositions[std::make_tuple(bin_R + 1, bin_phi, z_side)] or MIPT_seed >= MIPT_S) &&
-                 (vetoPositions[std::make_tuple(bin_R - 1, bin_phi, z_side)] or MIPT_seed > MIPT_N) &&
-                 (vetoPositions[std::make_tuple(bin_R, binRight, z_side)] or MIPT_seed >= MIPT_E) &&
-                 (vetoPositions[std::make_tuple(bin_R + 1, binRight, z_side)] or MIPT_seed >= MIPT_SE) &&
-                 (vetoPositions[std::make_tuple(bin_R - 1, binRight, z_side)] or MIPT_seed >= MIPT_NE) &&
-                 (vetoPositions[std::make_tuple(bin_R, binLeft, z_side)] or MIPT_seed > MIPT_W) &&
-                 (vetoPositions[std::make_tuple(bin_R + 1, binLeft, z_side)] or MIPT_seed > MIPT_SW) &&
-                 (vetoPositions[std::make_tuple(bin_R - 1, binLeft, z_side)] or MIPT_seed > MIPT_NW);
+        isMax &=
+            (((bin_R < nBinsRHisto_ - 1) && vetoPositions.at(z_side, bin_R + 1, bin_phi)) or MIPT_seed >= MIPT_S) &&
+            (((bin_R > 0) && vetoPositions.at(z_side, bin_R - 1, bin_phi)) or MIPT_seed > MIPT_N) &&
+            ((vetoPositions.at(z_side, bin_R, binRight)) or MIPT_seed >= MIPT_E) &&
+            (((bin_R < nBinsRHisto_ - 1) && vetoPositions.at(z_side, bin_R + 1, binRight)) or MIPT_seed >= MIPT_SE) &&
+            (((bin_R > 0) && vetoPositions.at(z_side, bin_R - 1, binRight)) or MIPT_seed >= MIPT_NE) &&
+            ((vetoPositions.at(z_side, bin_R, binLeft)) or MIPT_seed > MIPT_W) &&
+            (((bin_R < nBinsRHisto_ - 1) && vetoPositions.at(z_side, bin_R + 1, binLeft)) or MIPT_seed > MIPT_SW) &&
+            (((bin_R > 0) && vetoPositions.at(z_side, bin_R - 1, binLeft)) or MIPT_seed > MIPT_NW);
 
         if (isMax) {
           setSeedEnergyAndPosition(
-              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at({{z_side, bin_R, bin_phi}}));
+              seedPositionsEnergy, z_side, bin_R, bin_phi, histoClusters.at(z_side, bin_R, bin_phi));
         }
       }
     }
@@ -402,7 +385,6 @@ void HGCalHistoSeedingImpl::findHistoSeeds(const std::vector<edm::Ptr<l1t::HGCal
                                            std::vector<std::pair<GlobalPoint, double>>& seedPositionsEnergy) {
   /* put clusters into an r/z x phi histogram */
   Histogram histoCluster = fillHistoClusters(clustersPtrs);
-  //key[0] = z.side(), key[1] = bin_R, key[2] = bin_phi, content = MIPTs summed along depth
 
   /* smoothen along the phi direction + normalize each bin to same area */
   Histogram smoothPhiHistoCluster = fillSmoothPhiHistoClusters(histoCluster, binsSumsHisto_);

--- a/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
@@ -5,6 +5,9 @@
 
 #include <unordered_map>
 
+HGCalShowerShape::HGCalShowerShape(const edm::ParameterSet& conf)
+    : threshold_(conf.existsAs<double>("shape_threshold") ? conf.getParameter<double>("shape_threshold") : 0.) {}
+
 //Compute energy-weighted mean of any variable X in the cluster
 
 float HGCalShowerShape::meanX(const std::vector<pair<float, float>>& energy_X_tc) const {
@@ -28,6 +31,8 @@ int HGCalShowerShape::firstLayer(const l1t::HGCalMulticluster& c3d) const {
   int firstLayer = 999;
 
   for (const auto& id_clu : clustersPtrs) {
+    if (!pass(*id_clu.second))
+      continue;
     int layer = triggerTools_.layerWithOffset(id_clu.second->detId());
     if (layer < firstLayer)
       firstLayer = layer;
@@ -42,6 +47,8 @@ int HGCalShowerShape::maxLayer(const l1t::HGCalMulticluster& c3d) const {
   float max_pt = 0.;
   int max_layer = 0;
   for (const auto& id_cluster : clustersPtrs) {
+    if (!pass(*id_cluster.second))
+      continue;
     unsigned layer = triggerTools_.layerWithOffset(id_cluster.second->detId());
     auto itr_insert = layers_pt.emplace(layer, 0.);
     itr_insert.first->second += id_cluster.second->pt();
@@ -59,6 +66,8 @@ int HGCalShowerShape::lastLayer(const l1t::HGCalMulticluster& c3d) const {
   int lastLayer = -999;
 
   for (const auto& id_clu : clustersPtrs) {
+    if (!pass(*id_clu.second))
+      continue;
     int layer = triggerTools_.layerWithOffset(id_clu.second->detId());
     if (layer > lastLayer)
       lastLayer = layer;
@@ -73,6 +82,8 @@ int HGCalShowerShape::coreShowerLength(const l1t::HGCalMulticluster& c3d,
   unsigned nlayers = triggerTools_.layers(ForwardSubdetector::ForwardEmpty);
   std::vector<bool> layers(nlayers);
   for (const auto& id_cluster : clustersPtrs) {
+    if (!pass(*id_cluster.second))
+      continue;
     unsigned layer = triggerGeometry.triggerLayer(id_cluster.second->detId());
     if (layer == 0 || layer > nlayers)
       continue;
@@ -100,6 +111,8 @@ float HGCalShowerShape::sigmaEtaEtaTot(const l1t::HGCalMulticluster& c3d) const 
     const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
 
     for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
       tc_energy_eta.emplace_back(std::make_pair(id_tc.second->energy(), id_tc.second->eta()));
     }
   }
@@ -118,6 +131,8 @@ float HGCalShowerShape::sigmaPhiPhiTot(const l1t::HGCalMulticluster& c3d) const 
     const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
 
     for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
       tc_energy_phi.emplace_back(std::make_pair(id_tc.second->energy(), id_tc.second->phi()));
     }
   }
@@ -136,6 +151,8 @@ float HGCalShowerShape::sigmaRRTot(const l1t::HGCalMulticluster& c3d) const {
     const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
 
     for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
       float r = (id_tc.second->position().z() != 0.
                      ? std::sqrt(pow(id_tc.second->position().x(), 2) + pow(id_tc.second->position().y(), 2)) /
                            std::abs(id_tc.second->position().z())
@@ -164,6 +181,8 @@ float HGCalShowerShape::sigmaEtaEtaMax(const l1t::HGCalMulticluster& c3d) const 
     const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
 
     for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
       tc_layer_energy_eta[layer].emplace_back(std::make_pair(id_tc.second->energy(), id_tc.second->eta()));
     }
   }
@@ -195,6 +214,8 @@ float HGCalShowerShape::sigmaPhiPhiMax(const l1t::HGCalMulticluster& c3d) const 
     const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
 
     for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
       tc_layer_energy_phi[layer].emplace_back(std::make_pair(id_tc.second->energy(), id_tc.second->phi()));
     }
   }
@@ -223,6 +244,8 @@ float HGCalShowerShape::sigmaRRMax(const l1t::HGCalMulticluster& c3d) const {
     const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
 
     for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
       float r = (id_tc.second->position().z() != 0.
                      ? std::sqrt(pow(id_tc.second->position().x(), 2) + pow(id_tc.second->position().y(), 2)) /
                            std::abs(id_tc.second->position().z())
@@ -252,6 +275,8 @@ float HGCalShowerShape::sigmaRRMean(const l1t::HGCalMulticluster& c3d, float rad
     unsigned layer = triggerTools_.layerWithOffset(id_clu.second->detId());
     const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
     for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
       layers_tcs[layer].emplace_back(id_tc.second);
     }
   }
@@ -302,6 +327,8 @@ float HGCalShowerShape::eMax(const l1t::HGCalMulticluster& c3d) const {
   const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalCluster>>& clustersPtrs = c3d.constituents();
 
   for (const auto& id_clu : clustersPtrs) {
+    if (!pass(*id_clu.second))
+      continue;
     unsigned layer = triggerTools_.layerWithOffset(id_clu.second->detId());
     layer_energy[layer] += id_clu.second->energy();
   }
@@ -325,6 +352,8 @@ float HGCalShowerShape::sigmaZZ(const l1t::HGCalMulticluster& c3d) const {
     const std::unordered_map<uint32_t, edm::Ptr<l1t::HGCalTriggerCell>>& triggerCells = id_clu.second->constituents();
 
     for (const auto& id_tc : triggerCells) {
+      if (!pass(*id_tc.second))
+        continue;
       tc_energy_z.emplace_back(std::make_pair(id_tc.second->energy(), id_tc.second->position().z()));
     }
   }
@@ -341,6 +370,8 @@ float HGCalShowerShape::sigmaEtaEtaTot(const l1t::HGCalCluster& c2d) const {
   std::vector<std::pair<float, float>> tc_energy_eta;
 
   for (const auto& id_cell : cellsPtrs) {
+    if (!pass(*id_cell.second))
+      continue;
     tc_energy_eta.emplace_back(std::make_pair(id_cell.second->energy(), id_cell.second->eta()));
   }
 
@@ -355,6 +386,8 @@ float HGCalShowerShape::sigmaPhiPhiTot(const l1t::HGCalCluster& c2d) const {
   std::vector<std::pair<float, float>> tc_energy_phi;
 
   for (const auto& id_cell : cellsPtrs) {
+    if (!pass(*id_cell.second))
+      continue;
     tc_energy_phi.emplace_back(std::make_pair(id_cell.second->energy(), id_cell.second->phi()));
   }
 
@@ -369,6 +402,8 @@ float HGCalShowerShape::sigmaRRTot(const l1t::HGCalCluster& c2d) const {
   std::vector<std::pair<float, float>> tc_energy_r;
 
   for (const auto& id_cell : cellsPtrs) {
+    if (!pass(*id_cell.second))
+      continue;
     float r = (id_cell.second->position().z() != 0.
                    ? std::sqrt(pow(id_cell.second->position().x(), 2) + pow(id_cell.second->position().y(), 2)) /
                          std::abs(id_cell.second->position().z())

--- a/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
@@ -6,7 +6,7 @@
 #include <unordered_map>
 
 HGCalShowerShape::HGCalShowerShape(const edm::ParameterSet& conf)
-    : threshold_(conf.existsAs<double>("shape_threshold") ? conf.getParameter<double>("shape_threshold") : 0.) {}
+    : threshold_(conf.getParameter<double>("shape_threshold")) {}
 
 //Compute energy-weighted mean of any variable X in the cluster
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -1,0 +1,63 @@
+#include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h"
+
+HGCalConcentratorCoarsenerImpl::HGCalConcentratorCoarsenerImpl(const edm::ParameterSet& conf)
+    : fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC")),
+      coarseTCmapping_(std::vector<unsigned>{HGCalCoarseTriggerCellMapping::kCTCsizeVeryFine_,
+                                             HGCalCoarseTriggerCellMapping::kCTCsizeVeryFine_,
+                                             HGCalCoarseTriggerCellMapping::kCTCsizeVeryFine_,
+                                             HGCalCoarseTriggerCellMapping::kCTCsizeVeryFine_}) {}
+
+void HGCalConcentratorCoarsenerImpl::updateCoarseTriggerCellMaps(const l1t::HGCalTriggerCell& tc, uint32_t ctcid) {
+  auto& ctc = coarseTCs_[ctcid];
+
+  ctc.sumPt += tc.pt();
+  ctc.sumHwPt += tc.hwPt();
+  ctc.sumMipPt += tc.mipPt();
+
+  if (tc.mipPt() > ctc.maxMipPt) {
+    ctc.maxId = tc.detId();
+    ctc.maxMipPt = tc.mipPt();
+  }
+}
+
+void HGCalConcentratorCoarsenerImpl::assignCoarseTriggerCellEnergy(l1t::HGCalTriggerCell& tc,
+                                                                   const CoarseTC& ctc) const {
+  tc.setHwPt(ctc.sumHwPt);
+  tc.setMipPt(ctc.sumMipPt);
+  tc.setPt(ctc.sumPt);
+}
+
+void HGCalConcentratorCoarsenerImpl::coarsen(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
+                                             std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) {
+  coarseTCs_.clear();
+
+  // first pass, fill the coarse trigger cell information
+  for (const l1t::HGCalTriggerCell& tc : trigCellVecInput) {
+    int thickness = 0;
+    if (triggerTools_.isSilicon(tc.detId())) {
+      thickness = triggerTools_.thicknessIndex(tc.detId(), true);
+    } else if (triggerTools_.isScintillator(tc.detId())) {
+      thickness = 3;
+    }
+
+    if (fixedDataSizePerHGCROC_ && thickness == kHighDensityThickness_) {
+      trigCellVecOutput.push_back(tc);
+      continue;
+    }
+
+    uint32_t ctcid = coarseTCmapping_.getCoarseTriggerCellId(tc.detId());
+    updateCoarseTriggerCellMaps(tc, ctcid);
+  }
+
+  for (const auto& ctc : coarseTCs_) {
+    l1t::HGCalTriggerCell triggerCell;
+    assignCoarseTriggerCellEnergy(triggerCell, ctc.second);
+    uint32_t representativeId = coarseTCmapping_.getRepresentativeDetId(ctc.second.maxId);
+    triggerCell.setDetId(representativeId);
+    GlobalPoint point = coarseTCmapping_.getCoarseTriggerCellPosition(ctc.first);
+    math::PtEtaPhiMLorentzVector p4(triggerCell.pt(), point.eta(), point.phi(), 0);
+    triggerCell.setPosition(point);
+    triggerCell.setP4(p4);
+    trigCellVecOutput.push_back(triggerCell);
+  }
+}

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -37,7 +37,7 @@ void HGCalConcentratorCoarsenerImpl::coarsen(const std::vector<l1t::HGCalTrigger
     if (triggerTools_.isSilicon(tc.detId())) {
       thickness = triggerTools_.thicknessIndex(tc.detId(), true);
     } else if (triggerTools_.isScintillator(tc.detId())) {
-      thickness = kScintillatorPseudoThicknessIndex_;
+      thickness = HGCalTriggerTools::kScintillatorPseudoThicknessIndex_;
     }
 
     if (fixedDataSizePerHGCROC_ && thickness == kHighDensityThickness_) {

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -37,7 +37,7 @@ void HGCalConcentratorCoarsenerImpl::coarsen(const std::vector<l1t::HGCalTrigger
     if (triggerTools_.isSilicon(tc.detId())) {
       thickness = triggerTools_.thicknessIndex(tc.detId(), true);
     } else if (triggerTools_.isScintillator(tc.detId())) {
-      thickness = 3;
+      thickness = kScintillatorPseudoThicknessIndex_;
     }
 
     if (fixedDataSizePerHGCROC_ && thickness == kHighDensityThickness_) {

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -35,7 +35,7 @@ void HGCalConcentratorSuperTriggerCellImpl::createAllTriggerCells(
     if (triggerTools_.isSilicon(output_ids.at(0))) {
       thickness = triggerTools_.thicknessIndex(output_ids.at(0), true);
     } else if (triggerTools_.isScintillator(output_ids.at(0))) {
-      thickness = kScintillatorPseudoThicknessIndex_;
+      thickness = HGCalTriggerTools::kScintillatorPseudoThicknessIndex_;
     }
 
     for (const auto& id : output_ids) {
@@ -125,7 +125,7 @@ void HGCalConcentratorSuperTriggerCellImpl::assignSuperTriggerCellEnergyAndPosit
   if (triggerTools_.isSilicon(c.detId())) {
     thickness = triggerTools_.thicknessIndex(c.detId(), true);
   } else if (triggerTools_.isScintillator(c.detId())) {
-    thickness = kScintillatorPseudoThicknessIndex_;
+    thickness = HGCalTriggerTools::kScintillatorPseudoThicknessIndex_;
   }
 
   GlobalPoint point;

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -35,7 +35,7 @@ void HGCalConcentratorSuperTriggerCellImpl::createAllTriggerCells(
     if (triggerTools_.isSilicon(output_ids.at(0))) {
       thickness = triggerTools_.thicknessIndex(output_ids.at(0), true);
     } else if (triggerTools_.isScintillator(output_ids.at(0))) {
-      thickness = 3;
+      thickness = kScintillatorPseudoThicknessIndex_;
     }
 
     for (const auto& id : output_ids) {
@@ -104,9 +104,10 @@ void HGCalConcentratorSuperTriggerCellImpl::assignSuperTriggerCellEnergyAndPosit
                              ? double(kTriggerCellsForDivision_)
                              : double(superTCmapping_.getConstituentTriggerCells(stc.getSTCId()).size());
 
-    c.setHwPt(stc.getSumHwPt() / denominator);
-    c.setMipPt(stc.getSumMipPt() / denominator);
-    c.setPt(stc.getSumPt() / denominator);
+    double denominatorInv = 1. / denominator;
+    c.setHwPt(stc.getSumHwPt() * denominatorInv);
+    c.setMipPt(stc.getSumMipPt() * denominatorInv);
+    c.setPt(stc.getSumPt() * denominatorInv);
   } else if (energyDivisionType_ == oneBitFraction) {
     double frac = 0;
 
@@ -124,7 +125,7 @@ void HGCalConcentratorSuperTriggerCellImpl::assignSuperTriggerCellEnergyAndPosit
   if (triggerTools_.isSilicon(c.detId())) {
     thickness = triggerTools_.thicknessIndex(c.detId(), true);
   } else if (triggerTools_.isScintillator(c.detId())) {
-    thickness = 3;
+    thickness = kScintillatorPseudoThicknessIndex_;
   }
 
   GlobalPoint point;

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -1,110 +1,163 @@
 #include "L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h"
-#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
-
-#include <unordered_map>
 
 HGCalConcentratorSuperTriggerCellImpl::HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf)
-    : stcSize_(conf.getParameter<std::vector<unsigned> >("stcSize")) {
-  if (stcSize_.size() != kNLayers_) {
-    throw cms::Exception("HGCTriggerParameterError")
-        << "Inconsistent size of super trigger cell size vector" << stcSize_.size();
-  }
-  for (auto stc : stcSize_) {
-    if (stc != kSTCsizeFine_ && stc != kSTCsizeCoarse_) {
-      throw cms::Exception("HGCTriggerParameterError")
-          << "Super Trigger Cell should be of size " << kSTCsizeFine_ << " or " << kSTCsizeCoarse_;
-    }
-  }
-}
+    : fixedDataSizePerHGCROC_(conf.getParameter<bool>("fixedDataSizePerHGCROC")),
+      coarseTCmapping_(std::vector<unsigned>{HGCalCoarseTriggerCellMapping::kCTCsizeVeryFine_,
+                                             HGCalCoarseTriggerCellMapping::kCTCsizeVeryFine_,
+                                             HGCalCoarseTriggerCellMapping::kCTCsizeVeryFine_,
+                                             HGCalCoarseTriggerCellMapping::kCTCsizeVeryFine_}),
+      superTCmapping_(conf.getParameter<std::vector<unsigned>>("stcSize")) {
+  std::string energyType(conf.getParameter<string>("type_energy_division"));
 
-const std::map<int, int> HGCalConcentratorSuperTriggerCellImpl::kSplit_ = {{kSTCsizeFine_, kSplit_v8_Fine_},
-                                                                           {kSTCsizeCoarse_, kSplit_v8_Coarse_}};
+  if (energyType == "superTriggerCell") {
+    energyDivisionType_ = superTriggerCell;
+  } else if (energyType == "oneBitFraction") {
+    energyDivisionType_ = oneBitFraction;
 
-int HGCalConcentratorSuperTriggerCellImpl::getSuperTriggerCellId(int detid) const {
-  DetId TC_id(detid);
-  if (TC_id.det() == DetId::Forward) {  //V8
+    oneBitFractionThreshold_ = conf.getParameter<double>("oneBitFractionThreshold");
+    oneBitFractionLowValue_ = conf.getParameter<double>("oneBitFractionLowValue");
+    oneBitFractionHighValue_ = conf.getParameter<double>("oneBitFractionHighValue");
 
-    HGCalDetId TC_idV8(detid);
-
-    if (triggerTools_.isScintillator(detid)) {
-      return TC_idV8.cell();  //scintillator
-    } else {
-      int TC_wafer = TC_idV8.wafer();
-      int thickness = triggerTools_.thicknessIndex(detid, true);
-      int TC_split = (TC_idV8.cell() & kSplit_.at(stcSize_.at(thickness)));
-
-      return TC_wafer << kWafer_offset_ | TC_split;
-    }
-
-  }
-
-  else if (TC_id.det() == DetId::HGCalTrigger) {  //V9
-
-    if (triggerTools_.isScintillator(detid)) {
-      HGCScintillatorDetId TC_idV9(detid);
-      return TC_idV9.ietaAbs() << HGCScintillatorDetId::kHGCalPhiOffset | TC_idV9.iphi();  //scintillator
-    } else {
-      HGCalTriggerDetId TC_idV9(detid);
-
-      int TC_wafer = TC_idV9.waferU() << kWafer_offset_ | TC_idV9.waferV();
-      int thickness = triggerTools_.thicknessIndex(detid);
-
-      int TC_12th = 0;
-      int Uprime = 0;
-      int Vprime = 0;
-      int rocnum = detIdToROC_.getROCNumber(TC_idV9.triggerCellU(), TC_idV9.triggerCellV(), 1);
-
-      if (rocnum == 1) {
-        Uprime = TC_idV9.triggerCellU();
-        Vprime = TC_idV9.triggerCellV() - TC_idV9.triggerCellU();
-
-      } else if (rocnum == 2) {
-        Uprime = TC_idV9.triggerCellU() - TC_idV9.triggerCellV() - 1;
-        Vprime = TC_idV9.triggerCellV();
-
-      } else if (rocnum == 3) {
-        Uprime = TC_idV9.triggerCellU() - kRotate4_;
-        Vprime = TC_idV9.triggerCellV() - kRotate4_;
-      }
-
-      TC_12th = (rocnum << kRocShift_) | ((Uprime << kUShift_ | Vprime) & kSplit_v9_);
-
-      int TC_split = TC_12th;
-      if (stcSize_.at(thickness) == kSTCsizeCoarse_) {
-        TC_split = rocnum;
-      }
-
-      return TC_wafer << kWafer_offset_ | TC_split;
-    }
+  } else if (energyType == "equalShare") {
+    energyDivisionType_ = equalShare;
 
   } else {
-    return -1;
+    energyDivisionType_ = superTriggerCell;
   }
 }
 
-void HGCalConcentratorSuperTriggerCellImpl::superTriggerCellSelectImpl(
-    const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) {
-  std::unordered_map<unsigned, SuperTriggerCell> STCs;
+void HGCalConcentratorSuperTriggerCellImpl::createAllTriggerCells(
+    std::unordered_map<unsigned, SuperTriggerCell>& STCs, std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) const {
+  for (auto& s : STCs) {
+    int thickness = 0;
+    std::vector<uint32_t> output_ids = superTCmapping_.getConstituentTriggerCells(s.second.getSTCId());
 
-  // first pass, fill the super trigger cells
-  for (const l1t::HGCalTriggerCell& tc : trigCellVecInput) {
-    if (tc.subdetId() == HGCHEB)
-      continue;
-    STCs[getSuperTriggerCellId(tc.detId())].add(tc);
-  }
-
-  // second pass, write them out
-  for (const l1t::HGCalTriggerCell& tc : trigCellVecInput) {
-    //If scintillator use a simple threshold cut
-    if (tc.subdetId() == HGCHEB) {
-      trigCellVecOutput.push_back(tc);
-    } else {
-      const auto& stc = STCs[getSuperTriggerCellId(tc.detId())];
-      if (tc.detId() == stc.GetMaxId()) {
-        trigCellVecOutput.push_back(tc);
-        stc.assignEnergy(trigCellVecOutput.back());
-      }
+    if (triggerTools_.isSilicon(output_ids.at(0))) {
+      thickness = triggerTools_.thicknessIndex(output_ids.at(0), true);
+    } else if (triggerTools_.isScintillator(output_ids.at(0))) {
+      thickness = 3;
     }
 
-  }  // end of second loop
+    for (const auto& id : output_ids) {
+      if (fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_ &&
+          id != superTCmapping_.getRepresentativeDetId(id)) {
+        continue;
+      }
+
+      if (!triggerTools_.getTriggerGeometry()->validTriggerCell(id)) {
+        continue;
+      }
+
+      l1t::HGCalTriggerCell triggerCell;
+      triggerCell.setDetId(id);
+      if (energyDivisionType_ == superTriggerCell && id != s.second.getMaxId()) {
+        continue;
+      }
+
+      DetId tc_Id(id);
+
+      //To guard against the case in v8 geometry where
+      //there might be different thicknesses within a module
+      //This is a small effect, but in principle energy might
+      //be lost.
+      if (superTCmapping_.getCoarseTriggerCellId(id) != s.second.getSTCId()) {
+        if (triggerTools_.getTriggerGeometry()->isV9Geometry()) {
+          throw cms::Exception("NonExistingCoarseTC")
+              << "The coarse trigger cell correponsing to the nominal trigger cell does not exist";
+        } else {
+          continue;
+        }
+      }
+
+      trigCellVecOutput.push_back(triggerCell);
+
+      if (energyDivisionType_ == oneBitFraction) {  //Get the 1 bit fractions
+
+        if (id != s.second.getMaxId()) {
+          float tc_fraction = getTriggerCellOneBitFraction(s.second.getTCpt(id), s.second.getSumPt());
+          s.second.addToFractionSum(tc_fraction);
+        }
+      }
+    }
+  }
+
+  // assign energy
+  for (l1t::HGCalTriggerCell& tc : trigCellVecOutput) {
+    const auto& stc = STCs[superTCmapping_.getCoarseTriggerCellId(tc.detId())];
+    assignSuperTriggerCellEnergyAndPosition(tc, stc);
+  }
+}
+
+void HGCalConcentratorSuperTriggerCellImpl::assignSuperTriggerCellEnergyAndPosition(l1t::HGCalTriggerCell& c,
+                                                                                    const SuperTriggerCell& stc) const {
+  if (energyDivisionType_ == superTriggerCell) {
+    if (c.detId() == stc.getMaxId()) {
+      c.setHwPt(stc.getSumHwPt());
+      c.setMipPt(stc.getSumMipPt());
+      c.setPt(stc.getSumPt());
+    } else {
+      throw cms::Exception("NonMaxIdSuperTriggerCell")
+          << "Trigger Cell with detId not equal to the maximum of the superTriggerCell found";
+    }
+  } else if (energyDivisionType_ == equalShare) {
+    double denominator = fixedDataSizePerHGCROC_
+                             ? double(kTriggerCellsForDivision_)
+                             : double(superTCmapping_.getConstituentTriggerCells(stc.getSTCId()).size());
+
+    c.setHwPt(stc.getSumHwPt() / denominator);
+    c.setMipPt(stc.getSumMipPt() / denominator);
+    c.setPt(stc.getSumPt() / denominator);
+  } else if (energyDivisionType_ == oneBitFraction) {
+    double frac = 0;
+
+    if (c.detId() != stc.getMaxId()) {
+      frac = getTriggerCellOneBitFraction(stc.getTCpt(c.detId()), stc.getSumPt());
+    } else {
+      frac = 1 - stc.getFractionSum();
+    }
+    c.setHwPt(stc.getSumHwPt() * frac);
+    c.setMipPt(stc.getSumMipPt() * frac);
+    c.setPt(stc.getSumPt() * frac);
+  }
+
+  int thickness = 0;
+  if (triggerTools_.isSilicon(c.detId())) {
+    thickness = triggerTools_.thicknessIndex(c.detId(), true);
+  } else if (triggerTools_.isScintillator(c.detId())) {
+    thickness = 3;
+  }
+
+  GlobalPoint point;
+  if (fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_) {
+    point = coarseTCmapping_.getCoarseTriggerCellPosition(coarseTCmapping_.getCoarseTriggerCellId(c.detId()));
+  } else {
+    point = triggerTools_.getTCPosition(c.detId());
+  }
+  math::PtEtaPhiMLorentzVector p4(c.pt(), point.eta(), point.phi(), 0.);
+  c.setPosition(point);
+  c.setP4(p4);
+}
+
+float HGCalConcentratorSuperTriggerCellImpl::getTriggerCellOneBitFraction(float tcPt, float sumPt) const {
+  double f = tcPt / sumPt;
+  double frac = 0;
+  if (f < oneBitFractionThreshold_) {
+    frac = oneBitFractionLowValue_;
+  } else {
+    frac = oneBitFractionHighValue_;
+  }
+
+  return frac;
+}
+
+void HGCalConcentratorSuperTriggerCellImpl::select(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
+                                                   std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput) {
+  std::unordered_map<unsigned, SuperTriggerCell> STCs;
+  // first pass, fill the "coarse" trigger cells
+  for (const l1t::HGCalTriggerCell& tc : trigCellVecInput) {
+    uint32_t stcid = superTCmapping_.getCoarseTriggerCellId(tc.detId());
+    STCs[stcid].add(tc, stcid);
+  }
+
+  createAllTriggerCells(STCs, trigCellVecOutput);
 }

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_RelValV9_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_RelValV9_cfg.py
@@ -74,9 +74,6 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 # load HGCAL TPG simulation
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
-# To test V9Imp2
-#from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V9
-#process = custom_geometry_V9(process, implementation=2)
 
 
 process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_RelVal_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_RelVal_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 
 # For old samples use the digi converter
-#from Configuration.Eras.Era_Phase2_cff import Phase2
+from Configuration.Eras.Era_Phase2_cff import Phase2
 #process = cms.Process('DIGI',Phase2,convertHGCalDigisSim)
 process = cms.Process('DIGI',Phase2)
 

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
@@ -129,8 +129,14 @@ void HGCalTriggerNtupleHGCTriggerCells::initialize(TTree& tree,
   tree.Branch(withPrefix("zside"), &tc_side_);
   tree.Branch(withPrefix("layer"), &tc_layer_);
   tree.Branch(withPrefix("wafer"), &tc_wafer_);
+  tree.Branch(withPrefix("waferu"), &tc_waferu_);
+  tree.Branch(withPrefix("waferv"), &tc_waferv_);
   tree.Branch(withPrefix("wafertype"), &tc_wafertype_);
+  tree.Branch(withPrefix("panel_number"), &tc_panel_number_);
+  tree.Branch(withPrefix("panel_sector"), &tc_panel_sector_);
   tree.Branch(withPrefix("cell"), &tc_cell_);
+  tree.Branch(withPrefix("cellu"), &tc_cellu_);
+  tree.Branch(withPrefix("cellv"), &tc_cellv_);
   tree.Branch(withPrefix("data"), &tc_data_);
   tree.Branch(withPrefix("uncompressedCharge"), &tc_uncompressedCharge_);
   tree.Branch(withPrefix("compressedCharge"), &tc_compressedCharge_);

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -44,12 +44,14 @@ def create_histoMax(process, inputs,
                     nBins_Phi=histoMax_C3d_params.nBins_Phi_histo_multicluster,
                     binSumsHisto=histoMax_C3d_params.binSumsHisto,
                     seed_threshold=histoMax_C3d_params.threshold_histo_multicluster,
+                    shape_threshold=histoMax_C3d_params.shape_threshold,
                     ):
     producer = process.hgcalBackEndLayer2Producer.clone(
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
             )
     producer.ProcessorParameters.C3d_parameters = histoMax_C3d_params.clone()
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+            seed_threshold, shape_threshold)
     return producer
 
 
@@ -59,6 +61,7 @@ def create_histoMax_variableDr(process, inputs,
                                nBins_Phi=histoMaxVariableDR_C3d_params.nBins_Phi_histo_multicluster,
                                binSumsHisto=histoMaxVariableDR_C3d_params.binSumsHisto,
                                seed_threshold=histoMaxVariableDR_C3d_params.threshold_histo_multicluster,
+                               shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
                                ):
     producer = process.hgcalBackEndLayer2Producer.clone(
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
@@ -66,7 +69,8 @@ def create_histoMax_variableDr(process, inputs,
     producer.ProcessorParameters.C3d_parameters = histoMax_C3d_params.clone(
             dR_multicluster_byLayer_coefficientA = distances
             )
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, 0, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, 0, nBins_R, nBins_Phi, binSumsHisto,
+            seed_threshold, shape_threshold)
     return producer
 
 
@@ -76,6 +80,7 @@ def create_histoInterpolatedMax1stOrder(process, inputs,
                                         nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
                                         binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
                                         seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+                                        shape_threshold=histoInterpolatedMax_C3d_params.shape_threshold,
                                         ):
     producer = process.hgcalBackEndLayer2Producer.clone(
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
@@ -83,7 +88,8 @@ def create_histoInterpolatedMax1stOrder(process, inputs,
     producer.ProcessorParameters.C3d_parameters = histoInterpolatedMax_C3d_params.clone(
             neighbour_weights = neighbour_weights_1stOrder
             )
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+            seed_threshold, shape_threshold)
     return producer
 
 
@@ -93,6 +99,7 @@ def create_histoInterpolatedMax2ndOrder(process, inputs,
                                         nBins_Phi=histoInterpolatedMax_C3d_params.nBins_Phi_histo_multicluster,
                                         binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
                                         seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+                                        shape_threshold=histoInterpolatedMax_C3d_params.shape_threshold,
                                         ):
     producer = process.hgcalBackEndLayer2Producer.clone(
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
@@ -100,7 +107,8 @@ def create_histoInterpolatedMax2ndOrder(process, inputs,
     producer.ProcessorParameters.C3d_parameters = histoInterpolatedMax_C3d_params.clone(
             neighbour_weights = neighbour_weights_2ndOrder
             )
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, seed_threshold)
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+            seed_threshold, shape_threshold)
     return producer
 
 
@@ -109,11 +117,13 @@ def create_histoThreshold(process, inputs,
                           distance=histoThreshold_C3d_params.dR_multicluster,
                           nBins_R=histoThreshold_C3d_params.nBins_R_histo_multicluster,
                           nBins_Phi=histoThreshold_C3d_params.nBins_Phi_histo_multicluster,
-                          binSumsHisto=histoThreshold_C3d_params.binSumsHisto
+                          binSumsHisto=histoThreshold_C3d_params.binSumsHisto,
+                          shape_threshold=histoThreshold_C3d_params.shape_threshold,
                           ):
     producer = process.hgcalBackEndLayer2Producer.clone(
             InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
             )
     producer.ProcessorParameters.C3d_parameters = histoThreshold_C3d_params.clone()
-    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto, threshold)
+    set_histomax_params(producer.ProcessorParameters.C3d_parameters, distance, nBins_R, nBins_Phi, binSumsHisto,
+            threshold, shape_threshold)
     return producer

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -1,17 +1,21 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
-from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc
+from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc
 
 
 def create_supertriggercell(process, inputs,
-                            stcSize=supertc_conc_proc.stcSize
+                            stcSize=supertc_conc_proc.stcSize,
+                            type_energy_division=supertc_conc_proc.type_energy_division,
+                            fixedDataSizePerHGCROC=supertc_conc_proc.fixedDataSizePerHGCROC
                             ):
     producer = process.hgcalConcentratorProducer.clone(
             InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
             InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
             )
     producer.ProcessorParameters = supertc_conc_proc.clone(
-            stcSize = stcSize
+            stcSize = stcSize,
+            type_energy_division = type_energy_division,
+            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC
             )
     return producer
 
@@ -40,5 +44,20 @@ def create_bestchoice(process, inputs,
             )
     producer.ProcessorParameters = best_conc_proc.clone(
             NData = triggercells
+            )
+    return producer
+
+
+def create_onebitfraction(process, inputs,
+                            stcSize=coarsetc_onebitfraction_proc.stcSize,
+                            fixedDataSizePerHGCROC=coarsetc_onebitfraction_proc.fixedDataSizePerHGCROC
+                            ):
+    producer = process.hgcalConcentratorProducer.clone(
+            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
+            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
+            )
+    producer.ProcessorParameters = coarsetc_onebitfraction_proc.clone(
+            stcSize = stcSize,
+            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC
             )
     return producer

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelValV9_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelValV9_cfg.py
@@ -75,9 +75,6 @@ process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 #process.load('L1Trigger.L1THGCalUtilities.caloTruthCellsNtuples_cff')
 
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
-# To test V9Imp2
-#from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V9
-#process = custom_geometry_V9(process, implementation=2)
 
 
 # load ntuplizer

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelVal_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelVal_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 
 # For old samples use the digi converter
-#from Configuration.Eras.Era_Phase2_cff import Phase2
+from Configuration.Eras.Era_Phase2_cff import Phase2
 #process = cms.Process('DIGI',Phase2,convertHGCalDigisSim)
 process = cms.Process('DIGI',Phase2)
 

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
@@ -1,8 +1,7 @@
 import FWCore.ParameterSet.Config as cms 
-from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 
-# For old samples use the digi converter
-process = cms.Process('DIGI',eras.Phase2C4)
+from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+process = cms.Process('DIGI',Phase2C4)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
@@ -84,10 +84,8 @@ chains.register_concentrator("Supertriggercell", concentrator.create_supertrigge
 chains.register_concentrator("Threshold", concentrator.create_threshold)
 chains.register_concentrator("Bestchoice", concentrator.create_bestchoice)
 ## BE1
-chains.register_backend1("Ref2d", clustering2d.create_constrainedtopological)
 chains.register_backend1("Dummy", clustering2d.create_dummy)
 ## BE2
-chains.register_backend2("Ref3d", clustering3d.create_distance)
 chains.register_backend2("Histomax", clustering3d.create_histoMax)
 chains.register_backend2("Histomaxvardrth0", lambda p,i : clustering3d.create_histoMax_variableDr(p,i,seed_threshold=0.))
 chains.register_backend2("Histomaxvardrth10", lambda p,i : clustering3d.create_histoMax_variableDr(p,i,seed_threshold=10.))
@@ -95,21 +93,16 @@ chains.register_backend2("Histomaxvardrth20", lambda p,i : clustering3d.create_h
 # Register selector
 chains.register_selector("Genmatch", selectors.create_genmatch)
 # Register ntuples
-# Store gen info only in the reference ntuple
-ntuple_list_ref = ['event', 'gen', 'multiclusters']
-ntuple_list = ['event', 'multiclusters']
-chains.register_ntuple("Genclustersntuple", lambda p,i : ntuple.create_ntuple(p,i, ntuple_list_ref))
-chains.register_ntuple("Clustersntuple", lambda p,i : ntuple.create_ntuple(p,i, ntuple_list))
+ntuple_list = ['event', 'gen', 'multiclusters']
+chains.register_ntuple("Genclustersntuple", lambda p,i : ntuple.create_ntuple(p,i, ntuple_list))
 
 # Register trigger chains
-## Reference chain
-chains.register_chain('Floatingpoint8', "Threshold", 'Ref2d', 'Ref3d', 'Genmatch', 'Genclustersntuple')
 concentrator_algos = ['Supertriggercell', 'Threshold', 'Bestchoice']
 backend_algos = ['Histomax', 'Histomaxvardrth0', 'Histomaxvardrth10', 'Histomaxvardrth20']
 ## Make cross product fo ECON and BE algos
 import itertools
 for cc,be in itertools.product(concentrator_algos,backend_algos):
-    chains.register_chain('Floatingpoint8', cc, 'Dummy', be, 'Genmatch', 'Clustersntuple')
+    chains.register_chain('Floatingpoint8', cc, 'Dummy', be, 'Genmatch', 'Genclustersntuple')
 
 process = chains.create_sequences(process)
 


### PR DESCRIPTION
#### PR description:
* Large updates
  - Add several "Super" and "Coarse" trigger cell flavours (some details in this [presentation](https://indico.cern.ch/event/823686/contributions/3449392/attachments/1853040/3042714/20190528_HGCalBackend_SamuelWebb_v1.pdf))
   - Optimize cluster seeding (implementing histograms as vectors instead of maps)

* Small updates
  - Add option to set seed position as a weighted average instead of bin centers
  - Add an energy threshold when calculating cluster shapes
  - Update egamma ID BDT files for V9
  - Switch to V9 detid scheme for trigger cells as default 

Depends on external https://github.com/cms-data/L1Trigger-L1THGCal/pull/15

#### PR validation:

Code checks + V8/V9/V10 workflows
```
scram b code-checks
scram b code-format
runTheMatrix.py -w upgrade -l 21234.0 --maxSteps=2
runTheMatrix.py -w upgrade -l 27434.0 --maxSteps=2
runTheMatrix.py -w upgrade -l 29034.0 --maxSteps=2
```

