### PR TITLE
Running code-format for core

### DIFF
--- a/FWCore/ParameterSet/interface/ANDGroupDescription.h
+++ b/FWCore/ParameterSet/interface/ANDGroupDescription.h
@@ -37,7 +37,8 @@ namespace edm {
 
     void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
 
-    void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
+    void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
 
     void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
 

--- a/FWCore/ParameterSet/interface/AllowedLabelsDescriptionBase.h
+++ b/FWCore/ParameterSet/interface/AllowedLabelsDescriptionBase.h
@@ -34,7 +34,8 @@ namespace edm {
 
     void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
 
-    void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
+    void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
 
     void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
 

--- a/FWCore/ParameterSet/interface/EmptyGroupDescription.h
+++ b/FWCore/ParameterSet/interface/EmptyGroupDescription.h
@@ -25,7 +25,8 @@ namespace edm {
 
     void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
 
-    void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
+    void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
 
     void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
 

--- a/FWCore/ParameterSet/interface/IfExistsDescription.h
+++ b/FWCore/ParameterSet/interface/IfExistsDescription.h
@@ -37,7 +37,8 @@ namespace edm {
 
     void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
 
-    void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
+    void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
 
     void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
 

--- a/FWCore/ParameterSet/interface/ORGroupDescription.h
+++ b/FWCore/ParameterSet/interface/ORGroupDescription.h
@@ -35,7 +35,8 @@ namespace edm {
 
     void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
 
-    void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
+    void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
 
     void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
 

--- a/FWCore/ParameterSet/interface/ParameterDescriptionBase.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionBase.h
@@ -60,7 +60,8 @@ namespace edm {
 
     void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
 
-    void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
+    void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
 
     bool partiallyExists_(ParameterSet const& pset) const override;
 

--- a/FWCore/ParameterSet/interface/ParameterDescriptionNode.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionNode.h
@@ -217,7 +217,8 @@ namespace edm {
 
     virtual void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const = 0;
 
-    virtual void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const = 0;
+    virtual void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const = 0;
 
     virtual void print_(std::ostream&, bool /*optional*/, bool /*writeToCfi*/, DocFormatHelper&) const {}
 

--- a/FWCore/ParameterSet/interface/ParameterSwitch.h
+++ b/FWCore/ParameterSet/interface/ParameterSwitch.h
@@ -86,7 +86,8 @@ namespace edm {
       }
     }
 
-    void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override {
+    void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override {
       switch_.writeCfi(os, optional, startWithComma, indentation, wroteSomething);
 
       typename CaseMap::const_iterator selectedCase = cases_.find(switch_.getDefaultValue());

--- a/FWCore/ParameterSet/interface/ParameterWildcardBase.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcardBase.h
@@ -39,7 +39,8 @@ namespace edm {
                                     std::set<ParameterTypes>& parameterTypes,
                                     std::set<ParameterTypes>& wildcardTypes) const override;
 
-    void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
+    void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
 
     void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
 

--- a/FWCore/ParameterSet/interface/PluginDescription.h
+++ b/FWCore/ParameterSet/interface/PluginDescription.h
@@ -129,7 +129,8 @@ namespace edm {
       validatedLabels.insert(n.begin(), n.end());
     }
 
-    void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const final {
+    void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const final {
       if (not defaultType_.empty()) {
         if (!edmplugin::PluginManager::isAvailable()) {
           auto conf = edmplugin::standard::config();

--- a/FWCore/ParameterSet/interface/XORGroupDescription.h
+++ b/FWCore/ParameterSet/interface/XORGroupDescription.h
@@ -37,7 +37,8 @@ namespace edm {
 
     void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
 
-    void writeCfi_(std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
+    void writeCfi_(
+        std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const override;
 
     void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
 

--- a/FWCore/ParameterSet/src/ANDGroupDescription.cc
+++ b/FWCore/ParameterSet/src/ANDGroupDescription.cc
@@ -60,11 +60,8 @@ namespace edm {
     }
   }
 
-  void ANDGroupDescription::writeCfi_(std::ostream& os,
-                                      bool optional,
-                                      bool& startWithComma,
-                                      int indentation,
-                                      bool& wroteSomething) const {
+  void ANDGroupDescription::writeCfi_(
+      std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const {
     node_left_->writeCfi(os, optional, startWithComma, indentation, wroteSomething);
     node_right_->writeCfi(os, optional, startWithComma, indentation, wroteSomething);
   }

--- a/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
@@ -46,11 +46,8 @@ namespace edm {
     }
   }
 
-  void AllowedLabelsDescriptionBase::writeCfi_(std::ostream& os,
-                                               bool optional,
-                                               bool& startWithComma,
-                                               int indentation,
-                                               bool& wroteSomething) const {
+  void AllowedLabelsDescriptionBase::writeCfi_(
+      std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const {
     parameterHoldingLabels_.writeCfi(os, optional, startWithComma, indentation, wroteSomething);
   }
 

--- a/FWCore/ParameterSet/src/EmptyGroupDescription.cc
+++ b/FWCore/ParameterSet/src/EmptyGroupDescription.cc
@@ -16,11 +16,9 @@ namespace edm {
                                         std::set<std::string>& /*validatedLabels*/,
                                         bool /*optional*/) const {}
 
-  void EmptyGroupDescription::writeCfi_(std::ostream&,
-                                        bool /*optional*/,
-                                        bool& /*startWithComma*/,
-                                        int /*indentation*/,
-                                        bool& /*wroteSomething*/) const {}
+  void EmptyGroupDescription::writeCfi_(
+      std::ostream&, bool /*optional*/, bool& /*startWithComma*/, int /*indentation*/, bool& /*wroteSomething*/) const {
+  }
 
   void EmptyGroupDescription::print_(std::ostream& os,
                                      bool /*optional*/,

--- a/FWCore/ParameterSet/src/IfExistsDescription.cc
+++ b/FWCore/ParameterSet/src/IfExistsDescription.cc
@@ -72,11 +72,8 @@ namespace edm {
     }
   }
 
-  void IfExistsDescription::writeCfi_(std::ostream& os,
-                                      bool optional,
-                                      bool& startWithComma,
-                                      int indentation,
-                                      bool& wroteSomething) const {
+  void IfExistsDescription::writeCfi_(
+      std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const {
     node_left_->writeCfi(os, optional, startWithComma, indentation, wroteSomething);
     node_right_->writeCfi(os, optional, startWithComma, indentation, wroteSomething);
   }

--- a/FWCore/ParameterSet/src/ORGroupDescription.cc
+++ b/FWCore/ParameterSet/src/ORGroupDescription.cc
@@ -71,11 +71,8 @@ namespace edm {
     node_left_->validate(pset, validatedLabels, false);
   }
 
-  void ORGroupDescription::writeCfi_(std::ostream& os,
-                                     bool optional,
-                                     bool& startWithComma,
-                                     int indentation,
-                                     bool& wroteSomething) const {
+  void ORGroupDescription::writeCfi_(
+      std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const {
     node_left_->writeCfi(os, optional, startWithComma, indentation, wroteSomething);
   }
 

--- a/FWCore/ParameterSet/src/ParameterDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/ParameterDescriptionBase.cc
@@ -118,12 +118,8 @@ namespace edm {
     }
   }
 
-  void ParameterDescriptionBase::writeCfi_(std::ostream& os,
-                                           bool optional,
-                                           bool& startWithComma,
-                                           int indentation,
-                                           bool& wroteSomething) const {
-
+  void ParameterDescriptionBase::writeCfi_(
+      std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const {
     wroteSomething = true;
     if (startWithComma)
       os << ",";
@@ -133,16 +129,16 @@ namespace edm {
     printSpaces(os, indentation);
 
     os << label() << " = cms.";
-    
+
     if (!hasDefault()) {
-      if(optional) {
-        os <<"optional.";
+      if (optional) {
+        os << "optional.";
       } else {
-        os <<"required.";
+        os << "required.";
       }
       if (!isTracked())
         os << "untracked.";
-      os <<parameterTypeEnumToString(type());
+      os << parameterTypeEnumToString(type());
     } else {
       if (!isTracked())
         os << "untracked.";

--- a/FWCore/ParameterSet/src/ParameterWildcardBase.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcardBase.cc
@@ -146,11 +146,8 @@ namespace edm {
     }
   }
 
-  void ParameterWildcardBase::writeCfi_(std::ostream&,
-                                        bool /*optional*/,
-                                        bool& /*startWithComma*/,
-                                        int /*indentation*/,
-                                        bool& /*wroteSomething*/) const {
+  void ParameterWildcardBase::writeCfi_(
+      std::ostream&, bool /*optional*/, bool& /*startWithComma*/, int /*indentation*/, bool& /*wroteSomething*/) const {
     // Until we implement default labels and values there is nothing
     // to do here.
   }

--- a/FWCore/ParameterSet/src/XORGroupDescription.cc
+++ b/FWCore/ParameterSet/src/XORGroupDescription.cc
@@ -78,11 +78,8 @@ namespace edm {
     }
   }
 
-  void XORGroupDescription::writeCfi_(std::ostream& os,
-                                      bool optional,
-                                      bool& startWithComma,
-                                      int indentation,
-                                      bool& wroteSomething) const {
+  void XORGroupDescription::writeCfi_(
+      std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const {
     node_left_->writeCfi(os, optional, startWithComma, indentation, wroteSomething);
   }
 


### PR DESCRIPTION

Applying code-format for CMSSW category core.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/428//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


