### PR TITLE
Running code-format for simulation

### DIFF
--- a/DataFormats/EcalDigi/interface/EBDataFrame.h
+++ b/DataFormats/EcalDigi/interface/EBDataFrame.h
@@ -5,34 +5,29 @@
 #include "DataFormats/EcalDigi/interface/EcalDataFrame.h"
 #include <iosfwd>
 
-
-
 /** \class EBDataFrame
       
 */
-class EBDataFrame : public EcalDataFrame 
-{
- public:
-  typedef EBDetId key_type; ///< For the sorted collection
+class EBDataFrame : public EcalDataFrame {
+public:
+  typedef EBDetId key_type;  ///< For the sorted collection
   typedef EcalDataFrame Base;
 
   EBDataFrame() {}
   // EBDataFrame(DetId i) :  Base(i) {}
-  EBDataFrame(edm::DataFrame const & base) : Base(base) {}
-  EBDataFrame(EcalDataFrame const & base) : Base(base) {}
+  EBDataFrame(edm::DataFrame const& base) : Base(base) {}
+  EBDataFrame(EcalDataFrame const& base) : Base(base) {}
 
   /** estimator for a signal being a spike
    *  based on ratios between 4th, 5th and 6th sample
    */
   float spikeEstimator() const;
-    
+
   ~EBDataFrame() override {}
 
   key_type id() const { return Base::id(); }
-
 };
 
 std::ostream& operator<<(std::ostream&, const EBDataFrame&);
-
 
 #endif

--- a/DataFormats/EcalDigi/interface/EBSrFlag.h
+++ b/DataFormats/EcalDigi/interface/EBSrFlag.h
@@ -7,41 +7,40 @@
 #include "DataFormats/EcalDigi/interface/EcalSrFlag.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-
 /** This class holds a Selective Readout Flag (SRF) associated to an
  * ECAL barrel trigger tower.
  */
-class EBSrFlag: public EcalSrFlag {
+class EBSrFlag : public EcalSrFlag {
 public:
-  typedef EcalTrigTowerDetId key_type; //key for edm::SortedCollection
+  typedef EcalTrigTowerDetId key_type;  //key for edm::SortedCollection
 
 public:
   /** Default constructor.
    */
-  EBSrFlag() {}; 
-  
+  EBSrFlag(){};
+
   /** Constructor
    * @param tt trigger tower det id.
    * @param flag the srp flag, an integer in [0,7]. See constants SRF_xxx in EcalSrFlags class.
    */
-  EBSrFlag(const EcalTrigTowerDetId& tt, const int& flag): ttId_(tt){
+  EBSrFlag(const EcalTrigTowerDetId& tt, const int& flag) : ttId_(tt) {
     //SRP flag is coded on 3 bits:
-    if(flag<0  || flag>0x7) throw cms::Exception("InvalidValue", "srp flag greater than 0x7 or negative.");
-    flag_ = (unsigned char) flag;
+    if (flag < 0 || flag > 0x7)
+      throw cms::Exception("InvalidValue", "srp flag greater than 0x7 or negative.");
+    flag_ = (unsigned char)flag;
   }
-  
+
   /** For edm::SortedCollection.
    * @return det id of the trigger tower the flag is assigned to.
    */
-  const EcalTrigTowerDetId& id() const override { return ttId_;}
-  
+  const EcalTrigTowerDetId& id() const override { return ttId_; }
+
 private:
   /** trigger tower id
    */
-  EcalTrigTowerDetId ttId_;  
+  EcalTrigTowerDetId ttId_;
 };
-
 
 std::ostream& operator<<(std::ostream& s, const EBSrFlag& digi);
 
-#endif //EBSRFLAG_H not defined
+#endif  //EBSRFLAG_H not defined

--- a/DataFormats/EcalDigi/interface/EEDataFrame.h
+++ b/DataFormats/EcalDigi/interface/EEDataFrame.h
@@ -5,32 +5,25 @@
 #include "DataFormats/EcalDigi/interface/EcalDataFrame.h"
 #include <iosfwd>
 
-
-
 /** \class EEDataFrame
       
 */
 
-
-class EEDataFrame : public EcalDataFrame 
-{
- public:
-  typedef EEDetId key_type; ///< For the sorted collection
+class EEDataFrame : public EcalDataFrame {
+public:
+  typedef EEDetId key_type;  ///< For the sorted collection
   typedef EcalDataFrame Base;
 
   EEDataFrame() {}
   // EEDataFrame(DetId i) :  Base(i) {}
-  EEDataFrame(edm::DataFrame const & base) : Base(base) {}
-  EEDataFrame(EcalDataFrame const & base) : Base(base) {}
-    
+  EEDataFrame(edm::DataFrame const& base) : Base(base) {}
+  EEDataFrame(EcalDataFrame const& base) : Base(base) {}
+
   ~EEDataFrame() override {}
 
   key_type id() const { return Base::id(); }
-
 };
 
-
 std::ostream& operator<<(std::ostream&, const EEDataFrame&);
-
 
 #endif

--- a/DataFormats/EcalDigi/interface/EESrFlag.h
+++ b/DataFormats/EcalDigi/interface/EESrFlag.h
@@ -10,39 +10,38 @@
 /** This class holds a Selective Readout Flag (SRF) associated to an
  * ECAL endcap supercrystal.
  */
-class EESrFlag: public EcalSrFlag {
+class EESrFlag : public EcalSrFlag {
 public:
-
 public:
-  typedef EcalScDetId key_type; //key for edm::SortedCollection
+  typedef EcalScDetId key_type;  //key for edm::SortedCollection
 
 public:
   /** Default constructor.
    */
-  EESrFlag() {}; 
-  
+  EESrFlag(){};
+
   /** Constructor
    * @param sc supercrystal det id
    * @param flag the srp flag, an integer in [0,7]. See constants SRF_xxx in EcalSrFlags class.
    */
-  EESrFlag(const EcalScDetId& sc, const int& flag): scId_(sc){
+  EESrFlag(const EcalScDetId& sc, const int& flag) : scId_(sc) {
     //SRP flag is coded on 3 bits:
-    if(flag<0  || flag>0x7) throw cms::Exception("InvalidValue", "srp flag greater than 0x7 or negative.");
-    flag_ = (unsigned char) flag;
+    if (flag < 0 || flag > 0x7)
+      throw cms::Exception("InvalidValue", "srp flag greater than 0x7 or negative.");
+    flag_ = (unsigned char)flag;
   }
-  
+
   /** For edm::SortedCollection.
    * @return det id of the trigger tower the flag is assigned to.
    */
-  const EcalScDetId& id() const override { return scId_;}
-  
+  const EcalScDetId& id() const override { return scId_; }
+
 private:
   /** trigger tower id
    */
-  EcalScDetId scId_;  
+  EcalScDetId scId_;
 };
-
 
 std::ostream& operator<<(std::ostream& s, const EESrFlag& digi);
 
-#endif //EESRFLAG_H not defined
+#endif  //EESRFLAG_H not defined

--- a/DataFormats/EcalDigi/interface/ESDataFrame.h
+++ b/DataFormats/EcalDigi/interface/ESDataFrame.h
@@ -8,37 +8,34 @@
 #include <ostream>
 
 class ESDataFrame {
+public:
+  typedef ESDetId key_type;  ///< For the sorted collection
 
- public:
-
-  typedef ESDetId key_type; ///< For the sorted collection
-
-  ESDataFrame(); 
+  ESDataFrame();
   explicit ESDataFrame(const ESDetId& id);
 
-  ESDataFrame( const edm::DataFrame& df ) ;
-    
+  ESDataFrame(const edm::DataFrame& df);
+
   const ESDetId& id() const { return id_; }
-    
+
   int size() const { return size_; }
 
   const ESSample& operator[](int i) const { return data_[i]; }
   const ESSample& sample(int i) const { return data_[i]; }
-    
+
   void setSize(int size);
 
   void setSample(int i, const ESSample& sam) { data_[i] = sam; }
 
   static const int MAXSAMPLES = 3;
 
- private:
-
+private:
   ESDetId id_;
   int size_;
 
-  ESSample data_[MAXSAMPLES] ;
+  ESSample data_[MAXSAMPLES];
 };
-  
+
 std::ostream& operator<<(std::ostream&, const ESDataFrame&);
 
 #endif

--- a/DataFormats/EcalDigi/interface/ESSample.h
+++ b/DataFormats/EcalDigi/interface/ESSample.h
@@ -5,13 +5,11 @@
 #include <boost/cstdint.hpp>
 
 class ESSample {
-
- public:
-
+public:
   ESSample() { theSample = 0; }
   ESSample(int16_t data) { theSample = data; }
   ESSample(int adc);
-    
+
   /// get the raw word
   int16_t raw() const { return theSample; }
   /// get the ADC sample (singed 16 bits)
@@ -19,10 +17,8 @@ class ESSample {
   /// for streaming
   int16_t operator()() { return theSample; }
 
- private:
-
+private:
   int16_t theSample;
-
 };
 
 std::ostream& operator<<(std::ostream&, const ESSample&);

--- a/DataFormats/EcalDigi/interface/EcalDataFrame.h
+++ b/DataFormats/EcalDigi/interface/EcalDataFrame.h
@@ -6,26 +6,26 @@
 #include "DataFormats/Common/interface/DataFrame.h"
 
 #define EcalMgpaBitwiseGain12 1
-#define EcalMgpaBitwiseGain6  2
-#define EcalMgpaBitwiseGain1  3
-#define EcalMgpaBitwiseGain0  0
+#define EcalMgpaBitwiseGain6 2
+#define EcalMgpaBitwiseGain1 3
+#define EcalMgpaBitwiseGain0 0
 
 /** \class EcalDataFrame
       
 */
 class EcalDataFrame {
- public:
+public:
   EcalDataFrame() {}
   // EcalDataFrame(DetId i) :  m_data(i) {}
-  EcalDataFrame(edm::DataFrame const & iframe) : m_data(iframe){} 
+  EcalDataFrame(edm::DataFrame const& iframe) : m_data(iframe) {}
 
-  virtual ~EcalDataFrame() {} 
+  virtual ~EcalDataFrame() {}
 
-  DetId id() const { return m_data.id();}
-    
-  int size() const { return m_data.size();}
+  DetId id() const { return m_data.id(); }
 
-  EcalMGPASample operator[](int i) const { return m_data[i];}
+  int size() const { return m_data.size(); }
+
+  EcalMGPASample operator[](int i) const { return m_data[i]; }
   EcalMGPASample sample(int i) const { return m_data[i]; }
 
   // get the leading sample (the first non saturated sample)
@@ -35,25 +35,23 @@ class EcalDataFrame {
   // .. return -1 in case of no saturation
   int lastUnsaturatedSample() const;
   // just the boolean method
-  bool isSaturated() const { return ( lastUnsaturatedSample() != -1 ); }
-    
-  // FIXME (shall we throw??)
-  void setSize(int){}
-  // void setPresamples(int ps);
-  void setSample(int i, EcalMGPASample sam) { m_data[i]=sam; }
+  bool isSaturated() const { return (lastUnsaturatedSample() != -1); }
 
-  bool hasSwitchToGain6() const; 
-  bool hasSwitchToGain1() const; 
-  
+  // FIXME (shall we throw??)
+  void setSize(int) {}
+  // void setPresamples(int ps);
+  void setSample(int i, EcalMGPASample sam) { m_data[i] = sam; }
+
+  bool hasSwitchToGain6() const;
+  bool hasSwitchToGain1() const;
+
   static constexpr int MAXSAMPLES = 10;
 
-  edm::DataFrame const & frame() const { return m_data;}
-  edm::DataFrame & frame() { return m_data;}
+  edm::DataFrame const& frame() const { return m_data; }
+  edm::DataFrame& frame() { return m_data; }
 
- private:
- 
+private:
   edm::DataFrame m_data;
-  
 };
-  
+
 #endif

--- a/DataFormats/EcalDigi/interface/EcalFEMSample.h
+++ b/DataFormats/EcalDigi/interface/EcalFEMSample.h
@@ -12,26 +12,24 @@
  */
 
 class EcalFEMSample {
- public:
-  EcalFEMSample() { theSample=0; }
-  EcalFEMSample(uint16_t data) { theSample=data; }
+public:
+  EcalFEMSample() { theSample = 0; }
+  EcalFEMSample(uint16_t data) { theSample = data; }
   EcalFEMSample(int adc, int gainId);
-    
+
   /// get the raw word
   uint16_t raw() const { return theSample; }
   /// get the ADC sample (12 bits)
-  int adc() const { return theSample&0xFFF; }
+  int adc() const { return theSample & 0xFFF; }
   /// get the gainId (2 bits)
-  int gainId() const { return (theSample>>12)&0x3; }
+  int gainId() const { return (theSample >> 12) & 0x3; }
   /// for streaming
   uint16_t operator()() { return theSample; }
 
- private:
+private:
   uint16_t theSample;
 };
 
 std::ostream& operator<<(std::ostream&, const EcalFEMSample&);
-  
-
 
 #endif

--- a/DataFormats/EcalDigi/interface/EcalMGPASample.h
+++ b/DataFormats/EcalDigi/interface/EcalMGPASample.h
@@ -6,16 +6,13 @@
 
 namespace ecalMGPA {
   typedef uint16_t sample_type;
- 
-  /// get the ADC sample (12 bits)
-  constexpr int adc(sample_type sample) { return sample&0xFFF; }
-  /// get the gainId (2 bits)
-  constexpr int gainId(sample_type sample) { return (sample>>12)&0x3; }
-  constexpr sample_type pack(int adc, int gainId) {
-    return (adc&0xFFF) | ((gainId&0x3)<<12);
-  }
-}
 
+  /// get the ADC sample (12 bits)
+  constexpr int adc(sample_type sample) { return sample & 0xFFF; }
+  /// get the gainId (2 bits)
+  constexpr int gainId(sample_type sample) { return (sample >> 12) & 0x3; }
+  constexpr sample_type pack(int adc, int gainId) { return (adc & 0xFFF) | ((gainId & 0x3) << 12); }
+}  // namespace ecalMGPA
 
 /** \class EcalMGPASample
  *  Simple container packer/unpacker for a single sample from teh MGPA electronics
@@ -23,27 +20,25 @@ namespace ecalMGPA {
  *
  */
 class EcalMGPASample {
- public:
-  EcalMGPASample() { theSample=0; }
-  EcalMGPASample(uint16_t data) { theSample=data; }
+public:
+  EcalMGPASample() { theSample = 0; }
+  EcalMGPASample(uint16_t data) { theSample = data; }
   EcalMGPASample(int adc, int gainId);
-    
+
   /// get the raw word
   uint16_t raw() const { return theSample; }
   /// get the ADC sample (12 bits)
-  int adc() const { return theSample&0xFFF; }
+  int adc() const { return theSample & 0xFFF; }
   /// get the gainId (2 bits)
-  int gainId() const { return (theSample>>12)&0x3; }
+  int gainId() const { return (theSample >> 12) & 0x3; }
   /// for streaming
   uint16_t operator()() const { return theSample; }
-  operator uint16_t () const { return theSample; }
+  operator uint16_t() const { return theSample; }
 
- private:
+private:
   uint16_t theSample;
 };
 
 std::ostream& operator<<(std::ostream&, const EcalMGPASample&);
-  
-
 
 #endif

--- a/DataFormats/EcalDigi/interface/EcalMatacqDigi.h
+++ b/DataFormats/EcalDigi/interface/EcalMatacqDigi.h
@@ -24,15 +24,13 @@ public:
   static const int MAXSAMPLES = 2560;
 
 public:
-  typedef int key_type; //matacq channel id used as key for edm::SortedCollection
+  typedef int key_type;  //matacq channel id used as key for edm::SortedCollection
 
 public:
   /** Default constructor.
    */
-  EcalMatacqDigi(): chId_(-1), ts_(0.), tTrigS_(999.), version_(-1){
-    init();
-  }
-  
+  EcalMatacqDigi() : chId_(-1), ts_(0.), tTrigS_(999.), version_(-1) { init(); }
+
   /** Constructor
    * @param samples adc time samples
    * @param chId Matacq channel ID
@@ -40,14 +38,15 @@ public:
    * @param version Matacq raw data private version
    * @param tTrigg time position of the trigger in seconds
    */
-  EcalMatacqDigi(const std::vector<Short_t>& samples, const int& chId, const double& ts,
-		 const short& version=-1, const double& tTrig=999.)
-    : chId_(chId), data_(samples), ts_(ts), tTrigS_(tTrig),
-      version_(version){
+  EcalMatacqDigi(const std::vector<Short_t>& samples,
+                 const int& chId,
+                 const double& ts,
+                 const short& version = -1,
+                 const double& tTrig = 999.)
+      : chId_(chId), data_(samples), ts_(ts), tTrigS_(tTrig), version_(version) {
     init();
   };
-  
-  
+
   /** Gets amplitude in ADC count of time sample i. i between 0 and size()-1.
    * Note: Amplitude is pedestal subtracted at acquisition time.
    */
@@ -56,76 +55,76 @@ public:
   /** Gets amplitude in Volt of time sample i. i between 0 and size()-1.
    * Note: Amplitude is pedestal subtracted at acquisition time.
    */
-  const float amplitudeV(const int& i) const { return data_[i]*lsb_;}
+  const float amplitudeV(const int& i) const { return data_[i] * lsb_; }
 
   /** Gets Matacq electronics channel id
    */
-  int chId() const{ return chId_;}
+  int chId() const { return chId_; }
 
   /** For edm::SortedCollection.
    * @return as key the matacq channel id
    */
-  int id() const { return chId_;}
+  int id() const { return chId_; }
 
-//   /** Sets Matacq electronics channel id
-//    */
-//   void chId(int newChId){ chId_ = newChId;}
-  
+  //   /** Sets Matacq electronics channel id
+  //    */
+  //   void chId(int newChId){ chId_ = newChId;}
+
   /** Number of time samples
    */
-  int size() const { return data_.size();}
-  
+  int size() const { return data_.size(); }
+
   /** Swaps samples with the passed samples. For package internal use.
    * @param samples new time samples in unit used in raw data
    * (a priori ADC count).
    */
-  void swap(std::vector<short>& samples){ std::swap(data_, samples);}
+  void swap(std::vector<short>& samples) { std::swap(data_, samples); }
 
   void swap(EcalMatacqDigi& a);
-  
-//   /** Gets time of sample i. i between 0 and size()-1.
-//    */
-//   float t(int i) const { return ts()*i;}
-  
+
+  //   /** Gets time of sample i. i between 0 and size()-1.
+  //    */
+  //   float t(int i) const { return ts()*i;}
+
   /** Gets sampling time in seconds
    */
-  float ts() const { return ts_;}
+  float ts() const { return ts_; }
 
-//   /** Sets sampling time period
-//    * @param ts sampling time period in seconds
-//    */
-//   void ts(double newTs){
-//     ts_ = newTs;
-//   }
+  //   /** Sets sampling time period
+  //    * @param ts sampling time period in seconds
+  //    */
+  //   void ts(double newTs){
+  //     ts_ = newTs;
+  //   }
 
   /** Gets time of trigger in seconds.
    * @return (t_trig-t_0), with t_trig the trigger time and t_0 the first.
    * Returns 999 if not available.
    * sample time.
    */
-  float tTrig() const { return tTrigS_;}
+  float tTrig() const { return tTrigS_; }
 
-//   /** Sets trigger time position
-//    * @param tTrigS (t_trig-t_0) in seconds, with t_trig the time of MATACQ
-//    * trigger and t_0 the time of the first sample of each MATACQ channel.
-//    */
-//   void tTrig(double tTrigS){
-//     tTrigS_ = tTrigS;
-//   }
+  //   /** Sets trigger time position
+  //    * @param tTrigS (t_trig-t_0) in seconds, with t_trig the time of MATACQ
+  //    * trigger and t_0 the time of the first sample of each MATACQ channel.
+  //    */
+  //   void tTrig(double tTrigS){
+  //     tTrigS_ = tTrigS;
+  //   }
 
   /** version of raw data format, the digis originate from.
    * @return raw data format version, -1 if not available.
    */
-  short version() const {return version_;}
+  short version() const { return version_; }
 
-//   /** Sets the raw data format, the digi is issued from.
-//    * @param version internal matacq raw data format version
-//    */
-//   void version(short version){
-//     version_ = version;
-//   }
+  //   /** Sets the raw data format, the digi is issued from.
+  //    * @param version internal matacq raw data format version
+  //    */
+  //   void version(short version){
+  //     version_ = version;
+  //   }
 
-#if (ECAL_MATACQ_DIGI_VERS>=2)
+#if (ECAL_MATACQ_DIGI_VERS >= 2)
   /** Gets the bunch crossing id field contents.
    * @return BX id
    */
@@ -140,12 +139,12 @@ public:
    * @return l1a
    */
   int l1a() const { return l1a_; }
-  
+
   /** Sets level one accept counter of the event
    * @param value new value
    */
   void l1a(int value) { l1a_ = value; }
-  
+
   /** Gets type of test trigger
    * @return triggerType
    */
@@ -161,13 +160,21 @@ public:
    * second and microseconds since the EPOCH as defined in POSIX.1.
    * See time() standard c function and gettimeofday UNIX function.
    */
-  timeval timeStamp() const { timeval value; value.tv_sec = tv_sec_; value.tv_usec = tv_usec_; return value; }
+  timeval timeStamp() const {
+    timeval value;
+    value.tv_sec = tv_sec_;
+    value.tv_usec = tv_usec_;
+    return value;
+  }
 
   /** Sets the matcq event timestmap
    * @param value new value
    */
-  void timeStamp(timeval value) { tv_sec_ = value.tv_sec; tv_usec_ = value.tv_usec; }
-  
+  void timeStamp(timeval value) {
+    tv_sec_ = value.tv_sec;
+    tv_usec_ = value.tv_usec;
+  }
+
   /** Gets the LHC orbit ID of the event
    * Available only for Matacq data format version >=3 and for P5 data.
    * @return the LHC orbit ID
@@ -178,13 +185,13 @@ public:
    * @param value new value
    */
   void orbitId(UInt_t value) { orbitId_ = value; }
-  
+
   /** Gets the Trig Rec value (see Matacq documentation)
    * Available only for Matacq data format version >=3.
    * @return the Trig Rec value
    */
   int trigRec() const { return trigRec_; }
-  
+
   /** Sets the Trig Rec value (see Matacq documentation)
    * @param value new value
    */
@@ -204,13 +211,12 @@ public:
    * @return verniers
    */
   std::vector<int> vernier() const { return vernier_; }
-  
+
   /** Sets verniers
    * @param value new value
    */
   void vernier(const std::vector<int>& value) { vernier_ = value; }
 
-  
   /** Gets "Delay A" setting of laser delay box in ns.delayA
    * @return delayA
    */
@@ -225,17 +231,17 @@ public:
    * @return emtcDelay
    */
   int emtcDelay() const { return emtcDelay_; }
-  
+
   /** Sets the WTE-to-Laser delay of EMTC in LHC clock unit.
    * @param value new value
    */
   void emtcDelay(int value) { emtcDelay_ = value; }
-  
+
   /** Gets the EMTC laser phase in 1/8th LHC clock unit.
    * @return emtcPhase
    */
   int emtcPhase() const { return emtcPhase_; }
-  
+
   /** Sets the EMTC laser phase in 1/8th LHC clock unit.
    * @param value new value
    */
@@ -252,28 +258,28 @@ public:
    * @param value new value
    */
   void attenuation_dB(int value) { attenuation_dB_ = value; }
-  
+
   /** Gets the laser power setting in percents
    * (set with the linear attenuator),
    * @return laserPower
    */
   int laserPower() const { return laserPower_; }
-  
+
   /** Sets  the laser power setting in percents
    * (set with the linear attenuator),
    * @param value new value
    */
   void laserPower(int value) { laserPower_ = value; }
 
-  void init(){
-#if (ECAL_MATACQ_DIGI_VERS>=2)
+  void init() {
+#if (ECAL_MATACQ_DIGI_VERS >= 2)
     bxId_ = -1;
     l1a_ = -1;
     triggerType_ = -1;
     orbitId_ = -1;
     trigRec_ = -1;
     postTrig_ = -1;
-    vernier_ = std::vector<Int_t>(4,-1);
+    vernier_ = std::vector<Int_t>(4, -1);
     delayA_ = -1;
     emtcDelay_ = -1;
     emtcPhase_ = -1;
@@ -288,7 +294,7 @@ private:
   /** Electronic channel id
    */
   int chId_;
-  
+
   /** ADC count of time samples
    */
   std::vector<Short_t> data_;
@@ -296,7 +302,7 @@ private:
   /** Frequency mode. 1->1GHz sampling, 2->2GHz sampling
    */
   int freq;
-  
+
   /**Sampling period in seconds. In priniciple 1ns or 0.5ns
    */
   double ts_;
@@ -309,7 +315,7 @@ private:
    */
   short version_;
 
-#if (ECAL_MATACQ_DIGI_VERS>=2)
+#if (ECAL_MATACQ_DIGI_VERS >= 2)
   /** Type of test trigger
    * @return triggerType
    */
@@ -327,15 +333,15 @@ private:
   /** Event id. Actually LV1 ID.
    */
   Int_t l1a_;
-  
+
   /* LHC orbit ID
    */
   Int_t orbitId_;
-  
+
   /** Trig Rec value (see Matacq documentation)
    */
   Short_t trigRec_;
-  
+
   /** Posttrig value (see Matacq documentation)
    */
   Short_t postTrig_;
@@ -368,9 +374,7 @@ private:
   Long64_t tv_usec_;
 
 #endif
-  
 };
-
 
 std::ostream& operator<<(std::ostream& s, const EcalMatacqDigi& digi);
 

--- a/DataFormats/EcalDigi/interface/EcalPnDiodeDigi.h
+++ b/DataFormats/EcalDigi/interface/EcalPnDiodeDigi.h
@@ -6,38 +6,34 @@
 #include "DataFormats/EcalDetId/interface/EcalPnDiodeDetId.h"
 #include "DataFormats/EcalDigi/interface/EcalFEMSample.h"
 
-
-
 /** \class EcalPnDiodeDigi
       
 */
 
 class EcalPnDiodeDigi {
- public:
-  typedef EcalPnDiodeDetId key_type; ///< For the sorted collection
+public:
+  typedef EcalPnDiodeDetId key_type;  ///< For the sorted collection
 
-  EcalPnDiodeDigi(); // for persistence
+  EcalPnDiodeDigi();  // for persistence
   explicit EcalPnDiodeDigi(const EcalPnDiodeDetId& id);
-    
+
   const EcalPnDiodeDetId& id() const { return id_; }
   int size() const { return size_; }
-    
+
   const EcalFEMSample& operator[](int i) const { return data_[i]; }
   const EcalFEMSample& sample(int i) const { return data_[i]; }
-    
+
   void setSize(int size);
-  void setSample(int i, const EcalFEMSample& sam) { data_[i]=sam; }
-    
+  void setSample(int i, const EcalFEMSample& sam) { data_[i] = sam; }
+
   static const int MAXSAMPLES = 50;
- private:
+
+private:
   EcalPnDiodeDetId id_;
   int size_;
   std::vector<EcalFEMSample> data_;
 };
 
-
 std::ostream& operator<<(std::ostream& s, const EcalPnDiodeDigi& digi);
-
-
 
 #endif

--- a/DataFormats/EcalDigi/interface/EcalPseudoStripInputDigi.h
+++ b/DataFormats/EcalDigi/interface/EcalPseudoStripInputDigi.h
@@ -6,54 +6,47 @@
 #include "DataFormats/EcalDetId/interface/EcalTriggerElectronicsId.h"
 #include "DataFormats/EcalDigi/interface/EcalPseudoStripInputSample.h"
 
-
-
 /** \class EcalPseudoStripInputDigi
       
 */
 
 class EcalPseudoStripInputDigi {
- public:
-  typedef EcalTriggerElectronicsId key_type; ///< For the sorted collection
+public:
+  typedef EcalTriggerElectronicsId key_type;  ///< For the sorted collection
 
-  EcalPseudoStripInputDigi(); // for persistence
+  EcalPseudoStripInputDigi();  // for persistence
   explicit EcalPseudoStripInputDigi(const EcalTriggerElectronicsId& id);
-    
+
   const EcalTriggerElectronicsId& id() const { return id_; }
   int size() const { return size_; }
-    
+
   const EcalPseudoStripInputSample& operator[](int i) const { return data_[i]; }
   const EcalPseudoStripInputSample& sample(int i) const { return data_[i]; }
-    
+
   void setSize(int size);
-  void setSample(int i, const EcalPseudoStripInputSample& sam) { data_[i]=sam; }
+  void setSample(int i, const EcalPseudoStripInputSample& sam) { data_[i] = sam; }
   void setSampleValue(int i, uint16_t value) { data_[i].setValue(value); }
-    
+
   static const int MAXSAMPLES = 20;
 
   /// get the encoded/compressed Et of interesting sample
-  int pseudoStripInput() const; 
-  
-  
+  int pseudoStripInput() const;
+
   /// get the fine-grain bit of interesting sample
-  bool fineGrain() const; 
-  
+  bool fineGrain() const;
+
   /// True if debug mode (# of samples > 1)
   bool isDebug() const;
 
   /// Gets the interesting sample
   int sampleOfInterest() const;
-  
- private:
-  
+
+private:
   EcalTriggerElectronicsId id_;
   int size_;
   std::vector<EcalPseudoStripInputSample> data_;
 };
 
-
 std::ostream& operator<<(std::ostream& s, const EcalPseudoStripInputDigi& digi);
-
-
 
 #endif

--- a/DataFormats/EcalDigi/interface/EcalPseudoStripInputSample.h
+++ b/DataFormats/EcalDigi/interface/EcalPseudoStripInputSample.h
@@ -4,35 +4,33 @@
 #include <boost/cstdint.hpp>
 #include <ostream>
 
-
-
 /** \class EcalPseudoStripInputSample
       
 
 */
 
 class EcalPseudoStripInputSample {
- public:
+public:
   EcalPseudoStripInputSample();
   EcalPseudoStripInputSample(uint16_t data);
   EcalPseudoStripInputSample(int pseudoStripInput, bool finegrain);
 
   ///Set data
-  void setValue(uint16_t data){ theSample = data;}
+  void setValue(uint16_t data) { theSample = data; }
   /// get the raw word
   uint16_t raw() const { return theSample; }
-    /// get the pseudoStrip Input amplitude (12 bits)
-  int pseudoStripInput() const { return theSample&0xFFF; }
-  /// get the fine-grain bit (1 bit, the 13-th) 
-  bool fineGrain() const { return (theSample&0x1000)!=0; }
-    
+  /// get the pseudoStrip Input amplitude (12 bits)
+  int pseudoStripInput() const { return theSample & 0xFFF; }
+  /// get the fine-grain bit (1 bit, the 13-th)
+  bool fineGrain() const { return (theSample & 0x1000) != 0; }
+
   /// for streaming
   uint16_t operator()() { return theSample; }
 
- private:
+private:
   uint16_t theSample;
 };
 
 std::ostream& operator<<(std::ostream& s, const EcalPseudoStripInputSample& samp);
-  
+
 #endif

--- a/DataFormats/EcalDigi/interface/EcalSrFlag.h
+++ b/DataFormats/EcalDigi/interface/EcalSrFlag.h
@@ -31,55 +31,48 @@ public:
 public:
   /** Destructor
    */
-  virtual ~EcalSrFlag() {};    
+  virtual ~EcalSrFlag(){};
 
   /** Gets the Det Id the flag is associated to.
    * @return the det id of the readout unit (a barrel TT or a SC).
    */
-  virtual const DetId& id() const=0;
+  virtual const DetId& id() const = 0;
 
   /** SR flag value. See SRF_XXX constants.
    * @return the flag value
    */
-  int value() const{ return flag_;}
+  int value() const { return flag_; }
 
   /** Set the SR flag value. See SRF_XXX constants.
    * @param flag new flag value. Must be between 0 and 7.
    */
-  void setValue(const int& flag) { flag_ = (unsigned char) flag; }
+  void setValue(const int& flag) { flag_ = (unsigned char)flag; }
 
   /** Cast to int: same as value().
    * @return the SR flag value
    */
-  operator int() const{
-    return flag_;
-  }
+  operator int() const { return flag_; }
 
   /** Return a human readable flag name from its integer value.
    * @param flag the flag value
    * @return the human readable string (which can contain space).
    */
-  static std::string flagName(const int& flag){
-    return (flag==(flag&0x7))?srfNames[flag]:"Invalid";
-  }
+  static std::string flagName(const int& flag) { return (flag == (flag & 0x7)) ? srfNames[flag] : "Invalid"; }
 
   /** Return a human readable flag name from the flag value.
    * @return the human readable string (which can contain space).
    */
-  std::string flagName() const{
-    return flagName(flag_);
-  }
-  
+  std::string flagName() const { return flagName(flag_); }
+
 protected:
   /** The SRP flag.
    */
   unsigned char flag_;
-  
+
 private:
   /** Human readable flag value names
    */
   static const char* const srfNames[];
 };
-  
-#endif //ECALSRFLAG not defined
 
+#endif  //ECALSRFLAG not defined

--- a/DataFormats/EcalDigi/interface/EcalTimeDigi.h
+++ b/DataFormats/EcalDigi/interface/EcalTimeDigi.h
@@ -6,45 +6,40 @@
 #include "DataFormats/DetId/interface/DetId.h"
 
 class EcalTimeDigi {
- public:
-  typedef DetId key_type; ///< For the sorted collection
+public:
+  typedef DetId key_type;  ///< For the sorted collection
 
-  EcalTimeDigi(); // for persistence
+  EcalTimeDigi();  // for persistence
   explicit EcalTimeDigi(const DetId& id);
-  
+
   void swap(EcalTimeDigi& rh) {
-    std::swap(id_,rh.id_);
-    std::swap(size_,rh.size_);
-    std::swap(data_,rh.data_);
+    std::swap(id_, rh.id_);
+    std::swap(size_, rh.size_);
+    std::swap(data_, rh.data_);
   }
-  
+
   const DetId& id() const { return id_; }
   int size() const { return size_; }
-    
+
   const float& operator[](unsigned int i) const { return data_[i]; }
   const float& sample(unsigned int i) const { return data_[i]; }
-    
+
   void setSize(unsigned int size);
-  void setSample(unsigned int i, const float sam) { data_[i]=sam; }
-  void setSampleOfInterest(int i) { sampleOfInterest_=i; }
-  
+  void setSample(unsigned int i, const float sam) { data_[i] = sam; }
+  void setSampleOfInterest(int i) { sampleOfInterest_ = i; }
+
   /// Gets the BX==0 sample. If =-1 then it means that only OOT hits are present
   int sampleOfInterest() const { return sampleOfInterest_; }
 
-private:  
+private:
   DetId id_;
   unsigned int size_;
   int sampleOfInterest_;
   std::vector<float> data_;
 };
 
-
-inline void swap(EcalTimeDigi& lh, EcalTimeDigi& rh) {
-  lh.swap(rh);
-}
+inline void swap(EcalTimeDigi& lh, EcalTimeDigi& rh) { lh.swap(rh); }
 
 std::ostream& operator<<(std::ostream& s, const EcalTimeDigi& digi);
-
-
 
 #endif

--- a/DataFormats/EcalDigi/interface/EcalTrigPrimCompactColl.h
+++ b/DataFormats/EcalDigi/interface/EcalTrigPrimCompactColl.h
@@ -25,24 +25,25 @@ author: Ph. Gras CEA/IRFU Saclay
 */
 
 class EcalTrigPrimCompactColl {
-
 private:
   static const int nPhiBins = 72;
   static const int nEtaBins = 56;
-  static const int nBins = nPhiBins*nEtaBins;
+  static const int nBins = nPhiBins * nEtaBins;
 
 private:
-  static size_t index(int ieta, int iphi){
-    size_t r = unsigned(((ieta<0) ? (ieta+28) : (ieta+27))*nPhiBins + (iphi -1));
-    if(r >= (unsigned)nBins) throw cms::Exception("Invalid argument") << "Trigger tower index (" << ieta << "," << iphi << ") are out of range";
+  static size_t index(int ieta, int iphi) {
+    size_t r = unsigned(((ieta < 0) ? (ieta + 28) : (ieta + 27)) * nPhiBins + (iphi - 1));
+    if (r >= (unsigned)nBins)
+      throw cms::Exception("Invalid argument")
+          << "Trigger tower index (" << ieta << "," << iphi << ") are out of range";
     return r;
   }
-  
+
 public:
-  EcalTrigPrimCompactColl(): formatVers_(0), data_(nBins){};
-  
+  EcalTrigPrimCompactColl() : formatVers_(0), data_(nBins){};
+
   ///Set data
-  void setValue(int ieta, int iphi, uint16_t sample){ data_[index(ieta, iphi)] = sample;}
+  void setValue(int ieta, int iphi, uint16_t sample) { data_[index(ieta, iphi)] = sample; }
 
   //@{
   /// get the raw word
@@ -52,19 +53,19 @@ public:
 
   //@{
   /// get the encoded/compressed Et (8 bits)
-  int compressedEt(int ieta, int iphi) const { return raw(ieta, iphi)&0xFF; }
+  int compressedEt(int ieta, int iphi) const { return raw(ieta, iphi) & 0xFF; }
   int compressedEt(const EcalTrigTowerDetId& ttId) const { return compressedEt(ttId.ieta(), ttId.iphi()); }
   //@}
 
   //@{
-  /// get the fine-grain bit (1 bit) 
-  bool fineGrain(int ieta, int iphi) const { return (raw(ieta, iphi)&0x100)!=0; }
+  /// get the fine-grain bit (1 bit)
+  bool fineGrain(int ieta, int iphi) const { return (raw(ieta, iphi) & 0x100) != 0; }
   bool fineGrain(const EcalTrigTowerDetId& ttId) const { return fineGrain(ttId.ieta(), ttId.iphi()); }
   //@}
 
   //@{
   /// get the Trigger tower Flag (3 bits)
-  int ttFlag(int ieta, int iphi) const { return (raw(ieta, iphi)>>9)&0x7; }
+  int ttFlag(int ieta, int iphi) const { return (raw(ieta, iphi) >> 9) & 0x7; }
   int ttFlag(const EcalTrigTowerDetId& ttId) const { return ttFlag(ttId.ieta(), ttId.iphi()); }
   //@}
 
@@ -72,10 +73,10 @@ public:
   /// Gets the "strip fine grain veto bit" (sFGVB)  used as L1A spike detection
   /// @return 0 spike like pattern
   ///         1 EM shower like pattern
-  int sFGVB(int ieta, int iphi) const { return (raw(ieta, iphi) >>12) & 0x1; }
+  int sFGVB(int ieta, int iphi) const { return (raw(ieta, iphi) >> 12) & 0x1; }
   int sFGVB(const EcalTrigTowerDetId& ttId) const { return sFGVB(ttId.ieta(), ttId.iphi()); }
   //@}
-  
+
   //@{
   /// Gets the "strip fine grain veto bit" (sFGVB)  used as L1A spike detection
   /// Deprecated. Use instead sFGVB() method. Indeed the name of the method being missleading,
@@ -85,12 +86,12 @@ public:
   int l1aSpike(int ieta, int iphi) const { return sFGVB(ieta, iphi); }
   int l1aSpike(const EcalTrigTowerDetId& ttId) const { return sFGVB(ttId); }
   //@}
-  
+
   void toEcalTrigPrimDigiCollection(EcalTrigPrimDigiCollection& dest) const;
-  
- private:
+
+private:
   int16_t formatVers_;
   std::vector<uint16_t> data_;
 };
 
-#endif //ECALTRIGPRIMCOMPACTCOLL_H not defined
+#endif  //ECALTRIGPRIMCOMPACTCOLL_H not defined

--- a/DataFormats/EcalDigi/interface/EcalTriggerPrimitiveDigi.h
+++ b/DataFormats/EcalDigi/interface/EcalTriggerPrimitiveDigi.h
@@ -7,8 +7,6 @@
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 #include "DataFormats/EcalDigi/interface/EcalTriggerPrimitiveSample.h"
 
-
-
 /** \class EcalTriggerPrimitiveDigi
 
 see also EcalTrigPrimCompactColl.
@@ -16,43 +14,38 @@ see also EcalTrigPrimCompactColl.
 */
 
 class EcalTriggerPrimitiveDigi {
- public:
-  typedef EcalTrigTowerDetId key_type; ///< For the sorted collection
-  
+public:
+  typedef EcalTrigTowerDetId key_type;  ///< For the sorted collection
 
-  EcalTriggerPrimitiveDigi(); // for persistence
+  EcalTriggerPrimitiveDigi();  // for persistence
   explicit EcalTriggerPrimitiveDigi(const EcalTrigTowerDetId& id);
-  
-  
 
   void swap(EcalTriggerPrimitiveDigi& rh) {
-    std::swap(id_,rh.id_);
-    std::swap(size_,rh.size_);
-    std::swap(data_,rh.data_);
+    std::swap(id_, rh.id_);
+    std::swap(size_, rh.size_);
+    std::swap(data_, rh.data_);
   }
-  
-  
+
   const EcalTrigTowerDetId& id() const { return id_; }
   int size() const { return size_; }
-    
+
   const EcalTriggerPrimitiveSample& operator[](int i) const { return data_[i]; }
   const EcalTriggerPrimitiveSample& sample(int i) const { return data_[i]; }
-    
+
   void setSize(int size);
-  void setSample(int i, const EcalTriggerPrimitiveSample& sam) { data_[i]=sam;}
+  void setSample(int i, const EcalTriggerPrimitiveSample& sam) { data_[i] = sam; }
   void setSampleValue(int i, uint16_t value) { data_[i].setValue(value); }
-    
+
   static const int MAXSAMPLES = 20;
 
   /// get the encoded/compressed Et of interesting sample
-  int compressedEt() const; 
-  
-  
+  int compressedEt() const;
+
   /// get the fine-grain bit of interesting sample
-  bool fineGrain() const; 
-  
+  bool fineGrain() const;
+
   /// get the Trigger tower Flag of interesting sample
-  int ttFlag() const; 
+  int ttFlag() const;
 
   /// Gets the "strip fine grain veto bit" (sFGVB) used as L1A spike detection
   /// @return 0 spike like pattern
@@ -64,7 +57,7 @@ class EcalTriggerPrimitiveDigi {
   /// @return 0 spike like pattern
   ///         1 EM shower like pattern
   int l1aSpike() const { return sFGVB(); }
-  
+
   /// True if debug mode (# of samples > 1)
   bool isDebug() const;
 
@@ -77,13 +70,8 @@ private:
   std::vector<EcalTriggerPrimitiveSample> data_;
 };
 
-
-inline void swap(EcalTriggerPrimitiveDigi& lh, EcalTriggerPrimitiveDigi& rh) {
-  lh.swap(rh);
-}
+inline void swap(EcalTriggerPrimitiveDigi& lh, EcalTriggerPrimitiveDigi& rh) { lh.swap(rh); }
 
 std::ostream& operator<<(std::ostream& s, const EcalTriggerPrimitiveDigi& digi);
-
-
 
 #endif

--- a/DataFormats/EcalDigi/interface/EcalTriggerPrimitiveSample.h
+++ b/DataFormats/EcalDigi/interface/EcalTriggerPrimitiveSample.h
@@ -4,52 +4,47 @@
 #include <boost/cstdint.hpp>
 #include <ostream>
 
-
-
 /** \class EcalTriggerPrimitiveSample
       
 
 */
 
 class EcalTriggerPrimitiveSample {
- public:
+public:
   EcalTriggerPrimitiveSample();
   EcalTriggerPrimitiveSample(uint16_t data);
   EcalTriggerPrimitiveSample(int encodedEt, bool finegrain, int triggerFlag);
   EcalTriggerPrimitiveSample(int encodedEt, bool finegrain, int stripFGVB, int triggerFlag);
 
   ///Set data
-  void setValue(uint16_t data){ theSample = data;}
+  void setValue(uint16_t data) { theSample = data; }
   /// get the raw word
   uint16_t raw() const { return theSample; }
   /// get the encoded/compressed Et (8 bits)
-  int compressedEt() const { return theSample&0xFF; }
-  /// get the fine-grain bit (1 bit) 
-  bool fineGrain() const { return (theSample&0x100)!=0; }
+  int compressedEt() const { return theSample & 0xFF; }
+  /// get the fine-grain bit (1 bit)
+  bool fineGrain() const { return (theSample & 0x100) != 0; }
   /// get the Trigger tower Flag (3 bits)
-  int ttFlag() const { return (theSample>>9)&0x7; }
+  int ttFlag() const { return (theSample >> 9) & 0x7; }
 
   /// Gets the L1A spike detection flag. Beware the flag is inverted.
   /// Deprecated, use instead sFGVB() method, whose name is less missleading
   /// @return 0 spike like pattern
   ///         1 EM shower like pattern
-  int l1aSpike() const { return (theSample >>12) & 0x1; }
+  int l1aSpike() const { return (theSample >> 12) & 0x1; }
 
   /// Gets the "strip fine grain veto bit" (sFGVB) used as L1A spike detection
   /// @return 0 spike like pattern
   ///         1 EM shower like pattern
-  int sFGVB() const { return (theSample >>12) & 0x1; }
-  
+  int sFGVB() const { return (theSample >> 12) & 0x1; }
+
   /// for streaming
   uint16_t operator()() { return theSample; }
 
- private:
+private:
   uint16_t theSample;
 };
 
 std::ostream& operator<<(std::ostream& s, const EcalTriggerPrimitiveSample& samp);
-  
-
-
 
 #endif

--- a/DataFormats/EcalDigi/src/EBDataFrame.cc
+++ b/DataFormats/EcalDigi/src/EBDataFrame.cc
@@ -1,34 +1,34 @@
 #include "DataFormats/EcalDigi/interface/EBDataFrame.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include<iostream>
+#include <iostream>
 
-float EBDataFrame::spikeEstimator() const
-{
-        if ( size() != 10 ) {
-                edm::LogError("InvalidNumberOfSamples") << "This method only applies to signals sampled 10 times ("
-                        << size() << " samples found)";
-                return 10.;
-        }
-        // skip faulty channels
-        if ( sample(5).adc() == 0 ) return 10.;
-        size_t imax = 0;
-        int maxAdc = 0;
-        for ( int i = 0; i < size(); ++i ) {
-                if ( sample(i).adc() > maxAdc ) {
-                        imax = i;
-                        maxAdc = sample(i).adc();
-                }
-        }
-        // skip early signals
-        if ( imax < 4 ) return 10.;
-        float ped = 1./3. * (sample(0).adc() + sample(1).adc() + sample(2).adc());
-        return 0.18*(sample(4).adc()-ped)/(sample(5).adc()-ped) + (sample(6).adc()-ped)/(sample(5).adc()-ped);
+float EBDataFrame::spikeEstimator() const {
+  if (size() != 10) {
+    edm::LogError("InvalidNumberOfSamples")
+        << "This method only applies to signals sampled 10 times (" << size() << " samples found)";
+    return 10.;
+  }
+  // skip faulty channels
+  if (sample(5).adc() == 0)
+    return 10.;
+  size_t imax = 0;
+  int maxAdc = 0;
+  for (int i = 0; i < size(); ++i) {
+    if (sample(i).adc() > maxAdc) {
+      imax = i;
+      maxAdc = sample(i).adc();
+    }
+  }
+  // skip early signals
+  if (imax < 4)
+    return 10.;
+  float ped = 1. / 3. * (sample(0).adc() + sample(1).adc() + sample(2).adc());
+  return 0.18 * (sample(4).adc() - ped) / (sample(5).adc() - ped) + (sample(6).adc() - ped) / (sample(5).adc() - ped);
 }
-
 
 std::ostream& operator<<(std::ostream& s, const EBDataFrame& digi) {
   s << digi.id() << " " << digi.size() << " samples " << std::endl;
-  for (int i=0; i<digi.size(); i++) 
+  for (int i = 0; i < digi.size(); i++)
     s << "  " << digi[i] << std::endl;
   return s;
 }

--- a/DataFormats/EcalDigi/src/EBSrFlag.cc
+++ b/DataFormats/EcalDigi/src/EBSrFlag.cc
@@ -3,8 +3,6 @@
 #include "DataFormats/EcalDigi/interface/EBSrFlag.h"
 
 std::ostream& operator<<(std::ostream& s, const EBSrFlag& digi) {
-  s << digi.id() << " "<< digi.flagName() << "(0x"
-    << digi.value() << ")";
+  s << digi.id() << " " << digi.flagName() << "(0x" << digi.value() << ")";
   return s;
 }
-

--- a/DataFormats/EcalDigi/src/EEDataFrame.cc
+++ b/DataFormats/EcalDigi/src/EEDataFrame.cc
@@ -1,10 +1,9 @@
 #include "DataFormats/EcalDigi/interface/EEDataFrame.h"
-#include<iostream>
+#include <iostream>
 
 std::ostream& operator<<(std::ostream& s, const EEDataFrame& digi) {
   s << digi.id() << " " << digi.size() << " samples " << std::endl;
-  for (int i=0; i<digi.size(); i++) 
+  for (int i = 0; i < digi.size(); i++)
     s << "  " << digi.sample(i) << std::endl;
   return s;
 }
-

--- a/DataFormats/EcalDigi/src/EESrFlag.cc
+++ b/DataFormats/EcalDigi/src/EESrFlag.cc
@@ -3,8 +3,6 @@
 #include "DataFormats/EcalDigi/interface/EESrFlag.h"
 
 std::ostream& operator<<(std::ostream& s, const EESrFlag& digi) {
-  s << digi.id() << " "<< digi.flagName() << "(0x"
-    << digi.value() << ")";
+  s << digi.id() << " " << digi.flagName() << "(0x" << digi.value() << ")";
   return s;
 }
-

--- a/DataFormats/EcalDigi/src/ESDataFrame.cc
+++ b/DataFormats/EcalDigi/src/ESDataFrame.cc
@@ -1,39 +1,31 @@
 #include "DataFormats/EcalDigi/interface/ESDataFrame.h"
 
-ESDataFrame::ESDataFrame() : id_(0), 
-			     size_(0)
-{
-}
+ESDataFrame::ESDataFrame() : id_(0), size_(0) {}
 
-ESDataFrame::ESDataFrame(const ESDetId& id) : 
-  id_(id), 
-  size_(0)
-{
-}
+ESDataFrame::ESDataFrame(const ESDetId& id) : id_(id), size_(0) {}
 
-ESDataFrame::ESDataFrame(const edm::DataFrame& df) : 
-   id_   ( df.id()    )
-{
-   setSize( df.size() ) ;
-   for( int i ( 0 ) ; i != size_ ; ++i )
-   { 
-      static const int offset ( 65536 ) ; // for uint16 to int16
-      static const uint16_t limit  ( 32767 ) ;
-      const int dint ( limit < df[i] ? (int)df[i] - offset : df[i] ) ;
-      data_[i] = ESSample( (int16_t)dint ) ;
-   }
+ESDataFrame::ESDataFrame(const edm::DataFrame& df) : id_(df.id()) {
+  setSize(df.size());
+  for (int i(0); i != size_; ++i) {
+    static const int offset(65536);  // for uint16 to int16
+    static const uint16_t limit(32767);
+    const int dint(limit < df[i] ? (int)df[i] - offset : df[i]);
+    data_[i] = ESSample((int16_t)dint);
+  }
 }
 
 void ESDataFrame::setSize(int size) {
-  if (size > MAXSAMPLES) size_ = MAXSAMPLES;
-  else if (size <= 0) size_=0;
-  else size_ = size;
+  if (size > MAXSAMPLES)
+    size_ = MAXSAMPLES;
+  else if (size <= 0)
+    size_ = 0;
+  else
+    size_ = size;
 }
 
 std::ostream& operator<<(std::ostream& s, const ESDataFrame& digi) {
-   s << digi.id() << " " << digi.size() 
-     << " samples " << std::endl;
-   for (int i=0; i<digi.size(); i++) 
+  s << digi.id() << " " << digi.size() << " samples " << std::endl;
+  for (int i = 0; i < digi.size(); i++)
     s << "  " << digi.sample(i) << std::endl;
   return s;
 }

--- a/DataFormats/EcalDigi/src/ESSample.cc
+++ b/DataFormats/EcalDigi/src/ESSample.cc
@@ -1,10 +1,8 @@
 #include "DataFormats/EcalDigi/interface/ESSample.h"
 
-ESSample::ESSample(int adc) {
-  theSample = (int16_t)adc;
-}
+ESSample::ESSample(int adc) { theSample = (int16_t)adc; }
 
 std::ostream& operator<<(std::ostream& s, const ESSample& samp) {
-  s << "ADC = " << samp.adc() ;
+  s << "ADC = " << samp.adc();
   return s;
 }

--- a/DataFormats/EcalDigi/src/EcalDataFrame.cc
+++ b/DataFormats/EcalDigi/src/EcalDataFrame.cc
@@ -1,34 +1,31 @@
 #include "DataFormats/EcalDigi/interface/EcalDataFrame.h"
 
-int EcalDataFrame::lastUnsaturatedSample() const
-{
-        int cnt = 0;
-        for ( size_t i = 3; i < m_data.size(); ++i ) {
-                cnt = 0;
-                for ( size_t j = i; j < (i + 5) && j < m_data.size(); ++j ) {
-                        if ( ((EcalMGPASample)m_data[j]).gainId() == EcalMgpaBitwiseGain0 ) ++cnt;
-                }
-                if ( cnt == 5 ) return i-1; // the last unsaturated sample
-        }
-        return -1; // no saturation found
+int EcalDataFrame::lastUnsaturatedSample() const {
+  int cnt = 0;
+  for (size_t i = 3; i < m_data.size(); ++i) {
+    cnt = 0;
+    for (size_t j = i; j < (i + 5) && j < m_data.size(); ++j) {
+      if (((EcalMGPASample)m_data[j]).gainId() == EcalMgpaBitwiseGain0)
+        ++cnt;
+    }
+    if (cnt == 5)
+      return i - 1;  // the last unsaturated sample
+  }
+  return -1;  // no saturation found
 }
 
-
-bool EcalDataFrame:: hasSwitchToGain6() const
-{
-  for(unsigned int u=0; u<m_data.size(); u++) 
-    {
-      if ( ( static_cast<EcalMGPASample>(m_data[u]) ).gainId() == EcalMgpaBitwiseGain6 ) return true;
-    }
+bool EcalDataFrame::hasSwitchToGain6() const {
+  for (unsigned int u = 0; u < m_data.size(); u++) {
+    if ((static_cast<EcalMGPASample>(m_data[u])).gainId() == EcalMgpaBitwiseGain6)
+      return true;
+  }
   return false;
 }
 
-
-bool EcalDataFrame:: hasSwitchToGain1() const
-{
-  for(unsigned int u=0; u<m_data.size(); u++) 
-    {
-      if ( ( static_cast<EcalMGPASample>(m_data[u]) ).gainId() == EcalMgpaBitwiseGain1 ) return true;
-    }
+bool EcalDataFrame::hasSwitchToGain1() const {
+  for (unsigned int u = 0; u < m_data.size(); u++) {
+    if ((static_cast<EcalMGPASample>(m_data[u])).gainId() == EcalMgpaBitwiseGain1)
+      return true;
+  }
   return false;
 }

--- a/DataFormats/EcalDigi/src/EcalEBTriggerPrimitiveSample.cc
+++ b/DataFormats/EcalDigi/src/EcalEBTriggerPrimitiveSample.cc
@@ -1,29 +1,18 @@
 #include "DataFormats/EcalDigi/interface/EcalEBTriggerPrimitiveSample.h"
 
+EcalEBTriggerPrimitiveSample::EcalEBTriggerPrimitiveSample() : theSample(0) {}
+EcalEBTriggerPrimitiveSample::EcalEBTriggerPrimitiveSample(uint16_t data) : theSample(data) {}
 
-
-EcalEBTriggerPrimitiveSample::EcalEBTriggerPrimitiveSample() : theSample(0) { }
-EcalEBTriggerPrimitiveSample::EcalEBTriggerPrimitiveSample(uint16_t data) : theSample(data) { }
-
-EcalEBTriggerPrimitiveSample::EcalEBTriggerPrimitiveSample(int encodedEt, bool isASpike) { 
-  theSample=(encodedEt&0x3FF)| ((isASpike)?(0x400):(0));
+EcalEBTriggerPrimitiveSample::EcalEBTriggerPrimitiveSample(int encodedEt, bool isASpike) {
+  theSample = (encodedEt & 0x3FF) | ((isASpike) ? (0x400) : (0));
 }
 
-
-EcalEBTriggerPrimitiveSample::EcalEBTriggerPrimitiveSample(int encodedEt, bool isASpike, int timing) { 
-  theSample=(encodedEt&0x3FF)| ((isASpike)?(0x400):(0)) | timing<<11;
+EcalEBTriggerPrimitiveSample::EcalEBTriggerPrimitiveSample(int encodedEt, bool isASpike, int timing) {
+  theSample = (encodedEt & 0x3FF) | ((isASpike) ? (0x400) : (0)) | timing << 11;
 }
 
-
-EcalEBTriggerPrimitiveSample::EcalEBTriggerPrimitiveSample(int encodedEt) { 
-  theSample=encodedEt&0x3FF;
-}
-
-
+EcalEBTriggerPrimitiveSample::EcalEBTriggerPrimitiveSample(int encodedEt) { theSample = encodedEt & 0x3FF; }
 
 std::ostream& operator<<(std::ostream& s, const EcalEBTriggerPrimitiveSample& samp) {
-  return s << "ET=" << samp.encodedEt() << ", isASpike=" << samp.l1aSpike()<< " timing= " << samp.time() ; 
-
+  return s << "ET=" << samp.encodedEt() << ", isASpike=" << samp.l1aSpike() << " timing= " << samp.time();
 }
-
-

--- a/DataFormats/EcalDigi/src/EcalFEMSample.cc
+++ b/DataFormats/EcalDigi/src/EcalFEMSample.cc
@@ -1,8 +1,6 @@
 #include "DataFormats/EcalDigi/interface/EcalFEMSample.h"
 
-EcalFEMSample::EcalFEMSample(int adc, int gainId) {
-  theSample=(adc&0xFFF) | ((gainId&0x3)<<12);
-}
+EcalFEMSample::EcalFEMSample(int adc, int gainId) { theSample = (adc & 0xFFF) | ((gainId & 0x3) << 12); }
 
 std::ostream& operator<<(std::ostream& s, const EcalFEMSample& samp) {
   s << "ADC=" << samp.adc() << ", gainId=" << samp.gainId();

--- a/DataFormats/EcalDigi/src/EcalMGPASample.cc
+++ b/DataFormats/EcalDigi/src/EcalMGPASample.cc
@@ -1,9 +1,7 @@
 #include "DataFormats/EcalDigi/interface/EcalMGPASample.h"
-#include<iostream>
+#include <iostream>
 
-EcalMGPASample::EcalMGPASample(int adc,int gainId) {
-  theSample=(adc&0xFFF) | ((gainId&0x3)<<12);
-}
+EcalMGPASample::EcalMGPASample(int adc, int gainId) { theSample = (adc & 0xFFF) | ((gainId & 0x3) << 12); }
 
 std::ostream& operator<<(std::ostream& s, const EcalMGPASample& samp) {
   s << "ADC=" << samp.adc() << ", gainId=" << samp.gainId();

--- a/DataFormats/EcalDigi/src/EcalMatacqDigi.cc
+++ b/DataFormats/EcalDigi/src/EcalMatacqDigi.cc
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-const double EcalMatacqDigi::lsb_ = 0.25e-3;// in Volt
+const double EcalMatacqDigi::lsb_ = 0.25e-3;  // in Volt
 
 #if 0
 void EcalMatacqDigi::setSize(const int& size) {
@@ -12,22 +12,22 @@ void EcalMatacqDigi::setSize(const int& size) {
   else size_=size;
 }
 #endif
-  
+
 std::ostream& operator<<(std::ostream& s, const EcalMatacqDigi& digi) {
   s << digi.size() << " samples " << std::endl;
-  for (int i=0; i<digi.size(); i++){
+  for (int i = 0; i < digi.size(); i++) {
     s << "  " << digi.amplitudeV(i) << std::endl;
   }
   return s;
 }
 
-void EcalMatacqDigi::swap(EcalMatacqDigi& a){
+void EcalMatacqDigi::swap(EcalMatacqDigi& a) {
   data_.swap(a.data_);
   std::swap(chId_, a.chId_);
   std::swap(ts_, a.ts_);
   std::swap(tTrigS_, a.tTrigS_);
   std::swap(version_, a.version_);
-#if (ECAL_MATACQ_DIGI_VERS>=2)
+#if (ECAL_MATACQ_DIGI_VERS >= 2)
   std::swap(bxId_, a.bxId_);
   std::swap(l1a_, a.l1a_);
   std::swap(triggerType_, a.triggerType_);

--- a/DataFormats/EcalDigi/src/EcalPnDiodeDigi.cc
+++ b/DataFormats/EcalDigi/src/EcalPnDiodeDigi.cc
@@ -1,22 +1,20 @@
 #include "DataFormats/EcalDigi/interface/EcalPnDiodeDigi.h"
 
+EcalPnDiodeDigi::EcalPnDiodeDigi() : size_(0), data_(MAXSAMPLES) {}
+EcalPnDiodeDigi::EcalPnDiodeDigi(const EcalPnDiodeDetId& id) : id_(id), size_(0), data_(MAXSAMPLES) {}
 
-EcalPnDiodeDigi::EcalPnDiodeDigi() : size_(0), data_(MAXSAMPLES) {
-}
-EcalPnDiodeDigi::EcalPnDiodeDigi(const EcalPnDiodeDetId& id) : id_(id),
-										   size_(0), data_(MAXSAMPLES) {
-}
-  
 void EcalPnDiodeDigi::setSize(int size) {
-  if (size<0) size_=0;
-  else if (size>MAXSAMPLES) size_=MAXSAMPLES;
-  else size_=size;
+  if (size < 0)
+    size_ = 0;
+  else if (size > MAXSAMPLES)
+    size_ = MAXSAMPLES;
+  else
+    size_ = size;
 }
 
-  
 std::ostream& operator<<(std::ostream& s, const EcalPnDiodeDigi& digi) {
   s << digi.id() << " " << digi.size() << " samples " << std::endl;
-  for (int i=0; i<digi.size(); i++) 
+  for (int i = 0; i < digi.size(); i++)
     s << "  " << digi.sample(i) << std::endl;
   return s;
 }

--- a/DataFormats/EcalDigi/src/EcalPseudoStripInputDigi.cc
+++ b/DataFormats/EcalDigi/src/EcalPseudoStripInputDigi.cc
@@ -1,36 +1,30 @@
 #include "DataFormats/EcalDigi/interface/EcalPseudoStripInputDigi.h"
 
+EcalPseudoStripInputDigi::EcalPseudoStripInputDigi() : size_(0), data_(MAXSAMPLES) {}
 
-EcalPseudoStripInputDigi::EcalPseudoStripInputDigi() : size_(0), data_(MAXSAMPLES) {
-}
+EcalPseudoStripInputDigi::EcalPseudoStripInputDigi(const EcalTriggerElectronicsId& id)
+    : id_(id), size_(0), data_(MAXSAMPLES) {}
 
-EcalPseudoStripInputDigi::EcalPseudoStripInputDigi(const EcalTriggerElectronicsId& id) : id_(id),
-										   size_(0), data_(MAXSAMPLES) {
-}
-
-int EcalPseudoStripInputDigi::sampleOfInterest() const
-{
+int EcalPseudoStripInputDigi::sampleOfInterest() const {
   if (size_ == 1)
     return 0;
   else if (size_ == 5)
     return 2;
   else
     return -1;
-} 
+}
 
 /// get the pseudoStrip input of interesting sample
-int EcalPseudoStripInputDigi::pseudoStripInput() const 
-{
+int EcalPseudoStripInputDigi::pseudoStripInput() const {
   int sample = sampleOfInterest();
   if (sample != -1)
     return data_[sample].pseudoStripInput();
   else
     return -1;
 }
-  
+
 /// get the fine-grain bit of interesting sample
-bool EcalPseudoStripInputDigi::fineGrain() const 
-{ 
+bool EcalPseudoStripInputDigi::fineGrain() const {
   int sample = sampleOfInterest();
   if (sample != -1)
     return data_[sample].fineGrain();
@@ -38,8 +32,7 @@ bool EcalPseudoStripInputDigi::fineGrain() const
     return false;
 }
 
-bool EcalPseudoStripInputDigi::isDebug() const
-{
+bool EcalPseudoStripInputDigi::isDebug() const {
   if (size_ == 1)
     return false;
   else if (size_ > 1)
@@ -48,16 +41,17 @@ bool EcalPseudoStripInputDigi::isDebug() const
 }
 
 void EcalPseudoStripInputDigi::setSize(int size) {
-  if (size<0) size_=0;
-  else if (size>MAXSAMPLES) size_=MAXSAMPLES;
-  else size_=size;
+  if (size < 0)
+    size_ = 0;
+  else if (size > MAXSAMPLES)
+    size_ = MAXSAMPLES;
+  else
+    size_ = size;
 }
 
-  
 std::ostream& operator<<(std::ostream& s, const EcalPseudoStripInputDigi& digi) {
   s << digi.id() << " " << digi.size() << " samples " << std::endl;
-  for (int i=0; i<digi.size(); i++) 
+  for (int i = 0; i < digi.size(); i++)
     s << "  " << digi.sample(i) << std::endl;
   return s;
 }
-

--- a/DataFormats/EcalDigi/src/EcalPseudoStripInputSample.cc
+++ b/DataFormats/EcalDigi/src/EcalPseudoStripInputSample.cc
@@ -1,13 +1,11 @@
 #include "DataFormats/EcalDigi/interface/EcalPseudoStripInputSample.h"
 
+EcalPseudoStripInputSample::EcalPseudoStripInputSample() : theSample(0) {}
+EcalPseudoStripInputSample::EcalPseudoStripInputSample(uint16_t data) : theSample(data) {}
 
-EcalPseudoStripInputSample::EcalPseudoStripInputSample() : theSample(0) { }
-EcalPseudoStripInputSample::EcalPseudoStripInputSample(uint16_t data) : theSample(data) { }
-
-EcalPseudoStripInputSample::EcalPseudoStripInputSample(int pseudoStripInput, bool fineGrain) { 
-    theSample=(pseudoStripInput&0xFFF)|((fineGrain)?(0x1000):(0));
+EcalPseudoStripInputSample::EcalPseudoStripInputSample(int pseudoStripInput, bool fineGrain) {
+  theSample = (pseudoStripInput & 0xFFF) | ((fineGrain) ? (0x1000) : (0));
 }
-
 
 std::ostream& operator<<(std::ostream& s, const EcalPseudoStripInputSample& samp) {
   return s << "PSInput=" << samp.pseudoStripInput() << ", FG=" << samp.fineGrain();

--- a/DataFormats/EcalDigi/src/EcalSrFlag.cc
+++ b/DataFormats/EcalDigi/src/EcalSrFlag.cc
@@ -1,14 +1,12 @@
 #include "DataFormats/EcalDigi/interface/EcalSrFlag.h"
 
 const char* const EcalSrFlag::srfNames[] = {
-  "Suppress",           //SRF_SUPPRESS
-  "Zs1",                //SRF_ZS1
-  "Zs2",                //SRF_ZS2
-  "Full Readout",       //SRF_FULL      
-  "Forced Suppress",    //SRF_FORCED_MASK|SRF_SUPPRESS  
-  "Forced Zs1",	  //SRF_FORCED_MASK|SRF_ZS1	   
-  "Forced Zs2",	  //SRF_FORCED_MASK|SRF_ZS2	   
-  "Forced Full Readout" //SRF_FORCED_MASK|SRF_FULL      
+    "Suppress",            //SRF_SUPPRESS
+    "Zs1",                 //SRF_ZS1
+    "Zs2",                 //SRF_ZS2
+    "Full Readout",        //SRF_FULL
+    "Forced Suppress",     //SRF_FORCED_MASK|SRF_SUPPRESS
+    "Forced Zs1",          //SRF_FORCED_MASK|SRF_ZS1
+    "Forced Zs2",          //SRF_FORCED_MASK|SRF_ZS2
+    "Forced Full Readout"  //SRF_FORCED_MASK|SRF_FULL
 };
-
-

--- a/DataFormats/EcalDigi/src/EcalTimeDigi.cc
+++ b/DataFormats/EcalDigi/src/EcalTimeDigi.cc
@@ -4,19 +4,14 @@ namespace {
   constexpr unsigned int MAXSAMPLES = 10;
 }
 
-EcalTimeDigi::EcalTimeDigi() : id_(0), size_(0), sampleOfInterest_(-1), data_(MAXSAMPLES)  {
-}
+EcalTimeDigi::EcalTimeDigi() : id_(0), size_(0), sampleOfInterest_(-1), data_(MAXSAMPLES) {}
 
-EcalTimeDigi::EcalTimeDigi(const DetId& id) : id_(id),
-					      size_(0), sampleOfInterest_(-1), data_(MAXSAMPLES) {
-}
+EcalTimeDigi::EcalTimeDigi(const DetId& id) : id_(id), size_(0), sampleOfInterest_(-1), data_(MAXSAMPLES) {}
 
 void EcalTimeDigi::setSize(unsigned int size) {
-  if (size>MAXSAMPLES) size_=MAXSAMPLES;
-  else size_=size;
+  if (size > MAXSAMPLES)
+    size_ = MAXSAMPLES;
+  else
+    size_ = size;
   data_.resize(size_);
 }
-
-
-
-

--- a/DataFormats/EcalDigi/src/EcalTrigPrimCompactColl.cc
+++ b/DataFormats/EcalDigi/src/EcalTrigPrimCompactColl.cc
@@ -1,22 +1,22 @@
 #include "DataFormats/EcalDigi/interface/EcalTrigPrimCompactColl.h"
 
-void EcalTrigPrimCompactColl::toEcalTrigPrimDigiCollection(EcalTrigPrimDigiCollection& dest) const{
+void EcalTrigPrimCompactColl::toEcalTrigPrimDigiCollection(EcalTrigPrimDigiCollection& dest) const {
   const int nTtEtaBins = 56;
   const int nTtPhiBins = 72;
   EcalTrigPrimDigiCollection tpColl;
-  tpColl.reserve(nTtEtaBins*nTtPhiBins);
-  
-  for(int zside = -1; zside <= 1; zside +=2){
-    for(int iabseta = 1; iabseta <= nTtEtaBins/2; ++iabseta){
+  tpColl.reserve(nTtEtaBins * nTtPhiBins);
+
+  for (int zside = -1; zside <= 1; zside += 2) {
+    for (int iabseta = 1; iabseta <= nTtEtaBins / 2; ++iabseta) {
       EcalSubdetector subdet = (iabseta <= 17) ? EcalBarrel : EcalEndcap;
-      for(int iphi = 1; iphi <= 72; ++iphi){
-	const EcalTrigTowerDetId ttId(zside, subdet, iabseta, iphi, EcalTrigTowerDetId::SUBDETIJMODE);
-	EcalTriggerPrimitiveDigi tp(ttId);
-	const int rawTp = raw(ttId.ieta(), ttId.iphi());
-	const EcalTriggerPrimitiveSample tps(rawTp);
-	tp.setSize(1);
-	tp.setSample(0, tps);
-	tpColl.push_back(tp);
+      for (int iphi = 1; iphi <= 72; ++iphi) {
+        const EcalTrigTowerDetId ttId(zside, subdet, iabseta, iphi, EcalTrigTowerDetId::SUBDETIJMODE);
+        EcalTriggerPrimitiveDigi tp(ttId);
+        const int rawTp = raw(ttId.ieta(), ttId.iphi());
+        const EcalTriggerPrimitiveSample tps(rawTp);
+        tp.setSize(1);
+        tp.setSample(0, tps);
+        tpColl.push_back(tp);
       }
     }
   }

--- a/DataFormats/EcalDigi/src/EcalTriggerPrimitiveDigi.cc
+++ b/DataFormats/EcalDigi/src/EcalTriggerPrimitiveDigi.cc
@@ -1,38 +1,31 @@
 #include "DataFormats/EcalDigi/interface/EcalTriggerPrimitiveDigi.h"
 #include <iostream>
 
-EcalTriggerPrimitiveDigi::EcalTriggerPrimitiveDigi() : size_(0), data_(MAXSAMPLES) {
-}
+EcalTriggerPrimitiveDigi::EcalTriggerPrimitiveDigi() : size_(0), data_(MAXSAMPLES) {}
 
-EcalTriggerPrimitiveDigi::EcalTriggerPrimitiveDigi(const EcalTrigTowerDetId& id) : id_(id),
-size_(0), data_(MAXSAMPLES) {
-}
+EcalTriggerPrimitiveDigi::EcalTriggerPrimitiveDigi(const EcalTrigTowerDetId& id)
+    : id_(id), size_(0), data_(MAXSAMPLES) {}
 
-
-
-int EcalTriggerPrimitiveDigi::sampleOfInterest() const
-{
+int EcalTriggerPrimitiveDigi::sampleOfInterest() const {
   if (size_ == 1)
     return 0;
   else if (size_ == 5)
     return 2;
   else
     return -1;
-} 
+}
 
 /// get the encoded/compressed Et of interesting sample
-int EcalTriggerPrimitiveDigi::compressedEt() const 
-{
+int EcalTriggerPrimitiveDigi::compressedEt() const {
   int sample = sampleOfInterest();
   if (sample != -1)
     return data_[sample].compressedEt();
   else
     return -1;
 }
-  
+
 /// get the fine-grain bit of interesting sample
-bool EcalTriggerPrimitiveDigi::fineGrain() const 
-{ 
+bool EcalTriggerPrimitiveDigi::fineGrain() const {
   int sample = sampleOfInterest();
   if (sample != -1)
     return data_[sample].fineGrain();
@@ -40,17 +33,15 @@ bool EcalTriggerPrimitiveDigi::fineGrain() const
     return false;
 }
 /// get the Trigger tower Flag of interesting sample
-int EcalTriggerPrimitiveDigi::ttFlag() const 
-{ 
+int EcalTriggerPrimitiveDigi::ttFlag() const {
   int sample = sampleOfInterest();
   if (sample != -1)
     return data_[sample].ttFlag();
   else
     return -1;
-} 
+}
 
-int EcalTriggerPrimitiveDigi::sFGVB() const
-{
+int EcalTriggerPrimitiveDigi::sFGVB() const {
   int sample = sampleOfInterest();
   if (sample != -1)
     return data_[sample].l1aSpike();
@@ -58,8 +49,7 @@ int EcalTriggerPrimitiveDigi::sFGVB() const
     return -1;
 }
 
-bool EcalTriggerPrimitiveDigi::isDebug() const
-{
+bool EcalTriggerPrimitiveDigi::isDebug() const {
   if (size_ == 1)
     return false;
   else if (size_ > 1)
@@ -68,16 +58,17 @@ bool EcalTriggerPrimitiveDigi::isDebug() const
 }
 
 void EcalTriggerPrimitiveDigi::setSize(int size) {
-  if (size<0) size_=0;
-  else if (size>MAXSAMPLES) size_=MAXSAMPLES;
-  else size_=size;
+  if (size < 0)
+    size_ = 0;
+  else if (size > MAXSAMPLES)
+    size_ = MAXSAMPLES;
+  else
+    size_ = size;
 }
 
-  
 std::ostream& operator<<(std::ostream& s, const EcalTriggerPrimitiveDigi& digi) {
   s << digi.id() << " " << digi.size() << " samples " << std::endl;
-  for (int i=0; i<digi.size(); i++) 
+  for (int i = 0; i < digi.size(); i++)
     s << "  " << digi.sample(i) << std::endl;
   return s;
 }
-

--- a/DataFormats/EcalDigi/src/EcalTriggerPrimitiveSample.cc
+++ b/DataFormats/EcalDigi/src/EcalTriggerPrimitiveSample.cc
@@ -1,24 +1,17 @@
 #include "DataFormats/EcalDigi/interface/EcalTriggerPrimitiveSample.h"
 
+EcalTriggerPrimitiveSample::EcalTriggerPrimitiveSample() : theSample(0) {}
+EcalTriggerPrimitiveSample::EcalTriggerPrimitiveSample(uint16_t data) : theSample(data) {}
 
-
-EcalTriggerPrimitiveSample::EcalTriggerPrimitiveSample() : theSample(0) { }
-EcalTriggerPrimitiveSample::EcalTriggerPrimitiveSample(uint16_t data) : theSample(data) { }
-
-EcalTriggerPrimitiveSample::EcalTriggerPrimitiveSample(int encodedEt, bool fineGrain, int ttFlag) { 
-  theSample=((ttFlag&0x7)<<9)|(encodedEt&0xFF)|
-    ((fineGrain)?(0x100):(0));
+EcalTriggerPrimitiveSample::EcalTriggerPrimitiveSample(int encodedEt, bool fineGrain, int ttFlag) {
+  theSample = ((ttFlag & 0x7) << 9) | (encodedEt & 0xFF) | ((fineGrain) ? (0x100) : (0));
 }
 
-EcalTriggerPrimitiveSample::EcalTriggerPrimitiveSample(int encodedEt, bool finegrain, int stripFGVB, int ttFlag)
-{
-   theSample=((ttFlag&0x7)<<9)|(encodedEt&0xFF)|
-    ((finegrain)?(0x100):(0))|((stripFGVB&0x1)<<12);
+EcalTriggerPrimitiveSample::EcalTriggerPrimitiveSample(int encodedEt, bool finegrain, int stripFGVB, int ttFlag) {
+  theSample = ((ttFlag & 0x7) << 9) | (encodedEt & 0xFF) | ((finegrain) ? (0x100) : (0)) | ((stripFGVB & 0x1) << 12);
 }
 
 std::ostream& operator<<(std::ostream& s, const EcalTriggerPrimitiveSample& samp) {
-  return s << "ET=" << samp.compressedEt() << ", FG=" << samp.fineGrain()
-     << ", sFGVB=" << samp.sFGVB() << ", TTF=" << samp.ttFlag();
+  return s << "ET=" << samp.compressedEt() << ", FG=" << samp.fineGrain() << ", sFGVB=" << samp.sFGVB()
+           << ", TTF=" << samp.ttFlag();
 }
-
-

--- a/DataFormats/EcalDigi/test/EcalDigi_t.cpp
+++ b/DataFormats/EcalDigi/test/EcalDigi_t.cpp
@@ -5,13 +5,12 @@
 #include "DataFormats/Common/interface/DataFrame.h"
 #include "DataFormats/Common/interface/DataFrameContainer.h"
 
-#include<vector>
-#include<algorithm>
-#include<boost/function.hpp>
+#include <vector>
+#include <algorithm>
+#include <boost/function.hpp>
 
-template<typename DigiCollection>
-class TestEcalDigi: public CppUnit::TestFixture
-{
+template <typename DigiCollection>
+class TestEcalDigi : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TestEcalDigi);
   CPPUNIT_TEST(default_ctor);
   CPPUNIT_TEST(filling);
@@ -19,145 +18,141 @@ class TestEcalDigi: public CppUnit::TestFixture
 
   CPPUNIT_TEST_SUITE_END();
 
- public:
-  TestEcalDigi(); 
+public:
+  TestEcalDigi();
   ~TestEcalDigi() {}
   void setUp() {}
   void tearDown() {}
-  
+
   void default_ctor();
   void filling();
   void iterator();
-  
+
   void fill(int stride);
   //  void iter(int stride);
 
-
 public:
   std::vector<edm::DataFrame::data_type> sv;
-
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestEcalDigi<EBDigiCollection>);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestEcalDigi<EEDigiCollection>);
 
-template<typename DigiCollection>
-TestEcalDigi<DigiCollection>::TestEcalDigi() : sv(10){ 
-  edm::DataFrame::data_type v[10] = {0,1,2,3,4,5,6,7,8,9};
-  std::copy(v,v+10,sv.begin());
-} 
-
-
-template<typename DigiCollection>
-void TestEcalDigi<DigiCollection>::default_ctor() {
-
-  DigiCollection frames;
-  CPPUNIT_ASSERT(frames.stride()==10);
-  // against enum in ExDetID
-  CPPUNIT_ASSERT(frames.subdetId()==DigiCollection::DetId::Subdet);
-  // against static metod in ExDetID
-  CPPUNIT_ASSERT(frames.subdetId()==DigiCollection::DetId::subdet());
-  DigiCollection smallframes(1);
-  CPPUNIT_ASSERT(smallframes.stride()==1);
-
+template <typename DigiCollection>
+TestEcalDigi<DigiCollection>::TestEcalDigi() : sv(10) {
+  edm::DataFrame::data_type v[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::copy(v, v + 10, sv.begin());
 }
 
-template<typename DigiCollection>
+template <typename DigiCollection>
+void TestEcalDigi<DigiCollection>::default_ctor() {
+  DigiCollection frames;
+  CPPUNIT_ASSERT(frames.stride() == 10);
+  // against enum in ExDetID
+  CPPUNIT_ASSERT(frames.subdetId() == DigiCollection::DetId::Subdet);
+  // against static metod in ExDetID
+  CPPUNIT_ASSERT(frames.subdetId() == DigiCollection::DetId::subdet());
+  DigiCollection smallframes(1);
+  CPPUNIT_ASSERT(smallframes.stride() == 1);
+}
+
+template <typename DigiCollection>
 void TestEcalDigi<DigiCollection>::filling() {
   fill(10);
   fill(1);
-}  
+}
 
-template<typename DigiCollection>
+template <typename DigiCollection>
 void TestEcalDigi<DigiCollection>::fill(int stride) {
   std::vector<edm::DataFrame::data_type> v1(stride);
-  std::copy(sv.begin(),sv.begin()+stride,v1.begin());
-  
+  std::copy(sv.begin(), sv.begin() + stride, v1.begin());
+
   DigiCollection frames(stride);
-  for (int n=1;n<5;++n) {
+  for (int n = 1; n < 5; ++n) {
     typename DigiCollection::DetId id = DigiCollection::DetId::unhashIndex(n);
     frames.push_back(id);
-    CPPUNIT_ASSERT(int(frames.size())==n);
+    CPPUNIT_ASSERT(int(frames.size()) == n);
     typename DigiCollection::Digi df(frames.back());
-    CPPUNIT_ASSERT(df.size()==stride); 
-    CPPUNIT_ASSERT(df.id()==id); 
-    if (n%2==0) {
+    CPPUNIT_ASSERT(df.size() == stride);
+    CPPUNIT_ASSERT(df.id() == id);
+    if (n % 2 == 0) {
       // modern way of filling
-      std::copy(sv.begin(),sv.begin()+stride,df.frame().begin());
-      
+      std::copy(sv.begin(), sv.begin() + stride, df.frame().begin());
+
       std::vector<edm::DataFrame::data_type> v2(stride);
-      std::copy(frames.m_data.begin()+(n-1)*stride,frames.m_data.begin()+n*stride,v2.begin());
-      CPPUNIT_ASSERT(v1==v2);
+      std::copy(frames.m_data.begin() + (n - 1) * stride, frames.m_data.begin() + n * stride, v2.begin());
+      CPPUNIT_ASSERT(v1 == v2);
     } else {
       // classical way of filling
-      for (int i=0; i<stride; i++)
-	df.setSample(i,sv[i]);
-      
+      for (int i = 0; i < stride; i++)
+        df.setSample(i, sv[i]);
+
       std::vector<edm::DataFrame::data_type> v2(stride);
-      std::copy(frames.m_data.begin()+(n-1)*stride,frames.m_data.begin()+n*stride,v2.begin());
-      CPPUNIT_ASSERT(v1==v2);
+      std::copy(frames.m_data.begin() + (n - 1) * stride, frames.m_data.begin() + n * stride, v2.begin());
+      CPPUNIT_ASSERT(v1 == v2);
     }
   }
-  
 }
 
 namespace {
-  template<typename Digi>
-  struct VerifyIter{
-    VerifyIter( std::vector<edm::DataFrame::data_type> const & v):n(0), sv(v){}
-    void operator()(Digi const & df) {
+  template <typename Digi>
+  struct VerifyIter {
+    VerifyIter(std::vector<edm::DataFrame::data_type> const& v) : n(0), sv(v) {}
+    void operator()(Digi const& df) {
       typedef typename Digi::key_type DetId;
       ++n;
       DetId id = DetId::unhashIndex(n);
-      CPPUNIT_ASSERT(df.id()==id); 
+      CPPUNIT_ASSERT(df.id() == id);
       {
-	std::vector<edm::DataFrame::data_type> v2(10);
-	std::copy(df.frame().begin(),df.frame().end(),v2.begin());
-	CPPUNIT_ASSERT(sv==v2);
+        std::vector<edm::DataFrame::data_type> v2(10);
+        std::copy(df.frame().begin(), df.frame().end(), v2.begin());
+        CPPUNIT_ASSERT(sv == v2);
       }
       {
-	std::vector<edm::DataFrame::data_type> v2(10);
-	for (int i=0; i<10; i++){
-	  EcalMGPASample s=df.sample(i);
-	  v2[i]=s.raw();
-	}
-	CPPUNIT_ASSERT(sv==v2);
+        std::vector<edm::DataFrame::data_type> v2(10);
+        for (int i = 0; i < 10; i++) {
+          EcalMGPASample s = df.sample(i);
+          v2[i] = s.raw();
+        }
+        CPPUNIT_ASSERT(sv == v2);
       }
     }
     int n;
-    std::vector<edm::DataFrame::data_type> const & sv;
+    std::vector<edm::DataFrame::data_type> const& sv;
   };
 
   void verifyBarrelId(edm::DataFrame::id_type id) {
     try {
       EBDetId detid{DetId(id)};
-    } catch(...) {
-      bool NotBarrelID=false;
+    } catch (...) {
+      bool NotBarrelID = false;
       CPPUNIT_ASSERT(NotBarrelID);
     }
   }
   void verifyEndcapId(edm::DataFrame::id_type id) {
     try {
-      EEDetId detid{DetId(id)}; // detid(id) does not throw
-    } catch(...) {
-      bool NotEndcapID=false;
+      EEDetId detid{DetId(id)};  // detid(id) does not throw
+    } catch (...) {
+      bool NotEndcapID = false;
       CPPUNIT_ASSERT(NotEndcapID);
     }
   }
-  
+
   //one more way
   struct VerifyFrame {
-    VerifyFrame(std::vector<edm::DataFrame::data_type> const & v): n(0), b(v), e(v){}
-    
-    void operator()(edm::DataFrame const & df) {
+    VerifyFrame(std::vector<edm::DataFrame::data_type> const& v) : n(0), b(v), e(v) {}
+
+    void operator()(edm::DataFrame const& df) {
       DetId id(df.id());
-      if (id.subdetId()==EcalBarrel) {
-	b(df);n=b.n;
-      } else if(id.subdetId()==EcalEndcap) {
-	e(df);n=e.n;
+      if (id.subdetId() == EcalBarrel) {
+        b(df);
+        n = b.n;
+      } else if (id.subdetId() == EcalEndcap) {
+        e(df);
+        n = e.n;
       } else {
-	bool WrongSubdetId=false;
-	CPPUNIT_ASSERT(WrongSubdetId);
+        bool WrongSubdetId = false;
+        CPPUNIT_ASSERT(WrongSubdetId);
       }
     }
     int n;
@@ -165,53 +160,48 @@ namespace {
     VerifyIter<EEDataFrame> e;
   };
 
-
   // an alternative way
-  void iterate(EcalDigiCollection const & frames) {
+  void iterate(EcalDigiCollection const& frames) {
     boost::function<void(edm::DataFrame::id_type)> verifyId;
-    if (frames.subdetId()==EcalBarrel)
-      verifyId=verifyBarrelId;
-    else if(frames.subdetId()==EcalEndcap)
-      verifyId=verifyEndcapId;
+    if (frames.subdetId() == EcalBarrel)
+      verifyId = verifyBarrelId;
+    else if (frames.subdetId() == EcalEndcap)
+      verifyId = verifyEndcapId;
     else {
-      bool WrongSubdetId=false;
+      bool WrongSubdetId = false;
       CPPUNIT_ASSERT(WrongSubdetId);
     }
 
     //    std::for_each(frames.begin(),frames.end(),
     //		  boost::bind(verifyId,boost::bind(&edm::DataFrame::id,_1)));
     // same as above....
-    for (int n=0;n<int(frames.size());++n) {
+    for (int n = 0; n < int(frames.size()); ++n) {
       edm::DataFrame df = frames[n];
       verifyId(df.id());
     }
-
   }
 
-}
+}  // namespace
 
-template<typename DigiCollection>
+template <typename DigiCollection>
 void TestEcalDigi<DigiCollection>::iterator() {
   DigiCollection frames;
-  for (int n=1;n<5;++n) {
+  for (int n = 1; n < 5; ++n) {
     typename DigiCollection::DetId id = DigiCollection::DetId::unhashIndex(n);
     frames.push_back(id);
     typename DigiCollection::Digi df(frames.back());
-    std::copy(sv.begin(),sv.end(),df.frame().begin());
+    std::copy(sv.begin(), sv.end(), df.frame().begin());
   }
   // modern
-  CPPUNIT_ASSERT(std::for_each(frames.begin(),frames.end(),
-			       VerifyIter<typename DigiCollection::Digi>(this->sv)
-			       ).n==4);
+  CPPUNIT_ASSERT(std::for_each(frames.begin(), frames.end(), VerifyIter<typename DigiCollection::Digi>(this->sv)).n ==
+                 4);
   // classical
   VerifyIter<typename DigiCollection::Digi> vi(sv);
-  for (int n=0;n<int(frames.size());++n) {
+  for (int n = 0; n < int(frames.size()); ++n) {
     typename DigiCollection::Digi digi(frames[n]);
     vi(digi);
-  } 
+  }
   // alternatives
   iterate(frames);
-  CPPUNIT_ASSERT(std::for_each(frames.begin(),frames.end(),VerifyFrame(sv)).n==4);
+  CPPUNIT_ASSERT(std::for_each(frames.begin(), frames.end(), VerifyFrame(sv)).n == 4);
 }
-
-

--- a/SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h
+++ b/SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h
@@ -17,7 +17,7 @@ public:
 private:
   std::vector<std::string> logicalNamesFromClassName(const std::string &className) const;
   std::vector<std::string> classNames() const;
-  
+
   MapType theClassNameMap;
   MapType theROUNameMap;
 };


### PR DESCRIPTION

Applying code-format for CMSSW category simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/432//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


