### PR TITLE
Running code-format for alca

### DIFF
--- a/CalibTracker/SiStripESProducers/interface/Phase2TrackerCablingESProducer.h
+++ b/CalibTracker/SiStripESProducers/interface/Phase2TrackerCablingESProducer.h
@@ -10,22 +10,17 @@ class Phase2TrackerCabling;
 class Phase2TrackerCablingRcd;
 
 class Phase2TrackerCablingESProducer : public edm::ESProducer {
-  
- public:
-  
-  Phase2TrackerCablingESProducer( const edm::ParameterSet& );
+public:
+  Phase2TrackerCablingESProducer(const edm::ParameterSet&);
   ~Phase2TrackerCablingESProducer() override;
-  
-  virtual std::unique_ptr<Phase2TrackerCabling> produce( const Phase2TrackerCablingRcd& );
-  
- private:
-  
-  Phase2TrackerCablingESProducer( const Phase2TrackerCablingESProducer& ) = delete;
-  const Phase2TrackerCablingESProducer& operator=( const Phase2TrackerCablingESProducer& ) = delete;
-  
-  virtual Phase2TrackerCabling* make( const Phase2TrackerCablingRcd& ) = 0; 
-  
+
+  virtual std::unique_ptr<Phase2TrackerCabling> produce(const Phase2TrackerCablingRcd&);
+
+private:
+  Phase2TrackerCablingESProducer(const Phase2TrackerCablingESProducer&) = delete;
+  const Phase2TrackerCablingESProducer& operator=(const Phase2TrackerCablingESProducer&) = delete;
+
+  virtual Phase2TrackerCabling* make(const Phase2TrackerCablingRcd&) = 0;
 };
 
-#endif // CalibTracker_SiStripESProducers_Phase2TrackerCablingESProducer_H
-
+#endif  // CalibTracker_SiStripESProducers_Phase2TrackerCablingESProducer_H

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondObjPrinter.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondObjPrinter.h
@@ -13,44 +13,39 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include <string>
 
-
-
-template< typename TObject, typename TRecord>
+template <typename TObject, typename TRecord>
 class DummyCondObjPrinter : public edm::EDAnalyzer {
-
 public:
-
   explicit DummyCondObjPrinter(const edm::ParameterSet& iConfig);
   ~DummyCondObjPrinter() override;
-  void analyze(const edm::Event& e, const edm::EventSetup&es) override;
+  void analyze(const edm::Event& e, const edm::EventSetup& es) override;
 
-
- private:
+private:
   edm::ParameterSet iConfig_;
   unsigned long long cacheID;
 };
 
-template< typename TObject, typename TRecord>
-DummyCondObjPrinter<TObject,TRecord>::DummyCondObjPrinter(const edm::ParameterSet& iConfig):iConfig_(iConfig),cacheID(0){
-  edm::LogInfo("DummyCondObjPrinter") << "DummyCondObjPrinter constructor for typename " << typeid(TObject).name() << " and record " << typeid(TRecord).name() << std::endl;
+template <typename TObject, typename TRecord>
+DummyCondObjPrinter<TObject, TRecord>::DummyCondObjPrinter(const edm::ParameterSet& iConfig)
+    : iConfig_(iConfig), cacheID(0) {
+  edm::LogInfo("DummyCondObjPrinter") << "DummyCondObjPrinter constructor for typename " << typeid(TObject).name()
+                                      << " and record " << typeid(TRecord).name() << std::endl;
 }
 
-
-template< typename TObject, typename TRecord>
-DummyCondObjPrinter<TObject,TRecord>::~DummyCondObjPrinter(){
- edm::LogInfo("DummyCondObjPrinter") << "DummyCondObjPrinter::~DummyCondObjPrinter()" << std::endl;
+template <typename TObject, typename TRecord>
+DummyCondObjPrinter<TObject, TRecord>::~DummyCondObjPrinter() {
+  edm::LogInfo("DummyCondObjPrinter") << "DummyCondObjPrinter::~DummyCondObjPrinter()" << std::endl;
 }
 
-template< typename TObject,typename TRecord>
-void DummyCondObjPrinter<TObject,TRecord>::analyze(const edm::Event& e, const edm::EventSetup&es){
-
-  if( cacheID == es.get<TRecord>().cacheIdentifier())
+template <typename TObject, typename TRecord>
+void DummyCondObjPrinter<TObject, TRecord>::analyze(const edm::Event& e, const edm::EventSetup& es) {
+  if (cacheID == es.get<TRecord>().cacheIdentifier())
     return;
-  
+
   cacheID = es.get<TRecord>().cacheIdentifier();
 
   edm::ESHandle<TObject> esobj;
-  es.get<TRecord>().get( esobj );
+  es.get<TRecord>().get(esobj);
   edm::ESHandle<TrackerTopology> tTopo;
   es.get<TrackerTopologyRcd>().get(tTopo);
   std::stringstream sSummary, sDebug;
@@ -59,8 +54,8 @@ void DummyCondObjPrinter<TObject,TRecord>::analyze(const edm::Event& e, const ed
 
   //  edm::LogInfo("DummyCondObjPrinter") << "\nPrintSummary \n" << sSummary.str()  << std::endl;
   //  edm::LogWarning("DummyCondObjPrinter") << "\nPrintDebug \n" << sDebug.str()  << std::endl;
-  edm::LogPrint("DummyCondObjContentPrinter") << "\nPrintSummary \n" << sSummary.str()  << std::endl;
-  edm::LogVerbatim("DummyCondObjContentPrinter") << "\nPrintDebug \n" << sDebug.str()  << std::endl;
+  edm::LogPrint("DummyCondObjContentPrinter") << "\nPrintSummary \n" << sSummary.str() << std::endl;
+  edm::LogVerbatim("DummyCondObjContentPrinter") << "\nPrintDebug \n" << sDebug.str() << std::endl;
 }
 
 #endif

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.cc
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.cc
@@ -5,159 +5,155 @@
 #include <fstream>
 #include <iostream>
 
-SiStripFedCablingManipulator::SiStripFedCablingManipulator(const edm::ParameterSet& iConfig):iConfig_(iConfig){
-  edm::LogInfo("SiStripFedCablingManipulator") << "SiStripFedCablingManipulator constructor "<< std::endl;
+SiStripFedCablingManipulator::SiStripFedCablingManipulator(const edm::ParameterSet& iConfig) : iConfig_(iConfig) {
+  edm::LogInfo("SiStripFedCablingManipulator") << "SiStripFedCablingManipulator constructor " << std::endl;
 }
 
-
-SiStripFedCablingManipulator::~SiStripFedCablingManipulator(){
- edm::LogInfo("SiStripFedCablingManipulator") << "SiStripFedCablingManipulator::~SiStripFedCablingManipulator()" << std::endl;
+SiStripFedCablingManipulator::~SiStripFedCablingManipulator() {
+  edm::LogInfo("SiStripFedCablingManipulator")
+      << "SiStripFedCablingManipulator::~SiStripFedCablingManipulator()" << std::endl;
 }
 
-void SiStripFedCablingManipulator::endRun(const edm::Run & run, const edm::EventSetup & es){
+void SiStripFedCablingManipulator::endRun(const edm::Run& run, const edm::EventSetup& es) {
   edm::ESHandle<SiStripFedCabling> esobj;
-  es.get<SiStripFedCablingRcd>().get( esobj ); 
+  es.get<SiStripFedCablingRcd>().get(esobj);
 
-
-  SiStripFedCabling *obj=nullptr;
-  manipulate(esobj.product(),obj);
+  SiStripFedCabling* obj = nullptr;
+  manipulate(esobj.product(), obj);
 
   cond::Time_t Time_ = 0;
-  
+
   //And now write  data in DB
   edm::Service<cond::service::PoolDBOutputService> dbservice;
-  if( dbservice.isAvailable() ){
-
-    if(obj==nullptr){
-      edm::LogError("SiStripFedCablingManipulator")<<"null pointer obj. nothing will be written "<<std::endl;
+  if (dbservice.isAvailable()) {
+    if (obj == nullptr) {
+      edm::LogError("SiStripFedCablingManipulator") << "null pointer obj. nothing will be written " << std::endl;
       return;
     }
 
-    std::string openIovAt=iConfig_.getUntrackedParameter<std::string>("OpenIovAt","beginOfTime");
-    if(openIovAt=="beginOfTime")
-      Time_=dbservice->beginOfTime();
-    else if (openIovAt=="currentTime")
+    std::string openIovAt = iConfig_.getUntrackedParameter<std::string>("OpenIovAt", "beginOfTime");
+    if (openIovAt == "beginOfTime")
+      Time_ = dbservice->beginOfTime();
+    else if (openIovAt == "currentTime")
       dbservice->currentTime();
     else
-      Time_=iConfig_.getUntrackedParameter<uint32_t>("OpenIovAtTime",1);
-    
+      Time_ = iConfig_.getUntrackedParameter<uint32_t>("OpenIovAtTime", 1);
+
     //if first time tag is populated
-    if( dbservice->isNewTagRequest("SiStripFedCablingRcd")){
-      edm::LogInfo("SiStripFedCablingManipulator") << "first request for storing objects with Record "<< "SiStripFedCablingRcd" << " at time " << Time_ << std::endl;
-      dbservice->createNewIOV<SiStripFedCabling>(obj, Time_ ,dbservice->endOfTime(), "SiStripFedCablingRcd");      
+    if (dbservice->isNewTagRequest("SiStripFedCablingRcd")) {
+      edm::LogInfo("SiStripFedCablingManipulator") << "first request for storing objects with Record "
+                                                   << "SiStripFedCablingRcd"
+                                                   << " at time " << Time_ << std::endl;
+      dbservice->createNewIOV<SiStripFedCabling>(obj, Time_, dbservice->endOfTime(), "SiStripFedCablingRcd");
     } else {
-      edm::LogInfo("SiStripFedCablingManipulator") << "appending a new object to existing tag " <<"SiStripFedCablingRcd" <<" in since mode " << std::endl;
-      dbservice->appendSinceTime<SiStripFedCabling>(obj, Time_, "SiStripFedCablingRcd"); 
-    }    
-  } else{
-    edm::LogError("SiStripFedCablingManipulator")<<"Service is unavailable"<<std::endl;
+      edm::LogInfo("SiStripFedCablingManipulator") << "appending a new object to existing tag "
+                                                   << "SiStripFedCablingRcd"
+                                                   << " in since mode " << std::endl;
+      dbservice->appendSinceTime<SiStripFedCabling>(obj, Time_, "SiStripFedCablingRcd");
+    }
+  } else {
+    edm::LogError("SiStripFedCablingManipulator") << "Service is unavailable" << std::endl;
   }
 }
 
-void SiStripFedCablingManipulator::manipulate(const SiStripFedCabling* iobj,SiStripFedCabling*& oobj){
-  std::string fp=iConfig_.getParameter<std::string>("file");
-   
+void SiStripFedCablingManipulator::manipulate(const SiStripFedCabling* iobj, SiStripFedCabling*& oobj) {
+  std::string fp = iConfig_.getParameter<std::string>("file");
 
-  std::ifstream inputFile_; 
+  std::ifstream inputFile_;
   inputFile_.open(fp.c_str());
-  
-  std::map<uint32_t, std::pair<uint32_t, uint32_t> > dcuDetIdMap;
-  uint32_t dcuid, Olddetid, Newdetid; 
-  
-  // if(fp.c_str()==""){
-  if(fp.empty()){
-    edm::LogInfo("SiStripFedCablingManipulator") << "::manipulate : since no file is specified, the copy of the input cabling will be applied"<< std::endl;
-    oobj= new SiStripFedCabling(*iobj);
 
-  } else if (!inputFile_.is_open()){
+  std::map<uint32_t, std::pair<uint32_t, uint32_t> > dcuDetIdMap;
+  uint32_t dcuid, Olddetid, Newdetid;
+
+  // if(fp.c_str()==""){
+  if (fp.empty()) {
+    edm::LogInfo("SiStripFedCablingManipulator")
+        << "::manipulate : since no file is specified, the copy of the input cabling will be applied" << std::endl;
+    oobj = new SiStripFedCabling(*iobj);
+
+  } else if (!inputFile_.is_open()) {
     edm::LogError("SiStripFedCablingManipulator") << "::manipulate - ERROR in opening file  " << fp << std::endl;
-    throw cms::Exception("CorruptedData")  << "::manipulate - ERROR in opening file  " << fp << std::endl;
-  }else{
-    
-    for(;;) {
+    throw cms::Exception("CorruptedData") << "::manipulate - ERROR in opening file  " << fp << std::endl;
+  } else {
+    for (;;) {
       inputFile_ >> dcuid >> Olddetid >> Newdetid;
 
-      if (!(inputFile_.eof() || inputFile_.fail())){
-	
-	if(dcuDetIdMap.find(dcuid)==dcuDetIdMap.end()){
-	  
-	  edm::LogInfo("SiStripFedCablingManipulator") << dcuid << " " << Olddetid << " " << Newdetid << std::endl;
-	  
-	  dcuDetIdMap[dcuid]=std::pair<uint32_t, uint32_t>(Olddetid,Newdetid);
-	}else{
-	  edm::LogError("SiStripFedCablingManipulator") << "::manipulate - ERROR duplicated dcuid " << dcuid <<std::endl;     
-	  throw cms::Exception("CorruptedData") << "SiStripFedCablingManipulator::manipulate - ERROR duplicated dcuid " << dcuid ;
-	  break;
-	}
-      }else if (inputFile_.eof()){
-	edm::LogInfo("SiStripFedCablingManipulator")<< "::manipulate - END of file reached"<<std::endl;
-	break;
-      }else if (inputFile_.fail()) {
-	edm::LogError("SiStripFedCablingManipulator")<<"::manipulate - ERROR while reading file"<<std::endl;     
-	break;
+      if (!(inputFile_.eof() || inputFile_.fail())) {
+        if (dcuDetIdMap.find(dcuid) == dcuDetIdMap.end()) {
+          edm::LogInfo("SiStripFedCablingManipulator") << dcuid << " " << Olddetid << " " << Newdetid << std::endl;
+
+          dcuDetIdMap[dcuid] = std::pair<uint32_t, uint32_t>(Olddetid, Newdetid);
+        } else {
+          edm::LogError("SiStripFedCablingManipulator")
+              << "::manipulate - ERROR duplicated dcuid " << dcuid << std::endl;
+          throw cms::Exception("CorruptedData")
+              << "SiStripFedCablingManipulator::manipulate - ERROR duplicated dcuid " << dcuid;
+          break;
+        }
+      } else if (inputFile_.eof()) {
+        edm::LogInfo("SiStripFedCablingManipulator") << "::manipulate - END of file reached" << std::endl;
+        break;
+      } else if (inputFile_.fail()) {
+        edm::LogError("SiStripFedCablingManipulator") << "::manipulate - ERROR while reading file" << std::endl;
+        break;
       }
     }
     inputFile_.close();
-    std::map<uint32_t, std::pair<uint32_t, uint32_t> >::const_iterator it=dcuDetIdMap.begin();
-    for (;it!=dcuDetIdMap.end();++it)
-      edm::LogInfo("SiStripFedCablingManipulator")<< "::manipulate - Map "<< it->first << " " << it->second.first << " " << it->second.second;
-   
+    std::map<uint32_t, std::pair<uint32_t, uint32_t> >::const_iterator it = dcuDetIdMap.begin();
+    for (; it != dcuDetIdMap.end(); ++it)
+      edm::LogInfo("SiStripFedCablingManipulator")
+          << "::manipulate - Map " << it->first << " " << it->second.first << " " << it->second.second;
 
     std::vector<FedChannelConnection> conns;
-  
-    auto feds=iobj->fedIds();
-    for(auto ifeds=feds.begin();ifeds!=feds.end();ifeds++){
-      auto conns_per_fed =iobj->fedConnections( *ifeds );
-      for(auto iconn=conns_per_fed.begin();iconn!=conns_per_fed.end();++iconn){
-	std::map<uint32_t, std::pair<uint32_t, uint32_t> >::const_iterator it=dcuDetIdMap.find(iconn->dcuId());
-	if(it!=dcuDetIdMap.end() && it->second.first==iconn->detId()){
-	  edm::LogInfo("SiStripFedCablingManipulator")<< "::manipulate - fedid "<< *ifeds << " dcuid " <<  iconn->dcuId() << " oldDet " << iconn->detId() << " newDetID " << it->second.second ;
-	  conns.push_back(FedChannelConnection( 
-					       iconn->fecCrate(),
-					       iconn->fecSlot(),
-					       iconn->fecRing(),
-					       iconn->ccuAddr(),
-					       iconn->ccuChan(),
-					       iconn->i2cAddr(0),
-					       iconn->i2cAddr(1),
-					       iconn->dcuId(),
-					       it->second.second,  //<------ New detid
-					       iconn->nApvPairs(),
-					       iconn->fedId(),
-					       iconn->fedCh(),
-					       iconn->fiberLength(),
-					       iconn->dcu(),
-					       iconn->pll(),
-					       iconn->mux(),
-					       iconn->lld()
-					       )
-			  );
-	}else{
-	  conns.push_back(FedChannelConnection( 
-					       iconn->fecCrate(),
-					       iconn->fecSlot(),
-					       iconn->fecRing(),
-					       iconn->ccuAddr(),
-					       iconn->ccuChan(),
-					       iconn->i2cAddr(0),
-					       iconn->i2cAddr(1),
-					       iconn->dcuId(),
-					       iconn->detId(),
-					       iconn->nApvPairs(),
-					       iconn->fedId(),
-					       iconn->fedCh(),
-					       iconn->fiberLength(),
-					       iconn->dcu(),
-					       iconn->pll(),
-					       iconn->mux(),
-					       iconn->lld()
-					       )
-			  );
-	}
+
+    auto feds = iobj->fedIds();
+    for (auto ifeds = feds.begin(); ifeds != feds.end(); ifeds++) {
+      auto conns_per_fed = iobj->fedConnections(*ifeds);
+      for (auto iconn = conns_per_fed.begin(); iconn != conns_per_fed.end(); ++iconn) {
+        std::map<uint32_t, std::pair<uint32_t, uint32_t> >::const_iterator it = dcuDetIdMap.find(iconn->dcuId());
+        if (it != dcuDetIdMap.end() && it->second.first == iconn->detId()) {
+          edm::LogInfo("SiStripFedCablingManipulator")
+              << "::manipulate - fedid " << *ifeds << " dcuid " << iconn->dcuId() << " oldDet " << iconn->detId()
+              << " newDetID " << it->second.second;
+          conns.push_back(FedChannelConnection(iconn->fecCrate(),
+                                               iconn->fecSlot(),
+                                               iconn->fecRing(),
+                                               iconn->ccuAddr(),
+                                               iconn->ccuChan(),
+                                               iconn->i2cAddr(0),
+                                               iconn->i2cAddr(1),
+                                               iconn->dcuId(),
+                                               it->second.second,  //<------ New detid
+                                               iconn->nApvPairs(),
+                                               iconn->fedId(),
+                                               iconn->fedCh(),
+                                               iconn->fiberLength(),
+                                               iconn->dcu(),
+                                               iconn->pll(),
+                                               iconn->mux(),
+                                               iconn->lld()));
+        } else {
+          conns.push_back(FedChannelConnection(iconn->fecCrate(),
+                                               iconn->fecSlot(),
+                                               iconn->fecRing(),
+                                               iconn->ccuAddr(),
+                                               iconn->ccuChan(),
+                                               iconn->i2cAddr(0),
+                                               iconn->i2cAddr(1),
+                                               iconn->dcuId(),
+                                               iconn->detId(),
+                                               iconn->nApvPairs(),
+                                               iconn->fedId(),
+                                               iconn->fedCh(),
+                                               iconn->fiberLength(),
+                                               iconn->dcu(),
+                                               iconn->pll(),
+                                               iconn->mux(),
+                                               iconn->lld()));
+        }
       }
     }
-    
-    oobj = new SiStripFedCabling( conns );
 
-  }  
+    oobj = new SiStripFedCabling(conns);
+  }
 }

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.h
@@ -16,18 +16,15 @@
 class SiStripFedCabling;
 
 class SiStripFedCablingManipulator : public edm::EDAnalyzer {
-
 public:
-
   explicit SiStripFedCablingManipulator(const edm::ParameterSet& iConfig);
   ~SiStripFedCablingManipulator() override;
-  void analyze(const edm::Event& e, const edm::EventSetup&es) override{};
+  void analyze(const edm::Event& e, const edm::EventSetup& es) override{};
 
-  void endRun(const edm::Run & run, const edm::EventSetup & es) override;
+  void endRun(const edm::Run& run, const edm::EventSetup& es) override;
 
- private:
-
-  void manipulate(const SiStripFedCabling*,SiStripFedCabling*&);
+private:
+  void manipulate(const SiStripFedCabling*, SiStripFedCabling*&);
 
   edm::ParameterSet iConfig_;
 };

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/modules.cc
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/modules.cc
@@ -2,8 +2,6 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/SourceFactory.h"
 
-
-
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 
 //-----------------------------------------------------------------------------------------
@@ -15,71 +13,67 @@ DEFINE_FWK_MODULE(SiStripFedCablingManipulator);
 #include "CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h"
 
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
-typedef DummyCondDBWriter<SiStripFedCabling,SiStripFedCabling,SiStripFedCablingRcd> SiStripFedCablingDummyDBWriter;
+typedef DummyCondDBWriter<SiStripFedCabling, SiStripFedCabling, SiStripFedCablingRcd> SiStripFedCablingDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripFedCablingDummyDBWriter);
 
-
 #include "CondFormats/SiStripObjects/interface/SiStripPedestals.h"
-typedef DummyCondDBWriter<SiStripPedestals,SiStripPedestals,SiStripPedestalsRcd> SiStripPedestalsDummyDBWriter;
+typedef DummyCondDBWriter<SiStripPedestals, SiStripPedestals, SiStripPedestalsRcd> SiStripPedestalsDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripPedestalsDummyDBWriter);
 
-
 #include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
-typedef DummyCondDBWriter<SiStripNoises,SiStripNoises,SiStripNoisesRcd> SiStripNoisesDummyDBWriter;
+typedef DummyCondDBWriter<SiStripNoises, SiStripNoises, SiStripNoisesRcd> SiStripNoisesDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripNoisesDummyDBWriter);
 
-
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
-typedef DummyCondDBWriter<SiStripApvGain,SiStripApvGain,SiStripApvGainRcd> SiStripApvGainDummyDBWriter;
+typedef DummyCondDBWriter<SiStripApvGain, SiStripApvGain, SiStripApvGainRcd> SiStripApvGainDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripApvGainDummyDBWriter);
 
-
 #include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
-typedef DummyCondDBWriter<SiStripLorentzAngle,SiStripLorentzAngle,SiStripLorentzAngleRcd> SiStripLorentzAngleDummyDBWriter;
+typedef DummyCondDBWriter<SiStripLorentzAngle, SiStripLorentzAngle, SiStripLorentzAngleRcd>
+    SiStripLorentzAngleDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripLorentzAngleDummyDBWriter);
 
 #include "CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h"
-typedef DummyCondDBWriter<SiStripBackPlaneCorrection,SiStripBackPlaneCorrection,SiStripBackPlaneCorrectionRcd> SiStripBackPlaneCorrectionDummyDBWriter;
+typedef DummyCondDBWriter<SiStripBackPlaneCorrection, SiStripBackPlaneCorrection, SiStripBackPlaneCorrectionRcd>
+    SiStripBackPlaneCorrectionDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripBackPlaneCorrectionDummyDBWriter);
 
-
 #include "CondFormats/SiStripObjects/interface/SiStripThreshold.h"
-typedef DummyCondDBWriter<SiStripThreshold,SiStripThreshold,SiStripThresholdRcd> SiStripThresholdDummyDBWriter;
+typedef DummyCondDBWriter<SiStripThreshold, SiStripThreshold, SiStripThresholdRcd> SiStripThresholdDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripThresholdDummyDBWriter);
 
-
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
-typedef DummyCondDBWriter<SiStripBadStrip,SiStripBadStrip,SiStripBadStripRcd> SiStripBadStripDummyDBWriter;
+typedef DummyCondDBWriter<SiStripBadStrip, SiStripBadStrip, SiStripBadStripRcd> SiStripBadStripDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripBadStripDummyDBWriter);
 
-typedef DummyCondDBWriter<SiStripBadStrip,SiStripBadStrip,SiStripBadModuleRcd> SiStripBadModuleDummyDBWriter;
+typedef DummyCondDBWriter<SiStripBadStrip, SiStripBadStrip, SiStripBadModuleRcd> SiStripBadModuleDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripBadModuleDummyDBWriter);
 
-typedef DummyCondDBWriter<SiStripBadStrip,SiStripBadStrip,SiStripBadFiberRcd> SiStripBadFiberDummyDBWriter;
+typedef DummyCondDBWriter<SiStripBadStrip, SiStripBadStrip, SiStripBadFiberRcd> SiStripBadFiberDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripBadFiberDummyDBWriter);
 
-typedef DummyCondDBWriter<SiStripBadStrip,SiStripBadStrip,SiStripBadChannelRcd> SiStripBadChannelDummyDBWriter;
+typedef DummyCondDBWriter<SiStripBadStrip, SiStripBadStrip, SiStripBadChannelRcd> SiStripBadChannelDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripBadChannelDummyDBWriter);
 
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
-typedef DummyCondDBWriter<SiStripQuality,SiStripBadStrip,SiStripQualityRcd> SiStripBadStripFromQualityDummyDBWriter;
+typedef DummyCondDBWriter<SiStripQuality, SiStripBadStrip, SiStripQualityRcd> SiStripBadStripFromQualityDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripBadStripFromQualityDummyDBWriter);
 
 #include "CondFormats/SiStripObjects/interface/SiStripDetVOff.h"
-typedef DummyCondDBWriter<SiStripDetVOff,SiStripDetVOff,SiStripDetVOffRcd> SiStripDetVOffDummyDBWriter;
+typedef DummyCondDBWriter<SiStripDetVOff, SiStripDetVOff, SiStripDetVOffRcd> SiStripDetVOffDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripDetVOffDummyDBWriter);
 
 #include "CondFormats/SiStripObjects/interface/SiStripLatency.h"
-typedef DummyCondDBWriter<SiStripLatency,SiStripLatency,SiStripLatencyRcd> SiStripLatencyDummyDBWriter;
+typedef DummyCondDBWriter<SiStripLatency, SiStripLatency, SiStripLatencyRcd> SiStripLatencyDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripLatencyDummyDBWriter);
 
 #include "CondFormats/SiStripObjects/interface/SiStripBaseDelay.h"
-typedef DummyCondDBWriter<SiStripBaseDelay,SiStripBaseDelay,SiStripBaseDelayRcd> SiStripBaseDelayDummyDBWriter;
+typedef DummyCondDBWriter<SiStripBaseDelay, SiStripBaseDelay, SiStripBaseDelayRcd> SiStripBaseDelayDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripBaseDelayDummyDBWriter);
 
 #include "CondFormats/SiStripObjects/interface/SiStripConfObject.h"
-typedef DummyCondDBWriter<SiStripConfObject,SiStripConfObject, SiStripConfObjectRcd> SiStripConfObjectDummyDBWriter;
+typedef DummyCondDBWriter<SiStripConfObject, SiStripConfObject, SiStripConfObjectRcd> SiStripConfObjectDummyDBWriter;
 DEFINE_FWK_MODULE(SiStripConfObjectDummyDBWriter);
 
 //---------------------------------------------------------------------------------------------------------------
@@ -87,76 +81,78 @@ DEFINE_FWK_MODULE(SiStripConfObjectDummyDBWriter);
 
 #include "CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondObjPrinter.h"
 
-typedef DummyCondObjPrinter<SiStripNoises,SiStripNoisesRcd> SiStripNoises_DecModeDummyPrinter;
+typedef DummyCondObjPrinter<SiStripNoises, SiStripNoisesRcd> SiStripNoises_DecModeDummyPrinter;
 DEFINE_FWK_MODULE(SiStripNoises_DecModeDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripNoises,SiStripNoisesRcd> SiStripNoises_PeakModeDummyPrinter;
+typedef DummyCondObjPrinter<SiStripNoises, SiStripNoisesRcd> SiStripNoises_PeakModeDummyPrinter;
 DEFINE_FWK_MODULE(SiStripNoises_PeakModeDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripThreshold,SiStripThresholdRcd> SiStripThresholdDummyPrinter;
+typedef DummyCondObjPrinter<SiStripThreshold, SiStripThresholdRcd> SiStripThresholdDummyPrinter;
 DEFINE_FWK_MODULE(SiStripThresholdDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripThreshold,SiStripThresholdRcd> SiStripClusterThresholdDummyPrinter;
+typedef DummyCondObjPrinter<SiStripThreshold, SiStripThresholdRcd> SiStripClusterThresholdDummyPrinter;
 DEFINE_FWK_MODULE(SiStripClusterThresholdDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripLorentzAngle,SiStripLorentzAngleRcd> SiStripLorentzAngleDummyPrinter;
+typedef DummyCondObjPrinter<SiStripLorentzAngle, SiStripLorentzAngleRcd> SiStripLorentzAngleDummyPrinter;
 DEFINE_FWK_MODULE(SiStripLorentzAngleDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripBackPlaneCorrection,SiStripBackPlaneCorrectionRcd> SiStripBackPlaneCorrectionDummyPrinter;
+typedef DummyCondObjPrinter<SiStripBackPlaneCorrection, SiStripBackPlaneCorrectionRcd>
+    SiStripBackPlaneCorrectionDummyPrinter;
 DEFINE_FWK_MODULE(SiStripBackPlaneCorrectionDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripPedestals,SiStripPedestalsRcd> SiStripPedestalsDummyPrinter;
+typedef DummyCondObjPrinter<SiStripPedestals, SiStripPedestalsRcd> SiStripPedestalsDummyPrinter;
 DEFINE_FWK_MODULE(SiStripPedestalsDummyPrinter);
 
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
-typedef DummyCondObjPrinter<SiStripApvGain,SiStripApvGainRcd> SiStripApvGainDummyPrinter;
+typedef DummyCondObjPrinter<SiStripApvGain, SiStripApvGainRcd> SiStripApvGainDummyPrinter;
 DEFINE_FWK_MODULE(SiStripApvGainDummyPrinter);
 
 #include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
-typedef DummyCondObjPrinter<SiStripGain,SiStripGainRcd> SiStripGainDummyPrinter;
+typedef DummyCondObjPrinter<SiStripGain, SiStripGainRcd> SiStripGainDummyPrinter;
 DEFINE_FWK_MODULE(SiStripGainDummyPrinter);
 
 #include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
-typedef DummyCondObjPrinter<SiStripGain,SiStripGainSimRcd> SiStripGainSimDummyPrinter;
+typedef DummyCondObjPrinter<SiStripGain, SiStripGainSimRcd> SiStripGainSimDummyPrinter;
 DEFINE_FWK_MODULE(SiStripGainSimDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripDetVOff,SiStripDetVOffRcd> SiStripDetVOffDummyPrinter;
+typedef DummyCondObjPrinter<SiStripDetVOff, SiStripDetVOffRcd> SiStripDetVOffDummyPrinter;
 DEFINE_FWK_MODULE(SiStripDetVOffDummyPrinter);
 
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
-typedef DummyCondObjPrinter<SiStripDetCabling,SiStripDetCablingRcd> SiStripDetCablingDummyPrinter;
+typedef DummyCondObjPrinter<SiStripDetCabling, SiStripDetCablingRcd> SiStripDetCablingDummyPrinter;
 DEFINE_FWK_MODULE(SiStripDetCablingDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripFedCabling,SiStripFedCablingRcd> SiStripFedCablingDummyPrinter;
+typedef DummyCondObjPrinter<SiStripFedCabling, SiStripFedCablingRcd> SiStripFedCablingDummyPrinter;
 DEFINE_FWK_MODULE(SiStripFedCablingDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripBadStrip,SiStripBadStripRcd> SiStripBadStripDummyPrinter;
+typedef DummyCondObjPrinter<SiStripBadStrip, SiStripBadStripRcd> SiStripBadStripDummyPrinter;
 DEFINE_FWK_MODULE(SiStripBadStripDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripBadStrip,SiStripBadModuleRcd> SiStripBadModuleDummyPrinter;
+typedef DummyCondObjPrinter<SiStripBadStrip, SiStripBadModuleRcd> SiStripBadModuleDummyPrinter;
 DEFINE_FWK_MODULE(SiStripBadModuleDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripBadStrip,SiStripBadFiberRcd> SiStripBadFiberDummyPrinter;
+typedef DummyCondObjPrinter<SiStripBadStrip, SiStripBadFiberRcd> SiStripBadFiberDummyPrinter;
 DEFINE_FWK_MODULE(SiStripBadFiberDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripBadStrip,SiStripBadChannelRcd> SiStripBadChannelDummyPrinter;
+typedef DummyCondObjPrinter<SiStripBadStrip, SiStripBadChannelRcd> SiStripBadChannelDummyPrinter;
 DEFINE_FWK_MODULE(SiStripBadChannelDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripLatency,SiStripLatencyRcd> SiStripLatencyDummyPrinter;
+typedef DummyCondObjPrinter<SiStripLatency, SiStripLatencyRcd> SiStripLatencyDummyPrinter;
 DEFINE_FWK_MODULE(SiStripLatencyDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripBaseDelay,SiStripBaseDelayRcd> SiStripBaseDelayDummyPrinter;
+typedef DummyCondObjPrinter<SiStripBaseDelay, SiStripBaseDelayRcd> SiStripBaseDelayDummyPrinter;
 DEFINE_FWK_MODULE(SiStripBaseDelayDummyPrinter);
 
 #include "CalibFormats/SiStripObjects/interface/SiStripDelay.h"
-typedef DummyCondObjPrinter<SiStripDelay,SiStripDelayRcd> SiStripDelayDummyPrinter;
+typedef DummyCondObjPrinter<SiStripDelay, SiStripDelayRcd> SiStripDelayDummyPrinter;
 DEFINE_FWK_MODULE(SiStripDelayDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripLorentzAngle,SiStripLorentzAngleDepRcd> SiStripLorentzAngleDepDummyPrinter;
+typedef DummyCondObjPrinter<SiStripLorentzAngle, SiStripLorentzAngleDepRcd> SiStripLorentzAngleDepDummyPrinter;
 DEFINE_FWK_MODULE(SiStripLorentzAngleDepDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripBackPlaneCorrection,SiStripBackPlaneCorrectionDepRcd> SiStripBackPlaneCorrectionDepDummyPrinter;
+typedef DummyCondObjPrinter<SiStripBackPlaneCorrection, SiStripBackPlaneCorrectionDepRcd>
+    SiStripBackPlaneCorrectionDepDummyPrinter;
 DEFINE_FWK_MODULE(SiStripBackPlaneCorrectionDepDummyPrinter);
 
-typedef DummyCondObjPrinter<SiStripConfObject,SiStripConfObjectRcd> SiStripConfObjectDummyPrinter;
+typedef DummyCondObjPrinter<SiStripConfObject, SiStripConfObjectRcd> SiStripConfObjectDummyPrinter;
 DEFINE_FWK_MODULE(SiStripConfObjectDummyPrinter);

--- a/CalibTracker/SiStripESProducers/plugins/fake/Phase2TrackerCablingCfgESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/Phase2TrackerCablingCfgESSource.cc
@@ -12,49 +12,44 @@
 
 // -----------------------------------------------------------------------------
 //
-Phase2TrackerCablingCfgESSource::Phase2TrackerCablingCfgESSource( const edm::ParameterSet& pset )
-  : Phase2TrackerCablingESProducer( pset ), pset_(pset)
-{
+Phase2TrackerCablingCfgESSource::Phase2TrackerCablingCfgESSource(const edm::ParameterSet& pset)
+    : Phase2TrackerCablingESProducer(pset), pset_(pset) {
   findingRecord<Phase2TrackerCablingRcd>();
-  edm::LogVerbatim("Phase2TrackerCabling") 
-    << "[Phase2TrackerCablingCfgESSource::" << __func__ << "]"
-    << " Constructing object...";
+  edm::LogVerbatim("Phase2TrackerCabling") << "[Phase2TrackerCablingCfgESSource::" << __func__ << "]"
+                                           << " Constructing object...";
 }
 
 // -----------------------------------------------------------------------------
 //
 Phase2TrackerCablingCfgESSource::~Phase2TrackerCablingCfgESSource() {
-  edm::LogVerbatim("Phase2TrackerCabling")
-    << "[Phase2TrackerCablingCfgESSource::" << __func__ << "]"
-    << " Destructing object...";
+  edm::LogVerbatim("Phase2TrackerCabling") << "[Phase2TrackerCablingCfgESSource::" << __func__ << "]"
+                                           << " Destructing object...";
 }
 
 // -----------------------------------------------------------------------------
-// 
-Phase2TrackerCabling* Phase2TrackerCablingCfgESSource::make( const Phase2TrackerCablingRcd& ) {
-  edm::LogVerbatim("Phase2TrackerCabling")
-    << "[Phase2TrackerCablingCfgESSource::" << __func__ << "]"
-    << " Building FED cabling map from cfg.";
-  
+//
+Phase2TrackerCabling* Phase2TrackerCablingCfgESSource::make(const Phase2TrackerCablingRcd&) {
+  edm::LogVerbatim("Phase2TrackerCabling") << "[Phase2TrackerCablingCfgESSource::" << __func__ << "]"
+                                           << " Building FED cabling map from cfg.";
+
   std::vector<Phase2TrackerModule> conns;
 
   // iterate through the parameterset and create corresponding Phase2TrackerModule
   std::vector<edm::ParameterSet> modules = pset_.getParameterSetVector("modules");
-  uint32_t detid,gbtid,fedid,fedch,powerGroup,coolingLoop;
-  for(std::vector<edm::ParameterSet>::const_iterator it = modules.begin();it<modules.end();++it) {
-     detid = it->getParameter<uint32_t>("detid");
-     gbtid = it->getParameter<uint32_t>("gbtid");
-     fedid = it->getParameter<uint32_t>("fedid");
-     fedch = it->getParameter<uint32_t>("fedch");
-     powerGroup = it->getParameter<uint32_t>("powerGroup");
-     coolingLoop = it->getParameter<uint32_t>("coolingLoop");
-     Phase2TrackerModule::ModuleTypes type = it->getParameter<std::string>("moduleType")=="2S" ? Phase2TrackerModule::SS : Phase2TrackerModule::PS;
-     conns.push_back(Phase2TrackerModule(type,detid,gbtid,fedid,fedch,powerGroup,coolingLoop));
+  uint32_t detid, gbtid, fedid, fedch, powerGroup, coolingLoop;
+  for (std::vector<edm::ParameterSet>::const_iterator it = modules.begin(); it < modules.end(); ++it) {
+    detid = it->getParameter<uint32_t>("detid");
+    gbtid = it->getParameter<uint32_t>("gbtid");
+    fedid = it->getParameter<uint32_t>("fedid");
+    fedch = it->getParameter<uint32_t>("fedch");
+    powerGroup = it->getParameter<uint32_t>("powerGroup");
+    coolingLoop = it->getParameter<uint32_t>("coolingLoop");
+    Phase2TrackerModule::ModuleTypes type =
+        it->getParameter<std::string>("moduleType") == "2S" ? Phase2TrackerModule::SS : Phase2TrackerModule::PS;
+    conns.push_back(Phase2TrackerModule(type, detid, gbtid, fedid, fedch, powerGroup, coolingLoop));
   }
-  
-  // return the cabling 
-  Phase2TrackerCabling* cabling = new Phase2TrackerCabling( conns );
-  return cabling;
-  
-}
 
+  // return the cabling
+  Phase2TrackerCabling* cabling = new Phase2TrackerCabling(conns);
+  return cabling;
+}

--- a/CalibTracker/SiStripESProducers/plugins/fake/Phase2TrackerCablingCfgESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/Phase2TrackerCablingCfgESSource.h
@@ -8,31 +8,26 @@
 class Phase2TrackerCabling;
 class Phase2TrackerCablingRcd;
 
-class Phase2TrackerCablingCfgESSource : public Phase2TrackerCablingESProducer, public edm::EventSetupRecordIntervalFinder {
-  
- public:
-  
-  explicit Phase2TrackerCablingCfgESSource( const edm::ParameterSet& );
+class Phase2TrackerCablingCfgESSource : public Phase2TrackerCablingESProducer,
+                                        public edm::EventSetupRecordIntervalFinder {
+public:
+  explicit Phase2TrackerCablingCfgESSource(const edm::ParameterSet&);
   ~Phase2TrackerCablingCfgESSource() override;
-  
- protected:
-  
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey& key,
-			       const edm::IOVSyncValue& iov_sync,
-			       edm::ValidityInterval& iov_validity ) override {
-    edm::ValidityInterval infinity( iov_sync.beginOfTime(), iov_sync.endOfTime() );
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey& key,
+                      const edm::IOVSyncValue& iov_sync,
+                      edm::ValidityInterval& iov_validity) override {
+    edm::ValidityInterval infinity(iov_sync.beginOfTime(), iov_sync.endOfTime());
     iov_validity = infinity;
   }
 
- private:
-  
+private:
   // Builds cabling map based on the ParameterSet
-  Phase2TrackerCabling* make( const Phase2TrackerCablingRcd& ) override; 
+  Phase2TrackerCabling* make(const Phase2TrackerCablingRcd&) override;
 
   // The configuration used to generated the cabling record
   edm::ParameterSet pset_;
 };
 
-#endif // CalibTracker_SiStripESProducers_Phase2TrackerCablingCfgESSource_H
-
-
+#endif  // CalibTracker_SiStripESProducers_Phase2TrackerCablingCfgESSource_H

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripConfObjectFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripConfObjectFakeESSource.cc
@@ -27,7 +27,9 @@ public:
   SiStripConfObjectFakeESSource(const edm::ParameterSet&);
   ~SiStripConfObjectFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                      const edm::IOVSyncValue& iov,
+                      edm::ValidityInterval& iValidity) override;
 
   typedef std::unique_ptr<SiStripConfObject> ReturnType;
   ReturnType produce(const SiStripConfObjectRcd&);
@@ -38,8 +40,7 @@ private:
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-SiStripConfObjectFakeESSource::SiStripConfObjectFakeESSource(const edm::ParameterSet& iConfig)
-{
+SiStripConfObjectFakeESSource::SiStripConfObjectFakeESSource(const edm::ParameterSet& iConfig) {
   setWhatProduced(this);
   findingRecord<SiStripConfObjectRcd>();
 
@@ -48,39 +49,33 @@ SiStripConfObjectFakeESSource::SiStripConfObjectFakeESSource(const edm::Paramete
 
 SiStripConfObjectFakeESSource::~SiStripConfObjectFakeESSource() {}
 
-void SiStripConfObjectFakeESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity )
-{
+void SiStripConfObjectFakeESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                   const edm::IOVSyncValue& iov,
+                                                   edm::ValidityInterval& iValidity) {
   iValidity = edm::ValidityInterval{iov.beginOfTime(), iov.endOfTime()};
 }
 
 // ------------ method called to produce the data  ------------
-SiStripConfObjectFakeESSource::ReturnType
-SiStripConfObjectFakeESSource::produce(const SiStripConfObjectRcd& iRecord)
-{
+SiStripConfObjectFakeESSource::ReturnType SiStripConfObjectFakeESSource::produce(const SiStripConfObjectRcd& iRecord) {
   using namespace edm::es;
 
   auto confObject = std::make_unique<SiStripConfObject>();
 
-  for ( const auto& param : m_parameters ) {
+  for (const auto& param : m_parameters) {
     const std::string paramType{param.getParameter<std::string>("ParameterType")};
     const std::string paramName{param.getParameter<std::string>("ParameterName")};
-    if( paramType == "int" ) {
+    if (paramType == "int") {
       confObject->put(paramName, param.getParameter<int32_t>("ParameterValue"));
-    }
-    else if( paramType == "double" ) {
+    } else if (paramType == "double") {
       confObject->put(paramName, param.getParameter<double>("ParameterValue"));
-    }
-    else if( paramType == "string" ) {
+    } else if (paramType == "string") {
       confObject->put(paramName, param.getParameter<std::string>("ParameterValue"));
-    }
-    else if( paramType == "bool" ) {
+    } else if (paramType == "bool") {
       confObject->put(paramName, param.getParameter<bool>("ParameterValue"));
-    }
-    else if( paramType == "vint32" ) {
-      confObject->put(paramName, param.getParameter<std::vector<int> >("ParameterValue"));
-    }
-    else if( paramType == "vstring" ) {
-      confObject->put(paramName, param.getParameter<std::vector<std::string> >("ParameterValue"));
+    } else if (paramType == "vint32") {
+      confObject->put(paramName, param.getParameter<std::vector<int>>("ParameterValue"));
+    } else if (paramType == "vstring") {
+      confObject->put(paramName, param.getParameter<std::vector<std::string>>("ParameterValue"));
     }
   }
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripFakeAPVParameters.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripFakeAPVParameters.h
@@ -8,34 +8,33 @@
  */
 class SiStripFakeAPVParameters {
 public:
-  using index = std::pair<int,int>;
+  using index = std::pair<int, int>;
 
   SiStripFakeAPVParameters() {}
 
   /// Fills the parameters read from cfg and matching the name in the map
-  SiStripFakeAPVParameters(const edm::ParameterSet& pset, const std::string& parameterName)
-  {
+  SiStripFakeAPVParameters(const edm::ParameterSet& pset, const std::string& parameterName) {
     const int layersTIB = 4;
     const int ringsTID = 3;
     const int layersTOB = 6;
     const int ringsTEC = 7;
 
-    fillSubDetParameter(pset.getParameter<std::vector<double>>(parameterName+"TIB"), int(StripSubdetector::TIB), layersTIB );
-    fillSubDetParameter(pset.getParameter<std::vector<double>>(parameterName+"TID"), int(StripSubdetector::TID), ringsTID );
-    fillSubDetParameter(pset.getParameter<std::vector<double>>(parameterName+"TOB"), int(StripSubdetector::TOB), layersTOB );
-    fillSubDetParameter(pset.getParameter<std::vector<double>>(parameterName+"TEC"), int(StripSubdetector::TEC), ringsTEC );
+    fillSubDetParameter(
+        pset.getParameter<std::vector<double>>(parameterName + "TIB"), int(StripSubdetector::TIB), layersTIB);
+    fillSubDetParameter(
+        pset.getParameter<std::vector<double>>(parameterName + "TID"), int(StripSubdetector::TID), ringsTID);
+    fillSubDetParameter(
+        pset.getParameter<std::vector<double>>(parameterName + "TOB"), int(StripSubdetector::TOB), layersTOB);
+    fillSubDetParameter(
+        pset.getParameter<std::vector<double>>(parameterName + "TEC"), int(StripSubdetector::TEC), ringsTEC);
   }
 
-  inline double get(const index& idx) const
-  {
-    return m_data.at(idx.first)[idx.second];
-  }
+  inline double get(const index& idx) const { return m_data.at(idx.first)[idx.second]; }
 
-  static index getIndex(const TrackerTopology* tTopo, DetId id)
-  {
+  static index getIndex(const TrackerTopology* tTopo, DetId id) {
     int layerId{0};
-    const int subId =  StripSubdetector(id).subdetId();
-    switch(subId) {
+    const int subId = StripSubdetector(id).subdetId();
+    switch (subId) {
       case int(StripSubdetector::TIB):
         layerId = tTopo->tibLayer(id) - 1;
         break;
@@ -53,9 +52,10 @@ public:
     }
     return std::make_pair(subId, layerId);
   }
+
 private:
   using LayerParameters = std::vector<double>;
-  using SubdetParameters = std::map<int,LayerParameters>;
+  using SubdetParameters = std::map<int, LayerParameters>;
   SubdetParameters m_data;
 
   /**
@@ -65,17 +65,15 @@ private:
    * The only other possibility is that the number of parameters equals the number of layers, otherwise
    * an exception of type "Configuration" will be thrown.
    */
-  void fillSubDetParameter(const std::vector<double>& v, const int subDet, const unsigned short layers)
-  {
-    if( v.size() == layers ) {
-      m_data.insert(std::make_pair( subDet, v ));
-    }
-    else if( v.size() == 1 ) {
+  void fillSubDetParameter(const std::vector<double>& v, const int subDet, const unsigned short layers) {
+    if (v.size() == layers) {
+      m_data.insert(std::make_pair(subDet, v));
+    } else if (v.size() == 1) {
       LayerParameters parV(layers, v[0]);
-      m_data.insert(std::make_pair( subDet, parV ));
-    }
-    else {
-      throw cms::Exception("Configuration") << "ERROR: number of parameters for subDet " << subDet << " are " << v.size() << ". They must be either 1 or " << layers << std::endl;
+      m_data.insert(std::make_pair(subDet, parV));
+    } else {
+      throw cms::Exception("Configuration") << "ERROR: number of parameters for subDet " << subDet << " are "
+                                            << v.size() << ". They must be either 1 or " << layers << std::endl;
     }
   }
 };

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SiStripQualityFakeESSource
 // Class:      SiStripQualityFakeESSource
-// 
+//
 /**\class SiStripQualityFakeESSource  CalibTracker/SiStripQualityFakeESSource/plugins/fake/SiStripQualityFakeESSource.cc
 
  Description: <one line class summary>
@@ -18,23 +18,18 @@
 
 #include "CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.h"
 
-SiStripQualityFakeESSource::SiStripQualityFakeESSource(const edm::ParameterSet& iConfig)
-{
+SiStripQualityFakeESSource::SiStripQualityFakeESSource(const edm::ParameterSet& iConfig) {
   setWhatProduced(this);
   findingRecord<SiStripQualityRcd>();
 }
 
-
-std::unique_ptr<SiStripQuality> SiStripQualityFakeESSource::produce(const SiStripQualityRcd& iRecord)
-{
+std::unique_ptr<SiStripQuality> SiStripQualityFakeESSource::produce(const SiStripQualityRcd& iRecord) {
   return std::make_unique<SiStripQuality>();
 }
 
-void SiStripQualityFakeESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
-							 const edm::IOVSyncValue& iov,
-							 edm::ValidityInterval& iValidity){
-  edm::ValidityInterval infinity( iov.beginOfTime(), iov.endOfTime() );
+void SiStripQualityFakeESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                const edm::IOVSyncValue& iov,
+                                                edm::ValidityInterval& iValidity) {
+  edm::ValidityInterval infinity(iov.beginOfTime(), iov.endOfTime());
   iValidity = infinity;
 }
-
-

--- a/CalibTracker/SiStripESProducers/src/Phase2TrackerCablingESProducer.cc
+++ b/CalibTracker/SiStripESProducers/src/Phase2TrackerCablingESProducer.cc
@@ -5,8 +5,8 @@
 
 // -----------------------------------------------------------------------------
 //
-Phase2TrackerCablingESProducer::Phase2TrackerCablingESProducer( const edm::ParameterSet& pset ) {
-  setWhatProduced( this, &Phase2TrackerCablingESProducer::produce );
+Phase2TrackerCablingESProducer::Phase2TrackerCablingESProducer(const edm::ParameterSet& pset) {
+  setWhatProduced(this, &Phase2TrackerCablingESProducer::produce);
 }
 
 // -----------------------------------------------------------------------------
@@ -15,17 +15,14 @@ Phase2TrackerCablingESProducer::~Phase2TrackerCablingESProducer() {}
 
 // -----------------------------------------------------------------------------
 //
-std::unique_ptr<Phase2TrackerCabling> Phase2TrackerCablingESProducer::produce( const Phase2TrackerCablingRcd& rcd ) { 
-  
-  Phase2TrackerCabling* temp = make( rcd );
-  
-  if ( !temp ) {
-    edm::LogWarning("Phase2TrackerCabling")
-      << "[Phase2TrackerCablingESProducer::" << __func__ << "]"
-      << " Null pointer to Phase2TrackerCabling object!";
-  }
-  
-  std::unique_ptr<Phase2TrackerCabling> ptr( temp );
-  return ptr;
+std::unique_ptr<Phase2TrackerCabling> Phase2TrackerCablingESProducer::produce(const Phase2TrackerCablingRcd& rcd) {
+  Phase2TrackerCabling* temp = make(rcd);
 
+  if (!temp) {
+    edm::LogWarning("Phase2TrackerCabling") << "[Phase2TrackerCablingESProducer::" << __func__ << "]"
+                                            << " Null pointer to Phase2TrackerCabling object!";
+  }
+
+  std::unique_ptr<Phase2TrackerCabling> ptr(temp);
+  return ptr;
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripFedCablingESProducer.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripFedCablingESProducer.cc
@@ -9,8 +9,8 @@ using namespace sistrip;
 
 // -----------------------------------------------------------------------------
 //
-SiStripFedCablingESProducer::SiStripFedCablingESProducer( const edm::ParameterSet& pset ) {
-  setWhatProduced( this, &SiStripFedCablingESProducer::produce );
+SiStripFedCablingESProducer::SiStripFedCablingESProducer(const edm::ParameterSet& pset) {
+  setWhatProduced(this, &SiStripFedCablingESProducer::produce);
 }
 
 // -----------------------------------------------------------------------------
@@ -19,17 +19,14 @@ SiStripFedCablingESProducer::~SiStripFedCablingESProducer() {}
 
 // -----------------------------------------------------------------------------
 //
-std::unique_ptr<SiStripFedCabling> SiStripFedCablingESProducer::produce( const SiStripFedCablingRcd& rcd ) { 
-  
-  SiStripFedCabling* temp = make( rcd );
-  
-  if ( !temp ) {
-    edm::LogWarning(mlCabling_)
-      << "[SiStripFedCablingESProducer::" << __func__ << "]"
-      << " Null pointer to SiStripFedCabling object!";
-  }
-  
-  std::unique_ptr<SiStripFedCabling> ptr( temp );
-  return ptr;
+std::unique_ptr<SiStripFedCabling> SiStripFedCablingESProducer::produce(const SiStripFedCablingRcd& rcd) {
+  SiStripFedCabling* temp = make(rcd);
 
+  if (!temp) {
+    edm::LogWarning(mlCabling_) << "[SiStripFedCablingESProducer::" << __func__ << "]"
+                                << " Null pointer to SiStripFedCabling object!";
+  }
+
+  std::unique_ptr<SiStripFedCabling> ptr(temp);
+  return ptr;
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripGainESSource.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripGainESSource.cc
@@ -10,35 +10,30 @@ using namespace sistrip;
 
 // -----------------------------------------------------------------------------
 //
-SiStripGainESSource::SiStripGainESSource( const edm::ParameterSet& pset ) {
-  setWhatProduced( this );
+SiStripGainESSource::SiStripGainESSource(const edm::ParameterSet& pset) {
+  setWhatProduced(this);
   findingRecord<SiStripApvGainRcd>();
 }
 
 // -----------------------------------------------------------------------------
 //
-std::unique_ptr<SiStripApvGain> SiStripGainESSource::produce( const SiStripApvGainRcd& ) { 
-  
+std::unique_ptr<SiStripApvGain> SiStripGainESSource::produce(const SiStripApvGainRcd&) {
   SiStripApvGain* gain = makeGain();
-  
-  if ( !gain ) {
-    edm::LogWarning(mlESSources_)
-      << "[SiStripGainESSource::" << __func__ << "]"
-      << " Null pointer to SiStripApvGain object!";
+
+  if (!gain) {
+    edm::LogWarning(mlESSources_) << "[SiStripGainESSource::" << __func__ << "]"
+                                  << " Null pointer to SiStripApvGain object!";
   }
-  
+
   std::unique_ptr<SiStripApvGain> ptr(gain);
   return ptr;
-
 }
 
 // -----------------------------------------------------------------------------
 //
-void SiStripGainESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-					  const edm::IOVSyncValue& iosv, 
-					  edm::ValidityInterval& oValidity ) {
-  
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
+void SiStripGainESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                         const edm::IOVSyncValue& iosv,
+                                         edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
   oValidity = infinity;
-  
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripNoiseESSource.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripNoiseESSource.cc
@@ -9,35 +9,30 @@ using namespace sistrip;
 
 // -----------------------------------------------------------------------------
 //
-SiStripNoiseESSource::SiStripNoiseESSource( const edm::ParameterSet& pset ) {
-  setWhatProduced( this );
+SiStripNoiseESSource::SiStripNoiseESSource(const edm::ParameterSet& pset) {
+  setWhatProduced(this);
   findingRecord<SiStripNoisesRcd>();
 }
 
 // -----------------------------------------------------------------------------
 //
-std::unique_ptr<SiStripNoises> SiStripNoiseESSource::produce( const SiStripNoisesRcd& ) { 
-  
+std::unique_ptr<SiStripNoises> SiStripNoiseESSource::produce(const SiStripNoisesRcd&) {
   SiStripNoises* noise = makeNoise();
-  
-  if ( !noise ) {
-    edm::LogWarning(mlESSources_)
-      << "[SiStripNoiseESSource::" << __func__ << "]"
-      << " Null pointer to SiStripNoises object!";
+
+  if (!noise) {
+    edm::LogWarning(mlESSources_) << "[SiStripNoiseESSource::" << __func__ << "]"
+                                  << " Null pointer to SiStripNoises object!";
   }
-  
+
   std::unique_ptr<SiStripNoises> ptr(noise);
   return ptr;
-
 }
 
 // -----------------------------------------------------------------------------
 //
-void SiStripNoiseESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-					   const edm::IOVSyncValue& iosv, 
-					   edm::ValidityInterval& oValidity ) {
-  
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
+void SiStripNoiseESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                          const edm::IOVSyncValue& iosv,
+                                          edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
   oValidity = infinity;
-  
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripPedestalsESSource.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripPedestalsESSource.cc
@@ -9,35 +9,30 @@ using namespace sistrip;
 
 // -----------------------------------------------------------------------------
 //
-SiStripPedestalsESSource::SiStripPedestalsESSource( const edm::ParameterSet& pset ) {
-  setWhatProduced( this );
+SiStripPedestalsESSource::SiStripPedestalsESSource(const edm::ParameterSet& pset) {
+  setWhatProduced(this);
   findingRecord<SiStripPedestalsRcd>();
 }
 
 // -----------------------------------------------------------------------------
 //
-std::unique_ptr<SiStripPedestals> SiStripPedestalsESSource::produce( const SiStripPedestalsRcd& ) { 
-  
+std::unique_ptr<SiStripPedestals> SiStripPedestalsESSource::produce(const SiStripPedestalsRcd&) {
   SiStripPedestals* peds = makePedestals();
-  
-  if ( !peds ) {
-    edm::LogWarning(mlESSources_)
-      << "[SiStripPedestalsESSource::" << __func__ << "]"
-      << " Null pointer to SiStripPedestals object!";
+
+  if (!peds) {
+    edm::LogWarning(mlESSources_) << "[SiStripPedestalsESSource::" << __func__ << "]"
+                                  << " Null pointer to SiStripPedestals object!";
   }
-  
+
   std::unique_ptr<SiStripPedestals> ptr(peds);
   return ptr;
-
 }
 
 // -----------------------------------------------------------------------------
 //
-void SiStripPedestalsESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 
-						const edm::IOVSyncValue& iosv, 
-						edm::ValidityInterval& oValidity ) {
-
-  edm::ValidityInterval infinity( iosv.beginOfTime(), iosv.endOfTime() );
+void SiStripPedestalsESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                              const edm::IOVSyncValue& iosv,
+                                              edm::ValidityInterval& oValidity) {
+  edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
   oValidity = infinity;
-  
 }

--- a/CalibTracker/SiStripESProducers/test/CheckPhase2Cabling.cc
+++ b/CalibTracker/SiStripESProducers/test/CheckPhase2Cabling.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CheckPhase2Cabling
 // Class:      CheckPhase2Cabling
-// 
+//
 /**\class CheckPhase2Cabling CheckPhase2Cabling.cc CalibTracker/CheckPhase2Cabling/src/CheckPhase2Cabling.cc
 
  Description: simple check of the phase2 cabling
@@ -14,7 +14,6 @@
 // Original Author:  Christophe Delaere
 //         Created:  Fri Dec 20 19:37:34 CET 2013
 //
-
 
 // system include files
 #include <memory>
@@ -28,7 +27,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -38,30 +36,28 @@
 #include "CondFormats/SiStripObjects/interface/Phase2TrackerCabling.h"
 #include "CondFormats/DataRecord/interface/Phase2TrackerCablingRcd.h"
 
-
 //
 // class declaration
 //
 
 class CheckPhase2Cabling : public edm::EDAnalyzer {
-   public:
-      explicit CheckPhase2Cabling(const edm::ParameterSet&);
-      ~CheckPhase2Cabling();
+public:
+  explicit CheckPhase2Cabling(const edm::ParameterSet&);
+  ~CheckPhase2Cabling();
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+private:
+  virtual void beginJob();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void endJob();
 
-   private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+  //virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  //virtual void endRun(edm::Run const&, edm::EventSetup const&);
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
-      //virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-      //virtual void endRun(edm::Run const&, edm::EventSetup const&);
-      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
 //
@@ -78,69 +74,53 @@ class CheckPhase2Cabling : public edm::EDAnalyzer {
 CheckPhase2Cabling::CheckPhase2Cabling(const edm::ParameterSet& iConfig)
 
 {
-   //now do what ever initialization is needed
-
+  //now do what ever initialization is needed
 }
 
-
-CheckPhase2Cabling::~CheckPhase2Cabling()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+CheckPhase2Cabling::~CheckPhase2Cabling() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-CheckPhase2Cabling::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void CheckPhase2Cabling::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   ESHandle<Phase2TrackerCabling> cablingHandle;
-   iSetup.get<Phase2TrackerCablingRcd>().get(cablingHandle);
+  ESHandle<Phase2TrackerCabling> cablingHandle;
+  iSetup.get<Phase2TrackerCablingRcd>().get(cablingHandle);
 
-   // print general information about the cabling
-   std::cout << cablingHandle->summaryDescription() << std::endl;
-   // print detailed information
-   std::cout << cablingHandle->description() << std::endl;
+  // print general information about the cabling
+  std::cout << cablingHandle->summaryDescription() << std::endl;
+  // print detailed information
+  std::cout << cablingHandle->description() << std::endl;
 
-   // search information about one module
-   Phase2TrackerModule module = cablingHandle->findFedCh(std::make_pair(0,1));
+  // search information about one module
+  Phase2TrackerModule module = cablingHandle->findFedCh(std::make_pair(0, 1));
 
-   // print information about that module
-   std::cout << "Information about the module connected to FED 0.1:" << std::endl;
-   std::cout << module.description() << std::endl;
+  // print information about that module
+  std::cout << "Information about the module connected to FED 0.1:" << std::endl;
+  std::cout << module.description() << std::endl;
 
-   // look at one subset (based on cooling)
-   Phase2TrackerCabling coolingLoop = cablingHandle->filterByCoolingLine(0);
-   std::cout << "Subset in cooling line 0:" << std::endl;
-   std::cout << coolingLoop.description(1) << std::endl;
-  
-   // look at one subset (based on power)
-   Phase2TrackerCabling powerGroup = cablingHandle->filterByPowerGroup(1);
-   std::cout << "Subset in power group 1:" << std::endl;
-   std::cout << powerGroup.description(1) << std::endl;
-  
+  // look at one subset (based on cooling)
+  Phase2TrackerCabling coolingLoop = cablingHandle->filterByCoolingLine(0);
+  std::cout << "Subset in cooling line 0:" << std::endl;
+  std::cout << coolingLoop.description(1) << std::endl;
+
+  // look at one subset (based on power)
+  Phase2TrackerCabling powerGroup = cablingHandle->filterByPowerGroup(1);
+  std::cout << "Subset in power group 1:" << std::endl;
+  std::cout << powerGroup.description(1) << std::endl;
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-CheckPhase2Cabling::beginJob()
-{
-}
+void CheckPhase2Cabling::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-CheckPhase2Cabling::endJob() 
-{
-}
+void CheckPhase2Cabling::endJob() {}
 
 // ------------ method called when starting to processes a run  ------------
 /*
@@ -175,8 +155,7 @@ CheckPhase2Cabling::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSe
 */
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-CheckPhase2Cabling::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void CheckPhase2Cabling::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/CalibTracker/SiStripESProducers/test/SealModules.cc
+++ b/CalibTracker/SiStripESProducers/test/SealModules.cc
@@ -4,5 +4,4 @@
 
 #include "CalibTracker/SiStripESProducers/test/testSiStripQualityESProducer.h"
 
-
 DEFINE_FWK_MODULE(testSiStripQualityESProducer);

--- a/CalibTracker/SiStripESProducers/test/testSiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/test/testSiStripQualityESProducer.cc
@@ -8,111 +8,123 @@
 #include <sys/time.h>
 #include <sstream>
 
-testSiStripQualityESProducer::testSiStripQualityESProducer( const edm::ParameterSet& iConfig ):
-  printdebug_(iConfig.getUntrackedParameter<bool>("printDebug",false)),
-  m_cacheID_(0),firstIOV(true), 
-  twoRecordComparison_(iConfig.getUntrackedParameter<bool>("twoRecordComparison",false)),
-  dataLabel_(iConfig.getUntrackedParameter<std::string>("dataLabel","")),
-  dataLabelTwo_(iConfig.getUntrackedParameter<std::string>("dataLabelTwo","")){}
+testSiStripQualityESProducer::testSiStripQualityESProducer(const edm::ParameterSet& iConfig)
+    : printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)),
+      m_cacheID_(0),
+      firstIOV(true),
+      twoRecordComparison_(iConfig.getUntrackedParameter<bool>("twoRecordComparison", false)),
+      dataLabel_(iConfig.getUntrackedParameter<std::string>("dataLabel", "")),
+      dataLabelTwo_(iConfig.getUntrackedParameter<std::string>("dataLabelTwo", "")) {}
 
-void testSiStripQualityESProducer::analyze( const edm::Event& e, const edm::EventSetup& iSetup){
-
+void testSiStripQualityESProducer::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   unsigned long long cacheID = iSetup.get<SiStripQualityRcd>().cacheIdentifier();
 
-  if (m_cacheID_ == cacheID) 
+  if (m_cacheID_ == cacheID)
     return;
 
   m_cacheID_ = cacheID;
- 
-  char canvas[1024]="\n&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&\n";
+
+  char canvas[1024] = "\n&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&\n";
 
   //&&&&&&&&&&&&&&&&&&
   //First Record
   //&&&&&&&&&&&&&&&&&&
   edm::ESHandle<SiStripQuality> SiStripQualityESH_;
-  iSetup.get<SiStripQualityRcd>().get(dataLabel_,SiStripQualityESH_);
-  edm::LogInfo("testSiStripQualityESProducer") << canvas << "[testSiStripQualityESProducer::analyze] Print SiStripQualityRecord" << canvas << std::endl;
+  iSetup.get<SiStripQualityRcd>().get(dataLabel_, SiStripQualityESH_);
+  edm::LogInfo("testSiStripQualityESProducer")
+      << canvas << "[testSiStripQualityESProducer::analyze] Print SiStripQualityRecord" << canvas << std::endl;
   printObject(SiStripQualityESH_.product());
 
   //&&&&&&&&&&&&&&&&&&
   //Second Record
   //&&&&&&&&&&&&&&&&&&
   edm::ESHandle<SiStripQuality> twoSiStripQualityESH_;
-  if (twoRecordComparison_){
-    iSetup.get<SiStripQualityRcd>().get(dataLabelTwo_,twoSiStripQualityESH_);
-    edm::LogInfo("testSiStripQualityESProducer") << canvas << "[testSiStripQualityESProducer::analyze] Print Second SiStripQualityRecord" << canvas << std::endl;
+  if (twoRecordComparison_) {
+    iSetup.get<SiStripQualityRcd>().get(dataLabelTwo_, twoSiStripQualityESH_);
+    edm::LogInfo("testSiStripQualityESProducer")
+        << canvas << "[testSiStripQualityESProducer::analyze] Print Second SiStripQualityRecord" << canvas << std::endl;
     printObject(twoSiStripQualityESH_.product());
-  
-    edm::LogInfo("testSiStripQualityESProducer") << canvas << "[testSiStripQualityESProducer::analyze] Print difference (First - Second) SiStripQuality Rcd" << canvas << std::endl;
+
+    edm::LogInfo("testSiStripQualityESProducer")
+        << canvas << "[testSiStripQualityESProducer::analyze] Print difference (First - Second) SiStripQuality Rcd"
+        << canvas << std::endl;
     const SiStripQuality& tmp1 = *SiStripQualityESH_ - *twoSiStripQualityESH_;
     printObject(&tmp1);
-    edm::LogInfo("testSiStripQualityESProducer") << canvas << "[testSiStripQualityESProducer::analyze] Print difference (Second - First) SiStripQuality Rcd" << canvas << std::endl;
+    edm::LogInfo("testSiStripQualityESProducer")
+        << canvas << "[testSiStripQualityESProducer::analyze] Print difference (Second - First) SiStripQuality Rcd"
+        << canvas << std::endl;
     const SiStripQuality& tmp2 = *twoSiStripQualityESH_ - *SiStripQualityESH_;
-    printObject(&tmp2);    
+    printObject(&tmp2);
   }
-  
-  
-  if(!firstIOV){
-    edm::LogInfo("testSiStripQualityESProducer") << canvas << "[testSiStripQualityESProducer::analyze] Print previous SiStripQuality Rcd " << canvas << std::endl;
+
+  if (!firstIOV) {
+    edm::LogInfo("testSiStripQualityESProducer")
+        << canvas << "[testSiStripQualityESProducer::analyze] Print previous SiStripQuality Rcd " << canvas
+        << std::endl;
     printObject(m_Quality_);
-    edm::LogInfo("testSiStripQualityESProducer") << canvas << "[testSiStripQualityESProducer::analyze] Print difference (Current - Previous) SiStripQuality Rcd" << canvas << std::endl;
+    edm::LogInfo("testSiStripQualityESProducer")
+        << canvas << "[testSiStripQualityESProducer::analyze] Print difference (Current - Previous) SiStripQuality Rcd"
+        << canvas << std::endl;
     const SiStripQuality& tmp1 = *SiStripQualityESH_ - *m_Quality_;
     printObject(&tmp1);
-    edm::LogInfo("testSiStripQualityESProducer") << canvas << "[testSiStripQualityESProducer::analyze] Print difference (Previous - Current) SiStripQuality Rcd" << canvas << std::endl;
+    edm::LogInfo("testSiStripQualityESProducer")
+        << canvas << "[testSiStripQualityESProducer::analyze] Print difference (Previous - Current) SiStripQuality Rcd"
+        << canvas << std::endl;
     const SiStripQuality& tmp2 = *m_Quality_ - *SiStripQualityESH_;
     printObject(&tmp2);
   }
 
-  firstIOV=false;
-  edm::LogInfo("testSiStripQualityESProducer") << "[testSiStripQualityESProducer::analyze] Constructing new object " << std::endl;
-  m_Quality_= new SiStripQuality(*SiStripQualityESH_);  
-  
+  firstIOV = false;
+  edm::LogInfo("testSiStripQualityESProducer")
+      << "[testSiStripQualityESProducer::analyze] Constructing new object " << std::endl;
+  m_Quality_ = new SiStripQuality(*SiStripQualityESH_);
 }
 
-void testSiStripQualityESProducer::printObject(const SiStripQuality* SiStripQuality_){
+void testSiStripQualityESProducer::printObject(const SiStripQuality* SiStripQuality_) {
   std::stringstream ss;
 
   SiStripBadStrip::RegistryIterator rbegin = SiStripQuality_->getRegistryVectorBegin();
-  SiStripBadStrip::RegistryIterator rend   = SiStripQuality_->getRegistryVectorEnd();
+  SiStripBadStrip::RegistryIterator rend = SiStripQuality_->getRegistryVectorEnd();
   uint32_t detid;
-    
-  if (rbegin==rend)
+
+  if (rbegin == rend)
     return;
 
-  for (SiStripBadStrip::RegistryIterator rp=rbegin; rp != rend; ++rp) {
-    
-    detid=rp->detid;
-    SiStripBadStrip::Range range = SiStripBadStrip::Range( SiStripQuality_->getDataVectorBegin()+rp->ibegin , 
-							   SiStripQuality_->getDataVectorBegin()+rp->iend );
-    
+  for (SiStripBadStrip::RegistryIterator rp = rbegin; rp != rend; ++rp) {
+    detid = rp->detid;
+    SiStripBadStrip::Range range = SiStripBadStrip::Range(SiStripQuality_->getDataVectorBegin() + rp->ibegin,
+                                                          SiStripQuality_->getDataVectorBegin() + rp->iend);
 
-    SiStripBadStrip::ContainerIterator it=range.first;
-    ss<< "Full Info";
-      
-    for(;it!=range.second;++it){
-      unsigned int value=(*it);
-	  
+    SiStripBadStrip::ContainerIterator it = range.first;
+    ss << "Full Info";
+
+    for (; it != range.second; ++it) {
+      unsigned int value = (*it);
+
       ss << "\n\tdetid " << detid << " \t"
-	 << " firstBadStrip " <<  SiStripQuality_->decode(value).firstStrip << "\t "
-	 << " NconsecutiveBadStrips " << SiStripQuality_->decode(value).range  << "\t "
-	 << " flag " << SiStripQuality_->decode(value).flag  << "\t "
-	 << " packed integer 0x" <<  std::hex << value << std::dec << "\t ";
+         << " firstBadStrip " << SiStripQuality_->decode(value).firstStrip << "\t "
+         << " NconsecutiveBadStrips " << SiStripQuality_->decode(value).range << "\t "
+         << " flag " << SiStripQuality_->decode(value).flag << "\t "
+         << " packed integer 0x" << std::hex << value << std::dec << "\t ";
     }
-      
-    ss << "\n\nDetBase Info\n\t  IsModuleBad()="<<SiStripQuality_->IsModuleBad(detid)
-       << "\t IsFiberBad(n)="<< SiStripQuality_->IsFiberBad(detid,0) << " " << SiStripQuality_->IsFiberBad(detid,1) << " " << SiStripQuality_->IsFiberBad(detid,2)
-       << "\t getBadFibers()=" << SiStripQuality_->getBadFibers(detid)
-       << "\t IsApvBad()="<< SiStripQuality_->IsApvBad(detid,0) << " " << SiStripQuality_->IsApvBad(detid,1) << " " << SiStripQuality_->IsApvBad(detid,2) << " " << SiStripQuality_->IsApvBad(detid,3) << " " << SiStripQuality_->IsApvBad(detid,4) << " " << SiStripQuality_->IsApvBad(detid,5)   
+
+    ss << "\n\nDetBase Info\n\t  IsModuleBad()=" << SiStripQuality_->IsModuleBad(detid)
+       << "\t IsFiberBad(n)=" << SiStripQuality_->IsFiberBad(detid, 0) << " " << SiStripQuality_->IsFiberBad(detid, 1)
+       << " " << SiStripQuality_->IsFiberBad(detid, 2) << "\t getBadFibers()=" << SiStripQuality_->getBadFibers(detid)
+       << "\t IsApvBad()=" << SiStripQuality_->IsApvBad(detid, 0) << " " << SiStripQuality_->IsApvBad(detid, 1) << " "
+       << SiStripQuality_->IsApvBad(detid, 2) << " " << SiStripQuality_->IsApvBad(detid, 3) << " "
+       << SiStripQuality_->IsApvBad(detid, 4) << " " << SiStripQuality_->IsApvBad(detid, 5)
        << "\t getBadApvs()=" << SiStripQuality_->getBadApvs(detid);
     ss << "\n--------------------------------------------------\n";
   }
   ss << "\nGlobal Info";
   std::vector<SiStripQuality::BadComponent> BC = SiStripQuality_->getBadComponentList();
   ss << "\n\t detid \t IsModuleBad \t BadFibers \t BadApvs";
-    
-  for (size_t i=0;i<BC.size();++i)
-    ss << "\n\t" << BC[i].detid << "\t " << BC[i].BadModule << "\t "<< BC[i].BadFibers << "\t " << BC[i].BadApvs << "\t ";
-  ss<< std::endl;
+
+  for (size_t i = 0; i < BC.size(); ++i)
+    ss << "\n\t" << BC[i].detid << "\t " << BC[i].BadModule << "\t " << BC[i].BadFibers << "\t " << BC[i].BadApvs
+       << "\t ";
+  ss << std::endl;
 
   edm::LogInfo("testSiStripQualityESProducer") << ss.str();
 }

--- a/CalibTracker/SiStripESProducers/test/testSiStripQualityESProducer.h
+++ b/CalibTracker/SiStripESProducers/test/testSiStripQualityESProducer.h
@@ -17,14 +17,13 @@
 class SiStripQuality;
 
 class testSiStripQualityESProducer : public edm::EDAnalyzer {
-
- public:
-  explicit testSiStripQualityESProducer( const edm::ParameterSet& );
+public:
+  explicit testSiStripQualityESProducer(const edm::ParameterSet&);
   ~testSiStripQualityESProducer(){};
-  
-  void analyze( const edm::Event&, const edm::EventSetup& );
-    
- private:
+
+  void analyze(const edm::Event&, const edm::EventSetup&);
+
+private:
   void printObject(const SiStripQuality*);
   bool printdebug_;
   unsigned long long m_cacheID_;


### PR DESCRIPTION

Applying code-format for CMSSW category alca.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/433//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


