### PR TITLE
MTV : add chi2_vs_pt, assoc_chi2_vs_pt and assoc_chi2prob_vs_pt

### DIFF
--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
@@ -119,8 +119,8 @@ struct MTVHistoProducerAlgoForTrackerHistograms {
   std::vector<ConcurrentMonitorElement> h_assochi2, h_assochi2_prob;
 
   //chi2 and # lost hits vs eta: to be used with doProfileX
-  std::vector<ConcurrentMonitorElement> chi2_vs_eta, nlosthits_vs_eta;
-  std::vector<ConcurrentMonitorElement> assoc_chi2_vs_eta, assoc_chi2prob_vs_eta;
+  std::vector<ConcurrentMonitorElement> chi2_vs_eta, chi2_vs_pt, nlosthits_vs_eta;
+  std::vector<ConcurrentMonitorElement> assoc_chi2_vs_eta, assoc_chi2_vs_pt, assoc_chi2prob_vs_eta, assoc_chi2prob_vs_pt;
 
   //resolution of track params: to be used with fitslicesytool
   std::vector<ConcurrentMonitorElement> dxyres_vs_eta, ptres_vs_eta, dzres_vs_eta, phires_vs_eta, cotThetares_vs_eta;

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -462,7 +462,8 @@ _trackValidatorSeedingBuilding = trackValidator.clone( # common for built tracks
     dodEdxPlots = False,
     doPVAssociationPlots = False,
     doSimPlots = False,
-    doResolutionPlotsForLabels = ["disabled"],
+#    doResolutionPlotsForLabels = ["disabled"],
+    doResolutionPlotsForLabels = [], # enable resolution plots for building as well
 )
 trackValidatorBuilding = _trackValidatorSeedingBuilding.clone(
     dirName = "Tracking/TrackBuilding/",

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -371,7 +371,9 @@ _tuning = PlotGroup("tuning", [
     Plot("chi2_prob", stat=True, normalizeToUnitArea=True, drawStyle="hist", xtitle="Prob(#chi^{2})"),
     Plot("chi2mean", title="", xtitle="#eta", ytitle="< #chi^{2} / ndf >", ymin=[0, 0.5], ymax=[2, 2.5, 3, 5],
          fallback={"name": "chi2_vs_eta", "profileX": True}),
-    Plot("ptres_vs_eta_Mean", scale=100, title="", xtitle="TP #eta (PCA to beamline)", ytitle="< #delta p_{T} / p_{T} > (%)", ymin=_minResidualPt, ymax=_maxResidualPt)
+    Plot("ptres_vs_eta_Mean", scale=100, title="", xtitle="TP #eta (PCA to beamline)", ytitle="< #delta p_{T} / p_{T} > (%)", ymin=_minResidualPt, ymax=_maxResidualPt),
+    Plot("chi2mean_vs_pt", title="", xtitle="p_{T}", ytitle="< #chi^{2} / ndf >", ymin=[0, 0.5], ymax=[2, 2.5, 3, 5], xlog=True, fallback={"name": "chi2_vs_pt", "profileX": True}),
+    Plot("ptres_vs_pt_Mean", title="", xtitle="p_{T}", ytitle="< #delta p_{T}/p_{T} > (%)", scale=100, ymin=_minResidualPt, ymax=_maxResidualPt,xlog=True)
 ])
 _common = {"stat": True, "fit": True, "normalizeToUnitArea": True, "drawStyle": "hist", "drawCommand": "", "xmin": -10, "xmax": 10, "ylog": True, "ymin": 5e-5, "ymax": [0.01, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025], "ratioUncertainty": False}
 _pulls = PlotGroup("pulls", [

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -672,9 +672,12 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::ConcurrentBooker& 
 
   histograms.chi2_vs_eta.push_back( ibook.bookProfile("chi2mean","mean #chi^{2} vs #eta",nintEta,minEta,maxEta, 200, 0, 20, " " ));
   histograms.chi2_vs_phi.push_back( ibook.bookProfile("chi2mean_vs_phi","mean #chi^{2} vs #phi",nintPhi,minPhi,maxPhi, 200, 0, 20, " " ) );
+  histograms.chi2_vs_pt.push_back(  makeProfileIfLogX(ibook, useLogPt, "chi2mean_vs_pt","mean #chi^{2} vs p_{T}",nintPt, minPt, maxPt, 0, 20) );
 
   histograms.assoc_chi2_vs_eta.push_back    ( ibook.bookProfile("assoc_chi2mean",       "mean #chi^{2} vs #eta",            nintEta,minEta,maxEta, 200, 0., 20., " " ));
   histograms.assoc_chi2prob_vs_eta.push_back( ibook.bookProfile("assoc_chi2prob_vs_eta","mean #chi^{2} probability vs #eta",nintEta,minEta,maxEta, 100, 0.,  1., " " ));
+  histograms.assoc_chi2_vs_pt.push_back     ( makeProfileIfLogX(ibook, useLogPt, "assoc_chi2mean_vs_pt", "mean #chi^{2} vs p_{T}",             nintPt, minPt, maxPt,0., 20.) );
+  histograms.assoc_chi2prob_vs_pt.push_back ( makeProfileIfLogX(ibook, useLogPt, "assoc_chi2prob_vs_pt", "mean #chi^{2} probability vs p_{T}", nintPt, minPt, maxPt,0., 20.) );
 
   histograms.nhits_vs_eta.push_back( ibook.bookProfile("hits_eta","mean hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
   histograms.nPXBhits_vs_eta.push_back( ibook.bookProfile("PXBhits_vs_eta","mean # PXB its vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
@@ -1199,6 +1202,8 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(const Histogr
       histograms.h_assoc2chi2prob[count].fill(chi2prob);
       histograms.assoc_chi2_vs_eta[count].fill(eta,chi2);
       histograms.assoc_chi2prob_vs_eta[count].fill(eta,chi2prob);
+      histograms.assoc_chi2_vs_pt[count].fill(pt,chi2);
+      histograms.assoc_chi2prob_vs_pt[count].fill(pt,chi2prob);
       histograms.h_assoc2vertpos[count].fill(vertxy);
       histograms.h_assoc2zpos[count].fill(vertz);
       histograms.h_assoc2dr[count].fill(dR);
@@ -1349,6 +1354,10 @@ void MTVHistoProducerAlgoForTracker::fill_simAssociated_recoTrack_histos(const H
     const auto eta = getEta(track.eta());
     histograms.chi2_vs_eta[count].fill(eta, track.normalizedChi2());
     histograms.nhits_vs_eta[count].fill(eta, track.numberOfValidHits());
+
+    const auto pt = getPt(sqrt(track.momentum().perp2()));
+    histograms.chi2_vs_pt[count].fill(pt, track.normalizedChi2());
+
     const auto pxbHits = track.hitPattern().numberOfValidPixelBarrelHits();
     const auto pxfHits = track.hitPattern().numberOfValidPixelEndcapHits();
     const auto tibHits = track.hitPattern().numberOfValidStripTIBHits();


### PR DESCRIPTION
### PR description:
add chi2 plots vs pT to MTV
and enable resolution plots for the track building related collections

#### PR validation:
scram b distclean 
git cms-checkdeps -a -A
scram b -j 8
scram b runtests

runTheMatrix.py -l limited -i all --ibeos

#### if this PR is a backport please specify the original PR:
it is not, but I'll make a backport in 10_6_X