### PR TITLE
Running code-format for reconstruction-upgrade

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerClusterAlgoFactory.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerClusterAlgoFactory.h
@@ -1,12 +1,10 @@
 #ifndef RecoLocalCalo_HGCalRecProducers_HGCalLayerClusterAlgoFactory_H
 #define RecoLocalCalo_HGCalRecProducers_HGCalLayerClusterAlgoFactory_H
 
-
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h"
 
-typedef edmplugin::PluginFactory< HGCalClusteringAlgoBase * (const edm::ParameterSet&) > HGCalLayerClusterAlgoFactory;
+typedef edmplugin::PluginFactory<HGCalClusteringAlgoBase*(const edm::ParameterSet&)> HGCalLayerClusterAlgoFactory;
 
 #endif
-

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
@@ -14,7 +14,6 @@
 
 class HGCalLayerTiles {
 public:
-
   void fill(const std::vector<float>& x, const std::vector<float>& y) {
     auto cellsSize = x.size();
     for (unsigned int i = 0; i < cellsSize; ++i) {
@@ -60,7 +59,7 @@ public:
   const std::vector<int>& operator[](int globalBinId) const { return tiles_[globalBinId]; }
 
 private:
-  std::array<std::vector<int>, hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows  > tiles_;
+  std::array<std::vector<int>, hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows> tiles_;
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerBaseClass.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerBaseClass.h
@@ -4,19 +4,18 @@
 #include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
 
 namespace edm {
-        class Event;
-        class EventSetup;
-        class ParameterSet;
-}
+  class Event;
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
 class HGCalRecHitWorkerBaseClass {
-        public:
+public:
+  HGCalRecHitWorkerBaseClass(const edm::ParameterSet&){};
+  virtual ~HGCalRecHitWorkerBaseClass(){};
 
-                HGCalRecHitWorkerBaseClass(const edm::ParameterSet&) {};
-                virtual ~HGCalRecHitWorkerBaseClass() {};
-
-                virtual void set(const edm::EventSetup& es) = 0;
-                virtual bool run(const edm::Event& evt, const HGCUncalibratedRecHit& uncalibRH, HGCRecHitCollection & result) = 0;
+  virtual void set(const edm::EventSetup& es) = 0;
+  virtual bool run(const edm::Event& evt, const HGCUncalibratedRecHit& uncalibRH, HGCRecHitCollection& result) = 0;
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerFactory.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerFactory.h
@@ -3,6 +3,6 @@
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerBaseClass.h"
-typedef edmplugin::PluginFactory< HGCalRecHitWorkerBaseClass*(const edm::ParameterSet&) > HGCalRecHitWorkerFactory;
+typedef edmplugin::PluginFactory<HGCalRecHitWorkerBaseClass*(const edm::ParameterSet&)> HGCalRecHitWorkerFactory;
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerFactory.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerFactory.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerBaseClass.h"
-typedef edmplugin::PluginFactory< HGCalUncalibRecHitWorkerBaseClass*(const edm::ParameterSet&) > HGCalUncalibRecHitWorkerFactory;
+typedef edmplugin::PluginFactory<HGCalUncalibRecHitWorkerBaseClass*(const edm::ParameterSet&)>
+    HGCalUncalibRecHitWorkerFactory;
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalMultiClusterProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalMultiClusterProducer.cc
@@ -17,7 +17,6 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterEnergyCorrectorBase.h"
 
-
 #include "RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h"
@@ -29,33 +28,34 @@
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 
 class HGCalMultiClusterProducer : public edm::stream::EDProducer<> {
- public:
+public:
   HGCalMultiClusterProducer(const edm::ParameterSet&);
-  ~HGCalMultiClusterProducer() override { }
-  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  ~HGCalMultiClusterProducer() override {}
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
- private:
-    edm::EDGetTokenT<HGCRecHitCollection> hits_fh_token;
-    edm::EDGetTokenT<HGCRecHitCollection> hits_ee_token;
-    edm::EDGetTokenT<HGCRecHitCollection> hits_bh_token;
-    edm::EDGetTokenT<std::vector<reco::BasicCluster> > clusters_token;
-    edm::EDGetTokenT<std::vector<reco::BasicCluster> > clusters_sharing_token;
-    std::unique_ptr<HGCal3DClustering> multicluster_algo;
-    bool doSharing;
-    HGCalClusteringAlgoBase::VerbosityLevel verbosity;
+private:
+  edm::EDGetTokenT<HGCRecHitCollection> hits_fh_token;
+  edm::EDGetTokenT<HGCRecHitCollection> hits_ee_token;
+  edm::EDGetTokenT<HGCRecHitCollection> hits_bh_token;
+  edm::EDGetTokenT<std::vector<reco::BasicCluster>> clusters_token;
+  edm::EDGetTokenT<std::vector<reco::BasicCluster>> clusters_sharing_token;
+  std::unique_ptr<HGCal3DClustering> multicluster_algo;
+  bool doSharing;
+  HGCalClusteringAlgoBase::VerbosityLevel verbosity;
 };
 
 DEFINE_FWK_MODULE(HGCalMultiClusterProducer);
 
-HGCalMultiClusterProducer::HGCalMultiClusterProducer(const edm::ParameterSet &ps) :
-  doSharing(ps.getParameter<bool>("doSharing")),
-  verbosity((HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity",3)){
-  std::vector<double> multicluster_radii = ps.getParameter<std::vector<double> >("multiclusterRadii");
+HGCalMultiClusterProducer::HGCalMultiClusterProducer(const edm::ParameterSet& ps)
+    : doSharing(ps.getParameter<bool>("doSharing")),
+      verbosity((HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity", 3)) {
+  std::vector<double> multicluster_radii = ps.getParameter<std::vector<double>>("multiclusterRadii");
   double minClusters = ps.getParameter<unsigned>("minClusters");
-  clusters_token = consumes<std::vector<reco::BasicCluster> >(ps.getParameter<edm::InputTag>("HGCLayerClusters"));
-  clusters_sharing_token = consumes<std::vector<reco::BasicCluster> >(ps.getParameter<edm::InputTag>("HGCLayerClustersSharing"));
+  clusters_token = consumes<std::vector<reco::BasicCluster>>(ps.getParameter<edm::InputTag>("HGCLayerClusters"));
+  clusters_sharing_token =
+      consumes<std::vector<reco::BasicCluster>>(ps.getParameter<edm::InputTag>("HGCLayerClustersSharing"));
   hits_ee_token = consumes<HGCRecHitCollection>(ps.getParameter<edm::InputTag>("HGCEEInput"));
   hits_fh_token = consumes<HGCRecHitCollection>(ps.getParameter<edm::InputTag>("HGCFHInput"));
   hits_bh_token = consumes<HGCRecHitCollection>(ps.getParameter<edm::InputTag>("HGCBHInput"));
@@ -63,10 +63,9 @@ HGCalMultiClusterProducer::HGCalMultiClusterProducer(const edm::ParameterSet &ps
 
   multicluster_algo = std::make_unique<HGCal3DClustering>(ps, sumes, multicluster_radii, minClusters);
 
-  produces<std::vector<reco::HGCalMultiCluster> >();
-  produces<std::vector<reco::HGCalMultiCluster> >("sharing");
+  produces<std::vector<reco::HGCalMultiCluster>>();
+  produces<std::vector<reco::HGCalMultiCluster>>("sharing");
 }
-
 
 void HGCalMultiClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // hgcalMultiClusters
@@ -74,56 +73,53 @@ void HGCalMultiClusterProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<edm::InputTag>("HGCLayerClusters", edm::InputTag("hgcalLayerClusters"));
   desc.addUntracked<unsigned int>("verbosity", 3);
   desc.add<bool>("doSharing", false);
-  desc.add<edm::InputTag>("HGCEEInput", edm::InputTag("HGCalRecHit","HGCEERecHits"));
-  desc.add<edm::InputTag>("HGCFHInput", edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
-  desc.add<std::vector<double>>("multiclusterRadii", {
-    2.0,
-    5.0,
-    5.0,
-  });
-  desc.add<edm::InputTag>("HGCBHInput", edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
-  desc.add<edm::InputTag>("HGCLayerClustersSharing", edm::InputTag("hgcalLayerClusters","sharing"));
+  desc.add<edm::InputTag>("HGCEEInput", edm::InputTag("HGCalRecHit", "HGCEERecHits"));
+  desc.add<edm::InputTag>("HGCFHInput", edm::InputTag("HGCalRecHit", "HGCHEFRecHits"));
+  desc.add<std::vector<double>>("multiclusterRadii",
+                                {
+                                    2.0,
+                                    5.0,
+                                    5.0,
+                                });
+  desc.add<edm::InputTag>("HGCBHInput", edm::InputTag("HGCalRecHit", "HGCHEBRecHits"));
+  desc.add<edm::InputTag>("HGCLayerClustersSharing", edm::InputTag("hgcalLayerClusters", "sharing"));
   desc.add<unsigned int>("minClusters", 3);
   descriptions.add("hgcalMultiClusters", desc);
 }
 
 void HGCalMultiClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  edm::Handle<std::vector<reco::BasicCluster>> clusterHandle;
+  edm::Handle<std::vector<reco::BasicCluster>> clusterSharingHandle;
 
-    edm::Handle<std::vector<reco::BasicCluster> > clusterHandle;
-    edm::Handle<std::vector<reco::BasicCluster> > clusterSharingHandle;
+  evt.getByToken(clusters_token, clusterHandle);
+  if (doSharing)
+    evt.getByToken(clusters_sharing_token, clusterSharingHandle);
 
+  edm::PtrVector<reco::BasicCluster> clusterPtrs, clusterPtrsSharing;
+  for (unsigned i = 0; i < clusterHandle->size(); ++i) {
+    edm::Ptr<reco::BasicCluster> ptr(clusterHandle, i);
+    clusterPtrs.push_back(ptr);
+  }
 
-    evt.getByToken(clusters_token, clusterHandle);
-    if(doSharing) evt.getByToken(clusters_sharing_token, clusterSharingHandle);
-
-
-    edm::PtrVector<reco::BasicCluster> clusterPtrs, clusterPtrsSharing;
-    for( unsigned i = 0; i < clusterHandle->size(); ++i ) {
-        edm::Ptr<reco::BasicCluster> ptr(clusterHandle,i);
-        clusterPtrs.push_back(ptr);
+  if (doSharing) {
+    for (unsigned i = 0; i < clusterSharingHandle->size(); ++i) {
+      edm::Ptr<reco::BasicCluster> ptr(clusterSharingHandle, i);
+      clusterPtrsSharing.push_back(ptr);
     }
+  }
 
-    if(doSharing){
-        for( unsigned i = 0; i < clusterSharingHandle->size(); ++i ) {
-          edm::Ptr<reco::BasicCluster> ptr(clusterSharingHandle,i);
-          clusterPtrsSharing.push_back(ptr);
-        }
-    }
+  auto multiclusters = std::make_unique<std::vector<reco::HGCalMultiCluster>>();
+  auto multiclusters_sharing = std::make_unique<std::vector<reco::HGCalMultiCluster>>();
 
-    auto multiclusters = std::make_unique<std::vector<reco::HGCalMultiCluster>>();
-    auto multiclusters_sharing = std::make_unique<std::vector<reco::HGCalMultiCluster>>();
-
-
-    multicluster_algo->getEvent(evt);
-    multicluster_algo->getEventSetup(es);
+  multicluster_algo->getEvent(evt);
+  multicluster_algo->getEventSetup(es);
 
   *multiclusters = multicluster_algo->makeClusters(clusterPtrs);
-  if(doSharing)
+  if (doSharing)
     *multiclusters_sharing = multicluster_algo->makeClusters(clusterPtrsSharing);
   evt.put(std::move(multiclusters));
-  if(doSharing)
-    evt.put(std::move(multiclusters_sharing),"sharing");
-
+  if (doSharing)
+    evt.put(std::move(multiclusters_sharing), "sharing");
 }
 
 #endif


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction,upgrade.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/431//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


