### PR TITLE
Running code-format for generators

### DIFF
--- a/SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h
@@ -10,57 +10,49 @@
 
 class GenFilterInfo {
 public:
-  
   // constructors, destructors
   GenFilterInfo();
-  GenFilterInfo(unsigned int, unsigned int); // obsolete, should be avoided for new classes
-  GenFilterInfo(unsigned int, unsigned int, unsigned int, unsigned int,
-		double, double, double, double);
+  GenFilterInfo(unsigned int, unsigned int);  // obsolete, should be avoided for new classes
+  GenFilterInfo(unsigned int, unsigned int, unsigned int, unsigned int, double, double, double, double);
   GenFilterInfo(const GenFilterInfo&);
   virtual ~GenFilterInfo();
-  
+
   // getters
-  unsigned int numEventsTried() const { return (numTotalPositiveEvents_ + numTotalNegativeEvents_);}
-  unsigned int numEventsPassed() const { return fmax(0, (numPassPositiveEvents_ - numPassNegativeEvents_));}
-  unsigned int numEventsTotal() const { return fmax(0, (numTotalPositiveEvents_ - numTotalNegativeEvents_));}
+  unsigned int numEventsTried() const { return (numTotalPositiveEvents_ + numTotalNegativeEvents_); }
+  unsigned int numEventsPassed() const { return fmax(0, (numPassPositiveEvents_ - numPassNegativeEvents_)); }
+  unsigned int numEventsTotal() const { return fmax(0, (numTotalPositiveEvents_ - numTotalNegativeEvents_)); }
 
-  unsigned int  numPassPositiveEvents() const { return numPassPositiveEvents_;}
-  unsigned int  numTotalPositiveEvents() const { return numTotalPositiveEvents_;}
+  unsigned int numPassPositiveEvents() const { return numPassPositiveEvents_; }
+  unsigned int numTotalPositiveEvents() const { return numTotalPositiveEvents_; }
 
-  unsigned int  numPassNegativeEvents() const { return numPassNegativeEvents_;}
-  unsigned int  numTotalNegativeEvents() const { return numTotalNegativeEvents_;}
+  unsigned int numPassNegativeEvents() const { return numPassNegativeEvents_; }
+  unsigned int numTotalNegativeEvents() const { return numTotalNegativeEvents_; }
 
+  double sumPassWeights() const { return sumPassWeights_; }
+  double sumPassWeights2() const { return sumPassWeights2_; }
 
-  double sumPassWeights() const { return sumPassWeights_;}
-  double sumPassWeights2() const { return sumPassWeights2_;}
+  double sumFailWeights() const { return sumTotalWeights_ - sumPassWeights_; }
+  double sumFailWeights2() const { return sumTotalWeights2_ - sumPassWeights2_; }
 
-  double sumFailWeights() const { return sumTotalWeights_ - sumPassWeights_;}
-  double sumFailWeights2() const { return sumTotalWeights2_ - sumPassWeights2_;}
+  double sumWeights() const { return sumTotalWeights_; }
+  double sumWeights2() const { return sumTotalWeights2_; }
 
-  double sumWeights() const { return sumTotalWeights_;}
-  double sumWeights2() const { return sumTotalWeights2_;}
-
-  double filterEfficiency(int idwtup=+3) const;
-  double filterEfficiencyError(int idwtup=+3) const;
+  double filterEfficiency(int idwtup = +3) const;
+  double filterEfficiencyError(int idwtup = +3) const;
   // merge method. It will be used when merging different jobs populating the same lumi section
-  bool mergeProduct(GenFilterInfo const &other);
+  bool mergeProduct(GenFilterInfo const& other);
   void swap(GenFilterInfo& other);
 
 private:
-  
-  unsigned int  numPassPositiveEvents_;
-  unsigned int  numPassNegativeEvents_;
-  unsigned int  numTotalPositiveEvents_;
-  unsigned int  numTotalNegativeEvents_;
+  unsigned int numPassPositiveEvents_;
+  unsigned int numPassNegativeEvents_;
+  unsigned int numTotalPositiveEvents_;
+  unsigned int numTotalNegativeEvents_;
 
-  double        sumPassWeights_;
-  double        sumPassWeights2_;
-  double        sumTotalWeights_;
-  double        sumTotalWeights2_;
-
-
-
+  double sumPassWeights_;
+  double sumPassWeights2_;
+  double sumTotalWeights_;
+  double sumTotalWeights2_;
 };
 
-
-#endif // SimDataFormats_GeneratorProducts_GenFilterInfo_h
+#endif  // SimDataFormats_GeneratorProducts_GenFilterInfo_h

--- a/SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h
@@ -10,28 +10,26 @@
  */
 
 class GenLumiInfoHeader {
-  public:
+public:
+  GenLumiInfoHeader() : randomConfigIndex_(-1){};
 
-    GenLumiInfoHeader() : randomConfigIndex_(-1) {};
+  int randomConfigIndex() const { return randomConfigIndex_; }
+  void setRandomConfigIndex(int idx) { randomConfigIndex_ = idx; }
 
-    int randomConfigIndex() const { return randomConfigIndex_; }
-    void setRandomConfigIndex(int idx) { randomConfigIndex_ = idx; }
-    
-    const std::string &configDescription() const { return configDescription_; }
-    void setConfigDescription(const std::string &str) { configDescription_ = str; }
-    
-    const std::vector<std::pair<std::string, std::string> > &lheHeaders() const { return lheHeaders_; }
-    std::vector<std::pair<std::string, std::string> > &lheHeaders() { return lheHeaders_; }
-    
-    const std::vector<std::string> &weightNames() const { return weightNames_; }
-    std::vector<std::string> &weightNames() { return weightNames_; }
+  const std::string &configDescription() const { return configDescription_; }
+  void setConfigDescription(const std::string &str) { configDescription_ = str; }
 
-  private:
-    int randomConfigIndex_;
-    std::string configDescription_;
-    std::vector<std::pair<std::string, std::string> > lheHeaders_; //header name, header content
-    std::vector<std::string> weightNames_;
+  const std::vector<std::pair<std::string, std::string> > &lheHeaders() const { return lheHeaders_; }
+  std::vector<std::pair<std::string, std::string> > &lheHeaders() { return lheHeaders_; }
 
+  const std::vector<std::string> &weightNames() const { return weightNames_; }
+  std::vector<std::string> &weightNames() { return weightNames_; }
+
+private:
+  int randomConfigIndex_;
+  std::string configDescription_;
+  std::vector<std::pair<std::string, std::string> > lheHeaders_;  //header name, header content
+  std::vector<std::string> weightNames_;
 };
 
-#endif // SimDataFormats_GeneratorProducts_GenLumiInfoHeader_h
+#endif  // SimDataFormats_GeneratorProducts_GenLumiInfoHeader_h

--- a/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
@@ -8,7 +8,7 @@
  */
 
 class GenLumiInfoProduct {
- public:
+public:
   // a few forward declarations
   struct XSec;
   struct ProcessInfo;
@@ -21,22 +21,20 @@ class GenLumiInfoProduct {
 
   // getters
 
-  const int  getHEPIDWTUP() const {return hepidwtup_;}
-  const std::vector<ProcessInfo>& getProcessInfos() const {return internalProcesses_;}
+  const int getHEPIDWTUP() const { return hepidwtup_; }
+  const std::vector<ProcessInfo> &getProcessInfos() const { return internalProcesses_; }
 
   // setters
 
-  void setHEPIDWTUP(const int id) { hepidwtup_ = id;}
-  void setProcessInfo(const std::vector<ProcessInfo> & processes) {internalProcesses_ = processes;}
+  void setHEPIDWTUP(const int id) { hepidwtup_ = id; }
+  void setProcessInfo(const std::vector<ProcessInfo> &processes) { internalProcesses_ = processes; }
 
   // Struct- definitions
   struct XSec {
   public:
-  XSec() : value_(-1.), error_(-1.) {}
-  XSec(double v, double e = -1.) :
-    value_(v), error_(e) {}
-  XSec(const XSec &other) :
-    value_(other.value_), error_(other.error_) {}
+    XSec() : value_(-1.), error_(-1.) {}
+    XSec(double v, double e = -1.) : value_(v), error_(e) {}
+    XSec(const XSec &other) : value_(other.value_), error_(other.error_) {}
 
     double value() const { return value_; }
     double error() const { return error_; }
@@ -47,66 +45,62 @@ class GenLumiInfoProduct {
     operator double() const { return value_; }
     operator bool() const { return isSet(); }
 
-    bool operator == (const XSec &other) const
-    { return value_ == other.value_ && error_ == other.error_; }
-    bool operator != (const XSec &other) const { return !(*this == other); }
+    bool operator==(const XSec &other) const { return value_ == other.value_ && error_ == other.error_; }
+    bool operator!=(const XSec &other) const { return !(*this == other); }
 
   private:
     double value_, error_;
   };
 
-
   struct FinalStat {
   public:
-  FinalStat() : n_(0), sum_(0.0), sum2_(0.0) {}
-  FinalStat(unsigned int n1, double sum1, double sum21) :
-    n_(n1), sum_(sum1), sum2_(sum21) {}
-  FinalStat(const FinalStat &other) :
-    n_(other.n_), sum_(other.sum_), sum2_(other.sum2_) {}
+    FinalStat() : n_(0), sum_(0.0), sum2_(0.0) {}
+    FinalStat(unsigned int n1, double sum1, double sum21) : n_(n1), sum_(sum1), sum2_(sum21) {}
+    FinalStat(const FinalStat &other) : n_(other.n_), sum_(other.sum_), sum2_(other.sum2_) {}
 
     unsigned int n() const { return n_; }
     double sum() const { return sum_; }
-    double sum2() const{ return sum2_; }
+    double sum2() const { return sum2_; }
 
-    void add(const FinalStat& other)
-    {
+    void add(const FinalStat &other) {
       n_ += other.n();
       sum_ += other.sum();
       sum2_ += other.sum2();
-      }
+    }
 
-    bool operator == (const FinalStat &other) const
-    { return n_ == other.n_ && sum_ == other.sum_ && sum2_ == other.sum2_; }
-    bool operator != (const FinalStat &other) const { return !(*this == other); }
+    bool operator==(const FinalStat &other) const {
+      return n_ == other.n_ && sum_ == other.sum_ && sum2_ == other.sum2_;
+    }
+    bool operator!=(const FinalStat &other) const { return !(*this == other); }
+
   private:
-    unsigned int	n_;
-    double		sum_;
-    double		sum2_;
+    unsigned int n_;
+    double sum_;
+    double sum2_;
   };
-
 
   struct ProcessInfo {
   public:
-  ProcessInfo():process_(-1),nPassPos_(0),nPassNeg_(0),nTotalPos_(0),nTotalNeg_(0){}
-  ProcessInfo(int id):process_(id),nPassPos_(0),nPassNeg_(0),nTotalPos_(0),nTotalNeg_(0){}
+    ProcessInfo() : process_(-1), nPassPos_(0), nPassNeg_(0), nTotalPos_(0), nTotalNeg_(0) {}
+    ProcessInfo(int id) : process_(id), nPassPos_(0), nPassNeg_(0), nTotalPos_(0), nTotalNeg_(0) {}
 
     // accessors
-    int process() const {return process_;}
-    XSec lheXSec() const {return lheXSec_;}
+    int process() const { return process_; }
+    XSec lheXSec() const { return lheXSec_; }
 
-    unsigned int nPassPos() const {return nPassPos_;}
-    unsigned int nPassNeg() const {return nPassNeg_;}
-    unsigned int nTotalPos() const {return nTotalPos_;}
-    unsigned int nTotalNeg() const {return nTotalNeg_;}
+    unsigned int nPassPos() const { return nPassPos_; }
+    unsigned int nPassNeg() const { return nPassNeg_; }
+    unsigned int nTotalPos() const { return nTotalPos_; }
+    unsigned int nTotalNeg() const { return nTotalNeg_; }
 
-    FinalStat tried() const {return tried_;}
-    FinalStat selected() const {return selected_;}
-    FinalStat killed() const {return killed_;}
-    FinalStat accepted() const {return accepted_;}
-    FinalStat acceptedBr() const {return acceptedBr_;}
+    FinalStat tried() const { return tried_; }
+    FinalStat selected() const { return selected_; }
+    FinalStat killed() const { return killed_; }
+    FinalStat accepted() const { return accepted_; }
+    FinalStat acceptedBr() const { return acceptedBr_; }
 
     // setters
-    void addOthers(const ProcessInfo& other){
+    void addOthers(const ProcessInfo &other) {
       nPassPos_ += other.nPassPos();
       nPassNeg_ += other.nPassNeg();
       nTotalPos_ += other.nTotalPos();
@@ -118,44 +112,40 @@ class GenLumiInfoProduct {
       acceptedBr_.add(other.acceptedBr());
     }
     void setProcess(int id) { process_ = id; }
-    void setLheXSec(double value, double err) { lheXSec_ = XSec(value,err); }
+    void setLheXSec(double value, double err) { lheXSec_ = XSec(value, err); }
     void setNPassPos(unsigned int n) { nPassPos_ = n; }
     void setNPassNeg(unsigned int n) { nPassNeg_ = n; }
     void setNTotalPos(unsigned int n) { nTotalPos_ = n; }
     void setNTotalNeg(unsigned int n) { nTotalNeg_ = n; }
-    void setTried(unsigned int n, double sum, double sum2) { tried_ = FinalStat(n,sum,sum2); }
-    void setSelected(unsigned int n, double sum, double sum2) { selected_ = FinalStat(n,sum,sum2); }
-    void setKilled(unsigned int n, double sum, double sum2) { killed_ = FinalStat(n,sum,sum2); }
-    void setAccepted(unsigned int n, double sum, double sum2) { accepted_ = FinalStat(n,sum,sum2); }
-    void setAcceptedBr(unsigned int n, double sum, double sum2) { acceptedBr_ = FinalStat(n,sum,sum2); }
-	  
+    void setTried(unsigned int n, double sum, double sum2) { tried_ = FinalStat(n, sum, sum2); }
+    void setSelected(unsigned int n, double sum, double sum2) { selected_ = FinalStat(n, sum, sum2); }
+    void setKilled(unsigned int n, double sum, double sum2) { killed_ = FinalStat(n, sum, sum2); }
+    void setAccepted(unsigned int n, double sum, double sum2) { accepted_ = FinalStat(n, sum, sum2); }
+    void setAcceptedBr(unsigned int n, double sum, double sum2) { acceptedBr_ = FinalStat(n, sum, sum2); }
+
   private:
-    int             process_;
-    XSec            lheXSec_;
-    unsigned int    nPassPos_;
-    unsigned int    nPassNeg_;
-    unsigned int    nTotalPos_;
-    unsigned int    nTotalNeg_;
-    FinalStat       tried_;
-    FinalStat       selected_;
-    FinalStat       killed_;
-    FinalStat       accepted_;
-    FinalStat       acceptedBr_;
-
+    int process_;
+    XSec lheXSec_;
+    unsigned int nPassPos_;
+    unsigned int nPassNeg_;
+    unsigned int nTotalPos_;
+    unsigned int nTotalNeg_;
+    FinalStat tried_;
+    FinalStat selected_;
+    FinalStat killed_;
+    FinalStat accepted_;
+    FinalStat acceptedBr_;
   };
-
-
 
   // methods used by EDM
   virtual bool mergeProduct(const GenLumiInfoProduct &other);
-  void swap(GenLumiInfoProduct& other);
+  void swap(GenLumiInfoProduct &other);
   virtual bool isProductEqual(const GenLumiInfoProduct &other) const;
- private:
+
+private:
   // cross sections
-  int     hepidwtup_;
-  std::vector<ProcessInfo> internalProcesses_; 
-
-
+  int hepidwtup_;
+  std::vector<ProcessInfo> internalProcesses_;
 };
 
-#endif // SimDataFormats_GeneratorProducts_GenLumiInfoProduct_h
+#endif  // SimDataFormats_GeneratorProducts_GenLumiInfoProduct_h

--- a/SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h
@@ -6,66 +6,62 @@
  */
 
 class GenRunInfoProduct {
-    public:
-	// a few forward declarations
-	struct XSec;
+public:
+  // a few forward declarations
+  struct XSec;
 
-	// constructors, destructors
-	GenRunInfoProduct();
-	GenRunInfoProduct(const GenRunInfoProduct &other);
+  // constructors, destructors
+  GenRunInfoProduct();
+  GenRunInfoProduct(const GenRunInfoProduct &other);
 
-	// getters
+  // getters
 
-	const XSec &internalXSec() const { return internalXSec_; }
-	const XSec &externalXSecLO() const { return externalXSecLO_; }
-	const XSec &externalXSecNLO() const { return externalXSecNLO_; }
-	double filterEfficiency() const { return externalFilterEfficiency_; }
+  const XSec &internalXSec() const { return internalXSec_; }
+  const XSec &externalXSecLO() const { return externalXSecLO_; }
+  const XSec &externalXSecNLO() const { return externalXSecNLO_; }
+  double filterEfficiency() const { return externalFilterEfficiency_; }
 
-	// setters
+  // setters
 
-	void setInternalXSec(const XSec &xsec) { internalXSec_ = xsec; }
-	void setExternalXSecLO(const XSec &xsec) { externalXSecLO_ = xsec; }
-	void setExternalXSecNLO(const XSec &xsec) { externalXSecNLO_ = xsec; }
-	void setFilterEfficiency(double effic) { externalFilterEfficiency_ = effic; }
+  void setInternalXSec(const XSec &xsec) { internalXSec_ = xsec; }
+  void setExternalXSecLO(const XSec &xsec) { externalXSecLO_ = xsec; }
+  void setExternalXSecNLO(const XSec &xsec) { externalXSecNLO_ = xsec; }
+  void setFilterEfficiency(double effic) { externalFilterEfficiency_ = effic; }
 
-	// struct definitions
-	struct XSec {
-	    public:
-		XSec() : value_(-1.), error_(-1.) {}
-		XSec(double value, double error = -1.) :
-			value_(value), error_(error) {}
-		XSec(const XSec &other) :
-			value_(other.value_), error_(other.error_) {}
+  // struct definitions
+  struct XSec {
+  public:
+    XSec() : value_(-1.), error_(-1.) {}
+    XSec(double value, double error = -1.) : value_(value), error_(error) {}
+    XSec(const XSec &other) : value_(other.value_), error_(other.error_) {}
 
-		double value() const { return value_; }
-		double error() const { return error_; }
+    double value() const { return value_; }
+    double error() const { return error_; }
 
-		bool isSet() const { return value_ >= 0.; }
-		bool hasError() const { return error_ >= 0.; }
+    bool isSet() const { return value_ >= 0.; }
+    bool hasError() const { return error_ >= 0.; }
 
-		operator double() const { return value_; }
-		operator bool() const { return isSet(); }
+    operator double() const { return value_; }
+    operator bool() const { return isSet(); }
 
-		bool operator == (const XSec &other) const
-		{ return value_ == other.value_ && error_ == other.error_; }
-		bool operator != (const XSec &other) const { return !(*this == other); }
+    bool operator==(const XSec &other) const { return value_ == other.value_ && error_ == other.error_; }
+    bool operator!=(const XSec &other) const { return !(*this == other); }
 
-	    private:
-		double value_, error_;
-	};
+  private:
+    double value_, error_;
+  };
 
-	// convenience (return the value, prefer externally specified over internal one)
-	double crossSection() const
-	{ return externalXSecLO_ ? externalXSecLO_.value() : internalXSec_.value(); }
+  // convenience (return the value, prefer externally specified over internal one)
+  double crossSection() const { return externalXSecLO_ ? externalXSecLO_.value() : internalXSec_.value(); }
 
-	// methods used by EDM
-	bool isProductEqual(const GenRunInfoProduct &other) const;
+  // methods used by EDM
+  bool isProductEqual(const GenRunInfoProduct &other) const;
 
-    private:
-	// cross sections
-	XSec	internalXSec_;	// the one computed during cmsRun
-	XSec	externalXSecLO_, externalXSecNLO_;	// from config file
-	double	externalFilterEfficiency_;		// from config file
+private:
+  // cross sections
+  XSec internalXSec_;                      // the one computed during cmsRun
+  XSec externalXSecLO_, externalXSecNLO_;  // from config file
+  double externalFilterEfficiency_;        // from config file
 };
 
-#endif // SimDataFormats_GeneratorProducts_GenRunInfoProduct_h
+#endif  // SimDataFormats_GeneratorProducts_GenRunInfoProduct_h

--- a/SimDataFormats/GeneratorProducts/interface/HepMCProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/HepMCProduct.h
@@ -15,79 +15,74 @@
 #include "DataFormats/Common/interface/Ref.h"
 
 namespace edm {
-	class HepMCProduct {
-	    public:
-		HepMCProduct() :
-			evt_(nullptr), isVtxGenApplied_(false),
-			isVtxBoostApplied_(false), isPBoostApplied_(false) {}
+  class HepMCProduct {
+  public:
+    HepMCProduct() : evt_(nullptr), isVtxGenApplied_(false), isVtxBoostApplied_(false), isPBoostApplied_(false) {}
 
-		explicit HepMCProduct(HepMC::GenEvent *evt);
-		virtual ~HepMCProduct();
+    explicit HepMCProduct(HepMC::GenEvent *evt);
+    virtual ~HepMCProduct();
 
-		void addHepMCData(HepMC::GenEvent *evt);
+    void addHepMCData(HepMC::GenEvent *evt);
 
-		void applyVtxGen(HepMC::FourVector const* vtxShift) {
-                  applyVtxGen(*vtxShift);
-                }
-		void applyVtxGen(HepMC::FourVector const& vtxShift);
+    void applyVtxGen(HepMC::FourVector const *vtxShift) { applyVtxGen(*vtxShift); }
+    void applyVtxGen(HepMC::FourVector const &vtxShift);
 
-		void boostToLab(TMatrixD const* lorentz, std::string const& type);
+    void boostToLab(TMatrixD const *lorentz, std::string const &type);
 
-		const HepMC::GenEvent &getHepMCData() const;
+    const HepMC::GenEvent &getHepMCData() const;
 
-		const HepMC::GenEvent *GetEvent() const { return evt_; }
+    const HepMC::GenEvent *GetEvent() const { return evt_; }
 
-		bool isVtxGenApplied() const { return isVtxGenApplied_; }
-		bool isVtxBoostApplied() const { return isVtxBoostApplied_; }
-		bool isPBoostApplied() const { return isPBoostApplied_; }
+    bool isVtxGenApplied() const { return isVtxGenApplied_; }
+    bool isVtxBoostApplied() const { return isVtxBoostApplied_; }
+    bool isPBoostApplied() const { return isPBoostApplied_; }
 
-		HepMCProduct(HepMCProduct const &orig);
-		HepMCProduct &operator = (HepMCProduct const &other);
-		HepMCProduct(HepMCProduct&& orig);
-		HepMCProduct &operator=(HepMCProduct&& other);
-		void swap(HepMCProduct &other);
+    HepMCProduct(HepMCProduct const &orig);
+    HepMCProduct &operator=(HepMCProduct const &other);
+    HepMCProduct(HepMCProduct &&orig);
+    HepMCProduct &operator=(HepMCProduct &&other);
+    void swap(HepMCProduct &other);
 
-	    private:
-		HepMC::GenEvent	*evt_;
+  private:
+    HepMC::GenEvent *evt_;
 
-		bool	isVtxGenApplied_ ;
-		bool	isVtxBoostApplied_;
-		bool	isPBoostApplied_;
-	
-	};
+    bool isVtxGenApplied_;
+    bool isVtxBoostApplied_;
+    bool isPBoostApplied_;
+  };
 
-	// This allows edm::Refs to work with HepMCProduct
-	namespace refhelper {
-		template<> 
-		struct FindTrait<edm::HepMCProduct, HepMC::GenParticle> {
-			struct Find {
-                using first_argument_type  = edm::HepMCProduct const&;
-                using second_argument_type = int;
-                using result_type          = HepMC::GenParticle const*;
+  // This allows edm::Refs to work with HepMCProduct
+  namespace refhelper {
+    template <>
+    struct FindTrait<edm::HepMCProduct, HepMC::GenParticle> {
+      struct Find {
+        using first_argument_type = edm::HepMCProduct const &;
+        using second_argument_type = int;
+        using result_type = HepMC::GenParticle const *;
 
-				result_type operator () (first_argument_type iContainer,
-				                         second_argument_type iBarCode)
-				{ return iContainer.getHepMCData().barcode_to_particle(iBarCode); }
-			};
+        result_type operator()(first_argument_type iContainer, second_argument_type iBarCode) {
+          return iContainer.getHepMCData().barcode_to_particle(iBarCode);
+        }
+      };
 
-			typedef Find value;
-		};
+      typedef Find value;
+    };
 
-		template<> 
-		struct FindTrait<edm::HepMCProduct, HepMC::GenVertex> {
-			struct Find {
-                using first_argument_type  = edm::HepMCProduct const&;
-                using second_argument_type = int;
-                using result_type          = HepMC::GenVertex const*;
+    template <>
+    struct FindTrait<edm::HepMCProduct, HepMC::GenVertex> {
+      struct Find {
+        using first_argument_type = edm::HepMCProduct const &;
+        using second_argument_type = int;
+        using result_type = HepMC::GenVertex const *;
 
-				result_type operator () (first_argument_type iContainer,
-				                         second_argument_type iBarCode)
-				{ return iContainer.getHepMCData().barcode_to_vertex(iBarCode); }
-			};
+        result_type operator()(first_argument_type iContainer, second_argument_type iBarCode) {
+          return iContainer.getHepMCData().barcode_to_vertex(iBarCode);
+        }
+      };
 
-			typedef Find value;
-		};
-	} // namespace refhelper
-} // namespace edm
+      typedef Find value;
+    };
+  }  // namespace refhelper
+}  // namespace edm
 
-#endif // SimDataFormats_GeneratorProducts_HepMCProduct_h
+#endif  // SimDataFormats_GeneratorProducts_HepMCProduct_h

--- a/SimDataFormats/GeneratorProducts/interface/LHECommonBlocks.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHECommonBlocks.h
@@ -4,129 +4,125 @@
 #include "SimDataFormats/GeneratorProducts/interface/LesHouches.h"
 
 extern "C" {
-	extern struct HEPRUP_ {
-		int idbmup[2];
-		double ebmup[2];
-		int pdfgup[2];
-		int pdfsup[2];
-		int idwtup;
-		int nprup;
-		double xsecup[100];
-		double xerrup[100];
-		double xmaxup[100];
-		int lprup[100];
-	} heprup_;
+extern struct HEPRUP_ {
+  int idbmup[2];
+  double ebmup[2];
+  int pdfgup[2];
+  int pdfsup[2];
+  int idwtup;
+  int nprup;
+  double xsecup[100];
+  double xerrup[100];
+  double xmaxup[100];
+  int lprup[100];
+} heprup_;
 
-	extern struct HEPEUP_ {
-		int nup;
-		int idprup;
-		double xwgtup;
-		double scalup;
-		double aqedup;
-		double aqcdup;
-		int idup[500];
-		int istup[500];
-		int mothup[500][2];
-		int icolup[500][2];
-		double pup[500][5];
-		double vtimup[500];
-		double spinup[500];
-	} hepeup_;
-} // extern "C"
+extern struct HEPEUP_ {
+  int nup;
+  int idprup;
+  double xwgtup;
+  double scalup;
+  double aqedup;
+  double aqcdup;
+  int idup[500];
+  int istup[500];
+  int mothup[500][2];
+  int icolup[500][2];
+  double pup[500][5];
+  double vtimup[500];
+  double spinup[500];
+} hepeup_;
+}  // extern "C"
 
 namespace lhef {
 
-class CommonBlocks {
-    public:
-	static void fillHEPRUP(const HEPRUP *heprup)
-	{
-		heprup_.idbmup[0] = heprup->IDBMUP.first;
-		heprup_.idbmup[1] = heprup->IDBMUP.second;
-		heprup_.ebmup[0] = heprup->EBMUP.first;
-		heprup_.ebmup[1] = heprup->EBMUP.second;
-		heprup_.pdfgup[0] = heprup->PDFGUP.first;
-		heprup_.pdfgup[1] = heprup->PDFGUP.second;
-		heprup_.pdfsup[0] = heprup->PDFSUP.first;
-		heprup_.pdfsup[1] = heprup->PDFSUP.second;
-		heprup_.idwtup = heprup->IDWTUP;
-		heprup_.nprup = heprup->NPRUP;
-		for(int i = 0; i < heprup->NPRUP; i++) {
-			heprup_.xsecup[i] = heprup->XSECUP[i];
-			heprup_.xerrup[i] = heprup->XERRUP[i];
-			heprup_.xmaxup[i] = heprup->XMAXUP[i];
-			heprup_.lprup[i] = heprup->LPRUP[i];
-		}
-	}
+  class CommonBlocks {
+  public:
+    static void fillHEPRUP(const HEPRUP *heprup) {
+      heprup_.idbmup[0] = heprup->IDBMUP.first;
+      heprup_.idbmup[1] = heprup->IDBMUP.second;
+      heprup_.ebmup[0] = heprup->EBMUP.first;
+      heprup_.ebmup[1] = heprup->EBMUP.second;
+      heprup_.pdfgup[0] = heprup->PDFGUP.first;
+      heprup_.pdfgup[1] = heprup->PDFGUP.second;
+      heprup_.pdfsup[0] = heprup->PDFSUP.first;
+      heprup_.pdfsup[1] = heprup->PDFSUP.second;
+      heprup_.idwtup = heprup->IDWTUP;
+      heprup_.nprup = heprup->NPRUP;
+      for (int i = 0; i < heprup->NPRUP; i++) {
+        heprup_.xsecup[i] = heprup->XSECUP[i];
+        heprup_.xerrup[i] = heprup->XERRUP[i];
+        heprup_.xmaxup[i] = heprup->XMAXUP[i];
+        heprup_.lprup[i] = heprup->LPRUP[i];
+      }
+    }
 
-	static void fillHEPEUP(const HEPEUP *hepeup)
-	{
-		hepeup_.nup = hepeup->NUP;
-		hepeup_.idprup = hepeup->IDPRUP;
-		hepeup_.xwgtup = hepeup->XWGTUP;
-		hepeup_.scalup = hepeup->SCALUP;
-		hepeup_.aqedup = hepeup->AQEDUP;
-		hepeup_.aqcdup = hepeup->AQCDUP;
-		for(int i = 0; i < hepeup->NUP; i++) {
-			hepeup_.idup[i] = hepeup->IDUP[i];
-			hepeup_.istup[i] = hepeup->ISTUP[i];
-			hepeup_.mothup[i][0] = hepeup->MOTHUP[i].first;
-			hepeup_.mothup[i][1] = hepeup->MOTHUP[i].second;
-			hepeup_.icolup[i][0] = hepeup->ICOLUP[i].first;
-			hepeup_.icolup[i][1] = hepeup->ICOLUP[i].second;
-			for(unsigned int j = 0; j < 5; j++)
-				hepeup_.pup[i][j] = hepeup->PUP[i][j];
-			hepeup_.vtimup[i] = hepeup->VTIMUP[i];
-			hepeup_.spinup[i] = hepeup->SPINUP[i];
-		}
-	}
+    static void fillHEPEUP(const HEPEUP *hepeup) {
+      hepeup_.nup = hepeup->NUP;
+      hepeup_.idprup = hepeup->IDPRUP;
+      hepeup_.xwgtup = hepeup->XWGTUP;
+      hepeup_.scalup = hepeup->SCALUP;
+      hepeup_.aqedup = hepeup->AQEDUP;
+      hepeup_.aqcdup = hepeup->AQCDUP;
+      for (int i = 0; i < hepeup->NUP; i++) {
+        hepeup_.idup[i] = hepeup->IDUP[i];
+        hepeup_.istup[i] = hepeup->ISTUP[i];
+        hepeup_.mothup[i][0] = hepeup->MOTHUP[i].first;
+        hepeup_.mothup[i][1] = hepeup->MOTHUP[i].second;
+        hepeup_.icolup[i][0] = hepeup->ICOLUP[i].first;
+        hepeup_.icolup[i][1] = hepeup->ICOLUP[i].second;
+        for (unsigned int j = 0; j < 5; j++)
+          hepeup_.pup[i][j] = hepeup->PUP[i][j];
+        hepeup_.vtimup[i] = hepeup->VTIMUP[i];
+        hepeup_.spinup[i] = hepeup->SPINUP[i];
+      }
+    }
 
-	static void readHEPRUP(HEPRUP *heprup)
-	{
-		heprup->resize(heprup_.nprup);
-		heprup->IDBMUP.first = heprup_.idbmup[0];
-		heprup->IDBMUP.second = heprup_.idbmup[1];
-		heprup->EBMUP.first = heprup_.ebmup[0];
-		heprup->EBMUP.second = heprup_.ebmup[1];
-		heprup->PDFGUP.first = heprup_.pdfgup[0];
-		heprup->PDFGUP.second = heprup_.pdfgup[1];
-		heprup->PDFSUP.first = heprup_.pdfsup[0];
-		heprup->PDFSUP.second = heprup_.pdfsup[1];
-		heprup->IDWTUP = heprup_.idwtup;
-		for(int i = 0; i < heprup->NPRUP; i++) {
-			heprup->XSECUP[i] = heprup_.xsecup[i];
-			heprup->XERRUP[i] = heprup_.xerrup[i];
-			heprup->XMAXUP[i] = heprup_.xmaxup[i];
-			heprup->LPRUP[i] = heprup_.lprup[i];
-		}
-	}
+    static void readHEPRUP(HEPRUP *heprup) {
+      heprup->resize(heprup_.nprup);
+      heprup->IDBMUP.first = heprup_.idbmup[0];
+      heprup->IDBMUP.second = heprup_.idbmup[1];
+      heprup->EBMUP.first = heprup_.ebmup[0];
+      heprup->EBMUP.second = heprup_.ebmup[1];
+      heprup->PDFGUP.first = heprup_.pdfgup[0];
+      heprup->PDFGUP.second = heprup_.pdfgup[1];
+      heprup->PDFSUP.first = heprup_.pdfsup[0];
+      heprup->PDFSUP.second = heprup_.pdfsup[1];
+      heprup->IDWTUP = heprup_.idwtup;
+      for (int i = 0; i < heprup->NPRUP; i++) {
+        heprup->XSECUP[i] = heprup_.xsecup[i];
+        heprup->XERRUP[i] = heprup_.xerrup[i];
+        heprup->XMAXUP[i] = heprup_.xmaxup[i];
+        heprup->LPRUP[i] = heprup_.lprup[i];
+      }
+    }
 
-	static void readHEPEUP(HEPEUP *hepeup)
-	{
-		hepeup->resize(hepeup_.nup);
-		hepeup->IDPRUP = hepeup_.idprup;
-		hepeup->XWGTUP = hepeup_.xwgtup;
-		hepeup->SCALUP = hepeup_.scalup;
-		hepeup->AQEDUP = hepeup_.aqedup;
-		hepeup->AQCDUP = hepeup_.aqcdup;
-		for(int i = 0; i < hepeup->NUP; i++) {
-			hepeup->IDUP[i] = hepeup_.idup[i];
-			hepeup->ISTUP[i] = hepeup_.istup[i];
-			hepeup->MOTHUP[i].first = hepeup_.mothup[i][0];
-			hepeup->MOTHUP[i].second = hepeup_.mothup[i][1];
-			hepeup->ICOLUP[i].first = hepeup_.icolup[i][0];
-			hepeup->ICOLUP[i].second = hepeup_.icolup[i][1];
-			for(unsigned int j = 0; j < 5; j++)
-				hepeup->PUP[i][j] = hepeup_.pup[i][j];
-			hepeup->VTIMUP[i] = hepeup_.vtimup[i];
-			hepeup->SPINUP[i] = hepeup_.spinup[i];
-		}
-	}
+    static void readHEPEUP(HEPEUP *hepeup) {
+      hepeup->resize(hepeup_.nup);
+      hepeup->IDPRUP = hepeup_.idprup;
+      hepeup->XWGTUP = hepeup_.xwgtup;
+      hepeup->SCALUP = hepeup_.scalup;
+      hepeup->AQEDUP = hepeup_.aqedup;
+      hepeup->AQCDUP = hepeup_.aqcdup;
+      for (int i = 0; i < hepeup->NUP; i++) {
+        hepeup->IDUP[i] = hepeup_.idup[i];
+        hepeup->ISTUP[i] = hepeup_.istup[i];
+        hepeup->MOTHUP[i].first = hepeup_.mothup[i][0];
+        hepeup->MOTHUP[i].second = hepeup_.mothup[i][1];
+        hepeup->ICOLUP[i].first = hepeup_.icolup[i][0];
+        hepeup->ICOLUP[i].second = hepeup_.icolup[i][1];
+        for (unsigned int j = 0; j < 5; j++)
+          hepeup->PUP[i][j] = hepeup_.pup[i][j];
+        hepeup->VTIMUP[i] = hepeup_.vtimup[i];
+        hepeup->SPINUP[i] = hepeup_.spinup[i];
+      }
+    }
 
-    private:
-	CommonBlocks() = delete;
-	~CommonBlocks() = delete;
-};
+  private:
+    CommonBlocks() = delete;
+    ~CommonBlocks() = delete;
+  };
 
-} // namespace lhef
+}  // namespace lhef
 
-#endif // SimDataFormats_GeneratorProducts_LHECommonBlocks_h
+#endif  // SimDataFormats_GeneratorProducts_LHECommonBlocks_h

--- a/SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h
@@ -11,125 +11,119 @@
 #include "SimDataFormats/GeneratorProducts/interface/LesHouches.h"
 
 class LHERunInfoProduct {
-    public:
-    typedef std::vector<std::pair<std::string,std::string> > weights_defs;
-	class Header {
-	    public:
-		typedef std::vector<std::string>::const_iterator const_iterator;
-		typedef std::vector<std::string>::size_type size_type;
+public:
+  typedef std::vector<std::pair<std::string, std::string> > weights_defs;
+  class Header {
+  public:
+    typedef std::vector<std::string>::const_iterator const_iterator;
+    typedef std::vector<std::string>::size_type size_type;
 
-		Header() {}
-		Header(const std::string &tag) : tag_(tag) {}
-		~Header() {}
+    Header() {}
+    Header(const std::string &tag) : tag_(tag) {}
+    ~Header() {}
 
-		void addLine(const std::string &line) { lines_.push_back(line); }
+    void addLine(const std::string &line) { lines_.push_back(line); }
 
-		const std::string &tag() const { return tag_; }
-		const std::vector<std::string> &lines() const { return lines_; }
+    const std::string &tag() const { return tag_; }
+    const std::vector<std::string> &lines() const { return lines_; }
 
-		size_type size() const { return lines_.size(); }
-		const_iterator begin() const { return lines_.begin(); }
-		const_iterator end() const { return lines_.end(); }
+    size_type size() const { return lines_.size(); }
+    const_iterator begin() const { return lines_.begin(); }
+    const_iterator end() const { return lines_.end(); }
 
-		bool operator == (const Header &other) const
-		{ return tag_ == other.tag_ && lines_ == other.lines_; }
-		inline bool operator != (const Header &other) const
-		{ return !(*this == other); }
+    bool operator==(const Header &other) const { return tag_ == other.tag_ && lines_ == other.lines_; }
+    inline bool operator!=(const Header &other) const { return !(*this == other); }
 
-	    private:
-		std::string			tag_;
-		std::vector<std::string>	lines_;
-	};
+  private:
+    std::string tag_;
+    std::vector<std::string> lines_;
+  };
 
-	typedef std::vector<Header>::size_type size_type;
-	typedef std::vector<Header>::const_iterator headers_const_iterator;
-	typedef std::vector<std::string>::const_iterator
-						comments_const_iterator;
+  typedef std::vector<Header>::size_type size_type;
+  typedef std::vector<Header>::const_iterator headers_const_iterator;
+  typedef std::vector<std::string>::const_iterator comments_const_iterator;
 
-	LHERunInfoProduct() {}
-	LHERunInfoProduct(const lhef::HEPRUP &heprup) : heprup_(heprup) {}
-	~LHERunInfoProduct() {}
-  
-	bool find_if_checklist(const std::string x, std::vector<std::string> checklist);
-  
-	void addHeader(const Header &header) { headers_.push_back(header); }
-	void addComment(const std::string &line) { comments_.push_back(line); }
+  LHERunInfoProduct() {}
+  LHERunInfoProduct(const lhef::HEPRUP &heprup) : heprup_(heprup) {}
+  ~LHERunInfoProduct() {}
 
-	const lhef::HEPRUP &heprup() const { return heprup_; }
+  bool find_if_checklist(const std::string x, std::vector<std::string> checklist);
 
-	size_type headers_size() const { return headers_.size(); }
-	headers_const_iterator headers_begin() const { return headers_.begin(); }
-	headers_const_iterator headers_end() const { return headers_.end(); }
+  void addHeader(const Header &header) { headers_.push_back(header); }
+  void addComment(const std::string &line) { comments_.push_back(line); }
 
-	size_type comments_size() const { return comments_.size(); }
-	comments_const_iterator comments_begin() const { return comments_.begin(); }
-	comments_const_iterator comments_end() const { return comments_.end(); }
+  const lhef::HEPRUP &heprup() const { return heprup_; }
 
-	class const_iterator {
-	    public:
-		typedef std::forward_iterator_tag	iterator_category;
-		typedef std::string			value_type;
-		typedef std::ptrdiff_t			difference_type;
-		typedef std::string			*pointer;
-		typedef std::string			&reference;
+  size_type headers_size() const { return headers_.size(); }
+  headers_const_iterator headers_begin() const { return headers_.begin(); }
+  headers_const_iterator headers_end() const { return headers_.end(); }
 
-		const_iterator() : mode(kDone) {}
-		~const_iterator() {}
+  size_type comments_size() const { return comments_.size(); }
+  comments_const_iterator comments_begin() const { return comments_.begin(); }
+  comments_const_iterator comments_end() const { return comments_.end(); }
 
-		bool operator == (const const_iterator &other) const;
-		inline bool operator != (const const_iterator &other) const
-		{ return !operator == (other); }
+  class const_iterator {
+  public:
+    typedef std::forward_iterator_tag iterator_category;
+    typedef std::string value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef std::string *pointer;
+    typedef std::string &reference;
 
-		inline const_iterator &operator ++ ()
-		{ next(); return *this; }
-		inline const_iterator operator ++ (int dummy)
-		{ const_iterator orig = *this; next(); return orig; }
+    const_iterator() : mode(kDone) {}
+    ~const_iterator() {}
 
-		const std::string &operator * () const { return tmp; }
-		const std::string *operator -> () const { return &tmp; }
+    bool operator==(const const_iterator &other) const;
+    inline bool operator!=(const const_iterator &other) const { return !operator==(other); }
 
-	    private:
-		friend class LHERunInfoProduct;
+    inline const_iterator &operator++() {
+      next();
+      return *this;
+    }
+    inline const_iterator operator++(int dummy) {
+      const_iterator orig = *this;
+      next();
+      return orig;
+    }
 
-		void next();
+    const std::string &operator*() const { return tmp; }
+    const std::string *operator->() const { return &tmp; }
 
-		enum Mode {
-			kHeader,
-			kBody,
-			kInit,
-			kDone,
-			kFooter
-		};
+  private:
+    friend class LHERunInfoProduct;
 
-		const LHERunInfoProduct	*runInfo;
-		headers_const_iterator	header;
-		Header::const_iterator	iter;
-		Mode			mode;
-		unsigned int		line;
-		std::string		tmp;
-	};
+    void next();
 
-	const_iterator begin() const;
-	const_iterator init() const;
-	inline const_iterator end() const { return const_iterator(); }
+    enum Mode { kHeader, kBody, kInit, kDone, kFooter };
 
-	static const std::string &endOfFile();
+    const LHERunInfoProduct *runInfo;
+    headers_const_iterator header;
+    Header::const_iterator iter;
+    Mode mode;
+    unsigned int line;
+    std::string tmp;
+  };
 
-	bool operator == (const LHERunInfoProduct &other) const
-	{ return heprup_ == other.heprup_ && headers_ == other.headers_ && comments_ == other.comments_; }
-	inline bool operator != (const LHERunInfoProduct &other) const
-	{ return !(*this == other); }
+  const_iterator begin() const;
+  const_iterator init() const;
+  inline const_iterator end() const { return const_iterator(); }
 
-	bool mergeProduct(const LHERunInfoProduct &other);
-	void swap(LHERunInfoProduct& other);
-	bool isProductEqual(const LHERunInfoProduct &other) const
-	{ return *this == other; }
-	static bool isTagComparedInMerge(const std::string& tag);
+  static const std::string &endOfFile();
 
-    private:
-	lhef::HEPRUP			heprup_;
-	std::vector<Header>		headers_;
-	std::vector<std::string>	comments_;
+  bool operator==(const LHERunInfoProduct &other) const {
+    return heprup_ == other.heprup_ && headers_ == other.headers_ && comments_ == other.comments_;
+  }
+  inline bool operator!=(const LHERunInfoProduct &other) const { return !(*this == other); }
+
+  bool mergeProduct(const LHERunInfoProduct &other);
+  void swap(LHERunInfoProduct &other);
+  bool isProductEqual(const LHERunInfoProduct &other) const { return *this == other; }
+  static bool isTagComparedInMerge(const std::string &tag);
+
+private:
+  lhef::HEPRUP heprup_;
+  std::vector<Header> headers_;
+  std::vector<std::string> comments_;
 };
 
-#endif // GeneratorRunInfo_LHEInterface_LHERunInfoProduct_h
+#endif  // GeneratorRunInfo_LHEInterface_LHERunInfoProduct_h

--- a/SimDataFormats/GeneratorProducts/interface/LHEXMLStringProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEXMLStringProduct.h
@@ -11,33 +11,26 @@
 
 class LHEXMLStringProduct {
 public:
-    
   // constructors, destructors
   LHEXMLStringProduct();
   LHEXMLStringProduct(const std::string& content);
   virtual ~LHEXMLStringProduct();
-  
-  // getters
-  const std::vector<std::string>& getStrings() const{
-    return content_; 
-  }
 
-  const std::vector<std::vector<uint8_t> >& getCompressed() const{
-    return compressedContent_; 
-  }
-  
-  void fillCompressedContent(std::istream &input, unsigned int initialSize = 4*1024*1024);
-  void writeCompressedContent(std::ostream &output, unsigned int i) const;
-  
+  // getters
+  const std::vector<std::string>& getStrings() const { return content_; }
+
+  const std::vector<std::vector<uint8_t> >& getCompressed() const { return compressedContent_; }
+
+  void fillCompressedContent(std::istream& input, unsigned int initialSize = 4 * 1024 * 1024);
+  void writeCompressedContent(std::ostream& output, unsigned int i) const;
+
   // merge method. It will be used when merging different jobs populating the same lumi section
-  bool mergeProduct(LHEXMLStringProduct const &other);
+  bool mergeProduct(LHEXMLStringProduct const& other);
   void swap(LHEXMLStringProduct& other);
-  
+
 private:
   std::vector<std::string> content_;
   std::vector<std::vector<uint8_t> > compressedContent_;
-
 };
 
-
-#endif // SimDataFormats_GeneratorProducts_LHEXMLStringProduct_h
+#endif  // SimDataFormats_GeneratorProducts_LHEXMLStringProduct_h

--- a/SimDataFormats/GeneratorProducts/interface/LesHouches.h
+++ b/SimDataFormats/GeneratorProducts/interface/LesHouches.h
@@ -12,269 +12,253 @@
 
 namespace lhef {
 
-/**
+  /**
  * The HEPRUP class is a simple container corresponding to the Les
  * Houches accord (hep-ph/0109068) common block with the same
  * name. The members are named in the same way as in the common
  * block. However, fortran arrays are represented by vectors, except
  * for the arrays of length two which are represented by pair objects.
  */
-class HEPRUP {
-    public:
-	/** @name Standard constructors and destructors. */
-	//@{
-	/**
+  class HEPRUP {
+  public:
+    /** @name Standard constructors and destructors. */
+    //@{
+    /**
 	 * Default constructor.
 	 */
-	HEPRUP() : IDWTUP(0), NPRUP(0) {}
-	//@}
+    HEPRUP() : IDWTUP(0), NPRUP(0) {}
+    //@}
 
-    public:
-	bool operator == (const HEPRUP &other) const
-	{
-		return IDBMUP == other.IDBMUP &&
-		       EBMUP == other.EBMUP &&
-		       PDFGUP == other.PDFGUP &&
-		       PDFSUP == other.PDFSUP &&
-		       IDWTUP == other.IDWTUP &&
-		       NPRUP == other.NPRUP &&
-		       XSECUP == other.XSECUP &&
-		       XERRUP == other.XERRUP &&
-		       XMAXUP == other.XMAXUP &&
-		       LPRUP == other.LPRUP;
-	}
+  public:
+    bool operator==(const HEPRUP &other) const {
+      return IDBMUP == other.IDBMUP && EBMUP == other.EBMUP && PDFGUP == other.PDFGUP && PDFSUP == other.PDFSUP &&
+             IDWTUP == other.IDWTUP && NPRUP == other.NPRUP && XSECUP == other.XSECUP && XERRUP == other.XERRUP &&
+             XMAXUP == other.XMAXUP && LPRUP == other.LPRUP;
+    }
 
-	/**
+    /**
 	 * Set the NPRUP variable, corresponding to the number of
 	 * sub-processes, to \a nrup, and resize all relevant vectors
 	 * accordingly.
 	 */
-	void resize(int nrup)
-	{
-		NPRUP = nrup;
-		resize();
-	}
+    void resize(int nrup) {
+      NPRUP = nrup;
+      resize();
+    }
 
-	/**
+    /**
 	 * Assuming the NPRUP variable, corresponding to the number of
 	 * sub-processes, is correctly set, resize the relevant vectors
 	 * accordingly.
 	 */
-	void resize() {
-		XSECUP.resize(NPRUP);
-		XERRUP.resize(NPRUP);
-		XMAXUP.resize(NPRUP);
-		LPRUP.resize(NPRUP);
-	}
+    void resize() {
+      XSECUP.resize(NPRUP);
+      XERRUP.resize(NPRUP);
+      XMAXUP.resize(NPRUP);
+      LPRUP.resize(NPRUP);
+    }
 
-	void swap(HEPRUP& other) {
-		IDBMUP.swap(other.IDBMUP);
-		EBMUP.swap(other.EBMUP);
-		PDFGUP.swap(other.PDFGUP);
-		PDFSUP.swap(other.PDFSUP);
-		std::swap(IDWTUP, other.IDWTUP);
-		std::swap(NPRUP, other.NPRUP);
-		XSECUP.swap(other.XSECUP);
-		XERRUP.swap(other.XERRUP);
-		XMAXUP.swap(other.XMAXUP);
-		LPRUP.swap(other.LPRUP);
-	}
+    void swap(HEPRUP &other) {
+      IDBMUP.swap(other.IDBMUP);
+      EBMUP.swap(other.EBMUP);
+      PDFGUP.swap(other.PDFGUP);
+      PDFSUP.swap(other.PDFSUP);
+      std::swap(IDWTUP, other.IDWTUP);
+      std::swap(NPRUP, other.NPRUP);
+      XSECUP.swap(other.XSECUP);
+      XERRUP.swap(other.XERRUP);
+      XMAXUP.swap(other.XMAXUP);
+      LPRUP.swap(other.LPRUP);
+    }
 
-	/**
+    /**
 	 * PDG id's of beam particles. (first/second is in +/-z direction).
 	 */
-	std::pair<int, int> IDBMUP;
+    std::pair<int, int> IDBMUP;
 
-	/**
+    /**
 	 * Energy of beam particles given in GeV.
 	 */
-	std::pair<double, double> EBMUP;
+    std::pair<double, double> EBMUP;
 
-	/**
+    /**
 	 * The author group for the PDF used for the beams according to the
 	 * PDFLib specification.
 	 */
-	std::pair<int, int> PDFGUP;
+    std::pair<int, int> PDFGUP;
 
-	/**
+    /**
 	 * The id number the PDF used for the beams according to the
 	 * PDFLib specification.
 	 */
-	std::pair<int, int> PDFSUP;
+    std::pair<int, int> PDFSUP;
 
-	/**
+    /**
 	 * Master switch indicating how the ME generator envisages the
 	 * events weights should be interpreted according to the Les Houches
 	 * accord.
 	 */
-	int IDWTUP;
+    int IDWTUP;
 
-	/**
+    /**
 	 * The number of different subprocesses in this file (should
 	 * typically be just one)
 	 */
-	int NPRUP;
+    int NPRUP;
 
-	/**
+    /**
 	 * The cross sections for the different subprocesses in pb.
 	 */
-	std::vector<double> XSECUP;
+    std::vector<double> XSECUP;
 
-	/**
+    /**
 	 * The statistical error in the cross sections for the different
 	 * subprocesses in pb.
 	 */
-	std::vector<double> XERRUP;
+    std::vector<double> XERRUP;
 
-	/**
+    /**
 	 * The maximum event weights (in XWGTUP) for different subprocesses.
 	 */
-	std::vector<double> XMAXUP;
+    std::vector<double> XMAXUP;
 
-	/**
+    /**
 	 * The subprocess code for the different subprocesses.
 	 */
-	std::vector<int> LPRUP;
-};
+    std::vector<int> LPRUP;
+  };
 
-
-/**
+  /**
  * The HEPEUP class is a simple container corresponding to the Les
  * Houches accord (hep-ph/0109068) common block with the same
  * name. The members are named in the same way as in the common
  * block. However, fortran arrays are represented by vectors, except
  * for the arrays of length two which are represented by pair objects.
  */
-class HEPEUP {
-    public:
-	/** @name Standard constructors and destructors. */
-	//@{
-	/**
+  class HEPEUP {
+  public:
+    /** @name Standard constructors and destructors. */
+    //@{
+    /**
 	 * Default constructor.
 	 */
-	HEPEUP() :
-		NUP(0), IDPRUP(0), XWGTUP(0.0), XPDWUP(0.0, 0.0),
-		SCALUP(0.0), AQEDUP(0.0), AQCDUP(0.0)
-	{}
-	//@}
+    HEPEUP() : NUP(0), IDPRUP(0), XWGTUP(0.0), XPDWUP(0.0, 0.0), SCALUP(0.0), AQEDUP(0.0), AQCDUP(0.0) {}
+    //@}
 
-    public:
-	struct FiveVector {
-		double operator [] (unsigned int i) const { return x[i]; }
-		double &operator [] (unsigned int i) { return x[i]; }
+  public:
+    struct FiveVector {
+      double operator[](unsigned int i) const { return x[i]; }
+      double &operator[](unsigned int i) { return x[i]; }
 
-		double	x[5];
-	};
+      double x[5];
+    };
 
-	/**
+    /**
 	 * Set the NUP variable, corresponding to the number of particles in
 	 * the current event, to \a nup, and resize all relevant vectors
 	 * accordingly.
 	 */
-	void resize(int nup)
-	{
-		NUP = nup;
-		resize();
-	}
+    void resize(int nup) {
+      NUP = nup;
+      resize();
+    }
 
-	/**
+    /**
 	 * Assuming the NUP variable, corresponding to the number of
 	 * particles in the current event, is correctly set, resize the
 	 * relevant vectors accordingly.
 	 */
-	void resize()
-	{
-		IDUP.resize(NUP);
-		ISTUP.resize(NUP);
-		MOTHUP.resize(NUP);
-		ICOLUP.resize(NUP);
-		PUP.resize(NUP);
-		VTIMUP.resize(NUP);
-		SPINUP.resize(NUP);
-	}
+    void resize() {
+      IDUP.resize(NUP);
+      ISTUP.resize(NUP);
+      MOTHUP.resize(NUP);
+      ICOLUP.resize(NUP);
+      PUP.resize(NUP);
+      VTIMUP.resize(NUP);
+      SPINUP.resize(NUP);
+    }
 
-	/**
+    /**
 	 * The number of particle entries in the current event.
 	 */
-	int NUP;
+    int NUP;
 
-	/**
+    /**
 	 * The subprocess code for this event (as given in LPRUP).
 	 */
-	int IDPRUP;
+    int IDPRUP;
 
-	/**
+    /**
 	 * The weight for this event.
 	 */
-	double XWGTUP;
+    double XWGTUP;
 
-	/**
+    /**
 	 * The PDF weights for the two incoming partons. Note that this
 	 * variable is not present in the current LesHouches accord
 	 * (hep-ph/0109068), hopefully it will be present in a future
 	 * accord.
 	 */
-	std::pair<double, double> XPDWUP;
+    std::pair<double, double> XPDWUP;
 
-	/**
+    /**
 	 * The scale in GeV used in the calculation of the PDF's in this
 	 * event.
 	 */
-	double SCALUP;
+    double SCALUP;
 
-	/**
+    /**
 	 * The value of the QED coupling used in this event.
 	 */
-	double AQEDUP;
+    double AQEDUP;
 
-	/**
+    /**
 	 * The value of the QCD coupling used in this event.
 	 */
-	double AQCDUP;
+    double AQCDUP;
 
-	/**
+    /**
 	 * The PDG id's for the particle entries in this event.
 	 */
-	std::vector<int> IDUP;
+    std::vector<int> IDUP;
 
-	/**
+    /**
 	 * The status codes for the particle entries in this event.
 	 */
-	std::vector<int> ISTUP;
+    std::vector<int> ISTUP;
 
-	/**
+    /**
 	 * Indices for the first and last mother for the particle entries in
 	 * this event.
 	 */
-	std::vector< std::pair<int, int> > MOTHUP;
+    std::vector<std::pair<int, int> > MOTHUP;
 
-	/**
+    /**
 	 * The colour-line indices (first(second) is (anti)colour) for the
 	 * particle entries in this event.
 	 */
-	std::vector< std::pair<int, int> > ICOLUP;
+    std::vector<std::pair<int, int> > ICOLUP;
 
-	/**
+    /**
 	 * Lab frame momentum (Px, Py, Pz, E and M in GeV) for the particle
 	 * entries in this event.
 	 */
-	std::vector<FiveVector> PUP;
+    std::vector<FiveVector> PUP;
 
-	/**
+    /**
 	 * Invariant lifetime (c*tau, distance from production to decay im
 	 * mm) for the particle entries in this event.
 	 */
-	std::vector<double> VTIMUP;
+    std::vector<double> VTIMUP;
 
-	/**
+    /**
 	 * Spin info for the particle entries in this event given as the
 	 * cosine of the angle between the spin vector of a particle and the
 	 * 3-momentum of the decaying particle, specified in the lab frame.
 	 */
-	std::vector<double> SPINUP;
+    std::vector<double> SPINUP;
+  };
 
-};
+}  // namespace lhef
 
-} // namespace lhef
-
-#endif // SimDataFormats_GeneratorProducts_LesHouches_h
+#endif  // SimDataFormats_GeneratorProducts_LesHouches_h

--- a/SimDataFormats/GeneratorProducts/interface/PdfInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/PdfInfo.h
@@ -8,12 +8,12 @@
  */
 
 namespace gen {
-	struct PdfInfo {
-		std::pair<int, int>		id;
-		std::pair<double, double>	x;
-		std::pair<double, double>	xPDF;
-		double				scalePDF;
-	};
-}
+  struct PdfInfo {
+    std::pair<int, int> id;
+    std::pair<double, double> x;
+    std::pair<double, double> xPDF;
+    double scalePDF;
+  };
+}  // namespace gen
 
-#endif // SimDataFormats_GeneratorProducts_PdfInfo_h
+#endif  // SimDataFormats_GeneratorProducts_PdfInfo_h

--- a/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h
@@ -7,15 +7,13 @@
 #include <string>
 
 namespace gen {
-	struct WeightsInfo {
-	        WeightsInfo(): id(""), wgt(0.) {}
-	        WeightsInfo(const WeightsInfo& o):
-		  id(o.id), wgt(o.wgt) {}
-	        WeightsInfo(const std::string& s, const double w): 
-		  id(s),wgt(w) {}
-	        std::string	id;
-		double	        wgt;		
-	};
-}
+  struct WeightsInfo {
+    WeightsInfo() : id(""), wgt(0.) {}
+    WeightsInfo(const WeightsInfo& o) : id(o.id), wgt(o.wgt) {}
+    WeightsInfo(const std::string& s, const double w) : id(s), wgt(w) {}
+    std::string id;
+    double wgt;
+  };
+}  // namespace gen
 
-#endif // SimDataFormats_GeneratorProducts_WeightsInfo_h
+#endif  // SimDataFormats_GeneratorProducts_WeightsInfo_h

--- a/SimDataFormats/GeneratorProducts/src/GenEventInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenEventInfoProduct.cc
@@ -13,101 +13,88 @@ using std::ptrdiff_t;
 using namespace edm;
 using namespace std;
 
-GenEventInfoProduct::GenEventInfoProduct() :
-	signalProcessID_(0), qScale_(-1.), alphaQCD_(-1.), alphaQED_(-1.),
-	nMEPartons_(-1), nMEPartonsFiltered_(-1)
-{
+GenEventInfoProduct::GenEventInfoProduct()
+    : signalProcessID_(0), qScale_(-1.), alphaQCD_(-1.), alphaQED_(-1.), nMEPartons_(-1), nMEPartonsFiltered_(-1) {}
+
+GenEventInfoProduct::GenEventInfoProduct(const HepMC::GenEvent *evt)
+    : weights_(evt->weights().begin(), evt->weights().end()),
+      signalProcessID_(evt->signal_process_id()),
+      qScale_(evt->event_scale()),
+      alphaQCD_(evt->alphaQCD()),
+      alphaQED_(evt->alphaQED()),
+      nMEPartons_(-1),
+      nMEPartonsFiltered_(-1) {
+  const HepMC::PdfInfo *hepPDF = evt->pdf_info();
+  if (hepPDF) {
+    PDF pdf;
+
+    pdf.id = std::make_pair(hepPDF->id1(), hepPDF->id2());
+    pdf.x = std::make_pair(hepPDF->x1(), hepPDF->x2());
+    pdf.xPDF = std::make_pair(hepPDF->pdf1(), hepPDF->pdf2());
+    pdf.scalePDF = hepPDF->scalePDF();
+
+    setPDF(&pdf);
+  }
 }
 
-GenEventInfoProduct::GenEventInfoProduct(const HepMC::GenEvent *evt) :
-	weights_(evt->weights().begin(), evt->weights().end()),
-	signalProcessID_(evt->signal_process_id()),
-	qScale_(evt->event_scale()),
-	alphaQCD_(evt->alphaQCD()),
-	alphaQED_(evt->alphaQED()),
-	nMEPartons_(-1), nMEPartonsFiltered_(-1)
-{
-	const HepMC::PdfInfo *hepPDF = evt->pdf_info();    
-	if (hepPDF) {
-		PDF pdf;
-
-		pdf.id = std::make_pair(hepPDF->id1(), hepPDF->id2());
-		pdf.x = std::make_pair(hepPDF->x1(), hepPDF->x2());
-		pdf.xPDF = std::make_pair(hepPDF->pdf1(), hepPDF->pdf2());   
-		pdf.scalePDF = hepPDF->scalePDF();
-
-		setPDF(&pdf);
-	}
+GenEventInfoProduct::GenEventInfoProduct(GenEventInfoProduct const &other)
+    : weights_(other.weights_),
+      signalProcessID_(other.signalProcessID_),
+      qScale_(other.qScale_),
+      alphaQCD_(other.alphaQCD_),
+      alphaQED_(other.alphaQED_),
+      binningValues_(other.binningValues_),
+      DJRValues_(other.DJRValues_),
+      nMEPartons_(other.nMEPartons_),
+      nMEPartonsFiltered_(other.nMEPartons_) {
+  setPDF(other.pdf());
 }
 
-GenEventInfoProduct::GenEventInfoProduct(GenEventInfoProduct const &other) :
-	weights_(other.weights_),
-	signalProcessID_(other.signalProcessID_),
-	qScale_(other.qScale_),
-	alphaQCD_(other.alphaQCD_),
-	alphaQED_(other.alphaQED_),
-	binningValues_(other.binningValues_),
-	DJRValues_(other.DJRValues_),
-	nMEPartons_(other.nMEPartons_), nMEPartonsFiltered_(other.nMEPartons_)
-{
-	setPDF(other.pdf());
+GenEventInfoProduct::GenEventInfoProduct(GenEventInfoProduct &&other)
+    : weights_(std::move(other.weights_)),
+      signalProcessID_(other.signalProcessID_),
+      qScale_(other.qScale_),
+      alphaQCD_(other.alphaQCD_),
+      alphaQED_(other.alphaQED_),
+      pdf_(other.pdf_.release()),
+      binningValues_(std::move(other.binningValues_)),
+      DJRValues_(std::move(other.DJRValues_)),
+      nMEPartons_(other.nMEPartons_),
+      nMEPartonsFiltered_(other.nMEPartons_) {}
+
+GenEventInfoProduct::~GenEventInfoProduct() {}
+
+GenEventInfoProduct &GenEventInfoProduct::operator=(GenEventInfoProduct const &other) {
+  weights_ = other.weights_;
+  signalProcessID_ = other.signalProcessID_;
+  qScale_ = other.qScale_;
+  alphaQCD_ = other.alphaQCD_;
+  alphaQED_ = other.alphaQED_;
+  binningValues_ = other.binningValues_;
+  DJRValues_ = other.DJRValues_;
+  nMEPartons_ = other.nMEPartons_;
+  nMEPartonsFiltered_ = other.nMEPartonsFiltered_;
+
+  setPDF(other.pdf());
+
+  return *this;
 }
 
-GenEventInfoProduct::GenEventInfoProduct(GenEventInfoProduct&& other) :
-	weights_(std::move(other.weights_)),
-	signalProcessID_(other.signalProcessID_),
-	qScale_(other.qScale_),
-	alphaQCD_(other.alphaQCD_),
-	alphaQED_(other.alphaQED_),
-	pdf_(other.pdf_.release()),
-	binningValues_(std::move(other.binningValues_)),
-	DJRValues_(std::move(other.DJRValues_)),
-	nMEPartons_(other.nMEPartons_), nMEPartonsFiltered_(other.nMEPartons_)
-{
+GenEventInfoProduct &GenEventInfoProduct::operator=(GenEventInfoProduct &&other) {
+  weights_ = std::move(other.weights_);
+  signalProcessID_ = other.signalProcessID_;
+  qScale_ = other.qScale_;
+  alphaQCD_ = other.alphaQCD_;
+  alphaQED_ = other.alphaQED_;
+  binningValues_ = std::move(other.binningValues_);
+  DJRValues_ = std::move(other.DJRValues_);
+  nMEPartons_ = other.nMEPartons_;
+  nMEPartonsFiltered_ = other.nMEPartonsFiltered_;
+  pdf_.reset(other.pdf_.release());
+
+  return *this;
 }
 
-
-
-GenEventInfoProduct::~GenEventInfoProduct()
-{
-}
-
-GenEventInfoProduct &GenEventInfoProduct::operator = (GenEventInfoProduct const &other)
-{
-	weights_ = other.weights_;
-	signalProcessID_ = other.signalProcessID_;
-	qScale_ = other.qScale_;
-	alphaQCD_ = other.alphaQCD_;
-	alphaQED_ = other.alphaQED_;
-	binningValues_ = other.binningValues_;
-	DJRValues_ = other.DJRValues_;
-	nMEPartons_=other.nMEPartons_;
-        nMEPartonsFiltered_=other.nMEPartonsFiltered_;
-
-	setPDF(other.pdf());
-
-	return *this;
-}
-
-GenEventInfoProduct &GenEventInfoProduct::operator = (GenEventInfoProduct&& other)
-{
-	weights_ = std::move(other.weights_);
-	signalProcessID_ = other.signalProcessID_;
-	qScale_ = other.qScale_;
-	alphaQCD_ = other.alphaQCD_;
-	alphaQED_ = other.alphaQED_;
-	binningValues_ = std::move(other.binningValues_);
-	DJRValues_ = std::move(other.DJRValues_);
-	nMEPartons_=other.nMEPartons_;
-	nMEPartonsFiltered_=other.nMEPartonsFiltered_;
-	pdf_.reset(other.pdf_.release());
-
-	return *this;
-}
-
-
-double GenEventInfoProduct::weightProduct() const
-{
-	return std::accumulate(weights_.begin(), weights_.end(),
-	                       1., std::multiplies<double>());
+double GenEventInfoProduct::weightProduct() const {
+  return std::accumulate(weights_.begin(), weights_.end(), 1., std::multiplies<double>());
 }

--- a/SimDataFormats/GeneratorProducts/src/GenFilterInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenFilterInfo.cc
@@ -9,61 +9,56 @@
 using namespace edm;
 using namespace std;
 
-GenFilterInfo::GenFilterInfo() :
-  numPassPositiveEvents_(0),
-  numPassNegativeEvents_(0),
-  numTotalPositiveEvents_(0),
-  numTotalNegativeEvents_(0),
-  sumPassWeights_(0.),
-  sumPassWeights2_(0.),
-  sumTotalWeights_(0.),
-  sumTotalWeights2_(0.)
-{
-}
+GenFilterInfo::GenFilterInfo()
+    : numPassPositiveEvents_(0),
+      numPassNegativeEvents_(0),
+      numTotalPositiveEvents_(0),
+      numTotalNegativeEvents_(0),
+      sumPassWeights_(0.),
+      sumPassWeights2_(0.),
+      sumTotalWeights_(0.),
+      sumTotalWeights2_(0.) {}
 
-GenFilterInfo::GenFilterInfo(unsigned int tried, unsigned int pass) :
-  numPassPositiveEvents_(pass),
-  numPassNegativeEvents_(0),
-  numTotalPositiveEvents_(tried),
-  numTotalNegativeEvents_(0),
-  sumPassWeights_(pass),
-  sumPassWeights2_(pass),
-  sumTotalWeights_(tried),
-  sumTotalWeights2_(tried)
-{
-}
+GenFilterInfo::GenFilterInfo(unsigned int tried, unsigned int pass)
+    : numPassPositiveEvents_(pass),
+      numPassNegativeEvents_(0),
+      numTotalPositiveEvents_(tried),
+      numTotalNegativeEvents_(0),
+      sumPassWeights_(pass),
+      sumPassWeights2_(pass),
+      sumTotalWeights_(tried),
+      sumTotalWeights2_(tried) {}
 
-GenFilterInfo::GenFilterInfo(unsigned int passp, unsigned int passn, unsigned int totalp, unsigned int totaln,
-			     double passw, double passw2, double totalw, double totalw2) :
-  numPassPositiveEvents_(passp),
-  numPassNegativeEvents_(passn),
-  numTotalPositiveEvents_(totalp),
-  numTotalNegativeEvents_(totaln),
-  sumPassWeights_(passw),
-  sumPassWeights2_(passw2),
-  sumTotalWeights_(totalw),
-  sumTotalWeights2_(totalw2)
-{
-}
+GenFilterInfo::GenFilterInfo(unsigned int passp,
+                             unsigned int passn,
+                             unsigned int totalp,
+                             unsigned int totaln,
+                             double passw,
+                             double passw2,
+                             double totalw,
+                             double totalw2)
+    : numPassPositiveEvents_(passp),
+      numPassNegativeEvents_(passn),
+      numTotalPositiveEvents_(totalp),
+      numTotalNegativeEvents_(totaln),
+      sumPassWeights_(passw),
+      sumPassWeights2_(passw2),
+      sumTotalWeights_(totalw),
+      sumTotalWeights2_(totalw2) {}
 
-GenFilterInfo::GenFilterInfo(const GenFilterInfo& other):
-  numPassPositiveEvents_(other.numPassPositiveEvents_),
-  numPassNegativeEvents_(other.numPassNegativeEvents_),
-  numTotalPositiveEvents_(other.numTotalPositiveEvents_),
-  numTotalNegativeEvents_(other.numTotalNegativeEvents_),
-  sumPassWeights_(other.sumPassWeights_),
-  sumPassWeights2_(other.sumPassWeights2_),
-  sumTotalWeights_(other.sumTotalWeights_),
-  sumTotalWeights2_(other.sumTotalWeights2_)
-{
-}
+GenFilterInfo::GenFilterInfo(const GenFilterInfo& other)
+    : numPassPositiveEvents_(other.numPassPositiveEvents_),
+      numPassNegativeEvents_(other.numPassNegativeEvents_),
+      numTotalPositiveEvents_(other.numTotalPositiveEvents_),
+      numTotalNegativeEvents_(other.numTotalNegativeEvents_),
+      sumPassWeights_(other.sumPassWeights_),
+      sumPassWeights2_(other.sumPassWeights2_),
+      sumTotalWeights_(other.sumTotalWeights_),
+      sumTotalWeights2_(other.sumTotalWeights2_) {}
 
-GenFilterInfo::~GenFilterInfo()
-{
-}
+GenFilterInfo::~GenFilterInfo() {}
 
-bool GenFilterInfo::mergeProduct(GenFilterInfo const &other)
-{
+bool GenFilterInfo::mergeProduct(GenFilterInfo const& other) {
   // merging two GenFilterInfos means that the numerator and
   // denominator from the original product need to besummed with
   // those in the product we are going to merge
@@ -72,10 +67,10 @@ bool GenFilterInfo::mergeProduct(GenFilterInfo const &other)
   numPassNegativeEvents_ += other.numPassNegativeEvents_;
   numTotalPositiveEvents_ += other.numTotalPositiveEvents_;
   numTotalNegativeEvents_ += other.numTotalNegativeEvents_;
-  sumPassWeights_        += other.sumPassWeights_;
-  sumPassWeights2_       += other.sumPassWeights2_;
-  sumTotalWeights_        += other.sumTotalWeights_;
-  sumTotalWeights2_       += other.sumTotalWeights2_;
+  sumPassWeights_ += other.sumPassWeights_;
+  sumPassWeights2_ += other.sumPassWeights2_;
+  sumTotalWeights_ += other.sumTotalWeights_;
+  sumTotalWeights2_ += other.sumTotalWeights2_;
 
   return true;
 }
@@ -93,49 +88,43 @@ void GenFilterInfo::swap(GenFilterInfo& other) {
 
 double GenFilterInfo::filterEfficiency(int idwtup) const {
   double eff = -1;
-  switch(idwtup) {
-  case 3: case -3:
-    eff = numEventsTotal() > 0 ? (double) numEventsPassed() / (double) numEventsTotal(): -1;
-    break;
-  default:
-    eff = sumWeights() > 0? sumPassWeights()/sumWeights(): -1;
-    break;
+  switch (idwtup) {
+    case 3:
+    case -3:
+      eff = numEventsTotal() > 0 ? (double)numEventsPassed() / (double)numEventsTotal() : -1;
+      break;
+    default:
+      eff = sumWeights() > 0 ? sumPassWeights() / sumWeights() : -1;
+      break;
   }
   return eff;
-
 }
 
 double GenFilterInfo::filterEfficiencyError(int idwtup) const {
-
   double efferr = -1;
-  switch(idwtup) {
-  case 3: case -3:
-    {
-      double effp  = numTotalPositiveEvents() > 0? 
-	(double)numPassPositiveEvents()/(double)numTotalPositiveEvents():0;
-      double effp_err2 = numTotalPositiveEvents() > 0?
-	(1-effp)*effp/(double)numTotalPositiveEvents(): 0;
+  switch (idwtup) {
+    case 3:
+    case -3: {
+      double effp =
+          numTotalPositiveEvents() > 0 ? (double)numPassPositiveEvents() / (double)numTotalPositiveEvents() : 0;
+      double effp_err2 = numTotalPositiveEvents() > 0 ? (1 - effp) * effp / (double)numTotalPositiveEvents() : 0;
 
-      double effn  = numTotalNegativeEvents() > 0? 
-	(double)numPassNegativeEvents()/(double)numTotalNegativeEvents():0;
-      double effn_err2 = numTotalNegativeEvents() > 0? 
-	(1-effn)*effn/(double)numTotalNegativeEvents(): 0;
+      double effn =
+          numTotalNegativeEvents() > 0 ? (double)numPassNegativeEvents() / (double)numTotalNegativeEvents() : 0;
+      double effn_err2 = numTotalNegativeEvents() > 0 ? (1 - effn) * effn / (double)numTotalNegativeEvents() : 0;
 
-      efferr = numEventsTotal() > 0 ? sqrt ( 
-					    ((double)numTotalPositiveEvents()*(double)numTotalPositiveEvents()*effp_err2 + 
-					     (double)numTotalNegativeEvents()*(double)numTotalNegativeEvents()*effn_err2)
-					    /(double)numEventsTotal()/(double)numEventsTotal()
-					     ) : -1;
+      efferr = numEventsTotal() > 0
+                   ? sqrt(((double)numTotalPositiveEvents() * (double)numTotalPositiveEvents() * effp_err2 +
+                           (double)numTotalNegativeEvents() * (double)numTotalNegativeEvents() * effn_err2) /
+                          (double)numEventsTotal() / (double)numEventsTotal())
+                   : -1;
       break;
     }
-  default:
-    {
-      double denominator = sumWeights()*sumWeights()*sumWeights()*sumWeights();
-      double numerator =
-	sumPassWeights2() * sumFailWeights()* sumFailWeights() +
-	sumFailWeights2() * sumPassWeights()* sumPassWeights();
-      efferr = denominator>0? 
-	sqrt(numerator/denominator):-1;
+    default: {
+      double denominator = sumWeights() * sumWeights() * sumWeights() * sumWeights();
+      double numerator = sumPassWeights2() * sumFailWeights() * sumFailWeights() +
+                         sumFailWeights2() * sumPassWeights() * sumPassWeights();
+      efferr = denominator > 0 ? sqrt(numerator / denominator) : -1;
       break;
     }
   }

--- a/SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <algorithm> 
+#include <algorithm>
 #include <map>
 #include <utility>
 
@@ -10,129 +10,96 @@
 using namespace edm;
 using namespace std;
 
-
-const bool operator < (const GenLumiInfoProduct::ProcessInfo& lhs, const GenLumiInfoProduct::ProcessInfo& rhs) 
-{ return (lhs.process() < rhs.process()); }
-
-const bool operator != (const GenLumiInfoProduct::ProcessInfo& lhs, const GenLumiInfoProduct::ProcessInfo& rhs) 
-{ bool condition = (lhs.process() != rhs.process()) ||
-    (lhs.lheXSec() != rhs.lheXSec());
-  return condition; 
+const bool operator<(const GenLumiInfoProduct::ProcessInfo& lhs, const GenLumiInfoProduct::ProcessInfo& rhs) {
+  return (lhs.process() < rhs.process());
 }
 
-const bool operator == (const GenLumiInfoProduct::ProcessInfo& lhs, const GenLumiInfoProduct::ProcessInfo& rhs)
-{ 
-  bool condition=
-    (lhs.process() == rhs.process() && lhs.lheXSec() == rhs.lheXSec()
-     && lhs.nPassPos() == rhs.nPassPos() && lhs.nPassNeg() == rhs.nPassNeg()
-     && lhs.nTotalPos() == rhs.nTotalPos() && lhs.nTotalNeg() == rhs.nTotalNeg()
-     && lhs.tried() == rhs.tried() && lhs.selected() == rhs.selected()
-     && lhs.killed() == rhs.killed() && lhs.accepted() == rhs.accepted() 
-     && lhs.acceptedBr() == rhs.acceptedBr()); 
+const bool operator!=(const GenLumiInfoProduct::ProcessInfo& lhs, const GenLumiInfoProduct::ProcessInfo& rhs) {
+  bool condition = (lhs.process() != rhs.process()) || (lhs.lheXSec() != rhs.lheXSec());
   return condition;
 }
 
-const bool operator !=(const GenLumiInfoProduct& lhs, const GenLumiInfoProduct& rhs)
-{
+const bool operator==(const GenLumiInfoProduct::ProcessInfo& lhs, const GenLumiInfoProduct::ProcessInfo& rhs) {
+  bool condition =
+      (lhs.process() == rhs.process() && lhs.lheXSec() == rhs.lheXSec() && lhs.nPassPos() == rhs.nPassPos() &&
+       lhs.nPassNeg() == rhs.nPassNeg() && lhs.nTotalPos() == rhs.nTotalPos() && lhs.nTotalNeg() == rhs.nTotalNeg() &&
+       lhs.tried() == rhs.tried() && lhs.selected() == rhs.selected() && lhs.killed() == rhs.killed() &&
+       lhs.accepted() == rhs.accepted() && lhs.acceptedBr() == rhs.acceptedBr());
+  return condition;
+}
+
+const bool operator!=(const GenLumiInfoProduct& lhs, const GenLumiInfoProduct& rhs) {
   std::vector<GenLumiInfoProduct::ProcessInfo> lhsVector = lhs.getProcessInfos();
   std::vector<GenLumiInfoProduct::ProcessInfo> rhsVector = rhs.getProcessInfos();
-  std::sort(lhsVector.begin(),lhsVector.end());
-  std::sort(rhsVector.begin(),rhsVector.end());
-  unsigned int lhssize=lhsVector.size();
-  unsigned int rhssize=rhsVector.size();  
-  bool condition= (lhs.getHEPIDWTUP() != rhs.getHEPIDWTUP()) ||
-    (lhssize != rhssize);
-  bool fail=false;
-  if(!condition)
-    {
-      for(unsigned int i=0; i<lhssize; i++){
-	if(lhsVector[i] != rhsVector[i])
-	  {
-	    fail=true;
-	    break;
-	  }
-
-      }
-
-    }
-  return (condition || fail);
-  
-}
-
-
-const bool operator ==(const GenLumiInfoProduct& lhs, const GenLumiInfoProduct& rhs)
-{
-  std::vector<GenLumiInfoProduct::ProcessInfo> lhsVector = lhs.getProcessInfos();
-  std::vector<GenLumiInfoProduct::ProcessInfo> rhsVector = rhs.getProcessInfos();
-  std::sort(lhsVector.begin(),lhsVector.end());
-  std::sort(rhsVector.begin(),rhsVector.end());
-  unsigned int lhssize=lhsVector.size();
-  unsigned int rhssize=rhsVector.size();  
-
-  bool condition= (lhs.getHEPIDWTUP() == rhs.getHEPIDWTUP()) &&
-    (lhssize == rhssize);
-  unsigned int passCounts=-999;
-  if(condition)
-    {
-      for(unsigned int i=0; i<lhssize; i++){
-	if(lhsVector[i] == rhsVector[i])
-	  passCounts++;
+  std::sort(lhsVector.begin(), lhsVector.end());
+  std::sort(rhsVector.begin(), rhsVector.end());
+  unsigned int lhssize = lhsVector.size();
+  unsigned int rhssize = rhsVector.size();
+  bool condition = (lhs.getHEPIDWTUP() != rhs.getHEPIDWTUP()) || (lhssize != rhssize);
+  bool fail = false;
+  if (!condition) {
+    for (unsigned int i = 0; i < lhssize; i++) {
+      if (lhsVector[i] != rhsVector[i]) {
+        fail = true;
+        break;
       }
     }
-  return (condition && (passCounts==lhssize));
-  
-}
-
-
-GenLumiInfoProduct::GenLumiInfoProduct() :
-  hepidwtup_(-1)
-{
-  internalProcesses_.clear();
-  
-}
-
-GenLumiInfoProduct::GenLumiInfoProduct(const int id) :
-  hepidwtup_(id)
-{
-  internalProcesses_.clear();
-}
-
-GenLumiInfoProduct::GenLumiInfoProduct(GenLumiInfoProduct const &other) :
-  hepidwtup_(other.hepidwtup_),
-  internalProcesses_(other.internalProcesses_)
-{
-}
-
-GenLumiInfoProduct::~GenLumiInfoProduct()
-{
-}
-
-bool GenLumiInfoProduct::mergeProduct(GenLumiInfoProduct const &other)
-{
-  std::map<int, ProcessInfo> processes;
-  
-  for(unsigned int i = 0; i < getProcessInfos().size(); i++) {
-    int id = getProcessInfos()[i].process();
-    ProcessInfo &x = processes[id];
-    x=getProcessInfos()[i];
   }
-  
+  return (condition || fail);
+}
+
+const bool operator==(const GenLumiInfoProduct& lhs, const GenLumiInfoProduct& rhs) {
+  std::vector<GenLumiInfoProduct::ProcessInfo> lhsVector = lhs.getProcessInfos();
+  std::vector<GenLumiInfoProduct::ProcessInfo> rhsVector = rhs.getProcessInfos();
+  std::sort(lhsVector.begin(), lhsVector.end());
+  std::sort(rhsVector.begin(), rhsVector.end());
+  unsigned int lhssize = lhsVector.size();
+  unsigned int rhssize = rhsVector.size();
+
+  bool condition = (lhs.getHEPIDWTUP() == rhs.getHEPIDWTUP()) && (lhssize == rhssize);
+  unsigned int passCounts = -999;
+  if (condition) {
+    for (unsigned int i = 0; i < lhssize; i++) {
+      if (lhsVector[i] == rhsVector[i])
+        passCounts++;
+    }
+  }
+  return (condition && (passCounts == lhssize));
+}
+
+GenLumiInfoProduct::GenLumiInfoProduct() : hepidwtup_(-1) { internalProcesses_.clear(); }
+
+GenLumiInfoProduct::GenLumiInfoProduct(const int id) : hepidwtup_(id) { internalProcesses_.clear(); }
+
+GenLumiInfoProduct::GenLumiInfoProduct(GenLumiInfoProduct const& other)
+    : hepidwtup_(other.hepidwtup_), internalProcesses_(other.internalProcesses_) {}
+
+GenLumiInfoProduct::~GenLumiInfoProduct() {}
+
+bool GenLumiInfoProduct::mergeProduct(GenLumiInfoProduct const& other) {
+  std::map<int, ProcessInfo> processes;
+
+  for (unsigned int i = 0; i < getProcessInfos().size(); i++) {
+    int id = getProcessInfos()[i].process();
+    ProcessInfo& x = processes[id];
+    x = getProcessInfos()[i];
+  }
+
   // the two GenLuminInfoProducts may not have the same number
   // of processes
-  for(unsigned int i = 0; i < other.getProcessInfos().size(); i++) {
+  for (unsigned int i = 0; i < other.getProcessInfos().size(); i++) {
     int id = other.getProcessInfos()[i].process();
-    ProcessInfo &x = processes[id];
-    if(x.lheXSec().value()>0)
+    ProcessInfo& x = processes[id];
+    if (x.lheXSec().value() > 0)
       x.addOthers(other.getProcessInfos()[i]);
-    else 
+    else
       x = other.getProcessInfos()[i];
   }
 
   internalProcesses_.resize(processes.size());
   unsigned int i = 0;
-  for(std::map<int, ProcessInfo>::const_iterator iter = processes.begin();
-      iter != processes.end(); ++iter, i++) 
-	internalProcesses_[i]=iter->second;
+  for (std::map<int, ProcessInfo>::const_iterator iter = processes.begin(); iter != processes.end(); ++iter, i++)
+    internalProcesses_[i] = iter->second;
   return true;
 }
 
@@ -141,9 +108,4 @@ void GenLumiInfoProduct::swap(GenLumiInfoProduct& other) {
   internalProcesses_.swap(other.internalProcesses_);
 }
 
-bool GenLumiInfoProduct::isProductEqual(GenLumiInfoProduct const &other) const
-{
-  return ((*this) == other);
-}
-
-
+bool GenLumiInfoProduct::isProductEqual(GenLumiInfoProduct const& other) const { return ((*this) == other); }

--- a/SimDataFormats/GeneratorProducts/src/GenRunInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenRunInfoProduct.cc
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <algorithm> 
+#include <algorithm>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -8,30 +8,24 @@
 using namespace edm;
 using namespace std;
 
-GenRunInfoProduct::GenRunInfoProduct() :
-	externalFilterEfficiency_(-1.)
-{
-}
+GenRunInfoProduct::GenRunInfoProduct() : externalFilterEfficiency_(-1.) {}
 
-GenRunInfoProduct::GenRunInfoProduct(GenRunInfoProduct const &other) :
-	internalXSec_(other.internalXSec_),
-	externalXSecLO_(other.externalXSecLO_),
-	externalXSecNLO_(other.externalXSecNLO_),
-	externalFilterEfficiency_(other.externalFilterEfficiency_)
-{
-}
+GenRunInfoProduct::GenRunInfoProduct(GenRunInfoProduct const &other)
+    : internalXSec_(other.internalXSec_),
+      externalXSecLO_(other.externalXSecLO_),
+      externalXSecNLO_(other.externalXSecNLO_),
+      externalFilterEfficiency_(other.externalFilterEfficiency_) {}
 
-bool GenRunInfoProduct::isProductEqual(GenRunInfoProduct const &other) const
-{
-	bool result =  externalXSecLO_ == other.externalXSecLO_ &&
-                       externalXSecNLO_ == other.externalXSecNLO_ &&
-	               externalFilterEfficiency_ == other.externalFilterEfficiency_;
-        if( not result) {
-          edm::LogWarning("GenRunInfoProduct|ProductsNotMergeable")
-            << "You are merging runs with different cross-sections and/or "
-               "filter efficiencies (from GenRunInfoProduct)\n"
-               "The resulting cross-section will not be consistent." << std::endl;
-        }
+bool GenRunInfoProduct::isProductEqual(GenRunInfoProduct const &other) const {
+  bool result = externalXSecLO_ == other.externalXSecLO_ && externalXSecNLO_ == other.externalXSecNLO_ &&
+                externalFilterEfficiency_ == other.externalFilterEfficiency_;
+  if (not result) {
+    edm::LogWarning("GenRunInfoProduct|ProductsNotMergeable")
+        << "You are merging runs with different cross-sections and/or "
+           "filter efficiencies (from GenRunInfoProduct)\n"
+           "The resulting cross-section will not be consistent."
+        << std::endl;
+  }
 
-        return result;
+  return result;
 }

--- a/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc
@@ -5,7 +5,7 @@
  */
 
 #include <iostream>
-#include <algorithm> // because we use std::swap
+#include <algorithm>  // because we use std::swap
 
 //#include "CLHEP/Vector/ThreeVector.h"
 
@@ -14,149 +14,123 @@
 using namespace edm;
 using namespace std;
 
-HepMCProduct::HepMCProduct(HepMC::GenEvent* evt) :
-    evt_(evt), isVtxGenApplied_(false), isVtxBoostApplied_(false), isPBoostApplied_(false) {
+HepMCProduct::HepMCProduct(HepMC::GenEvent* evt)
+    : evt_(evt), isVtxGenApplied_(false), isVtxBoostApplied_(false), isPBoostApplied_(false) {}
+
+HepMCProduct::~HepMCProduct() {
+  delete evt_;
+  evt_ = nullptr;
+  isVtxGenApplied_ = false;
+  isVtxBoostApplied_ = false;
+  isPBoostApplied_ = false;
 }
 
-HepMCProduct::~HepMCProduct(){
-
-	delete evt_; evt_ = nullptr; isVtxGenApplied_ = false;
-	isVtxBoostApplied_ = false;
-	isPBoostApplied_ = false;
-}
-
-
-void HepMCProduct::addHepMCData( HepMC::GenEvent  *evt){
+void HepMCProduct::addHepMCData(HepMC::GenEvent* evt) {
   //  evt->print();
   // cout <<sizeof (evt)  <<"  " << sizeof ( HepMC::GenEvent)   << endl;
   evt_ = evt;
-  
+
   // same story about vertex smearing - GenEvent won't know it...
   // in fact, would be better to implement CmsGenEvent...
-  
 }
 
-void HepMCProduct::applyVtxGen( HepMC::FourVector const& vtxShift )
-{
-	//std::cout<< " applyVtxGen called " << isVtxGenApplied_ << endl;
-	//fTimeOffset = 0;
-	
-   if ( isVtxGenApplied() ) return ;
-      
-   for ( HepMC::GenEvent::vertex_iterator vt=evt_->vertices_begin();
-                                          vt!=evt_->vertices_end(); ++vt )
-   {
-            
-      double x = (*vt)->position().x() + vtxShift.x() ;
-      double y = (*vt)->position().y() + vtxShift.y() ;
-      double z = (*vt)->position().z() + vtxShift.z() ;
-      double t = (*vt)->position().t() + vtxShift.t() ;
-      //std::cout << " vertex (x,y,z)= " << x <<" " << y << " " << z << std::endl;
-      (*vt)->set_position( HepMC::FourVector(x,y,z,t) ) ;      
-   }
-      
-   isVtxGenApplied_ = true ;
-   
-   return ;
+void HepMCProduct::applyVtxGen(HepMC::FourVector const& vtxShift) {
+  //std::cout<< " applyVtxGen called " << isVtxGenApplied_ << endl;
+  //fTimeOffset = 0;
 
-} 
+  if (isVtxGenApplied())
+    return;
 
-void HepMCProduct::boostToLab( TMatrixD const* lorentz, std::string const& type ) {
+  for (HepMC::GenEvent::vertex_iterator vt = evt_->vertices_begin(); vt != evt_->vertices_end(); ++vt) {
+    double x = (*vt)->position().x() + vtxShift.x();
+    double y = (*vt)->position().y() + vtxShift.y();
+    double z = (*vt)->position().z() + vtxShift.z();
+    double t = (*vt)->position().t() + vtxShift.t();
+    //std::cout << " vertex (x,y,z)= " << x <<" " << y << " " << z << std::endl;
+    (*vt)->set_position(HepMC::FourVector(x, y, z, t));
+  }
 
-	//std::cout << "from boostToLab:" << std::endl;
-	
-  
-  
-	if ( lorentz == nullptr ) {
+  isVtxGenApplied_ = true;
 
-		//std::cout << " lorentz = 0 " << std::endl;
-		return;
-	}
+  return;
+}
 
-	//lorentz->Print();
+void HepMCProduct::boostToLab(TMatrixD const* lorentz, std::string const& type) {
+  //std::cout << "from boostToLab:" << std::endl;
+
+  if (lorentz == nullptr) {
+    //std::cout << " lorentz = 0 " << std::endl;
+    return;
+  }
+
+  //lorentz->Print();
 
   TMatrixD tmplorentz(*lorentz);
   //tmplorentz.Print();
-  
-	if ( type == "vertex") {
 
-		if ( isVtxBoostApplied() ) {
-			//std::cout << " isVtxBoostApplied true " << std::endl;
-			return ;
-		}
-		
-		for ( HepMC::GenEvent::vertex_iterator vt=evt_->vertices_begin();
-			  vt!=evt_->vertices_end(); ++vt ) {
+  if (type == "vertex") {
+    if (isVtxBoostApplied()) {
+      //std::cout << " isVtxBoostApplied true " << std::endl;
+      return;
+    }
 
-			// change basis to lorentz boost definition: (t,x,z,y)
-			TMatrixD p4(4,1);
-			p4(0,0) = (*vt)->position().t();
-			p4(1,0) = (*vt)->position().x();
-			p4(2,0) = (*vt)->position().z();
-			p4(3,0) = (*vt)->position().y();
+    for (HepMC::GenEvent::vertex_iterator vt = evt_->vertices_begin(); vt != evt_->vertices_end(); ++vt) {
+      // change basis to lorentz boost definition: (t,x,z,y)
+      TMatrixD p4(4, 1);
+      p4(0, 0) = (*vt)->position().t();
+      p4(1, 0) = (*vt)->position().x();
+      p4(2, 0) = (*vt)->position().z();
+      p4(3, 0) = (*vt)->position().y();
 
-			TMatrixD p4lab(4,1);
-			p4lab = tmplorentz * p4;
-			//std::cout << " vertex lorentz: " << p4lab(1,0) << " " << p4lab(3,0) << " " << p4lab(2,0) << std::endl;
-			(*vt)->set_position( HepMC::FourVector(p4lab(1,0),p4lab(3,0),p4lab(2,0), p4lab(0,0) ) ) ;      
-		}
-      
-		isVtxBoostApplied_ = true ;
-	}
-	else if ( type == "momentum") {
-		
-		if ( isPBoostApplied() ) {
-			//std::cout << " isPBoostApplied true " << std::endl;
-			return ;
-		}
-		
-		for ( HepMC::GenEvent::particle_iterator part=evt_->particles_begin();
-			  part!=evt_->particles_end(); ++part ) {
+      TMatrixD p4lab(4, 1);
+      p4lab = tmplorentz * p4;
+      //std::cout << " vertex lorentz: " << p4lab(1,0) << " " << p4lab(3,0) << " " << p4lab(2,0) << std::endl;
+      (*vt)->set_position(HepMC::FourVector(p4lab(1, 0), p4lab(3, 0), p4lab(2, 0), p4lab(0, 0)));
+    }
 
-			// change basis to lorentz boost definition: (E,Px,Pz,Py)
-			TMatrixD p4(4,1);
-			p4(0,0) = (*part)->momentum().e();
-			p4(1,0) = (*part)->momentum().x();
-			p4(2,0) = (*part)->momentum().z();
-			p4(3,0) = (*part)->momentum().y();
+    isVtxBoostApplied_ = true;
+  } else if (type == "momentum") {
+    if (isPBoostApplied()) {
+      //std::cout << " isPBoostApplied true " << std::endl;
+      return;
+    }
 
-			TMatrixD p4lab(4,1);
-			p4lab = tmplorentz * p4;
-			//std::cout << " momentum lorentz: " << p4lab(1,0) << " " << p4lab(3,0) << " " << p4lab(2,0) << std::endl;
-			(*part)->set_momentum( HepMC::FourVector(p4lab(1,0),p4lab(3,0),p4lab(2,0),p4lab(0,0) ) ) ;      
-		}
-      
-		isPBoostApplied_ = true ;
-	}
-	else {
-		std::cout << " no type found for boostToLab(std::string), options are vertex or momentum" << std::endl;
-	}
-		
-		 
-	return ;
+    for (HepMC::GenEvent::particle_iterator part = evt_->particles_begin(); part != evt_->particles_end(); ++part) {
+      // change basis to lorentz boost definition: (E,Px,Pz,Py)
+      TMatrixD p4(4, 1);
+      p4(0, 0) = (*part)->momentum().e();
+      p4(1, 0) = (*part)->momentum().x();
+      p4(2, 0) = (*part)->momentum().z();
+      p4(3, 0) = (*part)->momentum().y();
+
+      TMatrixD p4lab(4, 1);
+      p4lab = tmplorentz * p4;
+      //std::cout << " momentum lorentz: " << p4lab(1,0) << " " << p4lab(3,0) << " " << p4lab(2,0) << std::endl;
+      (*part)->set_momentum(HepMC::FourVector(p4lab(1, 0), p4lab(3, 0), p4lab(2, 0), p4lab(0, 0)));
+    }
+
+    isPBoostApplied_ = true;
+  } else {
+    std::cout << " no type found for boostToLab(std::string), options are vertex or momentum" << std::endl;
+  }
+
+  return;
 }
 
-
-const HepMC::GenEvent&  
-HepMCProduct::getHepMCData()const   {
-
-  return  * evt_;
-}
+const HepMC::GenEvent& HepMCProduct::getHepMCData() const { return *evt_; }
 
 // copy constructor
-HepMCProduct::HepMCProduct(HepMCProduct const& other) :
-  evt_(nullptr) {
-  
-   if (other.evt_) evt_=new HepMC::GenEvent(*other.evt_);
-   isVtxGenApplied_ = other.isVtxGenApplied_ ;
-   isVtxBoostApplied_ = other.isVtxBoostApplied_;
-   isPBoostApplied_ = other.isPBoostApplied_;
-   //fTimeOffset = other.fTimeOffset;
+HepMCProduct::HepMCProduct(HepMCProduct const& other) : evt_(nullptr) {
+  if (other.evt_)
+    evt_ = new HepMC::GenEvent(*other.evt_);
+  isVtxGenApplied_ = other.isVtxGenApplied_;
+  isVtxBoostApplied_ = other.isVtxBoostApplied_;
+  isPBoostApplied_ = other.isPBoostApplied_;
+  //fTimeOffset = other.fTimeOffset;
 }
 
 // swap
-void
-HepMCProduct::swap(HepMCProduct& other) {
+void HepMCProduct::swap(HepMCProduct& other) {
   std::swap(evt_, other.evt_);
   std::swap(isVtxGenApplied_, other.isVtxGenApplied_);
   std::swap(isVtxBoostApplied_, other.isVtxBoostApplied_);
@@ -165,18 +139,14 @@ HepMCProduct::swap(HepMCProduct& other) {
 }
 
 // assignment: use copy/swap idiom for exception safety.
-HepMCProduct&
-HepMCProduct::operator=(HepMCProduct const& other) {
+HepMCProduct& HepMCProduct::operator=(HepMCProduct const& other) {
   HepMCProduct temp(other);
   swap(temp);
   return *this;
-} 
+}
 
 // move, needed explicitly as we have raw pointer...
-HepMCProduct::HepMCProduct(HepMCProduct&& other):
-  evt_(nullptr) {
-  swap(other);
-}
+HepMCProduct::HepMCProduct(HepMCProduct&& other) : evt_(nullptr) { swap(other); }
 HepMCProduct& HepMCProduct::operator=(HepMCProduct&& other) {
   swap(other);
   return *this;

--- a/SimDataFormats/GeneratorProducts/src/LHEEventProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/LHEEventProduct.cc
@@ -6,93 +6,65 @@
 #include "SimDataFormats/GeneratorProducts/interface/LesHouches.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 
-void LHEEventProduct::const_iterator::next()
-{
-	const lhef::HEPEUP &hepeup = event->hepeup();
-	int line = this->line++;
+void LHEEventProduct::const_iterator::next() {
+  const lhef::HEPEUP &hepeup = event->hepeup();
+  int line = this->line++;
 
-	if (!line) {
-		std::ostringstream ss;
-		ss << std::setprecision(7)
-		   << std::scientific
-		   << std::uppercase
-		   << "    " << hepeup.NUP
-		   << "  " << hepeup.IDPRUP
-		   << "  " << event->originalXWGTUP()
-		   << "  " << hepeup.SCALUP
-		   << "  " << hepeup.AQEDUP
-		   << "  " << hepeup.AQCDUP << std::endl;
-		tmp = ss.str();
-		return;
-	}
-	line--;
+  if (!line) {
+    std::ostringstream ss;
+    ss << std::setprecision(7) << std::scientific << std::uppercase << "    " << hepeup.NUP << "  " << hepeup.IDPRUP
+       << "  " << event->originalXWGTUP() << "  " << hepeup.SCALUP << "  " << hepeup.AQEDUP << "  " << hepeup.AQCDUP
+       << std::endl;
+    tmp = ss.str();
+    return;
+  }
+  line--;
 
-	if (line < hepeup.NUP) {
-		std::ostringstream ss;
-		ss << std::setprecision(10)
-		   << std::scientific
-		   << std::uppercase
-		   << "\t" << hepeup.IDUP[line]
-		   << "\t" << hepeup.ISTUP[line]
-		   << "\t" << hepeup.MOTHUP[line].first
-		   << "\t" << hepeup.MOTHUP[line].second
-		   << "\t" << hepeup.ICOLUP[line].first
-		   << "\t" << hepeup.ICOLUP[line].second
-		   << "\t" << hepeup.PUP[line][0]
-		   << "\t" << hepeup.PUP[line][1]
-		   << "\t" << hepeup.PUP[line][2]
-		   << "\t" << hepeup.PUP[line][3]
-		   << "\t" << hepeup.PUP[line][4]
-		   << std::setprecision(3)
-		   << "\t" << hepeup.VTIMUP[line]
-		   << std::setprecision(1)
-		   << std::fixed
-		   << "\t" << hepeup.SPINUP[line] << std::endl;
-		tmp = ss.str();
-		return;
-	}
-	line -= hepeup.NUP;
+  if (line < hepeup.NUP) {
+    std::ostringstream ss;
+    ss << std::setprecision(10) << std::scientific << std::uppercase << "\t" << hepeup.IDUP[line] << "\t"
+       << hepeup.ISTUP[line] << "\t" << hepeup.MOTHUP[line].first << "\t" << hepeup.MOTHUP[line].second << "\t"
+       << hepeup.ICOLUP[line].first << "\t" << hepeup.ICOLUP[line].second << "\t" << hepeup.PUP[line][0] << "\t"
+       << hepeup.PUP[line][1] << "\t" << hepeup.PUP[line][2] << "\t" << hepeup.PUP[line][3] << "\t"
+       << hepeup.PUP[line][4] << std::setprecision(3) << "\t" << hepeup.VTIMUP[line] << std::setprecision(1)
+       << std::fixed << "\t" << hepeup.SPINUP[line] << std::endl;
+    tmp = ss.str();
+    return;
+  }
+  line -= hepeup.NUP;
 
-	if (event->pdf()) {
-		if (!line) {
-			const PDF &pdf = *event->pdf();
-			std::ostringstream ss;
-			ss << std::setprecision(7)
-			   << std::scientific
-			   << std::uppercase
-			   << "#pdf  " << pdf.id.first
-			   << "  " << pdf.id.second
-			   << "  " << pdf.x.first
-			   << "  " << pdf.x.second
-			   << "  " << pdf.scalePDF
-			   << "  " << pdf.xPDF.first
-			   << "  " << pdf.xPDF.second << std::endl;
-			tmp = ss.str();
-			return;
-		}
-		line--;
-	}
+  if (event->pdf()) {
+    if (!line) {
+      const PDF &pdf = *event->pdf();
+      std::ostringstream ss;
+      ss << std::setprecision(7) << std::scientific << std::uppercase << "#pdf  " << pdf.id.first << "  "
+         << pdf.id.second << "  " << pdf.x.first << "  " << pdf.x.second << "  " << pdf.scalePDF << "  "
+         << pdf.xPDF.first << "  " << pdf.xPDF.second << std::endl;
+      tmp = ss.str();
+      return;
+    }
+    line--;
+  }
 
-	if (line < (int)event->comments_size()) {
-		tmp = *(event->comments_begin() + line);
-		return;
-	}
-	line -= event->comments_size();
+  if (line < (int)event->comments_size()) {
+    tmp = *(event->comments_begin() + line);
+    return;
+  }
+  line -= event->comments_size();
 
-	if (!line) {
-		tmp = "</event>\n";
-		return;
-	}
+  if (!line) {
+    tmp = "</event>\n";
+    return;
+  }
 
-	tmp.clear();
-	this->line = npos;
+  tmp.clear();
+  this->line = npos;
 }
 
-LHEEventProduct::const_iterator LHEEventProduct::begin() const
-{
-	const_iterator result;
-	result.event = this;
-	result.line = 0;
-	result.tmp = "<event>\n";
-	return result;
+LHEEventProduct::const_iterator LHEEventProduct::begin() const {
+  const_iterator result;
+  result.event = this;
+  result.line = 0;
+  result.tmp = "<event>\n";
+  return result;
 }

--- a/SimDataFormats/GeneratorProducts/src/LHERunInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/LHERunInfoProduct.cc
@@ -13,302 +13,269 @@
 #include "SimDataFormats/GeneratorProducts/interface/LesHouches.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
 
-bool LHERunInfoProduct::const_iterator::operator ==
-					(const const_iterator &other) const
-{
-	if (mode != other.mode)
-		return false;
+bool LHERunInfoProduct::const_iterator::operator==(const const_iterator &other) const {
+  if (mode != other.mode)
+    return false;
 
-	switch(mode) {
-	    case kFooter:
-	    case kDone:
-		return true;
+  switch (mode) {
+    case kFooter:
+    case kDone:
+      return true;
 
-	    case kHeader:
-		return header == other.header;
+    case kHeader:
+      return header == other.header;
 
-	    case kBody:
-		return header == other.header && iter == other.iter;
+    case kBody:
+      return header == other.header && iter == other.iter;
 
-	    case kInit:
-		return line == other.line;
-	}
+    case kInit:
+      return line == other.line;
+  }
 
-	return false;
+  return false;
 }
 
-void LHERunInfoProduct::const_iterator::next()
-{
-	tmp.clear();
+void LHERunInfoProduct::const_iterator::next() {
+  tmp.clear();
 
-	do {
-		switch(mode) {
-		    case kHeader:
-			if (header == runInfo->headers_end()) {
-				if (line++ == 1)
-					tmp = "</header>\n";
-				else {
-					mode = kInit;
-					tmp = "<init>\n";
-					line = 0;
-				}
-				break;
-			} else if (!line) {
-				line++;
-				tmp = "<header>\n";
-				break;
-			} else {
-				mode = kBody;
-				const std::string &tag = header->tag();
-				tmp = tag.empty() ? "<!--" :
-				      (tag == "<>") ? "" : ("<" + tag + ">");
-				iter = header->begin();
-				continue;
-			}
+  do {
+    switch (mode) {
+      case kHeader:
+        if (header == runInfo->headers_end()) {
+          if (line++ == 1)
+            tmp = "</header>\n";
+          else {
+            mode = kInit;
+            tmp = "<init>\n";
+            line = 0;
+          }
+          break;
+        } else if (!line) {
+          line++;
+          tmp = "<header>\n";
+          break;
+        } else {
+          mode = kBody;
+          const std::string &tag = header->tag();
+          tmp = tag.empty() ? "<!--" : (tag == "<>") ? "" : ("<" + tag + ">");
+          iter = header->begin();
+          continue;
+        }
 
-		    case kBody:
-			if (iter == header->end()) {
-				mode = kHeader;
-				const std::string &tag = header->tag();
-				tmp += tag.empty() ? "-->" :
-				       (tag == "<>") ? "" : ("</" + tag + ">");
-				tmp += "\n";
-				header++;
-			} else {
-				tmp += *iter++;
-				if (iter == header->end() &&
-				    (tmp.empty() ||
-				     (tmp[tmp.length() - 1] != '\r' &&
-				      tmp[tmp.length() - 1] != '\n')))
-					continue;
-			}
-			break;
+      case kBody:
+        if (iter == header->end()) {
+          mode = kHeader;
+          const std::string &tag = header->tag();
+          tmp += tag.empty() ? "-->" : (tag == "<>") ? "" : ("</" + tag + ">");
+          tmp += "\n";
+          header++;
+        } else {
+          tmp += *iter++;
+          if (iter == header->end() &&
+              (tmp.empty() || (tmp[tmp.length() - 1] != '\r' && tmp[tmp.length() - 1] != '\n')))
+            continue;
+        }
+        break;
 
-		    case kInit: {
-			const lhef::HEPRUP &heprup = runInfo->heprup();
-			if (!line++) {
-				std::ostringstream ss;
-				ss << std::setprecision(7)
-				   << std::scientific
-				   << std::uppercase
-				   << "    " << heprup.IDBMUP.first
-				   << "  " << heprup.IDBMUP.second
-				   << "  " << heprup.EBMUP.first
-				   << "  " << heprup.EBMUP.second
-				   << "  " << heprup.PDFGUP.first
-				   << "  " << heprup.PDFGUP.second
-				   << "  " << heprup.PDFSUP.first
-				   << "  " << heprup.PDFSUP.second
-				   << "  " << heprup.IDWTUP
-				   << "  " << heprup.NPRUP << std::endl;
-				tmp = ss.str();
-				break;
-			}
-			if (line >= (unsigned int)heprup.NPRUP +
-			            runInfo->comments_size() + 2) {
-				tmp = "</init>\n";
-				mode = kFooter;
-				break;
-			} else if (line >= (unsigned int)heprup.NPRUP + 2) {
-				tmp = *(runInfo->comments_begin() + (line -
-				             (unsigned int)heprup.NPRUP - 2));
-				break;
-			}
+      case kInit: {
+        const lhef::HEPRUP &heprup = runInfo->heprup();
+        if (!line++) {
+          std::ostringstream ss;
+          ss << std::setprecision(7) << std::scientific << std::uppercase << "    " << heprup.IDBMUP.first << "  "
+             << heprup.IDBMUP.second << "  " << heprup.EBMUP.first << "  " << heprup.EBMUP.second << "  "
+             << heprup.PDFGUP.first << "  " << heprup.PDFGUP.second << "  " << heprup.PDFSUP.first << "  "
+             << heprup.PDFSUP.second << "  " << heprup.IDWTUP << "  " << heprup.NPRUP << std::endl;
+          tmp = ss.str();
+          break;
+        }
+        if (line >= (unsigned int)heprup.NPRUP + runInfo->comments_size() + 2) {
+          tmp = "</init>\n";
+          mode = kFooter;
+          break;
+        } else if (line >= (unsigned int)heprup.NPRUP + 2) {
+          tmp = *(runInfo->comments_begin() + (line - (unsigned int)heprup.NPRUP - 2));
+          break;
+        }
 
-			std::ostringstream ss;
-			ss << std::setprecision(7)
-			   << std::scientific
-			   << std::uppercase
-			   << "\t" << heprup.XSECUP[line - 2]
-			   << "\t" << heprup.XERRUP[line - 2]
-			   << "\t" << heprup.XMAXUP[line - 2]
-			   << "\t" << heprup.LPRUP[line - 2] << std::endl;
-			tmp = ss.str();
-		    }	break;
+        std::ostringstream ss;
+        ss << std::setprecision(7) << std::scientific << std::uppercase << "\t" << heprup.XSECUP[line - 2] << "\t"
+           << heprup.XERRUP[line - 2] << "\t" << heprup.XMAXUP[line - 2] << "\t" << heprup.LPRUP[line - 2] << std::endl;
+        tmp = ss.str();
+      } break;
 
-		    case kFooter:
-			mode = kDone;
+      case kFooter:
+        mode = kDone;
 
-		    default:
-			/* ... */;
-		}
-	} while(false);
+      default:
+          /* ... */;
+    }
+  } while (false);
 }
 
-LHERunInfoProduct::const_iterator LHERunInfoProduct::begin() const
-{
-	const_iterator result;
+LHERunInfoProduct::const_iterator LHERunInfoProduct::begin() const {
+  const_iterator result;
 
-	result.runInfo = this;
-	result.header = headers_begin();
-	result.mode = const_iterator::kHeader;
-	result.line = 0;
-	result.tmp = "<LesHouchesEvents version=\"1.0\">\n";
+  result.runInfo = this;
+  result.header = headers_begin();
+  result.mode = const_iterator::kHeader;
+  result.line = 0;
+  result.tmp = "<LesHouchesEvents version=\"1.0\">\n";
 
-	return result;
+  return result;
 }
 
-LHERunInfoProduct::const_iterator LHERunInfoProduct::init() const
-{
-	const_iterator result;
+LHERunInfoProduct::const_iterator LHERunInfoProduct::init() const {
+  const_iterator result;
 
-	result.runInfo = this;
-	result.mode = const_iterator::kInit;
-	result.line = 0;
-	result.tmp = "<init>\n";
+  result.runInfo = this;
+  result.mode = const_iterator::kInit;
+  result.line = 0;
+  result.tmp = "<init>\n";
 
-	return result;
+  return result;
 }
 
-const std::string &LHERunInfoProduct::endOfFile()
-{
-	static const std::string theEnd("</LesHouchesEvents>\n");
+const std::string &LHERunInfoProduct::endOfFile() {
+  static const std::string theEnd("</LesHouchesEvents>\n");
 
-	return theEnd;
+  return theEnd;
 }
 
 namespace {
-	struct XSec {
-		inline XSec() : xsec(0.0), err(0.0), max(0.0) {}
+  struct XSec {
+    inline XSec() : xsec(0.0), err(0.0), max(0.0) {}
 
-		double	xsec;
-		double	err;
-		double	max;
-	};
+    double xsec;
+    double err;
+    double max;
+  };
 
-	struct HeaderLess {
-		bool operator() (const LHERunInfoProduct::Header &a,
-		                 const LHERunInfoProduct::Header &b) const;
-	};
+  struct HeaderLess {
+    bool operator()(const LHERunInfoProduct::Header &a, const LHERunInfoProduct::Header &b) const;
+  };
+}  // namespace
+
+bool HeaderLess::operator()(const LHERunInfoProduct::Header &a, const LHERunInfoProduct::Header &b) const {
+  if (a == b)
+    return false;
+  if (a.tag() < b.tag())
+    return true;
+  if (a.tag() > b.tag())
+    return false;
+
+  LHERunInfoProduct::Header::const_iterator iter1 = a.begin();
+  LHERunInfoProduct::Header::const_iterator iter2 = b.begin();
+
+  for (; iter1 != a.end() && iter2 != b.end(); ++iter1, ++iter2) {
+    if (*iter1 < *iter2)
+      return true;
+    else if (*iter1 != *iter2)
+      return false;
+  }
+
+  return iter2 != b.end();
 }
 
-bool HeaderLess::operator() (const LHERunInfoProduct::Header &a,
-                             const LHERunInfoProduct::Header &b) const
-{
-	if (a == b)
-		return false;
-	if (a.tag() < b.tag())
-		return true;
-	if (a.tag() > b.tag())
-		return false;
-
-	LHERunInfoProduct::Header::const_iterator iter1 = a.begin();
-	LHERunInfoProduct::Header::const_iterator iter2 = b.begin();
-
-	for(; iter1 != a.end() && iter2 != b.end(); ++iter1, ++iter2) {
-		if (*iter1 < *iter2)
-			return true;
-		else if (*iter1 != *iter2)
-			return false;
-	}
-
-	return iter2 != b.end();
-}
-
-static std::vector<std::string> checklist{"iseed","Random",".log",".dat",".lhe"};
-static std::vector<std::string> tag_comparison_checklist{"","MGRunCard","mgruncard"};
+static std::vector<std::string> checklist{"iseed", "Random", ".log", ".dat", ".lhe"};
+static std::vector<std::string> tag_comparison_checklist{"", "MGRunCard", "mgruncard"};
 
 bool LHERunInfoProduct::find_if_checklist(const std::string x, std::vector<std::string> checklist) {
-    return checklist.end() != std::find_if(checklist.begin(),checklist.end(),[&](const std::string& y)
-                                            { return x.find(y) != std::string::npos; } );
+  return checklist.end() != std::find_if(checklist.begin(), checklist.end(), [&](const std::string &y) {
+           return x.find(y) != std::string::npos;
+         });
 }
 
-bool LHERunInfoProduct::isTagComparedInMerge(const std::string& tag) {
-        return !(tag.empty() || tag.find("Alpgen") == 0 || tag == "MGGridCard" || tag=="MGRunCard" || tag == "mgruncard" || tag=="MadSpin" || tag=="madspin");
+bool LHERunInfoProduct::isTagComparedInMerge(const std::string &tag) {
+  return !(tag.empty() || tag.find("Alpgen") == 0 || tag == "MGGridCard" || tag == "MGRunCard" || tag == "mgruncard" ||
+           tag == "MadSpin" || tag == "madspin");
 }
 
-bool LHERunInfoProduct::mergeProduct(const LHERunInfoProduct &other)
-{
+bool LHERunInfoProduct::mergeProduct(const LHERunInfoProduct &other) {
+  if (heprup_.IDBMUP != other.heprup_.IDBMUP || heprup_.EBMUP != other.heprup_.EBMUP ||
+      heprup_.PDFGUP != other.heprup_.PDFGUP || heprup_.PDFSUP != other.heprup_.PDFSUP ||
+      heprup_.IDWTUP != other.heprup_.IDWTUP) {
+    return false;
+  }
 
-  if (heprup_.IDBMUP != other.heprup_.IDBMUP ||
-	    heprup_.EBMUP != other.heprup_.EBMUP ||
-	    heprup_.PDFGUP != other.heprup_.PDFGUP ||
-	    heprup_.PDFSUP != other.heprup_.PDFSUP ||
-	    heprup_.IDWTUP != other.heprup_.IDWTUP) {
-        
-	  return false;	
-	}
+  bool compatibleHeaders = (headers_ == other.headers_);
 
-	bool compatibleHeaders = (headers_ == other.headers_);
+  // try to merge not equal but compatible headers (i.e. different iseed)
+  while (!compatibleHeaders) {
+    // okay, something is not the same.
+    // Let's try to merge, but don't duplicate identical headers
+    // and test the rest against a whitelist
 
-	// try to merge not equal but compatible headers (i.e. different iseed)
-	while(!compatibleHeaders) {
-		// okay, something is not the same.
-		// Let's try to merge, but don't duplicate identical headers
-		// and test the rest against a whitelist
-
-		std::set<Header, HeaderLess> headers;
-		std::copy(headers_begin(), headers_end(),
-		          std::inserter(headers, headers.begin()));
+    std::set<Header, HeaderLess> headers;
+    std::copy(headers_begin(), headers_end(), std::inserter(headers, headers.begin()));
 
     // make a list of headers contained in the second file
     std::vector<std::vector<std::string> > runcard_v2;
     std::vector<std::string> runcard_v2_header;
-    for(auto header2 : headers_) {
-        // fill a vector with the relevant header tags that can be not equal but sill compatible
-        if(find_if_checklist(header2.tag(),tag_comparison_checklist)){
-          runcard_v2.push_back(header2.lines());
-          runcard_v2_header.push_back(header2.tag());
-        }
+    for (auto header2 : headers_) {
+      // fill a vector with the relevant header tags that can be not equal but sill compatible
+      if (find_if_checklist(header2.tag(), tag_comparison_checklist)) {
+        runcard_v2.push_back(header2.lines());
+        runcard_v2_header.push_back(header2.tag());
+      }
     }
-    
+
     // loop over the headers of the original file
-		bool failed = false;
-		for(std::vector<LHERunInfoProduct::Header>::const_iterator
-					header = other.headers_begin();
-		    header != other.headers_end(); ++header) {
-          
-			if (headers.count(*header)) {
-				continue;
-			}
-            
-      if(find_if_checklist(header->tag(),tag_comparison_checklist)){
+    bool failed = false;
+    for (std::vector<LHERunInfoProduct::Header>::const_iterator header = other.headers_begin();
+         header != other.headers_end();
+         ++header) {
+      if (headers.count(*header)) {
+        continue;
+      }
+
+      if (find_if_checklist(header->tag(), tag_comparison_checklist)) {
         bool header_compatible = false;
-        for (unsigned int iter_runcard = 0; iter_runcard < runcard_v2.size(); iter_runcard++){
-          
+        for (unsigned int iter_runcard = 0; iter_runcard < runcard_v2.size(); iter_runcard++) {
           std::vector<std::string> runcard_v1 = header->lines();
-          runcard_v1.erase( std::remove_if( runcard_v1.begin(), runcard_v1.end(), 
-                                            [&](const std::string& x){ return find_if_checklist(x,checklist); } ), 
-                                            runcard_v1.end() );
-          runcard_v2[iter_runcard].erase( std::remove_if( runcard_v2[iter_runcard].begin(), runcard_v2[iter_runcard].end(), 
-                                            [&](const std::string& x){ return find_if_checklist(x,checklist); } ), 
-                                            runcard_v2[iter_runcard].end() );
-          
-          if(std::equal(runcard_v1.begin(), runcard_v1.end(), runcard_v2[iter_runcard].begin())){
+          runcard_v1.erase(std::remove_if(runcard_v1.begin(),
+                                          runcard_v1.end(),
+                                          [&](const std::string &x) { return find_if_checklist(x, checklist); }),
+                           runcard_v1.end());
+          runcard_v2[iter_runcard].erase(
+              std::remove_if(runcard_v2[iter_runcard].begin(),
+                             runcard_v2[iter_runcard].end(),
+                             [&](const std::string &x) { return find_if_checklist(x, checklist); }),
+              runcard_v2[iter_runcard].end());
+
+          if (std::equal(runcard_v1.begin(), runcard_v1.end(), runcard_v2[iter_runcard].begin())) {
             header_compatible = true;
             break;
           }
         }
-        if(header_compatible) continue;
+        if (header_compatible)
+          continue;
       }
-      
-			if(isTagComparedInMerge(header->tag())){ 
-				failed = true;
-			} else {
-				addHeader(*header);	
-				headers.insert(*header);
-			}
-		
+
+      if (isTagComparedInMerge(header->tag())) {
+        failed = true;
+      } else {
+        addHeader(*header);
+        headers.insert(*header);
+      }
     }
-    
-		if (failed) {
-			break;
-		}
 
-		compatibleHeaders = true;
-	}
+    if (failed) {
+      break;
+    }
 
-  
-	// still not compatible after fixups
-	if (!compatibleHeaders) {
+    compatibleHeaders = true;
+  }
+
+  // still not compatible after fixups
+  if (!compatibleHeaders) {
     return false;
-	}
+  }
 
-	// it is exactly the same, so merge
-	return true;
+  // it is exactly the same, so merge
+  return true;
 }
 
-void LHERunInfoProduct::swap(LHERunInfoProduct& other) {
+void LHERunInfoProduct::swap(LHERunInfoProduct &other) {
   heprup_.swap(other.heprup_);
   headers_.swap(other.headers_);
   comments_.swap(other.comments_);

--- a/SimDataFormats/GeneratorProducts/src/LHEXMLStringProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/LHEXMLStringProduct.cc
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <algorithm> 
+#include <algorithm>
 #include <lzma.h>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -9,52 +9,42 @@
 using namespace edm;
 using namespace std;
 
+LHEXMLStringProduct::LHEXMLStringProduct() {}
 
-LHEXMLStringProduct::LHEXMLStringProduct()
-{
-}
+LHEXMLStringProduct::LHEXMLStringProduct(const string &onelheoutput) : content_() { content_.push_back(onelheoutput); }
 
-LHEXMLStringProduct::LHEXMLStringProduct(const string& onelheoutput) :
-  content_()
-{
-  content_.push_back(onelheoutput);
-}
-
-
-LHEXMLStringProduct::~LHEXMLStringProduct()
-{
-}
+LHEXMLStringProduct::~LHEXMLStringProduct() {}
 
 void LHEXMLStringProduct::fillCompressedContent(std::istream &input, unsigned int initialSize) {
   //create blob with desired size
   compressedContent_.emplace_back(initialSize);
   std::vector<uint8_t> &output = compressedContent_.back();
-    
+
   //read buffer
   constexpr unsigned int bufsize = 4096;
   char inbuf[bufsize];
-  
-  const unsigned int threshsize = 32*1024*1024;
-  
+
+  const unsigned int threshsize = 32 * 1024 * 1024;
+
   //initialize lzma
   uint32_t preset = 9;
   lzma_stream strm = LZMA_STREAM_INIT;
   lzma_ret ret = lzma_easy_encoder(&strm, preset, LZMA_CHECK_CRC64);
-  
+
   lzma_action action = LZMA_RUN;
-  
-  strm.next_in = reinterpret_cast<uint8_t*>(&inbuf[0]);
+
+  strm.next_in = reinterpret_cast<uint8_t *>(&inbuf[0]);
   strm.avail_in = 0;
   strm.next_out = output.data();
   strm.avail_out = output.size();
-  
+
   unsigned int compressedSize = 0;
-    
-  while (ret==LZMA_OK) {
+
+  while (ret == LZMA_OK) {
     //read input to buffer if necessary
     if (strm.avail_in == 0 && !input.eof()) {
       input.read(inbuf, bufsize);
-      strm.next_in = reinterpret_cast<uint8_t*>(&inbuf[0]);
+      strm.next_in = reinterpret_cast<uint8_t *>(&inbuf[0]);
       strm.avail_in = input.gcount();
       if (input.eof()) {
         //signal to lzma that there is no more input
@@ -64,89 +54,78 @@ void LHEXMLStringProduct::fillCompressedContent(std::istream &input, unsigned in
 
     //actual compression
     ret = lzma_code(&strm, action);
-    
+
     //update compressed size
     compressedSize = output.size() - strm.avail_out;
-    
+
     //if output blob is full and compression is still going, allocate more memory
-    if (strm.avail_out == 0 && ret==LZMA_OK) {
+    if (strm.avail_out == 0 && ret == LZMA_OK) {
       unsigned int oldsize = output.size();
-      if (oldsize<threshsize) {
-        output.resize(2*oldsize);
-      }
-      else {
+      if (oldsize < threshsize) {
+        output.resize(2 * oldsize);
+      } else {
         output.resize(oldsize + threshsize);
       }
       strm.next_out = &output[oldsize];
       strm.avail_out = output.size() - oldsize;
     }
-    
   }
-  
+
   lzma_end(&strm);
-  
-  if (ret!=LZMA_STREAM_END) {
-    throw cms::Exception("CompressionError")
-      << "There was a failure in LZMA compression in LHEXMLStringProduct.";
+
+  if (ret != LZMA_STREAM_END) {
+    throw cms::Exception("CompressionError") << "There was a failure in LZMA compression in LHEXMLStringProduct.";
   }
-  
+
   //trim output blob
   output.resize(compressedSize);
-  
 }
 
 void LHEXMLStringProduct::writeCompressedContent(std::ostream &output, unsigned int i) const {
-  
   //initialize lzma
   lzma_stream strm = LZMA_STREAM_INIT;
   lzma_ret ret = lzma_stream_decoder(&strm, UINT64_MAX, LZMA_CONCATENATED);
   //all output available from the start, so start "close out" immediately
   lzma_action action = LZMA_FINISH;
-  
+
   //write buffer
   constexpr unsigned int bufsize = 4096;
   char outbuf[bufsize];
-  
+
   const std::vector<uint8_t> &input = compressedContent_[i];
-  
+
   strm.next_in = input.data();
   strm.avail_in = input.size();
-  strm.next_out = reinterpret_cast<uint8_t*>(&outbuf[0]);
+  strm.next_out = reinterpret_cast<uint8_t *>(&outbuf[0]);
   strm.avail_out = bufsize;
-  
-  while (ret==LZMA_OK) {
-    
+
+  while (ret == LZMA_OK) {
     ret = lzma_code(&strm, action);
-    
+
     //write to stream
-    output.write(outbuf,bufsize-strm.avail_out);
-    
+    output.write(outbuf, bufsize - strm.avail_out);
+
     //output buffer full, recycle
-    if (strm.avail_out==0 && ret==LZMA_OK) {
-      strm.next_out = reinterpret_cast<uint8_t*>(&outbuf[0]);
+    if (strm.avail_out == 0 && ret == LZMA_OK) {
+      strm.next_out = reinterpret_cast<uint8_t *>(&outbuf[0]);
       strm.avail_out = bufsize;
     }
   }
-    
+
   lzma_end(&strm);
-  
-  if (ret!=LZMA_STREAM_END) {
-    throw cms::Exception("DecompressionError")
-      << "There was a failure in LZMA decompression in LHEXMLStringProduct.";
+
+  if (ret != LZMA_STREAM_END) {
+    throw cms::Exception("DecompressionError") << "There was a failure in LZMA decompression in LHEXMLStringProduct.";
   }
-  
 }
 
-
-
-bool LHEXMLStringProduct::mergeProduct(LHEXMLStringProduct const &other)
-{
+bool LHEXMLStringProduct::mergeProduct(LHEXMLStringProduct const &other) {
   content_.insert(content_.end(), other.getStrings().begin(), other.getStrings().end());
   compressedContent_.insert(compressedContent_.end(), other.getCompressed().begin(), other.getCompressed().end());
   return true;
 }
 
-void LHEXMLStringProduct::swap(LHEXMLStringProduct& other) {
+void LHEXMLStringProduct::swap(LHEXMLStringProduct &other) {
   content_.swap(other.content_);
   compressedContent_.swap(other.compressedContent_);
 }

--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -24,14 +24,13 @@ namespace hepmc_rootio {
   void add_to_particles_in(HepMC::GenVertex*, HepMC::GenParticle*);
   void clear_particles_in(HepMC::GenVertex*);
 
-  inline void weightcontainer_set_default_names(unsigned int n, std::map<std::string,HepMC::WeightContainer::size_type>& names) {
-      std::ostringstream name;
-      for ( HepMC::WeightContainer::size_type count = 0; count<n; ++count ) 
-      { 
+  inline void weightcontainer_set_default_names(unsigned int n,
+                                                std::map<std::string, HepMC::WeightContainer::size_type>& names) {
+    std::ostringstream name;
+    for (HepMC::WeightContainer::size_type count = 0; count < n; ++count) {
       name.str(std::string());
       name << count;
       names[name.str()] = count;
-      }
+    }
   }
-}
-
+}  // namespace hepmc_rootio


### PR DESCRIPTION

Applying code-format for CMSSW category generators.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/438//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


