### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h
+++ b/RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h
@@ -9,40 +9,33 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 
 class AnyMVAEstimatorRun2Base {
-
- public:
+public:
   // Constructor, destructor
   AnyMVAEstimatorRun2Base(const edm::ParameterSet& conf)
-    : tag_         (conf.getParameter<std::string>("mvaTag"))
-    , nCategories_ (conf.getParameter<int>("nCategories"))
-    , debug_       (conf.getUntrackedParameter<bool>("debug", false))
-  {}
- 
- AnyMVAEstimatorRun2Base(const::std::string& mvaName,
-                         const::std::string& mvaTag, 
-                         int nCategories, 
-                         bool debug)
-    : name_        (mvaName)
-    , tag_         (mvaTag)
-    , nCategories_ (nCategories)
-    , debug_       (debug)
-  {}
+      : tag_(conf.getParameter<std::string>("mvaTag")),
+        nCategories_(conf.getParameter<int>("nCategories")),
+        debug_(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  AnyMVAEstimatorRun2Base(const ::std::string& mvaName, const ::std::string& mvaTag, int nCategories, bool debug)
+      : name_(mvaName), tag_(mvaTag), nCategories_(nCategories), debug_(debug) {}
   virtual ~AnyMVAEstimatorRun2Base(){};
 
   // Functions that must be provided in derived classes
   // These function should work on electrons or photons
   // of the reco or pat type
 
-  virtual float mvaValue( const reco::Candidate* candidate, std::vector<float> const& auxVariables, int &iCategory) const = 0;
-  float mvaValue( const reco::Candidate* candidate, std::vector<float> const& auxVariables) const {
-      int iCategory;
-      return mvaValue(candidate, auxVariables, iCategory);
+  virtual float mvaValue(const reco::Candidate* candidate,
+                         std::vector<float> const& auxVariables,
+                         int& iCategory) const = 0;
+  float mvaValue(const reco::Candidate* candidate, std::vector<float> const& auxVariables) const {
+    int iCategory;
+    return mvaValue(candidate, auxVariables, iCategory);
   };
 
   // A specific implementation of MVA is expected to have one or more categories
   // defined with respect to eta, pt, etc.
   // This function determines the category for a given candidate.
-  virtual int findCategory( const reco::Candidate* candidate) const = 0;
+  virtual int findCategory(const reco::Candidate* candidate) const = 0;
   int getNCategories() const { return nCategories_; }
   const std::string& getName() const { return name_; }
   // An extra variable string set during construction that can be used
@@ -58,8 +51,7 @@ class AnyMVAEstimatorRun2Base {
   // Implement these methods only if needed in the derived classes (use "override"
   // for certainty).
 
- private:
-
+private:
   //
   // Data members
   //
@@ -78,7 +70,6 @@ class AnyMVAEstimatorRun2Base {
 
 // define the factory for this base class
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< AnyMVAEstimatorRun2Base* (const edm::ParameterSet&) >
-        AnyMVAEstimatorRun2Factory;
+typedef edmplugin::PluginFactory<AnyMVAEstimatorRun2Base*(const edm::ParameterSet&)> AnyMVAEstimatorRun2Factory;
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/BaselinePFSCRegression.h
+++ b/RecoEgamma/EgammaTools/interface/BaselinePFSCRegression.h
@@ -4,7 +4,7 @@
 #include "RecoEgamma/EgammaTools/interface/SCRegressionCalculator.h"
 
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
-#include "Geometry/CaloTopology/interface/CaloTopology.h" 
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
@@ -27,23 +27,23 @@
 #include <vector>
 
 class BaselinePFSCRegression {
- public:
-  BaselinePFSCRegression() : topo_record(nullptr), geom_record(nullptr) {};
+public:
+  BaselinePFSCRegression() : topo_record(nullptr), geom_record(nullptr){};
   void update(const edm::EventSetup&);
   void set(const reco::SuperCluster&, std::vector<float>&) const;
   void setTokens(const edm::ParameterSet&, edm::ConsumesCollector&&);
   void setEvent(const edm::Event&);
 
- private:
+private:
   const CaloTopologyRecord* topo_record;
   const CaloGeometryRecord* geom_record;
   edm::ESHandle<CaloTopology> calotopo;
   edm::ESHandle<CaloGeometry> calogeom;
-  edm::EDGetTokenT<EcalRecHitCollection>          inputTagEBRecHits_;
-  edm::EDGetTokenT<EcalRecHitCollection>          inputTagEERecHits_;
-  edm::EDGetTokenT<reco::VertexCollection>        inputTagVertices_;
+  edm::EDGetTokenT<EcalRecHitCollection> inputTagEBRecHits_;
+  edm::EDGetTokenT<EcalRecHitCollection> inputTagEERecHits_;
+  edm::EDGetTokenT<reco::VertexCollection> inputTagVertices_;
   edm::Handle<reco::VertexCollection> vertices;
-  edm::Handle<EcalRecHitCollection>  rechitsEB,rechitsEE;
+  edm::Handle<EcalRecHitCollection> rechitsEB, rechitsEE;
 };
 
 typedef SCRegressionCalculator<BaselinePFSCRegression> PFSCRegressionCalc;

--- a/RecoEgamma/EgammaTools/interface/ConversionFinder.h
+++ b/RecoEgamma/EgammaTools/interface/ConversionFinder.h
@@ -23,8 +23,6 @@
 #include "Math/VectorUtil.h"
 #include "ConversionInfo.h"
 
-
-
 /*
    Class Looks for oppositely charged track in the
    track collection with the minimum delta cot(theta) between the track
@@ -39,30 +37,29 @@ namespace egammaTools {
   //returns a vector of Conversion Infos.
   //you have to decide which is the best
   std::vector<ConversionInfo> getConversionInfos(const reco::GsfElectronCore&,
-						const edm::Handle<reco::TrackCollection>& ctftracks_h,
-						const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
-						const double bFieldAtOrigin,
-						const double minFracSharedHits = 0.45);
+                                                 const edm::Handle<reco::TrackCollection>& ctftracks_h,
+                                                 const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
+                                                 const double bFieldAtOrigin,
+                                                 const double minFracSharedHits = 0.45);
 
   //retruns the "best" Conversion Info after calling getConversionInfos
   ConversionInfo getConversionInfo(const reco::GsfElectronCore&,
-				   const edm::Handle<reco::TrackCollection>& ctftracks_h,
-				   const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
-				   const double bFieldAtOrigin,
-				   const double minFracSharedHits = 0.45);
+                                   const edm::Handle<reco::TrackCollection>& ctftracks_h,
+                                   const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
+                                   const double bFieldAtOrigin,
+                                   const double minFracSharedHits = 0.45);
 
   //retruns the "best" Conversion Info after calling getConversionInfos
   ConversionInfo getConversionInfo(const reco::GsfElectron& gsfElectron,
-				   const edm::Handle<reco::TrackCollection>& ctftracks_h,
-				   const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
-				   const double bFieldAtOrigin,
-				   const double minFracSharedHits = 0.45);
+                                   const edm::Handle<reco::TrackCollection>& ctftracks_h,
+                                   const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
+                                   const double bFieldAtOrigin,
+                                   const double minFracSharedHits = 0.45);
 
   //takes in a vector of candidate conversion partners
   //and arbitrates between them returning the one with the
   //smallest R=sqrt(dist*dist + dcot*dcot)
   ConversionInfo arbitrateConversionPartnersbyR(const std::vector<ConversionInfo>& v_convCandidates);
-
 
   //places different cuts on dist, dcot, delmissing hits and arbitration based on R = sqrt(dist*dist + dcot*dcot)
   ConversionInfo findBestConversionMatch(const std::vector<ConversionInfo>& v_convCandidates);
@@ -70,13 +67,12 @@ namespace egammaTools {
   //for backwards compatibility. Does not use the GSF track collection. This function will be
   //deprecated soon
   ConversionInfo getConversionInfo(const reco::GsfElectron& gsfElectron,
-				   const edm::Handle<reco::TrackCollection>& track_h,
-				   const double bFieldAtOrigin,
-				   const double minFracSharedHits = 0.45);
-
+                                   const edm::Handle<reco::TrackCollection>& track_h,
+                                   const double bFieldAtOrigin,
+                                   const double minFracSharedHits = 0.45);
 
   // DEPRECATED
-  bool isFromConversion( const ConversionInfo &, double maxAbsDist = 0.02, double maxAbsDcot = 0.02);
+  bool isFromConversion(const ConversionInfo&, double maxAbsDist = 0.02, double maxAbsDcot = 0.02);
 
-}
+}  // namespace egammaTools
 #endif

--- a/RecoEgamma/EgammaTools/interface/ConversionInfo.h
+++ b/RecoEgamma/EgammaTools/interface/ConversionInfo.h
@@ -5,27 +5,24 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/Math/interface/Point3D.h"
 
+struct ConversionInfo {
+  const double dist;
+  const double dcot;
+  const double radiusOfConversion;
+  const math::XYZPoint pointOfConversion;
+  // if the partner track is found in the  GSF track collection,
+  // this is a ref to the GSF partner track
+  const reco::TrackRef conversionPartnerCtfTk;
+  // if the partner track is found in the  CTF track collection,
+  // this is a ref to the CTF partner track
+  const reco::GsfTrackRef conversionPartnerGsfTk;
+  const int deltaMissingHits;
+  const int flag;
 
-struct ConversionInfo
-{
-    const double dist;
-    const double dcot;
-    const double radiusOfConversion;
-    const math::XYZPoint pointOfConversion;
-    // if the partner track is found in the  GSF track collection,
-    // this is a ref to the GSF partner track
-    const reco::TrackRef conversionPartnerCtfTk;
-    // if the partner track is found in the  CTF track collection,
-    // this is a ref to the CTF partner track
-    const reco::GsfTrackRef conversionPartnerGsfTk;
-    const int deltaMissingHits;
-    const int flag;
-
-    // flag 0: Partner track found in the CTF collection using the electron's CTF track
-    // flag 1: Partner track found in the CTF collection using the electron's GSF track
-    // flag 2: Partner track found in the GSF collection using the electron's CTF track
-    // flag 3: Partner track found in the GSF collection using the electron's GSF track
+  // flag 0: Partner track found in the CTF collection using the electron's CTF track
+  // flag 1: Partner track found in the CTF collection using the electron's GSF track
+  // flag 2: Partner track found in the GSF collection using the electron's CTF track
+  // flag 3: Partner track found in the GSF collection using the electron's GSF track
 };
-
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/ConversionLikelihoodCalculator.h
+++ b/RecoEgamma/EgammaTools/interface/ConversionLikelihoodCalculator.h
@@ -7,24 +7,21 @@
 #include "TMVA/Reader.h"
 #include <memory>
 
-class ConversionLikelihoodCalculator
-{
-    public:
-        ConversionLikelihoodCalculator();
-        void setWeightsFile(const char * weightsFile);
+class ConversionLikelihoodCalculator {
+public:
+  ConversionLikelihoodCalculator();
+  void setWeightsFile(const char* weightsFile);
 
-        double calculateLikelihood(reco::ConversionRef conversion);
-        double calculateLikelihood(reco::Conversion & conversion);
+  double calculateLikelihood(reco::ConversionRef conversion);
+  double calculateLikelihood(reco::Conversion& conversion);
 
-    private:
-        std::unique_ptr<TMVA::Reader> reader_;
-        float log_e_over_p_;
-        float log_abs_cot_theta_;
-        float log_abs_delta_phi_;
-        float log_chi2_max_pt_;
-        float log_chi2_min_pt_;
-
+private:
+  std::unique_ptr<TMVA::Reader> reader_;
+  float log_e_over_p_;
+  float log_abs_cot_theta_;
+  float log_abs_delta_phi_;
+  float log_chi2_max_pt_;
+  float log_chi2_min_pt_;
 };
 
 #endif
-

--- a/RecoEgamma/EgammaTools/interface/ConversionTools.h
+++ b/RecoEgamma/EgammaTools/interface/ConversionTools.h
@@ -12,7 +12,7 @@
 //
 // Also implemented here is a "conversion-safe electron veto" for photons through the
 // matchedPromptElectron and hasMatchedPromptElectron functions
-// 
+//
 //
 // Authors: J.Bendavid
 //--------------------------------------------------------------------------------------------------
@@ -32,52 +32,108 @@
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
-class ConversionTools
-{
-  public:
-    ConversionTools() {}
-                                                      
-                                                
-    static bool                        isGoodConversion(const reco::Conversion &conv, const math::XYZPoint &beamspot, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=1);
-    
-    static bool                        matchesConversion(const reco::GsfElectron &ele, const reco::Conversion &conv, bool allowCkfMatch=true, bool allowAmbiguousGsfMatch=false);
-    static bool                        matchesConversion(const reco::GsfElectronCore &eleCore, const reco::Conversion &conv, bool allowCkfMatch=true);
-    static bool                        matchesConversion(const reco::SuperCluster &sc, const reco::Conversion &conv, float dRMax = 0.1, float dEtaMax = 999., float dPhiMax = 999.);
-    static bool                        matchesConversion(const edm::RefToBase<reco::Track> &trk, const reco::Conversion &conv);
-    static bool                        matchesConversion(const reco::TrackRef &trk, const reco::Conversion &conv);
-    static bool                        matchesConversion(const reco::GsfTrackRef &trk, const reco::Conversion &conv);
+class ConversionTools {
+public:
+  ConversionTools() {}
 
+  static bool isGoodConversion(const reco::Conversion &conv,
+                               const math::XYZPoint &beamspot,
+                               float lxyMin = 2.0,
+                               float probMin = 1e-6,
+                               unsigned int nHitsBeforeVtxMax = 1);
 
-    static bool                        hasMatchedConversion(const reco::GsfElectron &ele,
-                                                  const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch=true, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=0);
+  static bool matchesConversion(const reco::GsfElectron &ele,
+                                const reco::Conversion &conv,
+                                bool allowCkfMatch = true,
+                                bool allowAmbiguousGsfMatch = false);
+  static bool matchesConversion(const reco::GsfElectronCore &eleCore,
+                                const reco::Conversion &conv,
+                                bool allowCkfMatch = true);
+  static bool matchesConversion(const reco::SuperCluster &sc,
+                                const reco::Conversion &conv,
+                                float dRMax = 0.1,
+                                float dEtaMax = 999.,
+                                float dPhiMax = 999.);
+  static bool matchesConversion(const edm::RefToBase<reco::Track> &trk, const reco::Conversion &conv);
+  static bool matchesConversion(const reco::TrackRef &trk, const reco::Conversion &conv);
+  static bool matchesConversion(const reco::GsfTrackRef &trk, const reco::Conversion &conv);
 
-    static bool                        hasMatchedConversion(const reco::TrackRef &trk,
-                                                  const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=1);
+  static bool hasMatchedConversion(const reco::GsfElectron &ele,
+                                   const reco::ConversionCollection &convCol,
+                                   const math::XYZPoint &beamspot,
+                                   bool allowCkfMatch = true,
+                                   float lxyMin = 2.0,
+                                   float probMin = 1e-6,
+                                   unsigned int nHitsBeforeVtxMax = 0);
 
-    static bool                        hasMatchedConversion(const reco::SuperCluster &sc,
-                                                  const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, float dRMax = 0.1, float dEtaMax = 999., float dPhiMax = 999., float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=1);
+  static bool hasMatchedConversion(const reco::TrackRef &trk,
+                                   const reco::ConversionCollection &convCol,
+                                   const math::XYZPoint &beamspot,
+                                   float lxyMin = 2.0,
+                                   float probMin = 1e-6,
+                                   unsigned int nHitsBeforeVtxMax = 1);
 
+  static bool hasMatchedConversion(const reco::SuperCluster &sc,
+                                   const reco::ConversionCollection &convCol,
+                                   const math::XYZPoint &beamspot,
+                                   float dRMax = 0.1,
+                                   float dEtaMax = 999.,
+                                   float dPhiMax = 999.,
+                                   float lxyMin = 2.0,
+                                   float probMin = 1e-6,
+                                   unsigned int nHitsBeforeVtxMax = 1);
 
-    static reco::Conversion const*         matchedConversion(const reco::GsfElectron &ele,
-                                                  const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch=true, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=0);
+  static reco::Conversion const *matchedConversion(const reco::GsfElectron &ele,
+                                                   const reco::ConversionCollection &convCol,
+                                                   const math::XYZPoint &beamspot,
+                                                   bool allowCkfMatch = true,
+                                                   float lxyMin = 2.0,
+                                                   float probMin = 1e-6,
+                                                   unsigned int nHitsBeforeVtxMax = 0);
 
-    static reco::Conversion const*         matchedConversion(const reco::GsfElectronCore &eleCore,
-                                                  const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch=true, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=0);
+  static reco::Conversion const *matchedConversion(const reco::GsfElectronCore &eleCore,
+                                                   const reco::ConversionCollection &convCol,
+                                                   const math::XYZPoint &beamspot,
+                                                   bool allowCkfMatch = true,
+                                                   float lxyMin = 2.0,
+                                                   float probMin = 1e-6,
+                                                   unsigned int nHitsBeforeVtxMax = 0);
 
-    static reco::Conversion const*         matchedConversion(const reco::TrackRef &trk,
-                                                  const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=1);
+  static reco::Conversion const *matchedConversion(const reco::TrackRef &trk,
+                                                   const reco::ConversionCollection &convCol,
+                                                   const math::XYZPoint &beamspot,
+                                                   float lxyMin = 2.0,
+                                                   float probMin = 1e-6,
+                                                   unsigned int nHitsBeforeVtxMax = 1);
 
-    static reco::Conversion const*         matchedConversion(const reco::SuperCluster &sc,
-                                                  const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, float dRMax = 0.1, float dEtaMax = 999., float dPhiMax = 999., float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=1);
+  static reco::Conversion const *matchedConversion(const reco::SuperCluster &sc,
+                                                   const reco::ConversionCollection &convCol,
+                                                   const math::XYZPoint &beamspot,
+                                                   float dRMax = 0.1,
+                                                   float dEtaMax = 999.,
+                                                   float dPhiMax = 999.,
+                                                   float lxyMin = 2.0,
+                                                   float probMin = 1e-6,
+                                                   unsigned int nHitsBeforeVtxMax = 1);
 
-    static bool                        hasMatchedPromptElectron(const reco::SuperClusterRef &sc, const reco::GsfElectronCollection &eleCol,
-                                                  const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch=true, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=0);
+  static bool hasMatchedPromptElectron(const reco::SuperClusterRef &sc,
+                                       const reco::GsfElectronCollection &eleCol,
+                                       const reco::ConversionCollection &convCol,
+                                       const math::XYZPoint &beamspot,
+                                       bool allowCkfMatch = true,
+                                       float lxyMin = 2.0,
+                                       float probMin = 1e-6,
+                                       unsigned int nHitsBeforeVtxMax = 0);
 
+  static reco::GsfElectron const *matchedPromptElectron(const reco::SuperClusterRef &sc,
+                                                        const reco::GsfElectronCollection &eleCol,
+                                                        const reco::ConversionCollection &convCol,
+                                                        const math::XYZPoint &beamspot,
+                                                        bool allowCkfMatch = true,
+                                                        float lxyMin = 2.0,
+                                                        float probMin = 1e-6,
+                                                        unsigned int nHitsBeforeVtxMax = 0);
 
-    static reco::GsfElectron const*        matchedPromptElectron(const reco::SuperClusterRef &sc, const reco::GsfElectronCollection &eleCol,
-                                                  const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch=true, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=0);
-  
-  static float                             getVtxFitProb(const reco::Conversion* conv);
-
+  static float getVtxFitProb(const reco::Conversion *conv);
 };
 #endif

--- a/RecoEgamma/EgammaTools/interface/ECALPositionCalculator.h
+++ b/RecoEgamma/EgammaTools/interface/ECALPositionCalculator.h
@@ -6,11 +6,12 @@
 
 class MagneticField;
 
-namespace egammaTools
-{
-    double ecalPhi(const MagneticField &magField, const math::XYZVector &momentum, const math::XYZPoint &vertex, const int charge);
-    double ecalEta(const math::XYZVector &momentum, const math::XYZPoint &vertex);
-};
+namespace egammaTools {
+  double ecalPhi(const MagneticField &magField,
+                 const math::XYZVector &momentum,
+                 const math::XYZPoint &vertex,
+                 const int charge);
+  double ecalEta(const math::XYZVector &momentum, const math::XYZPoint &vertex);
+};  // namespace egammaTools
 
 #endif
-

--- a/RecoEgamma/EgammaTools/interface/EGEnergyCorrector.h
+++ b/RecoEgamma/EgammaTools/interface/EGEnergyCorrector.h
@@ -19,30 +19,43 @@
 class GBRForest;
 
 class EGEnergyCorrector {
-  public:
-    EGEnergyCorrector();
-    ~EGEnergyCorrector();
+public:
+  EGEnergyCorrector();
+  ~EGEnergyCorrector();
 
-    void Initialize(const edm::EventSetup &iSetup, std::string regweights, bool weightsFromDB=false);
-    Bool_t IsInitialized() const { return fIsInitialized; }
+  void Initialize(const edm::EventSetup &iSetup, std::string regweights, bool weightsFromDB = false);
+  Bool_t IsInitialized() const { return fIsInitialized; }
 
-    std::pair<double,double> CorrectedEnergyWithError(const reco::Photon &p, const reco::VertexCollection& vtxcol, EcalClusterLazyTools &clustertools, const edm::EventSetup &es);
-    std::pair<double,double> CorrectedEnergyWithError(const reco::GsfElectron &e, const reco::VertexCollection& vtxcol, EcalClusterLazyTools &clustertools, const edm::EventSetup &es);
+  std::pair<double, double> CorrectedEnergyWithError(const reco::Photon &p,
+                                                     const reco::VertexCollection &vtxcol,
+                                                     EcalClusterLazyTools &clustertools,
+                                                     const edm::EventSetup &es);
+  std::pair<double, double> CorrectedEnergyWithError(const reco::GsfElectron &e,
+                                                     const reco::VertexCollection &vtxcol,
+                                                     EcalClusterLazyTools &clustertools,
+                                                     const edm::EventSetup &es);
 
-    std::pair<double,double> CorrectedEnergyWithErrorV3(const reco::Photon &p, const reco::VertexCollection& vtxcol, double rho, EcalClusterLazyTools &clustertools, const edm::EventSetup &es, bool applyRescale = false);
-    std::pair<double,double> CorrectedEnergyWithErrorV3(const reco::GsfElectron &e, const reco::VertexCollection& vtxcol, double rho, EcalClusterLazyTools &clustertools, const edm::EventSetup &es);
+  std::pair<double, double> CorrectedEnergyWithErrorV3(const reco::Photon &p,
+                                                       const reco::VertexCollection &vtxcol,
+                                                       double rho,
+                                                       EcalClusterLazyTools &clustertools,
+                                                       const edm::EventSetup &es,
+                                                       bool applyRescale = false);
+  std::pair<double, double> CorrectedEnergyWithErrorV3(const reco::GsfElectron &e,
+                                                       const reco::VertexCollection &vtxcol,
+                                                       double rho,
+                                                       EcalClusterLazyTools &clustertools,
+                                                       const edm::EventSetup &es);
 
-  protected:
-    const GBRForest *fReadereb;
-    const GBRForest *fReaderebvariance;
-    const GBRForest *fReaderee;
-    const GBRForest *fReadereevariance;
+protected:
+  const GBRForest *fReadereb;
+  const GBRForest *fReaderebvariance;
+  const GBRForest *fReaderee;
+  const GBRForest *fReadereevariance;
 
-    Bool_t fIsInitialized;
-    Bool_t fOwnsForests;
-    Float_t *fVals;
-
-    };
-
+  Bool_t fIsInitialized;
+  Bool_t fOwnsForests;
+  Float_t *fVals;
+};
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EGEnergySysIndex.h
+++ b/RecoEgamma/EgammaTools/interface/EGEnergySysIndex.h
@@ -11,7 +11,7 @@
 class EGEnergySysIndex {
 public:
   enum Index {
-    kScaleStatUp=0,
+    kScaleStatUp = 0,
     kScaleStatDown,
     kScaleSystUp,
     kScaleSystDown,
@@ -37,15 +37,12 @@ public:
     kEcalTrkPostCorr,
     kEcalTrkErrPostCorr
   };
-  static constexpr size_t kNrSysErrs=kEcalTrkErrPostCorr+1; 
+  static constexpr size_t kNrSysErrs = kEcalTrkErrPostCorr + 1;
 
-  static const std::string& name(size_t index){return names_[index];}
+  static const std::string& name(size_t index) { return names_[index]; }
 
 private:
-  static const std::array<std::string,kNrSysErrs> names_;
-
-
-   
+  static const std::array<std::string, kNrSysErrs> names_;
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
+++ b/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
@@ -17,7 +17,7 @@ namespace {
 }
 
 //class: EGExtraInfoModifierFromValueMaps
-//  
+//
 //this is a generalisation of EGExtraInfoModiferFromFloatValueMaps
 //orginal author of EGExtraInfoModiferFromFloatValueMaps : L. Gray (FNAL)
 //converter to templated version: S. Harper (RAL)
@@ -27,12 +27,12 @@ namespace {
 //
 //IMPORTANT INFO:
 //by default the ValueMap is keyed to the object the pat::Electron/Photon was created from
-//if you want to use a ValueMap which is keyed to a different collection (ie perhaps the same 
+//if you want to use a ValueMap which is keyed to a different collection (ie perhaps the same
 //as the electrons you are aring, you must set "electronSrc" and "photonSrc" inside the ele/pho configs
-//so if you are running over slimmedElectrons and want to read a ValueMap keyed to slimmedElectrons 
+//so if you are running over slimmedElectrons and want to read a ValueMap keyed to slimmedElectrons
 //you need to set "electron_config.electronSrc = cms.InputTag("slimmedElectrons")"
 //
-//It assumes that the object can be added via pat::PATObject::userData, see pat::PATObject for the 
+//It assumes that the object can be added via pat::PATObject::userData, see pat::PATObject for the
 //constraints here
 //
 //The class has two template arguements:
@@ -41,280 +41,279 @@ namespace {
 //               this exists so you can specialise int and float (and future exceptions) to use
 //               pat::PATObject::userInt and pat::PATObject::userFloat
 //               The specialisations are done by EGXtraModFromVMObjFiller::addValueToObject
-//               
+//
 // MapType and OutputType do not have to be same (but are by default). This is useful as it allows
 // things like bools to and unsigned ints to be converted to ints to be stored as  a userInt
 // rather than having to go to the bother of setting up userData hooks for them
 
+namespace egmodifier {
+  class EGID {};  //dummy class to be used as a template arguement
+}  // namespace egmodifier
 
-namespace egmodifier{
-  class EGID{};//dummy class to be used as a template arguement 
-}
-
-template<typename OutputType>
+template <typename OutputType>
 class EGXtraModFromVMObjFiller {
 public:
-  EGXtraModFromVMObjFiller()=delete;
-  ~EGXtraModFromVMObjFiller()=delete;
+  EGXtraModFromVMObjFiller() = delete;
+  ~EGXtraModFromVMObjFiller() = delete;
 
   //will do a UserData add but specialisations exist for float and ints
-  template<typename ObjType,typename MapType>
-  static void 
-  addValueToObject(ObjType& obj,
-		   const edm::Ptr<reco::Candidate>& ptr,
-		   const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
-		   const std::pair<const std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > > & val_map,
-		   bool overrideExistingValues);
-  
-  template<typename ObjType,typename MapType>
-  static void 
-  addValuesToObject(ObjType& obj,
-		    const edm::Ptr<reco::Candidate>& ptr,
-		    const std::unordered_map<std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > > & vmaps_token,		  
-		    const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
-		    bool overrideExistingValues){
-    for( auto itr = vmaps_token.begin(); itr != vmaps_token.end(); ++itr ) {
-      addValueToObject(obj,ptr,vmaps,*itr,overrideExistingValues);
-    }  
-  }
-};		    
-		    
+  template <typename ObjType, typename MapType>
+  static void addValueToObject(ObjType& obj,
+                               const edm::Ptr<reco::Candidate>& ptr,
+                               const std::unordered_map<unsigned, edm::Handle<edm::ValueMap<MapType>>>& vmaps,
+                               const std::pair<const std::string, edm::EDGetTokenT<edm::ValueMap<MapType>>>& val_map,
+                               bool overrideExistingValues);
 
-template<typename MapType,typename OutputType=MapType>
+  template <typename ObjType, typename MapType>
+  static void addValuesToObject(
+      ObjType& obj,
+      const edm::Ptr<reco::Candidate>& ptr,
+      const std::unordered_map<std::string, edm::EDGetTokenT<edm::ValueMap<MapType>>>& vmaps_token,
+      const std::unordered_map<unsigned, edm::Handle<edm::ValueMap<MapType>>>& vmaps,
+      bool overrideExistingValues) {
+    for (auto itr = vmaps_token.begin(); itr != vmaps_token.end(); ++itr) {
+      addValueToObject(obj, ptr, vmaps, *itr, overrideExistingValues);
+    }
+  }
+};
+
+template <typename MapType, typename OutputType = MapType>
 class EGExtraInfoModifierFromValueMaps : public ModifyObjectValueBase {
 public:
-  using ValMapToken = edm::EDGetTokenT<edm::ValueMap<MapType> >;
-  using ValueMaps = std::unordered_map<std::string,ValMapToken>;
+  using ValMapToken = edm::EDGetTokenT<edm::ValueMap<MapType>>;
+  using ValueMaps = std::unordered_map<std::string, ValMapToken>;
   struct electron_config {
-    edm::EDGetTokenT<edm::View<pat::Electron> > tok_electron_src;
-    ValueMaps tok_valuemaps;    
+    edm::EDGetTokenT<edm::View<pat::Electron>> tok_electron_src;
+    ValueMaps tok_valuemaps;
   };
 
   struct photon_config {
-    edm::EDGetTokenT<edm::View<pat::Photon> > tok_photon_src;
-    ValueMaps tok_valuemaps; 
+    edm::EDGetTokenT<edm::View<pat::Photon>> tok_photon_src;
+    ValueMaps tok_valuemaps;
   };
 
   EGExtraInfoModifierFromValueMaps(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
-  
+
   void setEvent(const edm::Event&) final;
-  
+
   void modifyObject(pat::Electron&) const final;
   void modifyObject(pat::Photon&) const final;
 
- 
 private:
   electron_config e_conf;
-  photon_config   ph_conf;
-  std::vector<edm::Ptr<reco::GsfElectron>> eles_by_oop; // indexed by original object ptr
-  std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > > ele_vmaps;
+  photon_config ph_conf;
+  std::vector<edm::Ptr<reco::GsfElectron>> eles_by_oop;  // indexed by original object ptr
+  std::unordered_map<unsigned, edm::Handle<edm::ValueMap<MapType>>> ele_vmaps;
   std::vector<edm::Ptr<reco::Photon>> phos_by_oop;
-  std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > > pho_vmaps;
-  mutable unsigned ele_idx,pho_idx; // hack here until we figure out why some slimmedPhotons don't have original object ptrs
+  std::unordered_map<unsigned, edm::Handle<edm::ValueMap<MapType>>> pho_vmaps;
+  mutable unsigned ele_idx,
+      pho_idx;  // hack here until we figure out why some slimmedPhotons don't have original object ptrs
   bool overrideExistingValues_;
 };
 
-
-template<typename MapType,typename OutputType>
-EGExtraInfoModifierFromValueMaps<MapType,OutputType>::
-EGExtraInfoModifierFromValueMaps(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) :
-  ModifyObjectValueBase(conf) {
-  constexpr char electronSrc[] =  "electronSrc";
-  constexpr char photonSrc[] =  "photonSrc";
-  overrideExistingValues_ = conf.exists("overrideExistingValues") ? conf.getParameter<bool>("overrideExistingValues") : false;
-  if( conf.exists("electron_config") ) {
+template <typename MapType, typename OutputType>
+EGExtraInfoModifierFromValueMaps<MapType, OutputType>::EGExtraInfoModifierFromValueMaps(const edm::ParameterSet& conf,
+                                                                                        edm::ConsumesCollector& cc)
+    : ModifyObjectValueBase(conf) {
+  constexpr char electronSrc[] = "electronSrc";
+  constexpr char photonSrc[] = "photonSrc";
+  overrideExistingValues_ =
+      conf.exists("overrideExistingValues") ? conf.getParameter<bool>("overrideExistingValues") : false;
+  if (conf.exists("electron_config")) {
     const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
-    if( electrons.exists(electronSrc) ) e_conf.tok_electron_src = cc.consumes<edm::View<pat::Electron>>(electrons.getParameter<edm::InputTag>(electronSrc));
-  
+    if (electrons.exists(electronSrc))
+      e_conf.tok_electron_src =
+          cc.consumes<edm::View<pat::Electron>>(electrons.getParameter<edm::InputTag>(electronSrc));
+
     const std::vector<std::string> parameters = electrons.getParameterNames();
-    for( const std::string& name : parameters ) {
-      if( std::string(electronSrc) == name ) continue;
-      if( electrons.existsAs<edm::InputTag>(name) ) {
+    for (const std::string& name : parameters) {
+      if (std::string(electronSrc) == name)
+        continue;
+      if (electrons.existsAs<edm::InputTag>(name)) {
         e_conf.tok_valuemaps[name] = cc.consumes<edm::ValueMap<MapType>>(electrons.getParameter<edm::InputTag>(name));
       }
-    }    
+    }
   }
-  if( conf.exists("photon_config") ) {
+  if (conf.exists("photon_config")) {
     const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("photon_config");
-    if( photons.exists(photonSrc) ) ph_conf.tok_photon_src = cc.consumes<edm::View<pat::Photon>>(photons.getParameter<edm::InputTag>(photonSrc));
+    if (photons.exists(photonSrc))
+      ph_conf.tok_photon_src = cc.consumes<edm::View<pat::Photon>>(photons.getParameter<edm::InputTag>(photonSrc));
     const std::vector<std::string> parameters = photons.getParameterNames();
-    for( const std::string& name : parameters ) {
-      if( std::string(photonSrc) == name ) continue;
-      if( photons.existsAs<edm::InputTag>(name) ) {
+    for (const std::string& name : parameters) {
+      if (std::string(photonSrc) == name)
+        continue;
+      if (photons.existsAs<edm::InputTag>(name)) {
         ph_conf.tok_valuemaps[name] = cc.consumes<edm::ValueMap<MapType>>(photons.getParameter<edm::InputTag>(name));
       }
-    } 
+    }
   }
   ele_idx = pho_idx = 0;
 }
 
-template<typename MapType,typename OutputType>
-void EGExtraInfoModifierFromValueMaps<MapType,OutputType>::
-setEvent(const edm::Event& evt) {
+template <typename MapType, typename OutputType>
+void EGExtraInfoModifierFromValueMaps<MapType, OutputType>::setEvent(const edm::Event& evt) {
   eles_by_oop.clear();
-  phos_by_oop.clear();  
+  phos_by_oop.clear();
   ele_vmaps.clear();
   pho_vmaps.clear();
 
   ele_idx = pho_idx = 0;
 
-  if( !e_conf.tok_electron_src.isUninitialized() ) {
-    edm::Handle<edm::View<pat::Electron> > eles;
-    evt.getByToken(e_conf.tok_electron_src,eles);
-    
+  if (!e_conf.tok_electron_src.isUninitialized()) {
+    edm::Handle<edm::View<pat::Electron>> eles;
+    evt.getByToken(e_conf.tok_electron_src, eles);
+
     eles_by_oop.resize(eles->size());
     std::copy(eles->ptrs().begin(), eles->ptrs().end(), eles_by_oop.begin());
   }
 
-  for(auto const& itr : e_conf.tok_valuemaps) evt.getByToken(itr.second,ele_vmaps[itr.second.index()]);
+  for (auto const& itr : e_conf.tok_valuemaps)
+    evt.getByToken(itr.second, ele_vmaps[itr.second.index()]);
 
-  if( !ph_conf.tok_photon_src.isUninitialized() ) {
-    edm::Handle<edm::View<pat::Photon> > phos;
-    evt.getByToken(ph_conf.tok_photon_src,phos);
+  if (!ph_conf.tok_photon_src.isUninitialized()) {
+    edm::Handle<edm::View<pat::Photon>> phos;
+    evt.getByToken(ph_conf.tok_photon_src, phos);
 
     phos_by_oop.resize(phos->size());
     std::copy(phos->ptrs().begin(), phos->ptrs().end(), phos_by_oop.begin());
   }
 
-  for(auto const& itr : ph_conf.tok_valuemaps) evt.getByToken(itr.second,pho_vmaps[itr.second.index()]);
+  for (auto const& itr : ph_conf.tok_valuemaps)
+    evt.getByToken(itr.second, pho_vmaps[itr.second.index()]);
 }
 
 namespace {
-  template<typename T, typename U, typename V, typename MapType >
+  template <typename T, typename U, typename V, typename MapType>
   inline void assignValue(const T& ptr, const U& tok, const V& map, MapType& value) {
-    if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+    if (!tok.isUninitialized())
+      value = map.find(tok.index())->second->get(ptr.id(), ptr.key());
   }
-}
+}  // namespace
 
-template<typename MapType,typename OutputType>
-void EGExtraInfoModifierFromValueMaps<MapType,OutputType>::
-modifyObject(pat::Electron& ele) const {
+template <typename MapType, typename OutputType>
+void EGExtraInfoModifierFromValueMaps<MapType, OutputType>::modifyObject(pat::Electron& ele) const {
   // we encounter two cases here, either we are running AOD -> MINIAOD
   // and the value maps are to the reducedEG object, can use original object ptr
   // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference
   edm::Ptr<reco::Candidate> ptr(ele.originalObjectRef());
-  if( !e_conf.tok_electron_src.isUninitialized() ) ptr = eles_by_oop.at(ele_idx);
-  //now we go through and modify the objects using the valuemaps we read in 
-  EGXtraModFromVMObjFiller<OutputType>::addValuesToObject(ele,ptr,e_conf.tok_valuemaps,
-							  ele_vmaps,overrideExistingValues_);
+  if (!e_conf.tok_electron_src.isUninitialized())
+    ptr = eles_by_oop.at(ele_idx);
+  //now we go through and modify the objects using the valuemaps we read in
+  EGXtraModFromVMObjFiller<OutputType>::addValuesToObject(
+      ele, ptr, e_conf.tok_valuemaps, ele_vmaps, overrideExistingValues_);
   ++ele_idx;
 }
 
-
-template<typename MapType,typename OutputType>
-void EGExtraInfoModifierFromValueMaps<MapType,OutputType>::
-modifyObject(pat::Photon& pho) const {
+template <typename MapType, typename OutputType>
+void EGExtraInfoModifierFromValueMaps<MapType, OutputType>::modifyObject(pat::Photon& pho) const {
   // we encounter two cases here, either we are running AOD -> MINIAOD
   // and the value maps are to the reducedEG object, can use original object ptr
   // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference
   edm::Ptr<reco::Candidate> ptr(pho.originalObjectRef());
-  if( !ph_conf.tok_photon_src.isUninitialized() ) ptr = phos_by_oop.at(pho_idx);
+  if (!ph_conf.tok_photon_src.isUninitialized())
+    ptr = phos_by_oop.at(pho_idx);
   //now we go through and modify the objects using the valuemaps we read in
-  EGXtraModFromVMObjFiller<OutputType>::addValuesToObject(pho,ptr,ph_conf.tok_valuemaps,
-							  pho_vmaps,overrideExistingValues_);
-							  
+  EGXtraModFromVMObjFiller<OutputType>::addValuesToObject(
+      pho, ptr, ph_conf.tok_valuemaps, pho_vmaps, overrideExistingValues_);
+
   ++pho_idx;
 }
 
-
-template<typename OutputType>
-template<typename ObjType,typename MapType>
-void EGXtraModFromVMObjFiller<OutputType>::
-addValueToObject(ObjType& obj,
-		 const edm::Ptr<reco::Candidate>& ptr,
-		 const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
-		 const std::pair<const std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > > & val_map,
-		 bool overrideExistingValues)
-{
+template <typename OutputType>
+template <typename ObjType, typename MapType>
+void EGXtraModFromVMObjFiller<OutputType>::addValueToObject(
+    ObjType& obj,
+    const edm::Ptr<reco::Candidate>& ptr,
+    const std::unordered_map<unsigned, edm::Handle<edm::ValueMap<MapType>>>& vmaps,
+    const std::pair<const std::string, edm::EDGetTokenT<edm::ValueMap<MapType>>>& val_map,
+    bool overrideExistingValues) {
   MapType value{};
-  assignValue(ptr,val_map.second,vmaps,value);
-  if( overrideExistingValues || !obj.hasUserData(val_map.first) ) {
-    obj.addUserData(val_map.first,value,true);
+  assignValue(ptr, val_map.second, vmaps, value);
+  if (overrideExistingValues || !obj.hasUserData(val_map.first)) {
+    obj.addUserData(val_map.first, value, true);
   } else {
     throw cms::Exception("ValueNameAlreadyExists")
-      << "Trying to add new UserData = " << val_map.first
-      << " failed because it already exists and you didnt specify to override it (set in the config overrideExistingValues=cms.bool(True) )";
-  }
-}  
-
-template<>
-template<typename ObjType,typename MapType>
-void EGXtraModFromVMObjFiller<float>::
-addValueToObject(ObjType& obj,
-		 const edm::Ptr<reco::Candidate>& ptr,
-		 const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
-		 const std::pair<const std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > >& val_map,
-		 bool overrideExistingValues)
-{
-  float value(0.0);
-  assignValue(ptr,val_map.second,vmaps,value);
-  if( overrideExistingValues || !obj.hasUserFloat(val_map.first) ) {
-    obj.addUserFloat(val_map.first,value,true);
-  } else {
-    throw cms::Exception("ValueNameAlreadyExists")
-      << "Trying to add new UserFloat = " << val_map.first
-      << " failed because it already exists and you didnt specify to override it (set in the config overrideExistingValues=cms.bool(True) )";
+        << "Trying to add new UserData = " << val_map.first
+        << " failed because it already exists and you didnt specify to override it (set in the config "
+           "overrideExistingValues=cms.bool(True) )";
   }
 }
 
-template<>
-template<typename ObjType,typename MapType>
-void EGXtraModFromVMObjFiller<int>::
-addValueToObject(ObjType& obj,
-		 const edm::Ptr<reco::Candidate>& ptr,		 
-		 const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
-		 const std::pair<const std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > >& val_map,
-		 bool overrideExistingValues)
-{
-  int value(0);
-  assignValue(ptr,val_map.second,vmaps,value);
-  if( overrideExistingValues || !obj.hasUserInt(val_map.first) ) {
-    obj.addUserInt(val_map.first,value,true);
+template <>
+template <typename ObjType, typename MapType>
+void EGXtraModFromVMObjFiller<float>::addValueToObject(
+    ObjType& obj,
+    const edm::Ptr<reco::Candidate>& ptr,
+    const std::unordered_map<unsigned, edm::Handle<edm::ValueMap<MapType>>>& vmaps,
+    const std::pair<const std::string, edm::EDGetTokenT<edm::ValueMap<MapType>>>& val_map,
+    bool overrideExistingValues) {
+  float value(0.0);
+  assignValue(ptr, val_map.second, vmaps, value);
+  if (overrideExistingValues || !obj.hasUserFloat(val_map.first)) {
+    obj.addUserFloat(val_map.first, value, true);
   } else {
     throw cms::Exception("ValueNameAlreadyExists")
-      << "Trying to add new UserInt = " << val_map.first
-      << " failed because it already exists and you didnt specify to override it (set in the config overrideExistingValues=cms.bool(True) )";
+        << "Trying to add new UserFloat = " << val_map.first
+        << " failed because it already exists and you didnt specify to override it (set in the config "
+           "overrideExistingValues=cms.bool(True) )";
   }
-}  
+}
 
-template<>
-template<>
-void EGXtraModFromVMObjFiller<egmodifier::EGID>::
-addValuesToObject(pat::Electron& obj,
-		  const edm::Ptr<reco::Candidate>& ptr,
-		  const std::unordered_map<std::string,edm::EDGetTokenT<edm::ValueMap<float> > > & vmaps_token,		  
-		  const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > >& vmaps,
-		  bool overrideExistingValues)
-{
-  std::vector<std::pair<std::string,float >> ids;
-  for( auto itr = vmaps_token.begin(); itr != vmaps_token.end(); ++itr ) {
+template <>
+template <typename ObjType, typename MapType>
+void EGXtraModFromVMObjFiller<int>::addValueToObject(
+    ObjType& obj,
+    const edm::Ptr<reco::Candidate>& ptr,
+    const std::unordered_map<unsigned, edm::Handle<edm::ValueMap<MapType>>>& vmaps,
+    const std::pair<const std::string, edm::EDGetTokenT<edm::ValueMap<MapType>>>& val_map,
+    bool overrideExistingValues) {
+  int value(0);
+  assignValue(ptr, val_map.second, vmaps, value);
+  if (overrideExistingValues || !obj.hasUserInt(val_map.first)) {
+    obj.addUserInt(val_map.first, value, true);
+  } else {
+    throw cms::Exception("ValueNameAlreadyExists")
+        << "Trying to add new UserInt = " << val_map.first
+        << " failed because it already exists and you didnt specify to override it (set in the config "
+           "overrideExistingValues=cms.bool(True) )";
+  }
+}
+
+template <>
+template <>
+void EGXtraModFromVMObjFiller<egmodifier::EGID>::addValuesToObject(
+    pat::Electron& obj,
+    const edm::Ptr<reco::Candidate>& ptr,
+    const std::unordered_map<std::string, edm::EDGetTokenT<edm::ValueMap<float>>>& vmaps_token,
+    const std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float>>>& vmaps,
+    bool overrideExistingValues) {
+  std::vector<std::pair<std::string, float>> ids;
+  for (auto itr = vmaps_token.begin(); itr != vmaps_token.end(); ++itr) {
     float idVal(0);
-    assignValue(ptr,itr->second,vmaps,idVal);
-    ids.push_back({itr->first,idVal});
-  }   
-  std::sort(ids.begin(),ids.end(),[](auto& lhs,auto& rhs){return lhs.first<rhs.first;});
+    assignValue(ptr, itr->second, vmaps, idVal);
+    ids.push_back({itr->first, idVal});
+  }
+  std::sort(ids.begin(), ids.end(), [](auto& lhs, auto& rhs) { return lhs.first < rhs.first; });
   obj.setElectronIDs(ids);
 }
 
-template<>
-template<>
-void EGXtraModFromVMObjFiller<egmodifier::EGID>::
-addValuesToObject(pat::Photon& obj,
-		  const edm::Ptr<reco::Candidate>& ptr,
-		  const std::unordered_map<std::string,edm::EDGetTokenT<edm::ValueMap<float> > > & vmaps_token,		  
-		  const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > >& vmaps,
-		  bool overrideExistingValues)
-{
+template <>
+template <>
+void EGXtraModFromVMObjFiller<egmodifier::EGID>::addValuesToObject(
+    pat::Photon& obj,
+    const edm::Ptr<reco::Candidate>& ptr,
+    const std::unordered_map<std::string, edm::EDGetTokenT<edm::ValueMap<float>>>& vmaps_token,
+    const std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float>>>& vmaps,
+    bool overrideExistingValues) {
   //we do a float->bool conversion here to make things easier to be consistent with electrons
-  std::vector<std::pair<std::string,bool> > ids;
-  for( auto itr = vmaps_token.begin(); itr != vmaps_token.end(); ++itr ) {
+  std::vector<std::pair<std::string, bool>> ids;
+  for (auto itr = vmaps_token.begin(); itr != vmaps_token.end(); ++itr) {
     float idVal(0);
-    assignValue(ptr,itr->second,vmaps,idVal);
-    ids.push_back({itr->first,idVal});
-  }  
-  std::sort(ids.begin(),ids.end(),[](auto& lhs,auto& rhs){return lhs.first<rhs.first;});
+    assignValue(ptr, itr->second, vmaps, idVal);
+    ids.push_back({itr->first, idVal});
+  }
+  std::sort(ids.begin(), ids.end(), [](auto& lhs, auto& rhs) { return lhs.first < rhs.first; });
   obj.setPhotonIDs(ids);
 }
-
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EcalClusterLocal.h
+++ b/RecoEgamma/EgammaTools/interface/EcalClusterLocal.h
@@ -7,18 +7,29 @@
   *  \author Josh Bendavid, MIT, 2011
   */
 
-
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 
 class CaloGeometry;
 
 namespace egammaTools {
 
-    void localEcalClusterCoordsEB( const reco::CaloCluster &bclus, const CaloGeometry & geom, float &etacry,
-                                   float &phicry, int &ieta, int &iphi, float &thetatilt, float &phitilt);
-    void localEcalClusterCoordsEE( const reco::CaloCluster &bclus, const CaloGeometry & geom, float &xcry,
-                                   float &ycry, int &ix, int &iy, float &thetatilt, float &phitilt);
+  void localEcalClusterCoordsEB(const reco::CaloCluster &bclus,
+                                const CaloGeometry &geom,
+                                float &etacry,
+                                float &phicry,
+                                int &ieta,
+                                int &iphi,
+                                float &thetatilt,
+                                float &phitilt);
+  void localEcalClusterCoordsEE(const reco::CaloCluster &bclus,
+                                const CaloGeometry &geom,
+                                float &xcry,
+                                float &ycry,
+                                int &ix,
+                                int &iy,
+                                float &thetatilt,
+                                float &phitilt);
 
-};
+};  // namespace egammaTools
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EcalRegressionData.h
+++ b/RecoEgamma/EgammaTools/interface/EcalRegressionData.h
@@ -10,102 +10,103 @@
 class CaloGeometry;
 class CaloTopology;
 
-namespace reco{
+namespace reco {
   class SuperCluster;
 }
 
 class EcalRegressionData {
 public:
-  EcalRegressionData(){clear();}
-  
-  //this exists due to concerns that sub-cluster 1 is actually accessed 
-  //by subClusRawE_[0] and could potentially cause bugs 
-  //this although slightly wordy, makes it absolutely clear 
-  enum class SubClusNr{
-    C1=0,
-    C2=1,
-    C3=2
-  };
+  EcalRegressionData() { clear(); }
 
-  //direct accessors  
-  bool isEB()const{return isEB_;}
-  float scRawEnergy()const{return scRawEnergy_;}
-  float scCalibEnergy()const{return scCalibEnergy_;}
-  float scPreShowerEnergy()const{return scPreShowerEnergy_;}
-  float scEta()const{return scEta_;}
-  float scPhi()const{return scPhi_;}
-  float scEtaWidth()const{return scEtaWidth_;}
-  float scPhiWidth()const{return scPhiWidth_;}
-  int scNrAdditionalClusters()const{return scNrAdditionalClusters_;}
-  float seedClusEnergy()const{return seedClusEnergy_;}
-  float eMax()const{return eMax_;}
-  float e2nd()const{return e2nd_;}
-  float e3x3()const{return e3x3_;}
-  float eTop()const{return eTop_;}
-  float eBottom()const{return eBottom_;}
-  float eLeft()const{return eLeft_;}
-  float eRight()const{return eRight_;}
-  float sigmaIEtaIEta()const{return sigmaIEtaIEta_;}
-  float sigmaIEtaIPhi()const{return sigmaIEtaIPhi_;}
-  float sigmaIPhiIPhi()const{return sigmaIPhiIPhi_;}
- 
-  float seedCrysPhiOrY()const{return seedCrysPhiOrY_;}
-  float seedCrysEtaOrX()const{return seedCrysEtaOrX_;}
-  float seedCrysIEtaOrIX()const{return seedCrysIEtaOrIX_;}
-  float seedCrysIPhiOrIY()const{return seedCrysIPhiOrIY_;}
-  float maxSubClusDR()const{return std::sqrt(maxSubClusDR2_);}
-  float maxSubClusDRDPhi()const{return maxSubClusDRDPhi_;}
-  float maxSubClusDRDEta()const{return maxSubClusDRDEta_;}
-  float maxSubClusDRRawEnergy()const{return maxSubClusDRRawEnergy_;}
-  const std::vector<float>& subClusRawEnergy()const{return subClusRawEnergy_;}
-  const std::vector<float>& subClusDPhi()const{return subClusDPhi_;}
-  const std::vector<float>& subClusDEta()const{return subClusDEta_;}
-  int nrVtx()const{return nrVtx_;}
+  //this exists due to concerns that sub-cluster 1 is actually accessed
+  //by subClusRawE_[0] and could potentially cause bugs
+  //this although slightly wordy, makes it absolutely clear
+  enum class SubClusNr { C1 = 0, C2 = 1, C3 = 2 };
+
+  //direct accessors
+  bool isEB() const { return isEB_; }
+  float scRawEnergy() const { return scRawEnergy_; }
+  float scCalibEnergy() const { return scCalibEnergy_; }
+  float scPreShowerEnergy() const { return scPreShowerEnergy_; }
+  float scEta() const { return scEta_; }
+  float scPhi() const { return scPhi_; }
+  float scEtaWidth() const { return scEtaWidth_; }
+  float scPhiWidth() const { return scPhiWidth_; }
+  int scNrAdditionalClusters() const { return scNrAdditionalClusters_; }
+  float seedClusEnergy() const { return seedClusEnergy_; }
+  float eMax() const { return eMax_; }
+  float e2nd() const { return e2nd_; }
+  float e3x3() const { return e3x3_; }
+  float eTop() const { return eTop_; }
+  float eBottom() const { return eBottom_; }
+  float eLeft() const { return eLeft_; }
+  float eRight() const { return eRight_; }
+  float sigmaIEtaIEta() const { return sigmaIEtaIEta_; }
+  float sigmaIEtaIPhi() const { return sigmaIEtaIPhi_; }
+  float sigmaIPhiIPhi() const { return sigmaIPhiIPhi_; }
+
+  float seedCrysPhiOrY() const { return seedCrysPhiOrY_; }
+  float seedCrysEtaOrX() const { return seedCrysEtaOrX_; }
+  float seedCrysIEtaOrIX() const { return seedCrysIEtaOrIX_; }
+  float seedCrysIPhiOrIY() const { return seedCrysIPhiOrIY_; }
+  float maxSubClusDR() const { return std::sqrt(maxSubClusDR2_); }
+  float maxSubClusDRDPhi() const { return maxSubClusDRDPhi_; }
+  float maxSubClusDRDEta() const { return maxSubClusDRDEta_; }
+  float maxSubClusDRRawEnergy() const { return maxSubClusDRRawEnergy_; }
+  const std::vector<float>& subClusRawEnergy() const { return subClusRawEnergy_; }
+  const std::vector<float>& subClusDPhi() const { return subClusDPhi_; }
+  const std::vector<float>& subClusDEta() const { return subClusDEta_; }
+  int nrVtx() const { return nrVtx_; }
 
   //indirect accessors
-  float scPreShowerEnergyOverSCRawEnergy()const{return divideBySCRawEnergy_(scPreShowerEnergy());}
-  float scSeedR9()const{return divideBySCRawEnergy_(e3x3());}
-  float seedClusEnergyOverSCRawEnergy()const{return divideBySCRawEnergy_(seedClusEnergy());}
-  float eMaxOverSCRawEnergy()const{return divideBySCRawEnergy_(eMax());}
-  float e2ndOverSCRawEnergy()const{return divideBySCRawEnergy_(e2nd());}
-  float seedLeftRightAsym()const;
-  float seedTopBottomAsym()const;  
-  float maxSubClusDRRawEnergyOverSCRawEnergy()const{return divideBySCRawEnergy_(maxSubClusDRRawEnergy());}
-  float subClusRawEnergyOverSCRawEnergy(size_t clusNr)const{return divideBySCRawEnergy_(subClusRawEnergy(clusNr));}
-  float subClusRawEnergy(size_t clusNr)const;
-  float subClusDPhi(size_t clusNr)const;
-  float subClusDEta(size_t clusNr)const;
-  float subClusRawEnergyOverSCRawEnergy(SubClusNr clusNr)const{return subClusRawEnergyOverSCRawEnergy(static_cast<int>(clusNr));}
-  float subClusRawEnergy(SubClusNr clusNr)const{return subClusRawEnergy(static_cast<int>(clusNr));}
-  float subClusDPhi(SubClusNr clusNr)const{return subClusDPhi(static_cast<int>(clusNr));}
-  float subClusDEta(SubClusNr clusNr)const{return subClusDEta(static_cast<int>(clusNr));}
-  
+  float scPreShowerEnergyOverSCRawEnergy() const { return divideBySCRawEnergy_(scPreShowerEnergy()); }
+  float scSeedR9() const { return divideBySCRawEnergy_(e3x3()); }
+  float seedClusEnergyOverSCRawEnergy() const { return divideBySCRawEnergy_(seedClusEnergy()); }
+  float eMaxOverSCRawEnergy() const { return divideBySCRawEnergy_(eMax()); }
+  float e2ndOverSCRawEnergy() const { return divideBySCRawEnergy_(e2nd()); }
+  float seedLeftRightAsym() const;
+  float seedTopBottomAsym() const;
+  float maxSubClusDRRawEnergyOverSCRawEnergy() const { return divideBySCRawEnergy_(maxSubClusDRRawEnergy()); }
+  float subClusRawEnergyOverSCRawEnergy(size_t clusNr) const { return divideBySCRawEnergy_(subClusRawEnergy(clusNr)); }
+  float subClusRawEnergy(size_t clusNr) const;
+  float subClusDPhi(size_t clusNr) const;
+  float subClusDEta(size_t clusNr) const;
+  float subClusRawEnergyOverSCRawEnergy(SubClusNr clusNr) const {
+    return subClusRawEnergyOverSCRawEnergy(static_cast<int>(clusNr));
+  }
+  float subClusRawEnergy(SubClusNr clusNr) const { return subClusRawEnergy(static_cast<int>(clusNr)); }
+  float subClusDPhi(SubClusNr clusNr) const { return subClusDPhi(static_cast<int>(clusNr)); }
+  float subClusDEta(SubClusNr clusNr) const { return subClusDEta(static_cast<int>(clusNr)); }
 
   //modifiers
   void fill(const reco::SuperCluster& superClus,
-	    const EcalRecHitCollection* ebRecHits,const EcalRecHitCollection* eeRecHits,
-	    const CaloGeometry* geom,const CaloTopology* topology,
-	    const reco::VertexCollection* vertices){
-    fill(superClus,ebRecHits,eeRecHits,geom,topology,vertices->size());
+            const EcalRecHitCollection* ebRecHits,
+            const EcalRecHitCollection* eeRecHits,
+            const CaloGeometry* geom,
+            const CaloTopology* topology,
+            const reco::VertexCollection* vertices) {
+    fill(superClus, ebRecHits, eeRecHits, geom, topology, vertices->size());
   }
   void fill(const reco::SuperCluster& superClus,
-	    const EcalRecHitCollection* ebRecHits,const EcalRecHitCollection* eeRecHits,
-	    const CaloGeometry* geom,const CaloTopology* topology,
-	    int nrVertices);
+            const EcalRecHitCollection* ebRecHits,
+            const EcalRecHitCollection* eeRecHits,
+            const CaloGeometry* geom,
+            const CaloTopology* topology,
+            int nrVertices);
   void clear();
-  
+
   //converts output to single vector for use in training
-  void fillVec(std::vector<float>& inputVec)const;
-  
+  void fillVec(std::vector<float>& inputVec) const;
+
 private:
   //0 is obviously not a sensible energy for a supercluster so just return zero if this is the case
-  float divideBySCRawEnergy_(float numer)const{return scRawEnergy()!=0 ? numer/scRawEnergy() : 0.;}
-  void fillVecEB_(std::vector<float>& inputVec)const;
-  void fillVecEE_(std::vector<float>& inputVec)const;
-  
+  float divideBySCRawEnergy_(float numer) const { return scRawEnergy() != 0 ? numer / scRawEnergy() : 0.; }
+  void fillVecEB_(std::vector<float>& inputVec) const;
+  void fillVecEE_(std::vector<float>& inputVec) const;
+
 private:
   bool isEB_;
-  
+
   //supercluster quantities
   float scRawEnergy_;
   float scCalibEnergy_;
@@ -114,7 +115,7 @@ private:
   float scPhi_;
   float scEtaWidth_;
   float scPhiWidth_;
-  int scNrAdditionalClusters_; //excludes seed cluster
+  int scNrAdditionalClusters_;  //excludes seed cluster
 
   //seed cluster quantities
   float seedClusEnergy_;
@@ -146,7 +147,6 @@ private:
 
   //event quantities
   int nrVtx_;
-  
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EffectiveAreas.h
+++ b/RecoEgamma/EgammaTools/interface/EffectiveAreas.h
@@ -6,7 +6,6 @@
 #include <string>
 
 class EffectiveAreas {
-
 public:
   // Constructor, destructor
   EffectiveAreas(const std::string& filename);
@@ -20,11 +19,10 @@ public:
 
 private:
   // Data members
-  const std::string  filename_;  // effective areas source file name
-  std::vector<float> absEtaMin_; // low limit of the eta range
-  std::vector<float> absEtaMax_; // upper limit of the eta range
-  std::vector<float> effectiveAreaValues_; // effective area for this eta range
-
+  const std::string filename_;              // effective areas source file name
+  std::vector<float> absEtaMin_;            // low limit of the eta range
+  std::vector<float> absEtaMax_;            // upper limit of the eta range
+  std::vector<float> effectiveAreaValues_;  // effective area for this eta range
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EgammaBDTOutputTransformer.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaBDTOutputTransformer.h
@@ -2,25 +2,22 @@
 #define RecoEgamma_ElectronTools_EgammaBDTOutputTransformer_h
 
 //author: Sam Harper (RAL)
-//description: 
+//description:
 //  translates the raw value returned by the BDT output to the true value
 //  apparently its MINUIT-like, orginally taken from E/gamma regression applicator
 
 #include <vdt/vdtMath.h>
 
 class EgammaBDTOutputTransformer {
+public:
+  EgammaBDTOutputTransformer(const double limitLow, const double limitHigh)
+      : offset_(limitLow + 0.5 * (limitHigh - limitLow)), scale_(0.5 * (limitHigh - limitLow)) {}
 
-public:  
-  EgammaBDTOutputTransformer(const double limitLow,const double limitHigh):
-    offset_(limitLow + 0.5*(limitHigh-limitLow)),
-    scale_(0.5*(limitHigh-limitLow)){}
+  double operator()(const double rawVal) const { return offset_ + scale_ * vdt::fast_sin(rawVal); }
 
-  double operator()(const double rawVal)const{return offset_ + scale_*vdt::fast_sin(rawVal);}
- 
 private:
   const double offset_;
   const double scale_;
 };
-
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EgammaRandomSeeds.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaRandomSeeds.h
@@ -2,7 +2,7 @@
 #define RecoEgamma_EgammaTools_EgammaRandomSeeds_h
 
 //author: Sam Harper (RAL)
-//description: 
+//description:
 //  provides a seed for a random number generator based on object / event properties
 //  the supercluster method is prefered as it will be the same for electrons & photons
 //  the SC is based on seed ID and #crystals in SC, the #crystals in SC is for added
@@ -14,19 +14,24 @@
 
 #include <random>
 
-namespace egamma{
+namespace egamma {
 
-  uint32_t getRandomSeedFromSC(const edm::Event& iEvent,const reco::SuperClusterRef scRef);
-  template<typename T>
-  uint32_t getRandomSeedFromObj(const edm::Event& iEvent,const T& obj,size_t nrObjs,size_t objNr){
-    std::seed_seq seeder = {int(iEvent.id().event()), int(iEvent.id().luminosityBlock()), int(iEvent.id().run()),
-			    int(nrObjs),int(std::numeric_limits<int>::max()*obj.phi()/M_PI) & 0xFFF,int(objNr)};	   
+  uint32_t getRandomSeedFromSC(const edm::Event& iEvent, const reco::SuperClusterRef scRef);
+  template <typename T>
+  uint32_t getRandomSeedFromObj(const edm::Event& iEvent, const T& obj, size_t nrObjs, size_t objNr) {
+    std::seed_seq seeder = {int(iEvent.id().event()),
+                            int(iEvent.id().luminosityBlock()),
+                            int(iEvent.id().run()),
+                            int(nrObjs),
+                            int(std::numeric_limits<int>::max() * obj.phi() / M_PI) & 0xFFF,
+                            int(objNr)};
     uint32_t seed = 0, tries = 10;
     do {
-      seeder.generate(&seed,&seed+1); tries++;
+      seeder.generate(&seed, &seed + 1);
+      tries++;
     } while (seed == 0 && tries < 10);
-    return seed ? seed : iEvent.id().event() + 10000*objNr;
+    return seed ? seed : iEvent.id().event() + 10000 * objNr;
   }
-}
+}  // namespace egamma
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EgammaRegressionContainer.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaRegressionContainer.h
@@ -2,10 +2,10 @@
 #define RecoEgamma_EgammaTools_EgammaRegressionContainer_h
 
 //author: Sam Harper (RAL)
-//description: 
+//description:
 //  egamma energy regressions are binned in barrel/endcap and pt
 //  this simply contains the regression for each of (currently) 4 bins
-//  as well as the parameters to convert the raw BDT output back to 
+//  as well as the parameters to convert the raw BDT output back to
 //  the physical real value
 //  currently e/gamma also can optionally force saturated electrons
 //  to always be in the high et training
@@ -14,31 +14,30 @@
 
 #include <string>
 
-namespace edm{
+namespace edm {
   class ParameterSet;
   class ParameterSetDescription;
   class EventSetup;
-}
+}  // namespace edm
 class GBRForestD;
 
 class EgammaRegressionContainer {
 public:
-  
   EgammaRegressionContainer(const edm::ParameterSet& iConfig);
-  ~EgammaRegressionContainer(){}
+  ~EgammaRegressionContainer() {}
 
   static edm::ParameterSetDescription makePSetDescription();
 
-  void setEventContent(const edm::EventSetup& iSetup);  
+  void setEventContent(const edm::EventSetup& iSetup);
 
-  float operator()(const float et,const bool isEB,const bool isSaturated,const float* data)const;
+  float operator()(const float et, const bool isEB, const bool isSaturated, const float* data) const;
 
-  bool useLowEtBin(const float et,const bool isSaturated)const;
+  bool useLowEtBin(const float et, const bool isSaturated) const;
 
 private:
   const EgammaBDTOutputTransformer outputTransformerLowEt_;
   const EgammaBDTOutputTransformer outputTransformerHighEt_;
-  
+
   bool forceHighEnergyTrainingIfSaturated_;
   const float lowEtHighEtBoundary_;
   const std::string ebLowEtForestName_;
@@ -46,12 +45,10 @@ private:
   const std::string eeLowEtForestName_;
   const std::string eeHighEtForestName_;
 
-  const GBRForestD* ebLowEtForest_; //not owned
-  const GBRForestD* ebHighEtForest_; //not owned
-  const GBRForestD* eeLowEtForest_; //not owned
-  const GBRForestD* eeHighEtForest_; //not owned
-
+  const GBRForestD* ebLowEtForest_;   //not owned
+  const GBRForestD* ebHighEtForest_;  //not owned
+  const GBRForestD* eeLowEtForest_;   //not owned
+  const GBRForestD* eeHighEtForest_;  //not owned
 };
-
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EleEnergyRetriever.h
+++ b/RecoEgamma/EgammaTools/interface/EleEnergyRetriever.h
@@ -6,34 +6,41 @@
 
 class EleEnergyRetriever {
 public:
-  enum class EnergyType{EcalTrk,Ecal,SuperCluster,SuperClusterRaw};
-  
-  EleEnergyRetriever(const std::string& typeStr):
-    type_(convertFromStr(typeStr)){}
-       
-   static EnergyType convertFromStr(const std::string& typeStr){
-     if(typeStr=="EcalTrk") return EnergyType::EcalTrk;
-     else if(typeStr=="Ecal") return EnergyType::Ecal;
-     else if(typeStr=="SuperCluster") return EnergyType::SuperCluster;
-     else if(typeStr=="SuperClusterRaw") return EnergyType::SuperClusterRaw;
-     else {
-       throw cms::Exception("ConfigError") <<" type \""<<typeStr<<"\" not recognised, must be of type EcalTrk,Ecal,SuperCluster,SuperClusterRaw";
-     }
-   }
+  enum class EnergyType { EcalTrk, Ecal, SuperCluster, SuperClusterRaw };
 
-  float operator()(const reco::GsfElectron& ele)const{
-    switch(type_){
-    case EnergyType::EcalTrk: return ele.energy();
-    case EnergyType::Ecal: return ele.ecalEnergy();
-    case EnergyType::SuperCluster: return ele.superCluster()->energy();
-    case EnergyType::SuperClusterRaw: return ele.superCluster()->rawEnergy();
+  EleEnergyRetriever(const std::string& typeStr) : type_(convertFromStr(typeStr)) {}
+
+  static EnergyType convertFromStr(const std::string& typeStr) {
+    if (typeStr == "EcalTrk")
+      return EnergyType::EcalTrk;
+    else if (typeStr == "Ecal")
+      return EnergyType::Ecal;
+    else if (typeStr == "SuperCluster")
+      return EnergyType::SuperCluster;
+    else if (typeStr == "SuperClusterRaw")
+      return EnergyType::SuperClusterRaw;
+    else {
+      throw cms::Exception("ConfigError")
+          << " type \"" << typeStr << "\" not recognised, must be of type EcalTrk,Ecal,SuperCluster,SuperClusterRaw";
+    }
+  }
+
+  float operator()(const reco::GsfElectron& ele) const {
+    switch (type_) {
+      case EnergyType::EcalTrk:
+        return ele.energy();
+      case EnergyType::Ecal:
+        return ele.ecalEnergy();
+      case EnergyType::SuperCluster:
+        return ele.superCluster()->energy();
+      case EnergyType::SuperClusterRaw:
+        return ele.superCluster()->rawEnergy();
     }
     return 0.;
   }
 
 private:
   EnergyType type_;
-
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/ElectronEnergyCalibrator.h
+++ b/RecoEgamma/EgammaTools/interface/ElectronEnergyCalibrator.h
@@ -2,7 +2,7 @@
 #define RecoEgamma_EgammaTools_ElectronEnergyCalibrator_h
 
 //author: Alan Smithee
-//description: 
+//description:
 //  this class allows the residual scale and smearing to be applied to electrons
 //  the scale and smearing is on the ecal part of the energy
 //  hence the E/p combination needs to be re-don, hence the E/p Combination Tools
@@ -21,63 +21,64 @@
 
 #include <vector>
 
-class ElectronEnergyCalibrator
-{
+class ElectronEnergyCalibrator {
 public:
-  enum class EventType{
+  enum class EventType {
     DATA,
     MC,
   };
 
   ElectronEnergyCalibrator() {}
-  ElectronEnergyCalibrator(const EpCombinationTool &combinator, const std::string& correctionFile );
+  ElectronEnergyCalibrator(const EpCombinationTool& combinator, const std::string& correctionFile);
   ~ElectronEnergyCalibrator() {}
-  
+
   /// Initialize with a random number generator (if not done, it will use the CMSSW service)
   /// Caller code owns the TRandom.
-  void initPrivateRng(TRandom *rnd) ;
+  void initPrivateRng(TRandom* rnd);
 
   //set the minimum et to apply the correction to
-  void setMinEt(float val){minEt_=val;}
-  
+  void setMinEt(float val) { minEt_ = val; }
+
   /// Correct this electron.
   /// StreamID is needed when used with CMSSW Random Number Generator
-  std::array<float,EGEnergySysIndex::kNrSysErrs> 
-  calibrate(reco::GsfElectron &ele, const unsigned int runNumber, 
-	    const EcalRecHitCollection* recHits, edm::StreamID const & id, 
-	    const EventType eventType) const ;
+  std::array<float, EGEnergySysIndex::kNrSysErrs> calibrate(reco::GsfElectron& ele,
+                                                            const unsigned int runNumber,
+                                                            const EcalRecHitCollection* recHits,
+                                                            edm::StreamID const& id,
+                                                            const EventType eventType) const;
 
-  std::array<float,EGEnergySysIndex::kNrSysErrs>
-  calibrate(reco::GsfElectron &ele, const unsigned int runNumber, 
-	    const EcalRecHitCollection* recHits, const float smearNrSigma, 
-	    const EventType eventType) const ;
+  std::array<float, EGEnergySysIndex::kNrSysErrs> calibrate(reco::GsfElectron& ele,
+                                                            const unsigned int runNumber,
+                                                            const EcalRecHitCollection* recHits,
+                                                            const float smearNrSigma,
+                                                            const EventType eventType) const;
 
 private:
-  void setEnergyAndSystVarations(const float scale,const float smearNrSigma,const float et,
-				 const EnergyScaleCorrection::ScaleCorrection& scaleCorr,
-				 const EnergyScaleCorrection::SmearCorrection& smearCorr,
-				 reco::GsfElectron& ele,
-				 std::array<float,EGEnergySysIndex::kNrSysErrs>& energyData)const;
-    
-  void setEcalEnergy(reco::GsfElectron& ele,const float scale,const float smear)const;
-  std::pair<float,float> calCombinedMom(reco::GsfElectron& ele,const float scale,const float smear)const;
-  
+  void setEnergyAndSystVarations(const float scale,
+                                 const float smearNrSigma,
+                                 const float et,
+                                 const EnergyScaleCorrection::ScaleCorrection& scaleCorr,
+                                 const EnergyScaleCorrection::SmearCorrection& smearCorr,
+                                 reco::GsfElectron& ele,
+                                 std::array<float, EGEnergySysIndex::kNrSysErrs>& energyData) const;
+
+  void setEcalEnergy(reco::GsfElectron& ele, const float scale, const float smear) const;
+  std::pair<float, float> calCombinedMom(reco::GsfElectron& ele, const float scale, const float smear) const;
+
   /// Return a number distributed as a unit gaussian, drawn from the private RNG if initPrivateRng was called,
   /// or from the CMSSW RandomNumberGenerator service
   /// If synchronization is set to true, it returns a fixed number (1.0)
-  double gauss(edm::StreamID const& id) const ;
-  
+  double gauss(edm::StreamID const& id) const;
+
   // whatever data will be needed
   EnergyScaleCorrection correctionRetriever_;
-  const EpCombinationTool *epCombinationTool_; //this is not owned
-  TRandom *rng_; //this is not owned
+  const EpCombinationTool* epCombinationTool_;  //this is not owned
+  TRandom* rng_;                                //this is not owned
   float minEt_;
 
   //default values to access if no correction available
   static const EnergyScaleCorrection::ScaleCorrection defaultScaleCorr_;
   static const EnergyScaleCorrection::SmearCorrection defaultSmearCorr_;
-  
-
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EnergyScaleCorrection.h
+++ b/RecoEgamma/EgammaTools/interface/EnergyScaleCorrection.h
@@ -2,42 +2,29 @@
 #define RecoEgamma_EgammaTools_EnergyScaleCorrection_h
 
 //author: Alan Smithee
-//description: 
+//description:
 //  A port of Shervin Nourbakhsh's EnergyScaleCorrection_class in EgammaAnalysis/ElectronTools
 //  this reads the scale & smearing corrections in from a text file for given categories
 //  it then allows these values to be accessed
-
 
 #include <iostream>
 #include <fstream>
 #include <vector>
 #include <cmath>
 #include <string>
-#include <bitset> 
+#include <bitset>
 
+class EnergyScaleCorrection {
+public:
+  enum FileFormat { UNKNOWN = 0, GLOBE, ECALELF_TOY, ECALELF };
 
-class EnergyScaleCorrection
-{	
-public:  
-  enum FileFormat{
-    UNKNOWN=0,
-    GLOBE,
-    ECALELF_TOY,
-    ECALELF
-  };
+  enum ParamSmear { kNone = 0, kRho, kPhi, kNParamSmear };
 
-  enum ParamSmear{
-    kNone = 0,
-    kRho,
-    kPhi,
-    kNParamSmear
-  };
-  
-  enum ScaleNuisances{
+  enum ScaleNuisances {
     kErrStatBitNr = 0,
     kErrSystBitNr = 1,
     kErrGainBitNr = 2,
-    kErrNrBits=3,
+    kErrNrBits = 3,
     kErrNone = 0,
     kErrStat = 1,
     kErrSyst = 2,
@@ -47,138 +34,151 @@ public:
     kErrSystGain = 6,
     kErrStatSystGain = 7
   };
-  
-  
 
-  
-  class ScaleCorrection
-  {
-  public:  
-    ScaleCorrection():
-      scale_(1.),scaleErrStat_(0.),scaleErrSyst_(0.),scaleErrGain_(0.){}
-    ScaleCorrection(float iScale,float iScaleErrStat,float iScaleErrSyst,float iScaleErrGain):
-      scale_(iScale),scaleErrStat_(iScaleErrStat),scaleErrSyst_(iScaleErrSyst),scaleErrGain_(iScaleErrGain){}
-    
-    float scale()const{return scale_;}
-    float scaleErr(const std::bitset<kErrNrBits>& uncBitMask)const;
-    float scaleErrStat()const{return scaleErrStat_;}
-    float scaleErrSyst()const{return scaleErrSyst_;}
-    float scaleErrGain()const{return scaleErrGain_;}
+  class ScaleCorrection {
+  public:
+    ScaleCorrection() : scale_(1.), scaleErrStat_(0.), scaleErrSyst_(0.), scaleErrGain_(0.) {}
+    ScaleCorrection(float iScale, float iScaleErrStat, float iScaleErrSyst, float iScaleErrGain)
+        : scale_(iScale), scaleErrStat_(iScaleErrStat), scaleErrSyst_(iScaleErrSyst), scaleErrGain_(iScaleErrGain) {}
 
-    friend std::ostream& operator<<(std::ostream& os, const ScaleCorrection& a){return a.print(os);}
-    std::ostream& print(std::ostream& os)const;
-  private:    
+    float scale() const { return scale_; }
+    float scaleErr(const std::bitset<kErrNrBits>& uncBitMask) const;
+    float scaleErrStat() const { return scaleErrStat_; }
+    float scaleErrSyst() const { return scaleErrSyst_; }
+    float scaleErrGain() const { return scaleErrGain_; }
+
+    friend std::ostream& operator<<(std::ostream& os, const ScaleCorrection& a) { return a.print(os); }
+    std::ostream& print(std::ostream& os) const;
+
+  private:
     float scale_, scaleErrStat_, scaleErrSyst_, scaleErrGain_;
   };
-  
-  struct SmearCorrection
-  {
-  public:  
-    SmearCorrection():
-      rho_(0.),rhoErr_(0.),phi_(0.),phiErr_(0.),
-      eMean_(0.),eMeanErr_(0.){}
-    SmearCorrection(float iRho,float iRhoErr,float iPhi,float iPhiErr,float iEMean,float iEMeanErr):
-      rho_(iRho),rhoErr_(iRhoErr),phi_(iPhi),phiErr_(iPhiErr),
-      eMean_(iEMean),eMeanErr_(iEMeanErr){}
-    
-    friend std::ostream& operator<<(std::ostream& os, const SmearCorrection& a){return a.print(os);}
-    std::ostream& print(std::ostream& os)const;
-   
-   
-    float sigma(const float et,const float nrSigmaRho=0.,const float nrSigmaPhi=0.)const{
+
+  struct SmearCorrection {
+  public:
+    SmearCorrection() : rho_(0.), rhoErr_(0.), phi_(0.), phiErr_(0.), eMean_(0.), eMeanErr_(0.) {}
+    SmearCorrection(float iRho, float iRhoErr, float iPhi, float iPhiErr, float iEMean, float iEMeanErr)
+        : rho_(iRho), rhoErr_(iRhoErr), phi_(iPhi), phiErr_(iPhiErr), eMean_(iEMean), eMeanErr_(iEMeanErr) {}
+
+    friend std::ostream& operator<<(std::ostream& os, const SmearCorrection& a) { return a.print(os); }
+    std::ostream& print(std::ostream& os) const;
+
+    float sigma(const float et, const float nrSigmaRho = 0., const float nrSigmaPhi = 0.) const {
       const float rhoVal = rho_ + rhoErr_ * nrSigmaRho;
       const float phiVal = phi_ + phiErr_ * nrSigmaPhi;
-      const float constTerm =  rhoVal * std::sin(phiVal);
-      const float alpha =  rhoVal *  eMean_ * std::cos(phiVal);
+      const float constTerm = rhoVal * std::sin(phiVal);
+      const float alpha = rhoVal * eMean_ * std::cos(phiVal);
       return std::sqrt(constTerm * constTerm + alpha * alpha / et);
     }
+
   private:
     float rho_, rhoErr_;
     float phi_, phiErr_;
     float eMean_, eMeanErr_;
-
   };
-  
-  class CorrectionCategory
-  {  
+
+  class CorrectionCategory {
   public:
-    CorrectionCategory(const std::string& category,int runnrMin=0,int runnrMax=999999);
-    CorrectionCategory(const unsigned int runnr, const float et, const float eta, const float r9, 
-		       const unsigned int gainSeed):
-      runMin_(runnr),runMax_(runnr),etaMin_(std::abs(eta)),etaMax_(std::abs(eta)),
-      r9Min_(r9),r9Max_(r9),etMin_(et),etMax_(et),gain_(gainSeed){}
-    
+    CorrectionCategory(const std::string& category, int runnrMin = 0, int runnrMax = 999999);
+    CorrectionCategory(
+        const unsigned int runnr, const float et, const float eta, const float r9, const unsigned int gainSeed)
+        : runMin_(runnr),
+          runMax_(runnr),
+          etaMin_(std::abs(eta)),
+          etaMax_(std::abs(eta)),
+          r9Min_(r9),
+          r9Max_(r9),
+          etMin_(et),
+          etMax_(et),
+          gain_(gainSeed) {}
+
     bool operator<(const CorrectionCategory& b) const;
-    bool inCategory(const unsigned int runnr, const float et, const float eta, const float r9, 
-		    const unsigned int gainSeed)const;
-    
-    friend std::ostream& operator << (std::ostream& os, const CorrectionCategory& a){return a.print(os);}
-    std::ostream& print(std::ostream &os)const;
-    
+    bool inCategory(
+        const unsigned int runnr, const float et, const float eta, const float r9, const unsigned int gainSeed) const;
+
+    friend std::ostream& operator<<(std::ostream& os, const CorrectionCategory& a) { return a.print(os); }
+    std::ostream& print(std::ostream& os) const;
+
   private:
     //all boundaries are inclusive (X<=Y<=Z)
     unsigned int runMin_;
     unsigned int runMax_;
-    float etaMin_; ///< min eta value for the bin
-    float etaMax_; ///< max eta value for the bin
-    float r9Min_;  ///< min R9 vaule for the bin
-    float r9Max_;  ///< max R9 value for the bin
-    float etMin_;  ///< min Et value for the bin
-    float etMax_;  ///< max Et value for the bin
-    unsigned int gain_; ///< 12, 6, 1, 61 (double gain switch)
+    float etaMin_;       ///< min eta value for the bin
+    float etaMax_;       ///< max eta value for the bin
+    float r9Min_;        ///< min R9 vaule for the bin
+    float r9Max_;        ///< max R9 value for the bin
+    float etMin_;        ///< min Et value for the bin
+    float etMax_;        ///< max Et value for the bin
+    unsigned int gain_;  ///< 12, 6, 1, 61 (double gain switch)
   };
 
-    
 public:
-  EnergyScaleCorrection(const std::string& correctionFileName, unsigned int genSeed=0);
+  EnergyScaleCorrection(const std::string& correctionFileName, unsigned int genSeed = 0);
   EnergyScaleCorrection(){};
-  ~EnergyScaleCorrection(){}
-  
- 
-  float scaleCorr(unsigned int runnr, double et, double eta, double r9,
-		  unsigned int gainSeed=12, std::bitset<kErrNrBits> uncBitMask=kErrNone) const; 
-  
-  float scaleCorrUncert(unsigned int runnr, double et, double eta, double r9,
-			unsigned int gainSeed,std::bitset<kErrNrBits> uncBitMask=kErrNone) const;
-  
-  float smearingSigma(int runnr, double et, double eta, double r9, unsigned int gainSeed, ParamSmear par, float nSigma = 0.) const;
-  float smearingSigma(int runnr, double et, double eta, double r9, unsigned int gainSeed, float nSigmaRho, float nSigmaPhi) const;
-  
+  ~EnergyScaleCorrection() {}
+
+  float scaleCorr(unsigned int runnr,
+                  double et,
+                  double eta,
+                  double r9,
+                  unsigned int gainSeed = 12,
+                  std::bitset<kErrNrBits> uncBitMask = kErrNone) const;
+
+  float scaleCorrUncert(unsigned int runnr,
+                        double et,
+                        double eta,
+                        double r9,
+                        unsigned int gainSeed,
+                        std::bitset<kErrNrBits> uncBitMask = kErrNone) const;
+
+  float smearingSigma(
+      int runnr, double et, double eta, double r9, unsigned int gainSeed, ParamSmear par, float nSigma = 0.) const;
+  float smearingSigma(
+      int runnr, double et, double eta, double r9, unsigned int gainSeed, float nSigmaRho, float nSigmaPhi) const;
+
   void setSmearingType(FileFormat value);
 
-  const ScaleCorrection* getScaleCorr(unsigned int runnr, double et, double eta, double r9, unsigned int gainSeed) const; 
-  const SmearCorrection* getSmearCorr(unsigned int runnr, double et, double eta, double r9, unsigned int gainSeed) const; 
+  const ScaleCorrection* getScaleCorr(unsigned int runnr, double et, double eta, double r9, unsigned int gainSeed) const;
+  const SmearCorrection* getSmearCorr(unsigned int runnr, double et, double eta, double r9, unsigned int gainSeed) const;
 
- private:
+private:
+  void addScale(const std::string& category,
+                int runMin,
+                int runMax,
+                double deltaP,
+                double errDeltaP,
+                double errSystDeltaP,
+                double errDeltaPGain);
+  void addSmearing(const std::string& category,
+                   int runMin,
+                   int runMax,
+                   double rho,
+                   double errRho,
+                   double phi,
+                   double errPhi,
+                   double eMean,
+                   double errEMean);
 
-  void addScale(const std::string& category, int runMin, int runMax, 
-		double deltaP, double errDeltaP, double errSystDeltaP, double errDeltaPGain);
-  void addSmearing(const std::string& category, int runMin, int runMax,
-		   double rho, double errRho, double phi, double errPhi, 
-		   double eMean, double errEMean);
-  
-  void readScalesFromFile(const std::string& filename); 
-  void readSmearingsFromFile(const std::string& filename); 
+  void readScalesFromFile(const std::string& filename);
+  void readSmearingsFromFile(const std::string& filename);
 
   //static data members
   static constexpr float kDefaultScaleVal_ = 1.0;
   static constexpr float kDefaultSmearVal_ = 0.0;
 
   //data members
-  FileFormat smearingType_;  
-  std::vector<std::pair<CorrectionCategory,ScaleCorrection> >scales_;
-  std::vector<std::pair<CorrectionCategory,SmearCorrection> >smearings_;
-  
-  template<typename T1,typename T2>
-  class Sorter{
-  public:
-    bool operator()(const std::pair<T1,T2>& lhs,const T1& rhs)const{return lhs.first<rhs;}
-    bool operator()(const std::pair<T1,T2>& lhs,const std::pair<T1,T2>& rhs)const{return lhs.first<rhs.first;}
-    bool operator()(const T1& lhs,const std::pair<T1,T2>& rhs)const{return lhs<rhs.first;}
-    bool operator()(const T1& lhs,const T1& rhs)const{return lhs<rhs;}
-  };
-  
-};
+  FileFormat smearingType_;
+  std::vector<std::pair<CorrectionCategory, ScaleCorrection> > scales_;
+  std::vector<std::pair<CorrectionCategory, SmearCorrection> > smearings_;
 
+  template <typename T1, typename T2>
+  class Sorter {
+  public:
+    bool operator()(const std::pair<T1, T2>& lhs, const T1& rhs) const { return lhs.first < rhs; }
+    bool operator()(const std::pair<T1, T2>& lhs, const std::pair<T1, T2>& rhs) const { return lhs.first < rhs.first; }
+    bool operator()(const T1& lhs, const std::pair<T1, T2>& rhs) const { return lhs < rhs.first; }
+    bool operator()(const T1& lhs, const T1& rhs) const { return lhs < rhs; }
+  };
+};
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EpCombinationTool.h
+++ b/RecoEgamma/EgammaTools/interface/EpCombinationTool.h
@@ -7,26 +7,25 @@
 #include <vector>
 #include <utility>
 
-namespace edm{
+namespace edm {
   class ParameterSet;
   class ParameterSetDescription;
   class EventSetup;
-}
-namespace reco{
+}  // namespace edm
+namespace reco {
   class GsfElectron;
 }
 
-class EpCombinationTool
-{
+class EpCombinationTool {
 public:
   EpCombinationTool(const edm::ParameterSet& iConfig);
-  ~EpCombinationTool(){}
+  ~EpCombinationTool() {}
 
   static edm::ParameterSetDescription makePSetDescription();
 
   void setEventContent(const edm::EventSetup& iSetup);
   std::pair<float, float> combine(const reco::GsfElectron& electron) const;
-  std::pair<float, float> combine(const reco::GsfElectron& electron,float corrEcalEnergyErr) const;
+  std::pair<float, float> combine(const reco::GsfElectron& electron, float corrEcalEnergyErr) const;
 
 private:
   EgammaRegressionContainer ecalTrkEnergyRegress_;
@@ -35,8 +34,6 @@ private:
   float minEOverPForComb_;
   float maxEPDiffInSigmaForComb_;
   float maxRelTrkMomErrForComb_;
-  
 };
-
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/HGCalEgammaIDHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalEgammaIDHelper.h
@@ -17,7 +17,6 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
@@ -30,57 +29,57 @@
 
 class HGCalEgammaIDHelper {
 public:
-    HGCalEgammaIDHelper() {}
-    HGCalEgammaIDHelper(const edm::ParameterSet &, edm::ConsumesCollector && iC);
-    ~HGCalEgammaIDHelper() {}
+  HGCalEgammaIDHelper() {}
+  HGCalEgammaIDHelper(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+  ~HGCalEgammaIDHelper() {}
 
-    // Use eventInit once per event
-    void eventInit(const edm::Event& iEvent,const edm::EventSetup &iSetup);
+  // Use eventInit once per event
+  void eventInit(const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
-    // Call computeHGCAL before accessing results below
-    void computeHGCAL(const reco::Photon & thePhoton, float radius);
-    void computeHGCAL(const reco::GsfElectron & theElectron, float radius);
+  // Call computeHGCAL before accessing results below
+  void computeHGCAL(const reco::Photon& thePhoton, float radius);
+  void computeHGCAL(const reco::GsfElectron& theElectron, float radius);
 
-    // PCA results
-    double sigmaUU() const {  return pcaHelper_.sigmaUU();}
-    double sigmaVV() const {  return pcaHelper_.sigmaVV();}
-    double sigmaEE() const {  return pcaHelper_.sigmaEE();}
-    double sigmaPP() const {  return pcaHelper_.sigmaPP();}
-    const TVectorD& eigenValues () const {return pcaHelper_.eigenValues();}
-    const TVectorD& sigmas() const {return pcaHelper_.sigmas();}
-    const math::XYZPoint  & barycenter() const {return pcaHelper_.barycenter();}
-    const math::XYZVector & axis() const {return pcaHelper_.axis();}
+  // PCA results
+  double sigmaUU() const { return pcaHelper_.sigmaUU(); }
+  double sigmaVV() const { return pcaHelper_.sigmaVV(); }
+  double sigmaEE() const { return pcaHelper_.sigmaEE(); }
+  double sigmaPP() const { return pcaHelper_.sigmaPP(); }
+  const TVectorD& eigenValues() const { return pcaHelper_.eigenValues(); }
+  const TVectorD& sigmas() const { return pcaHelper_.sigmas(); }
+  const math::XYZPoint& barycenter() const { return pcaHelper_.barycenter(); }
+  const math::XYZVector& axis() const { return pcaHelper_.axis(); }
 
-    // longitudinal energy deposits and energy per subdetector as well as layers crossed
-    hgcal::LongDeps energyPerLayer(float radius, bool withHalo=true) {
-        return pcaHelper_.energyPerLayer(radius,withHalo);
-    }
+  // longitudinal energy deposits and energy per subdetector as well as layers crossed
+  hgcal::LongDeps energyPerLayer(float radius, bool withHalo = true) {
+    return pcaHelper_.energyPerLayer(radius, withHalo);
+  }
 
-    // shower depth (distance between start and shower max) from ShowerDepth tool
-    float clusterDepthCompatibility(const hgcal::LongDeps & ld, float & measDepth, float & expDepth, float & expSigma)
-        { return pcaHelper_.clusterDepthCompatibility(ld,measDepth,expDepth,expSigma);}
+  // shower depth (distance between start and shower max) from ShowerDepth tool
+  float clusterDepthCompatibility(const hgcal::LongDeps& ld, float& measDepth, float& expDepth, float& expSigma) {
+    return pcaHelper_.clusterDepthCompatibility(ld, measDepth, expDepth, expSigma);
+  }
 
-    // projective calo isolation
-    inline float getIsolationRing(unsigned int ring) const { return isoHelper_.getIso(ring); };
+  // projective calo isolation
+  inline float getIsolationRing(unsigned int ring) const { return isoHelper_.getIso(ring); };
 
-
-    // for debugging purposes
-    void printHits(float radius) const { pcaHelper_.printHits(radius); }
-    const hgcal::EGammaPCAHelper * pcaHelper () const {return &pcaHelper_;}
+  // for debugging purposes
+  void printHits(float radius) const { pcaHelper_.printHits(radius); }
+  const hgcal::EGammaPCAHelper* pcaHelper() const { return &pcaHelper_; }
 
 private:
-    edm::InputTag  eeRecHitInputTag_;
-    edm::InputTag  fhRecHitInputTag_;
-    edm::InputTag  bhRecHitInputTag_;
+  edm::InputTag eeRecHitInputTag_;
+  edm::InputTag fhRecHitInputTag_;
+  edm::InputTag bhRecHitInputTag_;
 
-    std::vector<double> dEdXWeights_;
-    hgcal::EGammaPCAHelper pcaHelper_;
-    HGCalIsoCalculator isoHelper_;
-    edm::EDGetTokenT<HGCRecHitCollection> recHitsEE_;
-    edm::EDGetTokenT<HGCRecHitCollection> recHitsFH_;
-    edm::EDGetTokenT<HGCRecHitCollection> recHitsBH_;
-    hgcal::RecHitTools recHitTools_;
-    bool debug_;
+  std::vector<double> dEdXWeights_;
+  hgcal::EGammaPCAHelper pcaHelper_;
+  HGCalIsoCalculator isoHelper_;
+  edm::EDGetTokenT<HGCRecHitCollection> recHitsEE_;
+  edm::EDGetTokenT<HGCRecHitCollection> recHitsFH_;
+  edm::EDGetTokenT<HGCRecHitCollection> recHitsBH_;
+  hgcal::RecHitTools recHitTools_;
+  bool debug_;
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/HGCalIsoCalculator.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalIsoCalculator.h
@@ -43,47 +43,44 @@
  *
  *
  */
-class HGCalIsoCalculator{
+class HGCalIsoCalculator {
 public:
-    HGCalIsoCalculator();
+  HGCalIsoCalculator();
 
-    ~HGCalIsoCalculator();
+  ~HGCalIsoCalculator();
 
-    void setDeltaR(const float dr){dr2_=dr*dr;}
+  void setDeltaR(const float dr) { dr2_ = dr * dr; }
 
-    void setMinDeltaR(const float dr){mindr2_=dr*dr;}
+  void setMinDeltaR(const float dr) { mindr2_ = dr * dr; }
 
-    void setRecHitTools(const hgcal::RecHitTools * recHitTools){rechittools_ = recHitTools;}
+  void setRecHitTools(const hgcal::RecHitTools* recHitTools) { rechittools_ = recHitTools; }
 
-    void setNRings(const size_t nrings);
+  void setNRings(const size_t nrings);
 
-    void setNLayers(unsigned int nLayers){nlayers_=nLayers;}
+  void setNLayers(unsigned int nLayers) { nlayers_ = nLayers; }
 
-    /// fill - once per event
-    void setRecHits(
-        edm::Handle<HGCRecHitCollection> hitsEE,
-        edm::Handle<HGCRecHitCollection> hitsFH,
-        edm::Handle<HGCRecHitCollection> hitsBH
-      );
+  /// fill - once per event
+  void setRecHits(edm::Handle<HGCRecHitCollection> hitsEE,
+                  edm::Handle<HGCRecHitCollection> hitsFH,
+                  edm::Handle<HGCRecHitCollection> hitsBH);
 
-    void produceHGCalIso(const reco::CaloClusterPtr & seedCluster);
+  void produceHGCalIso(const reco::CaloClusterPtr& seedCluster);
 
-    const float getIso(const unsigned int ring) const;
+  const float getIso(const unsigned int ring) const;
 
 private:
-    std::vector<float> isoringdeposits_;
-    std::vector<unsigned int> ringasso_;
+  std::vector<float> isoringdeposits_;
+  std::vector<unsigned int> ringasso_;
 
-    float dr2_,mindr2_;
+  float dr2_, mindr2_;
 
-    const hgcal::RecHitTools* rechittools_;
-    edm::Handle<HGCRecHitCollection> recHitsEE_;
-    edm::Handle<HGCRecHitCollection> recHitsFH_;
-    edm::Handle<HGCRecHitCollection> recHitsBH_;
-    std::vector<std::pair<float,float>> hitEtaPhiCache_;
-    bool debug_;
-    unsigned int nlayers_;
+  const hgcal::RecHitTools* rechittools_;
+  edm::Handle<HGCRecHitCollection> recHitsEE_;
+  edm::Handle<HGCRecHitCollection> recHitsFH_;
+  edm::Handle<HGCRecHitCollection> recHitsBH_;
+  std::vector<std::pair<float, float>> hitEtaPhiCache_;
+  bool debug_;
+  unsigned int nlayers_;
 };
-
 
 #endif /* RecoEgamma_EgammaTools_HGCalIsoCalculator_h */

--- a/RecoEgamma/EgammaTools/interface/HoECalculator.h
+++ b/RecoEgamma/EgammaTools/interface/HoECalculator.h
@@ -11,22 +11,16 @@
 
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
-class HoECalculator
-{
-  public:
-  
-   HoECalculator() ;
-   HoECalculator(const edm::ESHandle<CaloGeometry>&) ;
+class HoECalculator {
+public:
+  HoECalculator();
+  HoECalculator(const edm::ESHandle<CaloGeometry>&);
 
-   double operator() ( const reco::BasicCluster* , 
-                       const edm::Event& e , 
-		       const edm::EventSetup& c )  ;
-   
-   double operator() ( const reco::SuperCluster* , 
-                       const edm::Event& e , 
-		       const edm::EventSetup& c )  ;
-  
-   /*
+  double operator()(const reco::BasicCluster*, const edm::Event& e, const edm::EventSetup& c);
+
+  double operator()(const reco::SuperCluster*, const edm::Event& e, const edm::EventSetup& c);
+
+  /*
    double operator() ( const reco::SuperCluster* , 
                        HBHERecHitMetaCollection *mhbhe,
 		       int ialgo=1);
@@ -35,18 +29,15 @@ class HoECalculator
                        HBHERecHitMetaCollection *mhbhe);
    */
 
-  private:
-  
-   double getHoE(GlobalPoint pos, float energy,
-		 const edm::Event& e , 
-		 const edm::EventSetup& c )  ;
-   /*      
+private:
+  double getHoE(GlobalPoint pos, float energy, const edm::Event& e, const edm::EventSetup& c);
+  /*      
    double getHoE(GlobalPoint pos, float energy,
                  HBHERecHitMetaCollection *mhbhe);
    */
-   
-    edm::ESHandle<CaloGeometry>  theCaloGeom_ ;
-    const HBHERecHitCollection* hithbhe_ ;
+
+  edm::ESHandle<CaloGeometry> theCaloGeom_;
+  const HBHERecHitCollection* hithbhe_;
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/LongDeps.h
+++ b/RecoEgamma/EgammaTools/interface/LongDeps.h
@@ -11,36 +11,41 @@
 
 namespace hgcal {
 
-  class LongDeps{
-    public:
-      LongDeps(float radius, const std::vector<float>& energyPerLayer, float energyEE,float energyFH,float energyBH,const std::set<int>& layers);
-      ~LongDeps() {}
-      // to check the radius used
-      inline float radius() const {return radius_;};
-      inline float energyEE() const {return energyEE_;}
-      inline float energyFH() const {return energyFH_;}
-      inline float energyBH() const {return energyBH_;}
-      inline const std::vector<float>& energyPerLayer() const {return energyPerLayer_;}
-      inline const std::set<int> & layers() const {return layers_;}
-      inline unsigned nLayers() const { return layers_.size();}
-      inline int firstLayer() const { return (nLayers()>0 ? *layers_.begin() : -1 );}
-      inline int lastLayer() const { return (nLayers()>0 ? *layers_.rbegin() : -1) ;}
-      inline int layerEfrac10() const {return lay_Efrac10_ ; }
-      inline int layerEfrac90() const {return lay_Efrac90_ ; }
-      inline float e4oEtot () const {return e4oEtot_ ;}
+  class LongDeps {
+  public:
+    LongDeps(float radius,
+             const std::vector<float>& energyPerLayer,
+             float energyEE,
+             float energyFH,
+             float energyBH,
+             const std::set<int>& layers);
+    ~LongDeps() {}
+    // to check the radius used
+    inline float radius() const { return radius_; };
+    inline float energyEE() const { return energyEE_; }
+    inline float energyFH() const { return energyFH_; }
+    inline float energyBH() const { return energyBH_; }
+    inline const std::vector<float>& energyPerLayer() const { return energyPerLayer_; }
+    inline const std::set<int>& layers() const { return layers_; }
+    inline unsigned nLayers() const { return layers_.size(); }
+    inline int firstLayer() const { return (nLayers() > 0 ? *layers_.begin() : -1); }
+    inline int lastLayer() const { return (nLayers() > 0 ? *layers_.rbegin() : -1); }
+    inline int layerEfrac10() const { return lay_Efrac10_; }
+    inline int layerEfrac90() const { return lay_Efrac90_; }
+    inline float e4oEtot() const { return e4oEtot_; }
 
-    private:
-      std::vector<float> energyPerLayer_;
-      float radius_;
-      float energyEE_;
-      float energyFH_;
-      float energyBH_;
-      std::set<int> layers_;
-      int lay_Efrac10_ ;
-      int lay_Efrac90_ ;
-      float e4oEtot_;
-    };
+  private:
+    std::vector<float> energyPerLayer_;
+    float radius_;
+    float energyEE_;
+    float energyFH_;
+    float energyBH_;
+    std::set<int> layers_;
+    int lay_Efrac10_;
+    int lay_Efrac90_;
+    float e4oEtot_;
+  };
 
-}
+}  // namespace hgcal
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
+++ b/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
@@ -22,15 +22,12 @@
 
 template <class ParticleType>
 class MVAValueMapProducer : public edm::global::EDProducer<> {
-
-  public:
-
+public:
   MVAValueMapProducer(const edm::ParameterSet&);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  private:
-
+private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // for AOD and MiniAOD case
@@ -46,109 +43,100 @@ class MVAValueMapProducer : public edm::global::EDProducer<> {
 
   // To get the auxiliary MVA variables
   const MVAVariableHelper variableHelper_;
-
 };
 
 namespace {
 
-    template<typename ValueType, class HandleType>
-    void writeValueMap(edm::Event &iEvent,
-                       const edm::Handle<HandleType>& handle,
-                       const std::vector<ValueType>& values,
-                       const std::string& label)
-    {
-        auto valMap = std::make_unique<edm::ValueMap<ValueType>>();
-        typename edm::ValueMap<ValueType>::Filler filler(*valMap);
-        filler.insert(handle, values.begin(), values.end());
-        filler.fill();
-        iEvent.put(std::move(valMap),label);
-    }
+  template <typename ValueType, class HandleType>
+  void writeValueMap(edm::Event& iEvent,
+                     const edm::Handle<HandleType>& handle,
+                     const std::vector<ValueType>& values,
+                     const std::string& label) {
+    auto valMap = std::make_unique<edm::ValueMap<ValueType>>();
+    typename edm::ValueMap<ValueType>::Filler filler(*valMap);
+    filler.insert(handle, values.begin(), values.end());
+    filler.fill();
+    iEvent.put(std::move(valMap), label);
+  }
 
+  auto getMVAEstimators(const edm::VParameterSet& vConfig) {
+    std::vector<std::unique_ptr<AnyMVAEstimatorRun2Base>> mvaEstimators;
 
-    auto getMVAEstimators(const edm::VParameterSet& vConfig)
-    {
-      std::vector<std::unique_ptr<AnyMVAEstimatorRun2Base>> mvaEstimators;
+    // Loop over the list of MVA configurations passed here from python and
+    // construct all requested MVA estimators.
+    for (auto& imva : vConfig) {
+      // The factory below constructs the MVA of the appropriate type based
+      // on the "mvaName" which is the name of the derived MVA class (plugin)
+      if (!imva.empty()) {
+        mvaEstimators.emplace_back(
+            AnyMVAEstimatorRun2Factory::get()->create(imva.getParameter<std::string>("mvaName"), imva));
 
-      // Loop over the list of MVA configurations passed here from python and
-      // construct all requested MVA estimators.
-      for( auto &imva : vConfig )
-      {
-
-        // The factory below constructs the MVA of the appropriate type based
-        // on the "mvaName" which is the name of the derived MVA class (plugin)
-        if( !imva.empty() ) {
-
-          mvaEstimators.emplace_back(AnyMVAEstimatorRun2Factory::get()->create(
-                      imva.getParameter<std::string>("mvaName"), imva));
-
-        } else
-          throw cms::Exception(" MVA configuration not found: ")
+      } else
+        throw cms::Exception(" MVA configuration not found: ")
             << " failed to find proper configuration for one of the MVAs in the main python script " << std::endl;
-      }
-
-      return mvaEstimators;
     }
 
-    std::vector<std::string> getValueMapNames(const edm::VParameterSet& vConfig, std::string && suffix)
-    {
-      std::vector<std::string> names;
-      for( auto &imva : vConfig )
-      {
-        names.push_back(imva.getParameter<std::string>("mvaName") + imva.getParameter<std::string>("mvaTag") + suffix);
-      }
+    return mvaEstimators;
+  }
 
-      return names;
+  std::vector<std::string> getValueMapNames(const edm::VParameterSet& vConfig, std::string&& suffix) {
+    std::vector<std::string> names;
+    for (auto& imva : vConfig) {
+      names.push_back(imva.getParameter<std::string>("mvaName") + imva.getParameter<std::string>("mvaTag") + suffix);
     }
-}
+
+    return names;
+  }
+}  // namespace
 
 template <class ParticleType>
 MVAValueMapProducer<ParticleType>::MVAValueMapProducer(const edm::ParameterSet& iConfig)
-  : src_(consumes<edm::View<ParticleType>>(iConfig.getParameter<edm::InputTag>("src")))
-  , mvaEstimators_(getMVAEstimators(iConfig.getParameterSetVector("mvaConfigurations")))
-  , mvaValueMapNames_     (getValueMapNames(iConfig.getParameterSetVector("mvaConfigurations"), "Values"    ))
-  , mvaRawValueMapNames_  (getValueMapNames(iConfig.getParameterSetVector("mvaConfigurations"), "RawValues" ))
-  , mvaCategoriesMapNames_(getValueMapNames(iConfig.getParameterSetVector("mvaConfigurations"), "Categories"))
-  , variableHelper_(consumesCollector())
-{
-  for( auto const& name : mvaValueMapNames_      ) produces<edm::ValueMap<float>>(name);
-  for( auto const& name : mvaRawValueMapNames_   ) produces<edm::ValueMap<float>>(name);
-  for( auto const& name : mvaCategoriesMapNames_ ) produces<edm::ValueMap<int  >>(name);
+    : src_(consumes<edm::View<ParticleType>>(iConfig.getParameter<edm::InputTag>("src"))),
+      mvaEstimators_(getMVAEstimators(iConfig.getParameterSetVector("mvaConfigurations"))),
+      mvaValueMapNames_(getValueMapNames(iConfig.getParameterSetVector("mvaConfigurations"), "Values")),
+      mvaRawValueMapNames_(getValueMapNames(iConfig.getParameterSetVector("mvaConfigurations"), "RawValues")),
+      mvaCategoriesMapNames_(getValueMapNames(iConfig.getParameterSetVector("mvaConfigurations"), "Categories")),
+      variableHelper_(consumesCollector()) {
+  for (auto const& name : mvaValueMapNames_)
+    produces<edm::ValueMap<float>>(name);
+  for (auto const& name : mvaRawValueMapNames_)
+    produces<edm::ValueMap<float>>(name);
+  for (auto const& name : mvaCategoriesMapNames_)
+    produces<edm::ValueMap<int>>(name);
 }
 
 template <class ParticleType>
-void MVAValueMapProducer<ParticleType>::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
+void MVAValueMapProducer<ParticleType>::produce(edm::StreamID,
+                                                edm::Event& iEvent,
+                                                const edm::EventSetup& iSetup) const {
   std::vector<float> auxVariables = variableHelper_.getAuxVariables(iEvent);
 
   auto src = iEvent.getHandle(src_);
 
   // Loop over MVA estimators
-  for( unsigned iEstimator = 0; iEstimator < mvaEstimators_.size(); iEstimator++ ){
-
+  for (unsigned iEstimator = 0; iEstimator < mvaEstimators_.size(); iEstimator++) {
     std::vector<float> mvaValues;
     std::vector<float> mvaRawValues;
-    std::vector<int>   mvaCategories;
+    std::vector<int> mvaCategories;
 
     // Loop over particles
-    for (auto const& cand : src->ptrs())
-    {
-      int cat = -1; // Passed by reference to the mvaValue function to store the category
-      const float response = mvaEstimators_[iEstimator]->mvaValue( cand.get(), auxVariables, cat );
-      mvaRawValues.push_back( response ); // The MVA score
-      mvaValues.push_back( 2.0/(1.0+exp(-2.0*response))-1 ); // MVA output between -1 and 1
-      mvaCategories.push_back( cat );
-    } // end loop over particles
+    for (auto const& cand : src->ptrs()) {
+      int cat = -1;  // Passed by reference to the mvaValue function to store the category
+      const float response = mvaEstimators_[iEstimator]->mvaValue(cand.get(), auxVariables, cat);
+      mvaRawValues.push_back(response);                             // The MVA score
+      mvaValues.push_back(2.0 / (1.0 + exp(-2.0 * response)) - 1);  // MVA output between -1 and 1
+      mvaCategories.push_back(cat);
+    }  // end loop over particles
 
-    writeValueMap(iEvent, src, mvaValues    , mvaValueMapNames_     [iEstimator] );
-    writeValueMap(iEvent, src, mvaRawValues , mvaRawValueMapNames_  [iEstimator] );
-    writeValueMap(iEvent, src, mvaCategories, mvaCategoriesMapNames_[iEstimator] );
+    writeValueMap(iEvent, src, mvaValues, mvaValueMapNames_[iEstimator]);
+    writeValueMap(iEvent, src, mvaRawValues, mvaRawValueMapNames_[iEstimator]);
+    writeValueMap(iEvent, src, mvaCategories, mvaCategoriesMapNames_[iEstimator]);
 
-  } // end loop over estimators
-
+  }  // end loop over estimators
 }
 
 template <class ParticleType>
-  void MVAValueMapProducer<ParticleType>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void MVAValueMapProducer<ParticleType>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/RecoEgamma/EgammaTools/interface/MVAVariableHelper.h
+++ b/RecoEgamma/EgammaTools/interface/MVAVariableHelper.h
@@ -11,35 +11,29 @@
 #include <string>
 
 class MVAVariableIndexMap {
+public:
+  MVAVariableIndexMap();
 
-  public:
+  int getIndex(std::string const& name) const { return indexMap_.at(name); }
 
-    MVAVariableIndexMap();
-
-    int getIndex(std::string const& name) const { return indexMap_.at(name); }
-
-  private:
-
-    const std::unordered_map<std::string, int> indexMap_;
+private:
+  const std::unordered_map<std::string, int> indexMap_;
 };
 
 class MVAVariableHelper {
+public:
+  MVAVariableHelper(edm::ConsumesCollector&& cc);
 
-  public:
+  const std::vector<float> getAuxVariables(const edm::Event& iEvent) const;
 
-    MVAVariableHelper(edm::ConsumesCollector && cc);
+private:
+  static float getVariableFromDoubleToken(edm::EDGetToken const& token, const edm::Event& iEvent) {
+    edm::Handle<double> handle;
+    iEvent.getByToken(token, handle);
+    return *handle;
+  }
 
-    const std::vector<float> getAuxVariables(const edm::Event& iEvent) const;
-
-  private:
-
-    static float getVariableFromDoubleToken(edm::EDGetToken const& token, const edm::Event& iEvent) {
-        edm::Handle<double> handle;
-        iEvent.getByToken(token, handle);
-        return *handle;
-    }
-
-    const std::vector<edm::EDGetToken> tokens_;
+  const std::vector<edm::EDGetToken> tokens_;
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/MVAVariableManager.h
+++ b/RecoEgamma/EgammaTools/interface/MVAVariableManager.h
@@ -12,119 +12,114 @@
 
 template <class ParticleType>
 class MVAVariableManager {
+public:
+  MVAVariableManager(const std::string &variableDefinitionFileName) : nVars_(0) {
+    edm::FileInPath variableDefinitionFileEdm(variableDefinitionFileName);
+    std::ifstream file(variableDefinitionFileEdm.fullPath());
 
-  public:
-
-    MVAVariableManager(const std::string &variableDefinitionFileName)
-      : nVars_ (0)
-    {
-        edm::FileInPath variableDefinitionFileEdm(variableDefinitionFileName);
-        std::ifstream file(variableDefinitionFileEdm.fullPath());
-
-        std::string name, formula, upper, lower;
-        while( true ) {
-            file >> name;
-            if(file.eof()) {
-                break;
-            }
-            if (name.find("#") != std::string::npos) {
-                file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-                continue;
-            }
-            file >> formula >> lower >> upper;
-            if (file.eof()) {
-                break;
-            }
-            addVariable(name, formula, lower, upper);
-        }
+    std::string name, formula, upper, lower;
+    while (true) {
+      file >> name;
+      if (file.eof()) {
+        break;
+      }
+      if (name.find("#") != std::string::npos) {
+        file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        continue;
+      }
+      file >> formula >> lower >> upper;
+      if (file.eof()) {
+        break;
+      }
+      addVariable(name, formula, lower, upper);
     }
+  }
 
-    int getVarIndex(const std::string &name)
-    {
-        std::map<std::string,int>::iterator it = indexMap_.find(name);
-        if (it == indexMap_.end()) {
-            return -1;
-        } else {
-            return it->second;
-        }
+  int getVarIndex(const std::string &name) {
+    std::map<std::string, int>::iterator it = indexMap_.find(name);
+    if (it == indexMap_.end()) {
+      return -1;
+    } else {
+      return it->second;
     }
+  }
 
-    const std::string& getName(int index) const {
-        return names_[index];
+  const std::string &getName(int index) const { return names_[index]; }
+
+  int getNVars() const { return nVars_; }
+
+  float getValue(int index, const ParticleType &particle, const std::vector<float> &auxVariables) const {
+    float value;
+
+    MVAVariableInfo varInfo = variableInfos_[index];
+
+    if (varInfo.auxIndex >= 0)
+      value = auxVariables[varInfo.auxIndex];
+    else
+      value = functions_[index](particle);
+
+    if (varInfo.hasLowerClip && value < varInfo.lowerClipValue) {
+      value = varInfo.lowerClipValue;
     }
-
-    int getNVars() const {
-        return nVars_;
+    if (varInfo.hasUpperClip && value > varInfo.upperClipValue) {
+      value = varInfo.upperClipValue;
     }
+    return value;
+  }
 
-    float getValue(int index, const ParticleType& particle, const std::vector<float>& auxVariables) const {
-        float value;
+private:
+  struct MVAVariableInfo {
+    bool hasLowerClip;
+    bool hasUpperClip;
+    float lowerClipValue;
+    float upperClipValue;
+    int auxIndex;
+  };
 
-        MVAVariableInfo varInfo = variableInfos_[index];
+  void addVariable(const std::string &name,
+                   const std::string &formula,
+                   const std::string &lowerClip,
+                   const std::string &upperClip) {
+    bool hasLowerClip = lowerClip.find("None") == std::string::npos;
+    bool hasUpperClip = upperClip.find("None") == std::string::npos;
+    bool isAuxiliary = formula.find("Rho") != std::string::npos;  // *Rho* is still hardcoded...
+    float lowerClipValue = hasLowerClip ? (float)::atof(lowerClip.c_str()) : 0.;
+    float upperClipValue = hasUpperClip ? (float)::atof(upperClip.c_str()) : 0.;
 
-        if (varInfo.auxIndex >= 0) value = auxVariables[varInfo.auxIndex];
-        else value = functions_[index](particle);
+    if (!isAuxiliary)
+      functions_.emplace_back(formula);
+    // Else push back a dummy function since we won't use the
+    // StringObjectFunction to evaluate an auxiliary variable
+    else
+      functions_.emplace_back("pt");
 
-        if (varInfo.hasLowerClip && value < varInfo.lowerClipValue) {
-            value = varInfo.lowerClipValue;
-        }
-        if (varInfo.hasUpperClip && value > varInfo.upperClipValue) {
-            value = varInfo.upperClipValue;
-        }
-        return value;
-    }
+    formulas_.push_back(formula);
 
-  private:
+    int auxIndex = isAuxiliary ? indexMap.getIndex(formula) : -1;
 
-    struct MVAVariableInfo {
-        bool  hasLowerClip;
-        bool  hasUpperClip;
-        float lowerClipValue;
-        float upperClipValue;
-        int   auxIndex;
+    MVAVariableInfo varInfo{
+        .hasLowerClip = hasLowerClip,
+        .hasUpperClip = hasUpperClip,
+        .lowerClipValue = lowerClipValue,
+        .upperClipValue = upperClipValue,
+        .auxIndex = auxIndex,
     };
 
-    void addVariable(const std::string &name,      const std::string &formula,
-                     const std::string &lowerClip, const std::string &upperClip)
-    {
-        bool hasLowerClip = lowerClip.find("None") == std::string::npos;
-        bool hasUpperClip = upperClip.find("None") == std::string::npos;
-        bool isAuxiliary = formula.find("Rho") != std::string::npos; // *Rho* is still hardcoded...
-        float lowerClipValue = hasLowerClip ? (float)::atof(lowerClip.c_str()) : 0.;
-        float upperClipValue = hasUpperClip ? (float)::atof(upperClip.c_str()) : 0.;
+    variableInfos_.push_back(varInfo);
+    names_.push_back(name);
+    indexMap_[name] = nVars_;
+    nVars_++;
+  };
 
-        if ( !isAuxiliary ) functions_.emplace_back(formula);
-        // Else push back a dummy function since we won't use the
-        // StringObjectFunction to evaluate an auxiliary variable
-        else functions_.emplace_back("pt");
+  int nVars_;
 
-        formulas_.push_back(formula);
+  std::vector<MVAVariableInfo> variableInfos_;
+  std::vector<ThreadSafeStringCut<StringObjectFunction<ParticleType>, ParticleType>> functions_;
+  std::vector<std::string> formulas_;
+  std::vector<std::string> names_;
+  std::map<std::string, int> indexMap_;
 
-        int auxIndex = isAuxiliary ? indexMap.getIndex(formula) : -1;
-
-        MVAVariableInfo varInfo {
-            .hasLowerClip   = hasLowerClip,
-            .hasUpperClip   = hasUpperClip,
-            .lowerClipValue = lowerClipValue,
-            .upperClipValue = upperClipValue,
-            .auxIndex       = auxIndex,
-        };
-
-        variableInfos_.push_back(varInfo);
-        names_.push_back(name);
-        indexMap_[name] = nVars_;
-        nVars_++;
-    };
-
-    int nVars_;
-
-    std::vector<MVAVariableInfo> variableInfos_;
-    std::vector<ThreadSafeStringCut<StringObjectFunction<ParticleType>, ParticleType>> functions_;
-    std::vector<std::string> formulas_;
-    std::vector<std::string> names_;
-    std::map<std::string, int> indexMap_;
-
-    const MVAVariableIndexMap indexMap;
+  const MVAVariableIndexMap indexMap;
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/PhotonEnergyCalibrator.h
+++ b/RecoEgamma/EgammaTools/interface/PhotonEnergyCalibrator.h
@@ -2,7 +2,7 @@
 #define RecoEgamma_EgammaTools_PhotonEnergyCalibrator_h
 
 //author: Alan Smithee
-//description: 
+//description:
 //  this class allows the residual scale and smearing to be applied to photons
 //  returns a vector of calibrated energies and correction data, indexed by EGEnergySysIndex
 //  a port of EgammaAnalysis/ElectronTools/ElectronEnergyCalibratorRun2
@@ -17,57 +17,60 @@
 
 #include <vector>
 
-class PhotonEnergyCalibrator
-{
- public: 
-  enum class EventType{
+class PhotonEnergyCalibrator {
+public:
+  enum class EventType {
     DATA,
     MC,
   };
 
   PhotonEnergyCalibrator() {}
-  PhotonEnergyCalibrator(const std::string& correctionFile);  
-  ~PhotonEnergyCalibrator(){}
-  
+  PhotonEnergyCalibrator(const std::string& correctionFile);
+  ~PhotonEnergyCalibrator() {}
+
   /// Initialize with a random number generator (if not done, it will use the CMSSW service)
   /// Caller code owns the TRandom.
-  void initPrivateRng(TRandom *rnd) ;
+  void initPrivateRng(TRandom* rnd);
 
   //set the minimum et to apply the correction to
-  void setMinEt(float val){minEt_=val;}
-  
+  void setMinEt(float val) { minEt_ = val; }
+
   /// Correct this photon.
   /// StreamID is needed when used with CMSSW Random Number Generator
-  std::array<float,EGEnergySysIndex::kNrSysErrs> 
-  calibrate(reco::Photon &photon, const unsigned int runNumber, 
-	    const EcalRecHitCollection* recHits,  edm::StreamID const & id, const EventType eventType) const ;
+  std::array<float, EGEnergySysIndex::kNrSysErrs> calibrate(reco::Photon& photon,
+                                                            const unsigned int runNumber,
+                                                            const EcalRecHitCollection* recHits,
+                                                            edm::StreamID const& id,
+                                                            const EventType eventType) const;
 
-  std::array<float,EGEnergySysIndex::kNrSysErrs> 
-  calibrate(reco::Photon &photon, const unsigned int runNumber, 
-	    const EcalRecHitCollection* recHits, const float smearNrSigma, 
-	    const EventType eventType) const ;
-  
+  std::array<float, EGEnergySysIndex::kNrSysErrs> calibrate(reco::Photon& photon,
+                                                            const unsigned int runNumber,
+                                                            const EcalRecHitCollection* recHits,
+                                                            const float smearNrSigma,
+                                                            const EventType eventType) const;
+
 private:
-  void setEnergyAndSystVarations(const float scale,const float smearNrSigma,const float et,
-				 const EnergyScaleCorrection::ScaleCorrection& scaleCorr,
-				 const EnergyScaleCorrection::SmearCorrection& smearCorr,
-				 reco::Photon& photon,
-				 std::array<float,EGEnergySysIndex::kNrSysErrs>& energyData)const;
+  void setEnergyAndSystVarations(const float scale,
+                                 const float smearNrSigma,
+                                 const float et,
+                                 const EnergyScaleCorrection::ScaleCorrection& scaleCorr,
+                                 const EnergyScaleCorrection::SmearCorrection& smearCorr,
+                                 reco::Photon& photon,
+                                 std::array<float, EGEnergySysIndex::kNrSysErrs>& energyData) const;
 
   /// Return a number distributed as a unit gaussian, drawn from the private RNG if initPrivateRng was called,
   /// or from the CMSSW RandomNumberGenerator service
   /// If synchronization is set to true, it returns a fixed number (1.0)
-  double gauss(edm::StreamID const& id) const ;
+  double gauss(edm::StreamID const& id) const;
 
   // whatever data will be needed
   EnergyScaleCorrection correctionRetriever_;
-  TRandom *rng_; //this is not owned
+  TRandom* rng_;  //this is not owned
   float minEt_;
 
   //default values to access if no correction availible
   static const EnergyScaleCorrection::ScaleCorrection defaultScaleCorr_;
   static const EnergyScaleCorrection::SmearCorrection defaultSmearCorr_;
-  
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
@@ -10,7 +10,7 @@
 
 #ifndef EGAMMATOOLS_SCEnergyCorrectorSemiParm_H
 #define EGAMMATOOLS_SCEnergyCorrectorSemiParm_H
-    
+
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -18,7 +18,7 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
-#include "Geometry/CaloTopology/interface/CaloTopology.h" 
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -28,34 +28,34 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class SCEnergyCorrectorSemiParm {
- public:
+public:
   SCEnergyCorrectorSemiParm();
-  ~SCEnergyCorrectorSemiParm(); 
-  
+  ~SCEnergyCorrectorSemiParm();
+
   void setTokens(const edm::ParameterSet &iConfig, edm::ConsumesCollector &cc);
 
-  std::pair<double,double> getCorrections(const reco::SuperCluster &sc) const;
+  std::pair<double, double> getCorrections(const reco::SuperCluster &sc) const;
   void modifyObject(reco::SuperCluster &sc);
-  
+
   void setEventSetup(const edm::EventSetup &es);
   void setEvent(const edm::Event &e);
-  
- protected:    
+
+protected:
   const GBRForestD *foresteb_;
   const GBRForestD *forestee_;
   const GBRForestD *forestsigmaeb_;
   const GBRForestD *forestsigmaee_;
-  
+
   edm::ESHandle<CaloTopology> calotopo_;
   edm::ESHandle<CaloGeometry> calogeom_;
-  
+
   edm::EDGetTokenT<EcalRecHitCollection> tokenEBRecHits_;
   edm::EDGetTokenT<EcalRecHitCollection> tokenEERecHits_;
-  edm::EDGetTokenT<reco::VertexCollection> tokenVertices_;    
+  edm::EDGetTokenT<reco::VertexCollection> tokenVertices_;
 
   edm::Handle<reco::VertexCollection> vertices_;
-  edm::Handle<EcalRecHitCollection>  rechitsEB_;
-  edm::Handle<EcalRecHitCollection>  rechitsEE_;
+  edm::Handle<EcalRecHitCollection> rechitsEB_;
+  edm::Handle<EcalRecHitCollection> rechitsEE_;
 
   edm::InputTag ecalHitsEBInputTag_;
   edm::InputTag ecalHitsEEInputTag_;
@@ -66,9 +66,9 @@ class SCEnergyCorrectorSemiParm {
   std::string regressionKeyEE_;
   std::string uncertaintyKeyEE_;
 
- private:
+private:
   bool isHLT_;
-  bool applySigmaIetaIphiBug_; //there was a bug in sigmaIetaIphi for the 74X application
+  bool applySigmaIetaIphiBug_;  //there was a bug in sigmaIetaIphi for the 74X application
   int nHitsAboveThreshold_;
   float eThreshold_;
 };

--- a/RecoEgamma/EgammaTools/interface/SCRegressionCalculator.h
+++ b/RecoEgamma/EgammaTools/interface/SCRegressionCalculator.h
@@ -17,90 +17,80 @@
 #include <vector>
 #include <memory>
 
-template<class VarCalc> 
+template <class VarCalc>
 class SCRegressionCalculator {
- public:
+public:
   SCRegressionCalculator(const edm::ParameterSet&);
   void update(const edm::EventSetup&);
 
   std::unique_ptr<VarCalc>& varCalc() { return var_calc; }
 
   float getCorrection(const reco::SuperCluster&) const;
-  std::pair<float,float> 
-    getCorrectionWithErrors(const reco::SuperCluster&) const;  
+  std::pair<float, float> getCorrectionWithErrors(const reco::SuperCluster&) const;
 
- private:
+private:
   std::string eb_corr_name, ee_corr_name, eb_err_name, ee_err_name;
   const GBRWrapperRcd* gbr_record;
   edm::ESHandle<GBRForest> eb_corr, ee_corr, eb_err, ee_err;
-  std::unique_ptr<VarCalc> var_calc;  
+  std::unique_ptr<VarCalc> var_calc;
 };
 
-template<class VarCalc>
-SCRegressionCalculator<VarCalc>::
-SCRegressionCalculator(const edm::ParameterSet& conf) :
-  gbr_record(nullptr) {
+template <class VarCalc>
+SCRegressionCalculator<VarCalc>::SCRegressionCalculator(const edm::ParameterSet& conf) : gbr_record(nullptr) {
   var_calc.reset(new VarCalc());
   eb_corr_name = conf.getParameter<std::string>("regressionKeyEB");
   ee_corr_name = conf.getParameter<std::string>("regressionKeyEE");
-  if( conf.existsAs<std::string>("uncertaintyKeyEB") )
+  if (conf.existsAs<std::string>("uncertaintyKeyEB"))
     eb_err_name = conf.getParameter<std::string>("uncertaintyKeyEB");
-  if( conf.existsAs<std::string>("uncertaintyKeyEE") )
+  if (conf.existsAs<std::string>("uncertaintyKeyEE"))
     ee_err_name = conf.getParameter<std::string>("uncertaintyKeyEE");
-  
 }
 
-template<class VarCalc>
-void SCRegressionCalculator<VarCalc>::
-update(const edm::EventSetup& es) {
+template <class VarCalc>
+void SCRegressionCalculator<VarCalc>::update(const edm::EventSetup& es) {
   var_calc->update(es);
   const GBRWrapperRcd& gbrfrom_es = es.get<GBRWrapperRcd>();
-  if( !gbr_record || 
-      gbrfrom_es.cacheIdentifier() != gbr_record->cacheIdentifier() ) {
+  if (!gbr_record || gbrfrom_es.cacheIdentifier() != gbr_record->cacheIdentifier()) {
     gbr_record = &gbrfrom_es;
-    gbr_record->get(eb_corr_name.c_str(),eb_corr);    
-    gbr_record->get(ee_corr_name.c_str(),ee_corr);
-    if( eb_err_name.size() ) {
-      gbr_record->get(eb_err_name.c_str(),eb_err);      
+    gbr_record->get(eb_corr_name.c_str(), eb_corr);
+    gbr_record->get(ee_corr_name.c_str(), ee_corr);
+    if (eb_err_name.size()) {
+      gbr_record->get(eb_err_name.c_str(), eb_err);
     }
-    if( ee_err_name.size() ) {
-      gbr_record->get(ee_err_name.c_str(),ee_err);
+    if (ee_err_name.size()) {
+      gbr_record->get(ee_err_name.c_str(), ee_err);
     }
   }
 }
 
-template<class VarCalc>
-float SCRegressionCalculator<VarCalc>::
-getCorrection(const reco::SuperCluster& sc) const {
+template <class VarCalc>
+float SCRegressionCalculator<VarCalc>::getCorrection(const reco::SuperCluster& sc) const {
   std::vector<float> inputs;
-  var_calc->set(sc,inputs);
-  switch( sc.seed()->seed().subdetId() ) {
-  case EcalSubdetector::EcalBarrel:
-    return eb_corr->GetResponse(inputs.data());
-    break;
-  case EcalSubdetector::EcalEndcap:
-    return ee_corr->GetResponse(inputs.data());
-    break;
+  var_calc->set(sc, inputs);
+  switch (sc.seed()->seed().subdetId()) {
+    case EcalSubdetector::EcalBarrel:
+      return eb_corr->GetResponse(inputs.data());
+      break;
+    case EcalSubdetector::EcalEndcap:
+      return ee_corr->GetResponse(inputs.data());
+      break;
   }
   return -1.0f;
 }
 
-template<class VarCalc>
-std::pair<float,float> SCRegressionCalculator<VarCalc>::
-getCorrectionWithErrors(const reco::SuperCluster& sc) const {
+template <class VarCalc>
+std::pair<float, float> SCRegressionCalculator<VarCalc>::getCorrectionWithErrors(const reco::SuperCluster& sc) const {
   std::vector<float> inputs;
-  var_calc->set(sc,inputs);
-  switch( sc.seed()->seed().subdetId() ) {
-  case EcalSubdetector::EcalBarrel:
-    return std::make_pair( eb_corr->GetResponse(inputs.data()),
-			   eb_err->GetResponse(inputs.data())  );
-    break;
-  case EcalSubdetector::EcalEndcap:
-    return std::make_pair( ee_corr->GetResponse(inputs.data()),
-			   ee_err->GetResponse(inputs.data())  );
-    break;
+  var_calc->set(sc, inputs);
+  switch (sc.seed()->seed().subdetId()) {
+    case EcalSubdetector::EcalBarrel:
+      return std::make_pair(eb_corr->GetResponse(inputs.data()), eb_err->GetResponse(inputs.data()));
+      break;
+    case EcalSubdetector::EcalEndcap:
+      return std::make_pair(ee_corr->GetResponse(inputs.data()), ee_err->GetResponse(inputs.data()));
+      break;
   }
-  return std::make_pair(-1.0f,-1.0f);
+  return std::make_pair(-1.0f, -1.0f);
 }
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/ShowerDepth.h
+++ b/RecoEgamma/EgammaTools/interface/ShowerDepth.h
@@ -25,37 +25,40 @@
 namespace hgcal {
 
   class ShowerDepth {
-    public:
-      ShowerDepth() {}
-      ~ShowerDepth() {}
+  public:
+    ShowerDepth() {}
+    ~ShowerDepth() {}
 
-      float getClusterDepthCompatibility(float measuredDepth, float emEnergy, float & expectedDepth, float & expectedSigma) const;
+    float getClusterDepthCompatibility(float measuredDepth,
+                                       float emEnergy,
+                                       float& expectedDepth,
+                                       float& expectedSigma) const;
 
-    private:
-      // HGCAL average medium
-      static constexpr float criticalEnergy_ = 0.00536; // in GeV
-      static constexpr float radiationLength_ = 0.968; // in cm
+  private:
+    // HGCAL average medium
+    static constexpr float criticalEnergy_ = 0.00536;  // in GeV
+    static constexpr float radiationLength_ = 0.968;   // in cm
 
-      // mean values
-      // shower max <t_max> = t0 + t1*lny
-      static constexpr float meant0_{ -1.396 };
-      static constexpr float meant1_{ 1.007 };
-      // <alpha> = alpha0 + alpha1*lny
-      static constexpr float meanalpha0_{ -0.0433 };
-      static constexpr float meanalpha1_{ 0.540 };
-      // sigmas (relative uncertainty)
-      // sigma(ln(t_max)) = 1 / (sigmalnt0 + sigmalnt1*lny);
-      static constexpr float sigmalnt0_{ -2.506 };
-      static constexpr float sigmalnt1_{ 1.245 };
-      // sigma(ln(alpha)) = 1 / (sigmalnt0 + sigmalnt1*lny);
-      static constexpr float sigmalnalpha0_{ -0.08442 };
-      static constexpr float sigmalnalpha1_{ 0.7904 };
-      // correlation coefficient
-      // corr(ln(alpha), ln(t_max)) = corrlnalpha0_+corrlnalphalnt1_*lny
-      static constexpr float corrlnalphalnt0_{ 0.7858 };
-      static constexpr float corrlnalphalnt1_{ -0.0232 };
+    // mean values
+    // shower max <t_max> = t0 + t1*lny
+    static constexpr float meant0_{-1.396};
+    static constexpr float meant1_{1.007};
+    // <alpha> = alpha0 + alpha1*lny
+    static constexpr float meanalpha0_{-0.0433};
+    static constexpr float meanalpha1_{0.540};
+    // sigmas (relative uncertainty)
+    // sigma(ln(t_max)) = 1 / (sigmalnt0 + sigmalnt1*lny);
+    static constexpr float sigmalnt0_{-2.506};
+    static constexpr float sigmalnt1_{1.245};
+    // sigma(ln(alpha)) = 1 / (sigmalnt0 + sigmalnt1*lny);
+    static constexpr float sigmalnalpha0_{-0.08442};
+    static constexpr float sigmalnalpha1_{0.7904};
+    // correlation coefficient
+    // corr(ln(alpha), ln(t_max)) = corrlnalpha0_+corrlnalphalnt1_*lny
+    static constexpr float corrlnalphalnt0_{0.7858};
+    static constexpr float corrlnalphalnt1_{-0.0232};
   };
 
-}
+}  // namespace hgcal
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/Spot.h
+++ b/RecoEgamma/EgammaTools/interface/Spot.h
@@ -6,34 +6,41 @@
 
 namespace hgcal {
 
-  class Spot{
-    public:
-      Spot(DetId detid, double energy, const std::vector<double>& row, unsigned int layer, float fraction, double mip):
-          detId_(detid),energy_(energy),row_(row),layer_(layer),fraction_(fraction),
-          mip_(mip),multiplicity_(int(energy/mip)),subdet_(detid.subdetId()),isCore_(fraction>0.){}
-      ~Spot(){}
-      inline DetId detId() const {return detId_;}
-      inline float energy() const {return energy_;}
-      inline const double * row() const {return &row_[0];}
-      inline float fraction() const {return fraction_;}
-      inline float mip() const {return mip_;}
-      inline int multiplicity() const {return multiplicity_;}
-      inline unsigned int layer() const { return layer_;}
-      inline int subdet() const {return subdet_;}
-      inline bool isCore() const {return isCore_;}
+  class Spot {
+  public:
+    Spot(DetId detid, double energy, const std::vector<double>& row, unsigned int layer, float fraction, double mip)
+        : detId_(detid),
+          energy_(energy),
+          row_(row),
+          layer_(layer),
+          fraction_(fraction),
+          mip_(mip),
+          multiplicity_(int(energy / mip)),
+          subdet_(detid.subdetId()),
+          isCore_(fraction > 0.) {}
+    ~Spot() {}
+    inline DetId detId() const { return detId_; }
+    inline float energy() const { return energy_; }
+    inline const double* row() const { return &row_[0]; }
+    inline float fraction() const { return fraction_; }
+    inline float mip() const { return mip_; }
+    inline int multiplicity() const { return multiplicity_; }
+    inline unsigned int layer() const { return layer_; }
+    inline int subdet() const { return subdet_; }
+    inline bool isCore() const { return isCore_; }
 
-    private:
-      DetId detId_;
-      float energy_;
-      std::vector<double> row_;
-      unsigned int layer_;
-      float fraction_;
-      float mip_;
-      int multiplicity_;
-      int subdet_;
-      bool isCore_;
+  private:
+    DetId detId_;
+    float energy_;
+    std::vector<double> row_;
+    unsigned int layer_;
+    float fraction_;
+    float mip_;
+    int multiplicity_;
+    int subdet_;
+    bool isCore_;
   };
 
-}
+}  // namespace hgcal
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/ThreadSafeStringCut.h
+++ b/RecoEgamma/EgammaTools/interface/ThreadSafeStringCut.h
@@ -13,32 +13,24 @@
  *
  */
 
-template<class F, class T>
-class ThreadSafeStringCut
-{
-  public:
+template <class F, class T>
+class ThreadSafeStringCut {
+public:
+  ThreadSafeStringCut(const std::string& expr)  // constructor
+      : func_(expr), expr_(expr) {}
 
-    ThreadSafeStringCut(const std::string & expr) // constructor
-      : func_(expr)
-      , expr_(expr)
-    {}
+  ThreadSafeStringCut(ThreadSafeStringCut&& other) noexcept  // move constructor
+      : func_(std::move(other.func_)), expr_(std::move(other.expr_)) {}
 
-    ThreadSafeStringCut(ThreadSafeStringCut&& other) noexcept // move constructor
-      : func_(std::move(other.func_))
-      , expr_(std::move(other.expr_))
-    {}
+  typename std::invoke_result_t<F, T> operator()(const T& t) const {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return func_(t);
+  }
 
-    typename std::invoke_result_t<F,T> operator()(const T & t) const
-    {
-        std::lock_guard<std::mutex> guard(mutex_);
-        return func_(t);
-    }
-
-  private:
-
-    const F func_;
-    const std::string expr_;
-    CMS_THREAD_SAFE mutable std::mutex mutex_;
+private:
+  const F func_;
+  const std::string expr_;
+  CMS_THREAD_SAFE mutable std::mutex mutex_;
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/plugins/CalibratedElectronProducers.cc
+++ b/RecoEgamma/EgammaTools/plugins/CalibratedElectronProducers.cc
@@ -1,5 +1,5 @@
 //author: Alan Smithee
-//description: 
+//description:
 //  this class allows the residual scale and smearing to be applied to electrons
 //  the scale and smearing is on the ecal part of the energy
 //  hence the E/p combination needs to be re-don, hence the E/p Combination Tools
@@ -33,179 +33,163 @@
 
 #include <vector>
 
-
-template<typename T>
-class CalibratedElectronProducerT: public edm::stream::EDProducer<>
-{
+template <typename T>
+class CalibratedElectronProducerT : public edm::stream::EDProducer<> {
 public:
-  explicit CalibratedElectronProducerT( const edm::ParameterSet & ) ;
-  ~CalibratedElectronProducerT() override{}
+  explicit CalibratedElectronProducerT(const edm::ParameterSet&);
+  ~CalibratedElectronProducerT() override {}
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  void produce( edm::Event &, const edm::EventSetup & ) override ;
-  
-private: 
-  void setSemiDetRandomSeed(const edm::Event& iEvent,const T& obj,size_t nrObjs,size_t objNr);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-  edm::EDGetTokenT<edm::View<T> > electronToken_;
-  
-  EpCombinationTool        epCombinationTool_;
+private:
+  void setSemiDetRandomSeed(const edm::Event& iEvent, const T& obj, size_t nrObjs, size_t objNr);
+
+  edm::EDGetTokenT<edm::View<T>> electronToken_;
+
+  EpCombinationTool epCombinationTool_;
   ElectronEnergyCalibrator energyCorrector_;
   std::unique_ptr<TRandom> semiDeterministicRng_;
   edm::EDGetTokenT<EcalRecHitCollection> recHitCollectionEBToken_;
   edm::EDGetTokenT<EcalRecHitCollection> recHitCollectionEEToken_;
   bool produceCalibratedObjs_;
   static const std::vector<int> valMapsToStore_;
-
 };
 
-template<typename T>
+template <typename T>
 const std::vector<int> CalibratedElectronProducerT<T>::valMapsToStore_ = {
-  EGEnergySysIndex::kScaleStatUp,
-  EGEnergySysIndex::kScaleStatDown,
-  EGEnergySysIndex::kScaleSystUp,
-  EGEnergySysIndex::kScaleSystDown,
-  EGEnergySysIndex::kScaleGainUp,
-  EGEnergySysIndex::kScaleGainDown,
-  EGEnergySysIndex::kSmearRhoUp,
-  EGEnergySysIndex::kSmearRhoDown,
-  EGEnergySysIndex::kSmearPhiUp,
-  EGEnergySysIndex::kSmearPhiDown,
-  EGEnergySysIndex::kScaleUp,
-  EGEnergySysIndex::kScaleDown,
-  EGEnergySysIndex::kSmearUp,
-  EGEnergySysIndex::kSmearDown,
-  EGEnergySysIndex::kScaleValue,
-  EGEnergySysIndex::kSmearValue,
-  EGEnergySysIndex::kSmearNrSigma,
-  EGEnergySysIndex::kEcalPreCorr,
-  EGEnergySysIndex::kEcalErrPreCorr,
-  EGEnergySysIndex::kEcalPostCorr,
-  EGEnergySysIndex::kEcalErrPostCorr,
-  EGEnergySysIndex::kEcalTrkPreCorr,
-  EGEnergySysIndex::kEcalTrkErrPreCorr,
-  EGEnergySysIndex::kEcalTrkPostCorr,
-  EGEnergySysIndex::kEcalTrkErrPostCorr
-};
+    EGEnergySysIndex::kScaleStatUp,       EGEnergySysIndex::kScaleStatDown,     EGEnergySysIndex::kScaleSystUp,
+    EGEnergySysIndex::kScaleSystDown,     EGEnergySysIndex::kScaleGainUp,       EGEnergySysIndex::kScaleGainDown,
+    EGEnergySysIndex::kSmearRhoUp,        EGEnergySysIndex::kSmearRhoDown,      EGEnergySysIndex::kSmearPhiUp,
+    EGEnergySysIndex::kSmearPhiDown,      EGEnergySysIndex::kScaleUp,           EGEnergySysIndex::kScaleDown,
+    EGEnergySysIndex::kSmearUp,           EGEnergySysIndex::kSmearDown,         EGEnergySysIndex::kScaleValue,
+    EGEnergySysIndex::kSmearValue,        EGEnergySysIndex::kSmearNrSigma,      EGEnergySysIndex::kEcalPreCorr,
+    EGEnergySysIndex::kEcalErrPreCorr,    EGEnergySysIndex::kEcalPostCorr,      EGEnergySysIndex::kEcalErrPostCorr,
+    EGEnergySysIndex::kEcalTrkPreCorr,    EGEnergySysIndex::kEcalTrkErrPreCorr, EGEnergySysIndex::kEcalTrkPostCorr,
+    EGEnergySysIndex::kEcalTrkErrPostCorr};
 
-namespace{
-  template<typename HandleType,typename ValType>
-    void fillAndStoreValueMap(edm::Event& iEvent,HandleType objHandle,
-			      const std::vector<ValType>& vals,const std::string& name)
-  {
-    auto valMap = std::make_unique<edm::ValueMap<ValType> >();
+namespace {
+  template <typename HandleType, typename ValType>
+  void fillAndStoreValueMap(edm::Event& iEvent,
+                            HandleType objHandle,
+                            const std::vector<ValType>& vals,
+                            const std::string& name) {
+    auto valMap = std::make_unique<edm::ValueMap<ValType>>();
     typename edm::ValueMap<ValType>::Filler filler(*valMap);
-    filler.insert(objHandle,vals.begin(),vals.end());
+    filler.insert(objHandle, vals.begin(), vals.end());
     filler.fill();
-    iEvent.put(std::move(valMap),name);
+    iEvent.put(std::move(valMap), name);
   }
-}
+}  // namespace
 
-template<typename T>
-CalibratedElectronProducerT<T>::CalibratedElectronProducerT( const edm::ParameterSet & conf ) :
-  electronToken_(consumes<edm::View<T>>(conf.getParameter<edm::InputTag>("src"))),
-  epCombinationTool_(conf.getParameter<edm::ParameterSet>("epCombConfig")),
-  energyCorrector_(epCombinationTool_, conf.getParameter<std::string>("correctionFile")),
-  recHitCollectionEBToken_(consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitCollectionEB"))),
-  recHitCollectionEEToken_(consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitCollectionEE"))),
-  produceCalibratedObjs_(conf.getParameter<bool>("produceCalibratedObjs"))
-{
-  energyCorrector_.setMinEt(conf.getParameter<double>("minEtToCalibrate"));  
-  
+template <typename T>
+CalibratedElectronProducerT<T>::CalibratedElectronProducerT(const edm::ParameterSet& conf)
+    : electronToken_(consumes<edm::View<T>>(conf.getParameter<edm::InputTag>("src"))),
+      epCombinationTool_(conf.getParameter<edm::ParameterSet>("epCombConfig")),
+      energyCorrector_(epCombinationTool_, conf.getParameter<std::string>("correctionFile")),
+      recHitCollectionEBToken_(consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitCollectionEB"))),
+      recHitCollectionEEToken_(consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitCollectionEE"))),
+      produceCalibratedObjs_(conf.getParameter<bool>("produceCalibratedObjs")) {
+  energyCorrector_.setMinEt(conf.getParameter<double>("minEtToCalibrate"));
+
   if (conf.getParameter<bool>("semiDeterministic")) {
-     semiDeterministicRng_.reset(new TRandom2());
-     energyCorrector_.initPrivateRng(semiDeterministicRng_.get());
+    semiDeterministicRng_.reset(new TRandom2());
+    energyCorrector_.initPrivateRng(semiDeterministicRng_.get());
   }
 
-  if(produceCalibratedObjs_) produces<std::vector<T>>();
-  
-  for(const auto& toStore : valMapsToStore_){
+  if (produceCalibratedObjs_)
+    produces<std::vector<T>>();
+
+  for (const auto& toStore : valMapsToStore_) {
     produces<edm::ValueMap<float>>(EGEnergySysIndex::name(toStore));
   }
 }
 
-template<typename T>
-void CalibratedElectronProducerT<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
+template <typename T>
+void CalibratedElectronProducerT<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src",edm::InputTag("gedPhotons"));
-  desc.add<edm::ParameterSetDescription>("epCombConfig",EpCombinationTool::makePSetDescription());
-  desc.add<edm::InputTag>("recHitCollectionEB",edm::InputTag("reducedEcalRecHitsEB"));
-  desc.add<edm::InputTag>("recHitCollectionEE",edm::InputTag("reducedEcalRecHitsEE"));
-  desc.add<std::string>("correctionFile",std::string());
-  desc.add<double>("minEtToCalibrate",5.0);
-  desc.add<bool>("produceCalibratedObjs",true);
-  desc.add<bool>("semiDeterministic",true);
+  desc.add<edm::InputTag>("src", edm::InputTag("gedPhotons"));
+  desc.add<edm::ParameterSetDescription>("epCombConfig", EpCombinationTool::makePSetDescription());
+  desc.add<edm::InputTag>("recHitCollectionEB", edm::InputTag("reducedEcalRecHitsEB"));
+  desc.add<edm::InputTag>("recHitCollectionEE", edm::InputTag("reducedEcalRecHitsEE"));
+  desc.add<std::string>("correctionFile", std::string());
+  desc.add<double>("minEtToCalibrate", 5.0);
+  desc.add<bool>("produceCalibratedObjs", true);
+  desc.add<bool>("semiDeterministic", true);
   std::vector<std::string> valMapsProduced;
-  for(auto varToStore : valMapsToStore_) valMapsProduced.push_back(EGEnergySysIndex::name(varToStore));
-  desc.add<std::vector<std::string> >("valueMapsStored",valMapsProduced)->setComment("provides to python configs the list of valuemaps stored, can not be overriden in the python config");
+  for (auto varToStore : valMapsToStore_)
+    valMapsProduced.push_back(EGEnergySysIndex::name(varToStore));
+  desc.add<std::vector<std::string>>("valueMapsStored", valMapsProduced)
+      ->setComment(
+          "provides to python configs the list of valuemaps stored, can not be overriden in the python config");
   descriptions.addWithDefaultLabel(desc);
 }
 
-template<typename T>
-void
-CalibratedElectronProducerT<T>::produce( edm::Event & iEvent, const edm::EventSetup & iSetup ) 
-{
-  
+template <typename T>
+void CalibratedElectronProducerT<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   epCombinationTool_.setEventContent(iSetup);
-  
+
   edm::Handle<edm::View<T>> inHandle;
   iEvent.getByToken(electronToken_, inHandle);
-  
+
   edm::Handle<EcalRecHitCollection> recHitCollectionEBHandle;
   edm::Handle<EcalRecHitCollection> recHitCollectionEEHandle;
-  
+
   iEvent.getByToken(recHitCollectionEBToken_, recHitCollectionEBHandle);
   iEvent.getByToken(recHitCollectionEEToken_, recHitCollectionEEHandle);
-  
+
   std::unique_ptr<std::vector<T>> out = std::make_unique<std::vector<T>>();
 
   size_t nrObj = inHandle->size();
-  std::array<std::vector<float>,EGEnergySysIndex::kNrSysErrs> results;
-  for(auto& res : results) res.reserve(nrObj);
+  std::array<std::vector<float>, EGEnergySysIndex::kNrSysErrs> results;
+  for (auto& res : results)
+    res.reserve(nrObj);
 
-  const ElectronEnergyCalibrator::EventType evtType = iEvent.isRealData() ? 
-    ElectronEnergyCalibrator::EventType::DATA : ElectronEnergyCalibrator::EventType::MC; 
-  
-  
+  const ElectronEnergyCalibrator::EventType evtType =
+      iEvent.isRealData() ? ElectronEnergyCalibrator::EventType::DATA : ElectronEnergyCalibrator::EventType::MC;
+
   for (const auto& ele : *inHandle) {
     out->push_back(ele);
-    
-    if(semiDeterministicRng_) setSemiDetRandomSeed(iEvent,ele,nrObj,out->size());
 
-    const EcalRecHitCollection* recHits = (ele.isEB()) ? recHitCollectionEBHandle.product() : recHitCollectionEEHandle.product();
-    std::array<float,EGEnergySysIndex::kNrSysErrs> uncertainties = energyCorrector_.calibrate(out->back(), iEvent.id().run(), recHits, iEvent.streamID(), evtType);
-    
-    for(size_t index=0;index<EGEnergySysIndex::kNrSysErrs;index++){
+    if (semiDeterministicRng_)
+      setSemiDetRandomSeed(iEvent, ele, nrObj, out->size());
+
+    const EcalRecHitCollection* recHits =
+        (ele.isEB()) ? recHitCollectionEBHandle.product() : recHitCollectionEEHandle.product();
+    std::array<float, EGEnergySysIndex::kNrSysErrs> uncertainties =
+        energyCorrector_.calibrate(out->back(), iEvent.id().run(), recHits, iEvent.streamID(), evtType);
+
+    for (size_t index = 0; index < EGEnergySysIndex::kNrSysErrs; index++) {
       results[index].push_back(uncertainties[index]);
     }
   }
 
-  auto fillAndStore = [&](auto handle){
-    for(const auto& mapToStore : valMapsToStore_){
-      fillAndStoreValueMap(iEvent,handle,results[mapToStore],EGEnergySysIndex::name(mapToStore));
+  auto fillAndStore = [&](auto handle) {
+    for (const auto& mapToStore : valMapsToStore_) {
+      fillAndStoreValueMap(iEvent, handle, results[mapToStore], EGEnergySysIndex::name(mapToStore));
     }
   };
-  
-  if(produceCalibratedObjs_){
+
+  if (produceCalibratedObjs_) {
     fillAndStore(iEvent.put(std::move(out)));
-  }else{
+  } else {
     fillAndStore(inHandle);
   }
-  
 }
 
-template<typename T>
-void CalibratedElectronProducerT<T>::setSemiDetRandomSeed(const edm::Event& iEvent,const T& obj,size_t nrObjs,size_t objNr)
-{
-  if(obj.superCluster().isNonnull()){
-    semiDeterministicRng_->SetSeed(egamma::getRandomSeedFromSC(iEvent,obj.superCluster()));
-  }else{
-    semiDeterministicRng_->SetSeed(egamma::getRandomSeedFromObj(iEvent,obj,nrObjs,objNr));
+template <typename T>
+void CalibratedElectronProducerT<T>::setSemiDetRandomSeed(const edm::Event& iEvent,
+                                                          const T& obj,
+                                                          size_t nrObjs,
+                                                          size_t objNr) {
+  if (obj.superCluster().isNonnull()) {
+    semiDeterministicRng_->SetSeed(egamma::getRandomSeedFromSC(iEvent, obj.superCluster()));
+  } else {
+    semiDeterministicRng_->SetSeed(egamma::getRandomSeedFromObj(iEvent, obj, nrObjs, objNr));
   }
 }
 
 using CalibratedElectronProducer = CalibratedElectronProducerT<reco::GsfElectron>;
-using CalibratedPatElectronProducer = CalibratedElectronProducerT<pat::Electron>; 
+using CalibratedPatElectronProducer = CalibratedElectronProducerT<pat::Electron>;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/RecoEgamma/EgammaTools/plugins/CalibratedPhotonProducers.cc
+++ b/RecoEgamma/EgammaTools/plugins/CalibratedPhotonProducers.cc
@@ -1,7 +1,7 @@
 //author: Alan Smithee
-//description: 
+//description:
 //  this class allows the residual scale and smearing to be applied to photon
-//  it will write out all the calibration info in the event, such as scale correction value, 
+//  it will write out all the calibration info in the event, such as scale correction value,
 //  smearing correction value, random nr used, energy post calibration, energy pre calibration
 //  can optionally write out a new collection of photon with the energy corrected by default
 //  a port of EgammaAnalysis/ElectronTools/CalibratedPhotonProducerRun2
@@ -28,163 +28,152 @@
 #include <vector>
 #include <random>
 
-template<typename T>
-class CalibratedPhotonProducerT: public edm::stream::EDProducer<> {
+template <typename T>
+class CalibratedPhotonProducerT : public edm::stream::EDProducer<> {
 public:
-  explicit CalibratedPhotonProducerT( const edm::ParameterSet & ) ;
+  explicit CalibratedPhotonProducerT(const edm::ParameterSet&);
   ~CalibratedPhotonProducerT() override{};
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  void produce( edm::Event &, const edm::EventSetup & ) override ;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  void setSemiDetRandomSeed(const edm::Event& iEvent,const T& obj,size_t nrObjs,size_t objNr);
+  void setSemiDetRandomSeed(const edm::Event& iEvent, const T& obj, size_t nrObjs, size_t objNr);
 
-  edm::EDGetTokenT<edm::View<T> > photonToken_;
-  PhotonEnergyCalibrator      energyCorrector_;
+  edm::EDGetTokenT<edm::View<T>> photonToken_;
+  PhotonEnergyCalibrator energyCorrector_;
   std::unique_ptr<TRandom> semiDeterministicRng_;
   edm::EDGetTokenT<EcalRecHitCollection> recHitCollectionEBToken_;
   edm::EDGetTokenT<EcalRecHitCollection> recHitCollectionEEToken_;
   bool produceCalibratedObjs_;
 
   static const std::vector<int> valMapsToStore_;
-
 };
 
-template<typename T>
+template <typename T>
 const std::vector<int> CalibratedPhotonProducerT<T>::valMapsToStore_ = {
-  EGEnergySysIndex::kScaleStatUp,
-  EGEnergySysIndex::kScaleStatDown,
-  EGEnergySysIndex::kScaleSystUp,
-  EGEnergySysIndex::kScaleSystDown,
-  EGEnergySysIndex::kScaleGainUp,
-  EGEnergySysIndex::kScaleGainDown,
-  EGEnergySysIndex::kSmearRhoUp,
-  EGEnergySysIndex::kSmearRhoDown,
-  EGEnergySysIndex::kSmearPhiUp,
-  EGEnergySysIndex::kSmearPhiDown,
-  EGEnergySysIndex::kScaleUp,
-  EGEnergySysIndex::kScaleDown,
-  EGEnergySysIndex::kSmearUp,
-  EGEnergySysIndex::kSmearDown,
-  EGEnergySysIndex::kScaleValue,
-  EGEnergySysIndex::kSmearValue,
-  EGEnergySysIndex::kSmearNrSigma,
-  EGEnergySysIndex::kEcalPreCorr,
-  EGEnergySysIndex::kEcalErrPreCorr,
-  EGEnergySysIndex::kEcalPostCorr,
-  EGEnergySysIndex::kEcalErrPostCorr
-};
+    EGEnergySysIndex::kScaleStatUp,    EGEnergySysIndex::kScaleStatDown, EGEnergySysIndex::kScaleSystUp,
+    EGEnergySysIndex::kScaleSystDown,  EGEnergySysIndex::kScaleGainUp,   EGEnergySysIndex::kScaleGainDown,
+    EGEnergySysIndex::kSmearRhoUp,     EGEnergySysIndex::kSmearRhoDown,  EGEnergySysIndex::kSmearPhiUp,
+    EGEnergySysIndex::kSmearPhiDown,   EGEnergySysIndex::kScaleUp,       EGEnergySysIndex::kScaleDown,
+    EGEnergySysIndex::kSmearUp,        EGEnergySysIndex::kSmearDown,     EGEnergySysIndex::kScaleValue,
+    EGEnergySysIndex::kSmearValue,     EGEnergySysIndex::kSmearNrSigma,  EGEnergySysIndex::kEcalPreCorr,
+    EGEnergySysIndex::kEcalErrPreCorr, EGEnergySysIndex::kEcalPostCorr,  EGEnergySysIndex::kEcalErrPostCorr};
 
-namespace{
-  template<typename HandleType,typename ValType>
-    void fillAndStoreValueMap(edm::Event& iEvent,HandleType objHandle,
-			      const std::vector<ValType>& vals,const std::string& name)
-  {
-    auto valMap = std::make_unique<edm::ValueMap<ValType> >();
+namespace {
+  template <typename HandleType, typename ValType>
+  void fillAndStoreValueMap(edm::Event& iEvent,
+                            HandleType objHandle,
+                            const std::vector<ValType>& vals,
+                            const std::string& name) {
+    auto valMap = std::make_unique<edm::ValueMap<ValType>>();
     typename edm::ValueMap<ValType>::Filler filler(*valMap);
-    filler.insert(objHandle,vals.begin(),vals.end());
+    filler.insert(objHandle, vals.begin(), vals.end());
     filler.fill();
-    iEvent.put(std::move(valMap),name);
+    iEvent.put(std::move(valMap), name);
   }
-}
+}  // namespace
 
-template<typename T>
-CalibratedPhotonProducerT<T>::CalibratedPhotonProducerT( const edm::ParameterSet & conf ) :
-  photonToken_(consumes<edm::View<T> >(conf.getParameter<edm::InputTag>("src"))),
-  energyCorrector_(conf.getParameter<std::string >("correctionFile")),
-  recHitCollectionEBToken_(consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitCollectionEB"))),
-  recHitCollectionEEToken_(consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitCollectionEE"))),
-  produceCalibratedObjs_(conf.getParameter<bool>("produceCalibratedObjs"))
-{ 
-
+template <typename T>
+CalibratedPhotonProducerT<T>::CalibratedPhotonProducerT(const edm::ParameterSet& conf)
+    : photonToken_(consumes<edm::View<T>>(conf.getParameter<edm::InputTag>("src"))),
+      energyCorrector_(conf.getParameter<std::string>("correctionFile")),
+      recHitCollectionEBToken_(consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitCollectionEB"))),
+      recHitCollectionEEToken_(consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitCollectionEE"))),
+      produceCalibratedObjs_(conf.getParameter<bool>("produceCalibratedObjs")) {
   energyCorrector_.setMinEt(conf.getParameter<double>("minEtToCalibrate"));
 
   if (conf.getParameter<bool>("semiDeterministic")) {
-     semiDeterministicRng_.reset(new TRandom2());
-     energyCorrector_.initPrivateRng(semiDeterministicRng_.get());
+    semiDeterministicRng_.reset(new TRandom2());
+    energyCorrector_.initPrivateRng(semiDeterministicRng_.get());
   }
 
-  if(produceCalibratedObjs_) produces<std::vector<T>>();
-  
-  for(const auto& toStore : valMapsToStore_){
+  if (produceCalibratedObjs_)
+    produces<std::vector<T>>();
+
+  for (const auto& toStore : valMapsToStore_) {
     produces<edm::ValueMap<float>>(EGEnergySysIndex::name(toStore));
   }
 }
 
-template<typename T>
-void CalibratedPhotonProducerT<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
+template <typename T>
+void CalibratedPhotonProducerT<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src",edm::InputTag("gedGsfElectrons"));
-  desc.add<edm::InputTag>("recHitCollectionEB",edm::InputTag("reducedEcalRecHitsEB"));
-  desc.add<edm::InputTag>("recHitCollectionEE",edm::InputTag("reducedEcalRecHitsEE"));
-  desc.add<std::string>("correctionFile",std::string());
-  desc.add<double>("minEtToCalibrate",5.0);
-  desc.add<bool>("produceCalibratedObjs",true);
-  desc.add<bool>("semiDeterministic",true);
+  desc.add<edm::InputTag>("src", edm::InputTag("gedGsfElectrons"));
+  desc.add<edm::InputTag>("recHitCollectionEB", edm::InputTag("reducedEcalRecHitsEB"));
+  desc.add<edm::InputTag>("recHitCollectionEE", edm::InputTag("reducedEcalRecHitsEE"));
+  desc.add<std::string>("correctionFile", std::string());
+  desc.add<double>("minEtToCalibrate", 5.0);
+  desc.add<bool>("produceCalibratedObjs", true);
+  desc.add<bool>("semiDeterministic", true);
   std::vector<std::string> valMapsProduced;
-  for(auto varToStore : valMapsToStore_) valMapsProduced.push_back(EGEnergySysIndex::name(varToStore));
-  desc.add<std::vector<std::string> >("valueMapsStored",valMapsProduced)->setComment("provides to python configs the list of valuemaps stored, can not be overriden in the python config");
+  for (auto varToStore : valMapsToStore_)
+    valMapsProduced.push_back(EGEnergySysIndex::name(varToStore));
+  desc.add<std::vector<std::string>>("valueMapsStored", valMapsProduced)
+      ->setComment(
+          "provides to python configs the list of valuemaps stored, can not be overriden in the python config");
   descriptions.addWithDefaultLabel(desc);
 }
 
-template<typename T>
-void
-CalibratedPhotonProducerT<T>::produce( edm::Event & iEvent, const edm::EventSetup & iSetup ) {
-
+template <typename T>
+void CalibratedPhotonProducerT<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<edm::View<T>> inHandle;
   iEvent.getByToken(photonToken_, inHandle);
-  
+
   edm::Handle<EcalRecHitCollection> recHitCollectionEBHandle;
   edm::Handle<EcalRecHitCollection> recHitCollectionEEHandle;
-  
+
   iEvent.getByToken(recHitCollectionEBToken_, recHitCollectionEBHandle);
   iEvent.getByToken(recHitCollectionEEToken_, recHitCollectionEEHandle);
 
   std::unique_ptr<std::vector<T>> out = std::make_unique<std::vector<T>>();
 
   size_t nrObj = inHandle->size();
-  std::array<std::vector<float>,EGEnergySysIndex::kNrSysErrs> results;
-  for(auto& res : results) res.reserve(nrObj);
+  std::array<std::vector<float>, EGEnergySysIndex::kNrSysErrs> results;
+  for (auto& res : results)
+    res.reserve(nrObj);
 
-  const PhotonEnergyCalibrator::EventType evtType = iEvent.isRealData() ? 
-    PhotonEnergyCalibrator::EventType::DATA : PhotonEnergyCalibrator::EventType::MC; 
-  
+  const PhotonEnergyCalibrator::EventType evtType =
+      iEvent.isRealData() ? PhotonEnergyCalibrator::EventType::DATA : PhotonEnergyCalibrator::EventType::MC;
+
   for (const auto& pho : *inHandle) {
     out->emplace_back(pho);
 
-    if(semiDeterministicRng_) setSemiDetRandomSeed(iEvent,pho,nrObj,out->size());
+    if (semiDeterministicRng_)
+      setSemiDetRandomSeed(iEvent, pho, nrObj, out->size());
 
-    const EcalRecHitCollection* recHits = (pho.isEB()) ? recHitCollectionEBHandle.product() : recHitCollectionEEHandle.product();    
-    std::array<float,EGEnergySysIndex::kNrSysErrs> uncertainties = energyCorrector_.calibrate(out->back(), iEvent.id().run(), recHits, iEvent.streamID(), evtType);
-    
-    for(size_t index=0;index<EGEnergySysIndex::kNrSysErrs;index++){
+    const EcalRecHitCollection* recHits =
+        (pho.isEB()) ? recHitCollectionEBHandle.product() : recHitCollectionEEHandle.product();
+    std::array<float, EGEnergySysIndex::kNrSysErrs> uncertainties =
+        energyCorrector_.calibrate(out->back(), iEvent.id().run(), recHits, iEvent.streamID(), evtType);
+
+    for (size_t index = 0; index < EGEnergySysIndex::kNrSysErrs; index++) {
       results[index].push_back(uncertainties[index]);
     }
   }
-    
-  auto fillAndStore = [&](auto handle){
-    for(const auto& mapToStore : valMapsToStore_){
-      fillAndStoreValueMap(iEvent,handle,results[mapToStore],EGEnergySysIndex::name(mapToStore));
+
+  auto fillAndStore = [&](auto handle) {
+    for (const auto& mapToStore : valMapsToStore_) {
+      fillAndStoreValueMap(iEvent, handle, results[mapToStore], EGEnergySysIndex::name(mapToStore));
     }
   };
 
-  if(produceCalibratedObjs_){
+  if (produceCalibratedObjs_) {
     fillAndStore(iEvent.put(std::move(out)));
-  }else{
+  } else {
     fillAndStore(inHandle);
   }
-
 }
 
 //needs to be synced to CalibratedElectronProducers, want the same seed for a given SC
-template<typename T>
-void CalibratedPhotonProducerT<T>::setSemiDetRandomSeed(const edm::Event& iEvent,const T& obj,size_t nrObjs,size_t objNr)
-{
-  if(obj.superCluster().isNonnull()){
-    semiDeterministicRng_->SetSeed(egamma::getRandomSeedFromSC(iEvent,obj.superCluster()));
-  }else{
-    semiDeterministicRng_->SetSeed(egamma::getRandomSeedFromObj(iEvent,obj,nrObjs,objNr));
+template <typename T>
+void CalibratedPhotonProducerT<T>::setSemiDetRandomSeed(const edm::Event& iEvent,
+                                                        const T& obj,
+                                                        size_t nrObjs,
+                                                        size_t objNr) {
+  if (obj.superCluster().isNonnull()) {
+    semiDeterministicRng_->SetSeed(egamma::getRandomSeedFromSC(iEvent, obj.superCluster()));
+  } else {
+    semiDeterministicRng_->SetSeed(egamma::getRandomSeedFromObj(iEvent, obj, nrObjs, objNr));
   }
 }
 

--- a/RecoEgamma/EgammaTools/plugins/EG8XObjectUpdateModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EG8XObjectUpdateModifier.cc
@@ -1,7 +1,7 @@
 #include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/ESHandle.h" 
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
@@ -14,74 +14,64 @@
 
 #include <vdt/vdtMath.h>
 
-//this modifier fills variables where not present in CMSSW_8X 
+//this modifier fills variables where not present in CMSSW_8X
 //use case is when reading older 80X samples in newer releases, aka legacy
 
 class EG8XObjectUpdateModifier : public ModifyObjectValueBase {
 public:
   EG8XObjectUpdateModifier(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
-  ~EG8XObjectUpdateModifier() override{}
-  
+  ~EG8XObjectUpdateModifier() override {}
+
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
-  
+
   void modifyObject(reco::GsfElectron& ele) const final;
   void modifyObject(reco::Photon& pho) const final;
-  
-  void modifyObject(pat::Electron& ele) const final{return modifyObject(static_cast<reco::GsfElectron&>(ele));}
-  void modifyObject(pat::Photon& pho) const final{return modifyObject(static_cast<reco::Photon&>(pho));}
-  
+
+  void modifyObject(pat::Electron& ele) const final { return modifyObject(static_cast<reco::GsfElectron&>(ele)); }
+  void modifyObject(pat::Photon& pho) const final { return modifyObject(static_cast<reco::Photon&>(pho)); }
+
 private:
-  std::pair<int,bool> getSaturationInfo(const reco::SuperCluster& superClus)const;
-  
+  std::pair<int, bool> getSaturationInfo(const reco::SuperCluster& superClus) const;
+
   edm::ESHandle<CaloTopology> caloTopoHandle_;
   edm::Handle<EcalRecHitCollection> ecalRecHitsEBHandle_;
   edm::Handle<EcalRecHitCollection> ecalRecHitsEEHandle_;
   edm::EDGetTokenT<EcalRecHitCollection> ecalRecHitsEBToken_;
   edm::EDGetTokenT<EcalRecHitCollection> ecalRecHitsEEToken_;
-  
 };
 
-EG8XObjectUpdateModifier::EG8XObjectUpdateModifier(const edm::ParameterSet& conf, edm::ConsumesCollector& cc):
-  ModifyObjectValueBase(conf),
-  ecalRecHitsEBToken_(cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("ecalRecHitsEB"))),
-  ecalRecHitsEEToken_(cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("ecalRecHitsEE")))
-{
-  
+EG8XObjectUpdateModifier::EG8XObjectUpdateModifier(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : ModifyObjectValueBase(conf),
+      ecalRecHitsEBToken_(cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("ecalRecHitsEB"))),
+      ecalRecHitsEEToken_(cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("ecalRecHitsEE"))) {}
 
+void EG8XObjectUpdateModifier::setEvent(const edm::Event& iEvent) {
+  iEvent.getByToken(ecalRecHitsEBToken_, ecalRecHitsEBHandle_);
+  iEvent.getByToken(ecalRecHitsEEToken_, ecalRecHitsEEHandle_);
 }
 
-void EG8XObjectUpdateModifier::setEvent(const edm::Event& iEvent)
-{
-  iEvent.getByToken(ecalRecHitsEBToken_,ecalRecHitsEBHandle_);
-  iEvent.getByToken(ecalRecHitsEEToken_,ecalRecHitsEEHandle_);
-}
-
-void EG8XObjectUpdateModifier::setEventContent(const edm::EventSetup& iSetup)
-{
+void EG8XObjectUpdateModifier::setEventContent(const edm::EventSetup& iSetup) {
   iSetup.get<CaloTopologyRecord>().get(caloTopoHandle_);
 }
 
-
-void EG8XObjectUpdateModifier::modifyObject(reco::GsfElectron& ele)const
-{
-
+void EG8XObjectUpdateModifier::modifyObject(reco::GsfElectron& ele) const {
   const reco::CaloCluster& seedClus = *(ele.superCluster()->seed());
   const EcalRecHitCollection* ecalRecHits = ele.isEB() ? &*ecalRecHitsEBHandle_ : &*ecalRecHitsEEHandle_;
   const auto* caloTopo = caloTopoHandle_.product();
 
-  auto full5x5ShowerShapes = ele.full5x5_showerShape();  
-  full5x5ShowerShapes.e2x5Left   = noZS::EcalClusterTools::e2x5Left  (seedClus,ecalRecHits,caloTopo);
-  full5x5ShowerShapes.e2x5Right  = noZS::EcalClusterTools::e2x5Right (seedClus,ecalRecHits,caloTopo);
-  full5x5ShowerShapes.e2x5Top    = noZS::EcalClusterTools::e2x5Top   (seedClus,ecalRecHits,caloTopo);
-  full5x5ShowerShapes.e2x5Bottom = noZS::EcalClusterTools::e2x5Bottom(seedClus,ecalRecHits,caloTopo);
+  auto full5x5ShowerShapes = ele.full5x5_showerShape();
+  full5x5ShowerShapes.e2x5Left = noZS::EcalClusterTools::e2x5Left(seedClus, ecalRecHits, caloTopo);
+  full5x5ShowerShapes.e2x5Right = noZS::EcalClusterTools::e2x5Right(seedClus, ecalRecHits, caloTopo);
+  full5x5ShowerShapes.e2x5Top = noZS::EcalClusterTools::e2x5Top(seedClus, ecalRecHits, caloTopo);
+  full5x5ShowerShapes.e2x5Bottom = noZS::EcalClusterTools::e2x5Bottom(seedClus, ecalRecHits, caloTopo);
   ele.full5x5_setShowerShape(full5x5ShowerShapes);
-  
-  auto showerShapes = ele.showerShape();  
-  showerShapes.e2x5Left   = EcalClusterTools::e2x5Left  (seedClus,ecalRecHits,caloTopo);
-  showerShapes.e2x5Right  = EcalClusterTools::e2x5Right (seedClus,ecalRecHits,caloTopo);
-  showerShapes.e2x5Top    = EcalClusterTools::e2x5Top   (seedClus,ecalRecHits,caloTopo);
-  showerShapes.e2x5Bottom = EcalClusterTools::e2x5Bottom(seedClus,ecalRecHits,caloTopo);
+
+  auto showerShapes = ele.showerShape();
+  showerShapes.e2x5Left = EcalClusterTools::e2x5Left(seedClus, ecalRecHits, caloTopo);
+  showerShapes.e2x5Right = EcalClusterTools::e2x5Right(seedClus, ecalRecHits, caloTopo);
+  showerShapes.e2x5Top = EcalClusterTools::e2x5Top(seedClus, ecalRecHits, caloTopo);
+  showerShapes.e2x5Bottom = EcalClusterTools::e2x5Bottom(seedClus, ecalRecHits, caloTopo);
   ele.setShowerShape(showerShapes);
 
   reco::GsfElectron::SaturationInfo eleSatInfo;
@@ -91,8 +81,7 @@ void EG8XObjectUpdateModifier::modifyObject(reco::GsfElectron& ele)const
   ele.setSaturationInfo(eleSatInfo);
 }
 
-void EG8XObjectUpdateModifier::modifyObject(reco::Photon& pho)const
-{
+void EG8XObjectUpdateModifier::modifyObject(reco::Photon& pho) const {
   reco::Photon::SaturationInfo phoSatInfo;
   auto satInfo = getSaturationInfo(*pho.superCluster());
   phoSatInfo.nSaturatedXtals = satInfo.first;
@@ -100,26 +89,22 @@ void EG8XObjectUpdateModifier::modifyObject(reco::Photon& pho)const
   pho.setSaturationInfo(phoSatInfo);
 }
 
-
-std::pair<int,bool> EG8XObjectUpdateModifier::getSaturationInfo(const reco::SuperCluster& superClus)const
-{
-  bool isEB = superClus.seed()->seed().subdetId()==EcalBarrel;
+std::pair<int, bool> EG8XObjectUpdateModifier::getSaturationInfo(const reco::SuperCluster& superClus) const {
+  bool isEB = superClus.seed()->seed().subdetId() == EcalBarrel;
   const auto& ecalRecHits = isEB ? *ecalRecHitsEBHandle_ : *ecalRecHitsEEHandle_;
 
   int nrSatCrys = 0;
   bool seedSaturated = false;
   const auto& hitsAndFractions = superClus.seed()->hitsAndFractions();
-  for(const auto& hitFractionPair : hitsAndFractions) {    
+  for (const auto& hitFractionPair : hitsAndFractions) {
     auto ecalRecHitIt = ecalRecHits.find(hitFractionPair.first);
-    if(ecalRecHitIt != ecalRecHits.end() && 
-       ecalRecHitIt->checkFlag(EcalRecHit::Flags::kSaturated)){
+    if (ecalRecHitIt != ecalRecHits.end() && ecalRecHitIt->checkFlag(EcalRecHit::Flags::kSaturated)) {
       nrSatCrys++;
-      if(hitFractionPair.first == superClus.seed()->seed()) seedSaturated = true;
+      if (hitFractionPair.first == superClus.seed()->seed())
+        seedSaturated = true;
     }
   }
-  return {nrSatCrys,seedSaturated};
+  return {nrSatCrys, seedSaturated};
 }
-  
-DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EG8XObjectUpdateModifier,
-		  "EG8XObjectUpdateModifier");
+
+DEFINE_EDM_PLUGIN(ModifyObjectValueFactory, EG8XObjectUpdateModifier, "EG8XObjectUpdateModifier");

--- a/RecoEgamma/EgammaTools/plugins/EG9X105XObjectUpdateModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EG9X105XObjectUpdateModifier.cc
@@ -1,7 +1,7 @@
 #include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/ESHandle.h" 
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/ValueMap.h"
@@ -13,47 +13,45 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
 
-
 #include <vdt/vdtMath.h>
 
 //this modifier fills variables where not present in CMSSW_92X to CMSSW_105X
 //use case is when reading older new samples in newer releases, aka legacy
-//note we suffer from the problem of needing to use the electrons/photons the valuemaps 
-//are keyed to (something that is thankfully going away in 11X!) so we have to take 
+//note we suffer from the problem of needing to use the electrons/photons the valuemaps
+//are keyed to (something that is thankfully going away in 11X!) so we have to take
 //those collections in and figure out which ele/pho matches to them
 class EG9X105XObjectUpdateModifier : public ModifyObjectValueBase {
 public:
-  template<typename T>
-  class TokenHandlePair{
+  template <typename T>
+  class TokenHandlePair {
   public:
-    TokenHandlePair(const edm::ParameterSet& conf, const std::string& name,edm::ConsumesCollector& cc):
-      token_(cc.consumes<T>(conf.getParameter<edm::InputTag>(name))){}
-    void setHandle(const edm::Event& iEvent){
-      iEvent.getByToken(token_,handle_);
-    }
-    const edm::Handle<T>& handle()const{return handle_;}
+    TokenHandlePair(const edm::ParameterSet& conf, const std::string& name, edm::ConsumesCollector& cc)
+        : token_(cc.consumes<T>(conf.getParameter<edm::InputTag>(name))) {}
+    void setHandle(const edm::Event& iEvent) { iEvent.getByToken(token_, handle_); }
+    const edm::Handle<T>& handle() const { return handle_; }
+
   private:
     edm::EDGetTokenT<T> token_;
     edm::Handle<T> handle_;
   };
 
   EG9X105XObjectUpdateModifier(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
-  ~EG9X105XObjectUpdateModifier() override{}
-  
+  ~EG9X105XObjectUpdateModifier() override {}
+
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
-  
+
   void modifyObject(reco::GsfElectron& ele) const final;
   void modifyObject(reco::Photon& pho) const final;
-  
-  void modifyObject(pat::Electron& ele) const final{return modifyObject(static_cast<reco::GsfElectron&>(ele));}
-  void modifyObject(pat::Photon& pho) const final{return modifyObject(static_cast<reco::Photon&>(pho));}
-  
+
+  void modifyObject(pat::Electron& ele) const final { return modifyObject(static_cast<reco::GsfElectron&>(ele)); }
+  void modifyObject(pat::Photon& pho) const final { return modifyObject(static_cast<reco::Photon&>(pho)); }
+
 private:
-  template<typename ObjType>
+  template <typename ObjType>
   static edm::Ptr<ObjType> getPtrForValueMap(const ObjType& obj,
-					     const edm::Handle<edm::View<ObjType> >& objsVMIsKeyedTo);
-  
+                                             const edm::Handle<edm::View<ObjType> >& objsVMIsKeyedTo);
+
   TokenHandlePair<edm::View<reco::GsfElectron> > eleCollVMsAreKeyedTo_;
   TokenHandlePair<edm::View<reco::Photon> > phoCollVMsAreKeyedTo_;
 
@@ -61,7 +59,7 @@ private:
   TokenHandlePair<reco::BeamSpot> beamspot_;
   TokenHandlePair<EcalRecHitCollection> ecalRecHitsEB_;
   TokenHandlePair<EcalRecHitCollection> ecalRecHitsEE_;
-  
+
   TokenHandlePair<edm::ValueMap<float> > eleTrkIso_;
   TokenHandlePair<edm::ValueMap<float> > eleTrkIso04_;
   TokenHandlePair<edm::ValueMap<float> > phoPhotonIso_;
@@ -73,7 +71,7 @@ private:
   //there is a bug which GsfTracks are now allowed to be a match for conversions
   //due to improper linking of references in the miniAOD since 94X
   //this allows us to emulate it or not
-  //note: even if this enabled, it will do nothing on miniAOD produced with 94X, 102X 
+  //note: even if this enabled, it will do nothing on miniAOD produced with 94X, 102X
   //till upto whenever this is fixed (11X?) as the GsfTrack references point to a different
   //collection to the conversion track references
   bool allowGsfTrkMatchForConvs_;
@@ -83,34 +81,28 @@ private:
   //its still the same variable but can have differences hence inorder to allow IDs calculated on miniAOD
   //on the same file to be exactly reproduced, this option is set true
   bool updateChargedHadPFPVIso_;
-  
 };
 
-EG9X105XObjectUpdateModifier::EG9X105XObjectUpdateModifier(const edm::ParameterSet& conf, edm::ConsumesCollector& cc):
-  ModifyObjectValueBase(conf),
-  eleCollVMsAreKeyedTo_(conf,"eleCollVMsAreKeyedTo",cc),
-  phoCollVMsAreKeyedTo_(conf,"phoCollVMsAreKeyedTo",cc),
-  conversions_(conf,"conversions",cc),
-  beamspot_(conf,"beamspot",cc),
-  ecalRecHitsEB_(conf,"ecalRecHitsEB",cc),
-  ecalRecHitsEE_(conf,"ecalRecHitsEE",cc),
-  eleTrkIso_(conf,"eleTrkIso",cc),
-  eleTrkIso04_(conf,"eleTrkIso04",cc),
-  phoPhotonIso_(conf,"phoPhotonIso",cc),
-  phoNeutralHadIso_(conf,"phoNeutralHadIso",cc),
-  phoChargedHadIso_(conf,"phoChargedHadIso",cc),
-  phoChargedHadWorstVtxIso_(conf,"phoChargedHadWorstVtxIso",cc),
-  phoChargedHadWorstVtxConeVetoIso_(conf,"phoChargedHadWorstVtxConeVetoIso",cc),
-  phoChargedHadPFPVIso_(conf,"phoChargedHadPFPVIso",cc),
-  allowGsfTrkMatchForConvs_(conf.getParameter<bool>("allowGsfTrackForConvs")),
-  updateChargedHadPFPVIso_(conf.getParameter<bool>("updateChargedHadPFPVIso"))
-{
-  
+EG9X105XObjectUpdateModifier::EG9X105XObjectUpdateModifier(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : ModifyObjectValueBase(conf),
+      eleCollVMsAreKeyedTo_(conf, "eleCollVMsAreKeyedTo", cc),
+      phoCollVMsAreKeyedTo_(conf, "phoCollVMsAreKeyedTo", cc),
+      conversions_(conf, "conversions", cc),
+      beamspot_(conf, "beamspot", cc),
+      ecalRecHitsEB_(conf, "ecalRecHitsEB", cc),
+      ecalRecHitsEE_(conf, "ecalRecHitsEE", cc),
+      eleTrkIso_(conf, "eleTrkIso", cc),
+      eleTrkIso04_(conf, "eleTrkIso04", cc),
+      phoPhotonIso_(conf, "phoPhotonIso", cc),
+      phoNeutralHadIso_(conf, "phoNeutralHadIso", cc),
+      phoChargedHadIso_(conf, "phoChargedHadIso", cc),
+      phoChargedHadWorstVtxIso_(conf, "phoChargedHadWorstVtxIso", cc),
+      phoChargedHadWorstVtxConeVetoIso_(conf, "phoChargedHadWorstVtxConeVetoIso", cc),
+      phoChargedHadPFPVIso_(conf, "phoChargedHadPFPVIso", cc),
+      allowGsfTrkMatchForConvs_(conf.getParameter<bool>("allowGsfTrackForConvs")),
+      updateChargedHadPFPVIso_(conf.getParameter<bool>("updateChargedHadPFPVIso")) {}
 
-}
-
-void EG9X105XObjectUpdateModifier::setEvent(const edm::Event& iEvent)
-{
+void EG9X105XObjectUpdateModifier::setEvent(const edm::Event& iEvent) {
   eleCollVMsAreKeyedTo_.setHandle(iEvent);
   phoCollVMsAreKeyedTo_.setHandle(iEvent);
   conversions_.setHandle(iEvent);
@@ -124,29 +116,31 @@ void EG9X105XObjectUpdateModifier::setEvent(const edm::Event& iEvent)
   phoChargedHadIso_.setHandle(iEvent);
   phoChargedHadWorstVtxIso_.setHandle(iEvent);
   phoChargedHadWorstVtxConeVetoIso_.setHandle(iEvent);
-  if(updateChargedHadPFPVIso_) phoChargedHadPFPVIso_.setHandle(iEvent);
+  if (updateChargedHadPFPVIso_)
+    phoChargedHadPFPVIso_.setHandle(iEvent);
 }
 
-void EG9X105XObjectUpdateModifier::setEventContent(const edm::EventSetup& iSetup)
-{
+void EG9X105XObjectUpdateModifier::setEventContent(const edm::EventSetup& iSetup) {}
 
-}
-
-void EG9X105XObjectUpdateModifier::modifyObject(reco::GsfElectron& ele)const
-{
-  edm::Ptr<reco::GsfElectron> ptrForVM = getPtrForValueMap(ele,eleCollVMsAreKeyedTo_.handle());
-  if(ptrForVM.isNull()){
-    throw cms::Exception("LogicError") <<" in EG9X105ObjectUpdateModifier, line "<<__LINE__<<" electron "<<ele.et()<<" "<<ele.eta()<<" "<<ele.superCluster()->seed()->seed().rawId()<<" failed to match to the electrons the key map was keyed to, check the map collection is correct";
+void EG9X105XObjectUpdateModifier::modifyObject(reco::GsfElectron& ele) const {
+  edm::Ptr<reco::GsfElectron> ptrForVM = getPtrForValueMap(ele, eleCollVMsAreKeyedTo_.handle());
+  if (ptrForVM.isNull()) {
+    throw cms::Exception("LogicError")
+        << " in EG9X105ObjectUpdateModifier, line " << __LINE__ << " electron " << ele.et() << " " << ele.eta() << " "
+        << ele.superCluster()->seed()->seed().rawId()
+        << " failed to match to the electrons the key map was keyed to, check the map collection is correct";
   }
   reco::GsfElectron::ConversionRejection convRejVars = ele.conversionRejectionVariables();
-  if(allowGsfTrkMatchForConvs_){
-    convRejVars.vtxFitProb = ConversionTools::getVtxFitProb(ConversionTools::matchedConversion(ele.core(),*conversions_.handle(),beamspot_.handle()->position()));
-  }else{
+  if (allowGsfTrkMatchForConvs_) {
+    convRejVars.vtxFitProb = ConversionTools::getVtxFitProb(
+        ConversionTools::matchedConversion(ele.core(), *conversions_.handle(), beamspot_.handle()->position()));
+  } else {
     //its rather important to use the core function here to get the org trk ref
-    convRejVars.vtxFitProb = ConversionTools::getVtxFitProb(ConversionTools::matchedConversion(ele.core()->ctfTrack(),*conversions_.handle(),beamspot_.handle()->position(),2.0,1e-6,0));
+    convRejVars.vtxFitProb = ConversionTools::getVtxFitProb(ConversionTools::matchedConversion(
+        ele.core()->ctfTrack(), *conversions_.handle(), beamspot_.handle()->position(), 2.0, 1e-6, 0));
   }
   ele.setConversionRejectionVariables(convRejVars);
-  
+
   reco::GsfElectron::IsolationVariables isolVars03 = ele.dr03IsolationVariables();
   isolVars03.tkSumPtHEEP = (*eleTrkIso_.handle())[ptrForVM];
   ele.setDr03Isolation(isolVars03);
@@ -155,20 +149,22 @@ void EG9X105XObjectUpdateModifier::modifyObject(reco::GsfElectron& ele)const
   ele.setDr04Isolation(isolVars04);
 }
 
-void EG9X105XObjectUpdateModifier::modifyObject(reco::Photon& pho)const
-{
-  edm::Ptr<reco::Photon> ptrForVM = getPtrForValueMap(pho,phoCollVMsAreKeyedTo_.handle());
-  if(ptrForVM.isNull()){
-    throw cms::Exception("LogicError") <<" in EG9X105ObjectUpdateModifier, line "<<__LINE__<<" photon "<<pho.et()<<" "<<pho.eta()<<" "<<pho.superCluster()->seed()->seed().rawId()<<" failed to match to the photons the key map was keyed to, check the map collection is correct";
+void EG9X105XObjectUpdateModifier::modifyObject(reco::Photon& pho) const {
+  edm::Ptr<reco::Photon> ptrForVM = getPtrForValueMap(pho, phoCollVMsAreKeyedTo_.handle());
+  if (ptrForVM.isNull()) {
+    throw cms::Exception("LogicError")
+        << " in EG9X105ObjectUpdateModifier, line " << __LINE__ << " photon " << pho.et() << " " << pho.eta() << " "
+        << pho.superCluster()->seed()->seed().rawId()
+        << " failed to match to the photons the key map was keyed to, check the map collection is correct";
   }
-  
+
   reco::Photon::PflowIsolationVariables pfIso = pho.getPflowIsolationVariables();
   pfIso.photonIso = (*phoPhotonIso_.handle())[ptrForVM];
   pfIso.neutralHadronIso = (*phoNeutralHadIso_.handle())[ptrForVM];
   pfIso.chargedHadronIso = (*phoChargedHadIso_.handle())[ptrForVM];
   pfIso.chargedHadronWorstVtxIso = (*phoChargedHadWorstVtxIso_.handle())[ptrForVM];
   pfIso.chargedHadronWorstVtxGeomVetoIso = (*phoChargedHadWorstVtxConeVetoIso_.handle())[ptrForVM];
-  if(updateChargedHadPFPVIso_){
+  if (updateChargedHadPFPVIso_) {
     pfIso.chargedHadronPFPVIso = (*phoChargedHadPFPVIso_.handle())[ptrForVM];
   }
   pho.setPflowIsolationVariables(pfIso);
@@ -177,10 +173,10 @@ void EG9X105XObjectUpdateModifier::modifyObject(reco::Photon& pho)const
   reco::Photon::ShowerShape fullSS = pho.full5x5_showerShapeVariables();
 
   const reco::CaloClusterPtr seedClus = pho.superCluster()->seed();
-  const bool isEB = seedClus->seed().subdetId()==EcalBarrel;
+  const bool isEB = seedClus->seed().subdetId() == EcalBarrel;
   const auto& recHits = isEB ? *ecalRecHitsEB_.handle() : *ecalRecHitsEE_.handle();
-  Cluster2ndMoments clus2ndMomFrac = EcalClusterTools::cluster2ndMoments(*seedClus,recHits);
-  Cluster2ndMoments clus2ndMomFull = noZS::EcalClusterTools::cluster2ndMoments(*seedClus,recHits);
+  Cluster2ndMoments clus2ndMomFrac = EcalClusterTools::cluster2ndMoments(*seedClus, recHits);
+  Cluster2ndMoments clus2ndMomFull = noZS::EcalClusterTools::cluster2ndMoments(*seedClus, recHits);
   fracSS.smMajor = clus2ndMomFrac.sMaj;
   fracSS.smMinor = clus2ndMomFrac.sMin;
   fracSS.smAlpha = clus2ndMomFrac.alpha;
@@ -189,20 +185,16 @@ void EG9X105XObjectUpdateModifier::modifyObject(reco::Photon& pho)const
   fullSS.smAlpha = clus2ndMomFull.alpha;
   pho.setShowerShapeVariables(fracSS);
   pho.full5x5_setShowerShapeVariables(fullSS);
-
 }
 
-template<typename ObjType> edm::Ptr<ObjType> EG9X105XObjectUpdateModifier::
-getPtrForValueMap(const ObjType& obj,
-		  const edm::Handle<edm::View<ObjType> >& objsVMIsKeyedTo)
-{
-  for(auto& objVMPtr : objsVMIsKeyedTo->ptrs()){
-    if(obj.superCluster()->seed()->seed()==objVMPtr->superCluster()->seed()->seed()) return objVMPtr;
+template <typename ObjType>
+edm::Ptr<ObjType> EG9X105XObjectUpdateModifier::getPtrForValueMap(
+    const ObjType& obj, const edm::Handle<edm::View<ObjType> >& objsVMIsKeyedTo) {
+  for (auto& objVMPtr : objsVMIsKeyedTo->ptrs()) {
+    if (obj.superCluster()->seed()->seed() == objVMPtr->superCluster()->seed()->seed())
+      return objVMPtr;
   }
-  return edm::Ptr<ObjType>(objsVMIsKeyedTo.id()); //return null ptr if not found
+  return edm::Ptr<ObjType>(objsVMIsKeyedTo.id());  //return null ptr if not found
 }
 
-  
-DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EG9X105XObjectUpdateModifier,
-		  "EG9X105XObjectUpdateModifier");
+DEFINE_EDM_PLUGIN(ModifyObjectValueFactory, EG9X105XObjectUpdateModifier, "EG9X105XObjectUpdateModifier");

--- a/RecoEgamma/EgammaTools/plugins/EGEnergyAnalyzer.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGEnergyAnalyzer.cc
@@ -1,8 +1,8 @@
- // -*- C++ -*-
+// -*- C++ -*-
 //
 // Package:    EGEnergyAnalyzer
 // Class:      EGEnergyAnalyzer
-// 
+//
 /**\class EGEnergyAnalyzer EGEnergyAnalyzer.cc GBRWrap/EGEnergyAnalyzer/src/EGEnergyAnalyzer.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Tue Nov  8 22:26:45 CET 2011
 //
 //
-
 
 // system include files
 #include <memory>
@@ -40,7 +39,6 @@
 #include "RecoEgamma/EgammaTools/interface/EGEnergyCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
-
 //
 // class declaration
 //
@@ -49,101 +47,74 @@ class EGEnergyAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit EGEnergyAnalyzer(const edm::ParameterSet&);
   ~EGEnergyAnalyzer() override;
-  
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
-  
+
 private:
-  void beginJob() override ;
-  void analyze( const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
-  
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
   EGEnergyCorrector corfile;
   EGEnergyCorrector cordb;
-  
+
   edm::EDGetTokenT<EcalRecHitCollection> ebRHToken_, eeRHToken_;
 };
 
-
 EGEnergyAnalyzer::EGEnergyAnalyzer(const edm::ParameterSet& iConfig) {
-
   ebRHToken_ = consumes<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEB"));
   eeRHToken_ = consumes<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEE"));
 }
 
-
-EGEnergyAnalyzer::~EGEnergyAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+EGEnergyAnalyzer::~EGEnergyAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-EGEnergyAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void EGEnergyAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
   if (!corfile.IsInitialized()) {
-    corfile.Initialize(iSetup,"/afs/cern.ch/user/b/bendavid/cmspublic/gbrv3ph.root");
+    corfile.Initialize(iSetup, "/afs/cern.ch/user/b/bendavid/cmspublic/gbrv3ph.root");
     //corfile.Initialize(iSetup,"wgbrph",true);
   }
 
   if (!cordb.IsInitialized()) {
     //cordb.Initialize(iSetup,"/afs/cern.ch/user/b/bendavid/cmspublic/regweights/gbrph.root");
-    cordb.Initialize(iSetup,"wgbrph",true);
+    cordb.Initialize(iSetup, "wgbrph", true);
   }
 
   // get photon collection
   Handle<reco::PhotonCollection> hPhotonProduct;
-  iEvent.getByLabel("photons",hPhotonProduct);
-  
+  iEvent.getByLabel("photons", hPhotonProduct);
+
   EcalClusterLazyTools lazyTools(iEvent, iSetup, ebRHToken_, eeRHToken_);
-  
+
   Handle<reco::VertexCollection> hVertexProduct;
-  iEvent.getByLabel("offlinePrimaryVerticesWithBS", hVertexProduct);      
-  
-  for (reco::PhotonCollection::const_iterator it = hPhotonProduct->begin(); it!=hPhotonProduct->end(); ++it) {
-    std::pair<double,double> corsfile = corfile.CorrectedEnergyWithError(*it, *hVertexProduct, lazyTools, iSetup);
-    std::pair<double,double> corsdb = cordb.CorrectedEnergyWithError(*it, *hVertexProduct, lazyTools, iSetup);
+  iEvent.getByLabel("offlinePrimaryVerticesWithBS", hVertexProduct);
 
+  for (reco::PhotonCollection::const_iterator it = hPhotonProduct->begin(); it != hPhotonProduct->end(); ++it) {
+    std::pair<double, double> corsfile = corfile.CorrectedEnergyWithError(*it, *hVertexProduct, lazyTools, iSetup);
+    std::pair<double, double> corsdb = cordb.CorrectedEnergyWithError(*it, *hVertexProduct, lazyTools, iSetup);
 
-    printf("file: default = %5f, correction = %5f, uncertainty = %5f\n", it->energy(),corsfile.first,corsfile.second);
-    printf("db:   default = %5f, correction = %5f, uncertainty = %5f\n", it->energy(),corsdb.first,corsdb.second);
-
-  }  
-
-
-
-
+    printf("file: default = %5f, correction = %5f, uncertainty = %5f\n", it->energy(), corsfile.first, corsfile.second);
+    printf("db:   default = %5f, correction = %5f, uncertainty = %5f\n", it->energy(), corsdb.first, corsdb.second);
+  }
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-EGEnergyAnalyzer::beginJob()
-{
-
-
-
-}
+void EGEnergyAnalyzer::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-EGEnergyAnalyzer::endJob() 
-{
-}
+void EGEnergyAnalyzer::endJob() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-EGEnergyAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void EGEnergyAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/RecoEgamma/EgammaTools/plugins/EGEtScaleSysModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGEtScaleSysModifier.cc
@@ -6,71 +6,73 @@
 #include <vdt/vdtMath.h>
 
 //in the legacy re-reco we came across an Et scale issue, specifically an inflection at 45 GeV
-//it is problematic to address in the normal scale and smearing code therefore 
+//it is problematic to address in the normal scale and smearing code therefore
 //this patch modifies the e/gamma object to "patch in" this additional systematic
 //Questions:
 //1 ) Why dont we add this to the overall scale systematic?
 //Well we could but the whole point of this is to get a proper template which can be evolved
 //correctly. The issue is not that the current systematic doesnt cover this systematic on a
-//per bin basis, it does, the problem is the sign flips at 45 GeV so its fine if you use 
+//per bin basis, it does, the problem is the sign flips at 45 GeV so its fine if you use
 //only eles/phos > 45 or <45 GeV but the template cant simultaneously cover the entire spectrum
-//and you'll get a nasty constrained fit. 
-//And if you care about these sort of things (and you probably should), you shouldnt be using 
+//and you'll get a nasty constrained fit.
+//And if you care about these sort of things (and you probably should), you shouldnt be using
 //the overall systematic anyways but its seperate parts
 //
 //2 ) Why dont you do it inside the standard class
 //We could but we're rather hoping to solve this issue more cleanly in the future
 //but we would hold up the reminiAOD too long to do so so this is just to get something
-//which should be fine for 90% of analyses in the miniAOD. So this is a temporary fix 
-//which we hope to rip out soon (if you're reading this in 2024 because we're still doing it 
+//which should be fine for 90% of analyses in the miniAOD. So this is a temporary fix
+//which we hope to rip out soon (if you're reading this in 2024 because we're still doing it
 //this way, all I can say is sorry, we thought it would go away soon! )
-
 
 class EGEtScaleSysModifier : public ModifyObjectValueBase {
 public:
   EGEtScaleSysModifier(const edm::ParameterSet& conf, edm::ConsumesCollector&);
-  ~EGEtScaleSysModifier() override{}
-  
+  ~EGEtScaleSysModifier() override {}
+
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
-  
+
   void modifyObject(pat::Electron& ele) const final;
   void modifyObject(pat::Photon& pho) const final;
-  
-private:  
-  std::pair<float,float> calCombinedMom(reco::GsfElectron& ele,const float scale,
-					const float smear)const;
-  void setEcalEnergy(reco::GsfElectron& ele,const float scale,const float smear)const;
+
+private:
+  std::pair<float, float> calCombinedMom(reco::GsfElectron& ele, const float scale, const float smear) const;
+  void setEcalEnergy(reco::GsfElectron& ele, const float scale, const float smear) const;
 
   class UncertFuncBase {
   public:
-    UncertFuncBase(){}
-    virtual ~UncertFuncBase(){}
-    virtual float val(const float et)const=0;
+    UncertFuncBase() {}
+    virtual ~UncertFuncBase() {}
+    virtual float val(const float et) const = 0;
   };
-  
+
   //defines two uncertaintes, one Et<X and one Et>Y
   //for X<Et<Y, it linearly extrapolates betwen the two values
   class UncertFuncV1 : public UncertFuncBase {
   public:
-    UncertFuncV1(const edm::ParameterSet& conf):
-      lowEt_(conf.getParameter<double>("lowEt")),highEt_(conf.getParameter<double>("highEt")),
-      lowEtUncert_(conf.getParameter<double>("lowEtUncert")),
-      highEtUncert_(conf.getParameter<double>("highEtUncert")),
-      dEt_(highEt_-lowEt_),
-      dUncert_(highEtUncert_ - lowEtUncert_)
-    {
-      if(highEt_<=lowEt_) throw cms::Exception("ConfigError") <<" highEt "<<highEt_<<" is not higher than lowEt "<<lowEt_;
+    UncertFuncV1(const edm::ParameterSet& conf)
+        : lowEt_(conf.getParameter<double>("lowEt")),
+          highEt_(conf.getParameter<double>("highEt")),
+          lowEtUncert_(conf.getParameter<double>("lowEtUncert")),
+          highEtUncert_(conf.getParameter<double>("highEtUncert")),
+          dEt_(highEt_ - lowEt_),
+          dUncert_(highEtUncert_ - lowEtUncert_) {
+      if (highEt_ <= lowEt_)
+        throw cms::Exception("ConfigError") << " highEt " << highEt_ << " is not higher than lowEt " << lowEt_;
     }
-    ~UncertFuncV1() override{}
-   
-    float val(const float et)const override{
-      if(et<=lowEt_) return lowEtUncert_;
-      else if(et>=highEt_) return highEtUncert_;
-      else{
-	return (et-lowEt_)*dUncert_/dEt_+lowEtUncert_;
+    ~UncertFuncV1() override {}
+
+    float val(const float et) const override {
+      if (et <= lowEt_)
+        return lowEtUncert_;
+      else if (et >= highEt_)
+        return highEtUncert_;
+      else {
+        return (et - lowEt_) * dUncert_ / dEt_ + lowEtUncert_;
       }
     }
+
   private:
     float lowEt_;
     float highEt_;
@@ -79,53 +81,43 @@ private:
     float dEt_;
     float dUncert_;
   };
-    
+
   EpCombinationTool epCombTool_;
   std::unique_ptr<UncertFuncBase> uncertFunc_;
 };
 
-EGEtScaleSysModifier::EGEtScaleSysModifier(const edm::ParameterSet& conf, edm::ConsumesCollector&):
-  ModifyObjectValueBase(conf),
-  epCombTool_(conf.getParameter<edm::ParameterSet>("epCombConfig"))
-{
+EGEtScaleSysModifier::EGEtScaleSysModifier(const edm::ParameterSet& conf, edm::ConsumesCollector&)
+    : ModifyObjectValueBase(conf), epCombTool_(conf.getParameter<edm::ParameterSet>("epCombConfig")) {
   const edm::ParameterSet funcPSet = conf.getParameter<edm::ParameterSet>("uncertFunc");
   const std::string& funcName = funcPSet.getParameter<std::string>("name");
-  if(funcName == "UncertFuncV1"){
+  if (funcName == "UncertFuncV1") {
     uncertFunc_ = std::make_unique<UncertFuncV1>(funcPSet);
-  }else{
-    throw cms::Exception("ConfigError") <<"Error constructing EGEtScaleSysModifier, function name "<<funcName<<" not valid";
-  } 
-
+  } else {
+    throw cms::Exception("ConfigError") << "Error constructing EGEtScaleSysModifier, function name " << funcName
+                                        << " not valid";
+  }
 }
 
-void EGEtScaleSysModifier::setEvent(const edm::Event& iEvent)
-{
+void EGEtScaleSysModifier::setEvent(const edm::Event& iEvent) {}
 
-}
+void EGEtScaleSysModifier::setEventContent(const edm::EventSetup& iSetup) { epCombTool_.setEventContent(iSetup); }
 
-void EGEtScaleSysModifier::setEventContent(const edm::EventSetup& iSetup)
-{
-  epCombTool_.setEventContent(iSetup);
-}
-
-
-void EGEtScaleSysModifier::modifyObject(pat::Electron& ele)const
-{
-  auto getVal = [](const pat::Electron& ele,EGEnergySysIndex::Index valIndex){
+void EGEtScaleSysModifier::modifyObject(pat::Electron& ele) const {
+  auto getVal = [](const pat::Electron& ele, EGEnergySysIndex::Index valIndex) {
     return ele.userFloat(EGEnergySysIndex::name(valIndex));
   };
   //so ele.energy() may be either pre or post corrections, we have no idea
   //so we explicity access the pre and post correction ecal energies
   //we need the pre corrected to properly do the e/p combination
   //we need the post corrected to get et uncertainty
-  const float ecalEnergyPostCorr = getVal(ele,EGEnergySysIndex::kEcalPostCorr); 
-  const float ecalEnergyPreCorr = getVal(ele,EGEnergySysIndex::kEcalPreCorr);
-  const float ecalEnergyErrPreCorr = getVal(ele,EGEnergySysIndex::kEcalErrPreCorr);
+  const float ecalEnergyPostCorr = getVal(ele, EGEnergySysIndex::kEcalPostCorr);
+  const float ecalEnergyPreCorr = getVal(ele, EGEnergySysIndex::kEcalPreCorr);
+  const float ecalEnergyErrPreCorr = getVal(ele, EGEnergySysIndex::kEcalErrPreCorr);
 
   //the et cut is in terms of ecal et using the track angle and post corr ecal energy
-  const float etUncert = uncertFunc_->val(ele.et()/ele.energy()*ecalEnergyPostCorr); 
-  const float smear = getVal(ele,EGEnergySysIndex::kSmearValue);
-  const float corr = getVal(ele,EGEnergySysIndex::kScaleValue);
+  const float etUncert = uncertFunc_->val(ele.et() / ele.energy() * ecalEnergyPostCorr);
+  const float smear = getVal(ele, EGEnergySysIndex::kSmearValue);
+  const float corr = getVal(ele, EGEnergySysIndex::kScaleValue);
 
   //get the values we have to reset back to
   const float oldEcalEnergy = ele.ecalEnergy();
@@ -133,78 +125,66 @@ void EGEtScaleSysModifier::modifyObject(pat::Electron& ele)const
   const auto oldP4 = ele.p4();
   const float oldP4Err = ele.p4Error(reco::GsfElectron::P4_COMBINATION);
   const float oldTrkMomErr = ele.trackMomentumError();
-  
+
   ele.setCorrectedEcalEnergy(ecalEnergyPreCorr);
   ele.setCorrectedEcalEnergyError(ecalEnergyErrPreCorr);
-  
-  const float energyEtUncertUp = calCombinedMom(ele,corr+etUncert,smear).first;
-  const float energyEtUncertDn = calCombinedMom(ele,corr-etUncert,smear).first;
+
+  const float energyEtUncertUp = calCombinedMom(ele, corr + etUncert, smear).first;
+  const float energyEtUncertDn = calCombinedMom(ele, corr - etUncert, smear).first;
 
   //reset it back to how it was
   ele.setCorrectedEcalEnergy(oldEcalEnergy);
   ele.setCorrectedEcalEnergyError(oldEcalEnergyErr);
-  ele.correctMomentum(oldP4,oldTrkMomErr,oldP4Err);
-  
-  ele.addUserFloat("energyScaleEtUp",energyEtUncertUp);
-  ele.addUserFloat("energyScaleEtDown",energyEtUncertDn);
-						
+  ele.correctMomentum(oldP4, oldTrkMomErr, oldP4Err);
+
+  ele.addUserFloat("energyScaleEtUp", energyEtUncertUp);
+  ele.addUserFloat("energyScaleEtDown", energyEtUncertDn);
 }
 
-void EGEtScaleSysModifier::modifyObject(pat::Photon& pho)const
-{
-  auto getVal = [](const pat::Photon& pho,EGEnergySysIndex::Index valIndex){
+void EGEtScaleSysModifier::modifyObject(pat::Photon& pho) const {
+  auto getVal = [](const pat::Photon& pho, EGEnergySysIndex::Index valIndex) {
     return pho.userFloat(EGEnergySysIndex::name(valIndex));
   };
   //so pho.energy() may be either pre or post corrections, we have no idea
   //so we explicity access the pre and post correction ecal energies
   //post corr for the et value for the systematic, pre corr to apply them
-  const float ecalEnergyPostCorr = getVal(pho,EGEnergySysIndex::kEcalPostCorr); 
-  const float ecalEnergyPreCorr = getVal(pho,EGEnergySysIndex::kEcalPreCorr);
+  const float ecalEnergyPostCorr = getVal(pho, EGEnergySysIndex::kEcalPostCorr);
+  const float ecalEnergyPreCorr = getVal(pho, EGEnergySysIndex::kEcalPreCorr);
 
   //the et cut is in terms of post corr ecal energy
-  const float etUncert = uncertFunc_->val(pho.et()/pho.energy()*ecalEnergyPostCorr);
-  const float corr = getVal(pho,EGEnergySysIndex::kScaleValue);
+  const float etUncert = uncertFunc_->val(pho.et() / pho.energy() * ecalEnergyPostCorr);
+  const float corr = getVal(pho, EGEnergySysIndex::kScaleValue);
 
-  const float energyEtUncertUp = ecalEnergyPreCorr*(corr+etUncert);
-  const float energyEtUncertDn = ecalEnergyPreCorr*(corr-etUncert);
+  const float energyEtUncertUp = ecalEnergyPreCorr * (corr + etUncert);
+  const float energyEtUncertDn = ecalEnergyPreCorr * (corr - etUncert);
 
-  pho.addUserFloat("energyScaleEtUp",energyEtUncertUp);
-  pho.addUserFloat("energyScaleEtDown",energyEtUncertDn);
- 
+  pho.addUserFloat("energyScaleEtUp", energyEtUncertUp);
+  pho.addUserFloat("energyScaleEtDown", energyEtUncertDn);
 }
 
-std::pair<float,float> EGEtScaleSysModifier::calCombinedMom(reco::GsfElectron& ele,
-							    const float scale,
-							    const float smear)const
-{ 
+std::pair<float, float> EGEtScaleSysModifier::calCombinedMom(reco::GsfElectron& ele,
+                                                             const float scale,
+                                                             const float smear) const {
   const float oldEcalEnergy = ele.ecalEnergy();
   const float oldEcalEnergyErr = ele.ecalEnergyError();
   const auto oldP4 = ele.p4();
   const float oldP4Err = ele.p4Error(reco::GsfElectron::P4_COMBINATION);
   const float oldTrkMomErr = ele.trackMomentumError();
-  
-  setEcalEnergy(ele,scale,smear);
+
+  setEcalEnergy(ele, scale, smear);
   const auto& combinedMomentum = epCombTool_.combine(ele);
   ele.setCorrectedEcalEnergy(oldEcalEnergy);
   ele.setCorrectedEcalEnergyError(oldEcalEnergyErr);
-  ele.correctMomentum(oldP4,oldTrkMomErr,oldP4Err);
-
+  ele.correctMomentum(oldP4, oldTrkMomErr, oldP4Err);
 
   return combinedMomentum;
 }
 
-void EGEtScaleSysModifier::setEcalEnergy(reco::GsfElectron& ele,
-					 const float scale,
-					 const float smear)const
-{
+void EGEtScaleSysModifier::setEcalEnergy(reco::GsfElectron& ele, const float scale, const float smear) const {
   const float oldEcalEnergy = ele.ecalEnergy();
   const float oldEcalEnergyErr = ele.ecalEnergyError();
-  ele.setCorrectedEcalEnergy( oldEcalEnergy*scale );
-  ele.setCorrectedEcalEnergyError(std::hypot( oldEcalEnergyErr*scale, oldEcalEnergy*smear*scale ) );
+  ele.setCorrectedEcalEnergy(oldEcalEnergy * scale);
+  ele.setCorrectedEcalEnergyError(std::hypot(oldEcalEnergyErr * scale, oldEcalEnergy * smear * scale));
 }
 
-  
-  
-DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGEtScaleSysModifier,
-		  "EGEtScaleSysModifier");
+DEFINE_EDM_PLUGIN(ModifyObjectValueFactory, EGEtScaleSysModifier, "EGEtScaleSysModifier");

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromValueMaps.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromValueMaps.cc
@@ -2,41 +2,39 @@
 
 using EGExtraInfoModifierFromFloatValueMaps = EGExtraInfoModifierFromValueMaps<float>;
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGExtraInfoModifierFromFloatValueMaps,
-		  "EGExtraInfoModifierFromFloatValueMaps");
+                  EGExtraInfoModifierFromFloatValueMaps,
+                  "EGExtraInfoModifierFromFloatValueMaps");
 
 using EGExtraInfoModifierFromIntValueMaps = EGExtraInfoModifierFromValueMaps<int>;
-DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGExtraInfoModifierFromIntValueMaps,
-		  "EGExtraInfoModifierFromIntValueMaps");
+DEFINE_EDM_PLUGIN(ModifyObjectValueFactory, EGExtraInfoModifierFromIntValueMaps, "EGExtraInfoModifierFromIntValueMaps");
 
 using EGExtraInfoModifierFromBoolValueMaps = EGExtraInfoModifierFromValueMaps<bool>;
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGExtraInfoModifierFromBoolValueMaps,
-		  "EGExtraInfoModifierFromBoolValueMaps");
+                  EGExtraInfoModifierFromBoolValueMaps,
+                  "EGExtraInfoModifierFromBoolValueMaps");
 
-using EGExtraInfoModifierFromBoolToIntValueMaps = EGExtraInfoModifierFromValueMaps<bool,int>;
+using EGExtraInfoModifierFromBoolToIntValueMaps = EGExtraInfoModifierFromValueMaps<bool, int>;
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGExtraInfoModifierFromBoolToIntValueMaps,
-		  "EGExtraInfoModifierFromBoolToIntValueMaps");
+                  EGExtraInfoModifierFromBoolToIntValueMaps,
+                  "EGExtraInfoModifierFromBoolToIntValueMaps");
 
 using EGExtraInfoModifierFromUIntValueMaps = EGExtraInfoModifierFromValueMaps<unsigned int>;
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGExtraInfoModifierFromUIntValueMaps,
-		  "EGExtraInfoModifierFromUIntValueMaps");
+                  EGExtraInfoModifierFromUIntValueMaps,
+                  "EGExtraInfoModifierFromUIntValueMaps");
 
-using EGExtraInfoModifierFromUIntToIntValueMaps = EGExtraInfoModifierFromValueMaps<unsigned int,int>;
+using EGExtraInfoModifierFromUIntToIntValueMaps = EGExtraInfoModifierFromValueMaps<unsigned int, int>;
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGExtraInfoModifierFromUIntToIntValueMaps,
-		  "EGExtraInfoModifierFromUIntToIntValueMaps");
+                  EGExtraInfoModifierFromUIntToIntValueMaps,
+                  "EGExtraInfoModifierFromUIntToIntValueMaps");
 
 #include "DataFormats/PatCandidates/interface/VIDCutFlowResult.h"
 using EGExtraInfoModifierFromVIDCutFlowResultValueMaps = EGExtraInfoModifierFromValueMaps<vid::CutFlowResult>;
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGExtraInfoModifierFromVIDCutFlowResultValueMaps,
-		  "EGExtraInfoModifierFromVIDCutFlowResultValueMaps");
+                  EGExtraInfoModifierFromVIDCutFlowResultValueMaps,
+                  "EGExtraInfoModifierFromVIDCutFlowResultValueMaps");
 
-using EGExtraInfoModifierFromEGIDValueMaps = EGExtraInfoModifierFromValueMaps<float,egmodifier::EGID>;
+using EGExtraInfoModifierFromEGIDValueMaps = EGExtraInfoModifierFromValueMaps<float, egmodifier::EGID>;
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGExtraInfoModifierFromEGIDValueMaps,
-		  "EGExtraInfoModifierFromEGIDValueMaps");
+                  EGExtraInfoModifierFromEGIDValueMaps,
+                  "EGExtraInfoModifierFromEGIDValueMaps");

--- a/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
@@ -8,209 +8,232 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
 namespace {
-  const edm::EDGetTokenT<edm::ValueMap<float> > empty_token;
+  const edm::EDGetTokenT<edm::ValueMap<float>> empty_token;
   const edm::InputTag empty_tag("");
-  template<typename T, typename U, typename V>
-  inline void make_consumes(const T& tag, edm::EDGetTokenT<U>& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<U>(tag); }
-}
+  template <typename T, typename U, typename V>
+  inline void make_consumes(const T& tag, edm::EDGetTokenT<U>& tok, V& sume) {
+    if (!(empty_tag == tag))
+      tok = sume.template consumes<U>(tag);
+  }
+}  // namespace
 
 #include <unordered_map>
 
 class EGFull5x5ShowerShapeModifierFromValueMaps : public ModifyObjectValueBase {
 public:
   struct electron_config {
-    edm::EDGetTokenT<edm::View<pat::Electron> > tok_electron_src;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_sigmaEtaEta ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_sigmaIetaIeta ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_sigmaIphiIphi ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_e1x5 ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_e2x5Max ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_e5x5 ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_r9 ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_hcalDepth1OverEcal ;     
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_hcalDepth2OverEcal ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_hcalDepth1OverEcalBc ; 
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_hcalDepth2OverEcalBc ;
+    edm::EDGetTokenT<edm::View<pat::Electron>> tok_electron_src;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_sigmaEtaEta;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_sigmaIetaIeta;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_sigmaIphiIphi;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_e1x5;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_e2x5Max;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_e5x5;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_r9;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_hcalDepth1OverEcal;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_hcalDepth2OverEcal;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_hcalDepth1OverEcalBc;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_hcalDepth2OverEcalBc;
   };
 
   struct photon_config {
-    edm::EDGetTokenT<edm::View<pat::Photon> > tok_photon_src;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_sigmaEtaEta ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_sigmaIetaIeta ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_e1x5 ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_e2x5 ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_e3x3 ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_e5x5 ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_maxEnergyXtal ; 
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_hcalDepth1OverEcal ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_hcalDepth2OverEcal ;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_hcalDepth1OverEcalBc;
-    edm::EDGetTokenT<edm::ValueMap<float> > tok_hcalDepth2OverEcalBc;
+    edm::EDGetTokenT<edm::View<pat::Photon>> tok_photon_src;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_sigmaEtaEta;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_sigmaIetaIeta;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_e1x5;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_e2x5;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_e3x3;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_e5x5;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_maxEnergyXtal;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_hcalDepth1OverEcal;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_hcalDepth2OverEcal;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_hcalDepth1OverEcalBc;
+    edm::EDGetTokenT<edm::ValueMap<float>> tok_hcalDepth2OverEcalBc;
   };
 
   EGFull5x5ShowerShapeModifierFromValueMaps(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
-  
+
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
-  
+
   void modifyObject(pat::Electron&) const final;
   void modifyObject(pat::Photon&) const final;
 
 private:
   electron_config e_conf;
-  photon_config   ph_conf;
-  std::vector<edm::Ptr<reco::GsfElectron>> eles_by_oop; // indexed by original object ptr
-  std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > > ele_vmaps;
+  photon_config ph_conf;
+  std::vector<edm::Ptr<reco::GsfElectron>> eles_by_oop;  // indexed by original object ptr
+  std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float>>> ele_vmaps;
   std::vector<edm::Ptr<reco::Photon>> phos_by_oop;
-  std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > > pho_vmaps;
-  mutable unsigned ele_idx,pho_idx; // hack here until we figure out why some slimmedPhotons don't have original object ptrs
+  std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float>>> pho_vmaps;
+  mutable unsigned ele_idx,
+      pho_idx;  // hack here until we figure out why some slimmedPhotons don't have original object ptrs
 };
 
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGFull5x5ShowerShapeModifierFromValueMaps,
-		  "EGFull5x5ShowerShapeModifierFromValueMaps");
+                  EGFull5x5ShowerShapeModifierFromValueMaps,
+                  "EGFull5x5ShowerShapeModifierFromValueMaps");
 
-EGFull5x5ShowerShapeModifierFromValueMaps::
-EGFull5x5ShowerShapeModifierFromValueMaps(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) :
-  ModifyObjectValueBase(conf) {
-  if( conf.exists("electron_config") ) {
+EGFull5x5ShowerShapeModifierFromValueMaps::EGFull5x5ShowerShapeModifierFromValueMaps(const edm::ParameterSet& conf,
+                                                                                     edm::ConsumesCollector& cc)
+    : ModifyObjectValueBase(conf) {
+  if (conf.exists("electron_config")) {
     const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
-    if( electrons.exists("electronSrc") ) make_consumes(electrons.getParameter<edm::InputTag>("electronSrc"), e_conf.tok_electron_src, cc);
-    if( electrons.exists("sigmaEtaEta") ) make_consumes(electrons.getParameter<edm::InputTag>("sigmaEtaEta"), e_conf.tok_sigmaEtaEta, cc);
-    if( electrons.exists("sigmaIetaIeta") ) make_consumes(electrons.getParameter<edm::InputTag>("sigmaIetaIeta"), e_conf.tok_sigmaIetaIeta, cc);
-    if( electrons.exists("sigmaIphiIphi") ) make_consumes(electrons.getParameter<edm::InputTag>("sigmaIphiIphi"), e_conf.tok_sigmaIphiIphi, cc);
-    if( electrons.exists("e1x5") ) make_consumes(electrons.getParameter<edm::InputTag>("e1x5"), e_conf.tok_e1x5, cc);
-    if( electrons.exists("e2x5Max") ) make_consumes(electrons.getParameter<edm::InputTag>("e2x5Max"), e_conf.tok_e2x5Max, cc);
-    if( electrons.exists("e5x5") ) make_consumes(electrons.getParameter<edm::InputTag>("e5x5"), e_conf.tok_e5x5, cc);
-    if( electrons.exists("r9") ) make_consumes(electrons.getParameter<edm::InputTag>("r9"), e_conf.tok_r9, cc);
-    if( electrons.exists("hcalDepth1OverEcal") ) make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth1OverEcal"), e_conf.tok_hcalDepth1OverEcal, cc);
-    if( electrons.exists("hcalDepth2OverEcal") ) make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth2OverEcal"), e_conf.tok_hcalDepth2OverEcal, cc);
-    if( electrons.exists("hcalDepth1OverEcalBc") ) make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth1OverEcalBc"), e_conf.tok_hcalDepth1OverEcalBc, cc);
-    if( electrons.exists("hcalDepth2OverEcalBc") ) make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth2OverEcalBc"), e_conf.tok_hcalDepth2OverEcalBc, cc);
+    if (electrons.exists("electronSrc"))
+      make_consumes(electrons.getParameter<edm::InputTag>("electronSrc"), e_conf.tok_electron_src, cc);
+    if (electrons.exists("sigmaEtaEta"))
+      make_consumes(electrons.getParameter<edm::InputTag>("sigmaEtaEta"), e_conf.tok_sigmaEtaEta, cc);
+    if (electrons.exists("sigmaIetaIeta"))
+      make_consumes(electrons.getParameter<edm::InputTag>("sigmaIetaIeta"), e_conf.tok_sigmaIetaIeta, cc);
+    if (electrons.exists("sigmaIphiIphi"))
+      make_consumes(electrons.getParameter<edm::InputTag>("sigmaIphiIphi"), e_conf.tok_sigmaIphiIphi, cc);
+    if (electrons.exists("e1x5"))
+      make_consumes(electrons.getParameter<edm::InputTag>("e1x5"), e_conf.tok_e1x5, cc);
+    if (electrons.exists("e2x5Max"))
+      make_consumes(electrons.getParameter<edm::InputTag>("e2x5Max"), e_conf.tok_e2x5Max, cc);
+    if (electrons.exists("e5x5"))
+      make_consumes(electrons.getParameter<edm::InputTag>("e5x5"), e_conf.tok_e5x5, cc);
+    if (electrons.exists("r9"))
+      make_consumes(electrons.getParameter<edm::InputTag>("r9"), e_conf.tok_r9, cc);
+    if (electrons.exists("hcalDepth1OverEcal"))
+      make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth1OverEcal"), e_conf.tok_hcalDepth1OverEcal, cc);
+    if (electrons.exists("hcalDepth2OverEcal"))
+      make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth2OverEcal"), e_conf.tok_hcalDepth2OverEcal, cc);
+    if (electrons.exists("hcalDepth1OverEcalBc"))
+      make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth1OverEcalBc"), e_conf.tok_hcalDepth1OverEcalBc, cc);
+    if (electrons.exists("hcalDepth2OverEcalBc"))
+      make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth2OverEcalBc"), e_conf.tok_hcalDepth2OverEcalBc, cc);
   }
-  if( conf.exists("photon_config") ) {
+  if (conf.exists("photon_config")) {
     const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("photon_config");
-    if( photons.exists("photonSrc") ) make_consumes(photons.getParameter<edm::InputTag>("photonSrc"), ph_conf.tok_photon_src, cc);
-    if( photons.exists("sigmaEtaEta") ) make_consumes(photons.getParameter<edm::InputTag>("sigmaEtaEta"), ph_conf.tok_sigmaEtaEta, cc);
-    if( photons.exists("sigmaIetaIeta") ) make_consumes(photons.getParameter<edm::InputTag>("sigmaIetaIeta"), ph_conf.tok_sigmaIetaIeta, cc);
-    if( photons.exists("e1x5") ) make_consumes(photons.getParameter<edm::InputTag>("e1x5"), ph_conf.tok_e1x5, cc);
-    if( photons.exists("e2x5") ) make_consumes(photons.getParameter<edm::InputTag>("e2x5"), ph_conf.tok_e2x5, cc);
-    if( photons.exists("e3x3") ) make_consumes(photons.getParameter<edm::InputTag>("e3x3"), ph_conf.tok_e3x3, cc);
-    if( photons.exists("e5x5") ) make_consumes(photons.getParameter<edm::InputTag>("e5x5"), ph_conf.tok_e5x5, cc);
-    if( photons.exists("maxEnergyXtal") ) make_consumes(photons.getParameter<edm::InputTag>("maxEnergyXtal"), ph_conf.tok_maxEnergyXtal, cc);
-    if( photons.exists("hcalDepth1OverEcal") ) make_consumes(photons.getParameter<edm::InputTag>("hcalDepth1OverEcal"), ph_conf.tok_hcalDepth1OverEcal, cc);
-    if( photons.exists("hcalDepth2OverEcal") ) make_consumes(photons.getParameter<edm::InputTag>("hcalDepth2OverEcal"), ph_conf.tok_hcalDepth2OverEcal, cc);
-    if( photons.exists("hcalDepth1OverEcalBc") ) make_consumes(photons.getParameter<edm::InputTag>("hcalDepth1OverEcalBc"), ph_conf.tok_hcalDepth1OverEcalBc, cc);
-    if( photons.exists("hcalDepth2OverEcalBc") ) make_consumes(photons.getParameter<edm::InputTag>("hcalDepth2OverEcalBc"), ph_conf.tok_hcalDepth2OverEcalBc, cc);
+    if (photons.exists("photonSrc"))
+      make_consumes(photons.getParameter<edm::InputTag>("photonSrc"), ph_conf.tok_photon_src, cc);
+    if (photons.exists("sigmaEtaEta"))
+      make_consumes(photons.getParameter<edm::InputTag>("sigmaEtaEta"), ph_conf.tok_sigmaEtaEta, cc);
+    if (photons.exists("sigmaIetaIeta"))
+      make_consumes(photons.getParameter<edm::InputTag>("sigmaIetaIeta"), ph_conf.tok_sigmaIetaIeta, cc);
+    if (photons.exists("e1x5"))
+      make_consumes(photons.getParameter<edm::InputTag>("e1x5"), ph_conf.tok_e1x5, cc);
+    if (photons.exists("e2x5"))
+      make_consumes(photons.getParameter<edm::InputTag>("e2x5"), ph_conf.tok_e2x5, cc);
+    if (photons.exists("e3x3"))
+      make_consumes(photons.getParameter<edm::InputTag>("e3x3"), ph_conf.tok_e3x3, cc);
+    if (photons.exists("e5x5"))
+      make_consumes(photons.getParameter<edm::InputTag>("e5x5"), ph_conf.tok_e5x5, cc);
+    if (photons.exists("maxEnergyXtal"))
+      make_consumes(photons.getParameter<edm::InputTag>("maxEnergyXtal"), ph_conf.tok_maxEnergyXtal, cc);
+    if (photons.exists("hcalDepth1OverEcal"))
+      make_consumes(photons.getParameter<edm::InputTag>("hcalDepth1OverEcal"), ph_conf.tok_hcalDepth1OverEcal, cc);
+    if (photons.exists("hcalDepth2OverEcal"))
+      make_consumes(photons.getParameter<edm::InputTag>("hcalDepth2OverEcal"), ph_conf.tok_hcalDepth2OverEcal, cc);
+    if (photons.exists("hcalDepth1OverEcalBc"))
+      make_consumes(photons.getParameter<edm::InputTag>("hcalDepth1OverEcalBc"), ph_conf.tok_hcalDepth1OverEcalBc, cc);
+    if (photons.exists("hcalDepth2OverEcalBc"))
+      make_consumes(photons.getParameter<edm::InputTag>("hcalDepth2OverEcalBc"), ph_conf.tok_hcalDepth2OverEcalBc, cc);
   }
-  
+
   ele_idx = pho_idx = 0;
 }
 
 namespace {
   inline void get_product(const edm::Event& evt,
-                          const edm::EDGetTokenT<edm::ValueMap<float> >& tok,
-                          std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float> > >& map) {
-    if( !tok.isUninitialized() ) evt.getByToken(tok,map[tok.index()]);
+                          const edm::EDGetTokenT<edm::ValueMap<float>>& tok,
+                          std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float>>>& map) {
+    if (!tok.isUninitialized())
+      evt.getByToken(tok, map[tok.index()]);
   }
-}
+}  // namespace
 
-void EGFull5x5ShowerShapeModifierFromValueMaps::
-setEvent(const edm::Event& evt) {
+void EGFull5x5ShowerShapeModifierFromValueMaps::setEvent(const edm::Event& evt) {
   eles_by_oop.clear();
-  phos_by_oop.clear();  
+  phos_by_oop.clear();
   ele_vmaps.clear();
   pho_vmaps.clear();
 
   ele_idx = pho_idx = 0;
 
-  if( !e_conf.tok_electron_src.isUninitialized() ) {
-    edm::Handle<edm::View<pat::Electron> > eles;
-    evt.getByToken(e_conf.tok_electron_src,eles);
-    
+  if (!e_conf.tok_electron_src.isUninitialized()) {
+    edm::Handle<edm::View<pat::Electron>> eles;
+    evt.getByToken(e_conf.tok_electron_src, eles);
+
     eles_by_oop.resize(eles->size());
     std::copy(eles->ptrs().begin(), eles->ptrs().end(), eles_by_oop.begin());
   }
 
-  get_product(evt,e_conf.tok_sigmaEtaEta,ele_vmaps);
-  get_product(evt,e_conf.tok_sigmaIetaIeta,ele_vmaps);
-  get_product(evt,e_conf.tok_sigmaIphiIphi,ele_vmaps);
-  get_product(evt,e_conf.tok_e1x5,ele_vmaps);
-  get_product(evt,e_conf.tok_e2x5Max,ele_vmaps);
-  get_product(evt,e_conf.tok_e5x5,ele_vmaps);
-  get_product(evt,e_conf.tok_r9,ele_vmaps);
-  get_product(evt,e_conf.tok_hcalDepth1OverEcal,ele_vmaps);
-  get_product(evt,e_conf.tok_hcalDepth2OverEcal,ele_vmaps);
-  get_product(evt,e_conf.tok_hcalDepth1OverEcalBc,ele_vmaps);
-  get_product(evt,e_conf.tok_hcalDepth2OverEcalBc,ele_vmaps);
+  get_product(evt, e_conf.tok_sigmaEtaEta, ele_vmaps);
+  get_product(evt, e_conf.tok_sigmaIetaIeta, ele_vmaps);
+  get_product(evt, e_conf.tok_sigmaIphiIphi, ele_vmaps);
+  get_product(evt, e_conf.tok_e1x5, ele_vmaps);
+  get_product(evt, e_conf.tok_e2x5Max, ele_vmaps);
+  get_product(evt, e_conf.tok_e5x5, ele_vmaps);
+  get_product(evt, e_conf.tok_r9, ele_vmaps);
+  get_product(evt, e_conf.tok_hcalDepth1OverEcal, ele_vmaps);
+  get_product(evt, e_conf.tok_hcalDepth2OverEcal, ele_vmaps);
+  get_product(evt, e_conf.tok_hcalDepth1OverEcalBc, ele_vmaps);
+  get_product(evt, e_conf.tok_hcalDepth2OverEcalBc, ele_vmaps);
 
-  if( !ph_conf.tok_photon_src.isUninitialized() ) {
-    edm::Handle<edm::View<pat::Photon> > phos;
-    evt.getByToken(ph_conf.tok_photon_src,phos);
+  if (!ph_conf.tok_photon_src.isUninitialized()) {
+    edm::Handle<edm::View<pat::Photon>> phos;
+    evt.getByToken(ph_conf.tok_photon_src, phos);
 
     phos_by_oop.resize(phos->size());
     std::copy(phos->ptrs().begin(), phos->ptrs().end(), phos_by_oop.begin());
   }
 
-  get_product(evt,ph_conf.tok_sigmaEtaEta,pho_vmaps);
-  get_product(evt,ph_conf.tok_sigmaIetaIeta,pho_vmaps);
-  get_product(evt,ph_conf.tok_e1x5,pho_vmaps);
-  get_product(evt,ph_conf.tok_e2x5,pho_vmaps);
-  get_product(evt,ph_conf.tok_e3x3,pho_vmaps);
-  get_product(evt,ph_conf.tok_e5x5,pho_vmaps);
-  get_product(evt,ph_conf.tok_maxEnergyXtal,pho_vmaps);
-  get_product(evt,ph_conf.tok_hcalDepth1OverEcal,pho_vmaps);
-  get_product(evt,ph_conf.tok_hcalDepth2OverEcal,pho_vmaps);
-  get_product(evt,ph_conf.tok_hcalDepth1OverEcalBc,pho_vmaps);
-  get_product(evt,ph_conf.tok_hcalDepth2OverEcalBc,pho_vmaps);
-
+  get_product(evt, ph_conf.tok_sigmaEtaEta, pho_vmaps);
+  get_product(evt, ph_conf.tok_sigmaIetaIeta, pho_vmaps);
+  get_product(evt, ph_conf.tok_e1x5, pho_vmaps);
+  get_product(evt, ph_conf.tok_e2x5, pho_vmaps);
+  get_product(evt, ph_conf.tok_e3x3, pho_vmaps);
+  get_product(evt, ph_conf.tok_e5x5, pho_vmaps);
+  get_product(evt, ph_conf.tok_maxEnergyXtal, pho_vmaps);
+  get_product(evt, ph_conf.tok_hcalDepth1OverEcal, pho_vmaps);
+  get_product(evt, ph_conf.tok_hcalDepth2OverEcal, pho_vmaps);
+  get_product(evt, ph_conf.tok_hcalDepth1OverEcalBc, pho_vmaps);
+  get_product(evt, ph_conf.tok_hcalDepth2OverEcalBc, pho_vmaps);
 }
 
-void EGFull5x5ShowerShapeModifierFromValueMaps::
-setEventContent(const edm::EventSetup& evs) {
-}
+void EGFull5x5ShowerShapeModifierFromValueMaps::setEventContent(const edm::EventSetup& evs) {}
 
 namespace {
-  template<typename T, typename U, typename V>
+  template <typename T, typename U, typename V>
   inline void assignValue(const T& ptr, const U& tok, const V& map, float& value) {
-    if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+    if (!tok.isUninitialized())
+      value = map.find(tok.index())->second->get(ptr.id(), ptr.key());
   }
-}
+}  // namespace
 
-void EGFull5x5ShowerShapeModifierFromValueMaps::
-modifyObject(pat::Electron& ele) const {
+void EGFull5x5ShowerShapeModifierFromValueMaps::modifyObject(pat::Electron& ele) const {
   // we encounter two cases here, either we are running AOD -> MINIAOD
   // and the value maps are to the reducedEG object, can use original object ptr
-  // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference    
+  // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference
   edm::Ptr<reco::Candidate> ptr(ele.originalObjectRef());
-
 
   // The calls to this function should be matched to the order of the electrons
   // in eles_by_oop. In case it is called too many times, it will throw thanks
   // to the use of std::vector<T>::at().
-  if( !e_conf.tok_electron_src.isUninitialized() ) ptr = eles_by_oop.at(ele_idx);
+  if (!e_conf.tok_electron_src.isUninitialized())
+    ptr = eles_by_oop.at(ele_idx);
 
   //now we go through and modify the objects using the valuemaps we read in
   auto full5x5 = ele.full5x5_showerShape();
-  assignValue(ptr,e_conf.tok_sigmaEtaEta,ele_vmaps,full5x5.sigmaEtaEta);
-  assignValue(ptr,e_conf.tok_sigmaIetaIeta,ele_vmaps,full5x5.sigmaIetaIeta);
-  assignValue(ptr,e_conf.tok_sigmaIphiIphi,ele_vmaps,full5x5.sigmaIphiIphi);
-  assignValue(ptr,e_conf.tok_e1x5,ele_vmaps,full5x5.e1x5);
-  assignValue(ptr,e_conf.tok_e2x5Max,ele_vmaps,full5x5.e2x5Max);
-  assignValue(ptr,e_conf.tok_e5x5,ele_vmaps,full5x5.e5x5);
-  assignValue(ptr,e_conf.tok_r9,ele_vmaps,full5x5.r9);
-  assignValue(ptr,e_conf.tok_hcalDepth1OverEcal,ele_vmaps,full5x5.hcalDepth1OverEcal);
-  assignValue(ptr,e_conf.tok_hcalDepth2OverEcal,ele_vmaps,full5x5.hcalDepth2OverEcal);
-  assignValue(ptr,e_conf.tok_hcalDepth1OverEcalBc,ele_vmaps,full5x5.hcalDepth1OverEcalBc);
-  assignValue(ptr,e_conf.tok_hcalDepth2OverEcalBc,ele_vmaps,full5x5.hcalDepth2OverEcalBc);
+  assignValue(ptr, e_conf.tok_sigmaEtaEta, ele_vmaps, full5x5.sigmaEtaEta);
+  assignValue(ptr, e_conf.tok_sigmaIetaIeta, ele_vmaps, full5x5.sigmaIetaIeta);
+  assignValue(ptr, e_conf.tok_sigmaIphiIphi, ele_vmaps, full5x5.sigmaIphiIphi);
+  assignValue(ptr, e_conf.tok_e1x5, ele_vmaps, full5x5.e1x5);
+  assignValue(ptr, e_conf.tok_e2x5Max, ele_vmaps, full5x5.e2x5Max);
+  assignValue(ptr, e_conf.tok_e5x5, ele_vmaps, full5x5.e5x5);
+  assignValue(ptr, e_conf.tok_r9, ele_vmaps, full5x5.r9);
+  assignValue(ptr, e_conf.tok_hcalDepth1OverEcal, ele_vmaps, full5x5.hcalDepth1OverEcal);
+  assignValue(ptr, e_conf.tok_hcalDepth2OverEcal, ele_vmaps, full5x5.hcalDepth2OverEcal);
+  assignValue(ptr, e_conf.tok_hcalDepth1OverEcalBc, ele_vmaps, full5x5.hcalDepth1OverEcalBc);
+  assignValue(ptr, e_conf.tok_hcalDepth2OverEcalBc, ele_vmaps, full5x5.hcalDepth2OverEcalBc);
 
   ele.full5x5_setShowerShape(full5x5);
   ++ele_idx;
 }
 
-
-void EGFull5x5ShowerShapeModifierFromValueMaps::
-modifyObject(pat::Photon& pho) const {
+void EGFull5x5ShowerShapeModifierFromValueMaps::modifyObject(pat::Photon& pho) const {
   // we encounter two cases here, either we are running AOD -> MINIAOD
   // and the value maps are to the reducedEG object, can use original object ptr
   // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference
@@ -219,21 +242,22 @@ modifyObject(pat::Photon& pho) const {
   // The calls to this function should be matched to the order of the electrons
   // in eles_by_oop. In case it is called too many times, it will throw thanks
   // to the use of std::vector<T>::at().
-  if( !ph_conf.tok_photon_src.isUninitialized() ) ptr = phos_by_oop.at(pho_idx);
+  if (!ph_conf.tok_photon_src.isUninitialized())
+    ptr = phos_by_oop.at(pho_idx);
 
   //now we go through and modify the objects using the valuemaps we read in
   auto full5x5 = pho.full5x5_showerShapeVariables();
-  assignValue(ptr,ph_conf.tok_sigmaEtaEta,pho_vmaps,full5x5.sigmaEtaEta);
-  assignValue(ptr,ph_conf.tok_sigmaIetaIeta,pho_vmaps,full5x5.sigmaIetaIeta);
-  assignValue(ptr,ph_conf.tok_e1x5,pho_vmaps,full5x5.e1x5);
-  assignValue(ptr,ph_conf.tok_e2x5,pho_vmaps,full5x5.e2x5);
-  assignValue(ptr,ph_conf.tok_e3x3,pho_vmaps,full5x5.e3x3);
-  assignValue(ptr,ph_conf.tok_e5x5,pho_vmaps,full5x5.e5x5);
-  assignValue(ptr,ph_conf.tok_maxEnergyXtal,pho_vmaps,full5x5.maxEnergyXtal);
-  assignValue(ptr,ph_conf.tok_hcalDepth1OverEcal,pho_vmaps,full5x5.hcalDepth1OverEcal);
-  assignValue(ptr,ph_conf.tok_hcalDepth2OverEcal,pho_vmaps,full5x5.hcalDepth2OverEcal);
-  assignValue(ptr,ph_conf.tok_hcalDepth1OverEcalBc,pho_vmaps,full5x5.hcalDepth1OverEcalBc);
-  assignValue(ptr,ph_conf.tok_hcalDepth2OverEcalBc,pho_vmaps,full5x5.hcalDepth2OverEcalBc);
+  assignValue(ptr, ph_conf.tok_sigmaEtaEta, pho_vmaps, full5x5.sigmaEtaEta);
+  assignValue(ptr, ph_conf.tok_sigmaIetaIeta, pho_vmaps, full5x5.sigmaIetaIeta);
+  assignValue(ptr, ph_conf.tok_e1x5, pho_vmaps, full5x5.e1x5);
+  assignValue(ptr, ph_conf.tok_e2x5, pho_vmaps, full5x5.e2x5);
+  assignValue(ptr, ph_conf.tok_e3x3, pho_vmaps, full5x5.e3x3);
+  assignValue(ptr, ph_conf.tok_e5x5, pho_vmaps, full5x5.e5x5);
+  assignValue(ptr, ph_conf.tok_maxEnergyXtal, pho_vmaps, full5x5.maxEnergyXtal);
+  assignValue(ptr, ph_conf.tok_hcalDepth1OverEcal, pho_vmaps, full5x5.hcalDepth1OverEcal);
+  assignValue(ptr, ph_conf.tok_hcalDepth2OverEcal, pho_vmaps, full5x5.hcalDepth2OverEcal);
+  assignValue(ptr, ph_conf.tok_hcalDepth1OverEcalBc, pho_vmaps, full5x5.hcalDepth1OverEcalBc);
+  assignValue(ptr, ph_conf.tok_hcalDepth2OverEcalBc, pho_vmaps, full5x5.hcalDepth2OverEcalBc);
 
   pho.full5x5_setShowerShapeVariables(full5x5);
   ++pho_idx;

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierHelpers.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierHelpers.cc
@@ -1,15 +1,13 @@
 #include "RecoEgamma/EgammaTools/plugins/EGRegressionModifierHelpers.h"
 
-std::vector<const GBRForestD*> retrieveGBRForests(edm::EventSetup const& evs, std::vector<std::string> const& names)
-{
+std::vector<const GBRForestD*> retrieveGBRForests(edm::EventSetup const& evs, std::vector<std::string> const& names) {
   std::vector<const GBRForestD*> items;
   edm::ESHandle<GBRForestD> handle;
 
-  for(auto const& name : names) {
+  for (auto const& name : names) {
     evs.get<GBRDWrapperRcd>().get(name, handle);
     items.push_back(handle.product());
   }
 
   return items;
 }
-

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
@@ -17,7 +17,6 @@
 
 class EGRegressionModifierV1 : public ModifyObjectValueBase {
 public:
-
   EGRegressionModifierV1(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
 
   void setEvent(const edm::Event&) final;
@@ -31,7 +30,6 @@ public:
   void modifyObject(pat::Photon& pho) const final { modifyObject(static_cast<reco::Photon&>(pho)); }
 
 private:
-
   struct CondNames {
     std::vector<std::string> mean50ns;
     std::vector<std::string> sigma50ns;
@@ -66,41 +64,35 @@ private:
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory, EGRegressionModifierV1, "EGRegressionModifierV1");
 
 EGRegressionModifierV1::EGRegressionModifierV1(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
-  : ModifyObjectValueBase(conf)
-  , autoDetectBunchSpacing_(conf.getParameter<bool>("autoDetectBunchSpacing"))
-  , bunchspacing_(autoDetectBunchSpacing_ ? 450 : conf.getParameter<int>("manualBunchSpacing"))
-  , rhoToken_(cc.consumes<double>(conf.getParameter<edm::InputTag>("rhoCollection")))
-  , vtxToken_(cc.consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("vertexCollection")))
-  , applyExtraHighEnergyProtection_(conf.getParameter<bool>("applyExtraHighEnergyProtection"))
-{
+    : ModifyObjectValueBase(conf),
+      autoDetectBunchSpacing_(conf.getParameter<bool>("autoDetectBunchSpacing")),
+      bunchspacing_(autoDetectBunchSpacing_ ? 450 : conf.getParameter<int>("manualBunchSpacing")),
+      rhoToken_(cc.consumes<double>(conf.getParameter<edm::InputTag>("rhoCollection"))),
+      vtxToken_(cc.consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("vertexCollection"))),
+      applyExtraHighEnergyProtection_(conf.getParameter<bool>("applyExtraHighEnergyProtection")) {
   if (autoDetectBunchSpacing_)
     bunchSpacingToken_ = cc.consumes<unsigned int>(conf.getParameter<edm::InputTag>("bunchSpacingTag"));
 
   const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
-  eleCondNames_ = CondNames {
-      .mean50ns  = electrons.getParameter<std::vector<std::string> >("regressionKey_50ns"),
-      .sigma50ns = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_50ns"),
-      .mean25ns  = electrons.getParameter<std::vector<std::string> >("regressionKey_25ns"),
-      .sigma25ns = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_25ns")
-  };
-  condNamesWeight50ns_  = electrons.getParameter<std::string>("combinationKey_50ns");
-  condNamesWeight25ns_  = electrons.getParameter<std::string>("combinationKey_25ns");
+  eleCondNames_ = CondNames{.mean50ns = electrons.getParameter<std::vector<std::string>>("regressionKey_50ns"),
+                            .sigma50ns = electrons.getParameter<std::vector<std::string>>("uncertaintyKey_50ns"),
+                            .mean25ns = electrons.getParameter<std::vector<std::string>>("regressionKey_25ns"),
+                            .sigma25ns = electrons.getParameter<std::vector<std::string>>("uncertaintyKey_25ns")};
+  condNamesWeight50ns_ = electrons.getParameter<std::string>("combinationKey_50ns");
+  condNamesWeight25ns_ = electrons.getParameter<std::string>("combinationKey_25ns");
 
   const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("photon_config");
-  phoCondNames_ = CondNames {
-      .mean50ns  = photons.getParameter<std::vector<std::string>>("regressionKey_50ns"),
-      .sigma50ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_50ns"),
-      .mean25ns  = photons.getParameter<std::vector<std::string>>("regressionKey_25ns"),
-      .sigma25ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_25ns")
-  };
+  phoCondNames_ = CondNames{.mean50ns = photons.getParameter<std::vector<std::string>>("regressionKey_50ns"),
+                            .sigma50ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_50ns"),
+                            .mean25ns = photons.getParameter<std::vector<std::string>>("regressionKey_25ns"),
+                            .sigma25ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_25ns")};
 }
 
-void EGRegressionModifierV1::setEvent(const edm::Event& evt)
-{
+void EGRegressionModifierV1::setEvent(const edm::Event& evt) {
   if (autoDetectBunchSpacing_) {
-      edm::Handle<unsigned int> bunchSpacingH;
-      evt.getByToken(bunchSpacingToken_,bunchSpacingH);
-      bunchspacing_ = *bunchSpacingH;
+    edm::Handle<unsigned int> bunchSpacingH;
+    evt.getByToken(bunchSpacingToken_, bunchSpacingH);
+    bunchspacing_ = *bunchSpacingH;
   }
 
   edm::Handle<double> rhoH;
@@ -111,18 +103,17 @@ void EGRegressionModifierV1::setEvent(const edm::Event& evt)
   nVtx_ = vtxH_->size();
 }
 
-void EGRegressionModifierV1::setEventContent(const edm::EventSetup& evs)
-{
+void EGRegressionModifierV1::setEventContent(const edm::EventSetup& evs) {
   evs.get<CaloGeometryRecord>().get(caloGeomH_);
 
-  phoForestsMean_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? phoCondNames_.mean25ns  : phoCondNames_.mean50ns);
-  phoForestsSigma_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? phoCondNames_.sigma25ns  : phoCondNames_.sigma50ns);
+  phoForestsMean_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? phoCondNames_.mean25ns : phoCondNames_.mean50ns);
+  phoForestsSigma_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? phoCondNames_.sigma25ns : phoCondNames_.sigma50ns);
 
-  eleForestsMean_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? eleCondNames_.mean25ns  : eleCondNames_.mean50ns);
-  eleForestsSigma_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? eleCondNames_.sigma25ns  : eleCondNames_.sigma50ns);
+  eleForestsMean_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? eleCondNames_.mean25ns : eleCondNames_.mean50ns);
+  eleForestsSigma_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? eleCondNames_.sigma25ns : eleCondNames_.sigma50ns);
 
   edm::ESHandle<GBRForest> forestEH;
-  const std::string ep_condnames_weight  = (bunchspacing_ == 25) ? condNamesWeight25ns_  : condNamesWeight50ns_;
+  const std::string ep_condnames_weight = (bunchspacing_ == 25) ? condNamesWeight25ns_ : condNamesWeight50ns_;
   evs.get<GBRWrapperRcd>().get(ep_condnames_weight, forestEH);
   epForest_ = forestEH.product();
 }
@@ -132,32 +123,33 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
 
   const reco::SuperClusterRef& superClus = ele.superCluster();
   const edm::Ptr<reco::CaloCluster>& theseed = superClus->seed();
-  const int numberOfClusters =  superClus->clusters().size();
-  const bool missing_clusters = !superClus->clusters()[numberOfClusters-1].isAvailable();
+  const int numberOfClusters = superClus->clusters().size();
+  const bool missing_clusters = !superClus->clusters()[numberOfClusters - 1].isAvailable();
 
-  if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
+  if (missing_clusters)
+    return;  // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
 
   std::array<float, 33> eval;
   const double rawEnergy = superClus->rawEnergy();
   const auto& ess = ele.showerShape();
 
   // SET INPUTS
-  eval[0]  = nVtx_;
-  eval[1]  = rawEnergy;
-  eval[2]  = superClus->eta();
-  eval[3]  = superClus->phi();
-  eval[4]  = superClus->etaWidth();
-  eval[5]  = superClus->phiWidth();
-  eval[6]  = ess.r9;
-  eval[7]  = theseed->energy()/rawEnergy;
-  eval[8]  = ess.eMax/rawEnergy;
-  eval[9]  = ess.e2nd/rawEnergy;
-  eval[10] = (ess.eLeft + ess.eRight != 0.f  ? (ess.eLeft-ess.eRight)/(ess.eLeft+ess.eRight) : 0.f);
-  eval[11] = (ess.eTop  + ess.eBottom != 0.f ? (ess.eTop-ess.eBottom)/(ess.eTop+ess.eBottom) : 0.f);
+  eval[0] = nVtx_;
+  eval[1] = rawEnergy;
+  eval[2] = superClus->eta();
+  eval[3] = superClus->phi();
+  eval[4] = superClus->etaWidth();
+  eval[5] = superClus->phiWidth();
+  eval[6] = ess.r9;
+  eval[7] = theseed->energy() / rawEnergy;
+  eval[8] = ess.eMax / rawEnergy;
+  eval[9] = ess.e2nd / rawEnergy;
+  eval[10] = (ess.eLeft + ess.eRight != 0.f ? (ess.eLeft - ess.eRight) / (ess.eLeft + ess.eRight) : 0.f);
+  eval[11] = (ess.eTop + ess.eBottom != 0.f ? (ess.eTop - ess.eBottom) / (ess.eTop + ess.eBottom) : 0.f);
   eval[12] = ess.sigmaIetaIeta;
   eval[13] = ess.sigmaIetaIphi;
   eval[14] = ess.sigmaIphiIphi;
-  eval[15] = std::max(0,numberOfClusters-1);
+  eval[15] = std::max(0, numberOfClusters - 1);
 
   // calculate sub-cluster variables
   std::vector<float> clusterRawEnergy;
@@ -166,7 +158,7 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   clusterDEtaToSeed.resize(std::max(3, numberOfClusters), 0);
   std::vector<float> clusterDPhiToSeed;
   clusterDPhiToSeed.resize(std::max(3, numberOfClusters), 0);
-  float clusterMaxDR     = 999.;
+  float clusterMaxDR = 999.;
   float clusterMaxDRDPhi = 999.;
   float clusterMaxDRDEta = 999.;
   float clusterMaxDRRawEnergy = 0.;
@@ -174,17 +166,16 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   size_t iclus = 0;
   float maxDR = 0;
   // loop over all clusters that aren't the seed
-  for (auto const& pclus : superClus->clusters())
-  {
-    if(theseed == pclus )
+  for (auto const& pclus : superClus->clusters()) {
+    if (theseed == pclus)
       continue;
-    clusterRawEnergy[iclus]  = pclus->energy();
-    clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(),theseed->phi());
+    clusterRawEnergy[iclus] = pclus->energy();
+    clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(), theseed->phi());
     clusterDEtaToSeed[iclus] = pclus->eta() - theseed->eta();
 
     // find cluster with max dR
     const auto the_dr = reco::deltaR(*pclus, *theseed);
-    if(the_dr > maxDR) {
+    if (the_dr > maxDR) {
       maxDR = the_dr;
       clusterMaxDR = maxDR;
       clusterMaxDRDPhi = clusterDPhiToSeed[iclus];
@@ -197,10 +188,10 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   eval[16] = clusterMaxDR;
   eval[17] = clusterMaxDRDPhi;
   eval[18] = clusterMaxDRDEta;
-  eval[19] = clusterMaxDRRawEnergy/rawEnergy;
-  eval[20] = clusterRawEnergy[0]/rawEnergy;
-  eval[21] = clusterRawEnergy[1]/rawEnergy;
-  eval[22] = clusterRawEnergy[2]/rawEnergy;
+  eval[19] = clusterMaxDRRawEnergy / rawEnergy;
+  eval[20] = clusterRawEnergy[0] / rawEnergy;
+  eval[21] = clusterRawEnergy[1] / rawEnergy;
+  eval[22] = clusterRawEnergy[2] / rawEnergy;
   eval[23] = clusterDPhiToSeed[0];
   eval[24] = clusterDPhiToSeed[1];
   eval[25] = clusterDPhiToSeed[2];
@@ -226,20 +217,20 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
     eval[31] = iEta;
     eval[32] = iPhi;
   } else {
-    eval[29] = superClus->preshowerEnergy()/superClus->rawEnergy();
+    eval[29] = superClus->preshowerEnergy() / superClus->rawEnergy();
   }
 
   //magic numbers for MINUIT-like transformation of BDT output onto limited range
   //(These should be stored inside the conditions object in the future as well)
-  constexpr double meanlimlow  = 0.2;
+  constexpr double meanlimlow = 0.2;
   constexpr double meanlimhigh = 2.0;
-  constexpr double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
-  constexpr double meanscale   = 0.5*(meanlimhigh-meanlimlow);
+  constexpr double meanoffset = meanlimlow + 0.5 * (meanlimhigh - meanlimlow);
+  constexpr double meanscale = 0.5 * (meanlimhigh - meanlimlow);
 
-  constexpr double sigmalimlow  = 0.0002;
+  constexpr double sigmalimlow = 0.0002;
   constexpr double sigmalimhigh = 0.5;
-  constexpr double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
-  constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);
+  constexpr double sigmaoffset = sigmalimlow + 0.5 * (sigmalimhigh - sigmalimlow);
+  constexpr double sigmascale = 0.5 * (sigmalimhigh - sigmalimlow);
 
   const int coridx = isEB ? 0 : 1;
 
@@ -248,15 +239,15 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   double rawsigma = eleForestsSigma_[coridx]->GetResponse(eval.data());
 
   //apply transformation to limited output range (matching the training)
-  double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
-  double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
+  double mean = meanoffset + meanscale * vdt::fast_sin(rawmean);
+  double sigma = sigmaoffset + sigmascale * vdt::fast_sin(rawsigma);
 
   //regression target is ln(Etrue/Eraw)
   //so corrected energy is ecor=exp(mean)*e, uncertainty is exp(mean)*eraw*sigma=ecor*sigma
-  double ecor = mean*(eval[1]);
+  double ecor = mean * (eval[1]);
   if (!isEB)
-    ecor = mean*(eval[1]+superClus->preshowerEnergy());
-  const double sigmacor = sigma*ecor;
+    ecor = mean * (eval[1] + superClus->preshowerEnergy());
+  const double sigmacor = sigma * ecor;
 
   ele.setCorrectedEcalEnergy(ecor);
   ele.setCorrectedEcalEnergyError(sigmacor);
@@ -265,20 +256,20 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   std::array<float, 11> eval_ep;
 
   const float ep = ele.trackMomentumAtVtx().R();
-  const float tot_energy = superClus->rawEnergy()+superClus->preshowerEnergy();
+  const float tot_energy = superClus->rawEnergy() + superClus->preshowerEnergy();
   const float momentumError = ele.trackMomentumError();
-  const float trkMomentumRelError = ele.trackMomentumError()/ep;
-  const float eOverP = tot_energy*mean/ep;
-  eval_ep[0] = tot_energy*mean;
-  eval_ep[1] = sigma/mean;
+  const float trkMomentumRelError = ele.trackMomentumError() / ep;
+  const float eOverP = tot_energy * mean / ep;
+  eval_ep[0] = tot_energy * mean;
+  eval_ep[1] = sigma / mean;
   eval_ep[2] = ep;
   eval_ep[3] = trkMomentumRelError;
-  eval_ep[4] = sigma/mean/trkMomentumRelError;
-  eval_ep[5] = tot_energy*mean/ep;
-  eval_ep[6] = tot_energy*mean/ep*sqrt(sigma/mean*sigma/mean+trkMomentumRelError*trkMomentumRelError);
+  eval_ep[4] = sigma / mean / trkMomentumRelError;
+  eval_ep[5] = tot_energy * mean / ep;
+  eval_ep[6] = tot_energy * mean / ep * sqrt(sigma / mean * sigma / mean + trkMomentumRelError * trkMomentumRelError);
   eval_ep[7] = ele.ecalDriven();
   eval_ep[8] = ele.trackerDrivenSeed();
-  eval_ep[9] = int(ele.classification());//eleClass;
+  eval_ep[9] = int(ele.classification());  //eleClass;
   eval_ep[10] = isEB;
 
   // CODE FOR FUTURE SEMI_PARAMETRIC
@@ -289,22 +280,21 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
 
   // CODE FOR STANDARD BDT
   double weight = 0.;
-  if ( eOverP > 0.025 &&
-       std::abs(ep-ecor) < 15.*std::sqrt( momentumError*momentumError + sigmacor*sigmacor ) &&
-       (!applyExtraHighEnergyProtection_ || ((momentumError < 10.*ep) || (ecor < 200.)))
-       ) {
+  if (eOverP > 0.025 && std::abs(ep - ecor) < 15. * std::sqrt(momentumError * momentumError + sigmacor * sigmacor) &&
+      (!applyExtraHighEnergyProtection_ || ((momentumError < 10. * ep) || (ecor < 200.)))) {
     // protection against crazy track measurement
     weight = std::clamp(epForest_->GetResponse(eval_ep.data()), 0., 1.);
   }
 
-  double combinedMomentum = weight*ele.trackMomentumAtVtx().R() + (1.-weight)*ecor;
-  double combinedMomentumError = sqrt(weight*weight*ele.trackMomentumError()*ele.trackMomentumError() + (1.-weight)*(1.-weight)*sigmacor*sigmacor);
+  double combinedMomentum = weight * ele.trackMomentumAtVtx().R() + (1. - weight) * ecor;
+  double combinedMomentumError = sqrt(weight * weight * ele.trackMomentumError() * ele.trackMomentumError() +
+                                      (1. - weight) * (1. - weight) * sigmacor * sigmacor);
 
   math::XYZTLorentzVector oldMomentum = ele.p4();
-  math::XYZTLorentzVector newMomentum( oldMomentum.x()*combinedMomentum/oldMomentum.t(),
-                                       oldMomentum.y()*combinedMomentum/oldMomentum.t(),
-                                       oldMomentum.z()*combinedMomentum/oldMomentum.t(),
-                                       combinedMomentum );
+  math::XYZTLorentzVector newMomentum(oldMomentum.x() * combinedMomentum / oldMomentum.t(),
+                                      oldMomentum.y() * combinedMomentum / oldMomentum.t(),
+                                      oldMomentum.z() * combinedMomentum / oldMomentum.t(),
+                                      combinedMomentum);
 
   ele.correctMomentum(newMomentum, ele.trackMomentumError(), combinedMomentumError);
 }
@@ -316,77 +306,78 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
   const reco::SuperClusterRef& superClus = pho.superCluster();
   const edm::Ptr<reco::CaloCluster>& theseed = superClus->seed();
 
-  const int numberOfClusters =  superClus->clusters().size();
-  const bool missing_clusters = !superClus->clusters()[numberOfClusters-1].isAvailable();
+  const int numberOfClusters = superClus->clusters().size();
+  const bool missing_clusters = !superClus->clusters()[numberOfClusters - 1].isAvailable();
 
-  if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
+  if (missing_clusters)
+    return;  // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
 
   const double rawEnergy = superClus->rawEnergy();
   const auto& ess = pho.showerShapeVariables();
 
   // SET INPUTS
-  eval[0]  = rawEnergy;
-  eval[1]  = pho.r9();
-  eval[2]  = superClus->etaWidth();
-  eval[3]  = superClus->phiWidth();
-  eval[4]  = std::max(0,numberOfClusters - 1);
-  eval[5]  = pho.hadronicOverEm();
-  eval[6]  = rhoValue_;
-  eval[7]  = nVtx_;
-  eval[8] = theseed->eta()-superClus->position().Eta();
-  eval[9] = reco::deltaPhi(theseed->phi(),superClus->position().Phi());
-  eval[10] = theseed->energy()/rawEnergy;
-  eval[11] = ess.e3x3/ess.e5x5;
+  eval[0] = rawEnergy;
+  eval[1] = pho.r9();
+  eval[2] = superClus->etaWidth();
+  eval[3] = superClus->phiWidth();
+  eval[4] = std::max(0, numberOfClusters - 1);
+  eval[5] = pho.hadronicOverEm();
+  eval[6] = rhoValue_;
+  eval[7] = nVtx_;
+  eval[8] = theseed->eta() - superClus->position().Eta();
+  eval[9] = reco::deltaPhi(theseed->phi(), superClus->position().Phi());
+  eval[10] = theseed->energy() / rawEnergy;
+  eval[11] = ess.e3x3 / ess.e5x5;
   eval[12] = ess.sigmaIetaIeta;
   eval[13] = ess.sigmaIphiIphi;
-  eval[14] = ess.sigmaIetaIphi/(ess.sigmaIphiIphi*ess.sigmaIetaIeta);
-  eval[15] = ess.maxEnergyXtal/ess.e5x5;
-  eval[16] = ess.e2nd/ess.e5x5;
-  eval[17] = ess.eTop/ess.e5x5;
-  eval[18] = ess.eBottom/ess.e5x5;
-  eval[19] = ess.eLeft/ess.e5x5;
-  eval[20] = ess.eRight/ess.e5x5;
-  eval[21] = ess.e2x5Max/ess.e5x5;
-  eval[22] = ess.e2x5Left/ess.e5x5;
-  eval[23] = ess.e2x5Right/ess.e5x5;
-  eval[24] = ess.e2x5Top/ess.e5x5;
-  eval[25] = ess.e2x5Bottom/ess.e5x5;
+  eval[14] = ess.sigmaIetaIphi / (ess.sigmaIphiIphi * ess.sigmaIetaIeta);
+  eval[15] = ess.maxEnergyXtal / ess.e5x5;
+  eval[16] = ess.e2nd / ess.e5x5;
+  eval[17] = ess.eTop / ess.e5x5;
+  eval[18] = ess.eBottom / ess.e5x5;
+  eval[19] = ess.eLeft / ess.e5x5;
+  eval[20] = ess.eRight / ess.e5x5;
+  eval[21] = ess.e2x5Max / ess.e5x5;
+  eval[22] = ess.e2x5Left / ess.e5x5;
+  eval[23] = ess.e2x5Right / ess.e5x5;
+  eval[24] = ess.e2x5Top / ess.e5x5;
+  eval[25] = ess.e2x5Bottom / ess.e5x5;
 
   const bool isEB = pho.isEB();
   if (isEB) {
     EBDetId ebseedid(theseed->seed());
-    eval[26] = pho.e5x5()/theseed->energy();
+    eval[26] = pho.e5x5() / theseed->energy();
     int ieta = ebseedid.ieta();
     int iphi = ebseedid.iphi();
     eval[27] = ieta;
     eval[28] = iphi;
-    int signieta = ieta > 0 ? +1 : -1; /// this is 1*abs(ieta)/ieta in original training
-    eval[29] = (ieta-signieta)%5;
-    eval[30] = (iphi-1)%2;
-    eval[31] = (abs(ieta)<=25)*((ieta-signieta)) + (abs(ieta)>25)*((ieta-26*signieta)%20);
-    eval[32] = (iphi-1)%20;
+    int signieta = ieta > 0 ? +1 : -1;  /// this is 1*abs(ieta)/ieta in original training
+    eval[29] = (ieta - signieta) % 5;
+    eval[30] = (iphi - 1) % 2;
+    eval[31] = (abs(ieta) <= 25) * ((ieta - signieta)) + (abs(ieta) > 25) * ((ieta - 26 * signieta) % 20);
+    eval[32] = (iphi - 1) % 20;
     eval[33] = ieta;  /// duplicated variables but this was trained like that
     eval[34] = iphi;  /// duplicated variables but this was trained like that
   } else {
     EEDetId eeseedid(theseed->seed());
-    eval[26] = superClus->preshowerEnergy()/rawEnergy;
-    eval[27] = superClus->preshowerEnergyPlane1()/rawEnergy;
-    eval[28] = superClus->preshowerEnergyPlane2()/rawEnergy;
+    eval[26] = superClus->preshowerEnergy() / rawEnergy;
+    eval[27] = superClus->preshowerEnergyPlane1() / rawEnergy;
+    eval[28] = superClus->preshowerEnergyPlane2() / rawEnergy;
     eval[29] = eeseedid.ix();
     eval[30] = eeseedid.iy();
   }
 
   //magic numbers for MINUIT-like transformation of BDT output onto limited range
   //(These should be stored inside the conditions object in the future as well)
-  const double meanlimlow  = 0.2;
+  const double meanlimlow = 0.2;
   const double meanlimhigh = 2.0;
-  const double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
-  const double meanscale   = 0.5*(meanlimhigh-meanlimlow);
+  const double meanoffset = meanlimlow + 0.5 * (meanlimhigh - meanlimlow);
+  const double meanscale = 0.5 * (meanlimhigh - meanlimlow);
 
-  const double sigmalimlow  = 0.0002;
+  const double sigmalimlow = 0.0002;
   const double sigmalimhigh = 0.5;
-  const double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
-  const double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);
+  const double sigmaoffset = sigmalimlow + 0.5 * (sigmalimhigh - sigmalimlow);
+  const double sigmascale = 0.5 * (sigmalimhigh - sigmalimlow);
 
   const int coridx = isEB ? 0 : 1;
 
@@ -394,13 +385,13 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
   const double rawmean = phoForestsMean_[coridx]->GetResponse(eval.data());
   const double rawsigma = phoForestsSigma_[coridx]->GetResponse(eval.data());
   //apply transformation to limited output range (matching the training)
-  const double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
-  const double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
+  const double mean = meanoffset + meanscale * vdt::fast_sin(rawmean);
+  const double sigma = sigmaoffset + sigmascale * vdt::fast_sin(rawsigma);
 
   //regression target is ln(Etrue/Eraw)
   //so corrected energy is ecor=exp(mean)*e, uncertainty is exp(mean)*eraw*sigma=ecor*sigma
-  const double ecor = isEB ? mean*eval[0] : mean*(eval[0]+superClus->preshowerEnergy());
+  const double ecor = isEB ? mean * eval[0] : mean * (eval[0] + superClus->preshowerEnergy());
 
-  const double sigmacor = sigma*ecor;
+  const double sigmacor = sigma * ecor;
   pho.setCorrectedEnergy(reco::Photon::P4type::regression2, ecor, sigmacor, true);
 }

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
@@ -14,7 +14,6 @@
 #include <vdt/vdtMath.h>
 
 class EGRegressionModifierV2 : public ModifyObjectValueBase {
-
 public:
   EGRegressionModifierV2(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
 
@@ -46,42 +45,40 @@ private:
   std::vector<const GBRForestD*> eleForestsMean_;
   std::vector<const GBRForestD*> eleForestsSigma_;
 
-  const double lowEnergyEcalOnlyThr_;   // 300
-  const double lowEnergyEcalTrackThr_;  // 50
-  const double highEnergyEcalTrackThr_; // 200
-  const double eOverPEcalTrkThr_;       // 0.025
-  const double epDiffSigEcalTrackThr_;  // 15
-  const double epSigEcalTrackThr_;      // 10
+  const double lowEnergyEcalOnlyThr_;    // 300
+  const double lowEnergyEcalTrackThr_;   // 50
+  const double highEnergyEcalTrackThr_;  // 200
+  const double eOverPEcalTrkThr_;        // 0.025
+  const double epDiffSigEcalTrackThr_;   // 15
+  const double epSigEcalTrackThr_;       // 10
   const bool forceHighEnergyEcalTrainingIfSaturated_;
-
 };
 
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory, EGRegressionModifierV2, "EGRegressionModifierV2");
 
 EGRegressionModifierV2::EGRegressionModifierV2(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
-  : ModifyObjectValueBase(conf)
-  , rhoToken_(cc.consumes<double>(conf.getParameter<edm::InputTag>("rhoCollection")))
-  , lowEnergyEcalOnlyThr_(conf.getParameter<double>("lowEnergy_ECALonlyThr"))
-  , lowEnergyEcalTrackThr_(conf.getParameter<double>("lowEnergy_ECALTRKThr"))
-  , highEnergyEcalTrackThr_(conf.getParameter<double>("highEnergy_ECALTRKThr"))
-  , eOverPEcalTrkThr_(conf.getParameter<double>("eOverP_ECALTRKThr"))
-  , epDiffSigEcalTrackThr_(conf.getParameter<double>("epDiffSig_ECALTRKThr"))
-  , epSigEcalTrackThr_(conf.getParameter<double>("epSig_ECALTRKThr"))
-  , forceHighEnergyEcalTrainingIfSaturated_(conf.getParameter<bool>("forceHighEnergyEcalTrainingIfSaturated"))
-{
+    : ModifyObjectValueBase(conf),
+      rhoToken_(cc.consumes<double>(conf.getParameter<edm::InputTag>("rhoCollection"))),
+      lowEnergyEcalOnlyThr_(conf.getParameter<double>("lowEnergy_ECALonlyThr")),
+      lowEnergyEcalTrackThr_(conf.getParameter<double>("lowEnergy_ECALTRKThr")),
+      highEnergyEcalTrackThr_(conf.getParameter<double>("highEnergy_ECALTRKThr")),
+      eOverPEcalTrkThr_(conf.getParameter<double>("eOverP_ECALTRKThr")),
+      epDiffSigEcalTrackThr_(conf.getParameter<double>("epDiffSig_ECALTRKThr")),
+      epSigEcalTrackThr_(conf.getParameter<double>("epSig_ECALTRKThr")),
+      forceHighEnergyEcalTrainingIfSaturated_(conf.getParameter<bool>("forceHighEnergyEcalTrainingIfSaturated")) {
   const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
-  eleCondNames_ = CondNames {
-      .mean  = electrons.getParameter<std::vector<std::string> >("regressionKey"),
+  eleCondNames_ = CondNames{
+      .mean = electrons.getParameter<std::vector<std::string> >("regressionKey"),
       .sigma = electrons.getParameter<std::vector<std::string> >("uncertaintyKey"),
   };
 
   unsigned int encor = eleCondNames_.mean.size();
-  eleForestsMean_.reserve(2*encor);
-  eleForestsSigma_.reserve(2*encor);
+  eleForestsMean_.reserve(2 * encor);
+  eleForestsSigma_.reserve(2 * encor);
 
   const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("photon_config");
-  phoCondNames_ = CondNames {
-      .mean  = photons.getParameter<std::vector<std::string> >("regressionKey"),
+  phoCondNames_ = CondNames{
+      .mean = photons.getParameter<std::vector<std::string> >("regressionKey"),
       .sigma = photons.getParameter<std::vector<std::string> >("uncertaintyKey"),
   };
 
@@ -90,15 +87,13 @@ EGRegressionModifierV2::EGRegressionModifierV2(const edm::ParameterSet& conf, ed
   phoForestsSigma_.reserve(ncor);
 }
 
-void EGRegressionModifierV2::setEvent(const edm::Event& evt)
-{
+void EGRegressionModifierV2::setEvent(const edm::Event& evt) {
   edm::Handle<double> rhoH;
   evt.getByToken(rhoToken_, rhoH);
   rhoValue_ = *rhoH;
 }
 
-void EGRegressionModifierV2::setEventContent(const edm::EventSetup& evs)
-{
+void EGRegressionModifierV2::setEventContent(const edm::EventSetup& evs) {
   phoForestsMean_ = retrieveGBRForests(evs, phoCondNames_.mean);
   phoForestsSigma_ = retrieveGBRForests(evs, phoCondNames_.sigma);
 
@@ -109,22 +104,24 @@ void EGRegressionModifierV2::setEventContent(const edm::EventSetup& evs)
 }
 
 void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {
-
   // regression calculation needs no additional valuemaps
 
   const reco::SuperClusterRef& superClus = ele.superCluster();
   const edm::Ptr<reco::CaloCluster>& seed = superClus->seed();
 
   // skip HGCAL for now
-  if( EcalTools::isHGCalDet(seed->seed().det()) ) return;
+  if (EcalTools::isHGCalDet(seed->seed().det()))
+    return;
 
-  const int numberOfClusters =  superClus->clusters().size();
-  const bool missing_clusters = !superClus->clusters()[numberOfClusters-1].isAvailable();
-  if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
+  const int numberOfClusters = superClus->clusters().size();
+  const bool missing_clusters = !superClus->clusters()[numberOfClusters - 1].isAvailable();
+  if (missing_clusters)
+    return;  // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
 
   //check if fbrem is filled as its needed for E/p combination so abort if its set to the default value
   //this will be the case for <5 (or current cuts) for miniAOD electrons
-  if(ele.fbrem()==reco::GsfElectron::ClassificationVariables().trackFbrem) return;
+  if (ele.fbrem() == reco::GsfElectron::ClassificationVariables().trackFbrem)
+    return;
 
   const bool isEB = ele.isEB();
 
@@ -135,36 +132,35 @@ void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {
 
   float e5x5Inverse = full5x5_ess.e5x5 != 0. ? vdt::fast_inv(full5x5_ess.e5x5) : 0.;
 
-  eval[0]  = rawEnergy;
-  eval[1]  = superClus->etaWidth();
-  eval[2]  = superClus->phiWidth();
-  eval[3]  = superClus->seed()->energy()/rawEnergy;
-  eval[4]  = full5x5_ess.e5x5/rawEnergy;
-  eval[5]  = ele.hcalOverEcalBc();
-  eval[6]  = rhoValue_;
-  eval[7]  = seed->eta() - superClus->position().Eta();
-  eval[8]  = reco::deltaPhi( seed->phi(),superClus->position().Phi());
-  eval[9]  = full5x5_ess.r9;
-  eval[10]  = full5x5_ess.sigmaIetaIeta;
-  eval[11]  = full5x5_ess.sigmaIetaIphi;
-  eval[12]  = full5x5_ess.sigmaIphiIphi;
-  eval[13]  = full5x5_ess.eMax*e5x5Inverse;
-  eval[14]  = full5x5_ess.e2nd*e5x5Inverse;
-  eval[15]  = full5x5_ess.eTop*e5x5Inverse;
-  eval[16]  = full5x5_ess.eBottom*e5x5Inverse;
-  eval[17]  = full5x5_ess.eLeft*e5x5Inverse;
-  eval[18]  = full5x5_ess.eRight*e5x5Inverse;
-  eval[19]  = full5x5_ess.e2x5Max*e5x5Inverse;
-  eval[20]  = full5x5_ess.e2x5Left*e5x5Inverse;
-  eval[21]  = full5x5_ess.e2x5Right*e5x5Inverse;
-  eval[22]  = full5x5_ess.e2x5Top*e5x5Inverse;
-  eval[23]  = full5x5_ess.e2x5Bottom*e5x5Inverse;
-  eval[24]  = ele.nSaturatedXtals();
-  eval[25]  = std::max(0,numberOfClusters);
+  eval[0] = rawEnergy;
+  eval[1] = superClus->etaWidth();
+  eval[2] = superClus->phiWidth();
+  eval[3] = superClus->seed()->energy() / rawEnergy;
+  eval[4] = full5x5_ess.e5x5 / rawEnergy;
+  eval[5] = ele.hcalOverEcalBc();
+  eval[6] = rhoValue_;
+  eval[7] = seed->eta() - superClus->position().Eta();
+  eval[8] = reco::deltaPhi(seed->phi(), superClus->position().Phi());
+  eval[9] = full5x5_ess.r9;
+  eval[10] = full5x5_ess.sigmaIetaIeta;
+  eval[11] = full5x5_ess.sigmaIetaIphi;
+  eval[12] = full5x5_ess.sigmaIphiIphi;
+  eval[13] = full5x5_ess.eMax * e5x5Inverse;
+  eval[14] = full5x5_ess.e2nd * e5x5Inverse;
+  eval[15] = full5x5_ess.eTop * e5x5Inverse;
+  eval[16] = full5x5_ess.eBottom * e5x5Inverse;
+  eval[17] = full5x5_ess.eLeft * e5x5Inverse;
+  eval[18] = full5x5_ess.eRight * e5x5Inverse;
+  eval[19] = full5x5_ess.e2x5Max * e5x5Inverse;
+  eval[20] = full5x5_ess.e2x5Left * e5x5Inverse;
+  eval[21] = full5x5_ess.e2x5Right * e5x5Inverse;
+  eval[22] = full5x5_ess.e2x5Top * e5x5Inverse;
+  eval[23] = full5x5_ess.e2x5Bottom * e5x5Inverse;
+  eval[24] = ele.nSaturatedXtals();
+  eval[25] = std::max(0, numberOfClusters);
 
   // calculate coordinate variables
   if (isEB) {
-
     float dummy;
     int ieta;
     int iphi;
@@ -172,65 +168,65 @@ void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {
     eval[26] = ieta;
     eval[27] = iphi;
     int signieta = ieta > 0 ? +1 : -1;
-    eval[28] = (ieta-signieta)%5;
-    eval[29] = (iphi-1)%2;
-    eval[30] = (abs(ieta)<=25)*((ieta-signieta)) + (abs(ieta)>25)*((ieta-26*signieta)%20);
-    eval[31] = (iphi-1)%20;
+    eval[28] = (ieta - signieta) % 5;
+    eval[29] = (iphi - 1) % 2;
+    eval[30] = (abs(ieta) <= 25) * ((ieta - signieta)) + (abs(ieta) > 25) * ((ieta - 26 * signieta) % 20);
+    eval[31] = (iphi - 1) % 20;
 
   } else {
-
     float dummy;
     int ix;
     int iy;
     egammaTools::localEcalClusterCoordsEE(*seed, *caloGeometry_, dummy, dummy, ix, iy, dummy, dummy);
     eval[26] = ix;
     eval[27] = iy;
-    eval[28] = raw_es_energy/rawEnergy;
-
+    eval[28] = raw_es_energy / rawEnergy;
   }
 
   //magic numbers for MINUIT-like transformation of BDT output onto limited range
   //(These should be stored inside the conditions object in the future as well)
-  constexpr double meanlimlow  = -1.0;
+  constexpr double meanlimlow = -1.0;
   constexpr double meanlimhigh = 3.0;
-  constexpr double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
-  constexpr double meanscale   = 0.5*(meanlimhigh-meanlimlow);
+  constexpr double meanoffset = meanlimlow + 0.5 * (meanlimhigh - meanlimlow);
+  constexpr double meanscale = 0.5 * (meanlimhigh - meanlimlow);
 
-  constexpr double sigmalimlow  = 0.0002;
+  constexpr double sigmalimlow = 0.0002;
   constexpr double sigmalimhigh = 0.5;
-  constexpr double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
-  constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);
-
+  constexpr double sigmaoffset = sigmalimlow + 0.5 * (sigmalimhigh - sigmalimlow);
+  constexpr double sigmascale = 0.5 * (sigmalimhigh - sigmalimlow);
 
   size_t coridx = 0;
-  float rawPt = rawEnergy*superClus->position().rho()/superClus->position().r();
-  bool isSaturated = ele.nSaturatedXtals()!=0;
+  float rawPt = rawEnergy * superClus->position().rho() / superClus->position().r();
+  bool isSaturated = ele.nSaturatedXtals() != 0;
 
-  if(rawPt >= lowEnergyEcalOnlyThr_ ||
-     (isSaturated && forceHighEnergyEcalTrainingIfSaturated_)){
-    if(isEB) coridx = 1;
-    else coridx = 3;
-  }else{
-    if(isEB) coridx = 0;
-    else coridx = 2;
+  if (rawPt >= lowEnergyEcalOnlyThr_ || (isSaturated && forceHighEnergyEcalTrainingIfSaturated_)) {
+    if (isEB)
+      coridx = 1;
+    else
+      coridx = 3;
+  } else {
+    if (isEB)
+      coridx = 0;
+    else
+      coridx = 2;
   }
-
 
   //these are the actual BDT responses
   double rawmean = eleForestsMean_[coridx]->GetResponse(eval.data());
   double rawsigma = eleForestsSigma_[coridx]->GetResponse(eval.data());
 
   //apply transformation to limited output range (matching the training)
-  double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
-  double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
+  double mean = meanoffset + meanscale * vdt::fast_sin(rawmean);
+  double sigma = sigmaoffset + sigmascale * vdt::fast_sin(rawsigma);
 
   // Correct the energy. A negative energy means that the correction went
   // outside the boundaries of the training. In this case uses raw.
   // The resolution estimation, on the other hand should be ok.
-  if (mean < 0.) mean = 1.0;
+  if (mean < 0.)
+    mean = 1.0;
 
-  const double ecor = mean*(rawEnergy + raw_es_energy);
-  const double sigmacor = sigma*ecor;
+  const double ecor = mean * (rawEnergy + raw_es_energy);
+  const double sigmacor = sigma * ecor;
 
   ele.setCorrectedEcalEnergy(ecor);
   ele.setCorrectedEcalEnergyError(sigmacor);
@@ -240,20 +236,19 @@ void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {
 
   auto el_track = ele.gsfTrack();
   const float trkMomentum = el_track->pMode();
-  const float trkEta      = el_track->etaMode();
-  const float trkPhi      = el_track->phiMode();
-  const float trkMomentumError = std::abs(el_track->qoverpModeError())*trkMomentum*trkMomentum;
+  const float trkEta = el_track->etaMode();
+  const float trkPhi = el_track->phiMode();
+  const float trkMomentumError = std::abs(el_track->qoverpModeError()) * trkMomentum * trkMomentum;
 
-  const float eOverP = (rawEnergy+raw_es_energy)*mean/trkMomentum;
+  const float eOverP = (rawEnergy + raw_es_energy) * mean / trkMomentum;
   const float fbrem = ele.fbrem();
 
   // E-p combination
-  if (ecor < highEnergyEcalTrackThr_ &&
-      eOverP > eOverPEcalTrkThr_ &&
-      std::abs(ecor - trkMomentum) < epDiffSigEcalTrackThr_*std::sqrt(trkMomentumError*trkMomentumError+sigmacor*sigmacor) &&
-      trkMomentumError < epSigEcalTrackThr_*trkMomentum) {
-
-    rawPt = ecor/cosh(trkEta);
+  if (ecor < highEnergyEcalTrackThr_ && eOverP > eOverPEcalTrkThr_ &&
+      std::abs(ecor - trkMomentum) <
+          epDiffSigEcalTrackThr_ * std::sqrt(trkMomentumError * trkMomentumError + sigmacor * sigmacor) &&
+      trkMomentumError < epSigEcalTrackThr_ * trkMomentum) {
+    rawPt = ecor / cosh(trkEta);
     if (isEB && rawPt < lowEnergyEcalTrackThr_)
       coridx = 4;
     else if (isEB && rawPt >= lowEnergyEcalTrackThr_)
@@ -264,8 +259,8 @@ void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {
       coridx = 7;
 
     eval[0] = ecor;
-    eval[1] = sigma/mean;
-    eval[2] = trkMomentumError/trkMomentum;
+    eval[1] = sigma / mean;
+    eval[2] = trkMomentumError / trkMomentum;
     eval[3] = eOverP;
     eval[4] = ele.ecalDrivenSeed();
     eval[5] = full5x5_ess.r9;
@@ -273,33 +268,35 @@ void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {
     eval[7] = trkEta;
     eval[8] = trkPhi;
 
-    float ecalEnergyVar = (rawEnergy + raw_es_energy)*sigma;
-    float rawcombNormalization = (trkMomentumError*trkMomentumError + ecalEnergyVar*ecalEnergyVar);
-    float rawcomb = ( ecor*trkMomentumError*trkMomentumError + trkMomentum*ecalEnergyVar*ecalEnergyVar ) / rawcombNormalization;
+    float ecalEnergyVar = (rawEnergy + raw_es_energy) * sigma;
+    float rawcombNormalization = (trkMomentumError * trkMomentumError + ecalEnergyVar * ecalEnergyVar);
+    float rawcomb = (ecor * trkMomentumError * trkMomentumError + trkMomentum * ecalEnergyVar * ecalEnergyVar) /
+                    rawcombNormalization;
 
     //these are the actual BDT responses
     double rawmean_trk = eleForestsMean_[coridx]->GetResponse(eval.data());
     double rawsigma_trk = eleForestsSigma_[coridx]->GetResponse(eval.data());
 
     //apply transformation to limited output range (matching the training)
-    double mean_trk = meanoffset + meanscale*vdt::fast_sin(rawmean_trk);
-    double sigma_trk = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma_trk);
+    double mean_trk = meanoffset + meanscale * vdt::fast_sin(rawmean_trk);
+    double sigma_trk = sigmaoffset + sigmascale * vdt::fast_sin(rawsigma_trk);
 
     // Final correction
     // A negative energy means that the correction went
     // outside the boundaries of the training. In this case uses raw.
     // The resolution estimation, on the other hand should be ok.
-    if (mean_trk < 0.) mean_trk = 1.0;
+    if (mean_trk < 0.)
+      mean_trk = 1.0;
 
-    combinedEnergy = mean_trk*rawcomb;
-    combinedEnergyError = sigma_trk*rawcomb;
+    combinedEnergy = mean_trk * rawcomb;
+    combinedEnergyError = sigma_trk * rawcomb;
   }
 
   math::XYZTLorentzVector oldFourMomentum = ele.p4();
-  math::XYZTLorentzVector newFourMomentum( oldFourMomentum.x()*combinedEnergy/oldFourMomentum.t(),
-                                           oldFourMomentum.y()*combinedEnergy/oldFourMomentum.t(),
-                                           oldFourMomentum.z()*combinedEnergy/oldFourMomentum.t(),
-                                           combinedEnergy );
+  math::XYZTLorentzVector newFourMomentum(oldFourMomentum.x() * combinedEnergy / oldFourMomentum.t(),
+                                          oldFourMomentum.y() * combinedEnergy / oldFourMomentum.t(),
+                                          oldFourMomentum.z() * combinedEnergy / oldFourMomentum.t(),
+                                          combinedEnergy);
 
   ele.correctMomentum(newFourMomentum, ele.trackMomentumError(), combinedEnergyError);
 }
@@ -311,11 +308,13 @@ void EGRegressionModifierV2::modifyObject(reco::Photon& pho) const {
   const edm::Ptr<reco::CaloCluster>& seed = superClus->seed();
 
   // skip HGCAL for now
-  if( EcalTools::isHGCalDet(seed->seed().det()) ) return;
+  if (EcalTools::isHGCalDet(seed->seed().det()))
+    return;
 
-  const int numberOfClusters =  superClus->clusters().size();
-  const bool missing_clusters = !superClus->clusters()[numberOfClusters-1].isAvailable();
-  if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
+  const int numberOfClusters = superClus->clusters().size();
+  const bool missing_clusters = !superClus->clusters()[numberOfClusters - 1].isAvailable();
+  if (missing_clusters)
+    return;  // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
 
   const bool isEB = pho.isEB();
 
@@ -326,37 +325,36 @@ void EGRegressionModifierV2::modifyObject(reco::Photon& pho) const {
 
   float e5x5Inverse = full5x5_pss.e5x5 != 0. ? vdt::fast_inv(full5x5_pss.e5x5) : 0.;
 
-  eval[0]  = rawEnergy;
-  eval[1]  = superClus->etaWidth();
-  eval[2]  = superClus->phiWidth();
-  eval[3]  = superClus->seed()->energy()/rawEnergy;
-  eval[4]  = full5x5_pss.e5x5/rawEnergy;
-  eval[5]  = pho.hadronicOverEm();
-  eval[6]  = rhoValue_;
-  eval[7]  = seed->eta() - superClus->position().Eta();
-  eval[8]  = reco::deltaPhi( seed->phi(),superClus->position().Phi());
-  eval[9]  = pho.full5x5_r9();
-  eval[10]  = full5x5_pss.sigmaIetaIeta;
-  eval[11]  = full5x5_pss.sigmaIetaIphi;
-  eval[12]  = full5x5_pss.sigmaIphiIphi;
-  eval[13]  = full5x5_pss.maxEnergyXtal*e5x5Inverse;
-  eval[14]  = full5x5_pss.e2nd*e5x5Inverse;
-  eval[15]  = full5x5_pss.eTop*e5x5Inverse;
-  eval[16]  = full5x5_pss.eBottom*e5x5Inverse;
-  eval[17]  = full5x5_pss.eLeft*e5x5Inverse;
-  eval[18]  = full5x5_pss.eRight*e5x5Inverse;
-  eval[19]  = full5x5_pss.e2x5Max*e5x5Inverse;
-  eval[20]  = full5x5_pss.e2x5Left*e5x5Inverse;
-  eval[21]  = full5x5_pss.e2x5Right*e5x5Inverse;
-  eval[22]  = full5x5_pss.e2x5Top*e5x5Inverse;
-  eval[23]  = full5x5_pss.e2x5Bottom*e5x5Inverse;
-  eval[24]  = pho.nSaturatedXtals();
-  eval[25]  = std::max(0,numberOfClusters);
+  eval[0] = rawEnergy;
+  eval[1] = superClus->etaWidth();
+  eval[2] = superClus->phiWidth();
+  eval[3] = superClus->seed()->energy() / rawEnergy;
+  eval[4] = full5x5_pss.e5x5 / rawEnergy;
+  eval[5] = pho.hadronicOverEm();
+  eval[6] = rhoValue_;
+  eval[7] = seed->eta() - superClus->position().Eta();
+  eval[8] = reco::deltaPhi(seed->phi(), superClus->position().Phi());
+  eval[9] = pho.full5x5_r9();
+  eval[10] = full5x5_pss.sigmaIetaIeta;
+  eval[11] = full5x5_pss.sigmaIetaIphi;
+  eval[12] = full5x5_pss.sigmaIphiIphi;
+  eval[13] = full5x5_pss.maxEnergyXtal * e5x5Inverse;
+  eval[14] = full5x5_pss.e2nd * e5x5Inverse;
+  eval[15] = full5x5_pss.eTop * e5x5Inverse;
+  eval[16] = full5x5_pss.eBottom * e5x5Inverse;
+  eval[17] = full5x5_pss.eLeft * e5x5Inverse;
+  eval[18] = full5x5_pss.eRight * e5x5Inverse;
+  eval[19] = full5x5_pss.e2x5Max * e5x5Inverse;
+  eval[20] = full5x5_pss.e2x5Left * e5x5Inverse;
+  eval[21] = full5x5_pss.e2x5Right * e5x5Inverse;
+  eval[22] = full5x5_pss.e2x5Top * e5x5Inverse;
+  eval[23] = full5x5_pss.e2x5Bottom * e5x5Inverse;
+  eval[24] = pho.nSaturatedXtals();
+  eval[25] = std::max(0, numberOfClusters);
 
   // calculate coordinate variables
 
   if (isEB) {
-
     float dummy;
     int ieta;
     int iphi;
@@ -364,46 +362,47 @@ void EGRegressionModifierV2::modifyObject(reco::Photon& pho) const {
     eval[26] = ieta;
     eval[27] = iphi;
     int signieta = ieta > 0 ? +1 : -1;
-    eval[28] = (ieta-signieta)%5;
-    eval[29] = (iphi-1)%2;
-    eval[30] = (abs(ieta)<=25)*((ieta-signieta)) + (abs(ieta)>25)*((ieta-26*signieta)%20);
-    eval[31] = (iphi-1)%20;
+    eval[28] = (ieta - signieta) % 5;
+    eval[29] = (iphi - 1) % 2;
+    eval[30] = (abs(ieta) <= 25) * ((ieta - signieta)) + (abs(ieta) > 25) * ((ieta - 26 * signieta) % 20);
+    eval[31] = (iphi - 1) % 20;
 
   } else {
-
     float dummy;
     int ix;
     int iy;
     egammaTools::localEcalClusterCoordsEE(*seed, *caloGeometry_, dummy, dummy, ix, iy, dummy, dummy);
     eval[26] = ix;
     eval[27] = iy;
-    eval[28] = raw_es_energy/rawEnergy;
-
+    eval[28] = raw_es_energy / rawEnergy;
   }
 
   //magic numbers for MINUIT-like transformation of BDT output onto limited range
   //(These should be stored inside the conditions object in the future as well)
-  constexpr double meanlimlow  = -1.0;
+  constexpr double meanlimlow = -1.0;
   constexpr double meanlimhigh = 3.0;
-  constexpr double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
-  constexpr double meanscale   = 0.5*(meanlimhigh-meanlimlow);
+  constexpr double meanoffset = meanlimlow + 0.5 * (meanlimhigh - meanlimlow);
+  constexpr double meanscale = 0.5 * (meanlimhigh - meanlimlow);
 
-  constexpr double sigmalimlow  = 0.0002;
+  constexpr double sigmalimlow = 0.0002;
   constexpr double sigmalimhigh = 0.5;
-  constexpr double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
-  constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);
+  constexpr double sigmaoffset = sigmalimlow + 0.5 * (sigmalimhigh - sigmalimlow);
+  constexpr double sigmascale = 0.5 * (sigmalimhigh - sigmalimlow);
 
   size_t coridx = 0;
-  float rawPt = rawEnergy*superClus->position().rho()/superClus->position().r();
+  float rawPt = rawEnergy * superClus->position().rho() / superClus->position().r();
   bool isSaturated = pho.nSaturatedXtals();
 
-  if(rawPt >= lowEnergyEcalOnlyThr_ ||
-     (isSaturated && forceHighEnergyEcalTrainingIfSaturated_)){
-    if(isEB) coridx = 1;
-    else coridx = 3;
-  }else{
-    if(isEB) coridx = 0;
-    else coridx = 2;
+  if (rawPt >= lowEnergyEcalOnlyThr_ || (isSaturated && forceHighEnergyEcalTrainingIfSaturated_)) {
+    if (isEB)
+      coridx = 1;
+    else
+      coridx = 3;
+  } else {
+    if (isEB)
+      coridx = 0;
+    else
+      coridx = 2;
   }
 
   //these are the actual BDT responses
@@ -411,16 +410,17 @@ void EGRegressionModifierV2::modifyObject(reco::Photon& pho) const {
   double rawsigma = phoForestsSigma_[coridx]->GetResponse(eval.data());
 
   //apply transformation to limited output range (matching the training)
-  double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
-  double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
+  double mean = meanoffset + meanscale * vdt::fast_sin(rawmean);
+  double sigma = sigmaoffset + sigmascale * vdt::fast_sin(rawsigma);
 
   // Correct the energy. A negative energy means that the correction went
   // outside the boundaries of the training. In this case uses raw.
   // The resolution estimation, on the other hand should be ok.
-  if (mean < 0.) mean = 1.0;
+  if (mean < 0.)
+    mean = 1.0;
 
-  const double ecor = mean*(rawEnergy + raw_es_energy);
-  const double sigmacor = sigma*ecor;
+  const double ecor = mean * (rawEnergy + raw_es_energy);
+  const double sigmacor = sigma * ecor;
 
   pho.setCorrectedEnergy(reco::Photon::P4type::regression2, ecor, sigmacor, true);
 }

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV3.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV3.cc
@@ -20,7 +20,7 @@
 #include <vdt/vdtMath.h>
 
 class EGRegressionModifierV3 : public ModifyObjectValueBase {
-public: 
+public:
   struct EleRegs {
     EleRegs(const edm::ParameterSet& iConfig);
     void setEventContent(const edm::EventSetup& iSetup);
@@ -33,30 +33,30 @@ public:
     PhoRegs(const edm::ParameterSet& iConfig);
     void setEventContent(const edm::EventSetup& iSetup);
     EgammaRegressionContainer ecalOnlyMean;
-    EgammaRegressionContainer ecalOnlySigma;    
+    EgammaRegressionContainer ecalOnlySigma;
   };
 
   EGRegressionModifierV3(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
   ~EGRegressionModifierV3() override;
-    
+
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
-  
+
   void modifyObject(reco::GsfElectron&) const final;
   void modifyObject(reco::Photon&) const final;
-  
+
   // just calls reco versions
-  void modifyObject(pat::Electron&) const final; 
+  void modifyObject(pat::Electron&) const final;
   void modifyObject(pat::Photon&) const final;
 
 private:
-  std::array<float,32> getRegData(const reco::GsfElectron& ele)const;
-  std::array<float,32> getRegData(const reco::Photon& pho)const;
-  void getSeedCrysCoord(const reco::CaloCluster& clus,int& iEtaOrX,int& iPhiOrY)const;
+  std::array<float, 32> getRegData(const reco::GsfElectron& ele) const;
+  std::array<float, 32> getRegData(const reco::Photon& pho) const;
+  void getSeedCrysCoord(const reco::CaloCluster& clus, int& iEtaOrX, int& iPhiOrY) const;
 
   std::unique_ptr<EleRegs> eleRegs_;
   std::unique_ptr<PhoRegs> phoRegs_;
-  
+
   float rhoValue_;
   edm::EDGetTokenT<double> rhoToken_;
 
@@ -64,304 +64,293 @@ private:
   float maxRawEnergyForLowPtEBSigma_;
   float maxRawEnergyForLowPtEESigma_;
   edm::ESHandle<CaloGeometry> caloGeomHandle_;
-
 };
 
-DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
-		  EGRegressionModifierV3,
-		  "EGRegressionModifierV3");
+DEFINE_EDM_PLUGIN(ModifyObjectValueFactory, EGRegressionModifierV3, "EGRegressionModifierV3");
 
-EGRegressionModifierV3::EGRegressionModifierV3(const edm::ParameterSet& conf, 
-					       edm::ConsumesCollector& cc) :
-  ModifyObjectValueBase(conf),
-  rhoValue_(0.),
-  rhoToken_(cc.consumes<double>(conf.getParameter<edm::InputTag>("rhoTag"))),
-  useClosestToCentreSeedCrysDef_(conf.getParameter<bool>("useClosestToCentreSeedCrysDef")),
-  maxRawEnergyForLowPtEBSigma_(conf.getParameter<double>("maxRawEnergyForLowPtEBSigma")),
-  maxRawEnergyForLowPtEESigma_(conf.getParameter<double>("maxRawEnergyForLowPtEESigma"))
-{   
-  if(conf.exists("eleRegs")) {
+EGRegressionModifierV3::EGRegressionModifierV3(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
+    : ModifyObjectValueBase(conf),
+      rhoValue_(0.),
+      rhoToken_(cc.consumes<double>(conf.getParameter<edm::InputTag>("rhoTag"))),
+      useClosestToCentreSeedCrysDef_(conf.getParameter<bool>("useClosestToCentreSeedCrysDef")),
+      maxRawEnergyForLowPtEBSigma_(conf.getParameter<double>("maxRawEnergyForLowPtEBSigma")),
+      maxRawEnergyForLowPtEESigma_(conf.getParameter<double>("maxRawEnergyForLowPtEESigma")) {
+  if (conf.exists("eleRegs")) {
     eleRegs_ = std::make_unique<EleRegs>(conf.getParameter<edm::ParameterSet>("eleRegs"));
   }
-  if(conf.exists("phoRegs")) {
+  if (conf.exists("phoRegs")) {
     phoRegs_ = std::make_unique<PhoRegs>(conf.getParameter<edm::ParameterSet>("phoRegs"));
   }
 }
 
-EGRegressionModifierV3::~EGRegressionModifierV3(){}
+EGRegressionModifierV3::~EGRegressionModifierV3() {}
 
-void EGRegressionModifierV3::setEvent(const edm::Event& evt)
-{
+void EGRegressionModifierV3::setEvent(const edm::Event& evt) {
   edm::Handle<double> rhoHandle;
   evt.getByToken(rhoToken_, rhoHandle);
   rhoValue_ = *rhoHandle;
 }
 
-void EGRegressionModifierV3::setEventContent(const edm::EventSetup& iSetup)
-{
-  if(eleRegs_) eleRegs_->setEventContent(iSetup);
-  if(phoRegs_) phoRegs_->setEventContent(iSetup);
-  if(useClosestToCentreSeedCrysDef_) iSetup.get<CaloGeometryRecord>().get(caloGeomHandle_);
+void EGRegressionModifierV3::setEventContent(const edm::EventSetup& iSetup) {
+  if (eleRegs_)
+    eleRegs_->setEventContent(iSetup);
+  if (phoRegs_)
+    phoRegs_->setEventContent(iSetup);
+  if (useClosestToCentreSeedCrysDef_)
+    iSetup.get<CaloGeometryRecord>().get(caloGeomHandle_);
 }
 
-void EGRegressionModifierV3::modifyObject(reco::GsfElectron& ele) const
-{
+void EGRegressionModifierV3::modifyObject(reco::GsfElectron& ele) const {
   //check if we have specified an electron regression correction and
   //return the object unmodified if so
-  if(!eleRegs_) return;
+  if (!eleRegs_)
+    return;
 
   const reco::SuperClusterRef& superClus = ele.superCluster();
-  
+
   // skip HGCAL for now
-  if( superClus->seed()->seed().det() == DetId::Forward ) return;
+  if (superClus->seed()->seed().det() == DetId::Forward)
+    return;
 
   // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
-  if(!superClus->clusters().isAvailable()) return; 
+  if (!superClus->clusters().isAvailable())
+    return;
 
-  //check if fbrem is filled as its needed for E/p combination so abort if its set to the default value 
+  //check if fbrem is filled as its needed for E/p combination so abort if its set to the default value
   //this will be the case for <5 (or current cuts) for miniAOD electrons
-  if(ele.fbrem()==reco::GsfElectron::ClassificationVariables::kDefaultValue) return;
-  
+  if (ele.fbrem() == reco::GsfElectron::ClassificationVariables::kDefaultValue)
+    return;
+
   auto regData = getRegData(ele);
-  const float rawEnergy = superClus->rawEnergy(); 
+  const float rawEnergy = superClus->rawEnergy();
   const float rawESEnergy = superClus->preshowerEnergy();
   //bug here, it should include the ES, kept for backwards compat
-  const float rawEt = rawEnergy*superClus->position().rho()/superClus->position().r();
-  const bool isSaturated = ele.nSaturatedXtals()!=0;
+  const float rawEt = rawEnergy * superClus->position().rho() / superClus->position().r();
+  const bool isSaturated = ele.nSaturatedXtals() != 0;
 
-  const float ecalMean = eleRegs_->ecalOnlyMean(rawEt,ele.isEB(),isSaturated,regData.data());
+  const float ecalMean = eleRegs_->ecalOnlyMean(rawEt, ele.isEB(), isSaturated, regData.data());
   const float ecalMeanCorr = ecalMean > 0. ? ecalMean : 1.0;
   //as the sample is trained flat in pt, the regression's only source of very high energy
   //electrons is in the high endcap and therefore it gives a very poor resolution estimate
   //to any electrons with this energy, regardless of their actual eta
   //hence this lovely hack
-  if(ele.isEB() && maxRawEnergyForLowPtEBSigma_>=0 && 
-     eleRegs_->ecalOnlySigma.useLowEtBin(rawEt,isSaturated)){
-    regData[0] = std::min(regData[0],maxRawEnergyForLowPtEBSigma_);
+  if (ele.isEB() && maxRawEnergyForLowPtEBSigma_ >= 0 && eleRegs_->ecalOnlySigma.useLowEtBin(rawEt, isSaturated)) {
+    regData[0] = std::min(regData[0], maxRawEnergyForLowPtEBSigma_);
   }
-  if(!ele.isEB() && maxRawEnergyForLowPtEESigma_>=0 && 
-     eleRegs_->ecalOnlySigma.useLowEtBin(rawEt,isSaturated)){
-    regData[0] = std::min(regData[0],maxRawEnergyForLowPtEESigma_);
+  if (!ele.isEB() && maxRawEnergyForLowPtEESigma_ >= 0 && eleRegs_->ecalOnlySigma.useLowEtBin(rawEt, isSaturated)) {
+    regData[0] = std::min(regData[0], maxRawEnergyForLowPtEESigma_);
   }
-  const float ecalSigma = eleRegs_->ecalOnlySigma(rawEt,ele.isEB(),isSaturated,regData.data());
+  const float ecalSigma = eleRegs_->ecalOnlySigma(rawEt, ele.isEB(), isSaturated, regData.data());
 
-  const float corrEnergy = (rawEnergy + rawESEnergy)*ecalMeanCorr;
-  const float corrEnergyErr = corrEnergy*ecalSigma;
+  const float corrEnergy = (rawEnergy + rawESEnergy) * ecalMeanCorr;
+  const float corrEnergyErr = corrEnergy * ecalSigma;
 
   ele.setCorrectedEcalEnergy(corrEnergy);
   ele.setCorrectedEcalEnergyError(corrEnergyErr);
 
-  std::pair<float,float> combEnergyAndErr =  eleRegs_->epComb.combine(ele);
-  const math::XYZTLorentzVector newP4 = ele.p4()*combEnergyAndErr.first/ele.p4().t();
+  std::pair<float, float> combEnergyAndErr = eleRegs_->epComb.combine(ele);
+  const math::XYZTLorentzVector newP4 = ele.p4() * combEnergyAndErr.first / ele.p4().t();
   ele.correctMomentum(newP4, ele.trackMomentumError(), combEnergyAndErr.second);
 }
 
-void EGRegressionModifierV3::modifyObject(pat::Electron& ele) const
-{
+void EGRegressionModifierV3::modifyObject(pat::Electron& ele) const {
   modifyObject(static_cast<reco::GsfElectron&>(ele));
 }
 
-void EGRegressionModifierV3::modifyObject(reco::Photon& pho) const
-{
+void EGRegressionModifierV3::modifyObject(reco::Photon& pho) const {
   //check if we have specified an photon regression correction and
   //return the object unmodified if so
-  if(!phoRegs_) return;
-  
+  if (!phoRegs_)
+    return;
+
   const reco::SuperClusterRef& superClus = pho.superCluster();
 
   // skip HGCAL for now
-  if(superClus->seed()->seed().det() == DetId::Forward ) return;
+  if (superClus->seed()->seed().det() == DetId::Forward)
+    return;
 
   // do not apply corrections in case of missing info (happens for some slimmed MiniAOD photons)
-  if(!superClus->clusters().isAvailable()) return; 
+  if (!superClus->clusters().isAvailable())
+    return;
 
-  auto regData = getRegData(pho); 
+  auto regData = getRegData(pho);
 
-  const float rawEnergy = superClus->rawEnergy(); 
+  const float rawEnergy = superClus->rawEnergy();
   const float rawESEnergy = superClus->preshowerEnergy();
   //bug here, it should include the ES, kept for backwards compat
-  const float rawEt = rawEnergy*superClus->position().rho()/superClus->position().r();
+  const float rawEt = rawEnergy * superClus->position().rho() / superClus->position().r();
   const bool isSaturated = pho.nSaturatedXtals();
-  const float ecalMean = phoRegs_->ecalOnlyMean(rawEt,pho.isEB(),isSaturated,regData.data());
+  const float ecalMean = phoRegs_->ecalOnlyMean(rawEt, pho.isEB(), isSaturated, regData.data());
   const float ecalMeanCorr = ecalMean > 0. ? ecalMean : 1.0;
 
   //see the electrons for explaination of this lovely feature
-  if(pho.isEB() && maxRawEnergyForLowPtEBSigma_>=0 && 
-     phoRegs_->ecalOnlySigma.useLowEtBin(rawEt,isSaturated)){
-    regData[0] = std::min(regData[0],maxRawEnergyForLowPtEBSigma_);
+  if (pho.isEB() && maxRawEnergyForLowPtEBSigma_ >= 0 && phoRegs_->ecalOnlySigma.useLowEtBin(rawEt, isSaturated)) {
+    regData[0] = std::min(regData[0], maxRawEnergyForLowPtEBSigma_);
   }
-  if(!pho.isEB() && maxRawEnergyForLowPtEESigma_>=0 && 
-     phoRegs_->ecalOnlySigma.useLowEtBin(rawEt,isSaturated)){
-    regData[0] = std::min(regData[0],maxRawEnergyForLowPtEESigma_);
+  if (!pho.isEB() && maxRawEnergyForLowPtEESigma_ >= 0 && phoRegs_->ecalOnlySigma.useLowEtBin(rawEt, isSaturated)) {
+    regData[0] = std::min(regData[0], maxRawEnergyForLowPtEESigma_);
   }
-  const float ecalSigma = phoRegs_->ecalOnlySigma(rawEt,pho.isEB(),isSaturated,regData.data());
-    
-  const double corrEnergy = (rawEnergy + rawESEnergy)*ecalMeanCorr;
-  const double corrEnergyErr = corrEnergy*ecalSigma;
+  const float ecalSigma = phoRegs_->ecalOnlySigma(rawEt, pho.isEB(), isSaturated, regData.data());
 
-  pho.setCorrectedEnergy(reco::Photon::P4type::regression2, corrEnergy, corrEnergyErr, true);     
+  const double corrEnergy = (rawEnergy + rawESEnergy) * ecalMeanCorr;
+  const double corrEnergyErr = corrEnergy * ecalSigma;
+
+  pho.setCorrectedEnergy(reco::Photon::P4type::regression2, corrEnergy, corrEnergyErr, true);
 }
 
-void EGRegressionModifierV3::modifyObject(pat::Photon& pho) const {
-  modifyObject(static_cast<reco::Photon&>(pho));
-}
+void EGRegressionModifierV3::modifyObject(pat::Photon& pho) const { modifyObject(static_cast<reco::Photon&>(pho)); }
 
-std::array<float,32> EGRegressionModifierV3::getRegData(const reco::GsfElectron& ele)const
-{
-  std::array<float, 32> data;  
+std::array<float, 32> EGRegressionModifierV3::getRegData(const reco::GsfElectron& ele) const {
+  std::array<float, 32> data;
 
   const reco::SuperClusterRef& superClus = ele.superCluster();
   const edm::Ptr<reco::CaloCluster>& seedClus = superClus->seed();
-  
-  const bool isEB = ele.isEB();  
-  const double rawEnergy = superClus->rawEnergy(); 
+
+  const bool isEB = ele.isEB();
+  const double rawEnergy = superClus->rawEnergy();
   const double rawESEnergy = superClus->preshowerEnergy();
-  const int numberOfClusters =  superClus->clusters().size();
+  const int numberOfClusters = superClus->clusters().size();
   const auto& ssFull5x5 = ele.full5x5_showerShape();
 
   float e5x5Inverse = ssFull5x5.e5x5 != 0. ? vdt::fast_inv(ssFull5x5.e5x5) : 0.;
 
-  data[0]  = rawEnergy;
-  data[1]  = superClus->etaWidth();
-  data[2]  = superClus->phiWidth(); 
-  data[3]  = superClus->seed()->energy()/rawEnergy;
-  data[4]  = ssFull5x5.e5x5/rawEnergy;
-  data[5]  = ele.hcalOverEcalBc();
-  data[6]  = rhoValue_;
-  data[7]  = seedClus->eta() - superClus->position().Eta();
-  data[8]  = reco::deltaPhi( seedClus->phi(),superClus->position().Phi());
-  data[9]  = ssFull5x5.r9;
-  data[10]  = ssFull5x5.sigmaIetaIeta;
-  data[11]  = ssFull5x5.sigmaIetaIphi;
-  data[12]  = ssFull5x5.sigmaIphiIphi;
-  data[13]  = ssFull5x5.eMax*e5x5Inverse;
-  data[14]  = ssFull5x5.e2nd*e5x5Inverse;
-  data[15]  = ssFull5x5.eTop*e5x5Inverse;
-  data[16]  = ssFull5x5.eBottom*e5x5Inverse;
-  data[17]  = ssFull5x5.eLeft*e5x5Inverse;
-  data[18]  = ssFull5x5.eRight*e5x5Inverse;
-  data[19]  = ssFull5x5.e2x5Max*e5x5Inverse;
-  data[20]  = ssFull5x5.e2x5Left*e5x5Inverse;
-  data[21]  = ssFull5x5.e2x5Right*e5x5Inverse;
-  data[22]  = ssFull5x5.e2x5Top*e5x5Inverse;
-  data[23]  = ssFull5x5.e2x5Bottom*e5x5Inverse;
-  data[24]  = ele.nSaturatedXtals();
-  data[25]  = std::max(0,numberOfClusters);
-  
-  if(isEB){
-    int iEta,iPhi;
-    getSeedCrysCoord(*seedClus,iEta,iPhi);
+  data[0] = rawEnergy;
+  data[1] = superClus->etaWidth();
+  data[2] = superClus->phiWidth();
+  data[3] = superClus->seed()->energy() / rawEnergy;
+  data[4] = ssFull5x5.e5x5 / rawEnergy;
+  data[5] = ele.hcalOverEcalBc();
+  data[6] = rhoValue_;
+  data[7] = seedClus->eta() - superClus->position().Eta();
+  data[8] = reco::deltaPhi(seedClus->phi(), superClus->position().Phi());
+  data[9] = ssFull5x5.r9;
+  data[10] = ssFull5x5.sigmaIetaIeta;
+  data[11] = ssFull5x5.sigmaIetaIphi;
+  data[12] = ssFull5x5.sigmaIphiIphi;
+  data[13] = ssFull5x5.eMax * e5x5Inverse;
+  data[14] = ssFull5x5.e2nd * e5x5Inverse;
+  data[15] = ssFull5x5.eTop * e5x5Inverse;
+  data[16] = ssFull5x5.eBottom * e5x5Inverse;
+  data[17] = ssFull5x5.eLeft * e5x5Inverse;
+  data[18] = ssFull5x5.eRight * e5x5Inverse;
+  data[19] = ssFull5x5.e2x5Max * e5x5Inverse;
+  data[20] = ssFull5x5.e2x5Left * e5x5Inverse;
+  data[21] = ssFull5x5.e2x5Right * e5x5Inverse;
+  data[22] = ssFull5x5.e2x5Top * e5x5Inverse;
+  data[23] = ssFull5x5.e2x5Bottom * e5x5Inverse;
+  data[24] = ele.nSaturatedXtals();
+  data[25] = std::max(0, numberOfClusters);
+
+  if (isEB) {
+    int iEta, iPhi;
+    getSeedCrysCoord(*seedClus, iEta, iPhi);
     int signIEta = iEta > 0 ? +1 : -1;
     data[26] = iEta;
     data[27] = iPhi;
-    data[28] = (iEta-signIEta)%5;
-    data[29] = (iPhi-1)%2; 
+    data[28] = (iEta - signIEta) % 5;
+    data[29] = (iPhi - 1) % 2;
     const int iEtaCorr = iEta - (iEta > 0 ? +1 : -1);
     const int iEtaCorr26 = iEta - (iEta > 0 ? +26 : -26);
-    data[30] = std::abs(iEta)<=25 ? iEtaCorr%20 : iEtaCorr26%20;
-    data[31] = (iPhi-1)%20;
-  }else{
-    int iX,iY;
-    getSeedCrysCoord(*seedClus,iX,iY);
+    data[30] = std::abs(iEta) <= 25 ? iEtaCorr % 20 : iEtaCorr26 % 20;
+    data[31] = (iPhi - 1) % 20;
+  } else {
+    int iX, iY;
+    getSeedCrysCoord(*seedClus, iX, iY);
     data[26] = iX;
     data[27] = iY;
-    data[28] = rawESEnergy/rawEnergy;
+    data[28] = rawESEnergy / rawEnergy;
   }
 
   return data;
 }
 
-std::array<float,32> EGRegressionModifierV3::getRegData(const reco::Photon& pho)const
-{
-  std::array<float, 32> data;  
+std::array<float, 32> EGRegressionModifierV3::getRegData(const reco::Photon& pho) const {
+  std::array<float, 32> data;
 
   const reco::SuperClusterRef& superClus = pho.superCluster();
   const edm::Ptr<reco::CaloCluster>& seedClus = superClus->seed();
-  
-  const bool isEB = pho.isEB();  
-  const double rawEnergy = superClus->rawEnergy(); 
-  const double rawESEnergy = superClus->preshowerEnergy(); 
-  const int numberOfClusters =  superClus->clusters().size();
+
+  const bool isEB = pho.isEB();
+  const double rawEnergy = superClus->rawEnergy();
+  const double rawESEnergy = superClus->preshowerEnergy();
+  const int numberOfClusters = superClus->clusters().size();
   const auto& ssFull5x5 = pho.full5x5_showerShapeVariables();
 
   float e5x5Inverse = ssFull5x5.e5x5 != 0. ? vdt::fast_inv(ssFull5x5.e5x5) : 0.;
 
-  data[0]  = rawEnergy;
-  data[1]  = superClus->etaWidth();
-  data[2]  = superClus->phiWidth(); 
-  data[3]  = superClus->seed()->energy()/rawEnergy;
-  data[4]  = ssFull5x5.e5x5/rawEnergy;
+  data[0] = rawEnergy;
+  data[1] = superClus->etaWidth();
+  data[2] = superClus->phiWidth();
+  data[3] = superClus->seed()->energy() / rawEnergy;
+  data[4] = ssFull5x5.e5x5 / rawEnergy;
   //interestingly enough this differs from electrons where it uses cone based
   //naively Sam would have thought using cone based is even worse than tower based
-  data[5]  = pho.hadronicOverEm();
-  data[6]  = rhoValue_;
-  data[7]  = seedClus->eta() - superClus->position().Eta();
-  data[8]  = reco::deltaPhi( seedClus->phi(),superClus->position().Phi());
-  data[9]  = pho.full5x5_r9();
-  data[10]  = ssFull5x5.sigmaIetaIeta;
-  //interestingly sigmaIEtaIPhi differs in defination here from 
+  data[5] = pho.hadronicOverEm();
+  data[6] = rhoValue_;
+  data[7] = seedClus->eta() - superClus->position().Eta();
+  data[8] = reco::deltaPhi(seedClus->phi(), superClus->position().Phi());
+  data[9] = pho.full5x5_r9();
+  data[10] = ssFull5x5.sigmaIetaIeta;
+  //interestingly sigmaIEtaIPhi differs in defination here from
   //electron & sc definations of sigmaIEtaIPhi
-  data[11]  = ssFull5x5.sigmaIetaIphi;
-  data[12]  = ssFull5x5.sigmaIphiIphi;
-  data[13]  = ssFull5x5.maxEnergyXtal*e5x5Inverse;
-  data[14]  = ssFull5x5.e2nd*e5x5Inverse;
-  data[15]  = ssFull5x5.eTop*e5x5Inverse;
-  data[16]  = ssFull5x5.eBottom*e5x5Inverse;
-  data[17]  = ssFull5x5.eLeft*e5x5Inverse;
-  data[18]  = ssFull5x5.eRight*e5x5Inverse;
-  data[19]  = ssFull5x5.e2x5Max*e5x5Inverse;
-  data[20]  = ssFull5x5.e2x5Left*e5x5Inverse;
-  data[21]  = ssFull5x5.e2x5Right*e5x5Inverse;
-  data[22]  = ssFull5x5.e2x5Top*e5x5Inverse;
-  data[23]  = ssFull5x5.e2x5Bottom*e5x5Inverse;
-  data[24]  = pho.nSaturatedXtals();
-  data[25]  = std::max(0,numberOfClusters);
-      
-  if(isEB){
-    int iEta,iPhi;
-    getSeedCrysCoord(*seedClus,iEta,iPhi);
+  data[11] = ssFull5x5.sigmaIetaIphi;
+  data[12] = ssFull5x5.sigmaIphiIphi;
+  data[13] = ssFull5x5.maxEnergyXtal * e5x5Inverse;
+  data[14] = ssFull5x5.e2nd * e5x5Inverse;
+  data[15] = ssFull5x5.eTop * e5x5Inverse;
+  data[16] = ssFull5x5.eBottom * e5x5Inverse;
+  data[17] = ssFull5x5.eLeft * e5x5Inverse;
+  data[18] = ssFull5x5.eRight * e5x5Inverse;
+  data[19] = ssFull5x5.e2x5Max * e5x5Inverse;
+  data[20] = ssFull5x5.e2x5Left * e5x5Inverse;
+  data[21] = ssFull5x5.e2x5Right * e5x5Inverse;
+  data[22] = ssFull5x5.e2x5Top * e5x5Inverse;
+  data[23] = ssFull5x5.e2x5Bottom * e5x5Inverse;
+  data[24] = pho.nSaturatedXtals();
+  data[25] = std::max(0, numberOfClusters);
+
+  if (isEB) {
+    int iEta, iPhi;
+    getSeedCrysCoord(*seedClus, iEta, iPhi);
     data[26] = iEta;
     data[27] = iPhi;
     int signIEta = iEta > 0 ? +1 : -1;
-    data[28] = (iEta-signIEta)%5;
-    data[29] = (iPhi-1)%2;
+    data[28] = (iEta - signIEta) % 5;
+    data[29] = (iPhi - 1) % 2;
     const int iEtaCorr = iEta - (iEta > 0 ? +1 : -1);
     const int iEtaCorr26 = iEta - (iEta > 0 ? +26 : -26);
-    data[30] = std::abs(iEta)<=25 ? iEtaCorr%20 : iEtaCorr26%20;
-    data[31] = (iPhi-1)%20;
-  }else{
-    int iX,iY;
-    getSeedCrysCoord(*seedClus,iX,iY);
+    data[30] = std::abs(iEta) <= 25 ? iEtaCorr % 20 : iEtaCorr26 % 20;
+    data[31] = (iPhi - 1) % 20;
+  } else {
+    int iX, iY;
+    getSeedCrysCoord(*seedClus, iX, iY);
     data[26] = iX;
     data[27] = iY;
-    data[28] = rawESEnergy/rawEnergy;
+    data[28] = rawESEnergy / rawEnergy;
   }
 
   return data;
 }
 
-void EGRegressionModifierV3::getSeedCrysCoord(const reco::CaloCluster& clus,int& iEtaOrX,int& iPhiOrY)const
-{
+void EGRegressionModifierV3::getSeedCrysCoord(const reco::CaloCluster& clus, int& iEtaOrX, int& iPhiOrY) const {
   iEtaOrX = 0;
   iPhiOrY = 0;
 
-  const bool isEB = clus.seed().subdetId()==EcalBarrel;
+  const bool isEB = clus.seed().subdetId() == EcalBarrel;
 
-  if(useClosestToCentreSeedCrysDef_){
+  if (useClosestToCentreSeedCrysDef_) {
     float dummy;
-    if(isEB){
-      egammaTools::localEcalClusterCoordsEB(clus, *caloGeomHandle_, dummy, dummy, 
-					    iEtaOrX, iPhiOrY, dummy, dummy);
-    }else{
-      egammaTools::localEcalClusterCoordsEE(clus, *caloGeomHandle_, dummy, dummy, 
-					    iEtaOrX, iPhiOrY, dummy, dummy);
+    if (isEB) {
+      egammaTools::localEcalClusterCoordsEB(clus, *caloGeomHandle_, dummy, dummy, iEtaOrX, iPhiOrY, dummy, dummy);
+    } else {
+      egammaTools::localEcalClusterCoordsEE(clus, *caloGeomHandle_, dummy, dummy, iEtaOrX, iPhiOrY, dummy, dummy);
     }
-  }else{
-    if(isEB){
+  } else {
+    if (isEB) {
       const EBDetId ebId(clus.seed());
       iEtaOrX = ebId.ieta();
       iPhiOrY = ebId.iphi();
-    }else{
+    } else {
       const EEDetId eeId(clus.seed());
       iEtaOrX = eeId.ix();
       iPhiOrY = eeId.iy();
@@ -369,30 +358,22 @@ void EGRegressionModifierV3::getSeedCrysCoord(const reco::CaloCluster& clus,int&
   }
 }
 
-EGRegressionModifierV3::EleRegs::EleRegs(const edm::ParameterSet& iConfig):
-  ecalOnlyMean(iConfig.getParameter<edm::ParameterSet>("ecalOnlyMean")),
-  ecalOnlySigma(iConfig.getParameter<edm::ParameterSet>("ecalOnlySigma")),
-  epComb(iConfig.getParameter<edm::ParameterSet>("epComb"))
-{
-  
-}
+EGRegressionModifierV3::EleRegs::EleRegs(const edm::ParameterSet& iConfig)
+    : ecalOnlyMean(iConfig.getParameter<edm::ParameterSet>("ecalOnlyMean")),
+      ecalOnlySigma(iConfig.getParameter<edm::ParameterSet>("ecalOnlySigma")),
+      epComb(iConfig.getParameter<edm::ParameterSet>("epComb")) {}
 
-void EGRegressionModifierV3::EleRegs::setEventContent(const edm::EventSetup& iSetup)
-{
+void EGRegressionModifierV3::EleRegs::setEventContent(const edm::EventSetup& iSetup) {
   ecalOnlyMean.setEventContent(iSetup);
   ecalOnlySigma.setEventContent(iSetup);
   epComb.setEventContent(iSetup);
 }
 
-EGRegressionModifierV3::PhoRegs::PhoRegs(const edm::ParameterSet& iConfig):
-  ecalOnlyMean(iConfig.getParameter<edm::ParameterSet>("ecalOnlyMean")),
-  ecalOnlySigma(iConfig.getParameter<edm::ParameterSet>("ecalOnlySigma"))
-{
-  
-}
-  
-void EGRegressionModifierV3::PhoRegs::setEventContent(const edm::EventSetup& iSetup)
-{
+EGRegressionModifierV3::PhoRegs::PhoRegs(const edm::ParameterSet& iConfig)
+    : ecalOnlyMean(iConfig.getParameter<edm::ParameterSet>("ecalOnlyMean")),
+      ecalOnlySigma(iConfig.getParameter<edm::ParameterSet>("ecalOnlySigma")) {}
+
+void EGRegressionModifierV3::PhoRegs::setEventContent(const edm::EventSetup& iSetup) {
   ecalOnlyMean.setEventContent(iSetup);
   ecalOnlySigma.setEventContent(iSetup);
 }

--- a/RecoEgamma/EgammaTools/plugins/HGCalElectronFilter.cc
+++ b/RecoEgamma/EgammaTools/plugins/HGCalElectronFilter.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -39,93 +38,82 @@
 //
 
 class HGCalElectronFilter : public edm::stream::EDProducer<> {
-   public:
-      explicit HGCalElectronFilter(const edm::ParameterSet&);
-      ~HGCalElectronFilter() override;
+public:
+  explicit HGCalElectronFilter(const edm::ParameterSet&);
+  ~HGCalElectronFilter() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void beginStream(edm::StreamID) override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void endStream() override;
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-      // ----------member data ---------------------------
-      edm::EDGetTokenT<edm::View<reco::GsfElectron>> electronsToken_;
-      std::string  outputCollection_;
-      bool cleanBarrel_;
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<edm::View<reco::GsfElectron>> electronsToken_;
+  std::string outputCollection_;
+  bool cleanBarrel_;
 };
 
-
-HGCalElectronFilter::HGCalElectronFilter(const edm::ParameterSet& iConfig):
-    electronsToken_(consumes<edm::View<reco::GsfElectron>>(iConfig.getParameter<edm::InputTag>("inputGsfElectrons"))),
-    outputCollection_(iConfig.getParameter<std::string>("outputCollection")),
-    cleanBarrel_(iConfig.getParameter<bool>("cleanBarrel"))
-{
-    produces<reco::GsfElectronCollection>(outputCollection_);
+HGCalElectronFilter::HGCalElectronFilter(const edm::ParameterSet& iConfig)
+    : electronsToken_(consumes<edm::View<reco::GsfElectron>>(iConfig.getParameter<edm::InputTag>("inputGsfElectrons"))),
+      outputCollection_(iConfig.getParameter<std::string>("outputCollection")),
+      cleanBarrel_(iConfig.getParameter<bool>("cleanBarrel")) {
+  produces<reco::GsfElectronCollection>(outputCollection_);
 }
 
-
-HGCalElectronFilter::~HGCalElectronFilter() {
-}
-
+HGCalElectronFilter::~HGCalElectronFilter() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-HGCalElectronFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void HGCalElectronFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto gsfElectrons_p = std::make_unique<reco::GsfElectronCollection>();
 
-    auto gsfElectrons_p = std::make_unique<reco::GsfElectronCollection>();
+  edm::Handle<edm::View<reco::GsfElectron>> electronsH;
+  iEvent.getByToken(electronsToken_, electronsH);
 
-    edm::Handle<edm::View<reco::GsfElectron>> electronsH;
-    iEvent.getByToken(electronsToken_, electronsH);
-
-    for(const auto& electron1 : *electronsH) {
-        bool isBest = true;
-        if (!cleanBarrel_ && electron1.isEB()) { // keep all barrel electrons
-            gsfElectrons_p->push_back(electron1);
-            continue;
+  for (const auto& electron1 : *electronsH) {
+    bool isBest = true;
+    if (!cleanBarrel_ && electron1.isEB()) {  // keep all barrel electrons
+      gsfElectrons_p->push_back(electron1);
+      continue;
+    } else {
+      for (const auto& electron2 : *electronsH) {
+        if (&electron1 == &electron2)
+          continue;
+        if (electron1.superCluster() != electron2.superCluster())
+          continue;
+        if (electron1.electronCluster() != electron2.electronCluster()) {
+          if (electron1.electronCluster()->energy() < electron2.electronCluster()->energy()) {
+            isBest = false;
+            break;
+          }
         } else {
-            for (const auto& electron2 : *electronsH) {
-                if (&electron1 == &electron2) continue;
-                if (electron1.superCluster() != electron2.superCluster()) continue;
-                if (electron1.electronCluster() != electron2.electronCluster()) {
-                    if (electron1.electronCluster()->energy() < electron2.electronCluster()->energy()) {
-                        isBest=false;
-                        break;
-                    }
-                } else {
-                    if (fabs(electron1.eEleClusterOverPout()-1.) > fabs(electron2.eEleClusterOverPout()-1.)) {
-                        isBest=false;
-                        break;
-                    }
-                }
-            }
-            if (isBest) gsfElectrons_p->push_back(electron1);
+          if (fabs(electron1.eEleClusterOverPout() - 1.) > fabs(electron2.eEleClusterOverPout() - 1.)) {
+            isBest = false;
+            break;
+          }
         }
+      }
+      if (isBest)
+        gsfElectrons_p->push_back(electron1);
     }
+  }
 
-    iEvent.put(std::move(gsfElectrons_p), outputCollection_);
+  iEvent.put(std::move(gsfElectrons_p), outputCollection_);
 }
 
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-HGCalElectronFilter::beginStream(edm::StreamID)
-{
-}
+void HGCalElectronFilter::beginStream(edm::StreamID) {}
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-HGCalElectronFilter::endStream() {
-}
-
+void HGCalElectronFilter::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-HGCalElectronFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void HGCalElectronFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // cleanedEcalDrivenGsfElectronsFromMultiCl
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("inputGsfElectrons", edm::InputTag("ecalDrivenGsfElectronsFromMultiCl"));

--- a/RecoEgamma/EgammaTools/plugins/HGCalElectronIDValueMapProducer.cc
+++ b/RecoEgamma/EgammaTools/plugins/HGCalElectronIDValueMapProducer.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -40,76 +39,50 @@
 #include "RecoEgamma/EgammaTools/interface/LongDeps.h"
 
 class HGCalElectronIDValueMapProducer : public edm::stream::EDProducer<> {
-  public:
-    explicit HGCalElectronIDValueMapProducer(const edm::ParameterSet&);
-    ~HGCalElectronIDValueMapProducer() override;
+public:
+  explicit HGCalElectronIDValueMapProducer(const edm::ParameterSet&);
+  ~HGCalElectronIDValueMapProducer() override;
 
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  private:
-    void beginStream(edm::StreamID) override;
-    void produce(edm::Event&, const edm::EventSetup&) override;
-    void endStream() override;
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-    // ----------member data ---------------------------
-    edm::EDGetTokenT<edm::View<reco::GsfElectron>> electronsToken_;
-    float radius_;
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<edm::View<reco::GsfElectron>> electronsToken_;
+  float radius_;
 
-    static const std::vector<std::string> valuesProduced_;
-    std::map<const std::string, std::vector<float>> maps_;
+  static const std::vector<std::string> valuesProduced_;
+  std::map<const std::string, std::vector<float>> maps_;
 
-    std::unique_ptr<HGCalEgammaIDHelper> eIDHelper_;
+  std::unique_ptr<HGCalEgammaIDHelper> eIDHelper_;
 };
 
 // All the ValueMap names to output are defined in the auto-generated python cfi
 // so that potential consumers can configure themselves in a simple manner
 // Would be cool to use compile-time validation, but need constexpr strings, e.g. std::string_view in C++17
 const std::vector<std::string> HGCalElectronIDValueMapProducer::valuesProduced_ = {
-    "ecOrigEt",
-    "ecOrigEnergy",
-    "ecEt",
-    "ecEnergy",
-    "ecEnergyEE",
-    "ecEnergyFH",
-    "ecEnergyBH",
-    "pcaEig1",
-    "pcaEig2",
-    "pcaEig3",
-    "pcaSig1",
-    "pcaSig2",
-    "pcaSig3",
-    "pcaAxisX",
-    "pcaAxisY",
-    "pcaAxisZ",
-    "pcaPositionX",
-    "pcaPositionY",
-    "pcaPositionZ",
-    "sigmaUU",
-    "sigmaVV",
-    "sigmaEE",
-    "sigmaPP",
-    "nLayers",
-    "firstLayer",
-    "lastLayer",
-    "e4oEtot",
-    "layerEfrac10",
-    "layerEfrac90",
-    "measuredDepth",
-    "expectedDepth",
-    "expectedSigma",
-    "depthCompatibility",
-    "caloIsoRing0",
-    "caloIsoRing1",
-    "caloIsoRing2",
-    "caloIsoRing3",
-    "caloIsoRing4",
+    "ecOrigEt",      "ecOrigEnergy",  "ecEt",
+    "ecEnergy",      "ecEnergyEE",    "ecEnergyFH",
+    "ecEnergyBH",    "pcaEig1",       "pcaEig2",
+    "pcaEig3",       "pcaSig1",       "pcaSig2",
+    "pcaSig3",       "pcaAxisX",      "pcaAxisY",
+    "pcaAxisZ",      "pcaPositionX",  "pcaPositionY",
+    "pcaPositionZ",  "sigmaUU",       "sigmaVV",
+    "sigmaEE",       "sigmaPP",       "nLayers",
+    "firstLayer",    "lastLayer",     "e4oEtot",
+    "layerEfrac10",  "layerEfrac90",  "measuredDepth",
+    "expectedDepth", "expectedSigma", "depthCompatibility",
+    "caloIsoRing0",  "caloIsoRing1",  "caloIsoRing2",
+    "caloIsoRing3",  "caloIsoRing4",
 };
 
-HGCalElectronIDValueMapProducer::HGCalElectronIDValueMapProducer(const edm::ParameterSet& iConfig) :
-  electronsToken_(consumes<edm::View<reco::GsfElectron>>(iConfig.getParameter<edm::InputTag>("electrons"))),
-  radius_(iConfig.getParameter<double>("pcaRadius"))
-{
-  for(const auto& key : valuesProduced_) {
+HGCalElectronIDValueMapProducer::HGCalElectronIDValueMapProducer(const edm::ParameterSet& iConfig)
+    : electronsToken_(consumes<edm::View<reco::GsfElectron>>(iConfig.getParameter<edm::InputTag>("electrons"))),
+      radius_(iConfig.getParameter<double>("pcaRadius")) {
+  for (const auto& key : valuesProduced_) {
     maps_[key] = {};
     produces<edm::ValueMap<float>>(key);
   }
@@ -117,46 +90,39 @@ HGCalElectronIDValueMapProducer::HGCalElectronIDValueMapProducer(const edm::Para
   eIDHelper_.reset(new HGCalEgammaIDHelper(iConfig, consumesCollector()));
 }
 
-
-HGCalElectronIDValueMapProducer::~HGCalElectronIDValueMapProducer()
-{
-}
-
+HGCalElectronIDValueMapProducer::~HGCalElectronIDValueMapProducer() {}
 
 // ------------ method called to produce the data  ------------
-void
-HGCalElectronIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void HGCalElectronIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   Handle<edm::View<reco::GsfElectron>> electronsH;
   iEvent.getByToken(electronsToken_, electronsH);
 
   // Clear previous map
-  for(auto&& kv : maps_) {
+  for (auto&& kv : maps_) {
     kv.second.clear();
     kv.second.reserve(electronsH->size());
   }
 
   // Set up helper tool
-  eIDHelper_->eventInit(iEvent,iSetup);
+  eIDHelper_->eventInit(iEvent, iSetup);
 
-  for(const auto& electron : *electronsH) {
-    if(electron.isEB()) {
+  for (const auto& electron : *electronsH) {
+    if (electron.isEB()) {
       // Fill some dummy value
-      for(auto&& kv : maps_) {
-	kv.second.push_back(0.);
+      for (auto&& kv : maps_) {
+        kv.second.push_back(0.);
       }
-    }
-    else {
+    } else {
       eIDHelper_->computeHGCAL(electron, radius_);
 
       // check the PCA has worked out
-      if (eIDHelper_->sigmaUU() == -1){
-	  for(auto&& kv : maps_) {
-	      kv.second.push_back(0.);
-	  }
-	  continue;
+      if (eIDHelper_->sigmaUU() == -1) {
+        for (auto&& kv : maps_) {
+          kv.second.push_back(0.);
+        }
+        continue;
       }
 
       hgcal::LongDeps ld(eIDHelper_->energyPerLayer(radius_, true));
@@ -168,12 +134,12 @@ HGCalElectronIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSet
       // Energies / PT
       const auto* eleCluster = electron.electronCluster().get();
       const double sinTheta = eleCluster->position().rho() / eleCluster->position().r();
-      maps_["ecOrigEt"].push_back(eleCluster->energy() * sinTheta );
+      maps_["ecOrigEt"].push_back(eleCluster->energy() * sinTheta);
       maps_["ecOrigEnergy"].push_back(eleCluster->energy());
 
       // energies calculated in an cylinder around the axis of the electron cluster
       float ec_tot_energy = ld.energyEE() + ld.energyFH() + ld.energyBH();
-      maps_["ecEt"].push_back(ec_tot_energy * sinTheta );
+      maps_["ecEt"].push_back(ec_tot_energy * sinTheta);
       maps_["ecEnergy"].push_back(ec_tot_energy);
       maps_["ecEnergyEE"].push_back(ld.energyEE());
       maps_["ecEnergyFH"].push_back(ld.energyFH());
@@ -224,14 +190,16 @@ HGCalElectronIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSet
   }
 
   // Check we didn't make up a new variable and forget it in valuesProduced_
-  if ( maps_.size() != valuesProduced_.size() ) {
-    throw cms::Exception("HGCalElectronIDValueMapProducer") << "We have a miscoded value map producer, since map size changed";
+  if (maps_.size() != valuesProduced_.size()) {
+    throw cms::Exception("HGCalElectronIDValueMapProducer")
+        << "We have a miscoded value map producer, since map size changed";
   }
 
-  for(auto&& kv : maps_) {
+  for (auto&& kv : maps_) {
     // Check we didn't forget any values
-    if ( kv.second.size() != electronsH->size() ) {
-      throw cms::Exception("HGCalElectronIDValueMapProducer") << "We have a miscoded value map producer, since the variable " << kv.first << " wasn't filled.";
+    if (kv.second.size() != electronsH->size()) {
+      throw cms::Exception("HGCalElectronIDValueMapProducer")
+          << "We have a miscoded value map producer, since the variable " << kv.first << " wasn't filled.";
     }
     // Do the filling
     auto out = std::make_unique<edm::ValueMap<float>>();
@@ -244,31 +212,26 @@ HGCalElectronIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSet
 }
 
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-HGCalElectronIDValueMapProducer::beginStream(edm::StreamID)
-{
-}
+void HGCalElectronIDValueMapProducer::beginStream(edm::StreamID) {}
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-HGCalElectronIDValueMapProducer::endStream() {
-}
+void HGCalElectronIDValueMapProducer::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-HGCalElectronIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void HGCalElectronIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // Auto-generate hgcalElectronIDValueMap_cfi
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("electrons", edm::InputTag("ecalDrivenGsfElectronsFromMultiCl"));
   desc.add<double>("pcaRadius", 3.0);
   desc.add<std::vector<std::string>>("variables", valuesProduced_);
-  desc.add<std::vector<double>>("dEdXWeights")->setComment("This must be copied from dEdX_weights in RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi");
+  desc.add<std::vector<double>>("dEdXWeights")
+      ->setComment("This must be copied from dEdX_weights in RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi");
   desc.add<unsigned int>("isoNRings", 5);
   desc.add<double>("isoDeltaR", 0.15);
   desc.add<double>("isoDeltaRmin", 0.0);
-  desc.add<edm::InputTag>("EERecHits", edm::InputTag("HGCalRecHit","HGCEERecHits"));
-  desc.add<edm::InputTag>("FHRecHits", edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
-  desc.add<edm::InputTag>("BHRecHits", edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
+  desc.add<edm::InputTag>("EERecHits", edm::InputTag("HGCalRecHit", "HGCEERecHits"));
+  desc.add<edm::InputTag>("FHRecHits", edm::InputTag("HGCalRecHit", "HGCHEFRecHits"));
+  desc.add<edm::InputTag>("BHRecHits", edm::InputTag("HGCalRecHit", "HGCHEBRecHits"));
   descriptions.add("hgcalElectronIDValueMap", desc);
 }
 

--- a/RecoEgamma/EgammaTools/plugins/HGCalPhotonIDValueMapProducer.cc
+++ b/RecoEgamma/EgammaTools/plugins/HGCalPhotonIDValueMapProducer.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -39,69 +38,43 @@
 #include "RecoEgamma/EgammaTools/interface/LongDeps.h"
 
 class HGCalPhotonIDValueMapProducer : public edm::stream::EDProducer<> {
-  public:
-    explicit HGCalPhotonIDValueMapProducer(const edm::ParameterSet&);
-    ~HGCalPhotonIDValueMapProducer() override;
+public:
+  explicit HGCalPhotonIDValueMapProducer(const edm::ParameterSet&);
+  ~HGCalPhotonIDValueMapProducer() override;
 
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  private:
-    void beginStream(edm::StreamID) override;
-    void produce(edm::Event&, const edm::EventSetup&) override;
-    void endStream() override;
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-    // ----------member data ---------------------------
-    edm::EDGetTokenT<edm::View<reco::Photon>> photonsToken_;
-    float radius_;
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<edm::View<reco::Photon>> photonsToken_;
+  float radius_;
 
-    static const std::vector<std::string> valuesProduced_;
-    std::map<const std::string, std::vector<float>> maps_;
+  static const std::vector<std::string> valuesProduced_;
+  std::map<const std::string, std::vector<float>> maps_;
 
-    std::unique_ptr<HGCalEgammaIDHelper> phoIDHelper_;
+  std::unique_ptr<HGCalEgammaIDHelper> phoIDHelper_;
 };
 
 // All the ValueMap names to output are defined in the auto-generated python cfi
 // so that potential consumers can configure themselves in a simple manner
 // Would be cool to use compile-time validation, but need constexpr strings, e.g. std::string_view in C++17
 const std::vector<std::string> HGCalPhotonIDValueMapProducer::valuesProduced_ = {
-    "seedEt",
-    "seedEnergy",
-    "seedEnergyEE",
-    "seedEnergyFH",
-    "seedEnergyBH",
-    "pcaEig1",
-    "pcaEig2",
-    "pcaEig3",
-    "pcaSig1",
-    "pcaSig2",
-    "pcaSig3",
-    "sigmaUU",
-    "sigmaVV",
-    "sigmaEE",
-    "sigmaPP",
-    "nLayers",
-    "firstLayer",
-    "lastLayer",
-    "e4oEtot",
-    "layerEfrac10",
-    "layerEfrac90",
-    "measuredDepth",
-    "expectedDepth",
-    "expectedSigma",
-    "depthCompatibility",
-    "caloIsoRing0",
-    "caloIsoRing1",
-    "caloIsoRing2",
-    "caloIsoRing3",
-    "caloIsoRing4",
+    "seedEt",       "seedEnergy",    "seedEnergyEE",  "seedEnergyFH",  "seedEnergyBH",
+    "pcaEig1",      "pcaEig2",       "pcaEig3",       "pcaSig1",       "pcaSig2",
+    "pcaSig3",      "sigmaUU",       "sigmaVV",       "sigmaEE",       "sigmaPP",
+    "nLayers",      "firstLayer",    "lastLayer",     "e4oEtot",       "layerEfrac10",
+    "layerEfrac90", "measuredDepth", "expectedDepth", "expectedSigma", "depthCompatibility",
+    "caloIsoRing0", "caloIsoRing1",  "caloIsoRing2",  "caloIsoRing3",  "caloIsoRing4",
 };
 
-
-HGCalPhotonIDValueMapProducer::HGCalPhotonIDValueMapProducer(const edm::ParameterSet& iConfig) :
-  photonsToken_(consumes<edm::View<reco::Photon>>(iConfig.getParameter<edm::InputTag>("photons"))),
-  radius_(iConfig.getParameter<double>("pcaRadius"))
-{
-  for(const auto& key : valuesProduced_) {
+HGCalPhotonIDValueMapProducer::HGCalPhotonIDValueMapProducer(const edm::ParameterSet& iConfig)
+    : photonsToken_(consumes<edm::View<reco::Photon>>(iConfig.getParameter<edm::InputTag>("photons"))),
+      radius_(iConfig.getParameter<double>("pcaRadius")) {
+  for (const auto& key : valuesProduced_) {
     maps_[key] = {};
     produces<edm::ValueMap<float>>(key);
   }
@@ -109,43 +82,36 @@ HGCalPhotonIDValueMapProducer::HGCalPhotonIDValueMapProducer(const edm::Paramete
   phoIDHelper_.reset(new HGCalEgammaIDHelper(iConfig, consumesCollector()));
 }
 
-
-HGCalPhotonIDValueMapProducer::~HGCalPhotonIDValueMapProducer()
-{
-}
-
+HGCalPhotonIDValueMapProducer::~HGCalPhotonIDValueMapProducer() {}
 
 // ------------ method called to produce the data  ------------
-void
-HGCalPhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void HGCalPhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   Handle<edm::View<reco::Photon>> photonsH;
   iEvent.getByToken(photonsToken_, photonsH);
 
   // Clear previous map
-  for(auto&& kv : maps_) {
+  for (auto&& kv : maps_) {
     kv.second.clear();
     kv.second.reserve(photonsH->size());
   }
 
   // Set up helper tool
-  phoIDHelper_->eventInit(iEvent,iSetup);
+  phoIDHelper_->eventInit(iEvent, iSetup);
 
-  for(const auto& pho : *photonsH) {
-    if(pho.isEB()) {
+  for (const auto& pho : *photonsH) {
+    if (pho.isEB()) {
       // Fill some dummy value
-      for(auto&& kv : maps_) {
+      for (auto&& kv : maps_) {
         kv.second.push_back(0.);
       }
-    }
-    else {
+    } else {
       phoIDHelper_->computeHGCAL(pho, radius_);
 
       // check the PCA has worked out
-      if (phoIDHelper_->sigmaUU() == -1){
-        for(auto&& kv : maps_) {
+      if (phoIDHelper_->sigmaUU() == -1) {
+        for (auto&& kv : maps_) {
           kv.second.push_back(0.);
         }
         continue;
@@ -153,14 +119,16 @@ HGCalPhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup
 
       hgcal::LongDeps ld(phoIDHelper_->energyPerLayer(radius_, true));
       float measuredDepth, expectedDepth, expectedSigma;
-      float depthCompatibility = phoIDHelper_->clusterDepthCompatibility(ld, measuredDepth, expectedDepth, expectedSigma);
+      float depthCompatibility =
+          phoIDHelper_->clusterDepthCompatibility(ld, measuredDepth, expectedDepth, expectedSigma);
 
       // Fill here all the ValueMaps from their appropriate functions
 
       // energies calculated in an cylinder around the axis of the pho cluster
       float seed_tot_energy = ld.energyEE() + ld.energyFH() + ld.energyBH();
-      const double div_cosh_eta = pho.superCluster()->seed()->position().rho() / pho.superCluster()->seed()->position().r();
-      maps_["seedEt"].push_back(seed_tot_energy * div_cosh_eta );
+      const double div_cosh_eta =
+          pho.superCluster()->seed()->position().rho() / pho.superCluster()->seed()->position().r();
+      maps_["seedEt"].push_back(seed_tot_energy * div_cosh_eta);
       maps_["seedEnergy"].push_back(seed_tot_energy);
       maps_["seedEnergyEE"].push_back(ld.energyEE());
       maps_["seedEnergyFH"].push_back(ld.energyFH());
@@ -206,14 +174,16 @@ HGCalPhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup
 
   // Check we didn't make up a new variable and forget it in the constructor
   // (or some other pathology)
-  if ( maps_.size() != valuesProduced_.size() ) {
-    throw cms::Exception("HGCalPhotonIDValueMapProducer") << "We have a miscoded value map producer, since map size changed";
+  if (maps_.size() != valuesProduced_.size()) {
+    throw cms::Exception("HGCalPhotonIDValueMapProducer")
+        << "We have a miscoded value map producer, since map size changed";
   }
 
-  for(auto&& kv : maps_) {
+  for (auto&& kv : maps_) {
     // Check we didn't forget any values
-    if ( kv.second.size() != photonsH->size() ) {
-      throw cms::Exception("HGCalPhotonIDValueMapProducer") << "We have a miscoded value map producer, since the variable " << kv.first << " wasn't filled.";
+    if (kv.second.size() != photonsH->size()) {
+      throw cms::Exception("HGCalPhotonIDValueMapProducer")
+          << "We have a miscoded value map producer, since the variable " << kv.first << " wasn't filled.";
     }
     // Do the filling
     auto out = std::make_unique<edm::ValueMap<float>>();
@@ -226,31 +196,26 @@ HGCalPhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup
 }
 
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-HGCalPhotonIDValueMapProducer::beginStream(edm::StreamID)
-{
-}
+void HGCalPhotonIDValueMapProducer::beginStream(edm::StreamID) {}
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-HGCalPhotonIDValueMapProducer::endStream() {
-}
+void HGCalPhotonIDValueMapProducer::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-HGCalPhotonIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void HGCalPhotonIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // hgcalPhotonIDValueMap
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("photons", edm::InputTag("photonsFromMultiCl"));
   desc.add<double>("pcaRadius", 3.0);
   desc.add<std::vector<std::string>>("variables", valuesProduced_);
-  desc.add<std::vector<double>>("dEdXWeights")->setComment("This must be copied from dEdX_weights in RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi");
+  desc.add<std::vector<double>>("dEdXWeights")
+      ->setComment("This must be copied from dEdX_weights in RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi");
   desc.add<unsigned int>("isoNRings", 5);
   desc.add<double>("isoDeltaR", 0.15);
   desc.add<double>("isoDeltaRmin", 0.0);
-  desc.add<edm::InputTag>("EERecHits", edm::InputTag("HGCalRecHit","HGCEERecHits"));
-  desc.add<edm::InputTag>("FHRecHits", edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
-  desc.add<edm::InputTag>("BHRecHits", edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
+  desc.add<edm::InputTag>("EERecHits", edm::InputTag("HGCalRecHit", "HGCEERecHits"));
+  desc.add<edm::InputTag>("FHRecHits", edm::InputTag("HGCalRecHit", "HGCHEFRecHits"));
+  desc.add<edm::InputTag>("BHRecHits", edm::InputTag("HGCalRecHit", "HGCHEBRecHits"));
   descriptions.add("hgcalPhotonIDValueMap", desc);
 }
 

--- a/RecoEgamma/EgammaTools/src/AnyMVAEstimatorRun2Base.cc
+++ b/RecoEgamma/EgammaTools/src/AnyMVAEstimatorRun2Base.cc
@@ -1,4 +1,3 @@
 #include "RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h"
 
-EDM_REGISTER_PLUGINFACTORY(AnyMVAEstimatorRun2Factory,
-			   "AnyMVAEstimatorRun2Factory");
+EDM_REGISTER_PLUGINFACTORY(AnyMVAEstimatorRun2Factory, "AnyMVAEstimatorRun2Factory");

--- a/RecoEgamma/EgammaTools/src/BaselinePFSCRegression.cc
+++ b/RecoEgamma/EgammaTools/src/BaselinePFSCRegression.cc
@@ -8,47 +8,42 @@
 
 void BaselinePFSCRegression::update(const edm::EventSetup& es) {
   const CaloTopologyRecord& topofrom_es = es.get<CaloTopologyRecord>();
-  if( !topo_record ||
-      topofrom_es.cacheIdentifier() != topo_record->cacheIdentifier() ) {
+  if (!topo_record || topofrom_es.cacheIdentifier() != topo_record->cacheIdentifier()) {
     topo_record = &topofrom_es;
     topo_record->get(calotopo);
   }
   const CaloGeometryRecord& geomfrom_es = es.get<CaloGeometryRecord>();
-  if( !geom_record ||
-      geomfrom_es.cacheIdentifier() != geom_record->cacheIdentifier() ) {
+  if (!geom_record || geomfrom_es.cacheIdentifier() != geom_record->cacheIdentifier()) {
     geom_record = &geomfrom_es;
     geom_record->get(calogeom);
   }
 }
 
-void BaselinePFSCRegression::set(const reco::SuperCluster& sc,
-				 std::vector<float>& vars     ) const {
+void BaselinePFSCRegression::set(const reco::SuperCluster& sc, std::vector<float>& vars) const {
   EcalRegressionData regData;
-  regData.fill(sc,rechitsEB.product(),rechitsEE.product(),calogeom.product(),calotopo.product(),vertices.product());
+  regData.fill(
+      sc, rechitsEB.product(), rechitsEE.product(), calogeom.product(), calotopo.product(), vertices.product());
   regData.fillVec(vars);
 
   //solely to reproduce old exception behaviour, unnessessary although it likely is
-  if( sc.seed()->hitsAndFractions().at(0).first.subdetId()!=EcalBarrel &&
-      sc.seed()->hitsAndFractions().at(0).first.subdetId()!=EcalEndcap){
-   throw cms::Exception("PFECALSuperClusterProducer::calculateRegressedEnergy")
-     << "Supercluster seed is either EB nor EE!" << std::endl;
+  if (sc.seed()->hitsAndFractions().at(0).first.subdetId() != EcalBarrel &&
+      sc.seed()->hitsAndFractions().at(0).first.subdetId() != EcalEndcap) {
+    throw cms::Exception("PFECALSuperClusterProducer::calculateRegressedEnergy")
+        << "Supercluster seed is either EB nor EE!" << std::endl;
   }
-
- 
 }
 
-void BaselinePFSCRegression::
-setTokens(const edm::ParameterSet& ps, edm::ConsumesCollector&& cc) {
+void BaselinePFSCRegression::setTokens(const edm::ParameterSet& ps, edm::ConsumesCollector&& cc) {
   const edm::InputTag rceb = ps.getParameter<edm::InputTag>("ecalRecHitsEB");
   const edm::InputTag rcee = ps.getParameter<edm::InputTag>("ecalRecHitsEE");
   const edm::InputTag vtx = ps.getParameter<edm::InputTag>("vertexCollection");
-  inputTagEBRecHits_      = cc.consumes<EcalRecHitCollection>(rceb);
-  inputTagEERecHits_      = cc.consumes<EcalRecHitCollection>(rcee);
-  inputTagVertices_       = cc.consumes<reco::VertexCollection>(vtx);
+  inputTagEBRecHits_ = cc.consumes<EcalRecHitCollection>(rceb);
+  inputTagEERecHits_ = cc.consumes<EcalRecHitCollection>(rcee);
+  inputTagVertices_ = cc.consumes<reco::VertexCollection>(vtx);
 }
 
 void BaselinePFSCRegression::setEvent(const edm::Event& ev) {
-  ev.getByToken(inputTagEBRecHits_,rechitsEB);
-  ev.getByToken(inputTagEERecHits_,rechitsEE);
-  ev.getByToken(inputTagVertices_,vertices);
+  ev.getByToken(inputTagEBRecHits_, rechitsEB);
+  ev.getByToken(inputTagEERecHits_, rechitsEE);
+  ev.getByToken(inputTagVertices_, vertices);
 }

--- a/RecoEgamma/EgammaTools/src/ConversionFinder.cc
+++ b/RecoEgamma/EgammaTools/src/ConversionFinder.cc
@@ -7,564 +7,508 @@
 
 namespace egammaTools {
 
-typedef math::XYZTLorentzVector LorentzVector;
+  typedef math::XYZTLorentzVector LorentzVector;
 
-ConversionInfo getConversionInfo(const reco::Track *el_track,
-                                 const reco::Track *candPartnerTk,
-                                 const double bFieldAtOrigin);
+  ConversionInfo getConversionInfo(const reco::Track* el_track,
+                                   const reco::Track* candPartnerTk,
+                                   const double bFieldAtOrigin);
 
-const reco::Track* getElectronTrack(const reco::GsfElectron &, const float minFracSharedHits = 0.45);
+  const reco::Track* getElectronTrack(const reco::GsfElectron&, const float minFracSharedHits = 0.45);
 
-const reco::Track* getElectronTrack(const reco::GsfElectronCore &, const float minFracSharedHits = 0.45);
+  const reco::Track* getElectronTrack(const reco::GsfElectronCore&, const float minFracSharedHits = 0.45);
 
-bool isFromConversion(const ConversionInfo &convInfo,
-        double maxAbsDist, double maxAbsDcot)
-{
-  return (std::abs(convInfo.dist) < maxAbsDist) && (std::abs(convInfo.dcot) < maxAbsDcot);
-}
-
-//-----------------------------------------------------------------------------
-ConversionInfo getConversionInfo(const reco::GsfElectron& gsfElectron,
-								const edm::Handle<reco::TrackCollection>& ctftracks_h,
-								const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
-								const double bFieldAtOrigin,
-								const double minFracSharedHits) {
-
-  std::vector<ConversionInfo> temp = getConversionInfos(*gsfElectron.core(),ctftracks_h,gsftracks_h,bFieldAtOrigin,minFracSharedHits) ;
-  return findBestConversionMatch(temp);
-
-}
-//-----------------------------------------------------------------------------
-ConversionInfo getConversionInfo(const reco::GsfElectronCore& gsfElectron,
-						    const edm::Handle<reco::TrackCollection>& ctftracks_h,
-						    const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
-						    const double bFieldAtOrigin,
-						    const double minFracSharedHits) {
-
-  std::vector<ConversionInfo> temp = getConversionInfos(gsfElectron,ctftracks_h,gsftracks_h,bFieldAtOrigin,minFracSharedHits) ;
-  return findBestConversionMatch(temp);
-
-}
-
-
-//-----------------------------------------------------------------------------
-std::vector<ConversionInfo> getConversionInfos(const reco::GsfElectronCore& gsfElectron,
-								const edm::Handle<reco::TrackCollection>& ctftracks_h,
-								const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
-								const double bFieldAtOrigin,
-								const double minFracSharedHits) {
-
-
-
-  using namespace reco;
-  using namespace std;
-  using namespace edm;
-
-
-  //get the track collections
-  const TrackCollection    *ctftracks	= ctftracks_h.product();
-  const GsfTrackCollection *gsftracks	= gsftracks_h.product();
-
-  //get the references to the gsf and ctf tracks that are made
-  //by the electron
-  const reco::TrackRef    el_ctftrack	= gsfElectron.ctfTrack();
-  const reco::GsfTrackRef& el_gsftrack	= gsfElectron.gsfTrack();
-
-  //protect against the wrong collection being passed to the function
-  if(el_ctftrack.isNonnull() && el_ctftrack.id() != ctftracks_h.id())
-    throw cms::Exception("ConversionFinderError") << "ProductID of ctf track collection does not match ProductID of electron's CTF track! \n";
-  if(el_gsftrack.isNonnull() && el_gsftrack.id() != gsftracks_h.id())
-    throw cms::Exception("ConversionFinderError") << "ProductID of gsf track collection does not match ProductID of electron's GSF track! \n";
-
-  //make p4s for the electron's tracks for use later
-  LorentzVector el_ctftrack_p4;
-  if(el_ctftrack.isNonnull() && gsfElectron.ctfGsfOverlap() > minFracSharedHits)
-    el_ctftrack_p4 = LorentzVector(el_ctftrack->px(), el_ctftrack->py(), el_ctftrack->pz(), el_ctftrack->p());
-  LorentzVector el_gsftrack_p4(el_gsftrack->px(), el_gsftrack->py(), el_gsftrack->pz(), el_gsftrack->p());
-
-  //the electron's CTF track must share at least 45% of the inner hits
-  //with the electron's GSF track
-  int ctfidx = -999.;
-  int gsfidx = -999.;
-  if(el_ctftrack.isNonnull() && gsfElectron.ctfGsfOverlap() > minFracSharedHits)
-    ctfidx = static_cast<int>(el_ctftrack.key());
-
-  gsfidx = static_cast<int>(el_gsftrack.key());
-
-
-  //these vectors are for those candidate partner tracks that pass our cuts
-  vector<ConversionInfo> v_candidatePartners;
-  //track indices required to make references
-  int ctftk_i = 0;
-  int gsftk_i = 0;
-
-
-  //loop over the CTF tracks and try to find the partner track
-  for(TrackCollection::const_iterator ctftk = ctftracks->begin();
-      ctftk != ctftracks->end(); ctftk++, ctftk_i++) {
-
-    if(ctftk_i == ctfidx)
-      continue;
-
-    //candidate track's p4
-    LorentzVector ctftk_p4 = LorentzVector(ctftk->px(), ctftk->py(), ctftk->pz(), ctftk->p());
-
-    //apply quality cuts to remove bad tracks
-    if(ctftk->ptError()/ctftk->pt() > 0.05)
-      continue;
-    if(ctftk->numberOfValidHits() < 5)
-      continue;
-
-    if(el_ctftrack.isNonnull() &&
-       gsfElectron.ctfGsfOverlap() > minFracSharedHits &&
-       fabs(ctftk_p4.Pt() - el_ctftrack->pt())/el_ctftrack->pt() < 0.2)
-      continue;
-
-    //use the electron's CTF track, if not null, to search for the partner track
-    //look only in a cone of 0.5 to save time, and require that the track is opp. sign
-    if(el_ctftrack.isNonnull() && gsfElectron.ctfGsfOverlap() > minFracSharedHits &&
-       deltaR(el_ctftrack_p4, ctftk_p4) < 0.5 &&
-       (el_ctftrack->charge() + ctftk->charge() == 0) ) {
-
-      ConversionInfo convInfo = getConversionInfo((const reco::Track*)(el_ctftrack.get()), &(*ctftk), bFieldAtOrigin);
-
-      //need to add the track reference information for completeness
-      //because the overloaded fnc above does not make a trackRef
-      int deltaMissingHits = ctftk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS)
-          - el_ctftrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
-
-
-      v_candidatePartners.push_back({convInfo.dist,
-                                     convInfo.dcot,
-                                     convInfo.radiusOfConversion,
-                                     convInfo.pointOfConversion,
-                                     TrackRef(ctftracks_h, ctftk_i),
-                                     GsfTrackRef() ,
-                                     deltaMissingHits,
-                                     0});
-
-    }//using the electron's CTF track
-
-
-    //now we check using the electron's gsf track
-    if(deltaR(el_gsftrack_p4, ctftk_p4) < 0.5 &&
-       (el_gsftrack->charge() + ctftk->charge() == 0) &&
-       el_gsftrack->ptError()/el_gsftrack->pt() < 0.25) {
-
-      int deltaMissingHits = ctftk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS)
-          - el_gsftrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
-
-      ConversionInfo convInfo = getConversionInfo((const reco::Track*)(el_gsftrack.get()), &(*ctftk), bFieldAtOrigin);
-
-      v_candidatePartners.push_back({convInfo.dist,
-                                     convInfo.dcot,
-                                     convInfo.radiusOfConversion,
-                                     convInfo.pointOfConversion,
-                                     TrackRef(ctftracks_h, ctftk_i),
-                                     GsfTrackRef(),
-                                     deltaMissingHits,
-                                     1});
-    }//using the electron's GSF track
-
-  }//loop over the CTF track collection
-
-
-  //------------------------------------------------------ Loop over GSF collection ----------------------------------//
-  for(GsfTrackCollection::const_iterator gsftk = gsftracks->begin();
-      gsftk != gsftracks->end(); gsftk++, gsftk_i++) {
-
-    //reject the electron's own gsfTrack
-    if(gsfidx == gsftk_i)
-      continue;
-
-    LorentzVector gsftk_p4 = LorentzVector(gsftk->px(), gsftk->py(), gsftk->pz(), gsftk->p());
-
-    //apply quality cuts to remove bad tracks
-    if(gsftk->ptError()/gsftk->pt() > 0.5)
-      continue;
-    if(gsftk->numberOfValidHits() < 5)
-      continue;
-
-    if(fabs(gsftk->pt() - el_gsftrack->pt())/el_gsftrack->pt() < 0.25)
-      continue;
-
-    //try using the electron's CTF track first if it exists
-    //look only in a cone of 0.5 around the electron's track
-	//require opposite sign
-    if(el_ctftrack.isNonnull() && gsfElectron.ctfGsfOverlap() > minFracSharedHits &&
-       deltaR(el_ctftrack_p4, gsftk_p4) < 0.5 &&
-       (el_ctftrack->charge() + gsftk->charge() == 0)) {
-
-      int deltaMissingHits = gsftk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS)
-          - el_ctftrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
-      
-      ConversionInfo convInfo = getConversionInfo((const reco::Track*)(el_ctftrack.get()), (const reco::Track*)(&(*gsftk)), bFieldAtOrigin);
-      //fill the Ref info
-      v_candidatePartners.push_back({convInfo.dist,
-                                     convInfo.dcot,
-                                     convInfo.radiusOfConversion,
-                                     convInfo.pointOfConversion,
-                                     TrackRef(),
-                                     GsfTrackRef(gsftracks_h, gsftk_i),
-                                     deltaMissingHits,
-                                     2});
-    }
-
-    //use the electron's gsf track
-    if(deltaR(el_gsftrack_p4, gsftk_p4) < 0.5 &&
-       (el_gsftrack->charge() + gsftk->charge() == 0) &&
-       (el_gsftrack->ptError()/el_gsftrack_p4.pt() < 0.5)) {
-      ConversionInfo convInfo = getConversionInfo((const reco::Track*)(el_gsftrack.get()), (const reco::Track*)(&(*gsftk)), bFieldAtOrigin);
-      //fill the Ref info
-
-      int deltaMissingHits = gsftk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS)
-          - el_gsftrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
-
-
-      v_candidatePartners.push_back({convInfo.dist,
-                                     convInfo.dcot,
-                                     convInfo.radiusOfConversion,
-                                     convInfo.pointOfConversion,
-                                     TrackRef(),
-                                     GsfTrackRef(gsftracks_h, gsftk_i),
-                                     deltaMissingHits,
-                                     3});
-    }
-  }//loop over the gsf track collection
-
-
-  return v_candidatePartners;
-
-}
-
-
-//-------------------------------------------------------------------------------------
-ConversionInfo getConversionInfo(const reco::Track *el_track,
-						   const reco::Track *candPartnerTk,
-						   const double bFieldAtOrigin) {
-
-  using namespace reco;
-
-  //now calculate the conversion related information
-  LorentzVector el_tk_p4(el_track->px(), el_track->py(), el_track->pz(), el_track->p());
-  double elCurvature = -0.3*bFieldAtOrigin*(el_track->charge()/el_tk_p4.pt())/100.;
-  double rEl = fabs(1./elCurvature);
-  double xEl = -1*(1./elCurvature - el_track->d0())*sin(el_tk_p4.phi());
-  double yEl = (1./elCurvature - el_track->d0())*cos(el_tk_p4.phi());
-
-
-  LorentzVector cand_p4 = LorentzVector(candPartnerTk->px(), candPartnerTk->py(),candPartnerTk->pz(), candPartnerTk->p());
-  double candCurvature = -0.3*bFieldAtOrigin*(candPartnerTk->charge()/cand_p4.pt())/100.;
-  double rCand = fabs(1./candCurvature);
-  double xCand = -1*(1./candCurvature - candPartnerTk->d0())*sin(cand_p4.phi());
-  double yCand = (1./candCurvature - candPartnerTk->d0())*cos(cand_p4.phi());
-
-  double d = sqrt(pow(xEl-xCand, 2) + pow(yEl-yCand , 2));
-  double dist = d - (rEl + rCand);
-  double dcot = 1./tan(el_tk_p4.theta()) - 1./tan(cand_p4.theta());
-
-  //get the point of conversion
-  double xa1 = xEl   + (xCand-xEl) * rEl/d;
-  double xa2 = xCand + (xEl-xCand) * rCand/d;
-  double ya1 = yEl   + (yCand-yEl) * rEl/d;
-  double ya2 = yCand + (yEl-yCand) * rCand/d;
-
-  double x=.5*(xa1+xa2);
-  double y=.5*(ya1+ya2);
-  double rconv = sqrt(pow(x,2) + pow(y,2));
-  double z = el_track->dz() + rEl*el_track->pz()*TMath::ACos(1-pow(rconv,2)/(2.*pow(rEl,2)))/el_track->pt();
-
-  math::XYZPoint convPoint(x, y, z);
-
-  //now assign a sign to the radius of conversion
-  float tempsign = el_track->px()*x + el_track->py()*y;
-  tempsign = tempsign/fabs(tempsign);
-  rconv = tempsign*rconv;
-
-  //return an instance of ConversionInfo, but with a NULL track refs
-  return ConversionInfo{dist, dcot, rconv, convPoint, TrackRef(), GsfTrackRef(), -9999, -9999};
-
-}
-
-//-------------------------------------------------------------------------------------
-const reco::Track* getElectronTrack(const reco::GsfElectron& electron, const float minFracSharedHits) {
-
-  if(electron.closestCtfTrackRef().isNonnull() &&
-     electron.shFracInnerHits() > minFracSharedHits)
-    return (const reco::Track*)electron.closestCtfTrackRef().get();
-
-  return (const reco::Track*)(electron.gsfTrack().get());
-}
-
-//------------------------------------------------------------------------------------
-
-//takes in a vector of candidate conversion partners
-//and arbitrates between them returning the one with the
-//smallest R=sqrt(dist*dist + dcot*dcot)
-ConversionInfo arbitrateConversionPartnersbyR(const std::vector<ConversionInfo>& v_convCandidates) {
-
-  if(v_convCandidates.size() == 1)
-    return v_convCandidates.at(0);
-
-  double R = sqrt(pow(v_convCandidates.at(0).dist,2) + pow(v_convCandidates.at(0).dcot,2));
-
-  int iArbitrated = 0;
-  int i = 0;
-
-  for(auto const& temp : v_convCandidates) {
-    double temp_R = sqrt(pow(temp.dist,2) + pow(temp.dcot,2));
-    if(temp_R < R) {
-      R = temp_R;
-      iArbitrated = i;
-    }
-    ++i;
+  bool isFromConversion(const ConversionInfo& convInfo, double maxAbsDist, double maxAbsDcot) {
+    return (std::abs(convInfo.dist) < maxAbsDist) && (std::abs(convInfo.dcot) < maxAbsDcot);
   }
 
-  return v_convCandidates.at(iArbitrated);
+  //-----------------------------------------------------------------------------
+  ConversionInfo getConversionInfo(const reco::GsfElectron& gsfElectron,
+                                   const edm::Handle<reco::TrackCollection>& ctftracks_h,
+                                   const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
+                                   const double bFieldAtOrigin,
+                                   const double minFracSharedHits) {
+    std::vector<ConversionInfo> temp =
+        getConversionInfos(*gsfElectron.core(), ctftracks_h, gsftracks_h, bFieldAtOrigin, minFracSharedHits);
+    return findBestConversionMatch(temp);
+  }
+  //-----------------------------------------------------------------------------
+  ConversionInfo getConversionInfo(const reco::GsfElectronCore& gsfElectron,
+                                   const edm::Handle<reco::TrackCollection>& ctftracks_h,
+                                   const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
+                                   const double bFieldAtOrigin,
+                                   const double minFracSharedHits) {
+    std::vector<ConversionInfo> temp =
+        getConversionInfos(gsfElectron, ctftracks_h, gsftracks_h, bFieldAtOrigin, minFracSharedHits);
+    return findBestConversionMatch(temp);
+  }
 
- }
+  //-----------------------------------------------------------------------------
+  std::vector<ConversionInfo> getConversionInfos(const reco::GsfElectronCore& gsfElectron,
+                                                 const edm::Handle<reco::TrackCollection>& ctftracks_h,
+                                                 const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
+                                                 const double bFieldAtOrigin,
+                                                 const double minFracSharedHits) {
+    using namespace reco;
+    using namespace std;
+    using namespace edm;
 
-//------------------------------------------------------------------------------------
-ConversionInfo findBestConversionMatch(const std::vector<ConversionInfo>& v_convCandidates)
- {
-  using namespace std;
+    //get the track collections
+    const TrackCollection* ctftracks = ctftracks_h.product();
+    const GsfTrackCollection* gsftracks = gsftracks_h.product();
 
-  if(v_convCandidates.empty())
-    return   ConversionInfo{-9999.,-9999.,-9999.,
-			    math::XYZPoint(-9999.,-9999.,-9999),
-			    reco::TrackRef(), reco::GsfTrackRef(),
-			    -9999, -9999};
+    //get the references to the gsf and ctf tracks that are made
+    //by the electron
+    const reco::TrackRef el_ctftrack = gsfElectron.ctfTrack();
+    const reco::GsfTrackRef& el_gsftrack = gsfElectron.gsfTrack();
 
+    //protect against the wrong collection being passed to the function
+    if (el_ctftrack.isNonnull() && el_ctftrack.id() != ctftracks_h.id())
+      throw cms::Exception("ConversionFinderError")
+          << "ProductID of ctf track collection does not match ProductID of electron's CTF track! \n";
+    if (el_gsftrack.isNonnull() && el_gsftrack.id() != gsftracks_h.id())
+      throw cms::Exception("ConversionFinderError")
+          << "ProductID of gsf track collection does not match ProductID of electron's GSF track! \n";
 
-  if(v_convCandidates.size() == 1)
-    return v_convCandidates.at(0);
+    //make p4s for the electron's tracks for use later
+    LorentzVector el_ctftrack_p4;
+    if (el_ctftrack.isNonnull() && gsfElectron.ctfGsfOverlap() > minFracSharedHits)
+      el_ctftrack_p4 = LorentzVector(el_ctftrack->px(), el_ctftrack->py(), el_ctftrack->pz(), el_ctftrack->p());
+    LorentzVector el_gsftrack_p4(el_gsftrack->px(), el_gsftrack->py(), el_gsftrack->pz(), el_gsftrack->p());
 
-  vector<ConversionInfo> v_0;
-  vector<ConversionInfo> v_1;
-  vector<ConversionInfo> v_2;
-  vector<ConversionInfo> v_3;
-  //loop over the candidates
-  for(unsigned int i = 1; i < v_convCandidates.size(); i++) {
-    ConversionInfo temp = v_convCandidates.at(i);
+    //the electron's CTF track must share at least 45% of the inner hits
+    //with the electron's GSF track
+    int ctfidx = -999.;
+    int gsfidx = -999.;
+    if (el_ctftrack.isNonnull() && gsfElectron.ctfGsfOverlap() > minFracSharedHits)
+      ctfidx = static_cast<int>(el_ctftrack.key());
 
-    if(temp.flag == 0) {
-      bool isConv = false;
-      if(fabs(temp.dist) < 0.02 &&
-	 fabs(temp.dcot) < 0.02 &&
-	 temp.deltaMissingHits < 3 &&
-	 temp.radiusOfConversion > -2)
-	isConv = true;
-      if(sqrt(pow(temp.dist,2) + pow(temp.dcot,2)) < 0.05  &&
-	 temp.deltaMissingHits < 2 &&
-	 temp.radiusOfConversion > -2)
-	isConv = true;
+    gsfidx = static_cast<int>(el_gsftrack.key());
 
-      if(isConv)
-	v_0.push_back(temp);
+    //these vectors are for those candidate partner tracks that pass our cuts
+    vector<ConversionInfo> v_candidatePartners;
+    //track indices required to make references
+    int ctftk_i = 0;
+    int gsftk_i = 0;
+
+    //loop over the CTF tracks and try to find the partner track
+    for (TrackCollection::const_iterator ctftk = ctftracks->begin(); ctftk != ctftracks->end(); ctftk++, ctftk_i++) {
+      if (ctftk_i == ctfidx)
+        continue;
+
+      //candidate track's p4
+      LorentzVector ctftk_p4 = LorentzVector(ctftk->px(), ctftk->py(), ctftk->pz(), ctftk->p());
+
+      //apply quality cuts to remove bad tracks
+      if (ctftk->ptError() / ctftk->pt() > 0.05)
+        continue;
+      if (ctftk->numberOfValidHits() < 5)
+        continue;
+
+      if (el_ctftrack.isNonnull() && gsfElectron.ctfGsfOverlap() > minFracSharedHits &&
+          fabs(ctftk_p4.Pt() - el_ctftrack->pt()) / el_ctftrack->pt() < 0.2)
+        continue;
+
+      //use the electron's CTF track, if not null, to search for the partner track
+      //look only in a cone of 0.5 to save time, and require that the track is opp. sign
+      if (el_ctftrack.isNonnull() && gsfElectron.ctfGsfOverlap() > minFracSharedHits &&
+          deltaR(el_ctftrack_p4, ctftk_p4) < 0.5 && (el_ctftrack->charge() + ctftk->charge() == 0)) {
+        ConversionInfo convInfo = getConversionInfo((const reco::Track*)(el_ctftrack.get()), &(*ctftk), bFieldAtOrigin);
+
+        //need to add the track reference information for completeness
+        //because the overloaded fnc above does not make a trackRef
+        int deltaMissingHits = ctftk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) -
+                               el_ctftrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+
+        v_candidatePartners.push_back({convInfo.dist,
+                                       convInfo.dcot,
+                                       convInfo.radiusOfConversion,
+                                       convInfo.pointOfConversion,
+                                       TrackRef(ctftracks_h, ctftk_i),
+                                       GsfTrackRef(),
+                                       deltaMissingHits,
+                                       0});
+
+      }  //using the electron's CTF track
+
+      //now we check using the electron's gsf track
+      if (deltaR(el_gsftrack_p4, ctftk_p4) < 0.5 && (el_gsftrack->charge() + ctftk->charge() == 0) &&
+          el_gsftrack->ptError() / el_gsftrack->pt() < 0.25) {
+        int deltaMissingHits = ctftk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) -
+                               el_gsftrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+
+        ConversionInfo convInfo = getConversionInfo((const reco::Track*)(el_gsftrack.get()), &(*ctftk), bFieldAtOrigin);
+
+        v_candidatePartners.push_back({convInfo.dist,
+                                       convInfo.dcot,
+                                       convInfo.radiusOfConversion,
+                                       convInfo.pointOfConversion,
+                                       TrackRef(ctftracks_h, ctftk_i),
+                                       GsfTrackRef(),
+                                       deltaMissingHits,
+                                       1});
+      }  //using the electron's GSF track
+
+    }  //loop over the CTF track collection
+
+    //------------------------------------------------------ Loop over GSF collection ----------------------------------//
+    for (GsfTrackCollection::const_iterator gsftk = gsftracks->begin(); gsftk != gsftracks->end(); gsftk++, gsftk_i++) {
+      //reject the electron's own gsfTrack
+      if (gsfidx == gsftk_i)
+        continue;
+
+      LorentzVector gsftk_p4 = LorentzVector(gsftk->px(), gsftk->py(), gsftk->pz(), gsftk->p());
+
+      //apply quality cuts to remove bad tracks
+      if (gsftk->ptError() / gsftk->pt() > 0.5)
+        continue;
+      if (gsftk->numberOfValidHits() < 5)
+        continue;
+
+      if (fabs(gsftk->pt() - el_gsftrack->pt()) / el_gsftrack->pt() < 0.25)
+        continue;
+
+      //try using the electron's CTF track first if it exists
+      //look only in a cone of 0.5 around the electron's track
+      //require opposite sign
+      if (el_ctftrack.isNonnull() && gsfElectron.ctfGsfOverlap() > minFracSharedHits &&
+          deltaR(el_ctftrack_p4, gsftk_p4) < 0.5 && (el_ctftrack->charge() + gsftk->charge() == 0)) {
+        int deltaMissingHits = gsftk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) -
+                               el_ctftrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+
+        ConversionInfo convInfo =
+            getConversionInfo((const reco::Track*)(el_ctftrack.get()), (const reco::Track*)(&(*gsftk)), bFieldAtOrigin);
+        //fill the Ref info
+        v_candidatePartners.push_back({convInfo.dist,
+                                       convInfo.dcot,
+                                       convInfo.radiusOfConversion,
+                                       convInfo.pointOfConversion,
+                                       TrackRef(),
+                                       GsfTrackRef(gsftracks_h, gsftk_i),
+                                       deltaMissingHits,
+                                       2});
+      }
+
+      //use the electron's gsf track
+      if (deltaR(el_gsftrack_p4, gsftk_p4) < 0.5 && (el_gsftrack->charge() + gsftk->charge() == 0) &&
+          (el_gsftrack->ptError() / el_gsftrack_p4.pt() < 0.5)) {
+        ConversionInfo convInfo =
+            getConversionInfo((const reco::Track*)(el_gsftrack.get()), (const reco::Track*)(&(*gsftk)), bFieldAtOrigin);
+        //fill the Ref info
+
+        int deltaMissingHits = gsftk->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) -
+                               el_gsftrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+
+        v_candidatePartners.push_back({convInfo.dist,
+                                       convInfo.dcot,
+                                       convInfo.radiusOfConversion,
+                                       convInfo.pointOfConversion,
+                                       TrackRef(),
+                                       GsfTrackRef(gsftracks_h, gsftk_i),
+                                       deltaMissingHits,
+                                       3});
+      }
+    }  //loop over the gsf track collection
+
+    return v_candidatePartners;
+  }
+
+  //-------------------------------------------------------------------------------------
+  ConversionInfo getConversionInfo(const reco::Track* el_track,
+                                   const reco::Track* candPartnerTk,
+                                   const double bFieldAtOrigin) {
+    using namespace reco;
+
+    //now calculate the conversion related information
+    LorentzVector el_tk_p4(el_track->px(), el_track->py(), el_track->pz(), el_track->p());
+    double elCurvature = -0.3 * bFieldAtOrigin * (el_track->charge() / el_tk_p4.pt()) / 100.;
+    double rEl = fabs(1. / elCurvature);
+    double xEl = -1 * (1. / elCurvature - el_track->d0()) * sin(el_tk_p4.phi());
+    double yEl = (1. / elCurvature - el_track->d0()) * cos(el_tk_p4.phi());
+
+    LorentzVector cand_p4 =
+        LorentzVector(candPartnerTk->px(), candPartnerTk->py(), candPartnerTk->pz(), candPartnerTk->p());
+    double candCurvature = -0.3 * bFieldAtOrigin * (candPartnerTk->charge() / cand_p4.pt()) / 100.;
+    double rCand = fabs(1. / candCurvature);
+    double xCand = -1 * (1. / candCurvature - candPartnerTk->d0()) * sin(cand_p4.phi());
+    double yCand = (1. / candCurvature - candPartnerTk->d0()) * cos(cand_p4.phi());
+
+    double d = sqrt(pow(xEl - xCand, 2) + pow(yEl - yCand, 2));
+    double dist = d - (rEl + rCand);
+    double dcot = 1. / tan(el_tk_p4.theta()) - 1. / tan(cand_p4.theta());
+
+    //get the point of conversion
+    double xa1 = xEl + (xCand - xEl) * rEl / d;
+    double xa2 = xCand + (xEl - xCand) * rCand / d;
+    double ya1 = yEl + (yCand - yEl) * rEl / d;
+    double ya2 = yCand + (yEl - yCand) * rCand / d;
+
+    double x = .5 * (xa1 + xa2);
+    double y = .5 * (ya1 + ya2);
+    double rconv = sqrt(pow(x, 2) + pow(y, 2));
+    double z =
+        el_track->dz() + rEl * el_track->pz() * TMath::ACos(1 - pow(rconv, 2) / (2. * pow(rEl, 2))) / el_track->pt();
+
+    math::XYZPoint convPoint(x, y, z);
+
+    //now assign a sign to the radius of conversion
+    float tempsign = el_track->px() * x + el_track->py() * y;
+    tempsign = tempsign / fabs(tempsign);
+    rconv = tempsign * rconv;
+
+    //return an instance of ConversionInfo, but with a NULL track refs
+    return ConversionInfo{dist, dcot, rconv, convPoint, TrackRef(), GsfTrackRef(), -9999, -9999};
+  }
+
+  //-------------------------------------------------------------------------------------
+  const reco::Track* getElectronTrack(const reco::GsfElectron& electron, const float minFracSharedHits) {
+    if (electron.closestCtfTrackRef().isNonnull() && electron.shFracInnerHits() > minFracSharedHits)
+      return (const reco::Track*)electron.closestCtfTrackRef().get();
+
+    return (const reco::Track*)(electron.gsfTrack().get());
+  }
+
+  //------------------------------------------------------------------------------------
+
+  //takes in a vector of candidate conversion partners
+  //and arbitrates between them returning the one with the
+  //smallest R=sqrt(dist*dist + dcot*dcot)
+  ConversionInfo arbitrateConversionPartnersbyR(const std::vector<ConversionInfo>& v_convCandidates) {
+    if (v_convCandidates.size() == 1)
+      return v_convCandidates.at(0);
+
+    double R = sqrt(pow(v_convCandidates.at(0).dist, 2) + pow(v_convCandidates.at(0).dcot, 2));
+
+    int iArbitrated = 0;
+    int i = 0;
+
+    for (auto const& temp : v_convCandidates) {
+      double temp_R = sqrt(pow(temp.dist, 2) + pow(temp.dcot, 2));
+      if (temp_R < R) {
+        R = temp_R;
+        iArbitrated = i;
+      }
+      ++i;
     }
 
-    if(temp.flag == 1) {
+    return v_convCandidates.at(iArbitrated);
+  }
 
-      if(sqrt(pow(temp.dist,2) + pow(temp.dcot,2)) < 0.05  &&
-	 temp.deltaMissingHits < 2 &&
-	 temp.radiusOfConversion > -2)
-	v_1.push_back(temp);
-    }
-    if(temp.flag == 2) {
+  //------------------------------------------------------------------------------------
+  ConversionInfo findBestConversionMatch(const std::vector<ConversionInfo>& v_convCandidates) {
+    using namespace std;
 
-      if(sqrt(pow(temp.dist,2) + pow(temp.dcot*temp.dcot,2)) < 0.05 &&
-	 temp.deltaMissingHits < 2 &&
-	 temp.radiusOfConversion > -2)
-	v_2.push_back(temp);
+    if (v_convCandidates.empty())
+      return ConversionInfo{-9999.,
+                            -9999.,
+                            -9999.,
+                            math::XYZPoint(-9999., -9999., -9999),
+                            reco::TrackRef(),
+                            reco::GsfTrackRef(),
+                            -9999,
+                            -9999};
 
-    }
-    if(temp.flag == 3) {
+    if (v_convCandidates.size() == 1)
+      return v_convCandidates.at(0);
 
-      if(sqrt(temp.dist*temp.dist + temp.dcot*temp.dcot) < 0.05
-	 && temp.deltaMissingHits < 2
-	 && temp.radiusOfConversion > -2)
-	v_3.push_back(temp);
+    vector<ConversionInfo> v_0;
+    vector<ConversionInfo> v_1;
+    vector<ConversionInfo> v_2;
+    vector<ConversionInfo> v_3;
+    //loop over the candidates
+    for (unsigned int i = 1; i < v_convCandidates.size(); i++) {
+      ConversionInfo temp = v_convCandidates.at(i);
 
-    }
+      if (temp.flag == 0) {
+        bool isConv = false;
+        if (fabs(temp.dist) < 0.02 && fabs(temp.dcot) < 0.02 && temp.deltaMissingHits < 3 &&
+            temp.radiusOfConversion > -2)
+          isConv = true;
+        if (sqrt(pow(temp.dist, 2) + pow(temp.dcot, 2)) < 0.05 && temp.deltaMissingHits < 2 &&
+            temp.radiusOfConversion > -2)
+          isConv = true;
 
-  }//candidate conversion loop
+        if (isConv)
+          v_0.push_back(temp);
+      }
 
-  //now do some arbitration
+      if (temp.flag == 1) {
+        if (sqrt(pow(temp.dist, 2) + pow(temp.dcot, 2)) < 0.05 && temp.deltaMissingHits < 2 &&
+            temp.radiusOfConversion > -2)
+          v_1.push_back(temp);
+      }
+      if (temp.flag == 2) {
+        if (sqrt(pow(temp.dist, 2) + pow(temp.dcot * temp.dcot, 2)) < 0.05 && temp.deltaMissingHits < 2 &&
+            temp.radiusOfConversion > -2)
+          v_2.push_back(temp);
+      }
+      if (temp.flag == 3) {
+        if (sqrt(temp.dist * temp.dist + temp.dcot * temp.dcot) < 0.05 && temp.deltaMissingHits < 2 &&
+            temp.radiusOfConversion > -2)
+          v_3.push_back(temp);
+      }
 
-  //give preference to conversion partners found in the CTF collection
-  //using the electron's CTF track
-  if(!v_0.empty())
-    return arbitrateConversionPartnersbyR(v_0);
+    }  //candidate conversion loop
 
-  if(!v_1.empty())
-    return arbitrateConversionPartnersbyR(v_1);
+    //now do some arbitration
 
-  if(!v_2.empty())
-    return arbitrateConversionPartnersbyR(v_2);
+    //give preference to conversion partners found in the CTF collection
+    //using the electron's CTF track
+    if (!v_0.empty())
+      return arbitrateConversionPartnersbyR(v_0);
 
-  if(!v_3.empty())
-    return arbitrateConversionPartnersbyR(v_3);
+    if (!v_1.empty())
+      return arbitrateConversionPartnersbyR(v_1);
 
+    if (!v_2.empty())
+      return arbitrateConversionPartnersbyR(v_2);
 
-  //if we get here, we didn't find a candidate conversion partner that
-  //satisfied even the loose selections
-  //return the the closest partner by R
-  return arbitrateConversionPartnersbyR(v_convCandidates);
+    if (!v_3.empty())
+      return arbitrateConversionPartnersbyR(v_3);
 
- }
+    //if we get here, we didn't find a candidate conversion partner that
+    //satisfied even the loose selections
+    //return the the closest partner by R
+    return arbitrateConversionPartnersbyR(v_convCandidates);
+  }
 
+  //------------------------------------------------------------------------------------
 
+  //------------------------------------------------------------------------------------
+  // Exists here for backwards compatibility only. Provides only the dist and dcot
+  std::pair<double, double> getConversionInfo(LorentzVector trk1_p4,
+                                              int trk1_q,
+                                              float trk1_d0,
+                                              LorentzVector trk2_p4,
+                                              int trk2_q,
+                                              float trk2_d0,
+                                              float bFieldAtOrigin) {
+    double tk1Curvature = -0.3 * bFieldAtOrigin * (trk1_q / trk1_p4.pt()) / 100.;
+    double rTk1 = fabs(1. / tk1Curvature);
+    double xTk1 = -1. * (1. / tk1Curvature - trk1_d0) * sin(trk1_p4.phi());
+    double yTk1 = (1. / tk1Curvature - trk1_d0) * cos(trk1_p4.phi());
 
+    double tk2Curvature = -0.3 * bFieldAtOrigin * (trk2_q / trk2_p4.pt()) / 100.;
+    double rTk2 = fabs(1. / tk2Curvature);
+    double xTk2 = -1. * (1. / tk2Curvature - trk2_d0) * sin(trk2_p4.phi());
+    double yTk2 = (1. / tk2Curvature - trk2_d0) * cos(trk2_p4.phi());
 
-//------------------------------------------------------------------------------------
+    double dist = sqrt(pow(xTk1 - xTk2, 2) + pow(yTk1 - yTk2, 2));
+    dist = dist - (rTk1 + rTk2);
 
-//------------------------------------------------------------------------------------
-// Exists here for backwards compatibility only. Provides only the dist and dcot
-std::pair<double, double> getConversionInfo(LorentzVector trk1_p4,
-							      int trk1_q, float trk1_d0,
-							      LorentzVector trk2_p4,
-							      int trk2_q, float trk2_d0,
-							      float bFieldAtOrigin) {
+    double dcot = 1. / tan(trk1_p4.theta()) - 1. / tan(trk2_p4.theta());
 
+    return std::make_pair(dist, dcot);
+  }
 
-  double tk1Curvature = -0.3*bFieldAtOrigin*(trk1_q/trk1_p4.pt())/100.;
-  double rTk1 = fabs(1./tk1Curvature);
-  double xTk1 = -1.*(1./tk1Curvature - trk1_d0)*sin(trk1_p4.phi());
-  double yTk1 = (1./tk1Curvature - trk1_d0)*cos(trk1_p4.phi());
+  //-------------------------------------- Also for backwards compatibility reasons  ---------------------------------------------------------------
+  ConversionInfo getConversionInfo(const reco::GsfElectron& gsfElectron,
+                                   const edm::Handle<reco::TrackCollection>& track_h,
+                                   const double bFieldAtOrigin,
+                                   const double minFracSharedHits) {
+    using namespace reco;
+    using namespace std;
+    using namespace edm;
 
+    const TrackCollection* ctftracks = track_h.product();
+    const reco::TrackRef el_ctftrack = gsfElectron.closestCtfTrackRef();
+    int ctfidx = -999.;
+    int flag = -9999.;
+    if (el_ctftrack.isNonnull() && gsfElectron.shFracInnerHits() > minFracSharedHits) {
+      ctfidx = static_cast<int>(el_ctftrack.key());
+      flag = 0;
+    } else
+      flag = 1;
 
-  double tk2Curvature = -0.3*bFieldAtOrigin*(trk2_q/trk2_p4.pt())/100.;
-  double rTk2 = fabs(1./tk2Curvature);
-  double xTk2 = -1.*(1./tk2Curvature - trk2_d0)*sin(trk2_p4.phi());
-  double yTk2 = (1./tk2Curvature - trk2_d0)*cos(trk2_p4.phi());
-
-
-  double dist = sqrt(pow(xTk1-xTk2, 2) + pow(yTk1-yTk2 , 2));
-  dist = dist - (rTk1 + rTk2);
-
-  double dcot = 1./tan(trk1_p4.theta()) - 1./tan(trk2_p4.theta());
-
-  return std::make_pair(dist, dcot);
-
- }
-
-
-//-------------------------------------- Also for backwards compatibility reasons  ---------------------------------------------------------------
-ConversionInfo getConversionInfo(const reco::GsfElectron& gsfElectron,
-						   const edm::Handle<reco::TrackCollection>& track_h,
-						   const double bFieldAtOrigin,
-						   const double minFracSharedHits) {
-
-
-  using namespace reco;
-  using namespace std;
-  using namespace edm;
-
-
-  const TrackCollection *ctftracks = track_h.product();
-  const reco::TrackRef el_ctftrack = gsfElectron.closestCtfTrackRef();
-  int ctfidx = -999.;
-  int flag = -9999.;
-  if(el_ctftrack.isNonnull() && gsfElectron.shFracInnerHits() > minFracSharedHits) {
-    ctfidx = static_cast<int>(el_ctftrack.key());
-    flag = 0;
-  } else
-    flag = 1;
-
-
-  /*
+    /*
     determine whether we're going to use the CTF track or the GSF track
     using the electron's CTF track to find the dist, dcot has been shown
     to reduce the inefficiency
   */
-  const reco::Track* el_track = getElectronTrack(gsfElectron, minFracSharedHits);
-  LorentzVector el_tk_p4(el_track->px(), el_track->py(), el_track->pz(), el_track->p());
+    const reco::Track* el_track = getElectronTrack(gsfElectron, minFracSharedHits);
+    LorentzVector el_tk_p4(el_track->px(), el_track->py(), el_track->pz(), el_track->p());
 
+    int tk_i = 0;
+    double mindcot = 9999.;
+    //make a null Track Ref
+    TrackRef candCtfTrackRef = TrackRef();
 
-  int tk_i = 0;
-  double mindcot = 9999.;
-  //make a null Track Ref
-  TrackRef candCtfTrackRef = TrackRef() ;
+    for (TrackCollection::const_iterator tk = ctftracks->begin(); tk != ctftracks->end(); tk++, tk_i++) {
+      //if the general Track is the same one as made by the electron, skip it
+      if (tk_i == ctfidx)
+        continue;
 
+      LorentzVector tk_p4 = LorentzVector(tk->px(), tk->py(), tk->pz(), tk->p());
 
-  for(TrackCollection::const_iterator tk = ctftracks->begin();
-      tk != ctftracks->end(); tk++, tk_i++) {
-    //if the general Track is the same one as made by the electron, skip it
-    if(tk_i == ctfidx)
-      continue;
+      //look only in a cone of 0.5
+      double dR = deltaR(el_tk_p4, tk_p4);
+      if (dR > 0.5)
+        continue;
 
-    LorentzVector tk_p4 = LorentzVector(tk->px(), tk->py(),tk->pz(), tk->p());
+      //require opp. sign -> Should we use the majority logic??
+      if (tk->charge() + el_track->charge() != 0)
+        continue;
 
-    //look only in a cone of 0.5
-    double dR = deltaR(el_tk_p4, tk_p4);
-    if(dR>0.5)
-      continue;
+      double dcot = fabs(1. / tan(tk_p4.theta()) - 1. / tan(el_tk_p4.theta()));
+      if (dcot < mindcot) {
+        mindcot = dcot;
+        candCtfTrackRef = reco::TrackRef(track_h, tk_i);
+      }
+    }  //track loop
 
+    if (!candCtfTrackRef.isNonnull())
+      return ConversionInfo{-9999.,
+                            -9999.,
+                            -9999.,
+                            math::XYZPoint(-9999., -9999., -9999),
+                            reco::TrackRef(),
+                            reco::GsfTrackRef(),
+                            -9999,
+                            -9999};
 
-    //require opp. sign -> Should we use the majority logic??
-    if(tk->charge() + el_track->charge() != 0)
-      continue;
+    //now calculate the conversion related information
+    double elCurvature = -0.3 * bFieldAtOrigin * (el_track->charge() / el_tk_p4.pt()) / 100.;
+    double rEl = fabs(1. / elCurvature);
+    double xEl = -1 * (1. / elCurvature - el_track->d0()) * sin(el_tk_p4.phi());
+    double yEl = (1. / elCurvature - el_track->d0()) * cos(el_tk_p4.phi());
 
-    double dcot = fabs(1./tan(tk_p4.theta()) - 1./tan(el_tk_p4.theta()));
-    if(dcot < mindcot) {
-      mindcot = dcot;
-      candCtfTrackRef = reco::TrackRef(track_h, tk_i);
-    }
-  }//track loop
+    LorentzVector cand_p4 =
+        LorentzVector(candCtfTrackRef->px(), candCtfTrackRef->py(), candCtfTrackRef->pz(), candCtfTrackRef->p());
+    double candCurvature = -0.3 * bFieldAtOrigin * (candCtfTrackRef->charge() / cand_p4.pt()) / 100.;
+    double rCand = fabs(1. / candCurvature);
+    double xCand = -1 * (1. / candCurvature - candCtfTrackRef->d0()) * sin(cand_p4.phi());
+    double yCand = (1. / candCurvature - candCtfTrackRef->d0()) * cos(cand_p4.phi());
 
+    double d = sqrt(pow(xEl - xCand, 2) + pow(yEl - yCand, 2));
+    double dist = d - (rEl + rCand);
+    double dcot = 1. / tan(el_tk_p4.theta()) - 1. / tan(cand_p4.theta());
 
-  if(!candCtfTrackRef.isNonnull())
-    return ConversionInfo{-9999.,-9999.,-9999.,
-			  math::XYZPoint(-9999.,-9999.,-9999),
-			  reco::TrackRef(), reco::GsfTrackRef(),
-			  -9999, -9999};
+    //get the point of conversion
+    double xa1 = xEl + (xCand - xEl) * rEl / d;
+    double xa2 = xCand + (xEl - xCand) * rCand / d;
+    double ya1 = yEl + (yCand - yEl) * rEl / d;
+    double ya2 = yCand + (yEl - yCand) * rCand / d;
 
+    double x = .5 * (xa1 + xa2);
+    double y = .5 * (ya1 + ya2);
+    double rconv = sqrt(pow(x, 2) + pow(y, 2));
+    double z =
+        el_track->dz() + rEl * el_track->pz() * TMath::ACos(1 - pow(rconv, 2) / (2. * pow(rEl, 2))) / el_track->pt();
 
+    math::XYZPoint convPoint(x, y, z);
 
-  //now calculate the conversion related information
-  double elCurvature = -0.3*bFieldAtOrigin*(el_track->charge()/el_tk_p4.pt())/100.;
-  double rEl = fabs(1./elCurvature);
-  double xEl = -1*(1./elCurvature - el_track->d0())*sin(el_tk_p4.phi());
-  double yEl = (1./elCurvature - el_track->d0())*cos(el_tk_p4.phi());
+    //now assign a sign to the radius of conversion
+    float tempsign = el_track->px() * x + el_track->py() * y;
+    tempsign = tempsign / fabs(tempsign);
+    rconv = tempsign * rconv;
 
+    int deltaMissingHits = -9999;
 
-  LorentzVector cand_p4 = LorentzVector(candCtfTrackRef->px(), candCtfTrackRef->py(),candCtfTrackRef->pz(), candCtfTrackRef->p());
-  double candCurvature = -0.3*bFieldAtOrigin*(candCtfTrackRef->charge()/cand_p4.pt())/100.;
-  double rCand = fabs(1./candCurvature);
-  double xCand = -1*(1./candCurvature - candCtfTrackRef->d0())*sin(cand_p4.phi());
-  double yCand = (1./candCurvature - candCtfTrackRef->d0())*cos(cand_p4.phi());
+    deltaMissingHits = candCtfTrackRef->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) -
+                       el_track->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
 
-  double d = sqrt(pow(xEl-xCand, 2) + pow(yEl-yCand , 2));
-  double dist = d - (rEl + rCand);
-  double dcot = 1./tan(el_tk_p4.theta()) - 1./tan(cand_p4.theta());
+    return ConversionInfo{dist, dcot, rconv, convPoint, candCtfTrackRef, GsfTrackRef(), deltaMissingHits, flag};
+  }
 
-  //get the point of conversion
-  double xa1 = xEl   + (xCand-xEl) * rEl/d;
-  double xa2 = xCand + (xEl-xCand) * rCand/d;
-  double ya1 = yEl   + (yCand-yEl) * rEl/d;
-  double ya2 = yCand + (yEl-yCand) * rCand/d;
-
-  double x=.5*(xa1+xa2);
-  double y=.5*(ya1+ya2);
-  double rconv = sqrt(pow(x,2) + pow(y,2));
-  double z = el_track->dz() + rEl*el_track->pz()*TMath::ACos(1-pow(rconv,2)/(2.*pow(rEl,2)))/el_track->pt();
-
-  math::XYZPoint convPoint(x, y, z);
-
-  //now assign a sign to the radius of conversion
-  float tempsign = el_track->px()*x + el_track->py()*y;
-  tempsign = tempsign/fabs(tempsign);
-  rconv = tempsign*rconv;
-
-  int deltaMissingHits = -9999;
-
-  deltaMissingHits = candCtfTrackRef->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS)
-      - el_track->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
-
-  return ConversionInfo{dist, dcot, rconv, convPoint, candCtfTrackRef, GsfTrackRef(), deltaMissingHits, flag};
-
- }
-
-}
+}  // namespace egammaTools
 
 //-------------------------------------------------------------------------------------

--- a/RecoEgamma/EgammaTools/src/ConversionLikelihoodCalculator.cc
+++ b/RecoEgamma/EgammaTools/src/ConversionLikelihoodCalculator.cc
@@ -1,125 +1,121 @@
 #include "RecoEgamma/EgammaTools/interface/ConversionLikelihoodCalculator.h"
 
+ConversionLikelihoodCalculator::ConversionLikelihoodCalculator() {
+  reader_ = std::make_unique<TMVA::Reader>("!Color:Silent");
 
-ConversionLikelihoodCalculator::ConversionLikelihoodCalculator()
-{
-   reader_ = std::make_unique<TMVA::Reader>("!Color:Silent");
-   
-//   std::cout << "Init Reader()" << std::endl;
+  //   std::cout << "Init Reader()" << std::endl;
 
-   reader_->AddVariable("log(e_over_p)",        &log_e_over_p_);
-   reader_->AddVariable("log(abs(cot_theta))",  &log_abs_cot_theta_);
-   reader_->AddVariable("log(abs(delta_phi))",  &log_abs_delta_phi_);
-   reader_->AddVariable("log(chi2_max_pt)", &log_chi2_max_pt_);
-   reader_->AddVariable("log(chi2_min_pt)", &log_chi2_min_pt_);
-
+  reader_->AddVariable("log(e_over_p)", &log_e_over_p_);
+  reader_->AddVariable("log(abs(cot_theta))", &log_abs_cot_theta_);
+  reader_->AddVariable("log(abs(delta_phi))", &log_abs_delta_phi_);
+  reader_->AddVariable("log(chi2_max_pt)", &log_chi2_max_pt_);
+  reader_->AddVariable("log(chi2_min_pt)", &log_chi2_min_pt_);
 }
 
-void ConversionLikelihoodCalculator::setWeightsFile(const char * weightsFile)
-{
-//   std::cout << "Before BookMVA " << weightsFile << std::endl;
-   reader_->BookMVA("Likelihood", weightsFile);
-//   std::cout << "After  BookMVA" << std::endl;
+void ConversionLikelihoodCalculator::setWeightsFile(const char* weightsFile) {
+  //   std::cout << "Before BookMVA " << weightsFile << std::endl;
+  reader_->BookMVA("Likelihood", weightsFile);
+  //   std::cout << "After  BookMVA" << std::endl;
 }
 
-double ConversionLikelihoodCalculator::calculateLikelihood(reco::ConversionRef conversion)
-{
-   if (conversion->nTracks() != 2) return -1.;
-   
-   log_e_over_p_ = log(conversion->EoverP());
+double ConversionLikelihoodCalculator::calculateLikelihood(reco::ConversionRef conversion) {
+  if (conversion->nTracks() != 2)
+    return -1.;
 
-   log_abs_cot_theta_ = log(fabs(conversion->pairCotThetaSeparation()));
+  log_e_over_p_ = log(conversion->EoverP());
 
-   double delta_phi = conversion->tracks()[0]->innerMomentum().phi()-conversion->tracks()[1]->innerMomentum().phi();
-   double pi = 3.14159265;
-   // phi normalization
-   while (delta_phi > pi) delta_phi -= 2*pi;
-   while (delta_phi < -pi) delta_phi += 2*pi;
-   log_abs_delta_phi_ = log(fabs(delta_phi));
+  log_abs_cot_theta_ = log(fabs(conversion->pairCotThetaSeparation()));
 
-   double chi2_1 = conversion->tracks()[0]->normalizedChi2();
-   double pt_1 = conversion->tracks()[0]->pt();
+  double delta_phi = conversion->tracks()[0]->innerMomentum().phi() - conversion->tracks()[1]->innerMomentum().phi();
+  double pi = 3.14159265;
+  // phi normalization
+  while (delta_phi > pi)
+    delta_phi -= 2 * pi;
+  while (delta_phi < -pi)
+    delta_phi += 2 * pi;
+  log_abs_delta_phi_ = log(fabs(delta_phi));
 
-   double chi2_2 = conversion->tracks()[1]->normalizedChi2();
-   double pt_2 = conversion->tracks()[1]->pt();
+  double chi2_1 = conversion->tracks()[0]->normalizedChi2();
+  double pt_1 = conversion->tracks()[0]->pt();
 
-   double chi2_max_pt=chi2_1;
-   double chi2_min_pt=chi2_2;
+  double chi2_2 = conversion->tracks()[1]->normalizedChi2();
+  double pt_2 = conversion->tracks()[1]->pt();
 
-   if (pt_2 > pt_1) {
-      chi2_max_pt=chi2_2;
-      chi2_min_pt=chi2_1;
-   }
+  double chi2_max_pt = chi2_1;
+  double chi2_min_pt = chi2_2;
 
-   log_chi2_max_pt_ = log(chi2_max_pt);
-   log_chi2_min_pt_ = log(chi2_min_pt);
+  if (pt_2 > pt_1) {
+    chi2_max_pt = chi2_2;
+    chi2_min_pt = chi2_1;
+  }
 
-//   std::cout << "log_e_over_p_ " << log_e_over_p_ << std::endl;
-//   std::cout << "log_abs_cot_theta_ " << log_abs_cot_theta_ << std::endl;
-//   std::cout << "log_abs_delta_phi_ " << log_abs_delta_phi_ << std::endl;
-//   std::cout << "log_chi2_max_pt_ " << log_chi2_max_pt_ << std::endl;
-//   std::cout << "log_chi2_min_pt_ " << log_chi2_min_pt_ << std::endl;
-   std::vector<Float_t> inputVec;
-   inputVec.push_back(log_e_over_p_ );
-   inputVec.push_back(log_abs_cot_theta_ );
-   inputVec.push_back(log_abs_delta_phi_ );
-   inputVec.push_back(log_chi2_max_pt_ );
-   inputVec.push_back(log_chi2_min_pt_ );
-   float like = reader_->EvaluateMVA(inputVec,"Likelihood");
-//   std::cout << "reader_->EvaluateMVA(\"Likelihood\") " << reader_->EvaluateMVA(inputVec,"Likelihood") << std::endl;
+  log_chi2_max_pt_ = log(chi2_max_pt);
+  log_chi2_min_pt_ = log(chi2_min_pt);
 
-   return like;
+  //   std::cout << "log_e_over_p_ " << log_e_over_p_ << std::endl;
+  //   std::cout << "log_abs_cot_theta_ " << log_abs_cot_theta_ << std::endl;
+  //   std::cout << "log_abs_delta_phi_ " << log_abs_delta_phi_ << std::endl;
+  //   std::cout << "log_chi2_max_pt_ " << log_chi2_max_pt_ << std::endl;
+  //   std::cout << "log_chi2_min_pt_ " << log_chi2_min_pt_ << std::endl;
+  std::vector<Float_t> inputVec;
+  inputVec.push_back(log_e_over_p_);
+  inputVec.push_back(log_abs_cot_theta_);
+  inputVec.push_back(log_abs_delta_phi_);
+  inputVec.push_back(log_chi2_max_pt_);
+  inputVec.push_back(log_chi2_min_pt_);
+  float like = reader_->EvaluateMVA(inputVec, "Likelihood");
+  //   std::cout << "reader_->EvaluateMVA(\"Likelihood\") " << reader_->EvaluateMVA(inputVec,"Likelihood") << std::endl;
+
+  return like;
 }
 
-double ConversionLikelihoodCalculator::calculateLikelihood(reco::Conversion& conversion)
-{
+double ConversionLikelihoodCalculator::calculateLikelihood(reco::Conversion& conversion) {
+  if (conversion.nTracks() != 2)
+    return -1.;
 
-   if (conversion.nTracks() != 2) return -1.;
-   
-   log_e_over_p_ = log(conversion.EoverP());
+  log_e_over_p_ = log(conversion.EoverP());
 
-   log_abs_cot_theta_ = log(fabs(conversion.pairCotThetaSeparation()));
+  log_abs_cot_theta_ = log(fabs(conversion.pairCotThetaSeparation()));
 
+  double delta_phi = conversion.tracksPin()[0].phi() - conversion.tracksPin()[1].phi();
+  double pi = 3.14159265;
+  // phi normalization
+  while (delta_phi > pi)
+    delta_phi -= 2 * pi;
+  while (delta_phi < -pi)
+    delta_phi += 2 * pi;
+  log_abs_delta_phi_ = log(fabs(delta_phi));
 
-   double delta_phi = conversion.tracksPin()[0].phi()-conversion.tracksPin()[1].phi();
-   double pi = 3.14159265;
-   // phi normalization
-   while (delta_phi > pi) delta_phi -= 2*pi;
-   while (delta_phi < -pi) delta_phi += 2*pi;
-   log_abs_delta_phi_ = log(fabs(delta_phi));
+  double chi2_1 = conversion.tracks()[0]->normalizedChi2();
+  double pt_1 = conversion.tracks()[0]->pt();
 
-   double chi2_1 = conversion.tracks()[0]->normalizedChi2();
-   double pt_1 = conversion.tracks()[0]->pt();
+  double chi2_2 = conversion.tracks()[1]->normalizedChi2();
+  double pt_2 = conversion.tracks()[1]->pt();
 
-   double chi2_2 = conversion.tracks()[1]->normalizedChi2();
-   double pt_2 = conversion.tracks()[1]->pt();
+  double chi2_max_pt = chi2_1;
+  double chi2_min_pt = chi2_2;
 
-   double chi2_max_pt=chi2_1;
-   double chi2_min_pt=chi2_2;
+  if (pt_2 > pt_1) {
+    chi2_max_pt = chi2_2;
+    chi2_min_pt = chi2_1;
+  }
 
-   if (pt_2 > pt_1) {
-      chi2_max_pt=chi2_2;
-      chi2_min_pt=chi2_1;
-   }
+  log_chi2_max_pt_ = log(chi2_max_pt);
+  log_chi2_min_pt_ = log(chi2_min_pt);
 
-   log_chi2_max_pt_ = log(chi2_max_pt);
-   log_chi2_min_pt_ = log(chi2_min_pt);
+  //   std::cout << "log_e_over_p_ " << log_e_over_p_ << std::endl;
+  //   std::cout << "log_abs_cot_theta_ " << log_abs_cot_theta_ << std::endl;
+  //   std::cout << "log_abs_delta_phi_ " << log_abs_delta_phi_ << std::endl;
+  //   std::cout << "log_chi2_max_pt_ " << log_chi2_max_pt_ << std::endl;
+  //   std::cout << "log_chi2_min_pt_ " << log_chi2_min_pt_ << std::endl;
+  std::vector<Float_t> inputVec;
+  inputVec.push_back(log_e_over_p_);
+  inputVec.push_back(log_abs_cot_theta_);
+  inputVec.push_back(log_abs_delta_phi_);
+  inputVec.push_back(log_chi2_max_pt_);
+  inputVec.push_back(log_chi2_min_pt_);
+  float like = reader_->EvaluateMVA(inputVec, "Likelihood");
+  //   std::cout << "reader_->EvaluateMVA(\"Likelihood\") " << reader_->EvaluateMVA(inputVec,"Likelihood") << std::endl;
 
-//   std::cout << "log_e_over_p_ " << log_e_over_p_ << std::endl;
-//   std::cout << "log_abs_cot_theta_ " << log_abs_cot_theta_ << std::endl;
-//   std::cout << "log_abs_delta_phi_ " << log_abs_delta_phi_ << std::endl;
-//   std::cout << "log_chi2_max_pt_ " << log_chi2_max_pt_ << std::endl;
-//   std::cout << "log_chi2_min_pt_ " << log_chi2_min_pt_ << std::endl;
-   std::vector<Float_t> inputVec;
-   inputVec.push_back(log_e_over_p_ );
-   inputVec.push_back(log_abs_cot_theta_ );
-   inputVec.push_back(log_abs_delta_phi_ );
-   inputVec.push_back(log_chi2_max_pt_ );
-   inputVec.push_back(log_chi2_min_pt_ );
-   float like = reader_->EvaluateMVA(inputVec,"Likelihood");
-//   std::cout << "reader_->EvaluateMVA(\"Likelihood\") " << reader_->EvaluateMVA(inputVec,"Likelihood") << std::endl;
-
-   return like;
+  return like;
 }
-
-

--- a/RecoEgamma/EgammaTools/src/ConversionTools.cc
+++ b/RecoEgamma/EgammaTools/src/ConversionTools.cc
@@ -12,54 +12,69 @@
 using namespace edm;
 using namespace reco;
 
-
 //--------------------------------------------------------------------------------------------------
-bool ConversionTools::isGoodConversion(const Conversion &conv, const math::XYZPoint &beamspot, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
-{
-  
+bool ConversionTools::isGoodConversion(const Conversion &conv,
+                                       const math::XYZPoint &beamspot,
+                                       float lxyMin,
+                                       float probMin,
+                                       unsigned int nHitsBeforeVtxMax) {
   //Check if a given conversion candidate passes the conversion selection cuts
-  
+
   const reco::Vertex &vtx = conv.conversionVertex();
 
   //vertex validity
-  if (!vtx.isValid()) return false;
+  if (!vtx.isValid())
+    return false;
 
   //fit probability
-  if (TMath::Prob( vtx.chi2(),  vtx.ndof() )<probMin) return false;
+  if (TMath::Prob(vtx.chi2(), vtx.ndof()) < probMin)
+    return false;
 
   //compute transverse decay length
-  math::XYZVector mom(conv.refittedPairMomentum()); 
+  math::XYZVector mom(conv.refittedPairMomentum());
   double dbsx = vtx.x() - beamspot.x();
   double dbsy = vtx.y() - beamspot.y();
-  double lxy = (mom.x()*dbsx + mom.y()*dbsy)/mom.rho();
+  double lxy = (mom.x() * dbsx + mom.y() * dbsy) / mom.rho();
 
-  //transverse decay length  
-  if ( lxy<lxyMin )
+  //transverse decay length
+  if (lxy < lxyMin)
     return false;
-    
+
   //loop through daughters to check nhitsbeforevtx
-  for (std::vector<uint8_t>::const_iterator it = conv.nHitsBeforeVtx().begin(); it!=conv.nHitsBeforeVtx().end(); ++it) {
-    if ( (*it)>nHitsBeforeVtxMax ) return false;
+  for (std::vector<uint8_t>::const_iterator it = conv.nHitsBeforeVtx().begin(); it != conv.nHitsBeforeVtx().end();
+       ++it) {
+    if ((*it) > nHitsBeforeVtxMax)
+      return false;
   }
-  
+
   return true;
 }
 
 //--------------------------------------------------------------------------------------------------
-bool ConversionTools::matchesConversion(const reco::GsfElectron &ele, const reco::Conversion &conv, bool allowCkfMatch, bool allowAmbiguousGsfMatch)
-{
-
+bool ConversionTools::matchesConversion(const reco::GsfElectron &ele,
+                                        const reco::Conversion &conv,
+                                        bool allowCkfMatch,
+                                        bool allowAmbiguousGsfMatch) {
   //check if a given GsfElectron matches a given conversion (no quality cuts applied)
   //matching is always attempted through the gsf track ref, and optionally attempted through the
   //closest ctf track ref
 
   const std::vector<edm::RefToBase<reco::Track> > &convTracks = conv.tracks();
-  for (std::vector<edm::RefToBase<reco::Track> >::const_iterator it=convTracks.begin(); it!=convTracks.end(); ++it) {
-    if ( ele.reco::GsfElectron::gsfTrack().isNonnull() && ele.reco::GsfElectron::gsfTrack().id()==it->id() && ele.reco::GsfElectron::gsfTrack().key()==it->key()) return true;
-    else if ( allowCkfMatch && ele.reco::GsfElectron::closestCtfTrackRef().isNonnull() && ele.reco::GsfElectron::closestCtfTrackRef().id()==it->id() && ele.reco::GsfElectron::closestCtfTrackRef().key()==it->key() ) return true;
+  for (std::vector<edm::RefToBase<reco::Track> >::const_iterator it = convTracks.begin(); it != convTracks.end();
+       ++it) {
+    if (ele.reco::GsfElectron::gsfTrack().isNonnull() && ele.reco::GsfElectron::gsfTrack().id() == it->id() &&
+        ele.reco::GsfElectron::gsfTrack().key() == it->key())
+      return true;
+    else if (allowCkfMatch && ele.reco::GsfElectron::closestCtfTrackRef().isNonnull() &&
+             ele.reco::GsfElectron::closestCtfTrackRef().id() == it->id() &&
+             ele.reco::GsfElectron::closestCtfTrackRef().key() == it->key())
+      return true;
     if (allowAmbiguousGsfMatch) {
-      for (reco::GsfTrackRefVector::const_iterator tk = ele.ambiguousGsfTracksBegin(); tk!=ele.ambiguousGsfTracksEnd(); ++tk) {
-        if (tk->isNonnull() && tk->id()==it->id() && tk->key()==it->key()) return true;
+      for (reco::GsfTrackRefVector::const_iterator tk = ele.ambiguousGsfTracksBegin();
+           tk != ele.ambiguousGsfTracksEnd();
+           ++tk) {
+        if (tk->isNonnull() && tk->id() == it->id() && tk->key() == it->key())
+          return true;
       }
     }
   }
@@ -68,326 +83,367 @@ bool ConversionTools::matchesConversion(const reco::GsfElectron &ele, const reco
 }
 
 //--------------------------------------------------------------------------------------------------
-bool ConversionTools::matchesConversion(const reco::GsfElectronCore &eleCore, const reco::Conversion &conv, bool allowCkfMatch)
-{
-
+bool ConversionTools::matchesConversion(const reco::GsfElectronCore &eleCore,
+                                        const reco::Conversion &conv,
+                                        bool allowCkfMatch) {
   //check if a given GsfElectronCore matches a given conversion (no quality cuts applied)
   //matching is always attempted through the gsf track ref, and optionally attempted through the
   //closest ctf track ref
 
-  for (const auto& trkRef : conv.tracks() ){
-    if ( eleCore.gsfTrack().isNonnull() && eleCore.gsfTrack().id()==trkRef.id() &&
-	 eleCore.gsfTrack().key()==trkRef.key()) return true;
-    else if ( allowCkfMatch && eleCore.ctfTrack().isNonnull() &&
-	      eleCore.ctfTrack().id()==trkRef.id() &&
-	      eleCore.ctfTrack().key()==trkRef.key() ) return true;
+  for (const auto &trkRef : conv.tracks()) {
+    if (eleCore.gsfTrack().isNonnull() && eleCore.gsfTrack().id() == trkRef.id() &&
+        eleCore.gsfTrack().key() == trkRef.key())
+      return true;
+    else if (allowCkfMatch && eleCore.ctfTrack().isNonnull() && eleCore.ctfTrack().id() == trkRef.id() &&
+             eleCore.ctfTrack().key() == trkRef.key())
+      return true;
   }
 
   return false;
 }
 
-
 //--------------------------------------------------------------------------------------------------
-bool ConversionTools::matchesConversion(const reco::SuperCluster &sc, const reco::Conversion &conv, float dRMax, float dEtaMax, float dPhiMax) {
-
+bool ConversionTools::matchesConversion(
+    const reco::SuperCluster &sc, const reco::Conversion &conv, float dRMax, float dEtaMax, float dPhiMax) {
   //check if a given SuperCluster matches a given conversion (no quality cuts applied)
   //matching is geometric between conversion momentum and vector joining conversion vertex
   //to supercluster position
 
-
   math::XYZVector mom(conv.refittedPairMomentum());
-  
-  const math::XYZPoint& scpos(sc.position());
+
+  const math::XYZPoint &scpos(sc.position());
   math::XYZPoint cvtx(conv.conversionVertex().position());
 
-
   math::XYZVector cscvector = scpos - cvtx;
-  float dR = reco::deltaR(mom,cscvector);
+  float dR = reco::deltaR(mom, cscvector);
   float dEta = mom.eta() - cscvector.eta();
-  float dPhi = reco::deltaPhi(mom.phi(),cscvector.phi());
+  float dPhi = reco::deltaPhi(mom.phi(), cscvector.phi());
 
-  if (dR>dRMax) return false;
-  if (dEta>dEtaMax) return false;
-  if (dPhi>dPhiMax) return false;
+  if (dR > dRMax)
+    return false;
+  if (dEta > dEtaMax)
+    return false;
+  if (dPhi > dPhiMax)
+    return false;
 
   return true;
-
 }
 
-
 //--------------------------------------------------------------------------------------------------
-bool ConversionTools::matchesConversion(const edm::RefToBase<reco::Track> &trk, const reco::Conversion &conv)
-{
-
+bool ConversionTools::matchesConversion(const edm::RefToBase<reco::Track> &trk, const reco::Conversion &conv) {
   //check if given track matches given conversion (matching by ref)
 
-  if (trk.isNull()) return false;
+  if (trk.isNull())
+    return false;
 
   const std::vector<edm::RefToBase<reco::Track> > &convTracks = conv.tracks();
-  for (std::vector<edm::RefToBase<reco::Track> >::const_iterator it=convTracks.begin(); it!=convTracks.end(); ++it) {
-    if (trk.id()==it->id() && trk.key()==it->key()) return true;
+  for (std::vector<edm::RefToBase<reco::Track> >::const_iterator it = convTracks.begin(); it != convTracks.end();
+       ++it) {
+    if (trk.id() == it->id() && trk.key() == it->key())
+      return true;
   }
 
   return false;
 }
 
 //--------------------------------------------------------------------------------------------------
-bool ConversionTools::matchesConversion(const reco::TrackRef &trk, const reco::Conversion &conv)
-{
-
+bool ConversionTools::matchesConversion(const reco::TrackRef &trk, const reco::Conversion &conv) {
   //check if given track matches given conversion (matching by ref)
 
-  if (trk.isNull()) return false;
+  if (trk.isNull())
+    return false;
 
   const std::vector<edm::RefToBase<reco::Track> > &convTracks = conv.tracks();
-  for (std::vector<edm::RefToBase<reco::Track> >::const_iterator it=convTracks.begin(); it!=convTracks.end(); ++it) {
-    if (trk.id()==it->id() && trk.key()==it->key()) return true;
+  for (std::vector<edm::RefToBase<reco::Track> >::const_iterator it = convTracks.begin(); it != convTracks.end();
+       ++it) {
+    if (trk.id() == it->id() && trk.key() == it->key())
+      return true;
   }
 
   return false;
 }
 
 //--------------------------------------------------------------------------------------------------
-bool ConversionTools::matchesConversion(const reco::GsfTrackRef &trk, const reco::Conversion &conv)
-{
-
+bool ConversionTools::matchesConversion(const reco::GsfTrackRef &trk, const reco::Conversion &conv) {
   //check if given track matches given conversion (matching by ref)
 
-  if (trk.isNull()) return false;
+  if (trk.isNull())
+    return false;
 
   const std::vector<edm::RefToBase<reco::Track> > &convTracks = conv.tracks();
-  for (std::vector<edm::RefToBase<reco::Track> >::const_iterator it=convTracks.begin(); it!=convTracks.end(); ++it) {
-    if (trk.id()==it->id() && trk.key()==it->key()) return true;
+  for (std::vector<edm::RefToBase<reco::Track> >::const_iterator it = convTracks.begin(); it != convTracks.end();
+       ++it) {
+    if (trk.id() == it->id() && trk.key() == it->key())
+      return true;
   }
 
   return false;
 }
-
 
 //--------------------------------------------------------------------------------------------------
 bool ConversionTools::hasMatchedConversion(const reco::GsfElectron &ele,
-                                                  const reco::ConversionCollection &convCol,
-                                                  const math::XYZPoint &beamspot, bool allowCkfMatch, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
-{
+                                           const reco::ConversionCollection &convCol,
+                                           const math::XYZPoint &beamspot,
+                                           bool allowCkfMatch,
+                                           float lxyMin,
+                                           float probMin,
+                                           unsigned int nHitsBeforeVtxMax) {
   //check if a given electron candidate matches to at least one conversion candidate in the
   //collection which also passes the selection cuts, optionally match with the closestckf track in
   //in addition to just the gsf track (enabled in default arguments)
-  
-  for(auto const& it : convCol) {
-    if (!matchesConversion(ele, it, allowCkfMatch)) continue;
-    if (!isGoodConversion(it,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
-   
+
+  for (auto const &it : convCol) {
+    if (!matchesConversion(ele, it, allowCkfMatch))
+      continue;
+    if (!isGoodConversion(it, beamspot, lxyMin, probMin, nHitsBeforeVtxMax))
+      continue;
+
     return true;
   }
-  
+
   return false;
-  
 }
 
 //--------------------------------------------------------------------------------------------------
 bool ConversionTools::hasMatchedConversion(const reco::TrackRef &trk,
-                                                  const reco::ConversionCollection &convCol,
-                                                  const math::XYZPoint &beamspot, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
-{
+                                           const reco::ConversionCollection &convCol,
+                                           const math::XYZPoint &beamspot,
+                                           float lxyMin,
+                                           float probMin,
+                                           unsigned int nHitsBeforeVtxMax) {
   //check if a given track matches to at least one conversion candidate in the
   //collection which also passes the selection cuts
-  
-  if (trk.isNull()) return false;
-  
-  for(auto const& it : convCol) {
-    if (!matchesConversion(trk, it)) continue;
-    if (!isGoodConversion(it,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
-   
+
+  if (trk.isNull())
+    return false;
+
+  for (auto const &it : convCol) {
+    if (!matchesConversion(trk, it))
+      continue;
+    if (!isGoodConversion(it, beamspot, lxyMin, probMin, nHitsBeforeVtxMax))
+      continue;
+
     return true;
   }
-  
+
   return false;
-  
 }
 
 //--------------------------------------------------------------------------------------------------
 bool ConversionTools::hasMatchedConversion(const reco::SuperCluster &sc,
-                  const reco::ConversionCollection &convCol,
-                  const math::XYZPoint &beamspot, float dRMax, float dEtaMax, float dPhiMax, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
-{
-  
+                                           const reco::ConversionCollection &convCol,
+                                           const math::XYZPoint &beamspot,
+                                           float dRMax,
+                                           float dEtaMax,
+                                           float dPhiMax,
+                                           float lxyMin,
+                                           float probMin,
+                                           unsigned int nHitsBeforeVtxMax) {
   //check if a given SuperCluster matches to at least one conversion candidate in the
   //collection which also passes the selection cuts
 
-  for(auto const& it : convCol) {
-    if (!matchesConversion(sc, it)) continue;
-    if (!isGoodConversion(it,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
-   
+  for (auto const &it : convCol) {
+    if (!matchesConversion(sc, it))
+      continue;
+    if (!isGoodConversion(it, beamspot, lxyMin, probMin, nHitsBeforeVtxMax))
+      continue;
+
     return true;
   }
-  
+
   return false;
-
 }
 
-
 //--------------------------------------------------------------------------------------------------
-reco::Conversion const* ConversionTools::matchedConversion(const reco::GsfElectron &ele,
-                                                  const reco::ConversionCollection &convCol,
-                                                  const math::XYZPoint &beamspot, bool allowCkfMatch, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
-{
+reco::Conversion const *ConversionTools::matchedConversion(const reco::GsfElectron &ele,
+                                                           const reco::ConversionCollection &convCol,
+                                                           const math::XYZPoint &beamspot,
+                                                           bool allowCkfMatch,
+                                                           float lxyMin,
+                                                           float probMin,
+                                                           unsigned int nHitsBeforeVtxMax) {
   //check if a given electron candidate matches to at least one conversion candidate in the
   //collection which also passes the selection cuts, optionally match with the closestckf track in
   //in addition to just the gsf track (enabled in default arguments)
   //If multiple conversions are found, returned reference corresponds to minimum
   //conversion radius
-  
-  reco::Conversion const* match = nullptr;
-  
+
+  reco::Conversion const *match = nullptr;
+
   double minRho = 999.;
-  for(auto const& it : convCol) {
+  for (auto const &it : convCol) {
     float rho = it.conversionVertex().position().rho();
-    if (rho>minRho) continue;
-    if (!matchesConversion(ele, it, allowCkfMatch)) continue;
-    if (!isGoodConversion(it,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
-   
+    if (rho > minRho)
+      continue;
+    if (!matchesConversion(ele, it, allowCkfMatch))
+      continue;
+    if (!isGoodConversion(it, beamspot, lxyMin, probMin, nHitsBeforeVtxMax))
+      continue;
+
     minRho = rho;
     match = &it;
   }
-  
+
   return match;
-  
 }
 
 //--------------------------------------------------------------------------------------------------
-reco::Conversion const* ConversionTools::matchedConversion(const reco::GsfElectronCore &eleCore,
-                                                  const reco::ConversionCollection &convCol,
-                                                  const math::XYZPoint &beamspot, bool allowCkfMatch, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
-{
+reco::Conversion const *ConversionTools::matchedConversion(const reco::GsfElectronCore &eleCore,
+                                                           const reco::ConversionCollection &convCol,
+                                                           const math::XYZPoint &beamspot,
+                                                           bool allowCkfMatch,
+                                                           float lxyMin,
+                                                           float probMin,
+                                                           unsigned int nHitsBeforeVtxMax) {
   //check if a given electron candidate matches to at least one conversion candidate in the
   //collection which also passes the selection cuts, optionally match with the closestckf track in
   //in addition to just the gsf track (enabled in default arguments)
   //If multiple conversions are found, returned reference corresponds to minimum
   //conversion radius
-  
-  reco::Conversion const* match = nullptr;
-  
+
+  reco::Conversion const *match = nullptr;
+
   double minRho = 999.;
-  for(auto const& it : convCol) {
+  for (auto const &it : convCol) {
     float rho = it.conversionVertex().position().rho();
-    if (rho>minRho) continue;
-    if (!matchesConversion(eleCore, it, allowCkfMatch)) continue;
-    if (!isGoodConversion(it,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
-   
+    if (rho > minRho)
+      continue;
+    if (!matchesConversion(eleCore, it, allowCkfMatch))
+      continue;
+    if (!isGoodConversion(it, beamspot, lxyMin, probMin, nHitsBeforeVtxMax))
+      continue;
+
     minRho = rho;
     match = &it;
   }
-  
+
   return match;
-  
 }
 
 //--------------------------------------------------------------------------------------------------
-reco::Conversion const* ConversionTools::matchedConversion(const reco::TrackRef &trk,
-                                                  const reco::ConversionCollection &convCol,
-                                                  const math::XYZPoint &beamspot, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
-{
+reco::Conversion const *ConversionTools::matchedConversion(const reco::TrackRef &trk,
+                                                           const reco::ConversionCollection &convCol,
+                                                           const math::XYZPoint &beamspot,
+                                                           float lxyMin,
+                                                           float probMin,
+                                                           unsigned int nHitsBeforeVtxMax) {
   //check if a given track matches to at least one conversion candidate in the
   //collection which also passes the selection cuts
   //If multiple conversions are found, returned reference corresponds to minimum
   //conversion radius
-  
-  reco::Conversion const* match = nullptr;
 
-  if (trk.isNull()) return match;
-  
+  reco::Conversion const *match = nullptr;
+
+  if (trk.isNull())
+    return match;
+
   double minRho = 999.;
-  for(auto const& it : convCol) {
+  for (auto const &it : convCol) {
     float rho = it.conversionVertex().position().rho();
-    if (rho>minRho) continue;
-    if (!matchesConversion(trk, it)) continue;
-    if (!isGoodConversion(it,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
-   
+    if (rho > minRho)
+      continue;
+    if (!matchesConversion(trk, it))
+      continue;
+    if (!isGoodConversion(it, beamspot, lxyMin, probMin, nHitsBeforeVtxMax))
+      continue;
+
     minRho = rho;
     match = &it;
   }
-  
+
   return match;
-  
 }
 
 //--------------------------------------------------------------------------------------------------
-reco::Conversion const* ConversionTools::matchedConversion(const reco::SuperCluster &sc,
-                  const reco::ConversionCollection &convCol,
-                  const math::XYZPoint &beamspot, float dRMax, float dEtaMax, float dPhiMax, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
-{
-
+reco::Conversion const *ConversionTools::matchedConversion(const reco::SuperCluster &sc,
+                                                           const reco::ConversionCollection &convCol,
+                                                           const math::XYZPoint &beamspot,
+                                                           float dRMax,
+                                                           float dEtaMax,
+                                                           float dPhiMax,
+                                                           float lxyMin,
+                                                           float probMin,
+                                                           unsigned int nHitsBeforeVtxMax) {
   //check if a given SuperCluster matches to at least one conversion candidate in the
   //collection which also passes the selection cuts
   //If multiple conversions are found, returned reference corresponds to minimum
   //conversion radius
 
-  reco::Conversion const* match = nullptr;
-  
+  reco::Conversion const *match = nullptr;
+
   double minRho = 999.;
-  for(auto const& it : convCol) {
+  for (auto const &it : convCol) {
     float rho = it.conversionVertex().position().rho();
-    if (rho>minRho) continue;
-    if (!matchesConversion(sc, it, dRMax,dEtaMax,dPhiMax)) continue;
-    if (!isGoodConversion(it,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
-   
+    if (rho > minRho)
+      continue;
+    if (!matchesConversion(sc, it, dRMax, dEtaMax, dPhiMax))
+      continue;
+    if (!isGoodConversion(it, beamspot, lxyMin, probMin, nHitsBeforeVtxMax))
+      continue;
+
     minRho = rho;
     match = &it;
   }
-  
+
   return match;
-
 }
 
 //--------------------------------------------------------------------------------------------------
-bool ConversionTools::hasMatchedPromptElectron(const reco::SuperClusterRef &sc, const reco::GsfElectronCollection &eleCol,
-                   const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
-{
-
-  return !(matchedPromptElectron(sc, eleCol, convCol, beamspot,
-              allowCkfMatch, lxyMin, probMin, nHitsBeforeVtxMax) == nullptr);
+bool ConversionTools::hasMatchedPromptElectron(const reco::SuperClusterRef &sc,
+                                               const reco::GsfElectronCollection &eleCol,
+                                               const reco::ConversionCollection &convCol,
+                                               const math::XYZPoint &beamspot,
+                                               bool allowCkfMatch,
+                                               float lxyMin,
+                                               float probMin,
+                                               unsigned int nHitsBeforeVtxMax) {
+  return !(matchedPromptElectron(sc, eleCol, convCol, beamspot, allowCkfMatch, lxyMin, probMin, nHitsBeforeVtxMax) ==
+           nullptr);
 }
 
-
 //--------------------------------------------------------------------------------------------------
-reco::GsfElectron const* ConversionTools::matchedPromptElectron(const reco::SuperClusterRef &sc, const reco::GsfElectronCollection &eleCol,
-                   const reco::ConversionCollection &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
-{
-
+reco::GsfElectron const *ConversionTools::matchedPromptElectron(const reco::SuperClusterRef &sc,
+                                                                const reco::GsfElectronCollection &eleCol,
+                                                                const reco::ConversionCollection &convCol,
+                                                                const math::XYZPoint &beamspot,
+                                                                bool allowCkfMatch,
+                                                                float lxyMin,
+                                                                float probMin,
+                                                                unsigned int nHitsBeforeVtxMax) {
   //check if a given SuperCluster matches to at least one GsfElectron having zero expected inner hits
   //and not matching any conversion in the collection passing the quality cuts
 
-  reco::GsfElectron const* match = nullptr;
+  reco::GsfElectron const *match = nullptr;
 
-  if (sc.isNull()) return match;
-  
-  for(auto const& it : eleCol) {
+  if (sc.isNull())
+    return match;
+
+  for (auto const &it : eleCol) {
     //match electron to supercluster
-    if (it.superCluster()!=sc) continue;
+    if (it.superCluster() != sc)
+      continue;
 
     //check expected inner hits
-    if (it.gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) > 0) continue;
+    if (it.gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) > 0)
+      continue;
 
     //check if electron is matching to a conversion
-    if (hasMatchedConversion(it,convCol,beamspot,allowCkfMatch,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
-   
-   
+    if (hasMatchedConversion(it, convCol, beamspot, allowCkfMatch, lxyMin, probMin, nHitsBeforeVtxMax))
+      continue;
+
     match = &it;
   }
-  
+
   return match;
-
-
 }
 
 //--------------------------------------------------------------------------------------------------
-float ConversionTools::getVtxFitProb(const reco::Conversion* conv)
-{
-  if (conv!=nullptr) {
-    const reco::Vertex& vtx = conv->conversionVertex();
-    if( vtx.isValid() ) {
-      return TMath::Prob(vtx.chi2(),vtx.ndof()) ;
-    } 
+float ConversionTools::getVtxFitProb(const reco::Conversion *conv) {
+  if (conv != nullptr) {
+    const reco::Vertex &vtx = conv->conversionVertex();
+    if (vtx.isValid()) {
+      return TMath::Prob(vtx.chi2(), vtx.ndof());
+    }
   }
   return -1;
 }

--- a/RecoEgamma/EgammaTools/src/ECALPositionCalculator.cc
+++ b/RecoEgamma/EgammaTools/src/ECALPositionCalculator.cc
@@ -7,104 +7,103 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 
-static constexpr float R_ECAL           = 136.5;
-static constexpr float Z_Endcap         = 328.0;
-static constexpr float etaBarrelEndcap  = 1.479;
+static constexpr float R_ECAL = 136.5;
+static constexpr float Z_Endcap = 328.0;
+static constexpr float etaBarrelEndcap = 1.479;
 
 namespace egammaTools {
 
-double ecalPhi(const MagneticField &magField,const math::XYZVector &momentum, const math::XYZPoint &vertex, const int charge)
-{
+  double ecalPhi(const MagneticField &magField,
+                 const math::XYZVector &momentum,
+                 const math::XYZPoint &vertex,
+                 const int charge) {
+    // Get kinematic variables
 
-   // Get kinematic variables
+    float ptParticle = momentum.Rho();
+    float etaParticle = momentum.eta();
+    float phiParticle = momentum.phi();
+    float vRho = vertex.Rho();
 
-   float ptParticle = momentum.Rho();
-   float etaParticle = momentum.eta();
-   float phiParticle = momentum.phi();
-   float vRho = vertex.Rho();
+    // Magnetic field
 
-   // Magnetic field
+    const float RBARM = 1.357;  // was 1.31 , updated on 16122003
+    const float ZENDM = 3.186;  // was 3.15 , updated on 16122003
 
-   const float RBARM = 1.357 ;  	// was 1.31 , updated on 16122003
-   const float ZENDM = 3.186 ;  	// was 3.15 , updated on 16122003
+    float rbend = RBARM - (vRho / 100.0);  //Assumed vRho in cm
+    float bend = 0.3 * magField.inTesla(GlobalPoint(0., 0., 0.)).z() * rbend / 2.0;
+    float phi = 0.0;
 
-   float rbend = RBARM-(vRho/100.0); 	//Assumed vRho in cm
-   float bend  = 0.3 * magField.inTesla(GlobalPoint(0.,0.,0.)).z() * rbend / 2.0; 
-   float phi = 0.0;
-
-   if( fabs(etaParticle) <=  etaBarrelEndcap)
-   {
-      if (fabs(bend/ptParticle) <= 1.) 
-      {
-         phi = phiParticle - asin(bend/ptParticle)*charge;
-	 if(phi >  Geom::pi()) phi = phi - Geom::twoPi();
-	 if(phi < -Geom::pi()) phi = phi + Geom::twoPi();
+    if (fabs(etaParticle) <= etaBarrelEndcap) {
+      if (fabs(bend / ptParticle) <= 1.) {
+        phi = phiParticle - asin(bend / ptParticle) * charge;
+        if (phi > Geom::pi())
+          phi = phi - Geom::twoPi();
+        if (phi < -Geom::pi())
+          phi = phi + Geom::twoPi();
       } else {
-         edm::LogWarning("") << "[EcalPositionFromTrack::phiTransformation] Warning: "
-    			     << "Too low Pt, giving up";
-	 return phiParticle;
+        edm::LogWarning("") << "[EcalPositionFromTrack::phiTransformation] Warning: "
+                            << "Too low Pt, giving up";
+        return phiParticle;
       }
 
-   } // end if in the barrel
-  
-   if(fabs(etaParticle) > etaBarrelEndcap)
-   {
+    }  // end if in the barrel
+
+    if (fabs(etaParticle) > etaBarrelEndcap) {
       float rHit = 0.0;
       rHit = ZENDM / sinh(fabs(etaParticle));
-      if (fabs(((rHit-(vRho/100.0))/rbend)*bend/ptParticle) <= 1.0)
-      {
-         phi = phiParticle - asin(((rHit-(vRho/100.0)) / rbend)*bend/ptParticle)*charge;
-	 if(phi >  Geom::pi()) phi = phi - Geom::twoPi();
-	 if(phi < -Geom::pi()) phi = phi + Geom::twoPi();
+      if (fabs(((rHit - (vRho / 100.0)) / rbend) * bend / ptParticle) <= 1.0) {
+        phi = phiParticle - asin(((rHit - (vRho / 100.0)) / rbend) * bend / ptParticle) * charge;
+        if (phi > Geom::pi())
+          phi = phi - Geom::twoPi();
+        if (phi < -Geom::pi())
+          phi = phi + Geom::twoPi();
       } else {
-         edm::LogWarning("") << "[EcalPositionFromTrack::phiTransformation] Warning: "
-		             << "Too low Pt, giving up";
-	 return phiParticle;
-      }  
+        edm::LogWarning("") << "[EcalPositionFromTrack::phiTransformation] Warning: "
+                            << "Too low Pt, giving up";
+        return phiParticle;
+      }
 
-    } // end if in the endcap
-  
-   return phi;
+    }  // end if in the endcap
 
-}
+    return phi;
+  }
 
-double ecalEta(const math::XYZVector &momentum, const math::XYZPoint &vertex)
-{
+  double ecalEta(const math::XYZVector &momentum, const math::XYZPoint &vertex) {
+    // Get kinematic variables
 
-   // Get kinematic variables
+    float etaParticle = momentum.eta();
+    float vZ = vertex.z();
+    float vRho = vertex.Rho();
 
-   float etaParticle = momentum.eta();
-   float vZ = vertex.z();
-   float vRho = vertex.Rho();
-
-   if (etaParticle != 0.0)
-   {
+    if (etaParticle != 0.0) {
       float theta = 0.0;
-      float zEcal = (R_ECAL-vRho)*sinh(etaParticle)+vZ;
-      
-      if(zEcal != 0.0) theta = atan(R_ECAL/zEcal);
-      if(theta < 0.0) theta = theta + Geom::pi() ;
+      float zEcal = (R_ECAL - vRho) * sinh(etaParticle) + vZ;
 
-      float ETA = - log(tan(0.5*theta));
-      
-      if( fabs(ETA) > etaBarrelEndcap )
-      {
-         float Zend = Z_Endcap ;
-	 if(etaParticle < 0.0 )  Zend = - Zend;
-	 float Zlen = Zend - vZ ;
-	 float RR = Zlen/sinh(etaParticle);
-	 theta = atan((RR+vRho)/Zend);
-	 if(theta < 0.0) theta = theta+Geom::pi();
-	 ETA = -log(tan(0.5*theta));
+      if (zEcal != 0.0)
+        theta = atan(R_ECAL / zEcal);
+      if (theta < 0.0)
+        theta = theta + Geom::pi();
+
+      float ETA = -log(tan(0.5 * theta));
+
+      if (fabs(ETA) > etaBarrelEndcap) {
+        float Zend = Z_Endcap;
+        if (etaParticle < 0.0)
+          Zend = -Zend;
+        float Zlen = Zend - vZ;
+        float RR = Zlen / sinh(etaParticle);
+        theta = atan((RR + vRho) / Zend);
+        if (theta < 0.0)
+          theta = theta + Geom::pi();
+        ETA = -log(tan(0.5 * theta));
       }
       return ETA;
 
     } else {
-       edm::LogWarning("")  << "[EcalPositionFromTrack::etaTransformation] Warning: "
-			    << "Eta equals to zero, not correcting";
-       return etaParticle;
+      edm::LogWarning("") << "[EcalPositionFromTrack::etaTransformation] Warning: "
+                          << "Eta equals to zero, not correcting";
+      return etaParticle;
     }
+  }
 
-}
-
-}
+}  // namespace egammaTools

--- a/RecoEgamma/EgammaTools/src/EGEnergyCorrector.cc
+++ b/RecoEgamma/EgammaTools/src/EGEnergyCorrector.cc
@@ -15,91 +15,96 @@
 using namespace reco;
 
 //--------------------------------------------------------------------------------------------------
-EGEnergyCorrector::EGEnergyCorrector() :
-fReadereb(nullptr),
-fReaderebvariance(nullptr),
-fReaderee(nullptr),
-fReadereevariance(nullptr),
-fIsInitialized(kFALSE),
-fOwnsForests(kFALSE),
-fVals(nullptr)
-{
+EGEnergyCorrector::EGEnergyCorrector()
+    : fReadereb(nullptr),
+      fReaderebvariance(nullptr),
+      fReaderee(nullptr),
+      fReadereevariance(nullptr),
+      fIsInitialized(kFALSE),
+      fOwnsForests(kFALSE),
+      fVals(nullptr) {
   // Constructor.
 }
 
-
 //--------------------------------------------------------------------------------------------------
-EGEnergyCorrector::~EGEnergyCorrector()
-{
-
-  if (fVals) delete [] fVals;
+EGEnergyCorrector::~EGEnergyCorrector() {
+  if (fVals)
+    delete[] fVals;
 
   if (fOwnsForests) {
-    if (fReadereb) delete fReadereb;
-    if (fReaderebvariance) delete fReaderebvariance;
-    if (fReaderee) delete fReaderee;
-    if (fReadereevariance) delete fReadereevariance;
+    if (fReadereb)
+      delete fReadereb;
+    if (fReaderebvariance)
+      delete fReaderebvariance;
+    if (fReaderee)
+      delete fReaderee;
+    if (fReadereevariance)
+      delete fReadereevariance;
   }
-
 }
 
 //--------------------------------------------------------------------------------------------------
 void EGEnergyCorrector::Initialize(const edm::EventSetup &iSetup, std::string regweights, bool weightsFromDB) {
-    fIsInitialized = kTRUE;
+  fIsInitialized = kTRUE;
 
-    if (fVals) delete [] fVals;
-    if (fOwnsForests) {
-      if (fReadereb) delete fReadereb;
-      if (fReaderebvariance) delete fReaderebvariance;
-      if (fReaderee) delete fReaderee;
-      if (fReadereevariance) delete fReadereevariance;
-    }
+  if (fVals)
+    delete[] fVals;
+  if (fOwnsForests) {
+    if (fReadereb)
+      delete fReadereb;
+    if (fReaderebvariance)
+      delete fReaderebvariance;
+    if (fReaderee)
+      delete fReaderee;
+    if (fReadereevariance)
+      delete fReadereevariance;
+  }
 
-    fVals = new Float_t[73];
+  fVals = new Float_t[73];
 
-    if (weightsFromDB) { //weights from event setup
+  if (weightsFromDB) {  //weights from event setup
 
-      edm::ESHandle<GBRForest> readereb;
-      edm::ESHandle<GBRForest> readerebvar;
-      edm::ESHandle<GBRForest> readeree;
-      edm::ESHandle<GBRForest> readereevar;
+    edm::ESHandle<GBRForest> readereb;
+    edm::ESHandle<GBRForest> readerebvar;
+    edm::ESHandle<GBRForest> readeree;
+    edm::ESHandle<GBRForest> readereevar;
 
-      iSetup.get<GBRWrapperRcd>().get(regweights + "_EBCorrection", readereb);
-      iSetup.get<GBRWrapperRcd>().get(regweights + "_EBUncertainty", readerebvar);
-      iSetup.get<GBRWrapperRcd>().get(regweights + "_EECorrection", readeree);
-      iSetup.get<GBRWrapperRcd>().get(regweights + "_EEUncertainty", readereevar);
+    iSetup.get<GBRWrapperRcd>().get(regweights + "_EBCorrection", readereb);
+    iSetup.get<GBRWrapperRcd>().get(regweights + "_EBUncertainty", readerebvar);
+    iSetup.get<GBRWrapperRcd>().get(regweights + "_EECorrection", readeree);
+    iSetup.get<GBRWrapperRcd>().get(regweights + "_EEUncertainty", readereevar);
 
-      fReadereb = readereb.product();
-      fReaderebvariance = readerebvar.product();
-      fReaderee = readeree.product();
-      fReadereevariance = readereevar.product();
+    fReadereb = readereb.product();
+    fReaderebvariance = readerebvar.product();
+    fReaderee = readeree.product();
+    fReadereevariance = readereevar.product();
 
-    }
-    else { //weights from root file
-      fOwnsForests = kTRUE;
+  } else {  //weights from root file
+    fOwnsForests = kTRUE;
 
-      TFile *fgbr = TFile::Open(regweights.c_str(),"READ");
-      fReadereb = (GBRForest*)fgbr->Get("EBCorrection");
-      fReaderebvariance = (GBRForest*)fgbr->Get("EBUncertainty");
-      fReaderee = (GBRForest*)fgbr->Get("EECorrection");
-      fReadereevariance = (GBRForest*)fgbr->Get("EEUncertainty");
-      fgbr->Close();
-    }
-
+    TFile *fgbr = TFile::Open(regweights.c_str(), "READ");
+    fReadereb = (GBRForest *)fgbr->Get("EBCorrection");
+    fReaderebvariance = (GBRForest *)fgbr->Get("EBUncertainty");
+    fReaderee = (GBRForest *)fgbr->Get("EECorrection");
+    fReadereevariance = (GBRForest *)fgbr->Get("EEUncertainty");
+    fgbr->Close();
+  }
 }
 
 //--------------------------------------------------------------------------------------------------
-std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const Photon &p, const reco::VertexCollection& vtxcol, EcalClusterLazyTools &clustertools, const edm::EventSetup &es) {
-
+std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithError(const Photon &p,
+                                                                      const reco::VertexCollection &vtxcol,
+                                                                      EcalClusterLazyTools &clustertools,
+                                                                      const edm::EventSetup &es) {
   const SuperClusterRef s = p.superCluster();
-  const CaloClusterPtr b = s->seed(); //seed  basic cluster
+  const CaloClusterPtr b = s->seed();  //seed  basic cluster
 
   //highest energy basic cluster excluding seed basic cluster
   CaloClusterPtr b2;
   Double_t ebcmax = -99.;
-  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit!=s->clustersEnd(); ++bit) {
+  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit != s->clustersEnd(); ++bit) {
     const CaloClusterPtr bc = *bit;
-    if (bc->energy() > ebcmax && bc !=b) {
+    if (bc->energy() > ebcmax && bc != b) {
       b2 = bc;
       ebcmax = bc->energy();
     }
@@ -108,9 +113,9 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const Photo
   //lowest energy basic cluster excluding seed (for pileup mitigation)
   CaloClusterPtr bclast;
   Double_t ebcmin = 1e6;
-  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit!=s->clustersEnd(); ++bit) {
+  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit != s->clustersEnd(); ++bit) {
     const CaloClusterPtr bc = *bit;
-    if (bc->energy() < ebcmin && bc !=b) {
+    if (bc->energy() < ebcmin && bc != b) {
       bclast = bc;
       ebcmin = bc->energy();
     }
@@ -119,32 +124,29 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const Photo
   //2nd lowest energy basic cluster excluding seed (for pileup mitigation)
   CaloClusterPtr bclast2;
   ebcmin = 1e6;
-  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit!=s->clustersEnd(); ++bit) {
+  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit != s->clustersEnd(); ++bit) {
     const CaloClusterPtr bc = *bit;
-    if (bc->energy() < ebcmin && bc !=b && bc!=bclast) {
+    if (bc->energy() < ebcmin && bc != b && bc != bclast) {
       bclast2 = bc;
       ebcmin = bc->energy();
     }
   }
 
-  Bool_t isbarrel =  b->hitsAndFractions().at(0).first.subdetId()==EcalBarrel;
-  Bool_t hasbc2 = b2.isNonnull() && b2->energy()>0.;
-  Bool_t hasbclast = bclast.isNonnull() && bclast->energy()>0.;
-  Bool_t hasbclast2 = bclast2.isNonnull() && bclast2->energy()>0.;
-
+  Bool_t isbarrel = b->hitsAndFractions().at(0).first.subdetId() == EcalBarrel;
+  Bool_t hasbc2 = b2.isNonnull() && b2->energy() > 0.;
+  Bool_t hasbclast = bclast.isNonnull() && bclast->energy() > 0.;
+  Bool_t hasbclast2 = bclast2.isNonnull() && bclast2->energy() > 0.;
 
   if (isbarrel) {
-
     //basic supercluster variables
-    fVals[0]  = s->rawEnergy();
-    fVals[1]  = p.r9();
-    fVals[2]  = s->eta();
-    fVals[3]  = s->phi();
-    fVals[4]  = p.e5x5()/s->rawEnergy();
+    fVals[0] = s->rawEnergy();
+    fVals[1] = p.r9();
+    fVals[2] = s->eta();
+    fVals[3] = s->phi();
+    fVals[4] = p.e5x5() / s->rawEnergy();
     fVals[5] = p.hadronicOverEm();
     fVals[6] = s->etaWidth();
     fVals[7] = s->phiWidth();
-
 
     //seed basic cluster variables
     double bemax = clustertools.eMax(*b);
@@ -154,24 +156,22 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const Photo
     double beleft = clustertools.eLeft(*b);
     double beright = clustertools.eRight(*b);
 
-
-    fVals[8] = b->eta()-s->eta();
-    fVals[9] = reco::deltaPhi(b->phi(),s->phi());
-    fVals[10] = b->energy()/s->rawEnergy();
-    fVals[11] = clustertools.e3x3(*b)/b->energy();
-    fVals[12] = clustertools.e5x5(*b)/b->energy();
-    fVals[13] = sqrt(clustertools.localCovariances(*b)[0]); //sigietaieta
-    fVals[14] = sqrt(clustertools.localCovariances(*b)[2]); //sigiphiiphi
-    fVals[15] = clustertools.localCovariances(*b)[1];       //sigietaiphi
-    fVals[16] = bemax/b->energy();                       //crystal energy ratio gap variables
-    fVals[17] = log(be2nd/bemax);
-    fVals[18] = log(betop/bemax);
-    fVals[19] = log(bebottom/bemax);
-    fVals[20] = log(beleft/bemax);
-    fVals[21] = log(beright/bemax);
-    fVals[22] = (betop-bebottom)/(betop+bebottom);
-    fVals[23] = (beleft-beright)/(beleft+beright);
-
+    fVals[8] = b->eta() - s->eta();
+    fVals[9] = reco::deltaPhi(b->phi(), s->phi());
+    fVals[10] = b->energy() / s->rawEnergy();
+    fVals[11] = clustertools.e3x3(*b) / b->energy();
+    fVals[12] = clustertools.e5x5(*b) / b->energy();
+    fVals[13] = sqrt(clustertools.localCovariances(*b)[0]);  //sigietaieta
+    fVals[14] = sqrt(clustertools.localCovariances(*b)[2]);  //sigiphiiphi
+    fVals[15] = clustertools.localCovariances(*b)[1];        //sigietaiphi
+    fVals[16] = bemax / b->energy();                         //crystal energy ratio gap variables
+    fVals[17] = log(be2nd / bemax);
+    fVals[18] = log(betop / bemax);
+    fVals[19] = log(bebottom / bemax);
+    fVals[20] = log(beleft / bemax);
+    fVals[21] = log(beright / bemax);
+    fVals[22] = (betop - bebottom) / (betop + bebottom);
+    fVals[23] = (beleft - beright) / (beleft + beright);
 
     double bc2emax = hasbc2 ? clustertools.eMax(*b2) : 0.;
     double bc2e2nd = hasbc2 ? clustertools.e2nd(*b2) : 0.;
@@ -180,91 +180,91 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const Photo
     double bc2eleft = hasbc2 ? clustertools.eLeft(*b2) : 0.;
     double bc2eright = hasbc2 ? clustertools.eRight(*b2) : 0.;
 
-    fVals[24] = hasbc2 ? (b2->eta()-s->eta()) : 0.;
-    fVals[25] = hasbc2 ? reco::deltaPhi(b2->phi(),s->phi()) : 0.;
-    fVals[26] = hasbc2 ? b2->energy()/s->rawEnergy() : 0.;
-    fVals[27] = hasbc2 ? clustertools.e3x3(*b2)/b2->energy() : 0.;
-    fVals[28] = hasbc2 ? clustertools.e5x5(*b2)/b2->energy() : 0.;
+    fVals[24] = hasbc2 ? (b2->eta() - s->eta()) : 0.;
+    fVals[25] = hasbc2 ? reco::deltaPhi(b2->phi(), s->phi()) : 0.;
+    fVals[26] = hasbc2 ? b2->energy() / s->rawEnergy() : 0.;
+    fVals[27] = hasbc2 ? clustertools.e3x3(*b2) / b2->energy() : 0.;
+    fVals[28] = hasbc2 ? clustertools.e5x5(*b2) / b2->energy() : 0.;
     fVals[29] = hasbc2 ? sqrt(clustertools.localCovariances(*b2)[0]) : 0.;
     fVals[30] = hasbc2 ? sqrt(clustertools.localCovariances(*b2)[2]) : 0.;
     fVals[31] = hasbc2 ? clustertools.localCovariances(*b)[1] : 0.;
-    fVals[32] = hasbc2 ? bc2emax/b2->energy() : 0.;
-    fVals[33] = hasbc2 ? log(bc2e2nd/bc2emax) : 0.;
-    fVals[34] = hasbc2 ? log(bc2etop/bc2emax) : 0.;
-    fVals[35] = hasbc2 ? log(bc2ebottom/bc2emax) : 0.;
-    fVals[36] = hasbc2 ? log(bc2eleft/bc2emax) : 0.;
-    fVals[37] = hasbc2 ? log(bc2eright/bc2emax) : 0.;
-    fVals[38] = hasbc2 ? (bc2etop-bc2ebottom)/(bc2etop+bc2ebottom) : 0.;
-    fVals[39] = hasbc2 ? (bc2eleft-bc2eright)/(bc2eleft+bc2eright) : 0.;
+    fVals[32] = hasbc2 ? bc2emax / b2->energy() : 0.;
+    fVals[33] = hasbc2 ? log(bc2e2nd / bc2emax) : 0.;
+    fVals[34] = hasbc2 ? log(bc2etop / bc2emax) : 0.;
+    fVals[35] = hasbc2 ? log(bc2ebottom / bc2emax) : 0.;
+    fVals[36] = hasbc2 ? log(bc2eleft / bc2emax) : 0.;
+    fVals[37] = hasbc2 ? log(bc2eright / bc2emax) : 0.;
+    fVals[38] = hasbc2 ? (bc2etop - bc2ebottom) / (bc2etop + bc2ebottom) : 0.;
+    fVals[39] = hasbc2 ? (bc2eleft - bc2eright) / (bc2eleft + bc2eright) : 0.;
 
-    fVals[40] = hasbclast ? (bclast->eta()-s->eta()) : 0.;
-    fVals[41] = hasbclast ? reco::deltaPhi(bclast->phi(),s->phi()) : 0.;
-    fVals[42] = hasbclast ? bclast->energy()/s->rawEnergy() : 0.;
-    fVals[43] = hasbclast ? clustertools.e3x3(*bclast)/bclast->energy() : 0.;
-    fVals[44] = hasbclast ? clustertools.e5x5(*bclast)/bclast->energy() : 0.;
+    fVals[40] = hasbclast ? (bclast->eta() - s->eta()) : 0.;
+    fVals[41] = hasbclast ? reco::deltaPhi(bclast->phi(), s->phi()) : 0.;
+    fVals[42] = hasbclast ? bclast->energy() / s->rawEnergy() : 0.;
+    fVals[43] = hasbclast ? clustertools.e3x3(*bclast) / bclast->energy() : 0.;
+    fVals[44] = hasbclast ? clustertools.e5x5(*bclast) / bclast->energy() : 0.;
     fVals[45] = hasbclast ? sqrt(clustertools.localCovariances(*bclast)[0]) : 0.;
     fVals[46] = hasbclast ? sqrt(clustertools.localCovariances(*bclast)[2]) : 0.;
     fVals[47] = hasbclast ? clustertools.localCovariances(*bclast)[1] : 0.;
 
-    fVals[48] = hasbclast2 ? (bclast2->eta()-s->eta()) : 0.;
-    fVals[49] = hasbclast2 ? reco::deltaPhi(bclast2->phi(),s->phi()) : 0.;
-    fVals[50] = hasbclast2 ? bclast2->energy()/s->rawEnergy() : 0.;
-    fVals[51] = hasbclast2 ? clustertools.e3x3(*bclast2)/bclast2->energy() : 0.;
-    fVals[52] = hasbclast2 ? clustertools.e5x5(*bclast2)/bclast2->energy() : 0.;
+    fVals[48] = hasbclast2 ? (bclast2->eta() - s->eta()) : 0.;
+    fVals[49] = hasbclast2 ? reco::deltaPhi(bclast2->phi(), s->phi()) : 0.;
+    fVals[50] = hasbclast2 ? bclast2->energy() / s->rawEnergy() : 0.;
+    fVals[51] = hasbclast2 ? clustertools.e3x3(*bclast2) / bclast2->energy() : 0.;
+    fVals[52] = hasbclast2 ? clustertools.e5x5(*bclast2) / bclast2->energy() : 0.;
     fVals[53] = hasbclast2 ? sqrt(clustertools.localCovariances(*bclast2)[0]) : 0.;
     fVals[54] = hasbclast2 ? sqrt(clustertools.localCovariances(*bclast2)[2]) : 0.;
     fVals[55] = hasbclast2 ? clustertools.localCovariances(*bclast2)[1] : 0.;
 
-
     //local coordinates and crystal indices
-
 
     //seed cluster
     float betacry, bphicry, bthetatilt, bphitilt;
     int bieta, biphi;
     edm::ESHandle<CaloGeometry> caloGeometry;
-    es.get<CaloGeometryRecord>().get(caloGeometry); 
-    egammaTools::localEcalClusterCoordsEB(*b,*caloGeometry,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
+    es.get<CaloGeometryRecord>().get(caloGeometry);
+    egammaTools::localEcalClusterCoordsEB(*b, *caloGeometry, betacry, bphicry, bieta, biphi, bthetatilt, bphitilt);
 
-    fVals[56] = bieta; //crystal ieta
-    fVals[57] = biphi; //crystal iphi
-    fVals[58] = bieta%5; //submodule boundary eta symmetry
-    fVals[59] = biphi%2; //submodule boundary phi symmetry
-    fVals[60] = (TMath::Abs(bieta)<=25)*(bieta%25) + (TMath::Abs(bieta)>25)*((bieta-25*TMath::Abs(bieta)/bieta)%20);  //module boundary eta approximate symmetry
-    fVals[61] = biphi%20; //module boundary phi symmetry
-    fVals[62] = betacry; //local coordinates with respect to closest crystal center at nominal shower depth
+    fVals[56] = bieta;      //crystal ieta
+    fVals[57] = biphi;      //crystal iphi
+    fVals[58] = bieta % 5;  //submodule boundary eta symmetry
+    fVals[59] = biphi % 2;  //submodule boundary phi symmetry
+    fVals[60] = (TMath::Abs(bieta) <= 25) * (bieta % 25) +
+                (TMath::Abs(bieta) > 25) *
+                    ((bieta - 25 * TMath::Abs(bieta) / bieta) % 20);  //module boundary eta approximate symmetry
+    fVals[61] = biphi % 20;                                           //module boundary phi symmetry
+    fVals[62] = betacry;  //local coordinates with respect to closest crystal center at nominal shower depth
     fVals[63] = bphicry;
-
 
     //2nd cluster (meaningful gap corrections for converted photons)
     float bc2etacry, bc2phicry, bc2thetatilt, bc2phitilt;
     int bc2ieta, bc2iphi;
-    if (hasbc2) egammaTools::localEcalClusterCoordsEB( *b2,*caloGeometry,bc2etacry,bc2phicry,
-                                                       bc2ieta,bc2iphi,bc2thetatilt,bc2phitilt );
+    if (hasbc2)
+      egammaTools::localEcalClusterCoordsEB(
+          *b2, *caloGeometry, bc2etacry, bc2phicry, bc2ieta, bc2iphi, bc2thetatilt, bc2phitilt);
 
     fVals[64] = hasbc2 ? bc2ieta : 0.;
     fVals[65] = hasbc2 ? bc2iphi : 0.;
-    fVals[66] = hasbc2 ? bc2ieta%5 : 0.;
-    fVals[67] = hasbc2 ? bc2iphi%2 : 0.;
-    fVals[68] = hasbc2 ? (TMath::Abs(bc2ieta)<=25)*(bc2ieta%25) + (TMath::Abs(bc2ieta)>25)*((bc2ieta-25*TMath::Abs(bc2ieta)/bc2ieta)%20) : 0.;
-    fVals[69] = hasbc2 ? bc2iphi%20 : 0.;
+    fVals[66] = hasbc2 ? bc2ieta % 5 : 0.;
+    fVals[67] = hasbc2 ? bc2iphi % 2 : 0.;
+    fVals[68] = hasbc2 ? (TMath::Abs(bc2ieta) <= 25) * (bc2ieta % 25) +
+                             (TMath::Abs(bc2ieta) > 25) * ((bc2ieta - 25 * TMath::Abs(bc2ieta) / bc2ieta) % 20)
+                       : 0.;
+    fVals[69] = hasbc2 ? bc2iphi % 20 : 0.;
     fVals[70] = hasbc2 ? bc2etacry : 0.;
     fVals[71] = hasbc2 ? bc2phicry : 0.;
 
     fVals[72] = vtxcol.size();
 
-  }
-  else {
-    fVals[0]  = s->rawEnergy();
-    fVals[1]  = p.r9();
-    fVals[2]  = s->eta();
-    fVals[3]  = s->phi();
-    fVals[4]  = p.e5x5()/s->rawEnergy();
+  } else {
+    fVals[0] = s->rawEnergy();
+    fVals[1] = p.r9();
+    fVals[2] = s->eta();
+    fVals[3] = s->phi();
+    fVals[4] = p.e5x5() / s->rawEnergy();
     fVals[5] = s->etaWidth();
     fVals[6] = s->phiWidth();
     fVals[7] = vtxcol.size();
   }
-
 
   const Double_t varscale = 1.253;
   Double_t den;
@@ -274,40 +274,40 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const Photo
     den = s->rawEnergy();
     reader = fReadereb;
     readervar = fReaderebvariance;
-  }
-  else {
+  } else {
     den = s->rawEnergy() + s->preshowerEnergy();
     reader = fReaderee;
     readervar = fReadereevariance;
   }
 
-  Double_t ecor = reader->GetResponse(fVals)*den;
-  Double_t ecorerr = readervar->GetResponse(fVals)*den*varscale;
+  Double_t ecor = reader->GetResponse(fVals) * den;
+  Double_t ecorerr = readervar->GetResponse(fVals) * den * varscale;
 
   //printf("ecor = %5f, ecorerr = %5f\n",ecor,ecorerr);
 
-  return std::pair<double,double>(ecor,ecorerr);
+  return std::pair<double, double>(ecor, ecorerr);
 }
 
-
 //--------------------------------------------------------------------------------------------------
-std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const GsfElectron &e, const reco::VertexCollection& vtxcol, EcalClusterLazyTools &clustertools, const edm::EventSetup &es) {
-
+std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithError(const GsfElectron &e,
+                                                                      const reco::VertexCollection &vtxcol,
+                                                                      EcalClusterLazyTools &clustertools,
+                                                                      const edm::EventSetup &es) {
   //apply v2 regression to electrons
   //mostly duplicated from photon function above //TODO, make common underlying function
 
   //protection, this doesn't work properly on non-egamma-seeded electrons
-  if (!e.ecalDrivenSeed()) return std::pair<double,double>(0.,0.);
-
+  if (!e.ecalDrivenSeed())
+    return std::pair<double, double>(0., 0.);
 
   const SuperClusterRef s = e.superCluster();
   const CaloClusterPtr b = s->seed();
 
   CaloClusterPtr b2;
   Double_t ebcmax = -99.;
-  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit!=s->clustersEnd(); ++bit) {
+  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit != s->clustersEnd(); ++bit) {
     const CaloClusterPtr bc = *bit;
-    if (bc->energy() > ebcmax && bc !=b) {
+    if (bc->energy() > ebcmax && bc != b) {
       b2 = bc;
       ebcmax = bc->energy();
     }
@@ -315,9 +315,9 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const GsfEl
 
   CaloClusterPtr bclast;
   Double_t ebcmin = 1e6;
-  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit!=s->clustersEnd(); ++bit) {
+  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit != s->clustersEnd(); ++bit) {
     const CaloClusterPtr bc = *bit;
-    if (bc->energy() < ebcmin && bc !=b) {
+    if (bc->energy() < ebcmin && bc != b) {
       bclast = bc;
       ebcmin = bc->energy();
     }
@@ -325,30 +325,28 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const GsfEl
 
   CaloClusterPtr bclast2;
   ebcmin = 1e6;
-  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit!=s->clustersEnd(); ++bit) {
+  for (reco::CaloCluster_iterator bit = s->clustersBegin(); bit != s->clustersEnd(); ++bit) {
     const CaloClusterPtr bc = *bit;
-    if (bc->energy() < ebcmin && bc !=b && bc!=bclast) {
+    if (bc->energy() < ebcmin && bc != b && bc != bclast) {
       bclast2 = bc;
       ebcmin = bc->energy();
     }
   }
 
-  Bool_t isbarrel =  b->hitsAndFractions().at(0).first.subdetId()==EcalBarrel;
-  Bool_t hasbc2 = b2.isNonnull() && b2->energy()>0.;
-  Bool_t hasbclast = bclast.isNonnull() && bclast->energy()>0.;
-  Bool_t hasbclast2 = bclast2.isNonnull() && bclast2->energy()>0.;
-
+  Bool_t isbarrel = b->hitsAndFractions().at(0).first.subdetId() == EcalBarrel;
+  Bool_t hasbc2 = b2.isNonnull() && b2->energy() > 0.;
+  Bool_t hasbclast = bclast.isNonnull() && bclast->energy() > 0.;
+  Bool_t hasbclast2 = bclast2.isNonnull() && bclast2->energy() > 0.;
 
   if (isbarrel) {
-    fVals[0]  = s->rawEnergy();
-    fVals[1]  = clustertools.e3x3(*b)/s->rawEnergy(); //r9
-    fVals[2]  = s->eta();
-    fVals[3]  = s->phi();
-    fVals[4]  = clustertools.e5x5(*b)/s->rawEnergy();
+    fVals[0] = s->rawEnergy();
+    fVals[1] = clustertools.e3x3(*b) / s->rawEnergy();  //r9
+    fVals[2] = s->eta();
+    fVals[3] = s->phi();
+    fVals[4] = clustertools.e5x5(*b) / s->rawEnergy();
     fVals[5] = e.hcalOverEcal();
     fVals[6] = s->etaWidth();
     fVals[7] = s->phiWidth();
-
 
     double bemax = clustertools.eMax(*b);
     double be2nd = clustertools.e2nd(*b);
@@ -357,24 +355,22 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const GsfEl
     double beleft = clustertools.eLeft(*b);
     double beright = clustertools.eRight(*b);
 
-
-    fVals[8] = b->eta()-s->eta();
-    fVals[9] = reco::deltaPhi(b->phi(),s->phi());
-    fVals[10] = b->energy()/s->rawEnergy();
-    fVals[11] = clustertools.e3x3(*b)/b->energy();
-    fVals[12] = clustertools.e5x5(*b)/b->energy();
+    fVals[8] = b->eta() - s->eta();
+    fVals[9] = reco::deltaPhi(b->phi(), s->phi());
+    fVals[10] = b->energy() / s->rawEnergy();
+    fVals[11] = clustertools.e3x3(*b) / b->energy();
+    fVals[12] = clustertools.e5x5(*b) / b->energy();
     fVals[13] = sqrt(clustertools.localCovariances(*b)[0]);
     fVals[14] = sqrt(clustertools.localCovariances(*b)[2]);
     fVals[15] = clustertools.localCovariances(*b)[1];
-    fVals[16] = bemax/b->energy();
-    fVals[17] = log(be2nd/bemax);
-    fVals[18] = log(betop/bemax);
-    fVals[19] = log(bebottom/bemax);
-    fVals[20] = log(beleft/bemax);
-    fVals[21] = log(beright/bemax);
-    fVals[22] = (betop-bebottom)/(betop+bebottom);
-    fVals[23] = (beleft-beright)/(beleft+beright);
-
+    fVals[16] = bemax / b->energy();
+    fVals[17] = log(be2nd / bemax);
+    fVals[18] = log(betop / bemax);
+    fVals[19] = log(bebottom / bemax);
+    fVals[20] = log(beleft / bemax);
+    fVals[21] = log(beright / bemax);
+    fVals[22] = (betop - bebottom) / (betop + bebottom);
+    fVals[23] = (beleft - beright) / (beleft + beright);
 
     double bc2emax = hasbc2 ? clustertools.eMax(*b2) : 0.;
     double bc2e2nd = hasbc2 ? clustertools.e2nd(*b2) : 0.;
@@ -383,85 +379,86 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const GsfEl
     double bc2eleft = hasbc2 ? clustertools.eLeft(*b2) : 0.;
     double bc2eright = hasbc2 ? clustertools.eRight(*b2) : 0.;
 
-    fVals[24] = hasbc2 ? (b2->eta()-s->eta()) : 0.;
-    fVals[25] = hasbc2 ? reco::deltaPhi(b2->phi(),s->phi()) : 0.;
-    fVals[26] = hasbc2 ? b2->energy()/s->rawEnergy() : 0.;
-    fVals[27] = hasbc2 ? clustertools.e3x3(*b2)/b2->energy() : 0.;
-    fVals[28] = hasbc2 ? clustertools.e5x5(*b2)/b2->energy() : 0.;
+    fVals[24] = hasbc2 ? (b2->eta() - s->eta()) : 0.;
+    fVals[25] = hasbc2 ? reco::deltaPhi(b2->phi(), s->phi()) : 0.;
+    fVals[26] = hasbc2 ? b2->energy() / s->rawEnergy() : 0.;
+    fVals[27] = hasbc2 ? clustertools.e3x3(*b2) / b2->energy() : 0.;
+    fVals[28] = hasbc2 ? clustertools.e5x5(*b2) / b2->energy() : 0.;
     fVals[29] = hasbc2 ? sqrt(clustertools.localCovariances(*b2)[0]) : 0.;
     fVals[30] = hasbc2 ? sqrt(clustertools.localCovariances(*b2)[2]) : 0.;
     fVals[31] = hasbc2 ? clustertools.localCovariances(*b)[1] : 0.;
-    fVals[32] = hasbc2 ? bc2emax/b2->energy() : 0.;
-    fVals[33] = hasbc2 ? log(bc2e2nd/bc2emax) : 0.;
-    fVals[34] = hasbc2 ? log(bc2etop/bc2emax) : 0.;
-    fVals[35] = hasbc2 ? log(bc2ebottom/bc2emax) : 0.;
-    fVals[36] = hasbc2 ? log(bc2eleft/bc2emax) : 0.;
-    fVals[37] = hasbc2 ? log(bc2eright/bc2emax) : 0.;
-    fVals[38] = hasbc2 ? (bc2etop-bc2ebottom)/(bc2etop+bc2ebottom) : 0.;
-    fVals[39] = hasbc2 ? (bc2eleft-bc2eright)/(bc2eleft+bc2eright) : 0.;
+    fVals[32] = hasbc2 ? bc2emax / b2->energy() : 0.;
+    fVals[33] = hasbc2 ? log(bc2e2nd / bc2emax) : 0.;
+    fVals[34] = hasbc2 ? log(bc2etop / bc2emax) : 0.;
+    fVals[35] = hasbc2 ? log(bc2ebottom / bc2emax) : 0.;
+    fVals[36] = hasbc2 ? log(bc2eleft / bc2emax) : 0.;
+    fVals[37] = hasbc2 ? log(bc2eright / bc2emax) : 0.;
+    fVals[38] = hasbc2 ? (bc2etop - bc2ebottom) / (bc2etop + bc2ebottom) : 0.;
+    fVals[39] = hasbc2 ? (bc2eleft - bc2eright) / (bc2eleft + bc2eright) : 0.;
 
-    fVals[40] = hasbclast ? (bclast->eta()-s->eta()) : 0.;
-    fVals[41] = hasbclast ? reco::deltaPhi(bclast->phi(),s->phi()) : 0.;
-    fVals[42] = hasbclast ? bclast->energy()/s->rawEnergy() : 0.;
-    fVals[43] = hasbclast ? clustertools.e3x3(*bclast)/bclast->energy() : 0.;
-    fVals[44] = hasbclast ? clustertools.e5x5(*bclast)/bclast->energy() : 0.;
+    fVals[40] = hasbclast ? (bclast->eta() - s->eta()) : 0.;
+    fVals[41] = hasbclast ? reco::deltaPhi(bclast->phi(), s->phi()) : 0.;
+    fVals[42] = hasbclast ? bclast->energy() / s->rawEnergy() : 0.;
+    fVals[43] = hasbclast ? clustertools.e3x3(*bclast) / bclast->energy() : 0.;
+    fVals[44] = hasbclast ? clustertools.e5x5(*bclast) / bclast->energy() : 0.;
     fVals[45] = hasbclast ? sqrt(clustertools.localCovariances(*bclast)[0]) : 0.;
     fVals[46] = hasbclast ? sqrt(clustertools.localCovariances(*bclast)[2]) : 0.;
     fVals[47] = hasbclast ? clustertools.localCovariances(*bclast)[1] : 0.;
 
-    fVals[48] = hasbclast2 ? (bclast2->eta()-s->eta()) : 0.;
-    fVals[49] = hasbclast2 ? reco::deltaPhi(bclast2->phi(),s->phi()) : 0.;
-    fVals[50] = hasbclast2 ? bclast2->energy()/s->rawEnergy() : 0.;
-    fVals[51] = hasbclast2 ? clustertools.e3x3(*bclast2)/bclast2->energy() : 0.;
-    fVals[52] = hasbclast2 ? clustertools.e5x5(*bclast2)/bclast2->energy() : 0.;
+    fVals[48] = hasbclast2 ? (bclast2->eta() - s->eta()) : 0.;
+    fVals[49] = hasbclast2 ? reco::deltaPhi(bclast2->phi(), s->phi()) : 0.;
+    fVals[50] = hasbclast2 ? bclast2->energy() / s->rawEnergy() : 0.;
+    fVals[51] = hasbclast2 ? clustertools.e3x3(*bclast2) / bclast2->energy() : 0.;
+    fVals[52] = hasbclast2 ? clustertools.e5x5(*bclast2) / bclast2->energy() : 0.;
     fVals[53] = hasbclast2 ? sqrt(clustertools.localCovariances(*bclast2)[0]) : 0.;
     fVals[54] = hasbclast2 ? sqrt(clustertools.localCovariances(*bclast2)[2]) : 0.;
     fVals[55] = hasbclast2 ? clustertools.localCovariances(*bclast2)[1] : 0.;
 
-
     float betacry, bphicry, bthetatilt, bphitilt;
     int bieta, biphi;
     edm::ESHandle<CaloGeometry> caloGeometry;
-    es.get<CaloGeometryRecord>().get(caloGeometry); 
-    egammaTools::localEcalClusterCoordsEB(*b,*caloGeometry,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
+    es.get<CaloGeometryRecord>().get(caloGeometry);
+    egammaTools::localEcalClusterCoordsEB(*b, *caloGeometry, betacry, bphicry, bieta, biphi, bthetatilt, bphitilt);
 
     fVals[56] = bieta;
     fVals[57] = biphi;
-    fVals[58] = bieta%5;
-    fVals[59] = biphi%2;
-    fVals[60] = (TMath::Abs(bieta)<=25)*(bieta%25) + (TMath::Abs(bieta)>25)*((bieta-25*TMath::Abs(bieta)/bieta)%20);
-    fVals[61] = biphi%20;
+    fVals[58] = bieta % 5;
+    fVals[59] = biphi % 2;
+    fVals[60] = (TMath::Abs(bieta) <= 25) * (bieta % 25) +
+                (TMath::Abs(bieta) > 25) * ((bieta - 25 * TMath::Abs(bieta) / bieta) % 20);
+    fVals[61] = biphi % 20;
     fVals[62] = betacry;
     fVals[63] = bphicry;
 
     float bc2etacry, bc2phicry, bc2thetatilt, bc2phitilt;
     int bc2ieta, bc2iphi;
-    if (hasbc2) egammaTools::localEcalClusterCoordsEB( *b2,*caloGeometry,bc2etacry,bc2phicry,
-                                                       bc2ieta,bc2iphi,bc2thetatilt,bc2phitilt );
+    if (hasbc2)
+      egammaTools::localEcalClusterCoordsEB(
+          *b2, *caloGeometry, bc2etacry, bc2phicry, bc2ieta, bc2iphi, bc2thetatilt, bc2phitilt);
 
     fVals[64] = hasbc2 ? bc2ieta : 0.;
     fVals[65] = hasbc2 ? bc2iphi : 0.;
-    fVals[66] = hasbc2 ? bc2ieta%5 : 0.;
-    fVals[67] = hasbc2 ? bc2iphi%2 : 0.;
-    fVals[68] = hasbc2 ? (TMath::Abs(bc2ieta)<=25)*(bc2ieta%25) + (TMath::Abs(bc2ieta)>25)*((bc2ieta-25*TMath::Abs(bc2ieta)/bc2ieta)%20) : 0.;
-    fVals[69] = hasbc2 ? bc2iphi%20 : 0.;
+    fVals[66] = hasbc2 ? bc2ieta % 5 : 0.;
+    fVals[67] = hasbc2 ? bc2iphi % 2 : 0.;
+    fVals[68] = hasbc2 ? (TMath::Abs(bc2ieta) <= 25) * (bc2ieta % 25) +
+                             (TMath::Abs(bc2ieta) > 25) * ((bc2ieta - 25 * TMath::Abs(bc2ieta) / bc2ieta) % 20)
+                       : 0.;
+    fVals[69] = hasbc2 ? bc2iphi % 20 : 0.;
     fVals[70] = hasbc2 ? bc2etacry : 0.;
     fVals[71] = hasbc2 ? bc2phicry : 0.;
 
     fVals[72] = vtxcol.size();
 
-  }
-  else {
-    fVals[0]  = s->rawEnergy();
-    fVals[1]  = clustertools.e3x3(*b)/s->rawEnergy(); //r9
-    fVals[2]  = s->eta();
-    fVals[3]  = s->phi();
-    fVals[4]  = clustertools.e5x5(*b)/s->rawEnergy();
+  } else {
+    fVals[0] = s->rawEnergy();
+    fVals[1] = clustertools.e3x3(*b) / s->rawEnergy();  //r9
+    fVals[2] = s->eta();
+    fVals[3] = s->phi();
+    fVals[4] = clustertools.e5x5(*b) / s->rawEnergy();
     fVals[5] = s->etaWidth();
     fVals[6] = s->phiWidth();
     fVals[7] = vtxcol.size();
   }
-
 
   const Double_t varscale = 1.253;
   Double_t den;
@@ -471,36 +468,38 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const GsfEl
     den = s->rawEnergy();
     reader = fReadereb;
     readervar = fReaderebvariance;
-  }
-  else {
+  } else {
     den = s->rawEnergy() + s->preshowerEnergy();
     reader = fReaderee;
     readervar = fReadereevariance;
   }
 
-  Double_t ecor = reader->GetResponse(fVals)*den;
-  Double_t ecorerr = readervar->GetResponse(fVals)*den*varscale;
+  Double_t ecor = reader->GetResponse(fVals) * den;
+  Double_t ecorerr = readervar->GetResponse(fVals) * den * varscale;
 
   //printf("ecor = %5f, ecorerr = %5f\n",ecor,ecorerr);
 
-  return std::pair<double,double>(ecor,ecorerr);
-
+  return std::pair<double, double>(ecor, ecorerr);
 }
 
 //--------------------------------------------------------------------------------------------------
-std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Photon &p, const reco::VertexCollection& vtxcol, double rho, EcalClusterLazyTools &clustertools, const edm::EventSetup &es, bool applyRescale) {
-
+std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Photon &p,
+                                                                        const reco::VertexCollection &vtxcol,
+                                                                        double rho,
+                                                                        EcalClusterLazyTools &clustertools,
+                                                                        const edm::EventSetup &es,
+                                                                        bool applyRescale) {
   const SuperClusterRef s = p.superCluster();
-  const CaloClusterPtr b = s->seed(); //seed  basic cluster
+  const CaloClusterPtr b = s->seed();  //seed  basic cluster
 
-  Bool_t isbarrel =  b->hitsAndFractions().at(0).first.subdetId()==EcalBarrel;
+  Bool_t isbarrel = b->hitsAndFractions().at(0).first.subdetId() == EcalBarrel;
 
   //basic supercluster variables
-  fVals[0]  = s->rawEnergy();
-  fVals[1]  = s->eta();
-  fVals[2]  = s->phi();
-  fVals[3]  = p.r9();
-  fVals[4]  = p.e5x5()/s->rawEnergy();
+  fVals[0] = s->rawEnergy();
+  fVals[1] = s->eta();
+  fVals[2] = s->phi();
+  fVals[3] = p.r9();
+  fVals[4] = p.e5x5() / s->rawEnergy();
   fVals[5] = s->etaWidth();
   fVals[6] = s->phiWidth();
   fVals[7] = s->clustersSize();
@@ -522,25 +521,25 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Pho
   double be2x5left = clustertools.e2x5Left(*b);
   double be2x5right = clustertools.e2x5Right(*b);
 
-  fVals[11] = b->eta()-s->eta();
-  fVals[12] = reco::deltaPhi(b->phi(),s->phi());
-  fVals[13] = b->energy()/s->rawEnergy();
-  fVals[14] = clustertools.e3x3(*b)/b->energy();
-  fVals[15] = clustertools.e5x5(*b)/b->energy();
-  fVals[16] = sqrt(clustertools.localCovariances(*b)[0]); //sigietaieta
-  fVals[17] = sqrt(clustertools.localCovariances(*b)[2]); //sigiphiiphi
-  fVals[18] = clustertools.localCovariances(*b)[1];       //sigietaiphi
-  fVals[19] = bemax/b->energy();                       //crystal energy ratio gap variables
-  fVals[20] = be2nd/b->energy();
-  fVals[21] = betop/b->energy();
-  fVals[22] = bebottom/b->energy();
-  fVals[23] = beleft/b->energy();
-  fVals[24] = beright/b->energy();
-  fVals[25] = be2x5max/b->energy();                       //crystal energy ratio gap variables
-  fVals[26] = be2x5top/b->energy();
-  fVals[27] = be2x5bottom/b->energy();
-  fVals[28] = be2x5left/b->energy();
-  fVals[29] = be2x5right/b->energy();
+  fVals[11] = b->eta() - s->eta();
+  fVals[12] = reco::deltaPhi(b->phi(), s->phi());
+  fVals[13] = b->energy() / s->rawEnergy();
+  fVals[14] = clustertools.e3x3(*b) / b->energy();
+  fVals[15] = clustertools.e5x5(*b) / b->energy();
+  fVals[16] = sqrt(clustertools.localCovariances(*b)[0]);  //sigietaieta
+  fVals[17] = sqrt(clustertools.localCovariances(*b)[2]);  //sigiphiiphi
+  fVals[18] = clustertools.localCovariances(*b)[1];        //sigietaiphi
+  fVals[19] = bemax / b->energy();                         //crystal energy ratio gap variables
+  fVals[20] = be2nd / b->energy();
+  fVals[21] = betop / b->energy();
+  fVals[22] = bebottom / b->energy();
+  fVals[23] = beleft / b->energy();
+  fVals[24] = beright / b->energy();
+  fVals[25] = be2x5max / b->energy();  //crystal energy ratio gap variables
+  fVals[26] = be2x5top / b->energy();
+  fVals[27] = be2x5bottom / b->energy();
+  fVals[28] = be2x5left / b->energy();
+  fVals[29] = be2x5right / b->energy();
 
   if (isbarrel) {
     //local coordinates and crystal indices (barrel only)
@@ -549,28 +548,29 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Pho
     float betacry, bphicry, bthetatilt, bphitilt;
     int bieta, biphi;
     edm::ESHandle<CaloGeometry> caloGeometry;
-    es.get<CaloGeometryRecord>().get(caloGeometry); 
-    egammaTools::localEcalClusterCoordsEB(*b,*caloGeometry,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
+    es.get<CaloGeometryRecord>().get(caloGeometry);
+    egammaTools::localEcalClusterCoordsEB(*b, *caloGeometry, betacry, bphicry, bieta, biphi, bthetatilt, bphitilt);
 
-    fVals[30] = bieta; //crystal ieta
-    fVals[31] = biphi; //crystal iphi
-    fVals[32] = bieta%5; //submodule boundary eta symmetry
-    fVals[33] = biphi%2; //submodule boundary phi symmetry
-    fVals[34] = (TMath::Abs(bieta)<=25)*(bieta%25) + (TMath::Abs(bieta)>25)*((bieta-25*TMath::Abs(bieta)/bieta)%20);  //module boundary eta approximate symmetry
-    fVals[35] = biphi%20; //module boundary phi symmetry
-    fVals[36] = betacry; //local coordinates with respect to closest crystal center at nominal shower depth
+    fVals[30] = bieta;      //crystal ieta
+    fVals[31] = biphi;      //crystal iphi
+    fVals[32] = bieta % 5;  //submodule boundary eta symmetry
+    fVals[33] = biphi % 2;  //submodule boundary phi symmetry
+    fVals[34] = (TMath::Abs(bieta) <= 25) * (bieta % 25) +
+                (TMath::Abs(bieta) > 25) *
+                    ((bieta - 25 * TMath::Abs(bieta) / bieta) % 20);  //module boundary eta approximate symmetry
+    fVals[35] = biphi % 20;                                           //module boundary phi symmetry
+    fVals[36] = betacry;  //local coordinates with respect to closest crystal center at nominal shower depth
     fVals[37] = bphicry;
 
-  }
-  else {
+  } else {
     //preshower energy ratio (endcap only)
-    fVals[30]  = s->preshowerEnergy()/s->rawEnergy();
+    fVals[30] = s->preshowerEnergy() / s->rawEnergy();
   }
 
-//   if (isbarrel) {
-//     for (int i=0; i<38; ++i) printf("%i: %5f\n",i,fVals[i]);
-//   }
-//   else for (int i=0; i<31; ++i) printf("%i: %5f\n",i,fVals[i]);
+  //   if (isbarrel) {
+  //     for (int i=0; i<38; ++i) printf("%i: %5f\n",i,fVals[i]);
+  //   }
+  //   else for (int i=0; i<31; ++i) printf("%i: %5f\n",i,fVals[i]);
 
   Double_t den;
   const GBRForest *reader;
@@ -579,92 +579,92 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Pho
     den = s->rawEnergy();
     reader = fReadereb;
     readervar = fReaderebvariance;
-  }
-  else {
+  } else {
     den = s->rawEnergy() + s->preshowerEnergy();
     reader = fReaderee;
     readervar = fReadereevariance;
   }
 
-  Double_t ecor = reader->GetResponse(fVals)*den;
-
+  Double_t ecor = reader->GetResponse(fVals) * den;
 
   //apply shower shape rescaling - for Monte Carlo only, and only for calculation of energy uncertainty
   if (applyRescale) {
     if (isbarrel) {
-      fVals[3] = 1.0045*p.r9() +0.001; //r9
-      fVals[5] = 1.04302*s->etaWidth() - 0.000618; //etawidth
-      fVals[6] = 1.00002*s->phiWidth() - 0.000371;  //phiwidth
-      fVals[14] = fVals[3]*s->rawEnergy()/b->energy();  //compute consistent e3x3/eseed after r9 rescaling
-      if (fVals[15]<=1.0)  // rescale e5x5/eseed only if value is <=1.0, don't allow scaled values to exceed 1.0
-        fVals[15] = TMath::Min(1.0,1.0022*p.e5x5()/b->energy());
+      fVals[3] = 1.0045 * p.r9() + 0.001;                   //r9
+      fVals[5] = 1.04302 * s->etaWidth() - 0.000618;        //etawidth
+      fVals[6] = 1.00002 * s->phiWidth() - 0.000371;        //phiwidth
+      fVals[14] = fVals[3] * s->rawEnergy() / b->energy();  //compute consistent e3x3/eseed after r9 rescaling
+      if (fVals[15] <= 1.0)  // rescale e5x5/eseed only if value is <=1.0, don't allow scaled values to exceed 1.0
+        fVals[15] = TMath::Min(1.0, 1.0022 * p.e5x5() / b->energy());
 
-      fVals[4] = fVals[15]*b->energy()/s->rawEnergy(); // compute consistent e5x5()/rawEnergy() after e5x5/eseed resacling
+      fVals[4] =
+          fVals[15] * b->energy() / s->rawEnergy();  // compute consistent e5x5()/rawEnergy() after e5x5/eseed resacling
 
-      fVals[16] = 0.891832*sqrt(clustertools.localCovariances(*b)[0]) + 0.0009133; //sigietaieta
-      fVals[17] = 0.993*sqrt(clustertools.localCovariances(*b)[2]); //sigiphiiphi
+      fVals[16] = 0.891832 * sqrt(clustertools.localCovariances(*b)[0]) + 0.0009133;  //sigietaieta
+      fVals[17] = 0.993 * sqrt(clustertools.localCovariances(*b)[2]);                 //sigiphiiphi
 
-      fVals[19] = 1.012*bemax/b->energy();                       //crystal energy ratio gap variables
-      fVals[20] = 1.0*be2nd/b->energy();
-      fVals[21] = 0.94*betop/b->energy();
-      fVals[22] = 0.94*bebottom/b->energy();
-      fVals[23] = 0.94*beleft/b->energy();
-      fVals[24] = 0.94*beright/b->energy();
-      fVals[25] = 1.006*be2x5max/b->energy();                       //crystal energy ratio gap variables
-      fVals[26] = 1.09*be2x5top/b->energy();
-      fVals[27] = 1.09*be2x5bottom/b->energy();
-      fVals[28] = 1.09*be2x5left/b->energy();
-      fVals[29] = 1.09*be2x5right/b->energy();
+      fVals[19] = 1.012 * bemax / b->energy();  //crystal energy ratio gap variables
+      fVals[20] = 1.0 * be2nd / b->energy();
+      fVals[21] = 0.94 * betop / b->energy();
+      fVals[22] = 0.94 * bebottom / b->energy();
+      fVals[23] = 0.94 * beleft / b->energy();
+      fVals[24] = 0.94 * beright / b->energy();
+      fVals[25] = 1.006 * be2x5max / b->energy();  //crystal energy ratio gap variables
+      fVals[26] = 1.09 * be2x5top / b->energy();
+      fVals[27] = 1.09 * be2x5bottom / b->energy();
+      fVals[28] = 1.09 * be2x5left / b->energy();
+      fVals[29] = 1.09 * be2x5right / b->energy();
 
+    } else {
+      fVals[3] = 1.0086 * p.r9() - 0.0007;                             //r9
+      fVals[4] = TMath::Min(1.0, 1.0022 * p.e5x5() / s->rawEnergy());  //e5x5/rawenergy
+      fVals[5] = 0.903254 * s->etaWidth() + 0.001346;                  //etawidth
+      fVals[6] = 0.99992 * s->phiWidth() + 4.8e-07;                    //phiwidth
+      fVals[13] =
+          TMath::Min(1.0, 1.0022 * b->energy() / s->rawEnergy());  //eseed/rawenergy (practically equivalent to e5x5)
+
+      fVals[14] = fVals[3] * s->rawEnergy() / b->energy();  //compute consistent e3x3/eseed after r9 rescaling
+
+      fVals[16] = 0.9947 * sqrt(clustertools.localCovariances(*b)[0]) + 0.00003;  //sigietaieta
+
+      fVals[19] = 1.005 * bemax / b->energy();  //crystal energy ratio gap variables
+      fVals[20] = 1.02 * be2nd / b->energy();
+      fVals[21] = 0.96 * betop / b->energy();
+      fVals[22] = 0.96 * bebottom / b->energy();
+      fVals[23] = 0.96 * beleft / b->energy();
+      fVals[24] = 0.96 * beright / b->energy();
+      fVals[25] = 1.0075 * be2x5max / b->energy();  //crystal energy ratio gap variables
+      fVals[26] = 1.13 * be2x5top / b->energy();
+      fVals[27] = 1.13 * be2x5bottom / b->energy();
+      fVals[28] = 1.13 * be2x5left / b->energy();
+      fVals[29] = 1.13 * be2x5right / b->energy();
     }
-    else {
-      fVals[3] = 1.0086*p.r9() -0.0007;           //r9
-      fVals[4] = TMath::Min(1.0,1.0022*p.e5x5()/s->rawEnergy());  //e5x5/rawenergy
-      fVals[5] = 0.903254*s->etaWidth() +0.001346;  //etawidth
-      fVals[6] = 0.99992*s->phiWidth() +  4.8e-07;   //phiwidth
-      fVals[13] = TMath::Min(1.0,1.0022*b->energy()/s->rawEnergy());  //eseed/rawenergy (practically equivalent to e5x5)
-
-
-      fVals[14] = fVals[3]*s->rawEnergy()/b->energy(); //compute consistent e3x3/eseed after r9 rescaling
-
-      fVals[16] = 0.9947*sqrt(clustertools.localCovariances(*b)[0]) + 0.00003; //sigietaieta
-
-      fVals[19] = 1.005*bemax/b->energy();                       //crystal energy ratio gap variables
-      fVals[20] = 1.02*be2nd/b->energy();
-      fVals[21] = 0.96*betop/b->energy();
-      fVals[22] = 0.96*bebottom/b->energy();
-      fVals[23] = 0.96*beleft/b->energy();
-      fVals[24] = 0.96*beright/b->energy();
-      fVals[25] = 1.0075*be2x5max/b->energy();                       //crystal energy ratio gap variables
-      fVals[26] = 1.13*be2x5top/b->energy();
-      fVals[27] = 1.13*be2x5bottom/b->energy();
-      fVals[28] = 1.13*be2x5left/b->energy();
-      fVals[29] = 1.13*be2x5right/b->energy();
-    }
-
   }
 
-  Double_t ecorerr = readervar->GetResponse(fVals)*den;
+  Double_t ecorerr = readervar->GetResponse(fVals) * den;
 
   //printf("ecor = %5f, ecorerr = %5f\n",ecor,ecorerr);
 
-  return std::pair<double,double>(ecor,ecorerr);
+  return std::pair<double, double>(ecor, ecorerr);
 }
 
 //--------------------------------------------------------------------------------------------------
-std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const GsfElectron &e, const reco::VertexCollection& vtxcol, double rho, EcalClusterLazyTools &clustertools, const edm::EventSetup &es) {
-
+std::pair<double, double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const GsfElectron &e,
+                                                                        const reco::VertexCollection &vtxcol,
+                                                                        double rho,
+                                                                        EcalClusterLazyTools &clustertools,
+                                                                        const edm::EventSetup &es) {
   const SuperClusterRef s = e.superCluster();
-  const CaloClusterPtr b = s->seed(); //seed  basic cluster
+  const CaloClusterPtr b = s->seed();  //seed  basic cluster
 
-  Bool_t isbarrel =  b->hitsAndFractions().at(0).first.subdetId()==EcalBarrel;
+  Bool_t isbarrel = b->hitsAndFractions().at(0).first.subdetId() == EcalBarrel;
 
   //basic supercluster variables
-  fVals[0]  = s->rawEnergy();
-  fVals[1]  = s->eta();
-  fVals[2]  = s->phi();
-  fVals[3]  = clustertools.e3x3(*b)/s->rawEnergy(); //r9
-  fVals[4]  = clustertools.e5x5(*b)/s->rawEnergy();
+  fVals[0] = s->rawEnergy();
+  fVals[1] = s->eta();
+  fVals[2] = s->phi();
+  fVals[3] = clustertools.e3x3(*b) / s->rawEnergy();  //r9
+  fVals[4] = clustertools.e5x5(*b) / s->rawEnergy();
   fVals[5] = s->etaWidth();
   fVals[6] = s->phiWidth();
   fVals[7] = s->clustersSize();
@@ -686,25 +686,25 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Gsf
   double be2x5left = clustertools.e2x5Left(*b);
   double be2x5right = clustertools.e2x5Right(*b);
 
-  fVals[11] = b->eta()-s->eta();
-  fVals[12] = reco::deltaPhi(b->phi(),s->phi());
-  fVals[13] = b->energy()/s->rawEnergy();
-  fVals[14] = clustertools.e3x3(*b)/b->energy();
-  fVals[15] = clustertools.e5x5(*b)/b->energy();
-  fVals[16] = sqrt(clustertools.localCovariances(*b)[0]); //sigietaieta
-  fVals[17] = sqrt(clustertools.localCovariances(*b)[2]); //sigiphiiphi
-  fVals[18] = clustertools.localCovariances(*b)[1];       //sigietaiphi
-  fVals[19] = bemax/b->energy();                       //crystal energy ratio gap variables
-  fVals[20] = be2nd/b->energy();
-  fVals[21] = betop/b->energy();
-  fVals[22] = bebottom/b->energy();
-  fVals[23] = beleft/b->energy();
-  fVals[24] = beright/b->energy();
-  fVals[25] = be2x5max/b->energy();                       //crystal energy ratio gap variables
-  fVals[26] = be2x5top/b->energy();
-  fVals[27] = be2x5bottom/b->energy();
-  fVals[28] = be2x5left/b->energy();
-  fVals[29] = be2x5right/b->energy();
+  fVals[11] = b->eta() - s->eta();
+  fVals[12] = reco::deltaPhi(b->phi(), s->phi());
+  fVals[13] = b->energy() / s->rawEnergy();
+  fVals[14] = clustertools.e3x3(*b) / b->energy();
+  fVals[15] = clustertools.e5x5(*b) / b->energy();
+  fVals[16] = sqrt(clustertools.localCovariances(*b)[0]);  //sigietaieta
+  fVals[17] = sqrt(clustertools.localCovariances(*b)[2]);  //sigiphiiphi
+  fVals[18] = clustertools.localCovariances(*b)[1];        //sigietaiphi
+  fVals[19] = bemax / b->energy();                         //crystal energy ratio gap variables
+  fVals[20] = be2nd / b->energy();
+  fVals[21] = betop / b->energy();
+  fVals[22] = bebottom / b->energy();
+  fVals[23] = beleft / b->energy();
+  fVals[24] = beright / b->energy();
+  fVals[25] = be2x5max / b->energy();  //crystal energy ratio gap variables
+  fVals[26] = be2x5top / b->energy();
+  fVals[27] = be2x5bottom / b->energy();
+  fVals[28] = be2x5left / b->energy();
+  fVals[29] = be2x5right / b->energy();
 
   if (isbarrel) {
     //local coordinates and crystal indices (barrel only)
@@ -713,22 +713,23 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Gsf
     float betacry, bphicry, bthetatilt, bphitilt;
     int bieta, biphi;
     edm::ESHandle<CaloGeometry> caloGeometry;
-    es.get<CaloGeometryRecord>().get(caloGeometry); 
-    egammaTools::localEcalClusterCoordsEB(*b,*caloGeometry,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
+    es.get<CaloGeometryRecord>().get(caloGeometry);
+    egammaTools::localEcalClusterCoordsEB(*b, *caloGeometry, betacry, bphicry, bieta, biphi, bthetatilt, bphitilt);
 
-    fVals[30] = bieta; //crystal ieta
-    fVals[31] = biphi; //crystal iphi
-    fVals[32] = bieta%5; //submodule boundary eta symmetry
-    fVals[33] = biphi%2; //submodule boundary phi symmetry
-    fVals[34] = (TMath::Abs(bieta)<=25)*(bieta%25) + (TMath::Abs(bieta)>25)*((bieta-25*TMath::Abs(bieta)/bieta)%20);  //module boundary eta approximate symmetry
-    fVals[35] = biphi%20; //module boundary phi symmetry
-    fVals[36] = betacry; //local coordinates with respect to closest crystal center at nominal shower depth
+    fVals[30] = bieta;      //crystal ieta
+    fVals[31] = biphi;      //crystal iphi
+    fVals[32] = bieta % 5;  //submodule boundary eta symmetry
+    fVals[33] = biphi % 2;  //submodule boundary phi symmetry
+    fVals[34] = (TMath::Abs(bieta) <= 25) * (bieta % 25) +
+                (TMath::Abs(bieta) > 25) *
+                    ((bieta - 25 * TMath::Abs(bieta) / bieta) % 20);  //module boundary eta approximate symmetry
+    fVals[35] = biphi % 20;                                           //module boundary phi symmetry
+    fVals[36] = betacry;  //local coordinates with respect to closest crystal center at nominal shower depth
     fVals[37] = bphicry;
 
-  }
-  else {
+  } else {
     //preshower energy ratio (endcap only)
-    fVals[30]  = s->preshowerEnergy()/s->rawEnergy();
+    fVals[30] = s->preshowerEnergy() / s->rawEnergy();
   }
 
   Double_t den;
@@ -738,18 +739,16 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Gsf
     den = s->rawEnergy();
     reader = fReadereb;
     readervar = fReaderebvariance;
-  }
-  else {
+  } else {
     den = s->rawEnergy() + s->preshowerEnergy();
     reader = fReaderee;
     readervar = fReadereevariance;
   }
 
-  Double_t ecor = reader->GetResponse(fVals)*den;
-  Double_t ecorerr = readervar->GetResponse(fVals)*den;
+  Double_t ecor = reader->GetResponse(fVals) * den;
+  Double_t ecorerr = readervar->GetResponse(fVals) * den;
 
   //printf("ecor = %5f, ecorerr = %5f\n",ecor,ecorerr);
 
-  return std::pair<double,double>(ecor,ecorerr);
+  return std::pair<double, double>(ecor, ecorerr);
 }
-

--- a/RecoEgamma/EgammaTools/src/EGEnergySysIndex.cc
+++ b/RecoEgamma/EgammaTools/src/EGEnergySysIndex.cc
@@ -1,38 +1,35 @@
 #include "RecoEgamma/EgammaTools/interface/EGEnergySysIndex.h"
 
-namespace{
-  std::array<std::string,EGEnergySysIndex::kNrSysErrs> makeEGEnergySysNames(){
-    std::array<std::string,EGEnergySysIndex::kNrSysErrs> names;
-    names[EGEnergySysIndex::kScaleUp] = "energyScaleUp"; 
-    names[EGEnergySysIndex::kScaleDown] = "energyScaleDown"; 
-    names[EGEnergySysIndex::kScaleStatUp] = "energyScaleStatUp"; 
-    names[EGEnergySysIndex::kScaleStatDown] = "energyScaleStatDown"; 
-    names[EGEnergySysIndex::kScaleSystUp] = "energyScaleSystUp"; 
-    names[EGEnergySysIndex::kScaleSystDown] = "energyScaleSystDown"; 
-    names[EGEnergySysIndex::kScaleGainUp] = "energyScaleGainUp"; 
-    names[EGEnergySysIndex::kScaleGainDown] = "energyScaleGainDown"; 
-    names[EGEnergySysIndex::kSmearUp] = "energySigmaUp"; 
-    names[EGEnergySysIndex::kSmearDown] = "energySigmaDown"; 
-    names[EGEnergySysIndex::kSmearRhoUp] = "energySigmaRhoUp"; 
-    names[EGEnergySysIndex::kSmearRhoDown] = "energySigmaRhoDown"; 
-    names[EGEnergySysIndex::kSmearPhiUp] = "energySigmaPhiUp"; 
-    names[EGEnergySysIndex::kSmearPhiDown] = "energySigmaPhiDown"; 
-    names[EGEnergySysIndex::kScaleValue] = "energyScaleValue"; 
-    names[EGEnergySysIndex::kSmearValue] = "energySigmaValue"; 
-    names[EGEnergySysIndex::kSmearNrSigma] = "energySmearNrSigma"; 
-    names[EGEnergySysIndex::kEcalPreCorr] = "ecalEnergyPreCorr"; 
-    names[EGEnergySysIndex::kEcalErrPreCorr] = "ecalEnergyErrPreCorr"; 
-    names[EGEnergySysIndex::kEcalPostCorr] = "ecalEnergyPostCorr"; 
-    names[EGEnergySysIndex::kEcalErrPostCorr] = "ecalEnergyErrPostCorr"; 
-    names[EGEnergySysIndex::kEcalTrkPreCorr] = "ecalTrkEnergyPreCorr"; 
-    names[EGEnergySysIndex::kEcalTrkErrPreCorr] = "ecalTrkEnergyErrPreCorr";  
-    names[EGEnergySysIndex::kEcalTrkPostCorr] = "ecalTrkEnergyPostCorr"; 
+namespace {
+  std::array<std::string, EGEnergySysIndex::kNrSysErrs> makeEGEnergySysNames() {
+    std::array<std::string, EGEnergySysIndex::kNrSysErrs> names;
+    names[EGEnergySysIndex::kScaleUp] = "energyScaleUp";
+    names[EGEnergySysIndex::kScaleDown] = "energyScaleDown";
+    names[EGEnergySysIndex::kScaleStatUp] = "energyScaleStatUp";
+    names[EGEnergySysIndex::kScaleStatDown] = "energyScaleStatDown";
+    names[EGEnergySysIndex::kScaleSystUp] = "energyScaleSystUp";
+    names[EGEnergySysIndex::kScaleSystDown] = "energyScaleSystDown";
+    names[EGEnergySysIndex::kScaleGainUp] = "energyScaleGainUp";
+    names[EGEnergySysIndex::kScaleGainDown] = "energyScaleGainDown";
+    names[EGEnergySysIndex::kSmearUp] = "energySigmaUp";
+    names[EGEnergySysIndex::kSmearDown] = "energySigmaDown";
+    names[EGEnergySysIndex::kSmearRhoUp] = "energySigmaRhoUp";
+    names[EGEnergySysIndex::kSmearRhoDown] = "energySigmaRhoDown";
+    names[EGEnergySysIndex::kSmearPhiUp] = "energySigmaPhiUp";
+    names[EGEnergySysIndex::kSmearPhiDown] = "energySigmaPhiDown";
+    names[EGEnergySysIndex::kScaleValue] = "energyScaleValue";
+    names[EGEnergySysIndex::kSmearValue] = "energySigmaValue";
+    names[EGEnergySysIndex::kSmearNrSigma] = "energySmearNrSigma";
+    names[EGEnergySysIndex::kEcalPreCorr] = "ecalEnergyPreCorr";
+    names[EGEnergySysIndex::kEcalErrPreCorr] = "ecalEnergyErrPreCorr";
+    names[EGEnergySysIndex::kEcalPostCorr] = "ecalEnergyPostCorr";
+    names[EGEnergySysIndex::kEcalErrPostCorr] = "ecalEnergyErrPostCorr";
+    names[EGEnergySysIndex::kEcalTrkPreCorr] = "ecalTrkEnergyPreCorr";
+    names[EGEnergySysIndex::kEcalTrkErrPreCorr] = "ecalTrkEnergyErrPreCorr";
+    names[EGEnergySysIndex::kEcalTrkPostCorr] = "ecalTrkEnergyPostCorr";
     names[EGEnergySysIndex::kEcalTrkErrPostCorr] = "ecalTrkEnergyErrPostCorr";
     return names;
   }
-}
+}  // namespace
 
-
-const std::array<std::string,EGEnergySysIndex::kNrSysErrs> 
-EGEnergySysIndex::names_ = makeEGEnergySysNames();
-
+const std::array<std::string, EGEnergySysIndex::kNrSysErrs> EGEnergySysIndex::names_ = makeEGEnergySysNames();

--- a/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
+++ b/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
@@ -11,144 +11,152 @@
 
 namespace egammaTools {
 
-void localEcalClusterCoordsEB( const reco::CaloCluster &bclus, const CaloGeometry & caloGeometry,
-                               float &etacry, float &phicry, int &ieta, int &iphi, float &thetatilt, float &phitilt )
-{
-  
-  assert(bclus.hitsAndFractions().at(0).first.subdetId()==EcalBarrel);
-  
-  const CaloSubdetectorGeometry* geom=caloGeometry.getSubdetectorGeometry(DetId::Ecal,EcalBarrel);//EcalBarrel = 1
-  
-  const math::XYZPoint& position_ = bclus.position(); 
-  double Theta = -position_.theta()+0.5*TMath::Pi();
-  double Eta = position_.eta();
-  double Phi = TVector2::Phi_mpi_pi(position_.phi());
-  
-  //Calculate expected depth of the maximum shower from energy (like in PositionCalc::Calculate_Location()):
-  // The parameters X0 and T0 are hardcoded here because these values were used to calculate the corrections:
-  const float X0 = 0.89; const float T0 = 7.4;
-  double depth = X0 * (T0 + log(bclus.energy()));
-  
-  //find max energy crystal
-  std::vector< std::pair<DetId, float> > crystals_vector = bclus.hitsAndFractions();
-  float drmin = 999.;
-  EBDetId crystalseed;
-  //printf("starting loop over crystals, etot = %5f:\n",bclus.energy());
-  for (unsigned int icry=0; icry!=crystals_vector.size(); ++icry) {    
-    
-    EBDetId crystal(crystals_vector[icry].first);
-        
-    auto cell=geom->getGeometry(crystal);
-    const TruncatedPyramid* cpyr = dynamic_cast<const TruncatedPyramid*>(cell.get());
-    GlobalPoint center_pos = cpyr->getPosition(depth);
-    double EtaCentr = center_pos.eta();
-    double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
+  void localEcalClusterCoordsEB(const reco::CaloCluster &bclus,
+                                const CaloGeometry &caloGeometry,
+                                float &etacry,
+                                float &phicry,
+                                int &ieta,
+                                int &iphi,
+                                float &thetatilt,
+                                float &phitilt) {
+    assert(bclus.hitsAndFractions().at(0).first.subdetId() == EcalBarrel);
 
-    float dr = reco::deltaR(Eta,Phi,EtaCentr,PhiCentr);
-    if (dr<drmin) {
-      drmin = dr;
-      crystalseed = crystal;
+    const CaloSubdetectorGeometry *geom =
+        caloGeometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);  //EcalBarrel = 1
+
+    const math::XYZPoint &position_ = bclus.position();
+    double Theta = -position_.theta() + 0.5 * TMath::Pi();
+    double Eta = position_.eta();
+    double Phi = TVector2::Phi_mpi_pi(position_.phi());
+
+    //Calculate expected depth of the maximum shower from energy (like in PositionCalc::Calculate_Location()):
+    // The parameters X0 and T0 are hardcoded here because these values were used to calculate the corrections:
+    const float X0 = 0.89;
+    const float T0 = 7.4;
+    double depth = X0 * (T0 + log(bclus.energy()));
+
+    //find max energy crystal
+    std::vector<std::pair<DetId, float> > crystals_vector = bclus.hitsAndFractions();
+    float drmin = 999.;
+    EBDetId crystalseed;
+    //printf("starting loop over crystals, etot = %5f:\n",bclus.energy());
+    for (unsigned int icry = 0; icry != crystals_vector.size(); ++icry) {
+      EBDetId crystal(crystals_vector[icry].first);
+
+      auto cell = geom->getGeometry(crystal);
+      const TruncatedPyramid *cpyr = dynamic_cast<const TruncatedPyramid *>(cell.get());
+      GlobalPoint center_pos = cpyr->getPosition(depth);
+      double EtaCentr = center_pos.eta();
+      double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
+
+      float dr = reco::deltaR(Eta, Phi, EtaCentr, PhiCentr);
+      if (dr < drmin) {
+        drmin = dr;
+        crystalseed = crystal;
+      }
     }
-    
-  }
-  
-  ieta = crystalseed.ieta();
-  iphi = crystalseed.iphi();
-  
-  // Get center cell position from shower depth
-  auto cell=geom->getGeometry(crystalseed);
-  const TruncatedPyramid* cpyr = dynamic_cast<const TruncatedPyramid*>(cell.get());
 
-  thetatilt = cpyr->getThetaAxis();
-  phitilt = cpyr->getPhiAxis();
+    ieta = crystalseed.ieta();
+    iphi = crystalseed.iphi();
 
-  GlobalPoint center_pos = cpyr->getPosition(depth);
-  
-  double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
-  double PhiWidth = (TMath::Pi()/180.);
-  phicry = (TVector2::Phi_mpi_pi(Phi-PhiCentr))/PhiWidth;
-  //Some flips to take into account ECAL barrel symmetries:
-  if (ieta<0) phicry *= -1.;  
-  
-  double ThetaCentr = -center_pos.theta()+0.5*TMath::Pi();
-  double ThetaWidth = (TMath::Pi()/180.)*TMath::Cos(ThetaCentr);
-  etacry = (Theta-ThetaCentr)/ThetaWidth;    
-  //flip to take into account ECAL barrel symmetries:
-  if (ieta<0) etacry *= -1.;  
-  
-  return;
+    // Get center cell position from shower depth
+    auto cell = geom->getGeometry(crystalseed);
+    const TruncatedPyramid *cpyr = dynamic_cast<const TruncatedPyramid *>(cell.get());
 
-}
+    thetatilt = cpyr->getThetaAxis();
+    phitilt = cpyr->getPhiAxis();
 
-void localEcalClusterCoordsEE( const reco::CaloCluster &bclus, const CaloGeometry & caloGeometry,
-                               float &xcry, float &ycry, int &ix, int &iy, float &thetatilt, float &phitilt )
-{
-    
-  assert(bclus.hitsAndFractions().at(0).first.subdetId()==EcalEndcap);
-  
-  const CaloSubdetectorGeometry* geom=caloGeometry.getSubdetectorGeometry(DetId::Ecal,EcalEndcap);//EcalBarrel = 1
-  
-  const math::XYZPoint& position_ = bclus.position(); 
-  //double Theta = -position_.theta()+0.5*TMath::Pi();
-  double Eta = position_.eta();
-  double Phi = TVector2::Phi_mpi_pi(position_.phi());
-  double X = position_.x();
-  double Y = position_.y();
-  
-  //Calculate expected depth of the maximum shower from energy (like in PositionCalc::Calculate_Location()):
-  // The parameters X0 and T0 are hardcoded here because these values were used to calculate the corrections:
-  const float X0 = 0.89; float T0 = 1.2;
-  //different T0 value if outside of preshower coverage
-  if (TMath::Abs(bclus.eta())<1.653) T0 = 3.1;
-  
-  double depth = X0 * (T0 + log(bclus.energy()));
-  
-  //find max energy crystal
-  std::vector< std::pair<DetId, float> > crystals_vector = bclus.hitsAndFractions();
-  float drmin = 999.;
-  EEDetId crystalseed;
-  //printf("starting loop over crystals, etot = %5f:\n",bclus.energy());
-  for (unsigned int icry=0; icry!=crystals_vector.size(); ++icry) {    
-    
-    EEDetId crystal(crystals_vector[icry].first);
-        
-    auto cell=geom->getGeometry(crystal);
-    const TruncatedPyramid* cpyr = dynamic_cast<const TruncatedPyramid*>(cell.get());
     GlobalPoint center_pos = cpyr->getPosition(depth);
-    double EtaCentr = center_pos.eta();
+
     double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
+    double PhiWidth = (TMath::Pi() / 180.);
+    phicry = (TVector2::Phi_mpi_pi(Phi - PhiCentr)) / PhiWidth;
+    //Some flips to take into account ECAL barrel symmetries:
+    if (ieta < 0)
+      phicry *= -1.;
 
-    float dr = reco::deltaR(Eta,Phi,EtaCentr,PhiCentr);
-    if (dr<drmin) {
-      drmin = dr;
-      crystalseed = crystal;
-    }
-    
+    double ThetaCentr = -center_pos.theta() + 0.5 * TMath::Pi();
+    double ThetaWidth = (TMath::Pi() / 180.) * TMath::Cos(ThetaCentr);
+    etacry = (Theta - ThetaCentr) / ThetaWidth;
+    //flip to take into account ECAL barrel symmetries:
+    if (ieta < 0)
+      etacry *= -1.;
+
+    return;
   }
-  
-  ix = crystalseed.ix();
-  iy = crystalseed.iy();
-  
-  // Get center cell position from shower depth
-  auto cell=geom->getGeometry(crystalseed);
-  const TruncatedPyramid* cpyr = dynamic_cast<const TruncatedPyramid*>(cell.get());
 
-  thetatilt = cpyr->getThetaAxis();
-  phitilt = cpyr->getPhiAxis();
+  void localEcalClusterCoordsEE(const reco::CaloCluster &bclus,
+                                const CaloGeometry &caloGeometry,
+                                float &xcry,
+                                float &ycry,
+                                int &ix,
+                                int &iy,
+                                float &thetatilt,
+                                float &phitilt) {
+    assert(bclus.hitsAndFractions().at(0).first.subdetId() == EcalEndcap);
 
-  GlobalPoint center_pos = cpyr->getPosition(depth);
-  
-  double XCentr = center_pos.x();
-  double XWidth = 2.59;
-  xcry = (X-XCentr)/XWidth;
- 
-  
-  double YCentr = center_pos.y();
-  double YWidth = 2.59;
-  ycry = (Y-YCentr)/YWidth;
-  
-  return;
+    const CaloSubdetectorGeometry *geom =
+        caloGeometry.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);  //EcalBarrel = 1
 
-}
+    const math::XYZPoint &position_ = bclus.position();
+    //double Theta = -position_.theta()+0.5*TMath::Pi();
+    double Eta = position_.eta();
+    double Phi = TVector2::Phi_mpi_pi(position_.phi());
+    double X = position_.x();
+    double Y = position_.y();
 
-}
+    //Calculate expected depth of the maximum shower from energy (like in PositionCalc::Calculate_Location()):
+    // The parameters X0 and T0 are hardcoded here because these values were used to calculate the corrections:
+    const float X0 = 0.89;
+    float T0 = 1.2;
+    //different T0 value if outside of preshower coverage
+    if (TMath::Abs(bclus.eta()) < 1.653)
+      T0 = 3.1;
+
+    double depth = X0 * (T0 + log(bclus.energy()));
+
+    //find max energy crystal
+    std::vector<std::pair<DetId, float> > crystals_vector = bclus.hitsAndFractions();
+    float drmin = 999.;
+    EEDetId crystalseed;
+    //printf("starting loop over crystals, etot = %5f:\n",bclus.energy());
+    for (unsigned int icry = 0; icry != crystals_vector.size(); ++icry) {
+      EEDetId crystal(crystals_vector[icry].first);
+
+      auto cell = geom->getGeometry(crystal);
+      const TruncatedPyramid *cpyr = dynamic_cast<const TruncatedPyramid *>(cell.get());
+      GlobalPoint center_pos = cpyr->getPosition(depth);
+      double EtaCentr = center_pos.eta();
+      double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
+
+      float dr = reco::deltaR(Eta, Phi, EtaCentr, PhiCentr);
+      if (dr < drmin) {
+        drmin = dr;
+        crystalseed = crystal;
+      }
+    }
+
+    ix = crystalseed.ix();
+    iy = crystalseed.iy();
+
+    // Get center cell position from shower depth
+    auto cell = geom->getGeometry(crystalseed);
+    const TruncatedPyramid *cpyr = dynamic_cast<const TruncatedPyramid *>(cell.get());
+
+    thetatilt = cpyr->getThetaAxis();
+    phitilt = cpyr->getPhiAxis();
+
+    GlobalPoint center_pos = cpyr->getPosition(depth);
+
+    double XCentr = center_pos.x();
+    double XWidth = 2.59;
+    xcry = (X - XCentr) / XWidth;
+
+    double YCentr = center_pos.y();
+    double YWidth = 2.59;
+    ycry = (Y - YCentr) / YWidth;
+
+    return;
+  }
+
+}  // namespace egammaTools

--- a/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
+++ b/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
@@ -13,89 +13,95 @@
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
-float EcalRegressionData::seedLeftRightAsym()const
-{
-  float eLeftRightSum = eLeft()+eRight();
-  float eLeftRightDiff = eLeft()-eRight();
-  return eLeftRightSum !=0 ? eLeftRightDiff/eLeftRightSum : 0.;
+float EcalRegressionData::seedLeftRightAsym() const {
+  float eLeftRightSum = eLeft() + eRight();
+  float eLeftRightDiff = eLeft() - eRight();
+  return eLeftRightSum != 0 ? eLeftRightDiff / eLeftRightSum : 0.;
 }
 
-float EcalRegressionData::seedTopBottomAsym()const
-{
-  float eTopBottomSum = eTop()+eBottom();
-  float eTopBottomDiff = eTop()-eBottom();
-  return eTopBottomSum !=0 ? eTopBottomDiff/eTopBottomSum : 0.;
-}
-  
-float EcalRegressionData::subClusRawEnergy(size_t clusNr)const
-{
-  if(clusNr<subClusRawEnergy_.size()) return subClusRawEnergy_[clusNr];
-  else return 0.;
+float EcalRegressionData::seedTopBottomAsym() const {
+  float eTopBottomSum = eTop() + eBottom();
+  float eTopBottomDiff = eTop() - eBottom();
+  return eTopBottomSum != 0 ? eTopBottomDiff / eTopBottomSum : 0.;
 }
 
-float EcalRegressionData::subClusDEta(size_t clusNr)const
-{
-  if(clusNr<subClusDEta_.size()) return subClusDEta_[clusNr];
-  else return 0.;
+float EcalRegressionData::subClusRawEnergy(size_t clusNr) const {
+  if (clusNr < subClusRawEnergy_.size())
+    return subClusRawEnergy_[clusNr];
+  else
+    return 0.;
 }
 
-float EcalRegressionData::subClusDPhi(size_t clusNr)const
-{
-  if(clusNr<subClusDPhi_.size()) return subClusDPhi_[clusNr];
-  else return 0.;
+float EcalRegressionData::subClusDEta(size_t clusNr) const {
+  if (clusNr < subClusDEta_.size())
+    return subClusDEta_[clusNr];
+  else
+    return 0.;
+}
+
+float EcalRegressionData::subClusDPhi(size_t clusNr) const {
+  if (clusNr < subClusDPhi_.size())
+    return subClusDPhi_[clusNr];
+  else
+    return 0.;
 }
 
 void EcalRegressionData::fill(const reco::SuperCluster& superClus,
-			  const EcalRecHitCollection* ebRecHits,const EcalRecHitCollection* eeRecHits,
-			  const CaloGeometry* geom,const CaloTopology* topology,
-			  int nrVertices)
-{
+                              const EcalRecHitCollection* ebRecHits,
+                              const EcalRecHitCollection* eeRecHits,
+                              const CaloGeometry* geom,
+                              const CaloTopology* topology,
+                              int nrVertices) {
   clear();
-  
+
   const DetId& seedid = superClus.seed()->hitsAndFractions().at(0).first;
-  isEB_ = ( seedid.subdetId()==EcalBarrel );
-  
+  isEB_ = (seedid.subdetId() == EcalBarrel);
+
   // skip HGCal
-  if( EcalTools::isHGCalDet(seedid.det()) ) return;
-  
+  if (EcalTools::isHGCalDet(seedid.det()))
+    return;
+
   const EcalRecHitCollection* recHits = isEB_ ? ebRecHits : eeRecHits;
 
   scRawEnergy_ = superClus.rawEnergy();
   scCalibEnergy_ = superClus.correctedEnergy();
-  scPreShowerEnergy_ =  superClus.preshowerEnergy();
+  scPreShowerEnergy_ = superClus.preshowerEnergy();
   scEta_ = superClus.eta();
   scPhi_ = superClus.phi();
   scEtaWidth_ = superClus.etaWidth();
   scPhiWidth_ = superClus.phiWidth();
-  scNrAdditionalClusters_ = superClus.clustersSize()-1;
+  scNrAdditionalClusters_ = superClus.clustersSize() - 1;
 
   seedClusEnergy_ = superClus.seed()->energy();
-  eMax_ = EcalClusterTools::eMax(*superClus.seed(),recHits);
-  e2nd_ = EcalClusterTools::e2nd(*superClus.seed(),recHits);
-  e3x3_ = EcalClusterTools::e3x3(*superClus.seed(),recHits,topology);
-  eTop_ = EcalClusterTools::eTop(*superClus.seed(),recHits,topology);
-  eBottom_ = EcalClusterTools::eBottom(*superClus.seed(),recHits,topology);
-  eLeft_ = EcalClusterTools::eLeft(*superClus.seed(),recHits,topology);
-  eRight_ = EcalClusterTools::eRight(*superClus.seed(),recHits,topology);
-  std::vector<float> localCovs = EcalClusterTools::localCovariances(*superClus.seed(),recHits,topology);
+  eMax_ = EcalClusterTools::eMax(*superClus.seed(), recHits);
+  e2nd_ = EcalClusterTools::e2nd(*superClus.seed(), recHits);
+  e3x3_ = EcalClusterTools::e3x3(*superClus.seed(), recHits, topology);
+  eTop_ = EcalClusterTools::eTop(*superClus.seed(), recHits, topology);
+  eBottom_ = EcalClusterTools::eBottom(*superClus.seed(), recHits, topology);
+  eLeft_ = EcalClusterTools::eLeft(*superClus.seed(), recHits, topology);
+  eRight_ = EcalClusterTools::eRight(*superClus.seed(), recHits, topology);
+  std::vector<float> localCovs = EcalClusterTools::localCovariances(*superClus.seed(), recHits, topology);
   sigmaIEtaIEta_ = edm::isNotFinite(localCovs[0]) ? 0. : std::sqrt(localCovs[0]);
   sigmaIPhiIPhi_ = edm::isNotFinite(localCovs[2]) ? 0. : std::sqrt(localCovs[2]);
-  
-  if(sigmaIEtaIEta_*sigmaIPhiIPhi_>0) sigmaIEtaIPhi_ = localCovs[1]/(sigmaIEtaIEta_*sigmaIPhiIPhi_);
-  else if(localCovs[1]>0) sigmaIEtaIPhi_ = 1.;
-  else sigmaIEtaIPhi_ = -1.;
-  
+
+  if (sigmaIEtaIEta_ * sigmaIPhiIPhi_ > 0)
+    sigmaIEtaIPhi_ = localCovs[1] / (sigmaIEtaIEta_ * sigmaIPhiIPhi_);
+  else if (localCovs[1] > 0)
+    sigmaIEtaIPhi_ = 1.;
+  else
+    sigmaIEtaIPhi_ = -1.;
+
   auto localCoordsFunc = isEB() ? egammaTools::localEcalClusterCoordsEB : egammaTools::localEcalClusterCoordsEE;
 
   float dummy;
-  localCoordsFunc( *superClus.seed(),*geom, seedCrysEtaOrX_,seedCrysPhiOrY_,
-                   seedCrysIEtaOrIX_,seedCrysIPhiOrIY_, dummy, dummy );
+  localCoordsFunc(
+      *superClus.seed(), *geom, seedCrysEtaOrX_, seedCrysPhiOrY_, seedCrysIEtaOrIX_, seedCrysIPhiOrIY_, dummy, dummy);
 
-  for( auto clus = superClus.clustersBegin()+1;clus != superClus.clustersEnd(); ++clus ) {
+  for (auto clus = superClus.clustersBegin() + 1; clus != superClus.clustersEnd(); ++clus) {
     const float dEta = (*clus)->eta() - superClus.seed()->eta();
-    const float dPhi = reco::deltaPhi((*clus)->phi(),superClus.seed()->phi());
-    const float dR2 = dEta*dEta+dPhi*dPhi;
-    if(dR2 > maxSubClusDR2_ || maxSubClusDR2_ == 998001.) {
+    const float dPhi = reco::deltaPhi((*clus)->phi(), superClus.seed()->phi());
+    const float dR2 = dEta * dEta + dPhi * dPhi;
+    if (dR2 > maxSubClusDR2_ || maxSubClusDR2_ == 998001.) {
       maxSubClusDR2_ = dR2;
       maxSubClusDRDEta_ = dEta;
       maxSubClusDRDPhi_ = dPhi;
@@ -104,133 +110,129 @@ void EcalRegressionData::fill(const reco::SuperCluster& superClus,
     subClusRawEnergy_.push_back((*clus)->energy());
     subClusDEta_.push_back(dEta);
     subClusDPhi_.push_back(dPhi);
-    
   }
-  
-  nrVtx_ = nrVertices;
 
+  nrVtx_ = nrVertices;
 }
 
-void EcalRegressionData::clear()
-{
-  isEB_=false;
-  scRawEnergy_=0.;
-  scCalibEnergy_=0.;
-  scPreShowerEnergy_=0.;
-  scEta_=0.;
-  scPhi_=0.;
-  scEtaWidth_=0.;
-  scPhiWidth_=0.;
-  scNrAdditionalClusters_=0;
-  
-  seedClusEnergy_=0.;
-  eMax_=0.;
-  e2nd_=0.;
-  e3x3_=0.;
-  eTop_=0.;
-  eBottom_=0.;
-  eLeft_=0.;
-  eRight_=0.;
-  sigmaIEtaIEta_=0.;
-  sigmaIEtaIPhi_=0.;
-  sigmaIPhiIPhi_=0.;
-  
-  seedCrysPhiOrY_=0.;
-  seedCrysEtaOrX_=0.;
-  seedCrysIEtaOrIX_=0;
-  seedCrysIPhiOrIY_=0;
-  
-  maxSubClusDR2_=998001.;
-  maxSubClusDRDPhi_=999.;
-  maxSubClusDRDEta_=999;
-  maxSubClusDRRawEnergy_=0.;
-  
+void EcalRegressionData::clear() {
+  isEB_ = false;
+  scRawEnergy_ = 0.;
+  scCalibEnergy_ = 0.;
+  scPreShowerEnergy_ = 0.;
+  scEta_ = 0.;
+  scPhi_ = 0.;
+  scEtaWidth_ = 0.;
+  scPhiWidth_ = 0.;
+  scNrAdditionalClusters_ = 0;
+
+  seedClusEnergy_ = 0.;
+  eMax_ = 0.;
+  e2nd_ = 0.;
+  e3x3_ = 0.;
+  eTop_ = 0.;
+  eBottom_ = 0.;
+  eLeft_ = 0.;
+  eRight_ = 0.;
+  sigmaIEtaIEta_ = 0.;
+  sigmaIEtaIPhi_ = 0.;
+  sigmaIPhiIPhi_ = 0.;
+
+  seedCrysPhiOrY_ = 0.;
+  seedCrysEtaOrX_ = 0.;
+  seedCrysIEtaOrIX_ = 0;
+  seedCrysIPhiOrIY_ = 0;
+
+  maxSubClusDR2_ = 998001.;
+  maxSubClusDRDPhi_ = 999.;
+  maxSubClusDRDEta_ = 999;
+  maxSubClusDRRawEnergy_ = 0.;
+
   subClusRawEnergy_.clear();
   subClusDPhi_.clear();
   subClusDEta_.clear();
-  
-  nrVtx_=0;
-  
+
+  nrVtx_ = 0;
 }
 
-void EcalRegressionData::fillVec(std::vector<float>& inputVec)const
-{
-  if(isEB()) fillVecEB_(inputVec);
-  else fillVecEE_(inputVec);
+void EcalRegressionData::fillVec(std::vector<float>& inputVec) const {
+  if (isEB())
+    fillVecEB_(inputVec);
+  else
+    fillVecEE_(inputVec);
 }
 
-void EcalRegressionData::fillVecEB_(std::vector<float>& inputVec)const
-{
+void EcalRegressionData::fillVecEB_(std::vector<float>& inputVec) const {
   inputVec.clear();
   inputVec.resize(33);
-  inputVec[0] = nrVtx(); //nVtx
-  inputVec[1] = scEta(); //scEta
-  inputVec[2] = scPhi(); //scPhi
-  inputVec[3] = scEtaWidth(); //scEtaWidth
-  inputVec[4] = scPhiWidth(); //scPhiWidth
-  inputVec[5] = scSeedR9(); //scSeedR9
-  inputVec[6] = seedClusEnergyOverSCRawEnergy(); //scSeedRawEnergy/scRawEnergy
-  inputVec[7] = eMaxOverSCRawEnergy(); //scSeedEmax/scRawEnergy
-  inputVec[8] = e2ndOverSCRawEnergy(); //scSeedE2nd/scRawEnergy
-  inputVec[9] = seedLeftRightAsym();//scSeedLeftRightAsym
-  inputVec[10] = seedTopBottomAsym();//scSeedTopBottomAsym
-  inputVec[11] = sigmaIEtaIEta(); //scSeedSigmaIetaIeta
-  inputVec[12] = sigmaIEtaIPhi(); //scSeedSigmaIetaIphi
-  inputVec[13] = sigmaIPhiIPhi(); //scSeedSigmaIphiIphi
-  inputVec[14] = scNrAdditionalClusters(); //N_ECALClusters
-  inputVec[15] = maxSubClusDR(); //clusterMaxDR
-  inputVec[16] = maxSubClusDRDPhi(); //clusterMaxDRDPhi
-  inputVec[17] = maxSubClusDRDEta(); //clusterMaxDRDEta
-  inputVec[18] = maxSubClusDRRawEnergyOverSCRawEnergy(); //clusMaxDRRawEnergy/scRawEnergy
-  inputVec[19] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C1); //clusterRawEnergy[0]/scRawEnergy
-  inputVec[20] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C2); //clusterRawEnergy[1]/scRawEnergy  float scPreShowerEnergy()const{return scPreShowerEnergy_;}
+  inputVec[0] = nrVtx();                                          //nVtx
+  inputVec[1] = scEta();                                          //scEta
+  inputVec[2] = scPhi();                                          //scPhi
+  inputVec[3] = scEtaWidth();                                     //scEtaWidth
+  inputVec[4] = scPhiWidth();                                     //scPhiWidth
+  inputVec[5] = scSeedR9();                                       //scSeedR9
+  inputVec[6] = seedClusEnergyOverSCRawEnergy();                  //scSeedRawEnergy/scRawEnergy
+  inputVec[7] = eMaxOverSCRawEnergy();                            //scSeedEmax/scRawEnergy
+  inputVec[8] = e2ndOverSCRawEnergy();                            //scSeedE2nd/scRawEnergy
+  inputVec[9] = seedLeftRightAsym();                              //scSeedLeftRightAsym
+  inputVec[10] = seedTopBottomAsym();                             //scSeedTopBottomAsym
+  inputVec[11] = sigmaIEtaIEta();                                 //scSeedSigmaIetaIeta
+  inputVec[12] = sigmaIEtaIPhi();                                 //scSeedSigmaIetaIphi
+  inputVec[13] = sigmaIPhiIPhi();                                 //scSeedSigmaIphiIphi
+  inputVec[14] = scNrAdditionalClusters();                        //N_ECALClusters
+  inputVec[15] = maxSubClusDR();                                  //clusterMaxDR
+  inputVec[16] = maxSubClusDRDPhi();                              //clusterMaxDRDPhi
+  inputVec[17] = maxSubClusDRDEta();                              //clusterMaxDRDEta
+  inputVec[18] = maxSubClusDRRawEnergyOverSCRawEnergy();          //clusMaxDRRawEnergy/scRawEnergy
+  inputVec[19] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C1);  //clusterRawEnergy[0]/scRawEnergy
+  inputVec[20] = subClusRawEnergyOverSCRawEnergy(
+      SubClusNr::C2);  //clusterRawEnergy[1]/scRawEnergy  float scPreShowerEnergy()const{return scPreShowerEnergy_;}
 
-  inputVec[21] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C3); //clusterRawEnergy[2]/scRawEnergy
-  inputVec[22] = subClusDPhi(SubClusNr::C1); //clusterDPhiToSeed[0]
-  inputVec[23] = subClusDPhi(SubClusNr::C2); //clusterDPhiToSeed[1]
-  inputVec[24] = subClusDPhi(SubClusNr::C3); //clusterDPhiToSeed[2]
-  inputVec[25] = subClusDEta(SubClusNr::C1); //clusterDEtaToSeed[0]
-  inputVec[26] = subClusDEta(SubClusNr::C2); //clusterDEtaToSeed[1]
-  inputVec[27] = subClusDEta(SubClusNr::C3); //clusterDEtaToSeed[2]
-  inputVec[28] = seedCrysEtaOrX(); //scSeedCryEta
-  inputVec[29] = seedCrysPhiOrY(); //scSeedCryPhi
-  inputVec[30] = seedCrysIEtaOrIX(); //scSeedCryIeta
-  inputVec[31] = seedCrysIPhiOrIY(); //scSeedCryIphi
-  inputVec[32] = scCalibEnergy(); //scCalibratedEnergy
+  inputVec[21] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C3);  //clusterRawEnergy[2]/scRawEnergy
+  inputVec[22] = subClusDPhi(SubClusNr::C1);                      //clusterDPhiToSeed[0]
+  inputVec[23] = subClusDPhi(SubClusNr::C2);                      //clusterDPhiToSeed[1]
+  inputVec[24] = subClusDPhi(SubClusNr::C3);                      //clusterDPhiToSeed[2]
+  inputVec[25] = subClusDEta(SubClusNr::C1);                      //clusterDEtaToSeed[0]
+  inputVec[26] = subClusDEta(SubClusNr::C2);                      //clusterDEtaToSeed[1]
+  inputVec[27] = subClusDEta(SubClusNr::C3);                      //clusterDEtaToSeed[2]
+  inputVec[28] = seedCrysEtaOrX();                                //scSeedCryEta
+  inputVec[29] = seedCrysPhiOrY();                                //scSeedCryPhi
+  inputVec[30] = seedCrysIEtaOrIX();                              //scSeedCryIeta
+  inputVec[31] = seedCrysIPhiOrIY();                              //scSeedCryIphi
+  inputVec[32] = scCalibEnergy();                                 //scCalibratedEnergy
 }
 
-void EcalRegressionData::fillVecEE_(std::vector<float>& inputVec)const
-{
+void EcalRegressionData::fillVecEE_(std::vector<float>& inputVec) const {
   inputVec.clear();
-  inputVec.resize(33); //this emulates the old behaviour of RegressionHelper, even if past 29 we dont use elements
-  inputVec[0] = nrVtx(); //nVtx
-  inputVec[1] = scEta(); //scEta
-  inputVec[2] = scPhi(); //scPhi
-  inputVec[3] = scEtaWidth(); //scEtaWidth
-  inputVec[4] = scPhiWidth(); //scPhiWidth
-  inputVec[5] = scSeedR9(); //scSeedR9
-  inputVec[6] = seedClusEnergyOverSCRawEnergy(); //scSeedRawEnergy/scRawEnergy
-  inputVec[7] = eMaxOverSCRawEnergy(); //scSeedEmax/scRawEnergy
-  inputVec[8] = e2ndOverSCRawEnergy(); //scSeedE2nd/scRawEnergy
-  inputVec[9] = seedLeftRightAsym();//scSeedLeftRightAsym
-  inputVec[10] = seedTopBottomAsym();//scSeedTopBottomAsym
-  inputVec[11] = sigmaIEtaIEta(); //scSeedSigmaIetaIeta
-  inputVec[12] = sigmaIEtaIPhi(); //scSeedSigmaIetaIphi
-  inputVec[13] = sigmaIPhiIPhi(); //scSeedSigmaIphiIphi
-  inputVec[14] = scNrAdditionalClusters(); //N_ECALClusters
-  inputVec[15] = maxSubClusDR(); //clusterMaxDR
-  inputVec[16] = maxSubClusDRDPhi(); //clusterMaxDRDPhi
-  inputVec[17] = maxSubClusDRDEta(); //clusterMaxDRDEta
-  inputVec[18] = maxSubClusDRRawEnergyOverSCRawEnergy(); //clusMaxDRRawEnergy/scRawEnergy
-  inputVec[19] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C1); //clusterRawEnergy[0]/scRawEnergy
-  inputVec[20] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C2); //clusterRawEnergy[1]/scRawEnergy
-  inputVec[21] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C3); //clusterRawEnergy[2]/scRawEnergy
-  inputVec[22] = subClusDPhi(SubClusNr::C1); //clusterDPhiToSeed[0]
-  inputVec[23] = subClusDPhi(SubClusNr::C2); //clusterDPhiToSeed[1]
-  inputVec[24] = subClusDPhi(SubClusNr::C3); //clusterDPhiToSeed[2]
-  inputVec[25] = subClusDEta(SubClusNr::C1); //clusterDEtaToSeed[0]
-  inputVec[26] = subClusDEta(SubClusNr::C2); //clusterDEtaToSeed[1]
-  inputVec[27] = subClusDEta(SubClusNr::C3); //clusterDEtaToSeed[2]
+  inputVec.resize(33);    //this emulates the old behaviour of RegressionHelper, even if past 29 we dont use elements
+  inputVec[0] = nrVtx();  //nVtx
+  inputVec[1] = scEta();  //scEta
+  inputVec[2] = scPhi();  //scPhi
+  inputVec[3] = scEtaWidth();                                     //scEtaWidth
+  inputVec[4] = scPhiWidth();                                     //scPhiWidth
+  inputVec[5] = scSeedR9();                                       //scSeedR9
+  inputVec[6] = seedClusEnergyOverSCRawEnergy();                  //scSeedRawEnergy/scRawEnergy
+  inputVec[7] = eMaxOverSCRawEnergy();                            //scSeedEmax/scRawEnergy
+  inputVec[8] = e2ndOverSCRawEnergy();                            //scSeedE2nd/scRawEnergy
+  inputVec[9] = seedLeftRightAsym();                              //scSeedLeftRightAsym
+  inputVec[10] = seedTopBottomAsym();                             //scSeedTopBottomAsym
+  inputVec[11] = sigmaIEtaIEta();                                 //scSeedSigmaIetaIeta
+  inputVec[12] = sigmaIEtaIPhi();                                 //scSeedSigmaIetaIphi
+  inputVec[13] = sigmaIPhiIPhi();                                 //scSeedSigmaIphiIphi
+  inputVec[14] = scNrAdditionalClusters();                        //N_ECALClusters
+  inputVec[15] = maxSubClusDR();                                  //clusterMaxDR
+  inputVec[16] = maxSubClusDRDPhi();                              //clusterMaxDRDPhi
+  inputVec[17] = maxSubClusDRDEta();                              //clusterMaxDRDEta
+  inputVec[18] = maxSubClusDRRawEnergyOverSCRawEnergy();          //clusMaxDRRawEnergy/scRawEnergy
+  inputVec[19] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C1);  //clusterRawEnergy[0]/scRawEnergy
+  inputVec[20] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C2);  //clusterRawEnergy[1]/scRawEnergy
+  inputVec[21] = subClusRawEnergyOverSCRawEnergy(SubClusNr::C3);  //clusterRawEnergy[2]/scRawEnergy
+  inputVec[22] = subClusDPhi(SubClusNr::C1);                      //clusterDPhiToSeed[0]
+  inputVec[23] = subClusDPhi(SubClusNr::C2);                      //clusterDPhiToSeed[1]
+  inputVec[24] = subClusDPhi(SubClusNr::C3);                      //clusterDPhiToSeed[2]
+  inputVec[25] = subClusDEta(SubClusNr::C1);                      //clusterDEtaToSeed[0]
+  inputVec[26] = subClusDEta(SubClusNr::C2);                      //clusterDEtaToSeed[1]
+  inputVec[27] = subClusDEta(SubClusNr::C3);                      //clusterDEtaToSeed[2]
   inputVec[28] = scPreShowerEnergyOverSCRawEnergy();
-  inputVec[29] = scCalibEnergy(); //scCalibratedEnergy
+  inputVec[29] = scCalibEnergy();  //scCalibratedEnergy
 }

--- a/RecoEgamma/EgammaTools/src/EffectiveAreas.cc
+++ b/RecoEgamma/EgammaTools/src/EffectiveAreas.cc
@@ -6,36 +6,33 @@
 #include <string>
 #include <sstream>
 
-EffectiveAreas::EffectiveAreas(const std::string& filename):
-  filename_(filename)
-{
-
+EffectiveAreas::EffectiveAreas(const std::string& filename) : filename_(filename) {
   // Open the file with the effective area constants
   std::ifstream inputFile;
   inputFile.open(filename_.c_str());
-  if( !inputFile.is_open() )
-    throw cms::Exception("EffectiveAreas config failure")
-      << "failed to open the file " << filename_ << std::endl;
-  
+  if (!inputFile.is_open())
+    throw cms::Exception("EffectiveAreas config failure") << "failed to open the file " << filename_ << std::endl;
+
   // Read file line by line
   std::string line;
   const float undef = -999;
-  while( getline(inputFile, line) ){
-    if(line[0]=='#') continue; // skip the comments lines
+  while (getline(inputFile, line)) {
+    if (line[0] == '#')
+      continue;  // skip the comments lines
     float etaMin = undef, etaMax = undef, effArea = undef;
     std::stringstream ss(line);
-    ss >>  etaMin >> etaMax >> effArea;
+    ss >> etaMin >> etaMax >> effArea;
     // In case if the format is messed up, there are letters
     // instead of numbers, or not exactly three numbers in the line,
     // it is likely that one or more of these vars never changed
     // the original "undef" value:
-    if( etaMin==undef || etaMax==undef || effArea==undef )
+    if (etaMin == undef || etaMax == undef || effArea == undef)
       throw cms::Exception("EffectiveAreas config failure")
-	<< "wrong file format, file name " << filename_ << std::endl;
-    
-    absEtaMin_          .push_back( etaMin );
-    absEtaMax_          .push_back( etaMax );
-    effectiveAreaValues_.push_back( effArea );
+          << "wrong file format, file name " << filename_ << std::endl;
+
+    absEtaMin_.push_back(etaMin);
+    absEtaMax_.push_back(etaMax);
+    effectiveAreaValues_.push_back(effArea);
   }
 
   // Extra consistency checks are in the function below.
@@ -44,13 +41,11 @@ EffectiveAreas::EffectiveAreas(const std::string& filename):
 }
 
 // Return effective area for given eta
-const float EffectiveAreas::getEffectiveArea(float eta) const{
-
+const float EffectiveAreas::getEffectiveArea(float eta) const {
   float effArea = 0;
   uint nEtaBins = absEtaMin_.size();
-  for(uint iEta = 0; iEta<nEtaBins; iEta++){
-    if( std::abs(eta) >= absEtaMin_[iEta]
-	&& std::abs(eta) < absEtaMax_[iEta] ){
+  for (uint iEta = 0; iEta < nEtaBins; iEta++) {
+    if (std::abs(eta) >= absEtaMin_[iEta] && std::abs(eta) < absEtaMax_[iEta]) {
       effArea = effectiveAreaValues_[iEta];
       break;
     }
@@ -60,52 +55,40 @@ const float EffectiveAreas::getEffectiveArea(float eta) const{
 }
 
 void EffectiveAreas::printEffectiveAreas() const {
-
   printf("EffectiveAreas: source file %s\n", filename_.c_str());
   printf("  eta_min   eta_max    effective area\n");
   uint nEtaBins = absEtaMin_.size();
-  for(uint iEta = 0; iEta<nEtaBins; iEta++){
-    printf("  %8.4f    %8.4f   %8.5f\n",
-	   absEtaMin_[iEta], absEtaMax_[iEta],
-	   effectiveAreaValues_[iEta]);
+  for (uint iEta = 0; iEta < nEtaBins; iEta++) {
+    printf("  %8.4f    %8.4f   %8.5f\n", absEtaMin_[iEta], absEtaMax_[iEta], effectiveAreaValues_[iEta]);
   }
-
 }
 
 // Basic common sense checks
 void EffectiveAreas::checkConsistency() const {
-
   // There should be at least one eta range with one constant
-  if( effectiveAreaValues_.empty() )
+  if (effectiveAreaValues_.empty())
     throw cms::Exception("EffectiveAreas config failure")
-      << "found no effective area constans in the file " 
-      << filename_ << std::endl;
+        << "found no effective area constans in the file " << filename_ << std::endl;
 
   uint nEtaBins = absEtaMin_.size();
-  for(uint iEta = 0; iEta<nEtaBins; iEta++){
-
+  for (uint iEta = 0; iEta < nEtaBins; iEta++) {
     // The low limit should be lower than the upper limit
-    if( !( absEtaMin_[iEta] < absEtaMax_[iEta] ) )
+    if (!(absEtaMin_[iEta] < absEtaMax_[iEta]))
       throw cms::Exception("EffectiveAreas config failure")
-	<< "eta ranges improperly defined (min>max) in the file" 
-	<< filename_ << std::endl;
+          << "eta ranges improperly defined (min>max) in the file" << filename_ << std::endl;
 
     // The low limit of the next range should be (near) equal to the
     // upper limit of the previous range
-    if( iEta != nEtaBins-1 ) // don't do the check for the last bin
-      if( !( absEtaMin_[iEta+1] - absEtaMax_[iEta] < 0.0001 ) )
-	throw cms::Exception("EffectiveAreas config failure")
-	  << "eta ranges improperly defined (disjointed) in the file " 
-	  << filename_ << std::endl;
+    if (iEta != nEtaBins - 1)  // don't do the check for the last bin
+      if (!(absEtaMin_[iEta + 1] - absEtaMax_[iEta] < 0.0001))
+        throw cms::Exception("EffectiveAreas config failure")
+            << "eta ranges improperly defined (disjointed) in the file " << filename_ << std::endl;
 
     // The effective area should be non-negative number,
-    // and should be less than the whole calorimeter area 
+    // and should be less than the whole calorimeter area
     // eta range -2.5 to 2.5, phi 0 to 2pi => Amax = 5*2*pi ~= 31.4
-    if( !( effectiveAreaValues_[iEta] >= 0
-	   && effectiveAreaValues_[iEta] < 31.4 ) )
+    if (!(effectiveAreaValues_[iEta] >= 0 && effectiveAreaValues_[iEta] < 31.4))
       throw cms::Exception("EffectiveAreas config failure")
-	<< "effective area values are too large or negative in the file"
-	<< filename_ << std::endl;
+          << "effective area values are too large or negative in the file" << filename_ << std::endl;
   }
-
 }

--- a/RecoEgamma/EgammaTools/src/EgammaRandomSeeds.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaRandomSeeds.cc
@@ -2,15 +2,18 @@
 
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 
-uint32_t egamma::getRandomSeedFromSC(const edm::Event& iEvent,const reco::SuperClusterRef scRef)
-{
-  const int offset=0; //for future expansion
-  std::seed_seq seeder = {int(iEvent.id().event()), int(iEvent.id().luminosityBlock()), int(iEvent.id().run()),
-			  int(scRef->seed()->seed().rawId()),int(scRef->seed()->hitsAndFractions().size()),
-			  offset};
+uint32_t egamma::getRandomSeedFromSC(const edm::Event& iEvent, const reco::SuperClusterRef scRef) {
+  const int offset = 0;  //for future expansion
+  std::seed_seq seeder = {int(iEvent.id().event()),
+                          int(iEvent.id().luminosityBlock()),
+                          int(iEvent.id().run()),
+                          int(scRef->seed()->seed().rawId()),
+                          int(scRef->seed()->hitsAndFractions().size()),
+                          offset};
   uint32_t seed = 0, tries = 10;
   do {
-    seeder.generate(&seed,&seed+1); tries++;
+    seeder.generate(&seed, &seed + 1);
+    tries++;
   } while (seed == 0 && tries < 10);
-  return seed ? seed : iEvent.id().event() + 10000*scRef.key();
+  return seed ? seed : iEvent.id().event() + 10000 * scRef.key();
 }

--- a/RecoEgamma/EgammaTools/src/EgammaRegressionContainer.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaRegressionContainer.cc
@@ -7,66 +7,72 @@
 #include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
 #include "CondFormats/EgammaObjects/interface/GBRForestD.h"
 
-EgammaRegressionContainer::EgammaRegressionContainer(const edm::ParameterSet& iConfig):
-  outputTransformerLowEt_(iConfig.getParameter<double>("rangeMinLowEt"),iConfig.getParameter<double>("rangeMaxLowEt")),
-  outputTransformerHighEt_(iConfig.getParameter<double>("rangeMinHighEt"),iConfig.getParameter<double>("rangeMaxHighEt")),
-  forceHighEnergyTrainingIfSaturated_(iConfig.getParameter<bool>("forceHighEnergyTrainingIfSaturated")),
-  lowEtHighEtBoundary_(iConfig.getParameter<double>("lowEtHighEtBoundary")),
-  ebLowEtForestName_(iConfig.getParameter<std::string>("ebLowEtForestName")),
-  ebHighEtForestName_(iConfig.getParameter<std::string>("ebHighEtForestName")),
-  eeLowEtForestName_(iConfig.getParameter<std::string>("eeLowEtForestName")),
-  eeHighEtForestName_(iConfig.getParameter<std::string>("eeHighEtForestName")),
-  ebLowEtForest_(nullptr),ebHighEtForest_(nullptr),
-  eeLowEtForest_(nullptr),eeHighEtForest_(nullptr)
-{
+EgammaRegressionContainer::EgammaRegressionContainer(const edm::ParameterSet& iConfig)
+    : outputTransformerLowEt_(iConfig.getParameter<double>("rangeMinLowEt"),
+                              iConfig.getParameter<double>("rangeMaxLowEt")),
+      outputTransformerHighEt_(iConfig.getParameter<double>("rangeMinHighEt"),
+                               iConfig.getParameter<double>("rangeMaxHighEt")),
+      forceHighEnergyTrainingIfSaturated_(iConfig.getParameter<bool>("forceHighEnergyTrainingIfSaturated")),
+      lowEtHighEtBoundary_(iConfig.getParameter<double>("lowEtHighEtBoundary")),
+      ebLowEtForestName_(iConfig.getParameter<std::string>("ebLowEtForestName")),
+      ebHighEtForestName_(iConfig.getParameter<std::string>("ebHighEtForestName")),
+      eeLowEtForestName_(iConfig.getParameter<std::string>("eeLowEtForestName")),
+      eeHighEtForestName_(iConfig.getParameter<std::string>("eeHighEtForestName")),
+      ebLowEtForest_(nullptr),
+      ebHighEtForest_(nullptr),
+      eeLowEtForest_(nullptr),
+      eeHighEtForest_(nullptr) {}
 
-}
-
-edm::ParameterSetDescription EgammaRegressionContainer::makePSetDescription()
-{
+edm::ParameterSetDescription EgammaRegressionContainer::makePSetDescription() {
   edm::ParameterSetDescription desc;
-  desc.add<double>("rangeMinLowEt",-1.);
-  desc.add<double>("rangeMaxLowEt",3.0);
-  desc.add<double>("rangeMinHighEt",-1.);
-  desc.add<double>("rangeMaxHighEt",3.0);
-  desc.add<double>("lowEtHighEtBoundary",50.);
-  desc.add<bool>("forceHighEnergyTrainingIfSaturated",false);
-  desc.add<std::string>("ebLowEtForestName","electron_eb_ECALTRK_lowpt");
-  desc.add<std::string>("ebHighEtForestName","electron_eb_ECALTRK");
-  desc.add<std::string>("eeLowEtForestName","electron_ee_ECALTRK_lowpt");
-  desc.add<std::string>("eeHighEtForestName","electron_ee_ECALTRK");
+  desc.add<double>("rangeMinLowEt", -1.);
+  desc.add<double>("rangeMaxLowEt", 3.0);
+  desc.add<double>("rangeMinHighEt", -1.);
+  desc.add<double>("rangeMaxHighEt", 3.0);
+  desc.add<double>("lowEtHighEtBoundary", 50.);
+  desc.add<bool>("forceHighEnergyTrainingIfSaturated", false);
+  desc.add<std::string>("ebLowEtForestName", "electron_eb_ECALTRK_lowpt");
+  desc.add<std::string>("ebHighEtForestName", "electron_eb_ECALTRK");
+  desc.add<std::string>("eeLowEtForestName", "electron_ee_ECALTRK_lowpt");
+  desc.add<std::string>("eeHighEtForestName", "electron_ee_ECALTRK");
   return desc;
 }
 
-namespace{
-  const GBRForestD* getForest(const edm::EventSetup& iSetup,const std::string&name){
+namespace {
+  const GBRForestD* getForest(const edm::EventSetup& iSetup, const std::string& name) {
     edm::ESHandle<GBRForestD> handle;
-    iSetup.get<GBRDWrapperRcd>().get(name,handle);
+    iSetup.get<GBRDWrapperRcd>().get(name, handle);
     return handle.product();
   }
+}  // namespace
+
+void EgammaRegressionContainer::setEventContent(const edm::EventSetup& iSetup) {
+  ebLowEtForest_ = getForest(iSetup, ebLowEtForestName_);
+  ebHighEtForest_ = getForest(iSetup, ebHighEtForestName_);
+  eeLowEtForest_ = getForest(iSetup, eeLowEtForestName_);
+  eeHighEtForest_ = getForest(iSetup, eeHighEtForestName_);
 }
 
-void EgammaRegressionContainer::setEventContent(const edm::EventSetup& iSetup)
-{
-  ebLowEtForest_  = getForest(iSetup,ebLowEtForestName_);
-  ebHighEtForest_ = getForest(iSetup,ebHighEtForestName_);
-  eeLowEtForest_  = getForest(iSetup,eeLowEtForestName_);
-  eeHighEtForest_ = getForest(iSetup,eeHighEtForestName_); 
-}
-
-float EgammaRegressionContainer::operator()(const float et,const bool isEB,const bool isSaturated,const float* data)const
-{
-  if(useLowEtBin(et,isSaturated)){
-    if(isEB) return outputTransformerLowEt_(ebLowEtForest_->GetResponse(data));
-    else return outputTransformerLowEt_(eeLowEtForest_->GetResponse(data));
-  }else{
-    if(isEB) return outputTransformerHighEt_(ebHighEtForest_->GetResponse(data));
-    else return outputTransformerHighEt_(eeHighEtForest_->GetResponse(data));
+float EgammaRegressionContainer::operator()(const float et,
+                                            const bool isEB,
+                                            const bool isSaturated,
+                                            const float* data) const {
+  if (useLowEtBin(et, isSaturated)) {
+    if (isEB)
+      return outputTransformerLowEt_(ebLowEtForest_->GetResponse(data));
+    else
+      return outputTransformerLowEt_(eeLowEtForest_->GetResponse(data));
+  } else {
+    if (isEB)
+      return outputTransformerHighEt_(ebHighEtForest_->GetResponse(data));
+    else
+      return outputTransformerHighEt_(eeHighEtForest_->GetResponse(data));
   }
 }
- 
-bool EgammaRegressionContainer::useLowEtBin(const float et,const bool isSaturated)const
-{
-  if(isSaturated && forceHighEnergyTrainingIfSaturated_) return false;
-  else return et<lowEtHighEtBoundary_;
+
+bool EgammaRegressionContainer::useLowEtBin(const float et, const bool isSaturated) const {
+  if (isSaturated && forceHighEnergyTrainingIfSaturated_)
+    return false;
+  else
+    return et < lowEtHighEtBoundary_;
 }

--- a/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
@@ -9,45 +9,35 @@
 const EnergyScaleCorrection::ScaleCorrection ElectronEnergyCalibrator::defaultScaleCorr_;
 const EnergyScaleCorrection::SmearCorrection ElectronEnergyCalibrator::defaultSmearCorr_;
 
-ElectronEnergyCalibrator::ElectronEnergyCalibrator(const EpCombinationTool &combinator,
-						   const std::string& correctionFile) :
-  correctionRetriever_(correctionFile), 
-  epCombinationTool_(&combinator), 
-  rng_(nullptr),
-  minEt_(1.0)
-{
-  
+ElectronEnergyCalibrator::ElectronEnergyCalibrator(const EpCombinationTool& combinator,
+                                                   const std::string& correctionFile)
+    : correctionRetriever_(correctionFile), epCombinationTool_(&combinator), rng_(nullptr), minEt_(1.0) {}
+
+void ElectronEnergyCalibrator::initPrivateRng(TRandom* rnd) { rng_ = rnd; }
+
+std::array<float, EGEnergySysIndex::kNrSysErrs> ElectronEnergyCalibrator::calibrate(
+    reco::GsfElectron& ele,
+    const unsigned int runNumber,
+    const EcalRecHitCollection* recHits,
+    edm::StreamID const& id,
+    const ElectronEnergyCalibrator::EventType eventType) const {
+  return calibrate(ele, runNumber, recHits, gauss(id), eventType);
 }
 
-void ElectronEnergyCalibrator::initPrivateRng(TRandom *rnd)
-{
-  rng_ = rnd;
-}
-
-std::array<float,EGEnergySysIndex::kNrSysErrs> ElectronEnergyCalibrator::
-calibrate(reco::GsfElectron &ele,
-	  const unsigned int runNumber, 
-	  const EcalRecHitCollection *recHits, 
-	  edm::StreamID const & id, 
-	  const ElectronEnergyCalibrator::EventType eventType) const
-{
-  return calibrate(ele,runNumber,recHits,gauss(id),eventType);
-}
-
-std::array<float,EGEnergySysIndex::kNrSysErrs> ElectronEnergyCalibrator::
-calibrate(reco::GsfElectron &ele, unsigned int runNumber, 
-	  const EcalRecHitCollection *recHits, 
-	  const float smearNrSigma, 
-	  const ElectronEnergyCalibrator::EventType eventType) const
-{
+std::array<float, EGEnergySysIndex::kNrSysErrs> ElectronEnergyCalibrator::calibrate(
+    reco::GsfElectron& ele,
+    unsigned int runNumber,
+    const EcalRecHitCollection* recHits,
+    const float smearNrSigma,
+    const ElectronEnergyCalibrator::EventType eventType) const {
   const float scEtaAbs = std::abs(ele.superCluster()->eta());
   const float et = ele.ecalEnergy() / cosh(scEtaAbs);
 
-  if (et < minEt_ || edm::isNotFinite(et) ) {
-    std::array<float,EGEnergySysIndex::kNrSysErrs> retVal;
+  if (et < minEt_ || edm::isNotFinite(et)) {
+    std::array<float, EGEnergySysIndex::kNrSysErrs> retVal;
     retVal.fill(ele.energy());
-    retVal[EGEnergySysIndex::kScaleValue]  = 1.0;
-    retVal[EGEnergySysIndex::kSmearValue]  = 0.0;
+    retVal[EGEnergySysIndex::kScaleValue] = 1.0;
+    retVal[EGEnergySysIndex::kSmearValue] = 0.0;
     retVal[EGEnergySysIndex::kSmearNrSigma] = smearNrSigma;
     retVal[EGEnergySysIndex::kEcalPreCorr] = ele.ecalEnergy();
     retVal[EGEnergySysIndex::kEcalErrPreCorr] = ele.ecalEnergyError();
@@ -63,49 +53,55 @@ calibrate(reco::GsfElectron &ele, unsigned int runNumber,
   const DetId seedDetId = ele.superCluster()->seed()->seed();
   EcalRecHitCollection::const_iterator seedRecHit = recHits->find(seedDetId);
   unsigned int gainSeedSC = 12;
-  if (seedRecHit != recHits->end()) { 
-    if(seedRecHit->checkFlag(EcalRecHit::kHasSwitchToGain6)) gainSeedSC = 6;
-    if(seedRecHit->checkFlag(EcalRecHit::kHasSwitchToGain1)) gainSeedSC = 1;
+  if (seedRecHit != recHits->end()) {
+    if (seedRecHit->checkFlag(EcalRecHit::kHasSwitchToGain6))
+      gainSeedSC = 6;
+    if (seedRecHit->checkFlag(EcalRecHit::kHasSwitchToGain1))
+      gainSeedSC = 1;
   }
 
-  const EnergyScaleCorrection::ScaleCorrection* scaleCorr = correctionRetriever_.getScaleCorr(runNumber, et, scEtaAbs, ele.full5x5_r9(), gainSeedSC);  
-  const EnergyScaleCorrection::SmearCorrection* smearCorr = correctionRetriever_.getSmearCorr(runNumber, et, scEtaAbs, ele.full5x5_r9(), gainSeedSC);  
-  if(scaleCorr==nullptr) scaleCorr=&defaultScaleCorr_;
-  if(smearCorr==nullptr) smearCorr=&defaultSmearCorr_;
-  
-  std::array<float,EGEnergySysIndex::kNrSysErrs> uncertainties{};
-  
-  uncertainties[EGEnergySysIndex::kScaleValue]  = scaleCorr->scale();
-  uncertainties[EGEnergySysIndex::kSmearValue]  = smearCorr->sigma(et); //even though we use scale = 1.0, we still store the value returned for MC
-  uncertainties[EGEnergySysIndex::kSmearNrSigma]  = smearNrSigma;
+  const EnergyScaleCorrection::ScaleCorrection* scaleCorr =
+      correctionRetriever_.getScaleCorr(runNumber, et, scEtaAbs, ele.full5x5_r9(), gainSeedSC);
+  const EnergyScaleCorrection::SmearCorrection* smearCorr =
+      correctionRetriever_.getSmearCorr(runNumber, et, scEtaAbs, ele.full5x5_r9(), gainSeedSC);
+  if (scaleCorr == nullptr)
+    scaleCorr = &defaultScaleCorr_;
+  if (smearCorr == nullptr)
+    smearCorr = &defaultSmearCorr_;
+
+  std::array<float, EGEnergySysIndex::kNrSysErrs> uncertainties{};
+
+  uncertainties[EGEnergySysIndex::kScaleValue] = scaleCorr->scale();
+  uncertainties[EGEnergySysIndex::kSmearValue] =
+      smearCorr->sigma(et);  //even though we use scale = 1.0, we still store the value returned for MC
+  uncertainties[EGEnergySysIndex::kSmearNrSigma] = smearNrSigma;
   //MC central values are not scaled (scale = 1.0), data is not smeared (smearNrSigma = 0)
   //the smearing (or resolution extra parameter as it might better be called)
   //still has a second order effect on data as it enters the E/p combination as an adjustment
   //to the estimate of the resolution contained in caloEnergyError
   //MC gets all the scale systematics
-  if(eventType == EventType::DATA){ 
-    setEnergyAndSystVarations(scaleCorr->scale(),0.,et,*scaleCorr,*smearCorr,ele,uncertainties);
-  }else if(eventType == EventType::MC){
-    setEnergyAndSystVarations(1.0,smearNrSigma,et,*scaleCorr,*smearCorr,ele,uncertainties);
+  if (eventType == EventType::DATA) {
+    setEnergyAndSystVarations(scaleCorr->scale(), 0., et, *scaleCorr, *smearCorr, ele, uncertainties);
+  } else if (eventType == EventType::MC) {
+    setEnergyAndSystVarations(1.0, smearNrSigma, et, *scaleCorr, *smearCorr, ele, uncertainties);
   }
- 
+
   return uncertainties;
-  
 }
 
-void ElectronEnergyCalibrator::
-setEnergyAndSystVarations(const float scale,const float smearNrSigma,const float et,
-			  const EnergyScaleCorrection::ScaleCorrection& scaleCorr,
-			  const EnergyScaleCorrection::SmearCorrection& smearCorr,
-			  reco::GsfElectron& ele,
-			  std::array<float,EGEnergySysIndex::kNrSysErrs>& energyData)const
-{
- 
-  const float smear = smearCorr.sigma(et);   
-  const float smearRhoUp = smearCorr.sigma(et,1,0);
-  const float smearRhoDn = smearCorr.sigma(et,-1,0);
-  const float smearPhiUp = smearCorr.sigma(et,0,1);
-  const float smearPhiDn = smearCorr.sigma(et,0,-1);
+void ElectronEnergyCalibrator::setEnergyAndSystVarations(
+    const float scale,
+    const float smearNrSigma,
+    const float et,
+    const EnergyScaleCorrection::ScaleCorrection& scaleCorr,
+    const EnergyScaleCorrection::SmearCorrection& smearCorr,
+    reco::GsfElectron& ele,
+    std::array<float, EGEnergySysIndex::kNrSysErrs>& energyData) const {
+  const float smear = smearCorr.sigma(et);
+  const float smearRhoUp = smearCorr.sigma(et, 1, 0);
+  const float smearRhoDn = smearCorr.sigma(et, -1, 0);
+  const float smearPhiUp = smearCorr.sigma(et, 0, 1);
+  const float smearPhiDn = smearCorr.sigma(et, 0, -1);
   const float smearUp = smearRhoUp;
   const float smearDn = smearRhoDn;
 
@@ -117,100 +113,90 @@ setEnergyAndSystVarations(const float scale,const float smearNrSigma,const float
   const float corrUp = corrRhoUp;
   const float corrDn = corrRhoDn;
 
-  const float corrScaleStatUp = corr+scaleCorr.scaleErrStat();
-  const float corrScaleStatDn = corr-scaleCorr.scaleErrStat();
-  const float corrScaleSystUp = corr+scaleCorr.scaleErrSyst();
-  const float corrScaleSystDn = corr-scaleCorr.scaleErrSyst();
-  const float corrScaleGainUp = corr+scaleCorr.scaleErrGain();
-  const float corrScaleGainDn = corr-scaleCorr.scaleErrGain();
-  const float corrScaleUp = corr+scaleCorr.scaleErr(EnergyScaleCorrection::kErrStatSystGain);
-  const float corrScaleDn = corr-scaleCorr.scaleErr(EnergyScaleCorrection::kErrStatSystGain);
-  
+  const float corrScaleStatUp = corr + scaleCorr.scaleErrStat();
+  const float corrScaleStatDn = corr - scaleCorr.scaleErrStat();
+  const float corrScaleSystUp = corr + scaleCorr.scaleErrSyst();
+  const float corrScaleSystDn = corr - scaleCorr.scaleErrSyst();
+  const float corrScaleGainUp = corr + scaleCorr.scaleErrGain();
+  const float corrScaleGainDn = corr - scaleCorr.scaleErrGain();
+  const float corrScaleUp = corr + scaleCorr.scaleErr(EnergyScaleCorrection::kErrStatSystGain);
+  const float corrScaleDn = corr - scaleCorr.scaleErr(EnergyScaleCorrection::kErrStatSystGain);
+
   const math::XYZTLorentzVector oldP4 = ele.p4();
   energyData[EGEnergySysIndex::kEcalTrkPreCorr] = ele.energy();
   energyData[EGEnergySysIndex::kEcalTrkErrPreCorr] = ele.corrections().combinedP4Error;
   energyData[EGEnergySysIndex::kEcalPreCorr] = ele.ecalEnergy();
   energyData[EGEnergySysIndex::kEcalErrPreCorr] = ele.ecalEnergyError();
-  
-  energyData[EGEnergySysIndex::kScaleStatUp]   = calCombinedMom(ele,corrScaleStatUp,smear).first;
-  energyData[EGEnergySysIndex::kScaleStatDown] = calCombinedMom(ele,corrScaleStatDn,smear).first;
-  energyData[EGEnergySysIndex::kScaleSystUp]   = calCombinedMom(ele,corrScaleSystUp,smear).first;
-  energyData[EGEnergySysIndex::kScaleSystDown] = calCombinedMom(ele,corrScaleSystDn,smear).first;
-  energyData[EGEnergySysIndex::kScaleGainUp]   = calCombinedMom(ele,corrScaleGainUp,smear).first;
-  energyData[EGEnergySysIndex::kScaleGainDown] = calCombinedMom(ele,corrScaleGainDn,smear).first;
-  
-  energyData[EGEnergySysIndex::kSmearRhoUp]   = calCombinedMom(ele,corrRhoUp,smearRhoUp).first;
-  energyData[EGEnergySysIndex::kSmearRhoDown] = calCombinedMom(ele,corrRhoDn,smearRhoDn).first;
-  energyData[EGEnergySysIndex::kSmearPhiUp]   = calCombinedMom(ele,corrPhiUp,smearPhiUp).first;
-  energyData[EGEnergySysIndex::kSmearPhiDown] = calCombinedMom(ele,corrPhiDn,smearPhiDn).first;
-  
-  energyData[EGEnergySysIndex::kScaleUp]   = calCombinedMom(ele,corrScaleUp,smear).first;
-  energyData[EGEnergySysIndex::kScaleDown] = calCombinedMom(ele,corrScaleDn,smear).first;
-  energyData[EGEnergySysIndex::kSmearUp]   = calCombinedMom(ele,corrUp,smearUp).first;
-  energyData[EGEnergySysIndex::kSmearDown] = calCombinedMom(ele,corrDn,smearDn).first;
-  
-  const std::pair<float, float> combinedMomentum = calCombinedMom(ele,corr,smear);
-  setEcalEnergy(ele,corr,smear);
-  const float energyCorr =  combinedMomentum.first / oldP4.t();
 
-  const math::XYZTLorentzVector newP4(oldP4.x() * energyCorr,
-				      oldP4.y() * energyCorr,
-				      oldP4.z() * energyCorr,
-				      combinedMomentum.first);
-  
-  ele.correctMomentum(newP4, ele.trackMomentumError(), combinedMomentum.second); 
+  energyData[EGEnergySysIndex::kScaleStatUp] = calCombinedMom(ele, corrScaleStatUp, smear).first;
+  energyData[EGEnergySysIndex::kScaleStatDown] = calCombinedMom(ele, corrScaleStatDn, smear).first;
+  energyData[EGEnergySysIndex::kScaleSystUp] = calCombinedMom(ele, corrScaleSystUp, smear).first;
+  energyData[EGEnergySysIndex::kScaleSystDown] = calCombinedMom(ele, corrScaleSystDn, smear).first;
+  energyData[EGEnergySysIndex::kScaleGainUp] = calCombinedMom(ele, corrScaleGainUp, smear).first;
+  energyData[EGEnergySysIndex::kScaleGainDown] = calCombinedMom(ele, corrScaleGainDn, smear).first;
+
+  energyData[EGEnergySysIndex::kSmearRhoUp] = calCombinedMom(ele, corrRhoUp, smearRhoUp).first;
+  energyData[EGEnergySysIndex::kSmearRhoDown] = calCombinedMom(ele, corrRhoDn, smearRhoDn).first;
+  energyData[EGEnergySysIndex::kSmearPhiUp] = calCombinedMom(ele, corrPhiUp, smearPhiUp).first;
+  energyData[EGEnergySysIndex::kSmearPhiDown] = calCombinedMom(ele, corrPhiDn, smearPhiDn).first;
+
+  energyData[EGEnergySysIndex::kScaleUp] = calCombinedMom(ele, corrScaleUp, smear).first;
+  energyData[EGEnergySysIndex::kScaleDown] = calCombinedMom(ele, corrScaleDn, smear).first;
+  energyData[EGEnergySysIndex::kSmearUp] = calCombinedMom(ele, corrUp, smearUp).first;
+  energyData[EGEnergySysIndex::kSmearDown] = calCombinedMom(ele, corrDn, smearDn).first;
+
+  const std::pair<float, float> combinedMomentum = calCombinedMom(ele, corr, smear);
+  setEcalEnergy(ele, corr, smear);
+  const float energyCorr = combinedMomentum.first / oldP4.t();
+
+  const math::XYZTLorentzVector newP4(
+      oldP4.x() * energyCorr, oldP4.y() * energyCorr, oldP4.z() * energyCorr, combinedMomentum.first);
+
+  ele.correctMomentum(newP4, ele.trackMomentumError(), combinedMomentum.second);
   energyData[EGEnergySysIndex::kEcalTrkPostCorr] = ele.energy();
   energyData[EGEnergySysIndex::kEcalTrkErrPostCorr] = ele.corrections().combinedP4Error;
-  
+
   energyData[EGEnergySysIndex::kEcalPostCorr] = ele.ecalEnergy();
   energyData[EGEnergySysIndex::kEcalErrPostCorr] = ele.ecalEnergyError();
-  
 }
 
-
-void ElectronEnergyCalibrator::setEcalEnergy(reco::GsfElectron& ele,
-					     const float scale,
-					     const float smear)const
-{
+void ElectronEnergyCalibrator::setEcalEnergy(reco::GsfElectron& ele, const float scale, const float smear) const {
   const float oldEcalEnergy = ele.ecalEnergy();
   const float oldEcalEnergyErr = ele.ecalEnergyError();
-  ele.setCorrectedEcalEnergy( oldEcalEnergy*scale );
-  ele.setCorrectedEcalEnergyError(std::hypot( oldEcalEnergyErr*scale, oldEcalEnergy*smear*scale ) );
+  ele.setCorrectedEcalEnergy(oldEcalEnergy * scale);
+  ele.setCorrectedEcalEnergyError(std::hypot(oldEcalEnergyErr * scale, oldEcalEnergy * smear * scale));
 }
 
-std::pair<float,float> ElectronEnergyCalibrator::calCombinedMom(reco::GsfElectron& ele,
-								const float scale,
-								const float smear)const
-{ 
+std::pair<float, float> ElectronEnergyCalibrator::calCombinedMom(reco::GsfElectron& ele,
+                                                                 const float scale,
+                                                                 const float smear) const {
   const float oldEcalEnergy = ele.ecalEnergy();
   const float oldEcalEnergyErr = ele.ecalEnergyError();
 
   const auto oldP4 = ele.p4();
   const float oldP4Err = ele.p4Error(reco::GsfElectron::P4_COMBINATION);
   const float oldTrkMomErr = ele.trackMomentumError();
- 
-  setEcalEnergy(ele,scale,smear);
-  const auto& combinedMomentum = epCombinationTool_->combine(ele,oldEcalEnergyErr*scale);
-  
+
+  setEcalEnergy(ele, scale, smear);
+  const auto& combinedMomentum = epCombinationTool_->combine(ele, oldEcalEnergyErr * scale);
+
   ele.setCorrectedEcalEnergy(oldEcalEnergy);
   ele.setCorrectedEcalEnergyError(oldEcalEnergyErr);
-  ele.correctMomentum(oldP4,oldTrkMomErr,oldP4Err);
-  
+  ele.correctMomentum(oldP4, oldTrkMomErr, oldP4Err);
+
   return combinedMomentum;
 }
-						      
 
-double ElectronEnergyCalibrator::gauss(edm::StreamID const& id) const
-{
+double ElectronEnergyCalibrator::gauss(edm::StreamID const& id) const {
   if (rng_) {
     return rng_->Gaus();
   } else {
     edm::Service<edm::RandomNumberGenerator> rng;
-    if ( !rng.isAvailable() ) {
+    if (!rng.isAvailable()) {
       throw cms::Exception("Configuration")
-	<< "XXXXXXX requires the RandomNumberGeneratorService\n"
-	"which is not present in the configuration file.  You must add the service\n"
-	"in the configuration file or remove the modules that require it.";
+          << "XXXXXXX requires the RandomNumberGeneratorService\n"
+             "which is not present in the configuration file.  You must add the service\n"
+             "in the configuration file or remove the modules that require it.";
     }
     CLHEP::RandGaussQ gaussDistribution(rng->getEngine(id), 0.0, 1.0);
     return gaussDistribution.fire();

--- a/RecoEgamma/EgammaTools/src/EnergyScaleCorrection.cc
+++ b/RecoEgamma/EgammaTools/src/EnergyScaleCorrection.cc
@@ -8,200 +8,204 @@
 #include <iomanip>
 #include <algorithm>
 
-
-EnergyScaleCorrection::EnergyScaleCorrection(const std::string& correctionFileName, unsigned int genSeed):
-  smearingType_(ECALELF)
-{
-
-  if(!correctionFileName.empty()) { 
-    std::string filename = correctionFileName+"_scales.dat";
+EnergyScaleCorrection::EnergyScaleCorrection(const std::string& correctionFileName, unsigned int genSeed)
+    : smearingType_(ECALELF) {
+  if (!correctionFileName.empty()) {
+    std::string filename = correctionFileName + "_scales.dat";
     readScalesFromFile(filename);
-    if(scales_.empty()) {
+    if (scales_.empty()) {
       throw cms::Exception("EnergyScaleCorrection") << "scale correction map empty";
     }
   }
-  
-  if(!correctionFileName.empty()) { 
-    std::string filename = correctionFileName+"_smearings.dat";
+
+  if (!correctionFileName.empty()) {
+    std::string filename = correctionFileName + "_smearings.dat";
     readSmearingsFromFile(filename);
-    if(smearings_.empty()) {
+    if (smearings_.empty()) {
       throw cms::Exception("EnergyScaleCorrection") << "smearing correction map empty";
     }
   }
-
 }
 
-float EnergyScaleCorrection::scaleCorr(unsigned int runNumber, double et, double eta, double r9,
-				       unsigned int gainSeed, std::bitset<kErrNrBits> uncBitMask) const
-{
-  const ScaleCorrection* scaleCorr =  getScaleCorr(runNumber, et, eta, r9, gainSeed);
-  if(scaleCorr!=nullptr) return scaleCorr->scale();
-  else return kDefaultScaleVal_;
-}
-
-
-
-float EnergyScaleCorrection::scaleCorrUncert(unsigned int runNumber, double et, double eta, double r9,
-					     unsigned int gainSeed, std::bitset<kErrNrBits> uncBitMask) const
-{
-  
+float EnergyScaleCorrection::scaleCorr(unsigned int runNumber,
+                                       double et,
+                                       double eta,
+                                       double r9,
+                                       unsigned int gainSeed,
+                                       std::bitset<kErrNrBits> uncBitMask) const {
   const ScaleCorrection* scaleCorr = getScaleCorr(runNumber, et, eta, r9, gainSeed);
-  if(scaleCorr!=nullptr) return scaleCorr->scaleErr(uncBitMask);
-  else return 0.;
+  if (scaleCorr != nullptr)
+    return scaleCorr->scale();
+  else
+    return kDefaultScaleVal_;
 }
 
+float EnergyScaleCorrection::scaleCorrUncert(unsigned int runNumber,
+                                             double et,
+                                             double eta,
+                                             double r9,
+                                             unsigned int gainSeed,
+                                             std::bitset<kErrNrBits> uncBitMask) const {
+  const ScaleCorrection* scaleCorr = getScaleCorr(runNumber, et, eta, r9, gainSeed);
+  if (scaleCorr != nullptr)
+    return scaleCorr->scaleErr(uncBitMask);
+  else
+    return 0.;
+}
 
-float EnergyScaleCorrection::smearingSigma(int runnr, double et, double eta, double r9,
-					   unsigned int gainSeed, ParamSmear par, 
-					   float nSigma) const
-{
-  if (par == kRho) return smearingSigma(runnr, et, eta, r9, gainSeed, nSigma, 0.);
-  if (par == kPhi) return smearingSigma(runnr, et, eta, r9, gainSeed, 0., nSigma);
+float EnergyScaleCorrection::smearingSigma(
+    int runnr, double et, double eta, double r9, unsigned int gainSeed, ParamSmear par, float nSigma) const {
+  if (par == kRho)
+    return smearingSigma(runnr, et, eta, r9, gainSeed, nSigma, 0.);
+  if (par == kPhi)
+    return smearingSigma(runnr, et, eta, r9, gainSeed, 0., nSigma);
   return smearingSigma(runnr, et, eta, r9, gainSeed, 0., 0.);
 }
 
+float EnergyScaleCorrection::smearingSigma(
+    int runnr, double et, double eta, double r9, unsigned int gainSeed, float nrSigmaRho, float nrSigmaPhi) const {
+  const SmearCorrection* smearCorr = getSmearCorr(runnr, et, eta, r9, gainSeed);
 
-float EnergyScaleCorrection::smearingSigma(int runnr, double et, double eta, double r9,
-					   unsigned int gainSeed, float nrSigmaRho, 
-					   float nrSigmaPhi) const
-{
-  const SmearCorrection* smearCorr = getSmearCorr(runnr,et,eta,r9,gainSeed);
-						  
-  if(smearCorr!=nullptr) return smearCorr->sigma(nrSigmaRho,nrSigmaPhi);
-  else return kDefaultSmearVal_;
+  if (smearCorr != nullptr)
+    return smearCorr->sigma(nrSigmaRho, nrSigmaPhi);
+  else
+    return kDefaultSmearVal_;
 }
 
-
-const EnergyScaleCorrection::ScaleCorrection* 
-EnergyScaleCorrection::getScaleCorr(unsigned int runnr, double et, double eta, double r9,
-				    unsigned int gainSeed) const
-{
-
+const EnergyScaleCorrection::ScaleCorrection* EnergyScaleCorrection::getScaleCorr(
+    unsigned int runnr, double et, double eta, double r9, unsigned int gainSeed) const {
   // buld the category based on the values of the object
   CorrectionCategory category(runnr, et, eta, r9, gainSeed);
-  auto result = std::equal_range(scales_.begin(),scales_.end(),category,Sorter<CorrectionCategory,ScaleCorrection>()); 
-  auto nrFound = std::distance(result.first,result.second);
-  if(nrFound==0){
-    edm::LogInfo("EnergyScaleCorrection") << "Scale category not found: " << category << " Returning uncorrected value.";
+  auto result =
+      std::equal_range(scales_.begin(), scales_.end(), category, Sorter<CorrectionCategory, ScaleCorrection>());
+  auto nrFound = std::distance(result.first, result.second);
+  if (nrFound == 0) {
+    edm::LogInfo("EnergyScaleCorrection")
+        << "Scale category not found: " << category << " Returning uncorrected value.";
     return nullptr;
-  }else if(nrFound>1){
+  } else if (nrFound > 1) {
     std::ostringstream foundCats;
-    for(auto it = result.first;it!=result.second;++it){
-      foundCats<<"    "<<it->first<<std::endl;
+    for (auto it = result.first; it != result.second; ++it) {
+      foundCats << "    " << it->first << std::endl;
     }
-    throw cms::Exception("ConfigError") <<" scale error category "<<category<<" has "<<nrFound<<" entries "<<std::endl<<foundCats.str();
-  }  
+    throw cms::Exception("ConfigError") << " scale error category " << category << " has " << nrFound << " entries "
+                                        << std::endl
+                                        << foundCats.str();
+  }
   //validate the result, just to be sure
-  if(!result.first->first.inCategory(runnr,et,eta,r9,gainSeed)){
-    throw cms::Exception("LogicError") <<" error found scale category "<<result.first->first<<" that does not contain run "<<runnr<<" et "<<et<<" eta "<<eta<<" r9 "<<r9<<" gain seed "<<gainSeed;
+  if (!result.first->first.inCategory(runnr, et, eta, r9, gainSeed)) {
+    throw cms::Exception("LogicError") << " error found scale category " << result.first->first
+                                       << " that does not contain run " << runnr << " et " << et << " eta " << eta
+                                       << " r9 " << r9 << " gain seed " << gainSeed;
   }
   return &result.first->second;
 }
 
-const EnergyScaleCorrection::SmearCorrection* 
-EnergyScaleCorrection::getSmearCorr(unsigned int runnr, double et, double eta, double r9,
-				    unsigned int gainSeed) const
-{
-
+const EnergyScaleCorrection::SmearCorrection* EnergyScaleCorrection::getSmearCorr(
+    unsigned int runnr, double et, double eta, double r9, unsigned int gainSeed) const {
   // buld the category based on the values of the object
   CorrectionCategory category(runnr, et, eta, r9, gainSeed);
-  auto result = std::equal_range(smearings_.begin(),smearings_.end(),category,Sorter<CorrectionCategory,SmearCorrection>()); 
-  auto nrFound = std::distance(result.first,result.second);
-  if(nrFound==0){
-    edm::LogInfo("EnergyScaleCorrection") << "Smear category not found: " << category << " Returning uncorrected value.";
+  auto result =
+      std::equal_range(smearings_.begin(), smearings_.end(), category, Sorter<CorrectionCategory, SmearCorrection>());
+  auto nrFound = std::distance(result.first, result.second);
+  if (nrFound == 0) {
+    edm::LogInfo("EnergyScaleCorrection")
+        << "Smear category not found: " << category << " Returning uncorrected value.";
     return nullptr;
-  }else if(nrFound>1){
+  } else if (nrFound > 1) {
     std::ostringstream foundCats;
-    for(auto it = result.first;it!=result.second;++it){
-      foundCats<<"    "<<it->first<<std::endl;
+    for (auto it = result.first; it != result.second; ++it) {
+      foundCats << "    " << it->first << std::endl;
     }
-    throw cms::Exception("ConfigError") <<" error smear category "<<category<<" has "<<nrFound<<" entries "<<std::endl<<foundCats.str();
+    throw cms::Exception("ConfigError") << " error smear category " << category << " has " << nrFound << " entries "
+                                        << std::endl
+                                        << foundCats.str();
   }
   //validate the result, just to be sure
-  if(!result.first->first.inCategory(runnr,et,eta,r9,gainSeed)){
-    throw cms::Exception("LogicError") <<" error found smear category "<<result.first->first<<" that does not contain run "<<runnr<<" et "<<et<<" eta "<<eta<<" r9 "<<r9<<" gain seed "<<gainSeed;
+  if (!result.first->first.inCategory(runnr, et, eta, r9, gainSeed)) {
+    throw cms::Exception("LogicError") << " error found smear category " << result.first->first
+                                       << " that does not contain run " << runnr << " et " << et << " eta " << eta
+                                       << " r9 " << r9 << " gain seed " << gainSeed;
   }
   return &result.first->second;
 }
 
-
-void EnergyScaleCorrection::addScale(const std::string& category, int runMin, int runMax,  
-				     double energyScale, double energyScaleErrStat, 
-				     double energyScaleErrSyst, double energyScaleErrGain)
-{
-  
-  CorrectionCategory cat(category,runMin,runMax); // build the category from the string
-  auto result = std::equal_range(scales_.begin(),scales_.end(),cat,Sorter<CorrectionCategory,ScaleCorrection>());
-  if(result.first!=result.second){
-    throw cms::Exception("ConfigError") << "Category already defined! "<<cat;
+void EnergyScaleCorrection::addScale(const std::string& category,
+                                     int runMin,
+                                     int runMax,
+                                     double energyScale,
+                                     double energyScaleErrStat,
+                                     double energyScaleErrSyst,
+                                     double energyScaleErrGain) {
+  CorrectionCategory cat(category, runMin, runMax);  // build the category from the string
+  auto result = std::equal_range(scales_.begin(), scales_.end(), cat, Sorter<CorrectionCategory, ScaleCorrection>());
+  if (result.first != result.second) {
+    throw cms::Exception("ConfigError") << "Category already defined! " << cat;
   }
-  
-  ScaleCorrection corr(energyScale,energyScaleErrStat,energyScaleErrSyst,energyScaleErrGain);
-  scales_.push_back({cat,corr});
-  std::sort(scales_.begin(),scales_.end(),Sorter<CorrectionCategory,ScaleCorrection>()); 
-  
+
+  ScaleCorrection corr(energyScale, energyScaleErrStat, energyScaleErrSyst, energyScaleErrGain);
+  scales_.push_back({cat, corr});
+  std::sort(scales_.begin(), scales_.end(), Sorter<CorrectionCategory, ScaleCorrection>());
 }
 
-void EnergyScaleCorrection::addSmearing(const std::string& category,int runMin, int runMax,
-					double rho, double errRho, 
-					double phi, double errPhi,
-					double eMean, double errEMean)
-{
+void EnergyScaleCorrection::addSmearing(const std::string& category,
+                                        int runMin,
+                                        int runMax,
+                                        double rho,
+                                        double errRho,
+                                        double phi,
+                                        double errPhi,
+                                        double eMean,
+                                        double errEMean) {
   CorrectionCategory cat(category);
-  
-  auto res = std::equal_range(smearings_.begin(),smearings_.end(),cat,Sorter<CorrectionCategory,SmearCorrection>()); 
 
-  if(res.first!=res.second) {
-    throw cms::Exception("EnergyScaleCorrection") << "Smearing category already defined "<<cat;
+  auto res = std::equal_range(smearings_.begin(), smearings_.end(), cat, Sorter<CorrectionCategory, SmearCorrection>());
+
+  if (res.first != res.second) {
+    throw cms::Exception("EnergyScaleCorrection") << "Smearing category already defined " << cat;
   }
-  
-  SmearCorrection corr(rho,errRho,phi,errPhi,eMean,errEMean);
-  smearings_.push_back({cat,corr});
-  std::sort(smearings_.begin(),smearings_.end(),Sorter<CorrectionCategory,SmearCorrection>());
+
+  SmearCorrection corr(rho, errRho, phi, errPhi, eMean, errEMean);
+  smearings_.push_back({cat, corr});
+  std::sort(smearings_.begin(), smearings_.end(), Sorter<CorrectionCategory, SmearCorrection>());
 }
 
-
-void EnergyScaleCorrection::setSmearingType(FileFormat value)
-{
-  if(value >= 0 && value <= 1) {
+void EnergyScaleCorrection::setSmearingType(FileFormat value) {
+  if (value >= 0 && value <= 1) {
     smearingType_ = value;
   } else {
     smearingType_ = UNKNOWN;
   }
 }
 
-void EnergyScaleCorrection::readScalesFromFile(const std::string& filename)
-{
+void EnergyScaleCorrection::readScalesFromFile(const std::string& filename) {
   std::ifstream file(edm::FileInPath(filename).fullPath().c_str());
-  
-  if(!file.good()) {
+
+  if (!file.good()) {
     throw cms::Exception("EnergyScaleCorrection") << "file " << filename << " not readable.";
   }
-  
+
   int runMin, runMax;
   std::string category, region2;
   double energyScale, energyScaleErr, energyScaleErrStat, energyScaleErrSyst, energyScaleErrGain;
-  
-  for(file >> category; file.good(); file >> category) {
-    file >> region2
-	 >> runMin >> runMax
-	 >> energyScale >> energyScaleErr >> energyScaleErrStat >> energyScaleErrSyst >> energyScaleErrGain;
+
+  for (file >> category; file.good(); file >> category) {
+    file >> region2 >> runMin >> runMax >> energyScale >> energyScaleErr >> energyScaleErrStat >> energyScaleErrSyst >>
+        energyScaleErrGain;
     addScale(category, runMin, runMax, energyScale, energyScaleErrStat, energyScaleErrSyst, energyScaleErrGain);
   }
-  
-  file.close();  
+
+  file.close();
   return;
 }
 
-
 //also more or less untouched function from the orginal package
-void EnergyScaleCorrection::readSmearingsFromFile(const std::string& filename)
-{
+void EnergyScaleCorrection::readSmearingsFromFile(const std::string& filename) {
   std::ifstream file(edm::FileInPath(filename).fullPath().c_str());
-  if(!file.good()) {
+  if (!file.good()) {
     throw cms::Exception("EnergyScaleCorrection") << "file " << filename << " not readable";
   }
-  
+
   int runMin = 0;
   int runMax = 900000;
   int unused = 0;
@@ -209,107 +213,107 @@ void EnergyScaleCorrection::readSmearingsFromFile(const std::string& filename)
   double rho, phi, eMean, errRho, errPhi, errEMean;
   double etaMin, etaMax, r9Min, r9Max;
   std::string phiString, errPhiString;
-  
-  while(file.peek() != EOF && file.good()) {
-    if(file.peek() == 10) { // 10 = \n
+
+  while (file.peek() != EOF && file.good()) {
+    if (file.peek() == 10) {  // 10 = \n
       file.get();
       continue;
     }
-    
-    if(file.peek() == 35) { // 35 = #
-      file.ignore(1000, 10); // ignore the rest of the line until \n
+
+    if (file.peek() == 35) {  // 35 = #
+      file.ignore(1000, 10);  // ignore the rest of the line until \n
       continue;
     }
-    
-    if(smearingType_ == UNKNOWN) { // trying to guess: not recommended
-      throw cms::Exception("ConfigError") <<"unknown smearing type";
-      
-    }else if(smearingType_ == GLOBE) {
-      file >> category >> unused >> etaMin >> etaMax >> r9Min >> r9Max >> runMin >> runMax >>
-	eMean >> errEMean >>
-	rho >> errRho >> phi >> errPhi;
-      
-      addSmearing(category, runMin, runMax, rho,  errRho, phi, errPhi, eMean, errEMean);
-      
-    } else if(smearingType_ == ECALELF) {
-      file >> category >> 
-	eMean >> errEMean >>
-	rho >> errRho >> phiString >> errPhiString;
-      
-      if(phiString=="M_PI_2") phi=M_PI_2;
-      else phi = std::stod(phiString);
-      
-      if(errPhiString=="M_PI_2") errPhi=M_PI_2;
-      else errPhi = std::stod(errPhiString);
-      
-      addSmearing(category, runMin, runMax, rho,  errRho, phi, errPhi, eMean, errEMean);
-      
+
+    if (smearingType_ == UNKNOWN) {  // trying to guess: not recommended
+      throw cms::Exception("ConfigError") << "unknown smearing type";
+
+    } else if (smearingType_ == GLOBE) {
+      file >> category >> unused >> etaMin >> etaMax >> r9Min >> r9Max >> runMin >> runMax >> eMean >> errEMean >>
+          rho >> errRho >> phi >> errPhi;
+
+      addSmearing(category, runMin, runMax, rho, errRho, phi, errPhi, eMean, errEMean);
+
+    } else if (smearingType_ == ECALELF) {
+      file >> category >> eMean >> errEMean >> rho >> errRho >> phiString >> errPhiString;
+
+      if (phiString == "M_PI_2")
+        phi = M_PI_2;
+      else
+        phi = std::stod(phiString);
+
+      if (errPhiString == "M_PI_2")
+        errPhi = M_PI_2;
+      else
+        errPhi = std::stod(errPhiString);
+
+      addSmearing(category, runMin, runMax, rho, errRho, phi, errPhi, eMean, errEMean);
+
     } else {
       file >> category >> rho >> phi;
       errRho = errPhi = eMean = errEMean = 0;
-      addSmearing(category, runMin, runMax, rho,  errRho, phi, errPhi, eMean, errEMean);
+      addSmearing(category, runMin, runMax, rho, errRho, phi, errPhi, eMean, errEMean);
     }
-
   }
-  
+
   file.close();
   return;
 }
 
-std::ostream& EnergyScaleCorrection::ScaleCorrection::print(std::ostream& os)const
-{
-  os <<  "( "<< scale_ << " +/- " << scaleErrStat_ << " +/- " << scaleErrSyst_ << " +/- " << scaleErrGain_ <<")" ;
-  return os; 
+std::ostream& EnergyScaleCorrection::ScaleCorrection::print(std::ostream& os) const {
+  os << "( " << scale_ << " +/- " << scaleErrStat_ << " +/- " << scaleErrSyst_ << " +/- " << scaleErrGain_ << ")";
+  return os;
 }
 
-float EnergyScaleCorrection::ScaleCorrection::scaleErr(const std::bitset<kErrNrBits>& uncBitMask)const
-{
+float EnergyScaleCorrection::ScaleCorrection::scaleErr(const std::bitset<kErrNrBits>& uncBitMask) const {
   double totErr(0);
-  auto pow2 = [](const double& x){return x*x;};
-  
-  if(uncBitMask.test(kErrStatBitNr)) totErr+=pow2(scaleErrStat_);
-  if(uncBitMask.test(kErrSystBitNr)) totErr+=pow2(scaleErrSyst_);  
-  if(uncBitMask.test(kErrGainBitNr)) totErr+=pow2(scaleErrGain_);
-  
+  auto pow2 = [](const double& x) { return x * x; };
+
+  if (uncBitMask.test(kErrStatBitNr))
+    totErr += pow2(scaleErrStat_);
+  if (uncBitMask.test(kErrSystBitNr))
+    totErr += pow2(scaleErrSyst_);
+  if (uncBitMask.test(kErrGainBitNr))
+    totErr += pow2(scaleErrGain_);
+
   return std::sqrt(totErr);
 }
 
-std::ostream& EnergyScaleCorrection::SmearCorrection::print(std::ostream& os)const
-{
-  os << rho_ << " +/- " << rhoErr_ 
-     <<  "\t"
-     << phi_ << " +/- " << phiErr_
-     <<  "\t"
-     << eMean_ << " +/- " << eMeanErr_;
-  return os; 
+std::ostream& EnergyScaleCorrection::SmearCorrection::print(std::ostream& os) const {
+  os << rho_ << " +/- " << rhoErr_ << "\t" << phi_ << " +/- " << phiErr_ << "\t" << eMean_ << " +/- " << eMeanErr_;
+  return os;
 }
 
 //here be dragons
 //this function is nasty and needs to be replaced
-EnergyScaleCorrection::CorrectionCategory::CorrectionCategory(const std::string& category,int runnrMin,int runnrMax):
-  runMin_(runnrMin),runMax_(runnrMax),etaMin_(0),etaMax_(3),
-  r9Min_(-1),r9Max_(999),etMin_(0),etMax_(9999999),gain_(0)
-{
-  size_t p1, p2; // boundary
+EnergyScaleCorrection::CorrectionCategory::CorrectionCategory(const std::string& category, int runnrMin, int runnrMax)
+    : runMin_(runnrMin),
+      runMax_(runnrMax),
+      etaMin_(0),
+      etaMax_(3),
+      r9Min_(-1),
+      r9Max_(999),
+      etMin_(0),
+      etMax_(9999999),
+      gain_(0) {
+  size_t p1, p2;  // boundary
 
   // eta region
   p1 = category.find("absEta_");
-  if(category.find("absEta_0_1") != std::string::npos) {
+  if (category.find("absEta_0_1") != std::string::npos) {
     etaMin_ = 0;
     etaMax_ = 1;
-  } else if(category.find("absEta_1_1.4442") != std::string::npos) {
+  } else if (category.find("absEta_1_1.4442") != std::string::npos) {
     etaMin_ = 1;
     etaMax_ = 1.479;
-  }
-  else if(category.find("absEta_1.566_2") != std::string::npos) {
+  } else if (category.find("absEta_1.566_2") != std::string::npos) {
     etaMin_ = 1.479;
     etaMax_ = 2;
-  }
-  else if(category.find("absEta_2_2.5") != std::string::npos) {
+  } else if (category.find("absEta_2_2.5") != std::string::npos) {
     etaMin_ = 2;
     etaMax_ = 3;
   } else {
-    if(p1 != std::string::npos) {
+    if (p1 != std::string::npos) {
       p1 = category.find("_", p1);
       p2 = category.find("_", p1 + 1);
       etaMin_ = std::stof(category.substr(p1 + 1, p2 - p1 - 1));
@@ -318,28 +322,28 @@ EnergyScaleCorrection::CorrectionCategory::CorrectionCategory(const std::string&
       etaMax_ = std::stof(category.substr(p1 + 1, p2 - p1 - 1));
     }
   }
-  
-  if(category.find("EBlowEta") != std::string::npos) {
+
+  if (category.find("EBlowEta") != std::string::npos) {
     etaMin_ = 0;
     etaMax_ = 1;
   };
-  if(category.find("EBhighEta") != std::string::npos) {
+  if (category.find("EBhighEta") != std::string::npos) {
     etaMin_ = 1;
     etaMax_ = 1.479;
   };
-  if(category.find("EElowEta") != std::string::npos) {
+  if (category.find("EElowEta") != std::string::npos) {
     etaMin_ = 1.479;
     etaMax_ = 2;
   };
-  if(category.find("EEhighEta") != std::string::npos) {
+  if (category.find("EEhighEta") != std::string::npos) {
     etaMin_ = 2;
     etaMax_ = 7;
   };
-  
+
   // Et region
   p1 = category.find("-Et_");
-  
-  if(p1 != std::string::npos) {
+
+  if (p1 != std::string::npos) {
     p1 = category.find("_", p1);
     p2 = category.find("_", p1 + 1);
     etMin_ = std::stof(category.substr(p1 + 1, p2 - p1 - 1));
@@ -347,22 +351,19 @@ EnergyScaleCorrection::CorrectionCategory::CorrectionCategory(const std::string&
     p2 = category.find("-", p1);
     etMax_ = std::stof(category.substr(p1 + 1, p2 - p1 - 1));
   }
-  
-  if(category.find("gold")   != std::string::npos || 
-     category.find("Gold")   != std::string::npos || 
-     category.find("highR9") != std::string::npos) {
+
+  if (category.find("gold") != std::string::npos || category.find("Gold") != std::string::npos ||
+      category.find("highR9") != std::string::npos) {
     r9Min_ = 0.94;
     r9Max_ = std::numeric_limits<float>::max();
-  } else if(category.find("bad") != std::string::npos || 
-	    category.find("Bad") != std::string::npos ||
-	    category.find("lowR9") != std::string::npos
-	    ) {
+  } else if (category.find("bad") != std::string::npos || category.find("Bad") != std::string::npos ||
+             category.find("lowR9") != std::string::npos) {
     r9Min_ = -1;
     r9Max_ = 0.94;
-  };	
+  };
   // R9 region
   p1 = category.find("-R9");
-  if(p1 != std::string::npos) {
+  if (p1 != std::string::npos) {
     p1 = category.find("_", p1);
     p2 = category.find("_", p1 + 1);
     r9Min_ = std::stof(category.substr(p1 + 1, p2 - p1 - 1));
@@ -371,69 +372,65 @@ EnergyScaleCorrection::CorrectionCategory::CorrectionCategory(const std::string&
       p1 = p2;
       p2 = category.find("-", p1);
       r9Max_ = std::stof(category.substr(p1 + 1, p2 - p1 - 1));
-      if(r9Max_>=1.0) r9Max_ = std::numeric_limits<float>::max();
+      if (r9Max_ >= 1.0)
+        r9Max_ = std::numeric_limits<float>::max();
     }
   }
   //------------------------------
-  p1 = category.find("gainEle_");      // Position of first character
-  if(p1 != std::string::npos) {
-	  p1+=8;                       // Position of character after _
-	  p2 = category.find("-", p1); // Position of - or end of string
-	  gain_ = std::stoul(category.substr(p1, p2-p1), nullptr);
+  p1 = category.find("gainEle_");  // Position of first character
+  if (p1 != std::string::npos) {
+    p1 += 8;                      // Position of character after _
+    p2 = category.find("-", p1);  // Position of - or end of string
+    gain_ = std::stoul(category.substr(p1, p2 - p1), nullptr);
   }
   //so turns out the code does an includes X<=Y<=Z search for bins
   //which is what we want for run numbers
   //however then the problem is when we get a value exactly at the bin boundary
   //for the et/eta/r9 which then gives multiple bins
-  //so we just decrement the maxValues ever so slightly to ensure that they are different 
+  //so we just decrement the maxValues ever so slightly to ensure that they are different
   //from the next bins min value
-  etMax_ = std::nextafterf(etMax_,std::numeric_limits<float>::min());
-  etaMax_ = std::nextafterf(etaMax_,std::numeric_limits<float>::min());
-  r9Max_ =std::nextafterf(r9Max_,std::numeric_limits<float>::min());
-  
-  
-
+  etMax_ = std::nextafterf(etMax_, std::numeric_limits<float>::min());
+  etaMax_ = std::nextafterf(etaMax_, std::numeric_limits<float>::min());
+  r9Max_ = std::nextafterf(r9Max_, std::numeric_limits<float>::min());
 }
-bool EnergyScaleCorrection::CorrectionCategory::
-inCategory(const unsigned int runnr, const float et, const float eta, const float r9, 
-	   const unsigned int gainSeed)const
-{
-  return runnr>= runMin_ && runnr<= runMax_ &&
-    et>=etMin_ && et<=etMax_ &&
-    eta>=etaMin_ && eta<=etaMax_ &&
-    r9>=r9Min_ && r9<=r9Max_ &&
-    (gain_==0 || gainSeed==gain_);  
+bool EnergyScaleCorrection::CorrectionCategory::inCategory(
+    const unsigned int runnr, const float et, const float eta, const float r9, const unsigned int gainSeed) const {
+  return runnr >= runMin_ && runnr <= runMax_ && et >= etMin_ && et <= etMax_ && eta >= etaMin_ && eta <= etaMax_ &&
+         r9 >= r9Min_ && r9 <= r9Max_ && (gain_ == 0 || gainSeed == gain_);
 }
 
-bool EnergyScaleCorrection::CorrectionCategory::operator<(const  EnergyScaleCorrection::CorrectionCategory& b) const
-{
-  if(runMin_ < b.runMin_ && runMax_ < b.runMax_) return true;
-  if(runMax_ > b.runMax_ && runMin_ > b.runMin_) return false;
-  
-  if(etaMin_ < b.etaMin_ && etaMax_ < b.etaMax_) return true;
-  if(etaMax_ > b.etaMax_ && etaMin_ > b.etaMin_) return false;
-  
-  if(r9Min_  < b.r9Min_ && r9Max_ < b.r9Max_) return true;
-  if(r9Max_  > b.r9Max_ && r9Min_ > b.r9Min_) return  false;
-  
-  if(etMin_  < b.etMin_ && etMax_ < b.etMax_) return true;
-  if(etMax_  > b.etMax_ && etMin_ > b.etMin_) return  false;
+bool EnergyScaleCorrection::CorrectionCategory::operator<(const EnergyScaleCorrection::CorrectionCategory& b) const {
+  if (runMin_ < b.runMin_ && runMax_ < b.runMax_)
+    return true;
+  if (runMax_ > b.runMax_ && runMin_ > b.runMin_)
+    return false;
 
-  if(gain_==0 || b.gain_==0) return false; // if corrections are not categorized in gain then default gain value should always return false in order to have a match with the category
-  if(gain_   < b.gain_) return true;
-  else return false;
+  if (etaMin_ < b.etaMin_ && etaMax_ < b.etaMax_)
+    return true;
+  if (etaMax_ > b.etaMax_ && etaMin_ > b.etaMin_)
+    return false;
+
+  if (r9Min_ < b.r9Min_ && r9Max_ < b.r9Max_)
+    return true;
+  if (r9Max_ > b.r9Max_ && r9Min_ > b.r9Min_)
+    return false;
+
+  if (etMin_ < b.etMin_ && etMax_ < b.etMax_)
+    return true;
+  if (etMax_ > b.etMax_ && etMin_ > b.etMin_)
+    return false;
+
+  if (gain_ == 0 || b.gain_ == 0)
+    return false;  // if corrections are not categorized in gain then default gain value should always return false in order to have a match with the category
+  if (gain_ < b.gain_)
+    return true;
+  else
+    return false;
   return false;
-  
 }
 
-
-std::ostream&  EnergyScaleCorrection::CorrectionCategory::print(std::ostream &os)const
-{
-  os <<  runMin_ << " " << runMax_
-     << "\t" << etaMin_ << " " << etaMax_
-     << "\t" << r9Min_ << " " << r9Max_
-     << "\t" << etMin_ << " " << etMax_
-     << "\t" << gain_;    
+std::ostream& EnergyScaleCorrection::CorrectionCategory::print(std::ostream& os) const {
+  os << runMin_ << " " << runMax_ << "\t" << etaMin_ << " " << etaMax_ << "\t" << r9Min_ << " " << r9Max_ << "\t"
+     << etMin_ << " " << etMax_ << "\t" << gain_;
   return os;
 }
-

--- a/RecoEgamma/EgammaTools/src/EpCombinationTool.cc
+++ b/RecoEgamma/EgammaTools/src/EpCombinationTool.cc
@@ -11,99 +11,89 @@
 #include <vector>
 #include <vdt/vdtMath.h>
 
+EpCombinationTool::EpCombinationTool(const edm::ParameterSet& iConfig)
+    : ecalTrkEnergyRegress_(iConfig.getParameter<edm::ParameterSet>("ecalTrkRegressionConfig")),
+      ecalTrkEnergyRegressUncert_(iConfig.getParameter<edm::ParameterSet>("ecalTrkRegressionUncertConfig")),
+      maxEcalEnergyForComb_(iConfig.getParameter<double>("maxEcalEnergyForComb")),
+      minEOverPForComb_(iConfig.getParameter<double>("minEOverPForComb")),
+      maxEPDiffInSigmaForComb_(iConfig.getParameter<double>("maxEPDiffInSigmaForComb")),
+      maxRelTrkMomErrForComb_(iConfig.getParameter<double>("maxRelTrkMomErrForComb")) {}
 
-EpCombinationTool::EpCombinationTool(const edm::ParameterSet& iConfig):
-  ecalTrkEnergyRegress_(iConfig.getParameter<edm::ParameterSet>("ecalTrkRegressionConfig")),
-  ecalTrkEnergyRegressUncert_(iConfig.getParameter<edm::ParameterSet>("ecalTrkRegressionUncertConfig")),
-  maxEcalEnergyForComb_(iConfig.getParameter<double>("maxEcalEnergyForComb")),
-  minEOverPForComb_(iConfig.getParameter<double>("minEOverPForComb")),
-  maxEPDiffInSigmaForComb_(iConfig.getParameter<double>("maxEPDiffInSigmaForComb")),
-  maxRelTrkMomErrForComb_(iConfig.getParameter<double>("maxRelTrkMomErrForComb"))
-{
-
-}
-
-edm::ParameterSetDescription EpCombinationTool::makePSetDescription()
-{
+edm::ParameterSetDescription EpCombinationTool::makePSetDescription() {
   edm::ParameterSetDescription desc;
-  desc.add<edm::ParameterSetDescription>("ecalTrkRegressionConfig",EgammaRegressionContainer::makePSetDescription());
-  desc.add<edm::ParameterSetDescription>("ecalTrkRegressionUncertConfig",EgammaRegressionContainer::makePSetDescription());
-  desc.add<double>("maxEcalEnergyForComb",200.);
-  desc.add<double>("minEOverPForComb",0.025);
-  desc.add<double>("maxEPDiffInSigmaForComb",15.);
-  desc.add<double>("maxRelTrkMomErrForComb",10.);
+  desc.add<edm::ParameterSetDescription>("ecalTrkRegressionConfig", EgammaRegressionContainer::makePSetDescription());
+  desc.add<edm::ParameterSetDescription>("ecalTrkRegressionUncertConfig",
+                                         EgammaRegressionContainer::makePSetDescription());
+  desc.add<double>("maxEcalEnergyForComb", 200.);
+  desc.add<double>("minEOverPForComb", 0.025);
+  desc.add<double>("maxEPDiffInSigmaForComb", 15.);
+  desc.add<double>("maxRelTrkMomErrForComb", 10.);
   return desc;
 }
 
-
-void EpCombinationTool::setEventContent(const edm::EventSetup& iSetup)
-{
+void EpCombinationTool::setEventContent(const edm::EventSetup& iSetup) {
   ecalTrkEnergyRegress_.setEventContent(iSetup);
   ecalTrkEnergyRegressUncert_.setEventContent(iSetup);
 }
 
-std::pair<float, float> EpCombinationTool::combine(const reco::GsfElectron& ele)const
-{
-  return combine(ele,ele.correctedEcalEnergyError());
+std::pair<float, float> EpCombinationTool::combine(const reco::GsfElectron& ele) const {
+  return combine(ele, ele.correctedEcalEnergyError());
 }
 
 //when doing the E/p combination, its very important to ensure the ecalEnergyErr
 //that the regression is trained on is used, not the actual ecalEnergyErr of the electron
-//these differ when you correct the ecalEnergyErr by smearing value needed to get data/MC to agree 
-std::pair<float, float> EpCombinationTool::combine(const reco::GsfElectron& ele,const float corrEcalEnergyErr)const
-{
-  const float scRawEnergy = ele.superCluster()->rawEnergy(); 
+//these differ when you correct the ecalEnergyErr by smearing value needed to get data/MC to agree
+std::pair<float, float> EpCombinationTool::combine(const reco::GsfElectron& ele, const float corrEcalEnergyErr) const {
+  const float scRawEnergy = ele.superCluster()->rawEnergy();
   const float esEnergy = ele.superCluster()->preshowerEnergy();
-  
 
   const float corrEcalEnergy = ele.correctedEcalEnergy();
-  const float ecalMean = ele.correctedEcalEnergy() / (scRawEnergy+esEnergy);
-  const float ecalSigma =  corrEcalEnergyErr / corrEcalEnergy;
+  const float ecalMean = ele.correctedEcalEnergy() / (scRawEnergy + esEnergy);
+  const float ecalSigma = corrEcalEnergyErr / corrEcalEnergy;
 
   auto gsfTrk = ele.gsfTrack();
 
   const float trkP = gsfTrk->pMode();
   const float trkEta = gsfTrk->etaMode();
   const float trkPhi = gsfTrk->phiMode();
-  const float trkPErr = std::abs(gsfTrk->qoverpModeError())*trkP*trkP; 
-  const float eOverP = corrEcalEnergy/trkP;
+  const float trkPErr = std::abs(gsfTrk->qoverpModeError()) * trkP * trkP;
+  const float eOverP = corrEcalEnergy / trkP;
   const float fbrem = ele.fbrem();
 
-  if(corrEcalEnergy < maxEcalEnergyForComb_ &&
-     eOverP > minEOverPForComb_ && 
-     std::abs(corrEcalEnergy - trkP) < maxEPDiffInSigmaForComb_*std::sqrt(trkPErr*trkPErr+corrEcalEnergyErr*corrEcalEnergyErr) && 
-     trkPErr < maxRelTrkMomErrForComb_*trkP) { 
-
-    std::array<float, 9> eval;  
+  if (corrEcalEnergy < maxEcalEnergyForComb_ && eOverP > minEOverPForComb_ &&
+      std::abs(corrEcalEnergy - trkP) <
+          maxEPDiffInSigmaForComb_ * std::sqrt(trkPErr * trkPErr + corrEcalEnergyErr * corrEcalEnergyErr) &&
+      trkPErr < maxRelTrkMomErrForComb_ * trkP) {
+    std::array<float, 9> eval;
     eval[0] = corrEcalEnergy;
-    eval[1] = ecalSigma/ecalMean;
-    eval[2] = trkPErr/trkP;
+    eval[1] = ecalSigma / ecalMean;
+    eval[2] = trkPErr / trkP;
     eval[3] = eOverP;
     eval[4] = ele.ecalDrivenSeed();
     eval[5] = ele.full5x5_showerShape().r9;
     eval[6] = fbrem;
-    eval[7] = trkEta; 
-    eval[8] = trkPhi;  
+    eval[7] = trkEta;
+    eval[8] = trkPhi;
 
-    const float preCombinationEt = corrEcalEnergy/std::cosh(trkEta);
-    float mean  = ecalTrkEnergyRegress_(preCombinationEt,ele.isEB(),ele.nSaturatedXtals()!=0,eval.data());
-    float sigma  = ecalTrkEnergyRegressUncert_(preCombinationEt,ele.isEB(),ele.nSaturatedXtals()!=0,eval.data());
+    const float preCombinationEt = corrEcalEnergy / std::cosh(trkEta);
+    float mean = ecalTrkEnergyRegress_(preCombinationEt, ele.isEB(), ele.nSaturatedXtals() != 0, eval.data());
+    float sigma = ecalTrkEnergyRegressUncert_(preCombinationEt, ele.isEB(), ele.nSaturatedXtals() != 0, eval.data());
     // Final correction
     // A negative energy means that the correction went
     // outside the boundaries of the training. In this case uses raw.
     // The resolution estimation, on the other hand should be ok.
-    if (mean < 0.) mean = 1.0;
-    
+    if (mean < 0.)
+      mean = 1.0;
+
     //why this differs from the defination of corrEcalEnergyErr (it misses the mean) is not clear to me
     //still this is a direct port from EGExtraInfoModifierFromDB, potential bugs and all
-    const float ecalSigmaTimesRawEnergy = ecalSigma*(scRawEnergy+esEnergy);
-    const float rawCombEnergy = ( corrEcalEnergy*trkPErr*trkPErr +
-				  trkP*ecalSigmaTimesRawEnergy*ecalSigmaTimesRawEnergy ) /
-                                ( trkPErr*trkPErr +
-				  ecalSigmaTimesRawEnergy*ecalSigmaTimesRawEnergy );
+    const float ecalSigmaTimesRawEnergy = ecalSigma * (scRawEnergy + esEnergy);
+    const float rawCombEnergy =
+        (corrEcalEnergy * trkPErr * trkPErr + trkP * ecalSigmaTimesRawEnergy * ecalSigmaTimesRawEnergy) /
+        (trkPErr * trkPErr + ecalSigmaTimesRawEnergy * ecalSigmaTimesRawEnergy);
 
-    return std::make_pair(mean*rawCombEnergy,sigma*rawCombEnergy);
-  }else{
+    return std::make_pair(mean * rawCombEnergy, sigma * rawCombEnergy);
+  } else {
     return std::make_pair(corrEcalEnergy, corrEcalEnergyErr);
   }
 }

--- a/RecoEgamma/EgammaTools/src/HGCalEgammaIDHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalEgammaIDHelper.cc
@@ -2,82 +2,83 @@
 
 #include <iostream>
 
-HGCalEgammaIDHelper::HGCalEgammaIDHelper(const edm::ParameterSet  & iConfig,edm::ConsumesCollector && iC):
-        eeRecHitInputTag_(iConfig.getParameter<edm::InputTag> ("EERecHits") ),
-        fhRecHitInputTag_(iConfig.getParameter<edm::InputTag> ("FHRecHits") ),
-        bhRecHitInputTag_(iConfig.getParameter<edm::InputTag> ("BHRecHits") ),
-        dEdXWeights_(iConfig.getParameter<std::vector<double> >("dEdXWeights"))
-{
-    isoHelper_.setDeltaR(iConfig.getParameter<double>("isoDeltaR"));
-    isoHelper_.setNRings(iConfig.getParameter<unsigned int>("isoNRings"));
-    isoHelper_.setMinDeltaR(iConfig.getParameter<double>("isoDeltaRmin"));
+HGCalEgammaIDHelper::HGCalEgammaIDHelper(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
+    : eeRecHitInputTag_(iConfig.getParameter<edm::InputTag>("EERecHits")),
+      fhRecHitInputTag_(iConfig.getParameter<edm::InputTag>("FHRecHits")),
+      bhRecHitInputTag_(iConfig.getParameter<edm::InputTag>("BHRecHits")),
+      dEdXWeights_(iConfig.getParameter<std::vector<double> >("dEdXWeights")) {
+  isoHelper_.setDeltaR(iConfig.getParameter<double>("isoDeltaR"));
+  isoHelper_.setNRings(iConfig.getParameter<unsigned int>("isoNRings"));
+  isoHelper_.setMinDeltaR(iConfig.getParameter<double>("isoDeltaRmin"));
 
-    recHitsEE_ = iC.consumes<HGCRecHitCollection>(eeRecHitInputTag_);
-    recHitsFH_ = iC.consumes<HGCRecHitCollection>(fhRecHitInputTag_);
-    recHitsBH_ = iC.consumes<HGCRecHitCollection>(bhRecHitInputTag_);
-    pcaHelper_.setdEdXWeights(dEdXWeights_);
-    debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
+  recHitsEE_ = iC.consumes<HGCRecHitCollection>(eeRecHitInputTag_);
+  recHitsFH_ = iC.consumes<HGCRecHitCollection>(fhRecHitInputTag_);
+  recHitsBH_ = iC.consumes<HGCRecHitCollection>(bhRecHitInputTag_);
+  pcaHelper_.setdEdXWeights(dEdXWeights_);
+  debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
 }
 
-void HGCalEgammaIDHelper::eventInit(const edm::Event& iEvent,const edm::EventSetup &iSetup) {
-    edm::Handle<HGCRecHitCollection> recHitHandleEE;
-    iEvent.getByToken(recHitsEE_, recHitHandleEE);
-    edm::Handle<HGCRecHitCollection> recHitHandleFH;
-    iEvent.getByToken(recHitsFH_, recHitHandleFH);
-    edm::Handle<HGCRecHitCollection> recHitHandleBH;
-    iEvent.getByToken(recHitsBH_, recHitHandleBH);
+void HGCalEgammaIDHelper::eventInit(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<HGCRecHitCollection> recHitHandleEE;
+  iEvent.getByToken(recHitsEE_, recHitHandleEE);
+  edm::Handle<HGCRecHitCollection> recHitHandleFH;
+  iEvent.getByToken(recHitsFH_, recHitHandleFH);
+  edm::Handle<HGCRecHitCollection> recHitHandleBH;
+  iEvent.getByToken(recHitsBH_, recHitHandleBH);
 
-    recHitTools_.getEventSetup(iSetup);
-    pcaHelper_.setRecHitTools(&recHitTools_);
-    isoHelper_.setRecHitTools(&recHitTools_);
-    pcaHelper_.fillHitMap(*recHitHandleEE,*recHitHandleFH,*recHitHandleBH);
-    isoHelper_.setRecHits(recHitHandleEE, recHitHandleFH, recHitHandleBH);
+  recHitTools_.getEventSetup(iSetup);
+  pcaHelper_.setRecHitTools(&recHitTools_);
+  isoHelper_.setRecHitTools(&recHitTools_);
+  pcaHelper_.fillHitMap(*recHitHandleEE, *recHitHandleFH, *recHitHandleBH);
+  isoHelper_.setRecHits(recHitHandleEE, recHitHandleFH, recHitHandleBH);
 }
 
-void HGCalEgammaIDHelper::computeHGCAL(const reco::Photon & thePhoton, float radius) {
-    if (thePhoton.isEB()) {
-        if (debug_) std::cout << "The photon is in the barrel" <<std::endl;
-        pcaHelper_.clear();
-        return;
-    }
-
-    pcaHelper_.storeRecHits(*thePhoton.superCluster()->seed());
+void HGCalEgammaIDHelper::computeHGCAL(const reco::Photon& thePhoton, float radius) {
+  if (thePhoton.isEB()) {
     if (debug_)
-        std::cout << " Stored the hits belonging to the photon superCluster seed " << std::endl;
+      std::cout << "The photon is in the barrel" << std::endl;
+    pcaHelper_.clear();
+    return;
+  }
 
-    // initial computation, no radius cut, but halo hits not taken
-    if (debug_)
-        std::cout << " Calling PCA initial computation" << std::endl;
-    pcaHelper_.pcaInitialComputation();
-    // first computation within cylinder, halo hits included
-    pcaHelper_.computePCA(radius);
-    // second computation within cylinder, halo hits included
-    pcaHelper_.computePCA(radius);
-    pcaHelper_.computeShowerWidth(radius);
+  pcaHelper_.storeRecHits(*thePhoton.superCluster()->seed());
+  if (debug_)
+    std::cout << " Stored the hits belonging to the photon superCluster seed " << std::endl;
 
-    // isolation
-    isoHelper_.produceHGCalIso(thePhoton.superCluster()->seed());
+  // initial computation, no radius cut, but halo hits not taken
+  if (debug_)
+    std::cout << " Calling PCA initial computation" << std::endl;
+  pcaHelper_.pcaInitialComputation();
+  // first computation within cylinder, halo hits included
+  pcaHelper_.computePCA(radius);
+  // second computation within cylinder, halo hits included
+  pcaHelper_.computePCA(radius);
+  pcaHelper_.computeShowerWidth(radius);
+
+  // isolation
+  isoHelper_.produceHGCalIso(thePhoton.superCluster()->seed());
 }
 
-void HGCalEgammaIDHelper::computeHGCAL(const reco::GsfElectron & theElectron, float radius) {
-    if (theElectron.isEB()) {
-        if (debug_) std::cout << "The electron is in the barrel" <<std::endl;
-        pcaHelper_.clear();
-        return;
-    }
-
-    pcaHelper_.storeRecHits(*theElectron.electronCluster());
+void HGCalEgammaIDHelper::computeHGCAL(const reco::GsfElectron& theElectron, float radius) {
+  if (theElectron.isEB()) {
     if (debug_)
-        std::cout << " Stored the hits belonging to the electronCluster " << std::endl;
+      std::cout << "The electron is in the barrel" << std::endl;
+    pcaHelper_.clear();
+    return;
+  }
 
-    // initial computation, no radius cut, but halo hits not taken
-    if (debug_)
-        std::cout << " Calling PCA initial computation" << std::endl;
-    pcaHelper_.pcaInitialComputation();
-    // first computation within cylinder, halo hits included
-    pcaHelper_.computePCA(radius);
-    // second computation within cylinder, halo hits included
-    pcaHelper_.computePCA(radius);
-    pcaHelper_.computeShowerWidth(radius);
-    isoHelper_.produceHGCalIso(theElectron.electronCluster());
+  pcaHelper_.storeRecHits(*theElectron.electronCluster());
+  if (debug_)
+    std::cout << " Stored the hits belonging to the electronCluster " << std::endl;
+
+  // initial computation, no radius cut, but halo hits not taken
+  if (debug_)
+    std::cout << " Calling PCA initial computation" << std::endl;
+  pcaHelper_.pcaInitialComputation();
+  // first computation within cylinder, halo hits included
+  pcaHelper_.computePCA(radius);
+  // second computation within cylinder, halo hits included
+  pcaHelper_.computePCA(radius);
+  pcaHelper_.computeShowerWidth(radius);
+  isoHelper_.produceHGCalIso(theElectron.electronCluster());
 }

--- a/RecoEgamma/EgammaTools/src/HGCalIsoCalculator.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalIsoCalculator.cc
@@ -8,106 +8,111 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "RecoEgamma/EgammaTools/interface/HGCalIsoCalculator.h"
 
-HGCalIsoCalculator::HGCalIsoCalculator():dr2_(0.15*0.15),mindr2_(0),rechittools_(nullptr),debug_(false),nlayers_(30){
-    setNRings(5);
+HGCalIsoCalculator::HGCalIsoCalculator()
+    : dr2_(0.15 * 0.15), mindr2_(0), rechittools_(nullptr), debug_(false), nlayers_(30) {
+  setNRings(5);
 }
 
-HGCalIsoCalculator::~HGCalIsoCalculator(){
+HGCalIsoCalculator::~HGCalIsoCalculator() {}
+
+void HGCalIsoCalculator::setRecHits(edm::Handle<HGCRecHitCollection> hitsEE,
+                                    edm::Handle<HGCRecHitCollection> hitsFH,
+                                    edm::Handle<HGCRecHitCollection> hitsBH) {
+  recHitsEE_ = hitsEE;
+  recHitsFH_ = hitsFH;
+  recHitsBH_ = hitsBH;
+
+  if (!rechittools_)
+    throw cms::Exception("HGCalIsoCalculator::produceHGCalIso: rechittools not set");
+
+  hitEtaPhiCache_.clear();
+  hitEtaPhiCache_.reserve(recHitsEE_->size() + recHitsFH_->size() + recHitsBH_->size());
+
+  // Since HGCal is not projective and the rechits don't cache any
+  // eta,phi, we make our own here
+  auto makeEtaPhiPair = [this](const auto& hit) {
+    const GlobalPoint position = rechittools_->getPosition(hit.id());
+    float eta = rechittools_->getEta(position, 0);  //assume vertex at z=0
+    float phi = rechittools_->getPhi(position);
+    return std::make_pair(eta, phi);
+  };
+
+  for (const auto& hit : *recHitsEE_)
+    hitEtaPhiCache_.push_back(makeEtaPhiPair(hit));
+  for (const auto& hit : *recHitsFH_)
+    hitEtaPhiCache_.push_back(makeEtaPhiPair(hit));
+  for (const auto& hit : *recHitsBH_)
+    hitEtaPhiCache_.push_back(makeEtaPhiPair(hit));
 }
 
-void HGCalIsoCalculator::setRecHits(
-        edm::Handle<HGCRecHitCollection> hitsEE,
-        edm::Handle<HGCRecHitCollection> hitsFH,
-        edm::Handle<HGCRecHitCollection> hitsBH
-     ){
-    recHitsEE_=hitsEE;
-    recHitsFH_=hitsFH;
-    recHitsBH_=hitsBH;
+void HGCalIsoCalculator::produceHGCalIso(const reco::CaloClusterPtr& seed) {
+  if (!rechittools_)
+    throw cms::Exception("HGCalIsoCalculator::produceHGCalIso: rechittools not set");
 
-    if(!rechittools_)
-        throw cms::Exception("HGCalIsoCalculator::produceHGCalIso: rechittools not set");
-    
-    hitEtaPhiCache_.clear();
-    hitEtaPhiCache_.reserve(recHitsEE_->size()+recHitsFH_->size()+recHitsBH_->size());
+  for (auto& r : isoringdeposits_)
+    r = 0;
 
-    // Since HGCal is not projective and the rechits don't cache any
-    // eta,phi, we make our own here
-    auto makeEtaPhiPair = [this](const auto& hit) {
-        const GlobalPoint position = rechittools_->getPosition(hit.id());
-        float eta=rechittools_->getEta(position, 0); //assume vertex at z=0
-        float phi=rechittools_->getPhi(position);
-        return std::make_pair(eta, phi);
-    };
+  // make local temporaries to pass to the lambda
+  // avoids recomputing every iteration
+  const float seedEta = seed->eta();
+  const float seedPhi = seed->phi();
+  const std::vector<std::pair<DetId, float>>& seedHitsAndFractions = seed->hitsAndFractions();
 
-    for(const auto& hit : *recHitsEE_) hitEtaPhiCache_.push_back(makeEtaPhiPair(hit));
-    for(const auto& hit : *recHitsFH_) hitEtaPhiCache_.push_back(makeEtaPhiPair(hit));
-    for(const auto& hit : *recHitsBH_) hitEtaPhiCache_.push_back(makeEtaPhiPair(hit));
-}
+  auto checkAndFill = [this, &seedEta, &seedPhi, &seedHitsAndFractions](const HGCRecHit& hit,
+                                                                        std::pair<float, float> etaphiVal) {
+    float deltar2 = reco::deltaR2(etaphiVal.first, etaphiVal.second, seedEta, seedPhi);
+    if (deltar2 > dr2_ || deltar2 < mindr2_)
+      return;
 
-void HGCalIsoCalculator::produceHGCalIso(const reco::CaloClusterPtr & seed){
+    unsigned int layer = rechittools_->getLayerWithOffset(hit.id());
+    if (layer >= nlayers_)
+      return;
 
-    if(!rechittools_)
-        throw cms::Exception("HGCalIsoCalculator::produceHGCalIso: rechittools not set");
-
-    for(auto& r:isoringdeposits_)
-        r=0;
-
-    // make local temporaries to pass to the lambda
-    // avoids recomputing every iteration
-    const float seedEta=seed->eta();
-    const float seedPhi=seed->phi();
-    const std::vector<std::pair<DetId, float>> & seedHitsAndFractions = seed->hitsAndFractions();
-
-    auto checkAndFill = [this, &seedEta, &seedPhi, &seedHitsAndFractions](const HGCRecHit& hit, std::pair<float,float> etaphiVal) {
-        float deltar2=reco::deltaR2(etaphiVal.first,etaphiVal.second,seedEta,seedPhi);
-        if(deltar2>dr2_ || deltar2<mindr2_) return;
-
-        unsigned int layer=rechittools_->getLayerWithOffset(hit.id());
-        if(layer>=nlayers_) return;
-
-        //do not consider hits associated to the photon cluster
-        if( std::none_of(seedHitsAndFractions.begin(), seedHitsAndFractions.end(), [&hit](const auto& seedhit){return hit.id()==seedhit.first;}) ){
-            const unsigned int ring=ringasso_.at(layer);
-            isoringdeposits_.at(ring)+=hit.energy();
-        }
-    };
-
-    // The cache order is EE,FH,BH, so we should loop over them the same here
-    auto itEtaPhiCache = hitEtaPhiCache_.cbegin();
-    for(const auto& hit : *recHitsEE_){
-      checkAndFill(hit, *itEtaPhiCache);
-      itEtaPhiCache++;
+    //do not consider hits associated to the photon cluster
+    if (std::none_of(seedHitsAndFractions.begin(), seedHitsAndFractions.end(), [&hit](const auto& seedhit) {
+          return hit.id() == seedhit.first;
+        })) {
+      const unsigned int ring = ringasso_.at(layer);
+      isoringdeposits_.at(ring) += hit.energy();
     }
-    for(const auto& hit : *recHitsFH_){
-      checkAndFill(hit, *itEtaPhiCache);
-      itEtaPhiCache++;
-    }
-    for(const auto& hit : *recHitsBH_){
-      checkAndFill(hit, *itEtaPhiCache);
-      itEtaPhiCache++;
-    }
+  };
+
+  // The cache order is EE,FH,BH, so we should loop over them the same here
+  auto itEtaPhiCache = hitEtaPhiCache_.cbegin();
+  for (const auto& hit : *recHitsEE_) {
+    checkAndFill(hit, *itEtaPhiCache);
+    itEtaPhiCache++;
+  }
+  for (const auto& hit : *recHitsFH_) {
+    checkAndFill(hit, *itEtaPhiCache);
+    itEtaPhiCache++;
+  }
+  for (const auto& hit : *recHitsBH_) {
+    checkAndFill(hit, *itEtaPhiCache);
+    itEtaPhiCache++;
+  }
 }
 
-void HGCalIsoCalculator::setNRings(const size_t nrings){
-    if(nrings>nlayers_)
-        throw std::logic_error("PhotonHGCalIsoCalculator::setNRings: max number of rings reached");
+void HGCalIsoCalculator::setNRings(const size_t nrings) {
+  if (nrings > nlayers_)
+    throw std::logic_error("PhotonHGCalIsoCalculator::setNRings: max number of rings reached");
 
-    ringasso_.clear();
-    isoringdeposits_.clear();
-    unsigned int separator=nlayers_/nrings;
-    size_t counter=0;
-    for(size_t i=0;i<nlayers_+1;i++){
-        ringasso_.push_back(counter);
-        //the last ring might be larger.
-        if(i && !(i%separator) && (int)counter<(int)nrings-1){
-            counter++;
-        }
+  ringasso_.clear();
+  isoringdeposits_.clear();
+  unsigned int separator = nlayers_ / nrings;
+  size_t counter = 0;
+  for (size_t i = 0; i < nlayers_ + 1; i++) {
+    ringasso_.push_back(counter);
+    //the last ring might be larger.
+    if (i && !(i % separator) && (int)counter < (int)nrings - 1) {
+      counter++;
     }
-    isoringdeposits_.resize(nrings,0);
+  }
+  isoringdeposits_.resize(nrings, 0);
 }
 
-const float HGCalIsoCalculator::getIso(const unsigned int ring)const{
-    if(ring>=isoringdeposits_.size())
-        throw cms::Exception("HGCalIsoCalculator::getIso: ring index out of range");
-    return isoringdeposits_[ring];
+const float HGCalIsoCalculator::getIso(const unsigned int ring) const {
+  if (ring >= isoringdeposits_.size())
+    throw cms::Exception("HGCalIsoCalculator::getIso: ring index out of range");
+  return isoringdeposits_[ring];
 }

--- a/RecoEgamma/EgammaTools/src/HoECalculator.cc
+++ b/RecoEgamma/EgammaTools/src/HoECalculator.cc
@@ -4,23 +4,15 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 
-HoECalculator::HoECalculator () :
-               theCaloGeom_(nullptr)
-{
-} 
-HoECalculator::HoECalculator (const edm::ESHandle<CaloGeometry>  &caloGeom) :
-               theCaloGeom_(caloGeom)
-{
-} 
+HoECalculator::HoECalculator() : theCaloGeom_(nullptr) {}
+HoECalculator::HoECalculator(const edm::ESHandle<CaloGeometry>& caloGeom) : theCaloGeom_(caloGeom) {}
 
-double HoECalculator::operator() ( const reco::BasicCluster* clus , const edm::Event& e , const edm::EventSetup& c) 
-{
-  return getHoE(GlobalPoint(clus->x(),clus->y(),clus->z()), clus->energy(), e,c);
+double HoECalculator::operator()(const reco::BasicCluster* clus, const edm::Event& e, const edm::EventSetup& c) {
+  return getHoE(GlobalPoint(clus->x(), clus->y(), clus->z()), clus->energy(), e, c);
 }
 
-double HoECalculator::operator() ( const reco::SuperCluster* clus , const edm::Event& e , const edm::EventSetup& c) 
-{
-  return getHoE(GlobalPoint(clus->x(),clus->y(),clus->z()), clus->energy(), e,c);
+double HoECalculator::operator()(const reco::SuperCluster* clus, const edm::Event& e, const edm::EventSetup& c) {
+  return getHoE(GlobalPoint(clus->x(), clus->y(), clus->z()), clus->energy(), e, c);
 }
 
 /*
@@ -50,35 +42,34 @@ double HoECalculator::operator() ( const reco::BasicCluster* clus,
 
 */
 
-double HoECalculator::getHoE(GlobalPoint pclu, float ecalEnergy, const edm::Event& e , const edm::EventSetup& c )
-{
-  if ( !theCaloGeom_.isValid() )
-    c.get<CaloGeometryRecord>().get(theCaloGeom_) ;
+double HoECalculator::getHoE(GlobalPoint pclu, float ecalEnergy, const edm::Event& e, const edm::EventSetup& c) {
+  if (!theCaloGeom_.isValid())
+    c.get<CaloGeometryRecord>().get(theCaloGeom_);
 
   //product the geometry
-  theCaloGeom_.product() ;
+  theCaloGeom_.product();
 
   //Create a HBHERecHitCollection
-  edm::Handle< HBHERecHitCollection > hbhe ;
-  e.getByLabel("hbhereco","",hbhe);
+  edm::Handle<HBHERecHitCollection> hbhe;
+  e.getByLabel("hbhereco", "", hbhe);
   const HBHERecHitCollection* hithbhe_ = hbhe.product();
 
-  double HoE=0.;
-  const CaloGeometry& geometry = *theCaloGeom_ ;
-  const CaloSubdetectorGeometry *geometry_p ; 
-  geometry_p = geometry.getSubdetectorGeometry (DetId::Hcal,4) ;
-  DetId hcalDetId ;
-  hcalDetId = geometry_p->getClosestCell(pclu) ;
-  double hcalEnergy = 0 ;
+  double HoE = 0.;
+  const CaloGeometry& geometry = *theCaloGeom_;
+  const CaloSubdetectorGeometry* geometry_p;
+  geometry_p = geometry.getSubdetectorGeometry(DetId::Hcal, 4);
+  DetId hcalDetId;
+  hcalDetId = geometry_p->getClosestCell(pclu);
+  double hcalEnergy = 0;
 
-  HBHERecHitCollection::const_iterator iterRecHit ; 
-  iterRecHit = hithbhe_->find(hcalDetId) ;
-  if (iterRecHit!=hithbhe_->end()) {
-    hcalEnergy = iterRecHit->energy() ;
-    HoE = hcalEnergy/ecalEnergy ;
+  HBHERecHitCollection::const_iterator iterRecHit;
+  iterRecHit = hithbhe_->find(hcalDetId);
+  if (iterRecHit != hithbhe_->end()) {
+    hcalEnergy = iterRecHit->energy();
+    HoE = hcalEnergy / ecalEnergy;
   }
 
-  return HoE ;
+  return HoE;
 }
 
 /*

--- a/RecoEgamma/EgammaTools/src/LongDeps.cc
+++ b/RecoEgamma/EgammaTools/src/LongDeps.cc
@@ -2,24 +2,34 @@
 
 using namespace hgcal;
 
-LongDeps::LongDeps(float radius, const std::vector<float>& energyPerLayer, float energyEE,float energyFH,float energyBH,const std::set<int>& layers):
-energyPerLayer_(energyPerLayer),radius_(radius),energyEE_(energyEE),energyFH_(energyFH),
-energyBH_(energyBH),layers_(layers) {
-    lay_Efrac10_ = 0;
-    lay_Efrac90_ = 0;
-    float lay_energy = 0;
-    float e4 = 0.;
-    // NB: energyPerLayer_ is 1-indexed
-    for (unsigned lay = 1; lay < energyPerLayer_.size(); ++lay) {
-        lay_energy += energyPerLayer_[lay];
-        if (lay<5) e4 += energyPerLayer_[lay];
-        if (lay_Efrac10_ == 0 && lay_energy > 0.1 * energyEE_){
-            lay_Efrac10_ = lay;
-        }
-        if (lay_Efrac90_ == 0 && lay_energy > 0.9 * energyEE_){
-            lay_Efrac90_ = lay;
-        }
+LongDeps::LongDeps(float radius,
+                   const std::vector<float>& energyPerLayer,
+                   float energyEE,
+                   float energyFH,
+                   float energyBH,
+                   const std::set<int>& layers)
+    : energyPerLayer_(energyPerLayer),
+      radius_(radius),
+      energyEE_(energyEE),
+      energyFH_(energyFH),
+      energyBH_(energyBH),
+      layers_(layers) {
+  lay_Efrac10_ = 0;
+  lay_Efrac90_ = 0;
+  float lay_energy = 0;
+  float e4 = 0.;
+  // NB: energyPerLayer_ is 1-indexed
+  for (unsigned lay = 1; lay < energyPerLayer_.size(); ++lay) {
+    lay_energy += energyPerLayer_[lay];
+    if (lay < 5)
+      e4 += energyPerLayer_[lay];
+    if (lay_Efrac10_ == 0 && lay_energy > 0.1 * energyEE_) {
+      lay_Efrac10_ = lay;
     }
-    float etot = energyEE_ + energyFH_ + energyBH_;
-    e4oEtot_ =  (etot > 0.) ? e4/etot : -1. ;
+    if (lay_Efrac90_ == 0 && lay_energy > 0.9 * energyEE_) {
+      lay_Efrac90_ = lay;
+    }
+  }
+  float etot = energyEE_ + energyFH_ + energyBH_;
+  e4oEtot_ = (etot > 0.) ? e4 / etot : -1.;
 }

--- a/RecoEgamma/EgammaTools/src/MVAVariableHelper.cc
+++ b/RecoEgamma/EgammaTools/src/MVAVariableHelper.cc
@@ -1,23 +1,12 @@
 #include "RecoEgamma/EgammaTools/interface/MVAVariableHelper.h"
 
-MVAVariableHelper::MVAVariableHelper(edm::ConsumesCollector && cc)
-    : tokens_({
-            cc.consumes<double>(edm::InputTag("fixedGridRhoFastjetAll")),
-            cc.consumes<double>(edm::InputTag("fixedGridRhoAll"))
-        })
-{}
+MVAVariableHelper::MVAVariableHelper(edm::ConsumesCollector&& cc)
+    : tokens_({cc.consumes<double>(edm::InputTag("fixedGridRhoFastjetAll")),
+               cc.consumes<double>(edm::InputTag("fixedGridRhoAll"))}) {}
 
-const std::vector<float> MVAVariableHelper::getAuxVariables(const edm::Event& iEvent) const
-{
-    return std::vector<float> {
-        getVariableFromDoubleToken(tokens_[0], iEvent),
-        getVariableFromDoubleToken(tokens_[1], iEvent)
-    };
+const std::vector<float> MVAVariableHelper::getAuxVariables(const edm::Event& iEvent) const {
+  return std::vector<float>{getVariableFromDoubleToken(tokens_[0], iEvent),
+                            getVariableFromDoubleToken(tokens_[1], iEvent)};
 }
 
-MVAVariableIndexMap::MVAVariableIndexMap()
-    : indexMap_({
-            {"fixedGridRhoFastjetAll"                                           , 0},
-            {"fixedGridRhoAll"                                                  , 1}
-        })
-{}
+MVAVariableIndexMap::MVAVariableIndexMap() : indexMap_({{"fixedGridRhoFastjetAll", 0}, {"fixedGridRhoAll", 1}}) {}

--- a/RecoEgamma/EgammaTools/src/PhotonEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/PhotonEnergyCalibrator.cc
@@ -9,50 +9,42 @@
 const EnergyScaleCorrection::ScaleCorrection PhotonEnergyCalibrator::defaultScaleCorr_;
 const EnergyScaleCorrection::SmearCorrection PhotonEnergyCalibrator::defaultSmearCorr_;
 
-PhotonEnergyCalibrator::PhotonEnergyCalibrator(const std::string& correctionFile):
-  correctionRetriever_(correctionFile),
-  rng_(nullptr),
-  minEt_(1.0)
-{
+PhotonEnergyCalibrator::PhotonEnergyCalibrator(const std::string& correctionFile)
+    : correctionRetriever_(correctionFile), rng_(nullptr), minEt_(1.0) {}
 
+void PhotonEnergyCalibrator::initPrivateRng(TRandom* rnd) { rng_ = rnd; }
+
+std::array<float, EGEnergySysIndex::kNrSysErrs> PhotonEnergyCalibrator::calibrate(
+    reco::Photon& photon,
+    const unsigned int runNumber,
+    const EcalRecHitCollection* recHits,
+    edm::StreamID const& id,
+    const PhotonEnergyCalibrator::EventType eventType) const {
+  return calibrate(photon, runNumber, recHits, gauss(id), eventType);
 }
 
-void PhotonEnergyCalibrator::initPrivateRng(TRandom *rnd)
-{
-  rng_ = rnd;
-}
-
-std::array<float,EGEnergySysIndex::kNrSysErrs> PhotonEnergyCalibrator::
-calibrate(reco::Photon &photon,const unsigned int runNumber, 
-	  const EcalRecHitCollection *recHits, 
-	  edm::StreamID const & id, 
-	  const PhotonEnergyCalibrator::EventType eventType) const
-{
-  return calibrate(photon,runNumber,recHits,gauss(id),eventType);
-}
-
-std::array<float,EGEnergySysIndex::kNrSysErrs> PhotonEnergyCalibrator::
-calibrate(reco::Photon &photon,const unsigned int runNumber, 
-	  const EcalRecHitCollection *recHits, 
-	  const float smearNrSigma, 
-	  const PhotonEnergyCalibrator::EventType eventType) const
-{
+std::array<float, EGEnergySysIndex::kNrSysErrs> PhotonEnergyCalibrator::calibrate(
+    reco::Photon& photon,
+    const unsigned int runNumber,
+    const EcalRecHitCollection* recHits,
+    const float smearNrSigma,
+    const PhotonEnergyCalibrator::EventType eventType) const {
   const float scEtaAbs = std::abs(photon.superCluster()->eta());
   const float et = photon.getCorrectedEnergy(reco::Photon::P4type::regression2) / cosh(scEtaAbs);
 
-  if (et < minEt_ || edm::isNotFinite(et) ) {
-    std::array<float,EGEnergySysIndex::kNrSysErrs> retVal;
+  if (et < minEt_ || edm::isNotFinite(et)) {
+    std::array<float, EGEnergySysIndex::kNrSysErrs> retVal;
     retVal.fill(photon.getCorrectedEnergy(reco::Photon::P4type::regression2));
-    retVal[EGEnergySysIndex::kScaleValue]  = 1.0;
-    retVal[EGEnergySysIndex::kSmearValue]  = 0.0;
-    retVal[EGEnergySysIndex::kSmearNrSigma]  = smearNrSigma;
-    retVal[EGEnergySysIndex::kEcalErrPreCorr] = photon.getCorrectedEnergyError(reco::Photon::P4type::regression2); 
+    retVal[EGEnergySysIndex::kScaleValue] = 1.0;
+    retVal[EGEnergySysIndex::kSmearValue] = 0.0;
+    retVal[EGEnergySysIndex::kSmearNrSigma] = smearNrSigma;
+    retVal[EGEnergySysIndex::kEcalErrPreCorr] = photon.getCorrectedEnergyError(reco::Photon::P4type::regression2);
     retVal[EGEnergySysIndex::kEcalErrPostCorr] = photon.getCorrectedEnergyError(reco::Photon::P4type::regression2);
     retVal[EGEnergySysIndex::kEcalTrkPreCorr] = 0.;
     retVal[EGEnergySysIndex::kEcalTrkErrPreCorr] = 0.;
     retVal[EGEnergySysIndex::kEcalTrkPostCorr] = 0.;
     retVal[EGEnergySysIndex::kEcalTrkErrPostCorr] = 0.;
-    
+
     return retVal;
   }
 
@@ -60,49 +52,54 @@ calibrate(reco::Photon &photon,const unsigned int runNumber,
   EcalRecHitCollection::const_iterator seedRecHit = recHits->find(seedDetId);
   unsigned int gainSeedSC = 12;
   if (seedRecHit != recHits->end()) {
-    if(seedRecHit->checkFlag(EcalRecHit::kHasSwitchToGain6)) gainSeedSC = 6;
-    if(seedRecHit->checkFlag(EcalRecHit::kHasSwitchToGain1)) gainSeedSC = 1;
+    if (seedRecHit->checkFlag(EcalRecHit::kHasSwitchToGain6))
+      gainSeedSC = 6;
+    if (seedRecHit->checkFlag(EcalRecHit::kHasSwitchToGain1))
+      gainSeedSC = 1;
   }
-  
-  const EnergyScaleCorrection::ScaleCorrection* scaleCorr = correctionRetriever_.getScaleCorr(runNumber, et, scEtaAbs, photon.full5x5_r9(), gainSeedSC);  
-  const EnergyScaleCorrection::SmearCorrection* smearCorr = correctionRetriever_.getSmearCorr(runNumber, et, scEtaAbs, photon.full5x5_r9(), gainSeedSC);  
-  if(scaleCorr==nullptr) scaleCorr=&defaultScaleCorr_;
-  if(smearCorr==nullptr) smearCorr=&defaultSmearCorr_;
- 
 
-  std::array<float,EGEnergySysIndex::kNrSysErrs> uncertainties{};
-  
-  uncertainties[EGEnergySysIndex::kScaleValue]  = scaleCorr->scale();
-  uncertainties[EGEnergySysIndex::kSmearValue]  = smearCorr->sigma(et); //even though we use scale = 1.0, we still store the value returned for MC
-  uncertainties[EGEnergySysIndex::kSmearNrSigma]  = smearNrSigma;
+  const EnergyScaleCorrection::ScaleCorrection* scaleCorr =
+      correctionRetriever_.getScaleCorr(runNumber, et, scEtaAbs, photon.full5x5_r9(), gainSeedSC);
+  const EnergyScaleCorrection::SmearCorrection* smearCorr =
+      correctionRetriever_.getSmearCorr(runNumber, et, scEtaAbs, photon.full5x5_r9(), gainSeedSC);
+  if (scaleCorr == nullptr)
+    scaleCorr = &defaultScaleCorr_;
+  if (smearCorr == nullptr)
+    smearCorr = &defaultSmearCorr_;
+
+  std::array<float, EGEnergySysIndex::kNrSysErrs> uncertainties{};
+
+  uncertainties[EGEnergySysIndex::kScaleValue] = scaleCorr->scale();
+  uncertainties[EGEnergySysIndex::kSmearValue] =
+      smearCorr->sigma(et);  //even though we use scale = 1.0, we still store the value returned for MC
+  uncertainties[EGEnergySysIndex::kSmearNrSigma] = smearNrSigma;
   //MC central values are not scaled (scale = 1.0), data is not smeared (smearNrSigma = 0)
-  //smearing still has a second order effect on data as it enters the E/p combination as an 
+  //smearing still has a second order effect on data as it enters the E/p combination as an
   //extra uncertainty on the calo energy
   //MC gets all the scale systematics
-  if(eventType == EventType::DATA){ 
-    setEnergyAndSystVarations(scaleCorr->scale(),0.,et,*scaleCorr,*smearCorr,photon,uncertainties);
-  }else if(eventType == EventType::MC){
-    setEnergyAndSystVarations(1.0,smearNrSigma,et,*scaleCorr,*smearCorr,photon,uncertainties);
+  if (eventType == EventType::DATA) {
+    setEnergyAndSystVarations(scaleCorr->scale(), 0., et, *scaleCorr, *smearCorr, photon, uncertainties);
+  } else if (eventType == EventType::MC) {
+    setEnergyAndSystVarations(1.0, smearNrSigma, et, *scaleCorr, *smearCorr, photon, uncertainties);
   }
-  
+
   return uncertainties;
-  
 }
 
-void PhotonEnergyCalibrator::
-setEnergyAndSystVarations(const float scale,const float smearNrSigma,const float et,
-			  const EnergyScaleCorrection::ScaleCorrection& scaleCorr,
-			  const EnergyScaleCorrection::SmearCorrection& smearCorr,
-			  reco::Photon& photon,
-			  std::array<float,EGEnergySysIndex::kNrSysErrs>& energyData)const
-{
- 
-  const float smear = smearCorr.sigma(et);   
-  const float smearRhoUp = smearCorr.sigma(et,1,0);
-  const float smearRhoDn = smearCorr.sigma(et,-1,0);
-  const float smearPhiUp = smearCorr.sigma(et,0,1);
-  const float smearPhiDn = smearCorr.sigma(et,0,-1);
- 
+void PhotonEnergyCalibrator::setEnergyAndSystVarations(
+    const float scale,
+    const float smearNrSigma,
+    const float et,
+    const EnergyScaleCorrection::ScaleCorrection& scaleCorr,
+    const EnergyScaleCorrection::SmearCorrection& smearCorr,
+    reco::Photon& photon,
+    std::array<float, EGEnergySysIndex::kNrSysErrs>& energyData) const {
+  const float smear = smearCorr.sigma(et);
+  const float smearRhoUp = smearCorr.sigma(et, 1, 0);
+  const float smearRhoDn = smearCorr.sigma(et, -1, 0);
+  const float smearPhiUp = smearCorr.sigma(et, 0, 1);
+  const float smearPhiDn = smearCorr.sigma(et, 0, -1);
+
   const float corr = scale + smear * smearNrSigma;
   const float corrRhoUp = scale + smearRhoUp * smearNrSigma;
   const float corrRhoDn = scale + smearRhoDn * smearNrSigma;
@@ -111,54 +108,51 @@ setEnergyAndSystVarations(const float scale,const float smearNrSigma,const float
   const float corrUp = corrRhoUp;
   const float corrDn = corrRhoDn;
 
-  
   const double oldEcalEnergy = photon.getCorrectedEnergy(reco::Photon::P4type::regression2);
   const double oldEcalEnergyError = photon.getCorrectedEnergyError(reco::Photon::P4type::regression2);
-  
+
   energyData[EGEnergySysIndex::kEcalPreCorr] = oldEcalEnergy;
   energyData[EGEnergySysIndex::kEcalErrPreCorr] = oldEcalEnergyError;
 
-  const double newEcalEnergy      = oldEcalEnergy * corr;
+  const double newEcalEnergy = oldEcalEnergy * corr;
   const double newEcalEnergyError = std::hypot(oldEcalEnergyError * corr, smear * newEcalEnergy);
   photon.setCorrectedEnergy(reco::Photon::P4type::regression2, newEcalEnergy, newEcalEnergyError, true);
-  
-  energyData[EGEnergySysIndex::kScaleStatUp]   = oldEcalEnergy * (corr + scaleCorr.scaleErrStat());
+
+  energyData[EGEnergySysIndex::kScaleStatUp] = oldEcalEnergy * (corr + scaleCorr.scaleErrStat());
   energyData[EGEnergySysIndex::kScaleStatDown] = oldEcalEnergy * (corr - scaleCorr.scaleErrStat());
-  energyData[EGEnergySysIndex::kScaleSystUp]   = oldEcalEnergy * (corr + scaleCorr.scaleErrSyst());
+  energyData[EGEnergySysIndex::kScaleSystUp] = oldEcalEnergy * (corr + scaleCorr.scaleErrSyst());
   energyData[EGEnergySysIndex::kScaleSystDown] = oldEcalEnergy * (corr - scaleCorr.scaleErrSyst());
-  energyData[EGEnergySysIndex::kScaleGainUp]   = oldEcalEnergy * (corr + scaleCorr.scaleErrGain());
+  energyData[EGEnergySysIndex::kScaleGainUp] = oldEcalEnergy * (corr + scaleCorr.scaleErrGain());
   energyData[EGEnergySysIndex::kScaleGainDown] = oldEcalEnergy * (corr - scaleCorr.scaleErrGain());
-  energyData[EGEnergySysIndex::kSmearRhoUp]    = oldEcalEnergy * corrRhoUp;
-  energyData[EGEnergySysIndex::kSmearRhoDown]  = oldEcalEnergy * corrRhoDn;
-  energyData[EGEnergySysIndex::kSmearPhiUp]    = oldEcalEnergy * corrPhiUp;
-  energyData[EGEnergySysIndex::kSmearPhiDown]  = oldEcalEnergy * corrPhiDn;
-  
+  energyData[EGEnergySysIndex::kSmearRhoUp] = oldEcalEnergy * corrRhoUp;
+  energyData[EGEnergySysIndex::kSmearRhoDown] = oldEcalEnergy * corrRhoDn;
+  energyData[EGEnergySysIndex::kSmearPhiUp] = oldEcalEnergy * corrPhiUp;
+  energyData[EGEnergySysIndex::kSmearPhiDown] = oldEcalEnergy * corrPhiDn;
+
   // The total variation
-  energyData[EGEnergySysIndex::kScaleUp]   = oldEcalEnergy * (corr + scaleCorr.scaleErr(EnergyScaleCorrection::kErrStatSystGain));
-  energyData[EGEnergySysIndex::kScaleDown] = oldEcalEnergy * (corr - scaleCorr.scaleErr(EnergyScaleCorrection::kErrStatSystGain));
-  energyData[EGEnergySysIndex::kSmearUp]   = oldEcalEnergy * corrUp;
+  energyData[EGEnergySysIndex::kScaleUp] =
+      oldEcalEnergy * (corr + scaleCorr.scaleErr(EnergyScaleCorrection::kErrStatSystGain));
+  energyData[EGEnergySysIndex::kScaleDown] =
+      oldEcalEnergy * (corr - scaleCorr.scaleErr(EnergyScaleCorrection::kErrStatSystGain));
+  energyData[EGEnergySysIndex::kSmearUp] = oldEcalEnergy * corrUp;
   energyData[EGEnergySysIndex::kSmearDown] = oldEcalEnergy * corrDn;
 
-  
   energyData[EGEnergySysIndex::kEcalPostCorr] = photon.getCorrectedEnergy(reco::Photon::P4type::regression2);
   energyData[EGEnergySysIndex::kEcalErrPostCorr] = photon.getCorrectedEnergyError(reco::Photon::P4type::regression2);
-}  
+}
 
-
-double PhotonEnergyCalibrator::gauss(edm::StreamID const& id) const
-{
+double PhotonEnergyCalibrator::gauss(edm::StreamID const& id) const {
   if (rng_) {
     return rng_->Gaus();
   } else {
     edm::Service<edm::RandomNumberGenerator> rng;
-    if ( !rng.isAvailable() ) {
+    if (!rng.isAvailable()) {
       throw cms::Exception("Configuration")
-	<< "XXXXXXX requires the RandomNumberGeneratorService\n"
-	"which is not present in the configuration file.  You must add the service\n"
-	"in the configuration file or remove the modules that require it.";
-		}
+          << "XXXXXXX requires the RandomNumberGeneratorService\n"
+             "which is not present in the configuration file.  You must add the service\n"
+             "in the configuration file or remove the modules that require it.";
+    }
     CLHEP::RandGaussQ gaussDistribution(rng->getEngine(id), 0.0, 1.0);
     return gaussDistribution.fire();
   }
 }
-

--- a/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
@@ -14,42 +14,38 @@
 using namespace reco;
 
 //--------------------------------------------------------------------------------------------------
-SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm() :
-foresteb_(nullptr),
-forestee_(nullptr),
-forestsigmaeb_(nullptr),
-forestsigmaee_(nullptr),
-calotopo_(nullptr),
-calogeom_(nullptr)
-{}
+SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm()
+    : foresteb_(nullptr),
+      forestee_(nullptr),
+      forestsigmaeb_(nullptr),
+      forestsigmaee_(nullptr),
+      calotopo_(nullptr),
+      calogeom_(nullptr) {}
 
 //--------------------------------------------------------------------------------------------------
-SCEnergyCorrectorSemiParm::~SCEnergyCorrectorSemiParm()
-{}
+SCEnergyCorrectorSemiParm::~SCEnergyCorrectorSemiParm() {}
 
 //--------------------------------------------------------------------------------------------------
 void SCEnergyCorrectorSemiParm::setTokens(const edm::ParameterSet &iConfig, edm::ConsumesCollector &cc) {
-  
   isHLT_ = iConfig.getParameter<bool>("isHLT");
   applySigmaIetaIphiBug_ = iConfig.getParameter<bool>("applySigmaIetaIphiBug");
-  tokenEBRecHits_   = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEB"));
-  tokenEERecHits_   = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEE"));
+  tokenEBRecHits_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEB"));
+  tokenEERecHits_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEE"));
 
-  regressionKeyEB_  = iConfig.getParameter<std::string>("regressionKeyEB");
+  regressionKeyEB_ = iConfig.getParameter<std::string>("regressionKeyEB");
   uncertaintyKeyEB_ = iConfig.getParameter<std::string>("uncertaintyKeyEB");
-  regressionKeyEE_  = iConfig.getParameter<std::string>("regressionKeyEE");
+  regressionKeyEE_ = iConfig.getParameter<std::string>("regressionKeyEE");
   uncertaintyKeyEE_ = iConfig.getParameter<std::string>("uncertaintyKeyEE");
- 
-  if (not isHLT_){
-    tokenVertices_     = cc.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"));
-  }else{
-    eThreshold_       = iConfig.getParameter<double>("eRecHitThreshold");
+
+  if (not isHLT_) {
+    tokenVertices_ = cc.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"));
+  } else {
+    eThreshold_ = iConfig.getParameter<double>("eRecHitThreshold");
   }
 }
 
 //--------------------------------------------------------------------------------------------------
 void SCEnergyCorrectorSemiParm::setEventSetup(const edm::EventSetup &es) {
-
   es.get<CaloTopologyRecord>().get(calotopo_);
   es.get<CaloGeometryRecord>().get(calogeom_);
 
@@ -57,42 +53,41 @@ void SCEnergyCorrectorSemiParm::setEventSetup(const edm::EventSetup &es) {
   edm::ESHandle<GBRForestD> readerebvar;
   edm::ESHandle<GBRForestD> readeree;
   edm::ESHandle<GBRForestD> readereevar;
-    
-  es.get<GBRDWrapperRcd>().get(regressionKeyEB_,  readereb);
+
+  es.get<GBRDWrapperRcd>().get(regressionKeyEB_, readereb);
   es.get<GBRDWrapperRcd>().get(uncertaintyKeyEB_, readerebvar);
-  es.get<GBRDWrapperRcd>().get(regressionKeyEE_,  readeree);
+  es.get<GBRDWrapperRcd>().get(regressionKeyEE_, readeree);
   es.get<GBRDWrapperRcd>().get(uncertaintyKeyEE_, readereevar);
 
-  foresteb_      = readereb.product();
+  foresteb_ = readereb.product();
   forestsigmaeb_ = readerebvar.product();
-  forestee_      = readeree.product();
+  forestee_ = readeree.product();
   forestsigmaee_ = readereevar.product();
 }
 
 //--------------------------------------------------------------------------------------------------
 void SCEnergyCorrectorSemiParm::setEvent(const edm::Event &e) {
-  
-  e.getByToken(tokenEBRecHits_,rechitsEB_);
-  e.getByToken(tokenEERecHits_,rechitsEE_);
+  e.getByToken(tokenEBRecHits_, rechitsEB_);
+  e.getByToken(tokenEERecHits_, rechitsEE_);
 
   if (not isHLT_)
-    e.getByToken(tokenVertices_,vertices_);
+    e.getByToken(tokenVertices_, vertices_);
   else {
     nHitsAboveThreshold_ = 0;
-    const EcalRecHitCollection *recHitsEB = ( rechitsEB_.isValid() ? rechitsEB_.product() : nullptr );
-    const EcalRecHitCollection *recHitsEE = ( rechitsEE_.isValid() ? rechitsEE_.product() : nullptr ); 
-    
-    if( nullptr != recHitsEB ) {
-      for (EcalRecHitCollection::const_iterator it=recHitsEB->begin(); it!=recHitsEB->end(); ++it) {
-	if (it->energy() > eThreshold_)
-	  nHitsAboveThreshold_++;
+    const EcalRecHitCollection *recHitsEB = (rechitsEB_.isValid() ? rechitsEB_.product() : nullptr);
+    const EcalRecHitCollection *recHitsEE = (rechitsEE_.isValid() ? rechitsEE_.product() : nullptr);
+
+    if (nullptr != recHitsEB) {
+      for (EcalRecHitCollection::const_iterator it = recHitsEB->begin(); it != recHitsEB->end(); ++it) {
+        if (it->energy() > eThreshold_)
+          nHitsAboveThreshold_++;
       }
     }
-    
-    if( nullptr != recHitsEE ) {
-      for (EcalRecHitCollection::const_iterator it=recHitsEE->begin(); it!=recHitsEE->end(); ++it) {
-	if (it->energy() > eThreshold_)
-	  nHitsAboveThreshold_++;
+
+    if (nullptr != recHitsEE) {
+      for (EcalRecHitCollection::const_iterator it = recHitsEE->begin(); it != recHitsEE->end(); ++it) {
+        if (it->energy() > eThreshold_)
+          nHitsAboveThreshold_++;
       }
     }
   }
@@ -101,47 +96,50 @@ void SCEnergyCorrectorSemiParm::setEvent(const edm::Event &e) {
 //--------------------------------------------------------------------------------------------------
 std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::SuperCluster &sc) const {
   std::pair<double, double> p;
-  p.first=-1;
-  p.second=-1;
+  p.first = -1;
+  p.second = -1;
 
   // protect against HGCal, don't mod the object
-  if( EcalTools::isHGCalDet(sc.seed()->seed().det()) ) return p;
+  if (EcalTools::isHGCalDet(sc.seed()->seed().det()))
+    return p;
 
   const reco::CaloCluster &seedCluster = *(sc.seed());
   const bool iseb = seedCluster.hitsAndFractions()[0].first.subdetId() == EcalBarrel;
   const EcalRecHitCollection *recHits = iseb ? rechitsEB_.product() : rechitsEE_.product();
 
   const CaloTopology *topo = calotopo_.product();
-  
-  const double raw_energy = sc.rawEnergy();   
-  const int numberOfClusters =  sc.clusters().size();
 
-  std::vector<float> localCovariances = EcalClusterTools::localCovariances(seedCluster,recHits,topo) ;
-  
+  const double raw_energy = sc.rawEnergy();
+  const int numberOfClusters = sc.clusters().size();
+
+  std::vector<float> localCovariances = EcalClusterTools::localCovariances(seedCluster, recHits, topo);
+
   if (not isHLT_) {
     std::array<float, 30> eval;
-    
-    const float eLeft = EcalClusterTools::eLeft(seedCluster,recHits,topo);
-    const float eRight = EcalClusterTools::eRight(seedCluster,recHits,topo);
-    const float eTop = EcalClusterTools::eTop(seedCluster,recHits,topo);
-    const float eBottom = EcalClusterTools::eBottom(seedCluster,recHits,topo);
-    
+
+    const float eLeft = EcalClusterTools::eLeft(seedCluster, recHits, topo);
+    const float eRight = EcalClusterTools::eRight(seedCluster, recHits, topo);
+    const float eTop = EcalClusterTools::eTop(seedCluster, recHits, topo);
+    const float eBottom = EcalClusterTools::eBottom(seedCluster, recHits, topo);
+
     float sigmaIetaIeta = sqrt(localCovariances[0]);
     float sigmaIetaIphi = std::numeric_limits<float>::max();
     float sigmaIphiIphi = std::numeric_limits<float>::max();
 
-    if (!edm::isNotFinite(localCovariances[2])) sigmaIphiIphi = sqrt(localCovariances[2]) ;
+    if (!edm::isNotFinite(localCovariances[2]))
+      sigmaIphiIphi = sqrt(localCovariances[2]);
 
     // extra shower shapes
-    const float see_by_spp = sigmaIetaIeta*(applySigmaIetaIphiBug_ ? std::numeric_limits<float>::max() : sigmaIphiIphi);
-    if(  see_by_spp > 0 ) {
+    const float see_by_spp =
+        sigmaIetaIeta * (applySigmaIetaIphiBug_ ? std::numeric_limits<float>::max() : sigmaIphiIphi);
+    if (see_by_spp > 0) {
       sigmaIetaIphi = localCovariances[1] / see_by_spp;
-    } else if ( localCovariances[1] > 0 ) {
+    } else if (localCovariances[1] > 0) {
       sigmaIetaIphi = 1.f;
     } else {
       sigmaIetaIphi = -1.f;
     }
-    
+
     // calculate sub-cluster variables
     std::vector<float> clusterRawEnergy;
     clusterRawEnergy.resize(std::max(3, numberOfClusters), 0);
@@ -149,60 +147,60 @@ std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::
     clusterDEtaToSeed.resize(std::max(3, numberOfClusters), 0);
     std::vector<float> clusterDPhiToSeed;
     clusterDPhiToSeed.resize(std::max(3, numberOfClusters), 0);
-    float clusterMaxDR     = 999.;
+    float clusterMaxDR = 999.;
     float clusterMaxDRDPhi = 999.;
     float clusterMaxDRDEta = 999.;
     float clusterMaxDRRawEnergy = 0.;
-    
+
     size_t iclus = 0;
     float maxDR = 0;
     edm::Ptr<reco::CaloCluster> pclus;
-    const edm::Ptr<reco::CaloCluster>& theseed = sc.seed();
-    // loop over all clusters that aren't the seed  
+    const edm::Ptr<reco::CaloCluster> &theseed = sc.seed();
+    // loop over all clusters that aren't the seed
     auto clusend = sc.clustersEnd();
-    for( auto clus = sc.clustersBegin(); clus != clusend; ++clus ) {
+    for (auto clus = sc.clustersBegin(); clus != clusend; ++clus) {
       pclus = *clus;
-      
-      if(theseed == pclus ) 
-	continue;
-      clusterRawEnergy[iclus]  = pclus->energy();
-      clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(),theseed->phi());
+
+      if (theseed == pclus)
+        continue;
+      clusterRawEnergy[iclus] = pclus->energy();
+      clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(), theseed->phi());
       clusterDEtaToSeed[iclus] = pclus->eta() - theseed->eta();
-      
+
       // find cluster with max dR
       const auto the_dr = reco::deltaR(*pclus, *theseed);
-      if(the_dr > maxDR) {
-	maxDR = the_dr;
-	clusterMaxDR = maxDR;
-	clusterMaxDRDPhi = clusterDPhiToSeed[iclus];
-	clusterMaxDRDEta = clusterDEtaToSeed[iclus];
-	clusterMaxDRRawEnergy = clusterRawEnergy[iclus];
-      }      
+      if (the_dr > maxDR) {
+        maxDR = the_dr;
+        clusterMaxDR = maxDR;
+        clusterMaxDRDPhi = clusterDPhiToSeed[iclus];
+        clusterMaxDRDEta = clusterDEtaToSeed[iclus];
+        clusterMaxDRRawEnergy = clusterRawEnergy[iclus];
+      }
       ++iclus;
-    }  
-    
+    }
+
     // SET INPUTS
-    eval[0]  = vertices_->size();
-    eval[1]  = raw_energy;
-    eval[2]  = sc.etaWidth();
-    eval[3]  = sc.phiWidth();
-    eval[4]  = EcalClusterTools::e3x3(seedCluster,recHits,topo)/raw_energy; 
-    eval[5]  = seedCluster.energy()/raw_energy;
-    eval[6]  = EcalClusterTools::eMax(seedCluster,recHits)/raw_energy;
-    eval[7]  = EcalClusterTools::e2nd(seedCluster,recHits)/raw_energy;
-    eval[8] = (eLeft + eRight != 0.f  ? (eLeft-eRight)/(eLeft+eRight) : 0.f);
-    eval[9] = (eTop  + eBottom != 0.f ? (eTop-eBottom)/(eTop+eBottom) : 0.f);
+    eval[0] = vertices_->size();
+    eval[1] = raw_energy;
+    eval[2] = sc.etaWidth();
+    eval[3] = sc.phiWidth();
+    eval[4] = EcalClusterTools::e3x3(seedCluster, recHits, topo) / raw_energy;
+    eval[5] = seedCluster.energy() / raw_energy;
+    eval[6] = EcalClusterTools::eMax(seedCluster, recHits) / raw_energy;
+    eval[7] = EcalClusterTools::e2nd(seedCluster, recHits) / raw_energy;
+    eval[8] = (eLeft + eRight != 0.f ? (eLeft - eRight) / (eLeft + eRight) : 0.f);
+    eval[9] = (eTop + eBottom != 0.f ? (eTop - eBottom) / (eTop + eBottom) : 0.f);
     eval[10] = sigmaIetaIeta;
     eval[11] = sigmaIetaIphi;
     eval[12] = sigmaIphiIphi;
-    eval[13] = std::max(0,numberOfClusters-1);
+    eval[13] = std::max(0, numberOfClusters - 1);
     eval[14] = clusterMaxDR;
     eval[15] = clusterMaxDRDPhi;
     eval[16] = clusterMaxDRDEta;
-    eval[17] = clusterMaxDRRawEnergy/raw_energy;
-    eval[18] = clusterRawEnergy[0]/raw_energy;
-    eval[19] = clusterRawEnergy[1]/raw_energy;
-    eval[20] = clusterRawEnergy[2]/raw_energy;
+    eval[17] = clusterMaxDRRawEnergy / raw_energy;
+    eval[18] = clusterRawEnergy[0] / raw_energy;
+    eval[19] = clusterRawEnergy[1] / raw_energy;
+    eval[20] = clusterRawEnergy[2] / raw_energy;
     eval[21] = clusterDPhiToSeed[0];
     eval[22] = clusterDPhiToSeed[1];
     eval[23] = clusterDPhiToSeed[2];
@@ -221,103 +219,102 @@ std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::
       //and was not used in the 74X regression however as its just an extra varaible
       //at the end, its harmless to add for the 74X regression
       eval[29] = seedCluster.eta();
-    }  
+    }
 
     //magic numbers for MINUIT-like transformation of BDT output onto limited range
     //(These should be stored inside the conditions object in the future as well)
-    constexpr double meanlimlow  = 0.2;
+    constexpr double meanlimlow = 0.2;
     constexpr double meanlimhigh = 2.0;
-    constexpr double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
-    constexpr double meanscale   = 0.5*(meanlimhigh-meanlimlow);
-    
-    constexpr double sigmalimlow  = 0.0002;
+    constexpr double meanoffset = meanlimlow + 0.5 * (meanlimhigh - meanlimlow);
+    constexpr double meanscale = 0.5 * (meanlimhigh - meanlimlow);
+
+    constexpr double sigmalimlow = 0.0002;
     constexpr double sigmalimhigh = 0.5;
-    constexpr double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
-    constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);  
-    
+    constexpr double sigmaoffset = sigmalimlow + 0.5 * (sigmalimhigh - sigmalimlow);
+    constexpr double sigmascale = 0.5 * (sigmalimhigh - sigmalimlow);
+
     const GBRForestD *forestmean = iseb ? foresteb_ : forestee_;
     const GBRForestD *forestsigma = iseb ? forestsigmaeb_ : forestsigmaee_;
-    
+
     //these are the actual BDT responses
     double rawmean = forestmean->GetResponse(eval.data());
     double rawsigma = forestsigma->GetResponse(eval.data());
-    
+
     //apply transformation to limited output range (matching the training)
-    double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
-    double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
-    
-    double ecor = mean*(eval[1]);
-    const double sigmacor = sigma*ecor;
-    
-	p.first  = ecor;
-	p.second = sigmacor;
+    double mean = meanoffset + meanscale * vdt::fast_sin(rawmean);
+    double sigma = sigmaoffset + sigmascale * vdt::fast_sin(rawsigma);
+
+    double ecor = mean * (eval[1]);
+    const double sigmacor = sigma * ecor;
+
+    p.first = ecor;
+    p.second = sigmacor;
 
   } else {
-
-    std::array<float, 7> eval;  
+    std::array<float, 7> eval;
     float clusterMaxDR = 999.;
 
     size_t iclus = 0;
     float maxDR = 0;
     edm::Ptr<reco::CaloCluster> pclus;
-    const edm::Ptr<reco::CaloCluster>& theseed = sc.seed();
+    const edm::Ptr<reco::CaloCluster> &theseed = sc.seed();
 
-    // loop over all clusters that aren't the seed  
+    // loop over all clusters that aren't the seed
     auto clusend = sc.clustersEnd();
-    for( auto clus = sc.clustersBegin(); clus != clusend; ++clus ) {
+    for (auto clus = sc.clustersBegin(); clus != clusend; ++clus) {
       pclus = *clus;
-      
-      if(theseed == pclus ) 
-	continue;
-      
+
+      if (theseed == pclus)
+        continue;
+
       // find cluster with max dR
       const auto the_dr = reco::deltaR(*pclus, *theseed);
-      if(the_dr > maxDR) {
-	maxDR = the_dr;
-	clusterMaxDR = maxDR;
-      }      
+      if (the_dr > maxDR) {
+        maxDR = the_dr;
+        clusterMaxDR = maxDR;
+      }
       ++iclus;
-    }  
-    
+    }
+
     // SET INPUTS
     eval[0] = nHitsAboveThreshold_;
-    eval[1] = sc.eta(); 
-    eval[2] = sc.phiWidth(); 
-    eval[3] = EcalClusterTools::e3x3(seedCluster,recHits,topo)/raw_energy;
-    eval[4] = std::max(0,numberOfClusters-1);
+    eval[1] = sc.eta();
+    eval[2] = sc.phiWidth();
+    eval[3] = EcalClusterTools::e3x3(seedCluster, recHits, topo) / raw_energy;
+    eval[4] = std::max(0, numberOfClusters - 1);
     eval[5] = clusterMaxDR;
     eval[6] = raw_energy;
-    
+
     //magic numbers for MINUIT-like transformation of BDT output onto limited range
     //(These should be stored inside the conditions object in the future as well)
-    constexpr double meanlimlow  = 0.2;
+    constexpr double meanlimlow = 0.2;
     constexpr double meanlimhigh = 2.0;
-    constexpr double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
-    constexpr double meanscale   = 0.5*(meanlimhigh-meanlimlow);
-    
+    constexpr double meanoffset = meanlimlow + 0.5 * (meanlimhigh - meanlimlow);
+    constexpr double meanscale = 0.5 * (meanlimhigh - meanlimlow);
+
     const GBRForestD *forestmean = iseb ? foresteb_ : forestee_;
 
     double rawmean = forestmean->GetResponse(eval.data());
-    double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
+    double mean = meanoffset + meanscale * vdt::fast_sin(rawmean);
 
-    double ecor = mean*eval[6];
-    if (!iseb)  
-      ecor = mean*eval[6]+sc.preshowerEnergy();
+    double ecor = mean * eval[6];
+    if (!iseb)
+      ecor = mean * eval[6] + sc.preshowerEnergy();
 
-	p.first  = ecor;
-	//p.second unchanged 
+    p.first = ecor;
+    //p.second unchanged
   }
 
   return p;
 }
-   
+
 //--------------------------------------------------------------------------------------------------
 void SCEnergyCorrectorSemiParm::modifyObject(reco::SuperCluster &sc) {
-  
-	std::pair<double, double> cor = getCorrections(sc);
-	if(cor.first<0) return;
-	sc.setEnergy(cor.first);
-	sc.setCorrectedEnergy(cor.first);
-	if(! isHLT_ && cor.second>=0.) sc.setCorrectedEnergyUncertainty(cor.second);
+  std::pair<double, double> cor = getCorrections(sc);
+  if (cor.first < 0)
+    return;
+  sc.setEnergy(cor.first);
+  sc.setCorrectedEnergy(cor.first);
+  if (!isHLT_ && cor.second >= 0.)
+    sc.setCorrectedEnergyUncertainty(cor.second);
 }
-

--- a/RecoEgamma/EgammaTools/src/ShowerDepth.cc
+++ b/RecoEgamma/EgammaTools/src/ShowerDepth.cc
@@ -3,28 +3,33 @@
 
 using namespace hgcal;
 
-float ShowerDepth::getClusterDepthCompatibility(float measuredDepth, float emEnergy, float& expectedDepth, float& expectedSigma) const {
-    float lny = (emEnergy > criticalEnergy_) ? std::log(emEnergy/criticalEnergy_) : 0.;
+float ShowerDepth::getClusterDepthCompatibility(float measuredDepth,
+                                                float emEnergy,
+                                                float& expectedDepth,
+                                                float& expectedSigma) const {
+  float lny = (emEnergy > criticalEnergy_) ? std::log(emEnergy / criticalEnergy_) : 0.;
 
-    // inject here parametrization results
-    float meantmax = meant0_ + meant1_*lny;
-    float meanalpha = meanalpha0_ + meanalpha1_*lny;
-    if ( meanalpha < 1. ) meanalpha = 1.1; // no poles
-    float sigmalntmax = 1. / (sigmalnt0_+sigmalnt1_*lny);
-    float sigmalnalpha = 1. / (sigmalnalpha0_+sigmalnalpha1_*lny);
-    float corrlnalphalntmax = corrlnalphalnt0_+corrlnalphalnt1_*lny;
+  // inject here parametrization results
+  float meantmax = meant0_ + meant1_ * lny;
+  float meanalpha = meanalpha0_ + meanalpha1_ * lny;
+  if (meanalpha < 1.)
+    meanalpha = 1.1;  // no poles
+  float sigmalntmax = 1. / (sigmalnt0_ + sigmalnt1_ * lny);
+  float sigmalnalpha = 1. / (sigmalnalpha0_ + sigmalnalpha1_ * lny);
+  float corrlnalphalntmax = corrlnalphalnt0_ + corrlnalphalnt1_ * lny;
 
-    float invbeta = meantmax/(meanalpha-1.);
-    float predictedDepth = meanalpha*invbeta;
-    predictedDepth *= radiationLength_;
+  float invbeta = meantmax / (meanalpha - 1.);
+  float predictedDepth = meanalpha * invbeta;
+  predictedDepth *= radiationLength_;
 
-    float predictedSigma = sigmalnalpha*sigmalnalpha/((meanalpha-1.)*(meanalpha-1.));
-    predictedSigma += sigmalntmax*sigmalntmax;
-    predictedSigma -= 2*sigmalnalpha*sigmalntmax*corrlnalphalntmax/(meanalpha-1.);
-    if ( predictedSigma < 0. ) predictedSigma = 1.e10; // say we can't predict anything
-    predictedSigma = predictedDepth*std::sqrt(predictedSigma);
+  float predictedSigma = sigmalnalpha * sigmalnalpha / ((meanalpha - 1.) * (meanalpha - 1.));
+  predictedSigma += sigmalntmax * sigmalntmax;
+  predictedSigma -= 2 * sigmalnalpha * sigmalntmax * corrlnalphalntmax / (meanalpha - 1.);
+  if (predictedSigma < 0.)
+    predictedSigma = 1.e10;  // say we can't predict anything
+  predictedSigma = predictedDepth * std::sqrt(predictedSigma);
 
-    expectedDepth = predictedDepth;
-    expectedSigma = predictedSigma;
-    return (measuredDepth-predictedDepth)/predictedSigma;
+  expectedDepth = predictedDepth;
+  expectedSigma = predictedSigma;
+  return (measuredDepth - predictedDepth) / predictedSigma;
 }

--- a/RecoEgamma/EgammaTools/test/GBRWrapperMaker.cc
+++ b/RecoEgamma/EgammaTools/test/GBRWrapperMaker.cc
@@ -3,7 +3,7 @@
 //
 // Package:    GBRWrapperMaker
 // Class:      GBRWrapperMaker
-// 
+//
 /**\class GBRWrapperMaker GBRWrapperMaker.cc GBRWrap/GBRWrapperMaker/src/GBRWrapperMaker.cc
 
  Description: [one line class summary]
@@ -16,7 +16,6 @@
 //         Created:  Tue Nov  8 22:26:45 CET 2011
 //
 //
-
 
 // system include files
 #include <memory>
@@ -40,30 +39,28 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 
-
 //
 // class declaration
 //
 
 class GBRWrapperMaker : public edm::EDAnalyzer {
-   public:
-      explicit GBRWrapperMaker(const edm::ParameterSet&);
-      ~GBRWrapperMaker();
+public:
+  explicit GBRWrapperMaker(const edm::ParameterSet&);
+  ~GBRWrapperMaker();
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+private:
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
-   private:
-      virtual void beginJob() override ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-      virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-      virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-      virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
 //
@@ -80,98 +77,65 @@ class GBRWrapperMaker : public edm::EDAnalyzer {
 GBRWrapperMaker::GBRWrapperMaker(const edm::ParameterSet& iConfig)
 
 {
-   //now do what ever initialization is needed
-
+  //now do what ever initialization is needed
 }
 
-
-GBRWrapperMaker::~GBRWrapperMaker()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+GBRWrapperMaker::~GBRWrapperMaker() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-GBRWrapperMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void GBRWrapperMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   //from Josh:
   //TFile *infile = new TFile("../data/GBRLikelihood_Clustering_746_bx25_Electrons_NoPosition_standardShapes_NoPS_PFMustache_results_PROD.root","READ");
-  TFile *infile = new TFile("../data/GBRLikelihood_Clustering_746_bx25_HLT.root","READ");
+  TFile* infile = new TFile("../data/GBRLikelihood_Clustering_746_bx25_HLT.root", "READ");
   printf("load forest\n");
-  
+
   //GBRForestD *p4comb = (GBRForest*)infile->Get("CombinationWeight");
-  GBRForestD *gbreb = (GBRForestD*)infile->Get("EBCorrection");
-  GBRForestD *gbrebvar = (GBRForestD*)infile->Get("EBUncertainty");
-  GBRForestD *gbree = (GBRForestD*)infile->Get("EECorrection");
-  GBRForestD *gbreevar = (GBRForestD*)infile->Get("EEUncertainty");
-  
+  GBRForestD* gbreb = (GBRForestD*)infile->Get("EBCorrection");
+  GBRForestD* gbrebvar = (GBRForestD*)infile->Get("EBUncertainty");
+  GBRForestD* gbree = (GBRForestD*)infile->Get("EECorrection");
+  GBRForestD* gbreevar = (GBRForestD*)infile->Get("EEUncertainty");
+
   printf("made objects\n");
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    
     //poolDbService->writeOne( p4comb, poolDbService->beginOfTime(),
     //		     "gedelectron_p4combination"  );
-    poolDbService->writeOne( gbreb, poolDbService->beginOfTime(),
-			     "mustacheSC_online_EBCorrection"  );
-    poolDbService->writeOne( gbrebvar, poolDbService->beginOfTime(),
-			     "mustacheSC_online_EBUncertainty"  );
-    poolDbService->writeOne( gbree, poolDbService->beginOfTime(),
-			     "mustacheSC_online_EECorrection"  );
-    poolDbService->writeOne( gbreevar, poolDbService->beginOfTime(),
-			     "mustacheSC_online_EEUncertainty"  );
+    poolDbService->writeOne(gbreb, poolDbService->beginOfTime(), "mustacheSC_online_EBCorrection");
+    poolDbService->writeOne(gbrebvar, poolDbService->beginOfTime(), "mustacheSC_online_EBUncertainty");
+    poolDbService->writeOne(gbree, poolDbService->beginOfTime(), "mustacheSC_online_EECorrection");
+    poolDbService->writeOne(gbreevar, poolDbService->beginOfTime(), "mustacheSC_online_EEUncertainty");
   }
 }
 
-
 // ------------ method called once each job just before starting event loop  ------------
-void 
-GBRWrapperMaker::beginJob()
-{
-}
+void GBRWrapperMaker::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-GBRWrapperMaker::endJob() 
-{
-}
+void GBRWrapperMaker::endJob() {}
 
 // ------------ method called when starting to processes a run  ------------
-void 
-GBRWrapperMaker::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
+void GBRWrapperMaker::beginRun(edm::Run const&, edm::EventSetup const&) {}
 
 // ------------ method called when ending the processing of a run  ------------
-void 
-GBRWrapperMaker::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
+void GBRWrapperMaker::endRun(edm::Run const&, edm::EventSetup const&) {}
 
 // ------------ method called when starting to processes a luminosity block  ------------
-void 
-GBRWrapperMaker::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
+void GBRWrapperMaker::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
 
 // ------------ method called when ending the processing of a luminosity block  ------------
-void 
-GBRWrapperMaker::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
+void GBRWrapperMaker::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-GBRWrapperMaker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void GBRWrapperMaker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -131,7 +131,7 @@ void CorrectedECALPFClusterProducer::fillDescriptions(edm::ConfigurationDescript
     psd0.add<bool>("applyCrackCorrections", false);
     psd0.add<bool>("applyMVACorrections", false);
     psd0.add<bool>("srfAwareCorrection", false);
-    psd0.add<bool>("setEnergyUncertainty",false);
+    psd0.add<bool>("setEnergyUncertainty", false);
     psd0.add<bool>("autoDetectBunchSpacing", true);
     psd0.add<int>("bunchSpacing", 25);
     psd0.add<double>("maxPtForMVAEvaluation", -99.);

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -11,7 +11,6 @@ namespace {
   double getScale(const double lo, const double hi) { return 0.5 * (hi - lo); }
 }  // namespace
 
-
 PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet &conf, edm::ConsumesCollector &&cc)
     : calibrator_(new PFEnergyCalibration) {
   applyCrackCorrections_ = conf.getParameter<bool>("applyCrackCorrections");
@@ -245,8 +244,10 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
       double sigmacor = sigma * ecor;
 
       cluster.setCorrectedEnergy(ecor);
-      if(setEnergyUncertainty_) cluster.setCorrectedEnergyUncertainty(sigmacor);
-      else cluster.setCorrectedEnergyUncertainty(0.);
+      if (setEnergyUncertainty_)
+        cluster.setCorrectedEnergyUncertainty(sigmacor);
+      else
+        cluster.setCorrectedEnergyUncertainty(0.);
     }
     return;
   }
@@ -414,8 +415,10 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
         << "response : correction = " << exp(mean) << " " << ecor;
 
     cluster.setCorrectedEnergy(ecor);
-    if(setEnergyUncertainty_) cluster.setCorrectedEnergyUncertainty(sigmacor);
-    else cluster.setCorrectedEnergyUncertainty(0.);
+    if (setEnergyUncertainty_)
+      cluster.setCorrectedEnergyUncertainty(sigmacor);
+    else
+      cluster.setCorrectedEnergyUncertainty(0.);
   }
 }
 

--- a/RecoParticleFlow/PFProducer/interface/BlockElementImporterBase.h
+++ b/RecoParticleFlow/PFProducer/interface/BlockElementImporterBase.h
@@ -12,27 +12,26 @@
 #include <memory>
 
 class BlockElementImporterBase {
- public:
- typedef std::vector<std::unique_ptr<reco::PFBlockElement> > ElementList;
- BlockElementImporterBase(const edm::ParameterSet& conf,
-			  edm::ConsumesCollector & sumes ):
-  _importerName( conf.getParameter<std::string>("importerName") ) { }
-  BlockElementImporterBase(const BlockElementImporterBase& ) = delete;
+public:
+  typedef std::vector<std::unique_ptr<reco::PFBlockElement> > ElementList;
+  BlockElementImporterBase(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : _importerName(conf.getParameter<std::string>("importerName")) {}
+  BlockElementImporterBase(const BlockElementImporterBase&) = delete;
   virtual ~BlockElementImporterBase() = default;
   BlockElementImporterBase& operator=(const BlockElementImporterBase&) = delete;
 
-  virtual void updateEventSetup(const edm::EventSetup& ) {}
+  virtual void updateEventSetup(const edm::EventSetup&) {}
 
-  virtual void importToBlock( const edm::Event& ,
-			      ElementList& ) const = 0;
+  virtual void importToBlock(const edm::Event&, ElementList&) const = 0;
 
   const std::string& name() const { return _importerName; }
-  
- private:
+
+private:
   const std::string _importerName;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< BlockElementImporterBase* (const edm::ParameterSet&,edm::ConsumesCollector&) > BlockElementImporterFactory;
+typedef edmplugin::PluginFactory<BlockElementImporterBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
+    BlockElementImporterFactory;
 
 #endif

--- a/RecoParticleFlow/PFProducer/interface/BlockElementLinkerBase.h
+++ b/RecoParticleFlow/PFProducer/interface/BlockElementLinkerBase.h
@@ -8,27 +8,23 @@
 #include <string>
 
 class BlockElementLinkerBase {
- public:
- BlockElementLinkerBase(const edm::ParameterSet& conf):
-  _linkerName( conf.getParameter<std::string>("linkerName") ) { }
-  BlockElementLinkerBase(const BlockElementLinkerBase& ) = delete;
+public:
+  BlockElementLinkerBase(const edm::ParameterSet& conf) : _linkerName(conf.getParameter<std::string>("linkerName")) {}
+  BlockElementLinkerBase(const BlockElementLinkerBase&) = delete;
   virtual ~BlockElementLinkerBase() = default;
   BlockElementLinkerBase& operator=(const BlockElementLinkerBase&) = delete;
 
-  virtual bool linkPrefilter( const reco::PFBlockElement*,
-			      const reco::PFBlockElement* ) const 
-  { return true; }
+  virtual bool linkPrefilter(const reco::PFBlockElement*, const reco::PFBlockElement*) const { return true; }
 
-  virtual double testLink( const reco::PFBlockElement*,
-			   const reco::PFBlockElement* ) const = 0;
+  virtual double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const = 0;
 
   const std::string& name() const { return _linkerName; }
-  
- private:
+
+private:
   const std::string _linkerName;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< BlockElementLinkerBase* (const edm::ParameterSet&) > BlockElementLinkerFactory;
+typedef edmplugin::PluginFactory<BlockElementLinkerBase*(const edm::ParameterSet&)> BlockElementLinkerFactory;
 
 #endif

--- a/RecoParticleFlow/PFProducer/interface/KDTreeLinkerBase.h
+++ b/RecoParticleFlow/PFProducer/interface/KDTreeLinkerBase.h
@@ -15,26 +15,17 @@ using RecHitSet = std::set<const reco::PFRecHit *>;
 using RecHit2BlockEltMap = std::map<const reco::PFRecHit *, BlockEltSet>;
 using BlockElt2BlockEltMap = std::map<reco::PFBlockElement *, BlockEltSet>;
 
-class KDTreeLinkerBase
-{
- public:
+class KDTreeLinkerBase {
+public:
   virtual ~KDTreeLinkerBase() {}
 
-  void setTargetType(const reco::PFBlockElement::Type& tgt) { 
-    _targetType = tgt; 
-  }
+  void setTargetType(const reco::PFBlockElement::Type &tgt) { _targetType = tgt; }
 
-  void setFieldType(const reco::PFBlockElement::Type& fld) { 
-    _fieldType = fld;
-  }
+  void setFieldType(const reco::PFBlockElement::Type &fld) { _fieldType = fld; }
 
-  const reco::PFBlockElement::Type& targetType() const { 
-    return _targetType; 
-  }
+  const reco::PFBlockElement::Type &targetType() const { return _targetType; }
 
-  const reco::PFBlockElement::Type& fieldType() const { 
-    return _fieldType; 
-  }
+  const reco::PFBlockElement::Type &fieldType() const { return _fieldType; }
 
   // Get/Set of the maximal size of the cristal (ECAL, HCAL,...) in phi/eta and
   // X/Y. By default, thus value are set for the ECAL cristal.
@@ -42,16 +33,16 @@ class KDTreeLinkerBase
   // Get/Set phi offset. See bellow in the description of phiOffset_ to understand
   // the application.
 
-  // Debug flag. 
+  // Debug flag.
   void setDebug(bool isDebug);
 
   // With this method, we create the list of elements that we want to link.
-  virtual void insertTargetElt(reco::PFBlockElement		*target) = 0;
+  virtual void insertTargetElt(reco::PFBlockElement *target) = 0;
 
   // Here, we create the list of cluster that we want to link. From cluster
   // and fraction, we will create a second list of rechits that will be used to
   // build the KDTree.
-  virtual void insertFieldClusterElt(reco::PFBlockElement	*cluster) = 0;  
+  virtual void insertFieldClusterElt(reco::PFBlockElement *cluster) = 0;
 
   // The KDTree building from rechits list.
   virtual void buildTree() = 0;
@@ -64,41 +55,37 @@ class KDTreeLinkerBase
   // Here, we will store all target/cluster founded links in the PFBlockElement class
   // of each target in the PFmultilinks field.
   virtual void updatePFBlockEltWithLinks() = 0;
-  
+
   // Here we free all allocated structures.
   virtual void clear() = 0;
 
-  // This method calls is the good order buildTree(), searchLinks(), 
+  // This method calls is the good order buildTree(), searchLinks(),
   // updatePFBlockEltWithLinks() and clear()
-  inline void process()
-  {
+  inline void process() {
     buildTree();
     searchLinks();
     updatePFBlockEltWithLinks();
     clear();
   }
 
- protected:
+protected:
   // target and field
-  reco::PFBlockElement::Type _targetType,_fieldType;
+  reco::PFBlockElement::Type _targetType, _fieldType;
   // Cristal maximal size. By default, thus value are set for the ECAL cristal.
-  float			cristalPhiEtaMaxSize_ = 0.04;
-  float			cristalXYMaxSize_ = 3.;
+  float cristalPhiEtaMaxSize_ = 0.04;
+  float cristalXYMaxSize_ = 3.;
 
-  // Usually, phi is between -Pi and +Pi. But phi space is circular, that's why an element 
-  // with phi = 3.13 and another with phi = -3.14 are close. To solve this problem, during  
+  // Usually, phi is between -Pi and +Pi. But phi space is circular, that's why an element
+  // with phi = 3.13 and another with phi = -3.14 are close. To solve this problem, during
   // the kdtree building step, we duplicate some elements close enough to +Pi (resp -Pi) by
   // substracting (adding) 2Pi. This field define the threshold of this operation.
-  float			phiOffset_ = 0.25;
+  float phiOffset_ = 0.25;
 
   // Debug boolean. Not used until now.
-  bool			debug_ = false;
+  bool debug_ = false;
 };
 
-
-
-
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< KDTreeLinkerBase* () > KDTreeLinkerFactory;
+typedef edmplugin::PluginFactory<KDTreeLinkerBase *()> KDTreeLinkerFactory;
 
 #endif /* !KDTreeLinkerBase_h */

--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -1,5 +1,5 @@
 #ifndef RecoParticleFlow_PFProducer_PFAlgo_h
-#define RecoParticleFlow_PFProducer_PFAlgo_h 
+#define RecoParticleFlow_PFProducer_PFAlgo_h
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/OrphanHandle.h"
@@ -29,13 +29,11 @@
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibrationHF.h"
 
-
 /// \brief Particle Flow Algorithm
 /*!
   \author Colin Bernet
   \date January 2006
 */
-
 
 class PFMuonAlgo;
 
@@ -53,173 +51,206 @@ public:
 };
 
 class PFAlgo {
-
- public:
-
+public:
   /// constructor
-  PFAlgo(double nSigmaECAL, double nSigmaHCAL, PFEnergyCalibration& calibration, PFEnergyCalibrationHF& thepfEnergyCalibrationHF, const edm::ParameterSet& pset, bool debug);
+  PFAlgo(double nSigmaECAL,
+         double nSigmaHCAL,
+         PFEnergyCalibration& calibration,
+         PFEnergyCalibrationHF& thepfEnergyCalibrationHF,
+         const edm::ParameterSet& pset,
+         bool debug);
 
-  void setHOTag(bool ho) { useHO_ = ho;}
+  void setHOTag(bool ho) { useHO_ = ho; }
   void setMuonHandle(const edm::Handle<reco::MuonCollection>&);
 
-  void setCandConnectorParameters( const edm::ParameterSet& iCfgCandConnector ){
+  void setCandConnectorParameters(const edm::ParameterSet& iCfgCandConnector) {
     connector_.setParameters(iCfgCandConnector);
   }
- 
-  void setCandConnectorParameters(bool bCorrect, 
-				  bool bCalibPrimary, 
-				  double dptRel_PrimaryTrack, 
-				  double dptRel_MergedTrack, 
-				  double ptErrorSecondary, 
-				  const std::vector<double>& nuclCalibFactors){
-    connector_.setParameters(bCorrect, bCalibPrimary, dptRel_PrimaryTrack, dptRel_MergedTrack, ptErrorSecondary, nuclCalibFactors);
+
+  void setCandConnectorParameters(bool bCorrect,
+                                  bool bCalibPrimary,
+                                  double dptRel_PrimaryTrack,
+                                  double dptRel_MergedTrack,
+                                  double ptErrorSecondary,
+                                  const std::vector<double>& nuclCalibFactors) {
+    connector_.setParameters(
+        bCorrect, bCalibPrimary, dptRel_PrimaryTrack, dptRel_MergedTrack, ptErrorSecondary, nuclCalibFactors);
   }
 
-  PFMuonAlgo*  getPFMuonAlgo();
-  
+  PFMuonAlgo* getPFMuonAlgo();
+
   void setEGammaParameters(bool use_EGammaFilters, bool useProtectionsForJetMET);
 
-  
-  void setEGammaCollections(const edm::View<reco::PFCandidate> & pfEgammaCandidates,
-			    const edm::ValueMap<reco::GsfElectronRef> & valueMapGedElectrons, 
- 			    const edm::ValueMap<reco::PhotonRef> & valueMapGedPhotons); 
-  
+  void setEGammaCollections(const edm::View<reco::PFCandidate>& pfEgammaCandidates,
+                            const edm::ValueMap<reco::GsfElectronRef>& valueMapGedElectrons,
+                            const edm::ValueMap<reco::PhotonRef>& valueMapGedPhotons);
+
   void setPostHFCleaningParameters(bool postHFCleaning,
-				   double minHFCleaningPt,
-				   double minSignificance,
-				   double maxSignificance,
-				   double minSignificanceReduction,
-				   double maxDeltaPhiPt,
-				   double minDeltaMet);
+                                   double minHFCleaningPt,
+                                   double minSignificance,
+                                   double maxSignificance,
+                                   double minSignificanceReduction,
+                                   double maxDeltaPhiPt,
+                                   double minDeltaMet);
 
   void setDisplacedVerticesParameters(bool rejectTracks_Bad,
-				      bool rejectTracks_Step45,
-				      bool usePFNuclearInteractions,
-				      bool usePFConversions,
-				      bool usePFDecays,
-				      double dptRel_DispVtx);
-  
-  //MIKEB : Parameters for the vertices..
-  void setPFVertexParameters(bool useVertex, reco::VertexCollection const&  primaryVertices);
-  
-  // FlorianB : Collection of e/g electrons
-  void setEGElectronCollection(const reco::GsfElectronCollection & egelectrons);
+                                      bool rejectTracks_Step45,
+                                      bool usePFNuclearInteractions,
+                                      bool usePFConversions,
+                                      bool usePFDecays,
+                                      double dptRel_DispVtx);
 
-  /// reconstruct particles 
+  //MIKEB : Parameters for the vertices..
+  void setPFVertexParameters(bool useVertex, reco::VertexCollection const& primaryVertices);
+
+  // FlorianB : Collection of e/g electrons
+  void setEGElectronCollection(const reco::GsfElectronCollection& egelectrons);
+
+  /// reconstruct particles
   void reconstructParticles(const reco::PFBlockHandle& blockHandle, PFEGammaFilters const* pfegamma);
 
   /// Check HF Cleaning
-  void checkCleaning( const reco::PFRecHitCollection& cleanedHF );
+  void checkCleaning(const reco::PFRecHitCollection& cleanedHF);
 
   /// \return collection of cleaned HF candidates
-  reco::PFCandidateCollection& getCleanedCandidates() {
-    return pfCleanedCandidates_;
-  }
+  reco::PFCandidateCollection& getCleanedCandidates() { return pfCleanedCandidates_; }
 
   /// \return the collection of candidates
-  reco::PFCandidateCollection makeConnectedCandidates() {
-    return connector_.connect(*pfCandidates_);
-  }
-  
+  reco::PFCandidateCollection makeConnectedCandidates() { return connector_.connect(*pfCandidates_); }
+
   friend std::ostream& operator<<(std::ostream& out, const PFAlgo& algo);
-  
- private:
 
-  void egammaFilters(const reco::PFBlockRef &blockref, std::vector<bool>& active, PFEGammaFilters const* pfegamma);
-  void conversionAlgo(const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active);
-  void elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
-  int decideType(const edm::OwnVector<reco::PFBlockElement> &elements, const reco::PFBlockElement::Type type, std::vector<bool>& active, ElementIndices& inds, std::vector<bool> &deadArea, unsigned int iEle);
-  bool recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, const reco::PFBlockRef &blockref, std::vector<bool>& active, bool goodTrackDeadHcal, bool hasDeadHcal, unsigned int iTrack, std::multimap<double, unsigned>& ecalElems, reco::TrackRef& trackRef);
-
+private:
+  void egammaFilters(const reco::PFBlockRef& blockref, std::vector<bool>& active, PFEGammaFilters const* pfegamma);
+  void conversionAlgo(const edm::OwnVector<reco::PFBlockElement>& elements, std::vector<bool>& active);
+  void elementLoop(const reco::PFBlock& block,
+                   reco::PFBlock::LinkData& linkData,
+                   const edm::OwnVector<reco::PFBlockElement>& elements,
+                   std::vector<bool>& active,
+                   const reco::PFBlockRef& blockref,
+                   ElementIndices& inds,
+                   std::vector<bool>& deadArea);
+  int decideType(const edm::OwnVector<reco::PFBlockElement>& elements,
+                 const reco::PFBlockElement::Type type,
+                 std::vector<bool>& active,
+                 ElementIndices& inds,
+                 std::vector<bool>& deadArea,
+                 unsigned int iEle);
+  bool recoTracksNotHCAL(const reco::PFBlock& block,
+                         reco::PFBlock::LinkData& linkData,
+                         const edm::OwnVector<reco::PFBlockElement>& elements,
+                         const reco::PFBlockRef& blockref,
+                         std::vector<bool>& active,
+                         bool goodTrackDeadHcal,
+                         bool hasDeadHcal,
+                         unsigned int iTrack,
+                         std::multimap<double, unsigned>& ecalElems,
+                         reco::TrackRef& trackRef);
 
   //Looks for a HF-associated element in the block and produces a PFCandidate from it with HF_EM and/or HF_HAD calibrations
-  void createCandidateHF(const reco::PFBlock &block, const reco::PFBlockRef &blockref, const edm::OwnVector<reco::PFBlockElement> &elements, ElementIndices& inds);
+  void createCandidateHF(const reco::PFBlock& block,
+                         const reco::PFBlockRef& blockref,
+                         const edm::OwnVector<reco::PFBlockElement>& elements,
+                         ElementIndices& inds);
 
-  void createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
-  void createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
+  void createCandidatesHCAL(const reco::PFBlock& block,
+                            reco::PFBlock::LinkData& linkData,
+                            const edm::OwnVector<reco::PFBlockElement>& elements,
+                            std::vector<bool>& active,
+                            const reco::PFBlockRef& blockref,
+                            ElementIndices& inds,
+                            std::vector<bool>& deadArea);
+  void createCandidatesHCALUnlinked(const reco::PFBlock& block,
+                                    reco::PFBlock::LinkData& linkData,
+                                    const edm::OwnVector<reco::PFBlockElement>& elements,
+                                    std::vector<bool>& active,
+                                    const reco::PFBlockRef& blockref,
+                                    ElementIndices& inds,
+                                    std::vector<bool>& deadArea);
 
-void createCandidatesECAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
+  void createCandidatesECAL(const reco::PFBlock& block,
+                            reco::PFBlock::LinkData& linkData,
+                            const edm::OwnVector<reco::PFBlockElement>& elements,
+                            std::vector<bool>& active,
+                            const reco::PFBlockRef& blockref,
+                            ElementIndices& inds,
+                            std::vector<bool>& deadArea);
 
-  /// process one block. can be reimplemented in more sophisticated 
+  /// process one block. can be reimplemented in more sophisticated
   /// algorithms
-  void processBlock( const reco::PFBlockRef& blockref,
-                             std::list<reco::PFBlockRef>& hcalBlockRefs, 
-                             std::list<reco::PFBlockRef>& ecalBlockRefs, PFEGammaFilters const* pfegamma );
-  
+  void processBlock(const reco::PFBlockRef& blockref,
+                    std::list<reco::PFBlockRef>& hcalBlockRefs,
+                    std::list<reco::PFBlockRef>& ecalBlockRefs,
+                    PFEGammaFilters const* pfegamma);
+
   /// Reconstruct a charged particle from a track
   /// Returns the index of the newly created candidate in pfCandidates_
   /// Michalis added a flag here to treat muons inside jets
-  unsigned reconstructTrack( const reco::PFBlockElement& elt,bool allowLoose= false);
+  unsigned reconstructTrack(const reco::PFBlockElement& elt, bool allowLoose = false);
 
-  /// Reconstruct a neutral particle from a cluster. 
-  /// If chargedEnergy is specified, the neutral 
-  /// particle is created only if the cluster energy is significantly 
-  /// larger than the chargedEnergy. In this case, the energy of the 
+  /// Reconstruct a neutral particle from a cluster.
+  /// If chargedEnergy is specified, the neutral
+  /// particle is created only if the cluster energy is significantly
+  /// larger than the chargedEnergy. In this case, the energy of the
   /// neutral particle is cluster energy - chargedEnergy
 
-  unsigned reconstructCluster( const reco::PFCluster& cluster,
-                               double particleEnergy,
-			       bool useDirection = false,
-			       double particleX=0.,
-			       double particleY=0.,
-			       double particleZ=0.);
+  unsigned reconstructCluster(const reco::PFCluster& cluster,
+                              double particleEnergy,
+                              bool useDirection = false,
+                              double particleX = 0.,
+                              double particleY = 0.,
+                              double particleZ = 0.);
 
-  void setHcalDepthInfo(reco::PFCandidate & cand, const reco::PFCluster& cluster) const ;
+  void setHcalDepthInfo(reco::PFCandidate& cand, const reco::PFCluster& cluster) const;
 
   /// todo: use PFClusterTools for this
-  double neutralHadronEnergyResolution( double clusterEnergy,
-					double clusterEta ) const;
+  double neutralHadronEnergyResolution(double clusterEnergy, double clusterEta) const;
 
- 
-  double nSigmaHCAL( double clusterEnergy, 
-		     double clusterEta ) const;
+  double nSigmaHCAL(double clusterEnergy, double clusterEta) const;
 
-  std::unique_ptr<reco::PFCandidateCollection>    pfCandidates_;
+  std::unique_ptr<reco::PFCandidateCollection> pfCandidates_;
   // the post-HF-cleaned candidates
   reco::PFCandidateCollection pfCleanedCandidates_;
 
   /// Associate PS clusters to a given ECAL cluster, and return their energy
   void associatePSClusters(unsigned iEcal,
-			   reco::PFBlockElement::Type psElementType,
-			   const reco::PFBlock& block,
-			   const edm::OwnVector< reco::PFBlockElement >& elements, 
-			   const reco::PFBlock::LinkData& linkData, 
-			   std::vector<bool>& active, 
-			   std::vector<double>& psEne);
+                           reco::PFBlockElement::Type psElementType,
+                           const reco::PFBlock& block,
+                           const edm::OwnVector<reco::PFBlockElement>& elements,
+                           const reco::PFBlock::LinkData& linkData,
+                           std::vector<bool>& active,
+                           std::vector<double>& psEne);
 
-  bool isFromSecInt(const reco::PFBlockElement& eTrack,  std::string order) const;
-
+  bool isFromSecInt(const reco::PFBlockElement& eTrack, std::string order) const;
 
   // Post HF Cleaning
   void postCleaning();
 
   /// number of sigma to judge energy excess in ECAL
   const double nSigmaECAL_;
-  
+
   /// number of sigma to judge energy excess in HCAL
   const double nSigmaHCAL_;
-  
-  PFEnergyCalibration & calibration_;
-  PFEnergyCalibrationHF & thepfEnergyCalibrationHF_;
 
-  bool               useHO_;
-  const bool         debug_;
+  PFEnergyCalibration& calibration_;
+  PFEnergyCalibrationHF& thepfEnergyCalibrationHF_;
+
+  bool useHO_;
+  const bool debug_;
 
   std::unique_ptr<PFMuonAlgo> pfmu_;
-
 
   /// Variables for NEW EGAMMA selection
   bool useEGammaFilters_;
   bool useProtectionsForJetMET_;
-  const edm::View<reco::PFCandidate> * pfEgammaCandidates_;
-  const edm::ValueMap<reco::GsfElectronRef> * valueMapGedElectrons_;
-  const edm::ValueMap<reco::PhotonRef> * valueMapGedPhotons_;  
-
+  const edm::View<reco::PFCandidate>* pfEgammaCandidates_;
+  const edm::ValueMap<reco::GsfElectronRef>* valueMapGedElectrons_;
+  const edm::ValueMap<reco::PhotonRef>* valueMapGedPhotons_;
 
   // Option to let PF decide the muon momentum
   bool usePFMuonMomAssign_;
 
-  /// Flags to use the protection against fakes 
+  /// Flags to use the protection against fakes
   /// and not reconstructed displaced vertices
   bool rejectTracks_Bad_;
   bool rejectTracks_Step45_;
@@ -228,7 +259,7 @@ void createCandidatesECAL(const reco::PFBlock &block, reco::PFBlock::LinkData& l
   bool usePFConversions_;
   bool usePFDecays_;
 
-  /// Maximal relative uncertainty on the tracks going to or incoming from the 
+  /// Maximal relative uncertainty on the tracks going to or incoming from the
   /// displcaed vertex to be used in the PFAlgo
   double dptRel_DispVtx_;
   int nVtx_;
@@ -236,7 +267,7 @@ void createCandidatesECAL(const reco::PFBlock &block, reco::PFBlock::LinkData& l
   /// A tool used for a postprocessing of displaced vertices
   /// based on reconstructed PFCandidates
   PFCandConnector connector_;
-    
+
   /// Variables for muons and fakes
   std::vector<double> muonHCAL_;
   std::vector<double> muonECAL_;
@@ -248,7 +279,7 @@ void createCandidatesECAL(const reco::PFBlock &block, reco::PFBlock::LinkData& l
   /// Variables for track cleaning in bad HCal areas
   float goodTrackDeadHcal_ptErrRel_;
   float goodTrackDeadHcal_chi2n_;
-  int   goodTrackDeadHcal_layers_;
+  int goodTrackDeadHcal_layers_;
   float goodTrackDeadHcal_validFr_;
   float goodTrackDeadHcal_dxy_;
 
@@ -256,11 +287,10 @@ void createCandidatesECAL(const reco::PFBlock &block, reco::PFBlock::LinkData& l
   float goodPixelTrackDeadHcal_maxPt_;
   float goodPixelTrackDeadHcal_ptErrRel_;
   float goodPixelTrackDeadHcal_chi2n_;
-  int   goodPixelTrackDeadHcal_maxLost3Hit_;
-  int   goodPixelTrackDeadHcal_maxLost4Hit_;
+  int goodPixelTrackDeadHcal_maxLost3Hit_;
+  int goodPixelTrackDeadHcal_maxLost4Hit_;
   float goodPixelTrackDeadHcal_dxy_;
   float goodPixelTrackDeadHcal_dz_;
-
 
   // Parameters for post HF cleaning
   bool postHFCleaning_;
@@ -274,12 +304,10 @@ void createCandidatesECAL(const reco::PFBlock &block, reco::PFBlock::LinkData& l
   double useBestMuonTrack_;
 
   //MIKE -May19th: Add option for the vertices....
-  reco::Vertex       primaryVertex_;
-  bool               useVertices_ = false;
+  reco::Vertex primaryVertex_;
+  bool useVertices_ = false;
 
   edm::Handle<reco::MuonCollection> muonHandle_;
-
 };
-
 
 #endif

--- a/RecoParticleFlow/PFProducer/interface/PFBlockAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFBlockAlgo.h
@@ -1,5 +1,5 @@
 #ifndef RecoParticleFlow_PFProducer_PFBlockAlgo_h
-#define RecoParticleFlow_PFProducer_PFBlockAlgo_h 
+#define RecoParticleFlow_PFProducer_PFBlockAlgo_h
 
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
@@ -17,15 +17,13 @@
 #include <vector>
 
 namespace std {
-  template<>
-    struct hash<std::pair<unsigned int,unsigned int> > {
-    typedef std::pair<unsigned int,unsigned int> arg_type;
+  template <>
+  struct hash<std::pair<unsigned int, unsigned int>> {
+    typedef std::pair<unsigned int, unsigned int> arg_type;
     typedef unsigned int value_type;
-    value_type operator()(const arg_type& arg) const {
-      return arg.first ^ (arg.second << 1);
-    }
+    value_type operator()(const arg_type& arg) const { return arg.first ^ (arg.second << 1); }
   };
-}
+}  // namespace std
 
 /// \brief Particle Flow Algorithm
 /*!
@@ -34,63 +32,57 @@ namespace std {
 */
 
 class PFBlockAlgo {
-
- public:
+public:
   // the element list should **always** be a list of (smart) pointers
-  typedef std::vector<std::unique_ptr<reco::PFBlockElement> > ElementList;
+  typedef std::vector<std::unique_ptr<reco::PFBlockElement>> ElementList;
   //for skipping ranges
-  typedef std::array<std::pair<unsigned int,unsigned int>,reco::PFBlockElement::kNBETypes> ElementRanges;
-  
+  typedef std::array<std::pair<unsigned int, unsigned int>, reco::PFBlockElement::kNBETypes> ElementRanges;
+
   PFBlockAlgo();
 
   ~PFBlockAlgo();
-    
+
   void setLinkers(const std::vector<edm::ParameterSet>&);
 
-  void setImporters(const std::vector<edm::ParameterSet>&,
-		    edm::ConsumesCollector&);
-  
+  void setImporters(const std::vector<edm::ParameterSet>&, edm::ConsumesCollector&);
+
   // update event setup info of all linkers
   void updateEventSetup(const edm::EventSetup&);
 
   // run all of the importers and build KDtrees
   void buildElements(const edm::Event&);
-  
+
   /// build blocks
-  reco::PFBlockCollection  findBlocks();
+  reco::PFBlockCollection findBlocks();
 
   /// sets debug printout flag
-  void setDebug( bool debug ) {debug_ = debug;}
-    
- private:
-  
-  /// compute missing links in the blocks 
-  /// (the recursive procedure does not build all links)  
-  void packLinks(reco::PFBlock& block, 
-		 const std::unordered_map<std::pair<unsigned int,unsigned int>,double>& links) const; 
-  
+  void setDebug(bool debug) { debug_ = debug; }
+
+private:
+  /// compute missing links in the blocks
+  /// (the recursive procedure does not build all links)
+  void packLinks(reco::PFBlock& block,
+                 const std::unordered_map<std::pair<unsigned int, unsigned int>, double>& links) const;
+
   /// check whether 2 elements are linked. Returns distance
-  inline void link( const reco::PFBlockElement* el1, 
-		    const reco::PFBlockElement* el2, 
-		    double& dist) const;
-  
+  inline void link(const reco::PFBlockElement* el1, const reco::PFBlockElement* el2, double& dist) const;
+
   // the test elements will be transferred to the blocks
-  ElementList       elements_; 
-  ElementRanges     ranges_;
-  
+  ElementList elements_;
+  ElementRanges ranges_;
+
   /// if true, debug printouts activated
-  bool   debug_;
-  
+  bool debug_;
+
   friend std::ostream& operator<<(std::ostream&, const PFBlockAlgo&);
   bool useHO_;
 
   std::vector<std::unique_ptr<BlockElementImporterBase>> importers_;
 
-  const std::unordered_map<std::string,reco::PFBlockElement::Type> 
-    elementTypes_;
+  const std::unordered_map<std::string, reco::PFBlockElement::Type> elementTypes_;
   std::vector<std::unique_ptr<BlockElementLinkerBase>> linkTests_;
   unsigned int linkTestSquare_[reco::PFBlockElement::kNBETypes][reco::PFBlockElement::kNBETypes];
-  
+
   std::vector<std::unique_ptr<KDTreeLinkerBase>> kdtrees_;
 };
 

--- a/RecoParticleFlow/PFProducer/interface/PFBlockElementSCEqual.h
+++ b/RecoParticleFlow/PFProducer/interface/PFBlockElementSCEqual.h
@@ -5,16 +5,19 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
 
 class PFBlockElementSCEqual {
- public:
-  PFBlockElementSCEqual(reco::SuperClusterRef scRef):ref_(scRef) {;}
-    inline bool operator() (const std::unique_ptr<reco::PFBlockElement>& el) {
-      return (el->type()==reco::PFBlockElement::SC && (static_cast<const reco::PFBlockElementSuperCluster*>(el.get()))->superClusterRef()==ref_);
-    }
-    inline bool operator() (const reco::PFBlockElement* el) {
-      return (el->type()==reco::PFBlockElement::SC && (static_cast<const reco::PFBlockElementSuperCluster*>(el))->superClusterRef()==ref_);
-    }
- private:
-    reco::SuperClusterRef ref_;
+public:
+  PFBlockElementSCEqual(reco::SuperClusterRef scRef) : ref_(scRef) { ; }
+  inline bool operator()(const std::unique_ptr<reco::PFBlockElement>& el) {
+    return (el->type() == reco::PFBlockElement::SC &&
+            (static_cast<const reco::PFBlockElementSuperCluster*>(el.get()))->superClusterRef() == ref_);
+  }
+  inline bool operator()(const reco::PFBlockElement* el) {
+    return (el->type() == reco::PFBlockElement::SC &&
+            (static_cast<const reco::PFBlockElementSuperCluster*>(el))->superClusterRef() == ref_);
+  }
+
+private:
+  reco::SuperClusterRef ref_;
 };
 
 #endif

--- a/RecoParticleFlow/PFProducer/interface/PFCandConnector.h
+++ b/RecoParticleFlow/PFProducer/interface/PFCandConnector.h
@@ -5,7 +5,7 @@
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 // \author : M. Gouzevitch
@@ -14,94 +14,106 @@
 /// Based on a class from : V. Roberfroid, February 2008
 
 class PFCandConnector {
-    
-    public :
-       
-       PFCandConnector(bool debug=false)
-       : debug_(debug)
-       { 
-	 bCorrect_ = false;
-	 bCalibPrimary_ =  false;
+public:
+  PFCandConnector(bool debug = false) : debug_(debug) {
+    bCorrect_ = false;
+    bCalibPrimary_ = false;
 
-	 fConst_.push_back(1), fConst_.push_back(0);
-	 fNorm_.push_back(0), fNorm_.push_back(0);
-	 fExp_.push_back(0);
+    fConst_.push_back(1), fConst_.push_back(0);
+    fNorm_.push_back(0), fNorm_.push_back(0);
+    fExp_.push_back(0);
 
-	 dptRel_PrimaryTrack_ = 0.;
-         dptRel_MergedTrack_ = 0.;
-	 ptErrorSecondary_ = 0.;
-       }
-       
-       void setParameters(const edm::ParameterSet& iCfgCandConnector){
-	 
-	 bool bCorrect, bCalibPrimary;
-	 double dptRel_PrimaryTrack, dptRel_MergedTrack, ptErrorSecondary;
-	 std::vector<double> nuclCalibFactors;
+    dptRel_PrimaryTrack_ = 0.;
+    dptRel_MergedTrack_ = 0.;
+    ptErrorSecondary_ = 0.;
+  }
 
-	 /// Flag to apply the correction procedure for nuclear interactions
-	 bCorrect = iCfgCandConnector.getParameter<bool>("bCorrect");
-	 /// Flag to calibrate the reconstructed nuclear interactions with primary or merged tracks
-	 bCalibPrimary =  iCfgCandConnector.getParameter<bool>("bCalibPrimary");
+  void setParameters(const edm::ParameterSet& iCfgCandConnector) {
+    bool bCorrect, bCalibPrimary;
+    double dptRel_PrimaryTrack, dptRel_MergedTrack, ptErrorSecondary;
+    std::vector<double> nuclCalibFactors;
 
-	 if(iCfgCandConnector.exists("dptRel_PrimaryTrack")) dptRel_PrimaryTrack = iCfgCandConnector.getParameter<double>("dptRel_PrimaryTrack");
-	 else { edm::LogWarning("PFCandConnector")  << "dptRel_PrimaryTrack doesn't exist. Setting a default safe value 0" << std::endl; dptRel_PrimaryTrack = 0;}
+    /// Flag to apply the correction procedure for nuclear interactions
+    bCorrect = iCfgCandConnector.getParameter<bool>("bCorrect");
+    /// Flag to calibrate the reconstructed nuclear interactions with primary or merged tracks
+    bCalibPrimary = iCfgCandConnector.getParameter<bool>("bCalibPrimary");
 
-	 if(iCfgCandConnector.exists("dptRel_MergedTrack"))  dptRel_MergedTrack = iCfgCandConnector.getParameter<double>("dptRel_MergedTrack");
-	 else { edm::LogWarning("PFCandConnector") << "dptRel_MergedTrack doesn't exist. Setting a default safe value 0" << std::endl; dptRel_MergedTrack = 0;}
+    if (iCfgCandConnector.exists("dptRel_PrimaryTrack"))
+      dptRel_PrimaryTrack = iCfgCandConnector.getParameter<double>("dptRel_PrimaryTrack");
+    else {
+      edm::LogWarning("PFCandConnector") << "dptRel_PrimaryTrack doesn't exist. Setting a default safe value 0"
+                                         << std::endl;
+      dptRel_PrimaryTrack = 0;
+    }
 
-	 if(iCfgCandConnector.exists("ptErrorSecondary"))    ptErrorSecondary = iCfgCandConnector.getParameter<double>("ptErrorSecondary");
-	 else { edm::LogWarning("PFCandConnector")  << "ptErrorSecondary doesn't exist. Setting a default safe value 0" << std::endl; ptErrorSecondary = 0;}
+    if (iCfgCandConnector.exists("dptRel_MergedTrack"))
+      dptRel_MergedTrack = iCfgCandConnector.getParameter<double>("dptRel_MergedTrack");
+    else {
+      edm::LogWarning("PFCandConnector") << "dptRel_MergedTrack doesn't exist. Setting a default safe value 0"
+                                         << std::endl;
+      dptRel_MergedTrack = 0;
+    }
 
-	 if(iCfgCandConnector.exists("nuclCalibFactors"))    nuclCalibFactors = iCfgCandConnector.getParameter<std::vector<double> >("nuclCalibFactors");  
-	 else { edm::LogWarning("PFCandConnector")  << "nuclear calib factors doesn't exist the factor would not be applyed" << std::endl; }
+    if (iCfgCandConnector.exists("ptErrorSecondary"))
+      ptErrorSecondary = iCfgCandConnector.getParameter<double>("ptErrorSecondary");
+    else {
+      edm::LogWarning("PFCandConnector") << "ptErrorSecondary doesn't exist. Setting a default safe value 0"
+                                         << std::endl;
+      ptErrorSecondary = 0;
+    }
 
-	 setParameters(bCorrect, bCalibPrimary, dptRel_PrimaryTrack, dptRel_MergedTrack, ptErrorSecondary, nuclCalibFactors);
+    if (iCfgCandConnector.exists("nuclCalibFactors"))
+      nuclCalibFactors = iCfgCandConnector.getParameter<std::vector<double> >("nuclCalibFactors");
+    else {
+      edm::LogWarning("PFCandConnector") << "nuclear calib factors doesn't exist the factor would not be applyed"
+                                         << std::endl;
+    }
 
-       }
+    setParameters(bCorrect, bCalibPrimary, dptRel_PrimaryTrack, dptRel_MergedTrack, ptErrorSecondary, nuclCalibFactors);
+  }
 
+  void setParameters(bool bCorrect,
+                     bool bCalibPrimary,
+                     double dptRel_PrimaryTrack,
+                     double dptRel_MergedTrack,
+                     double ptErrorSecondary,
+                     const std::vector<double>& nuclCalibFactors);
 
-       void setParameters(bool bCorrect, bool bCalibPrimary, double dptRel_PrimaryTrack, double dptRel_MergedTrack, double ptErrorSecondary, const std::vector<double>& nuclCalibFactors);
+  reco::PFCandidateCollection connect(reco::PFCandidateCollection& pfCand) const;
 
-       
+private:
+  /// Analyse nuclear interactions where a primary or merged track is present
+  void analyseNuclearWPrim(reco::PFCandidateCollection&, std::vector<bool>&, unsigned int) const;
 
-       reco::PFCandidateCollection connect(reco::PFCandidateCollection& pfCand) const;
+  /// Analyse nuclear interactions where a secondary track is present
+  void analyseNuclearWSec(reco::PFCandidateCollection&, std::vector<bool>&, unsigned int) const;
 
-       
- 
-    private :
+  bool isPrimaryNucl(const reco::PFCandidate& pf) const;
 
-       /// Analyse nuclear interactions where a primary or merged track is present
-       void analyseNuclearWPrim(reco::PFCandidateCollection&, std::vector<bool> &, unsigned int) const;
+  bool isSecondaryNucl(const reco::PFCandidate& pf) const;
 
-       /// Analyse nuclear interactions where a secondary track is present
-       void analyseNuclearWSec(reco::PFCandidateCollection&, std::vector<bool> &, unsigned int) const;
+  /// Return a calibration factor for a reconstructed nuclear interaction
+  double rescaleFactor(const double pt, const double cFrac) const;
 
-       bool isPrimaryNucl( const reco::PFCandidate& pf ) const;
+  /// Parameters
+  const bool debug_;
+  bool bCorrect_;
 
-       bool isSecondaryNucl( const reco::PFCandidate& pf ) const;
+  /// Calibration parameters for the reconstructed nuclear interactions
+  bool bCalibPrimary_;
+  std::vector<double> fConst_;
+  std::vector<double> fNorm_;
+  std::vector<double> fExp_;
 
-       /// Return a calibration factor for a reconstructed nuclear interaction
-       double rescaleFactor( const double pt, const double cFrac ) const;
+  // Maximal accepatble uncertainty on primary tracks to usem them as MC truth for calibration
+  double dptRel_PrimaryTrack_;
+  double dptRel_MergedTrack_;
+  double ptErrorSecondary_;
 
-       /// Parameters
-       const bool debug_;
-       bool bCorrect_;
-
-       /// Calibration parameters for the reconstructed nuclear interactions
-       bool bCalibPrimary_;
-       std::vector< double > fConst_;
-       std::vector< double > fNorm_;
-       std::vector< double > fExp_;
-
-       // Maximal accepatble uncertainty on primary tracks to usem them as MC truth for calibration
-       double dptRel_PrimaryTrack_;
-       double dptRel_MergedTrack_;
-       double ptErrorSecondary_;
-
-       /// Useful constants
-       static const double pion_mass2;
-       static const reco::PFCandidate::Flags fT_TO_DISP_;
-       static const reco::PFCandidate::Flags fT_FROM_DISP_;
+  /// Useful constants
+  static const double pion_mass2;
+  static const reco::PFCandidate::Flags fT_TO_DISP_;
+  static const reco::PFCandidate::Flags fT_FROM_DISP_;
 };
 
 #endif

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
@@ -57,59 +57,56 @@
 
 #include <memory>
 
-
 class PFEnergyCalibration;
 
-
 class PFEGammaAlgo {
- public:
+public:
   typedef reco::PFCluster::EEtoPSAssociation EEtoPSAssociation;
   typedef reco::PFBlockElementSuperCluster PFSCElement;
   typedef reco::PFBlockElementBrem PFBremElement;
   typedef reco::PFBlockElementGsfTrack PFGSFElement;
   typedef reco::PFBlockElementTrack PFKFElement;
   typedef reco::PFBlockElementCluster PFClusterElement;
-  typedef std::unordered_map<const PFKFElement*, float > KFValMap;  
+  typedef std::unordered_map<const PFKFElement*, float> KFValMap;
 
-  using ClusterMap = std::unordered_map<PFClusterElement const*,std::vector<PFClusterElement const*>>;
+  using ClusterMap = std::unordered_map<PFClusterElement const*, std::vector<PFClusterElement const*>>;
 
   class GBRForests {
   public:
     GBRForests(const edm::ParameterSet& conf)
-      : ele_       (createGBRForest(conf.getParameter<edm::FileInPath>("pf_electronID_mvaWeightFile")))
-      , singleLeg_ (createGBRForest(conf.getParameter<edm::FileInPath>("pf_convID_mvaWeightFile")))
-    {}
+        : ele_(createGBRForest(conf.getParameter<edm::FileInPath>("pf_electronID_mvaWeightFile"))),
+          singleLeg_(createGBRForest(conf.getParameter<edm::FileInPath>("pf_convID_mvaWeightFile"))) {}
 
     const std::unique_ptr<const GBRForest> ele_;
     const std::unique_ptr<const GBRForest> singleLeg_;
   };
-    
+
   struct ProtoEGObject {
     reco::PFBlockRef parentBlock;
-    const PFSCElement* parentSC = nullptr; // if ECAL driven
-    reco::ElectronSeedRef electronSeed; // if there is one
+    const PFSCElement* parentSC = nullptr;  // if ECAL driven
+    reco::ElectronSeedRef electronSeed;     // if there is one
     // this is a mutable list of clusters
     // if ECAL driven we take the PF SC and refine it
     // if Tracker driven we add things to it as we discover more valid clusters
     std::vector<FlaggedPtr<const PFClusterElement>> ecalclusters;
     ClusterMap ecal2ps;
     // associations to tracks of various sorts
-    std::vector<PFGSFElement const*> primaryGSFs; 
+    std::vector<PFGSFElement const*> primaryGSFs;
     std::vector<PFKFElement const*> primaryKFs;
-    std::vector<PFBremElement const*> brems; // these are tangent based brems
-    // for manual brem recovery 
+    std::vector<PFBremElement const*> brems;  // these are tangent based brems
+    // for manual brem recovery
     std::vector<PFGSFElement const*> secondaryGSFs;
-    std::vector<PFKFElement const*> secondaryKFs;    
+    std::vector<PFKFElement const*> secondaryKFs;
     KFValMap singleLegConversionMvaMap;
     // for track-HCAL cluster linking
     std::vector<PFClusterElement const*> hcalClusters;
     CommutativePairs<const reco::PFBlockElement*> localMap;
     // cluster closest to the gsf track(s), primary kf if none for gsf
     // last brem tangent cluster if neither of those work
-    std::vector<const PFClusterElement*> electronClusters; 
+    std::vector<const PFClusterElement*> electronClusters;
     int firstBrem, lateBrem, nBremsWithClusters;
-  };  
-  
+  };
+
   struct PFEGConfigInfo {
     double mvaEleCut;
     bool applyCrackCorrections;
@@ -128,23 +125,20 @@ class PFEGammaAlgo {
 
   void setEEtoPSAssociation(EEtoPSAssociation const& eetops) { eetops_ = &eetops; }
 
-  void setAlphaGamma_ESplanes_fromDB(const ESEEIntercalibConstants* esEEInterCalib){
+  void setAlphaGamma_ESplanes_fromDB(const ESEEIntercalibConstants* esEEInterCalib) {
     thePFEnergyCalibration_.initAlphaGamma_ESplanes_fromDB(esEEInterCalib);
   }
 
-  void setESChannelStatus(const ESChannelStatus* channelStatus){
-    channelStatus_ = channelStatus;
-  }
+  void setESChannelStatus(const ESChannelStatus* channelStatus) { channelStatus_ = channelStatus; }
 
   void setPrimaryVertex(reco::Vertex const& primaryVertex) { primaryVertex_ = &primaryVertex; }
 
   // this runs the functions below
   EgammaObjects operator()(const reco::PFBlockRef& block);
 
-private: 
-
+private:
   GBRForests const& gbrForests_;
-  
+
   PFEnergyCalibration thePFEnergyCalibration_;
 
   // ------ rewritten basic processing pieces and cleaning algorithms
@@ -153,10 +147,10 @@ private:
   // hopefully we get an enum that lets us just make an array in the future
   reco::PFCluster::EEtoPSAssociation const* eetops_;
   reco::PFBlockRef _currentblock;
-  reco::PFBlock::LinkData _currentlinks;  
+  reco::PFBlock::LinkData _currentlinks;
   // keep a map of pf indices to the splayed block for convenience
   // sadly we're mashing together two ways of thinking about the block
-  std::vector<std::vector<FlaggedPtr<const reco::PFBlockElement>>> _splayedblock; 
+  std::vector<std::vector<FlaggedPtr<const reco::PFBlockElement>>> _splayedblock;
 
   // pre-cleaning for the splayed block
   bool isMuon(const reco::PFBlockElement&);
@@ -166,23 +160,21 @@ private:
   // functions:
 
   // build proto eg object using all available unflagged resources in block.
-  // this will be kind of like the old 'SetLinks' but with simplified and 
+  // this will be kind of like the old 'SetLinks' but with simplified and
   // maximally inclusive logic that builds a list of 'refinable' objects
   // that we will perform operations on to clean/remove as needed
   void initializeProtoCands(std::list<ProtoEGObject>&);
 
-  // turn a supercluster into a map of ECAL cluster elements 
+  // turn a supercluster into a map of ECAL cluster elements
   // related to PS cluster elements
   bool unwrapSuperCluster(const reco::PFBlockElementSuperCluster*,
-			  std::vector<FlaggedPtr<const PFClusterElement>>&,
-			  ClusterMap&);    
-  
-  int attachPSClusters(const PFClusterElement*,
-		       ClusterMap::mapped_type&);  
+                          std::vector<FlaggedPtr<const PFClusterElement>>&,
+                          ClusterMap&);
 
-  
+  int attachPSClusters(const PFClusterElement*, ClusterMap::mapped_type&);
+
   void dumpCurrentRefinableObjects() const;
-  
+
   // wax on
 
   // the key merging operation, done after building up links
@@ -195,7 +187,7 @@ private:
   void linkRefinableObjectPrimaryGSFTrackToHCAL(ProtoEGObject&);
   void linkRefinableObjectKFTracksToECAL(ProtoEGObject&);
   void linkRefinableObjectBremTangentsToECAL(ProtoEGObject&);
-  // WARNING! this should be ONLY used after doing the ECAL->track 
+  // WARNING! this should be ONLY used after doing the ECAL->track
   // reverse lookup after the primary linking!
   void linkRefinableObjectConvSecondaryKFsToSecondaryKFs(ProtoEGObject&);
   void linkRefinableObjectSecondaryKFsToECAL(ProtoEGObject&);
@@ -204,7 +196,7 @@ private:
 
   // refining steps doing the ECAL -> track piece
   // this is the factorization of the old PF photon algo stuff
-  // which through arcane means I came to understand was conversion matching  
+  // which through arcane means I came to understand was conversion matching
   void linkRefinableObjectECALToSingleLegConv(ProtoEGObject&);
 
   // wax off
@@ -215,37 +207,28 @@ private:
   // behavior determined by bools passed to unlink_KFandECALMatchedToHCAL
   void unlinkRefinableObjectKFandECALWithBadEoverP(ProtoEGObject&);
   void unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject&,
-						   bool removeFreeECAL = false,
-						   bool removeSCECAL = false);
-  
+                                                   bool removeFreeECAL = false,
+                                                   bool removeSCECAL = false);
 
-  // things for building the final candidate and refined SC collections    
+  // things for building the final candidate and refined SC collections
   EgammaObjects fillPFCandidates(const std::list<ProtoEGObject>&);
   reco::SuperCluster buildRefinedSuperCluster(const ProtoEGObject&);
-  
+
   // helper functions for that
 
-  float calculateEleMVA(const ProtoEGObject&,
-                        reco::PFCandidateEGammaExtra&) const;
-  void fillExtraInfo(const ProtoEGObject&,
-		       reco::PFCandidateEGammaExtra&);
-  
-  // ------ end of new stuff 
-  
-  
+  float calculateEleMVA(const ProtoEGObject&, reco::PFCandidateEGammaExtra&) const;
+  void fillExtraInfo(const ProtoEGObject&, reco::PFCandidateEGammaExtra&);
 
+  // ------ end of new stuff
 
-  bool isPrimaryTrack(const reco::PFBlockElementTrack& KfEl,
-		      const reco::PFBlockElementGsfTrack& GsfEl);  
+  bool isPrimaryTrack(const reco::PFBlockElementTrack& KfEl, const reco::PFBlockElementGsfTrack& GsfEl);
 
   const PFEGConfigInfo cfg_;
   reco::Vertex const* primaryVertex_;
 
   const ESChannelStatus* channelStatus_;
-  
-  float evaluateSingleLegMVA(const reco::PFBlockRef& blockref, 
-                             const reco::Vertex& primaryVtx,
-                             unsigned int trackIndex);
+
+  float evaluateSingleLegMVA(const reco::PFBlockRef& blockref, const reco::Vertex& primaryVtx, unsigned int trackIndex);
 };
 
 #endif

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -14,29 +14,22 @@
 #include <iostream>
 
 class PFEGammaFilters {
-  
- public:
-   
-  PFEGammaFilters(const edm::ParameterSet& iConfig);
-  
+public:
+  PFEGammaFilters(const edm::ParameterSet &iConfig);
+
   bool passPhotonSelection(const reco::Photon &) const;
-  bool passElectronSelection(const reco::GsfElectron &, 
-			     const reco::PFCandidate &,
-			     const int & ) const;
-  bool isElectron(const reco::GsfElectron & ) const;
-  
-  bool isElectronSafeForJetMET(const reco::GsfElectron &, 
-			       const reco::PFCandidate &,
-			       const reco::Vertex &,
-			       bool& lockTracks) const;
+  bool passElectronSelection(const reco::GsfElectron &, const reco::PFCandidate &, const int &) const;
+  bool isElectron(const reco::GsfElectron &) const;
 
-  bool isPhotonSafeForJetMET(const reco::Photon &, 
-			     const reco::PFCandidate &) const;
-  
+  bool isElectronSafeForJetMET(const reco::GsfElectron &,
+                               const reco::PFCandidate &,
+                               const reco::Vertex &,
+                               bool &lockTracks) const;
 
- private:
+  bool isPhotonSafeForJetMET(const reco::Photon &, const reco::PFCandidate &) const;
+
+private:
   bool passGsfElePreSelWithOnlyConeHadem(const reco::GsfElectron &) const;
-
 
   // Photon selections
   const float ph_Et_;
@@ -47,7 +40,7 @@ class PFEGammaFilters {
   float pho_sumPtTrackIso_;
   float pho_sumPtTrackIsoSlope_;
 
-  // Electron selections 
+  // Electron selections
   const float ele_iso_pt_;
   const float ele_iso_mva_eb_;
   const float ele_iso_mva_ee_;
@@ -72,10 +65,10 @@ class PFEGammaFilters {
   float ele_maxDPhiIN_;
 
   // dead hcal selections (electrons)
-  std::array<float,2> badHcal_full5x5_sigmaIetaIeta_;
-  std::array<float,2> badHcal_eInvPInv_;
-  std::array<float,2> badHcal_dEta_;
-  std::array<float,2> badHcal_dPhi_;
+  std::array<float, 2> badHcal_full5x5_sigmaIetaIeta_;
+  std::array<float, 2> badHcal_eInvPInv_;
+  std::array<float, 2> badHcal_dEta_;
+  std::array<float, 2> badHcal_dPhi_;
   bool badHcal_eleEnable_;
 
   // dead hcal selections (photons)

--- a/RecoParticleFlow/PFProducer/interface/PFElectronExtraEqual.h
+++ b/RecoParticleFlow/PFProducer/interface/PFElectronExtraEqual.h
@@ -6,13 +6,12 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateElectronExtra.h"
 
 class PFElectronExtraEqual {
- public:
-  PFElectronExtraEqual(const reco::GsfTrackRef & gsfTrackRef):ref_(gsfTrackRef) {;}
-    inline bool operator() (const reco::PFCandidateElectronExtra & extra) {
-      return (ref_==extra.gsfTrackRef());
-    }
- private:
-    reco::GsfTrackRef ref_;
+public:
+  PFElectronExtraEqual(const reco::GsfTrackRef& gsfTrackRef) : ref_(gsfTrackRef) { ; }
+  inline bool operator()(const reco::PFCandidateElectronExtra& extra) { return (ref_ == extra.gsfTrackRef()); }
+
+private:
+  reco::GsfTrackRef ref_;
 };
 
 #endif

--- a/RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h
@@ -1,5 +1,5 @@
 #ifndef RecoParticleFlow_PFProducer_PFMuonAlgo_h
-#define RecoParticleFlow_PFProducer_PFMuonAlgo_h 
+#define RecoParticleFlow_PFProducer_PFMuonAlgo_h
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -10,50 +10,43 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
 class PFMuonAlgo {
-
   typedef reco::Muon::MuonTrackTypePair MuonTrackTypePair;
-  typedef reco::Muon::MuonTrackType  MuonTrackType;
+  typedef reco::Muon::MuonTrackType MuonTrackType;
 
- public:
-
+public:
   /// constructor
   PFMuonAlgo(edm::ParameterSet const&);
-  
+
   ////STATIC MUON ID METHODS
-  static bool isMuon( const reco::PFBlockElement& elt );
-  static bool isLooseMuon( const reco::PFBlockElement& elt );
-  static bool isGlobalTightMuon( const reco::PFBlockElement& elt );
-  static bool isGlobalLooseMuon( const reco::PFBlockElement& elt );
-  static bool isTrackerTightMuon( const reco::PFBlockElement& elt );
-  static bool isTrackerLooseMuon( const reco::PFBlockElement& elt );
-  static bool isIsolatedMuon( const reco::PFBlockElement& elt );
-  static bool isMuon( const reco::MuonRef& muonRef );  
-  static bool isLooseMuon( const reco::MuonRef& muonRef );
-  static bool isGlobalTightMuon( const reco::MuonRef& muonRef );
-  static bool isGlobalLooseMuon( const reco::MuonRef& muonRef );
+  static bool isMuon(const reco::PFBlockElement& elt);
+  static bool isLooseMuon(const reco::PFBlockElement& elt);
+  static bool isGlobalTightMuon(const reco::PFBlockElement& elt);
+  static bool isGlobalLooseMuon(const reco::PFBlockElement& elt);
+  static bool isTrackerTightMuon(const reco::PFBlockElement& elt);
+  static bool isTrackerLooseMuon(const reco::PFBlockElement& elt);
+  static bool isIsolatedMuon(const reco::PFBlockElement& elt);
+  static bool isMuon(const reco::MuonRef& muonRef);
+  static bool isLooseMuon(const reco::MuonRef& muonRef);
+  static bool isGlobalTightMuon(const reco::MuonRef& muonRef);
+  static bool isGlobalLooseMuon(const reco::MuonRef& muonRef);
 
-  static bool isTrackerTightMuon( const reco::MuonRef& muonRef );
-  static bool isTrackerLooseMuon( const reco::MuonRef& muonRef );
-  static bool isIsolatedMuon( const reco::MuonRef& muonRef );
+  static bool isTrackerTightMuon(const reco::MuonRef& muonRef);
+  static bool isTrackerLooseMuon(const reco::MuonRef& muonRef);
+  static bool isIsolatedMuon(const reco::MuonRef& muonRef);
   static bool isTightMuonPOG(const reco::MuonRef& muonRef);
-  static void printMuonProperties( const reco::MuonRef& muonRef );
-
+  static void printMuonProperties(const reco::MuonRef& muonRef);
 
   ////POST CLEANING AND MOMEMNTUM ASSIGNMENT
-  bool hasValidTrack(const reco::MuonRef& muonRef,bool loose =false);
-
-
-
+  bool hasValidTrack(const reco::MuonRef& muonRef, bool loose = false);
 
   //Make a PF Muon : Basic method
-  bool reconstructMuon(reco::PFCandidate&, const reco::MuonRef&,bool allowLoose = false);
-
+  bool reconstructMuon(reco::PFCandidate&, const reco::MuonRef&, bool allowLoose = false);
 
   //Assign a different track to the muon
-  void changeTrack(reco::PFCandidate&,const MuonTrackTypePair&);
+  void changeTrack(reco::PFCandidate&, const MuonTrackTypePair&);
   //PF Post cleaning algorithm
-  void setInputsForCleaning(reco::VertexCollection const&); 
-  void postClean(reco::PFCandidateCollection *);
+  void setInputsForCleaning(reco::VertexCollection const&);
+  void postClean(reco::PFCandidateCollection*);
   void addMissingMuons(edm::Handle<reco::MuonCollection>, reco::PFCandidateCollection* cands);
 
   std::unique_ptr<reco::PFCandidateCollection> transferCleanedCosmicCandidates() {
@@ -80,30 +73,29 @@ class PFMuonAlgo {
     return std::move(pfAddedMuonCandidates_);
   }
 
- private:
+private:
   //Gives the track with the smallest Dpt/Pt
   MuonTrackTypePair getTrackWithSmallestError(const std::vector<MuonTrackTypePair>&);
 
-  std::vector<reco::Muon::MuonTrackTypePair> muonTracks(const reco::MuonRef& muon,bool includeSA = false,double dpt = 1e+9);
+  std::vector<reco::Muon::MuonTrackTypePair> muonTracks(const reco::MuonRef& muon,
+                                                        bool includeSA = false,
+                                                        double dpt = 1e+9);
 
   //Gets the good tracks
-  std::vector<reco::Muon::MuonTrackTypePair> goodMuonTracks(const reco::MuonRef& muon,bool includeSA = false);
-
+  std::vector<reco::Muon::MuonTrackTypePair> goodMuonTracks(const reco::MuonRef& muon, bool includeSA = false);
 
   //Estimate MET and SUmET for post cleaning
-  void estimateEventQuantities(const reco::PFCandidateCollection*  );
+  void estimateEventQuantities(const reco::PFCandidateCollection*);
 
   //Post cleaning Sub-methods
-  bool cleanMismeasured(reco::PFCandidate&,unsigned int);
-  bool cleanPunchThroughAndFakes(reco::PFCandidate&,reco::PFCandidateCollection* ,unsigned int );
+  bool cleanMismeasured(reco::PFCandidate&, unsigned int);
+  bool cleanPunchThroughAndFakes(reco::PFCandidate&, reco::PFCandidateCollection*, unsigned int);
 
-  void  removeDeadCandidates(reco::PFCandidateCollection*, const std::vector<unsigned int>&);
+  void removeDeadCandidates(reco::PFCandidateCollection*, const std::vector<unsigned int>&);
 
-
-
-  //helpers  
-  std::pair<double,double> getMinMaxMET2(const reco::PFCandidate&);
-  std::vector<MuonTrackTypePair> tracksWithBetterMET(const std::vector<MuonTrackTypePair>& ,const reco::PFCandidate&);
+  //helpers
+  std::pair<double, double> getMinMaxMET2(const reco::PFCandidate&);
+  std::vector<MuonTrackTypePair> tracksWithBetterMET(const std::vector<MuonTrackTypePair>&, const reco::PFCandidate&);
   std::vector<MuonTrackTypePair> tracksPointingAtMET(const std::vector<MuonTrackTypePair>&);
 
   //Output collections for post cleaning
@@ -119,14 +111,11 @@ class PFMuonAlgo {
   std::unique_ptr<reco::PFCandidateCollection> pfPunchThroughHadronCleanedCandidates_;
   /// the collection of  added muon candidates
   std::unique_ptr<reco::PFCandidateCollection> pfAddedMuonCandidates_;
-  
-  std::vector<unsigned int > maskedIndices_;
 
-  
+  std::vector<unsigned int> maskedIndices_;
+
   //////////////////////////////////////////////////////////////////////////////////////
-  const reco::VertexCollection *  vertices_;
-
-
+  const reco::VertexCollection* vertices_;
 
   //Configurables
   const double maxDPtOPt_;
@@ -158,56 +147,46 @@ class PFMuonAlgo {
   double METX_;
   double METY_;
 
-
   ///////COMPARATORS
 
   class TrackMETComparator {
   public:
-    TrackMETComparator(double METX,double METY) {metx_ = METX; mety_=METY;}
-    ~TrackMETComparator() {}
-    
-    bool operator()(const MuonTrackTypePair& mu1,const MuonTrackTypePair& mu2) {
-      return pow(metx_+mu1.first->px(),2)+pow(mety_+mu1.first->py(),2) < pow(metx_+mu2.first->px(),2)+pow(mety_+mu2.first->py(),2);
+    TrackMETComparator(double METX, double METY) {
+      metx_ = METX;
+      mety_ = METY;
     }
+    ~TrackMETComparator() {}
+
+    bool operator()(const MuonTrackTypePair& mu1, const MuonTrackTypePair& mu2) {
+      return pow(metx_ + mu1.first->px(), 2) + pow(mety_ + mu1.first->py(), 2) <
+             pow(metx_ + mu2.first->px(), 2) + pow(mety_ + mu2.first->py(), 2);
+    }
+
   private:
     double metx_;
     double mety_;
-
-
   };
-
 
   class IndexPtComparator {
   public:
-
-    IndexPtComparator(const reco::PFCandidateCollection* coll):coll_(coll) {
-    }
+    IndexPtComparator(const reco::PFCandidateCollection* coll) : coll_(coll) {}
     ~IndexPtComparator() {}
-    
-    bool operator()(int mu1,int mu2) {
-      return coll_->at(mu1).pt() > coll_->at(mu2).pt();
-    }
+
+    bool operator()(int mu1, int mu2) { return coll_->at(mu1).pt() > coll_->at(mu2).pt(); }
 
   private:
-    const reco::PFCandidateCollection * coll_;
-
+    const reco::PFCandidateCollection* coll_;
   };
-
-
-
 
   class TrackPtErrorSorter {
   public:
     TrackPtErrorSorter() {}
     ~TrackPtErrorSorter() {}
 
-    bool operator()(const MuonTrackTypePair& mu1,const MuonTrackTypePair& mu2) {
-      return mu1.first->ptError()/mu1.first->pt() < mu2.first->ptError()/mu2.first->pt();
+    bool operator()(const MuonTrackTypePair& mu1, const MuonTrackTypePair& mu2) {
+      return mu1.first->ptError() / mu1.first->pt() < mu2.first->ptError() / mu2.first->pt();
     }
   };
-
-
-
 };
 
 #endif

--- a/RecoParticleFlow/PFProducer/interface/PhotonSelectorAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PhotonSelectorAlgo.h
@@ -5,40 +5,38 @@
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
-
 class PhotonSelectorAlgo {
-  
- public:
-   
+public:
   PhotonSelectorAlgo(float choice,
-		     float c_Et_,
-		     float c_iso_track_a, float c_iso_track_b,
-		     float c_iso_ecal_a, float c_iso_ecal_b,
-		     float c_iso_hcal_a, float c_hcal_b,
-		     float c_hoe_,
-		     float comb_iso,
-		     float loose_hoe
-		     );
-  
+                     float c_Et_,
+                     float c_iso_track_a,
+                     float c_iso_track_b,
+                     float c_iso_ecal_a,
+                     float c_iso_ecal_b,
+                     float c_iso_hcal_a,
+                     float c_hcal_b,
+                     float c_hoe_,
+                     float comb_iso,
+                     float loose_hoe);
 
   ~PhotonSelectorAlgo(){};
-  
-  bool passPhotonSelection(const reco::Photon &) const ;
-  
- private:
+
+  bool passPhotonSelection(const reco::Photon &) const;
+
+private:
   //Choice of the cuts
   int choice_;
   //First Choice int 0
   // Et cut
-    float c_Et_;
+  float c_Et_;
   // Track iso, constant term & slope
   float c_iso_track_a_, c_iso_track_b_;
-  // ECAL iso, constant term & slope 
-  float c_iso_ecal_a_,  c_iso_ecal_b_;
+  // ECAL iso, constant term & slope
+  float c_iso_ecal_a_, c_iso_ecal_b_;
   // HCAL iso, constant term & slope
-  float c_iso_hcal_a_,  c_iso_hcal_b_;
+  float c_iso_hcal_a_, c_iso_hcal_b_;
   float c_hoe_;
-  
+
   //second choice int 1
   float comb_iso_;
   float loose_hoe_;

--- a/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc
@@ -23,14 +23,12 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
 
-class ChargedHadronPFTrackIsolationProducer : public edm::global::EDProducer<> 
-{
+class ChargedHadronPFTrackIsolationProducer : public edm::global::EDProducer<> {
 public:
-
   explicit ChargedHadronPFTrackIsolationProducer(const edm::ParameterSet& cfg);
   ~ChargedHadronPFTrackIsolationProducer() override {}
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   // input collection
@@ -38,57 +36,56 @@ private:
   edm::EDGetTokenT<edm::View<reco::PFCandidate> > candidatesToken_;
   double minTrackPt_;
   double minRawCaloEnergy_;
-
 };
 
-ChargedHadronPFTrackIsolationProducer::ChargedHadronPFTrackIsolationProducer(const edm::ParameterSet& cfg)
-{
+ChargedHadronPFTrackIsolationProducer::ChargedHadronPFTrackIsolationProducer(const edm::ParameterSet& cfg) {
   srccandidates_ = cfg.getParameter<edm::InputTag>("src");
   candidatesToken_ = consumes<edm::View<reco::PFCandidate> >(srccandidates_);
   minTrackPt_ = cfg.getParameter<double>("minTrackPt");
   minRawCaloEnergy_ = cfg.getParameter<double>("minRawCaloEnergy");
-  
+
   produces<edm::ValueMap<bool> >();
 }
 
-void ChargedHadronPFTrackIsolationProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const
-{
+void ChargedHadronPFTrackIsolationProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const {
   // get a view of our candidates via the base candidates
   auto candidates = evt.getHandle(candidatesToken_);
-  
+
   std::vector<bool> values;
 
-  for( auto const& c : *candidates ) {
+  for (auto const& c : *candidates) {
     // Check that there is only one track in the block.
     unsigned int nTracks = 0;
-    if ((c.particleId()==1) && (c.pt()>minTrackPt_) && ((c.rawEcalEnergy()+c.rawHcalEnergy())>minRawCaloEnergy_)) {
+    if ((c.particleId() == 1) && (c.pt() > minTrackPt_) &&
+        ((c.rawEcalEnergy() + c.rawHcalEnergy()) > minRawCaloEnergy_)) {
       const reco::PFCandidate::ElementsInBlocks& theElements = c.elementsInBlocks();
-      if( theElements.empty() ) continue;
+      if (theElements.empty())
+        continue;
       const reco::PFBlockRef blockRef = theElements[0].first;
       const edm::OwnVector<reco::PFBlockElement>& elements = blockRef->elements();
       // Find the tracks in the block
-      for( auto const & ele : elements ) {
-         reco::PFBlockElement::Type type = ele.type();
-         if( type== reco::PFBlockElement::TRACK)
-           nTracks++;
+      for (auto const& ele : elements) {
+        reco::PFBlockElement::Type type = ele.type();
+        if (type == reco::PFBlockElement::TRACK)
+          nTracks++;
       }
     }
-    values.push_back((nTracks==1));
+    values.push_back((nTracks == 1));
   }
 
   std::unique_ptr<edm::ValueMap<bool> > out(new edm::ValueMap<bool>());
   edm::ValueMap<bool>::Filler filler(*out);
-  filler.insert(candidates,values.begin(),values.end());
+  filler.insert(candidates, values.begin(), values.end());
   filler.fill();
   evt.put(std::move(out));
 }
 
-void ChargedHadronPFTrackIsolationProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-   edm::ParameterSetDescription desc;
-   desc.add<edm::InputTag>("src", edm::InputTag("particleFlow"));
-   desc.add<double>("minTrackPt", 1);
-   desc.add<double>("minRawCaloEnergy", 0.5);
-   descriptions.add("chargedHadronPFTrackIsolation", desc);
+void ChargedHadronPFTrackIsolationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("particleFlow"));
+  desc.add<double>("minTrackPt", 1);
+  desc.add<double>("minRawCaloEnergy", 0.5);
+  descriptions.add("chargedHadronPFTrackIsolation", desc);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
@@ -18,26 +18,21 @@ flow blocks This is done at a later stage, see PFProducer and PFAlgo.
 
 class FSimEvent;
 
-
-
 class PFBlockProducer : public edm::stream::EDProducer<> {
- public:
-
+public:
   explicit PFBlockProducer(const edm::ParameterSet&);
 
-  void beginLuminosityBlock(edm::LuminosityBlock const&, 
-				    edm::EventSetup const&) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
- private:
+private:
   /// verbose ?
-  const bool   verbose_;
+  const bool verbose_;
   const edm::EDPutTokenT<reco::PFBlockCollection> putToken_;
-  
-  /// Particle flow block algorithm 
-  PFBlockAlgo            pfBlockAlgo_;
 
+  /// Particle flow block algorithm
+  PFBlockAlgo pfBlockAlgo_;
 };
 
 DEFINE_FWK_MODULE(PFBlockProducer);
@@ -45,52 +40,40 @@ DEFINE_FWK_MODULE(PFBlockProducer);
 using namespace std;
 using namespace edm;
 
-PFBlockProducer::PFBlockProducer(const edm::ParameterSet& iConfig) :
-  verbose_{ iConfig.getUntrackedParameter<bool>("verbose",false)},
-  putToken_{produces<reco::PFBlockCollection>()}
-{
-  bool debug_ = 
-    iConfig.getUntrackedParameter<bool>("debug",false);  
-  pfBlockAlgo_.setDebug(debug_);  
-      
-  edm::ConsumesCollector coll = consumesCollector();
-  const std::vector<edm::ParameterSet>& importers
-    = iConfig.getParameterSetVector("elementImporters");      
-  pfBlockAlgo_.setImporters(importers,coll);
+PFBlockProducer::PFBlockProducer(const edm::ParameterSet& iConfig)
+    : verbose_{iConfig.getUntrackedParameter<bool>("verbose", false)}, putToken_{produces<reco::PFBlockCollection>()} {
+  bool debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
+  pfBlockAlgo_.setDebug(debug_);
 
-  const std::vector<edm::ParameterSet>& linkdefs 
-    = iConfig.getParameterSetVector("linkDefinitions");
-  pfBlockAlgo_.setLinkers(linkdefs);  
-  
+  edm::ConsumesCollector coll = consumesCollector();
+  const std::vector<edm::ParameterSet>& importers = iConfig.getParameterSetVector("elementImporters");
+  pfBlockAlgo_.setImporters(importers, coll);
+
+  const std::vector<edm::ParameterSet>& linkdefs = iConfig.getParameterSetVector("linkDefinitions");
+  pfBlockAlgo_.setLinkers(linkdefs);
 }
 
-void PFBlockProducer::
-beginLuminosityBlock(edm::LuminosityBlock const& lb, 
-		     edm::EventSetup const& es) {
+void PFBlockProducer::beginLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
   pfBlockAlgo_.updateEventSetup(es);
 }
 
-void 
-PFBlockProducer::produce(Event& iEvent, 
-			 const EventSetup& iSetup) {
-    
+void PFBlockProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   pfBlockAlgo_.buildElements(iEvent);
-  
+
   auto blocks = pfBlockAlgo_.findBlocks();
-  
-  if(verbose_) {
-    ostringstream  str;
-    str<<pfBlockAlgo_<<endl;
-    str<<"number of blocks : "<<blocks.size()<<endl;
-    str<<endl;
-    
-    for(auto const& block : blocks) {
-      str<< block <<endl;
+
+  if (verbose_) {
+    ostringstream str;
+    str << pfBlockAlgo_ << endl;
+    str << "number of blocks : " << blocks.size() << endl;
+    str << endl;
+
+    for (auto const& block : blocks) {
+      str << block << endl;
     }
 
-    LogInfo("PFBlockProducer") << str.str()<<endl;
-  }    
+    LogInfo("PFBlockProducer") << str.str() << endl;
+  }
 
-  iEvent.emplace(putToken_,blocks);
-    
+  iEvent.emplace(putToken_, blocks);
 }

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -49,34 +49,30 @@ This producer makes use of PFAlgo, the particle flow algorithm.
 #include <memory>
 
 class PFEGammaProducer : public edm::stream::EDProducer<edm::GlobalCache<PFEGammaAlgo::GBRForests> > {
+public:
+  explicit PFEGammaProducer(const edm::ParameterSet&, const PFEGammaAlgo::GBRForests*);
 
- public:
-  explicit PFEGammaProducer(const edm::ParameterSet&, const PFEGammaAlgo::GBRForests* );
+  static std::unique_ptr<PFEGammaAlgo::GBRForests> initializeGlobalCache(const edm::ParameterSet& conf) {
+    return std::unique_ptr<PFEGammaAlgo::GBRForests>(new PFEGammaAlgo::GBRForests(conf));
+  }
 
-  static std::unique_ptr<PFEGammaAlgo::GBRForests>
-    initializeGlobalCache( const edm::ParameterSet& conf ) {
-       return std::unique_ptr<PFEGammaAlgo::GBRForests>(new PFEGammaAlgo::GBRForests(conf));
-   }
-
-  static void globalEndJob(PFEGammaAlgo::GBRForests const* ) {}
+  static void globalEndJob(PFEGammaAlgo::GBRForests const*) {}
 
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void beginRun(const edm::Run &, const edm::EventSetup &) override {}
+  void beginRun(const edm::Run&, const edm::EventSetup&) override {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
+private:
+  void setPFVertexParameters(reco::VertexCollection const& primaryVertices);
 
-  void setPFVertexParameters(reco::VertexCollection const&  primaryVertices);
+  void createSingleLegConversions(reco::PFCandidateEGammaExtraCollection& extras,
+                                  reco::ConversionCollection& oneLegConversions,
+                                  const edm::RefProd<reco::ConversionCollection>& convProd);
 
-  void createSingleLegConversions(reco::PFCandidateEGammaExtraCollection &extras,
-                                  reco::ConversionCollection &oneLegConversions,
-                                  const edm::RefProd<reco::ConversionCollection> &convProd);
-
-
-  const edm::EDGetTokenT<reco::PFBlockCollection>            inputTagBlocks_;
+  const edm::EDGetTokenT<reco::PFBlockCollection> inputTagBlocks_;
   const edm::EDGetTokenT<reco::PFCluster::EEtoPSAssociation> eetopsSrc_;
-  const edm::EDGetTokenT<reco::VertexCollection>             vertices_;
+  const edm::EDGetTokenT<reco::VertexCollection> vertices_;
 
   // Use vertices for Neutral particles ?
   const bool useVerticesForNeutral_;
@@ -90,83 +86,67 @@ class PFEGammaProducer : public edm::stream::EDProducer<edm::GlobalCache<PFEGamm
 
   const std::string ebeeClustersCollection_;
   const std::string esClustersCollection_;
-
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(PFEGammaProducer);
 
 #ifdef PFLOW_DEBUG
-#define LOGDRESSED(x)  edm::LogInfo(x)
+#define LOGDRESSED(x) edm::LogInfo(x)
 #else
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-PFEGammaProducer::PFEGammaProducer(const edm::ParameterSet& iConfig,
-                                   const PFEGammaAlgo::GBRForests* gbrForests)
-  : inputTagBlocks_        (consumes<reco::PFBlockCollection>(iConfig.getParameter<edm::InputTag>("blocks")))
-  , eetopsSrc_             (consumes<reco::PFCluster::EEtoPSAssociation>(
-                            iConfig.getParameter<edm::InputTag>("EEtoPS_source")))
-  , vertices_              (consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection")))
-  , useVerticesForNeutral_ (iConfig.getParameter<bool>("useVerticesForNeutral"))
-  , primaryVertex_         (reco::Vertex())
-  , ebeeClustersCollection_("EBEEClusters")
-  , esClustersCollection_  ("ESClusters")
-{
-    
+PFEGammaProducer::PFEGammaProducer(const edm::ParameterSet& iConfig, const PFEGammaAlgo::GBRForests* gbrForests)
+    : inputTagBlocks_(consumes<reco::PFBlockCollection>(iConfig.getParameter<edm::InputTag>("blocks"))),
+      eetopsSrc_(consumes<reco::PFCluster::EEtoPSAssociation>(iConfig.getParameter<edm::InputTag>("EEtoPS_source"))),
+      vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"))),
+      useVerticesForNeutral_(iConfig.getParameter<bool>("useVerticesForNeutral")),
+      primaryVertex_(reco::Vertex()),
+      ebeeClustersCollection_("EBEEClusters"),
+      esClustersCollection_("ESClusters") {
   PFEGammaAlgo::PFEGConfigInfo algo_config;
 
-  algo_config.produceEGCandsWithNoSuperCluster = 
-    iConfig.getParameter<bool>("produceEGCandsWithNoSuperCluster");
+  algo_config.produceEGCandsWithNoSuperCluster = iConfig.getParameter<bool>("produceEGCandsWithNoSuperCluster");
 
   // register products
   produces<reco::PFCandidateCollection>();
-  produces<reco::PFCandidateEGammaExtraCollection>();  
+  produces<reco::PFCandidateEGammaExtraCollection>();
   produces<reco::SuperClusterCollection>();
   produces<reco::CaloClusterCollection>(ebeeClustersCollection_);
-  produces<reco::CaloClusterCollection>(esClustersCollection_);  
+  produces<reco::CaloClusterCollection>(esClustersCollection_);
   produces<reco::ConversionCollection>();
-  
-  //PFElectrons Configuration
-  algo_config.mvaEleCut
-    = iConfig.getParameter<double>("pf_electron_mvaCut");
 
-  
-  algo_config.applyCrackCorrections
-    = iConfig.getParameter<bool>("pf_electronID_crackCorrection");
-    
-  algo_config.mvaConvCut = iConfig.getParameter<double>("pf_conv_mvaCut");  
+  //PFElectrons Configuration
+  algo_config.mvaEleCut = iConfig.getParameter<double>("pf_electron_mvaCut");
+
+  algo_config.applyCrackCorrections = iConfig.getParameter<bool>("pf_electronID_crackCorrection");
+
+  algo_config.mvaConvCut = iConfig.getParameter<double>("pf_conv_mvaCut");
 
   //PFEGamma
-  //for MVA pass PV if there is one in the collection otherwise pass a dummy  
-  if(!useVerticesForNeutral_) { // create a dummy PV  
-    reco::Vertex::Error e;  
-    e(0, 0) = 0.0015 * 0.0015;  
-    e(1, 1) = 0.0015 * 0.0015;  
-    e(2, 2) = 15. * 15.;  
-    reco::Vertex::Point p(0, 0, 0);  
-    primaryVertex_ = reco::Vertex(p, e, 0, 0, 0);  
-  }  
+  //for MVA pass PV if there is one in the collection otherwise pass a dummy
+  if (!useVerticesForNeutral_) {  // create a dummy PV
+    reco::Vertex::Error e;
+    e(0, 0) = 0.0015 * 0.0015;
+    e(1, 1) = 0.0015 * 0.0015;
+    e(2, 2) = 15. * 15.;
+    reco::Vertex::Point p(0, 0, 0);
+    primaryVertex_ = reco::Vertex(p, e, 0, 0, 0);
+  }
   pfeg_ = std::make_unique<PFEGammaAlgo>(algo_config, *gbrForests);
-  pfeg_->setPrimaryVertex(primaryVertex_ );
-
+  pfeg_->setPrimaryVertex(primaryVertex_);
 }
 
-void 
-PFEGammaProducer::produce(edm::Event& iEvent, 
-			     const edm::EventSetup& iSetup) {
-  
-  LOGDRESSED("PFEGammaProducer")
-    <<"START event: "
-    <<iEvent.id().event()
-    <<" in run "<<iEvent.id().run()<<std::endl;
-  
+void PFEGammaProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  LOGDRESSED("PFEGammaProducer") << "START event: " << iEvent.id().event() << " in run " << iEvent.id().run()
+                                 << std::endl;
 
   // output collections
   auto egCandidates_ = std::make_unique<reco::PFCandidateCollection>();
-  auto egExtra_      = std::make_unique<reco::PFCandidateEGammaExtraCollection>();
-  auto sClusters_    = std::make_unique<reco::SuperClusterCollection>();
-    
+  auto egExtra_ = std::make_unique<reco::PFCandidateEGammaExtraCollection>();
+  auto sClusters_ = std::make_unique<reco::SuperClusterCollection>();
+
   // Get the EE-PS associations
   pfeg_->setEEtoPSAssociation(iEvent.get(eetopsSrc_));
 
@@ -182,74 +162,70 @@ PFEGammaProducer::produce(edm::Event& iEvent,
   //Assign the PFAlgo Parameters
   setPFVertexParameters(iEvent.get(vertices_));
 
-  // get the collection of blocks 
+  // get the collection of blocks
 
-  LOGDRESSED("PFEGammaProducer")<<"getting blocks"<<std::endl;
-  auto blocks = iEvent.getHandle( inputTagBlocks_);  
-  
-  LOGDRESSED("PFEGammaProducer")
-    <<"EGPFlow is starting..."<<std::endl;
+  LOGDRESSED("PFEGammaProducer") << "getting blocks" << std::endl;
+  auto blocks = iEvent.getHandle(inputTagBlocks_);
+
+  LOGDRESSED("PFEGammaProducer") << "EGPFlow is starting..." << std::endl;
 
 #ifdef PFLOW_DEBUG
-  assert( blocks.isValid() && "edm::Handle to blocks was null!");
-  std::ostringstream  str;
+  assert(blocks.isValid() && "edm::Handle to blocks was null!");
+  std::ostringstream str;
   //str<<(*pfAlgo_)<<std::endl;
   //    cout << (*pfAlgo_) << std::endl;
-  LOGDRESSED("PFEGammaProducer") <<str.str()<<std::endl;
-#endif  
+  LOGDRESSED("PFEGammaProducer") << str.str() << std::endl;
+#endif
 
   // sort elements in three lists:
-  std::list< reco::PFBlockRef > hcalBlockRefs;
-  std::list< reco::PFBlockRef > ecalBlockRefs;
-  std::list< reco::PFBlockRef > hoBlockRefs;
-  std::list< reco::PFBlockRef > otherBlockRefs;
-  
-  for( unsigned i=0; i<blocks->size(); ++i ) {
+  std::list<reco::PFBlockRef> hcalBlockRefs;
+  std::list<reco::PFBlockRef> ecalBlockRefs;
+  std::list<reco::PFBlockRef> hoBlockRefs;
+  std::list<reco::PFBlockRef> otherBlockRefs;
+
+  for (unsigned i = 0; i < blocks->size(); ++i) {
     // reco::PFBlockRef blockref( blockh,i );
     //reco::PFBlockRef blockref = createBlockRef( *blocks, i);
-    reco::PFBlockRef blockref(blocks, i);    
-    
-    const edm::OwnVector< reco::PFBlockElement >& 
-      elements = blockref->elements();
-   
-    LOGDRESSED("PFEGammaProducer") 
-      << "Found " << elements.size() 
-      << " PFBlockElements in block: " << i << std::endl;
-    
+    reco::PFBlockRef blockref(blocks, i);
+
+    const edm::OwnVector<reco::PFBlockElement>& elements = blockref->elements();
+
+    LOGDRESSED("PFEGammaProducer") << "Found " << elements.size() << " PFBlockElements in block: " << i << std::endl;
+
     bool singleEcalOrHcal = false;
-    if( elements.size() == 1 ){
-      switch( elements[0].type() ) {
-      case reco::PFBlockElement::SC:
-	edm::LogError("PFEGammaProducer")
-	  << "PFBLOCKALGO BUG!!!! Found a SuperCluster in a block by itself!";
-      case reco::PFBlockElement::PS1:
-      case reco::PFBlockElement::PS2:
-      case reco::PFBlockElement::ECAL:
-        ecalBlockRefs.push_back( blockref );
-        singleEcalOrHcal = true;
-	break;
-      case reco::PFBlockElement::HFEM:
-      case reco::PFBlockElement::HFHAD:
-      case reco::PFBlockElement::HCAL:
-        if (elements[0].clusterRef()->flags() & reco::CaloCluster::badHcalMarker) continue;
-        hcalBlockRefs.push_back( blockref );
-        singleEcalOrHcal = true;
-	break;
-      case reco::PFBlockElement::HO:
-        // Single HO elements are likely to be noise. Not considered for now.
-        hoBlockRefs.push_back( blockref );
-        singleEcalOrHcal = true;
-	break;
-      default:
-	break;
+    if (elements.size() == 1) {
+      switch (elements[0].type()) {
+        case reco::PFBlockElement::SC:
+          edm::LogError("PFEGammaProducer") << "PFBLOCKALGO BUG!!!! Found a SuperCluster in a block by itself!";
+        case reco::PFBlockElement::PS1:
+        case reco::PFBlockElement::PS2:
+        case reco::PFBlockElement::ECAL:
+          ecalBlockRefs.push_back(blockref);
+          singleEcalOrHcal = true;
+          break;
+        case reco::PFBlockElement::HFEM:
+        case reco::PFBlockElement::HFHAD:
+        case reco::PFBlockElement::HCAL:
+          if (elements[0].clusterRef()->flags() & reco::CaloCluster::badHcalMarker)
+            continue;
+          hcalBlockRefs.push_back(blockref);
+          singleEcalOrHcal = true;
+          break;
+        case reco::PFBlockElement::HO:
+          // Single HO elements are likely to be noise. Not considered for now.
+          hoBlockRefs.push_back(blockref);
+          singleEcalOrHcal = true;
+          break;
+        default:
+          break;
       }
     }
-    
-    if(!singleEcalOrHcal) {
-      otherBlockRefs.push_back( blockref );
+
+    if (!singleEcalOrHcal) {
+      otherBlockRefs.push_back(blockref);
     }
-  }//loop blocks
-  
+  }  //loop blocks
+
   // loop on blocks that are not single ecal, single ps1, single ps2 , or
   // single hcal and produce unbiased collection of EGamma Candidates
 
@@ -257,27 +233,24 @@ PFEGammaProducer::produce(edm::Event& iEvent,
   unsigned nblcks = 0;
 
   // this auto is a const reco::PFBlockRef&
-  for( const auto& blockref : otherBlockRefs ) {
+  for (const auto& blockref : otherBlockRefs) {
     ++nblcks;
     // this auto is a: const edm::OwnVector< reco::PFBlockElement >&
     const auto& elements = blockref->elements();
     // make a copy of the link data, which will be edited.
     //PFBlock::LinkData linkData =  block.linkData();
-    
+
     auto output = (*pfeg_)(blockref);
 
-    if( !output.candidates.empty() ) {
-      LOGDRESSED("PFEGammaProducer")
-      << "Block with " << elements.size() 
-      << " elements produced " 
-      << output.candidates.size() 
-      << " e-g candidates!" << std::endl;      
+    if (!output.candidates.empty()) {
+      LOGDRESSED("PFEGammaProducer") << "Block with " << elements.size() << " elements produced "
+                                     << output.candidates.size() << " e-g candidates!" << std::endl;
     }
 
     const size_t egsize = egCandidates_->size();
     egCandidates_->resize(egsize + output.candidates.size());
     std::move(output.candidates.begin(), output.candidates.end(), egCandidates_->begin() + egsize);
-    
+
     const size_t egxsize = egExtra_->size();
     egExtra_->resize(egxsize + output.candidateExtras.size());
     std::move(output.candidateExtras.begin(), output.candidateExtras.end(), egExtra_->begin() + egxsize);
@@ -287,93 +260,88 @@ PFEGammaProducer::produce(edm::Event& iEvent,
     std::move(output.refinedSuperClusters.begin(), output.refinedSuperClusters.end(), sClusters_->begin() + rscsize);
   }
 
-  LOGDRESSED("PFEGammaProducer")
-      << "Running PFEGammaAlgo on all blocks produced = " 
-      << egCandidates_->size() << " e-g candidates!"
-      << std::endl;
-  
-  edm::RefProd<reco::SuperClusterCollection> sClusterProd = 
-    iEvent.getRefBeforePut<reco::SuperClusterCollection>();
+  LOGDRESSED("PFEGammaProducer") << "Running PFEGammaAlgo on all blocks produced = " << egCandidates_->size()
+                                 << " e-g candidates!" << std::endl;
 
-  edm::RefProd<reco::PFCandidateEGammaExtraCollection> egXtraProd = 
-    iEvent.getRefBeforePut<reco::PFCandidateEGammaExtraCollection>();
-    
+  edm::RefProd<reco::SuperClusterCollection> sClusterProd = iEvent.getRefBeforePut<reco::SuperClusterCollection>();
+
+  edm::RefProd<reco::PFCandidateEGammaExtraCollection> egXtraProd =
+      iEvent.getRefBeforePut<reco::PFCandidateEGammaExtraCollection>();
+
   //set the correct references to refined SC and EG extra using the refprods
-  for (unsigned int i=0; i < egCandidates_->size(); ++i) {
-    reco::PFCandidate &cand = egCandidates_->at(i);
-    reco::PFCandidateEGammaExtra &xtra = egExtra_->at(i);
-    
-    reco::PFCandidateEGammaExtraRef extraref(egXtraProd,i);
-    reco::SuperClusterRef refinedSCRef(sClusterProd,i);
+  for (unsigned int i = 0; i < egCandidates_->size(); ++i) {
+    reco::PFCandidate& cand = egCandidates_->at(i);
+    reco::PFCandidateEGammaExtra& xtra = egExtra_->at(i);
 
-    xtra.setSuperClusterRef(refinedSCRef); 
+    reco::PFCandidateEGammaExtraRef extraref(egXtraProd, i);
+    reco::SuperClusterRef refinedSCRef(sClusterProd, i);
+
+    xtra.setSuperClusterRef(refinedSCRef);
     cand.setSuperClusterRef(refinedSCRef);
-    cand.setPFEGammaExtraRef(extraref);    
+    cand.setPFEGammaExtraRef(extraref);
   }
-  
+
   //build collections of output CaloClusters from the used PFClusters
   auto caloClustersEBEE = std::make_unique<reco::CaloClusterCollection>();
   auto caloClustersES = std::make_unique<reco::CaloClusterCollection>();
-  
-  std::map<edm::Ptr<reco::CaloCluster>, unsigned int> pfClusterMapEBEE; //maps of pfclusters to caloclusters 
-  std::map<edm::Ptr<reco::CaloCluster>, unsigned int> pfClusterMapES;  
-  
-  for( const auto& sc : *sClusters_ ) {
-    for (reco::CaloCluster_iterator pfclus = sc.clustersBegin(); pfclus!=sc.clustersEnd(); ++pfclus) {
+
+  std::map<edm::Ptr<reco::CaloCluster>, unsigned int> pfClusterMapEBEE;  //maps of pfclusters to caloclusters
+  std::map<edm::Ptr<reco::CaloCluster>, unsigned int> pfClusterMapES;
+
+  for (const auto& sc : *sClusters_) {
+    for (reco::CaloCluster_iterator pfclus = sc.clustersBegin(); pfclus != sc.clustersEnd(); ++pfclus) {
       if (!pfClusterMapEBEE.count(*pfclus)) {
         reco::CaloCluster caloclus(**pfclus);
         caloClustersEBEE->push_back(caloclus);
         pfClusterMapEBEE[*pfclus] = caloClustersEBEE->size() - 1;
-      }
-      else {
+      } else {
         throw cms::Exception("PFEgammaProducer::produce")
-            << "Found an EB/EE pfcluster matched to more than one supercluster!" 
-            << std::dec << std::endl;
+            << "Found an EB/EE pfcluster matched to more than one supercluster!" << std::dec << std::endl;
       }
     }
-    for (reco::CaloCluster_iterator pfclus = sc.preshowerClustersBegin(); pfclus!=sc.preshowerClustersEnd(); ++pfclus) {
+    for (reco::CaloCluster_iterator pfclus = sc.preshowerClustersBegin(); pfclus != sc.preshowerClustersEnd();
+         ++pfclus) {
       if (!pfClusterMapES.count(*pfclus)) {
         reco::CaloCluster caloclus(**pfclus);
         caloClustersES->push_back(caloclus);
         pfClusterMapES[*pfclus] = caloClustersES->size() - 1;
-      }
-      else {
+      } else {
         throw cms::Exception("PFEgammaProducer::produce")
-            << "Found an ES pfcluster matched to more than one supercluster!" 
-            << std::dec << std::endl;
+            << "Found an ES pfcluster matched to more than one supercluster!" << std::dec << std::endl;
       }
     }
   }
-  
+
   //put calocluster output collections in event and get orphan handles to create ptrs
-  auto const& caloClusHandleEBEE = iEvent.put(std::move(caloClustersEBEE),ebeeClustersCollection_);
-  auto const& caloClusHandleES = iEvent.put(std::move(caloClustersES),esClustersCollection_);
-  
+  auto const& caloClusHandleEBEE = iEvent.put(std::move(caloClustersEBEE), ebeeClustersCollection_);
+  auto const& caloClusHandleES = iEvent.put(std::move(caloClustersES), esClustersCollection_);
+
   //relink superclusters to output caloclusters
-  for( auto& sc : *sClusters_ ) {
-    edm::Ptr<reco::CaloCluster> seedptr(caloClusHandleEBEE,pfClusterMapEBEE[sc.seed()]);
+  for (auto& sc : *sClusters_) {
+    edm::Ptr<reco::CaloCluster> seedptr(caloClusHandleEBEE, pfClusterMapEBEE[sc.seed()]);
     sc.setSeed(seedptr);
-    
+
     reco::CaloClusterPtrVector clusters;
-    for (reco::CaloCluster_iterator pfclus = sc.clustersBegin(); pfclus!=sc.clustersEnd(); ++pfclus) {
-      edm::Ptr<reco::CaloCluster> clusptr(caloClusHandleEBEE,pfClusterMapEBEE[*pfclus]);
+    for (reco::CaloCluster_iterator pfclus = sc.clustersBegin(); pfclus != sc.clustersEnd(); ++pfclus) {
+      edm::Ptr<reco::CaloCluster> clusptr(caloClusHandleEBEE, pfClusterMapEBEE[*pfclus]);
       clusters.push_back(clusptr);
     }
     sc.setClusters(clusters);
-    
+
     reco::CaloClusterPtrVector psclusters;
-    for (reco::CaloCluster_iterator pfclus = sc.preshowerClustersBegin(); pfclus!=sc.preshowerClustersEnd(); ++pfclus) {
-      edm::Ptr<reco::CaloCluster> clusptr(caloClusHandleES,pfClusterMapES[*pfclus]);
+    for (reco::CaloCluster_iterator pfclus = sc.preshowerClustersBegin(); pfclus != sc.preshowerClustersEnd();
+         ++pfclus) {
+      edm::Ptr<reco::CaloCluster> clusptr(caloClusHandleES, pfClusterMapES[*pfclus]);
       psclusters.push_back(clusptr);
     }
-    sc.setPreshowerClusters(psclusters);  
+    sc.setPreshowerClusters(psclusters);
   }
-  
+
   //create and fill references to single leg conversions
   edm::RefProd<reco::ConversionCollection> convProd = iEvent.getRefBeforePut<reco::ConversionCollection>();
   auto singleLegConv_ = std::make_unique<reco::ConversionCollection>();
   createSingleLegConversions(*egExtra_, *singleLegConv_, convProd);
-  
+
   // release our demonspawn into the wild to cause havoc
   iEvent.put(std::move(sClusters_));
   iEvent.put(std::move(egExtra_));
@@ -381,47 +349,42 @@ PFEGammaProducer::produce(edm::Event& iEvent,
   iEvent.put(std::move(egCandidates_));
 }
 
-
-void
-PFEGammaProducer::setPFVertexParameters(reco::VertexCollection const&  primaryVertices)
-{
-    primaryVertex_ = primaryVertices.front();
-    for(auto const& pv : primaryVertices) {
-        if(pv.isValid() && !pv.isFake()) {
-            primaryVertex_ = pv;
-            break;
-        }
+void PFEGammaProducer::setPFVertexParameters(reco::VertexCollection const& primaryVertices) {
+  primaryVertex_ = primaryVertices.front();
+  for (auto const& pv : primaryVertices) {
+    if (pv.isValid() && !pv.isFake()) {
+      primaryVertex_ = pv;
+      break;
     }
+  }
 
-    pfeg_->setPrimaryVertex(primaryVertex_ );
+  pfeg_->setPrimaryVertex(primaryVertex_);
 }
 
-void PFEGammaProducer::createSingleLegConversions(reco::PFCandidateEGammaExtraCollection &extras,
-                                                  reco::ConversionCollection &oneLegConversions,
-                                                  const edm::RefProd<reco::ConversionCollection> &convProd)
-{
- 
+void PFEGammaProducer::createSingleLegConversions(reco::PFCandidateEGammaExtraCollection& extras,
+                                                  reco::ConversionCollection& oneLegConversions,
+                                                  const edm::RefProd<reco::ConversionCollection>& convProd) {
   math::Error<3>::type error;
-  for (auto &extra : extras){
-    for (const auto &tkrefmva : extra.singleLegConvTrackRefMva()) {
-      const reco::Track &trk = *tkrefmva.first;
-            
+  for (auto& extra : extras) {
+    for (const auto& tkrefmva : extra.singleLegConvTrackRefMva()) {
+      const reco::Track& trk = *tkrefmva.first;
+
       const reco::Vertex convVtx(trk.innerPosition(), error);
       std::vector<reco::TrackRef> OneLegConvVector;
       OneLegConvVector.push_back(tkrefmva.first);
-      std::vector< float > OneLegMvaVector;
+      std::vector<float> OneLegMvaVector;
       OneLegMvaVector.push_back(tkrefmva.second);
       std::vector<reco::CaloClusterPtr> dummymatchingBC;
       reco::CaloClusterPtrVector scPtrVec;
       scPtrVec.push_back(edm::refToPtr(extra.superClusterRef()));
 
-      std::vector<math::XYZPointF>trackPositionAtEcalVec;
-      std::vector<math::XYZPointF>innPointVec;
-      std::vector<math::XYZVectorF>trackPinVec;
-      std::vector<math::XYZVectorF>trackPoutVec;
+      std::vector<math::XYZPointF> trackPositionAtEcalVec;
+      std::vector<math::XYZPointF> innPointVec;
+      std::vector<math::XYZVectorF> trackPinVec;
+      std::vector<math::XYZVectorF> trackPoutVec;
       math::XYZPointF trackPositionAtEcal(trk.outerPosition().X(), trk.outerPosition().Y(), trk.outerPosition().Z());
       trackPositionAtEcalVec.push_back(trackPositionAtEcal);
-      
+
       math::XYZPointF innPoint(trk.innerPosition().X(), trk.innerPosition().Y(), trk.innerPosition().Z());
       innPointVec.push_back(innPoint);
 
@@ -429,46 +392,45 @@ void PFEGammaProducer::createSingleLegConversions(reco::PFCandidateEGammaExtraCo
       trackPinVec.push_back(trackPin);
 
       math::XYZVectorF trackPout(trk.outerMomentum().X(), trk.outerMomentum().Y(), trk.outerMomentum().Z());
-      trackPoutVec.push_back( trackPout );
-      
-      float DCA = trk.d0() ;
-      float mvaval = tkrefmva.second;
-      reco::Conversion singleLegConvCandidate(scPtrVec, 
-                                          OneLegConvVector,
-                                          trackPositionAtEcalVec,
-                                          convVtx,
-                                          dummymatchingBC,
-                                          DCA,
-                                          innPointVec,
-                                          trackPinVec,
-                                          trackPoutVec,
-                                          mvaval,                         
-                                          reco::Conversion::pflow);
-      singleLegConvCandidate.setOneLegMVA(OneLegMvaVector); 
-      oneLegConversions.push_back(singleLegConvCandidate);
-            
-      reco::ConversionRef convref(convProd,oneLegConversions.size()-1);
-      extra.addSingleLegConversionRef(convref);
-    
-    }
+      trackPoutVec.push_back(trackPout);
 
-  } 
-  
+      float DCA = trk.d0();
+      float mvaval = tkrefmva.second;
+      reco::Conversion singleLegConvCandidate(scPtrVec,
+                                              OneLegConvVector,
+                                              trackPositionAtEcalVec,
+                                              convVtx,
+                                              dummymatchingBC,
+                                              DCA,
+                                              innPointVec,
+                                              trackPinVec,
+                                              trackPoutVec,
+                                              mvaval,
+                                              reco::Conversion::pflow);
+      singleLegConvCandidate.setOneLegMVA(OneLegMvaVector);
+      oneLegConversions.push_back(singleLegConvCandidate);
+
+      reco::ConversionRef convref(convProd, oneLegConversions.size() - 1);
+      extra.addSingleLegConversionRef(convref);
+    }
+  }
 }
 
 void PFEGammaProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<bool>  ("useVerticesForNeutral",            true);
-  desc.add<bool>  ("produceEGCandsWithNoSuperCluster", false)->setComment("Allow building of candidates with no input or output supercluster?");
-  desc.add<double>("pf_electron_mvaCut",               -0.1);
-  desc.add<bool>  ("pf_electronID_crackCorrection",    false);
-  desc.add<double>("pf_conv_mvaCut",                   0.0);
-  desc.add<edm::InputTag>  ("blocks",          edm::InputTag("particleFlowBlock"))->setComment("PF Blocks label");
-  desc.add<edm::InputTag>  ("EEtoPS_source",   edm::InputTag("particleFlowClusterECAL"))->setComment("EE to PS association");
-  desc.add<edm::InputTag>  ("vertexCollection",                edm::InputTag("offlinePrimaryVertices"));
+  desc.add<bool>("useVerticesForNeutral", true);
+  desc.add<bool>("produceEGCandsWithNoSuperCluster", false)
+      ->setComment("Allow building of candidates with no input or output supercluster?");
+  desc.add<double>("pf_electron_mvaCut", -0.1);
+  desc.add<bool>("pf_electronID_crackCorrection", false);
+  desc.add<double>("pf_conv_mvaCut", 0.0);
+  desc.add<edm::InputTag>("blocks", edm::InputTag("particleFlowBlock"))->setComment("PF Blocks label");
+  desc.add<edm::InputTag>("EEtoPS_source", edm::InputTag("particleFlowClusterECAL"))
+      ->setComment("EE to PS association");
+  desc.add<edm::InputTag>("vertexCollection", edm::InputTag("offlinePrimaryVertices"));
   desc.add<edm::FileInPath>("pf_electronID_mvaWeightFile",
-      edm::FileInPath("RecoParticleFlow/PFProducer/data/PfElectrons23Jan_BDT.weights.xml.gz"));
+                            edm::FileInPath("RecoParticleFlow/PFProducer/data/PfElectrons23Jan_BDT.weights.xml.gz"));
   desc.add<edm::FileInPath>("pf_convID_mvaWeightFile",
-      edm::FileInPath("RecoParticleFlow/PFProducer/data/pfConversionAug0411_BDT.weights.xml.gz"));
+                            edm::FileInPath("RecoParticleFlow/PFProducer/data/pfConversionAug0411_BDT.weights.xml.gz"));
   descriptions.add("particleFlowEGamma", desc);
 }

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -33,7 +33,6 @@
 
 #include "TFile.h"
 
-
 /**\class PFProducer 
 \brief Producer for particle flow reconstructed particles (PFCandidates)
 
@@ -44,45 +43,43 @@ This producer makes use of PFAlgo, the particle flow algorithm.
 */
 
 class PFProducer : public edm::stream::EDProducer<> {
- public:
+public:
   explicit PFProducer(const edm::ParameterSet&);
-  
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  void beginRun(const edm::Run &, const edm::EventSetup &) override;
 
- private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+
+private:
   const edm::EDPutTokenT<reco::PFCandidateCollection> pfCandidatesToken_;
   const edm::EDPutTokenT<reco::PFCandidateCollection> pfCleanedCandidatesToken_;
 
-  const edm::EDGetTokenT<reco::PFBlockCollection>  inputTagBlocks_;
-  edm::EDGetTokenT<reco::MuonCollection>     inputTagMuons_;
-  edm::EDGetTokenT<reco::VertexCollection>   vertices_;
+  const edm::EDGetTokenT<reco::PFBlockCollection> inputTagBlocks_;
+  edm::EDGetTokenT<reco::MuonCollection> inputTagMuons_;
+  edm::EDGetTokenT<reco::VertexCollection> vertices_;
   edm::EDGetTokenT<reco::GsfElectronCollection> inputTagEgammaElectrons_;
 
-
-  std::vector<edm::EDGetTokenT<reco::PFRecHitCollection> >  inputTagCleanedHF_;
+  std::vector<edm::EDGetTokenT<reco::PFRecHitCollection>> inputTagCleanedHF_;
   std::string electronOutputCol_;
   std::string electronExtraOutputCol_;
   std::string photonExtraOutputCol_;
 
   // NEW EGamma Filters
-  edm::EDGetTokenT<edm::ValueMap<reco::GsfElectronRef> >inputTagValueMapGedElectrons_;
-  edm::EDGetTokenT<edm::ValueMap<reco::PhotonRef> > inputTagValueMapGedPhotons_;
-  edm::EDGetTokenT<edm::View<reco::PFCandidate> > inputTagPFEGammaCandidates_;
+  edm::EDGetTokenT<edm::ValueMap<reco::GsfElectronRef>> inputTagValueMapGedElectrons_;
+  edm::EDGetTokenT<edm::ValueMap<reco::PhotonRef>> inputTagValueMapGedPhotons_;
+  edm::EDGetTokenT<edm::View<reco::PFCandidate>> inputTagPFEGammaCandidates_;
 
   bool use_EGammaFilters_;
   std::unique_ptr<PFEGammaFilters> pfegamma_ = nullptr;
-
 
   //Use of HO clusters and links in PF Reconstruction
   bool useHO_;
 
   /// verbose ?
-  bool  verbose_;
+  bool verbose_;
 
   // Post muon cleaning ?
   bool postMuonCleaning_;
-  
+
   // what about e/g electrons ?
   bool useEGammaElectrons_;
 
@@ -96,7 +93,7 @@ class PFProducer : public edm::stream::EDProducer<> {
   bool postHFCleaning_;
   // Name of the calibration functions to read from the database
   // std::vector<std::string> fToRead;
-  
+
   // calibrations
   PFEnergyCalibration pfEnergyCalibration_;
   PFEnergyCalibrationHF pfEnergyCalibrationHF_;
@@ -107,49 +104,43 @@ class PFProducer : public edm::stream::EDProducer<> {
 
 DEFINE_FWK_MODULE(PFProducer);
 
-
 using namespace std;
 using namespace edm;
 
-
 PFProducer::PFProducer(const edm::ParameterSet& iConfig)
-  : pfCandidatesToken_{produces<reco::PFCandidateCollection>()}
-  , pfCleanedCandidatesToken_{produces<reco::PFCandidateCollection>("CleanedHF")}
-  , inputTagBlocks_(consumes<reco::PFBlockCollection>(iConfig.getParameter<InputTag>("blocks")))
-  , pfEnergyCalibrationHF_(iConfig.getParameter<bool>("calibHF_use"),
-                           iConfig.getParameter<std::vector<double> >("calibHF_eta_step"),
-                           iConfig.getParameter<std::vector<double> >("calibHF_a_EMonly"),
-                           iConfig.getParameter<std::vector<double> >("calibHF_b_HADonly"),
-                           iConfig.getParameter<std::vector<double> >("calibHF_a_EMHAD"),
-                           iConfig.getParameter<std::vector<double> >("calibHF_b_EMHAD"))
-  , pfAlgo_(iConfig.getParameter<double>("pf_nsigma_ECAL"),
-            iConfig.getParameter<double>("pf_nsigma_HCAL"),
-            pfEnergyCalibration_,
-            pfEnergyCalibrationHF_,
-            iConfig,
-            iConfig.getUntrackedParameter<bool>("debug",false))
-{
-  
+    : pfCandidatesToken_{produces<reco::PFCandidateCollection>()},
+      pfCleanedCandidatesToken_{produces<reco::PFCandidateCollection>("CleanedHF")},
+      inputTagBlocks_(consumes<reco::PFBlockCollection>(iConfig.getParameter<InputTag>("blocks"))),
+      pfEnergyCalibrationHF_(iConfig.getParameter<bool>("calibHF_use"),
+                             iConfig.getParameter<std::vector<double>>("calibHF_eta_step"),
+                             iConfig.getParameter<std::vector<double>>("calibHF_a_EMonly"),
+                             iConfig.getParameter<std::vector<double>>("calibHF_b_HADonly"),
+                             iConfig.getParameter<std::vector<double>>("calibHF_a_EMHAD"),
+                             iConfig.getParameter<std::vector<double>>("calibHF_b_EMHAD")),
+      pfAlgo_(iConfig.getParameter<double>("pf_nsigma_ECAL"),
+              iConfig.getParameter<double>("pf_nsigma_HCAL"),
+              pfEnergyCalibration_,
+              pfEnergyCalibrationHF_,
+              iConfig,
+              iConfig.getUntrackedParameter<bool>("debug", false)) {
   //Post cleaning of the muons
   inputTagMuons_ = consumes<reco::MuonCollection>(iConfig.getParameter<InputTag>("muons"));
-  postMuonCleaning_
-    = iConfig.getParameter<bool>("postMuonCleaning");
+  postMuonCleaning_ = iConfig.getParameter<bool>("postMuonCleaning");
 
-  if( iConfig.existsAs<bool>("useEGammaFilters") ) {
-    use_EGammaFilters_ =  iConfig.getParameter<bool>("useEGammaFilters");    
+  if (iConfig.existsAs<bool>("useEGammaFilters")) {
+    use_EGammaFilters_ = iConfig.getParameter<bool>("useEGammaFilters");
   } else {
     use_EGammaFilters_ = false;
   }
 
-  useEGammaElectrons_
-    = iConfig.getParameter<bool>("useEGammaElectrons");    
+  useEGammaElectrons_ = iConfig.getParameter<bool>("useEGammaElectrons");
 
-  if(  useEGammaElectrons_) {
-    inputTagEgammaElectrons_ = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("egammaElectrons"));
+  if (useEGammaElectrons_) {
+    inputTagEgammaElectrons_ =
+        consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("egammaElectrons"));
   }
 
-  electronOutputCol_
-    = iConfig.getParameter<std::string>("pf_electron_output_col");
+  electronOutputCol_ = iConfig.getParameter<std::string>("pf_electron_output_col");
 
   // register products
   produces<reco::PFCandidateCollection>("CleanedCosmicsMuons");
@@ -159,9 +150,7 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig)
   produces<reco::PFCandidateCollection>("CleanedPunchThroughNeutralHadrons");
   produces<reco::PFCandidateCollection>("AddedMuonsAndHadrons");
 
-
-  string mvaWeightFileEleID
-    = iConfig.getParameter<string>("pf_electronID_mvaWeightFile");
+  string mvaWeightFileEleID = iConfig.getParameter<string>("pf_electronID_mvaWeightFile");
 
   string path_mvaWeightFileEleID;
 
@@ -174,194 +163,173 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig)
   string path_X0_Map;
   string path_mvaWeightFileRes;
 
-
   // Reading new EGamma selection cuts
   bool useProtectionsForJetMET(false);
- // Reading new EGamma ubiased collections and value maps
- if(use_EGammaFilters_) {
-   inputTagPFEGammaCandidates_ = consumes<edm::View<reco::PFCandidate> >((iConfig.getParameter<edm::InputTag>("PFEGammaCandidates")));
-   inputTagValueMapGedElectrons_ = consumes<edm::ValueMap<reco::GsfElectronRef>>(iConfig.getParameter<edm::InputTag>("GedElectronValueMap")); 
-   inputTagValueMapGedPhotons_ = consumes<edm::ValueMap<reco::PhotonRef> >(iConfig.getParameter<edm::InputTag>("GedPhotonValueMap")); 
-   useProtectionsForJetMET = iConfig.getParameter<bool>("useProtectionsForJetMET");
- }
+  // Reading new EGamma ubiased collections and value maps
+  if (use_EGammaFilters_) {
+    inputTagPFEGammaCandidates_ =
+        consumes<edm::View<reco::PFCandidate>>((iConfig.getParameter<edm::InputTag>("PFEGammaCandidates")));
+    inputTagValueMapGedElectrons_ =
+        consumes<edm::ValueMap<reco::GsfElectronRef>>(iConfig.getParameter<edm::InputTag>("GedElectronValueMap"));
+    inputTagValueMapGedPhotons_ =
+        consumes<edm::ValueMap<reco::PhotonRef>>(iConfig.getParameter<edm::InputTag>("GedPhotonValueMap"));
+    useProtectionsForJetMET = iConfig.getParameter<bool>("useProtectionsForJetMET");
+  }
 
   //Secondary tracks and displaced vertices parameters
 
-  bool rejectTracks_Bad
-    = iConfig.getParameter<bool>("rejectTracks_Bad");
+  bool rejectTracks_Bad = iConfig.getParameter<bool>("rejectTracks_Bad");
 
-  bool rejectTracks_Step45
-    = iConfig.getParameter<bool>("rejectTracks_Step45");
+  bool rejectTracks_Step45 = iConfig.getParameter<bool>("rejectTracks_Step45");
 
-  bool usePFNuclearInteractions
-    = iConfig.getParameter<bool>("usePFNuclearInteractions");
+  bool usePFNuclearInteractions = iConfig.getParameter<bool>("usePFNuclearInteractions");
 
-  bool usePFConversions
-    = iConfig.getParameter<bool>("usePFConversions");  
+  bool usePFConversions = iConfig.getParameter<bool>("usePFConversions");
 
-  bool usePFDecays
-    = iConfig.getParameter<bool>("usePFDecays");
+  bool usePFDecays = iConfig.getParameter<bool>("usePFDecays");
 
-  double dptRel_DispVtx
-    = iConfig.getParameter<double>("dptRel_DispVtx");
+  double dptRel_DispVtx = iConfig.getParameter<double>("dptRel_DispVtx");
 
-  useCalibrationsFromDB_
-    = iConfig.getParameter<bool>("useCalibrationsFromDB");
+  useCalibrationsFromDB_ = iConfig.getParameter<bool>("useCalibrationsFromDB");
 
   if (useCalibrationsFromDB_)
     calibrationsLabel_ = iConfig.getParameter<std::string>("calibrationsLabel");
 
   // NEW EGamma Filters
-   pfAlgo_.setEGammaParameters(use_EGammaFilters_, useProtectionsForJetMET);
+  pfAlgo_.setEGammaParameters(use_EGammaFilters_, useProtectionsForJetMET);
 
-  if(use_EGammaFilters_) pfegamma_ = std::make_unique<PFEGammaFilters>(iConfig);
-
+  if (use_EGammaFilters_)
+    pfegamma_ = std::make_unique<PFEGammaFilters>(iConfig);
 
   //Secondary tracks and displaced vertices parameters
-  
-  pfAlgo_.setDisplacedVerticesParameters(rejectTracks_Bad,
-					  rejectTracks_Step45,
-					  usePFNuclearInteractions,
- 					  usePFConversions,
-	 				  usePFDecays,
-					  dptRel_DispVtx);
-  
+
+  pfAlgo_.setDisplacedVerticesParameters(
+      rejectTracks_Bad, rejectTracks_Step45, usePFNuclearInteractions, usePFConversions, usePFDecays, dptRel_DispVtx);
+
   if (usePFNuclearInteractions)
-    pfAlgo_.setCandConnectorParameters( iConfig.getParameter<edm::ParameterSet>("iCfgCandConnector") );
+    pfAlgo_.setCandConnectorParameters(iConfig.getParameter<edm::ParameterSet>("iCfgCandConnector"));
 
   //Post cleaning of the HF
-  postHFCleaning_
-    = iConfig.getParameter<bool>("postHFCleaning");
-  double minHFCleaningPt 
-    = iConfig.getParameter<double>("minHFCleaningPt");
-  double minSignificance
-    = iConfig.getParameter<double>("minSignificance");
-  double maxSignificance
-    = iConfig.getParameter<double>("maxSignificance");
-  double minSignificanceReduction
-    = iConfig.getParameter<double>("minSignificanceReduction");
-  double maxDeltaPhiPt
-    = iConfig.getParameter<double>("maxDeltaPhiPt");
-  double minDeltaMet
-    = iConfig.getParameter<double>("minDeltaMet");
+  postHFCleaning_ = iConfig.getParameter<bool>("postHFCleaning");
+  double minHFCleaningPt = iConfig.getParameter<double>("minHFCleaningPt");
+  double minSignificance = iConfig.getParameter<double>("minSignificance");
+  double maxSignificance = iConfig.getParameter<double>("maxSignificance");
+  double minSignificanceReduction = iConfig.getParameter<double>("minSignificanceReduction");
+  double maxDeltaPhiPt = iConfig.getParameter<double>("maxDeltaPhiPt");
+  double minDeltaMet = iConfig.getParameter<double>("minDeltaMet");
 
   // Set post HF cleaning muon parameters
   pfAlgo_.setPostHFCleaningParameters(postHFCleaning_,
-				       minHFCleaningPt,
-				       minSignificance,
-				       maxSignificance,
-				       minSignificanceReduction,
-				       maxDeltaPhiPt,
-				       minDeltaMet);
+                                      minHFCleaningPt,
+                                      minSignificance,
+                                      maxSignificance,
+                                      minSignificanceReduction,
+                                      maxDeltaPhiPt,
+                                      minDeltaMet);
 
   // Input tags for HF cleaned rechits
-  std::vector<edm::InputTag> tags =iConfig.getParameter< std::vector<edm::InputTag> >("cleanedHF");
-  for (unsigned int i=0;i<tags.size();++i)
-    inputTagCleanedHF_.push_back(consumes<reco::PFRecHitCollection>(tags[i])); 
+  std::vector<edm::InputTag> tags = iConfig.getParameter<std::vector<edm::InputTag>>("cleanedHF");
+  for (unsigned int i = 0; i < tags.size(); ++i)
+    inputTagCleanedHF_.push_back(consumes<reco::PFRecHitCollection>(tags[i]));
   //MIKE: Vertex Parameters
   vertices_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"));
   useVerticesForNeutral_ = iConfig.getParameter<bool>("useVerticesForNeutral");
 
   // Use HO clusters and links in the PF reconstruction
-  useHO_= iConfig.getParameter<bool>("useHO");
+  useHO_ = iConfig.getParameter<bool>("useHO");
   pfAlgo_.setHOTag(useHO_);
 
-  verbose_ = 
-    iConfig.getUntrackedParameter<bool>("verbose",false);
+  verbose_ = iConfig.getUntrackedParameter<bool>("verbose", false);
 }
 
-
-void 
-PFProducer::beginRun(const edm::Run & run, 
-		     const edm::EventSetup & es) 
-{
-
-  if ( useCalibrationsFromDB_ ) { 
+void PFProducer::beginRun(const edm::Run& run, const edm::EventSetup& es) {
+  if (useCalibrationsFromDB_) {
     // read the PFCalibration functions from the global tags
     edm::ESHandle<PerformancePayload> perfH;
     es.get<PFCalibrationRcd>().get(calibrationsLabel_, perfH);
 
-    PerformancePayloadFromTFormula const * pfCalibrations = static_cast< const PerformancePayloadFromTFormula *>(perfH.product());
-    
+    PerformancePayloadFromTFormula const* pfCalibrations =
+        static_cast<const PerformancePayloadFromTFormula*>(perfH.product());
+
     pfEnergyCalibration_.setCalibrationFunctions(pfCalibrations);
   }
 }
 
-
-void 
-PFProducer::produce(Event& iEvent, const EventSetup& iSetup)
-{
-  LogDebug("PFProducer")<<"START event: " <<iEvent.id().event() <<" in run "<<iEvent.id().run()<<endl;
+void PFProducer::produce(Event& iEvent, const EventSetup& iSetup) {
+  LogDebug("PFProducer") << "START event: " << iEvent.id().event() << " in run " << iEvent.id().run() << endl;
 
   //Assign the PFAlgo Parameters
   pfAlgo_.setPFVertexParameters(useVerticesForNeutral_, iEvent.get(vertices_));
 
-  // get the collection of blocks 
-  auto blocks = iEvent.getHandle( inputTagBlocks_);
-  assert( blocks.isValid() );
+  // get the collection of blocks
+  auto blocks = iEvent.getHandle(inputTagBlocks_);
+  assert(blocks.isValid());
 
-  // get the collection of muons 
-  if ( postMuonCleaning_ ) pfAlgo_.setMuonHandle( iEvent.getHandle(inputTagMuons_) );
+  // get the collection of muons
+  if (postMuonCleaning_)
+    pfAlgo_.setMuonHandle(iEvent.getHandle(inputTagMuons_));
 
-  if(use_EGammaFilters_) pfAlgo_.setEGammaCollections( iEvent.get(inputTagPFEGammaCandidates_),
-                                                        iEvent.get(inputTagValueMapGedElectrons_),
-                                                        iEvent.get(inputTagValueMapGedPhotons_));
+  if (use_EGammaFilters_)
+    pfAlgo_.setEGammaCollections(iEvent.get(inputTagPFEGammaCandidates_),
+                                 iEvent.get(inputTagValueMapGedElectrons_),
+                                 iEvent.get(inputTagValueMapGedPhotons_));
 
+  LogDebug("PFProducer") << "particle flow is starting" << endl;
 
-  LogDebug("PFProducer")<<"particle flow is starting"<<endl;
+  pfAlgo_.reconstructParticles(blocks, pfegamma_.get());
 
-  pfAlgo_.reconstructParticles( blocks, pfegamma_.get() );
-  
-  if(verbose_) {
-    ostringstream  str;
-    str<< pfAlgo_ <<endl;
-    LogInfo("PFProducer") <<str.str()<<endl;
-  }  
+  if (verbose_) {
+    ostringstream str;
+    str << pfAlgo_ << endl;
+    LogInfo("PFProducer") << str.str() << endl;
+  }
 
   // Check HF overcleaning
   if (postHFCleaning_) {
     reco::PFRecHitCollection hfCopy;
-    for ( unsigned ihf=0; ihf<inputTagCleanedHF_.size(); ++ihf ) {
-      Handle< reco::PFRecHitCollection > hfCleaned;
-      bool foundHF = iEvent.getByToken( inputTagCleanedHF_[ihf], hfCleaned );  
-      if (!foundHF) continue;
-      for ( unsigned jhf=0; jhf<(*hfCleaned).size(); ++jhf ) { 
-        hfCopy.push_back( (*hfCleaned)[jhf] );
+    for (unsigned ihf = 0; ihf < inputTagCleanedHF_.size(); ++ihf) {
+      Handle<reco::PFRecHitCollection> hfCleaned;
+      bool foundHF = iEvent.getByToken(inputTagCleanedHF_[ihf], hfCleaned);
+      if (!foundHF)
+        continue;
+      for (unsigned jhf = 0; jhf < (*hfCleaned).size(); ++jhf) {
+        hfCopy.push_back((*hfCleaned)[jhf]);
       }
     }
-    pfAlgo_.checkCleaning( hfCopy );
+    pfAlgo_.checkCleaning(hfCopy);
   }
 
   // Save the final PFCandidate collection
   auto pOutputCandidateCollection = pfAlgo_.makeConnectedCandidates();
 
-  LogDebug("PFProducer")<<"particle flow: putting products in the event"<<endl;
-  if ( verbose_ ) std::cout <<"particle flow: putting products in the event. Here the full list"<<endl;
-  int nC=0;
-  for(auto const& cand : pOutputCandidateCollection) {
+  LogDebug("PFProducer") << "particle flow: putting products in the event" << endl;
+  if (verbose_)
+    std::cout << "particle flow: putting products in the event. Here the full list" << endl;
+  int nC = 0;
+  for (auto const& cand : pOutputCandidateCollection) {
     nC++;
-      if (verbose_ ) std::cout << nC << ")" << cand.particleId() << std::endl;
-
+    if (verbose_)
+      std::cout << nC << ")" << cand.particleId() << std::endl;
   }
 
   // Write in the event
-  iEvent.emplace(pfCandidatesToken_,pOutputCandidateCollection);
+  iEvent.emplace(pfCandidatesToken_, pOutputCandidateCollection);
   iEvent.emplace(pfCleanedCandidatesToken_, pfAlgo_.getCleanedCandidates());
 
-  if ( postMuonCleaning_ ) { 
+  if (postMuonCleaning_) {
     auto& muAlgo = *pfAlgo_.getPFMuonAlgo();
 
     // Save cosmic cleaned muon candidates
-    iEvent.put(muAlgo.transferCleanedCosmicCandidates(),"CleanedCosmicsMuons");
+    iEvent.put(muAlgo.transferCleanedCosmicCandidates(), "CleanedCosmicsMuons");
     // Save tracker/global cleaned muon candidates
-    iEvent.put(muAlgo.transferCleanedTrackerAndGlobalCandidates(),"CleanedTrackerAndGlobalMuons");
+    iEvent.put(muAlgo.transferCleanedTrackerAndGlobalCandidates(), "CleanedTrackerAndGlobalMuons");
     // Save fake cleaned muon candidates
-    iEvent.put(muAlgo.transferCleanedFakeCandidates(),"CleanedFakeMuons");
+    iEvent.put(muAlgo.transferCleanedFakeCandidates(), "CleanedFakeMuons");
     // Save punch-through cleaned muon candidates
-    iEvent.put(muAlgo.transferPunchThroughCleanedMuonCandidates(),"CleanedPunchThroughMuons");
+    iEvent.put(muAlgo.transferPunchThroughCleanedMuonCandidates(), "CleanedPunchThroughMuons");
     // Save punch-through cleaned neutral hadron candidates
-    iEvent.put(muAlgo.transferPunchThroughCleanedHadronCandidates(),"CleanedPunchThroughNeutralHadrons");
+    iEvent.put(muAlgo.transferPunchThroughCleanedHadronCandidates(), "CleanedPunchThroughNeutralHadrons");
     // Save added muon candidates
-    iEvent.put(muAlgo.transferAddedMuonCandidates(),"AddedMuonsAndHadrons");
+    iEvent.put(muAlgo.transferAddedMuonCandidates(), "AddedMuonsAndHadrons");
   }
 }

--- a/RecoParticleFlow/PFProducer/plugins/importers/ConvBremTrackImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/ConvBremTrackImporter.cc
@@ -4,22 +4,16 @@
 namespace {
   class ConvBremAdaptor {
   public:
-    static bool check_importable(const reco::GsfPFRecTrackCollection::value_type& t) {
-      return true;
-    }
-    static const std::vector<reco::PFRecTrackRef>& 
-    get_track_refs(const reco::GsfPFRecTrackCollection::value_type& t) {
+    static bool check_importable(const reco::GsfPFRecTrackCollection::value_type& t) { return true; }
+    static const std::vector<reco::PFRecTrackRef>& get_track_refs(const reco::GsfPFRecTrackCollection::value_type& t) {
       return t.convBremPFRecTrackRef();
     }
-    static void set_element_info(reco::PFBlockElement* elem,
-				 const edm::Ref<reco::GsfPFRecTrackCollection>& parref) {
-	elem->setTrackType(reco::PFBlockElement::T_FROM_GAMMACONV, true);
+    static void set_element_info(reco::PFBlockElement* elem, const edm::Ref<reco::GsfPFRecTrackCollection>& parref) {
+      elem->setTrackType(reco::PFBlockElement::T_FROM_GAMMACONV, true);
     }
-  };  
-}
+  };
+}  // namespace
 
-typedef pflow::importers::TrackFromParentImporter<reco::GsfPFRecTrackCollection,ConvBremAdaptor> ConvBremTrackImporter;
+typedef pflow::importers::TrackFromParentImporter<reco::GsfPFRecTrackCollection, ConvBremAdaptor> ConvBremTrackImporter;
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  ConvBremTrackImporter, 
-		  "ConvBremTrackImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, ConvBremTrackImporter, "ConvBremTrackImporter");

--- a/RecoParticleFlow/PFProducer/plugins/importers/ConversionTrackImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/ConversionTrackImporter.cc
@@ -8,20 +8,16 @@ namespace {
     static bool check_importable(const reco::PFConversionCollection::value_type& t) {
       return (t.pfTracks().size() >= 2);
     }
-    static const std::vector<reco::PFRecTrackRef>& 
-    get_track_refs(const reco::PFConversionCollection::value_type& t) {
+    static const std::vector<reco::PFRecTrackRef>& get_track_refs(const reco::PFConversionCollection::value_type& t) {
       return t.pfTracks();
     }
-    static void set_element_info(reco::PFBlockElement* elem,
-				 const edm::Ref<reco::PFConversionCollection>& parref) {
-      elem->setConversionRef(parref->originalConversion(),
-			     reco::PFBlockElement::T_FROM_GAMMACONV);
+    static void set_element_info(reco::PFBlockElement* elem, const edm::Ref<reco::PFConversionCollection>& parref) {
+      elem->setConversionRef(parref->originalConversion(), reco::PFBlockElement::T_FROM_GAMMACONV);
     }
   };
-}
+}  // namespace
 
-typedef pflow::importers::TrackFromParentImporter<reco::PFConversionCollection,ConversionAdaptor> ConversionTrackImporter;
+typedef pflow::importers::TrackFromParentImporter<reco::PFConversionCollection, ConversionAdaptor>
+    ConversionTrackImporter;
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  ConversionTrackImporter, 
-		  "ConversionTrackImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, ConversionTrackImporter, "ConversionTrackImporter");

--- a/RecoParticleFlow/PFProducer/plugins/importers/EGPhotonImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/EGPhotonImporter.cc
@@ -12,38 +12,31 @@
 
 class EGPhotonImporter : public BlockElementImporterBase {
 public:
-  enum SelectionChoices {SeparateDetectorIso,CombinedDetectorIso};
+  enum SelectionChoices { SeparateDetectorIso, CombinedDetectorIso };
 
-  EGPhotonImporter(const edm::ParameterSet&,edm::ConsumesCollector&);
-  
-  void importToBlock( const edm::Event& ,
-		      ElementList& ) const override;
+  EGPhotonImporter(const edm::ParameterSet&, edm::ConsumesCollector&);
+
+  void importToBlock(const edm::Event&, ElementList&) const override;
 
 private:
   edm::EDGetTokenT<reco::PhotonCollection> _src;
-  const std::unordered_map<std::string,SelectionChoices> _selectionTypes;
+  const std::unordered_map<std::string, SelectionChoices> _selectionTypes;
   SelectionChoices _selectionChoice;
   std::unique_ptr<const PhotonSelectorAlgo> _selector;
   bool _superClustersArePF;
-  
 };
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  EGPhotonImporter, 
-		  "EGPhotonImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, EGPhotonImporter, "EGPhotonImporter");
 
-EGPhotonImporter::EGPhotonImporter(const edm::ParameterSet& conf,
-				   edm::ConsumesCollector& sumes) :
-    BlockElementImporterBase(conf,sumes),
-    _src(sumes.consumes<reco::PhotonCollection>(conf.getParameter<edm::InputTag>("source"))),
-    _selectionTypes({ {"SeparateDetectorIso",EGPhotonImporter::SeparateDetectorIso},
-	  {"CombinedDetectorIso",EGPhotonImporter::CombinedDetectorIso} }),
-    _superClustersArePF(conf.getParameter<bool>("superClustersArePF")) {
-  const std::string& selChoice = 
-    conf.getParameter<std::string>("SelectionChoice");
+EGPhotonImporter::EGPhotonImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+    : BlockElementImporterBase(conf, sumes),
+      _src(sumes.consumes<reco::PhotonCollection>(conf.getParameter<edm::InputTag>("source"))),
+      _selectionTypes({{"SeparateDetectorIso", EGPhotonImporter::SeparateDetectorIso},
+                       {"CombinedDetectorIso", EGPhotonImporter::CombinedDetectorIso}}),
+      _superClustersArePF(conf.getParameter<bool>("superClustersArePF")) {
+  const std::string& selChoice = conf.getParameter<std::string>("SelectionChoice");
   _selectionChoice = _selectionTypes.at(selChoice);
-  const edm::ParameterSet& selDef = 
-    conf.getParameterSet("SelectionDefinition");
+  const edm::ParameterSet& selDef = conf.getParameterSet("SelectionDefinition");
   const float minEt = selDef.getParameter<double>("minEt");
   const float trackIso_const = selDef.getParameter<double>("trackIsoConstTerm");
   const float trackIso_slope = selDef.getParameter<double>("trackIsoSlopeTerm");
@@ -55,58 +48,57 @@ EGPhotonImporter::EGPhotonImporter(const edm::ParameterSet& conf,
   const float loose_hoe = selDef.getParameter<double>("LooseHoverE");
   const float combIso = selDef.getParameter<double>("combIsoConstTerm");
   _selector.reset(new PhotonSelectorAlgo((float)_selectionChoice,
-					 minEt,
-					 trackIso_const, trackIso_slope,
-					 ecalIso_const, ecalIso_slope,
-					 hcalIso_const, hcalIso_slope,
-					 hoe,
-					 combIso,
-					 loose_hoe));
+                                         minEt,
+                                         trackIso_const,
+                                         trackIso_slope,
+                                         ecalIso_const,
+                                         ecalIso_slope,
+                                         hcalIso_const,
+                                         hcalIso_slope,
+                                         hoe,
+                                         combIso,
+                                         loose_hoe));
 }
 
-void EGPhotonImporter::
-importToBlock( const edm::Event& e, 
-	       BlockElementImporterBase::ElementList& elems ) const {
-  typedef BlockElementImporterBase::ElementList::value_type ElementType;  
+void EGPhotonImporter::importToBlock(const edm::Event& e, BlockElementImporterBase::ElementList& elems) const {
+  typedef BlockElementImporterBase::ElementList::value_type ElementType;
   auto photons = e.getHandle(_src);
-  elems.reserve(elems.size()+photons->size());
+  elems.reserve(elems.size() + photons->size());
   // setup our elements so that all the SCs are grouped together
-  auto SCs_end = std::partition(elems.begin(),elems.end(),
-				[](const ElementType& a){
-				  return a->type() == reco::PFBlockElement::SC;
-				});  
+  auto SCs_end = std::partition(
+      elems.begin(), elems.end(), [](const ElementType& a) { return a->type() == reco::PFBlockElement::SC; });
   //now add the photons
   auto bphoton = photons->cbegin();
   auto ephoton = photons->cend();
   reco::PFBlockElementSuperCluster* scbe = nullptr;
   reco::PhotonRef phoref;
-  for( auto photon = bphoton; photon != ephoton; ++photon ) {
-    if( _selector->passPhotonSelection(*photon) ) {
-      phoref = reco::PhotonRef(photons,std::distance(bphoton,photon));
+  for (auto photon = bphoton; photon != ephoton; ++photon) {
+    if (_selector->passPhotonSelection(*photon)) {
+      phoref = reco::PhotonRef(photons, std::distance(bphoton, photon));
       const reco::SuperClusterRef& scref = photon->superCluster();
       PFBlockElementSCEqual myEqual(scref);
-      auto sc_elem = std::find_if(elems.begin(),SCs_end,myEqual);
-      if( sc_elem != SCs_end ) {
-	scbe = static_cast<reco::PFBlockElementSuperCluster*>(sc_elem->get());
-	scbe->setFromPhoton(true);
-	scbe->setPhotonRef(phoref);
-	scbe->setTrackIso(photon->trkSumPtHollowConeDR04());
-	scbe->setEcalIso(photon->ecalRecHitSumEtConeDR04());
-	scbe->setHcalIso(photon->hcalTowerSumEtConeDR04());
-	scbe->setHoE(photon->hadronicOverEm());
+      auto sc_elem = std::find_if(elems.begin(), SCs_end, myEqual);
+      if (sc_elem != SCs_end) {
+        scbe = static_cast<reco::PFBlockElementSuperCluster*>(sc_elem->get());
+        scbe->setFromPhoton(true);
+        scbe->setPhotonRef(phoref);
+        scbe->setTrackIso(photon->trkSumPtHollowConeDR04());
+        scbe->setEcalIso(photon->ecalRecHitSumEtConeDR04());
+        scbe->setHcalIso(photon->hcalTowerSumEtConeDR04());
+        scbe->setHoE(photon->hadronicOverEm());
       } else {
-	scbe = new reco::PFBlockElementSuperCluster(scref);
-	scbe->setFromPhoton(true);
-	scbe->setFromPFSuperCluster(_superClustersArePF);
-	scbe->setPhotonRef(phoref);
-	scbe->setTrackIso(photon->trkSumPtHollowConeDR04());
-	scbe->setEcalIso(photon->ecalRecHitSumEtConeDR04());
-	scbe->setHcalIso(photon->hcalTowerSumEtConeDR04());
-	scbe->setHoE(photon->hadronicOverEm());
-	SCs_end = elems.insert(SCs_end,ElementType(scbe));
-	++SCs_end; // point to element *after* the new one
+        scbe = new reco::PFBlockElementSuperCluster(scref);
+        scbe->setFromPhoton(true);
+        scbe->setFromPFSuperCluster(_superClustersArePF);
+        scbe->setPhotonRef(phoref);
+        scbe->setTrackIso(photon->trkSumPtHollowConeDR04());
+        scbe->setEcalIso(photon->ecalRecHitSumEtConeDR04());
+        scbe->setHcalIso(photon->hcalTowerSumEtConeDR04());
+        scbe->setHoE(photon->hadronicOverEm());
+        SCs_end = elems.insert(SCs_end, ElementType(scbe));
+        ++SCs_end;  // point to element *after* the new one
       }
     }
-  }// loop on photons
+  }  // loop on photons
   elems.shrink_to_fit();
 }

--- a/RecoParticleFlow/PFProducer/plugins/importers/GSFTrackImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GSFTrackImporter.cc
@@ -13,106 +13,95 @@
 
 class GSFTrackImporter : public BlockElementImporterBase {
 public:
-  GSFTrackImporter(const edm::ParameterSet& conf,
-		    edm::ConsumesCollector& sumes) :
-    BlockElementImporterBase(conf,sumes),
-    _src(sumes.consumes<reco::GsfPFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
-    _isSecondary(conf.getParameter<bool>("gsfsAreSecondary")),
-    _superClustersArePF(conf.getParameter<bool>("superClustersArePF")){}
-  
-  void importToBlock( const edm::Event& ,
-		      ElementList& ) const override;
+  GSFTrackImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : BlockElementImporterBase(conf, sumes),
+        _src(sumes.consumes<reco::GsfPFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
+        _isSecondary(conf.getParameter<bool>("gsfsAreSecondary")),
+        _superClustersArePF(conf.getParameter<bool>("superClustersArePF")) {}
+
+  void importToBlock(const edm::Event&, ElementList&) const override;
 
 private:
   edm::EDGetTokenT<reco::GsfPFRecTrackCollection> _src;
   const bool _isSecondary, _superClustersArePF;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  GSFTrackImporter, 
-		  "GSFTrackImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, GSFTrackImporter, "GSFTrackImporter");
 
-void GSFTrackImporter::
-importToBlock( const edm::Event& e, 
-	       BlockElementImporterBase::ElementList& elems ) const {
+void GSFTrackImporter::importToBlock(const edm::Event& e, BlockElementImporterBase::ElementList& elems) const {
   auto gsftracks = e.getHandle(_src);
   elems.reserve(elems.size() + gsftracks->size());
   // setup our elements so that all the SCs are grouped together
-  auto SCs_end = std::partition(elems.begin(),elems.end(),
-				[](const auto& a){
-				  return a->type() == reco::PFBlockElement::SC;
-				});
+  auto SCs_end =
+      std::partition(elems.begin(), elems.end(), [](const auto& a) { return a->type() == reco::PFBlockElement::SC; });
   // insert gsf tracks and SCs, binding pre-existing SCs to ECAL-Driven GSF
   auto bgsf = gsftracks->cbegin();
   auto egsf = gsftracks->cend();
-  for( auto gsftrack =  bgsf; gsftrack != egsf; ++gsftrack ) {
-    reco::GsfPFRecTrackRef gsfref(gsftracks,std::distance(bgsf,gsftrack));
-    const reco::GsfTrackRef& basegsfref = gsftrack->gsfTrackRef();    
+  for (auto gsftrack = bgsf; gsftrack != egsf; ++gsftrack) {
+    reco::GsfPFRecTrackRef gsfref(gsftracks, std::distance(bgsf, gsftrack));
+    const reco::GsfTrackRef& basegsfref = gsftrack->gsfTrackRef();
     const auto& gsfextraref = basegsfref->extra();
     // import associated super clusters
-    if( gsfextraref.isAvailable() && gsfextraref->seedRef().isAvailable()) {
-      reco::ElectronSeedRef seedref = 
-	gsfextraref->seedRef().castTo<reco::ElectronSeedRef>();
-      if( seedref.isAvailable() && seedref->isEcalDriven() ) {
-	reco::SuperClusterRef scref = 
-	  seedref->caloCluster().castTo<reco::SuperClusterRef>();
-	if( scref.isNonnull() ) {
-	  // explicitly veto HGCal super clusters
-	  if( scref->seed()->seed().det() == DetId::Forward ) continue;
-	  PFBlockElementSCEqual myEqual(scref);
-	  auto sc_elem = std::find_if(elems.begin(),SCs_end,myEqual);
-	  if( sc_elem != SCs_end ) {
-	    reco::PFBlockElementSuperCluster* scbe = 
-	      static_cast<reco::PFBlockElementSuperCluster*>(sc_elem->get());
-	    scbe->setFromGsfElectron(true);
-	  } else {
-	    reco::PFBlockElementSuperCluster* scbe = 
-	      new reco::PFBlockElementSuperCluster(scref);
-	    scbe->setFromGsfElectron(true);
-	    scbe->setFromPFSuperCluster(_superClustersArePF);
-	    SCs_end = elems.emplace(SCs_end,scbe);
-	    ++SCs_end; // point to element *after* the new one
-	  }
-	} 		   
+    if (gsfextraref.isAvailable() && gsfextraref->seedRef().isAvailable()) {
+      reco::ElectronSeedRef seedref = gsfextraref->seedRef().castTo<reco::ElectronSeedRef>();
+      if (seedref.isAvailable() && seedref->isEcalDriven()) {
+        reco::SuperClusterRef scref = seedref->caloCluster().castTo<reco::SuperClusterRef>();
+        if (scref.isNonnull()) {
+          // explicitly veto HGCal super clusters
+          if (scref->seed()->seed().det() == DetId::Forward)
+            continue;
+          PFBlockElementSCEqual myEqual(scref);
+          auto sc_elem = std::find_if(elems.begin(), SCs_end, myEqual);
+          if (sc_elem != SCs_end) {
+            reco::PFBlockElementSuperCluster* scbe = static_cast<reco::PFBlockElementSuperCluster*>(sc_elem->get());
+            scbe->setFromGsfElectron(true);
+          } else {
+            reco::PFBlockElementSuperCluster* scbe = new reco::PFBlockElementSuperCluster(scref);
+            scbe->setFromGsfElectron(true);
+            scbe->setFromPFSuperCluster(_superClustersArePF);
+            SCs_end = elems.emplace(SCs_end, scbe);
+            ++SCs_end;  // point to element *after* the new one
+          }
+        }
       }
-    }// gsf extra ref?
+    }  // gsf extra ref?
     // cache the SC_end offset
-    size_t SCs_end_position = std::distance(elems.begin(),SCs_end);
+    size_t SCs_end_position = std::distance(elems.begin(), SCs_end);
     // get track momentum information
     const std::vector<reco::PFTrajectoryPoint>& PfGsfPoint = gsftrack->trajectoryPoints();
-    unsigned int c_gsf=0;
+    unsigned int c_gsf = 0;
     bool PassTracker = false;
     unsigned int IndexPout = 0;
-    for(const auto& pfGsfPoint : PfGsfPoint) {      
-      if (pfGsfPoint.isValid()){
-	int layGsfP = pfGsfPoint.layer();
-	if (layGsfP == -1) PassTracker = true;
-	else if (PassTracker && layGsfP > 0) {
-	  IndexPout = c_gsf-1;
-	  break;
-	}
-	++c_gsf;
+    for (const auto& pfGsfPoint : PfGsfPoint) {
+      if (pfGsfPoint.isValid()) {
+        int layGsfP = pfGsfPoint.layer();
+        if (layGsfP == -1)
+          PassTracker = true;
+        else if (PassTracker && layGsfP > 0) {
+          IndexPout = c_gsf - 1;
+          break;
+        }
+        ++c_gsf;
       }
     }
-    const math::XYZTLorentzVector& pin = PfGsfPoint[0].momentum();      
+    const math::XYZTLorentzVector& pin = PfGsfPoint[0].momentum();
     const math::XYZTLorentzVector& pout = PfGsfPoint[IndexPout].momentum();
-    reco::PFBlockElementGsfTrack* temp =
-      new reco::PFBlockElementGsfTrack(gsfref,pin,pout);
-    if( _isSecondary ) {
-      temp->setTrackType(reco::PFBlockElement::T_FROM_GAMMACONV,true);
+    reco::PFBlockElementGsfTrack* temp = new reco::PFBlockElementGsfTrack(gsfref, pin, pout);
+    if (_isSecondary) {
+      temp->setTrackType(reco::PFBlockElement::T_FROM_GAMMACONV, true);
     }
     elems.emplace_back(temp);
     // import brems from this primary gsf
-    for( const auto& brem : gsfref->PFRecBrem() ) {
+    for (const auto& brem : gsfref->PFRecBrem()) {
       const unsigned TrajP = brem.indTrajPoint();
-      if( TrajP != 99 ) {
-	const double DP = brem.DeltaP();
-	const double sDP = brem.SigmaDeltaP();
-	elems.emplace_back(new reco::PFBlockElementBrem(gsfref,DP,sDP,TrajP));
+      if (TrajP != 99) {
+        const double DP = brem.DeltaP();
+        const double sDP = brem.SigmaDeltaP();
+        elems.emplace_back(new reco::PFBlockElementBrem(gsfref, DP, sDP, TrajP));
       }
     }
     // protect against reallocations, create a fresh iterator
     SCs_end = elems.begin() + SCs_end_position;
-  }// loop on gsf tracks
+  }  // loop on gsf tracks
   elems.shrink_to_fit();
 }

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -11,145 +11,128 @@
 
 class GeneralTracksImporter : public BlockElementImporterBase {
 public:
-  GeneralTracksImporter(const edm::ParameterSet& conf,
-		    edm::ConsumesCollector& sumes) :
-    BlockElementImporterBase(conf,sumes),
-    src_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
-    muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
-    DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
-    NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),    
-    useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
-    cleanBadConvBrems_(conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false),
-    debug_(conf.getUntrackedParameter<bool>("debug",false)) {
-    
+  GeneralTracksImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : BlockElementImporterBase(conf, sumes),
+        src_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
+        muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
+        DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
+        NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
+        useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
+        cleanBadConvBrems_(
+            conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false),
+        debug_(conf.getUntrackedParameter<bool>("debug", false)) {
     pfmu_ = std::unique_ptr<PFMuonAlgo>(new PFMuonAlgo(conf));
-    
   }
-  
-  void importToBlock( const edm::Event& ,
-		      ElementList& ) const override;
+
+  void importToBlock(const edm::Event&, ElementList&) const override;
 
 private:
-  int muAssocToTrack( const reco::TrackRef& trackref,
-		      const edm::Handle<reco::MuonCollection>& muonh) const;
+  int muAssocToTrack(const reco::TrackRef& trackref, const edm::Handle<reco::MuonCollection>& muonh) const;
 
   edm::EDGetTokenT<reco::PFRecTrackCollection> src_;
   edm::EDGetTokenT<reco::MuonCollection> muons_;
   const std::vector<double> DPtovPtCut_;
   const std::vector<unsigned> NHitCut_;
-  const bool useIterTracking_,cleanBadConvBrems_,debug_;
+  const bool useIterTracking_, cleanBadConvBrems_, debug_;
 
   std::unique_ptr<PFMuonAlgo> pfmu_;
-
 };
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  GeneralTracksImporter, 
-		  "GeneralTracksImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, GeneralTracksImporter, "GeneralTracksImporter");
 
-void GeneralTracksImporter::
-importToBlock( const edm::Event& e, 
-	       BlockElementImporterBase::ElementList& elems ) const {
-  typedef BlockElementImporterBase::ElementList::value_type ElementType;  
+void GeneralTracksImporter::importToBlock(const edm::Event& e, BlockElementImporterBase::ElementList& elems) const {
+  typedef BlockElementImporterBase::ElementList::value_type ElementType;
   auto tracks = e.getHandle(src_);
   auto muons = e.getHandle(muons_);
   elems.reserve(elems.size() + tracks->size());
-  std::vector<bool> mask(tracks->size(),true);
+  std::vector<bool> mask(tracks->size(), true);
   reco::MuonRef muonref;
-  
+
   // remove converted brems with bad pT resolution if requested
   // this reproduces the old behavior of PFBlockAlgo
-  if( cleanBadConvBrems_ ) {
+  if (cleanBadConvBrems_) {
     auto itr = elems.begin();
-    while( itr != elems.end() ) {
-      if( (*itr)->type() == reco::PFBlockElement::TRACK ) {
-	const reco::PFBlockElementTrack* trkel =
-	  static_cast<reco::PFBlockElementTrack*>(itr->get());
-	const reco::ConversionRefVector& cRef = trkel->convRefs();
-	const reco::PFDisplacedTrackerVertexRef& dvRef = 
-	  trkel->displacedVertexRef(reco::PFBlockElement::T_FROM_DISP);
-	const reco::VertexCompositeCandidateRef& v0Ref =
-	  trkel->V0Ref();
-	// if there is no displaced vertex reference  and it is marked
-	// as a conversion it's gotta be a converted brem
-	if( trkel->trackType(reco::PFBlockElement::T_FROM_GAMMACONV) &&
-	    cRef.empty() && dvRef.isNull() && v0Ref.isNull() ) {
-	  // if the Pt resolution is bad we kill this element
-	  if( !PFTrackAlgoTools::goodPtResolution( trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_ ) ) {
-	    itr = elems.erase(itr);
-	    continue;
-	  }
-	}
+    while (itr != elems.end()) {
+      if ((*itr)->type() == reco::PFBlockElement::TRACK) {
+        const reco::PFBlockElementTrack* trkel = static_cast<reco::PFBlockElementTrack*>(itr->get());
+        const reco::ConversionRefVector& cRef = trkel->convRefs();
+        const reco::PFDisplacedTrackerVertexRef& dvRef = trkel->displacedVertexRef(reco::PFBlockElement::T_FROM_DISP);
+        const reco::VertexCompositeCandidateRef& v0Ref = trkel->V0Ref();
+        // if there is no displaced vertex reference  and it is marked
+        // as a conversion it's gotta be a converted brem
+        if (trkel->trackType(reco::PFBlockElement::T_FROM_GAMMACONV) && cRef.empty() && dvRef.isNull() &&
+            v0Ref.isNull()) {
+          // if the Pt resolution is bad we kill this element
+          if (!PFTrackAlgoTools::goodPtResolution(trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_)) {
+            itr = elems.erase(itr);
+            continue;
+          }
+        }
       }
       ++itr;
-    } // loop on existing elements
+    }  // loop on existing elements
   }
   // preprocess existing tracks in the element list and create a mask
-  // so that we do not import tracks twice, tag muons we find 
-  // in this collection  
-  auto TKs_end = std::partition(elems.begin(),elems.end(),
-				[](const ElementType& a){
-			        return a->type() == reco::PFBlockElement::TRACK;
-				});  
+  // so that we do not import tracks twice, tag muons we find
+  // in this collection
+  auto TKs_end = std::partition(
+      elems.begin(), elems.end(), [](const ElementType& a) { return a->type() == reco::PFBlockElement::TRACK; });
   auto btk_elems = elems.begin();
   auto btrack = tracks->cbegin();
   auto etrack = tracks->cend();
-  for( auto track = btrack;  track != etrack; ++track) {
-    auto tk_elem = std::find_if(btk_elems,TKs_end,
-				[&](const ElementType& a){
-				  return ( a->trackRef() == 
-					   track->trackRef() );
-				});
-    if( tk_elem != TKs_end ) {
-      mask[std::distance(tracks->cbegin(),track)] = false;
+  for (auto track = btrack; track != etrack; ++track) {
+    auto tk_elem =
+        std::find_if(btk_elems, TKs_end, [&](const ElementType& a) { return (a->trackRef() == track->trackRef()); });
+    if (tk_elem != TKs_end) {
+      mask[std::distance(tracks->cbegin(), track)] = false;
       // check and update if this track is a muon
-      const int muId = muAssocToTrack( (*tk_elem)->trackRef(), muons );
-      if( muId != -1 ) {
-	muonref= reco::MuonRef( muons, muId );
-	if( PFMuonAlgo::isLooseMuon(muonref) || PFMuonAlgo::isMuon(muonref) ) {
-	  static_cast<reco::PFBlockElementTrack*>(tk_elem->get())->setMuonRef(muonref);
-	}
+      const int muId = muAssocToTrack((*tk_elem)->trackRef(), muons);
+      if (muId != -1) {
+        muonref = reco::MuonRef(muons, muId);
+        if (PFMuonAlgo::isLooseMuon(muonref) || PFMuonAlgo::isMuon(muonref)) {
+          static_cast<reco::PFBlockElementTrack*>(tk_elem->get())->setMuonRef(muonref);
+        }
       }
-    }    
+    }
   }
   // now we actually insert tracks, again tagging muons along the way
-  reco::PFRecTrackRef pftrackref;  
+  reco::PFRecTrackRef pftrackref;
   reco::PFBlockElementTrack* trkElem = nullptr;
-  for( auto track = btrack;  track != etrack; ++track) {
-    const unsigned idx = std::distance(btrack,track);
+  for (auto track = btrack; track != etrack; ++track) {
+    const unsigned idx = std::distance(btrack, track);
     // since we already set muon refs in the previously imported tracks,
-    // here we can skip everything that is already imported 
-    if( !mask[idx] ) continue; 
+    // here we can skip everything that is already imported
+    if (!mask[idx])
+      continue;
     muonref = reco::MuonRef();
-    pftrackref = reco::PFRecTrackRef(tracks,idx);    
+    pftrackref = reco::PFRecTrackRef(tracks, idx);
     // Get the eventual muon associated to this track
-    const int muId = muAssocToTrack( pftrackref->trackRef(), muons );
+    const int muId = muAssocToTrack(pftrackref->trackRef(), muons);
     bool thisIsAPotentialMuon = false;
-    if( muId != -1 ) {
-      muonref= reco::MuonRef( muons, muId );
-      thisIsAPotentialMuon = ( (pfmu_->hasValidTrack(muonref,true)&&PFMuonAlgo::isLooseMuon(muonref)) || 
-			       (pfmu_->hasValidTrack(muonref,false)&&PFMuonAlgo::isMuon(muonref)));
+    if (muId != -1) {
+      muonref = reco::MuonRef(muons, muId);
+      thisIsAPotentialMuon = ((pfmu_->hasValidTrack(muonref, true) && PFMuonAlgo::isLooseMuon(muonref)) ||
+                              (pfmu_->hasValidTrack(muonref, false) && PFMuonAlgo::isMuon(muonref)));
     }
-    if(thisIsAPotentialMuon || PFTrackAlgoTools::goodPtResolution( pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_ ) ) {
-      trkElem = new reco::PFBlockElementTrack( pftrackref );
+    if (thisIsAPotentialMuon ||
+        PFTrackAlgoTools::goodPtResolution(pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_)) {
+      trkElem = new reco::PFBlockElementTrack(pftrackref);
       if (thisIsAPotentialMuon && debug_) {
-	std::cout << "Potential Muon P " <<  pftrackref->trackRef()->p() 
-		  << " pt " << pftrackref->trackRef()->p() << std::endl; 
+        std::cout << "Potential Muon P " << pftrackref->trackRef()->p() << " pt " << pftrackref->trackRef()->p()
+                  << std::endl;
       }
-      if( muId != -1 ) trkElem->setMuonRef(muonref);      
+      if (muId != -1)
+        trkElem->setMuonRef(muonref);
       elems.emplace_back(trkElem);
     }
   }
   elems.shrink_to_fit();
 }
 
-int GeneralTracksImporter::
-muAssocToTrack( const reco::TrackRef& trackref,
-		const edm::Handle<reco::MuonCollection>& muonh) const {
-  auto muon = std::find_if(muonh->cbegin(),muonh->cend(),
-			   [&](const reco::Muon& m) {
-			     return ( m.track().isNonnull() && 
-				      m.track() == trackref    );
-			   });  
-  return ( muon != muonh->cend() ? std::distance(muonh->cbegin(),muon) : -1 );
+int GeneralTracksImporter::muAssocToTrack(const reco::TrackRef& trackref,
+                                          const edm::Handle<reco::MuonCollection>& muonh) const {
+  auto muon = std::find_if(muonh->cbegin(), muonh->cend(), [&](const reco::Muon& m) {
+    return (m.track().isNonnull() && m.track() == trackref);
+  });
+  return (muon != muonh->cend() ? std::distance(muonh->cbegin(), muon) : -1);
 }

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
@@ -11,155 +11,139 @@
 
 class GeneralTracksImporterWithVeto : public BlockElementImporterBase {
 public:
-  GeneralTracksImporterWithVeto(const edm::ParameterSet& conf,
-		    edm::ConsumesCollector& sumes) :
-    BlockElementImporterBase(conf,sumes),
-    src_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
-    veto_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("veto"))),
-    muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
-    DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
-    NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),    
-    useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
-    cleanBadConvBrems_(conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false),
-    debug_(conf.getUntrackedParameter<bool>("debug",false)) {
-    
+  GeneralTracksImporterWithVeto(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : BlockElementImporterBase(conf, sumes),
+        src_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
+        veto_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("veto"))),
+        muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
+        DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
+        NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
+        useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
+        cleanBadConvBrems_(
+            conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false),
+        debug_(conf.getUntrackedParameter<bool>("debug", false)) {
     pfmu_ = std::unique_ptr<PFMuonAlgo>(new PFMuonAlgo(conf));
-    
   }
-  
-  void importToBlock( const edm::Event& ,
-		      ElementList& ) const override;
+
+  void importToBlock(const edm::Event&, ElementList&) const override;
 
 private:
-  int muAssocToTrack( const reco::TrackRef& trackref,
-		      const edm::Handle<reco::MuonCollection>& muonh) const;
+  int muAssocToTrack(const reco::TrackRef& trackref, const edm::Handle<reco::MuonCollection>& muonh) const;
 
   edm::EDGetTokenT<reco::PFRecTrackCollection> src_, veto_;
   edm::EDGetTokenT<reco::MuonCollection> muons_;
   const std::vector<double> DPtovPtCut_;
-  const std::vector<unsigned> NHitCut_;  
-  const bool useIterTracking_,cleanBadConvBrems_,debug_;
+  const std::vector<unsigned> NHitCut_;
+  const bool useIterTracking_, cleanBadConvBrems_, debug_;
 
   std::unique_ptr<PFMuonAlgo> pfmu_;
-
 };
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  GeneralTracksImporterWithVeto, 
-		  "GeneralTracksImporterWithVeto");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, GeneralTracksImporterWithVeto, "GeneralTracksImporterWithVeto");
 
-void GeneralTracksImporterWithVeto::
-importToBlock( const edm::Event& e, 
-	       BlockElementImporterBase::ElementList& elems ) const {
-  typedef BlockElementImporterBase::ElementList::value_type ElementType;  
+void GeneralTracksImporterWithVeto::importToBlock(const edm::Event& e,
+                                                  BlockElementImporterBase::ElementList& elems) const {
+  typedef BlockElementImporterBase::ElementList::value_type ElementType;
   auto tracks = e.getHandle(src_);
   auto vetosH = e.getHandle(veto_);
   const auto& vetos = *vetosH;
   std::unordered_set<unsigned> vetoed;
-  for(unsigned i = 0; i < vetos.size(); ++i ) {
+  for (unsigned i = 0; i < vetos.size(); ++i) {
     vetoed.insert(vetos[i].trackRef().key());
   }
   auto muons = e.getHandle(muons_);
   elems.reserve(elems.size() + tracks->size());
-  std::vector<bool> mask(tracks->size(),true);
+  std::vector<bool> mask(tracks->size(), true);
   reco::MuonRef muonref;
-  
+
   // remove converted brems with bad pT resolution if requested
   // this reproduces the old behavior of PFBlockAlgo
-  if( cleanBadConvBrems_ ) {
+  if (cleanBadConvBrems_) {
     auto itr = elems.begin();
-    while( itr != elems.end() ) {
-      if( (*itr)->type() == reco::PFBlockElement::TRACK ) {
-	const reco::PFBlockElementTrack* trkel =
-	  static_cast<reco::PFBlockElementTrack*>(itr->get());
-	const reco::ConversionRefVector& cRef = trkel->convRefs();
-	const reco::PFDisplacedTrackerVertexRef& dvRef = 
-	  trkel->displacedVertexRef(reco::PFBlockElement::T_FROM_DISP);
-	const reco::VertexCompositeCandidateRef& v0Ref =
-	  trkel->V0Ref();
-	// if there is no displaced vertex reference  and it is marked
-	// as a conversion it's gotta be a converted brem
-	if( trkel->trackType(reco::PFBlockElement::T_FROM_GAMMACONV) &&
-	    cRef.empty() && dvRef.isNull() && v0Ref.isNull() ) {
-	  // if the Pt resolution is bad we kill this element
-	  if( !PFTrackAlgoTools::goodPtResolution( trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_ ) ) {
-	    itr = elems.erase(itr);
-	    continue;
-	  }
-	}
+    while (itr != elems.end()) {
+      if ((*itr)->type() == reco::PFBlockElement::TRACK) {
+        const reco::PFBlockElementTrack* trkel = static_cast<reco::PFBlockElementTrack*>(itr->get());
+        const reco::ConversionRefVector& cRef = trkel->convRefs();
+        const reco::PFDisplacedTrackerVertexRef& dvRef = trkel->displacedVertexRef(reco::PFBlockElement::T_FROM_DISP);
+        const reco::VertexCompositeCandidateRef& v0Ref = trkel->V0Ref();
+        // if there is no displaced vertex reference  and it is marked
+        // as a conversion it's gotta be a converted brem
+        if (trkel->trackType(reco::PFBlockElement::T_FROM_GAMMACONV) && cRef.empty() && dvRef.isNull() &&
+            v0Ref.isNull()) {
+          // if the Pt resolution is bad we kill this element
+          if (!PFTrackAlgoTools::goodPtResolution(trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_)) {
+            itr = elems.erase(itr);
+            continue;
+          }
+        }
       }
       ++itr;
-    } // loop on existing elements
+    }  // loop on existing elements
   }
   // preprocess existing tracks in the element list and create a mask
-  // so that we do not import tracks twice, tag muons we find 
-  // in this collection  
-  auto TKs_end = std::partition(elems.begin(),elems.end(),
-				[](const ElementType& a){
-			        return a->type() == reco::PFBlockElement::TRACK;
-				});  
+  // so that we do not import tracks twice, tag muons we find
+  // in this collection
+  auto TKs_end = std::partition(
+      elems.begin(), elems.end(), [](const ElementType& a) { return a->type() == reco::PFBlockElement::TRACK; });
   auto btk_elems = elems.begin();
   auto btrack = tracks->cbegin();
   auto etrack = tracks->cend();
-  for( auto track = btrack;  track != etrack; ++track) {
-    auto tk_elem = std::find_if(btk_elems,TKs_end,
-				[&](const ElementType& a){
-				  return ( a->trackRef() == 
-					   track->trackRef() );
-				});
-    if( tk_elem != TKs_end ) {
-      mask[std::distance(tracks->cbegin(),track)] = false;
+  for (auto track = btrack; track != etrack; ++track) {
+    auto tk_elem =
+        std::find_if(btk_elems, TKs_end, [&](const ElementType& a) { return (a->trackRef() == track->trackRef()); });
+    if (tk_elem != TKs_end) {
+      mask[std::distance(tracks->cbegin(), track)] = false;
       // check and update if this track is a muon
-      const int muId = muAssocToTrack( (*tk_elem)->trackRef(), muons );
-      if( muId != -1 ) {
-	muonref= reco::MuonRef( muons, muId );
-	if( PFMuonAlgo::isLooseMuon(muonref) || PFMuonAlgo::isMuon(muonref) ) {
-	  static_cast<reco::PFBlockElementTrack*>(tk_elem->get())->setMuonRef(muonref);
-	}
+      const int muId = muAssocToTrack((*tk_elem)->trackRef(), muons);
+      if (muId != -1) {
+        muonref = reco::MuonRef(muons, muId);
+        if (PFMuonAlgo::isLooseMuon(muonref) || PFMuonAlgo::isMuon(muonref)) {
+          static_cast<reco::PFBlockElementTrack*>(tk_elem->get())->setMuonRef(muonref);
+        }
       }
-    }    
+    }
   }
   // now we actually insert tracks, again tagging muons along the way
-  reco::PFRecTrackRef pftrackref;  
+  reco::PFRecTrackRef pftrackref;
   reco::PFBlockElementTrack* trkElem = nullptr;
-  for( auto track = btrack;  track != etrack; ++track) {
-    const unsigned idx = std::distance(btrack,track);
+  for (auto track = btrack; track != etrack; ++track) {
+    const unsigned idx = std::distance(btrack, track);
     // since we already set muon refs in the previously imported tracks,
-    // here we can skip everything that is already imported 
-    if( !mask[idx] ) continue; 
+    // here we can skip everything that is already imported
+    if (!mask[idx])
+      continue;
     muonref = reco::MuonRef();
-    pftrackref = reco::PFRecTrackRef(tracks,idx);    
+    pftrackref = reco::PFRecTrackRef(tracks, idx);
     // Get the eventual muon associated to this track
-    const int muId = muAssocToTrack( pftrackref->trackRef(), muons );
+    const int muId = muAssocToTrack(pftrackref->trackRef(), muons);
     bool thisIsAPotentialMuon = false;
-    if( muId != -1 ) {
-      muonref= reco::MuonRef( muons, muId );
-      thisIsAPotentialMuon = ( (pfmu_->hasValidTrack(muonref,true)&&PFMuonAlgo::isLooseMuon(muonref)) || 
-			       (pfmu_->hasValidTrack(muonref,false)&&PFMuonAlgo::isMuon(muonref)));
+    if (muId != -1) {
+      muonref = reco::MuonRef(muons, muId);
+      thisIsAPotentialMuon = ((pfmu_->hasValidTrack(muonref, true) && PFMuonAlgo::isLooseMuon(muonref)) ||
+                              (pfmu_->hasValidTrack(muonref, false) && PFMuonAlgo::isMuon(muonref)));
     }
-    if(thisIsAPotentialMuon || PFTrackAlgoTools::goodPtResolution( pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_ ) ) {
-      trkElem = new reco::PFBlockElementTrack( pftrackref );
+    if (thisIsAPotentialMuon ||
+        PFTrackAlgoTools::goodPtResolution(pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_)) {
+      trkElem = new reco::PFBlockElementTrack(pftrackref);
       if (thisIsAPotentialMuon && debug_) {
-	std::cout << "Potential Muon P " <<  pftrackref->trackRef()->p() 
-		  << " pt " << pftrackref->trackRef()->p() << std::endl; 
+        std::cout << "Potential Muon P " << pftrackref->trackRef()->p() << " pt " << pftrackref->trackRef()->p()
+                  << std::endl;
       }
-      if( muId != -1 ) trkElem->setMuonRef(muonref);
-      if( vetoed.count(pftrackref->trackRef().key()) == 0 || muonref.isNonnull()){
-	elems.emplace_back(trkElem);
-      }
-      else delete trkElem;
+      if (muId != -1)
+        trkElem->setMuonRef(muonref);
+      if (vetoed.count(pftrackref->trackRef().key()) == 0 || muonref.isNonnull()) {
+        elems.emplace_back(trkElem);
+      } else
+        delete trkElem;
     }
   }
   elems.shrink_to_fit();
 }
 
-int GeneralTracksImporterWithVeto::
-muAssocToTrack( const reco::TrackRef& trackref,
-		const edm::Handle<reco::MuonCollection>& muonh) const {
-  auto muon = std::find_if(muonh->cbegin(),muonh->cend(),
-			   [&](const reco::Muon& m) {
-			     return ( m.track().isNonnull() && 
-				      m.track() == trackref    );
-			   });  
-  return ( muon != muonh->cend() ? std::distance(muonh->cbegin(),muon) : -1 );
+int GeneralTracksImporterWithVeto::muAssocToTrack(const reco::TrackRef& trackref,
+                                                  const edm::Handle<reco::MuonCollection>& muonh) const {
+  auto muon = std::find_if(muonh->cbegin(), muonh->cend(), [&](const reco::Muon& m) {
+    return (m.track().isNonnull() && m.track() == trackref);
+  });
+  return (muon != muonh->cend() ? std::distance(muonh->cbegin(), muon) : -1);
 }

--- a/RecoParticleFlow/PFProducer/plugins/importers/GenericClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GenericClusterImporter.cc
@@ -5,63 +5,56 @@
 
 class GenericClusterImporter : public BlockElementImporterBase {
 public:
-  GenericClusterImporter(const edm::ParameterSet& conf,
-		    edm::ConsumesCollector& sumes) :
-    BlockElementImporterBase(conf,sumes),
-    _src(sumes.consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("source"))) {}
-  
-  void importToBlock( const edm::Event& ,
-		      ElementList& ) const override;
+  GenericClusterImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : BlockElementImporterBase(conf, sumes),
+        _src(sumes.consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("source"))) {}
+
+  void importToBlock(const edm::Event&, ElementList&) const override;
 
 private:
   edm::EDGetTokenT<reco::PFClusterCollection> _src;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  GenericClusterImporter, 
-		  "GenericClusterImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, GenericClusterImporter, "GenericClusterImporter");
 
-void GenericClusterImporter::
-importToBlock( const edm::Event& e, 
-	       BlockElementImporterBase::ElementList& elems ) const {
+void GenericClusterImporter::importToBlock(const edm::Event& e, BlockElementImporterBase::ElementList& elems) const {
   auto clusters = e.getHandle(_src);
   auto cbegin = clusters->cbegin();
-  auto cend   = clusters->cend(); 
-  for( auto clus = cbegin; clus != cend; ++clus ) {
-    reco::PFBlockElement::Type type = reco::PFBlockElement::NONE;  
-    reco::PFClusterRef cref(clusters,std::distance(cbegin,clus));
-    switch( clus->layer() ) {
-    case PFLayer::PS1:
-      type = reco::PFBlockElement::PS1;
-      break;
-    case PFLayer::PS2:
-      type = reco::PFBlockElement::PS2;
-      break;
-    case PFLayer::ECAL_BARREL:
-    case PFLayer::ECAL_ENDCAP:
-      type = reco::PFBlockElement::ECAL;
-      break;
-    case PFLayer::HCAL_BARREL1:
-    case PFLayer::HCAL_ENDCAP:
-      type = reco::PFBlockElement::HCAL;
-      break;
-    case PFLayer::HCAL_BARREL2:
-      type = reco::PFBlockElement::HO;
-      break;
-    case PFLayer::HF_EM:
-      type = reco::PFBlockElement::HFEM;
-      break;
-    case PFLayer::HF_HAD:
-      type = reco::PFBlockElement::HFHAD;
-      break;
-    case PFLayer::HGCAL:
-      type = reco::PFBlockElement::HGCAL;
-      break;
-    default:
-      throw cms::Exception("InvalidPFLayer")
-	<< "Layer given, " << clus->layer() << " is not a valid PFLayer!";
+  auto cend = clusters->cend();
+  for (auto clus = cbegin; clus != cend; ++clus) {
+    reco::PFBlockElement::Type type = reco::PFBlockElement::NONE;
+    reco::PFClusterRef cref(clusters, std::distance(cbegin, clus));
+    switch (clus->layer()) {
+      case PFLayer::PS1:
+        type = reco::PFBlockElement::PS1;
+        break;
+      case PFLayer::PS2:
+        type = reco::PFBlockElement::PS2;
+        break;
+      case PFLayer::ECAL_BARREL:
+      case PFLayer::ECAL_ENDCAP:
+        type = reco::PFBlockElement::ECAL;
+        break;
+      case PFLayer::HCAL_BARREL1:
+      case PFLayer::HCAL_ENDCAP:
+        type = reco::PFBlockElement::HCAL;
+        break;
+      case PFLayer::HCAL_BARREL2:
+        type = reco::PFBlockElement::HO;
+        break;
+      case PFLayer::HF_EM:
+        type = reco::PFBlockElement::HFEM;
+        break;
+      case PFLayer::HF_HAD:
+        type = reco::PFBlockElement::HFHAD;
+        break;
+      case PFLayer::HGCAL:
+        type = reco::PFBlockElement::HGCAL;
+        break;
+      default:
+        throw cms::Exception("InvalidPFLayer") << "Layer given, " << clus->layer() << " is not a valid PFLayer!";
     }
-    reco::PFBlockElement* cptr = new reco::PFBlockElementCluster(cref,type);
+    reco::PFBlockElement* cptr = new reco::PFBlockElementCluster(cref, type);
     elems.emplace_back(cptr);
   }
 }

--- a/RecoParticleFlow/PFProducer/plugins/importers/LooseNuclearInteractionTrackImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/LooseNuclearInteractionTrackImporter.cc
@@ -1,35 +1,34 @@
 #include "TrackFromParentImporter.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
 
-namespace{
+namespace {
   class LooseNuclAdaptor {
   public:
     static bool check_importable(const reco::PFDisplacedTrackerVertexCollection::value_type& t) {
       const auto& vtx = t.displacedVertexRef();
-      return ( ( vtx->isNucl() && vtx->position().rho() > 2.7 ) ||
-	       ( vtx->isNucl_Loose() ));
+      return ((vtx->isNucl() && vtx->position().rho() > 2.7) || (vtx->isNucl_Loose()));
     }
-    static const reco::PFRecTrackRefVector&
-    get_track_refs(const reco::PFDisplacedTrackerVertexCollection::value_type& t) {
+    static const reco::PFRecTrackRefVector& get_track_refs(
+        const reco::PFDisplacedTrackerVertexCollection::value_type& t) {
       return t.pfRecTracks();
     }
     static void set_element_info(reco::PFBlockElement* elem,
-				 const edm::Ref<reco::PFDisplacedTrackerVertexCollection>& parref) {
-      const reco::PFBlockElementTrack *tkelem = 
-	static_cast<const reco::PFBlockElementTrack*>(elem);
+                                 const edm::Ref<reco::PFDisplacedTrackerVertexCollection>& parref) {
+      const reco::PFBlockElementTrack* tkelem = static_cast<const reco::PFBlockElementTrack*>(elem);
       const reco::PFRecTrackRef& reftrack = tkelem->trackRefPF();
-      reco::PFBlockElement::TrackType tkType = reco::PFBlockElement::DEFAULT;     
-      if(parref->isIncomingTrack(reftrack)) 
-	tkType = reco::PFBlockElement::T_TO_DISP;
-      else if (parref->isOutgoingTrack(reftrack)) 
-	tkType = reco::PFBlockElement::T_FROM_DISP;   
-      elem->setDisplacedVertexRef(parref,tkType);
+      reco::PFBlockElement::TrackType tkType = reco::PFBlockElement::DEFAULT;
+      if (parref->isIncomingTrack(reftrack))
+        tkType = reco::PFBlockElement::T_TO_DISP;
+      else if (parref->isOutgoingTrack(reftrack))
+        tkType = reco::PFBlockElement::T_FROM_DISP;
+      elem->setDisplacedVertexRef(parref, tkType);
     }
   };
-}
+}  // namespace
 
-typedef pflow::importers::TrackFromParentImporter<reco::PFDisplacedTrackerVertexCollection,LooseNuclAdaptor> LooseNuclearInteractionTrackImporter;
+typedef pflow::importers::TrackFromParentImporter<reco::PFDisplacedTrackerVertexCollection, LooseNuclAdaptor>
+    LooseNuclearInteractionTrackImporter;
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  LooseNuclearInteractionTrackImporter, 
-		  "LooseNuclearInteractionTrackImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory,
+                  LooseNuclearInteractionTrackImporter,
+                  "LooseNuclearInteractionTrackImporter");

--- a/RecoParticleFlow/PFProducer/plugins/importers/NuclearInteractionTrackImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/NuclearInteractionTrackImporter.cc
@@ -6,29 +6,27 @@ namespace {
   public:
     static bool check_importable(const reco::PFDisplacedTrackerVertexCollection::value_type& t) {
       const auto& vtx = t.displacedVertexRef();
-      return ( vtx->isNucl() && vtx->position().rho() > 2.7 );
+      return (vtx->isNucl() && vtx->position().rho() > 2.7);
     }
-    static const reco::PFRecTrackRefVector&
-    get_track_refs(const reco::PFDisplacedTrackerVertexCollection::value_type& t) {
+    static const reco::PFRecTrackRefVector& get_track_refs(
+        const reco::PFDisplacedTrackerVertexCollection::value_type& t) {
       return t.pfRecTracks();
     }
     static void set_element_info(reco::PFBlockElement* elem,
-				 const edm::Ref<reco::PFDisplacedTrackerVertexCollection>& parref) {
-      const reco::PFBlockElementTrack *tkelem = 
-	static_cast<const reco::PFBlockElementTrack*>(elem);
+                                 const edm::Ref<reco::PFDisplacedTrackerVertexCollection>& parref) {
+      const reco::PFBlockElementTrack* tkelem = static_cast<const reco::PFBlockElementTrack*>(elem);
       const reco::PFRecTrackRef& reftrack = tkelem->trackRefPF();
-      reco::PFBlockElement::TrackType tkType = reco::PFBlockElement::DEFAULT;     
-      if(parref->isIncomingTrack(reftrack)) 
-	tkType = reco::PFBlockElement::T_TO_DISP;
-      else if (parref->isOutgoingTrack(reftrack)) 
-	tkType = reco::PFBlockElement::T_FROM_DISP;   
-      elem->setDisplacedVertexRef(parref,tkType);
+      reco::PFBlockElement::TrackType tkType = reco::PFBlockElement::DEFAULT;
+      if (parref->isIncomingTrack(reftrack))
+        tkType = reco::PFBlockElement::T_TO_DISP;
+      else if (parref->isOutgoingTrack(reftrack))
+        tkType = reco::PFBlockElement::T_FROM_DISP;
+      elem->setDisplacedVertexRef(parref, tkType);
     }
   };
-}
+}  // namespace
 
-typedef pflow::importers::TrackFromParentImporter<reco::PFDisplacedTrackerVertexCollection,NuclAdaptor> NuclearInteractionTrackImporter;
+typedef pflow::importers::TrackFromParentImporter<reco::PFDisplacedTrackerVertexCollection, NuclAdaptor>
+    NuclearInteractionTrackImporter;
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  NuclearInteractionTrackImporter, 
-		  "NuclearInteractionTrackImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, NuclearInteractionTrackImporter, "NuclearInteractionTrackImporter");

--- a/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
@@ -11,26 +11,23 @@
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h"
 
 //quick pT for superclusters
-inline double ptFast( const double energy,
-		      const math::XYZPoint& position,
-		      const math::XYZPoint& origin ) {
+inline double ptFast(const double energy, const math::XYZPoint& position, const math::XYZPoint& origin) {
   const auto v = position - origin;
-  return energy*std::sqrt(v.perp2()/v.mag2());
+  return energy * std::sqrt(v.perp2() / v.mag2());
 }
 
 #include <unordered_map>
 
 class SuperClusterImporter : public BlockElementImporterBase {
-public:  
-  SuperClusterImporter(const edm::ParameterSet&,edm::ConsumesCollector&);
-  
-  void updateEventSetup( const edm::EventSetup& es ) override;
+public:
+  SuperClusterImporter(const edm::ParameterSet&, edm::ConsumesCollector&);
 
-  void importToBlock( const edm::Event& ,
-		      ElementList& ) const override;
+  void updateEventSetup(const edm::EventSetup& es) override;
+
+  void importToBlock(const edm::Event&, ElementList&) const override;
 
 private:
-  edm::EDGetTokenT<reco::SuperClusterCollection> _srcEB,_srcEE;  
+  edm::EDGetTokenT<reco::SuperClusterCollection> _srcEB, _srcEE;
   edm::EDGetTokenT<CaloTowerCollection> _srcTowers;
   const double _maxHoverE, _pTbyPass, _minSCPt;
   std::unique_ptr<EgammaHadTower> _hadTower;
@@ -38,82 +35,69 @@ private:
   static const math::XYZPoint _zero;
 };
 
-const math::XYZPoint SuperClusterImporter::_zero = math::XYZPoint(0,0,0);
+const math::XYZPoint SuperClusterImporter::_zero = math::XYZPoint(0, 0, 0);
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  SuperClusterImporter, 
-		  "SuperClusterImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, SuperClusterImporter, "SuperClusterImporter");
 
-SuperClusterImporter::SuperClusterImporter(const edm::ParameterSet& conf,
-				   edm::ConsumesCollector& sumes) :
-    BlockElementImporterBase(conf,sumes),
-    _srcEB(sumes.consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("source_eb"))),
-    _srcEE(sumes.consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("source_ee"))),
-    _srcTowers(sumes.consumes<CaloTowerCollection>(conf.getParameter<edm::InputTag>("source_towers"))),
-    _maxHoverE(conf.getParameter<double>("maximumHoverE")),
-    _pTbyPass(conf.getParameter<double>("minPTforBypass")),
-    _minSCPt(conf.getParameter<double>("minSuperClusterPt")),
-    _hadTower(nullptr),
-    _superClustersArePF(conf.getParameter<bool>("superClustersArePF")) {  
+SuperClusterImporter::SuperClusterImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+    : BlockElementImporterBase(conf, sumes),
+      _srcEB(sumes.consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("source_eb"))),
+      _srcEE(sumes.consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("source_ee"))),
+      _srcTowers(sumes.consumes<CaloTowerCollection>(conf.getParameter<edm::InputTag>("source_towers"))),
+      _maxHoverE(conf.getParameter<double>("maximumHoverE")),
+      _pTbyPass(conf.getParameter<double>("minPTforBypass")),
+      _minSCPt(conf.getParameter<double>("minSuperClusterPt")),
+      _hadTower(nullptr),
+      _superClustersArePF(conf.getParameter<bool>("superClustersArePF")) {}
+
+void SuperClusterImporter::updateEventSetup(const edm::EventSetup& es) {
+  _hadTower.reset(new EgammaHadTower(es, EgammaHadTower::SingleTower));
 }
 
-void SuperClusterImporter::
-updateEventSetup(const edm::EventSetup& es) {
-  _hadTower.reset(new EgammaHadTower(es,EgammaHadTower::SingleTower));
-}
-
-void SuperClusterImporter::
-importToBlock( const edm::Event& e, 
-	       BlockElementImporterBase::ElementList& elems ) const {
+void SuperClusterImporter::importToBlock(const edm::Event& e, BlockElementImporterBase::ElementList& elems) const {
   auto eb_scs = e.getHandle(_srcEB);
   auto ee_scs = e.getHandle(_srcEE);
   auto towers = e.getHandle(_srcTowers);
   _hadTower->setTowerCollection(towers.product());
-  elems.reserve(elems.size()+eb_scs->size()+ee_scs->size());
+  elems.reserve(elems.size() + eb_scs->size() + ee_scs->size());
   // setup our elements so that all the SCs are grouped together
-  auto SCs_end = std::partition(elems.begin(),elems.end(),
-				[](auto const& a){
-				  return a->type() == reco::PFBlockElement::SC;
-				});  
+  auto SCs_end =
+      std::partition(elems.begin(), elems.end(), [](auto const& a) { return a->type() == reco::PFBlockElement::SC; });
   // add eb superclusters
   auto bsc = eb_scs->cbegin();
   auto esc = eb_scs->cend();
   reco::PFBlockElementSuperCluster* scbe = nullptr;
   reco::SuperClusterRef scref;
-  for( auto sc = bsc; sc != esc; ++sc ) {
-    scref = reco::SuperClusterRef(eb_scs,std::distance(bsc,sc));
+  for (auto sc = bsc; sc != esc; ++sc) {
+    scref = reco::SuperClusterRef(eb_scs, std::distance(bsc, sc));
     PFBlockElementSCEqual myEqual(scref);
-    auto sc_elem = std::find_if(elems.begin(),SCs_end,myEqual);
-    const double scpT = ptFast(sc->energy(),sc->position(),_zero);    
-    const double H_tower = ( _hadTower->getDepth1HcalESum(*sc) +
-			     _hadTower->getDepth2HcalESum(*sc)   );
-    const double HoverE = H_tower/sc->energy();
-    if( sc_elem == SCs_end && scpT > _minSCPt &&
-	(scpT > _pTbyPass || HoverE < _maxHoverE) ) {	
-      scbe = new reco::PFBlockElementSuperCluster(scref);      
+    auto sc_elem = std::find_if(elems.begin(), SCs_end, myEqual);
+    const double scpT = ptFast(sc->energy(), sc->position(), _zero);
+    const double H_tower = (_hadTower->getDepth1HcalESum(*sc) + _hadTower->getDepth2HcalESum(*sc));
+    const double HoverE = H_tower / sc->energy();
+    if (sc_elem == SCs_end && scpT > _minSCPt && (scpT > _pTbyPass || HoverE < _maxHoverE)) {
+      scbe = new reco::PFBlockElementSuperCluster(scref);
       scbe->setFromPFSuperCluster(_superClustersArePF);
       SCs_end = elems.emplace(SCs_end, scbe);
-      ++SCs_end; // point to element *after* the new one
-    }    
-  }// loop on eb superclusters
+      ++SCs_end;  // point to element *after* the new one
+    }
+  }  // loop on eb superclusters
   // add ee superclusters
   bsc = ee_scs->cbegin();
   esc = ee_scs->cend();
-  for( auto sc = bsc; sc != esc; ++sc ) {
-    scref = reco::SuperClusterRef(ee_scs,std::distance(bsc,sc));
+  for (auto sc = bsc; sc != esc; ++sc) {
+    scref = reco::SuperClusterRef(ee_scs, std::distance(bsc, sc));
     PFBlockElementSCEqual myEqual(scref);
-    auto sc_elem = std::find_if(elems.begin(),SCs_end,myEqual);
-    const double scpT = ptFast(sc->energy(),sc->position(),_zero);    
-    const double H_tower = ( _hadTower->getDepth1HcalESum(*sc) +
-			     _hadTower->getDepth2HcalESum(*sc)   );
-    const double HoverE = H_tower/sc->energy();
-    if( sc_elem == SCs_end && scpT > _minSCPt &&
-	(scpT > _pTbyPass || HoverE < _maxHoverE)) {	
-      scbe = new reco::PFBlockElementSuperCluster(scref);  
+    auto sc_elem = std::find_if(elems.begin(), SCs_end, myEqual);
+    const double scpT = ptFast(sc->energy(), sc->position(), _zero);
+    const double H_tower = (_hadTower->getDepth1HcalESum(*sc) + _hadTower->getDepth2HcalESum(*sc));
+    const double HoverE = H_tower / sc->energy();
+    if (sc_elem == SCs_end && scpT > _minSCPt && (scpT > _pTbyPass || HoverE < _maxHoverE)) {
+      scbe = new reco::PFBlockElementSuperCluster(scref);
       scbe->setFromPFSuperCluster(_superClustersArePF);
       SCs_end = elems.emplace(SCs_end, scbe);
-      ++SCs_end; // point to element *after* the new one
-    }    
-  }// loop on ee superclusters
+      ++SCs_end;  // point to element *after* the new one
+    }
+  }  // loop on ee superclusters
   elems.shrink_to_fit();
 }

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackFromParentImporter.h
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackFromParentImporter.h
@@ -8,81 +8,67 @@
 
 namespace pflow {
   namespace noop {
-    // this adaptor class gets redefined later to match the 
+    // this adaptor class gets redefined later to match the
     // needs of the collection and importing cuts we are using
-    template<class Collection>
-      class ParentCollectionAdaptor {
-    public:  
-      static bool check_importable(const typename Collection::value_type&) {
-	return true;
+    template <class Collection>
+    class ParentCollectionAdaptor {
+    public:
+      static bool check_importable(const typename Collection::value_type&) { return true; }
+      static const std::vector<reco::PFRecTrackRef>& get_track_refs(const typename Collection::value_type&) {
+        return _empty;
       }
-      static const std::vector<reco::PFRecTrackRef>& 
-	get_track_refs(const typename Collection::value_type&) {
-	return _empty;
-      }
-      static void set_element_info(reco::PFBlockElement*,
-				   const typename edm::Ref<Collection>&) {    
-      }
+      static void set_element_info(reco::PFBlockElement*, const typename edm::Ref<Collection>&) {}
       static const std::vector<reco::PFRecTrackRef> _empty;
     };
-  }
-  namespace importers {    
-    template<class Collection,class Adaptor=noop::ParentCollectionAdaptor<Collection> >
-      class TrackFromParentImporter : public BlockElementImporterBase {
+  }  // namespace noop
+  namespace importers {
+    template <class Collection, class Adaptor = noop::ParentCollectionAdaptor<Collection> >
+    class TrackFromParentImporter : public BlockElementImporterBase {
     public:
-    TrackFromParentImporter(const edm::ParameterSet& conf,
-			    edm::ConsumesCollector& sumes) :
-      BlockElementImporterBase(conf,sumes),
-	_src(sumes.consumes<Collection>(conf.getParameter<edm::InputTag>("source"))) {}
-      
-      void importToBlock( const edm::Event& ,
-			  ElementList& ) const override;
-      
+      TrackFromParentImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+          : BlockElementImporterBase(conf, sumes),
+            _src(sumes.consumes<Collection>(conf.getParameter<edm::InputTag>("source"))) {}
+
+      void importToBlock(const edm::Event&, ElementList&) const override;
+
     private:
       edm::EDGetTokenT<Collection> _src;
     };
-    
-    
-    template<class Collection, class Adaptor>
-      void TrackFromParentImporter<Collection,Adaptor>::
-      importToBlock( const edm::Event& e, 
-		     BlockElementImporterBase::ElementList& elems ) const {
-      typedef BlockElementImporterBase::ElementList::value_type ElementType;  
+
+    template <class Collection, class Adaptor>
+    void TrackFromParentImporter<Collection, Adaptor>::importToBlock(
+        const edm::Event& e, BlockElementImporterBase::ElementList& elems) const {
+      typedef BlockElementImporterBase::ElementList::value_type ElementType;
       auto pfparents = e.getHandle(_src);
-      elems.reserve(elems.size() + 2*pfparents->size());
+      elems.reserve(elems.size() + 2 * pfparents->size());
       // setup our elements so that all the SCs are grouped together
-      auto TKs_end = std::partition(elems.begin(),elems.end(),
-				    [](const ElementType& a){
-				      return a->type() == reco::PFBlockElement::TRACK;
-				    });  
+      auto TKs_end = std::partition(
+          elems.begin(), elems.end(), [](const ElementType& a) { return a->type() == reco::PFBlockElement::TRACK; });
       // insert tracks into the element list, updating tracks that exist already
       auto bpar = pfparents->cbegin();
       auto epar = pfparents->cend();
       edm::Ref<Collection> parentRef;
       reco::PFBlockElement* trkElem = nullptr;
-      for( auto pfparent =  bpar; pfparent != epar; ++pfparent ) {
-	if( Adaptor::check_importable(*pfparent) ) {
-	  parentRef = edm::Ref<Collection>(pfparents,std::distance(bpar,pfparent));
-	  const auto& pftracks = Adaptor::get_track_refs(*pfparent);
-	  for( const auto& pftrack : pftracks ) {
-	    auto tk_elem = std::find_if(elems.begin(),TKs_end,
-					[&](const ElementType& a){
-					  return ( a->trackRef() == 
-						   pftrack->trackRef() );
-					});
-	    if( tk_elem != TKs_end ) { // if found flag the track, otherwise import
-	      Adaptor::set_element_info(tk_elem->get(),parentRef);
-	    } else {
-	      trkElem = new reco::PFBlockElementTrack(pftrack);
-	      Adaptor::set_element_info(trkElem,parentRef);
-	      TKs_end = elems.insert(TKs_end,ElementType(trkElem));
-	      ++TKs_end;
-	    }
-	  }
-	}
-      }// loop on tracking coming from common parent
+      for (auto pfparent = bpar; pfparent != epar; ++pfparent) {
+        if (Adaptor::check_importable(*pfparent)) {
+          parentRef = edm::Ref<Collection>(pfparents, std::distance(bpar, pfparent));
+          const auto& pftracks = Adaptor::get_track_refs(*pfparent);
+          for (const auto& pftrack : pftracks) {
+            auto tk_elem = std::find_if(
+                elems.begin(), TKs_end, [&](const ElementType& a) { return (a->trackRef() == pftrack->trackRef()); });
+            if (tk_elem != TKs_end) {  // if found flag the track, otherwise import
+              Adaptor::set_element_info(tk_elem->get(), parentRef);
+            } else {
+              trkElem = new reco::PFBlockElementTrack(pftrack);
+              Adaptor::set_element_info(trkElem, parentRef);
+              TKs_end = elems.insert(TKs_end, ElementType(trkElem));
+              ++TKs_end;
+            }
+          }
+        }
+      }  // loop on tracking coming from common parent
       elems.shrink_to_fit();
     }
-  } // importers
-} // pflow
+  }  // namespace importers
+}  // namespace pflow
 #endif

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
@@ -10,66 +10,57 @@
 #include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 
-// this doesn't actually import anything, 
+// this doesn't actually import anything,
 // but rather applies time stamps to tracks after they are all inserted
 
 class TrackTimingImporter : public BlockElementImporterBase {
 public:
-  TrackTimingImporter(const edm::ParameterSet& conf,
-		    edm::ConsumesCollector& sumes) :
-    BlockElementImporterBase(conf,sumes),    
-    srcTime_( sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeValueMap")) ),
-    srcTimeError_( sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeErrorMap")) ),
-    srcTimeGsf_( sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeValueMapGsf")) ),
-    srcTimeErrorGsf_( sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeErrorMapGsf")) ),
-    debug_(conf.getUntrackedParameter<bool>("debug",false)) {    
-  }
-  
-  void importToBlock( const edm::Event& ,
-		      ElementList& ) const override;
+  TrackTimingImporter(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : BlockElementImporterBase(conf, sumes),
+        srcTime_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeValueMap"))),
+        srcTimeError_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeErrorMap"))),
+        srcTimeGsf_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeValueMapGsf"))),
+        srcTimeErrorGsf_(sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeErrorMapGsf"))),
+        debug_(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  void importToBlock(const edm::Event&, ElementList&) const override;
 
 private:
-    
   edm::EDGetTokenT<edm::ValueMap<float> > srcTime_, srcTimeError_, srcTimeGsf_, srcTimeErrorGsf_;
   const bool debug_;
-  
 };
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  TrackTimingImporter, 
-		  "TrackTimingImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, TrackTimingImporter, "TrackTimingImporter");
 
-void TrackTimingImporter::
-importToBlock( const edm::Event& e, 
-	       BlockElementImporterBase::ElementList& elems ) const {
-  typedef BlockElementImporterBase::ElementList::value_type ElementType;  
-  
+void TrackTimingImporter::importToBlock(const edm::Event& e, BlockElementImporterBase::ElementList& elems) const {
+  typedef BlockElementImporterBase::ElementList::value_type ElementType;
+
   auto const& time = e.get(srcTime_);
   auto const& timeErr = e.get(srcTimeError_);
   auto const& timeGsf = e.get(srcTimeGsf_);
   auto const& timeErrGsf = e.get(srcTimeErrorGsf_);
-  
-  for( auto& elem : elems ) {
-    if( reco::PFBlockElement::TRACK == elem->type() ) {
+
+  for (auto& elem : elems) {
+    if (reco::PFBlockElement::TRACK == elem->type()) {
       const auto& ref = elem->trackRef();
       if (time.contains(ref.id())) {
-	elem->setTime( time[ref], timeErr[ref] );
+        elem->setTime(time[ref], timeErr[ref]);
       }
-      if( debug_ ) {
-	edm::LogInfo("TrackTimingImporter") 
-	  << "Track with pT / eta " << ref->pt() << " / " << ref->eta() 
-	  << " has time: " << elem->time() << " +/- " << elem->timeError() << std::endl;
+      if (debug_) {
+        edm::LogInfo("TrackTimingImporter")
+            << "Track with pT / eta " << ref->pt() << " / " << ref->eta() << " has time: " << elem->time() << " +/- "
+            << elem->timeError() << std::endl;
       }
-    } else if ( reco::PFBlockElement::GSF == elem->type() ) {
+    } else if (reco::PFBlockElement::GSF == elem->type()) {
       const auto& ref = static_cast<const reco::PFBlockElementGsfTrack*>(elem.get())->GsftrackRef();
       if (timeGsf.contains(ref.id())) {
-	elem->setTime( timeGsf[ref], timeErrGsf[ref] );
+        elem->setTime(timeGsf[ref], timeErrGsf[ref]);
       }
-      if( debug_ ) {
-	edm::LogInfo("TrackTimingImporter") 
-	  << "Track with pT / eta " << ref->pt() << " / " << ref->eta() 
-	  << " has time: " << elem->time() << " +/- " << elem->timeError() << std::endl;
+      if (debug_) {
+        edm::LogInfo("TrackTimingImporter")
+            << "Track with pT / eta " << ref->pt() << " / " << ref->eta() << " has time: " << elem->time() << " +/- "
+            << elem->timeError() << std::endl;
       }
-    } 
-  }  
+    }
+  }
 }

--- a/RecoParticleFlow/PFProducer/plugins/importers/V0TrackImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/V0TrackImporter.cc
@@ -5,22 +5,16 @@
 namespace {
   class V0Adaptor {
   public:
-    static bool check_importable(const reco::PFV0Collection::value_type& t) {
-      return true;
-    }
-    static const std::vector<reco::PFRecTrackRef>& 
-    get_track_refs(const reco::PFV0Collection::value_type& t) {
+    static bool check_importable(const reco::PFV0Collection::value_type& t) { return true; }
+    static const std::vector<reco::PFRecTrackRef>& get_track_refs(const reco::PFV0Collection::value_type& t) {
       return t.pfTracks();
     }
-    static void set_element_info(reco::PFBlockElement* elem,
-				 const edm::Ref<reco::PFV0Collection>& parref) {
+    static void set_element_info(reco::PFBlockElement* elem, const edm::Ref<reco::PFV0Collection>& parref) {
       elem->setV0Ref(parref->originalV0(), reco::PFBlockElement::T_FROM_V0);
     }
   };
-}
+}  // namespace
 
-typedef pflow::importers::TrackFromParentImporter<reco::PFV0Collection,V0Adaptor> V0TrackImporter;
+typedef pflow::importers::TrackFromParentImporter<reco::PFV0Collection, V0Adaptor> V0TrackImporter;
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  V0TrackImporter, 
-		  "V0TrackImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, V0TrackImporter, "V0TrackImporter");

--- a/RecoParticleFlow/PFProducer/plugins/importers/VeryLooseNuclearInteractionTrackImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/VeryLooseNuclearInteractionTrackImporter.cc
@@ -6,32 +6,29 @@ namespace {
   public:
     static bool check_importable(const reco::PFDisplacedTrackerVertexCollection::value_type& t) {
       const auto& vtx = t.displacedVertexRef();
-      return ( ( vtx->isNucl() && vtx->position().rho() > 2.7 ) ||
-	       ( vtx->isNucl_Loose() )  ||
-	       ( vtx->isNucl_Kink() )      );
+      return ((vtx->isNucl() && vtx->position().rho() > 2.7) || (vtx->isNucl_Loose()) || (vtx->isNucl_Kink()));
     }
-    static const reco::PFRecTrackRefVector&
-    get_track_refs(const reco::PFDisplacedTrackerVertexCollection::value_type& t) {
+    static const reco::PFRecTrackRefVector& get_track_refs(
+        const reco::PFDisplacedTrackerVertexCollection::value_type& t) {
       return t.pfRecTracks();
     }
     static void set_element_info(reco::PFBlockElement* elem,
-				 const edm::Ref<reco::PFDisplacedTrackerVertexCollection>& parref) {
-      const reco::PFBlockElementTrack *tkelem = 
-	static_cast<const reco::PFBlockElementTrack*>(elem);
+                                 const edm::Ref<reco::PFDisplacedTrackerVertexCollection>& parref) {
+      const reco::PFBlockElementTrack* tkelem = static_cast<const reco::PFBlockElementTrack*>(elem);
       const reco::PFRecTrackRef& reftrack = tkelem->trackRefPF();
-      reco::PFBlockElement::TrackType tkType = reco::PFBlockElement::DEFAULT;     
-      if(parref->isIncomingTrack(reftrack)) 
-	tkType = reco::PFBlockElement::T_TO_DISP;
-      else if (parref->isOutgoingTrack(reftrack)) 
-	tkType = reco::PFBlockElement::T_FROM_DISP;   
-      elem->setDisplacedVertexRef(parref,tkType);
+      reco::PFBlockElement::TrackType tkType = reco::PFBlockElement::DEFAULT;
+      if (parref->isIncomingTrack(reftrack))
+        tkType = reco::PFBlockElement::T_TO_DISP;
+      else if (parref->isOutgoingTrack(reftrack))
+        tkType = reco::PFBlockElement::T_FROM_DISP;
+      elem->setDisplacedVertexRef(parref, tkType);
     }
   };
-}
+}  // namespace
 
+typedef pflow::importers::TrackFromParentImporter<reco::PFDisplacedTrackerVertexCollection, VeryLooseNuclAdaptor>
+    VeryLooseNuclearInteractionTrackImporter;
 
-typedef pflow::importers::TrackFromParentImporter<reco::PFDisplacedTrackerVertexCollection,VeryLooseNuclAdaptor> VeryLooseNuclearInteractionTrackImporter;
-
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  VeryLooseNuclearInteractionTrackImporter, 
-		  "VeryLooseNuclearInteractionTrackImporter");
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory,
+                  VeryLooseNuclearInteractionTrackImporter,
+                  "VeryLooseNuclearInteractionTrackImporter");

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.cc
@@ -120,14 +120,14 @@ void KDTreeLinkerPSEcal::buildTree() {
 
 void KDTreeLinkerPSEcal::buildTree(const RecHitSet &rechitsSet, KDTreeLinkerAlgo<reco::PFRecHit const *> &tree) {
   // List of pseudo-rechits that will be used to create the KDTree
-  std::vector<KDTreeNodeInfo<reco::PFRecHit const*,2>> eltList;
+  std::vector<KDTreeNodeInfo<reco::PFRecHit const *, 2>> eltList;
 
   // Filling of this eltList
   for (RecHitSet::const_iterator it = rechitsSet.begin(); it != rechitsSet.end(); it++) {
     const reco::PFRecHit *rh = *it;
     const auto &posxyz = rh->position();
 
-    KDTreeNodeInfo<reco::PFRecHit const*,2> rhinfo {rh, posxyz.x(), posxyz.y()};
+    KDTreeNodeInfo<reco::PFRecHit const *, 2> rhinfo{rh, posxyz.x(), posxyz.y()};
     eltList.push_back(rhinfo);
   }
 

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.cc
@@ -99,26 +99,26 @@ void KDTreeLinkerTrackEcal::insertFieldClusterElt(reco::PFBlockElement *ecalClus
 
 void KDTreeLinkerTrackEcal::buildTree() {
   // List of pseudo-rechits that will be used to create the KDTree
-  std::vector<KDTreeNodeInfo<reco::PFRecHit const*,2>> eltList;
+  std::vector<KDTreeNodeInfo<reco::PFRecHit const *, 2>> eltList;
 
   // Filling of this list
   for (RecHitSet::const_iterator it = rechitsSet_.begin(); it != rechitsSet_.end(); it++) {
     const reco::PFRecHit::REPPoint &posrep = (*it)->positionREP();
-    
-    KDTreeNodeInfo<reco::PFRecHit const*,2> rh1 (*it, posrep.eta(), posrep.phi());
+
+    KDTreeNodeInfo<reco::PFRecHit const *, 2> rh1(*it, posrep.eta(), posrep.phi());
     eltList.push_back(rh1);
 
     // Here we solve the problem of phi circular set by duplicating some rechits
     // too close to -Pi (or to Pi) and adding (substracting) to them 2 * Pi.
     if (rh1.dims[1] > (M_PI - phiOffset_)) {
       float phi = rh1.dims[1] - 2 * M_PI;
-      KDTreeNodeInfo<reco::PFRecHit const*,2> rh2(*it, float(posrep.eta()), phi);
+      KDTreeNodeInfo<reco::PFRecHit const *, 2> rh2(*it, float(posrep.eta()), phi);
       eltList.push_back(rh2);
     }
 
     if (rh1.dims[1] < (M_PI * -1.0 + phiOffset_)) {
       float phi = rh1.dims[1] + 2 * M_PI;
-      KDTreeNodeInfo<reco::PFRecHit const*,2> rh3(*it, float(posrep.eta()), phi);
+      KDTreeNodeInfo<reco::PFRecHit const *, 2> rh3(*it, float(posrep.eta()), phi);
       eltList.push_back(rh3);
     }
   }

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.cc
@@ -100,26 +100,26 @@ void KDTreeLinkerTrackHcal::insertFieldClusterElt(reco::PFBlockElement* hcalClus
 
 void KDTreeLinkerTrackHcal::buildTree() {
   // List of pseudo-rechits that will be used to create the KDTree
-  std::vector<KDTreeNodeInfo<reco::PFRecHit const*,2>> eltList;
+  std::vector<KDTreeNodeInfo<reco::PFRecHit const*, 2>> eltList;
 
   // Filling of this list
   for (RecHitSet::const_iterator it = rechitsSet_.begin(); it != rechitsSet_.end(); it++) {
     const reco::PFRecHit::REPPoint& posrep = (*it)->positionREP();
 
-    KDTreeNodeInfo<reco::PFRecHit const*,2> rh1(*it, posrep.eta(), posrep.phi());
+    KDTreeNodeInfo<reco::PFRecHit const*, 2> rh1(*it, posrep.eta(), posrep.phi());
     eltList.push_back(rh1);
 
     // Here we solve the problem of phi circular set by duplicating some rechits
     // too close to -Pi (or to Pi) and adding (substracting) to them 2 * Pi.
     if (rh1.dims[1] > (M_PI - phiOffset_)) {
       float phi = rh1.dims[1] - 2 * M_PI;
-      KDTreeNodeInfo<reco::PFRecHit const*,2> rh2(*it, float(posrep.eta()), phi);
+      KDTreeNodeInfo<reco::PFRecHit const*, 2> rh2(*it, float(posrep.eta()), phi);
       eltList.push_back(rh2);
     }
 
     if (rh1.dims[1] < (M_PI * -1.0 + phiOffset_)) {
       float phi = rh1.dims[1] + 2 * M_PI;
-      KDTreeNodeInfo<reco::PFRecHit const*,2> rh3(*it, float(posrep.eta()), phi);
+      KDTreeNodeInfo<reco::PFRecHit const*, 2> rh3(*it, float(posrep.eta()), phi);
       eltList.push_back(rh3);
     }
   }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndBREMLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndBREMLinker.cc
@@ -6,32 +6,25 @@
 
 class ECALAndBREMLinker : public BlockElementLinkerBase {
 public:
-  ECALAndBREMLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  ECALAndBREMLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  ECALAndBREMLinker, 
-		  "ECALAndBREMLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, ECALAndBREMLinker, "ECALAndBREMLinker");
 
-double ECALAndBREMLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const { 
-  constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax =
-    reco::PFTrajectoryPoint::ECALShowerMax;
-  const reco::PFBlockElementCluster *ecalelem(nullptr);
-  const reco::PFBlockElementBrem    *bremelem(nullptr);
+double ECALAndBREMLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax = reco::PFTrajectoryPoint::ECALShowerMax;
+  const reco::PFBlockElementCluster* ecalelem(nullptr);
+  const reco::PFBlockElementBrem* bremelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     bremelem = static_cast<const reco::PFBlockElementBrem*>(elem2);
   } else {
@@ -40,11 +33,9 @@ double ECALAndBREMLinker::testLink
   }
   const reco::PFClusterRef& clusterref = ecalelem->clusterRef();
   const reco::PFRecTrack& track = bremelem->trackPF();
-  const reco::PFTrajectoryPoint& tkAtECAL =
-    track.extrapolatedPoint( ECALShowerMax );
-  if( tkAtECAL.isValid() ) {
-    dist = LinkByRecHit::testTrackAndClusterByRecHit( track, *clusterref, 
-						      true, _debug );
-  }  
+  const reco::PFTrajectoryPoint& tkAtECAL = track.extrapolatedPoint(ECALShowerMax);
+  if (tkAtECAL.isValid()) {
+    dist = LinkByRecHit::testTrackAndClusterByRecHit(track, *clusterref, true, _debug);
+  }
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndECALLinker.cc
@@ -5,57 +5,42 @@
 
 class ECALAndECALLinker : public BlockElementLinkerBase {
 public:
-  ECALAndECALLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  bool linkPrefilter( const reco::PFBlockElement*,
-		      const reco::PFBlockElement* ) const override;
-  
-  double testLink( const reco::PFBlockElement*,
-		   const reco::PFBlockElement* ) const override;
+  ECALAndECALLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  bool linkPrefilter(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  ECALAndECALLinker, 
-		  "ECALAndECALLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, ECALAndECALLinker, "ECALAndECALLinker");
 
-bool ECALAndECALLinker::
-linkPrefilter( const reco::PFBlockElement* elem1,
-	       const reco::PFBlockElement* elem2) const { 
-  const reco::PFBlockElementCluster* ecal1 = 
-    static_cast<const reco::PFBlockElementCluster*>(elem1);
-  const reco::PFBlockElementCluster* ecal2 = 
-    static_cast<const reco::PFBlockElementCluster*>(elem2);
-  return ( ecal1->superClusterRef().isNonnull() && 
-	   ecal2->superClusterRef().isNonnull()    ); 
+bool ECALAndECALLinker::linkPrefilter(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  const reco::PFBlockElementCluster* ecal1 = static_cast<const reco::PFBlockElementCluster*>(elem1);
+  const reco::PFBlockElementCluster* ecal2 = static_cast<const reco::PFBlockElementCluster*>(elem2);
+  return (ecal1->superClusterRef().isNonnull() && ecal2->superClusterRef().isNonnull());
 }
 
-double ECALAndECALLinker::
-testLink( const reco::PFBlockElement* elem1,
-	  const reco::PFBlockElement* elem2) const { 
+double ECALAndECALLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   double dist = -1.0;
-  
-  const reco::PFBlockElementCluster* ecal1 = 
-    static_cast<const reco::PFBlockElementCluster*>(elem1);
-  const reco::PFBlockElementCluster* ecal2 = 
-    static_cast<const reco::PFBlockElementCluster*>(elem2);
- 
+
+  const reco::PFBlockElementCluster* ecal1 = static_cast<const reco::PFBlockElementCluster*>(elem1);
+  const reco::PFBlockElementCluster* ecal2 = static_cast<const reco::PFBlockElementCluster*>(elem2);
+
   const reco::SuperClusterRef& sc1 = ecal1->superClusterRef();
   const reco::SuperClusterRef& sc2 = ecal2->superClusterRef();
 
   const reco::PFClusterRef& clus1 = ecal1->clusterRef();
   const reco::PFClusterRef& clus2 = ecal2->clusterRef();
 
-  if( sc1.isNonnull() && sc2.isNonnull() && sc1 == sc2 ) {    
-    dist=LinkByRecHit::computeDist( clus1->positionREP().Eta(),
-				    clus1->positionREP().Phi(), 
-				    clus2->positionREP().Eta(), 
-				    clus2->positionREP().Phi() );
+  if (sc1.isNonnull() && sc2.isNonnull() && sc1 == sc2) {
+    dist = LinkByRecHit::computeDist(
+        clus1->positionREP().Eta(), clus1->positionREP().Phi(), clus2->positionREP().Eta(), clus2->positionREP().Phi());
   }
 
   return dist;

--- a/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndHCALCaloJetLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndHCALCaloJetLinker.cc
@@ -5,29 +5,23 @@
 
 class ECALAndHCALCaloJetLinker : public BlockElementLinkerBase {
 public:
-  ECALAndHCALCaloJetLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  ECALAndHCALCaloJetLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  ECALAndHCALCaloJetLinker, 
-		  "ECALAndHCALCaloJetLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, ECALAndHCALCaloJetLinker, "ECALAndHCALCaloJetLinker");
 
-double ECALAndHCALCaloJetLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const {  
+double ECALAndHCALCaloJetLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   const reco::PFBlockElementCluster *hcalelem(nullptr), *ecalelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
   } else {
@@ -37,21 +31,18 @@ double ECALAndHCALCaloJetLinker::testLink
   const reco::PFClusterRef& ecalref = ecalelem->clusterRef();
   const reco::PFClusterRef& hcalref = hcalelem->clusterRef();
   const reco::PFCluster::REPPoint& ecalreppos = ecalref->positionREP();
-  if( hcalref.isNull() || ecalref.isNull() ) {
-    throw cms::Exception("BadClusterRefs") 
-      << "PFBlockElementCluster's refs are null!";
-  }  
+  if (hcalref.isNull() || ecalref.isNull()) {
+    throw cms::Exception("BadClusterRefs") << "PFBlockElementCluster's refs are null!";
+  }
   //dist = ( std::abs(ecalreppos.Eta()) > 2.5 ?
   //	   LinkByRecHit::computeDist( ecalreppos.Eta(),
-  //				      ecalreppos.Phi(), 
-  // 				      hcalref->positionREP().Eta(), 
+  //				      ecalreppos.Phi(),
+  // 				      hcalref->positionREP().Eta(),
   //				      hcalref->positionREP().Phi() )
   //	   : -1.0 );
   // return (dist < 0.2 ? dist : -1.0);
-  dist = LinkByRecHit::computeDist( ecalreppos.Eta(),
-                                    ecalreppos.Phi(), 
-                                    hcalref->positionREP().Eta(), 
-                                    hcalref->positionREP().Phi() ) ;
-  
+  dist = LinkByRecHit::computeDist(
+      ecalreppos.Eta(), ecalreppos.Phi(), hcalref->positionREP().Eta(), hcalref->positionREP().Phi());
+
   return (dist < 0.2 ? dist : -1.0);
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndHCALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndHCALLinker.cc
@@ -5,29 +5,23 @@
 
 class ECALAndHCALLinker : public BlockElementLinkerBase {
 public:
-  ECALAndHCALLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  ECALAndHCALLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  ECALAndHCALLinker, 
-		  "ECALAndHCALLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, ECALAndHCALLinker, "ECALAndHCALLinker");
 
-double ECALAndHCALLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const {  
+double ECALAndHCALLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   const reco::PFBlockElementCluster *hcalelem(nullptr), *ecalelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
   } else {
@@ -37,15 +31,12 @@ double ECALAndHCALLinker::testLink
   const reco::PFClusterRef& ecalref = ecalelem->clusterRef();
   const reco::PFClusterRef& hcalref = hcalelem->clusterRef();
   const reco::PFCluster::REPPoint& ecalreppos = ecalref->positionREP();
-  if( hcalref.isNull() || ecalref.isNull() ) {
-    throw cms::Exception("BadClusterRefs") 
-      << "PFBlockElementCluster's refs are null!";
-  }  
-  dist = ( std::abs(ecalreppos.Eta()) > 2.5 ?
-	   LinkByRecHit::computeDist( ecalreppos.Eta(),
-				      ecalreppos.Phi(), 
-				      hcalref->positionREP().Eta(), 
-				      hcalref->positionREP().Phi() )
-	   : -1.0 );
+  if (hcalref.isNull() || ecalref.isNull()) {
+    throw cms::Exception("BadClusterRefs") << "PFBlockElementCluster's refs are null!";
+  }
+  dist = (std::abs(ecalreppos.Eta()) > 2.5
+              ? LinkByRecHit::computeDist(
+                    ecalreppos.Eta(), ecalreppos.Phi(), hcalref->positionREP().Eta(), hcalref->positionREP().Phi())
+              : -1.0);
   return (dist < 0.2 ? dist : -1.0);
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndBREMLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndBREMLinker.cc
@@ -6,39 +6,33 @@
 
 class GSFAndBREMLinker : public BlockElementLinkerBase {
 public:
-  GSFAndBREMLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  GSFAndBREMLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  GSFAndBREMLinker, 
-		  "GSFAndBREMLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, GSFAndBREMLinker, "GSFAndBREMLinker");
 
-double GSFAndBREMLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const {   
+double GSFAndBREMLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   double dist = -1.0;
-  const reco::PFBlockElementGsfTrack * gsfelem(nullptr);
-  const reco::PFBlockElementBrem * bremelem(nullptr);
-  if( elem1->type() < elem2->type() ) {
-    gsfelem = static_cast<const reco::PFBlockElementGsfTrack *>(elem1);
-    bremelem = static_cast<const reco::PFBlockElementBrem *>(elem2);
+  const reco::PFBlockElementGsfTrack* gsfelem(nullptr);
+  const reco::PFBlockElementBrem* bremelem(nullptr);
+  if (elem1->type() < elem2->type()) {
+    gsfelem = static_cast<const reco::PFBlockElementGsfTrack*>(elem1);
+    bremelem = static_cast<const reco::PFBlockElementBrem*>(elem2);
   } else {
-    gsfelem = static_cast<const reco::PFBlockElementGsfTrack *>(elem2);
-    bremelem = static_cast<const reco::PFBlockElementBrem *>(elem1);
-  }  
+    gsfelem = static_cast<const reco::PFBlockElementGsfTrack*>(elem2);
+    bremelem = static_cast<const reco::PFBlockElementBrem*>(elem1);
+  }
   const reco::GsfPFRecTrackRef& gsfref = gsfelem->GsftrackRefPF();
   const reco::GsfPFRecTrackRef& bremref = bremelem->GsftrackRefPF();
-  if( gsfref.isNonnull() && bremref.isNonnull() && gsfref == bremref ) {
+  if (gsfref.isNonnull() && bremref.isNonnull() && gsfref == bremref) {
     dist = 0.001;
   }
   return dist;

--- a/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndECALLinker.cc
@@ -6,55 +6,46 @@
 
 class GSFAndECALLinker : public BlockElementLinkerBase {
 public:
-  GSFAndECALLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  GSFAndECALLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  GSFAndECALLinker, 
-		  "GSFAndECALLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, GSFAndECALLinker, "GSFAndECALLinker");
 
-double GSFAndECALLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const {  
-  constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax =
-    reco::PFTrajectoryPoint::ECALShowerMax;
-  const reco::PFBlockElementCluster  *ecalelem(nullptr);
-  const reco::PFBlockElementGsfTrack *gsfelem(nullptr);
+double GSFAndECALLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax = reco::PFTrajectoryPoint::ECALShowerMax;
+  const reco::PFBlockElementCluster* ecalelem(nullptr);
+  const reco::PFBlockElementGsfTrack* gsfelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
-    gsfelem  = static_cast<const reco::PFBlockElementGsfTrack*>(elem2);
+    gsfelem = static_cast<const reco::PFBlockElementGsfTrack*>(elem2);
   } else {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
-    gsfelem  = static_cast<const reco::PFBlockElementGsfTrack*>(elem1);
+    gsfelem = static_cast<const reco::PFBlockElementGsfTrack*>(elem1);
   }
   const reco::PFRecTrack& track = gsfelem->GsftrackPF();
   const reco::PFClusterRef& clusterref = ecalelem->clusterRef();
-  const reco::PFTrajectoryPoint& tkAtECAL =
-    track.extrapolatedPoint( ECALShowerMax );
-  if( tkAtECAL.isValid() ) {
-    dist = LinkByRecHit::testTrackAndClusterByRecHit( track, *clusterref, 
-						      false, _debug );
+  const reco::PFTrajectoryPoint& tkAtECAL = track.extrapolatedPoint(ECALShowerMax);
+  if (tkAtECAL.isValid()) {
+    dist = LinkByRecHit::testTrackAndClusterByRecHit(track, *clusterref, false, _debug);
   }
-  if ( _debug ) {
-    if ( dist > 0. ) {
-      std::cout << " Here a link has been established" 
-		<< " between a GSF track an Ecal with dist  " 
-		<< dist <<  std::endl;
+  if (_debug) {
+    if (dist > 0.) {
+      std::cout << " Here a link has been established"
+                << " between a GSF track an Ecal with dist  " << dist << std::endl;
     } else {
-      if( _debug ) std::cout << " No link found " << std::endl;
+      if (_debug)
+        std::cout << " No link found " << std::endl;
     }
   }
-  
+
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndGSFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndGSFLinker.cc
@@ -6,41 +6,32 @@
 
 class GSFAndGSFLinker : public BlockElementLinkerBase {
 public:
-  GSFAndGSFLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  GSFAndGSFLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  GSFAndGSFLinker, 
-		  "GSFAndGSFLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, GSFAndGSFLinker, "GSFAndGSFLinker");
 
-double GSFAndGSFLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const { 
-  constexpr reco::PFBlockElement::TrackType T_FROM_GAMMACONV =
-    reco::PFBlockElement::T_FROM_GAMMACONV;
+double GSFAndGSFLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFBlockElement::TrackType T_FROM_GAMMACONV = reco::PFBlockElement::T_FROM_GAMMACONV;
   double dist = -1.0;
-  const reco::PFBlockElementGsfTrack * gsfelem1 =
-    static_cast<const reco::PFBlockElementGsfTrack *>(elem1);
-  const reco::PFBlockElementGsfTrack * gsfelem2 = 
-    static_cast<const reco::PFBlockElementGsfTrack *>(elem2);
+  const reco::PFBlockElementGsfTrack* gsfelem1 = static_cast<const reco::PFBlockElementGsfTrack*>(elem1);
+  const reco::PFBlockElementGsfTrack* gsfelem2 = static_cast<const reco::PFBlockElementGsfTrack*>(elem2);
   const reco::GsfPFRecTrackRef& gsfref1 = gsfelem1->GsftrackRefPF();
   const reco::GsfPFRecTrackRef& gsfref2 = gsfelem2->GsftrackRefPF();
-  if( gsfref1.isNonnull() && gsfref2.isNonnull() ) {
-    if( gsfelem1->trackType(T_FROM_GAMMACONV) != // we want **one** primary GSF 
-	gsfelem2->trackType(T_FROM_GAMMACONV) &&
-	gsfref1->trackId() == gsfref2->trackId() ) {
+  if (gsfref1.isNonnull() && gsfref2.isNonnull()) {
+    if (gsfelem1->trackType(T_FROM_GAMMACONV) !=  // we want **one** primary GSF
+            gsfelem2->trackType(T_FROM_GAMMACONV) &&
+        gsfref1->trackId() == gsfref2->trackId()) {
       dist = 0.001;
-    }	
+    }
   }
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndHCALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndHCALLinker.cc
@@ -6,55 +6,46 @@
 
 class GSFAndHCALLinker : public BlockElementLinkerBase {
 public:
-  GSFAndHCALLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  GSFAndHCALLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  GSFAndHCALLinker, 
-		  "GSFAndHCALLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, GSFAndHCALLinker, "GSFAndHCALLinker");
 
-double GSFAndHCALLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const {  
-  constexpr reco::PFTrajectoryPoint::LayerType HCALEnt =
-    reco::PFTrajectoryPoint::HCALEntrance;
-  const reco::PFBlockElementCluster  *hcalelem(nullptr);
-  const reco::PFBlockElementGsfTrack *gsfelem(nullptr);
+double GSFAndHCALLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFTrajectoryPoint::LayerType HCALEnt = reco::PFTrajectoryPoint::HCALEntrance;
+  const reco::PFBlockElementCluster* hcalelem(nullptr);
+  const reco::PFBlockElementGsfTrack* gsfelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
-    gsfelem  = static_cast<const reco::PFBlockElementGsfTrack*>(elem2);
+    gsfelem = static_cast<const reco::PFBlockElementGsfTrack*>(elem2);
   } else {
     hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
-    gsfelem  = static_cast<const reco::PFBlockElementGsfTrack*>(elem1);
+    gsfelem = static_cast<const reco::PFBlockElementGsfTrack*>(elem1);
   }
   const reco::PFRecTrack& track = gsfelem->GsftrackPF();
   const reco::PFClusterRef& clusterref = hcalelem->clusterRef();
-  const reco::PFTrajectoryPoint& tkAtHCAL =
-    track.extrapolatedPoint( HCALEnt );
-  if( tkAtHCAL.isValid() ) {
-    dist = LinkByRecHit::testTrackAndClusterByRecHit( track, *clusterref, 
-						      false, _debug );
+  const reco::PFTrajectoryPoint& tkAtHCAL = track.extrapolatedPoint(HCALEnt);
+  if (tkAtHCAL.isValid()) {
+    dist = LinkByRecHit::testTrackAndClusterByRecHit(track, *clusterref, false, _debug);
   }
-  if ( _debug ) {
-    if ( dist > 0. ) {
-      std::cout << " Here a link has been established" 
-		<< " between a GSF track an Hcal with dist  " 
-		<< dist <<  std::endl;
+  if (_debug) {
+    if (dist > 0.) {
+      std::cout << " Here a link has been established"
+                << " between a GSF track an Hcal with dist  " << dist << std::endl;
     } else {
-      if( _debug ) std::cout << " No link found " << std::endl;
+      if (_debug)
+        std::cout << " No link found " << std::endl;
     }
   }
-  
+
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndHGCalLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndHGCalLinker.cc
@@ -6,58 +6,51 @@
 
 class GSFAndHGCalLinker : public BlockElementLinkerBase {
 public:
-  GSFAndHGCalLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  GSFAndHGCalLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  GSFAndHGCalLinker, 
-		  "GSFAndHGCalLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, GSFAndHGCalLinker, "GSFAndHGCalLinker");
 
-double GSFAndHGCalLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const {  
-  constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax =
-    reco::PFTrajectoryPoint::ECALShowerMax;
-  const reco::PFBlockElementCluster  *hgcalelem(nullptr);
-  const reco::PFBlockElementGsfTrack *gsfelem(nullptr);
+double GSFAndHGCalLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax = reco::PFTrajectoryPoint::ECALShowerMax;
+  const reco::PFBlockElementCluster* hgcalelem(nullptr);
+  const reco::PFBlockElementGsfTrack* gsfelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() > elem2->type() ) {
+  if (elem1->type() > elem2->type()) {
     hgcalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
-    gsfelem  = static_cast<const reco::PFBlockElementGsfTrack*>(elem2);
+    gsfelem = static_cast<const reco::PFBlockElementGsfTrack*>(elem2);
   } else {
     hgcalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
-    gsfelem  = static_cast<const reco::PFBlockElementGsfTrack*>(elem1);
+    gsfelem = static_cast<const reco::PFBlockElementGsfTrack*>(elem1);
   }
   const reco::PFRecTrack& track = gsfelem->GsftrackPF();
   const reco::PFClusterRef& clusterref = hgcalelem->clusterRef();
-  const reco::PFTrajectoryPoint& tkAtECAL =
-    track.extrapolatedPoint( ECALShowerMax );
-  if( tkAtECAL.isValid() ) {
-    dist = LinkByRecHit::computeDist( tkAtECAL.positionREP().eta(),
-				      tkAtECAL.positionREP().phi(), 
-				      clusterref->positionREP().Eta(), 
-				      clusterref->positionREP().Phi() );
-    if( dist > 0.3 ) dist = -1.0;
+  const reco::PFTrajectoryPoint& tkAtECAL = track.extrapolatedPoint(ECALShowerMax);
+  if (tkAtECAL.isValid()) {
+    dist = LinkByRecHit::computeDist(tkAtECAL.positionREP().eta(),
+                                     tkAtECAL.positionREP().phi(),
+                                     clusterref->positionREP().Eta(),
+                                     clusterref->positionREP().Phi());
+    if (dist > 0.3)
+      dist = -1.0;
   }
-  if ( _debug ) {
-    if ( dist > 0. ) {
-      std::cout << " Here a link has been established" 
-		<< " between a GSF track an HGCal with dist  " 
-		<< dist <<  std::endl;
+  if (_debug) {
+    if (dist > 0.) {
+      std::cout << " Here a link has been established"
+                << " between a GSF track an HGCal with dist  " << dist << std::endl;
     } else {
-      if( _debug ) std::cout << " No link found " << std::endl;
+      if (_debug)
+        std::cout << " No link found " << std::endl;
     }
   }
-  
+
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/HCALAndBREMLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/HCALAndBREMLinker.cc
@@ -6,32 +6,25 @@
 
 class HCALAndBREMLinker : public BlockElementLinkerBase {
 public:
-  HCALAndBREMLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  HCALAndBREMLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  HCALAndBREMLinker, 
-		  "HCALAndBREMLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, HCALAndBREMLinker, "HCALAndBREMLinker");
 
-double HCALAndBREMLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const { 
-  constexpr reco::PFTrajectoryPoint::LayerType HCALEnt =
-    reco::PFTrajectoryPoint::HCALEntrance;
-  const reco::PFBlockElementCluster *hcalelem(nullptr);
-  const reco::PFBlockElementBrem    *bremelem(nullptr);
+double HCALAndBREMLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFTrajectoryPoint::LayerType HCALEnt = reco::PFTrajectoryPoint::HCALEntrance;
+  const reco::PFBlockElementCluster* hcalelem(nullptr);
+  const reco::PFBlockElementBrem* bremelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     bremelem = static_cast<const reco::PFBlockElementBrem*>(elem2);
   } else {
@@ -40,11 +33,9 @@ double HCALAndBREMLinker::testLink
   }
   const reco::PFClusterRef& clusterref = hcalelem->clusterRef();
   const reco::PFRecTrack& track = bremelem->trackPF();
-  const reco::PFTrajectoryPoint& tkAtHCAL =
-    track.extrapolatedPoint( HCALEnt );
-  if( tkAtHCAL.isValid() ) {
-    dist = LinkByRecHit::testTrackAndClusterByRecHit( track, *clusterref, 
-						      true, _debug );
-  }  
+  const reco::PFTrajectoryPoint& tkAtHCAL = track.extrapolatedPoint(HCALEnt);
+  if (tkAtHCAL.isValid()) {
+    dist = LinkByRecHit::testTrackAndClusterByRecHit(track, *clusterref, true, _debug);
+  }
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/HCALAndHOLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/HCALAndHOLinker.cc
@@ -5,29 +5,23 @@
 
 class HCALAndHOLinker : public BlockElementLinkerBase {
 public:
-  HCALAndHOLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  HCALAndHOLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  HCALAndHOLinker, 
-		  "HCALAndHOLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, HCALAndHOLinker, "HCALAndHOLinker");
 
-double HCALAndHOLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const {  
+double HCALAndHOLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   const reco::PFBlockElementCluster *hcalelem(nullptr), *hoelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     hoelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
   } else {
@@ -37,15 +31,12 @@ double HCALAndHOLinker::testLink
   const reco::PFClusterRef& hcalref = hcalelem->clusterRef();
   const reco::PFClusterRef& horef = hoelem->clusterRef();
   const reco::PFCluster::REPPoint& hcalreppos = hcalref->positionREP();
-  if( hcalref.isNull() || horef.isNull() ) {
-    throw cms::Exception("BadClusterRefs") 
-      << "PFBlockElementCluster's refs are null!";
-  }  
-  dist = ( std::abs(hcalreppos.Eta()) < 1.5 ?
-	   LinkByRecHit::computeDist( hcalreppos.Eta(),
-				      hcalreppos.Phi(), 
-				      horef->positionREP().Eta(), 
-				      horef->positionREP().Phi() )
-	   : -1.0 );
+  if (hcalref.isNull() || horef.isNull()) {
+    throw cms::Exception("BadClusterRefs") << "PFBlockElementCluster's refs are null!";
+  }
+  dist = (std::abs(hcalreppos.Eta()) < 1.5
+              ? LinkByRecHit::computeDist(
+                    hcalreppos.Eta(), hcalreppos.Phi(), horef->positionREP().Eta(), horef->positionREP().Phi())
+              : -1.0);
   return (dist < 0.2 ? dist : -1.0);
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/HFEMAndHFHADLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/HFEMAndHFHADLinker.cc
@@ -5,39 +5,32 @@
 
 class HFEMAndHFHADLinker : public BlockElementLinkerBase {
 public:
-  HFEMAndHFHADLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  HFEMAndHFHADLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  HFEMAndHFHADLinker, 
-		  "HFEMAndHFHADLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, HFEMAndHFHADLinker, "HFEMAndHFHADLinker");
 
-double HFEMAndHFHADLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const {  
+double HFEMAndHFHADLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   const reco::PFBlockElementCluster *hfemelem(nullptr), *hfhadelem(nullptr);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     hfemelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     hfhadelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
   } else {
     hfemelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
     hfhadelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
   }
-  const reco::PFClusterRef& hfemref  = hfemelem->clusterRef();
+  const reco::PFClusterRef& hfemref = hfemelem->clusterRef();
   const reco::PFClusterRef& hfhadref = hfhadelem->clusterRef();
-  if( hfemref.isNull() || hfhadref.isNull() ) {
-    throw cms::Exception("BadClusterRefs") 
-      << "PFBlockElementCluster's refs are null!";
-  }    
-  return LinkByRecHit::testHFEMAndHFHADByRecHit( *hfemref, *hfhadref, _debug );
+  if (hfemref.isNull() || hfhadref.isNull()) {
+    throw cms::Exception("BadClusterRefs") << "PFBlockElementCluster's refs are null!";
+  }
+  return LinkByRecHit::testHFEMAndHFHADByRecHit(*hfemref, *hfhadref, _debug);
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/HGCalandBREMLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/HGCalandBREMLinker.cc
@@ -6,32 +6,25 @@
 
 class HGCalAndBREMLinker : public BlockElementLinkerBase {
 public:
-  HGCalAndBREMLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  HGCalAndBREMLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  HGCalAndBREMLinker, 
-		  "HGCalAndBREMLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, HGCalAndBREMLinker, "HGCalAndBREMLinker");
 
-double HGCalAndBREMLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const { 
-  constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax =
-    reco::PFTrajectoryPoint::ECALShowerMax;
-  const reco::PFBlockElementCluster *ecalelem(nullptr);
-  const reco::PFBlockElementBrem    *bremelem(nullptr);
+double HGCalAndBREMLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax = reco::PFTrajectoryPoint::ECALShowerMax;
+  const reco::PFBlockElementCluster* ecalelem(nullptr);
+  const reco::PFBlockElementBrem* bremelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() > elem2->type() ) {
+  if (elem1->type() > elem2->type()) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     bremelem = static_cast<const reco::PFBlockElementBrem*>(elem2);
   } else {
@@ -40,14 +33,14 @@ double HGCalAndBREMLinker::testLink
   }
   const reco::PFClusterRef& clusterref = ecalelem->clusterRef();
   const reco::PFRecTrack& track = bremelem->trackPF();
-  const reco::PFTrajectoryPoint& tkAtECAL =
-    track.extrapolatedPoint( ECALShowerMax );
-  if( tkAtECAL.isValid() ) {
-    dist = LinkByRecHit::computeDist( tkAtECAL.positionREP().eta(),
-				      tkAtECAL.positionREP().phi(), 
-				      clusterref->positionREP().Eta(), 
-				      clusterref->positionREP().Phi() );
-    if( dist > 0.3 ) dist = -1.0;
-  }  
+  const reco::PFTrajectoryPoint& tkAtECAL = track.extrapolatedPoint(ECALShowerMax);
+  if (tkAtECAL.isValid()) {
+    dist = LinkByRecHit::computeDist(tkAtECAL.positionREP().eta(),
+                                     tkAtECAL.positionREP().phi(),
+                                     clusterref->positionREP().Eta(),
+                                     clusterref->positionREP().Phi());
+    if (dist > 0.3)
+      dist = -1.0;
+  }
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
@@ -5,51 +5,41 @@
 
 class PreshowerAndECALLinker : public BlockElementLinkerBase {
 public:
-  PreshowerAndECALLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  bool linkPrefilter( const reco::PFBlockElement*,
-		      const reco::PFBlockElement* ) const override;
+  PreshowerAndECALLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
 
-  double testLink( const reco::PFBlockElement*,
-		   const reco::PFBlockElement* ) const override;
+  bool linkPrefilter(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  PreshowerAndECALLinker, 
-		  "PreshowerAndECALLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, PreshowerAndECALLinker, "PreshowerAndECALLinker");
 
-bool PreshowerAndECALLinker::
-linkPrefilter( const reco::PFBlockElement* elem1,
-	       const reco::PFBlockElement* elem2 ) const {  
+bool PreshowerAndECALLinker::linkPrefilter(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   bool result = false;
-  switch( elem1->type() ){
-  case reco::PFBlockElement::PS1:
-  case reco::PFBlockElement::PS2:
-    result = ( elem1->isMultilinksValide() && 
-	       !elem1->getMultilinks().empty() );    
-    break;
-  case reco::PFBlockElement::ECAL:
-    result = ( elem2->isMultilinksValide() && 
-	       !elem2->getMultilinks().empty() );
-    break;
-  default:
-    break;
-  }   
+  switch (elem1->type()) {
+    case reco::PFBlockElement::PS1:
+    case reco::PFBlockElement::PS2:
+      result = (elem1->isMultilinksValide() && !elem1->getMultilinks().empty());
+      break;
+    case reco::PFBlockElement::ECAL:
+      result = (elem2->isMultilinksValide() && !elem2->getMultilinks().empty());
+      break;
+    default:
+      break;
+  }
   return (_useKDTree ? result : true);
 }
 
-double PreshowerAndECALLinker::
-testLink( const reco::PFBlockElement* elem1,
-	  const reco::PFBlockElement* elem2) const {  
+double PreshowerAndECALLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   const reco::PFBlockElementCluster *pselem(nullptr), *ecalelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     pselem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
   } else {
@@ -57,36 +47,33 @@ testLink( const reco::PFBlockElement* elem1,
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
   }
   const reco::PFClusterRef& psref = pselem->clusterRef();
-  const reco::PFClusterRef& ecalref = ecalelem->clusterRef();  
-  if( psref.isNull() || ecalref.isNull() ) {
-    throw cms::Exception("BadClusterRefs") 
-      << "PFBlockElementCluster's refs are null!";
-  }  
+  const reco::PFClusterRef& ecalref = ecalelem->clusterRef();
+  if (psref.isNull() || ecalref.isNull()) {
+    throw cms::Exception("BadClusterRefs") << "PFBlockElementCluster's refs are null!";
+  }
   // Check if the linking has been done using the KDTree algo
   // Glowinski & Gouzevitch
-  if ( _useKDTree && pselem->isMultilinksValide() ) { // KDTree algo
-    const reco::PFMultilinksType& multilinks = pselem->getMultilinks();	
-    const reco::PFCluster::REPPoint&  ecalreppos = ecalref->positionREP();
+  if (_useKDTree && pselem->isMultilinksValide()) {  // KDTree algo
+    const reco::PFMultilinksType& multilinks = pselem->getMultilinks();
+    const reco::PFCluster::REPPoint& ecalreppos = ecalref->positionREP();
     const math::XYZPoint& ecalxyzpos = ecalref->position();
     const math::XYZPoint& psxyzpos = psref->position();
     const double ecalPhi = ecalreppos.Phi();
     const double ecalEta = ecalreppos.Eta();
-    
+
     // Check if the link PS/Ecal exist
     reco::PFMultilinksType::const_iterator mlit = multilinks.begin();
     for (; mlit != multilinks.end(); ++mlit)
       if ((mlit->first == ecalPhi) && (mlit->second == ecalEta))
-	break;
-    
-    // If the link exist, we fill dist and linktest. 
-    if (mlit != multilinks.end()){      
-      dist = 
-	LinkByRecHit::computeDist(ecalxyzpos.X()/1000.,ecalxyzpos.Y()/1000.,
-				  psxyzpos.X()/1000.  ,psxyzpos.Y()/1000., 
-				  false);
-    }   
-  } else { //Old algorithm
-    dist = LinkByRecHit::testECALAndPSByRecHit( *ecalref, *psref ,_debug);
+        break;
+
+    // If the link exist, we fill dist and linktest.
+    if (mlit != multilinks.end()) {
+      dist = LinkByRecHit::computeDist(
+          ecalxyzpos.X() / 1000., ecalxyzpos.Y() / 1000., psxyzpos.X() / 1000., psxyzpos.Y() / 1000., false);
+    }
+  } else {  //Old algorithm
+    dist = LinkByRecHit::testECALAndPSByRecHit(*ecalref, *psref, _debug);
   }
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/SCAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/SCAndECALLinker.cc
@@ -7,31 +7,25 @@
 
 class SCAndECALLinker : public BlockElementLinkerBase {
 public:
-  SCAndECALLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)),
-    _superClusterMatchByRef(conf.getParameter<bool>("SuperClusterMatchByRef")){}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  SCAndECALLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)),
+        _superClusterMatchByRef(conf.getParameter<bool>("SuperClusterMatchByRef")) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug,_superClusterMatchByRef;
+  bool _useKDTree, _debug, _superClusterMatchByRef;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  SCAndECALLinker, 
-		  "SCAndECALLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, SCAndECALLinker, "SCAndECALLinker");
 
-double SCAndECALLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const { 
-  double dist = -1.0;  
-  const reco::PFBlockElementCluster* ecalelem(nullptr);    
-  const reco::PFBlockElementSuperCluster* scelem(nullptr); 
-  if( elem1->type() < elem2->type() ) {
+double SCAndECALLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  double dist = -1.0;
+  const reco::PFBlockElementCluster* ecalelem(nullptr);
+  const reco::PFBlockElementSuperCluster* scelem(nullptr);
+  if (elem1->type() < elem2->type()) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     scelem = static_cast<const reco::PFBlockElementSuperCluster*>(elem2);
   } else {
@@ -40,19 +34,17 @@ double SCAndECALLinker::testLink
   }
   const reco::PFClusterRef& clus = ecalelem->clusterRef();
   const reco::SuperClusterRef& sclus = scelem->superClusterRef();
-  if( sclus.isNull() ) {
-    throw cms::Exception("BadRef")
-      << "SuperClusterRef is invalid!";
+  if (sclus.isNull()) {
+    throw cms::Exception("BadRef") << "SuperClusterRef is invalid!";
   }
-  
-  if( _superClusterMatchByRef ) {
-    if( sclus == ecalelem->superClusterRef() ) dist = 0.001;
+
+  if (_superClusterMatchByRef) {
+    if (sclus == ecalelem->superClusterRef())
+      dist = 0.001;
   } else {
-    if( ClusterClusterMapping::overlap(*sclus,*clus) ) {
-      dist = LinkByRecHit::computeDist( sclus->position().eta(),
-					sclus->position().phi(), 
-					clus->positionREP().Eta(), 
-					clus->positionREP().Phi() );
+    if (ClusterClusterMapping::overlap(*sclus, *clus)) {
+      dist = LinkByRecHit::computeDist(
+          sclus->position().eta(), sclus->position().phi(), clus->positionREP().Eta(), clus->positionREP().Phi());
     }
   }
   return dist;

--- a/RecoParticleFlow/PFProducer/plugins/linkers/SCAndHGCalLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/SCAndHGCalLinker.cc
@@ -7,31 +7,25 @@
 
 class SCAndHGCalLinker : public BlockElementLinkerBase {
 public:
-  SCAndHGCalLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)),
-    _superClusterMatchByRef(conf.getParameter<bool>("SuperClusterMatchByRef")){}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  SCAndHGCalLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)),
+        _superClusterMatchByRef(conf.getParameter<bool>("SuperClusterMatchByRef")) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug,_superClusterMatchByRef;
+  bool _useKDTree, _debug, _superClusterMatchByRef;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  SCAndHGCalLinker, 
-		  "SCAndHGCalLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, SCAndHGCalLinker, "SCAndHGCalLinker");
 
-double SCAndHGCalLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const { 
-  double dist = -1.0;  
-  const reco::PFBlockElementCluster* ecalelem(nullptr);    
-  const reco::PFBlockElementSuperCluster* scelem(nullptr); 
-  if( elem1->type() > elem2->type() ) {
+double SCAndHGCalLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  double dist = -1.0;
+  const reco::PFBlockElementCluster* ecalelem(nullptr);
+  const reco::PFBlockElementSuperCluster* scelem(nullptr);
+  if (elem1->type() > elem2->type()) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     scelem = static_cast<const reco::PFBlockElementSuperCluster*>(elem2);
   } else {
@@ -40,21 +34,19 @@ double SCAndHGCalLinker::testLink
   }
   const reco::PFClusterRef& clus = ecalelem->clusterRef();
   const reco::SuperClusterRef& sclus = scelem->superClusterRef();
-  if( sclus.isNull() ) {
-    throw cms::Exception("BadRef")
-      << "SuperClusterRef is invalid!";
+  if (sclus.isNull()) {
+    throw cms::Exception("BadRef") << "SuperClusterRef is invalid!";
   }
-  
-  if( _superClusterMatchByRef ) {
-    if( sclus == ecalelem->superClusterRef() ) dist = 0.001;
+
+  if (_superClusterMatchByRef) {
+    if (sclus == ecalelem->superClusterRef())
+      dist = 0.001;
   } else {
-    if( ClusterClusterMapping::overlap(*sclus,*clus) ) {
-      dist = LinkByRecHit::computeDist( sclus->position().eta(),
-					sclus->position().phi(), 
-					clus->positionREP().Eta(), 
-					clus->positionREP().Phi() );
+    if (ClusterClusterMapping::overlap(*sclus, *clus)) {
+      dist = LinkByRecHit::computeDist(
+          sclus->position().eta(), sclus->position().phi(), clus->positionREP().Eta(), clus->positionREP().Phi());
     }
   }
-  
+
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndECALLinker.cc
@@ -6,50 +6,41 @@
 
 class TrackAndECALLinker : public BlockElementLinkerBase {
 public:
-  TrackAndECALLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  bool linkPrefilter( const reco::PFBlockElement*,
-		      const reco::PFBlockElement* ) const override;
+  TrackAndECALLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
 
-  double testLink( const reco::PFBlockElement*,
-		   const reco::PFBlockElement* ) const override;
+  bool linkPrefilter(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  const bool _useKDTree,_debug;
+  const bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  TrackAndECALLinker, 
-		  "TrackAndECALLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, TrackAndECALLinker, "TrackAndECALLinker");
 
-bool TrackAndECALLinker::
-linkPrefilter( const reco::PFBlockElement* elem1,
-	       const reco::PFBlockElement* elem2 ) const {  
+bool TrackAndECALLinker::linkPrefilter(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   bool result = false;
-  switch( elem1->type() ){ 
-  case reco::PFBlockElement::TRACK:
-    result = (elem1->isMultilinksValide() && !elem1->getMultilinks().empty());
-    break;
-  case reco::PFBlockElement::ECAL:
-    result = (elem2->isMultilinksValide() && !elem2->getMultilinks().empty());
-  default:
-    break;
-  } 
-  return (_useKDTree ? result : true);  
+  switch (elem1->type()) {
+    case reco::PFBlockElement::TRACK:
+      result = (elem1->isMultilinksValide() && !elem1->getMultilinks().empty());
+      break;
+    case reco::PFBlockElement::ECAL:
+      result = (elem2->isMultilinksValide() && !elem2->getMultilinks().empty());
+    default:
+      break;
+  }
+  return (_useKDTree ? result : true);
 }
 
-double TrackAndECALLinker::
-testLink( const reco::PFBlockElement* elem1,
-	  const reco::PFBlockElement* elem2 ) const {  
-  constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax =
-    reco::PFTrajectoryPoint::ECALShowerMax;
-  const reco::PFBlockElementCluster *ecalelem(nullptr);
-  const reco::PFBlockElementTrack   *tkelem(nullptr);
+double TrackAndECALLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax = reco::PFTrajectoryPoint::ECALShowerMax;
+  const reco::PFBlockElementCluster* ecalelem(nullptr);
+  const reco::PFBlockElementTrack* tkelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     tkelem = static_cast<const reco::PFBlockElementTrack*>(elem1);
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
   } else {
@@ -58,44 +49,39 @@ testLink( const reco::PFBlockElement* elem1,
   }
   const reco::PFRecTrackRef& trackref = tkelem->trackRefPF();
   const reco::PFClusterRef& clusterref = ecalelem->clusterRef();
-  const reco::PFCluster::REPPoint& ecalreppos = clusterref->positionREP(); 
-  const reco::PFTrajectoryPoint& tkAtECAL =
-    trackref->extrapolatedPoint( ECALShowerMax );
-   const reco::PFCluster::REPPoint& tkreppos = tkAtECAL.positionREP();
+  const reco::PFCluster::REPPoint& ecalreppos = clusterref->positionREP();
+  const reco::PFTrajectoryPoint& tkAtECAL = trackref->extrapolatedPoint(ECALShowerMax);
+  const reco::PFCluster::REPPoint& tkreppos = tkAtECAL.positionREP();
 
   // Check if the linking has been done using the KDTree algo
   // Glowinski & Gouzevitch
-  if ( _useKDTree && tkelem->isMultilinksValide() ) { //KDTree Algo    
+  if (_useKDTree && tkelem->isMultilinksValide()) {  //KDTree Algo
     const reco::PFMultilinksType& multilinks = tkelem->getMultilinks();
     const double ecalphi = ecalreppos.Phi();
     const double ecaleta = ecalreppos.Eta();
-    
+
     // Check if the link Track/Ecal exist
     reco::PFMultilinksType::const_iterator mlit = multilinks.begin();
     for (; mlit != multilinks.end(); ++mlit)
       if ((mlit->first == ecalphi) && (mlit->second == ecaleta))
-	break;
-    
-    // If the link exist, we fill dist and linktest. 
-    if (mlit != multilinks.end()){      
-      dist = LinkByRecHit::computeDist(ecaleta, ecalphi, 
-				       tkreppos.Eta(), tkreppos.Phi());
+        break;
+
+    // If the link exist, we fill dist and linktest.
+    if (mlit != multilinks.end()) {
+      dist = LinkByRecHit::computeDist(ecaleta, ecalphi, tkreppos.Eta(), tkreppos.Phi());
     }
-    
-  } else {// Old algorithm
-    if ( tkAtECAL.isValid() )
-      dist = LinkByRecHit::testTrackAndClusterByRecHit( *trackref, 
-							*clusterref, 
-							false, _debug );
+
+  } else {  // Old algorithm
+    if (tkAtECAL.isValid())
+      dist = LinkByRecHit::testTrackAndClusterByRecHit(*trackref, *clusterref, false, _debug);
   }
-  
-  if ( _debug ) { 
-    if( dist > 0. ) { 
+
+  if (_debug) {
+    if (dist > 0.) {
       std::cout << " Here a link has been established"
-		<< " between a track an Ecal with dist  " 
-		<< dist <<  std::endl;
+                << " between a track an Ecal with dist  " << dist << std::endl;
     } else
       std::cout << " No link found " << std::endl;
-  }  
+  }
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndGSFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndGSFLinker.cc
@@ -6,70 +6,60 @@
 
 class TrackAndGSFLinker : public BlockElementLinkerBase {
 public:
-  TrackAndGSFLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _useConvertedBrems(conf.getParameter<bool>("useConvertedBrems")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  TrackAndGSFLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _useConvertedBrems(conf.getParameter<bool>("useConvertedBrems")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_useConvertedBrems,_debug;
+  bool _useKDTree, _useConvertedBrems, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  TrackAndGSFLinker, 
-		  "TrackAndGSFLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, TrackAndGSFLinker, "TrackAndGSFLinker");
 
-double TrackAndGSFLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const { 
-  constexpr reco::PFBlockElement::TrackType T_FROM_GAMMACONV =
-    reco::PFBlockElement::T_FROM_GAMMACONV;
+double TrackAndGSFLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFBlockElement::TrackType T_FROM_GAMMACONV = reco::PFBlockElement::T_FROM_GAMMACONV;
   double dist = -1.0;
-  const reco::PFBlockElementGsfTrack * gsfelem(nullptr);
-  const reco::PFBlockElementTrack * tkelem(nullptr);
-  if( elem1->type() < elem2->type() ) {
-    tkelem = static_cast<const reco::PFBlockElementTrack *>(elem1);
-    gsfelem = static_cast<const reco::PFBlockElementGsfTrack *>(elem2);
+  const reco::PFBlockElementGsfTrack* gsfelem(nullptr);
+  const reco::PFBlockElementTrack* tkelem(nullptr);
+  if (elem1->type() < elem2->type()) {
+    tkelem = static_cast<const reco::PFBlockElementTrack*>(elem1);
+    gsfelem = static_cast<const reco::PFBlockElementGsfTrack*>(elem2);
   } else {
-    tkelem = static_cast<const reco::PFBlockElementTrack *>(elem2);
-    gsfelem = static_cast<const reco::PFBlockElementGsfTrack *>(elem1);
-  }  
-  
-  const reco::PFRecTrackRef& trackref = tkelem->trackRefPF();  	  
+    tkelem = static_cast<const reco::PFBlockElementTrack*>(elem2);
+    gsfelem = static_cast<const reco::PFBlockElementGsfTrack*>(elem1);
+  }
+
+  const reco::PFRecTrackRef& trackref = tkelem->trackRefPF();
   const reco::GsfPFRecTrackRef& gsfref = gsfelem->GsftrackRefPF();
-  const reco::TrackRef& kftrackref= trackref->trackRef();
+  const reco::TrackRef& kftrackref = trackref->trackRef();
   const reco::TrackBaseRef kftrackrefbase(kftrackref);
   const reco::PFRecTrackRef& refkf = gsfref->kfPFRecTrackRef();
-  if(refkf.isNonnull()) {
+  if (refkf.isNonnull()) {
     const reco::TrackRef& gsftrackref = refkf->trackRef();
-    if ( gsftrackref.isNonnull() && kftrackref.isNonnull() &&
-	 kftrackref == gsftrackref ) {      
-	dist = 0.001;
+    if (gsftrackref.isNonnull() && kftrackref.isNonnull() && kftrackref == gsftrackref) {
+      dist = 0.001;
     }
   }
-  
+
   //override for converted brems
-  if(_useConvertedBrems) {
-    if(tkelem->isLinkedToDisplacedVertex()){
-      const std::vector<reco::PFRecTrackRef>& convbrems = 
-	gsfref->convBremPFRecTrackRef();
-      for( const auto& convbrem : convbrems ) {
-	if( tkelem->trackType(T_FROM_GAMMACONV) &&
-	    kftrackref == convbrem->trackRef() ) {
-	  dist = 0.001;
-	} else { // check the base ref as well (for dedicated conversions?)
-	  const reco::TrackBaseRef convbrembase(convbrem->trackRef());
-	  if( convbrembase == kftrackrefbase ) {
-	    dist = 0.001;
-	  }
-	}
+  if (_useConvertedBrems) {
+    if (tkelem->isLinkedToDisplacedVertex()) {
+      const std::vector<reco::PFRecTrackRef>& convbrems = gsfref->convBremPFRecTrackRef();
+      for (const auto& convbrem : convbrems) {
+        if (tkelem->trackType(T_FROM_GAMMACONV) && kftrackref == convbrem->trackRef()) {
+          dist = 0.001;
+        } else {  // check the base ref as well (for dedicated conversions?)
+          const reco::TrackBaseRef convbrembase(convbrem->trackRef());
+          if (convbrembase == kftrackrefbase) {
+            dist = 0.001;
+          }
+        }
       }
     }
-  }  
+  }
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
@@ -8,34 +8,26 @@
 
 class TrackAndHCALLinker : public BlockElementLinkerBase {
 public:
-  TrackAndHCALLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  TrackAndHCALLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  TrackAndHCALLinker, 
-		  "TrackAndHCALLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, TrackAndHCALLinker, "TrackAndHCALLinker");
 
-double TrackAndHCALLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const {  
-  constexpr reco::PFTrajectoryPoint::LayerType HCALEntrance =
-    reco::PFTrajectoryPoint::HCALEntrance;
-  constexpr reco::PFTrajectoryPoint::LayerType HCALExit =
-    reco::PFTrajectoryPoint::HCALExit;
-  const reco::PFBlockElementCluster *hcalelem(nullptr);
-  const reco::PFBlockElementTrack   *tkelem(nullptr);
+double TrackAndHCALLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFTrajectoryPoint::LayerType HCALEntrance = reco::PFTrajectoryPoint::HCALEntrance;
+  constexpr reco::PFTrajectoryPoint::LayerType HCALExit = reco::PFTrajectoryPoint::HCALExit;
+  const reco::PFBlockElementCluster* hcalelem(nullptr);
+  const reco::PFBlockElementTrack* tkelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     tkelem = static_cast<const reco::PFBlockElementTrack*>(elem1);
     hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
   } else {
@@ -44,58 +36,42 @@ double TrackAndHCALLinker::testLink
   }
   const reco::PFRecTrackRef& trackref = tkelem->trackRefPF();
   const reco::PFClusterRef& clusterref = hcalelem->clusterRef();
-  const reco::PFCluster::REPPoint& hcalreppos = clusterref->positionREP(); 
-  const reco::PFTrajectoryPoint& tkAtHCALEnt =
-    trackref->extrapolatedPoint( HCALEntrance );
-  const reco::PFTrajectoryPoint& tkAtHCALEx =
-    trackref->extrapolatedPoint( HCALExit );
-  const double dHEta = ( tkAtHCALEx.positionREP().Eta() - 
-			 tkAtHCALEnt.positionREP().Eta()  );
-  const double dHPhi = reco::deltaPhi( tkAtHCALEx.positionREP().Phi(), 
-				       tkAtHCALEnt.positionREP().Phi() );
-  if ( _useKDTree && hcalelem->isMultilinksValide() ) { //KDTree Algo
+  const reco::PFCluster::REPPoint& hcalreppos = clusterref->positionREP();
+  const reco::PFTrajectoryPoint& tkAtHCALEnt = trackref->extrapolatedPoint(HCALEntrance);
+  const reco::PFTrajectoryPoint& tkAtHCALEx = trackref->extrapolatedPoint(HCALExit);
+  const double dHEta = (tkAtHCALEx.positionREP().Eta() - tkAtHCALEnt.positionREP().Eta());
+  const double dHPhi = reco::deltaPhi(tkAtHCALEx.positionREP().Phi(), tkAtHCALEnt.positionREP().Phi());
+  if (_useKDTree && hcalelem->isMultilinksValide()) {  //KDTree Algo
     const reco::PFMultilinksType& multilinks = hcalelem->getMultilinks();
     const double tracketa = tkAtHCALEnt.positionREP().Eta();
     const double trackphi = tkAtHCALEnt.positionREP().Phi();
-    
+
     // Check if the link Track/Hcal exist
     reco::PFMultilinksType::const_iterator mlit = multilinks.begin();
     for (; mlit != multilinks.end(); ++mlit)
       if ((mlit->first == trackphi) && (mlit->second == tracketa))
-	break;
-    
-    // If the link exist, we fill dist and linktest.     
+        break;
 
+    // If the link exist, we fill dist and linktest.
 
-
-    if (mlit != multilinks.end()){     
-
-
+    if (mlit != multilinks.end()) {
       //special case ! A looper  can exit the barrel inwards and hit the endcap
       //In this case calculate the distance based on the first crossing since
       //the looper will probably never make it to the endcap
-      if (tkAtHCALEx.position().R()<tkAtHCALEnt.position().R()) {
-	dist = LinkByRecHit::computeDist(hcalreppos.Eta(), 
-					 hcalreppos.Phi(), 
-					 tracketa, 
-					 trackphi);
-	
-	edm::LogWarning("TrackHCALLinker ") <<"Special case of linking with track hitting HCAL and looping back in the tracker ";
-      }
-      else {
-	dist = LinkByRecHit::computeDist(hcalreppos.Eta(), 
-				       hcalreppos.Phi(), 
-				       tracketa + 0.1 * dHEta, 
-				       trackphi + 0.1 * dHPhi);
-      }
+      if (tkAtHCALEx.position().R() < tkAtHCALEnt.position().R()) {
+        dist = LinkByRecHit::computeDist(hcalreppos.Eta(), hcalreppos.Phi(), tracketa, trackphi);
 
+        edm::LogWarning("TrackHCALLinker ")
+            << "Special case of linking with track hitting HCAL and looping back in the tracker ";
+      } else {
+        dist = LinkByRecHit::computeDist(
+            hcalreppos.Eta(), hcalreppos.Phi(), tracketa + 0.1 * dHEta, trackphi + 0.1 * dHPhi);
+      }
     }
 
-  }    else {// Old algorithm
-    if ( tkAtHCALEnt.isValid() )
-      dist = LinkByRecHit::testTrackAndClusterByRecHit( *trackref, 
-							*clusterref,
-							false, _debug );
+  } else {  // Old algorithm
+    if (tkAtHCALEnt.isValid())
+      dist = LinkByRecHit::testTrackAndClusterByRecHit(*trackref, *clusterref, false, _debug);
   }
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHOLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHOLinker.cc
@@ -6,32 +6,25 @@
 
 class TrackAndHOLinker : public BlockElementLinkerBase {
 public:
-  TrackAndHOLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  double testLink 
-  ( const reco::PFBlockElement*,
-    const reco::PFBlockElement* ) const override;
+  TrackAndHOLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  TrackAndHOLinker, 
-		  "TrackAndHOLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, TrackAndHOLinker, "TrackAndHOLinker");
 
-double TrackAndHOLinker::testLink
-  ( const reco::PFBlockElement* elem1,
-    const reco::PFBlockElement* elem2) const {  
-  constexpr reco::PFTrajectoryPoint::LayerType HOLayer =
-    reco::PFTrajectoryPoint::HOLayer;
-  const reco::PFBlockElementTrack   *tkelem(nullptr);
-  const reco::PFBlockElementCluster *hoelem(nullptr);
+double TrackAndHOLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFTrajectoryPoint::LayerType HOLayer = reco::PFTrajectoryPoint::HOLayer;
+  const reco::PFBlockElementTrack* tkelem(nullptr);
+  const reco::PFBlockElementCluster* hoelem(nullptr);
   double dist(-1.0);
-  if( elem1->type() < elem2->type() ) {
+  if (elem1->type() < elem2->type()) {
     tkelem = static_cast<const reco::PFBlockElementTrack*>(elem1);
     hoelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
   } else {
@@ -39,15 +32,12 @@ double TrackAndHOLinker::testLink
     hoelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
   }
   const reco::PFClusterRef& horef = hoelem->clusterRef();
-  const reco::PFRecTrackRef& tkref = tkelem->trackRefPF();  
-  if( horef.isNull() || tkref.isNull() ) {
-    throw cms::Exception("BadClusterRefs") 
-      << "PFBlockElementCluster's refs are null!";
-  }  
-  if ( tkelem->trackRef()->pt() > 3.00001 && 
-       tkref->extrapolatedPoint( HOLayer ).isValid() ) {
-    dist = LinkByRecHit::testTrackAndClusterByRecHit( *tkref, *horef, 
-						      false, _debug );
+  const reco::PFRecTrackRef& tkref = tkelem->trackRefPF();
+  if (horef.isNull() || tkref.isNull()) {
+    throw cms::Exception("BadClusterRefs") << "PFBlockElementCluster's refs are null!";
+  }
+  if (tkelem->trackRef()->pt() > 3.00001 && tkref->extrapolatedPoint(HOLayer).isValid()) {
+    dist = LinkByRecHit::testTrackAndClusterByRecHit(*tkref, *horef, false, _debug);
   } else {
     dist = -1.;
   }

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndTrackLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndTrackLinker.cc
@@ -6,80 +6,69 @@
 
 class TrackAndTrackLinker : public BlockElementLinkerBase {
 public:
-  TrackAndTrackLinker(const edm::ParameterSet& conf) :
-    BlockElementLinkerBase(conf),
-    _useKDTree(conf.getParameter<bool>("useKDTree")),
-    _debug(conf.getUntrackedParameter<bool>("debug",false)) {}
-  
-  bool linkPrefilter( const reco::PFBlockElement*,
-		      const reco::PFBlockElement* ) const override;
+  TrackAndTrackLinker(const edm::ParameterSet& conf)
+      : BlockElementLinkerBase(conf),
+        _useKDTree(conf.getParameter<bool>("useKDTree")),
+        _debug(conf.getUntrackedParameter<bool>("debug", false)) {}
 
-  double testLink( const reco::PFBlockElement*,
-		   const reco::PFBlockElement* ) const override;
+  bool linkPrefilter(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
+
+  double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
-  bool _useKDTree,_debug;
+  bool _useKDTree, _debug;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, 
-		  TrackAndTrackLinker, 
-		  "TrackAndTrackLinker");
+DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, TrackAndTrackLinker, "TrackAndTrackLinker");
 
-bool TrackAndTrackLinker::
-linkPrefilter( const reco::PFBlockElement* e1,
-	       const reco::PFBlockElement* e2 ) const {
-  return ( e1->isLinkedToDisplacedVertex() || 
-	   e2->isLinkedToDisplacedVertex()    );
+bool TrackAndTrackLinker::linkPrefilter(const reco::PFBlockElement* e1, const reco::PFBlockElement* e2) const {
+  return (e1->isLinkedToDisplacedVertex() || e2->isLinkedToDisplacedVertex());
 }
 
-double TrackAndTrackLinker::
-testLink( const reco::PFBlockElement* elem1,
-	  const reco::PFBlockElement* elem2) const { 
-  constexpr reco::PFBlockElement::TrackType T_TO_DISP = 
-    reco::PFBlockElement::T_TO_DISP;
-  constexpr reco::PFBlockElement::TrackType T_FROM_DISP = 
-    reco::PFBlockElement::T_FROM_DISP;
+double TrackAndTrackLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  constexpr reco::PFBlockElement::TrackType T_TO_DISP = reco::PFBlockElement::T_TO_DISP;
+  constexpr reco::PFBlockElement::TrackType T_FROM_DISP = reco::PFBlockElement::T_FROM_DISP;
   double dist = -1.0;
-  
-  const reco::PFDisplacedTrackerVertexRef& ni1_TO_DISP = 
-    elem1->displacedVertexRef(T_TO_DISP);
-  const reco::PFDisplacedTrackerVertexRef& ni2_TO_DISP = 
-    elem2->displacedVertexRef(T_TO_DISP);
-  const reco::PFDisplacedTrackerVertexRef& ni1_FROM_DISP = 
-    elem1->displacedVertexRef(T_FROM_DISP);
-  const reco::PFDisplacedTrackerVertexRef& ni2_FROM_DISP = 
-    elem2->displacedVertexRef(T_FROM_DISP);
 
-  if( ni1_TO_DISP.isNonnull() && ni2_FROM_DISP.isNonnull())
-    if( ni1_TO_DISP == ni2_FROM_DISP ) { dist = 1.0; }
+  const reco::PFDisplacedTrackerVertexRef& ni1_TO_DISP = elem1->displacedVertexRef(T_TO_DISP);
+  const reco::PFDisplacedTrackerVertexRef& ni2_TO_DISP = elem2->displacedVertexRef(T_TO_DISP);
+  const reco::PFDisplacedTrackerVertexRef& ni1_FROM_DISP = elem1->displacedVertexRef(T_FROM_DISP);
+  const reco::PFDisplacedTrackerVertexRef& ni2_FROM_DISP = elem2->displacedVertexRef(T_FROM_DISP);
 
-  if( ni1_FROM_DISP.isNonnull() && ni2_TO_DISP.isNonnull())
-    if( ni1_FROM_DISP == ni2_TO_DISP ) { dist = 1.0; }
+  if (ni1_TO_DISP.isNonnull() && ni2_FROM_DISP.isNonnull())
+    if (ni1_TO_DISP == ni2_FROM_DISP) {
+      dist = 1.0;
+    }
 
-  if( ni1_FROM_DISP.isNonnull() && ni2_FROM_DISP.isNonnull())
-    if( ni1_FROM_DISP == ni2_FROM_DISP ) { dist = 1.0; }
+  if (ni1_FROM_DISP.isNonnull() && ni2_TO_DISP.isNonnull())
+    if (ni1_FROM_DISP == ni2_TO_DISP) {
+      dist = 1.0;
+    }
 
-  if (  elem1->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)  &&
-	elem2->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)  ) {
-    for( const auto& conv1 : elem1->convRefs() ) {
-      for( const auto& conv2 : elem2->convRefs() ) {
-	if( conv1.isNonnull() && conv2.isNonnull() &&
-	    conv1 == conv2 ) {
-	  dist=1.0;
-	  break;
-	}
+  if (ni1_FROM_DISP.isNonnull() && ni2_FROM_DISP.isNonnull())
+    if (ni1_FROM_DISP == ni2_FROM_DISP) {
+      dist = 1.0;
+    }
+
+  if (elem1->trackType(reco::PFBlockElement::T_FROM_GAMMACONV) &&
+      elem2->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)) {
+    for (const auto& conv1 : elem1->convRefs()) {
+      for (const auto& conv2 : elem2->convRefs()) {
+        if (conv1.isNonnull() && conv2.isNonnull() && conv1 == conv2) {
+          dist = 1.0;
+          break;
+        }
       }
     }
   }
-  
-  if (  elem1->trackType(reco::PFBlockElement::T_FROM_V0)  &&
-	elem2->trackType(reco::PFBlockElement::T_FROM_V0)  ) {
-    if ( elem1->V0Ref().isNonnull() && elem2->V0Ref().isNonnull() ) {      
-      if ( elem1->V0Ref() ==  elem2->V0Ref() ) {
-	dist=1.0;
+
+  if (elem1->trackType(reco::PFBlockElement::T_FROM_V0) && elem2->trackType(reco::PFBlockElement::T_FROM_V0)) {
+    if (elem1->V0Ref().isNonnull() && elem2->V0Ref().isNonnull()) {
+      if (elem1->V0Ref() == elem2->V0Ref()) {
+        dist = 1.0;
       }
     }
   }
-  
+
   return dist;
 }

--- a/RecoParticleFlow/PFProducer/plugins/plugins.cc
+++ b/RecoParticleFlow/PFProducer/plugins/plugins.cc
@@ -15,9 +15,9 @@
 
 typedef Merger<reco::PFCandidateCollection> PFCandidateListMerger;
 typedef edm::ProductFromFwdPtrProducer<reco::PFCandidate, reco::PFCandidateWithSrcPtrFactory>
-        PFCandidateProductFromFwdPtrProducer;
+    PFCandidateProductFromFwdPtrProducer;
 typedef edm::FwdPtrProducer<reco::PFCandidate, reco::PFCandidateFwdPtrFactory> PFCandidateFwdPtrProducer;
 
-DEFINE_FWK_MODULE( PFCandidateListMerger );
+DEFINE_FWK_MODULE(PFCandidateListMerger);
 DEFINE_FWK_MODULE(PFCandidateProductFromFwdPtrProducer);
 DEFINE_FWK_MODULE(PFCandidateFwdPtrProducer);

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -8,31 +8,33 @@
 
 #include <numeric>
 
-
 using namespace std;
 using namespace reco;
 
-
-PFAlgo::PFAlgo(double nSigmaECAL, double nSigmaHCAL, PFEnergyCalibration& calibration, PFEnergyCalibrationHF& thepfEnergyCalibrationHF, const edm::ParameterSet& pset, bool debug)
-  : pfCandidates_( new PFCandidateCollection),
-    nSigmaECAL_(nSigmaECAL),
-    nSigmaHCAL_(nSigmaHCAL),
-    calibration_(calibration),
-    thepfEnergyCalibrationHF_(thepfEnergyCalibrationHF),
-    debug_(debug),
-    connector_(debug)
-{
+PFAlgo::PFAlgo(double nSigmaECAL,
+               double nSigmaHCAL,
+               PFEnergyCalibration& calibration,
+               PFEnergyCalibrationHF& thepfEnergyCalibrationHF,
+               const edm::ParameterSet& pset,
+               bool debug)
+    : pfCandidates_(new PFCandidateCollection),
+      nSigmaECAL_(nSigmaECAL),
+      nSigmaHCAL_(nSigmaHCAL),
+      calibration_(calibration),
+      thepfEnergyCalibrationHF_(thepfEnergyCalibrationHF),
+      debug_(debug),
+      connector_(debug) {
   pfmu_ = std::make_unique<PFMuonAlgo>(pset);
 
   // Muon parameters
-  muonHCAL_= pset.getParameter<std::vector<double> >("muon_HCAL");
-  muonECAL_= pset.getParameter<std::vector<double> >("muon_ECAL");
-  muonHO_= pset.getParameter<std::vector<double> >("muon_HO");
-  assert ( muonHCAL_.size() == 2 && muonECAL_.size() == 2 && muonHO_.size() == 2);
-  nSigmaTRACK_= pset.getParameter<double>("nsigma_TRACK");
-  ptError_= pset.getParameter<double>("pt_Error");
-  factors45_ = pset.getParameter<std::vector<double> >("factors_45");
-  assert ( factors45_.size() == 2 );
+  muonHCAL_ = pset.getParameter<std::vector<double>>("muon_HCAL");
+  muonECAL_ = pset.getParameter<std::vector<double>>("muon_ECAL");
+  muonHO_ = pset.getParameter<std::vector<double>>("muon_HO");
+  assert(muonHCAL_.size() == 2 && muonECAL_.size() == 2 && muonHO_.size() == 2);
+  nSigmaTRACK_ = pset.getParameter<double>("nsigma_TRACK");
+  ptError_ = pset.getParameter<double>("pt_Error");
+  factors45_ = pset.getParameter<std::vector<double>>("factors_45");
+  assert(factors45_.size() == 2);
 
   // Bad Hcal Track Parameters
   goodTrackDeadHcal_ptErrRel_ = pset.getParameter<double>("goodTrackDeadHcal_ptErrRel");
@@ -51,172 +53,155 @@ PFAlgo::PFAlgo(double nSigmaECAL, double nSigmaHCAL, PFEnergyCalibration& calibr
   goodPixelTrackDeadHcal_dz_ = pset.getParameter<double>("goodPixelTrackDeadHcal_dz");
 }
 
-PFMuonAlgo* PFAlgo::getPFMuonAlgo() {
-  return pfmu_.get();
-}
+PFMuonAlgo* PFAlgo::getPFMuonAlgo() { return pfmu_.get(); }
 
-void PFAlgo::setEGammaParameters(bool use_EGammaFilters, bool useProtectionsForJetMET)
-{
-
+void PFAlgo::setEGammaParameters(bool use_EGammaFilters, bool useProtectionsForJetMET) {
   useEGammaFilters_ = use_EGammaFilters;
 
-  if(!useEGammaFilters_ ) return;
+  if (!useEGammaFilters_)
+    return;
 
   useProtectionsForJetMET_ = useProtectionsForJetMET;
 }
-void  PFAlgo::setEGammaCollections(const edm::View<reco::PFCandidate> & pfEgammaCandidates,
-				   const edm::ValueMap<reco::GsfElectronRef> & valueMapGedElectrons,
-				   const edm::ValueMap<reco::PhotonRef> & valueMapGedPhotons){
-  if(useEGammaFilters_) {
-    pfEgammaCandidates_ = & pfEgammaCandidates;
-    valueMapGedElectrons_ = & valueMapGedElectrons;
-    valueMapGedPhotons_ = & valueMapGedPhotons;
+void PFAlgo::setEGammaCollections(const edm::View<reco::PFCandidate>& pfEgammaCandidates,
+                                  const edm::ValueMap<reco::GsfElectronRef>& valueMapGedElectrons,
+                                  const edm::ValueMap<reco::PhotonRef>& valueMapGedPhotons) {
+  if (useEGammaFilters_) {
+    pfEgammaCandidates_ = &pfEgammaCandidates;
+    valueMapGedElectrons_ = &valueMapGedElectrons;
+    valueMapGedPhotons_ = &valueMapGedPhotons;
   }
 }
 
-void
-PFAlgo::setMuonHandle(const edm::Handle<reco::MuonCollection>& muons) {
-  muonHandle_ = muons;
-}
-  
-void 
-PFAlgo::setPostHFCleaningParameters(bool postHFCleaning,
-				    double minHFCleaningPt,
-				    double minSignificance,
-				    double maxSignificance,
-				    double minSignificanceReduction,
-				    double maxDeltaPhiPt,
-				    double minDeltaMet) {
+void PFAlgo::setMuonHandle(const edm::Handle<reco::MuonCollection>& muons) { muonHandle_ = muons; }
+
+void PFAlgo::setPostHFCleaningParameters(bool postHFCleaning,
+                                         double minHFCleaningPt,
+                                         double minSignificance,
+                                         double maxSignificance,
+                                         double minSignificanceReduction,
+                                         double maxDeltaPhiPt,
+                                         double minDeltaMet) {
   postHFCleaning_ = postHFCleaning;
   minHFCleaningPt_ = minHFCleaningPt;
   minSignificance_ = minSignificance;
   maxSignificance_ = maxSignificance;
-  minSignificanceReduction_= minSignificanceReduction;
+  minSignificanceReduction_ = minSignificanceReduction;
   maxDeltaPhiPt_ = maxDeltaPhiPt;
   minDeltaMet_ = minDeltaMet;
 }
 
-void
-PFAlgo::setDisplacedVerticesParameters(bool rejectTracks_Bad,
-				       bool rejectTracks_Step45,
-				       bool usePFNuclearInteractions,
-				       bool usePFConversions,
-				       bool usePFDecays,
-				       double dptRel_DispVtx){
-
+void PFAlgo::setDisplacedVerticesParameters(bool rejectTracks_Bad,
+                                            bool rejectTracks_Step45,
+                                            bool usePFNuclearInteractions,
+                                            bool usePFConversions,
+                                            bool usePFDecays,
+                                            double dptRel_DispVtx) {
   rejectTracks_Bad_ = rejectTracks_Bad;
   rejectTracks_Step45_ = rejectTracks_Step45;
   usePFNuclearInteractions_ = usePFNuclearInteractions;
   usePFConversions_ = usePFConversions;
   usePFDecays_ = usePFDecays;
   dptRel_DispVtx_ = dptRel_DispVtx;
-
 }
 
-void
-PFAlgo::setPFVertexParameters(bool useVertex, reco::VertexCollection const&  primaryVertices)
-{
+void PFAlgo::setPFVertexParameters(bool useVertex, reco::VertexCollection const& primaryVertices) {
   useVertices_ = useVertex;
 
   //Set the vertices for muon cleaning
   pfmu_->setInputsForCleaning(primaryVertices);
 
-
   //Now find the primary vertex!
   bool primaryVertexFound = false;
   nVtx_ = primaryVertices.size();
-  for(auto const& vertex : primaryVertices)
-    {
-      if(vertex.isValid()&&(!vertex.isFake()))
-	{
-	  primaryVertex_ = vertex;
-	  primaryVertexFound = true;
-          break;
-	}
+  for (auto const& vertex : primaryVertices) {
+    if (vertex.isValid() && (!vertex.isFake())) {
+      primaryVertex_ = vertex;
+      primaryVertexFound = true;
+      break;
     }
+  }
   //Use vertices if the user wants to but only if it exists a good vertex
   useVertices_ = useVertex && primaryVertexFound;
 }
 
-void PFAlgo::reconstructParticles( const reco::PFBlockHandle& blockHandle, PFEGammaFilters const* pfegamma ) {
-
+void PFAlgo::reconstructParticles(const reco::PFBlockHandle& blockHandle, PFEGammaFilters const* pfegamma) {
   auto const& blocks = *blockHandle;
 
   // reset output collection
   pfCandidates_->clear();
 
-  if( debug_ ) {
-    cout<<"*********************************************************"<<endl;
-    cout<<"*****           Particle flow algorithm             *****"<<endl;
-    cout<<"*********************************************************"<<endl;
+  if (debug_) {
+    cout << "*********************************************************" << endl;
+    cout << "*****           Particle flow algorithm             *****" << endl;
+    cout << "*********************************************************" << endl;
   }
 
   // sort elements in three lists:
-  std::list< reco::PFBlockRef > hcalBlockRefs;
-  std::list< reco::PFBlockRef > ecalBlockRefs;
-  std::list< reco::PFBlockRef > hoBlockRefs;
-  std::list< reco::PFBlockRef > otherBlockRefs;
+  std::list<reco::PFBlockRef> hcalBlockRefs;
+  std::list<reco::PFBlockRef> ecalBlockRefs;
+  std::list<reco::PFBlockRef> hoBlockRefs;
+  std::list<reco::PFBlockRef> otherBlockRefs;
 
-  for( unsigned i=0; i<blocks.size(); ++i ) {
-    reco::PFBlockRef blockref = reco::PFBlockRef(  blockHandle, i );
+  for (unsigned i = 0; i < blocks.size(); ++i) {
+    reco::PFBlockRef blockref = reco::PFBlockRef(blockHandle, i);
 
     const reco::PFBlock& block = *blockref;
-    const edm::OwnVector< reco::PFBlockElement >&
-      elements = block.elements();
+    const edm::OwnVector<reco::PFBlockElement>& elements = block.elements();
 
     bool singleEcalOrHcal = false;
-    if( elements.size() == 1 ){
-      if( elements[0].type() == reco::PFBlockElement::ECAL ){
-	ecalBlockRefs.push_back( blockref );
-	singleEcalOrHcal = true;
+    if (elements.size() == 1) {
+      if (elements[0].type() == reco::PFBlockElement::ECAL) {
+        ecalBlockRefs.push_back(blockref);
+        singleEcalOrHcal = true;
       }
-      if( elements[0].type() == reco::PFBlockElement::HCAL ){
-	hcalBlockRefs.push_back( blockref );
-	singleEcalOrHcal = true;
+      if (elements[0].type() == reco::PFBlockElement::HCAL) {
+        hcalBlockRefs.push_back(blockref);
+        singleEcalOrHcal = true;
       }
-      if( elements[0].type() == reco::PFBlockElement::HO ){
-	// Single HO elements are likely to be noise. Not considered for now.
-	hoBlockRefs.push_back( blockref );
-	singleEcalOrHcal = true;
+      if (elements[0].type() == reco::PFBlockElement::HO) {
+        // Single HO elements are likely to be noise. Not considered for now.
+        hoBlockRefs.push_back(blockref);
+        singleEcalOrHcal = true;
       }
     }
 
-    if(!singleEcalOrHcal) {
-      otherBlockRefs.push_back( blockref );
+    if (!singleEcalOrHcal) {
+      otherBlockRefs.push_back(blockref);
     }
-  }//loop blocks
+  }  //loop blocks
 
-  if( debug_ ){
-    cout<<"# Ecal blocks: "<<ecalBlockRefs.size()
-        <<", # Hcal blocks: "<<hcalBlockRefs.size()
-        <<", # HO blocks: "<<hoBlockRefs.size()
-        <<", # Other blocks: "<<otherBlockRefs.size()<<endl;
+  if (debug_) {
+    cout << "# Ecal blocks: " << ecalBlockRefs.size() << ", # Hcal blocks: " << hcalBlockRefs.size()
+         << ", # HO blocks: " << hoBlockRefs.size() << ", # Other blocks: " << otherBlockRefs.size() << endl;
   }
-
 
   // loop on blocks that are not single ecal,
   // and not single hcal.
 
   unsigned nblcks = 0;
-  for(auto const& other : otherBlockRefs) {
-    if ( debug_ ) std::cout << "Block number " << nblcks++ << std::endl;
-    processBlock( other, hcalBlockRefs, ecalBlockRefs, pfegamma );
+  for (auto const& other : otherBlockRefs) {
+    if (debug_)
+      std::cout << "Block number " << nblcks++ << std::endl;
+    processBlock(other, hcalBlockRefs, ecalBlockRefs, pfegamma);
   }
 
-  std::list< reco::PFBlockRef > empty;
+  std::list<reco::PFBlockRef> empty;
 
   unsigned hblcks = 0;
   // process remaining single hcal blocks
-  for(auto const& hcal : hcalBlockRefs) {
-    if ( debug_ ) std::cout << "HCAL block number " << hblcks++ << std::endl;
-    processBlock( hcal, empty, empty, pfegamma );
+  for (auto const& hcal : hcalBlockRefs) {
+    if (debug_)
+      std::cout << "HCAL block number " << hblcks++ << std::endl;
+    processBlock(hcal, empty, empty, pfegamma);
   }
 
   unsigned eblcks = 0;
   // process remaining single ecal blocks
-  for(auto const& ecal : ecalBlockRefs) {
-    if ( debug_ ) std::cout << "ECAL block number " << eblcks++ << std::endl;
-    processBlock( ecal, empty, empty, pfegamma );
+  for (auto const& ecal : ecalBlockRefs) {
+    if (debug_)
+      std::cout << "ECAL block number " << eblcks++ << std::endl;
+    processBlock(ecal, empty, empty, pfegamma);
   }
 
   // Post HF Cleaning
@@ -230,262 +215,250 @@ void PFAlgo::reconstructParticles( const reco::PFBlockHandle& blockHandle, PFEGa
   pfmu_->postClean(pfCandidates_.get());
 
   //Add Missing muons
-   if( muonHandle_.isValid())
-     pfmu_->addMissingMuons(muonHandle_,pfCandidates_.get());
+  if (muonHandle_.isValid())
+    pfmu_->addMissingMuons(muonHandle_, pfCandidates_.get());
 }
 
+void PFAlgo::egammaFilters(const reco::PFBlockRef& blockref,
+                           std::vector<bool>& active,
+                           PFEGammaFilters const* pfegamma) {
+  // const edm::ValueMap<reco::GsfElectronRef> & myGedElectronValMap(*valueMapGedElectrons_);
+  bool egmLocalDebug = debug_;
+  bool egmLocalBlockDebug = false;
 
-void PFAlgo::egammaFilters(const reco::PFBlockRef &blockref, std::vector<bool>& active, PFEGammaFilters const* pfegamma) {
-    // const edm::ValueMap<reco::GsfElectronRef> & myGedElectronValMap(*valueMapGedElectrons_);
-    bool egmLocalDebug = debug_;
-    bool egmLocalBlockDebug = false;
+  unsigned int negmcandidates = pfEgammaCandidates_->size();
+  for (unsigned int ieg = 0; ieg < negmcandidates; ++ieg) {
+    //      const reco::PFCandidate & egmcand((*pfEgammaCandidates_)[ieg]);
+    reco::PFCandidateRef pfEgmRef = pfEgammaCandidates_->refAt(ieg).castTo<reco::PFCandidateRef>();
 
-    unsigned int negmcandidates = pfEgammaCandidates_->size();
-    for(unsigned int ieg=0 ; ieg <  negmcandidates; ++ieg) {
-      //      const reco::PFCandidate & egmcand((*pfEgammaCandidates_)[ieg]);
-      reco::PFCandidateRef pfEgmRef = pfEgammaCandidates_->refAt(ieg).castTo<reco::PFCandidateRef>();
+    const PFCandidate::ElementsInBlocks& theElements = (*pfEgmRef).elementsInBlocks();
+    PFCandidate::ElementsInBlocks::const_iterator iegfirst = theElements.begin();
+    bool sameBlock = false;
+    bool isGoodElectron = false;
+    bool isGoodPhoton = false;
+    bool isPrimaryElectron = false;
+    if (iegfirst->first == blockref)
+      sameBlock = true;
+    if (sameBlock) {
+      if (egmLocalDebug)
+        cout << " I am in looping on EGamma Candidates: pt " << (*pfEgmRef).pt() << " eta,phi " << (*pfEgmRef).eta()
+             << ", " << (*pfEgmRef).phi() << " charge " << (*pfEgmRef).charge() << endl;
 
-      const PFCandidate::ElementsInBlocks& theElements = (*pfEgmRef).elementsInBlocks();
-      PFCandidate::ElementsInBlocks::const_iterator iegfirst = theElements.begin();
-      bool sameBlock = false;
-      bool isGoodElectron = false;
-      bool isGoodPhoton = false;
-      bool isPrimaryElectron = false;
-      if(iegfirst->first == blockref)
-	sameBlock = true;
-      if(sameBlock) {
-
-	if(egmLocalDebug)
-	  cout << " I am in looping on EGamma Candidates: pt " << (*pfEgmRef).pt()
-	       << " eta,phi " << (*pfEgmRef).eta() << ", " << (*pfEgmRef).phi()
-	       << " charge " << (*pfEgmRef).charge() << endl;
-
-	if((*pfEgmRef).gsfTrackRef().isNonnull()) {
-
-	  reco::GsfElectronRef gedEleRef = (*valueMapGedElectrons_)[pfEgmRef];
-	  if(gedEleRef.isNonnull()) {
-	    isGoodElectron = pfegamma->passElectronSelection(*gedEleRef,*pfEgmRef,nVtx_);
-	    isPrimaryElectron = pfegamma->isElectron(*gedEleRef);
-	    if(egmLocalDebug){
-	      if(isGoodElectron)
-		cout << "** Good Electron, pt " << gedEleRef->pt()
-		     << " eta, phi " << gedEleRef->eta() << ", " << gedEleRef->phi()
-		     << " charge " << gedEleRef->charge()
-		     << " isPrimary " << isPrimaryElectron
-		     << " isoDr03 " << (gedEleRef->dr03TkSumPt() + gedEleRef->dr03EcalRecHitSumEt() + gedEleRef->dr03HcalTowerSumEt())
-		     << " mva_isolated " << gedEleRef->mva_Isolated()
-		     << " mva_e_pi " << gedEleRef->mva_e_pi()
-		     << endl;
-	    }
-
-
-	  }
-	}
-	if((*pfEgmRef).superClusterRef().isNonnull()) {
-
-	  reco::PhotonRef gedPhoRef = (*valueMapGedPhotons_)[pfEgmRef];
-	  if(gedPhoRef.isNonnull()) {
-	    isGoodPhoton =  pfegamma->passPhotonSelection(*gedPhoRef);
-	    if(egmLocalDebug) {
-	      if(isGoodPhoton)
-		cout << "** Good Photon, pt " << gedPhoRef->pt()
-		     << " eta, phi " << gedPhoRef->eta() << ", " << gedPhoRef->phi() << endl;
-	    }
-	  }
-	}
-      } // end same block
-
-      if(isGoodElectron && isGoodPhoton) {
-	if(isPrimaryElectron)
-	  isGoodPhoton = false;
-	else
-	  isGoodElectron = false;
-      }
-
-      // isElectron
-      if(isGoodElectron) {
-	reco::GsfElectronRef gedEleRef = (*valueMapGedElectrons_)[pfEgmRef];
-	reco::PFCandidate myPFElectron = *pfEgmRef;
-	// run protections
-	bool lockTracks = false;
-	bool isSafe = true;
-	if( useProtectionsForJetMET_) {
-	  lockTracks = true;
-	  isSafe = pfegamma->isElectronSafeForJetMET(*gedEleRef,myPFElectron,primaryVertex_,lockTracks);
-	}
-
-	if(isSafe) {
-	  reco::PFCandidate::ParticleType particleType = reco::PFCandidate::e;
-	  myPFElectron.setParticleType(particleType);
-	  myPFElectron.setCharge(gedEleRef->charge());
-	  myPFElectron.setP4(gedEleRef->p4());
-	  myPFElectron.set_mva_e_pi(gedEleRef->mva_e_pi());
-          myPFElectron.set_mva_Isolated(gedEleRef->mva_Isolated());
-
-	  if(egmLocalDebug) {
-	    cout << " PFAlgo: found an electron with NEW EGamma code " << endl;
-	    cout << " myPFElectron: pt " << myPFElectron.pt()
-		 << " eta,phi " << myPFElectron.eta() << ", " <<myPFElectron.phi()
-		 << " mva " << myPFElectron.mva_e_pi()
-		 << " charge " << myPFElectron.charge() << endl;
-	  }
-
-
-	  // Lock all the elements
-	  if(egmLocalBlockDebug)
-	    cout << " THE BLOCK " << *blockref << endl;
-	  for (auto const& eb : theElements) {
-	    active[eb.second] = false;
-	    if(egmLocalBlockDebug||(debug_&&egmLocalDebug))
-	      cout << " Elements used " <<  eb.second << endl;
-	  }
-
-	  // The electron is considered safe for JetMET and the additional tracks pointing to it are locked
-	  if(lockTracks) {
-	    const PFCandidate::ElementsInBlocks& extraTracks = myPFElectron.egammaExtraRef()->extraNonConvTracks();
-        for (auto const& trk : extraTracks) {
-              if(egmLocalBlockDebug||(debug_&&egmLocalDebug)) {
-                  cout << " Extra locked track " <<  trk.second << endl;
-              }
-              active[trk.second] = false;
+      if ((*pfEgmRef).gsfTrackRef().isNonnull()) {
+        reco::GsfElectronRef gedEleRef = (*valueMapGedElectrons_)[pfEgmRef];
+        if (gedEleRef.isNonnull()) {
+          isGoodElectron = pfegamma->passElectronSelection(*gedEleRef, *pfEgmRef, nVtx_);
+          isPrimaryElectron = pfegamma->isElectron(*gedEleRef);
+          if (egmLocalDebug) {
+            if (isGoodElectron)
+              cout << "** Good Electron, pt " << gedEleRef->pt() << " eta, phi " << gedEleRef->eta() << ", "
+                   << gedEleRef->phi() << " charge " << gedEleRef->charge() << " isPrimary " << isPrimaryElectron
+                   << " isoDr03 "
+                   << (gedEleRef->dr03TkSumPt() + gedEleRef->dr03EcalRecHitSumEt() + gedEleRef->dr03HcalTowerSumEt())
+                   << " mva_isolated " << gedEleRef->mva_Isolated() << " mva_e_pi " << gedEleRef->mva_e_pi() << endl;
+          }
         }
       }
-
-	  pfCandidates_->push_back(myPFElectron);
-
-	}
-	else {
-	  if(egmLocalDebug)
-	    cout << "PFAlgo: Electron DISCARDED, NOT SAFE FOR JETMET " << endl;
-	}
+      if ((*pfEgmRef).superClusterRef().isNonnull()) {
+        reco::PhotonRef gedPhoRef = (*valueMapGedPhotons_)[pfEgmRef];
+        if (gedPhoRef.isNonnull()) {
+          isGoodPhoton = pfegamma->passPhotonSelection(*gedPhoRef);
+          if (egmLocalDebug) {
+            if (isGoodPhoton)
+              cout << "** Good Photon, pt " << gedPhoRef->pt() << " eta, phi " << gedPhoRef->eta() << ", "
+                   << gedPhoRef->phi() << endl;
+          }
+        }
       }
-      if(isGoodPhoton) {
-	reco::PhotonRef gedPhoRef = (*valueMapGedPhotons_)[pfEgmRef];
-	reco::PFCandidate myPFPhoton = *pfEgmRef;
-	bool isSafe = true;
-	if( useProtectionsForJetMET_) {
-	  isSafe = pfegamma->isPhotonSafeForJetMET(*gedPhoRef,myPFPhoton);
-	}
+    }  // end same block
 
+    if (isGoodElectron && isGoodPhoton) {
+      if (isPrimaryElectron)
+        isGoodPhoton = false;
+      else
+        isGoodElectron = false;
+    }
 
+    // isElectron
+    if (isGoodElectron) {
+      reco::GsfElectronRef gedEleRef = (*valueMapGedElectrons_)[pfEgmRef];
+      reco::PFCandidate myPFElectron = *pfEgmRef;
+      // run protections
+      bool lockTracks = false;
+      bool isSafe = true;
+      if (useProtectionsForJetMET_) {
+        lockTracks = true;
+        isSafe = pfegamma->isElectronSafeForJetMET(*gedEleRef, myPFElectron, primaryVertex_, lockTracks);
+      }
 
-	if(isSafe) {
-	  reco::PFCandidate::ParticleType particleType = reco::PFCandidate::gamma;
-	  myPFPhoton.setParticleType(particleType);
-	  myPFPhoton.setCharge(0);
-	  myPFPhoton.set_mva_nothing_gamma(1.);
-	  ::math::XYZPoint v(primaryVertex_.x(), primaryVertex_.y(), primaryVertex_.z());
-	  myPFPhoton.setVertex( v  );
-	  myPFPhoton.setP4(gedPhoRef->p4());
-	  if(egmLocalDebug) {
-	    cout << " PFAlgo: found a photon with NEW EGamma code " << endl;
-	    cout << " myPFPhoton: pt " << myPFPhoton.pt()
-		 << " eta,phi " << myPFPhoton.eta() << ", " <<myPFPhoton.phi()
-		 << " charge " << myPFPhoton.charge() << endl;
-	  }
+      if (isSafe) {
+        reco::PFCandidate::ParticleType particleType = reco::PFCandidate::e;
+        myPFElectron.setParticleType(particleType);
+        myPFElectron.setCharge(gedEleRef->charge());
+        myPFElectron.setP4(gedEleRef->p4());
+        myPFElectron.set_mva_e_pi(gedEleRef->mva_e_pi());
+        myPFElectron.set_mva_Isolated(gedEleRef->mva_Isolated());
 
-	  // Lock all the elements
-	  if(egmLocalBlockDebug)
-	    cout << " THE BLOCK " << *blockref << endl;
-	  for (auto const& eb : theElements) {
-	    active[eb.second] = false;
-	    if(egmLocalBlockDebug||(debug_&&egmLocalDebug))
-	      cout << " Elements used " <<  eb.second << endl;
-	  }
-	  pfCandidates_->push_back(myPFPhoton);
+        if (egmLocalDebug) {
+          cout << " PFAlgo: found an electron with NEW EGamma code " << endl;
+          cout << " myPFElectron: pt " << myPFElectron.pt() << " eta,phi " << myPFElectron.eta() << ", "
+               << myPFElectron.phi() << " mva " << myPFElectron.mva_e_pi() << " charge " << myPFElectron.charge()
+               << endl;
+        }
 
-	} // end isSafe
-      } // end isGoodPhoton
-    } // end loop on EGM candidates
+        // Lock all the elements
+        if (egmLocalBlockDebug)
+          cout << " THE BLOCK " << *blockref << endl;
+        for (auto const& eb : theElements) {
+          active[eb.second] = false;
+          if (egmLocalBlockDebug || (debug_ && egmLocalDebug))
+            cout << " Elements used " << eb.second << endl;
+        }
+
+        // The electron is considered safe for JetMET and the additional tracks pointing to it are locked
+        if (lockTracks) {
+          const PFCandidate::ElementsInBlocks& extraTracks = myPFElectron.egammaExtraRef()->extraNonConvTracks();
+          for (auto const& trk : extraTracks) {
+            if (egmLocalBlockDebug || (debug_ && egmLocalDebug)) {
+              cout << " Extra locked track " << trk.second << endl;
+            }
+            active[trk.second] = false;
+          }
+        }
+
+        pfCandidates_->push_back(myPFElectron);
+
+      } else {
+        if (egmLocalDebug)
+          cout << "PFAlgo: Electron DISCARDED, NOT SAFE FOR JETMET " << endl;
+      }
+    }
+    if (isGoodPhoton) {
+      reco::PhotonRef gedPhoRef = (*valueMapGedPhotons_)[pfEgmRef];
+      reco::PFCandidate myPFPhoton = *pfEgmRef;
+      bool isSafe = true;
+      if (useProtectionsForJetMET_) {
+        isSafe = pfegamma->isPhotonSafeForJetMET(*gedPhoRef, myPFPhoton);
+      }
+
+      if (isSafe) {
+        reco::PFCandidate::ParticleType particleType = reco::PFCandidate::gamma;
+        myPFPhoton.setParticleType(particleType);
+        myPFPhoton.setCharge(0);
+        myPFPhoton.set_mva_nothing_gamma(1.);
+        ::math::XYZPoint v(primaryVertex_.x(), primaryVertex_.y(), primaryVertex_.z());
+        myPFPhoton.setVertex(v);
+        myPFPhoton.setP4(gedPhoRef->p4());
+        if (egmLocalDebug) {
+          cout << " PFAlgo: found a photon with NEW EGamma code " << endl;
+          cout << " myPFPhoton: pt " << myPFPhoton.pt() << " eta,phi " << myPFPhoton.eta() << ", " << myPFPhoton.phi()
+               << " charge " << myPFPhoton.charge() << endl;
+        }
+
+        // Lock all the elements
+        if (egmLocalBlockDebug)
+          cout << " THE BLOCK " << *blockref << endl;
+        for (auto const& eb : theElements) {
+          active[eb.second] = false;
+          if (egmLocalBlockDebug || (debug_ && egmLocalDebug))
+            cout << " Elements used " << eb.second << endl;
+        }
+        pfCandidates_->push_back(myPFPhoton);
+
+      }  // end isSafe
+    }    // end isGoodPhoton
+  }      // end loop on EGM candidates
 }
 
-void PFAlgo::conversionAlgo(const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active) {
-  for(unsigned iEle=0; iEle<elements.size(); iEle++) {
+void PFAlgo::conversionAlgo(const edm::OwnVector<reco::PFBlockElement>& elements, std::vector<bool>& active) {
+  for (unsigned iEle = 0; iEle < elements.size(); iEle++) {
     PFBlockElement::Type type = elements[iEle].type();
-    if(type==PFBlockElement::TRACK)
-      {
-        if(elements[iEle].trackRef()->algo() == reco::TrackBase::conversionStep)
-          active[iEle]=false;
-        if(elements[iEle].trackRef()->quality(reco::TrackBase::highPurity))continue;
-        const auto* trackRef = dynamic_cast<const reco::PFBlockElementTrack*>((&elements[iEle]));
-        if(!(trackRef->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)))continue;
-        if(!elements[iEle].convRefs().empty())active[iEle]=false;
-      }
+    if (type == PFBlockElement::TRACK) {
+      if (elements[iEle].trackRef()->algo() == reco::TrackBase::conversionStep)
+        active[iEle] = false;
+      if (elements[iEle].trackRef()->quality(reco::TrackBase::highPurity))
+        continue;
+      const auto* trackRef = dynamic_cast<const reco::PFBlockElementTrack*>((&elements[iEle]));
+      if (!(trackRef->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)))
+        continue;
+      if (!elements[iEle].convRefs().empty())
+        active[iEle] = false;
+    }
   }
 }
 
-
-bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData,
-  const edm::OwnVector<reco::PFBlockElement> &elements,
-  const reco::PFBlockRef &blockref, std::vector<bool>& active,
-  bool goodTrackDeadHcal, bool hasDeadHcal, unsigned int iTrack,
-  std::multimap<double, unsigned>& ecalElems, reco::TrackRef& trackRef) {
-  if ( debug_ )
+bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock& block,
+                               reco::PFBlock::LinkData& linkData,
+                               const edm::OwnVector<reco::PFBlockElement>& elements,
+                               const reco::PFBlockRef& blockref,
+                               std::vector<bool>& active,
+                               bool goodTrackDeadHcal,
+                               bool hasDeadHcal,
+                               unsigned int iTrack,
+                               std::multimap<double, unsigned>& ecalElems,
+                               reco::TrackRef& trackRef) {
+  if (debug_)
     std::cout << "Now deals with tracks linked to no HCAL clusters. Was HCal active? " << (!hasDeadHcal) << std::endl;
   // vector<unsigned> elementIndices;
   // elementIndices.push_back(iTrack);
 
   // The track momentum
   double trackMomentum = elements[iTrack].trackRef()->p();
-  if ( debug_ )
+  if (debug_)
     std::cout << elements[iTrack] << std::endl;
 
   // Is it a "tight" muon ? In that case assume no
   //Track momentum corresponds to the calorimeter
   //energy for now
   bool thisIsAMuon = PFMuonAlgo::isMuon(elements[iTrack]);
-  if ( thisIsAMuon ) trackMomentum = 0.;
+  if (thisIsAMuon)
+    trackMomentum = 0.;
 
   // If it is not a muon check if Is it a fake track ?
   //Michalis: I wonder if we should convert this to dpt/pt?
-  if ( !thisIsAMuon  && elements[iTrack].trackRef()->ptError() > ptError_ ) {
-
+  if (!thisIsAMuon && elements[iTrack].trackRef()->ptError() > ptError_) {
     double deficit = trackMomentum;
-    double resol = neutralHadronEnergyResolution(trackMomentum,
-    					     elements[iTrack].trackRef()->eta());
+    double resol = neutralHadronEnergyResolution(trackMomentum, elements[iTrack].trackRef()->eta());
     resol *= trackMomentum;
 
-    if ( !ecalElems.empty() ) {
+    if (!ecalElems.empty()) {
       unsigned thisEcal = ecalElems.begin()->second;
       reco::PFClusterRef clusterRef = elements[thisEcal].clusterRef();
       bool useCluster = true;
       if (hasDeadHcal) {
         std::multimap<double, unsigned> sortedTracks;
-        block.associatedElements( thisEcal,  linkData,
-    			sortedTracks,
-    			reco::PFBlockElement::TRACK,
-    			reco::PFBlock::LINKTEST_ALL );
+        block.associatedElements(
+            thisEcal, linkData, sortedTracks, reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL);
         useCluster = (sortedTracks.begin()->second == iTrack);
       }
       if (useCluster) {
         deficit -= clusterRef->energy();
-        resol = neutralHadronEnergyResolution(trackMomentum,
-                                              clusterRef->positionREP().Eta());
+        resol = neutralHadronEnergyResolution(trackMomentum, clusterRef->positionREP().Eta());
         resol *= trackMomentum;
       }
     }
 
     bool isPrimary = isFromSecInt(elements[iTrack], "primary");
 
-    if ( deficit > nSigmaTRACK_*resol && !isPrimary && !goodTrackDeadHcal) {
+    if (deficit > nSigmaTRACK_ * resol && !isPrimary && !goodTrackDeadHcal) {
       active[iTrack] = false;
-      if ( debug_ )
+      if (debug_)
         std::cout << elements[iTrack] << std::endl
-    	       << " deficit " << deficit << " > " << nSigmaTRACK_ << " x " << resol
-    	       << " track pt " << trackRef->pt() << " +- " << trackRef->ptError()
-    	       << " layers valid " << trackRef->hitPattern().trackerLayersWithMeasurement()
-    	             << ", lost " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS)
-    	             << ", lost outer " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_OUTER_HITS)
-    	             << ", lost inner " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_INNER_HITS)
-    	             << "(valid fraction " << trackRef->validFraction() <<")"
-    	       << " chi2/ndf " << trackRef->normalizedChi2()
-    	       << " |dxy| " << std::abs(trackRef->dxy(primaryVertex_.position())) << " +- " << trackRef->dxyError()
-                   << " |dz| " << std::abs(trackRef->dz(primaryVertex_.position())) << " +- " << trackRef->dzError()
-    	      << "is probably a fake (1) --> lock the track"
-    	      << std::endl;
-    return true;
+                  << " deficit " << deficit << " > " << nSigmaTRACK_ << " x " << resol << " track pt " << trackRef->pt()
+                  << " +- " << trackRef->ptError() << " layers valid "
+                  << trackRef->hitPattern().trackerLayersWithMeasurement() << ", lost "
+                  << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS) << ", lost outer "
+                  << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_OUTER_HITS)
+                  << ", lost inner "
+                  << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_INNER_HITS)
+                  << "(valid fraction " << trackRef->validFraction() << ")"
+                  << " chi2/ndf " << trackRef->normalizedChi2() << " |dxy| "
+                  << std::abs(trackRef->dxy(primaryVertex_.position())) << " +- " << trackRef->dxyError() << " |dz| "
+                  << std::abs(trackRef->dz(primaryVertex_.position())) << " +- " << trackRef->dzError()
+                  << "is probably a fake (1) --> lock the track" << std::endl;
+      return true;
     }
-  } // !thisIsaMuon
+  }  // !thisIsaMuon
 
   // Create a track candidate
   // unsigned tmpi = reconstructTrack( elements[iTrack] );
@@ -496,60 +469,56 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
   // Some cleaning : secondary tracks without calo's and large momentum must be fake
   double Dpt = trackRef->ptError();
 
-  if ( rejectTracks_Step45_ && ecalElems.empty() &&
-       trackMomentum > 30. && Dpt > 0.5 &&
-       ( PFTrackAlgoTools::step45(trackRef->algo())
-        && !goodTrackDeadHcal) ) {
-
-    double dptRel = Dpt/trackRef->pt()*100;
+  if (rejectTracks_Step45_ && ecalElems.empty() && trackMomentum > 30. && Dpt > 0.5 &&
+      (PFTrackAlgoTools::step45(trackRef->algo()) && !goodTrackDeadHcal)) {
+    double dptRel = Dpt / trackRef->pt() * 100;
     bool isPrimaryOrSecondary = isFromSecInt(elements[iTrack], "all");
 
-    if ( isPrimaryOrSecondary && dptRel < dptRel_DispVtx_) { return true; };
-    unsigned nHits =  elements[iTrack].trackRef()->hitPattern().trackerLayersWithMeasurement();
+    if (isPrimaryOrSecondary && dptRel < dptRel_DispVtx_) {
+      return true;
+    };
+    unsigned nHits = elements[iTrack].trackRef()->hitPattern().trackerLayersWithMeasurement();
     unsigned int NLostHit = trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS);
 
-    if ( debug_ )
-      std::cout << "A track (algo = " << trackRef->algo() << ") with momentum " << trackMomentum
-    	    << " / " << elements[iTrack].trackRef()->pt() << " +/- " << Dpt
-    	    << " / " << elements[iTrack].trackRef()->eta()
-    	    << " without any link to ECAL/HCAL and with " << nHits << " (" << NLostHit
-    	    << ") hits (lost hits) has been cleaned" << std::endl;
+    if (debug_)
+      std::cout << "A track (algo = " << trackRef->algo() << ") with momentum " << trackMomentum << " / "
+                << elements[iTrack].trackRef()->pt() << " +/- " << Dpt << " / " << elements[iTrack].trackRef()->eta()
+                << " without any link to ECAL/HCAL and with " << nHits << " (" << NLostHit
+                << ") hits (lost hits) has been cleaned" << std::endl;
     active[iTrack] = false;
     return true;
   }
 
-
-  tmpi.push_back(reconstructTrack( elements[iTrack]));
+  tmpi.push_back(reconstructTrack(elements[iTrack]));
 
   kTrack.push_back(iTrack);
   active[iTrack] = false;
 
   // No ECAL cluster either ... continue...
-  if ( ecalElems.empty() ) {
-    (*pfCandidates_)[tmpi[0]].setEcalEnergy( 0., 0. );
-    (*pfCandidates_)[tmpi[0]].setHcalEnergy( 0., 0. );
-    (*pfCandidates_)[tmpi[0]].setHoEnergy( 0., 0. );
-    (*pfCandidates_)[tmpi[0]].setPs1Energy( 0 );
-    (*pfCandidates_)[tmpi[0]].setPs2Energy( 0 );
-    (*pfCandidates_)[tmpi[0]].addElementInBlock( blockref, kTrack[0] );
+  if (ecalElems.empty()) {
+    (*pfCandidates_)[tmpi[0]].setEcalEnergy(0., 0.);
+    (*pfCandidates_)[tmpi[0]].setHcalEnergy(0., 0.);
+    (*pfCandidates_)[tmpi[0]].setHoEnergy(0., 0.);
+    (*pfCandidates_)[tmpi[0]].setPs1Energy(0);
+    (*pfCandidates_)[tmpi[0]].setPs2Energy(0);
+    (*pfCandidates_)[tmpi[0]].addElementInBlock(blockref, kTrack[0]);
     return true;
   }
 
   // Look for closest ECAL cluster
   const unsigned int thisEcal = ecalElems.begin()->second;
   reco::PFClusterRef clusterRef = elements[thisEcal].clusterRef();
-  if ( debug_ ) std::cout << " is associated to " << elements[thisEcal] << std::endl;
-
+  if (debug_)
+    std::cout << " is associated to " << elements[thisEcal] << std::endl;
 
   // Set ECAL energy for muons
-  if ( thisIsAMuon ) {
-    (*pfCandidates_)[tmpi[0]].setEcalEnergy( clusterRef->energy(),
-    					 std::min(clusterRef->energy(), muonECAL_[0]) );
-    (*pfCandidates_)[tmpi[0]].setHcalEnergy( 0., 0. );
-    (*pfCandidates_)[tmpi[0]].setHoEnergy( 0., 0. );
-    (*pfCandidates_)[tmpi[0]].setPs1Energy( 0 );
-    (*pfCandidates_)[tmpi[0]].setPs2Energy( 0 );
-    (*pfCandidates_)[tmpi[0]].addElementInBlock( blockref, kTrack[0] );
+  if (thisIsAMuon) {
+    (*pfCandidates_)[tmpi[0]].setEcalEnergy(clusterRef->energy(), std::min(clusterRef->energy(), muonECAL_[0]));
+    (*pfCandidates_)[tmpi[0]].setHcalEnergy(0., 0.);
+    (*pfCandidates_)[tmpi[0]].setHoEnergy(0., 0.);
+    (*pfCandidates_)[tmpi[0]].setPs1Energy(0);
+    (*pfCandidates_)[tmpi[0]].setPs2Energy(0);
+    (*pfCandidates_)[tmpi[0]].addElementInBlock(blockref, kTrack[0]);
   }
 
   double slopeEcal = 1.;
@@ -561,38 +530,45 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
 
   // Consider charged particles closest to the same ECAL cluster
   std::multimap<double, unsigned> sortedTracks;
-  block.associatedElements( thisEcal,  linkData,
-    			sortedTracks,
-    			reco::PFBlockElement::TRACK,
-    			reco::PFBlock::LINKTEST_ALL );
-  if (debug_) cout << "the closest ECAL cluster, id " << thisEcal << ", has " << sortedTracks.size() << " associated tracks, now processing them. " << endl;
+  block.associatedElements(thisEcal, linkData, sortedTracks, reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL);
+  if (debug_)
+    cout << "the closest ECAL cluster, id " << thisEcal << ", has " << sortedTracks.size()
+         << " associated tracks, now processing them. " << endl;
 
   if (hasDeadHcal && !sortedTracks.empty()) {
-      // GP: only allow the ecal cluster closest to this track to be considered
-      if (debug_) cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second << " (distance " << sortedTracks.begin()->first << ")" << endl;
-      if (sortedTracks.begin()->second != iTrack) {
-        if (debug_) cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second << " which is not the one being processed. Will skip ECAL linking for this track" << endl;
-        (*pfCandidates_)[tmpi[0]].setEcalEnergy( 0., 0. );
-        (*pfCandidates_)[tmpi[0]].setHcalEnergy( 0., 0. );
-        (*pfCandidates_)[tmpi[0]].setHoEnergy( 0., 0. );
-        (*pfCandidates_)[tmpi[0]].setPs1Energy( 0 );
-        (*pfCandidates_)[tmpi[0]].setPs2Energy( 0 );
-        (*pfCandidates_)[tmpi[0]].addElementInBlock( blockref, kTrack[0] );
-        return true;
-      } else {
-        if (debug_) cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second << " which is the one being processed. Will skip ECAL linking for all other track" << endl;
-        sortedTracks.clear();
-      }
+    // GP: only allow the ecal cluster closest to this track to be considered
+    if (debug_)
+      cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second << " (distance "
+           << sortedTracks.begin()->first << ")" << endl;
+    if (sortedTracks.begin()->second != iTrack) {
+      if (debug_)
+        cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second
+             << " which is not the one being processed. Will skip ECAL linking for this track" << endl;
+      (*pfCandidates_)[tmpi[0]].setEcalEnergy(0., 0.);
+      (*pfCandidates_)[tmpi[0]].setHcalEnergy(0., 0.);
+      (*pfCandidates_)[tmpi[0]].setHoEnergy(0., 0.);
+      (*pfCandidates_)[tmpi[0]].setPs1Energy(0);
+      (*pfCandidates_)[tmpi[0]].setPs2Energy(0);
+      (*pfCandidates_)[tmpi[0]].addElementInBlock(blockref, kTrack[0]);
+      return true;
+    } else {
+      if (debug_)
+        cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second
+             << " which is the one being processed. Will skip ECAL linking for all other track" << endl;
+      sortedTracks.clear();
+    }
   }
 
-  for(auto const& trk : sortedTracks) {
+  for (auto const& trk : sortedTracks) {
     unsigned jTrack = trk.second;
 
     // Don't consider already used tracks
-    if ( !active[jTrack] ) continue;
+    if (!active[jTrack])
+      continue;
 
     // The loop is on the other tracks !
-    if ( jTrack == iTrack ) continue;
+    if (jTrack == iTrack)
+      continue;
 
     // Check if the ECAL cluster closest to this track is
     // indeed the current ECAL cluster. Only tracks not
@@ -601,53 +577,52 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
     // to the same Ecal cluster and that also has an Hcal link
     // we would have also linked iTrack to that Hcal above)
     std::multimap<double, unsigned> sortedECAL;
-    block.associatedElements( jTrack,  linkData,
-    			  sortedECAL,
-    			  reco::PFBlockElement::ECAL,
-    			  reco::PFBlock::LINKTEST_ALL );
-    if ( sortedECAL.begin()->second != thisEcal ) continue;
+    block.associatedElements(jTrack, linkData, sortedECAL, reco::PFBlockElement::ECAL, reco::PFBlock::LINKTEST_ALL);
+    if (sortedECAL.begin()->second != thisEcal)
+      continue;
 
     // Check if this track is a muon
     bool thatIsAMuon = PFMuonAlgo::isMuon(elements[jTrack]);
     if (debug_) {
-        cout << " found track " << jTrack << (thatIsAMuon ? " (muon) " : " (non-muon)") << ", with distance = " << sortedECAL.begin()->first << std::endl;
+      cout << " found track " << jTrack << (thatIsAMuon ? " (muon) " : " (non-muon)")
+           << ", with distance = " << sortedECAL.begin()->first << std::endl;
     }
-
 
     // Check if this track is not a fake
     bool rejectFake = false;
     reco::TrackRef trackRef = elements[jTrack].trackRef();
-    if ( !thatIsAMuon && trackRef->ptError() > ptError_) {
+    if (!thatIsAMuon && trackRef->ptError() > ptError_) {
       // GP: FIXME this selection should be adapted depending on hasDeadHcal
       //     but we don't know if jTrack is linked to a dead Hcal or not
       double deficit = trackMomentum + trackRef->p() - clusterRef->energy();
-      double resol = nSigmaTRACK_*neutralHadronEnergyResolution(trackMomentum+trackRef->p(),
-    							    clusterRef->positionREP().Eta());
-      resol *= (trackMomentum+trackRef->p());
-      if ( deficit > nSigmaTRACK_*resol  && !goodTrackDeadHcal) {
+      double resol =
+          nSigmaTRACK_ * neutralHadronEnergyResolution(trackMomentum + trackRef->p(), clusterRef->positionREP().Eta());
+      resol *= (trackMomentum + trackRef->p());
+      if (deficit > nSigmaTRACK_ * resol && !goodTrackDeadHcal) {
         rejectFake = true;
         kTrack.push_back(jTrack);
         active[jTrack] = false;
-        if ( debug_ )
+        if (debug_)
           std::cout << elements[jTrack] << std::endl
-    		<< "is probably a fake (2) --> lock the track"
-    		<< "(trackMomentum = " << trackMomentum << ", clusterEnergy = " << clusterRef->energy() <<
-    		        ", deficit = " << deficit << " > " << nSigmaTRACK_ << " x " << resol <<
-    		        " assuming neutralHadronEnergyResolution " << neutralHadronEnergyResolution(trackMomentum+trackRef->p(), clusterRef->positionREP().Eta()) << ") "
-    		<< std::endl;
+                    << "is probably a fake (2) --> lock the track"
+                    << "(trackMomentum = " << trackMomentum << ", clusterEnergy = " << clusterRef->energy()
+                    << ", deficit = " << deficit << " > " << nSigmaTRACK_ << " x " << resol
+                    << " assuming neutralHadronEnergyResolution "
+                    << neutralHadronEnergyResolution(trackMomentum + trackRef->p(), clusterRef->positionREP().Eta())
+                    << ") " << std::endl;
       }
     }
-    if ( rejectFake ) continue;
-
+    if (rejectFake)
+      continue;
 
     // Otherwise, add this track momentum to the total track momentum
     /* */
     // reco::TrackRef trackRef = elements[jTrack].trackRef();
-    if ( !thatIsAMuon ) {
-      if ( debug_ )
+    if (!thatIsAMuon) {
+      if (debug_)
         std::cout << "Track momentum increased from " << trackMomentum << " GeV ";
       trackMomentum += trackRef->p();
-      if ( debug_ ) {
+      if (debug_) {
         std::cout << "to " << trackMomentum << " GeV." << std::endl;
         std::cout << "with " << elements[jTrack] << std::endl;
       }
@@ -658,61 +633,61 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
 
     // And create a charged particle candidate !
 
-    tmpi.push_back(reconstructTrack( elements[jTrack] ));
-
+    tmpi.push_back(reconstructTrack(elements[jTrack]));
 
     kTrack.push_back(jTrack);
     active[jTrack] = false;
 
-    if ( thatIsAMuon ) {
-      (*pfCandidates_)[tmpi.back()].setEcalEnergy(clusterRef->energy(),
-    					      std::min(clusterRef->energy(),muonECAL_[0]));
-      (*pfCandidates_)[tmpi.back()].setHcalEnergy( 0., 0. );
-      (*pfCandidates_)[tmpi.back()].setHoEnergy( 0., 0. );
-      (*pfCandidates_)[tmpi.back()].setPs1Energy( 0 );
-      (*pfCandidates_)[tmpi.back()].setPs2Energy( 0 );
-      (*pfCandidates_)[tmpi.back()].addElementInBlock( blockref, kTrack.back() );
+    if (thatIsAMuon) {
+      (*pfCandidates_)[tmpi.back()].setEcalEnergy(clusterRef->energy(), std::min(clusterRef->energy(), muonECAL_[0]));
+      (*pfCandidates_)[tmpi.back()].setHcalEnergy(0., 0.);
+      (*pfCandidates_)[tmpi.back()].setHoEnergy(0., 0.);
+      (*pfCandidates_)[tmpi.back()].setPs1Energy(0);
+      (*pfCandidates_)[tmpi.back()].setPs2Energy(0);
+      (*pfCandidates_)[tmpi.back()].addElementInBlock(blockref, kTrack.back());
     }
   }
 
-
-  if ( debug_ ) std::cout << "Loop over all associated ECAL clusters" << std::endl;
+  if (debug_)
+    std::cout << "Loop over all associated ECAL clusters" << std::endl;
   // Loop over all ECAL linked clusters ordered by increasing distance.
-  for(auto const& ecal : ecalElems)
-  {
+  for (auto const& ecal : ecalElems) {
     const unsigned index = ecal.second;
     const PFBlockElement::Type type = elements[index].type();
-    assert( type == PFBlockElement::ECAL );
-    if ( debug_ ) std::cout << elements[index] << std::endl;
+    assert(type == PFBlockElement::ECAL);
+    if (debug_)
+      std::cout << elements[index] << std::endl;
 
     // Just skip clusters already taken
-    if ( debug_ && ! active[index] ) std::cout << "is not active  - ignore " << std::endl;
-    if ( ! active[index] ) continue;
+    if (debug_ && !active[index])
+      std::cout << "is not active  - ignore " << std::endl;
+    if (!active[index])
+      continue;
 
     // Just skip this cluster if it's closer to another track
-    block.associatedElements( index,  linkData, sortedTracks,
-                              reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL );
+    block.associatedElements(index, linkData, sortedTracks, reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL);
 
-    const bool skip = std::none_of(kTrack.begin(), kTrack.end(), [&](unsigned iTrack){
-                return sortedTracks.begin()->second == iTrack;
-            });
+    const bool skip = std::none_of(
+        kTrack.begin(), kTrack.end(), [&](unsigned iTrack) { return sortedTracks.begin()->second == iTrack; });
 
-    if ( debug_ && skip ) std::cout << "is closer to another track - ignore " << std::endl;
-    if ( skip ) continue;
+    if (debug_ && skip)
+      std::cout << "is closer to another track - ignore " << std::endl;
+    if (skip)
+      continue;
 
     // The corresponding PFCluster and energy
     const reco::PFClusterRef clusterRef = elements[index].clusterRef();
-    assert( !clusterRef.isNull() );
+    assert(!clusterRef.isNull());
 
-    if ( debug_ ) {
-      std::cout <<"Ecal cluster with raw energy = " << clusterRef->energy()
-            <<" linked with distance = " << ecal.first << std::endl;
+    if (debug_) {
+      std::cout << "Ecal cluster with raw energy = " << clusterRef->energy() << " linked with distance = " << ecal.first
+                << std::endl;
     }
     //double dist = ie->first;
     //if ( !connectedToEcal && dist > 0.1 ) {
-      //std::cout << "Warning - first ECAL cluster at a distance of " << dist << "from the closest track!" << std::endl;
-      //cout<<"\telement "<<elements[index]<<" linked with distance = "<< dist <<endl;
-      //cout<<"\telement "<<elements[iTrack]<<" linked with distance = "<< dist <<endl;
+    //std::cout << "Warning - first ECAL cluster at a distance of " << dist << "from the closest track!" << std::endl;
+    //cout<<"\telement "<<elements[index]<<" linked with distance = "<< dist <<endl;
+    //cout<<"\telement "<<elements[iTrack]<<" linked with distance = "<< dist <<endl;
     //}
 
     // Check the presence of preshower clusters in the vicinity
@@ -726,32 +701,33 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
 
     // KH: use raw ECAL energy for PF hadron calibration. use calibrated ECAL energy when adding PF photons
     const double ecalEnergy = clusterRef->energy();
-    const double ecalEnergyCalibrated = clusterRef->correctedEnergy(); // calibrated based on the egamma hypothesis
-    if ( debug_ ) std::cout << "Corrected ECAL(+PS) energy = " << ecalEnergy << std::endl;
+    const double ecalEnergyCalibrated = clusterRef->correctedEnergy();  // calibrated based on the egamma hypothesis
+    if (debug_)
+      std::cout << "Corrected ECAL(+PS) energy = " << ecalEnergy << std::endl;
 
     // Since the electrons were found beforehand, this track must be a hadron. Calibrate
     // the energy under the hadron hypothesis.
     totalEcal += ecalEnergy;
     const double previousCalibEcal = calibEcal;
     const double previousSlopeEcal = slopeEcal;
-    calibEcal = std::max(totalEcal,0.);
+    calibEcal = std::max(totalEcal, 0.);
     calibHcal = 0.;
-    calibration_.energyEmHad( trackMomentum,calibEcal,calibHcal,
-                               clusterRef->positionREP().Eta(),
-                               clusterRef->positionREP().Phi() );
-    if ( totalEcal > 0.) slopeEcal = calibEcal/totalEcal;
+    calibration_.energyEmHad(
+        trackMomentum, calibEcal, calibHcal, clusterRef->positionREP().Eta(), clusterRef->positionREP().Phi());
+    if (totalEcal > 0.)
+      slopeEcal = calibEcal / totalEcal;
 
-    if ( debug_ )
-      std::cout << "The total calibrated energy so far amounts to = " << calibEcal << " (slope = " << slopeEcal << ")" << std::endl;
-
+    if (debug_)
+      std::cout << "The total calibrated energy so far amounts to = " << calibEcal << " (slope = " << slopeEcal << ")"
+                << std::endl;
 
     // Stop the loop when adding more ECAL clusters ruins the compatibility
-    if ( connectedToEcal && calibEcal - trackMomentum >= 0. ) {
-    // if ( connectedToEcal && calibEcal - trackMomentum >=
-    //     nSigmaECAL_*neutralHadronEnergyResolution(trackMomentum,clusterRef->positionREP().Eta())  ) {
+    if (connectedToEcal && calibEcal - trackMomentum >= 0.) {
+      // if ( connectedToEcal && calibEcal - trackMomentum >=
+      //     nSigmaECAL_*neutralHadronEnergyResolution(trackMomentum,clusterRef->positionREP().Eta())  ) {
       calibEcal = previousCalibEcal;
       slopeEcal = previousSlopeEcal;
-      totalEcal = calibEcal/slopeEcal;
+      totalEcal = calibEcal / slopeEcal;
 
       // Turn this last cluster in a photon
       // (The PS clusters are already locked in "associatePSClusters")
@@ -759,25 +735,24 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
 
       // Find the associated tracks
       std::multimap<double, unsigned> assTracks;
-      block.associatedElements( index,  linkData,
-                                assTracks,
-                                reco::PFBlockElement::TRACK,
-                                reco::PFBlock::LINKTEST_ALL );
+      block.associatedElements(index, linkData, assTracks, reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL);
 
-      auto& ecalCand = (*pfCandidates_)[reconstructCluster( *clusterRef, ecalEnergyCalibrated )]; // KH: use the PF ECAL cluster calibrated energy
-      ecalCand.setEcalEnergy( clusterRef->energy(), ecalEnergyCalibrated );
-      ecalCand.setHcalEnergy( 0., 0. );
-      ecalCand.setHoEnergy( 0., 0. );
-      ecalCand.setPs1Energy( ps1Ene[0] );
-      ecalCand.setPs2Energy( ps2Ene[0] );
-      ecalCand.addElementInBlock( blockref, index );
+      auto& ecalCand = (*pfCandidates_)[reconstructCluster(
+          *clusterRef, ecalEnergyCalibrated)];  // KH: use the PF ECAL cluster calibrated energy
+      ecalCand.setEcalEnergy(clusterRef->energy(), ecalEnergyCalibrated);
+      ecalCand.setHcalEnergy(0., 0.);
+      ecalCand.setHoEnergy(0., 0.);
+      ecalCand.setPs1Energy(ps1Ene[0]);
+      ecalCand.setPs2Energy(ps2Ene[0]);
+      ecalCand.addElementInBlock(blockref, index);
       // Check that there is at least one track
-      if(!assTracks.empty()) {
-        ecalCand.addElementInBlock( blockref, assTracks.begin()->second );
+      if (!assTracks.empty()) {
+        ecalCand.addElementInBlock(blockref, assTracks.begin()->second);
 
         // Assign the position of the track at the ECAL entrance
         const ::math::XYZPointF& chargedPosition =
-          dynamic_cast<const reco::PFBlockElementTrack*>(&elements[assTracks.begin()->second])->positionAtECALEntrance();
+            dynamic_cast<const reco::PFBlockElementTrack*>(&elements[assTracks.begin()->second])
+                ->positionAtECALEntrance();
         ecalCand.setPositionAtECALEntrance(chargedPosition);
       }
       break;
@@ -787,14 +762,15 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
     connectedToEcal = true;
     iEcal = index;
     active[index] = false;
-    for (unsigned ic : tmpi) (*pfCandidates_)[ic].addElementInBlock( blockref, iEcal );
+    for (unsigned ic : tmpi)
+      (*pfCandidates_)[ic].addElementInBlock(blockref, iEcal);
 
-  } // Loop ecal elements
+  }  // Loop ecal elements
 
   bool bNeutralProduced = false;
 
   // Create a photon if the ecal energy is too large
-  if( connectedToEcal ) {
+  if (connectedToEcal) {
     reco::PFClusterRef pivotalRef = elements[iEcal].clusterRef();
 
     double neutralEnergy = calibEcal - trackMomentum;
@@ -833,64 +809,70 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
     */
 
     // Add a photon if the energy excess is large enough
-    double resol = neutralHadronEnergyResolution(trackMomentum,pivotalRef->positionREP().Eta());
+    double resol = neutralHadronEnergyResolution(trackMomentum, pivotalRef->positionREP().Eta());
     resol *= trackMomentum;
-    if ( neutralEnergy > std::max(0.5,nSigmaECAL_*resol) ) {
+    if (neutralEnergy > std::max(0.5, nSigmaECAL_ * resol)) {
       neutralEnergy /= slopeEcal;
-      unsigned tmpj = reconstructCluster( *pivotalRef, neutralEnergy );
-      (*pfCandidates_)[tmpj].setEcalEnergy( pivotalRef->energy(), neutralEnergy );
-      (*pfCandidates_)[tmpj].setHcalEnergy( 0., 0. );
-      (*pfCandidates_)[tmpj].setHoEnergy( 0., 0. );
-      (*pfCandidates_)[tmpj].setPs1Energy( 0. );
-      (*pfCandidates_)[tmpj].setPs2Energy( 0. );
+      unsigned tmpj = reconstructCluster(*pivotalRef, neutralEnergy);
+      (*pfCandidates_)[tmpj].setEcalEnergy(pivotalRef->energy(), neutralEnergy);
+      (*pfCandidates_)[tmpj].setHcalEnergy(0., 0.);
+      (*pfCandidates_)[tmpj].setHoEnergy(0., 0.);
+      (*pfCandidates_)[tmpj].setPs1Energy(0.);
+      (*pfCandidates_)[tmpj].setPs2Energy(0.);
       (*pfCandidates_)[tmpj].addElementInBlock(blockref, iEcal);
       bNeutralProduced = true;
-      for (unsigned ic=0; ic<kTrack.size();++ic)
-        (*pfCandidates_)[tmpj].addElementInBlock( blockref, kTrack[ic] );
-    } // End neutral energy
+      for (unsigned ic = 0; ic < kTrack.size(); ++ic)
+        (*pfCandidates_)[tmpj].addElementInBlock(blockref, kTrack[ic]);
+    }  // End neutral energy
 
     // Set elements in blocks and ECAL energies to all tracks
-  	for (unsigned ic=0; ic<tmpi.size();++ic) {
-
+    for (unsigned ic = 0; ic < tmpi.size(); ++ic) {
       // Skip muons
-      if ( (*pfCandidates_)[tmpi[ic]].particleId() == reco::PFCandidate::mu ) continue;
+      if ((*pfCandidates_)[tmpi[ic]].particleId() == reco::PFCandidate::mu)
+        continue;
 
-      double fraction = trackMomentum > 0 ? (*pfCandidates_)[tmpi[ic]].trackRef()->p()/trackMomentum : 0;
-      double ecalCal = bNeutralProduced ?
-        (calibEcal-neutralEnergy*slopeEcal)*fraction : calibEcal*fraction;
-      double ecalRaw = totalEcal*fraction;
+      double fraction = trackMomentum > 0 ? (*pfCandidates_)[tmpi[ic]].trackRef()->p() / trackMomentum : 0;
+      double ecalCal = bNeutralProduced ? (calibEcal - neutralEnergy * slopeEcal) * fraction : calibEcal * fraction;
+      double ecalRaw = totalEcal * fraction;
 
-      if (debug_) cout << "The fraction after photon supression is " << fraction << " calibrated ecal = " << ecalCal << endl;
+      if (debug_)
+        cout << "The fraction after photon supression is " << fraction << " calibrated ecal = " << ecalCal << endl;
 
-      (*pfCandidates_)[tmpi[ic]].setEcalEnergy( ecalRaw, ecalCal );
-      (*pfCandidates_)[tmpi[ic]].setHcalEnergy( 0., 0. );
-      (*pfCandidates_)[tmpi[ic]].setHoEnergy( 0., 0. );
-      (*pfCandidates_)[tmpi[ic]].setPs1Energy( 0 );
-      (*pfCandidates_)[tmpi[ic]].setPs2Energy( 0 );
-      (*pfCandidates_)[tmpi[ic]].addElementInBlock( blockref, kTrack[ic] );
+      (*pfCandidates_)[tmpi[ic]].setEcalEnergy(ecalRaw, ecalCal);
+      (*pfCandidates_)[tmpi[ic]].setHcalEnergy(0., 0.);
+      (*pfCandidates_)[tmpi[ic]].setHoEnergy(0., 0.);
+      (*pfCandidates_)[tmpi[ic]].setPs1Energy(0);
+      (*pfCandidates_)[tmpi[ic]].setPs2Energy(0);
+      (*pfCandidates_)[tmpi[ic]].addElementInBlock(blockref, kTrack[ic]);
     }
 
-  } // End connected ECAL
+  }  // End connected ECAL
 
   // Fill the element_in_block for tracks that are eventually linked to no ECAL clusters at all.
-  for (unsigned ic=0; ic<tmpi.size();++ic) {
+  for (unsigned ic = 0; ic < tmpi.size(); ++ic) {
     const PFCandidate& pfc = (*pfCandidates_)[tmpi[ic]];
     const PFCandidate::ElementsInBlocks& eleInBlocks = pfc.elementsInBlocks();
-    if ( eleInBlocks.empty() ) {
-      if ( debug_ )std::cout << "Single track / Fill element in block! " << std::endl;
-      (*pfCandidates_)[tmpi[ic]].addElementInBlock( blockref, kTrack[ic] );
+    if (eleInBlocks.empty()) {
+      if (debug_)
+        std::cout << "Single track / Fill element in block! " << std::endl;
+      (*pfCandidates_)[tmpi[ic]].addElementInBlock(blockref, kTrack[ic]);
     }
   }
   return false;
 }
 
-void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData,
-  const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active,
-  const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea) {
-  for(unsigned iEle=0; iEle<elements.size(); iEle++) {
+void PFAlgo::elementLoop(const reco::PFBlock& block,
+                         reco::PFBlock::LinkData& linkData,
+                         const edm::OwnVector<reco::PFBlockElement>& elements,
+                         std::vector<bool>& active,
+                         const reco::PFBlockRef& blockref,
+                         ElementIndices& inds,
+                         std::vector<bool>& deadArea) {
+  for (unsigned iEle = 0; iEle < elements.size(); iEle++) {
     PFBlockElement::Type type = elements[iEle].type();
 
-    if(debug_ && type != PFBlockElement::BREM ) cout<<endl<<elements[iEle];
+    if (debug_ && type != PFBlockElement::BREM)
+      cout << endl << elements[iEle];
     auto ret_decideType = decideType(elements, type, active, inds, deadArea, iEle);
     if (ret_decideType == 1) {
       continue;
@@ -900,43 +882,46 @@ void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& li
     unsigned iTrack = iEle;
     reco::MuonRef muonRef = elements[iTrack].muonRef();
     if (debug_ && muonRef.isNonnull()) {
-        cout << "track " << iTrack << " has a valid muon reference. " << std::endl;
-        cout << "   - isMuon: " << PFMuonAlgo::isMuon(muonRef) << endl;
-        cout << "   - isGlobalTightMuon: " << PFMuonAlgo::isGlobalTightMuon(muonRef) << endl;
-        cout << "   - isTrackerTightMuon: " << PFMuonAlgo::isTrackerTightMuon(muonRef) << endl;
-        cout << "   - isIsolatedMuon: " << PFMuonAlgo::isIsolatedMuon(muonRef) << endl;
+      cout << "track " << iTrack << " has a valid muon reference. " << std::endl;
+      cout << "   - isMuon: " << PFMuonAlgo::isMuon(muonRef) << endl;
+      cout << "   - isGlobalTightMuon: " << PFMuonAlgo::isGlobalTightMuon(muonRef) << endl;
+      cout << "   - isTrackerTightMuon: " << PFMuonAlgo::isTrackerTightMuon(muonRef) << endl;
+      cout << "   - isIsolatedMuon: " << PFMuonAlgo::isIsolatedMuon(muonRef) << endl;
     }
 
     //Check if the track is a primary track of a secondary interaction
     //If that is the case reconstruct a charged hadron noly using that
     //track
-    if (active[iTrack] && isFromSecInt(elements[iEle], "primary")){
-      bool isPrimaryTrack = elements[iEle].displacedVertexRef(PFBlockElement::T_TO_DISP)->displacedVertexRef()->isTherePrimaryTracks();
+    if (active[iTrack] && isFromSecInt(elements[iEle], "primary")) {
+      bool isPrimaryTrack =
+          elements[iEle].displacedVertexRef(PFBlockElement::T_TO_DISP)->displacedVertexRef()->isTherePrimaryTracks();
       if (isPrimaryTrack) {
-	if (debug_) cout << "Primary Track reconstructed alone" << endl;
+        if (debug_)
+          cout << "Primary Track reconstructed alone" << endl;
 
-	unsigned tmpi = reconstructTrack(elements[iEle]);
-	(*pfCandidates_)[tmpi].addElementInBlock( blockref, iEle );
-	active[iTrack] = false;
+        unsigned tmpi = reconstructTrack(elements[iEle]);
+        (*pfCandidates_)[tmpi].addElementInBlock(blockref, iEle);
+        active[iTrack] = false;
       }
     }
 
-    if(debug_) {
-      if ( !active[iTrack] )
-	cout << "Already used by electrons, muons, conversions" << endl;
+    if (debug_) {
+      if (!active[iTrack])
+        cout << "Already used by electrons, muons, conversions" << endl;
     }
 
     // Track already used as electron, muon, conversion?
     // Added a check on the activated element
-    if ( ! active[iTrack] ) continue;
+    if (!active[iTrack])
+      continue;
 
     reco::TrackRef trackRef = elements[iTrack].trackRef();
-    assert( !trackRef.isNull() );
+    assert(!trackRef.isNull());
 
-    if (debug_ ) {
-      cout <<"PFAlgo:processBlock "<<" "<< inds.trackIs.size()<<" "
-        << inds.ecalIs.size()<<" "<< inds.hcalIs.size()<<" "
-        << inds.hoIs.size()<<endl;
+    if (debug_) {
+      cout << "PFAlgo:processBlock "
+           << " " << inds.trackIs.size() << " " << inds.ecalIs.size() << " " << inds.hcalIs.size() << " "
+           << inds.hoIs.size() << endl;
     }
 
     // look for associated elements of all types
@@ -944,25 +929,21 @@ void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& li
     // all types of links are considered.
     // the elements are sorted by increasing distance
     std::multimap<double, unsigned> ecalElems;
-    block.associatedElements( iTrack,  linkData,
-                              ecalElems ,
-                              reco::PFBlockElement::ECAL,
-			      reco::PFBlock::LINKTEST_ALL );
+    block.associatedElements(iTrack, linkData, ecalElems, reco::PFBlockElement::ECAL, reco::PFBlock::LINKTEST_ALL);
 
     std::multimap<double, unsigned> hcalElems;
-    block.associatedElements( iTrack,  linkData,
-                              hcalElems,
-                              reco::PFBlockElement::HCAL,
-                              reco::PFBlock::LINKTEST_ALL );
+    block.associatedElements(iTrack, linkData, hcalElems, reco::PFBlockElement::HCAL, reco::PFBlock::LINKTEST_ALL);
 
-    if (debug_ ) {
-        std::cout << "\tTrack " << iTrack << " is linked to " << ecalElems.size() << " ecal and " << hcalElems.size() << " hcal elements" << std::endl;
-        for (const auto & pair : ecalElems) {
-            std::cout << "ecal: dist " << pair.first << "\t elem " << pair.second << std::endl;
-        }
-        for (const auto & pair : hcalElems) {
-            std::cout << "hcal: dist " << pair.first << "\t elem " << pair.second << (deadArea[pair.second] ? "  DEAD AREA MARKER" : "") <<  std::endl;
-        }
+    if (debug_) {
+      std::cout << "\tTrack " << iTrack << " is linked to " << ecalElems.size() << " ecal and " << hcalElems.size()
+                << " hcal elements" << std::endl;
+      for (const auto& pair : ecalElems) {
+        std::cout << "ecal: dist " << pair.first << "\t elem " << pair.second << std::endl;
+      }
+      for (const auto& pair : hcalElems) {
+        std::cout << "hcal: dist " << pair.first << "\t elem " << pair.second
+                  << (deadArea[pair.second] ? "  DEAD AREA MARKER" : "") << std::endl;
+      }
     }
     // there's 3 possible options possible here, in principle:
     //    1) flag everything that may be associated to a dead hcal marker
@@ -978,8 +959,8 @@ void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& li
     //--- option (2) --
     bool hasDeadHcal = false;
     if (!hcalElems.empty() && deadArea[hcalElems.begin()->second]) {
-        hasDeadHcal = true;
-        hcalElems.clear();
+      hasDeadHcal = true;
+      hcalElems.clear();
     }
     //--- option (3) --
     //bool hasDeadHcal = true;
@@ -991,105 +972,98 @@ void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& li
     // for tracks with bad Hcal, check the quality
     bool goodTrackDeadHcal = false;
     if (hasDeadHcal) {
-       goodTrackDeadHcal = ( trackRef->ptError() < goodTrackDeadHcal_ptErrRel_ * trackRef->pt() &&
-                             trackRef->normalizedChi2() < goodTrackDeadHcal_chi2n_ &&
-                             trackRef->hitPattern().trackerLayersWithMeasurement() >= goodTrackDeadHcal_layers_ &&
-                             trackRef->validFraction() > goodTrackDeadHcal_validFr_ &&
-                             std::abs(trackRef->dxy(primaryVertex_.position())) < goodTrackDeadHcal_dxy_ );
-       // now we add an extra block for tracks at high |eta|
-       if (!goodTrackDeadHcal &&
-            std::abs(trackRef->eta()) > goodPixelTrackDeadHcal_minEta_ && // high eta
-            trackRef->hitPattern().pixelLayersWithMeasurement() >= 3   && // pixel track
-            trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS) == 0 &&
-            trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_INNER_HITS) == 0 &&
-            trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_OUTER_HITS) <= (
-                trackRef->hitPattern().pixelLayersWithMeasurement() > 3 ?
-                goodPixelTrackDeadHcal_maxLost4Hit_ : goodPixelTrackDeadHcal_maxLost3Hit_  ) &&
-            trackRef->normalizedChi2() < goodPixelTrackDeadHcal_chi2n_ && // tighter cut
-            std::abs(trackRef->dxy(primaryVertex_.position())) < goodPixelTrackDeadHcal_dxy_  &&
-            std::abs(trackRef->dz(primaryVertex_.position()))  < goodPixelTrackDeadHcal_dz_  &&
-            trackRef->ptError() < goodPixelTrackDeadHcal_ptErrRel_*trackRef->pt() && // sanity
-            trackRef->pt() < goodPixelTrackDeadHcal_maxPt_) {                        // sanity
-            goodTrackDeadHcal = true;
-            // FIXME: may decide to do something to the track pT
-       }
-       //if (!goodTrackDeadHcal && trackRef->hitPattern().trackerLayersWithMeasurement() == 4 && trackRef->validFraction() == 1
-       if (debug_) cout << " track pt " << trackRef->pt() << " +- " << trackRef->ptError()
-          << " layers valid " << trackRef->hitPattern().trackerLayersWithMeasurement()
-                << ", lost " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS)
-                << ", lost outer " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_OUTER_HITS)
-                << ", lost inner " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_INNER_HITS)
-                << "(valid fraction " << trackRef->validFraction() << ")"
-          << " chi2/ndf " << trackRef->normalizedChi2()
-          << " |dxy| " << std::abs(trackRef->dxy(primaryVertex_.position())) << " +- " << trackRef->dxyError()
-          << " |dz| " << std::abs(trackRef->dz(primaryVertex_.position())) << " +- " << trackRef->dzError()
-          << (goodTrackDeadHcal ? " passes " : " fails ") << "quality cuts" << std::endl;
+      goodTrackDeadHcal = (trackRef->ptError() < goodTrackDeadHcal_ptErrRel_ * trackRef->pt() &&
+                           trackRef->normalizedChi2() < goodTrackDeadHcal_chi2n_ &&
+                           trackRef->hitPattern().trackerLayersWithMeasurement() >= goodTrackDeadHcal_layers_ &&
+                           trackRef->validFraction() > goodTrackDeadHcal_validFr_ &&
+                           std::abs(trackRef->dxy(primaryVertex_.position())) < goodTrackDeadHcal_dxy_);
+      // now we add an extra block for tracks at high |eta|
+      if (!goodTrackDeadHcal && std::abs(trackRef->eta()) > goodPixelTrackDeadHcal_minEta_ &&  // high eta
+          trackRef->hitPattern().pixelLayersWithMeasurement() >= 3 &&                          // pixel track
+          trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS) == 0 &&
+          trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_INNER_HITS) == 0 &&
+          trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_OUTER_HITS) <=
+              (trackRef->hitPattern().pixelLayersWithMeasurement() > 3 ? goodPixelTrackDeadHcal_maxLost4Hit_
+                                                                       : goodPixelTrackDeadHcal_maxLost3Hit_) &&
+          trackRef->normalizedChi2() < goodPixelTrackDeadHcal_chi2n_ &&  // tighter cut
+          std::abs(trackRef->dxy(primaryVertex_.position())) < goodPixelTrackDeadHcal_dxy_ &&
+          std::abs(trackRef->dz(primaryVertex_.position())) < goodPixelTrackDeadHcal_dz_ &&
+          trackRef->ptError() < goodPixelTrackDeadHcal_ptErrRel_ * trackRef->pt() &&  // sanity
+          trackRef->pt() < goodPixelTrackDeadHcal_maxPt_) {                           // sanity
+        goodTrackDeadHcal = true;
+        // FIXME: may decide to do something to the track pT
+      }
+      //if (!goodTrackDeadHcal && trackRef->hitPattern().trackerLayersWithMeasurement() == 4 && trackRef->validFraction() == 1
+      if (debug_)
+        cout << " track pt " << trackRef->pt() << " +- " << trackRef->ptError() << " layers valid "
+             << trackRef->hitPattern().trackerLayersWithMeasurement() << ", lost "
+             << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS) << ", lost outer "
+             << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_OUTER_HITS)
+             << ", lost inner "
+             << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_INNER_HITS)
+             << "(valid fraction " << trackRef->validFraction() << ")"
+             << " chi2/ndf " << trackRef->normalizedChi2() << " |dxy| "
+             << std::abs(trackRef->dxy(primaryVertex_.position())) << " +- " << trackRef->dxyError() << " |dz| "
+             << std::abs(trackRef->dz(primaryVertex_.position())) << " +- " << trackRef->dzError()
+             << (goodTrackDeadHcal ? " passes " : " fails ") << "quality cuts" << std::endl;
     }
 
     // When a track has no HCAL cluster linked, but another track is linked to the same
     // ECAL cluster and an HCAL cluster, link the track to the HCAL cluster for
     // later analysis
-    if ( hcalElems.empty() && !ecalElems.empty() && !hasDeadHcal) {
+    if (hcalElems.empty() && !ecalElems.empty() && !hasDeadHcal) {
       // debug_ = true;
       unsigned ntt = 1;
       unsigned index = ecalElems.begin()->second;
       std::multimap<double, unsigned> sortedTracks;
-      block.associatedElements( index,  linkData,
-				sortedTracks,
-				reco::PFBlockElement::TRACK,
-				reco::PFBlock::LINKTEST_ALL );
-      if (debug_ ) std::cout << "The closest ECAL cluster is linked to " << sortedTracks.size() << " tracks, with distance = " << ecalElems.begin()->first << std::endl;
+      block.associatedElements(index, linkData, sortedTracks, reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL);
+      if (debug_)
+        std::cout << "The closest ECAL cluster is linked to " << sortedTracks.size()
+                  << " tracks, with distance = " << ecalElems.begin()->first << std::endl;
 
       // Loop over all tracks
-      for(auto const& trk : sortedTracks) {
-	unsigned jTrack = trk.second;
-	//std::cout << "Track " << jTrack << std::endl;
-	// Track must be active
-	if ( !active[jTrack] ) continue;
-	//std::cout << "Active " << std::endl;
+      for (auto const& trk : sortedTracks) {
+        unsigned jTrack = trk.second;
+        //std::cout << "Track " << jTrack << std::endl;
+        // Track must be active
+        if (!active[jTrack])
+          continue;
+        //std::cout << "Active " << std::endl;
 
-	// The loop is on the other tracks !
-	if ( jTrack == iTrack ) continue;
-	//std::cout << "A different track ! " << std::endl;
+        // The loop is on the other tracks !
+        if (jTrack == iTrack)
+          continue;
+        //std::cout << "A different track ! " << std::endl;
 
-	// Check if the ECAL closest to this track is the current ECAL
-	// Otherwise ignore this track in the neutral energy determination
-	std::multimap<double, unsigned> sortedECAL;
-	block.associatedElements( jTrack,  linkData,
-				  sortedECAL,
-				  reco::PFBlockElement::ECAL,
-				  reco::PFBlock::LINKTEST_ALL );
-	if ( sortedECAL.begin()->second != index ) continue;
-	if (debug_ ) std::cout << "  track " << jTrack << " with closest ECAL identical " << std::endl;
+        // Check if the ECAL closest to this track is the current ECAL
+        // Otherwise ignore this track in the neutral energy determination
+        std::multimap<double, unsigned> sortedECAL;
+        block.associatedElements(jTrack, linkData, sortedECAL, reco::PFBlockElement::ECAL, reco::PFBlock::LINKTEST_ALL);
+        if (sortedECAL.begin()->second != index)
+          continue;
+        if (debug_)
+          std::cout << "  track " << jTrack << " with closest ECAL identical " << std::endl;
 
+        // Check if this track is also linked to an HCAL
+        std::multimap<double, unsigned> sortedHCAL;
+        block.associatedElements(jTrack, linkData, sortedHCAL, reco::PFBlockElement::HCAL, reco::PFBlock::LINKTEST_ALL);
+        if (sortedHCAL.empty())
+          continue;
+        if (debug_)
+          std::cout << "  and with an HCAL cluster " << sortedHCAL.begin()->second << std::endl;
+        ntt++;
 
-	// Check if this track is also linked to an HCAL
-	std::multimap<double, unsigned> sortedHCAL;
-	block.associatedElements( jTrack,  linkData,
-				  sortedHCAL,
-				  reco::PFBlockElement::HCAL,
-				  reco::PFBlock::LINKTEST_ALL );
-	if ( sortedHCAL.empty() ) continue;
-	if (debug_ ) std::cout << "  and with an HCAL cluster " << sortedHCAL.begin()->second << std::endl;
-	ntt++;
+        // In that case establish a link with the first track
+        block.setLink(
+            iTrack, sortedHCAL.begin()->second, sortedECAL.begin()->first, linkData, PFBlock::LINKTEST_RECHIT);
 
-	// In that case establish a link with the first track
-	block.setLink( iTrack,
-		       sortedHCAL.begin()->second,
-		       sortedECAL.begin()->first,
-		       linkData,
-		       PFBlock::LINKTEST_RECHIT );
-
-      } // End other tracks
+      }  // End other tracks
 
       // Redefine HCAL elements
-      block.associatedElements( iTrack,  linkData,
-				hcalElems,
-				reco::PFBlockElement::HCAL,
-				reco::PFBlock::LINKTEST_ALL );
+      block.associatedElements(iTrack, linkData, hcalElems, reco::PFBlockElement::HCAL, reco::PFBlock::LINKTEST_ALL);
 
-      if ( debug_ && !hcalElems.empty() )
-	std::cout << "Track linked back to HCAL due to ECAL sharing with other tracks" << std::endl;
+      if (debug_ && !hcalElems.empty())
+        std::cout << "Track linked back to HCAL due to ECAL sharing with other tracks" << std::endl;
     }
 
     //MICHELE
@@ -1099,11 +1073,11 @@ void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& li
     // the mva_e_pi of the charged hadron will be set to 1
     // if a GSF element is associated to the current TRACK element
     // This information will be used in the electron rejection for tau ID.
-    std::multimap<double,unsigned> gsfElems;
-    block.associatedElements( iTrack, linkData, gsfElems, reco::PFBlockElement::GSF );
+    std::multimap<double, unsigned> gsfElems;
+    block.associatedElements(iTrack, linkData, gsfElems, reco::PFBlockElement::GSF);
 
-    if(hcalElems.empty() && debug_) {
-      cout<<"no hcal element connected to track "<<iTrack<<endl;
+    if (hcalElems.empty() && debug_) {
+      cout << "no hcal element connected to track " << iTrack << endl;
     }
 
     // will now loop on associated elements ...
@@ -1111,246 +1085,253 @@ void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& li
 
     bool hcalFound = false;
 
-    if(debug_)
-      cout<<"now looping on elements associated to the track"<<endl;
+    if (debug_)
+      cout << "now looping on elements associated to the track" << endl;
 
     // ... first on associated ECAL elements
     // Check if there is still a free ECAL for this track
-    for(auto const& ecal : ecalElems) {
-
+    for (auto const& ecal : ecalElems) {
       unsigned index = ecal.second;
       // Sanity checks and optional printout
       PFBlockElement::Type type = elements[index].type();
-      if(debug_) {
-	double  dist  = ecal.first;
-        cout<<"\telement "<<elements[index]<<" linked with distance = "<< dist <<endl;
-	if ( ! active[index] ) cout << "This ECAL is already used - skip it" << endl;
+      if (debug_) {
+        double dist = ecal.first;
+        cout << "\telement " << elements[index] << " linked with distance = " << dist << endl;
+        if (!active[index])
+          cout << "This ECAL is already used - skip it" << endl;
       }
-      assert( type == PFBlockElement::ECAL );
+      assert(type == PFBlockElement::ECAL);
 
       // This ECAL is not free (taken by an electron?) - just skip it
-      if ( ! active[index] ) continue;
+      if (!active[index])
+        continue;
 
       // Flag ECAL clusters for which the corresponding track is not linked to an HCAL cluster
 
       //reco::PFClusterRef clusterRef = elements[index].clusterRef();
       //assert( !clusterRef.isNull() );
-      if( !hcalElems.empty() && debug_)
-	cout<<"\t\tat least one hcal element connected to the track."
-	    <<" Sparing Ecal cluster for the hcal loop"<<endl;
+      if (!hcalElems.empty() && debug_)
+        cout << "\t\tat least one hcal element connected to the track."
+             << " Sparing Ecal cluster for the hcal loop" << endl;
 
-    } //loop print ecal elements
-
+    }  //loop print ecal elements
 
     // tracks which are not linked to an HCAL
     // are reconstructed now.
 
-    if( hcalElems.empty() ) {
-      auto ret_continue = recoTracksNotHCAL(block, linkData, elements, blockref, active, goodTrackDeadHcal, hasDeadHcal, iTrack, ecalElems, trackRef);
-       if (ret_continue) {
-         continue;
-       }
-    } // end if( hcalElems.empty() )
-
+    if (hcalElems.empty()) {
+      auto ret_continue = recoTracksNotHCAL(
+          block, linkData, elements, blockref, active, goodTrackDeadHcal, hasDeadHcal, iTrack, ecalElems, trackRef);
+      if (ret_continue) {
+        continue;
+      }
+    }  // end if( hcalElems.empty() )
 
     // In case several HCAL elements are linked to this track,
     // unlinking all of them except the closest.
-    for(auto const& hcal : hcalElems) {
-
+    for (auto const& hcal : hcalElems) {
       unsigned index = hcal.second;
 
       PFBlockElement::Type type = elements[index].type();
 
-      if(debug_) {
-	double dist = block.dist(iTrack,index,linkData,reco::PFBlock::LINKTEST_ALL);
-        cout<<"\telement "<<elements[index]<<" linked with distance "<< dist <<endl;
+      if (debug_) {
+        double dist = block.dist(iTrack, index, linkData, reco::PFBlock::LINKTEST_ALL);
+        cout << "\telement " << elements[index] << " linked with distance " << dist << endl;
       }
 
-      assert( type == PFBlockElement::HCAL );
+      assert(type == PFBlockElement::HCAL);
 
       // all hcal clusters except the closest
       // will be unlinked from the track
-      if( !hcalFound ) { // closest hcal
-        if(debug_)
-          cout<<"\t\tclosest hcal cluster, doing nothing"<<endl;
+      if (!hcalFound) {  // closest hcal
+        if (debug_)
+          cout << "\t\tclosest hcal cluster, doing nothing" << endl;
 
         hcalFound = true;
 
         // active[index] = false;
         // hcalUsed.push_back( index );
-      }
-      else { // other associated hcal
+      } else {  // other associated hcal
         // unlink from the track
-        if(debug_)
-          cout<<"\t\tsecondary hcal cluster. unlinking"<<endl;
-        block.setLink( iTrack, index, -1., linkData,
-                       PFBlock::LINKTEST_RECHIT );
+        if (debug_)
+          cout << "\t\tsecondary hcal cluster. unlinking" << endl;
+        block.setLink(iTrack, index, -1., linkData, PFBlock::LINKTEST_RECHIT);
       }
-    } //loop hcal elements
-  } // end of loop 1 on elements iEle of any type
+    }  //loop hcal elements
+  }    // end of loop 1 on elements iEle of any type
 }
 
-int PFAlgo::decideType(const edm::OwnVector<reco::PFBlockElement> &elements,
-  const reco::PFBlockElement::Type type, std::vector<bool>& active,
-  ElementIndices& inds, std::vector<bool> &deadArea, unsigned int iEle) {
-  switch( type ) {
-  case PFBlockElement::TRACK:
-    if ( active[iEle] ) {
-      inds.trackIs.push_back( iEle );
-      if(debug_) cout<<"TRACK, stored index, continue"<<endl;
-    }
-    break;
-  case PFBlockElement::ECAL:
-    if ( active[iEle]  ) {
-      inds.ecalIs.push_back( iEle );
-      if(debug_) cout<<"ECAL, stored index, continue"<<endl;
-    }
-    return 1; //continue
-  case PFBlockElement::HCAL:
-    if ( active[iEle] ) {
-      if (elements[iEle].clusterRef()->flags() & reco::CaloCluster::badHcalMarker) {
-        if(debug_) cout<<"HCAL DEAD AREA: remember and skip."<<endl;
-        active[iEle] = false;
-        deadArea[iEle] = true;
-        return 1; //continue
+int PFAlgo::decideType(const edm::OwnVector<reco::PFBlockElement>& elements,
+                       const reco::PFBlockElement::Type type,
+                       std::vector<bool>& active,
+                       ElementIndices& inds,
+                       std::vector<bool>& deadArea,
+                       unsigned int iEle) {
+  switch (type) {
+    case PFBlockElement::TRACK:
+      if (active[iEle]) {
+        inds.trackIs.push_back(iEle);
+        if (debug_)
+          cout << "TRACK, stored index, continue" << endl;
       }
-      inds.hcalIs.push_back( iEle );
-      if(debug_) cout<<"HCAL, stored index, continue"<<endl;
-    }
-    return 1; //continue
-  case PFBlockElement::HO:
-    if (useHO_) {
-      if ( active[iEle] ) {
-        inds.hoIs.push_back( iEle );
-        if(debug_) cout<<"HO, stored index, continue"<<endl;
+      break;
+    case PFBlockElement::ECAL:
+      if (active[iEle]) {
+        inds.ecalIs.push_back(iEle);
+        if (debug_)
+          cout << "ECAL, stored index, continue" << endl;
       }
-    }
-    return 1; //continue
-  case PFBlockElement::HFEM:
-    if ( active[iEle] ) {
-      inds.hfEmIs.push_back( iEle );
-      if(debug_) cout<<"HFEM, stored index, continue"<<endl;
-    }
-    return 1; //continue
-  case PFBlockElement::HFHAD:
-    if ( active[iEle] ) {
-      inds.hfHadIs.push_back( iEle );
-      if(debug_) cout<<"HFHAD, stored index, continue"<<endl;
-    }
-    return 1; //continue
-  default:
-    return 1; //continue
+      return 1;  //continue
+    case PFBlockElement::HCAL:
+      if (active[iEle]) {
+        if (elements[iEle].clusterRef()->flags() & reco::CaloCluster::badHcalMarker) {
+          if (debug_)
+            cout << "HCAL DEAD AREA: remember and skip." << endl;
+          active[iEle] = false;
+          deadArea[iEle] = true;
+          return 1;  //continue
+        }
+        inds.hcalIs.push_back(iEle);
+        if (debug_)
+          cout << "HCAL, stored index, continue" << endl;
+      }
+      return 1;  //continue
+    case PFBlockElement::HO:
+      if (useHO_) {
+        if (active[iEle]) {
+          inds.hoIs.push_back(iEle);
+          if (debug_)
+            cout << "HO, stored index, continue" << endl;
+        }
+      }
+      return 1;  //continue
+    case PFBlockElement::HFEM:
+      if (active[iEle]) {
+        inds.hfEmIs.push_back(iEle);
+        if (debug_)
+          cout << "HFEM, stored index, continue" << endl;
+      }
+      return 1;  //continue
+    case PFBlockElement::HFHAD:
+      if (active[iEle]) {
+        inds.hfHadIs.push_back(iEle);
+        if (debug_)
+          cout << "HFHAD, stored index, continue" << endl;
+      }
+      return 1;  //continue
+    default:
+      return 1;  //continue
   }
   return 0;
 }
 
-void PFAlgo::createCandidateHF(const reco::PFBlock &block, const reco::PFBlockRef &blockref, const edm::OwnVector<reco::PFBlockElement> &elements, ElementIndices& inds) {
-    // there is at least one HF element in this block.
-    // so all elements must be HF.
-    assert( inds.hfEmIs.size() + inds.hfHadIs.size() == elements.size() );
+void PFAlgo::createCandidateHF(const reco::PFBlock& block,
+                               const reco::PFBlockRef& blockref,
+                               const edm::OwnVector<reco::PFBlockElement>& elements,
+                               ElementIndices& inds) {
+  // there is at least one HF element in this block.
+  // so all elements must be HF.
+  assert(inds.hfEmIs.size() + inds.hfHadIs.size() == elements.size());
 
-    if( elements.size() == 1 ) {
-      //Auguste: HAD-only calibration here
-      reco::PFClusterRef clusterRef = elements[0].clusterRef();
-      double energyHF = 0.;
-      double uncalibratedenergyHF = 0.;
-      unsigned tmpi = 0;
-      switch( clusterRef->layer() ) {
+  if (elements.size() == 1) {
+    //Auguste: HAD-only calibration here
+    reco::PFClusterRef clusterRef = elements[0].clusterRef();
+    double energyHF = 0.;
+    double uncalibratedenergyHF = 0.;
+    unsigned tmpi = 0;
+    switch (clusterRef->layer()) {
       case PFLayer::HF_EM:
-	// do EM-only calibration here
-	energyHF = clusterRef->energy();
-	uncalibratedenergyHF = energyHF;
-	if(thepfEnergyCalibrationHF_.getcalibHF_use()==true){
-	  energyHF = thepfEnergyCalibrationHF_.energyEm(uncalibratedenergyHF,
-							 clusterRef->positionREP().Eta(),
-							 clusterRef->positionREP().Phi());
-	}
-	tmpi = reconstructCluster( *clusterRef, energyHF );
-	(*pfCandidates_)[tmpi].setEcalEnergy( uncalibratedenergyHF, energyHF );
-	(*pfCandidates_)[tmpi].setHcalEnergy( 0., 0.);
-	(*pfCandidates_)[tmpi].setHoEnergy( 0., 0.);
-	(*pfCandidates_)[tmpi].setPs1Energy( 0. );
-	(*pfCandidates_)[tmpi].setPs2Energy( 0. );
-	(*pfCandidates_)[tmpi].addElementInBlock( blockref, inds.hfEmIs[0] );
-	//std::cout << "HF EM alone ! " << energyHF << std::endl;
-	break;
+        // do EM-only calibration here
+        energyHF = clusterRef->energy();
+        uncalibratedenergyHF = energyHF;
+        if (thepfEnergyCalibrationHF_.getcalibHF_use() == true) {
+          energyHF = thepfEnergyCalibrationHF_.energyEm(
+              uncalibratedenergyHF, clusterRef->positionREP().Eta(), clusterRef->positionREP().Phi());
+        }
+        tmpi = reconstructCluster(*clusterRef, energyHF);
+        (*pfCandidates_)[tmpi].setEcalEnergy(uncalibratedenergyHF, energyHF);
+        (*pfCandidates_)[tmpi].setHcalEnergy(0., 0.);
+        (*pfCandidates_)[tmpi].setHoEnergy(0., 0.);
+        (*pfCandidates_)[tmpi].setPs1Energy(0.);
+        (*pfCandidates_)[tmpi].setPs2Energy(0.);
+        (*pfCandidates_)[tmpi].addElementInBlock(blockref, inds.hfEmIs[0]);
+        //std::cout << "HF EM alone ! " << energyHF << std::endl;
+        break;
       case PFLayer::HF_HAD:
-	// do HAD-only calibration here
-	energyHF = clusterRef->energy();
-	uncalibratedenergyHF = energyHF;
-	if(thepfEnergyCalibrationHF_.getcalibHF_use()==true){
-	  energyHF = thepfEnergyCalibrationHF_.energyHad(uncalibratedenergyHF,
-							 clusterRef->positionREP().Eta(),
-							 clusterRef->positionREP().Phi());
-	}
-	tmpi = reconstructCluster( *clusterRef, energyHF );
-	(*pfCandidates_)[tmpi].setHcalEnergy( uncalibratedenergyHF, energyHF );
-	(*pfCandidates_)[tmpi].setEcalEnergy( 0., 0.);
-	(*pfCandidates_)[tmpi].setHoEnergy( 0., 0.);
-	(*pfCandidates_)[tmpi].setPs1Energy( 0. );
-	(*pfCandidates_)[tmpi].setPs2Energy( 0. );
-	(*pfCandidates_)[tmpi].addElementInBlock( blockref, inds.hfHadIs[0] );
-	//std::cout << "HF Had alone ! " << energyHF << std::endl;
-	break;
+        // do HAD-only calibration here
+        energyHF = clusterRef->energy();
+        uncalibratedenergyHF = energyHF;
+        if (thepfEnergyCalibrationHF_.getcalibHF_use() == true) {
+          energyHF = thepfEnergyCalibrationHF_.energyHad(
+              uncalibratedenergyHF, clusterRef->positionREP().Eta(), clusterRef->positionREP().Phi());
+        }
+        tmpi = reconstructCluster(*clusterRef, energyHF);
+        (*pfCandidates_)[tmpi].setHcalEnergy(uncalibratedenergyHF, energyHF);
+        (*pfCandidates_)[tmpi].setEcalEnergy(0., 0.);
+        (*pfCandidates_)[tmpi].setHoEnergy(0., 0.);
+        (*pfCandidates_)[tmpi].setPs1Energy(0.);
+        (*pfCandidates_)[tmpi].setPs2Energy(0.);
+        (*pfCandidates_)[tmpi].addElementInBlock(blockref, inds.hfHadIs[0]);
+        //std::cout << "HF Had alone ! " << energyHF << std::endl;
+        break;
       default:
-	assert(0);
-      }
+        assert(0);
     }
-    else if(  elements.size() == 2 ) {
-      //Auguste: EM + HAD calibration here
-      reco::PFClusterRef c0 = elements[0].clusterRef();
-      reco::PFClusterRef c1 = elements[1].clusterRef();
-      // 2 HF elements. Must be in each layer.
-      reco::PFClusterRef cem =  ( c0->layer() == PFLayer::HF_EM ? c0 : c1 );
-      reco::PFClusterRef chad = ( c1->layer() == PFLayer::HF_HAD ? c1 : c0 );
+  } else if (elements.size() == 2) {
+    //Auguste: EM + HAD calibration here
+    reco::PFClusterRef c0 = elements[0].clusterRef();
+    reco::PFClusterRef c1 = elements[1].clusterRef();
+    // 2 HF elements. Must be in each layer.
+    reco::PFClusterRef cem = (c0->layer() == PFLayer::HF_EM ? c0 : c1);
+    reco::PFClusterRef chad = (c1->layer() == PFLayer::HF_HAD ? c1 : c0);
 
-      if( cem->layer() != PFLayer::HF_EM || chad->layer() != PFLayer::HF_HAD ) {
-	cerr<<"Error: 2 elements, but not 1 HFEM and 1 HFHAD"<<endl;
-	cerr<<block<<endl;
-	assert(0);
-// 	assert( c1->layer()== PFLayer::HF_EM &&
-// 		c0->layer()== PFLayer::HF_HAD );
-      }
-      // do EM+HAD calibration here
-      double energyHfEm = cem->energy();
-      double energyHfHad = chad->energy();
-      double uncalibratedenergyHFEm = energyHfEm;
-      double uncalibratedenergyHFHad = energyHfHad;
-      if(thepfEnergyCalibrationHF_.getcalibHF_use()==true){
-
-	energyHfEm = thepfEnergyCalibrationHF_.energyEmHad(uncalibratedenergyHFEm,
-							    0.0,
-							    c0->positionREP().Eta(),
-							    c0->positionREP().Phi());
-	energyHfHad = thepfEnergyCalibrationHF_.energyEmHad(0.0,
-							     uncalibratedenergyHFHad,
-							     c1->positionREP().Eta(),
-							     c1->positionREP().Phi());
-      }
-      auto& cand = (*pfCandidates_)[reconstructCluster( *chad, energyHfEm+energyHfHad )];
-      cand.setEcalEnergy( uncalibratedenergyHFEm, energyHfEm );
-      cand.setHcalEnergy( uncalibratedenergyHFHad, energyHfHad);
-      cand.setHoEnergy( 0., 0.);
-      cand.setPs1Energy( 0. );
-      cand.setPs2Energy( 0. );
-      cand.addElementInBlock( blockref, inds.hfEmIs[0] );
-      cand.addElementInBlock( blockref, inds.hfHadIs[0] );
-      //std::cout << "HF EM+HAD found ! " << energyHfEm << " " << energyHfHad << std::endl;
+    if (cem->layer() != PFLayer::HF_EM || chad->layer() != PFLayer::HF_HAD) {
+      cerr << "Error: 2 elements, but not 1 HFEM and 1 HFHAD" << endl;
+      cerr << block << endl;
+      assert(0);
+      // 	assert( c1->layer()== PFLayer::HF_EM &&
+      // 		c0->layer()== PFLayer::HF_HAD );
     }
-    else {
-      // 1 HF element in the block,
-      // but number of elements not equal to 1 or 2
-      cerr<<"Warning: HF, but n elem different from 1 or 2"<<endl;
-      cerr<<block<<endl;
-//       assert(0);
-//       cerr<<"not ready for navigation in the HF!"<<endl;
+    // do EM+HAD calibration here
+    double energyHfEm = cem->energy();
+    double energyHfHad = chad->energy();
+    double uncalibratedenergyHFEm = energyHfEm;
+    double uncalibratedenergyHFHad = energyHfHad;
+    if (thepfEnergyCalibrationHF_.getcalibHF_use() == true) {
+      energyHfEm = thepfEnergyCalibrationHF_.energyEmHad(
+          uncalibratedenergyHFEm, 0.0, c0->positionREP().Eta(), c0->positionREP().Phi());
+      energyHfHad = thepfEnergyCalibrationHF_.energyEmHad(
+          0.0, uncalibratedenergyHFHad, c1->positionREP().Eta(), c1->positionREP().Phi());
     }
+    auto& cand = (*pfCandidates_)[reconstructCluster(*chad, energyHfEm + energyHfHad)];
+    cand.setEcalEnergy(uncalibratedenergyHFEm, energyHfEm);
+    cand.setHcalEnergy(uncalibratedenergyHFHad, energyHfHad);
+    cand.setHoEnergy(0., 0.);
+    cand.setPs1Energy(0.);
+    cand.setPs2Energy(0.);
+    cand.addElementInBlock(blockref, inds.hfEmIs[0]);
+    cand.addElementInBlock(blockref, inds.hfHadIs[0]);
+    //std::cout << "HF EM+HAD found ! " << energyHfEm << " " << energyHfHad << std::endl;
+  } else {
+    // 1 HF element in the block,
+    // but number of elements not equal to 1 or 2
+    cerr << "Warning: HF, but n elem different from 1 or 2" << endl;
+    cerr << block << endl;
+    //       assert(0);
+    //       cerr<<"not ready for navigation in the HF!"<<endl;
+  }
 }
-  
-void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea) {
-  if(debug_) {
-    cout<<endl;
-    cout<<endl<<"--------------- loop hcal ---------------------"<<endl;
+
+void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
+                                  reco::PFBlock::LinkData& linkData,
+                                  const edm::OwnVector<reco::PFBlockElement>& elements,
+                                  std::vector<bool>& active,
+                                  const reco::PFBlockRef& blockref,
+                                  ElementIndices& inds,
+                                  std::vector<bool>& deadArea) {
+  if (debug_) {
+    cout << endl;
+    cout << endl << "--------------- loop hcal ---------------------" << endl;
   }
 
   // track information:
@@ -1359,39 +1340,37 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
   // hcal energy
   // rescale
 
-  for(unsigned iHcal : inds.hcalIs) {
+  for (unsigned iHcal : inds.hcalIs) {
     PFBlockElement::Type type = elements[iHcal].type();
 
-    assert( type == PFBlockElement::HCAL );
+    assert(type == PFBlockElement::HCAL);
 
-    if(debug_) cout<<endl<<elements[iHcal]<<endl;
+    if (debug_)
+      cout << endl << elements[iHcal] << endl;
 
     // vector<unsigned> elementIndices;
     // elementIndices.push_back(iHcal);
 
     // associated tracks
     std::multimap<double, unsigned> sortedTracks;
-    block.associatedElements( iHcal,  linkData,
-			      sortedTracks,
-			      reco::PFBlockElement::TRACK,
-			      reco::PFBlock::LINKTEST_ALL );
+    block.associatedElements(iHcal, linkData, sortedTracks, reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL);
 
-    std::multimap< unsigned, std::pair<double, unsigned> > associatedEcals;
+    std::multimap<unsigned, std::pair<double, unsigned>> associatedEcals;
 
-    std::map< unsigned, std::pair<double, double> > associatedPSs;
+    std::map<unsigned, std::pair<double, double>> associatedPSs;
 
-    std::multimap<double, std::pair<unsigned,bool> > associatedTracks;
+    std::multimap<double, std::pair<unsigned, bool>> associatedTracks;
 
     // A temporary maps for ECAL satellite clusters
-    std::multimap<double,std::tuple<unsigned,::math::XYZVector,double> > ecalSatellites; // last element (double) : correction under the egamma hypothesis
-    std::tuple<unsigned,::math::XYZVector,double> fakeSatellite(iHcal,::math::XYZVector(0.,0.,0.),1.);
+    std::multimap<double, std::tuple<unsigned, ::math::XYZVector, double>>
+        ecalSatellites;  // last element (double) : correction under the egamma hypothesis
+    std::tuple<unsigned, ::math::XYZVector, double> fakeSatellite(iHcal, ::math::XYZVector(0., 0., 0.), 1.);
     ecalSatellites.emplace(-1., fakeSatellite);
 
-    std::multimap< unsigned, std::pair<double, unsigned> > associatedHOs;
+    std::multimap<unsigned, std::pair<double, unsigned>> associatedHOs;
 
     PFClusterRef hclusterref = elements[iHcal].clusterRef();
-    assert(!hclusterref.isNull() );
-
+    assert(!hclusterref.isNull());
 
     //if there is no track attached to that HCAL, then do not
     //reconstruct an HCAL alone, check if it can be recovered
@@ -1400,22 +1379,22 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
     // if no associated tracks, create a neutral hadron
     //if(sortedTracks.empty() ) {
 
-    if( sortedTracks.empty() ) {
-      if(debug_)
-        cout<<"\tno associated tracks, keep for later"<<endl;
+    if (sortedTracks.empty()) {
+      if (debug_)
+        cout << "\tno associated tracks, keep for later" << endl;
       continue;
     }
 
     // Lock the HCAL cluster
     active[iHcal] = false;
 
-
     // in the following, tracks are associated to this hcal cluster.
     // will look for an excess of energy in the calorimeters w/r to
     // the charged energy, and turn this excess into a neutral hadron or
     // a photon.
 
-    if(debug_) cout<<"\t"<<sortedTracks.size()<<" associated tracks:"<<endl;
+    if (debug_)
+      cout << "\t" << sortedTracks.size() << " associated tracks:" << endl;
 
     double totalChargedMomentum = 0;
     double sumpError2 = 0.;
@@ -1429,8 +1408,8 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
     double maxDPovP = -9999.;
 
     //Keep track of how much energy is assigned to calorimeter-vs-track energy/momentum excess
-    vector< unsigned > chargedHadronsIndices;
-    vector< unsigned > chargedHadronsInBlock;
+    vector<unsigned> chargedHadronsIndices;
+    vector<unsigned> chargedHadronsInBlock;
     double mergedNeutralHadronEnergy = 0;
     double mergedPhotonEnergy = 0;
     double muonHCALEnergy = 0.;
@@ -1439,186 +1418,182 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
     double muonECALError = 0.;
     unsigned nMuons = 0;
 
-
-    ::math::XYZVector photonAtECAL(0.,0.,0.);
-    std::vector<std::tuple<unsigned,::math::XYZVector,double> > ecalClusters; // last element (double) : correction under the egamma hypothesis
-    double sumEcalClusters=0;
-    ::math::XYZVector hadronDirection(hclusterref->position().X(),
-				    hclusterref->position().Y(),
-				    hclusterref->position().Z());
+    ::math::XYZVector photonAtECAL(0., 0., 0.);
+    std::vector<std::tuple<unsigned, ::math::XYZVector, double>>
+        ecalClusters;  // last element (double) : correction under the egamma hypothesis
+    double sumEcalClusters = 0;
+    ::math::XYZVector hadronDirection(
+        hclusterref->position().X(), hclusterref->position().Y(), hclusterref->position().Z());
     hadronDirection = hadronDirection.Unit();
     ::math::XYZVector hadronAtECAL = totalHcal * hadronDirection;
 
     // Loop over all tracks associated to this HCAL cluster
-    for(auto const& trk : sortedTracks) {
-
+    for (auto const& trk : sortedTracks) {
       unsigned iTrack = trk.second;
 
       // Check the track has not already been used (e.g., in electrons, conversions...)
-      if ( !active[iTrack] ) continue;
+      if (!active[iTrack])
+        continue;
       // Sanity check 1
       PFBlockElement::Type type = elements[iTrack].type();
-      assert( type == reco::PFBlockElement::TRACK );
+      assert(type == reco::PFBlockElement::TRACK);
       // Sanity check 2
       reco::TrackRef trackRef = elements[iTrack].trackRef();
-      assert( !trackRef.isNull() );
+      assert(!trackRef.isNull());
 
       // The direction at ECAL entrance
       const ::math::XYZPointF& chargedPosition =
-	dynamic_cast<const reco::PFBlockElementTrack*>(&elements[iTrack])->positionAtECALEntrance();
-      ::math::XYZVector chargedDirection(chargedPosition.X(),chargedPosition.Y(),chargedPosition.Z());
+          dynamic_cast<const reco::PFBlockElementTrack*>(&elements[iTrack])->positionAtECALEntrance();
+      ::math::XYZVector chargedDirection(chargedPosition.X(), chargedPosition.Y(), chargedPosition.Z());
       chargedDirection = chargedDirection.Unit();
 
       // look for ECAL elements associated to iTrack (associated to iHcal)
       std::multimap<double, unsigned> sortedEcals;
-      block.associatedElements( iTrack,  linkData,
-                                sortedEcals,
-				reco::PFBlockElement::ECAL,
-				reco::PFBlock::LINKTEST_ALL );
+      block.associatedElements(iTrack, linkData, sortedEcals, reco::PFBlockElement::ECAL, reco::PFBlock::LINKTEST_ALL);
 
-      if(debug_) cout<<"\t\t\tnumber of Ecal elements linked to this track: "
-                     <<sortedEcals.size()<<endl;
+      if (debug_)
+        cout << "\t\t\tnumber of Ecal elements linked to this track: " << sortedEcals.size() << endl;
 
       // look for HO elements associated to iTrack (associated to iHcal)
       std::multimap<double, unsigned> sortedHOs;
       if (useHO_) {
-	block.associatedElements( iTrack,  linkData,
-				  sortedHOs,
-				  reco::PFBlockElement::HO,
-				  reco::PFBlock::LINKTEST_ALL );
-
+        block.associatedElements(iTrack, linkData, sortedHOs, reco::PFBlockElement::HO, reco::PFBlock::LINKTEST_ALL);
       }
-      if(debug_)
-	cout<<"PFAlgo : number of HO elements linked to this track: "
-	    <<sortedHOs.size()<<endl;
+      if (debug_)
+        cout << "PFAlgo : number of HO elements linked to this track: " << sortedHOs.size() << endl;
 
       // Create a PF Candidate right away if the track is a tight muon
       reco::MuonRef muonRef = elements[iTrack].muonRef();
-
 
       bool thisIsAMuon = PFMuonAlgo::isMuon(elements[iTrack]);
       bool thisIsAnIsolatedMuon = PFMuonAlgo::isIsolatedMuon(elements[iTrack]);
       bool thisIsALooseMuon = false;
 
-
-      if(!thisIsAMuon ) {
-	thisIsALooseMuon = PFMuonAlgo::isLooseMuon(elements[iTrack]);
+      if (!thisIsAMuon) {
+        thisIsALooseMuon = PFMuonAlgo::isLooseMuon(elements[iTrack]);
       }
 
+      if (thisIsAMuon) {
+        if (debug_) {
+          std::cout << "\t\tThis track is identified as a muon - remove it from the stack" << std::endl;
+          std::cout << "\t\t" << elements[iTrack] << std::endl;
+        }
 
-      if ( thisIsAMuon ) {
-	if ( debug_ ) {
-	  std::cout << "\t\tThis track is identified as a muon - remove it from the stack" << std::endl;
-	  std::cout << "\t\t" << elements[iTrack] << std::endl;
-	}
+        // Create a muon.
 
-	// Create a muon.
+        unsigned tmpi = reconstructTrack(elements[iTrack]);
 
-	unsigned tmpi = reconstructTrack( elements[iTrack] );
+        (*pfCandidates_)[tmpi].addElementInBlock(blockref, iTrack);
+        (*pfCandidates_)[tmpi].addElementInBlock(blockref, iHcal);
+        double muonHcal = std::min(muonHCAL_[0] + muonHCAL_[1], totalHcal);
 
+        // if muon is isolated and muon momentum exceeds the calo energy, absorb the calo energy
+        // rationale : there has been a EM showering by the muon in the calorimeter - or the coil -
+        // and we don't want to double count the energy
+        bool letMuonEatCaloEnergy = false;
 
-	(*pfCandidates_)[tmpi].addElementInBlock( blockref, iTrack );
-	(*pfCandidates_)[tmpi].addElementInBlock( blockref, iHcal );
-	double muonHcal = std::min(muonHCAL_[0]+muonHCAL_[1],totalHcal);
+        if (thisIsAnIsolatedMuon) {
+          // The factor 1.3 is the e/pi factor in HCAL...
+          double totalCaloEnergy = totalHcal / 1.30;
+          unsigned iEcal = 0;
+          if (!sortedEcals.empty()) {
+            iEcal = sortedEcals.begin()->second;
+            PFClusterRef eclusterref = elements[iEcal].clusterRef();
+            totalCaloEnergy += eclusterref->energy();
+          }
 
-	// if muon is isolated and muon momentum exceeds the calo energy, absorb the calo energy
-	// rationale : there has been a EM showering by the muon in the calorimeter - or the coil -
-	// and we don't want to double count the energy
-	bool letMuonEatCaloEnergy = false;
+          if (useHO_) {
+            // The factor 1.3 is assumed to be the e/pi factor in HO, too.
+            unsigned iHO = 0;
+            if (!sortedHOs.empty()) {
+              iHO = sortedHOs.begin()->second;
+              PFClusterRef eclusterref = elements[iHO].clusterRef();
+              totalCaloEnergy += eclusterref->energy() / 1.30;
+            }
+          }
 
-	if(thisIsAnIsolatedMuon){
-	  // The factor 1.3 is the e/pi factor in HCAL...
-	  double totalCaloEnergy = totalHcal / 1.30;
-	  unsigned iEcal = 0;
-	  if( !sortedEcals.empty() ) {
-	    iEcal = sortedEcals.begin()->second;
-	    PFClusterRef eclusterref = elements[iEcal].clusterRef();
-	    totalCaloEnergy += eclusterref->energy();
-	  }
+          // std::cout << "muon p / total calo = " << muonRef->p() << " "  << (pfCandidates_->back()).p() << " " << totalCaloEnergy << std::endl;
+          //if(muonRef->p() > totalCaloEnergy ) letMuonEatCaloEnergy = true;
+          if ((pfCandidates_->back()).p() > totalCaloEnergy)
+            letMuonEatCaloEnergy = true;
+        }
 
-	  if (useHO_) {
-	    // The factor 1.3 is assumed to be the e/pi factor in HO, too.
-	    unsigned iHO = 0;
-	    if( !sortedHOs.empty() ) {
-	      iHO = sortedHOs.begin()->second;
-	      PFClusterRef eclusterref = elements[iHO].clusterRef();
-	      totalCaloEnergy += eclusterref->energy() / 1.30;
-	    }
-	  }
-
-	  // std::cout << "muon p / total calo = " << muonRef->p() << " "  << (pfCandidates_->back()).p() << " " << totalCaloEnergy << std::endl;
-	  //if(muonRef->p() > totalCaloEnergy ) letMuonEatCaloEnergy = true;
-	  if( (pfCandidates_->back()).p() > totalCaloEnergy ) letMuonEatCaloEnergy = true;
-	}
-
-	if(letMuonEatCaloEnergy) muonHcal = totalHcal;
-	double muonEcal =0.;
-	unsigned iEcal = 0;
-	if( !sortedEcals.empty() ) {
-	  iEcal = sortedEcals.begin()->second;
-	  PFClusterRef eclusterref = elements[iEcal].clusterRef();
-	  (*pfCandidates_)[tmpi].addElementInBlock( blockref, iEcal);
-	  muonEcal = std::min(muonECAL_[0]+muonECAL_[1],eclusterref->energy());
-	  if(letMuonEatCaloEnergy) muonEcal = eclusterref->energy();
-	  // If the muon expected energy accounts for the whole ecal cluster energy, lock the ecal cluster
-	  if ( eclusterref->energy() - muonEcal  < 0.2 ) active[iEcal] = false;
-	  (*pfCandidates_)[tmpi].setEcalEnergy(eclusterref->energy(), muonEcal);
-	}
-	unsigned iHO = 0;
-	double muonHO =0.;
-	if (useHO_) {
-	  if( !sortedHOs.empty() ) {
-	    iHO = sortedHOs.begin()->second;
-	    PFClusterRef hoclusterref = elements[iHO].clusterRef();
-	    (*pfCandidates_)[tmpi].addElementInBlock( blockref, iHO);
-	    muonHO = std::min(muonHO_[0]+muonHO_[1],hoclusterref->energy());
-	    if(letMuonEatCaloEnergy) muonHO = hoclusterref->energy();
-	    // If the muon expected energy accounts for the whole HO cluster energy, lock the HO cluster
-	    if ( hoclusterref->energy() - muonHO  < 0.2 ) active[iHO] = false;
-	    (*pfCandidates_)[tmpi].setHcalEnergy(totalHcal, muonHcal);
-	    (*pfCandidates_)[tmpi].setHoEnergy(hoclusterref->energy(), muonHO);
-	  }
-	} else {
-	  (*pfCandidates_)[tmpi].setHcalEnergy(totalHcal, muonHcal);
-	}
+        if (letMuonEatCaloEnergy)
+          muonHcal = totalHcal;
+        double muonEcal = 0.;
+        unsigned iEcal = 0;
+        if (!sortedEcals.empty()) {
+          iEcal = sortedEcals.begin()->second;
+          PFClusterRef eclusterref = elements[iEcal].clusterRef();
+          (*pfCandidates_)[tmpi].addElementInBlock(blockref, iEcal);
+          muonEcal = std::min(muonECAL_[0] + muonECAL_[1], eclusterref->energy());
+          if (letMuonEatCaloEnergy)
+            muonEcal = eclusterref->energy();
+          // If the muon expected energy accounts for the whole ecal cluster energy, lock the ecal cluster
+          if (eclusterref->energy() - muonEcal < 0.2)
+            active[iEcal] = false;
+          (*pfCandidates_)[tmpi].setEcalEnergy(eclusterref->energy(), muonEcal);
+        }
+        unsigned iHO = 0;
+        double muonHO = 0.;
+        if (useHO_) {
+          if (!sortedHOs.empty()) {
+            iHO = sortedHOs.begin()->second;
+            PFClusterRef hoclusterref = elements[iHO].clusterRef();
+            (*pfCandidates_)[tmpi].addElementInBlock(blockref, iHO);
+            muonHO = std::min(muonHO_[0] + muonHO_[1], hoclusterref->energy());
+            if (letMuonEatCaloEnergy)
+              muonHO = hoclusterref->energy();
+            // If the muon expected energy accounts for the whole HO cluster energy, lock the HO cluster
+            if (hoclusterref->energy() - muonHO < 0.2)
+              active[iHO] = false;
+            (*pfCandidates_)[tmpi].setHcalEnergy(totalHcal, muonHcal);
+            (*pfCandidates_)[tmpi].setHoEnergy(hoclusterref->energy(), muonHO);
+          }
+        } else {
+          (*pfCandidates_)[tmpi].setHcalEnergy(totalHcal, muonHcal);
+        }
         setHcalDepthInfo((*pfCandidates_)[tmpi], *hclusterref);
 
-	if(letMuonEatCaloEnergy){
-	  muonHCALEnergy += totalHcal;
-	  if (useHO_) muonHCALEnergy +=muonHO;
-	  muonHCALError += 0.;
-	  muonECALEnergy += muonEcal;
-	  muonECALError += 0.;
-	  photonAtECAL -= muonEcal*chargedDirection;
-	  hadronAtECAL -= totalHcal*chargedDirection;
-	  if ( !sortedEcals.empty() ) active[iEcal] = false;
-	  active[iHcal] = false;
-	  if (useHO_ && !sortedHOs.empty() ) active[iHO] = false;
-	}
-	else{
-	// Estimate of the energy deposit & resolution in the calorimeters
-	  muonHCALEnergy += muonHCAL_[0];
-	  muonHCALError += muonHCAL_[1]*muonHCAL_[1];
-	  if ( muonHO > 0. ) {
-	    muonHCALEnergy += muonHO_[0];
-	    muonHCALError += muonHO_[1]*muonHO_[1];
-	  }
-	  muonECALEnergy += muonECAL_[0];
-	  muonECALError += muonECAL_[1]*muonECAL_[1];
-	  // ... as well as the equivalent "momentum" at ECAL entrance
-	  photonAtECAL -= muonECAL_[0]*chargedDirection;
-	  hadronAtECAL -= muonHCAL_[0]*chargedDirection;
-	}
+        if (letMuonEatCaloEnergy) {
+          muonHCALEnergy += totalHcal;
+          if (useHO_)
+            muonHCALEnergy += muonHO;
+          muonHCALError += 0.;
+          muonECALEnergy += muonEcal;
+          muonECALError += 0.;
+          photonAtECAL -= muonEcal * chargedDirection;
+          hadronAtECAL -= totalHcal * chargedDirection;
+          if (!sortedEcals.empty())
+            active[iEcal] = false;
+          active[iHcal] = false;
+          if (useHO_ && !sortedHOs.empty())
+            active[iHO] = false;
+        } else {
+          // Estimate of the energy deposit & resolution in the calorimeters
+          muonHCALEnergy += muonHCAL_[0];
+          muonHCALError += muonHCAL_[1] * muonHCAL_[1];
+          if (muonHO > 0.) {
+            muonHCALEnergy += muonHO_[0];
+            muonHCALError += muonHO_[1] * muonHO_[1];
+          }
+          muonECALEnergy += muonECAL_[0];
+          muonECALError += muonECAL_[1] * muonECAL_[1];
+          // ... as well as the equivalent "momentum" at ECAL entrance
+          photonAtECAL -= muonECAL_[0] * chargedDirection;
+          hadronAtECAL -= muonHCAL_[0] * chargedDirection;
+        }
 
-	// Remove it from the stack
-	active[iTrack] = false;
-	// Go to next track
-	continue;
+        // Remove it from the stack
+        active[iTrack] = false;
+        // Go to next track
+        continue;
       }
 
       //
 
-      if(debug_) cout<<"\t\t"<<elements[iTrack]<<endl;
+      if (debug_)
+        cout << "\t\t" << elements[iTrack] << endl;
 
       // introduce  tracking errors
       double trackMomentum = trackRef->p();
@@ -1626,148 +1601,144 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
 
       // If the track is not a tight muon, but still resembles a muon
       // keep it for later for blocks with too large a charged energy
-      if ( thisIsALooseMuon && !thisIsAMuon ) nMuons += 1;
+      if (thisIsALooseMuon && !thisIsAMuon)
+        nMuons += 1;
 
       // ... and keep anyway the pt error for possible fake rejection
       // ... blow up errors of 5th anf 4th iteration, to reject those
       // ... tracks first (in case it's needed)
       double Dpt = trackRef->ptError();
-      double blowError = PFTrackAlgoTools::errorScale(trackRef->algo(),factors45_);
+      double blowError = PFTrackAlgoTools::errorScale(trackRef->algo(), factors45_);
       // except if it is from an interaction
       bool isPrimaryOrSecondary = isFromSecInt(elements[iTrack], "all");
 
-      if ( isPrimaryOrSecondary ) blowError = 1.;
+      if (isPrimaryOrSecondary)
+        blowError = 1.;
 
-      std::pair<unsigned,bool> tkmuon(iTrack,thisIsALooseMuon);
-      associatedTracks.emplace(-Dpt*blowError, tkmuon);
+      std::pair<unsigned, bool> tkmuon(iTrack, thisIsALooseMuon);
+      associatedTracks.emplace(-Dpt * blowError, tkmuon);
 
       // Also keep the total track momentum error for comparison with the calo energy
-      double Dp = trackRef->qoverpError()*trackMomentum*trackMomentum;
-      sumpError2 += Dp*Dp;
+      double Dp = trackRef->qoverpError() * trackMomentum * trackMomentum;
+      sumpError2 += Dp * Dp;
 
-      bool connectedToEcal = false; // Will become true if there is at least one ECAL cluster connected
-      if( !sortedEcals.empty() )
-        { // start case: at least one ecal element associated to iTrack
+      bool connectedToEcal = false;  // Will become true if there is at least one ECAL cluster connected
+      if (!sortedEcals.empty()) {    // start case: at least one ecal element associated to iTrack
 
-	  // Loop over all connected ECAL clusters
-	  for (auto const& ecal : sortedEcals) {
+        // Loop over all connected ECAL clusters
+        for (auto const& ecal : sortedEcals) {
+          unsigned iEcal = ecal.second;
+          double dist = ecal.first;
 
-	    unsigned iEcal = ecal.second;
-	    double dist = ecal.first;
+          // Ignore ECAL cluters already used
+          if (!active[iEcal]) {
+            if (debug_)
+              cout << "\t\tcluster locked" << endl;
+            continue;
+          }
 
-	    // Ignore ECAL cluters already used
-	    if( !active[iEcal] ) {
-	      if(debug_) cout<<"\t\tcluster locked"<<endl;
-	      continue;
-	    }
+          // Sanity checks
+          PFBlockElement::Type type = elements[iEcal].type();
+          assert(type == PFBlockElement::ECAL);
+          PFClusterRef eclusterref = elements[iEcal].clusterRef();
+          assert(!eclusterref.isNull());
 
-	    // Sanity checks
-	    PFBlockElement::Type type = elements[ iEcal ].type();
-	    assert( type == PFBlockElement::ECAL );
-	    PFClusterRef eclusterref = elements[iEcal].clusterRef();
-	    assert(!eclusterref.isNull() );
+          // Check if this ECAL is not closer to another track - ignore it in that case
+          std::multimap<double, unsigned> sortedTracksEcal;
+          block.associatedElements(
+              iEcal, linkData, sortedTracksEcal, reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL);
+          unsigned jTrack = sortedTracksEcal.begin()->second;
+          if (jTrack != iTrack)
+            continue;
 
-	    // Check if this ECAL is not closer to another track - ignore it in that case
-	    std::multimap<double, unsigned> sortedTracksEcal;
-	    block.associatedElements( iEcal,  linkData,
-				      sortedTracksEcal,
-				      reco::PFBlockElement::TRACK,
-				      reco::PFBlock::LINKTEST_ALL );
-	    unsigned jTrack = sortedTracksEcal.begin()->second;
-	    if ( jTrack != iTrack ) continue;
+          // double chi2Ecal = block.chi2(jTrack,iEcal,linkData,
+          //                              reco::PFBlock::LINKTEST_ALL);
+          double distEcal = block.dist(jTrack, iEcal, linkData, reco::PFBlock::LINKTEST_ALL);
 
-	    // double chi2Ecal = block.chi2(jTrack,iEcal,linkData,
-	    //                              reco::PFBlock::LINKTEST_ALL);
-	    double distEcal = block.dist(jTrack,iEcal,linkData,
-					 reco::PFBlock::LINKTEST_ALL);
+          // totalEcal += eclusterref->energy();
+          // float ecalEnergyUnCalibrated = eclusterref->energy();
+          //std::cout << "Ecal Uncalibrated " << ecalEnergyUnCalibrated << std::endl;
 
-	    // totalEcal += eclusterref->energy();
-	    // float ecalEnergyUnCalibrated = eclusterref->energy();
-	    //std::cout << "Ecal Uncalibrated " << ecalEnergyUnCalibrated << std::endl;
+          float ecalEnergyCalibrated = eclusterref->correctedEnergy();  // calibrated based on the egamma hypothesis
+          float ecalEnergy = eclusterref->energy();
+          ::math::XYZVector photonDirection(
+              eclusterref->position().X(), eclusterref->position().Y(), eclusterref->position().Z());
+          photonDirection = photonDirection.Unit();
 
-	    float ecalEnergyCalibrated = eclusterref->correctedEnergy(); // calibrated based on the egamma hypothesis
-	    float ecalEnergy = eclusterref->energy();
-	    ::math::XYZVector photonDirection(eclusterref->position().X(),
-					    eclusterref->position().Y(),
-					    eclusterref->position().Z());
-	    photonDirection = photonDirection.Unit();
+          if (!connectedToEcal) {  // This is the closest ECAL cluster - will add its energy later
 
-	    if ( !connectedToEcal ) { // This is the closest ECAL cluster - will add its energy later
+            if (debug_)
+              cout << "\t\t\tclosest: " << elements[iEcal] << endl;
 
-	      if(debug_) cout<<"\t\t\tclosest: "
-			     <<elements[iEcal]<<endl;
+            connectedToEcal = true;
+            // PJ 1st-April-09 : To be done somewhere !!! (Had to comment it, but it is needed)
+            // currentChargedHadron.addElementInBlock( blockref, iEcal );
 
-	      connectedToEcal = true;
-	      // PJ 1st-April-09 : To be done somewhere !!! (Had to comment it, but it is needed)
-	      // currentChargedHadron.addElementInBlock( blockref, iEcal );
-       
-	      // KH: we don't know if this satellite is due to egamma or hadron shower. use raw energy for PF hadron calibration_. store also calibration constant.
-	      double ecalCalibFactor = (ecalEnergy>1E-9) ? ecalEnergyCalibrated/ecalEnergy : 1.;
-	      std::tuple<unsigned,::math::XYZVector,double> satellite(iEcal,ecalEnergy*photonDirection,ecalCalibFactor);
-	      ecalSatellites.emplace(-1., satellite);
+            // KH: we don't know if this satellite is due to egamma or hadron shower. use raw energy for PF hadron calibration_. store also calibration constant.
+            double ecalCalibFactor = (ecalEnergy > 1E-9) ? ecalEnergyCalibrated / ecalEnergy : 1.;
+            std::tuple<unsigned, ::math::XYZVector, double> satellite(
+                iEcal, ecalEnergy * photonDirection, ecalCalibFactor);
+            ecalSatellites.emplace(-1., satellite);
 
-	    } else { // Keep satellite clusters for later
-	      
-	      // KH: same as above.
-	      double ecalCalibFactor = (ecalEnergy>1E-9) ? ecalEnergyCalibrated/ecalEnergy : 1.;
-	      std::tuple<unsigned,::math::XYZVector,double> satellite(iEcal,ecalEnergy*photonDirection,ecalCalibFactor);
-	      ecalSatellites.emplace(dist, satellite);
-	      
-	    }
+          } else {  // Keep satellite clusters for later
 
-	    std::pair<double, unsigned> associatedEcal( distEcal, iEcal );
-	    associatedEcals.emplace(iTrack, associatedEcal);
+            // KH: same as above.
+            double ecalCalibFactor = (ecalEnergy > 1E-9) ? ecalEnergyCalibrated / ecalEnergy : 1.;
+            std::tuple<unsigned, ::math::XYZVector, double> satellite(
+                iEcal, ecalEnergy * photonDirection, ecalCalibFactor);
+            ecalSatellites.emplace(dist, satellite);
+          }
 
-	  } // End loop ecal associated to iTrack
-	} // end case: at least one ecal element associated to iTrack
+          std::pair<double, unsigned> associatedEcal(distEcal, iEcal);
+          associatedEcals.emplace(iTrack, associatedEcal);
 
-      if( useHO_ && !sortedHOs.empty() )
-        { // start case: at least one ho element associated to iTrack
+        }  // End loop ecal associated to iTrack
+      }    // end case: at least one ecal element associated to iTrack
 
-	  // Loop over all connected HO clusters
-	  for (auto const& ho : sortedHOs) {
+      if (useHO_ && !sortedHOs.empty()) {  // start case: at least one ho element associated to iTrack
 
-	    unsigned iHO = ho.second;
-	    double distHO = ho.first;
+        // Loop over all connected HO clusters
+        for (auto const& ho : sortedHOs) {
+          unsigned iHO = ho.second;
+          double distHO = ho.first;
 
-	    // Ignore HO cluters already used
-	    if( !active[iHO] ) {
-	      if(debug_) cout<<"\t\tcluster locked"<<endl;
-	      continue;
-	    }
+          // Ignore HO cluters already used
+          if (!active[iHO]) {
+            if (debug_)
+              cout << "\t\tcluster locked" << endl;
+            continue;
+          }
 
-	    // Sanity checks
-	    PFBlockElement::Type type = elements[ iHO ].type();
-	    assert( type == PFBlockElement::HO );
-	    PFClusterRef hoclusterref = elements[iHO].clusterRef();
-	    assert(!hoclusterref.isNull() );
+          // Sanity checks
+          PFBlockElement::Type type = elements[iHO].type();
+          assert(type == PFBlockElement::HO);
+          PFClusterRef hoclusterref = elements[iHO].clusterRef();
+          assert(!hoclusterref.isNull());
 
-	    // Check if this HO is not closer to another track - ignore it in that case
-	    std::multimap<double, unsigned> sortedTracksHO;
-	    block.associatedElements( iHO,  linkData,
-				      sortedTracksHO,
-				      reco::PFBlockElement::TRACK,
-				      reco::PFBlock::LINKTEST_ALL );
-	    unsigned jTrack = sortedTracksHO.begin()->second;
-	    if ( jTrack != iTrack ) continue;
+          // Check if this HO is not closer to another track - ignore it in that case
+          std::multimap<double, unsigned> sortedTracksHO;
+          block.associatedElements(
+              iHO, linkData, sortedTracksHO, reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL);
+          unsigned jTrack = sortedTracksHO.begin()->second;
+          if (jTrack != iTrack)
+            continue;
 
-	    // double chi2HO = block.chi2(jTrack,iHO,linkData,
-	    //                              reco::PFBlock::LINKTEST_ALL);
-	    //double distHO = block.dist(jTrack,iHO,linkData,
-	    //		       reco::PFBlock::LINKTEST_ALL);
+          // double chi2HO = block.chi2(jTrack,iHO,linkData,
+          //                              reco::PFBlock::LINKTEST_ALL);
+          //double distHO = block.dist(jTrack,iHO,linkData,
+          //		       reco::PFBlock::LINKTEST_ALL);
 
-	    // Increment the total energy by the energy of this HO cluster
-	    totalHO += hoclusterref->energy();
-	    active[iHO] = false;
-	    // Keep track for later reference in the PFCandidate.
-	    std::pair<double, unsigned> associatedHO( distHO, iHO );
-	    associatedHOs.emplace(iTrack, associatedHO);
+          // Increment the total energy by the energy of this HO cluster
+          totalHO += hoclusterref->energy();
+          active[iHO] = false;
+          // Keep track for later reference in the PFCandidate.
+          std::pair<double, unsigned> associatedHO(distHO, iHO);
+          associatedHOs.emplace(iTrack, associatedHO);
 
-	  } // End loop ho associated to iTrack
-	} // end case: at least one ho element associated to iTrack
+        }  // End loop ho associated to iTrack
+      }    // end case: at least one ho element associated to iTrack
 
-
-    } // end loop on tracks associated to hcal element iHcal
+    }  // end loop on tracks associated to hcal element iHcal
 
     // Include totalHO in totalHCAL for the time being (it will be calibrated as HCAL energy)
     totalHcal += totalHO;
@@ -1781,22 +1752,23 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
     hadronDirection = hadronAtECAL.Unit();
 
     // Determine the expected calo resolution from the total charged momentum
-    double Caloresolution = neutralHadronEnergyResolution( totalChargedMomentum, hclusterref->positionREP().Eta());
+    double Caloresolution = neutralHadronEnergyResolution(totalChargedMomentum, hclusterref->positionREP().Eta());
     Caloresolution *= totalChargedMomentum;
     // Account for muons
-    Caloresolution = std::sqrt(Caloresolution*Caloresolution + muonHCALError + muonECALError);
-    totalEcal -= std::min(totalEcal,muonECALEnergy);
-    totalEcalEGMCalib -= std::min(totalEcalEGMCalib,muonECALEnergy);
-    totalHcal -= std::min(totalHcal,muonHCALEnergy);
-    if ( totalEcal < 1E-9 ) photonAtECAL = ::math::XYZVector(0.,0.,0.);
-    if ( totalHcal < 1E-9 ) hadronAtECAL = ::math::XYZVector(0.,0.,0.);
+    Caloresolution = std::sqrt(Caloresolution * Caloresolution + muonHCALError + muonECALError);
+    totalEcal -= std::min(totalEcal, muonECALEnergy);
+    totalEcalEGMCalib -= std::min(totalEcalEGMCalib, muonECALEnergy);
+    totalHcal -= std::min(totalHcal, muonHCALEnergy);
+    if (totalEcal < 1E-9)
+      photonAtECAL = ::math::XYZVector(0., 0., 0.);
+    if (totalHcal < 1E-9)
+      hadronAtECAL = ::math::XYZVector(0., 0., 0.);
 
     // Loop over all ECAL satellites, starting for the closest to the various tracks
     // and adding other satellites until saturation of the total track momentum
     // Note : for code simplicity, the first element of the loop is the HCAL cluster
     // with 0 energy in the ECAL
-    for(auto const& ecalSatellite : ecalSatellites) {
-
+    for (auto const& ecalSatellite : ecalSatellites) {
       // Add the energy of this ECAL cluster
       double previousCalibEcal = calibEcal;
       double previousCalibHcal = calibHcal;
@@ -1804,31 +1776,40 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
       double previousSlopeEcal = slopeEcal;
       ::math::XYZVector previousHadronAtECAL = hadronAtECAL;
       //
-      totalEcal         += sqrt(std::get<1>(ecalSatellite.second).Mag2()); // KH: raw ECAL energy for input to PF hadron calibration
-      totalEcalEGMCalib += sqrt(std::get<1>(ecalSatellite.second).Mag2())*std::get<2>(ecalSatellite.second); // KH: calibrated ECAL energy under the egamma hypothesis
-      photonAtECAL      += std::get<1>(ecalSatellite.second)*std::get<2>(ecalSatellite.second); // KH: calibrated ECAL energy under the egamma hypothesis
-      calibEcal = std::max(0.,totalEcal); // KH: preparing for hadron calibration
-      calibHcal = std::max(0.,totalHcal);
+      totalEcal +=
+          sqrt(std::get<1>(ecalSatellite.second).Mag2());  // KH: raw ECAL energy for input to PF hadron calibration
+      totalEcalEGMCalib += sqrt(std::get<1>(ecalSatellite.second).Mag2()) *
+                           std::get<2>(ecalSatellite.second);  // KH: calibrated ECAL energy under the egamma hypothesis
+      photonAtECAL += std::get<1>(ecalSatellite.second) *
+                      std::get<2>(ecalSatellite.second);  // KH: calibrated ECAL energy under the egamma hypothesis
+      calibEcal = std::max(0., totalEcal);                // KH: preparing for hadron calibration
+      calibHcal = std::max(0., totalHcal);
       hadronAtECAL = calibHcal * hadronDirection;
       // Calibrate ECAL and HCAL energy under the hadron hypothesis.
-      calibration_.energyEmHad( totalChargedMomentum,calibEcal,calibHcal,
-                                 hclusterref->positionREP().Eta(),
-                                 hclusterref->positionREP().Phi() );
-      caloEnergy = calibEcal+calibHcal;
-      if ( totalEcal > 0.) slopeEcal = calibEcal/totalEcal;
+      calibration_.energyEmHad(totalChargedMomentum,
+                               calibEcal,
+                               calibHcal,
+                               hclusterref->positionREP().Eta(),
+                               hclusterref->positionREP().Phi());
+      caloEnergy = calibEcal + calibHcal;
+      if (totalEcal > 0.)
+        slopeEcal = calibEcal / totalEcal;
 
       hadronAtECAL = calibHcal * hadronDirection;
 
       // Continue looping until all closest clusters are exhausted and as long as
       // the calorimetric energy does not saturate the total momentum.
-      if ( ecalSatellite.first < 0. || caloEnergy - totalChargedMomentum <= 0. ) {
-        if(debug_) cout<<"\t\t\tactive, adding "<<std::get<1>(ecalSatellite.second)
-		       <<" to ECAL energy, and locking"<<endl;
+      if (ecalSatellite.first < 0. || caloEnergy - totalChargedMomentum <= 0.) {
+        if (debug_)
+          cout << "\t\t\tactive, adding " << std::get<1>(ecalSatellite.second) << " to ECAL energy, and locking"
+               << endl;
         active[std::get<0>(ecalSatellite.second)] = false;
-        double clusterEnergy=sqrt(std::get<1>(ecalSatellite.second).Mag2())*std::get<2>(ecalSatellite.second); // KH: ECAL energy calibrated under the egamma hypothesis
-        if(clusterEnergy>50) { // KH: used to split energetic ecal clusters (E>50 GeV)
+        double clusterEnergy =
+            sqrt(std::get<1>(ecalSatellite.second).Mag2()) *
+            std::get<2>(ecalSatellite.second);  // KH: ECAL energy calibrated under the egamma hypothesis
+        if (clusterEnergy > 50) {               // KH: used to split energetic ecal clusters (E>50 GeV)
           ecalClusters.push_back(ecalSatellite.second);
-          sumEcalClusters+=clusterEnergy;
+          sumEcalClusters += clusterEnergy;
         }
         continue;
       }
@@ -1836,8 +1817,8 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
       // Otherwise, do not consider the last cluster examined and exit.
       // active[is->second.first] = true;
       totalEcal -= sqrt(std::get<1>(ecalSatellite.second).Mag2());
-      totalEcalEGMCalib -= sqrt(std::get<1>(ecalSatellite.second).Mag2())*std::get<2>(ecalSatellite.second);
-      photonAtECAL -= std::get<1>(ecalSatellite.second)*std::get<2>(ecalSatellite.second);
+      totalEcalEGMCalib -= sqrt(std::get<1>(ecalSatellite.second).Mag2()) * std::get<2>(ecalSatellite.second);
+      photonAtECAL -= std::get<1>(ecalSatellite.second) * std::get<2>(ecalSatellite.second);
       calibEcal = previousCalibEcal;
       calibHcal = previousCalibHcal;
       hadronAtECAL = previousHadronAtECAL;
@@ -1845,11 +1826,10 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
       caloEnergy = previousCaloEnergy;
 
       break;
-
     }
 
     // Sanity check !
-    assert(caloEnergy>=0);
+    assert(caloEnergy >= 0);
 
     // And now check for hadronic energy excess...
 
@@ -1864,8 +1844,7 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
 
     /* */
     ////////////////////// TRACKER MUCH LARGER THAN CALO /////////////////////////
-    if ( totalChargedMomentum - caloEnergy > nSigmaTRACK_*Caloresolution ) {
-
+    if (totalChargedMomentum - caloEnergy > nSigmaTRACK_ * Caloresolution) {
       /*
       cout<<"\tCompare Calo Energy to total charged momentum "<<endl;
       cout<<"\t\tsum p    = "<<totalChargedMomentum<<" +- "<<sqrt(sumpError2)<<endl;
@@ -1878,76 +1857,76 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
       cout << "\t\tNumber/momentum of muons found in the block : " << nMuons << std::endl;
       */
       // First consider loose muons
-      if ( nMuons > 0 ) {
-        for(auto const& trk : associatedTracks) {
-
+      if (nMuons > 0) {
+        for (auto const& trk : associatedTracks) {
           // Only muons
-          if ( !trk.second.second ) continue;
+          if (!trk.second.second)
+            continue;
 
           const unsigned int iTrack = trk.second.first;
           // Only active tracks
-          if ( !active[iTrack] ) continue;
+          if (!active[iTrack])
+            continue;
 
           const double trackMomentum = elements[trk.second.first].trackRef()->p();
 
           // look for ECAL elements associated to iTrack (associated to iHcal)
           std::multimap<double, unsigned> sortedEcals;
-          block.associatedElements( iTrack,  linkData,
-                                    sortedEcals,
-                                    reco::PFBlockElement::ECAL,
-                                    reco::PFBlock::LINKTEST_ALL );
+          block.associatedElements(
+              iTrack, linkData, sortedEcals, reco::PFBlockElement::ECAL, reco::PFBlock::LINKTEST_ALL);
           std::multimap<double, unsigned> sortedHOs;
-          block.associatedElements( iTrack,  linkData,
-                                    sortedHOs,
-                                    reco::PFBlockElement::HO,
-                                    reco::PFBlock::LINKTEST_ALL );
+          block.associatedElements(iTrack, linkData, sortedHOs, reco::PFBlockElement::HO, reco::PFBlock::LINKTEST_ALL);
 
           //Here allow for loose muons!
-          auto& muon = (*pfCandidates_)[reconstructTrack( elements[iTrack],true)];
+          auto& muon = (*pfCandidates_)[reconstructTrack(elements[iTrack], true)];
 
-          muon.addElementInBlock( blockref, iTrack );
-          muon.addElementInBlock( blockref, iHcal );
-          const double muonHcal = std::min(muonHCAL_[0]+muonHCAL_[1],totalHcal-totalHO);
+          muon.addElementInBlock(blockref, iTrack);
+          muon.addElementInBlock(blockref, iHcal);
+          const double muonHcal = std::min(muonHCAL_[0] + muonHCAL_[1], totalHcal - totalHO);
           double muonHO = 0.;
-          muon.setHcalEnergy(totalHcal,muonHcal);
-          if( !sortedEcals.empty() ) {
+          muon.setHcalEnergy(totalHcal, muonHcal);
+          if (!sortedEcals.empty()) {
             const unsigned int iEcal = sortedEcals.begin()->second;
             PFClusterRef eclusterref = elements[iEcal].clusterRef();
-            muon.addElementInBlock( blockref, iEcal);
-            const double muonEcal = std::min(muonECAL_[0]+muonECAL_[1],eclusterref->energy());
-            muon.setEcalEnergy(eclusterref->energy(),muonEcal);
+            muon.addElementInBlock(blockref, iEcal);
+            const double muonEcal = std::min(muonECAL_[0] + muonECAL_[1], eclusterref->energy());
+            muon.setEcalEnergy(eclusterref->energy(), muonEcal);
           }
-          if( useHO_ && !sortedHOs.empty() ) {
+          if (useHO_ && !sortedHOs.empty()) {
             const unsigned int iHO = sortedHOs.begin()->second;
             PFClusterRef hoclusterref = elements[iHO].clusterRef();
-            muon.addElementInBlock( blockref, iHO);
-            muonHO = std::min(muonHO_[0]+muonHO_[1],hoclusterref->energy());
-            muon.setHcalEnergy(max(totalHcal-totalHO,0.0),muonHcal);
-            muon.setHoEnergy(hoclusterref->energy(),muonHO);
+            muon.addElementInBlock(blockref, iHO);
+            muonHO = std::min(muonHO_[0] + muonHO_[1], hoclusterref->energy());
+            muon.setHcalEnergy(max(totalHcal - totalHO, 0.0), muonHcal);
+            muon.setHoEnergy(hoclusterref->energy(), muonHO);
           }
           setHcalDepthInfo(muon, *hclusterref);
           // Remove it from the block
           const ::math::XYZPointF& chargedPosition =
-            dynamic_cast<const reco::PFBlockElementTrack*>(&elements[trk.second.first])->positionAtECALEntrance();
+              dynamic_cast<const reco::PFBlockElementTrack*>(&elements[trk.second.first])->positionAtECALEntrance();
           ::math::XYZVector chargedDirection(chargedPosition.X(), chargedPosition.Y(), chargedPosition.Z());
           chargedDirection = chargedDirection.Unit();
           totalChargedMomentum -= trackMomentum;
           // Update the calo energies
-          if ( totalEcal > 0. ) calibEcal -= std::min(calibEcal,muonECAL_[0]*calibEcal/totalEcal);
-          if ( totalHcal > 0. ) calibHcal -= std::min(calibHcal,muonHCAL_[0]*calibHcal/totalHcal);
-          totalEcal -= std::min(totalEcal,muonECAL_[0]);
-          totalHcal -= std::min(totalHcal,muonHCAL_[0]);
-          if ( totalEcal > muonECAL_[0] ) photonAtECAL -= muonECAL_[0] * chargedDirection;
-          if ( totalHcal > muonHCAL_[0] ) hadronAtECAL -= muonHCAL_[0]*calibHcal/totalHcal * chargedDirection;
+          if (totalEcal > 0.)
+            calibEcal -= std::min(calibEcal, muonECAL_[0] * calibEcal / totalEcal);
+          if (totalHcal > 0.)
+            calibHcal -= std::min(calibHcal, muonHCAL_[0] * calibHcal / totalHcal);
+          totalEcal -= std::min(totalEcal, muonECAL_[0]);
+          totalHcal -= std::min(totalHcal, muonHCAL_[0]);
+          if (totalEcal > muonECAL_[0])
+            photonAtECAL -= muonECAL_[0] * chargedDirection;
+          if (totalHcal > muonHCAL_[0])
+            hadronAtECAL -= muonHCAL_[0] * calibHcal / totalHcal * chargedDirection;
           caloEnergy = calibEcal + calibHcal;
           muonHCALEnergy += muonHCAL_[0];
           muonHCALError += muonHCAL_[1] * muonHCAL_[1];
-          if ( muonHO > 0. ) {
+          if (muonHO > 0.) {
             muonHCALEnergy += muonHO_[0];
             muonHCALError += muonHO_[1] * muonHO_[1];
-            if ( totalHcal > 0. ) {
-              calibHcal -= std::min(calibHcal,muonHO_[0] * calibHcal/totalHcal);
-              totalHcal -= std::min(totalHcal,muonHO_[0]);
+            if (totalHcal > 0.) {
+              calibHcal -= std::min(calibHcal, muonHO_[0] * calibHcal / totalHcal);
+              totalHcal -= std::min(totalHcal, muonHO_[0]);
             }
           }
           muonECALEnergy += muonECAL_[0];
@@ -1958,231 +1937,223 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
           //if ( totalChargedMomentum < caloEnergy ) break;
         }
         // New calo resolution.
-        Caloresolution = neutralHadronEnergyResolution( totalChargedMomentum, hclusterref->positionREP().Eta());
+        Caloresolution = neutralHadronEnergyResolution(totalChargedMomentum, hclusterref->positionREP().Eta());
         Caloresolution *= totalChargedMomentum;
-        Caloresolution = std::sqrt(Caloresolution*Caloresolution + muonHCALError + muonECALError);
+        Caloresolution = std::sqrt(Caloresolution * Caloresolution + muonHCALError + muonECALError);
       }
     }
 
-    if(debug_){
-      cout<<"\tBefore Cleaning "<<endl;
-      cout<<"\tCompare Calo Energy to total charged momentum "<<endl;
-      cout<<"\t\tsum p    = "<<totalChargedMomentum<<" +- "<<sqrt(sumpError2)<<endl;
-      cout<<"\t\tsum ecal = "<<totalEcal<<endl;
-      cout<<"\t\tsum hcal = "<<totalHcal<<endl;
-      cout<<"\t\t => Calo Energy = "<<caloEnergy<<" +- "<<Caloresolution<<endl;
-      cout<<"\t\t => Calo Energy- total charged momentum = "
-	  <<caloEnergy-totalChargedMomentum<<" +- "<<sqrt(sumpError2 + Caloresolution*Caloresolution)<<endl;
-      cout<<endl;
+    if (debug_) {
+      cout << "\tBefore Cleaning " << endl;
+      cout << "\tCompare Calo Energy to total charged momentum " << endl;
+      cout << "\t\tsum p    = " << totalChargedMomentum << " +- " << sqrt(sumpError2) << endl;
+      cout << "\t\tsum ecal = " << totalEcal << endl;
+      cout << "\t\tsum hcal = " << totalHcal << endl;
+      cout << "\t\t => Calo Energy = " << caloEnergy << " +- " << Caloresolution << endl;
+      cout << "\t\t => Calo Energy- total charged momentum = " << caloEnergy - totalChargedMomentum << " +- "
+           << sqrt(sumpError2 + Caloresolution * Caloresolution) << endl;
+      cout << endl;
     }
-
 
     // Second consider bad tracks (if still needed after muon removal)
     unsigned corrTrack = 10000000;
     double corrFact = 1.;
 
-    if (rejectTracks_Bad_ && totalChargedMomentum - caloEnergy > nSigmaTRACK_*Caloresolution)
-    {
-      for(auto const& trk : associatedTracks)
-      {
+    if (rejectTracks_Bad_ && totalChargedMomentum - caloEnergy > nSigmaTRACK_ * Caloresolution) {
+      for (auto const& trk : associatedTracks) {
         const unsigned iTrack = trk.second.first;
         // Only active tracks
-        if ( !active[iTrack] ) continue;
+        if (!active[iTrack])
+          continue;
         const reco::TrackRef& trackref = elements[trk.second.first].trackRef();
 
-        const double dptRel = fabs(trk.first)/trackref->pt()*100;
+        const double dptRel = fabs(trk.first) / trackref->pt() * 100;
         const bool isSecondary = isFromSecInt(elements[iTrack], "secondary");
         const bool isPrimary = isFromSecInt(elements[iTrack], "primary");
 
-        if ( isSecondary && dptRel < dptRel_DispVtx_ ) continue;
+        if (isSecondary && dptRel < dptRel_DispVtx_)
+          continue;
         // Consider only bad tracks
-        if ( fabs(trk.first) < ptError_ ) break;
+        if (fabs(trk.first) < ptError_)
+          break;
         // What would become the block charged momentum if this track were removed
         const double wouldBeTotalChargedMomentum = totalChargedMomentum - trackref->p();
         // Reject worst tracks, as long as the total charged momentum
         // is larger than the calo energy
 
-        if ( wouldBeTotalChargedMomentum > caloEnergy ) {
+        if (wouldBeTotalChargedMomentum > caloEnergy) {
           if (debug_ && isSecondary) {
-            cout << "In bad track rejection step dptRel = " << dptRel << " dptRel_DispVtx_ = " << dptRel_DispVtx_ << endl;
-            cout << "The calo energy would be still smaller even without this track but it is attached to a NI"<< endl;
+            cout << "In bad track rejection step dptRel = " << dptRel << " dptRel_DispVtx_ = " << dptRel_DispVtx_
+                 << endl;
+            cout << "The calo energy would be still smaller even without this track but it is attached to a NI" << endl;
           }
 
-          if(isPrimary || (isSecondary && dptRel < dptRel_DispVtx_)) continue;
+          if (isPrimary || (isSecondary && dptRel < dptRel_DispVtx_))
+            continue;
           active[iTrack] = false;
           totalChargedMomentum = wouldBeTotalChargedMomentum;
-          if ( debug_ )
-            std::cout << "\tElement  " << elements[iTrack]
-                  << " rejected (Dpt = " << -trk.first
-                  << " GeV/c, algo = " << trackref->algo() << ")" << std::endl;
-        // Just rescale the nth worst track momentum to equalize the calo energy
+          if (debug_)
+            std::cout << "\tElement  " << elements[iTrack] << " rejected (Dpt = " << -trk.first
+                      << " GeV/c, algo = " << trackref->algo() << ")" << std::endl;
+          // Just rescale the nth worst track momentum to equalize the calo energy
         } else {
-          if(isPrimary) break;
+          if (isPrimary)
+            break;
           corrTrack = iTrack;
-          corrFact = (caloEnergy - wouldBeTotalChargedMomentum)/elements[trk.second.first].trackRef()->p();
-          if ( trackref->p()*corrFact < 0.05 ) {
+          corrFact = (caloEnergy - wouldBeTotalChargedMomentum) / elements[trk.second.first].trackRef()->p();
+          if (trackref->p() * corrFact < 0.05) {
             corrFact = 0.;
             active[iTrack] = false;
           }
-          totalChargedMomentum -= trackref->p()*(1.-corrFact);
-          if ( debug_ )
-            std::cout << "\tElement  " << elements[iTrack]
-                  << " (Dpt = " << -trk.first
-                  << " GeV/c, algo = " << trackref->algo()
-                  << ") rescaled by " << corrFact
-                  << " Now the total charged momentum is " << totalChargedMomentum  << endl;
+          totalChargedMomentum -= trackref->p() * (1. - corrFact);
+          if (debug_)
+            std::cout << "\tElement  " << elements[iTrack] << " (Dpt = " << -trk.first
+                      << " GeV/c, algo = " << trackref->algo() << ") rescaled by " << corrFact
+                      << " Now the total charged momentum is " << totalChargedMomentum << endl;
           break;
         }
       }
     }
 
     // New determination of the calo and track resolution avec track deletion/rescaling.
-    Caloresolution = neutralHadronEnergyResolution( totalChargedMomentum, hclusterref->positionREP().Eta());
+    Caloresolution = neutralHadronEnergyResolution(totalChargedMomentum, hclusterref->positionREP().Eta());
     Caloresolution *= totalChargedMomentum;
-    Caloresolution = std::sqrt(Caloresolution*Caloresolution + muonHCALError + muonECALError);
+    Caloresolution = std::sqrt(Caloresolution * Caloresolution + muonHCALError + muonECALError);
 
     // Check if the charged momentum is still very inconsistent with the calo measurement.
     // In this case, just drop all tracks from 4th and 5th iteration linked to this block
 
-    if ( rejectTracks_Step45_ &&
-	 sortedTracks.size() > 1 &&
-	 totalChargedMomentum - caloEnergy > nSigmaTRACK_*Caloresolution ) {
-      for(auto const& trk : associatedTracks) {
-	unsigned iTrack = trk.second.first;
-	reco::TrackRef trackref = elements[iTrack].trackRef();
-	if ( !active[iTrack] ) continue;
+    if (rejectTracks_Step45_ && sortedTracks.size() > 1 &&
+        totalChargedMomentum - caloEnergy > nSigmaTRACK_ * Caloresolution) {
+      for (auto const& trk : associatedTracks) {
+        unsigned iTrack = trk.second.first;
+        reco::TrackRef trackref = elements[iTrack].trackRef();
+        if (!active[iTrack])
+          continue;
 
-	double dptRel = fabs(trk.first)/trackref->pt()*100;
-	bool isPrimaryOrSecondary = isFromSecInt(elements[iTrack], "all");
+        double dptRel = fabs(trk.first) / trackref->pt() * 100;
+        bool isPrimaryOrSecondary = isFromSecInt(elements[iTrack], "all");
 
+        if (isPrimaryOrSecondary && dptRel < dptRel_DispVtx_)
+          continue;
 
+        if (PFTrackAlgoTools::step5(trackref->algo())) {
+          active[iTrack] = false;
+          totalChargedMomentum -= trackref->p();
 
-
-	if (isPrimaryOrSecondary && dptRel < dptRel_DispVtx_) continue;
-
-	if (PFTrackAlgoTools::step5(trackref->algo())) {
-	  active[iTrack] = false;
-	  totalChargedMomentum -= trackref->p();
-
-	  if ( debug_ )
-	    std::cout << "\tElement  " << elements[iTrack]
-		      << " rejected (Dpt = " << -trk.first
-		      << " GeV/c, algo = " << trackref->algo() << ")" << std::endl;
-
-	}
+          if (debug_)
+            std::cout << "\tElement  " << elements[iTrack] << " rejected (Dpt = " << -trk.first
+                      << " GeV/c, algo = " << trackref->algo() << ")" << std::endl;
+        }
       }
-
     }
 
     // New determination of the calo and track resolution avec track deletion/rescaling.
-    Caloresolution = neutralHadronEnergyResolution( totalChargedMomentum, hclusterref->positionREP().Eta());
+    Caloresolution = neutralHadronEnergyResolution(totalChargedMomentum, hclusterref->positionREP().Eta());
     Caloresolution *= totalChargedMomentum;
-    Caloresolution = std::sqrt(Caloresolution*Caloresolution + muonHCALError + muonECALError);
+    Caloresolution = std::sqrt(Caloresolution * Caloresolution + muonHCALError + muonECALError);
 
     // Make PF candidates with the remaining tracks in the block
     sumpError2 = 0.;
-    for(auto const& trk : associatedTracks) {
+    for (auto const& trk : associatedTracks) {
       unsigned iTrack = trk.second.first;
-      if ( !active[iTrack] ) continue;
+      if (!active[iTrack])
+        continue;
       reco::TrackRef trackRef = elements[iTrack].trackRef();
       double trackMomentum = trackRef->p();
-      double Dp = trackRef->qoverpError()*trackMomentum*trackMomentum;
-      unsigned tmpi = reconstructTrack( elements[iTrack] );
+      double Dp = trackRef->qoverpError() * trackMomentum * trackMomentum;
+      unsigned tmpi = reconstructTrack(elements[iTrack]);
 
-
-      (*pfCandidates_)[tmpi].addElementInBlock( blockref, iTrack );
-      (*pfCandidates_)[tmpi].addElementInBlock( blockref, iHcal );
+      (*pfCandidates_)[tmpi].addElementInBlock(blockref, iTrack);
+      (*pfCandidates_)[tmpi].addElementInBlock(blockref, iHcal);
       setHcalDepthInfo((*pfCandidates_)[tmpi], *hclusterref);
       auto myEcals = associatedEcals.equal_range(iTrack);
-      for (auto ii=myEcals.first; ii!=myEcals.second; ++ii ) {
-	unsigned iEcal = ii->second.second;
-	if ( active[iEcal] ) continue;
-	(*pfCandidates_)[tmpi].addElementInBlock( blockref, iEcal );
+      for (auto ii = myEcals.first; ii != myEcals.second; ++ii) {
+        unsigned iEcal = ii->second.second;
+        if (active[iEcal])
+          continue;
+        (*pfCandidates_)[tmpi].addElementInBlock(blockref, iEcal);
       }
 
       if (useHO_) {
-	auto myHOs = associatedHOs.equal_range(iTrack);
-	for (auto ii=myHOs.first; ii!=myHOs.second; ++ii ) {
-	  unsigned iHO = ii->second.second;
-	  if ( active[iHO] ) continue;
-	  (*pfCandidates_)[tmpi].addElementInBlock( blockref, iHO );
-	}
+        auto myHOs = associatedHOs.equal_range(iTrack);
+        for (auto ii = myHOs.first; ii != myHOs.second; ++ii) {
+          unsigned iHO = ii->second.second;
+          if (active[iHO])
+            continue;
+          (*pfCandidates_)[tmpi].addElementInBlock(blockref, iHO);
+        }
       }
 
-      if ( iTrack == corrTrack ) {
-	(*pfCandidates_)[tmpi].rescaleMomentum(corrFact);
-	trackMomentum *= corrFact;
+      if (iTrack == corrTrack) {
+        (*pfCandidates_)[tmpi].rescaleMomentum(corrFact);
+        trackMomentum *= corrFact;
       }
-      chargedHadronsIndices.push_back( tmpi );
-      chargedHadronsInBlock.push_back( iTrack );
+      chargedHadronsIndices.push_back(tmpi);
+      chargedHadronsInBlock.push_back(iTrack);
       active[iTrack] = false;
       hcalP.push_back(trackMomentum);
       hcalDP.push_back(Dp);
-      if (Dp/trackMomentum > maxDPovP) maxDPovP = Dp/trackMomentum;
-      sumpError2 += Dp*Dp;
+      if (Dp / trackMomentum > maxDPovP)
+        maxDPovP = Dp / trackMomentum;
+      sumpError2 += Dp * Dp;
     }
 
     // The total uncertainty of the difference Calo-Track
-    double TotalError = sqrt(sumpError2 + Caloresolution*Caloresolution);
+    double TotalError = sqrt(sumpError2 + Caloresolution * Caloresolution);
 
-    if ( debug_ ) {
-      cout<<"\tCompare Calo Energy to total charged momentum "<<endl;
-      cout<<"\t\tsum p    = "<<totalChargedMomentum<<" +- "<<sqrt(sumpError2)<<endl;
-      cout<<"\t\tsum ecal = "<<totalEcal<<endl;
-      cout<<"\t\tsum hcal = "<<totalHcal<<endl;
-      cout<<"\t\t => Calo Energy = "<<caloEnergy<<" +- "<<Caloresolution<<endl;
-      cout<<"\t\t => Calo Energy- total charged momentum = "
-	  <<caloEnergy-totalChargedMomentum<<" +- "<<TotalError<<endl;
-      cout<<endl;
+    if (debug_) {
+      cout << "\tCompare Calo Energy to total charged momentum " << endl;
+      cout << "\t\tsum p    = " << totalChargedMomentum << " +- " << sqrt(sumpError2) << endl;
+      cout << "\t\tsum ecal = " << totalEcal << endl;
+      cout << "\t\tsum hcal = " << totalHcal << endl;
+      cout << "\t\t => Calo Energy = " << caloEnergy << " +- " << Caloresolution << endl;
+      cout << "\t\t => Calo Energy- total charged momentum = " << caloEnergy - totalChargedMomentum << " +- "
+           << TotalError << endl;
+      cout << endl;
     }
 
     /* */
 
     /////////////// TRACKER AND CALO COMPATIBLE  ////////////////
-    double nsigma = nSigmaHCAL(totalChargedMomentum,hclusterref->positionREP().Eta());
+    double nsigma = nSigmaHCAL(totalChargedMomentum, hclusterref->positionREP().Eta());
     //double nsigma = nSigmaHCAL(caloEnergy,hclusterref->positionREP().Eta());
-    if ( abs(totalChargedMomentum-caloEnergy)<nsigma*TotalError ) {
-
+    if (abs(totalChargedMomentum - caloEnergy) < nsigma * TotalError) {
       // deposited caloEnergy compatible with total charged momentum
       // if tracking errors are large take weighted average
 
-      if(debug_) {
-	cout<<"\t\tcase 1: COMPATIBLE "
-	    <<"|Calo Energy- total charged momentum| = "
-	    <<abs(caloEnergy-totalChargedMomentum)
-	    <<" < "<<nsigma<<" x "<<TotalError<<endl;
-	if (maxDPovP < 0.1 )
-	  cout<<"\t\t\tmax DP/P = "<< maxDPovP
-	      <<" less than 0.1: do nothing "<<endl;
-	else
-	  cout<<"\t\t\tmax DP/P = "<< maxDPovP
-	      <<" >  0.1: take weighted averages "<<endl;
+      if (debug_) {
+        cout << "\t\tcase 1: COMPATIBLE "
+             << "|Calo Energy- total charged momentum| = " << abs(caloEnergy - totalChargedMomentum) << " < " << nsigma
+             << " x " << TotalError << endl;
+        if (maxDPovP < 0.1)
+          cout << "\t\t\tmax DP/P = " << maxDPovP << " less than 0.1: do nothing " << endl;
+        else
+          cout << "\t\t\tmax DP/P = " << maxDPovP << " >  0.1: take weighted averages " << endl;
       }
 
       // if max DP/P < 10%  do nothing
       if (maxDPovP > 0.1) {
-
         // for each track associated to hcal
         //      int nrows = tkIs.size();
         int nrows = chargedHadronsIndices.size();
-        TMatrixTSym<double> a (nrows);
-        TVectorD b (nrows);
+        TMatrixTSym<double> a(nrows);
+        TVectorD b(nrows);
         TVectorD check(nrows);
-        double sigma2E = Caloresolution*Caloresolution;
-        for(int i=0; i<nrows; i++) {
-          double sigma2i = hcalDP[i]*hcalDP[i];
-          if (debug_){
-            cout<<"\t\t\ttrack associated to hcal "<<i
-                <<" P = "<<hcalP[i]<<" +- "
-                <<hcalDP[i]<<endl;
-	  }
-          a(i,i) = 1./sigma2i + 1./sigma2E;
-          b(i) = hcalP[i]/sigma2i + caloEnergy/sigma2E;
-          for(int j=0; j<nrows; j++) {
-            if (i==j) continue;
-            a(i,j) = 1./sigma2E;
-          } // end loop on j
-        } // end loop on i
+        double sigma2E = Caloresolution * Caloresolution;
+        for (int i = 0; i < nrows; i++) {
+          double sigma2i = hcalDP[i] * hcalDP[i];
+          if (debug_) {
+            cout << "\t\t\ttrack associated to hcal " << i << " P = " << hcalP[i] << " +- " << hcalDP[i] << endl;
+          }
+          a(i, i) = 1. / sigma2i + 1. / sigma2E;
+          b(i) = hcalP[i] / sigma2i + caloEnergy / sigma2E;
+          for (int j = 0; j < nrows; j++) {
+            if (i == j)
+              continue;
+            a(i, j) = 1. / sigma2E;
+          }  // end loop on j
+        }    // end loop on i
 
         // solve ax = b
         //if (debug_){// debug1
@@ -2197,29 +2168,25 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
         // for each track create a PFCandidate track
         // with a momentum rescaled to weighted average
         if (ok) {
-          for (int i=0; i<nrows; i++){
+          for (int i = 0; i < nrows; i++) {
             //      unsigned iTrack = trackInfos[i].index;
             unsigned ich = chargedHadronsIndices[i];
-            double rescaleFactor =  x(i)/hcalP[i];
-            (*pfCandidates_)[ich].rescaleMomentum( rescaleFactor );
+            double rescaleFactor = x(i) / hcalP[i];
+            (*pfCandidates_)[ich].rescaleMomentum(rescaleFactor);
 
-            if(debug_){
-              cout<<"\t\t\told p "<<hcalP[i]
-                  <<" new p "<<x(i)
-                  <<" rescale "<<rescaleFactor<<endl;
+            if (debug_) {
+              cout << "\t\t\told p " << hcalP[i] << " new p " << x(i) << " rescale " << rescaleFactor << endl;
             }
           }
-        }
-        else {
-          cerr<<"not ok!"<<endl;
+        } else {
+          cerr << "not ok!" << endl;
           assert(0);
         }
       }
     }
 
     /////////////// NEUTRAL DETECTION  ////////////////
-    else if( caloEnergy > totalChargedMomentum ) {
-
+    else if (caloEnergy > totalChargedMomentum) {
       //case 2: caloEnergy > totalChargedMomentum + nsigma*TotalError
       //there is an excess of energy in the calos
       //create a neutral hadron or a photon
@@ -2238,48 +2205,47 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
       }
       */
       double eNeutralHadron = caloEnergy - totalChargedMomentum;
-      double ePhoton = (caloEnergy - totalChargedMomentum) / slopeEcal; // KH: this slopeEcal is computed based on ECAL energy under the hadron hypothesis,
-                                                                        // thought we are creating photons. 
-                                                                        // This is a fuzzy case, but it should be better than corrected twice under both egamma and hadron hypotheses.
+      double ePhoton = (caloEnergy - totalChargedMomentum) /
+                       slopeEcal;  // KH: this slopeEcal is computed based on ECAL energy under the hadron hypothesis,
+                                   // thought we are creating photons.
+      // This is a fuzzy case, but it should be better than corrected twice under both egamma and hadron hypotheses.
 
-      if(debug_) {
-        if(!sortedTracks.empty() ){
-          cout<<"\t\tcase 2: NEUTRAL DETECTION "
-              <<caloEnergy<<" > "<<nsigma<<"x"<<TotalError
-              <<" + "<<totalChargedMomentum<<endl;
-          cout<<"\t\tneutral activity detected: "<<endl
-              <<"\t\t\t           photon = "<<ePhoton<<endl
-              <<"\t\t\tor neutral hadron = "<<eNeutralHadron<<endl;
+      if (debug_) {
+        if (!sortedTracks.empty()) {
+          cout << "\t\tcase 2: NEUTRAL DETECTION " << caloEnergy << " > " << nsigma << "x" << TotalError << " + "
+               << totalChargedMomentum << endl;
+          cout << "\t\tneutral activity detected: " << endl
+               << "\t\t\t           photon = " << ePhoton << endl
+               << "\t\t\tor neutral hadron = " << eNeutralHadron << endl;
 
-          cout<<"\t\tphoton or hadron ?"<<endl;}
+          cout << "\t\tphoton or hadron ?" << endl;
+        }
 
-        if(sortedTracks.empty() )
-          cout<<"\t\tno track -> hadron "<<endl;
+        if (sortedTracks.empty())
+          cout << "\t\tno track -> hadron " << endl;
         else
-          cout<<"\t\t"<<sortedTracks.size()
-              <<" tracks -> check if the excess is photonic or hadronic"<<endl;
+          cout << "\t\t" << sortedTracks.size() << " tracks -> check if the excess is photonic or hadronic" << endl;
       }
-
 
       double ratioMax = 0.;
       reco::PFClusterRef maxEcalRef;
-      unsigned maxiEcal= 9999;
+      unsigned maxiEcal = 9999;
 
       // for each track associated to hcal: iterator IE ie :
 
-      for(auto const& trk : sortedTracks) {
-
+      for (auto const& trk : sortedTracks) {
         unsigned iTrack = trk.second;
 
         PFBlockElement::Type type = elements[iTrack].type();
-        assert( type == reco::PFBlockElement::TRACK );
+        assert(type == reco::PFBlockElement::TRACK);
 
         reco::TrackRef trackRef = elements[iTrack].trackRef();
-        assert( !trackRef.isNull() );
+        assert(!trackRef.isNull());
 
         auto iae = associatedEcals.find(iTrack);
 
-        if( iae == associatedEcals.end() ) continue;
+        if (iae == associatedEcals.end())
+          continue;
 
         // double distECAL = iae->second.first;
         unsigned iEcal = iae->second.second;
@@ -2288,17 +2254,17 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
         assert(typeEcal == reco::PFBlockElement::ECAL);
 
         reco::PFClusterRef clusterRef = elements[iEcal].clusterRef();
-        assert( !clusterRef.isNull() );
+        assert(!clusterRef.isNull());
 
         double pTrack = trackRef->p();
         double eECAL = clusterRef->energy();
         double eECALOverpTrack = eECAL / pTrack;
 
-	if ( eECALOverpTrack > ratioMax ) {
-	  ratioMax = eECALOverpTrack;
-	  maxEcalRef = clusterRef;
-	  maxiEcal = iEcal;
-	}
+        if (eECALOverpTrack > ratioMax) {
+          ratioMax = eECALOverpTrack;
+          maxEcalRef = clusterRef;
+          maxiEcal = iEcal;
+        }
 
       }  // end loop on tracks associated to hcal: iterator IE ie
 
@@ -2309,116 +2275,125 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
 
       // If the excess is smaller than the ecal energy, assign the whole
       // excess to photons
-      if ( ePhoton < totalEcal || eNeutralHadron-calibEcal < 1E-10 ) {
-        if ( !maxEcalRef.isNull() ) {
-	 // So the merged photon energy is,
-	 mergedPhotonEnergy  = ePhoton;
+      if (ePhoton < totalEcal || eNeutralHadron - calibEcal < 1E-10) {
+        if (!maxEcalRef.isNull()) {
+          // So the merged photon energy is,
+          mergedPhotonEnergy = ePhoton;
         }
       } else {
-	// Otherwise assign the whole ECAL energy to the photons
-        if ( !maxEcalRef.isNull() ) {
-	 // So the merged photon energy is,
-	  mergedPhotonEnergy  = totalEcalEGMCalib; // KH: use calibrated ECAL energy under the egamma hypothesis
+        // Otherwise assign the whole ECAL energy to the photons
+        if (!maxEcalRef.isNull()) {
+          // So the merged photon energy is,
+          mergedPhotonEnergy = totalEcalEGMCalib;  // KH: use calibrated ECAL energy under the egamma hypothesis
         }
-	// ... and assign the remaining excess to neutral hadrons using the direction of ecal clusters
-        mergedNeutralHadronEnergy = eNeutralHadron-calibEcal;
+        // ... and assign the remaining excess to neutral hadrons using the direction of ecal clusters
+        mergedNeutralHadronEnergy = eNeutralHadron - calibEcal;
       }
 
-      if ( mergedPhotonEnergy > 0 ) {
-          // Split merged photon into photons for each energetic ecal cluster (necessary for jet substructure reconstruction)
-          // make only one merged photon if less than 2 ecal clusters
-	  // KH: this part still needs review, after using non-corrected ECAL energy for PF hadron calibrations
-	  if ( ecalClusters.size()<=1 ) {
-            ecalClusters.clear();
-            ecalClusters.emplace_back(maxiEcal, photonAtECAL, 1.); // KH: calibration factor of 1, which should be ok as long as sumEcalClusters is consistent with photonAtECAL in this case
-            sumEcalClusters=sqrt(photonAtECAL.Mag2());
-          }
-          for(auto const& pae : ecalClusters) {
-            const double clusterEnergyCalibrated=sqrt(std::get<1>(pae).Mag2())*std::get<2>(pae); // KH: calibrated under the egamma hypothesis. Note: sumEcalClusters is normally calibrated under egamma hypothesis
-            particleEnergy.push_back(mergedPhotonEnergy*clusterEnergyCalibrated/sumEcalClusters);
-            particleDirection.push_back(std::get<1>(pae));
-            ecalEnergy.push_back(mergedPhotonEnergy*clusterEnergyCalibrated/sumEcalClusters);
-            hcalEnergy.push_back(0.);
-            rawecalEnergy.push_back(totalEcal);
-            rawhcalEnergy.push_back(totalHcal);
-            pivotalClusterRef.push_back(elements[std::get<0>(pae)].clusterRef());
-            iPivotal.push_back(std::get<0>(pae));
-          }
+      if (mergedPhotonEnergy > 0) {
+        // Split merged photon into photons for each energetic ecal cluster (necessary for jet substructure reconstruction)
+        // make only one merged photon if less than 2 ecal clusters
+        // KH: this part still needs review, after using non-corrected ECAL energy for PF hadron calibrations
+        if (ecalClusters.size() <= 1) {
+          ecalClusters.clear();
+          ecalClusters.emplace_back(
+              maxiEcal,
+              photonAtECAL,
+              1.);  // KH: calibration factor of 1, which should be ok as long as sumEcalClusters is consistent with photonAtECAL in this case
+          sumEcalClusters = sqrt(photonAtECAL.Mag2());
+        }
+        for (auto const& pae : ecalClusters) {
+          const double clusterEnergyCalibrated =
+              sqrt(std::get<1>(pae).Mag2()) *
+              std::get<2>(
+                  pae);  // KH: calibrated under the egamma hypothesis. Note: sumEcalClusters is normally calibrated under egamma hypothesis
+          particleEnergy.push_back(mergedPhotonEnergy * clusterEnergyCalibrated / sumEcalClusters);
+          particleDirection.push_back(std::get<1>(pae));
+          ecalEnergy.push_back(mergedPhotonEnergy * clusterEnergyCalibrated / sumEcalClusters);
+          hcalEnergy.push_back(0.);
+          rawecalEnergy.push_back(totalEcal);
+          rawhcalEnergy.push_back(totalHcal);
+          pivotalClusterRef.push_back(elements[std::get<0>(pae)].clusterRef());
+          iPivotal.push_back(std::get<0>(pae));
+        }
       }
 
-      if ( mergedNeutralHadronEnergy > 1.0 ) {
-          // Split merged neutral hadrons according to directions of energetic ecal clusters (necessary for jet substructure reconstruction)
-          // make only one merged neutral hadron if less than 2 ecal clusters
-          if ( ecalClusters.size()<=1 ) {
-              ecalClusters.clear();
-              ecalClusters.emplace_back(iHcal, hadronAtECAL, 1.); // KH: calibration factor of 1, which should be ok as long as sumEcalClusters is consistent with photonAtECAL
-              sumEcalClusters=sqrt(hadronAtECAL.Mag2());
-          }
-         for(auto const& pae : ecalClusters) {
-           const double clusterEnergyCalibrated=sqrt(std::get<1>(pae).Mag2())*std::get<2>(pae); // KH: calibrated under the egamma hypothesis. Note: sumEcalClusters is normally calibrated under egamma hypothesis
-           particleEnergy.push_back(mergedNeutralHadronEnergy*clusterEnergyCalibrated/sumEcalClusters);
-           particleDirection.push_back(std::get<1>(pae));
-           ecalEnergy.push_back(0.);
-           hcalEnergy.push_back(mergedNeutralHadronEnergy*clusterEnergyCalibrated/sumEcalClusters);
-           rawecalEnergy.push_back(totalEcal);
-           rawhcalEnergy.push_back(totalHcal);
-           pivotalClusterRef.push_back(hclusterref);
-           iPivotal.push_back(iHcal);
-         }
+      if (mergedNeutralHadronEnergy > 1.0) {
+        // Split merged neutral hadrons according to directions of energetic ecal clusters (necessary for jet substructure reconstruction)
+        // make only one merged neutral hadron if less than 2 ecal clusters
+        if (ecalClusters.size() <= 1) {
+          ecalClusters.clear();
+          ecalClusters.emplace_back(
+              iHcal,
+              hadronAtECAL,
+              1.);  // KH: calibration factor of 1, which should be ok as long as sumEcalClusters is consistent with photonAtECAL
+          sumEcalClusters = sqrt(hadronAtECAL.Mag2());
+        }
+        for (auto const& pae : ecalClusters) {
+          const double clusterEnergyCalibrated =
+              sqrt(std::get<1>(pae).Mag2()) *
+              std::get<2>(
+                  pae);  // KH: calibrated under the egamma hypothesis. Note: sumEcalClusters is normally calibrated under egamma hypothesis
+          particleEnergy.push_back(mergedNeutralHadronEnergy * clusterEnergyCalibrated / sumEcalClusters);
+          particleDirection.push_back(std::get<1>(pae));
+          ecalEnergy.push_back(0.);
+          hcalEnergy.push_back(mergedNeutralHadronEnergy * clusterEnergyCalibrated / sumEcalClusters);
+          rawecalEnergy.push_back(totalEcal);
+          rawhcalEnergy.push_back(totalHcal);
+          pivotalClusterRef.push_back(hclusterref);
+          iPivotal.push_back(iHcal);
+        }
       }
 
       // reconstructing a merged neutral
       // the type of PFCandidate is known from the
       // reference to the pivotal cluster.
 
-      for ( unsigned iPivot=0; iPivot<iPivotal.size(); ++iPivot ) {
-
-        if ( particleEnergy[iPivot] < 0. )
-          std::cout << "ALARM = Negative energy ! "
-                << particleEnergy[iPivot] << std::endl;
+      for (unsigned iPivot = 0; iPivot < iPivotal.size(); ++iPivot) {
+        if (particleEnergy[iPivot] < 0.)
+          std::cout << "ALARM = Negative energy ! " << particleEnergy[iPivot] << std::endl;
 
         const bool useDirection = true;
-        auto& neutral = (*pfCandidates_)[reconstructCluster( *pivotalClusterRef[iPivot],
-                                                             particleEnergy[iPivot],
-                                                             useDirection,
-                                                             particleDirection[iPivot].X(),
-                                                             particleDirection[iPivot].Y(),
-                                                             particleDirection[iPivot].Z() )];
+        auto& neutral = (*pfCandidates_)[reconstructCluster(*pivotalClusterRef[iPivot],
+                                                            particleEnergy[iPivot],
+                                                            useDirection,
+                                                            particleDirection[iPivot].X(),
+                                                            particleDirection[iPivot].Y(),
+                                                            particleDirection[iPivot].Z())];
 
-
-        neutral.setEcalEnergy( rawecalEnergy[iPivot],ecalEnergy[iPivot] );
-        if ( !useHO_ ) {
-          neutral.setHcalEnergy( rawhcalEnergy[iPivot],hcalEnergy[iPivot] );
+        neutral.setEcalEnergy(rawecalEnergy[iPivot], ecalEnergy[iPivot]);
+        if (!useHO_) {
+          neutral.setHcalEnergy(rawhcalEnergy[iPivot], hcalEnergy[iPivot]);
           neutral.setHoEnergy(0., 0.);
         } else {
-          neutral.setHcalEnergy( max(rawhcalEnergy[iPivot]-totalHO,0.0),hcalEnergy[iPivot]*(1.-totalHO/rawhcalEnergy[iPivot]));
-          neutral.setHoEnergy(totalHO, totalHO * hcalEnergy[iPivot]/rawhcalEnergy[iPivot]);
+          neutral.setHcalEnergy(max(rawhcalEnergy[iPivot] - totalHO, 0.0),
+                                hcalEnergy[iPivot] * (1. - totalHO / rawhcalEnergy[iPivot]));
+          neutral.setHoEnergy(totalHO, totalHO * hcalEnergy[iPivot] / rawhcalEnergy[iPivot]);
         }
-        neutral.setPs1Energy( 0. );
-        neutral.setPs2Energy( 0. );
-        neutral.set_mva_nothing_gamma( -1. );
+        neutral.setPs1Energy(0.);
+        neutral.setPs2Energy(0.);
+        neutral.set_mva_nothing_gamma(-1.);
         //       neutral.addElement(&elements[iPivotal]);
         // neutral.addElementInBlock(blockref, iPivotal[iPivot]);
-        neutral.addElementInBlock( blockref, iHcal );
+        neutral.addElementInBlock(blockref, iHcal);
         for (unsigned iTrack : chargedHadronsInBlock) {
-          neutral.addElementInBlock( blockref, iTrack );
+          neutral.addElementInBlock(blockref, iTrack);
           // Assign the position of the track at the ECAL entrance
           const ::math::XYZPointF& chargedPosition =
-            dynamic_cast<const reco::PFBlockElementTrack*>(&elements[iTrack])->positionAtECALEntrance();
+              dynamic_cast<const reco::PFBlockElementTrack*>(&elements[iTrack])->positionAtECALEntrance();
           neutral.setPositionAtECALEntrance(chargedPosition);
 
           auto myEcals = associatedEcals.equal_range(iTrack);
-          for (auto ii=myEcals.first; ii!=myEcals.second; ++ii ) {
+          for (auto ii = myEcals.first; ii != myEcals.second; ++ii) {
             unsigned iEcal = ii->second.second;
-            if ( active[iEcal] ) continue;
-            neutral.addElementInBlock( blockref, iEcal );
+            if (active[iEcal])
+              continue;
+            neutral.addElementInBlock(blockref, iEcal);
           }
         }
-
       }
 
-    } // excess of energy
-
+    }  // excess of energy
 
     // will now share the hcal energy between the various charged hadron
     // candidates, taking into account the potential neutral hadrons
@@ -2429,7 +2404,7 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
     //the remaining hadrons be assigned the remaining ecal energy?
     //*Temporary solution*: follow HCAL example with fractions...
 
-   /*
+    /*
     if(totalEcal>0) {
       // removing ecal energy from abc calibration
       totalHcalEnergyCalibrated  -= calibEcal;
@@ -2447,117 +2422,117 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::Lin
     //COLIN can compute this before
     // not exactly equal to sum p, this is sum E
     double chargedHadronsTotalEnergy = 0;
-    for(unsigned index : chargedHadronsIndices) {
+    for (unsigned index : chargedHadronsIndices) {
       reco::PFCandidate& chargedHadron = (*pfCandidates_)[index];
       chargedHadronsTotalEnergy += chargedHadron.energy();
     }
 
-    for(unsigned index : chargedHadronsIndices) {
+    for (unsigned index : chargedHadronsIndices) {
       reco::PFCandidate& chargedHadron = (*pfCandidates_)[index];
-      float fraction = chargedHadron.energy()/chargedHadronsTotalEnergy;
+      float fraction = chargedHadron.energy() / chargedHadronsTotalEnergy;
 
-      if ( !useHO_ ) {
-	chargedHadron.setHcalEnergy(  fraction * totalHcal, fraction * totalHcalEnergyCalibrated );
-	chargedHadron.setHoEnergy(  0., 0. );
+      if (!useHO_) {
+        chargedHadron.setHcalEnergy(fraction * totalHcal, fraction * totalHcalEnergyCalibrated);
+        chargedHadron.setHoEnergy(0., 0.);
       } else {
-	chargedHadron.setHcalEnergy(  fraction * max(totalHcal-totalHO,0.0), fraction * totalHcalEnergyCalibrated * (1.-totalHO/totalHcal) );
-	chargedHadron.setHoEnergy( fraction * totalHO, fraction * totalHO * totalHcalEnergyCalibrated / totalHcal );
+        chargedHadron.setHcalEnergy(fraction * max(totalHcal - totalHO, 0.0),
+                                    fraction * totalHcalEnergyCalibrated * (1. - totalHO / totalHcal));
+        chargedHadron.setHoEnergy(fraction * totalHO, fraction * totalHO * totalHcalEnergyCalibrated / totalHcal);
       }
       //JB: fixing up (previously omitted) setting of ECAL energy gouzevit
-      chargedHadron.setEcalEnergy( fraction * totalEcal, fraction * totalEcalEnergyCalibrated );
+      chargedHadron.setEcalEnergy(fraction * totalEcal, fraction * totalEcalEnergyCalibrated);
     }
 
     // Finally treat unused ecal satellites as photons.
-    for(auto const& ecalSatellite : ecalSatellites) {
-
+    for (auto const& ecalSatellite : ecalSatellites) {
       // Ignore satellites already taken
       unsigned iEcal = std::get<0>(ecalSatellite.second);
-      if ( !active[iEcal] ) continue;
+      if (!active[iEcal])
+        continue;
 
       // Sanity checks again (well not useful, this time!)
-      PFBlockElement::Type type = elements[ iEcal ].type();
-      assert( type == PFBlockElement::ECAL );
+      PFBlockElement::Type type = elements[iEcal].type();
+      assert(type == PFBlockElement::ECAL);
       PFClusterRef eclusterref = elements[iEcal].clusterRef();
-      assert(!eclusterref.isNull() );
+      assert(!eclusterref.isNull());
 
       // Lock the cluster
       active[iEcal] = false;
 
       // Find the associated tracks
       std::multimap<double, unsigned> assTracks;
-      block.associatedElements( iEcal,  linkData,
-				assTracks,
-				reco::PFBlockElement::TRACK,
-				reco::PFBlock::LINKTEST_ALL );
+      block.associatedElements(iEcal, linkData, assTracks, reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL);
 
       // Create a photon
-      double ecalClusterEnergyCalibrated = sqrt(std::get<1>(ecalSatellite.second).Mag2()) * std::get<2>(ecalSatellite.second); // KH: calibrated under the egamma hypothesis (rawEcalClusterEnergy * calibration)
-      auto& cand = (*pfCandidates_)[reconstructCluster( *eclusterref, ecalClusterEnergyCalibrated )];
-      cand.setEcalEnergy( eclusterref->energy(), ecalClusterEnergyCalibrated );
-      cand.setHcalEnergy( 0., 0. );
-      cand.setHoEnergy( 0., 0. );
-      cand.setPs1Energy( associatedPSs[iEcal].first );
-      cand.setPs2Energy( associatedPSs[iEcal].second );
-      cand.addElementInBlock( blockref, iEcal );
-      cand.addElementInBlock( blockref, sortedTracks.begin()->second) ;
+      double ecalClusterEnergyCalibrated =
+          sqrt(std::get<1>(ecalSatellite.second).Mag2()) *
+          std::get<2>(
+              ecalSatellite.second);  // KH: calibrated under the egamma hypothesis (rawEcalClusterEnergy * calibration)
+      auto& cand = (*pfCandidates_)[reconstructCluster(*eclusterref, ecalClusterEnergyCalibrated)];
+      cand.setEcalEnergy(eclusterref->energy(), ecalClusterEnergyCalibrated);
+      cand.setHcalEnergy(0., 0.);
+      cand.setHoEnergy(0., 0.);
+      cand.setPs1Energy(associatedPSs[iEcal].first);
+      cand.setPs2Energy(associatedPSs[iEcal].second);
+      cand.addElementInBlock(blockref, iEcal);
+      cand.addElementInBlock(blockref, sortedTracks.begin()->second);
 
-      if ( fabs(eclusterref->energy() - sqrt(std::get<1>(ecalSatellite.second).Mag2()))>1e-3 || fabs(eclusterref->correctedEnergy() - ecalClusterEnergyCalibrated)>1e-3 )
-	edm::LogWarning("PFAlgo:processBlock") << "ecalCluster vs ecalSatellites look inconsistent (eCluster E, calibE, ecalSatellite E, calib E): "
-					       << eclusterref->energy() << " " << eclusterref->correctedEnergy() << " "
-					       << sqrt(std::get<1>(ecalSatellite.second).Mag2()) << " " << ecalClusterEnergyCalibrated;
-      
-    } // ecalSatellites
+      if (fabs(eclusterref->energy() - sqrt(std::get<1>(ecalSatellite.second).Mag2())) > 1e-3 ||
+          fabs(eclusterref->correctedEnergy() - ecalClusterEnergyCalibrated) > 1e-3)
+        edm::LogWarning("PFAlgo:processBlock")
+            << "ecalCluster vs ecalSatellites look inconsistent (eCluster E, calibE, ecalSatellite E, calib E): "
+            << eclusterref->energy() << " " << eclusterref->correctedEnergy() << " "
+            << sqrt(std::get<1>(ecalSatellite.second).Mag2()) << " " << ecalClusterEnergyCalibrated;
 
-  } // hcalIs
-  // end loop on hcal element iHcal= hcalIs[i] 
+    }  // ecalSatellites
 
-    
+  }  // hcalIs
+  // end loop on hcal element iHcal= hcalIs[i]
 }
- 
-void PFAlgo::createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea) {
-  
+
+void PFAlgo::createCandidatesHCALUnlinked(const reco::PFBlock& block,
+                                          reco::PFBlock::LinkData& linkData,
+                                          const edm::OwnVector<reco::PFBlockElement>& elements,
+                                          std::vector<bool>& active,
+                                          const reco::PFBlockRef& blockref,
+                                          ElementIndices& inds,
+                                          std::vector<bool>& deadArea) {
   // Processing the remaining HCAL clusters
-  if(debug_) {
-    cout << endl << endl <<"---- loop remaining hcal ------- " << endl;
+  if (debug_) {
+    cout << endl << endl << "---- loop remaining hcal ------- " << endl;
   }
 
-
-  for(unsigned iHcal : inds.hcalIs) {
-
+  for (unsigned iHcal : inds.hcalIs) {
     // Keep ECAL and HO elements for reference in the PFCandidate
     std::vector<unsigned> ecalRefs;
     std::vector<unsigned> hoRefs;
 
-    if(debug_)
-      cout<<endl<<elements[iHcal]<<" ";
+    if (debug_)
+      cout << endl << elements[iHcal] << " ";
 
-
-    if( !active[iHcal] ) {
-      if(debug_)
-        cout<<"not active"<<endl;
+    if (!active[iHcal]) {
+      if (debug_)
+        cout << "not active" << endl;
       continue;
     }
 
     // Find the ECAL elements linked to it
     std::multimap<double, unsigned> ecalElems;
-    block.associatedElements( iHcal,  linkData,
-                              ecalElems ,
-                              reco::PFBlockElement::ECAL,
-			      reco::PFBlock::LINKTEST_ALL );
+    block.associatedElements(iHcal, linkData, ecalElems, reco::PFBlockElement::ECAL, reco::PFBlock::LINKTEST_ALL);
 
     // Loop on these ECAL elements
     float totalEcal = 0.;
     float ecalMax = 0.;
     reco::PFClusterRef eClusterRef;
-    for(auto const& ecal : ecalElems) {
-
+    for (auto const& ecal : ecalElems) {
       unsigned iEcal = ecal.second;
       double dist = ecal.first;
       PFBlockElement::Type type = elements[iEcal].type();
-      assert( type == PFBlockElement::ECAL );
+      assert(type == PFBlockElement::ECAL);
 
       // Check if already used
-      if( !active[iEcal] ) continue;
+      if (!active[iEcal])
+        continue;
 
       // Check the distance (one HCALPlusECAL tower, roughly)
       // if ( dist > 0.15 ) continue;
@@ -2579,33 +2554,30 @@ void PFAlgo::createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBl
 
       // Check if not closer from another free HCAL
       std::multimap<double, unsigned> hcalElems;
-      block.associatedElements( iEcal,  linkData,
-                                hcalElems ,
-                                reco::PFBlockElement::HCAL,
-                                reco::PFBlock::LINKTEST_ALL );
+      block.associatedElements(iEcal, linkData, hcalElems, reco::PFBlockElement::HCAL, reco::PFBlock::LINKTEST_ALL);
 
-      const bool isClosest = std::none_of(hcalElems.begin(), hcalElems.end(), [&](auto const& hcal){
-                  return active[hcal.second] && hcal.first < dist;
-              });
+      const bool isClosest = std::none_of(hcalElems.begin(), hcalElems.end(), [&](auto const& hcal) {
+        return active[hcal.second] && hcal.first < dist;
+      });
 
-      if (!isClosest) continue;
+      if (!isClosest)
+        continue;
 
-
-      if(debug_) {
-        cout<<"\telement "<<elements[iEcal]<<" linked with dist "<< dist<<endl;
-        cout<<"Added to HCAL cluster to form a neutral hadron"<<endl;
+      if (debug_) {
+        cout << "\telement " << elements[iEcal] << " linked with dist " << dist << endl;
+        cout << "Added to HCAL cluster to form a neutral hadron" << endl;
       }
 
       reco::PFClusterRef eclusterRef = elements[iEcal].clusterRef();
-      assert( !eclusterRef.isNull() );
+      assert(!eclusterRef.isNull());
 
-      // KH: use raw ECAL energy for PF hadron calibration_. 
-      double ecalEnergy = eclusterRef->energy(); // ecalEnergy = eclusterRef->correctedEnergy();
+      // KH: use raw ECAL energy for PF hadron calibration_.
+      double ecalEnergy = eclusterRef->energy();  // ecalEnergy = eclusterRef->correctedEnergy();
 
       //std::cout << "EcalEnergy, ps1, ps2 = " << ecalEnergy
       //          << ", " << ps1Ene[0] << ", " << ps2Ene[0] << std::endl;
       totalEcal += ecalEnergy;
-      if ( ecalEnergy > ecalMax ) {
+      if (ecalEnergy > ecalMax) {
         ecalMax = ecalEnergy;
         eClusterRef = eclusterRef;
       }
@@ -2613,8 +2585,7 @@ void PFAlgo::createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBl
       ecalRefs.push_back(iEcal);
       active[iEcal] = false;
 
-
-    }// End loop ECAL
+    }  // End loop ECAL
 
     // Now find the HO clusters linked to the HCAL cluster
     double totalHO = 0.;
@@ -2622,54 +2593,50 @@ void PFAlgo::createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBl
     //unsigned jHO = 0;
     if (useHO_) {
       std::multimap<double, unsigned> hoElems;
-      block.associatedElements( iHcal,  linkData,
-                                hoElems ,
-                                reco::PFBlockElement::HO,
-                                reco::PFBlock::LINKTEST_ALL );
+      block.associatedElements(iHcal, linkData, hoElems, reco::PFBlockElement::HO, reco::PFBlock::LINKTEST_ALL);
 
       // Loop on these HO elements
       //      double totalHO = 0.;
       //      double hoMax = 0.;
       //      unsigned jHO = 0;
       reco::PFClusterRef hoClusterRef;
-      for(auto const& ho : hoElems) {
-
+      for (auto const& ho : hoElems) {
         unsigned iHO = ho.second;
         double dist = ho.first;
         PFBlockElement::Type type = elements[iHO].type();
-        assert( type == PFBlockElement::HO );
+        assert(type == PFBlockElement::HO);
 
         // Check if already used
-        if( !active[iHO] ) continue;
+        if (!active[iHO])
+          continue;
 
         // Check the distance (one HCALPlusHO tower, roughly)
         // if ( dist > 0.15 ) continue;
 
         // Check if not closer from another free HCAL
         std::multimap<double, unsigned> hcalElems;
-        block.associatedElements( iHO,  linkData,
-                                  hcalElems ,
-                                  reco::PFBlockElement::HCAL,
-                                  reco::PFBlock::LINKTEST_ALL );
+        block.associatedElements(iHO, linkData, hcalElems, reco::PFBlockElement::HCAL, reco::PFBlock::LINKTEST_ALL);
 
-        const bool isClosest = std::none_of(hcalElems.begin(), hcalElems.end(), [&](auto const& hcal){
-                    return active[hcal.second] && hcal.first < dist;
-                });
+        const bool isClosest = std::none_of(hcalElems.begin(), hcalElems.end(), [&](auto const& hcal) {
+          return active[hcal.second] && hcal.first < dist;
+        });
 
-        if (!isClosest) continue;
+        if (!isClosest)
+          continue;
 
-        if(debug_ && useHO_) {
-          cout<<"\telement "<<elements[iHO]<<" linked with dist "<< dist<<endl;
-          cout<<"Added to HCAL cluster to form a neutral hadron"<<endl;
+        if (debug_ && useHO_) {
+          cout << "\telement " << elements[iHO] << " linked with dist " << dist << endl;
+          cout << "Added to HCAL cluster to form a neutral hadron" << endl;
         }
 
         reco::PFClusterRef hoclusterRef = elements[iHO].clusterRef();
-        assert( !hoclusterRef.isNull() );
+        assert(!hoclusterRef.isNull());
 
-        double hoEnergy = hoclusterRef->energy(); // calibration_.energyEm(*hoclusterRef,ps1Ene,ps2Ene,crackCorrection);
+        double hoEnergy =
+            hoclusterRef->energy();  // calibration_.energyEm(*hoclusterRef,ps1Ene,ps2Ene,crackCorrection);
 
         totalHO += hoEnergy;
-        if ( hoEnergy > hoMax ) {
+        if (hoEnergy > hoMax) {
           hoMax = hoEnergy;
           hoClusterRef = hoclusterRef;
           //jHO = iHO;
@@ -2678,17 +2645,17 @@ void PFAlgo::createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBl
         hoRefs.push_back(iHO);
         active[iHO] = false;
 
-      }// End loop HO
+      }  // End loop HO
     }
 
-    PFClusterRef hclusterRef
-      = elements[iHcal].clusterRef();
-    assert( !hclusterRef.isNull() );
+    PFClusterRef hclusterRef = elements[iHcal].clusterRef();
+    assert(!hclusterRef.isNull());
 
     // HCAL energy
-    double totalHcal =  hclusterRef->energy();
+    double totalHcal = hclusterRef->energy();
     // Include the HO energy
-    if ( useHO_ ) totalHcal += totalHO;
+    if (useHO_)
+      totalHcal += totalHO;
 
     // std::cout << "Hcal Energy,eta : " << totalHcal
     //          << ", " << hclusterRef->positionREP().Eta()
@@ -2697,15 +2664,13 @@ void PFAlgo::createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBl
     //double caloEnergy = totalHcal;
     // double slopeEcal = 1.0;
     double calibEcal = totalEcal > 0. ? totalEcal : 0.;
-    double calibHcal = std::max(0.,totalHcal);
-    if  (  hclusterRef->layer() == PFLayer::HF_HAD  ||
-	   hclusterRef->layer() == PFLayer::HF_EM ) {
+    double calibHcal = std::max(0., totalHcal);
+    if (hclusterRef->layer() == PFLayer::HF_HAD || hclusterRef->layer() == PFLayer::HF_EM) {
       //caloEnergy = totalHcal/0.7;
       calibEcal = totalEcal;
     } else {
-      calibration_.energyEmHad(-1.,calibEcal,calibHcal,
-				hclusterRef->positionREP().Eta(),
-				hclusterRef->positionREP().Phi());
+      calibration_.energyEmHad(
+          -1., calibEcal, calibHcal, hclusterRef->positionREP().Eta(), hclusterRef->positionREP().Phi());
       //caloEnergy = calibEcal+calibHcal;
     }
 
@@ -2717,47 +2682,56 @@ void PFAlgo::createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBl
     // double particleEnergy = totalEcal + calibHcal;
     // particleEnergy /= (1.-0.724/sqrt(particleEnergy)-0.0226/particleEnergy);
 
-    auto& cand = (*pfCandidates_)[reconstructCluster( *hclusterRef, calibEcal+calibHcal )];
+    auto& cand = (*pfCandidates_)[reconstructCluster(*hclusterRef, calibEcal + calibHcal)];
 
-    cand.setEcalEnergy( totalEcal, calibEcal );
-    if ( !useHO_ ) {
-      cand.setHcalEnergy( totalHcal, calibHcal );
-      cand.setHoEnergy(0.,0.);
+    cand.setEcalEnergy(totalEcal, calibEcal);
+    if (!useHO_) {
+      cand.setHcalEnergy(totalHcal, calibHcal);
+      cand.setHoEnergy(0., 0.);
     } else {
-      cand.setHcalEnergy( max(totalHcal-totalHO,0.0), calibHcal*(1.-totalHO/totalHcal));
-      cand.setHoEnergy(totalHO,totalHO*calibHcal/totalHcal);
+      cand.setHcalEnergy(max(totalHcal - totalHO, 0.0), calibHcal * (1. - totalHO / totalHcal));
+      cand.setHoEnergy(totalHO, totalHO * calibHcal / totalHcal);
     }
-    cand.setPs1Energy( 0. );
-    cand.setPs2Energy( 0. );
-    cand.addElementInBlock( blockref, iHcal );
-    for (auto const& ec : ecalRefs) cand.addElementInBlock( blockref, ec );
-    for (auto const& ho : hoRefs) cand.addElementInBlock( blockref, ho );
+    cand.setPs1Energy(0.);
+    cand.setPs2Energy(0.);
+    cand.addElementInBlock(blockref, iHcal);
+    for (auto const& ec : ecalRefs)
+      cand.addElementInBlock(blockref, ec);
+    for (auto const& ho : hoRefs)
+      cand.addElementInBlock(blockref, ho);
 
-  }//loop hcal elements
+  }  //loop hcal elements
 }
 
-void PFAlgo::createCandidatesECAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea) {
-  if(debug_) std::cout << std::endl << std::endl << "---- loop ecal------- " << std::endl;
+void PFAlgo::createCandidatesECAL(const reco::PFBlock& block,
+                                  reco::PFBlock::LinkData& linkData,
+                                  const edm::OwnVector<reco::PFBlockElement>& elements,
+                                  std::vector<bool>& active,
+                                  const reco::PFBlockRef& blockref,
+                                  ElementIndices& inds,
+                                  std::vector<bool>& deadArea) {
+  if (debug_)
+    std::cout << std::endl << std::endl << "---- loop ecal------- " << std::endl;
 
   // for each ecal element iEcal = ecalIs[i] in turn:
 
-  for(unsigned i=0; i<inds.ecalIs.size(); i++) {
+  for (unsigned i = 0; i < inds.ecalIs.size(); i++) {
     unsigned iEcal = inds.ecalIs[i];
 
-    if(debug_)
-      cout<<endl<<elements[iEcal]<<" ";
+    if (debug_)
+      cout << endl << elements[iEcal] << " ";
 
-    if( ! active[iEcal] ) {
-      if(debug_)
-        cout<<"not active"<<endl;
+    if (!active[iEcal]) {
+      if (debug_)
+        cout << "not active" << endl;
       continue;
     }
 
-    PFBlockElement::Type type = elements[ iEcal ].type();
-    assert( type == PFBlockElement::ECAL );
+    PFBlockElement::Type type = elements[iEcal].type();
+    assert(type == PFBlockElement::ECAL);
 
     PFClusterRef clusterref = elements[iEcal].clusterRef();
-    assert(!clusterref.isNull() );
+    assert(!clusterref.isNull());
 
     active[iEcal] = false;
 
@@ -2765,66 +2739,57 @@ void PFAlgo::createCandidatesECAL(const reco::PFBlock &block, reco::PFBlock::Lin
     // float ecalEnergy = calibration_.energyEm( clusterref->energy() );
     double particleEnergy = ecalEnergy;
 
-    auto& cand = (*pfCandidates_)[reconstructCluster( *clusterref, particleEnergy )];
+    auto& cand = (*pfCandidates_)[reconstructCluster(*clusterref, particleEnergy)];
 
-    cand.setEcalEnergy( clusterref->energy(),ecalEnergy );
-    cand.setHcalEnergy( 0., 0. );
-    cand.setHoEnergy( 0., 0. );
-    cand.setPs1Energy( 0. );
-    cand.setPs2Energy( 0. );
-    cand.addElementInBlock( blockref, iEcal );
+    cand.setEcalEnergy(clusterref->energy(), ecalEnergy);
+    cand.setHcalEnergy(0., 0.);
+    cand.setHoEnergy(0., 0.);
+    cand.setPs1Energy(0.);
+    cand.setPs2Energy(0.);
+    cand.addElementInBlock(blockref, iEcal);
 
   }  // end loop on ecal elements iEcal = ecalIs[i]
 }
 
-void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
-                           std::list<reco::PFBlockRef>& hcalBlockRefs,
-                           std::list<reco::PFBlockRef>& ecalBlockRefs, PFEGammaFilters const* pfegamma  ) {
-
+void PFAlgo::processBlock(const reco::PFBlockRef& blockref,
+                          std::list<reco::PFBlockRef>& hcalBlockRefs,
+                          std::list<reco::PFBlockRef>& ecalBlockRefs,
+                          PFEGammaFilters const* pfegamma) {
   // debug_ = false;
-  assert(!blockref.isNull() );
+  assert(!blockref.isNull());
   const reco::PFBlock& block = *blockref;
 
-  if(debug_) {
-    cout<<"#########################################################"<<endl;
-    cout<<"#####           Process Block:                      #####"<<endl;
-    cout<<"#########################################################"<<endl;
-    cout<<block<<endl;
+  if (debug_) {
+    cout << "#########################################################" << endl;
+    cout << "#####           Process Block:                      #####" << endl;
+    cout << "#########################################################" << endl;
+    cout << block << endl;
   }
 
-
-  const edm::OwnVector< reco::PFBlockElement >& elements = block.elements();
+  const edm::OwnVector<reco::PFBlockElement>& elements = block.elements();
   // make a copy of the link data, which will be edited.
-  PFBlock::LinkData linkData =  block.linkData();
+  PFBlock::LinkData linkData = block.linkData();
 
   // keep track of the elements which are still active.
-  vector<bool>   active( elements.size(), true );
-
+  vector<bool> active(elements.size(), true);
 
   // //PFElectrons:
   // usePFElectrons_ external configurable parameter to set the usage of pf electron
   std::vector<reco::PFCandidate> tempElectronCandidates;
   tempElectronCandidates.clear();
 
-
   // New EGamma Reconstruction 10/10/2013
-  if(useEGammaFilters_) {
+  if (useEGammaFilters_) {
     egammaFilters(blockref, active, pfegamma);
-  } // end if use EGammaFilters
-
-
+  }  // end if use EGammaFilters
 
   //Lock extra conversion tracks not used by Photon Algo
-  if (usePFConversions_  ) {
+  if (usePFConversions_) {
     conversionAlgo(elements, active);
   }
 
-
-
-
-
-  if(debug_)
-    cout<<endl<<"--------------- loop 1 ------------------"<<endl;
+  if (debug_)
+    cout << endl << "--------------- loop 1 ------------------" << endl;
 
   //COLINFEB16
   // In loop 1, we loop on all elements.
@@ -2851,112 +2816,108 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
   //       - cut link to farthest hcal cluster, if more than 1.
 
   vector<bool> deadArea(elements.size(), false);
-  
+
   // vectors to store indices to ho, hcal and ecal elements
   ElementIndices inds;
 
   elementLoop(block, linkData, elements, active, blockref, inds, deadArea);
 
   // deal with HF.
-  if( !(inds.hfEmIs.empty() &&  inds.hfHadIs.empty() ) ) {
+  if (!(inds.hfEmIs.empty() && inds.hfHadIs.empty())) {
     createCandidateHF(block, blockref, elements, inds);
   }
 
   createCandidatesHCAL(block, linkData, elements, active, blockref, inds, deadArea);
   // COLINFEB16: now dealing with the HCAL elements that are not linked to any track
-  createCandidatesHCALUnlinked(block, linkData, elements, active, blockref, inds, deadArea); 
+  createCandidatesHCALUnlinked(block, linkData, elements, active, blockref, inds, deadArea);
   createCandidatesECAL(block, linkData, elements, active, blockref, inds, deadArea);
-
 
 }  // end processBlock
 
 /////////////////////////////////////////////////////////////////////
-unsigned PFAlgo::reconstructTrack( const reco::PFBlockElement& elt, bool allowLoose) {
-
+unsigned PFAlgo::reconstructTrack(const reco::PFBlockElement& elt, bool allowLoose) {
   const auto* eltTrack = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
 
   const reco::TrackRef& trackRef = eltTrack->trackRef();
   const reco::Track& track = *trackRef;
   const reco::MuonRef& muonRef = eltTrack->muonRef();
-  int charge = track.charge()>0 ? 1 : -1;
+  int charge = track.charge() > 0 ? 1 : -1;
 
   // Assume this particle is a charged Hadron
   double px = track.px();
   double py = track.py();
   double pz = track.pz();
-  double energy = sqrt(track.p()*track.p() + 0.13957*0.13957);
+  double energy = sqrt(track.p() * track.p() + 0.13957 * 0.13957);
 
-  if (debug_) cout << "Reconstructing PF candidate from track of pT = " << track.pt() << " eta = " << track.eta() << " phi = " << track.phi() << " px = " << px << " py = " << py << " pz = " << pz << " energy = " << energy << endl;
-
+  if (debug_)
+    cout << "Reconstructing PF candidate from track of pT = " << track.pt() << " eta = " << track.eta()
+         << " phi = " << track.phi() << " px = " << px << " py = " << py << " pz = " << pz << " energy = " << energy
+         << endl;
 
   // Create a PF Candidate
-  ::math::XYZTLorentzVector momentum(px,py,pz,energy);
-  reco::PFCandidate::ParticleType particleType
-    = reco::PFCandidate::h;
+  ::math::XYZTLorentzVector momentum(px, py, pz, energy);
+  reco::PFCandidate::ParticleType particleType = reco::PFCandidate::h;
 
   // Add it to the stack
-  pfCandidates_->push_back( PFCandidate( charge,
-                                         momentum,
-                                         particleType ) );
+  pfCandidates_->push_back(PFCandidate(charge, momentum, particleType));
   //Set vertex and stuff like this
-  pfCandidates_->back().setVertexSource( PFCandidate::kTrkVertex );
-  pfCandidates_->back().setTrackRef( trackRef );
-  pfCandidates_->back().setPositionAtECALEntrance( eltTrack->positionAtECALEntrance());
-  if( muonRef.isNonnull())
-    pfCandidates_->back().setMuonRef( muonRef );
-
+  pfCandidates_->back().setVertexSource(PFCandidate::kTrkVertex);
+  pfCandidates_->back().setTrackRef(trackRef);
+  pfCandidates_->back().setPositionAtECALEntrance(eltTrack->positionAtECALEntrance());
+  if (muonRef.isNonnull())
+    pfCandidates_->back().setMuonRef(muonRef);
 
   //Set time
-  if (elt.isTimeValid()) pfCandidates_->back().setTime( elt.time(), elt.timeError() );
+  if (elt.isTimeValid())
+    pfCandidates_->back().setTime(elt.time(), elt.timeError());
 
   //OK Now try to reconstruct the particle as a muon
-  bool isMuon=pfmu_->reconstructMuon(pfCandidates_->back(),muonRef,allowLoose);
+  bool isMuon = pfmu_->reconstructMuon(pfCandidates_->back(), muonRef, allowLoose);
   bool isFromDisp = isFromSecInt(elt, "secondary");
-
 
   if ((!isMuon) && isFromDisp) {
     double Dpt = trackRef->ptError();
-    double dptRel = Dpt/trackRef->pt()*100;
+    double dptRel = Dpt / trackRef->pt() * 100;
     //If the track is ill measured it is better to not refit it, since the track information probably would not be used.
     //In the PFAlgo we use the trackref information. If the track error is too big the refitted information might be very different
     // from the not refitted one.
-    if (dptRel < dptRel_DispVtx_){
+    if (dptRel < dptRel_DispVtx_) {
       if (debug_)
-	cout << "Not refitted px = " << px << " py = " << py << " pz = " << pz << " energy = " << energy << endl;
+        cout << "Not refitted px = " << px << " py = " << py << " pz = " << pz << " energy = " << energy << endl;
       //reco::TrackRef trackRef = eltTrack->trackRef();
-      reco::PFDisplacedVertexRef vRef = eltTrack->displacedVertexRef(reco::PFBlockElement::T_FROM_DISP)->displacedVertexRef();
+      reco::PFDisplacedVertexRef vRef =
+          eltTrack->displacedVertexRef(reco::PFBlockElement::T_FROM_DISP)->displacedVertexRef();
       reco::Track trackRefit = vRef->refittedTrack(trackRef);
       //change the momentum with the refitted track
-      ::math::XYZTLorentzVector momentum(trackRefit.px(),
-				       trackRefit.py(),
-				       trackRefit.pz(),
-				       sqrt(trackRefit.p()*trackRefit.p() + 0.13957*0.13957));
+      ::math::XYZTLorentzVector momentum(
+          trackRefit.px(), trackRefit.py(), trackRefit.pz(), sqrt(trackRefit.p() * trackRefit.p() + 0.13957 * 0.13957));
       if (debug_)
-	cout << "Refitted px = " << px << " py = " << py << " pz = " << pz << " energy = " << energy << endl;
+        cout << "Refitted px = " << px << " py = " << py << " pz = " << pz << " energy = " << energy << endl;
     }
-    pfCandidates_->back().setFlag( reco::PFCandidate::T_FROM_DISP, true);
-    pfCandidates_->back().setDisplacedVertexRef( eltTrack->displacedVertexRef(reco::PFBlockElement::T_FROM_DISP)->displacedVertexRef(), reco::PFCandidate::T_FROM_DISP);
+    pfCandidates_->back().setFlag(reco::PFCandidate::T_FROM_DISP, true);
+    pfCandidates_->back().setDisplacedVertexRef(
+        eltTrack->displacedVertexRef(reco::PFBlockElement::T_FROM_DISP)->displacedVertexRef(),
+        reco::PFCandidate::T_FROM_DISP);
   }
 
   // do not label as primary a track which would be recognised as a muon. A muon cannot produce NI. It is with high probability a fake
-  if(isFromSecInt(elt, "primary") && !isMuon) {
-    pfCandidates_->back().setFlag( reco::PFCandidate::T_TO_DISP, true);
-    pfCandidates_->back().setDisplacedVertexRef( eltTrack->displacedVertexRef(reco::PFBlockElement::T_TO_DISP)->displacedVertexRef(), reco::PFCandidate::T_TO_DISP);
+  if (isFromSecInt(elt, "primary") && !isMuon) {
+    pfCandidates_->back().setFlag(reco::PFCandidate::T_TO_DISP, true);
+    pfCandidates_->back().setDisplacedVertexRef(
+        eltTrack->displacedVertexRef(reco::PFBlockElement::T_TO_DISP)->displacedVertexRef(),
+        reco::PFCandidate::T_TO_DISP);
   }
 
   // returns index to the newly created PFCandidate
-  return pfCandidates_->size()-1;
+  return pfCandidates_->size() - 1;
 }
 
-
-unsigned
-PFAlgo::reconstructCluster(const reco::PFCluster& cluster,
-                           double particleEnergy,
-                           bool useDirection,
-			   double particleX,
-			   double particleY,
-			   double particleZ) {
-
+unsigned PFAlgo::reconstructCluster(const reco::PFCluster& cluster,
+                                    double particleEnergy,
+                                    bool useDirection,
+                                    double particleX,
+                                    double particleY,
+                                    double particleZ) {
   reco::PFCandidate::ParticleType particleType = reco::PFCandidate::X;
 
   // need to convert the ::math::XYZPoint data member of the PFCluster class=
@@ -2964,36 +2925,34 @@ PFAlgo::reconstructCluster(const reco::PFCluster& cluster,
 
   // Transform particleX,Y,Z to a position at ECAL/HCAL entrance
   double factor = 1.;
-  if ( useDirection ) {
-    switch( cluster.layer() ) {
-    case PFLayer::ECAL_BARREL:
-    case PFLayer::HCAL_BARREL1:
-      factor = std::sqrt(cluster.position().Perp2()/(particleX*particleX+particleY*particleY));
-      break;
-    case PFLayer::ECAL_ENDCAP:
-    case PFLayer::HCAL_ENDCAP:
-    case PFLayer::HF_HAD:
-    case PFLayer::HF_EM:
-      factor = cluster.position().Z()/particleZ;
-      break;
-    default:
-      assert(0);
+  if (useDirection) {
+    switch (cluster.layer()) {
+      case PFLayer::ECAL_BARREL:
+      case PFLayer::HCAL_BARREL1:
+        factor = std::sqrt(cluster.position().Perp2() / (particleX * particleX + particleY * particleY));
+        break;
+      case PFLayer::ECAL_ENDCAP:
+      case PFLayer::HCAL_ENDCAP:
+      case PFLayer::HF_HAD:
+      case PFLayer::HF_EM:
+        factor = cluster.position().Z() / particleZ;
+        break;
+      default:
+        assert(0);
     }
   }
   //MIKE First of all let's check if we have vertex.
   ::math::XYZPoint vertexPos;
-  if(useVertices_)
-    vertexPos = ::math::XYZPoint(primaryVertex_.x(),primaryVertex_.y(),primaryVertex_.z());
+  if (useVertices_)
+    vertexPos = ::math::XYZPoint(primaryVertex_.x(), primaryVertex_.y(), primaryVertex_.z());
   else
-    vertexPos = ::math::XYZPoint(0.0,0.0,0.0);
+    vertexPos = ::math::XYZPoint(0.0, 0.0, 0.0);
 
-
-  ::math::XYZVector clusterPos( cluster.position().X()-vertexPos.X(),
-			      cluster.position().Y()-vertexPos.Y(),
-			      cluster.position().Z()-vertexPos.Z());
-  ::math::XYZVector particleDirection ( particleX*factor-vertexPos.X(),
-				      particleY*factor-vertexPos.Y(),
-				      particleZ*factor-vertexPos.Z() );
+  ::math::XYZVector clusterPos(cluster.position().X() - vertexPos.X(),
+                               cluster.position().Y() - vertexPos.Y(),
+                               cluster.position().Z() - vertexPos.Z());
+  ::math::XYZVector particleDirection(
+      particleX * factor - vertexPos.X(), particleY * factor - vertexPos.Y(), particleZ * factor - vertexPos.Z());
 
   //::math::XYZVector clusterPos( cluster.position().X(), cluster.position().Y(),cluster.position().Z() );
   //::math::XYZVector particleDirection ( particleX, particleY, particleZ );
@@ -3005,10 +2964,10 @@ PFAlgo::reconstructCluster(const reco::PFCluster& cluster,
   // with a magnitude equal to the cluster energy.
 
   double mass = 0;
-  ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >
-    momentum( clusterPos.X(), clusterPos.Y(), clusterPos.Z(), mass);
+  ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>> momentum(
+      clusterPos.X(), clusterPos.Y(), clusterPos.Z(), mass);
   // mathcore is a piece of #$%
-  ::math::XYZTLorentzVector  tmp;
+  ::math::XYZTLorentzVector tmp;
   // implicit constructor not allowed
   tmp = momentum;
 
@@ -3016,36 +2975,32 @@ PFAlgo::reconstructCluster(const reco::PFCluster& cluster,
   int charge = 0;
 
   // Type
-  switch( cluster.layer() ) {
-  case PFLayer::ECAL_BARREL:
-  case PFLayer::ECAL_ENDCAP:
-    particleType = PFCandidate::gamma;
-    break;
-  case PFLayer::HCAL_BARREL1:
-  case PFLayer::HCAL_ENDCAP:
-    particleType = PFCandidate::h0;
-    break;
-  case PFLayer::HF_HAD:
-    particleType = PFCandidate::h_HF;
-    break;
-  case PFLayer::HF_EM:
-    particleType = PFCandidate::egamma_HF;
-    break;
-  default:
-    assert(0);
+  switch (cluster.layer()) {
+    case PFLayer::ECAL_BARREL:
+    case PFLayer::ECAL_ENDCAP:
+      particleType = PFCandidate::gamma;
+      break;
+    case PFLayer::HCAL_BARREL1:
+    case PFLayer::HCAL_ENDCAP:
+      particleType = PFCandidate::h0;
+      break;
+    case PFLayer::HF_HAD:
+      particleType = PFCandidate::h_HF;
+      break;
+    case PFLayer::HF_EM:
+      particleType = PFCandidate::egamma_HF;
+      break;
+    default:
+      assert(0);
   }
 
   // The pf candidate
-  pfCandidates_->push_back( PFCandidate( charge,
-                                         tmp,
-                                         particleType ) );
+  pfCandidates_->push_back(PFCandidate(charge, tmp, particleType));
 
   // The position at ECAL entrance (well: watch out, it is not true
   // for HCAL clusters... to be fixed)
-  pfCandidates_->back().
-    setPositionAtECALEntrance(::math::XYZPointF(cluster.position().X(),
-					      cluster.position().Y(),
-					      cluster.position().Z()));
+  pfCandidates_->back().setPositionAtECALEntrance(
+      ::math::XYZPointF(cluster.position().X(), cluster.position().Y(), cluster.position().Z()));
 
   //Set the cnadidate Vertex
   pfCandidates_->back().setVertex(vertexPos);
@@ -3055,101 +3010,91 @@ PFAlgo::reconstructCluster(const reco::PFCluster& cluster,
 
   //*TODO* cluster time is not reliable at the moment, so only use track timing
 
-  if(debug_)
-    cout<<"** candidate: "<<pfCandidates_->back()<<endl;
+  if (debug_)
+    cout << "** candidate: " << pfCandidates_->back() << endl;
 
   // returns index to the newly created PFCandidate
-  return pfCandidates_->size()-1;
-
+  return pfCandidates_->size() - 1;
 }
 
-void
-PFAlgo::setHcalDepthInfo(reco::PFCandidate & cand, const reco::PFCluster& cluster) const {
-    std::array<double,7> energyPerDepth;
-    std::fill(energyPerDepth.begin(), energyPerDepth.end(), 0.0);
-    for (auto & hitRefAndFrac : cluster.recHitFractions()) {
-        const auto & hit = *hitRefAndFrac.recHitRef();
-        if (DetId(hit.detId()).det() == DetId::Hcal) {
-            if (hit.depth() == 0) {
-                edm::LogWarning("setHcalDepthInfo") << "Depth zero found";
-                continue;
-            }
-            if (hit.depth() < 1 || hit.depth() > 7) {
-                throw cms::Exception("CorruptData") << "Bogus depth " << hit.depth() << " at detid " << hit.detId() << "\n";
-            }
-            energyPerDepth[hit.depth()-1] += hitRefAndFrac.fraction()*hit.energy();
-        }
+void PFAlgo::setHcalDepthInfo(reco::PFCandidate& cand, const reco::PFCluster& cluster) const {
+  std::array<double, 7> energyPerDepth;
+  std::fill(energyPerDepth.begin(), energyPerDepth.end(), 0.0);
+  for (auto& hitRefAndFrac : cluster.recHitFractions()) {
+    const auto& hit = *hitRefAndFrac.recHitRef();
+    if (DetId(hit.detId()).det() == DetId::Hcal) {
+      if (hit.depth() == 0) {
+        edm::LogWarning("setHcalDepthInfo") << "Depth zero found";
+        continue;
+      }
+      if (hit.depth() < 1 || hit.depth() > 7) {
+        throw cms::Exception("CorruptData") << "Bogus depth " << hit.depth() << " at detid " << hit.detId() << "\n";
+      }
+      energyPerDepth[hit.depth() - 1] += hitRefAndFrac.fraction() * hit.energy();
     }
-    double sum = std::accumulate(energyPerDepth.begin(), energyPerDepth.end(), 0.);
-    std::array<float,7> depthFractions;
-    if (sum > 0) {
-        for (unsigned int i = 0; i < depthFractions.size(); ++i) {
-            depthFractions[i] = energyPerDepth[i]/sum;
-        }
-    } else {
-        std::fill(depthFractions.begin(), depthFractions.end(), 0.f);
+  }
+  double sum = std::accumulate(energyPerDepth.begin(), energyPerDepth.end(), 0.);
+  std::array<float, 7> depthFractions;
+  if (sum > 0) {
+    for (unsigned int i = 0; i < depthFractions.size(); ++i) {
+      depthFractions[i] = energyPerDepth[i] / sum;
     }
-    cand.setHcalDepthEnergyFractions(depthFractions);
+  } else {
+    std::fill(depthFractions.begin(), depthFractions.end(), 0.f);
+  }
+  cand.setHcalDepthEnergyFractions(depthFractions);
 }
 
 //GMA need the followign two for HO also
 
-double
-PFAlgo::neutralHadronEnergyResolution(double clusterEnergyHCAL, double eta) const {
-
+double PFAlgo::neutralHadronEnergyResolution(double clusterEnergyHCAL, double eta) const {
   // Add a protection
-  if ( clusterEnergyHCAL < 1. ) clusterEnergyHCAL = 1.;
+  if (clusterEnergyHCAL < 1.)
+    clusterEnergyHCAL = 1.;
 
-  double resol =  fabs(eta) < 1.48 ?
-    sqrt (1.02*1.02/clusterEnergyHCAL + 0.065*0.065)
-    :
-    sqrt (1.20*1.20/clusterEnergyHCAL + 0.028*0.028);
+  double resol = fabs(eta) < 1.48 ? sqrt(1.02 * 1.02 / clusterEnergyHCAL + 0.065 * 0.065)
+                                  : sqrt(1.20 * 1.20 / clusterEnergyHCAL + 0.028 * 0.028);
 
   return resol;
-
 }
 
-double
-PFAlgo::nSigmaHCAL(double clusterEnergyHCAL, double eta) const {
-  double nS = fabs(eta) < 1.48 ?
-    nSigmaHCAL_ * (1. + exp(-clusterEnergyHCAL/100.))
-    :
-    nSigmaHCAL_ * (1. + exp(-clusterEnergyHCAL/100.));
+double PFAlgo::nSigmaHCAL(double clusterEnergyHCAL, double eta) const {
+  double nS = fabs(eta) < 1.48 ? nSigmaHCAL_ * (1. + exp(-clusterEnergyHCAL / 100.))
+                               : nSigmaHCAL_ * (1. + exp(-clusterEnergyHCAL / 100.));
 
   return nS;
 }
 
-
 ostream& operator<<(ostream& out, const PFAlgo& algo) {
-  if(!out ) return out;
+  if (!out)
+    return out;
 
-  out<<"====== Particle Flow Algorithm ======= ";
-  out<<endl;
-  out<<"nSigmaECAL_     "<<algo.nSigmaECAL_<<endl;
-  out<<"nSigmaHCAL_     "<<algo.nSigmaHCAL_<<endl;
-  out<<endl;
-  out<<algo.calibration_<<endl;
-  out<<endl;
-  out<<"reconstructed particles: "<<endl;
+  out << "====== Particle Flow Algorithm ======= ";
+  out << endl;
+  out << "nSigmaECAL_     " << algo.nSigmaECAL_ << endl;
+  out << "nSigmaHCAL_     " << algo.nSigmaHCAL_ << endl;
+  out << endl;
+  out << algo.calibration_ << endl;
+  out << endl;
+  out << "reconstructed particles: " << endl;
 
-  if(!algo.pfCandidates_.get() ) {
-    out<<"candidates already transfered"<<endl;
+  if (!algo.pfCandidates_.get()) {
+    out << "candidates already transfered" << endl;
     return out;
   }
-  for(auto const& c : *algo.pfCandidates_) out << c << endl;
+  for (auto const& c : *algo.pfCandidates_)
+    out << c << endl;
 
   return out;
 }
 
-void
-PFAlgo::associatePSClusters(unsigned iEcal,
-			    reco::PFBlockElement::Type psElementType,
-			    const reco::PFBlock& block,
-			    const edm::OwnVector< reco::PFBlockElement >& elements,
-			    const reco::PFBlock::LinkData& linkData,
-			    std::vector<bool>& active,
-			    std::vector<double>& psEne) {
-
+void PFAlgo::associatePSClusters(unsigned iEcal,
+                                 reco::PFBlockElement::Type psElementType,
+                                 const reco::PFBlock& block,
+                                 const edm::OwnVector<reco::PFBlockElement>& elements,
+                                 const reco::PFBlock::LinkData& linkData,
+                                 std::vector<bool>& active,
+                                 std::vector<double>& psEne) {
   // Find all PS clusters with type psElement associated to ECAL cluster iEcal,
   // within all PFBlockElement "elements" of a given PFBlock "block"
   // psElement can be reco::PFBlockElement::PS1 or reco::PFBlockElement::PS2
@@ -3157,47 +3102,38 @@ PFAlgo::associatePSClusters(unsigned iEcal,
 
   // Find all PS clusters linked to the iEcal cluster
   std::multimap<double, unsigned> sortedPS;
-  block.associatedElements( iEcal,  linkData,
-			    sortedPS, psElementType,
-			    reco::PFBlock::LINKTEST_ALL );
+  block.associatedElements(iEcal, linkData, sortedPS, psElementType, reco::PFBlock::LINKTEST_ALL);
 
   // Loop over these PS clusters
   double totalPS = 0.;
-  for(auto const& ps : sortedPS) {
-
+  for (auto const& ps : sortedPS) {
     // CLuster index and distance to iEcal
     unsigned iPS = ps.second;
     // double distPS = ps.first;
 
     // Ignore clusters already in use
-    if (!active[iPS]) continue;
+    if (!active[iPS])
+      continue;
 
     // Check that this cluster is not closer to another ECAL cluster
     std::multimap<double, unsigned> sortedECAL;
-    block.associatedElements( iPS,  linkData,
-			      sortedECAL,
-			      reco::PFBlockElement::ECAL,
-			      reco::PFBlock::LINKTEST_ALL );
+    block.associatedElements(iPS, linkData, sortedECAL, reco::PFBlockElement::ECAL, reco::PFBlock::LINKTEST_ALL);
     unsigned jEcal = sortedECAL.begin()->second;
-    if ( jEcal != iEcal ) continue;
+    if (jEcal != iEcal)
+      continue;
 
     // Update PS energy
-    PFBlockElement::Type pstype = elements[ iPS ].type();
-    assert( pstype == psElementType );
+    PFBlockElement::Type pstype = elements[iPS].type();
+    assert(pstype == psElementType);
     PFClusterRef psclusterref = elements[iPS].clusterRef();
-    assert(!psclusterref.isNull() );
+    assert(!psclusterref.isNull());
     totalPS += psclusterref->energy();
     psEne[0] += psclusterref->energy();
     active[iPS] = false;
   }
-
-
 }
 
-
-bool
-PFAlgo::isFromSecInt(const reco::PFBlockElement& eTrack, string order) const {
-
+bool PFAlgo::isFromSecInt(const reco::PFBlockElement& eTrack, string order) const {
   reco::PFBlockElement::TrackType T_TO_DISP = reco::PFBlockElement::T_TO_DISP;
   reco::PFBlockElement::TrackType T_FROM_DISP = reco::PFBlockElement::T_FROM_DISP;
   //  reco::PFBlockElement::TrackType T_FROM_GAMMACONV = reco::PFBlockElement::T_FROM_GAMMACONV;
@@ -3210,41 +3146,38 @@ PFAlgo::isFromSecInt(const reco::PFBlockElement& eTrack, string order) const {
   bool isToDisp = usePFNuclearInteractions_ && eTrack.trackType(T_TO_DISP);
   bool isFromDisp = usePFNuclearInteractions_ && eTrack.trackType(T_FROM_DISP);
 
-  if (bPrimary && isToDisp) return true;
-  if (bSecondary && isFromDisp ) return true;
-  if (bAll && ( isToDisp || isFromDisp ) ) return true;
+  if (bPrimary && isToDisp)
+    return true;
+  if (bSecondary && isFromDisp)
+    return true;
+  if (bAll && (isToDisp || isFromDisp))
+    return true;
 
-//   bool isFromConv = usePFConversions_ && eTrack.trackType(T_FROM_GAMMACONV);
+  //   bool isFromConv = usePFConversions_ && eTrack.trackType(T_FROM_GAMMACONV);
 
-//   if ((bAll || bSecondary)&& isFromConv) return true;
+  //   if ((bAll || bSecondary)&& isFromConv) return true;
 
   bool isFromDecay = (bAll || bSecondary) && usePFDecays_ && eTrack.trackType(T_FROM_V0);
 
   return isFromDecay;
-
-
 }
 
-
-void
-PFAlgo::postCleaning() {
-
+void PFAlgo::postCleaning() {
   //Compute met and met significance (met/sqrt(SumEt))
   double metX = 0.;
   double metY = 0.;
   double sumet = 0;
   std::vector<unsigned int> pfCandidatesToBeRemoved;
-  for(auto const& pfc : *pfCandidates_) {
+  for (auto const& pfc : *pfCandidates_) {
     metX += pfc.px();
     metY += pfc.py();
     sumet += pfc.pt();
   }
-  double met2 = metX*metX+metY*metY;
+  double met2 = metX * metX + metY * metY;
   // Select events with large MET significance.
-  double significance = std::sqrt(met2/sumet);
+  double significance = std::sqrt(met2 / sumet);
   double significanceCor = significance;
-  if ( significance > minSignificance_ ) {
-
+  if (significance > minSignificance_) {
     double metXCor = metX;
     double metYCor = metY;
     double sumetCor = sumet;
@@ -3255,94 +3188,92 @@ PFAlgo::postCleaning() {
     unsigned iCor = 1E9;
 
     // Find the HF candidate with the largest effect on the MET
-    while ( next ) {
-
+    while (next) {
       double metReduc = -1.;
       // Loop on the candidates
-      for(unsigned i=0; i<pfCandidates_->size(); ++i) {
-	const PFCandidate& pfc = (*pfCandidates_)[i];
+      for (unsigned i = 0; i < pfCandidates_->size(); ++i) {
+        const PFCandidate& pfc = (*pfCandidates_)[i];
 
-	// Check that the pfCandidate is in the HF
-	if ( pfc.particleId() != reco::PFCandidate::h_HF &&
-	     pfc.particleId() != reco::PFCandidate::egamma_HF ) continue;
+        // Check that the pfCandidate is in the HF
+        if (pfc.particleId() != reco::PFCandidate::h_HF && pfc.particleId() != reco::PFCandidate::egamma_HF)
+          continue;
 
-	// Check if has meaningful pt
-	if ( pfc.pt() < minHFCleaningPt_ ) continue;
+        // Check if has meaningful pt
+        if (pfc.pt() < minHFCleaningPt_)
+          continue;
 
-	// Check that it is  not already scheculed to be cleaned
-    const bool skip = std::any_of(pfCandidatesToBeRemoved.begin(), pfCandidatesToBeRemoved.end(),
-            [&](unsigned int j){ return i == j; });
-	if ( skip ) continue;
+        // Check that it is  not already scheculed to be cleaned
+        const bool skip = std::any_of(
+            pfCandidatesToBeRemoved.begin(), pfCandidatesToBeRemoved.end(), [&](unsigned int j) { return i == j; });
+        if (skip)
+          continue;
 
-	// Check that the pt and the MET are aligned
-	deltaPhi = std::acos((metX*pfc.px()+metY*pfc.py())/(pfc.pt()*std::sqrt(met2)));
-	deltaPhiPt = deltaPhi*pfc.pt();
-	if ( deltaPhiPt > maxDeltaPhiPt_ ) continue;
+        // Check that the pt and the MET are aligned
+        deltaPhi = std::acos((metX * pfc.px() + metY * pfc.py()) / (pfc.pt() * std::sqrt(met2)));
+        deltaPhiPt = deltaPhi * pfc.pt();
+        if (deltaPhiPt > maxDeltaPhiPt_)
+          continue;
 
-	// Now remove the candidate from the MET
-	double metXInt = metX - pfc.px();
-	double metYInt = metY - pfc.py();
-	double sumetInt = sumet - pfc.pt();
-	double met2Int = metXInt*metXInt+metYInt*metYInt;
-	if ( met2Int < met2Cor ) {
-	  metXCor = metXInt;
-	  metYCor = metYInt;
-	  metReduc = (met2-met2Int)/met2Int;
-	  met2Cor = met2Int;
-	  sumetCor = sumetInt;
-	  significanceCor = std::sqrt(met2Cor/sumetCor);
-	  iCor = i;
-	}
+        // Now remove the candidate from the MET
+        double metXInt = metX - pfc.px();
+        double metYInt = metY - pfc.py();
+        double sumetInt = sumet - pfc.pt();
+        double met2Int = metXInt * metXInt + metYInt * metYInt;
+        if (met2Int < met2Cor) {
+          metXCor = metXInt;
+          metYCor = metYInt;
+          metReduc = (met2 - met2Int) / met2Int;
+          met2Cor = met2Int;
+          sumetCor = sumetInt;
+          significanceCor = std::sqrt(met2Cor / sumetCor);
+          iCor = i;
+        }
       }
       //
       // If the MET must be significanly reduced, schedule the candidate to be cleaned
-      if ( metReduc > minDeltaMet_ ) {
-	pfCandidatesToBeRemoved.push_back(iCor);
-	metX = metXCor;
-	metY = metYCor;
-	sumet = sumetCor;
-	met2 = met2Cor;
+      if (metReduc > minDeltaMet_) {
+        pfCandidatesToBeRemoved.push_back(iCor);
+        metX = metXCor;
+        metY = metYCor;
+        sumet = sumetCor;
+        met2 = met2Cor;
       } else {
-      // Otherwise just stop the loop
-	next = false;
+        // Otherwise just stop the loop
+        next = false;
       }
     }
     //
     // The significance must be significantly reduced to indeed clean the candidates
-    if ( significance - significanceCor > minSignificanceReduction_ &&
-	 significanceCor < maxSignificance_ ) {
-      std::cout << "Significance reduction = " << significance << " -> "
-		<< significanceCor << " = " << significanceCor - significance
-		<< std::endl;
-      for(unsigned int toRemove : pfCandidatesToBeRemoved) {
-	std::cout << "Removed : " << (*pfCandidates_)[toRemove] << std::endl;
-	pfCleanedCandidates_.push_back( (*pfCandidates_)[toRemove] );
-	(*pfCandidates_)[toRemove].rescaleMomentum(1E-6);
-	//reco::PFCandidate::ParticleType unknown = reco::PFCandidate::X;
-	//(*pfCandidates_)[toRemove].setParticleType(unknown);
+    if (significance - significanceCor > minSignificanceReduction_ && significanceCor < maxSignificance_) {
+      std::cout << "Significance reduction = " << significance << " -> " << significanceCor << " = "
+                << significanceCor - significance << std::endl;
+      for (unsigned int toRemove : pfCandidatesToBeRemoved) {
+        std::cout << "Removed : " << (*pfCandidates_)[toRemove] << std::endl;
+        pfCleanedCandidates_.push_back((*pfCandidates_)[toRemove]);
+        (*pfCandidates_)[toRemove].rescaleMomentum(1E-6);
+        //reco::PFCandidate::ParticleType unknown = reco::PFCandidate::X;
+        //(*pfCandidates_)[toRemove].setParticleType(unknown);
       }
     }
   }
 }
 
-void
-PFAlgo::checkCleaning( const reco::PFRecHitCollection& cleanedHits ) {
-
-
+void PFAlgo::checkCleaning(const reco::PFRecHitCollection& cleanedHits) {
   // No hits to recover, leave.
-  if ( cleanedHits.empty() ) return;
+  if (cleanedHits.empty())
+    return;
 
   //Compute met and met significance (met/sqrt(SumEt))
   double metX = 0.;
   double metY = 0.;
   double sumet = 0;
   std::vector<unsigned int> hitsToBeAdded;
-  for(auto const& pfc : *pfCandidates_) {
+  for (auto const& pfc : *pfCandidates_) {
     metX += pfc.px();
     metY += pfc.py();
     sumet += pfc.pt();
   }
-  double met2 = metX*metX+metY*metY;
+  double met2 = metX * metX + metY * metY;
   double met2_Original = met2;
   // Select events with large MET significance.
   // double significance = std::sqrt(met2/sumet);
@@ -3355,46 +3286,48 @@ PFAlgo::checkCleaning( const reco::PFRecHitCollection& cleanedHits ) {
   unsigned iCor = 1E9;
 
   // Find the cleaned hit with the largest effect on the MET
-  while ( next ) {
-
+  while (next) {
     double metReduc = -1.;
     // Loop on the candidates
-    for(unsigned i=0; i<cleanedHits.size(); ++i) {
+    for (unsigned i = 0; i < cleanedHits.size(); ++i) {
       const PFRecHit& hit = cleanedHits[i];
       double length = std::sqrt(hit.position().mag2());
-      double px = hit.energy() * hit.position().x()/length;
-      double py = hit.energy() * hit.position().y()/length;
-      double pt = std::sqrt(px*px + py*py);
+      double px = hit.energy() * hit.position().x() / length;
+      double py = hit.energy() * hit.position().y() / length;
+      double pt = std::sqrt(px * px + py * py);
 
       // Check that it is  not already scheculed to be cleaned
       bool skip = false;
-      for(unsigned int hitIdx : hitsToBeAdded) {
-	if ( i == hitIdx ) skip = true;
-	if ( skip ) break;
+      for (unsigned int hitIdx : hitsToBeAdded) {
+        if (i == hitIdx)
+          skip = true;
+        if (skip)
+          break;
       }
-      if ( skip ) continue;
+      if (skip)
+        continue;
 
       // Now add the candidate to the MET
       double metXInt = metX + px;
       double metYInt = metY + py;
       double sumetInt = sumet + pt;
-      double met2Int = metXInt*metXInt+metYInt*metYInt;
+      double met2Int = metXInt * metXInt + metYInt * metYInt;
 
       // And check if it could contribute to a MET reduction
-      if ( met2Int < met2Cor ) {
-	metXCor = metXInt;
-	metYCor = metYInt;
-	metReduc = (met2-met2Int)/met2Int;
-	met2Cor = met2Int;
-	sumetCor = sumetInt;
-	// significanceCor = std::sqrt(met2Cor/sumetCor);
-	iCor = i;
+      if (met2Int < met2Cor) {
+        metXCor = metXInt;
+        metYCor = metYInt;
+        metReduc = (met2 - met2Int) / met2Int;
+        met2Cor = met2Int;
+        sumetCor = sumetInt;
+        // significanceCor = std::sqrt(met2Cor/sumetCor);
+        iCor = i;
       }
     }
     //
     // If the MET must be significanly reduced, schedule the candidate to be added
     //
-    if ( metReduc > minDeltaMet_ ) {
+    if (metReduc > minDeltaMet_) {
       hitsToBeAdded.push_back(iCor);
       metX = metXCor;
       metY = metYCor;
@@ -3407,23 +3340,20 @@ PFAlgo::checkCleaning( const reco::PFRecHitCollection& cleanedHits ) {
   }
   //
   // At least 10 GeV MET reduction
-  if ( std::sqrt(met2_Original) - std::sqrt(met2) > 5. ) {
-    if ( debug_ ) {
+  if (std::sqrt(met2_Original) - std::sqrt(met2) > 5.) {
+    if (debug_) {
       std::cout << hitsToBeAdded.size() << " hits were re-added " << std::endl;
-      std::cout << "MET reduction = " << std::sqrt(met2_Original) << " -> "
-		<< std::sqrt(met2Cor) << " = " <<  std::sqrt(met2Cor) - std::sqrt(met2_Original)
-		<< std::endl;
+      std::cout << "MET reduction = " << std::sqrt(met2_Original) << " -> " << std::sqrt(met2Cor) << " = "
+                << std::sqrt(met2Cor) - std::sqrt(met2_Original) << std::endl;
       std::cout << "Added after cleaning check : " << std::endl;
     }
-    for(unsigned int hitIdx : hitsToBeAdded) {
+    for (unsigned int hitIdx : hitsToBeAdded) {
       const PFRecHit& hit = cleanedHits[hitIdx];
-      PFCluster cluster(hit.layer(), hit.energy(),
-			hit.position().x(), hit.position().y(), hit.position().z() );
-      reconstructCluster(cluster,hit.energy());
-      if ( debug_ ) {
-	std::cout << pfCandidates_->back() << ". time = " << hit.time() << std::endl;
+      PFCluster cluster(hit.layer(), hit.energy(), hit.position().x(), hit.position().y(), hit.position().z());
+      reconstructCluster(cluster, hit.energy());
+      if (debug_) {
+        std::cout << pfCandidates_->back() << ". time = " << hit.time() << std::endl;
       }
     }
   }
-
 }

--- a/RecoParticleFlow/PFProducer/src/PFCandConnector.cc
+++ b/RecoParticleFlow/PFProducer/src/PFCandConnector.cc
@@ -1,9 +1,9 @@
 #include "RecoParticleFlow/PFProducer/interface/PFCandConnector.h"
-#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h" 
-#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h" 
-#include "DataFormats/ParticleFlowReco/interface/PFBlock.h" 
-#include "DataFormats/GsfTrackReco/interface/GsfTrack.h" 
-#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace reco;
 using namespace std;
@@ -13,46 +13,55 @@ const double PFCandConnector::pion_mass2 = 0.0194;
 const reco::PFCandidate::Flags PFCandConnector::fT_TO_DISP_ = PFCandidate::T_TO_DISP;
 const reco::PFCandidate::Flags PFCandConnector::fT_FROM_DISP_ = PFCandidate::T_FROM_DISP;
 
-void PFCandConnector::setParameters(bool bCorrect, bool bCalibPrimary, double dptRel_PrimaryTrack, double dptRel_MergedTrack, double ptErrorSecondary, const std::vector<double>& nuclCalibFactors){
+void PFCandConnector::setParameters(bool bCorrect,
+                                    bool bCalibPrimary,
+                                    double dptRel_PrimaryTrack,
+                                    double dptRel_MergedTrack,
+                                    double ptErrorSecondary,
+                                    const std::vector<double>& nuclCalibFactors) {
+  bCorrect_ = bCorrect;
+  bCalibPrimary_ = bCalibPrimary;
+  dptRel_PrimaryTrack_ = dptRel_PrimaryTrack;
+  dptRel_MergedTrack_ = dptRel_MergedTrack;
+  ptErrorSecondary_ = ptErrorSecondary;
 
-	 bCorrect_ = bCorrect;
-	 bCalibPrimary_ =  bCalibPrimary;
-	 dptRel_PrimaryTrack_ = dptRel_PrimaryTrack;
-	 dptRel_MergedTrack_ = 	dptRel_MergedTrack;
-	 ptErrorSecondary_ = ptErrorSecondary;
+  if (nuclCalibFactors.size() == 5) {
+    fConst_[0] = nuclCalibFactors[0];
+    fConst_[1] = nuclCalibFactors[1];
 
-	 if (nuclCalibFactors.size() == 5) {
-	   fConst_[0] =  nuclCalibFactors[0]; 
-	   fConst_[1] =  nuclCalibFactors[1]; 
-	   
-	   fNorm_[0] = nuclCalibFactors[2]; 
-	   fNorm_[1] = nuclCalibFactors[3]; 
-	   
-	   fExp_[0] = nuclCalibFactors[4];
-	 } else {
-	   edm::LogWarning("PFCandConnector") << "Wrong calibration factors for nuclear interactions. The calibration procedure would not be applyed." << std::endl;
-	   bCalibPrimary_ =  false;
-	 }
+    fNorm_[0] = nuclCalibFactors[2];
+    fNorm_[1] = nuclCalibFactors[3];
 
-	 std::string sCorrect = bCorrect_ ? "On" : "Off";
-	 edm::LogInfo("PFCandConnector")  << " ====================== The PFCandConnector is switched " << sCorrect.c_str() << " ==================== " << std::endl;
-	 std::string sCalibPrimary = bCalibPrimary_ ? "used for calibration" : "not used for calibration";
-	 if (bCorrect_) edm::LogInfo("PFCandConnector")  << "Primary Tracks are " << sCalibPrimary.c_str() << std::endl;
-	 if (bCorrect_ && bCalibPrimary_) edm::LogInfo("PFCandConnector") << "Under the condition that the precision on the Primary track is better than " << dptRel_PrimaryTrack_ << " % "<< std::endl;
-	 if (bCorrect_ && bCalibPrimary_) edm::LogInfo("PFCandConnector") << "      and on merged tracks better than " <<  dptRel_MergedTrack_ << " % "<< std::endl;
-	 if (bCorrect_ && bCalibPrimary_) edm::LogInfo("PFCandConnector") << "      and secondary tracks in some cases more precise than " << ptErrorSecondary_ << " GeV"<< std::endl;
-	 if (bCorrect_ && bCalibPrimary_) edm::LogInfo("PFCandConnector") << "factor = (" << fConst_[0] << " + " << fConst_[1] << "*cFrac) - (" 
-				       << fNorm_[0] << " - " << fNorm_[1] << "cFrac)*exp( "
-				       << -1*fExp_[0] << "*pT )"<< std::endl;
-	 edm::LogInfo("PFCandConnector") << " =========================================================== " << std::endl;	 
+    fExp_[0] = nuclCalibFactors[4];
+  } else {
+    edm::LogWarning("PFCandConnector")
+        << "Wrong calibration factors for nuclear interactions. The calibration procedure would not be applyed."
+        << std::endl;
+    bCalibPrimary_ = false;
+  }
 
-       }
+  std::string sCorrect = bCorrect_ ? "On" : "Off";
+  edm::LogInfo("PFCandConnector") << " ====================== The PFCandConnector is switched " << sCorrect.c_str()
+                                  << " ==================== " << std::endl;
+  std::string sCalibPrimary = bCalibPrimary_ ? "used for calibration" : "not used for calibration";
+  if (bCorrect_)
+    edm::LogInfo("PFCandConnector") << "Primary Tracks are " << sCalibPrimary.c_str() << std::endl;
+  if (bCorrect_ && bCalibPrimary_)
+    edm::LogInfo("PFCandConnector") << "Under the condition that the precision on the Primary track is better than "
+                                    << dptRel_PrimaryTrack_ << " % " << std::endl;
+  if (bCorrect_ && bCalibPrimary_)
+    edm::LogInfo("PFCandConnector") << "      and on merged tracks better than " << dptRel_MergedTrack_ << " % "
+                                    << std::endl;
+  if (bCorrect_ && bCalibPrimary_)
+    edm::LogInfo("PFCandConnector") << "      and secondary tracks in some cases more precise than "
+                                    << ptErrorSecondary_ << " GeV" << std::endl;
+  if (bCorrect_ && bCalibPrimary_)
+    edm::LogInfo("PFCandConnector") << "factor = (" << fConst_[0] << " + " << fConst_[1] << "*cFrac) - (" << fNorm_[0]
+                                    << " - " << fNorm_[1] << "cFrac)*exp( " << -1 * fExp_[0] << "*pT )" << std::endl;
+  edm::LogInfo("PFCandConnector") << " =========================================================== " << std::endl;
+}
 
-
-
-reco::PFCandidateCollection
-PFCandConnector::connect(PFCandidateCollection& pfCand) const {
-   
+reco::PFCandidateCollection PFCandConnector::connect(PFCandidateCollection& pfCand) const {
   /// Collection of primary PFCandidates to be transmitted to the Event
   PFCandidateCollection pfC{};
   /// A mask to define the candidates which shall not be transmitted
@@ -62,101 +71,93 @@ PFCandConnector::connect(PFCandidateCollection& pfCand) const {
   // debug_ = true;
 
   // loop on primary
-  if (bCorrect_){
-    if(debug_){
+  if (bCorrect_) {
+    if (debug_) {
       cout << "" << endl;
       cout << "==================== ------------------------------ ===============" << endl;
       cout << "====================         Cand Connector         ===============" << endl;
       cout << "==================== ------------------------------ ===============" << endl;
-      cout << "====================   \tfor " <<  pfCand.size() << " Candidates\t  =============" << endl; 
+      cout << "====================   \tfor " << pfCand.size() << " Candidates\t  =============" << endl;
       cout << "==================== primary calibrated " << bCalibPrimary_ << "     =============" << endl;
     }
 
-    for( unsigned int ce1=0; ce1 < pfCand.size(); ++ce1){
-      if ( isPrimaryNucl(pfCand.at(ce1)) ){
+    for (unsigned int ce1 = 0; ce1 < pfCand.size(); ++ce1) {
+      if (isPrimaryNucl(pfCand.at(ce1))) {
+        if (debug_)
+          cout << "" << endl
+               << "Nuclear Interaction w Primary Candidate " << ce1 << " " << pfCand.at(ce1) << endl
+               << " based on the Track " << pfCand.at(ce1).trackRef().key()
+               << " w pT = " << pfCand.at(ce1).trackRef()->pt() << " #pm "
+               << pfCand.at(ce1).trackRef()->ptError() / pfCand.at(ce1).trackRef()->pt() * 100 << " %"
+               << " ECAL = " << pfCand.at(ce1).ecalEnergy() << " HCAL = " << pfCand.at(ce1).hcalEnergy() << endl;
 
-	if (debug_) 
-	  cout << "" << endl << "Nuclear Interaction w Primary Candidate " << ce1 
-	       << " " << pfCand.at(ce1) << endl
-	       << " based on the Track " << pfCand.at(ce1).trackRef().key()
-	       << " w pT = " << pfCand.at(ce1).trackRef()->pt()
-	       << " #pm " << pfCand.at(ce1).trackRef()->ptError()/pfCand.at(ce1).trackRef()->pt()*100 << " %" 
-	       << " ECAL = " << pfCand.at(ce1).ecalEnergy() 
-	       << " HCAL = " << pfCand.at(ce1).hcalEnergy() << endl;
+        if (debug_)
+          (pfCand.at(ce1)).displacedVertexRef(fT_TO_DISP_)->Dump();
 
-	if (debug_) (pfCand.at(ce1)).displacedVertexRef(fT_TO_DISP_)->Dump();
+        analyseNuclearWPrim(pfCand, bMask, ce1);
 
-	analyseNuclearWPrim(pfCand, bMask, ce1);
-	    
-	if (debug_){
-	  cout << "After Connection the candidate " << ce1 
-	       << " is " << pfCand.at(ce1) << endl << endl;
-	  
-	  PFCandidate::ElementsInBlocks elementsInBlocks = pfCand.at(ce1).elementsInBlocks();
-	  for (unsigned blockElem = 0; blockElem < elementsInBlocks.size(); blockElem++){
-	    if (blockElem == 0) cout << *(elementsInBlocks[blockElem].first) << endl;  
-	    cout << " position " << elementsInBlocks[blockElem].second;
-	  }	    
-	}
+        if (debug_) {
+          cout << "After Connection the candidate " << ce1 << " is " << pfCand.at(ce1) << endl << endl;
 
+          PFCandidate::ElementsInBlocks elementsInBlocks = pfCand.at(ce1).elementsInBlocks();
+          for (unsigned blockElem = 0; blockElem < elementsInBlocks.size(); blockElem++) {
+            if (blockElem == 0)
+              cout << *(elementsInBlocks[blockElem].first) << endl;
+            cout << " position " << elementsInBlocks[blockElem].second;
+          }
+        }
       }
-
     }
 
-    for( unsigned int ce1=0; ce1 < pfCand.size(); ++ce1){
-      if ( !bMask[ce1] && isSecondaryNucl(pfCand.at(ce1)) ){
-	if (debug_) 
-	  cout << "" << endl << "Nuclear Interaction w no Primary Candidate " << ce1 
-	       << " " << pfCand.at(ce1) << endl
-	       << " based on the Track " << pfCand.at(ce1).trackRef().key()
-	       << " w pT = " << pfCand.at(ce1).trackRef()->pt()
-	       << " #pm " << pfCand.at(ce1).trackRef()->ptError() << " %" 
-	       << " ECAL = " << pfCand.at(ce1).ecalEnergy() 
-	       << " HCAL = " << pfCand.at(ce1).hcalEnergy() 
-	       << " dE(Trk-CALO) = " << pfCand.at(ce1).trackRef()->p()-pfCand.at(ce1).ecalEnergy()-pfCand.at(ce1).hcalEnergy() 
-	       << " Nmissing hits = " << pfCand.at(ce1).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS) << endl;
+    for (unsigned int ce1 = 0; ce1 < pfCand.size(); ++ce1) {
+      if (!bMask[ce1] && isSecondaryNucl(pfCand.at(ce1))) {
+        if (debug_)
+          cout << "" << endl
+               << "Nuclear Interaction w no Primary Candidate " << ce1 << " " << pfCand.at(ce1) << endl
+               << " based on the Track " << pfCand.at(ce1).trackRef().key()
+               << " w pT = " << pfCand.at(ce1).trackRef()->pt() << " #pm " << pfCand.at(ce1).trackRef()->ptError()
+               << " %"
+               << " ECAL = " << pfCand.at(ce1).ecalEnergy() << " HCAL = " << pfCand.at(ce1).hcalEnergy()
+               << " dE(Trk-CALO) = "
+               << pfCand.at(ce1).trackRef()->p() - pfCand.at(ce1).ecalEnergy() - pfCand.at(ce1).hcalEnergy()
+               << " Nmissing hits = "
+               << pfCand.at(ce1).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS)
+               << endl;
 
-	if (debug_) (pfCand.at(ce1)).displacedVertexRef(fT_FROM_DISP_)->Dump();
-		
-	analyseNuclearWSec(pfCand, bMask, ce1);
-	
-	if (debug_) {
-	  cout << "After Connection the candidate " << ce1 
-	       << " is " << pfCand.at(ce1)
-	       << " and elements connected to it are: " << endl;
-	  
-	  PFCandidate::ElementsInBlocks elementsInBlocks = pfCand.at(ce1).elementsInBlocks();
-	  for (unsigned blockElem = 0; blockElem < elementsInBlocks.size(); blockElem++){
-	    if (blockElem == 0) cout << *(elementsInBlocks[blockElem].first) << endl;  
-	    cout << " position " << elementsInBlocks[blockElem].second;
-	  }	    
-	}
+        if (debug_)
+          (pfCand.at(ce1)).displacedVertexRef(fT_FROM_DISP_)->Dump();
 
+        analyseNuclearWSec(pfCand, bMask, ce1);
+
+        if (debug_) {
+          cout << "After Connection the candidate " << ce1 << " is " << pfCand.at(ce1)
+               << " and elements connected to it are: " << endl;
+
+          PFCandidate::ElementsInBlocks elementsInBlocks = pfCand.at(ce1).elementsInBlocks();
+          for (unsigned blockElem = 0; blockElem < elementsInBlocks.size(); blockElem++) {
+            if (blockElem == 0)
+              cout << *(elementsInBlocks[blockElem].first) << endl;
+            cout << " position " << elementsInBlocks[blockElem].second;
+          }
+        }
       }
-
-
     }
-  }   
-  
+  }
 
-    
+  for (unsigned int ce1 = 0; ce1 < pfCand.size(); ++ce1)
+    if (!bMask[ce1])
+      pfC.push_back(pfCand.at(ce1));
 
-  for( unsigned int ce1=0; ce1 < pfCand.size(); ++ce1)
-    if (!bMask[ce1]) pfC.push_back(pfCand.at(ce1));
+  if (debug_ && bCorrect_)
+    cout << "==================== ------------------------------ ===============" << endl << endl << endl;
 
-
-  if(debug_ && bCorrect_) cout << "==================== ------------------------------ ===============" << endl<< endl << endl;
-   
   return pfC;
-
-
 }
 
-void 
-PFCandConnector::analyseNuclearWPrim(PFCandidateCollection& pfCand, std::vector<bool> & bMask, unsigned int ce1) const {
-
-
-  PFDisplacedVertexRef ref1, ref2, ref1_bis;  
+void PFCandConnector::analyseNuclearWPrim(PFCandidateCollection& pfCand,
+                                          std::vector<bool>& bMask,
+                                          unsigned int ce1) const {
+  PFDisplacedVertexRef ref1, ref2, ref1_bis;
 
   PFCandidate primaryCand = pfCand.at(ce1);
 
@@ -166,296 +167,307 @@ PFCandConnector::analyseNuclearWPrim(PFCandidateCollection& pfCand, std::vector<
 
   math::XYZTLorentzVectorD momentumSec;
 
-  momentumSec = momentumPrim/momentumPrim.E()*(primaryCand.ecalEnergy() + primaryCand.hcalEnergy());
+  momentumSec = momentumPrim / momentumPrim.E() * (primaryCand.ecalEnergy() + primaryCand.hcalEnergy());
 
   map<double, math::XYZTLorentzVectorD> candidatesWithTrackExcess;
   map<double, math::XYZTLorentzVectorD> candidatesWithoutCalo;
-  
-    
+
   ref1 = primaryCand.displacedVertexRef(fT_TO_DISP_);
-  
-  for( unsigned int ce2=0; ce2 < pfCand.size(); ++ce2) {
-    if (ce2 != ce1 && isSecondaryNucl(pfCand.at(ce2))){
-      
+
+  for (unsigned int ce2 = 0; ce2 < pfCand.size(); ++ce2) {
+    if (ce2 != ce1 && isSecondaryNucl(pfCand.at(ce2))) {
       ref2 = (pfCand.at(ce2)).displacedVertexRef(fT_FROM_DISP_);
-      
+
       if (ref1 == ref2) {
-	
-	if (debug_) cout << "\t here is a Secondary Candidate " << ce2  
-			 << " " << pfCand.at(ce2) << endl
-			 << "\t based on the Track " << pfCand.at(ce2).trackRef().key()
-			 << " w p = " << pfCand.at(ce2).trackRef()->p()
-			 << " w pT = " << pfCand.at(ce2).trackRef()->pt()
-			 << " #pm " << pfCand.at(ce2).trackRef()->ptError() << " %"
-			 << " ECAL = " << pfCand.at(ce2).ecalEnergy() 
-			 << " HCAL = " << pfCand.at(ce2).hcalEnergy() 
-			 << " dE(Trk-CALO) = " << pfCand.at(ce2).trackRef()->p()-pfCand.at(ce2).ecalEnergy()-pfCand.at(ce2).hcalEnergy() 
-			 << " Nmissing hits = " << pfCand.at(ce2).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS) << endl;
+        if (debug_)
+          cout << "\t here is a Secondary Candidate " << ce2 << " " << pfCand.at(ce2) << endl
+               << "\t based on the Track " << pfCand.at(ce2).trackRef().key()
+               << " w p = " << pfCand.at(ce2).trackRef()->p() << " w pT = " << pfCand.at(ce2).trackRef()->pt()
+               << " #pm " << pfCand.at(ce2).trackRef()->ptError() << " %"
+               << " ECAL = " << pfCand.at(ce2).ecalEnergy() << " HCAL = " << pfCand.at(ce2).hcalEnergy()
+               << " dE(Trk-CALO) = "
+               << pfCand.at(ce2).trackRef()->p() - pfCand.at(ce2).ecalEnergy() - pfCand.at(ce2).hcalEnergy()
+               << " Nmissing hits = "
+               << pfCand.at(ce2).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS)
+               << endl;
 
-	if(isPrimaryNucl(pfCand.at(ce2))){
-	  if (debug_) cout << "\t\t but it is also a Primary Candidate " << ce2 << endl;
-	  
-	  ref1_bis = (pfCand.at(ce2)).displacedVertexRef(fT_TO_DISP_);
-	  if(ref1_bis.isNonnull()) analyseNuclearWPrim(pfCand, bMask, ce2);  
-	}
+        if (isPrimaryNucl(pfCand.at(ce2))) {
+          if (debug_)
+            cout << "\t\t but it is also a Primary Candidate " << ce2 << endl;
 
-	// Take now the parameters of the secondary track that are relevant and use them to construct the NI candidate
+          ref1_bis = (pfCand.at(ce2)).displacedVertexRef(fT_TO_DISP_);
+          if (ref1_bis.isNonnull())
+            analyseNuclearWPrim(pfCand, bMask, ce2);
+        }
 
-	PFCandidate::ElementsInBlocks elementsInBlocks = pfCand.at(ce2).elementsInBlocks();
-	PFCandidate::ElementsInBlocks elementsAlreadyInBlocks = pfCand.at(ce1).elementsInBlocks();
-	for (unsigned blockElem = 0; blockElem < elementsInBlocks.size(); blockElem++){
-	  bool isAlreadyHere = false;
-	  for (unsigned alreadyBlock = 0; alreadyBlock < elementsAlreadyInBlocks.size(); alreadyBlock++){
-	    if (elementsAlreadyInBlocks[alreadyBlock].second == elementsInBlocks[blockElem].second) isAlreadyHere = true;
-	  }
-	  if (!isAlreadyHere) pfCand.at(ce1).addElementInBlock( elementsInBlocks[blockElem].first,  elementsInBlocks[blockElem].second);
-	}
+        // Take now the parameters of the secondary track that are relevant and use them to construct the NI candidate
 
-	double caloEn = pfCand.at(ce2).ecalEnergy() + pfCand.at(ce2).hcalEnergy();
-	double deltaEn =  pfCand.at(ce2).p4().E() - caloEn;
-	int nMissOuterHits = pfCand.at(ce2).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS);
-	
+        PFCandidate::ElementsInBlocks elementsInBlocks = pfCand.at(ce2).elementsInBlocks();
+        PFCandidate::ElementsInBlocks elementsAlreadyInBlocks = pfCand.at(ce1).elementsInBlocks();
+        for (unsigned blockElem = 0; blockElem < elementsInBlocks.size(); blockElem++) {
+          bool isAlreadyHere = false;
+          for (unsigned alreadyBlock = 0; alreadyBlock < elementsAlreadyInBlocks.size(); alreadyBlock++) {
+            if (elementsAlreadyInBlocks[alreadyBlock].second == elementsInBlocks[blockElem].second)
+              isAlreadyHere = true;
+          }
+          if (!isAlreadyHere)
+            pfCand.at(ce1).addElementInBlock(elementsInBlocks[blockElem].first, elementsInBlocks[blockElem].second);
+        }
 
-	// Check if the difference Track Calo is not too large and if we can trust the track, ie it doesn't miss too much hits.
-	if (deltaEn > 1  && nMissOuterHits > 1) {
-	  math::XYZTLorentzVectorD momentumToAdd = pfCand.at(ce2).p4()*caloEn/pfCand.at(ce2).p4().E();
-	  momentumSec += momentumToAdd;
-	  if (debug_) cout << "The difference track-calo s really large and the track miss at least 2 hits. A secondary NI may have happened. Let's trust the calo energy" << endl << "add " << momentumToAdd << endl;
-	  
-	} else {
-	  // Check if the difference Track Calo is not too large and if we can trust the track, ie it doesn't miss too much hits.
-	  if (caloEn > 0.01 && deltaEn > 1  && nMissOuterHits > 0) {
-	    math::XYZTLorentzVectorD momentumExcess = pfCand.at(ce2).p4()*deltaEn/pfCand.at(ce2).p4().E();
-	    candidatesWithTrackExcess[pfCand.at(ce2).trackRef()->pt()/pfCand.at(ce2).trackRef()->ptError()] =  momentumExcess;
-	  }
-	  else if(caloEn < 0.01) candidatesWithoutCalo[pfCand.at(ce2).trackRef()->pt()/pfCand.at(ce2).trackRef()->ptError()] = pfCand.at(ce2).p4();
-	  momentumSec += (pfCand.at(ce2)).p4();
-	}
+        double caloEn = pfCand.at(ce2).ecalEnergy() + pfCand.at(ce2).hcalEnergy();
+        double deltaEn = pfCand.at(ce2).p4().E() - caloEn;
+        int nMissOuterHits =
+            pfCand.at(ce2).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS);
 
-	bMask[ce2] = true;
+        // Check if the difference Track Calo is not too large and if we can trust the track, ie it doesn't miss too much hits.
+        if (deltaEn > 1 && nMissOuterHits > 1) {
+          math::XYZTLorentzVectorD momentumToAdd = pfCand.at(ce2).p4() * caloEn / pfCand.at(ce2).p4().E();
+          momentumSec += momentumToAdd;
+          if (debug_)
+            cout << "The difference track-calo s really large and the track miss at least 2 hits. A secondary NI may "
+                    "have happened. Let's trust the calo energy"
+                 << endl
+                 << "add " << momentumToAdd << endl;
 
+        } else {
+          // Check if the difference Track Calo is not too large and if we can trust the track, ie it doesn't miss too much hits.
+          if (caloEn > 0.01 && deltaEn > 1 && nMissOuterHits > 0) {
+            math::XYZTLorentzVectorD momentumExcess = pfCand.at(ce2).p4() * deltaEn / pfCand.at(ce2).p4().E();
+            candidatesWithTrackExcess[pfCand.at(ce2).trackRef()->pt() / pfCand.at(ce2).trackRef()->ptError()] =
+                momentumExcess;
+          } else if (caloEn < 0.01)
+            candidatesWithoutCalo[pfCand.at(ce2).trackRef()->pt() / pfCand.at(ce2).trackRef()->ptError()] =
+                pfCand.at(ce2).p4();
+          momentumSec += (pfCand.at(ce2)).p4();
+        }
 
-	
+        bMask[ce2] = true;
       }
     }
   }
-  
-  
+
   // We have more primary energy than secondary: reject all secondary tracks which have no calo energy attached.
-  
-  
-  if (momentumPrim.E() < momentumSec.E()){
-    
-    if(debug_) cout << "Size of 0 calo Energy secondary candidates" << candidatesWithoutCalo.size() << endl;
-    for( map<double, math::XYZTLorentzVectorD>::iterator iter = candidatesWithoutCalo.begin(); iter != candidatesWithoutCalo.end() && momentumPrim.E() < momentumSec.E(); iter++)
-      if (momentumSec.E() > iter->second.E()+0.1) {
-	momentumSec -= iter->second;   
-    
-	if(debug_) cout << "\t Remove a SecondaryCandidate with 0 calo energy " << iter->second << endl;
-	
-	if(debug_) cout << "momentumPrim.E() = " << momentumPrim.E() << " and momentumSec.E() = " <<  momentumSec.E() << endl; 
-	    
+
+  if (momentumPrim.E() < momentumSec.E()) {
+    if (debug_)
+      cout << "Size of 0 calo Energy secondary candidates" << candidatesWithoutCalo.size() << endl;
+    for (map<double, math::XYZTLorentzVectorD>::iterator iter = candidatesWithoutCalo.begin();
+         iter != candidatesWithoutCalo.end() && momentumPrim.E() < momentumSec.E();
+         iter++)
+      if (momentumSec.E() > iter->second.E() + 0.1) {
+        momentumSec -= iter->second;
+
+        if (debug_)
+          cout << "\t Remove a SecondaryCandidate with 0 calo energy " << iter->second << endl;
+
+        if (debug_)
+          cout << "momentumPrim.E() = " << momentumPrim.E() << " and momentumSec.E() = " << momentumSec.E() << endl;
       }
-
   }
 
-      
-  if (momentumPrim.E() < momentumSec.E()){
-    if(debug_) cout << "0 Calo Energy rejected but still not sufficient. Size of not enough calo Energy secondary candidates" << candidatesWithTrackExcess.size() << endl;
-     for( map<double, math::XYZTLorentzVectorD>::iterator iter = candidatesWithTrackExcess.begin(); iter != candidatesWithTrackExcess.end() && momentumPrim.E() < momentumSec.E(); iter++)
-      if (momentumSec.E() > iter->second.E()+0.1) momentumSec -= iter->second;   
-     
+  if (momentumPrim.E() < momentumSec.E()) {
+    if (debug_)
+      cout << "0 Calo Energy rejected but still not sufficient. Size of not enough calo Energy secondary candidates"
+           << candidatesWithTrackExcess.size() << endl;
+    for (map<double, math::XYZTLorentzVectorD>::iterator iter = candidatesWithTrackExcess.begin();
+         iter != candidatesWithTrackExcess.end() && momentumPrim.E() < momentumSec.E();
+         iter++)
+      if (momentumSec.E() > iter->second.E() + 0.1)
+        momentumSec -= iter->second;
   }
 
-
-    
-
-  double dpt = pfCand.at(ce1).trackRef()->ptError()/pfCand.at(ce1).trackRef()->pt()*100; 
+  double dpt = pfCand.at(ce1).trackRef()->ptError() / pfCand.at(ce1).trackRef()->pt() * 100;
 
   if (momentumSec.E() < 0.1) {
     bMask[ce1] = true;
     return;
   }
-  
+
   // Rescale the secondary candidates to account for the loss of energy, but only if we can trust the primary track:
   // if it has more energy than secondaries and is precise enough and secondary exist and was not eaten or rejected during the PFAlgo step.
-  
-  if( ( (ref1->isTherePrimaryTracks() && dpt<dptRel_PrimaryTrack_)  || (ref1->isThereMergedTracks() && dpt<dptRel_MergedTrack_) ) && momentumPrim.E() > momentumSec.E() && momentumSec.E() > 0.1) {
-      
-    if (bCalibPrimary_){
-      double factor = rescaleFactor( momentumPrim.Pt(), momentumSec.E()/momentumPrim.E()); 
-      if (debug_) cout << "factor = " << factor << endl;
-      if (factor*momentumPrim.Pt() < momentumSec.Pt()) momentumSec = momentumPrim;
-      else momentumSec += (1-factor)*momentumPrim;
+
+  if (((ref1->isTherePrimaryTracks() && dpt < dptRel_PrimaryTrack_) ||
+       (ref1->isThereMergedTracks() && dpt < dptRel_MergedTrack_)) &&
+      momentumPrim.E() > momentumSec.E() && momentumSec.E() > 0.1) {
+    if (bCalibPrimary_) {
+      double factor = rescaleFactor(momentumPrim.Pt(), momentumSec.E() / momentumPrim.E());
+      if (debug_)
+        cout << "factor = " << factor << endl;
+      if (factor * momentumPrim.Pt() < momentumSec.Pt())
+        momentumSec = momentumPrim;
+      else
+        momentumSec += (1 - factor) * momentumPrim;
     }
-    
-    double px = momentumPrim.Px()*momentumSec.P()/momentumPrim.P();
-    double py = momentumPrim.Py()*momentumSec.P()/momentumPrim.P();
-    double pz = momentumPrim.Pz()*momentumSec.P()/momentumPrim.P();
-    double E  = sqrt(px*px + py*py + pz*pz + pion_mass2);
+
+    double px = momentumPrim.Px() * momentumSec.P() / momentumPrim.P();
+    double py = momentumPrim.Py() * momentumSec.P() / momentumPrim.P();
+    double pz = momentumPrim.Pz() * momentumSec.P() / momentumPrim.P();
+    double E = sqrt(px * px + py * py + pz * pz + pion_mass2);
     math::XYZTLorentzVectorD momentum(px, py, pz, E);
     pfCand.at(ce1).setP4(momentum);
-    
+
     return;
-    
+
   } else {
+    math::XYZVector primDir = ref1->primaryDirection();
 
-    math::XYZVector primDir =  ref1->primaryDirection();
-
-    
-    if (primDir.Mag2() < 0.1){
+    if (primDir.Mag2() < 0.1) {
       // It might be 0 but this situation should never happend. Throw a warning if it happens.
       edm::LogWarning("PFCandConnector") << "A Nuclear Interaction do not have primary direction" << std::endl;
       pfCand.at(ce1).setP4(momentumSec);
       return;
     } else {
-      // rescale the primary direction to the optimal momentum. But take care of the factthat it shall not be completly 0 to avoid a warning if Jet Area. 
+      // rescale the primary direction to the optimal momentum. But take care of the factthat it shall not be completly 0 to avoid a warning if Jet Area.
       double momentumS = momentumSec.P();
-      if (momentumS < 1e-4) momentumS = 1e-4;
-      double px = momentumS*primDir.x();
-      double py = momentumS*primDir.y();
-      double pz = momentumS*primDir.z();
-      double E  = sqrt(px*px + py*py + pz*pz + pion_mass2);
-      
+      if (momentumS < 1e-4)
+        momentumS = 1e-4;
+      double px = momentumS * primDir.x();
+      double py = momentumS * primDir.y();
+      double pz = momentumS * primDir.z();
+      double E = sqrt(px * px + py * py + pz * pz + pion_mass2);
+
       math::XYZTLorentzVectorD momentum(px, py, pz, E);
       pfCand.at(ce1).setP4(momentum);
       return;
     }
   }
-  
-  
-
 }
 
-
-
-
-void 
-PFCandConnector::analyseNuclearWSec(PFCandidateCollection& pfCand, std::vector<bool> & bMask, unsigned int ce1) const {
-
-  PFDisplacedVertexRef ref1, ref2;  
-
+void PFCandConnector::analyseNuclearWSec(PFCandidateCollection& pfCand,
+                                         std::vector<bool>& bMask,
+                                         unsigned int ce1) const {
+  PFDisplacedVertexRef ref1, ref2;
 
   // Check if the track excess was not too large and track may miss some outer hits. This may point to a secondary NI.
 
   double caloEn = pfCand.at(ce1).ecalEnergy() + pfCand.at(ce1).hcalEnergy();
-  double deltaEn =  pfCand.at(ce1).p4().E() - caloEn;
+  double deltaEn = pfCand.at(ce1).p4().E() - caloEn;
   int nMissOuterHits = pfCand.at(ce1).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS);
-
 
   ref1 = pfCand.at(ce1).displacedVertexRef(fT_FROM_DISP_);
 
   // ------- check if an electron or a muon vas spotted as incoming track -------- //
   // ------- this mean probably that the NI was fake thus we do not correct it -------- /
 
-  if (ref1->isTherePrimaryTracks() || ref1->isThereMergedTracks()){
-    
+  if (ref1->isTherePrimaryTracks() || ref1->isThereMergedTracks()) {
     std::vector<reco::Track> refittedTracks = ref1->refittedTracks();
-    for(unsigned it = 0; it < refittedTracks.size(); it++){
-      reco::TrackBaseRef primaryBaseRef = ref1->originalTrack(refittedTracks[it]);  
+    for (unsigned it = 0; it < refittedTracks.size(); it++) {
+      reco::TrackBaseRef primaryBaseRef = ref1->originalTrack(refittedTracks[it]);
       if (ref1->isIncomingTrack(primaryBaseRef))
-	if (debug_) cout << "There is a Primary track ref with pt = " << primaryBaseRef->pt()<< endl;
+        if (debug_)
+          cout << "There is a Primary track ref with pt = " << primaryBaseRef->pt() << endl;
 
-      for( unsigned int ce=0; ce < pfCand.size(); ++ce){
-	//	  cout << "PFCand Id = " << (pfCand.at(ce)).particleId() << endl;
-	if ((pfCand.at(ce)).particleId() == reco::PFCandidate::e || (pfCand.at(ce)).particleId() == reco::PFCandidate::mu) {
+      for (unsigned int ce = 0; ce < pfCand.size(); ++ce) {
+        //	  cout << "PFCand Id = " << (pfCand.at(ce)).particleId() << endl;
+        if ((pfCand.at(ce)).particleId() == reco::PFCandidate::e ||
+            (pfCand.at(ce)).particleId() == reco::PFCandidate::mu) {
+          if (debug_)
+            cout << " It is an electron and it has a ref to a track " << (pfCand.at(ce)).trackRef().isNonnull() << endl;
 
-	  if (debug_) cout << " It is an electron and it has a ref to a track " << (pfCand.at(ce)).trackRef().isNonnull() << endl;
-	  
+          if ((pfCand.at(ce)).trackRef().isNonnull()) {
+            reco::TrackRef tRef = (pfCand.at(ce)).trackRef();
+            reco::TrackBaseRef bRef(tRef);
+            if (debug_)
+              cout << "With Track Ref pt = " << (pfCand.at(ce)).trackRef()->pt() << endl;
 
-	  if ( (pfCand.at(ce)).trackRef().isNonnull() ){
-	    reco::TrackRef tRef = (pfCand.at(ce)).trackRef();
-	    reco::TrackBaseRef bRef(tRef);
-	    if (debug_) cout << "With Track Ref pt = " << (pfCand.at(ce)).trackRef()->pt() << endl;
+            if (bRef == primaryBaseRef) {
+              if (debug_ && (pfCand.at(ce)).particleId() == reco::PFCandidate::e)
+                cout << "It is a NI from electron. NI Discarded. Just release the candidate." << endl;
+              if (debug_ && (pfCand.at(ce)).particleId() == reco::PFCandidate::mu)
+                cout << "It is a NI from muon. NI Discarded. Just release the candidate" << endl;
 
-	    if (bRef == primaryBaseRef) {
-	      if (debug_ && (pfCand.at(ce)).particleId() == reco::PFCandidate::e) cout << "It is a NI from electron. NI Discarded. Just release the candidate." << endl; 
-	      if (debug_ && (pfCand.at(ce)).particleId() == reco::PFCandidate::mu) cout << "It is a NI from muon. NI Discarded. Just release the candidate" << endl; 
-	
-	      // release the track but take care of not overcounting bad tracks. In fact those tracks was protected against destruction in 
-	      // PFAlgo. Now we treat them as if they was treated in PFAlgo
+              // release the track but take care of not overcounting bad tracks. In fact those tracks was protected against destruction in
+              // PFAlgo. Now we treat them as if they was treated in PFAlgo
 
-	      if (caloEn < 0.1 && pfCand.at(ce1).trackRef()->ptError() > ptErrorSecondary_) { 
-		cout << "discarded track since no calo energy and ill measured" << endl; 
-		bMask[ce1] = true;
-	      }
-	      if (caloEn > 0.1 && deltaEn >ptErrorSecondary_  && pfCand.at(ce1).trackRef()->ptError() > ptErrorSecondary_) { 
-		cout << "rescaled momentum of the track since no calo energy and ill measured" << endl;
-		
-		double factor = caloEn/pfCand.at(ce1).p4().E();
-		pfCand.at(ce1).rescaleMomentum(factor);
-	      }
+              if (caloEn < 0.1 && pfCand.at(ce1).trackRef()->ptError() > ptErrorSecondary_) {
+                cout << "discarded track since no calo energy and ill measured" << endl;
+                bMask[ce1] = true;
+              }
+              if (caloEn > 0.1 && deltaEn > ptErrorSecondary_ &&
+                  pfCand.at(ce1).trackRef()->ptError() > ptErrorSecondary_) {
+                cout << "rescaled momentum of the track since no calo energy and ill measured" << endl;
 
-	      return;
-	    }
-	  }
-	}
+                double factor = caloEn / pfCand.at(ce1).p4().E();
+                pfCand.at(ce1).rescaleMomentum(factor);
+              }
+
+              return;
+            }
+          }
+        }
       }
     }
   }
-
 
   PFCandidate secondaryCand = pfCand.at(ce1);
 
   math::XYZTLorentzVectorD momentumSec = secondaryCand.p4();
 
-  if (deltaEn > ptErrorSecondary_  && nMissOuterHits > 1) {
-    math::XYZTLorentzVectorD momentumToAdd = pfCand.at(ce1).p4()*caloEn/pfCand.at(ce1).p4().E();
+  if (deltaEn > ptErrorSecondary_ && nMissOuterHits > 1) {
+    math::XYZTLorentzVectorD momentumToAdd = pfCand.at(ce1).p4() * caloEn / pfCand.at(ce1).p4().E();
     momentumSec = momentumToAdd;
-    if (debug_) cout << "The difference track-calo s really large and the track miss at least 2 hits. A secondary NI may have happened. Let's trust the calo energy" << endl << "add " << momentumToAdd << endl;  
+    if (debug_)
+      cout << "The difference track-calo s really large and the track miss at least 2 hits. A secondary NI may have "
+              "happened. Let's trust the calo energy"
+           << endl
+           << "add " << momentumToAdd << endl;
   }
 
-
   // ------- look for the little friends -------- //
-  for( unsigned int ce2=ce1+1; ce2 < pfCand.size(); ++ce2) {
-    if (isSecondaryNucl(pfCand.at(ce2))){
+  for (unsigned int ce2 = ce1 + 1; ce2 < pfCand.size(); ++ce2) {
+    if (isSecondaryNucl(pfCand.at(ce2))) {
       ref2 = (pfCand.at(ce2)).displacedVertexRef(fT_FROM_DISP_);
 
       if (ref1 == ref2) {
-	 
-	if (debug_) cout << "\t here is a Secondary Candidate " << ce2  
-			 << " " << pfCand.at(ce2) << endl
-			 << "\t based on the Track " << pfCand.at(ce2).trackRef().key()
-			 << " w pT = " << pfCand.at(ce2).trackRef()->pt()
-			 << " #pm " << pfCand.at(ce2).trackRef()->ptError() << " %" 
-			 << " ECAL = " << pfCand.at(ce2).ecalEnergy() 
-			 << " HCAL = " << pfCand.at(ce2).hcalEnergy() 
-			 << " dE(Trk-CALO) = " << pfCand.at(ce2).trackRef()->p()-pfCand.at(ce2).ecalEnergy()-pfCand.at(ce2).hcalEnergy() 
-			 << " Nmissing hits = " << pfCand.at(ce2).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS) << endl;
+        if (debug_)
+          cout << "\t here is a Secondary Candidate " << ce2 << " " << pfCand.at(ce2) << endl
+               << "\t based on the Track " << pfCand.at(ce2).trackRef().key()
+               << " w pT = " << pfCand.at(ce2).trackRef()->pt() << " #pm " << pfCand.at(ce2).trackRef()->ptError()
+               << " %"
+               << " ECAL = " << pfCand.at(ce2).ecalEnergy() << " HCAL = " << pfCand.at(ce2).hcalEnergy()
+               << " dE(Trk-CALO) = "
+               << pfCand.at(ce2).trackRef()->p() - pfCand.at(ce2).ecalEnergy() - pfCand.at(ce2).hcalEnergy()
+               << " Nmissing hits = "
+               << pfCand.at(ce2).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS)
+               << endl;
 
-	// Take now the parameters of the secondary track that are relevant and use them to construct the NI candidate
-	PFCandidate::ElementsInBlocks elementsInBlocks = pfCand.at(ce2).elementsInBlocks();
-	PFCandidate::ElementsInBlocks elementsAlreadyInBlocks = pfCand.at(ce1).elementsInBlocks();
-	for (unsigned blockElem = 0; blockElem < elementsInBlocks.size(); blockElem++){
-	  bool isAlreadyHere = false;
-	  for (unsigned alreadyBlock = 0; alreadyBlock < elementsAlreadyInBlocks.size(); alreadyBlock++){
-	    if (elementsAlreadyInBlocks[alreadyBlock].second == elementsInBlocks[blockElem].second) isAlreadyHere = true;
-	  }
-	  if (!isAlreadyHere) pfCand.at(ce1).addElementInBlock( elementsInBlocks[blockElem].first,  elementsInBlocks[blockElem].second);
-	}
+        // Take now the parameters of the secondary track that are relevant and use them to construct the NI candidate
+        PFCandidate::ElementsInBlocks elementsInBlocks = pfCand.at(ce2).elementsInBlocks();
+        PFCandidate::ElementsInBlocks elementsAlreadyInBlocks = pfCand.at(ce1).elementsInBlocks();
+        for (unsigned blockElem = 0; blockElem < elementsInBlocks.size(); blockElem++) {
+          bool isAlreadyHere = false;
+          for (unsigned alreadyBlock = 0; alreadyBlock < elementsAlreadyInBlocks.size(); alreadyBlock++) {
+            if (elementsAlreadyInBlocks[alreadyBlock].second == elementsInBlocks[blockElem].second)
+              isAlreadyHere = true;
+          }
+          if (!isAlreadyHere)
+            pfCand.at(ce1).addElementInBlock(elementsInBlocks[blockElem].first, elementsInBlocks[blockElem].second);
+        }
 
-	double caloEn = pfCand.at(ce2).ecalEnergy() + pfCand.at(ce2).hcalEnergy();
-	double deltaEn =  pfCand.at(ce2).p4().E() - caloEn;
-	int nMissOuterHits = pfCand.at(ce2).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS); 
-	if (deltaEn > ptErrorSecondary_ && nMissOuterHits > 1) {
-	  math::XYZTLorentzVectorD momentumToAdd = pfCand.at(ce2).p4()*caloEn/pfCand.at(ce2).p4().E();
-	  momentumSec += momentumToAdd;
-	  if (debug_) cout << "The difference track-calo s really large and the track miss at least 2 hits. A secondary NI may have happened. Let's trust the calo energy" << endl << "add " << momentumToAdd << endl;  
-	} else {
-	  momentumSec += (pfCand.at(ce2)).p4();	
-	}
+        double caloEn = pfCand.at(ce2).ecalEnergy() + pfCand.at(ce2).hcalEnergy();
+        double deltaEn = pfCand.at(ce2).p4().E() - caloEn;
+        int nMissOuterHits =
+            pfCand.at(ce2).trackRef()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_OUTER_HITS);
+        if (deltaEn > ptErrorSecondary_ && nMissOuterHits > 1) {
+          math::XYZTLorentzVectorD momentumToAdd = pfCand.at(ce2).p4() * caloEn / pfCand.at(ce2).p4().E();
+          momentumSec += momentumToAdd;
+          if (debug_)
+            cout << "The difference track-calo s really large and the track miss at least 2 hits. A secondary NI may "
+                    "have happened. Let's trust the calo energy"
+                 << endl
+                 << "add " << momentumToAdd << endl;
+        } else {
+          momentumSec += (pfCand.at(ce2)).p4();
+        }
 
-	bMask[ce2] = true;
+        bMask[ce2] = true;
       }
     }
   }
-  
-  
 
+  math::XYZVector primDir = ref1->primaryDirection();
 
-  math::XYZVector primDir =  ref1->primaryDirection();
-
-  if (primDir.Mag2() < 0.1){
+  if (primDir.Mag2() < 0.1) {
     // It might be 0 but this situation should never happend. Throw a warning if it happens.
     pfCand.at(ce1).setP4(momentumSec);
     edm::LogWarning("PFCandConnector") << "A Nuclear Interaction do not have primary direction" << std::endl;
@@ -463,59 +475,53 @@ PFCandConnector::analyseNuclearWSec(PFCandidateCollection& pfCand, std::vector<b
   } else {
     // rescale the primary direction to the optimal momentum. But take care of the factthat it shall not be completly 0 to avoid a warning if Jet Area.
     double momentumS = momentumSec.P();
-    if (momentumS < 1e-4) momentumS = 1e-4;
-    double px = momentumS*primDir.x();
-    double py = momentumS*primDir.y();
-    double pz = momentumS*primDir.z();
-    double E  = sqrt(px*px + py*py + pz*pz + pion_mass2);
-     
+    if (momentumS < 1e-4)
+      momentumS = 1e-4;
+    double px = momentumS * primDir.x();
+    double py = momentumS * primDir.y();
+    double pz = momentumS * primDir.z();
+    double E = sqrt(px * px + py * py + pz * pz + pion_mass2);
+
     math::XYZTLorentzVectorD momentum(px, py, pz, E);
-     
+
     pfCand.at(ce1).setP4(momentum);
     return;
   }
-
 }
 
-bool 
-PFCandConnector::isSecondaryNucl( const PFCandidate& pf ) const {
-  
+bool PFCandConnector::isSecondaryNucl(const PFCandidate& pf) const {
   PFDisplacedVertexRef ref1;
   // nuclear
-  if( pf.flag( fT_FROM_DISP_ ) ) {
+  if (pf.flag(fT_FROM_DISP_)) {
     ref1 = pf.displacedVertexRef(fT_FROM_DISP_);
     //    ref1->Dump();
-    if (!ref1.isNonnull()) return false;
+    if (!ref1.isNonnull())
+      return false;
     else if (ref1->isNucl() || ref1->isNucl_Loose() || ref1->isNucl_Kink())
-    return true;
+      return true;
   }
-  
+
   return false;
 }
 
-bool 
-PFCandConnector::isPrimaryNucl( const PFCandidate& pf ) const {
-
+bool PFCandConnector::isPrimaryNucl(const PFCandidate& pf) const {
   PFDisplacedVertexRef ref1;
-  
+
   // nuclear
-  if( pf.flag( fT_TO_DISP_ ) ) {
+  if (pf.flag(fT_TO_DISP_)) {
     ref1 = pf.displacedVertexRef(fT_TO_DISP_);
     //ref1->Dump();
 
-    if (!ref1.isNonnull()) return false;
-    else if (ref1->isNucl()|| ref1->isNucl_Loose() || ref1->isNucl_Kink())
-    return true;
+    if (!ref1.isNonnull())
+      return false;
+    else if (ref1->isNucl() || ref1->isNucl_Loose() || ref1->isNucl_Kink())
+      return true;
   }
-  
+
   return false;
 }
 
-
-double
-PFCandConnector::rescaleFactor( const double pt, const double cFrac ) const {
-
-
+double PFCandConnector::rescaleFactor(const double pt, const double cFrac) const {
   /*
     LOG NORMAL FIT
  FCN=35.8181 FROM MIGRAD    STATUS=CONVERGED     257 CALLS         258 TOTAL
@@ -528,7 +534,6 @@ PFCandConnector::rescaleFactor( const double pt, const double cFrac ) const {
    4  p3           4.54043e-01   5.00908e-02   3.17625e-05   3.86622e-03
    5  p4          -4.61736e-02   8.07940e-03   3.25775e-06  -1.37247e-02
   */
-
 
   /*
     FCN=34.4051 FROM MIGRAD    STATUS=CONVERGED     221 CALLS         222 TOTAL
@@ -548,12 +553,11 @@ PFCandConnector::rescaleFactor( const double pt, const double cFrac ) const {
 
   double fConst, fNorm, fExp;
 
-  fConst = fConst_[0] + fConst_[1]*cFrac;
-  fNorm = fNorm_[0] - fNorm_[1]*cFrac;
-  fExp = fExp_[0];  
+  fConst = fConst_[0] + fConst_[1] * cFrac;
+  fNorm = fNorm_[0] - fNorm_[1] * cFrac;
+  fExp = fExp_[0];
 
-  double factor = fConst - fNorm*exp( -fExp*pt );
+  double factor = fConst - fNorm * exp(-fExp * pt);
 
   return factor;
-
 }

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1,7 +1,7 @@
 #include "RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h"
 #include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
-#include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h" 
+#include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 #include "RecoParticleFlow/PFClusterTools/interface/ClusterClusterMapping.h"
@@ -39,13 +39,13 @@
 //#define PFLOW_DEBUG
 
 #ifdef PFLOW_DEBUG
-#define docast(x,y) dynamic_cast<x>(y)
+#define docast(x, y) dynamic_cast<x>(y)
 #define LOGVERB(x) edm::LogVerbatim(x)
 #define LOGWARN(x) edm::LogWarning(x)
 #define LOGERR(x) edm::LogError(x)
-#define LOGDRESSED(x)  edm::LogInfo(x)
+#define LOGDRESSED(x) edm::LogInfo(x)
 #else
-#define docast(x,y) reinterpret_cast<x>(y)
+#define docast(x, y) reinterpret_cast<x>(y)
 #define LOGVERB(x) LogTrace(x)
 #define LOGWARN(x) edm::LogWarning(x)
 #define LOGERR(x) edm::LogError(x)
@@ -59,664 +59,527 @@ using namespace std::placeholders;  // for _1, _2, _3...
 namespace {
   typedef PFEGammaAlgo::PFSCElement SCElement;
   typedef PFEGammaAlgo::EEtoPSAssociation EEtoPSAssociation;
-  typedef std::pair<CaloClusterPtr::key_type,CaloClusterPtr> EEtoPSElement;
+  typedef std::pair<CaloClusterPtr::key_type, CaloClusterPtr> EEtoPSElement;
   typedef PFEGammaAlgo::PFClusterElement ClusterElement;
 
   class SeedMatchesToProtoObject {
-    public:
-      SeedMatchesToProtoObject(const reco::ElectronSeedRef& s)
-        : scfromseed_(s->caloCluster().castTo<reco::SuperClusterRef>())
-      {
-        ispfsc_ = false;
-        if( scfromseed_.isNonnull() )
-        {
+  public:
+    SeedMatchesToProtoObject(const reco::ElectronSeedRef& s)
+        : scfromseed_(s->caloCluster().castTo<reco::SuperClusterRef>()) {
+      ispfsc_ = false;
+      if (scfromseed_.isNonnull()) {
         const edm::Ptr<reco::PFCluster> testCast(scfromseed_->seed());
         ispfsc_ = testCast.isNonnull();
-        }      
       }
-      bool operator()(const PFEGammaAlgo::ProtoEGObject& po)
-      {
-        if( scfromseed_.isNull() || !po.parentSC ) return false;      
-        if( ispfsc_ )
-        {
-          return ( scfromseed_->seed() == po.parentSC->superClusterRef()->seed() ); 
-        }      
-        return ( scfromseed_->seed()->seed() == po.parentSC->superClusterRef()->seed()->seed() );
+    }
+    bool operator()(const PFEGammaAlgo::ProtoEGObject& po) {
+      if (scfromseed_.isNull() || !po.parentSC)
+        return false;
+      if (ispfsc_) {
+        return (scfromseed_->seed() == po.parentSC->superClusterRef()->seed());
+      }
+      return (scfromseed_->seed()->seed() == po.parentSC->superClusterRef()->seed()->seed());
     }
 
-    private:
-      const reco::SuperClusterRef scfromseed_;
-      bool ispfsc_;
-  }; 
-  
-  template<bool useConvs=false>
-  bool elementNotCloserToOther(const reco::PFBlockRef& block,
-			       const PFBlockElement::Type& keytype,
-			       const size_t key, 
-			       const PFBlockElement::Type& valtype,
-			       const size_t test,
-			       const float EoPin_cut = 1.0e6) {
-    constexpr reco::PFBlockElement::TrackType ConvType =
-	reco::PFBlockElement::T_FROM_GAMMACONV;
-    // this is inside out but I just want something that works right now
-    switch( keytype ) {
-    case reco::PFBlockElement::GSF:
-      {
-	const reco::PFBlockElementGsfTrack* elemasgsf  =  
-	  docast(const reco::PFBlockElementGsfTrack*,
-		 &(block->elements()[key]));
-	if( elemasgsf && valtype == PFBlockElement::ECAL ) {
-	  const ClusterElement* elemasclus =
-	 reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
-	  float cluster_e = elemasclus->clusterRef()->correctedEnergy();
-	  float trk_pin   = elemasgsf->Pin().P();
-	  if( cluster_e / trk_pin > EoPin_cut ) {
-	    LOGDRESSED("elementNotCloserToOther")
-	      << "GSF track failed EoP cut to match with cluster!";
-	    return false;
-	  }
-	}
-      }
-      break;
-    case reco::PFBlockElement::TRACK:
-      {
-	const reco::PFBlockElementTrack* elemaskf  = 
-	  docast(const reco::PFBlockElementTrack*,
-		 &(block->elements()[key]));
-	if( elemaskf && valtype == PFBlockElement::ECAL ) {
-	  const ClusterElement* elemasclus =
-	  reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
-	  float cluster_e = elemasclus->clusterRef()->correctedEnergy();
-	  float trk_pin   = 
-	    std::sqrt(elemaskf->trackRef()->innerMomentum().mag2());
-	  if( cluster_e / trk_pin > EoPin_cut ) {
-	    LOGDRESSED("elementNotCloserToOther")
-	      << "KF track failed EoP cut to match with cluster!";
-	    return false;
-	  }
-	}
-      }	
-      break;
-    default:
-      break;
-    }	        
+  private:
+    const reco::SuperClusterRef scfromseed_;
+    bool ispfsc_;
+  };
 
-    const float dist = 
-      block->dist(key,test,block->linkData(),reco::PFBlock::LINKTEST_ALL);
-    if( dist == -1.0f ) return false; // don't associate non-linked elems
-    std::multimap<double, unsigned> dists_to_val; 
-    block->associatedElements(test,block->linkData(),dists_to_val,keytype,
-			      reco::PFBlock::LINKTEST_ALL); 
-  
-    for( const auto& valdist : dists_to_val ) {
+  template <bool useConvs = false>
+  bool elementNotCloserToOther(const reco::PFBlockRef& block,
+                               const PFBlockElement::Type& keytype,
+                               const size_t key,
+                               const PFBlockElement::Type& valtype,
+                               const size_t test,
+                               const float EoPin_cut = 1.0e6) {
+    constexpr reco::PFBlockElement::TrackType ConvType = reco::PFBlockElement::T_FROM_GAMMACONV;
+    // this is inside out but I just want something that works right now
+    switch (keytype) {
+      case reco::PFBlockElement::GSF: {
+        const reco::PFBlockElementGsfTrack* elemasgsf =
+            docast(const reco::PFBlockElementGsfTrack*, &(block->elements()[key]));
+        if (elemasgsf && valtype == PFBlockElement::ECAL) {
+          const ClusterElement* elemasclus = reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
+          float cluster_e = elemasclus->clusterRef()->correctedEnergy();
+          float trk_pin = elemasgsf->Pin().P();
+          if (cluster_e / trk_pin > EoPin_cut) {
+            LOGDRESSED("elementNotCloserToOther") << "GSF track failed EoP cut to match with cluster!";
+            return false;
+          }
+        }
+      } break;
+      case reco::PFBlockElement::TRACK: {
+        const reco::PFBlockElementTrack* elemaskf = docast(const reco::PFBlockElementTrack*, &(block->elements()[key]));
+        if (elemaskf && valtype == PFBlockElement::ECAL) {
+          const ClusterElement* elemasclus = reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
+          float cluster_e = elemasclus->clusterRef()->correctedEnergy();
+          float trk_pin = std::sqrt(elemaskf->trackRef()->innerMomentum().mag2());
+          if (cluster_e / trk_pin > EoPin_cut) {
+            LOGDRESSED("elementNotCloserToOther") << "KF track failed EoP cut to match with cluster!";
+            return false;
+          }
+        }
+      } break;
+      default:
+        break;
+    }
+
+    const float dist = block->dist(key, test, block->linkData(), reco::PFBlock::LINKTEST_ALL);
+    if (dist == -1.0f)
+      return false;  // don't associate non-linked elems
+    std::multimap<double, unsigned> dists_to_val;
+    block->associatedElements(test, block->linkData(), dists_to_val, keytype, reco::PFBlock::LINKTEST_ALL);
+
+    for (const auto& valdist : dists_to_val) {
       const size_t idx = valdist.second;
       // check track types for conversion info
-      switch( keytype ) {
-      case reco::PFBlockElement::GSF:
-	{
-	  const reco::PFBlockElementGsfTrack* elemasgsf  =  
-	    docast(const reco::PFBlockElementGsfTrack*,
-		   &(block->elements()[idx]));
-	  if( !useConvs && elemasgsf->trackType(ConvType) ) return false;
-	  if( elemasgsf && valtype == PFBlockElement::ECAL ) {
-	    const ClusterElement* elemasclus =
-	      docast(const ClusterElement*,&(block->elements()[test]));
-	    float cluster_e = elemasclus->clusterRef()->correctedEnergy();
-	    float trk_pin   = elemasgsf->Pin().P();
-	    if( cluster_e / trk_pin > EoPin_cut ) continue;
-	  }
-	}
-	break;
-      case reco::PFBlockElement::TRACK:
-	{
-	  const reco::PFBlockElementTrack* elemaskf  = 
-	    docast(const reco::PFBlockElementTrack*,
-		   &(block->elements()[idx]));
-	  if( !useConvs && elemaskf->trackType(ConvType) ) return false;
-	  if( elemaskf && valtype == PFBlockElement::ECAL ) {
-	    const ClusterElement* elemasclus =
-	    reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
-	    float cluster_e = elemasclus->clusterRef()->correctedEnergy();
-	    float trk_pin   = 
-	      std::sqrt(elemaskf->trackRef()->innerMomentum().mag2());
-	    if( cluster_e / trk_pin > EoPin_cut ) continue;
-	  }
-	}	
-	break;
-      default:
-	break;
-      }	        
-      if( valdist.first < dist && idx != key ) {
-	LOGDRESSED("elementNotCloserToOther") 
-	  << "key element of type " << keytype 
-	  << " is closer to another element of type" << valtype 
-	  << std::endl;
-	return false; // false if closer element of specified type found
+      switch (keytype) {
+        case reco::PFBlockElement::GSF: {
+          const reco::PFBlockElementGsfTrack* elemasgsf =
+              docast(const reco::PFBlockElementGsfTrack*, &(block->elements()[idx]));
+          if (!useConvs && elemasgsf->trackType(ConvType))
+            return false;
+          if (elemasgsf && valtype == PFBlockElement::ECAL) {
+            const ClusterElement* elemasclus = docast(const ClusterElement*, &(block->elements()[test]));
+            float cluster_e = elemasclus->clusterRef()->correctedEnergy();
+            float trk_pin = elemasgsf->Pin().P();
+            if (cluster_e / trk_pin > EoPin_cut)
+              continue;
+          }
+        } break;
+        case reco::PFBlockElement::TRACK: {
+          const reco::PFBlockElementTrack* elemaskf =
+              docast(const reco::PFBlockElementTrack*, &(block->elements()[idx]));
+          if (!useConvs && elemaskf->trackType(ConvType))
+            return false;
+          if (elemaskf && valtype == PFBlockElement::ECAL) {
+            const ClusterElement* elemasclus = reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
+            float cluster_e = elemasclus->clusterRef()->correctedEnergy();
+            float trk_pin = std::sqrt(elemaskf->trackRef()->innerMomentum().mag2());
+            if (cluster_e / trk_pin > EoPin_cut)
+              continue;
+          }
+        } break;
+        default:
+          break;
+      }
+      if (valdist.first < dist && idx != key) {
+        LOGDRESSED("elementNotCloserToOther")
+            << "key element of type " << keytype << " is closer to another element of type" << valtype << std::endl;
+        return false;  // false if closer element of specified type found
       }
     }
     return true;
   }
 
-  template<class Element1, class Element2>
-  bool compatibleEoPOut(const Element1& e, const Element2& comp)
-  {
-    if( PFBlockElement::ECAL != e.type() )
-    {
-        return false;
+  template <class Element1, class Element2>
+  bool compatibleEoPOut(const Element1& e, const Element2& comp) {
+    if (PFBlockElement::ECAL != e.type()) {
+      return false;
     }
-    const ClusterElement& elemascluster = docast(ClusterElement const&,e);
+    const ClusterElement& elemascluster = docast(ClusterElement const&, e);
     const float gsf_eta_diff = std::abs(comp.positionAtECALEntrance().eta() - comp.Pout().eta());
     const reco::PFClusterRef& cRef = elemascluster.clusterRef();
-    return ( gsf_eta_diff <= 0.3 && cRef->energy()/comp.Pout().t() <= 5 );
+    return (gsf_eta_diff <= 0.3 && cRef->energy() / comp.Pout().t() <= 5);
   }
 
   constexpr reco::PFBlockElement::TrackType ConvType = reco::PFBlockElement::T_FROM_GAMMACONV;
 
-  template<PFBlockElement::Type keytype, 
-	   PFBlockElement::Type valtype,
-	   bool useConv=false>
+  template <PFBlockElement::Type keytype, PFBlockElement::Type valtype, bool useConv = false>
 
   struct NotCloserToOther {
     const reco::PFBlockElement* comp;
     const reco::PFBlockRef& block;
     const float EoPin_cut;
-    NotCloserToOther(const reco::PFBlockRef& b,
-		     const reco::PFBlockElement* e,
-		     const float EoPcut=1.0e6): comp(e), 
-						block(b), 
-						EoPin_cut(EoPcut) {
-    }
-    template<class T>
-    bool operator () (const T& e) {        
-      if( !e.flag() || valtype != e->type() ) return false;      
-      return elementNotCloserToOther<useConv>(block,
-					      keytype,comp->index(),
-					      valtype,e->index(),
-					      EoPin_cut);
+    NotCloserToOther(const reco::PFBlockRef& b, const reco::PFBlockElement* e, const float EoPcut = 1.0e6)
+        : comp(e), block(b), EoPin_cut(EoPcut) {}
+    template <class T>
+    bool operator()(const T& e) {
+      if (!e.flag() || valtype != e->type())
+        return false;
+      return elementNotCloserToOther<useConv>(block, keytype, comp->index(), valtype, e->index(), EoPin_cut);
     }
   };
 
   struct LesserByDistance {
     const reco::PFBlockElement* comp;
     const reco::PFBlockRef& block;
-    const reco::PFBlock::LinkData& links; 
-    LesserByDistance(const reco::PFBlockRef& b,
-		     const reco::PFBlock::LinkData& l,
-		     const reco::PFBlockElement* e): comp(e), 
-						     block(b), 
-						     links(l) {}
-    bool operator () (FlaggedPtr<const reco::PFBlockElement> const& e1,
-                      FlaggedPtr<const reco::PFBlockElement> const& e2) {
-      double dist1 = block->dist(comp->index(), 
-				 e1->index(),
-				 links,
-				 reco::PFBlock::LINKTEST_ALL);   
-      double dist2 = block->dist(comp->index(), 
-				 e2->index(),
-				 links,
-				 reco::PFBlock::LINKTEST_ALL);   
-      dist1 = ( dist1 == -1.0 ? 1e6 : dist1 );
-      dist2 = ( dist2 == -1.0 ? 1e6 : dist2 );
+    const reco::PFBlock::LinkData& links;
+    LesserByDistance(const reco::PFBlockRef& b, const reco::PFBlock::LinkData& l, const reco::PFBlockElement* e)
+        : comp(e), block(b), links(l) {}
+    bool operator()(FlaggedPtr<const reco::PFBlockElement> const& e1,
+                    FlaggedPtr<const reco::PFBlockElement> const& e2) {
+      double dist1 = block->dist(comp->index(), e1->index(), links, reco::PFBlock::LINKTEST_ALL);
+      double dist2 = block->dist(comp->index(), e2->index(), links, reco::PFBlock::LINKTEST_ALL);
+      dist1 = (dist1 == -1.0 ? 1e6 : dist1);
+      dist2 = (dist2 == -1.0 ? 1e6 : dist2);
       return dist1 < dist2;
     }
   };
-  
-  bool isROLinkedByClusterOrTrack(const PFEGammaAlgo::ProtoEGObject& RO1,
-				  const PFEGammaAlgo::ProtoEGObject& RO2 ) {
+
+  bool isROLinkedByClusterOrTrack(const PFEGammaAlgo::ProtoEGObject& RO1, const PFEGammaAlgo::ProtoEGObject& RO2) {
     // also don't allow ROs where both have clusters
     // and GSF tracks to merge (10 Dec 2013)
-    if(!RO1.primaryGSFs.empty() && !RO2.primaryGSFs.empty()) {
-      LOGDRESSED("isROLinkedByClusterOrTrack") 
-	<< "cannot merge, both have GSFs!" << std::endl;
+    if (!RO1.primaryGSFs.empty() && !RO2.primaryGSFs.empty()) {
+      LOGDRESSED("isROLinkedByClusterOrTrack") << "cannot merge, both have GSFs!" << std::endl;
       return false;
     }
     // don't allow EB/EE to mix (11 Sept 2013)
-    if( !RO1.ecalclusters.empty() && !RO2.ecalclusters.empty() ) {
-      if(RO1.ecalclusters.front()->clusterRef()->layer() !=
-	 RO2.ecalclusters.front()->clusterRef()->layer() ) {
-	LOGDRESSED("isROLinkedByClusterOrTrack") 
-	  << "cannot merge, different ECAL types!" << std::endl;
-	return false;
+    if (!RO1.ecalclusters.empty() && !RO2.ecalclusters.empty()) {
+      if (RO1.ecalclusters.front()->clusterRef()->layer() != RO2.ecalclusters.front()->clusterRef()->layer()) {
+        LOGDRESSED("isROLinkedByClusterOrTrack") << "cannot merge, different ECAL types!" << std::endl;
+        return false;
       }
     }
-    const reco::PFBlockRef& blk = RO1.parentBlock;    
+    const reco::PFBlockRef& blk = RO1.parentBlock;
     bool not_closer;
     // check links track -> cluster
-    for( const auto& cluster: RO1.ecalclusters ) {
-      for( const auto& primgsf : RO2.primaryGSFs ) {
-	not_closer = 
-	  elementNotCloserToOther(blk,
-				  cluster->type(),
-				  cluster->index(),
-				  primgsf->type(),
-				  primgsf->index());
-	if( not_closer ) {
-	  LOGDRESSED("isROLinkedByClusterOrTrack") 
-	    << "merged by cluster to primary GSF" << std::endl;
-	  return true;	  
-	} else {
-	  LOGDRESSED("isROLinkedByClusterOrTrack") 
-	    << "cluster to primary GSF failed since"
-	    << " cluster closer to another GSF" << std::endl;
-	}
+    for (const auto& cluster : RO1.ecalclusters) {
+      for (const auto& primgsf : RO2.primaryGSFs) {
+        not_closer = elementNotCloserToOther(blk, cluster->type(), cluster->index(), primgsf->type(), primgsf->index());
+        if (not_closer) {
+          LOGDRESSED("isROLinkedByClusterOrTrack") << "merged by cluster to primary GSF" << std::endl;
+          return true;
+        } else {
+          LOGDRESSED("isROLinkedByClusterOrTrack") << "cluster to primary GSF failed since"
+                                                   << " cluster closer to another GSF" << std::endl;
+        }
       }
-      for( const auto& primkf : RO2.primaryKFs) {
-	not_closer = 
-	  elementNotCloserToOther(blk,
-				  cluster->type(),
-				  cluster->index(),
-				  primkf->type(),
-				  primkf->index());
-	if( not_closer ) {
-	   LOGDRESSED("isROLinkedByClusterOrTrack") 
-	     << "merged by cluster to primary KF" << std::endl;
-	  return true;
-	}
+      for (const auto& primkf : RO2.primaryKFs) {
+        not_closer = elementNotCloserToOther(blk, cluster->type(), cluster->index(), primkf->type(), primkf->index());
+        if (not_closer) {
+          LOGDRESSED("isROLinkedByClusterOrTrack") << "merged by cluster to primary KF" << std::endl;
+          return true;
+        }
       }
-      for( const auto& secdkf : RO2.secondaryKFs) {
-	not_closer = 
-	    elementNotCloserToOther(blk,
-				    cluster->type(),
-				    cluster->index(),
-				    secdkf->type(),
-				    secdkf->index());
-	if( not_closer ) {
-	  LOGDRESSED("isROLinkedByClusterOrTrack") 
-	     << "merged by cluster to secondary KF" << std::endl;
-	  return true;	  
-	}
+      for (const auto& secdkf : RO2.secondaryKFs) {
+        not_closer = elementNotCloserToOther(blk, cluster->type(), cluster->index(), secdkf->type(), secdkf->index());
+        if (not_closer) {
+          LOGDRESSED("isROLinkedByClusterOrTrack") << "merged by cluster to secondary KF" << std::endl;
+          return true;
+        }
       }
       // check links brem -> cluster
-      for( const auto& brem : RO2.brems ) {
-	not_closer = elementNotCloserToOther(blk,
-					     cluster->type(),
-					     cluster->index(),
-					     brem->type(),
-					     brem->index());
-	if( not_closer ) {
-	  LOGDRESSED("isROLinkedByClusterOrTrack") 
-	     << "merged by cluster to brem KF" << std::endl;
-	  return true;
-	}
+      for (const auto& brem : RO2.brems) {
+        not_closer = elementNotCloserToOther(blk, cluster->type(), cluster->index(), brem->type(), brem->index());
+        if (not_closer) {
+          LOGDRESSED("isROLinkedByClusterOrTrack") << "merged by cluster to brem KF" << std::endl;
+          return true;
+        }
       }
-    }    
+    }
     // check links primary gsf -> secondary kf
-    for( const auto& primgsf : RO1.primaryGSFs ) {      
-      for( const auto& secdkf : RO2.secondaryKFs) {
-	not_closer = 
-	    elementNotCloserToOther(blk,
-				    primgsf->type(),
-				    primgsf->index(),
-				    secdkf->type(),
-				    secdkf->index());
-	if( not_closer ) {
-	  LOGDRESSED("isROLinkedByClusterOrTrack") 
-	     << "merged by GSF to secondary KF" << std::endl;
-	  return true;	  
-	}
+    for (const auto& primgsf : RO1.primaryGSFs) {
+      for (const auto& secdkf : RO2.secondaryKFs) {
+        not_closer = elementNotCloserToOther(blk, primgsf->type(), primgsf->index(), secdkf->type(), secdkf->index());
+        if (not_closer) {
+          LOGDRESSED("isROLinkedByClusterOrTrack") << "merged by GSF to secondary KF" << std::endl;
+          return true;
+        }
       }
     }
     // check links primary kf -> secondary kf
-    for( const auto& primkf : RO1.primaryKFs ) {      
-      for( const auto& secdkf : RO2.secondaryKFs) {
-	not_closer = 
-	    elementNotCloserToOther(blk,
-				    primkf->type(),
-				    primkf->index(),
-				    secdkf->type(),
-				    secdkf->index());
-	if( not_closer ) {
-	  LOGDRESSED("isROLinkedByClusterOrTrack") 
-	     << "merged by primary KF to secondary KF" << std::endl;
-	  return true;	  
-	}
+    for (const auto& primkf : RO1.primaryKFs) {
+      for (const auto& secdkf : RO2.secondaryKFs) {
+        not_closer = elementNotCloserToOther(blk, primkf->type(), primkf->index(), secdkf->type(), secdkf->index());
+        if (not_closer) {
+          LOGDRESSED("isROLinkedByClusterOrTrack") << "merged by primary KF to secondary KF" << std::endl;
+          return true;
+        }
       }
     }
     // check links secondary kf -> secondary kf
-    for( const auto& secdkf1 : RO1.secondaryKFs ) {           
-      for( const auto& secdkf2 : RO2.secondaryKFs) {
-	not_closer = 
-	    elementNotCloserToOther<true>(blk,
-					  secdkf1->type(),
-					  secdkf1->index(),
-					  secdkf2->type(),
-					  secdkf2->index());
-	if( not_closer ) {
-	  LOGDRESSED("isROLinkedByClusterOrTrack") 
-	     << "merged by secondary KF to secondary KF" << std::endl;
-	  return true;	  
-	}
+    for (const auto& secdkf1 : RO1.secondaryKFs) {
+      for (const auto& secdkf2 : RO2.secondaryKFs) {
+        not_closer =
+            elementNotCloserToOther<true>(blk, secdkf1->type(), secdkf1->index(), secdkf2->type(), secdkf2->index());
+        if (not_closer) {
+          LOGDRESSED("isROLinkedByClusterOrTrack") << "merged by secondary KF to secondary KF" << std::endl;
+          return true;
+        }
       }
-    }    
+    }
     return false;
   }
 
-  bool testIfROMergableByLink(const PFEGammaAlgo::ProtoEGObject& ro, PFEGammaAlgo::ProtoEGObject& comp)
-  {
-    const bool result = ( isROLinkedByClusterOrTrack(comp,ro) || isROLinkedByClusterOrTrack(ro,comp)   );
-    return result;      
+  bool testIfROMergableByLink(const PFEGammaAlgo::ProtoEGObject& ro, PFEGammaAlgo::ProtoEGObject& comp) {
+    const bool result = (isROLinkedByClusterOrTrack(comp, ro) || isROLinkedByClusterOrTrack(ro, comp));
+    return result;
   }
-  
-  std::vector<const ClusterElement*> 
-  getSCAssociatedECALsSafe(const reco::SuperClusterRef& scref,
-			   std::vector<FlaggedPtr<const reco::PFBlockElement>>& ecals) {
-    std::vector<const ClusterElement*> cluster_list;    
+
+  std::vector<const ClusterElement*> getSCAssociatedECALsSafe(
+      const reco::SuperClusterRef& scref, std::vector<FlaggedPtr<const reco::PFBlockElement>>& ecals) {
+    std::vector<const ClusterElement*> cluster_list;
     auto sccl = scref->clustersBegin();
     auto scend = scref->clustersEnd();
     auto pfc = ecals.begin();
     auto pfcend = ecals.end();
-    for( ; sccl != scend; ++sccl ) {
+    for (; sccl != scend; ++sccl) {
       std::vector<const ClusterElement*> matched_pfcs;
       const double eg_energy = (*sccl)->energy();
 
-      for( pfc = ecals.begin(); pfc != pfcend; ++pfc ) {
-	const ClusterElement *pfcel = 
-	  docast(const ClusterElement*, pfc->get());
-	const bool matched = 
-	  ClusterClusterMapping::overlap(**sccl,*(pfcel->clusterRef()));
-     // need to protect against high energy clusters being attached
-     // to low-energy SCs          
-	if( matched && pfcel->clusterRef()->energy() < 1.2*scref->energy()) {
-	  matched_pfcs.push_back(pfcel);
-	}
+      for (pfc = ecals.begin(); pfc != pfcend; ++pfc) {
+        const ClusterElement* pfcel = docast(const ClusterElement*, pfc->get());
+        const bool matched = ClusterClusterMapping::overlap(**sccl, *(pfcel->clusterRef()));
+        // need to protect against high energy clusters being attached
+        // to low-energy SCs
+        if (matched && pfcel->clusterRef()->energy() < 1.2 * scref->energy()) {
+          matched_pfcs.push_back(pfcel);
+        }
       }
-      std::sort(matched_pfcs.begin(),matched_pfcs.end());
+      std::sort(matched_pfcs.begin(), matched_pfcs.end());
 
       double min_residual = 1e6;
       std::vector<const ClusterElement*> best_comb;
-      for( size_t i = 1; i <= matched_pfcs.size(); ++i ) {
-	//now we find the combination of PF-clusters which
-	//has the smallest energy residual with respect to the
-	//EG-cluster we are looking at now
-	do {
-	  double energy = std::accumulate(matched_pfcs.begin(),
-					  matched_pfcs.begin()+i,
-					  0.0,
-					  [](const double a,
-					     const ClusterElement* c) 
-			       { return a + c->clusterRef()->energy(); });
-	  const double resid = std::abs(energy - eg_energy);
-	  if( resid < min_residual ) {
-	    best_comb.clear();
-	    best_comb.reserve(i);
-	    min_residual = resid;
-	    best_comb.insert(best_comb.begin(),
-			     matched_pfcs.begin(),
-			     matched_pfcs.begin()+i);
-	  }
-	}while(notboost::next_combination(matched_pfcs.begin(),
-                                          matched_pfcs.begin()+i,
-                                          matched_pfcs.end()));
+      for (size_t i = 1; i <= matched_pfcs.size(); ++i) {
+        //now we find the combination of PF-clusters which
+        //has the smallest energy residual with respect to the
+        //EG-cluster we are looking at now
+        do {
+          double energy = std::accumulate(
+              matched_pfcs.begin(), matched_pfcs.begin() + i, 0.0, [](const double a, const ClusterElement* c) {
+                return a + c->clusterRef()->energy();
+              });
+          const double resid = std::abs(energy - eg_energy);
+          if (resid < min_residual) {
+            best_comb.clear();
+            best_comb.reserve(i);
+            min_residual = resid;
+            best_comb.insert(best_comb.begin(), matched_pfcs.begin(), matched_pfcs.begin() + i);
+          }
+        } while (notboost::next_combination(matched_pfcs.begin(), matched_pfcs.begin() + i, matched_pfcs.end()));
       }
-      for( const auto& clelem : best_comb ) {
-	if( std::find(cluster_list.begin(),cluster_list.end(),clelem) ==
-	    cluster_list.end() ) {
-	  cluster_list.push_back(clelem);
-	}
+      for (const auto& clelem : best_comb) {
+        if (std::find(cluster_list.begin(), cluster_list.end(), clelem) == cluster_list.end()) {
+          cluster_list.push_back(clelem);
+        }
       }
     }
     return cluster_list;
   }
-  bool addPFClusterToROSafe(const ClusterElement* cl,
-			    PFEGammaAlgo::ProtoEGObject& RO) {
-    if( RO.ecalclusters.empty() ) {
-      RO.ecalclusters.emplace_back(cl,true);
+  bool addPFClusterToROSafe(const ClusterElement* cl, PFEGammaAlgo::ProtoEGObject& RO) {
+    if (RO.ecalclusters.empty()) {
+      RO.ecalclusters.emplace_back(cl, true);
       return true;
     } else {
       const PFLayer::Layer clayer = cl->clusterRef()->layer();
-      const PFLayer::Layer blayer = 
-	RO.ecalclusters.back()->clusterRef()->layer();
-      if( clayer == blayer ) {
-	RO.ecalclusters.emplace_back(cl,true);
-	return true;
+      const PFLayer::Layer blayer = RO.ecalclusters.back()->clusterRef()->layer();
+      if (clayer == blayer) {
+        RO.ecalclusters.emplace_back(cl, true);
+        return true;
       }
     }
     return false;
   }
-  
+
   // sets the cluster best associated to the GSF track
   // leave it null if no GSF track
   void setROElectronCluster(PFEGammaAlgo::ProtoEGObject& RO) {
-    if( RO.ecalclusters.empty() ) return;
+    if (RO.ecalclusters.empty())
+      return;
     RO.lateBrem = -1;
     RO.firstBrem = -1;
-    RO.nBremsWithClusters = -1;    
+    RO.nBremsWithClusters = -1;
     const reco::PFBlockElementBrem *firstBrem = nullptr, *lastBrem = nullptr;
-    const reco::PFBlockElementCluster *bremCluster = nullptr, *gsfCluster = nullptr,
-      *kfCluster = nullptr, *gsfCluster_noassc = nullptr;
+    const reco::PFBlockElementCluster *bremCluster = nullptr, *gsfCluster = nullptr, *kfCluster = nullptr,
+                                      *gsfCluster_noassc = nullptr;
     const reco::PFBlockRef& parent = RO.parentBlock;
     int nBremClusters = 0;
     constexpr float maxDist = 1e6;
     float mDist_gsf(maxDist), mDist_gsf_noassc(maxDist), mDist_kf(maxDist);
-    for( const auto& cluster : RO.ecalclusters ) {      
-      for( const auto& gsf : RO.primaryGSFs ) {
-	const bool hasclu = elementNotCloserToOther(parent,
-						    gsf->type(),
-						    gsf->index(),
-						    cluster->type(),
-						    cluster->index());
-	const float deta = 
-	  std::abs(cluster->clusterRef()->positionREP().eta() -
-		   gsf->positionAtECALEntrance().eta());
-	const float dphi = 
-	  std::abs(TVector2::Phi_mpi_pi(
-			cluster->clusterRef()->positionREP().phi() - 
-			gsf->positionAtECALEntrance().phi()));
-	const float dist = std::hypot(deta,dphi);
-	if( hasclu && dist < mDist_gsf ) {	  
-	  gsfCluster = cluster.get();
-	  mDist_gsf = dist;
-	} else if ( dist < mDist_gsf_noassc ) {
-	  gsfCluster_noassc = cluster.get();
-	  mDist_gsf_noassc = dist;
-	}
-      }    
-      for( const auto& kf  : RO.primaryKFs ) {
-	const bool hasclu = elementNotCloserToOther(parent,
-						    kf->type(),
-						    kf->index(),
-						    cluster->type(),
-						    cluster->index());
-	const float dist = parent->dist(cluster->index(),
-					kf->index(),
-					parent->linkData(),
-					reco::PFBlock::LINKTEST_ALL);
-	if( hasclu && dist < mDist_kf ) {
-	  kfCluster = cluster.get();
-	  mDist_kf = dist;
-	}
+    for (const auto& cluster : RO.ecalclusters) {
+      for (const auto& gsf : RO.primaryGSFs) {
+        const bool hasclu =
+            elementNotCloserToOther(parent, gsf->type(), gsf->index(), cluster->type(), cluster->index());
+        const float deta = std::abs(cluster->clusterRef()->positionREP().eta() - gsf->positionAtECALEntrance().eta());
+        const float dphi = std::abs(
+            TVector2::Phi_mpi_pi(cluster->clusterRef()->positionREP().phi() - gsf->positionAtECALEntrance().phi()));
+        const float dist = std::hypot(deta, dphi);
+        if (hasclu && dist < mDist_gsf) {
+          gsfCluster = cluster.get();
+          mDist_gsf = dist;
+        } else if (dist < mDist_gsf_noassc) {
+          gsfCluster_noassc = cluster.get();
+          mDist_gsf_noassc = dist;
+        }
       }
-      for( const auto& brem : RO.brems ) {
-	const bool hasclu = elementNotCloserToOther(parent,
-						    brem->type(),
-						    brem->index(),
-						    cluster->type(),
-						    cluster->index());
-	if( hasclu ) {	
-	  ++nBremClusters;
-	  if( !firstBrem || 
-	      ( firstBrem->indTrajPoint() - 2 > 
-		brem->indTrajPoint() - 2) ) {
-	    firstBrem = brem;
-	  }
-	  if( !lastBrem || 
-	      ( lastBrem->indTrajPoint() - 2 < 
-		brem->indTrajPoint() - 2) ) {
-	    lastBrem = brem;
-	    bremCluster = cluster.get();
-	  }
-	}
+      for (const auto& kf : RO.primaryKFs) {
+        const bool hasclu = elementNotCloserToOther(parent, kf->type(), kf->index(), cluster->type(), cluster->index());
+        const float dist = parent->dist(cluster->index(), kf->index(), parent->linkData(), reco::PFBlock::LINKTEST_ALL);
+        if (hasclu && dist < mDist_kf) {
+          kfCluster = cluster.get();
+          mDist_kf = dist;
+        }
+      }
+      for (const auto& brem : RO.brems) {
+        const bool hasclu =
+            elementNotCloserToOther(parent, brem->type(), brem->index(), cluster->type(), cluster->index());
+        if (hasclu) {
+          ++nBremClusters;
+          if (!firstBrem || (firstBrem->indTrajPoint() - 2 > brem->indTrajPoint() - 2)) {
+            firstBrem = brem;
+          }
+          if (!lastBrem || (lastBrem->indTrajPoint() - 2 < brem->indTrajPoint() - 2)) {
+            lastBrem = brem;
+            bremCluster = cluster.get();
+          }
+        }
       }
     }
-    if( !gsfCluster && !kfCluster && !bremCluster ) {
+    if (!gsfCluster && !kfCluster && !bremCluster) {
       gsfCluster = gsfCluster_noassc;
     }
     RO.nBremsWithClusters = nBremClusters;
     RO.lateBrem = 0;
-    if( gsfCluster ) {
+    if (gsfCluster) {
       RO.electronClusters.push_back(gsfCluster);
-    } else if ( kfCluster ) {
+    } else if (kfCluster) {
       RO.electronClusters.push_back(kfCluster);
     }
-    if( bremCluster && !gsfCluster && !kfCluster ) {
+    if (bremCluster && !gsfCluster && !kfCluster) {
       RO.electronClusters.push_back(bremCluster);
     }
-    if( firstBrem && RO.ecalclusters.size() > 1 ) {      
+    if (firstBrem && RO.ecalclusters.size() > 1) {
       RO.firstBrem = firstBrem->indTrajPoint() - 2;
-      if( bremCluster == gsfCluster ) RO.lateBrem = 1;
+      if (bremCluster == gsfCluster)
+        RO.lateBrem = 1;
     }
   }
-}
+}  // namespace
 
-PFEGammaAlgo::
-PFEGammaAlgo(const PFEGammaAlgo::PFEGConfigInfo& cfg, GBRForests const& gbrForests)
-    : gbrForests_(gbrForests) , cfg_(cfg)
-{}
+PFEGammaAlgo::PFEGammaAlgo(const PFEGammaAlgo::PFEGConfigInfo& cfg, GBRForests const& gbrForests)
+    : gbrForests_(gbrForests), cfg_(cfg) {}
 
-float PFEGammaAlgo::evaluateSingleLegMVA(const reco::PFBlockRef& blockRef, 
-                                         const reco::Vertex& primaryVtx, 
-                                         unsigned int trackIndex)
-{
-  const reco::PFBlock& block = *blockRef;  
-  const edm::OwnVector< reco::PFBlockElement >& elements = block.elements();  
-  //use this to store linkdata in the associatedElements function below  
-  const PFBlock::LinkData& linkData =  block.linkData();  
-  //calculate MVA Variables  
-  const float chi2     = elements[trackIndex].trackRef()->chi2()/elements[trackIndex].trackRef()->ndof(); 
-  const float nlost    = elements[trackIndex].trackRef()->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS); 
-  const float nLayers  = elements[trackIndex].trackRef()->hitPattern().trackerLayersWithMeasurement(); 
-  const float trackPt  = elements[trackIndex].trackRef()->pt();  
-  const float stip     = elements[trackIndex].trackRefPF()->STIP();  
-   
+float PFEGammaAlgo::evaluateSingleLegMVA(const reco::PFBlockRef& blockRef,
+                                         const reco::Vertex& primaryVtx,
+                                         unsigned int trackIndex) {
+  const reco::PFBlock& block = *blockRef;
+  const edm::OwnVector<reco::PFBlockElement>& elements = block.elements();
+  //use this to store linkdata in the associatedElements function below
+  const PFBlock::LinkData& linkData = block.linkData();
+  //calculate MVA Variables
+  const float chi2 = elements[trackIndex].trackRef()->chi2() / elements[trackIndex].trackRef()->ndof();
+  const float nlost = elements[trackIndex].trackRef()->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS);
+  const float nLayers = elements[trackIndex].trackRef()->hitPattern().trackerLayersWithMeasurement();
+  const float trackPt = elements[trackIndex].trackRef()->pt();
+  const float stip = elements[trackIndex].trackRefPF()->STIP();
+
   float linkedE = 0;
   float linkedH = 0;
-  std::multimap<double, unsigned int> ecalAssoTrack;  
-  block.associatedElements(trackIndex,linkData,  
-                           ecalAssoTrack,  
-                           reco::PFBlockElement::ECAL,  
-                           reco::PFBlock::LINKTEST_ALL );  
-  std::multimap<double, unsigned int> hcalAssoTrack;  
-  block.associatedElements(trackIndex,linkData,  
-                           hcalAssoTrack,  
-                           reco::PFBlockElement::HCAL,  
-                           reco::PFBlock::LINKTEST_ALL );  
-  if(!ecalAssoTrack.empty())
-  {
-    for (auto & itecal : ecalAssoTrack)
-    {
-      linkedE = linkedE+elements[itecal.second].clusterRef()->energy();  
-    }  
-  }  
-  if(!hcalAssoTrack.empty())
-  {
-    for (auto & ithcal : hcalAssoTrack)
-    {
-      linkedH = linkedH+elements[ithcal.second].clusterRef()->energy();  
-    }  
-  }  
-  const float eOverPt = linkedE / elements[trackIndex].trackRef()->pt();  
-  const float hOverPt = linkedH / elements[trackIndex].trackRef()->pt();  
-  GlobalVector rvtx(elements[trackIndex].trackRef()->innerPosition().X()-primaryVtx.x(),  
-                    elements[trackIndex].trackRef()->innerPosition().Y()-primaryVtx.y(),  
-                    elements[trackIndex].trackRef()->innerPosition().Z()-primaryVtx.z());  
-  double vtxPhi = rvtx.phi();  
-  //delta Phi between conversion vertex and track  
-  float delPhi = fabs(deltaPhi(vtxPhi, elements[trackIndex].trackRef()->innerMomentum().Phi()));  
-  
-  float vars[] = { delPhi, nLayers, chi2, eOverPt,
-                   hOverPt, trackPt, stip, nlost };
+  std::multimap<double, unsigned int> ecalAssoTrack;
+  block.associatedElements(
+      trackIndex, linkData, ecalAssoTrack, reco::PFBlockElement::ECAL, reco::PFBlock::LINKTEST_ALL);
+  std::multimap<double, unsigned int> hcalAssoTrack;
+  block.associatedElements(
+      trackIndex, linkData, hcalAssoTrack, reco::PFBlockElement::HCAL, reco::PFBlock::LINKTEST_ALL);
+  if (!ecalAssoTrack.empty()) {
+    for (auto& itecal : ecalAssoTrack) {
+      linkedE = linkedE + elements[itecal.second].clusterRef()->energy();
+    }
+  }
+  if (!hcalAssoTrack.empty()) {
+    for (auto& ithcal : hcalAssoTrack) {
+      linkedH = linkedH + elements[ithcal.second].clusterRef()->energy();
+    }
+  }
+  const float eOverPt = linkedE / elements[trackIndex].trackRef()->pt();
+  const float hOverPt = linkedH / elements[trackIndex].trackRef()->pt();
+  GlobalVector rvtx(elements[trackIndex].trackRef()->innerPosition().X() - primaryVtx.x(),
+                    elements[trackIndex].trackRef()->innerPosition().Y() - primaryVtx.y(),
+                    elements[trackIndex].trackRef()->innerPosition().Z() - primaryVtx.z());
+  double vtxPhi = rvtx.phi();
+  //delta Phi between conversion vertex and track
+  float delPhi = fabs(deltaPhi(vtxPhi, elements[trackIndex].trackRef()->innerMomentum().Phi()));
+
+  float vars[] = {delPhi, nLayers, chi2, eOverPt, hOverPt, trackPt, stip, nlost};
 
   return gbrForests_.singleLeg_->GetAdaBoostClassifier(vars);
 }
 
 bool PFEGammaAlgo::isMuon(const reco::PFBlockElement& pfbe) {
-  switch( pfbe.type() ) {
-  case reco::PFBlockElement::GSF:    
-    {
+  switch (pfbe.type()) {
+    case reco::PFBlockElement::GSF: {
       auto& elements = _currentblock->elements();
-      std::multimap<double,unsigned> tks;
-      _currentblock->associatedElements(pfbe.index(),
-					_currentlinks,
-					tks,
-					reco::PFBlockElement::TRACK,
-					reco::PFBlock::LINKTEST_ALL);      
-      for( const auto& tk : tks ) {
-	if( PFMuonAlgo::isMuon(elements[tk.second]) ) {
-	  return true;
-	}
+      std::multimap<double, unsigned> tks;
+      _currentblock->associatedElements(
+          pfbe.index(), _currentlinks, tks, reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL);
+      for (const auto& tk : tks) {
+        if (PFMuonAlgo::isMuon(elements[tk.second])) {
+          return true;
+        }
       }
-    }
-    break;
-  case reco::PFBlockElement::TRACK:
-    return PFMuonAlgo::isMuon(pfbe);
-    break;
-  default:
-    break;
+    } break;
+    case reco::PFBlockElement::TRACK:
+      return PFMuonAlgo::isMuon(pfbe);
+      break;
+    default:
+      break;
   }
   return false;
 }
 
 PFEGammaAlgo::EgammaObjects PFEGammaAlgo::operator()(const reco::PFBlockRef& block) {
-  LOGVERB("PFEGammaAlgo") 
-    << "Resetting PFEGammaAlgo for new block and running!" << std::endl;
+  LOGVERB("PFEGammaAlgo") << "Resetting PFEGammaAlgo for new block and running!" << std::endl;
 
   // candidate collections:
-  // this starts off as an inclusive list of prototype objects built from 
+  // this starts off as an inclusive list of prototype objects built from
   // supercluster/ecal-driven seeds and tracker driven seeds in a block
-  // it is then refined through by various cleanings, determining the energy 
+  // it is then refined through by various cleanings, determining the energy
   // flow.
   // use list for constant-time removals
   std::list<ProtoEGObject> refinableObjects;
 
   _splayedblock.clear();
-  _splayedblock.resize(13); // make sure that we always have the HGCAL entry
+  _splayedblock.resize(13);  // make sure that we always have the HGCAL entry
 
   _currentblock = block;
   _currentlinks = block->linkData();
   //LOGDRESSED("PFEGammaAlgo") << *_currentblock << std::endl;
-  LOGVERB("PFEGammaAlgo") << "Splaying block" << std::endl;  
+  LOGVERB("PFEGammaAlgo") << "Splaying block" << std::endl;
   //unwrap the PF block into a fast access map
-  for( const auto& pfelement : _currentblock->elements() ) {
-    if( isMuon(pfelement) ) continue; // don't allow muons in our element list
-    if (pfelement.type() == PFBlockElement::HCAL && 
-        pfelement.clusterRef()->flags() & reco::CaloCluster::badHcalMarker) continue; // skip also dead area markers for now
-    const size_t itype = (size_t)pfelement.type();    
-    if( itype >= _splayedblock.size() ) _splayedblock.resize(itype+1);    
-    _splayedblock[itype].emplace_back(&pfelement,true);
+  for (const auto& pfelement : _currentblock->elements()) {
+    if (isMuon(pfelement))
+      continue;  // don't allow muons in our element list
+    if (pfelement.type() == PFBlockElement::HCAL && pfelement.clusterRef()->flags() & reco::CaloCluster::badHcalMarker)
+      continue;  // skip also dead area markers for now
+    const size_t itype = (size_t)pfelement.type();
+    if (itype >= _splayedblock.size())
+      _splayedblock.resize(itype + 1);
+    _splayedblock[itype].emplace_back(&pfelement, true);
   }
 
   // show the result of splaying the tree if it's really *really* needed
 #ifdef PFLOW_DEBUG
   std::stringstream splayout;
-  for( size_t itype = 0; itype < _splayedblock.size(); ++itype ) {
+  for (size_t itype = 0; itype < _splayedblock.size(); ++itype) {
     splayout << "\tType: " << itype << " indices: ";
-    for( const auto& flaggedelement : _splayedblock[itype] ) {
+    for (const auto& flaggedelement : _splayedblock[itype]) {
       splayout << flaggedelement->index() << ' ';
     }
-    if( itype != _splayedblock.size() - 1 ) splayout << std::endl;
+    if (itype != _splayedblock.size() - 1)
+      splayout << std::endl;
   }
-  LOGVERB("PFEGammaAlgo") << splayout.str();  
+  LOGVERB("PFEGammaAlgo") << splayout.str();
 #endif
 
   // precleaning of the ECAL clusters with respect to primary KF tracks
   // we don't allow clusters in super clusters to be locked out this way
   removeOrLinkECALClustersToKFTracks();
 
-  initializeProtoCands(refinableObjects); 
-  LOGDRESSED("PFEGammaAlgo") 
-    << "Initialized " << refinableObjects.size() << " proto-EGamma objects"
-    << std::endl;
+  initializeProtoCands(refinableObjects);
+  LOGDRESSED("PFEGammaAlgo") << "Initialized " << refinableObjects.size() << " proto-EGamma objects" << std::endl;
   dumpCurrentRefinableObjects();
 
   //
   // now we start the refining steps
   //
   //
-  
+
   // --- Primary Linking Step ---
   // since this is particle flow and we try to work from the pixels out
   // we start by linking the tracks together and finding the ECAL clusters
-  for( auto& RO : refinableObjects ) {
+  for (auto& RO : refinableObjects) {
     // find the KF tracks associated to GSF primary tracks
     linkRefinableObjectGSFTracksToKFs(RO);
     // do the same for HCAL clusters associated to the GSF
@@ -731,21 +594,19 @@ PFEGammaAlgo::EgammaObjects PFEGammaAlgo::operator()(const reco::PFBlockRef& blo
     linkRefinableObjectBremTangentsToECAL(RO);
   }
 
-  LOGDRESSED("PFEGammaAlgo")
-    << "Dumping after GSF and KF Track (Primary) Linking : " << std::endl;
+  LOGDRESSED("PFEGammaAlgo") << "Dumping after GSF and KF Track (Primary) Linking : " << std::endl;
   dumpCurrentRefinableObjects();
 
   // merge objects after primary linking
   mergeROsByAnyLink(refinableObjects);
 
-  LOGDRESSED("PFEGammaAlgo")
-    << "Dumping after first merging operation : " << std::endl;
+  LOGDRESSED("PFEGammaAlgo") << "Dumping after first merging operation : " << std::endl;
   dumpCurrentRefinableObjects();
 
   // --- Secondary Linking Step ---
   // after this we go through the ECAL clusters on the remaining tracks
   // and try to link those in...
-  for( auto& RO : refinableObjects ) {    
+  for (auto& RO : refinableObjects) {
     // look for conversion legs
     linkRefinableObjectECALToSingleLegConv(RO);
     dumpCurrentRefinableObjects();
@@ -753,66 +614,57 @@ PFEGammaAlgo::EgammaObjects PFEGammaAlgo::operator()(const reco::PFBlockRef& blo
     linkRefinableObjectConvSecondaryKFsToSecondaryKFs(RO);
     // look again for ECAL clusters (this time with an e/p cut)
     linkRefinableObjectSecondaryKFsToECAL(RO);
-  } 
+  }
 
-  LOGDRESSED("PFEGammaAlgo")
-    << "Dumping after ECAL to Track (Secondary) Linking : " << std::endl;
+  LOGDRESSED("PFEGammaAlgo") << "Dumping after ECAL to Track (Secondary) Linking : " << std::endl;
   dumpCurrentRefinableObjects();
 
   // merge objects after primary linking
   mergeROsByAnyLink(refinableObjects);
 
-  LOGDRESSED("PFEGammaAlgo")
-    << "There are " << refinableObjects.size() 
-    << " after the 2nd merging step." << std::endl;
+  LOGDRESSED("PFEGammaAlgo") << "There are " << refinableObjects.size() << " after the 2nd merging step." << std::endl;
   dumpCurrentRefinableObjects();
 
   // -- unlinking and proto-object vetos, final sorting
-  for( auto& RO : refinableObjects ) {
+  for (auto& RO : refinableObjects) {
     // remove secondary KFs (and possibly ECALs) matched to HCAL clusters
     unlinkRefinableObjectKFandECALMatchedToHCAL(RO, false, false);
-    // remove secondary KFs and ECALs linked to them that have bad E/p_in 
+    // remove secondary KFs and ECALs linked to them that have bad E/p_in
     // and spoil the resolution
     unlinkRefinableObjectKFandECALWithBadEoverP(RO);
     // put things back in order after partitioning
-    std::sort(RO.ecalclusters.begin(), RO.ecalclusters.end(),
-	    [](auto const& a, auto const& b) 
-	    { return ( a->clusterRef()->correctedEnergy() > 
-		       b->clusterRef()->correctedEnergy() ) ; });
+    std::sort(RO.ecalclusters.begin(), RO.ecalclusters.end(), [](auto const& a, auto const& b) {
+      return (a->clusterRef()->correctedEnergy() > b->clusterRef()->correctedEnergy());
+    });
     setROElectronCluster(RO);
   }
 
-  LOGDRESSED("PFEGammaAlgo")
-    << "There are " << refinableObjects.size() 
-    << " after the unlinking and vetos step." << std::endl;
+  LOGDRESSED("PFEGammaAlgo") << "There are " << refinableObjects.size() << " after the unlinking and vetos step."
+                             << std::endl;
   dumpCurrentRefinableObjects();
 
   // fill the PF candidates and then build the refined SC
   return fillPFCandidates(refinableObjects);
-
 }
 
-void PFEGammaAlgo::
-initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
+void PFEGammaAlgo::initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
   // step 1: build SC based proto-candidates
   // in the future there will be an SC Et requirement made here to control
   // block size
-  for( auto& element : _splayedblock[PFBlockElement::SC] ) {
-    LOGDRESSED("PFEGammaAlgo") 
-      << "creating SC-based proto-object" << std::endl
-      << "\tSC at index: " << element->index() 
-      << " has type: " << element->type() << std::endl;
+  for (auto& element : _splayedblock[PFBlockElement::SC]) {
+    LOGDRESSED("PFEGammaAlgo") << "creating SC-based proto-object" << std::endl
+                               << "\tSC at index: " << element->index() << " has type: " << element->type()
+                               << std::endl;
     element.setFlag(false);
     ProtoEGObject fromSC;
     fromSC.nBremsWithClusters = -1;
     fromSC.firstBrem = -1;
     fromSC.lateBrem = -1;
     fromSC.parentBlock = _currentblock;
-    fromSC.parentSC = docast(const PFSCElement*,element.get());
+    fromSC.parentSC = docast(const PFSCElement*, element.get());
     // splay the supercluster so we can knock out used elements
-    bool sc_success = 
-      unwrapSuperCluster(fromSC.parentSC,fromSC.ecalclusters,fromSC.ecal2ps);
-    if( sc_success ) {
+    bool sc_success = unwrapSuperCluster(fromSC.parentSC, fromSC.ecalclusters, fromSC.ecal2ps);
+    if (sc_success) {
       /*
       auto ins_pos = std::lower_bound(refinableObjects.begin(),
 				      refinableObjects.end(),
@@ -826,233 +678,203 @@ initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
 					return a_en < b_en;
 				      });
       */
-      egobjs.insert(egobjs.end(),fromSC);
+      egobjs.insert(egobjs.end(), fromSC);
     }
   }
   // step 2: build GSF-seed-based proto-candidates
   reco::GsfTrackRef gsfref_forextra;
   reco::TrackExtraRef gsftrk_extra;
-  reco::ElectronSeedRef theseedref; 
-  for( auto& element : _splayedblock[PFBlockElement::GSF] ) {
-    LOGDRESSED("PFEGammaAlgo") 
-      << "creating GSF-based proto-object" << std::endl
-      << "\tGSF at index: " << element->index() 
-      << " has type: " << element->type() << std::endl;
-    const PFGSFElement* elementAsGSF = 
-      docast(const PFGSFElement*,element.get());
-    if( elementAsGSF->trackType(reco::PFBlockElement::T_FROM_GAMMACONV) ) {
-      continue; // for now, do not allow dedicated brems to make proto-objects
+  reco::ElectronSeedRef theseedref;
+  for (auto& element : _splayedblock[PFBlockElement::GSF]) {
+    LOGDRESSED("PFEGammaAlgo") << "creating GSF-based proto-object" << std::endl
+                               << "\tGSF at index: " << element->index() << " has type: " << element->type()
+                               << std::endl;
+    const PFGSFElement* elementAsGSF = docast(const PFGSFElement*, element.get());
+    if (elementAsGSF->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)) {
+      continue;  // for now, do not allow dedicated brems to make proto-objects
     }
     element.setFlag(false);
-    
-    ProtoEGObject fromGSF;  
+
+    ProtoEGObject fromGSF;
     fromGSF.nBremsWithClusters = -1;
     fromGSF.firstBrem = -1;
     fromGSF.lateBrem = 0;
     gsfref_forextra = elementAsGSF->GsftrackRef();
-    gsftrk_extra = ( gsfref_forextra.isAvailable() ? 
-		     gsfref_forextra->extra() : reco::TrackExtraRef() );
-    theseedref = ( gsftrk_extra.isAvailable() ?
-		   gsftrk_extra->seedRef().castTo<reco::ElectronSeedRef>() :
-		   reco::ElectronSeedRef() );  
+    gsftrk_extra = (gsfref_forextra.isAvailable() ? gsfref_forextra->extra() : reco::TrackExtraRef());
+    theseedref = (gsftrk_extra.isAvailable() ? gsftrk_extra->seedRef().castTo<reco::ElectronSeedRef>()
+                                             : reco::ElectronSeedRef());
     fromGSF.electronSeed = theseedref;
     // exception if there's no seed
-    if(fromGSF.electronSeed.isNull() || !fromGSF.electronSeed.isAvailable()) {
+    if (fromGSF.electronSeed.isNull() || !fromGSF.electronSeed.isAvailable()) {
       std::stringstream gsf_err;
-      elementAsGSF->Dump(gsf_err,"\t");
+      elementAsGSF->Dump(gsf_err, "\t");
       throw cms::Exception("PFEGammaAlgo::initializeProtoCands()")
-	<< "Found a GSF track with no seed! This should not happen!" 
-	<< std::endl << gsf_err.str() << std::endl;
+          << "Found a GSF track with no seed! This should not happen!" << std::endl
+          << gsf_err.str() << std::endl;
     }
     // flag this GSF element as globally used and push back the track ref
     // into the protocand
     element.setFlag(false);
     fromGSF.parentBlock = _currentblock;
     fromGSF.primaryGSFs.push_back(elementAsGSF);
-    // add the directly matched brem tangents    
-    for( auto& brem : _splayedblock[PFBlockElement::BREM] ) {
-      float dist = _currentblock->dist(elementAsGSF->index(),
-				       brem->index(),
-				       _currentlinks,
-				       reco::PFBlock::LINKTEST_ALL);
-      if( dist == 0.001f ) {
-	const PFBremElement* eAsBrem = 
-	  docast(const PFBremElement*,brem.get());
-	fromGSF.brems.push_back(eAsBrem);
-	fromGSF.localMap.insert(eAsBrem,elementAsGSF);
-	 brem.setFlag(false);
-       }
-     }
-     // if this track is ECAL seeded reset links or import cluster
-     // tracker (this is pixel only, right?) driven seeds just get the GSF
-     // track associated since this only branches for ECAL Driven seeds
-     if( fromGSF.electronSeed->isEcalDriven() ) {
-       // step 2a: either merge with existing ProtoEG object with SC or add 
-       //          SC directly to this proto EG object if not present
-       LOGDRESSED("PFEGammaAlgo")
-	 << "GSF-based proto-object is ECAL driven, merging SC-cand"
-	 << std::endl;
-       LOGVERB("PFEGammaAlgo")
-	 << "ECAL Seed Ptr: " << fromGSF.electronSeed.get() 
-	 << " isAvailable: " << fromGSF.electronSeed.isAvailable() 
-	 << " isNonnull: " << fromGSF.electronSeed.isNonnull() 
-	 << std::endl;           
-       SeedMatchesToProtoObject sctoseedmatch(fromGSF.electronSeed);      
-       auto objsbegin = egobjs.begin();
-       auto objsend   = egobjs.end();
-       // this auto is a std::list<ProtoEGObject>::iterator
-       auto clusmatch = std::find_if(objsbegin,objsend,sctoseedmatch);
-       if( clusmatch != objsend ) {
-	 fromGSF.parentSC = clusmatch->parentSC;
-	 fromGSF.ecalclusters = std::move(clusmatch->ecalclusters);
-	 fromGSF.ecal2ps  = std::move(clusmatch->ecal2ps);
-	 egobjs.erase(clusmatch);	
-       } else if (fromGSF.electronSeed.isAvailable()  && 
-		  fromGSF.electronSeed.isNonnull()) {
-	 // link tests in the gap region can current split a gap electron
-	 // HEY THIS IS A WORK AROUND FOR A KNOWN BUG IN PFBLOCKALGO
-	 // MAYBE WE SHOULD FIX IT??????????????????????????????????
-	 LOGDRESSED("PFEGammaAlgo")
-	   << "Encountered the known GSF-SC splitting bug "
-	   << " in PFBlockAlgo! We should really fix this!" << std::endl; 
-       } else { // SC was not in a earlier proto-object	
-	 std::stringstream gsf_err;
-	 elementAsGSF->Dump(gsf_err,"\t");
-	 throw cms::Exception("PFEGammaAlgo::initializeProtoCands()")
-	   << "Expected SuperCluster from ECAL driven GSF seed "
-	   << "was not found in the block!" << std::endl 
-	   << gsf_err.str() << std::endl;
-       } // supercluster in block
-     } // is ECAL driven seed?   
+    // add the directly matched brem tangents
+    for (auto& brem : _splayedblock[PFBlockElement::BREM]) {
+      float dist =
+          _currentblock->dist(elementAsGSF->index(), brem->index(), _currentlinks, reco::PFBlock::LINKTEST_ALL);
+      if (dist == 0.001f) {
+        const PFBremElement* eAsBrem = docast(const PFBremElement*, brem.get());
+        fromGSF.brems.push_back(eAsBrem);
+        fromGSF.localMap.insert(eAsBrem, elementAsGSF);
+        brem.setFlag(false);
+      }
+    }
+    // if this track is ECAL seeded reset links or import cluster
+    // tracker (this is pixel only, right?) driven seeds just get the GSF
+    // track associated since this only branches for ECAL Driven seeds
+    if (fromGSF.electronSeed->isEcalDriven()) {
+      // step 2a: either merge with existing ProtoEG object with SC or add
+      //          SC directly to this proto EG object if not present
+      LOGDRESSED("PFEGammaAlgo") << "GSF-based proto-object is ECAL driven, merging SC-cand" << std::endl;
+      LOGVERB("PFEGammaAlgo") << "ECAL Seed Ptr: " << fromGSF.electronSeed.get()
+                              << " isAvailable: " << fromGSF.electronSeed.isAvailable()
+                              << " isNonnull: " << fromGSF.electronSeed.isNonnull() << std::endl;
+      SeedMatchesToProtoObject sctoseedmatch(fromGSF.electronSeed);
+      auto objsbegin = egobjs.begin();
+      auto objsend = egobjs.end();
+      // this auto is a std::list<ProtoEGObject>::iterator
+      auto clusmatch = std::find_if(objsbegin, objsend, sctoseedmatch);
+      if (clusmatch != objsend) {
+        fromGSF.parentSC = clusmatch->parentSC;
+        fromGSF.ecalclusters = std::move(clusmatch->ecalclusters);
+        fromGSF.ecal2ps = std::move(clusmatch->ecal2ps);
+        egobjs.erase(clusmatch);
+      } else if (fromGSF.electronSeed.isAvailable() && fromGSF.electronSeed.isNonnull()) {
+        // link tests in the gap region can current split a gap electron
+        // HEY THIS IS A WORK AROUND FOR A KNOWN BUG IN PFBLOCKALGO
+        // MAYBE WE SHOULD FIX IT??????????????????????????????????
+        LOGDRESSED("PFEGammaAlgo") << "Encountered the known GSF-SC splitting bug "
+                                   << " in PFBlockAlgo! We should really fix this!" << std::endl;
+      } else {  // SC was not in a earlier proto-object
+        std::stringstream gsf_err;
+        elementAsGSF->Dump(gsf_err, "\t");
+        throw cms::Exception("PFEGammaAlgo::initializeProtoCands()")
+            << "Expected SuperCluster from ECAL driven GSF seed "
+            << "was not found in the block!" << std::endl
+            << gsf_err.str() << std::endl;
+      }  // supercluster in block
+    }    // is ECAL driven seed?
 
-     egobjs.insert(egobjs.end(),fromGSF);
-   } // end loop on GSF elements of block
+    egobjs.insert(egobjs.end(), fromGSF);
+  }  // end loop on GSF elements of block
 }
 
- bool PFEGammaAlgo::
- unwrapSuperCluster(const PFSCElement* thesc,
-		    std::vector<FlaggedPtr<const PFClusterElement>>& ecalclusters,
-		    ClusterMap& ecal2ps) {
-   ecalclusters.clear();
-   ecal2ps.clear();
-   LOGVERB("PFEGammaAlgo")
-     << "Pointer to SC element: 0x" 
-     << std::hex << thesc << std::dec << std::endl
-     << "cleared ecalclusters and ecal2ps!" << std::endl;  
-   auto ecalbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
-   auto ecalend = _splayedblock[reco::PFBlockElement::ECAL].end(); 
-   auto hgcalbegin = _splayedblock[reco::PFBlockElement::HGCAL].begin();
-   auto hgcalend = _splayedblock[reco::PFBlockElement::HGCAL].end(); 
-   if( ecalbegin == ecalend && hgcalbegin == hgcalend ) {
-     LOGERR("PFEGammaAlgo::unwrapSuperCluster()")
-       << "There are no ECAL elements in a block with imported SC!" 
-       << " This is a bug we should fix this!" 
-       << std::endl;
-     return false;
-   }
-   reco::SuperClusterRef scref = thesc->superClusterRef();
-   const bool is_pf_sc = thesc->fromPFSuperCluster();
-   if( !(scref.isAvailable() && scref.isNonnull()) ) {
-     throw cms::Exception("PFEGammaAlgo::unwrapSuperCluster()")
-       << "SuperCluster pointed to by block element is null!" 
-       << std::endl;
-   }
-   LOGDRESSED("PFEGammaAlgo")
-     << "Got a valid super cluster ref! 0x" 
-     << std::hex << scref.get() << std::dec << std::endl;
-   const size_t nscclusters = scref->clustersSize();
-   const size_t nscpsclusters = scref->preshowerClustersSize();
-   size_t npfpsclusters = 0;
-   size_t npfclusters = 0;
-   LOGDRESSED("PFEGammaAlgo")
-     << "Precalculated cluster multiplicities: " 
-     << nscclusters << ' ' << nscpsclusters << std::endl;
-   NotCloserToOther<reco::PFBlockElement::SC,reco::PFBlockElement::ECAL> 
-     ecalClustersInSC(_currentblock,thesc);
-   NotCloserToOther<reco::PFBlockElement::SC,reco::PFBlockElement::HGCAL> 
-     hgcalClustersInSC(_currentblock,thesc);
-   auto ecalfirstnotinsc = std::partition(ecalbegin,ecalend,ecalClustersInSC);
-   auto hgcalfirstnotinsc = std::partition(hgcalbegin,hgcalend,hgcalClustersInSC);
-   //reset the begin and end iterators
-   ecalbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
-   ecalend = _splayedblock[reco::PFBlockElement::ECAL].end();  
+bool PFEGammaAlgo::unwrapSuperCluster(const PFSCElement* thesc,
+                                      std::vector<FlaggedPtr<const PFClusterElement>>& ecalclusters,
+                                      ClusterMap& ecal2ps) {
+  ecalclusters.clear();
+  ecal2ps.clear();
+  LOGVERB("PFEGammaAlgo") << "Pointer to SC element: 0x" << std::hex << thesc << std::dec << std::endl
+                          << "cleared ecalclusters and ecal2ps!" << std::endl;
+  auto ecalbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
+  auto ecalend = _splayedblock[reco::PFBlockElement::ECAL].end();
+  auto hgcalbegin = _splayedblock[reco::PFBlockElement::HGCAL].begin();
+  auto hgcalend = _splayedblock[reco::PFBlockElement::HGCAL].end();
+  if (ecalbegin == ecalend && hgcalbegin == hgcalend) {
+    LOGERR("PFEGammaAlgo::unwrapSuperCluster()") << "There are no ECAL elements in a block with imported SC!"
+                                                 << " This is a bug we should fix this!" << std::endl;
+    return false;
+  }
+  reco::SuperClusterRef scref = thesc->superClusterRef();
+  const bool is_pf_sc = thesc->fromPFSuperCluster();
+  if (!(scref.isAvailable() && scref.isNonnull())) {
+    throw cms::Exception("PFEGammaAlgo::unwrapSuperCluster()")
+        << "SuperCluster pointed to by block element is null!" << std::endl;
+  }
+  LOGDRESSED("PFEGammaAlgo") << "Got a valid super cluster ref! 0x" << std::hex << scref.get() << std::dec << std::endl;
+  const size_t nscclusters = scref->clustersSize();
+  const size_t nscpsclusters = scref->preshowerClustersSize();
+  size_t npfpsclusters = 0;
+  size_t npfclusters = 0;
+  LOGDRESSED("PFEGammaAlgo") << "Precalculated cluster multiplicities: " << nscclusters << ' ' << nscpsclusters
+                             << std::endl;
+  NotCloserToOther<reco::PFBlockElement::SC, reco::PFBlockElement::ECAL> ecalClustersInSC(_currentblock, thesc);
+  NotCloserToOther<reco::PFBlockElement::SC, reco::PFBlockElement::HGCAL> hgcalClustersInSC(_currentblock, thesc);
+  auto ecalfirstnotinsc = std::partition(ecalbegin, ecalend, ecalClustersInSC);
+  auto hgcalfirstnotinsc = std::partition(hgcalbegin, hgcalend, hgcalClustersInSC);
+  //reset the begin and end iterators
+  ecalbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
+  ecalend = _splayedblock[reco::PFBlockElement::ECAL].end();
 
-   hgcalbegin = _splayedblock[reco::PFBlockElement::HGCAL].begin();
-   hgcalend = _splayedblock[reco::PFBlockElement::HGCAL].end();  
+  hgcalbegin = _splayedblock[reco::PFBlockElement::HGCAL].begin();
+  hgcalend = _splayedblock[reco::PFBlockElement::HGCAL].end();
 
-   //get list of associated clusters by det id and energy matching
-   //(only needed when using non-pf supercluster)
-   std::vector<const ClusterElement*> safePFClusters = is_pf_sc ? std::vector<const ClusterElement*>() : getSCAssociatedECALsSafe(scref,_splayedblock[reco::PFBlockElement::ECAL]);
-   
-   if( ecalfirstnotinsc == ecalbegin &&  
-       hgcalfirstnotinsc == hgcalbegin) {
-     LOGERR("PFEGammaAlgo::unwrapSuperCluster()")
-       << "No associated block elements to SuperCluster!" 
-       << " This is a bug we should fix!"
-       << std::endl;
-     return false;
-   }
-   npfclusters = std::distance(ecalbegin,ecalfirstnotinsc) + std::distance(hgcalbegin,hgcalfirstnotinsc);
-   // ensure we have found the correct number of PF ecal clusters in the case
-   // that this is a PF supercluster, otherwise all bets are off
-   if( is_pf_sc && nscclusters != npfclusters ) {
-     std::stringstream sc_err;
-     thesc->Dump(sc_err,"\t");
-     throw cms::Exception("PFEGammaAlgo::unwrapSuperCluster()")
-       << "The number of found ecal elements ("
-       << nscclusters << ") in block is not the same as"
-       << " the number of ecal PF clusters reported by the PFSuperCluster"
-       << " itself (" << npfclusters
-       << ")! This should not happen!" << std::endl 
-       << sc_err.str() << std::endl;
-   }
-   for( auto ecalitr = ecalbegin; ecalitr != ecalfirstnotinsc; ++ecalitr ) {    
-     const PFClusterElement* elemascluster = 
-       docast(const PFClusterElement*,ecalitr->get());
+  //get list of associated clusters by det id and energy matching
+  //(only needed when using non-pf supercluster)
+  std::vector<const ClusterElement*> safePFClusters =
+      is_pf_sc ? std::vector<const ClusterElement*>()
+               : getSCAssociatedECALsSafe(scref, _splayedblock[reco::PFBlockElement::ECAL]);
 
-     // reject clusters that really shouldn't be associated to the SC
-     // (only needed when using non-pf-supercluster)
-     if(!is_pf_sc && std::find(safePFClusters.begin(),safePFClusters.end(),elemascluster) ==
-	safePFClusters.end() ) continue;
+  if (ecalfirstnotinsc == ecalbegin && hgcalfirstnotinsc == hgcalbegin) {
+    LOGERR("PFEGammaAlgo::unwrapSuperCluster()") << "No associated block elements to SuperCluster!"
+                                                 << " This is a bug we should fix!" << std::endl;
+    return false;
+  }
+  npfclusters = std::distance(ecalbegin, ecalfirstnotinsc) + std::distance(hgcalbegin, hgcalfirstnotinsc);
+  // ensure we have found the correct number of PF ecal clusters in the case
+  // that this is a PF supercluster, otherwise all bets are off
+  if (is_pf_sc && nscclusters != npfclusters) {
+    std::stringstream sc_err;
+    thesc->Dump(sc_err, "\t");
+    throw cms::Exception("PFEGammaAlgo::unwrapSuperCluster()")
+        << "The number of found ecal elements (" << nscclusters << ") in block is not the same as"
+        << " the number of ecal PF clusters reported by the PFSuperCluster"
+        << " itself (" << npfclusters << ")! This should not happen!" << std::endl
+        << sc_err.str() << std::endl;
+  }
+  for (auto ecalitr = ecalbegin; ecalitr != ecalfirstnotinsc; ++ecalitr) {
+    const PFClusterElement* elemascluster = docast(const PFClusterElement*, ecalitr->get());
 
-     //add cluster
-     ecalclusters.emplace_back(elemascluster,true);
-     //mark cluster as used
-     ecalitr->setFlag(false);
-     
-     // process the ES elements
-     // auto is a pair<Iterator,bool> here, bool is false when placing fails
-     auto emplaceresult = ecal2ps.emplace(elemascluster,
-					  ClusterMap::mapped_type());    
-     if( !emplaceresult.second ) {
-       std::stringstream clus_err;
-       elemascluster->Dump(clus_err,"\t");
-       throw cms::Exception("PFEGammaAlgo::unwrapSuperCluster()")
-	 << "List of pointers to ECAL block elements contains non-unique items!"
-	 << " This is very bad!" << std::endl
-	 << "cluster ptr = 0x" << std::hex << elemascluster << std::dec 
-	 << std::endl << clus_err.str() << std::endl;
-     }    
-     ClusterMap::mapped_type& eslist = emplaceresult.first->second;    
-     npfpsclusters += attachPSClusters(elemascluster,eslist);    
-   } // loop over ecal elements
+    // reject clusters that really shouldn't be associated to the SC
+    // (only needed when using non-pf-supercluster)
+    if (!is_pf_sc && std::find(safePFClusters.begin(), safePFClusters.end(), elemascluster) == safePFClusters.end())
+      continue;
 
-   for( auto hgcalitr = hgcalbegin; hgcalitr != hgcalfirstnotinsc; ++hgcalitr ) {    
-     const PFClusterElement* elemascluster = 
-       docast(const PFClusterElement*,hgcalitr->get());
+    //add cluster
+    ecalclusters.emplace_back(elemascluster, true);
+    //mark cluster as used
+    ecalitr->setFlag(false);
 
-     // reject clusters that really shouldn't be associated to the SC
-     // (only needed when using non-pf-supercluster)
-     if(!is_pf_sc && std::find(safePFClusters.begin(),safePFClusters.end(),elemascluster) ==
-	safePFClusters.end() ) continue;
+    // process the ES elements
+    // auto is a pair<Iterator,bool> here, bool is false when placing fails
+    auto emplaceresult = ecal2ps.emplace(elemascluster, ClusterMap::mapped_type());
+    if (!emplaceresult.second) {
+      std::stringstream clus_err;
+      elemascluster->Dump(clus_err, "\t");
+      throw cms::Exception("PFEGammaAlgo::unwrapSuperCluster()")
+          << "List of pointers to ECAL block elements contains non-unique items!"
+          << " This is very bad!" << std::endl
+          << "cluster ptr = 0x" << std::hex << elemascluster << std::dec << std::endl
+          << clus_err.str() << std::endl;
+    }
+    ClusterMap::mapped_type& eslist = emplaceresult.first->second;
+    npfpsclusters += attachPSClusters(elemascluster, eslist);
+  }  // loop over ecal elements
 
-     //add cluster
-     ecalclusters.emplace_back(elemascluster,true);
-     //mark cluster as used
-     hgcalitr->setFlag(false);
-   } // loop over ecal elements
-   
-   /*
+  for (auto hgcalitr = hgcalbegin; hgcalitr != hgcalfirstnotinsc; ++hgcalitr) {
+    const PFClusterElement* elemascluster = docast(const PFClusterElement*, hgcalitr->get());
+
+    // reject clusters that really shouldn't be associated to the SC
+    // (only needed when using non-pf-supercluster)
+    if (!is_pf_sc && std::find(safePFClusters.begin(), safePFClusters.end(), elemascluster) == safePFClusters.end())
+      continue;
+
+    //add cluster
+    ecalclusters.emplace_back(elemascluster, true);
+    //mark cluster as used
+    hgcalitr->setFlag(false);
+  }  // loop over ecal elements
+
+  /*
    if( is_pf_sc && nscpsclusters != npfpsclusters) {
      std::stringstream sc_err;
      thesc->Dump(sc_err,"\t");
@@ -1066,661 +888,579 @@ initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
    }
    */
 
-   LOGDRESSED("PFEGammaAlgo")
-     << " Unwrapped SC has " << npfclusters << " ECAL sub-clusters"
-     << " and " << npfpsclusters << " PreShower layers 1 & 2 clusters!" 
-     << std::endl; 
-   return true;
- }
-
-
- int PFEGammaAlgo::attachPSClusters(const ClusterElement* ecalclus,
-				    ClusterMap::mapped_type& eslist) {  
-   if( ecalclus->clusterRef()->layer() == PFLayer::ECAL_BARREL ) return 0;
-   edm::Ptr<reco::PFCluster> clusptr = refToPtr(ecalclus->clusterRef());
-   EEtoPSElement ecalkey(clusptr.key(),clusptr);
-   auto assc_ps = std::equal_range(eetops_->cbegin(),
-				   eetops_->cend(),
-				   ecalkey,
-				   [](const EEtoPSElement& a, const EEtoPSElement& b){return a.first < b.first;});
-   for( const auto& ps1 : _splayedblock[reco::PFBlockElement::PS1] ) {
-     edm::Ptr<reco::PFCluster> temp = refToPtr(ps1->clusterRef());
-     for( auto pscl = assc_ps.first; pscl != assc_ps.second; ++pscl ) {
-       if( pscl->second == temp ) {
-	 const ClusterElement* pstemp = 
-	   docast(const ClusterElement*,ps1.get());
-	 eslist.emplace_back(pstemp);
-       }
-     }
-   }
-   for( const auto& ps2 : _splayedblock[reco::PFBlockElement::PS2] ) {
-     edm::Ptr<reco::PFCluster> temp = refToPtr(ps2->clusterRef());
-     for( auto pscl = assc_ps.first; pscl != assc_ps.second; ++pscl ) {
-       if( pscl->second == temp ) {
-	 const ClusterElement* pstemp = 
-	   docast(const ClusterElement*,ps2.get());
-	 eslist.emplace_back(pstemp);
-       }
-     }
-   }
-   return eslist.size();
- }
-
- void PFEGammaAlgo::dumpCurrentRefinableObjects() const {
- #ifdef PFLOW_DEBUG
-   edm::LogVerbatim("PFEGammaAlgo") 
-     //<< "Dumping current block: " << std::endl << *_currentblock << std::endl
-     << "Dumping " << refinableObjects.size()
-     << " refinable objects for this block: " << std::endl;
-   for( const auto& ro : refinableObjects ) {    
-     std::stringstream info;
-     info << "Refinable Object:" << std::endl;
-     if( ro.parentSC ) {
-       info << "\tSuperCluster element attached to object:" << std::endl 
-	    << '\t';
-       ro.parentSC->Dump(info,"\t");
-       info << std::endl;      
-     } 
-     if( ro.electronSeed.isNonnull() ) {
-       info << "\tGSF element attached to object:" << std::endl;
-       ro.primaryGSFs.front()->Dump(info,"\t");
-       info << std::endl;
-       info << "firstBrem : " << ro.firstBrem 
-	    << " lateBrem : " << ro.lateBrem
-	    << " nBrems with cluster : " << ro.nBremsWithClusters
-	    << std::endl;;
-       if( ro.electronClusters.size() && ro.electronClusters[0] ) {
-	 info << "electron cluster : ";
-	 ro.electronClusters[0]->Dump(info,"\t");
-	 info << std::endl;
-       } else {
-	 info << " no electron cluster." << std::endl;
-       }	 
-     }
-     if( ro.primaryKFs.size() ) {
-       info << "\tPrimary KF tracks attached to object: " << std::endl;
-       for( const auto& kf : ro.primaryKFs ) {
-	 kf->Dump(info,"\t");
-	 info << std::endl;
-       }
-     }
-     if( ro.secondaryKFs.size() ) {
-       info << "\tSecondary KF tracks attached to object: " << std::endl;
-       for( const auto& kf : ro.secondaryKFs ) {
-	 kf->Dump(info,"\t");
-	 info << std::endl;
-       }
-     }
-     if( ro.brems.size() ) {
-       info << "\tBrem tangents attached to object: " << std::endl;
-       for( const auto& brem : ro.brems ) {
-	 brem->Dump(info,"\t");
-	 info << std::endl;
-       }
-     }
-     if( ro.ecalclusters.size() ) {
-       info << "\tECAL clusters attached to object: " << std::endl;
-       for( const auto& clus : ro.ecalclusters ) {
-	 clus->Dump(info,"\t");
-	 info << std::endl;
-	 if( ro.ecal2ps.find(clus) != ro.ecal2ps.end() ) {
-	   for( const auto& psclus : ro.ecal2ps.at(clus) ) {
-	     info << "\t\t Attached PS Cluster: ";
-	     psclus->Dump(info,"");
-	     info << std::endl;
-	   }
-	 }
-       }
-     }
-     edm::LogVerbatim("PFEGammaAlgo") << info.str();
-   }
- #endif
- }
-
- // look through our KF tracks in this block and match 
- void PFEGammaAlgo::
- removeOrLinkECALClustersToKFTracks() {
-   typedef std::multimap<double, unsigned> MatchedMap;
-   typedef const reco::PFBlockElementGsfTrack* GsfTrackElementPtr;
-   if( _splayedblock[reco::PFBlockElement::ECAL].empty() ||
-       _splayedblock[reco::PFBlockElement::TRACK].empty()   ) return;
-   MatchedMap matchedGSFs, matchedECALs;
-   std::unordered_map<GsfTrackElementPtr,MatchedMap> gsf_ecal_cache;
-   for( auto& kftrack : _splayedblock[reco::PFBlockElement::TRACK] ) {
-     matchedGSFs.clear();
-     _currentblock->associatedElements(kftrack->index(), _currentlinks,
-				       matchedGSFs,
-				       reco::PFBlockElement::GSF,
-				       reco::PFBlock::LINKTEST_ALL);
-     if( matchedGSFs.empty() ) { // only run this if we aren't associated to GSF
-       LesserByDistance closestTrackToECAL(_currentblock,_currentlinks,
-					   kftrack.get());      
-       auto ecalbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
-       auto ecalend   = _splayedblock[reco::PFBlockElement::ECAL].end();
-       std::partial_sort(ecalbegin,ecalbegin+1,ecalend,closestTrackToECAL);
-       auto& closestECAL = _splayedblock[reco::PFBlockElement::ECAL].front();
-       const float dist = _currentblock->dist(kftrack->index(), 
-					      closestECAL->index(),
-					      _currentlinks,
-					      reco::PFBlock::LINKTEST_ALL);
-       bool inSC = false;
-       for( auto& sc : _splayedblock[reco::PFBlockElement::SC] ) {
-	 float dist_sc = _currentblock->dist(sc->index(), 
-					     closestECAL->index(),
-					     _currentlinks,
-					     reco::PFBlock::LINKTEST_ALL);
-	 if( dist_sc != -1.0f) { inSC = true; break; }
-       }
-
-       if( dist != -1.0f && closestECAL.flag() ) {
-	 bool gsflinked = false;
-	 // check that this cluster is not associated to a GSF track
-	 for(const auto& gsfflag : _splayedblock[reco::PFBlockElement::GSF]) {
-	   const reco::PFBlockElementGsfTrack* elemasgsf =
-	     docast(const reco::PFBlockElementGsfTrack*,gsfflag.get());
-	   if(elemasgsf->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)) {
-	     continue; // keep clusters that have a found conversion GSF near
-	   }
-	   // make sure cache exists
-	   if( !gsf_ecal_cache.count(elemasgsf) ) {
-	     matchedECALs.clear();
-	     _currentblock->associatedElements(elemasgsf->index(), _currentlinks,
-					       matchedECALs,
-					       reco::PFBlockElement::ECAL,
-					       reco::PFBlock::LINKTEST_ALL);
-	     gsf_ecal_cache.emplace(elemasgsf,matchedECALs);
-	     MatchedMap().swap(matchedECALs);
-	   } 
-	   const MatchedMap& ecal_matches = gsf_ecal_cache[elemasgsf];	   
-	   if( !ecal_matches.empty() ) {
-	     if( ecal_matches.begin()->second == closestECAL->index() ) {
-	       gsflinked = true;
-	       break;
-	     }
-	   }			    
-	 } // loop over primary GSF tracks
-	 if( !gsflinked && !inSC) { 
-	   // determine if we should remove the matched cluster
-	   const reco::PFBlockElementTrack * kfEle = 
-	     docast(const reco::PFBlockElementTrack*,kftrack.get());
-	   const reco::TrackRef& trackref = kfEle->trackRef();
-
-	   const int nexhits = 
-	     trackref->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS);
-	   bool fromprimaryvertex = false;
-	   for( auto vtxtks = primaryVertex_->tracks_begin();
-		vtxtks != primaryVertex_->tracks_end(); ++ vtxtks ) {
-	     if( trackref == vtxtks->castTo<reco::TrackRef>() ) {
-	       fromprimaryvertex = true;
-	       break;
-	     }
-	   }// loop over tracks in primary vertex
-	    // if associated to good non-GSF matched track remove this cluster
-	   if( PFTrackAlgoTools::isGoodForEGMPrimary(trackref->algo()) && nexhits == 0 && fromprimaryvertex ) {
-	     closestECAL.setFlag(false);
-	   }
-	 }
-       } // found a good closest ECAL match
-     } // no GSF track matched to KF
-   } // loop over KF elements
- }
-
- void PFEGammaAlgo::
- mergeROsByAnyLink(std::list<PFEGammaAlgo::ProtoEGObject>& ROs) {
-   if( ROs.size() < 2 ) return; // nothing to do with one or zero ROs  
-   bool check_for_merge = true;
-   while( check_for_merge ) {   
-     // bugfix for early termination merging loop (15 April 2014)
-     // check all pairwise combinations in the list
-     // if one has a merge shuffle it to the front of the list
-     // if there are no merges left to do we can terminate
-     for( auto it1 = ROs.begin(); it1 != ROs.end(); ++it1 ) {
-       auto find_start = it1; ++find_start;
-       auto has_merge = std::find_if(find_start,ROs.end(),
-               std::bind(testIfROMergableByLink, _1, *it1));
-       if( has_merge != ROs.end() && it1 != ROs.begin() ) {
-	 std::swap(*(ROs.begin()),*it1);
-	 break;
-       }
-     }// ensure mergables are shuffled to the front
-     ProtoEGObject& thefront = ROs.front();
-     auto mergestart = ROs.begin(); ++mergestart;    
-     auto nomerge = std::partition(mergestart,ROs.end(),
-             std::bind(testIfROMergableByLink, _1, thefront));
-     if( nomerge != mergestart ) {
-       LOGDRESSED("PFEGammaAlgo::mergeROsByAnyLink()")       
-	 << "Found objects " << std::distance(mergestart,nomerge)
-	 << " to merge by links to the front!" << std::endl;
-       for( auto roToMerge = mergestart; roToMerge != nomerge; ++roToMerge) {
-         //bugfix! L.Gray 14 Jan 2016 
-         // -- check that the front is still mergeable!
-         if( !thefront.ecalclusters.empty() && !roToMerge->ecalclusters.empty() ) {
-           if( thefront.ecalclusters.front()->clusterRef()->layer() !=   
-               roToMerge->ecalclusters.front()->clusterRef()->layer() ) {
-             LOGWARN("PFEGammaAlgo::mergeROsByAnyLink") 
-               << "Tried to merge EB and EE clusters! Skipping!";
-             ROs.push_back(*roToMerge);
-             continue;
-           }
-         }         
-         //end bugfix
-	 thefront.ecalclusters.insert(thefront.ecalclusters.end(),
-				      roToMerge->ecalclusters.begin(),
-				      roToMerge->ecalclusters.end());
-	 thefront.ecal2ps.insert(roToMerge->ecal2ps.begin(),
-				 roToMerge->ecal2ps.end());
-	 thefront.secondaryKFs.insert(thefront.secondaryKFs.end(),
-				      roToMerge->secondaryKFs.begin(),
-				      roToMerge->secondaryKFs.end());
-
-	 thefront.localMap.concatenate(roToMerge->localMap);
-	 // TO FIX -> use best (E_gsf - E_clustersum)/E_GSF
-	 if( !thefront.parentSC && roToMerge->parentSC ) {
-	   thefront.parentSC = roToMerge->parentSC;
-	 }
-	 if( thefront.electronSeed.isNull() && 
-	     roToMerge->electronSeed.isNonnull() ) {
-	   thefront.electronSeed = roToMerge->electronSeed;
-	   thefront.primaryGSFs.insert(thefront.primaryGSFs.end(),
-				       roToMerge->primaryGSFs.begin(),
-				       roToMerge->primaryGSFs.end());
-	   thefront.primaryKFs.insert(thefront.primaryKFs.end(),
-				      roToMerge->primaryKFs.begin(),
-				      roToMerge->primaryKFs.end());
-	   thefront.brems.insert(thefront.brems.end(),
-				 roToMerge->brems.begin(),
-				 roToMerge->brems.end());
-	   thefront.electronClusters = roToMerge->electronClusters;
-	   thefront.nBremsWithClusters = roToMerge->nBremsWithClusters;
-	   thefront.firstBrem = roToMerge->firstBrem;
-	   thefront.lateBrem = roToMerge->lateBrem;
-	 } else if ( thefront.electronSeed.isNonnull() && 
-		     roToMerge->electronSeed.isNonnull()) {
-	   LOGDRESSED("PFEGammaAlgo::mergeROsByAnyLink")
-	     << "Need to implement proper merging of two gsf candidates!"
-	     << std::endl;
-	 }
-       }      
-       ROs.erase(mergestart,nomerge);
-       // put the merged element in the back of the cleaned list
-       ROs.push_back(ROs.front());
-       ROs.pop_front();
-     } else {       
-       check_for_merge = false;    
-     }
-   }
-   LOGDRESSED("PFEGammaAlgo::mergeROsByAnyLink()") 
-     << "After merging by links there are: " << ROs.size() 
-     << " refinable EGamma objects!" << std::endl;
- }
-
-// pull in KF tracks associated to the RO but not closer to another
-// NB: in initializeProtoCands() we forced the GSF tracks not to be 
-//     from a conversion, but we will leave a protection here just in
-//     case things change in the future
-void PFEGammaAlgo::
-linkRefinableObjectGSFTracksToKFs(ProtoEGObject& RO) {
-  constexpr reco::PFBlockElement::TrackType convType = 
-    reco::PFBlockElement::T_FROM_GAMMACONV;
-  if( _splayedblock[reco::PFBlockElement::TRACK].empty() ) return;
-  auto KFbegin = _splayedblock[reco::PFBlockElement::TRACK].begin();
-  auto KFend = _splayedblock[reco::PFBlockElement::TRACK].end();
-  for( auto& gsfflagged : RO.primaryGSFs ) {
-    const PFGSFElement* seedtk = gsfflagged;
-    // don't process SC-only ROs or secondary seeded ROs
-    if( RO.electronSeed.isNull() || seedtk->trackType(convType) ) continue;
-    NotCloserToOther<reco::PFBlockElement::GSF,reco::PFBlockElement::TRACK>
-      gsfTrackToKFs(_currentblock,seedtk);
-    // get KF tracks not closer to another and not already used
-    auto notlinked = std::partition(KFbegin,KFend,gsfTrackToKFs);
-    // attach tracks and set as used
-    for( auto kft = KFbegin; kft != notlinked; ++kft ) {
-      const PFKFElement* elemaskf = 
-	docast(const PFKFElement*,kft->get());
-      // don't care about things that aren't primaries or directly 
-      // associated secondary tracks
-      if( isPrimaryTrack(*elemaskf,*seedtk) &&
-	  !elemaskf->trackType(convType)       ) {
-	kft->setFlag(false);
-	RO.primaryKFs.push_back(elemaskf);
-	RO.localMap.insert(seedtk,elemaskf);
-      } else if ( elemaskf->trackType(convType) ) {
-	kft->setFlag(false);
-	RO.secondaryKFs.push_back(elemaskf);
-	RO.localMap.insert(seedtk,elemaskf);
-      }
-    }// loop on closest KFs not closer to other GSFs
-  } // loop on GSF primaries on RO  
+  LOGDRESSED("PFEGammaAlgo") << " Unwrapped SC has " << npfclusters << " ECAL sub-clusters"
+                             << " and " << npfpsclusters << " PreShower layers 1 & 2 clusters!" << std::endl;
+  return true;
 }
 
-void PFEGammaAlgo::
-linkRefinableObjectPrimaryKFsToSecondaryKFs(ProtoEGObject& RO) {
-  constexpr reco::PFBlockElement::TrackType convType = 
-    reco::PFBlockElement::T_FROM_GAMMACONV;
-  if( _splayedblock[reco::PFBlockElement::TRACK].empty() ) return;
+int PFEGammaAlgo::attachPSClusters(const ClusterElement* ecalclus, ClusterMap::mapped_type& eslist) {
+  if (ecalclus->clusterRef()->layer() == PFLayer::ECAL_BARREL)
+    return 0;
+  edm::Ptr<reco::PFCluster> clusptr = refToPtr(ecalclus->clusterRef());
+  EEtoPSElement ecalkey(clusptr.key(), clusptr);
+  auto assc_ps =
+      std::equal_range(eetops_->cbegin(), eetops_->cend(), ecalkey, [](const EEtoPSElement& a, const EEtoPSElement& b) {
+        return a.first < b.first;
+      });
+  for (const auto& ps1 : _splayedblock[reco::PFBlockElement::PS1]) {
+    edm::Ptr<reco::PFCluster> temp = refToPtr(ps1->clusterRef());
+    for (auto pscl = assc_ps.first; pscl != assc_ps.second; ++pscl) {
+      if (pscl->second == temp) {
+        const ClusterElement* pstemp = docast(const ClusterElement*, ps1.get());
+        eslist.emplace_back(pstemp);
+      }
+    }
+  }
+  for (const auto& ps2 : _splayedblock[reco::PFBlockElement::PS2]) {
+    edm::Ptr<reco::PFCluster> temp = refToPtr(ps2->clusterRef());
+    for (auto pscl = assc_ps.first; pscl != assc_ps.second; ++pscl) {
+      if (pscl->second == temp) {
+        const ClusterElement* pstemp = docast(const ClusterElement*, ps2.get());
+        eslist.emplace_back(pstemp);
+      }
+    }
+  }
+  return eslist.size();
+}
+
+void PFEGammaAlgo::dumpCurrentRefinableObjects() const {
+#ifdef PFLOW_DEBUG
+  edm::LogVerbatim("PFEGammaAlgo")
+      //<< "Dumping current block: " << std::endl << *_currentblock << std::endl
+      << "Dumping " << refinableObjects.size() << " refinable objects for this block: " << std::endl;
+  for (const auto& ro : refinableObjects) {
+    std::stringstream info;
+    info << "Refinable Object:" << std::endl;
+    if (ro.parentSC) {
+      info << "\tSuperCluster element attached to object:" << std::endl << '\t';
+      ro.parentSC->Dump(info, "\t");
+      info << std::endl;
+    }
+    if (ro.electronSeed.isNonnull()) {
+      info << "\tGSF element attached to object:" << std::endl;
+      ro.primaryGSFs.front()->Dump(info, "\t");
+      info << std::endl;
+      info << "firstBrem : " << ro.firstBrem << " lateBrem : " << ro.lateBrem
+           << " nBrems with cluster : " << ro.nBremsWithClusters << std::endl;
+      ;
+      if (ro.electronClusters.size() && ro.electronClusters[0]) {
+        info << "electron cluster : ";
+        ro.electronClusters[0]->Dump(info, "\t");
+        info << std::endl;
+      } else {
+        info << " no electron cluster." << std::endl;
+      }
+    }
+    if (ro.primaryKFs.size()) {
+      info << "\tPrimary KF tracks attached to object: " << std::endl;
+      for (const auto& kf : ro.primaryKFs) {
+        kf->Dump(info, "\t");
+        info << std::endl;
+      }
+    }
+    if (ro.secondaryKFs.size()) {
+      info << "\tSecondary KF tracks attached to object: " << std::endl;
+      for (const auto& kf : ro.secondaryKFs) {
+        kf->Dump(info, "\t");
+        info << std::endl;
+      }
+    }
+    if (ro.brems.size()) {
+      info << "\tBrem tangents attached to object: " << std::endl;
+      for (const auto& brem : ro.brems) {
+        brem->Dump(info, "\t");
+        info << std::endl;
+      }
+    }
+    if (ro.ecalclusters.size()) {
+      info << "\tECAL clusters attached to object: " << std::endl;
+      for (const auto& clus : ro.ecalclusters) {
+        clus->Dump(info, "\t");
+        info << std::endl;
+        if (ro.ecal2ps.find(clus) != ro.ecal2ps.end()) {
+          for (const auto& psclus : ro.ecal2ps.at(clus)) {
+            info << "\t\t Attached PS Cluster: ";
+            psclus->Dump(info, "");
+            info << std::endl;
+          }
+        }
+      }
+    }
+    edm::LogVerbatim("PFEGammaAlgo") << info.str();
+  }
+#endif
+}
+
+// look through our KF tracks in this block and match
+void PFEGammaAlgo::removeOrLinkECALClustersToKFTracks() {
+  typedef std::multimap<double, unsigned> MatchedMap;
+  typedef const reco::PFBlockElementGsfTrack* GsfTrackElementPtr;
+  if (_splayedblock[reco::PFBlockElement::ECAL].empty() || _splayedblock[reco::PFBlockElement::TRACK].empty())
+    return;
+  MatchedMap matchedGSFs, matchedECALs;
+  std::unordered_map<GsfTrackElementPtr, MatchedMap> gsf_ecal_cache;
+  for (auto& kftrack : _splayedblock[reco::PFBlockElement::TRACK]) {
+    matchedGSFs.clear();
+    _currentblock->associatedElements(
+        kftrack->index(), _currentlinks, matchedGSFs, reco::PFBlockElement::GSF, reco::PFBlock::LINKTEST_ALL);
+    if (matchedGSFs.empty()) {  // only run this if we aren't associated to GSF
+      LesserByDistance closestTrackToECAL(_currentblock, _currentlinks, kftrack.get());
+      auto ecalbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
+      auto ecalend = _splayedblock[reco::PFBlockElement::ECAL].end();
+      std::partial_sort(ecalbegin, ecalbegin + 1, ecalend, closestTrackToECAL);
+      auto& closestECAL = _splayedblock[reco::PFBlockElement::ECAL].front();
+      const float dist =
+          _currentblock->dist(kftrack->index(), closestECAL->index(), _currentlinks, reco::PFBlock::LINKTEST_ALL);
+      bool inSC = false;
+      for (auto& sc : _splayedblock[reco::PFBlockElement::SC]) {
+        float dist_sc =
+            _currentblock->dist(sc->index(), closestECAL->index(), _currentlinks, reco::PFBlock::LINKTEST_ALL);
+        if (dist_sc != -1.0f) {
+          inSC = true;
+          break;
+        }
+      }
+
+      if (dist != -1.0f && closestECAL.flag()) {
+        bool gsflinked = false;
+        // check that this cluster is not associated to a GSF track
+        for (const auto& gsfflag : _splayedblock[reco::PFBlockElement::GSF]) {
+          const reco::PFBlockElementGsfTrack* elemasgsf = docast(const reco::PFBlockElementGsfTrack*, gsfflag.get());
+          if (elemasgsf->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)) {
+            continue;  // keep clusters that have a found conversion GSF near
+          }
+          // make sure cache exists
+          if (!gsf_ecal_cache.count(elemasgsf)) {
+            matchedECALs.clear();
+            _currentblock->associatedElements(elemasgsf->index(),
+                                              _currentlinks,
+                                              matchedECALs,
+                                              reco::PFBlockElement::ECAL,
+                                              reco::PFBlock::LINKTEST_ALL);
+            gsf_ecal_cache.emplace(elemasgsf, matchedECALs);
+            MatchedMap().swap(matchedECALs);
+          }
+          const MatchedMap& ecal_matches = gsf_ecal_cache[elemasgsf];
+          if (!ecal_matches.empty()) {
+            if (ecal_matches.begin()->second == closestECAL->index()) {
+              gsflinked = true;
+              break;
+            }
+          }
+        }  // loop over primary GSF tracks
+        if (!gsflinked && !inSC) {
+          // determine if we should remove the matched cluster
+          const reco::PFBlockElementTrack* kfEle = docast(const reco::PFBlockElementTrack*, kftrack.get());
+          const reco::TrackRef& trackref = kfEle->trackRef();
+
+          const int nexhits = trackref->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS);
+          bool fromprimaryvertex = false;
+          for (auto vtxtks = primaryVertex_->tracks_begin(); vtxtks != primaryVertex_->tracks_end(); ++vtxtks) {
+            if (trackref == vtxtks->castTo<reco::TrackRef>()) {
+              fromprimaryvertex = true;
+              break;
+            }
+          }  // loop over tracks in primary vertex
+             // if associated to good non-GSF matched track remove this cluster
+          if (PFTrackAlgoTools::isGoodForEGMPrimary(trackref->algo()) && nexhits == 0 && fromprimaryvertex) {
+            closestECAL.setFlag(false);
+          }
+        }
+      }  // found a good closest ECAL match
+    }    // no GSF track matched to KF
+  }      // loop over KF elements
+}
+
+void PFEGammaAlgo::mergeROsByAnyLink(std::list<PFEGammaAlgo::ProtoEGObject>& ROs) {
+  if (ROs.size() < 2)
+    return;  // nothing to do with one or zero ROs
+  bool check_for_merge = true;
+  while (check_for_merge) {
+    // bugfix for early termination merging loop (15 April 2014)
+    // check all pairwise combinations in the list
+    // if one has a merge shuffle it to the front of the list
+    // if there are no merges left to do we can terminate
+    for (auto it1 = ROs.begin(); it1 != ROs.end(); ++it1) {
+      auto find_start = it1;
+      ++find_start;
+      auto has_merge = std::find_if(find_start, ROs.end(), std::bind(testIfROMergableByLink, _1, *it1));
+      if (has_merge != ROs.end() && it1 != ROs.begin()) {
+        std::swap(*(ROs.begin()), *it1);
+        break;
+      }
+    }  // ensure mergables are shuffled to the front
+    ProtoEGObject& thefront = ROs.front();
+    auto mergestart = ROs.begin();
+    ++mergestart;
+    auto nomerge = std::partition(mergestart, ROs.end(), std::bind(testIfROMergableByLink, _1, thefront));
+    if (nomerge != mergestart) {
+      LOGDRESSED("PFEGammaAlgo::mergeROsByAnyLink()")
+          << "Found objects " << std::distance(mergestart, nomerge) << " to merge by links to the front!" << std::endl;
+      for (auto roToMerge = mergestart; roToMerge != nomerge; ++roToMerge) {
+        //bugfix! L.Gray 14 Jan 2016
+        // -- check that the front is still mergeable!
+        if (!thefront.ecalclusters.empty() && !roToMerge->ecalclusters.empty()) {
+          if (thefront.ecalclusters.front()->clusterRef()->layer() !=
+              roToMerge->ecalclusters.front()->clusterRef()->layer()) {
+            LOGWARN("PFEGammaAlgo::mergeROsByAnyLink") << "Tried to merge EB and EE clusters! Skipping!";
+            ROs.push_back(*roToMerge);
+            continue;
+          }
+        }
+        //end bugfix
+        thefront.ecalclusters.insert(
+            thefront.ecalclusters.end(), roToMerge->ecalclusters.begin(), roToMerge->ecalclusters.end());
+        thefront.ecal2ps.insert(roToMerge->ecal2ps.begin(), roToMerge->ecal2ps.end());
+        thefront.secondaryKFs.insert(
+            thefront.secondaryKFs.end(), roToMerge->secondaryKFs.begin(), roToMerge->secondaryKFs.end());
+
+        thefront.localMap.concatenate(roToMerge->localMap);
+        // TO FIX -> use best (E_gsf - E_clustersum)/E_GSF
+        if (!thefront.parentSC && roToMerge->parentSC) {
+          thefront.parentSC = roToMerge->parentSC;
+        }
+        if (thefront.electronSeed.isNull() && roToMerge->electronSeed.isNonnull()) {
+          thefront.electronSeed = roToMerge->electronSeed;
+          thefront.primaryGSFs.insert(
+              thefront.primaryGSFs.end(), roToMerge->primaryGSFs.begin(), roToMerge->primaryGSFs.end());
+          thefront.primaryKFs.insert(
+              thefront.primaryKFs.end(), roToMerge->primaryKFs.begin(), roToMerge->primaryKFs.end());
+          thefront.brems.insert(thefront.brems.end(), roToMerge->brems.begin(), roToMerge->brems.end());
+          thefront.electronClusters = roToMerge->electronClusters;
+          thefront.nBremsWithClusters = roToMerge->nBremsWithClusters;
+          thefront.firstBrem = roToMerge->firstBrem;
+          thefront.lateBrem = roToMerge->lateBrem;
+        } else if (thefront.electronSeed.isNonnull() && roToMerge->electronSeed.isNonnull()) {
+          LOGDRESSED("PFEGammaAlgo::mergeROsByAnyLink")
+              << "Need to implement proper merging of two gsf candidates!" << std::endl;
+        }
+      }
+      ROs.erase(mergestart, nomerge);
+      // put the merged element in the back of the cleaned list
+      ROs.push_back(ROs.front());
+      ROs.pop_front();
+    } else {
+      check_for_merge = false;
+    }
+  }
+  LOGDRESSED("PFEGammaAlgo::mergeROsByAnyLink()")
+      << "After merging by links there are: " << ROs.size() << " refinable EGamma objects!" << std::endl;
+}
+
+// pull in KF tracks associated to the RO but not closer to another
+// NB: in initializeProtoCands() we forced the GSF tracks not to be
+//     from a conversion, but we will leave a protection here just in
+//     case things change in the future
+void PFEGammaAlgo::linkRefinableObjectGSFTracksToKFs(ProtoEGObject& RO) {
+  constexpr reco::PFBlockElement::TrackType convType = reco::PFBlockElement::T_FROM_GAMMACONV;
+  if (_splayedblock[reco::PFBlockElement::TRACK].empty())
+    return;
   auto KFbegin = _splayedblock[reco::PFBlockElement::TRACK].begin();
   auto KFend = _splayedblock[reco::PFBlockElement::TRACK].end();
-  for( auto& primkf : RO.primaryKFs ) {
+  for (auto& gsfflagged : RO.primaryGSFs) {
+    const PFGSFElement* seedtk = gsfflagged;
     // don't process SC-only ROs or secondary seeded ROs
-    if( primkf->trackType(convType) ) {
-      throw cms::Exception("PFEGammaAlgo::linkRefinableObjectPrimaryKFsToSecondaryKFs()")
-	<< "A KF track from conversion has been assigned as a primary!!"
-	<< std::endl;
-    }
-    NotCloserToOther<reco::PFBlockElement::TRACK,reco::PFBlockElement::TRACK,true>
-	kfTrackToKFs(_currentblock,primkf);
+    if (RO.electronSeed.isNull() || seedtk->trackType(convType))
+      continue;
+    NotCloserToOther<reco::PFBlockElement::GSF, reco::PFBlockElement::TRACK> gsfTrackToKFs(_currentblock, seedtk);
     // get KF tracks not closer to another and not already used
-    auto notlinked = std::partition(KFbegin,KFend,kfTrackToKFs);
+    auto notlinked = std::partition(KFbegin, KFend, gsfTrackToKFs);
     // attach tracks and set as used
-    for( auto kft = KFbegin; kft != notlinked; ++kft ) {
-      const PFKFElement* elemaskf = 
-	docast(const PFKFElement*,kft->get());
-      // don't care about things that aren't primaries or directly 
+    for (auto kft = KFbegin; kft != notlinked; ++kft) {
+      const PFKFElement* elemaskf = docast(const PFKFElement*, kft->get());
+      // don't care about things that aren't primaries or directly
       // associated secondary tracks
-      if( elemaskf->trackType(convType) ) {
-	kft->setFlag(false);
-	RO.secondaryKFs.push_back(elemaskf);
-	RO.localMap.insert(primkf,elemaskf);
-      } 
-    }// loop on closest KFs not closer to other KFs
-  } // loop on KF primaries on RO
+      if (isPrimaryTrack(*elemaskf, *seedtk) && !elemaskf->trackType(convType)) {
+        kft->setFlag(false);
+        RO.primaryKFs.push_back(elemaskf);
+        RO.localMap.insert(seedtk, elemaskf);
+      } else if (elemaskf->trackType(convType)) {
+        kft->setFlag(false);
+        RO.secondaryKFs.push_back(elemaskf);
+        RO.localMap.insert(seedtk, elemaskf);
+      }
+    }  // loop on closest KFs not closer to other GSFs
+  }    // loop on GSF primaries on RO
+}
+
+void PFEGammaAlgo::linkRefinableObjectPrimaryKFsToSecondaryKFs(ProtoEGObject& RO) {
+  constexpr reco::PFBlockElement::TrackType convType = reco::PFBlockElement::T_FROM_GAMMACONV;
+  if (_splayedblock[reco::PFBlockElement::TRACK].empty())
+    return;
+  auto KFbegin = _splayedblock[reco::PFBlockElement::TRACK].begin();
+  auto KFend = _splayedblock[reco::PFBlockElement::TRACK].end();
+  for (auto& primkf : RO.primaryKFs) {
+    // don't process SC-only ROs or secondary seeded ROs
+    if (primkf->trackType(convType)) {
+      throw cms::Exception("PFEGammaAlgo::linkRefinableObjectPrimaryKFsToSecondaryKFs()")
+          << "A KF track from conversion has been assigned as a primary!!" << std::endl;
+    }
+    NotCloserToOther<reco::PFBlockElement::TRACK, reco::PFBlockElement::TRACK, true> kfTrackToKFs(_currentblock,
+                                                                                                  primkf);
+    // get KF tracks not closer to another and not already used
+    auto notlinked = std::partition(KFbegin, KFend, kfTrackToKFs);
+    // attach tracks and set as used
+    for (auto kft = KFbegin; kft != notlinked; ++kft) {
+      const PFKFElement* elemaskf = docast(const PFKFElement*, kft->get());
+      // don't care about things that aren't primaries or directly
+      // associated secondary tracks
+      if (elemaskf->trackType(convType)) {
+        kft->setFlag(false);
+        RO.secondaryKFs.push_back(elemaskf);
+        RO.localMap.insert(primkf, elemaskf);
+      }
+    }  // loop on closest KFs not closer to other KFs
+  }    // loop on KF primaries on RO
 }
 
 // try to associate the tracks to cluster elements which are not used
-void PFEGammaAlgo::
-linkRefinableObjectPrimaryGSFTrackToECAL(ProtoEGObject& RO) {
-  if( _splayedblock[reco::PFBlockElement::ECAL].empty() ) {
+void PFEGammaAlgo::linkRefinableObjectPrimaryGSFTrackToECAL(ProtoEGObject& RO) {
+  if (_splayedblock[reco::PFBlockElement::ECAL].empty()) {
     RO.electronClusters.push_back(nullptr);
-    return; 
+    return;
   }
   auto ECALbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
   auto ECALend = _splayedblock[reco::PFBlockElement::ECAL].end();
-  for( auto& primgsf : RO.primaryGSFs ) {    
-    NotCloserToOther<reco::PFBlockElement::GSF,reco::PFBlockElement::ECAL>
-      gsfTracksToECALs(_currentblock,primgsf);
+  for (auto& primgsf : RO.primaryGSFs) {
+    NotCloserToOther<reco::PFBlockElement::GSF, reco::PFBlockElement::ECAL> gsfTracksToECALs(_currentblock, primgsf);
     // get set of matching ecals not already in SC
-    auto notmatched_blk = std::partition(ECALbegin,ECALend,gsfTracksToECALs);
-    notmatched_blk = std::partition(ECALbegin,notmatched_blk,
-				   [&primgsf](auto const& x){ return compatibleEoPOut(*x, *primgsf); });
+    auto notmatched_blk = std::partition(ECALbegin, ECALend, gsfTracksToECALs);
+    notmatched_blk =
+        std::partition(ECALbegin, notmatched_blk, [&primgsf](auto const& x) { return compatibleEoPOut(*x, *primgsf); });
     // get set of matching ecals already in the RO
-    auto notmatched_sc = std::partition(RO.ecalclusters.begin(),
-					RO.ecalclusters.end(),
-					gsfTracksToECALs);
-    notmatched_sc = std::partition(RO.ecalclusters.begin(),
-				   notmatched_sc,
-				   [&primgsf](auto const& x){ return compatibleEoPOut(*x, *primgsf); });
+    auto notmatched_sc = std::partition(RO.ecalclusters.begin(), RO.ecalclusters.end(), gsfTracksToECALs);
+    notmatched_sc = std::partition(
+        RO.ecalclusters.begin(), notmatched_sc, [&primgsf](auto const& x) { return compatibleEoPOut(*x, *primgsf); });
     // look inside the SC for the ECAL cluster
-    for( auto ecal = RO.ecalclusters.begin(); ecal != notmatched_sc; ++ecal ) {
-      const PFClusterElement* elemascluster = 
-	docast(const PFClusterElement*,ecal->get());    
-      FlaggedPtr<const PFClusterElement> temp(elemascluster,true);
-      LOGDRESSED("PFEGammaAlgo::linkGSFTracktoECAL()") 
-	<< "Found a cluster already in RO by GSF extrapolation"
-	<< " at ECAL surface!" << std::endl
-	<< *elemascluster << std::endl;
-            
-      RO.localMap.insert(primgsf,temp.get());
+    for (auto ecal = RO.ecalclusters.begin(); ecal != notmatched_sc; ++ecal) {
+      const PFClusterElement* elemascluster = docast(const PFClusterElement*, ecal->get());
+      FlaggedPtr<const PFClusterElement> temp(elemascluster, true);
+      LOGDRESSED("PFEGammaAlgo::linkGSFTracktoECAL()") << "Found a cluster already in RO by GSF extrapolation"
+                                                       << " at ECAL surface!" << std::endl
+                                                       << *elemascluster << std::endl;
+
+      RO.localMap.insert(primgsf, temp.get());
     }
     // look outside the SC for the ecal cluster
-    for( auto ecal = ECALbegin; ecal != notmatched_blk; ++ecal ) {
-      const PFClusterElement* elemascluster = 
-	docast(const PFClusterElement*,ecal->get());    
-      LOGDRESSED("PFEGammaAlgo::linkGSFTracktoECAL()") 
-	<< "Found a cluster not already in RO by GSF extrapolation"
-	<< " at ECAL surface!" << std::endl
-	<< *elemascluster << std::endl;
-      if( addPFClusterToROSafe(elemascluster,RO) ) {
-	attachPSClusters(elemascluster,RO.ecal2ps[elemascluster]);      
-	RO.localMap.insert(primgsf,elemascluster);
-	ecal->setFlag(false);
+    for (auto ecal = ECALbegin; ecal != notmatched_blk; ++ecal) {
+      const PFClusterElement* elemascluster = docast(const PFClusterElement*, ecal->get());
+      LOGDRESSED("PFEGammaAlgo::linkGSFTracktoECAL()") << "Found a cluster not already in RO by GSF extrapolation"
+                                                       << " at ECAL surface!" << std::endl
+                                                       << *elemascluster << std::endl;
+      if (addPFClusterToROSafe(elemascluster, RO)) {
+        attachPSClusters(elemascluster, RO.ecal2ps[elemascluster]);
+        RO.localMap.insert(primgsf, elemascluster);
+        ecal->setFlag(false);
       }
-    }    
+    }
   }
 }
 
 // try to associate the tracks to cluster elements which are not used
-void PFEGammaAlgo::
-linkRefinableObjectPrimaryGSFTrackToHCAL(ProtoEGObject& RO) {
-  if( _splayedblock[reco::PFBlockElement::HCAL].empty() ) return; 
+void PFEGammaAlgo::linkRefinableObjectPrimaryGSFTrackToHCAL(ProtoEGObject& RO) {
+  if (_splayedblock[reco::PFBlockElement::HCAL].empty())
+    return;
   auto HCALbegin = _splayedblock[reco::PFBlockElement::HCAL].begin();
   auto HCALend = _splayedblock[reco::PFBlockElement::HCAL].end();
-  for( auto& primgsf : RO.primaryGSFs ) {
-    NotCloserToOther<reco::PFBlockElement::GSF,reco::PFBlockElement::HCAL>
-      gsfTracksToHCALs(_currentblock,primgsf);
-    auto notmatched = std::partition(HCALbegin,HCALend,gsfTracksToHCALs);    
-    for( auto hcal = HCALbegin; hcal != notmatched; ++hcal ) { 
-      const PFClusterElement* elemascluster = 
-	docast(const PFClusterElement*,hcal->get());    
-      FlaggedPtr<const PFClusterElement> temp(elemascluster,true);    
-      LOGDRESSED("PFEGammaAlgo::linkGSFTracktoECAL()") 
-	<< "Found an HCAL cluster associated to GSF extrapolation" 
-	<< std::endl;
+  for (auto& primgsf : RO.primaryGSFs) {
+    NotCloserToOther<reco::PFBlockElement::GSF, reco::PFBlockElement::HCAL> gsfTracksToHCALs(_currentblock, primgsf);
+    auto notmatched = std::partition(HCALbegin, HCALend, gsfTracksToHCALs);
+    for (auto hcal = HCALbegin; hcal != notmatched; ++hcal) {
+      const PFClusterElement* elemascluster = docast(const PFClusterElement*, hcal->get());
+      FlaggedPtr<const PFClusterElement> temp(elemascluster, true);
+      LOGDRESSED("PFEGammaAlgo::linkGSFTracktoECAL()")
+          << "Found an HCAL cluster associated to GSF extrapolation" << std::endl;
       RO.hcalClusters.push_back(temp.get());
-      RO.localMap.insert(primgsf,temp.get());
+      RO.localMap.insert(primgsf, temp.get());
       hcal->setFlag(false);
     }
   }
 }
 
 // try to associate the tracks to cluster elements which are not used
-void PFEGammaAlgo::
-linkRefinableObjectKFTracksToECAL(ProtoEGObject& RO) {
-  if( _splayedblock[reco::PFBlockElement::ECAL].empty() ) return;  
-  for( auto& primkf : RO.primaryKFs ) linkKFTrackToECAL(primkf,RO);
-  for( auto& secdkf : RO.secondaryKFs ) linkKFTrackToECAL(secdkf,RO);
+void PFEGammaAlgo::linkRefinableObjectKFTracksToECAL(ProtoEGObject& RO) {
+  if (_splayedblock[reco::PFBlockElement::ECAL].empty())
+    return;
+  for (auto& primkf : RO.primaryKFs)
+    linkKFTrackToECAL(primkf, RO);
+  for (auto& secdkf : RO.secondaryKFs)
+    linkKFTrackToECAL(secdkf, RO);
 }
 
-void 
-PFEGammaAlgo::linkKFTrackToECAL(PFKFElement const* kfflagged,
-				ProtoEGObject& RO) {
+void PFEGammaAlgo::linkKFTrackToECAL(PFKFElement const* kfflagged, ProtoEGObject& RO) {
   std::vector<FlaggedPtr<const PFClusterElement>>& currentECAL = RO.ecalclusters;
   auto ECALbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
-  auto ECALend = _splayedblock[reco::PFBlockElement::ECAL].end();  
-  NotCloserToOther<reco::PFBlockElement::TRACK,reco::PFBlockElement::ECAL>
-    kfTrackToECALs(_currentblock,kfflagged);
-  NotCloserToOther<reco::PFBlockElement::GSF,reco::PFBlockElement::ECAL>
-    kfTrackGSFToECALs(_currentblock,kfflagged);
+  auto ECALend = _splayedblock[reco::PFBlockElement::ECAL].end();
+  NotCloserToOther<reco::PFBlockElement::TRACK, reco::PFBlockElement::ECAL> kfTrackToECALs(_currentblock, kfflagged);
+  NotCloserToOther<reco::PFBlockElement::GSF, reco::PFBlockElement::ECAL> kfTrackGSFToECALs(_currentblock, kfflagged);
   //get the ECAL elements not used and not closer to another KF
-  auto notmatched_sc = std::partition(currentECAL.begin(),
-				      currentECAL.end(),
-				      kfTrackToECALs);
+  auto notmatched_sc = std::partition(currentECAL.begin(), currentECAL.end(), kfTrackToECALs);
   //get subset ECAL elements not used or closer to another GSF of any type
-  notmatched_sc = std::partition(currentECAL.begin(),
-				 notmatched_sc,
-				 kfTrackGSFToECALs);
-  for( auto ecalitr = currentECAL.begin(); ecalitr != notmatched_sc; 
-       ++ecalitr ) {
-    const PFClusterElement* elemascluster = 
-      docast(const PFClusterElement*,ecalitr->get());
-    FlaggedPtr<const PFClusterElement> flaggedclus(elemascluster,true);
-        
-    LOGDRESSED("PFEGammaAlgo::linkKFTracktoECAL()") 
-	<< "Found a cluster already in RO by KF extrapolation"
-	<< " at ECAL surface!" << std::endl
-	<< *elemascluster << std::endl;
-    RO.localMap.insert(elemascluster,kfflagged);
+  notmatched_sc = std::partition(currentECAL.begin(), notmatched_sc, kfTrackGSFToECALs);
+  for (auto ecalitr = currentECAL.begin(); ecalitr != notmatched_sc; ++ecalitr) {
+    const PFClusterElement* elemascluster = docast(const PFClusterElement*, ecalitr->get());
+    FlaggedPtr<const PFClusterElement> flaggedclus(elemascluster, true);
+
+    LOGDRESSED("PFEGammaAlgo::linkKFTracktoECAL()") << "Found a cluster already in RO by KF extrapolation"
+                                                    << " at ECAL surface!" << std::endl
+                                                    << *elemascluster << std::endl;
+    RO.localMap.insert(elemascluster, kfflagged);
   }
   //get the ECAL elements not used and not closer to another KF
-  auto notmatched_blk = std::partition(ECALbegin,ECALend,kfTrackToECALs);
+  auto notmatched_blk = std::partition(ECALbegin, ECALend, kfTrackToECALs);
   //get subset ECAL elements not used or closer to another GSF of any type
-  notmatched_blk = std::partition(ECALbegin,notmatched_blk,kfTrackGSFToECALs);
-  for( auto ecalitr = ECALbegin; ecalitr != notmatched_blk; ++ecalitr ) {
-    const PFClusterElement* elemascluster = 
-      docast(const PFClusterElement*,ecalitr->get());
-    if( addPFClusterToROSafe(elemascluster,RO) ) {
-      attachPSClusters(elemascluster,RO.ecal2ps[elemascluster]);	  
+  notmatched_blk = std::partition(ECALbegin, notmatched_blk, kfTrackGSFToECALs);
+  for (auto ecalitr = ECALbegin; ecalitr != notmatched_blk; ++ecalitr) {
+    const PFClusterElement* elemascluster = docast(const PFClusterElement*, ecalitr->get());
+    if (addPFClusterToROSafe(elemascluster, RO)) {
+      attachPSClusters(elemascluster, RO.ecal2ps[elemascluster]);
       ecalitr->setFlag(false);
-      
-      LOGDRESSED("PFEGammaAlgo::linkKFTracktoECAL()") 
-	<< "Found a cluster not in RO by KF extrapolation"
-	<< " at ECAL surface!" << std::endl
-	<< *elemascluster << std::endl;
-      RO.localMap.insert(elemascluster,kfflagged);
+
+      LOGDRESSED("PFEGammaAlgo::linkKFTracktoECAL()") << "Found a cluster not in RO by KF extrapolation"
+                                                      << " at ECAL surface!" << std::endl
+                                                      << *elemascluster << std::endl;
+      RO.localMap.insert(elemascluster, kfflagged);
     }
-  }  
+  }
 }
 
-void PFEGammaAlgo::
-linkRefinableObjectBremTangentsToECAL(ProtoEGObject& RO) {
-  if( RO.brems.empty() ) return;
+void PFEGammaAlgo::linkRefinableObjectBremTangentsToECAL(ProtoEGObject& RO) {
+  if (RO.brems.empty())
+    return;
   int FirstBrem = -1;
   int TrajPos = -1;
-  int lastBremTrajPos = -1;  
-  for( auto& brem : RO.brems ) {
+  int lastBremTrajPos = -1;
+  for (auto& brem : RO.brems) {
     bool has_clusters = false;
-    TrajPos = (brem->indTrajPoint())-2;
+    TrajPos = (brem->indTrajPoint()) - 2;
     auto ECALbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
     auto ECALend = _splayedblock[reco::PFBlockElement::ECAL].end();
-    NotCloserToOther<reco::PFBlockElement::BREM,reco::PFBlockElement::ECAL>
-      BremToECALs(_currentblock,brem);
+    NotCloserToOther<reco::PFBlockElement::BREM, reco::PFBlockElement::ECAL> BremToECALs(_currentblock, brem);
     // check for late brem using clusters already in the SC
     auto RSCBegin = RO.ecalclusters.begin();
     auto RSCEnd = RO.ecalclusters.end();
-    auto notmatched_rsc = std::partition(RSCBegin,RSCEnd,BremToECALs);
-    for( auto ecal = RSCBegin; ecal != notmatched_rsc; ++ecal ) {
-      float deta = 
-	std::abs( (*ecal)->clusterRef()->positionREP().eta() -
-		  brem->positionAtECALEntrance().eta() );
-      if( deta < 0.015 ) {
-	has_clusters = true;
-	if( lastBremTrajPos == -1 || lastBremTrajPos < TrajPos ) {
-	  lastBremTrajPos = TrajPos;	  
-	}
-	if( FirstBrem == -1 || TrajPos < FirstBrem ) { // set brem information
-	  FirstBrem = TrajPos;
-	  RO.firstBrem = TrajPos;
-	}	
-	LOGDRESSED("PFEGammaAlgo::linkBremToECAL()") 
-	  << "Found a cluster already in SC linked to brem extrapolation"
-	  << " at ECAL surface!" << std::endl;
-	RO.localMap.insert(ecal->get(),brem);
+    auto notmatched_rsc = std::partition(RSCBegin, RSCEnd, BremToECALs);
+    for (auto ecal = RSCBegin; ecal != notmatched_rsc; ++ecal) {
+      float deta = std::abs((*ecal)->clusterRef()->positionREP().eta() - brem->positionAtECALEntrance().eta());
+      if (deta < 0.015) {
+        has_clusters = true;
+        if (lastBremTrajPos == -1 || lastBremTrajPos < TrajPos) {
+          lastBremTrajPos = TrajPos;
+        }
+        if (FirstBrem == -1 || TrajPos < FirstBrem) {  // set brem information
+          FirstBrem = TrajPos;
+          RO.firstBrem = TrajPos;
+        }
+        LOGDRESSED("PFEGammaAlgo::linkBremToECAL()") << "Found a cluster already in SC linked to brem extrapolation"
+                                                     << " at ECAL surface!" << std::endl;
+        RO.localMap.insert(ecal->get(), brem);
       }
     }
     // grab new clusters from the block (ensured to not be late brem)
-    auto notmatched_block = std::partition(ECALbegin,ECALend,BremToECALs);   
-    for( auto ecal = ECALbegin; ecal != notmatched_block; ++ecal ) {
-      float deta = 
-	std::abs( (*ecal)->clusterRef()->positionREP().eta() -
-		  brem->positionAtECALEntrance().eta() );
-      if( deta < 0.015 ) { 	
-	has_clusters = true;
-	if( lastBremTrajPos == -1 || lastBremTrajPos < TrajPos ) {
-	  lastBremTrajPos = TrajPos;	  
-	}
-	if( FirstBrem == -1 || TrajPos < FirstBrem ) { // set brem information
-	  
-	  FirstBrem = TrajPos;
-	  RO.firstBrem = TrajPos;
-	}	
-	const PFClusterElement* elemasclus =
-	  docast(const PFClusterElement*,ecal->get());    
-	if( addPFClusterToROSafe(elemasclus,RO) ) {
-	  attachPSClusters(elemasclus,RO.ecal2ps[elemasclus]);
-	  
-	  RO.localMap.insert(ecal->get(),brem);
-	  ecal->setFlag(false);
-	  LOGDRESSED("PFEGammaAlgo::linkBremToECAL()") 
-	    << "Found a cluster not already associated by brem extrapolation"
-	    << " at ECAL surface!" << std::endl;
-	}
-	
+    auto notmatched_block = std::partition(ECALbegin, ECALend, BremToECALs);
+    for (auto ecal = ECALbegin; ecal != notmatched_block; ++ecal) {
+      float deta = std::abs((*ecal)->clusterRef()->positionREP().eta() - brem->positionAtECALEntrance().eta());
+      if (deta < 0.015) {
+        has_clusters = true;
+        if (lastBremTrajPos == -1 || lastBremTrajPos < TrajPos) {
+          lastBremTrajPos = TrajPos;
+        }
+        if (FirstBrem == -1 || TrajPos < FirstBrem) {  // set brem information
+
+          FirstBrem = TrajPos;
+          RO.firstBrem = TrajPos;
+        }
+        const PFClusterElement* elemasclus = docast(const PFClusterElement*, ecal->get());
+        if (addPFClusterToROSafe(elemasclus, RO)) {
+          attachPSClusters(elemasclus, RO.ecal2ps[elemasclus]);
+
+          RO.localMap.insert(ecal->get(), brem);
+          ecal->setFlag(false);
+          LOGDRESSED("PFEGammaAlgo::linkBremToECAL()") << "Found a cluster not already associated by brem extrapolation"
+                                                       << " at ECAL surface!" << std::endl;
+        }
       }
     }
-    if(has_clusters) {
-      if( RO.nBremsWithClusters == -1 ) RO.nBremsWithClusters = 0;
+    if (has_clusters) {
+      if (RO.nBremsWithClusters == -1)
+        RO.nBremsWithClusters = 0;
       ++RO.nBremsWithClusters;
     }
-  }  
-}
-
-void PFEGammaAlgo::
-linkRefinableObjectConvSecondaryKFsToSecondaryKFs(ProtoEGObject& RO) {
-  auto KFbegin = _splayedblock[reco::PFBlockElement::TRACK].begin();
-  auto KFend   = _splayedblock[reco::PFBlockElement::TRACK].end();
-  auto BeginROskfs = RO.secondaryKFs.begin();
-  auto EndROskfs   = RO.secondaryKFs.end();  
-  auto ronotconv = std::partition(BeginROskfs,EndROskfs, [](auto const& x){ return x->trackType(ConvType); });
-  size_t convkfs_end = std::distance(BeginROskfs,ronotconv);  
-  for( size_t idx = 0; idx < convkfs_end; ++idx ) { 
-    auto const& secKFs = RO.secondaryKFs; //we want the entry at the index but we allocate to secondaryKFs in loop which invalidates all iterators, references and pointers, hence we need to get the entry fresh each time
-    NotCloserToOther<reco::PFBlockElement::TRACK,
-                     reco::PFBlockElement::TRACK,
-                     true> 
-      TracksToTracks(_currentblock, secKFs[idx]);
-    auto notmatched = std::partition(KFbegin,KFend,TracksToTracks);    
-    notmatched = std::partition(KFbegin,notmatched,[](auto const& x){ return x->trackType(ConvType); });
-    for( auto kf = KFbegin; kf != notmatched; ++kf ) {
-      const reco::PFBlockElementTrack* elemaskf =
-	docast(const reco::PFBlockElementTrack*,kf->get());      
-      RO.secondaryKFs.push_back(elemaskf);
-      RO.localMap.insert(secKFs[idx],kf->get());
-      kf->setFlag(false);
-    }    
   }
 }
 
-void PFEGammaAlgo::
-linkRefinableObjectECALToSingleLegConv(ProtoEGObject& RO) { 
+void PFEGammaAlgo::linkRefinableObjectConvSecondaryKFsToSecondaryKFs(ProtoEGObject& RO) {
   auto KFbegin = _splayedblock[reco::PFBlockElement::TRACK].begin();
-  auto KFend = _splayedblock[reco::PFBlockElement::TRACK].end();  
-  for( auto& ecal : RO.ecalclusters ) {
-    NotCloserToOther<reco::PFBlockElement::ECAL,
-                     reco::PFBlockElement::TRACK,
-                     true>
-      ECALToTracks(_currentblock,ecal.get());
-    auto notmatchedkf  = std::partition(KFbegin,KFend,ECALToTracks);
-    auto notconvkf     = std::partition(KFbegin,notmatchedkf,[](auto const& x){ return x->trackType(ConvType); });
-    // add identified KF conversion tracks
-    for( auto kf = KFbegin; kf != notconvkf; ++kf ) {
-      const reco::PFBlockElementTrack* elemaskf =
-	docast(const reco::PFBlockElementTrack*,kf->get());
+  auto KFend = _splayedblock[reco::PFBlockElement::TRACK].end();
+  auto BeginROskfs = RO.secondaryKFs.begin();
+  auto EndROskfs = RO.secondaryKFs.end();
+  auto ronotconv = std::partition(BeginROskfs, EndROskfs, [](auto const& x) { return x->trackType(ConvType); });
+  size_t convkfs_end = std::distance(BeginROskfs, ronotconv);
+  for (size_t idx = 0; idx < convkfs_end; ++idx) {
+    auto const& secKFs =
+        RO.secondaryKFs;  //we want the entry at the index but we allocate to secondaryKFs in loop which invalidates all iterators, references and pointers, hence we need to get the entry fresh each time
+    NotCloserToOther<reco::PFBlockElement::TRACK, reco::PFBlockElement::TRACK, true> TracksToTracks(_currentblock,
+                                                                                                    secKFs[idx]);
+    auto notmatched = std::partition(KFbegin, KFend, TracksToTracks);
+    notmatched = std::partition(KFbegin, notmatched, [](auto const& x) { return x->trackType(ConvType); });
+    for (auto kf = KFbegin; kf != notmatched; ++kf) {
+      const reco::PFBlockElementTrack* elemaskf = docast(const reco::PFBlockElementTrack*, kf->get());
       RO.secondaryKFs.push_back(elemaskf);
-      RO.localMap.insert(ecal.get(),elemaskf);
+      RO.localMap.insert(secKFs[idx], kf->get());
+      kf->setFlag(false);
+    }
+  }
+}
+
+void PFEGammaAlgo::linkRefinableObjectECALToSingleLegConv(ProtoEGObject& RO) {
+  auto KFbegin = _splayedblock[reco::PFBlockElement::TRACK].begin();
+  auto KFend = _splayedblock[reco::PFBlockElement::TRACK].end();
+  for (auto& ecal : RO.ecalclusters) {
+    NotCloserToOther<reco::PFBlockElement::ECAL, reco::PFBlockElement::TRACK, true> ECALToTracks(_currentblock,
+                                                                                                 ecal.get());
+    auto notmatchedkf = std::partition(KFbegin, KFend, ECALToTracks);
+    auto notconvkf = std::partition(KFbegin, notmatchedkf, [](auto const& x) { return x->trackType(ConvType); });
+    // add identified KF conversion tracks
+    for (auto kf = KFbegin; kf != notconvkf; ++kf) {
+      const reco::PFBlockElementTrack* elemaskf = docast(const reco::PFBlockElementTrack*, kf->get());
+      RO.secondaryKFs.push_back(elemaskf);
+      RO.localMap.insert(ecal.get(), elemaskf);
       kf->setFlag(false);
     }
     // go through non-conv-identified kfs and check MVA to add conversions
-    for( auto kf = notconvkf; kf != notmatchedkf; ++kf ) {
-      float mvaval = evaluateSingleLegMVA(_currentblock, 
-                                          *primaryVertex_, 
-                                          (*kf)->index());
-      if(mvaval > cfg_.mvaConvCut) {
-	const reco::PFBlockElementTrack* elemaskf =
-	  docast(const reco::PFBlockElementTrack*,kf->get());
-	RO.secondaryKFs.push_back(elemaskf);
-	RO.localMap.insert(ecal.get(),elemaskf);
-	kf->setFlag(false);
-        
-        RO.singleLegConversionMvaMap.emplace(elemaskf, mvaval);
-      }
-    }    
-  }
-}
+    for (auto kf = notconvkf; kf != notmatchedkf; ++kf) {
+      float mvaval = evaluateSingleLegMVA(_currentblock, *primaryVertex_, (*kf)->index());
+      if (mvaval > cfg_.mvaConvCut) {
+        const reco::PFBlockElementTrack* elemaskf = docast(const reco::PFBlockElementTrack*, kf->get());
+        RO.secondaryKFs.push_back(elemaskf);
+        RO.localMap.insert(ecal.get(), elemaskf);
+        kf->setFlag(false);
 
-void  PFEGammaAlgo::
-linkRefinableObjectSecondaryKFsToECAL(ProtoEGObject& RO) {
-  auto ECALbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
-  auto ECALend = _splayedblock[reco::PFBlockElement::ECAL].end(); 
-  for( auto& skf : RO.secondaryKFs ) {
-    NotCloserToOther<reco::PFBlockElement::TRACK,
-                     reco::PFBlockElement::ECAL,
-                     false>
-      TracksToECALwithCut(_currentblock,skf,1.5f);
-    auto notmatched = std::partition(ECALbegin,ECALend,TracksToECALwithCut);
-    for( auto ecal = ECALbegin; ecal != notmatched; ++ecal ) {
-      const reco::PFBlockElementCluster* elemascluster =
-	docast(const reco::PFBlockElementCluster*,ecal->get());      
-      if( addPFClusterToROSafe(elemascluster,RO) ) {
-	attachPSClusters(elemascluster,RO.ecal2ps[elemascluster]);
-	RO.localMap.insert(skf,elemascluster);
-	ecal->setFlag(false);
+        RO.singleLegConversionMvaMap.emplace(elemaskf, mvaval);
       }
     }
   }
 }
 
-PFEGammaAlgo::EgammaObjects PFEGammaAlgo::
-fillPFCandidates(const std::list<PFEGammaAlgo::ProtoEGObject>& ROs) {
+void PFEGammaAlgo::linkRefinableObjectSecondaryKFsToECAL(ProtoEGObject& RO) {
+  auto ECALbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
+  auto ECALend = _splayedblock[reco::PFBlockElement::ECAL].end();
+  for (auto& skf : RO.secondaryKFs) {
+    NotCloserToOther<reco::PFBlockElement::TRACK, reco::PFBlockElement::ECAL, false> TracksToECALwithCut(
+        _currentblock, skf, 1.5f);
+    auto notmatched = std::partition(ECALbegin, ECALend, TracksToECALwithCut);
+    for (auto ecal = ECALbegin; ecal != notmatched; ++ecal) {
+      const reco::PFBlockElementCluster* elemascluster = docast(const reco::PFBlockElementCluster*, ecal->get());
+      if (addPFClusterToROSafe(elemascluster, RO)) {
+        attachPSClusters(elemascluster, RO.ecal2ps[elemascluster]);
+        RO.localMap.insert(skf, elemascluster);
+        ecal->setFlag(false);
+      }
+    }
+  }
+}
 
+PFEGammaAlgo::EgammaObjects PFEGammaAlgo::fillPFCandidates(const std::list<PFEGammaAlgo::ProtoEGObject>& ROs) {
   EgammaObjects output;
 
   // reserve output collections
@@ -1728,269 +1468,247 @@ fillPFCandidates(const std::list<PFEGammaAlgo::ProtoEGObject>& ROs) {
   output.candidateExtras.reserve(ROs.size());
   output.refinedSuperClusters.reserve(ROs.size());
 
-  for( auto& RO : ROs ) {    
-    if( RO.ecalclusters.empty()  && 
-	!cfg_.produceEGCandsWithNoSuperCluster ) continue;
-    
+  for (auto& RO : ROs) {
+    if (RO.ecalclusters.empty() && !cfg_.produceEGCandsWithNoSuperCluster)
+      continue;
+
     reco::PFCandidate cand;
     reco::PFCandidateEGammaExtra xtra;
-    if( !RO.primaryGSFs.empty() || !RO.primaryKFs.empty() ) {
-      cand.setPdgId(-11); // anything with a primary track is an electron
+    if (!RO.primaryGSFs.empty() || !RO.primaryKFs.empty()) {
+      cand.setPdgId(-11);  // anything with a primary track is an electron
     } else {
-      cand.setPdgId(22); // anything with no primary track is a photon
-    }    
-    if( !RO.primaryKFs.empty() ) {
+      cand.setPdgId(22);  // anything with no primary track is a photon
+    }
+    if (!RO.primaryKFs.empty()) {
       cand.setCharge(RO.primaryKFs[0]->trackRef()->charge());
       xtra.setKfTrackRef(RO.primaryKFs[0]->trackRef());
       cand.setTrackRef(RO.primaryKFs[0]->trackRef());
-      cand.addElementInBlock(_currentblock,RO.primaryKFs[0]->index());
+      cand.addElementInBlock(_currentblock, RO.primaryKFs[0]->index());
     }
-    if( !RO.primaryGSFs.empty() ) {        
+    if (!RO.primaryGSFs.empty()) {
       cand.setCharge(RO.primaryGSFs[0]->GsftrackRef()->chargeMode());
       xtra.setGsfTrackRef(RO.primaryGSFs[0]->GsftrackRef());
       cand.setGsfTrackRef(RO.primaryGSFs[0]->GsftrackRef());
-      cand.addElementInBlock(_currentblock,RO.primaryGSFs[0]->index());
+      cand.addElementInBlock(_currentblock, RO.primaryGSFs[0]->index());
     }
-    if( RO.parentSC ) {
-      xtra.setSuperClusterPFECALRef(RO.parentSC->superClusterRef());      
+    if (RO.parentSC) {
+      xtra.setSuperClusterPFECALRef(RO.parentSC->superClusterRef());
       // we'll set to the refined supercluster back up in the producer
       cand.setSuperClusterRef(RO.parentSC->superClusterRef());
-      xtra.setSuperClusterRef(RO.parentSC->superClusterRef());      
-      cand.addElementInBlock(_currentblock,RO.parentSC->index());
+      xtra.setSuperClusterRef(RO.parentSC->superClusterRef());
+      cand.addElementInBlock(_currentblock, RO.parentSC->index());
     }
     // add brems
-    for( const auto& brem : RO.brems ) {
-      cand.addElementInBlock(_currentblock,brem->index());      
+    for (const auto& brem : RO.brems) {
+      cand.addElementInBlock(_currentblock, brem->index());
     }
     // add clusters and ps clusters
-    for( const auto& ecal : RO.ecalclusters ) {
+    for (const auto& ecal : RO.ecalclusters) {
       const PFClusterElement* clus = ecal.get();
-      cand.addElementInBlock(_currentblock,clus->index());      
-      if( RO.ecal2ps.count(clus) ) {
-	for( auto& psclus : RO.ecal2ps.at(clus) ) {
-	  cand.addElementInBlock(_currentblock,psclus->index());	
-	}
+      cand.addElementInBlock(_currentblock, clus->index());
+      if (RO.ecal2ps.count(clus)) {
+        for (auto& psclus : RO.ecal2ps.at(clus)) {
+          cand.addElementInBlock(_currentblock, psclus->index());
+        }
       }
     }
     // add secondary tracks
-    for( const auto& kf : RO.secondaryKFs ) {
-      cand.addElementInBlock(_currentblock,kf->index());
+    for (const auto& kf : RO.secondaryKFs) {
+      cand.addElementInBlock(_currentblock, kf->index());
       const reco::ConversionRefVector& convrefs = kf->convRefs();
       bool no_conv_ref = true;
-      for( const auto& convref : convrefs ) {
-	if( convref.isNonnull() && convref.isAvailable() ) {
-	  xtra.addConversionRef(convref);
-	  no_conv_ref = false;
-	}
+      for (const auto& convref : convrefs) {
+        if (convref.isNonnull() && convref.isAvailable()) {
+          xtra.addConversionRef(convref);
+          no_conv_ref = false;
+        }
       }
-      if( no_conv_ref ) {
+      if (no_conv_ref) {
         //single leg conversions
-        
+
         //look for stored mva value in map or else recompute
-        const auto &mvavalmapped = RO.singleLegConversionMvaMap.find(kf);
+        const auto& mvavalmapped = RO.singleLegConversionMvaMap.find(kf);
         //FIXME: Abuse single mva value to store both provenance and single leg mva score
         //by storing 3.0 + mvaval
-        float mvaval = ( mvavalmapped != RO.singleLegConversionMvaMap.end() ? 
-                         mvavalmapped->second : 
-                         3.0 + evaluateSingleLegMVA(_currentblock,
-                                                    *primaryVertex_,
-                                                    kf->index()) );
-        
-        xtra.addSingleLegConvTrackRefMva(std::make_pair(kf->trackRef(),mvaval));
+        float mvaval = (mvavalmapped != RO.singleLegConversionMvaMap.end()
+                            ? mvavalmapped->second
+                            : 3.0 + evaluateSingleLegMVA(_currentblock, *primaryVertex_, kf->index()));
+
+        xtra.addSingleLegConvTrackRefMva(std::make_pair(kf->trackRef(), mvaval));
       }
     }
-    
+
     // build the refined supercluster from those clusters left in the cand
     output.refinedSuperClusters.push_back(buildRefinedSuperCluster(RO));
 
     //*TODO* cluster time is not reliable at the moment, so only use track timing
     float trkTime = 0, trkTimeErr = -1;
     if (!RO.primaryGSFs.empty() && RO.primaryGSFs[0]->isTimeValid()) {
-        trkTime = RO.primaryGSFs[0]->time();
-        trkTimeErr = RO.primaryGSFs[0]->timeError();
+      trkTime = RO.primaryGSFs[0]->time();
+      trkTimeErr = RO.primaryGSFs[0]->timeError();
     } else if (!RO.primaryKFs.empty() && RO.primaryKFs[0]->isTimeValid()) {
-        trkTime = RO.primaryKFs[0]->time();
-        trkTimeErr = RO.primaryKFs[0]->timeError();
+      trkTime = RO.primaryKFs[0]->time();
+      trkTimeErr = RO.primaryKFs[0]->timeError();
     }
     if (trkTimeErr >= 0) {
-      cand.setTime( trkTime, trkTimeErr );
+      cand.setTime(trkTime, trkTimeErr);
     }
-    
+
     const reco::SuperCluster& the_sc = output.refinedSuperClusters.back();
-    // with the refined SC in hand we build a naive candidate p4 
-    // and set the candidate ECAL position to either the barycenter of the 
+    // with the refined SC in hand we build a naive candidate p4
+    // and set the candidate ECAL position to either the barycenter of the
     // supercluster (if super-cluster present) or the seed of the
-    // new SC generated by the EGAlgo 
+    // new SC generated by the EGAlgo
     const double scE = the_sc.energy();
-    if( scE != 0.0 ) {
+    if (scE != 0.0) {
       const math::XYZPoint& seedPos = the_sc.seed()->position();
-      math::XYZVector egDir = the_sc.position()-primaryVertex_->position();
-      egDir = egDir.Unit();      
-      cand.setP4(math::XYZTLorentzVector(scE*egDir.x(),
-					 scE*egDir.y(),
-					 scE*egDir.z(),
-					 scE           ));
-      math::XYZPointF ecalPOS_f(seedPos.x(),seedPos.y(),seedPos.z());
+      math::XYZVector egDir = the_sc.position() - primaryVertex_->position();
+      egDir = egDir.Unit();
+      cand.setP4(math::XYZTLorentzVector(scE * egDir.x(), scE * egDir.y(), scE * egDir.z(), scE));
+      math::XYZPointF ecalPOS_f(seedPos.x(), seedPos.y(), seedPos.z());
       cand.setPositionAtECALEntrance(ecalPOS_f);
-      cand.setEcalEnergy(the_sc.rawEnergy(),the_sc.energy());
-    } else if ( cfg_.produceEGCandsWithNoSuperCluster && 
-		!RO.primaryGSFs.empty() ) {
+      cand.setEcalEnergy(the_sc.rawEnergy(), the_sc.energy());
+    } else if (cfg_.produceEGCandsWithNoSuperCluster && !RO.primaryGSFs.empty()) {
       const PFGSFElement* gsf = RO.primaryGSFs[0];
       const reco::GsfTrackRef& gref = gsf->GsftrackRef();
-      math::XYZTLorentzVector p4(gref->pxMode(),gref->pyMode(),
-				 gref->pzMode(),gref->pMode());
-      cand.setP4(p4);      
+      math::XYZTLorentzVector p4(gref->pxMode(), gref->pyMode(), gref->pzMode(), gref->pMode());
+      cand.setP4(p4);
       cand.setPositionAtECALEntrance(gsf->positionAtECALEntrance());
-    } else if ( cfg_.produceEGCandsWithNoSuperCluster &&
-		!RO.primaryKFs.empty() ) {
+    } else if (cfg_.produceEGCandsWithNoSuperCluster && !RO.primaryKFs.empty()) {
       const PFKFElement* kf = RO.primaryKFs[0];
       reco::TrackRef kref = RO.primaryKFs[0]->trackRef();
-      math::XYZTLorentzVector p4(kref->px(),kref->py(),kref->pz(),kref->p());
-      cand.setP4(p4);   
+      math::XYZTLorentzVector p4(kref->px(), kref->py(), kref->pz(), kref->p());
+      cand.setP4(p4);
       cand.setPositionAtECALEntrance(kf->positionAtECALEntrance());
-    }    
-    const float eleMVAValue = calculateEleMVA(RO,xtra);
-    fillExtraInfo(RO,xtra);
+    }
+    const float eleMVAValue = calculateEleMVA(RO, xtra);
+    fillExtraInfo(RO, xtra);
     //std::cout << "PFEG eleMVA: " << eleMVAValue << std::endl;
-    xtra.setMVA(eleMVAValue);    
+    xtra.setMVA(eleMVAValue);
     cand.set_mva_e_pi(eleMVAValue);
     output.candidates.push_back(cand);
-    output.candidateExtras.push_back(xtra);    
+    output.candidateExtras.push_back(xtra);
   }
 
   return output;
 }
 
-float PFEGammaAlgo::calculateEleMVA(const PFEGammaAlgo::ProtoEGObject& ro,
-                                    reco::PFCandidateEGammaExtra& xtra) const
-{
-  if( ro.primaryGSFs.empty() ) 
-  {
+float PFEGammaAlgo::calculateEleMVA(const PFEGammaAlgo::ProtoEGObject& ro, reco::PFCandidateEGammaExtra& xtra) const {
+  if (ro.primaryGSFs.empty()) {
     return -2.0f;
   }
   const PFGSFElement* gsfElement = ro.primaryGSFs.front();
-  const PFKFElement*  kfElement  = nullptr;
-  if( !ro.primaryKFs.empty() )
-  {
+  const PFKFElement* kfElement = nullptr;
+  if (!ro.primaryKFs.empty()) {
     kfElement = ro.primaryKFs.front();
   }
   auto const& refGsf = gsfElement->GsftrackRef();
   reco::TrackRef refKf;
   constexpr float mEl = 0.000511;
-  const double eInGsf = std::hypot(refGsf->pMode(),mEl);
-  double dEtGsfEcal   = 1e6;
-  double sigmaEtaEta  = 1e-14;
-  const double eneHcalGsf = std::accumulate(
-                         ro.hcalClusters.begin(),
-                         ro.hcalClusters.end(),
-                         0.0,
-                         [](const double a, auto const& b) 
-                           { return a + b->clusterRef()->energy(); }
-                         );
-  if( !ro.primaryKFs.empty() )
-  {
+  const double eInGsf = std::hypot(refGsf->pMode(), mEl);
+  double dEtGsfEcal = 1e6;
+  double sigmaEtaEta = 1e-14;
+  const double eneHcalGsf =
+      std::accumulate(ro.hcalClusters.begin(), ro.hcalClusters.end(), 0.0, [](const double a, auto const& b) {
+        return a + b->clusterRef()->energy();
+      });
+  if (!ro.primaryKFs.empty()) {
     refKf = ro.primaryKFs.front()->trackRef();
   }
-  const double eOutGsf   = gsfElement->Pout().t();
+  const double eOutGsf = gsfElement->Pout().t();
   const double etaOutGsf = gsfElement->positionAtECALEntrance().eta();
-  double firstEcalGsfEnergy {0.0};
-  double otherEcalGsfEnergy {0.0};
-  double ecalBremEnergy     {0.0};
+  double firstEcalGsfEnergy{0.0};
+  double otherEcalGsfEnergy{0.0};
+  double ecalBremEnergy{0.0};
   //shower shape of cluster closest to gsf track
-  std::vector<const reco::PFCluster*> gsfCluster;  
-  for( const auto& ecal : ro.ecalclusters )
-  {
+  std::vector<const reco::PFCluster*> gsfCluster;
+  for (const auto& ecal : ro.ecalclusters) {
     const double cenergy = ecal->clusterRef()->correctedEnergy();
-    bool hasgsf  = ro.localMap.contains(gsfElement,ecal.get());
-    bool haskf   = ro.localMap.contains(kfElement,ecal.get());
+    bool hasgsf = ro.localMap.contains(gsfElement, ecal.get());
+    bool haskf = ro.localMap.contains(kfElement, ecal.get());
     bool hasbrem = false;
-    for( const auto& brem : ro.brems )
-    {
-      if(ro.localMap.contains(brem,ecal.get()))
-      {
+    for (const auto& brem : ro.brems) {
+      if (ro.localMap.contains(brem, ecal.get())) {
         hasbrem = true;
       }
     }
-    if( hasbrem && ecal.get() != ro.electronClusters[0] )
-    {
+    if (hasbrem && ecal.get() != ro.electronClusters[0]) {
       ecalBremEnergy += cenergy;
-    } 
-    if( !hasbrem && ecal.get() != ro.electronClusters[0] )
-    {
-      if( hasgsf ) otherEcalGsfEnergy += cenergy;
-      if( haskf  ) ecalBremEnergy += cenergy; // from conv. brem!
-      if( !(hasgsf || haskf) ) otherEcalGsfEnergy += cenergy; // stuff from SC
+    }
+    if (!hasbrem && ecal.get() != ro.electronClusters[0]) {
+      if (hasgsf)
+        otherEcalGsfEnergy += cenergy;
+      if (haskf)
+        ecalBremEnergy += cenergy;  // from conv. brem!
+      if (!(hasgsf || haskf))
+        otherEcalGsfEnergy += cenergy;  // stuff from SC
     }
   }
-  
-  if( ro.electronClusters[0] )
-  {
+
+  if (ro.electronClusters[0]) {
     reco::PFClusterRef cref = ro.electronClusters[0]->clusterRef();
-    xtra.setGsfElectronClusterRef(_currentblock,*(ro.electronClusters[0]));
-    firstEcalGsfEnergy = cref->correctedEnergy();    
+    xtra.setGsfElectronClusterRef(_currentblock, *(ro.electronClusters[0]));
+    firstEcalGsfEnergy = cref->correctedEnergy();
     dEtGsfEcal = cref->positionREP().eta() - etaOutGsf;
     gsfCluster.push_back(cref.get());
     PFClusterWidthAlgo pfwidth(gsfCluster);
     sigmaEtaEta = pfwidth.pflowSigmaEtaEta();
-  } 
+  }
 
   // brem sequence information
-  float firstBrem {-1.0f};
-  float earlyBrem {-1.0f};
-  float lateBrem  {-1.0f};
-  if(ro.nBremsWithClusters > 0)
-  {
+  float firstBrem{-1.0f};
+  float earlyBrem{-1.0f};
+  float lateBrem{-1.0f};
+  if (ro.nBremsWithClusters > 0) {
     firstBrem = ro.firstBrem;
     earlyBrem = ro.firstBrem < 4 ? 1.0f : 0.0f;
-    lateBrem  = ro.lateBrem == 1 ? 1.0f : 0.0f;
-  }     
+    lateBrem = ro.lateBrem == 1 ? 1.0f : 0.0f;
+  }
   xtra.setEarlyBrem(earlyBrem);
   xtra.setLateBrem(lateBrem);
-  if( firstEcalGsfEnergy > 0.0 )
-  {
-    if( refGsf.isNonnull() )
-    {
+  if (firstEcalGsfEnergy > 0.0) {
+    if (refGsf.isNonnull()) {
       xtra.setGsfTrackPout(gsfElement->Pout());
       // normalization observables
-      const float ptGsf   = refGsf->ptMode();
-      const float etaGsf  = refGsf->etaMode();
+      const float ptGsf = refGsf->ptMode();
+      const float etaGsf = refGsf->etaMode();
       // tracking observables
       const double ptModeErrorGsf = refGsf->ptModeError();
-      float ptModeErrOverPtGsf    = (ptModeErrorGsf > 0. ? ptModeErrorGsf/ptGsf : 1.0);
-      float chi2Gsf               = refGsf->normalizedChi2();
-      float dPtOverPtGsf          = (ptGsf - gsfElement->Pout().pt())/ptGsf;
+      float ptModeErrOverPtGsf = (ptModeErrorGsf > 0. ? ptModeErrorGsf / ptGsf : 1.0);
+      float chi2Gsf = refGsf->normalizedChi2();
+      float dPtOverPtGsf = (ptGsf - gsfElement->Pout().pt()) / ptGsf;
       // kalman filter vars
-      float nHitKf      = refKf.isNonnull() ? refKf->hitPattern().trackerLayersWithMeasurement() : 0;
-      float chi2Kf      = refKf.isNonnull() ? refKf->normalizedChi2() : -0.01;
+      float nHitKf = refKf.isNonnull() ? refKf->hitPattern().trackerLayersWithMeasurement() : 0;
+      float chi2Kf = refKf.isNonnull() ? refKf->normalizedChi2() : -0.01;
 
       //tracker + calorimetry observables
-      float eTotPinMode         = (firstEcalGsfEnergy+otherEcalGsfEnergy+ecalBremEnergy)/ eInGsf;
-      float eGsfPoutMode        = firstEcalGsfEnergy / eOutGsf;
+      float eTotPinMode = (firstEcalGsfEnergy + otherEcalGsfEnergy + ecalBremEnergy) / eInGsf;
+      float eGsfPoutMode = firstEcalGsfEnergy / eOutGsf;
       float eTotBremPinPoutMode = (ecalBremEnergy + otherEcalGsfEnergy) / (eInGsf - eOutGsf);
-      float dEtaGsfEcalClust    = std::abs(dEtGsfEcal);
-      float logSigmaEtaEta      = std::log(sigmaEtaEta);
-      float hOverHe             = eneHcalGsf/(eneHcalGsf + firstEcalGsfEnergy);
+      float dEtaGsfEcalClust = std::abs(dEtGsfEcal);
+      float logSigmaEtaEta = std::log(sigmaEtaEta);
+      float hOverHe = eneHcalGsf / (eneHcalGsf + firstEcalGsfEnergy);
 
       xtra.setDeltaEta(dEtaGsfEcalClust);
-      xtra.setSigmaEtaEta(sigmaEtaEta);      
+      xtra.setSigmaEtaEta(sigmaEtaEta);
       xtra.setHadEnergy(eneHcalGsf);
 
       // Apply bounds to variables and calculate MVA
-      dPtOverPtGsf        = std::clamp(dPtOverPtGsf, -0.2f, 1.0f);
-      ptModeErrOverPtGsf  = std::min(ptModeErrOverPtGsf,0.3f);  
-      chi2Gsf             = std::min(chi2Gsf,10.0f);  
-      chi2Kf              = std::min(chi2Kf,10.0f);  
-      eTotPinMode         = std::clamp(eTotPinMode,0.0f, 5.0f);  
-      eGsfPoutMode        = std::clamp(eGsfPoutMode,0.0f, 5.0f);  
-      eTotBremPinPoutMode = std::clamp(eTotBremPinPoutMode,0.0f, 5.0f);  
-      dEtaGsfEcalClust    = std::min(dEtaGsfEcalClust,0.1f);  
-      logSigmaEtaEta      = std::max(logSigmaEtaEta,-14.0f);  
+      dPtOverPtGsf = std::clamp(dPtOverPtGsf, -0.2f, 1.0f);
+      ptModeErrOverPtGsf = std::min(ptModeErrOverPtGsf, 0.3f);
+      chi2Gsf = std::min(chi2Gsf, 10.0f);
+      chi2Kf = std::min(chi2Kf, 10.0f);
+      eTotPinMode = std::clamp(eTotPinMode, 0.0f, 5.0f);
+      eGsfPoutMode = std::clamp(eGsfPoutMode, 0.0f, 5.0f);
+      eTotBremPinPoutMode = std::clamp(eTotBremPinPoutMode, 0.0f, 5.0f);
+      dEtaGsfEcalClust = std::min(dEtaGsfEcalClust, 0.1f);
+      logSigmaEtaEta = std::max(logSigmaEtaEta, -14.0f);
 
       // not used for moment, weird behavior of variable
       //float dPtOverPtKf = refKf.isNonnull() ? (refKf->pt() - refKf->outerPt())/refKf->pt() : -0.01;
       //dPtOverPtKf       = std::clamp(dPtOverPtKf,-0.2f, 1.0f);
 
-/*
+      /*
  *      To be used for debugging:
  *      pretty-print the PFEgamma electron MVA input variables
  *
@@ -2017,9 +1735,21 @@ float PFEGammaAlgo::calculateEleMVA(const PFEGammaAlgo::ProtoEGObject& ro,
  *        << " firstBrem " << firstBrem << endl;
  */
 
-      float vars[] = { std::log(ptGsf), etaGsf, ptModeErrOverPtGsf, dPtOverPtGsf, chi2Gsf,
-                       nHitKf, chi2Kf, eTotPinMode, eGsfPoutMode, eTotBremPinPoutMode,
-                       dEtaGsfEcalClust, logSigmaEtaEta, hOverHe, lateBrem, firstBrem };
+      float vars[] = {std::log(ptGsf),
+                      etaGsf,
+                      ptModeErrOverPtGsf,
+                      dPtOverPtGsf,
+                      chi2Gsf,
+                      nHitKf,
+                      chi2Kf,
+                      eTotPinMode,
+                      eGsfPoutMode,
+                      eTotBremPinPoutMode,
+                      dEtaGsfEcalClust,
+                      logSigmaEtaEta,
+                      hOverHe,
+                      lateBrem,
+                      firstBrem};
 
       return gbrForests_.ele_->GetAdaBoostClassifier(vars);
     }
@@ -2027,24 +1757,20 @@ float PFEGammaAlgo::calculateEleMVA(const PFEGammaAlgo::ProtoEGObject& ro,
   return -2.0f;
 }
 
-void PFEGammaAlgo::fillExtraInfo(const ProtoEGObject& RO,
-                                 reco::PFCandidateEGammaExtra& xtra ) {
+void PFEGammaAlgo::fillExtraInfo(const ProtoEGObject& RO, reco::PFCandidateEGammaExtra& xtra) {
   // add tracks associated to clusters that are not T_FROM_GAMMACONV
   // info about single-leg convs is already save, so just veto in loops
   auto KFbegin = _splayedblock[reco::PFBlockElement::TRACK].begin();
-  auto KFend = _splayedblock[reco::PFBlockElement::TRACK].end();  
-  for( auto& ecal : RO.ecalclusters ) {
-    NotCloserToOther<reco::PFBlockElement::ECAL,
-                     reco::PFBlockElement::TRACK,
-                     true>
-      ECALToTracks(_currentblock,ecal.get());
-    auto notmatchedkf  = std::partition(KFbegin,KFend,ECALToTracks);
-    auto notconvkf     = std::partition(KFbegin,notmatchedkf,[](auto const& x){ return x->trackType(ConvType); });
+  auto KFend = _splayedblock[reco::PFBlockElement::TRACK].end();
+  for (auto& ecal : RO.ecalclusters) {
+    NotCloserToOther<reco::PFBlockElement::ECAL, reco::PFBlockElement::TRACK, true> ECALToTracks(_currentblock,
+                                                                                                 ecal.get());
+    auto notmatchedkf = std::partition(KFbegin, KFend, ECALToTracks);
+    auto notconvkf = std::partition(KFbegin, notmatchedkf, [](auto const& x) { return x->trackType(ConvType); });
     // go through non-conv-identified kfs and check MVA to add conversions
-    for( auto kf = notconvkf; kf != notmatchedkf; ++kf ) {      
-      const reco::PFBlockElementTrack* elemaskf =
-	docast(const reco::PFBlockElementTrack*,kf->get());
-      xtra.addExtraNonConvTrack(_currentblock,*elemaskf);   
+    for (auto kf = notconvkf; kf != notmatchedkf; ++kf) {
+      const reco::PFBlockElementTrack* elemaskf = docast(const reco::PFBlockElementTrack*, kf->get());
+      xtra.addExtraNonConvTrack(_currentblock, *elemaskf);
     }
   }
 }
@@ -2052,10 +1778,9 @@ void PFEGammaAlgo::fillExtraInfo(const ProtoEGObject& RO,
 // currently stolen from PFECALSuperClusterAlgo, we should
 // try to factor this correctly since the operation is the same in
 // both places...
-reco::SuperCluster PFEGammaAlgo::
-buildRefinedSuperCluster(const PFEGammaAlgo::ProtoEGObject& RO) {
-  if( RO.ecalclusters.empty() ) { 
-    return reco::SuperCluster(0.0,math::XYZPoint(0,0,0));
+reco::SuperCluster PFEGammaAlgo::buildRefinedSuperCluster(const PFEGammaAlgo::ProtoEGObject& RO) {
+  if (RO.ecalclusters.empty()) {
+    return reco::SuperCluster(0.0, math::XYZPoint(0, 0, 0));
   }
 
   bool isEE = false;
@@ -2063,18 +1788,15 @@ buildRefinedSuperCluster(const PFEGammaAlgo::ProtoEGObject& RO) {
   // need the vector of raw pointers for a PF width class
   std::vector<const reco::PFCluster*> bare_ptrs;
   // calculate necessary parameters and build the SC
-  double posX(0), posY(0), posZ(0),
-    rawSCEnergy(0), corrSCEnergy(0), corrPSEnergy(0),
-    PS1_clus_sum(0), PS2_clus_sum(0),
-    ePS1(0), ePS2(0), ps1_energy(0.0), ps2_energy(0.0); 
+  double posX(0), posY(0), posZ(0), rawSCEnergy(0), corrSCEnergy(0), corrPSEnergy(0), PS1_clus_sum(0), PS2_clus_sum(0),
+      ePS1(0), ePS2(0), ps1_energy(0.0), ps2_energy(0.0);
   int condP1(1), condP2(1);
-  for( auto& clus : RO.ecalclusters ) {
+  for (auto& clus : RO.ecalclusters) {
     ePS1 = 0;
     ePS2 = 0;
     isEE = PFLayer::ECAL_ENDCAP == clus->clusterRef()->layer();
-    clusptr = 
-      edm::refToPtr<reco::PFClusterCollection>(clus->clusterRef());
-    bare_ptrs.push_back(clusptr.get());    
+    clusptr = edm::refToPtr<reco::PFClusterCollection>(clus->clusterRef());
+    bare_ptrs.push_back(clusptr.get());
 
     const double cluseraw = clusptr->energy();
     double cluscalibe = clusptr->correctedEnergy();
@@ -2083,322 +1805,289 @@ buildRefinedSuperCluster(const PFEGammaAlgo::ProtoEGObject& RO) {
     posY += cluseraw * cluspos.Y();
     posZ += cluseraw * cluspos.Z();
     // update EE calibrated super cluster energies
-    if( isEE && RO.ecal2ps.count(clus.get())) {
+    if (isEE && RO.ecal2ps.count(clus.get())) {
       ePS1 = 0;
       ePS2 = 0;
       condP1 = condP2 = 1;
 
       const auto& psclusters = RO.ecal2ps.at(clus.get());
-      
-      for( auto i_ps = psclusters.begin(); i_ps != psclusters.end(); ++i_ps) {
-	const PFClusterRef&  psclus = (*i_ps)->clusterRef();
-	
-	auto const& recH_Frac = psclus->recHitFractions();	
-	
-	switch( psclus->layer() ) {
-	case PFLayer::PS1:
-	  for (auto const& recH : recH_Frac){
-	    ESDetId strip1 = recH.recHitRef()->detId();
-	    if(strip1 != ESDetId(0)){
-	      ESChannelStatusMap::const_iterator status_p1 = channelStatus_->getMap().find(strip1);
-	      //getStatusCode() == 0 => active channel
-	      // apply correction if all recHits are dead
-	      if(status_p1->getStatusCode() == 0) condP1 = 0;
-	    }
-	  }
-	  break;
-	case PFLayer::PS2:
-	  for (auto const& recH : recH_Frac){
-	    ESDetId strip2 = recH.recHitRef()->detId();
-	    if(strip2 != ESDetId(0)) {
-	      ESChannelStatusMap::const_iterator status_p2 = channelStatus_->getMap().find(strip2);
-	      if(status_p2->getStatusCode() == 0) condP2 = 0;
-	    }
-	  }
-	  break;
-	default:
-	  break;
-	}
+
+      for (auto i_ps = psclusters.begin(); i_ps != psclusters.end(); ++i_ps) {
+        const PFClusterRef& psclus = (*i_ps)->clusterRef();
+
+        auto const& recH_Frac = psclus->recHitFractions();
+
+        switch (psclus->layer()) {
+          case PFLayer::PS1:
+            for (auto const& recH : recH_Frac) {
+              ESDetId strip1 = recH.recHitRef()->detId();
+              if (strip1 != ESDetId(0)) {
+                ESChannelStatusMap::const_iterator status_p1 = channelStatus_->getMap().find(strip1);
+                //getStatusCode() == 0 => active channel
+                // apply correction if all recHits are dead
+                if (status_p1->getStatusCode() == 0)
+                  condP1 = 0;
+              }
+            }
+            break;
+          case PFLayer::PS2:
+            for (auto const& recH : recH_Frac) {
+              ESDetId strip2 = recH.recHitRef()->detId();
+              if (strip2 != ESDetId(0)) {
+                ESChannelStatusMap::const_iterator status_p2 = channelStatus_->getMap().find(strip2);
+                if (status_p2->getStatusCode() == 0)
+                  condP2 = 0;
+              }
+            }
+            break;
+          default:
+            break;
+        }
       }
-      
-      auto sumPSEnergy = [](double a, const ClusterElement * b, PFLayer::Layer layer)
-          { return a + (layer == b->clusterRef()->layer())*b->clusterRef()->energy(); };
 
-      PS1_clus_sum = std::accumulate(psclusters.begin(),psclusters.end(),
-				     0.0,std::bind(sumPSEnergy, _1, _2, PFLayer::PS1));
-      PS2_clus_sum = std::accumulate(psclusters.begin(),psclusters.end(),
-				     0.0,std::bind(sumPSEnergy, _1, _2, PFLayer::PS2));
-            
-      if(condP1 == 1) ePS1 = -1.;
-      if(condP2 == 1) ePS2 = -1.;
+      auto sumPSEnergy = [](double a, const ClusterElement* b, PFLayer::Layer layer) {
+        return a + (layer == b->clusterRef()->layer()) * b->clusterRef()->energy();
+      };
 
-      cluscalibe = 
-	thePFEnergyCalibration_.energyEm(*clusptr,
-					      PS1_clus_sum,PS2_clus_sum,
-					      ePS1, ePS2,
-					      cfg_.applyCrackCorrections);
+      PS1_clus_sum =
+          std::accumulate(psclusters.begin(), psclusters.end(), 0.0, std::bind(sumPSEnergy, _1, _2, PFLayer::PS1));
+      PS2_clus_sum =
+          std::accumulate(psclusters.begin(), psclusters.end(), 0.0, std::bind(sumPSEnergy, _1, _2, PFLayer::PS2));
+
+      if (condP1 == 1)
+        ePS1 = -1.;
+      if (condP2 == 1)
+        ePS2 = -1.;
+
+      cluscalibe = thePFEnergyCalibration_.energyEm(
+          *clusptr, PS1_clus_sum, PS2_clus_sum, ePS1, ePS2, cfg_.applyCrackCorrections);
     }
-    if(ePS1 == -1.) ePS1 = 0;
-    if(ePS2 == -1.) ePS2 = 0;
+    if (ePS1 == -1.)
+      ePS1 = 0;
+    if (ePS2 == -1.)
+      ePS2 = 0;
 
-    rawSCEnergy  += cluseraw;
-    corrSCEnergy += cluscalibe;    
-    ps1_energy   += ePS1;
-    ps2_energy   += ePS2;
-    corrPSEnergy += ePS1 + ePS2;    
+    rawSCEnergy += cluseraw;
+    corrSCEnergy += cluscalibe;
+    ps1_energy += ePS1;
+    ps2_energy += ePS2;
+    corrPSEnergy += ePS1 + ePS2;
   }
   posX /= rawSCEnergy;
   posY /= rawSCEnergy;
   posZ /= rawSCEnergy;
 
   // now build the supercluster
-  reco::SuperCluster new_sc(corrSCEnergy,math::XYZPoint(posX,posY,posZ)); 
+  reco::SuperCluster new_sc(corrSCEnergy, math::XYZPoint(posX, posY, posZ));
 
-  clusptr = 
-    edm::refToPtr<reco::PFClusterCollection>(RO.ecalclusters.front()->clusterRef());
+  clusptr = edm::refToPtr<reco::PFClusterCollection>(RO.ecalclusters.front()->clusterRef());
   new_sc.setCorrectedEnergy(corrSCEnergy);
   new_sc.setSeed(clusptr);
   new_sc.setPreshowerEnergyPlane1(ps1_energy);
   new_sc.setPreshowerEnergyPlane2(ps2_energy);
-  new_sc.setPreshowerEnergy(corrPSEnergy); 
-  for( const auto& clus : RO.ecalclusters ) {
-    clusptr = 
-      edm::refToPtr<reco::PFClusterCollection>(clus->clusterRef());
+  new_sc.setPreshowerEnergy(corrPSEnergy);
+  for (const auto& clus : RO.ecalclusters) {
+    clusptr = edm::refToPtr<reco::PFClusterCollection>(clus->clusterRef());
     new_sc.addCluster(clusptr);
     auto& hits_and_fractions = clusptr->hitsAndFractions();
-    for( auto& hit_and_fraction : hits_and_fractions ) {
-      new_sc.addHitAndFraction(hit_and_fraction.first,hit_and_fraction.second);
+    for (auto& hit_and_fraction : hits_and_fractions) {
+      new_sc.addHitAndFraction(hit_and_fraction.first, hit_and_fraction.second);
     }
-     // put the preshower stuff back in later
-    if( RO.ecal2ps.count(clus.get()) ) {
+    // put the preshower stuff back in later
+    if (RO.ecal2ps.count(clus.get())) {
       const auto& cluspsassociation = RO.ecal2ps.at(clus.get());
       // EE rechits should be uniquely matched to sets of pre-shower
       // clusters at this point, so we throw an exception if otherwise
       // now wrapped in EDM debug flags
-      for( const auto& pscluselem : cluspsassociation ) {    
-	edm::Ptr<reco::PFCluster> psclus = 
-	  edm::refToPtr<reco::PFClusterCollection>(pscluselem->clusterRef());
+      for (const auto& pscluselem : cluspsassociation) {
+        edm::Ptr<reco::PFCluster> psclus = edm::refToPtr<reco::PFClusterCollection>(pscluselem->clusterRef());
 #ifdef PFFLOW_DEBUG
-	auto found_pscluster = std::find(new_sc.preshowerClustersBegin(),
-					 new_sc.preshowerClustersEnd(),
-					 reco::CaloClusterPtr(psclus));
-	if( found_pscluster == new_sc.preshowerClustersEnd() ) {
-#endif		  
-	  new_sc.addPreshowerCluster(psclus);
-#ifdef PFFLOW_DEBUG
-	} else {
-	  throw cms::Exception("PFECALSuperClusterAlgo::buildSuperCluster")
-	    << "Found a PS cluster matched to more than one EE cluster!" 
-	    << std::endl << std::hex << psclus.get() << " == " 
-	    << found_pscluster->get() << std::dec << std::endl;
-	}
+        auto found_pscluster =
+            std::find(new_sc.preshowerClustersBegin(), new_sc.preshowerClustersEnd(), reco::CaloClusterPtr(psclus));
+        if (found_pscluster == new_sc.preshowerClustersEnd()) {
 #endif
-      }    
+          new_sc.addPreshowerCluster(psclus);
+#ifdef PFFLOW_DEBUG
+        } else {
+          throw cms::Exception("PFECALSuperClusterAlgo::buildSuperCluster")
+              << "Found a PS cluster matched to more than one EE cluster!" << std::endl
+              << std::hex << psclus.get() << " == " << found_pscluster->get() << std::dec << std::endl;
+        }
+#endif
+      }
     }
   }
-  
+
   // calculate linearly weighted cluster widths
   PFClusterWidthAlgo pfwidth(bare_ptrs);
   new_sc.setEtaWidth(pfwidth.pflowEtaWidth());
   new_sc.setPhiWidth(pfwidth.pflowPhiWidth());
-  
-  // cache the value of the raw energy  
+
+  // cache the value of the raw energy
   new_sc.rawEnergy();
-  
+
   return new_sc;
 }
 
-void PFEGammaAlgo::
-unlinkRefinableObjectKFandECALWithBadEoverP(ProtoEGObject& RO) {  
+void PFEGammaAlgo::unlinkRefinableObjectKFandECALWithBadEoverP(ProtoEGObject& RO) {
   // this only means something for ROs with a primary GSF track
-  if( RO.primaryGSFs.empty() ) return;  
+  if (RO.primaryGSFs.empty())
+    return;
   // need energy sums to tell if we've added crap or not
   const double Pin_gsf = RO.primaryGSFs.front()->GsftrackRef()->pMode();
-  const double gsfOuterEta  = 
-    RO.primaryGSFs.front()->positionAtECALEntrance().Eta();
-  double tot_ecal= 0.0;  
+  const double gsfOuterEta = RO.primaryGSFs.front()->positionAtECALEntrance().Eta();
+  double tot_ecal = 0.0;
   std::vector<double> min_brem_dists;
-  std::vector<double> closest_brem_eta;    
+  std::vector<double> closest_brem_eta;
   // first get the total ecal energy (we should replace this with a cache)
-  for( const auto& ecal : RO.ecalclusters ) {
+  for (const auto& ecal : RO.ecalclusters) {
     tot_ecal += ecal->clusterRef()->correctedEnergy();
     // we also need to look at the minimum distance to brems
     // since energetic brems will be closer to the brem than the track
-    double min_brem_dist = 5000.0; 
+    double min_brem_dist = 5000.0;
     double eta = -999.0;
-    for( const auto& brem : RO.brems ) {
-      const float dist = _currentblock->dist(brem->index(),
-					     ecal->index(),
-					     _currentlinks,
-					     reco::PFBlock::LINKTEST_ALL);
-      if( dist < min_brem_dist && dist != -1.0f ) {
-	min_brem_dist = dist;
-	eta = brem->positionAtECALEntrance().Eta();
+    for (const auto& brem : RO.brems) {
+      const float dist = _currentblock->dist(brem->index(), ecal->index(), _currentlinks, reco::PFBlock::LINKTEST_ALL);
+      if (dist < min_brem_dist && dist != -1.0f) {
+        min_brem_dist = dist;
+        eta = brem->positionAtECALEntrance().Eta();
       }
     }
     min_brem_dists.push_back(min_brem_dist);
     closest_brem_eta.push_back(eta);
-  }  
-  
+  }
+
   // loop through the ECAL clusters and remove ECAL clusters matched to
   // secondary track either in *or* out of the SC if the E/pin is bad
-  for( auto secd_kf = RO.secondaryKFs.begin(); 
-       secd_kf != RO.secondaryKFs.end(); ++secd_kf ) {
-    reco::TrackRef trkRef =   (*secd_kf)->trackRef();   
-    const float secpin = (*secd_kf)->trackRef()->p();  
+  for (auto secd_kf = RO.secondaryKFs.begin(); secd_kf != RO.secondaryKFs.end(); ++secd_kf) {
+    reco::TrackRef trkRef = (*secd_kf)->trackRef();
+    const float secpin = (*secd_kf)->trackRef()->p();
     bool remove_this_kf = false;
-    for( auto ecal = RO.ecalclusters.begin(); 
-	 ecal != RO.ecalclusters.end(); ++ecal ) {
-      size_t bremidx = std::distance(RO.ecalclusters.begin(),ecal);
+    for (auto ecal = RO.ecalclusters.begin(); ecal != RO.ecalclusters.end(); ++ecal) {
+      size_t bremidx = std::distance(RO.ecalclusters.begin(), ecal);
       const float minbremdist = min_brem_dists[bremidx];
       const double ecalenergy = (*ecal)->clusterRef()->correctedEnergy();
-      const double Epin = ecalenergy/secpin;
-      const double detaGsf = 
-	std::abs(gsfOuterEta - (*ecal)->clusterRef()->positionREP().Eta());
-      const double detaBrem = 
-	std::abs(closest_brem_eta[bremidx] - 
-		 (*ecal)->clusterRef()->positionREP().Eta());
-      
-      bool kf_matched = RO.localMap.contains(ecal->get(),*secd_kf);
-      
-      const float tkdist = _currentblock->dist((*secd_kf)->index(),
-					       (*ecal)->index(),
-					       _currentlinks,
-					       reco::PFBlock::LINKTEST_ALL);
-      
+      const double Epin = ecalenergy / secpin;
+      const double detaGsf = std::abs(gsfOuterEta - (*ecal)->clusterRef()->positionREP().Eta());
+      const double detaBrem = std::abs(closest_brem_eta[bremidx] - (*ecal)->clusterRef()->positionREP().Eta());
+
+      bool kf_matched = RO.localMap.contains(ecal->get(), *secd_kf);
+
+      const float tkdist =
+          _currentblock->dist((*secd_kf)->index(), (*ecal)->index(), _currentlinks, reco::PFBlock::LINKTEST_ALL);
+
       // do not reject this track if it is closer to a brem than the
       // secondary track, or if it lies in the delta-eta plane with the
       // gsf track or if it is in the dEta plane with the brems
-      if( Epin > 3 && kf_matched && 
-	  tkdist != -1.0f && tkdist < minbremdist &&
-	  detaGsf > 0.05 && detaBrem > 0.015) {
-	double res_with = std::abs((tot_ecal-Pin_gsf)/Pin_gsf);
-	double res_without = std::abs((tot_ecal-ecalenergy-Pin_gsf)/Pin_gsf);
-	if(res_without < res_with) {	  
-	    LOGDRESSED("PFEGammaAlgo")
-	      << " REJECTED_RES totenergy " << tot_ecal
-	      << " Pin_gsf " << Pin_gsf 
-	      << " cluster to secondary " <<  ecalenergy
-	      << " res_with " <<  res_with
-	      << " res_without " << res_without << std::endl;
-	    tot_ecal -= ecalenergy;	    
-	    remove_this_kf = true;   
-	    ecal = RO.ecalclusters.erase(ecal);
-	    if( ecal == RO.ecalclusters.end() ) break;	    
-	}
+      if (Epin > 3 && kf_matched && tkdist != -1.0f && tkdist < minbremdist && detaGsf > 0.05 && detaBrem > 0.015) {
+        double res_with = std::abs((tot_ecal - Pin_gsf) / Pin_gsf);
+        double res_without = std::abs((tot_ecal - ecalenergy - Pin_gsf) / Pin_gsf);
+        if (res_without < res_with) {
+          LOGDRESSED("PFEGammaAlgo") << " REJECTED_RES totenergy " << tot_ecal << " Pin_gsf " << Pin_gsf
+                                     << " cluster to secondary " << ecalenergy << " res_with " << res_with
+                                     << " res_without " << res_without << std::endl;
+          tot_ecal -= ecalenergy;
+          remove_this_kf = true;
+          ecal = RO.ecalclusters.erase(ecal);
+          if (ecal == RO.ecalclusters.end())
+            break;
+        }
       }
     }
-    if( remove_this_kf ) {
+    if (remove_this_kf) {
       secd_kf = RO.secondaryKFs.erase(secd_kf);
-      if( secd_kf == RO.secondaryKFs.end() ) break;
+      if (secd_kf == RO.secondaryKFs.end())
+        break;
     }
-  }  
+  }
 }
 
-void PFEGammaAlgo::
-unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject& RO,
-					    bool removeFreeECAL,
-					    bool removeSCEcal) {
-  std::vector<bool> cluster_in_sc;    
+void PFEGammaAlgo::unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject& RO,
+                                                               bool removeFreeECAL,
+                                                               bool removeSCEcal) {
+  std::vector<bool> cluster_in_sc;
   auto ecal_begin = RO.ecalclusters.begin();
-  auto ecal_end   = RO.ecalclusters.end();
+  auto ecal_end = RO.ecalclusters.end();
   auto hcal_begin = _splayedblock[reco::PFBlockElement::HCAL].begin();
-  auto hcal_end   = _splayedblock[reco::PFBlockElement::HCAL].end();
-  for( auto secd_kf = RO.secondaryKFs.begin(); 
-       secd_kf != RO.secondaryKFs.end(); ++secd_kf ) {
+  auto hcal_end = _splayedblock[reco::PFBlockElement::HCAL].end();
+  for (auto secd_kf = RO.secondaryKFs.begin(); secd_kf != RO.secondaryKFs.end(); ++secd_kf) {
     bool remove_this_kf = false;
-    NotCloserToOther<reco::PFBlockElement::TRACK,reco::PFBlockElement::HCAL>
-      tracksToHCALs(_currentblock,*secd_kf);
-    reco::TrackRef trkRef =   (*secd_kf)->trackRef();
+    NotCloserToOther<reco::PFBlockElement::TRACK, reco::PFBlockElement::HCAL> tracksToHCALs(_currentblock, *secd_kf);
+    reco::TrackRef trkRef = (*secd_kf)->trackRef();
 
     bool goodTrack = PFTrackAlgoTools::isGoodForEGM(trkRef->algo());
-    const float secpin = trkRef->p();       
-    
-    for( auto ecal = ecal_begin; ecal != ecal_end; ++ecal ) {
+    const float secpin = trkRef->p();
+
+    for (auto ecal = ecal_begin; ecal != ecal_end; ++ecal) {
       const double ecalenergy = (*ecal)->clusterRef()->correctedEnergy();
       // first check if the cluster is in the SC (use dist calc for fastness)
-      const size_t clus_idx = std::distance(ecal_begin,ecal);
-      if( cluster_in_sc.size() < clus_idx + 1) {
-	float dist = -1.0f;
-	if( RO.parentSC ) {
-	  dist = _currentblock->dist((*secd_kf)->index(),
-				     (*ecal)->index(),
-				     _currentlinks,
-				     reco::PFBlock::LINKTEST_ALL);
-	} 
-	cluster_in_sc.push_back(dist != -1.0f); 
+      const size_t clus_idx = std::distance(ecal_begin, ecal);
+      if (cluster_in_sc.size() < clus_idx + 1) {
+        float dist = -1.0f;
+        if (RO.parentSC) {
+          dist = _currentblock->dist((*secd_kf)->index(), (*ecal)->index(), _currentlinks, reco::PFBlock::LINKTEST_ALL);
+        }
+        cluster_in_sc.push_back(dist != -1.0f);
       }
 
       // if we've found a secondary KF that matches this ecal cluster
-      // now we see if it is matched to HCAL 
-      // if it is matched to an HCAL cluster we take different 
+      // now we see if it is matched to HCAL
+      // if it is matched to an HCAL cluster we take different
       // actions if the cluster was in an SC or not
-      if( RO.localMap.contains(ecal->get(),*secd_kf) ) {
-	auto hcal_matched = std::partition(hcal_begin,hcal_end,tracksToHCALs);
-	for( auto hcalclus = hcal_begin; 
-	     hcalclus != hcal_matched; 
-	     ++hcalclus                 ) {
-	  const reco::PFBlockElementCluster * clusthcal =  
-	    dynamic_cast<const reco::PFBlockElementCluster*>(hcalclus->get()); 
-	  const double hcalenergy = clusthcal->clusterRef()->energy();	  
-	  const double hpluse = ecalenergy+hcalenergy;
-	  const bool isHoHE = ( (hcalenergy / hpluse ) > 0.1 && goodTrack );
-	  const bool isHoE  = ( hcalenergy > ecalenergy );
-	  const bool isPoHE = ( secpin > hpluse );	
-	  if( cluster_in_sc[clus_idx] ) {
-	    if(isHoE || isPoHE) {
-	      LOGDRESSED("PFEGammaAlgo")
-		<< "REJECTED TRACK FOR H/E or P/(H+E), CLUSTER IN SC"
-		<< " H/H+E " << (hcalenergy / hpluse)
-		<< " H/E " << (hcalenergy > ecalenergy)
-		<< " P/(H+E) " << (secpin/hpluse)
-		<< " HCAL ENE " << hcalenergy
-		<< " ECAL ENE " << ecalenergy
-		<< " secPIN " << secpin 
-		<< " Algo Track " << trkRef->algo() << std::endl;
-	      remove_this_kf = true;
-	    }
-	  } else {
-	    if(isHoHE){
-	      LOGDRESSED("PFEGammaAlgo")
-		<< "REJECTED TRACK FOR H/H+E, CLUSTER NOT IN SC"
-		<< " H/H+E " << (hcalenergy / hpluse)
-		<< " H/E " << (hcalenergy > ecalenergy)
-		<< " P/(H+E) " << (secpin/hpluse) 
-		<< " HCAL ENE " << hcalenergy
-		<< " ECAL ENE " << ecalenergy
-		<< " secPIN " << secpin 
-		<< " Algo Track " <<trkRef->algo() << std::endl;
-	      remove_this_kf = true;
-	    }
-	  }  
-	}
+      if (RO.localMap.contains(ecal->get(), *secd_kf)) {
+        auto hcal_matched = std::partition(hcal_begin, hcal_end, tracksToHCALs);
+        for (auto hcalclus = hcal_begin; hcalclus != hcal_matched; ++hcalclus) {
+          const reco::PFBlockElementCluster* clusthcal =
+              dynamic_cast<const reco::PFBlockElementCluster*>(hcalclus->get());
+          const double hcalenergy = clusthcal->clusterRef()->energy();
+          const double hpluse = ecalenergy + hcalenergy;
+          const bool isHoHE = ((hcalenergy / hpluse) > 0.1 && goodTrack);
+          const bool isHoE = (hcalenergy > ecalenergy);
+          const bool isPoHE = (secpin > hpluse);
+          if (cluster_in_sc[clus_idx]) {
+            if (isHoE || isPoHE) {
+              LOGDRESSED("PFEGammaAlgo") << "REJECTED TRACK FOR H/E or P/(H+E), CLUSTER IN SC"
+                                         << " H/H+E " << (hcalenergy / hpluse) << " H/E " << (hcalenergy > ecalenergy)
+                                         << " P/(H+E) " << (secpin / hpluse) << " HCAL ENE " << hcalenergy
+                                         << " ECAL ENE " << ecalenergy << " secPIN " << secpin << " Algo Track "
+                                         << trkRef->algo() << std::endl;
+              remove_this_kf = true;
+            }
+          } else {
+            if (isHoHE) {
+              LOGDRESSED("PFEGammaAlgo") << "REJECTED TRACK FOR H/H+E, CLUSTER NOT IN SC"
+                                         << " H/H+E " << (hcalenergy / hpluse) << " H/E " << (hcalenergy > ecalenergy)
+                                         << " P/(H+E) " << (secpin / hpluse) << " HCAL ENE " << hcalenergy
+                                         << " ECAL ENE " << ecalenergy << " secPIN " << secpin << " Algo Track "
+                                         << trkRef->algo() << std::endl;
+              remove_this_kf = true;
+            }
+          }
+        }
       }
     }
-    if( remove_this_kf ) {
+    if (remove_this_kf) {
       secd_kf = RO.secondaryKFs.erase(secd_kf);
-      if( secd_kf == RO.secondaryKFs.end() ) break;
+      if (secd_kf == RO.secondaryKFs.end())
+        break;
     }
-  }  
+  }
 }
 
-
-
-bool PFEGammaAlgo::isPrimaryTrack(const reco::PFBlockElementTrack& KfEl,
-				    const reco::PFBlockElementGsfTrack& GsfEl) {
+bool PFEGammaAlgo::isPrimaryTrack(const reco::PFBlockElementTrack& KfEl, const reco::PFBlockElementGsfTrack& GsfEl) {
   bool isPrimary = false;
-  
+
   const GsfPFRecTrackRef& gsfPfRef = GsfEl.GsftrackRefPF();
-  
-  if(gsfPfRef.isNonnull()) {
-    const PFRecTrackRef&  kfPfRef = KfEl.trackRefPF();
-    PFRecTrackRef  kfPfRef_fromGsf = (*gsfPfRef).kfPFRecTrackRef();
-    if(kfPfRef.isNonnull() && kfPfRef_fromGsf.isNonnull()) {
-      reco::TrackRef kfref= (*kfPfRef).trackRef();
+
+  if (gsfPfRef.isNonnull()) {
+    const PFRecTrackRef& kfPfRef = KfEl.trackRefPF();
+    PFRecTrackRef kfPfRef_fromGsf = (*gsfPfRef).kfPFRecTrackRef();
+    if (kfPfRef.isNonnull() && kfPfRef_fromGsf.isNonnull()) {
+      reco::TrackRef kfref = (*kfPfRef).trackRef();
       reco::TrackRef kfref_fromGsf = (*kfPfRef_fromGsf).trackRef();
-      if(kfref.isNonnull() && kfref_fromGsf.isNonnull()) {
-	if(kfref ==  kfref_fromGsf)
-	  isPrimary = true;
+      if (kfref.isNonnull() && kfref_fromGsf.isNonnull()) {
+        if (kfref == kfref_fromGsf)
+          isPrimary = true;
       }
     }
   }

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -1,4 +1,4 @@
-// 
+//
 // Original Authors: Nicholas Wardle, Florian Beaudette
 //
 #include "RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h"
@@ -12,223 +12,209 @@ using namespace reco;
 
 namespace {
 
-  void readEBEEParams_( const edm::ParameterSet &pset,
-                        const std::string &name,
-                        std::array<float,2> & out)
-  {
-    const auto & vals = pset.getParameter<std::vector<double>>(name);
-    if (vals.size() != 2) throw cms::Exception("Configuration") << "Parameter "
-        << name << " does not contain exactly 2 values (EB, EE)\n";
-    out[0] = vals[0]; 
-    out[1] = vals[1]; 
+  void readEBEEParams_(const edm::ParameterSet& pset, const std::string& name, std::array<float, 2>& out) {
+    const auto& vals = pset.getParameter<std::vector<double>>(name);
+    if (vals.size() != 2)
+      throw cms::Exception("Configuration") << "Parameter " << name << " does not contain exactly 2 values (EB, EE)\n";
+    out[0] = vals[0];
+    out[1] = vals[1];
   }
 
-}
- 
+}  // namespace
 
-PFEGammaFilters::PFEGammaFilters(const edm::ParameterSet& cfg) :
-  ph_Et_(cfg.getParameter<double>("photon_MinEt")),
-  ph_combIso_(cfg.getParameter<double>("photon_combIso")),
-  ph_loose_hoe_(cfg.getParameter<double>("photon_HoE")),
-  ph_sietaieta_eb_(cfg.getParameter<double>("photon_SigmaiEtaiEta_barrel")),
-  ph_sietaieta_ee_(cfg.getParameter<double>("photon_SigmaiEtaiEta_endcap")),
-  ele_iso_pt_(cfg.getParameter<double>("electron_iso_pt")),
-  ele_iso_mva_eb_(cfg.getParameter<double>("electron_iso_mva_barrel")),
-  ele_iso_mva_ee_(cfg.getParameter<double>("electron_iso_mva_endcap")),
-  ele_iso_combIso_eb_(cfg.getParameter<double>("electron_iso_combIso_barrel")),
-  ele_iso_combIso_ee_(cfg.getParameter<double>("electron_iso_combIso_endcap")),
-  ele_noniso_mva_(cfg.getParameter<double>("electron_noniso_mvaCut")),
-  ele_missinghits_(cfg.getParameter<unsigned int>("electron_missinghits")),
-  ele_ecalDrivenHademPreselCut_(cfg.getParameter<double>("electron_ecalDrivenHademPreselCut")),
-  ele_maxElePtForOnlyMVAPresel_(cfg.getParameter<double>("electron_maxElePtForOnlyMVAPresel"))
-{
-    auto const& eleProtectionsForBadHcal = cfg.getParameter<edm::ParameterSet>("electron_protectionsForBadHcal");
-    auto const& eleProtectionsForJetMET = cfg.getParameter<edm::ParameterSet>("electron_protectionsForJetMET");
-    auto const& phoProtectionsForBadHcal = cfg.getParameter<edm::ParameterSet>("photon_protectionsForBadHcal");
-    auto const& phoProtectionsForJetMET = cfg.getParameter<edm::ParameterSet>("photon_protectionsForJetMET");
+PFEGammaFilters::PFEGammaFilters(const edm::ParameterSet& cfg)
+    : ph_Et_(cfg.getParameter<double>("photon_MinEt")),
+      ph_combIso_(cfg.getParameter<double>("photon_combIso")),
+      ph_loose_hoe_(cfg.getParameter<double>("photon_HoE")),
+      ph_sietaieta_eb_(cfg.getParameter<double>("photon_SigmaiEtaiEta_barrel")),
+      ph_sietaieta_ee_(cfg.getParameter<double>("photon_SigmaiEtaiEta_endcap")),
+      ele_iso_pt_(cfg.getParameter<double>("electron_iso_pt")),
+      ele_iso_mva_eb_(cfg.getParameter<double>("electron_iso_mva_barrel")),
+      ele_iso_mva_ee_(cfg.getParameter<double>("electron_iso_mva_endcap")),
+      ele_iso_combIso_eb_(cfg.getParameter<double>("electron_iso_combIso_barrel")),
+      ele_iso_combIso_ee_(cfg.getParameter<double>("electron_iso_combIso_endcap")),
+      ele_noniso_mva_(cfg.getParameter<double>("electron_noniso_mvaCut")),
+      ele_missinghits_(cfg.getParameter<unsigned int>("electron_missinghits")),
+      ele_ecalDrivenHademPreselCut_(cfg.getParameter<double>("electron_ecalDrivenHademPreselCut")),
+      ele_maxElePtForOnlyMVAPresel_(cfg.getParameter<double>("electron_maxElePtForOnlyMVAPresel")) {
+  auto const& eleProtectionsForBadHcal = cfg.getParameter<edm::ParameterSet>("electron_protectionsForBadHcal");
+  auto const& eleProtectionsForJetMET = cfg.getParameter<edm::ParameterSet>("electron_protectionsForJetMET");
+  auto const& phoProtectionsForBadHcal = cfg.getParameter<edm::ParameterSet>("photon_protectionsForBadHcal");
+  auto const& phoProtectionsForJetMET = cfg.getParameter<edm::ParameterSet>("photon_protectionsForJetMET");
 
-    pho_sumPtTrackIso_ = phoProtectionsForJetMET.getParameter<double>("sumPtTrackIso");
-    pho_sumPtTrackIsoSlope_ = phoProtectionsForJetMET.getParameter<double>("sumPtTrackIsoSlope");
+  pho_sumPtTrackIso_ = phoProtectionsForJetMET.getParameter<double>("sumPtTrackIso");
+  pho_sumPtTrackIsoSlope_ = phoProtectionsForJetMET.getParameter<double>("sumPtTrackIsoSlope");
 
-    ele_maxNtracks_ = eleProtectionsForJetMET.getParameter<double>("maxNtracks");
-    ele_maxHcalE_ = eleProtectionsForJetMET.getParameter<double>("maxHcalE");
-    ele_maxTrackPOverEele_ = eleProtectionsForJetMET.getParameter<double>("maxTrackPOverEele");
-    ele_maxE_ = eleProtectionsForJetMET.getParameter<double>("maxE");
-    ele_maxEleHcalEOverEcalE_ = eleProtectionsForJetMET.getParameter<double>("maxEleHcalEOverEcalE");
-    ele_maxEcalEOverPRes_ = eleProtectionsForJetMET.getParameter<double>("maxEcalEOverPRes");
-    ele_maxEeleOverPoutRes_ = eleProtectionsForJetMET.getParameter<double>("maxEeleOverPoutRes");
-    ele_maxHcalEOverP_ = eleProtectionsForJetMET.getParameter<double>("maxHcalEOverP");
-    ele_maxHcalEOverEcalE_ = eleProtectionsForJetMET.getParameter<double>("maxHcalEOverEcalE");
-    ele_maxEcalEOverP_1_ = eleProtectionsForJetMET.getParameter<double>("maxEcalEOverP_1");
-    ele_maxEcalEOverP_2_ = eleProtectionsForJetMET.getParameter<double>("maxEcalEOverP_2");
-    ele_maxEeleOverPout_ = eleProtectionsForJetMET.getParameter<double>("maxEeleOverPout");
-    ele_maxDPhiIN_ = eleProtectionsForJetMET.getParameter<double>("maxDPhiIN");
+  ele_maxNtracks_ = eleProtectionsForJetMET.getParameter<double>("maxNtracks");
+  ele_maxHcalE_ = eleProtectionsForJetMET.getParameter<double>("maxHcalE");
+  ele_maxTrackPOverEele_ = eleProtectionsForJetMET.getParameter<double>("maxTrackPOverEele");
+  ele_maxE_ = eleProtectionsForJetMET.getParameter<double>("maxE");
+  ele_maxEleHcalEOverEcalE_ = eleProtectionsForJetMET.getParameter<double>("maxEleHcalEOverEcalE");
+  ele_maxEcalEOverPRes_ = eleProtectionsForJetMET.getParameter<double>("maxEcalEOverPRes");
+  ele_maxEeleOverPoutRes_ = eleProtectionsForJetMET.getParameter<double>("maxEeleOverPoutRes");
+  ele_maxHcalEOverP_ = eleProtectionsForJetMET.getParameter<double>("maxHcalEOverP");
+  ele_maxHcalEOverEcalE_ = eleProtectionsForJetMET.getParameter<double>("maxHcalEOverEcalE");
+  ele_maxEcalEOverP_1_ = eleProtectionsForJetMET.getParameter<double>("maxEcalEOverP_1");
+  ele_maxEcalEOverP_2_ = eleProtectionsForJetMET.getParameter<double>("maxEcalEOverP_2");
+  ele_maxEeleOverPout_ = eleProtectionsForJetMET.getParameter<double>("maxEeleOverPout");
+  ele_maxDPhiIN_ = eleProtectionsForJetMET.getParameter<double>("maxDPhiIN");
 
-    readEBEEParams_(eleProtectionsForBadHcal, "full5x5_sigmaIetaIeta", badHcal_full5x5_sigmaIetaIeta_);
-    readEBEEParams_(eleProtectionsForBadHcal, "eInvPInv", badHcal_eInvPInv_);
-    readEBEEParams_(eleProtectionsForBadHcal, "dEta", badHcal_dEta_);
-    readEBEEParams_(eleProtectionsForBadHcal, "dPhi", badHcal_dPhi_);
+  readEBEEParams_(eleProtectionsForBadHcal, "full5x5_sigmaIetaIeta", badHcal_full5x5_sigmaIetaIeta_);
+  readEBEEParams_(eleProtectionsForBadHcal, "eInvPInv", badHcal_eInvPInv_);
+  readEBEEParams_(eleProtectionsForBadHcal, "dEta", badHcal_dEta_);
+  readEBEEParams_(eleProtectionsForBadHcal, "dPhi", badHcal_dPhi_);
 
-    badHcal_eleEnable_ = eleProtectionsForBadHcal.getParameter<bool>("enableProtections");
-    badHcal_phoTrkSolidConeIso_offs_ = phoProtectionsForBadHcal.getParameter<double>("solidConeTrkIsoOffset");
-    badHcal_phoTrkSolidConeIso_slope_ = phoProtectionsForBadHcal.getParameter<double>("solidConeTrkIsoSlope");
-    badHcal_phoEnable_ = phoProtectionsForBadHcal.getParameter<bool>("enableProtections");
+  badHcal_eleEnable_ = eleProtectionsForBadHcal.getParameter<bool>("enableProtections");
+  badHcal_phoTrkSolidConeIso_offs_ = phoProtectionsForBadHcal.getParameter<double>("solidConeTrkIsoOffset");
+  badHcal_phoTrkSolidConeIso_slope_ = phoProtectionsForBadHcal.getParameter<double>("solidConeTrkIsoSlope");
+  badHcal_phoEnable_ = phoProtectionsForBadHcal.getParameter<bool>("enableProtections");
 }
 
-
-bool PFEGammaFilters::passPhotonSelection(const reco::Photon & photon) const {
+bool PFEGammaFilters::passPhotonSelection(const reco::Photon& photon) const {
   // First simple selection, same as the Run1 to be improved in CMSSW_710
 
-
   // Photon ET
-  if(photon.pt()  < ph_Et_ ) return false;
+  if (photon.pt() < ph_Et_)
+    return false;
   bool validHoverE = photon.hadTowOverEmValid();
-  if (debug_) std::cout<< "PFEGammaFilters:: photon pt " << photon.pt()
-		     << "   eta, phi " << photon.eta() << ", " << photon.phi() 
-		     << "   isoDr03 " << (photon.trkSumPtHollowConeDR03()+photon.ecalRecHitSumEtConeDR03()+photon.hcalTowerSumEtConeDR03())  << " (cut: " << ph_combIso_ << ")"
-		     << "   H/E " << photon.hadTowOverEm() << " (valid? " << validHoverE << ", cut: " << ph_loose_hoe_ << ")"
-		     << "   s(ieie) " << photon.sigmaIetaIeta()  << " (cut: " << (photon.isEB() ? ph_sietaieta_eb_ : ph_sietaieta_ee_) << ")"
-		     << "   isoTrkDr03Solid " << (photon.trkSumPtSolidConeDR03())  << " (cut: " << (
-		                    validHoverE || !badHcal_phoEnable_ ? 
-		                    -1 : 
-		                    badHcal_phoTrkSolidConeIso_offs_ + badHcal_phoTrkSolidConeIso_slope_*photon.pt()) << ")"
- << std::endl;
+  if (debug_)
+    std::cout << "PFEGammaFilters:: photon pt " << photon.pt() << "   eta, phi " << photon.eta() << ", " << photon.phi()
+              << "   isoDr03 "
+              << (photon.trkSumPtHollowConeDR03() + photon.ecalRecHitSumEtConeDR03() + photon.hcalTowerSumEtConeDR03())
+              << " (cut: " << ph_combIso_ << ")"
+              << "   H/E " << photon.hadTowOverEm() << " (valid? " << validHoverE << ", cut: " << ph_loose_hoe_ << ")"
+              << "   s(ieie) " << photon.sigmaIetaIeta()
+              << " (cut: " << (photon.isEB() ? ph_sietaieta_eb_ : ph_sietaieta_ee_) << ")"
+              << "   isoTrkDr03Solid " << (photon.trkSumPtSolidConeDR03()) << " (cut: "
+              << (validHoverE || !badHcal_phoEnable_
+                      ? -1
+                      : badHcal_phoTrkSolidConeIso_offs_ + badHcal_phoTrkSolidConeIso_slope_ * photon.pt())
+              << ")" << std::endl;
 
-  if (photon.hadTowOverEm() >ph_loose_hoe_ ) return false;
+  if (photon.hadTowOverEm() > ph_loose_hoe_)
+    return false;
   //Isolation variables in 0.3 cone combined
-  if(photon.trkSumPtHollowConeDR03()+photon.ecalRecHitSumEtConeDR03()+photon.hcalTowerSumEtConeDR03() > ph_combIso_)
+  if (photon.trkSumPtHollowConeDR03() + photon.ecalRecHitSumEtConeDR03() + photon.hcalTowerSumEtConeDR03() >
+      ph_combIso_)
     return false;
 
   //patch for bad hcal
-  if (!validHoverE && badHcal_phoEnable_ && photon.trkSumPtSolidConeDR03() > badHcal_phoTrkSolidConeIso_offs_ + badHcal_phoTrkSolidConeIso_slope_*photon.pt()) {
+  if (!validHoverE && badHcal_phoEnable_ &&
+      photon.trkSumPtSolidConeDR03() >
+          badHcal_phoTrkSolidConeIso_offs_ + badHcal_phoTrkSolidConeIso_slope_ * photon.pt()) {
     return false;
   }
-  
-  if(photon.isEB()) {
-    if(photon.sigmaIetaIeta() > ph_sietaieta_eb_) 
-      return false;
-  }
-  else {
-    if(photon.sigmaIetaIeta() > ph_sietaieta_ee_) 
-      return false;
-  }
 
+  if (photon.isEB()) {
+    if (photon.sigmaIetaIeta() > ph_sietaieta_eb_)
+      return false;
+  } else {
+    if (photon.sigmaIetaIeta() > ph_sietaieta_ee_)
+      return false;
+  }
 
   return true;
 }
 
-bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron & electron,
-					    const reco::PFCandidate & pfcand, 
-					    const int & nVtx) const {
+bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron& electron,
+                                            const reco::PFCandidate& pfcand,
+                                            const int& nVtx) const {
   // First simple selection, same as the Run1 to be improved in CMSSW_710
- 
+
   bool validHoverE = electron.hcalOverEcalValid();
-  if (debug_) std::cout << "PFEGammaFilters:: Electron pt " << electron.pt()
-		     << " eta, phi " << electron.eta() << ", " << electron.phi() 
-		     << " charge " << electron.charge() 
-		     << " isoDr03 " << (electron.dr03TkSumPt() + electron.dr03EcalRecHitSumEt() + electron.dr03HcalTowerSumEt()) 
-		     << " mva_isolated " << electron.mva_Isolated() 
-		     << " mva_e_pi " << electron.mva_e_pi() 
-		     << " H/E_valid " << validHoverE 
-		     << " s(ieie) " << electron.full5x5_sigmaIetaIeta()
-		     << " H/E " << electron.hcalOverEcal()
-		     << " 1/e-1/p " << (1.0-electron.eSuperClusterOverP())/electron.ecalEnergy()
-		     << " deta " << std::abs(electron.deltaEtaSeedClusterTrackAtVtx())
-		     << " dphi " << std::abs(electron.deltaPhiSuperClusterTrackAtVtx()) 
-		     << endl;
+  if (debug_)
+    std::cout << "PFEGammaFilters:: Electron pt " << electron.pt() << " eta, phi " << electron.eta() << ", "
+              << electron.phi() << " charge " << electron.charge() << " isoDr03 "
+              << (electron.dr03TkSumPt() + electron.dr03EcalRecHitSumEt() + electron.dr03HcalTowerSumEt())
+              << " mva_isolated " << electron.mva_Isolated() << " mva_e_pi " << electron.mva_e_pi() << " H/E_valid "
+              << validHoverE << " s(ieie) " << electron.full5x5_sigmaIetaIeta() << " H/E " << electron.hcalOverEcal()
+              << " 1/e-1/p " << (1.0 - electron.eSuperClusterOverP()) / electron.ecalEnergy() << " deta "
+              << std::abs(electron.deltaEtaSeedClusterTrackAtVtx()) << " dphi "
+              << std::abs(electron.deltaPhiSuperClusterTrackAtVtx()) << endl;
 
   bool passEleSelection = false;
-  
+
   // Electron ET
   float electronPt = electron.pt();
-  
-  if( electronPt > ele_iso_pt_) {
 
+  if (electronPt > ele_iso_pt_) {
     double isoDr03 = electron.dr03TkSumPt() + electron.dr03EcalRecHitSumEt() + electron.dr03HcalTowerSumEt();
     double eleEta = fabs(electron.eta());
     if (eleEta <= 1.485 && isoDr03 < ele_iso_combIso_eb_) {
-      if( electron.mva_Isolated() > ele_iso_mva_eb_ ) 
-	passEleSelection = true;
+      if (electron.mva_Isolated() > ele_iso_mva_eb_)
+        passEleSelection = true;
+    } else if (eleEta > 1.485 && isoDr03 < ele_iso_combIso_ee_) {
+      if (electron.mva_Isolated() > ele_iso_mva_ee_)
+        passEleSelection = true;
     }
-    else if (eleEta > 1.485  && isoDr03 < ele_iso_combIso_ee_) {
-      if( electron.mva_Isolated() > ele_iso_mva_ee_ ) 
-	passEleSelection = true;
-    }
-
   }
 
   //  cout << " My OLD MVA " << pfcand.mva_e_pi() << " MyNEW MVA " << electron.mva() << endl;
-  if(electron.mva_e_pi() > ele_noniso_mva_) {
+  if (electron.mva_e_pi() > ele_noniso_mva_) {
     if (validHoverE || !badHcal_eleEnable_) {
-        passEleSelection = true; 
+      passEleSelection = true;
     } else {
-        bool EE = (std::abs(electron.eta()) > 1.485); // for prefer consistency with above than with E/gamma for now
-        if ((electron.full5x5_sigmaIetaIeta() < badHcal_full5x5_sigmaIetaIeta_[EE]) &&
-            (std::abs(1.0-electron.eSuperClusterOverP())/electron.ecalEnergy()  < badHcal_eInvPInv_[EE]) && 
-            (std::abs(electron.deltaEtaSeedClusterTrackAtVtx())  < badHcal_dEta_[EE]) && // looser in case of misalignment
-            (std::abs(electron.deltaPhiSuperClusterTrackAtVtx())  < badHcal_dPhi_[EE])) {
-            passEleSelection = true; 
-        } 
+      bool EE = (std::abs(electron.eta()) > 1.485);  // for prefer consistency with above than with E/gamma for now
+      if ((electron.full5x5_sigmaIetaIeta() < badHcal_full5x5_sigmaIetaIeta_[EE]) &&
+          (std::abs(1.0 - electron.eSuperClusterOverP()) / electron.ecalEnergy() < badHcal_eInvPInv_[EE]) &&
+          (std::abs(electron.deltaEtaSeedClusterTrackAtVtx()) < badHcal_dEta_[EE]) &&  // looser in case of misalignment
+          (std::abs(electron.deltaPhiSuperClusterTrackAtVtx()) < badHcal_dPhi_[EE])) {
+        passEleSelection = true;
+      }
     }
   }
-  
+
   return passEleSelection && passGsfElePreSelWithOnlyConeHadem(electron);
 }
 
-
-bool PFEGammaFilters::isElectron(const reco::GsfElectron & electron) const {
- 
+bool PFEGammaFilters::isElectron(const reco::GsfElectron& electron) const {
   unsigned int nmisshits = electron.gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
-  if(nmisshits > ele_missinghits_)
+  if (nmisshits > ele_missinghits_)
     return false;
 
   return true;
 }
 
-
-bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron, 
-					      const reco::PFCandidate & pfcand,
-					      const reco::Vertex & primaryVertex,
-					      bool& lockTracks) const {
-
+bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron& electron,
+                                              const reco::PFCandidate& pfcand,
+                                              const reco::Vertex& primaryVertex,
+                                              bool& lockTracks) const {
   bool debugSafeForJetMET = false;
   bool isSafeForJetMET = true;
 
-//   cout << " ele_maxNtracks_ " <<  ele_maxNtracks_ << endl
-//        << " ele_maxHcalE_ " << ele_maxHcalE_ << endl
-//        << " ele_maxTrackPOverEele_ " << ele_maxTrackPOverEele_ << endl
-//        << " ele_maxE_ " << ele_maxE_ << endl
-//        << " ele_maxEleHcalEOverEcalE_ "<< ele_maxEleHcalEOverEcalE_ << endl
-//        << " ele_maxEcalEOverPRes_ " << ele_maxEcalEOverPRes_ << endl
-//        << " ele_maxEeleOverPoutRes_ "  << ele_maxEeleOverPoutRes_ << endl
-//        << " ele_maxHcalEOverP_ " << ele_maxHcalEOverP_ << endl
-//        << " ele_maxHcalEOverEcalE_ " << ele_maxHcalEOverEcalE_ << endl
-//        << " ele_maxEcalEOverP_1_ " << ele_maxEcalEOverP_1_ << endl
-//        << " ele_maxEcalEOverP_2_ " << ele_maxEcalEOverP_2_ << endl
-//        << " ele_maxEeleOverPout_ "  << ele_maxEeleOverPout_ << endl
-//        << " ele_maxDPhiIN_ " << ele_maxDPhiIN_ << endl;
-    
+  //   cout << " ele_maxNtracks_ " <<  ele_maxNtracks_ << endl
+  //        << " ele_maxHcalE_ " << ele_maxHcalE_ << endl
+  //        << " ele_maxTrackPOverEele_ " << ele_maxTrackPOverEele_ << endl
+  //        << " ele_maxE_ " << ele_maxE_ << endl
+  //        << " ele_maxEleHcalEOverEcalE_ "<< ele_maxEleHcalEOverEcalE_ << endl
+  //        << " ele_maxEcalEOverPRes_ " << ele_maxEcalEOverPRes_ << endl
+  //        << " ele_maxEeleOverPoutRes_ "  << ele_maxEeleOverPoutRes_ << endl
+  //        << " ele_maxHcalEOverP_ " << ele_maxHcalEOverP_ << endl
+  //        << " ele_maxHcalEOverEcalE_ " << ele_maxHcalEOverEcalE_ << endl
+  //        << " ele_maxEcalEOverP_1_ " << ele_maxEcalEOverP_1_ << endl
+  //        << " ele_maxEcalEOverP_2_ " << ele_maxEcalEOverP_2_ << endl
+  //        << " ele_maxEeleOverPout_ "  << ele_maxEeleOverPout_ << endl
+  //        << " ele_maxDPhiIN_ " << ele_maxDPhiIN_ << endl;
+
   // loop on the extra-tracks associated to the electron
   PFCandidateEGammaExtraRef pfcandextra = pfcand.egammaExtraRef();
-  
+
   unsigned int iextratrack = 0;
   unsigned int itrackHcalLinked = 0;
   float SumExtraKfP = 0.;
   //float Ene_ecalgsf = 0.;
 
-
   // problems here: for now get the electron cluster from the gsf electron
   //  const PFCandidate::ElementsInBlocks& eleCluster = pfcandextra->gsfElectronClusterRef();
-  // PFCandidate::ElementsInBlocks::const_iterator iegfirst = eleCluster.begin(); 
+  // PFCandidate::ElementsInBlocks::const_iterator iegfirst = eleCluster.begin();
   //  float Ene_hcalgsf = pfcandextra->
-
 
   float ETtotal = electron.ecalEnergy();
 
   //NOTE take this from EGammaExtra
   float Ene_ecalgsf = electron.electronCluster()->energy();
   float Ene_hcalgsf = pfcandextra->hadEnergy();
-  float HOverHE = Ene_hcalgsf/(Ene_hcalgsf + Ene_ecalgsf);
+  float HOverHE = Ene_hcalgsf / (Ene_hcalgsf + Ene_ecalgsf);
   float EtotPinMode = electron.eSuperClusterOverP();
 
   //NOTE take this from EGammaExtra
@@ -236,203 +222,185 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
   float HOverPin = Ene_hcalgsf / electron.gsfTrack()->pMode();
   float dphi_normalsc = electron.deltaPhiSuperClusterTrackAtVtx();
 
-
   const PFCandidate::ElementsInBlocks& extraTracks = pfcandextra->extraNonConvTracks();
-  for (PFCandidate::ElementsInBlocks::const_iterator itrk = extraTracks.begin(); 
-       itrk<extraTracks.end(); ++itrk) {
+  for (PFCandidate::ElementsInBlocks::const_iterator itrk = extraTracks.begin(); itrk < extraTracks.end(); ++itrk) {
     const PFBlock& block = *(itrk->first);
-    const PFBlock::LinkData& linkData =  block.linkData();
+    const PFBlock::LinkData& linkData = block.linkData();
     const PFBlockElement& pfele = block.elements()[itrk->second];
 
-    if(debugSafeForJetMET) 
-      cout << " My track element number " <<  itrk->second << endl;
-    if(pfele.type()==reco::PFBlockElement::TRACK) {
+    if (debugSafeForJetMET)
+      cout << " My track element number " << itrk->second << endl;
+    if (pfele.type() == reco::PFBlockElement::TRACK) {
       const reco::TrackRef& trackref = pfele.trackRef();
 
       bool goodTrack = PFTrackAlgoTools::isGoodForEGM(trackref->algo());
       // iter0, iter1, iter2, iter3 = Algo < 3
       // algo 4,5,6,7
-      int nexhits = trackref->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS); 
-      
-      bool trackIsFromPrimaryVertex = false;
-      for (Vertex::trackRef_iterator trackIt = primaryVertex.tracks_begin(); trackIt != primaryVertex.tracks_end(); ++trackIt) {
-	if ( (*trackIt).castTo<TrackRef>() == trackref ) {
-	  trackIsFromPrimaryVertex = true;
-	  break;
-	}
-      }
-      
-      // probably we could now remove the algo request?? 
-      if(goodTrack && nexhits == 0 && trackIsFromPrimaryVertex) {
-	float p_trk = trackref->p();
-	SumExtraKfP += p_trk;
-	iextratrack++;
-	// Check if these extra tracks are HCAL linked
-	std::multimap<double, unsigned int> hcalKfElems;
-	block.associatedElements( itrk->second,
-				  linkData,
-				  hcalKfElems,
-				  reco::PFBlockElement::HCAL,
-				  reco::PFBlock::LINKTEST_ALL );
-	if(!hcalKfElems.empty()) {
-	  itrackHcalLinked++;
-	}
-	if(debugSafeForJetMET) 
-	  cout << " The ecalGsf cluster is not isolated: >0 KF extra with algo < 3" 
-	       << " Algo " << trackref->algo()
-	       << " nexhits " << nexhits
-	       << " trackIsFromPrimaryVertex " << trackIsFromPrimaryVertex << endl;
-	if(debugSafeForJetMET) 
-	  cout << " My track PT " << trackref->pt() << endl;
+      int nexhits = trackref->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
 
+      bool trackIsFromPrimaryVertex = false;
+      for (Vertex::trackRef_iterator trackIt = primaryVertex.tracks_begin(); trackIt != primaryVertex.tracks_end();
+           ++trackIt) {
+        if ((*trackIt).castTo<TrackRef>() == trackref) {
+          trackIsFromPrimaryVertex = true;
+          break;
+        }
       }
-      else {
-	if(debugSafeForJetMET) 
-	  cout << " Tracks from PU " 
-	       << " Algo " << trackref->algo()
-	       << " nexhits " << nexhits
-	       << " trackIsFromPrimaryVertex " << trackIsFromPrimaryVertex << endl;
-	if(debugSafeForJetMET) 
-	  cout << " My track PT " << trackref->pt() << endl;
+
+      // probably we could now remove the algo request??
+      if (goodTrack && nexhits == 0 && trackIsFromPrimaryVertex) {
+        float p_trk = trackref->p();
+        SumExtraKfP += p_trk;
+        iextratrack++;
+        // Check if these extra tracks are HCAL linked
+        std::multimap<double, unsigned int> hcalKfElems;
+        block.associatedElements(
+            itrk->second, linkData, hcalKfElems, reco::PFBlockElement::HCAL, reco::PFBlock::LINKTEST_ALL);
+        if (!hcalKfElems.empty()) {
+          itrackHcalLinked++;
+        }
+        if (debugSafeForJetMET)
+          cout << " The ecalGsf cluster is not isolated: >0 KF extra with algo < 3"
+               << " Algo " << trackref->algo() << " nexhits " << nexhits << " trackIsFromPrimaryVertex "
+               << trackIsFromPrimaryVertex << endl;
+        if (debugSafeForJetMET)
+          cout << " My track PT " << trackref->pt() << endl;
+
+      } else {
+        if (debugSafeForJetMET)
+          cout << " Tracks from PU "
+               << " Algo " << trackref->algo() << " nexhits " << nexhits << " trackIsFromPrimaryVertex "
+               << trackIsFromPrimaryVertex << endl;
+        if (debugSafeForJetMET)
+          cout << " My track PT " << trackref->pt() << endl;
       }
     }
   }
-  if( iextratrack > 0) {
-    if(iextratrack > ele_maxNtracks_ || Ene_hcalgsf > ele_maxHcalE_ || (SumExtraKfP/Ene_ecalgsf) > ele_maxTrackPOverEele_ 
-       || (ETtotal > ele_maxE_ && iextratrack > 1 && (Ene_hcalgsf/Ene_ecalgsf) > ele_maxEleHcalEOverEcalE_) ) {
-      if(debugSafeForJetMET) 
-	cout << " *****This electron candidate is discarded: Non isolated  # tracks "		
-	     << iextratrack << " HOverHE " << HOverHE 
-	     << " SumExtraKfP/Ene_ecalgsf " << SumExtraKfP/Ene_ecalgsf 
-	     << " SumExtraKfP " << SumExtraKfP 
-	     << " Ene_ecalgsf " << Ene_ecalgsf
-	     << " ETtotal " << ETtotal
-	     << " Ene_hcalgsf/Ene_ecalgsf " << Ene_hcalgsf/Ene_ecalgsf
-	     << endl;
-      
+  if (iextratrack > 0) {
+    if (iextratrack > ele_maxNtracks_ || Ene_hcalgsf > ele_maxHcalE_ ||
+        (SumExtraKfP / Ene_ecalgsf) > ele_maxTrackPOverEele_ ||
+        (ETtotal > ele_maxE_ && iextratrack > 1 && (Ene_hcalgsf / Ene_ecalgsf) > ele_maxEleHcalEOverEcalE_)) {
+      if (debugSafeForJetMET)
+        cout << " *****This electron candidate is discarded: Non isolated  # tracks " << iextratrack << " HOverHE "
+             << HOverHE << " SumExtraKfP/Ene_ecalgsf " << SumExtraKfP / Ene_ecalgsf << " SumExtraKfP " << SumExtraKfP
+             << " Ene_ecalgsf " << Ene_ecalgsf << " ETtotal " << ETtotal << " Ene_hcalgsf/Ene_ecalgsf "
+             << Ene_hcalgsf / Ene_ecalgsf << endl;
+
       isSafeForJetMET = false;
     }
     // the electron is retained and the kf tracks are not locked
-    if( (fabs(1.-EtotPinMode) < ele_maxEcalEOverPRes_ && (fabs(electron.eta()) < 1.0 || fabs(electron.eta()) > 2.0)) ||
-	((EtotPinMode < 1.1 && EtotPinMode > 0.6) && (fabs(electron.eta()) >= 1.0 && fabs(electron.eta()) <= 2.0))) {
-      if( fabs(1.-EGsfPoutMode) < ele_maxEeleOverPoutRes_ && 
-	  (itrackHcalLinked == iextratrack)) {
-
-	lockTracks = false;
-	//	lockExtraKf = false;
-	if(debugSafeForJetMET) 
-	  cout << " *****This electron is reactivated  # tracks "		
-	       << iextratrack << " #tracks hcal linked " << itrackHcalLinked 
-	       << " SumExtraKfP/Ene_ecalgsf " << SumExtraKfP/Ene_ecalgsf  
-	       << " EtotPinMode " << EtotPinMode << " EGsfPoutMode " << EGsfPoutMode 
-	       << " eta gsf " << electron.eta()  <<endl;
+    if ((fabs(1. - EtotPinMode) < ele_maxEcalEOverPRes_ &&
+         (fabs(electron.eta()) < 1.0 || fabs(electron.eta()) > 2.0)) ||
+        ((EtotPinMode < 1.1 && EtotPinMode > 0.6) && (fabs(electron.eta()) >= 1.0 && fabs(electron.eta()) <= 2.0))) {
+      if (fabs(1. - EGsfPoutMode) < ele_maxEeleOverPoutRes_ && (itrackHcalLinked == iextratrack)) {
+        lockTracks = false;
+        //	lockExtraKf = false;
+        if (debugSafeForJetMET)
+          cout << " *****This electron is reactivated  # tracks " << iextratrack << " #tracks hcal linked "
+               << itrackHcalLinked << " SumExtraKfP/Ene_ecalgsf " << SumExtraKfP / Ene_ecalgsf << " EtotPinMode "
+               << EtotPinMode << " EGsfPoutMode " << EGsfPoutMode << " eta gsf " << electron.eta() << endl;
       }
     }
   }
 
   if (HOverPin > ele_maxHcalEOverP_ && HOverHE > ele_maxHcalEOverEcalE_ && EtotPinMode < ele_maxEcalEOverP_1_) {
-    if(debugSafeForJetMET) 
-      cout << " *****This electron candidate is discarded  HCAL ENERGY "	
-	   << " HOverPin " << HOverPin << " HOverHE " << HOverHE  << " EtotPinMode" << EtotPinMode << endl;
+    if (debugSafeForJetMET)
+      cout << " *****This electron candidate is discarded  HCAL ENERGY "
+           << " HOverPin " << HOverPin << " HOverHE " << HOverHE << " EtotPinMode" << EtotPinMode << endl;
     isSafeForJetMET = false;
   }
-  
-  // Reject Crazy E/p values... to be understood in the future how to train a 
-  // BDT in order to avoid to select this bad electron candidates. 
-  
-  if( EtotPinMode < ele_maxEcalEOverP_2_ && EGsfPoutMode < ele_maxEeleOverPout_ ) {
-    if(debugSafeForJetMET) 
+
+  // Reject Crazy E/p values... to be understood in the future how to train a
+  // BDT in order to avoid to select this bad electron candidates.
+
+  if (EtotPinMode < ele_maxEcalEOverP_2_ && EGsfPoutMode < ele_maxEeleOverPout_) {
+    if (debugSafeForJetMET)
       cout << " *****This electron candidate is discarded  Low ETOTPIN "
-	   << " EtotPinMode " << EtotPinMode << " EGsfPoutMode " << EGsfPoutMode << endl;
+           << " EtotPinMode " << EtotPinMode << " EGsfPoutMode " << EGsfPoutMode << endl;
     isSafeForJetMET = false;
   }
-  
+
   // For not-preselected Gsf Tracks ET > 50 GeV, apply dphi preselection
-  if(ETtotal > ele_maxE_ && fabs(dphi_normalsc) > ele_maxDPhiIN_ ) {
-    if(debugSafeForJetMET) 
+  if (ETtotal > ele_maxE_ && fabs(dphi_normalsc) > ele_maxDPhiIN_) {
+    if (debugSafeForJetMET)
       cout << " *****This electron candidate is discarded  Large ANGLE "
-	   << " ETtotal " << ETtotal << " EGsfPoutMode " << dphi_normalsc << endl;
+           << " ETtotal " << ETtotal << " EGsfPoutMode " << dphi_normalsc << endl;
     isSafeForJetMET = false;
   }
-
-
 
   return isSafeForJetMET;
 }
-bool PFEGammaFilters::isPhotonSafeForJetMET(const reco::Photon & photon, const reco::PFCandidate & pfcand) const {
-
+bool PFEGammaFilters::isPhotonSafeForJetMET(const reco::Photon& photon, const reco::PFCandidate& pfcand) const {
   bool isSafeForJetMET = true;
   bool debugSafeForJetMET = false;
 
-//   cout << " pho_sumPtTrackIso_ForPhoton " << pho_sumPtTrackIso_
-//        << " pho_sumPtTrackIsoSlope_ForPhoton " << pho_sumPtTrackIsoSlope_ <<  endl;
+  //   cout << " pho_sumPtTrackIso_ForPhoton " << pho_sumPtTrackIso_
+  //        << " pho_sumPtTrackIsoSlope_ForPhoton " << pho_sumPtTrackIsoSlope_ <<  endl;
 
   float sum_track_pt = 0.;
 
   PFCandidateEGammaExtraRef pfcandextra = pfcand.egammaExtraRef();
   const PFCandidate::ElementsInBlocks& extraTracks = pfcandextra->extraNonConvTracks();
-  for (PFCandidate::ElementsInBlocks::const_iterator itrk = extraTracks.begin(); 
-       itrk<extraTracks.end(); ++itrk) {
+  for (PFCandidate::ElementsInBlocks::const_iterator itrk = extraTracks.begin(); itrk < extraTracks.end(); ++itrk) {
     const PFBlock& block = *(itrk->first);
     const PFBlockElement& pfele = block.elements()[itrk->second];
- 
-    
-    if(pfele.type()==reco::PFBlockElement::TRACK) {
 
-     
+    if (pfele.type() == reco::PFBlockElement::TRACK) {
       const reco::TrackRef& trackref = pfele.trackRef();
-      
-      if(debugSafeForJetMET)
-	cout << "PFEGammaFilters::isPhotonSafeForJetMET photon track:pt " << trackref->pt() << " SingleLegSize " << pfcandextra->singleLegConvTrackRefMva().size() << endl;
-   
-      
-      //const std::vector<reco::TrackRef>&  mySingleLeg = 
+
+      if (debugSafeForJetMET)
+        cout << "PFEGammaFilters::isPhotonSafeForJetMET photon track:pt " << trackref->pt() << " SingleLegSize "
+             << pfcandextra->singleLegConvTrackRefMva().size() << endl;
+
+      //const std::vector<reco::TrackRef>&  mySingleLeg =
       bool singleLegConv = false;
-      for(unsigned int iconv =0; iconv<pfcandextra->singleLegConvTrackRefMva().size(); iconv++) {
-	if(debugSafeForJetMET)
-	  cout << "PFEGammaFilters::SingleLeg track:pt " << (pfcandextra->singleLegConvTrackRefMva()[iconv].first)->pt() << endl;
-	
-	if(pfcandextra->singleLegConvTrackRefMva()[iconv].first == trackref) {
-	  singleLegConv = true;
-	  if(debugSafeForJetMET)
-	    cout << "PFEGammaFilters::isPhotonSafeForJetMET: SingleLeg conv track " << endl;
-	  break;
+      for (unsigned int iconv = 0; iconv < pfcandextra->singleLegConvTrackRefMva().size(); iconv++) {
+        if (debugSafeForJetMET)
+          cout << "PFEGammaFilters::SingleLeg track:pt " << (pfcandextra->singleLegConvTrackRefMva()[iconv].first)->pt()
+               << endl;
 
-	}
+        if (pfcandextra->singleLegConvTrackRefMva()[iconv].first == trackref) {
+          singleLegConv = true;
+          if (debugSafeForJetMET)
+            cout << "PFEGammaFilters::isPhotonSafeForJetMET: SingleLeg conv track " << endl;
+          break;
+        }
       }
-      if(singleLegConv)
-	continue;
-      
+      if (singleLegConv)
+        continue;
+
       sum_track_pt += trackref->pt();
-
     }
-
   }
 
-  if(debugSafeForJetMET)
+  if (debugSafeForJetMET)
     cout << " PFEGammaFilters::isPhotonSafeForJetMET: SumPt " << sum_track_pt << endl;
 
-  if(sum_track_pt>(pho_sumPtTrackIso_ + pho_sumPtTrackIsoSlope_ * photon.pt())) {
+  if (sum_track_pt > (pho_sumPtTrackIso_ + pho_sumPtTrackIsoSlope_ * photon.pt())) {
     isSafeForJetMET = false;
-    if(debugSafeForJetMET)
-      cout << "************************************!!!! PFEGammaFilters::isPhotonSafeForJetMET: Photon Discaded !!! " << endl;
+    if (debugSafeForJetMET)
+      cout << "************************************!!!! PFEGammaFilters::isPhotonSafeForJetMET: Photon Discaded !!! "
+           << endl;
   }
 
   return isSafeForJetMET;
 }
 
-//in CMSSW_10_4_0 we changed the electron preselection to be  H/E(cone 0.15) < 0.15 
+//in CMSSW_10_4_0 we changed the electron preselection to be  H/E(cone 0.15) < 0.15
 //OR H/E(single tower) < 0.15, with the tower being new.
-//However CMS is scared of making any change to the PF content and therefore 
+//However CMS is scared of making any change to the PF content and therefore
 //we have to explicitly reject them here
-//has to be insync here with GsfElectronAlgo::isPreselected 
-bool PFEGammaFilters::passGsfElePreSelWithOnlyConeHadem(const reco::GsfElectron & ele) const
-{
-  bool passCutBased=ele.passingCutBasedPreselection();
-  if(ele.hadronicOverEm()>ele_ecalDrivenHademPreselCut_) passCutBased = false;
+//has to be insync here with GsfElectronAlgo::isPreselected
+bool PFEGammaFilters::passGsfElePreSelWithOnlyConeHadem(const reco::GsfElectron& ele) const {
+  bool passCutBased = ele.passingCutBasedPreselection();
+  if (ele.hadronicOverEm() > ele_ecalDrivenHademPreselCut_)
+    passCutBased = false;
   bool passMVA = ele.passingMvaPreselection();
-  if(!ele.ecalDrivenSeed()){
-    if(ele.pt() > ele_maxElePtForOnlyMVAPresel_) return passMVA && passCutBased;
-    else return passMVA;
-  }else return passCutBased || passMVA;
+  if (!ele.ecalDrivenSeed()) {
+    if (ele.pt() > ele_maxElePtForOnlyMVAPresel_)
+      return passMVA && passCutBased;
+    else
+      return passMVA;
+  } else
+    return passCutBased || passMVA;
 }

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -9,754 +9,646 @@
 #include "DataFormats/MuonReco/interface/MuonCocktails.h"
 #include <iostream>
 
-
 using namespace std;
 using namespace reco;
 using namespace boost;
 
 namespace {
 
-    template<class T>
-    T getParameter(edm::ParameterSet const& pset, std::string && name, T && defaultValue) {
-        return pset.exists(name) ? pset.getParameter<T>(name) : defaultValue;
-    }
+  template <class T>
+  T getParameter(edm::ParameterSet const& pset, std::string&& name, T&& defaultValue) {
+    return pset.exists(name) ? pset.getParameter<T>(name) : defaultValue;
+  }
 
-}
+}  // namespace
 
 PFMuonAlgo::PFMuonAlgo(const edm::ParameterSet& iConfig)
 
-  : pfCosmicsMuonCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>())
-  , pfCleanedTrackerAndGlobalMuonCandidates_(std::make_unique<reco::PFCandidateCollection>())
-  , pfFakeMuonCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>())
-  , pfPunchThroughMuonCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>())
-  , pfPunchThroughHadronCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>())
-  , pfAddedMuonCandidates_(std::make_unique<reco::PFCandidateCollection>())
+    : pfCosmicsMuonCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>()),
+      pfCleanedTrackerAndGlobalMuonCandidates_(std::make_unique<reco::PFCandidateCollection>()),
+      pfFakeMuonCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>()),
+      pfPunchThroughMuonCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>()),
+      pfPunchThroughHadronCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>()),
+      pfAddedMuonCandidates_(std::make_unique<reco::PFCandidateCollection>())
 
-  , maxDPtOPt_(getParameter<double>(iConfig, "maxDPtOPt", 1.0))
-  , minTrackerHits_(getParameter<int>(iConfig, "minTrackerHits", 8))
-  , minPixelHits_(getParameter<int>(iConfig, "minPixelHits", 1))
-  , trackQuality_(reco::TrackBase::qualityByName(getParameter<std::string>(iConfig, "trackQuality", "highPurity")))
-  , errorCompScale_(getParameter<double>(iConfig, "ptErrorScale", 4.0))
-  , eventFractionCleaning_(getParameter<double>(iConfig, "eventFractionForCleaning", 0.75))
-  , dzPV_(getParameter<double>(iConfig, "dzPV", 0.2))
-  , postCleaning_(getParameter<bool>(iConfig, "postMuonCleaning", false)) // disable by default (for HLT)
-  , minPostCleaningPt_(getParameter<double>(iConfig, "minPtForPostCleaning", 20.))
-  , eventFactorCosmics_(getParameter<double>(iConfig, "eventFactorForCosmics", 10.))
-  , metSigForCleaning_(getParameter<double>(iConfig, "metSignificanceForCleaning", 3.))
-  , metSigForRejection_(getParameter<double>(iConfig, "metSignificanceForRejection", 4.))
-  , metFactorCleaning_(getParameter<double>(iConfig, "metFactorForCleaning", 4.))
-  , eventFractionRejection_(getParameter<double>(iConfig, "eventFractionForRejection", 0.75))
-  , metFactorRejection_(getParameter<double>(iConfig, "metFactorForRejection", 4.))
-  , metFactorHighEta_(getParameter<double>(iConfig, "metFactorForHighEta", 4.))
-  , ptFactorHighEta_(getParameter<double>(iConfig, "ptFactorForHighEta", 2.))
-  , metFactorFake_(getParameter<double>(iConfig, "metFactorForFakes", 4.))
-  , minPunchThroughMomentum_(getParameter<double>(iConfig, "minMomentumForPunchThrough", 100.))
-  , minPunchThroughEnergy_(getParameter<double>(iConfig, "minEnergyForPunchThrough", 100.))
-  , punchThroughFactor_(getParameter<double>(iConfig, "punchThroughFactor", 3.))
-  , punchThroughMETFactor_(getParameter<double>(iConfig, "punchThroughMETFactor", 4.))
-  , cosmicRejDistance_(getParameter<double>(iConfig, "cosmicRejectionDistance", 1.))
-{}
+      ,
+      maxDPtOPt_(getParameter<double>(iConfig, "maxDPtOPt", 1.0)),
+      minTrackerHits_(getParameter<int>(iConfig, "minTrackerHits", 8)),
+      minPixelHits_(getParameter<int>(iConfig, "minPixelHits", 1)),
+      trackQuality_(reco::TrackBase::qualityByName(getParameter<std::string>(iConfig, "trackQuality", "highPurity"))),
+      errorCompScale_(getParameter<double>(iConfig, "ptErrorScale", 4.0)),
+      eventFractionCleaning_(getParameter<double>(iConfig, "eventFractionForCleaning", 0.75)),
+      dzPV_(getParameter<double>(iConfig, "dzPV", 0.2)),
+      postCleaning_(getParameter<bool>(iConfig, "postMuonCleaning", false))  // disable by default (for HLT)
+      ,
+      minPostCleaningPt_(getParameter<double>(iConfig, "minPtForPostCleaning", 20.)),
+      eventFactorCosmics_(getParameter<double>(iConfig, "eventFactorForCosmics", 10.)),
+      metSigForCleaning_(getParameter<double>(iConfig, "metSignificanceForCleaning", 3.)),
+      metSigForRejection_(getParameter<double>(iConfig, "metSignificanceForRejection", 4.)),
+      metFactorCleaning_(getParameter<double>(iConfig, "metFactorForCleaning", 4.)),
+      eventFractionRejection_(getParameter<double>(iConfig, "eventFractionForRejection", 0.75)),
+      metFactorRejection_(getParameter<double>(iConfig, "metFactorForRejection", 4.)),
+      metFactorHighEta_(getParameter<double>(iConfig, "metFactorForHighEta", 4.)),
+      ptFactorHighEta_(getParameter<double>(iConfig, "ptFactorForHighEta", 2.)),
+      metFactorFake_(getParameter<double>(iConfig, "metFactorForFakes", 4.)),
+      minPunchThroughMomentum_(getParameter<double>(iConfig, "minMomentumForPunchThrough", 100.)),
+      minPunchThroughEnergy_(getParameter<double>(iConfig, "minEnergyForPunchThrough", 100.)),
+      punchThroughFactor_(getParameter<double>(iConfig, "punchThroughFactor", 3.)),
+      punchThroughMETFactor_(getParameter<double>(iConfig, "punchThroughMETFactor", 4.)),
+      cosmicRejDistance_(getParameter<double>(iConfig, "cosmicRejectionDistance", 1.)) {}
 
-
-
-
-
-
-bool
-PFMuonAlgo::isMuon( const reco::PFBlockElement& elt ) {
-
+bool PFMuonAlgo::isMuon(const reco::PFBlockElement& elt) {
   const auto* eltTrack = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
 
-  assert ( eltTrack );
+  assert(eltTrack);
   reco::MuonRef muonRef = eltTrack->muonRef();
 
   return isMuon(muonRef);
-
 }
 
-bool
-PFMuonAlgo::isLooseMuon( const reco::PFBlockElement& elt ) {
+bool PFMuonAlgo::isLooseMuon(const reco::PFBlockElement& elt) {
+  const reco::PFBlockElementTrack* eltTrack = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
 
-
-  const reco::PFBlockElementTrack* eltTrack 
-    = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
-
-
-
-  assert ( eltTrack );
-
+  assert(eltTrack);
 
   reco::MuonRef muonRef = eltTrack->muonRef();
-
 
   return isLooseMuon(muonRef);
-
 }
 
+bool PFMuonAlgo::isGlobalTightMuon(const reco::PFBlockElement& elt) {
+  const reco::PFBlockElementTrack* eltTrack = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
 
-bool
-PFMuonAlgo::isGlobalTightMuon( const reco::PFBlockElement& elt ) {
-
-  const reco::PFBlockElementTrack* eltTrack 
-    = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
-
-  assert ( eltTrack );
+  assert(eltTrack);
   reco::MuonRef muonRef = eltTrack->muonRef();
-  
-  return isGlobalTightMuon(muonRef);
 
+  return isGlobalTightMuon(muonRef);
 }
 
-bool
-PFMuonAlgo::isGlobalLooseMuon( const reco::PFBlockElement& elt ) {
+bool PFMuonAlgo::isGlobalLooseMuon(const reco::PFBlockElement& elt) {
+  const reco::PFBlockElementTrack* eltTrack = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
 
-  const reco::PFBlockElementTrack* eltTrack 
-    = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
-
-  assert ( eltTrack );
+  assert(eltTrack);
   reco::MuonRef muonRef = eltTrack->muonRef();
 
   return isGlobalLooseMuon(muonRef);
-
 }
 
-bool
-PFMuonAlgo::isTrackerTightMuon( const reco::PFBlockElement& elt ) {
+bool PFMuonAlgo::isTrackerTightMuon(const reco::PFBlockElement& elt) {
+  const reco::PFBlockElementTrack* eltTrack = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
 
-  const reco::PFBlockElementTrack* eltTrack 
-    = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
-
-  assert ( eltTrack );
+  assert(eltTrack);
   reco::MuonRef muonRef = eltTrack->muonRef();
 
   return isTrackerTightMuon(muonRef);
-
 }
 
-bool
-PFMuonAlgo::isIsolatedMuon( const reco::PFBlockElement& elt ) {
+bool PFMuonAlgo::isIsolatedMuon(const reco::PFBlockElement& elt) {
+  const reco::PFBlockElementTrack* eltTrack = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
 
-  const reco::PFBlockElementTrack* eltTrack 
-    = dynamic_cast<const reco::PFBlockElementTrack*>(&elt);
-
-  assert ( eltTrack );
+  assert(eltTrack);
   reco::MuonRef muonRef = eltTrack->muonRef();
 
   return isIsolatedMuon(muonRef);
-
 }
 
-bool
-PFMuonAlgo::isMuon(const reco::MuonRef& muonRef ){
-
+bool PFMuonAlgo::isMuon(const reco::MuonRef& muonRef) {
   return isGlobalTightMuon(muonRef) || isTrackerTightMuon(muonRef) || isIsolatedMuon(muonRef);
 }
 
-bool
-PFMuonAlgo::isLooseMuon(const reco::MuonRef& muonRef ){
-
+bool PFMuonAlgo::isLooseMuon(const reco::MuonRef& muonRef) {
   return (isGlobalLooseMuon(muonRef) || isTrackerLooseMuon(muonRef));
-
 }
 
-bool
-PFMuonAlgo::isGlobalTightMuon( const reco::MuonRef& muonRef ) {
+bool PFMuonAlgo::isGlobalTightMuon(const reco::MuonRef& muonRef) {
+  if (!muonRef.isNonnull())
+    return false;
 
- if ( !muonRef.isNonnull() ) return false;
+  if (!muonRef->isGlobalMuon())
+    return false;
+  if (!muonRef->isStandAloneMuon())
+    return false;
 
- if ( !muonRef->isGlobalMuon() ) return false;
- if ( !muonRef->isStandAloneMuon() ) return false;
- 
- 
- if ( muonRef->isTrackerMuon() ) { 
-  
-   bool result = muon::isGoodMuon(*muonRef,muon::GlobalMuonPromptTight);
-   
-   bool isTM2DCompatibilityTight =  muon::isGoodMuon(*muonRef,muon::TM2DCompatibilityTight);   
-   int nMatches = muonRef->numberOfMatches();
-   bool quality = nMatches > 2 || isTM2DCompatibilityTight;
-   
-   return result && quality;
-   
- } else {
+  if (muonRef->isTrackerMuon()) {
+    bool result = muon::isGoodMuon(*muonRef, muon::GlobalMuonPromptTight);
 
-   reco::TrackRef standAloneMu = muonRef->standAloneMuon();
-   
+    bool isTM2DCompatibilityTight = muon::isGoodMuon(*muonRef, muon::TM2DCompatibilityTight);
+    int nMatches = muonRef->numberOfMatches();
+    bool quality = nMatches > 2 || isTM2DCompatibilityTight;
+
+    return result && quality;
+
+  } else {
+    reco::TrackRef standAloneMu = muonRef->standAloneMuon();
+
     // No tracker muon -> Request a perfect stand-alone muon, or an even better global muon
     bool result = false;
-      
-    // Check the quality of the stand-alone muon : 
+
+    // Check the quality of the stand-alone muon :
     // good chi**2 and large number of hits and good pt error
-    if ( ( standAloneMu->hitPattern().numberOfValidMuonDTHits() < 22 &&
-	   standAloneMu->hitPattern().numberOfValidMuonCSCHits() < 15 ) ||
-	 standAloneMu->normalizedChi2() > 10. || 
-	 standAloneMu->ptError()/standAloneMu->pt() > 0.20 ) {
+    if ((standAloneMu->hitPattern().numberOfValidMuonDTHits() < 22 &&
+         standAloneMu->hitPattern().numberOfValidMuonCSCHits() < 15) ||
+        standAloneMu->normalizedChi2() > 10. || standAloneMu->ptError() / standAloneMu->pt() > 0.20) {
       result = false;
-    } else { 
-      
+    } else {
       reco::TrackRef combinedMu = muonRef->combinedMuon();
       reco::TrackRef trackerMu = muonRef->track();
-            
-      // If the stand-alone muon is good, check the global muon
-      if ( combinedMu->normalizedChi2() > standAloneMu->normalizedChi2() ) {
-	// If the combined muon is worse than the stand-alone, it 
-	// means that either the corresponding tracker track was not 
-	// reconstructed, or that the sta muon comes from a late 
-	// pion decay (hence with a momentum smaller than the track)
-	// Take the stand-alone muon only if its momentum is larger
-	// than that of the track
-	result = standAloneMu->pt() > trackerMu->pt() ;
-     } else { 
-	// If the combined muon is better (and good enough), take the 
-	// global muon
-	result = 
-	  combinedMu->ptError()/combinedMu->pt() < 
-	  std::min(0.20,standAloneMu->ptError()/standAloneMu->pt());
-      }
-    }      
 
-    return result;    
+      // If the stand-alone muon is good, check the global muon
+      if (combinedMu->normalizedChi2() > standAloneMu->normalizedChi2()) {
+        // If the combined muon is worse than the stand-alone, it
+        // means that either the corresponding tracker track was not
+        // reconstructed, or that the sta muon comes from a late
+        // pion decay (hence with a momentum smaller than the track)
+        // Take the stand-alone muon only if its momentum is larger
+        // than that of the track
+        result = standAloneMu->pt() > trackerMu->pt();
+      } else {
+        // If the combined muon is better (and good enough), take the
+        // global muon
+        result =
+            combinedMu->ptError() / combinedMu->pt() < std::min(0.20, standAloneMu->ptError() / standAloneMu->pt());
+      }
+    }
+
+    return result;
   }
 
   return false;
-
 }
 
-bool
-PFMuonAlgo::isTrackerTightMuon( const reco::MuonRef& muonRef ) {
+bool PFMuonAlgo::isTrackerTightMuon(const reco::MuonRef& muonRef) {
+  if (!muonRef.isNonnull())
+    return false;
 
-  if ( !muonRef.isNonnull() ) return false;
-    
-  if(!muonRef->isTrackerMuon()) return false;
-  
+  if (!muonRef->isTrackerMuon())
+    return false;
+
   reco::TrackRef trackerMu = muonRef->track();
   const reco::Track& track = *trackerMu;
-  
-  unsigned nTrackerHits =  track.hitPattern().numberOfValidTrackerHits();
-  
-  if(nTrackerHits<=12) return false;
-  
-  bool isAllArbitrated = muon::isGoodMuon(*muonRef,muon::AllArbitrated);
-  
-  bool isTM2DCompatibilityTight = muon::isGoodMuon(*muonRef,muon::TM2DCompatibilityTight);
-  
-  if(!isAllArbitrated || !isTM2DCompatibilityTight)  return false;
 
-  if((trackerMu->ptError()/trackerMu->pt() > 0.10)){
+  unsigned nTrackerHits = track.hitPattern().numberOfValidTrackerHits();
+
+  if (nTrackerHits <= 12)
+    return false;
+
+  bool isAllArbitrated = muon::isGoodMuon(*muonRef, muon::AllArbitrated);
+
+  bool isTM2DCompatibilityTight = muon::isGoodMuon(*muonRef, muon::TM2DCompatibilityTight);
+
+  if (!isAllArbitrated || !isTM2DCompatibilityTight)
+    return false;
+
+  if ((trackerMu->ptError() / trackerMu->pt() > 0.10)) {
     //std::cout<<" PT ERROR > 10 % "<< trackerMu->pt() <<std::endl;
     return false;
   }
   return true;
-  
 }
 
-bool
-PFMuonAlgo::isGlobalLooseMuon( const reco::MuonRef& muonRef ) {
+bool PFMuonAlgo::isGlobalLooseMuon(const reco::MuonRef& muonRef) {
+  if (!muonRef.isNonnull())
+    return false;
+  if (!muonRef->isGlobalMuon())
+    return false;
+  if (!muonRef->isStandAloneMuon())
+    return false;
 
-  if ( !muonRef.isNonnull() ) return false;
-  if ( !muonRef->isGlobalMuon() ) return false;
-  if ( !muonRef->isStandAloneMuon() ) return false;
-  
   reco::TrackRef standAloneMu = muonRef->standAloneMuon();
   reco::TrackRef combinedMu = muonRef->combinedMuon();
   reco::TrackRef trackerMu = muonRef->track();
- 
-  unsigned nMuonHits =
-    standAloneMu->hitPattern().numberOfValidMuonDTHits() +
-    2*standAloneMu->hitPattern().numberOfValidMuonCSCHits();
-    
-  bool quality = false;
-  
-  if ( muonRef->isTrackerMuon() ){
 
+  unsigned nMuonHits =
+      standAloneMu->hitPattern().numberOfValidMuonDTHits() + 2 * standAloneMu->hitPattern().numberOfValidMuonCSCHits();
+
+  bool quality = false;
+
+  if (muonRef->isTrackerMuon()) {
     bool result = combinedMu->normalizedChi2() < 100.;
-    
-    bool laststation =
-      muon::isGoodMuon(*muonRef,muon::TMLastStationAngTight);
-        
-    int nMatches = muonRef->numberOfMatches();    
-    
+
+    bool laststation = muon::isGoodMuon(*muonRef, muon::TMLastStationAngTight);
+
+    int nMatches = muonRef->numberOfMatches();
+
     quality = laststation && nMuonHits > 12 && nMatches > 1;
 
     return result && quality;
-    
-  }
-  else{
 
-    // Check the quality of the stand-alone muon : 
+  } else {
+    // Check the quality of the stand-alone muon :
     // good chi**2 and large number of hits and good pt error
-    if (  nMuonHits <=15  ||
-	  standAloneMu->normalizedChi2() > 10. || 
-	  standAloneMu->ptError()/standAloneMu->pt() > 0.20 ) {
+    if (nMuonHits <= 15 || standAloneMu->normalizedChi2() > 10. ||
+        standAloneMu->ptError() / standAloneMu->pt() > 0.20) {
       quality = false;
-    }
-   else { 
+    } else {
       // If the stand-alone muon is good, check the global muon
-      if ( combinedMu->normalizedChi2() > standAloneMu->normalizedChi2() ) {
-	// If the combined muon is worse than the stand-alone, it 
-	// means that either the corresponding tracker track was not 
-	// reconstructed, or that the sta muon comes from a late 
-	// pion decay (hence with a momentum smaller than the track)
-	// Take the stand-alone muon only if its momentum is larger
-	// than that of the track
+      if (combinedMu->normalizedChi2() > standAloneMu->normalizedChi2()) {
+        // If the combined muon is worse than the stand-alone, it
+        // means that either the corresponding tracker track was not
+        // reconstructed, or that the sta muon comes from a late
+        // pion decay (hence with a momentum smaller than the track)
+        // Take the stand-alone muon only if its momentum is larger
+        // than that of the track
 
-	// Note that here we even take the standAlone if it has a smaller pT, in contrast to GlobalTight
-	if(standAloneMu->pt() > trackerMu->pt() || combinedMu->normalizedChi2()<5.) quality =  true;
+        // Note that here we even take the standAlone if it has a smaller pT, in contrast to GlobalTight
+        if (standAloneMu->pt() > trackerMu->pt() || combinedMu->normalizedChi2() < 5.)
+          quality = true;
+      } else {
+        // If the combined muon is better (and good enough), take the
+        // global muon
+        if (combinedMu->ptError() / combinedMu->pt() < std::min(0.20, standAloneMu->ptError() / standAloneMu->pt()))
+          quality = true;
       }
-      else { 
-	// If the combined muon is better (and good enough), take the 
-	// global muon
-	if(combinedMu->ptError()/combinedMu->pt() < std::min(0.20,standAloneMu->ptError()/standAloneMu->pt())) 
-	  quality = true;
-	
-      }
-   }         
+    }
   }
-  
 
   return quality;
-
 }
 
-
-bool
-PFMuonAlgo::isTrackerLooseMuon( const reco::MuonRef& muonRef ) {
-
-  if ( !muonRef.isNonnull() ) return false;
-  if(!muonRef->isTrackerMuon()) return false;
+bool PFMuonAlgo::isTrackerLooseMuon(const reco::MuonRef& muonRef) {
+  if (!muonRef.isNonnull())
+    return false;
+  if (!muonRef->isTrackerMuon())
+    return false;
 
   reco::TrackRef trackerMu = muonRef->track();
 
-  if(trackerMu->ptError()/trackerMu->pt() > 0.20) return false;
+  if (trackerMu->ptError() / trackerMu->pt() > 0.20)
+    return false;
 
   // this doesn't seem to be necessary on the small samples looked at, but keep it around as insurance
-  if(trackerMu->pt()>20.) return false;
-    
-  bool isAllArbitrated = muon::isGoodMuon(*muonRef,muon::AllArbitrated);
-  bool isTMLastStationAngTight = muon::isGoodMuon(*muonRef,muon::TMLastStationAngTight);
+  if (trackerMu->pt() > 20.)
+    return false;
+
+  bool isAllArbitrated = muon::isGoodMuon(*muonRef, muon::AllArbitrated);
+  bool isTMLastStationAngTight = muon::isGoodMuon(*muonRef, muon::TMLastStationAngTight);
 
   bool quality = isAllArbitrated && isTMLastStationAngTight;
 
   return quality;
-  
 }
 
-bool
-PFMuonAlgo::isIsolatedMuon( const reco::MuonRef& muonRef ){
+bool PFMuonAlgo::isIsolatedMuon(const reco::MuonRef& muonRef) {
+  if (!muonRef.isNonnull())
+    return false;
+  if (!muonRef->isIsolationValid())
+    return false;
 
-
-  if ( !muonRef.isNonnull() ) return false;
-  if ( !muonRef->isIsolationValid() ) return false;
-  
   // Isolated Muons which are missed by standard cuts are nearly always global+tracker
-  if ( !muonRef->isGlobalMuon() ) return false;
+  if (!muonRef->isGlobalMuon())
+    return false;
 
   // If it's not a tracker muon, only take it if there are valid muon hits
 
   reco::TrackRef standAloneMu = muonRef->standAloneMuon();
 
-  if ( !muonRef->isTrackerMuon() ){
-    if(standAloneMu->hitPattern().numberOfValidMuonDTHits() == 0 &&
-       standAloneMu->hitPattern().numberOfValidMuonCSCHits() ==0) return false;
+  if (!muonRef->isTrackerMuon()) {
+    if (standAloneMu->hitPattern().numberOfValidMuonDTHits() == 0 &&
+        standAloneMu->hitPattern().numberOfValidMuonCSCHits() == 0)
+      return false;
   }
-  
+
   // for isolation, take the smallest pt available to reject fakes
 
   reco::TrackRef combinedMu = muonRef->combinedMuon();
   double smallestMuPt = combinedMu->pt();
-  
-  if(standAloneMu->pt()<smallestMuPt) smallestMuPt = standAloneMu->pt();
-  
-  if(muonRef->isTrackerMuon())
-    {
-      reco::TrackRef trackerMu = muonRef->track();
-      if(trackerMu->pt() < smallestMuPt) smallestMuPt= trackerMu->pt();
-    }
 
-   
+  if (standAloneMu->pt() < smallestMuPt)
+    smallestMuPt = standAloneMu->pt();
+
+  if (muonRef->isTrackerMuon()) {
+    reco::TrackRef trackerMu = muonRef->track();
+    if (trackerMu->pt() < smallestMuPt)
+      smallestMuPt = trackerMu->pt();
+  }
+
   double sumPtR03 = muonRef->isolationR03().sumPt;
-  
-  double relIso = sumPtR03/smallestMuPt;
 
+  double relIso = sumPtR03 / smallestMuPt;
 
-
-  
-  if(relIso<0.1) return true;
-  else return false;
+  if (relIso < 0.1)
+    return true;
+  else
+    return false;
 }
 
-bool 
-PFMuonAlgo::isTightMuonPOG(const reco::MuonRef& muonRef) {
+bool PFMuonAlgo::isTightMuonPOG(const reco::MuonRef& muonRef) {
+  if (!muon::isGoodMuon(*muonRef, muon::GlobalMuonPromptTight))
+    return false;
 
-  if(!muon::isGoodMuon(*muonRef,muon::GlobalMuonPromptTight)) return false;
+  if (!muonRef->isTrackerMuon())
+    return false;
 
-  if(!muonRef->isTrackerMuon()) return false;
-  
-  if(muonRef->numberOfMatches()<2) return false;
-  
-  //const reco::TrackRef& combinedMuon = muonRef->combinedMuon();    
-  const reco::TrackRef& combinedMuon = muonRef->globalTrack();    
-  
-  if(combinedMuon->hitPattern().numberOfValidTrackerHits()<11) return false;
-  
-  if(combinedMuon->hitPattern().numberOfValidPixelHits()==0) return false;
-  
-  if(combinedMuon->hitPattern().numberOfValidMuonHits()==0) return false;  
+  if (muonRef->numberOfMatches() < 2)
+    return false;
+
+  //const reco::TrackRef& combinedMuon = muonRef->combinedMuon();
+  const reco::TrackRef& combinedMuon = muonRef->globalTrack();
+
+  if (combinedMuon->hitPattern().numberOfValidTrackerHits() < 11)
+    return false;
+
+  if (combinedMuon->hitPattern().numberOfValidPixelHits() == 0)
+    return false;
+
+  if (combinedMuon->hitPattern().numberOfValidMuonHits() == 0)
+    return false;
 
   return true;
-
 }
 
-
-bool 
-PFMuonAlgo::hasValidTrack(const reco::MuonRef& muonRef,bool loose) {
-  if(loose)
+bool PFMuonAlgo::hasValidTrack(const reco::MuonRef& muonRef, bool loose) {
+  if (loose)
     return !muonTracks(muonRef).empty();
   else
     return !goodMuonTracks(muonRef).empty();
-
 }
 
+void PFMuonAlgo::printMuonProperties(const reco::MuonRef& muonRef) {
+  if (!muonRef.isNonnull())
+    return;
 
-void 
-PFMuonAlgo::printMuonProperties(const reco::MuonRef& muonRef){
-  
-  if ( !muonRef.isNonnull() ) return;
-  
   bool isGL = muonRef->isGlobalMuon();
   bool isTR = muonRef->isTrackerMuon();
   bool isST = muonRef->isStandAloneMuon();
 
-  std::cout<<" GL: "<<isGL<<" TR: "<<isTR<<" ST: "<<isST<<std::endl;
-  std::cout<<" nMatches "<<muonRef->numberOfMatches()<<std::endl;
-  
-  if ( muonRef->isGlobalMuon() ){
+  std::cout << " GL: " << isGL << " TR: " << isTR << " ST: " << isST << std::endl;
+  std::cout << " nMatches " << muonRef->numberOfMatches() << std::endl;
+
+  if (muonRef->isGlobalMuon()) {
     reco::TrackRef combinedMu = muonRef->combinedMuon();
-    std::cout<<" GL,  pt: " << combinedMu->pt() 
-	<< " +/- " << combinedMu->ptError()/combinedMu->pt() 
-	     << " chi**2 GBL : " << combinedMu->normalizedChi2()<<std::endl;
-    std::cout<< " Total Muon Hits : " << combinedMu->hitPattern().numberOfValidMuonHits()
-	     << "/" << combinedMu->hitPattern().numberOfLostMuonHits()
-	<< " DT Hits : " << combinedMu->hitPattern().numberOfValidMuonDTHits()
-	<< "/" << combinedMu->hitPattern().numberOfLostMuonDTHits()
-	<< " CSC Hits : " << combinedMu->hitPattern().numberOfValidMuonCSCHits()
-	<< "/" << combinedMu->hitPattern().numberOfLostMuonCSCHits()
-	<< " RPC Hits : " << combinedMu->hitPattern().numberOfValidMuonRPCHits()
-	     << "/" << combinedMu->hitPattern().numberOfLostMuonRPCHits()<<std::endl;
+    std::cout << " GL,  pt: " << combinedMu->pt() << " +/- " << combinedMu->ptError() / combinedMu->pt()
+              << " chi**2 GBL : " << combinedMu->normalizedChi2() << std::endl;
+    std::cout << " Total Muon Hits : " << combinedMu->hitPattern().numberOfValidMuonHits() << "/"
+              << combinedMu->hitPattern().numberOfLostMuonHits()
+              << " DT Hits : " << combinedMu->hitPattern().numberOfValidMuonDTHits() << "/"
+              << combinedMu->hitPattern().numberOfLostMuonDTHits()
+              << " CSC Hits : " << combinedMu->hitPattern().numberOfValidMuonCSCHits() << "/"
+              << combinedMu->hitPattern().numberOfLostMuonCSCHits()
+              << " RPC Hits : " << combinedMu->hitPattern().numberOfValidMuonRPCHits() << "/"
+              << combinedMu->hitPattern().numberOfLostMuonRPCHits() << std::endl;
 
-    std::cout<<"  # of Valid Tracker Hits "<<combinedMu->hitPattern().numberOfValidTrackerHits()<<std::endl;
-    std::cout<<"  # of Valid Pixel Hits "<<combinedMu->hitPattern().numberOfValidPixelHits()<<std::endl;
+    std::cout << "  # of Valid Tracker Hits " << combinedMu->hitPattern().numberOfValidTrackerHits() << std::endl;
+    std::cout << "  # of Valid Pixel Hits " << combinedMu->hitPattern().numberOfValidPixelHits() << std::endl;
   }
-  if ( muonRef->isStandAloneMuon() ){
+  if (muonRef->isStandAloneMuon()) {
     reco::TrackRef standAloneMu = muonRef->standAloneMuon();
-    std::cout<<" ST,  pt: " << standAloneMu->pt() 
-	<< " +/- " << standAloneMu->ptError()/standAloneMu->pt() 
-	<< " eta : " << standAloneMu->eta()  
-	<< " DT Hits : " << standAloneMu->hitPattern().numberOfValidMuonDTHits()
-	<< "/" << standAloneMu->hitPattern().numberOfLostMuonDTHits()
-	<< " CSC Hits : " << standAloneMu->hitPattern().numberOfValidMuonCSCHits()
-	<< "/" << standAloneMu->hitPattern().numberOfLostMuonCSCHits()
-	<< " RPC Hits : " << standAloneMu->hitPattern().numberOfValidMuonRPCHits()
-	<< "/" << standAloneMu->hitPattern().numberOfLostMuonRPCHits()
-	     << " chi**2 STA : " << standAloneMu->normalizedChi2()<<std::endl;
-      }
+    std::cout << " ST,  pt: " << standAloneMu->pt() << " +/- " << standAloneMu->ptError() / standAloneMu->pt()
+              << " eta : " << standAloneMu->eta()
+              << " DT Hits : " << standAloneMu->hitPattern().numberOfValidMuonDTHits() << "/"
+              << standAloneMu->hitPattern().numberOfLostMuonDTHits()
+              << " CSC Hits : " << standAloneMu->hitPattern().numberOfValidMuonCSCHits() << "/"
+              << standAloneMu->hitPattern().numberOfLostMuonCSCHits()
+              << " RPC Hits : " << standAloneMu->hitPattern().numberOfValidMuonRPCHits() << "/"
+              << standAloneMu->hitPattern().numberOfLostMuonRPCHits()
+              << " chi**2 STA : " << standAloneMu->normalizedChi2() << std::endl;
+  }
 
-
-  if ( muonRef->isTrackerMuon() ){
+  if (muonRef->isTrackerMuon()) {
     reco::TrackRef trackerMu = muonRef->track();
     const reco::Track& track = *trackerMu;
-    std::cout<<" TR,  pt: " << trackerMu->pt() 
-	<< " +/- " << trackerMu->ptError()/trackerMu->pt() 
-	     << " chi**2 TR : " << trackerMu->normalizedChi2()<<std::endl;    
-    std::cout<<" nTrackerHits "<<track.hitPattern().numberOfValidTrackerHits()<<std::endl;
-    std::cout<< "TMLastStationAngLoose               "
-	<< muon::isGoodMuon(*muonRef,muon::TMLastStationAngLoose) << std::endl       
-	<< "TMLastStationAngTight               "
-	<< muon::isGoodMuon(*muonRef,muon::TMLastStationAngTight) << std::endl          
-	<< "TMLastStationLoose               "
-	<< muon::isGoodMuon(*muonRef,muon::TMLastStationLoose) << std::endl       
-	<< "TMLastStationTight               "
-	<< muon::isGoodMuon(*muonRef,muon::TMLastStationTight) << std::endl          
-	<< "TMOneStationLoose                "
-	<< muon::isGoodMuon(*muonRef,muon::TMOneStationLoose) << std::endl       
-	<< "TMOneStationTight                "
-	<< muon::isGoodMuon(*muonRef,muon::TMOneStationTight) << std::endl       
-	<< "TMLastStationOptimizedLowPtLoose " 
-	<< muon::isGoodMuon(*muonRef,muon::TMLastStationOptimizedLowPtLoose) << std::endl
-	<< "TMLastStationOptimizedLowPtTight " 
-	<< muon::isGoodMuon(*muonRef,muon::TMLastStationOptimizedLowPtTight) << std::endl 
-	<< "TMLastStationOptimizedBarrelLowPtLoose " 
-	<< muon::isGoodMuon(*muonRef,muon::TMLastStationOptimizedBarrelLowPtLoose) << std::endl
-	<< "TMLastStationOptimizedBarrelLowPtTight " 
-	<< muon::isGoodMuon(*muonRef,muon::TMLastStationOptimizedBarrelLowPtTight) << std::endl 
-	<< std::endl;
-
+    std::cout << " TR,  pt: " << trackerMu->pt() << " +/- " << trackerMu->ptError() / trackerMu->pt()
+              << " chi**2 TR : " << trackerMu->normalizedChi2() << std::endl;
+    std::cout << " nTrackerHits " << track.hitPattern().numberOfValidTrackerHits() << std::endl;
+    std::cout << "TMLastStationAngLoose               " << muon::isGoodMuon(*muonRef, muon::TMLastStationAngLoose)
+              << std::endl
+              << "TMLastStationAngTight               " << muon::isGoodMuon(*muonRef, muon::TMLastStationAngTight)
+              << std::endl
+              << "TMLastStationLoose               " << muon::isGoodMuon(*muonRef, muon::TMLastStationLoose)
+              << std::endl
+              << "TMLastStationTight               " << muon::isGoodMuon(*muonRef, muon::TMLastStationTight)
+              << std::endl
+              << "TMOneStationLoose                " << muon::isGoodMuon(*muonRef, muon::TMOneStationLoose) << std::endl
+              << "TMOneStationTight                " << muon::isGoodMuon(*muonRef, muon::TMOneStationTight) << std::endl
+              << "TMLastStationOptimizedLowPtLoose "
+              << muon::isGoodMuon(*muonRef, muon::TMLastStationOptimizedLowPtLoose) << std::endl
+              << "TMLastStationOptimizedLowPtTight "
+              << muon::isGoodMuon(*muonRef, muon::TMLastStationOptimizedLowPtTight) << std::endl
+              << "TMLastStationOptimizedBarrelLowPtLoose "
+              << muon::isGoodMuon(*muonRef, muon::TMLastStationOptimizedBarrelLowPtLoose) << std::endl
+              << "TMLastStationOptimizedBarrelLowPtTight "
+              << muon::isGoodMuon(*muonRef, muon::TMLastStationOptimizedBarrelLowPtTight) << std::endl
+              << std::endl;
   }
 
-  std::cout<< "TM2DCompatibilityLoose           "
-      << muon::isGoodMuon(*muonRef,muon::TM2DCompatibilityLoose) << std::endl 
-      << "TM2DCompatibilityTight           "
-	   << muon::isGoodMuon(*muonRef,muon::TM2DCompatibilityTight) << std::endl;
+  std::cout << "TM2DCompatibilityLoose           " << muon::isGoodMuon(*muonRef, muon::TM2DCompatibilityLoose)
+            << std::endl
+            << "TM2DCompatibilityTight           " << muon::isGoodMuon(*muonRef, muon::TM2DCompatibilityTight)
+            << std::endl;
 
-
-
-  if (	    muonRef->isGlobalMuon() &&  muonRef->isTrackerMuon() &&  muonRef->isStandAloneMuon() ){
+  if (muonRef->isGlobalMuon() && muonRef->isTrackerMuon() && muonRef->isStandAloneMuon()) {
     reco::TrackRef combinedMu = muonRef->combinedMuon();
     reco::TrackRef trackerMu = muonRef->track();
     reco::TrackRef standAloneMu = muonRef->standAloneMuon();
-    
-    double sigmaCombined = combinedMu->ptError()/(combinedMu->pt()*combinedMu->pt()); 	 
-    double sigmaTracker = trackerMu->ptError()/(trackerMu->pt()*trackerMu->pt()); 	 
-    double sigmaStandAlone = standAloneMu->ptError()/(standAloneMu->pt()*standAloneMu->pt()); 	 
-    
-    bool combined = combinedMu->ptError()/combinedMu->pt() < 0.20; 	 
-    bool tracker = trackerMu->ptError()/trackerMu->pt() < 0.20; 	 
-    bool standAlone = standAloneMu->ptError()/standAloneMu->pt() < 0.20; 	 
-  
-    double delta1 =  combined && tracker ? 	 
-      fabs(1./combinedMu->pt() -1./trackerMu->pt()) 	 
-      /sqrt(sigmaCombined*sigmaCombined + sigmaTracker*sigmaTracker) : 100.; 	 
-    double delta2 = combined && standAlone ? 	 
-      fabs(1./combinedMu->pt() -1./standAloneMu->pt()) 	 
-      /sqrt(sigmaCombined*sigmaCombined + sigmaStandAlone*sigmaStandAlone) : 100.; 	 
-    double delta3 = standAlone && tracker ? 	 
-      fabs(1./standAloneMu->pt() -1./trackerMu->pt()) 	 
-      /sqrt(sigmaStandAlone*sigmaStandAlone + sigmaTracker*sigmaTracker) : 100.; 	 
-    
-    double delta = 	 
-      standAloneMu->hitPattern().numberOfValidMuonDTHits()+ 	 
-      standAloneMu->hitPattern().numberOfValidMuonCSCHits() > 0 ? 	 
-      std::min(delta3,std::min(delta1,delta2)) : std::max(delta3,std::max(delta1,delta2)); 	 
 
-    std::cout << "delta = " << delta << " delta1 "<<delta1<<" delta2 "<<delta2<<" delta3 "<<delta3<<std::endl; 	 
-    
-    double ratio = 	 
-      combinedMu->ptError()/combinedMu->pt() 	 
-      / (trackerMu->ptError()/trackerMu->pt()); 	 
+    double sigmaCombined = combinedMu->ptError() / (combinedMu->pt() * combinedMu->pt());
+    double sigmaTracker = trackerMu->ptError() / (trackerMu->pt() * trackerMu->pt());
+    double sigmaStandAlone = standAloneMu->ptError() / (standAloneMu->pt() * standAloneMu->pt());
+
+    bool combined = combinedMu->ptError() / combinedMu->pt() < 0.20;
+    bool tracker = trackerMu->ptError() / trackerMu->pt() < 0.20;
+    bool standAlone = standAloneMu->ptError() / standAloneMu->pt() < 0.20;
+
+    double delta1 = combined && tracker ? fabs(1. / combinedMu->pt() - 1. / trackerMu->pt()) /
+                                              sqrt(sigmaCombined * sigmaCombined + sigmaTracker * sigmaTracker)
+                                        : 100.;
+    double delta2 = combined && standAlone ? fabs(1. / combinedMu->pt() - 1. / standAloneMu->pt()) /
+                                                 sqrt(sigmaCombined * sigmaCombined + sigmaStandAlone * sigmaStandAlone)
+                                           : 100.;
+    double delta3 = standAlone && tracker ? fabs(1. / standAloneMu->pt() - 1. / trackerMu->pt()) /
+                                                sqrt(sigmaStandAlone * sigmaStandAlone + sigmaTracker * sigmaTracker)
+                                          : 100.;
+
+    double delta =
+        standAloneMu->hitPattern().numberOfValidMuonDTHits() + standAloneMu->hitPattern().numberOfValidMuonCSCHits() > 0
+            ? std::min(delta3, std::min(delta1, delta2))
+            : std::max(delta3, std::max(delta1, delta2));
+
+    std::cout << "delta = " << delta << " delta1 " << delta1 << " delta2 " << delta2 << " delta3 " << delta3
+              << std::endl;
+
+    double ratio = combinedMu->ptError() / combinedMu->pt() / (trackerMu->ptError() / trackerMu->pt());
     //if ( ratio > 2. && delta < 3. ) std::cout << "ALARM ! " << ratio << ", " << delta << std::endl;
-    std::cout<<" ratio "<<ratio<<" combined mu pt "<<combinedMu->pt()<<std::endl;
+    std::cout << " ratio " << ratio << " combined mu pt " << combinedMu->pt() << std::endl;
     //bool quality3 =  ( combinedMu->pt() < 50. || ratio < 2. ) && delta <  3.;
-
-
   }
 
-    double sumPtR03 = muonRef->isolationR03().sumPt;
-    double emEtR03 = muonRef->isolationR03().emEt;
-    double hadEtR03 = muonRef->isolationR03().hadEt;    
-    double relIsoR03 = (sumPtR03 + emEtR03 + hadEtR03)/muonRef->pt();
-    double sumPtR05 = muonRef->isolationR05().sumPt;
-    double emEtR05 = muonRef->isolationR05().emEt;
-    double hadEtR05 = muonRef->isolationR05().hadEt;    
-    double relIsoR05 = (sumPtR05 + emEtR05 + hadEtR05)/muonRef->pt();
-    std::cout<<" 0.3 Radion Rel Iso: "<<relIsoR03<<" sumPt "<<sumPtR03<<" emEt "<<emEtR03<<" hadEt "<<hadEtR03<<std::endl;
-    std::cout<<" 0.5 Radion Rel Iso: "<<relIsoR05<<" sumPt "<<sumPtR05<<" emEt "<<emEtR05<<" hadEt "<<hadEtR05<<std::endl;
+  double sumPtR03 = muonRef->isolationR03().sumPt;
+  double emEtR03 = muonRef->isolationR03().emEt;
+  double hadEtR03 = muonRef->isolationR03().hadEt;
+  double relIsoR03 = (sumPtR03 + emEtR03 + hadEtR03) / muonRef->pt();
+  double sumPtR05 = muonRef->isolationR05().sumPt;
+  double emEtR05 = muonRef->isolationR05().emEt;
+  double hadEtR05 = muonRef->isolationR05().hadEt;
+  double relIsoR05 = (sumPtR05 + emEtR05 + hadEtR05) / muonRef->pt();
+  std::cout << " 0.3 Radion Rel Iso: " << relIsoR03 << " sumPt " << sumPtR03 << " emEt " << emEtR03 << " hadEt "
+            << hadEtR03 << std::endl;
+  std::cout << " 0.5 Radion Rel Iso: " << relIsoR05 << " sumPt " << sumPtR05 << " emEt " << emEtR05 << " hadEt "
+            << hadEtR05 << std::endl;
   return;
-
 }
 
-
-
-std::vector<reco::Muon::MuonTrackTypePair> PFMuonAlgo::goodMuonTracks(const reco::MuonRef& muon,bool includeSA) {
-  return muonTracks(muon,includeSA,maxDPtOPt_);
+std::vector<reco::Muon::MuonTrackTypePair> PFMuonAlgo::goodMuonTracks(const reco::MuonRef& muon, bool includeSA) {
+  return muonTracks(muon, includeSA, maxDPtOPt_);
 }
 
-
-
-std::vector<reco::Muon::MuonTrackTypePair> PFMuonAlgo::muonTracks(const reco::MuonRef& muon,bool includeSA,double dpt) {
-
-
-
+std::vector<reco::Muon::MuonTrackTypePair> PFMuonAlgo::muonTracks(const reco::MuonRef& muon,
+                                                                  bool includeSA,
+                                                                  double dpt) {
   std::vector<reco::Muon::MuonTrackTypePair> out;
 
-  
-  if(muon->globalTrack().isNonnull() && muon->globalTrack()->pt()>0) 
-    if(muon->globalTrack()->ptError()/muon->globalTrack()->pt()<dpt)
-      out.emplace_back(muon->globalTrack(),reco::Muon::CombinedTrack);
+  if (muon->globalTrack().isNonnull() && muon->globalTrack()->pt() > 0)
+    if (muon->globalTrack()->ptError() / muon->globalTrack()->pt() < dpt)
+      out.emplace_back(muon->globalTrack(), reco::Muon::CombinedTrack);
 
-  if(muon->innerTrack().isNonnull() && muon->innerTrack()->pt()>0) 
-    if(muon->innerTrack()->ptError()/muon->innerTrack()->pt()<dpt)//Here Loose!@
-      out.emplace_back(muon->innerTrack(),reco::Muon::InnerTrack);
+  if (muon->innerTrack().isNonnull() && muon->innerTrack()->pt() > 0)
+    if (muon->innerTrack()->ptError() / muon->innerTrack()->pt() < dpt)  //Here Loose!@
+      out.emplace_back(muon->innerTrack(), reco::Muon::InnerTrack);
 
-  bool pickyExists=false; 
-  double pickyDpt=99999.; 
-  if(muon->pickyTrack().isNonnull() && muon->pickyTrack()->pt()>0) {
-    pickyDpt = muon->pickyTrack()->ptError()/muon->pickyTrack()->pt(); 
-    if(pickyDpt<dpt) 
-      out.emplace_back(muon->pickyTrack(),reco::Muon::Picky);
-    pickyExists=true;
+  bool pickyExists = false;
+  double pickyDpt = 99999.;
+  if (muon->pickyTrack().isNonnull() && muon->pickyTrack()->pt() > 0) {
+    pickyDpt = muon->pickyTrack()->ptError() / muon->pickyTrack()->pt();
+    if (pickyDpt < dpt)
+      out.emplace_back(muon->pickyTrack(), reco::Muon::Picky);
+    pickyExists = true;
   }
 
-  bool dytExists=false; 
-  double dytDpt=99999.; 
-  if(muon->dytTrack().isNonnull() && muon->dytTrack()->pt()>0) {
-    dytDpt = muon->dytTrack()->ptError()/muon->dytTrack()->pt(); 
-    if(dytDpt<dpt) 
-      out.emplace_back(muon->dytTrack(),reco::Muon::DYT);
-    dytExists=true;
+  bool dytExists = false;
+  double dytDpt = 99999.;
+  if (muon->dytTrack().isNonnull() && muon->dytTrack()->pt() > 0) {
+    dytDpt = muon->dytTrack()->ptError() / muon->dytTrack()->pt();
+    if (dytDpt < dpt)
+      out.emplace_back(muon->dytTrack(), reco::Muon::DYT);
+    dytExists = true;
   }
 
   //Magic: TPFMS is not a really good track especially under misalignment
   //IT is kind of crap because if mu system is displaced it can make a change
   //So allow TPFMS if there is no picky or the error of tpfms is better than picky
   //AND if there is no DYT or the error of tpfms is better than DYT
-  if(muon->tpfmsTrack().isNonnull() && muon->tpfmsTrack()->pt()>0) { 
-    double tpfmsDpt = muon->tpfmsTrack()->ptError()/muon->tpfmsTrack()->pt(); 
-    if( ( (pickyExists && tpfmsDpt<pickyDpt) || (!pickyExists) ) && 
-	( (dytExists   && tpfmsDpt<dytDpt)   || (!dytExists)   ) && 
-	tpfmsDpt<dpt )
-      out.emplace_back(muon->tpfmsTrack(),reco::Muon::TPFMS);
+  if (muon->tpfmsTrack().isNonnull() && muon->tpfmsTrack()->pt() > 0) {
+    double tpfmsDpt = muon->tpfmsTrack()->ptError() / muon->tpfmsTrack()->pt();
+    if (((pickyExists && tpfmsDpt < pickyDpt) || (!pickyExists)) &&
+        ((dytExists && tpfmsDpt < dytDpt) || (!dytExists)) && tpfmsDpt < dpt)
+      out.emplace_back(muon->tpfmsTrack(), reco::Muon::TPFMS);
   }
 
-  if(includeSA && muon->outerTrack().isNonnull())
-    if(muon->outerTrack()->ptError()/muon->outerTrack()->pt()<dpt)
-      out.emplace_back(muon->outerTrack(),reco::Muon::OuterTrack);
+  if (includeSA && muon->outerTrack().isNonnull())
+    if (muon->outerTrack()->ptError() / muon->outerTrack()->pt() < dpt)
+      out.emplace_back(muon->outerTrack(), reco::Muon::OuterTrack);
 
   return out;
-
 }
-
-
-
-
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-
-
-
 bool PFMuonAlgo::reconstructMuon(reco::PFCandidate& candidate, const reco::MuonRef& muon, bool allowLoose) {
-    using namespace std;
-    using namespace reco;
-
-    if (!muon.isNonnull())
-      return false;
-
-
-    
-
-    bool isMu=false;
-
-    if(allowLoose) 
-      isMu = isMuon(muon) || isLooseMuon(muon);
-    else
-      isMu = isMuon(muon);
-
-    if( !isMu)
-      return false;
-
-
-
-
-
-    //get the valid tracks(without standalone except we allow loose muons)
-    //MIKE: Here we need to be careful. If we have a muon inside a dense 
-    //jet environment often the track is badly measured. In this case 
-    //we should not apply Dpt/Pt<1
- 
-    std::vector<reco::Muon::MuonTrackTypePair> validTracks = goodMuonTracks(muon);
-    if (!allowLoose)
-      validTracks = goodMuonTracks(muon);
-    else
-      validTracks = muonTracks(muon);
-
-    if( validTracks.empty())
-      return false;
-
-
-
-
-    //check what is the track used.Rerun TuneP
-    reco::Muon::MuonTrackTypePair bestTrackPair = muon::tevOptimized(*muon);
-    
-    TrackRef bestTrack = bestTrackPair.first;
-    MuonTrackType trackType = bestTrackPair.second;
-
-
-
-    MuonTrackTypePair trackPairWithSmallestError = getTrackWithSmallestError(validTracks);
-    TrackRef trackWithSmallestError = trackPairWithSmallestError.first;
-    
-    if( trackType == reco::Muon::InnerTrack && 
-	(!bestTrack->quality(trackQuality_) ||
-	 bestTrack->ptError()/bestTrack->pt()> errorCompScale_*trackWithSmallestError->ptError()/trackWithSmallestError->pt() )) {
-      bestTrack = trackWithSmallestError;
-      trackType = trackPairWithSmallestError.second;
-    }
-    else if (trackType != reco::Muon::InnerTrack &&
-	     bestTrack->ptError()/bestTrack->pt()> errorCompScale_*trackWithSmallestError->ptError()/trackWithSmallestError->pt())  {
-      bestTrack = trackWithSmallestError;
-      trackType = trackPairWithSmallestError.second;
-      
-    }
-
-
-    changeTrack(candidate,std::make_pair(bestTrack,trackType));
-    candidate.setMuonRef( muon );
-
-    return true;
-}
-
-
-
-
-void  PFMuonAlgo::changeTrack(reco::PFCandidate& candidate,const MuonTrackTypePair& track) {
+  using namespace std;
   using namespace reco;
-    reco::TrackRef      bestTrack = track.first;
-    MuonTrackType trackType = track.second;
-    //OK Now redefine the canddiate with that track
-    double px = bestTrack->px();
-    double py = bestTrack->py();
-    double pz = bestTrack->pz();
-    double energy = sqrt(bestTrack->p()*bestTrack->p() + 0.1057*0.1057);
 
-    candidate.setCharge(bestTrack->charge()>0 ? 1 : -1);
-    candidate.setP4(math::XYZTLorentzVector(px,py,pz,energy));
-    candidate.setParticleType(reco::PFCandidate::mu);
-    //    candidate.setTrackRef( bestTrack );  
-    candidate.setMuonTrackType(trackType);
-    if(trackType == reco::Muon::InnerTrack)
-      candidate.setVertexSource( PFCandidate::kTrkMuonVertex );
-    else if(trackType == reco::Muon::CombinedTrack)
-      candidate.setVertexSource( PFCandidate::kComMuonVertex );
-    else if(trackType == reco::Muon::TPFMS)
-      candidate.setVertexSource( PFCandidate::kTPFMSMuonVertex );
-    else if(trackType == reco::Muon::Picky)
-      candidate.setVertexSource( PFCandidate::kPickyMuonVertex );
-    else if(trackType == reco::Muon::DYT)
-      candidate.setVertexSource( PFCandidate::kDYTMuonVertex );
+  if (!muon.isNonnull())
+    return false;
+
+  bool isMu = false;
+
+  if (allowLoose)
+    isMu = isMuon(muon) || isLooseMuon(muon);
+  else
+    isMu = isMuon(muon);
+
+  if (!isMu)
+    return false;
+
+  //get the valid tracks(without standalone except we allow loose muons)
+  //MIKE: Here we need to be careful. If we have a muon inside a dense
+  //jet environment often the track is badly measured. In this case
+  //we should not apply Dpt/Pt<1
+
+  std::vector<reco::Muon::MuonTrackTypePair> validTracks = goodMuonTracks(muon);
+  if (!allowLoose)
+    validTracks = goodMuonTracks(muon);
+  else
+    validTracks = muonTracks(muon);
+
+  if (validTracks.empty())
+    return false;
+
+  //check what is the track used.Rerun TuneP
+  reco::Muon::MuonTrackTypePair bestTrackPair = muon::tevOptimized(*muon);
+
+  TrackRef bestTrack = bestTrackPair.first;
+  MuonTrackType trackType = bestTrackPair.second;
+
+  MuonTrackTypePair trackPairWithSmallestError = getTrackWithSmallestError(validTracks);
+  TrackRef trackWithSmallestError = trackPairWithSmallestError.first;
+
+  if (trackType == reco::Muon::InnerTrack &&
+      (!bestTrack->quality(trackQuality_) ||
+       bestTrack->ptError() / bestTrack->pt() >
+           errorCompScale_ * trackWithSmallestError->ptError() / trackWithSmallestError->pt())) {
+    bestTrack = trackWithSmallestError;
+    trackType = trackPairWithSmallestError.second;
+  } else if (trackType != reco::Muon::InnerTrack &&
+             bestTrack->ptError() / bestTrack->pt() >
+                 errorCompScale_ * trackWithSmallestError->ptError() / trackWithSmallestError->pt()) {
+    bestTrack = trackWithSmallestError;
+    trackType = trackPairWithSmallestError.second;
   }
 
+  changeTrack(candidate, std::make_pair(bestTrack, trackType));
+  candidate.setMuonRef(muon);
 
-reco::Muon::MuonTrackTypePair 
-PFMuonAlgo::getTrackWithSmallestError(const std::vector<reco::Muon::MuonTrackTypePair>& tracks) {
-    TrackPtErrorSorter sorter;
-    return *std::min_element(tracks.begin(),tracks.end(),sorter);
+  return true;
 }
 
+void PFMuonAlgo::changeTrack(reco::PFCandidate& candidate, const MuonTrackTypePair& track) {
+  using namespace reco;
+  reco::TrackRef bestTrack = track.first;
+  MuonTrackType trackType = track.second;
+  //OK Now redefine the canddiate with that track
+  double px = bestTrack->px();
+  double py = bestTrack->py();
+  double pz = bestTrack->pz();
+  double energy = sqrt(bestTrack->p() * bestTrack->p() + 0.1057 * 0.1057);
 
+  candidate.setCharge(bestTrack->charge() > 0 ? 1 : -1);
+  candidate.setP4(math::XYZTLorentzVector(px, py, pz, energy));
+  candidate.setParticleType(reco::PFCandidate::mu);
+  //    candidate.setTrackRef( bestTrack );
+  candidate.setMuonTrackType(trackType);
+  if (trackType == reco::Muon::InnerTrack)
+    candidate.setVertexSource(PFCandidate::kTrkMuonVertex);
+  else if (trackType == reco::Muon::CombinedTrack)
+    candidate.setVertexSource(PFCandidate::kComMuonVertex);
+  else if (trackType == reco::Muon::TPFMS)
+    candidate.setVertexSource(PFCandidate::kTPFMSMuonVertex);
+  else if (trackType == reco::Muon::Picky)
+    candidate.setVertexSource(PFCandidate::kPickyMuonVertex);
+  else if (trackType == reco::Muon::DYT)
+    candidate.setVertexSource(PFCandidate::kDYTMuonVertex);
+}
 
+reco::Muon::MuonTrackTypePair PFMuonAlgo::getTrackWithSmallestError(
+    const std::vector<reco::Muon::MuonTrackTypePair>& tracks) {
+  TrackPtErrorSorter sorter;
+  return *std::min_element(tracks.begin(), tracks.end(), sorter);
+}
 
-
-void PFMuonAlgo::estimateEventQuantities(const reco::PFCandidateCollection* pfc)
-{
-  //SUM ET 
+void PFMuonAlgo::estimateEventQuantities(const reco::PFCandidateCollection* pfc) {
+  //SUM ET
   sumetPU_ = 0.0;
-  METX_=0.;
-  METY_=0.;
-  sumet_=0.0;
-  for(reco::PFCandidateCollection::const_iterator i = pfc->begin();i!=pfc->end();++i) {
-    sumet_+=i->pt();
-    METX_+=i->px();
-    METY_+=i->py();
+  METX_ = 0.;
+  METY_ = 0.;
+  sumet_ = 0.0;
+  for (reco::PFCandidateCollection::const_iterator i = pfc->begin(); i != pfc->end(); ++i) {
+    sumet_ += i->pt();
+    METX_ += i->px();
+    METY_ += i->py();
   }
-
 }
 
-
-
-
-
-void PFMuonAlgo::postClean(reco::PFCandidateCollection*  cands) {
+void PFMuonAlgo::postClean(reco::PFCandidateCollection* cands) {
   using namespace std;
   using namespace reco;
   if (!postCleaning_)
@@ -764,419 +656,384 @@ void PFMuonAlgo::postClean(reco::PFCandidateCollection*  cands) {
 
   //Initialize vectors
 
-  if(pfCosmicsMuonCleanedCandidates_.get() )
+  if (pfCosmicsMuonCleanedCandidates_.get())
     pfCosmicsMuonCleanedCandidates_->clear();
-  else 
-    pfCosmicsMuonCleanedCandidates_.reset( new reco::PFCandidateCollection );
+  else
+    pfCosmicsMuonCleanedCandidates_.reset(new reco::PFCandidateCollection);
 
-  if(pfCleanedTrackerAndGlobalMuonCandidates_.get() )
+  if (pfCleanedTrackerAndGlobalMuonCandidates_.get())
     pfCleanedTrackerAndGlobalMuonCandidates_->clear();
-  else 
-    pfCleanedTrackerAndGlobalMuonCandidates_.reset( new reco::PFCandidateCollection );
+  else
+    pfCleanedTrackerAndGlobalMuonCandidates_.reset(new reco::PFCandidateCollection);
 
-  if( pfFakeMuonCleanedCandidates_.get() )
-     pfFakeMuonCleanedCandidates_->clear();
-  else 
-     pfFakeMuonCleanedCandidates_.reset( new reco::PFCandidateCollection );
+  if (pfFakeMuonCleanedCandidates_.get())
+    pfFakeMuonCleanedCandidates_->clear();
+  else
+    pfFakeMuonCleanedCandidates_.reset(new reco::PFCandidateCollection);
 
+  if (pfPunchThroughMuonCleanedCandidates_.get())
+    pfPunchThroughMuonCleanedCandidates_->clear();
+  else
+    pfPunchThroughMuonCleanedCandidates_.reset(new reco::PFCandidateCollection);
 
-  if( pfPunchThroughMuonCleanedCandidates_.get() )
-     pfPunchThroughMuonCleanedCandidates_->clear();
-  else 
-     pfPunchThroughMuonCleanedCandidates_.reset( new reco::PFCandidateCollection );
-
-  if( pfPunchThroughHadronCleanedCandidates_.get() )
-     pfPunchThroughHadronCleanedCandidates_->clear();
-  else 
-     pfPunchThroughHadronCleanedCandidates_.reset( new reco::PFCandidateCollection );
-
-
+  if (pfPunchThroughHadronCleanedCandidates_.get())
+    pfPunchThroughHadronCleanedCandidates_->clear();
+  else
+    pfPunchThroughHadronCleanedCandidates_.reset(new reco::PFCandidateCollection);
 
   pfPunchThroughHadronCleanedCandidates_->clear();
-  
+
   maskedIndices_.clear();
 
   //Estimate MET and SumET
 
   estimateEventQuantities(cands);
 
-  
   std::vector<int> muons;
   std::vector<int> cosmics;
   //get the muons
-  for(unsigned int i=0;i<cands->size();++i)  {
+  for (unsigned int i = 0; i < cands->size(); ++i) {
     const reco::PFCandidate& cand = (*cands)[i];
-    if ( cand.particleId() == reco::PFCandidate::mu )
+    if (cand.particleId() == reco::PFCandidate::mu)
       muons.push_back(i);
-      
   }
   //Then sort the muon indicess by decsending pt
 
   IndexPtComparator comparator(cands);
-  std::sort(muons.begin(),muons.end(),comparator);
-
+  std::sort(muons.begin(), muons.end(), comparator);
 
   //first kill cosmics
-  double METXCosmics=0;
-  double METYCosmics=0;
-  double SUMETCosmics=0.0;
+  double METXCosmics = 0;
+  double METYCosmics = 0;
+  double SUMETCosmics = 0.0;
 
-  for(unsigned int i=0;i<muons.size();++i) {
+  for (unsigned int i = 0; i < muons.size(); ++i) {
     const PFCandidate& pfc = cands->at(muons[i]);
-    double origin=0.0;
-    if(!vertices_->empty()&& vertices_->at(0).isValid() && ! vertices_->at(0).isFake())
+    double origin = 0.0;
+    if (!vertices_->empty() && vertices_->at(0).isValid() && !vertices_->at(0).isFake())
       origin = pfc.muonRef()->muonBestTrack()->dxy(vertices_->at(0).position());
 
-    if( origin> cosmicRejDistance_) {
+    if (origin > cosmicRejDistance_) {
       cosmics.push_back(muons[i]);
-      METXCosmics +=pfc.px();
-      METYCosmics +=pfc.py();
-      SUMETCosmics +=pfc.pt();
+      METXCosmics += pfc.px();
+      METYCosmics += pfc.py();
+      SUMETCosmics += pfc.pt();
     }
   }
-  double MET2Cosmics = METXCosmics*METXCosmics+METYCosmics*METYCosmics;
+  double MET2Cosmics = METXCosmics * METXCosmics + METYCosmics * METYCosmics;
 
-  if ( SUMETCosmics > (sumet_-sumetPU_)/eventFactorCosmics_ && MET2Cosmics < METX_*METX_+ METY_*METY_)
-    for(unsigned int i=0;i<cosmics.size();++i) {
+  if (SUMETCosmics > (sumet_ - sumetPU_) / eventFactorCosmics_ && MET2Cosmics < METX_ * METX_ + METY_ * METY_)
+    for (unsigned int i = 0; i < cosmics.size(); ++i) {
       maskedIndices_.push_back(cosmics[i]);
       pfCosmicsMuonCleanedCandidates_->push_back(cands->at(cosmics[i]));
     }
 
   //Loop on the muons candidates and clean
-  for(unsigned int i=0;i<muons.size();++i) {  
-    if( cleanMismeasured(cands->at(muons[i]),muons[i]))
+  for (unsigned int i = 0; i < muons.size(); ++i) {
+    if (cleanMismeasured(cands->at(muons[i]), muons[i]))
       continue;
-    cleanPunchThroughAndFakes(cands->at(muons[i]),cands,muons[i]);
-  
+    cleanPunchThroughAndFakes(cands->at(muons[i]), cands, muons[i]);
   }
 
-
-
-  //OK Now do the hard job ->remove the candidates that were cleaned 
-  removeDeadCandidates(cands,maskedIndices_);
-
-
-
-
+  //OK Now do the hard job ->remove the candidates that were cleaned
+  removeDeadCandidates(cands, maskedIndices_);
 }
 
 void PFMuonAlgo::addMissingMuons(edm::Handle<reco::MuonCollection> muons, reco::PFCandidateCollection* cands) {
-  if(!postCleaning_)
+  if (!postCleaning_)
     return;
 
+  if (pfAddedMuonCandidates_.get())
+    pfAddedMuonCandidates_->clear();
+  else
+    pfAddedMuonCandidates_.reset(new reco::PFCandidateCollection);
 
-  if( pfAddedMuonCandidates_.get() )
-     pfAddedMuonCandidates_->clear();
-  else 
-     pfAddedMuonCandidates_.reset( new reco::PFCandidateCollection );
-
-
-
-  for ( unsigned imu = 0; imu < muons->size(); ++imu ) {
-    reco::MuonRef muonRef( muons, imu );
+  for (unsigned imu = 0; imu < muons->size(); ++imu) {
+    reco::MuonRef muonRef(muons, imu);
     bool used = false;
     bool hadron = false;
-    for(unsigned i=0; i<cands->size(); i++) {
+    for (unsigned i = 0; i < cands->size(); i++) {
       const PFCandidate& pfc = cands->at(i);
-      if ( !pfc.trackRef().isNonnull() ) continue;
-      if ( pfc.trackRef().isNonnull() && pfc.trackRef() == muonRef->track() )
-	hadron = true;
-      if ( !pfc.muonRef().isNonnull() ) continue;
+      if (!pfc.trackRef().isNonnull())
+        continue;
+      if (pfc.trackRef().isNonnull() && pfc.trackRef() == muonRef->track())
+        hadron = true;
+      if (!pfc.muonRef().isNonnull())
+        continue;
 
-      if ( pfc.muonRef()->innerTrack() == muonRef->innerTrack())
-	used = true;
+      if (pfc.muonRef()->innerTrack() == muonRef->innerTrack())
+        used = true;
       else {
-	// Check if the stand-alone muon is not a spurious copy of an existing muon 
-	// (Protection needed for HLT)
-	if ( pfc.muonRef()->isStandAloneMuon() && muonRef->isStandAloneMuon() ) { 
-	  double dEta = pfc.muonRef()->standAloneMuon()->eta() - muonRef->standAloneMuon()->eta();
-	  double dPhi = pfc.muonRef()->standAloneMuon()->phi() - muonRef->standAloneMuon()->phi();
-	  double dR = sqrt(dEta*dEta + dPhi*dPhi);
-	  if ( dR < 0.005 ) { 
-	    used = true;
-	  }
-	}
+        // Check if the stand-alone muon is not a spurious copy of an existing muon
+        // (Protection needed for HLT)
+        if (pfc.muonRef()->isStandAloneMuon() && muonRef->isStandAloneMuon()) {
+          double dEta = pfc.muonRef()->standAloneMuon()->eta() - muonRef->standAloneMuon()->eta();
+          double dPhi = pfc.muonRef()->standAloneMuon()->phi() - muonRef->standAloneMuon()->phi();
+          double dR = sqrt(dEta * dEta + dPhi * dPhi);
+          if (dR < 0.005) {
+            used = true;
+          }
+        }
       }
-  
-    if ( used ) break; 
+
+      if (used)
+        break;
     }
 
-    if ( used ||hadron||(!muonRef.isNonnull()) ) continue;
+    if (used || hadron || (!muonRef.isNonnull()))
+      continue;
 
-
-    TrackMETComparator comparator(METX_,METY_);
+    TrackMETComparator comparator(METX_, METY_);
     //Low pt dont need to be cleaned
-  
-    std::vector<reco::Muon::MuonTrackTypePair> tracks  = goodMuonTracks(muonRef,true);
-    //If there is at least 1 track choice  try to change the track 
-    if(!tracks.empty()) {
 
-    //Find tracks that change dramatically MET or Pt
-    std::vector<reco::Muon::MuonTrackTypePair> tracksThatChangeMET = tracksPointingAtMET(tracks);
-    //From those tracks get the one with smallest MET 
-    if (!tracksThatChangeMET.empty()) {
-      reco::Muon::MuonTrackTypePair bestTrackType = *std::min_element(tracksThatChangeMET.begin(),tracksThatChangeMET.end(),comparator);
+    std::vector<reco::Muon::MuonTrackTypePair> tracks = goodMuonTracks(muonRef, true);
+    //If there is at least 1 track choice  try to change the track
+    if (!tracks.empty()) {
+      //Find tracks that change dramatically MET or Pt
+      std::vector<reco::Muon::MuonTrackTypePair> tracksThatChangeMET = tracksPointingAtMET(tracks);
+      //From those tracks get the one with smallest MET
+      if (!tracksThatChangeMET.empty()) {
+        reco::Muon::MuonTrackTypePair bestTrackType =
+            *std::min_element(tracksThatChangeMET.begin(), tracksThatChangeMET.end(), comparator);
 
-      //Make sure it is not cosmic
-      if((vertices_->empty()) ||bestTrackType.first->dz(vertices_->at(0).position())<cosmicRejDistance_){
-	
-	//make a pfcandidate
-	int charge = bestTrackType.first->charge()>0 ? 1 : -1;
-	math::XYZTLorentzVector momentum(bestTrackType.first->px(),
-					 bestTrackType.first->py(),
-					 bestTrackType.first->pz(),
-				       sqrt(bestTrackType.first->p()*bestTrackType.first->p()+0.1057*0.1057));
-      
-	cands->push_back( PFCandidate( charge, 
-				      momentum,
-				      reco::PFCandidate::mu ) );
+        //Make sure it is not cosmic
+        if ((vertices_->empty()) || bestTrackType.first->dz(vertices_->at(0).position()) < cosmicRejDistance_) {
+          //make a pfcandidate
+          int charge = bestTrackType.first->charge() > 0 ? 1 : -1;
+          math::XYZTLorentzVector momentum(bestTrackType.first->px(),
+                                           bestTrackType.first->py(),
+                                           bestTrackType.first->pz(),
+                                           sqrt(bestTrackType.first->p() * bestTrackType.first->p() + 0.1057 * 0.1057));
 
-	changeTrack(cands->back(),bestTrackType);
+          cands->push_back(PFCandidate(charge, momentum, reco::PFCandidate::mu));
 
-	if (muonRef->track().isNonnull() ) 
-	  cands->back().setTrackRef( muonRef->track() );
+          changeTrack(cands->back(), bestTrackType);
 
-	cands->back().setMuonRef(muonRef);
+          if (muonRef->track().isNonnull())
+            cands->back().setTrackRef(muonRef->track());
 
+          cands->back().setMuonRef(muonRef);
 
-	pfAddedMuonCandidates_->push_back(cands->back());
-
+          pfAddedMuonCandidates_->push_back(cands->back());
+        }
       }
-    }
     }
   }
 }
 
-std::pair<double,double> 
-PFMuonAlgo::getMinMaxMET2(const reco::PFCandidate&pfc) {
-  std::vector<reco::Muon::MuonTrackTypePair> tracks  = goodMuonTracks((pfc.muonRef()),true);
+std::pair<double, double> PFMuonAlgo::getMinMaxMET2(const reco::PFCandidate& pfc) {
+  std::vector<reco::Muon::MuonTrackTypePair> tracks = goodMuonTracks((pfc.muonRef()), true);
 
-  double METXNO = METX_-pfc.px();
-  double METYNO = METY_-pfc.py();
+  double METXNO = METX_ - pfc.px();
+  double METYNO = METY_ - pfc.py();
   std::vector<double> met2;
-  for (unsigned int i=0;i<tracks.size();++i) {
-    met2.push_back(pow(METXNO+tracks.at(i).first->px(),2)+pow(METYNO+tracks.at(i).first->py(),2));
+  for (unsigned int i = 0; i < tracks.size(); ++i) {
+    met2.push_back(pow(METXNO + tracks.at(i).first->px(), 2) + pow(METYNO + tracks.at(i).first->py(), 2));
   }
 
   //PROTECT for cases of only one track. If there is only one track it will crash .
   //Has never happened but could likely happen!
 
-  if(tracks.size()>1)
-    return std::make_pair(*std::min_element(met2.begin(),met2.end()),*std::max_element(met2.begin(),met2.end()));
+  if (tracks.size() > 1)
+    return std::make_pair(*std::min_element(met2.begin(), met2.end()), *std::max_element(met2.begin(), met2.end()));
   else
-    return std::make_pair(0,0);
+    return std::make_pair(0, 0);
 }
 
-
-bool PFMuonAlgo::cleanMismeasured(reco::PFCandidate& pfc,unsigned int i ){
+bool PFMuonAlgo::cleanMismeasured(reco::PFCandidate& pfc, unsigned int i) {
   using namespace std;
   using namespace reco;
-  bool cleaned=false;
+  bool cleaned = false;
 
   //First define the MET without this guy
   double METNOX = METX_ - pfc.px();
   double METNOY = METY_ - pfc.py();
-  double SUMETNO = sumet_  -pfc.pt(); 
-  
-  TrackMETComparator comparator(METNOX,METNOY);
+  double SUMETNO = sumet_ - pfc.pt();
+
+  TrackMETComparator comparator(METNOX, METNOY);
   //Low pt dont need to be cleaned
-  if (pfc.pt()<minPostCleaningPt_)
+  if (pfc.pt() < minPostCleaningPt_)
     return false;
-  std::vector<reco::Muon::MuonTrackTypePair> tracks  = goodMuonTracks(pfc.muonRef(),false);
-  
+  std::vector<reco::Muon::MuonTrackTypePair> tracks = goodMuonTracks(pfc.muonRef(), false);
 
-
-  //If there is more than 1 track choice  try to change the track 
-  if(tracks.size()>1) {
+  //If there is more than 1 track choice  try to change the track
+  if (tracks.size() > 1) {
     //Find tracks that change dramatically MET or Pt
-    std::vector<reco::Muon::MuonTrackTypePair> tracksThatChangeMET = tracksWithBetterMET(tracks,pfc);
-    //From those tracks get the one with smallest MET 
+    std::vector<reco::Muon::MuonTrackTypePair> tracksThatChangeMET = tracksWithBetterMET(tracks, pfc);
+    //From those tracks get the one with smallest MET
     if (!tracksThatChangeMET.empty()) {
-      reco::Muon::MuonTrackTypePair bestTrackType = *std::min_element(tracksThatChangeMET.begin(),tracksThatChangeMET.end(),comparator);
-      changeTrack(pfc,bestTrackType);
+      reco::Muon::MuonTrackTypePair bestTrackType =
+          *std::min_element(tracksThatChangeMET.begin(), tracksThatChangeMET.end(), comparator);
+      changeTrack(pfc, bestTrackType);
 
       pfCleanedTrackerAndGlobalMuonCandidates_->push_back(pfc);
       //update eventquantities
-      METX_ = METNOX+pfc.px();
-      METY_ = METNOY+pfc.py();
-      sumet_=SUMETNO+pfc.pt();
-
-    }      
+      METX_ = METNOX + pfc.px();
+      METY_ = METNOY + pfc.py();
+      sumet_ = SUMETNO + pfc.pt();
+    }
   }
 
-  //Now attempt to kill it 
+  //Now attempt to kill it
   if (!(pfc.muonRef()->isGlobalMuon() && pfc.muonRef()->isTrackerMuon())) {
     //define MET significance and SUM ET
-    double MET2 = METX_*METX_+METY_*METY_;
-    double newMET2 = METNOX*METNOX+METNOY*METNOY;
-    double METSig = sqrt(MET2)/sqrt(sumet_-sumetPU_);
-    if( METSig>metSigForRejection_)
-      if((newMET2 < MET2/metFactorRejection_) &&
-	 ((SUMETNO-sumetPU_)/(sumet_-sumetPU_)<eventFractionRejection_)) {
-	   pfFakeMuonCleanedCandidates_->push_back(pfc);
-	   maskedIndices_.push_back(i);
-	   METX_ = METNOX;
-	   METY_ = METNOY;
-	   sumet_=SUMETNO;
-	   cleaned=true;
+    double MET2 = METX_ * METX_ + METY_ * METY_;
+    double newMET2 = METNOX * METNOX + METNOY * METNOY;
+    double METSig = sqrt(MET2) / sqrt(sumet_ - sumetPU_);
+    if (METSig > metSigForRejection_)
+      if ((newMET2 < MET2 / metFactorRejection_) &&
+          ((SUMETNO - sumetPU_) / (sumet_ - sumetPU_) < eventFractionRejection_)) {
+        pfFakeMuonCleanedCandidates_->push_back(pfc);
+        maskedIndices_.push_back(i);
+        METX_ = METNOX;
+        METY_ = METNOY;
+        sumet_ = SUMETNO;
+        cleaned = true;
+      }
+  }
+  return cleaned;
+}
+
+std::vector<reco::Muon::MuonTrackTypePair> PFMuonAlgo::tracksWithBetterMET(
+    const std::vector<reco::Muon::MuonTrackTypePair>& tracks, const reco::PFCandidate& pfc) {
+  std::vector<reco::Muon::MuonTrackTypePair> outputTracks;
+
+  double METNOX = METX_ - pfc.px();
+  double METNOY = METY_ - pfc.py();
+  double SUMETNO = sumet_ - pfc.pt();
+  double MET2 = METX_ * METX_ + METY_ * METY_;
+  double newMET2 = 0.0;
+  double newSUMET = 0.0;
+  double METSIG = sqrt(MET2) / sqrt(sumet_ - sumetPU_);
+
+  if (METSIG > metSigForCleaning_)
+    for (unsigned int i = 0; i < tracks.size(); ++i) {
+      //calculate new SUM ET and MET2
+      newSUMET = SUMETNO + tracks.at(i).first->pt() - sumetPU_;
+      newMET2 = pow(METNOX + tracks.at(i).first->px(), 2) + pow(METNOY + tracks.at(i).first->py(), 2);
+
+      if (newSUMET / (sumet_ - sumetPU_) > eventFractionCleaning_ && newMET2 < MET2 / metFactorCleaning_)
+        outputTracks.push_back(tracks.at(i));
     }
-    
-  }
-    return cleaned;
 
-}
-      
-std::vector<reco::Muon::MuonTrackTypePair> 
-PFMuonAlgo::tracksWithBetterMET(const std::vector<reco::Muon::MuonTrackTypePair>& tracks ,const reco::PFCandidate& pfc) {
-  std::vector<reco::Muon::MuonTrackTypePair> outputTracks;
-
-  double METNOX  = METX_ - pfc.px();
-  double METNOY  = METY_ - pfc.py();
-  double SUMETNO = sumet_  -pfc.pt(); 
-  double MET2 = METX_*METX_+METY_*METY_;
-  double newMET2=0.0;
-  double newSUMET=0.0;
-  double METSIG = sqrt(MET2)/sqrt(sumet_-sumetPU_);
-
-
-  if(METSIG>metSigForCleaning_)
-  for( unsigned int i=0;i<tracks.size();++i) {
-    //calculate new SUM ET and MET2
-    newSUMET = SUMETNO+tracks.at(i).first->pt()-sumetPU_;
-    newMET2  = pow(METNOX+tracks.at(i).first->px(),2)+pow(METNOY+tracks.at(i).first->py(),2);
-    
-    if(newSUMET/(sumet_-sumetPU_)>eventFractionCleaning_ &&  newMET2<MET2/metFactorCleaning_)
-      outputTracks.push_back(tracks.at(i));
-  }
-  
-  
   return outputTracks;
 }
 
-
-std::vector<reco::Muon::MuonTrackTypePair> 
-PFMuonAlgo::tracksPointingAtMET(const std::vector<reco::Muon::MuonTrackTypePair>& tracks) {
+std::vector<reco::Muon::MuonTrackTypePair> PFMuonAlgo::tracksPointingAtMET(
+    const std::vector<reco::Muon::MuonTrackTypePair>& tracks) {
   std::vector<reco::Muon::MuonTrackTypePair> outputTracks;
 
+  double newMET2 = 0.0;
 
-  double newMET2=0.0;
-
-  for( unsigned int i=0;i<tracks.size();++i) {
+  for (unsigned int i = 0; i < tracks.size(); ++i) {
     //calculate new SUM ET and MET2
-    newMET2  = pow(METX_+tracks.at(i).first->px(),2)+pow(METY_+tracks.at(i).first->py(),2);
-    
-    if(newMET2<(METX_*METX_+METY_*METY_)/metFactorCleaning_)
+    newMET2 = pow(METX_ + tracks.at(i).first->px(), 2) + pow(METY_ + tracks.at(i).first->py(), 2);
+
+    if (newMET2 < (METX_ * METX_ + METY_ * METY_) / metFactorCleaning_)
       outputTracks.push_back(tracks.at(i));
   }
-  
-  
+
   return outputTracks;
 }
-  
 
-  
-void PFMuonAlgo::setInputsForCleaning(reco::VertexCollection const&  vertices) { vertices_ = &vertices; }
+void PFMuonAlgo::setInputsForCleaning(reco::VertexCollection const& vertices) { vertices_ = &vertices; }
 
-bool PFMuonAlgo::cleanPunchThroughAndFakes(reco::PFCandidate&pfc,reco::PFCandidateCollection* cands,unsigned int imu ){
+bool PFMuonAlgo::cleanPunchThroughAndFakes(reco::PFCandidate& pfc,
+                                           reco::PFCandidateCollection* cands,
+                                           unsigned int imu) {
   using namespace reco;
 
-  bool cleaned=false;
+  bool cleaned = false;
 
-  if (pfc.pt()<minPostCleaningPt_)
+  if (pfc.pt() < minPostCleaningPt_)
     return false;
 
+  double METXNO = METX_ - pfc.pt();
+  double METYNO = METY_ - pfc.pt();
+  double MET2NO = METXNO * METXNO + METYNO * METYNO;
+  double MET2 = METX_ * METX_ + METY_ * METY_;
+  bool fake1 = false;
 
-  double METXNO = METX_-pfc.pt();
-  double METYNO = METY_-pfc.pt();
-  double MET2NO = METXNO*METXNO+METYNO*METYNO;
-  double MET2   = METX_*METX_+METY_*METY_;
-  bool fake1=false;
-
-  std::pair<double,double> met2 = getMinMaxMET2(pfc);
+  std::pair<double, double> met2 = getMinMaxMET2(pfc);
 
   //Check for Fakes at high pseudorapidity
-  if(pfc.muonRef()->standAloneMuon().isNonnull()) 
-    fake1 =fabs ( pfc.eta() ) > 2.15 && 
-      met2.first<met2.second/2 &&
-      MET2NO < MET2/metFactorHighEta_ && 
-      pfc.muonRef()->standAloneMuon()->pt() < pfc.pt()/ptFactorHighEta_;
+  if (pfc.muonRef()->standAloneMuon().isNonnull())
+    fake1 = fabs(pfc.eta()) > 2.15 && met2.first < met2.second / 2 && MET2NO < MET2 / metFactorHighEta_ &&
+            pfc.muonRef()->standAloneMuon()->pt() < pfc.pt() / ptFactorHighEta_;
 
-  double factor = std::max(2.,2000./(sumet_-pfc.pt()-sumetPU_));
-  bool fake2 = ( pfc.pt()/(sumet_-sumetPU_) < 0.25 && MET2NO < MET2/metFactorFake_ && met2.first<met2.second/factor );
+  double factor = std::max(2., 2000. / (sumet_ - pfc.pt() - sumetPU_));
+  bool fake2 =
+      (pfc.pt() / (sumet_ - sumetPU_) < 0.25 && MET2NO < MET2 / metFactorFake_ && met2.first < met2.second / factor);
 
-  bool punchthrough =pfc.p() > minPunchThroughMomentum_ &&  
-    pfc.rawHcalEnergy() > minPunchThroughEnergy_ && 
-    pfc.rawEcalEnergy()+pfc.rawHcalEnergy() > pfc.p()/punchThroughFactor_ &&
-    !isIsolatedMuon(pfc.muonRef()) && MET2NO < MET2/punchThroughMETFactor_;
+  bool punchthrough = pfc.p() > minPunchThroughMomentum_ && pfc.rawHcalEnergy() > minPunchThroughEnergy_ &&
+                      pfc.rawEcalEnergy() + pfc.rawHcalEnergy() > pfc.p() / punchThroughFactor_ &&
+                      !isIsolatedMuon(pfc.muonRef()) && MET2NO < MET2 / punchThroughMETFactor_;
 
-
-  if(fake1 || fake2||punchthrough) {
+  if (fake1 || fake2 || punchthrough) {
     // Find the block of the muon
     const PFCandidate::ElementsInBlocks& eleInBlocks = pfc.elementsInBlocks();
-    if ( !eleInBlocks.empty() ) { 
+    if (!eleInBlocks.empty()) {
       PFBlockRef blockRefMuon = eleInBlocks[0].first;
       unsigned indexMuon = eleInBlocks[0].second;
-      if (eleInBlocks.size()>1)
-	indexMuon = eleInBlocks[1].second;
-	  
+      if (eleInBlocks.size() > 1)
+        indexMuon = eleInBlocks[1].second;
+
       // Check if the muon gave rise to a neutral hadron
       double iHad = 1E9;
       bool hadron = false;
-      for ( unsigned i = imu+1; i < cands->size(); ++i ) { 
-	const PFCandidate& pfcn = cands->at(i);
-	    const PFCandidate::ElementsInBlocks& ele = pfcn.elementsInBlocks();
-	    if ( ele.empty() ) { 
-	      continue;
-	    }
-	    PFBlockRef blockRefHadron = ele[0].first;
-	    unsigned indexHadron = ele[0].second;
-	    // We are out of the block -> exit the loop
-	    if ( blockRefHadron.key() != blockRefMuon.key() ) break;
-	    // Check that this particle is a neutral hadron
-	    if ( indexHadron == indexMuon && 
-		 pfcn.particleId() == reco::PFCandidate::h0 ) {
-	      iHad = i;
-	      hadron = true;
-	    }
-	    if ( hadron ) break;
-	  }
-	  
-	  if ( hadron ) { 
+      for (unsigned i = imu + 1; i < cands->size(); ++i) {
+        const PFCandidate& pfcn = cands->at(i);
+        const PFCandidate::ElementsInBlocks& ele = pfcn.elementsInBlocks();
+        if (ele.empty()) {
+          continue;
+        }
+        PFBlockRef blockRefHadron = ele[0].first;
+        unsigned indexHadron = ele[0].second;
+        // We are out of the block -> exit the loop
+        if (blockRefHadron.key() != blockRefMuon.key())
+          break;
+        // Check that this particle is a neutral hadron
+        if (indexHadron == indexMuon && pfcn.particleId() == reco::PFCandidate::h0) {
+          iHad = i;
+          hadron = true;
+        }
+        if (hadron)
+          break;
+      }
 
-    double rescaleFactor = cands->at(iHad).p()/cands->at(imu).p();
-	    METX_ -=  cands->at(imu).px() + cands->at(iHad).px();
-	    METY_ -=  cands->at(imu).py() + cands->at(iHad).py();
-	    sumet_ -=cands->at(imu).pt();
-	    cands->at(imu).rescaleMomentum(rescaleFactor);
-	    maskedIndices_.push_back(iHad);
-	    pfPunchThroughHadronCleanedCandidates_->push_back(cands->at(iHad));
-	    cands->at(imu).setParticleType(reco::PFCandidate::h);
-	    pfPunchThroughMuonCleanedCandidates_->push_back(cands->at(imu));
-	    METX_ +=  cands->at(imu).px();
-	    METY_ +=  cands->at(imu).py();	  
-	    sumet_ += cands->at(imu).pt();
+      if (hadron) {
+        double rescaleFactor = cands->at(iHad).p() / cands->at(imu).p();
+        METX_ -= cands->at(imu).px() + cands->at(iHad).px();
+        METY_ -= cands->at(imu).py() + cands->at(iHad).py();
+        sumet_ -= cands->at(imu).pt();
+        cands->at(imu).rescaleMomentum(rescaleFactor);
+        maskedIndices_.push_back(iHad);
+        pfPunchThroughHadronCleanedCandidates_->push_back(cands->at(iHad));
+        cands->at(imu).setParticleType(reco::PFCandidate::h);
+        pfPunchThroughMuonCleanedCandidates_->push_back(cands->at(imu));
+        METX_ += cands->at(imu).px();
+        METY_ += cands->at(imu).py();
+        sumet_ += cands->at(imu).pt();
 
-	  } else if ( fake1 || fake2 ) {
-	    METX_ -=  cands->at(imu).px();
-	    METY_ -=  cands->at(imu).py();	  
-	    sumet_ -= cands->at(imu).pt();
-	    maskedIndices_.push_back(imu);
-	    pfFakeMuonCleanedCandidates_->push_back(cands->at(imu));
-	    cleaned=true;
-	  }
+      } else if (fake1 || fake2) {
+        METX_ -= cands->at(imu).px();
+        METY_ -= cands->at(imu).py();
+        sumet_ -= cands->at(imu).pt();
+        maskedIndices_.push_back(imu);
+        pfFakeMuonCleanedCandidates_->push_back(cands->at(imu));
+        cleaned = true;
+      }
     }
   }
   return cleaned;
 }
 
-
-void  PFMuonAlgo::removeDeadCandidates(reco::PFCandidateCollection* obj, const std::vector<unsigned int>& indices)
-{
+void PFMuonAlgo::removeDeadCandidates(reco::PFCandidateCollection* obj, const std::vector<unsigned int>& indices) {
   size_t N = indices.size();
   size_t collSize = obj->size();
 
-  for (size_t i = 0 ; i < N ; ++i)
-    obj->at(indices.at(i)) = obj->at(collSize-i-1);
+  for (size_t i = 0; i < N; ++i)
+    obj->at(indices.at(i)) = obj->at(collSize - i - 1);
 
   obj->resize(collSize - indices.size());
 }

--- a/RecoParticleFlow/PFProducer/src/PhotonSelectorAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PhotonSelectorAlgo.cc
@@ -1,58 +1,66 @@
-// 
+//
 // Original Authors: Nicholas Wardle, Florian Beaudette
 //
 #include "RecoParticleFlow/PFProducer/interface/PhotonSelectorAlgo.h"
 
-PhotonSelectorAlgo::PhotonSelectorAlgo(
-				       float choice,
-				       float c_Et,
-				       float c_iso_track_a, float c_iso_track_b,
-				       float c_iso_ecal_a, float c_iso_ecal_b,
-				       float c_iso_hcal_a, float c_iso_hcal_b,
-				       float c_hoe,
-				       float comb_iso,
-				       float loose_hoe
-				       ):
-  choice_(choice),
-  c_Et_(c_Et),
-  c_iso_track_a_(c_iso_track_a),  c_iso_track_b_(c_iso_track_b),
-  c_iso_ecal_a_(c_iso_ecal_a),  c_iso_ecal_b_(c_iso_ecal_b),
-  c_iso_hcal_a_(c_iso_hcal_a), c_iso_hcal_b_(c_iso_hcal_b),
-  c_hoe_(c_hoe),
-  comb_iso_(comb_iso),
-  loose_hoe_(loose_hoe)
-{
+PhotonSelectorAlgo::PhotonSelectorAlgo(float choice,
+                                       float c_Et,
+                                       float c_iso_track_a,
+                                       float c_iso_track_b,
+                                       float c_iso_ecal_a,
+                                       float c_iso_ecal_b,
+                                       float c_iso_hcal_a,
+                                       float c_iso_hcal_b,
+                                       float c_hoe,
+                                       float comb_iso,
+                                       float loose_hoe)
+    : choice_(choice),
+      c_Et_(c_Et),
+      c_iso_track_a_(c_iso_track_a),
+      c_iso_track_b_(c_iso_track_b),
+      c_iso_ecal_a_(c_iso_ecal_a),
+      c_iso_ecal_b_(c_iso_ecal_b),
+      c_iso_hcal_a_(c_iso_hcal_a),
+      c_iso_hcal_b_(c_iso_hcal_b),
+      c_hoe_(c_hoe),
+      comb_iso_(comb_iso),
+      loose_hoe_(loose_hoe) {
   ;
 }
 
-bool PhotonSelectorAlgo::passPhotonSelection(const reco::Photon & photon) const {
-
+bool PhotonSelectorAlgo::passPhotonSelection(const reco::Photon& photon) const {
   // Photon ET
-  float photonPt=photon.pt();
-  if( photonPt < c_Et_ ) return false;
-  if(choice_<0.1) //EGM Loose
-    {
-      //std::cout<<"Cuts:"<<c_Et_<<" H/E "<<c_hoe_<<"ECal Iso "<<c_iso_ecal_a_<<"HCal Iso "<<c_iso_hcal_a_<<"Track Iso "<<c_iso_track_a_<<std::endl;
-      // HoE
-      if (photon.hadronicOverEm() > c_hoe_ ) return false;
-      
-      // Track iso
-      if( photon.trkSumPtHollowConeDR04() > c_iso_track_a_ + c_iso_track_b_*photonPt) return false;
-      
-      // ECAL iso
-      if (photon.ecalRecHitSumEtConeDR04() > c_iso_ecal_a_ + c_iso_ecal_b_*photonPt) return false;
-      
-      // HCAL iso
-      if (photon.hcalTowerSumEtConeDR04() > c_iso_hcal_a_ + c_iso_hcal_b_*photonPt) return false ;
-    }
-  if(choice_>0.99)
-    {
-      
-      //std::cout<<"Cuts "<<comb_iso_<<" H/E "<<loose_hoe_<<std::endl;
-      if (photon.hadronicOverEm() >loose_hoe_ ) return false;
-      //Isolation variables in 0.3 cone combined
-        if(photon.trkSumPtHollowConeDR03()+photon.ecalRecHitSumEtConeDR03()+photon.hcalTowerSumEtConeDR03()>comb_iso_)return false;		
-    }
+  float photonPt = photon.pt();
+  if (photonPt < c_Et_)
+    return false;
+  if (choice_ < 0.1)  //EGM Loose
+  {
+    //std::cout<<"Cuts:"<<c_Et_<<" H/E "<<c_hoe_<<"ECal Iso "<<c_iso_ecal_a_<<"HCal Iso "<<c_iso_hcal_a_<<"Track Iso "<<c_iso_track_a_<<std::endl;
+    // HoE
+    if (photon.hadronicOverEm() > c_hoe_)
+      return false;
+
+    // Track iso
+    if (photon.trkSumPtHollowConeDR04() > c_iso_track_a_ + c_iso_track_b_ * photonPt)
+      return false;
+
+    // ECAL iso
+    if (photon.ecalRecHitSumEtConeDR04() > c_iso_ecal_a_ + c_iso_ecal_b_ * photonPt)
+      return false;
+
+    // HCAL iso
+    if (photon.hcalTowerSumEtConeDR04() > c_iso_hcal_a_ + c_iso_hcal_b_ * photonPt)
+      return false;
+  }
+  if (choice_ > 0.99) {
+    //std::cout<<"Cuts "<<comb_iso_<<" H/E "<<loose_hoe_<<std::endl;
+    if (photon.hadronicOverEm() > loose_hoe_)
+      return false;
+    //Isolation variables in 0.3 cone combined
+    if (photon.trkSumPtHollowConeDR03() + photon.ecalRecHitSumEtConeDR03() + photon.hcalTowerSumEtConeDR03() >
+        comb_iso_)
+      return false;
+  }
 
   return true;
 }

--- a/RecoParticleFlow/PFProducer/src/combination.hpp
+++ b/RecoParticleFlow/PFProducer/src/combination.hpp
@@ -17,66 +17,63 @@ Dec 27, 2018:  Removed code not used, changed namespace to notboost since this w
 
 namespace notboost {
 
-namespace detail {
+  namespace detail {
 
-template<class BidirectionalIterator> 
-  bool next_combination(BidirectionalIterator first1,
-                        BidirectionalIterator last1,
-                        BidirectionalIterator first2,
-                        BidirectionalIterator last2)
-  {
+    template <class BidirectionalIterator>
+    bool next_combination(BidirectionalIterator first1,
+                          BidirectionalIterator last1,
+                          BidirectionalIterator first2,
+                          BidirectionalIterator last2) {
       if ((first1 == last1) || (first2 == last2)) {
-          return false;
+        return false;
       }
-      
+
       BidirectionalIterator m1 = last1;
-      BidirectionalIterator m2 = last2; --m2;
-      
+      BidirectionalIterator m2 = last2;
+      --m2;
+
       // Find first m1 not less than *m2 (i.e., lower_bound(first1, last1, *m2)).
       // Actually, this loop stops at one position before that, except perhaps
       // if m1 == first1 (in which case one must compare *first1 with *m2).
       while (--m1 != first1 && !(*m1 < *m2)) {
       }
-      
+
       // Test if all elements in [first1, last1) not less than *m2.
       bool result = (m1 == first1) && !(*first1 < *m2);
-      
-      if (!result) {
 
-          // Find first first2 greater than *m1 (since *m1 < *m2, we know it
-          // can't pass m2 and there's no need to test m2).
-          while (first2 != m2 && !(*m1 < *first2)) {
-              ++first2;
-          }
-          
-          first1 = m1;
-          std::iter_swap (first1, first2);
-          ++first1;
+      if (!result) {
+        // Find first first2 greater than *m1 (since *m1 < *m2, we know it
+        // can't pass m2 and there's no need to test m2).
+        while (first2 != m2 && !(*m1 < *first2)) {
           ++first2;
+        }
+
+        first1 = m1;
+        std::iter_swap(first1, first2);
+        ++first1;
+        ++first2;
       }
-      
+
       // Merge [first1, last1) with [first2, last2), given that the rest of the
       // original ranges are sorted and compare appropriately.
-      if ((first1 != last1) && (first2 != last2)) {      
-          for (m1 = last1, m2 = first2;  (m1 != first1) && (m2 != last2); ++m2) {
-              std::iter_swap (--m1, m2);
-          }
-          
-          std::reverse (first1, m1);
-          std::reverse (first1, last1);
-          
-          std::reverse (m2, last2);
-          std::reverse (first2, last2);
+      if ((first1 != last1) && (first2 != last2)) {
+        for (m1 = last1, m2 = first2; (m1 != first1) && (m2 != last2); ++m2) {
+          std::iter_swap(--m1, m2);
+        }
+
+        std::reverse(first1, m1);
+        std::reverse(first1, last1);
+
+        std::reverse(m2, last2);
+        std::reverse(first2, last2);
       }
-      
+
       return !result;
-  }
-      
-}  // namespace detail
+    }
 
+  }  // namespace detail
 
-
-/* PROPOSED STANDARD EXTENSIONS:
+  /* PROPOSED STANDARD EXTENSIONS:
  *
  * template<class BidirectionalIterator> 
  *   bool next_combination(BidirectionalIterator first,
@@ -85,14 +82,11 @@ template<class BidirectionalIterator>
  *
  */
 
-template<class BidirectionalIterator> 
-  bool next_combination(BidirectionalIterator first,
-                        BidirectionalIterator middle,
-                        BidirectionalIterator last)
-  {
+  template <class BidirectionalIterator>
+  bool next_combination(BidirectionalIterator first, BidirectionalIterator middle, BidirectionalIterator last) {
     return detail::next_combination(first, middle, middle, last);
   }
 
-} // namespace notboost
+}  // namespace notboost
 
-#endif // NOTBOOST_ALGORITHM_COMBINATION_HPP
+#endif  // NOTBOOST_ALGORITHM_COMBINATION_HPP

--- a/RecoParticleFlow/PFProducer/src/pluginFactories.cc
+++ b/RecoParticleFlow/PFProducer/src/pluginFactories.cc
@@ -5,4 +5,4 @@ EDM_REGISTER_PLUGINFACTORY(BlockElementImporterFactory, "BlockElementImporterFac
 EDM_REGISTER_PLUGINFACTORY(BlockElementLinkerFactory, "BlockElementLinkerFactory");
 
 #include "RecoParticleFlow/PFProducer/interface/KDTreeLinkerBase.h"
-EDM_REGISTER_PLUGINFACTORY(KDTreeLinkerFactory,"KDTreeLinkerFactory");
+EDM_REGISTER_PLUGINFACTORY(KDTreeLinkerFactory, "KDTreeLinkerFactory");

--- a/RecoParticleFlow/PFProducer/test/EgGEDPhotonAnalyzer.cc
+++ b/RecoParticleFlow/PFProducer/test/EgGEDPhotonAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EgGEDPhotonAnalyzer
 // Class:      EgGEDPhotonAnalyzer
-// 
+//
 /**\class EgGEDPhotonAnalyzer
 
  Description: <one line class summary>
@@ -12,8 +12,6 @@
 */
 //
 // Original Author:  Daniele Benedetti
-
-
 
 // system include files
 #include <memory>
@@ -42,7 +40,7 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h" 
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "DataFormats/Math/interface/normalizedPhi.h"
 
 #include <vector>
@@ -60,43 +58,36 @@ using namespace edm;
 using namespace reco;
 using namespace std;
 class EgGEDPhotonAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
-   public:
-      explicit EgGEDPhotonAnalyzer(const edm::ParameterSet&);
-      ~EgGEDPhotonAnalyzer() override;
+public:
+  explicit EgGEDPhotonAnalyzer(const edm::ParameterSet &);
+  ~EgGEDPhotonAnalyzer() override;
 
+private:
+  void beginJob() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void endJob() override;
 
-   private:
-      void beginJob() override;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
-  
   ParameterSet conf_;
 
-
   unsigned int ev;
-      // ----------member data ---------------------------
-  
+  // ----------member data ---------------------------
 
-  TH1F *h_etamc_ele,*h_etaec_ele,*h_etaeg_ele,*h_etaged_ele;
-  TH1F *h_ptmc_ele,*h_ptec_ele,*h_pteg_ele,*h_ptged_ele;
-
+  TH1F *h_etamc_ele, *h_etaec_ele, *h_etaeg_ele, *h_etaged_ele;
+  TH1F *h_ptmc_ele, *h_ptec_ele, *h_pteg_ele, *h_ptged_ele;
 
   TH2F *etaphi_nonreco;
 
+  TH1F *eg_EEcalEtrue_1, *eg_EEcalEtrue_2, *eg_EEcalEtrue_3, *eg_EEcalEtrue_4, *eg_EEcalEtrue_5;
+  TH1F *pf_EEcalEtrue_1, *pf_EEcalEtrue_2, *pf_EEcalEtrue_3, *pf_EEcalEtrue_4, *pf_EEcalEtrue_5;
+  TH1F *ged_EEcalEtrue_1, *ged_EEcalEtrue_2, *ged_EEcalEtrue_3, *ged_EEcalEtrue_4, *ged_EEcalEtrue_5;
 
-  TH1F *eg_EEcalEtrue_1,*eg_EEcalEtrue_2,*eg_EEcalEtrue_3,*eg_EEcalEtrue_4,*eg_EEcalEtrue_5;
-  TH1F *pf_EEcalEtrue_1,*pf_EEcalEtrue_2,*pf_EEcalEtrue_3,*pf_EEcalEtrue_4,*pf_EEcalEtrue_5;
-  TH1F *ged_EEcalEtrue_1,*ged_EEcalEtrue_2,*ged_EEcalEtrue_3,*ged_EEcalEtrue_4,*ged_EEcalEtrue_5;
+  TH1F *eg_hoe, *pf_hoe, *ged_hoe;
 
-  TH1F *eg_hoe,*pf_hoe,*ged_hoe; 
+  TH1F *eg_sigmaetaeta_eb, *pf_sigmaetaeta_eb, *ged_sigmaetaeta_eb;
+  TH1F *eg_sigmaetaeta_ee, *pf_sigmaetaeta_ee, *ged_sigmaetaeta_ee;
 
-  TH1F *eg_sigmaetaeta_eb,*pf_sigmaetaeta_eb,*ged_sigmaetaeta_eb; 
-  TH1F *eg_sigmaetaeta_ee,*pf_sigmaetaeta_ee,*ged_sigmaetaeta_ee; 
-  
-  TH1F *eg_r9_eb,*pf_r9_eb,*ged_r9_eb; 
-  TH1F *eg_r9_ee,*pf_r9_ee,*ged_r9_ee; 
-
-
+  TH1F *eg_r9_eb, *pf_r9_eb, *ged_r9_eb;
+  TH1F *eg_r9_ee, *pf_r9_ee, *ged_r9_ee;
 };
 
 //
@@ -110,380 +101,298 @@ class EgGEDPhotonAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResource
 //
 // constructors and destructor
 //
-EgGEDPhotonAnalyzer::EgGEDPhotonAnalyzer(const edm::ParameterSet& iConfig):
-  conf_(iConfig)
+EgGEDPhotonAnalyzer::EgGEDPhotonAnalyzer(const edm::ParameterSet &iConfig)
+    : conf_(iConfig)
 
 {
   usesResource(TFileService::kSharedResource);
-  
+
   edm::Service<TFileService> fs;
 
   // Efficiency plots
 
-  h_etamc_ele = fs->make<TH1F>("h_etamc_ele"," ",50,-2.5,2.5);
-  h_etaec_ele = fs->make<TH1F>("h_etaec_ele"," ",50,-2.5,2.5);
-  h_etaeg_ele = fs->make<TH1F>("h_etaeg_ele"," ",50,-2.5,2.5);
-  h_etaged_ele = fs->make<TH1F>("h_etaged_ele"," ",50,-2.5,2.5);
+  h_etamc_ele = fs->make<TH1F>("h_etamc_ele", " ", 50, -2.5, 2.5);
+  h_etaec_ele = fs->make<TH1F>("h_etaec_ele", " ", 50, -2.5, 2.5);
+  h_etaeg_ele = fs->make<TH1F>("h_etaeg_ele", " ", 50, -2.5, 2.5);
+  h_etaged_ele = fs->make<TH1F>("h_etaged_ele", " ", 50, -2.5, 2.5);
 
+  h_ptmc_ele = fs->make<TH1F>("h_ptmc_ele", " ", 50, 0, 100.);
+  h_ptec_ele = fs->make<TH1F>("h_ptec_ele", " ", 50, 0, 100.);
+  h_pteg_ele = fs->make<TH1F>("h_pteg_ele", " ", 50, 0, 100.);
 
+  h_ptged_ele = fs->make<TH1F>("h_ptged_ele", " ", 50, 0, 100.);
 
+  pf_hoe = fs->make<TH1F>("pf_hoe", " ", 100, 0, 1.);
+  eg_hoe = fs->make<TH1F>("eg_hoe", " ", 100, 0, 1.);
+  ged_hoe = fs->make<TH1F>("ged_hoe", " ", 100, 0, 1.);
 
-  h_ptmc_ele = fs->make<TH1F>("h_ptmc_ele"," ",50,0,100.);
-  h_ptec_ele = fs->make<TH1F>("h_ptec_ele"," ",50,0,100.);
-  h_pteg_ele = fs->make<TH1F>("h_pteg_ele"," ",50,0,100.);
+  pf_sigmaetaeta_eb = fs->make<TH1F>("pf_sigmaetaeta_eb", " ", 100, 0., 0.03);
+  eg_sigmaetaeta_eb = fs->make<TH1F>("eg_sigmaetaeta_eb", " ", 100, 0., 0.03);
+  ged_sigmaetaeta_eb = fs->make<TH1F>("ged_sigmaetaeta_eb", " ", 100, 0., 0.03);
 
-  h_ptged_ele = fs->make<TH1F>("h_ptged_ele"," ",50,0,100.);
+  pf_sigmaetaeta_ee = fs->make<TH1F>("pf_sigmaetaeta_ee", " ", 100, 0., 0.1);
+  eg_sigmaetaeta_ee = fs->make<TH1F>("eg_sigmaetaeta_ee", " ", 100, 0., 0.1);
+  ged_sigmaetaeta_ee = fs->make<TH1F>("ged_sigmaetaeta_ee", " ", 100, 0., 0.1);
 
-  pf_hoe = fs->make<TH1F>("pf_hoe"," ",100,0,1.);
-  eg_hoe = fs->make<TH1F>("eg_hoe"," ",100,0,1.);
-  ged_hoe = fs->make<TH1F>("ged_hoe"," ",100,0,1.);
+  pf_r9_eb = fs->make<TH1F>("pf_r9_eb", " ", 100, 0., 1.0);
+  eg_r9_eb = fs->make<TH1F>("eg_r9_eb", " ", 100, 0., 1.0);
+  ged_r9_eb = fs->make<TH1F>("ged_r9_eb", " ", 100, 0., 1.0);
 
-
-  pf_sigmaetaeta_eb = fs->make<TH1F>("pf_sigmaetaeta_eb"," ",100,0.,0.03);
-  eg_sigmaetaeta_eb = fs->make<TH1F>("eg_sigmaetaeta_eb"," ",100,0.,0.03);
-  ged_sigmaetaeta_eb = fs->make<TH1F>("ged_sigmaetaeta_eb"," ",100,0.,0.03);
-
-  pf_sigmaetaeta_ee = fs->make<TH1F>("pf_sigmaetaeta_ee"," ",100,0.,0.1);
-  eg_sigmaetaeta_ee = fs->make<TH1F>("eg_sigmaetaeta_ee"," ",100,0.,0.1);
-  ged_sigmaetaeta_ee = fs->make<TH1F>("ged_sigmaetaeta_ee"," ",100,0.,0.1);
-
-
-  pf_r9_eb = fs->make<TH1F>("pf_r9_eb"," ",100,0.,1.0);
-  eg_r9_eb = fs->make<TH1F>("eg_r9_eb"," ",100,0.,1.0);
-  ged_r9_eb = fs->make<TH1F>("ged_r9_eb"," ",100,0.,1.0);
-
-  pf_r9_ee = fs->make<TH1F>("pf_r9_ee"," ",100,0.,1.0);
-  eg_r9_ee = fs->make<TH1F>("eg_r9_ee"," ",100,0.,1.0);
-  ged_r9_ee = fs->make<TH1F>("ged_r9_ee"," ",100,0.,1.0);
-
+  pf_r9_ee = fs->make<TH1F>("pf_r9_ee", " ", 100, 0., 1.0);
+  eg_r9_ee = fs->make<TH1F>("eg_r9_ee", " ", 100, 0., 1.0);
+  ged_r9_ee = fs->make<TH1F>("ged_r9_ee", " ", 100, 0., 1.0);
 
   // Ecal map
-  etaphi_nonreco  = fs->make<TH2F>("etaphi_nonreco"," ",50,-2.5,2.5,50,-3.2,3.2);
-
-
-
+  etaphi_nonreco = fs->make<TH2F>("etaphi_nonreco", " ", 50, -2.5, 2.5, 50, -3.2, 3.2);
 
   // Energies
-  eg_EEcalEtrue_1 =  fs->make<TH1F>("eg_EEcalEtrue_1","  ",50,0.,2.);
-  eg_EEcalEtrue_2 =  fs->make<TH1F>("eg_EEcalEtrue_2","  ",50,0.,2.);
-  eg_EEcalEtrue_3 =  fs->make<TH1F>("eg_EEcalEtrue_3","  ",50,0.,2.);
-  eg_EEcalEtrue_4 =  fs->make<TH1F>("eg_EEcalEtrue_4","  ",50,0.,2.);
-  eg_EEcalEtrue_5 =  fs->make<TH1F>("eg_EEcalEtrue_5","  ",50,0.,2.);
+  eg_EEcalEtrue_1 = fs->make<TH1F>("eg_EEcalEtrue_1", "  ", 50, 0., 2.);
+  eg_EEcalEtrue_2 = fs->make<TH1F>("eg_EEcalEtrue_2", "  ", 50, 0., 2.);
+  eg_EEcalEtrue_3 = fs->make<TH1F>("eg_EEcalEtrue_3", "  ", 50, 0., 2.);
+  eg_EEcalEtrue_4 = fs->make<TH1F>("eg_EEcalEtrue_4", "  ", 50, 0., 2.);
+  eg_EEcalEtrue_5 = fs->make<TH1F>("eg_EEcalEtrue_5", "  ", 50, 0., 2.);
 
-  pf_EEcalEtrue_1 =  fs->make<TH1F>("pf_EEcalEtrue_1","  ",50,0.,2.);
-  pf_EEcalEtrue_2 =  fs->make<TH1F>("pf_EEcalEtrue_2","  ",50,0.,2.);
-  pf_EEcalEtrue_3 =  fs->make<TH1F>("pf_EEcalEtrue_3","  ",50,0.,2.);
-  pf_EEcalEtrue_4 =  fs->make<TH1F>("pf_EEcalEtrue_4","  ",50,0.,2.);
-  pf_EEcalEtrue_5 =  fs->make<TH1F>("pf_EEcalEtrue_5","  ",50,0.,2.);
+  pf_EEcalEtrue_1 = fs->make<TH1F>("pf_EEcalEtrue_1", "  ", 50, 0., 2.);
+  pf_EEcalEtrue_2 = fs->make<TH1F>("pf_EEcalEtrue_2", "  ", 50, 0., 2.);
+  pf_EEcalEtrue_3 = fs->make<TH1F>("pf_EEcalEtrue_3", "  ", 50, 0., 2.);
+  pf_EEcalEtrue_4 = fs->make<TH1F>("pf_EEcalEtrue_4", "  ", 50, 0., 2.);
+  pf_EEcalEtrue_5 = fs->make<TH1F>("pf_EEcalEtrue_5", "  ", 50, 0., 2.);
 
-
-  ged_EEcalEtrue_1 =  fs->make<TH1F>("ged_EEcalEtrue_1","  ",50,0.,2.);
-  ged_EEcalEtrue_2 =  fs->make<TH1F>("ged_EEcalEtrue_2","  ",50,0.,2.);
-  ged_EEcalEtrue_3 =  fs->make<TH1F>("ged_EEcalEtrue_3","  ",50,0.,2.);
-  ged_EEcalEtrue_4 =  fs->make<TH1F>("ged_EEcalEtrue_4","  ",50,0.,2.);
-  ged_EEcalEtrue_5 =  fs->make<TH1F>("ged_EEcalEtrue_5","  ",50,0.,2.);
-
-
+  ged_EEcalEtrue_1 = fs->make<TH1F>("ged_EEcalEtrue_1", "  ", 50, 0., 2.);
+  ged_EEcalEtrue_2 = fs->make<TH1F>("ged_EEcalEtrue_2", "  ", 50, 0., 2.);
+  ged_EEcalEtrue_3 = fs->make<TH1F>("ged_EEcalEtrue_3", "  ", 50, 0., 2.);
+  ged_EEcalEtrue_4 = fs->make<TH1F>("ged_EEcalEtrue_4", "  ", 50, 0., 2.);
+  ged_EEcalEtrue_5 = fs->make<TH1F>("ged_EEcalEtrue_5", "  ", 50, 0., 2.);
 }
 
-
-EgGEDPhotonAnalyzer::~EgGEDPhotonAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+EgGEDPhotonAnalyzer::~EgGEDPhotonAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-EgGEDPhotonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
-
-
+void EgGEDPhotonAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Candidate info
   Handle<reco::PFCandidateCollection> collection;
-  InputTag label("particleFlow");  // <- Special electron coll. 
+  InputTag label("particleFlow");  // <- Special electron coll.
   iEvent.getByLabel(label, collection);
   std::vector<reco::PFCandidate> candidates = (*collection.product());
 
-
   InputTag recoPhotonLabel(string("photons"));
   Handle<PhotonCollection> theRecoPhotonCollection;
-  iEvent.getByLabel(recoPhotonLabel,theRecoPhotonCollection);
+  iEvent.getByLabel(recoPhotonLabel, theRecoPhotonCollection);
   const PhotonCollection theRecoPh = *(theRecoPhotonCollection.product());
 
-
-  InputTag  MCTruthCollection(string("VtxSmeared"));
+  InputTag MCTruthCollection(string("VtxSmeared"));
   edm::Handle<edm::HepMCProduct> pMCTruth;
-  iEvent.getByLabel(MCTruthCollection,pMCTruth);
-  const HepMC::GenEvent* genEvent = pMCTruth->GetEvent();
-
-
+  iEvent.getByLabel(MCTruthCollection, pMCTruth);
+  const HepMC::GenEvent *genEvent = pMCTruth->GetEvent();
 
   InputTag gedPhotonLabel(string("gedPhotons"));
   Handle<PhotonCollection> theGedPhotonCollection;
-  iEvent.getByLabel(gedPhotonLabel,theGedPhotonCollection);
+  iEvent.getByLabel(gedPhotonLabel, theGedPhotonCollection);
   const PhotonCollection theGedPh = *(theGedPhotonCollection.product());
-
-
-
 
   bool debug = true;
 
-
   ev++;
 
-  if(debug)
+  if (debug)
     cout << "************************* New Event:: " << ev << " *************************" << endl;
 
-  // Validation from generator events 
+  // Validation from generator events
 
-  for(HepMC::GenEvent::particle_const_iterator cP = genEvent->particles_begin(); 
-      cP != genEvent->particles_end(); cP++ ) {
-
-    float etamc= (*cP)->momentum().eta();
-    float phimc= (*cP)->momentum().phi();
+  for (HepMC::GenEvent::particle_const_iterator cP = genEvent->particles_begin(); cP != genEvent->particles_end();
+       cP++) {
+    float etamc = (*cP)->momentum().eta();
+    float phimc = (*cP)->momentum().phi();
     float ptmc = (*cP)->momentum().perp();
     float Emc = (*cP)->momentum().e();
 
-
-    if(abs((*cP)->pdg_id())==22 && (*cP)->status()==1 
-       && (*cP)->momentum().perp() > 8. && 
-       fabs((*cP)->momentum().eta()) < 2.5 ){
-   
+    if (abs((*cP)->pdg_id()) == 22 && (*cP)->status() == 1 && (*cP)->momentum().perp() > 8. &&
+        fabs((*cP)->momentum().eta()) < 2.5) {
       h_etamc_ele->Fill(etamc);
       h_ptmc_ele->Fill(ptmc);
-      
+
       float MindR = 1000.;
- 
 
-
-      if(debug)
-	cout << " MC particle:  pt " << ptmc << " eta,phi " <<  etamc << ", " << phimc << endl;
-
-
+      if (debug)
+        cout << " MC particle:  pt " << ptmc << " eta,phi " << etamc << ", " << phimc << endl;
 
       std::vector<reco::PFCandidate>::iterator it;
-      for ( it = candidates.begin(); it != candidates.end(); ++it )   {
-	reco::PFCandidate::ParticleType type = (*it).particleId();
+      for (it = candidates.begin(); it != candidates.end(); ++it) {
+        reco::PFCandidate::ParticleType type = (*it).particleId();
 
-	if ( type == reco::PFCandidate::gamma )	{ 
-	  
-	  reco::PhotonRef phref = (*it).photonRef(); 
-	  float eta =  (*it).eta();
-	  float phi =  (*it).phi();
+        if (type == reco::PFCandidate::gamma) {
+          reco::PhotonRef phref = (*it).photonRef();
+          float eta = (*it).eta();
+          float phi = (*it).phi();
 
-	  float deta = etamc - eta;
-	  float dphi = normalizedPhi(phimc - phi);
-	  float dR = sqrt(deta*deta + dphi*dphi);
+          float deta = etamc - eta;
+          float dphi = normalizedPhi(phimc - phi);
+          float dR = sqrt(deta * deta + dphi * dphi);
 
-	  if(dR < 0.1){
-	    MindR = dR;
+          if (dR < 0.1) {
+            MindR = dR;
 
-	    if(phref.isNonnull()) {
-	      
-	      float SCPF = phref->energy();
-	      float EpfEtrue = SCPF/Emc;
-	      if (fabs(etamc) < 0.5) {
-		pf_EEcalEtrue_1->Fill(EpfEtrue);
-	      }
-	      if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {	
-		pf_EEcalEtrue_2->Fill(EpfEtrue);
-	      }
-	      if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {	
-		pf_EEcalEtrue_3->Fill(EpfEtrue);
-	      }
-	      if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
-		pf_EEcalEtrue_4->Fill(EpfEtrue);
-	      }
-	      if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
-		pf_EEcalEtrue_5->Fill(EpfEtrue);
-	      }
+            if (phref.isNonnull()) {
+              float SCPF = phref->energy();
+              float EpfEtrue = SCPF / Emc;
+              if (fabs(etamc) < 0.5) {
+                pf_EEcalEtrue_1->Fill(EpfEtrue);
+              }
+              if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {
+                pf_EEcalEtrue_2->Fill(EpfEtrue);
+              }
+              if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {
+                pf_EEcalEtrue_3->Fill(EpfEtrue);
+              }
+              if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
+                pf_EEcalEtrue_4->Fill(EpfEtrue);
+              }
+              if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
+                pf_EEcalEtrue_5->Fill(EpfEtrue);
+              }
 
-	      pf_hoe->Fill(phref->hadronicOverEm());
-	      if(fabs(etamc) < 1.479) {
-		pf_r9_eb->Fill(phref->r9());
-		pf_sigmaetaeta_eb->Fill(phref->sigmaEtaEta());
-	      }
-	      else if(fabs(etamc) > 1.479 && fabs(etamc) < 2.5) {
-		pf_r9_ee->Fill(phref->r9());
-		pf_sigmaetaeta_ee->Fill(phref->sigmaEtaEta());
-	      }
+              pf_hoe->Fill(phref->hadronicOverEm());
+              if (fabs(etamc) < 1.479) {
+                pf_r9_eb->Fill(phref->r9());
+                pf_sigmaetaeta_eb->Fill(phref->sigmaEtaEta());
+              } else if (fabs(etamc) > 1.479 && fabs(etamc) < 2.5) {
+                pf_r9_ee->Fill(phref->r9());
+                pf_sigmaetaeta_ee->Fill(phref->sigmaEtaEta());
+              }
+            }
 
+            if (debug)
+              cout << " PF photon matched:  pt " << (*it).pt() << " eta,phi " << eta << ", " << phi << endl;
+            // all for the moment
+          }
+        }  // End PFCandidates Electron Selection
+      }    // End Loop PFCandidates
 
-	    }
+      if (MindR < 0.1) {
+        h_etaec_ele->Fill(etamc);
+        h_ptec_ele->Fill(ptmc);
 
-	    if(debug)
-	      cout << " PF photon matched:  pt " << (*it).pt()  << " eta,phi " <<  eta << ", " << phi << endl;
-	    // all for the moment
-	  }
-	} // End PFCandidates Electron Selection
-      } // End Loop PFCandidates
-      
-      if (MindR < 0.1) {      
-
-    	h_etaec_ele->Fill(etamc);
-	h_ptec_ele->Fill(ptmc);
-	
-
-
-
-      }
-      else {
-	etaphi_nonreco->Fill(etamc,phimc);
-
+      } else {
+        etaphi_nonreco->Fill(etamc, phimc);
       }
 
-      float MindREG =1000;
-      for (uint j=0; j<theRecoPh.size();j++) {
+      float MindREG = 1000;
+      for (uint j = 0; j < theRecoPh.size(); j++) {
+        float etareco = theRecoPh[j].eta();
+        float phireco = theRecoPh[j].phi();
 
-	float etareco = theRecoPh[j].eta();
-	float phireco = theRecoPh[j].phi();
+        float deta = etamc - etareco;
+        float dphi = normalizedPhi(phimc - phireco);
+        float dR = sqrt(deta * deta + dphi * dphi);
 
+        float SCEnergy = (theRecoPh[j]).energy();
+        float ErecoEtrue = SCEnergy / Emc;
 
+        if (dR < 0.1) {
+          if (debug)
+            cout << " EG ele matched: pt " << theRecoPh[j].pt() << " eta,phi " << etareco << ", " << phireco << endl;
 
-	float deta = etamc - etareco;
-	float dphi = normalizedPhi(phimc - phireco);
-	float dR = sqrt(deta*deta + dphi*dphi);
+          if (fabs(etamc) < 0.5) {
+            eg_EEcalEtrue_1->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {
+            eg_EEcalEtrue_2->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {
+            eg_EEcalEtrue_3->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
+            eg_EEcalEtrue_4->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
+            eg_EEcalEtrue_5->Fill(ErecoEtrue);
+          }
 
-	float SCEnergy = (theRecoPh[j]).energy();
-	float ErecoEtrue = SCEnergy/Emc;
+          eg_hoe->Fill(theRecoPh[j].hadronicOverEm());
+          if (fabs(etamc) < 1.479) {
+            eg_r9_eb->Fill(theRecoPh[j].r9());
+            eg_sigmaetaeta_eb->Fill(theRecoPh[j].sigmaEtaEta());
+          } else if (fabs(etamc) > 1.479 && fabs(etamc) < 2.5) {
+            eg_r9_ee->Fill(theRecoPh[j].r9());
+            eg_sigmaetaeta_ee->Fill(theRecoPh[j].sigmaEtaEta());
+          }
 
-
-
-	if(dR < 0.1){
-	  if(debug)
-	    cout << " EG ele matched: pt " << theRecoPh[j].pt() << " eta,phi " <<  etareco << ", " << phireco <<  endl;
-	
-
-	  if (fabs(etamc) < 0.5) {
-	    eg_EEcalEtrue_1->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {	
-	    eg_EEcalEtrue_2->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {	
-	    eg_EEcalEtrue_3->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
-	    eg_EEcalEtrue_4->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
-	    eg_EEcalEtrue_5->Fill(ErecoEtrue);
-	  }
-
-	
-	  eg_hoe->Fill(theRecoPh[j].hadronicOverEm());  
-	  if(fabs(etamc) < 1.479) {
-	    eg_r9_eb->Fill(theRecoPh[j].r9());
-	    eg_sigmaetaeta_eb->Fill(theRecoPh[j].sigmaEtaEta());
-	  }
-	  else if(fabs(etamc) > 1.479 && fabs(etamc) < 2.5) {
-	    eg_r9_ee->Fill(theRecoPh[j].r9());
-	    eg_sigmaetaeta_ee->Fill(theRecoPh[j].sigmaEtaEta());
-	  }
-
-
-	  MindREG = dR;
-	}
+          MindREG = dR;
+        }
       }
-      if(MindREG < 0.1) {
-	h_etaeg_ele->Fill(etamc);
-	h_pteg_ele->Fill(ptmc);
+      if (MindREG < 0.1) {
+        h_etaeg_ele->Fill(etamc);
+        h_pteg_ele->Fill(ptmc);
       }
-
-
-
 
       //Add loop on the GED electrons
-      
-      
-      float MindRGedEg =1000;
-       
-      for (uint j=0; j<theGedPh.size();j++) {
-	reco::GsfTrackRef egGsfTrackRef = (theGedPh[j]).gsfTrack();
-	float etareco = theGedPh[j].eta();
-	float phireco = theGedPh[j].phi();
-	
-	
-	float deta = etamc - etareco;
-	float dphi = normalizedPhi(phimc - phireco);
-	float dR = sqrt(deta*deta + dphi*dphi);
-	
-	float SCEnergy = (theGedPh[j]).energy();
-	float ErecoEtrue = SCEnergy/Emc;
 
+      float MindRGedEg = 1000;
 
+      for (uint j = 0; j < theGedPh.size(); j++) {
+        reco::GsfTrackRef egGsfTrackRef = (theGedPh[j]).gsfTrack();
+        float etareco = theGedPh[j].eta();
+        float phireco = theGedPh[j].phi();
 
-	if(dR < 0.1){
-	  if(debug)
-	    cout << " GED ele matched: pt " << theGedPh[j].pt() << " eta,phi " <<  etareco << ", " << phireco << endl;
-	  
-	  if (fabs(etamc) < 0.5) {
-	    ged_EEcalEtrue_1->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {	
-	    ged_EEcalEtrue_2->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {	
-	    ged_EEcalEtrue_3->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
-	    ged_EEcalEtrue_4->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
-	    ged_EEcalEtrue_5->Fill(ErecoEtrue);
-	  }
+        float deta = etamc - etareco;
+        float dphi = normalizedPhi(phimc - phireco);
+        float dR = sqrt(deta * deta + dphi * dphi);
 
+        float SCEnergy = (theGedPh[j]).energy();
+        float ErecoEtrue = SCEnergy / Emc;
 
-	  ged_hoe->Fill(theGedPh[j].hadronicOverEm());
-	  if(fabs(etamc) < 1.479) {
-	    ged_r9_eb->Fill(theGedPh[j].r9());
-	    ged_sigmaetaeta_eb->Fill(theGedPh[j].sigmaEtaEta());
-	  }
-	  else if(fabs(etamc) > 1.479 && fabs(etamc) < 2.5) {
-	    ged_r9_ee->Fill(theGedPh[j].r9());
-	    ged_sigmaetaeta_ee->Fill(theGedPh[j].sigmaEtaEta());
-	  }
+        if (dR < 0.1) {
+          if (debug)
+            cout << " GED ele matched: pt " << theGedPh[j].pt() << " eta,phi " << etareco << ", " << phireco << endl;
 
+          if (fabs(etamc) < 0.5) {
+            ged_EEcalEtrue_1->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {
+            ged_EEcalEtrue_2->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {
+            ged_EEcalEtrue_3->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
+            ged_EEcalEtrue_4->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
+            ged_EEcalEtrue_5->Fill(ErecoEtrue);
+          }
 
-	  MindRGedEg = dR;
+          ged_hoe->Fill(theGedPh[j].hadronicOverEm());
+          if (fabs(etamc) < 1.479) {
+            ged_r9_eb->Fill(theGedPh[j].r9());
+            ged_sigmaetaeta_eb->Fill(theGedPh[j].sigmaEtaEta());
+          } else if (fabs(etamc) > 1.479 && fabs(etamc) < 2.5) {
+            ged_r9_ee->Fill(theGedPh[j].r9());
+            ged_sigmaetaeta_ee->Fill(theGedPh[j].sigmaEtaEta());
+          }
 
-	}
+          MindRGedEg = dR;
+        }
       }
-      if(MindRGedEg < 0.1) {
-	h_etaged_ele->Fill(etamc);
-	h_ptged_ele->Fill(ptmc);
-      }//End Loop Generator Particles  
-      
-      
+      if (MindRGedEg < 0.1) {
+        h_etaged_ele->Fill(etamc);
+        h_ptged_ele->Fill(ptmc);
+      }  //End Loop Generator Particles
 
+    }  //End IF Generator Particles
 
-    } //End IF Generator Particles 
-  
-  
-  } //End Loop Generator Particles 
-
+  }  //End Loop Generator Particles
 }
 // ------------ method called once each job just before starting event loop  ------------
-void 
-EgGEDPhotonAnalyzer::beginJob()
-{
-
-  ev = 0;
-}
+void EgGEDPhotonAnalyzer::beginJob() { ev = 0; }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-EgGEDPhotonAnalyzer::endJob() {
-  cout << " endJob:: #events " << ev << endl;
-}
+void EgGEDPhotonAnalyzer::endJob() { cout << " endJob:: #events " << ev << endl; }
 //define this as a plug-in
 DEFINE_FWK_MODULE(EgGEDPhotonAnalyzer);

--- a/RecoParticleFlow/PFProducer/test/GsfGEDElectronAnalyzer.cc
+++ b/RecoParticleFlow/PFProducer/test/GsfGEDElectronAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    GsfGEDElectronAnalyzer
 // Class:      GsfGEDElectronAnalyzer
-// 
+//
 /**\class GsfGEDElectronAnalyzer
 
  Description: <one line class summary>
@@ -12,8 +12,6 @@
 */
 //
 // Original Author:  Daniele Benedetti
-
-
 
 // system include files
 #include <memory>
@@ -43,10 +41,9 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/METReco/interface/PFMET.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h" 
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/Math/interface/normalizedPhi.h"
-
 
 #include <vector>
 #include <TROOT.h>
@@ -63,56 +60,48 @@ using namespace edm;
 using namespace reco;
 using namespace std;
 class GsfGEDElectronAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
-   public:
-      explicit GsfGEDElectronAnalyzer(const edm::ParameterSet&);
-      ~GsfGEDElectronAnalyzer() override;
+public:
+  explicit GsfGEDElectronAnalyzer(const edm::ParameterSet &);
+  ~GsfGEDElectronAnalyzer() override;
 
+private:
+  void beginJob() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void endJob() override;
 
-   private:
-      void beginJob() override;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
-  
   ParameterSet conf_;
 
-
   unsigned int ev;
-      // ----------member data ---------------------------
-  
+  // ----------member data ---------------------------
 
-  TH1F *h_etamc_ele,*h_etaec_ele,*h_etaecTrDr_ele,*h_etaecEcDr_ele,
-    *h_etaeg_ele,*h_etaegTrDr_ele,*h_etaegEcDr_ele,
-    *h_etaged_ele,*h_etagedTrDr_ele,*h_etagedEcDr_ele;
+  TH1F *h_etamc_ele, *h_etaec_ele, *h_etaecTrDr_ele, *h_etaecEcDr_ele, *h_etaeg_ele, *h_etaegTrDr_ele, *h_etaegEcDr_ele,
+      *h_etaged_ele, *h_etagedTrDr_ele, *h_etagedEcDr_ele;
 
-
-
-
-
-  TH1F  *h_ptmc_ele,*h_ptec_ele,*h_ptecEcDr_ele,*h_ptecTrDr_ele,
-    *h_pteg_ele,*h_ptegTrDr_ele,*h_ptegEcDr_ele,
-    *h_ptged_ele,*h_ptgedTrDr_ele,*h_ptgedEcDr_ele;
-
+  TH1F *h_ptmc_ele, *h_ptec_ele, *h_ptecEcDr_ele, *h_ptecTrDr_ele, *h_pteg_ele, *h_ptegTrDr_ele, *h_ptegEcDr_ele,
+      *h_ptged_ele, *h_ptgedTrDr_ele, *h_ptgedEcDr_ele;
 
   TH1F *h_mva_ele;
   TH2F *etaphi_nonreco;
 
+  TH1F *eg_EEcalEtrue_1, *eg_EEcalEtrue_2, *eg_EEcalEtrue_3, *eg_EEcalEtrue_4, *eg_EEcalEtrue_5;
+  TH1F *pf_EEcalEtrue_1, *pf_EEcalEtrue_2, *pf_EEcalEtrue_3, *pf_EEcalEtrue_4, *pf_EEcalEtrue_5;
+  TH1F *ged_EEcalEtrue_1, *ged_EEcalEtrue_2, *ged_EEcalEtrue_3, *ged_EEcalEtrue_4, *ged_EEcalEtrue_5;
 
-  TH1F *eg_EEcalEtrue_1,*eg_EEcalEtrue_2,*eg_EEcalEtrue_3,*eg_EEcalEtrue_4,*eg_EEcalEtrue_5;
-  TH1F *pf_EEcalEtrue_1,*pf_EEcalEtrue_2,*pf_EEcalEtrue_3,*pf_EEcalEtrue_4,*pf_EEcalEtrue_5;
-  TH1F *ged_EEcalEtrue_1,*ged_EEcalEtrue_2,*ged_EEcalEtrue_3,*ged_EEcalEtrue_4,*ged_EEcalEtrue_5;
+  TH1F *eg_e1x5_all, *eg_e1x5_eb, *eg_e1x5_ee, *ged_e1x5_all, *ged_e1x5_eb, *ged_e1x5_ee, *pf_e1x5_all, *pf_e1x5_eb,
+      *pf_e1x5_ee;
 
-  TH1F *eg_e1x5_all,*eg_e1x5_eb,*eg_e1x5_ee,*ged_e1x5_all,*ged_e1x5_eb,*ged_e1x5_ee,*pf_e1x5_all,*pf_e1x5_eb,*pf_e1x5_ee;
+  TH1F *eg_sihih_all, *eg_sihih_eb, *eg_sihih_ee, *ged_sihih_all, *ged_sihih_eb, *ged_sihih_ee, *pf_sihih_all,
+      *pf_sihih_eb, *pf_sihih_ee;
 
-  TH1F *eg_sihih_all,*eg_sihih_eb,*eg_sihih_ee,*ged_sihih_all,*ged_sihih_eb,*ged_sihih_ee,*pf_sihih_all,*pf_sihih_eb,*pf_sihih_ee;
+  TH1F *eg_r9_all, *eg_r9_eb, *eg_r9_ee, *ged_r9_all, *ged_r9_eb, *ged_r9_ee, *pf_r9_all, *pf_r9_eb, *pf_r9_ee;
 
-  TH1F *eg_r9_all,*eg_r9_eb,*eg_r9_ee,*ged_r9_all,*ged_r9_eb,*ged_r9_ee,*pf_r9_all,*pf_r9_eb,*pf_r9_ee;
+  TH1F *eg_scshh_all, *eg_scshh_eb, *eg_scshh_ee, *ged_scshh_all, *ged_scshh_eb, *ged_scshh_ee, *pf_scshh_all,
+      *pf_scshh_eb, *pf_scshh_ee;
 
-  TH1F *eg_scshh_all,*eg_scshh_eb,*eg_scshh_ee,*ged_scshh_all,*ged_scshh_eb,*ged_scshh_ee,*pf_scshh_all,*pf_scshh_eb,*pf_scshh_ee;
+  TH1F *eg_scsff_all, *eg_scsff_eb, *eg_scsff_ee, *ged_scsff_all, *ged_scsff_eb, *ged_scsff_ee, *pf_scsff_all,
+      *pf_scsff_eb, *pf_scsff_ee;
 
-  TH1F *eg_scsff_all,*eg_scsff_eb,*eg_scsff_ee,*ged_scsff_all,*ged_scsff_eb,*ged_scsff_ee,*pf_scsff_all,*pf_scsff_eb,*pf_scsff_ee;
-
-
-  TH1F *pf_MET_reco ,*pf_MET_rereco;
+  TH1F *pf_MET_reco, *pf_MET_rereco;
 };
 
 //
@@ -126,482 +115,434 @@ class GsfGEDElectronAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResou
 //
 // constructors and destructor
 //
-GsfGEDElectronAnalyzer::GsfGEDElectronAnalyzer(const edm::ParameterSet& iConfig):
-  conf_(iConfig)
+GsfGEDElectronAnalyzer::GsfGEDElectronAnalyzer(const edm::ParameterSet &iConfig)
+    : conf_(iConfig)
 
 {
   usesResource(TFileService::kSharedResource);
-  
+
   edm::Service<TFileService> fs;
 
   // Efficiency plots
 
-  h_etamc_ele = fs->make<TH1F>("h_etamc_ele"," ",50,-2.5,2.5);
-  h_etaec_ele = fs->make<TH1F>("h_etaec_ele"," ",50,-2.5,2.5);
-  h_etaecTrDr_ele = fs->make<TH1F>("h_etaecTrDr_ele"," ",50,-2.5,2.5);
-  h_etaecEcDr_ele = fs->make<TH1F>("h_etaecEcDr_ele"," ",50,-2.5,2.5);
-  h_etaeg_ele = fs->make<TH1F>("h_etaeg_ele"," ",50,-2.5,2.5);
-  h_etaegTrDr_ele = fs->make<TH1F>("h_etaegTrDr_ele"," ",50,-2.5,2.5);
-  h_etaegEcDr_ele = fs->make<TH1F>("h_etaegEcDr_ele"," ",50,-2.5,2.5);
-  h_etaged_ele = fs->make<TH1F>("h_etaged_ele"," ",50,-2.5,2.5);
-  h_etagedTrDr_ele = fs->make<TH1F>("h_etagedTrDr_ele"," ",50,-2.5,2.5);
-  h_etagedEcDr_ele = fs->make<TH1F>("h_etagedEcDr_ele"," ",50,-2.5,2.5);
+  h_etamc_ele = fs->make<TH1F>("h_etamc_ele", " ", 50, -2.5, 2.5);
+  h_etaec_ele = fs->make<TH1F>("h_etaec_ele", " ", 50, -2.5, 2.5);
+  h_etaecTrDr_ele = fs->make<TH1F>("h_etaecTrDr_ele", " ", 50, -2.5, 2.5);
+  h_etaecEcDr_ele = fs->make<TH1F>("h_etaecEcDr_ele", " ", 50, -2.5, 2.5);
+  h_etaeg_ele = fs->make<TH1F>("h_etaeg_ele", " ", 50, -2.5, 2.5);
+  h_etaegTrDr_ele = fs->make<TH1F>("h_etaegTrDr_ele", " ", 50, -2.5, 2.5);
+  h_etaegEcDr_ele = fs->make<TH1F>("h_etaegEcDr_ele", " ", 50, -2.5, 2.5);
+  h_etaged_ele = fs->make<TH1F>("h_etaged_ele", " ", 50, -2.5, 2.5);
+  h_etagedTrDr_ele = fs->make<TH1F>("h_etagedTrDr_ele", " ", 50, -2.5, 2.5);
+  h_etagedEcDr_ele = fs->make<TH1F>("h_etagedEcDr_ele", " ", 50, -2.5, 2.5);
 
+  h_ptmc_ele = fs->make<TH1F>("h_ptmc_ele", " ", 50, 0, 100.);
+  h_ptec_ele = fs->make<TH1F>("h_ptec_ele", " ", 50, 0, 100.);
+  h_ptecTrDr_ele = fs->make<TH1F>("h_ptecTrDr_ele", " ", 50, 0, 100.);
+  h_ptecEcDr_ele = fs->make<TH1F>("h_ptecEcDr_ele", " ", 50, 0, 100.);
+  h_pteg_ele = fs->make<TH1F>("h_pteg_ele", " ", 50, 0, 100.);
+  h_ptegTrDr_ele = fs->make<TH1F>("h_ptegTrDr_ele", " ", 50, 0, 100.);
+  h_ptegEcDr_ele = fs->make<TH1F>("h_ptegEcDr_ele", " ", 50, 0, 100.);
+  h_ptged_ele = fs->make<TH1F>("h_ptged_ele", " ", 50, 0, 100.);
+  h_ptgedTrDr_ele = fs->make<TH1F>("h_ptgedTrDr_ele", " ", 50, 0, 100.);
+  h_ptgedEcDr_ele = fs->make<TH1F>("h_ptgedEcDr_ele", " ", 50, 0, 100.);
 
-
-
-  h_ptmc_ele = fs->make<TH1F>("h_ptmc_ele"," ",50,0,100.);
-  h_ptec_ele = fs->make<TH1F>("h_ptec_ele"," ",50,0,100.);
-  h_ptecTrDr_ele = fs->make<TH1F>("h_ptecTrDr_ele"," ",50,0,100.);
-  h_ptecEcDr_ele = fs->make<TH1F>("h_ptecEcDr_ele"," ",50,0,100.);
-  h_pteg_ele = fs->make<TH1F>("h_pteg_ele"," ",50,0,100.);
-  h_ptegTrDr_ele = fs->make<TH1F>("h_ptegTrDr_ele"," ",50,0,100.);
-  h_ptegEcDr_ele = fs->make<TH1F>("h_ptegEcDr_ele"," ",50,0,100.);
-  h_ptged_ele = fs->make<TH1F>("h_ptged_ele"," ",50,0,100.);
-  h_ptgedTrDr_ele = fs->make<TH1F>("h_ptgedTrDr_ele"," ",50,0,100.);
-  h_ptgedEcDr_ele = fs->make<TH1F>("h_ptgedEcDr_ele"," ",50,0,100.);
-
-  
-  h_mva_ele  = fs->make<TH1F>("h_mva_ele"," ",50,-1.1,1.1);
+  h_mva_ele = fs->make<TH1F>("h_mva_ele", " ", 50, -1.1, 1.1);
 
   // Ecal map
-  etaphi_nonreco  = fs->make<TH2F>("etaphi_nonreco"," ",50,-2.5,2.5,50,-3.2,3.2);
+  etaphi_nonreco = fs->make<TH2F>("etaphi_nonreco", " ", 50, -2.5, 2.5, 50, -3.2, 3.2);
 
   // Energies
-  eg_EEcalEtrue_1 =  fs->make<TH1F>("eg_EEcalEtrue_1","  ",50,0.,2.);
-  eg_EEcalEtrue_2 =  fs->make<TH1F>("eg_EEcalEtrue_2","  ",50,0.,2.);
-  eg_EEcalEtrue_3 =  fs->make<TH1F>("eg_EEcalEtrue_3","  ",50,0.,2.);
-  eg_EEcalEtrue_4 =  fs->make<TH1F>("eg_EEcalEtrue_4","  ",50,0.,2.);
-  eg_EEcalEtrue_5 =  fs->make<TH1F>("eg_EEcalEtrue_5","  ",50,0.,2.);
+  eg_EEcalEtrue_1 = fs->make<TH1F>("eg_EEcalEtrue_1", "  ", 50, 0., 2.);
+  eg_EEcalEtrue_2 = fs->make<TH1F>("eg_EEcalEtrue_2", "  ", 50, 0., 2.);
+  eg_EEcalEtrue_3 = fs->make<TH1F>("eg_EEcalEtrue_3", "  ", 50, 0., 2.);
+  eg_EEcalEtrue_4 = fs->make<TH1F>("eg_EEcalEtrue_4", "  ", 50, 0., 2.);
+  eg_EEcalEtrue_5 = fs->make<TH1F>("eg_EEcalEtrue_5", "  ", 50, 0., 2.);
 
-  pf_EEcalEtrue_1 =  fs->make<TH1F>("pf_EEcalEtrue_1","  ",50,0.,2.);
-  pf_EEcalEtrue_2 =  fs->make<TH1F>("pf_EEcalEtrue_2","  ",50,0.,2.);
-  pf_EEcalEtrue_3 =  fs->make<TH1F>("pf_EEcalEtrue_3","  ",50,0.,2.);
-  pf_EEcalEtrue_4 =  fs->make<TH1F>("pf_EEcalEtrue_4","  ",50,0.,2.);
-  pf_EEcalEtrue_5 =  fs->make<TH1F>("pf_EEcalEtrue_5","  ",50,0.,2.);
+  pf_EEcalEtrue_1 = fs->make<TH1F>("pf_EEcalEtrue_1", "  ", 50, 0., 2.);
+  pf_EEcalEtrue_2 = fs->make<TH1F>("pf_EEcalEtrue_2", "  ", 50, 0., 2.);
+  pf_EEcalEtrue_3 = fs->make<TH1F>("pf_EEcalEtrue_3", "  ", 50, 0., 2.);
+  pf_EEcalEtrue_4 = fs->make<TH1F>("pf_EEcalEtrue_4", "  ", 50, 0., 2.);
+  pf_EEcalEtrue_5 = fs->make<TH1F>("pf_EEcalEtrue_5", "  ", 50, 0., 2.);
 
-  ged_EEcalEtrue_1 =  fs->make<TH1F>("ged_EEcalEtrue_1","  ",50,0.,2.);
-  ged_EEcalEtrue_2 =  fs->make<TH1F>("ged_EEcalEtrue_2","  ",50,0.,2.);
-  ged_EEcalEtrue_3 =  fs->make<TH1F>("ged_EEcalEtrue_3","  ",50,0.,2.);
-  ged_EEcalEtrue_4 =  fs->make<TH1F>("ged_EEcalEtrue_4","  ",50,0.,2.);
-  ged_EEcalEtrue_5 =  fs->make<TH1F>("ged_EEcalEtrue_5","  ",50,0.,2.);
-  
+  ged_EEcalEtrue_1 = fs->make<TH1F>("ged_EEcalEtrue_1", "  ", 50, 0., 2.);
+  ged_EEcalEtrue_2 = fs->make<TH1F>("ged_EEcalEtrue_2", "  ", 50, 0., 2.);
+  ged_EEcalEtrue_3 = fs->make<TH1F>("ged_EEcalEtrue_3", "  ", 50, 0., 2.);
+  ged_EEcalEtrue_4 = fs->make<TH1F>("ged_EEcalEtrue_4", "  ", 50, 0., 2.);
+  ged_EEcalEtrue_5 = fs->make<TH1F>("ged_EEcalEtrue_5", "  ", 50, 0., 2.);
+
   //shower shapes
-  eg_e1x5_all  = fs->make<TH1F>("eg_e1x5_all","  ",60,0.,300.);
-  eg_e1x5_eb   = fs->make<TH1F>("eg_e1x5_eb","  ",60,0.,300.);
-  eg_e1x5_ee   = fs->make<TH1F>("eg_e1x5_ee","  ",60,0.,300.);
+  eg_e1x5_all = fs->make<TH1F>("eg_e1x5_all", "  ", 60, 0., 300.);
+  eg_e1x5_eb = fs->make<TH1F>("eg_e1x5_eb", "  ", 60, 0., 300.);
+  eg_e1x5_ee = fs->make<TH1F>("eg_e1x5_ee", "  ", 60, 0., 300.);
 
-  ged_e1x5_all = fs->make<TH1F>("ged_e1x5_all","  ",60,0.,300.);
-  ged_e1x5_eb  = fs->make<TH1F>("ged_e1x5_eb","  ",60,0.,300.);
-  ged_e1x5_ee  = fs->make<TH1F>("ged_e1x5_ee","  ",60,0.,300.);
+  ged_e1x5_all = fs->make<TH1F>("ged_e1x5_all", "  ", 60, 0., 300.);
+  ged_e1x5_eb = fs->make<TH1F>("ged_e1x5_eb", "  ", 60, 0., 300.);
+  ged_e1x5_ee = fs->make<TH1F>("ged_e1x5_ee", "  ", 60, 0., 300.);
 
-  pf_e1x5_all = fs->make<TH1F>("pf_e1x5_all","  ",60,0.,300.);
-  pf_e1x5_eb  = fs->make<TH1F>("pf_e1x5_eb","  ",60,0.,300.);
-  pf_e1x5_ee  = fs->make<TH1F>("pf_e1x5_ee","  ",60,0.,300.);
+  pf_e1x5_all = fs->make<TH1F>("pf_e1x5_all", "  ", 60, 0., 300.);
+  pf_e1x5_eb = fs->make<TH1F>("pf_e1x5_eb", "  ", 60, 0., 300.);
+  pf_e1x5_ee = fs->make<TH1F>("pf_e1x5_ee", "  ", 60, 0., 300.);
 
-  eg_sihih_all  = fs->make<TH1F>("eg_sihih_all","  ",100,0.0,0.05);
-  eg_sihih_eb   = fs->make<TH1F>("eg_sihih_eb","  ",100,0.0,0.05);
-  eg_sihih_ee   = fs->make<TH1F>("eg_sihih_ee","  ",100,0.0,0.05);
+  eg_sihih_all = fs->make<TH1F>("eg_sihih_all", "  ", 100, 0.0, 0.05);
+  eg_sihih_eb = fs->make<TH1F>("eg_sihih_eb", "  ", 100, 0.0, 0.05);
+  eg_sihih_ee = fs->make<TH1F>("eg_sihih_ee", "  ", 100, 0.0, 0.05);
 
-  ged_sihih_all = fs->make<TH1F>("ged_sihih_all","  ",100,0.0,0.05);
-  ged_sihih_eb  = fs->make<TH1F>("ged_sihih_eb","  ",100,0.0,0.05);
-  ged_sihih_ee  = fs->make<TH1F>("ged_sihih_ee","  ",100,0.0,0.05);
+  ged_sihih_all = fs->make<TH1F>("ged_sihih_all", "  ", 100, 0.0, 0.05);
+  ged_sihih_eb = fs->make<TH1F>("ged_sihih_eb", "  ", 100, 0.0, 0.05);
+  ged_sihih_ee = fs->make<TH1F>("ged_sihih_ee", "  ", 100, 0.0, 0.05);
 
-  pf_sihih_all = fs->make<TH1F>("pf_sihih_all","  ",100,0.0,0.05);
-  pf_sihih_eb  = fs->make<TH1F>("pf_sihih_eb","  ",100,0.0,0.05);
-  pf_sihih_ee  = fs->make<TH1F>("pf_sihih_ee","  ",100,0.0,0.05);
+  pf_sihih_all = fs->make<TH1F>("pf_sihih_all", "  ", 100, 0.0, 0.05);
+  pf_sihih_eb = fs->make<TH1F>("pf_sihih_eb", "  ", 100, 0.0, 0.05);
+  pf_sihih_ee = fs->make<TH1F>("pf_sihih_ee", "  ", 100, 0.0, 0.05);
 
-  eg_r9_all  = fs->make<TH1F>("eg_r9_all","  ",200,0.0,2.0);
-  eg_r9_eb   = fs->make<TH1F>("eg_r9_eb","  ",200,0.0,2.0);
-  eg_r9_ee   = fs->make<TH1F>("eg_r9_ee","  ",200,0.0,2.0);
+  eg_r9_all = fs->make<TH1F>("eg_r9_all", "  ", 200, 0.0, 2.0);
+  eg_r9_eb = fs->make<TH1F>("eg_r9_eb", "  ", 200, 0.0, 2.0);
+  eg_r9_ee = fs->make<TH1F>("eg_r9_ee", "  ", 200, 0.0, 2.0);
 
-  ged_r9_all = fs->make<TH1F>("ged_r9_all","  ",200,0.0,2.0);
-  ged_r9_eb  = fs->make<TH1F>("ged_r9_eb","  ",200,0.0,2.0);
-  ged_r9_ee  = fs->make<TH1F>("ged_r9_ee","  ",200,0.0,2.0);
+  ged_r9_all = fs->make<TH1F>("ged_r9_all", "  ", 200, 0.0, 2.0);
+  ged_r9_eb = fs->make<TH1F>("ged_r9_eb", "  ", 200, 0.0, 2.0);
+  ged_r9_ee = fs->make<TH1F>("ged_r9_ee", "  ", 200, 0.0, 2.0);
 
-  pf_r9_all = fs->make<TH1F>("pf_r9_all","  ",200,0.0,2.0);
-  pf_r9_eb  = fs->make<TH1F>("pf_r9_eb","  ",200,0.0,2.0);
-  pf_r9_ee  = fs->make<TH1F>("pf_r9_ee","  ",200,0.0,2.0);
+  pf_r9_all = fs->make<TH1F>("pf_r9_all", "  ", 200, 0.0, 2.0);
+  pf_r9_eb = fs->make<TH1F>("pf_r9_eb", "  ", 200, 0.0, 2.0);
+  pf_r9_ee = fs->make<TH1F>("pf_r9_ee", "  ", 200, 0.0, 2.0);
 
-  eg_scshh_all  = fs->make<TH1F>("eg_scshh_all","  ",100,0.0,0.06);
-  eg_scshh_eb   = fs->make<TH1F>("eg_scshh_eb","  ",100,0.0,0.06);
-  eg_scshh_ee   = fs->make<TH1F>("eg_scshh_ee","  ",100,0.0,0.06);
+  eg_scshh_all = fs->make<TH1F>("eg_scshh_all", "  ", 100, 0.0, 0.06);
+  eg_scshh_eb = fs->make<TH1F>("eg_scshh_eb", "  ", 100, 0.0, 0.06);
+  eg_scshh_ee = fs->make<TH1F>("eg_scshh_ee", "  ", 100, 0.0, 0.06);
 
-  ged_scshh_all = fs->make<TH1F>("ged_scshh_all","  ",100,0.0,0.06);
-  ged_scshh_eb  = fs->make<TH1F>("ged_scshh_eb","  ",100,0.0,0.06);
-  ged_scshh_ee  = fs->make<TH1F>("ged_scshh_ee","  ",100,0.0,0.06);
+  ged_scshh_all = fs->make<TH1F>("ged_scshh_all", "  ", 100, 0.0, 0.06);
+  ged_scshh_eb = fs->make<TH1F>("ged_scshh_eb", "  ", 100, 0.0, 0.06);
+  ged_scshh_ee = fs->make<TH1F>("ged_scshh_ee", "  ", 100, 0.0, 0.06);
 
-  pf_scshh_all = fs->make<TH1F>("pf_scshh_all","  ",100,0.0,0.06);
-  pf_scshh_eb  = fs->make<TH1F>("pf_scshh_eb","  ",100,0.0,0.06);
-  pf_scshh_ee  = fs->make<TH1F>("pf_scshh_ee","  ",100,0.0,0.06);
+  pf_scshh_all = fs->make<TH1F>("pf_scshh_all", "  ", 100, 0.0, 0.06);
+  pf_scshh_eb = fs->make<TH1F>("pf_scshh_eb", "  ", 100, 0.0, 0.06);
+  pf_scshh_ee = fs->make<TH1F>("pf_scshh_ee", "  ", 100, 0.0, 0.06);
 
-  eg_scsff_all  = fs->make<TH1F>("eg_scsff_all","  ",150,0.0,0.15);
-  eg_scsff_eb   = fs->make<TH1F>("eg_scsff_eb","  ",150,0.0,0.15);
-  eg_scsff_ee   = fs->make<TH1F>("eg_scsff_ee","  ",150,0.0,0.15);
+  eg_scsff_all = fs->make<TH1F>("eg_scsff_all", "  ", 150, 0.0, 0.15);
+  eg_scsff_eb = fs->make<TH1F>("eg_scsff_eb", "  ", 150, 0.0, 0.15);
+  eg_scsff_ee = fs->make<TH1F>("eg_scsff_ee", "  ", 150, 0.0, 0.15);
 
-  ged_scsff_all = fs->make<TH1F>("ged_scsff_all","  ",150,0.0,0.15);
-  ged_scsff_eb  = fs->make<TH1F>("ged_scsff_eb","  ",150,0.0,0.15);
-  ged_scsff_ee  = fs->make<TH1F>("ged_scsff_ee","  ",150,0.0,0.15);
+  ged_scsff_all = fs->make<TH1F>("ged_scsff_all", "  ", 150, 0.0, 0.15);
+  ged_scsff_eb = fs->make<TH1F>("ged_scsff_eb", "  ", 150, 0.0, 0.15);
+  ged_scsff_ee = fs->make<TH1F>("ged_scsff_ee", "  ", 150, 0.0, 0.15);
 
-  pf_scsff_all = fs->make<TH1F>("pf_scsff_all","  ",150,0.0,0.15);
-  pf_scsff_eb  = fs->make<TH1F>("pf_scsff_eb","  ",150,0.0,0.15);
-  pf_scsff_ee  = fs->make<TH1F>("pf_scsff_ee","  ",150,0.0,0.15);
- 
-  // MET 
-  pf_MET_reco = fs->make<TH1F>("pf_MET_reco","  ",10,0,1000);
-  pf_MET_rereco = fs->make<TH1F>("pf_MET_rereco","  ",10,0,1000);
- 
+  pf_scsff_all = fs->make<TH1F>("pf_scsff_all", "  ", 150, 0.0, 0.15);
+  pf_scsff_eb = fs->make<TH1F>("pf_scsff_eb", "  ", 150, 0.0, 0.15);
+  pf_scsff_ee = fs->make<TH1F>("pf_scsff_ee", "  ", 150, 0.0, 0.15);
+
+  // MET
+  pf_MET_reco = fs->make<TH1F>("pf_MET_reco", "  ", 10, 0, 1000);
+  pf_MET_rereco = fs->make<TH1F>("pf_MET_rereco", "  ", 10, 0, 1000);
 }
 
-
-GsfGEDElectronAnalyzer::~GsfGEDElectronAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+GsfGEDElectronAnalyzer::~GsfGEDElectronAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-GsfGEDElectronAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
-
-
+void GsfGEDElectronAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Candidate info
   Handle<reco::PFCandidateCollection> collection;
-  InputTag label("particleFlow::reRECO");  // <- Special electron coll. 
+  InputTag label("particleFlow::reRECO");  // <- Special electron coll.
   iEvent.getByLabel(label, collection);
   std::vector<reco::PFCandidate> candidates = (*collection.product());
 
-
   InputTag egammaLabel(string("gsfElectrons"));
   Handle<GsfElectronCollection> theGsfEleCollection;
-  iEvent.getByLabel(egammaLabel,theGsfEleCollection);
+  iEvent.getByLabel(egammaLabel, theGsfEleCollection);
   const GsfElectronCollection theGsfEle = *(theGsfEleCollection.product());
 
-
-  InputTag  MCTruthCollection(string("genParticles"));
+  InputTag MCTruthCollection(string("genParticles"));
   edm::Handle<std::vector<reco::GenParticle> > pMCTruth;
-  iEvent.getByLabel(MCTruthCollection,pMCTruth);
-
+  iEvent.getByLabel(MCTruthCollection, pMCTruth);
 
   InputTag gedEleLabel(string("gedGsfElectrons::reRECO"));
   Handle<GsfElectronCollection> theGedEleCollection;
-  iEvent.getByLabel(gedEleLabel,theGedEleCollection);
+  iEvent.getByLabel(gedEleLabel, theGedEleCollection);
   const GsfElectronCollection theGedEle = *(theGedEleCollection.product());
-
 
   //get and plot the reco met
   InputTag pfMETRecoLabel("pfMet::RECO");
   Handle<std::vector<reco::PFMET> > recoMet;
-  iEvent.getByLabel(pfMETRecoLabel,recoMet);
+  iEvent.getByLabel(pfMETRecoLabel, recoMet);
   pf_MET_reco->Fill(recoMet->at(0).et());
-  
+
   //get and plot the rereco met
   InputTag pfMETReRecoLabel("pfMet::reRECO");
   Handle<std::vector<reco::PFMET> > rerecoMet;
-  iEvent.getByLabel(pfMETReRecoLabel,rerecoMet);
+  iEvent.getByLabel(pfMETReRecoLabel, rerecoMet);
   pf_MET_rereco->Fill(rerecoMet->at(0).et());
-
 
   bool debug = true;
 
-
   ev++;
 
-  if(debug)
+  if (debug)
     cout << "************************* New Event:: " << ev << " *************************" << endl;
 
-  // Validation from generator events 
+  // Validation from generator events
 
-  for(std::vector<reco::GenParticle>::const_iterator cP = pMCTruth->begin(); 
-      cP != pMCTruth->end(); cP++ ) {
-
-    float etamc= cP->eta();
-    float phimc= cP->phi();
+  for (std::vector<reco::GenParticle>::const_iterator cP = pMCTruth->begin(); cP != pMCTruth->end(); cP++) {
+    float etamc = cP->eta();
+    float phimc = cP->phi();
     float ptmc = cP->pt();
     float Emc = cP->energy();
 
-
-    if(abs(cP->pdgId())==11 && cP->status()==1 
-       && cP->pt() > 2. && 
-       fabs(cP->eta()) < 2.5 ){
-   
+    if (abs(cP->pdgId()) == 11 && cP->status() == 1 && cP->pt() > 2. && fabs(cP->eta()) < 2.5) {
       h_etamc_ele->Fill(etamc);
       h_ptmc_ele->Fill(ptmc);
-      
+
       float MindR = 1000.;
       float mvaCutEle = -1.;
       bool isPfTrDr = false;
       bool isPfEcDr = false;
 
-
-
-      if(debug)
-	cout << " MC particle:  pt " << ptmc << " eta,phi " <<  etamc << ", " << phimc << endl;
-
-
+      if (debug)
+        cout << " MC particle:  pt " << ptmc << " eta,phi " << etamc << ", " << phimc << endl;
 
       std::vector<reco::PFCandidate>::iterator it;
-      for ( it = candidates.begin(); it != candidates.end(); ++it )   {
-	reco::PFCandidate::ParticleType type = (*it).particleId();
+      for (it = candidates.begin(); it != candidates.end(); ++it) {
+        reco::PFCandidate::ParticleType type = (*it).particleId();
 
-	if ( type == reco::PFCandidate::e )	{ 
-	  
-	 
-	  float eta =  (*it).eta();
-	  float phi =  (*it).phi();
-	  float pfmva = (*it).mva_e_pi();
+        if (type == reco::PFCandidate::e) {
+          float eta = (*it).eta();
+          float phi = (*it).phi();
+          float pfmva = (*it).mva_e_pi();
 
+          reco::GsfTrackRef refGsf = (*it).gsfTrackRef();
+          //ElectronSeedRef seedRef= refGsf->extra()->seedRef().castTo<ElectronSeedRef>();
 
-	  reco::GsfTrackRef refGsf = (*it).gsfTrackRef();
-	  //ElectronSeedRef seedRef= refGsf->extra()->seedRef().castTo<ElectronSeedRef>();
+          float deta = etamc - eta;
+          float dphi = normalizedPhi(phimc - phi);
+          float dR = sqrt(deta * deta + dphi * dphi);
 
-
-	  float deta = etamc - eta;
-	  float dphi = normalizedPhi(phimc - phi);
-	  float dR = sqrt(deta*deta + dphi*dphi);
-
-	  if(dR < 0.05){
-	    MindR = dR;
-	    mvaCutEle = (*it).mva_e_pi();
-	    /*
+          if (dR < 0.05) {
+            MindR = dR;
+            mvaCutEle = (*it).mva_e_pi();
+            /*
 	    if(seedRef->isEcalDriven())
 	      isPfEcDr = true;
 	    if(seedRef->isTrackerDriven())
 	      isPfTrDr = true;
 	    */
 
-	    if(debug)
-	      cout << " PF ele matched:  pt " << (*it).pt()  << " (" << (*it).ecalEnergy()/std::cosh(eta) << ") "<< " eta,phi " <<  eta << ", " << phi << " pfmva " << pfmva << endl;
-	    // all for the moment
-	  }
-	} // End PFCandidates Electron Selection
-      } // End Loop PFCandidates
-      
-      if (MindR < 0.05) {      
-	h_mva_ele->Fill(mvaCutEle);
-    	h_etaec_ele->Fill(etamc);
-	h_ptec_ele->Fill(ptmc);
+            if (debug)
+              cout << " PF ele matched:  pt " << (*it).pt() << " (" << (*it).ecalEnergy() / std::cosh(eta) << ") "
+                   << " eta,phi " << eta << ", " << phi << " pfmva " << pfmva << endl;
+            // all for the moment
+          }
+        }  // End PFCandidates Electron Selection
+      }    // End Loop PFCandidates
 
-	if(isPfEcDr) {
-	  h_etaecEcDr_ele->Fill(etamc);
-	  h_ptecEcDr_ele->Fill(ptmc);
-	}
-	if(isPfTrDr) {
-	  h_etaecTrDr_ele->Fill(etamc);
-	  h_ptecTrDr_ele->Fill(ptmc);
-	}
+      if (MindR < 0.05) {
+        h_mva_ele->Fill(mvaCutEle);
+        h_etaec_ele->Fill(etamc);
+        h_ptec_ele->Fill(ptmc);
+
+        if (isPfEcDr) {
+          h_etaecEcDr_ele->Fill(etamc);
+          h_ptecEcDr_ele->Fill(ptmc);
+        }
+        if (isPfTrDr) {
+          h_etaecTrDr_ele->Fill(etamc);
+          h_ptecTrDr_ele->Fill(ptmc);
+        }
+      } else {
+        etaphi_nonreco->Fill(etamc, phimc);
       }
-      else {
-	etaphi_nonreco->Fill(etamc,phimc);
 
-      }
-
-      float MindREG =1000;
+      float MindREG = 1000;
       bool isEgTrDr = false;
       bool isEgEcDr = false;
-      
-      for (uint j=0; j<theGsfEle.size();j++) {
-	reco::GsfTrackRef egGsfTrackRef = (theGsfEle[j]).gsfTrack();
-	float etareco = theGsfEle[j].eta();
-	float phireco = theGsfEle[j].phi();
 
-	float pfmva =  theGsfEle[j].mva_e_pi();
+      for (uint j = 0; j < theGsfEle.size(); j++) {
+        reco::GsfTrackRef egGsfTrackRef = (theGsfEle[j]).gsfTrack();
+        float etareco = theGsfEle[j].eta();
+        float phireco = theGsfEle[j].phi();
 
-	reco::GsfTrackRef refGsf =  theGsfEle[j].gsfTrack();
-	//ElectronSeedRef seedRef= refGsf->extra()->seedRef().castTo<ElectronSeedRef>();
+        float pfmva = theGsfEle[j].mva_e_pi();
 
+        reco::GsfTrackRef refGsf = theGsfEle[j].gsfTrack();
+        //ElectronSeedRef seedRef= refGsf->extra()->seedRef().castTo<ElectronSeedRef>();
 
-	float deta = etamc - etareco;
-	float dphi = normalizedPhi(phimc - phireco);
-	float dR = sqrt(deta*deta + dphi*dphi);
+        float deta = etamc - etareco;
+        float dphi = normalizedPhi(phimc - phireco);
+        float dR = sqrt(deta * deta + dphi * dphi);
 
-	float SCEnergy = (theGsfEle[j]).superCluster()->energy();
-	float ErecoEtrue = SCEnergy/Emc;
+        float SCEnergy = (theGsfEle[j]).superCluster()->energy();
+        float ErecoEtrue = SCEnergy / Emc;
 
+        if (dR < 0.05) {
+          if (debug)
+            cout << " EG ele matched: pt " << theGsfEle[j].pt() << " (" << SCEnergy / std::cosh(etareco) << ") "
+                 << " eta,phi " << etareco << ", " << phireco << " pfmva " << pfmva << endl;
 
+          if (fabs(etamc) < 0.5) {
+            eg_EEcalEtrue_1->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {
+            eg_EEcalEtrue_2->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {
+            eg_EEcalEtrue_3->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
+            eg_EEcalEtrue_4->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
+            eg_EEcalEtrue_5->Fill(ErecoEtrue);
+          }
 
-	if(dR < 0.05){
-	  if(debug)
-	    cout << " EG ele matched: pt " << theGsfEle[j].pt() << " (" << SCEnergy/std::cosh(etareco) << ") " << " eta,phi " <<  etareco << ", " << phireco << " pfmva " <<  pfmva << endl;
-	
+          if ((theGsfEle[j].parentSuperCluster()).isNonnull()) {
+            float SCPF = (theGsfEle[j]).parentSuperCluster()->rawEnergy();
+            float EpfEtrue = SCPF / Emc;
+            if (fabs(etamc) < 0.5) {
+              pf_EEcalEtrue_1->Fill(EpfEtrue);
+            }
+            if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {
+              pf_EEcalEtrue_2->Fill(EpfEtrue);
+            }
+            if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {
+              pf_EEcalEtrue_3->Fill(EpfEtrue);
+            }
+            if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
+              pf_EEcalEtrue_4->Fill(EpfEtrue);
+            }
+            if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
+              pf_EEcalEtrue_5->Fill(EpfEtrue);
+            }
+            const reco::GsfElectron::ShowerShape &pfshapes = theGsfEle[j].showerShape();
 
-	  if (fabs(etamc) < 0.5) {
-	    eg_EEcalEtrue_1->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {	
-	    eg_EEcalEtrue_2->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {	
-	    eg_EEcalEtrue_3->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
-	    eg_EEcalEtrue_4->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
-	    eg_EEcalEtrue_5->Fill(ErecoEtrue);
-	  }
+            pf_e1x5_all->Fill(pfshapes.e1x5);
+            pf_sihih_all->Fill(pfshapes.sigmaIetaIeta);
+            pf_r9_all->Fill(pfshapes.r9);
+            pf_scshh_all->Fill((theGsfEle[j]).parentSuperCluster()->etaWidth());
+            pf_scsff_all->Fill((theGsfEle[j]).parentSuperCluster()->phiWidth());
+            if (std::abs(etareco) < 1.479) {
+              pf_e1x5_eb->Fill(pfshapes.e1x5);
+              pf_sihih_eb->Fill(pfshapes.sigmaIetaIeta);
+              pf_r9_eb->Fill(pfshapes.r9);
+              pf_scshh_eb->Fill((theGsfEle[j]).parentSuperCluster()->etaWidth());
+              pf_scsff_eb->Fill((theGsfEle[j]).parentSuperCluster()->phiWidth());
+            }
+            if (std::abs(etareco) >= 1.479) {
+              pf_e1x5_ee->Fill(pfshapes.e1x5);
+              pf_sihih_ee->Fill(pfshapes.sigmaIetaIeta);
+              pf_r9_ee->Fill(pfshapes.r9);
+              pf_scshh_ee->Fill((theGsfEle[j]).parentSuperCluster()->etaWidth());
+              pf_scsff_ee->Fill((theGsfEle[j]).parentSuperCluster()->phiWidth());
+            }
+          }
 
-	  if( (theGsfEle[j].parentSuperCluster()).isNonnull()) {
-	    float SCPF = (theGsfEle[j]).parentSuperCluster()->rawEnergy();
-	    float EpfEtrue = SCPF/Emc;
-	    if (fabs(etamc) < 0.5) {
-	      pf_EEcalEtrue_1->Fill(EpfEtrue);
-	    }
-	    if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {	
-	      pf_EEcalEtrue_2->Fill(EpfEtrue);
-	    }
-	    if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {	
-	      pf_EEcalEtrue_3->Fill(EpfEtrue);
-	    }
-	    if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
-	      pf_EEcalEtrue_4->Fill(EpfEtrue);
-	    }
-	    if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
-	      pf_EEcalEtrue_5->Fill(EpfEtrue);
-	    }
-	    const reco::GsfElectron::ShowerShape& pfshapes = 
-	      theGsfEle[j].showerShape();
-	    
-	    pf_e1x5_all->Fill(pfshapes.e1x5);
-	    pf_sihih_all->Fill(pfshapes.sigmaIetaIeta);
-	    pf_r9_all->Fill(pfshapes.r9);
-	    pf_scshh_all->Fill((theGsfEle[j]).parentSuperCluster()->etaWidth());
-	    pf_scsff_all->Fill((theGsfEle[j]).parentSuperCluster()->phiWidth());
-	    if( std::abs(etareco) < 1.479 ) {
-	      pf_e1x5_eb->Fill(pfshapes.e1x5);
-	      pf_sihih_eb->Fill(pfshapes.sigmaIetaIeta);
-	      pf_r9_eb->Fill(pfshapes.r9);
-	      pf_scshh_eb->Fill((theGsfEle[j]).parentSuperCluster()->etaWidth());
-	      pf_scsff_eb->Fill((theGsfEle[j]).parentSuperCluster()->phiWidth());
-	    }
-	    if( std::abs(etareco) >= 1.479 ) {
-	      pf_e1x5_ee->Fill(pfshapes.e1x5);
-	      pf_sihih_ee->Fill(pfshapes.sigmaIetaIeta);
-	      pf_r9_ee->Fill(pfshapes.r9);
-	      pf_scshh_ee->Fill((theGsfEle[j]).parentSuperCluster()->etaWidth());
-	      pf_scsff_ee->Fill((theGsfEle[j]).parentSuperCluster()->phiWidth());
-	    }
-	    
-	  }
+          eg_e1x5_all->Fill(theGsfEle[j].e1x5());
+          eg_sihih_all->Fill(theGsfEle[j].sigmaIetaIeta());
+          eg_r9_all->Fill(theGsfEle[j].r9());
+          eg_scshh_all->Fill((theGsfEle[j]).superCluster()->etaWidth());
+          eg_scsff_all->Fill((theGsfEle[j]).superCluster()->phiWidth());
+          if (std::abs(etareco) < 1.479) {
+            eg_e1x5_eb->Fill(theGsfEle[j].e1x5());
+            eg_sihih_eb->Fill(theGsfEle[j].sigmaIetaIeta());
+            eg_r9_eb->Fill(theGsfEle[j].r9());
+            eg_scshh_eb->Fill((theGsfEle[j]).superCluster()->etaWidth());
+            eg_scsff_eb->Fill((theGsfEle[j]).superCluster()->phiWidth());
+          }
+          if (std::abs(etareco) >= 1.479) {
+            eg_e1x5_ee->Fill(theGsfEle[j].e1x5());
+            eg_sihih_ee->Fill(theGsfEle[j].sigmaIetaIeta());
+            eg_r9_ee->Fill(theGsfEle[j].r9());
+            eg_scshh_ee->Fill((theGsfEle[j]).superCluster()->etaWidth());
+            eg_scsff_ee->Fill((theGsfEle[j]).superCluster()->phiWidth());
+          }
 
-	  eg_e1x5_all->Fill(theGsfEle[j].e1x5());
-	  eg_sihih_all->Fill(theGsfEle[j].sigmaIetaIeta());
-	  eg_r9_all->Fill(theGsfEle[j].r9());
-	  eg_scshh_all->Fill((theGsfEle[j]).superCluster()->etaWidth());
-	  eg_scsff_all->Fill((theGsfEle[j]).superCluster()->phiWidth());
-	  if( std::abs(etareco) < 1.479 ) {
-	    eg_e1x5_eb->Fill(theGsfEle[j].e1x5());
-	    eg_sihih_eb->Fill(theGsfEle[j].sigmaIetaIeta());
-	    eg_r9_eb->Fill(theGsfEle[j].r9());
-	    eg_scshh_eb->Fill((theGsfEle[j]).superCluster()->etaWidth());
-	    eg_scsff_eb->Fill((theGsfEle[j]).superCluster()->phiWidth());
-	  }
-	  if( std::abs(etareco) >= 1.479 ) {
-	    eg_e1x5_ee->Fill(theGsfEle[j].e1x5());
-	    eg_sihih_ee->Fill(theGsfEle[j].sigmaIetaIeta());
-	    eg_r9_ee->Fill(theGsfEle[j].r9());
-	    eg_scshh_ee->Fill((theGsfEle[j]).superCluster()->etaWidth());
-	    eg_scsff_ee->Fill((theGsfEle[j]).superCluster()->phiWidth());
-	  }
-  
-	  MindREG = dR;
-	  /*
+          MindREG = dR;
+          /*
 	  if(seedRef->isEcalDriven())
 	    isEgEcDr = true;
 	  if(seedRef->isTrackerDriven())
 	    isEgTrDr = true;
 	  */
-	}
+        }
       }
-      if(MindREG < 0.05) {
-	h_etaeg_ele->Fill(etamc);
-	h_pteg_ele->Fill(ptmc);
+      if (MindREG < 0.05) {
+        h_etaeg_ele->Fill(etamc);
+        h_pteg_ele->Fill(ptmc);
 
-
-	// This is to understand the contribution of each seed type. 
-	if(isEgEcDr) {
-	  h_etaegEcDr_ele->Fill(etamc);
-	  h_ptegEcDr_ele->Fill(ptmc);
-	}
-	if(isEgTrDr) {
-	  h_etaegTrDr_ele->Fill(etamc);
-	  h_ptegTrDr_ele->Fill(ptmc);
-	}
+        // This is to understand the contribution of each seed type.
+        if (isEgEcDr) {
+          h_etaegEcDr_ele->Fill(etamc);
+          h_ptegEcDr_ele->Fill(ptmc);
+        }
+        if (isEgTrDr) {
+          h_etaegTrDr_ele->Fill(etamc);
+          h_ptegTrDr_ele->Fill(ptmc);
+        }
       }
-
-
-
 
       //Add loop on the GED electrons
-      
-      
-      float MindRGedEg =1000;
+
+      float MindRGedEg = 1000;
       bool isGedEgTrDr = false;
       bool isGedEgEcDr = false;
-      
-      for (uint j=0; j<theGedEle.size();j++) {
-	reco::GsfTrackRef egGsfTrackRef = (theGedEle[j]).gsfTrack();
-	float etareco = theGedEle[j].eta();
-	float phireco = theGedEle[j].phi();	
-	float pfmva =  theGedEle[j].mva_e_pi();
-	
-	reco::GsfTrackRef refGsf =  theGedEle[j].gsfTrack();
-	//ElectronSeedRef seedRef= refGsf->extra()->seedRef().castTo<ElectronSeedRef>();
-	
-	
-	float deta = etamc - etareco;
-	float dphi = normalizedPhi(phimc - phireco);
-	float dR = sqrt(deta*deta + dphi*dphi);
-	
-	float SCEnergy = (theGedEle[j]).superCluster()->energy();
-	float ErecoEtrue = SCEnergy/Emc;
 
-	
+      for (uint j = 0; j < theGedEle.size(); j++) {
+        reco::GsfTrackRef egGsfTrackRef = (theGedEle[j]).gsfTrack();
+        float etareco = theGedEle[j].eta();
+        float phireco = theGedEle[j].phi();
+        float pfmva = theGedEle[j].mva_e_pi();
 
-	if(dR < 0.05){	  
-	  const reco::PFCandidate* matchPF = NULL;
-	  if(debug)
-	    cout << " GED ele matched: pt " << theGedEle[j].pt() << " (" << SCEnergy/std::cosh(etareco) << ") "<< " eta,phi " <<  etareco << ", " << phireco << " pfmva " <<  pfmva << endl;
-	  
-	  for( unsigned k = 0; k < candidates.size(); ++k ) {
-	    if( std::abs(candidates[k].pdgId()) == 11 ) {
-	      reco::GsfTrackRef gsfEleGsfTrackRef = 
-		candidates[k].gsfTrackRef();
-	      if( gsfEleGsfTrackRef->ptMode() == egGsfTrackRef->ptMode() ) {
-		matchPF = &candidates[k];	     
-	      }
-	    }
-	  }
+        reco::GsfTrackRef refGsf = theGedEle[j].gsfTrack();
+        //ElectronSeedRef seedRef= refGsf->extra()->seedRef().castTo<ElectronSeedRef>();
 
-	  if( debug && matchPF ) std::cout << "GED-PF match!" << std::endl;
+        float deta = etamc - etareco;
+        float dphi = normalizedPhi(phimc - phireco);
+        float dR = sqrt(deta * deta + dphi * dphi);
 
-	  if( ErecoEtrue < 0.6 ) std::cout << "++bad Ereco/Etrue: " 
-					   << ErecoEtrue << std::endl;
+        float SCEnergy = (theGedEle[j]).superCluster()->energy();
+        float ErecoEtrue = SCEnergy / Emc;
 
-	  if (fabs(etamc) < 0.5) {
-	    ged_EEcalEtrue_1->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {	
-	    ged_EEcalEtrue_2->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {	
-	    ged_EEcalEtrue_3->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
-	    ged_EEcalEtrue_4->Fill(ErecoEtrue);
-	  }
-	  if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
-	    ged_EEcalEtrue_5->Fill(ErecoEtrue);
-	    /*
+        if (dR < 0.05) {
+          const reco::PFCandidate *matchPF = NULL;
+          if (debug)
+            cout << " GED ele matched: pt " << theGedEle[j].pt() << " (" << SCEnergy / std::cosh(etareco) << ") "
+                 << " eta,phi " << etareco << ", " << phireco << " pfmva " << pfmva << endl;
+
+          for (unsigned k = 0; k < candidates.size(); ++k) {
+            if (std::abs(candidates[k].pdgId()) == 11) {
+              reco::GsfTrackRef gsfEleGsfTrackRef = candidates[k].gsfTrackRef();
+              if (gsfEleGsfTrackRef->ptMode() == egGsfTrackRef->ptMode()) {
+                matchPF = &candidates[k];
+              }
+            }
+          }
+
+          if (debug && matchPF)
+            std::cout << "GED-PF match!" << std::endl;
+
+          if (ErecoEtrue < 0.6)
+            std::cout << "++bad Ereco/Etrue: " << ErecoEtrue << std::endl;
+
+          if (fabs(etamc) < 0.5) {
+            ged_EEcalEtrue_1->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 0.5 && fabs(etamc) < 1.0) {
+            ged_EEcalEtrue_2->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 1.0 && fabs(etamc) < 1.5) {
+            ged_EEcalEtrue_3->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 1.5 && fabs(etamc) < 2.0) {
+            ged_EEcalEtrue_4->Fill(ErecoEtrue);
+          }
+          if (fabs(etamc) >= 2.0 && fabs(etamc) < 2.5) {
+            ged_EEcalEtrue_5->Fill(ErecoEtrue);
+            /*
 	    if( debug && matchPF && ErecoEtrue > 1.30 ) {
 	      cout << " -PF ele matched: pt " 
 		   << matchPF->pt()
@@ -623,74 +564,60 @@ GsfGEDElectronAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
 	      
 	    }
 	    */
-	  }
+          }
 
-	  ged_e1x5_all->Fill(theGedEle[j].e1x5());
-	  ged_sihih_all->Fill(theGedEle[j].sigmaIetaIeta());
-	  ged_r9_all->Fill(theGedEle[j].r9());
-	  ged_scshh_all->Fill((theGedEle[j]).superCluster()->etaWidth());
-	  ged_scsff_all->Fill((theGedEle[j]).superCluster()->phiWidth());
-	  if( std::abs(etareco) < 1.479 ) {
-	    ged_e1x5_eb->Fill(theGedEle[j].e1x5());
-	    ged_sihih_eb->Fill(theGedEle[j].sigmaIetaIeta());
-	    ged_r9_eb->Fill(theGedEle[j].r9());
-	    ged_scshh_eb->Fill((theGedEle[j]).superCluster()->etaWidth());
-	    ged_scsff_eb->Fill((theGedEle[j]).superCluster()->phiWidth());
-	  }
-	  if( std::abs(etareco) >= 1.479 ) {
-	    ged_e1x5_ee->Fill(theGedEle[j].e1x5());
-	    ged_sihih_ee->Fill(theGedEle[j].sigmaIetaIeta());
-	    ged_r9_ee->Fill(theGedEle[j].r9());
-	    ged_scshh_ee->Fill((theGedEle[j]).superCluster()->etaWidth());
-	    ged_scsff_eb->Fill((theGedEle[j]).superCluster()->phiWidth());
-	  }
+          ged_e1x5_all->Fill(theGedEle[j].e1x5());
+          ged_sihih_all->Fill(theGedEle[j].sigmaIetaIeta());
+          ged_r9_all->Fill(theGedEle[j].r9());
+          ged_scshh_all->Fill((theGedEle[j]).superCluster()->etaWidth());
+          ged_scsff_all->Fill((theGedEle[j]).superCluster()->phiWidth());
+          if (std::abs(etareco) < 1.479) {
+            ged_e1x5_eb->Fill(theGedEle[j].e1x5());
+            ged_sihih_eb->Fill(theGedEle[j].sigmaIetaIeta());
+            ged_r9_eb->Fill(theGedEle[j].r9());
+            ged_scshh_eb->Fill((theGedEle[j]).superCluster()->etaWidth());
+            ged_scsff_eb->Fill((theGedEle[j]).superCluster()->phiWidth());
+          }
+          if (std::abs(etareco) >= 1.479) {
+            ged_e1x5_ee->Fill(theGedEle[j].e1x5());
+            ged_sihih_ee->Fill(theGedEle[j].sigmaIetaIeta());
+            ged_r9_ee->Fill(theGedEle[j].r9());
+            ged_scshh_ee->Fill((theGedEle[j]).superCluster()->etaWidth());
+            ged_scsff_eb->Fill((theGedEle[j]).superCluster()->phiWidth());
+          }
 
-	  MindRGedEg = dR;
-	  /*
+          MindRGedEg = dR;
+          /*
 	  if(seedRef->isEcalDriven())
 	    isGedEgEcDr = true;
 	  if(seedRef->isTrackerDriven())
 	    isGedEgTrDr = true;
 	  */
-	}
+        }
       }
-      if(MindRGedEg < 0.05) {
-	h_etaged_ele->Fill(etamc);
-	h_ptged_ele->Fill(ptmc);
-	
-	
-	// This is to understand the contribution of each seed type. 
-	if(isGedEgEcDr) {
-	  h_etagedEcDr_ele->Fill(etamc);
-	  h_ptgedEcDr_ele->Fill(ptmc);
-	}
-	if(isGedEgTrDr) {
-	  h_etagedTrDr_ele->Fill(etamc);
-	  h_ptgedTrDr_ele->Fill(ptmc);
-	}
-      }//End Loop Generator Particles  
-      
-      
+      if (MindRGedEg < 0.05) {
+        h_etaged_ele->Fill(etamc);
+        h_ptged_ele->Fill(ptmc);
 
+        // This is to understand the contribution of each seed type.
+        if (isGedEgEcDr) {
+          h_etagedEcDr_ele->Fill(etamc);
+          h_ptgedEcDr_ele->Fill(ptmc);
+        }
+        if (isGedEgTrDr) {
+          h_etagedTrDr_ele->Fill(etamc);
+          h_ptgedTrDr_ele->Fill(ptmc);
+        }
+      }  //End Loop Generator Particles
 
-    } //End IF Generator Particles 
-  
-  
-  } //End Loop Generator Particles 
+    }  //End IF Generator Particles
 
+  }  //End Loop Generator Particles
 }
 // ------------ method called once each job just before starting event loop  ------------
-void 
-GsfGEDElectronAnalyzer::beginJob()
-{
-
-  ev = 0;
-}
+void GsfGEDElectronAnalyzer::beginJob() { ev = 0; }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-GsfGEDElectronAnalyzer::endJob() {
-  cout << " endJob:: #events " << ev << endl;
-}
+void GsfGEDElectronAnalyzer::endJob() { cout << " endJob:: #events " << ev << endl; }
 //define this as a plug-in
 DEFINE_FWK_MODULE(GsfGEDElectronAnalyzer);

--- a/RecoParticleFlow/PFProducer/test/PFBlockComparator.cc
+++ b/RecoParticleFlow/PFProducer/test/PFBlockComparator.cc
@@ -2,7 +2,7 @@
 // Class: PFEGCandidateTreeMaker.cc
 //
 // Info: Outputs a tree with PF-EGamma information, mostly SC info.
-//       Checks to see if the input EG candidates are matched to 
+//       Checks to see if the input EG candidates are matched to
 //       some existing PF reco (PF-Photons and PF-Electrons).
 //
 // Author: L. Gray (FNAL)
@@ -76,68 +76,49 @@ namespace {
   struct ElementEquals {
     const reco::PFBlockElement& cmpElem;
     ElementEquals(const reco::PFBlockElement& e) : cmpElem(e) {}
-    bool operator()(const reco::PFBlockElement& chkElem ) const {
+    bool operator()(const reco::PFBlockElement& chkElem) const {
       bool result = false;
-      if( cmpElem.type() == chkElem.type() ) {
-	switch( cmpElem.type() ) {
-	case reco::PFBlockElement::TRACK:
-	  result = ( cmpElem.trackRef().isNonnull() &&
-		     chkElem.trackRef().isNonnull() &&
-		     cmpElem.trackRef()->momentum() == 
-		     chkElem.trackRef()->momentum() );	    
-	  break;
-	case reco::PFBlockElement::PS1:
-	case reco::PFBlockElement::PS2:
-	case reco::PFBlockElement::ECAL:
-	case reco::PFBlockElement::HCAL:
-	case reco::PFBlockElement::HFEM:
-	case reco::PFBlockElement::HFHAD:
-	case reco::PFBlockElement::HO:
-	  result = ( cmpElem.clusterRef().isNonnull() &&
-		     chkElem.clusterRef().isNonnull() &&
-		     cmpElem.clusterRef().key() == chkElem.clusterRef().key() );	    
-	  break;
-	case reco::PFBlockElement::SC:
-	  {
-	    const reco::PFBlockElementSuperCluster& cmpSC= 
-	      static_cast<const reco::PFBlockElementSuperCluster&>(cmpElem);
-	    const reco::PFBlockElementSuperCluster& chkSC= 
-	      static_cast<const reco::PFBlockElementSuperCluster&>(chkElem);	      
-	    result = ( cmpSC.superClusterRef().isNonnull() &&
-		       chkSC.superClusterRef().isNonnull() &&
-		       cmpSC.superClusterRef()->position() == 
-		       chkSC.superClusterRef()->position() );	      
-	  }
-	  break;
-	case reco::PFBlockElement::GSF:
-	  {
-	    const reco::PFBlockElementGsfTrack& cmpGSF = 
-	      static_cast<const reco::PFBlockElementGsfTrack&>(cmpElem);
-	    const reco::PFBlockElementGsfTrack& chkGSF = 
-	      static_cast<const reco::PFBlockElementGsfTrack&>(chkElem);	      
-	    result = ( cmpGSF.GsftrackRef().isNonnull() &&
-		       chkGSF.GsftrackRef().isNonnull() &&
-		       cmpGSF.GsftrackRef()->momentum() == 
-		       chkGSF.GsftrackRef()->momentum() );	      
-	  }
-	  break;
-	case reco::PFBlockElement::BREM:
-	  {
-	    const reco::PFBlockElementBrem& cmpBREM = 
-	      static_cast<const reco::PFBlockElementBrem&>(cmpElem);
-	    const reco::PFBlockElementBrem& chkBREM = 
-	      static_cast<const reco::PFBlockElementBrem&>(chkElem);	      
-	    result = ( cmpBREM.GsftrackRef().isNonnull() &&
-		       chkBREM.GsftrackRef().isNonnull() &&
-		       cmpBREM.GsftrackRef()->momentum() == 
-		       chkBREM.GsftrackRef()->momentum() &&
-		       cmpBREM.indTrajPoint() == chkBREM.indTrajPoint() );	      
-	  }
-	  break;
-	default:
-	  throw cms::Exception("UnknownBlockElementType")
-	    << cmpElem.type() << " is not a known PFBlockElement type!" << std::endl;
-	}
+      if (cmpElem.type() == chkElem.type()) {
+        switch (cmpElem.type()) {
+          case reco::PFBlockElement::TRACK:
+            result = (cmpElem.trackRef().isNonnull() && chkElem.trackRef().isNonnull() &&
+                      cmpElem.trackRef()->momentum() == chkElem.trackRef()->momentum());
+            break;
+          case reco::PFBlockElement::PS1:
+          case reco::PFBlockElement::PS2:
+          case reco::PFBlockElement::ECAL:
+          case reco::PFBlockElement::HCAL:
+          case reco::PFBlockElement::HFEM:
+          case reco::PFBlockElement::HFHAD:
+          case reco::PFBlockElement::HO:
+            result = (cmpElem.clusterRef().isNonnull() && chkElem.clusterRef().isNonnull() &&
+                      cmpElem.clusterRef().key() == chkElem.clusterRef().key());
+            break;
+          case reco::PFBlockElement::SC: {
+            const reco::PFBlockElementSuperCluster& cmpSC =
+                static_cast<const reco::PFBlockElementSuperCluster&>(cmpElem);
+            const reco::PFBlockElementSuperCluster& chkSC =
+                static_cast<const reco::PFBlockElementSuperCluster&>(chkElem);
+            result = (cmpSC.superClusterRef().isNonnull() && chkSC.superClusterRef().isNonnull() &&
+                      cmpSC.superClusterRef()->position() == chkSC.superClusterRef()->position());
+          } break;
+          case reco::PFBlockElement::GSF: {
+            const reco::PFBlockElementGsfTrack& cmpGSF = static_cast<const reco::PFBlockElementGsfTrack&>(cmpElem);
+            const reco::PFBlockElementGsfTrack& chkGSF = static_cast<const reco::PFBlockElementGsfTrack&>(chkElem);
+            result = (cmpGSF.GsftrackRef().isNonnull() && chkGSF.GsftrackRef().isNonnull() &&
+                      cmpGSF.GsftrackRef()->momentum() == chkGSF.GsftrackRef()->momentum());
+          } break;
+          case reco::PFBlockElement::BREM: {
+            const reco::PFBlockElementBrem& cmpBREM = static_cast<const reco::PFBlockElementBrem&>(cmpElem);
+            const reco::PFBlockElementBrem& chkBREM = static_cast<const reco::PFBlockElementBrem&>(chkElem);
+            result = (cmpBREM.GsftrackRef().isNonnull() && chkBREM.GsftrackRef().isNonnull() &&
+                      cmpBREM.GsftrackRef()->momentum() == chkBREM.GsftrackRef()->momentum() &&
+                      cmpBREM.indTrajPoint() == chkBREM.indTrajPoint());
+          } break;
+          default:
+            throw cms::Exception("UnknownBlockElementType")
+                << cmpElem.type() << " is not a known PFBlockElement type!" << std::endl;
+        }
       }
       return result;
     }
@@ -147,176 +128,158 @@ namespace {
     const reco::PFBlock* tocompare;
     HasElementOverlap(const reco::PFBlock& a) : tocompare(&a) {}
     bool operator()(const reco::PFBlock& b) const {
-      bool result = false;     
-      for( const auto& cmpElem : tocompare->elements() ) {		  
-	for( const auto& chkElem : b.elements() ) {	  
-	  // can't be equal elements if type not equal
-	  if( cmpElem.type() != chkElem.type() ) continue; 
-	  switch( cmpElem.type() ) {
-	  case reco::PFBlockElement::TRACK:
-	    result = ( cmpElem.trackRef().isNonnull() &&
-		       chkElem.trackRef().isNonnull() &&
-		       cmpElem.trackRef()->momentum() == chkElem.trackRef()->momentum() );	    
-	    break;
-	  case reco::PFBlockElement::PS1:
-	  case reco::PFBlockElement::PS2:
-	  case reco::PFBlockElement::ECAL:
-	  case reco::PFBlockElement::HCAL:
-	  case reco::PFBlockElement::HFEM:
-	  case reco::PFBlockElement::HFHAD:
-	  case reco::PFBlockElement::HO:
-	    result = ( cmpElem.clusterRef().isNonnull() &&
-		       chkElem.clusterRef().isNonnull() &&
-		       cmpElem.clusterRef().key() == chkElem.clusterRef().key() );	    
-	    break;
-	  case reco::PFBlockElement::SC:
-	    {
-	      const reco::PFBlockElementSuperCluster& cmpSC= 
-		static_cast<const reco::PFBlockElementSuperCluster&>(cmpElem);
-	      const reco::PFBlockElementSuperCluster& chkSC= 
-		static_cast<const reco::PFBlockElementSuperCluster&>(chkElem);	      
-	      result = ( cmpSC.superClusterRef().isNonnull() &&
-			 chkSC.superClusterRef().isNonnull() &&
-			 cmpSC.superClusterRef()->position() == 
-			 chkSC.superClusterRef()->position() );	      
-	    }
-	    break;
-	  case reco::PFBlockElement::GSF:
-	    {
-	      const reco::PFBlockElementGsfTrack& cmpGSF = 
-		static_cast<const reco::PFBlockElementGsfTrack&>(cmpElem);
-	      const reco::PFBlockElementGsfTrack& chkGSF = 
-		static_cast<const reco::PFBlockElementGsfTrack&>(chkElem);	      
-	      result = ( cmpGSF.GsftrackRef().isNonnull() &&
-			 chkGSF.GsftrackRef().isNonnull() &&
-			 cmpGSF.GsftrackRef()->momentum() == chkGSF.GsftrackRef()->momentum() );	      
-	    }
-	    break;
-	  case reco::PFBlockElement::BREM:
-	    {
-	      const reco::PFBlockElementBrem& cmpBREM = 
-		static_cast<const reco::PFBlockElementBrem&>(cmpElem);
-	      const reco::PFBlockElementBrem& chkBREM = 
-		static_cast<const reco::PFBlockElementBrem&>(chkElem);	      
-	      result = ( cmpBREM.GsftrackRef().isNonnull() &&
-			 chkBREM.GsftrackRef().isNonnull() &&
-			 cmpBREM.GsftrackRef()->momentum() == chkBREM.GsftrackRef()->momentum() &&
-			 cmpBREM.indTrajPoint() == chkBREM.indTrajPoint() );	      
-	    }
-	    break;
-	  default:
-	    throw cms::Exception("UnknownBlockElementType")
-	      << cmpElem.type() << " is not a known PFBlockElement type!" << std::endl;
-	  }
-	  if( result ) break;
-	}
-	if( result ) break;
+      bool result = false;
+      for (const auto& cmpElem : tocompare->elements()) {
+        for (const auto& chkElem : b.elements()) {
+          // can't be equal elements if type not equal
+          if (cmpElem.type() != chkElem.type())
+            continue;
+          switch (cmpElem.type()) {
+            case reco::PFBlockElement::TRACK:
+              result = (cmpElem.trackRef().isNonnull() && chkElem.trackRef().isNonnull() &&
+                        cmpElem.trackRef()->momentum() == chkElem.trackRef()->momentum());
+              break;
+            case reco::PFBlockElement::PS1:
+            case reco::PFBlockElement::PS2:
+            case reco::PFBlockElement::ECAL:
+            case reco::PFBlockElement::HCAL:
+            case reco::PFBlockElement::HFEM:
+            case reco::PFBlockElement::HFHAD:
+            case reco::PFBlockElement::HO:
+              result = (cmpElem.clusterRef().isNonnull() && chkElem.clusterRef().isNonnull() &&
+                        cmpElem.clusterRef().key() == chkElem.clusterRef().key());
+              break;
+            case reco::PFBlockElement::SC: {
+              const reco::PFBlockElementSuperCluster& cmpSC =
+                  static_cast<const reco::PFBlockElementSuperCluster&>(cmpElem);
+              const reco::PFBlockElementSuperCluster& chkSC =
+                  static_cast<const reco::PFBlockElementSuperCluster&>(chkElem);
+              result = (cmpSC.superClusterRef().isNonnull() && chkSC.superClusterRef().isNonnull() &&
+                        cmpSC.superClusterRef()->position() == chkSC.superClusterRef()->position());
+            } break;
+            case reco::PFBlockElement::GSF: {
+              const reco::PFBlockElementGsfTrack& cmpGSF = static_cast<const reco::PFBlockElementGsfTrack&>(cmpElem);
+              const reco::PFBlockElementGsfTrack& chkGSF = static_cast<const reco::PFBlockElementGsfTrack&>(chkElem);
+              result = (cmpGSF.GsftrackRef().isNonnull() && chkGSF.GsftrackRef().isNonnull() &&
+                        cmpGSF.GsftrackRef()->momentum() == chkGSF.GsftrackRef()->momentum());
+            } break;
+            case reco::PFBlockElement::BREM: {
+              const reco::PFBlockElementBrem& cmpBREM = static_cast<const reco::PFBlockElementBrem&>(cmpElem);
+              const reco::PFBlockElementBrem& chkBREM = static_cast<const reco::PFBlockElementBrem&>(chkElem);
+              result = (cmpBREM.GsftrackRef().isNonnull() && chkBREM.GsftrackRef().isNonnull() &&
+                        cmpBREM.GsftrackRef()->momentum() == chkBREM.GsftrackRef()->momentum() &&
+                        cmpBREM.indTrajPoint() == chkBREM.indTrajPoint());
+            } break;
+            default:
+              throw cms::Exception("UnknownBlockElementType")
+                  << cmpElem.type() << " is not a known PFBlockElement type!" << std::endl;
+          }
+          if (result)
+            break;
+        }
+        if (result)
+          break;
       }
       return result;
     }
   };
-}
+}  // namespace
 
 typedef edm::ParameterSet PSet;
 
 class PFBlockComparator : public edm::EDAnalyzer {
 public:
-  PFBlockComparator(const PSet& c) : 
-    _src(c.getParameter<edm::InputTag>("source")),
-    _srcOld(c.getParameter<edm::InputTag>("sourceOld")){};
+  PFBlockComparator(const PSet& c)
+      : _src(c.getParameter<edm::InputTag>("source")), _srcOld(c.getParameter<edm::InputTag>("sourceOld")){};
   ~PFBlockComparator() {}
 
   void analyze(const edm::Event&, const edm::EventSetup&);
-private:    
+
+private:
   edm::InputTag _src;
   edm::InputTag _srcOld;
 };
 
-void PFBlockComparator::analyze(const edm::Event& e, 
-				const edm::EventSetup& es) {
+void PFBlockComparator::analyze(const edm::Event& e, const edm::EventSetup& es) {
   edm::Handle<reco::PFBlockCollection> blocks;
-  e.getByLabel(_src,blocks);
+  e.getByLabel(_src, blocks);
   edm::Handle<reco::PFBlockCollection> oldblocks;
-  e.getByLabel(_srcOld,oldblocks);
-  
+  e.getByLabel(_srcOld, oldblocks);
+
   unsigned matchedblocks = 0;
 
-  if( blocks->size() != oldblocks->size() ) {
+  if (blocks->size() != oldblocks->size()) {
     std::cout << "+++WARNING+++ Number of new blocks does not match number of old blocks!!!!" << std::endl;
     std::cout << "              " << blocks->size() << " != " << oldblocks->size() << std::endl;
   }
 
-  for( const auto& block : *blocks ) {
+  for (const auto& block : *blocks) {
     HasElementOverlap checker(block);
-    auto matched_block = std::find_if(oldblocks->begin(),oldblocks->end(),checker);
-    if( matched_block != oldblocks->end() ) {
+    auto matched_block = std::find_if(oldblocks->begin(), oldblocks->end(), checker);
+    if (matched_block != oldblocks->end()) {
       ++matchedblocks;
-      if( block.elements().size() != matched_block->elements().size() ) {
-	std::cout << "Number of elements in the block is not the same!" << std::endl;
-	std::cout << block.elements().size() << ' ' << matched_block->elements().size() << std::endl;
+      if (block.elements().size() != matched_block->elements().size()) {
+        std::cout << "Number of elements in the block is not the same!" << std::endl;
+        std::cout << block.elements().size() << ' ' << matched_block->elements().size() << std::endl;
       }
-      if( block.linkData().size() != matched_block->linkData().size() ) {
-	std::cout << "Something is really fucked up, captain..." << std::endl;
-	std::cout << block.elements().size() << ' ' << matched_block->elements().size() << std::endl;
+      if (block.linkData().size() != matched_block->linkData().size()) {
+        std::cout << "Something is really fucked up, captain..." << std::endl;
+        std::cout << block.elements().size() << ' ' << matched_block->elements().size() << std::endl;
       }
       unsigned found_elements = 0;
-      for( const auto& elem : block.elements() ) {
-	ElementEquals ele_check(elem);	
-	auto matched_elem = std::find_if(matched_block->elements().begin(),
-					 matched_block->elements().end(),ele_check);
-	if( matched_elem != matched_block->elements().end() ) {
-	  ++found_elements;
-	  std::multimap<double,unsigned> new_elems, old_elems;
-	  block.associatedElements(elem.index(),block.linkData(),new_elems);
-	  matched_block->associatedElements(matched_elem->index(),matched_block->linkData(),old_elems);
-	  
-	  if(new_elems.size() == old_elems.size()) {
-	    for(auto newitr = new_elems.begin(), olditr = old_elems.begin(); 
-		newitr != new_elems.end(); ++newitr, ++olditr ) {	      
-	      if( newitr->first != olditr->first ||
-		  block.elements()[newitr->second].type() != matched_block->elements()[olditr->second].type() ) {
-		std::cout << "( " << newitr->first << " , " << block.elements()[newitr->second].type() << " ) != ( "
-			  << olditr->first << " , " << matched_block->elements()[olditr->second].type() << " )" << std::endl;
-	      }
-	    }
-	  }
-	  if(new_elems.size() != old_elems.size()) {
-	    std::cout << "block links for element " << elem.index() << " are different from old links!" << std::endl;
-	    std::cout << "new: ";
-	    for(auto newassc : new_elems ) { 
-	      std::cout << "( " << newassc.first << " , " 
-			<< newassc.second << " , " 
-			<< block.elements()[newassc.second].type() << " ), "; 
-	    }
-	    std::cout << std::endl;
-	    std::cout << "old: ";
-	    for(auto oldassc : old_elems ) { 
-	      std::cout << "( " << oldassc.first << " , " 
-			<< oldassc.second << " , "
-			<< matched_block->elements()[oldassc.second].type() << " ), "; 
-	    }
-	    std::cout << std::endl;	      
-	  }
-	} else {
-	  std::cout << "+++WARNING+++ : couldn't find match for element: " << elem << std::endl;
-	}
-      }     
-      if( found_elements != block.elements().size() ||
-	  found_elements != matched_block->elements().size() ) {
-	std::cout << "+++WARNING+++ : couldn't find all elements in block with " 
-		  << block.elements().size() << " elements matched to block with " 
-		  << matched_block->elements().size() << "!" << std::endl;
-	std::cout << "new block: " << std::endl;
-	std::cout << block << std::endl;
-	std::cout << "old block: " << std::endl;
-	std::cout << *matched_block << std::endl;
+      for (const auto& elem : block.elements()) {
+        ElementEquals ele_check(elem);
+        auto matched_elem = std::find_if(matched_block->elements().begin(), matched_block->elements().end(), ele_check);
+        if (matched_elem != matched_block->elements().end()) {
+          ++found_elements;
+          std::multimap<double, unsigned> new_elems, old_elems;
+          block.associatedElements(elem.index(), block.linkData(), new_elems);
+          matched_block->associatedElements(matched_elem->index(), matched_block->linkData(), old_elems);
+
+          if (new_elems.size() == old_elems.size()) {
+            for (auto newitr = new_elems.begin(), olditr = old_elems.begin(); newitr != new_elems.end();
+                 ++newitr, ++olditr) {
+              if (newitr->first != olditr->first ||
+                  block.elements()[newitr->second].type() != matched_block->elements()[olditr->second].type()) {
+                std::cout << "( " << newitr->first << " , " << block.elements()[newitr->second].type() << " ) != ( "
+                          << olditr->first << " , " << matched_block->elements()[olditr->second].type() << " )"
+                          << std::endl;
+              }
+            }
+          }
+          if (new_elems.size() != old_elems.size()) {
+            std::cout << "block links for element " << elem.index() << " are different from old links!" << std::endl;
+            std::cout << "new: ";
+            for (auto newassc : new_elems) {
+              std::cout << "( " << newassc.first << " , " << newassc.second << " , "
+                        << block.elements()[newassc.second].type() << " ), ";
+            }
+            std::cout << std::endl;
+            std::cout << "old: ";
+            for (auto oldassc : old_elems) {
+              std::cout << "( " << oldassc.first << " , " << oldassc.second << " , "
+                        << matched_block->elements()[oldassc.second].type() << " ), ";
+            }
+            std::cout << std::endl;
+          }
+        } else {
+          std::cout << "+++WARNING+++ : couldn't find match for element: " << elem << std::endl;
+        }
+      }
+      if (found_elements != block.elements().size() || found_elements != matched_block->elements().size()) {
+        std::cout << "+++WARNING+++ : couldn't find all elements in block with " << block.elements().size()
+                  << " elements matched to block with " << matched_block->elements().size() << "!" << std::endl;
+        std::cout << "new block: " << std::endl;
+        std::cout << block << std::endl;
+        std::cout << "old block: " << std::endl;
+        std::cout << *matched_block << std::endl;
       }
     } else {
       std::cout << "+++WARNING+++ : couldn't find another block that matched the new block!" << std::endl;
       std::cout << block << std::endl;
     }
-  } // block
-  if( matchedblocks != oldblocks->size() ) {
+  }  // block
+  if (matchedblocks != oldblocks->size()) {
     std::cout << "Wasn't able to match all blocks!" << std::endl;
   }
 }

--- a/RecoParticleFlow/PFProducer/test/PFEGCandidateTreeMaker.cc
+++ b/RecoParticleFlow/PFProducer/test/PFEGCandidateTreeMaker.cc
@@ -2,7 +2,7 @@
 // Class: PFEGCandidateTreeMaker.cc
 //
 // Info: Outputs a tree with PF-EGamma information, mostly SC info.
-//       Checks to see if the input EG candidates are matched to 
+//       Checks to see if the input EG candidates are matched to
 //       some existing PF reco (PF-Photons and PF-Electrons).
 //
 // Author: L. Gray (FNAL)
@@ -66,45 +66,44 @@ namespace MK = reco::MustacheKernel;
 
 typedef edm::ParameterSet PSet;
 
-namespace {  
-  template<typename T>
-  struct array_deleter{
-    void operator () (T* arr) { delete [] arr; }
+namespace {
+  template <typename T>
+  struct array_deleter {
+    void operator()(T* arr) { delete[] arr; }
   };
 
   struct GetSharedRecHitFraction {
-    const edm::Ptr<reco::PFCluster> the_seed;    
+    const edm::Ptr<reco::PFCluster> the_seed;
     double x_rechits_tot, x_rechits_match;
-    GetSharedRecHitFraction(const edm::Ptr<reco::PFCluster>& s) : 
-      the_seed(s) {}
-    double operator()(const edm::Ptr<reco::PFCluster>& x) {      
+    GetSharedRecHitFraction(const edm::Ptr<reco::PFCluster>& s) : the_seed(s) {}
+    double operator()(const edm::Ptr<reco::PFCluster>& x) {
       // now see if the clusters overlap in rechits
-      const auto& seedHitsAndFractions = 
-	the_seed->hitsAndFractions();
-      const auto& xHitsAndFractions = 
-	x->hitsAndFractions();      
-      x_rechits_tot   = xHitsAndFractions.size();
-      x_rechits_match = 0.0;      
-      for( const std::pair<DetId, float>& seedHit : seedHitsAndFractions ) {
-	for( const std::pair<DetId, float>& xHit : xHitsAndFractions ) {
-	  if( seedHit.first == xHit.first ) {	    
-	    x_rechits_match += 1.0;
-	  }
-	}	
-      }      
-      return x_rechits_match/x_rechits_tot;
+      const auto& seedHitsAndFractions = the_seed->hitsAndFractions();
+      const auto& xHitsAndFractions = x->hitsAndFractions();
+      x_rechits_tot = xHitsAndFractions.size();
+      x_rechits_match = 0.0;
+      for (const std::pair<DetId, float>& seedHit : seedHitsAndFractions) {
+        for (const std::pair<DetId, float>& xHit : xHitsAndFractions) {
+          if (seedHit.first == xHit.first) {
+            x_rechits_match += 1.0;
+          }
+        }
+      }
+      return x_rechits_match / x_rechits_tot;
     }
   };
-}
+}  // namespace
 
 class PFEGCandidateTreeMaker : public edm::EDAnalyzer {
-  typedef TTree* treeptr;  
+  typedef TTree* treeptr;
+
 public:
   PFEGCandidateTreeMaker(const PSet&);
   ~PFEGCandidateTreeMaker() {}
 
   void analyze(const edm::Event&, const edm::EventSetup&);
-private:    
+
+private:
   edm::Service<TFileService> _fs;
   bool _dogen;
   edm::InputTag _geninput;
@@ -112,149 +111,139 @@ private:
   edm::InputTag _pfEGInput;
   edm::InputTag _pfInput;
   PFEnergyCalibration _calib;
-  std::map<reco::PFCandidateRef,reco::GenParticleRef> _genmatched;
-  void findBestGenMatches(const edm::Event& e, 
-			  const edm::Handle<reco::PFCandidateCollection>&);
+  std::map<reco::PFCandidateRef, reco::GenParticleRef> _genmatched;
+  void findBestGenMatches(const edm::Event& e, const edm::Handle<reco::PFCandidateCollection>&);
   void processEGCandidateFillTree(const edm::Event&,
-			     const reco::PFCandidateRef&,
-			     const edm::Handle<reco::PFCandidateCollection>&);
-  bool getPFCandMatch(const reco::PFCandidate&,
-		      const edm::Handle<reco::PFCandidateCollection>&,
-		      const int );
-  // the tree  
-  void setTreeArraysForSize(const size_t N_ECAL,const size_t N_PS);
+                                  const reco::PFCandidateRef&,
+                                  const edm::Handle<reco::PFCandidateCollection>&);
+  bool getPFCandMatch(const reco::PFCandidate&, const edm::Handle<reco::PFCandidateCollection>&, const int);
+  // the tree
+  void setTreeArraysForSize(const size_t N_ECAL, const size_t N_PS);
   treeptr _tree;
   Int_t nVtx;
-  Float_t scRawEnergy, scCalibratedEnergy, scPreshowerEnergy,
-    scEta, scPhi, scR, scPhiWidth, scEtaWidth, scSeedRawEnergy, 
-    scSeedCalibratedEnergy, scSeedEta, scSeedPhi;
+  Float_t scRawEnergy, scCalibratedEnergy, scPreshowerEnergy, scEta, scPhi, scR, scPhiWidth, scEtaWidth,
+      scSeedRawEnergy, scSeedCalibratedEnergy, scSeedEta, scSeedPhi;
   Int_t hasParentSC, pfPhotonMatch, pfElectronMatch;
   Float_t genEnergy, genEta, genPhi, genDRToCentroid, genDRToSeed;
   Int_t N_ECALClusters;
   std::vector<Float_t> clusterRawEnergy;
   std::vector<Float_t> clusterCalibEnergy;
-  std::vector<Float_t> clusterEta, clusterPhi, clusterDPhiToSeed, clusterDEtaToSeed, 
-    clusterDPhiToCentroid, clusterDEtaToCentroid, 
-    clusterDPhiToGen, clusterDEtaToGen, clusterHitFractionSharedWithSeed;
+  std::vector<Float_t> clusterEta, clusterPhi, clusterDPhiToSeed, clusterDEtaToSeed, clusterDPhiToCentroid,
+      clusterDEtaToCentroid, clusterDPhiToGen, clusterDEtaToGen, clusterHitFractionSharedWithSeed;
   std::vector<Int_t> clusterInMustache, clusterInDynDPhi;
   Int_t N_PSClusters;
   std::vector<Float_t> psClusterRawEnergy, psClusterEta, psClusterPhi;
 };
 
-void PFEGCandidateTreeMaker::analyze(const edm::Event& e, 
-				     const edm::EventSetup& es) {
+void PFEGCandidateTreeMaker::analyze(const edm::Event& e, const edm::EventSetup& es) {
   edm::Handle<reco::VertexCollection> vtcs;
-  e.getByLabel(_vtxsrc,vtcs);
-  if( vtcs.isValid() ) nVtx = vtcs->size();
-  else nVtx = -1;
+  e.getByLabel(_vtxsrc, vtcs);
+  if (vtcs.isValid())
+    nVtx = vtcs->size();
+  else
+    nVtx = -1;
 
   edm::Handle<reco::PFCandidateCollection> pfEG;
   edm::Handle<reco::PFCandidateCollection> pfCands;
-  e.getByLabel(_pfEGInput, pfEG);  
-  e.getByLabel(_pfInput, pfCands);  
- 
-  if( pfEG.isValid() ) {
+  e.getByLabel(_pfEGInput, pfEG);
+  e.getByLabel(_pfInput, pfCands);
+
+  if (pfEG.isValid()) {
     findBestGenMatches(e, pfEG);
-    for( size_t i = 0; i < pfEG->size(); ++i ) {
-      processEGCandidateFillTree(e, reco::PFCandidateRef(pfEG,i), pfCands);
+    for (size_t i = 0; i < pfEG->size(); ++i) {
+      processEGCandidateFillTree(e, reco::PFCandidateRef(pfEG, i), pfCands);
     }
   } else {
     throw cms::Exception("PFEGCandidateTreeMaker")
-      << "Product ID for the EB SuperCluster collection was invalid!"
-      << std::endl;
-  }  
+        << "Product ID for the EB SuperCluster collection was invalid!" << std::endl;
+  }
 }
 
-void PFEGCandidateTreeMaker::
-findBestGenMatches(const edm::Event& e, 
-		   const edm::Handle<reco::PFCandidateCollection>& pfs) {
+void PFEGCandidateTreeMaker::findBestGenMatches(const edm::Event& e,
+                                                const edm::Handle<reco::PFCandidateCollection>& pfs) {
   _genmatched.clear();
   reco::GenParticleRef genmatch;
   // gen information (if needed)
-  if( _dogen ) {
+  if (_dogen) {
     edm::Handle<reco::GenParticleCollection> genp;
     std::vector<reco::GenParticleRef> elesandphos;
-    e.getByLabel(_geninput,genp);
-    if( genp.isValid() ) {     
+    e.getByLabel(_geninput, genp);
+    if (genp.isValid()) {
       reco::GenParticleRef bestmatch;
-      for(size_t i = 0; i < genp->size(); ++i) {	
-	const int pdgid = std::abs(genp->at(i).pdgId());
-	if( pdgid == 22 || pdgid == 11 ) {	     
-	  elesandphos.push_back(reco::GenParticleRef(genp,i));
-	}
+      for (size_t i = 0; i < genp->size(); ++i) {
+        const int pdgid = std::abs(genp->at(i).pdgId());
+        if (pdgid == 22 || pdgid == 11) {
+          elesandphos.push_back(reco::GenParticleRef(genp, i));
+        }
       }
-      for( size_t i = 0; i < elesandphos.size(); ++i ) {
-	double dE_min = -1;
-	reco::PFCandidateRef bestmatch;
-	for( size_t k = 0; k < pfs->size(); ++k ) {	  
-	  reco::SuperClusterRef scref = pfs->at(k).superClusterRef();
-	  if( scref.isAvailable() && scref.isNonnull() && 
-	      reco::deltaR(*scref,*elesandphos[i]) < 0.3 ) {
-	    double dE = std::abs(scref->energy()-elesandphos[i]->energy());
-	    if( dE_min == -1 || dE < dE_min ) {
-	      dE_min = dE;
-	      bestmatch = reco::PFCandidateRef(pfs,k);
-	    }
-	  }
-	}
-      	_genmatched[bestmatch] = elesandphos[i];
+      for (size_t i = 0; i < elesandphos.size(); ++i) {
+        double dE_min = -1;
+        reco::PFCandidateRef bestmatch;
+        for (size_t k = 0; k < pfs->size(); ++k) {
+          reco::SuperClusterRef scref = pfs->at(k).superClusterRef();
+          if (scref.isAvailable() && scref.isNonnull() && reco::deltaR(*scref, *elesandphos[i]) < 0.3) {
+            double dE = std::abs(scref->energy() - elesandphos[i]->energy());
+            if (dE_min == -1 || dE < dE_min) {
+              dE_min = dE;
+              bestmatch = reco::PFCandidateRef(pfs, k);
+            }
+          }
+        }
+        _genmatched[bestmatch] = elesandphos[i];
       }
     } else {
       throw cms::Exception("PFSuperClusterTreeMaker")
-      << "Requested generator level information was not available!"
-      << std::endl;
+          << "Requested generator level information was not available!" << std::endl;
     }
   }
 }
 
-void PFEGCandidateTreeMaker::
-processEGCandidateFillTree(const edm::Event& e, 
-		      const reco::PFCandidateRef& pf,
-		      const edm::Handle<reco::PFCandidateCollection>& pfCands) {
-  if( pf->superClusterRef().isNull() || !pf->superClusterRef().isAvailable() ) {
+void PFEGCandidateTreeMaker::processEGCandidateFillTree(const edm::Event& e,
+                                                        const reco::PFCandidateRef& pf,
+                                                        const edm::Handle<reco::PFCandidateCollection>& pfCands) {
+  if (pf->superClusterRef().isNull() || !pf->superClusterRef().isAvailable()) {
     return;
   }
-  if( pf->egammaExtraRef().isNull() || !pf->egammaExtraRef().isAvailable() ) {
+  if (pf->egammaExtraRef().isNull() || !pf->egammaExtraRef().isAvailable()) {
     return;
   }
   const reco::SuperCluster& sc = *(pf->superClusterRef());
   reco::SuperClusterRef egsc = pf->egammaExtraRef()->superClusterPFECALRef();
-  bool eleMatch(getPFCandMatch(*pf,pfCands,11));
-  bool phoMatch(getPFCandMatch(*pf,pfCands,22));
-
+  bool eleMatch(getPFCandMatch(*pf, pfCands, 11));
+  bool phoMatch(getPFCandMatch(*pf, pfCands, 22));
 
   const int N_ECAL = sc.clustersSize();
-  const int N_PS   = sc.preshowerClustersSize();
+  const int N_PS = sc.preshowerClustersSize();
   const double sc_eta = std::abs(sc.position().Eta());
   const double sc_cosheta = std::cosh(sc_eta);
-  const double sc_pt = sc.rawEnergy()/sc_cosheta;
-  if( !N_ECAL ) return;
-  if( (sc_pt < 3.0 && sc_eta < 2.0) || 
-      (sc_pt < 4.0 && sc_eta < 2.5 && sc_eta > 2.0) ||
-      (sc_pt < 6.0 && sc_eta > 2.5) ) return;
-  N_ECALClusters = std::max(0,N_ECAL - 1); // minus 1 because of seed
+  const double sc_pt = sc.rawEnergy() / sc_cosheta;
+  if (!N_ECAL)
+    return;
+  if ((sc_pt < 3.0 && sc_eta < 2.0) || (sc_pt < 4.0 && sc_eta < 2.5 && sc_eta > 2.0) || (sc_pt < 6.0 && sc_eta > 2.5))
+    return;
+  N_ECALClusters = std::max(0, N_ECAL - 1);  // minus 1 because of seed
   N_PSClusters = N_PS;
   reco::GenParticleRef genmatch;
   // gen information (if needed)
-  if( _dogen ) {    
-    std::map<reco::PFCandidateRef,reco::GenParticleRef>::iterator itrmatch;
-    if(  (itrmatch = _genmatched.find(pf)) != _genmatched.end() ) {
-      genmatch  = itrmatch->second;           
+  if (_dogen) {
+    std::map<reco::PFCandidateRef, reco::GenParticleRef>::iterator itrmatch;
+    if ((itrmatch = _genmatched.find(pf)) != _genmatched.end()) {
+      genmatch = itrmatch->second;
       genEnergy = genmatch->energy();
-      genEta    = genmatch->eta();
-      genPhi    = genmatch->phi();
-      genDRToCentroid = reco::deltaR(sc,*genmatch);
-      genDRToSeed = reco::deltaR(*genmatch,**(sc.clustersBegin()));
+      genEta = genmatch->eta();
+      genPhi = genmatch->phi();
+      genDRToCentroid = reco::deltaR(sc, *genmatch);
+      genDRToSeed = reco::deltaR(*genmatch, **(sc.clustersBegin()));
     } else {
       genEnergy = -1.0;
-      genEta    = 999.0;
-      genPhi    = 999.0;
+      genEta = 999.0;
+      genPhi = 999.0;
       genDRToCentroid = 999.0;
       genDRToSeed = 999.0;
-    }    
-  }  
+    }
+  }
   // supercluster information
-  setTreeArraysForSize(N_ECALClusters,N_PSClusters);
+  setTreeArraysForSize(N_ECALClusters, N_PSClusters);
   hasParentSC = (Int_t)(egsc.isAvailable() && egsc.isNonnull());
   pfElectronMatch = (Int_t)eleMatch;
   pfPhotonMatch = (Int_t)phoMatch;
@@ -263,128 +252,110 @@ processEGCandidateFillTree(const edm::Event& e,
   scPreshowerEnergy = sc.preshowerEnergy();
   scEta = sc.position().Eta();
   scPhi = sc.position().Phi();
-  scR   = sc.position().R();
+  scR = sc.position().R();
   scPhiWidth = sc.phiWidth();
   scEtaWidth = sc.etaWidth();
   // sc seed information
   edm::Ptr<reco::PFCluster> theseed = edm::Ptr<reco::PFCluster>(sc.seed());
   GetSharedRecHitFraction fractionOfSeed(theseed);
   scSeedRawEnergy = theseed->energy();
-  scSeedCalibratedEnergy = _calib.energyEm(*theseed,0.0,0.0,false);
+  scSeedCalibratedEnergy = _calib.energyEm(*theseed, 0.0, 0.0, false);
   scSeedEta = theseed->eta();
   scSeedPhi = theseed->phi();
   // loop over all clusters that aren't the seed
   auto clusend = sc.clustersEnd();
   size_t iclus = 0;
   edm::Ptr<reco::PFCluster> pclus;
-  for( auto clus = sc.clustersBegin(); clus != clusend; ++clus ) {
+  for (auto clus = sc.clustersBegin(); clus != clusend; ++clus) {
     pclus = edm::Ptr<reco::PFCluster>(*clus);
-    if( theseed == pclus ) continue;
+    if (theseed == pclus)
+      continue;
     clusterRawEnergy[iclus] = pclus->energy();
-    clusterCalibEnergy[iclus] = _calib.energyEm(*pclus,0.0,0.0,false);
+    clusterCalibEnergy[iclus] = _calib.energyEm(*pclus, 0.0, 0.0, false);
     clusterEta[iclus] = pclus->eta();
     clusterPhi[iclus] = pclus->phi();
-    clusterDPhiToSeed[iclus] = 
-      TVector2::Phi_mpi_pi(pclus->phi() - theseed->phi());
+    clusterDPhiToSeed[iclus] = TVector2::Phi_mpi_pi(pclus->phi() - theseed->phi());
     clusterDEtaToSeed[iclus] = pclus->eta() - theseed->eta();
-    clusterDPhiToCentroid[iclus] = 
-      TVector2::Phi_mpi_pi(pclus->phi() - sc.phi());
+    clusterDPhiToCentroid[iclus] = TVector2::Phi_mpi_pi(pclus->phi() - sc.phi());
     clusterDEtaToCentroid[iclus] = pclus->eta() - sc.eta();
-    clusterDPhiToCentroid[iclus] = 
-      TVector2::Phi_mpi_pi(pclus->phi() - sc.phi());
+    clusterDPhiToCentroid[iclus] = TVector2::Phi_mpi_pi(pclus->phi() - sc.phi());
     clusterDEtaToCentroid[iclus] = pclus->eta() - sc.eta();
     clusterHitFractionSharedWithSeed[iclus] = fractionOfSeed(pclus);
-    if( _dogen && genmatch.isNonnull() ) {
-      clusterDPhiToGen[iclus] = 
-	TVector2::Phi_mpi_pi(pclus->phi() - genmatch->phi());
+    if (_dogen && genmatch.isNonnull()) {
+      clusterDPhiToGen[iclus] = TVector2::Phi_mpi_pi(pclus->phi() - genmatch->phi());
       clusterDEtaToGen[iclus] = pclus->eta() - genmatch->eta();
     }
-    clusterInMustache[iclus] = (Int_t) MK::inMustache(theseed->eta(),
-							     theseed->phi(),
-							     pclus->energy(),
-							     pclus->eta(),
-							     pclus->phi());
-    clusterInDynDPhi[iclus] = (Int_t)
-      MK::inDynamicDPhiWindow(PFLayer::ECAL_BARREL == pclus->layer(),
-			      theseed->phi(),
-			      pclus->energy(),
-			      pclus->eta(),
-			      pclus->phi());      
+    clusterInMustache[iclus] =
+        (Int_t)MK::inMustache(theseed->eta(), theseed->phi(), pclus->energy(), pclus->eta(), pclus->phi());
+    clusterInDynDPhi[iclus] = (Int_t)MK::inDynamicDPhiWindow(
+        PFLayer::ECAL_BARREL == pclus->layer(), theseed->phi(), pclus->energy(), pclus->eta(), pclus->phi());
     ++iclus;
   }
-  // loop over all preshower clusters 
+  // loop over all preshower clusters
   auto psclusend = sc.preshowerClustersEnd();
   size_t ipsclus = 0;
   edm::Ptr<reco::PFCluster> ppsclus;
-  for( auto psclus = sc.preshowerClustersBegin(); psclus != psclusend; 
-       ++psclus ) {
+  for (auto psclus = sc.preshowerClustersBegin(); psclus != psclusend; ++psclus) {
     ppsclus = edm::Ptr<reco::PFCluster>(*psclus);
-    psClusterRawEnergy[ipsclus] = ppsclus->energy();    
-    psClusterEta[ipsclus] = ppsclus->eta();    
+    psClusterRawEnergy[ipsclus] = ppsclus->energy();
+    psClusterEta[ipsclus] = ppsclus->eta();
     psClusterPhi[ipsclus] = ppsclus->phi();
     ++ipsclus;
   }
   _tree->Fill();
 }
 
-
-
-bool PFEGCandidateTreeMaker::
-getPFCandMatch(const reco::PFCandidate& cand,
-	       const edm::Handle<reco::PFCandidateCollection>& pf,
-	       const int pdgid_search) {
+bool PFEGCandidateTreeMaker::getPFCandMatch(const reco::PFCandidate& cand,
+                                            const edm::Handle<reco::PFCandidateCollection>& pf,
+                                            const int pdgid_search) {
   reco::PFCandidateEGammaExtraRef egxtra = cand.egammaExtraRef();
-  if( egxtra.isAvailable() && egxtra.isNonnull() ) {
+  if (egxtra.isAvailable() && egxtra.isNonnull()) {
     reco::SuperClusterRef scref = egxtra->superClusterPFECALRef();
-    if( scref.isAvailable() && scref.isNonnull() ) {
-      for( auto ipf = pf->begin(); ipf != pf->end(); ++ipf ) {
-	if( std::abs(ipf->pdgId()) == pdgid_search  && pdgid_search == 11) {
-	  reco::GsfTrackRef gsfref = ipf->gsfTrackRef();	    
-	  reco::ElectronSeedRef sRef = gsfref->seedRef().castTo<reco::ElectronSeedRef>();
-	  if( sRef.isNonnull() && sRef.isAvailable() && sRef->isEcalDriven() ) {
-	    reco::SuperClusterRef temp(sRef->caloCluster().castTo<reco::SuperClusterRef>());
-	    if( scref == temp ) {
-	      return true;
-	    }
-	  }
-	} else if ( std::abs(ipf->pdgId()) == 22 && pdgid_search == 22) {
-	  reco::SuperClusterRef temp(ipf->superClusterRef());
-	  if( scref == temp ) {
-	    return true;
-	  }
-	}
+    if (scref.isAvailable() && scref.isNonnull()) {
+      for (auto ipf = pf->begin(); ipf != pf->end(); ++ipf) {
+        if (std::abs(ipf->pdgId()) == pdgid_search && pdgid_search == 11) {
+          reco::GsfTrackRef gsfref = ipf->gsfTrackRef();
+          reco::ElectronSeedRef sRef = gsfref->seedRef().castTo<reco::ElectronSeedRef>();
+          if (sRef.isNonnull() && sRef.isAvailable() && sRef->isEcalDriven()) {
+            reco::SuperClusterRef temp(sRef->caloCluster().castTo<reco::SuperClusterRef>());
+            if (scref == temp) {
+              return true;
+            }
+          }
+        } else if (std::abs(ipf->pdgId()) == 22 && pdgid_search == 22) {
+          reco::SuperClusterRef temp(ipf->superClusterRef());
+          if (scref == temp) {
+            return true;
+          }
+        }
       }
     }
   }
   return false;
 }
 
-
-
 PFEGCandidateTreeMaker::PFEGCandidateTreeMaker(const PSet& p) {
   N_ECALClusters = 1;
-  N_PSClusters   = 1;
-  _tree = _fs->make<TTree>("SuperClusterTree","Dump of all available SC info");
-  _tree->Branch("N_ECALClusters",&N_ECALClusters,"N_ECALClusters/I");
-  _tree->Branch("N_PSClusters",&N_PSClusters,"N_PSClusters/I");
-  _tree->Branch("nVtx",&nVtx,"nVtx/I");
-  _tree->Branch("hasParentSC",&hasParentSC,"hasParentSC/I");
-  _tree->Branch("pfPhotonMatch",&pfPhotonMatch,"pfPhotonMatch/I");
-  _tree->Branch("pfElectronMatch",&pfElectronMatch,"pfElectronMatch/I");
-  _tree->Branch("scRawEnergy",&scRawEnergy,"scRawEnergy/F");
-  _tree->Branch("scCalibratedEnergy",&scCalibratedEnergy,
-		"scCalibratedEnergy/F");
-  _tree->Branch("scPreshowerEnergy",&scPreshowerEnergy,"scPreshowerEnergy/F");
-  _tree->Branch("scEta",&scEta,"scEta/F");
-  _tree->Branch("scPhi",&scPhi,"scPhi/F");
-  _tree->Branch("scR",&scR,"scR/F");
-  _tree->Branch("scPhiWidth",&scPhiWidth,"scPhiWidth/F");
-  _tree->Branch("scEtaWidth",&scEtaWidth,"scEtaWidth/F");
-  _tree->Branch("scSeedRawEnergy",&scSeedRawEnergy,"scSeedRawEnergy/F");
-  _tree->Branch("scSeedCalibratedEnergy",&scSeedCalibratedEnergy,
-		"scSeedCalibratedEnergy/F");
-  _tree->Branch("scSeedEta",&scSeedEta,"scSeedEta/F");
-  _tree->Branch("scSeedPhi",&scSeedPhi,"scSeedPhi/F");
+  N_PSClusters = 1;
+  _tree = _fs->make<TTree>("SuperClusterTree", "Dump of all available SC info");
+  _tree->Branch("N_ECALClusters", &N_ECALClusters, "N_ECALClusters/I");
+  _tree->Branch("N_PSClusters", &N_PSClusters, "N_PSClusters/I");
+  _tree->Branch("nVtx", &nVtx, "nVtx/I");
+  _tree->Branch("hasParentSC", &hasParentSC, "hasParentSC/I");
+  _tree->Branch("pfPhotonMatch", &pfPhotonMatch, "pfPhotonMatch/I");
+  _tree->Branch("pfElectronMatch", &pfElectronMatch, "pfElectronMatch/I");
+  _tree->Branch("scRawEnergy", &scRawEnergy, "scRawEnergy/F");
+  _tree->Branch("scCalibratedEnergy", &scCalibratedEnergy, "scCalibratedEnergy/F");
+  _tree->Branch("scPreshowerEnergy", &scPreshowerEnergy, "scPreshowerEnergy/F");
+  _tree->Branch("scEta", &scEta, "scEta/F");
+  _tree->Branch("scPhi", &scPhi, "scPhi/F");
+  _tree->Branch("scR", &scR, "scR/F");
+  _tree->Branch("scPhiWidth", &scPhiWidth, "scPhiWidth/F");
+  _tree->Branch("scEtaWidth", &scEtaWidth, "scEtaWidth/F");
+  _tree->Branch("scSeedRawEnergy", &scSeedRawEnergy, "scSeedRawEnergy/F");
+  _tree->Branch("scSeedCalibratedEnergy", &scSeedCalibratedEnergy, "scSeedCalibratedEnergy/F");
+  _tree->Branch("scSeedEta", &scSeedEta, "scSeedEta/F");
+  _tree->Branch("scSeedPhi", &scSeedPhi, "scSeedPhi/F");
   // ecal cluster information
   clusterRawEnergy.resize(1);
   _tree->Branch("clusterRawEnergy", &clusterRawEnergy[0], "clusterRawEnergy[N_ECALClusters]/F");
@@ -397,14 +368,15 @@ PFEGCandidateTreeMaker::PFEGCandidateTreeMaker(const PSet& p) {
   clusterDPhiToSeed.resize(1);
   _tree->Branch("clusterDPhiToSeed", &clusterDPhiToSeed[0], "clusterDPhiToSeed[N_ECALClusters]/F");
   clusterDEtaToSeed.resize(1);
-  _tree->Branch("clusterDEtaToSeed", &clusterDEtaToSeed[0], "clusterDEtaToSeed[N_ECALClusters]/F");  
+  _tree->Branch("clusterDEtaToSeed", &clusterDEtaToSeed[0], "clusterDEtaToSeed[N_ECALClusters]/F");
   clusterDPhiToCentroid.resize(1);
   _tree->Branch("clusterDPhiToCentroid", &clusterDPhiToCentroid[0], "clusterDPhiToCentroid[N_ECALClusters]/F");
   clusterDEtaToCentroid.resize(1);
   _tree->Branch("clusterDEtaToCentroid", &clusterDEtaToCentroid[0], "clusterDEtaToCentroid[N_ECALClusters]/F");
   clusterHitFractionSharedWithSeed.resize(1);
-  _tree->Branch("clusterHitFractionSharedWithSeed", &clusterHitFractionSharedWithSeed[0],
-                                                    "clusterHitFractionSharedWithSeed[N_ECALClusters]/F");
+  _tree->Branch("clusterHitFractionSharedWithSeed",
+                &clusterHitFractionSharedWithSeed[0],
+                "clusterHitFractionSharedWithSeed[N_ECALClusters]/F");
   clusterInMustache.resize(1);
   _tree->Branch("clusterInMustache", &clusterInMustache[0], "clusterInMustache[N_ECALClusters]/I");
   clusterInDynDPhi.resize(1);
@@ -417,29 +389,25 @@ PFEGCandidateTreeMaker::PFEGCandidateTreeMaker(const PSet& p) {
   psClusterPhi.resize(1);
   _tree->Branch("psClusterPhi", &psClusterPhi[0], "psClusterPhi[N_PSClusters]/F");
 
+  if ((_dogen = p.getUntrackedParameter<bool>("doGen", false))) {
+    _geninput = p.getParameter<edm::InputTag>("genSrc");
+    _tree->Branch("genEta", &genEta, "genEta/F");
+    _tree->Branch("genPhi", &genPhi, "genPhi/F");
+    _tree->Branch("genEnergy", &genEnergy, "genEnergy/F");
+    _tree->Branch("genDRToCentroid", &genDRToCentroid, "genDRToCentroid/F");
+    _tree->Branch("genDRToSeed", &genDRToSeed, "genDRToSeed/F");
 
-  if( (_dogen = p.getUntrackedParameter<bool>("doGen",false)) ) {
-    _geninput = p.getParameter<edm::InputTag>("genSrc");    
-    _tree->Branch("genEta",&genEta,"genEta/F");
-    _tree->Branch("genPhi",&genPhi,"genPhi/F");
-    _tree->Branch("genEnergy",&genEnergy,"genEnergy/F");
-    _tree->Branch("genDRToCentroid",&genDRToCentroid,"genDRToCentroid/F");
-    _tree->Branch("genDRToSeed",&genDRToSeed,"genDRToSeed/F");
-    
     clusterDPhiToGen.resize(1);
     _tree->Branch("clusterDPhiToGen", &clusterDPhiToGen[0], "clusterDPhiToGen[N_ECALClusters]/F");
     clusterDEtaToGen.resize(1);
     _tree->Branch("clusterDEtaToGen", &clusterDEtaToGen[0], "clusterDPhiToGen[N_ECALClusters]/F");
   }
-  _vtxsrc    = p.getParameter<edm::InputTag>("primaryVertices");
-  _pfEGInput  = p.getParameter<edm::InputTag>("pfEGammaCandSrc");
-  _pfInput = p.getParameter<edm::InputTag>("pfCandSrc"); 
-
+  _vtxsrc = p.getParameter<edm::InputTag>("primaryVertices");
+  _pfEGInput = p.getParameter<edm::InputTag>("pfEGammaCandSrc");
+  _pfInput = p.getParameter<edm::InputTag>("pfCandSrc");
 }
 
-
-void PFEGCandidateTreeMaker::setTreeArraysForSize(const size_t N_ECAL,
-						   const size_t N_PS) {
+void PFEGCandidateTreeMaker::setTreeArraysForSize(const size_t N_ECAL, const size_t N_PS) {
   clusterRawEnergy.resize(N_ECAL);
   _tree->GetBranch("clusterRawEnergy")->SetAddress(&clusterRawEnergy[0]);
   clusterCalibEnergy.resize(N_ECAL);
@@ -458,8 +426,8 @@ void PFEGCandidateTreeMaker::setTreeArraysForSize(const size_t N_ECAL,
   _tree->GetBranch("clusterDEtaToCentroid")->SetAddress(&clusterDEtaToCentroid[0]);
   clusterHitFractionSharedWithSeed.resize(N_ECAL);
   _tree->GetBranch("clusterHitFractionSharedWithSeed")->SetAddress(&clusterHitFractionSharedWithSeed[0]);
-  
-  if( _dogen ) {
+
+  if (_dogen) {
     clusterDPhiToGen.resize(N_ECAL);
     _tree->GetBranch("clusterDPhiToGen")->SetAddress(&clusterDPhiToGen[0]);
     clusterDEtaToGen.resize(N_ECAL);

--- a/RecoParticleFlow/PFProducer/test/PFEGammaCandidateChecker.cc
+++ b/RecoParticleFlow/PFProducer/test/PFEGammaCandidateChecker.cc
@@ -14,21 +14,18 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-
 using namespace std;
 using namespace edm;
 using namespace reco;
 
-// we always assume we a looping over a 
+// we always assume we a looping over a
 namespace {
   struct gsfequals {
     reco::GsfTrackRef mytrack;
-    gsfequals(const reco::PFCandidate& tofind) : mytrack(tofind.gsfTrackRef())
-    {}
-    bool operator()( const reco::PFCandidate& c ) const {
-      if( c.gsfTrackRef().isNonnull() ) {
-	return ( c.gsfTrackRef()->ptMode() == mytrack->ptMode() &&
-		 c.gsfTrackRef()->etaMode() == mytrack->etaMode() );
+    gsfequals(const reco::PFCandidate& tofind) : mytrack(tofind.gsfTrackRef()) {}
+    bool operator()(const reco::PFCandidate& c) const {
+      if (c.gsfTrackRef().isNonnull()) {
+        return (c.gsfTrackRef()->ptMode() == mytrack->ptMode() && c.gsfTrackRef()->etaMode() == mytrack->etaMode());
       }
       return false;
     }
@@ -36,81 +33,52 @@ namespace {
   struct scequals {
     reco::SuperClusterRef mysc;
     scequals(const reco::PFCandidate& tofind) {
-      if( tofind.photonRef().isNonnull() ) {
-	mysc = tofind.photonRef()->superCluster();
+      if (tofind.photonRef().isNonnull()) {
+        mysc = tofind.photonRef()->superCluster();
       }
     }
-    bool operator()( const reco::PFCandidate& c ) const {
-      return ( mysc.isNonnull() && c.egammaExtraRef().isNonnull() && 
-	       ( c.egammaExtraRef()->superClusterPFECALRef()->seed() == 
-		 mysc->seed() ) );
+    bool operator()(const reco::PFCandidate& c) const {
+      return (mysc.isNonnull() && c.egammaExtraRef().isNonnull() &&
+              (c.egammaExtraRef()->superClusterPFECALRef()->seed() == mysc->seed()));
     }
   };
-}
-
+}  // namespace
 
 PFEGammaCandidateChecker::PFEGammaCandidateChecker(const edm::ParameterSet& iConfig) {
-  
+  inputTagPFCandidatesReco_ = iConfig.getParameter<InputTag>("pfCandidatesReco");
 
+  inputTagPFCandidatesReReco_ = iConfig.getParameter<InputTag>("pfCandidatesReReco");
 
-  inputTagPFCandidatesReco_ 
-    = iConfig.getParameter<InputTag>("pfCandidatesReco");
+  inputTagPFJetsReco_ = iConfig.getParameter<InputTag>("pfJetsReco");
 
-  inputTagPFCandidatesReReco_ 
-    = iConfig.getParameter<InputTag>("pfCandidatesReReco");
+  inputTagPFJetsReReco_ = iConfig.getParameter<InputTag>("pfJetsReReco");
 
-  inputTagPFJetsReco_ 
-    = iConfig.getParameter<InputTag>("pfJetsReco");
+  deltaEMax_ = iConfig.getParameter<double>("deltaEMax");
 
-  inputTagPFJetsReReco_ 
-    = iConfig.getParameter<InputTag>("pfJetsReReco");
+  deltaEtaMax_ = iConfig.getParameter<double>("deltaEtaMax");
 
-  deltaEMax_ 
-    = iConfig.getParameter<double>("deltaEMax");
+  deltaPhiMax_ = iConfig.getParameter<double>("deltaPhiMax");
 
-  deltaEtaMax_ 
-    = iConfig.getParameter<double>("deltaEtaMax");
+  verbose_ = iConfig.getUntrackedParameter<bool>("verbose", false);
 
-  deltaPhiMax_ 
-    = iConfig.getParameter<double>("deltaPhiMax");
+  printBlocks_ = iConfig.getUntrackedParameter<bool>("printBlocks", false);
 
-  verbose_ = 
-    iConfig.getUntrackedParameter<bool>("verbose",false);
-
-  printBlocks_ = 
-    iConfig.getUntrackedParameter<bool>("printBlocks",false);
-
-  rankByPt_ = 
-    iConfig.getUntrackedParameter<bool>("rankByPt",false);
+  rankByPt_ = iConfig.getUntrackedParameter<bool>("rankByPt", false);
 
   entry_ = 0;
 
-
-  LogDebug("PFEGammaCandidateChecker")
-    <<" input collections : "<<inputTagPFCandidatesReco_<<" "<<inputTagPFCandidatesReReco_;
-   
+  LogDebug("PFEGammaCandidateChecker") << " input collections : " << inputTagPFCandidatesReco_ << " "
+                                       << inputTagPFCandidatesReReco_;
 }
 
+PFEGammaCandidateChecker::~PFEGammaCandidateChecker() {}
 
+void PFEGammaCandidateChecker::beginRun(const edm::Run& run, const edm::EventSetup& es) {}
 
-PFEGammaCandidateChecker::~PFEGammaCandidateChecker() { }
+void PFEGammaCandidateChecker::analyze(const Event& iEvent, const EventSetup& iSetup) {
+  LogDebug("PFEGammaCandidateChecker") << "START event: " << iEvent.id().event() << " in run " << iEvent.id().run()
+                                       << endl;
 
-
-
-void 
-PFEGammaCandidateChecker::beginRun(const edm::Run& run, 
-			      const edm::EventSetup & es) { }
-
-
-void 
-PFEGammaCandidateChecker::analyze(const Event& iEvent, 
-			     const EventSetup& iSetup) {
-  
-  LogDebug("PFEGammaCandidateChecker")<<"START event: "<<iEvent.id().event()
-			 <<" in run "<<iEvent.id().run()<<endl;
-  
-  
-  
   // get PFCandidates
 
   Handle<PFCandidateCollection> pfCandidatesReco;
@@ -125,297 +93,266 @@ PFEGammaCandidateChecker::analyze(const Event& iEvent,
   Handle<PFJetCollection> pfJetsReReco;
   iEvent.getByLabel(inputTagPFJetsReReco_, pfJetsReReco);
 
-  reco::PFCandidateCollection pfReco, pfReReco;  
+  reco::PFCandidateCollection pfReco, pfReReco;
 
   // to sort, one needs to copy
-  if(rankByPt_)
-    {
-      pfReco=*pfCandidatesReco;
-      pfReReco=*pfCandidatesReReco;
-      sort(pfReco.begin(),pfReco.end(),greaterPt);
-      sort(pfReReco.begin(),pfReReco.end(),greaterPt);
-    }
-  
+  if (rankByPt_) {
+    pfReco = *pfCandidatesReco;
+    pfReReco = *pfCandidatesReReco;
+    sort(pfReco.begin(), pfReco.end(), greaterPt);
+    sort(pfReReco.begin(), pfReReco.end(), greaterPt);
+  }
+
   unsigned recoSize = pfReco.size();
   unsigned reRecoSize = pfReReco.size();
   //unsigned minSize = std::min(recoSize,pfReReco.size());
   bool differentCand = false;
   bool differentSize = pfReco.size() != pfReReco.size();
-  if ( differentSize ) 
-    std::cout << "+++WARNING+++ PFCandidate size changed for entry " 
-	      << entry_ << " !" << endl
-	      << " - RECO    size : " << pfReco.size() << endl 
-	      << " - Re-RECO size : " << pfReReco.size() << endl;
+  if (differentSize)
+    std::cout << "+++WARNING+++ PFCandidate size changed for entry " << entry_ << " !" << endl
+              << " - RECO    size : " << pfReco.size() << endl
+              << " - Re-RECO size : " << pfReReco.size() << endl;
 
   unsigned npr = 0;
 
   std::cout << "========= check pf -> ged =========" << std::endl;
-  for( unsigned i=0; i<recoSize; i++ ) {
-    
-    const reco::PFCandidate & candReco = (rankByPt_) ? pfReco[i] : (*pfCandidatesReco)[i];
-    const reco::PFCandidate * candReReco = NULL;
+  for (unsigned i = 0; i < recoSize; i++) {
+    const reco::PFCandidate& candReco = (rankByPt_) ? pfReco[i] : (*pfCandidatesReco)[i];
+    const reco::PFCandidate* candReReco = NULL;
 
-    switch( std::abs(candReco.pdgId()) ) {
-    case 11:
-      {
-	std::cout << "got a pfElectron!" << std::endl;
-	std::cout << '\t' << candReco << std::endl;
-	std::cout << '\t' << candReco.gsfTrackRef()->ptMode() << std::endl;
-	gsfequals findbygsf(candReco);
-	reco::PFCandidateCollection::const_iterator found = 
-	  std::find_if(pfReReco.begin(),pfReReco.end(),findbygsf);
-	if( found != pfReReco.end() ) {
-	  std::cout << "Found matching electron candidate by gsf track!" 
-		    << std::endl;
-	  candReReco = &*found;
-	} else {
-	  std::cout << "NO MATCHING GED ELECTRON" << std::endl;
-	}
-	reco::GsfElectronRef oldpf = candReco.gsfElectronRef();
-	reco::GsfElectronRef pfeg;
-	if( candReReco ) pfeg = candReReco->gsfElectronRef();
-	if( oldpf.isNonnull() && pfeg.isNonnull() ) {
-	  const double oldpf_sihih = oldpf->sigmaIetaIeta();
-	  const double pfeg_sihih  = pfeg->sigmaIetaIeta();
-	  std::cout << "matched set of gsf electrons" << std::endl;
-	  if( oldpf_sihih < pfeg_sihih ) {
-	    std::cout << "pfeg sigma-ieta-ieta > oldpf sigma-ieta-ieta" << std::endl;
-	  }
-	  if( oldpf_sihih > pfeg_sihih ) {
-	    std::cout << "pfeg sigma-ieta-ieta < oldpf sigma-ieta-ieta" << std::endl;
-	  }	  
-	}	
-      }
-      break;
-    case 22:
-      { 
-	scequals findbysc(candReco);
-	reco::PFCandidateCollection::const_iterator found = 
-	  std::find_if(pfReReco.begin(),pfReReco.end(),findbysc);
-	if( candReco.photonRef().isNonnull() && found != pfReReco.end() ) {
-	  std::cout << "Found matching photon candidate by parent!" 
-		    << std::endl;
-	  candReReco = &*found;
-	}
-      }
-      break;
-    default:
-      break;
+    switch (std::abs(candReco.pdgId())) {
+      case 11: {
+        std::cout << "got a pfElectron!" << std::endl;
+        std::cout << '\t' << candReco << std::endl;
+        std::cout << '\t' << candReco.gsfTrackRef()->ptMode() << std::endl;
+        gsfequals findbygsf(candReco);
+        reco::PFCandidateCollection::const_iterator found = std::find_if(pfReReco.begin(), pfReReco.end(), findbygsf);
+        if (found != pfReReco.end()) {
+          std::cout << "Found matching electron candidate by gsf track!" << std::endl;
+          candReReco = &*found;
+        } else {
+          std::cout << "NO MATCHING GED ELECTRON" << std::endl;
+        }
+        reco::GsfElectronRef oldpf = candReco.gsfElectronRef();
+        reco::GsfElectronRef pfeg;
+        if (candReReco)
+          pfeg = candReReco->gsfElectronRef();
+        if (oldpf.isNonnull() && pfeg.isNonnull()) {
+          const double oldpf_sihih = oldpf->sigmaIetaIeta();
+          const double pfeg_sihih = pfeg->sigmaIetaIeta();
+          std::cout << "matched set of gsf electrons" << std::endl;
+          if (oldpf_sihih < pfeg_sihih) {
+            std::cout << "pfeg sigma-ieta-ieta > oldpf sigma-ieta-ieta" << std::endl;
+          }
+          if (oldpf_sihih > pfeg_sihih) {
+            std::cout << "pfeg sigma-ieta-ieta < oldpf sigma-ieta-ieta" << std::endl;
+          }
+        }
+      } break;
+      case 22: {
+        scequals findbysc(candReco);
+        reco::PFCandidateCollection::const_iterator found = std::find_if(pfReReco.begin(), pfReReco.end(), findbysc);
+        if (candReco.photonRef().isNonnull() && found != pfReReco.end()) {
+          std::cout << "Found matching photon candidate by parent!" << std::endl;
+          candReReco = &*found;
+        }
+      } break;
+      default:
+        break;
     }
 
-    if( candReReco != NULL ) {
-    
-      double deltaE = (candReReco->energy()-candReco.energy())/(candReReco->energy()+candReco.energy());
-      double deltaEta = candReReco->eta()-candReco.eta();
-      double deltaPhi = candReReco->phi()-candReco.phi();
-      if ( fabs(deltaE) > deltaEMax_ ||
-	   fabs(deltaEta) > deltaEtaMax_ ||
-	   fabs(deltaPhi) > deltaPhiMax_ ) { 
-	differentCand = true;
-	std::cout << "+++WARNING+++ PFCandidate (e or gamma) " << i 
-		  << " changed  for entry " << entry_ << " ! " << std::endl 
-		  << " - RECO     : " << candReco << std::endl
-		  << " - Re-RECO  : " << *candReReco << std::endl
-		  << " DeltaE   = : " << deltaE << std::endl
-		  << " DeltaEta = : " << deltaEta << std::endl
-		  << " DeltaPhi = : " << deltaPhi << std::endl << std::endl;
-	if (printBlocks_) {
-	  std::cout << "Elements in Block for RECO: " <<std::endl;
-	  printElementsInBlocks(candReco);
-	  std::cout << "Elements in Block for Re-RECO: " <<std::endl;
-	  printElementsInBlocks(*candReReco);
-	}
-	if ( ++npr == 5 ) break;
+    if (candReReco != NULL) {
+      double deltaE = (candReReco->energy() - candReco.energy()) / (candReReco->energy() + candReco.energy());
+      double deltaEta = candReReco->eta() - candReco.eta();
+      double deltaPhi = candReReco->phi() - candReco.phi();
+      if (fabs(deltaE) > deltaEMax_ || fabs(deltaEta) > deltaEtaMax_ || fabs(deltaPhi) > deltaPhiMax_) {
+        differentCand = true;
+        std::cout << "+++WARNING+++ PFCandidate (e or gamma) " << i << " changed  for entry " << entry_ << " ! "
+                  << std::endl
+                  << " - RECO     : " << candReco << std::endl
+                  << " - Re-RECO  : " << *candReReco << std::endl
+                  << " DeltaE   = : " << deltaE << std::endl
+                  << " DeltaEta = : " << deltaEta << std::endl
+                  << " DeltaPhi = : " << deltaPhi << std::endl
+                  << std::endl;
+        if (printBlocks_) {
+          std::cout << "Elements in Block for RECO: " << std::endl;
+          printElementsInBlocks(candReco);
+          std::cout << "Elements in Block for Re-RECO: " << std::endl;
+          printElementsInBlocks(*candReReco);
+        }
+        if (++npr == 5)
+          break;
       }
     }
   }
   std::cout << "========= check ged -> pf =========" << std::endl;
-  for( unsigned i=0; i<reRecoSize; i++ ) {
-    
-    const reco::PFCandidate * candReco = NULL;
-    const reco::PFCandidate & candReReco = (rankByPt_) ? pfReReco[i] : (*pfCandidatesReReco)[i];
+  for (unsigned i = 0; i < reRecoSize; i++) {
+    const reco::PFCandidate* candReco = NULL;
+    const reco::PFCandidate& candReReco = (rankByPt_) ? pfReReco[i] : (*pfCandidatesReReco)[i];
 
-    switch( std::abs(candReReco.pdgId()) ) {
-    case 11:
-      {
-	std::cout << "got a ged electron!" << std::endl;
-	std::cout << '\t' << candReReco << std::endl;
-	std::cout << '\t' << candReReco.gsfTrackRef()->ptMode() << std::endl;
-	gsfequals findbygsf(candReReco);
-	reco::PFCandidateCollection::const_iterator found = 
-	  std::find_if(pfReco.begin(),pfReco.end(),findbygsf);
-	if( found != pfReco.end() ) {
-	  std::cout << "Found matching electron candidate by gsf track!" 
-		    << std::endl;
-	  candReco = &*found;
-	}
-	reco::GsfElectronRef oldpf;
-	reco::GsfElectronRef pfeg  = candReReco.gsfElectronRef();
-	if( candReco ) oldpf = candReco->gsfElectronRef();
-	if( pfeg.isNonnull() ) {
-	  const double pfeg_sihih  = pfeg->sigmaIetaIeta();
-	  if( ( std::abs(pfeg->superCluster()->eta()) < 1.479 && pfeg_sihih > 0.012 ) ||
-	      ( std::abs(pfeg->superCluster()->eta()) > 1.479 && pfeg_sihih > 0.032 )   ) {
-	    std::cout << "anomalously large sigma ieta ieta in pfeg!" << std::endl;
-	    std::cout << "\tsihih    : " << pfeg_sihih << std::endl;
-	    std::cout << "\te1x5     : " << pfeg->e1x5() << std::endl;
-	    std::cout << "\te2x5 max : " << pfeg->e2x5Max() << std::endl;
-	    std::cout << "\te5x5     : " << pfeg->e5x5() << std::endl;
-	    std::cout << "\tfBrem    : " << pfeg->trackFbrem() << std::endl;
-	  }
-	  if( oldpf.isNonnull() && pfeg.isNonnull() ) {
-	    const double oldpf_sihih = oldpf->sigmaIetaIeta();	    
-	    std::cout << "matched set of gsf electrons" << std::endl;
-	    if( oldpf_sihih < pfeg_sihih ) {
-	      std::cout << "pfeg sigma-ieta-ieta > oldpf sigma-ieta-ieta" << std::endl;
-	    }
-	    if( oldpf_sihih > pfeg_sihih ) {
-	      std::cout << "pfeg sigma-ieta-ieta < oldpf sigma-ieta-ieta" << std::endl;
-	    }
-	  }
-	}	
-      }
-      break;
-    case 22:
-      { 
-	scequals findbysc(candReReco);
-	reco::PFCandidateCollection::const_iterator found = 
-	  std::find_if(pfReco.begin(),pfReco.end(),findbysc);
-	if( candReReco.photonRef().isNonnull() && found != pfReco.end() ) {
-	  std::cout << "Found matching photon candidate by parent!" 
-		    << std::endl;
-	  candReco = &*found;
-	}
-      }
-      break;
-    default:
-      break;
+    switch (std::abs(candReReco.pdgId())) {
+      case 11: {
+        std::cout << "got a ged electron!" << std::endl;
+        std::cout << '\t' << candReReco << std::endl;
+        std::cout << '\t' << candReReco.gsfTrackRef()->ptMode() << std::endl;
+        gsfequals findbygsf(candReReco);
+        reco::PFCandidateCollection::const_iterator found = std::find_if(pfReco.begin(), pfReco.end(), findbygsf);
+        if (found != pfReco.end()) {
+          std::cout << "Found matching electron candidate by gsf track!" << std::endl;
+          candReco = &*found;
+        }
+        reco::GsfElectronRef oldpf;
+        reco::GsfElectronRef pfeg = candReReco.gsfElectronRef();
+        if (candReco)
+          oldpf = candReco->gsfElectronRef();
+        if (pfeg.isNonnull()) {
+          const double pfeg_sihih = pfeg->sigmaIetaIeta();
+          if ((std::abs(pfeg->superCluster()->eta()) < 1.479 && pfeg_sihih > 0.012) ||
+              (std::abs(pfeg->superCluster()->eta()) > 1.479 && pfeg_sihih > 0.032)) {
+            std::cout << "anomalously large sigma ieta ieta in pfeg!" << std::endl;
+            std::cout << "\tsihih    : " << pfeg_sihih << std::endl;
+            std::cout << "\te1x5     : " << pfeg->e1x5() << std::endl;
+            std::cout << "\te2x5 max : " << pfeg->e2x5Max() << std::endl;
+            std::cout << "\te5x5     : " << pfeg->e5x5() << std::endl;
+            std::cout << "\tfBrem    : " << pfeg->trackFbrem() << std::endl;
+          }
+          if (oldpf.isNonnull() && pfeg.isNonnull()) {
+            const double oldpf_sihih = oldpf->sigmaIetaIeta();
+            std::cout << "matched set of gsf electrons" << std::endl;
+            if (oldpf_sihih < pfeg_sihih) {
+              std::cout << "pfeg sigma-ieta-ieta > oldpf sigma-ieta-ieta" << std::endl;
+            }
+            if (oldpf_sihih > pfeg_sihih) {
+              std::cout << "pfeg sigma-ieta-ieta < oldpf sigma-ieta-ieta" << std::endl;
+            }
+          }
+        }
+      } break;
+      case 22: {
+        scequals findbysc(candReReco);
+        reco::PFCandidateCollection::const_iterator found = std::find_if(pfReco.begin(), pfReco.end(), findbysc);
+        if (candReReco.photonRef().isNonnull() && found != pfReco.end()) {
+          std::cout << "Found matching photon candidate by parent!" << std::endl;
+          candReco = &*found;
+        }
+      } break;
+      default:
+        break;
     }
 
-    if( candReco != NULL ) {
-    
-      double deltaE = (candReReco.energy()-candReco->energy())/(candReReco.energy()+candReco->energy());
-      double deltaEta = candReReco.eta()-candReco->eta();
-      double deltaPhi = candReReco.phi()-candReco->phi();
-      if ( fabs(deltaE) > deltaEMax_ ||
-	   fabs(deltaEta) > deltaEtaMax_ ||
-	   fabs(deltaPhi) > deltaPhiMax_ ) { 
-	differentCand = true;
-	std::cout << "+++WARNING+++ PFCandidate (e or gamma) " << i 
-		  << " changed  for entry " << entry_ << " ! " << std::endl 
-		  << " - RECO     : " << *candReco << std::endl
-		  << " - Re-RECO  : " << candReReco << std::endl
-		  << " DeltaE   = : " << deltaE << std::endl
-		  << " DeltaEta = : " << deltaEta << std::endl
-		  << " DeltaPhi = : " << deltaPhi << std::endl << std::endl;
-	if (printBlocks_) {
-	  std::cout << "Elements in Block for RECO: " <<std::endl;
-	  printElementsInBlocks(*candReco);
-	  std::cout << "Elements in Block for Re-RECO: " <<std::endl;
-	  printElementsInBlocks(candReReco);
-	}
-	if ( ++npr == 5 ) break;
+    if (candReco != NULL) {
+      double deltaE = (candReReco.energy() - candReco->energy()) / (candReReco.energy() + candReco->energy());
+      double deltaEta = candReReco.eta() - candReco->eta();
+      double deltaPhi = candReReco.phi() - candReco->phi();
+      if (fabs(deltaE) > deltaEMax_ || fabs(deltaEta) > deltaEtaMax_ || fabs(deltaPhi) > deltaPhiMax_) {
+        differentCand = true;
+        std::cout << "+++WARNING+++ PFCandidate (e or gamma) " << i << " changed  for entry " << entry_ << " ! "
+                  << std::endl
+                  << " - RECO     : " << *candReco << std::endl
+                  << " - Re-RECO  : " << candReReco << std::endl
+                  << " DeltaE   = : " << deltaE << std::endl
+                  << " DeltaEta = : " << deltaEta << std::endl
+                  << " DeltaPhi = : " << deltaPhi << std::endl
+                  << std::endl;
+        if (printBlocks_) {
+          std::cout << "Elements in Block for RECO: " << std::endl;
+          printElementsInBlocks(*candReco);
+          std::cout << "Elements in Block for Re-RECO: " << std::endl;
+          printElementsInBlocks(candReReco);
+        }
+        if (++npr == 5)
+          break;
       }
-    }    
+    }
   }
 
-
-  if ( differentSize || differentCand ) { 
+  if (differentSize || differentCand) {
     printJets(*pfJetsReco, *pfJetsReReco);
     printMet(pfReco, pfReReco);
   }
 
   ++entry_;
-  LogDebug("PFEGammaCandidateChecker")<<"STOP event: "<<iEvent.id().event()
-			 <<" in run "<<iEvent.id().run()<<std::endl;
+  LogDebug("PFEGammaCandidateChecker") << "STOP event: " << iEvent.id().event() << " in run " << iEvent.id().run()
+                                       << std::endl;
 }
 
-
 void PFEGammaCandidateChecker::printMet(const PFCandidateCollection& pfReco,
-				  const PFCandidateCollection& pfReReco) const { 
-
+                                        const PFCandidateCollection& pfReReco) const {
   double metX = 0.;
   double metY = 0.;
-  for( unsigned i=0; i<pfReco.size(); i++ ) {
+  for (unsigned i = 0; i < pfReco.size(); i++) {
     metX += pfReco[i].px();
     metY += pfReco[i].py();
   }
-  double met = std::sqrt(metX*metX + metY*metY);
+  double met = std::sqrt(metX * metX + metY * metY);
   std::cout << "MET RECO    = " << metX << " " << metY << " " << met << std::endl;
 
   metX = 0.;
   metY = 0.;
-  for( unsigned i=0; i<pfReReco.size(); i++ ) {
+  for (unsigned i = 0; i < pfReReco.size(); i++) {
     metX += pfReReco[i].px();
     metY += pfReReco[i].py();
   }
-  met = std::sqrt(metX*metX + metY*metY);
+  met = std::sqrt(metX * metX + metY * metY);
   std::cout << "MET Re-RECO = " << metX << " " << metY << " " << met << std::endl;
-
 }
 
-void PFEGammaCandidateChecker::printJets(const PFJetCollection& pfJetsReco,
-				   const PFJetCollection& pfJetsReReco) const { 
-
+void PFEGammaCandidateChecker::printJets(const PFJetCollection& pfJetsReco, const PFJetCollection& pfJetsReReco) const {
   bool differentSize = pfJetsReco.size() != pfJetsReReco.size();
-  if ( differentSize ) 
-    std::cout << "+++WARNING+++ PFJet size changed for entry " 
-	      << entry_ << " !" << endl
-	      << " - RECO    size : " << pfJetsReco.size() << endl 
-	      << " - Re-RECO size : " << pfJetsReReco.size() << endl;
-  unsigned minSize = pfJetsReco.size() < pfJetsReReco.size() ? pfJetsReco.size() : pfJetsReReco.size(); 
+  if (differentSize)
+    std::cout << "+++WARNING+++ PFJet size changed for entry " << entry_ << " !" << endl
+              << " - RECO    size : " << pfJetsReco.size() << endl
+              << " - Re-RECO size : " << pfJetsReReco.size() << endl;
+  unsigned minSize = pfJetsReco.size() < pfJetsReReco.size() ? pfJetsReco.size() : pfJetsReReco.size();
   unsigned npr = 0;
-  for ( unsigned i = 0; i < minSize; ++i) {
-    const reco::PFJet & candReco = pfJetsReco[i];
-    const reco::PFJet & candReReco = pfJetsReReco[i];
-    if ( candReco.et() < 20. && candReReco.et() < 20. ) break;
-    double deltaE = (candReReco.et()-candReco.et())/(candReReco.et()+candReco.et());
-    double deltaEta = candReReco.eta()-candReco.eta();
-    double deltaPhi = candReReco.phi()-candReco.phi();
-    if ( fabs(deltaE) > deltaEMax_ ||
-	 fabs(deltaEta) > deltaEtaMax_ ||
-	 fabs(deltaPhi) > deltaPhiMax_ ) { 
-      std::cout << "+++WARNING+++ PFJet " << i 
-		<< " changed  for entry " << entry_ << " ! " << std::endl 
-		<< " - RECO     : " << candReco.et() << " " << candReco.eta() << " " << candReco.phi() << std::endl
-		<< " - Re-RECO  : " << candReReco.et() << " " << candReReco.eta() << " " << candReReco.phi() << std::endl
-		<< " DeltaE   = : " << deltaE << std::endl
-		<< " DeltaEta = : " << deltaEta << std::endl
-		<< " DeltaPhi = : " << deltaPhi << std::endl << std::endl;
-      if ( ++npr == 5 ) break;
-    } else { 
+  for (unsigned i = 0; i < minSize; ++i) {
+    const reco::PFJet& candReco = pfJetsReco[i];
+    const reco::PFJet& candReReco = pfJetsReReco[i];
+    if (candReco.et() < 20. && candReReco.et() < 20.)
+      break;
+    double deltaE = (candReReco.et() - candReco.et()) / (candReReco.et() + candReco.et());
+    double deltaEta = candReReco.eta() - candReco.eta();
+    double deltaPhi = candReReco.phi() - candReco.phi();
+    if (fabs(deltaE) > deltaEMax_ || fabs(deltaEta) > deltaEtaMax_ || fabs(deltaPhi) > deltaPhiMax_) {
+      std::cout << "+++WARNING+++ PFJet " << i << " changed  for entry " << entry_ << " ! " << std::endl
+                << " - RECO     : " << candReco.et() << " " << candReco.eta() << " " << candReco.phi() << std::endl
+                << " - Re-RECO  : " << candReReco.et() << " " << candReReco.eta() << " " << candReReco.phi()
+                << std::endl
+                << " DeltaE   = : " << deltaE << std::endl
+                << " DeltaEta = : " << deltaEta << std::endl
+                << " DeltaPhi = : " << deltaPhi << std::endl
+                << std::endl;
+      if (++npr == 5)
+        break;
+    } else {
       std::cout << "Jet " << i << " " << candReco.et() << std::endl;
     }
   }
-
 }
 
-
-void PFEGammaCandidateChecker::printElementsInBlocks(const PFCandidate& cand,
-						ostream& out) const {
-  if(!out) return;
+void PFEGammaCandidateChecker::printElementsInBlocks(const PFCandidate& cand, ostream& out) const {
+  if (!out)
+    return;
 
   PFBlockRef firstRef;
 
-  assert(!cand.elementsInBlocks().empty() );
-  for(unsigned i=0; i<cand.elementsInBlocks().size(); i++) {
+  assert(!cand.elementsInBlocks().empty());
+  for (unsigned i = 0; i < cand.elementsInBlocks().size(); i++) {
     PFBlockRef blockRef = cand.elementsInBlocks()[i].first;
 
-    if(blockRef.isNull()) {
-      cerr<<"ERROR! no block ref!";
+    if (blockRef.isNull()) {
+      cerr << "ERROR! no block ref!";
       continue;
     }
 
-    if(!i) {
-      out<<(*blockRef);
+    if (!i) {
+      out << (*blockRef);
       firstRef = blockRef;
+    } else if (blockRef != firstRef) {
+      cerr << "WARNING! This PFCandidate is not made from a single block" << endl;
     }
-    else if( blockRef!=firstRef) {
-      cerr<<"WARNING! This PFCandidate is not made from a single block"<<endl;
-    }
- 
-    out<<"\t"<<cand.elementsInBlocks()[i].second<<endl;
+
+    out << "\t" << cand.elementsInBlocks()[i].second << endl;
   }
 }
-
-

--- a/RecoParticleFlow/PFProducer/test/PFEGammaCandidateChecker.h
+++ b/RecoParticleFlow/PFProducer/test/PFEGammaCandidateChecker.h
@@ -25,49 +25,39 @@
 \date   August 2011
 */
 
-
-
-
 class PFEGammaCandidateChecker : public edm::EDAnalyzer {
- public:
-
+public:
   explicit PFEGammaCandidateChecker(const edm::ParameterSet&);
 
   ~PFEGammaCandidateChecker();
-  
+
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-  virtual void beginRun(const edm::Run & r, const edm::EventSetup & c);
+  virtual void beginRun(const edm::Run& r, const edm::EventSetup& c);
 
- private:
-  
-  void printJets(const reco::PFJetCollection& pfJetsReco,
-		 const reco::PFJetCollection& pfJetsReReco) const;
+private:
+  void printJets(const reco::PFJetCollection& pfJetsReco, const reco::PFJetCollection& pfJetsReReco) const;
 
-  void printMet(const reco::PFCandidateCollection& pfReco,
-		const reco::PFCandidateCollection& pfReReco) const; 
+  void printMet(const reco::PFCandidateCollection& pfReco, const reco::PFCandidateCollection& pfReReco) const;
 
-  void printElementsInBlocks(const reco::PFCandidate& cand,
-			     std::ostream& out=std::cout) const;
+  void printElementsInBlocks(const reco::PFCandidate& cand, std::ostream& out = std::cout) const;
 
-
-  
-  /// PFCandidates in which we'll look for pile up particles 
-  edm::InputTag   inputTagPFCandidatesReco_;
-  edm::InputTag   inputTagPFCandidatesReReco_;
-  edm::InputTag   inputTagPFJetsReco_;
-  edm::InputTag   inputTagPFJetsReReco_;
+  /// PFCandidates in which we'll look for pile up particles
+  edm::InputTag inputTagPFCandidatesReco_;
+  edm::InputTag inputTagPFCandidatesReReco_;
+  edm::InputTag inputTagPFJetsReco_;
+  edm::InputTag inputTagPFJetsReReco_;
 
   /// Cuts for comparison
   double deltaEMax_;
   double deltaEtaMax_;
   double deltaPhiMax_;
-  
+
   /// verbose ?
-  bool   verbose_;
+  bool verbose_;
 
   /// print the blocks associated to a given candidate ?
-  bool   printBlocks_;
+  bool printBlocks_;
 
   /// rank the candidates by Pt
   bool rankByPt_;
@@ -75,12 +65,7 @@ class PFEGammaCandidateChecker : public edm::EDAnalyzer {
   /// Counter
   unsigned entry_;
 
-  static bool greaterPt( const reco::PFCandidate& a, const reco::PFCandidate& b ) {
-    return (a.pt()>b.pt());
-  }
-
-
-
+  static bool greaterPt(const reco::PFCandidate& a, const reco::PFCandidate& b) { return (a.pt() > b.pt()); }
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoParticleFlow/PFProducer/test/PFIsoReader.cc
+++ b/RecoParticleFlow/PFProducer/test/PFIsoReader.cc
@@ -9,151 +9,140 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
-PFIsoReader::PFIsoReader(const edm::ParameterSet& iConfig)
-{
+PFIsoReader::PFIsoReader(const edm::ParameterSet& iConfig) {
   inputTagGsfElectrons_ = iConfig.getParameter<edm::InputTag>("Electrons");
   inputTagPhotons_ = iConfig.getParameter<edm::InputTag>("Photons");
   inputTagPFCandidates_ = iConfig.getParameter<edm::InputTag>("PFCandidates");
 
   useValueMaps_ = iConfig.getParameter<bool>("useEGPFValueMaps");
-  inputTagValueMapPhotons_   = iConfig.getParameter<edm::InputTag>("PhotonValueMap");  
-  inputTagValueMapElectrons_  = iConfig.getParameter<edm::InputTag>("ElectronValueMap");  
-  inputTagValueMapMerged_  = iConfig.getParameter<edm::InputTag>("MergedValueMap");  
+  inputTagValueMapPhotons_ = iConfig.getParameter<edm::InputTag>("PhotonValueMap");
+  inputTagValueMapElectrons_ = iConfig.getParameter<edm::InputTag>("ElectronValueMap");
+  inputTagValueMapMerged_ = iConfig.getParameter<edm::InputTag>("MergedValueMap");
 
   inputTagElectronIsoDeposits_ = iConfig.getParameter<std::vector<edm::InputTag> >("ElectronIsoDeposits");
   inputTagPhotonIsoDeposits_ = iConfig.getParameter<std::vector<edm::InputTag> >("PhotonIsoDeposits");
-
 }
 
-PFIsoReader::~PFIsoReader(){;}
+PFIsoReader::~PFIsoReader() { ; }
 
-void 
-PFIsoReader::beginRun(edm::Run const&, edm::EventSetup const& ){;}
+void PFIsoReader::beginRun(edm::Run const&, edm::EventSetup const&) { ; }
 
-void PFIsoReader::analyze(const edm::Event & iEvent,const edm::EventSetup & c)
-{
+void PFIsoReader::analyze(const edm::Event& iEvent, const edm::EventSetup& c) {
   edm::Handle<reco::PFCandidateCollection> pfCandidatesH;
-  bool found=iEvent.getByLabel(inputTagPFCandidates_,pfCandidatesH);
-  if(!found ) {
-    std::ostringstream  err;
-    err<<" cannot get PFCandidates: "
-       <<inputTagPFCandidates_<<std::endl;
-    edm::LogError("PFIsoReader")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
-  }  
-
+  bool found = iEvent.getByLabel(inputTagPFCandidates_, pfCandidatesH);
+  if (!found) {
+    std::ostringstream err;
+    err << " cannot get PFCandidates: " << inputTagPFCandidates_ << std::endl;
+    edm::LogError("PFIsoReader") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
+  }
 
   edm::Handle<reco::GsfElectronCollection> gsfElectronH;
-  found=iEvent.getByLabel(inputTagGsfElectrons_,gsfElectronH);
-  if(!found ) {
-    std::ostringstream  err;
-    err<<" cannot get GsfElectrons: "
-       <<inputTagGsfElectrons_<<std::endl;
-    edm::LogError("PFIsoReader")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
-  }  
+  found = iEvent.getByLabel(inputTagGsfElectrons_, gsfElectronH);
+  if (!found) {
+    std::ostringstream err;
+    err << " cannot get GsfElectrons: " << inputTagGsfElectrons_ << std::endl;
+    edm::LogError("PFIsoReader") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
+  }
 
   edm::Handle<reco::PhotonCollection> photonH;
-  found=iEvent.getByLabel(inputTagPhotons_,photonH);
-  if(!found ) {
-    std::ostringstream  err;
-    err<<" cannot get Photonss: "
-       <<inputTagPhotons_<<std::endl;
-    edm::LogError("PFIsoReader")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
-  }  
+  found = iEvent.getByLabel(inputTagPhotons_, photonH);
+  if (!found) {
+    std::ostringstream err;
+    err << " cannot get Photonss: " << inputTagPhotons_ << std::endl;
+    edm::LogError("PFIsoReader") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
+  }
 
   // Get the value maps
 
   edm::Handle<edm::ValueMap<reco::PFCandidatePtr> > electronValMapH;
-  found = iEvent.getByLabel(inputTagValueMapElectrons_,electronValMapH);
-  const edm::ValueMap<reco::PFCandidatePtr> & myElectronValMap(*electronValMapH);
-  
+  found = iEvent.getByLabel(inputTagValueMapElectrons_, electronValMapH);
+  const edm::ValueMap<reco::PFCandidatePtr>& myElectronValMap(*electronValMapH);
+
   std::cout << " Read Electron Value Map " << myElectronValMap.size() << std::endl;
 
-//  edm::Handle<edm::ValueMap<reco::PFCandidatePtr> > photonValMapH;
-//  found = iEvent.getByLabel(inputTagValueMapPhotons_,photonValMapH);
-//   const edm::ValueMap<reco::PFCandidatePtr> & myPhotonValMap(*photonValMapH);  
+  //  edm::Handle<edm::ValueMap<reco::PFCandidatePtr> > photonValMapH;
+  //  found = iEvent.getByLabel(inputTagValueMapPhotons_,photonValMapH);
+  //   const edm::ValueMap<reco::PFCandidatePtr> & myPhotonValMap(*photonValMapH);
 
   edm::Handle<edm::ValueMap<reco::PFCandidatePtr> > mergedValMapH;
-  found = iEvent.getByLabel(inputTagValueMapMerged_,mergedValMapH);
-  const edm::ValueMap<reco::PFCandidatePtr> & myMergedValMap(*mergedValMapH);  
-  
+  found = iEvent.getByLabel(inputTagValueMapMerged_, mergedValMapH);
+  const edm::ValueMap<reco::PFCandidatePtr>& myMergedValMap(*mergedValMapH);
+
   // get the iso deposits
   IsoDepositMaps electronIsoDep(inputTagElectronIsoDeposits_.size());
-  IsoDepositMaps photonIsoDep(inputTagPhotonIsoDeposits_.size());   
-  
-  for (size_t j = 0; j<inputTagElectronIsoDeposits_.size(); ++j) {
+  IsoDepositMaps photonIsoDep(inputTagPhotonIsoDeposits_.size());
+
+  for (size_t j = 0; j < inputTagElectronIsoDeposits_.size(); ++j) {
     iEvent.getByLabel(inputTagElectronIsoDeposits_[j], electronIsoDep[j]);
   }
-  for (size_t j = 0; j<inputTagPhotonIsoDeposits_.size(); ++j) {
-    iEvent.getByLabel(inputTagPhotonIsoDeposits_[j], photonIsoDep[j]) ;
+  for (size_t j = 0; j < inputTagPhotonIsoDeposits_.size(); ++j) {
+    iEvent.getByLabel(inputTagPhotonIsoDeposits_[j], photonIsoDep[j]);
   }
 
-  // Photons - from reco 
-  unsigned nphot=photonH->size();
-  std::cout<<"Photon: "<<nphot<<std::endl;
-  for(unsigned iphot=0; iphot<nphot;++iphot) {
-    reco::PhotonRef myPhotRef(photonH,iphot);
+  // Photons - from reco
+  unsigned nphot = photonH->size();
+  std::cout << "Photon: " << nphot << std::endl;
+  for (unsigned iphot = 0; iphot < nphot; ++iphot) {
+    reco::PhotonRef myPhotRef(photonH, iphot);
     //    const reco::PFCandidatePtr & pfPhotPtr(myPhotonValMap[myPhotRef]);
-    const reco::PFCandidatePtr & pfPhotPtr(myMergedValMap[myPhotRef]);
-    printIsoDeposits(photonIsoDep,pfPhotPtr);
+    const reco::PFCandidatePtr& pfPhotPtr(myMergedValMap[myPhotRef]);
+    printIsoDeposits(photonIsoDep, pfPhotPtr);
   }
 
-  // Photons - from PF Candidates 
-  unsigned ncandidates= pfCandidatesH->size();
-  std::cout<<"Candidates: "<<ncandidates<<std::endl;
-  for(unsigned icand=0;icand<ncandidates;++icand) {
-    const reco::PFCandidate & cand((*pfCandidatesH)[icand]);
+  // Photons - from PF Candidates
+  unsigned ncandidates = pfCandidatesH->size();
+  std::cout << "Candidates: " << ncandidates << std::endl;
+  for (unsigned icand = 0; icand < ncandidates; ++icand) {
+    const reco::PFCandidate& cand((*pfCandidatesH)[icand]);
     //    std::cout << " Pdg " << cand.pdgId() << " mva " << cand.mva_nothing_gamma() << std::endl;
-    if(!(cand.pdgId()==22 && cand.mva_nothing_gamma()>0)) continue;
+    if (!(cand.pdgId() == 22 && cand.mva_nothing_gamma() > 0))
+      continue;
 
-    reco::PFCandidatePtr myPFCandidatePtr(pfCandidatesH,icand);
-    printIsoDeposits(photonIsoDep,myPFCandidatePtr);
-  }  
+    reco::PFCandidatePtr myPFCandidatePtr(pfCandidatesH, icand);
+    printIsoDeposits(photonIsoDep, myPFCandidatePtr);
+  }
 
+  // Electrons - from reco
+  unsigned nele = gsfElectronH->size();
+  std::cout << "Electron: " << nele << std::endl;
+  for (unsigned iele = 0; iele < nele; ++iele) {
+    reco::GsfElectronRef myElectronRef(gsfElectronH, iele);
 
-  // Electrons - from reco 
-  unsigned nele=gsfElectronH->size();
-  std::cout<<"Electron: "<<nele<<std::endl;
-  for(unsigned iele=0; iele<nele;++iele) {
-    reco::GsfElectronRef myElectronRef(gsfElectronH,iele);
-
-    if(myElectronRef->mva_e_pi()<-1) continue;
+    if (myElectronRef->mva_e_pi() < -1)
+      continue;
     //const reco::PFCandidatePtr & pfElePtr(myElectronValMap[myElectronRef]);
     const reco::PFCandidatePtr pfElePtr(myElectronValMap[myElectronRef]);
-    printIsoDeposits(electronIsoDep,pfElePtr);
+    printIsoDeposits(electronIsoDep, pfElePtr);
   }
 
   // Electrons - from PFCandidate
-  nele=gsfElectronH->size();
-  std::cout<<"Candidates: "<<nele<<std::endl;
-  for(unsigned icand=0; icand<ncandidates;++icand) {
-    const reco::PFCandidate & cand((*pfCandidatesH)[icand]);
-    
-    if (!(abs(cand.pdgId())==11)) continue;
+  nele = gsfElectronH->size();
+  std::cout << "Candidates: " << nele << std::endl;
+  for (unsigned icand = 0; icand < ncandidates; ++icand) {
+    const reco::PFCandidate& cand((*pfCandidatesH)[icand]);
 
-    reco::PFCandidatePtr myPFCandidatePtr(pfCandidatesH,icand);
-    printIsoDeposits(electronIsoDep,myPFCandidatePtr);
+    if (!(abs(cand.pdgId()) == 11))
+      continue;
+
+    reco::PFCandidatePtr myPFCandidatePtr(pfCandidatesH, icand);
+    printIsoDeposits(electronIsoDep, myPFCandidatePtr);
   }
-  
-  
-}
-  
-void PFIsoReader::printIsoDeposits(const IsoDepositMaps & isodepmap, const reco::PFCandidatePtr & ptr) const {
-  std::cout << " Isodeposits for " << ptr.id() << " " << ptr.key() << std::endl;
-  unsigned nIsoDepTypes=isodepmap.size(); // should be 3 (charged hadrons, photons, neutral hadrons)
-    for(unsigned ideptype=0; ideptype<nIsoDepTypes;++ideptype) {
-      const reco::IsoDeposit & isoDep((*isodepmap[ideptype])[ptr]);
-      typedef reco::IsoDeposit::const_iterator IM;
-      std::cout << " Iso deposits type " << ideptype << std::endl;
-      for(IM im=isoDep.begin(); im != isoDep.end(); ++im) {
-	std::cout << "dR " << im->dR() << " val " << im->value() << std::endl;
-      }
-    }   
 }
 
+void PFIsoReader::printIsoDeposits(const IsoDepositMaps& isodepmap, const reco::PFCandidatePtr& ptr) const {
+  std::cout << " Isodeposits for " << ptr.id() << " " << ptr.key() << std::endl;
+  unsigned nIsoDepTypes = isodepmap.size();  // should be 3 (charged hadrons, photons, neutral hadrons)
+  for (unsigned ideptype = 0; ideptype < nIsoDepTypes; ++ideptype) {
+    const reco::IsoDeposit& isoDep((*isodepmap[ideptype])[ptr]);
+    typedef reco::IsoDeposit::const_iterator IM;
+    std::cout << " Iso deposits type " << ideptype << std::endl;
+    for (IM im = isoDep.begin(); im != isoDep.end(); ++im) {
+      std::cout << "dR " << im->dR() << " val " << im->value() << std::endl;
+    }
+  }
+}
 
 DEFINE_FWK_MODULE(PFIsoReader);
-
-

--- a/RecoParticleFlow/PFProducer/test/PFIsoReader.h
+++ b/RecoParticleFlow/PFProducer/test/PFIsoReader.h
@@ -8,19 +8,17 @@
 #include <string>
 #include <map>
 
-
-class PFIsoReader : public edm::EDAnalyzer
-{
- public:
+class PFIsoReader : public edm::EDAnalyzer {
+public:
   explicit PFIsoReader(const edm::ParameterSet&);
   ~PFIsoReader();
-  virtual void beginRun(edm::Run const&, edm::EventSetup const& );
-  virtual void analyze(const edm::Event & iEvent,const edm::EventSetup & c);
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& c);
 
- private:
-  typedef std::vector< edm::Handle< edm::ValueMap<reco::IsoDeposit> > > IsoDepositMaps;
-  void printIsoDeposits(const IsoDepositMaps & depmap, const reco::PFCandidatePtr & ptr) const;
-  
+private:
+  typedef std::vector<edm::Handle<edm::ValueMap<reco::IsoDeposit> > > IsoDepositMaps;
+  void printIsoDeposits(const IsoDepositMaps& depmap, const reco::PFCandidatePtr& ptr) const;
+
   edm::InputTag inputTagGsfElectrons_;
   edm::InputTag inputTagPhotons_;
   edm::InputTag inputTagValueMapPhotons_;

--- a/RecoParticleFlow/PFProducer/test/PFSuperClusterReader.cc
+++ b/RecoParticleFlow/PFProducer/test/PFSuperClusterReader.cc
@@ -16,131 +16,115 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 
-PFSuperClusterReader::PFSuperClusterReader(const edm::ParameterSet& iConfig)
-{
-  inputTagGSFTracks_    = iConfig.getParameter<edm::InputTag>("GSFTracks");  
-  inputTagValueMapSC_   = iConfig.getParameter<edm::InputTag>("SuperClusterRefMap");  
-  inputTagValueMapMVA_  = iConfig.getParameter<edm::InputTag>("MVAMap");  
+PFSuperClusterReader::PFSuperClusterReader(const edm::ParameterSet& iConfig) {
+  inputTagGSFTracks_ = iConfig.getParameter<edm::InputTag>("GSFTracks");
+  inputTagValueMapSC_ = iConfig.getParameter<edm::InputTag>("SuperClusterRefMap");
+  inputTagValueMapMVA_ = iConfig.getParameter<edm::InputTag>("MVAMap");
   inputTagPFCandidates_ = iConfig.getParameter<edm::InputTag>("PFCandidate");
 }
 
-PFSuperClusterReader::~PFSuperClusterReader(){;}
+PFSuperClusterReader::~PFSuperClusterReader() { ; }
 
-void 
-PFSuperClusterReader::beginRun(edm::Run const&, edm::EventSetup const& ){;}
+void PFSuperClusterReader::beginRun(edm::Run const&, edm::EventSetup const&) { ; }
 
-void PFSuperClusterReader::analyze(const edm::Event & iEvent,const edm::EventSetup & c)
-{
+void PFSuperClusterReader::analyze(const edm::Event& iEvent, const edm::EventSetup& c) {
   edm::Handle<reco::GsfTrackCollection> gsfTracksH;
-  bool found=iEvent.getByLabel(inputTagGSFTracks_,gsfTracksH);
-  if(!found ) {
-    std::ostringstream  err;
-    err<<" cannot get GsfTracks: "
-       <<inputTagGSFTracks_<<std::endl;
-    edm::LogError("PFSuperClusterReader")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
-  }  
+  bool found = iEvent.getByLabel(inputTagGSFTracks_, gsfTracksH);
+  if (!found) {
+    std::ostringstream err;
+    err << " cannot get GsfTracks: " << inputTagGSFTracks_ << std::endl;
+    edm::LogError("PFSuperClusterReader") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
+  }
 
   edm::Handle<reco::PFCandidateCollection> pfCandidatesH;
-  found=iEvent.getByLabel(inputTagPFCandidates_,pfCandidatesH);
-  if(!found ) {
-    std::ostringstream  err;
-    err<<" cannot get PFCandidates: "
-       <<inputTagPFCandidates_<<std::endl;
-    edm::LogError("PFSuperClusterReader")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
+  found = iEvent.getByLabel(inputTagPFCandidates_, pfCandidatesH);
+  if (!found) {
+    std::ostringstream err;
+    err << " cannot get PFCandidates: " << inputTagPFCandidates_ << std::endl;
+    edm::LogError("PFSuperClusterReader") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
   }
 
   edm::Handle<edm::ValueMap<reco::SuperClusterRef> > pfClusterTracksH;
-  found = iEvent.getByLabel(inputTagValueMapSC_,pfClusterTracksH); 
-  if(!found ) {
-    std::ostringstream  err;
-    err<<" cannot get SuperClusterRef Map: "
-       <<inputTagValueMapSC_<<std::endl;
-    edm::LogError("PFSuperClusterReader")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
-  }  
+  found = iEvent.getByLabel(inputTagValueMapSC_, pfClusterTracksH);
+  if (!found) {
+    std::ostringstream err;
+    err << " cannot get SuperClusterRef Map: " << inputTagValueMapSC_ << std::endl;
+    edm::LogError("PFSuperClusterReader") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
+  }
 
   edm::Handle<edm::ValueMap<float> > pfMVAH;
-  found = iEvent.getByLabel(inputTagValueMapMVA_,pfMVAH); 
-  if(!found ) {
-    std::ostringstream  err;
-    err<<" cannot get MVA Map: "
-       <<inputTagValueMapSC_<<std::endl;
-    edm::LogError("PFSuperClusterReader")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
-  }  
+  found = iEvent.getByLabel(inputTagValueMapMVA_, pfMVAH);
+  if (!found) {
+    std::ostringstream err;
+    err << " cannot get MVA Map: " << inputTagValueMapSC_ << std::endl;
+    edm::LogError("PFSuperClusterReader") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
+  }
 
-  const edm::ValueMap<reco::SuperClusterRef> & mySCValueMap=*pfClusterTracksH;
-  const edm::ValueMap<float> & myMVAValueMap=*pfMVAH;
+  const edm::ValueMap<reco::SuperClusterRef>& mySCValueMap = *pfClusterTracksH;
+  const edm::ValueMap<float>& myMVAValueMap = *pfMVAH;
 
-  unsigned ngsf=gsfTracksH->size();
-  for(unsigned igsf=0;igsf<ngsf;++igsf)
-    {
-      reco::GsfTrackRef theTrackRef(gsfTracksH, igsf);
-      if(mySCValueMap[theTrackRef].isNull()) 
-	{
-	  continue;
-	}
-      const reco::SuperCluster & mySuperCluster(*(mySCValueMap[theTrackRef]));
-      float mva=myMVAValueMap[theTrackRef];
-      float eta=mySuperCluster.position().eta();
-      float et=mySuperCluster.energy()*sin(mySuperCluster.position().theta());
-      std::cout << " Super Cluster energy, eta, Et , EtaWidth, PhiWidth " << mySuperCluster.energy() << " " ;
-      std::cout <<  eta << " " << et << " " << mySuperCluster.etaWidth() << " " << mySuperCluster.phiWidth() << std::endl;
-      
-      const reco::PFCandidate * myPFCandidate = findPFCandidate(pfCandidatesH.product(),theTrackRef);
-
-      if(mySuperCluster.seed().isNull())
-	{
-	  continue;
-	}
-      std::cout << " Super Cluster seed energy " << mySuperCluster.seed()->energy() << std::endl;
-      std::cout << " Preshower contribution " << mySuperCluster.preshowerEnergy() << std::endl;
-      std::cout << " MVA value " << mva << std::endl;
-      std::cout << " List of basic clusters " << std::endl;
-      reco::CaloCluster_iterator it=mySuperCluster.clustersBegin();
-      reco::CaloCluster_iterator it_end=mySuperCluster.clustersEnd();
-      float etotbasic=0;
-      for(;it!=it_end;++it)
-	{
-	  std::cout << " Basic cluster " << (*it)->energy() << std::endl ;
-	  etotbasic += (*it)->energy();
-	}
-      it = mySuperCluster.preshowerClustersBegin();
-      it_end = mySuperCluster.preshowerClustersEnd();
-      for(;it!=it_end;++it)
-	{
-	  std::cout << " Preshower cluster " << (*it)->energy() << std::endl;
-	}
-
-      std::cout << " Comparison with PFCandidate : Energy " << myPFCandidate->ecalEnergy() << " SC : " << mySuperCluster.energy() << std::endl;
-      std::cout << " Sum of Basic clusters :" << etotbasic ;
-      std::cout << " Calibrated preshower energy : " << mySuperCluster.preshowerEnergy() ;
-      etotbasic += mySuperCluster.preshowerEnergy();
-      std::cout << " Basic Clusters + PS :" << etotbasic << std::endl;
-      std::cout << " Summary " << mySuperCluster.energy() << " " << eta << " " << et ;
-      std::cout << " " <<mySuperCluster.preshowerEnergy() << " " << mva << std::endl;
-      std::cout << std::endl;
+  unsigned ngsf = gsfTracksH->size();
+  for (unsigned igsf = 0; igsf < ngsf; ++igsf) {
+    reco::GsfTrackRef theTrackRef(gsfTracksH, igsf);
+    if (mySCValueMap[theTrackRef].isNull()) {
+      continue;
     }
+    const reco::SuperCluster& mySuperCluster(*(mySCValueMap[theTrackRef]));
+    float mva = myMVAValueMap[theTrackRef];
+    float eta = mySuperCluster.position().eta();
+    float et = mySuperCluster.energy() * sin(mySuperCluster.position().theta());
+    std::cout << " Super Cluster energy, eta, Et , EtaWidth, PhiWidth " << mySuperCluster.energy() << " ";
+    std::cout << eta << " " << et << " " << mySuperCluster.etaWidth() << " " << mySuperCluster.phiWidth() << std::endl;
+
+    const reco::PFCandidate* myPFCandidate = findPFCandidate(pfCandidatesH.product(), theTrackRef);
+
+    if (mySuperCluster.seed().isNull()) {
+      continue;
+    }
+    std::cout << " Super Cluster seed energy " << mySuperCluster.seed()->energy() << std::endl;
+    std::cout << " Preshower contribution " << mySuperCluster.preshowerEnergy() << std::endl;
+    std::cout << " MVA value " << mva << std::endl;
+    std::cout << " List of basic clusters " << std::endl;
+    reco::CaloCluster_iterator it = mySuperCluster.clustersBegin();
+    reco::CaloCluster_iterator it_end = mySuperCluster.clustersEnd();
+    float etotbasic = 0;
+    for (; it != it_end; ++it) {
+      std::cout << " Basic cluster " << (*it)->energy() << std::endl;
+      etotbasic += (*it)->energy();
+    }
+    it = mySuperCluster.preshowerClustersBegin();
+    it_end = mySuperCluster.preshowerClustersEnd();
+    for (; it != it_end; ++it) {
+      std::cout << " Preshower cluster " << (*it)->energy() << std::endl;
+    }
+
+    std::cout << " Comparison with PFCandidate : Energy " << myPFCandidate->ecalEnergy()
+              << " SC : " << mySuperCluster.energy() << std::endl;
+    std::cout << " Sum of Basic clusters :" << etotbasic;
+    std::cout << " Calibrated preshower energy : " << mySuperCluster.preshowerEnergy();
+    etotbasic += mySuperCluster.preshowerEnergy();
+    std::cout << " Basic Clusters + PS :" << etotbasic << std::endl;
+    std::cout << " Summary " << mySuperCluster.energy() << " " << eta << " " << et;
+    std::cout << " " << mySuperCluster.preshowerEnergy() << " " << mva << std::endl;
+    std::cout << std::endl;
+  }
 }
 
-const reco::PFCandidate * PFSuperClusterReader::findPFCandidate(const reco::PFCandidateCollection * coll,const reco::GsfTrackRef & ref)
-{
-  const reco::PFCandidate * result=0;
-  unsigned ncand=coll->size();
-  for(unsigned icand=0;icand<ncand;++icand)
-    {
-      if(!(*coll)[icand].gsfTrackRef().isNull() && (*coll)[icand].gsfTrackRef()==ref)
-	{
-	  result=&((*coll)[icand]);      
-	  return result;
-	}
+const reco::PFCandidate* PFSuperClusterReader::findPFCandidate(const reco::PFCandidateCollection* coll,
+                                                               const reco::GsfTrackRef& ref) {
+  const reco::PFCandidate* result = 0;
+  unsigned ncand = coll->size();
+  for (unsigned icand = 0; icand < ncand; ++icand) {
+    if (!(*coll)[icand].gsfTrackRef().isNull() && (*coll)[icand].gsfTrackRef() == ref) {
+      result = &((*coll)[icand]);
+      return result;
     }
+  }
   return result;
 }
 
-
 DEFINE_FWK_MODULE(PFSuperClusterReader);
-
-

--- a/RecoParticleFlow/PFProducer/test/PFSuperClusterReader.h
+++ b/RecoParticleFlow/PFProducer/test/PFSuperClusterReader.h
@@ -11,21 +11,19 @@
 #include <string>
 #include <map>
 
-
-class PFSuperClusterReader : public edm::EDAnalyzer
-{
- public:
+class PFSuperClusterReader : public edm::EDAnalyzer {
+public:
   explicit PFSuperClusterReader(const edm::ParameterSet&);
   ~PFSuperClusterReader();
-  virtual void beginRun(edm::Run const&, edm::EventSetup const& );
-  virtual void analyze(const edm::Event & iEvent,const edm::EventSetup & c);
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& c);
 
- private:
+private:
   edm::InputTag inputTagGSFTracks_;
   edm::InputTag inputTagValueMapSC_;
   edm::InputTag inputTagValueMapMVA_;
   edm::InputTag inputTagPFCandidates_;
 
-  const reco::PFCandidate * findPFCandidate(const reco::PFCandidateCollection * coll,const reco::GsfTrackRef& ref);
+  const reco::PFCandidate* findPFCandidate(const reco::PFCandidateCollection* coll, const reco::GsfTrackRef& ref);
 };
 #endif


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/430//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


