### PR TITLE
Final global tags for 2017 UL reprocessing

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v16',
+    'run1_data'         :   '106X_dataRun2_v17',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v16',
+    'run2_data'         :   '106X_dataRun2_v17',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v15',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v16',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -46,7 +46,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v5',
+    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
     'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -46,7 +46,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v6',
+    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
     'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v13',
+    'run1_data'         :   '106X_dataRun2_v14',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v13',
+    'run2_data'         :   '106X_dataRun2_v14',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v12',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v13',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v8',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v15',
+    'run1_data'         :   '106X_dataRun2_v16',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v15',
+    'run2_data'         :   '106X_dataRun2_v16',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v14',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v15',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v14',
+    'run1_data'         :   '106X_dataRun2_v15',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v14',
+    'run2_data'         :   '106X_dataRun2_v15',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v13',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v14',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -30,10 +30,10 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '106X_dataRun2_relval_v13',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v8',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v9',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v9',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v10',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v10',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
#### PR description:

This PR updates the global tags relevant for the 2017 UL reprocessing, as well as a fix for PPS conditions in prompt-like global tags. Both data and MC global tags are updated.

The changes are as follows:

106X_dataRun2_v17:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v17/106X_dataRun2_v13

106X_dataRun2_relval_v16:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v16/106X_dataRun2_relval_v12

106X_dataRun2_PromptLike_HEfail_v9:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HEfail_v9/106X_dataRun2_PromptLike_HEfail_v8

106X_dataRun2_PromptLike_v10:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_v10/106X_dataRun2_PromptLike_v9

106X_dataRun2_PromptLike_HI_v10:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HI_v10/106X_dataRun2_PromptLike_HI_v9

106X_mc2017_realistic_v7:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_realistic_v7/106X_mc2017_realistic_v5

#### PR validation:

An enormous amount of work went into validating the conditions for this PR. Details can be found at the sign-off talks listed at:

- Data: https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4163.html
- MC: https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4159.html

As a technical check, I ran `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR:

This PR is not a backport but a backport will be prepared for 10_6_X.
