### PR TITLE
Sim SD: Pass EventSetup refernece instead of DDCompactView

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -44,7 +44,7 @@ class CaloSD : public SensitiveCaloDetector,
                public Observer<const EndOfEvent*> {
 public:
   CaloSD(const std::string& aSDname,
-         const DDCompactView& cpv,
+         const edm::EventSetup& es,
          const SensitiveDetectorCatalog& clg,
          edm::ParameterSet const& p,
          const SimTrackManager*,

--- a/SimG4CMS/Calo/interface/CaloTrkProcessing.h
+++ b/SimG4CMS/Calo/interface/CaloTrkProcessing.h
@@ -25,7 +25,7 @@ class CaloTrkProcessing : public SensitiveCaloDetector,
                           public Observer<const G4Step*> {
 public:
   CaloTrkProcessing(const std::string& aSDname,
-                    const DDCompactView& cpv,
+                    const edm::EventSetup& es,
                     const SensitiveDetectorCatalog& clg,
                     edm::ParameterSet const& p,
                     const SimTrackManager*);

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -30,7 +30,7 @@ class EnergyResolutionVsLumi;
 class ECalSD : public CaloSD {
 public:
   ECalSD(const std::string &,
-         const DDCompactView &,
+         const edm::EventSetup &,
          const SensitiveDetectorCatalog &,
          edm::ParameterSet const &p,
          const SimTrackManager *);
@@ -44,7 +44,7 @@ protected:
   uint16_t getDepth(const G4Step *) override;
 
 private:
-  void initMap(const G4String &, const DDCompactView &);
+  void initMap(const G4String &, const edm::EventSetup &);
   uint16_t getRadiationLength(const G4StepPoint *hitPoint, const G4LogicalVolume *lv);
   uint16_t getLayerIDForTimeSim();
   double curve_LY(const G4LogicalVolume *);
@@ -56,9 +56,7 @@ private:
   std::vector<std::string> getStringArray(const std::string &, const DDsvalues_type &);
 
   // initialised before run
-  bool isEB;
-  bool isEE;
-  EcalNumberingScheme *numberingScheme;
+  EcalNumberingScheme *numberingScheme_;
   bool useWeight, storeTrack, storeRL, storeLayerTimeSim;
   bool useBirk, useBirkL3;
   double birk1, birk2, birk3, birkSlope, birkCut;
@@ -75,7 +73,6 @@ private:
   double crystalLength;
   double crystalDepth;
   uint16_t depth;
-
 #ifdef plotDebug
   TH2F *g2L_[4];
 #endif

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -26,7 +26,6 @@
 #include <map>
 #include <string>
 
-class DDCompactView;
 class DDFilteredView;
 class G4LogicalVolume;
 class G4Material;
@@ -37,7 +36,7 @@ class TH1F;
 class HCalSD : public CaloSD, public Observer<const BeginOfJob*> {
 public:
   HCalSD(const std::string&,
-         const DDCompactView&,
+         const edm::EventSetup&,
          const SensitiveDetectorCatalog&,
          edm::ParameterSet const&,
          const SimTrackManager*);
@@ -56,7 +55,7 @@ protected:
 private:
   void fillLogVolumeVector(const std::string&,
                            const std::string&,
-                           const DDCompactView&,
+                           const edm::EventSetup&,
                            std::vector<const G4LogicalVolume*>&,
                            std::vector<G4String>&);
 

--- a/SimG4CMS/Calo/interface/HFNoseSD.h
+++ b/SimG4CMS/Calo/interface/HFNoseSD.h
@@ -13,7 +13,6 @@
 
 #include <string>
 
-class DDCompactView;
 class HGCalDDDConstants;
 class G4LogicalVolume;
 class G4Step;
@@ -21,7 +20,7 @@ class G4Step;
 class HFNoseSD : public CaloSD, public Observer<const BeginOfJob *> {
 public:
   HFNoseSD(const std::string &,
-           const DDCompactView &,
+           const edm::EventSetup &,
            const SensitiveDetectorCatalog &,
            edm::ParameterSet const &,
            const SimTrackManager *);

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -16,8 +16,6 @@
 #include <string>
 #include <TTree.h>
 
-class DDCompactView;
-class DDFilteredView;
 class G4LogicalVolume;
 class G4Material;
 class G4Step;
@@ -25,7 +23,7 @@ class G4Step;
 class HGCSD : public CaloSD, public Observer<const BeginOfJob *> {
 public:
   HGCSD(const std::string &,
-        const DDCompactView &,
+        const edm::EventSetup &,
         const SensitiveDetectorCatalog &,
         edm::ParameterSet const &,
         const SimTrackManager *);

--- a/SimG4CMS/Calo/interface/HGCScintSD.h
+++ b/SimG4CMS/Calo/interface/HGCScintSD.h
@@ -12,7 +12,6 @@
 
 #include <string>
 
-class DDCompactView;
 class HGCalDDDConstants;
 class G4LogicalVolume;
 class G4Step;
@@ -20,7 +19,7 @@ class G4Step;
 class HGCScintSD : public CaloSD, public Observer<const BeginOfJob *> {
 public:
   HGCScintSD(const std::string &,
-             const DDCompactView &,
+             const edm::EventSetup &,
              const SensitiveDetectorCatalog &,
              edm::ParameterSet const &,
              const SimTrackManager *);

--- a/SimG4CMS/Calo/interface/HGCalSD.h
+++ b/SimG4CMS/Calo/interface/HGCalSD.h
@@ -13,7 +13,6 @@
 
 #include <string>
 
-class DDCompactView;
 class HGCalDDDConstants;
 class G4LogicalVolume;
 class G4Step;
@@ -21,7 +20,7 @@ class G4Step;
 class HGCalSD : public CaloSD, public Observer<const BeginOfJob *> {
 public:
   HGCalSD(const std::string &,
-          const DDCompactView &,
+          const edm::EventSetup &,
           const SensitiveDetectorCatalog &,
           edm::ParameterSet const &,
           const SimTrackManager *);

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -25,13 +25,13 @@
 //#define EDM_ML_DEBUG
 
 CaloSD::CaloSD(const std::string& name,
-               const DDCompactView& cpv,
+               const edm::EventSetup& es,
                const SensitiveDetectorCatalog& clg,
                edm::ParameterSet const& p,
                const SimTrackManager* manager,
                float timeSliceUnit,
                bool ignoreTkID)
-    : SensitiveCaloDetector(name, cpv, clg, p),
+    : SensitiveCaloDetector(name, es, clg, p),
       G4VGFlashSensitiveDetector(),
       eminHit(0.),
       currentHit(nullptr),

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -5,10 +5,13 @@
 
 #include "SimG4CMS/Calo/interface/CaloTrkProcessing.h"
 
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "DetectorDescription/Core/interface/DDFilter.h"
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 #include "DetectorDescription/Core/interface/DDSolid.h"
 #include "DetectorDescription/Core/interface/DDValue.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "G4EventManager.hh"
@@ -23,11 +26,11 @@
 //#define EDM_ML_DEBUG
 
 CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
-                                     const DDCompactView& cpv,
+				     const edm::EventSetup& es,
                                      const SensitiveDetectorCatalog& clg,
                                      edm::ParameterSet const& p,
                                      const SimTrackManager* manager)
-    : SensitiveCaloDetector(name, cpv, clg, p), lastTrackID(-1), m_trackManager(manager) {
+    : SensitiveCaloDetector(name, es, clg, p), lastTrackID(-1), m_trackManager(manager) {
   //Initialise the parameter set
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("CaloTrkProcessing");
   testBeam = m_p.getParameter<bool>("TestBeam");
@@ -38,10 +41,13 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
                               << " MeV and"
                               << " History flag " << putHistory;
 
+  edm::ESTransientHandle<DDCompactView> cpv;
+  es.get<IdealGeometryRecord>().get(cpv);
+
   //Get the names
   G4String attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, name, 0)};
-  DDFilteredView fv(cpv, filter);
+  DDFilteredView fv(*cpv, filter);
   fv.firstChild();
   DDsvalues_type sv(fv.mergedSpecifics());
 

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -26,7 +26,7 @@
 //#define EDM_ML_DEBUG
 
 CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
-				     const edm::EventSetup& es,
+                                     const edm::EventSetup& es,
                                      const SensitiveDetectorCatalog& clg,
                                      edm::ParameterSet const& p,
                                      const SimTrackManager* manager)

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -42,18 +42,18 @@ bool any(const std::vector<T>& v, const T& what) {
 }
 
 ECalSD::ECalSD(const std::string& name,
-	       const edm::EventSetup& es,
-	       const SensitiveDetectorCatalog& clg,
-	       edm::ParameterSet const& p,
-	       const SimTrackManager* manager)
-  : CaloSD(name,
+               const edm::EventSetup& es,
+               const SensitiveDetectorCatalog& clg,
+               edm::ParameterSet const& p,
+               const SimTrackManager* manager)
+    : CaloSD(name,
              es,
              clg,
              p,
-	     manager,
-	     (float)(p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit")),
-	     p.getParameter<edm::ParameterSet>("ECalSD").getParameter<bool>("IgnoreTrackID")),
-    numberingScheme_(nullptr) {
+             manager,
+             (float)(p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit")),
+             p.getParameter<edm::ParameterSet>("ECalSD").getParameter<bool>("IgnoreTrackID")),
+      numberingScheme_(nullptr) {
   //   static SimpleConfigurable<bool>   on1(false,  "ECalSD:UseBirkLaw");
   //   static SimpleConfigurable<double> bk1(0.00463,"ECalSD:BirkC1");
   //   static SimpleConfigurable<double> bk2(-0.03,  "ECalSD:BirkC2");

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -10,6 +10,8 @@
 #include "Geometry/EcalCommonData/interface/EcalPreshowerNumberingScheme.h"
 #include "Geometry/EcalCommonData/interface/ESTBNumberingScheme.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "DetectorDescription/Core/interface/DDFilter.h"
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 #include "DetectorDescription/Core/interface/DDSolid.h"
@@ -17,6 +19,7 @@
 #include "DetectorDescription/Core/interface/DDValue.h"
 
 #include "Geometry/EcalCommonData/interface/EcalBaseNumber.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
@@ -39,18 +42,18 @@ bool any(const std::vector<T>& v, const T& what) {
 }
 
 ECalSD::ECalSD(const std::string& name,
-               const DDCompactView& cpv,
-               const SensitiveDetectorCatalog& clg,
-               edm::ParameterSet const& p,
-               const SimTrackManager* manager)
-    : CaloSD(name,
-             cpv,
+	       const edm::EventSetup& es,
+	       const SensitiveDetectorCatalog& clg,
+	       edm::ParameterSet const& p,
+	       const SimTrackManager* manager)
+  : CaloSD(name,
+             es,
              clg,
              p,
-             manager,
-             (float)(p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit")),
-             p.getParameter<edm::ParameterSet>("ECalSD").getParameter<bool>("IgnoreTrackID")),
-      numberingScheme(nullptr) {
+	     manager,
+	     (float)(p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit")),
+	     p.getParameter<edm::ParameterSet>("ECalSD").getParameter<bool>("IgnoreTrackID")),
+    numberingScheme_(nullptr) {
   //   static SimpleConfigurable<bool>   on1(false,  "ECalSD:UseBirkLaw");
   //   static SimpleConfigurable<double> bk1(0.00463,"ECalSD:BirkC1");
   //   static SimpleConfigurable<double> bk2(-0.03,  "ECalSD:BirkC2");
@@ -59,7 +62,6 @@ ECalSD::ECalSD(const std::string& name,
   //   useBirk          = on1.value();
   //   birk1            = bk1.value()*(g/(MeV*cm2));
   //   birk2            = bk2.value()*(g/(MeV*cm2))*(g/(MeV*cm2));
-
   edm::ParameterSet m_EC = p.getParameter<edm::ParameterSet>("ECalSD");
   useBirk = m_EC.getParameter<bool>("UseBirkLaw");
   useBirkL3 = m_EC.getParameter<bool>("BirkL3Parametrization");
@@ -84,10 +86,13 @@ ECalSD::ECalSD(const std::string& name,
     ageing.setLumies(p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("DelivLuminosity"),
                      p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("InstLuminosity"));
 
+  edm::ESTransientHandle<DDCompactView> cpv;
+  es.get<IdealGeometryRecord>().get(cpv);
+
   //Material list for HB/HE/HO sensitive detectors
   std::string attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, name, 0)};
-  DDFilteredView fv(cpv, filter);
+  DDFilteredView fv(*cpv, filter);
   fv.firstChild();
   DDsvalues_type sv(fv.mergedSpecifics());
   // Use of Weight
@@ -118,10 +123,8 @@ ECalSD::ECalSD(const std::string& name,
     scheme = nullptr;
   } else if (name == "EcalHitsEB") {
     scheme = dynamic_cast<EcalNumberingScheme*>(new EcalBarrelNumberingScheme());
-    isEB = true;
   } else if (name == "EcalHitsEE") {
     scheme = dynamic_cast<EcalNumberingScheme*>(new EcalEndcapNumberingScheme());
-    isEE = true;
   } else if (name == "EcalHitsES") {
     if (isItTB)
       scheme = dynamic_cast<EcalNumberingScheme*>(new ESTBNumberingScheme());
@@ -158,7 +161,7 @@ ECalSD::ECalSD(const std::string& name,
                               << p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit")
                               << " ns";
   if (useWeight)
-    initMap(name, cpv);
+    initMap(name, es);
 #ifdef plotDebug
   edm::Service<TFileService> tfile;
   if (tfile.isAvailable()) {
@@ -177,7 +180,7 @@ ECalSD::ECalSD(const std::string& name,
 #endif
 }
 
-ECalSD::~ECalSD() { delete numberingScheme; }
+ECalSD::~ECalSD() { delete numberingScheme_; }
 
 double ECalSD::getEnergyDeposit(const G4Step* aStep) {
   const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
@@ -293,27 +296,30 @@ uint16_t ECalSD::getLayerIDForTimeSim() {
 }
 
 uint32_t ECalSD::setDetUnitId(const G4Step* aStep) {
-  if (numberingScheme == nullptr) {
+  if (numberingScheme_ == nullptr) {
     return EBDetId(1, 1)();
   } else {
     getBaseNumber(aStep);
-    return numberingScheme->getUnitID(theBaseNumber);
+    return numberingScheme_->getUnitID(theBaseNumber);
   }
 }
 
 void ECalSD::setNumberingScheme(EcalNumberingScheme* scheme) {
   if (scheme != nullptr) {
     edm::LogVerbatim("EcalSim") << "EcalSD: updates numbering scheme for " << GetName();
-    if (numberingScheme)
-      delete numberingScheme;
-    numberingScheme = scheme;
+    if (numberingScheme_)
+      delete numberingScheme_;
+    numberingScheme_ = scheme;
   }
 }
 
-void ECalSD::initMap(const G4String& sd, const DDCompactView& cpv) {
+void ECalSD::initMap(const G4String& sd, const edm::EventSetup& es) {
+  edm::ESTransientHandle<DDCompactView> cpv;
+  es.get<IdealGeometryRecord>().get(cpv);
+
   G4String attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, sd, 0)};
-  DDFilteredView fv(cpv, filter);
+  DDFilteredView fv(*cpv, filter);
   fv.firstChild();
 
   std::vector<const G4LogicalVolume*> lvused;

--- a/SimG4CMS/Calo/src/HFNoseSD.cc
+++ b/SimG4CMS/Calo/src/HFNoseSD.cc
@@ -28,12 +28,12 @@
 //#define EDM_ML_DEBUG
 
 HFNoseSD::HFNoseSD(const std::string& name,
-                   const DDCompactView& cpv,
+                   const edm::EventSetup& es,
                    const SensitiveDetectorCatalog& clg,
                    edm::ParameterSet const& p,
                    const SimTrackManager* manager)
     : CaloSD(name,
-             cpv,
+             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -37,12 +37,12 @@
 //#define plotDebug
 
 HGCSD::HGCSD(const std::string& name,
-             const DDCompactView& cpv,
+             const edm::EventSetup& es,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
     : CaloSD(name,
-             cpv,
+             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/Calo/src/HGCScintSD.cc
+++ b/SimG4CMS/Calo/src/HGCScintSD.cc
@@ -35,12 +35,12 @@
 //#define EDM_ML_DEBUG
 
 HGCScintSD::HGCScintSD(const std::string& name,
-                       const DDCompactView& cpv,
+                       const edm::EventSetup& es,
                        const SensitiveDetectorCatalog& clg,
                        edm::ParameterSet const& p,
                        const SimTrackManager* manager)
     : CaloSD(name,
-             cpv,
+             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/Calo/src/HGCalSD.cc
+++ b/SimG4CMS/Calo/src/HGCalSD.cc
@@ -28,12 +28,12 @@
 //#define EDM_ML_DEBUG
 
 HGCalSD::HGCalSD(const std::string& name,
-                 const DDCompactView& cpv,
+                 const edm::EventSetup& es,
                  const SensitiveDetectorCatalog& clg,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
     : CaloSD(name,
-             cpv,
+             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -15,7 +15,7 @@ class G4LogicalVolume;
 class DreamSD : public CaloSD {
 public:
   DreamSD(const std::string &,
-          const DDCompactView &,
+          const edm::EventSetup &,
           const SensitiveDetectorCatalog &,
           edm::ParameterSet const &,
           const SimTrackManager *);
@@ -31,7 +31,7 @@ private:
   typedef std::pair<double, double> Doubles;
   typedef std::map<G4LogicalVolume *, Doubles> DimensionMap;
 
-  void initMap(const std::string &, const DDCompactView &);
+  void initMap(const std::string &, const edm::EventSetup &);
   double curve_LY(const G4Step *, int);
   double crystalLength(G4LogicalVolume *) const;
   double crystalWidth(G4LogicalVolume *) const;

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -1,4 +1,6 @@
 
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "DetectorDescription/Core/interface/DDFilter.h"
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 #include "DetectorDescription/Core/interface/DDSolid.h"
@@ -13,6 +15,8 @@
 #include "G4Track.hh"
 #include "G4VProcess.hh"
 
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+
 // Histogramming
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -25,11 +29,11 @@
 
 //________________________________________________________________________________________
 DreamSD::DreamSD(const std::string &name,
-                 const DDCompactView &cpv,
+                 const edm::EventSetup &es,
                  const SensitiveDetectorCatalog &clg,
                  edm::ParameterSet const &p,
                  const SimTrackManager *manager)
-    : CaloSD(name, cpv, clg, p, manager) {
+    : CaloSD(name, es, clg, p, manager) {
   edm::ParameterSet m_EC = p.getParameter<edm::ParameterSet>("ECalSD");
   useBirk = m_EC.getParameter<bool>("UseBirkLaw");
   doCherenkov_ = m_EC.getParameter<bool>("doCherenkov");
@@ -48,7 +52,7 @@ DreamSD::DreamSD(const std::string &name,
                           << "          Parameterization of Cherenkov is set to " << doCherenkov_
                           << " and readout both sides is " << readBothSide_;
 
-  initMap(name, cpv);
+  initMap(name, es);
 }
 
 //________________________________________________________________________________________
@@ -101,10 +105,14 @@ uint32_t DreamSD::setDetUnitId(const G4Step *aStep) {
 }
 
 //________________________________________________________________________________________
-void DreamSD::initMap(const std::string &sd, const DDCompactView &cpv) {
+void DreamSD::initMap(const std::string &sd, const edm::EventSetup &es) {
+
+  edm::ESTransientHandle<DDCompactView> cpv;
+  es.get<IdealGeometryRecord>().get(cpv);
+
   G4String attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, sd, 0)};
-  DDFilteredView fv(cpv, filter);
+  DDFilteredView fv(*cpv, filter);
   fv.firstChild();
 
   const G4LogicalVolumeStore *lvs = G4LogicalVolumeStore::GetInstance();

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -106,7 +106,6 @@ uint32_t DreamSD::setDetUnitId(const G4Step *aStep) {
 
 //________________________________________________________________________________________
 void DreamSD::initMap(const std::string &sd, const edm::EventSetup &es) {
-
   edm::ESTransientHandle<DDCompactView> cpv;
   es.get<IdealGeometryRecord>().get(cpv);
 

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
@@ -20,7 +20,7 @@ class EcalBaseNumber;
 class EcalTBH4BeamSD : public CaloSD {
 public:
   EcalTBH4BeamSD(const std::string &,
-                 const DDCompactView &,
+                 const edm::EventSetup &,
                  const SensitiveDetectorCatalog &,
                  edm::ParameterSet const &,
                  const SimTrackManager *);

--- a/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
+++ b/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
@@ -20,11 +20,11 @@
 #include "G4SystemOfUnits.hh"
 
 EcalTBH4BeamSD::EcalTBH4BeamSD(const std::string &name,
-                               const DDCompactView &cpv,
+                               const edm::EventSetup &es,
                                const SensitiveDetectorCatalog &clg,
                                edm::ParameterSet const &p,
                                const SimTrackManager *manager)
-    : CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
+    : CaloSD(name, es, clg, p, manager), numberingScheme(nullptr) {
   edm::ParameterSet m_EcalTBH4BeamSD = p.getParameter<edm::ParameterSet>("EcalTBH4BeamSD");
   useBirk = m_EcalTBH4BeamSD.getParameter<bool>("UseBirkLaw");
   birk1 = m_EcalTBH4BeamSD.getParameter<double>("BirkC1") * (g / (MeV * cm2));

--- a/SimG4CMS/FP420/interface/FP420SD.h
+++ b/SimG4CMS/FP420/interface/FP420SD.h
@@ -44,7 +44,7 @@ class FP420SD : public SensitiveTkDetector,
                 public Observer<const EndOfEvent*> {
 public:
   FP420SD(const std::string&,
-          const DDCompactView&,
+          const edm::EventSetup&,
           const SensitiveDetectorCatalog&,
           edm::ParameterSet const&,
           const SimTrackManager*);

--- a/SimG4CMS/FP420/plugins/FP420SD.cc
+++ b/SimG4CMS/FP420/plugins/FP420SD.cc
@@ -44,11 +44,11 @@
 //#define debug
 //-------------------------------------------------------------------
 FP420SD::FP420SD(const std::string& name,
-                 const DDCompactView& cpv,
+                 const edm::EventSetup& es,
                  const SensitiveDetectorCatalog& clg,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
-    : SensitiveTkDetector(name, cpv, clg, p),
+    : SensitiveTkDetector(name, es, clg, p),
       numberingScheme(nullptr),
       hcID(-1),
       theHC(nullptr),

--- a/SimG4CMS/Forward/interface/BHMSD.h
+++ b/SimG4CMS/Forward/interface/BHMSD.h
@@ -14,7 +14,7 @@ class BHMNumberingScheme;
 class BHMSD : public TimingSD {
 public:
   BHMSD(const std::string &,
-        const DDCompactView &,
+        const edm::EventSetup &,
         const SensitiveDetectorCatalog &,
         edm::ParameterSet const &,
         const SimTrackManager *);

--- a/SimG4CMS/Forward/interface/Bcm1fSD.h
+++ b/SimG4CMS/Forward/interface/Bcm1fSD.h
@@ -11,7 +11,7 @@ class G4Step;
 class Bcm1fSD : public TimingSD {
 public:
   Bcm1fSD(const std::string &,
-          const DDCompactView &,
+          const edm::EventSetup &,
           const SensitiveDetectorCatalog &,
           edm::ParameterSet const &,
           const SimTrackManager *);

--- a/SimG4CMS/Forward/interface/BscSD.h
+++ b/SimG4CMS/Forward/interface/BscSD.h
@@ -13,7 +13,7 @@ class BscNumberingScheme;
 class BscSD : public TimingSD {
 public:
   BscSD(const std::string &,
-        const DDCompactView &,
+        const edm::EventSetup &,
         const SensitiveDetectorCatalog &,
         edm::ParameterSet const &,
         const SimTrackManager *);

--- a/SimG4CMS/Forward/interface/CastorSD.h
+++ b/SimG4CMS/Forward/interface/CastorSD.h
@@ -30,7 +30,7 @@
 class CastorSD : public CaloSD {
 public:
   CastorSD(const std::string &,
-           const DDCompactView &,
+           const edm::EventSetup &,
            const SensitiveDetectorCatalog &clg,
            edm::ParameterSet const &,
            const SimTrackManager *);

--- a/SimG4CMS/Forward/interface/FastTimerSD.h
+++ b/SimG4CMS/Forward/interface/FastTimerSD.h
@@ -19,7 +19,7 @@ class FastTimeDDDConstants;
 class FastTimerSD : public TimingSD, public Observer<const BeginOfJob *> {
 public:
   FastTimerSD(const std::string &,
-              const DDCompactView &,
+              const edm::EventSetup &,
               const SensitiveDetectorCatalog &,
               edm::ParameterSet const &,
               const SimTrackManager *);

--- a/SimG4CMS/Forward/interface/MtdSD.h
+++ b/SimG4CMS/Forward/interface/MtdSD.h
@@ -18,7 +18,7 @@ class SimTrackManager;
 class MtdSD : public TimingSD {
 public:
   MtdSD(const std::string &,
-        const DDCompactView &,
+        const edm::EventSetup &,
         const SensitiveDetectorCatalog &,
         edm::ParameterSet const &,
         const SimTrackManager *);

--- a/SimG4CMS/Forward/interface/PltSD.h
+++ b/SimG4CMS/Forward/interface/PltSD.h
@@ -11,7 +11,7 @@ class SimTrackManager;
 class PltSD : public TimingSD {
 public:
   PltSD(const std::string &,
-        const DDCompactView &,
+        const edm::EventSetup &,
         const SensitiveDetectorCatalog &,
         edm::ParameterSet const &,
         const SimTrackManager *);

--- a/SimG4CMS/Forward/interface/TimingSD.h
+++ b/SimG4CMS/Forward/interface/TimingSD.h
@@ -29,7 +29,7 @@ class G4ProcessTypeEnumerator;
 class TimingSD : public SensitiveTkDetector, public Observer<const BeginOfEvent*> {
 public:
   TimingSD(const std::string&,
-           const DDCompactView&,
+           const edm::EventSetup&,
            const SensitiveDetectorCatalog&,
            const edm::ParameterSet&,
            const SimTrackManager*);

--- a/SimG4CMS/Forward/interface/TotemSD.h
+++ b/SimG4CMS/Forward/interface/TotemSD.h
@@ -43,7 +43,7 @@ class SimTrackManager;
 class TotemSD : public SensitiveTkDetector, public Observer<const BeginOfEvent*> {
 public:
   TotemSD(const std::string&,
-          const DDCompactView&,
+          const edm::EventSetup&,
           const SensitiveDetectorCatalog&,
           edm::ParameterSet const&,
           const SimTrackManager*);

--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -13,7 +13,7 @@
 class ZdcSD : public CaloSD {
 public:
   ZdcSD(const std::string &,
-        const DDCompactView &,
+        const edm::EventSetup &,
         const SensitiveDetectorCatalog &,
         edm::ParameterSet const &,
         const SimTrackManager *);

--- a/SimG4CMS/Forward/src/BHMSD.cc
+++ b/SimG4CMS/Forward/src/BHMSD.cc
@@ -12,11 +12,11 @@
 //#define debug
 //-------------------------------------------------------------------
 BHMSD::BHMSD(const std::string& name,
-             const DDCompactView& cpv,
+             const edm::EventSetup& es,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
-    : TimingSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
+    : TimingSD(name, es, clg, p, manager), numberingScheme(nullptr) {
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("BHMSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");

--- a/SimG4CMS/Forward/src/Bcm1fSD.cc
+++ b/SimG4CMS/Forward/src/Bcm1fSD.cc
@@ -31,11 +31,11 @@
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
 Bcm1fSD::Bcm1fSD(const std::string& name,
-                 const DDCompactView& cpv,
+                 const edm::EventSetup& es,
                  const SensitiveDetectorCatalog& clg,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
-    : TimingSD(name, cpv, clg, p, manager) {
+    : TimingSD(name, es, clg, p, manager) {
   edm::ParameterSet m_TrackerSD = p.getParameter<edm::ParameterSet>("Bcm1fSD");
   energyCut = m_TrackerSD.getParameter<double>("EnergyThresholdForPersistencyInGeV") * GeV;  //default must be 0.5 (?)
   energyHistoryCut =

--- a/SimG4CMS/Forward/src/BscSD.cc
+++ b/SimG4CMS/Forward/src/BscSD.cc
@@ -21,11 +21,11 @@
 #define debug
 //-------------------------------------------------------------------
 BscSD::BscSD(const std::string& name,
-             const DDCompactView& cpv,
+             const edm::EventSetup& es,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
-    : TimingSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
+    : TimingSD(name, es, clg, p, manager), numberingScheme(nullptr) {
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("BscSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -29,11 +29,11 @@
 //#define debugLog
 
 CastorSD::CastorSD(const std::string& name,
-                   const DDCompactView& cpv,
+                   const edm::EventSetup& es,
                    const SensitiveDetectorCatalog& clg,
                    edm::ParameterSet const& p,
                    const SimTrackManager* manager)
-    : CaloSD(name, cpv, clg, p, manager),
+    : CaloSD(name, es, clg, p, manager),
       numberingScheme(nullptr),
       lvC3EF(nullptr),
       lvC3HF(nullptr),

--- a/SimG4CMS/Forward/src/FastTimerSD.cc
+++ b/SimG4CMS/Forward/src/FastTimerSD.cc
@@ -28,20 +28,23 @@
 //#define EDM_ML_DEBUG
 //-------------------------------------------------------------------
 FastTimerSD::FastTimerSD(const std::string& name,
-                         const DDCompactView& cpv,
+                         const edm::EventSetup& es,
                          const SensitiveDetectorCatalog& clg,
                          edm::ParameterSet const& p,
                          const SimTrackManager* manager)
-    : TimingSD(name, cpv, clg, p, manager), ftcons(nullptr) {
+    : TimingSD(name, es, clg, p, manager), ftcons(nullptr) {
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("FastTimerSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");
 
   SetVerboseLevel(verbn);
 
+  edm::ESTransientHandle<DDCompactView> cpv;
+  es.get<IdealGeometryRecord>().get(cpv);
+
   std::string attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, name, 0)};
-  DDFilteredView fv(cpv, filter);
+  DDFilteredView fv(*cpv, filter);
   fv.firstChild();
   DDsvalues_type sv(fv.mergedSpecifics());
   std::vector<int> temp = dbl_to_int(getDDDArray("Type", sv));

--- a/SimG4CMS/Forward/src/MtdSD.cc
+++ b/SimG4CMS/Forward/src/MtdSD.cc
@@ -26,20 +26,23 @@
 //#define EDM_ML_DEBUG
 //-------------------------------------------------------------------
 MtdSD::MtdSD(const std::string& name,
-             const DDCompactView& cpv,
+             const edm::EventSetup& es,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
-    : TimingSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
+    : TimingSD(name, es, clg, p, manager), numberingScheme(nullptr) {
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("MtdSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");
 
   SetVerboseLevel(verbn);
 
+  edm::ESTransientHandle<DDCompactView> cpv;
+  es.get<IdealGeometryRecord>().get(cpv);
+
   std::string attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, name, 0)};
-  DDFilteredView fv(cpv, filter);
+  DDFilteredView fv(*cpv, filter);
   fv.firstChild();
   DDsvalues_type sv(fv.mergedSpecifics());
   std::vector<int> temp = dbl_to_int(getDDDArray("Type", sv));

--- a/SimG4CMS/Forward/src/PltSD.cc
+++ b/SimG4CMS/Forward/src/PltSD.cc
@@ -16,11 +16,11 @@
 #include <iostream>
 
 PltSD::PltSD(const std::string& name,
-             const DDCompactView& cpv,
+             const edm::EventSetup& es,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
-    : TimingSD(name, cpv, clg, p, manager) {
+    : TimingSD(name, es, clg, p, manager) {
   edm::ParameterSet m_TrackerSD = p.getParameter<edm::ParameterSet>("PltSD");
   energyCut =
       m_TrackerSD.getParameter<double>("EnergyThresholdForPersistencyInGeV") * CLHEP::GeV;  //default must be 0.5

--- a/SimG4CMS/Forward/src/TimingSD.cc
+++ b/SimG4CMS/Forward/src/TimingSD.cc
@@ -38,11 +38,11 @@ static const double invdeg = 1.0 / CLHEP::deg;
 
 //-------------------------------------------------------------------
 TimingSD::TimingSD(const std::string& name,
-                   const DDCompactView& cpv,
+                   const edm::EventSetup& es,
                    const SensitiveDetectorCatalog& clg,
                    edm::ParameterSet const& p,
                    const SimTrackManager* manager)
-    : SensitiveTkDetector(name, cpv, clg, p),
+    : SensitiveTkDetector(name, es, clg, p),
       theManager(manager),
       theHC(nullptr),
       currentHit(nullptr),

--- a/SimG4CMS/Forward/src/TotemSD.cc
+++ b/SimG4CMS/Forward/src/TotemSD.cc
@@ -45,11 +45,11 @@
 // constructors and destructor
 //
 TotemSD::TotemSD(const std::string& name,
-                 const DDCompactView& cpv,
+                 const edm::EventSetup& es,
                  const SensitiveDetectorCatalog& clg,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
-    : SensitiveTkDetector(name, cpv, clg, p),
+    : SensitiveTkDetector(name, es, clg, p),
       numberingScheme(nullptr),
       hcID(-1),
       theHC(nullptr),

--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -6,6 +6,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include "SimG4CMS/Forward/interface/ZdcSD.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 
 #include "G4SDManager.hh"
@@ -21,11 +24,11 @@
 #include "G4Poisson.hh"
 
 ZdcSD::ZdcSD(const std::string& name,
-             const DDCompactView& cpv,
+             const edm::EventSetup& es,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
-    : CaloSD(name, cpv, clg, p, manager) {
+    : CaloSD(name, es, clg, p, manager) {
   edm::ParameterSet m_ZdcSD = p.getParameter<edm::ParameterSet>("ZdcSD");
   useShowerLibrary = m_ZdcSD.getParameter<bool>("UseShowerLibrary");
   useShowerHits = m_ZdcSD.getParameter<bool>("UseShowerHits");
@@ -47,8 +50,11 @@ ZdcSD::ZdcSD(const std::string& name,
 
   edm::LogInfo("ForwardSim") << "\nEnergy Threshold Cut set to " << zdcHitEnergyCut / GeV << " (GeV)";
 
+  edm::ESTransientHandle<DDCompactView> cpv;
+  es.get<IdealGeometryRecord>().get(cpv);
+
   if (useShowerLibrary) {
-    showerLibrary.reset(new ZdcShowerLibrary(name, cpv, p));
+    showerLibrary.reset(new ZdcShowerLibrary(name, *cpv, p));
     setParameterized(true);
   } else {
     showerLibrary.reset(nullptr);

--- a/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
@@ -24,7 +24,7 @@
 class AHCalSD : public CaloSD {
 public:
   AHCalSD(const std::string&,
-          const DDCompactView&,
+          const edm::EventSetup&,
           const SensitiveDetectorCatalog&,
           edm::ParameterSet const&,
           const SimTrackManager*);
@@ -43,12 +43,12 @@ private:
 };
 
 AHCalSD::AHCalSD(const std::string& name,
-                 const DDCompactView& cpv,
+                 const edm::EventSetup& es,
                  const SensitiveDetectorCatalog& clg,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
     : CaloSD(name,
-             cpv,
+             es,
              clg,
              p,
              manager,

--- a/SimG4CMS/HGCalTestBeam/plugins/HGCalTB16SD01.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/HGCalTB16SD01.cc
@@ -21,7 +21,7 @@
 class HGCalTB16SD01 : public CaloSD {
 public:
   HGCalTB16SD01(const std::string&,
-                const DDCompactView&,
+                const edm::EventSetup&,
                 const SensitiveDetectorCatalog&,
                 edm::ParameterSet const&,
                 const SimTrackManager*);
@@ -44,11 +44,11 @@ private:
 };
 
 HGCalTB16SD01::HGCalTB16SD01(const std::string& name,
-                             const DDCompactView& cpv,
+                             const edm::EventSetup& es,
                              const SensitiveDetectorCatalog& clg,
                              edm::ParameterSet const& p,
                              const SimTrackManager* manager)
-    : CaloSD(name, cpv, clg, p, manager), initialize_(true) {
+    : CaloSD(name, es, clg, p, manager), initialize_(true) {
   // Values from NIM 80 (1970) 239-244: as implemented in Geant3
   edm::ParameterSet m_HC = p.getParameter<edm::ParameterSet>("HGCalTestBeamSD");
   matName_ = m_HC.getParameter<std::string>("Material");

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
@@ -29,7 +29,7 @@
 class HcalTB02SD : public CaloSD {
 public:
   HcalTB02SD(const std::string&,
-             const DDCompactView&,
+             const edm::EventSetup&,
              const SensitiveDetectorCatalog&,
              edm::ParameterSet const&,
              const SimTrackManager*);
@@ -41,7 +41,7 @@ protected:
   double getEnergyDeposit(const G4Step*) override;
 
 private:
-  void initMap(const std::string&, const DDCompactView&);
+  void initMap(const std::string&, const edm::EventSetup&);
   double curve_LY(const G4String&, const G4StepPoint*);
   double crystalLength(const G4String&);
 

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
@@ -12,15 +12,14 @@
 
 #include <string>
 
-class DDCompactView;
-class DDFilteredView;
 class G4Step;
 class G4Material;
+class DDFilteredView;
 
 class HcalTB06BeamSD : public CaloSD {
 public:
   HcalTB06BeamSD(const std::string &,
-                 const DDCompactView &,
+                 const edm::EventSetup &,
                  const SensitiveDetectorCatalog &,
                  edm::ParameterSet const &,
                  const SimTrackManager *);

--- a/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
+++ b/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
@@ -36,7 +36,7 @@ class SimTrackManager;
 class MuonSensitiveDetector : public SensitiveTkDetector, public Observer<const BeginOfEvent*> {
 public:
   explicit MuonSensitiveDetector(const std::string&,
-                                 const DDCompactView&,
+                                 const edm::EventSetup&,
                                  const SensitiveDetectorCatalog&,
                                  edm::ParameterSet const&,
                                  const SimTrackManager*);

--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -14,10 +14,14 @@
 #include "SimG4CMS/Muon/interface/MuonG4Numbering.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/MuonSimHitNumberingScheme.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
 
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
+
+#include "FWCore/Framework/interface/ESTransientHandle.h"
 
 #include "G4VProcess.hh"
 #include "G4EventManager.hh"
@@ -33,11 +37,11 @@
 //#define DebugLog
 
 MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name,
-                                             const DDCompactView& cpv,
+                                             const edm::EventSetup& es,
                                              const SensitiveDetectorCatalog& clg,
                                              edm::ParameterSet const& p,
                                              const SimTrackManager* manager)
-    : SensitiveTkDetector(name, cpv, clg, p),
+    : SensitiveTkDetector(name, es, clg, p),
       thePV(nullptr),
       theHit(nullptr),
       theDetUnitId(0),
@@ -55,8 +59,11 @@ MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name,
   LogDebug("MuonSimDebug") << "create MuonSubDetector " << name;
   detector = new MuonSubDetector(name);
 
+  edm::ESTransientHandle<DDCompactView> cpv;
+  es.get<IdealGeometryRecord>().get(cpv);
+
   //The constants take time to calculate and are needed by many helpers
-  MuonDDDConstants constants(cpv);
+  MuonDDDConstants constants(*cpv);
   G4String sdet = "unknown";
   if (detector->isEndcap()) {
     theRotation = new MuonEndcapFrameRotation();

--- a/SimG4CMS/ShowerLibraryProducer/interface/FiberSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/FiberSD.h
@@ -30,7 +30,7 @@ class FiberSD : public SensitiveCaloDetector,
                 public Observer<const EndOfEvent *> {
 public:
   explicit FiberSD(const std::string &,
-                   const DDCompactView &,
+                   const edm::EventSetup &,
                    const SensitiveDetectorCatalog &,
                    edm::ParameterSet const &,
                    const SimTrackManager *);

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFChamberSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFChamberSD.h
@@ -19,7 +19,7 @@ class G4HCofThisEvent;
 class HFChamberSD : public SensitiveCaloDetector {
 public:
   explicit HFChamberSD(const std::string&,
-                       const DDCompactView&,
+                       const edm::EventSetup&,
                        const SensitiveDetectorCatalog&,
                        const edm::ParameterSet&,
                        const SimTrackManager*);

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFWedgeSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFWedgeSD.h
@@ -18,7 +18,7 @@ class G4HCofThisEvent;
 class HFWedgeSD : public SensitiveCaloDetector {
 public:
   explicit HFWedgeSD(const std::string&,
-                     const DDCompactView& cpv,
+                     const edm::EventSetup& cpv,
                      const SensitiveDetectorCatalog& clg,
                      edm::ParameterSet const& p,
                      const SimTrackManager*);

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
@@ -3,7 +3,10 @@
 #include "DataFormats/Math/interface/Point3D.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDSimConstants.h"
 #include "Geometry/Records/interface/HcalSimNumberingRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "G4VPhysicalVolume.hh"
@@ -19,12 +22,14 @@
 #include "G4ios.hh"
 
 FiberSD::FiberSD(const std::string& iname,
-                 const DDCompactView& cpv,
+                 const edm::EventSetup& es,
                  const SensitiveDetectorCatalog& clg,
                  edm::ParameterSet const& p,
                  const SimTrackManager* manager)
-    : SensitiveCaloDetector(iname, cpv, clg, p), m_trackManager(manager), theHCID(-1), theHC(nullptr) {
-  theShower = new HFShower(iname, cpv, p, 1);
+    : SensitiveCaloDetector(iname, es, clg, p), m_trackManager(manager), theHCID(-1), theHC(nullptr) {
+  edm::ESTransientHandle<DDCompactView> cpv;
+  es.get<IdealGeometryRecord>().get(cpv);
+  theShower = new HFShower(iname, *cpv, p, 1);
 }
 
 FiberSD::~FiberSD() {

--- a/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
@@ -17,11 +17,11 @@
 #include "G4SystemOfUnits.hh"
 
 HFChamberSD::HFChamberSD(const std::string& name,
-                         const DDCompactView& cpv,
+                         const edm::EventSetup& es,
                          const SensitiveDetectorCatalog& clg,
                          edm::ParameterSet const& p,
                          const SimTrackManager* manager)
-    : SensitiveCaloDetector(name, cpv, clg, p), m_trackManager(manager), theHCID(-1), theHC(nullptr), theNSteps(0) {}
+    : SensitiveCaloDetector(name, es, clg, p), m_trackManager(manager), theHCID(-1), theHC(nullptr), theNSteps(0) {}
 
 HFChamberSD::~HFChamberSD() { delete theHC; }
 

--- a/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
@@ -17,11 +17,11 @@
 #include "G4SystemOfUnits.hh"
 
 HFWedgeSD::HFWedgeSD(const std::string& iname,
-                     const DDCompactView& cpv,
+                     const edm::EventSetup& es,
                      const SensitiveDetectorCatalog& clg,
                      edm::ParameterSet const& p,
                      const SimTrackManager* manager)
-    : SensitiveCaloDetector(iname, cpv, clg, p),
+    : SensitiveCaloDetector(iname, es, clg, p),
       m_trackManager(manager),
       hcID(-1),
       theHC(nullptr),

--- a/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
+++ b/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
@@ -31,7 +31,7 @@ class TkAccumulatingSensitiveDetector : public SensitiveTkDetector,
                                         public Observer<const BeginOfJob *> {
 public:
   TkAccumulatingSensitiveDetector(const std::string &,
-                                  const DDCompactView &,
+                                  const edm::EventSetup &,
                                   const SensitiveDetectorCatalog &,
                                   edm::ParameterSet const &,
                                   const SimTrackManager *);

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -43,11 +43,11 @@ static TrackerG4SimHitNumberingScheme& numberingScheme(const DDCompactView& cpv,
 }
 
 TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(const std::string& name,
-                                                                 const DDCompactView& cpv,
+                                                                 const edm::EventSetup& es,
                                                                  const SensitiveDetectorCatalog& clg,
                                                                  edm::ParameterSet const& p,
                                                                  const SimTrackManager* manager)
-    : SensitiveTkDetector(name, cpv, clg, p),
+    : SensitiveTkDetector(name, es, clg, p),
       theManager(manager),
       rTracker(1200. * CLHEP::mm),
       zTracker(3000. * CLHEP::mm),

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -234,7 +234,7 @@ void RunManager::initG4(const edm::EventSetup& es) {
     // attach sensitive detector
 
     AttachSD attach;
-    auto sensDets = attach.create((*pDD), catalog_, m_p, m_trackManager.get(), m_registry);
+    auto sensDets = attach.create(es, catalog_, m_p, m_trackManager.get(), m_registry);
 
     m_sensTkDets.swap(sensDets.first);
     m_sensCaloDets.swap(sensDets.second);

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -300,7 +300,7 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
   // attach sensitive detector
   AttachSD attach;
   auto sensDets =
-      attach.create(*pDD, runManagerMaster.catalog(), m_p, m_tls->trackManager.get(), *(m_tls->registry.get()));
+      attach.create(es, runManagerMaster.catalog(), m_p, m_tls->trackManager.get(), *(m_tls->registry.get()));
 
   m_tls->sensTkDets.swap(sensDets.first);
   m_tls->sensCaloDets.swap(sensDets.second);

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -135,7 +135,7 @@ void GeometryProducer::produce(edm::Event &e, const edm::EventSetup &es) {
       m_attach = new AttachSD;
     {
       std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *>> sensDets =
-          m_attach->create((*pDD), catalog_, m_p, m_trackManager.get(), m_registry);
+          m_attach->create(es, catalog_, m_p, m_trackManager.get(), m_registry);
 
       m_sensTkDets.swap(sensDets.first);
       m_sensCaloDets.swap(sensDets.second);

--- a/SimG4Core/SensitiveDetector/interface/AttachSD.h
+++ b/SimG4Core/SensitiveDetector/interface/AttachSD.h
@@ -4,9 +4,10 @@
 #include <vector>
 
 namespace edm {
+  class EventSetup;
   class ParameterSet;
 }
-class DDCompactView;
+
 class SensitiveDetectorCatalog;
 class SensitiveTkDetector;
 class SensitiveCaloDetector;
@@ -19,7 +20,7 @@ public:
   ~AttachSD();
 
   std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *> > create(
-      const DDCompactView &,
+      const edm::EventSetup &,
       const SensitiveDetectorCatalog &,
       edm::ParameterSet const &,
       const SimTrackManager *,

--- a/SimG4Core/SensitiveDetector/interface/AttachSD.h
+++ b/SimG4Core/SensitiveDetector/interface/AttachSD.h
@@ -6,7 +6,7 @@
 namespace edm {
   class EventSetup;
   class ParameterSet;
-}
+}  // namespace edm
 
 class SensitiveDetectorCatalog;
 class SensitiveTkDetector;

--- a/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
@@ -10,10 +10,10 @@
 class SensitiveCaloDetector : public SensitiveDetector {
 public:
   explicit SensitiveCaloDetector(const std::string& iname,
-                                 const DDCompactView& cpv,
+                                 const edm::EventSetup& es,
                                  const SensitiveDetectorCatalog& clg,
                                  edm::ParameterSet const& p)
-      : SensitiveDetector(iname, cpv, clg, p, true){};
+      : SensitiveDetector(iname, es, clg, p, true){};
 
   virtual void fillHits(edm::PCaloHitContainer&, const std::string& hname) = 0;
   virtual void reset(){};

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -17,12 +17,15 @@ class G4Step;
 class G4HCofThisEvent;
 class G4TouchableHistory;
 class G4VPhysicalVolume;
-class DDCompactView;
+
+namespace edm {
+  class EventSetup;
+}
 
 class SensitiveDetector : public G4VSensitiveDetector {
 public:
   explicit SensitiveDetector(const std::string& iname,
-                             const DDCompactView& cpv,
+                             const edm::EventSetup& es,
                              const SensitiveDetectorCatalog&,
                              edm::ParameterSet const& p,
                              bool calo);

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -18,12 +18,12 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // forward declarations
-class DDCompactView;
 class SimTrackManager;
 class SimActivityRegistry;
 class SensitiveDetectorCatalog;
 
 namespace edm {
+  class EventSetup;
   class ParameterSet;
 }
 
@@ -34,12 +34,12 @@ public:
 
   // ---------- const member functions ---------------------
   SensitiveDetector* make(const std::string& iname,
-                          const DDCompactView& cpv,
+                          const edm::EventSetup& es,
                           const SensitiveDetectorCatalog& clg,
                           const edm::ParameterSet& p,
                           const SimTrackManager* man,
                           SimActivityRegistry& reg) const override {
-    T* sd = new T(iname, cpv, clg, p, man);
+    T* sd = new T(iname, es, clg, p, man);
     SimActivityRegistryEnroller::enroll(reg, sd);
     return static_cast<SensitiveDetector*>(sd);
   };

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -25,7 +25,7 @@ class SensitiveDetectorCatalog;
 namespace edm {
   class EventSetup;
   class ParameterSet;
-}
+}  // namespace edm
 
 template <class T>
 class SensitiveDetectorMaker : public SensitiveDetectorMakerBase {

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -16,11 +16,11 @@
 
 // forward declarations
 class SimActivityRegistry;
-class DDCompactView;
 class SimTrackManager;
 class SensitiveDetectorCatalog;
 
 namespace edm {
+  class EventSetup;
   class ParameterSet;
 }
 
@@ -31,7 +31,7 @@ public:
 
   // ---------- const member functions ---------------------
   virtual SensitiveDetector* make(const std::string& iname,
-                                  const DDCompactView& cpv,
+                                  const edm::EventSetup& es,
                                   const SensitiveDetectorCatalog& clg,
                                   const edm::ParameterSet& p,
                                   const SimTrackManager* man,

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -22,7 +22,7 @@ class SensitiveDetectorCatalog;
 namespace edm {
   class EventSetup;
   class ParameterSet;
-}
+}  // namespace edm
 
 class SensitiveDetectorMakerBase {
 public:

--- a/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
@@ -8,10 +8,10 @@
 class SensitiveTkDetector : public SensitiveDetector {
 public:
   explicit SensitiveTkDetector(const std::string& iname,
-                               const DDCompactView& cpv,
+                               const edm::EventSetup& es,
                                const SensitiveDetectorCatalog& clg,
                                edm::ParameterSet const& p)
-      : SensitiveDetector(iname, cpv, clg, p, false) {}
+      : SensitiveDetector(iname, es, clg, p, false) {}
   virtual void fillHits(edm::PSimHitContainer&, const std::string& hname) = 0;
 };
 

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -13,7 +13,7 @@ AttachSD::AttachSD() {}
 AttachSD::~AttachSD() {}
 
 std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*> > AttachSD::create(
-    const DDCompactView& cpv,
+    const edm::EventSetup& es,
     const SensitiveDetectorCatalog& clg,
     edm::ParameterSet const& p,
     const SimTrackManager* man,
@@ -25,7 +25,7 @@ std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*>
     std::string className = clg.className(rname);
     std::unique_ptr<SensitiveDetectorMakerBase> temp{SensitiveDetectorPluginFactory::get()->create(className)};
 
-    std::unique_ptr<SensitiveDetector> sd{temp->make(rname, cpv, clg, p, man, reg)};
+    std::unique_ptr<SensitiveDetector> sd{temp->make(rname, es, clg, p, man, reg)};
 
     std::stringstream ss;
     ss << " AttachSD: created a " << className << " with name " << rname;

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -16,7 +16,7 @@
 #include <sstream>
 
 SensitiveDetector::SensitiveDetector(const std::string& iname,
-                                     const DDCompactView& cpv,
+                                     const edm::EventSetup& es,
                                      const SensitiveDetectorCatalog& clg,
                                      edm::ParameterSet const& p,
                                      bool calo)


### PR DESCRIPTION
#### PR description:

* Replacing a DDCompactView reference with an EventSetup one means that the objects that need a DDCompactView should obtain it from the EventSetup when they need it.

This should have no impact on simulation results, but facilitates the migration to DD4hep by reducing the number of classes which will have to be modified.

Other issues to be noted (not addressed in this PR as being out of its scope):

 * The SD code would benefit from using smart pointers
 * Plotting capabilities of the SD classes could be factored out
 * Naming conventions should be applied
 * Unused variables and legacy features can be removed 

#### PR validation:

usual RelVal validation

@civanch, @kpedro88:
NOTE: It would be nice to run performance comparison tests if there are any.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
