### PR TITLE
Running code-format for analysis-reconstruction

### DIFF
--- a/DataFormats/PatCandidates/interface/CandKinResolution.h
+++ b/DataFormats/PatCandidates/interface/CandKinResolution.h
@@ -7,8 +7,8 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 
 namespace pat {
-  class CandKinResolution  {
-		/** 
+  class CandKinResolution {
+    /** 
 		  <h2>Parametrizations</h2>
                    (lowercase means values, uppercase means fixed parameters)<br />
 		   <b>Cart</b> = (px, py, pz, m)                KinFitter uses (px, py, pz, m/M0) with M0 = mass of the starting p4  <br />
@@ -28,130 +28,130 @@ namespace pat {
                    <b>EScaledMomDev</b> = (p/P0, dp_theta, dp_phi,E/P=E0/P0) with the P defined as for MomDev, fixed E/p to E0/P0 <br />
                    <br />
 		*/
-     public:
-        typedef math::XYZTLorentzVector LorentzVector;
-        typedef float Scalar;
+  public:
+    typedef math::XYZTLorentzVector LorentzVector;
+    typedef float Scalar;
 
-        enum Parametrization { Invalid=0, 
-                // 4D = 0xN4
-                Cart          = 0x04, 
-                ECart         = 0x14, 
-                Spher         = 0x24, 
-                ESpher        = 0x34, 
-                MomDev        = 0x44, 
-                EMomDev       = 0x54, 
-                // 3D =0xN3
-                MCCart        = 0x03, 
-                MCSpher       = 0x13, 
-                MCPInvSpher   = 0x23, 
-                EtEtaPhi      = 0x33, 
-                EtThetaPhi    = 0x43,
-                MCMomDev      = 0x53, 
-                EScaledMomDev = 0x63
-                };
-        CandKinResolution() ; 
+    enum Parametrization {
+      Invalid = 0,
+      // 4D = 0xN4
+      Cart = 0x04,
+      ECart = 0x14,
+      Spher = 0x24,
+      ESpher = 0x34,
+      MomDev = 0x44,
+      EMomDev = 0x54,
+      // 3D =0xN3
+      MCCart = 0x03,
+      MCSpher = 0x13,
+      MCPInvSpher = 0x23,
+      EtEtaPhi = 0x33,
+      EtThetaPhi = 0x43,
+      MCMomDev = 0x53,
+      EScaledMomDev = 0x63
+    };
+    CandKinResolution();
 
-        /// Create a resolution object given a parametrization code, 
-        /// a covariance matrix (streamed as a vector) and a vector of constraints.
-        ///
-        /// In the vector you can put either the full triangular block or just the diagonal terms
-        ///
-        /// The triangular block should be written in a way that the constructor
-        ///  <code>AlgebraicSymMatrixNN(covariance.begin(), covariance.end())</code>
-        /// works (N = 3 or 4)
-        CandKinResolution(Parametrization parametrization, const std::vector<Scalar> &covariances, 
-                            const std::vector<Scalar> &constraints = std::vector<Scalar>()) ;
+    /// Create a resolution object given a parametrization code,
+    /// a covariance matrix (streamed as a vector) and a vector of constraints.
+    ///
+    /// In the vector you can put either the full triangular block or just the diagonal terms
+    ///
+    /// The triangular block should be written in a way that the constructor
+    ///  <code>AlgebraicSymMatrixNN(covariance.begin(), covariance.end())</code>
+    /// works (N = 3 or 4)
+    CandKinResolution(Parametrization parametrization,
+                      const std::vector<Scalar> &covariances,
+                      const std::vector<Scalar> &constraints = std::vector<Scalar>());
 
-        /// Fill in a cresolution object given a parametrization code, a covariance matrix and a vector of constraints.
-        CandKinResolution(Parametrization parametrization, const AlgebraicSymMatrix44 &covariance,
-                            const std::vector<Scalar> &constraints = std::vector<Scalar>()) ;
-        ~CandKinResolution() ;
+    /// Fill in a cresolution object given a parametrization code, a covariance matrix and a vector of constraints.
+    CandKinResolution(Parametrization parametrization,
+                      const AlgebraicSymMatrix44 &covariance,
+                      const std::vector<Scalar> &constraints = std::vector<Scalar>());
+    ~CandKinResolution();
 
-        /// Return the code of the parametrization used in this object
-        Parametrization parametrization() const { return parametrization_; }
+    /// Return the code of the parametrization used in this object
+    Parametrization parametrization() const { return parametrization_; }
 
-        /// Returns the number of free parameters in this parametrization
-        uint32_t dimension() const { 
-            return dimensionFrom(parametrization_);
-        }
+    /// Returns the number of free parameters in this parametrization
+    uint32_t dimension() const { return dimensionFrom(parametrization_); }
 
-        /// Returns the full covariance matrix
-        const AlgebraicSymMatrix44 & covariance()  const { 
-            return covmatrix_; 
-        }
+    /// Returns the full covariance matrix
+    const AlgebraicSymMatrix44 &covariance() const { return covmatrix_; }
 
-        /// The constraints associated with this parametrization
-        const std::vector<Scalar> & constraints() const { return constraints_; }
+    /// The constraints associated with this parametrization
+    const std::vector<Scalar> &constraints() const { return constraints_; }
 
-        /// Resolution on eta, given the 4-momentum of the associated Candidate
-	double resolEta(const LorentzVector &p4) const ;
+    /// Resolution on eta, given the 4-momentum of the associated Candidate
+    double resolEta(const LorentzVector &p4) const;
 
-        /// Resolution on theta, given the 4-momentum of the associated Candidate
-	double resolTheta(const LorentzVector &p4) const ;
+    /// Resolution on theta, given the 4-momentum of the associated Candidate
+    double resolTheta(const LorentzVector &p4) const;
 
-        /// Resolution on phi, given the 4-momentum of the associated Candidate
-	double resolPhi(const LorentzVector &p4) const ;
+    /// Resolution on phi, given the 4-momentum of the associated Candidate
+    double resolPhi(const LorentzVector &p4) const;
 
-        /// Resolution on energy, given the 4-momentum of the associated Candidate
-	double resolE(const LorentzVector &p4) const ;
+    /// Resolution on energy, given the 4-momentum of the associated Candidate
+    double resolE(const LorentzVector &p4) const;
 
-        /// Resolution on et, given the 4-momentum of the associated Candidate
-	double resolEt(const LorentzVector &p4) const ;
+    /// Resolution on et, given the 4-momentum of the associated Candidate
+    double resolEt(const LorentzVector &p4) const;
 
-        /// Resolution on the invariant mass, given the 4-momentum of the associated Candidate
-        /// Warning: returns 0 for mass-constrained parametrizations.
-	double resolM(const LorentzVector &p4) const ;
+    /// Resolution on the invariant mass, given the 4-momentum of the associated Candidate
+    /// Warning: returns 0 for mass-constrained parametrizations.
+    double resolM(const LorentzVector &p4) const;
 
-        /// Resolution on p, given the 4-momentum of the associated Candidate
-	double resolP(const LorentzVector &p4) const ;
+    /// Resolution on p, given the 4-momentum of the associated Candidate
+    double resolP(const LorentzVector &p4) const;
 
-        /// Resolution on pt, given the 4-momentum of the associated Candidate
-	double resolPt(const LorentzVector &p4) const ;
+    /// Resolution on pt, given the 4-momentum of the associated Candidate
+    double resolPt(const LorentzVector &p4) const;
 
-        /// Resolution on 1/p, given the 4-momentum of the associated Candidate
-	double resolPInv(const LorentzVector &p4) const ;
+    /// Resolution on 1/p, given the 4-momentum of the associated Candidate
+    double resolPInv(const LorentzVector &p4) const;
 
-        /// Resolution on px, given the 4-momentum of the associated Candidate
-	double resolPx(const LorentzVector &p4) const ;
+    /// Resolution on px, given the 4-momentum of the associated Candidate
+    double resolPx(const LorentzVector &p4) const;
 
-        /// Resolution on py, given the 4-momentum of the associated Candidate
-	double resolPy(const LorentzVector &p4) const ;
+    /// Resolution on py, given the 4-momentum of the associated Candidate
+    double resolPy(const LorentzVector &p4) const;
 
-        /// Resolution on pz, given the 4-momentum of the associated Candidate
-	double resolPz(const LorentzVector &p4) const ;
+    /// Resolution on pz, given the 4-momentum of the associated Candidate
+    double resolPz(const LorentzVector &p4) const;
 
-        static int dimensionFrom(Parametrization parametrization) {
-          return (static_cast<uint32_t>(parametrization) & 0x0F);
-        }
+    static int dimensionFrom(Parametrization parametrization) {
+      return (static_cast<uint32_t>(parametrization) & 0x0F);
+    }
 
-        static void fillMatrixFrom( Parametrization parametrization, const std::vector<Scalar>& covariances,
-                                    AlgebraicSymMatrix44& covmatrix);
+    static void fillMatrixFrom(Parametrization parametrization,
+                               const std::vector<Scalar> &covariances,
+                               AlgebraicSymMatrix44 &covmatrix);
 
-     private:
-        // persistent 
-        /// Parametrization code
-        Parametrization parametrization_;
-        /// Matrix, streamed as a vector
-        std::vector<Scalar> covariances_;
-        /// Constraints
-        std::vector<Scalar> constraints_;
+  private:
+    // persistent
+    /// Parametrization code
+    Parametrization parametrization_;
+    /// Matrix, streamed as a vector
+    std::vector<Scalar> covariances_;
+    /// Constraints
+    std::vector<Scalar> constraints_;
 
-        // transient
+    // transient
 
-        /// Transient copy of the full 4x4 covariance matrix
-        AlgebraicSymMatrix44 covmatrix_;
+    /// Transient copy of the full 4x4 covariance matrix
+    AlgebraicSymMatrix44 covmatrix_;
 
-        //methods
+    //methods
 
-        /// Fill matrix from vector
-        void fillMatrix() ;
+    /// Fill matrix from vector
+    void fillMatrix();
 
-        /// Fill vectoor from matrix
-        void fillVector() ;
+    /// Fill vectoor from matrix
+    void fillVector();
   };
 
-  typedef std::vector<CandKinResolution>   CandKinResolutionCollection;
+  typedef std::vector<CandKinResolution> CandKinResolutionCollection;
   typedef edm::ValueMap<CandKinResolution> CandKinResolutionValueMap;
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/CompositeCandidate.h
+++ b/DataFormats/PatCandidates/interface/CompositeCandidate.h
@@ -17,37 +17,30 @@
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"
 #include "DataFormats/PatCandidates/interface/PATObject.h"
 
-
 // Define typedefs for convenience
 namespace pat {
   class CompositeCandidate;
-  typedef std::vector<CompositeCandidate>              CompositeCandidateCollection; 
-  typedef edm::Ref<CompositeCandidateCollection>       CompositeCandidateRef; 
-  typedef edm::RefVector<CompositeCandidateCollection> CompositeCandidateRefVector; 
-}
-
+  typedef std::vector<CompositeCandidate> CompositeCandidateCollection;
+  typedef edm::Ref<CompositeCandidateCollection> CompositeCandidateRef;
+  typedef edm::RefVector<CompositeCandidateCollection> CompositeCandidateRefVector;
+}  // namespace pat
 
 // Class definition
 namespace pat {
 
-
   class CompositeCandidate : public PATObject<reco::CompositeCandidate> {
+  public:
+    /// default constructor
+    CompositeCandidate();
+    /// constructor from a composite candidate
+    CompositeCandidate(const reco::CompositeCandidate& aCompositeCandidate);
+    /// destructor
+    ~CompositeCandidate() override;
 
-    public:
-
-      /// default constructor
-      CompositeCandidate();
-      /// constructor from a composite candidate
-      CompositeCandidate(const reco::CompositeCandidate & aCompositeCandidate);
-      /// destructor
-      ~CompositeCandidate() override;
-
-      /// required reimplementation of the Candidate's clone method
-      CompositeCandidate * clone() const override { return new CompositeCandidate(*this); }
-
+    /// required reimplementation of the Candidate's clone method
+    CompositeCandidate* clone() const override { return new CompositeCandidate(*this); }
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/Conversion.h
+++ b/DataFormats/PatCandidates/interface/Conversion.h
@@ -11,27 +11,26 @@
 // Define typedefs for convenience
 namespace pat {
   class Conversion;
-  typedef std::vector<Conversion>              ConversionCollection;
-  typedef edm::Ref<ConversionCollection>       ConversionRef;
+  typedef std::vector<Conversion> ConversionCollection;
+  typedef edm::Ref<ConversionCollection> ConversionRef;
   typedef edm::RefVector<ConversionCollection> ConversionRefVector;
-}
-
+}  // namespace pat
 
 //we use index to match with electron. However, can we do this with gsfTrack instead of index?
 namespace pat {
   class Conversion {
   public:
-    Conversion () {}
-    Conversion ( int index );
+    Conversion() {}
+    Conversion(int index);
     virtual ~Conversion() {}
 
-    const double vtxProb() const {return vtxProb_;}
+    const double vtxProb() const { return vtxProb_; }
     void setVtxProb(double vtxProb);
-    const double lxy() const {return lxy_;}
-    void setLxy( double lxy );
-    const int nHitsMax() const {return nHitsMax_;}
-    void setNHitsMax( int nHitsMax );
-    const int index() const {return index_; }     
+    const double lxy() const { return lxy_; }
+    void setLxy(double lxy);
+    const int nHitsMax() const { return nHitsMax_; }
+    void setNHitsMax(int nHitsMax);
+    const int index() const { return index_; }
 
   private:
     double vtxProb_;
@@ -40,8 +39,7 @@ namespace pat {
 
     //electron index matched with conversion
     int index_;
-
   };
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/CovarianceParameterization.h
+++ b/DataFormats/PatCandidates/interface/CovarianceParameterization.h
@@ -7,48 +7,70 @@
 #include <array>
 #include <TKey.h>
 class CompressionElement {
-    public:
-      enum Method {float16=0,reduceMantissa=1,logPack=2,tanLogPack=3,zero=4,one=5};
-      enum Target {realValue=0,ratioToRef=1,differenceToRef=2};
-      CompressionElement():method(zero),target(realValue){}
-      CompressionElement(Method m, Target t, int bitsUsed, std::vector<float> p): method(m),target(t),bits(bitsUsed),params(p){}
-      Method method;
-      Target target;
-      int bits;
-      std::vector<float> params;
-      uint16_t pack(float value, float ref=0.) const ;
-      float unpack(uint16_t packed, float ref=0.) const;
-
+public:
+  enum Method { float16 = 0, reduceMantissa = 1, logPack = 2, tanLogPack = 3, zero = 4, one = 5 };
+  enum Target { realValue = 0, ratioToRef = 1, differenceToRef = 2 };
+  CompressionElement() : method(zero), target(realValue) {}
+  CompressionElement(Method m, Target t, int bitsUsed, std::vector<float> p)
+      : method(m), target(t), bits(bitsUsed), params(p) {}
+  Method method;
+  Target target;
+  int bits;
+  std::vector<float> params;
+  uint16_t pack(float value, float ref = 0.) const;
+  float unpack(uint16_t packed, float ref = 0.) const;
 };
-  
 
 class CovarianceParameterization {
-    public:
-        static int index(int i, int j) {if(i>=j) return j+i*(i+1)/2; else return i+j*(j+1)/2 ; }
-        struct CompressionSchema {
-             CompressionSchema() {}
-             std::array<CompressionElement,15> elements;
-             CompressionElement & operator()(int i,int j) {return elements[index(i,j)];}
-             const CompressionElement & operator()(int i,int j) const {return elements[index(i,j)];}
-        };
-        CovarianceParameterization() : loadedVersion_(-1) 
-        {
-        }
-        bool isValid() const {return loadedVersion_!=-1; }
-        int loadedVersion() const {return loadedVersion_; }
-        void load(int version);
-        float  meanValue(int i,int j,int sign,float pt, float eta, int nHits,int pixelHits,  float cii=1.,float cjj=1.) const ;
-        float  pack(float value,int schema, int i,int j,float pt, float eta, int nHits,int pixelHits,  float cii=1.,float cjj=1.) const;
-        float  unpack(uint16_t packed,int schema, int i,int j,float pt, float eta, int nHits,int pixelHits,  float cii=1.,float cjj=1.) const;
-    private:
-        void readFile( TFile &);
-        void  addTheHistogram(std::vector<TH3D *> * HistoVector, std::string StringToAddInTheName, int i, int j, TFile & fileToRead);
-        int loadedVersion_;
-	TFile * fileToRead_;
-        std::unordered_map<uint16_t,CompressionSchema> schemas; 
-        std::vector<TH3D *>  cov_elements_pixelHit;
-        std::vector<TH3D *>  cov_elements_noPixelHit;
+public:
+  static int index(int i, int j) {
+    if (i >= j)
+      return j + i * (i + 1) / 2;
+    else
+      return i + j * (j + 1) / 2;
+  }
+  struct CompressionSchema {
+    CompressionSchema() {}
+    std::array<CompressionElement, 15> elements;
+    CompressionElement &operator()(int i, int j) { return elements[index(i, j)]; }
+    const CompressionElement &operator()(int i, int j) const { return elements[index(i, j)]; }
+  };
+  CovarianceParameterization() : loadedVersion_(-1) {}
+  bool isValid() const { return loadedVersion_ != -1; }
+  int loadedVersion() const { return loadedVersion_; }
+  void load(int version);
+  float meanValue(
+      int i, int j, int sign, float pt, float eta, int nHits, int pixelHits, float cii = 1., float cjj = 1.) const;
+  float pack(float value,
+             int schema,
+             int i,
+             int j,
+             float pt,
+             float eta,
+             int nHits,
+             int pixelHits,
+             float cii = 1.,
+             float cjj = 1.) const;
+  float unpack(uint16_t packed,
+               int schema,
+               int i,
+               int j,
+               float pt,
+               float eta,
+               int nHits,
+               int pixelHits,
+               float cii = 1.,
+               float cjj = 1.) const;
+
+private:
+  void readFile(TFile &);
+  void addTheHistogram(
+      std::vector<TH3D *> *HistoVector, std::string StringToAddInTheName, int i, int j, TFile &fileToRead);
+  int loadedVersion_;
+  TFile *fileToRead_;
+  std::unordered_map<uint16_t, CompressionSchema> schemas;
+  std::vector<TH3D *> cov_elements_pixelHit;
+  std::vector<TH3D *> cov_elements_noPixelHit;
 };
 
 #endif
-

--- a/DataFormats/PatCandidates/interface/Electron.h
+++ b/DataFormats/PatCandidates/interface/Electron.h
@@ -17,7 +17,6 @@
   \author   Steven Lowette, Giovanni Petrucciani, Frederic Ronga
 */
 
-
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronCore.h"
@@ -35,354 +34,348 @@
 // Define typedefs for convenience
 namespace pat {
   class Electron;
-  typedef std::vector<Electron>              ElectronCollection;
-  typedef edm::Ref<ElectronCollection>       ElectronRef;
+  typedef std::vector<Electron> ElectronCollection;
+  typedef edm::Ref<ElectronCollection> ElectronRef;
   typedef edm::RefVector<ElectronCollection> ElectronRefVector;
-}
+}  // namespace pat
 
 namespace reco {
   /// pipe operator (introduced to use pat::Electron with PFTopProjectors)
   std::ostream& operator<<(std::ostream& out, const pat::Electron& obj);
-}
+}  // namespace reco
 
 // Class definition
 namespace pat {
   class PATElectronSlimmer;
 
   class Electron : public Lepton<reco::GsfElectron> {
+  public:
+    typedef std::pair<std::string, float> IdPair;
 
-    public:
+    /// default constructor
+    Electron();
+    /// constructor from reco::GsfElectron
+    Electron(const reco::GsfElectron& anElectron);
+    /// constructor from a RefToBase to a reco::GsfElectron (to be superseded by Ptr counterpart)
+    Electron(const edm::RefToBase<reco::GsfElectron>& anElectronRef);
+    /// constructor from a Ptr to a reco::GsfElectron
+    Electron(const edm::Ptr<reco::GsfElectron>& anElectronRef);
+    /// destructor
+    ~Electron() override;
 
-      typedef std::pair<std::string,float> IdPair;
+    /// required reimplementation of the Candidate's clone method
+    Electron* clone() const override { return new Electron(*this); }
 
-      /// default constructor
-      Electron();
-      /// constructor from reco::GsfElectron
-      Electron(const reco::GsfElectron & anElectron);
-      /// constructor from a RefToBase to a reco::GsfElectron (to be superseded by Ptr counterpart)
-      Electron(const edm::RefToBase<reco::GsfElectron> & anElectronRef);
-      /// constructor from a Ptr to a reco::GsfElectron
-      Electron(const edm::Ptr<reco::GsfElectron> & anElectronRef);
-      /// destructor
-      ~Electron() override;
+    // ---- methods for content embedding ----
+    /// override the virtual reco::GsfElectron::core method, so that the embedded core can be used by GsfElectron client methods
+    reco::GsfElectronCoreRef core() const override;
+    /// override the reco::GsfElectron::gsfTrack method, to access the internal storage of the supercluster
+    reco::GsfTrackRef gsfTrack() const override;
+    /// override the reco::GsfElectron::superCluster method, to access the internal storage of the supercluster
+    reco::SuperClusterRef superCluster() const override;
+    /// override the reco::GsfElectron::pflowSuperCluster method, to access the internal storage of the pflowSuperCluster
+    reco::SuperClusterRef parentSuperCluster() const override;
+    /// returns nothing. Use either gsfTrack or closestCtfTrack
+    reco::TrackRef track() const override;
+    /// override the reco::GsfElectron::closestCtfTrackRef method, to access the internal storage of the track
+    reco::TrackRef closestCtfTrackRef() const override;
+    /// direct access to the seed cluster
+    reco::CaloClusterPtr seed() const;
 
-      /// required reimplementation of the Candidate's clone method
-      Electron * clone() const override { return new Electron(*this); }
+    //method to access the basic clusters
+    const std::vector<reco::CaloCluster>& basicClusters() const { return basicClusters_; }
+    //method to access the preshower clusters
+    const std::vector<reco::CaloCluster>& preshowerClusters() const { return preshowerClusters_; }
+    //method to access the pflow basic clusters
+    const std::vector<reco::CaloCluster>& pflowBasicClusters() const { return pflowBasicClusters_; }
+    //method to access the pflow preshower clusters
+    const std::vector<reco::CaloCluster>& pflowPreshowerClusters() const { return pflowPreshowerClusters_; }
 
-      // ---- methods for content embedding ----
-      /// override the virtual reco::GsfElectron::core method, so that the embedded core can be used by GsfElectron client methods
-      reco::GsfElectronCoreRef core() const override;
-      /// override the reco::GsfElectron::gsfTrack method, to access the internal storage of the supercluster
-      reco::GsfTrackRef gsfTrack() const override;
-      /// override the reco::GsfElectron::superCluster method, to access the internal storage of the supercluster
-      reco::SuperClusterRef superCluster() const override;
-      /// override the reco::GsfElectron::pflowSuperCluster method, to access the internal storage of the pflowSuperCluster
-      reco::SuperClusterRef parentSuperCluster() const override;
-      /// returns nothing. Use either gsfTrack or closestCtfTrack
-      reco::TrackRef track() const override;
-      /// override the reco::GsfElectron::closestCtfTrackRef method, to access the internal storage of the track
-      reco::TrackRef closestCtfTrackRef() const override;
-      /// direct access to the seed cluster
-      reco::CaloClusterPtr seed() const; 
+    using reco::RecoCandidate::track;  // avoid hiding the base implementation
+    /// method to store the electron's core internally
+    void embedGsfElectronCore();
+    /// method to store the electron's GsfTrack internally
+    void embedGsfTrack();
+    /// method to store the electron's SuperCluster internally
+    void embedSuperCluster();
+    /// method to store the electron's PflowSuperCluster internally
+    void embedPflowSuperCluster();
+    /// method to store the electron's seedcluster internally
+    void embedSeedCluster();
+    /// method to store the electron's basic clusters
+    void embedBasicClusters();
+    /// method to store the electron's preshower clusters
+    void embedPreshowerClusters();
+    /// method to store the electron's pflow basic clusters
+    void embedPflowBasicClusters();
+    /// method to store the electron's pflow preshower clusters
+    void embedPflowPreshowerClusters();
+    /// method to store the electron's Track internally
+    void embedTrack();
+    /// method to store the RecHits internally - can be called from the PATElectronProducer
+    void embedRecHits(const EcalRecHitCollection* rechits);
 
-      //method to access the basic clusters
-      const std::vector<reco::CaloCluster>& basicClusters() const { return basicClusters_ ; }
-      //method to access the preshower clusters
-      const std::vector<reco::CaloCluster>& preshowerClusters() const { return preshowerClusters_ ; }
-      //method to access the pflow basic clusters
-      const std::vector<reco::CaloCluster>& pflowBasicClusters() const { return pflowBasicClusters_ ; }
-      //method to access the pflow preshower clusters
-      const std::vector<reco::CaloCluster>& pflowPreshowerClusters() const { return pflowPreshowerClusters_ ; }
+    // ---- methods for electron ID ----
+    /// Returns a specific electron ID associated to the pat::Electron given its name
+    // For cut-based IDs, the value map has the following meaning:
+    // 0: fails,
+    // 1: passes electron ID only,
+    // 2: passes electron Isolation only,
+    // 3: passes electron ID and Isolation only,
+    // 4: passes conversion rejection,
+    // 5: passes conversion rejection and ID,
+    // 6: passes conversion rejection and Isolation,
+    // 7: passes the whole selection.
+    // For more details have a look at:
+    // https://twiki.cern.ch/twiki/bin/view/CMS/SimpleCutBasedEleID
+    // https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideCategoryBasedElectronID
+    // Note: an exception is thrown if the specified ID is not available
+    float electronID(const std::string& name) const;
+    float electronID(const char* name) const { return electronID(std::string(name)); }
+    /// Returns true if a specific ID is available in this pat::Electron
+    bool isElectronIDAvailable(const std::string& name) const;
+    bool isElectronIDAvailable(const char* name) const { return isElectronIDAvailable(std::string(name)); }
+    /// Returns all the electron IDs in the form of <name,value> pairs. The 'default' ID is the first in the list
+    const std::vector<IdPair>& electronIDs() const { return electronIDs_; }
+    /// Store multiple electron ID values, discarding existing ones. The first one in the list becomes the 'default' electron id
+    void setElectronIDs(const std::vector<IdPair>& ids) { electronIDs_ = ids; }
 
-      using reco::RecoCandidate::track; // avoid hiding the base implementation
-      /// method to store the electron's core internally
-      void embedGsfElectronCore();
-      /// method to store the electron's GsfTrack internally
-      void embedGsfTrack();
-      /// method to store the electron's SuperCluster internally
-      void embedSuperCluster();
-      /// method to store the electron's PflowSuperCluster internally
-      void embedPflowSuperCluster();
-      /// method to store the electron's seedcluster internally
-      void embedSeedCluster();
-      /// method to store the electron's basic clusters
-      void embedBasicClusters();
-      /// method to store the electron's preshower clusters
-      void embedPreshowerClusters();
-      /// method to store the electron's pflow basic clusters
-      void embedPflowBasicClusters();
-      /// method to store the electron's pflow preshower clusters
-      void embedPflowPreshowerClusters();
-      /// method to store the electron's Track internally
-      void embedTrack();
-      /// method to store the RecHits internally - can be called from the PATElectronProducer
-      void embedRecHits(const EcalRecHitCollection * rechits); 
+    // ---- overload of isolation functions ----
+    /// Overload of pat::Lepton::trackIso(); returns the value of the summed track pt in a cone of deltaR<0.4
+    float trackIso() const { return dr04TkSumPt(); }
+    /// Overload of pat::Lepton::ecalIso(); returns the value of the summed Et of all recHits in the ecal in a cone of deltaR<0.4
+    float ecalIso() const { return dr04EcalRecHitSumEt(); }
+    /// Overload of pat::Lepton::hcalIso(); returns the value of the summed Et of all caloTowers in the hcal in a cone of deltaR<0.4
+    float hcalIso() const { return dr04HcalTowerSumEt(); }
+    /// Overload of pat::Lepton::caloIso(); returns the sum of ecalIso() and hcalIso
+    float caloIso() const { return ecalIso() + hcalIso(); }
+    /// returns PUPPI isolations
+    float puppiChargedHadronIso() const { return puppiChargedHadronIso_; }
+    float puppiNeutralHadronIso() const { return puppiNeutralHadronIso_; }
+    float puppiPhotonIso() const { return puppiPhotonIso_; }
+    /// returns PUPPINoLeptons isolations
+    float puppiNoLeptonsChargedHadronIso() const { return puppiNoLeptonsChargedHadronIso_; }
+    float puppiNoLeptonsNeutralHadronIso() const { return puppiNoLeptonsNeutralHadronIso_; }
+    float puppiNoLeptonsPhotonIso() const { return puppiNoLeptonsPhotonIso_; }
+    /// sets PUPPI isolations
+    void setIsolationPUPPI(float chargedhadrons_, float neutralhadrons_, float photons_) {
+      puppiChargedHadronIso_ = chargedhadrons_;
+      puppiNeutralHadronIso_ = neutralhadrons_;
+      puppiPhotonIso_ = photons_;
+    }
+    /// sets PUPPINoLeptons isolations
+    void setIsolationPUPPINoLeptons(float chargedhadrons_, float neutralhadrons_, float photons_) {
+      puppiNoLeptonsChargedHadronIso_ = chargedhadrons_;
+      puppiNoLeptonsNeutralHadronIso_ = neutralhadrons_;
+      puppiNoLeptonsPhotonIso_ = photons_;
+    }
+    // ---- PF specific methods ----
+    bool isPF() const { return isPF_; }
+    void setIsPF(bool hasPFCandidate) { isPF_ = hasPFCandidate; }
 
-      // ---- methods for electron ID ----
-      /// Returns a specific electron ID associated to the pat::Electron given its name
-      // For cut-based IDs, the value map has the following meaning:
-      // 0: fails,
-      // 1: passes electron ID only,
-      // 2: passes electron Isolation only,
-      // 3: passes electron ID and Isolation only,
-      // 4: passes conversion rejection,
-      // 5: passes conversion rejection and ID,
-      // 6: passes conversion rejection and Isolation,
-      // 7: passes the whole selection.
-      // For more details have a look at:
-      // https://twiki.cern.ch/twiki/bin/view/CMS/SimpleCutBasedEleID
-      // https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideCategoryBasedElectronID
-      // Note: an exception is thrown if the specified ID is not available
-      float electronID(const std::string& name) const;
-      float electronID(const char* name) const { return electronID( std::string(name) );}
-      /// Returns true if a specific ID is available in this pat::Electron
-      bool isElectronIDAvailable(const std::string& name) const;
-      bool isElectronIDAvailable(const char* name) const {
-	return isElectronIDAvailable(std::string(name));
-      }
-      /// Returns all the electron IDs in the form of <name,value> pairs. The 'default' ID is the first in the list
-      const std::vector<IdPair> &  electronIDs() const { return electronIDs_; }
-      /// Store multiple electron ID values, discarding existing ones. The first one in the list becomes the 'default' electron id
-      void setElectronIDs(const std::vector<IdPair> & ids) { electronIDs_ = ids; }
+    /// reference to the source PFCandidates; null if this has been built from a standard electron
+    reco::PFCandidateRef pfCandidateRef() const;
+    /// add a reference to the source IsolatedPFCandidate
+    void setPFCandidateRef(const reco::PFCandidateRef& ref) { pfCandidateRef_ = ref; }
+    /// embed the PFCandidate pointed to by pfCandidateRef_
+    void embedPFCandidate();
+    /// get the number of non-null PFCandidates
+    size_t numberOfSourceCandidatePtrs() const override {
+      return (pfCandidateRef_.isNonnull() ? 1 : 0) + associatedPackedFCandidateIndices_.size();
+    }
+    /// get the source candidate pointer with index i
+    reco::CandidatePtr sourceCandidatePtr(size_type i) const override;
 
-      // ---- overload of isolation functions ----
-      /// Overload of pat::Lepton::trackIso(); returns the value of the summed track pt in a cone of deltaR<0.4
-      float trackIso() const { return dr04TkSumPt(); }
-      /// Overload of pat::Lepton::ecalIso(); returns the value of the summed Et of all recHits in the ecal in a cone of deltaR<0.4
-      float ecalIso()  const { return dr04EcalRecHitSumEt(); }
-      /// Overload of pat::Lepton::hcalIso(); returns the value of the summed Et of all caloTowers in the hcal in a cone of deltaR<0.4
-      float hcalIso()  const { return dr04HcalTowerSumEt(); }
-      /// Overload of pat::Lepton::caloIso(); returns the sum of ecalIso() and hcalIso
-      float caloIso()  const { return ecalIso()+hcalIso(); }
-      /// returns PUPPI isolations			
-      float puppiChargedHadronIso() const {return puppiChargedHadronIso_; }
-      float puppiNeutralHadronIso() const {return puppiNeutralHadronIso_; }
-      float puppiPhotonIso() const {return puppiPhotonIso_; }
-      /// returns PUPPINoLeptons isolations
-      float puppiNoLeptonsChargedHadronIso() const {return puppiNoLeptonsChargedHadronIso_; }
-      float puppiNoLeptonsNeutralHadronIso() const {return puppiNoLeptonsNeutralHadronIso_; }
-      float puppiNoLeptonsPhotonIso() const {return puppiNoLeptonsPhotonIso_; }
-      /// sets PUPPI isolations
-      void setIsolationPUPPI(float chargedhadrons_, float neutralhadrons_, float photons_)
-      {  
-         puppiChargedHadronIso_ = chargedhadrons_;
-         puppiNeutralHadronIso_ = neutralhadrons_;
-         puppiPhotonIso_ = photons_;
+    // ---- embed various impact parameters with errors ----
+    typedef enum IPTYPE { PV2D = 0, PV3D = 1, BS2D = 2, BS3D = 3, PVDZ = 4, IpTypeSize = 5 } IpType;
+    /// Impact parameter wrt primary vertex or beamspot
+    double dB(IPTYPE type) const;
+    /// Uncertainty on the corresponding impact parameter
+    double edB(IPTYPE type) const;
+    /// the version without arguments returns PD2D, but with an absolute value (for backwards compatibility)
+    double dB() const { return std::abs(dB(PV2D)); }
+    /// the version without arguments returns PD2D, but with an absolute value (for backwards compatibility)
+    double edB() const { return std::abs(edB(PV2D)); }
+    /// Set impact parameter of a certain type and its uncertainty
+    void setDB(double dB, double edB, IPTYPE type);
 
-      }
-      /// sets PUPPINoLeptons isolations
-      void setIsolationPUPPINoLeptons(float chargedhadrons_, float neutralhadrons_, float photons_)
-      {  
-         puppiNoLeptonsChargedHadronIso_ = chargedhadrons_;
-         puppiNoLeptonsNeutralHadronIso_ = neutralhadrons_;
-         puppiNoLeptonsPhotonIso_ = photons_;
+    // ---- Momentum estimate specific methods ----
+    const LorentzVector& ecalDrivenMomentum() const { return ecalDrivenMomentum_; }
+    void setEcalDrivenMomentum(const Candidate::LorentzVector& mom) { ecalDrivenMomentum_ = mom; }
 
-      }
-      // ---- PF specific methods ----
-      bool isPF() const{ return isPF_; }
-      void setIsPF(bool hasPFCandidate) { isPF_ = hasPFCandidate ; }
+    /// pipe operator (introduced to use pat::Electron with PFTopProjectors)
+    friend std::ostream& reco::operator<<(std::ostream& out, const pat::Electron& obj);
 
-      /// reference to the source PFCandidates; null if this has been built from a standard electron
-      reco::PFCandidateRef pfCandidateRef() const;
-      /// add a reference to the source IsolatedPFCandidate
-      void setPFCandidateRef(const reco::PFCandidateRef& ref) {
-        pfCandidateRef_ = ref;
-      }
-      /// embed the PFCandidate pointed to by pfCandidateRef_
-      void embedPFCandidate();
-      /// get the number of non-null PFCandidates
-      size_t numberOfSourceCandidatePtrs() const override {
-        return (pfCandidateRef_.isNonnull() ? 1 : 0) + associatedPackedFCandidateIndices_.size();
-      }
-      /// get the source candidate pointer with index i
-      reco::CandidatePtr sourceCandidatePtr( size_type i ) const override;
+    /// additional mva input variables
+    /// sigmaIEtaIPhi
+    float sigmaIetaIphi() const { return sigmaIetaIphi_; }
+    /// sigmaIEtaIPhi (from full 5x5 non-ZS clusters without fractions, a la 5.3.X)
+    float full5x5_sigmaIetaIphi() const { return full5x5_sigmaIetaIphi_; }
+    /// ip3d
+    double ip3d() const { return ip3d_; }
+    /// set missing mva input variables
+    void setMvaVariables(double sigmaIetaIphi, double ip3d);
+    void full5x5_setSigmaIetaIphi(float sigmaIetaIphi) { full5x5_sigmaIetaIphi_ = sigmaIetaIphi; }
 
-      // ---- embed various impact parameters with errors ----
-      typedef enum IPTYPE { PV2D = 0, PV3D = 1, BS2D = 2, BS3D = 3, PVDZ = 4, IpTypeSize = 5 } IpType;
-      /// Impact parameter wrt primary vertex or beamspot
-      double dB(IPTYPE type) const;
-      /// Uncertainty on the corresponding impact parameter
-      double edB(IPTYPE type) const;
-      /// the version without arguments returns PD2D, but with an absolute value (for backwards compatibility)
-      double dB() const { return std::abs(dB(PV2D)); }
-      /// the version without arguments returns PD2D, but with an absolute value (for backwards compatibility)
-      double edB() const { return std::abs(edB(PV2D)); }
-      /// Set impact parameter of a certain type and its uncertainty
-      void setDB(double dB, double edB, IPTYPE type);
+    const EcalRecHitCollection* recHits() const { return &recHits_; }
 
-      // ---- Momentum estimate specific methods ----
-      const LorentzVector & ecalDrivenMomentum() const {return ecalDrivenMomentum_;}
-      void setEcalDrivenMomentum(const Candidate::LorentzVector& mom) {ecalDrivenMomentum_=mom;}
+    /// additional regression variables
+    /// regression1
+    double ecalRegressionEnergy() const { return ecalRegressionEnergy_; }
+    double ecalRegressionError() const { return ecalRegressionError_; }
+    /// regression2
+    double ecalTrackRegressionEnergy() const { return ecalTrackRegressionEnergy_; }
+    double ecalTrackRegressionError() const { return ecalTrackRegressionError_; }
+    /// set regression1
+    void setEcalRegressionEnergy(double val, double err) {
+      ecalRegressionEnergy_ = val;
+      ecalRegressionError_ = err;
+    }
+    /// set regression2
+    void setEcalTrackRegressionEnergy(double val, double err) {
+      ecalTrackRegressionEnergy_ = val;
+      ecalTrackRegressionError_ = err;
+    }
 
-      /// pipe operator (introduced to use pat::Electron with PFTopProjectors)
-      friend std::ostream& reco::operator<<(std::ostream& out, const pat::Electron& obj);
+    /// set scale corrections / smearings
+    void setEcalScale(double val) { ecalScale_ = val; }
+    void setEcalSmear(double val) { ecalSmear_ = val; }
+    void setEcalRegressionScale(double val) { ecalRegressionScale_ = val; }
+    void setEcalRegressionSmear(double val) { ecalRegressionSmear_ = val; }
+    void setEcalTrackRegressionScale(double val) { ecalTrackRegressionScale_ = val; }
+    void setEcalTrackRegressionSmear(double val) { ecalTrackRegressionSmear_ = val; }
 
-      /// additional mva input variables
-      /// sigmaIEtaIPhi
-      float sigmaIetaIphi() const { return sigmaIetaIphi_; }
-      /// sigmaIEtaIPhi (from full 5x5 non-ZS clusters without fractions, a la 5.3.X)
-      float full5x5_sigmaIetaIphi() const { return full5x5_sigmaIetaIphi_; }
-      /// ip3d
-      double ip3d() const { return ip3d_; }
-      /// set missing mva input variables
-      void setMvaVariables( double sigmaIetaIphi, double ip3d );
-      void full5x5_setSigmaIetaIphi(float sigmaIetaIphi) { full5x5_sigmaIetaIphi_ = sigmaIetaIphi; }
+    /// get scale corrections /smearings
+    double ecalScale() const { return ecalScale_; }
+    double ecalSmear() const { return ecalSmear_; }
+    double ecalRegressionScale() const { return ecalRegressionScale_; }
+    double ecalRegressionSmear() const { return ecalRegressionSmear_; }
+    double ecalTrackRegressionScale() const { return ecalTrackRegressionScale_; }
+    double ecalTrackRegressionSmear() const { return ecalTrackRegressionSmear_; }
+    /// vertex fit combined with missing number of hits method
+    bool passConversionVeto() const { return passConversionVeto_; }
+    void setPassConversionVeto(bool flag) { passConversionVeto_ = flag; }
 
-      const EcalRecHitCollection * recHits() const { return &recHits_;}
+    /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
+    edm::RefVector<pat::PackedCandidateCollection> associatedPackedPFCandidates() const;
+    /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
+    template <typename T>
+    void setAssociatedPackedPFCandidates(const edm::RefProd<pat::PackedCandidateCollection>& refprod,
+                                         T beginIndexItr,
+                                         T endIndexItr) {
+      packedPFCandidates_ = refprod;
+      associatedPackedFCandidateIndices_.clear();
+      associatedPackedFCandidateIndices_.insert(associatedPackedFCandidateIndices_.end(), beginIndexItr, endIndexItr);
+    }
 
-      /// additional regression variables
-      /// regression1
-      double ecalRegressionEnergy() const { return ecalRegressionEnergy_;}
-      double ecalRegressionError() const { return ecalRegressionError_;}
-      /// regression2
-      double ecalTrackRegressionEnergy() const { return ecalTrackRegressionEnergy_; }
-      double ecalTrackRegressionError() const { return ecalTrackRegressionError_; }
-      /// set regression1
-      void setEcalRegressionEnergy(double val, double err) { ecalRegressionEnergy_ = val; ecalRegressionError_ = err; }
-      /// set regression2
-      void setEcalTrackRegressionEnergy(double val, double err) { ecalTrackRegressionEnergy_ = val; ecalTrackRegressionError_ = err; }
+    friend class PATElectronSlimmer;
 
-      /// set scale corrections / smearings
-      void setEcalScale(double val) { ecalScale_= val ;}               
-      void setEcalSmear(double val) { ecalSmear_= val;}                
-      void setEcalRegressionScale(double val) {	ecalRegressionScale_ = val ;}     
-      void setEcalRegressionSmear(double val) {	ecalRegressionSmear_ = val;}     
-      void setEcalTrackRegressionScale(double val) { ecalTrackRegressionScale_ = val;}
-      void setEcalTrackRegressionSmear(double val) { ecalTrackRegressionSmear_ = val;}
+  protected:
+    /// init impact parameter defaults (for use in a constructor)
+    void initImpactParameters();
 
-      /// get scale corrections /smearings
-      double ecalScale() const  { return ecalScale_ ;}               
-      double ecalSmear() const  { return ecalSmear_;}                
-      double ecalRegressionScale() const  { return ecalRegressionScale_  ;}     
-      double ecalRegressionSmear() const  {	return ecalRegressionSmear_ ;}     
-      double ecalTrackRegressionScale() const  { return ecalTrackRegressionScale_ ;}
-      double ecalTrackRegressionSmear() const  { return ecalTrackRegressionSmear_ ;}
-      /// vertex fit combined with missing number of hits method
-      bool passConversionVeto() const { return passConversionVeto_; }
-      void setPassConversionVeto( bool flag ) { passConversionVeto_ = flag; }
+    // ---- for content embedding ----
+    /// True if electron's gsfElectronCore is stored internally
+    bool embeddedGsfElectronCore_;
+    /// Place to store electron's gsfElectronCore internally
+    std::vector<reco::GsfElectronCore> gsfElectronCore_;
+    /// True if electron's gsfTrack is stored internally
+    bool embeddedGsfTrack_;
+    /// Place to store electron's gsfTrack internally
+    std::vector<reco::GsfTrack> gsfTrack_;
+    /// True if electron's supercluster is stored internally
+    bool embeddedSuperCluster_;
+    /// True if electron's pflowsupercluster is stored internally
+    bool embeddedPflowSuperCluster_;
+    /// Place to store electron's supercluster internally
+    std::vector<reco::SuperCluster> superCluster_;
+    /// Place to temporarily store the electron's supercluster after relinking the seed to it
+    edm::AtomicPtrCache<std::vector<reco::SuperCluster> > superClusterRelinked_;
+    /// Place to store electron's basic clusters internally
+    std::vector<reco::CaloCluster> basicClusters_;
+    /// Place to store electron's preshower clusters internally
+    std::vector<reco::CaloCluster> preshowerClusters_;
+    /// Place to store electron's pflow basic clusters internally
+    std::vector<reco::CaloCluster> pflowBasicClusters_;
+    /// Place to store electron's pflow preshower clusters internally
+    std::vector<reco::CaloCluster> pflowPreshowerClusters_;
+    /// Place to store electron's pflow supercluster internally
+    std::vector<reco::SuperCluster> pflowSuperCluster_;
+    /// True if electron's track is stored internally
+    bool embeddedTrack_;
+    /// Place to store electron's track internally
+    std::vector<reco::Track> track_;
+    /// True if seed cluster is stored internally
+    bool embeddedSeedCluster_;
+    /// Place to store electron's seed cluster internally
+    std::vector<reco::CaloCluster> seedCluster_;
+    /// True if RecHits stored internally
+    bool embeddedRecHits_;
+    /// Place to store electron's RecHits internally (5x5 around seed+ all RecHits)
+    EcalRecHitCollection recHits_;
 
-      /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
-      edm::RefVector<pat::PackedCandidateCollection> associatedPackedPFCandidates() const ;
-      /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
-      template<typename T>
-      void setAssociatedPackedPFCandidates(const edm::RefProd<pat::PackedCandidateCollection> & refprod,
-                                           T beginIndexItr,
-                                           T endIndexItr) {
-        packedPFCandidates_ = refprod;
-        associatedPackedFCandidateIndices_.clear();
-        associatedPackedFCandidateIndices_.insert(associatedPackedFCandidateIndices_.end(),
-                                                  beginIndexItr,
-                                                  endIndexItr);
-      }
+    // ---- electron ID's holder ----
+    /// Electron IDs
+    std::vector<IdPair> electronIDs_;
 
-      friend class PATElectronSlimmer;
+    // ---- PF specific members ----
+    bool isPF_;
+    /// true if the IsolatedPFCandidate is embedded
+    bool embeddedPFCandidate_;
+    /// A copy of the source IsolatedPFCandidate is stored in this vector if embeddedPFCandidate_ if True
+    reco::PFCandidateCollection pfCandidate_;
+    /// reference to the IsolatedPFCandidate this has been built from; null if this has been built from a standard electron
+    reco::PFCandidateRef pfCandidateRef_;
 
-    protected:
-      /// init impact parameter defaults (for use in a constructor)
-      void initImpactParameters();
+    // ---- specific members : Momentum estimates ----
+    /// ECAL-driven momentum
+    LorentzVector ecalDrivenMomentum_;
 
-      // ---- for content embedding ----
-      /// True if electron's gsfElectronCore is stored internally
-      bool embeddedGsfElectronCore_;
-      /// Place to store electron's gsfElectronCore internally
-      std::vector<reco::GsfElectronCore> gsfElectronCore_;
-      /// True if electron's gsfTrack is stored internally
-      bool embeddedGsfTrack_;
-      /// Place to store electron's gsfTrack internally
-      std::vector<reco::GsfTrack> gsfTrack_;
-      /// True if electron's supercluster is stored internally
-      bool embeddedSuperCluster_;
-      /// True if electron's pflowsupercluster is stored internally
-      bool embeddedPflowSuperCluster_;
-      /// Place to store electron's supercluster internally
-      std::vector<reco::SuperCluster> superCluster_;
-      /// Place to temporarily store the electron's supercluster after relinking the seed to it
-      edm::AtomicPtrCache<std::vector<reco::SuperCluster> > superClusterRelinked_;
-      /// Place to store electron's basic clusters internally 
-      std::vector<reco::CaloCluster> basicClusters_;
-      /// Place to store electron's preshower clusters internally      
-      std::vector<reco::CaloCluster> preshowerClusters_;
-      /// Place to store electron's pflow basic clusters internally
-      std::vector<reco::CaloCluster> pflowBasicClusters_;
-      /// Place to store electron's pflow preshower clusters internally
-      std::vector<reco::CaloCluster> pflowPreshowerClusters_;
-      /// Place to store electron's pflow supercluster internally
-      std::vector<reco::SuperCluster> pflowSuperCluster_;
-      /// True if electron's track is stored internally
-      bool embeddedTrack_;
-      /// Place to store electron's track internally
-      std::vector<reco::Track> track_;
-      /// True if seed cluster is stored internally
-      bool embeddedSeedCluster_;
-      /// Place to store electron's seed cluster internally
-      std::vector<reco::CaloCluster> seedCluster_;
-      /// True if RecHits stored internally
-      bool embeddedRecHits_;	
-      /// Place to store electron's RecHits internally (5x5 around seed+ all RecHits)
-      EcalRecHitCollection recHits_;
+    /// additional missing mva variables : 14/04/2012
+    float sigmaIetaIphi_, full5x5_sigmaIetaIphi_;
+    double ip3d_;
 
-      // ---- electron ID's holder ----
-      /// Electron IDs
-      std::vector<IdPair> electronIDs_;
+    /// output of regression
+    double ecalRegressionEnergy_;
+    double ecalTrackRegressionEnergy_;
+    double ecalRegressionError_;
+    double ecalTrackRegressionError_;
 
-      // ---- PF specific members ----
-      bool isPF_;
-      /// true if the IsolatedPFCandidate is embedded
-      bool embeddedPFCandidate_;
-      /// A copy of the source IsolatedPFCandidate is stored in this vector if embeddedPFCandidate_ if True
-      reco::PFCandidateCollection pfCandidate_;
-      /// reference to the IsolatedPFCandidate this has been built from; null if this has been built from a standard electron
-      reco::PFCandidateRef pfCandidateRef_;
+    /// scale corrections and smearing applied or to be be applied. Initialized to -99999.
+    double ecalScale_;
+    double ecalSmear_;
 
-      // ---- specific members : Momentum estimates ----
-      /// ECAL-driven momentum
-      LorentzVector ecalDrivenMomentum_;
+    double ecalRegressionScale_;
+    double ecalRegressionSmear_;
 
-      /// additional missing mva variables : 14/04/2012
-      float sigmaIetaIphi_, full5x5_sigmaIetaIphi_;
-      double ip3d_;
+    double ecalTrackRegressionScale_;
+    double ecalTrackRegressionSmear_;
 
-      /// output of regression
-      double ecalRegressionEnergy_;
-      double ecalTrackRegressionEnergy_;
-      double ecalRegressionError_;
-      double ecalTrackRegressionError_;
+    /// PUPPI isolations
+    float puppiChargedHadronIso_;
+    float puppiNeutralHadronIso_;
+    float puppiPhotonIso_;
 
-      /// scale corrections and smearing applied or to be be applied. Initialized to -99999.
-      double ecalScale_;
-      double ecalSmear_;
+    /// PUPPINoLeptons isolations
+    float puppiNoLeptonsChargedHadronIso_;
+    float puppiNoLeptonsNeutralHadronIso_;
+    float puppiNoLeptonsPhotonIso_;
 
-      double ecalRegressionScale_;
-      double ecalRegressionSmear_;
+    /// conversion veto
+    bool passConversionVeto_;
 
-      double ecalTrackRegressionScale_;
-      double ecalTrackRegressionSmear_;
-      
-      /// PUPPI isolations
-      float puppiChargedHadronIso_;
-      float puppiNeutralHadronIso_;
-      float puppiPhotonIso_;
+    // ---- cached impact parameters ----
+    /// True if the IP (former dB) has been cached
+    uint8_t cachedIP_;
+    /// Impact parameter at the primary vertex,
+    float ip_[IpTypeSize];
+    /// Impact parameter uncertainty as recommended by the tracking group
+    float eip_[IpTypeSize];
 
-      /// PUPPINoLeptons isolations
-      float puppiNoLeptonsChargedHadronIso_;
-      float puppiNoLeptonsNeutralHadronIso_;
-      float puppiNoLeptonsPhotonIso_;
-
-      /// conversion veto
-      bool passConversionVeto_;
-
-      // ---- cached impact parameters ----
-      /// True if the IP (former dB) has been cached
-      uint8_t    cachedIP_;
-      /// Impact parameter at the primary vertex,
-      float  ip_[IpTypeSize];    
-      /// Impact parameter uncertainty as recommended by the tracking group
-      float  eip_[IpTypeSize];      
-
-      // ---- link to PackedPFCandidates
-      edm::RefProd<pat::PackedCandidateCollection> packedPFCandidates_;
-      std::vector<uint16_t> associatedPackedFCandidateIndices_;
+    // ---- link to PackedPFCandidates
+    edm::RefProd<pat::PackedCandidateCollection> packedPFCandidates_;
+    std::vector<uint16_t> associatedPackedFCandidateIndices_;
   };
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/EventHypothesis.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesis.h
@@ -11,199 +11,202 @@
 #include <cxxabi.h>
 
 namespace pat {
-   // forward declaration
-   namespace eventhypothesis { template<typename T> class Looper; }
-   // real declarations
-   namespace eventhypothesis { 
-        // typedef for the Ref
-        typedef reco::CandidatePtr CandRefType; // Ptr one day in the future
-        // filter
-        struct ParticleFilter {
-            virtual ~ParticleFilter() {}
-            bool operator()(const std::pair<std::string, CandRefType> &p) const { return operator()(p.second, p.first); }
-            virtual bool operator()(const CandRefType &cand, const std::string &role) const = 0;
-        };
-        // smart pointer to the filter
-        typedef boost::shared_ptr<const ParticleFilter> ParticleFilterPtr;
-   }
-   // the class
-   class EventHypothesis {
-        public:
-            typedef eventhypothesis::CandRefType              CandRefType;
-            typedef std::pair<std::string, CandRefType>       value_type;
-            typedef std::vector<value_type>                   vector_type;
-            typedef vector_type::const_iterator               const_iterator;
-            typedef vector_type::const_reverse_iterator       const_reverse_iterator;
-            typedef eventhypothesis::Looper<reco::Candidate>  CandLooper;
+  // forward declaration
+  namespace eventhypothesis {
+    template <typename T>
+    class Looper;
+  }
+  // real declarations
+  namespace eventhypothesis {
+    // typedef for the Ref
+    typedef reco::CandidatePtr CandRefType;  // Ptr one day in the future
+    // filter
+    struct ParticleFilter {
+      virtual ~ParticleFilter() {}
+      bool operator()(const std::pair<std::string, CandRefType> &p) const { return operator()(p.second, p.first); }
+      virtual bool operator()(const CandRefType &cand, const std::string &role) const = 0;
+    };
+    // smart pointer to the filter
+    typedef boost::shared_ptr<const ParticleFilter> ParticleFilterPtr;
+  }  // namespace eventhypothesis
+  // the class
+  class EventHypothesis {
+  public:
+    typedef eventhypothesis::CandRefType CandRefType;
+    typedef std::pair<std::string, CandRefType> value_type;
+    typedef std::vector<value_type> vector_type;
+    typedef vector_type::const_iterator const_iterator;
+    typedef vector_type::const_reverse_iterator const_reverse_iterator;
+    typedef eventhypothesis::Looper<reco::Candidate> CandLooper;
 
-            void add(const CandRefType &ref, const std::string &role) ;
+    void add(const CandRefType &ref, const std::string &role);
 
-            const_iterator begin() const { return particles_.begin(); }
-            const_iterator end()   const { return particles_.end();   }
-            const_reverse_iterator rbegin() const { return particles_.rbegin(); }
-            const_reverse_iterator rend()   const { return particles_.rend();   }
+    const_iterator begin() const { return particles_.begin(); }
+    const_iterator end() const { return particles_.end(); }
+    const_reverse_iterator rbegin() const { return particles_.rbegin(); }
+    const_reverse_iterator rend() const { return particles_.rend(); }
 
-            class ByRole {
-                public:
-                    ByRole(const std::string &role) : role_(role) {}
-                    bool operator()(const value_type &p) const { return p.first == role_; }
-                private:
-                    const std::string &role_;
-            };
+    class ByRole {
+    public:
+      ByRole(const std::string &role) : role_(role) {}
+      bool operator()(const value_type &p) const { return p.first == role_; }
 
-            typedef eventhypothesis::ParticleFilter ParticleFilter;
-            typedef eventhypothesis::ParticleFilterPtr ParticleFilterPtr;
-    
-            const CandRefType & get(const std::string &role, int index=0) const ;
-            const CandRefType & get(const ParticleFilter &filter, int index=0) const ;
-            template<typename T> const T * getAs(const std::string &role, int index=0) const ;
-            template<typename T> const T * getAs(const ParticleFilter &filter, int index=0) const ;
-            const CandRefType & operator[](const std::string &role) const { return get(role,0); }
-            const CandRefType & operator[](const ParticleFilter &filter) const { return get(filter,0); }
+    private:
+      const std::string &role_;
+    };
 
-            /// Return EDM references to all particles which have certaint roles. 
-            std::vector<CandRefType> all(const std::string &roleRegexp) const;
-            /// Return EDM references to all particles which satisfy some condition. 
-            std::vector<CandRefType> all(const ParticleFilter &filter) const;
+    typedef eventhypothesis::ParticleFilter ParticleFilter;
+    typedef eventhypothesis::ParticleFilterPtr ParticleFilterPtr;
 
-            size_t count() const { return particles_.size(); }
-            /// Counts particles which have certaint roles. 
-            size_t count(const std::string &roleRegexp) const;
-            /// Counts particles which satisfy some condition. 
-            size_t count(const ParticleFilter &role) const;
-            
-            /// Loops over all particles
-            CandLooper loop() const ;
-            /// Loops over particles which have certaint roles. 
-            CandLooper loop(const std::string &roleRegexp) const;
-            /// Loops over particles which satisfy some condition. 
-            /// The caller code owns the filter, and must take care it is not deleted while the looper is still being used
-            CandLooper loop(const ParticleFilter &filter) const;
-            /// Loops over particles which satisfy some condition. 
-            /// The looper owns the filter, which will be deleted when the looper is deleted.
-            /// That is, you can call eventHypothesis.loop(new WhateverFilterYouLike(...))
-            CandLooper loop(const ParticleFilter *filter) const;
-            /// Loops over particles which satisfy some condition. 
-            CandLooper loop(const ParticleFilterPtr &filter) const;
+    const CandRefType &get(const std::string &role, int index = 0) const;
+    const CandRefType &get(const ParticleFilter &filter, int index = 0) const;
+    template <typename T>
+    const T *getAs(const std::string &role, int index = 0) const;
+    template <typename T>
+    const T *getAs(const ParticleFilter &filter, int index = 0) const;
+    const CandRefType &operator[](const std::string &role) const { return get(role, 0); }
+    const CandRefType &operator[](const ParticleFilter &filter) const { return get(filter, 0); }
 
+    /// Return EDM references to all particles which have certaint roles.
+    std::vector<CandRefType> all(const std::string &roleRegexp) const;
+    /// Return EDM references to all particles which satisfy some condition.
+    std::vector<CandRefType> all(const ParticleFilter &filter) const;
 
+    size_t count() const { return particles_.size(); }
+    /// Counts particles which have certaint roles.
+    size_t count(const std::string &roleRegexp) const;
+    /// Counts particles which satisfy some condition.
+    size_t count(const ParticleFilter &role) const;
 
-            /// Loops over particles which have certaint roles. 
-            template<typename T> eventhypothesis::Looper<T> loopAs(const std::string &roleRegexp) const ;
-            /// Loops over particles which satisfy some condition. 
-            /// The caller code owns the filter, and must take care it is not deleted while the looper is still being used
-            template<typename T> eventhypothesis::Looper<T> loopAs(const ParticleFilter &filter) const;
-            /// Loops over particles which satisfy some condition. 
-            /// The looper owns the filter, which will be deleted when the looper is deleted.
-            /// That is, you can call eventHypothesis.loopAs<...>(new WhateverFilterYouLike(...))
-            template<typename T> eventhypothesis::Looper<T> loopAs(const ParticleFilter *filter) const;
-            /// Loops over particles which satisfy some condition. 
-            template<typename T> eventhypothesis::Looper<T> loopAs(const ParticleFilterPtr &filter) const;
-        private:
-            template<typename Iterator, typename Predicate>
-            Iterator realGet(const Iterator &realBegin, const Iterator &realEnd, const Predicate &p, size_t idx) const ;
-	    char * getDemangledSymbol(const char* mangledSymbol) const;
-	    template<typename T> std::string createExceptionMessage(const CandRefType &ref) const;
+    /// Loops over all particles
+    CandLooper loop() const;
+    /// Loops over particles which have certaint roles.
+    CandLooper loop(const std::string &roleRegexp) const;
+    /// Loops over particles which satisfy some condition.
+    /// The caller code owns the filter, and must take care it is not deleted while the looper is still being used
+    CandLooper loop(const ParticleFilter &filter) const;
+    /// Loops over particles which satisfy some condition.
+    /// The looper owns the filter, which will be deleted when the looper is deleted.
+    /// That is, you can call eventHypothesis.loop(new WhateverFilterYouLike(...))
+    CandLooper loop(const ParticleFilter *filter) const;
+    /// Loops over particles which satisfy some condition.
+    CandLooper loop(const ParticleFilterPtr &filter) const;
 
-            std::vector<value_type> particles_;
+    /// Loops over particles which have certaint roles.
+    template <typename T>
+    eventhypothesis::Looper<T> loopAs(const std::string &roleRegexp) const;
+    /// Loops over particles which satisfy some condition.
+    /// The caller code owns the filter, and must take care it is not deleted while the looper is still being used
+    template <typename T>
+    eventhypothesis::Looper<T> loopAs(const ParticleFilter &filter) const;
+    /// Loops over particles which satisfy some condition.
+    /// The looper owns the filter, which will be deleted when the looper is deleted.
+    /// That is, you can call eventHypothesis.loopAs<...>(new WhateverFilterYouLike(...))
+    template <typename T>
+    eventhypothesis::Looper<T> loopAs(const ParticleFilter *filter) const;
+    /// Loops over particles which satisfy some condition.
+    template <typename T>
+    eventhypothesis::Looper<T> loopAs(const ParticleFilterPtr &filter) const;
 
-   } ;
+  private:
+    template <typename Iterator, typename Predicate>
+    Iterator realGet(const Iterator &realBegin, const Iterator &realEnd, const Predicate &p, size_t idx) const;
+    char *getDemangledSymbol(const char *mangledSymbol) const;
+    template <typename T>
+    std::string createExceptionMessage(const CandRefType &ref) const;
 
-   namespace eventhypothesis {
-        struct AcceptAllFilter : public ParticleFilter {
-            AcceptAllFilter(){}
-            static const AcceptAllFilter & get() { return s_dummyFilter; }
-            bool operator()(const CandRefType &cand, const std::string &role) const override { return true; }
-            private:
-               static const AcceptAllFilter s_dummyFilter;
-        };
-        class RoleRegexpFilter : public ParticleFilter {
-            public:
-                explicit RoleRegexpFilter(const std::string &roleRegexp) : re_(roleRegexp) {}
-                bool operator()(const CandRefType &cand, const std::string &role) const override {
-                    return boost::regex_match(role, re_);
-                }
-            private:
-                boost::regex re_;
-        };
-   }
- 
-   template<typename Iterator, typename Predicate>
-   Iterator EventHypothesis::realGet(const Iterator &realBegin, const Iterator &realEnd, const Predicate &pred, size_t idx) const  
-   {
-        Iterator it = realBegin;
-        while (it != realEnd) {
-            if (pred(*it)) {
-                if (idx == 0) return it;
-                idx--;
-            }
-            ++it;
-        }
-        return it;
-   }
+    std::vector<value_type> particles_;
+  };
 
-   template<typename T>
-   std::string
-   EventHypothesis::createExceptionMessage(const CandRefType &ref) const {
-     std::stringstream message;
-     char *currentType = getDemangledSymbol(typeid(std::remove_reference<decltype(ref)>::type::value_type).name());
-     char *targetType = getDemangledSymbol(typeid(T).name());
-     if (currentType != nullptr && targetType != nullptr) {
-       message << "You can't convert a '" << currentType << "' to a '" << targetType << "'" << std::endl;
-       free(currentType);
-       free(targetType);
-     } else {
-       message << "You can't convert a '" << typeid(ref).name() << "' to a '" << typeid(T).name() << "'" << std::endl;
-       message << "Note: you can use 'c++filt -t' command to convert the above in human readable types." << std::endl;
-     }
-     return message.str();
-   }
+  namespace eventhypothesis {
+    struct AcceptAllFilter : public ParticleFilter {
+      AcceptAllFilter() {}
+      static const AcceptAllFilter &get() { return s_dummyFilter; }
+      bool operator()(const CandRefType &cand, const std::string &role) const override { return true; }
 
-   template<typename T> 
-   const T * 
-   EventHypothesis::getAs(const std::string &role, int index) const 
-   {
-       CandRefType ref = get(role, index);
-       const T* ret = dynamic_cast<const T*>(ref.get());
-       if ((ret == 0) && (ref.get() != nullptr)) throw cms::Exception("Type Checking") << createExceptionMessage<T>(ref);
-       return ret;
-   }
-   template<typename T> 
-   const T * 
-   EventHypothesis::getAs(const ParticleFilter &filter, int index) const 
-   {
-       CandRefType ref = get(filter, index);
-       const T* ret = dynamic_cast<const T*>(ref.get());
-       if ((ret == 0) && (ref.get() != nullptr)) throw cms::Exception("Type Checking") << createExceptionMessage<T>(ref);
-       return ret;
-   }
-   template<typename T>
-   eventhypothesis::Looper<T>
-   EventHypothesis::loopAs(const std::string &roleRegexp) const 
-   {
-       return loopAs<T>(new pat::eventhypothesis::RoleRegexpFilter(roleRegexp));
-   }
+    private:
+      static const AcceptAllFilter s_dummyFilter;
+    };
+    class RoleRegexpFilter : public ParticleFilter {
+    public:
+      explicit RoleRegexpFilter(const std::string &roleRegexp) : re_(roleRegexp) {}
+      bool operator()(const CandRefType &cand, const std::string &role) const override {
+        return boost::regex_match(role, re_);
+      }
 
-   template<typename T>
-   eventhypothesis::Looper<T>
-   EventHypothesis::loopAs(const ParticleFilter &role) const
-   {
-       return pat::eventhypothesis::Looper<T>(*this, role);
-   }
+    private:
+      boost::regex re_;
+    };
+  }  // namespace eventhypothesis
 
-   template<typename T>
-   eventhypothesis::Looper<T>
-   EventHypothesis::loopAs(const ParticleFilter *role) const
-   {
-       return pat::eventhypothesis::Looper<T>(*this, role);
-   }
+  template <typename Iterator, typename Predicate>
+  Iterator EventHypothesis::realGet(const Iterator &realBegin,
+                                    const Iterator &realEnd,
+                                    const Predicate &pred,
+                                    size_t idx) const {
+    Iterator it = realBegin;
+    while (it != realEnd) {
+      if (pred(*it)) {
+        if (idx == 0)
+          return it;
+        idx--;
+      }
+      ++it;
+    }
+    return it;
+  }
 
-   template<typename T>
-   eventhypothesis::Looper<T>
-   EventHypothesis::loopAs(const ParticleFilterPtr &role) const
-   {
-       return pat::eventhypothesis::Looper<T>(*this, role);
-   }
-}
+  template <typename T>
+  std::string EventHypothesis::createExceptionMessage(const CandRefType &ref) const {
+    std::stringstream message;
+    char *currentType = getDemangledSymbol(typeid(std::remove_reference<decltype(ref)>::type::value_type).name());
+    char *targetType = getDemangledSymbol(typeid(T).name());
+    if (currentType != nullptr && targetType != nullptr) {
+      message << "You can't convert a '" << currentType << "' to a '" << targetType << "'" << std::endl;
+      free(currentType);
+      free(targetType);
+    } else {
+      message << "You can't convert a '" << typeid(ref).name() << "' to a '" << typeid(T).name() << "'" << std::endl;
+      message << "Note: you can use 'c++filt -t' command to convert the above in human readable types." << std::endl;
+    }
+    return message.str();
+  }
+
+  template <typename T>
+  const T *EventHypothesis::getAs(const std::string &role, int index) const {
+    CandRefType ref = get(role, index);
+    const T *ret = dynamic_cast<const T *>(ref.get());
+    if ((ret == 0) && (ref.get() != nullptr))
+      throw cms::Exception("Type Checking") << createExceptionMessage<T>(ref);
+    return ret;
+  }
+  template <typename T>
+  const T *EventHypothesis::getAs(const ParticleFilter &filter, int index) const {
+    CandRefType ref = get(filter, index);
+    const T *ret = dynamic_cast<const T *>(ref.get());
+    if ((ret == 0) && (ref.get() != nullptr))
+      throw cms::Exception("Type Checking") << createExceptionMessage<T>(ref);
+    return ret;
+  }
+  template <typename T>
+  eventhypothesis::Looper<T> EventHypothesis::loopAs(const std::string &roleRegexp) const {
+    return loopAs<T>(new pat::eventhypothesis::RoleRegexpFilter(roleRegexp));
+  }
+
+  template <typename T>
+  eventhypothesis::Looper<T> EventHypothesis::loopAs(const ParticleFilter &role) const {
+    return pat::eventhypothesis::Looper<T>(*this, role);
+  }
+
+  template <typename T>
+  eventhypothesis::Looper<T> EventHypothesis::loopAs(const ParticleFilter *role) const {
+    return pat::eventhypothesis::Looper<T>(*this, role);
+  }
+
+  template <typename T>
+  eventhypothesis::Looper<T> EventHypothesis::loopAs(const ParticleFilterPtr &role) const {
+    return pat::eventhypothesis::Looper<T>(*this, role);
+  }
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/EventHypothesisLooper.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesisLooper.h
@@ -5,232 +5,270 @@
 #include "DataFormats/PatCandidates/interface/EventHypothesis.h"
 #include <algorithm>
 
-namespace pat { namespace eventhypothesis {
-        template<typename T>
-        class DynCastCandPtr {
-            public:
-                const T *get(const reco::Candidate *ptr) ;
-                void clearCache() { isPtrCached_ = false; }
-                bool typeOk(const reco::Candidate *ptr) { doPtr(ptr); return cachePtr_ != 0; }
-            private:
-                void       doPtr(const reco::Candidate *ptr) ;
-                bool       isPtrCached_;
-                const T *  cachePtr_;
-        };
-        template<typename T>
-        void DynCastCandPtr<T>::doPtr(const reco::Candidate *ptr) {
-            if (!isPtrCached_) { 
-                cachePtr_    = dynamic_cast<const T *>(ptr); 
-                isPtrCached_ = true;
-            }
+namespace pat {
+  namespace eventhypothesis {
+    template <typename T>
+    class DynCastCandPtr {
+    public:
+      const T *get(const reco::Candidate *ptr);
+      void clearCache() { isPtrCached_ = false; }
+      bool typeOk(const reco::Candidate *ptr) {
+        doPtr(ptr);
+        return cachePtr_ != 0;
+      }
+
+    private:
+      void doPtr(const reco::Candidate *ptr);
+      bool isPtrCached_;
+      const T *cachePtr_;
+    };
+    template <typename T>
+    void DynCastCandPtr<T>::doPtr(const reco::Candidate *ptr) {
+      if (!isPtrCached_) {
+        cachePtr_ = dynamic_cast<const T *>(ptr);
+        isPtrCached_ = true;
+      }
+    }
+    template <typename T>
+    const T *DynCastCandPtr<T>::get(const reco::Candidate *ptr) {
+      doPtr(ptr);
+      if ((ptr != nullptr) && (cachePtr_ == 0))
+        throw cms::Exception("Type Checking")
+            << "You can't convert a " << typeid(*ptr).name() << " to a " << typeid(T).name() << "\n"
+            << "note: you can use c++filt command to convert the above in human readable types.\n";
+      return cachePtr_;
+    }
+
+    template <>
+    struct DynCastCandPtr<reco::Candidate> {
+      const reco::Candidate *get(const reco::Candidate *ptr) { return ptr; }
+      void clearCache() {}
+      bool typeOk(const reco::Candidate *ptr) { return true; }
+    };
+
+    template <typename T>
+    class Looper {
+    public:
+      /// Looper from EventHypothesis and an external, not owned, ParticleFilter.
+      /// That is: MyFilter flt; Looper(eh, flt);
+      Looper(const EventHypothesis &eh, const ParticleFilter &filter);
+
+      /// Looper from EventHypothesis and an internal, owned, ParticleFilter
+      /// That is: Looper(eh, new MyFilter());
+      Looper(const EventHypothesis &eh, const ParticleFilter *filter);
+      /// Looper from EventHypothesis and a shared ParticleFilter
+      /// That is: Looper(eh, ParticleFilterPtr(new MyFilter()));
+      Looper(const EventHypothesis &eh, const ParticleFilterPtr &filter);
+      ~Looper() {}
+
+      /// Accessor as if it was a const_iterator on a list of T
+      const T &operator*() const { return ptr_.get(iter_->second.get()); }
+      /// Accessor as if it was a const_iterator on a list of T
+      const T *operator->() const { return ptr_.get(iter_->second.get()); }
+      /// Accessor as if it was a smart pointer to const T *
+      const T *get() const { return ptr_.get(iter_->second.get()); }
+
+      /// test if the type is correct
+      bool isTypeOk() const { return ptr_.typeOk(iter_->second.get()); }
+
+      /// Role of pointed item
+      const std::string &role() const { return iter_->first; }
+      /// EDM Ref to pointed particle
+      const CandRefType &ref() const { return iter_->second; }
+      /// C++ reference to pointed particle
+      const reco::Candidate &cand() const { return *iter_->second; }
+
+      /// Index of this item in the full EventHypothesis
+      size_t globalIndex() { return iter_ - eh_.begin(); }
+      /// Index of this item among those in the loop
+      size_t index() const { return num_; }
+      /// Number of particles in the loop
+      size_t size() const {
+        if (total_ < 0)
+          realSize();
+        return total_;
+      }
+
+      /// iteration
+      Looper &operator++();
+      /// iteration
+      Looper &operator--();
+      /// skip (might be slow)
+      Looper &skip(int delta);
+      /// Reset to the start or to any other specific item; negatives count from the end.
+      /// might be slow, especially with negative items
+      Looper &reset(int item = 0);
+
+      /// Returns true if you have not run out of the boundaries.
+      /// It does NOT check if typeOk()
+      operator bool() const;
+
+      /// returns true if loopers point to the same record
+      template <typename T2>
+      bool operator==(const Looper<T2> &other) const {
+        return iter_ == other.iter_;
+      }
+      template <typename T2>
+      bool operator!=(const Looper<T2> &other) const {
+        return iter_ != other.iter_;
+      }
+      template <typename T2>
+      bool operator<=(const Looper<T2> &other) const {
+        return iter_ <= other.iter_;
+      }
+      template <typename T2>
+      bool operator>=(const Looper<T2> &other) const {
+        return iter_ >= other.iter_;
+      }
+      template <typename T2>
+      bool operator<(const Looper<T2> &other) const {
+        return iter_ < other.iter_;
+      }
+      template <typename T2>
+      bool operator>(const Looper<T2> &other) const {
+        return iter_ > other.iter_;
+      }
+
+    private:
+      struct null_deleter {
+        void operator()(void const *) const {}
+      };
+      typedef typename EventHypothesis::const_iterator const_iterator;
+
+      void first();
+      void realSize() const;
+      bool assertOk() const;
+
+      const EventHypothesis &eh_;
+      const ParticleFilterPtr filter_;
+      const_iterator iter_;
+      int num_;
+      mutable int total_;  // mutable as it is not computed unless needed
+      mutable DynCastCandPtr<T> ptr_;
+    };
+    typedef Looper<reco::Candidate> CandLooper;
+
+    template <typename T>
+    Looper<T>::Looper(const EventHypothesis &eh, const ParticleFilter &filter)
+        : eh_(eh), filter_(ParticleFilterPtr(&filter, typename Looper<T>::null_deleter())), total_(-1) {
+      first();
+    }
+
+    template <typename T>
+    Looper<T>::Looper(const EventHypothesis &eh, const ParticleFilter *filter) : eh_(eh), filter_(filter), total_(-1) {
+      first();
+    }
+
+    template <typename T>
+    Looper<T>::Looper(const EventHypothesis &eh, const ParticleFilterPtr &filter)
+        : eh_(eh), filter_(filter), total_(-1) {
+      first();
+    }
+
+    template <typename T>
+    bool Looper<T>::assertOk() const {
+      assert(iter_ <= eh_.end());
+      assert((iter_ + 1) >= eh_.begin());
+      assert((iter_ < eh_.begin()) || (iter_ == eh_.end()) || ((*filter_)(*iter_)));
+      return true;
+    }
+
+    template <typename T>
+    Looper<T> &Looper<T>::operator++() {
+      ptr_.clearCache();
+      assert(assertOk());
+      if (iter_ == eh_.end())
+        return *this;
+      do {
+        ++iter_;
+        if (iter_ == eh_.end())
+          break;
+        if ((*filter_)(*iter_)) {
+          assert(assertOk());
+          ++num_;
+          return *this;
         }
-        template<typename T>
-        const T * DynCastCandPtr<T>::get(const reco::Candidate *ptr) {
-            doPtr(ptr);
-            if ((ptr != nullptr) && (cachePtr_ == 0)) throw cms::Exception("Type Checking") <<
-                "You can't convert a " << typeid(*ptr).name() << " to a " << typeid(T).name() << "\n" <<
-                "note: you can use c++filt command to convert the above in human readable types.\n";
-            return cachePtr_;
+      } while (true);
+      assert(assertOk());
+      return *this;
+    }
+    template <typename T>
+    Looper<T> &Looper<T>::operator--() {
+      ptr_.clearCache();
+      assert(assertOk());
+      if (num_ < 0)
+        return *this;
+      do {
+        --iter_;
+        if (iter_ < eh_.begin()) {
+          num_ = -1;
+          break;
         }
-
-        template<>
-        struct DynCastCandPtr<reco::Candidate> {
-            const reco::Candidate *get(const reco::Candidate *ptr) { return ptr; }
-            void clearCache() {}
-            bool typeOk(const reco::Candidate *ptr) { return true; }
-        };
-
-        template<typename T>
-        class Looper {
-            public:
-                /// Looper from EventHypothesis and an external, not owned, ParticleFilter.
-                /// That is: MyFilter flt; Looper(eh, flt);
-                Looper(const EventHypothesis &eh, const ParticleFilter &filter) ;
-
-                /// Looper from EventHypothesis and an internal, owned, ParticleFilter
-                /// That is: Looper(eh, new MyFilter());
-                Looper(const EventHypothesis &eh, const ParticleFilter *filter) ;
-                /// Looper from EventHypothesis and a shared ParticleFilter
-                /// That is: Looper(eh, ParticleFilterPtr(new MyFilter()));
-                Looper(const EventHypothesis &eh, const ParticleFilterPtr &filter) ;
-                ~Looper() {}
-
-                /// Accessor as if it was a const_iterator on a list of T
-                const T & operator*()  const { return ptr_.get(iter_->second.get()); }
-                /// Accessor as if it was a const_iterator on a list of T
-                const T * operator->() const { return ptr_.get(iter_->second.get()); }
-                /// Accessor as if it was a smart pointer to const T *
-                const T * get()        const { return ptr_.get(iter_->second.get()); }
-                
-                /// test if the type is correct
-                bool  isTypeOk()       const { return ptr_.typeOk(iter_->second.get()); }
-
-                /// Role of pointed item
-                const std::string &     role()  const { return  iter_->first; }
-                /// EDM Ref to pointed particle
-                const CandRefType &     ref ()  const { return  iter_->second; }
-                /// C++ reference to pointed particle
-                const reco::Candidate & cand () const { return *iter_->second; }
-
-                /// Index of this item in the full EventHypothesis
-                size_t globalIndex()  { return iter_ - eh_.begin(); }
-                /// Index of this item among those in the loop
-                size_t index() const { return num_; }
-                /// Number of particles in the loop
-                size_t size()  const { if (total_ < 0) realSize(); return total_; }
-
-                /// iteration
-                Looper & operator++() ;                    
-                /// iteration
-                Looper & operator--() ;                    
-                /// skip (might be slow)
-                Looper & skip(int delta) ; 
-                /// Reset to the start or to any other specific item; negatives count from the end.
-                /// might be slow, especially with negative items
-                Looper & reset(int item=0) ; 
-
-                /// Returns true if you have not run out of the boundaries.
-                /// It does NOT check if typeOk()
-                operator bool() const ;
-
-                /// returns true if loopers point to the same record
-                template<typename T2> bool operator==(const Looper<T2> &other) const { return iter_ == other.iter_; }
-                template<typename T2> bool operator!=(const Looper<T2> &other) const { return iter_ != other.iter_; }
-                template<typename T2> bool operator<=(const Looper<T2> &other) const { return iter_ <= other.iter_; }
-                template<typename T2> bool operator>=(const Looper<T2> &other) const { return iter_ >= other.iter_; }
-                template<typename T2> bool operator<(const Looper<T2> &other)  const { return iter_ < other.iter_; }
-                template<typename T2> bool operator>(const Looper<T2> &other)  const { return iter_ > other.iter_; }
-
-            private:
-                struct null_deleter{  void operator()(void const *) const { } };
-                typedef typename EventHypothesis::const_iterator const_iterator;
-
-                void first() ;
-                void realSize() const ; 
-                bool assertOk() const;
-
-                const EventHypothesis   & eh_;
-                const ParticleFilterPtr   filter_;
-                const_iterator            iter_;
-                int                       num_;
-                mutable int               total_; // mutable as it is not computed unless needed
-                mutable DynCastCandPtr<T> ptr_;
-        };
-        typedef Looper<reco::Candidate> CandLooper;
-
-        template<typename T>
-        Looper<T>::Looper(const EventHypothesis &eh, const ParticleFilter &filter) :
-            eh_(eh), filter_(ParticleFilterPtr(&filter, typename Looper<T>::null_deleter())), total_(-1)
-        {
-            first();
+        if ((*filter_)(*iter_)) {
+          assert(assertOk());
+          --num_;
+          return *this;
         }
+      } while (true);
+      assert(assertOk());
+      return *this;
+    }
 
-        template<typename T>
-        Looper<T>::Looper(const EventHypothesis &eh, const ParticleFilter *filter) :
-            eh_(eh), filter_(filter), total_(-1)
-        {
-            first();
-        }
+    template <typename T>
+    Looper<T> &Looper<T>::skip(int delta) {
+      assert(assertOk());
+      std::advance(this, delta);
+      assert(assertOk());
+      return *this;
+    }
 
-       template<typename T>
-        Looper<T>::Looper(const EventHypothesis &eh, const ParticleFilterPtr &filter) :
-            eh_(eh), filter_(filter), total_(-1)
-        {
-            first();
-        }
+    template <typename T>
+    Looper<T> &Looper<T>::reset(int item) {
+      assert(assertOk());
+      if (item >= 0) {
+        first();
+        std::advance(this, item);
+      } else {
+        num_ = item + 1;
+        iter_ = eh_.end();
+        std::advance(this, item);
+      }
+      assert(assertOk());
+      return *this;
+    }
 
+    template <typename T>
+    void Looper<T>::first() {
+      num_ = 0;
+      iter_ = eh_.begin();
+      ptr_.clearCache();
+      for (; iter_ != eh_.end(); ++iter_) {
+        if ((*filter_)(*iter_))
+          break;
+      }
+      assert(assertOk());
+    }
 
-        template<typename T>
-        bool Looper<T>::assertOk() const {
-            assert(iter_ <= eh_.end());
-            assert((iter_+1) >= eh_.begin());
-            assert((iter_ < eh_.begin()) || (iter_ == eh_.end()) || ((*filter_)(*iter_)));
-            return true;
-        }
+    template <typename T>
+    Looper<T>::operator bool() const {
+      return (iter_ < eh_.end()) && (iter_ >= eh_.begin());
+    }
 
-        template<typename T>
-        Looper<T> & Looper<T>::operator++() { 
-            ptr_.clearCache();
-            assert(assertOk());
-            if (iter_ == eh_.end()) return *this;
-            do {
-                ++iter_; 
-                if (iter_ == eh_.end()) break;
-                if ((*filter_)(*iter_)) {
-                    assert(assertOk());
-                    ++num_; return *this;
-                }
-            } while (true);
-            assert(assertOk());
-            return *this;
-        }
-        template<typename T>
-        Looper<T> & Looper<T>::operator--() { 
-            ptr_.clearCache();
-            assert(assertOk());
-            if (num_ < 0) return *this;
-            do {
-                --iter_; 
-                if (iter_ < eh_.begin()) { num_ = -1; break; }
-                if ((*filter_)(*iter_)) {
-                    assert(assertOk());
-                    --num_; return *this;
-                }
-            } while (true);
-            assert(assertOk());
-            return *this;
-        }
-
-        template<typename T>
-        Looper<T> & Looper<T>::skip(int delta) {
-            assert(assertOk());
-            std::advance(this, delta);
-            assert(assertOk());
-            return *this;
-        }
-    
-        template<typename T>
-        Looper<T> & Looper<T>::reset(int item) {
-            assert(assertOk());
-            if (item >= 0) {
-                first();
-                std::advance(this, item);
-            } else {
-                num_ = item + 1; iter_ = eh_.end();
-                std::advance(this, item);
-            }
-            assert(assertOk());
-            return *this;
-        }
-
-        template<typename T>
-        void Looper<T>::first() {
-            num_ = 0; 
-            iter_ = eh_.begin(); 
-            ptr_.clearCache();
-            for (; iter_ != eh_.end(); ++iter_) {
-                if ((*filter_)(*iter_)) break;
-            }
-            assert(assertOk());
-        }
-
-        template<typename T>
-        Looper<T>::operator bool() const {
-            return  (iter_ < eh_.end()) && (iter_ >= eh_.begin());
-        }
-
-        template<typename T>
-        void Looper<T>::realSize() const {
-            EventHypothesis::const_iterator it = iter_;
-            if (it < eh_.begin()) { 
-                it = eh_.begin(); total_ = 0; 
-            } else {
-                total_ = num_;
-            }
-            for (; it != eh_.end(); ++it) { 
-                if ((*filter_)(*it)) ++total_;
-            }
-        }
-} } // namespaces
+    template <typename T>
+    void Looper<T>::realSize() const {
+      EventHypothesis::const_iterator it = iter_;
+      if (it < eh_.begin()) {
+        it = eh_.begin();
+        total_ = 0;
+      } else {
+        total_ = num_;
+      }
+      for (; it != eh_.end(); ++it) {
+        if ((*filter_)(*it))
+          ++total_;
+      }
+    }
+  }  // namespace eventhypothesis
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/Flags.h
+++ b/DataFormats/PatCandidates/interface/Flags.h
@@ -13,106 +13,106 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include <string>
 #include <vector>
-#include <boost/cstdint.hpp> 
+#include <boost/cstdint.hpp>
 
 namespace pat {
-    struct Flags {
-        enum CleanerFlags {
-            AllBits       = 0xFFFFFFFF,
-            CoreBits      = 0x0000000F,
-            SelectionBits = 0x0000FFF0,
-            OverlapBits   = 0x00FF0000,
-            IsolationBits = 0xFF000000
+  struct Flags {
+    enum CleanerFlags {
+      AllBits = 0xFFFFFFFF,
+      CoreBits = 0x0000000F,
+      SelectionBits = 0x0000FFF0,
+      OverlapBits = 0x00FF0000,
+      IsolationBits = 0xFF000000
 
-        };
-        inline static bool test(uint32_t val, uint32_t mask) { return (val & mask) == 0; }
-        inline static bool test(const reco::Candidate &c, uint32_t mask) { return test(c.status(), mask); }
-
-        static const std::string & bitToString( uint32_t bit );
-        static std::string maskToString( uint32_t bit );
-        static uint32_t  get ( const std::string & str );
-        static uint32_t  get ( const std::vector<std::string> & str );
-
-        struct Core {
-            enum { Shift =  0 };
-            enum Bits {
-                All           = 0x0000000F,
-                Duplicate     = 0x00000001, // internal duplication
-                Preselection  = 0x00000002, // base preselection 1 (e.g. pt, eta cuts)
-                Vertexing     = 0x00000004, // vertex association cuts
-                Overflow      = 0x00000008, // if one requests to save "at most X items", 
-                                            // the overflowing ones will have this bit set
-                Undefined     = 0x00000000
-            };
-            static const std::string & bitToString( Bits bit );
-            static Bits      get ( const std::string & str );
-            static uint32_t  get ( const std::vector<std::string> & str );
-        };
-
-        struct Overlap {
-            enum { Shift =  16 };
-            enum Bits {
-                All       = 0x00FF0000,
-                Jets      = 0x00010000,
-                Electrons = 0x00020000,
-                Muons     = 0x00040000,
-                Taus      = 0x00080000,
-                Photons   = 0x00100000,
-                User      = 0X00E00000,
-                User1     = 0x00200000,
-                User2     = 0x00400000,
-                User3     = 0x00800000,
-                Undefined = 0x00000000
-            };
-            static const std::string & bitToString( Bits bit );
-            static Bits      get ( const std::string & str );
-            static uint32_t  get ( const std::vector<std::string> & str );
-        };
-
-        struct Selection {
-            enum { Shift =  4 };
-            enum Bits {
-                All       = 0x0000FFF0,
-                Bit0      = 0x00000010, 
-                Bit1      = 0x00000020, 
-                Bit2      = 0x00000040, 
-                Bit3      = 0x00000080, 
-                Bit4      = 0x00000100,
-                Bit5      = 0x00000200,
-                Bit6      = 0x00000400,
-                Bit7      = 0x00000800,
-                Bit8      = 0x00001000,
-                Bit9      = 0x00002000,
-                Bit10     = 0x00004000,
-                Bit11     = 0x00008000,
-                Undefined = 0x00000000
-            };
-            static const std::string & bitToString( Bits bit );
-            static Bits     get ( int8_t bit );
-            static Bits     get ( const std::string & str );
-            static uint32_t get ( const std::vector<std::string> & str );
-        };
-        struct Isolation {
-            enum { Shift =  24 };
-            enum Bits {
-                All       = 0xFF000000,
-                Tracker   = 0x01000000,
-                ECal      = 0x02000000,
-                HCal      = 0x04000000,
-                Calo      = 0x06000000,
-                User      = 0xF8000000,
-                User1     = 0x08000000,
-                User2     = 0x10000000,
-                User3     = 0x20000000,
-                User4     = 0x40000000,
-                User5     = 0x80000000,
-                Undefined = 0x00000000
-            };
-            static const std::string & bitToString( Bits bit );
-            static Bits      get ( const std::string & str );
-            static uint32_t  get ( const std::vector<std::string> & str );
-        };
     };
-}
+    inline static bool test(uint32_t val, uint32_t mask) { return (val & mask) == 0; }
+    inline static bool test(const reco::Candidate &c, uint32_t mask) { return test(c.status(), mask); }
+
+    static const std::string &bitToString(uint32_t bit);
+    static std::string maskToString(uint32_t bit);
+    static uint32_t get(const std::string &str);
+    static uint32_t get(const std::vector<std::string> &str);
+
+    struct Core {
+      enum { Shift = 0 };
+      enum Bits {
+        All = 0x0000000F,
+        Duplicate = 0x00000001,     // internal duplication
+        Preselection = 0x00000002,  // base preselection 1 (e.g. pt, eta cuts)
+        Vertexing = 0x00000004,     // vertex association cuts
+        Overflow = 0x00000008,      // if one requests to save "at most X items",
+                                    // the overflowing ones will have this bit set
+        Undefined = 0x00000000
+      };
+      static const std::string &bitToString(Bits bit);
+      static Bits get(const std::string &str);
+      static uint32_t get(const std::vector<std::string> &str);
+    };
+
+    struct Overlap {
+      enum { Shift = 16 };
+      enum Bits {
+        All = 0x00FF0000,
+        Jets = 0x00010000,
+        Electrons = 0x00020000,
+        Muons = 0x00040000,
+        Taus = 0x00080000,
+        Photons = 0x00100000,
+        User = 0X00E00000,
+        User1 = 0x00200000,
+        User2 = 0x00400000,
+        User3 = 0x00800000,
+        Undefined = 0x00000000
+      };
+      static const std::string &bitToString(Bits bit);
+      static Bits get(const std::string &str);
+      static uint32_t get(const std::vector<std::string> &str);
+    };
+
+    struct Selection {
+      enum { Shift = 4 };
+      enum Bits {
+        All = 0x0000FFF0,
+        Bit0 = 0x00000010,
+        Bit1 = 0x00000020,
+        Bit2 = 0x00000040,
+        Bit3 = 0x00000080,
+        Bit4 = 0x00000100,
+        Bit5 = 0x00000200,
+        Bit6 = 0x00000400,
+        Bit7 = 0x00000800,
+        Bit8 = 0x00001000,
+        Bit9 = 0x00002000,
+        Bit10 = 0x00004000,
+        Bit11 = 0x00008000,
+        Undefined = 0x00000000
+      };
+      static const std::string &bitToString(Bits bit);
+      static Bits get(int8_t bit);
+      static Bits get(const std::string &str);
+      static uint32_t get(const std::vector<std::string> &str);
+    };
+    struct Isolation {
+      enum { Shift = 24 };
+      enum Bits {
+        All = 0xFF000000,
+        Tracker = 0x01000000,
+        ECal = 0x02000000,
+        HCal = 0x04000000,
+        Calo = 0x06000000,
+        User = 0xF8000000,
+        User1 = 0x08000000,
+        User2 = 0x10000000,
+        User3 = 0x20000000,
+        User4 = 0x40000000,
+        User5 = 0x80000000,
+        Undefined = 0x00000000
+      };
+      static const std::string &bitToString(Bits bit);
+      static Bits get(const std::string &str);
+      static uint32_t get(const std::vector<std::string> &str);
+    };
+  };
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/GenericParticle.h
+++ b/DataFormats/PatCandidates/interface/GenericParticle.h
@@ -27,269 +27,301 @@
 // Define typedefs for convenience
 namespace pat {
   class GenericParticle;
-  typedef std::vector<GenericParticle>              GenericParticleCollection; 
-  typedef edm::Ref<GenericParticleCollection>       GenericParticleRef; 
-  typedef edm::RefVector<GenericParticleCollection> GenericParticleRefVector; 
-}
-
+  typedef std::vector<GenericParticle> GenericParticleCollection;
+  typedef edm::Ref<GenericParticleCollection> GenericParticleRef;
+  typedef edm::RefVector<GenericParticleCollection> GenericParticleRefVector;
+}  // namespace pat
 
 // Class definition
 namespace pat {
 
-
   class GenericParticle : public PATObject<reco::RecoCandidate> {
+  public:
+    /// default constructor
+    GenericParticle();
+    /// constructor from Candidate
+    GenericParticle(const reco::Candidate &aGenericParticle);
+    /// constructor from ref to Candidate
+    GenericParticle(const edm::RefToBase<reco::Candidate> &aGenericParticleRef);
+    /// constructor from ref to Candidate
+    GenericParticle(const edm::Ptr<reco::Candidate> &aGenericParticleRef);
+    /// destructor
+    ~GenericParticle() override;
 
-    public:
+    /// required reimplementation of the Candidate's clone method
+    GenericParticle *clone() const override { return new GenericParticle(*this); }
 
-      /// default constructor
-      GenericParticle();
-      /// constructor from Candidate
-      GenericParticle(const reco::Candidate & aGenericParticle);
-      /// constructor from ref to Candidate
-      GenericParticle(const edm::RefToBase<reco::Candidate> & aGenericParticleRef);
-      /// constructor from ref to Candidate
-      GenericParticle(const edm::Ptr<reco::Candidate> & aGenericParticleRef);
-      /// destructor
-      ~GenericParticle() override;
+    /// Checks for overlap with another candidate.
+    /// It will return 'true' if the other candidate is a RecoCandidate,
+    /// and if they reference to at least one same non null track, supercluster or calotower (except for the multiple tracks)
+    /// NOTE: It won't work with embedded references
+    bool overlap(const Candidate &) const override;
 
-      /// required reimplementation of the Candidate's clone method
-      GenericParticle * clone() const override { return new GenericParticle(*this); }
+    /// reference to a master track (might be transient refs if Tracks are embedded)
+    /// returns null ref if there is no master track
+    reco::TrackRef track() const override { return track_.empty() ? trackRef_ : reco::TrackRef(&track_, 0); }
+    /// reference to one of a set of multiple tracks (might be transient refs if Tracks are embedded)
+    /// throws exception if idx >= numberOfTracks()
+    reco::TrackRef track(size_t idx) const override {
+      if (idx >= numberOfTracks())
+        throw cms::Exception("Index out of bounds")
+            << "Requested track " << idx << " out of " << numberOfTracks() << ".\n";
+      return (tracks_.empty() ? trackRefs_[idx] : reco::TrackRef(&tracks_, idx));
+    }
+    /// number of multiple tracks (not including the master one)
+    size_t numberOfTracks() const override { return tracks_.empty() ? trackRefs_.size() : tracks_.size(); }
+    /// reference to a GsfTrack (might be transient ref if SuperCluster is embedded)
+    /// returns null ref if there is no gsf track
+    reco::GsfTrackRef gsfTrack() const override {
+      return (gsfTrack_.empty() ? gsfTrackRef_ : reco::GsfTrackRef(&gsfTrack_, 0));
+    }
+    /// reference to a stand-alone muon Track (might be transient ref if SuperCluster is embedded)
+    /// returns null ref if there is no stand-alone muon track
+    reco::TrackRef standAloneMuon() const override {
+      return (standaloneTrack_.empty() ? standaloneTrackRef_ : reco::TrackRef(&standaloneTrack_, 0));
+    }
+    /// reference to a combined muon Track (might be transient ref if SuperCluster is embedded)
+    /// returns null ref if there is no combined muon track
+    reco::TrackRef combinedMuon() const override {
+      return (combinedTrack_.empty() ? combinedTrackRef_ : reco::TrackRef(&combinedTrack_, 0));
+    }
+    /// reference to a SuperCluster (might be transient ref if SuperCluster is embedded)
+    /// returns null ref if there is no supercluster
+    reco::SuperClusterRef superCluster() const override {
+      return superCluster_.empty() ? superClusterRef_ : reco::SuperClusterRef(&superCluster_, 0);
+    }
+    /// reference to a CaloTower  (might be transient ref if CaloTower is embedded)
+    /// returns null ref if there is no calotower
+    CaloTowerRef caloTower() const override {
+      return caloTower_.empty() ? caloTowerRef_ : CaloTowerRef(&caloTower_, 0);
+    }
 
-      /// Checks for overlap with another candidate. 
-      /// It will return 'true' if the other candidate is a RecoCandidate, 
-      /// and if they reference to at least one same non null track, supercluster or calotower (except for the multiple tracks)
-      /// NOTE: It won't work with embedded references
-      bool overlap( const Candidate & ) const override ;
+    /// sets master track reference (or even embed it into the object)
+    virtual void setTrack(const reco::TrackRef &ref, bool embed = false);
+    /// sets multiple track references (or even embed the tracks into the object - whatch out for disk size issues!)
+    virtual void setTracks(const reco::TrackRefVector &refs, bool embed = false);
+    /// sets stand-alone muon track reference (or even embed it into the object)
+    virtual void setStandAloneMuon(const reco::TrackRef &ref, bool embed = false);
+    /// sets combined muon track reference (or even embed it into the object)
+    virtual void setCombinedMuon(const reco::TrackRef &ref, bool embed = false);
+    /// sets gsf track reference (or even embed it into the object)
+    virtual void setGsfTrack(const reco::GsfTrackRef &ref, bool embed = false);
+    /// sets supercluster reference (or even embed it into the object)
+    virtual void setSuperCluster(const reco::SuperClusterRef &ref, bool embed = false);
+    /// sets calotower reference (or even embed it into the object)
+    virtual void setCaloTower(const CaloTowerRef &ref, bool embed = false);
 
-      /// reference to a master track (might be transient refs if Tracks are embedded)
-      /// returns null ref if there is no master track
-      reco::TrackRef track() const override    { return track_.empty() ? trackRef_ : reco::TrackRef(&track_, 0); }
-      /// reference to one of a set of multiple tracks (might be transient refs if Tracks are embedded)
-      /// throws exception if idx >= numberOfTracks()
-      reco::TrackRef track( size_t idx ) const override {  
-            if (idx >= numberOfTracks()) throw cms::Exception("Index out of bounds") << "Requested track " << idx << " out of " << numberOfTracks() << ".\n";
-            return (tracks_.empty() ? trackRefs_[idx] : reco::TrackRef(&tracks_, idx) );
+    /// embeds the master track instead of keeping a reference to it
+    void embedTrack();
+    /// embeds the other tracks instead of keeping references
+    void embedTracks();
+    /// embeds the stand-alone track instead of keeping a reference to it
+    void embedStandalone();
+    /// embeds the combined track instead of keeping a reference to it
+    void embedCombined();
+    /// embeds the gsf track instead of keeping a reference to it
+    void embedGsfTrack();
+    /// embeds the supercluster instead of keeping a reference to it
+    void embedSuperCluster();
+    /// embeds the calotower instead of keeping a reference to it
+    void embedCaloTower();
+
+    /// returns a user defined quality value, if set by the user to some meaningful value
+    float quality() { return quality_; }
+    /// sets a user defined quality value
+    void setQuality(float quality) { quality_ = quality; }
+
+    //============ BEGIN ISOLATION BLOCK =====
+    /// Returns the isolation variable for a specifc key (or
+    /// pseudo-key like CaloIso), or -1.0 if not available
+    float userIsolation(IsolationKeys key) const {
+      if (key >= 0) {
+        //if (key >= isolations_.size()) throw cms::Excepton("Missing Data")
+        //<< "Isolation corresponding to key "
+        //<< key << " was not stored for this particle.";
+        if (size_t(key) >= isolations_.size())
+          return -1.0;
+        return isolations_[key];
+      } else
+        switch (key) {
+          case pat::CaloIso:
+            //if (isolations_.size() <= pat::HcalIso) throw cms::Excepton("Missing Data")
+            //<< "CalIsoo Isolation was not stored for this particle.";
+            if (isolations_.size() <= pat::HcalIso)
+              return -1.0;
+            return isolations_[pat::EcalIso] + isolations_[pat::HcalIso];
+          default:
+            return -1.0;
+            //throw cms::Excepton("Missing Data") << "Isolation corresponding to key "
+            //<< key << " was not stored for this particle.";
+        }
+    }
+    /// Returns the isolation variable for string type function arguments
+    /// (to be used with the cut-string parser);
+    /// the possible values of the strings are the enums defined in
+    /// DataFormats/PatCandidates/interface/Isolation.h
+    float userIsolation(const std::string &key) const {
+      // remove leading namespace specifier
+      std::string prunedKey = (key.find("pat::") == 0) ? std::string(key, 5) : key;
+      if (prunedKey == "TrackIso")
+        return userIsolation(pat::TrackIso);
+      if (prunedKey == "EcalIso")
+        return userIsolation(pat::EcalIso);
+      if (prunedKey == "HcalIso")
+        return userIsolation(pat::HcalIso);
+      if (prunedKey == "PfAllParticleIso")
+        return userIsolation(pat::PfAllParticleIso);
+      if (prunedKey == "PfChargedHadronIso")
+        return userIsolation(pat::PfChargedHadronIso);
+      if (prunedKey == "PfNeutralHadronIso")
+        return userIsolation(pat::PfNeutralHadronIso);
+      if (prunedKey == "PfGammaIso")
+        return userIsolation(pat::PfGammaIso);
+      if (prunedKey == "User1Iso")
+        return userIsolation(pat::User1Iso);
+      if (prunedKey == "User2Iso")
+        return userIsolation(pat::User2Iso);
+      if (prunedKey == "User3Iso")
+        return userIsolation(pat::User3Iso);
+      if (prunedKey == "User4Iso")
+        return userIsolation(pat::User4Iso);
+      if (prunedKey == "User5Iso")
+        return userIsolation(pat::User5Iso);
+      if (prunedKey == "UserBaseIso")
+        return userIsolation(pat::UserBaseIso);
+      if (prunedKey == "CaloIso")
+        return userIsolation(pat::CaloIso);
+      //throw cms::Excepton("Missing Data")
+      //<< "Isolation corresponding to key "
+      //<< key << " was not stored for this particle.";
+      return -1.0;
+    }
+    /// Sets the isolation variable for a specifc key.
+    /// Note that you can't set isolation for a pseudo-key like CaloIso
+    void setIsolation(IsolationKeys key, float value) {
+      if (key >= 0) {
+        if (size_t(key) >= isolations_.size())
+          isolations_.resize(key + 1, -1.0);
+        isolations_[key] = value;
+      } else {
+        throw cms::Exception("Illegal Argument")
+            << "The key for which you're setting isolation does not correspond "
+            << "to an individual isolation but to the sum of more independent isolations "
+            << "(e.g. Calo = Ecal + Hcal), so you can't SET the value, just GET it.\n"
+            << "Please set up each component independly.\n";
       }
-      /// number of multiple tracks (not including the master one)
-      size_t numberOfTracks() const override { return tracks_.empty() ? trackRefs_.size() : tracks_.size(); }
-      /// reference to a GsfTrack (might be transient ref if SuperCluster is embedded)
-      /// returns null ref if there is no gsf track
-      reco::GsfTrackRef gsfTrack() const override    { return (gsfTrack_.empty() ? gsfTrackRef_ : reco::GsfTrackRef(&gsfTrack_, 0)); }
-      /// reference to a stand-alone muon Track (might be transient ref if SuperCluster is embedded)
-      /// returns null ref if there is no stand-alone muon track
-      reco::TrackRef standAloneMuon() const override { return (standaloneTrack_.empty() ? standaloneTrackRef_ : reco::TrackRef(&standaloneTrack_, 0)); }
-      /// reference to a combined muon Track (might be transient ref if SuperCluster is embedded)
-      /// returns null ref if there is no combined muon track
-      reco::TrackRef combinedMuon()   const override { return (combinedTrack_.empty() ? combinedTrackRef_ : reco::TrackRef(&combinedTrack_, 0)); }
-      /// reference to a SuperCluster (might be transient ref if SuperCluster is embedded)
-      /// returns null ref if there is no supercluster
-      reco::SuperClusterRef superCluster() const override { return superCluster_.empty() ? superClusterRef_ : reco::SuperClusterRef(&superCluster_, 0); }
-      /// reference to a CaloTower  (might be transient ref if CaloTower is embedded)
-      /// returns null ref if there is no calotower
-      CaloTowerRef caloTower() const override { return caloTower_.empty() ? caloTowerRef_ : CaloTowerRef(&caloTower_, 0); }
+    }
 
-      /// sets master track reference (or even embed it into the object)
-      virtual void setTrack(const reco::TrackRef &ref, bool embed=false) ;
-      /// sets multiple track references (or even embed the tracks into the object - whatch out for disk size issues!)
-      virtual void setTracks(const reco::TrackRefVector &refs, bool embed=false) ;
-      /// sets stand-alone muon track reference (or even embed it into the object)
-      virtual void setStandAloneMuon(const reco::TrackRef &ref, bool embed=false) ;
-      /// sets combined muon track reference (or even embed it into the object)
-      virtual void setCombinedMuon(const reco::TrackRef &ref, bool embed=false) ;
-      /// sets gsf track reference (or even embed it into the object)
-      virtual void setGsfTrack(const reco::GsfTrackRef &ref, bool embed=false) ;
-      /// sets supercluster reference (or even embed it into the object)
-      virtual void setSuperCluster(const reco::SuperClusterRef &ref, bool embed=false) ;
-      /// sets calotower reference (or even embed it into the object)
-      virtual void setCaloTower(const CaloTowerRef &ref, bool embed=false) ;
+    // ---- specific getters ----
+    /// Return the tracker isolation variable that was stored in this
+    /// object when produced, or -1.0 if there is none
+    float trackIso() const { return userIsolation(pat::TrackIso); }
+    /// Return the sum of ecal and hcal isolation variable that were
+    /// stored in this object when produced, or -1.0 if at least one
+    /// is missing
+    float caloIso() const { return userIsolation(pat::CaloIso); }
+    /// Return the ecal isolation variable that was stored in this
+    /// object when produced, or -1.0 if there is none
+    float ecalIso() const { return userIsolation(pat::EcalIso); }
+    /// Return the hcal isolation variable that was stored in this
+    /// object when produced, or -1.0 if there is none
+    float hcalIso() const { return userIsolation(pat::HcalIso); }
 
-      /// embeds the master track instead of keeping a reference to it      
-      void embedTrack() ; 
-      /// embeds the other tracks instead of keeping references
-      void embedTracks() ; 
-      /// embeds the stand-alone track instead of keeping a reference to it      
-      void embedStandalone() ; 
-      /// embeds the combined track instead of keeping a reference to it      
-      void embedCombined() ; 
-      /// embeds the gsf track instead of keeping a reference to it      
-      void embedGsfTrack() ; 
-      /// embeds the supercluster instead of keeping a reference to it      
-      void embedSuperCluster() ; 
-      /// embeds the calotower instead of keeping a reference to it      
-      void embedCaloTower() ; 
+    // ---- specific setters ----
+    /// Sets tracker isolation variable
+    void setTrackIso(float trackIso) { setIsolation(pat::TrackIso, trackIso); }
+    /// Sets ecal isolation variable
+    void setEcalIso(float caloIso) { setIsolation(pat::EcalIso, caloIso); }
+    /// Sets hcal isolation variable
+    void setHcalIso(float caloIso) { setIsolation(pat::HcalIso, caloIso); }
+    /// Sets user isolation variable #index
+    void setUserIso(float value, uint8_t index = 0) { setIsolation(IsolationKeys(UserBaseIso + index), value); }
 
-      /// returns a user defined quality value, if set by the user to some meaningful value
-      float quality() { return quality_; }
-      /// sets a user defined quality value   
-      void setQuality(float quality) { quality_ = quality; }
-      
-      //============ BEGIN ISOLATION BLOCK =====
-      /// Returns the isolation variable for a specifc key (or 
-      /// pseudo-key like CaloIso), or -1.0 if not available
-      float userIsolation(IsolationKeys key) const { 
-          if (key >= 0) {
-              //if (key >= isolations_.size()) throw cms::Excepton("Missing Data") 
-	      //<< "Isolation corresponding to key " 
-	      //<< key << " was not stored for this particle.";
-              if (size_t(key) >= isolations_.size()) return -1.0;
-              return isolations_[key];
-          } else switch (key) {
-	  case pat::CaloIso:  
-	    //if (isolations_.size() <= pat::HcalIso) throw cms::Excepton("Missing Data") 
-	    //<< "CalIsoo Isolation was not stored for this particle.";
-	    if (isolations_.size() <= pat::HcalIso) return -1.0; 
-	    return isolations_[pat::EcalIso] + isolations_[pat::HcalIso];
-	  default:
-	    return -1.0;
-	    //throw cms::Excepton("Missing Data") << "Isolation corresponding to key " 
-	    //<< key << " was not stored for this particle.";
-          }
+    //============ BEGIN ISODEPOSIT BLOCK =====
+    /// Returns the IsoDeposit associated with some key, or a null pointer if it is not available
+    const IsoDeposit *isoDeposit(IsolationKeys key) const {
+      for (IsoDepositPairs::const_iterator it = isoDeposits_.begin(), ed = isoDeposits_.end(); it != ed; ++it) {
+        if (it->first == key)
+          return &it->second;
       }
-      /// Returns the isolation variable for string type function arguments
-      /// (to be used with the cut-string parser);
-      /// the possible values of the strings are the enums defined in
-      /// DataFormats/PatCandidates/interface/Isolation.h
-      float userIsolation(const std::string& key) const {
-	// remove leading namespace specifier
-	std::string prunedKey = ( key.find("pat::") == 0 ) ? std::string(key, 5) : key;
-	if ( prunedKey == "TrackIso" ) return userIsolation(pat::TrackIso);
-	if ( prunedKey == "EcalIso" ) return userIsolation(pat::EcalIso);
-	if ( prunedKey == "HcalIso" ) return userIsolation(pat::HcalIso);
-	if ( prunedKey == "PfAllParticleIso" ) return userIsolation(pat::PfAllParticleIso);
-	if ( prunedKey == "PfChargedHadronIso" ) return userIsolation(pat::PfChargedHadronIso);
-	if ( prunedKey == "PfNeutralHadronIso" ) return userIsolation(pat::PfNeutralHadronIso);
-	if ( prunedKey == "PfGammaIso" ) return userIsolation(pat::PfGammaIso);
-	if ( prunedKey == "User1Iso" ) return userIsolation(pat::User1Iso);
-	if ( prunedKey == "User2Iso" ) return userIsolation(pat::User2Iso);
-	if ( prunedKey == "User3Iso" ) return userIsolation(pat::User3Iso);
-	if ( prunedKey == "User4Iso" ) return userIsolation(pat::User4Iso);
-	if ( prunedKey == "User5Iso" ) return userIsolation(pat::User5Iso);
-	if ( prunedKey == "UserBaseIso" ) return userIsolation(pat::UserBaseIso);
-	if ( prunedKey == "CaloIso" ) return userIsolation(pat::CaloIso);
-	//throw cms::Excepton("Missing Data")
-	//<< "Isolation corresponding to key " 
-	//<< key << " was not stored for this particle.";
-	return -1.0;
+      return nullptr;
+    }
+
+    /// Sets the IsoDeposit associated with some key; if it is already existent, it is overwritten.
+    void setIsoDeposit(IsolationKeys key, const IsoDeposit &dep) {
+      IsoDepositPairs::iterator it = isoDeposits_.begin(), ed = isoDeposits_.end();
+      for (; it != ed; ++it) {
+        if (it->first == key) {
+          it->second = dep;
+          return;
+        }
       }
-      /// Sets the isolation variable for a specifc key.
-      /// Note that you can't set isolation for a pseudo-key like CaloIso
-      void setIsolation(IsolationKeys key, float value) {
-          if (key >= 0) {
-              if (size_t(key) >= isolations_.size()) isolations_.resize(key+1, -1.0);
-              isolations_[key] = value;
-          } else {
-              throw cms::Exception("Illegal Argument") << 
-                  "The key for which you're setting isolation does not correspond " <<
-                  "to an individual isolation but to the sum of more independent isolations " <<
-                  "(e.g. Calo = Ecal + Hcal), so you can't SET the value, just GET it.\n" <<
-                  "Please set up each component independly.\n";
-          }
-      }
+      isoDeposits_.push_back(std::make_pair(key, dep));
+    }
 
-      // ---- specific getters ----
-      /// Return the tracker isolation variable that was stored in this 
-      /// object when produced, or -1.0 if there is none
-      float trackIso() const { return userIsolation(pat::TrackIso); }
-      /// Return the sum of ecal and hcal isolation variable that were 
-      /// stored in this object when produced, or -1.0 if at least one 
-      /// is missing
-      float caloIso()  const { return userIsolation(pat::CaloIso); }
-      /// Return the ecal isolation variable that was stored in this 
-      /// object when produced, or -1.0 if there is none
-      float ecalIso()  const { return userIsolation(pat::EcalIso); }
-      /// Return the hcal isolation variable that was stored in this 
-      /// object when produced, or -1.0 if there is none
-      float hcalIso()  const { return userIsolation(pat::HcalIso); }
+    // ---- specific getters ----
+    const IsoDeposit *trackIsoDeposit() const { return isoDeposit(pat::TrackIso); }
+    const IsoDeposit *ecalIsoDeposit() const { return isoDeposit(pat::EcalIso); }
+    const IsoDeposit *hcalIsoDeposit() const { return isoDeposit(pat::HcalIso); }
+    const IsoDeposit *userIsoDeposit(uint8_t index = 0) const { return isoDeposit(IsolationKeys(UserBaseIso + index)); }
 
-      // ---- specific setters ----
-      /// Sets tracker isolation variable
-      void setTrackIso(float trackIso) { setIsolation(pat::TrackIso, trackIso); }
-      /// Sets ecal isolation variable
-      void setEcalIso(float caloIso)   { setIsolation(pat::EcalIso, caloIso);  } 
-      /// Sets hcal isolation variable
-      void setHcalIso(float caloIso)   { setIsolation(pat::HcalIso, caloIso);  }
-      /// Sets user isolation variable #index
-      void setUserIso(float value, uint8_t index=0)  { setIsolation(IsolationKeys(UserBaseIso + index), value); }
+    // ---- specific setters ----
+    void trackIsoDeposit(const IsoDeposit &dep) { setIsoDeposit(pat::TrackIso, dep); }
+    void ecalIsoDeposit(const IsoDeposit &dep) { setIsoDeposit(pat::EcalIso, dep); }
+    void hcalIsoDeposit(const IsoDeposit &dep) { setIsoDeposit(pat::HcalIso, dep); }
+    void userIsoDeposit(const IsoDeposit &dep, uint8_t index = 0) {
+      setIsoDeposit(IsolationKeys(UserBaseIso + index), dep);
+    }
 
+    /// Vertex association (or associations, if any). Return null pointer if none has been set
+    const pat::VertexAssociation *vertexAssociation(size_t index = 0) const {
+      return vtxAss_.size() > index ? &vtxAss_[index] : nullptr;
+    }
+    /// Vertex associations. Can be empty if it was not enabled in the config file
+    const std::vector<pat::VertexAssociation> &vertexAssociations() const { return vtxAss_; }
+    /// Set a single vertex association
+    void setVertexAssociation(const pat::VertexAssociation &assoc) {
+      vtxAss_ = std::vector<pat::VertexAssociation>(1, assoc);
+    }
+    /// Set multiple vertex associations
+    void setVertexAssociations(const std::vector<pat::VertexAssociation> &assocs) { vtxAss_ = assocs; }
 
-      //============ BEGIN ISODEPOSIT BLOCK =====
-      /// Returns the IsoDeposit associated with some key, or a null pointer if it is not available
-      const IsoDeposit * isoDeposit(IsolationKeys key) const {
-          for (IsoDepositPairs::const_iterator it = isoDeposits_.begin(), ed = isoDeposits_.end(); 
-                  it != ed; ++it) 
-          {
-              if (it->first == key) return & it->second;
-          }
-          return nullptr;
-      } 
+  protected:
+    // Any sort of single tracks
+    reco::TrackRef trackRef_, standaloneTrackRef_, combinedTrackRef_;  // ref
+    reco::TrackCollection track_, standaloneTrack_, combinedTrack_;    // embedded
 
-      /// Sets the IsoDeposit associated with some key; if it is already existent, it is overwritten.
-      void setIsoDeposit(IsolationKeys key, const IsoDeposit &dep) {
-          IsoDepositPairs::iterator it = isoDeposits_.begin(), ed = isoDeposits_.end();
-          for (; it != ed; ++it) {
-              if (it->first == key) { it->second = dep; return; }
-          }
-          isoDeposits_.push_back(std::make_pair(key,dep));
-      } 
+    // GsfTrack
+    reco::GsfTrackRef gsfTrackRef_;      // normal
+    reco::GsfTrackCollection gsfTrack_;  // embedded
 
-      // ---- specific getters ----
-      const IsoDeposit * trackIsoDeposit() const { return isoDeposit(pat::TrackIso); }
-      const IsoDeposit * ecalIsoDeposit()  const { return isoDeposit(pat::EcalIso ); }
-      const IsoDeposit * hcalIsoDeposit()  const { return isoDeposit(pat::HcalIso ); }
-      const IsoDeposit * userIsoDeposit(uint8_t index=0) const { return isoDeposit(IsolationKeys(UserBaseIso + index)); }
+    // CaloTower
+    CaloTowerRef caloTowerRef_;      // ref
+    CaloTowerCollection caloTower_;  // embedded
 
-      // ---- specific setters ----
-      void trackIsoDeposit(const IsoDeposit &dep) { setIsoDeposit(pat::TrackIso, dep); }
-      void ecalIsoDeposit(const IsoDeposit &dep)  { setIsoDeposit(pat::EcalIso,  dep); }
-      void hcalIsoDeposit(const IsoDeposit &dep)  { setIsoDeposit(pat::HcalIso,  dep); }
-      void userIsoDeposit(const IsoDeposit &dep, uint8_t index=0) { setIsoDeposit(IsolationKeys(UserBaseIso + index), dep); }
+    // SuperCluster
+    reco::SuperClusterRef superClusterRef_;      // ref
+    reco::SuperClusterCollection superCluster_;  // embedded
 
-      /// Vertex association (or associations, if any). Return null pointer if none has been set
-      const pat::VertexAssociation              * vertexAssociation(size_t index=0) const { return vtxAss_.size() > index ? & vtxAss_[index] : nullptr; }
-      /// Vertex associations. Can be empty if it was not enabled in the config file
-      const std::vector<pat::VertexAssociation> & vertexAssociations()              const { return vtxAss_; }
-      /// Set a single vertex association
-      void  setVertexAssociation(const pat::VertexAssociation &assoc)  { vtxAss_ = std::vector<pat::VertexAssociation>(1, assoc); }
-      /// Set multiple vertex associations
-      void  setVertexAssociations(const std::vector<pat::VertexAssociation> &assocs) { vtxAss_ = assocs; }
-    protected:
-      // Any sort of single tracks
-      reco::TrackRef           trackRef_, standaloneTrackRef_, combinedTrackRef_; // ref
-      reco::TrackCollection    track_,    standaloneTrack_,    combinedTrack_;    // embedded
+    // Multiple tracks
+    reco::TrackRefVector trackRefs_;  // by ref
+    reco::TrackCollection tracks_;    // embedded
 
-      // GsfTrack
-      reco::GsfTrackRef        gsfTrackRef_; // normal
-      reco::GsfTrackCollection gsfTrack_;    // embedded
+    // information originally in external branches
+    // some quality variable
+    float quality_;
 
-      // CaloTower
-      CaloTowerRef           caloTowerRef_;    // ref
-      CaloTowerCollection    caloTower_;       // embedded
+    // --- Isolation and IsoDeposit related datamebers ---
+    typedef std::vector<std::pair<IsolationKeys, pat::IsoDeposit> > IsoDepositPairs;
+    IsoDepositPairs isoDeposits_;
+    std::vector<float> isolations_;
 
-      // SuperCluster
-      reco::SuperClusterRef        superClusterRef_; // ref
-      reco::SuperClusterCollection superCluster_;    // embedded
+    // --- Vertexing information
+    std::vector<pat::VertexAssociation> vtxAss_;
 
-      // Multiple tracks
-      reco::TrackRefVector  trackRefs_; // by ref
-      reco::TrackCollection tracks_;    // embedded
-
-      // information originally in external branches
-      // some quality variable
-      float quality_;
-
-      // --- Isolation and IsoDeposit related datamebers ---
-      typedef std::vector<std::pair<IsolationKeys, pat::IsoDeposit> > IsoDepositPairs;
-      IsoDepositPairs    isoDeposits_;
-      std::vector<float> isolations_;
-
-      // --- Vertexing information
-      std::vector<pat::VertexAssociation> vtxAss_;
-
-      void fillInFrom(const reco::Candidate &cand); 
-    
+    void fillInFrom(const reco::Candidate &cand);
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/HcalDepthEnergyFractions.h
+++ b/DataFormats/PatCandidates/interface/HcalDepthEnergyFractions.h
@@ -4,33 +4,34 @@
 #include <vector>
 #include <cstdint>
 
-namespace pat{
+namespace pat {
 
   //
   // Hcal depth energy fracrtion struct
   //
   class HcalDepthEnergyFractions {
-
   private:
     //do not store
     std::vector<float> fractions_;
     //store
     std::vector<uint8_t> fractionsI_;
+
   public:
-    explicit HcalDepthEnergyFractions(const std::vector<float>& v):
-                              fractions_(v),fractionsI_() { initUint8Vector(); }
-    HcalDepthEnergyFractions():fractions_(),fractionsI_() { }
-    
+    explicit HcalDepthEnergyFractions(const std::vector<float>& v) : fractions_(v), fractionsI_() { initUint8Vector(); }
+    HcalDepthEnergyFractions() : fractions_(), fractionsI_() {}
+
     // produce vector of uint8 from vector of float
     void initUint8Vector() {
       fractionsI_.clear();
-      for (auto frac : fractions_) fractionsI_.push_back((uint8_t)(frac*200.));
+      for (auto frac : fractions_)
+        fractionsI_.push_back((uint8_t)(frac * 200.));
     }
-    
+
     // produce vector of float from vector of uint8_t
     void initFloatVector() {
       fractions_.clear();
-      for (auto fracI : fractionsI_) fractions_.push_back(float(fracI)/200.);
+      for (auto fracI : fractionsI_)
+        fractions_.push_back(float(fracI) / 200.);
     }
 
     // reset vectors
@@ -40,30 +41,28 @@ namespace pat{
     }
 
     // provide a full vector for each depth
-    const std::vector<float>& fractions() const {
-      return fractions_;
-    }
+    const std::vector<float>& fractions() const { return fractions_; }
 
     // provide info for individual depth
     float fraction(unsigned int i) const {
-      if (i<fractions_.size()) return fractions_[i];
-      else return -1.;
+      if (i < fractions_.size())
+        return fractions_[i];
+      else
+        return -1.;
     }
-    
+
     // provide a full vector (in uint8_t) for each depth
-    const std::vector<uint8_t>& fractionsI() const {
-      return fractionsI_;
-    }
+    const std::vector<uint8_t>& fractionsI() const { return fractionsI_; }
 
     // provide info for individual depth (uint8_t)
     int fractionI(unsigned int i) const {
-      if (i<fractionsI_.size()) return int(fractionsI_[i]);
-      else return -1; // physical range 0-200
+      if (i < fractionsI_.size())
+        return int(fractionsI_[i]);
+      else
+        return -1;  // physical range 0-200
     }
-    
   };
 
-}
- 
-#endif
+}  // namespace pat
 
+#endif

--- a/DataFormats/PatCandidates/interface/Hemisphere.h
+++ b/DataFormats/PatCandidates/interface/Hemisphere.h
@@ -7,21 +7,20 @@
 // Define typedefs for convenience
 namespace pat {
   class Hemisphere;
-  typedef std::vector<Hemisphere>              HemisphereCollection; 
-  typedef edm::Ref<HemisphereCollection>       HemisphereRef; 
-  typedef edm::RefVector<HemisphereCollection> HemisphereRefVector; 
-}
+  typedef std::vector<Hemisphere> HemisphereCollection;
+  typedef edm::Ref<HemisphereCollection> HemisphereRef;
+  typedef edm::RefVector<HemisphereCollection> HemisphereRefVector;
+}  // namespace pat
 
 namespace pat {
-  
+
   class Hemisphere : public reco::CompositePtrCandidate {
   public:
-    Hemisphere () {}
-    Hemisphere (const Candidate::LorentzVector& p4) :
-    CompositePtrCandidate(0,p4) {}
-    ~Hemisphere () override {}
+    Hemisphere() {}
+    Hemisphere(const Candidate::LorentzVector& p4) : CompositePtrCandidate(0, p4) {}
+    ~Hemisphere() override {}
   };
 
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -18,117 +18,151 @@
 
 namespace pat {
 
-    class IsolatedTrack : public reco::LeafCandidate {
-
-      public:
-
-        IsolatedTrack() :
-          LeafCandidate(0, LorentzVector(0,0,0,0)),
+  class IsolatedTrack : public reco::LeafCandidate {
+  public:
+    IsolatedTrack()
+        : LeafCandidate(0, LorentzVector(0, 0, 0, 0)),
           pfIsolationDR03_(pat::PFIsolation()),
-          miniIsolation_(pat::PFIsolation()), 
-          matchedCaloJetEmEnergy_(0.), matchedCaloJetHadEnergy_(0.),
-	  pfLepOverlap_(false), pfNeutralSum_(0.),
-          dz_(0.), dxy_(0.), dzError_(0.), dxyError_(0.), fromPV_(-1), trackQuality_(0),
-          dEdxStrip_(0), dEdxPixel_(0), hitPattern_(reco::HitPattern()),
+          miniIsolation_(pat::PFIsolation()),
+          matchedCaloJetEmEnergy_(0.),
+          matchedCaloJetHadEnergy_(0.),
+          pfLepOverlap_(false),
+          pfNeutralSum_(0.),
+          dz_(0.),
+          dxy_(0.),
+          dzError_(0.),
+          dxyError_(0.),
+          fromPV_(-1),
+          trackQuality_(0),
+          dEdxStrip_(0),
+          dEdxPixel_(0),
+          hitPattern_(reco::HitPattern()),
           crossedEcalStatus_(std::vector<uint16_t>()),
           crossedHcalStatus_(std::vector<uint32_t>()),
-	  deltaEta_(0), deltaPhi_(0),
-	  packedCandRef_(PackedCandidateRef()), 
-	  nearestPFPackedCandRef_(PackedCandidateRef()),
-	  nearestLostTrackPackedCandRef_(PackedCandidateRef()) {}
+          deltaEta_(0),
+          deltaPhi_(0),
+          packedCandRef_(PackedCandidateRef()),
+          nearestPFPackedCandRef_(PackedCandidateRef()),
+          nearestLostTrackPackedCandRef_(PackedCandidateRef()) {}
 
-        explicit IsolatedTrack(const PFIsolation &iso, const PFIsolation &miniiso, float caloJetEm, float caloJetHad,
-			       bool pfLepOverlap, float pfNeutralSum,
-                               const LorentzVector &p4, int charge, int id,
-                               float dz, float dxy, float dzError, float dxyError,
-                               const reco::HitPattern &hp, float dEdxS, float dEdxP, int fromPV, int tkQual,
-                               const std::vector<uint16_t> &ecalst,
-                               const std::vector<uint32_t> & hcalst, int dEta, int dPhi,
-                               const PackedCandidateRef &pcref, const PackedCandidateRef &refToNearestPF, const PackedCandidateRef &refToNearestLostTrack) :
-          LeafCandidate(charge, p4, Point(0.,0.,0.), id),
-          pfIsolationDR03_(iso), miniIsolation_(miniiso), 
-          matchedCaloJetEmEnergy_(caloJetEm), matchedCaloJetHadEnergy_(caloJetHad),
-	  pfLepOverlap_(pfLepOverlap), pfNeutralSum_(pfNeutralSum),
-	  dz_(dz), dxy_(dxy), dzError_(dzError), dxyError_(dxyError),
-          fromPV_(fromPV), trackQuality_(tkQual), dEdxStrip_(dEdxS), dEdxPixel_(dEdxP), 
-          hitPattern_(hp), 
-          crossedEcalStatus_(ecalst), crossedHcalStatus_(hcalst),
-          deltaEta_(dEta), deltaPhi_(dPhi),
-	  packedCandRef_(pcref),
-	  nearestPFPackedCandRef_(refToNearestPF),
-	  nearestLostTrackPackedCandRef_(refToNearestLostTrack) {}
+    explicit IsolatedTrack(const PFIsolation& iso,
+                           const PFIsolation& miniiso,
+                           float caloJetEm,
+                           float caloJetHad,
+                           bool pfLepOverlap,
+                           float pfNeutralSum,
+                           const LorentzVector& p4,
+                           int charge,
+                           int id,
+                           float dz,
+                           float dxy,
+                           float dzError,
+                           float dxyError,
+                           const reco::HitPattern& hp,
+                           float dEdxS,
+                           float dEdxP,
+                           int fromPV,
+                           int tkQual,
+                           const std::vector<uint16_t>& ecalst,
+                           const std::vector<uint32_t>& hcalst,
+                           int dEta,
+                           int dPhi,
+                           const PackedCandidateRef& pcref,
+                           const PackedCandidateRef& refToNearestPF,
+                           const PackedCandidateRef& refToNearestLostTrack)
+        : LeafCandidate(charge, p4, Point(0., 0., 0.), id),
+          pfIsolationDR03_(iso),
+          miniIsolation_(miniiso),
+          matchedCaloJetEmEnergy_(caloJetEm),
+          matchedCaloJetHadEnergy_(caloJetHad),
+          pfLepOverlap_(pfLepOverlap),
+          pfNeutralSum_(pfNeutralSum),
+          dz_(dz),
+          dxy_(dxy),
+          dzError_(dzError),
+          dxyError_(dxyError),
+          fromPV_(fromPV),
+          trackQuality_(tkQual),
+          dEdxStrip_(dEdxS),
+          dEdxPixel_(dEdxP),
+          hitPattern_(hp),
+          crossedEcalStatus_(ecalst),
+          crossedHcalStatus_(hcalst),
+          deltaEta_(dEta),
+          deltaPhi_(dPhi),
+          packedCandRef_(pcref),
+          nearestPFPackedCandRef_(refToNearestPF),
+          nearestLostTrackPackedCandRef_(refToNearestLostTrack) {}
 
-        ~IsolatedTrack() override {}
+    ~IsolatedTrack() override {}
 
-        const PFIsolation& pfIsolationDR03() const  { return pfIsolationDR03_; }
+    const PFIsolation& pfIsolationDR03() const { return pfIsolationDR03_; }
 
-        const PFIsolation& miniPFIsolation() const { return miniIsolation_; }
+    const PFIsolation& miniPFIsolation() const { return miniIsolation_; }
 
-        float matchedCaloJetEmEnergy() const { return matchedCaloJetEmEnergy_; }
-        float matchedCaloJetHadEnergy() const { return matchedCaloJetHadEnergy_; }
+    float matchedCaloJetEmEnergy() const { return matchedCaloJetEmEnergy_; }
+    float matchedCaloJetHadEnergy() const { return matchedCaloJetHadEnergy_; }
 
-	bool pfLepOverlap() const { return pfLepOverlap_; }
-	float pfNeutralSum() const { return pfNeutralSum_; }
+    bool pfLepOverlap() const { return pfLepOverlap_; }
+    float pfNeutralSum() const { return pfNeutralSum_; }
 
-        float dz() const { return dz_; }
-        float dzError() const override { return dzError_; }
-        float dxy() const { return dxy_; }
-        float dxyError() const override { return dxyError_; }
+    float dz() const { return dz_; }
+    float dzError() const override { return dzError_; }
+    float dxy() const { return dxy_; }
+    float dxyError() const override { return dxyError_; }
 
-        int fromPV() const { return fromPV_; }
+    int fromPV() const { return fromPV_; }
 
-        bool isHighPurityTrack() const 
-          {  return (trackQuality_ & (1 << reco::TrackBase::highPurity)) >> reco::TrackBase::highPurity; }
-        bool isTightTrack() const 
-          {  return (trackQuality_ & (1 << reco::TrackBase::tight)) >> reco::TrackBase::tight; }
-        bool isLooseTrack() const 
-          {  return (trackQuality_ & (1 << reco::TrackBase::loose)) >> reco::TrackBase::loose; }
+    bool isHighPurityTrack() const {
+      return (trackQuality_ & (1 << reco::TrackBase::highPurity)) >> reco::TrackBase::highPurity;
+    }
+    bool isTightTrack() const { return (trackQuality_ & (1 << reco::TrackBase::tight)) >> reco::TrackBase::tight; }
+    bool isLooseTrack() const { return (trackQuality_ & (1 << reco::TrackBase::loose)) >> reco::TrackBase::loose; }
 
-        const reco::HitPattern& hitPattern() const { return hitPattern_; }
-        
-        float dEdxStrip() const { return dEdxStrip_; }
-        float dEdxPixel() const { return dEdxPixel_; }
+    const reco::HitPattern& hitPattern() const { return hitPattern_; }
 
-        //! just the status code part of an EcalChannelStatusCode for all crossed Ecal cells
-        const std::vector<uint16_t>& crossedEcalStatus() const { return crossedEcalStatus_; }
-        //! just the status code part of an HcalChannelStatus for all crossed Hcal cells
-        const std::vector<uint32_t>& crossedHcalStatus() const { return crossedHcalStatus_; }
+    float dEdxStrip() const { return dEdxStrip_; }
+    float dEdxPixel() const { return dEdxPixel_; }
 
-        //! difference in eta/phi between initial traj and intersection w/ ecal
-        //! Values are between +-0.5 with a precision of 0.002
-        float deltaEta() const { return float(deltaEta_)/500.f; }
-        float deltaPhi() const { return float(deltaPhi_)/500.f; }
+    //! just the status code part of an EcalChannelStatusCode for all crossed Ecal cells
+    const std::vector<uint16_t>& crossedEcalStatus() const { return crossedEcalStatus_; }
+    //! just the status code part of an HcalChannelStatus for all crossed Hcal cells
+    const std::vector<uint32_t>& crossedHcalStatus() const { return crossedHcalStatus_; }
 
-        const PackedCandidateRef& packedCandRef() const { return packedCandRef_; }
-        const PackedCandidateRef& nearestPFPackedCandRef() const { return nearestPFPackedCandRef_; }
-        const PackedCandidateRef& nearestLostTrackPackedCandRef() const { return nearestPFPackedCandRef_; }
+    //! difference in eta/phi between initial traj and intersection w/ ecal
+    //! Values are between +-0.5 with a precision of 0.002
+    float deltaEta() const { return float(deltaEta_) / 500.f; }
+    float deltaPhi() const { return float(deltaPhi_) / 500.f; }
 
-      protected:
-        PFIsolation pfIsolationDR03_;
-        PFIsolation miniIsolation_;
-        float matchedCaloJetEmEnergy_;  //energy of nearest calojet within a given dR;
-        float matchedCaloJetHadEnergy_;
-	bool pfLepOverlap_;
-	float pfNeutralSum_;
-        float dz_, dxy_, dzError_, dxyError_;        
-        int fromPV_;  //only stored for packedPFCandidates
-        int trackQuality_;
-        float dEdxStrip_, dEdxPixel_; //in MeV/mm
+    const PackedCandidateRef& packedCandRef() const { return packedCandRef_; }
+    const PackedCandidateRef& nearestPFPackedCandRef() const { return nearestPFPackedCandRef_; }
+    const PackedCandidateRef& nearestLostTrackPackedCandRef() const { return nearestPFPackedCandRef_; }
 
-        reco::HitPattern hitPattern_;
+  protected:
+    PFIsolation pfIsolationDR03_;
+    PFIsolation miniIsolation_;
+    float matchedCaloJetEmEnergy_;  //energy of nearest calojet within a given dR;
+    float matchedCaloJetHadEnergy_;
+    bool pfLepOverlap_;
+    float pfNeutralSum_;
+    float dz_, dxy_, dzError_, dxyError_;
+    int fromPV_;  //only stored for packedPFCandidates
+    int trackQuality_;
+    float dEdxStrip_, dEdxPixel_;  //in MeV/mm
 
-        std::vector<uint16_t> crossedEcalStatus_;
-        std::vector<uint32_t> crossedHcalStatus_;
-        int deltaEta_, deltaPhi_;
+    reco::HitPattern hitPattern_;
 
-        PackedCandidateRef packedCandRef_; // stored only for packedPFCands/lostTracks. NULL for generalTracks
-        PackedCandidateRef nearestPFPackedCandRef_; 
-        PackedCandidateRef nearestLostTrackPackedCandRef_; 
+    std::vector<uint16_t> crossedEcalStatus_;
+    std::vector<uint32_t> crossedHcalStatus_;
+    int deltaEta_, deltaPhi_;
 
-    };
+    PackedCandidateRef packedCandRef_;  // stored only for packedPFCands/lostTracks. NULL for generalTracks
+    PackedCandidateRef nearestPFPackedCandRef_;
+    PackedCandidateRef nearestLostTrackPackedCandRef_;
+  };
 
-    typedef std::vector<IsolatedTrack> IsolatedTrackCollection;
+  typedef std::vector<IsolatedTrack> IsolatedTrackCollection;
 
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/Isolation.h
+++ b/DataFormats/PatCandidates/interface/Isolation.h
@@ -4,16 +4,26 @@
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
 
 namespace pat {
-    typedef reco::IsoDeposit IsoDeposit;
-    /// Enum defining isolation keys
-    enum IsolationKeys { TrackIso=0, EcalIso=1, HcalIso=2,
-			 PfAllParticleIso=3,PfChargedHadronIso=4, PfNeutralHadronIso=5, PfGammaIso=6, 
-			 User1Iso=7, User2Iso=8, User3Iso=9, User4Iso=10, User5Iso=11,
-			 UserBaseIso=7, // offset of the first user isolation
-			 CaloIso=-1,     // keys which are not real indices are mapped to negative numbers.
-			 PfPUChargedHadronIso=12,
-			 PfChargedAllIso=13
-    };
-}
+  typedef reco::IsoDeposit IsoDeposit;
+  /// Enum defining isolation keys
+  enum IsolationKeys {
+    TrackIso = 0,
+    EcalIso = 1,
+    HcalIso = 2,
+    PfAllParticleIso = 3,
+    PfChargedHadronIso = 4,
+    PfNeutralHadronIso = 5,
+    PfGammaIso = 6,
+    User1Iso = 7,
+    User2Iso = 8,
+    User3Iso = 9,
+    User4Iso = 10,
+    User5Iso = 11,
+    UserBaseIso = 7,  // offset of the first user isolation
+    CaloIso = -1,     // keys which are not real indices are mapped to negative numbers.
+    PfPUChargedHadronIso = 12,
+    PfChargedAllIso = 13
+  };
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -14,7 +14,6 @@
   \author   Steven Lowette, Giovanni Petrucciani, Roger Wolf, Christian Autermann
 */
 
-
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/BasicJet.h"
 #include "DataFormats/JetReco/interface/JPTJet.h"
@@ -49,24 +48,23 @@
 
 #include <numeric>
 
-
 // Define typedefs for convenience
 namespace pat {
   class Jet;
-  typedef std::vector<Jet>              JetCollection;
-  typedef edm::Ref<JetCollection>       JetRef;
+  typedef std::vector<Jet> JetCollection;
+  typedef edm::Ref<JetCollection> JetRef;
   typedef edm::RefVector<JetCollection> JetRefVector;
-}
+}  // namespace pat
 
 namespace reco {
   /// pipe operator (introduced to use pat::Jet with PFTopProjectors)
   std::ostream& operator<<(std::ostream& out, const pat::Jet& obj);
-}
+}  // namespace reco
 
 // Class definition
 namespace pat {
 
-   class PATJetSlimmer;
+  class PATJetSlimmer;
 
   typedef reco::CaloJet::Specific CaloSpecific;
   typedef reco::JPTJet::Specific JPTSpecific;
@@ -76,7 +74,6 @@ namespace pat {
   typedef std::vector<edm::FwdPtr<CaloTower> > CaloTowerFwdPtrCollection;
   typedef std::vector<edm::Ptr<pat::Jet> > JetPtrCollection;
 
-
   class Jet : public PATObject<reco::Jet> {
     /// make friends with PATJetProducer so that it can set the an initial
     /// jet energy scale unequal to raw calling the private initializeJEC
@@ -85,615 +82,670 @@ namespace pat {
     friend class PATJetSlimmer;
     friend class PATJetUpdater;
 
-    public:
+  public:
+    /// default constructor
+    Jet();
+    /// constructor from a reco::Jet
+    Jet(const reco::Jet& aJet);
+    /// constructor from ref to reco::Jet
+    Jet(const edm::RefToBase<reco::Jet>& aJetRef);
+    /// constructor from ref to reco::Jet
+    Jet(const edm::Ptr<reco::Jet>& aJetRef);
+    /// constructure from ref to pat::Jet
+    Jet(const edm::RefToBase<pat::Jet>& aJetRef);
+    /// constructure from ref to pat::Jet
+    Jet(const edm::Ptr<pat::Jet>& aJetRef);
+    /// destructor
+    ~Jet() override;
+    /// required reimplementation of the Candidate's clone method
+    Jet* clone() const override { return new Jet(*this); }
 
-      /// default constructor
-      Jet();
-      /// constructor from a reco::Jet
-      Jet(const reco::Jet & aJet);
-      /// constructor from ref to reco::Jet
-      Jet(const edm::RefToBase<reco::Jet> & aJetRef);
-      /// constructor from ref to reco::Jet
-      Jet(const edm::Ptr<reco::Jet> & aJetRef);
-      /// constructure from ref to pat::Jet
-      Jet(const edm::RefToBase<pat::Jet> & aJetRef);
-      /// constructure from ref to pat::Jet
-      Jet(const edm::Ptr<pat::Jet> & aJetRef);
-      /// destructor
-      ~Jet() override;
-      /// required reimplementation of the Candidate's clone method
-      Jet * clone() const override { return new Jet(*this); }
+    /// ---- methods for MC matching ----
 
-      /// ---- methods for MC matching ----
-
-      /// return the matched generated parton
-      const reco::GenParticle * genParton() const { return genParticle(); }
-      /// return the matched generated jet
-      const reco::GenJet * genJet() const;
-      /// return the parton-based flavour of the jet
-      int partonFlavour() const;
-      /// return the hadron-based flavour of the jet
-      int hadronFlavour() const;
-      /// return the JetFlavourInfo of the jet
-      const reco::JetFlavourInfo & jetFlavourInfo() const;
+    /// return the matched generated parton
+    const reco::GenParticle* genParton() const { return genParticle(); }
+    /// return the matched generated jet
+    const reco::GenJet* genJet() const;
+    /// return the parton-based flavour of the jet
+    int partonFlavour() const;
+    /// return the hadron-based flavour of the jet
+    int hadronFlavour() const;
+    /// return the JetFlavourInfo of the jet
+    const reco::JetFlavourInfo& jetFlavourInfo() const;
 
   public:
-      /// ---- methods for jet corrections ----
+    /// ---- methods for jet corrections ----
 
-      /// returns the labels of all available sets of jet energy corrections
-      const std::vector<std::string> availableJECSets() const;
-      // returns the available JEC Levels for a given jecSet
-      const std::vector<std::string> availableJECLevels(const int& set=0) const;
-      // returns the available JEC Levels for a given jecSet
-      const std::vector<std::string> availableJECLevels(const std::string& set) const { return availableJECLevels(jecSet(set)); };
-      /// returns true if the jet carries jet energy correction information
-      /// at all
-      bool jecSetsAvailable() const { return !jec_.empty(); }
-      /// returns true if the jet carries a set of jet energy correction
-      /// factors with the given label
-      bool jecSetAvailable(const std::string& set) const {return (jecSet(set)>=0); };
-      /// returns true if the jet carries a set of jet energy correction
-      /// factors with the given label
-      bool jecSetAvailable(const unsigned int& set) const {return (set<jec_.size()); };
-      /// returns the label of the current set of jet energy corrections
-      std::string currentJECSet() const { return currentJECSet_<jec_.size() ? jec_.at(currentJECSet_).jecSet() : std::string("ERROR"); }
-      /// return the name of the current step of jet energy corrections
-      std::string currentJECLevel() const { return currentJECSet_<jec_.size() ? jec_.at(currentJECSet_).jecLevel(currentJECLevel_) : std::string("ERROR"); };
-      /// return flavour of the current step of jet energy corrections
-      JetCorrFactors::Flavor currentJECFlavor() const { return currentJECFlavor_; };
-      /// correction factor to the given level for a specific set
-      /// of correction factors, starting from the current level
-      float jecFactor(const std::string& level, const std::string& flavor="none", const std::string& set="") const;
-      /// correction factor to the given level for a specific set
-      /// of correction factors, starting from the current level
-      float jecFactor(const unsigned int& level, const JetCorrFactors::Flavor& flavor=JetCorrFactors::NONE, const unsigned int& set=0) const;
-      /// copy of the jet corrected up to the given level for the set
-      /// of jet energy correction factors, which is currently in use
-      Jet correctedJet(const std::string& level, const std::string& flavor="none", const std::string& set="") const;
-      /// copy of the jet corrected up to the given level for the set
-      /// of jet energy correction factors, which is currently in use
-      Jet correctedJet(const unsigned int& level, const JetCorrFactors::Flavor& flavor=JetCorrFactors::NONE, const unsigned int& set=0) const;
-      /// p4 of the jet corrected up to the given level for the set
-      /// of jet energy correction factors, which is currently in use
-      const LorentzVector correctedP4(const std::string& level, const std::string& flavor="none", const std::string& set="") const { return correctedJet(level, flavor, set).p4(); };
-      /// p4 of the jet corrected up to the given level for the set
-      /// of jet energy correction factors, which is currently in use
-      const LorentzVector correctedP4(const unsigned int& level, const JetCorrFactors::Flavor& flavor=JetCorrFactors::NONE, const unsigned int& set=0) const { return correctedJet(level, flavor, set).p4(); };
+    /// returns the labels of all available sets of jet energy corrections
+    const std::vector<std::string> availableJECSets() const;
+    // returns the available JEC Levels for a given jecSet
+    const std::vector<std::string> availableJECLevels(const int& set = 0) const;
+    // returns the available JEC Levels for a given jecSet
+    const std::vector<std::string> availableJECLevels(const std::string& set) const {
+      return availableJECLevels(jecSet(set));
+    };
+    /// returns true if the jet carries jet energy correction information
+    /// at all
+    bool jecSetsAvailable() const { return !jec_.empty(); }
+    /// returns true if the jet carries a set of jet energy correction
+    /// factors with the given label
+    bool jecSetAvailable(const std::string& set) const { return (jecSet(set) >= 0); };
+    /// returns true if the jet carries a set of jet energy correction
+    /// factors with the given label
+    bool jecSetAvailable(const unsigned int& set) const { return (set < jec_.size()); };
+    /// returns the label of the current set of jet energy corrections
+    std::string currentJECSet() const {
+      return currentJECSet_ < jec_.size() ? jec_.at(currentJECSet_).jecSet() : std::string("ERROR");
+    }
+    /// return the name of the current step of jet energy corrections
+    std::string currentJECLevel() const {
+      return currentJECSet_ < jec_.size() ? jec_.at(currentJECSet_).jecLevel(currentJECLevel_) : std::string("ERROR");
+    };
+    /// return flavour of the current step of jet energy corrections
+    JetCorrFactors::Flavor currentJECFlavor() const { return currentJECFlavor_; };
+    /// correction factor to the given level for a specific set
+    /// of correction factors, starting from the current level
+    float jecFactor(const std::string& level, const std::string& flavor = "none", const std::string& set = "") const;
+    /// correction factor to the given level for a specific set
+    /// of correction factors, starting from the current level
+    float jecFactor(const unsigned int& level,
+                    const JetCorrFactors::Flavor& flavor = JetCorrFactors::NONE,
+                    const unsigned int& set = 0) const;
+    /// copy of the jet corrected up to the given level for the set
+    /// of jet energy correction factors, which is currently in use
+    Jet correctedJet(const std::string& level, const std::string& flavor = "none", const std::string& set = "") const;
+    /// copy of the jet corrected up to the given level for the set
+    /// of jet energy correction factors, which is currently in use
+    Jet correctedJet(const unsigned int& level,
+                     const JetCorrFactors::Flavor& flavor = JetCorrFactors::NONE,
+                     const unsigned int& set = 0) const;
+    /// p4 of the jet corrected up to the given level for the set
+    /// of jet energy correction factors, which is currently in use
+    const LorentzVector correctedP4(const std::string& level,
+                                    const std::string& flavor = "none",
+                                    const std::string& set = "") const {
+      return correctedJet(level, flavor, set).p4();
+    };
+    /// p4 of the jet corrected up to the given level for the set
+    /// of jet energy correction factors, which is currently in use
+    const LorentzVector correctedP4(const unsigned int& level,
+                                    const JetCorrFactors::Flavor& flavor = JetCorrFactors::NONE,
+                                    const unsigned int& set = 0) const {
+      return correctedJet(level, flavor, set).p4();
+    };
 
   private:
-      /// index of the set of jec factors with given label; returns -1 if no set
-      /// of jec factors exists with the given label
-      int jecSet(const std::string& label) const;
-      /// update the current JEC set; used by correctedJet
-      void currentJECSet(const unsigned int& set) { currentJECSet_=set; };
-      /// update the current JEC level; used by correctedJet
-      void currentJECLevel(const unsigned int& level) { currentJECLevel_=level; };
-      /// update the current JEC flavor; used by correctedJet
-      void currentJECFlavor(const JetCorrFactors::Flavor& flavor) { currentJECFlavor_=flavor; };
-      /// add more sets of energy correction factors
-      void addJECFactors(const JetCorrFactors& jec) {jec_.push_back(jec); };
-      /// initialize the jet to a given JEC level during creation starting from Uncorrected
-      void initializeJEC(unsigned int level, const JetCorrFactors::Flavor& flavor=JetCorrFactors::NONE, unsigned int set=0);
+    /// index of the set of jec factors with given label; returns -1 if no set
+    /// of jec factors exists with the given label
+    int jecSet(const std::string& label) const;
+    /// update the current JEC set; used by correctedJet
+    void currentJECSet(const unsigned int& set) { currentJECSet_ = set; };
+    /// update the current JEC level; used by correctedJet
+    void currentJECLevel(const unsigned int& level) { currentJECLevel_ = level; };
+    /// update the current JEC flavor; used by correctedJet
+    void currentJECFlavor(const JetCorrFactors::Flavor& flavor) { currentJECFlavor_ = flavor; };
+    /// add more sets of energy correction factors
+    void addJECFactors(const JetCorrFactors& jec) { jec_.push_back(jec); };
+    /// initialize the jet to a given JEC level during creation starting from Uncorrected
+    void initializeJEC(unsigned int level,
+                       const JetCorrFactors::Flavor& flavor = JetCorrFactors::NONE,
+                       unsigned int set = 0);
 
   public:
-      /// ---- methods for accessing b-tagging info ----
+    /// ---- methods for accessing b-tagging info ----
 
-      /// get b discriminant from label name
-      float bDiscriminator(const std::string &theLabel) const;
-      /// get vector of paire labelname-disciValue
-      const std::vector<std::pair<std::string, float> > & getPairDiscri() const;
-      /// get list of tag info labels
-      std::vector<std::string> const & tagInfoLabels() const { return tagInfoLabels_; }
-      /// check to see if the given tag info is nonzero
-      bool hasTagInfo( const std::string label) const { return tagInfo(label) != nullptr; }
-      /// get a tagInfo with the given name, or NULL if none is found.
-      /// You should omit the 'TagInfos' part from the label
-      const reco::BaseTagInfo            * tagInfo(const std::string &label) const;
-      /// get a tagInfo with the given name and type or NULL if none is found.
-      /// If the label is empty or not specified, it returns the first tagInfo of that type (if any one exists)
-      /// you should omit the 'TagInfos' part from the label
-      const reco::CandIPTagInfo          * tagInfoCandIP(const std::string &label="") const;
-      const reco::TrackIPTagInfo         * tagInfoTrackIP(const std::string &label="") const;
-      /// get a tagInfo with the given name and type or NULL if none is found.
-      /// If the label is empty or not specified, it returns the first tagInfo of that type (if any one exists)
-      /// you should omit the 'TagInfos' part from the label
-      const reco::CandSoftLeptonTagInfo  * tagInfoCandSoftLepton(const std::string &label="") const;
-      const reco::SoftLeptonTagInfo      * tagInfoSoftLepton(const std::string &label="") const;
-      /// get a tagInfo with the given name and type or NULL if none is found.
-      /// If the label is empty or not specified, it returns the first tagInfo of that type (if any one exists)
-      /// you should omit the 'TagInfos' part from the label
-      const reco::CandSecondaryVertexTagInfo * tagInfoCandSecondaryVertex(const std::string &label="") const;
-      const reco::SecondaryVertexTagInfo     * tagInfoSecondaryVertex(const std::string &label="") const;
-      const reco::BoostedDoubleSVTagInfo     * tagInfoBoostedDoubleSV(const std::string &label="") const;
-      /// method to add a algolabel-discriminator pair
-      void addBDiscriminatorPair(const std::pair<std::string, float> & thePair);
-      /// sets a tagInfo with the given name from an edm::Ptr<T> to it.
-      /// If the label ends with 'TagInfos', the 'TagInfos' is stripped out.
-      void  addTagInfo(const std::string &label,
-		       const TagInfoFwdPtrCollection::value_type &info) ;
+    /// get b discriminant from label name
+    float bDiscriminator(const std::string& theLabel) const;
+    /// get vector of paire labelname-disciValue
+    const std::vector<std::pair<std::string, float> >& getPairDiscri() const;
+    /// get list of tag info labels
+    std::vector<std::string> const& tagInfoLabels() const { return tagInfoLabels_; }
+    /// check to see if the given tag info is nonzero
+    bool hasTagInfo(const std::string label) const { return tagInfo(label) != nullptr; }
+    /// get a tagInfo with the given name, or NULL if none is found.
+    /// You should omit the 'TagInfos' part from the label
+    const reco::BaseTagInfo* tagInfo(const std::string& label) const;
+    /// get a tagInfo with the given name and type or NULL if none is found.
+    /// If the label is empty or not specified, it returns the first tagInfo of that type (if any one exists)
+    /// you should omit the 'TagInfos' part from the label
+    const reco::CandIPTagInfo* tagInfoCandIP(const std::string& label = "") const;
+    const reco::TrackIPTagInfo* tagInfoTrackIP(const std::string& label = "") const;
+    /// get a tagInfo with the given name and type or NULL if none is found.
+    /// If the label is empty or not specified, it returns the first tagInfo of that type (if any one exists)
+    /// you should omit the 'TagInfos' part from the label
+    const reco::CandSoftLeptonTagInfo* tagInfoCandSoftLepton(const std::string& label = "") const;
+    const reco::SoftLeptonTagInfo* tagInfoSoftLepton(const std::string& label = "") const;
+    /// get a tagInfo with the given name and type or NULL if none is found.
+    /// If the label is empty or not specified, it returns the first tagInfo of that type (if any one exists)
+    /// you should omit the 'TagInfos' part from the label
+    const reco::CandSecondaryVertexTagInfo* tagInfoCandSecondaryVertex(const std::string& label = "") const;
+    const reco::SecondaryVertexTagInfo* tagInfoSecondaryVertex(const std::string& label = "") const;
+    const reco::BoostedDoubleSVTagInfo* tagInfoBoostedDoubleSV(const std::string& label = "") const;
+    /// method to add a algolabel-discriminator pair
+    void addBDiscriminatorPair(const std::pair<std::string, float>& thePair);
+    /// sets a tagInfo with the given name from an edm::Ptr<T> to it.
+    /// If the label ends with 'TagInfos', the 'TagInfos' is stripped out.
+    void addTagInfo(const std::string& label, const TagInfoFwdPtrCollection::value_type& info);
 
+    // ---- track related methods ----
 
-      // ---- track related methods ----
+    /// method to return the JetCharge computed when creating the Jet
+    float jetCharge() const;
+    /// method to return a vector of refs to the tracks associated to this jet
+    const reco::TrackRefVector& associatedTracks() const;
+    /// method to set the jet charge
+    void setJetCharge(float jetCharge);
+    /// method to set the vector of refs to the tracks associated to this jet
+    void setAssociatedTracks(const reco::TrackRefVector& tracks);
 
-      /// method to return the JetCharge computed when creating the Jet
-      float jetCharge() const;
-      /// method to return a vector of refs to the tracks associated to this jet
-      const reco::TrackRefVector & associatedTracks() const;
-      /// method to set the jet charge
-      void setJetCharge(float jetCharge);
-      /// method to set the vector of refs to the tracks associated to this jet
-      void setAssociatedTracks(const reco::TrackRefVector &tracks);
+    // ---- methods for content embedding ----
 
-      // ---- methods for content embedding ----
+    /// method to store the CaloJet constituents internally
+    void setCaloTowers(const CaloTowerFwdPtrCollection& caloTowers);
+    /// method to store the PFCandidate constituents internally
+    void setPFCandidates(const PFCandidateFwdPtrCollection& pfCandidates);
+    /// method to set the matched parton
+    void setGenParton(const reco::GenParticleRef& gp, bool embed = false) { setGenParticleRef(gp, embed); }
+    /// method to set the matched generated jet reference, embedding if requested
+    void setGenJetRef(const edm::FwdRef<reco::GenJetCollection>& gj);
+    /// method to set the parton-based flavour of the jet
+    void setPartonFlavour(int partonFl);
+    /// method to set the hadron-based flavour of the jet
+    void setHadronFlavour(int hadronFl);
+    /// method to set the JetFlavourInfo of the jet
+    void setJetFlavourInfo(const reco::JetFlavourInfo& jetFlavourInfo);
 
-      /// method to store the CaloJet constituents internally
-      void setCaloTowers(const CaloTowerFwdPtrCollection & caloTowers);
-      /// method to store the PFCandidate constituents internally
-      void setPFCandidates(const PFCandidateFwdPtrCollection & pfCandidates);
-      /// method to set the matched parton
-      void setGenParton(const reco::GenParticleRef & gp, bool embed=false) { setGenParticleRef(gp, embed); }
-      /// method to set the matched generated jet reference, embedding if requested
-      void setGenJetRef(const edm::FwdRef<reco::GenJetCollection> & gj);
-      /// method to set the parton-based flavour of the jet
-      void setPartonFlavour(int partonFl);
-      /// method to set the hadron-based flavour of the jet
-      void setHadronFlavour(int hadronFl);
-      /// method to set the JetFlavourInfo of the jet
-      void setJetFlavourInfo(const reco::JetFlavourInfo & jetFlavourInfo);
+    /// methods for jet ID
+    void setJetID(reco::JetID const& id) { jetID_ = id; }
 
+    // ---- jet specific methods ----
 
-      /// methods for jet ID
-      void setJetID( reco::JetID const & id ) { jetID_ = id; }
+    /// check to see if the jet is a reco::CaloJet
+    bool isCaloJet() const { return !specificCalo_.empty() && !isJPTJet(); }
+    /// check to see if the jet is a reco::JPTJet
+    bool isJPTJet() const { return !specificJPT_.empty(); }
+    /// check to see if the jet is a reco::PFJet
+    bool isPFJet() const { return !specificPF_.empty(); }
+    /// check to see if the jet is no more than a reco::BasicJet
+    bool isBasicJet() const { return !(isCaloJet() || isPFJet() || isJPTJet()); }
+    /// retrieve the calo specific part of the jet
+    const CaloSpecific& caloSpecific() const {
+      if (specificCalo_.empty())
+        throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a CaloJet.\n";
+      return specificCalo_[0];
+    }
+    /// retrieve the jpt specific part of the jet
+    const JPTSpecific& jptSpecific() const {
+      if (specificJPT_.empty())
+        throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet.\n";
+      return specificJPT_[0];
+    }
+    /// check to see if the PFSpecific object is stored
+    bool hasPFSpecific() const { return !specificPF_.empty(); }
+    /// retrieve the pf specific part of the jet
+    const PFSpecific& pfSpecific() const {
+      if (specificPF_.empty())
+        throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a PFJet.\n";
+      return specificPF_[0];
+    }
+    /// set the calo specific part of the jet
+    void setCaloSpecific(const CaloSpecific& newCaloSpecific) {
+      if (specificCalo_.empty())
+        throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a CaloJet.\n";
+      specificCalo_[0] = newCaloSpecific;
+    }
+    /// set the jpt specific part of the jet
+    void setJPTSpecific(const JPTSpecific& newJPTSpecific) {
+      if (specificJPT_.empty())
+        throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet.\n";
+      specificJPT_[0] = newJPTSpecific;
+    }
+    /// set the pf specific part of the jet
+    void setPFSpecific(const PFSpecific& newPFSpecific) {
+      if (specificPF_.empty())
+        throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a PFJet.\n";
+      specificPF_[0] = newPFSpecific;
+    }
 
-      // ---- jet specific methods ----
+    // ---- Calo Jet specific information ----
 
-      /// check to see if the jet is a reco::CaloJet
-      bool isCaloJet()  const { return !specificCalo_.empty() && !isJPTJet(); }
-      /// check to see if the jet is a reco::JPTJet
-      bool isJPTJet()   const { return !specificJPT_.empty(); }
-      /// check to see if the jet is a reco::PFJet
-      bool isPFJet()    const { return !specificPF_.empty(); }
-      /// check to see if the jet is no more than a reco::BasicJet
-      bool isBasicJet() const { return !(isCaloJet() || isPFJet() || isJPTJet()); }
-      /// retrieve the calo specific part of the jet
-      const CaloSpecific& caloSpecific() const {
-	if (specificCalo_.empty()) throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a CaloJet.\n";
-	return specificCalo_[0];
+    /// returns the maximum energy deposited in ECAL towers
+    float maxEInEmTowers() const { return caloSpecific().mMaxEInEmTowers; }
+    /// returns the maximum energy deposited in HCAL towers
+    float maxEInHadTowers() const { return caloSpecific().mMaxEInHadTowers; }
+    /// returns the jet hadronic energy fraction
+    float energyFractionHadronic() const { return caloSpecific().mEnergyFractionHadronic; }
+    /// returns the jet electromagnetic energy fraction
+    float emEnergyFraction() const { return caloSpecific().mEnergyFractionEm; }
+    /// returns the jet hadronic energy in HB
+    float hadEnergyInHB() const { return caloSpecific().mHadEnergyInHB; }
+    /// returns the jet hadronic energy in HO
+    float hadEnergyInHO() const { return caloSpecific().mHadEnergyInHO; }
+    /// returns the jet hadronic energy in HE
+    float hadEnergyInHE() const { return caloSpecific().mHadEnergyInHE; }
+    /// returns the jet hadronic energy in HF
+    float hadEnergyInHF() const { return caloSpecific().mHadEnergyInHF; }
+    /// returns the jet electromagnetic energy in EB
+    float emEnergyInEB() const { return caloSpecific().mEmEnergyInEB; }
+    /// returns the jet electromagnetic energy in EE
+    float emEnergyInEE() const { return caloSpecific().mEmEnergyInEE; }
+    /// returns the jet electromagnetic energy extracted from HF
+    float emEnergyInHF() const { return caloSpecific().mEmEnergyInHF; }
+    /// returns area of contributing towers
+    float towersArea() const { return caloSpecific().mTowersArea; }
+    /// returns the number of constituents carrying a 90% of the total Jet energy*/
+    int n90() const { return nCarrying(0.9); }
+    /// returns the number of constituents carrying a 60% of the total Jet energy*/
+    int n60() const { return nCarrying(0.6); }
+
+    /// convert generic constituent to specific type
+    //  static CaloTowerPtr caloTower (const reco::Candidate* fConstituent);
+    /// get specific constituent of the CaloJet.
+    /// if the caloTowers were embedded, this reference is transient only and must not be persisted
+    CaloTowerPtr getCaloConstituent(unsigned fIndex) const;
+    /// get the constituents of the CaloJet.
+    /// If the caloTowers were embedded, these reference are transient only and must not be persisted
+    std::vector<CaloTowerPtr> const& getCaloConstituents() const;
+
+    // ---- JPT Jet specific information ----
+
+    /// pions fully contained in cone
+    const reco::TrackRefVector& pionsInVertexInCalo() const { return jptSpecific().pionsInVertexInCalo; }
+    /// pions that curled out
+    const reco::TrackRefVector& pionsInVertexOutCalo() const { return jptSpecific().pionsInVertexOutCalo; }
+    /// pions that curled in
+    const reco::TrackRefVector& pionsOutVertexInCalo() const { return jptSpecific().pionsOutVertexInCalo; }
+    /// muons fully contained in cone
+    const reco::TrackRefVector& muonsInVertexInCalo() const { return jptSpecific().muonsInVertexInCalo; }
+    /// muons that curled out
+    const reco::TrackRefVector& muonsInVertexOutCalo() const { return jptSpecific().muonsInVertexOutCalo; }
+    /// muons that curled in
+    const reco::TrackRefVector& muonsOutVertexInCalo() const { return jptSpecific().muonsOutVertexInCalo; }
+    /// electrons fully contained in cone
+    const reco::TrackRefVector& elecsInVertexInCalo() const { return jptSpecific().elecsInVertexInCalo; }
+    /// electrons that curled out
+    const reco::TrackRefVector& elecsInVertexOutCalo() const { return jptSpecific().elecsInVertexOutCalo; }
+    /// electrons that curled in
+    const reco::TrackRefVector& elecsOutVertexInCalo() const { return jptSpecific().elecsOutVertexInCalo; }
+    /// zero suppression correction
+    const float& zspCorrection() const { return jptSpecific().mZSPCor; }
+    /// chargedMultiplicity
+    float elecMultiplicity() const {
+      return jptSpecific().elecsInVertexInCalo.size() + jptSpecific().elecsInVertexOutCalo.size();
+    }
+
+    // ---- JPT or PF Jet specific information ----
+
+    /// muonMultiplicity
+    int muonMultiplicity() const;
+    /// chargedMultiplicity
+    int chargedMultiplicity() const;
+    /// chargedEmEnergy
+    float chargedEmEnergy() const;
+    /// neutralEmEnergy
+    float neutralEmEnergy() const;
+    /// chargedHadronEnergy
+    float chargedHadronEnergy() const;
+    /// neutralHadronEnergy
+    float neutralHadronEnergy() const;
+
+    /// chargedHadronEnergyFraction (relative to uncorrected jet energy)
+    float chargedHadronEnergyFraction() const {
+      return chargedHadronEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy());
+    }
+    /// neutralHadronEnergyFraction (relative to uncorrected jet energy)
+    float neutralHadronEnergyFraction() const {
+      return neutralHadronEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy());
+    }
+    /// chargedEmEnergyFraction (relative to uncorrected jet energy)
+    float chargedEmEnergyFraction() const {
+      return chargedEmEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy());
+    }
+    /// neutralEmEnergyFraction (relative to uncorrected jet energy)
+    float neutralEmEnergyFraction() const {
+      return neutralEmEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy());
+    }
+
+    // ---- PF Jet specific information ----
+    /// photonEnergy
+    float photonEnergy() const { return pfSpecific().mPhotonEnergy; }
+    /// photonEnergyFraction (relative to corrected jet energy)
+    float photonEnergyFraction() const {
+      return photonEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy());
+    }
+    /// electronEnergy
+    float electronEnergy() const { return pfSpecific().mElectronEnergy; }
+    /// electronEnergyFraction (relative to corrected jet energy)
+    float electronEnergyFraction() const {
+      return electronEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy());
+    }
+    /// muonEnergy
+    float muonEnergy() const { return pfSpecific().mMuonEnergy; }
+    /// muonEnergyFraction (relative to corrected jet energy)
+    float muonEnergyFraction() const { return muonEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy()); }
+    /// HFHadronEnergy
+    float HFHadronEnergy() const { return pfSpecific().mHFHadronEnergy; }
+    /// HFHadronEnergyFraction (relative to corrected jet energy)
+    float HFHadronEnergyFraction() const {
+      return HFHadronEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy());
+    }
+    /// HFEMEnergy
+    float HFEMEnergy() const { return pfSpecific().mHFEMEnergy; }
+    /// HFEMEnergyFraction (relative to corrected jet energy)
+    float HFEMEnergyFraction() const { return HFEMEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy()); }
+
+    /// chargedHadronMultiplicity
+    int chargedHadronMultiplicity() const { return pfSpecific().mChargedHadronMultiplicity; }
+    /// neutralHadronMultiplicity
+    int neutralHadronMultiplicity() const { return pfSpecific().mNeutralHadronMultiplicity; }
+    /// photonMultiplicity
+    int photonMultiplicity() const { return pfSpecific().mPhotonMultiplicity; }
+    /// electronMultiplicity
+    int electronMultiplicity() const { return pfSpecific().mElectronMultiplicity; }
+
+    /// HFHadronMultiplicity
+    int HFHadronMultiplicity() const { return pfSpecific().mHFHadronMultiplicity; }
+    /// HFEMMultiplicity
+    int HFEMMultiplicity() const { return pfSpecific().mHFEMMultiplicity; }
+
+    /// chargedMuEnergy
+    float chargedMuEnergy() const { return pfSpecific().mChargedMuEnergy; }
+    /// chargedMuEnergyFraction
+    float chargedMuEnergyFraction() const {
+      return chargedMuEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy());
+    }
+
+    /// neutralMultiplicity
+    int neutralMultiplicity() const { return pfSpecific().mNeutralMultiplicity; }
+
+    /// hoEnergy
+    float hoEnergy() const { return pfSpecific().mHOEnergy; }
+    /// hoEnergyFraction (relative to corrected jet energy)
+    float hoEnergyFraction() const { return hoEnergy() / ((jecSetsAvailable() ? jecFactor(0) : 1.) * energy()); }
+    /// convert generic constituent to specific type
+
+    //  static CaloTowerPtr caloTower (const reco::Candidate* fConstituent);
+    /// get specific constituent of the CaloJet.
+    /// if the caloTowers were embedded, this reference is transient only and must not be persisted
+    reco::PFCandidatePtr getPFConstituent(unsigned fIndex) const;
+    /// get the constituents of the CaloJet.
+    /// If the caloTowers were embedded, these reference are transient only and must not be persisted
+    std::vector<reco::PFCandidatePtr> const& getPFConstituents() const;
+
+    /// get a pointer to a Candididate constituent of the jet
+    ///    If using refactorized PAT, return that. (constituents size > 0)
+    ///    Else check the old version of PAT (embedded constituents size > 0)
+    ///    Else return the reco Jet number of constituents
+    const reco::Candidate* daughter(size_t i) const override;
+
+    reco::CandidatePtr daughterPtr(size_t i) const override;
+    const reco::CompositePtrCandidate::daughters& daughterPtrVector() const override;
+
+    using reco::LeafCandidate::daughter;  // avoid hiding the base implementation
+
+    /// Return number of daughters:
+    ///    If using refactorized PAT, return that. (constituents size > 0)
+    ///    Else check the old version of PAT (embedded constituents size > 0)
+    ///    Else return the reco Jet number of constituents
+    size_t numberOfDaughters() const override;
+
+    /// clear daughter references
+    void clearDaughters() override {
+      PATObject<reco::Jet>::clearDaughters();
+      daughtersTemp_.reset();  // need to reset daughtersTemp_ as well
+    }
+
+    /// accessing Jet ID information
+    reco::JetID const& jetID() const { return jetID_; }
+
+    /// Access to bare FwdPtr collections
+    CaloTowerFwdPtrVector const& caloTowersFwdPtr() const { return caloTowersFwdPtr_; }
+    reco::PFCandidateFwdPtrVector const& pfCandidatesFwdPtr() const { return pfCandidatesFwdPtr_; }
+    edm::FwdRef<reco::GenJetCollection> const& genJetFwdRef() const { return genJetFwdRef_; }
+    TagInfoFwdPtrCollection const& tagInfosFwdPtr() const { return tagInfosFwdPtr_; }
+
+    /// Update bare FwdPtr and FwdRef "forward" pointers while keeping the
+    /// "back" pointers the same (i.e. the ref "forwarding")
+    void updateFwdCaloTowerFwdPtr(unsigned int index, const edm::Ptr<CaloTower>& updateFwd) {
+      if (index < caloTowersFwdPtr_.size()) {
+        caloTowersFwdPtr_[index] = CaloTowerFwdPtrVector::value_type(updateFwd, caloTowersFwdPtr_[index].backPtr());
+      } else {
+        throw cms::Exception("OutOfRange") << "Index " << index << " is out of range" << std::endl;
       }
-      /// retrieve the jpt specific part of the jet
-      const JPTSpecific& jptSpecific() const {
-	if (specificJPT_.empty()) throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet.\n";
-	return specificJPT_[0];
+    }
+
+    void updateFwdPFCandidateFwdPtr(unsigned int index, const edm::Ptr<reco::PFCandidate>& updateFwd) {
+      if (index < pfCandidatesFwdPtr_.size()) {
+        pfCandidatesFwdPtr_[index] =
+            reco::PFCandidateFwdPtrVector::value_type(updateFwd, pfCandidatesFwdPtr_[index].backPtr());
+      } else {
+        throw cms::Exception("OutOfRange") << "Index " << index << " is out of range" << std::endl;
       }
-      /// check to see if the PFSpecific object is stored
-      bool hasPFSpecific() const { return !specificPF_.empty(); }
-      /// retrieve the pf specific part of the jet
-      const PFSpecific& pfSpecific() const {
-	if (specificPF_.empty()) throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a PFJet.\n";
-	return specificPF_[0];
+    }
+
+    void updateFwdTagInfoFwdPtr(unsigned int index, const edm::Ptr<reco::BaseTagInfo>& updateFwd) {
+      if (index < tagInfosFwdPtr_.size()) {
+        tagInfosFwdPtr_[index] = TagInfoFwdPtrCollection::value_type(updateFwd, tagInfosFwdPtr_[index].backPtr());
+      } else {
+        throw cms::Exception("OutOfRange") << "Index " << index << " is out of range" << std::endl;
       }
-      /// set the calo specific part of the jet
-      void setCaloSpecific(const CaloSpecific& newCaloSpecific) {
-	if (specificCalo_.empty()) throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a CaloJet.\n";
-	specificCalo_[0] = newCaloSpecific;
-      }
-      /// set the jpt specific part of the jet
-      void setJPTSpecific(const JPTSpecific& newJPTSpecific) {
-	if (specificJPT_.empty()) throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet.\n";
-	specificJPT_[0] = newJPTSpecific;
-      }
-      /// set the pf specific part of the jet
-      void setPFSpecific(const PFSpecific& newPFSpecific) {
-	if (specificPF_.empty()) throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a PFJet.\n";
-	specificPF_[0] = newPFSpecific;
-      }
+    }
 
-      // ---- Calo Jet specific information ----
+    void updateFwdGenJetFwdRef(edm::Ref<reco::GenJetCollection> updateRef) {
+      genJetFwdRef_ = edm::FwdRef<reco::GenJetCollection>(updateRef, genJetFwdRef_.backRef());
+    }
 
-      /// returns the maximum energy deposited in ECAL towers
-      float maxEInEmTowers() const {return caloSpecific().mMaxEInEmTowers;}
-      /// returns the maximum energy deposited in HCAL towers
-      float maxEInHadTowers() const {return caloSpecific().mMaxEInHadTowers;}
-      /// returns the jet hadronic energy fraction
-      float energyFractionHadronic () const {return caloSpecific().mEnergyFractionHadronic;}
-      /// returns the jet electromagnetic energy fraction
-      float emEnergyFraction() const {return caloSpecific().mEnergyFractionEm;}
-      /// returns the jet hadronic energy in HB
-      float hadEnergyInHB() const {return caloSpecific().mHadEnergyInHB;}
-      /// returns the jet hadronic energy in HO
-      float hadEnergyInHO() const {return caloSpecific().mHadEnergyInHO;}
-      /// returns the jet hadronic energy in HE
-      float hadEnergyInHE() const {return caloSpecific().mHadEnergyInHE;}
-      /// returns the jet hadronic energy in HF
-      float hadEnergyInHF() const {return caloSpecific().mHadEnergyInHF;}
-      /// returns the jet electromagnetic energy in EB
-      float emEnergyInEB() const {return caloSpecific().mEmEnergyInEB;}
-      /// returns the jet electromagnetic energy in EE
-      float emEnergyInEE() const {return caloSpecific().mEmEnergyInEE;}
-      /// returns the jet electromagnetic energy extracted from HF
-      float emEnergyInHF() const {return caloSpecific().mEmEnergyInHF;}
-      /// returns area of contributing towers
-      float towersArea() const {return caloSpecific().mTowersArea;}
-      /// returns the number of constituents carrying a 90% of the total Jet energy*/
-      int n90() const {return nCarrying (0.9);}
-      /// returns the number of constituents carrying a 60% of the total Jet energy*/
-      int n60() const {return nCarrying (0.6);}
+    /// pipe operator (introduced to use pat::Jet with PFTopProjectors)
+    friend std::ostream& reco::operator<<(std::ostream& out, const pat::Jet& obj);
 
-      /// convert generic constituent to specific type
-      //  static CaloTowerPtr caloTower (const reco::Candidate* fConstituent);
-      /// get specific constituent of the CaloJet.
-      /// if the caloTowers were embedded, this reference is transient only and must not be persisted
-      CaloTowerPtr getCaloConstituent (unsigned fIndex) const;
-      /// get the constituents of the CaloJet.
-      /// If the caloTowers were embedded, these reference are transient only and must not be persisted
-      std::vector<CaloTowerPtr> const & getCaloConstituents () const;
+    /// Access to subjet list
+    pat::JetPtrCollection const& subjets(unsigned int index = 0) const;
 
-      // ---- JPT Jet specific information ----
+    /// String access to subjet list
+    pat::JetPtrCollection const& subjets(std::string const& label) const;
 
-      /// pions fully contained in cone
-      const reco::TrackRefVector& pionsInVertexInCalo () const{return jptSpecific().pionsInVertexInCalo; }
-      /// pions that curled out
-      const reco::TrackRefVector& pionsInVertexOutCalo() const{return jptSpecific().pionsInVertexOutCalo;}
-      /// pions that curled in
-      const reco::TrackRefVector& pionsOutVertexInCalo() const{return jptSpecific().pionsOutVertexInCalo;}
-      /// muons fully contained in cone
-      const reco::TrackRefVector& muonsInVertexInCalo () const{return jptSpecific().muonsInVertexInCalo; }
-      /// muons that curled out
-      const reco::TrackRefVector& muonsInVertexOutCalo() const{return jptSpecific().muonsInVertexOutCalo;}
-      /// muons that curled in
-      const reco::TrackRefVector& muonsOutVertexInCalo() const{return jptSpecific().muonsOutVertexInCalo;}
-      /// electrons fully contained in cone
-      const reco::TrackRefVector& elecsInVertexInCalo () const{return jptSpecific().elecsInVertexInCalo; }
-      /// electrons that curled out
-      const reco::TrackRefVector& elecsInVertexOutCalo() const{return jptSpecific().elecsInVertexOutCalo;}
-      /// electrons that curled in
-      const reco::TrackRefVector& elecsOutVertexInCalo() const{return jptSpecific().elecsOutVertexInCalo;}
-      /// zero suppression correction
-      const float& zspCorrection() const {return jptSpecific().mZSPCor;}
-      /// chargedMultiplicity
-      float elecMultiplicity () const {return jptSpecific().elecsInVertexInCalo.size()+jptSpecific().elecsInVertexOutCalo.size();}
+    /// Add new set of subjets
+    void addSubjets(pat::JetPtrCollection const& pieces, std::string const& label = "");
 
-      // ---- JPT or PF Jet specific information ----
+    /// Check to see if the subjet collection exists
+    bool hasSubjets(std::string const& label) const {
+      return find(subjetLabels_.begin(), subjetLabels_.end(), label) != subjetLabels_.end();
+    }
 
-      /// muonMultiplicity
-      int muonMultiplicity() const;
-      /// chargedMultiplicity
-      int chargedMultiplicity() const;
-      /// chargedEmEnergy
-      float chargedEmEnergy()  const;
-      /// neutralEmEnergy
-      float neutralEmEnergy()  const;
-      /// chargedHadronEnergy
-      float chargedHadronEnergy() const;
-      /// neutralHadronEnergy
-      float neutralHadronEnergy() const;
+    /// Number of subjet collections
+    unsigned int nSubjetCollections() const { return subjetCollections_.size(); }
 
-      /// chargedHadronEnergyFraction (relative to uncorrected jet energy)
-      float chargedHadronEnergyFraction() const {return chargedHadronEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
-      /// neutralHadronEnergyFraction (relative to uncorrected jet energy)
-      float neutralHadronEnergyFraction() const {return neutralHadronEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
-      /// chargedEmEnergyFraction (relative to uncorrected jet energy)
-      float chargedEmEnergyFraction()     const {return chargedEmEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
-      /// neutralEmEnergyFraction (relative to uncorrected jet energy)
-      float neutralEmEnergyFraction()     const {return neutralEmEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
+    /// Subjet collection names
+    std::vector<std::string> const& subjetCollectionNames() const { return subjetLabels_; }
 
-      // ---- PF Jet specific information ----
-      /// photonEnergy
-      float photonEnergy () const {return pfSpecific().mPhotonEnergy;}
-      /// photonEnergyFraction (relative to corrected jet energy)
-      float photonEnergyFraction () const {return photonEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
-      /// electronEnergy
-      float electronEnergy () const {return pfSpecific().mElectronEnergy;}
-      /// electronEnergyFraction (relative to corrected jet energy)
-      float electronEnergyFraction () const {return electronEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
-      /// muonEnergy
-      float muonEnergy () const {return pfSpecific().mMuonEnergy;}
-      /// muonEnergyFraction (relative to corrected jet energy)
-      float muonEnergyFraction () const {return muonEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
-      /// HFHadronEnergy
-      float HFHadronEnergy () const {return pfSpecific().mHFHadronEnergy;}
-      /// HFHadronEnergyFraction (relative to corrected jet energy)
-      float HFHadronEnergyFraction () const {return HFHadronEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
-      /// HFEMEnergy
-      float HFEMEnergy () const {return pfSpecific().mHFEMEnergy;}
-      /// HFEMEnergyFraction (relative to corrected jet energy)
-      float HFEMEnergyFraction () const {return HFEMEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
+    /// Access to mass of subjets
+    double groomedMass(unsigned int index = 0) const {
+      auto const& sub = subjets(index);
+      return nSubjetCollections() > index && !sub.empty()
+                 ? std::accumulate(
+                       sub.begin(),
+                       sub.end(),
+                       reco::Candidate::LorentzVector(),
+                       [](reco::Candidate::LorentzVector const& a, reco::CandidatePtr const& b) { return a + b->p4(); })
+                       .mass()
+                 : -1.0;
+    }
+    double groomedMass(std::string const& label) const {
+      auto const& sub = subjets(label);
+      return hasSubjets(label) && !sub.empty()
+                 ? std::accumulate(
+                       sub.begin(),
+                       sub.end(),
+                       reco::Candidate::LorentzVector(),
+                       [](reco::Candidate::LorentzVector const& a, reco::CandidatePtr const& b) { return a + b->p4(); })
+                       .mass()
+                 : -1.0;
+    }
 
-      /// chargedHadronMultiplicity
-      int chargedHadronMultiplicity () const {return pfSpecific().mChargedHadronMultiplicity;}
-      /// neutralHadronMultiplicity
-      int neutralHadronMultiplicity () const {return pfSpecific().mNeutralHadronMultiplicity;}
-      /// photonMultiplicity
-      int photonMultiplicity () const {return pfSpecific().mPhotonMultiplicity;}
-      /// electronMultiplicity
-      int electronMultiplicity () const {return pfSpecific().mElectronMultiplicity;}
+  protected:
+    // ---- for content embedding ----
 
-      /// HFHadronMultiplicity
-      int HFHadronMultiplicity () const {return pfSpecific().mHFHadronMultiplicity;}
-      /// HFEMMultiplicity
-      int HFEMMultiplicity () const {return pfSpecific().mHFEMMultiplicity;}
+    bool embeddedCaloTowers_;
+    edm::AtomicPtrCache<std::vector<CaloTowerPtr> > caloTowersTemp_;  // to simplify user interface
+    CaloTowerCollection caloTowers_;                                  // Compatibility embedding
+    CaloTowerFwdPtrVector caloTowersFwdPtr_;                          // Refactorized content embedding
 
-      /// chargedMuEnergy
-      float chargedMuEnergy () const {return pfSpecific().mChargedMuEnergy;}
-      /// chargedMuEnergyFraction
-      float chargedMuEnergyFraction () const {return chargedMuEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
+    bool embeddedPFCandidates_;
+    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > pfCandidatesTemp_;  // to simplify user interface
+    reco::PFCandidateCollection pfCandidates_;                                  // Compatibility embedding
+    reco::PFCandidateFwdPtrVector pfCandidatesFwdPtr_;                          // Refactorized content embedding
 
-      /// neutralMultiplicity
-      int neutralMultiplicity () const {return pfSpecific().mNeutralMultiplicity;}
+    // ---- Jet Substructure ----
+    std::vector<pat::JetPtrCollection> subjetCollections_;
+    std::vector<std::string> subjetLabels_;
+    edm::AtomicPtrCache<std::vector<reco::CandidatePtr> > daughtersTemp_;
 
-      /// hoEnergy
-      float hoEnergy () const {return pfSpecific().mHOEnergy;}
-      /// hoEnergyFraction (relative to corrected jet energy)
-      float hoEnergyFraction () const {return hoEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
-      /// convert generic constituent to specific type
+    // ---- MC info ----
 
-      //  static CaloTowerPtr caloTower (const reco::Candidate* fConstituent);
-      /// get specific constituent of the CaloJet.
-      /// if the caloTowers were embedded, this reference is transient only and must not be persisted
-      reco::PFCandidatePtr getPFConstituent (unsigned fIndex) const;
-      /// get the constituents of the CaloJet.
-      /// If the caloTowers were embedded, these reference are transient only and must not be persisted
-      std::vector<reco::PFCandidatePtr> const & getPFConstituents () const;
+    std::vector<reco::GenJet> genJet_;
+    reco::GenJetRefVector genJetRef_;
+    edm::FwdRef<reco::GenJetCollection> genJetFwdRef_;
+    reco::JetFlavourInfo jetFlavourInfo_;
 
-      /// get a pointer to a Candididate constituent of the jet
-      ///    If using refactorized PAT, return that. (constituents size > 0)
-      ///    Else check the old version of PAT (embedded constituents size > 0)
-      ///    Else return the reco Jet number of constituents
-      const reco::Candidate * daughter(size_t i) const override;
+    // ---- energy scale correction factors ----
 
-      reco::CandidatePtr daughterPtr( size_t i ) const override;
-      const reco::CompositePtrCandidate::daughters & daughterPtrVector() const override;
+    // energy scale correction factors; the string carries a potential label if
+    // more then one set of correction factors is embedded. The label corresponds
+    // to the label of the jetCorrFactors module that has been embedded.
+    std::vector<pat::JetCorrFactors> jec_;
+    // currently applied set of jet energy correction factors (i.e. the index in
+    // jetEnergyCorrections_)
+    unsigned int currentJECSet_;
+    // currently applied jet energy correction level
+    unsigned int currentJECLevel_;
+    // currently applied jet energy correction flavor (can be NONE, GLUON, UDS,
+    // CHARM or BOTTOM)
+    JetCorrFactors::Flavor currentJECFlavor_;
 
-      using reco::LeafCandidate::daughter; // avoid hiding the base implementation
+    // ---- b-tag related members ----
 
-      /// Return number of daughters:
-      ///    If using refactorized PAT, return that. (constituents size > 0)
-      ///    Else check the old version of PAT (embedded constituents size > 0)
-      ///    Else return the reco Jet number of constituents
-      size_t numberOfDaughters() const override;
+    std::vector<std::pair<std::string, float> > pairDiscriVector_;
+    std::vector<std::string> tagInfoLabels_;
+    edm::OwnVector<reco::BaseTagInfo> tagInfos_;  // Compatibility embedding
+    TagInfoFwdPtrCollection tagInfosFwdPtr_;      // Refactorized embedding
 
-      /// clear daughter references
-      void clearDaughters() override {
-        PATObject<reco::Jet>::clearDaughters();
-        daughtersTemp_.reset(); // need to reset daughtersTemp_ as well
-      }
+    // ---- track related members ----
 
-      /// accessing Jet ID information
-      reco::JetID const & jetID () const { return jetID_;}
+    float jetCharge_;
+    reco::TrackRefVector associatedTracks_;
 
+    // ---- specific members ----
 
-      /// Access to bare FwdPtr collections
-      CaloTowerFwdPtrVector               const & caloTowersFwdPtr()   const { return caloTowersFwdPtr_;}
-      reco::PFCandidateFwdPtrVector       const & pfCandidatesFwdPtr() const { return pfCandidatesFwdPtr_; }
-      edm::FwdRef<reco::GenJetCollection> const & genJetFwdRef()       const { return genJetFwdRef_; }
-      TagInfoFwdPtrCollection             const & tagInfosFwdPtr()     const { return tagInfosFwdPtr_; }
+    std::vector<CaloSpecific> specificCalo_;
+    std::vector<JPTSpecific> specificJPT_;
+    std::vector<PFSpecific> specificPF_;
 
-      /// Update bare FwdPtr and FwdRef "forward" pointers while keeping the
-      /// "back" pointers the same (i.e. the ref "forwarding")
-      void updateFwdCaloTowerFwdPtr( unsigned int index, const edm::Ptr<CaloTower>& updateFwd ) {
-	if ( index < caloTowersFwdPtr_.size() ) {
-	  caloTowersFwdPtr_[index] = CaloTowerFwdPtrVector::value_type( updateFwd, caloTowersFwdPtr_[index].backPtr() );
-	} else {
-	  throw cms::Exception("OutOfRange") << "Index " << index << " is out of range" << std::endl;
-	}
-      }
+    // ---- id functions ----
+    reco::JetID jetID_;
 
-      void updateFwdPFCandidateFwdPtr( unsigned int index, const edm::Ptr<reco::PFCandidate>& updateFwd ) {
-	if ( index < pfCandidatesFwdPtr_.size() ) {
-	  pfCandidatesFwdPtr_[index] = reco::PFCandidateFwdPtrVector::value_type( updateFwd, pfCandidatesFwdPtr_[index].backPtr() );
-	} else {
-	  throw cms::Exception("OutOfRange") << "Index " << index << " is out of range" << std::endl;
-	}
-      }
+  private:
+    // ---- helper functions ----
 
+    void tryImportSpecific(const reco::Jet& source);
 
-      void updateFwdTagInfoFwdPtr( unsigned int index, const edm::Ptr<reco::BaseTagInfo>& updateFwd ) {
-	if ( index < tagInfosFwdPtr_.size() ) {
-	  tagInfosFwdPtr_[index] = TagInfoFwdPtrCollection::value_type( updateFwd, tagInfosFwdPtr_[index].backPtr() );
-	} else {
-	  throw cms::Exception("OutOfRange") << "Index " << index << " is out of range" << std::endl;
-	}
-      }
-
-      void updateFwdGenJetFwdRef( edm::Ref<reco::GenJetCollection> updateRef ) {
-	genJetFwdRef_ = edm::FwdRef<reco::GenJetCollection>( updateRef, genJetFwdRef_.backRef() );
-      }
-
-      /// pipe operator (introduced to use pat::Jet with PFTopProjectors)
-      friend std::ostream& reco::operator<<(std::ostream& out, const pat::Jet& obj);
-
-
-
-      /// Access to subjet list
-      pat::JetPtrCollection const & subjets( unsigned int index = 0 ) const;
-
-
-      /// String access to subjet list
-      pat::JetPtrCollection const & subjets( std::string const & label ) const ;
-
-      /// Add new set of subjets
-      void addSubjets( pat::JetPtrCollection const & pieces, std::string const & label = ""  );
-
-      /// Check to see if the subjet collection exists
-      bool hasSubjets( std::string const & label ) const { return find( subjetLabels_.begin(), subjetLabels_.end(), label) != subjetLabels_.end(); }
-
-      /// Number of subjet collections
-      unsigned int nSubjetCollections(  ) const { return  subjetCollections_.size(); }
-
-      /// Subjet collection names
-      std::vector<std::string> const & subjetCollectionNames() const { return subjetLabels_; }
-
-      /// Access to mass of subjets
-      double groomedMass(unsigned int index = 0) const{
-	auto const& sub = subjets(index);
-	return nSubjetCollections() > index && !sub.empty() ?
-	  std::accumulate( sub.begin(), sub.end(),
-			   reco::Candidate::LorentzVector(),
-			   [] (reco::Candidate::LorentzVector const & a, reco::CandidatePtr const & b){return a + b->p4();}).mass() :
-	  -1.0;
-      }
-      double groomedMass(std::string const & label) const{
-	auto const& sub = subjets(label);
-	return hasSubjets(label) && !sub.empty() ?
-	  std::accumulate( sub.begin(), sub.end(),
-			   reco::Candidate::LorentzVector(),
-			   [] (reco::Candidate::LorentzVector const & a, reco::CandidatePtr const & b){return a + b->p4();}).mass() :
-	  -1.0;
-      }
-
-    protected:
-
-      // ---- for content embedding ----
-
-      bool embeddedCaloTowers_;
-      edm::AtomicPtrCache<std::vector<CaloTowerPtr> > caloTowersTemp_; // to simplify user interface
-      CaloTowerCollection caloTowers_; // Compatibility embedding
-      CaloTowerFwdPtrVector caloTowersFwdPtr_; // Refactorized content embedding
-
-
-      bool embeddedPFCandidates_;
-      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > pfCandidatesTemp_; // to simplify user interface
-      reco::PFCandidateCollection pfCandidates_; // Compatibility embedding
-      reco::PFCandidateFwdPtrVector pfCandidatesFwdPtr_; // Refactorized content embedding
-
-
-      // ---- Jet Substructure ----
-      std::vector< pat::JetPtrCollection> subjetCollections_;
-      std::vector< std::string>          subjetLabels_;
-      edm::AtomicPtrCache<std::vector< reco::CandidatePtr > > daughtersTemp_;
-
-      // ---- MC info ----
-
-      std::vector<reco::GenJet> genJet_;
-      reco::GenJetRefVector genJetRef_;
-      edm::FwdRef<reco::GenJetCollection>  genJetFwdRef_;
-      reco::JetFlavourInfo jetFlavourInfo_;
-
-      // ---- energy scale correction factors ----
-
-      // energy scale correction factors; the string carries a potential label if
-      // more then one set of correction factors is embedded. The label corresponds
-      // to the label of the jetCorrFactors module that has been embedded.
-      std::vector<pat::JetCorrFactors> jec_;
-      // currently applied set of jet energy correction factors (i.e. the index in
-      // jetEnergyCorrections_)
-      unsigned int currentJECSet_;
-      // currently applied jet energy correction level
-      unsigned int currentJECLevel_;
-      // currently applied jet energy correction flavor (can be NONE, GLUON, UDS,
-      // CHARM or BOTTOM)
-      JetCorrFactors::Flavor currentJECFlavor_;
-
-      // ---- b-tag related members ----
-
-      std::vector<std::pair<std::string, float> >           pairDiscriVector_;
-      std::vector<std::string>          tagInfoLabels_;
-      edm::OwnVector<reco::BaseTagInfo> tagInfos_; // Compatibility embedding
-      TagInfoFwdPtrCollection  tagInfosFwdPtr_; // Refactorized embedding
-
-
-      // ---- track related members ----
-
-      float jetCharge_;
-      reco::TrackRefVector associatedTracks_;
-
-      // ---- specific members ----
-
-      std::vector<CaloSpecific> specificCalo_;
-      std::vector<JPTSpecific>  specificJPT_;
-      std::vector<PFSpecific>   specificPF_;
-
-      // ---- id functions ----
-      reco::JetID    jetID_;
-
-
-    private:
-
-      // ---- helper functions ----
-
-      void tryImportSpecific(const reco::Jet &source);
-
-      template<typename T> const T * tagInfoByType() const
-      {
-        // First check the factorized PAT version
-        for (size_t i = 0, n = tagInfosFwdPtr_.size(); i < n; ++i) {
-          TagInfoFwdPtrCollection::value_type const & val = tagInfosFwdPtr_[i];
-          reco::BaseTagInfo const * baseTagInfo = val.get();
-          if ( typeid(*baseTagInfo) == typeid(T) ) {
-            return static_cast<const T *>( baseTagInfo );
-          }
+    template <typename T>
+    const T* tagInfoByType() const {
+      // First check the factorized PAT version
+      for (size_t i = 0, n = tagInfosFwdPtr_.size(); i < n; ++i) {
+        TagInfoFwdPtrCollection::value_type const& val = tagInfosFwdPtr_[i];
+        reco::BaseTagInfo const* baseTagInfo = val.get();
+        if (typeid(*baseTagInfo) == typeid(T)) {
+          return static_cast<const T*>(baseTagInfo);
         }
-        // Then check compatibility version
-        for (size_t i = 0, n = tagInfos_.size(); i < n; ++i) {
-          edm::OwnVector<reco::BaseTagInfo>::value_type const & val = tagInfos_[i];
-          reco::BaseTagInfo const * baseTagInfo = &val;
-          if ( typeid(*baseTagInfo) == typeid(T) ) {
-            return static_cast<const T *>( baseTagInfo );
-          }
+      }
+      // Then check compatibility version
+      for (size_t i = 0, n = tagInfos_.size(); i < n; ++i) {
+        edm::OwnVector<reco::BaseTagInfo>::value_type const& val = tagInfos_[i];
+        reco::BaseTagInfo const* baseTagInfo = &val;
+        if (typeid(*baseTagInfo) == typeid(T)) {
+          return static_cast<const T*>(baseTagInfo);
         }
-        return nullptr;
       }
+      return nullptr;
+    }
 
-      template<typename T> const T * tagInfoByTypeOrLabel(const std::string &label="") const
-      {
-        return ( label.empty() ? tagInfoByType<T>() : dynamic_cast<const T *>(tagInfo(label)) );
-      }
+    template <typename T>
+    const T* tagInfoByTypeOrLabel(const std::string& label = "") const {
+      return (label.empty() ? tagInfoByType<T>() : dynamic_cast<const T*>(tagInfo(label)));
+    }
 
-      /// return the jet correction factors of a different set, for systematic studies
-      const JetCorrFactors * corrFactors_(const std::string& set) const ;
-      /// return the correction factor for this jet. Throws if they're not available.
-      const JetCorrFactors * corrFactors_() const;
+    /// return the jet correction factors of a different set, for systematic studies
+    const JetCorrFactors* corrFactors_(const std::string& set) const;
+    /// return the correction factor for this jet. Throws if they're not available.
+    const JetCorrFactors* corrFactors_() const;
 
-      /// cache calo towers
-      void cacheCaloTowers() const;
-      void cachePFCandidates() const;
-      void cacheDaughters() const;
-
+    /// cache calo towers
+    void cacheCaloTowers() const;
+    void cachePFCandidates() const;
+    void cacheDaughters() const;
   };
+}  // namespace pat
+
+inline float pat::Jet::chargedHadronEnergy() const {
+  if (isPFJet()) {
+    return pfSpecific().mChargedHadronEnergy;
+  } else if (isJPTJet()) {
+    return jptSpecific().mChargedHadronEnergy;
+  } else {
+    throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
+  }
 }
 
-inline float pat::Jet::chargedHadronEnergy() const
-{
-  if(isPFJet()){ return pfSpecific().mChargedHadronEnergy; }
-  else if( isJPTJet() ){ return jptSpecific().mChargedHadronEnergy; }
-  else{ throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n"; }
+inline float pat::Jet::neutralHadronEnergy() const {
+  if (isPFJet()) {
+    return pfSpecific().mNeutralHadronEnergy;
+  } else if (isJPTJet()) {
+    return jptSpecific().mNeutralHadronEnergy;
+  } else {
+    throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
+  }
 }
 
-inline float pat::Jet::neutralHadronEnergy() const
-{
-  if(isPFJet()){ return pfSpecific().mNeutralHadronEnergy; }
-  else if( isJPTJet() ){ return jptSpecific().mNeutralHadronEnergy; }
-  else{ throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n"; }
+inline float pat::Jet::chargedEmEnergy() const {
+  if (isPFJet()) {
+    return pfSpecific().mChargedEmEnergy;
+  } else if (isJPTJet()) {
+    return jptSpecific().mChargedEmEnergy;
+  } else {
+    throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
+  }
 }
 
-inline float pat::Jet::chargedEmEnergy() const
-{
-  if(isPFJet()){ return pfSpecific().mChargedEmEnergy; }
-  else if( isJPTJet() ){ return jptSpecific().mChargedEmEnergy;}
-  else{ throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n"; }
+inline float pat::Jet::neutralEmEnergy() const {
+  if (isPFJet()) {
+    return pfSpecific().mNeutralEmEnergy;
+  } else if (isJPTJet()) {
+    return jptSpecific().mNeutralEmEnergy;
+  } else {
+    throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
+  }
 }
 
-inline float pat::Jet::neutralEmEnergy() const
-{
-  if(isPFJet()){ return pfSpecific().mNeutralEmEnergy; }
-  else if( isJPTJet() ){ return jptSpecific().mNeutralEmEnergy;}
-  else{ throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n"; }
+inline int pat::Jet::muonMultiplicity() const {
+  if (isPFJet()) {
+    return pfSpecific().mMuonMultiplicity;
+  } else if (isJPTJet()) {
+    return jptSpecific().muonsInVertexInCalo.size() + jptSpecific().muonsInVertexOutCalo.size();
+  } else {
+    throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
+  }
 }
 
-inline int pat::Jet::muonMultiplicity() const
-{
-  if(isPFJet()){ return pfSpecific().mMuonMultiplicity; }
-  else if( isJPTJet() ){ return jptSpecific().muonsInVertexInCalo.size()+jptSpecific().muonsInVertexOutCalo.size();}
-  else{ throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n"; }
-}
-
-inline int pat::Jet::chargedMultiplicity() const
-{
-  if(isPFJet()){ return pfSpecific().mChargedMultiplicity; }
-  else if( isJPTJet() ){ return jptSpecific().muonsInVertexInCalo.size()+jptSpecific().muonsInVertexOutCalo.size()+
-                                jptSpecific().pionsInVertexInCalo.size()+jptSpecific().pionsInVertexOutCalo.size()+
-                                jptSpecific().elecsInVertexInCalo.size()+jptSpecific().elecsInVertexOutCalo.size();}
-  else{ throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n"; }
+inline int pat::Jet::chargedMultiplicity() const {
+  if (isPFJet()) {
+    return pfSpecific().mChargedMultiplicity;
+  } else if (isJPTJet()) {
+    return jptSpecific().muonsInVertexInCalo.size() + jptSpecific().muonsInVertexOutCalo.size() +
+           jptSpecific().pionsInVertexInCalo.size() + jptSpecific().pionsInVertexOutCalo.size() +
+           jptSpecific().elecsInVertexInCalo.size() + jptSpecific().elecsInVertexOutCalo.size();
+  } else {
+    throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
+  }
 }
 
 #endif

--- a/DataFormats/PatCandidates/interface/JetCorrFactors.h
+++ b/DataFormats/PatCandidates/interface/JetCorrFactors.h
@@ -35,12 +35,11 @@
 namespace pat {
 
   class JetCorrFactors {
-
   public:
     // jet energy correction factor. For flavor independent jet energy corrections the
     // std::vector<float> holds just a single entry. From the first flavor dependent entry
-    // in the chain on it holds five floats corresponding to the flavors: none, gluon, uds, 
-    // charm, bottom; in this case the entry for none will be set to -1; the std::string 
+    // in the chain on it holds five floats corresponding to the flavors: none, gluon, uds,
+    // charm, bottom; in this case the entry for none will be set to -1; the std::string
     // indicates the correction level according to jetMET definitions.
     typedef std::pair<std::string, std::vector<float> > CorrectionFactor;
     // order of flavor dependent CorrectionFactors
@@ -50,11 +49,11 @@ namespace pat {
 
   public:
     // default Constructor
-    JetCorrFactors() {};
+    JetCorrFactors(){};
     // constructor by value
     JetCorrFactors(const std::string& label, const std::vector<CorrectionFactor>& jec);
 
-    // instance label of the jet energy corrections set 
+    // instance label of the jet energy corrections set
     std::string jecSet() const { return label_; }
     // correction level from unsigned int
     std::string jecLevel(const unsigned int& level) const { return jec_.at(level).first; };
@@ -66,15 +65,19 @@ namespace pat {
     Flavor jecFlavor(std::string flavor) const;
 
     // correction factor up to a given level and flavor (per default the flavor is NONE)
-    float correction(unsigned int level, Flavor flavor=NONE) const;
+    float correction(unsigned int level, Flavor flavor = NONE) const;
     // a list of the labels of all correction levels according to jetMET definitions, separated by '\n'
     std::string correctionLabelString() const;
     // a vector of the labels of all correction levels according to jetMET definitions
     std::vector<std::string> correctionLabels() const;
     // label of a specific correction factor according to jetMET definitions; for overflow a string ERROR is returned
-    std::string correctionLabel(unsigned int level) const { return (level<jec_.size() ? jec_.at(level).first : std::string("ERROR")); };
+    std::string correctionLabel(unsigned int level) const {
+      return (level < jec_.size() ? jec_.at(level).first : std::string("ERROR"));
+    };
     // check whether CorrectionFactor is flavor independent or not
-    bool flavorDependent(unsigned int level) const { return (level<jec_.size() ? jec_.at(level).second.size()==MAX_FLAVORS : false); };
+    bool flavorDependent(unsigned int level) const {
+      return (level < jec_.size() ? jec_.at(level).second.size() == MAX_FLAVORS : false);
+    };
     // number of available correction factors
     unsigned int numberOfCorrectionLevels() const { return jec_.size(); };
     // print function for debugging
@@ -82,24 +85,24 @@ namespace pat {
 
   private:
     // check consistency of input vector
-    bool flavorDependent(const CorrectionFactor& jec) const { return (jec.second.size()==MAX_FLAVORS); }
+    bool flavorDependent(const CorrectionFactor& jec) const { return (jec.second.size() == MAX_FLAVORS); }
     // check consistency of input vector
-    bool flavorIndependent(const CorrectionFactor& jec) const { return (jec.second.size()==1); }
+    bool flavorIndependent(const CorrectionFactor& jec) const { return (jec.second.size() == 1); }
     // check consistency of input vector
-    bool isValid(const CorrectionFactor& jec) const { return (flavorDependent(jec) || flavorIndependent(jec)); }    
-    
+    bool isValid(const CorrectionFactor& jec) const { return (flavorDependent(jec) || flavorIndependent(jec)); }
+
   private:
     // instance label of jet energy correction factors
     std::string label_;
-    // vector of CorrectionFactors. NOTE: the correction factors are expected to appear 
-    // nested; they may appear in arbitary number and order according to the configuration 
-    // of the jetCorrFactors module. CorrectionFactors appear in two versions: as a single 
-    // float (for flavor independent corrections) or as a std::vector of four floats (for 
-    // flavor dependent corrections). Due to the nested structure of the CorrectionFactors 
-    // from the first flavor dependent CorrectionFactor in the chain on each correction is 
-    // flavor dependent. 
+    // vector of CorrectionFactors. NOTE: the correction factors are expected to appear
+    // nested; they may appear in arbitary number and order according to the configuration
+    // of the jetCorrFactors module. CorrectionFactors appear in two versions: as a single
+    // float (for flavor independent corrections) or as a std::vector of four floats (for
+    // flavor dependent corrections). Due to the nested structure of the CorrectionFactors
+    // from the first flavor dependent CorrectionFactor in the chain on each correction is
+    // flavor dependent.
     std::vector<CorrectionFactor> jec_;
   };
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/Lepton.h
+++ b/DataFormats/PatCandidates/interface/Lepton.h
@@ -23,193 +23,211 @@
 #include "DataFormats/PatCandidates/interface/Isolation.h"
 #include "DataFormats/PatCandidates/interface/PFIsolation.h"
 
-
 namespace pat {
-
 
   template <class LeptonType>
   class Lepton : public PATObject<LeptonType> {
+  public:
+    Lepton();
+    Lepton(const LeptonType &aLepton);
+    Lepton(const edm::RefToBase<LeptonType> &aLeptonRef);
+    Lepton(const edm::Ptr<LeptonType> &aLeptonRef);
+    ~Lepton() override;
 
-    public:
+    Lepton<LeptonType> *clone() const override { return new Lepton<LeptonType>(*this); }
 
-      Lepton();
-      Lepton(const LeptonType & aLepton);
-      Lepton(const edm::RefToBase<LeptonType> & aLeptonRef);
-      Lepton(const edm::Ptr<LeptonType> & aLeptonRef);
-      ~Lepton() override;
+    const reco::GenParticle *genLepton() const { return PATObject<LeptonType>::genParticle(); }
 
-      Lepton<LeptonType> * clone() const override { return new Lepton<LeptonType>(*this); }
+    void setGenLepton(const reco::GenParticleRef &gl, bool embed = false) {
+      PATObject<LeptonType>::setGenParticleRef(gl, embed);
+    }
 
-      const reco::GenParticle * genLepton() const { return PATObject<LeptonType>::genParticle(); }
-
-      void setGenLepton(const reco::GenParticleRef & gl, bool embed=false) { PATObject<LeptonType>::setGenParticleRef(gl, embed); }
-
-      //============ BEGIN ISOLATION BLOCK =====      
-      /// Returns the isolation variable for a specific key (or 
-      /// pseudo-key like CaloIso), or -1.0 if not available
-      float userIsolation(IsolationKeys key) const { 
-          if (key >= 0) {
-	    //if (key >= isolations_.size()) throw cms::Excepton("Missing Data") 
-	    //<< "Isolation corresponding to key " 
-	    //<< key << " was not stored for this particle.";
-              if (size_t(key) >= isolations_.size()) return -1.0;
-              return isolations_[key];
-          } else switch (key) {
-	  case pat::CaloIso:  
-	    //if (isolations_.size() <= pat::HcalIso) throw cms::Excepton("Missing Data") 
-	    //<< "CaloIso Isolation was not stored for this particle.";
-	    if (isolations_.size() <= pat::HcalIso) return -1.0; 
-	    return isolations_[pat::EcalIso] + isolations_[pat::HcalIso];
-	  default:
-	    return -1.0;
-	    //throw cms::Excepton("Missing Data") << "Isolation corresponding to key " 
-	    //<< key << " was not stored for this particle.";
-          }
+    //============ BEGIN ISOLATION BLOCK =====
+    /// Returns the isolation variable for a specific key (or
+    /// pseudo-key like CaloIso), or -1.0 if not available
+    float userIsolation(IsolationKeys key) const {
+      if (key >= 0) {
+        //if (key >= isolations_.size()) throw cms::Excepton("Missing Data")
+        //<< "Isolation corresponding to key "
+        //<< key << " was not stored for this particle.";
+        if (size_t(key) >= isolations_.size())
+          return -1.0;
+        return isolations_[key];
+      } else
+        switch (key) {
+          case pat::CaloIso:
+            //if (isolations_.size() <= pat::HcalIso) throw cms::Excepton("Missing Data")
+            //<< "CaloIso Isolation was not stored for this particle.";
+            if (isolations_.size() <= pat::HcalIso)
+              return -1.0;
+            return isolations_[pat::EcalIso] + isolations_[pat::HcalIso];
+          default:
+            return -1.0;
+            //throw cms::Excepton("Missing Data") << "Isolation corresponding to key "
+            //<< key << " was not stored for this particle.";
+        }
+    }
+    /// Returns the isolation variable for string type function arguments
+    /// (to be used with the cut-string parser);
+    /// the possible values of the strings are the enums defined in
+    /// DataFormats/PatCandidates/interface/Isolation.h
+    float userIsolation(const std::string &key) const {
+      // remove leading namespace specifier
+      std::string prunedKey = (key.find("pat::") == 0) ? std::string(key, 5) : key;
+      if (prunedKey == "TrackIso")
+        return userIsolation(pat::TrackIso);
+      if (prunedKey == "EcalIso")
+        return userIsolation(pat::EcalIso);
+      if (prunedKey == "HcalIso")
+        return userIsolation(pat::HcalIso);
+      if (prunedKey == "PfAllParticleIso")
+        return userIsolation(pat::PfAllParticleIso);
+      if (prunedKey == "PfChargedHadronIso")
+        return userIsolation(pat::PfChargedHadronIso);
+      if (prunedKey == "PfNeutralHadronIso")
+        return userIsolation(pat::PfNeutralHadronIso);
+      if (prunedKey == "PfGammaIso")
+        return userIsolation(pat::PfGammaIso);
+      if (prunedKey == "User1Iso")
+        return userIsolation(pat::User1Iso);
+      if (prunedKey == "User2Iso")
+        return userIsolation(pat::User2Iso);
+      if (prunedKey == "User3Iso")
+        return userIsolation(pat::User3Iso);
+      if (prunedKey == "User4Iso")
+        return userIsolation(pat::User4Iso);
+      if (prunedKey == "User5Iso")
+        return userIsolation(pat::User5Iso);
+      if (prunedKey == "UserBaseIso")
+        return userIsolation(pat::UserBaseIso);
+      if (prunedKey == "CaloIso")
+        return userIsolation(pat::CaloIso);
+      if (prunedKey == "PfPUChargedHadronIso")
+        return userIsolation(pat::PfPUChargedHadronIso);
+      //throw cms::Excepton("Missing Data")
+      //<< "Isolation corresponding to key "
+      //<< key << " was not stored for this particle.";
+      return -1.0;
+    }
+    /// Sets the userIsolation variable for a specific key.
+    /// Note that you can't set isolation for a pseudo-key
+    /// like CaloIso
+    void setIsolation(IsolationKeys key, float value) {
+      if (key >= 0) {
+        if (size_t(key) >= isolations_.size())
+          isolations_.resize(key + 1, -1.0);
+        isolations_[key] = value;
+      } else {
+        throw cms::Exception("Illegal Argument")
+            << "The key for which you're setting isolation does not correspond "
+            << "to an individual isolation but to the sum of more independent isolations "
+            << "(e.g. Calo = Ecal + Hcal), so you can't SET the value, just GET it.\n"
+            << "Please set up each component independly.\n";
       }
-      /// Returns the isolation variable for string type function arguments
-      /// (to be used with the cut-string parser);
-      /// the possible values of the strings are the enums defined in
-      /// DataFormats/PatCandidates/interface/Isolation.h
-      float userIsolation(const std::string& key) const {
-	// remove leading namespace specifier
-	std::string prunedKey = ( key.find("pat::") == 0 ) ? std::string(key, 5) : key;
-	if ( prunedKey == "TrackIso" ) return userIsolation(pat::TrackIso);
-	if ( prunedKey == "EcalIso" ) return userIsolation(pat::EcalIso);
-	if ( prunedKey == "HcalIso" ) return userIsolation(pat::HcalIso);
-	if ( prunedKey == "PfAllParticleIso" ) return userIsolation(pat::PfAllParticleIso);
-	if ( prunedKey == "PfChargedHadronIso" ) return userIsolation(pat::PfChargedHadronIso);
-	if ( prunedKey == "PfNeutralHadronIso" ) return userIsolation(pat::PfNeutralHadronIso);
-	if ( prunedKey == "PfGammaIso" ) return userIsolation(pat::PfGammaIso);
-	if ( prunedKey == "User1Iso" ) return userIsolation(pat::User1Iso);
-	if ( prunedKey == "User2Iso" ) return userIsolation(pat::User2Iso);
-	if ( prunedKey == "User3Iso" ) return userIsolation(pat::User3Iso);
-	if ( prunedKey == "User4Iso" ) return userIsolation(pat::User4Iso);
-	if ( prunedKey == "User5Iso" ) return userIsolation(pat::User5Iso);
-	if ( prunedKey == "UserBaseIso" ) return userIsolation(pat::UserBaseIso);
-	if ( prunedKey == "CaloIso" ) return userIsolation(pat::CaloIso);
-	if ( prunedKey == "PfPUChargedHadronIso" ) return userIsolation(pat::PfPUChargedHadronIso);
-	//throw cms::Excepton("Missing Data")
-	//<< "Isolation corresponding to key " 
-	//<< key << " was not stored for this particle.";
-	return -1.0;
+    }
+
+    // ---- specific getters ----
+    /// Returns the tracker isolation variable that was stored in this
+    /// object when produced, or -1.0 if there is none (overloaded if
+    /// specific isolation functions are available from the derived
+    /// objects)
+    float trackIso() const { return userIsolation(pat::TrackIso); }
+    /// Returns the sum of ecal and hcal isolation variable that were
+    /// stored in this object when produced, or -1.0 if at least one
+    /// is missing (overloaded if specific isolation functions are
+    /// available from the derived objects)
+    float caloIso() const { return userIsolation(pat::CaloIso); }
+    /// Returns the ecal isolation variable that was stored in this
+    /// object when produced, or -1.0 if there is none (overloaded
+    /// if specific isolation functions are available from the
+    /// derived objects)
+    float ecalIso() const { return userIsolation(pat::EcalIso); }
+    /// Returns the hcal isolation variable that was stored in this
+    /// object when produced, or -1.0 if there is none (overloaded
+    /// if specific isolation functions are available from the
+    /// derived objects)
+    float hcalIso() const { return userIsolation(pat::HcalIso); }
+
+    /// PARTICLE FLOW ISOLATION
+    /// Returns the isolation calculated with all the PFCandidates
+    float particleIso() const { return userIsolation(pat::PfAllParticleIso); }
+    /// Returns the isolation calculated with only the charged hadron
+    /// PFCandidates
+    float chargedHadronIso() const { return userIsolation(pat::PfChargedHadronIso); }
+    /// Returns the isolation calculated with only the neutral hadron
+    /// PFCandidates
+    float neutralHadronIso() const { return userIsolation(pat::PfNeutralHadronIso); }
+    /// Returns the isolation calculated with only the gamma
+    /// PFCandidates
+    float photonIso() const { return userIsolation(pat::PfGammaIso); }
+    /// Returns the isolation calculated with only the pile-up charged hadron
+    /// PFCandidates
+    float puChargedHadronIso() const { return userIsolation(pat::PfPUChargedHadronIso); }
+    /// Returns the user defined isolation variable #index that was
+    /// stored in this object when produced, or -1.0 if there is none
+    float userIso(uint8_t index = 0) const { return userIsolation(IsolationKeys(UserBaseIso + index)); }
+
+    // ---- specific setters ----
+    /// Sets tracker isolation variable
+    void setTrackIso(float trackIso) { setIsolation(pat::TrackIso, trackIso); }
+    /// Sets ecal isolation variable
+    void setEcalIso(float caloIso) { setIsolation(pat::EcalIso, caloIso); }
+    /// Sets hcal isolation variable
+    void setHcalIso(float caloIso) { setIsolation(pat::HcalIso, caloIso); }
+    /// Sets user isolation variable #index
+    void setUserIso(float value, uint8_t index = 0) { setIsolation(IsolationKeys(UserBaseIso + index), value); }
+
+    //============ BEGIN ISODEPOSIT BLOCK =====
+    /// Returns the IsoDeposit associated with some key, or a null pointer if it is not available
+    const IsoDeposit *isoDeposit(IsolationKeys key) const {
+      for (IsoDepositPairs::const_iterator it = isoDeposits_.begin(), ed = isoDeposits_.end(); it != ed; ++it) {
+        if (it->first == key)
+          return &it->second;
       }
-      /// Sets the userIsolation variable for a specific key.
-      /// Note that you can't set isolation for a pseudo-key 
-      /// like CaloIso
-      void setIsolation(IsolationKeys key, float value) {
-          if (key >= 0) {
-              if (size_t(key) >= isolations_.size()) isolations_.resize(key+1, -1.0);
-              isolations_[key] = value;
-          } else {
-              throw cms::Exception("Illegal Argument") << 
-                  "The key for which you're setting isolation does not correspond " <<
-                  "to an individual isolation but to the sum of more independent isolations " <<
-                  "(e.g. Calo = Ecal + Hcal), so you can't SET the value, just GET it.\n" <<
-                  "Please set up each component independly.\n";
-          }
+      return nullptr;
+    }
+
+    /// Sets the IsoDeposit associated with some key; if it is already existent, it is overwritten.
+    void setIsoDeposit(IsolationKeys key, const IsoDeposit &dep) {
+      IsoDepositPairs::iterator it = isoDeposits_.begin(), ed = isoDeposits_.end();
+      for (; it != ed; ++it) {
+        if (it->first == key) {
+          it->second = dep;
+          return;
+        }
       }
+      isoDeposits_.push_back(std::make_pair(key, dep));
+    }
 
-      // ---- specific getters ----
-      /// Returns the tracker isolation variable that was stored in this 
-      /// object when produced, or -1.0 if there is none (overloaded if
-      /// specific isolation functions are available from the derived 
-      /// objects)
-      float trackIso() const { return userIsolation(pat::TrackIso); }
-      /// Returns the sum of ecal and hcal isolation variable that were 
-      /// stored in this object when produced, or -1.0 if at least one 
-      /// is missing (overloaded if specific isolation functions are 
-      /// available from the derived objects) 
-      float caloIso()  const { return userIsolation(pat::CaloIso); }
-      /// Returns the ecal isolation variable that was stored in this 
-      /// object when produced, or -1.0 if there is none (overloaded 
-      /// if specific isolation functions are available from the 
-      /// derived objects)
-      float ecalIso()  const { return userIsolation(pat::EcalIso); }
-      /// Returns the hcal isolation variable that was stored in this 
-      /// object when produced, or -1.0 if there is none (overloaded 
-      /// if specific isolation functions are available from the 
-      /// derived objects)
-      float hcalIso()  const { return userIsolation(pat::HcalIso); }
+    // ---- specific getters ----
+    const IsoDeposit *trackIsoDeposit() const { return isoDeposit(pat::TrackIso); }
+    const IsoDeposit *ecalIsoDeposit() const { return isoDeposit(pat::EcalIso); }
+    const IsoDeposit *hcalIsoDeposit() const { return isoDeposit(pat::HcalIso); }
+    const IsoDeposit *userIsoDeposit(uint8_t index = 0) const { return isoDeposit(IsolationKeys(UserBaseIso + index)); }
 
-      /// PARTICLE FLOW ISOLATION
-      /// Returns the isolation calculated with all the PFCandidates
-      float particleIso() const { return userIsolation(pat::PfAllParticleIso); }
-      /// Returns the isolation calculated with only the charged hadron 
-      /// PFCandidates
-      float chargedHadronIso() const { return userIsolation(pat::PfChargedHadronIso); }
-      /// Returns the isolation calculated with only the neutral hadron 
-      /// PFCandidates      
-      float neutralHadronIso() const { return userIsolation(pat::PfNeutralHadronIso); }	
-      /// Returns the isolation calculated with only the gamma 
-      /// PFCandidates  
-      float photonIso() const { return userIsolation(pat::PfGammaIso); }
-      /// Returns the isolation calculated with only the pile-up charged hadron 
-      /// PFCandidates
-      float puChargedHadronIso() const { return userIsolation(pat::PfPUChargedHadronIso); }	
-      /// Returns the user defined isolation variable #index that was 
-      /// stored in this object when produced, or -1.0 if there is none
-      float userIso(uint8_t index=0)  const { return userIsolation(IsolationKeys(UserBaseIso + index)); }
+    // ---- specific setters ----
+    void trackIsoDeposit(const IsoDeposit &dep) { setIsoDeposit(pat::TrackIso, dep); }
+    void ecalIsoDeposit(const IsoDeposit &dep) { setIsoDeposit(pat::EcalIso, dep); }
+    void hcalIsoDeposit(const IsoDeposit &dep) { setIsoDeposit(pat::HcalIso, dep); }
+    void userIsoDeposit(const IsoDeposit &dep, uint8_t index = 0) {
+      setIsoDeposit(IsolationKeys(UserBaseIso + index), dep);
+    }
 
-      // ---- specific setters ----
-      /// Sets tracker isolation variable
-      void setTrackIso(float trackIso) { setIsolation(pat::TrackIso, trackIso); }
-      /// Sets ecal isolation variable
-      void setEcalIso(float caloIso)   { setIsolation(pat::EcalIso, caloIso);  } 
-      /// Sets hcal isolation variable
-      void setHcalIso(float caloIso)   { setIsolation(pat::HcalIso, caloIso);  }
-      /// Sets user isolation variable #index
-      void setUserIso(float value, uint8_t index=0)  { setIsolation(IsolationKeys(UserBaseIso + index), value); }
+    const PFIsolation &miniPFIsolation() const { return miniPFIsolation_; }
+    void setMiniPFIsolation(PFIsolation const &iso) { miniPFIsolation_ = iso; }
 
+  protected:
+    // --- Isolation and IsoDeposit related datamebers ---
+    typedef std::vector<std::pair<IsolationKeys, pat::IsoDeposit> > IsoDepositPairs;
+    IsoDepositPairs isoDeposits_;
+    std::vector<float> isolations_;
 
-      //============ BEGIN ISODEPOSIT BLOCK =====
-      /// Returns the IsoDeposit associated with some key, or a null pointer if it is not available
-      const IsoDeposit * isoDeposit(IsolationKeys key) const {
-          for (IsoDepositPairs::const_iterator it = isoDeposits_.begin(), ed = isoDeposits_.end(); 
-                  it != ed; ++it) 
-          {
-              if (it->first == key) return & it->second;
-          }
-          return nullptr;
-      } 
-
-      /// Sets the IsoDeposit associated with some key; if it is already existent, it is overwritten.
-      void setIsoDeposit(IsolationKeys key, const IsoDeposit &dep) {
-          IsoDepositPairs::iterator it = isoDeposits_.begin(), ed = isoDeposits_.end();
-          for (; it != ed; ++it) {
-              if (it->first == key) { it->second = dep; return; }
-          }
-          isoDeposits_.push_back(std::make_pair(key,dep));
-      } 
-
-      // ---- specific getters ----
-      const IsoDeposit * trackIsoDeposit() const { return isoDeposit(pat::TrackIso); }
-      const IsoDeposit * ecalIsoDeposit()  const { return isoDeposit(pat::EcalIso ); }
-      const IsoDeposit * hcalIsoDeposit()  const { return isoDeposit(pat::HcalIso ); }
-      const IsoDeposit * userIsoDeposit(uint8_t index=0) const { return isoDeposit(IsolationKeys(UserBaseIso + index)); }
-
-      // ---- specific setters ----
-      void trackIsoDeposit(const IsoDeposit &dep) { setIsoDeposit(pat::TrackIso,dep); }
-      void ecalIsoDeposit(const IsoDeposit &dep)  { setIsoDeposit(pat::EcalIso, dep); }
-      void hcalIsoDeposit(const IsoDeposit &dep)  { setIsoDeposit(pat::HcalIso, dep); }
-      void userIsoDeposit(const IsoDeposit &dep, uint8_t index=0) { setIsoDeposit(IsolationKeys(UserBaseIso + index), dep); }
-
-      const PFIsolation& miniPFIsolation() const { return miniPFIsolation_; }
-      void setMiniPFIsolation(PFIsolation const& iso)  { miniPFIsolation_ = iso; }
-
-    protected:
-      // --- Isolation and IsoDeposit related datamebers ---
-      typedef std::vector<std::pair<IsolationKeys, pat::IsoDeposit> > IsoDepositPairs;
-      IsoDepositPairs    isoDeposits_;
-      std::vector<float> isolations_;
-
-      PFIsolation miniPFIsolation_;
+    PFIsolation miniPFIsolation_;
   };
-
 
   /// default constructor
   template <class LeptonType>
-  Lepton<LeptonType>::Lepton() :
-    PATObject<LeptonType>(LeptonType()) {
+  Lepton<LeptonType>::Lepton() : PATObject<LeptonType>(LeptonType()) {
     // no common constructor, so initialize the candidate manually
     this->setCharge(0);
     this->setP4(reco::Particle::LorentzVector(0, 0, 0, 0));
@@ -217,35 +235,27 @@ namespace pat {
     this->setMiniPFIsolation(pat::PFIsolation());
   }
 
-
   /// constructor from LeptonType
   template <class LeptonType>
-  Lepton<LeptonType>::Lepton(const LeptonType & aLepton) :
-    PATObject<LeptonType>(aLepton) {
+  Lepton<LeptonType>::Lepton(const LeptonType &aLepton) : PATObject<LeptonType>(aLepton) {
     this->setMiniPFIsolation(pat::PFIsolation());
   }
-
 
   /// constructor from ref to LeptonType
   template <class LeptonType>
-  Lepton<LeptonType>::Lepton(const edm::RefToBase<LeptonType> & aLeptonRef) :
-    PATObject<LeptonType>(aLeptonRef) {
+  Lepton<LeptonType>::Lepton(const edm::RefToBase<LeptonType> &aLeptonRef) : PATObject<LeptonType>(aLeptonRef) {
     this->setMiniPFIsolation(pat::PFIsolation());
   }
-
 
   /// constructor from ref to LeptonType
   template <class LeptonType>
-  Lepton<LeptonType>::Lepton(const edm::Ptr<LeptonType> & aLeptonRef) :
-    PATObject<LeptonType>(aLeptonRef) {
+  Lepton<LeptonType>::Lepton(const edm::Ptr<LeptonType> &aLeptonRef) : PATObject<LeptonType>(aLeptonRef) {
     this->setMiniPFIsolation(pat::PFIsolation());
   }
-
 
   /// destructor
   template <class LeptonType>
-  Lepton<LeptonType>::~Lepton() {
-  }
-}
+  Lepton<LeptonType>::~Lepton() {}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/LookupTableRecord.h
+++ b/DataFormats/PatCandidates/interface/LookupTableRecord.h
@@ -16,26 +16,25 @@
 #include <boost/cstdint.hpp>
 
 namespace pat {
-    class LookupTableRecord {
-        public:
-            LookupTableRecord() : value_(0), error_(0), bin_(0) {}
-            LookupTableRecord(float value, float error, uint16_t bin=0) :
-                value_(value), error_(error), bin_(bin) {}
-            LookupTableRecord(float value, uint16_t bin=0) :
-                value_(value), error_(0), bin_(bin) {}
-            LookupTableRecord(const Measurement1DFloat &meas, uint16_t bin=0) :
-                value_(meas.value()), error_(meas.error()), bin_(bin) {}
+  class LookupTableRecord {
+  public:
+    LookupTableRecord() : value_(0), error_(0), bin_(0) {}
+    LookupTableRecord(float value, float error, uint16_t bin = 0) : value_(value), error_(error), bin_(bin) {}
+    LookupTableRecord(float value, uint16_t bin = 0) : value_(value), error_(0), bin_(bin) {}
+    LookupTableRecord(const Measurement1DFloat &meas, uint16_t bin = 0)
+        : value_(meas.value()), error_(meas.error()), bin_(bin) {}
 
-            // Get the stored value
-            float    value() const { return value_; }
-            // Get the uncertainty on the stored value (note: it CAN be ZERO)
-            float    error() const { return error_; }
-            // Get the bin of the table used to compute this value (if available, otherwise 0)
-            uint16_t bin()   const { return bin_; }
-        private:
-            float    value_, error_;
-            uint16_t bin_;
-    };
-}
+    // Get the stored value
+    float value() const { return value_; }
+    // Get the uncertainty on the stored value (note: it CAN be ZERO)
+    float error() const { return error_; }
+    // Get the bin of the table used to compute this value (if available, otherwise 0)
+    uint16_t bin() const { return bin_; }
+
+  private:
+    float value_, error_;
+    uint16_t bin_;
+  };
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -4,7 +4,6 @@
 #ifndef DataFormats_PatCandidates_MET_h
 #define DataFormats_PatCandidates_MET_h
 
-
 /**
   \class    pat::MET MET.h "DataFormats/PatCandidates/interface/MET.h"
   \brief    Analysis-level MET class
@@ -30,248 +29,311 @@
 // Define typedefs for convenience
 namespace pat {
   class MET;
-  typedef std::vector<MET>              METCollection; 
-  typedef edm::Ref<METCollection>       METRef; 
-  typedef edm::RefVector<METCollection> METRefVector; 
-}
-
+  typedef std::vector<MET> METCollection;
+  typedef edm::Ref<METCollection> METRef;
+  typedef edm::RefVector<METCollection> METRefVector;
+}  // namespace pat
 
 // Class definition
 namespace pat {
 
-
   class MET : public PATObject<reco::MET> {
+  public:
+    /// default constructor
+    MET();
+    /// constructor from reco::MET
+    MET(const reco::MET& aMET);
+    /// constructor from a RefToBase to reco::MET (to be superseded by Ptr counterpart)
+    MET(const edm::RefToBase<reco::MET>& aMETRef);
+    /// constructor from a Ptr to a reco::MET
+    MET(const edm::Ptr<reco::MET>& aMETRef);
+    /// copy constructor
+    MET(MET const&);
+    /// constructor for corrected METs (keeping specific informations from src MET)
+    MET(const reco::MET& corMET, const MET& srcMET);
+    /// destructor
+    ~MET() override;
 
+    MET& operator=(MET const&);
+
+    /// required reimplementation of the Candidate's clone method
+    MET* clone() const override { return new MET(*this); }
+
+    // ---- methods for generated MET link ----
+    /// return the associated GenMET
+    const reco::GenMET* genMET() const;
+    /// set the associated GenMET
+    void setGenMET(const reco::GenMET& gm);
+
+    // ----- MET significance functions ----
+    // set the MET Significance
+    void setMETSignificance(const double& metSig);
+    // get the MET significance
+    double metSignificance() const;
+
+    // ---- methods for uncorrected MET ----
+    // Methods not yet defined
+    //float uncorrectedPt() const;
+    //float uncorrectedPhi() const;
+    //float uncorrectedSumEt() const;
+
+    // ---- methods to know what the pat::MET was constructed from ----
+    /// True if this pat::MET was made from a reco::CaloMET
+    bool isCaloMET() const { return !caloMET_.empty(); }
+    /// True if this pat::MET was made from a reco::pfMET
+    bool isPFMET() const { return !pfMET_.empty(); }
+    /// True if this pat::MET was NOT made from a reco::CaloMET nor a reco::pfMET
+    bool isRecoMET() const { return (caloMET_.empty() && pfMET_.empty()); }
+
+    // ---- methods for CaloMET specific stuff ----
+    /// Returns the maximum energy deposited in ECAL towers
+    double maxEtInEmTowers() const { return caloSpecific().MaxEtInEmTowers; }
+    /// Returns the maximum energy deposited in HCAL towers
+    double maxEtInHadTowers() const { return caloSpecific().MaxEtInHadTowers; }
+    /// Returns the event hadronic energy fraction
+    double etFractionHadronic() const { return caloSpecific().EtFractionHadronic; }
+    /// Returns the event electromagnetic energy fraction
+    double emEtFraction() const { return caloSpecific().EtFractionEm; }
+    /// Returns the event hadronic energy in HB
+    double hadEtInHB() const { return caloSpecific().HadEtInHB; }
+    /// Returns the event hadronic energy in HO
+    double hadEtInHO() const { return caloSpecific().HadEtInHO; }
+    /// Returns the event hadronic energy in HE
+    double hadEtInHE() const { return caloSpecific().HadEtInHE; }
+    /// Returns the event hadronic energy in HF
+    double hadEtInHF() const { return caloSpecific().HadEtInHF; }
+    /// Returns the event electromagnetic energy in EB
+    double emEtInEB() const { return caloSpecific().EmEtInEB; }
+    /// Returns the event electromagnetic energy in EE
+    double emEtInEE() const { return caloSpecific().EmEtInEE; }
+    /// Returns the event electromagnetic energy extracted from HF
+    double emEtInHF() const { return caloSpecific().EmEtInHF; }
+    /// Returns the event MET Significance
+    double caloMetSignificance() const { return caloSpecific().METSignificance; }
+    /// Returns the event SET in HF+
+    double CaloSETInpHF() const { return caloSpecific().CaloSETInpHF; }
+    /// Returns the event SET in HF-
+    double CaloSETInmHF() const { return caloSpecific().CaloSETInmHF; }
+    /// Returns the event MET in HF+
+    double CaloMETInpHF() const { return caloSpecific().CaloMETInpHF; }
+    /// Returns the event MET in HF-
+    double CaloMETInmHF() const { return caloSpecific().CaloMETInmHF; }
+    /// Returns the event MET-phi in HF+
+    double CaloMETPhiInpHF() const { return caloSpecific().CaloMETPhiInpHF; }
+    /// Returns the event MET-phi in HF-
+    double CaloMETPhiInmHF() const { return caloSpecific().CaloMETPhiInmHF; }
+    /// accessor for the CaloMET-specific structure
+    const SpecificCaloMETData& caloSpecific() const {
+      if (!isCaloMET())
+        throw cms::Exception("pat::MET") << "This pat::MET has not been made from a reco::CaloMET\n";
+      return caloMET_[0];
+    }
+
+    // ---- methods for PFMET specific stuff ----
+    double NeutralEMFraction() const { return pfSpecific().NeutralEMFraction; }
+    double NeutralHadEtFraction() const { return pfSpecific().NeutralHadFraction; }
+    double ChargedEMEtFraction() const { return pfSpecific().ChargedEMFraction; }
+    double ChargedHadEtFraction() const { return pfSpecific().ChargedHadFraction; }
+    double MuonEtFraction() const { return pfSpecific().MuonFraction; }
+    double Type6EtFraction() const { return pfSpecific().Type6Fraction; }
+    double Type7EtFraction() const { return pfSpecific().Type7Fraction; }
+    /// accessor for the pfMET-specific structure
+    const SpecificPFMETData& pfSpecific() const {
+      if (!isPFMET())
+        throw cms::Exception("pat::MET") << "This pat::MET has not been made from a reco::PFMET\n";
+      return pfMET_[0];
+    }
+
+    // ---- members for MET corrections ----
+    enum METUncertainty {
+      JetResUp = 0,
+      JetResDown = 1,
+      JetEnUp = 2,
+      JetEnDown = 3,
+      MuonEnUp = 4,
+      MuonEnDown = 5,
+      ElectronEnUp = 6,
+      ElectronEnDown = 7,
+      TauEnUp = 8,
+      TauEnDown = 9,
+      UnclusteredEnUp = 10,
+      UnclusteredEnDown = 11,
+      PhotonEnUp = 12,
+      PhotonEnDown = 13,
+      NoShift = 14,
+      METUncertaintySize = 15,
+      JetResUpSmear = 16,
+      JetResDownSmear = 17,
+      METFullUncertaintySize = 18
+    };
+    enum METCorrectionLevel {
+      Raw = 0,
+      Type1 = 1,
+      Type01 = 2,
+      TypeXY = 3,
+      Type1XY = 4,
+      Type01XY = 5,
+      Type1Smear = 6,
+      Type01Smear = 7,
+      Type1SmearXY = 8,
+      Type01SmearXY = 9,
+      RawCalo = 10,
+      RawChs = 11,
+      RawTrk = 12,
+      METCorrectionLevelSize = 13
+    };
+    enum METCorrectionType {
+      None = 0,
+      T1 = 1,
+      T0 = 2,
+      TXY = 3,
+      TXYForRaw = 4,
+      TXYForT01 = 5,
+      TXYForT1Smear = 6,
+      TXYForT01Smear = 7,
+      Smear = 8,
+      Calo = 9,
+      Chs = 10,
+      Trk = 11,
+      METCorrectionTypeSize = 12
+    };
+
+    struct Vector2 {
+      double px, py;
+      double pt() const { return hypotf(px, py); }
+      double phi() const { return std::atan2(py, px); }
+    };
+
+    Vector2 shiftedP2(METUncertainty shift, METCorrectionLevel level = Type1) const;
+    Vector shiftedP3(METUncertainty shift, METCorrectionLevel level = Type1) const;
+    LorentzVector shiftedP4(METUncertainty shift, METCorrectionLevel level = Type1) const;
+    double shiftedPx(METUncertainty shift, METCorrectionLevel level = Type1) const {
+      return shiftedP2(shift, level).px;
+    };
+    double shiftedPy(METUncertainty shift, METCorrectionLevel level = Type1) const {
+      return shiftedP2(shift, level).py;
+    };
+    double shiftedPt(METUncertainty shift, METCorrectionLevel level = Type1) const {
+      return shiftedP2(shift, level).pt();
+    };
+    double shiftedPhi(METUncertainty shift, METCorrectionLevel level = Type1) const {
+      return shiftedP2(shift, level).phi();
+    };
+    double shiftedSumEt(METUncertainty shift, METCorrectionLevel level = Type1) const;
+
+    Vector2 corP2(METCorrectionLevel level = Type1) const;
+    Vector corP3(METCorrectionLevel level = Type1) const;
+    LorentzVector corP4(METCorrectionLevel level = Type1) const;
+    double corPx(METCorrectionLevel level = Type1) const { return corP2(level).px; };
+    double corPy(METCorrectionLevel level = Type1) const { return corP2(level).py; };
+    double corPt(METCorrectionLevel level = Type1) const { return corP2(level).pt(); };
+    double corPhi(METCorrectionLevel level = Type1) const { return corP2(level).phi(); };
+    double corSumEt(METCorrectionLevel level = Type1) const;
+
+    Vector2 uncorP2() const;
+    Vector uncorP3() const;
+    LorentzVector uncorP4() const;
+    double uncorPx() const { return uncorP2().px; };
+    double uncorPy() const { return uncorP2().py; };
+    double uncorPt() const { return uncorP2().pt(); };
+    double uncorPhi() const { return uncorP2().phi(); };
+    double uncorSumEt() const;
+
+    void setUncShift(double px, double py, double sumEt, METUncertainty shift, bool isSmeared = false);
+    void setCorShift(double px, double py, double sumEt, METCorrectionType level);
+
+    // specific method to fill and retrieve the caloMET quickly from miniAODs,
+    //should be used by JetMET experts only for the beginning
+    //of the runII, will be discarded later once we are sure
+    //everything is fine
+    Vector2 caloMETP2() const;
+    double caloMETPt() const;
+    double caloMETPhi() const;
+    double caloMETSumEt() const;
+
+    //Functions for backward compatibility with 74X samples.
+    // allow access to 74X samples, transparent and not used in 75
+    Vector2 shiftedP2_74x(METUncertainty shift, METCorrectionLevel level) const;
+    Vector shiftedP3_74x(METUncertainty shift, METCorrectionLevel level) const;
+    LorentzVector shiftedP4_74x(METUncertainty shift, METCorrectionLevel level) const;
+    double shiftedSumEt_74x(METUncertainty shift, METCorrectionLevel level) const;
+
+    /// this below should be private but Reflex doesn't like it
+    class PackedMETUncertainty {
+      // defined as C++ class so that I can change the packing without having to touch the code elsewhere
+      // the compiler should anyway inline everything whenever possible
     public:
-
-      /// default constructor
-      MET();
-      /// constructor from reco::MET
-      MET(const reco::MET & aMET);
-      /// constructor from a RefToBase to reco::MET (to be superseded by Ptr counterpart)
-      MET(const edm::RefToBase<reco::MET> & aMETRef);
-      /// constructor from a Ptr to a reco::MET
-      MET(const edm::Ptr<reco::MET> & aMETRef);
-      /// copy constructor
-      MET( MET const&);
-      /// constructor for corrected METs (keeping specific informations from src MET)
-      MET(const reco::MET & corMET, const MET& srcMET );
-      /// destructor
-      ~MET() override;
-
-      MET& operator=(MET const&);
-
-      /// required reimplementation of the Candidate's clone method
-      MET * clone() const override { return new MET(*this); }
-
-      // ---- methods for generated MET link ----
-      /// return the associated GenMET
-      const reco::GenMET * genMET() const;
-      /// set the associated GenMET
-      void setGenMET(const reco::GenMET & gm);
-
-      // ----- MET significance functions ----
-      // set the MET Significance
-      void setMETSignificance(const double& metSig);
-      // get the MET significance
-      double metSignificance() const;
-
-      // ---- methods for uncorrected MET ----
-      // Methods not yet defined
-      //float uncorrectedPt() const;
-      //float uncorrectedPhi() const;
-      //float uncorrectedSumEt() const;
-
-      // ---- methods to know what the pat::MET was constructed from ----
-      /// True if this pat::MET was made from a reco::CaloMET
-      bool isCaloMET() const { return !caloMET_.empty(); }
-      /// True if this pat::MET was made from a reco::pfMET
-      bool isPFMET() const { return !pfMET_.empty(); }
-      /// True if this pat::MET was NOT made from a reco::CaloMET nor a reco::pfMET
-      bool isRecoMET() const { return  ( caloMET_.empty() && pfMET_.empty() ); }
-
-      // ---- methods for CaloMET specific stuff ----
-      /// Returns the maximum energy deposited in ECAL towers
-      double maxEtInEmTowers() const {return caloSpecific().MaxEtInEmTowers;}
-      /// Returns the maximum energy deposited in HCAL towers
-      double maxEtInHadTowers() const {return caloSpecific().MaxEtInHadTowers;}
-      /// Returns the event hadronic energy fraction
-      double etFractionHadronic () const {return caloSpecific().EtFractionHadronic;}
-      /// Returns the event electromagnetic energy fraction
-      double emEtFraction() const {return caloSpecific().EtFractionEm;}
-      /// Returns the event hadronic energy in HB
-      double hadEtInHB() const {return caloSpecific().HadEtInHB;}
-      /// Returns the event hadronic energy in HO
-      double hadEtInHO() const {return caloSpecific().HadEtInHO;}
-      /// Returns the event hadronic energy in HE
-      double hadEtInHE() const {return caloSpecific().HadEtInHE;}
-      /// Returns the event hadronic energy in HF
-      double hadEtInHF() const {return caloSpecific().HadEtInHF;}
-      /// Returns the event electromagnetic energy in EB
-      double emEtInEB() const {return caloSpecific().EmEtInEB;}
-      /// Returns the event electromagnetic energy in EE
-      double emEtInEE() const {return caloSpecific().EmEtInEE;}
-      /// Returns the event electromagnetic energy extracted from HF
-      double emEtInHF() const {return caloSpecific().EmEtInHF;}
-      /// Returns the event MET Significance
-      double caloMetSignificance() const {return caloSpecific().METSignificance;}
-      /// Returns the event SET in HF+
-      double CaloSETInpHF() const {return caloSpecific().CaloSETInpHF;}
-      /// Returns the event SET in HF-
-      double CaloSETInmHF() const {return caloSpecific().CaloSETInmHF;}
-      /// Returns the event MET in HF+
-      double CaloMETInpHF() const {return caloSpecific().CaloMETInpHF;}
-      /// Returns the event MET in HF-
-      double CaloMETInmHF() const {return caloSpecific().CaloMETInmHF;}
-      /// Returns the event MET-phi in HF+
-      double CaloMETPhiInpHF() const {return caloSpecific().CaloMETPhiInpHF;}
-      /// Returns the event MET-phi in HF-
-      double CaloMETPhiInmHF() const {return caloSpecific().CaloMETPhiInmHF;}
-      /// accessor for the CaloMET-specific structure
-      const SpecificCaloMETData & caloSpecific() const {
-          if (!isCaloMET()) throw cms::Exception("pat::MET") << "This pat::MET has not been made from a reco::CaloMET\n";
-          return caloMET_[0];
+      PackedMETUncertainty() : dpx_(0), dpy_(0), dsumEt_(0) {
+        pack();
+        unpack();
       }
-
-      // ---- methods for PFMET specific stuff ----
-      double NeutralEMFraction() const { return pfSpecific().NeutralEMFraction; }
-      double NeutralHadEtFraction() const { return pfSpecific().NeutralHadFraction; }
-      double ChargedEMEtFraction() const { return pfSpecific().ChargedEMFraction; }
-      double ChargedHadEtFraction() const { return pfSpecific().ChargedHadFraction; }
-      double MuonEtFraction() const { return pfSpecific().MuonFraction; }
-      double Type6EtFraction() const { return pfSpecific().Type6Fraction; }
-      double Type7EtFraction() const { return pfSpecific().Type7Fraction; }
-      /// accessor for the pfMET-specific structure
-      const SpecificPFMETData & pfSpecific() const {
-          if (!isPFMET()) throw cms::Exception("pat::MET") << "This pat::MET has not been made from a reco::PFMET\n";
-          return pfMET_[0];
+      PackedMETUncertainty(float dpx, float dpy, float dsumEt) : dpx_(dpx), dpy_(dpy), dsumEt_(dsumEt) {
+        pack();
+        unpack();
       }
-
-      // ---- members for MET corrections ----
-      enum METUncertainty {
-       JetResUp=0, JetResDown=1, JetEnUp=2, JetEnDown=3,
-       MuonEnUp=4, MuonEnDown=5, ElectronEnUp=6, ElectronEnDown=7,
-       TauEnUp=8, TauEnDown=9, UnclusteredEnUp=10, UnclusteredEnDown=11,
-       PhotonEnUp=12, PhotonEnDown=13, NoShift=14, METUncertaintySize=15,
-       JetResUpSmear=16, JetResDownSmear=17, METFullUncertaintySize=18
-      };
-      enum METCorrectionLevel {
-       Raw=0, Type1=1, Type01=2, TypeXY=3, Type1XY=4, Type01XY=5,
-       Type1Smear=6, Type01Smear=7, Type1SmearXY=8, 
-       Type01SmearXY=9, RawCalo=10, RawChs=11, RawTrk=12, METCorrectionLevelSize=13
-      };
-      enum METCorrectionType {
-       None=0, T1=1, T0=2, TXY=3, TXYForRaw=4,
-       TXYForT01=5, TXYForT1Smear=6, TXYForT01Smear=7,
-       Smear=8, Calo=9, Chs=10, Trk=11, METCorrectionTypeSize=12
-      };
-
-      struct Vector2 { 
-        double px, py; 
-        double pt() const { return hypotf(px,py); }  
-        double phi() const { return std::atan2(py,px); }
-      };
-
-      Vector2 shiftedP2(METUncertainty shift, METCorrectionLevel level=Type1)  const ;
-      Vector shiftedP3(METUncertainty shift, METCorrectionLevel level=Type1)  const ;
-      LorentzVector shiftedP4(METUncertainty shift, METCorrectionLevel level=Type1)  const ;
-      double shiftedPx(METUncertainty shift, METCorrectionLevel level=Type1)  const { return shiftedP2(shift,level).px; };
-      double shiftedPy(METUncertainty shift, METCorrectionLevel level=Type1)  const { return shiftedP2(shift,level).py; };
-      double shiftedPt(METUncertainty shift, METCorrectionLevel level=Type1)  const { return shiftedP2(shift,level).pt(); };
-      double shiftedPhi(METUncertainty shift, METCorrectionLevel level=Type1) const { return shiftedP2(shift,level).phi(); };
-      double shiftedSumEt(METUncertainty shift, METCorrectionLevel level=Type1) const ;
-
-      Vector2 corP2(METCorrectionLevel level=Type1)  const ;
-      Vector corP3(METCorrectionLevel level=Type1)  const ;
-      LorentzVector corP4(METCorrectionLevel level=Type1)  const ;
-      double corPx(METCorrectionLevel level=Type1)  const { return corP2(level).px; };
-      double corPy(METCorrectionLevel level=Type1)  const { return corP2(level).py; };
-      double corPt(METCorrectionLevel level=Type1)  const { return corP2(level).pt(); };
-      double corPhi(METCorrectionLevel level=Type1) const { return corP2(level).phi(); };
-      double corSumEt(METCorrectionLevel level=Type1) const ;
-
-      Vector2 uncorP2() const;
-      Vector uncorP3()  const ;
-      LorentzVector uncorP4()  const ;
-      double uncorPx() const { return uncorP2().px; };
-      double uncorPy() const { return uncorP2().py; };
-      double uncorPt() const { return uncorP2().pt(); };
-      double uncorPhi() const { return uncorP2().phi(); };
-      double uncorSumEt() const;
-
-      void setUncShift(double px, double py, double sumEt, METUncertainty shift, bool isSmeared=false);
-      void setCorShift(double px, double py, double sumEt, METCorrectionType level);
-
-      // specific method to fill and retrieve the caloMET quickly from miniAODs, 
-      //should be used by JetMET experts only for the beginning
-      //of the runII, will be discarded later once we are sure
-      //everything is fine
-      Vector2 caloMETP2() const;
-      double caloMETPt() const;
-      double caloMETPhi() const;
-      double caloMETSumEt() const;
-
-      //Functions for backward compatibility with 74X samples.
-      // allow access to 74X samples, transparent and not used in 75
-      Vector2 shiftedP2_74x(METUncertainty shift, METCorrectionLevel level) const ;
-      Vector shiftedP3_74x(METUncertainty shift, METCorrectionLevel level) const ;
-      LorentzVector shiftedP4_74x(METUncertainty shift, METCorrectionLevel level) const ;
-      double shiftedSumEt_74x(METUncertainty shift, METCorrectionLevel level) const ;
-	
-
-      /// this below should be private but Reflex doesn't like it
-      class PackedMETUncertainty {
-        // defined as C++ class so that I can change the packing without having to touch the code elsewhere
-        // the compiler should anyway inline everything whenever possible
-        public:
-            PackedMETUncertainty() : dpx_(0), dpy_(0), dsumEt_(0) {pack(); unpack();}
-            PackedMETUncertainty(float dpx, float dpy, float dsumEt) : dpx_(dpx), dpy_(dpy), dsumEt_(dsumEt) {pack();unpack();}
-            double dpx() const { if(!unpacked_) unpack(); return dpx_; }
-            double dpy() const { if(!unpacked_) unpack(); return dpy_; }
-            double dsumEt() const { if(!unpacked_) unpack(); return dsumEt_; }
-            void set(float dpx, float dpy, float dsumEt) { dpx_ = dpx; dpy_ = dpy; dsumEt_ = dsumEt; pack(); unpack();}
-	    void add(float dpx, float dpy, float dsumEt) { dpx_ += dpx; dpy_ += dpy; dsumEt_ += dsumEt; }
-            void  unpack() const ;
-            void  pack();
-
-        protected:
-            mutable float dpx_, dpy_, dsumEt_;
-            mutable bool unpacked_;
-            uint16_t packedDpx_,packedDpy_,packedDSumEt_;
-      };
-    private:
-
-      // ---- GenMET holder ----
-      std::vector<reco::GenMET> genMET_;
-      // ---- holder for CaloMET specific info ---
-      std::vector<SpecificCaloMETData> caloMET_;
-      // ---- holder for pfMET specific info ---
-      std::vector<SpecificPFMETData> pfMET_;
-
-      // MET significance
-      double metSig_;
-      
-      const PackedMETUncertainty findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const;
-   
-      std::map<MET::METCorrectionLevel, std::vector<MET::METCorrectionType> > corMap_;
-      void initCorMap();
-
-    
+      double dpx() const {
+        if (!unpacked_)
+          unpack();
+        return dpx_;
+      }
+      double dpy() const {
+        if (!unpacked_)
+          unpack();
+        return dpy_;
+      }
+      double dsumEt() const {
+        if (!unpacked_)
+          unpack();
+        return dsumEt_;
+      }
+      void set(float dpx, float dpy, float dsumEt) {
+        dpx_ = dpx;
+        dpy_ = dpy;
+        dsumEt_ = dsumEt;
+        pack();
+        unpack();
+      }
+      void add(float dpx, float dpy, float dsumEt) {
+        dpx_ += dpx;
+        dpy_ += dpy;
+        dsumEt_ += dsumEt;
+      }
+      void unpack() const;
+      void pack();
 
     protected:
+      mutable float dpx_, dpy_, dsumEt_;
+      mutable bool unpacked_;
+      uint16_t packedDpx_, packedDpy_, packedDSumEt_;
+    };
 
-      // ---- non-public correction utilities ----
-      //kept for 74X backward-compatibility, not initialized and used in 75X
-      std::vector<PackedMETUncertainty> uncertaintiesRaw_, uncertaintiesType1_, uncertaintiesType1p2_;
-      
-      std::vector<PackedMETUncertainty> uncertainties_;
-      std::vector<PackedMETUncertainty> corrections_;
-      
-      PackedMETUncertainty caloPackedMet_;
+  private:
+    // ---- GenMET holder ----
+    std::vector<reco::GenMET> genMET_;
+    // ---- holder for CaloMET specific info ---
+    std::vector<SpecificCaloMETData> caloMET_;
+    // ---- holder for pfMET specific info ---
+    std::vector<SpecificPFMETData> pfMET_;
 
+    // MET significance
+    double metSig_;
+
+    const PackedMETUncertainty findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const;
+
+    std::map<MET::METCorrectionLevel, std::vector<MET::METCorrectionType> > corMap_;
+    void initCorMap();
+
+  protected:
+    // ---- non-public correction utilities ----
+    //kept for 74X backward-compatibility, not initialized and used in 75X
+    std::vector<PackedMETUncertainty> uncertaintiesRaw_, uncertaintiesType1_, uncertaintiesType1p2_;
+
+    std::vector<PackedMETUncertainty> uncertainties_;
+    std::vector<PackedMETUncertainty> corrections_;
+
+    PackedMETUncertainty caloPackedMet_;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/MHT.h
+++ b/DataFormats/PatCandidates/interface/MHT.h
@@ -4,47 +4,39 @@
 #include "DataFormats/Candidate/interface/CompositeRefBaseCandidate.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-
 namespace pat {
-  
+
   class MHT : public reco::CompositeRefBaseCandidate {
   public:
-    MHT () {}
-    MHT (const Candidate::LorentzVector& p4, double ht, double signif) :
-      CompositeRefBaseCandidate(0,p4), ht_(ht), significance_(signif) {}
-    ~MHT () override {}
-    
-    double mht() const {return pt();}
+    MHT() {}
+    MHT(const Candidate::LorentzVector& p4, double ht, double signif)
+        : CompositeRefBaseCandidate(0, p4), ht_(ht), significance_(signif) {}
+    ~MHT() override {}
+
+    double mht() const { return pt(); }
     // ????double phi() const {return phi();}
-    double ht()  const {return ht_;}
-    double significance() const {return significance_;}
-    double error()  const{return 0.5*significance()*mht()*mht();}
-    
+    double ht() const { return ht_; }
+    double significance() const { return significance_; }
+    double error() const { return 0.5 * significance() * mht() * mht(); }
+
     double getNumberOfJets() const;
-    void   setNumberOfJets(const double & numberOfJets);
-    
+    void setNumberOfJets(const double& numberOfJets);
+
     double getNumberOfElectrons() const;
-    void   setNumberOfElectrons(const double & numberOfElectrons);
+    void setNumberOfElectrons(const double& numberOfElectrons);
 
     double getNumberOfMuons() const;
-    void   setNumberOfMuons(const double & numberOfMuons);
+    void setNumberOfMuons(const double& numberOfMuons);
 
-   private:
-    
+  private:
     double ht_;
     double significance_;
     double number_of_jets_;
     double number_of_electrons_;
     double number_of_muons_;
   };
-  
+
   typedef std::vector<pat::MHT> MHTCollection;
-}
+}  // namespace pat
 
 #endif
-
-
-
-
-
-

--- a/DataFormats/PatCandidates/interface/PATObject.h
+++ b/DataFormats/PatCandidates/interface/PATObject.h
@@ -16,7 +16,6 @@
   \author   Steven Lowette, Giovanni Petrucciani, Frederic Ronga, Volker Adler, Sal Rappoccio
 */
 
-
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -43,929 +42,1002 @@ namespace pat {
   namespace pat_statics {
     static const reco::CandidatePtrVector EMPTY_CPV;
     static const std::string EMPTY_STR("");
-  }
+  }  // namespace pat_statics
 
   template <class ObjectType>
   class PATObject : public ObjectType {
-    public:
+  public:
+    typedef ObjectType base_type;
 
-      typedef  ObjectType             base_type;
+    /// default constructor
+    PATObject();
+    /// constructor from a base object (leaves invalid reference to original object!)
+    PATObject(const ObjectType &obj);
+    /// constructor from reference
+    PATObject(const edm::RefToBase<ObjectType> &ref);
+    /// constructor from reference
+    PATObject(const edm::Ptr<ObjectType> &ref);
+    /// destructor
+    ~PATObject() override {}
+    // returns a clone                                  // NO: ObjectType can be an abstract type like reco::Candidate
+    // virtual PATObject<ObjectType> * clone() const ;  //     for which the clone() can't be defined
 
-      /// default constructor
-      PATObject();
-      /// constructor from a base object (leaves invalid reference to original object!)
-      PATObject(const ObjectType & obj);
-      /// constructor from reference
-      PATObject(const edm::RefToBase<ObjectType> & ref);
-      /// constructor from reference
-      PATObject(const edm::Ptr<ObjectType> & ref);
-      /// destructor
-      ~PATObject() override {}
-      // returns a clone                                  // NO: ObjectType can be an abstract type like reco::Candidate
-      // virtual PATObject<ObjectType> * clone() const ;  //     for which the clone() can't be defined
+    /// access to the original object; returns zero for null Ref and throws for unavailable collection
+    const reco::Candidate *originalObject() const;
+    /// reference to original object. Returns a null reference if not available
+    const edm::Ptr<reco::Candidate> &originalObjectRef() const;
 
-      /// access to the original object; returns zero for null Ref and throws for unavailable collection
-      const reco::Candidate * originalObject() const;
-      /// reference to original object. Returns a null reference if not available
-      const edm::Ptr<reco::Candidate> & originalObjectRef() const;
+    /// access to embedded trigger matches:
+    /// duplicated functions using 'char*' instead of 'std::string' are needed in order to work properly in CINT command lines;
+    /// duplicated functions using 'unsigned' instead of 'bool' are needed in order to work properly in the cut string parser;
 
-      /// access to embedded trigger matches:
-      /// duplicated functions using 'char*' instead of 'std::string' are needed in order to work properly in CINT command lines;
-      /// duplicated functions using 'unsigned' instead of 'bool' are needed in order to work properly in the cut string parser;
+    /// get all matched trigger objects
+    const TriggerObjectStandAloneCollection &triggerObjectMatches() const { return triggerObjectMatchesEmbedded_; };
+    /// get one matched trigger object by index
+    const TriggerObjectStandAlone *triggerObjectMatch(const size_t idx = 0) const;
+    /// get all matched trigger objects of a certain type;
+    /// trigger object types are defined in 'enum trigger::TriggerObjectType' (DataFormats/HLTReco/interface/TriggerTypeDefs.h)
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByType(
+        const trigger::TriggerObjectType triggerObjectType) const;
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByType(const unsigned triggerObjectType) const {
+      return triggerObjectMatchesByType(trigger::TriggerObjectType(triggerObjectType));
+    };
+    // for backward compatibility
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByFilterID(const unsigned triggerObjectType) const {
+      return triggerObjectMatchesByType(trigger::TriggerObjectType(triggerObjectType));
+    };
+    /// get one matched trigger object of a certain type by index
+    const TriggerObjectStandAlone *triggerObjectMatchByType(const trigger::TriggerObjectType triggerObjectType,
+                                                            const size_t idx = 0) const;
+    const TriggerObjectStandAlone *triggerObjectMatchByType(const unsigned triggerObjectType,
+                                                            const size_t idx = 0) const {
+      return triggerObjectMatchByType(trigger::TriggerObjectType(triggerObjectType), idx);
+    };
+    // for backward compatibility
+    const TriggerObjectStandAlone *triggerObjectMatchByFilterID(const unsigned triggerObjectType,
+                                                                const size_t idx = 0) const {
+      return triggerObjectMatchByType(trigger::TriggerObjectType(triggerObjectType), idx);
+    };
+    /// get all matched trigger objects from a certain collection
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByCollection(const std::string &coll) const;
+    // for RooT command line
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByCollection(const char *coll) const {
+      return triggerObjectMatchesByCollection(std::string(coll));
+    };
+    /// get one matched trigger object from a certain collection by index
+    const TriggerObjectStandAlone *triggerObjectMatchByCollection(const std::string &coll, const size_t idx = 0) const;
+    // for RooT command line
+    const TriggerObjectStandAlone *triggerObjectMatchByCollection(const char *coll, const size_t idx = 0) const {
+      return triggerObjectMatchByCollection(std::string(coll), idx);
+    };
+    /// get all matched L1 objects used in a succeeding object combination of a certain L1 condition
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByCondition(const std::string &nameCondition) const;
+    // for RooT command line
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByCondition(const char *nameCondition) const {
+      return triggerObjectMatchesByCondition(std::string(nameCondition));
+    };
+    /// get one matched L1 object used in a succeeding object combination of a certain L1 condition by index
+    const TriggerObjectStandAlone *triggerObjectMatchByCondition(const std::string &nameCondition,
+                                                                 const size_t idx = 0) const;
+    // for RooT command line
+    const TriggerObjectStandAlone *triggerObjectMatchByCondition(const char *nameCondition,
+                                                                 const size_t idx = 0) const {
+      return triggerObjectMatchByCondition(std::string(nameCondition), idx);
+    };
+    /// get all matched L1 objects used in a succeeding object combination of a condition in a certain L1 (physics) algorithm;
+    /// if 'algoCondAccepted' is set to 'true' (default), only objects used in succeeding conditions of succeeding algorithms are considered
+    /// ("firing" objects)
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByAlgorithm(const std::string &nameAlgorithm,
+                                                                            const bool algoCondAccepted = true) const;
+    // for RooT command line
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByAlgorithm(const char *nameAlgorithm,
+                                                                            const bool algoCondAccepted = true) const {
+      return triggerObjectMatchesByAlgorithm(std::string(nameAlgorithm), algoCondAccepted);
+    };
+    // for the cut string parser
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByAlgorithm(const std::string &nameAlgorithm,
+                                                                            const unsigned algoCondAccepted) const {
+      return triggerObjectMatchesByAlgorithm(nameAlgorithm, bool(algoCondAccepted));
+    };
+    // for RooT command line and the cut string parser
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByAlgorithm(const char *nameAlgorithm,
+                                                                            const unsigned algoCondAccepted) const {
+      return triggerObjectMatchesByAlgorithm(std::string(nameAlgorithm), bool(algoCondAccepted));
+    };
+    /// get one matched L1 object used in a succeeding object combination of a condition in a certain L1 (physics) algorithm by index;
+    /// if 'algoCondAccepted' is set to 'true' (default), only objects used in succeeding conditions of succeeding algorithms are considered
+    /// ("firing" objects)
+    const TriggerObjectStandAlone *triggerObjectMatchByAlgorithm(const std::string &nameAlgorithm,
+                                                                 const bool algoCondAccepted = true,
+                                                                 const size_t idx = 0) const;
+    // for RooT command line
+    const TriggerObjectStandAlone *triggerObjectMatchByAlgorithm(const char *nameAlgorithm,
+                                                                 const bool algoCondAccepted = true,
+                                                                 const size_t idx = 0) const {
+      return triggerObjectMatchByAlgorithm(std::string(nameAlgorithm), algoCondAccepted, idx);
+    };
+    // for the cut string parser
+    const TriggerObjectStandAlone *triggerObjectMatchByAlgorithm(const std::string &nameAlgorithm,
+                                                                 const unsigned algoCondAccepted,
+                                                                 const size_t idx = 0) const {
+      return triggerObjectMatchByAlgorithm(nameAlgorithm, bool(algoCondAccepted), idx);
+    };
+    // for RooT command line and the cut string parser
+    const TriggerObjectStandAlone *triggerObjectMatchByAlgorithm(const char *nameAlgorithm,
+                                                                 const unsigned algoCondAccepted,
+                                                                 const size_t idx = 0) const {
+      return triggerObjectMatchByAlgorithm(std::string(nameAlgorithm), bool(algoCondAccepted), idx);
+    };
+    /// get all matched HLT objects used in a certain HLT filter
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByFilter(const std::string &labelFilter) const;
+    // for RooT command line
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByFilter(const char *labelFilter) const {
+      return triggerObjectMatchesByFilter(std::string(labelFilter));
+    };
+    /// get one matched HLT object used in a certain HLT filter by index
+    const TriggerObjectStandAlone *triggerObjectMatchByFilter(const std::string &labelFilter,
+                                                              const size_t idx = 0) const;
+    // for RooT command line
+    const TriggerObjectStandAlone *triggerObjectMatchByFilter(const char *labelFilter, const size_t idx = 0) const {
+      return triggerObjectMatchByFilter(std::string(labelFilter), idx);
+    };
+    /// get all matched HLT objects used in a certain HLT path;
+    /// if 'pathLastFilterAccepted' is set to 'true' (default), only objects used in the final filter of a succeeding path are considered
+    /// ("firing" objects old style only valid for single object triggers);
+    /// if 'pathL3FilterAccepted' is set to 'true' (default), only objects used in L3 filters (identified by the "saveTags" parameter being 'true')
+    /// of a succeeding path are considered ("firing" objects old style only valid for single object triggers)
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByPath(const std::string &namePath,
+                                                                       const bool pathLastFilterAccepted = false,
+                                                                       const bool pathL3FilterAccepted = true) const;
+    // for RooT command line
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByPath(const char *namePath,
+                                                                       const bool pathLastFilterAccepted = false,
+                                                                       const bool pathL3FilterAccepted = true) const {
+      return triggerObjectMatchesByPath(std::string(namePath), pathLastFilterAccepted, pathL3FilterAccepted);
+    };
+    // for the cut string parser
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByPath(const std::string &namePath,
+                                                                       const unsigned pathLastFilterAccepted,
+                                                                       const unsigned pathL3FilterAccepted = 1) const {
+      return triggerObjectMatchesByPath(namePath, bool(pathLastFilterAccepted), bool(pathL3FilterAccepted));
+    };
+    // for RooT command line and the cut string parser
+    const TriggerObjectStandAloneCollection triggerObjectMatchesByPath(const char *namePath,
+                                                                       const unsigned pathLastFilterAccepted,
+                                                                       const unsigned pathL3FilterAccepted = 1) const {
+      return triggerObjectMatchesByPath(
+          std::string(namePath), bool(pathLastFilterAccepted), bool(pathL3FilterAccepted));
+    };
+    /// get one matched HLT object used in a certain HLT path by index;
+    /// if 'pathLastFilterAccepted' is set to 'true' (default), only objects used in the final filter of a succeeding path are considered
+    /// ("firing" objects, old style only valid for single object triggers);
+    /// if 'pathL3FilterAccepted' is set to 'true' (default), only objects used in L3 filters (identified by the "saveTags" parameter being 'true')
+    /// of a succeeding path are considered ("firing" objects also valid for x-triggers)
+    const TriggerObjectStandAlone *triggerObjectMatchByPath(const std::string &namePath,
+                                                            const bool pathLastFilterAccepted = false,
+                                                            const bool pathL3FilterAccepted = true,
+                                                            const size_t idx = 0) const;
+    // for RooT command line
+    const TriggerObjectStandAlone *triggerObjectMatchByPath(const char *namePath,
+                                                            const bool pathLastFilterAccepted = false,
+                                                            const bool pathL3FilterAccepted = true,
+                                                            const size_t idx = 0) const {
+      return triggerObjectMatchByPath(std::string(namePath), pathLastFilterAccepted, pathL3FilterAccepted, idx);
+    };
+    // for the cut string parser
+    const TriggerObjectStandAlone *triggerObjectMatchByPath(const std::string &namePath,
+                                                            const unsigned pathLastFilterAccepted,
+                                                            const unsigned pathL3FilterAccepted = 1,
+                                                            const size_t idx = 0) const {
+      return triggerObjectMatchByPath(namePath, bool(pathLastFilterAccepted), bool(pathL3FilterAccepted), idx);
+    };
+    // for RooT command line and the cut string parser
+    const TriggerObjectStandAlone *triggerObjectMatchByPath(const char *namePath,
+                                                            const unsigned pathLastFilterAccepted,
+                                                            const unsigned pathL3FilterAccepted = 1,
+                                                            const size_t idx = 0) const {
+      return triggerObjectMatchByPath(
+          std::string(namePath), bool(pathLastFilterAccepted), bool(pathL3FilterAccepted), idx);
+    };
+    /// add a trigger match
+    void addTriggerObjectMatch(const TriggerObjectStandAlone &trigObj) {
+      triggerObjectMatchesEmbedded_.push_back(trigObj);
+    };
+    /// unpack path names of matched trigger objects (if they were packed before embedding, which is not normally the case)
+    void unpackTriggerObjectPathNames(const edm::TriggerNames &names) {
+      for (std::vector<TriggerObjectStandAlone>::iterator it = triggerObjectMatchesEmbedded_.begin(),
+                                                          ed = triggerObjectMatchesEmbedded_.end();
+           it != ed;
+           ++it)
+        it->unpackPathNames(names);
+    }
 
-      /// get all matched trigger objects
-      const TriggerObjectStandAloneCollection & triggerObjectMatches() const { return triggerObjectMatchesEmbedded_; };
-      /// get one matched trigger object by index
-      const TriggerObjectStandAlone * triggerObjectMatch( const size_t idx = 0 ) const;
-      /// get all matched trigger objects of a certain type;
-      /// trigger object types are defined in 'enum trigger::TriggerObjectType' (DataFormats/HLTReco/interface/TriggerTypeDefs.h)
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByType( const trigger::TriggerObjectType triggerObjectType ) const;
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByType( const unsigned triggerObjectType ) const {
-        return triggerObjectMatchesByType( trigger::TriggerObjectType( triggerObjectType ) );
-      };
-      // for backward compatibility
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByFilterID( const unsigned triggerObjectType ) const {
-        return triggerObjectMatchesByType( trigger::TriggerObjectType( triggerObjectType ) );
-      };
-      /// get one matched trigger object of a certain type by index
-      const TriggerObjectStandAlone * triggerObjectMatchByType( const trigger::TriggerObjectType triggerObjectType, const size_t idx = 0 ) const;
-      const TriggerObjectStandAlone * triggerObjectMatchByType( const unsigned triggerObjectType, const size_t idx = 0 ) const {
-        return triggerObjectMatchByType( trigger::TriggerObjectType( triggerObjectType ), idx );
-      };
-      // for backward compatibility
-      const TriggerObjectStandAlone * triggerObjectMatchByFilterID( const unsigned triggerObjectType, const size_t idx = 0 ) const {
-        return triggerObjectMatchByType( trigger::TriggerObjectType( triggerObjectType ), idx );
-      };
-      /// get all matched trigger objects from a certain collection
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByCollection( const std::string & coll ) const;
-      // for RooT command line
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByCollection( const char * coll ) const {
-        return triggerObjectMatchesByCollection( std::string( coll ) );
-      };
-      /// get one matched trigger object from a certain collection by index
-      const TriggerObjectStandAlone * triggerObjectMatchByCollection( const std::string & coll, const size_t idx = 0 ) const;
-      // for RooT command line
-      const TriggerObjectStandAlone * triggerObjectMatchByCollection( const char * coll, const size_t idx = 0 ) const {
-        return triggerObjectMatchByCollection( std::string( coll ), idx );
-      };
-      /// get all matched L1 objects used in a succeeding object combination of a certain L1 condition
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByCondition( const std::string & nameCondition ) const;
-      // for RooT command line
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByCondition( const char * nameCondition ) const {
-        return triggerObjectMatchesByCondition( std::string( nameCondition ) );
-      };
-      /// get one matched L1 object used in a succeeding object combination of a certain L1 condition by index
-      const TriggerObjectStandAlone * triggerObjectMatchByCondition( const std::string & nameCondition, const size_t idx = 0 ) const;
-      // for RooT command line
-      const TriggerObjectStandAlone * triggerObjectMatchByCondition( const char * nameCondition, const size_t idx = 0 ) const {
-        return triggerObjectMatchByCondition( std::string( nameCondition ), idx );
-      };
-      /// get all matched L1 objects used in a succeeding object combination of a condition in a certain L1 (physics) algorithm;
-      /// if 'algoCondAccepted' is set to 'true' (default), only objects used in succeeding conditions of succeeding algorithms are considered
-      /// ("firing" objects)
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByAlgorithm( const std::string & nameAlgorithm, const bool algoCondAccepted = true ) const;
-      // for RooT command line
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByAlgorithm( const char * nameAlgorithm, const bool algoCondAccepted = true ) const {
-        return triggerObjectMatchesByAlgorithm( std::string( nameAlgorithm ), algoCondAccepted );
-      };
-      // for the cut string parser
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByAlgorithm( const std::string & nameAlgorithm, const unsigned algoCondAccepted ) const {
-        return triggerObjectMatchesByAlgorithm( nameAlgorithm, bool( algoCondAccepted ) );
-      };
-      // for RooT command line and the cut string parser
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByAlgorithm( const char * nameAlgorithm, const unsigned algoCondAccepted ) const {
-        return triggerObjectMatchesByAlgorithm( std::string( nameAlgorithm ), bool( algoCondAccepted ) );
-      };
-      /// get one matched L1 object used in a succeeding object combination of a condition in a certain L1 (physics) algorithm by index;
-      /// if 'algoCondAccepted' is set to 'true' (default), only objects used in succeeding conditions of succeeding algorithms are considered
-      /// ("firing" objects)
-      const TriggerObjectStandAlone * triggerObjectMatchByAlgorithm( const std::string & nameAlgorithm, const bool algoCondAccepted = true, const size_t idx = 0 ) const;
-      // for RooT command line
-      const TriggerObjectStandAlone * triggerObjectMatchByAlgorithm( const char * nameAlgorithm, const bool algoCondAccepted = true, const size_t idx = 0 ) const {
-        return triggerObjectMatchByAlgorithm( std::string( nameAlgorithm ), algoCondAccepted, idx );
-      };
-      // for the cut string parser
-      const TriggerObjectStandAlone * triggerObjectMatchByAlgorithm( const std::string & nameAlgorithm, const unsigned algoCondAccepted, const size_t idx = 0 ) const {
-        return triggerObjectMatchByAlgorithm( nameAlgorithm, bool( algoCondAccepted ), idx );
-      };
-      // for RooT command line and the cut string parser
-      const TriggerObjectStandAlone * triggerObjectMatchByAlgorithm( const char * nameAlgorithm, const unsigned algoCondAccepted, const size_t idx = 0 ) const {
-        return triggerObjectMatchByAlgorithm( std::string( nameAlgorithm ), bool( algoCondAccepted ), idx );
-      };
-      /// get all matched HLT objects used in a certain HLT filter
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByFilter( const std::string & labelFilter ) const;
-      // for RooT command line
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByFilter( const char * labelFilter ) const {
-        return triggerObjectMatchesByFilter( std::string( labelFilter ) );
-      };
-      /// get one matched HLT object used in a certain HLT filter by index
-      const TriggerObjectStandAlone * triggerObjectMatchByFilter( const std::string & labelFilter, const size_t idx = 0 ) const;
-      // for RooT command line
-      const TriggerObjectStandAlone * triggerObjectMatchByFilter( const char * labelFilter, const size_t idx = 0 ) const {
-        return triggerObjectMatchByFilter( std::string( labelFilter ), idx );
-      };
-      /// get all matched HLT objects used in a certain HLT path;
-      /// if 'pathLastFilterAccepted' is set to 'true' (default), only objects used in the final filter of a succeeding path are considered
-      /// ("firing" objects old style only valid for single object triggers);
-      /// if 'pathL3FilterAccepted' is set to 'true' (default), only objects used in L3 filters (identified by the "saveTags" parameter being 'true')
-      /// of a succeeding path are considered ("firing" objects old style only valid for single object triggers)
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByPath( const std::string & namePath, const bool pathLastFilterAccepted = false, const bool pathL3FilterAccepted = true ) const;
-      // for RooT command line
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByPath( const char * namePath, const bool pathLastFilterAccepted = false, const bool pathL3FilterAccepted = true ) const {
-        return triggerObjectMatchesByPath( std::string( namePath ), pathLastFilterAccepted, pathL3FilterAccepted );
-      };
-      // for the cut string parser
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByPath( const std::string & namePath, const unsigned pathLastFilterAccepted, const unsigned pathL3FilterAccepted = 1 ) const {
-        return triggerObjectMatchesByPath( namePath, bool( pathLastFilterAccepted ), bool( pathL3FilterAccepted ) );
-      };
-      // for RooT command line and the cut string parser
-      const TriggerObjectStandAloneCollection triggerObjectMatchesByPath( const char * namePath, const unsigned pathLastFilterAccepted, const unsigned pathL3FilterAccepted = 1 ) const {
-        return triggerObjectMatchesByPath( std::string( namePath ), bool( pathLastFilterAccepted ), bool( pathL3FilterAccepted ) );
-      };
-      /// get one matched HLT object used in a certain HLT path by index;
-      /// if 'pathLastFilterAccepted' is set to 'true' (default), only objects used in the final filter of a succeeding path are considered
-      /// ("firing" objects, old style only valid for single object triggers);
-      /// if 'pathL3FilterAccepted' is set to 'true' (default), only objects used in L3 filters (identified by the "saveTags" parameter being 'true')
-      /// of a succeeding path are considered ("firing" objects also valid for x-triggers)
-      const TriggerObjectStandAlone * triggerObjectMatchByPath( const std::string & namePath, const bool pathLastFilterAccepted = false, const bool pathL3FilterAccepted = true, const size_t idx = 0 ) const;
-      // for RooT command line
-      const TriggerObjectStandAlone * triggerObjectMatchByPath( const char * namePath, const bool pathLastFilterAccepted = false, const bool pathL3FilterAccepted = true, const size_t idx = 0 ) const {
-        return triggerObjectMatchByPath( std::string( namePath ), pathLastFilterAccepted, pathL3FilterAccepted, idx );
-      };
-      // for the cut string parser
-      const TriggerObjectStandAlone * triggerObjectMatchByPath( const std::string & namePath, const unsigned pathLastFilterAccepted, const unsigned pathL3FilterAccepted = 1, const size_t idx = 0 ) const {
-        return triggerObjectMatchByPath( namePath, bool( pathLastFilterAccepted ), bool( pathL3FilterAccepted ), idx );
-      };
-      // for RooT command line and the cut string parser
-      const TriggerObjectStandAlone * triggerObjectMatchByPath( const char * namePath, const unsigned pathLastFilterAccepted, const unsigned pathL3FilterAccepted = 1, const size_t idx = 0 ) const {
-        return triggerObjectMatchByPath( std::string( namePath ), bool( pathLastFilterAccepted ), bool( pathL3FilterAccepted ), idx );
-      };
-      /// add a trigger match
-      void addTriggerObjectMatch( const TriggerObjectStandAlone & trigObj ) { triggerObjectMatchesEmbedded_.push_back( trigObj ); };
-      /// unpack path names of matched trigger objects (if they were packed before embedding, which is not normally the case)
-      void unpackTriggerObjectPathNames( const edm::TriggerNames &names ) {
-        for (std::vector<TriggerObjectStandAlone>::iterator it = triggerObjectMatchesEmbedded_.begin(), ed = triggerObjectMatchesEmbedded_.end(); it != ed; ++it) it->unpackPathNames(names);
-      }
+    /// Returns an efficiency given its name
+    const pat::LookupTableRecord &efficiency(const std::string &name) const;
+    /// Returns the efficiencies as <name,value> pairs (by value)
+    std::vector<std::pair<std::string, pat::LookupTableRecord> > efficiencies() const;
+    /// Returns the list of the names of the stored efficiencies
+    const std::vector<std::string> &efficiencyNames() const { return efficiencyNames_; }
+    /// Returns the list of the values of the stored efficiencies (the ordering is the same as in efficiencyNames())
+    const std::vector<pat::LookupTableRecord> &efficiencyValues() const { return efficiencyValues_; }
+    /// Store one efficiency in this item, in addition to the existing ones
+    /// If an efficiency with the same name exists, the old value is replaced by this one
+    /// Calling this method many times with names not sorted alphabetically will be slow
+    void setEfficiency(const std::string &name, const pat::LookupTableRecord &value);
 
-      /// Returns an efficiency given its name
-      const pat::LookupTableRecord       & efficiency(const std::string &name) const ;
-      /// Returns the efficiencies as <name,value> pairs (by value)
-      std::vector<std::pair<std::string,pat::LookupTableRecord> > efficiencies() const ;
-      /// Returns the list of the names of the stored efficiencies
-      const std::vector<std::string> & efficiencyNames() const { return efficiencyNames_; }
-      /// Returns the list of the values of the stored efficiencies (the ordering is the same as in efficiencyNames())
-      const std::vector<pat::LookupTableRecord> & efficiencyValues() const { return efficiencyValues_; }
-      /// Store one efficiency in this item, in addition to the existing ones
-      /// If an efficiency with the same name exists, the old value is replaced by this one
-      /// Calling this method many times with names not sorted alphabetically will be slow
-      void setEfficiency(const std::string &name, const pat::LookupTableRecord & value) ;
+    /// Get generator level particle reference (might be a transient ref if the genParticle was embedded)
+    /// If you stored multiple GenParticles, you can specify which one you want.
+    reco::GenParticleRef genParticleRef(size_t idx = 0) const {
+      if (idx >= genParticlesSize())
+        return reco::GenParticleRef();
+      return genParticleEmbedded_.empty() ? genParticleRef_[idx] : reco::GenParticleRef(&genParticleEmbedded_, idx);
+    }
+    /// Get a generator level particle reference with a given pdg id and status
+    /// If there is no MC match with that pdgId and status, it will return a null ref
+    /// Note: this might be a transient ref if the genParticle was embedded
+    /// If status == 0, only the pdgId will be checked; likewise, if pdgId == 0, only the status will be checked.
+    /// When autoCharge is set to true, and a charged reco particle is matched to a charged gen particle,
+    /// positive pdgId means 'same charge', negative pdgId means 'opposite charge';
+    /// for example, electron.genParticleById(11,0,true) will get an e^+ matched to e^+ or e^- matched to e^-,
+    /// while genParticleById(-15,0,true) will get e^+ matched to e^- or vice versa.
+    /// If a neutral reco particle is matched to a charged gen particle, the sign of the pdgId passed to getParticleById must match that of the gen particle;
+    /// for example photon.getParticleById(11) will match gamma to e^-, while genParticleById(-11) will match gamma to e^+ (pdgId=-11)
+    // implementation note: uint8_t instead of bool, because the string parser doesn't allow bool currently
+    reco::GenParticleRef genParticleById(int pdgId, int status, uint8_t autoCharge = 0) const;
 
-      /// Get generator level particle reference (might be a transient ref if the genParticle was embedded)
-      /// If you stored multiple GenParticles, you can specify which one you want.
-      reco::GenParticleRef      genParticleRef(size_t idx=0) const {
-            if (idx >= genParticlesSize()) return reco::GenParticleRef();
-            return genParticleEmbedded_.empty() ? genParticleRef_[idx] : reco::GenParticleRef(&genParticleEmbedded_, idx);
-      }
-      /// Get a generator level particle reference with a given pdg id and status
-      /// If there is no MC match with that pdgId and status, it will return a null ref
-      /// Note: this might be a transient ref if the genParticle was embedded
-      /// If status == 0, only the pdgId will be checked; likewise, if pdgId == 0, only the status will be checked.
-      /// When autoCharge is set to true, and a charged reco particle is matched to a charged gen particle,
-      /// positive pdgId means 'same charge', negative pdgId means 'opposite charge';
-      /// for example, electron.genParticleById(11,0,true) will get an e^+ matched to e^+ or e^- matched to e^-,
-      /// while genParticleById(-15,0,true) will get e^+ matched to e^- or vice versa.
-      /// If a neutral reco particle is matched to a charged gen particle, the sign of the pdgId passed to getParticleById must match that of the gen particle;
-      /// for example photon.getParticleById(11) will match gamma to e^-, while genParticleById(-11) will match gamma to e^+ (pdgId=-11)
-      // implementation note: uint8_t instead of bool, because the string parser doesn't allow bool currently
-      reco::GenParticleRef      genParticleById(int pdgId, int status, uint8_t autoCharge=0) const ;
+    /// Get generator level particle, as C++ pointer (might be 0 if the ref was null)
+    /// If you stored multiple GenParticles, you can specify which one you want.
+    const reco::GenParticle *genParticle(size_t idx = 0) const {
+      reco::GenParticleRef ref = genParticleRef(idx);
+      return ref.isNonnull() ? ref.get() : nullptr;
+    }
+    /// Number of generator level particles stored as ref or embedded
+    size_t genParticlesSize() const {
+      return genParticleEmbedded_.empty() ? genParticleRef_.size() : genParticleEmbedded_.size();
+    }
+    /// Return the list of generator level particles.
+    /// Note that the refs can be transient refs to embedded GenParticles
+    std::vector<reco::GenParticleRef> genParticleRefs() const;
 
-      /// Get generator level particle, as C++ pointer (might be 0 if the ref was null)
-      /// If you stored multiple GenParticles, you can specify which one you want.
-      const reco::GenParticle * genParticle(size_t idx=0)    const {
-            reco::GenParticleRef ref = genParticleRef(idx);
-            return ref.isNonnull() ? ref.get() : nullptr;
-      }
-      /// Number of generator level particles stored as ref or embedded
-      size_t genParticlesSize() const {
-            return genParticleEmbedded_.empty() ? genParticleRef_.size() : genParticleEmbedded_.size();
-      }
-      /// Return the list of generator level particles.
-      /// Note that the refs can be transient refs to embedded GenParticles
-      std::vector<reco::GenParticleRef> genParticleRefs() const ;
+    /// Set the generator level particle reference
+    void setGenParticleRef(const reco::GenParticleRef &ref, bool embed = false);
+    /// Add a generator level particle reference
+    /// If there is already an embedded particle, this ref will be embedded too
+    void addGenParticleRef(const reco::GenParticleRef &ref);
+    /// Set the generator level particle from a particle not in the Event (embedding it, of course)
+    void setGenParticle(const reco::GenParticle &particle);
+    /// Embed the generator level particle(s) in this PATObject
+    /// Note that generator level particles can only be all embedded or all not embedded.
+    void embedGenParticle();
 
-      /// Set the generator level particle reference
-      void setGenParticleRef(const reco::GenParticleRef &ref, bool embed=false) ;
-      /// Add a generator level particle reference
-      /// If there is already an embedded particle, this ref will be embedded too
-      void addGenParticleRef(const reco::GenParticleRef &ref) ;
-      /// Set the generator level particle from a particle not in the Event (embedding it, of course)
-      void setGenParticle( const reco::GenParticle &particle ) ;
-      /// Embed the generator level particle(s) in this PATObject
-      /// Note that generator level particles can only be all embedded or all not embedded.
-      void embedGenParticle() ;
+    /// Returns true if there was at least one overlap for this test label
+    bool hasOverlaps(const std::string &label) const;
+    /// Return the list of overlaps for one label (can be empty)
+    /// The original ordering of items is kept (usually it's by increasing deltaR from this item)
+    const reco::CandidatePtrVector &overlaps(const std::string &label) const;
+    /// Returns the labels of the overlap tests that found at least one overlap
+    const std::vector<std::string> &overlapLabels() const { return overlapLabels_; }
+    /// Sets the list of overlapping items for one label
+    /// Note that adding an empty PtrVector has no effect at all
+    /// Items within the list should already be sorted appropriately (this method won't sort them)
+    void setOverlaps(const std::string &label, const reco::CandidatePtrVector &overlaps);
 
-      /// Returns true if there was at least one overlap for this test label
-      bool hasOverlaps(const std::string &label) const ;
-      /// Return the list of overlaps for one label (can be empty)
-      /// The original ordering of items is kept (usually it's by increasing deltaR from this item)
-      const reco::CandidatePtrVector & overlaps(const std::string &label) const ;
-      /// Returns the labels of the overlap tests that found at least one overlap
-      const std::vector<std::string> & overlapLabels() const { return overlapLabels_; }
-      /// Sets the list of overlapping items for one label
-      /// Note that adding an empty PtrVector has no effect at all
-      /// Items within the list should already be sorted appropriately (this method won't sort them)
-      void setOverlaps(const std::string &label, const reco::CandidatePtrVector & overlaps) ;
+    /// Returns user-defined data. Returns NULL if the data is not present, or not of type T.
+    template <typename T>
+    const T *userData(const std::string &key) const {
+      const pat::UserData *data = userDataObject_(key);
+      return (data != nullptr ? data->template get<T>() : nullptr);
+    }
+    /// Check if user data with a specific type is present
+    bool hasUserData(const std::string &key) const { return (userDataObject_(key) != nullptr); }
+    /// Get human-readable type of user data object, for debugging
+    const std::string &userDataObjectType(const std::string &key) const {
+      const pat::UserData *data = userDataObject_(key);
+      return (data != nullptr ? data->typeName() : pat_statics::EMPTY_STR);
+    };
+    /// Get list of user data object names
+    const std::vector<std::string> &userDataNames() const { return userDataLabels_; }
 
-      /// Returns user-defined data. Returns NULL if the data is not present, or not of type T.
-      template<typename T> const T * userData(const std::string &key) const {
-          const pat::UserData * data = userDataObject_(key);
-          return (data != nullptr ? data->template get<T>() : nullptr);
+    /// Get the data as a void *, for CINT usage.
+    /// COMPLETELY UNSUPPORTED, USE ONLY FOR DEBUGGING
+    const void *userDataBare(const std::string &key) const {
+      const pat::UserData *data = userDataObject_(key);
+      return (data != nullptr ? data->bareData() : nullptr);
+    }
 
-      }
-      /// Check if user data with a specific type is present
-      bool hasUserData(const std::string &key) const {
-          return (userDataObject_(key) != nullptr);
-      }
-      /// Get human-readable type of user data object, for debugging
-      const std::string & userDataObjectType(const std::string &key) const {
-          const pat::UserData * data = userDataObject_(key);
-          return (data != nullptr ? data->typeName() : pat_statics::EMPTY_STR);
-      };
-      /// Get list of user data object names
-      const std::vector<std::string> & userDataNames() const  { return userDataLabels_; }
+    /// Set user-defined data
+    /// Needs dictionaries for T and for pat::UserHolder<T>,
+    /// and it will throw exception if they're missing,
+    /// unless transientOnly is set to true
+    template <typename T>
+    void addUserData(const std::string &label, const T &data, bool transientOnly = false, bool overwrite = false) {
+      std::unique_ptr<pat::UserData> made(pat::UserData::make<T>(data, transientOnly));
+      addUserDataObject_(label, std::move(made), overwrite);
+    }
 
-      /// Get the data as a void *, for CINT usage.
-      /// COMPLETELY UNSUPPORTED, USE ONLY FOR DEBUGGING
-      const void * userDataBare(const std::string &key) const {
-          const pat::UserData * data = userDataObject_(key);
-          return (data != nullptr ? data->bareData() : nullptr);
-      }
+    /// Set user-defined data. To be used only to fill from ValueMap<Ptr<UserData>>
+    /// Do not use unless you know what you are doing.
+    void addUserDataFromPtr(const std::string &label, const edm::Ptr<pat::UserData> &data, bool overwrite = false) {
+      std::unique_ptr<pat::UserData> cloned(data->clone());
+      addUserDataObject_(label, std::move(cloned), overwrite);
+    }
 
-      /// Set user-defined data
-      /// Needs dictionaries for T and for pat::UserHolder<T>,
-      /// and it will throw exception if they're missing,
-      /// unless transientOnly is set to true
-      template<typename T>
-      void addUserData( const std::string & label, const T & data, bool transientOnly=false, bool overwrite=false ) {
-        std::unique_ptr<pat::UserData> made(pat::UserData::make<T>(data, transientOnly));
-        addUserDataObject_( label, std::move(made), overwrite );
-      }
+    /// Get user-defined float
+    /// Note: throws if the key is not found; you can check if the key exists with 'hasUserFloat' method.
+    float userFloat(const std::string &key) const;
+    /// return a range of values corresponding to key
+    std::vector<float> userFloatRange(const std::string &key) const;
+    /// a CINT-friendly interface
+    float userFloat(const char *key) const { return userFloat(std::string(key)); }
 
-      /// Set user-defined data. To be used only to fill from ValueMap<Ptr<UserData>>
-      /// Do not use unless you know what you are doing.
-      void addUserDataFromPtr( const std::string & label, const edm::Ptr<pat::UserData> & data, bool overwrite=false ) {
-        std::unique_ptr<pat::UserData> cloned(data->clone());
-        addUserDataObject_( label, std::move(cloned), overwrite );
-      }
+    /// Set user-defined float
+    void addUserFloat(const std::string &label, float data, const bool overwrite = false);
+    /// Get list of user-defined float names
+    const std::vector<std::string> &userFloatNames() const { return userFloatLabels_; }
+    /// Return true if there is a user-defined float with a given name
+    bool hasUserFloat(const std::string &key) const {
+      auto it = std::lower_bound(userFloatLabels_.cbegin(), userFloatLabels_.cend(), key);
+      return (it != userFloatLabels_.cend() && *it == key);
+    }
+    /// a CINT-friendly interface
+    bool hasUserFloat(const char *key) const { return hasUserFloat(std::string(key)); }
 
-      /// Get user-defined float
-      /// Note: throws if the key is not found; you can check if the key exists with 'hasUserFloat' method.
-      float userFloat( const std::string & key ) const;
-      /// return a range of values corresponding to key
-      std::vector<float> userFloatRange( const std::string& key ) const;
-      /// a CINT-friendly interface
-      float userFloat( const char* key ) const { return userFloat( std::string(key) ); }
-      
-      /// Set user-defined float
-      void addUserFloat( const  std::string & label, float data, const bool overwrite = false );
-      /// Get list of user-defined float names
-      const std::vector<std::string> & userFloatNames() const  { return userFloatLabels_; }
-      /// Return true if there is a user-defined float with a given name
-      bool hasUserFloat( const std::string & key ) const {
-        auto it = std::lower_bound(userFloatLabels_.cbegin(), userFloatLabels_.cend(), key); 
-        return ( it != userFloatLabels_.cend() && *it == key );
-      }
-      /// a CINT-friendly interface
-      bool hasUserFloat( const char* key ) const {return hasUserFloat( std::string(key) );}
+    /// Get user-defined int
+    /// Note: throws if the key is not found; you can check if the key exists with 'hasUserInt' method.
+    int32_t userInt(const std::string &key) const;
+    /// returns a range of values corresponding to key
+    std::vector<int> userIntRange(const std::string &key) const;
+    /// Set user-defined int
+    void addUserInt(const std::string &label, int32_t data, const bool overwrite = false);
+    /// Get list of user-defined int names
+    const std::vector<std::string> &userIntNames() const { return userIntLabels_; }
+    /// Return true if there is a user-defined int with a given name
+    bool hasUserInt(const std::string &key) const {
+      auto it = std::lower_bound(userIntLabels_.cbegin(), userIntLabels_.cend(), key);
+      return (it != userIntLabels_.cend() && *it == key);
+    }
 
-      /// Get user-defined int
-      /// Note: throws if the key is not found; you can check if the key exists with 'hasUserInt' method.
-      int32_t userInt( const std::string & key ) const;
-      /// returns a range of values corresponding to key
-      std::vector<int> userIntRange( const std::string& key ) const;
-      /// Set user-defined int
-      void addUserInt( const std::string & label,  int32_t data, const bool overwrite = false );
-      /// Get list of user-defined int names
-      const std::vector<std::string> & userIntNames() const  { return userIntLabels_; }
-      /// Return true if there is a user-defined int with a given name
-      bool hasUserInt( const std::string & key ) const {
-        auto it = std::lower_bound(userIntLabels_.cbegin(), userIntLabels_.cend(), key);
-        return ( it != userIntLabels_.cend() && *it == key );
-      }
+    /// Get user-defined candidate ptr
+    /// Note: it will a null pointer if the key is not found; you can check if the key exists with 'hasUserInt' method.
+    reco::CandidatePtr userCand(const std::string &key) const;
+    /// Set user-defined int
+    void addUserCand(const std::string &label, const reco::CandidatePtr &data, const bool overwrite = false);
+    /// Get list of user-defined cand names
+    const std::vector<std::string> &userCandNames() const { return userCandLabels_; }
+    /// Return true if there is a user-defined int with a given name
+    bool hasUserCand(const std::string &key) const {
+      auto it = std::lower_bound(userCandLabels_.cbegin(), userCandLabels_.cend(), key);
+      return (it != userCandLabels_.cend() && *it == key);
+    }
 
-      /// Get user-defined candidate ptr
-      /// Note: it will a null pointer if the key is not found; you can check if the key exists with 'hasUserInt' method.
-      reco::CandidatePtr userCand( const std::string & key ) const;
-      /// Set user-defined int
-      void addUserCand( const std::string & label,  const reco::CandidatePtr & data, const bool overwrite = false );
-      /// Get list of user-defined cand names
-      const std::vector<std::string> & userCandNames() const  { return userCandLabels_; }
-      /// Return true if there is a user-defined int with a given name
-      bool hasUserCand( const std::string & key ) const {
-        auto it = std::lower_bound(userCandLabels_.cbegin(), userCandLabels_.cend(), key);
-        return ( it != userCandLabels_.cend() && *it == key );
-      }
+    // === New Kinematic Resolutions
+    /// Return the kinematic resolutions associated to this object, possibly specifying a label for it.
+    /// If not present, it will throw an exception.
+    const pat::CandKinResolution &getKinResolution(const std::string &label = "") const;
 
-      // === New Kinematic Resolutions
-      /// Return the kinematic resolutions associated to this object, possibly specifying a label for it.
-      /// If not present, it will throw an exception.
-      const pat::CandKinResolution & getKinResolution(const std::string &label="") const ;
+    /// Check if the kinematic resolutions are stored into this object (possibly specifying a label for them)
+    bool hasKinResolution(const std::string &label = "") const;
 
-      /// Check if the kinematic resolutions are stored into this object (possibly specifying a label for them)
-      bool hasKinResolution(const std::string &label="") const ;
+    /// Add a kinematic resolution to this object (possibly with a label)
+    void setKinResolution(const pat::CandKinResolution &resol, const std::string &label = "");
 
-      /// Add a kinematic resolution to this object (possibly with a label)
-      void setKinResolution(const pat::CandKinResolution &resol, const std::string &label="") ;
+    /// Resolution on eta, possibly with a label to specify which resolution to use
+    double resolEta(const std::string &label = "") const { return getKinResolution(label).resolEta(this->p4()); }
 
-      /// Resolution on eta, possibly with a label to specify which resolution to use
-      double resolEta(const std::string &label="") const { return getKinResolution(label).resolEta(this->p4()); }
+    /// Resolution on theta, possibly with a label to specify which resolution to use
+    double resolTheta(const std::string &label = "") const { return getKinResolution(label).resolTheta(this->p4()); }
 
-      /// Resolution on theta, possibly with a label to specify which resolution to use
-      double resolTheta(const std::string &label="") const { return getKinResolution(label).resolTheta(this->p4()); }
+    /// Resolution on phi, possibly with a label to specify which resolution to use
+    double resolPhi(const std::string &label = "") const { return getKinResolution(label).resolPhi(this->p4()); }
 
-      /// Resolution on phi, possibly with a label to specify which resolution to use
-      double resolPhi(const std::string &label="") const { return getKinResolution(label).resolPhi(this->p4()); }
+    /// Resolution on energy, possibly with a label to specify which resolution to use
+    double resolE(const std::string &label = "") const { return getKinResolution(label).resolE(this->p4()); }
 
-      /// Resolution on energy, possibly with a label to specify which resolution to use
-      double resolE(const std::string &label="") const { return getKinResolution(label).resolE(this->p4()); }
+    /// Resolution on et, possibly with a label to specify which resolution to use
+    double resolEt(const std::string &label = "") const { return getKinResolution(label).resolEt(this->p4()); }
 
-      /// Resolution on et, possibly with a label to specify which resolution to use
-      double resolEt(const std::string &label="") const { return getKinResolution(label).resolEt(this->p4()); }
+    /// Resolution on p, possibly with a label to specify which resolution to use
+    double resolP(const std::string &label = "") const { return getKinResolution(label).resolP(this->p4()); }
 
-      /// Resolution on p, possibly with a label to specify which resolution to use
-      double resolP(const std::string &label="") const { return getKinResolution(label).resolP(this->p4()); }
+    /// Resolution on pt, possibly with a label to specify which resolution to use
+    double resolPt(const std::string &label = "") const { return getKinResolution(label).resolPt(this->p4()); }
 
-      /// Resolution on pt, possibly with a label to specify which resolution to use
-      double resolPt(const std::string &label="") const { return getKinResolution(label).resolPt(this->p4()); }
+    /// Resolution on 1/p, possibly with a label to specify which resolution to use
+    double resolPInv(const std::string &label = "") const { return getKinResolution(label).resolPInv(this->p4()); }
 
-      /// Resolution on 1/p, possibly with a label to specify which resolution to use
-      double resolPInv(const std::string &label="") const { return getKinResolution(label).resolPInv(this->p4()); }
+    /// Resolution on px, possibly with a label to specify which resolution to use
+    double resolPx(const std::string &label = "") const { return getKinResolution(label).resolPx(this->p4()); }
 
-      /// Resolution on px, possibly with a label to specify which resolution to use
-      double resolPx(const std::string &label="") const { return getKinResolution(label).resolPx(this->p4()); }
+    /// Resolution on py, possibly with a label to specify which resolution to use
+    double resolPy(const std::string &label = "") const { return getKinResolution(label).resolPy(this->p4()); }
 
-      /// Resolution on py, possibly with a label to specify which resolution to use
-      double resolPy(const std::string &label="") const { return getKinResolution(label).resolPy(this->p4()); }
+    /// Resolution on pz, possibly with a label to specify which resolution to use
+    double resolPz(const std::string &label = "") const { return getKinResolution(label).resolPz(this->p4()); }
 
-      /// Resolution on pz, possibly with a label to specify which resolution to use
-      double resolPz(const std::string &label="") const { return getKinResolution(label).resolPz(this->p4()); }
+    /// Resolution on mass, possibly with a label to specify which resolution to use
+    /// Note: this will be zero if a mass-constrained parametrization is used for this object
+    double resolM(const std::string &label = "") const { return getKinResolution(label).resolM(this->p4()); }
 
-      /// Resolution on mass, possibly with a label to specify which resolution to use
-      /// Note: this will be zero if a mass-constrained parametrization is used for this object
-      double resolM(const std::string &label="") const { return getKinResolution(label).resolM(this->p4()); }
+  protected:
+    // reference back to the original object
+    edm::Ptr<reco::Candidate> refToOrig_;
 
+    /// vector of trigger matches
+    TriggerObjectStandAloneCollection triggerObjectMatchesEmbedded_;
 
+    /// vector of the efficiencies (values)
+    std::vector<pat::LookupTableRecord> efficiencyValues_;
+    /// vector of the efficiencies (names)
+    std::vector<std::string> efficiencyNames_;
 
-    protected:
-      // reference back to the original object
-      edm::Ptr<reco::Candidate> refToOrig_;
+    /// Reference to a generator level particle
+    std::vector<reco::GenParticleRef> genParticleRef_;
+    /// vector to hold an embedded generator level particle
+    std::vector<reco::GenParticle> genParticleEmbedded_;
 
-      /// vector of trigger matches
-      TriggerObjectStandAloneCollection triggerObjectMatchesEmbedded_;
+    /// Overlapping test labels (only if there are any overlaps)
+    std::vector<std::string> overlapLabels_;
+    /// Overlapping items (sorted by distance)
+    std::vector<reco::CandidatePtrVector> overlapItems_;
 
-      /// vector of the efficiencies (values)
-      std::vector<pat::LookupTableRecord> efficiencyValues_;
-      /// vector of the efficiencies (names)
-      std::vector<std::string> efficiencyNames_;
+    /// User data object
+    std::vector<std::string> userDataLabels_;
+    pat::UserDataCollection userDataObjects_;
+    // User float values
+    std::vector<std::string> userFloatLabels_;
+    std::vector<float> userFloats_;
+    // User int values
+    std::vector<std::string> userIntLabels_;
+    std::vector<int32_t> userInts_;
+    // User candidate matches
+    std::vector<std::string> userCandLabels_;
+    std::vector<reco::CandidatePtr> userCands_;
 
-      /// Reference to a generator level particle
-      std::vector<reco::GenParticleRef> genParticleRef_;
-      /// vector to hold an embedded generator level particle
-      std::vector<reco::GenParticle>    genParticleEmbedded_;
+    /// Kinematic resolutions.
+    std::vector<pat::CandKinResolution> kinResolutions_;
+    /// Labels for the kinematic resolutions.
+    /// if (kinResolutions_.size() == kinResolutionLabels_.size()+1), then the first resolution has no label.
+    std::vector<std::string> kinResolutionLabels_;
 
-      /// Overlapping test labels (only if there are any overlaps)
-      std::vector<std::string> overlapLabels_;
-      /// Overlapping items (sorted by distance)
-      std::vector<reco::CandidatePtrVector> overlapItems_;
+    void addUserDataObject_(const std::string &label, std::unique_ptr<pat::UserData> value, bool overwrite = false);
 
-      /// User data object
-      std::vector<std::string>      userDataLabels_;
-      pat::UserDataCollection       userDataObjects_;
-      // User float values
-      std::vector<std::string>      userFloatLabels_;
-      std::vector<float>            userFloats_;
-      // User int values
-      std::vector<std::string>      userIntLabels_;
-      std::vector<int32_t>          userInts_;
-      // User candidate matches
-      std::vector<std::string>        userCandLabels_;
-      std::vector<reco::CandidatePtr> userCands_;
-
-      /// Kinematic resolutions.
-      std::vector<pat::CandKinResolution> kinResolutions_;
-      /// Labels for the kinematic resolutions.
-      /// if (kinResolutions_.size() == kinResolutionLabels_.size()+1), then the first resolution has no label.
-      std::vector<std::string>            kinResolutionLabels_;
-
-      void addUserDataObject_( const std::string & label, std::unique_ptr<pat::UserData> value, bool overwrite = false ) ;
-
-    private:
-      const pat::UserData *  userDataObject_(const std::string &key) const ;
+  private:
+    const pat::UserData *userDataObject_(const std::string &key) const;
   };
 
+  template <class ObjectType>
+  PATObject<ObjectType>::PATObject() {}
 
-  template <class ObjectType> PATObject<ObjectType>::PATObject() {
-  }
+  template <class ObjectType>
+  PATObject<ObjectType>::PATObject(const ObjectType &obj) : ObjectType(obj), refToOrig_() {}
 
-  template <class ObjectType> PATObject<ObjectType>::PATObject(const ObjectType & obj) :
-    ObjectType(obj),
-    refToOrig_() {
-  }
+  template <class ObjectType>
+  PATObject<ObjectType>::PATObject(const edm::RefToBase<ObjectType> &ref)
+      : ObjectType(*ref),
+        refToOrig_(ref.id(),
+                   ref.get(),
+                   ref.key())  // correct way to convert RefToBase=>Ptr, if ref is guaranteed to be available
+                               // which happens to be true, otherwise the line before this throws ex. already
+  {}
 
-  template <class ObjectType> PATObject<ObjectType>::PATObject(const edm::RefToBase<ObjectType> & ref) :
-    ObjectType(*ref),
-    refToOrig_(ref.id(), ref.get(), ref.key()) // correct way to convert RefToBase=>Ptr, if ref is guaranteed to be available
-                                               // which happens to be true, otherwise the line before this throws ex. already
-      {
-      }
+  template <class ObjectType>
+  PATObject<ObjectType>::PATObject(const edm::Ptr<ObjectType> &ref) : ObjectType(*ref), refToOrig_(ref) {}
 
-  template <class ObjectType> PATObject<ObjectType>::PATObject(const edm::Ptr<ObjectType> & ref) :
-    ObjectType(*ref),
-    refToOrig_(ref) {
-  }
-
-  template <class ObjectType> const reco::Candidate * PATObject<ObjectType>::originalObject() const {
+  template <class ObjectType>
+  const reco::Candidate *PATObject<ObjectType>::originalObject() const {
     if (refToOrig_.isNull()) {
       // this object was not produced from a reference, so no link to the
       // original object exists -> return a 0-pointer
       return nullptr;
     } else if (!refToOrig_.isAvailable()) {
-      throw edm::Exception(edm::errors::ProductNotFound) << "The original collection from which this PAT object was made is not present any more in the event, hence you cannot access the originating object anymore.";
+      throw edm::Exception(edm::errors::ProductNotFound)
+          << "The original collection from which this PAT object was made is not present any more in the event, hence "
+             "you cannot access the originating object anymore.";
     } else {
       return refToOrig_.get();
     }
   }
 
   template <class ObjectType>
-  const edm::Ptr<reco::Candidate> & PATObject<ObjectType>::originalObjectRef() const { return refToOrig_; }
+  const edm::Ptr<reco::Candidate> &PATObject<ObjectType>::originalObjectRef() const {
+    return refToOrig_;
+  }
 
   template <class ObjectType>
-  const TriggerObjectStandAlone * PATObject<ObjectType>::triggerObjectMatch( const size_t idx ) const {
-    if ( idx >= triggerObjectMatches().size() ) return nullptr;
-    TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, idx );
+  const TriggerObjectStandAlone *PATObject<ObjectType>::triggerObjectMatch(const size_t idx) const {
+    if (idx >= triggerObjectMatches().size())
+      return nullptr;
+    TriggerObjectStandAloneRef ref(&triggerObjectMatchesEmbedded_, idx);
     return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByType( const trigger::TriggerObjectType triggerObjectType ) const {
+  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByType(
+      const trigger::TriggerObjectType triggerObjectType) const {
     TriggerObjectStandAloneCollection matches;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasTriggerObjectType( triggerObjectType ) ) matches.push_back( *( triggerObjectMatch( i ) ) );
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != 0 && triggerObjectMatch(i)->hasTriggerObjectType(triggerObjectType))
+        matches.push_back(*(triggerObjectMatch(i)));
     }
     return matches;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAlone * PATObject<ObjectType>::triggerObjectMatchByType( const trigger::TriggerObjectType triggerObjectType, const size_t idx ) const {
-    std::vector< size_t > refs;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != nullptr && triggerObjectMatch( i )->hasTriggerObjectType( triggerObjectType ) ) refs.push_back( i );
+  const TriggerObjectStandAlone *PATObject<ObjectType>::triggerObjectMatchByType(
+      const trigger::TriggerObjectType triggerObjectType, const size_t idx) const {
+    std::vector<size_t> refs;
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != nullptr && triggerObjectMatch(i)->hasTriggerObjectType(triggerObjectType))
+        refs.push_back(i);
     }
-    if ( idx >= refs.size() ) return nullptr;
-    TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
+    if (idx >= refs.size())
+      return nullptr;
+    TriggerObjectStandAloneRef ref(&triggerObjectMatchesEmbedded_, refs.at(idx));
     return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByCollection( const std::string & coll ) const {
+  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByCollection(
+      const std::string &coll) const {
     TriggerObjectStandAloneCollection matches;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasCollection( coll ) ) matches.push_back( *( triggerObjectMatch( i ) ) );
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != 0 && triggerObjectMatch(i)->hasCollection(coll))
+        matches.push_back(*(triggerObjectMatch(i)));
     }
     return matches;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAlone * PATObject<ObjectType>::triggerObjectMatchByCollection( const std::string & coll, const size_t idx ) const {
-    std::vector< size_t > refs;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasCollection( coll ) ) {
-        refs.push_back( i );
+  const TriggerObjectStandAlone *PATObject<ObjectType>::triggerObjectMatchByCollection(const std::string &coll,
+                                                                                       const size_t idx) const {
+    std::vector<size_t> refs;
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != 0 && triggerObjectMatch(i)->hasCollection(coll)) {
+        refs.push_back(i);
       }
     }
-    if ( idx >= refs.size() ) return nullptr;
-    TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
+    if (idx >= refs.size())
+      return nullptr;
+    TriggerObjectStandAloneRef ref(&triggerObjectMatchesEmbedded_, refs.at(idx));
     return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByCondition( const std::string & nameCondition ) const {
+  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByCondition(
+      const std::string &nameCondition) const {
     TriggerObjectStandAloneCollection matches;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasConditionName( nameCondition ) ) matches.push_back( *( triggerObjectMatch( i ) ) );
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != 0 && triggerObjectMatch(i)->hasConditionName(nameCondition))
+        matches.push_back(*(triggerObjectMatch(i)));
     }
     return matches;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAlone * PATObject<ObjectType>::triggerObjectMatchByCondition( const std::string & nameCondition, const size_t idx ) const {
-    std::vector< size_t > refs;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasConditionName( nameCondition ) ) refs.push_back( i );
+  const TriggerObjectStandAlone *PATObject<ObjectType>::triggerObjectMatchByCondition(const std::string &nameCondition,
+                                                                                      const size_t idx) const {
+    std::vector<size_t> refs;
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != 0 && triggerObjectMatch(i)->hasConditionName(nameCondition))
+        refs.push_back(i);
     }
-    if ( idx >= refs.size() ) return nullptr;
-    TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
+    if (idx >= refs.size())
+      return nullptr;
+    TriggerObjectStandAloneRef ref(&triggerObjectMatchesEmbedded_, refs.at(idx));
     return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByAlgorithm( const std::string & nameAlgorithm, const bool algoCondAccepted ) const {
+  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByAlgorithm(
+      const std::string &nameAlgorithm, const bool algoCondAccepted) const {
     TriggerObjectStandAloneCollection matches;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasAlgorithmName( nameAlgorithm, algoCondAccepted ) ) matches.push_back( *( triggerObjectMatch( i ) ) );
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != 0 && triggerObjectMatch(i)->hasAlgorithmName(nameAlgorithm, algoCondAccepted))
+        matches.push_back(*(triggerObjectMatch(i)));
     }
     return matches;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAlone * PATObject<ObjectType>::triggerObjectMatchByAlgorithm( const std::string & nameAlgorithm, const bool algoCondAccepted, const size_t idx ) const {
-    std::vector< size_t > refs;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasAlgorithmName( nameAlgorithm, algoCondAccepted ) ) refs.push_back( i );
+  const TriggerObjectStandAlone *PATObject<ObjectType>::triggerObjectMatchByAlgorithm(const std::string &nameAlgorithm,
+                                                                                      const bool algoCondAccepted,
+                                                                                      const size_t idx) const {
+    std::vector<size_t> refs;
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != 0 && triggerObjectMatch(i)->hasAlgorithmName(nameAlgorithm, algoCondAccepted))
+        refs.push_back(i);
     }
-    if ( idx >= refs.size() ) return nullptr;
-    TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
+    if (idx >= refs.size())
+      return nullptr;
+    TriggerObjectStandAloneRef ref(&triggerObjectMatchesEmbedded_, refs.at(idx));
     return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByFilter( const std::string & labelFilter ) const {
+  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByFilter(
+      const std::string &labelFilter) const {
     TriggerObjectStandAloneCollection matches;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasFilterLabel( labelFilter ) ) matches.push_back( *( triggerObjectMatch( i ) ) );
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != 0 && triggerObjectMatch(i)->hasFilterLabel(labelFilter))
+        matches.push_back(*(triggerObjectMatch(i)));
     }
     return matches;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAlone * PATObject<ObjectType>::triggerObjectMatchByFilter( const std::string & labelFilter, const size_t idx ) const {
-    std::vector< size_t > refs;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasFilterLabel( labelFilter ) ) refs.push_back( i );
+  const TriggerObjectStandAlone *PATObject<ObjectType>::triggerObjectMatchByFilter(const std::string &labelFilter,
+                                                                                   const size_t idx) const {
+    std::vector<size_t> refs;
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != 0 && triggerObjectMatch(i)->hasFilterLabel(labelFilter))
+        refs.push_back(i);
     }
-    if ( idx >= refs.size() ) return nullptr;
-    TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
+    if (idx >= refs.size())
+      return nullptr;
+    TriggerObjectStandAloneRef ref(&triggerObjectMatchesEmbedded_, refs.at(idx));
     return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByPath( const std::string & namePath, const bool pathLastFilterAccepted, const bool pathL3FilterAccepted ) const {
+  const TriggerObjectStandAloneCollection PATObject<ObjectType>::triggerObjectMatchesByPath(
+      const std::string &namePath, const bool pathLastFilterAccepted, const bool pathL3FilterAccepted) const {
     TriggerObjectStandAloneCollection matches;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != nullptr && triggerObjectMatch( i )->hasPathName( namePath, pathLastFilterAccepted, pathL3FilterAccepted ) ) matches.push_back( *( triggerObjectMatch( i ) ) );
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != nullptr &&
+          triggerObjectMatch(i)->hasPathName(namePath, pathLastFilterAccepted, pathL3FilterAccepted))
+        matches.push_back(*(triggerObjectMatch(i)));
     }
     return matches;
   }
 
   template <class ObjectType>
-  const TriggerObjectStandAlone * PATObject<ObjectType>::triggerObjectMatchByPath( const std::string & namePath, const bool pathLastFilterAccepted, const bool pathL3FilterAccepted, const size_t idx ) const {
-    std::vector< size_t > refs;
-    for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != nullptr && triggerObjectMatch( i )->hasPathName( namePath, pathLastFilterAccepted, pathL3FilterAccepted ) ) refs.push_back( i );
+  const TriggerObjectStandAlone *PATObject<ObjectType>::triggerObjectMatchByPath(const std::string &namePath,
+                                                                                 const bool pathLastFilterAccepted,
+                                                                                 const bool pathL3FilterAccepted,
+                                                                                 const size_t idx) const {
+    std::vector<size_t> refs;
+    for (size_t i = 0; i < triggerObjectMatches().size(); ++i) {
+      if (triggerObjectMatch(i) != nullptr &&
+          triggerObjectMatch(i)->hasPathName(namePath, pathLastFilterAccepted, pathL3FilterAccepted))
+        refs.push_back(i);
     }
-    if ( idx >= refs.size() ) return nullptr;
-    TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
+    if (idx >= refs.size())
+      return nullptr;
+    TriggerObjectStandAloneRef ref(&triggerObjectMatchesEmbedded_, refs.at(idx));
     return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
-  const pat::LookupTableRecord &
-  PATObject<ObjectType>::efficiency(const std::string &name) const {
+  const pat::LookupTableRecord &PATObject<ObjectType>::efficiency(const std::string &name) const {
     // find the name in the (sorted) list of names
     auto it = std::lower_bound(efficiencyNames_.cbegin(), efficiencyNames_.cend(), name);
     if ((it == efficiencyNames_.end()) || (*it != name)) {
-        throw cms::Exception("Invalid Label") << "There is no efficiency with name '" << name << "' in this PAT Object\n";
+      throw cms::Exception("Invalid Label") << "There is no efficiency with name '" << name << "' in this PAT Object\n";
     }
-    return efficiencyValues_[std::distance(efficiencyNames_.cbegin(),it)];
+    return efficiencyValues_[std::distance(efficiencyNames_.cbegin(), it)];
   }
 
   template <class ObjectType>
-  std::vector<std::pair<std::string,pat::LookupTableRecord> >
-  PATObject<ObjectType>::efficiencies() const {
-    std::vector<std::pair<std::string,pat::LookupTableRecord> > ret;
+  std::vector<std::pair<std::string, pat::LookupTableRecord> > PATObject<ObjectType>::efficiencies() const {
+    std::vector<std::pair<std::string, pat::LookupTableRecord> > ret;
     std::vector<std::string>::const_iterator itn = efficiencyNames_.begin(), edn = efficiencyNames_.end();
     std::vector<pat::LookupTableRecord>::const_iterator itv = efficiencyValues_.begin();
-    for ( ; itn != edn; ++itn, ++itv) {
-        ret.emplace_back( *itn, *itv);
+    for (; itn != edn; ++itn, ++itv) {
+      ret.emplace_back(*itn, *itv);
     }
     return ret;
   }
 
   template <class ObjectType>
-  void PATObject<ObjectType>::setEfficiency(const std::string &name, const pat::LookupTableRecord & value) {
+  void PATObject<ObjectType>::setEfficiency(const std::string &name, const pat::LookupTableRecord &value) {
     // look for the name, or to the place where we can insert it without violating the alphabetic order
     auto it = std::lower_bound(efficiencyNames_.begin(), efficiencyNames_.end(), name);
-    const auto dist = std::distance(efficiencyNames_.begin(),it);
-    if (it == efficiencyNames_.end()) { // insert at the end
-        efficiencyNames_.push_back(name);
-        efficiencyValues_.push_back(value);
-    } else if (*it == name) {           // replace existing
-        efficiencyValues_[dist] = value;
-    } else {                            // insert in the middle :-(
-        efficiencyNames_. insert(it, name);
-        efficiencyValues_.insert( efficiencyValues_.begin() + dist, value );
+    const auto dist = std::distance(efficiencyNames_.begin(), it);
+    if (it == efficiencyNames_.end()) {  // insert at the end
+      efficiencyNames_.push_back(name);
+      efficiencyValues_.push_back(value);
+    } else if (*it == name) {  // replace existing
+      efficiencyValues_[dist] = value;
+    } else {  // insert in the middle :-(
+      efficiencyNames_.insert(it, name);
+      efficiencyValues_.insert(efficiencyValues_.begin() + dist, value);
     }
   }
 
   template <class ObjectType>
   void PATObject<ObjectType>::setGenParticleRef(const reco::GenParticleRef &ref, bool embed) {
-          genParticleRef_ = std::vector<reco::GenParticleRef>(1,ref);
-          genParticleEmbedded_.clear();
-          if (embed) embedGenParticle();
+    genParticleRef_ = std::vector<reco::GenParticleRef>(1, ref);
+    genParticleEmbedded_.clear();
+    if (embed)
+      embedGenParticle();
   }
 
   template <class ObjectType>
   void PATObject<ObjectType>::addGenParticleRef(const reco::GenParticleRef &ref) {
-      if (!genParticleEmbedded_.empty()) { // we're embedding
-          if (ref.isNonnull()) genParticleEmbedded_.push_back(*ref);
-      } else {
-          genParticleRef_.push_back(ref);
-      }
+    if (!genParticleEmbedded_.empty()) {  // we're embedding
+      if (ref.isNonnull())
+        genParticleEmbedded_.push_back(*ref);
+    } else {
+      genParticleRef_.push_back(ref);
+    }
   }
 
   template <class ObjectType>
-  void PATObject<ObjectType>::setGenParticle( const reco::GenParticle &particle ) {
-      genParticleEmbedded_.clear();
-      genParticleEmbedded_.push_back(particle);
-      genParticleRef_.clear();
+  void PATObject<ObjectType>::setGenParticle(const reco::GenParticle &particle) {
+    genParticleEmbedded_.clear();
+    genParticleEmbedded_.push_back(particle);
+    genParticleRef_.clear();
   }
 
   template <class ObjectType>
   void PATObject<ObjectType>::embedGenParticle() {
-      genParticleEmbedded_.clear();
-      for (std::vector<reco::GenParticleRef>::const_iterator it = genParticleRef_.begin(); it != genParticleRef_.end(); ++it) {
-          if (it->isNonnull()) genParticleEmbedded_.push_back(**it);
-      }
-      genParticleRef_.clear();
+    genParticleEmbedded_.clear();
+    for (std::vector<reco::GenParticleRef>::const_iterator it = genParticleRef_.begin(); it != genParticleRef_.end();
+         ++it) {
+      if (it->isNonnull())
+        genParticleEmbedded_.push_back(**it);
+    }
+    genParticleRef_.clear();
   }
 
   template <class ObjectType>
   std::vector<reco::GenParticleRef> PATObject<ObjectType>::genParticleRefs() const {
-        if (genParticleEmbedded_.empty()) return genParticleRef_;
-        std::vector<reco::GenParticleRef> ret(genParticleEmbedded_.size());
-        for (size_t i = 0, n = ret.size(); i < n; ++i) {
-            ret[i] = reco::GenParticleRef(&genParticleEmbedded_, i);
-        }
-        return ret;
+    if (genParticleEmbedded_.empty())
+      return genParticleRef_;
+    std::vector<reco::GenParticleRef> ret(genParticleEmbedded_.size());
+    for (size_t i = 0, n = ret.size(); i < n; ++i) {
+      ret[i] = reco::GenParticleRef(&genParticleEmbedded_, i);
+    }
+    return ret;
   }
 
   template <class ObjectType>
   reco::GenParticleRef PATObject<ObjectType>::genParticleById(int pdgId, int status, uint8_t autoCharge) const {
-        // get a vector, avoiding an unneeded copy if there is no embedding
-        const std::vector<reco::GenParticleRef> & vec = (genParticleEmbedded_.empty() ? genParticleRef_ : genParticleRefs());
-        for (std::vector<reco::GenParticleRef>::const_iterator ref = vec.begin(), end = vec.end(); ref != end; ++ref) {
-            if (ref->isNonnull()) {
-                const reco::GenParticle & g = **ref;
-                if ((status != 0) && (g.status() != status)) continue;
-                if (pdgId == 0) {
-                    return *ref;
-                } else if (!autoCharge) {
-                    if (pdgId == g.pdgId()) return *ref;
-                } else if (abs(pdgId) == abs(g.pdgId())) {
-                    // I want pdgId > 0 to match "correct charge" (for charged particles)
-                    if (g.charge() == 0) return *ref;
-                    else if ((this->charge() == 0) && (pdgId == g.pdgId())) return *ref;
-                    else if (g.charge()*this->charge()*pdgId > 0) return *ref;
-                }
-            }
+    // get a vector, avoiding an unneeded copy if there is no embedding
+    const std::vector<reco::GenParticleRef> &vec = (genParticleEmbedded_.empty() ? genParticleRef_ : genParticleRefs());
+    for (std::vector<reco::GenParticleRef>::const_iterator ref = vec.begin(), end = vec.end(); ref != end; ++ref) {
+      if (ref->isNonnull()) {
+        const reco::GenParticle &g = **ref;
+        if ((status != 0) && (g.status() != status))
+          continue;
+        if (pdgId == 0) {
+          return *ref;
+        } else if (!autoCharge) {
+          if (pdgId == g.pdgId())
+            return *ref;
+        } else if (abs(pdgId) == abs(g.pdgId())) {
+          // I want pdgId > 0 to match "correct charge" (for charged particles)
+          if (g.charge() == 0)
+            return *ref;
+          else if ((this->charge() == 0) && (pdgId == g.pdgId()))
+            return *ref;
+          else if (g.charge() * this->charge() * pdgId > 0)
+            return *ref;
         }
-        return reco::GenParticleRef();
+      }
+    }
+    return reco::GenParticleRef();
   }
 
   template <class ObjectType>
   bool PATObject<ObjectType>::hasOverlaps(const std::string &label) const {
-        auto match = std::lower_bound(overlapLabels_.cbegin(), overlapLabels_.cend(), label);
-        return ( match != overlapLabels_.end() && *match == label );
+    auto match = std::lower_bound(overlapLabels_.cbegin(), overlapLabels_.cend(), label);
+    return (match != overlapLabels_.end() && *match == label);
   }
 
   template <class ObjectType>
-  const reco::CandidatePtrVector & PATObject<ObjectType>::overlaps(const std::string &label) const {
-        
-        auto match = std::lower_bound(overlapLabels_.cbegin(), overlapLabels_.cend(), label);
-        if( match == overlapLabels_.cend() || *match != label ) return pat_statics::EMPTY_CPV;
-        return overlapItems_[std::distance(overlapLabels_.begin(),match)];
+  const reco::CandidatePtrVector &PATObject<ObjectType>::overlaps(const std::string &label) const {
+    auto match = std::lower_bound(overlapLabels_.cbegin(), overlapLabels_.cend(), label);
+    if (match == overlapLabels_.cend() || *match != label)
+      return pat_statics::EMPTY_CPV;
+    return overlapItems_[std::distance(overlapLabels_.begin(), match)];
   }
 
   template <class ObjectType>
-  void PATObject<ObjectType>::setOverlaps(const std::string &label, const reco::CandidatePtrVector & overlaps) {
-      
-        auto match = std::lower_bound(overlapLabels_.begin(), overlapLabels_.end(), label);
-        const auto dist = std::distance(overlapLabels_.begin(),match);
-        if ( match == overlapLabels_.end() || *match != label ) {
-          overlapLabels_.insert(match,label);
-          overlapItems_.insert(overlapItems_.begin()+dist,overlaps);
-        } else {
-          overlapItems_[dist] = overlaps;
-        }        
+  void PATObject<ObjectType>::setOverlaps(const std::string &label, const reco::CandidatePtrVector &overlaps) {
+    auto match = std::lower_bound(overlapLabels_.begin(), overlapLabels_.end(), label);
+    const auto dist = std::distance(overlapLabels_.begin(), match);
+    if (match == overlapLabels_.end() || *match != label) {
+      overlapLabels_.insert(match, label);
+      overlapItems_.insert(overlapItems_.begin() + dist, overlaps);
+    } else {
+      overlapItems_[dist] = overlaps;
+    }
   }
 
   template <class ObjectType>
-  const pat::UserData * PATObject<ObjectType>::userDataObject_( const std::string & key ) const
-  {
-    auto it = std::lower_bound(userDataLabels_.cbegin(),userDataLabels_.cend(),key);
-    if ( it != userDataLabels_.cend() && *it == key) {
-      return &userDataObjects_[std::distance(userDataLabels_.cbegin(),it)];
+  const pat::UserData *PATObject<ObjectType>::userDataObject_(const std::string &key) const {
+    auto it = std::lower_bound(userDataLabels_.cbegin(), userDataLabels_.cend(), key);
+    if (it != userDataLabels_.cend() && *it == key) {
+      return &userDataObjects_[std::distance(userDataLabels_.cbegin(), it)];
     }
     return nullptr;
   }
 
   template <class ObjectType>
-  void PATObject<ObjectType>::addUserDataObject_( const std::string & label, std::unique_ptr<pat::UserData> data, bool overwrite ) 
-  {
+  void PATObject<ObjectType>::addUserDataObject_(const std::string &label,
+                                                 std::unique_ptr<pat::UserData> data,
+                                                 bool overwrite) {
     auto it = std::lower_bound(userDataLabels_.begin(), userDataLabels_.end(), label);
     const auto dist = std::distance(userDataLabels_.begin(), it);
-    if( it == userDataLabels_.end() || *it != label ) {
-        userDataLabels_.insert(it,label);
-        userDataObjects_.insert(userDataObjects_.begin()+dist, std::move(data));
-    } else if( overwrite ) {
-        userDataObjects_.set(dist, std::move(data));
+    if (it == userDataLabels_.end() || *it != label) {
+      userDataLabels_.insert(it, label);
+      userDataObjects_.insert(userDataObjects_.begin() + dist, std::move(data));
+    } else if (overwrite) {
+      userDataObjects_.set(dist, std::move(data));
     } else {
-        //create a range by adding behind the first entry
-        userDataLabels_.insert(it+1,label);
-        userDataObjects_.insert(userDataObjects_.begin()+dist+1, std::move(data));
+      //create a range by adding behind the first entry
+      userDataLabels_.insert(it + 1, label);
+      userDataObjects_.insert(userDataObjects_.begin() + dist + 1, std::move(data));
     }
   }
 
-
   template <class ObjectType>
-  float PATObject<ObjectType>::userFloat( const std::string &key ) const
-  {
-    auto it = std::lower_bound(userFloatLabels_.cbegin(),userFloatLabels_.cend(),key);
-    if( it != userFloatLabels_.cend() && *it == key ) {
-      return userFloats_[std::distance(userFloatLabels_.cbegin(),it)];
+  float PATObject<ObjectType>::userFloat(const std::string &key) const {
+    auto it = std::lower_bound(userFloatLabels_.cbegin(), userFloatLabels_.cend(), key);
+    if (it != userFloatLabels_.cend() && *it == key) {
+      return userFloats_[std::distance(userFloatLabels_.cbegin(), it)];
     }
-    throwMissingLabel("UserFloat",key,userFloatLabels_);
+    throwMissingLabel("UserFloat", key, userFloatLabels_);
     return std::numeric_limits<float>::quiet_NaN();
   }
 
-  template<class ObjectType>
-  std::vector<float> PATObject<ObjectType>::userFloatRange( const std::string& key ) const {
-    auto range = std::equal_range(userFloatLabels_.cbegin(),userFloatLabels_.cend(),key);
+  template <class ObjectType>
+  std::vector<float> PATObject<ObjectType>::userFloatRange(const std::string &key) const {
+    auto range = std::equal_range(userFloatLabels_.cbegin(), userFloatLabels_.cend(), key);
     std::vector<float> result;
-    result.reserve(std::distance(range.first,range.second));
-    for( auto it = range.first; it != range.second; ++it ) {
-      result.push_back(userFloats_[std::distance(userFloatLabels_.cbegin(),it)]);
+    result.reserve(std::distance(range.first, range.second));
+    for (auto it = range.first; it != range.second; ++it) {
+      result.push_back(userFloats_[std::distance(userFloatLabels_.cbegin(), it)]);
     }
     return result;
   }
 
   template <class ObjectType>
-  void PATObject<ObjectType>::addUserFloat( const std::string & label,
-					    float data,
-                                            const bool overwrite )
-  {
-    auto it = std::lower_bound(userFloatLabels_.begin(),userFloatLabels_.end(),label);
-    const auto dist = std::distance(userFloatLabels_.begin(),it);
-    if( it == userFloatLabels_.end() || *it != label ) {      
-      userFloatLabels_.insert(it,label);
-      userFloats_.insert(userFloats_.begin()+dist,data);
-    } else if( overwrite ) {
-      userFloats_[ dist ] = data;
+  void PATObject<ObjectType>::addUserFloat(const std::string &label, float data, const bool overwrite) {
+    auto it = std::lower_bound(userFloatLabels_.begin(), userFloatLabels_.end(), label);
+    const auto dist = std::distance(userFloatLabels_.begin(), it);
+    if (it == userFloatLabels_.end() || *it != label) {
+      userFloatLabels_.insert(it, label);
+      userFloats_.insert(userFloats_.begin() + dist, data);
+    } else if (overwrite) {
+      userFloats_[dist] = data;
     } else {
       //create a range by adding behind the first entry
-      userFloatLabels_.insert(it+1,label);
-      userFloats_.insert(userFloats_.begin()+dist+1, data); 
+      userFloatLabels_.insert(it + 1, label);
+      userFloats_.insert(userFloats_.begin() + dist + 1, data);
     }
   }
 
-
   template <class ObjectType>
-  int PATObject<ObjectType>::userInt( const std::string & key ) const
-  {
+  int PATObject<ObjectType>::userInt(const std::string &key) const {
     auto it = std::lower_bound(userIntLabels_.cbegin(), userIntLabels_.cend(), key);
-    if ( it != userIntLabels_.cend() && *it == key ) {
-      return userInts_[std::distance(userIntLabels_.cbegin(),it)];
+    if (it != userIntLabels_.cend() && *it == key) {
+      return userInts_[std::distance(userIntLabels_.cbegin(), it)];
     }
-    throwMissingLabel("UserInt",key,userIntLabels_);
+    throwMissingLabel("UserInt", key, userIntLabels_);
     return std::numeric_limits<int>::max();
   }
 
-  template<class ObjectType>
-  std::vector<int> PATObject<ObjectType>::userIntRange( const std::string& key ) const{
-    auto range = std::equal_range(userIntLabels_.cbegin(),userIntLabels_.cend(),key);
+  template <class ObjectType>
+  std::vector<int> PATObject<ObjectType>::userIntRange(const std::string &key) const {
+    auto range = std::equal_range(userIntLabels_.cbegin(), userIntLabels_.cend(), key);
     std::vector<int> result;
-    result.reserve(std::distance(range.first,range.second));
-    for( auto it = range.first; it != range.second; ++it ) {
-      result.push_back(userInts_[std::distance(userIntLabels_.cbegin(),it)]);
+    result.reserve(std::distance(range.first, range.second));
+    for (auto it = range.first; it != range.second; ++it) {
+      result.push_back(userInts_[std::distance(userIntLabels_.cbegin(), it)]);
     }
     return result;
   }
 
   template <class ObjectType>
-  void PATObject<ObjectType>::addUserInt( const std::string &label,
-                                          int data,
-                                          bool overwrite )
-  {
-    auto it = std::lower_bound(userIntLabels_.begin(),userIntLabels_.end(),label);
-    const auto dist = std::distance(userIntLabels_.begin(),it);
-    if( it == userIntLabels_.end() || *it != label ) { 
-      userIntLabels_.insert(it,label);
-      userInts_.insert(userInts_.begin()+dist,data);
-    } else if( overwrite ) {
+  void PATObject<ObjectType>::addUserInt(const std::string &label, int data, bool overwrite) {
+    auto it = std::lower_bound(userIntLabels_.begin(), userIntLabels_.end(), label);
+    const auto dist = std::distance(userIntLabels_.begin(), it);
+    if (it == userIntLabels_.end() || *it != label) {
+      userIntLabels_.insert(it, label);
+      userInts_.insert(userInts_.begin() + dist, data);
+    } else if (overwrite) {
       userInts_[dist] = data;
     } else {
       //create a range by adding behind the first entry
-      userIntLabels_.insert(it+1, label);
-      userInts_.insert(userInts_.begin()+dist+1,data);
+      userIntLabels_.insert(it + 1, label);
+      userInts_.insert(userInts_.begin() + dist + 1, data);
     }
   }
 
   template <class ObjectType>
-  reco::CandidatePtr PATObject<ObjectType>::userCand( const std::string & key ) const
-  {
+  reco::CandidatePtr PATObject<ObjectType>::userCand(const std::string &key) const {
     auto it = std::lower_bound(userCandLabels_.cbegin(), userCandLabels_.cend(), key);
     if (it != userCandLabels_.cend()) {
-      return userCands_[std::distance(userCandLabels_.begin(),it)];
+      return userCands_[std::distance(userCandLabels_.begin(), it)];
     }
     return reco::CandidatePtr();
   }
 
   template <class ObjectType>
-  void PATObject<ObjectType>::addUserCand( const std::string &label,
-					   const reco::CandidatePtr & data,
-                                           const bool overwrite )
-  {
-    auto it = std::lower_bound(userCandLabels_.begin(),userCandLabels_.end(),label);
-    const auto dist = std::distance(userCandLabels_.begin(),it);
-    if( it == userCandLabels_.end() || *it != label ) {      
-      userCandLabels_.insert(it,label);
-      userCands_.insert(userCands_.begin()+dist,data);
-    } else if( overwrite ) {
+  void PATObject<ObjectType>::addUserCand(const std::string &label,
+                                          const reco::CandidatePtr &data,
+                                          const bool overwrite) {
+    auto it = std::lower_bound(userCandLabels_.begin(), userCandLabels_.end(), label);
+    const auto dist = std::distance(userCandLabels_.begin(), it);
+    if (it == userCandLabels_.end() || *it != label) {
+      userCandLabels_.insert(it, label);
+      userCands_.insert(userCands_.begin() + dist, data);
+    } else if (overwrite) {
       userCands_[dist] = data;
     } else {
-      userCandLabels_.insert(it+1,label);
-      userCands_.insert(userCands_.begin()+dist+1,data);
-    }    
+      userCandLabels_.insert(it + 1, label);
+      userCands_.insert(userCands_.begin() + dist + 1, data);
+    }
   }
 
-
   template <class ObjectType>
-  const pat::CandKinResolution & PATObject<ObjectType>::getKinResolution(const std::string &label) const {
-    const bool has_unlabelled = (kinResolutionLabels_.size()+1 == kinResolutions_.size());
+  const pat::CandKinResolution &PATObject<ObjectType>::getKinResolution(const std::string &label) const {
+    const bool has_unlabelled = (kinResolutionLabels_.size() + 1 == kinResolutions_.size());
     if (label.empty()) {
-        if ( has_unlabelled ) {
-            return kinResolutions_[0];
-        } else {
-            throw cms::Exception("Missing Data", "This object does not contain an un-labelled kinematic resolution");
-        }
+      if (has_unlabelled) {
+        return kinResolutions_[0];
+      } else {
+        throw cms::Exception("Missing Data", "This object does not contain an un-labelled kinematic resolution");
+      }
     } else {
-        auto match = std::lower_bound(kinResolutionLabels_.cbegin(), kinResolutionLabels_.cend(), label);
-        const auto dist = std::distance(kinResolutionLabels_.begin(),match);
-        const size_t increment = ( has_unlabelled ? 1 : 0 );
-        if ( match == kinResolutionLabels_.end() || *match != label ) {
-            cms::Exception ex("Missing Data");
-            ex << "This object does not contain a kinematic resolution with name '" << label << "'.\n";
-            ex << "The known labels are: " ;
-            for (std::vector<std::string>::const_iterator it = kinResolutionLabels_.cbegin(); it != kinResolutionLabels_.cend(); ++it) {
-                ex << "'" << *it << "' ";
-            }
-            ex << "\n";
-            throw ex;
-        } else {           
-            return kinResolutions_[dist+increment];          
+      auto match = std::lower_bound(kinResolutionLabels_.cbegin(), kinResolutionLabels_.cend(), label);
+      const auto dist = std::distance(kinResolutionLabels_.begin(), match);
+      const size_t increment = (has_unlabelled ? 1 : 0);
+      if (match == kinResolutionLabels_.end() || *match != label) {
+        cms::Exception ex("Missing Data");
+        ex << "This object does not contain a kinematic resolution with name '" << label << "'.\n";
+        ex << "The known labels are: ";
+        for (std::vector<std::string>::const_iterator it = kinResolutionLabels_.cbegin();
+             it != kinResolutionLabels_.cend();
+             ++it) {
+          ex << "'" << *it << "' ";
         }
+        ex << "\n";
+        throw ex;
+      } else {
+        return kinResolutions_[dist + increment];
+      }
     }
   }
 
   template <class ObjectType>
   bool PATObject<ObjectType>::hasKinResolution(const std::string &label) const {
     if (label.empty()) {
-        return (kinResolutionLabels_.size()+1 == kinResolutions_.size());
+      return (kinResolutionLabels_.size() + 1 == kinResolutions_.size());
     } else {
-        auto match = std::lower_bound(kinResolutionLabels_.cbegin(), kinResolutionLabels_.cend(), label);
-        return ( match != kinResolutionLabels_.cend() && *match == label );
+      auto match = std::lower_bound(kinResolutionLabels_.cbegin(), kinResolutionLabels_.cend(), label);
+      return (match != kinResolutionLabels_.cend() && *match == label);
     }
   }
 
   template <class ObjectType>
   void PATObject<ObjectType>::setKinResolution(const pat::CandKinResolution &resol, const std::string &label) {
-    const bool has_unlabelled = (kinResolutionLabels_.size()+1 == kinResolutions_.size());
+    const bool has_unlabelled = (kinResolutionLabels_.size() + 1 == kinResolutions_.size());
     if (label.empty()) {
-        if (has_unlabelled) {
-            // There is already an un-labelled object. Replace it
-            kinResolutions_[0] = resol;
-        } else {
-            // Insert. Note that the un-labelled is always the first, so we need to insert before begin()
-            // (for an empty vector, this should not cost more than push_back)
-            kinResolutions_.insert(kinResolutions_.begin(), resol);
-        }
+      if (has_unlabelled) {
+        // There is already an un-labelled object. Replace it
+        kinResolutions_[0] = resol;
+      } else {
+        // Insert. Note that the un-labelled is always the first, so we need to insert before begin()
+        // (for an empty vector, this should not cost more than push_back)
+        kinResolutions_.insert(kinResolutions_.begin(), resol);
+      }
     } else {
-        auto match = std::lower_bound(kinResolutionLabels_.begin(), kinResolutionLabels_.end(), label);
-        const auto dist = std::distance(kinResolutionLabels_.begin(),match);
-        const size_t increment = ( has_unlabelled ? 1 : 0 );
-        if ( match != kinResolutionLabels_.end() && *match == label ) {
-            // Existing object: replace
-            kinResolutions_[dist+increment] = resol;
-        } else {
-            kinResolutionLabels_.insert(match,label);
-            kinResolutions_.insert(kinResolutions_.begin()+dist+increment,resol);
-        }
+      auto match = std::lower_bound(kinResolutionLabels_.begin(), kinResolutionLabels_.end(), label);
+      const auto dist = std::distance(kinResolutionLabels_.begin(), match);
+      const size_t increment = (has_unlabelled ? 1 : 0);
+      if (match != kinResolutionLabels_.end() && *match == label) {
+        // Existing object: replace
+        kinResolutions_[dist + increment] = resol;
+      } else {
+        kinResolutionLabels_.insert(match, label);
+        kinResolutions_.insert(kinResolutions_.begin() + dist + increment, resol);
+      }
     }
   }
 
-
-
-
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/PATObject.h
+++ b/DataFormats/PatCandidates/interface/PATObject.h
@@ -519,7 +519,7 @@ namespace pat {
   const TriggerObjectStandAlone * PATObject<ObjectType>::triggerObjectMatchByType( const trigger::TriggerObjectType triggerObjectType, const size_t idx ) const {
     std::vector< size_t > refs;
     for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasTriggerObjectType( triggerObjectType ) ) refs.push_back( i );
+      if ( triggerObjectMatch( i ) != nullptr && triggerObjectMatch( i )->hasTriggerObjectType( triggerObjectType ) ) refs.push_back( i );
     }
     if ( idx >= refs.size() ) return nullptr;
     TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
@@ -621,7 +621,7 @@ namespace pat {
   const TriggerObjectStandAlone * PATObject<ObjectType>::triggerObjectMatchByPath( const std::string & namePath, const bool pathLastFilterAccepted, const bool pathL3FilterAccepted, const size_t idx ) const {
     std::vector< size_t > refs;
     for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
-      if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasPathName( namePath, pathLastFilterAccepted, pathL3FilterAccepted ) ) refs.push_back( i );
+      if ( triggerObjectMatch( i ) != nullptr && triggerObjectMatch( i )->hasPathName( namePath, pathLastFilterAccepted, pathL3FilterAccepted ) ) refs.push_back( i );
     }
     if ( idx >= refs.size() ) return nullptr;
     TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );

--- a/DataFormats/PatCandidates/interface/PATTauDiscriminator.h
+++ b/DataFormats/PatCandidates/interface/PATTauDiscriminator.h
@@ -7,22 +7,22 @@
 #include <vector>
 
 namespace pat {
-  typedef edm::AssociationVector<pat::TauRefProd,std::vector<float> > PATTauDiscriminatorBase;
+  typedef edm::AssociationVector<pat::TauRefProd, std::vector<float> > PATTauDiscriminatorBase;
 
   class PATTauDiscriminator : public PATTauDiscriminatorBase {
   public:
     /// empty constructor
-    PATTauDiscriminator(); // : PATTauDiscriminatorBase() {}
+    PATTauDiscriminator();  // : PATTauDiscriminatorBase() {}
     /// constructor from reference to pat::Tau
-    PATTauDiscriminator(const pat::TauRefProd & ref) : PATTauDiscriminatorBase(ref) {}
-    /// constructor from base object   
+    PATTauDiscriminator(const pat::TauRefProd &ref) : PATTauDiscriminatorBase(ref) {}
+    /// constructor from base object
     PATTauDiscriminator(const PATTauDiscriminatorBase &v) : PATTauDiscriminatorBase(v) {}
   };
 
-  typedef pat::PATTauDiscriminator::value_type PATTauDiscriminatorVT;  
-  typedef edm::Ref<pat::PATTauDiscriminator> PATTauDiscriminatorRef;  
-  typedef edm::RefProd<pat::PATTauDiscriminator> PATTauDiscriminatorRefProd;  
-  typedef edm::RefVector<pat::PATTauDiscriminator> PATTauDiscriminatorRefVector; 
-}
+  typedef pat::PATTauDiscriminator::value_type PATTauDiscriminatorVT;
+  typedef edm::Ref<pat::PATTauDiscriminator> PATTauDiscriminatorRef;
+  typedef edm::RefProd<pat::PATTauDiscriminator> PATTauDiscriminatorRefProd;
+  typedef edm::RefVector<pat::PATTauDiscriminator> PATTauDiscriminatorRefVector;
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/PFIsolation.h
+++ b/DataFormats/PatCandidates/interface/PFIsolation.h
@@ -7,42 +7,36 @@
   \author   Bennett Marsh
 */
 
-
 namespace pat {
 
-    class PFIsolation{
-    public:
-        PFIsolation() :
-            chiso_(9999.), nhiso_(9999.), 
-            phiso_(9999.), puiso_(9999.) {}
+  class PFIsolation {
+  public:
+    PFIsolation() : chiso_(9999.), nhiso_(9999.), phiso_(9999.), puiso_(9999.) {}
 
-        PFIsolation(float ch, float nh, float ph, float pu) :
-            chiso_(ch), nhiso_(nh),
-            phiso_(ph), puiso_(pu) {}
+    PFIsolation(float ch, float nh, float ph, float pu) : chiso_(ch), nhiso_(nh), phiso_(ph), puiso_(pu) {}
 
-        ~PFIsolation() {}
+    ~PFIsolation() {}
 
-        PFIsolation& operator=(const PFIsolation& iso) {
-            chiso_ = iso.chiso_;
-            nhiso_ = iso.nhiso_;
-            phiso_ = iso.phiso_;
-            puiso_ = iso.puiso_;
-            return *this;
-        }
+    PFIsolation& operator=(const PFIsolation& iso) {
+      chiso_ = iso.chiso_;
+      nhiso_ = iso.nhiso_;
+      phiso_ = iso.phiso_;
+      puiso_ = iso.puiso_;
+      return *this;
+    }
 
-        float chargedHadronIso()   const { return chiso_; }
-        float neutralHadronIso()   const { return nhiso_; }
-        float photonIso()          const { return phiso_; }
-        float puChargedHadronIso() const { return puiso_; }
+    float chargedHadronIso() const { return chiso_; }
+    float neutralHadronIso() const { return nhiso_; }
+    float photonIso() const { return phiso_; }
+    float puChargedHadronIso() const { return puiso_; }
 
-    private:
-        float chiso_; // charged hadrons from PV
-        float nhiso_; // neutral hadrons
-        float phiso_; // photons
-        float puiso_; // pileup contribution (charged hadrons not from PV)
+  private:
+    float chiso_;  // charged hadrons from PV
+    float nhiso_;  // neutral hadrons
+    float phiso_;  // photons
+    float puiso_;  // pileup contribution (charged hadrons not from PV)
+  };
 
-    };
-
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/PFParticle.h
+++ b/DataFormats/PatCandidates/interface/PFParticle.h
@@ -18,37 +18,30 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/PatCandidates/interface/PATObject.h"
 
-
 // Define typedefs for convenience
 namespace pat {
   class PFParticle;
-  typedef std::vector<PFParticle>              PFParticleCollection; 
-  typedef edm::Ref<PFParticleCollection>       PFParticleRef; 
-  typedef edm::RefVector<PFParticleCollection> PFParticleRefVector; 
-}
-
+  typedef std::vector<PFParticle> PFParticleCollection;
+  typedef edm::Ref<PFParticleCollection> PFParticleRef;
+  typedef edm::RefVector<PFParticleCollection> PFParticleRefVector;
+}  // namespace pat
 
 // Class definition
 namespace pat {
 
-
   class PFParticle : public PATObject<reco::PFCandidate> {
-    
-    public:
-    
-      /// default constructor
-      PFParticle() {}
-      /// constructor from ref
-      PFParticle(const edm::RefToBase<reco::PFCandidate> & aPFParticle);
-      /// destructor
-      ~PFParticle() override {}
+  public:
+    /// default constructor
+    PFParticle() {}
+    /// constructor from ref
+    PFParticle(const edm::RefToBase<reco::PFCandidate>& aPFParticle);
+    /// destructor
+    ~PFParticle() override {}
 
-      /// required reimplementation of the Candidate's clone method
-      PFParticle * clone() const override { return new PFParticle(*this); }
-    
+    /// required reimplementation of the Candidate's clone method
+    PFParticle* clone() const override { return new PFParticle(*this); }
   };
-  
 
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -19,1080 +19,1116 @@
 class testPackedCandidate;
 
 namespace pat {
-class PackedCandidate : public reco::Candidate {
-public:
-  /// collection of daughter candidates
-  typedef reco::CandidateCollection daughters;
-  /// Lorentz vector
-  typedef math::XYZTLorentzVector LorentzVector;
-  /// Lorentz vector
-  typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;
-  /// point in the space
-  typedef math::XYZPoint Point;
-  /// point in the space
-  typedef math::XYZVector Vector;
+  class PackedCandidate : public reco::Candidate {
+  public:
+    /// collection of daughter candidates
+    typedef reco::CandidateCollection daughters;
+    /// Lorentz vector
+    typedef math::XYZTLorentzVector LorentzVector;
+    /// Lorentz vector
+    typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;
+    /// point in the space
+    typedef math::XYZPoint Point;
+    /// point in the space
+    typedef math::XYZVector Vector;
 
-  typedef unsigned int index;
-  /// default constructor
-  PackedCandidate()
-      : packedPt_(0), packedEta_(0), packedPhi_(0), packedM_(0), packedDxy_(0),
-        packedDz_(0), packedDPhi_(0), packedDEta_(0), packedDTrkPt_(0),
-        packedCovariance_(), packedPuppiweight_(0),
-        packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0),
-        rawHcalFraction_(0), caloFraction_(0), hcalFraction_(0), packedTime_(0),
-        packedTimeError_(0), isIsolatedChargedHadron_(false),
-        p4_(new PolarLorentzVector(0, 0, 0, 0)),
-        p4c_(new LorentzVector(0, 0, 0, 0)), vertex_(new Point(0, 0, 0)),
-        dphi_(0), deta_(0), dtrkpt_(0), track_(nullptr), pdgId_(0),
-        qualityFlags_(0), pvRefKey_(reco::VertexRef::invalidKey()), m_(nullptr),
-        packedHits_(0), packedLayers_(0), normalizedChi2_(0),
-        covarianceVersion_(0), covarianceSchema_(0), firstHit_(0) {}
+    typedef unsigned int index;
+    /// default constructor
+    PackedCandidate()
+        : packedPt_(0),
+          packedEta_(0),
+          packedPhi_(0),
+          packedM_(0),
+          packedDxy_(0),
+          packedDz_(0),
+          packedDPhi_(0),
+          packedDEta_(0),
+          packedDTrkPt_(0),
+          packedCovariance_(),
+          packedPuppiweight_(0),
+          packedPuppiweightNoLepDiff_(0),
+          rawCaloFraction_(0),
+          rawHcalFraction_(0),
+          caloFraction_(0),
+          hcalFraction_(0),
+          packedTime_(0),
+          packedTimeError_(0),
+          isIsolatedChargedHadron_(false),
+          p4_(new PolarLorentzVector(0, 0, 0, 0)),
+          p4c_(new LorentzVector(0, 0, 0, 0)),
+          vertex_(new Point(0, 0, 0)),
+          dphi_(0),
+          deta_(0),
+          dtrkpt_(0),
+          track_(nullptr),
+          pdgId_(0),
+          qualityFlags_(0),
+          pvRefKey_(reco::VertexRef::invalidKey()),
+          m_(nullptr),
+          packedHits_(0),
+          packedLayers_(0),
+          normalizedChi2_(0),
+          covarianceVersion_(0),
+          covarianceSchema_(0),
+          firstHit_(0) {}
 
-  explicit PackedCandidate(const reco::Candidate &c,
-                           const reco::VertexRefProd &pvRefProd,
-                           reco::VertexRef::key_type pvRefKey)
-      : packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0),
-        rawCaloFraction_(0), rawHcalFraction_(0), caloFraction_(0),
-        hcalFraction_(0), packedTime_(0), packedTimeError_(0),
-        isIsolatedChargedHadron_(false),
-        p4_(new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())),
-        p4c_(new LorentzVector(*p4_)), vertex_(new Point(c.vertex())), dphi_(0),
-        deta_(0), dtrkpt_(0), track_(nullptr), pdgId_(c.pdgId()),
-        qualityFlags_(0), pvRefProd_(pvRefProd), pvRefKey_(pvRefKey),
-        m_(nullptr), packedHits_(0), packedLayers_(0), normalizedChi2_(0),
-        covarianceVersion_(0), covarianceSchema_(0), firstHit_(0) {
-    packBoth();
-  }
+    explicit PackedCandidate(const reco::Candidate &c,
+                             const reco::VertexRefProd &pvRefProd,
+                             reco::VertexRef::key_type pvRefKey)
+        : packedPuppiweight_(0),
+          packedPuppiweightNoLepDiff_(0),
+          rawCaloFraction_(0),
+          rawHcalFraction_(0),
+          caloFraction_(0),
+          hcalFraction_(0),
+          packedTime_(0),
+          packedTimeError_(0),
+          isIsolatedChargedHadron_(false),
+          p4_(new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())),
+          p4c_(new LorentzVector(*p4_)),
+          vertex_(new Point(c.vertex())),
+          dphi_(0),
+          deta_(0),
+          dtrkpt_(0),
+          track_(nullptr),
+          pdgId_(c.pdgId()),
+          qualityFlags_(0),
+          pvRefProd_(pvRefProd),
+          pvRefKey_(pvRefKey),
+          m_(nullptr),
+          packedHits_(0),
+          packedLayers_(0),
+          normalizedChi2_(0),
+          covarianceVersion_(0),
+          covarianceSchema_(0),
+          firstHit_(0) {
+      packBoth();
+    }
 
-  explicit PackedCandidate(const PolarLorentzVector &p4, const Point &vtx,
-                           float trkPt, float etaAtVtx, float phiAtVtx,
-                           int pdgId, const reco::VertexRefProd &pvRefProd,
-                           reco::VertexRef::key_type pvRefKey)
-      : packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0),
-        rawCaloFraction_(0), rawHcalFraction_(0), caloFraction_(0),
-        hcalFraction_(0), packedTime_(0), packedTimeError_(0),
-        isIsolatedChargedHadron_(false), p4_(new PolarLorentzVector(p4)),
-        p4c_(new LorentzVector(*p4_)), vertex_(new Point(vtx)),
-        dphi_(reco::deltaPhi(phiAtVtx, p4_.load()->phi())),
-        deta_(std::abs(etaAtVtx - p4_.load()->eta()) >= kMinDEtaToStore_
-                  ? etaAtVtx - p4_.load()->eta()
-                  : 0.),
-        dtrkpt_(std::abs(trkPt - p4_.load()->pt()) >= kMinDTrkPtToStore_
-                    ? trkPt - p4_.load()->pt()
-                    : 0.),
-        track_(nullptr), pdgId_(pdgId), qualityFlags_(0), pvRefProd_(pvRefProd),
-        pvRefKey_(pvRefKey), m_(nullptr), packedHits_(0), packedLayers_(0),
-        normalizedChi2_(0), covarianceVersion_(0), covarianceSchema_(0),
-        firstHit_(0) {
-    packBoth();
-  }
+    explicit PackedCandidate(const PolarLorentzVector &p4,
+                             const Point &vtx,
+                             float trkPt,
+                             float etaAtVtx,
+                             float phiAtVtx,
+                             int pdgId,
+                             const reco::VertexRefProd &pvRefProd,
+                             reco::VertexRef::key_type pvRefKey)
+        : packedPuppiweight_(0),
+          packedPuppiweightNoLepDiff_(0),
+          rawCaloFraction_(0),
+          rawHcalFraction_(0),
+          caloFraction_(0),
+          hcalFraction_(0),
+          packedTime_(0),
+          packedTimeError_(0),
+          isIsolatedChargedHadron_(false),
+          p4_(new PolarLorentzVector(p4)),
+          p4c_(new LorentzVector(*p4_)),
+          vertex_(new Point(vtx)),
+          dphi_(reco::deltaPhi(phiAtVtx, p4_.load()->phi())),
+          deta_(std::abs(etaAtVtx - p4_.load()->eta()) >= kMinDEtaToStore_ ? etaAtVtx - p4_.load()->eta() : 0.),
+          dtrkpt_(std::abs(trkPt - p4_.load()->pt()) >= kMinDTrkPtToStore_ ? trkPt - p4_.load()->pt() : 0.),
+          track_(nullptr),
+          pdgId_(pdgId),
+          qualityFlags_(0),
+          pvRefProd_(pvRefProd),
+          pvRefKey_(pvRefKey),
+          m_(nullptr),
+          packedHits_(0),
+          packedLayers_(0),
+          normalizedChi2_(0),
+          covarianceVersion_(0),
+          covarianceSchema_(0),
+          firstHit_(0) {
+      packBoth();
+    }
 
-  explicit PackedCandidate(const LorentzVector &p4, const Point &vtx,
-                           float trkPt, float etaAtVtx, float phiAtVtx,
-                           int pdgId, const reco::VertexRefProd &pvRefProd,
-                           reco::VertexRef::key_type pvRefKey)
-      : packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0),
-        rawCaloFraction_(0), rawHcalFraction_(0), caloFraction_(0),
-        hcalFraction_(0), packedTime_(0), packedTimeError_(0),
-        isIsolatedChargedHadron_(false),
-        p4_(new PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M())),
-        p4c_(new LorentzVector(p4)), vertex_(new Point(vtx)),
-        dphi_(reco::deltaPhi(phiAtVtx, p4_.load()->phi())),
-        deta_(std::abs(etaAtVtx - p4_.load()->eta()) >= kMinDEtaToStore_
-                  ? etaAtVtx - p4_.load()->eta()
-                  : 0.),
-        dtrkpt_(std::abs(trkPt - p4_.load()->pt()) >= kMinDTrkPtToStore_
-                    ? trkPt - p4_.load()->pt()
-                    : 0.),
-        track_(nullptr), pdgId_(pdgId), qualityFlags_(0), pvRefProd_(pvRefProd),
-        pvRefKey_(pvRefKey), m_(nullptr), packedHits_(0), packedLayers_(0),
-        normalizedChi2_(0), covarianceVersion_(0), covarianceSchema_(0),
-        firstHit_(0) {
-    packBoth();
-  }
+    explicit PackedCandidate(const LorentzVector &p4,
+                             const Point &vtx,
+                             float trkPt,
+                             float etaAtVtx,
+                             float phiAtVtx,
+                             int pdgId,
+                             const reco::VertexRefProd &pvRefProd,
+                             reco::VertexRef::key_type pvRefKey)
+        : packedPuppiweight_(0),
+          packedPuppiweightNoLepDiff_(0),
+          rawCaloFraction_(0),
+          rawHcalFraction_(0),
+          caloFraction_(0),
+          hcalFraction_(0),
+          packedTime_(0),
+          packedTimeError_(0),
+          isIsolatedChargedHadron_(false),
+          p4_(new PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M())),
+          p4c_(new LorentzVector(p4)),
+          vertex_(new Point(vtx)),
+          dphi_(reco::deltaPhi(phiAtVtx, p4_.load()->phi())),
+          deta_(std::abs(etaAtVtx - p4_.load()->eta()) >= kMinDEtaToStore_ ? etaAtVtx - p4_.load()->eta() : 0.),
+          dtrkpt_(std::abs(trkPt - p4_.load()->pt()) >= kMinDTrkPtToStore_ ? trkPt - p4_.load()->pt() : 0.),
+          track_(nullptr),
+          pdgId_(pdgId),
+          qualityFlags_(0),
+          pvRefProd_(pvRefProd),
+          pvRefKey_(pvRefKey),
+          m_(nullptr),
+          packedHits_(0),
+          packedLayers_(0),
+          normalizedChi2_(0),
+          covarianceVersion_(0),
+          covarianceSchema_(0),
+          firstHit_(0) {
+      packBoth();
+    }
 
-  PackedCandidate(const PackedCandidate &iOther)
-      : packedPt_(iOther.packedPt_), packedEta_(iOther.packedEta_),
-        packedPhi_(iOther.packedPhi_), packedM_(iOther.packedM_),
-        packedDxy_(iOther.packedDxy_), packedDz_(iOther.packedDz_),
-        packedDPhi_(iOther.packedDPhi_), packedDEta_(iOther.packedDEta_),
-        packedDTrkPt_(iOther.packedDTrkPt_),
-        packedCovariance_(iOther.packedCovariance_),
-        packedPuppiweight_(iOther.packedPuppiweight_),
-        packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
-        rawCaloFraction_(iOther.rawCaloFraction_),
-        rawHcalFraction_(iOther.rawHcalFraction_),
-        caloFraction_(iOther.caloFraction_),
-        hcalFraction_(iOther.hcalFraction_), packedTime_(iOther.packedTime_),
-        packedTimeError_(iOther.packedTimeError_),
-        isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
-        // Need to trigger unpacking in iOther
-        p4_(new PolarLorentzVector(iOther.polarP4())),
-        p4c_(new LorentzVector(iOther.p4())),
-        vertex_(new Point(iOther.vertex())), dxy_(iOther.dxy_), dz_(iOther.dz_),
-        dphi_(iOther.dphi_), deta_(iOther.deta_), dtrkpt_(iOther.dtrkpt_),
-        track_(iOther.track_ ? new reco::Track(*iOther.track_) : nullptr),
-        pdgId_(iOther.pdgId_), qualityFlags_(iOther.qualityFlags_),
-        pvRefProd_(iOther.pvRefProd_), pvRefKey_(iOther.pvRefKey_),
-        m_(iOther.m_ ? new reco::TrackBase::CovarianceMatrix(*iOther.m_)
-                     : nullptr),
-        packedHits_(iOther.packedHits_), packedLayers_(iOther.packedLayers_),
-        normalizedChi2_(iOther.normalizedChi2_),
-        covarianceVersion_(iOther.covarianceVersion_),
-        covarianceSchema_(iOther.covarianceSchema_),
-        firstHit_(iOther.firstHit_) {}
+    PackedCandidate(const PackedCandidate &iOther)
+        : packedPt_(iOther.packedPt_),
+          packedEta_(iOther.packedEta_),
+          packedPhi_(iOther.packedPhi_),
+          packedM_(iOther.packedM_),
+          packedDxy_(iOther.packedDxy_),
+          packedDz_(iOther.packedDz_),
+          packedDPhi_(iOther.packedDPhi_),
+          packedDEta_(iOther.packedDEta_),
+          packedDTrkPt_(iOther.packedDTrkPt_),
+          packedCovariance_(iOther.packedCovariance_),
+          packedPuppiweight_(iOther.packedPuppiweight_),
+          packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
+          rawCaloFraction_(iOther.rawCaloFraction_),
+          rawHcalFraction_(iOther.rawHcalFraction_),
+          caloFraction_(iOther.caloFraction_),
+          hcalFraction_(iOther.hcalFraction_),
+          packedTime_(iOther.packedTime_),
+          packedTimeError_(iOther.packedTimeError_),
+          isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
+          // Need to trigger unpacking in iOther
+          p4_(new PolarLorentzVector(iOther.polarP4())),
+          p4c_(new LorentzVector(iOther.p4())),
+          vertex_(new Point(iOther.vertex())),
+          dxy_(iOther.dxy_),
+          dz_(iOther.dz_),
+          dphi_(iOther.dphi_),
+          deta_(iOther.deta_),
+          dtrkpt_(iOther.dtrkpt_),
+          track_(iOther.track_ ? new reco::Track(*iOther.track_) : nullptr),
+          pdgId_(iOther.pdgId_),
+          qualityFlags_(iOther.qualityFlags_),
+          pvRefProd_(iOther.pvRefProd_),
+          pvRefKey_(iOther.pvRefKey_),
+          m_(iOther.m_ ? new reco::TrackBase::CovarianceMatrix(*iOther.m_) : nullptr),
+          packedHits_(iOther.packedHits_),
+          packedLayers_(iOther.packedLayers_),
+          normalizedChi2_(iOther.normalizedChi2_),
+          covarianceVersion_(iOther.covarianceVersion_),
+          covarianceSchema_(iOther.covarianceSchema_),
+          firstHit_(iOther.firstHit_) {}
 
-  PackedCandidate(PackedCandidate &&iOther)
-      : packedPt_(iOther.packedPt_), packedEta_(iOther.packedEta_),
-        packedPhi_(iOther.packedPhi_), packedM_(iOther.packedM_),
-        packedDxy_(iOther.packedDxy_), packedDz_(iOther.packedDz_),
-        packedDPhi_(iOther.packedDPhi_), packedDEta_(iOther.packedDEta_),
-        packedDTrkPt_(iOther.packedDTrkPt_),
-        packedCovariance_(iOther.packedCovariance_),
-        packedPuppiweight_(iOther.packedPuppiweight_),
-        packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
-        rawCaloFraction_(iOther.rawCaloFraction_),
-        rawHcalFraction_(iOther.rawHcalFraction_),
-        caloFraction_(iOther.caloFraction_),
-        hcalFraction_(iOther.hcalFraction_), packedTime_(iOther.packedTime_),
-        packedTimeError_(iOther.packedTimeError_),
-        isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
-        p4_(iOther.p4_.exchange(nullptr)), p4c_(iOther.p4c_.exchange(nullptr)),
-        vertex_(iOther.vertex_.exchange(nullptr)), dxy_(iOther.dxy_),
-        dz_(iOther.dz_), dphi_(iOther.dphi_), deta_(iOther.deta_),
-        dtrkpt_(iOther.dtrkpt_), track_(iOther.track_.exchange(nullptr)),
-        pdgId_(iOther.pdgId_), qualityFlags_(iOther.qualityFlags_),
-        pvRefProd_(std::move(iOther.pvRefProd_)), pvRefKey_(iOther.pvRefKey_),
-        m_(iOther.m_.exchange(nullptr)), packedHits_(iOther.packedHits_),
-        packedLayers_(iOther.packedLayers_),
-        normalizedChi2_(iOther.normalizedChi2_),
-        covarianceVersion_(iOther.covarianceVersion_),
-        covarianceSchema_(iOther.covarianceSchema_),
-        firstHit_(iOther.firstHit_) {}
+    PackedCandidate(PackedCandidate &&iOther)
+        : packedPt_(iOther.packedPt_),
+          packedEta_(iOther.packedEta_),
+          packedPhi_(iOther.packedPhi_),
+          packedM_(iOther.packedM_),
+          packedDxy_(iOther.packedDxy_),
+          packedDz_(iOther.packedDz_),
+          packedDPhi_(iOther.packedDPhi_),
+          packedDEta_(iOther.packedDEta_),
+          packedDTrkPt_(iOther.packedDTrkPt_),
+          packedCovariance_(iOther.packedCovariance_),
+          packedPuppiweight_(iOther.packedPuppiweight_),
+          packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
+          rawCaloFraction_(iOther.rawCaloFraction_),
+          rawHcalFraction_(iOther.rawHcalFraction_),
+          caloFraction_(iOther.caloFraction_),
+          hcalFraction_(iOther.hcalFraction_),
+          packedTime_(iOther.packedTime_),
+          packedTimeError_(iOther.packedTimeError_),
+          isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
+          p4_(iOther.p4_.exchange(nullptr)),
+          p4c_(iOther.p4c_.exchange(nullptr)),
+          vertex_(iOther.vertex_.exchange(nullptr)),
+          dxy_(iOther.dxy_),
+          dz_(iOther.dz_),
+          dphi_(iOther.dphi_),
+          deta_(iOther.deta_),
+          dtrkpt_(iOther.dtrkpt_),
+          track_(iOther.track_.exchange(nullptr)),
+          pdgId_(iOther.pdgId_),
+          qualityFlags_(iOther.qualityFlags_),
+          pvRefProd_(std::move(iOther.pvRefProd_)),
+          pvRefKey_(iOther.pvRefKey_),
+          m_(iOther.m_.exchange(nullptr)),
+          packedHits_(iOther.packedHits_),
+          packedLayers_(iOther.packedLayers_),
+          normalizedChi2_(iOther.normalizedChi2_),
+          covarianceVersion_(iOther.covarianceVersion_),
+          covarianceSchema_(iOther.covarianceSchema_),
+          firstHit_(iOther.firstHit_) {}
 
-  PackedCandidate &operator=(const PackedCandidate &iOther) {
-    if (this == &iOther) {
+    PackedCandidate &operator=(const PackedCandidate &iOther) {
+      if (this == &iOther) {
+        return *this;
+      }
+      packedPt_ = iOther.packedPt_;
+      packedEta_ = iOther.packedEta_;
+      packedPhi_ = iOther.packedPhi_;
+      packedM_ = iOther.packedM_;
+      packedDxy_ = iOther.packedDxy_;
+      packedDz_ = iOther.packedDz_;
+      packedDPhi_ = iOther.packedDPhi_;
+      packedDEta_ = iOther.packedDEta_;
+      packedDTrkPt_ = iOther.packedDTrkPt_;
+      packedCovariance_ = iOther.packedCovariance_;
+      packedPuppiweight_ = iOther.packedPuppiweight_;
+      packedPuppiweightNoLepDiff_ = iOther.packedPuppiweightNoLepDiff_;
+      rawCaloFraction_ = iOther.rawCaloFraction_;
+      rawHcalFraction_ = iOther.rawHcalFraction_;
+      caloFraction_ = iOther.caloFraction_;
+      hcalFraction_ = iOther.hcalFraction_;
+      packedTime_ = iOther.packedTime_;
+      packedTimeError_ = iOther.packedTimeError_;
+      isIsolatedChargedHadron_ = iOther.isIsolatedChargedHadron_;
+      // Need to trigger unpacking in iOther
+      if (p4_) {
+        *p4_ = iOther.polarP4();
+      } else {
+        p4_.store(new PolarLorentzVector(iOther.polarP4()));
+      }
+      if (p4c_) {
+        *p4c_ = iOther.p4();
+      } else {
+        p4c_.store(new LorentzVector(iOther.p4()));
+      }
+      if (vertex_) {
+        *vertex_ = iOther.vertex();
+      } else {
+        vertex_.store(new Point(iOther.vertex()));
+      }
+      dxy_ = iOther.dxy_;
+      dz_ = iOther.dz_;
+      dphi_ = iOther.dphi_;
+      deta_ = iOther.deta_;
+      dtrkpt_ = iOther.dtrkpt_;
+
+      if (!iOther.track_) {
+        delete track_.exchange(nullptr);
+      } else {
+        if (!track_) {
+          track_.store(new reco::Track(*iOther.track_));
+        } else {
+          *track_ = *(iOther.track_);
+        }
+      }
+
+      pdgId_ = iOther.pdgId_;
+      qualityFlags_ = iOther.qualityFlags_;
+      pvRefProd_ = iOther.pvRefProd_;
+      pvRefKey_ = iOther.pvRefKey_;
+      if (!iOther.m_) {
+        delete m_.exchange(nullptr);
+      } else {
+        if (!m_) {
+          m_.store(new reco::Track::CovarianceMatrix(*iOther.m_));
+        } else {
+          *m_ = *(iOther.m_);
+        }
+      }
+
+      packedHits_ = iOther.packedHits_;
+      packedLayers_ = iOther.packedLayers_;
+      normalizedChi2_ = iOther.normalizedChi2_;
+      covarianceVersion_ = iOther.covarianceVersion_;
+      covarianceSchema_ = iOther.covarianceSchema_;
+      firstHit_ = iOther.firstHit_;
       return *this;
     }
-    packedPt_ = iOther.packedPt_;
-    packedEta_ = iOther.packedEta_;
-    packedPhi_ = iOther.packedPhi_;
-    packedM_ = iOther.packedM_;
-    packedDxy_ = iOther.packedDxy_;
-    packedDz_ = iOther.packedDz_;
-    packedDPhi_ = iOther.packedDPhi_;
-    packedDEta_ = iOther.packedDEta_;
-    packedDTrkPt_ = iOther.packedDTrkPt_;
-    packedCovariance_ = iOther.packedCovariance_;
-    packedPuppiweight_ = iOther.packedPuppiweight_;
-    packedPuppiweightNoLepDiff_ = iOther.packedPuppiweightNoLepDiff_;
-    rawCaloFraction_ = iOther.rawCaloFraction_;
-    rawHcalFraction_ = iOther.rawHcalFraction_;
-    caloFraction_ = iOther.caloFraction_;
-    hcalFraction_ = iOther.hcalFraction_;
-    packedTime_ = iOther.packedTime_;
-    packedTimeError_ = iOther.packedTimeError_;
-    isIsolatedChargedHadron_ = iOther.isIsolatedChargedHadron_;
-    // Need to trigger unpacking in iOther
-    if (p4_) {
-      *p4_ = iOther.polarP4();
-    } else {
-      p4_.store(new PolarLorentzVector(iOther.polarP4()));
-    }
-    if (p4c_) {
-      *p4c_ = iOther.p4();
-    } else {
-      p4c_.store(new LorentzVector(iOther.p4()));
-    }
-    if (vertex_) {
-      *vertex_ = iOther.vertex();
-    } else {
-      vertex_.store(new Point(iOther.vertex()));
-    }
-    dxy_ = iOther.dxy_;
-    dz_ = iOther.dz_;
-    dphi_ = iOther.dphi_;
-    deta_ = iOther.deta_;
-    dtrkpt_ = iOther.dtrkpt_;
 
-    if (!iOther.track_) {
-      delete track_.exchange(nullptr);
-    } else {
-      if (!track_) {
-        track_.store(new reco::Track(*iOther.track_));
-      } else {
-        *track_ = *(iOther.track_);
+    PackedCandidate &operator=(PackedCandidate &&iOther) {
+      if (this == &iOther) {
+        return *this;
       }
-    }
-
-    pdgId_ = iOther.pdgId_;
-    qualityFlags_ = iOther.qualityFlags_;
-    pvRefProd_ = iOther.pvRefProd_;
-    pvRefKey_ = iOther.pvRefKey_;
-    if (!iOther.m_) {
-      delete m_.exchange(nullptr);
-    } else {
-      if (!m_) {
-        m_.store(new reco::Track::CovarianceMatrix(*iOther.m_));
-      } else {
-        *m_ = *(iOther.m_);
-      }
-    }
-
-    packedHits_ = iOther.packedHits_;
-    packedLayers_ = iOther.packedLayers_;
-    normalizedChi2_ = iOther.normalizedChi2_;
-    covarianceVersion_ = iOther.covarianceVersion_;
-    covarianceSchema_ = iOther.covarianceSchema_;
-    firstHit_ = iOther.firstHit_;
-    return *this;
-  }
-
-  PackedCandidate &operator=(PackedCandidate &&iOther) {
-    if (this == &iOther) {
+      packedPt_ = iOther.packedPt_;
+      packedEta_ = iOther.packedEta_;
+      packedPhi_ = iOther.packedPhi_;
+      packedM_ = iOther.packedM_;
+      packedDxy_ = iOther.packedDxy_;
+      packedDz_ = iOther.packedDz_;
+      packedDPhi_ = iOther.packedDPhi_;
+      packedDEta_ = iOther.packedDEta_;
+      packedDTrkPt_ = iOther.packedDTrkPt_;
+      packedCovariance_ = iOther.packedCovariance_;
+      packedPuppiweight_ = iOther.packedPuppiweight_;
+      packedPuppiweightNoLepDiff_ = iOther.packedPuppiweightNoLepDiff_;
+      rawCaloFraction_ = iOther.rawCaloFraction_;
+      rawHcalFraction_ = iOther.rawHcalFraction_;
+      caloFraction_ = iOther.caloFraction_;
+      hcalFraction_ = iOther.hcalFraction_;
+      packedTime_ = iOther.packedTime_;
+      packedTimeError_ = iOther.packedTimeError_;
+      isIsolatedChargedHadron_ = iOther.isIsolatedChargedHadron_;
+      delete p4_.exchange(iOther.p4_.exchange(nullptr));
+      delete p4c_.exchange(iOther.p4c_.exchange(nullptr));
+      delete vertex_.exchange(iOther.vertex_.exchange(nullptr));
+      dxy_ = iOther.dxy_;
+      dz_ = iOther.dz_;
+      dphi_ = iOther.dphi_;
+      deta_ = iOther.deta_;
+      dtrkpt_ = iOther.dtrkpt_;
+      delete track_.exchange(iOther.track_.exchange(nullptr));
+      pdgId_ = iOther.pdgId_;
+      qualityFlags_ = iOther.qualityFlags_;
+      pvRefProd_ = iOther.pvRefProd_;
+      pvRefKey_ = iOther.pvRefKey_;
+      delete m_.exchange(iOther.m_.exchange(nullptr));
+      packedHits_ = iOther.packedHits_;
+      packedLayers_ = iOther.packedLayers_;
+      normalizedChi2_ = iOther.normalizedChi2_;
+      covarianceVersion_ = iOther.covarianceVersion_;
+      covarianceSchema_ = iOther.covarianceSchema_;
+      firstHit_ = iOther.firstHit_;
       return *this;
     }
-    packedPt_ = iOther.packedPt_;
-    packedEta_ = iOther.packedEta_;
-    packedPhi_ = iOther.packedPhi_;
-    packedM_ = iOther.packedM_;
-    packedDxy_ = iOther.packedDxy_;
-    packedDz_ = iOther.packedDz_;
-    packedDPhi_ = iOther.packedDPhi_;
-    packedDEta_ = iOther.packedDEta_;
-    packedDTrkPt_ = iOther.packedDTrkPt_;
-    packedCovariance_ = iOther.packedCovariance_;
-    packedPuppiweight_ = iOther.packedPuppiweight_;
-    packedPuppiweightNoLepDiff_ = iOther.packedPuppiweightNoLepDiff_;
-    rawCaloFraction_ = iOther.rawCaloFraction_;
-    rawHcalFraction_ = iOther.rawHcalFraction_;
-    caloFraction_ = iOther.caloFraction_;
-    hcalFraction_ = iOther.hcalFraction_;
-    packedTime_ = iOther.packedTime_;
-    packedTimeError_ = iOther.packedTimeError_;
-    isIsolatedChargedHadron_ = iOther.isIsolatedChargedHadron_;
-    delete p4_.exchange(iOther.p4_.exchange(nullptr));
-    delete p4c_.exchange(iOther.p4c_.exchange(nullptr));
-    delete vertex_.exchange(iOther.vertex_.exchange(nullptr));
-    dxy_ = iOther.dxy_;
-    dz_ = iOther.dz_;
-    dphi_ = iOther.dphi_;
-    deta_ = iOther.deta_;
-    dtrkpt_ = iOther.dtrkpt_;
-    delete track_.exchange(iOther.track_.exchange(nullptr));
-    pdgId_ = iOther.pdgId_;
-    qualityFlags_ = iOther.qualityFlags_;
-    pvRefProd_ = iOther.pvRefProd_;
-    pvRefKey_ = iOther.pvRefKey_;
-    delete m_.exchange(iOther.m_.exchange(nullptr));
-    packedHits_ = iOther.packedHits_;
-    packedLayers_ = iOther.packedLayers_;
-    normalizedChi2_ = iOther.normalizedChi2_;
-    covarianceVersion_ = iOther.covarianceVersion_;
-    covarianceSchema_ = iOther.covarianceSchema_;
-    firstHit_ = iOther.firstHit_;
-    return *this;
-  }
 
-  /// destructor
-  ~PackedCandidate() override;
-  /// number of daughters
-  size_t numberOfDaughters() const override;
-  /// return daughter at a given position (throws an exception)
-  const reco::Candidate *daughter(size_type) const override;
-  /// number of mothers
-  size_t numberOfMothers() const override;
-  /// return mother at a given position (throws an exception)
-  const reco::Candidate *mother(size_type) const override;
-  /// return daughter at a given position (throws an exception)
-  reco::Candidate *daughter(size_type) override;
-  /// return daughter with a specified role name
-  reco::Candidate *daughter(const std::string &s) override;
-  /// return daughter with a specified role name
-  const reco::Candidate *daughter(const std::string &s) const override;
-  /// return the number of source Candidates
-  /// ( the candidates used to construct this Candidate)
-  size_t numberOfSourceCandidatePtrs() const override { return 0; }
-  /// return a Ptr to one of the source Candidates
-  /// ( the candidates used to construct this Candidate)
-  reco::CandidatePtr sourceCandidatePtr(size_type i) const override {
-    return reco::CandidatePtr();
-  }
+    /// destructor
+    ~PackedCandidate() override;
+    /// number of daughters
+    size_t numberOfDaughters() const override;
+    /// return daughter at a given position (throws an exception)
+    const reco::Candidate *daughter(size_type) const override;
+    /// number of mothers
+    size_t numberOfMothers() const override;
+    /// return mother at a given position (throws an exception)
+    const reco::Candidate *mother(size_type) const override;
+    /// return daughter at a given position (throws an exception)
+    reco::Candidate *daughter(size_type) override;
+    /// return daughter with a specified role name
+    reco::Candidate *daughter(const std::string &s) override;
+    /// return daughter with a specified role name
+    const reco::Candidate *daughter(const std::string &s) const override;
+    /// return the number of source Candidates
+    /// ( the candidates used to construct this Candidate)
+    size_t numberOfSourceCandidatePtrs() const override { return 0; }
+    /// return a Ptr to one of the source Candidates
+    /// ( the candidates used to construct this Candidate)
+    reco::CandidatePtr sourceCandidatePtr(size_type i) const override { return reco::CandidatePtr(); }
 
-  /// electric charge
-  int charge() const override {
-    switch (abs(pdgId_)) {
-    case 211:
-      return (pdgId_ > 0) - (pdgId_ < 0);
-    case 11:
-      return (-1) * (pdgId_ > 0) + (pdgId_ < 0); // e
-    case 13:
-      return (-1) * (pdgId_ > 0) + (pdgId_ < 0); // mu
-    case 15:
-      return (-1) * (pdgId_ > 0) + (pdgId_ < 0); // tau
-    case 24:
-      return (pdgId_ > 0) - (pdgId_ < 0); // W
-    default:
-      return 0; // FIXME: charge is not defined
+    /// electric charge
+    int charge() const override {
+      switch (abs(pdgId_)) {
+        case 211:
+          return (pdgId_ > 0) - (pdgId_ < 0);
+        case 11:
+          return (-1) * (pdgId_ > 0) + (pdgId_ < 0);  // e
+        case 13:
+          return (-1) * (pdgId_ > 0) + (pdgId_ < 0);  // mu
+        case 15:
+          return (-1) * (pdgId_ > 0) + (pdgId_ < 0);  // tau
+        case 24:
+          return (pdgId_ > 0) - (pdgId_ < 0);  // W
+        default:
+          return 0;  // FIXME: charge is not defined
+      }
     }
-  }
-  /// set electric charge
-  void setCharge(int charge) override {}
-  /// electric charge
-  int threeCharge() const override { return charge() * 3; }
-  /// set electric charge
-  void setThreeCharge(int threecharge) override {}
-  /// four-momentum Lorentz vecto r
-  const LorentzVector &p4() const override {
-    if (!p4c_)
-      unpack();
-    return *p4c_;
-  }
-  /// four-momentum Lorentz vector
-  const PolarLorentzVector &polarP4() const override {
-    if (!p4c_)
-      unpack();
-    return *p4_;
-  }
-  /// spatial momentum vector
-  Vector momentum() const override {
-    if (!p4c_)
-      unpack();
-    return p4c_.load()->Vect();
-  }
-  /// boost vector to boost a Lorentz vector
-  /// to the particle center of mass system
-  Vector boostToCM() const override {
-    if (!p4c_)
-      unpack();
-    return p4c_.load()->BoostToCM();
-  }
-  /// magnitude of momentum vector
-  double p() const override {
-    if (!p4c_)
-      unpack();
-    return p4c_.load()->P();
-  }
-  /// energy
-  double energy() const override {
-    if (!p4c_)
-      unpack();
-    return p4c_.load()->E();
-  }
-  /// transverse energy
-  double et() const override { return (pt() <= 0) ? 0 : p4c_.load()->Et(); }
-  /// transverse energy squared (use this for cuts)!
-  double et2() const override { return (pt() <= 0) ? 0 : p4c_.load()->Et2(); }
-  /// mass
-  double mass() const override {
-    if (!p4c_)
-      unpack();
-    return p4_.load()->M();
-  }
-  /// mass squared
-  double massSqr() const override {
-    if (!p4c_)
-      unpack();
-    auto m = p4_.load()->M();
-    return m * m;
-  }
+    /// set electric charge
+    void setCharge(int charge) override {}
+    /// electric charge
+    int threeCharge() const override { return charge() * 3; }
+    /// set electric charge
+    void setThreeCharge(int threecharge) override {}
+    /// four-momentum Lorentz vecto r
+    const LorentzVector &p4() const override {
+      if (!p4c_)
+        unpack();
+      return *p4c_;
+    }
+    /// four-momentum Lorentz vector
+    const PolarLorentzVector &polarP4() const override {
+      if (!p4c_)
+        unpack();
+      return *p4_;
+    }
+    /// spatial momentum vector
+    Vector momentum() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->Vect();
+    }
+    /// boost vector to boost a Lorentz vector
+    /// to the particle center of mass system
+    Vector boostToCM() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->BoostToCM();
+    }
+    /// magnitude of momentum vector
+    double p() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->P();
+    }
+    /// energy
+    double energy() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->E();
+    }
+    /// transverse energy
+    double et() const override { return (pt() <= 0) ? 0 : p4c_.load()->Et(); }
+    /// transverse energy squared (use this for cuts)!
+    double et2() const override { return (pt() <= 0) ? 0 : p4c_.load()->Et2(); }
+    /// mass
+    double mass() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->M();
+    }
+    /// mass squared
+    double massSqr() const override {
+      if (!p4c_)
+        unpack();
+      auto m = p4_.load()->M();
+      return m * m;
+    }
 
-  /// transverse mass
-  double mt() const override {
-    if (!p4c_)
-      unpack();
-    return p4_.load()->Mt();
-  }
-  /// transverse mass squared
-  double mtSqr() const override {
-    if (!p4c_)
-      unpack();
-    return p4_.load()->Mt2();
-  }
-  /// x coordinate of momentum vector
-  double px() const override {
-    if (!p4c_)
-      unpack();
-    return p4c_.load()->Px();
-  }
-  /// y coordinate of momentum vector
-  double py() const override {
-    if (!p4c_)
-      unpack();
-    return p4c_.load()->Py();
-  }
-  /// z coordinate of momentum vector
-  double pz() const override {
-    if (!p4c_)
-      unpack();
-    return p4c_.load()->Pz();
-  }
-  /// transverse momentum
-  double pt() const override {
-    if (!p4c_)
-      unpack();
-    return p4_.load()->Pt();
-  }
-  /// momentum azimuthal angle
-  double phi() const override {
-    if (!p4c_)
-      unpack();
-    return p4_.load()->Phi();
-  }
+    /// transverse mass
+    double mt() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Mt();
+    }
+    /// transverse mass squared
+    double mtSqr() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Mt2();
+    }
+    /// x coordinate of momentum vector
+    double px() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->Px();
+    }
+    /// y coordinate of momentum vector
+    double py() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->Py();
+    }
+    /// z coordinate of momentum vector
+    double pz() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->Pz();
+    }
+    /// transverse momentum
+    double pt() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Pt();
+    }
+    /// momentum azimuthal angle
+    double phi() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Phi();
+    }
 
-  /// pt from the track (normally identical to pt())
-  virtual double ptTrk() const {
-    maybeUnpackBoth();
-    return p4_.load()->pt() + dtrkpt_;
-  }
-  /// momentum azimuthal angle from the track (normally identical to phi())
-  virtual float phiAtVtx() const {
-    maybeUnpackBoth();
-    float ret = p4_.load()->Phi() + dphi_;
-    while (ret > float(M_PI))
-      ret -= 2 * float(M_PI);
-    while (ret < -float(M_PI))
-      ret += 2 * float(M_PI);
-    return ret;
-  }
-  /// eta from the track (normally identical to eta())
-  virtual float etaAtVtx() const {
-    maybeUnpackBoth();
-    return p4_.load()->eta() + deta_;
-  }
+    /// pt from the track (normally identical to pt())
+    virtual double ptTrk() const {
+      maybeUnpackBoth();
+      return p4_.load()->pt() + dtrkpt_;
+    }
+    /// momentum azimuthal angle from the track (normally identical to phi())
+    virtual float phiAtVtx() const {
+      maybeUnpackBoth();
+      float ret = p4_.load()->Phi() + dphi_;
+      while (ret > float(M_PI))
+        ret -= 2 * float(M_PI);
+      while (ret < -float(M_PI))
+        ret += 2 * float(M_PI);
+      return ret;
+    }
+    /// eta from the track (normally identical to eta())
+    virtual float etaAtVtx() const {
+      maybeUnpackBoth();
+      return p4_.load()->eta() + deta_;
+    }
 
-  /// momentum polar angle
-  double theta() const override {
-    if (!p4c_)
-      unpack();
-    return p4_.load()->Theta();
-  }
-  /// momentum pseudorapidity
-  double eta() const override {
-    if (!p4c_)
-      unpack();
-    return p4_.load()->Eta();
-  }
-  /// rapidity
-  double rapidity() const override {
-    if (!p4c_)
-      unpack();
-    return p4_.load()->Rapidity();
-  }
-  /// rapidity
-  double y() const override {
-    if (!p4c_)
-      unpack();
-    return p4_.load()->Rapidity();
-  }
-  /// set 4-momentum
-  void setP4(const LorentzVector &p4) override {
-    maybeUnpackBoth(); // changing px,py,pz changes also mapping between dxy,dz
-                       // and x,y,z
-    dphi_ += polarP4().Phi() - p4.Phi();
-    deta_ += polarP4().Eta() - p4.Eta();
-    dtrkpt_ += polarP4().Pt() - p4.Pt();
-    *p4_ = PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M());
-    packBoth();
-  }
-  /// set 4-momentum
-  void setP4(const PolarLorentzVector &p4) override {
-    maybeUnpackBoth(); // changing px,py,pz changes also mapping between dxy,dz
-                       // and x,y,z
-    dphi_ += polarP4().Phi() - p4.Phi();
-    deta_ += polarP4().Eta() - p4.Eta();
-    dtrkpt_ += polarP4().Pt() - p4.Pt();
-    *p4_ = p4;
-    packBoth();
-  }
-  /// set particle mass
-  void setMass(double m) override {
-    if (!p4c_)
-      unpack();
-    *p4_ = PolarLorentzVector(p4_.load()->Pt(), p4_.load()->Eta(),
-                              p4_.load()->Phi(), m);
-    pack();
-  }
-  void setPz(double pz) override {
-    maybeUnpackBoth(); // changing px,py,pz changes also mapping between dxy,dz
-                       // and x,y,z
-    *p4c_ = LorentzVector(p4c_.load()->Px(), p4c_.load()->Py(), pz,
-                          p4c_.load()->E());
-    dphi_ += polarP4().Phi() - p4c_.load()->Phi();
-    deta_ += polarP4().Eta() - p4c_.load()->Eta();
-    dtrkpt_ += polarP4().Pt() - p4c_.load()->Pt();
-    *p4_ = PolarLorentzVector(p4c_.load()->Pt(), p4c_.load()->Eta(),
-                              p4c_.load()->Phi(), p4c_.load()->M());
-    packBoth();
-  }
-  /// set impact parameters covariance
+    /// momentum polar angle
+    double theta() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Theta();
+    }
+    /// momentum pseudorapidity
+    double eta() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Eta();
+    }
+    /// rapidity
+    double rapidity() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Rapidity();
+    }
+    /// rapidity
+    double y() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Rapidity();
+    }
+    /// set 4-momentum
+    void setP4(const LorentzVector &p4) override {
+      maybeUnpackBoth();  // changing px,py,pz changes also mapping between dxy,dz
+                          // and x,y,z
+      dphi_ += polarP4().Phi() - p4.Phi();
+      deta_ += polarP4().Eta() - p4.Eta();
+      dtrkpt_ += polarP4().Pt() - p4.Pt();
+      *p4_ = PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M());
+      packBoth();
+    }
+    /// set 4-momentum
+    void setP4(const PolarLorentzVector &p4) override {
+      maybeUnpackBoth();  // changing px,py,pz changes also mapping between dxy,dz
+                          // and x,y,z
+      dphi_ += polarP4().Phi() - p4.Phi();
+      deta_ += polarP4().Eta() - p4.Eta();
+      dtrkpt_ += polarP4().Pt() - p4.Pt();
+      *p4_ = p4;
+      packBoth();
+    }
+    /// set particle mass
+    void setMass(double m) override {
+      if (!p4c_)
+        unpack();
+      *p4_ = PolarLorentzVector(p4_.load()->Pt(), p4_.load()->Eta(), p4_.load()->Phi(), m);
+      pack();
+    }
+    void setPz(double pz) override {
+      maybeUnpackBoth();  // changing px,py,pz changes also mapping between dxy,dz
+                          // and x,y,z
+      *p4c_ = LorentzVector(p4c_.load()->Px(), p4c_.load()->Py(), pz, p4c_.load()->E());
+      dphi_ += polarP4().Phi() - p4c_.load()->Phi();
+      deta_ += polarP4().Eta() - p4c_.load()->Eta();
+      dtrkpt_ += polarP4().Pt() - p4c_.load()->Pt();
+      *p4_ = PolarLorentzVector(p4c_.load()->Pt(), p4c_.load()->Eta(), p4c_.load()->Phi(), p4c_.load()->M());
+      packBoth();
+    }
+    /// set impact parameters covariance
 
-  // Note: mask is also the maximum value
-  enum trackHitShiftsAndMasks {
-    trackPixelHitsMask = 7,
-    trackStripHitsMask = 31,
-    trackStripHitsShift = 3
-  };
+    // Note: mask is also the maximum value
+    enum trackHitShiftsAndMasks { trackPixelHitsMask = 7, trackStripHitsMask = 31, trackStripHitsShift = 3 };
 
-  // set number of tracker hits and layers
-  virtual void setHits(const reco::Track &tk) {
-    // first we count the number of layers with hits
-    int numberOfPixelLayers_ = tk.hitPattern().pixelLayersWithMeasurement();
-    if (numberOfPixelLayers_ > trackPixelHitsMask)
-      numberOfPixelLayers_ = trackPixelHitsMask;
-    int numberOfStripLayers_ = tk.hitPattern().stripLayersWithMeasurement();
-    if (numberOfStripLayers_ > trackStripHitsMask)
-      numberOfStripLayers_ = trackStripHitsMask;
-    packedLayers_ = (numberOfPixelLayers_ & trackPixelHitsMask) |
-                    (numberOfStripLayers_ << trackStripHitsShift);
-    // now we count number of additional hits, beyond the one-per-layer implied
-    // by packedLayers_
-    int numberOfPixelHits_ =
-        tk.hitPattern().numberOfValidPixelHits() - numberOfPixelLayers_;
-    if (numberOfPixelHits_ > trackPixelHitsMask)
-      numberOfPixelHits_ = trackPixelHitsMask;
-    int numberOfStripHits_ = tk.hitPattern().numberOfValidHits() -
-                             numberOfPixelHits_ - numberOfPixelLayers_ -
-                             numberOfStripLayers_;
-    if (numberOfStripHits_ > trackStripHitsMask)
-      numberOfStripHits_ = trackStripHitsMask;
+    // set number of tracker hits and layers
+    virtual void setHits(const reco::Track &tk) {
+      // first we count the number of layers with hits
+      int numberOfPixelLayers_ = tk.hitPattern().pixelLayersWithMeasurement();
+      if (numberOfPixelLayers_ > trackPixelHitsMask)
+        numberOfPixelLayers_ = trackPixelHitsMask;
+      int numberOfStripLayers_ = tk.hitPattern().stripLayersWithMeasurement();
+      if (numberOfStripLayers_ > trackStripHitsMask)
+        numberOfStripLayers_ = trackStripHitsMask;
+      packedLayers_ = (numberOfPixelLayers_ & trackPixelHitsMask) | (numberOfStripLayers_ << trackStripHitsShift);
+      // now we count number of additional hits, beyond the one-per-layer implied
+      // by packedLayers_
+      int numberOfPixelHits_ = tk.hitPattern().numberOfValidPixelHits() - numberOfPixelLayers_;
+      if (numberOfPixelHits_ > trackPixelHitsMask)
+        numberOfPixelHits_ = trackPixelHitsMask;
+      int numberOfStripHits_ =
+          tk.hitPattern().numberOfValidHits() - numberOfPixelHits_ - numberOfPixelLayers_ - numberOfStripLayers_;
+      if (numberOfStripHits_ > trackStripHitsMask)
+        numberOfStripHits_ = trackStripHitsMask;
 
-    packedHits_ = (numberOfPixelHits_ & trackPixelHitsMask) |
-                  (numberOfStripHits_ << trackStripHitsShift);
-  }
+      packedHits_ = (numberOfPixelHits_ & trackPixelHitsMask) | (numberOfStripHits_ << trackStripHitsShift);
+    }
 
-  virtual void
-  setTrackProperties(const reco::Track &tk,
-                     const reco::Track::CovarianceMatrix &covariance,
-                     int quality, int covarianceVersion) {
-    covarianceVersion_ = covarianceVersion;
-    covarianceSchema_ = quality;
-    normalizedChi2_ = tk.normalizedChi2();
-    setHits(tk);
-    packBoth();
-    packCovariance(covariance, false);
-  }
+    virtual void setTrackProperties(const reco::Track &tk,
+                                    const reco::Track::CovarianceMatrix &covariance,
+                                    int quality,
+                                    int covarianceVersion) {
+      covarianceVersion_ = covarianceVersion;
+      covarianceSchema_ = quality;
+      normalizedChi2_ = tk.normalizedChi2();
+      setHits(tk);
+      packBoth();
+      packCovariance(covariance, false);
+    }
 
-  // set track properties using quality and covarianceVersion to define the
-  // level of details in the cov. matrix
-  virtual void setTrackProperties(const reco::Track &tk, int quality,
-                                  int covarianceVersion) {
-    setTrackProperties(tk, tk.covariance(), quality, covarianceVersion);
-  }
+    // set track properties using quality and covarianceVersion to define the
+    // level of details in the cov. matrix
+    virtual void setTrackProperties(const reco::Track &tk, int quality, int covarianceVersion) {
+      setTrackProperties(tk, tk.covariance(), quality, covarianceVersion);
+    }
 
-  int numberOfPixelHits() const {
-    return (packedHits_ & trackPixelHitsMask) + pixelLayersWithMeasurement();
-  }
-  int numberOfHits() const {
-    return (packedHits_ >> trackStripHitsShift) + stripLayersWithMeasurement() +
-           numberOfPixelHits();
-  }
-  int pixelLayersWithMeasurement() const {
-    return packedLayers_ & trackPixelHitsMask;
-  }
-  int stripLayersWithMeasurement() const {
-    return (packedLayers_ >> trackStripHitsShift);
-  }
-  int trackerLayersWithMeasurement() const {
-    return stripLayersWithMeasurement() + pixelLayersWithMeasurement();
-  }
-  virtual void setCovarianceVersion(int v) { covarianceVersion_ = v; }
-  int covarianceVersion() const { return covarianceVersion_; }
-  int covarianceSchema() const { return covarianceSchema_; }
+    int numberOfPixelHits() const { return (packedHits_ & trackPixelHitsMask) + pixelLayersWithMeasurement(); }
+    int numberOfHits() const {
+      return (packedHits_ >> trackStripHitsShift) + stripLayersWithMeasurement() + numberOfPixelHits();
+    }
+    int pixelLayersWithMeasurement() const { return packedLayers_ & trackPixelHitsMask; }
+    int stripLayersWithMeasurement() const { return (packedLayers_ >> trackStripHitsShift); }
+    int trackerLayersWithMeasurement() const { return stripLayersWithMeasurement() + pixelLayersWithMeasurement(); }
+    virtual void setCovarianceVersion(int v) { covarianceVersion_ = v; }
+    int covarianceVersion() const { return covarianceVersion_; }
+    int covarianceSchema() const { return covarianceSchema_; }
 
-  /// vertex position
-  const Point &vertex() const override {
-    maybeUnpackBoth();
-    return *vertex_;
-  } //{ if (fromPV_) return Point(0,0,0); else return Point(0,0,100); }
-  /// x coordinate of vertex position
-  double vx() const override {
-    maybeUnpackBoth();
-    return vertex_.load()->X();
-  } //{ return 0; }
-  /// y coordinate of vertex position
-  double vy() const override {
-    maybeUnpackBoth();
-    return vertex_.load()->Y();
-  } //{ return 0; }
-  /// z coordinate of vertex position
-  double vz() const override {
-    maybeUnpackBoth();
-    return vertex_.load()->Z();
-  } //{ if (fromPV_) return 0; else return 100; }
-  /// set vertex
-  void setVertex(const Point &vertex) override {
-    maybeUnpackBoth();
-    *vertex_ = vertex;
-    packVtx();
-  }
+    /// vertex position
+    const Point &vertex() const override {
+      maybeUnpackBoth();
+      return *vertex_;
+    }  //{ if (fromPV_) return Point(0,0,0); else return Point(0,0,100); }
+    /// x coordinate of vertex position
+    double vx() const override {
+      maybeUnpackBoth();
+      return vertex_.load()->X();
+    }  //{ return 0; }
+    /// y coordinate of vertex position
+    double vy() const override {
+      maybeUnpackBoth();
+      return vertex_.load()->Y();
+    }  //{ return 0; }
+    /// z coordinate of vertex position
+    double vz() const override {
+      maybeUnpackBoth();
+      return vertex_.load()->Z();
+    }  //{ if (fromPV_) return 0; else return 100; }
+    /// set vertex
+    void setVertex(const Point &vertex) override {
+      maybeUnpackBoth();
+      *vertex_ = vertex;
+      packVtx();
+    }
 
-  /// This refers to the association to PV=ipv. >=PVLoose corresponds to JME
-  /// definition, >=PVTight to isolation definition
-  enum PVAssoc { NoPV = 0, PVLoose = 1, PVTight = 2, PVUsedInFit = 3 };
-  const PVAssoc fromPV(size_t ipv = 0) const {
-    reco::VertexRef pvRef = vertexRef();
-    if (pvAssociationQuality() == UsedInFitTight and pvRef.key() == ipv)
-      return PVUsedInFit;
-    if (pvRef.key() == ipv or abs(pdgId()) == 13 or abs(pdgId()) == 11)
-      return PVTight;
-    if (pvAssociationQuality() == CompatibilityBTag and
-        std::abs(dzAssociatedPV()) > std::abs(dz(ipv)))
-      return PVTight; // it is not closest, but at least prevents the B
-                      // assignment stealing
-    if (pvAssociationQuality() < UsedInFitLoose or pvRef->ndof() < 4.0)
-      return PVLoose;
-    return NoPV;
-  }
+    /// This refers to the association to PV=ipv. >=PVLoose corresponds to JME
+    /// definition, >=PVTight to isolation definition
+    enum PVAssoc { NoPV = 0, PVLoose = 1, PVTight = 2, PVUsedInFit = 3 };
+    const PVAssoc fromPV(size_t ipv = 0) const {
+      reco::VertexRef pvRef = vertexRef();
+      if (pvAssociationQuality() == UsedInFitTight and pvRef.key() == ipv)
+        return PVUsedInFit;
+      if (pvRef.key() == ipv or abs(pdgId()) == 13 or abs(pdgId()) == 11)
+        return PVTight;
+      if (pvAssociationQuality() == CompatibilityBTag and std::abs(dzAssociatedPV()) > std::abs(dz(ipv)))
+        return PVTight;  // it is not closest, but at least prevents the B
+                         // assignment stealing
+      if (pvAssociationQuality() < UsedInFitLoose or pvRef->ndof() < 4.0)
+        return PVLoose;
+      return NoPV;
+    }
 
-  /// The following contains information about how the association to the PV,
-  /// given in vertexRef, is obtained.
-  ///
-  enum PVAssociationQuality {
-    NotReconstructedPrimary = 0,
-    OtherDeltaZ = 1,
-    CompatibilityBTag = 4,
-    CompatibilityDz = 5,
-    UsedInFitLoose = 6,
-    UsedInFitTight = 7
-  };
-  const PVAssociationQuality pvAssociationQuality() const {
-    return PVAssociationQuality((qualityFlags_ & assignmentQualityMask) >>
-                                assignmentQualityShift);
-  }
-  void setAssociationQuality(PVAssociationQuality q) {
-    qualityFlags_ = (qualityFlags_ & ~assignmentQualityMask) |
-                    ((q << assignmentQualityShift) & assignmentQualityMask);
-  }
+    /// The following contains information about how the association to the PV,
+    /// given in vertexRef, is obtained.
+    ///
+    enum PVAssociationQuality {
+      NotReconstructedPrimary = 0,
+      OtherDeltaZ = 1,
+      CompatibilityBTag = 4,
+      CompatibilityDz = 5,
+      UsedInFitLoose = 6,
+      UsedInFitTight = 7
+    };
+    const PVAssociationQuality pvAssociationQuality() const {
+      return PVAssociationQuality((qualityFlags_ & assignmentQualityMask) >> assignmentQualityShift);
+    }
+    void setAssociationQuality(PVAssociationQuality q) {
+      qualityFlags_ =
+          (qualityFlags_ & ~assignmentQualityMask) | ((q << assignmentQualityShift) & assignmentQualityMask);
+    }
 
-  const reco::VertexRef vertexRef() const {
-    return reco::VertexRef(pvRefProd_, pvRefKey_);
-  }
+    const reco::VertexRef vertexRef() const { return reco::VertexRef(pvRefProd_, pvRefKey_); }
 
-  /// dxy with respect to the PV ref
-  virtual float dxy() const {
-    maybeUnpackBoth();
-    return dxy_;
-  }
-  /// dz with respect to the PV[ipv]
-  virtual float dz(size_t ipv = 0) const {
-    maybeUnpackBoth();
-    return dz_ + (*pvRefProd_)[pvRefKey_].position().z() -
-           (*pvRefProd_)[ipv].position().z();
-  }
-  /// dz with respect to the PV ref
-  virtual float dzAssociatedPV() const {
-    maybeUnpackBoth();
-    return dz_;
-  }
-  /// dxy with respect to another point
-  virtual float dxy(const Point &p) const;
-  /// dz  with respect to another point
-  virtual float dz(const Point &p) const;
+    /// dxy with respect to the PV ref
+    virtual float dxy() const {
+      maybeUnpackBoth();
+      return dxy_;
+    }
+    /// dz with respect to the PV[ipv]
+    virtual float dz(size_t ipv = 0) const {
+      maybeUnpackBoth();
+      return dz_ + (*pvRefProd_)[pvRefKey_].position().z() - (*pvRefProd_)[ipv].position().z();
+    }
+    /// dz with respect to the PV ref
+    virtual float dzAssociatedPV() const {
+      maybeUnpackBoth();
+      return dz_;
+    }
+    /// dxy with respect to another point
+    virtual float dxy(const Point &p) const;
+    /// dz  with respect to another point
+    virtual float dz(const Point &p) const;
 
-  /// uncertainty on dz
-  float dzError() const override {
-    maybeUnpackCovariance();
-    return sqrt((*m_.load())(4, 4));
-  }
-  /// uncertainty on dxy
-  float dxyError() const override {
-    maybeUnpackCovariance();
-    return sqrt((*m_.load())(3, 3));
-  }
+    /// uncertainty on dz
+    float dzError() const override {
+      maybeUnpackCovariance();
+      return sqrt((*m_.load())(4, 4));
+    }
+    /// uncertainty on dxy
+    float dxyError() const override {
+      maybeUnpackCovariance();
+      return sqrt((*m_.load())(3, 3));
+    }
 
-  /// Return reference to a pseudo track made with candidate kinematics,
-  /// parameterized error for eta,phi,pt and full IP covariance
-  virtual const reco::Track &pseudoTrack() const {
-    if (!track_)
-      unpackTrk();
-    return *track_;
-  }
+    /// Return reference to a pseudo track made with candidate kinematics,
+    /// parameterized error for eta,phi,pt and full IP covariance
+    virtual const reco::Track &pseudoTrack() const {
+      if (!track_)
+        unpackTrk();
+      return *track_;
+    }
 
-  /// return a pointer to the track if present. otherwise, return a null pointer
-  const reco::Track *bestTrack() const override {
-    if (packedHits_ != 0 || packedLayers_ != 0) {
-      maybeUnpackTrack();
-      return track_.load();
-    } else
-      return nullptr;
-  }
-  /// Return true if a bestTrack can be extracted from this Candidate
-  bool hasTrackDetails() const {
-    return (packedHits_ != 0 || packedLayers_ != 0);
-  }
+    /// return a pointer to the track if present. otherwise, return a null pointer
+    const reco::Track *bestTrack() const override {
+      if (packedHits_ != 0 || packedLayers_ != 0) {
+        maybeUnpackTrack();
+        return track_.load();
+      } else
+        return nullptr;
+    }
+    /// Return true if a bestTrack can be extracted from this Candidate
+    bool hasTrackDetails() const { return (packedHits_ != 0 || packedLayers_ != 0); }
 
-  /// true if the track had the highPurity quality bit
-  bool trackHighPurity() const {
-    return (qualityFlags_ & trackHighPurityMask) >> trackHighPurityShift;
-  }
-  /// set to true if the track had the highPurity quality bit
-  void setTrackHighPurity(bool highPurity) {
-    qualityFlags_ =
-        (qualityFlags_ & ~trackHighPurityMask) |
-        ((highPurity << trackHighPurityShift) & trackHighPurityMask);
-  }
+    /// true if the track had the highPurity quality bit
+    bool trackHighPurity() const { return (qualityFlags_ & trackHighPurityMask) >> trackHighPurityShift; }
+    /// set to true if the track had the highPurity quality bit
+    void setTrackHighPurity(bool highPurity) {
+      qualityFlags_ =
+          (qualityFlags_ & ~trackHighPurityMask) | ((highPurity << trackHighPurityShift) & trackHighPurityMask);
+    }
 
-  /// Enumerator specifying the
-  enum LostInnerHits {
-    validHitInFirstPixelBarrelLayer = -1,
-    noLostInnerHits = 0, // it could still not have a hit in the first layer,
-                         // e.g. if it crosses an inactive sensor
-    oneLostInnerHit = 1,
-    moreLostInnerHits = 2
-  };
-  LostInnerHits lostInnerHits() const {
-    return LostInnerHits(
-        int16_t((qualityFlags_ & lostInnerHitsMask) >> lostInnerHitsShift) - 1);
-  }
-  void setLostInnerHits(LostInnerHits hits) {
-    int lost = hits;
-    if (lost > 2)
-      lost = 2; // protection against misuse
-    lost++;     // shift so it's 0 .. 3 instead of (-1) .. 2
-    qualityFlags_ = (qualityFlags_ & ~lostInnerHitsMask) |
-                    ((lost << lostInnerHitsShift) & lostInnerHitsMask);
-  }
+    /// Enumerator specifying the
+    enum LostInnerHits {
+      validHitInFirstPixelBarrelLayer = -1,
+      noLostInnerHits = 0,  // it could still not have a hit in the first layer,
+                            // e.g. if it crosses an inactive sensor
+      oneLostInnerHit = 1,
+      moreLostInnerHits = 2
+    };
+    LostInnerHits lostInnerHits() const {
+      return LostInnerHits(int16_t((qualityFlags_ & lostInnerHitsMask) >> lostInnerHitsShift) - 1);
+    }
+    void setLostInnerHits(LostInnerHits hits) {
+      int lost = hits;
+      if (lost > 2)
+        lost = 2;  // protection against misuse
+      lost++;      // shift so it's 0 .. 3 instead of (-1) .. 2
+      qualityFlags_ = (qualityFlags_ & ~lostInnerHitsMask) | ((lost << lostInnerHitsShift) & lostInnerHitsMask);
+    }
 
-  /// Set first hit from HitPattern
-  void setFirstHit(uint16_t pattern) { firstHit_ = pattern; }
-  /// Return first hit from HitPattern for tracks with high level details
-  uint16_t firstHit() const { return firstHit_; }
+    /// Set first hit from HitPattern
+    void setFirstHit(uint16_t pattern) { firstHit_ = pattern; }
+    /// Return first hit from HitPattern for tracks with high level details
+    uint16_t firstHit() const { return firstHit_; }
 
-  void setMuonID(bool isStandAlone, bool isGlobal) {
-    int16_t muonFlags = isStandAlone | (2 * isGlobal);
-    qualityFlags_ = (qualityFlags_ & ~muonFlagsMask) |
-                    ((muonFlags << muonFlagsShift) & muonFlagsMask);
-  }
+    void setMuonID(bool isStandAlone, bool isGlobal) {
+      int16_t muonFlags = isStandAlone | (2 * isGlobal);
+      qualityFlags_ = (qualityFlags_ & ~muonFlagsMask) | ((muonFlags << muonFlagsShift) & muonFlagsMask);
+    }
 
-  void setGoodEgamma(bool isGoodEgamma = true) {
-    int16_t egFlags = (isGoodEgamma << egammaFlagsShift) & egammaFlagsMask;
-    qualityFlags_ = (qualityFlags_ & ~egammaFlagsMask) | egFlags;
-  }
+    void setGoodEgamma(bool isGoodEgamma = true) {
+      int16_t egFlags = (isGoodEgamma << egammaFlagsShift) & egammaFlagsMask;
+      qualityFlags_ = (qualityFlags_ & ~egammaFlagsMask) | egFlags;
+    }
 
-  /// PDG identifier
-  int pdgId() const override { return pdgId_; }
-  // set PDG identifier
-  void setPdgId(int pdgId) override { pdgId_ = pdgId; }
-  /// status word
-  int status() const override { return qualityFlags_; } /*FIXME*/
-  /// set status word
-  void setStatus(int status) override {} /*FIXME*/
-  /// long lived flag
-  static const unsigned int longLivedTag = 0; /*FIXME*/
-  /// set long lived flag
-  void setLongLived() override {} /*FIXME*/
-  /// is long lived?
-  bool longLived() const override;
-  /// do mass constraint flag
-  static const unsigned int massConstraintTag = 0; /*FIXME*/
-  /// set mass constraint flag
-  void setMassConstraint() override {} /*FIXME*/
-  /// do mass constraint?
-  bool massConstraint() const override;
+    /// PDG identifier
+    int pdgId() const override { return pdgId_; }
+    // set PDG identifier
+    void setPdgId(int pdgId) override { pdgId_ = pdgId; }
+    /// status word
+    int status() const override { return qualityFlags_; } /*FIXME*/
+    /// set status word
+    void setStatus(int status) override {} /*FIXME*/
+    /// long lived flag
+    static const unsigned int longLivedTag = 0; /*FIXME*/
+    /// set long lived flag
+    void setLongLived() override {} /*FIXME*/
+    /// is long lived?
+    bool longLived() const override;
+    /// do mass constraint flag
+    static const unsigned int massConstraintTag = 0; /*FIXME*/
+    /// set mass constraint flag
+    void setMassConstraint() override {} /*FIXME*/
+    /// do mass constraint?
+    bool massConstraint() const override;
 
-  /// returns a clone of the Candidate object
-  PackedCandidate *clone() const override { return new PackedCandidate(*this); }
+    /// returns a clone of the Candidate object
+    PackedCandidate *clone() const override { return new PackedCandidate(*this); }
 
-  /// chi-squares
-  double vertexChi2() const override;
-  /** Number of degrees of freedom
+    /// chi-squares
+    double vertexChi2() const override;
+    /** Number of degrees of freedom
    *  Meant to be Double32_t for soft-assignment fitters:
    *  tracks may contribute to the vertex with fractional weights.
    *  The ndof is then = to the sum of the track weights.
    *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002
    */
-  double vertexNdof() const override;
-  /// chi-squared divided by n.d.o.f.
-  double vertexNormalizedChi2() const override;
-  /// (i, j)-th element of error matrix, i, j = 0, ... 2
-  double vertexCovariance(int i, int j) const override;
-  /// return SMatrix
-  CovarianceMatrix vertexCovariance() const override {
-    CovarianceMatrix m;
-    fillVertexCovariance(m);
-    return m;
-  }
-  /// fill SMatrix
-  void fillVertexCovariance(CovarianceMatrix &v) const override;
-  /// returns true if this candidate has a reference to a master clone.
-  /// This only happens if the concrete Candidate type is ShallowCloneCandidate
-  bool hasMasterClone() const override;
-  /// returns ptr to master clone, if existing.
-  /// Throws an exception unless the concrete Candidate type is
-  /// ShallowCloneCandidate
-  const reco::CandidateBaseRef &masterClone() const override;
-  /// returns true if this candidate has a ptr to a master clone.
-  /// This only happens if the concrete Candidate type is
-  /// ShallowClonePtrCandidate
-  bool hasMasterClonePtr() const override;
-  /// returns ptr to master clone, if existing.
-  /// Throws an exception unless the concrete Candidate type is
-  /// ShallowClonePtrCandidate
+    double vertexNdof() const override;
+    /// chi-squared divided by n.d.o.f.
+    double vertexNormalizedChi2() const override;
+    /// (i, j)-th element of error matrix, i, j = 0, ... 2
+    double vertexCovariance(int i, int j) const override;
+    /// return SMatrix
+    CovarianceMatrix vertexCovariance() const override {
+      CovarianceMatrix m;
+      fillVertexCovariance(m);
+      return m;
+    }
+    /// fill SMatrix
+    void fillVertexCovariance(CovarianceMatrix &v) const override;
+    /// returns true if this candidate has a reference to a master clone.
+    /// This only happens if the concrete Candidate type is ShallowCloneCandidate
+    bool hasMasterClone() const override;
+    /// returns ptr to master clone, if existing.
+    /// Throws an exception unless the concrete Candidate type is
+    /// ShallowCloneCandidate
+    const reco::CandidateBaseRef &masterClone() const override;
+    /// returns true if this candidate has a ptr to a master clone.
+    /// This only happens if the concrete Candidate type is
+    /// ShallowClonePtrCandidate
+    bool hasMasterClonePtr() const override;
+    /// returns ptr to master clone, if existing.
+    /// Throws an exception unless the concrete Candidate type is
+    /// ShallowClonePtrCandidate
 
-  const reco::CandidatePtr &masterClonePtr() const override;
+    const reco::CandidatePtr &masterClonePtr() const override;
 
-  /// cast master clone reference to a concrete type
-  template <typename Ref> Ref masterRef() const {
-    return masterClone().template castTo<Ref>();
-  }
+    /// cast master clone reference to a concrete type
+    template <typename Ref>
+    Ref masterRef() const {
+      return masterClone().template castTo<Ref>();
+    }
 
-  bool isElectron() const override { return false; }
-  bool isMuon() const override { return false; }
-  bool isStandAloneMuon() const override {
-    return ((qualityFlags_ & muonFlagsMask) >> muonFlagsShift) & 1;
-  }
-  bool isGlobalMuon() const override {
-    return ((qualityFlags_ & muonFlagsMask) >> muonFlagsShift) & 2;
-  }
-  bool isTrackerMuon() const override { return false; }
-  bool isCaloMuon() const override { return false; }
-  bool isPhoton() const override { return false; }
-  bool isConvertedPhoton() const override { return false; }
-  bool isJet() const override { return false; }
-  bool isGoodEgamma() const { return (qualityFlags_ & egammaFlagsMask) != 0; }
+    bool isElectron() const override { return false; }
+    bool isMuon() const override { return false; }
+    bool isStandAloneMuon() const override { return ((qualityFlags_ & muonFlagsMask) >> muonFlagsShift) & 1; }
+    bool isGlobalMuon() const override { return ((qualityFlags_ & muonFlagsMask) >> muonFlagsShift) & 2; }
+    bool isTrackerMuon() const override { return false; }
+    bool isCaloMuon() const override { return false; }
+    bool isPhoton() const override { return false; }
+    bool isConvertedPhoton() const override { return false; }
+    bool isJet() const override { return false; }
+    bool isGoodEgamma() const { return (qualityFlags_ & egammaFlagsMask) != 0; }
 
-  // puppiweights
-  void setPuppiWeight(float p,
-                      float p_nolep = 0.0); /// Set both weights at once (with
-                                            /// option for only full PUPPI)
-  float puppiWeight() const;                /// Weight from full PUPPI
-  float puppiWeightNoLep() const; /// Weight from PUPPI removing leptons
+    // puppiweights
+    void setPuppiWeight(float p,
+                        float p_nolep = 0.0);  /// Set both weights at once (with
+                                               /// option for only full PUPPI)
+    float puppiWeight() const;                 /// Weight from full PUPPI
+    float puppiWeightNoLep() const;            /// Weight from PUPPI removing leptons
 
-  // for the neutral fractions
-  void
-  setRawCaloFraction(float p); /// Set the raw ECAL+HCAL energy over candidate
-                               /// energy for isolated charged hadrons
-  float rawCaloFraction() const {
-    return (rawCaloFraction_ / 100.);
-  } /// Raw ECAL+HCAL energy over candidate energy for isolated charged hadrons
-  void setRawHcalFraction(
-      float p); /// Set the fraction of Hcal needed isolated charged hadrons
-  float rawHcalFraction() const {
-    return (rawHcalFraction_ / 100.);
-  } /// Fraction of Hcal for isolated charged hadrons
-  void setCaloFraction(
-      float p); /// Set the fraction of ECAL+HCAL energy over candidate energy
-  float caloFraction() const {
-    return (caloFraction_ / 100.);
-  } /// Fraction of ECAL+HCAL energy over candidate energy
-  void setHcalFraction(float p); /// Set the fraction of Hcal needed for HF,
-                                 /// neutral hadrons, and charged particles
-  float hcalFraction() const {
-    return (hcalFraction_ / 100.);
-  } /// Fraction of Hcal for HF, neutral hadrons, and charged particles
+    // for the neutral fractions
+    void setRawCaloFraction(float p);  /// Set the raw ECAL+HCAL energy over candidate
+                                       /// energy for isolated charged hadrons
+    float rawCaloFraction() const {
+      return (rawCaloFraction_ / 100.);
+    }                                  /// Raw ECAL+HCAL energy over candidate energy for isolated charged hadrons
+    void setRawHcalFraction(float p);  /// Set the fraction of Hcal needed isolated charged hadrons
+    float rawHcalFraction() const {
+      return (rawHcalFraction_ / 100.);
+    }                               /// Fraction of Hcal for isolated charged hadrons
+    void setCaloFraction(float p);  /// Set the fraction of ECAL+HCAL energy over candidate energy
+    float caloFraction() const {
+      return (caloFraction_ / 100.);
+    }                               /// Fraction of ECAL+HCAL energy over candidate energy
+    void setHcalFraction(float p);  /// Set the fraction of Hcal needed for HF,
+                                    /// neutral hadrons, and charged particles
+    float hcalFraction() const {
+      return (hcalFraction_ / 100.);
+    }  /// Fraction of Hcal for HF, neutral hadrons, and charged particles
 
-  // isolated charged hadrons
-  void setIsIsolatedChargedHadron(
-      bool p); /// Set isolation (as in particle flow, i.e. at calorimeter
-               /// surface rather than at PV) flat for charged hadrons
-  bool isIsolatedChargedHadron() const {
-    return isIsolatedChargedHadron_;
-  } /// Flag isolation (as in particle flow, i.e. at calorimeter surface rather
+    // isolated charged hadrons
+    void setIsIsolatedChargedHadron(bool p);  /// Set isolation (as in particle flow, i.e. at calorimeter
+                                              /// surface rather than at PV) flat for charged hadrons
+    bool isIsolatedChargedHadron() const {
+      return isIsolatedChargedHadron_;
+    }  /// Flag isolation (as in particle flow, i.e. at calorimeter surface rather
     /// than at PV) flag for charged hadrons
 
-  struct PackedCovariance {
-    PackedCovariance()
-        : dxydxy(0), dxydz(0), dzdz(0), dlambdadz(0), dphidxy(0), dptdpt(0),
-          detadeta(0), dphidphi(0) {}
-    // 3D IP covariance
-    uint16_t dxydxy;
-    uint16_t dxydz;
-    uint16_t dzdz;
-    // other IP relevant elements
-    uint16_t dlambdadz;
-    uint16_t dphidxy;
-    // other diag elements
-    uint16_t dptdpt;
-    uint16_t detadeta;
-    uint16_t dphidphi;
-  };
+    struct PackedCovariance {
+      PackedCovariance()
+          : dxydxy(0), dxydz(0), dzdz(0), dlambdadz(0), dphidxy(0), dptdpt(0), detadeta(0), dphidphi(0) {}
+      // 3D IP covariance
+      uint16_t dxydxy;
+      uint16_t dxydz;
+      uint16_t dzdz;
+      // other IP relevant elements
+      uint16_t dlambdadz;
+      uint16_t dphidxy;
+      // other diag elements
+      uint16_t dptdpt;
+      uint16_t detadeta;
+      uint16_t dphidphi;
+    };
 
-  /// time (wrt nominal zero of the collision)
-  virtual float time() const { return vertexRef()->t() + dtimeAssociatedPV(); }
-  /// dtime with respect to the PV[ipv]
-  virtual float dtime(size_t ipv = 0) const {
-    return dtimeAssociatedPV() + (*pvRefProd_)[pvRefKey_].t() -
-           (*pvRefProd_)[ipv].t();
-  }
-  /// dtime with respect to the PV ref
-  virtual float dtimeAssociatedPV() const {
-    if (packedTime_ == 0)
-      return 0.f;
-    if (packedTimeError_ > 0)
-      return unpackTimeWithError(packedTime_, packedTimeError_);
-    else
-      return unpackTimeNoError(packedTime_);
-  }
-  /// time measurement uncertainty (-1 if not available)
-  virtual float timeError() const { return unpackTimeError(packedTimeError_); }
-  /// set time measurement
-  void setDTimeAssociatedPV(float aTime, float aTimeError = 0);
-  /// set time measurement
-  void setTime(float aTime, float aTimeError = 0) {
-    setDTimeAssociatedPV(aTime - vertexRef()->t(), aTimeError);
-  }
-
-private:
-  void unpackCovarianceElement(reco::TrackBase::CovarianceMatrix &m,
-                               uint16_t packed, int i, int j) const {
-    m(i, j) = covarianceParameterization().unpack(
-        packed, covarianceSchema_, i, j, pt(), eta(), numberOfHits(),
-        numberOfPixelHits());
-  }
-  uint16_t packCovarianceElement(const reco::TrackBase::CovarianceMatrix &m,
-                                 int i, int j) const {
-    return covarianceParameterization().pack(m(i, j), covarianceSchema_, i, j,
-                                             pt(), eta(), numberOfHits(),
-                                             numberOfPixelHits());
-  }
-
-protected:
-  friend class ::testPackedCandidate;
-  static constexpr float kMinDEtaToStore_ = 0.001;
-  static constexpr float kMinDTrkPtToStore_ = 0.001;
-
-  uint16_t packedPt_, packedEta_, packedPhi_, packedM_;
-  uint16_t packedDxy_, packedDz_, packedDPhi_, packedDEta_, packedDTrkPt_;
-  PackedCovariance packedCovariance_;
-
-  void pack(bool unpackAfterwards = true);
-  void unpack() const;
-  void packVtx(bool unpackAfterwards = true);
-  void unpackVtx() const;
-  void packCovariance(const reco::TrackBase::CovarianceMatrix &m,
-                      bool unpackAfterwards = true);
-  void unpackCovariance() const;
-  void maybeUnpackBoth() const {
-    if (!p4c_)
-      unpack();
-    if (!vertex_)
-      unpackVtx();
-  }
-  void maybeUnpackTrack() const {
-    if (!track_)
-      unpackTrk();
-  }
-  void maybeUnpackCovariance() const {
-    if (!m_)
-      unpackCovariance();
-  }
-  void packBoth() {
-    pack(false);
-    packVtx(false);
-    delete p4_.exchange(nullptr);
-    delete p4c_.exchange(nullptr);
-    delete vertex_.exchange(nullptr);
-    unpack();
-    unpackVtx();
-  } // do it this way, so that we don't loose precision on the angles before
-    // computing dxy,dz
-  void unpackTrk() const;
-
-  uint8_t packedPuppiweight_;
-  int8_t packedPuppiweightNoLepDiff_; // storing the DIFFERENCE of (all - "no
-                                      // lep") for compression optimization
-  uint8_t rawCaloFraction_;
-  int8_t rawHcalFraction_;
-  uint8_t caloFraction_;
-  int8_t hcalFraction_;
-  int16_t packedTime_;
-  uint8_t packedTimeError_;
-
-  bool isIsolatedChargedHadron_;
-
-  /// the four vector
-  mutable std::atomic<PolarLorentzVector *> p4_;
-  mutable std::atomic<LorentzVector *> p4c_;
-  /// vertex position
-  mutable std::atomic<Point *> vertex_;
-  CMS_THREAD_GUARD(vertex_) mutable float dxy_, dz_, dphi_, deta_, dtrkpt_;
-  /// reco::Track
-  mutable std::atomic<reco::Track *> track_;
-  /// PDG identifier
-  int pdgId_;
-  uint16_t qualityFlags_;
-  /// Use these to build a Ref to primary vertex
-  reco::VertexRefProd pvRefProd_;
-  reco::VertexRef::key_type pvRefKey_;
-
-  /// IP covariance
-  mutable std::atomic<reco::TrackBase::CovarianceMatrix *> m_;
-  uint8_t packedHits_,
-      packedLayers_; // packedLayers_ -> layers with valid hits; packedHits_ ->
-                     // extra hits beyond the one-per-layer implied by
-                     // packedLayers_
-
-  /// track quality information
-  uint8_t normalizedChi2_;
-  uint16_t covarianceVersion_;
-  uint16_t covarianceSchema_;
-  CMS_THREAD_SAFE static CovarianceParameterization covarianceParameterization_;
-  // static std::atomic<CovarianceParameterization*>
-  // covarianceParameterization_;
-  static std::once_flag covariance_load_flag;
-  const CovarianceParameterization &covarianceParameterization() const {
-    if (!hasTrackDetails())
-      throw edm::Exception(edm::errors::InvalidReference,
-                           "Trying to access covariance matrix for a "
-                           "PackedCandidate for which it's not available. "
-                           "Check hasTrackDetails() before!\n");
-    std::call_once(covariance_load_flag,
-                   [](int v) { covarianceParameterization_.load(v); },
-                   covarianceVersion_);
-    if (covarianceParameterization_.loadedVersion() != covarianceVersion_) {
-      throw edm::Exception(edm::errors::UnimplementedFeature)
-          << "Attempting to load multiple covariance version in same process. "
-             "This is not supported.";
+    /// time (wrt nominal zero of the collision)
+    virtual float time() const { return vertexRef()->t() + dtimeAssociatedPV(); }
+    /// dtime with respect to the PV[ipv]
+    virtual float dtime(size_t ipv = 0) const {
+      return dtimeAssociatedPV() + (*pvRefProd_)[pvRefKey_].t() - (*pvRefProd_)[ipv].t();
     }
-    return covarianceParameterization_;
-  }
+    /// dtime with respect to the PV ref
+    virtual float dtimeAssociatedPV() const {
+      if (packedTime_ == 0)
+        return 0.f;
+      if (packedTimeError_ > 0)
+        return unpackTimeWithError(packedTime_, packedTimeError_);
+      else
+        return unpackTimeNoError(packedTime_);
+    }
+    /// time measurement uncertainty (-1 if not available)
+    virtual float timeError() const { return unpackTimeError(packedTimeError_); }
+    /// set time measurement
+    void setDTimeAssociatedPV(float aTime, float aTimeError = 0);
+    /// set time measurement
+    void setTime(float aTime, float aTimeError = 0) { setDTimeAssociatedPV(aTime - vertexRef()->t(), aTimeError); }
 
-  /// check overlap with another Candidate
-  bool overlap(const reco::Candidate &) const override;
-  template <typename, typename, typename> friend struct component;
-  friend class ::OverlapChecker;
-  friend class ShallowCloneCandidate;
-  friend class ShallowClonePtrCandidate;
+  private:
+    void unpackCovarianceElement(reco::TrackBase::CovarianceMatrix &m, uint16_t packed, int i, int j) const {
+      m(i, j) = covarianceParameterization().unpack(
+          packed, covarianceSchema_, i, j, pt(), eta(), numberOfHits(), numberOfPixelHits());
+    }
+    uint16_t packCovarianceElement(const reco::TrackBase::CovarianceMatrix &m, int i, int j) const {
+      return covarianceParameterization().pack(
+          m(i, j), covarianceSchema_, i, j, pt(), eta(), numberOfHits(), numberOfPixelHits());
+    }
 
-  enum qualityFlagsShiftsAndMasks {
-    assignmentQualityMask = 0x7,
-    assignmentQualityShift = 0,
-    trackHighPurityMask = 0x8,
-    trackHighPurityShift = 3,
-    lostInnerHitsMask = 0x30,
-    lostInnerHitsShift = 4,
-    muonFlagsMask = 0x0600,
-    muonFlagsShift = 9,
-    egammaFlagsMask = 0x0800,
-    egammaFlagsShift = 11
+  protected:
+    friend class ::testPackedCandidate;
+    static constexpr float kMinDEtaToStore_ = 0.001;
+    static constexpr float kMinDTrkPtToStore_ = 0.001;
+
+    uint16_t packedPt_, packedEta_, packedPhi_, packedM_;
+    uint16_t packedDxy_, packedDz_, packedDPhi_, packedDEta_, packedDTrkPt_;
+    PackedCovariance packedCovariance_;
+
+    void pack(bool unpackAfterwards = true);
+    void unpack() const;
+    void packVtx(bool unpackAfterwards = true);
+    void unpackVtx() const;
+    void packCovariance(const reco::TrackBase::CovarianceMatrix &m, bool unpackAfterwards = true);
+    void unpackCovariance() const;
+    void maybeUnpackBoth() const {
+      if (!p4c_)
+        unpack();
+      if (!vertex_)
+        unpackVtx();
+    }
+    void maybeUnpackTrack() const {
+      if (!track_)
+        unpackTrk();
+    }
+    void maybeUnpackCovariance() const {
+      if (!m_)
+        unpackCovariance();
+    }
+    void packBoth() {
+      pack(false);
+      packVtx(false);
+      delete p4_.exchange(nullptr);
+      delete p4c_.exchange(nullptr);
+      delete vertex_.exchange(nullptr);
+      unpack();
+      unpackVtx();
+    }  // do it this way, so that we don't loose precision on the angles before
+    // computing dxy,dz
+    void unpackTrk() const;
+
+    uint8_t packedPuppiweight_;
+    int8_t packedPuppiweightNoLepDiff_;  // storing the DIFFERENCE of (all - "no
+                                         // lep") for compression optimization
+    uint8_t rawCaloFraction_;
+    int8_t rawHcalFraction_;
+    uint8_t caloFraction_;
+    int8_t hcalFraction_;
+    int16_t packedTime_;
+    uint8_t packedTimeError_;
+
+    bool isIsolatedChargedHadron_;
+
+    /// the four vector
+    mutable std::atomic<PolarLorentzVector *> p4_;
+    mutable std::atomic<LorentzVector *> p4c_;
+    /// vertex position
+    mutable std::atomic<Point *> vertex_;
+    CMS_THREAD_GUARD(vertex_) mutable float dxy_, dz_, dphi_, deta_, dtrkpt_;
+    /// reco::Track
+    mutable std::atomic<reco::Track *> track_;
+    /// PDG identifier
+    int pdgId_;
+    uint16_t qualityFlags_;
+    /// Use these to build a Ref to primary vertex
+    reco::VertexRefProd pvRefProd_;
+    reco::VertexRef::key_type pvRefKey_;
+
+    /// IP covariance
+    mutable std::atomic<reco::TrackBase::CovarianceMatrix *> m_;
+    uint8_t packedHits_,
+        packedLayers_;  // packedLayers_ -> layers with valid hits; packedHits_ ->
+                        // extra hits beyond the one-per-layer implied by
+                        // packedLayers_
+
+    /// track quality information
+    uint8_t normalizedChi2_;
+    uint16_t covarianceVersion_;
+    uint16_t covarianceSchema_;
+    CMS_THREAD_SAFE static CovarianceParameterization covarianceParameterization_;
+    // static std::atomic<CovarianceParameterization*>
+    // covarianceParameterization_;
+    static std::once_flag covariance_load_flag;
+    const CovarianceParameterization &covarianceParameterization() const {
+      if (!hasTrackDetails())
+        throw edm::Exception(edm::errors::InvalidReference,
+                             "Trying to access covariance matrix for a "
+                             "PackedCandidate for which it's not available. "
+                             "Check hasTrackDetails() before!\n");
+      std::call_once(covariance_load_flag, [](int v) { covarianceParameterization_.load(v); }, covarianceVersion_);
+      if (covarianceParameterization_.loadedVersion() != covarianceVersion_) {
+        throw edm::Exception(edm::errors::UnimplementedFeature)
+            << "Attempting to load multiple covariance version in same process. "
+               "This is not supported.";
+      }
+      return covarianceParameterization_;
+    }
+
+    /// check overlap with another Candidate
+    bool overlap(const reco::Candidate &) const override;
+    template <typename, typename, typename>
+    friend struct component;
+    friend class ::OverlapChecker;
+    friend class ShallowCloneCandidate;
+    friend class ShallowClonePtrCandidate;
+
+    enum qualityFlagsShiftsAndMasks {
+      assignmentQualityMask = 0x7,
+      assignmentQualityShift = 0,
+      trackHighPurityMask = 0x8,
+      trackHighPurityShift = 3,
+      lostInnerHitsMask = 0x30,
+      lostInnerHitsShift = 4,
+      muonFlagsMask = 0x0600,
+      muonFlagsShift = 9,
+      egammaFlagsMask = 0x0800,
+      egammaFlagsShift = 11
+    };
+
+    /// static to allow unit testing
+    static uint8_t packTimeError(float timeError);
+    static float unpackTimeError(uint8_t timeError);
+    static float unpackTimeNoError(int16_t time);
+    static int16_t packTimeNoError(float time);
+    static float unpackTimeWithError(int16_t time, uint8_t timeError);
+    static int16_t packTimeWithError(float time, float timeError);
+    static constexpr float MIN_TIMEERROR = 0.002f;      // 2 ps, smallest storable non-zero uncertainty
+    static constexpr float MIN_TIME_NOERROR = 0.0002f;  // 0.2 ps, smallest non-zero time that can be stored by
+                                                        // packTimeNoError
+    static constexpr int EXPO_TIMEERROR = 5;            // power of 2 used in encoding timeError
+    static constexpr int EXPO_TIME_NOERROR = 6;         // power of 2 used in encoding time without timeError
+    static constexpr int EXPO_TIME_WITHERROR = -6;      // power of 2 used in encoding time with timeError
+  public:
+    uint16_t firstHit_;
   };
 
-  /// static to allow unit testing
-  static uint8_t packTimeError(float timeError);
-  static float unpackTimeError(uint8_t timeError);
-  static float unpackTimeNoError(int16_t time);
-  static int16_t packTimeNoError(float time);
-  static float unpackTimeWithError(int16_t time, uint8_t timeError);
-  static int16_t packTimeWithError(float time, float timeError);
-  static constexpr float MIN_TIMEERROR =
-      0.002f; // 2 ps, smallest storable non-zero uncertainty
-  static constexpr float MIN_TIME_NOERROR =
-      0.0002f; // 0.2 ps, smallest non-zero time that can be stored by
-               // packTimeNoError
-  static constexpr int EXPO_TIMEERROR =
-      5; // power of 2 used in encoding timeError
-  static constexpr int EXPO_TIME_NOERROR =
-      6; // power of 2 used in encoding time without timeError
-  static constexpr int EXPO_TIME_WITHERROR =
-      -6; // power of 2 used in encoding time with timeError
-public:
-  uint16_t firstHit_;
-};
-
-typedef std::vector<pat::PackedCandidate> PackedCandidateCollection;
-typedef edm::Ref<pat::PackedCandidateCollection> PackedCandidateRef;
-typedef edm::RefVector<pat::PackedCandidateCollection> PackedCandidateRefVector;
-} // namespace pat
+  typedef std::vector<pat::PackedCandidate> PackedCandidateCollection;
+  typedef edm::Ref<pat::PackedCandidateCollection> PackedCandidateRef;
+  typedef edm::RefVector<pat::PackedCandidateCollection> PackedCandidateRefVector;
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/PackedGenParticle.h
+++ b/DataFormats/PatCandidates/interface/PackedGenParticle.h
@@ -10,7 +10,7 @@
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/Math/interface/deltaPhi.h" 
+#include "DataFormats/Math/interface/deltaPhi.h"
 /* #include "DataFormats/Math/interface/PtEtaPhiMass.h" */
 
 class testPackedGenParticle;
@@ -20,68 +20,107 @@ namespace pat {
   public:
     friend class ::testPackedGenParticle;
 
-    /// collection of daughter candidates                                                 
+    /// collection of daughter candidates
     typedef reco::CandidateCollection daughters;
-    /// Lorentz vector                                                                    
+    /// Lorentz vector
     typedef math::XYZTLorentzVector LorentzVector;
-    /// Lorentz vector                                                                    
+    /// Lorentz vector
     typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;
-    /// point in the space                                                                
+    /// point in the space
     typedef math::XYZPoint Point;
-    /// point in the space                                                                
+    /// point in the space
     typedef math::XYZVector Vector;
 
     typedef unsigned int index;
 
-    /// default constructor  
+    /// default constructor
     PackedGenParticle()
-    : packedPt_(0), packedY_(0), packedPhi_(0), packedM_(0), 
-    p4_(nullptr), p4c_(nullptr), vertex_(0,0,0),  pdgId_(0), charge_(0) { }
-    explicit PackedGenParticle( const reco::GenParticle & c)
-    : p4_(new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())), p4c_( new LorentzVector(*p4_)), vertex_(0,0,0), pdgId_(c.pdgId()), charge_(c.charge()), mother_(c.motherRef(0)),
-      statusFlags_(c.statusFlags()) { pack(); }
-    explicit PackedGenParticle( const reco::GenParticle & c, const edm::Ref<reco::GenParticleCollection> &  mother)
-    : p4_(new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())), p4c_(new LorentzVector(*p4_)), vertex_(0,0,0), pdgId_(c.pdgId()), charge_(c.charge()), mother_(mother),
-      statusFlags_(c.statusFlags()) { pack(); }
+        : packedPt_(0),
+          packedY_(0),
+          packedPhi_(0),
+          packedM_(0),
+          p4_(nullptr),
+          p4c_(nullptr),
+          vertex_(0, 0, 0),
+          pdgId_(0),
+          charge_(0) {}
+    explicit PackedGenParticle(const reco::GenParticle& c)
+        : p4_(new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())),
+          p4c_(new LorentzVector(*p4_)),
+          vertex_(0, 0, 0),
+          pdgId_(c.pdgId()),
+          charge_(c.charge()),
+          mother_(c.motherRef(0)),
+          statusFlags_(c.statusFlags()) {
+      pack();
+    }
+    explicit PackedGenParticle(const reco::GenParticle& c, const edm::Ref<reco::GenParticleCollection>& mother)
+        : p4_(new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())),
+          p4c_(new LorentzVector(*p4_)),
+          vertex_(0, 0, 0),
+          pdgId_(c.pdgId()),
+          charge_(c.charge()),
+          mother_(mother),
+          statusFlags_(c.statusFlags()) {
+      pack();
+    }
 
     PackedGenParticle(const PackedGenParticle& iOther)
-    : packedPt_(iOther.packedPt_), packedY_(iOther.packedY_), packedPhi_(iOther.packedPhi_), packedM_(iOther.packedM_),
-      p4_(nullptr),p4c_(nullptr),
-      vertex_(iOther.vertex_), dxy_(iOther.dxy_), dz_(iOther.dz_),dphi_(iOther.dphi_),
-      pdgId_(iOther.pdgId_),charge_(iOther.charge_),mother_(iOther.mother_),
-      statusFlags_(iOther.statusFlags_) {
-      if(iOther.p4c_) {
-        p4_.store( new PolarLorentzVector(*iOther.p4_) );
-        p4c_.store( new LorentzVector(*iOther.p4c_) );
+        : packedPt_(iOther.packedPt_),
+          packedY_(iOther.packedY_),
+          packedPhi_(iOther.packedPhi_),
+          packedM_(iOther.packedM_),
+          p4_(nullptr),
+          p4c_(nullptr),
+          vertex_(iOther.vertex_),
+          dxy_(iOther.dxy_),
+          dz_(iOther.dz_),
+          dphi_(iOther.dphi_),
+          pdgId_(iOther.pdgId_),
+          charge_(iOther.charge_),
+          mother_(iOther.mother_),
+          statusFlags_(iOther.statusFlags_) {
+      if (iOther.p4c_) {
+        p4_.store(new PolarLorentzVector(*iOther.p4_));
+        p4c_.store(new LorentzVector(*iOther.p4c_));
       }
     }
 
     PackedGenParticle(PackedGenParticle&& iOther)
-    : packedPt_(iOther.packedPt_), packedY_(iOther.packedY_), packedPhi_(iOther.packedPhi_), packedM_(iOther.packedM_),
-      p4_(nullptr),p4c_(nullptr),
-      vertex_(std::move(iOther.vertex_)), dxy_(iOther.dxy_), dz_(iOther.dz_),dphi_(iOther.dphi_),
-      pdgId_(iOther.pdgId_),charge_(iOther.charge_),mother_(std::move(iOther.mother_)),
-      statusFlags_(iOther.statusFlags_) {
-      if(iOther.p4c_) {
-        p4_.store( p4_.exchange(nullptr) );
-        p4c_.store( p4c_.exchange(nullptr) );
+        : packedPt_(iOther.packedPt_),
+          packedY_(iOther.packedY_),
+          packedPhi_(iOther.packedPhi_),
+          packedM_(iOther.packedM_),
+          p4_(nullptr),
+          p4c_(nullptr),
+          vertex_(std::move(iOther.vertex_)),
+          dxy_(iOther.dxy_),
+          dz_(iOther.dz_),
+          dphi_(iOther.dphi_),
+          pdgId_(iOther.pdgId_),
+          charge_(iOther.charge_),
+          mother_(std::move(iOther.mother_)),
+          statusFlags_(iOther.statusFlags_) {
+      if (iOther.p4c_) {
+        p4_.store(p4_.exchange(nullptr));
+        p4c_.store(p4c_.exchange(nullptr));
       }
     }
 
     PackedGenParticle& operator=(PackedGenParticle&& iOther) {
-      if(this != &iOther) {
+      if (this != &iOther) {
         packedPt_ = iOther.packedPt_;
         packedY_ = iOther.packedY_;
         packedPhi_ = iOther.packedPhi_;
         packedM_ = iOther.packedM_;
-        if(p4c_) {
+        if (p4c_) {
           delete p4_.exchange(iOther.p4_.exchange(nullptr));
-          delete p4c_.exchange(iOther.p4c_.exchange(nullptr)) ;
+          delete p4c_.exchange(iOther.p4c_.exchange(nullptr));
         } else {
           delete p4_.exchange(nullptr);
           delete p4c_.exchange(nullptr);
         }
-        vertex_=std::move(iOther.vertex_);
+        vertex_ = std::move(iOther.vertex_);
         dxy_ = iOther.dxy_;
         dz_ = iOther.dz_;
         dphi_ = iOther.dphi_;
@@ -104,169 +143,247 @@ namespace pat {
     /// number of daughters
     size_t numberOfDaughters() const override;
     /// return daughter at a given position (throws an exception)
-    const reco::Candidate * daughter( size_type ) const override;
+    const reco::Candidate* daughter(size_type) const override;
     /// number of mothers
     size_t numberOfMothers() const override;
     /// return mother at a given position (throws an exception)
-    const reco::Candidate * mother( size_type ) const override;
+    const reco::Candidate* mother(size_type) const override;
     /// direct access to the mother reference (may be null)
-    reco::GenParticleRef motherRef() const { 
-	if(mother_.isNonnull() && mother_.isAvailable()&& mother_->status()==1 ){ //if pointing to the pruned version of myself
-   	  if(mother_->numberOfMothers() > 0) 
-	  	  return mother_->motherRef(0); // return my mother's (that is actually myself) mother
-	 	else
-		  return edm::Ref<reco::GenParticleCollection>(); // return null ref
-	} else { 
-	  return mother_; //the stored ref is really my mother, or null, return that
-	}
+    reco::GenParticleRef motherRef() const {
+      if (mother_.isNonnull() && mother_.isAvailable() &&
+          mother_->status() == 1) {  //if pointing to the pruned version of myself
+        if (mother_->numberOfMothers() > 0)
+          return mother_->motherRef(0);  // return my mother's (that is actually myself) mother
+        else
+          return edm::Ref<reco::GenParticleCollection>();  // return null ref
+      } else {
+        return mother_;  //the stored ref is really my mother, or null, return that
+      }
     }
     /// last surviving in pruned
-    const reco::GenParticleRef & lastPrunedRef() const { return mother_; }
+    const reco::GenParticleRef& lastPrunedRef() const { return mother_; }
 
     /// return daughter at a given position (throws an exception)
-    reco::Candidate * daughter( size_type ) override;
+    reco::Candidate* daughter(size_type) override;
     /// return daughter with a specified role name
-    reco::Candidate * daughter(const std::string& s ) override;
-    /// return daughter with a specified role name                                        
-    const reco::Candidate * daughter(const std::string& s ) const override;
-    /// return the number of source Candidates                                            
-    /// ( the candidates used to construct this Candidate)                                
-    size_t numberOfSourceCandidatePtrs() const override {return 0;}
-    /// return a Ptr to one of the source Candidates                                      
-    /// ( the candidates used to construct this Candidate)                                
-    reco::CandidatePtr sourceCandidatePtr( size_type i ) const override {
-      return reco::CandidatePtr();
-    }
+    reco::Candidate* daughter(const std::string& s) override;
+    /// return daughter with a specified role name
+    const reco::Candidate* daughter(const std::string& s) const override;
+    /// return the number of source Candidates
+    /// ( the candidates used to construct this Candidate)
+    size_t numberOfSourceCandidatePtrs() const override { return 0; }
+    /// return a Ptr to one of the source Candidates
+    /// ( the candidates used to construct this Candidate)
+    reco::CandidatePtr sourceCandidatePtr(size_type i) const override { return reco::CandidatePtr(); }
 
     /// electric charge
-    int charge() const override {
-	return charge_;	
+    int charge() const override { return charge_; }
+    /// set electric charge
+    void setCharge(int charge) override { charge_ = charge; }
+    /// electric charge
+    int threeCharge() const override { return charge() * 3; }
+    /// set electric charge
+    void setThreeCharge(int threecharge) override {}
+    /// four-momentum Lorentz vecto r
+    const LorentzVector& p4() const override {
+      if (!p4c_)
+        unpack();
+      return *p4c_;
     }
-    /// set electric charge                                                               
-    void setCharge( int charge) override {charge_=charge;}
-    /// electric charge                                                                   
-    int threeCharge() const override {return charge()*3;}
-    /// set electric charge                                                               
-    void setThreeCharge( int threecharge) override {}
-    /// four-momentum Lorentz vecto r                                                      
-    const LorentzVector & p4() const override { if (!p4c_) unpack(); return *p4c_; }  
-    /// four-momentum Lorentz vector                                                      
-    const PolarLorentzVector & polarP4() const override { if (!p4c_) unpack(); return *p4_; }
-    /// spatial momentum vector                                                           
-    Vector momentum() const override  { if (!p4c_) unpack(); return p4c_.load()->Vect(); }
-    /// boost vector to boost a Lorentz vector                                            
-    /// to the particle center of mass system                                             
-    Vector boostToCM() const override { if (!p4c_) unpack(); return p4c_.load()->BoostToCM(); }
-    /// magnitude of momentum vector                                                      
-    double p() const override { if (!p4c_) unpack(); return p4c_.load()->P(); }
-    /// energy                                                                            
-    double energy() const override { if (!p4c_) unpack(); return p4c_.load()->E(); }
-   /// transverse energy   
-    double et() const override { return (pt()<=0) ? 0 : p4c_.load()->Et(); }
+    /// four-momentum Lorentz vector
+    const PolarLorentzVector& polarP4() const override {
+      if (!p4c_)
+        unpack();
+      return *p4_;
+    }
+    /// spatial momentum vector
+    Vector momentum() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->Vect();
+    }
+    /// boost vector to boost a Lorentz vector
+    /// to the particle center of mass system
+    Vector boostToCM() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->BoostToCM();
+    }
+    /// magnitude of momentum vector
+    double p() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->P();
+    }
+    /// energy
+    double energy() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->E();
+    }
+    /// transverse energy
+    double et() const override { return (pt() <= 0) ? 0 : p4c_.load()->Et(); }
     /// transverse energy squared (use this for cuts)!
-    double et2() const override { return (pt()<=0) ? 0 : p4c_.load()->Et2(); }
-    /// mass                                                                              
-    double mass() const override { if (!p4c_) unpack(); return p4_.load()->M(); }
-    /// mass squared                                                                      
-    double massSqr() const override { if (!p4c_) unpack(); return p4_.load()->M()*p4_.load()->M(); }
+    double et2() const override { return (pt() <= 0) ? 0 : p4c_.load()->Et2(); }
+    /// mass
+    double mass() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->M();
+    }
+    /// mass squared
+    double massSqr() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->M() * p4_.load()->M();
+    }
 
-    /// transverse mass                                                                   
-    double mt() const override { if (!p4c_) unpack(); return p4_.load()->Mt(); }
-    /// transverse mass squared                                                           
-    double mtSqr() const override { if (!p4c_) unpack(); return p4_.load()->Mt2(); }
-    /// x coordinate of momentum vector                                                   
-    double px() const override { if (!p4c_) unpack(); return p4c_.load()->Px(); }
-    /// y coordinate of momentum vector                                                   
-    double py() const override { if (!p4c_) unpack(); return p4c_.load()->Py(); }
-    /// z coordinate of momentum vector                                                   
-    double pz() const override { if (!p4c_) unpack(); return p4c_.load()->Pz(); }
-    /// transverse momentum                                                               
-    double pt() const override { if (!p4c_) unpack(); return p4_.load()->Pt();}
-    /// momentum azimuthal angle                                                          
-    double phi() const override { if (!p4c_) unpack(); return p4_.load()->Phi(); }
-    /// momentum polar angle                                                              
-    double theta() const override { if (!p4c_) unpack(); return p4_.load()->Theta(); }
-    /// momentum pseudorapidity                                                           
-    double eta() const override { if (!p4c_) unpack(); return p4_.load()->Eta(); }
-    /// rapidity                                                                          
-    double rapidity() const override { if (!p4c_) unpack(); return p4_.load()->Rapidity(); }
-    /// rapidity                                                                          
-    double y() const override { if (!p4c_) unpack(); return p4_.load()->Rapidity(); }
-    /// set 4-momentum                                                                    
-    void setP4( const LorentzVector & p4 ) override { 
-        unpack(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
-        *p4_ = PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M());
-        pack();
+    /// transverse mass
+    double mt() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Mt();
     }
-    /// set 4-momentum                                                                    
-    void setP4( const PolarLorentzVector & p4 ) override { 
-        unpack(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
-        *p4_ = p4; 
-        pack();
+    /// transverse mass squared
+    double mtSqr() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Mt2();
     }
-    /// set particle mass                                                                 
-    void setMass( double m ) override {
-      if (!p4c_) unpack(); 
-      *p4_ = PolarLorentzVector(p4_.load()->Pt(), p4_.load()->Eta(), p4_.load()->Phi(), m); 
+    /// x coordinate of momentum vector
+    double px() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->Px();
+    }
+    /// y coordinate of momentum vector
+    double py() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->Py();
+    }
+    /// z coordinate of momentum vector
+    double pz() const override {
+      if (!p4c_)
+        unpack();
+      return p4c_.load()->Pz();
+    }
+    /// transverse momentum
+    double pt() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Pt();
+    }
+    /// momentum azimuthal angle
+    double phi() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Phi();
+    }
+    /// momentum polar angle
+    double theta() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Theta();
+    }
+    /// momentum pseudorapidity
+    double eta() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Eta();
+    }
+    /// rapidity
+    double rapidity() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Rapidity();
+    }
+    /// rapidity
+    double y() const override {
+      if (!p4c_)
+        unpack();
+      return p4_.load()->Rapidity();
+    }
+    /// set 4-momentum
+    void setP4(const LorentzVector& p4) override {
+      unpack();  // changing px,py,pz changes also mapping between dxy,dz and x,y,z
+      *p4_ = PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M());
       pack();
     }
-    void setPz( double pz ) override {
-      unpack(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
+    /// set 4-momentum
+    void setP4(const PolarLorentzVector& p4) override {
+      unpack();  // changing px,py,pz changes also mapping between dxy,dz and x,y,z
+      *p4_ = p4;
+      pack();
+    }
+    /// set particle mass
+    void setMass(double m) override {
+      if (!p4c_)
+        unpack();
+      *p4_ = PolarLorentzVector(p4_.load()->Pt(), p4_.load()->Eta(), p4_.load()->Phi(), m);
+      pack();
+    }
+    void setPz(double pz) override {
+      unpack();  // changing px,py,pz changes also mapping between dxy,dz and x,y,z
       *p4c_ = LorentzVector(p4c_.load()->Px(), p4c_.load()->Py(), pz, p4c_.load()->E());
-      *p4_  = PolarLorentzVector(p4c_.load()->Pt(), p4c_.load()->Eta(), p4c_.load()->Phi(), p4c_.load()->M());
+      *p4_ = PolarLorentzVector(p4c_.load()->Pt(), p4c_.load()->Eta(), p4c_.load()->Phi(), p4c_.load()->M());
       pack();
     }
     /// vertex position
-    const Point & vertex() const override { return vertex_; }//{ if (fromPV_) return Point(0,0,0); else return Point(0,0,100); }
-    /// x coordinate of vertex position                                                   
-    double vx() const override  {  return vertex_.X(); }//{ return 0; }
-    /// y coordinate of vertex position                                                   
-    double vy() const override  {  return vertex_.Y(); }//{ return 0; }
-    /// z coordinate of vertex position                                                   
-    double vz() const override  {  return vertex_.Z(); }//{ if (fromPV_) return 0; else return 100; }
-    /// set vertex                                                                        
-    void setVertex( const Point & vertex ) override { vertex_ = vertex;  }
+    const Point& vertex() const override {
+      return vertex_;
+    }  //{ if (fromPV_) return Point(0,0,0); else return Point(0,0,100); }
+    /// x coordinate of vertex position
+    double vx() const override { return vertex_.X(); }  //{ return 0; }
+    /// y coordinate of vertex position
+    double vy() const override { return vertex_.Y(); }  //{ return 0; }
+    /// z coordinate of vertex position
+    double vz() const override { return vertex_.Z(); }  //{ if (fromPV_) return 0; else return 100; }
+    /// set vertex
+    void setVertex(const Point& vertex) override { vertex_ = vertex; }
 
-    enum PVAssoc { NoPV=0, PVLoose=1, PVTight=2, PVUsedInFit=3 } ;
-
+    enum PVAssoc { NoPV = 0, PVLoose = 1, PVTight = 2, PVUsedInFit = 3 };
 
     /// dxy with respect to the PV ref
-    virtual float dxy() const { unpack(); return dxy_; }
+    virtual float dxy() const {
+      unpack();
+      return dxy_;
+    }
     /// dz with respect to the PV ref
-    virtual float dz()  const { unpack(); return dz_; }
+    virtual float dz() const {
+      unpack();
+      return dz_;
+    }
     /// dxy with respect to another point
-    virtual float dxy(const Point &p) const ;
+    virtual float dxy(const Point& p) const;
     /// dz  with respect to another point
-    virtual float dz(const Point &p)  const ;
+    virtual float dz(const Point& p) const;
 
-
-    /// PDG identifier                                                                    
-    int pdgId() const override   { return pdgId_; }
-    // set PDG identifier                                                                 
-    void setPdgId( int pdgId ) override   { pdgId_ = pdgId; }
-    /// status word                                                                       
-    int status() const override   { return 1; } /*FIXME*/
-    /// set status word                                                                   
-    void setStatus( int status ) override {} /*FIXME*/
-    /// long lived flag                                                                   
+    /// PDG identifier
+    int pdgId() const override { return pdgId_; }
+    // set PDG identifier
+    void setPdgId(int pdgId) override { pdgId_ = pdgId; }
+    /// status word
+    int status() const override { return 1; } /*FIXME*/
+    /// set status word
+    void setStatus(int status) override {} /*FIXME*/
+    /// long lived flag
     static const unsigned int longLivedTag = 0; /*FIXME*/
-    /// set long lived flag                                                               
+    /// set long lived flag
     void setLongLived() override {} /*FIXME*/
-    /// is long lived?                                                                    
+    /// is long lived?
     bool longLived() const override;
     /// do mass constraint flag
-    static const unsigned int massConstraintTag = 0; /*FIXME*/ 
+    static const unsigned int massConstraintTag = 0; /*FIXME*/
     /// set mass constraint flag
     void setMassConstraint() override {} /*FIXME*/
     /// do mass constraint?
     bool massConstraint() const override;
 
-    /// returns a clone of the Candidate object                                           
-    PackedGenParticle * clone() const override  {
-      return new PackedGenParticle( *this );
-    }
+    /// returns a clone of the Candidate object
+    PackedGenParticle* clone() const override { return new PackedGenParticle(*this); }
 
-    /// chi-squares                                                                                                    
+    /// chi-squares
     double vertexChi2() const override;
     /** Number of degrees of freedom                                                                                   
      *  Meant to be Double32_t for soft-assignment fitters:                                                            
@@ -275,31 +392,37 @@ namespace pat {
      *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002                                                                  
      */
     double vertexNdof() const override;
-    /// chi-squared divided by n.d.o.f.                                                                                
+    /// chi-squared divided by n.d.o.f.
     double vertexNormalizedChi2() const override;
-    /// (i, j)-th element of error matrix, i, j = 0, ... 2                                                             
+    /// (i, j)-th element of error matrix, i, j = 0, ... 2
     double vertexCovariance(int i, int j) const override;
-    /// return SMatrix                                                                                                 
-    CovarianceMatrix vertexCovariance() const override   { CovarianceMatrix m; fillVertexCovariance(m); return m; }
-    /// fill SMatrix                                                                                                   
-    void fillVertexCovariance(CovarianceMatrix & v) const override;
-    /// returns true if this candidate has a reference to a master clone.                                              
-    /// This only happens if the concrete Candidate type is ShallowCloneCandidate                                      
+    /// return SMatrix
+    CovarianceMatrix vertexCovariance() const override {
+      CovarianceMatrix m;
+      fillVertexCovariance(m);
+      return m;
+    }
+    /// fill SMatrix
+    void fillVertexCovariance(CovarianceMatrix& v) const override;
+    /// returns true if this candidate has a reference to a master clone.
+    /// This only happens if the concrete Candidate type is ShallowCloneCandidate
     bool hasMasterClone() const override;
-    /// returns ptr to master clone, if existing.                                                                      
-    /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate                                
-    const reco::CandidateBaseRef & masterClone() const override;
-    /// returns true if this candidate has a ptr to a master clone.                                                    
-    /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate                                   
+    /// returns ptr to master clone, if existing.
+    /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate
+    const reco::CandidateBaseRef& masterClone() const override;
+    /// returns true if this candidate has a ptr to a master clone.
+    /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate
     bool hasMasterClonePtr() const override;
-    /// returns ptr to master clone, if existing.                                                                      
-    /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate                             
+    /// returns ptr to master clone, if existing.
+    /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate
 
-    const reco::CandidatePtr & masterClonePtr() const override;
+    const reco::CandidatePtr& masterClonePtr() const override;
 
     /// cast master clone reference to a concrete type
-    template<typename Ref>
-      Ref masterRef() const { return masterClone().template castTo<Ref>(); }
+    template <typename Ref>
+    Ref masterRef() const {
+      return masterClone().template castTo<Ref>();
+    }
     /// get a component
 
     bool isElectron() const override;
@@ -311,54 +434,57 @@ namespace pat {
     bool isPhoton() const override;
     bool isConvertedPhoton() const override;
     bool isJet() const override;
-    
-    const reco::GenStatusFlags &statusFlags() const { return statusFlags_; }
-    reco::GenStatusFlags &statusFlags() { return statusFlags_; }
-    
+
+    const reco::GenStatusFlags& statusFlags() const { return statusFlags_; }
+    reco::GenStatusFlags& statusFlags() { return statusFlags_; }
+
     /////////////////////////////////////////////////////////////////////////////
     //basic set of gen status flags accessible directly here
     //the rest accessible through statusFlags()
     //(see GenStatusFlags.h for their meaning)
-    
+
     /////////////////////////////////////////////////////////////////////////////
     //these are robust, generator-independent functions for categorizing
     //mainly final state particles, but also intermediate hadrons/taus
-    
+
     //is particle prompt (not from hadron, muon, or tau decay) and final state
-    bool isPromptFinalState() const { return status()==1 && statusFlags_.isPrompt(); }
-        
+    bool isPromptFinalState() const { return status() == 1 && statusFlags_.isPrompt(); }
+
     //this particle is a direct decay product of a prompt tau and is final state
     //(eg an electron or muon from a leptonic decay of a prompt tau)
-    bool isDirectPromptTauDecayProductFinalState() const { return status()==1 && statusFlags_.isDirectPromptTauDecayProduct(); }
-    
+    bool isDirectPromptTauDecayProductFinalState() const {
+      return status() == 1 && statusFlags_.isDirectPromptTauDecayProduct();
+    }
+
     /////////////////////////////////////////////////////////////////////////////
     //these are generator history-dependent functions for tagging particles
     //associated with the hard process
-    //Currently implemented for Pythia 6 and Pythia 8 status codes and history   
+    //Currently implemented for Pythia 6 and Pythia 8 status codes and history
     //and may not have 100% consistent meaning across all types of processes
     //Users are strongly encouraged to stick to the more robust flags above,
     //as well as the expanded set available in GenStatusFlags.h
-    
-    //this particle is the final state direct descendant of a hard process particle  
-    bool fromHardProcessFinalState() const { return status()==1 && statusFlags_.fromHardProcess(); }
-        
+
+    //this particle is the final state direct descendant of a hard process particle
+    bool fromHardProcessFinalState() const { return status() == 1 && statusFlags_.fromHardProcess(); }
+
     //this particle is a direct decay product of a hardprocess tau and is final state
     //(eg an electron or muon from a leptonic decay of a tau from the hard process)
-    bool isDirectHardProcessTauDecayProductFinalState() const { return status()==1 && statusFlags_.isDirectHardProcessTauDecayProduct(); }
-        
+    bool isDirectHardProcessTauDecayProductFinalState() const {
+      return status() == 1 && statusFlags_.isDirectHardProcessTauDecayProduct();
+    }
 
   protected:
     uint16_t packedPt_, packedY_, packedPhi_, packedM_;
-    void pack(bool unpackAfterwards=true) ;
-    void unpack() const ;
- 
-    /// the four vector                                                 
+    void pack(bool unpackAfterwards = true);
+    void unpack() const;
+
+    /// the four vector
     mutable std::atomic<PolarLorentzVector*> p4_;
     mutable std::atomic<LorentzVector*> p4c_;
-    /// vertex position                                                                   
+    /// vertex position
     Point vertex_;
     float dxy_, dz_, dphi_;
-    /// PDG identifier                                                                    
+    /// PDG identifier
     int pdgId_;
     /// Charge
     int8_t charge_;
@@ -367,18 +493,18 @@ namespace pat {
     //status flags
     reco::GenStatusFlags statusFlags_;
 
-    /// check overlap with another Candidate                                              
-    bool overlap( const reco::Candidate & ) const override;
-    template<typename, typename, typename> friend struct component;
+    /// check overlap with another Candidate
+    bool overlap(const reco::Candidate&) const override;
+    template <typename, typename, typename>
+    friend struct component;
     friend class ::OverlapChecker;
     friend class ShallowCloneCandidate;
     friend class ShallowClonePtrCandidate;
-
   };
 
   typedef std::vector<pat::PackedGenParticle> PackedGenParticleCollection;
   typedef edm::Ref<pat::PackedGenParticleCollection> PackedGenParticleRef;
   typedef edm::RefVector<pat::PackedGenParticleCollection> PackedGenParticleRefVector;
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/PackedTriggerPrescales.h
+++ b/DataFormats/PatCandidates/interface/PackedTriggerPrescales.h
@@ -7,36 +7,33 @@
 
 namespace pat {
 
-class PackedTriggerPrescales {
-    public:
-        PackedTriggerPrescales() : triggerNames_(nullptr) {}
-        PackedTriggerPrescales(const edm::Handle<edm::TriggerResults> & handle) ;
-        ~PackedTriggerPrescales() {}
+  class PackedTriggerPrescales {
+  public:
+    PackedTriggerPrescales() : triggerNames_(nullptr) {}
+    PackedTriggerPrescales(const edm::Handle<edm::TriggerResults> &handle);
+    ~PackedTriggerPrescales() {}
 
-        // get prescale by index.
-        int getPrescaleForIndex(int index) const ;
-        // get prescale by name or name prefix (if setTriggerNames was called)
-        int getPrescaleForName(const std::string & name, bool prefixOnly=false) const ; 
+    // get prescale by index.
+    int getPrescaleForIndex(int index) const;
+    // get prescale by name or name prefix (if setTriggerNames was called)
+    int getPrescaleForName(const std::string &name, bool prefixOnly = false) const;
 
-        // return the TriggerResults associated with this
-        const edm::TriggerResults & triggerResults() const {
-            return *edm::getProduct<edm::TriggerResults>(triggerResults_);
-        }
+    // return the TriggerResults associated with this
+    const edm::TriggerResults &triggerResults() const { return *edm::getProduct<edm::TriggerResults>(triggerResults_); }
 
-        // use this method first if you want to be able to access the prescales by name
-        // you can get the TriggerNames from the TriggerResults and the Event (edm or fwlite)
-        void setTriggerNames(const edm::TriggerNames &names) { triggerNames_ = &names; }
+    // use this method first if you want to be able to access the prescales by name
+    // you can get the TriggerNames from the TriggerResults and the Event (edm or fwlite)
+    void setTriggerNames(const edm::TriggerNames &names) { triggerNames_ = &names; }
 
-        // set that the trigger of given index has a given prescale
-        void addPrescaledTrigger(int index, int prescale) ;
+    // set that the trigger of given index has a given prescale
+    void addPrescaledTrigger(int index, int prescale);
 
-    protected:
-        std::vector<int> prescaleValues_;
-        edm::RefCore triggerResults_;
-        const edm::TriggerNames *triggerNames_;
-};
+  protected:
+    std::vector<int> prescaleValues_;
+    edm::RefCore triggerResults_;
+    const edm::TriggerNames *triggerNames_;
+  };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/ParametrizationHelper.h
+++ b/DataFormats/PatCandidates/interface/ParametrizationHelper.h
@@ -4,52 +4,61 @@
 #include "DataFormats/PatCandidates/interface/CandKinResolution.h"
 #include <string>
 
-namespace pat { namespace helper {
-namespace ParametrizationHelper {
+namespace pat {
+  namespace helper {
+    namespace ParametrizationHelper {
 
-    /// Returns the number of free parameters in a parametrization (3 or 4)
-    inline uint32_t dimension(pat::CandKinResolution::Parametrization parametrization) {
+      /// Returns the number of free parameters in a parametrization (3 or 4)
+      inline uint32_t dimension(pat::CandKinResolution::Parametrization parametrization) {
         return (static_cast<uint32_t>(parametrization) & 0x0F);
-    }
+      }
 
-    /// Convert a name into a parametrization code
-    pat::CandKinResolution::Parametrization fromString(const std::string &name) ;
+      /// Convert a name into a parametrization code
+      pat::CandKinResolution::Parametrization fromString(const std::string &name);
 
-    /// Convert a number into a string
-    const char * name(pat::CandKinResolution::Parametrization param) ;   
+      /// Convert a number into a string
+      const char *name(pat::CandKinResolution::Parametrization param);
 
-    /// Given a choice of coordinate frame, a vector of coordinates and a reference 4-vector, produce a new 4 vector with the specified parameters.
-    /// The new 4-vector is not guaranteed to satisfy the constraints of these parametrization if the initial 4-vector does not satisfy them.
-    /// In the future this method will throw an exception if you go in an unphysical point of the coordinate system (e.g. E^2 < P^2)
-    math::PtEtaPhiMLorentzVector polarP4fromParameters( pat::CandKinResolution::Parametrization parametrization, 
-                                                        const AlgebraicVector4 &parameters, 
-                                                        const math::PtEtaPhiMLorentzVector &initialP4) ;
+      /// Given a choice of coordinate frame, a vector of coordinates and a reference 4-vector, produce a new 4 vector with the specified parameters.
+      /// The new 4-vector is not guaranteed to satisfy the constraints of these parametrization if the initial 4-vector does not satisfy them.
+      /// In the future this method will throw an exception if you go in an unphysical point of the coordinate system (e.g. E^2 < P^2)
+      math::PtEtaPhiMLorentzVector polarP4fromParameters(pat::CandKinResolution::Parametrization parametrization,
+                                                         const AlgebraicVector4 &parameters,
+                                                         const math::PtEtaPhiMLorentzVector &initialP4);
 
-    /// Given a choice of coordinate frame, a vector of coordinates and a reference 4-vector, produce a new 4 vector with the specified parameters.
-    /// The new 4-vector is not guaranteed to satisfy the constraints of these parametrization if the initial 4-vector does not satisfy them.
-    /// In the future this method will throw an exception if you go in an unphysical point of the coordinate system (e.g. E^2 < P^2)
-    math::XYZTLorentzVector p4fromParameters(pat::CandKinResolution::Parametrization parametrization, 
-                                            const AlgebraicVector4 &parameters,
-                                            const math::XYZTLorentzVector &initialP4) ;
+      /// Given a choice of coordinate frame, a vector of coordinates and a reference 4-vector, produce a new 4 vector with the specified parameters.
+      /// The new 4-vector is not guaranteed to satisfy the constraints of these parametrization if the initial 4-vector does not satisfy them.
+      /// In the future this method will throw an exception if you go in an unphysical point of the coordinate system (e.g. E^2 < P^2)
+      math::XYZTLorentzVector p4fromParameters(pat::CandKinResolution::Parametrization parametrization,
+                                               const AlgebraicVector4 &parameters,
+                                               const math::XYZTLorentzVector &initialP4);
 
-    /// Returns a vector of coordinates values given a coordinate frame and a 4-vector.
-    AlgebraicVector4 parametersFromP4(pat::CandKinResolution::Parametrization parametrization, const math::XYZTLorentzVector &p4) ;
+      /// Returns a vector of coordinates values given a coordinate frame and a 4-vector.
+      AlgebraicVector4 parametersFromP4(pat::CandKinResolution::Parametrization parametrization,
+                                        const math::XYZTLorentzVector &p4);
 
-    /// Returns a vector of coordinates values given a coordinate frame and a 4-vector.
-    AlgebraicVector4 parametersFromP4(pat::CandKinResolution::Parametrization parametrization, const math::PtEtaPhiMLorentzVector &p4) ;
+      /// Returns a vector of coordinates values given a coordinate frame and a 4-vector.
+      AlgebraicVector4 parametersFromP4(pat::CandKinResolution::Parametrization parametrization,
+                                        const math::PtEtaPhiMLorentzVector &p4);
 
-    /// Set the values of the parameters for a given 4-momentum
-    void setParametersFromP4(pat::CandKinResolution::Parametrization parametrization, AlgebraicVector4 &pars, const math::XYZTLorentzVector &p4) ;
+      /// Set the values of the parameters for a given 4-momentum
+      void setParametersFromP4(pat::CandKinResolution::Parametrization parametrization,
+                               AlgebraicVector4 &pars,
+                               const math::XYZTLorentzVector &p4);
 
-    /// Set the values of the parameters for a given 4-momentum
-    void setParametersFromP4(pat::CandKinResolution::Parametrization parametrization, AlgebraicVector4 &pars, const math::PtEtaPhiMLorentzVector &p4) ;
+      /// Set the values of the parameters for a given 4-momentum
+      void setParametersFromP4(pat::CandKinResolution::Parametrization parametrization,
+                               AlgebraicVector4 &pars,
+                               const math::PtEtaPhiMLorentzVector &p4);
 
-    /// For internal use only, so we provide only the interface. Use the 'setParametersFromP4'.
-    template <typename T>
-    void setParametersFromAnyVector(pat::CandKinResolution::Parametrization parametrization, AlgebraicVector4 &pars, const T &p4) ;
+      /// For internal use only, so we provide only the interface. Use the 'setParametersFromP4'.
+      template <typename T>
+      void setParametersFromAnyVector(pat::CandKinResolution::Parametrization parametrization,
+                                      AlgebraicVector4 &pars,
+                                      const T &p4);
 
-    /// Expresses the difference between two 4-momentum vectors as a shift in coordinates in a given frame.
-    /** Basically, if you do:
+      /// Expresses the difference between two 4-momentum vectors as a shift in coordinates in a given frame.
+      /** Basically, if you do:
      *  <code>
      *      pars = parametersFromP4(param, simp4);
      *      diff = diffToParameters(param, simP4, recP4);
@@ -57,11 +66,12 @@ namespace ParametrizationHelper {
      *  then up to roundoff errors
      *  <code>recP4  == p4fromParameters(param, pars+diff, simP4);</code>
      */
-    AlgebraicVector4 diffToParameters(pat::CandKinResolution::Parametrization parametrization, 
-                const math::XYZTLorentzVector &p4ini, const math::XYZTLorentzVector &p4fin) ;
+      AlgebraicVector4 diffToParameters(pat::CandKinResolution::Parametrization parametrization,
+                                        const math::XYZTLorentzVector &p4ini,
+                                        const math::XYZTLorentzVector &p4fin);
 
-    /// Expresses the difference between two 4-momentum vectors as a shift in coordinates in a given frame.
-    /** Basically, if you do:
+      /// Expresses the difference between two 4-momentum vectors as a shift in coordinates in a given frame.
+      /** Basically, if you do:
      *  <code>
      *      pars = parametersFromP4(param, simp4);
      *      diff = diffToParameters(param, simP4, recP4);
@@ -69,25 +79,29 @@ namespace ParametrizationHelper {
      *  then up to roundoff errors
      *  <code>recP4  == p4fromParameters(param, pars+diff, simP4);</code>
      */
-    AlgebraicVector4 diffToParameters(pat::CandKinResolution::Parametrization parametrization, 
-                const math::PtEtaPhiMLorentzVector &p4ini, const math::PtEtaPhiMLorentzVector &p4fin) ;
+      AlgebraicVector4 diffToParameters(pat::CandKinResolution::Parametrization parametrization,
+                                        const math::PtEtaPhiMLorentzVector &p4ini,
+                                        const math::PtEtaPhiMLorentzVector &p4fin);
 
- 
-    /// Is this parametrization usable only with massless objects?
-    bool isAlwaysMassless(pat::CandKinResolution::Parametrization parametrization) ;
+      /// Is this parametrization usable only with massless objects?
+      bool isAlwaysMassless(pat::CandKinResolution::Parametrization parametrization);
 
-    /// Is this parametrization usable only with massive objects?
-    bool isAlwaysMassive(pat::CandKinResolution::Parametrization parametrization) ;
+      /// Is this parametrization usable only with massive objects?
+      bool isAlwaysMassive(pat::CandKinResolution::Parametrization parametrization);
 
-    /// If this parametrization has a mass constraint (including the 'isAlwaysMassless' case)
-    bool isMassConstrained(pat::CandKinResolution::Parametrization parametrization) ;
+      /// If this parametrization has a mass constraint (including the 'isAlwaysMassless' case)
+      bool isMassConstrained(pat::CandKinResolution::Parametrization parametrization);
 
-    /// If this value of the parameters is meaningful in this parametrization. 
-    /// It can be used e.g. when doing random smearing to check you're still within the physical region
-    /// This DOES check inequalities (e.g. E >= P, M >= 0, theta in [0,PI], ..)
-    /// This DOES NOT check strict equalities (e.g. M == 0)
-    /// This DOES NOT check that your parameters comply with your constraints (e.g. fixed mass constraint)
-    bool isPhysical(pat::CandKinResolution::Parametrization parametrization, const AlgebraicVector4 &v4, const math::PtEtaPhiMLorentzVector &initialP4) ;
-} } }
+      /// If this value of the parameters is meaningful in this parametrization.
+      /// It can be used e.g. when doing random smearing to check you're still within the physical region
+      /// This DOES check inequalities (e.g. E >= P, M >= 0, theta in [0,PI], ..)
+      /// This DOES NOT check strict equalities (e.g. M == 0)
+      /// This DOES NOT check that your parameters comply with your constraints (e.g. fixed mass constraint)
+      bool isPhysical(pat::CandKinResolution::Parametrization parametrization,
+                      const AlgebraicVector4 &v4,
+                      const math::PtEtaPhiMLorentzVector &initialP4);
+    }  // namespace ParametrizationHelper
+  }    // namespace helper
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/Particle.h
+++ b/DataFormats/PatCandidates/interface/Particle.h
@@ -17,35 +17,29 @@
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/PatCandidates/interface/PATObject.h"
 
-
 // Define typedefs for convenience
 namespace pat {
   class Particle;
-  typedef std::vector<Particle>              ParticleCollection; 
-  typedef edm::Ref<ParticleCollection>       ParticleRef; 
-  typedef edm::RefVector<ParticleCollection> ParticleRefVector; 
-}
+  typedef std::vector<Particle> ParticleCollection;
+  typedef edm::Ref<ParticleCollection> ParticleRef;
+  typedef edm::RefVector<ParticleCollection> ParticleRefVector;
+}  // namespace pat
 
 namespace pat {
 
-
   class Particle : public PATObject<reco::LeafCandidate> {
+  public:
+    /// default constructor
+    Particle();
+    /// constructor from a LeafCandidate
+    Particle(const reco::LeafCandidate& aParticle);
+    /// destructor
+    ~Particle() override;
 
-    public:
-
-      /// default constructor
-      Particle();
-      /// constructor from a LeafCandidate
-      Particle(const reco::LeafCandidate & aParticle);
-      /// destructor
-      ~Particle() override;
-
-      /// required reimplementation of the Candidate's clone method
-      Particle * clone() const override { return new Particle(*this); }
-
+    /// required reimplementation of the Candidate's clone method
+    Particle* clone() const override { return new Particle(*this); }
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/Photon.h
+++ b/DataFormats/PatCandidates/interface/Photon.h
@@ -26,387 +26,384 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/Common/interface/AtomicPtrCache.h"
 
-
 // Define typedefs for convenience
 namespace pat {
   class Photon;
-  typedef std::vector<Photon>              PhotonCollection; 
-  typedef edm::Ref<PhotonCollection>       PhotonRef; 
-  typedef edm::RefVector<PhotonCollection> PhotonRefVector; 
-}
+  typedef std::vector<Photon> PhotonCollection;
+  typedef edm::Ref<PhotonCollection> PhotonRef;
+  typedef edm::RefVector<PhotonCollection> PhotonRefVector;
+}  // namespace pat
 
 namespace reco {
   /// pipe operator (introduced to use pat::Photon with PFTopProjectors)
   std::ostream& operator<<(std::ostream& out, const pat::Photon& obj);
-}
+}  // namespace reco
 
 // Class definition
 namespace pat {
   class PATPhotonSlimmer;
 
   class Photon : public PATObject<reco::Photon> {
+  public:
+    typedef std::pair<std::string, Bool_t> IdPair;
 
-    public:
+    /// default constructor
+    Photon();
+    /// constructor from a reco photon
+    Photon(const reco::Photon& aPhoton);
+    /// constructor from a RefToBase to a reco photon (to be superseded by Ptr counterpart)
+    Photon(const edm::RefToBase<reco::Photon>& aPhotonRef);
+    /// constructor from a Ptr to a reco photon
+    Photon(const edm::Ptr<reco::Photon>& aPhotonRef);
+    /// destructor
+    ~Photon() override;
 
-      typedef std::pair<std::string,Bool_t> IdPair;
+    /// required reimplementation of the Candidate's clone method
+    Photon* clone() const override { return new Photon(*this); }
 
-      /// default constructor
-      Photon();
-      /// constructor from a reco photon
-      Photon(const reco::Photon & aPhoton);
-      /// constructor from a RefToBase to a reco photon (to be superseded by Ptr counterpart)
-      Photon(const edm::RefToBase<reco::Photon> & aPhotonRef);
-      /// constructor from a Ptr to a reco photon
-      Photon(const edm::Ptr<reco::Photon> & aPhotonRef);
-      /// destructor
-      ~Photon() override;
+    // ---- methods for content embedding ----
+    /// override the superCluster method from CaloJet, to access the internal storage of the supercluster
+    reco::SuperClusterRef superCluster() const override;
+    /// direct access to the seed cluster
+    reco::CaloClusterPtr seed() const;
 
-      /// required reimplementation of the Candidate's clone method
-      Photon * clone() const override { return new Photon(*this); }
+    //method to access the basic clusters
+    const std::vector<reco::CaloCluster>& basicClusters() const { return basicClusters_; }
+    //method to access the preshower clusters
+    const std::vector<reco::CaloCluster>& preshowerClusters() const { return preshowerClusters_; }
 
-      // ---- methods for content embedding ----
-      /// override the superCluster method from CaloJet, to access the internal storage of the supercluster
-      reco::SuperClusterRef superCluster() const override;
-      /// direct access to the seed cluster
-      reco::CaloClusterPtr seed() const; 
+    //method to access embedded ecal RecHits
+    const EcalRecHitCollection* recHits() const { return &recHits_; }
 
-      //method to access the basic clusters
-      const std::vector<reco::CaloCluster>& basicClusters() const { return basicClusters_ ; }
-      //method to access the preshower clusters
-      const std::vector<reco::CaloCluster>& preshowerClusters() const { return preshowerClusters_ ; }      
-      
-      //method to access embedded ecal RecHits
-      const EcalRecHitCollection * recHits() const { return &recHits_;}      
-      
-      /// method to store the photon's supercluster internally
-      void embedSuperCluster();
-      /// method to store the electron's seedcluster internally
-      void embedSeedCluster();
-      /// method to store the electron's basic clusters
-      void embedBasicClusters();
-      /// method to store the electron's preshower clusters
-      void embedPreshowerClusters();
-      /// method to store the RecHits internally - can be called from the PATElectronProducer
-      void embedRecHits(const EcalRecHitCollection * rechits); 
-      
-      
-      // ---- methods for access the generated photon ----
-      /// return the match to the generated photon
-      const reco::Candidate * genPhoton() const { return genParticle(); }
-      /// method to set the generated photon
-      void setGenPhoton(const reco::GenParticleRef & gp, bool embed=false) { setGenParticleRef(gp, embed); }
+    /// method to store the photon's supercluster internally
+    void embedSuperCluster();
+    /// method to store the electron's seedcluster internally
+    void embedSeedCluster();
+    /// method to store the electron's basic clusters
+    void embedBasicClusters();
+    /// method to store the electron's preshower clusters
+    void embedPreshowerClusters();
+    /// method to store the RecHits internally - can be called from the PATElectronProducer
+    void embedRecHits(const EcalRecHitCollection* rechits);
 
-      // ---- methods for photon ID ----
-      /// Returns a specific photon ID associated to the pat::Photon given its name.
-      /// Note: an exception is thrown if the specified ID is not available
-      Bool_t photonID(const std::string & name) const;
-      /// Returns true if a specific ID is available in this pat::Photon
-      bool isPhotonIDAvailable(const std::string & name) const;
-      /// Returns all the Photon IDs in the form of <name,value> pairs
-      /// The 'default' ID is the first in the list
-      const std::vector<IdPair> &  photonIDs() const { return photonIDs_; }
-      /// Store multiple photon ID values, discarding existing ones
-      /// The first one in the list becomes the 'default' photon id 
-      void setPhotonIDs(const std::vector<IdPair> & ids) { photonIDs_ = ids; }
+    // ---- methods for access the generated photon ----
+    /// return the match to the generated photon
+    const reco::Candidate* genPhoton() const { return genParticle(); }
+    /// method to set the generated photon
+    void setGenPhoton(const reco::GenParticleRef& gp, bool embed = false) { setGenParticleRef(gp, embed); }
 
+    // ---- methods for photon ID ----
+    /// Returns a specific photon ID associated to the pat::Photon given its name.
+    /// Note: an exception is thrown if the specified ID is not available
+    Bool_t photonID(const std::string& name) const;
+    /// Returns true if a specific ID is available in this pat::Photon
+    bool isPhotonIDAvailable(const std::string& name) const;
+    /// Returns all the Photon IDs in the form of <name,value> pairs
+    /// The 'default' ID is the first in the list
+    const std::vector<IdPair>& photonIDs() const { return photonIDs_; }
+    /// Store multiple photon ID values, discarding existing ones
+    /// The first one in the list becomes the 'default' photon id
+    void setPhotonIDs(const std::vector<IdPair>& ids) { photonIDs_ = ids; }
 
-      // ---- methods for photon isolation ----
-      /// Returns the summed track pt in a cone of deltaR<0.4 
-      /// including the region of the reconstructed photon 
-      float trackIso() const { return trkSumPtSolidConeDR04(); }
-      /// Returns the summed Et in a cone of deltaR<0.4 
-      /// calculated from recHits
-      float ecalIso()  const { return ecalRecHitSumEtConeDR04(); }
-      /// Returns summed Et in a cone of deltaR<0.4 calculated 
-      /// from caloTowers
-      float hcalIso()  const { return hcalTowerSumEtConeDR04(); }
-      /// Returns the calorimeter isolation combined from ecal 
-      /// and hcal 
-      float caloIso()  const { return ecalIso()+hcalIso(); }
+    // ---- methods for photon isolation ----
+    /// Returns the summed track pt in a cone of deltaR<0.4
+    /// including the region of the reconstructed photon
+    float trackIso() const { return trkSumPtSolidConeDR04(); }
+    /// Returns the summed Et in a cone of deltaR<0.4
+    /// calculated from recHits
+    float ecalIso() const { return ecalRecHitSumEtConeDR04(); }
+    /// Returns summed Et in a cone of deltaR<0.4 calculated
+    /// from caloTowers
+    float hcalIso() const { return hcalTowerSumEtConeDR04(); }
+    /// Returns the calorimeter isolation combined from ecal
+    /// and hcal
+    float caloIso() const { return ecalIso() + hcalIso(); }
 
-      /// PARTICLE FLOW ISOLATION
-      /// Returns the isolation calculated with all the PFCandidates
-      float patParticleIso() const { return userIsolation(pat::PfAllParticleIso); }
-      /// Returns the isolation calculated with only the charged hadron
-      /// PFCandidates
-      float chargedHadronIso() const { return reco::Photon::chargedHadronIso(); }
-      /// Returns the isolation calculated with only the neutral hadron
-      /// PFCandidates
-      float neutralHadronIso() const { return reco::Photon::neutralHadronIso(); }
-      /// Returns the isolation calculated with only the gamma
-      /// PFCandidates
-      float photonIso() const { return reco::Photon::photonIso(); }
-      /// Returns the isolation calculated with only the pile-up charged hadron
-      /// PFCandidates
-      float puChargedHadronIso() const { return userIsolation(pat::PfPUChargedHadronIso); }        
+    /// PARTICLE FLOW ISOLATION
+    /// Returns the isolation calculated with all the PFCandidates
+    float patParticleIso() const { return userIsolation(pat::PfAllParticleIso); }
+    /// Returns the isolation calculated with only the charged hadron
+    /// PFCandidates
+    float chargedHadronIso() const { return reco::Photon::chargedHadronIso(); }
+    /// Returns the isolation calculated with only the neutral hadron
+    /// PFCandidates
+    float neutralHadronIso() const { return reco::Photon::neutralHadronIso(); }
+    /// Returns the isolation calculated with only the gamma
+    /// PFCandidates
+    float photonIso() const { return reco::Photon::photonIso(); }
+    /// Returns the isolation calculated with only the pile-up charged hadron
+    /// PFCandidates
+    float puChargedHadronIso() const { return userIsolation(pat::PfPUChargedHadronIso); }
 
-      /// Returns a user defined isolation value
-      float userIso(uint8_t index=0)  const { return userIsolation(IsolationKeys(UserBaseIso + index)); }
-      /// Returns the isolation variable for a specifc key (or 
-      /// pseudo-key like CaloIso), or -1.0 if not available
-      float userIsolation(IsolationKeys key) const { 
-          if (key >= 0) {
-	    //if (key >= isolations_.size()) throw cms::Excepton("Missing Data") 
-	    //<< "Isolation corresponding to key " << key 
-	    //<< " was not stored for this particle.";
-              if (size_t(key) >= isolations_.size()) return -1.0;
-              return isolations_[key];
-          } else switch (key) {
-	  case pat::CaloIso:  
-		//if (isolations_.size() <= pat::HcalIso) throw cms::Excepton("Missing Data") 
-		//<< "CalIsoo Isolation was not stored for this particle.";
-		if (isolations_.size() <= pat::HcalIso) return -1.0; 
-		return isolations_[pat::EcalIso] + isolations_[pat::HcalIso];
-	  default:
-	    return -1.0;
-	    //throw cms::Excepton("Missing Data") << "Isolation corresponding to key " 
-	    //<< key << " was not stored for this particle.";
-          }
+    /// Returns a user defined isolation value
+    float userIso(uint8_t index = 0) const { return userIsolation(IsolationKeys(UserBaseIso + index)); }
+    /// Returns the isolation variable for a specifc key (or
+    /// pseudo-key like CaloIso), or -1.0 if not available
+    float userIsolation(IsolationKeys key) const {
+      if (key >= 0) {
+        //if (key >= isolations_.size()) throw cms::Excepton("Missing Data")
+        //<< "Isolation corresponding to key " << key
+        //<< " was not stored for this particle.";
+        if (size_t(key) >= isolations_.size())
+          return -1.0;
+        return isolations_[key];
+      } else
+        switch (key) {
+          case pat::CaloIso:
+            //if (isolations_.size() <= pat::HcalIso) throw cms::Excepton("Missing Data")
+            //<< "CalIsoo Isolation was not stored for this particle.";
+            if (isolations_.size() <= pat::HcalIso)
+              return -1.0;
+            return isolations_[pat::EcalIso] + isolations_[pat::HcalIso];
+          default:
+            return -1.0;
+            //throw cms::Excepton("Missing Data") << "Isolation corresponding to key "
+            //<< key << " was not stored for this particle.";
+        }
+    }
+
+    float puppiChargedHadronIso() const { return puppiChargedHadronIso_; }
+    float puppiNeutralHadronIso() const { return puppiNeutralHadronIso_; }
+    float puppiPhotonIso() const { return puppiPhotonIso_; }
+
+    /// Sets the isolation variable for a specifc key.
+    /// Note that you can't set isolation for a pseudo-key like CaloIso
+    void setIsolation(IsolationKeys key, float value) {
+      if (key >= 0) {
+        if (size_t(key) >= isolations_.size())
+          isolations_.resize(key + 1, -1.0);
+        isolations_[key] = value;
+      } else {
+        throw cms::Exception("Illegal Argument")
+            << "The key for which you're setting isolation does not correspond "
+            << "to an individual isolation but to the sum of more independent isolations "
+            << "(e.g. Calo = Ecal + Hcal), so you can't SET the value, just GET it.\n"
+            << "Please set up each component independly.\n";
       }
+    }
+    /// Sets tracker isolation variable
+    void setTrackIso(float trackIso) { setIsolation(TrackIso, trackIso); }
+    /// Sets ecal isolation variable
+    void setEcalIso(float caloIso) { setIsolation(EcalIso, caloIso); }
+    /// Sets hcal isolation variable
+    void setHcalIso(float caloIso) { setIsolation(HcalIso, caloIso); }
+    /// Sets user isolation variable #index
+    void setUserIso(float value, uint8_t index = 0) { setIsolation(IsolationKeys(UserBaseIso + index), value); }
+    /// Sets PUPPI isolation
+    void setIsolationPUPPI(float chargedhadrons_, float neutralhadrons_, float photons_) {
+      puppiChargedHadronIso_ = chargedhadrons_;
+      puppiNeutralHadronIso_ = neutralhadrons_;
+      puppiPhotonIso_ = photons_;
+    }
 
-      float puppiChargedHadronIso() const {return puppiChargedHadronIso_; }
-      float puppiNeutralHadronIso() const {return puppiNeutralHadronIso_; }
-      float puppiPhotonIso() const {return puppiPhotonIso_; }
-
-      /// Sets the isolation variable for a specifc key.
-      /// Note that you can't set isolation for a pseudo-key like CaloIso
-      void setIsolation(IsolationKeys key, float value) {
-          if (key >= 0) {
-              if (size_t(key) >= isolations_.size()) isolations_.resize(key+1, -1.0);
-              isolations_[key] = value;
-          } else {
-              throw cms::Exception("Illegal Argument") << 
-                  "The key for which you're setting isolation does not correspond " <<
-                  "to an individual isolation but to the sum of more independent isolations " <<
-                  "(e.g. Calo = Ecal + Hcal), so you can't SET the value, just GET it.\n" <<
-                  "Please set up each component independly.\n";
-          }
+    // ---- methods for photon isolation deposits ----
+    /// Returns the IsoDeposit associated with some key, or a null pointer if it is not available
+    const IsoDeposit* isoDeposit(IsolationKeys key) const {
+      for (IsoDepositPairs::const_iterator it = isoDeposits_.begin(), ed = isoDeposits_.end(); it != ed; ++it) {
+        if (it->first == key)
+          return &it->second;
       }
-      /// Sets tracker isolation variable
-      void setTrackIso(float trackIso) { setIsolation(TrackIso, trackIso); }
-      /// Sets ecal isolation variable
-      void setEcalIso(float caloIso)   { setIsolation(EcalIso,  caloIso);  } 
-      /// Sets hcal isolation variable
-      void setHcalIso(float caloIso)   { setIsolation(HcalIso,  caloIso);  }
-      /// Sets user isolation variable #index
-      void setUserIso(float value, uint8_t index=0)  { setIsolation(IsolationKeys(UserBaseIso + index), value); }
-      /// Sets PUPPI isolation
-      void setIsolationPUPPI(float chargedhadrons_, float neutralhadrons_, float photons_)
-      {  
-         puppiChargedHadronIso_ = chargedhadrons_;
-         puppiNeutralHadronIso_ = neutralhadrons_;
-         puppiPhotonIso_ = photons_;
-
+      return nullptr;
+    }
+    /// Return the tracker IsoDeposit
+    const IsoDeposit* trackIsoDeposit() const { return isoDeposit(pat::TrackIso); }
+    /// Return the ecal IsoDeposit
+    const IsoDeposit* ecalIsoDeposit() const { return isoDeposit(pat::EcalIso); }
+    /// Return the hcal IsoDeposit
+    const IsoDeposit* hcalIsoDeposit() const { return isoDeposit(pat::HcalIso); }
+    /// Return a specified user-level IsoDeposit
+    const IsoDeposit* userIsoDeposit(uint8_t index = 0) const { return isoDeposit(IsolationKeys(UserBaseIso + index)); }
+    /// Sets the IsoDeposit associated with some key; if it is already existent, it is overwritten.
+    void setIsoDeposit(IsolationKeys key, const IsoDeposit& dep) {
+      IsoDepositPairs::iterator it = isoDeposits_.begin(), ed = isoDeposits_.end();
+      for (; it != ed; ++it) {
+        if (it->first == key) {
+          it->second = dep;
+          return;
+        }
       }
+      isoDeposits_.push_back(std::make_pair(key, dep));
+    }
+    /// Sets tracker IsoDeposit
+    void trackIsoDeposit(const IsoDeposit& dep) { setIsoDeposit(pat::TrackIso, dep); }
+    /// Sets ecal IsoDeposit
+    void ecalIsoDeposit(const IsoDeposit& dep) { setIsoDeposit(pat::EcalIso, dep); }
+    /// Sets hcal IsoDeposit
+    void hcalIsoDeposit(const IsoDeposit& dep) { setIsoDeposit(pat::HcalIso, dep); }
+    /// Sets user-level IsoDeposit
+    void userIsoDeposit(const IsoDeposit& dep, uint8_t index = 0) {
+      setIsoDeposit(IsolationKeys(UserBaseIso + index), dep);
+    }
+    /// vertex fit method
+    bool passElectronVeto() const { return passElectronVeto_; }
+    void setPassElectronVeto(bool flag) { passElectronVeto_ = flag; }
+    //pixel seed to veto electron (not recommended by EGM POG but it seems very efficient)
+    bool hasPixelSeed() const { return hasPixelSeed_; }
+    void setHasPixelSeed(bool flag) { hasPixelSeed_ = flag; }
 
-      // ---- methods for photon isolation deposits ----
-      /// Returns the IsoDeposit associated with some key, or a null pointer if it is not available
-      const IsoDeposit * isoDeposit(IsolationKeys key) const {
-          for (IsoDepositPairs::const_iterator it = isoDeposits_.begin(), ed = isoDeposits_.end(); 
-                  it != ed; ++it) 
-          {
-              if (it->first == key) return & it->second;
-          }
-          return nullptr;
-      } 
-      /// Return the tracker IsoDeposit
-      const IsoDeposit * trackIsoDeposit() const { return isoDeposit(pat::TrackIso); }
-      /// Return the ecal IsoDeposit
-      const IsoDeposit * ecalIsoDeposit()  const { return isoDeposit(pat::EcalIso ); }
-      /// Return the hcal IsoDeposit
-      const IsoDeposit * hcalIsoDeposit()  const { return isoDeposit(pat::HcalIso ); }
-      /// Return a specified user-level IsoDeposit
-      const IsoDeposit * userIsoDeposit(uint8_t index=0) const { return isoDeposit(IsolationKeys(UserBaseIso + index)); }
-      /// Sets the IsoDeposit associated with some key; if it is already existent, it is overwritten.
-      void setIsoDeposit(IsolationKeys key, const IsoDeposit &dep) {
-          IsoDepositPairs::iterator it = isoDeposits_.begin(), ed = isoDeposits_.end();
-          for (; it != ed; ++it) {
-              if (it->first == key) { it->second = dep; return; }
-          }
-          isoDeposits_.push_back(std::make_pair(key,dep));
-      } 
-      /// Sets tracker IsoDeposit
-      void trackIsoDeposit(const IsoDeposit &dep) { setIsoDeposit(pat::TrackIso, dep); }
-      /// Sets ecal IsoDeposit
-      void ecalIsoDeposit(const IsoDeposit &dep)  { setIsoDeposit(pat::EcalIso,  dep); }
-      /// Sets hcal IsoDeposit
-      void hcalIsoDeposit(const IsoDeposit &dep)  { setIsoDeposit(pat::HcalIso,  dep); }
-      /// Sets user-level IsoDeposit
-      void userIsoDeposit(const IsoDeposit &dep, uint8_t index=0) { setIsoDeposit(IsolationKeys(UserBaseIso + index), dep); }
-      /// vertex fit method 
-      bool passElectronVeto() const { return passElectronVeto_; }
-      void setPassElectronVeto( bool flag ) { passElectronVeto_ = flag; }
-      //pixel seed to veto electron (not recommended by EGM POG but it seems very efficient)
-      bool hasPixelSeed() const { return hasPixelSeed_; }
-      void setHasPixelSeed( bool flag ) { hasPixelSeed_ = flag; }
+    /// input variables for regression energy corrections
+    float seedEnergy() const { return seedEnergy_; }
+    void setSeedEnergy(float e) { seedEnergy_ = e; }
 
-       /// input variables for regression energy corrections
-      float seedEnergy() const { return seedEnergy_;}
-      void setSeedEnergy( float e ){ seedEnergy_ = e; }
+    float eMax() const { return eMax_; }
+    void setEMax(float e) { eMax_ = e; }
+    float e2nd() const { return e2nd_; }
+    void setE2nd(float e) { e2nd_ = e; }
+    float e3x3() const { return e3x3_; }
+    void setE3x3(float e) { e3x3_ = e; }
+    float eTop() const { return eTop_; }
+    void setETop(float e) { eTop_ = e; }
+    float eBottom() const { return eBottom_; }
+    void setEBottom(float e) { eBottom_ = e; }
+    float eLeft() const { return eLeft_; }
+    void setELeft(float e) { eLeft_ = e; }
+    float eRight() const { return eRight_; }
+    void setERight(float e) { eRight_ = e; }
 
-      float eMax() const { return eMax_;}
-      void setEMax( float e ){ eMax_ = e;}
-      float e2nd() const { return e2nd_;}
-      void setE2nd( float e ){ e2nd_ = e;}
-      float e3x3() const { return e3x3_;}
-      void setE3x3( float e ){ e3x3_ = e;}
-      float eTop() const { return eTop_;}
-      void setETop( float e ){ eTop_ = e;}
-      float eBottom() const { return eBottom_;}
-      void setEBottom( float e ){ eBottom_ = e;}
-      float eLeft() const { return eLeft_;}
-      void setELeft( float e ){ eLeft_ = e;}
-      float eRight() const { return eRight_;}
-      void setERight( float e ){ eRight_ = e;}
-  
-      float see() const { return see_;}
-      void setSee( float s ){ see_ = s;}
-      float spp() const { return spp_;}
-      void setSpp( float s ){ spp_ = s;}
-      float sep() const { return sep_;}
-      void setSep( float s ){ sep_ = s;}
+    float see() const { return see_; }
+    void setSee(float s) { see_ = s; }
+    float spp() const { return spp_; }
+    void setSpp(float s) { spp_ = s; }
+    float sep() const { return sep_; }
+    void setSep(float s) { sep_ = s; }
 
-      float maxDR() const { return maxDR_;}
-      void setMaxDR( float m ){ maxDR_ = m;}
-      float maxDRDPhi() const { return maxDRDPhi_;}
-      void setMaxDRDPhi( float m ){ maxDRDPhi_ = m;}
-      float maxDRDEta() const { return maxDRDEta_;}
-      void setMaxDRDEta( float m ){ maxDRDEta_ = m;}
-      float maxDRRawEnergy() const { return maxDRRawEnergy_;}
-      void setMaxDRRawEnergy( float m ){ maxDRRawEnergy_ = m;}
+    float maxDR() const { return maxDR_; }
+    void setMaxDR(float m) { maxDR_ = m; }
+    float maxDRDPhi() const { return maxDRDPhi_; }
+    void setMaxDRDPhi(float m) { maxDRDPhi_ = m; }
+    float maxDRDEta() const { return maxDRDEta_; }
+    void setMaxDRDEta(float m) { maxDRDEta_ = m; }
+    float maxDRRawEnergy() const { return maxDRRawEnergy_; }
+    void setMaxDRRawEnergy(float m) { maxDRRawEnergy_ = m; }
 
-      float subClusRawE1() const { return subClusRawE1_;}
-      void setSubClusRawE1( float s ){ subClusRawE1_ = s;}
-      float subClusRawE2() const { return subClusRawE2_;}
-      void setSubClusRawE2( float s ){ subClusRawE2_ = s;}
-      float subClusRawE3() const { return subClusRawE3_;}
-      void setSubClusRawE3( float s ){ subClusRawE3_ = s;}
+    float subClusRawE1() const { return subClusRawE1_; }
+    void setSubClusRawE1(float s) { subClusRawE1_ = s; }
+    float subClusRawE2() const { return subClusRawE2_; }
+    void setSubClusRawE2(float s) { subClusRawE2_ = s; }
+    float subClusRawE3() const { return subClusRawE3_; }
+    void setSubClusRawE3(float s) { subClusRawE3_ = s; }
 
-      float subClusDPhi1() const { return subClusDPhi1_;}
-      void setSubClusDPhi1( float s ){ subClusDPhi1_ = s;}
-      float subClusDPhi2() const { return subClusDPhi2_;}
-      void setSubClusDPhi2( float s ){ subClusDPhi2_ = s;}
-      float subClusDPhi3() const { return subClusDPhi3_;}
-      void setSubClusDPhi3( float s ){ subClusDPhi3_ = s;}
+    float subClusDPhi1() const { return subClusDPhi1_; }
+    void setSubClusDPhi1(float s) { subClusDPhi1_ = s; }
+    float subClusDPhi2() const { return subClusDPhi2_; }
+    void setSubClusDPhi2(float s) { subClusDPhi2_ = s; }
+    float subClusDPhi3() const { return subClusDPhi3_; }
+    void setSubClusDPhi3(float s) { subClusDPhi3_ = s; }
 
-      float subClusDEta1() const { return subClusDEta1_;}
-      void setSubClusDEta1( float s ){ subClusDEta1_ = s;}
-      float subClusDEta2() const { return subClusDEta2_;}
-      void setSubClusDEta2( float s ){ subClusDEta2_ = s;}
-      float subClusDEta3() const { return subClusDEta3_;}
-      void setSubClusDEta3( float s ){ subClusDEta3_ = s;}
+    float subClusDEta1() const { return subClusDEta1_; }
+    void setSubClusDEta1(float s) { subClusDEta1_ = s; }
+    float subClusDEta2() const { return subClusDEta2_; }
+    void setSubClusDEta2(float s) { subClusDEta2_ = s; }
+    float subClusDEta3() const { return subClusDEta3_; }
+    void setSubClusDEta3(float s) { subClusDEta3_ = s; }
 
-      float cryPhi() const { return cryPhi_;}
-      void setCryPhi( float c ){ cryPhi_ = c;}
-      float cryEta() const { return cryEta_;}
-      void setCryEta( float c ){ cryEta_ = c;}
+    float cryPhi() const { return cryPhi_; }
+    void setCryPhi(float c) { cryPhi_ = c; }
+    float cryEta() const { return cryEta_; }
+    void setCryEta(float c) { cryEta_ = c; }
 
-      float iPhi() const { return iPhi_;}
-      void setIPhi( float i ){ iPhi_ = i;}
-      float iEta() const { return iEta_;}
-      void setIEta( float i ){ iEta_ = i;}
+    float iPhi() const { return iPhi_; }
+    void setIPhi(float i) { iPhi_ = i; }
+    float iEta() const { return iEta_; }
+    void setIEta(float i) { iEta_ = i; }
 
-      /// pipe operator (introduced to use pat::Photon with PFTopProjectors)
-      friend std::ostream& reco::operator<<(std::ostream& out, const pat::Photon& obj);
+    /// pipe operator (introduced to use pat::Photon with PFTopProjectors)
+    friend std::ostream& reco::operator<<(std::ostream& out, const pat::Photon& obj);
 
-      /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
-      edm::RefVector<pat::PackedCandidateCollection> associatedPackedPFCandidates() const ;
-      /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
-      template<typename T>
-      void setAssociatedPackedPFCandidates(const edm::RefProd<pat::PackedCandidateCollection> & refprod,
-                                           T beginIndexItr,
-                                           T endIndexItr) {
-        packedPFCandidates_ = refprod;
-        associatedPackedFCandidateIndices_.clear();
-        associatedPackedFCandidateIndices_.insert(associatedPackedFCandidateIndices_.begin(),
-                                                  beginIndexItr,
-                                                  endIndexItr);
-      }
- 
-      /// get the number of non-null PFCandidates
-      size_t numberOfSourceCandidatePtrs() const override { return associatedPackedFCandidateIndices_.size(); }
-      /// get the source candidate pointer with index i
-      reco::CandidatePtr sourceCandidatePtr( size_type i ) const override;
+    /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
+    edm::RefVector<pat::PackedCandidateCollection> associatedPackedPFCandidates() const;
+    /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
+    template <typename T>
+    void setAssociatedPackedPFCandidates(const edm::RefProd<pat::PackedCandidateCollection>& refprod,
+                                         T beginIndexItr,
+                                         T endIndexItr) {
+      packedPFCandidates_ = refprod;
+      associatedPackedFCandidateIndices_.clear();
+      associatedPackedFCandidateIndices_.insert(associatedPackedFCandidateIndices_.begin(), beginIndexItr, endIndexItr);
+    }
 
-      friend class PATPhotonSlimmer;
+    /// get the number of non-null PFCandidates
+    size_t numberOfSourceCandidatePtrs() const override { return associatedPackedFCandidateIndices_.size(); }
+    /// get the source candidate pointer with index i
+    reco::CandidatePtr sourceCandidatePtr(size_type i) const override;
 
-    protected:
+    friend class PATPhotonSlimmer;
 
-      // ---- for content embedding ----
-      bool embeddedSuperCluster_;
-      std::vector<reco::SuperCluster> superCluster_;
-      /// Place to temporarily store the electron's supercluster after relinking the seed to it
-      edm::AtomicPtrCache<std::vector<reco::SuperCluster> > superClusterRelinked_;
-      /// Place to store electron's basic clusters internally 
-      std::vector<reco::CaloCluster> basicClusters_;
-      /// Place to store electron's preshower clusters internally      
-      std::vector<reco::CaloCluster> preshowerClusters_;      
-      /// True if seed cluster is stored internally
-      bool embeddedSeedCluster_;
-      /// Place to store electron's seed cluster internally
-      std::vector<reco::CaloCluster> seedCluster_;
-      /// True if RecHits stored internally
-      bool embeddedRecHits_;    
-      /// Place to store electron's RecHits internally (5x5 around seed+ all RecHits)
-      EcalRecHitCollection recHits_;      
-      // ---- photon ID's holder ----
-      std::vector<IdPair> photonIDs_;
-      // ---- Isolation and IsoDeposit related datamebers ----
-      typedef std::vector<std::pair<IsolationKeys, pat::IsoDeposit> > IsoDepositPairs;
-      IsoDepositPairs    isoDeposits_;
-      std::vector<float> isolations_;
+  protected:
+    // ---- for content embedding ----
+    bool embeddedSuperCluster_;
+    std::vector<reco::SuperCluster> superCluster_;
+    /// Place to temporarily store the electron's supercluster after relinking the seed to it
+    edm::AtomicPtrCache<std::vector<reco::SuperCluster> > superClusterRelinked_;
+    /// Place to store electron's basic clusters internally
+    std::vector<reco::CaloCluster> basicClusters_;
+    /// Place to store electron's preshower clusters internally
+    std::vector<reco::CaloCluster> preshowerClusters_;
+    /// True if seed cluster is stored internally
+    bool embeddedSeedCluster_;
+    /// Place to store electron's seed cluster internally
+    std::vector<reco::CaloCluster> seedCluster_;
+    /// True if RecHits stored internally
+    bool embeddedRecHits_;
+    /// Place to store electron's RecHits internally (5x5 around seed+ all RecHits)
+    EcalRecHitCollection recHits_;
+    // ---- photon ID's holder ----
+    std::vector<IdPair> photonIDs_;
+    // ---- Isolation and IsoDeposit related datamebers ----
+    typedef std::vector<std::pair<IsolationKeys, pat::IsoDeposit> > IsoDepositPairs;
+    IsoDepositPairs isoDeposits_;
+    std::vector<float> isolations_;
 
-      /// ---- conversion veto ----
-      bool passElectronVeto_;
-      bool hasPixelSeed_;
-      
-      /// ---- input variables for regression energy corrections ----
-      float seedEnergy_;
-      float eMax_;
-      float e2nd_;
-      float e3x3_;
-      float eTop_;
-      float eBottom_;
-      float eLeft_;
-      float eRight_;
+    /// ---- conversion veto ----
+    bool passElectronVeto_;
+    bool hasPixelSeed_;
 
-      float see_;
-      float spp_;
-      float sep_;
+    /// ---- input variables for regression energy corrections ----
+    float seedEnergy_;
+    float eMax_;
+    float e2nd_;
+    float e3x3_;
+    float eTop_;
+    float eBottom_;
+    float eLeft_;
+    float eRight_;
 
-      float maxDR_;
-      float maxDRDPhi_;
-      float maxDRDEta_;
-      float maxDRRawEnergy_;
-   
-      float subClusRawE1_;
-      float subClusRawE2_;
-      float subClusRawE3_;
+    float see_;
+    float spp_;
+    float sep_;
 
-      float subClusDPhi1_;
-      float subClusDPhi2_;
-      float subClusDPhi3_;
+    float maxDR_;
+    float maxDRDPhi_;
+    float maxDRDEta_;
+    float maxDRRawEnergy_;
 
-      float subClusDEta1_;
-      float subClusDEta2_;
-      float subClusDEta3_;
+    float subClusRawE1_;
+    float subClusRawE2_;
+    float subClusRawE3_;
 
-      float cryEta_;
-      float cryPhi_;
-      float iEta_;
-      float iPhi_;
+    float subClusDPhi1_;
+    float subClusDPhi2_;
+    float subClusDPhi3_;
 
-      //PUPPI isolations
-      float puppiChargedHadronIso_;
-      float puppiNeutralHadronIso_;
-      float puppiPhotonIso_;
+    float subClusDEta1_;
+    float subClusDEta2_;
+    float subClusDEta3_;
 
-      // ---- link to PackedPFCandidates
-      edm::RefProd<pat::PackedCandidateCollection> packedPFCandidates_;
-      std::vector<uint16_t> associatedPackedFCandidateIndices_;
+    float cryEta_;
+    float cryPhi_;
+    float iEta_;
+    float iPhi_;
+
+    //PUPPI isolations
+    float puppiChargedHadronIso_;
+    float puppiNeutralHadronIso_;
+    float puppiPhotonIso_;
+
+    // ---- link to PackedPFCandidates
+    edm::RefProd<pat::PackedCandidateCollection> packedPFCandidates_;
+    std::vector<uint16_t> associatedPackedFCandidateIndices_;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/ResolutionHelper.h
+++ b/DataFormats/PatCandidates/interface/ResolutionHelper.h
@@ -3,47 +3,50 @@
 
 #include "DataFormats/PatCandidates/interface/CandKinResolution.h"
 
-namespace pat { namespace helper {
-namespace ResolutionHelper {
-    void   rescaleForKinFitter(const pat::CandKinResolution::Parametrization parametrization, 
-                               AlgebraicSymMatrix44 &covariance, 
+namespace pat {
+  namespace helper {
+    namespace ResolutionHelper {
+      void rescaleForKinFitter(const pat::CandKinResolution::Parametrization parametrization,
+                               AlgebraicSymMatrix44 &covariance,
                                const math::XYZTLorentzVector &initialP4);
-    double getResolEta(pat::CandKinResolution::Parametrization parametrization,
+      double getResolEta(pat::CandKinResolution::Parametrization parametrization,
+                         const AlgebraicSymMatrix44 &covariance,
+                         const pat::CandKinResolution::LorentzVector &p4);
+      double getResolTheta(pat::CandKinResolution::Parametrization parametrization,
+                           const AlgebraicSymMatrix44 &covariance,
+                           const pat::CandKinResolution::LorentzVector &p4);
+      double getResolPhi(pat::CandKinResolution::Parametrization parametrization,
+                         const AlgebraicSymMatrix44 &covariance,
+                         const pat::CandKinResolution::LorentzVector &p4);
+      double getResolE(pat::CandKinResolution::Parametrization parametrization,
                        const AlgebraicSymMatrix44 &covariance,
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolTheta(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolPhi(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolE(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolEt(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolM(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolP(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolPt(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolPInv(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolPx(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolPy(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-    double getResolPz(pat::CandKinResolution::Parametrization parametrization,
-                       const AlgebraicSymMatrix44 &covariance, 
-                       const pat::CandKinResolution::LorentzVector &p4) ; 
-} } }
+                       const pat::CandKinResolution::LorentzVector &p4);
+      double getResolEt(pat::CandKinResolution::Parametrization parametrization,
+                        const AlgebraicSymMatrix44 &covariance,
+                        const pat::CandKinResolution::LorentzVector &p4);
+      double getResolM(pat::CandKinResolution::Parametrization parametrization,
+                       const AlgebraicSymMatrix44 &covariance,
+                       const pat::CandKinResolution::LorentzVector &p4);
+      double getResolP(pat::CandKinResolution::Parametrization parametrization,
+                       const AlgebraicSymMatrix44 &covariance,
+                       const pat::CandKinResolution::LorentzVector &p4);
+      double getResolPt(pat::CandKinResolution::Parametrization parametrization,
+                        const AlgebraicSymMatrix44 &covariance,
+                        const pat::CandKinResolution::LorentzVector &p4);
+      double getResolPInv(pat::CandKinResolution::Parametrization parametrization,
+                          const AlgebraicSymMatrix44 &covariance,
+                          const pat::CandKinResolution::LorentzVector &p4);
+      double getResolPx(pat::CandKinResolution::Parametrization parametrization,
+                        const AlgebraicSymMatrix44 &covariance,
+                        const pat::CandKinResolution::LorentzVector &p4);
+      double getResolPy(pat::CandKinResolution::Parametrization parametrization,
+                        const AlgebraicSymMatrix44 &covariance,
+                        const pat::CandKinResolution::LorentzVector &p4);
+      double getResolPz(pat::CandKinResolution::Parametrization parametrization,
+                        const AlgebraicSymMatrix44 &covariance,
+                        const pat::CandKinResolution::LorentzVector &p4);
+    }  // namespace ResolutionHelper
+  }    // namespace helper
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/StringMap.h
+++ b/DataFormats/PatCandidates/interface/StringMap.h
@@ -3,54 +3,55 @@
 
 #include <string>
 #include <vector>
-#include <algorithm>   // for std::pair
+#include <algorithm>  // for std::pair
 
 class StringMap {
-    public:
-        typedef std::pair<std::string, int32_t> value_type;
-        typedef std::vector<value_type>         vector_type;
-        typedef vector_type::const_iterator     const_iterator;
+public:
+  typedef std::pair<std::string, int32_t> value_type;
+  typedef std::vector<value_type> vector_type;
+  typedef vector_type::const_iterator const_iterator;
 
-        void add(const std::string &string, int32_t value) ;
-        void sort();
-        void clear();
+  void add(const std::string &string, int32_t value);
+  void sort();
+  void clear();
 
-        /// return associated number, or -1 if no one is found
-        /// in case the association is not unque, the choice of the returned value is undetermined
-        /// note: works only after it's sorted
-        int32_t operator[](const std::string &string) const ;
+  /// return associated number, or -1 if no one is found
+  /// in case the association is not unque, the choice of the returned value is undetermined
+  /// note: works only after it's sorted
+  int32_t operator[](const std::string &string) const;
 
-        /// return associated string, or "" if none is there
-        /// in case the association is not unque, the choice of the returned value is undetermined
-        /// note: works only after it's sorted
-        const std::string & operator[](int32_t number) const ;
+  /// return associated string, or "" if none is there
+  /// in case the association is not unque, the choice of the returned value is undetermined
+  /// note: works only after it's sorted
+  const std::string &operator[](int32_t number) const;
 
-        const_iterator find(const std::string &string) const ;
-        const_iterator find(int32_t number) const ;
+  const_iterator find(const std::string &string) const;
+  const_iterator find(int32_t number) const;
 
-        const_iterator begin() const { return entries_.begin(); }
-        const_iterator end() const { return entries_.end(); }
-    
-        size_t size() const { return entries_.size(); }
-        class MatchByString {
-            public:
-                MatchByString() {}
-                //MatchByString(const std::string &string) : string_(string) {}
-                bool operator()(const value_type &val, const std::string &string) const { return  val.first < string; }
-                //bool operator()(const value_type &val) const { return string_ == val.first; }
-            private:
-                //const std::string &string_;
-        };
-        class MatchByNumber {
-            public:
-                MatchByNumber(int32_t number) : number_(number) {}
-                bool operator()(const value_type &val) const { return number_ == val.second; }
-            private:
-                int32_t number_;
-        };
-    private:
-        std::vector< std::pair<std::string, int32_t> > entries_;
-        
-} ;
+  const_iterator begin() const { return entries_.begin(); }
+  const_iterator end() const { return entries_.end(); }
+
+  size_t size() const { return entries_.size(); }
+  class MatchByString {
+  public:
+    MatchByString() {}
+    //MatchByString(const std::string &string) : string_(string) {}
+    bool operator()(const value_type &val, const std::string &string) const { return val.first < string; }
+    //bool operator()(const value_type &val) const { return string_ == val.first; }
+  private:
+    //const std::string &string_;
+  };
+  class MatchByNumber {
+  public:
+    MatchByNumber(int32_t number) : number_(number) {}
+    bool operator()(const value_type &val) const { return number_ == val.second; }
+
+  private:
+    int32_t number_;
+  };
+
+private:
+  std::vector<std::pair<std::string, int32_t> > entries_;
+};
 
 #endif

--- a/DataFormats/PatCandidates/interface/Tau.h
+++ b/DataFormats/PatCandidates/interface/Tau.h
@@ -15,7 +15,6 @@
   \author Steven Lowette, Christophe Delaere, Giovanni Petrucciani, Frederic Ronga, Colin Bernet
 */
 
-
 #include "DataFormats/TauReco/interface/BaseTau.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameter.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -35,21 +34,20 @@
 // Define typedefs for convenience
 namespace pat {
   class Tau;
-  typedef std::vector<Tau>              TauCollection; 
-  typedef edm::Ref<TauCollection>       TauRef; 
-  typedef edm::RefProd<TauCollection>	TauRefProd;
-  typedef edm::RefVector<TauCollection> TauRefVector; 
-}
+  typedef std::vector<Tau> TauCollection;
+  typedef edm::Ref<TauCollection> TauRef;
+  typedef edm::RefProd<TauCollection> TauRefProd;
+  typedef edm::RefVector<TauCollection> TauRefVector;
+}  // namespace pat
 
 namespace reco {
   /// pipe operator (introduced to use pat::Tau with PFTopProjectors)
   std::ostream& operator<<(std::ostream& out, const pat::Tau& obj);
   //  bool sortByPt(const CandidatePtrVector::const_iterator &lhs, const CandidatePtrVector::const_iterator &rhs) { return (*lhs)->pt() < (*rhs)->pt(); }
-}
+}  // namespace reco
 
 // Class definition
 namespace pat {
-  
 
   class PATTauSlimmer;
 
@@ -59,484 +57,479 @@ namespace pat {
     /// function, which should be non accessible to any other user
     friend class PATTauProducer;
 
-    public:
+  public:
+    typedef std::pair<std::string, float> IdPair;
 
-      typedef std::pair<std::string, float> IdPair;
+    /// default constructor
+    Tau();
+    /// constructor from a reco tau
+    Tau(const reco::BaseTau& aTau);
+    /// constructor from a RefToBase to a reco tau (to be superseded by Ptr counterpart)
+    Tau(const edm::RefToBase<reco::BaseTau>& aTauRef);
+    /// constructor from a Ptr to a reco tau
+    Tau(const edm::Ptr<reco::BaseTau>& aTauRef);
+    /// destructor
+    ~Tau() override;
 
-      /// default constructor
-      Tau();
-      /// constructor from a reco tau
-      Tau(const reco::BaseTau & aTau);
-      /// constructor from a RefToBase to a reco tau (to be superseded by Ptr counterpart)
-      Tau(const edm::RefToBase<reco::BaseTau> & aTauRef);
-      /// constructor from a Ptr to a reco tau
-      Tau(const edm::Ptr<reco::BaseTau> & aTauRef);
-      /// destructor
-      ~Tau() override;
+    /// required reimplementation of the Candidate's clone method
+    Tau* clone() const override { return new Tau(*this); }
 
-      /// required reimplementation of the Candidate's clone method
-      Tau * clone() const override { return new Tau(*this); }
+    // ---- methods for content embedding ----
+    /// override the reco::BaseTau::isolationTracks method, to access the internal storage of the isolation tracks
+    const reco::TrackRefVector& isolationTracks() const override;
+    /// override the reco::BaseTau::leadTrack method, to access the internal storage of the leading track
+    reco::TrackRef leadTrack() const override;
+    /// override the reco::BaseTau::signalTracks method, to access the internal storage of the signal tracks
+    const reco::TrackRefVector& signalTracks() const override;
+    /// method to store the isolation tracks internally
+    void embedIsolationTracks();
+    /// method to store the leading track internally
+    void embedLeadTrack();
+    /// method to store the signal tracks internally
+    void embedSignalTracks();
+    ///- PFTau specific content -
+    /// method to store the leading candidate internally
+    void embedLeadPFCand();
+    /// method to store the leading charged hadron candidate internally
+    void embedLeadPFChargedHadrCand();
+    /// method to store the leading neutral candidate internally
+    void embedLeadPFNeutralCand();
+    /// method to store the signal candidates internally
+    void embedSignalPFCands();
+    /// method to store the signal charged hadrons candidates internally
+    void embedSignalPFChargedHadrCands();
+    /// method to store the signal neutral hadrons candidates internally
+    void embedSignalPFNeutralHadrCands();
+    /// method to store the signal gamma candidates internally
+    void embedSignalPFGammaCands();
+    /// method to store the isolation candidates internally
+    void embedIsolationPFCands();
+    /// method to store the isolation charged hadrons candidates internally
+    void embedIsolationPFChargedHadrCands();
+    /// method to store the isolation neutral hadrons candidates internally
+    void embedIsolationPFNeutralHadrCands();
+    /// method to store the isolation gamma candidates internally
+    void embedIsolationPFGammaCands();
 
-      // ---- methods for content embedding ----
-      /// override the reco::BaseTau::isolationTracks method, to access the internal storage of the isolation tracks
-      const reco::TrackRefVector & isolationTracks() const override;
-      /// override the reco::BaseTau::leadTrack method, to access the internal storage of the leading track
-      reco::TrackRef leadTrack() const override;
-      /// override the reco::BaseTau::signalTracks method, to access the internal storage of the signal tracks
-      const reco::TrackRefVector & signalTracks() const override;	
-      /// method to store the isolation tracks internally
-      void embedIsolationTracks();
-      /// method to store the leading track internally
-      void embedLeadTrack();
-      /// method to store the signal tracks internally
-      void embedSignalTracks();
-      ///- PFTau specific content -
-      /// method to store the leading candidate internally
-      void embedLeadPFCand();
-      /// method to store the leading charged hadron candidate internally
-      void embedLeadPFChargedHadrCand();
-      /// method to store the leading neutral candidate internally
-      void embedLeadPFNeutralCand();
-      /// method to store the signal candidates internally
-      void embedSignalPFCands();
-      /// method to store the signal charged hadrons candidates internally
-      void embedSignalPFChargedHadrCands();
-      /// method to store the signal neutral hadrons candidates internally
-      void embedSignalPFNeutralHadrCands();
-      /// method to store the signal gamma candidates internally
-      void embedSignalPFGammaCands();
-      /// method to store the isolation candidates internally
-      void embedIsolationPFCands();
-      /// method to store the isolation charged hadrons candidates internally
-      void embedIsolationPFChargedHadrCands();
-      /// method to store the isolation neutral hadrons candidates internally
-      void embedIsolationPFNeutralHadrCands();
-      /// method to store the isolation gamma candidates internally
-      void embedIsolationPFGammaCands();
-      
-      // ---- matched GenJet methods ----
-      /// return matched GenJet, built from the visible particles of a generated tau
-      const reco::GenJet * genJet() const;
-      /// set the matched GenJet
-      void setGenJet(const reco::GenJetRef & ref);
+    // ---- matched GenJet methods ----
+    /// return matched GenJet, built from the visible particles of a generated tau
+    const reco::GenJet* genJet() const;
+    /// set the matched GenJet
+    void setGenJet(const reco::GenJetRef& ref);
 
-      // ---- CaloTau accessors (getters only) ----
-      /// Returns true if this pat::Tau was made from a reco::CaloTau
-      bool isCaloTau() const { return !caloSpecific_.empty(); }
-      /// return CaloTau info or throw exception 'not CaloTau'
-      const pat::tau::TauCaloSpecific & caloSpecific() const ;
-      /// Method copied from reco::CaloTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
-      reco::CaloTauTagInfoRef caloTauTagInfoRef() const { return caloSpecific().CaloTauTagInfoRef_; }
-      /// Method copied from reco::CaloTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
-      float leadTracksignedSipt() const { return caloSpecific().leadTracksignedSipt_; }
-      /// Method copied from reco::CaloTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
-      float leadTrackHCAL3x3hitsEtSum() const { return caloSpecific().leadTrackHCAL3x3hitsEtSum_; }
-      /// Method copied from reco::CaloTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
-      float leadTrackHCAL3x3hottesthitDEta() const { return caloSpecific().leadTrackHCAL3x3hottesthitDEta_; }
-      /// Method copied from reco::CaloTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
-      float signalTracksInvariantMass() const { return caloSpecific().signalTracksInvariantMass_; }
-      /// Method copied from reco::CaloTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
-      float TracksInvariantMass() const { return caloSpecific().TracksInvariantMass_; } 
-      /// Method copied from reco::CaloTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
-      float isolationTracksPtSum() const { return caloSpecific().isolationTracksPtSum_; }
-      /// Method copied from reco::CaloTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
-      float isolationECALhitsEtSum() const { return caloSpecific().isolationECALhitsEtSum_; }
-      /// Method copied from reco::CaloTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
-      float maximumHCALhitEt() const { return caloSpecific().maximumHCALhitEt_; }
+    // ---- CaloTau accessors (getters only) ----
+    /// Returns true if this pat::Tau was made from a reco::CaloTau
+    bool isCaloTau() const { return !caloSpecific_.empty(); }
+    /// return CaloTau info or throw exception 'not CaloTau'
+    const pat::tau::TauCaloSpecific& caloSpecific() const;
+    /// Method copied from reco::CaloTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
+    reco::CaloTauTagInfoRef caloTauTagInfoRef() const { return caloSpecific().CaloTauTagInfoRef_; }
+    /// Method copied from reco::CaloTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
+    float leadTracksignedSipt() const { return caloSpecific().leadTracksignedSipt_; }
+    /// Method copied from reco::CaloTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
+    float leadTrackHCAL3x3hitsEtSum() const { return caloSpecific().leadTrackHCAL3x3hitsEtSum_; }
+    /// Method copied from reco::CaloTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
+    float leadTrackHCAL3x3hottesthitDEta() const { return caloSpecific().leadTrackHCAL3x3hottesthitDEta_; }
+    /// Method copied from reco::CaloTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
+    float signalTracksInvariantMass() const { return caloSpecific().signalTracksInvariantMass_; }
+    /// Method copied from reco::CaloTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
+    float TracksInvariantMass() const { return caloSpecific().TracksInvariantMass_; }
+    /// Method copied from reco::CaloTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
+    float isolationTracksPtSum() const { return caloSpecific().isolationTracksPtSum_; }
+    /// Method copied from reco::CaloTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
+    float isolationECALhitsEtSum() const { return caloSpecific().isolationECALhitsEtSum_; }
+    /// Method copied from reco::CaloTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::CaloTau
+    float maximumHCALhitEt() const { return caloSpecific().maximumHCALhitEt_; }
 
-      // ---- PFTau accessors (getters only) ----
-      /// Returns true if this pat::Tau was made from a reco::PFTau
-      bool isPFTau() const { return !pfSpecific_.empty(); }
-      /// return PFTau info or throw exception 'not PFTau'
-      const pat::tau::TauPFSpecific & pfSpecific() const ;
-      const pat::tau::TauPFEssential & pfEssential() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const reco::JetBaseRef & pfJetRef() const { return pfSpecific().pfJetRef_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      reco::PFRecoTauChargedHadronRef leadTauChargedHadronCandidate() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const reco::PFCandidatePtr leadPFChargedHadrCand() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float leadPFChargedHadrCandsignedSipt() const { return pfSpecific().leadPFChargedHadrCandsignedSipt_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const reco::PFCandidatePtr leadPFNeutralCand() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const reco::PFCandidatePtr leadPFCand() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& signalPFCands() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& signalPFChargedHadrCands() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& signalPFNeutrHadrCands() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& signalPFGammaCands() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFRecoTauChargedHadron> & signalTauChargedHadronCandidates() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::RecoTauPiZero> & signalPiZeroCandidates() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& isolationPFCands() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& isolationPFChargedHadrCands() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& isolationPFNeutrHadrCands() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& isolationPFGammaCands() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFRecoTauChargedHadron> & isolationTauChargedHadronCandidates() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::RecoTauPiZero> & isolationPiZeroCandidates() const;
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float isolationPFChargedHadrCandsPtSum() const { return pfSpecific().isolationPFChargedHadrCandsPtSum_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float isolationPFGammaCandsEtSum() const { return pfSpecific().isolationPFGammaCandsEtSum_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float maximumHCALPFClusterEt() const { return pfSpecific().maximumHCALPFClusterEt_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float emFraction() const { return pfSpecific().emFraction_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float hcalTotOverPLead() const { return pfSpecific().hcalTotOverPLead_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float hcalMaxOverPLead() const { return pfSpecific().hcalMaxOverPLead_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float hcal3x3OverPLead() const { return pfSpecific().hcal3x3OverPLead_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float ecalStripSumEOverPLead() const { return pfSpecific().ecalStripSumEOverPLead_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float bremsRecoveryEOverPLead() const { return pfSpecific().bremsRecoveryEOverPLead_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const reco::TrackRef & electronPreIDTrack() const { return pfSpecific().electronPreIDTrack_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float electronPreIDOutput() const { return pfSpecific().electronPreIDOutput_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      bool electronPreIDDecision() const { return pfSpecific().electronPreIDDecision_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float caloComp() const { return pfSpecific().caloComp_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      float segComp() const { return pfSpecific().segComp_; }
-      /// Method copied from reco::PFTau. 
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      bool muonDecision() const { return pfSpecific().muonDecision_; }
-     
-      /// ----- Methods returning associated PFCandidates that work on PAT+AOD, PAT+embedding and miniAOD -----
-      /// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      const reco::CandidatePtr leadChargedHadrCand() const;
-      /// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      const reco::CandidatePtr leadNeutralCand() const;
-      /// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      const reco::CandidatePtr leadCand() const;
-      /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      /// note that the vector is returned by value.
-      bool ExistSignalCands() const;
-      bool ExistIsolationCands() const;
-      reco::CandidatePtrVector signalCands() const;
-      /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      /// note that the vector is returned by value.
-      reco::CandidatePtrVector signalChargedHadrCands() const;
-      /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      /// note that the vector is returned by value.
-      reco::CandidatePtrVector signalNeutrHadrCands() const;
-      /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      /// note that the vector is returned by value.
-      reco::CandidatePtrVector signalGammaCands() const;
-      /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      /// note that the vector is returned by value.
-      reco::CandidatePtrVector isolationCands() const;
-      /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      /// note that the vector is returned by value.
-      reco::CandidatePtrVector isolationChargedHadrCands() const;
-      /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      /// note that the vector is returned by value.
-      reco::CandidatePtrVector isolationNeutrHadrCands() const;
-      /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-      /// note that the vector is returned by value.
-      reco::CandidatePtrVector isolationGammaCands() const;
+    // ---- PFTau accessors (getters only) ----
+    /// Returns true if this pat::Tau was made from a reco::PFTau
+    bool isPFTau() const { return !pfSpecific_.empty(); }
+    /// return PFTau info or throw exception 'not PFTau'
+    const pat::tau::TauPFSpecific& pfSpecific() const;
+    const pat::tau::TauPFEssential& pfEssential() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const reco::JetBaseRef& pfJetRef() const { return pfSpecific().pfJetRef_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    reco::PFRecoTauChargedHadronRef leadTauChargedHadronCandidate() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const reco::PFCandidatePtr leadPFChargedHadrCand() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float leadPFChargedHadrCandsignedSipt() const { return pfSpecific().leadPFChargedHadrCandsignedSipt_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const reco::PFCandidatePtr leadPFNeutralCand() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const reco::PFCandidatePtr leadPFCand() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::PFCandidatePtr>& signalPFCands() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::PFCandidatePtr>& signalPFChargedHadrCands() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::PFCandidatePtr>& signalPFNeutrHadrCands() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::PFCandidatePtr>& signalPFGammaCands() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::PFRecoTauChargedHadron>& signalTauChargedHadronCandidates() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::RecoTauPiZero>& signalPiZeroCandidates() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::PFCandidatePtr>& isolationPFCands() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::PFCandidatePtr>& isolationPFChargedHadrCands() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::PFCandidatePtr>& isolationPFNeutrHadrCands() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::PFCandidatePtr>& isolationPFGammaCands() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::PFRecoTauChargedHadron>& isolationTauChargedHadronCandidates() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const std::vector<reco::RecoTauPiZero>& isolationPiZeroCandidates() const;
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float isolationPFChargedHadrCandsPtSum() const { return pfSpecific().isolationPFChargedHadrCandsPtSum_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float isolationPFGammaCandsEtSum() const { return pfSpecific().isolationPFGammaCandsEtSum_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float maximumHCALPFClusterEt() const { return pfSpecific().maximumHCALPFClusterEt_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float emFraction() const { return pfSpecific().emFraction_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float hcalTotOverPLead() const { return pfSpecific().hcalTotOverPLead_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float hcalMaxOverPLead() const { return pfSpecific().hcalMaxOverPLead_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float hcal3x3OverPLead() const { return pfSpecific().hcal3x3OverPLead_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float ecalStripSumEOverPLead() const { return pfSpecific().ecalStripSumEOverPLead_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float bremsRecoveryEOverPLead() const { return pfSpecific().bremsRecoveryEOverPLead_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const reco::TrackRef& electronPreIDTrack() const { return pfSpecific().electronPreIDTrack_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float electronPreIDOutput() const { return pfSpecific().electronPreIDOutput_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    bool electronPreIDDecision() const { return pfSpecific().electronPreIDDecision_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float caloComp() const { return pfSpecific().caloComp_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    float segComp() const { return pfSpecific().segComp_; }
+    /// Method copied from reco::PFTau.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    bool muonDecision() const { return pfSpecific().muonDecision_; }
 
-      /// setters for the PtrVectors (for miniAOD)
-      void setSignalChargedHadrCands(const reco::CandidatePtrVector &ptrs) { signalChargedHadrCandPtrs_ = ptrs;}
-      void setSignalNeutralHadrCands(const reco::CandidatePtrVector &ptrs) { signalNeutralHadrCandPtrs_ = ptrs;}
-      void setSignalGammaCands(const reco::CandidatePtrVector &ptrs) { signalGammaCandPtrs_ = ptrs;}
-      void setIsolationChargedHadrCands(const reco::CandidatePtrVector &ptrs) { isolationChargedHadrCandPtrs_ = ptrs;}
-      void setIsolationNeutralHadrCands(const reco::CandidatePtrVector &ptrs) { isolationNeutralHadrCandPtrs_ = ptrs;}
-      void setIsolationGammaCands(const reco::CandidatePtrVector &ptrs) { isolationGammaCandPtrs_ = ptrs;}
+    /// ----- Methods returning associated PFCandidates that work on PAT+AOD, PAT+embedding and miniAOD -----
+    /// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    const reco::CandidatePtr leadChargedHadrCand() const;
+    /// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    const reco::CandidatePtr leadNeutralCand() const;
+    /// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    const reco::CandidatePtr leadCand() const;
+    /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    /// note that the vector is returned by value.
+    bool ExistSignalCands() const;
+    bool ExistIsolationCands() const;
+    reco::CandidatePtrVector signalCands() const;
+    /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    /// note that the vector is returned by value.
+    reco::CandidatePtrVector signalChargedHadrCands() const;
+    /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    /// note that the vector is returned by value.
+    reco::CandidatePtrVector signalNeutrHadrCands() const;
+    /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    /// note that the vector is returned by value.
+    reco::CandidatePtrVector signalGammaCands() const;
+    /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    /// note that the vector is returned by value.
+    reco::CandidatePtrVector isolationCands() const;
+    /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    /// note that the vector is returned by value.
+    reco::CandidatePtrVector isolationChargedHadrCands() const;
+    /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    /// note that the vector is returned by value.
+    reco::CandidatePtrVector isolationNeutrHadrCands() const;
+    /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+    /// note that the vector is returned by value.
+    reco::CandidatePtrVector isolationGammaCands() const;
 
-      /// ----- Top Projection business ------- 
-      /// get the number of non-null PFCandidates
-      size_t numberOfSourceCandidatePtrs() const override ;
-      /// get the source candidate pointer with index i
-      reco::CandidatePtr sourceCandidatePtr( size_type i ) const override;
+    /// setters for the PtrVectors (for miniAOD)
+    void setSignalChargedHadrCands(const reco::CandidatePtrVector& ptrs) { signalChargedHadrCandPtrs_ = ptrs; }
+    void setSignalNeutralHadrCands(const reco::CandidatePtrVector& ptrs) { signalNeutralHadrCandPtrs_ = ptrs; }
+    void setSignalGammaCands(const reco::CandidatePtrVector& ptrs) { signalGammaCandPtrs_ = ptrs; }
+    void setIsolationChargedHadrCands(const reco::CandidatePtrVector& ptrs) { isolationChargedHadrCandPtrs_ = ptrs; }
+    void setIsolationNeutralHadrCands(const reco::CandidatePtrVector& ptrs) { isolationNeutralHadrCandPtrs_ = ptrs; }
+    void setIsolationGammaCands(const reco::CandidatePtrVector& ptrs) { isolationGammaCandPtrs_ = ptrs; }
 
+    /// ----- Top Projection business -------
+    /// get the number of non-null PFCandidates
+    size_t numberOfSourceCandidatePtrs() const override;
+    /// get the source candidate pointer with index i
+    reco::CandidatePtr sourceCandidatePtr(size_type i) const override;
 
-      /// ---- Tau lifetime information ----
-      /// Filled from PFTauTIPAssociation.
-      /// Throws an exception if this pat::Tau was not made from a reco::PFTau	
-      const pat::tau::TauPFEssential::Point& dxy_PCA() const { return pfEssential().dxy_PCA_; }
-      float dxy() const { return pfEssential().dxy_; }
-      float dxy_error() const { return pfEssential().dxy_error_; }
-      float dxy_Sig() const;
-      const reco::VertexRef& primaryVertex() const { return pfEssential().pv_; }
-      const pat::tau::TauPFEssential::Point& primaryVertexPos() const { return pfEssential().pvPos_; }
-      const pat::tau::TauPFEssential::CovMatrix& primaryVertexCov() const { return pfEssential().pvCov_; }
-      bool hasSecondaryVertex() const { return pfEssential().hasSV_; }
-      const pat::tau::TauPFEssential::Vector& flightLength() const { return pfEssential().flightLength_; } 
-      float flightLengthSig() const { return pfEssential().flightLengthSig_; }
-      pat::tau::TauPFEssential::CovMatrix flightLengthCov() const;
-      const reco::VertexRef& secondaryVertex() const { return pfEssential().sv_; }
-      const pat::tau::TauPFEssential::Point& secondaryVertexPos() const { return pfEssential().svPos_; }
-      const pat::tau::TauPFEssential::CovMatrix& secondaryVertexCov() const { return pfEssential().svCov_; }
-      float ip3d() const { return pfEssential().ip3d_; }
-      float ip3d_error() const { return pfEssential().ip3d_error_; }
-      float ip3d_Sig() const;
+    /// ---- Tau lifetime information ----
+    /// Filled from PFTauTIPAssociation.
+    /// Throws an exception if this pat::Tau was not made from a reco::PFTau
+    const pat::tau::TauPFEssential::Point& dxy_PCA() const { return pfEssential().dxy_PCA_; }
+    float dxy() const { return pfEssential().dxy_; }
+    float dxy_error() const { return pfEssential().dxy_error_; }
+    float dxy_Sig() const;
+    const reco::VertexRef& primaryVertex() const { return pfEssential().pv_; }
+    const pat::tau::TauPFEssential::Point& primaryVertexPos() const { return pfEssential().pvPos_; }
+    const pat::tau::TauPFEssential::CovMatrix& primaryVertexCov() const { return pfEssential().pvCov_; }
+    bool hasSecondaryVertex() const { return pfEssential().hasSV_; }
+    const pat::tau::TauPFEssential::Vector& flightLength() const { return pfEssential().flightLength_; }
+    float flightLengthSig() const { return pfEssential().flightLengthSig_; }
+    pat::tau::TauPFEssential::CovMatrix flightLengthCov() const;
+    const reco::VertexRef& secondaryVertex() const { return pfEssential().sv_; }
+    const pat::tau::TauPFEssential::Point& secondaryVertexPos() const { return pfEssential().svPos_; }
+    const pat::tau::TauPFEssential::CovMatrix& secondaryVertexCov() const { return pfEssential().svCov_; }
+    float ip3d() const { return pfEssential().ip3d_; }
+    float ip3d_error() const { return pfEssential().ip3d_error_; }
+    float ip3d_Sig() const;
 
-      /// ---- Information for MVA isolation ----
-      /// Needed to recompute MVA isolation on MiniAOD
-      /// return sum of ecal energies from signal candidates
-      float ecalEnergy() const { return pfEssential().ecalEnergy_; }
-      /// return sum of hcal energies from signal candidates
-      float hcalEnergy() const { return pfEssential().hcalEnergy_; }
-      /// return normalized chi2 of leading track
-      float leadingTrackNormChi2() const { return pfEssential().leadingTrackNormChi2_; }
+    /// ---- Information for MVA isolation ----
+    /// Needed to recompute MVA isolation on MiniAOD
+    /// return sum of ecal energies from signal candidates
+    float ecalEnergy() const { return pfEssential().ecalEnergy_; }
+    /// return sum of hcal energies from signal candidates
+    float hcalEnergy() const { return pfEssential().hcalEnergy_; }
+    /// return normalized chi2 of leading track
+    float leadingTrackNormChi2() const { return pfEssential().leadingTrackNormChi2_; }
 
-      /// ---- Information for anti-electron training ----
-      /// Needed to recompute on MiniAOD
-      /// return ecal energy from LeadChargedHadrCand
-      float ecalEnergyLeadChargedHadrCand() const { return pfEssential().ecalEnergyLeadChargedHadrCand_; }
-      /// return hcal energy from LeadChargedHadrCand
-      float hcalEnergyLeadChargedHadrCand() const { return pfEssential().hcalEnergyLeadChargedHadrCand_; }
-      /// return phiAtEcalEntrance
-      float phiAtEcalEntrance() const { return pfEssential().phiAtEcalEntrance_; }
-      /// return etaAtEcalEntrance
-      float etaAtEcalEntrance() const { return pfEssential().etaAtEcalEntrance_; }
-      /// return etaAtEcalEntrance from LeadChargedCand
-      float etaAtEcalEntranceLeadChargedCand() const { return pfEssential().etaAtEcalEntranceLeadChargedCand_; }
-      /// return pt from  LeadChargedCand
-      float ptLeadChargedCand() const { return pfEssential().ptLeadChargedCand_; }
-      /// return emFraction_MVA
-      float emFraction_MVA() const { return pfEssential().emFraction_; }
+    /// ---- Information for anti-electron training ----
+    /// Needed to recompute on MiniAOD
+    /// return ecal energy from LeadChargedHadrCand
+    float ecalEnergyLeadChargedHadrCand() const { return pfEssential().ecalEnergyLeadChargedHadrCand_; }
+    /// return hcal energy from LeadChargedHadrCand
+    float hcalEnergyLeadChargedHadrCand() const { return pfEssential().hcalEnergyLeadChargedHadrCand_; }
+    /// return phiAtEcalEntrance
+    float phiAtEcalEntrance() const { return pfEssential().phiAtEcalEntrance_; }
+    /// return etaAtEcalEntrance
+    float etaAtEcalEntrance() const { return pfEssential().etaAtEcalEntrance_; }
+    /// return etaAtEcalEntrance from LeadChargedCand
+    float etaAtEcalEntranceLeadChargedCand() const { return pfEssential().etaAtEcalEntranceLeadChargedCand_; }
+    /// return pt from  LeadChargedCand
+    float ptLeadChargedCand() const { return pfEssential().ptLeadChargedCand_; }
+    /// return emFraction_MVA
+    float emFraction_MVA() const { return pfEssential().emFraction_; }
 
-      /// Methods copied from reco::Jet.
-      /// (accessible from reco::CaloTau/reco::PFTau via reco::CaloTauTagInfo/reco::PFTauTagInfo)
-      reco::Candidate::LorentzVector p4Jet() const;
-      float etaetaMoment() const;
-      float phiphiMoment() const;
-      float etaphiMoment() const;
+    /// Methods copied from reco::Jet.
+    /// (accessible from reco::CaloTau/reco::PFTau via reco::CaloTauTagInfo/reco::PFTauTagInfo)
+    reco::Candidate::LorentzVector p4Jet() const;
+    float etaetaMoment() const;
+    float phiphiMoment() const;
+    float etaphiMoment() const;
 
-      /// reconstructed tau decay mode (specific to PFTau)
-      int decayMode() const { return pfEssential().decayMode_; }
-      /// set decay mode
-      void setDecayMode(int);
+    /// reconstructed tau decay mode (specific to PFTau)
+    int decayMode() const { return pfEssential().decayMode_; }
+    /// set decay mode
+    void setDecayMode(int);
 
-      // ---- methods for tau ID ----
-      /// Returns a specific tau ID associated to the pat::Tau given its name
-      /// For cut-based IDs, the value is 1.0 for good, 0.0 for bad.
-      /// The names are defined within the configuration parameterset "tauIDSources"
-      /// in PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cfi.py .
-      /// Note: an exception is thrown if the specified ID is not available
-      float tauID(const std::string & name) const;
-      float tauID(const char* name ) const {return tauID( std::string(name) );}
-      /// Returns true if a specific ID is available in this pat::Tau
-      bool isTauIDAvailable(const std::string & name) const;
-      /// Returns all the tau IDs in the form of <name,value> pairs
-      /// The 'default' ID is the first in the list
-      const std::vector<IdPair> &  tauIDs() const { return tauIDs_; }
-      /// Store multiple tau ID values, discarding existing ones
-      /// The first one in the list becomes the 'default' tau id 
-      void setTauIDs(const std::vector<IdPair> & ids) { tauIDs_ = ids; }
+    // ---- methods for tau ID ----
+    /// Returns a specific tau ID associated to the pat::Tau given its name
+    /// For cut-based IDs, the value is 1.0 for good, 0.0 for bad.
+    /// The names are defined within the configuration parameterset "tauIDSources"
+    /// in PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cfi.py .
+    /// Note: an exception is thrown if the specified ID is not available
+    float tauID(const std::string& name) const;
+    float tauID(const char* name) const { return tauID(std::string(name)); }
+    /// Returns true if a specific ID is available in this pat::Tau
+    bool isTauIDAvailable(const std::string& name) const;
+    /// Returns all the tau IDs in the form of <name,value> pairs
+    /// The 'default' ID is the first in the list
+    const std::vector<IdPair>& tauIDs() const { return tauIDs_; }
+    /// Store multiple tau ID values, discarding existing ones
+    /// The first one in the list becomes the 'default' tau id
+    void setTauIDs(const std::vector<IdPair>& ids) { tauIDs_ = ids; }
 
-      /// pipe operator (introduced to use pat::Tau with PFTopProjectors)
-      friend std::ostream& reco::operator<<(std::ostream& out, const Tau& obj);
+    /// pipe operator (introduced to use pat::Tau with PFTopProjectors)
+    friend std::ostream& reco::operator<<(std::ostream& out, const Tau& obj);
 
-      /// ---- methods for jet corrections ----
-      /// returns the labels of all available sets of jet energy corrections
-      const std::vector<std::string> availableJECSets() const;
-      // returns the available JEC Levels for a given jecSet
-      const std::vector<std::string> availableJECLevels(const int& set = 0) const;
-      // returns the available JEC Levels for a given jecSet
-      const std::vector<std::string> availableJECLevels(const std::string& set) const { return availableJECLevels(jecSet(set)); };
-      /// returns true if the jet carries jet energy correction information
-      /// at all
-      bool jecSetsAvailable() const { return !jec_.empty(); }
-      /// returns true if the jet carries a set of jet energy correction
-      /// factors with the given label
-      bool jecSetAvailable(const std::string& set) const {return (jecSet(set) >= 0); };
-      /// returns true if the jet carries a set of jet energy correction
-      /// factors with the given label
-      bool jecSetAvailable(const unsigned int& set) const {return (set < jec_.size()); };
-      /// returns the label of the current set of jet energy corrections
-      std::string currentJECSet() const { 
-	return currentJECSet_<jec_.size() ? jec_.at(currentJECSet_).jecSet() : std::string("ERROR"); 
-      }
-      /// return the name of the current step of jet energy corrections
-      std::string currentJECLevel() const { 
-	return currentJECSet_<jec_.size() ? jec_.at(currentJECSet_).jecLevel(currentJECLevel_) : std::string("ERROR"); 
-      }
-      /// correction factor to the given level for a specific set
-      /// of correction factors, starting from the current level
-      float jecFactor(const std::string& level, const std::string& set = "") const;
-      /// correction factor to the given level for a specific set
-      /// of correction factors, starting from the current level
-      float jecFactor(const unsigned int& level, const unsigned int& set = 0) const;
-      /// copy of the jet corrected up to the given level for the set
-      /// of jet energy correction factors, which is currently in use
-      Tau correctedTauJet(const std::string& level, const std::string& set = "") const;
-      /// copy of the jet corrected up to the given level for the set
-      /// of jet energy correction factors, which is currently in use
-      Tau correctedTauJet(const unsigned int& level, const unsigned int& set = 0) const;
-      /// p4 of the jet corrected up to the given level for the set
-      /// of jet energy correction factors, which is currently in use
-      const LorentzVector& correctedP4(const std::string& level, const std::string& set = "") const { 
-	return correctedTauJet(level, set).p4(); 
-      }
-      /// p4 of the jet corrected up to the given level for the set
-      /// of jet energy correction factors, which is currently in use
-      const LorentzVector& correctedP4(const unsigned int& level, const unsigned int& set = 0) const { 
-	return correctedTauJet(level, set).p4(); 
-      }
+    /// ---- methods for jet corrections ----
+    /// returns the labels of all available sets of jet energy corrections
+    const std::vector<std::string> availableJECSets() const;
+    // returns the available JEC Levels for a given jecSet
+    const std::vector<std::string> availableJECLevels(const int& set = 0) const;
+    // returns the available JEC Levels for a given jecSet
+    const std::vector<std::string> availableJECLevels(const std::string& set) const {
+      return availableJECLevels(jecSet(set));
+    };
+    /// returns true if the jet carries jet energy correction information
+    /// at all
+    bool jecSetsAvailable() const { return !jec_.empty(); }
+    /// returns true if the jet carries a set of jet energy correction
+    /// factors with the given label
+    bool jecSetAvailable(const std::string& set) const { return (jecSet(set) >= 0); };
+    /// returns true if the jet carries a set of jet energy correction
+    /// factors with the given label
+    bool jecSetAvailable(const unsigned int& set) const { return (set < jec_.size()); };
+    /// returns the label of the current set of jet energy corrections
+    std::string currentJECSet() const {
+      return currentJECSet_ < jec_.size() ? jec_.at(currentJECSet_).jecSet() : std::string("ERROR");
+    }
+    /// return the name of the current step of jet energy corrections
+    std::string currentJECLevel() const {
+      return currentJECSet_ < jec_.size() ? jec_.at(currentJECSet_).jecLevel(currentJECLevel_) : std::string("ERROR");
+    }
+    /// correction factor to the given level for a specific set
+    /// of correction factors, starting from the current level
+    float jecFactor(const std::string& level, const std::string& set = "") const;
+    /// correction factor to the given level for a specific set
+    /// of correction factors, starting from the current level
+    float jecFactor(const unsigned int& level, const unsigned int& set = 0) const;
+    /// copy of the jet corrected up to the given level for the set
+    /// of jet energy correction factors, which is currently in use
+    Tau correctedTauJet(const std::string& level, const std::string& set = "") const;
+    /// copy of the jet corrected up to the given level for the set
+    /// of jet energy correction factors, which is currently in use
+    Tau correctedTauJet(const unsigned int& level, const unsigned int& set = 0) const;
+    /// p4 of the jet corrected up to the given level for the set
+    /// of jet energy correction factors, which is currently in use
+    const LorentzVector& correctedP4(const std::string& level, const std::string& set = "") const {
+      return correctedTauJet(level, set).p4();
+    }
+    /// p4 of the jet corrected up to the given level for the set
+    /// of jet energy correction factors, which is currently in use
+    const LorentzVector& correctedP4(const unsigned int& level, const unsigned int& set = 0) const {
+      return correctedTauJet(level, set).p4();
+    }
 
+    friend class PATTauSlimmer;
 
-      friend class PATTauSlimmer;
-
-    protected:
-   
-      /// index of the set of jec factors with given label; returns -1 if no set
-      /// of jec factors exists with the given label
-      int jecSet(const std::string& label) const;
-      /// update the current JEC set; used by correctedJet
-      void currentJECSet(const unsigned int& set) { currentJECSet_=set; };
-      /// update the current JEC level; used by correctedJet
-      void currentJECLevel(const unsigned int& level) { currentJECLevel_=level; };
-      /// add more sets of energy correction factors
-      void addJECFactors(const TauJetCorrFactors& jec) {jec_.push_back(jec); };
-      /// initialize the jet to a given JEC level during creation starting from Uncorrected
-      void initializeJEC(unsigned int level, const unsigned int set = 0);
-
+  protected:
+    /// index of the set of jec factors with given label; returns -1 if no set
+    /// of jec factors exists with the given label
+    int jecSet(const std::string& label) const;
+    /// update the current JEC set; used by correctedJet
+    void currentJECSet(const unsigned int& set) { currentJECSet_ = set; };
+    /// update the current JEC level; used by correctedJet
+    void currentJECLevel(const unsigned int& level) { currentJECLevel_ = level; };
+    /// add more sets of energy correction factors
+    void addJECFactors(const TauJetCorrFactors& jec) { jec_.push_back(jec); };
+    /// initialize the jet to a given JEC level during creation starting from Uncorrected
+    void initializeJEC(unsigned int level, const unsigned int set = 0);
 
   private:
-      /// helper to avoid code duplication in constructors
-      void initFromBaseTau(const reco::BaseTau& aTau);
-      // ---- for content embedding ----
-      bool embeddedIsolationTracks_;
-      std::vector<reco::Track> isolationTracks_;
-      edm::AtomicPtrCache<reco::TrackRefVector> isolationTracksTransientRefVector_;
-      bool embeddedLeadTrack_;
-      std::vector<reco::Track> leadTrack_;
-      bool embeddedSignalTracks_;
-      std::vector<reco::Track> signalTracks_;
-      edm::AtomicPtrCache<reco::TrackRefVector> signalTracksTransientRefVector_;
-      // specific for PFTau
-      std::vector<reco::PFCandidate> leadPFCand_;
-      bool embeddedLeadPFCand_;
-      std::vector<reco::PFCandidate> leadPFChargedHadrCand_;
-      bool embeddedLeadPFChargedHadrCand_;
-      std::vector<reco::PFCandidate> leadPFNeutralCand_;
-      bool embeddedLeadPFNeutralCand_;
+    /// helper to avoid code duplication in constructors
+    void initFromBaseTau(const reco::BaseTau& aTau);
+    // ---- for content embedding ----
+    bool embeddedIsolationTracks_;
+    std::vector<reco::Track> isolationTracks_;
+    edm::AtomicPtrCache<reco::TrackRefVector> isolationTracksTransientRefVector_;
+    bool embeddedLeadTrack_;
+    std::vector<reco::Track> leadTrack_;
+    bool embeddedSignalTracks_;
+    std::vector<reco::Track> signalTracks_;
+    edm::AtomicPtrCache<reco::TrackRefVector> signalTracksTransientRefVector_;
+    // specific for PFTau
+    std::vector<reco::PFCandidate> leadPFCand_;
+    bool embeddedLeadPFCand_;
+    std::vector<reco::PFCandidate> leadPFChargedHadrCand_;
+    bool embeddedLeadPFChargedHadrCand_;
+    std::vector<reco::PFCandidate> leadPFNeutralCand_;
+    bool embeddedLeadPFNeutralCand_;
 
-      std::vector<reco::PFCandidate> signalPFCands_;
-      bool embeddedSignalPFCands_;
-      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > signalPFCandsTransientPtrs_;
-      std::vector<reco::PFCandidate> signalPFChargedHadrCands_;
-      bool embeddedSignalPFChargedHadrCands_;
-      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > signalPFChargedHadrCandsTransientPtrs_;
-      std::vector<reco::PFCandidate> signalPFNeutralHadrCands_;
-      bool embeddedSignalPFNeutralHadrCands_;
-      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > signalPFNeutralHadrCandsTransientPtrs_;
-      std::vector<reco::PFCandidate> signalPFGammaCands_;
-      bool embeddedSignalPFGammaCands_;
-      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > signalPFGammaCandsTransientPtrs_;
-      std::vector<reco::PFCandidate> isolationPFCands_;
-      bool embeddedIsolationPFCands_;
-      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > isolationPFCandsTransientPtrs_;
-      std::vector<reco::PFCandidate> isolationPFChargedHadrCands_;
-      bool embeddedIsolationPFChargedHadrCands_;
-      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > isolationPFChargedHadrCandsTransientPtrs_;
-      std::vector<reco::PFCandidate> isolationPFNeutralHadrCands_;
-      bool embeddedIsolationPFNeutralHadrCands_;
-      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > isolationPFNeutralHadrCandsTransientPtrs_;
-      std::vector<reco::PFCandidate> isolationPFGammaCands_;
-      bool embeddedIsolationPFGammaCands_;
-      edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > isolationPFGammaCandsTransientPtrs_;
+    std::vector<reco::PFCandidate> signalPFCands_;
+    bool embeddedSignalPFCands_;
+    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > signalPFCandsTransientPtrs_;
+    std::vector<reco::PFCandidate> signalPFChargedHadrCands_;
+    bool embeddedSignalPFChargedHadrCands_;
+    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > signalPFChargedHadrCandsTransientPtrs_;
+    std::vector<reco::PFCandidate> signalPFNeutralHadrCands_;
+    bool embeddedSignalPFNeutralHadrCands_;
+    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > signalPFNeutralHadrCandsTransientPtrs_;
+    std::vector<reco::PFCandidate> signalPFGammaCands_;
+    bool embeddedSignalPFGammaCands_;
+    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > signalPFGammaCandsTransientPtrs_;
+    std::vector<reco::PFCandidate> isolationPFCands_;
+    bool embeddedIsolationPFCands_;
+    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > isolationPFCandsTransientPtrs_;
+    std::vector<reco::PFCandidate> isolationPFChargedHadrCands_;
+    bool embeddedIsolationPFChargedHadrCands_;
+    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > isolationPFChargedHadrCandsTransientPtrs_;
+    std::vector<reco::PFCandidate> isolationPFNeutralHadrCands_;
+    bool embeddedIsolationPFNeutralHadrCands_;
+    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > isolationPFNeutralHadrCandsTransientPtrs_;
+    std::vector<reco::PFCandidate> isolationPFGammaCands_;
+    bool embeddedIsolationPFGammaCands_;
+    edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> > isolationPFGammaCandsTransientPtrs_;
 
-      // ---- matched GenJet holder ----
-      std::vector<reco::GenJet> genJet_;
+    // ---- matched GenJet holder ----
+    std::vector<reco::GenJet> genJet_;
 
-      // ---- tau ID's holder ----
-      std::vector<IdPair> tauIDs_;
+    // ---- tau ID's holder ----
+    std::vector<IdPair> tauIDs_;
 
-      // ---- PFTau specific variables  ----
-      /// holder for PFTau info, or empty vector if CaloTau
-      std::vector<pat::tau::TauPFSpecific> pfSpecific_;
+    // ---- PFTau specific variables  ----
+    /// holder for PFTau info, or empty vector if CaloTau
+    std::vector<pat::tau::TauPFSpecific> pfSpecific_;
 
-      // ---- CaloTau specific variables  ----
-      /// holder for CaloTau info, or empty vector if PFTau
-      std::vector<pat::tau::TauCaloSpecific> caloSpecific_;
+    // ---- CaloTau specific variables  ----
+    /// holder for CaloTau info, or empty vector if PFTau
+    std::vector<pat::tau::TauCaloSpecific> caloSpecific_;
 
-      // ---- energy scale correction factors ----
-      // energy scale correction factors; the string carries a potential label if
-      // more then one set of correction factors is embedded. The label corresponds
-      // to the label of the jetCorrFactors module that has been embedded.
-      std::vector<pat::TauJetCorrFactors> jec_;
-      // currently applied set of jet energy correction factors (i.e. the index in
-      // jetEnergyCorrections_)
-      unsigned int currentJECSet_;
-      // currently applied jet energy correction level
-      unsigned int currentJECLevel_;
+    // ---- energy scale correction factors ----
+    // energy scale correction factors; the string carries a potential label if
+    // more then one set of correction factors is embedded. The label corresponds
+    // to the label of the jetCorrFactors module that has been embedded.
+    std::vector<pat::TauJetCorrFactors> jec_;
+    // currently applied set of jet energy correction factors (i.e. the index in
+    // jetEnergyCorrections_)
+    unsigned int currentJECSet_;
+    // currently applied jet energy correction level
+    unsigned int currentJECLevel_;
 
-      // ---- references to packed pf candidates -----
-      reco::CandidatePtrVector signalChargedHadrCandPtrs_;
-      reco::CandidatePtrVector signalNeutralHadrCandPtrs_;
-      reco::CandidatePtrVector signalGammaCandPtrs_;
+    // ---- references to packed pf candidates -----
+    reco::CandidatePtrVector signalChargedHadrCandPtrs_;
+    reco::CandidatePtrVector signalNeutralHadrCandPtrs_;
+    reco::CandidatePtrVector signalGammaCandPtrs_;
 
-      reco::CandidatePtrVector isolationChargedHadrCandPtrs_;
-      reco::CandidatePtrVector isolationNeutralHadrCandPtrs_;
-      reco::CandidatePtrVector isolationGammaCandPtrs_;
+    reco::CandidatePtrVector isolationChargedHadrCandPtrs_;
+    reco::CandidatePtrVector isolationNeutralHadrCandPtrs_;
+    reco::CandidatePtrVector isolationGammaCandPtrs_;
 
-      // -- essential info to keep
+    // -- essential info to keep
 
-      std::vector<pat::tau::TauPFEssential>  pfEssential_;
-
-
+    std::vector<pat::tau::TauPFEssential> pfEssential_;
   };
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TauCaloSpecific.h
+++ b/DataFormats/PatCandidates/interface/TauCaloSpecific.h
@@ -14,29 +14,31 @@
 #include "DataFormats/TauReco/interface/CaloTau.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-namespace pat { namespace tau {
+namespace pat {
+  namespace tau {
 
-struct TauCaloSpecific {
-// dummy constructor for ROOT I/O
-    TauCaloSpecific() {}
-// constructor from CaloTau
-    TauCaloSpecific(const reco::CaloTau &tau) ;
-// datamembers 
-    reco::CaloTauTagInfoRef CaloTauTagInfoRef_;
-    float leadTracksignedSipt_;
-    float leadTrackHCAL3x3hitsEtSum_;
-    float leadTrackHCAL3x3hottesthitDEta_;
-    float signalTracksInvariantMass_;
-    float TracksInvariantMass_; 
-    float isolationTracksPtSum_;
-    float isolationECALhitsEtSum_;
-    float maximumHCALhitEt_;
-    reco::Candidate::LorentzVector p4Jet_;
-    float etaetaMoment_;
-    float phiphiMoment_;
-    float etaphiMoment_;
-};
+    struct TauCaloSpecific {
+      // dummy constructor for ROOT I/O
+      TauCaloSpecific() {}
+      // constructor from CaloTau
+      TauCaloSpecific(const reco::CaloTau &tau);
+      // datamembers
+      reco::CaloTauTagInfoRef CaloTauTagInfoRef_;
+      float leadTracksignedSipt_;
+      float leadTrackHCAL3x3hitsEtSum_;
+      float leadTrackHCAL3x3hottesthitDEta_;
+      float signalTracksInvariantMass_;
+      float TracksInvariantMass_;
+      float isolationTracksPtSum_;
+      float isolationECALhitsEtSum_;
+      float maximumHCALhitEt_;
+      reco::Candidate::LorentzVector p4Jet_;
+      float etaetaMoment_;
+      float phiphiMoment_;
+      float etaphiMoment_;
+    };
 
-} }
+  }  // namespace tau
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TauJetCorrFactors.h
+++ b/DataFormats/PatCandidates/interface/TauJetCorrFactors.h
@@ -29,19 +29,18 @@
 namespace pat {
 
   class TauJetCorrFactors {
-
   public:
-    // tau-jet energy correction factor. 
+    // tau-jet energy correction factor.
     // the std::string indicates the correction level according to jetMET definitions.
     typedef std::pair<std::string, float> CorrectionFactor;
 
   public:
     // default Constructor
-    TauJetCorrFactors() {};
+    TauJetCorrFactors(){};
     // constructor by value
     TauJetCorrFactors(const std::string& label, const std::vector<CorrectionFactor>& jec);
 
-    // instance label of the jet energy corrections set 
+    // instance label of the jet energy corrections set
     std::string jecSet() const { return label_; }
     // correction level from unsigned int
     std::string jecLevel(const unsigned int& level) const { return jec_.at(level).first; };
@@ -55,7 +54,9 @@ namespace pat {
     // a vector of the labels of all correction levels according to jetMET definitions
     std::vector<std::string> correctionLabels() const;
     // label of a specific correction factor according to jetMET definitions; for overflow a string ERROR is returned
-    std::string correctionLabel(unsigned int level) const { return (level<jec_.size() ? jec_.at(level).first : std::string("ERROR")); };
+    std::string correctionLabel(unsigned int level) const {
+      return (level < jec_.size() ? jec_.at(level).first : std::string("ERROR"));
+    };
     // number of available correction factors
     unsigned int numberOfCorrectionLevels() const { return jec_.size(); };
     // print function for debugging
@@ -64,11 +65,11 @@ namespace pat {
   private:
     // instance label of jet energy correction factors
     std::string label_;
-    // vector of CorrectionFactors. NOTE: the correction factors are expected to appear 
-    // nested; they may appear in arbitary number and order according to the configuration 
-    // of the jetCorrFactors module. 
+    // vector of CorrectionFactors. NOTE: the correction factors are expected to appear
+    // nested; they may appear in arbitary number and order according to the configuration
+    // of the jetCorrFactors module.
     std::vector<CorrectionFactor> jec_;
   };
-}
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TauPFEssential.h
+++ b/DataFormats/PatCandidates/interface/TauPFEssential.h
@@ -16,52 +16,54 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-namespace pat { namespace tau {
+namespace pat {
+  namespace tau {
 
-struct TauPFEssential {
-  // define a float-precision version of the typedefs in reco::PFTauTransverseImpactParameter class
-  typedef math::PtEtaPhiMLorentzVectorF LorentzVector;
-  typedef math::XYZPointF Point;
-  typedef math::XYZVectorF Vector;
-  typedef math::ErrorF<3>::type CovMatrix;
+    struct TauPFEssential {
+      // define a float-precision version of the typedefs in reco::PFTauTransverseImpactParameter class
+      typedef math::PtEtaPhiMLorentzVectorF LorentzVector;
+      typedef math::XYZPointF Point;
+      typedef math::XYZVectorF Vector;
+      typedef math::ErrorF<3>::type CovMatrix;
 
-// dummy constructor for ROOT I/O
-  TauPFEssential() {}
-// constructor from PFTau
-  TauPFEssential(const reco::PFTau& tau);
-// datamembers 
-  LorentzVector p4Jet_;
-  LorentzVector p4CorrJet_;
-  
-  int decayMode_;
-  
-  Point dxy_PCA_;
-  float dxy_;
-  float dxy_error_;
-  float dxy_Sig_;
-  reco::VertexRef pv_;
-  Point pvPos_;
-  CovMatrix pvCov_;
-  bool hasSV_;
-  Vector flightLength_;
-  float flightLengthSig_;
-  reco::VertexRef sv_;
-  Point svPos_;
-  CovMatrix svCov_;
-  float ip3d_;
-  float ip3d_error_;
-  float ecalEnergy_;
-  float hcalEnergy_;
-  float leadingTrackNormChi2_;
-  float phiAtEcalEntrance_;
-  float etaAtEcalEntrance_;
-  float ecalEnergyLeadChargedHadrCand_;
-  float hcalEnergyLeadChargedHadrCand_;
-  float etaAtEcalEntranceLeadChargedCand_;
-  float ptLeadChargedCand_;
-  float emFraction_;
-};
+      // dummy constructor for ROOT I/O
+      TauPFEssential() {}
+      // constructor from PFTau
+      TauPFEssential(const reco::PFTau& tau);
+      // datamembers
+      LorentzVector p4Jet_;
+      LorentzVector p4CorrJet_;
 
-} }
+      int decayMode_;
+
+      Point dxy_PCA_;
+      float dxy_;
+      float dxy_error_;
+      float dxy_Sig_;
+      reco::VertexRef pv_;
+      Point pvPos_;
+      CovMatrix pvCov_;
+      bool hasSV_;
+      Vector flightLength_;
+      float flightLengthSig_;
+      reco::VertexRef sv_;
+      Point svPos_;
+      CovMatrix svCov_;
+      float ip3d_;
+      float ip3d_error_;
+      float ecalEnergy_;
+      float hcalEnergy_;
+      float leadingTrackNormChi2_;
+      float phiAtEcalEntrance_;
+      float etaAtEcalEntrance_;
+      float ecalEnergyLeadChargedHadrCand_;
+      float hcalEnergyLeadChargedHadrCand_;
+      float etaAtEcalEntranceLeadChargedCand_;
+      float ptLeadChargedCand_;
+      float emFraction_;
+    };
+
+  }  // namespace tau
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TauPFSpecific.h
+++ b/DataFormats/PatCandidates/interface/TauPFSpecific.h
@@ -16,57 +16,59 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-namespace pat { namespace tau {
+namespace pat {
+  namespace tau {
 
-struct TauPFSpecific {
-// dummy constructor for ROOT I/O
-  TauPFSpecific() {}
-// constructor from PFTau
-  TauPFSpecific(const reco::PFTau& tau);
-// datamembers 
-  reco::JetBaseRef pfJetRef_;
-  reco::CandidatePtr leadPFChargedHadrCand_;
-  float leadPFChargedHadrCandsignedSipt_;
-  reco::PFCandidatePtr leadPFNeutralCand_;
-  reco::PFCandidatePtr leadPFCand_;
-  std::vector<reco::PFCandidatePtr> selectedSignalPFCands_;
-  std::vector<reco::PFCandidatePtr> selectedSignalPFChargedHadrCands_;
-  std::vector<reco::PFCandidatePtr> selectedSignalPFNeutrHadrCands_;
-  std::vector<reco::PFCandidatePtr> selectedSignalPFGammaCands_;
-  std::vector<reco::PFRecoTauChargedHadron> signalTauChargedHadronCandidates_;
-  std::vector<reco::RecoTauPiZero> signalPiZeroCandidates_;
-  std::vector<reco::PFCandidatePtr> selectedIsolationPFCands_;
-  std::vector<reco::PFCandidatePtr> selectedIsolationPFChargedHadrCands_;
-  std::vector<reco::PFCandidatePtr> selectedIsolationPFNeutrHadrCands_;
-  std::vector<reco::PFCandidatePtr> selectedIsolationPFGammaCands_;
-  std::vector<reco::PFRecoTauChargedHadron> isolationTauChargedHadronCandidates_;
-  std::vector<reco::RecoTauPiZero> isolationPiZeroCandidates_;
-  float isolationPFChargedHadrCandsPtSum_;
-  float isolationPFGammaCandsEtSum_;
-  float maximumHCALPFClusterEt_;
-  
-  float emFraction_;
-  float hcalTotOverPLead_;
-  float hcalMaxOverPLead_;
-  float hcal3x3OverPLead_;
-  float ecalStripSumEOverPLead_;
-  float bremsRecoveryEOverPLead_;
-  reco::TrackRef electronPreIDTrack_;
-  float electronPreIDOutput_;
-  bool electronPreIDDecision_;
+    struct TauPFSpecific {
+      // dummy constructor for ROOT I/O
+      TauPFSpecific() {}
+      // constructor from PFTau
+      TauPFSpecific(const reco::PFTau& tau);
+      // datamembers
+      reco::JetBaseRef pfJetRef_;
+      reco::CandidatePtr leadPFChargedHadrCand_;
+      float leadPFChargedHadrCandsignedSipt_;
+      reco::PFCandidatePtr leadPFNeutralCand_;
+      reco::PFCandidatePtr leadPFCand_;
+      std::vector<reco::PFCandidatePtr> selectedSignalPFCands_;
+      std::vector<reco::PFCandidatePtr> selectedSignalPFChargedHadrCands_;
+      std::vector<reco::PFCandidatePtr> selectedSignalPFNeutrHadrCands_;
+      std::vector<reco::PFCandidatePtr> selectedSignalPFGammaCands_;
+      std::vector<reco::PFRecoTauChargedHadron> signalTauChargedHadronCandidates_;
+      std::vector<reco::RecoTauPiZero> signalPiZeroCandidates_;
+      std::vector<reco::PFCandidatePtr> selectedIsolationPFCands_;
+      std::vector<reco::PFCandidatePtr> selectedIsolationPFChargedHadrCands_;
+      std::vector<reco::PFCandidatePtr> selectedIsolationPFNeutrHadrCands_;
+      std::vector<reco::PFCandidatePtr> selectedIsolationPFGammaCands_;
+      std::vector<reco::PFRecoTauChargedHadron> isolationTauChargedHadronCandidates_;
+      std::vector<reco::RecoTauPiZero> isolationPiZeroCandidates_;
+      float isolationPFChargedHadrCandsPtSum_;
+      float isolationPFGammaCandsEtSum_;
+      float maximumHCALPFClusterEt_;
 
-  float caloComp_;
-  float segComp_;
-  bool muonDecision_;
-  
-  float etaetaMoment_;
-  float phiphiMoment_;
-  float etaphiMoment_;
-  
-  float bendCorrMass_;
-  float signalConeSize_;
-};
+      float emFraction_;
+      float hcalTotOverPLead_;
+      float hcalMaxOverPLead_;
+      float hcal3x3OverPLead_;
+      float ecalStripSumEOverPLead_;
+      float bremsRecoveryEOverPLead_;
+      reco::TrackRef electronPreIDTrack_;
+      float electronPreIDOutput_;
+      bool electronPreIDDecision_;
 
-} }
+      float caloComp_;
+      float segComp_;
+      bool muonDecision_;
+
+      float etaetaMoment_;
+      float phiphiMoment_;
+      float etaphiMoment_;
+
+      float bendCorrMass_;
+      float signalConeSize_;
+    };
+
+  }  // namespace tau
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TriggerAlgorithm.h
+++ b/DataFormats/PatCandidates/interface/TriggerAlgorithm.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_PatCandidates_TriggerAlgorithm_h
 #define DataFormats_PatCandidates_TriggerAlgorithm_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatCandidates
@@ -19,7 +18,6 @@
   \author   Volker Adler
 */
 
-
 #include <string>
 #include <vector>
 
@@ -28,119 +26,131 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefVectorIterator.h"
 
-
 namespace pat {
 
   class TriggerAlgorithm {
+    /// Data Members
 
-      /// Data Members
+    /// L1 algorithm name
+    std::string name_;
+    /// L1 algorithm alias
+    std::string alias_;
+    /// L1 algorithm logival expression
+    std::string logic_;
+    /// Flag for technical L1 algorithms
+    bool tech_;
+    /// L1 algorithm bit number
+    unsigned bit_;
+    /// L1 algorithm result as determined on the GTL board
+    bool gtlResult_;
+    /// L1 algorithm pre-scale
+    unsigned prescale_;
+    /// L1 algorithm mask
+    bool mask_;
+    /// L1 algorithm decision, not considering the mask
+    bool decisionBeforeMask_;
+    /// L1 algorithm decision, considering the mask
+    bool decisionAfterMask_;
+    /// Indeces of trigger conditions in pat::TriggerConditionCollection in event
+    /// as produced together with the pat::TriggerAlgorithmCollection
+    std::vector<unsigned> conditionKeys_;
 
-      /// L1 algorithm name
-      std::string name_;
-      /// L1 algorithm alias
-      std::string alias_;
-      /// L1 algorithm logival expression
-      std::string logic_;
-      /// Flag for technical L1 algorithms
-      bool tech_;
-      /// L1 algorithm bit number
-      unsigned bit_;
-      /// L1 algorithm result as determined on the GTL board
-      bool gtlResult_;
-      /// L1 algorithm pre-scale
-      unsigned prescale_;
-      /// L1 algorithm mask
-      bool mask_;
-      /// L1 algorithm decision, not considering the mask
-      bool decisionBeforeMask_;
-      /// L1 algorithm decision, considering the mask
-      bool decisionAfterMask_;
-      /// Indeces of trigger conditions in pat::TriggerConditionCollection in event
-      /// as produced together with the pat::TriggerAlgorithmCollection
-      std::vector< unsigned > conditionKeys_;
+  public:
+    /// Constructors and Destructor
 
-    public:
+    /// Default constructor
+    TriggerAlgorithm();
+    /// Constructor from algorithm name only
+    TriggerAlgorithm(const std::string& name);
+    /// Constructors from values
+    TriggerAlgorithm(const std::string& name,
+                     const std::string& alias,
+                     bool tech,
+                     unsigned bit,
+                     unsigned prescale,
+                     bool mask,
+                     bool decisionBeforeMask,
+                     bool decisionAfterMask);  // for backward compatibility
+    TriggerAlgorithm(const std::string& name,
+                     const std::string& alias,
+                     bool tech,
+                     unsigned bit,
+                     bool gtlResult,
+                     unsigned prescale,
+                     bool mask,
+                     bool decisionBeforeMask,
+                     bool decisionAfterMask);
 
-      /// Constructors and Destructor
+    /// Destructor
+    virtual ~TriggerAlgorithm(){};
 
-      /// Default constructor
-      TriggerAlgorithm();
-      /// Constructor from algorithm name only
-      TriggerAlgorithm( const std::string & name );
-      /// Constructors from values
-      TriggerAlgorithm( const std::string & name, const std::string & alias, bool tech, unsigned bit, unsigned prescale, bool mask, bool decisionBeforeMask, bool decisionAfterMask ); // for backward compatibility
-      TriggerAlgorithm( const std::string & name, const std::string & alias, bool tech, unsigned bit, bool gtlResult, unsigned prescale, bool mask, bool decisionBeforeMask, bool decisionAfterMask );
+    /// Methods
 
-      /// Destructor
-      virtual ~TriggerAlgorithm() {};
-
-      /// Methods
-
-      /// Set L1 algorithm name
-      void setName( const std::string & name ) { name_ = name; };
-      /// Set L1 algorithm alias
-      void setAlias( const std::string & alias ) { alias_ = alias; };
-      /// Set L1 algorithm logical expression
-      void setLogicalExpression( const std::string & expression ) { logic_ = expression; };
-      /// Set flag for technical L1 algorithms
-      void setTechTrigger( bool tech ) { tech_ = tech; };
-      /// Set L1 algorithm bit number
-      void setBit( unsigned bit ) { bit_ = bit; };
-      /// Set L1 algorithm GTL result
-      void setGtlResult( bool gtlResult ) { gtlResult_ = gtlResult; };
-      /// Set L1 algorithm pre-scale
-      void setPrescale( unsigned prescale )  { prescale_ = prescale; };
-      /// Set L1 algorithm mask
-      void setMask( bool mask ) { mask_ = mask; };
-      /// Set L1 algorithm decision, not considering the mask
-      void setDecisionBeforeMask( bool decisionBeforeMask ) { decisionBeforeMask_ = decisionBeforeMask; };
-      /// Set L1 algorithm decision, considering the mask
-      void setDecisionAfterMas( bool decisionAfterMask ) { decisionAfterMask_ = decisionAfterMask; };
-      /// Add a new trigger condition collection index
-      void addConditionKey( unsigned conditionKey ) { if ( ! hasConditionKey( conditionKey ) ) conditionKeys_.push_back( conditionKey ); };
-      /// Get L1 algorithm name
-      const std::string & name() const { return name_; };
-      /// Get L1 algorithm alias
-      const std::string & alias() const { return alias_; };
-      /// Get L1 algorithm logical expression
-      const std::string & logicalExpression() const { return logic_; };
-      /// Get flag for technical L1 algorithms
-      bool techTrigger() const { return tech_; };
-      /// Get L1 algorithm bit number
-      unsigned bit() const { return bit_; };
-      /// Get L1 algorithm GTL result
-      bool gtlResult() const { return gtlResult_; };
-      /// Get L1 algorithm pre-scale
-      unsigned prescale() const { return prescale_; };
-      /// Get L1 algorithm mask
-      bool mask() const { return mask_; };
-      /// Get L1 algorithm decision, not considering the mask
-      bool decisionBeforeMask() const { return decisionBeforeMask_; };
-      /// Get L1 algorithm decision, considering the mask
-      bool decisionAfterMask() const { return decisionAfterMask_; };
-      /// Get L1 algorithm decision as applied,
-      /// identical to L1 algorithm decision, considering the mask
-      bool decision() const { return decisionAfterMask(); };
-      /// Get all trigger condition collection indeces
-      const std::vector< unsigned > & conditionKeys() const { return conditionKeys_; };
-      /// Checks, if a certain trigger condition collection index is assigned
-      bool hasConditionKey( unsigned conditionKey ) const;
-
+    /// Set L1 algorithm name
+    void setName(const std::string& name) { name_ = name; };
+    /// Set L1 algorithm alias
+    void setAlias(const std::string& alias) { alias_ = alias; };
+    /// Set L1 algorithm logical expression
+    void setLogicalExpression(const std::string& expression) { logic_ = expression; };
+    /// Set flag for technical L1 algorithms
+    void setTechTrigger(bool tech) { tech_ = tech; };
+    /// Set L1 algorithm bit number
+    void setBit(unsigned bit) { bit_ = bit; };
+    /// Set L1 algorithm GTL result
+    void setGtlResult(bool gtlResult) { gtlResult_ = gtlResult; };
+    /// Set L1 algorithm pre-scale
+    void setPrescale(unsigned prescale) { prescale_ = prescale; };
+    /// Set L1 algorithm mask
+    void setMask(bool mask) { mask_ = mask; };
+    /// Set L1 algorithm decision, not considering the mask
+    void setDecisionBeforeMask(bool decisionBeforeMask) { decisionBeforeMask_ = decisionBeforeMask; };
+    /// Set L1 algorithm decision, considering the mask
+    void setDecisionAfterMas(bool decisionAfterMask) { decisionAfterMask_ = decisionAfterMask; };
+    /// Add a new trigger condition collection index
+    void addConditionKey(unsigned conditionKey) {
+      if (!hasConditionKey(conditionKey))
+        conditionKeys_.push_back(conditionKey);
+    };
+    /// Get L1 algorithm name
+    const std::string& name() const { return name_; };
+    /// Get L1 algorithm alias
+    const std::string& alias() const { return alias_; };
+    /// Get L1 algorithm logical expression
+    const std::string& logicalExpression() const { return logic_; };
+    /// Get flag for technical L1 algorithms
+    bool techTrigger() const { return tech_; };
+    /// Get L1 algorithm bit number
+    unsigned bit() const { return bit_; };
+    /// Get L1 algorithm GTL result
+    bool gtlResult() const { return gtlResult_; };
+    /// Get L1 algorithm pre-scale
+    unsigned prescale() const { return prescale_; };
+    /// Get L1 algorithm mask
+    bool mask() const { return mask_; };
+    /// Get L1 algorithm decision, not considering the mask
+    bool decisionBeforeMask() const { return decisionBeforeMask_; };
+    /// Get L1 algorithm decision, considering the mask
+    bool decisionAfterMask() const { return decisionAfterMask_; };
+    /// Get L1 algorithm decision as applied,
+    /// identical to L1 algorithm decision, considering the mask
+    bool decision() const { return decisionAfterMask(); };
+    /// Get all trigger condition collection indeces
+    const std::vector<unsigned>& conditionKeys() const { return conditionKeys_; };
+    /// Checks, if a certain trigger condition collection index is assigned
+    bool hasConditionKey(unsigned conditionKey) const;
   };
 
-
   /// Collection of TriggerAlgorithm
-  typedef std::vector< TriggerAlgorithm >                      TriggerAlgorithmCollection;
+  typedef std::vector<TriggerAlgorithm> TriggerAlgorithmCollection;
   /// Persistent reference to an item in a TriggerAlgorithmCollection
-  typedef edm::Ref< TriggerAlgorithmCollection >               TriggerAlgorithmRef;
+  typedef edm::Ref<TriggerAlgorithmCollection> TriggerAlgorithmRef;
   /// Persistent reference to a TriggerAlgorithmCollection product
-  typedef edm::RefProd< TriggerAlgorithmCollection >           TriggerAlgorithmRefProd;
+  typedef edm::RefProd<TriggerAlgorithmCollection> TriggerAlgorithmRefProd;
   /// Vector of persistent references to items in the same TriggerAlgorithmCollection
-  typedef edm::RefVector< TriggerAlgorithmCollection >         TriggerAlgorithmRefVector;
+  typedef edm::RefVector<TriggerAlgorithmCollection> TriggerAlgorithmRefVector;
   /// Const iterator over vector of persistent references to items in the same TriggerAlgorithmCollection
-  typedef edm::RefVectorIterator< TriggerAlgorithmCollection > TriggerAlgorithmRefVectorIterator;
+  typedef edm::RefVectorIterator<TriggerAlgorithmCollection> TriggerAlgorithmRefVectorIterator;
 
-}
-
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TriggerCondition.h
+++ b/DataFormats/PatCandidates/interface/TriggerCondition.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_PatCandidates_TriggerCondition_h
 #define DataFormats_PatCandidates_TriggerCondition_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatCandidates
@@ -19,7 +18,6 @@
   \author   Volker Adler
 */
 
-
 #include <string>
 #include <vector>
 
@@ -34,89 +32,93 @@
 namespace pat {
 
   class TriggerCondition {
+    /// Data Members
 
-      /// Data Members
+    /// Name of the condition
+    std::string name_;
+    /// Did condition succeed?
+    bool accept_;
+    /// L1 condition category as defined in CondFormats/L1TObjects/interface/L1GtFwd.h
+    L1GtConditionCategory category_;
+    /// L1 condition type as defined in CondFormats/L1TObjects/interface/L1GtFwd.h
+    L1GtConditionType type_;
+    /// Special identifiers for the used trigger object type as defined in
+    /// DataFormats/HLTReco/interface/TriggerTypeDefs.h
+    /// translated from L1GtObject type (DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h)
+    std::vector<trigger::TriggerObjectType> triggerObjectTypes_;
+    /// Indeces of trigger objects from succeeding combinations in pat::TriggerObjectCollection in event
+    /// as produced together with the pat::TriggerAlgorithmCollection
+    std::vector<unsigned> objectKeys_;
 
-      /// Name of the condition
-      std::string name_;
-      /// Did condition succeed?
-      bool accept_;
-      /// L1 condition category as defined in CondFormats/L1TObjects/interface/L1GtFwd.h
-      L1GtConditionCategory category_;
-      /// L1 condition type as defined in CondFormats/L1TObjects/interface/L1GtFwd.h
-      L1GtConditionType type_;
-      /// Special identifiers for the used trigger object type as defined in
-      /// DataFormats/HLTReco/interface/TriggerTypeDefs.h
-      /// translated from L1GtObject type (DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h)
-      std::vector< trigger::TriggerObjectType > triggerObjectTypes_;
-      /// Indeces of trigger objects from succeeding combinations in pat::TriggerObjectCollection in event
-      /// as produced together with the pat::TriggerAlgorithmCollection
-      std::vector< unsigned > objectKeys_;
+  public:
+    /// Constructors and Desctructor
 
-    public:
+    /// Default constructor
+    TriggerCondition();
+    /// Constructor from condition name "only"
+    TriggerCondition(const std::string& name);
+    /// Constructor from values
+    TriggerCondition(const std::string& name, bool accept);
 
-      /// Constructors and Desctructor
+    /// Destructor
+    virtual ~TriggerCondition(){};
 
-      /// Default constructor
-      TriggerCondition();
-      /// Constructor from condition name "only"
-      TriggerCondition( const std::string & name );
-      /// Constructor from values
-      TriggerCondition( const std::string & name, bool accept );
+    /// Methods
 
-      /// Destructor
-      virtual ~TriggerCondition() {};
-
-      /// Methods
-
-      /// Set the condition name
-      void setName( const std::string & name ) { name_ = name; };
-      /// Set the success flag
-      void setAccept( bool accept ) { accept_ = accept; };
-      /// Set the condition category
-      void setCategory( L1GtConditionCategory category ) { category_ = category; };
-      void setCategory( int category )                   { category_ = L1GtConditionCategory( category ); };
-      /// Set the condition type
-      void setType( L1GtConditionType type ) { type_ = type; };
-      void setType( int type )               { type_ = L1GtConditionType( type ); };
-      /// Add a new trigger object type
-      void addTriggerObjectType( trigger::TriggerObjectType triggerObjectType ) { triggerObjectTypes_.push_back( triggerObjectType ); }; // explicitely NOT checking for existence
-      void addTriggerObjectType( int triggerObjectType )                        { addTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); };
-      /// Add a new trigger object collection index
-      void addObjectKey( unsigned objectKey ) { if ( ! hasObjectKey( objectKey ) ) objectKeys_.push_back( objectKey ); };
-      /// Get the filter label
-      const std::string & name() const { return name_; };
-      /// Get the success flag
-      bool wasAccept() const { return accept_; };
-      /// Get the condition category
-      int category() const { return int( category_ ); };
-      /// Get the condition type
-      int type() const { return int( type_ ); };
-      /// Get the trigger object types
-      std::vector< int > triggerObjectTypes() const;
-      /// Checks, if a certain trigger object type is assigned
-      bool hasTriggerObjectType( trigger::TriggerObjectType triggerObjectType ) const;
-      bool hasTriggerObjectType( int triggerObjectType ) const { return hasTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); };
-      /// Get all trigger object collection indeces
-      const std::vector< unsigned > & objectKeys() const { return objectKeys_; };
-      /// Checks, if a certain trigger object collection index is assigned
-      bool hasObjectKey( unsigned objectKey ) const;
-
+    /// Set the condition name
+    void setName(const std::string& name) { name_ = name; };
+    /// Set the success flag
+    void setAccept(bool accept) { accept_ = accept; };
+    /// Set the condition category
+    void setCategory(L1GtConditionCategory category) { category_ = category; };
+    void setCategory(int category) { category_ = L1GtConditionCategory(category); };
+    /// Set the condition type
+    void setType(L1GtConditionType type) { type_ = type; };
+    void setType(int type) { type_ = L1GtConditionType(type); };
+    /// Add a new trigger object type
+    void addTriggerObjectType(trigger::TriggerObjectType triggerObjectType) {
+      triggerObjectTypes_.push_back(triggerObjectType);
+    };  // explicitely NOT checking for existence
+    void addTriggerObjectType(int triggerObjectType) {
+      addTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };
+    /// Add a new trigger object collection index
+    void addObjectKey(unsigned objectKey) {
+      if (!hasObjectKey(objectKey))
+        objectKeys_.push_back(objectKey);
+    };
+    /// Get the filter label
+    const std::string& name() const { return name_; };
+    /// Get the success flag
+    bool wasAccept() const { return accept_; };
+    /// Get the condition category
+    int category() const { return int(category_); };
+    /// Get the condition type
+    int type() const { return int(type_); };
+    /// Get the trigger object types
+    std::vector<int> triggerObjectTypes() const;
+    /// Checks, if a certain trigger object type is assigned
+    bool hasTriggerObjectType(trigger::TriggerObjectType triggerObjectType) const;
+    bool hasTriggerObjectType(int triggerObjectType) const {
+      return hasTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };
+    /// Get all trigger object collection indeces
+    const std::vector<unsigned>& objectKeys() const { return objectKeys_; };
+    /// Checks, if a certain trigger object collection index is assigned
+    bool hasObjectKey(unsigned objectKey) const;
   };
 
-
   /// Collection of TriggerCondition
-  typedef std::vector< TriggerCondition >                      TriggerConditionCollection;
+  typedef std::vector<TriggerCondition> TriggerConditionCollection;
   /// Persistent reference to an item in a TriggerConditionCollection
-  typedef edm::Ref< TriggerConditionCollection >               TriggerConditionRef;
+  typedef edm::Ref<TriggerConditionCollection> TriggerConditionRef;
   /// Persistent reference to a TriggerConditionCollection product
-  typedef edm::RefProd< TriggerConditionCollection >           TriggerConditionRefProd;
+  typedef edm::RefProd<TriggerConditionCollection> TriggerConditionRefProd;
   /// Vector of persistent references to items in the same TriggerConditionCollection
-  typedef edm::RefVector< TriggerConditionCollection >         TriggerConditionRefVector;
+  typedef edm::RefVector<TriggerConditionCollection> TriggerConditionRefVector;
   /// Const iterator over vector of persistent references to items in the same TriggerConditionCollection
-  typedef edm::RefVectorIterator< TriggerConditionCollection > TriggerConditionRefVectorIterator;
+  typedef edm::RefVectorIterator<TriggerConditionCollection> TriggerConditionRefVectorIterator;
 
-}
-
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TriggerEvent.h
+++ b/DataFormats/PatCandidates/interface/TriggerEvent.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_PatCandidates_TriggerEvent_h
 #define DataFormats_PatCandidates_TriggerEvent_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatCandidates
@@ -20,7 +19,6 @@
   \author   Volker Adler
 */
 
-
 #include "DataFormats/PatCandidates/interface/TriggerAlgorithm.h"
 #include "DataFormats/PatCandidates/interface/TriggerCondition.h"
 #include "DataFormats/PatCandidates/interface/TriggerPath.h"
@@ -36,324 +34,342 @@
 #include "DataFormats/Common/interface/OrphanHandle.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-
 namespace pat {
 
   class TriggerEvent {
+    /// Data Members
 
-      /// Data Members
+    /// Name of the L1 trigger menu
+    std::string nameL1Menu_;
+    /// Name of the HLT trigger table
+    std::string nameHltTable_;
+    /// Was HLT run?
+    bool run_;
+    /// Did HLT succeed?
+    bool accept_;
+    /// Was HLT in error?
+    bool error_;
+    /// PhysicsDeclared GT bit
+    bool physDecl_;
+    /// LHC fill number
+    boost::uint32_t lhcFill_;
+    /// LHC beam mode
+    /// as defined in http://bdidev1.cern.ch/bdisoft/operational/abbdisw_wiki/LHC/BST-config --> Beam mode.
+    boost::uint16_t beamMode_;
+    /// LHC beam momentum in GeV
+    boost::uint16_t beamMomentum_;
+    /// LHC beam 1 intensity in ???
+    boost::uint32_t intensityBeam1_;
+    /// LHC beam 2 intensity in ???
+    boost::uint32_t intensityBeam2_;
+    /// LHC master status
+    /// as defined in http://bdidev1.cern.ch/bdisoft/operational/abbdisw_wiki/LHC/BST-config
+    boost::uint16_t bstMasterStatus_;
+    /// LHC beam turn counter
+    boost::uint32_t turnCount_;
+    /// CMS magnet current in ??? at start of run
+    float bCurrentStart_;
+    /// CMS magnet current in ??? at end of run
+    float bCurrentStop_;
+    /// CMS magnet current in ??? averaged over run
+    float bCurrentAvg_;
 
-      /// Name of the L1 trigger menu
-      std::string nameL1Menu_;
-      /// Name of the HLT trigger table
-      std::string nameHltTable_;
-      /// Was HLT run?
-      bool run_;
-      /// Did HLT succeed?
-      bool accept_;
-      /// Was HLT in error?
-      bool error_;
-      /// PhysicsDeclared GT bit
-      bool physDecl_;
-      /// LHC fill number
-      boost::uint32_t lhcFill_;
-      /// LHC beam mode
-      /// as defined in http://bdidev1.cern.ch/bdisoft/operational/abbdisw_wiki/LHC/BST-config --> Beam mode.
-      boost::uint16_t beamMode_;
-      /// LHC beam momentum in GeV
-      boost::uint16_t beamMomentum_;
-      /// LHC beam 1 intensity in ???
-      boost::uint32_t intensityBeam1_;
-      /// LHC beam 2 intensity in ???
-      boost::uint32_t intensityBeam2_;
-      /// LHC master status
-      /// as defined in http://bdidev1.cern.ch/bdisoft/operational/abbdisw_wiki/LHC/BST-config
-      boost::uint16_t bstMasterStatus_;
-      /// LHC beam turn counter
-      boost::uint32_t turnCount_;
-      /// CMS magnet current in ??? at start of run
-      float bCurrentStart_;
-      /// CMS magnet current in ??? at end of run
-      float bCurrentStop_;
-      /// CMS magnet current in ??? averaged over run
-      float bCurrentAvg_;
+    /// Member collection related data members
+    /// Reference to pat::TriggerAlgorithmCollection in event
+    TriggerAlgorithmRefProd algorithms_;
+    /// Reference to pat::TriggerConditionCollection in event
+    TriggerConditionRefProd conditions_;
+    /// Reference to pat::TriggerPathCollection in event
+    TriggerPathRefProd paths_;
+    /// Reference to pat::TriggerAlgorithmCollection in event
+    TriggerFilterRefProd filters_;
+    /// Reference to pat::TriggerObjectCollection in event
+    TriggerObjectRefProd objects_;
+    /// Table of references to pat::TriggerObjectMatch associations in event
+    TriggerObjectMatchContainer objectMatchResults_;
 
-      /// Member collection related data members
-      /// Reference to pat::TriggerAlgorithmCollection in event
-      TriggerAlgorithmRefProd algorithms_;
-      /// Reference to pat::TriggerConditionCollection in event
-      TriggerConditionRefProd conditions_;
-      /// Reference to pat::TriggerPathCollection in event
-      TriggerPathRefProd paths_;
-      /// Reference to pat::TriggerAlgorithmCollection in event
-      TriggerFilterRefProd filters_;
-      /// Reference to pat::TriggerObjectCollection in event
-      TriggerObjectRefProd objects_;
-      /// Table of references to pat::TriggerObjectMatch associations in event
-      TriggerObjectMatchContainer objectMatchResults_;
+  public:
+    /// Constructors and Desctructor
 
-    public:
+    /// Default constructor
+    TriggerEvent();
+    /// Constructor from values, HLT only
+    TriggerEvent(
+        const std::string& nameHltTable, bool run = true, bool accept = true, bool error = false, bool physDecl = true);
+    /// Constructor from values, HLT and L1/GT
+    TriggerEvent(const std::string& nameL1Menu,
+                 const std::string& nameHltTable,
+                 bool run = true,
+                 bool accept = true,
+                 bool error = false,
+                 bool physDecl = true);
 
-      /// Constructors and Desctructor
+    /// Destructor
+    virtual ~TriggerEvent(){};
 
-      /// Default constructor
-      TriggerEvent();
-      /// Constructor from values, HLT only
-      TriggerEvent( const std::string & nameHltTable, bool run = true, bool accept = true, bool error = false, bool physDecl = true );
-      /// Constructor from values, HLT and L1/GT
-      TriggerEvent( const std::string & nameL1Menu, const std::string & nameHltTable, bool run = true, bool accept = true, bool error = false, bool physDecl = true );
+    /// Methods
 
-      /// Destructor
-      virtual ~TriggerEvent() {};
+    /// Trigger event
+    /// Set the name of the L1 trigger menu
+    void setNameL1Menu(const std::string& name) { nameL1Menu_ = name; };
+    /// Set the name of the HLT trigger table
+    void setNameHltTable(const std::string& name) { nameHltTable_ = name; };
+    /// Set the run flag
+    void setRun(bool run) { run_ = run; };
+    /// Set the success flag
+    void setAccept(bool accept) { accept_ = accept; };
+    /// Set the error flag
+    void setError(bool error) { error_ = error; };
+    /// Set the PhysicsDeclared GT bit
+    void setPhysDecl(bool physDecl) { physDecl_ = physDecl; };
+    /// Set the LHC fill number
+    void setLhcFill(boost::uint32_t lhcFill) { lhcFill_ = lhcFill; };
+    /// Set the LHC beam mode
+    void setBeamMode(boost::uint16_t beamMode) { beamMode_ = beamMode; };
+    /// Set the LHC beam momentum
+    void setBeamMomentum(boost::uint16_t beamMomentum) { beamMomentum_ = beamMomentum; };
+    /// Set the LHC beam 1 intensity
+    void setIntensityBeam1(boost::uint32_t intensityBeam1) { intensityBeam1_ = intensityBeam1; };
+    /// Set the LHC beam 2 intensity
+    void setIntensityBeam2(boost::uint32_t intensityBeam2) { intensityBeam2_ = intensityBeam2; };
+    /// Set the LHC master status
+    void setBstMasterStatus(boost::uint16_t bstMasterStatus) { bstMasterStatus_ = bstMasterStatus; };
+    /// Set the LHC beam turn counter
+    void setTurnCount(boost::uint32_t turnCount) { turnCount_ = turnCount; };
+    /// Set the CMS magnet current at start of run
+    void setBCurrentStart(float bCurrentStart) { bCurrentStart_ = bCurrentStart; };
+    /// Set the CMS magnet current at end of run
+    void setBCurrentStop(float bCurrentStop) { bCurrentStop_ = bCurrentStop; };
+    /// Set the CMS magnet current averaged over run
+    void setBCurrentAvg(float bCurrentAvg) { bCurrentAvg_ = bCurrentAvg; };
+    /// Get the name of the L1 trigger menu
+    const std::string& nameL1Menu() const { return nameL1Menu_; };
+    /// Get the name of the HLT trigger table
+    const std::string& nameHltTable() const { return nameHltTable_; };
+    /// Get the run flag
+    bool wasRun() const { return run_; };
+    /// Get the success flag
+    bool wasAccept() const { return accept_; };
+    /// Get the error flag
+    bool wasError() const { return error_; };
+    /// Get the PhysicsDeclared GT bit
+    bool wasPhysDecl() const { return physDecl_; };
+    /// Get the LHC fill number
+    boost::uint32_t lhcFill() const { return lhcFill_; };
+    /// Get the LHC beam mode
+    boost::uint16_t beamMode() const { return beamMode_; };
+    /// Get the LHC beam momentum
+    boost::uint16_t beamMomentum() const { return beamMomentum_; };
+    /// Get the LHC beam 1 intensity
+    boost::uint32_t intensityBeam1() const { return intensityBeam1_; };
+    /// Get the LHC beam 2 intensity
+    boost::uint32_t intensityBeam2() const { return intensityBeam2_; };
+    /// Get the LHC master status
+    boost::uint16_t bstMasterStatus() const { return bstMasterStatus_; };
+    /// Get the LHC beam turn counter
+    boost::uint32_t turnCount() const { return turnCount_; };
+    /// Get the CMS magnet current at start of run
+    float bCurrentStart() const { return bCurrentStart_; };
+    /// Get the CMS magnet current at end of run
+    float bCurrentStop() const { return bCurrentStop_; };
+    /// Get the CMS magnet current averaged over run
+    float bCurrentAvg() const { return bCurrentAvg_; };
 
-      /// Methods
+    /// L1 algorithms
+    /// Set the reference to the pat::TriggerAlgorithmCollection in the event
+    void setAlgorithms(const edm::Handle<TriggerAlgorithmCollection>& handleTriggerAlgorithms) {
+      algorithms_ = TriggerAlgorithmRefProd(handleTriggerAlgorithms);
+    };
+    /// Get a pointer to all L1 algorithms,
+    /// returns 0, if RefProd is NULL
+    const TriggerAlgorithmCollection* algorithms() const { return algorithms_.get(); };
+    /// Get a vector of references to all L1 algorithms,
+    /// empty, if RefProd is NULL
+    const TriggerAlgorithmRefVector algorithmRefs() const;
+    /// Get a pointer to a certain L1 algorithm by name,
+    /// returns 0, if algorithm is not found
+    const TriggerAlgorithm* algorithm(const std::string& nameAlgorithm) const;
+    /// Get a reference to a certain L1 algorithm by name,
+    /// NULL, if algorithm is not found
+    const TriggerAlgorithmRef algorithmRef(const std::string& nameAlgorithm) const;
+    /// Get the name of a certain L1 algorithm in the event collection by bit number physics or technical (default) algorithms,
+    /// returns empty string, if algorithm is not found
+    std::string nameAlgorithm(const unsigned bitAlgorithm, const bool techAlgorithm = true) const;
+    /// Get the index of a certain L1 algorithm in the event collection by name,
+    /// returns size of algorithm collection, if algorithm is not found
+    unsigned indexAlgorithm(const std::string& nameAlgorithm) const;
+    /// Get a vector of references to all succeeding L1 algorithms
+    TriggerAlgorithmRefVector acceptedAlgorithms() const;
+    /// Get a vector of references to all L1 algorithms succeeding on the GTL board
+    TriggerAlgorithmRefVector acceptedAlgorithmsGtl() const;
+    /// Get a vector of references to all technical L1 algorithms
+    TriggerAlgorithmRefVector techAlgorithms() const;
+    /// Get a vector of references to all succeeding technical L1 algorithms
+    TriggerAlgorithmRefVector acceptedTechAlgorithms() const;
+    /// Get a vector of references to all technical L1 algorithms succeeding on the GTL board
+    TriggerAlgorithmRefVector acceptedTechAlgorithmsGtl() const;
+    /// Get a vector of references to all physics L1 algorithms
+    TriggerAlgorithmRefVector physAlgorithms() const;
+    /// Get a vector of references to all succeeding physics L1 algorithms
+    TriggerAlgorithmRefVector acceptedPhysAlgorithms() const;
+    /// Get a vector of references to all physics L1 algorithms succeeding on the GTL board
+    TriggerAlgorithmRefVector acceptedPhysAlgorithmsGtl() const;
 
-      /// Trigger event
-      /// Set the name of the L1 trigger menu
-      void setNameL1Menu( const std::string & name ) { nameL1Menu_  = name; };
-      /// Set the name of the HLT trigger table
-      void setNameHltTable( const std::string & name ) { nameHltTable_ = name; };
-      /// Set the run flag
-      void setRun( bool run ) { run_ = run; };
-      /// Set the success flag
-      void setAccept( bool accept ) { accept_ = accept; };
-      /// Set the error flag
-      void setError( bool error ) { error_ = error; };
-      /// Set the PhysicsDeclared GT bit
-      void setPhysDecl( bool physDecl ) { physDecl_ = physDecl; };
-      /// Set the LHC fill number
-      void setLhcFill( boost::uint32_t lhcFill )  { lhcFill_  = lhcFill; };
-      /// Set the LHC beam mode
-      void setBeamMode( boost::uint16_t beamMode ) { beamMode_  = beamMode; };
-      /// Set the LHC beam momentum
-      void setBeamMomentum( boost::uint16_t beamMomentum ) { beamMomentum_ = beamMomentum; };
-      /// Set the LHC beam 1 intensity
-      void setIntensityBeam1( boost::uint32_t intensityBeam1 ) { intensityBeam1_ = intensityBeam1; };
-      /// Set the LHC beam 2 intensity
-      void setIntensityBeam2( boost::uint32_t intensityBeam2 ) { intensityBeam2_ = intensityBeam2; };
-      /// Set the LHC master status
-      void setBstMasterStatus( boost::uint16_t bstMasterStatus ) { bstMasterStatus_ = bstMasterStatus; };
-      /// Set the LHC beam turn counter
-      void setTurnCount( boost::uint32_t turnCount ) { turnCount_ = turnCount; };
-      /// Set the CMS magnet current at start of run
-      void setBCurrentStart( float bCurrentStart )  { bCurrentStart_ = bCurrentStart; };
-      /// Set the CMS magnet current at end of run
-      void setBCurrentStop( float bCurrentStop ) { bCurrentStop_ = bCurrentStop; };
-      /// Set the CMS magnet current averaged over run
-      void setBCurrentAvg( float bCurrentAvg ) { bCurrentAvg_  = bCurrentAvg; };
-      /// Get the name of the L1 trigger menu
-      const std::string & nameL1Menu() const { return nameL1Menu_; };
-      /// Get the name of the HLT trigger table
-      const std::string & nameHltTable() const { return nameHltTable_; };
-      /// Get the run flag
-      bool wasRun() const { return run_; };
-      /// Get the success flag
-      bool wasAccept() const { return accept_; };
-      /// Get the error flag
-      bool wasError() const { return error_; };
-      /// Get the PhysicsDeclared GT bit
-      bool wasPhysDecl() const { return physDecl_; };
-      /// Get the LHC fill number
-      boost::uint32_t lhcFill() const { return lhcFill_; };
-      /// Get the LHC beam mode
-      boost::uint16_t beamMode() const { return beamMode_; };
-      /// Get the LHC beam momentum
-      boost::uint16_t beamMomentum() const { return beamMomentum_; };
-      /// Get the LHC beam 1 intensity
-      boost::uint32_t intensityBeam1() const { return intensityBeam1_; };
-      /// Get the LHC beam 2 intensity
-      boost::uint32_t intensityBeam2() const { return intensityBeam2_; };
-      /// Get the LHC master status
-      boost::uint16_t bstMasterStatus() const { return bstMasterStatus_; };
-      /// Get the LHC beam turn counter
-      boost::uint32_t turnCount() const { return turnCount_; };
-      /// Get the CMS magnet current at start of run
-      float bCurrentStart() const { return bCurrentStart_; };
-      /// Get the CMS magnet current at end of run
-      float bCurrentStop() const { return bCurrentStop_; };
-      /// Get the CMS magnet current averaged over run
-      float bCurrentAvg() const { return bCurrentAvg_; };
+    /// L1 conditions
+    /// Set the reference to the pat::TriggerConditionCollection in the event
+    void setConditions(const edm::Handle<TriggerConditionCollection>& handleTriggerConditions) {
+      conditions_ = TriggerConditionRefProd(handleTriggerConditions);
+    };
+    /// Get a pointer to all L1 condition,
+    /// returns 0, if RefProd is NULL
+    const TriggerConditionCollection* conditions() const { return conditions_.get(); };
+    /// Get a vector of references to all L1 conditions,
+    /// empty, if RefProd is NULL
+    const TriggerConditionRefVector conditionRefs() const;
+    /// Get a pointer to a certain L1 condition by name,
+    /// returns 0, if condition is not found
+    const TriggerCondition* condition(const std::string& nameCondition) const;
+    /// Get a reference to a certain L1 condition by name,
+    /// NULL, if condition is not found
+    const TriggerConditionRef conditionRef(const std::string& nameCondition) const;
+    /// Get the index of a certain L1 condition in the event collection by name,
+    /// returns size of condition collection, if condition is not found
+    unsigned indexCondition(const std::string& nameCondition) const;
+    /// Get a vector of references to all succeeding L1 condition
+    TriggerConditionRefVector acceptedConditions() const;
 
-      /// L1 algorithms
-      /// Set the reference to the pat::TriggerAlgorithmCollection in the event
-      void setAlgorithms( const edm::Handle< TriggerAlgorithmCollection > & handleTriggerAlgorithms ) { algorithms_ = TriggerAlgorithmRefProd( handleTriggerAlgorithms ); };
-      /// Get a pointer to all L1 algorithms,
-      /// returns 0, if RefProd is NULL
-      const TriggerAlgorithmCollection * algorithms() const { return algorithms_.get(); };
-      /// Get a vector of references to all L1 algorithms,
-      /// empty, if RefProd is NULL
-      const TriggerAlgorithmRefVector algorithmRefs() const;
-      /// Get a pointer to a certain L1 algorithm by name,
-      /// returns 0, if algorithm is not found
-      const TriggerAlgorithm * algorithm( const std::string & nameAlgorithm ) const;
-      /// Get a reference to a certain L1 algorithm by name,
-      /// NULL, if algorithm is not found
-      const TriggerAlgorithmRef algorithmRef( const std::string & nameAlgorithm ) const;
-      /// Get the name of a certain L1 algorithm in the event collection by bit number physics or technical (default) algorithms,
-      /// returns empty string, if algorithm is not found
-      std::string nameAlgorithm( const unsigned bitAlgorithm, const bool techAlgorithm = true ) const;
-      /// Get the index of a certain L1 algorithm in the event collection by name,
-      /// returns size of algorithm collection, if algorithm is not found
-      unsigned indexAlgorithm( const std::string & nameAlgorithm ) const;
-      /// Get a vector of references to all succeeding L1 algorithms
-      TriggerAlgorithmRefVector acceptedAlgorithms() const;
-      /// Get a vector of references to all L1 algorithms succeeding on the GTL board
-      TriggerAlgorithmRefVector acceptedAlgorithmsGtl() const;
-      /// Get a vector of references to all technical L1 algorithms
-      TriggerAlgorithmRefVector techAlgorithms() const;
-      /// Get a vector of references to all succeeding technical L1 algorithms
-      TriggerAlgorithmRefVector acceptedTechAlgorithms() const;
-      /// Get a vector of references to all technical L1 algorithms succeeding on the GTL board
-      TriggerAlgorithmRefVector acceptedTechAlgorithmsGtl() const;
-      /// Get a vector of references to all physics L1 algorithms
-      TriggerAlgorithmRefVector physAlgorithms() const;
-      /// Get a vector of references to all succeeding physics L1 algorithms
-      TriggerAlgorithmRefVector acceptedPhysAlgorithms() const;
-      /// Get a vector of references to all physics L1 algorithms succeeding on the GTL board
-      TriggerAlgorithmRefVector acceptedPhysAlgorithmsGtl() const;
+    /// HLT paths
+    /// Set the reference to the pat::TriggerPathCollection in the event
+    void setPaths(const edm::Handle<TriggerPathCollection>& handleTriggerPaths) {
+      paths_ = TriggerPathRefProd(handleTriggerPaths);
+    };
+    /// Get a pointer to all HLT paths,
+    /// returns 0, if RefProd is NULL
+    const TriggerPathCollection* paths() const { return paths_.get(); };
+    /// Get a vector of references to all HLT paths,
+    /// empty, if RefProd is NULL
+    const TriggerPathRefVector pathRefs() const;
+    /// Get a pointer to a certain HLT path by name,
+    /// returns 0, if algorithm is not found
+    const TriggerPath* path(const std::string& namePath) const;
+    /// Get a reference to a certain HLT path by name,
+    /// NULL, if path is not found
+    const TriggerPathRef pathRef(const std::string& namePath) const;
+    /// Get the index of a certain HLT path in the event collection by name,
+    /// returns size of algorithm collection, if algorithm is not found
+    unsigned indexPath(const std::string& namePath) const;
+    /// Get a vector of references to all succeeding HLT paths
+    TriggerPathRefVector acceptedPaths() const;
 
-      /// L1 conditions
-      /// Set the reference to the pat::TriggerConditionCollection in the event
-      void setConditions( const edm::Handle< TriggerConditionCollection > & handleTriggerConditions ) { conditions_ = TriggerConditionRefProd( handleTriggerConditions ); };
-      /// Get a pointer to all L1 condition,
-      /// returns 0, if RefProd is NULL
-      const TriggerConditionCollection * conditions() const { return conditions_.get(); };
-      /// Get a vector of references to all L1 conditions,
-      /// empty, if RefProd is NULL
-      const TriggerConditionRefVector conditionRefs() const;
-      /// Get a pointer to a certain L1 condition by name,
-      /// returns 0, if condition is not found
-      const TriggerCondition * condition( const std::string & nameCondition ) const;
-      /// Get a reference to a certain L1 condition by name,
-      /// NULL, if condition is not found
-      const TriggerConditionRef conditionRef( const std::string & nameCondition ) const;
-      /// Get the index of a certain L1 condition in the event collection by name,
-      /// returns size of condition collection, if condition is not found
-      unsigned indexCondition( const std::string & nameCondition ) const;
-      /// Get a vector of references to all succeeding L1 condition
-      TriggerConditionRefVector acceptedConditions() const;
+    /// HLT filters
+    /// Set the reference to the pat::TriggerFilterCollection in the event
+    void setFilters(const edm::Handle<TriggerFilterCollection>& handleTriggerFilters) {
+      filters_ = TriggerFilterRefProd(handleTriggerFilters);
+    };
+    /// Get a pointer to all HLT filters,
+    /// returns 0, if RefProd is NULL
+    const TriggerFilterCollection* filters() const { return filters_.get(); };
+    /// Get a vector of references to all HLT filters,
+    /// empty, if RefProd is NULL
+    const TriggerFilterRefVector filterRefs() const;
+    /// Get a pointer to a certain HLT filter by label,
+    /// returns 0, if algorithm is not found
+    const TriggerFilter* filter(const std::string& labelFilter) const;
+    /// Get a reference to a certain HLT filter by label,
+    /// NULL, if filter is not found
+    const TriggerFilterRef filterRef(const std::string& labelFilter) const;
+    /// Get the index of a certain HLT filter in the event collection by label,
+    /// returns size of algorithm collection, if algorithm is not found
+    unsigned indexFilter(const std::string& labelFilter) const;
+    /// Get a vector of references to all succeeding HLT filters
+    TriggerFilterRefVector acceptedFilters() const;
 
-      /// HLT paths
-      /// Set the reference to the pat::TriggerPathCollection in the event
-      void setPaths( const edm::Handle< TriggerPathCollection > & handleTriggerPaths ) { paths_ = TriggerPathRefProd( handleTriggerPaths ); };
-      /// Get a pointer to all HLT paths,
-      /// returns 0, if RefProd is NULL
-      const TriggerPathCollection * paths() const { return paths_.get(); };
-      /// Get a vector of references to all HLT paths,
-      /// empty, if RefProd is NULL
-      const TriggerPathRefVector pathRefs() const;
-      /// Get a pointer to a certain HLT path by name,
-      /// returns 0, if algorithm is not found
-      const TriggerPath * path( const std::string & namePath ) const;
-      /// Get a reference to a certain HLT path by name,
-      /// NULL, if path is not found
-      const TriggerPathRef pathRef( const std::string & namePath ) const;
-      /// Get the index of a certain HLT path in the event collection by name,
-      /// returns size of algorithm collection, if algorithm is not found
-      unsigned indexPath( const std::string & namePath ) const;
-      /// Get a vector of references to all succeeding HLT paths
-      TriggerPathRefVector acceptedPaths() const;
+    /// Trigger objects
+    /// Set the reference to the pat::TriggerObjectCollection in the event
+    void setObjects(const edm::Handle<TriggerObjectCollection>& handleTriggerObjects) {
+      objects_ = TriggerObjectRefProd(handleTriggerObjects);
+    };
+    /// Get a pointer to all trigger objects,
+    /// returns 0, if RefProd is NULL
+    const TriggerObjectCollection* objects() const { return objects_.get(); };
+    /// Get a vector of references to all trigger objects,
+    /// empty, if RefProd is NULL
+    const TriggerObjectRefVector objectRefs() const;
+    /// Get a vector of references to all trigger objects by trigger object type
+    TriggerObjectRefVector objects(trigger::TriggerObjectType triggerObjectType) const;
+    TriggerObjectRefVector objects(int triggerObjectType) const {
+      return objects(trigger::TriggerObjectType(triggerObjectType));
+    };  // for backward compatibility
 
-      /// HLT filters
-      /// Set the reference to the pat::TriggerFilterCollection in the event
-      void setFilters( const edm::Handle< TriggerFilterCollection > & handleTriggerFilters ) { filters_ = TriggerFilterRefProd( handleTriggerFilters ); };
-      /// Get a pointer to all HLT filters,
-      /// returns 0, if RefProd is NULL
-      const TriggerFilterCollection * filters() const { return filters_.get(); };
-      /// Get a vector of references to all HLT filters,
-      /// empty, if RefProd is NULL
-      const TriggerFilterRefVector filterRefs() const;
-      /// Get a pointer to a certain HLT filter by label,
-      /// returns 0, if algorithm is not found
-      const TriggerFilter * filter( const std::string & labelFilter ) const;
-      /// Get a reference to a certain HLT filter by label,
-      /// NULL, if filter is not found
-      const TriggerFilterRef filterRef( const std::string & labelFilter ) const;
-      /// Get the index of a certain HLT filter in the event collection by label,
-      /// returns size of algorithm collection, if algorithm is not found
-      unsigned indexFilter( const std::string & labelFilter ) const;
-      /// Get a vector of references to all succeeding HLT filters
-      TriggerFilterRefVector acceptedFilters() const;
+    /// L1 x-links
+    /// Get a vector of references to all conditions assigned to a certain algorithm given by name
+    TriggerConditionRefVector algorithmConditions(const std::string& nameAlgorithm) const;
+    /// Checks, if a condition is assigned to a certain algorithm given by name
+    bool conditionInAlgorithm(const TriggerConditionRef& conditionRef, const std::string& nameAlgorithm) const;
+    /// Get a vector of references to all algorithms, which have a certain condition assigned
+    TriggerAlgorithmRefVector conditionAlgorithms(const TriggerConditionRef& conditionRef) const;
+    /// Get a list of all trigger object collections used in a certain condition given by name
+    std::vector<std::string> conditionCollections(const std::string& nameAlgorithm) const;
+    /// Get a vector of references to all objects, which were used in a certain condition given by name
+    TriggerObjectRefVector conditionObjects(const std::string& nameCondition) const;
+    /// Checks, if an object was used in a certain condition given by name
+    bool objectInCondition(const TriggerObjectRef& objectRef, const std::string& nameCondition) const;
+    /// Get a vector of references to all conditions, which have a certain object assigned
+    TriggerConditionRefVector objectConditions(const TriggerObjectRef& objectRef) const;
+    /// Get a vector of references to all objects, which were used in a certain algorithm given by name
+    TriggerObjectRefVector algorithmObjects(const std::string& nameAlgorithm) const;
+    /// Checks, if an object was used in a certain algorithm given by name
+    bool objectInAlgorithm(const TriggerObjectRef& objectRef, const std::string& nameAlgorithm) const;
+    /// Get a vector of references to all algorithms, which have a certain object assigned
+    TriggerAlgorithmRefVector objectAlgorithms(const TriggerObjectRef& objectRef) const;
 
-      /// Trigger objects
-      /// Set the reference to the pat::TriggerObjectCollection in the event
-      void setObjects( const edm::Handle< TriggerObjectCollection > & handleTriggerObjects ) { objects_ = TriggerObjectRefProd( handleTriggerObjects ); };
-      /// Get a pointer to all trigger objects,
-      /// returns 0, if RefProd is NULL
-      const TriggerObjectCollection * objects() const { return objects_.get(); };
-      /// Get a vector of references to all trigger objects,
-      /// empty, if RefProd is NULL
-      const TriggerObjectRefVector objectRefs() const;
-      /// Get a vector of references to all trigger objects by trigger object type
-      TriggerObjectRefVector objects( trigger::TriggerObjectType triggerObjectType ) const;
-      TriggerObjectRefVector objects( int                        triggerObjectType ) const { return objects( trigger::TriggerObjectType( triggerObjectType ) ); }; // for backward compatibility
+    /// HLT x-links
+    /// Get a vector of references to all modules assigned to a certain path given by name,
+    /// setting 'all' to 'false' returns the run filters only.
+    TriggerFilterRefVector pathModules(const std::string& namePath, bool all = true) const;
+    /// Get a vector of references to all active HLT filters assigned to a certain path given by name
+    TriggerFilterRefVector pathFilters(const std::string& namePath, bool firing = true) const;
+    /// Checks, if a filter is assigned to and was run in a certain path given by name
+    bool filterInPath(const TriggerFilterRef& filterRef, const std::string& namePath, bool firing = true) const;
+    /// Get a vector of references to all paths, which have a certain filter assigned
+    TriggerPathRefVector filterPaths(const TriggerFilterRef& filterRef, bool firing = true) const;
+    /// Get a list of all trigger object collections used in a certain filter given by name
+    std::vector<std::string> filterCollections(const std::string& labelFilter) const;
+    /// Get a vector of references to all objects, which were used in a certain filter given by name
+    TriggerObjectRefVector filterObjects(const std::string& labelFilter) const;
+    /// Checks, if an object was used in a certain filter given by name
+    bool objectInFilter(const TriggerObjectRef& objectRef, const std::string& labelFilter) const;
+    /// Get a vector of references to all filters, which have a certain object assigned
+    TriggerFilterRefVector objectFilters(const TriggerObjectRef& objectRef, bool firing = true) const;
+    /// Get a vector of references to all objects, which were used in a certain path given by name
+    TriggerObjectRefVector pathObjects(const std::string& namePath, bool firing = true) const;
+    /// Checks, if an object was used in a certain path given by name
+    bool objectInPath(const TriggerObjectRef& objectRef, const std::string& namePath, bool firing = true) const;
+    /// Get a vector of references to all paths, which have a certain object assigned
+    TriggerPathRefVector objectPaths(const TriggerObjectRef& objectRef, bool firing = true) const;
 
-      /// L1 x-links
-      /// Get a vector of references to all conditions assigned to a certain algorithm given by name
-      TriggerConditionRefVector algorithmConditions( const std::string & nameAlgorithm ) const;
-      /// Checks, if a condition is assigned to a certain algorithm given by name
-      bool conditionInAlgorithm( const TriggerConditionRef & conditionRef, const std::string & nameAlgorithm ) const;
-      /// Get a vector of references to all algorithms, which have a certain condition assigned
-      TriggerAlgorithmRefVector conditionAlgorithms( const TriggerConditionRef & conditionRef ) const;
-      /// Get a list of all trigger object collections used in a certain condition given by name
-      std::vector< std::string > conditionCollections( const std::string & nameAlgorithm ) const;
-      /// Get a vector of references to all objects, which were used in a certain condition given by name
-      TriggerObjectRefVector conditionObjects( const std::string & nameCondition ) const;
-      /// Checks, if an object was used in a certain condition given by name
-      bool objectInCondition( const TriggerObjectRef & objectRef, const std::string & nameCondition ) const;
-      /// Get a vector of references to all conditions, which have a certain object assigned
-      TriggerConditionRefVector objectConditions( const TriggerObjectRef & objectRef ) const;
-      /// Get a vector of references to all objects, which were used in a certain algorithm given by name
-      TriggerObjectRefVector algorithmObjects( const std::string & nameAlgorithm ) const;
-      /// Checks, if an object was used in a certain algorithm given by name
-      bool objectInAlgorithm( const TriggerObjectRef & objectRef, const std::string & nameAlgorithm ) const;
-      /// Get a vector of references to all algorithms, which have a certain object assigned
-      TriggerAlgorithmRefVector objectAlgorithms( const TriggerObjectRef & objectRef  ) const;
+    /// Add a pat::TriggerObjectMatch association
+    /// returns 'false', if 'matcher' alreadey exists
+    bool addObjectMatchResult(const TriggerObjectMatchRefProd& trigMatches, const std::string& labelMatcher);
+    bool addObjectMatchResult(const edm::Handle<TriggerObjectMatch>& trigMatches, const std::string& labelMatcher) {
+      return addObjectMatchResult(TriggerObjectMatchRefProd(trigMatches), labelMatcher);
+    };
+    bool addObjectMatchResult(const edm::OrphanHandle<TriggerObjectMatch>& trigMatches,
+                              const std::string& labelMatcher) {
+      return addObjectMatchResult(TriggerObjectMatchRefProd(trigMatches), labelMatcher);
+    };
+    /// Get a list of all linked trigger matches
+    std::vector<std::string> triggerMatchers() const;
+    /// Get all trigger matches
+    const TriggerObjectMatchContainer* triggerObjectMatchResults() const { return &objectMatchResults_; };
+    /// Get a pointer to a certain trigger match given by label,
+    /// performs proper "range check" (better than '(*triggerObjectMatchResults())[labelMatcher]'),
+    /// returns 0, if matcher not found
+    const TriggerObjectMatch* triggerObjectMatchResult(const std::string& labelMatcher) const;
 
-      /// HLT x-links
-      /// Get a vector of references to all modules assigned to a certain path given by name,
-      /// setting 'all' to 'false' returns the run filters only.
-      TriggerFilterRefVector pathModules( const std::string & namePath, bool all = true ) const;
-      /// Get a vector of references to all active HLT filters assigned to a certain path given by name
-      TriggerFilterRefVector pathFilters( const std::string & namePath, bool firing = true ) const;
-      /// Checks, if a filter is assigned to and was run in a certain path given by name
-      bool filterInPath( const TriggerFilterRef & filterRef, const std::string & namePath, bool firing = true ) const;
-      /// Get a vector of references to all paths, which have a certain filter assigned
-      TriggerPathRefVector filterPaths( const TriggerFilterRef & filterRef, bool firing = true ) const;
-      /// Get a list of all trigger object collections used in a certain filter given by name
-      std::vector< std::string > filterCollections( const std::string & labelFilter ) const;
-      /// Get a vector of references to all objects, which were used in a certain filter given by name
-      TriggerObjectRefVector filterObjects( const std::string & labelFilter ) const;
-      /// Checks, if an object was used in a certain filter given by name
-      bool objectInFilter( const TriggerObjectRef & objectRef, const std::string & labelFilter ) const;
-      /// Get a vector of references to all filters, which have a certain object assigned
-      TriggerFilterRefVector objectFilters( const TriggerObjectRef & objectRef, bool firing = true ) const;
-      /// Get a vector of references to all objects, which were used in a certain path given by name
-      TriggerObjectRefVector pathObjects( const std::string & namePath, bool firing = true ) const;
-      /// Checks, if an object was used in a certain path given by name
-      bool objectInPath( const TriggerObjectRef & objectRef, const std::string & namePath, bool firing = true ) const;
-      /// Get a vector of references to all paths, which have a certain object assigned
-      TriggerPathRefVector objectPaths( const TriggerObjectRef & objectRef, bool firing = true  ) const;
-
-      /// Add a pat::TriggerObjectMatch association
-      /// returns 'false', if 'matcher' alreadey exists
-      bool addObjectMatchResult( const TriggerObjectMatchRefProd               & trigMatches, const std::string & labelMatcher );
-      bool addObjectMatchResult( const edm::Handle< TriggerObjectMatch >       & trigMatches, const std::string & labelMatcher ) { return addObjectMatchResult( TriggerObjectMatchRefProd( trigMatches ), labelMatcher ); };
-      bool addObjectMatchResult( const edm::OrphanHandle< TriggerObjectMatch > & trigMatches, const std::string & labelMatcher ) { return addObjectMatchResult( TriggerObjectMatchRefProd( trigMatches ), labelMatcher ); };
-      /// Get a list of all linked trigger matches
-      std::vector< std::string > triggerMatchers() const;
-      /// Get all trigger matches
-      const TriggerObjectMatchContainer * triggerObjectMatchResults() const { return &objectMatchResults_; };
-      /// Get a pointer to a certain trigger match given by label,
-      /// performs proper "range check" (better than '(*triggerObjectMatchResults())[labelMatcher]'),
-      /// returns 0, if matcher not found
-      const TriggerObjectMatch * triggerObjectMatchResult( const std::string & labelMatcher ) const;
-
-      /// Further methods are provided by the pat::helper::TriggerMatchHelper in PhysicsTools/PatUtils/interface/TriggerHelper.h
-
+    /// Further methods are provided by the pat::helper::TriggerMatchHelper in PhysicsTools/PatUtils/interface/TriggerHelper.h
   };
 
-}
-
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TriggerFilter.h
+++ b/DataFormats/PatCandidates/interface/TriggerFilter.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_PatCandidates_TriggerFilter_h
 #define DataFormats_PatCandidates_TriggerFilter_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatCandidates
@@ -19,7 +18,6 @@
   \author   Volker Adler
 */
 
-
 #include <string>
 #include <vector>
 
@@ -33,98 +31,111 @@
 namespace pat {
 
   class TriggerFilter {
+    /// Data Members
 
-      /// Data Members
+    /// Label of the filter
+    std::string label_;
+    /// CMSSW module type
+    std::string type_;
+    /// Indeces of trigger objects in pat::TriggerObjectCollection in event
+    /// as produced together with the pat::TriggerFilterCollection
+    std::vector<unsigned> objectKeys_;
+    /// List of (unique) special identifiers for the used trigger object types as defined in
+    /// trigger::TriggerObjectType (DataFormats/HLTReco/interface/TriggerTypeDefs.h),
+    /// possibly empty or containing also zeroes
+    std::vector<trigger::TriggerObjectType> triggerObjectTypes_;
+    /// Indicator for filter status: -1: not run, 0: failed, 1: succeeded
+    int status_;
+    /// Indicator for being an L3 filter
+    /// available starting from CMSSW_4_2_3
+    bool saveTags_;
 
-      /// Label of the filter
-      std::string label_;
-      /// CMSSW module type
-      std::string type_;
-      /// Indeces of trigger objects in pat::TriggerObjectCollection in event
-      /// as produced together with the pat::TriggerFilterCollection
-      std::vector< unsigned > objectKeys_;
-      /// List of (unique) special identifiers for the used trigger object types as defined in
-      /// trigger::TriggerObjectType (DataFormats/HLTReco/interface/TriggerTypeDefs.h),
-      /// possibly empty or containing also zeroes
-      std::vector< trigger::TriggerObjectType > triggerObjectTypes_;
-      /// Indicator for filter status: -1: not run, 0: failed, 1: succeeded
-      int status_;
-      /// Indicator for being an L3 filter
-      /// available starting from CMSSW_4_2_3
-      bool saveTags_;
+  public:
+    /// Constructors and Desctructor
 
-    public:
+    /// Default constructor
+    TriggerFilter();
+    /// Constructor from std::string for filter label
+    TriggerFilter(const std::string& label, int status = -1, bool saveTags = false);
+    /// Constructor from edm::InputTag for filter label
+    TriggerFilter(const edm::InputTag& tag, int status = -1, bool saveTags = false);
 
-      /// Constructors and Desctructor
+    /// Destructor
+    virtual ~TriggerFilter(){};
 
-      /// Default constructor
-      TriggerFilter();
-      /// Constructor from std::string for filter label
-      TriggerFilter( const std::string & label, int status = -1, bool saveTags = false );
-      /// Constructor from edm::InputTag for filter label
-      TriggerFilter( const edm::InputTag & tag, int status = -1, bool saveTags = false );
+    /// Methods
 
-      /// Destructor
-      virtual ~TriggerFilter() {};
-
-      /// Methods
-
-      /// Set the filter label
-      void setLabel( const std::string & label ) { label_ = label; };
-      /// Set the filter module type
-      void setType( const std::string & type ) { type_  = type; };
-      /// Add a new trigger object collection index
-      void addObjectKey( unsigned objectKey ) { if ( ! hasObjectKey( objectKey ) ) objectKeys_.push_back( objectKey ); };
-      /// Add a new trigger object type identifier
-      void addTriggerObjectType( trigger::TriggerObjectType triggerObjectType ) { if ( ! hasTriggerObjectType( triggerObjectType ) ) triggerObjectTypes_.push_back( triggerObjectType ); };
-      void addTriggerObjectType( int triggerObjectType )                        { addTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); };
-      void addObjectId( trigger::TriggerObjectType triggerObjectType ) { addTriggerObjectType( triggerObjectType ); };                               // for backward compatibility
-      void addObjectId( int triggerObjectType )                        { addTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); }; // for backward compatibility
-      /// Set the filter status,
-      /// only -1,0,1 accepted; returns 'false' (and does not modify the status) otherwise
-      bool setStatus( int status );
-      /// Set the L3 status
-      void setSaveTags( bool saveTags ) { saveTags_ = saveTags; };
-      /// Get the filter label
-      const std::string & label() const { return label_; };
-      /// Get the filter module type
-      const std::string & type() const { return type_; };
-      /// Get all trigger object collection indeces
-      const std::vector< unsigned > & objectKeys() const { return objectKeys_; };
-      /// Get all trigger object type identifiers
-//       std::vector< trigger::TriggerObjectType > triggerObjectTypes() const { return triggerObjectTypes_; };
-//       std::vector< trigger::TriggerObjectType > objectIds()          const { return triggerObjectTypes(); }; // for backward compatibility
-      std::vector< int > triggerObjectTypes() const;  // for backward compatibilit
-      std::vector< int > objectIds()          const { return triggerObjectTypes(); }; // for double backward compatibility
-      /// Get the filter status
-      int status() const { return status_; };
-      /// Get the L3 status
-      bool saveTags() const { return saveTags_; };
-      bool isL3() const { return saveTags(); };
-      bool isFiring() const { return ( saveTags() && status() == 1 ); };
-      /// Checks, if a certain trigger object collection index is assigned
-      bool hasObjectKey( unsigned objectKey ) const;
-      /// Checks, if a certain trigger object type identifier is assigned
-      bool hasTriggerObjectType( trigger::TriggerObjectType triggerObjectType ) const;
-      bool hasTriggerObjectType( int triggerObjectType )                        const { return hasTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); };
-      bool hasObjectId( trigger::TriggerObjectType triggerObjectType ) const { return hasTriggerObjectType( triggerObjectType ); };                               // for backward compatibility
-      bool hasObjectId( int triggerObjectType )                        const { return hasTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); }; // for backward compatibility
-
+    /// Set the filter label
+    void setLabel(const std::string& label) { label_ = label; };
+    /// Set the filter module type
+    void setType(const std::string& type) { type_ = type; };
+    /// Add a new trigger object collection index
+    void addObjectKey(unsigned objectKey) {
+      if (!hasObjectKey(objectKey))
+        objectKeys_.push_back(objectKey);
+    };
+    /// Add a new trigger object type identifier
+    void addTriggerObjectType(trigger::TriggerObjectType triggerObjectType) {
+      if (!hasTriggerObjectType(triggerObjectType))
+        triggerObjectTypes_.push_back(triggerObjectType);
+    };
+    void addTriggerObjectType(int triggerObjectType) {
+      addTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };
+    void addObjectId(trigger::TriggerObjectType triggerObjectType) {
+      addTriggerObjectType(triggerObjectType);
+    };  // for backward compatibility
+    void addObjectId(int triggerObjectType) {
+      addTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };  // for backward compatibility
+    /// Set the filter status,
+    /// only -1,0,1 accepted; returns 'false' (and does not modify the status) otherwise
+    bool setStatus(int status);
+    /// Set the L3 status
+    void setSaveTags(bool saveTags) { saveTags_ = saveTags; };
+    /// Get the filter label
+    const std::string& label() const { return label_; };
+    /// Get the filter module type
+    const std::string& type() const { return type_; };
+    /// Get all trigger object collection indeces
+    const std::vector<unsigned>& objectKeys() const { return objectKeys_; };
+    /// Get all trigger object type identifiers
+    //       std::vector< trigger::TriggerObjectType > triggerObjectTypes() const { return triggerObjectTypes_; };
+    //       std::vector< trigger::TriggerObjectType > objectIds()          const { return triggerObjectTypes(); }; // for backward compatibility
+    std::vector<int> triggerObjectTypes() const;                          // for backward compatibilit
+    std::vector<int> objectIds() const { return triggerObjectTypes(); };  // for double backward compatibility
+    /// Get the filter status
+    int status() const { return status_; };
+    /// Get the L3 status
+    bool saveTags() const { return saveTags_; };
+    bool isL3() const { return saveTags(); };
+    bool isFiring() const { return (saveTags() && status() == 1); };
+    /// Checks, if a certain trigger object collection index is assigned
+    bool hasObjectKey(unsigned objectKey) const;
+    /// Checks, if a certain trigger object type identifier is assigned
+    bool hasTriggerObjectType(trigger::TriggerObjectType triggerObjectType) const;
+    bool hasTriggerObjectType(int triggerObjectType) const {
+      return hasTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };
+    bool hasObjectId(trigger::TriggerObjectType triggerObjectType) const {
+      return hasTriggerObjectType(triggerObjectType);
+    };  // for backward compatibility
+    bool hasObjectId(int triggerObjectType) const {
+      return hasTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };  // for backward compatibility
   };
 
-
   /// Collection of TriggerFilter
-  typedef std::vector< TriggerFilter >                      TriggerFilterCollection;
+  typedef std::vector<TriggerFilter> TriggerFilterCollection;
   /// Persistent reference to an item in a TriggerFilterCollection
-  typedef edm::Ref< TriggerFilterCollection >               TriggerFilterRef;
+  typedef edm::Ref<TriggerFilterCollection> TriggerFilterRef;
   /// Persistent reference to a TriggerFilterCollection product
-  typedef edm::RefProd< TriggerFilterCollection >           TriggerFilterRefProd;
+  typedef edm::RefProd<TriggerFilterCollection> TriggerFilterRefProd;
   /// Vector of persistent references to items in the same TriggerFilterCollection
-  typedef edm::RefVector< TriggerFilterCollection >         TriggerFilterRefVector;
+  typedef edm::RefVector<TriggerFilterCollection> TriggerFilterRefVector;
   /// Const iterator over vector of persistent references to items in the same TriggerFilterCollection
-  typedef edm::RefVectorIterator< TriggerFilterCollection > TriggerFilterRefVectorIterator;
+  typedef edm::RefVectorIterator<TriggerFilterCollection> TriggerFilterRefVectorIterator;
 
-}
-
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TriggerObject.h
+++ b/DataFormats/PatCandidates/interface/TriggerObject.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_PatCandidates_TriggerObject_h
 #define DataFormats_PatCandidates_TriggerObject_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatCandidates
@@ -18,7 +17,6 @@
 
   \author   Volker Adler
 */
-
 
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 
@@ -41,126 +39,155 @@
 #include "DataFormats/Common/interface/Association.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-
 namespace pat {
 
   class TriggerObject : public reco::LeafCandidate {
+    /// Data Members
 
-      /// Data Members
+    /// Label of the collection the trigger object originates from
+    std::string collection_;
+    /// Vector of special identifiers for the trigger object type as defined in
+    /// trigger::TriggerObjectType (DataFormats/HLTReco/interface/TriggerTypeDefs.h),
+    /// possibly empty
+    std::vector<trigger::TriggerObjectType> triggerObjectTypes_;
+    /// Reference to trigger object,
+    /// meant for 'l1extra' particles to access their additional functionalities,
+    /// empty otherwise
+    reco::CandidateBaseRef refToOrig_;
 
-      /// Label of the collection the trigger object originates from
-      std::string collection_;
-      /// Vector of special identifiers for the trigger object type as defined in
-      /// trigger::TriggerObjectType (DataFormats/HLTReco/interface/TriggerTypeDefs.h),
-      /// possibly empty
-      std::vector< trigger::TriggerObjectType > triggerObjectTypes_;
-      /// Reference to trigger object,
-      /// meant for 'l1extra' particles to access their additional functionalities,
-      /// empty otherwise
-      reco::CandidateBaseRef refToOrig_;
+  public:
+    /// Constructors and Destructor
 
-    public:
+    /// Default constructor
+    TriggerObject();
+    /// Constructor from trigger::TriggerObject
+    TriggerObject(const trigger::TriggerObject& trigObj);
+    /// Constructors from base class object
+    TriggerObject(const reco::LeafCandidate& leafCand);
+    /// Constructors from base candidate reference (for 'l1extra' particles)
+    TriggerObject(const reco::CandidateBaseRef& candRef);
+    /// Constructors from Lorentz-vectors and (optional) PDG ID
+    TriggerObject(const reco::Particle::LorentzVector& vec, int id = 0);
+    TriggerObject(const reco::Particle::PolarLorentzVector& vec, int id = 0);
 
-      /// Constructors and Destructor
+    /// Destructor
+    ~TriggerObject() override{};
 
-      /// Default constructor
-      TriggerObject();
-      /// Constructor from trigger::TriggerObject
-      TriggerObject( const trigger::TriggerObject & trigObj );
-      /// Constructors from base class object
-      TriggerObject( const reco::LeafCandidate    & leafCand );
-      /// Constructors from base candidate reference (for 'l1extra' particles)
-      TriggerObject( const reco::CandidateBaseRef & candRef );
-      /// Constructors from Lorentz-vectors and (optional) PDG ID
-      TriggerObject( const reco::Particle::LorentzVector      & vec, int id = 0 );
-      TriggerObject( const reco::Particle::PolarLorentzVector & vec, int id = 0 );
+    /// Methods
 
-      /// Destructor
-      ~TriggerObject() override {};
+    /// Set the label of the collection the trigger object originates from
+    void setCollection(const std::string& collName) { collection_ = collName; };
+    void setCollection(const edm::InputTag& collName) { collection_ = collName.encode(); };
+    /// Add a new trigger object type identifier
+    void addTriggerObjectType(trigger::TriggerObjectType triggerObjectType) {
+      if (!hasTriggerObjectType(triggerObjectType))
+        triggerObjectTypes_.push_back(triggerObjectType);
+    };
+    void addTriggerObjectType(int triggerObjectType) {
+      addTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };
+    void addFilterId(trigger::TriggerObjectType triggerObjectType) {
+      addTriggerObjectType(triggerObjectType);
+    };  // for backward compatibility
+    void addFilterId(int triggerObjectType) {
+      addTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };  // for backward compatibility
+    /// Get the label of the collection the trigger object originates from
+    const std::string& collection() const { return collection_; };
+    /// Get all trigger object type identifiers
+    //       std::vector< trigger::TriggerObjectType > triggerObjectTypes() const { return triggerObjectTypes_; };
+    //       std::vector< trigger::TriggerObjectType > filterIds()          const { return triggerObjectTypes(); }; // for backward compatibility
+    std::vector<int> triggerObjectTypes() const;                          // for backward compatibility
+    std::vector<int> filterIds() const { return triggerObjectTypes(); };  // for double backward compatibility
+    /// Checks, if a certain label of original collection is assigned
+    virtual bool hasCollection(const std::string& collName) const;
+    virtual bool hasCollection(const edm::InputTag& collName) const { return hasCollection(collName.encode()); };
+    /// Checks, if a certain trigger object type identifier is assigned
+    bool hasTriggerObjectType(trigger::TriggerObjectType triggerObjectType) const;
+    bool hasTriggerObjectType(int triggerObjectType) const {
+      return hasTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };
+    bool hasFilterId(trigger::TriggerObjectType triggerObjectType) const {
+      return hasTriggerObjectType(triggerObjectType);
+    };  // for backward compatibility
+    bool hasFilterId(int triggerObjectType) const {
+      return hasTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };  // for backward compatibility
 
-      /// Methods
+    /// Special methods for 'l1extra' particles
 
-      /// Set the label of the collection the trigger object originates from
-      void setCollection( const std::string & collName )   { collection_ = collName; };
-      void setCollection( const edm::InputTag & collName ) { collection_ = collName.encode(); };
-      /// Add a new trigger object type identifier
-      void addTriggerObjectType( trigger::TriggerObjectType triggerObjectType ) { if ( ! hasTriggerObjectType( triggerObjectType ) ) triggerObjectTypes_.push_back( triggerObjectType ); };
-      void addTriggerObjectType( int                        triggerObjectType ) { addTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); };
-      void addFilterId( trigger::TriggerObjectType triggerObjectType ) { addTriggerObjectType( triggerObjectType ); };                               // for backward compatibility
-      void addFilterId( int                        triggerObjectType ) { addTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); }; // for backward compatibility
-      /// Get the label of the collection the trigger object originates from
-      const std::string & collection() const { return collection_; };
-      /// Get all trigger object type identifiers
-//       std::vector< trigger::TriggerObjectType > triggerObjectTypes() const { return triggerObjectTypes_; };
-//       std::vector< trigger::TriggerObjectType > filterIds()          const { return triggerObjectTypes(); }; // for backward compatibility
-      std::vector< int > triggerObjectTypes() const;                                  // for backward compatibility
-      std::vector< int > filterIds()          const { return triggerObjectTypes(); }; // for double backward compatibility
-      /// Checks, if a certain label of original collection is assigned
-      virtual bool hasCollection( const std::string   & collName ) const;
-      virtual bool hasCollection( const edm::InputTag & collName ) const { return hasCollection( collName.encode() ); };
-      /// Checks, if a certain trigger object type identifier is assigned
-      bool hasTriggerObjectType( trigger::TriggerObjectType triggerObjectType ) const;
-      bool hasTriggerObjectType( int                        triggerObjectType ) const { return hasTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); };
-      bool hasFilterId( trigger::TriggerObjectType triggerObjectType ) const { return hasTriggerObjectType( triggerObjectType ); };                               // for backward compatibility
-      bool hasFilterId( int                        triggerObjectType ) const { return hasTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); }; // for backward compatibility
+    /// General getters
+    const reco::CandidateBaseRef& origObjRef() const { return refToOrig_; };
+    const reco::Candidate* origObjCand() const { return refToOrig_.get(); };
+    /// Getters specific to the 'l1extra' particle type for
+    /// - EM
+    const l1extra::L1EmParticleRef origL1EmRef() const;
+    const L1GctEmCand* origL1GctEmCand() const {
+      return origL1EmRef().isNonnull() ? origL1EmRef()->gctEmCand() : nullptr;
+    };
+    /// - EtMiss
+    const l1extra::L1EtMissParticleRef origL1EtMissRef() const;
+    const L1GctEtMiss* origL1GctEtMiss() const {
+      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtMiss() : nullptr;
+    };
+    const L1GctEtTotal* origL1GctEtTotal() const {
+      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtTotal() : nullptr;
+    };
+    const L1GctHtMiss* origL1GctHtMiss() const {
+      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctHtMiss() : nullptr;
+    };
+    const L1GctEtHad* origL1GctEtHad() const {
+      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtHad() : nullptr;
+    };
+    /// - Jet
+    const l1extra::L1JetParticleRef origL1JetRef() const;
+    const L1GctJetCand* origL1GctJetCand() const {
+      return origL1JetRef().isNonnull() ? origL1JetRef()->gctJetCand() : nullptr;
+    };
+    /// - Muon
+    const l1extra::L1MuonParticleRef origL1MuonRef() const;
+    const L1MuGMTExtendedCand* origL1GmtMuonCand() const {
+      return origL1MuonRef().isNonnull() ? &(origL1MuonRef()->gmtMuonCand()) : nullptr;
+    };
 
-      /// Special methods for 'l1extra' particles
+    /// Special methods for the cut string parser
+    /// - argument types usable in the cut string parser
+    /// - short names for readable configuration files
 
-      /// General getters
-      const reco::CandidateBaseRef & origObjRef()  const { return refToOrig_; };
-      const reco::Candidate        * origObjCand() const { return refToOrig_.get(); };
-      /// Getters specific to the 'l1extra' particle type for
-      /// - EM
-      const l1extra::L1EmParticleRef origL1EmRef() const;
-      const L1GctEmCand * origL1GctEmCand() const { return origL1EmRef().isNonnull() ? origL1EmRef()->gctEmCand() : nullptr; };
-      /// - EtMiss
-      const l1extra::L1EtMissParticleRef origL1EtMissRef() const;
-      const L1GctEtMiss  * origL1GctEtMiss()  const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtMiss()  : nullptr; };
-      const L1GctEtTotal * origL1GctEtTotal() const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtTotal() : nullptr; };
-      const L1GctHtMiss  * origL1GctHtMiss()  const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctHtMiss()  : nullptr; };
-      const L1GctEtHad   * origL1GctEtHad()   const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtHad()   : nullptr; };
-      /// - Jet
-      const l1extra::L1JetParticleRef origL1JetRef() const;
-      const L1GctJetCand * origL1GctJetCand() const { return origL1JetRef().isNonnull() ? origL1JetRef()->gctJetCand() : nullptr; };
-      /// - Muon
-      const l1extra::L1MuonParticleRef origL1MuonRef() const;
-      const L1MuGMTExtendedCand * origL1GmtMuonCand() const { return origL1MuonRef().isNonnull() ? &( origL1MuonRef()->gmtMuonCand() ) : nullptr; };
-
-      /// Special methods for the cut string parser
-      /// - argument types usable in the cut string parser
-      /// - short names for readable configuration files
-
-      /// Calls 'hasCollection(...)'
-      virtual bool coll( const std::string & collName ) const { return hasCollection( collName ); };
-      /// Calls 'hasTriggerObjectType(...)'
-      bool type( trigger::TriggerObjectType triggerObjectType ) const { return hasTriggerObjectType( triggerObjectType ); };
-      bool type( int                        triggerObjectType ) const { return hasTriggerObjectType( trigger::TriggerObjectType ( triggerObjectType ) ); };
-      bool id( trigger::TriggerObjectType triggerObjectType ) const { return hasTriggerObjectType( triggerObjectType ); };                                // for backward compatibility
-      bool id( int                        triggerObjectType ) const { return hasTriggerObjectType( trigger::TriggerObjectType ( triggerObjectType ) ); }; // for backward compatibility
-
+    /// Calls 'hasCollection(...)'
+    virtual bool coll(const std::string& collName) const { return hasCollection(collName); };
+    /// Calls 'hasTriggerObjectType(...)'
+    bool type(trigger::TriggerObjectType triggerObjectType) const { return hasTriggerObjectType(triggerObjectType); };
+    bool type(int triggerObjectType) const {
+      return hasTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };
+    bool id(trigger::TriggerObjectType triggerObjectType) const {
+      return hasTriggerObjectType(triggerObjectType);
+    };  // for backward compatibility
+    bool id(int triggerObjectType) const {
+      return hasTriggerObjectType(trigger::TriggerObjectType(triggerObjectType));
+    };  // for backward compatibility
   };
 
-
   /// Collection of TriggerObject
-  typedef std::vector< TriggerObject >                       TriggerObjectCollection;
+  typedef std::vector<TriggerObject> TriggerObjectCollection;
   /// Persistent reference to an item in a TriggerObjectCollection
-  typedef edm::Ref< TriggerObjectCollection >                TriggerObjectRef;
+  typedef edm::Ref<TriggerObjectCollection> TriggerObjectRef;
   /// Container to store match references from different producers (for one PAT object)
-  typedef std::map< std::string, TriggerObjectRef >          TriggerObjectMatchMap;
+  typedef std::map<std::string, TriggerObjectRef> TriggerObjectMatchMap;
   /// Persistent reference to a TriggerObjectCollection product
-  typedef edm::RefProd< TriggerObjectCollection >            TriggerObjectRefProd;
+  typedef edm::RefProd<TriggerObjectCollection> TriggerObjectRefProd;
   /// Vector of persistent references to items in the same TriggerObjectCollection
-  typedef edm::RefVector< TriggerObjectCollection >          TriggerObjectRefVector;
+  typedef edm::RefVector<TriggerObjectCollection> TriggerObjectRefVector;
   /// Const iterator over vector of persistent references to items in the same TriggerObjectCollection
-  typedef edm::RefVectorIterator< TriggerObjectCollection >  TriggerObjectRefVectorIterator;
+  typedef edm::RefVectorIterator<TriggerObjectCollection> TriggerObjectRefVectorIterator;
   /// Association of TriggerObjects to store matches to Candidates
-  typedef edm::Association< TriggerObjectCollection >        TriggerObjectMatch;
+  typedef edm::Association<TriggerObjectCollection> TriggerObjectMatch;
   /// Persistent reference to a TriggerObjectMatch product
-  typedef edm::RefProd< TriggerObjectMatch >                 TriggerObjectMatchRefProd;
+  typedef edm::RefProd<TriggerObjectMatch> TriggerObjectMatchRefProd;
   /// Container to store references to matches from different producers in the trigger event
-  typedef std::map< std::string, TriggerObjectMatchRefProd > TriggerObjectMatchContainer;
+  typedef std::map<std::string, TriggerObjectMatchRefProd> TriggerObjectMatchContainer;
 
-}
-
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h
+++ b/DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_PatCandidates_TriggerObjectStandAlone_h
 #define DataFormats_PatCandidates_TriggerObjectStandAlone_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatCandidates
@@ -21,187 +20,214 @@
   \author   Volker Adler
 */
 
-
 #include "DataFormats/PatCandidates/interface/TriggerObject.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/Common/interface/EventBase.h"
-namespace edm { class TriggerNames; }
+namespace edm {
+  class TriggerNames;
+}
 
 namespace pat {
 
   class TriggerObjectStandAlone : public TriggerObject {
+    /// Data Members
+    /// Keeping the old names of the data members for backward compatibility,
+    /// although they refer only to HLT objects.
 
-      /// Data Members
-      /// Keeping the old names of the data members for backward compatibility,
-      /// although they refer only to HLT objects.
+    /// Vector of labels of all HLT filters or names of L1 conditions the trigger objects has been used in
+    std::vector<std::string> filterLabels_;
+    std::vector<uint16_t> filterLabelIndices_;
 
-      /// Vector of labels of all HLT filters or names of L1 conditions the trigger objects has been used in
-      std::vector< std::string > filterLabels_;
-      std::vector< uint16_t >    filterLabelIndices_; 
+    /// Vector of names of all HLT paths or L1 algorithms the trigger objects has been used in
+    std::vector<std::string> pathNames_;
+    std::vector<uint16_t> pathIndices_;
 
-      /// Vector of names of all HLT paths or L1 algorithms the trigger objects has been used in
-      std::vector< std::string > pathNames_;  
-      std::vector< uint16_t >    pathIndices_; 
+    /// Vector alligned with 'pathNames_' of boolean indicating the usage of the trigger object
+    /// An element is true, if the corresponding path succeeded and the trigger object was used in the last filter (HLT)
+    /// or the corresponding algorithm succeeded as well as the corresponding condition (L1).
+    /// The vector is empty for data (size 0), if the according information is not available.
+    std::vector<bool> pathLastFilterAccepted_;
+    /// Vector alligned with 'pathNames_' of boolean indicating the usage of the trigger object
+    /// An element is true, if the corresponding path succeeded and the trigger object was used in an L3 filter (HLT only)
+    /// The vector is empty for data (size 0), if the according information is not available.
+    std::vector<bool> pathL3FilterAccepted_;
 
-      /// Vector alligned with 'pathNames_' of boolean indicating the usage of the trigger object
-      /// An element is true, if the corresponding path succeeded and the trigger object was used in the last filter (HLT)
-      /// or the corresponding algorithm succeeded as well as the corresponding condition (L1).
-      /// The vector is empty for data (size 0), if the according information is not available.
-      std::vector< bool > pathLastFilterAccepted_;
-      /// Vector alligned with 'pathNames_' of boolean indicating the usage of the trigger object
-      /// An element is true, if the corresponding path succeeded and the trigger object was used in an L3 filter (HLT only)
-      /// The vector is empty for data (size 0), if the according information is not available.
-      std::vector< bool > pathL3FilterAccepted_;
+    edm::ParameterSetID psetId_;
 
-      edm::ParameterSetID  psetId_;
+    /// Constants
 
-      /// Constants
+    /// Constant defining the wild-card used in 'hasAnyName()'
+    static const char wildcard_ = '*';
 
-      /// Constant defining the wild-card used in 'hasAnyName()'
-      static const char wildcard_ = '*';
+    /// Private methods
 
-      /// Private methods
+    /// Checks a string vector for occurence of a certain string, incl. wild-card mechanism
+    bool hasAnyName(const std::string &name, const std::vector<std::string> &nameVec) const;
+    /// Adds a new HLT filter label or L1 condition name
+    void addFilterOrCondition(const std::string &name) {
+      if (!hasFilterOrCondition(name))
+        filterLabels_.push_back(name);
+    };
+    /// Adds a new HLT path or L1 algorithm name
+    void addPathOrAlgorithm(const std::string &name, bool pathLastFilterAccepted, bool pathL3FilterAccepted);
+    /// Gets all HLT filter labels or L1 condition names
+    const std::vector<std::string> &filtersOrConditions() const {
+      checkIfFiltersAreUnpacked();
+      return filterLabels_;
+    };
+    /// Gets all HLT path or L1 algorithm names
+    std::vector<std::string> pathsOrAlgorithms(bool pathLastFilterAccepted, bool pathL3FilterAccepted) const;
+    /// Checks, if a certain HLT filter label or L1 condition name is assigned
+    bool hasFilterOrCondition(const std::string &name) const;
+    /// Checks, if a certain HLT path or L1 algorithm name is assigned
+    bool hasPathOrAlgorithm(const std::string &name, bool pathLastFilterAccepted, bool pathL3FilterAccepted) const;
+    /// Check, if the usage indicator vectors have been filled
+    bool hasLastFilter() const {
+      return (!pathLastFilterAccepted_.empty() && pathLastFilterAccepted_.size() == pathNames_.size());
+    };
+    bool hasL3Filter() const {
+      return (!pathL3FilterAccepted_.empty() && pathL3FilterAccepted_.size() == pathNames_.size());
+    };
 
-      /// Checks a string vector for occurence of a certain string, incl. wild-card mechanism
-      bool hasAnyName( const std::string & name, const std::vector< std::string > & nameVec ) const;
-      /// Adds a new HLT filter label or L1 condition name
-      void addFilterOrCondition( const std::string & name ) { if ( ! hasFilterOrCondition( name ) ) filterLabels_.push_back( name ); };
-      /// Adds a new HLT path or L1 algorithm name
-      void addPathOrAlgorithm( const std::string & name, bool pathLastFilterAccepted, bool pathL3FilterAccepted );
-      /// Gets all HLT filter labels or L1 condition names
-      const std::vector< std::string > & filtersOrConditions() const { checkIfFiltersAreUnpacked(); return filterLabels_; };
-      /// Gets all HLT path or L1 algorithm names
-      std::vector< std::string > pathsOrAlgorithms( bool pathLastFilterAccepted, bool pathL3FilterAccepted ) const;
-      /// Checks, if a certain HLT filter label or L1 condition name is assigned
-      bool hasFilterOrCondition( const std::string & name ) const;
-      /// Checks, if a certain HLT path or L1 algorithm name is assigned
-      bool hasPathOrAlgorithm( const std::string & name, bool pathLastFilterAccepted, bool pathL3FilterAccepted ) const;
-      /// Check, if the usage indicator vectors have been filled
-      bool hasLastFilter() const { return ( !pathLastFilterAccepted_.empty() && pathLastFilterAccepted_.size() == pathNames_.size() ); };
-      bool hasL3Filter() const { return ( !pathL3FilterAccepted_.empty() && pathL3FilterAccepted_.size() == pathNames_.size() ); };
+    /// Check if trigger names have been packed by calling packPathNames() and not yet unpacked
+    bool checkIfPathsAreUnpacked(bool throwIfPacked = true) const;
+    /// Check if trigger names have been packed by calling packFilterLabels() and not yet unpacked
+    bool checkIfFiltersAreUnpacked(bool throwIfPacked = true) const;
 
-      /// Check if trigger names have been packed by calling packPathNames() and not yet unpacked
-      bool checkIfPathsAreUnpacked(bool throwIfPacked=true) const ;
-      /// Check if trigger names have been packed by calling packFilterLabels() and not yet unpacked
-      bool checkIfFiltersAreUnpacked(bool  throwIfPacked=true) const ;
+  public:
+    /// Constructors and Destructor
 
-    public:
+    /// Default constructor
+    TriggerObjectStandAlone();
+    /// Constructor from pat::TriggerObject
+    TriggerObjectStandAlone(const TriggerObject &trigObj);
+    /// Constructor from trigger::TriggerObject
+    TriggerObjectStandAlone(const trigger::TriggerObject &trigObj);
+    /// Constructor from reco::Candidate
+    TriggerObjectStandAlone(const reco::LeafCandidate &leafCand);
+    /// Constructors from Lorentz-vectors and (optional) PDG ID
+    TriggerObjectStandAlone(const reco::Particle::LorentzVector &vec, int id = 0);
+    TriggerObjectStandAlone(const reco::Particle::PolarLorentzVector &vec, int id = 0);
+    TriggerObjectStandAlone(const TriggerObjectStandAlone &) = default;
 
-      /// Constructors and Destructor
+    /// Destructor
+    ~TriggerObjectStandAlone() override{};
 
-      /// Default constructor
-      TriggerObjectStandAlone();
-      /// Constructor from pat::TriggerObject
-      TriggerObjectStandAlone( const TriggerObject & trigObj );
-      /// Constructor from trigger::TriggerObject
-      TriggerObjectStandAlone( const trigger::TriggerObject & trigObj );
-      /// Constructor from reco::Candidate
-      TriggerObjectStandAlone( const reco::LeafCandidate & leafCand );
-      /// Constructors from Lorentz-vectors and (optional) PDG ID
-      TriggerObjectStandAlone( const reco::Particle::LorentzVector & vec, int id = 0 );
-      TriggerObjectStandAlone( const reco::Particle::PolarLorentzVector & vec, int id = 0 );
-      TriggerObjectStandAlone( const TriggerObjectStandAlone& ) = default;
+    /// Methods
 
-      /// Destructor
-      ~TriggerObjectStandAlone() override {};
+    TriggerObjectStandAlone copy() const { return *this; }
 
-      /// Methods
+    /// Adds a new HLT filter label
+    void addFilterLabel(const std::string &filterLabel) { addFilterOrCondition(filterLabel); };
+    /// Adds a new L1 condition name
+    void addConditionName(const std::string &conditionName) { addFilterOrCondition(conditionName); };
+    /// Adds a new HLT path name
+    void addPathName(const std::string &pathName,
+                     bool pathLastFilterAccepted = true,
+                     bool pathL3FilterAccepted = true) {
+      addPathOrAlgorithm(pathName, pathLastFilterAccepted, pathL3FilterAccepted);
+    };
+    /// Adds a new L1 algorithm name
+    void addAlgorithmName(const std::string &algorithmName, bool algoCondAccepted = true) {
+      addPathOrAlgorithm(algorithmName, algoCondAccepted, false);
+    };
+    /// Gets all HLT filter labels
+    const std::vector<std::string> &filterLabels() const { return filtersOrConditions(); };
+    /// Gets all L1 condition names
+    const std::vector<std::string> &conditionNames() const { return filtersOrConditions(); };
+    /// Gets all HLT path names
+    std::vector<std::string> pathNames(bool pathLastFilterAccepted = false, bool pathL3FilterAccepted = true) const {
+      return pathsOrAlgorithms(pathLastFilterAccepted, pathL3FilterAccepted);
+    };
+    /// Gets all L1 algorithm names
+    std::vector<std::string> algorithmNames(bool algoCondAccepted = true) const {
+      return pathsOrAlgorithms(algoCondAccepted, false);
+    };
+    /// Gets the pat::TriggerObject (parent class)
+    TriggerObject triggerObject();
+    /// Checks, if a certain HLT filter label is assigned
+    bool hasFilterLabel(const std::string &filterLabel) const { return hasFilterOrCondition(filterLabel); };
+    /// Checks, if a certain L1 condition name is assigned
+    bool hasConditionName(const std::string &conditionName) const { return hasFilterOrCondition(conditionName); };
+    /// Checks, if a certain HLT path name is assigned
+    bool hasPathName(const std::string &pathName,
+                     bool pathLastFilterAccepted = false,
+                     bool pathL3FilterAccepted = true) const {
+      return hasPathOrAlgorithm(pathName, pathLastFilterAccepted, pathL3FilterAccepted);
+    };
+    /// Checks, if a certain L1 algorithm name is assigned
+    bool hasAlgorithmName(const std::string &algorithmName, bool algoCondAccepted = true) const {
+      return hasPathOrAlgorithm(algorithmName, algoCondAccepted, false);
+    };
+    /// Checks, if a certain label of original collection is assigned (method overrides)
+    bool hasCollection(const std::string &collName) const override;
+    bool hasCollection(const edm::InputTag &collName) const override { return hasCollection(collName.encode()); };
+    /// Checks, if the usage indicator vector has been filled
+    bool hasPathLastFilterAccepted() const { return hasLastFilter(); };
+    bool hasAlgoCondAccepted() const { return hasLastFilter(); };
+    bool hasPathL3FilterAccepted() const { return hasL3Filter(); };
 
-      TriggerObjectStandAlone copy() const {
-        return *this;
-      }
+    /// Special methods for the cut string parser
+    /// - argument types usable in the cut string parser
+    /// - short names for readable configuration files
 
-      /// Adds a new HLT filter label
-      void addFilterLabel( const std::string & filterLabel ) { addFilterOrCondition( filterLabel ); };
-      /// Adds a new L1 condition name
-      void addConditionName( const std::string & conditionName ) { addFilterOrCondition( conditionName ); };
-      /// Adds a new HLT path name
-      void addPathName( const std::string & pathName, bool pathLastFilterAccepted = true, bool pathL3FilterAccepted = true ) { addPathOrAlgorithm( pathName, pathLastFilterAccepted, pathL3FilterAccepted ); };
-      /// Adds a new L1 algorithm name
-      void addAlgorithmName( const std::string & algorithmName, bool algoCondAccepted = true ) { addPathOrAlgorithm( algorithmName, algoCondAccepted, false ); };
-      /// Gets all HLT filter labels
-      const std::vector< std::string > & filterLabels() const { return filtersOrConditions(); };
-      /// Gets all L1 condition names
-      const std::vector< std::string > & conditionNames() const { return filtersOrConditions(); };
-      /// Gets all HLT path names
-      std::vector< std::string > pathNames( bool pathLastFilterAccepted = false, bool pathL3FilterAccepted = true ) const { return pathsOrAlgorithms( pathLastFilterAccepted, pathL3FilterAccepted ); };
-      /// Gets all L1 algorithm names
-      std::vector< std::string > algorithmNames( bool algoCondAccepted = true ) const { return pathsOrAlgorithms( algoCondAccepted, false ); };
-      /// Gets the pat::TriggerObject (parent class)
-      TriggerObject triggerObject();
-      /// Checks, if a certain HLT filter label is assigned
-      bool hasFilterLabel( const std::string & filterLabel ) const { return hasFilterOrCondition( filterLabel ); };
-      /// Checks, if a certain L1 condition name is assigned
-      bool hasConditionName( const std::string & conditionName ) const { return hasFilterOrCondition( conditionName ); };
-      /// Checks, if a certain HLT path name is assigned
-      bool hasPathName( const std::string & pathName, bool pathLastFilterAccepted = false, bool pathL3FilterAccepted = true ) const { return hasPathOrAlgorithm( pathName, pathLastFilterAccepted, pathL3FilterAccepted ); };
-      /// Checks, if a certain L1 algorithm name is assigned
-      bool hasAlgorithmName( const std::string & algorithmName, bool algoCondAccepted = true ) const { return hasPathOrAlgorithm( algorithmName, algoCondAccepted, false ); };
-      /// Checks, if a certain label of original collection is assigned (method overrides)
-      bool hasCollection( const std::string & collName ) const override;
-      bool hasCollection( const edm::InputTag & collName ) const override { return hasCollection( collName.encode() ); };
-      /// Checks, if the usage indicator vector has been filled
-      bool hasPathLastFilterAccepted() const { return hasLastFilter(); };
-      bool hasAlgoCondAccepted() const { return hasLastFilter(); };
-      bool hasPathL3FilterAccepted() const { return hasL3Filter(); };
+    /// Calls 'hasFilterLabel(...)'
+    bool filter(const std::string &filterLabel) const { return hasFilterLabel(filterLabel); };
+    /// Calls 'hasConditionName(...)'
+    bool cond(const std::string &conditionName) const { return hasConditionName(conditionName); };
+    /// Calls 'hasPathName(...)'
+    bool path(const std::string &pathName,
+              unsigned pathLastFilterAccepted = 0,
+              unsigned pathL3FilterAccepted = 1) const {
+      return hasPathName(pathName, bool(pathLastFilterAccepted), bool(pathL3FilterAccepted));
+    };
+    /// Calls 'hasAlgorithmName(...)'
+    bool algo(const std::string &algorithmName, unsigned algoCondAccepted = 1) const {
+      return hasAlgorithmName(algorithmName, bool(algoCondAccepted));
+    };
+    /// Calls 'hasCollection(...)' (method override)
+    bool coll(const std::string &collName) const override { return hasCollection(collName); };
 
-      /// Special methods for the cut string parser
-      /// - argument types usable in the cut string parser
-      /// - short names for readable configuration files
+    ///set the psetid of the trigger process
+    void setPSetID(const edm::ParameterSetID &psetId) { psetId_ = psetId; }
 
-      /// Calls 'hasFilterLabel(...)'
-      bool filter( const std::string & filterLabel ) const { return hasFilterLabel( filterLabel ); };
-      /// Calls 'hasConditionName(...)'
-      bool cond( const std::string & conditionName ) const { return hasConditionName( conditionName ); };
-      /// Calls 'hasPathName(...)'
-      bool path( const std::string & pathName, unsigned pathLastFilterAccepted = 0, unsigned pathL3FilterAccepted = 1 ) const { return hasPathName( pathName, bool( pathLastFilterAccepted ), bool( pathL3FilterAccepted ) ); };
-      /// Calls 'hasAlgorithmName(...)'
-      bool algo( const std::string & algorithmName, unsigned algoCondAccepted = 1 ) const { return hasAlgorithmName( algorithmName, bool( algoCondAccepted ) ); };
-      /// Calls 'hasCollection(...)' (method override)
-      bool coll( const std::string & collName ) const override { return hasCollection( collName ); };
+    const edm::ParameterSetID &psetID() const { return psetId_; }
 
-      ///set the psetid of the trigger process
-      void setPSetID(const edm::ParameterSetID &psetId){psetId_=psetId;}
-      
-      const edm::ParameterSetID &psetID() const {return psetId_;}
+    void packFilterLabels(const edm::EventBase &event, const edm::TriggerResults &res);
+    ///  pack trigger names into indices
+    void packPathNames(const edm::TriggerNames &names);
+    ///  unpack trigger names into indices
+    void unpackPathNames(const edm::TriggerNames &names);
+    ///  pack filter labels into indices; note that the labels must be sorted!
+    void packFilterLabels(const std::vector<std::string> &labels);
+    ///  unpack filter labels from indices
+    void unpackFilterLabels(const std::vector<std::string> &labels);
+    ///  unpack filter labels from indices
+    void unpackFilterLabels(const edm::EventBase &event, const edm::TriggerResults &res);
+    /// unpack both filter labels and trigger names
+    void unpackNamesAndLabels(const edm::EventBase &event, const edm::TriggerResults &res);
 
+    /// reduce the precision on the 4-vector
+    void packP4();
 
-      void packFilterLabels(const edm::EventBase &event,const edm::TriggerResults &res);
-      ///  pack trigger names into indices 
-      void packPathNames(const edm::TriggerNames &names) ;
-      ///  unpack trigger names into indices 
-      void unpackPathNames(const edm::TriggerNames &names) ;
-      ///  pack filter labels into indices; note that the labels must be sorted!
-      void packFilterLabels(const std::vector<std::string> &labels)  ;
-      ///  unpack filter labels from indices
-      void unpackFilterLabels(const std::vector<std::string> &labels)  ;
-      ///  unpack filter labels from indices
-      void unpackFilterLabels(const edm::EventBase & event,const edm::TriggerResults &res)  ;
-      /// unpack both filter labels and trigger names
-      void unpackNamesAndLabels(const edm::EventBase & event,const edm::TriggerResults &res);
-
-      /// reduce the precision on the 4-vector
-      void packP4();
-
-      std::vector<std::string> const* allLabels(edm::ParameterSetID const& psetid,const edm::EventBase & event,const edm::TriggerResults &res) const ;
-
+    std::vector<std::string> const *allLabels(edm::ParameterSetID const &psetid,
+                                              const edm::EventBase &event,
+                                              const edm::TriggerResults &res) const;
   };
 
-
   /// Collection of TriggerObjectStandAlone
-  typedef std::vector< TriggerObjectStandAlone >                      TriggerObjectStandAloneCollection;
+  typedef std::vector<TriggerObjectStandAlone> TriggerObjectStandAloneCollection;
   /// Persistent reference to an item in a TriggerObjectStandAloneCollection
-  typedef edm::Ref< TriggerObjectStandAloneCollection >               TriggerObjectStandAloneRef;
+  typedef edm::Ref<TriggerObjectStandAloneCollection> TriggerObjectStandAloneRef;
   /// Persistent reference to a TriggerObjectStandAloneCollection product
-  typedef edm::RefProd< TriggerObjectStandAloneCollection >           TriggerObjectStandAloneRefProd;
+  typedef edm::RefProd<TriggerObjectStandAloneCollection> TriggerObjectStandAloneRefProd;
   /// Vector of persistent references to items in the same TriggerObjectStandAloneCollection
-  typedef edm::RefVector< TriggerObjectStandAloneCollection >         TriggerObjectStandAloneRefVector;
+  typedef edm::RefVector<TriggerObjectStandAloneCollection> TriggerObjectStandAloneRefVector;
   /// Const iterator over vector of persistent references to items in the same TriggerObjectStandAloneCollection
-  typedef edm::RefVectorIterator< TriggerObjectStandAloneCollection > TriggerObjectStandAloneRefVectorIterator;
+  typedef edm::RefVectorIterator<TriggerObjectStandAloneCollection> TriggerObjectStandAloneRefVectorIterator;
   /// Association of TriggerObjectStandAlones to store matches to Candidates
-  typedef edm::Association< TriggerObjectStandAloneCollection >       TriggerObjectStandAloneMatch;
+  typedef edm::Association<TriggerObjectStandAloneCollection> TriggerObjectStandAloneMatch;
 
-}
-
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/TriggerPath.h
+++ b/DataFormats/PatCandidates/interface/TriggerPath.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_PatCandidates_TriggerPath_h
 #define DataFormats_PatCandidates_TriggerPath_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatCandidates
@@ -19,7 +18,6 @@
   \author   Volker Adler
 */
 
-
 #include <string>
 #include <vector>
 
@@ -28,139 +26,140 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefVectorIterator.h"
 
-
 namespace pat {
 
   /// Pair to store decision and name of L1 seeds
-  typedef std::pair< bool, std::string > L1Seed;
+  typedef std::pair<bool, std::string> L1Seed;
   /// Collection of L1Seed
-  typedef std::vector< L1Seed >          L1SeedCollection;
+  typedef std::vector<L1Seed> L1SeedCollection;
 
   class TriggerPath {
+    /// Data Members
 
-      /// Data Members
+    /// Path name
+    std::string name_;
+    /// Path index in trigger table
+    unsigned index_;
+    /// Pre-scale
+    unsigned prescale_;
+    /// Was path run?
+    bool run_;
+    /// Did path succeed?
+    bool accept_;
+    /// Was path in error?
+    bool error_;
+    /// List of all module labels in the path
+    /// filled in correct order by PATTriggerProducer;
+    /// modules not necessarily in filter collection;
+    /// consumes disc space
+    std::vector<std::string> modules_;
+    /// Indeces of trigger filters in pat::TriggerFilterCollection in event
+    /// as produced together with the pat::TriggerPathCollection;
+    /// also filled in correct order by PATTriggerProducer;
+    /// indices of active filters in filter collection
+    std::vector<unsigned> filterIndices_;
+    /// Index of the last active filter in the list of modules
+    unsigned lastActiveFilterSlot_;
+    /// Number of modules identified as L3 filters by the 'saveTags' parameter
+    /// available starting from CMSSW_4_2_3
+    unsigned l3Filters_;
+    /// List of L1 seeds and their decisions
+    L1SeedCollection l1Seeds_;
 
-      /// Path name
-      std::string name_;
-      /// Path index in trigger table
-      unsigned index_;
-      /// Pre-scale
-      unsigned prescale_;
-      /// Was path run?
-      bool run_;
-      /// Did path succeed?
-      bool accept_;
-      /// Was path in error?
-      bool error_;
-      /// List of all module labels in the path
-      /// filled in correct order by PATTriggerProducer;
-      /// modules not necessarily in filter collection;
-      /// consumes disc space
-      std::vector< std::string > modules_;
-      /// Indeces of trigger filters in pat::TriggerFilterCollection in event
-      /// as produced together with the pat::TriggerPathCollection;
-      /// also filled in correct order by PATTriggerProducer;
-      /// indices of active filters in filter collection
-      std::vector< unsigned > filterIndices_;
-      /// Index of the last active filter in the list of modules
-      unsigned lastActiveFilterSlot_;
-      /// Number of modules identified as L3 filters by the 'saveTags' parameter
-      /// available starting from CMSSW_4_2_3
-      unsigned l3Filters_;
-      /// List of L1 seeds and their decisions
-      L1SeedCollection l1Seeds_;
+  public:
+    /// Constructors and Desctructor
 
-    public:
+    /// Default constructor
+    TriggerPath();
+    /// Constructor from path name only
+    TriggerPath(const std::string& name);
+    /// Constructor from values
+    TriggerPath(const std::string& name,
+                unsigned index,
+                unsigned prescale,
+                bool run,
+                bool accept,
+                bool error,
+                unsigned lastActiveFilterSlot,
+                unsigned l3Filters = 0);
 
-      /// Constructors and Desctructor
+    /// Destructor
+    virtual ~TriggerPath(){};
 
-      /// Default constructor
-      TriggerPath();
-      /// Constructor from path name only
-      TriggerPath( const std::string & name );
-      /// Constructor from values
-      TriggerPath( const std::string & name, unsigned index, unsigned prescale, bool run, bool accept, bool error, unsigned lastActiveFilterSlot, unsigned l3Filters = 0 );
+    /// Methods
 
-      /// Destructor
-      virtual ~TriggerPath() {};
-
-      /// Methods
-
-      /// Set the path name
-      void setName( const std::string & name ) { name_ = name; };
-      /// Set the path index
-      void setIndex( unsigned index ) { index_ = index; };
-      /// Set the path pre-scale
-      void setPrescale( unsigned prescale ) { prescale_ = prescale; };
-      /// Set the run flag
-      void setRun( bool run ) { run_ = run; };
-      /// Set the success flag
-      void setAccept( bool accept ) { accept_ = accept; };
-      /// Set the error flag
-      void setError( bool error ) { error_ = error; };
-      /// Set the index of the last active filter
-      void setLastActiveFilterSlot( unsigned lastActiveFilterSlot ) { lastActiveFilterSlot_ = lastActiveFilterSlot; };
-      /// Set the number of modules identified as L3 filter
-      void setL3Filters( unsigned l3Filters ) { l3Filters_ = l3Filters; };
-      /// Add a new module label
-      void addModule( const std::string & name ) { modules_.push_back( name ); };
-      /// Add a new trigger fillter collection index
-      void addFilterIndex( const unsigned index ) { filterIndices_.push_back( index ); };
-      /// Add a new L1 seed
-      void addL1Seed( const L1Seed & seed )                           { l1Seeds_.push_back( seed ); };
-      void addL1Seed( bool decision, const std::string & expression ) { l1Seeds_.push_back( L1Seed( decision, expression ) ); };
-      /// Get the path name
-      const std::string & name() const { return name_; };
-      /// Get the path index
-      unsigned index() const { return index_; };
-      /// Get the path pre-scale
-      unsigned prescale() const { return prescale_; };
-      /// Get the run flag
-      bool wasRun() const { return run_; };
-      /// Get the success flag
-      bool wasAccept() const { return accept_; };
-      /// Get the error flag
-      bool wasError() const { return error_; };
-      /// Get the index of the last active filter
-      unsigned lastActiveFilterSlot() const { return lastActiveFilterSlot_; };
-      /// Get the number of modules identified as L3 filter
-      /// available starting from CMSSW_4_2_3
-      unsigned l3Filters() const { return l3Filters_; };
-      /// Determines, if the path is a x-trigger, based on the number of modules identified as L3 filter
-      /// available starting from CMSSW_4_2_3
-      bool xTrigger() const { return ( l3Filters_ > 2 ); };
-      /// Get all module labels
-      const std::vector< std::string > & modules() const { return modules_; };
-      /// Get all trigger fillter collection indeces
-      const std::vector< unsigned > & filterIndices() const { return filterIndices_; };
-      /// Get the index of a certain module;
-      /// returns size of 'modules_' ( modules().size() ) if name is unknown
-      /// and -1 if list of modules is not filled
-      int indexModule( const std::string & name ) const;
-      /// Get all L1 seeds
-      const L1SeedCollection & l1Seeds() const { return l1Seeds_; };
-      /// Get names of all L1 seeds with a certain decision
-      std::vector< std::string > l1Seeds( const bool decision ) const;
-      /// Get names of all succeeding L1 seeds
-      std::vector< std::string > acceptedL1Seeds() const { return l1Seeds( true ); };
-      /// Get names of all failing L1 seeds
-      std::vector< std::string > failedL1Seeds() const { return l1Seeds( false ); };
-
+    /// Set the path name
+    void setName(const std::string& name) { name_ = name; };
+    /// Set the path index
+    void setIndex(unsigned index) { index_ = index; };
+    /// Set the path pre-scale
+    void setPrescale(unsigned prescale) { prescale_ = prescale; };
+    /// Set the run flag
+    void setRun(bool run) { run_ = run; };
+    /// Set the success flag
+    void setAccept(bool accept) { accept_ = accept; };
+    /// Set the error flag
+    void setError(bool error) { error_ = error; };
+    /// Set the index of the last active filter
+    void setLastActiveFilterSlot(unsigned lastActiveFilterSlot) { lastActiveFilterSlot_ = lastActiveFilterSlot; };
+    /// Set the number of modules identified as L3 filter
+    void setL3Filters(unsigned l3Filters) { l3Filters_ = l3Filters; };
+    /// Add a new module label
+    void addModule(const std::string& name) { modules_.push_back(name); };
+    /// Add a new trigger fillter collection index
+    void addFilterIndex(const unsigned index) { filterIndices_.push_back(index); };
+    /// Add a new L1 seed
+    void addL1Seed(const L1Seed& seed) { l1Seeds_.push_back(seed); };
+    void addL1Seed(bool decision, const std::string& expression) { l1Seeds_.push_back(L1Seed(decision, expression)); };
+    /// Get the path name
+    const std::string& name() const { return name_; };
+    /// Get the path index
+    unsigned index() const { return index_; };
+    /// Get the path pre-scale
+    unsigned prescale() const { return prescale_; };
+    /// Get the run flag
+    bool wasRun() const { return run_; };
+    /// Get the success flag
+    bool wasAccept() const { return accept_; };
+    /// Get the error flag
+    bool wasError() const { return error_; };
+    /// Get the index of the last active filter
+    unsigned lastActiveFilterSlot() const { return lastActiveFilterSlot_; };
+    /// Get the number of modules identified as L3 filter
+    /// available starting from CMSSW_4_2_3
+    unsigned l3Filters() const { return l3Filters_; };
+    /// Determines, if the path is a x-trigger, based on the number of modules identified as L3 filter
+    /// available starting from CMSSW_4_2_3
+    bool xTrigger() const { return (l3Filters_ > 2); };
+    /// Get all module labels
+    const std::vector<std::string>& modules() const { return modules_; };
+    /// Get all trigger fillter collection indeces
+    const std::vector<unsigned>& filterIndices() const { return filterIndices_; };
+    /// Get the index of a certain module;
+    /// returns size of 'modules_' ( modules().size() ) if name is unknown
+    /// and -1 if list of modules is not filled
+    int indexModule(const std::string& name) const;
+    /// Get all L1 seeds
+    const L1SeedCollection& l1Seeds() const { return l1Seeds_; };
+    /// Get names of all L1 seeds with a certain decision
+    std::vector<std::string> l1Seeds(const bool decision) const;
+    /// Get names of all succeeding L1 seeds
+    std::vector<std::string> acceptedL1Seeds() const { return l1Seeds(true); };
+    /// Get names of all failing L1 seeds
+    std::vector<std::string> failedL1Seeds() const { return l1Seeds(false); };
   };
 
-
   /// Collection of TriggerPath
-  typedef std::vector< TriggerPath >                      TriggerPathCollection;
+  typedef std::vector<TriggerPath> TriggerPathCollection;
   /// Persistent reference to an item in a TriggerPathCollection
-  typedef edm::Ref< TriggerPathCollection >               TriggerPathRef;
+  typedef edm::Ref<TriggerPathCollection> TriggerPathRef;
   /// Persistent reference to a TriggerPathCollection product
-  typedef edm::RefProd< TriggerPathCollection >           TriggerPathRefProd;
+  typedef edm::RefProd<TriggerPathCollection> TriggerPathRefProd;
   /// Vector of persistent references to items in the same TriggerPathCollection
-  typedef edm::RefVector< TriggerPathCollection >         TriggerPathRefVector;
+  typedef edm::RefVector<TriggerPathCollection> TriggerPathRefVector;
   /// Const iterator over vector of persistent references to items in the same TriggerPathCollection
-  typedef edm::RefVectorIterator< TriggerPathCollection > TriggerPathRefVectorIterator;
+  typedef edm::RefVectorIterator<TriggerPathCollection> TriggerPathRefVectorIterator;
 
-}
-
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/UserData.h
+++ b/DataFormats/PatCandidates/interface/UserData.h
@@ -18,7 +18,6 @@
 #include <typeinfo>
 #include "DataFormats/Common/interface/OwnVector.h"
 
-
 namespace pat {
 
   class UserData {
@@ -27,77 +26,79 @@ namespace pat {
     virtual ~UserData() {}
 
     /// Necessary for deep copy in OwnVector
-    virtual UserData * clone() const = 0;
+    virtual UserData *clone() const = 0;
 
     /// Concrete type of stored data
-    virtual const std::type_info & typeId() const = 0;
+    virtual const std::type_info &typeId() const = 0;
     /// Human readable name of the concrete type of stored data
-    virtual const std::string    & typeName() const = 0;
+    virtual const std::string &typeName() const = 0;
 
     /// Extract data in a typesafe way. <T> must be the *concrete* type of the data.
     /*  I don't think there is an easy way to get it working with generic type T,
         barrying the use of ROOT::Reflex and all the edm::Ptr technicalities.
         I'd say we can live without polymorphic storage of polymorphic data */
-    template<typename T> const T * get() const {
-        if (typeid(T) != typeId()) return nullptr;
-        return static_cast<const T *>(data_());
+    template <typename T>
+    const T *get() const {
+      if (typeid(T) != typeId())
+        return nullptr;
+      return static_cast<const T *>(data_());
     }
 
     /// Get the data as a void *, for CINT usage.
     /// COMPLETELY UNSUPPORTED, USE ONLY FOR DEBUGGING
     //  Really needed for CINT? I would really like to avoid this
-    const void * bareData() const { return data_(); }
+    const void *bareData() const { return data_(); }
 
     /// Make a UserData pointer from some value, wrapping it appropriately.
     /// It will check for dictionaries, unless 'transientOnly' is true
-    template<typename T>
-    static std::unique_ptr<UserData> make(const T &value, bool transientOnly=false) ;
+    template <typename T>
+    static std::unique_ptr<UserData> make(const T &value, bool transientOnly = false);
 
   protected:
     /// Get out the data (can't template non virtual functions)
-    virtual const void * data_  () const = 0;
-    static std::string typeNameFor(std::type_info const& iInfo);
+    virtual const void *data_() const = 0;
+    static std::string typeNameFor(std::type_info const &iInfo);
 
   private:
-    static void checkDictionaries(const std::type_info &type) ;
-    
+    static void checkDictionaries(const std::type_info &type);
   };
 
-  template<typename T>
+  template <typename T>
   class UserHolder : public UserData {
-    public:
-        UserHolder() : obj_() {}
-        UserHolder(const T &data) : obj_(data) {}
-        /// Clone
-        UserHolder<T> * clone() const override { return new UserHolder<T>(*this); }
-        /// Concrete type of stored data
-        const std::type_info & typeId()   const override { return typeid(T); }
-        /// Human readable name of the concrete type of stored data
-        const std::string    & typeName() const override { return typeName_(); }
-    protected:
-        const void *           data_()  const override { return &obj_; }
-    private: 
-        T obj_;
-        static const std::string & typeName_() ;
+  public:
+    UserHolder() : obj_() {}
+    UserHolder(const T &data) : obj_(data) {}
+    /// Clone
+    UserHolder<T> *clone() const override { return new UserHolder<T>(*this); }
+    /// Concrete type of stored data
+    const std::type_info &typeId() const override { return typeid(T); }
+    /// Human readable name of the concrete type of stored data
+    const std::string &typeName() const override { return typeName_(); }
+
+  protected:
+    const void *data_() const override { return &obj_; }
+
+  private:
+    T obj_;
+    static const std::string &typeName_();
   };
 
-  typedef edm::OwnVector<pat::UserData>   UserDataCollection;
-}
+  typedef edm::OwnVector<pat::UserData> UserDataCollection;
+}  // namespace pat
 
-
-template<typename T>
+template <typename T>
 std::unique_ptr<pat::UserData> pat::UserData::make(const T &value, bool transientOnly) {
-    if (!transientOnly) {
-        checkDictionaries(typeid(T));
-        checkDictionaries(typeid(pat::UserHolder<T>));
-    }
-    return std::unique_ptr<UserData>(new pat::UserHolder<T>(value));  
+  if (!transientOnly) {
+    checkDictionaries(typeid(T));
+    checkDictionaries(typeid(pat::UserHolder<T>));
+  }
+  return std::unique_ptr<UserData>(new pat::UserHolder<T>(value));
 }
 
-template<typename T> 
-const std::string & pat::UserHolder<T>::typeName_() {
-    static const std::string name(typeNameFor(typeid(T)));
-    return name;
+template <typename T>
+const std::string &pat::UserHolder<T>::typeName_() {
+  static const std::string name(typeNameFor(typeid(T)));
+  return name;
 }
 
 #endif

--- a/DataFormats/PatCandidates/interface/VIDCutFlowResult.h
+++ b/DataFormats/PatCandidates/interface/VIDCutFlowResult.h
@@ -24,34 +24,35 @@
  *********/
 
 namespace vid {
-  class CutFlowResult {    
-    template<class T> friend class VersionedSelector;
-  public:    
+  class CutFlowResult {
+    template <class T>
+    friend class VersionedSelector;
 
+  public:
     CutFlowResult() : bitmap_(0) {}
     CutFlowResult(const std::string& name,
                   const std::string& hash,
-                  const std::map<std::string,unsigned>& n2idx,                   
+                  const std::map<std::string, unsigned>& n2idx,
                   const std::vector<double>& values,
                   unsigned bitmap,
                   unsigned mask = 0);
 
     // get the original name of this cutflow
-    const std::string& cutFlowName()   const { return name_; }
+    const std::string& cutFlowName() const { return name_; }
     // get the md5 hash for this cutflow
-    const std::string& cutFlowHash()   const { return hash_; }
+    const std::string& cutFlowHash() const { return hash_; }
     // did this cutflow (in its current state!) pass?
-    bool               cutFlowPassed() const { 
+    bool cutFlowPassed() const {
       const unsigned all_pass = (1 << indices_.size()) - 1;
-      return (all_pass&bitmap_) == all_pass; 
-    } 
+      return (all_pass & bitmap_) == all_pass;
+    }
     // how many cuts in this cutflow?
-    size_t             cutFlowSize()   const { return indices_.size(); } 
-    
+    size_t cutFlowSize() const { return indices_.size(); }
+
     // get the name of a cut in the cutflow
     // indexed by order it was executed
     const std::string& getNameAtIndex(const unsigned idx) const;
-    
+
     // get the individual cut result (pass/fail) either by name or by index
     bool getCutResultByIndex(const unsigned idx) const;
     bool getCutResultByName(const std::string& name) const;
@@ -68,7 +69,7 @@ namespace vid {
     // can be done either by name or by index
     CutFlowResult getCutFlowResultMasking(const unsigned idx) const;
     CutFlowResult getCutFlowResultMasking(const std::string& name) const;
-    
+
     CutFlowResult getCutFlowResultMasking(const std::vector<unsigned>& idxs) const;
     CutFlowResult getCutFlowResultMasking(const std::vector<std::string>& names) const;
 
@@ -85,28 +86,15 @@ namespace vid {
                   const std::vector<unsigned>& indices,
                   const std::vector<double>& values,
                   unsigned bitmap,
-                  unsigned mask) :
-      name_(name),
-      hash_(hash),
-      bitmap_(bitmap),
-      mask_(mask),
-      values_(values),
-      names_(names),
-      indices_(indices) {}
-      
+                  unsigned mask)
+        : name_(name), hash_(hash), bitmap_(bitmap), mask_(mask), values_(values), names_(names), indices_(indices) {}
 
-    bool getMaskBit(const unsigned idx) const {
-      return (bool)(0x1&(mask_>>idx));
-    }
+    bool getMaskBit(const unsigned idx) const { return (bool)(0x1 & (mask_ >> idx)); }
 
-    bool getCutBit(const unsigned idx) const { 
-      return (bool)(0x1&(bitmap_>>idx)); 
-    }
+    bool getCutBit(const unsigned idx) const { return (bool)(0x1 & (bitmap_ >> idx)); }
 
-    double getCutValue(const unsigned idx) const {
-      return values_[idx];
-    } 
+    double getCutValue(const unsigned idx) const { return values_[idx]; }
   };
-}
+}  // namespace vid
 
 #endif

--- a/DataFormats/PatCandidates/interface/Vertexing.h
+++ b/DataFormats/PatCandidates/interface/Vertexing.h
@@ -21,78 +21,77 @@
   \author   Giovanni Petrucciani
 */
 
-
 namespace pat {
-    class VertexAssociation {
-        public:
-            //! Create a null vertx association
-            VertexAssociation() {}
-            //! Create a vertex association given a ref to a vertex
-            VertexAssociation(const reco::VertexRef &vertex) : vertex_(vertex) {}
-            //! Create a vertex association given a ref to a vertex and a reference to a track object
-            /// Note: you also have to set the distances, they can be computed by the VertexAssociation itself
-            /// because it requires access to the magnetic field and other condition data.
-            VertexAssociation(const reco::VertexRef &vertex, const reco::TrackBaseRef &tk) : vertex_(vertex), track_(tk) {}
-            // --- Methods to mimick VertexRef
-            //! Return 'true' if this is a null association (that is, no vertex)
-            bool  isNull() const      { return vertex_.isNull(); }
-            //! Return 'true' unless this is a null association (that is, no vertex)
-            bool  isNonnull() const   { return vertex_.isNonnull(); }
-            //! Return 'true' if the reco::Vertex is available in the file, false if it has been dropped.
-            bool  isAvailable() const { return vertex_.isAvailable(); }
-            //! Return the vertex (that is, you can do "const reco::Vertex &vtx = *assoc")
-            const reco::Vertex & operator*()  const { return * operator->(); }
-            //! Allows VertexAssociation to behave like a vertex ref  (e.g. to do "assoc->position()")
-            const reco::Vertex * operator->() const { return vertex_.isNull() ? nullptr : vertex_.get(); }
-            // --- Methods to get the Vertex and track
-            //! Returns the reference to the vertex (can be a null reference)
-            const reco::VertexRef & vertexRef() const  { return vertex_; }
-            //! Returns a pointer to the vertex, or a null pointer if there is no vertex (null association)
-            const reco::Vertex    * vertex()    const  { return vertex_.isNull() ? nullptr : vertex_.get(); }
-            //! Returns 'true' if a reference to a track was stored in this VertexAssociation
-            bool                       hasTrack() const { return !track_.isNull(); }
-            //! Returns a reference to the track stored in this vertex (can be null)
-            const reco::TrackBaseRef & trackRef() const { return track_; }
-            //! Returns a C++ pointer to the track stored in this vertex (can be a null pointer)
-            const reco::Track        * track()    const { return hasTrack() ? track_.get() : nullptr; }
-            // --- Methods to return distances
-            //! Distance between the object and the vertex along the Z axis, and it's error.
-            /// Note 1: if the BeamSpot was used as Vertex, the error includes the BeamSpot spread!
-            const Measurement1DFloat & dz() const { return dz_; }
-            //! Distance between the object and the vertex in the transverse plane, and it's error.
-            const Measurement1DFloat & dr() const { return dr_; }
-            //! True if the transverse distance was computed for this VertexAssociation
-            bool  hasTransverseIP() const { return (dr_.value() != 0); }
-            //! True if the errors on dr and dz have been set, false if they're nulls
-            bool  hasErrors()       const { return (dz_.error() != 0) && ( !hasTransverseIP() || dr_.error() != 0 ); }
-            // ---- Methods to set distances 
-            void setDz(const Measurement1DFloat & dz) { dz_ = dz; }
-            void setDr(const Measurement1DFloat & dr) { dr_ = dr; }
-            void setDz(const Measurement1D & dz)      { dz_ = Measurement1DFloat(dz.value(), dz.error()); }
-            void setDr(const Measurement1D & dr)      { dr_ = Measurement1DFloat(dr.value(), dr.error()); }
-            //! Set dz and dr given the distance and the 3x3 total covariance matrix of the distance
-            void setDistances(const AlgebraicVector3 & dist, const AlgebraicSymMatrix33 &err) ;
-            //! Set dz and dr given the two points (object and vertex) and the 3x3 total covariance matrix of the distance
-            /// The covariance matrix must already include the covariance matrix of the vertex
-            /// 'p1', 'p2' can be anything that has methods .x(), .y(), .z() (e.g. GlobalPoint, Vertex, ...)
-            template<typename T1, typename T2>
-            void setDistances(const T1 & p1, const T2 &p2, const AlgebraicSymMatrix33 &err) {
-                AlgebraicVector3 dist(p1.x() - p2.x(), p1.y() - p2.y(), p1.z() - p2.z());
-                setDistances(dist, err);
-            }
-            // ---- 3D significance of the impact parameter
-            // float signif3d()           const { return signif3d_; }
-            // bool  hasSignif3d()        const { return signif3d_ != 0; }
-            // void setSignif3d(float signif3d) { signif3d_ = signif3d; }
-        private:
-            // basic information
-            reco::VertexRef vertex_;
-            Measurement1DFloat dz_, dr_;
-            // float signif3d_;
-            // extended info
-            reco::TrackBaseRef track_;
-            // fixme: add refitted momentum
-    };
-}
+  class VertexAssociation {
+  public:
+    //! Create a null vertx association
+    VertexAssociation() {}
+    //! Create a vertex association given a ref to a vertex
+    VertexAssociation(const reco::VertexRef &vertex) : vertex_(vertex) {}
+    //! Create a vertex association given a ref to a vertex and a reference to a track object
+    /// Note: you also have to set the distances, they can be computed by the VertexAssociation itself
+    /// because it requires access to the magnetic field and other condition data.
+    VertexAssociation(const reco::VertexRef &vertex, const reco::TrackBaseRef &tk) : vertex_(vertex), track_(tk) {}
+    // --- Methods to mimick VertexRef
+    //! Return 'true' if this is a null association (that is, no vertex)
+    bool isNull() const { return vertex_.isNull(); }
+    //! Return 'true' unless this is a null association (that is, no vertex)
+    bool isNonnull() const { return vertex_.isNonnull(); }
+    //! Return 'true' if the reco::Vertex is available in the file, false if it has been dropped.
+    bool isAvailable() const { return vertex_.isAvailable(); }
+    //! Return the vertex (that is, you can do "const reco::Vertex &vtx = *assoc")
+    const reco::Vertex &operator*() const { return *operator->(); }
+    //! Allows VertexAssociation to behave like a vertex ref  (e.g. to do "assoc->position()")
+    const reco::Vertex *operator->() const { return vertex_.isNull() ? nullptr : vertex_.get(); }
+    // --- Methods to get the Vertex and track
+    //! Returns the reference to the vertex (can be a null reference)
+    const reco::VertexRef &vertexRef() const { return vertex_; }
+    //! Returns a pointer to the vertex, or a null pointer if there is no vertex (null association)
+    const reco::Vertex *vertex() const { return vertex_.isNull() ? nullptr : vertex_.get(); }
+    //! Returns 'true' if a reference to a track was stored in this VertexAssociation
+    bool hasTrack() const { return !track_.isNull(); }
+    //! Returns a reference to the track stored in this vertex (can be null)
+    const reco::TrackBaseRef &trackRef() const { return track_; }
+    //! Returns a C++ pointer to the track stored in this vertex (can be a null pointer)
+    const reco::Track *track() const { return hasTrack() ? track_.get() : nullptr; }
+    // --- Methods to return distances
+    //! Distance between the object and the vertex along the Z axis, and it's error.
+    /// Note 1: if the BeamSpot was used as Vertex, the error includes the BeamSpot spread!
+    const Measurement1DFloat &dz() const { return dz_; }
+    //! Distance between the object and the vertex in the transverse plane, and it's error.
+    const Measurement1DFloat &dr() const { return dr_; }
+    //! True if the transverse distance was computed for this VertexAssociation
+    bool hasTransverseIP() const { return (dr_.value() != 0); }
+    //! True if the errors on dr and dz have been set, false if they're nulls
+    bool hasErrors() const { return (dz_.error() != 0) && (!hasTransverseIP() || dr_.error() != 0); }
+    // ---- Methods to set distances
+    void setDz(const Measurement1DFloat &dz) { dz_ = dz; }
+    void setDr(const Measurement1DFloat &dr) { dr_ = dr; }
+    void setDz(const Measurement1D &dz) { dz_ = Measurement1DFloat(dz.value(), dz.error()); }
+    void setDr(const Measurement1D &dr) { dr_ = Measurement1DFloat(dr.value(), dr.error()); }
+    //! Set dz and dr given the distance and the 3x3 total covariance matrix of the distance
+    void setDistances(const AlgebraicVector3 &dist, const AlgebraicSymMatrix33 &err);
+    //! Set dz and dr given the two points (object and vertex) and the 3x3 total covariance matrix of the distance
+    /// The covariance matrix must already include the covariance matrix of the vertex
+    /// 'p1', 'p2' can be anything that has methods .x(), .y(), .z() (e.g. GlobalPoint, Vertex, ...)
+    template <typename T1, typename T2>
+    void setDistances(const T1 &p1, const T2 &p2, const AlgebraicSymMatrix33 &err) {
+      AlgebraicVector3 dist(p1.x() - p2.x(), p1.y() - p2.y(), p1.z() - p2.z());
+      setDistances(dist, err);
+    }
+    // ---- 3D significance of the impact parameter
+    // float signif3d()           const { return signif3d_; }
+    // bool  hasSignif3d()        const { return signif3d_ != 0; }
+    // void setSignif3d(float signif3d) { signif3d_ = signif3d; }
+  private:
+    // basic information
+    reco::VertexRef vertex_;
+    Measurement1DFloat dz_, dr_;
+    // float signif3d_;
+    // extended info
+    reco::TrackBaseRef track_;
+    // fixme: add refitted momentum
+  };
+}  // namespace pat
 
 #endif

--- a/DataFormats/PatCandidates/interface/ioread_packedgen.h
+++ b/DataFormats/PatCandidates/interface/ioread_packedgen.h
@@ -1,12 +1,10 @@
 #include "DataFormats/Math/interface/libminifloat.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
-int16_t convertPackedEtaToPackedY(int16_t packedPt_, int16_t packedEta_,int16_t packedM_)
-{
- reco::Candidate::PolarLorentzVector p4(MiniFloatConverter::float16to32(packedPt_),
-                         int16_t(packedEta_)*6.0f/std::numeric_limits<int16_t>::max(),
-                         0,
-                         MiniFloatConverter::float16to32(packedM_));
+int16_t convertPackedEtaToPackedY(int16_t packedPt_, int16_t packedEta_, int16_t packedM_) {
+  reco::Candidate::PolarLorentzVector p4(MiniFloatConverter::float16to32(packedPt_),
+                                         int16_t(packedEta_) * 6.0f / std::numeric_limits<int16_t>::max(),
+                                         0,
+                                         MiniFloatConverter::float16to32(packedM_));
 
- return int16_t(p4.Rapidity()/6.0f*std::numeric_limits<int16_t>::max());
+  return int16_t(p4.Rapidity() / 6.0f * std::numeric_limits<int16_t>::max());
 }
-

--- a/DataFormats/PatCandidates/interface/throwMissingLabel.h
+++ b/DataFormats/PatCandidates/interface/throwMissingLabel.h
@@ -5,7 +5,8 @@
 #include <vector>
 
 namespace pat {
-  void throwMissingLabel(const std::string& what, const std::string& bad_label, 
+  void throwMissingLabel(const std::string& what,
+                         const std::string& bad_label,
                          const std::vector<std::string>& available);
 }
 

--- a/DataFormats/PatCandidates/src/CandKinResolution.cc
+++ b/DataFormats/PatCandidates/src/CandKinResolution.cc
@@ -2,117 +2,92 @@
 #include <DataFormats/PatCandidates/interface/ResolutionHelper.h>
 #include <DataFormats/PatCandidates/interface/ParametrizationHelper.h>
 
+pat::CandKinResolution::CandKinResolution() : parametrization_(Invalid), covariances_(), constraints_(), covmatrix_() {}
 
-pat::CandKinResolution::CandKinResolution() : 
-    parametrization_(Invalid), 
-    covariances_(),
-    constraints_(),
-    covmatrix_() 
-{ 
-}
-
-pat::CandKinResolution::CandKinResolution(Parametrization parametrization, const std::vector<Scalar> &covariances, const std::vector<Scalar> &constraints) :
-    parametrization_(parametrization),
-    covariances_(covariances), 
-    constraints_(constraints),
-    covmatrix_()
-{
-    fillMatrix();
+pat::CandKinResolution::CandKinResolution(Parametrization parametrization,
+                                          const std::vector<Scalar> &covariances,
+                                          const std::vector<Scalar> &constraints)
+    : parametrization_(parametrization), covariances_(covariances), constraints_(constraints), covmatrix_() {
+  fillMatrix();
 }
 
-pat::CandKinResolution::CandKinResolution(Parametrization parametrization, const AlgebraicSymMatrix44 &covariance, const std::vector<Scalar> &constraints) :
-    parametrization_(parametrization),
-    covariances_(), 
-    constraints_(constraints),
-    covmatrix_(covariance)
-{
-    fillVector();
-    if (sizeof(double) != sizeof(Scalar)) { // should become boost::mpl::if_c
-        fillMatrix(); // forcing double => float => double conversion 
-    }
+pat::CandKinResolution::CandKinResolution(Parametrization parametrization,
+                                          const AlgebraicSymMatrix44 &covariance,
+                                          const std::vector<Scalar> &constraints)
+    : parametrization_(parametrization), covariances_(), constraints_(constraints), covmatrix_(covariance) {
+  fillVector();
+  if (sizeof(double) != sizeof(Scalar)) {  // should become boost::mpl::if_c
+    fillMatrix();                          // forcing double => float => double conversion
+  }
 }
 
-pat::CandKinResolution::~CandKinResolution() {
+pat::CandKinResolution::~CandKinResolution() {}
+
+double pat::CandKinResolution::resolEta(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolEta(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolTheta(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolTheta(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolPhi(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolPhi(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolE(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolE(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolEt(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolEt(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolM(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolM(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolP(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolP(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolPt(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolPt(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolPInv(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolPInv(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolPx(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolPx(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolPy(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolPy(parametrization_, covmatrix_, p4);
+}
+double pat::CandKinResolution::resolPz(const pat::CandKinResolution::LorentzVector &p4) const {
+  return pat::helper::ResolutionHelper::getResolPz(parametrization_, covmatrix_, p4);
 }
 
-double pat::CandKinResolution::resolEta(const pat::CandKinResolution::LorentzVector &p4)   const
-{
-    return pat::helper::ResolutionHelper::getResolEta(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolTheta(const pat::CandKinResolution::LorentzVector &p4) const
-{
-    return pat::helper::ResolutionHelper::getResolTheta(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolPhi(const pat::CandKinResolution::LorentzVector &p4)   const
-{
-    return pat::helper::ResolutionHelper::getResolPhi(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolE(const pat::CandKinResolution::LorentzVector &p4)     const
-{
-    return pat::helper::ResolutionHelper::getResolE(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolEt(const pat::CandKinResolution::LorentzVector &p4)    const
-{
-    return pat::helper::ResolutionHelper::getResolEt(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolM(const pat::CandKinResolution::LorentzVector &p4)     const
-{
-    return pat::helper::ResolutionHelper::getResolM(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolP(const pat::CandKinResolution::LorentzVector &p4)     const
-{
-    return pat::helper::ResolutionHelper::getResolP(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolPt(const pat::CandKinResolution::LorentzVector &p4)    const
-{
-    return pat::helper::ResolutionHelper::getResolPt(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolPInv(const pat::CandKinResolution::LorentzVector &p4)  const
-{
-    return pat::helper::ResolutionHelper::getResolPInv(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolPx(const pat::CandKinResolution::LorentzVector &p4)    const
-{
-    return pat::helper::ResolutionHelper::getResolPx(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolPy(const pat::CandKinResolution::LorentzVector &p4)    const
-{
-    return pat::helper::ResolutionHelper::getResolPy(parametrization_, covmatrix_, p4);
-}
-double pat::CandKinResolution::resolPz(const pat::CandKinResolution::LorentzVector &p4)    const
-{
-    return pat::helper::ResolutionHelper::getResolPz(parametrization_, covmatrix_, p4);
+void pat::CandKinResolution::fillVector() {
+  if (dimension() == 3) {
+    AlgebraicSymMatrix33 sub = covmatrix_.Sub<AlgebraicSymMatrix33>(0, 0);
+    covariances_.insert(covariances_.end(), sub.begin(), sub.end());
+  } else {
+    covariances_.insert(covariances_.end(), covmatrix_.begin(), covmatrix_.end());
+  }
 }
 
-void pat::CandKinResolution::fillVector() { 
-    if (dimension() == 3) {
-        AlgebraicSymMatrix33 sub = covmatrix_.Sub<AlgebraicSymMatrix33>(0,0);
-        covariances_.insert(covariances_.end(), sub.begin(), sub.end());
+void pat::CandKinResolution::fillMatrixFrom(Parametrization parametrization,
+                                            const std::vector<Scalar> &covariances,
+                                            AlgebraicSymMatrix44 &covmatrix) {
+  int dimension = dimensionFrom(parametrization);
+  if (dimension == 3) {
+    if (covariances.size() == 3) {
+      for (int i = 0; i < 3; ++i)
+        covmatrix(i, i) = covariances[i];
     } else {
-        covariances_.insert(covariances_.end(), covmatrix_.begin(), covmatrix_.end());
+      covmatrix.Place_at(AlgebraicSymMatrix33(covariances.begin(), covariances.end()), 0, 0);
     }
-}
-
-void pat::CandKinResolution::fillMatrixFrom(Parametrization parametrization, 
-                                            const std::vector<Scalar>& covariances,
-                                            AlgebraicSymMatrix44& covmatrix) { 
-    int dimension = dimensionFrom(parametrization);
-    if (dimension == 3) {
-        if (covariances.size() == 3) {
-            for (int i = 0; i < 3; ++i) covmatrix(i,i) = covariances[i];
-        } else {
-            covmatrix.Place_at(AlgebraicSymMatrix33(covariances.begin(), covariances.end()), 0, 0);
-        }
-    } else if (dimension == 4) {
-        if (covariances.size() == 4) {
-            for (int i = 0; i < 4; ++i) covmatrix(i,i) = covariances[i];
-        } else {
-            covmatrix = AlgebraicSymMatrix44(covariances.begin(), covariances.end());
-        }
+  } else if (dimension == 4) {
+    if (covariances.size() == 4) {
+      for (int i = 0; i < 4; ++i)
+        covmatrix(i, i) = covariances[i];
+    } else {
+      covmatrix = AlgebraicSymMatrix44(covariances.begin(), covariances.end());
     }
+  }
 }
 
-
-void pat::CandKinResolution::fillMatrix() { 
-    fillMatrixFrom(parametrization_, covariances_, covmatrix_);
-}
+void pat::CandKinResolution::fillMatrix() { fillMatrixFrom(parametrization_, covariances_, covmatrix_); }

--- a/DataFormats/PatCandidates/src/CompositeCandidate.cc
+++ b/DataFormats/PatCandidates/src/CompositeCandidate.cc
@@ -3,22 +3,16 @@
 
 #include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
 
-
 using namespace pat;
 
-
 /// default constructor
-CompositeCandidate::CompositeCandidate() : 
-  PATObject<reco::CompositeCandidate>(reco::CompositeCandidate(0, reco::CompositeCandidate::LorentzVector(0, 0, 0, 0), reco::CompositeCandidate::Point(0,0,0))) {
-}
-
+CompositeCandidate::CompositeCandidate()
+    : PATObject<reco::CompositeCandidate>(reco::CompositeCandidate(
+          0, reco::CompositeCandidate::LorentzVector(0, 0, 0, 0), reco::CompositeCandidate::Point(0, 0, 0))) {}
 
 /// constructor from CompositeCandidateType
-CompositeCandidate::CompositeCandidate(const reco::CompositeCandidate & aCompositeCandidate) : 
-  PATObject<reco::CompositeCandidate>(aCompositeCandidate) {
-}
-
+CompositeCandidate::CompositeCandidate(const reco::CompositeCandidate& aCompositeCandidate)
+    : PATObject<reco::CompositeCandidate>(aCompositeCandidate) {}
 
 /// destructor
-CompositeCandidate::~CompositeCandidate() {
-}
+CompositeCandidate::~CompositeCandidate() {}

--- a/DataFormats/PatCandidates/src/Conversion.cc
+++ b/DataFormats/PatCandidates/src/Conversion.cc
@@ -3,23 +3,10 @@
 
 using namespace pat;
 
-Conversion::Conversion( int index):
-vtxProb_(0.0),
-lxy_(0.0),
-nHitsMax_(0)
-{
-  index_ = index;
-}
+Conversion::Conversion(int index) : vtxProb_(0.0), lxy_(0.0), nHitsMax_(0) { index_ = index; }
 
-void Conversion::setVtxProb( double vtxProb ){
-  vtxProb_ = vtxProb;
-}
+void Conversion::setVtxProb(double vtxProb) { vtxProb_ = vtxProb; }
 
-void Conversion::setLxy( double lxy ){
-  lxy_ = lxy;
-}
+void Conversion::setLxy(double lxy) { lxy_ = lxy; }
 
-void Conversion::setNHitsMax( int nHitsMax ){
-  nHitsMax_ = nHitsMax;
-}
-
+void Conversion::setNHitsMax(int nHitsMax) { nHitsMax_ = nHitsMax; }

--- a/DataFormats/PatCandidates/src/CovarianceParameterization.cc
+++ b/DataFormats/PatCandidates/src/CovarianceParameterization.cc
@@ -8,207 +8,200 @@
 #include <TVector.h>
 #include <TFolder.h>
 
-uint16_t CompressionElement::pack(float value, float ref) const
-{
-    float toCompress=0;
-    switch(target) {
-        case(realValue):
-          toCompress=value;
-          break;
-        case(ratioToRef):
-          toCompress=value/ref;
-          break;
-        case(differenceToRef):
-          toCompress=value-ref;
-          break;
-    }
-    switch(method) {
-        case(float16):
-          return MiniFloatConverter::float32to16(toCompress*params[0]);
-          break;
-        case(reduceMantissa):
-          return MiniFloatConverter::reduceMantissaToNbits(toCompress,params[0]);
-          break;
-        case(zero):
-          return 0;
-          break;
-        case(one):
-          return 1.0;
-          break;
-        case(tanLogPack):
-          return 0; //FIXME: should be implemented
-          break;
-        case(logPack):
-          int16_t r=logintpack::pack16log(toCompress,params[0],params[1],bits);
-          return * reinterpret_cast<uint16_t *>(&r); 
-          break;
-      
-    }
+uint16_t CompressionElement::pack(float value, float ref) const {
+  float toCompress = 0;
+  switch (target) {
+    case (realValue):
+      toCompress = value;
+      break;
+    case (ratioToRef):
+      toCompress = value / ref;
+      break;
+    case (differenceToRef):
+      toCompress = value - ref;
+      break;
+  }
+  switch (method) {
+    case (float16):
+      return MiniFloatConverter::float32to16(toCompress * params[0]);
+      break;
+    case (reduceMantissa):
+      return MiniFloatConverter::reduceMantissaToNbits(toCompress, params[0]);
+      break;
+    case (zero):
+      return 0;
+      break;
+    case (one):
+      return 1.0;
+      break;
+    case (tanLogPack):
+      return 0;  //FIXME: should be implemented
+      break;
+    case (logPack):
+      int16_t r = logintpack::pack16log(toCompress, params[0], params[1], bits);
+      return *reinterpret_cast<uint16_t *>(&r);
+      break;
+  }
   return 0;
 }
-float CompressionElement::unpack(uint16_t packed, float ref) const
-{
-    float unpacked=0;
-    switch(method) {
-        case(float16):
-          unpacked= MiniFloatConverter::float16to32(packed)/params[0];
-          break;
-        case(reduceMantissa):
-          unpacked=packed;
-          break;
-        case(logPack):
-          unpacked=logintpack::unpack16log(* reinterpret_cast<int16_t *>(&packed),params[0],params[1],bits);
-          break;
-        case(zero):
-          unpacked=0;
-          break;
-        case(one):
-        case(tanLogPack):
-          unpacked=1; //FIXME: should be implemented
-    }
-    switch(target) {
-        case(realValue):
-          return unpacked;
-        case(ratioToRef):
-          return unpacked*ref;
-        case(differenceToRef):
-          return unpacked+ref;
-    }
+float CompressionElement::unpack(uint16_t packed, float ref) const {
+  float unpacked = 0;
+  switch (method) {
+    case (float16):
+      unpacked = MiniFloatConverter::float16to32(packed) / params[0];
+      break;
+    case (reduceMantissa):
+      unpacked = packed;
+      break;
+    case (logPack):
+      unpacked = logintpack::unpack16log(*reinterpret_cast<int16_t *>(&packed), params[0], params[1], bits);
+      break;
+    case (zero):
+      unpacked = 0;
+      break;
+    case (one):
+    case (tanLogPack):
+      unpacked = 1;  //FIXME: should be implemented
+  }
+  switch (target) {
+    case (realValue):
+      return unpacked;
+    case (ratioToRef):
+      return unpacked * ref;
+    case (differenceToRef):
+      return unpacked + ref;
+  }
 
-    return ref;
-  
+  return ref;
 }
 
+void CovarianceParameterization::load(int version) {
+  edm::FileInPath fip(
+      (boost::format("DataFormats/PatCandidates/data/CovarianceParameterization_version%d.root") % version).str());
+  fileToRead_ = TFile::Open(fip.fullPath().c_str());
+  TFile &fileToRead = *fileToRead_;
+  //Read files from here fip.fullPath().c_str();
+  if (fileToRead.IsOpen()) {
+    readFile(fileToRead);
 
-
-
-
-
-void CovarianceParameterization::load(int version)
-{
- edm::FileInPath fip((boost::format("DataFormats/PatCandidates/data/CovarianceParameterization_version%d.root") % version).str());
- fileToRead_ = TFile::Open(fip.fullPath().c_str()); 
- TFile & fileToRead=*fileToRead_;
-//Read files from here fip.fullPath().c_str();
- if(fileToRead.IsOpen())  {
-     readFile(fileToRead);
-
-     TIter next(((TDirectoryFile*)fileToRead.Get("schemas"))->GetListOfKeys());
-     TKey *key;
-     while ((key = (TKey*)next())) {
+    TIter next(((TDirectoryFile *)fileToRead.Get("schemas"))->GetListOfKeys());
+    TKey *key;
+    while ((key = (TKey *)next())) {
       TClass *cl = gROOT->GetClass(key->GetClassName());
-      if (!cl->InheritsFrom("TDirectoryFile")) continue;
+      if (!cl->InheritsFrom("TDirectoryFile"))
+        continue;
       std::string schemaNumber = key->ReadObj()->GetName();
       uint16_t schemaN = std::stoi(schemaNumber);
-     //for (int folderNumber = 0; folderNumber < 6 ; folderNumber++) {
-      CompressionSchema schema; 
+      //for (int folderNumber = 0; folderNumber < 6 ; folderNumber++) {
+      CompressionSchema schema;
       for (int i = 0; i < 5; i++) {
-            for (int j = i; j < 5; j++) {        //FILLING ONLY THE SCHEMA OF SOME ELEMENTS
-                  std::string folder = "schemas/" + schemaNumber + "/"  + char(48+i) + char(48+j);
-                std::string methodString = folder + "/method";
-                std::string targetString = folder + "/target";
-                std::string bitString = folder + "/bit";
-                std::vector<float> vParams ;
-                TVector *p=(TVector*) fileToRead.Get((folder+"/param").c_str());
-                for(int k = 0 ; k < p->GetNoElements() ; k++){
-                    vParams.push_back((*p)[k]);
-                }
+        for (int j = i; j < 5; j++) {  //FILLING ONLY THE SCHEMA OF SOME ELEMENTS
+          std::string folder = "schemas/" + schemaNumber + "/" + char(48 + i) + char(48 + j);
+          std::string methodString = folder + "/method";
+          std::string targetString = folder + "/target";
+          std::string bitString = folder + "/bit";
+          std::vector<float> vParams;
+          TVector *p = (TVector *)fileToRead.Get((folder + "/param").c_str());
+          for (int k = 0; k < p->GetNoElements(); k++) {
+            vParams.push_back((*p)[k]);
+          }
 
-                schema(i,j)=CompressionElement((CompressionElement::Method) ((TParameter<int>*) fileToRead.Get(methodString.c_str()))->GetVal(),
-		(CompressionElement::Target) ((TParameter<int>*) fileToRead.Get(targetString.c_str()))->GetVal(),
-		 (int) ((TParameter<int>*) fileToRead.Get(bitString.c_str()))->GetVal(), vParams);
-        
-                
-            }
+          schema(i, j) = CompressionElement(
+              (CompressionElement::Method)((TParameter<int> *)fileToRead.Get(methodString.c_str()))->GetVal(),
+              (CompressionElement::Target)((TParameter<int> *)fileToRead.Get(targetString.c_str()))->GetVal(),
+              (int)((TParameter<int> *)fileToRead.Get(bitString.c_str()))->GetVal(),
+              vParams);
         }
-     schemas[schemaN]=schema; 
-     }
-
-    loadedVersion_=version; 
- } else {loadedVersion_=-1;}
-
-}
-
-
-
-void CovarianceParameterization::readFile( TFile & f) {
-
-    for (int i = 0; i < 5; i++) {
-        for (int j = i; j < 5; j++) {
-
-            std::string String_first_positive = "_pixel_";
-            std::string String_second_positive = "_noPixel_";
-
-            addTheHistogram(&cov_elements_pixelHit, String_first_positive, i, j,f);
-            addTheHistogram(&cov_elements_noPixelHit, String_second_positive, i, j,f);
-
-
-        }
-    }
-}
-
-
-void CovarianceParameterization::addTheHistogram(std::vector<TH3D *> * HistoVector, std::string StringToAddInTheName, int i, int j,  TFile & fileToRead) {
-
-    std::string  List_covName[5] = {"qoverp", "lambda", "phi", "dxy", "dsz"};
-
-    std::string histoNameString = "covariance_" + List_covName[i] + "_" + List_covName[j] + StringToAddInTheName+"parametrization" ;// + "_entries";
-    TH3D * matrixElememtHistogramm = (TH3D*) fileToRead.Get(histoNameString.c_str());
-    HistoVector->push_back(matrixElememtHistogramm);
-}
-
-
-
-float CovarianceParameterization::meanValue(int i,int j,int sign,float pt, float eta, int nHits,int pixelHits,  float cii,float cjj) const {
-    int hitNumberToUse = nHits;
-    if (hitNumberToUse < 2 ) hitNumberToUse = 2;
-    if (hitNumberToUse > 32 ) hitNumberToUse = 32;
-    int  ptBin = cov_elements_pixelHit[0]->GetXaxis()->FindBin(pt);
-    int etaBin = cov_elements_pixelHit[0]->GetYaxis()->FindBin(std::abs(eta));
-    int hitBin = cov_elements_pixelHit[0]->GetZaxis()->FindBin(hitNumberToUse);
-    int min_idx = i;
-    int max_idx = j;
-
-    if (i>j) {
-        min_idx = j;
-        max_idx = i;
+      }
+      schemas[schemaN] = schema;
     }
 
-    int indexOfTheHitogramInTheList = ((9 - min_idx)*min_idx)/2 + max_idx;
-
-    double meanValue = 0.;
-    if (pixelHits > 0) {
-            meanValue =sign* cov_elements_pixelHit[indexOfTheHitogramInTheList]->GetBinContent(ptBin, etaBin, hitBin);
-        }
-        else {
-            meanValue = sign*cov_elements_noPixelHit[indexOfTheHitogramInTheList]->GetBinContent(ptBin, etaBin, hitBin);
-        }
-    return meanValue;
-
+    loadedVersion_ = version;
+  } else {
+    loadedVersion_ = -1;
+  }
 }
 
-float CovarianceParameterization::pack(float value, int schema, int i,int j,float pt, float eta, int nHits,int pixelHits,  float cii,float cjj) const {
-    if(i>j) std::swap(i,j);
-    float ref=meanValue(i,j,1.,pt,eta,nHits,pixelHits,cii,cjj);
-    if(ref==0) {
-      schema=0;
+void CovarianceParameterization::readFile(TFile &f) {
+  for (int i = 0; i < 5; i++) {
+    for (int j = i; j < 5; j++) {
+      std::string String_first_positive = "_pixel_";
+      std::string String_second_positive = "_noPixel_";
+
+      addTheHistogram(&cov_elements_pixelHit, String_first_positive, i, j, f);
+      addTheHistogram(&cov_elements_noPixelHit, String_second_positive, i, j, f);
     }
-    if(schema==0 && i==j && (i==2 || i==0) ) ref=1./(pt*pt);
-/*  //Used for debugging, to be later removed  
+  }
+}
+
+void CovarianceParameterization::addTheHistogram(
+    std::vector<TH3D *> *HistoVector, std::string StringToAddInTheName, int i, int j, TFile &fileToRead) {
+  std::string List_covName[5] = {"qoverp", "lambda", "phi", "dxy", "dsz"};
+
+  std::string histoNameString = "covariance_" + List_covName[i] + "_" + List_covName[j] + StringToAddInTheName +
+                                "parametrization";  // + "_entries";
+  TH3D *matrixElememtHistogramm = (TH3D *)fileToRead.Get(histoNameString.c_str());
+  HistoVector->push_back(matrixElememtHistogramm);
+}
+
+float CovarianceParameterization::meanValue(
+    int i, int j, int sign, float pt, float eta, int nHits, int pixelHits, float cii, float cjj) const {
+  int hitNumberToUse = nHits;
+  if (hitNumberToUse < 2)
+    hitNumberToUse = 2;
+  if (hitNumberToUse > 32)
+    hitNumberToUse = 32;
+  int ptBin = cov_elements_pixelHit[0]->GetXaxis()->FindBin(pt);
+  int etaBin = cov_elements_pixelHit[0]->GetYaxis()->FindBin(std::abs(eta));
+  int hitBin = cov_elements_pixelHit[0]->GetZaxis()->FindBin(hitNumberToUse);
+  int min_idx = i;
+  int max_idx = j;
+
+  if (i > j) {
+    min_idx = j;
+    max_idx = i;
+  }
+
+  int indexOfTheHitogramInTheList = ((9 - min_idx) * min_idx) / 2 + max_idx;
+
+  double meanValue = 0.;
+  if (pixelHits > 0) {
+    meanValue = sign * cov_elements_pixelHit[indexOfTheHitogramInTheList]->GetBinContent(ptBin, etaBin, hitBin);
+  } else {
+    meanValue = sign * cov_elements_noPixelHit[indexOfTheHitogramInTheList]->GetBinContent(ptBin, etaBin, hitBin);
+  }
+  return meanValue;
+}
+
+float CovarianceParameterization::pack(
+    float value, int schema, int i, int j, float pt, float eta, int nHits, int pixelHits, float cii, float cjj) const {
+  if (i > j)
+    std::swap(i, j);
+  float ref = meanValue(i, j, 1., pt, eta, nHits, pixelHits, cii, cjj);
+  if (ref == 0) {
+    schema = 0;
+  }
+  if (schema == 0 && i == j && (i == 2 || i == 0))
+    ref = 1. / (pt * pt);
+  /*  //Used for debugging, to be later removed  
     uint16_t p=(*schemas.find(schema)).second(i,j).pack(value,ref);
     float up=(*schemas.find(schema)).second(i,j).unpack(p,ref);
     std::cout << "check " << i << " " << j << " " << value << " " << up << " " << p << " " << ref << " " << schema<< std::endl;*/
-    return (*schemas.find(schema)).second(i,j).pack(value,ref);
+  return (*schemas.find(schema)).second(i, j).pack(value, ref);
 }
-float CovarianceParameterization::unpack(uint16_t packed, int schema, int i,int j,float pt, float eta, int nHits,int pixelHits,  float cii,float cjj) const {
-    if(i>j) std::swap(i,j);
-    float ref=meanValue(i,j,1.,pt,eta,nHits,pixelHits,cii,cjj);
-    if(ref==0) {
-      schema=0;
-    }
-    if(schema==0 && i==j && (i==2 || i==0) ) ref=1./(pt*pt);
-    if(i==j && (*schemas.find(schema)).second(i,j).unpack(packed,ref)==0) return 1e-9;
-    else
-    return (*schemas.find(schema)).second(i,j).unpack(packed,ref);
- 
+float CovarianceParameterization::unpack(
+    uint16_t packed, int schema, int i, int j, float pt, float eta, int nHits, int pixelHits, float cii, float cjj)
+    const {
+  if (i > j)
+    std::swap(i, j);
+  float ref = meanValue(i, j, 1., pt, eta, nHits, pixelHits, cii, cjj);
+  if (ref == 0) {
+    schema = 0;
+  }
+  if (schema == 0 && i == j && (i == 2 || i == 0))
+    ref = 1. / (pt * pt);
+  if (i == j && (*schemas.find(schema)).second(i, j).unpack(packed, ref) == 0)
+    return 1e-9;
+  else
+    return (*schemas.find(schema)).second(i, j).unpack(packed, ref);
 }

--- a/DataFormats/PatCandidates/src/Electron.cc
+++ b/DataFormats/PatCandidates/src/Electron.cc
@@ -10,110 +10,99 @@
 using namespace pat;
 
 /// default constructor
-Electron::Electron() :
-    Lepton<reco::GsfElectron>(),
-    embeddedGsfElectronCore_(false),
-    embeddedGsfTrack_(false),
-    embeddedSuperCluster_(false),
-    embeddedPflowSuperCluster_(false),
-    embeddedTrack_(false),
-    embeddedSeedCluster_(false),
-    embeddedRecHits_(false),
-    embeddedPFCandidate_(false),
-    ecalDrivenMomentum_(Candidate::LorentzVector(0.,0.,0.,0.)),
-    ecalRegressionEnergy_(0.0),
-    ecalTrackRegressionEnergy_(0.0),
-    ecalRegressionError_(0.0),
-    ecalTrackRegressionError_(0.0),
-    ecalScale_(-99999.),
-    ecalSmear_(-99999.),
-    ecalRegressionScale_(-99999.),
-    ecalRegressionSmear_(-99999.),
-    ecalTrackRegressionScale_(-99999.),
-    ecalTrackRegressionSmear_(-99999.),
-    packedPFCandidates_(),
-    associatedPackedFCandidateIndices_()
-{
+Electron::Electron()
+    : Lepton<reco::GsfElectron>(),
+      embeddedGsfElectronCore_(false),
+      embeddedGsfTrack_(false),
+      embeddedSuperCluster_(false),
+      embeddedPflowSuperCluster_(false),
+      embeddedTrack_(false),
+      embeddedSeedCluster_(false),
+      embeddedRecHits_(false),
+      embeddedPFCandidate_(false),
+      ecalDrivenMomentum_(Candidate::LorentzVector(0., 0., 0., 0.)),
+      ecalRegressionEnergy_(0.0),
+      ecalTrackRegressionEnergy_(0.0),
+      ecalRegressionError_(0.0),
+      ecalTrackRegressionError_(0.0),
+      ecalScale_(-99999.),
+      ecalSmear_(-99999.),
+      ecalRegressionScale_(-99999.),
+      ecalRegressionSmear_(-99999.),
+      ecalTrackRegressionScale_(-99999.),
+      ecalTrackRegressionSmear_(-99999.),
+      packedPFCandidates_(),
+      associatedPackedFCandidateIndices_() {
   initImpactParameters();
 }
 
 /// constructor from reco::GsfElectron
-Electron::Electron(const reco::GsfElectron & anElectron) :
-    Lepton<reco::GsfElectron>(anElectron),
-    embeddedGsfElectronCore_(false),
-    embeddedGsfTrack_(false),
-    embeddedSuperCluster_(false),
-    embeddedPflowSuperCluster_(false),
-    embeddedTrack_(false),
-    embeddedSeedCluster_(false),
-    embeddedRecHits_(false),
-    embeddedPFCandidate_(false),
-    ecalDrivenMomentum_(anElectron.p4())
-{
+Electron::Electron(const reco::GsfElectron& anElectron)
+    : Lepton<reco::GsfElectron>(anElectron),
+      embeddedGsfElectronCore_(false),
+      embeddedGsfTrack_(false),
+      embeddedSuperCluster_(false),
+      embeddedPflowSuperCluster_(false),
+      embeddedTrack_(false),
+      embeddedSeedCluster_(false),
+      embeddedRecHits_(false),
+      embeddedPFCandidate_(false),
+      ecalDrivenMomentum_(anElectron.p4()) {
   initImpactParameters();
 }
 
 /// constructor from a RefToBase to a reco::GsfElectron (to be superseded by Ptr counterpart)
-Electron::Electron(const edm::RefToBase<reco::GsfElectron> & anElectronRef) :
-    Lepton<reco::GsfElectron>(anElectronRef),
-    embeddedGsfElectronCore_(false),
-    embeddedGsfTrack_(false),
-    embeddedSuperCluster_(false),
-    embeddedPflowSuperCluster_(false),
-    embeddedTrack_(false), 
-    embeddedSeedCluster_(false),
-    embeddedRecHits_(false),
-    embeddedPFCandidate_(false),
-    ecalDrivenMomentum_(anElectronRef->p4())
-{
+Electron::Electron(const edm::RefToBase<reco::GsfElectron>& anElectronRef)
+    : Lepton<reco::GsfElectron>(anElectronRef),
+      embeddedGsfElectronCore_(false),
+      embeddedGsfTrack_(false),
+      embeddedSuperCluster_(false),
+      embeddedPflowSuperCluster_(false),
+      embeddedTrack_(false),
+      embeddedSeedCluster_(false),
+      embeddedRecHits_(false),
+      embeddedPFCandidate_(false),
+      ecalDrivenMomentum_(anElectronRef->p4()) {
   initImpactParameters();
 }
 
 /// constructor from a Ptr to a reco::GsfElectron
-Electron::Electron(const edm::Ptr<reco::GsfElectron> & anElectronRef) :
-    Lepton<reco::GsfElectron>(anElectronRef),
-    embeddedGsfElectronCore_(false),
-    embeddedGsfTrack_(false),
-    embeddedSuperCluster_(false),
-    embeddedPflowSuperCluster_(false),
-    embeddedTrack_(false),
-    embeddedSeedCluster_(false),
-    embeddedRecHits_(false),
-    embeddedPFCandidate_(false),
-    ecalDrivenMomentum_(anElectronRef->p4())
-{
+Electron::Electron(const edm::Ptr<reco::GsfElectron>& anElectronRef)
+    : Lepton<reco::GsfElectron>(anElectronRef),
+      embeddedGsfElectronCore_(false),
+      embeddedGsfTrack_(false),
+      embeddedSuperCluster_(false),
+      embeddedPflowSuperCluster_(false),
+      embeddedTrack_(false),
+      embeddedSeedCluster_(false),
+      embeddedRecHits_(false),
+      embeddedPFCandidate_(false),
+      ecalDrivenMomentum_(anElectronRef->p4()) {
   initImpactParameters();
 }
 
 /// destructor
-Electron::~Electron() {
-}
+Electron::~Electron() {}
 
 /// pipe operator (introduced to use pat::Electron with PFTopProjectors)
-std::ostream& 
-reco::operator<<(std::ostream& out, const pat::Electron& obj) 
-{
-  if(!out) return out;
-  
+std::ostream& reco::operator<<(std::ostream& out, const pat::Electron& obj) {
+  if (!out)
+    return out;
+
   out << "\tpat::Electron: ";
   out << std::setiosflags(std::ios::right);
   out << std::setiosflags(std::ios::fixed);
   out << std::setprecision(3);
-  out << " E/pT/eta/phi " 
-      << obj.energy()<<"/"
-      << obj.pt()<<"/"
-      << obj.eta()<<"/"
-      << obj.phi();
-  return out; 
+  out << " E/pT/eta/phi " << obj.energy() << "/" << obj.pt() << "/" << obj.eta() << "/" << obj.phi();
+  return out;
 }
 
 /// initializes the impact parameter container vars
 void Electron::initImpactParameters() {
-  std::fill(ip_, ip_+IpTypeSize, 0.0f);
-  std::fill(eip_, eip_+IpTypeSize, 0.0f);
+  std::fill(ip_, ip_ + IpTypeSize, 0.0f);
+  std::fill(eip_, eip_ + IpTypeSize, 0.0f);
   cachedIP_ = 0;
 }
-
 
 /// override the reco::GsfElectron::gsfTrack method, to access the internal storage of the supercluster
 reco::GsfTrackRef Electron::gsfTrack() const {
@@ -133,35 +122,34 @@ reco::GsfElectronCoreRef Electron::core() const {
   }
 }
 
-
 /// override the reco::GsfElectron::superCluster method, to access the internal storage of the supercluster
 reco::SuperClusterRef Electron::superCluster() const {
   if (embeddedSuperCluster_) {
     if (embeddedSeedCluster_ || !basicClusters_.empty() || !preshowerClusters_.empty()) {
-        if (!superClusterRelinked_.isSet()) {
-            std::unique_ptr<std::vector<reco::SuperCluster> > sc(new std::vector<reco::SuperCluster>(superCluster_));
-            if (embeddedSeedCluster_ && !(*sc)[0].seed().isAvailable()) {
-                (*sc)[0].setSeed(seed());
-            }
-            if (!basicClusters_.empty() && !(*sc)[0].clusters().isAvailable()) {
-                reco::CaloClusterPtrVector clusters;
-                for (unsigned int iclus=0; iclus<basicClusters_.size(); ++iclus) {
-                    clusters.push_back(reco::CaloClusterPtr(&basicClusters_,iclus));
-                }
-                (*sc)[0].setClusters(clusters);
-            }
-            if (!preshowerClusters_.empty() && !(*sc)[0].preshowerClusters().isAvailable()) {
-                reco::CaloClusterPtrVector clusters;
-                for (unsigned int iclus=0; iclus<preshowerClusters_.size(); ++iclus) {
-                    clusters.push_back(reco::CaloClusterPtr(&preshowerClusters_,iclus));
-                }
-                (*sc)[0].setPreshowerClusters(clusters);
-            }
-            superClusterRelinked_.set(std::move(sc));
+      if (!superClusterRelinked_.isSet()) {
+        std::unique_ptr<std::vector<reco::SuperCluster> > sc(new std::vector<reco::SuperCluster>(superCluster_));
+        if (embeddedSeedCluster_ && !(*sc)[0].seed().isAvailable()) {
+          (*sc)[0].setSeed(seed());
         }
-        return reco::SuperClusterRef(&*superClusterRelinked_, 0);
+        if (!basicClusters_.empty() && !(*sc)[0].clusters().isAvailable()) {
+          reco::CaloClusterPtrVector clusters;
+          for (unsigned int iclus = 0; iclus < basicClusters_.size(); ++iclus) {
+            clusters.push_back(reco::CaloClusterPtr(&basicClusters_, iclus));
+          }
+          (*sc)[0].setClusters(clusters);
+        }
+        if (!preshowerClusters_.empty() && !(*sc)[0].preshowerClusters().isAvailable()) {
+          reco::CaloClusterPtrVector clusters;
+          for (unsigned int iclus = 0; iclus < preshowerClusters_.size(); ++iclus) {
+            clusters.push_back(reco::CaloClusterPtr(&preshowerClusters_, iclus));
+          }
+          (*sc)[0].setPreshowerClusters(clusters);
+        }
+        superClusterRelinked_.set(std::move(sc));
+      }
+      return reco::SuperClusterRef(&*superClusterRelinked_, 0);
     } else {
-        return reco::SuperClusterRef(&superCluster_, 0);
+      return reco::SuperClusterRef(&superCluster_, 0);
     }
     //relink caloclusters if needed
     return reco::SuperClusterRef(&superCluster_, 0);
@@ -181,8 +169,8 @@ reco::SuperClusterRef Electron::parentSuperCluster() const {
 
 /// direct access to the seed cluster
 reco::CaloClusterPtr Electron::seed() const {
-  if(embeddedSeedCluster_){
-    return reco::CaloClusterPtr(&seedCluster_,0);
+  if (embeddedSeedCluster_) {
+    return reco::CaloClusterPtr(&seedCluster_, 0);
   } else {
     return reco::GsfElectron::superCluster()->seed();
   }
@@ -198,16 +186,14 @@ reco::TrackRef Electron::closestCtfTrackRef() const {
 }
 
 // the name of the method is misleading, users should use gsfTrack of closestCtfTrack
-reco::TrackRef Electron::track() const {
-  return reco::TrackRef();
-}
+reco::TrackRef Electron::track() const { return reco::TrackRef(); }
 
 /// Stores the electron's core (reco::GsfElectronCoreRef) internally
 void Electron::embedGsfElectronCore() {
   gsfElectronCore_.clear();
   if (reco::GsfElectron::core().isNonnull()) {
-      gsfElectronCore_.push_back(*reco::GsfElectron::core());
-      embeddedGsfElectronCore_ = true;
+    gsfElectronCore_.push_back(*reco::GsfElectron::core());
+    embeddedGsfElectronCore_ = true;
   }
 }
 
@@ -215,18 +201,17 @@ void Electron::embedGsfElectronCore() {
 void Electron::embedGsfTrack() {
   gsfTrack_.clear();
   if (reco::GsfElectron::gsfTrack().isNonnull()) {
-      gsfTrack_.push_back(*reco::GsfElectron::gsfTrack());
-      embeddedGsfTrack_ = true;
+    gsfTrack_.push_back(*reco::GsfElectron::gsfTrack());
+    embeddedGsfTrack_ = true;
   }
 }
-
 
 /// Stores the electron's SuperCluster (reco::SuperClusterRef) internally
 void Electron::embedSuperCluster() {
   superCluster_.clear();
   if (reco::GsfElectron::superCluster().isNonnull()) {
-      superCluster_.push_back(*reco::GsfElectron::superCluster());
-      embeddedSuperCluster_ = true;
+    superCluster_.push_back(*reco::GsfElectron::superCluster());
+    embeddedSuperCluster_ = true;
   }
 }
 
@@ -234,8 +219,8 @@ void Electron::embedSuperCluster() {
 void Electron::embedPflowSuperCluster() {
   pflowSuperCluster_.clear();
   if (reco::GsfElectron::parentSuperCluster().isNonnull()) {
-      pflowSuperCluster_.push_back(*reco::GsfElectron::parentSuperCluster());
-      embeddedPflowSuperCluster_ = true;
+    pflowSuperCluster_.push_back(*reco::GsfElectron::parentSuperCluster());
+    embeddedPflowSuperCluster_ = true;
   }
 }
 
@@ -251,23 +236,23 @@ void Electron::embedSeedCluster() {
 /// Stores the electron's BasicCluster (reco::CaloCluster) internally
 void Electron::embedBasicClusters() {
   basicClusters_.clear();
-  if (reco::GsfElectron::superCluster().isNonnull()){
+  if (reco::GsfElectron::superCluster().isNonnull()) {
     reco::CaloCluster_iterator itscl = reco::GsfElectron::superCluster()->clustersBegin();
     reco::CaloCluster_iterator itsclE = reco::GsfElectron::superCluster()->clustersEnd();
-    for(;itscl!=itsclE;++itscl){
-      basicClusters_.push_back( **itscl ) ;
-    } 
+    for (; itscl != itsclE; ++itscl) {
+      basicClusters_.push_back(**itscl);
+    }
   }
 }
 
 /// Stores the electron's PreshowerCluster (reco::CaloCluster) internally
 void Electron::embedPreshowerClusters() {
   preshowerClusters_.clear();
-  if (reco::GsfElectron::superCluster().isNonnull()){
+  if (reco::GsfElectron::superCluster().isNonnull()) {
     reco::CaloCluster_iterator itscl = reco::GsfElectron::superCluster()->preshowerClustersBegin();
     reco::CaloCluster_iterator itsclE = reco::GsfElectron::superCluster()->preshowerClustersEnd();
-    for(;itscl!=itsclE;++itscl){
-      preshowerClusters_.push_back( **itscl ) ;
+    for (; itscl != itsclE; ++itscl) {
+      preshowerClusters_.push_back(**itscl);
     }
   }
 }
@@ -275,11 +260,11 @@ void Electron::embedPreshowerClusters() {
 /// Stores the electron's PflowBasicCluster (reco::CaloCluster) internally
 void Electron::embedPflowBasicClusters() {
   pflowBasicClusters_.clear();
-  if (reco::GsfElectron::parentSuperCluster().isNonnull()){
+  if (reco::GsfElectron::parentSuperCluster().isNonnull()) {
     reco::CaloCluster_iterator itscl = reco::GsfElectron::parentSuperCluster()->clustersBegin();
     reco::CaloCluster_iterator itsclE = reco::GsfElectron::parentSuperCluster()->clustersEnd();
-    for(;itscl!=itsclE;++itscl){
-      pflowBasicClusters_.push_back( **itscl ) ;
+    for (; itscl != itsclE; ++itscl) {
+      pflowBasicClusters_.push_back(**itscl);
     }
   }
 }
@@ -287,11 +272,11 @@ void Electron::embedPflowBasicClusters() {
 /// Stores the electron's PflowPreshowerCluster (reco::CaloCluster) internally
 void Electron::embedPflowPreshowerClusters() {
   pflowPreshowerClusters_.clear();
-  if (reco::GsfElectron::parentSuperCluster().isNonnull()){
+  if (reco::GsfElectron::parentSuperCluster().isNonnull()) {
     reco::CaloCluster_iterator itscl = reco::GsfElectron::parentSuperCluster()->preshowerClustersBegin();
     reco::CaloCluster_iterator itsclE = reco::GsfElectron::parentSuperCluster()->preshowerClustersEnd();
-    for(;itscl!=itsclE;++itscl){
-      pflowPreshowerClusters_.push_back( **itscl ) ;
+    for (; itscl != itsclE; ++itscl) {
+      pflowPreshowerClusters_.push_back(**itscl);
     }
   }
 }
@@ -300,14 +285,14 @@ void Electron::embedPflowPreshowerClusters() {
 void Electron::embedTrack() {
   track_.clear();
   if (reco::GsfElectron::closestCtfTrackRef().isNonnull()) {
-      track_.push_back(*reco::GsfElectron::closestCtfTrackRef());
-      embeddedTrack_ = true;
+    track_.push_back(*reco::GsfElectron::closestCtfTrackRef());
+    embeddedTrack_ = true;
   }
 }
 
 // method to store the RecHits internally
-void Electron::embedRecHits(const EcalRecHitCollection * rechits) {
-  if (rechits!=nullptr) {
+void Electron::embedRecHits(const EcalRecHitCollection* rechits) {
+  if (rechits != nullptr) {
     recHits_ = *rechits;
     embeddedRecHits_ = true;
   }
@@ -328,27 +313,28 @@ void Electron::embedRecHits(const EcalRecHitCollection * rechits) {
 /// https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideCategoryBasedElectronID
 /// Note: an exception is thrown if the specified ID is not available
 float Electron::electronID(const std::string& name) const {
-    for (std::vector<IdPair>::const_iterator it = electronIDs_.begin(), ed = electronIDs_.end(); it != ed; ++it) {
-        if (it->first == name) return it->second;
-    }
-    cms::Exception ex("Key not found");
-    ex << "pat::Electron: the ID " << name << " can't be found in this pat::Electron.\n";
-    ex << "The available IDs are: ";
-    for (std::vector<IdPair>::const_iterator it = electronIDs_.begin(), ed = electronIDs_.end(); it != ed; ++it) {
-        ex << "'" << it->first << "' ";
-    }
-    ex << ".\n";
-    throw ex;
+  for (std::vector<IdPair>::const_iterator it = electronIDs_.begin(), ed = electronIDs_.end(); it != ed; ++it) {
+    if (it->first == name)
+      return it->second;
+  }
+  cms::Exception ex("Key not found");
+  ex << "pat::Electron: the ID " << name << " can't be found in this pat::Electron.\n";
+  ex << "The available IDs are: ";
+  for (std::vector<IdPair>::const_iterator it = electronIDs_.begin(), ed = electronIDs_.end(); it != ed; ++it) {
+    ex << "'" << it->first << "' ";
+  }
+  ex << ".\n";
+  throw ex;
 }
 
 /// Checks if a specific electron ID is associated to the pat::Electron.
 bool Electron::isElectronIDAvailable(const std::string& name) const {
-    for (std::vector<IdPair>::const_iterator it = electronIDs_.begin(), ed = electronIDs_.end(); it != ed; ++it) {
-        if (it->first == name) return true;
-    }
-    return false;
+  for (std::vector<IdPair>::const_iterator it = electronIDs_.begin(), ed = electronIDs_.end(); it != ed; ++it) {
+    if (it->first == name)
+      return true;
+  }
+  return false;
 }
-
 
 /// reference to the source PFCandidates
 reco::PFCandidateRef Electron::pfCandidateRef() const {
@@ -362,30 +348,29 @@ reco::PFCandidateRef Electron::pfCandidateRef() const {
 /// Stores the PFCandidate pointed to by pfCandidateRef_ internally
 void Electron::embedPFCandidate() {
   pfCandidate_.clear();
-  if ( pfCandidateRef_.isAvailable() && pfCandidateRef_.isNonnull()) {
-    pfCandidate_.push_back( *pfCandidateRef_ );
+  if (pfCandidateRef_.isAvailable() && pfCandidateRef_.isNonnull()) {
+    pfCandidate_.push_back(*pfCandidateRef_);
     embeddedPFCandidate_ = true;
   }
 }
 
 /// Returns the reference to the parent PF candidate with index i.
 /// For use in TopProjector.
-reco::CandidatePtr Electron::sourceCandidatePtr( size_type i ) const {
-    if (pfCandidateRef_.isNonnull()) {
-        if (i == 0) {
-            return reco::CandidatePtr(edm::refToPtr(pfCandidateRef_));
-        } else {
-            i--;
-        }
-    }
-    if (i >= associatedPackedFCandidateIndices_.size()) {
-        return reco::CandidatePtr();
+reco::CandidatePtr Electron::sourceCandidatePtr(size_type i) const {
+  if (pfCandidateRef_.isNonnull()) {
+    if (i == 0) {
+      return reco::CandidatePtr(edm::refToPtr(pfCandidateRef_));
     } else {
-        return reco::CandidatePtr(edm::refToPtr(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, associatedPackedFCandidateIndices_[i])));
+      i--;
     }
+  }
+  if (i >= associatedPackedFCandidateIndices_.size()) {
+    return reco::CandidatePtr();
+  } else {
+    return reco::CandidatePtr(edm::refToPtr(
+        edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, associatedPackedFCandidateIndices_[i])));
+  }
 }
-
-
 
 /// dB gives the impact parameter wrt the beamline.
 /// If this is not cached it is not meaningful, since
@@ -399,7 +384,7 @@ reco::CandidatePtr Electron::sourceCandidatePtr( size_type i ) const {
 /// relative to the primary vertex.
 double Electron::dB(IpType type_) const {
   // more IP types (new)
-  if ( cachedIP_ & (1 << int(type_))) {
+  if (cachedIP_ & (1 << int(type_))) {
     return ip_[type_];
   } else {
     return std::numeric_limits<double>::max();
@@ -408,7 +393,7 @@ double Electron::dB(IpType type_) const {
 
 /// edB gives the uncertainty on the impact parameter wrt the beamline.
 /// If this is not cached it is not meaningful, since
-/// it relies on the distance to the beamline. 
+/// it relies on the distance to the beamline.
 ///
 /// IpType defines the type of the impact parameter
 /// None is default and reverts to the old functionality.
@@ -418,7 +403,7 @@ double Electron::dB(IpType type_) const {
 /// relative to the primary vertex.
 double Electron::edB(IpType type_) const {
   // more IP types (new)
-  if ( cachedIP_ & (1 << int(type_))) {
+  if (cachedIP_ & (1 << int(type_))) {
     return eip_[type_];
   } else {
     return std::numeric_limits<double>::max();
@@ -426,22 +411,22 @@ double Electron::edB(IpType type_) const {
 }
 
 /// Sets the impact parameter and its error wrt the beamline and caches it.
-void Electron::setDB(double dB, double edB, IpType type){
-  ip_[type] = dB; eip_[type] = edB; cachedIP_ |= (1 << int(type));
+void Electron::setDB(double dB, double edB, IpType type) {
+  ip_[type] = dB;
+  eip_[type] = edB;
+  cachedIP_ |= (1 << int(type));
 }
 
 /// Set additional missing mva input variables for new mva ID (71X update)
-void Electron::setMvaVariables( double sigmaIetaIphi, double ip3d){
+void Electron::setMvaVariables(double sigmaIetaIphi, double ip3d) {
   sigmaIetaIphi_ = sigmaIetaIphi;
   ip3d_ = ip3d;
-} 
-
-edm::RefVector<pat::PackedCandidateCollection> Electron::associatedPackedPFCandidates() const {
-    edm::RefVector<pat::PackedCandidateCollection> ret(packedPFCandidates_.id());
-    for (uint16_t idx : associatedPackedFCandidateIndices_) {
-        ret.push_back(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, idx));
-    }
-    return ret;
 }
 
-
+edm::RefVector<pat::PackedCandidateCollection> Electron::associatedPackedPFCandidates() const {
+  edm::RefVector<pat::PackedCandidateCollection> ret(packedPFCandidates_.id());
+  for (uint16_t idx : associatedPackedFCandidateIndices_) {
+    ret.push_back(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, idx));
+  }
+  return ret;
+}

--- a/DataFormats/PatCandidates/src/EventHypothesis.cc
+++ b/DataFormats/PatCandidates/src/EventHypothesis.cc
@@ -1,106 +1,94 @@
 #include "DataFormats/PatCandidates/interface/EventHypothesis.h"
 #include "DataFormats/PatCandidates/interface/EventHypothesisLooper.h"
 
-char *
-pat::EventHypothesis::getDemangledSymbol(const char* mangledSymbol) const {
-    int status;
-    char *demangledSymbol = abi::__cxa_demangle(mangledSymbol, nullptr, nullptr, &status);
-    return (status == 0) ? demangledSymbol : nullptr;
+char *pat::EventHypothesis::getDemangledSymbol(const char *mangledSymbol) const {
+  int status;
+  char *demangledSymbol = abi::__cxa_demangle(mangledSymbol, nullptr, nullptr, &status);
+  return (status == 0) ? demangledSymbol : nullptr;
 }
 
 void pat::EventHypothesis::add(const CandRefType &ref, const std::string &role) {
-    particles_.push_back(value_type(role,ref));
+  particles_.push_back(value_type(role, ref));
 }
 
-const pat::EventHypothesis::CandRefType & 
-pat::EventHypothesis::get(const std::string &role, int index) const 
-{
-    if (index >= 0) {
-        const_iterator it = realGet(begin(), end(), ByRole(role), index);
-        if (it == end()) { throw cms::Exception("Index not found") << "Can't find a particle with role " << role << " and index " << index << "\n"; }
-        return it->second;
-    } else {
-        const_reverse_iterator it = realGet(rbegin(), rend(), ByRole(role), -index);
-        if (it == rend()) { throw cms::Exception("Index not found") << "Can't find a particle with role " << role << " and index " << index << "\n"; }
-        return it->second;
+const pat::EventHypothesis::CandRefType &pat::EventHypothesis::get(const std::string &role, int index) const {
+  if (index >= 0) {
+    const_iterator it = realGet(begin(), end(), ByRole(role), index);
+    if (it == end()) {
+      throw cms::Exception("Index not found")
+          << "Can't find a particle with role " << role << " and index " << index << "\n";
     }
-}
-
-const pat::EventHypothesis::CandRefType &
-pat::EventHypothesis::get(const ParticleFilter &filter, int index) const 
-{
-    if (index >= 0) {
-        const_iterator it = realGet(begin(), end(), filter, index);
-        if (it == end()) { throw cms::Exception("Index not found") << "Can't find a particle matching filter with index " << index << "\n"; }
-        return it->second;
-    } else {
-        const_reverse_iterator it = realGet(rbegin(), rend(), filter, -index);
-        if (it == rend()) { throw cms::Exception("Index not found") << "Can't find a particle matching filter with index " << index << "\n"; }
-        return it->second;
+    return it->second;
+  } else {
+    const_reverse_iterator it = realGet(rbegin(), rend(), ByRole(role), -index);
+    if (it == rend()) {
+      throw cms::Exception("Index not found")
+          << "Can't find a particle with role " << role << " and index " << index << "\n";
     }
+    return it->second;
+  }
 }
 
-
-std::vector<pat::EventHypothesis::CandRefType> 
-pat::EventHypothesis::all(const std::string &roleRegexp) const 
-{
-    return all(pat::eventhypothesis::RoleRegexpFilter(roleRegexp));
-}
-
-std::vector<pat::EventHypothesis::CandRefType> 
-pat::EventHypothesis::all(const ParticleFilter &filter) const 
-{
-    std::vector<pat::EventHypothesis::CandRefType> ret;
-    for (const_iterator it = begin(); it != end(); ++it) {
-        if (filter(*it)) ret.push_back(it->second);
+const pat::EventHypothesis::CandRefType &pat::EventHypothesis::get(const ParticleFilter &filter, int index) const {
+  if (index >= 0) {
+    const_iterator it = realGet(begin(), end(), filter, index);
+    if (it == end()) {
+      throw cms::Exception("Index not found") << "Can't find a particle matching filter with index " << index << "\n";
     }
-    return ret;
-}
-
-size_t
-pat::EventHypothesis::count(const std::string &roleRegexp) const 
-{
-    return count(pat::eventhypothesis::RoleRegexpFilter(roleRegexp));
-}
-
-size_t
-pat::EventHypothesis::count(const ParticleFilter &role) const 
-{
-    size_t n = 0;
-    for (const_iterator it = begin(); it != end(); ++it) {
-        if (role(*it)) ++n;
+    return it->second;
+  } else {
+    const_reverse_iterator it = realGet(rbegin(), rend(), filter, -index);
+    if (it == rend()) {
+      throw cms::Exception("Index not found") << "Can't find a particle matching filter with index " << index << "\n";
     }
-    return n;
+    return it->second;
+  }
 }
 
-pat::EventHypothesis::CandLooper
-pat::EventHypothesis::loop() const 
-{
-    return loop(pat::eventhypothesis::AcceptAllFilter::get());
+std::vector<pat::EventHypothesis::CandRefType> pat::EventHypothesis::all(const std::string &roleRegexp) const {
+  return all(pat::eventhypothesis::RoleRegexpFilter(roleRegexp));
 }
 
-pat::EventHypothesis::CandLooper
-pat::EventHypothesis::loop(const std::string &roleRegexp) const
-{
-    return loop(new pat::eventhypothesis::RoleRegexpFilter(roleRegexp));
+std::vector<pat::EventHypothesis::CandRefType> pat::EventHypothesis::all(const ParticleFilter &filter) const {
+  std::vector<pat::EventHypothesis::CandRefType> ret;
+  for (const_iterator it = begin(); it != end(); ++it) {
+    if (filter(*it))
+      ret.push_back(it->second);
+  }
+  return ret;
 }
 
-pat::EventHypothesis::CandLooper
-pat::EventHypothesis::loop(const ParticleFilter &role) const 
-{
-    return CandLooper(*this, role); 
+size_t pat::EventHypothesis::count(const std::string &roleRegexp) const {
+  return count(pat::eventhypothesis::RoleRegexpFilter(roleRegexp));
 }
 
-pat::EventHypothesis::CandLooper
-pat::EventHypothesis::loop(const ParticleFilter *role) const 
-{
-    return CandLooper(*this, role); 
+size_t pat::EventHypothesis::count(const ParticleFilter &role) const {
+  size_t n = 0;
+  for (const_iterator it = begin(); it != end(); ++it) {
+    if (role(*it))
+      ++n;
+  }
+  return n;
 }
 
-pat::EventHypothesis::CandLooper
-pat::EventHypothesis::loop(const ParticleFilterPtr &role) const 
-{
-    return CandLooper(*this, role); 
+pat::EventHypothesis::CandLooper pat::EventHypothesis::loop() const {
+  return loop(pat::eventhypothesis::AcceptAllFilter::get());
+}
+
+pat::EventHypothesis::CandLooper pat::EventHypothesis::loop(const std::string &roleRegexp) const {
+  return loop(new pat::eventhypothesis::RoleRegexpFilter(roleRegexp));
+}
+
+pat::EventHypothesis::CandLooper pat::EventHypothesis::loop(const ParticleFilter &role) const {
+  return CandLooper(*this, role);
+}
+
+pat::EventHypothesis::CandLooper pat::EventHypothesis::loop(const ParticleFilter *role) const {
+  return CandLooper(*this, role);
+}
+
+pat::EventHypothesis::CandLooper pat::EventHypothesis::loop(const ParticleFilterPtr &role) const {
+  return CandLooper(*this, role);
 }
 
 const pat::eventhypothesis::AcceptAllFilter pat::eventhypothesis::AcceptAllFilter::s_dummyFilter;

--- a/DataFormats/PatCandidates/src/Flags.cc
+++ b/DataFormats/PatCandidates/src/Flags.cc
@@ -2,272 +2,322 @@
 
 using pat::Flags;
 
-const std::string & 
-Flags::bitToString(uint32_t bit) {
-    static const std::string UNDEFINED_UNDEFINED = "Undefined/Undefined";
-    if      (bit & CoreBits      ) return Core::bitToString( Core::Bits(bit) );
-    else if (bit & SelectionBits ) return Selection::bitToString( Selection::Bits(bit) );
-    else if (bit & OverlapBits   ) return Overlap::bitToString( Overlap::Bits(bit) );
-    else if (bit & IsolationBits ) return Isolation::bitToString( Isolation::Bits(bit) );
-    else return UNDEFINED_UNDEFINED;
+const std::string &Flags::bitToString(uint32_t bit) {
+  static const std::string UNDEFINED_UNDEFINED = "Undefined/Undefined";
+  if (bit & CoreBits)
+    return Core::bitToString(Core::Bits(bit));
+  else if (bit & SelectionBits)
+    return Selection::bitToString(Selection::Bits(bit));
+  else if (bit & OverlapBits)
+    return Overlap::bitToString(Overlap::Bits(bit));
+  else if (bit & IsolationBits)
+    return Isolation::bitToString(Isolation::Bits(bit));
+  else
+    return UNDEFINED_UNDEFINED;
 }
 
-std::string Flags::maskToString ( uint32_t mask ) {
-    std::string ret;
-    bool first = false;
-    for (uint32_t i = 1; i != 0; i <<= 1) {
-        if ( mask & i ) {
-            if (first) { first = false;  } else { ret += " + "; }
-            ret += bitToString ( mask & i );
-        }
+std::string Flags::maskToString(uint32_t mask) {
+  std::string ret;
+  bool first = false;
+  for (uint32_t i = 1; i != 0; i <<= 1) {
+    if (mask & i) {
+      if (first) {
+        first = false;
+      } else {
+        ret += " + ";
+      }
+      ret += bitToString(mask & i);
     }
-    return ret;
+  }
+  return ret;
 }
 
-uint32_t
-Flags::get( const std::string & str ) {
-    size_t idx = str.find_first_of("/");
-    if (idx != std::string::npos) {
-        std::string set = str.substr(0, idx);
-        if (set == "Core")      return Core::get(     str.substr(idx+1));
-        if (set == "Overlap")   return Overlap::get(  str.substr(idx+1));
-        if (set == "Isolation") return Isolation::get(str.substr(idx+1));
-        if (set == "Selection") return Selection::get(str.substr(idx+1)); 
-    }
-    return 0;
+uint32_t Flags::get(const std::string &str) {
+  size_t idx = str.find_first_of("/");
+  if (idx != std::string::npos) {
+    std::string set = str.substr(0, idx);
+    if (set == "Core")
+      return Core::get(str.substr(idx + 1));
+    if (set == "Overlap")
+      return Overlap::get(str.substr(idx + 1));
+    if (set == "Isolation")
+      return Isolation::get(str.substr(idx + 1));
+    if (set == "Selection")
+      return Selection::get(str.substr(idx + 1));
+  }
+  return 0;
 }
 
-uint32_t
-Flags::get( const std::vector<std::string> & strs ) {
-    uint32_t ret = 0;
-    for (std::vector<std::string>::const_iterator it = strs.begin(), ed = strs.end(); it != ed; ++it) {
-        ret |= get( *it );
-    }
-    return ret;
+uint32_t Flags::get(const std::vector<std::string> &strs) {
+  uint32_t ret = 0;
+  for (std::vector<std::string>::const_iterator it = strs.begin(), ed = strs.end(); it != ed; ++it) {
+    ret |= get(*it);
+  }
+  return ret;
 }
 
-const std::string & 
-Flags::Core:: bitToString( Core::Bits bit ) {
-    static const std::string STR_All           = "Core/All", 
-                             STR_Duplicate     = "Core/Duplicate",
-                             STR_Preselection  = "Core/Preselection",
-                             STR_Vertexing     = "Core/Vertexing",
-                             STR_Overflow      = "Core/Overflow",
-                             STR_Undefined     = "Core/Undefined";
-                              
-    switch (bit) {
-        case All:           return STR_All;
-        case Duplicate:     return STR_Duplicate;
-        case Preselection:  return STR_Preselection;
-        case Vertexing:     return STR_Vertexing;
-        case Overflow:      return STR_Overflow;
-        default:            return STR_Undefined;
-    }
+const std::string &Flags::Core::bitToString(Core::Bits bit) {
+  static const std::string STR_All = "Core/All", STR_Duplicate = "Core/Duplicate",
+                           STR_Preselection = "Core/Preselection", STR_Vertexing = "Core/Vertexing",
+                           STR_Overflow = "Core/Overflow", STR_Undefined = "Core/Undefined";
+
+  switch (bit) {
+    case All:
+      return STR_All;
+    case Duplicate:
+      return STR_Duplicate;
+    case Preselection:
+      return STR_Preselection;
+    case Vertexing:
+      return STR_Vertexing;
+    case Overflow:
+      return STR_Overflow;
+    default:
+      return STR_Undefined;
+  }
 }
 
-Flags::Core::Bits 
-Flags::Core::get ( const std::string & instr ) {
-    size_t idx = instr.find_first_of("/");
-    const std::string &str  = (idx == std::string::npos) ? instr : instr.substr(idx+1);
-    if      (str == "All")           return All;
-    else if (str == "Duplicate"    ) return Duplicate;
-    else if (str == "Preselection" ) return Preselection;
-    else if (str == "Vertexing"    ) return Vertexing;
-    else if (str == "Overlfow"     ) return Overflow;
-    return Undefined;
+Flags::Core::Bits Flags::Core::get(const std::string &instr) {
+  size_t idx = instr.find_first_of("/");
+  const std::string &str = (idx == std::string::npos) ? instr : instr.substr(idx + 1);
+  if (str == "All")
+    return All;
+  else if (str == "Duplicate")
+    return Duplicate;
+  else if (str == "Preselection")
+    return Preselection;
+  else if (str == "Vertexing")
+    return Vertexing;
+  else if (str == "Overlfow")
+    return Overflow;
+  return Undefined;
 }
 
-uint32_t
-Flags::Core::get ( const std::vector<std::string> & strs ) {
-    uint32_t ret = 0;
-    for (std::vector<std::string>::const_iterator it = strs.begin(), ed = strs.end(); it != ed; ++it) {
-        ret |= get( *it );
-    }
-    return ret;
+uint32_t Flags::Core::get(const std::vector<std::string> &strs) {
+  uint32_t ret = 0;
+  for (std::vector<std::string>::const_iterator it = strs.begin(), ed = strs.end(); it != ed; ++it) {
+    ret |= get(*it);
+  }
+  return ret;
 }
 
-const std::string & 
-Flags::Selection:: bitToString( Selection::Bits bit ) {
-    static const std::string    STR_All =       "Selection/All",
-                                STR_Bit0 =      "Selection/Bit0",
-                                STR_Bit1 =      "Selection/Bit1",
-                                STR_Bit2 =      "Selection/Bit2",
-                                STR_Bit3 =      "Selection/Bit3",
-                                STR_Bit4 =      "Selection/Bit4",
-                                STR_Bit5 =      "Selection/Bit5",
-                                STR_Bit6 =      "Selection/Bit6",
-                                STR_Bit7 =      "Selection/Bit7",
-                                STR_Bit8 =      "Selection/Bit8",
-                                STR_Bit9 =      "Selection/Bit9",
-                                STR_Bit10 =     "Selection/Bit10",
-                                STR_Bit11 =     "Selection/Bit11",
-                                STR_Undefined = "Selection/Undefined";
-    switch (bit) {
-        case All:   return STR_All;
-        case Bit0:  return STR_Bit0;
-        case Bit1:  return STR_Bit1;
-        case Bit2:  return STR_Bit2;
-        case Bit3:  return STR_Bit3;
-        case Bit4:  return STR_Bit4;
-        case Bit5:  return STR_Bit5;
-        case Bit6:  return STR_Bit6;
-        case Bit7:  return STR_Bit7;
-        case Bit8:  return STR_Bit8;
-        case Bit9:  return STR_Bit9;
-        case Bit10: return STR_Bit10;
-        case Bit11: return STR_Bit11;
-        default:
-            return STR_Undefined;
-    }
+const std::string &Flags::Selection::bitToString(Selection::Bits bit) {
+  static const std::string STR_All = "Selection/All", STR_Bit0 = "Selection/Bit0", STR_Bit1 = "Selection/Bit1",
+                           STR_Bit2 = "Selection/Bit2", STR_Bit3 = "Selection/Bit3", STR_Bit4 = "Selection/Bit4",
+                           STR_Bit5 = "Selection/Bit5", STR_Bit6 = "Selection/Bit6", STR_Bit7 = "Selection/Bit7",
+                           STR_Bit8 = "Selection/Bit8", STR_Bit9 = "Selection/Bit9", STR_Bit10 = "Selection/Bit10",
+                           STR_Bit11 = "Selection/Bit11", STR_Undefined = "Selection/Undefined";
+  switch (bit) {
+    case All:
+      return STR_All;
+    case Bit0:
+      return STR_Bit0;
+    case Bit1:
+      return STR_Bit1;
+    case Bit2:
+      return STR_Bit2;
+    case Bit3:
+      return STR_Bit3;
+    case Bit4:
+      return STR_Bit4;
+    case Bit5:
+      return STR_Bit5;
+    case Bit6:
+      return STR_Bit6;
+    case Bit7:
+      return STR_Bit7;
+    case Bit8:
+      return STR_Bit8;
+    case Bit9:
+      return STR_Bit9;
+    case Bit10:
+      return STR_Bit10;
+    case Bit11:
+      return STR_Bit11;
+    default:
+      return STR_Undefined;
+  }
 }
 
-Flags::Selection::Bits 
-Flags::Selection::get ( int8_t bit) {
-    if (bit == -1) return All;
-    if (bit <= 11) return Bits((1 << bit) << 8);
-    return Undefined;
+Flags::Selection::Bits Flags::Selection::get(int8_t bit) {
+  if (bit == -1)
+    return All;
+  if (bit <= 11)
+    return Bits((1 << bit) << 8);
+  return Undefined;
 }
 
-Flags::Selection::Bits 
-Flags::Selection::get ( const std::string & instr ) {
-    size_t idx = instr.find_first_of("/");
-    const std::string &str  = (idx == std::string::npos) ? instr : instr.substr(idx+1);
-    if      (str == "All"   ) return All;
-    else if (str == "Bit0"  ) return Bit0;
-    else if (str == "Bit1"  ) return Bit1;
-    else if (str == "Bit2"  ) return Bit2;
-    else if (str == "Bit3"  ) return Bit3;
-    else if (str == "Bit4"  ) return Bit4;
-    else if (str == "Bit5"  ) return Bit5;
-    else if (str == "Bit6"  ) return Bit6;
-    else if (str == "Bit7"  ) return Bit7;
-    else if (str == "Bit8"  ) return Bit8;
-    else if (str == "Bit9"  ) return Bit9;
-    else if (str == "Bit10" ) return Bit10;
-    else if (str == "Bit11" ) return Bit11;
-    return Undefined;
+Flags::Selection::Bits Flags::Selection::get(const std::string &instr) {
+  size_t idx = instr.find_first_of("/");
+  const std::string &str = (idx == std::string::npos) ? instr : instr.substr(idx + 1);
+  if (str == "All")
+    return All;
+  else if (str == "Bit0")
+    return Bit0;
+  else if (str == "Bit1")
+    return Bit1;
+  else if (str == "Bit2")
+    return Bit2;
+  else if (str == "Bit3")
+    return Bit3;
+  else if (str == "Bit4")
+    return Bit4;
+  else if (str == "Bit5")
+    return Bit5;
+  else if (str == "Bit6")
+    return Bit6;
+  else if (str == "Bit7")
+    return Bit7;
+  else if (str == "Bit8")
+    return Bit8;
+  else if (str == "Bit9")
+    return Bit9;
+  else if (str == "Bit10")
+    return Bit10;
+  else if (str == "Bit11")
+    return Bit11;
+  return Undefined;
 }
 
-uint32_t
-Flags::Selection::get ( const std::vector<std::string> & strs ) {
-    uint32_t ret = 0;
-    for (std::vector<std::string>::const_iterator it = strs.begin(), ed = strs.end(); it != ed; ++it) {
-        ret |= get( *it );
-    }
-    return ret;
+uint32_t Flags::Selection::get(const std::vector<std::string> &strs) {
+  uint32_t ret = 0;
+  for (std::vector<std::string>::const_iterator it = strs.begin(), ed = strs.end(); it != ed; ++it) {
+    ret |= get(*it);
+  }
+  return ret;
 }
 
-const std::string & 
-Flags::Overlap:: bitToString( Overlap::Bits bit ) {
-    static const std::string STR_All =       "Overlap/All",
-                             STR_Jets =      "Overlap/Jets",
-                             STR_Electrons = "Overlap/Electrons",
-                             STR_Muons =     "Overlap/Muons",
-                             STR_Taus =      "Overlap/Taus",
-                             STR_Photons =   "Overlap/Photons",
-                             STR_User =     "Overlap/User",
-                             STR_User1 =     "Overlap/User1",
-                             STR_User2 =     "Overlap/User2",
-                             STR_User3 =     "Overlap/User3",
-                             STR_Undefined = "Overlap/Undefined";
-    switch (bit) {
-        case All:       return STR_All;
-        case Jets:      return STR_Jets;
-        case Electrons: return STR_Electrons;
-        case Muons:     return STR_Muons;
-        case Taus:      return STR_Taus;
-        case Photons:   return STR_Photons;
-        case User:      return STR_User;
-        case User1:     return STR_User1;
-        case User2:     return STR_User2;
-        case User3:     return STR_User3;
-        default:
-            return STR_Undefined;
-    }
+const std::string &Flags::Overlap::bitToString(Overlap::Bits bit) {
+  static const std::string STR_All = "Overlap/All", STR_Jets = "Overlap/Jets", STR_Electrons = "Overlap/Electrons",
+                           STR_Muons = "Overlap/Muons", STR_Taus = "Overlap/Taus", STR_Photons = "Overlap/Photons",
+                           STR_User = "Overlap/User", STR_User1 = "Overlap/User1", STR_User2 = "Overlap/User2",
+                           STR_User3 = "Overlap/User3", STR_Undefined = "Overlap/Undefined";
+  switch (bit) {
+    case All:
+      return STR_All;
+    case Jets:
+      return STR_Jets;
+    case Electrons:
+      return STR_Electrons;
+    case Muons:
+      return STR_Muons;
+    case Taus:
+      return STR_Taus;
+    case Photons:
+      return STR_Photons;
+    case User:
+      return STR_User;
+    case User1:
+      return STR_User1;
+    case User2:
+      return STR_User2;
+    case User3:
+      return STR_User3;
+    default:
+      return STR_Undefined;
+  }
 }
 
-Flags::Overlap::Bits 
-Flags::Overlap::get ( const std::string & instr ) {
-    size_t idx = instr.find_first_of("/");
-    const std::string &str  = (idx == std::string::npos) ? instr : instr.substr(idx+1);
-    if      (str == "All"      ) return All;
-    else if (str == "Jets"     ) return Jets;
-    else if (str == "Electrons") return Electrons;
-    else if (str == "Muons"    ) return Muons;
-    else if (str == "Taus"     ) return Taus;
-    else if (str == "Photons"  ) return Photons;
-    else if (str == "User"    )  return User;
-    else if (str == "User1"    ) return User1;
-    else if (str == "User2"    ) return User2;
-    else if (str == "User3"    ) return User3;
-    return Undefined;
+Flags::Overlap::Bits Flags::Overlap::get(const std::string &instr) {
+  size_t idx = instr.find_first_of("/");
+  const std::string &str = (idx == std::string::npos) ? instr : instr.substr(idx + 1);
+  if (str == "All")
+    return All;
+  else if (str == "Jets")
+    return Jets;
+  else if (str == "Electrons")
+    return Electrons;
+  else if (str == "Muons")
+    return Muons;
+  else if (str == "Taus")
+    return Taus;
+  else if (str == "Photons")
+    return Photons;
+  else if (str == "User")
+    return User;
+  else if (str == "User1")
+    return User1;
+  else if (str == "User2")
+    return User2;
+  else if (str == "User3")
+    return User3;
+  return Undefined;
 }
 
-uint32_t
-Flags::Overlap::get ( const std::vector<std::string> & strs ) {
-    uint32_t ret = 0;
-    for (std::vector<std::string>::const_iterator it = strs.begin(), ed = strs.end(); it != ed; ++it) {
-        ret |= get( *it );
-    }
-    return ret;
+uint32_t Flags::Overlap::get(const std::vector<std::string> &strs) {
+  uint32_t ret = 0;
+  for (std::vector<std::string>::const_iterator it = strs.begin(), ed = strs.end(); it != ed; ++it) {
+    ret |= get(*it);
+  }
+  return ret;
 }
 
-const std::string & 
-Flags::Isolation:: bitToString( Isolation::Bits bit ) {
-    static const std::string    STR_All =     "Isolation/All",
-                                STR_Tracker = "Isolation/Tracker",
-                                STR_ECal =    "Isolation/ECal",
-                                STR_HCal =    "Isolation/HCal",
-                                STR_Calo =    "Isolation/Calo",
-                                STR_User =    "Isolation/User",
-                                STR_User1 =   "Isolation/User1",
-                                STR_User2 =   "Isolation/User2",
-                                STR_User3 =   "Isolation/User3",
-                                STR_User4 =   "Isolation/User4",
-                                STR_User5 =   "Isolation/User5",
-                                STR_Undefined="Isolation/Undefined";
-    switch (bit) {
-        case All:       return STR_All;
-        case Tracker:   return STR_Tracker;
-        case ECal:      return STR_ECal;
-        case HCal:      return STR_HCal;
-        case Calo:      return STR_Calo;
-        case User:      return STR_User;
-        case User1:     return STR_User1;
-        case User2:     return STR_User2;
-        case User3:     return STR_User3;
-        case User4:     return STR_User4;
-        case User5:     return STR_User5;
-        default:
-            return STR_Undefined;
-    }
+const std::string &Flags::Isolation::bitToString(Isolation::Bits bit) {
+  static const std::string STR_All = "Isolation/All", STR_Tracker = "Isolation/Tracker", STR_ECal = "Isolation/ECal",
+                           STR_HCal = "Isolation/HCal", STR_Calo = "Isolation/Calo", STR_User = "Isolation/User",
+                           STR_User1 = "Isolation/User1", STR_User2 = "Isolation/User2", STR_User3 = "Isolation/User3",
+                           STR_User4 = "Isolation/User4", STR_User5 = "Isolation/User5",
+                           STR_Undefined = "Isolation/Undefined";
+  switch (bit) {
+    case All:
+      return STR_All;
+    case Tracker:
+      return STR_Tracker;
+    case ECal:
+      return STR_ECal;
+    case HCal:
+      return STR_HCal;
+    case Calo:
+      return STR_Calo;
+    case User:
+      return STR_User;
+    case User1:
+      return STR_User1;
+    case User2:
+      return STR_User2;
+    case User3:
+      return STR_User3;
+    case User4:
+      return STR_User4;
+    case User5:
+      return STR_User5;
+    default:
+      return STR_Undefined;
+  }
 }
 
-Flags::Isolation::Bits 
-Flags::Isolation::get ( const std::string & instr ) {
-    size_t idx = instr.find_first_of("/");
-    const std::string &str  = (idx == std::string::npos) ? instr : instr.substr(idx+1);
-    if      (str == "All"      ) return All;
-    else if (str == "Tracker"  ) return Tracker;
-    else if (str == "ECal"     ) return ECal;
-    else if (str == "HCal"     ) return HCal;
-    else if (str == "Calo"     ) return Calo;
-    else if (str == "User"     ) return User1;
-    else if (str == "User1"    ) return User1;
-    else if (str == "User2"    ) return User2;
-    else if (str == "User3"    ) return User3;
-    else if (str == "User4"    ) return User4;
-    else if (str == "User5"    ) return User5;
-    return Undefined;
+Flags::Isolation::Bits Flags::Isolation::get(const std::string &instr) {
+  size_t idx = instr.find_first_of("/");
+  const std::string &str = (idx == std::string::npos) ? instr : instr.substr(idx + 1);
+  if (str == "All")
+    return All;
+  else if (str == "Tracker")
+    return Tracker;
+  else if (str == "ECal")
+    return ECal;
+  else if (str == "HCal")
+    return HCal;
+  else if (str == "Calo")
+    return Calo;
+  else if (str == "User")
+    return User1;
+  else if (str == "User1")
+    return User1;
+  else if (str == "User2")
+    return User2;
+  else if (str == "User3")
+    return User3;
+  else if (str == "User4")
+    return User4;
+  else if (str == "User5")
+    return User5;
+  return Undefined;
 }
 
-uint32_t
-Flags::Isolation::get ( const std::vector<std::string> & strs ) {
-    uint32_t ret = 0;
-    for (std::vector<std::string>::const_iterator it = strs.begin(), ed = strs.end(); it != ed; ++it) {
-        ret |= get( *it );
-    }
-    return ret;
+uint32_t Flags::Isolation::get(const std::vector<std::string> &strs) {
+  uint32_t ret = 0;
+  for (std::vector<std::string>::const_iterator it = strs.begin(), ed = strs.end(); it != ed; ++it) {
+    ret |= get(*it);
+  }
+  return ret;
 }
-
-

--- a/DataFormats/PatCandidates/src/GenericParticle.cc
+++ b/DataFormats/PatCandidates/src/GenericParticle.cc
@@ -3,189 +3,207 @@
 
 #include "DataFormats/PatCandidates/interface/GenericParticle.h"
 
-
 using pat::GenericParticle;
 
-
 /// default constructor
-GenericParticle::GenericParticle() :
-    PATObject<reco::RecoCandidate>()
-{
-}
-
+GenericParticle::GenericParticle() : PATObject<reco::RecoCandidate>() {}
 
 /// constructor from Candidate
-GenericParticle::GenericParticle(const Candidate & cand) :
-    PATObject<reco::RecoCandidate>()
-{
-    fillInFrom(cand);
-}
-
+GenericParticle::GenericParticle(const Candidate &cand) : PATObject<reco::RecoCandidate>() { fillInFrom(cand); }
 
 /// constructor from ref to RecoCandidate
-GenericParticle::GenericParticle(const edm::RefToBase<Candidate> & cand) :
-    PATObject<reco::RecoCandidate>()
-{
-    fillInFrom(*cand);
-    refToOrig_ = edm::Ptr<reco::Candidate>(cand.id(), cand.get(), cand.key()); // correct RefToBase=>Ptr conversion
+GenericParticle::GenericParticle(const edm::RefToBase<Candidate> &cand) : PATObject<reco::RecoCandidate>() {
+  fillInFrom(*cand);
+  refToOrig_ = edm::Ptr<reco::Candidate>(cand.id(), cand.get(), cand.key());  // correct RefToBase=>Ptr conversion
 }
 
 /// constructor from ref to RecoCandidate
-GenericParticle::GenericParticle(const edm::Ptr<Candidate> & cand) :
-    PATObject<reco::RecoCandidate>()
-{
-    fillInFrom(*cand);
-    refToOrig_ = cand;
+GenericParticle::GenericParticle(const edm::Ptr<Candidate> &cand) : PATObject<reco::RecoCandidate>() {
+  fillInFrom(*cand);
+  refToOrig_ = cand;
 }
-
-
 
 /// destructor
-GenericParticle::~GenericParticle() {
-}
+GenericParticle::~GenericParticle() {}
 
 // ====== SETTERS =====
 /// sets master track reference (or even embed it into the object)
 void GenericParticle::setTrack(const reco::TrackRef &ref, bool embed) {
-    trackRef_ = ref;
-    if (embed) embedTrack(); else track_.clear();
+  trackRef_ = ref;
+  if (embed)
+    embedTrack();
+  else
+    track_.clear();
 }
 
 /// sets multiple track references (or even embed the tracks into the object - whatch out for disk size issues!)
 void GenericParticle::setTracks(const reco::TrackRefVector &refs, bool embed) {
-    trackRefs_ = refs;
-    if (embed) embedTracks(); else tracks_.clear();
+  trackRefs_ = refs;
+  if (embed)
+    embedTracks();
+  else
+    tracks_.clear();
 }
 
 /// sets stand-alone muon track reference (or even embed it into the object)
 void GenericParticle::setStandAloneMuon(const reco::TrackRef &ref, bool embed) {
-    standaloneTrackRef_ = ref;
-    if (embed) embedStandalone(); else standaloneTrack_.clear();
+  standaloneTrackRef_ = ref;
+  if (embed)
+    embedStandalone();
+  else
+    standaloneTrack_.clear();
 }
 
 /// sets combined muon track reference (or even embed it into the object)
 void GenericParticle::setCombinedMuon(const reco::TrackRef &ref, bool embed) {
-    combinedTrackRef_ = ref;
-    if (embed) embedCombined(); else combinedTrack_.clear();
+  combinedTrackRef_ = ref;
+  if (embed)
+    embedCombined();
+  else
+    combinedTrack_.clear();
 }
 
 /// sets gsf track reference (or even embed it into the object)
 void GenericParticle::setGsfTrack(const reco::GsfTrackRef &ref, bool embed) {
-    gsfTrackRef_ = ref;
-    if (embed) embedGsfTrack(); else gsfTrack_.clear();
+  gsfTrackRef_ = ref;
+  if (embed)
+    embedGsfTrack();
+  else
+    gsfTrack_.clear();
 }
 
 /// sets supercluster reference (or even embed it into the object)
 void GenericParticle::setSuperCluster(const reco::SuperClusterRef &ref, bool embed) {
-    superClusterRef_ = ref;
-    if (embed) embedSuperCluster(); else superCluster_.clear();
+  superClusterRef_ = ref;
+  if (embed)
+    embedSuperCluster();
+  else
+    superCluster_.clear();
 }
 
 /// sets calotower reference (or even embed it into the object)
 void GenericParticle::setCaloTower(const CaloTowerRef &ref, bool embed) {
-    caloTowerRef_ = ref;
-    if (embed) { 
-        embedCaloTower(); 
-    } else if (!caloTower_.empty()) { 
-        CaloTowerCollection().swap(caloTower_); 
-    }
+  caloTowerRef_ = ref;
+  if (embed) {
+    embedCaloTower();
+  } else if (!caloTower_.empty()) {
+    CaloTowerCollection().swap(caloTower_);
+  }
 }
-
 
 // ========== EMBEDDER METHODS
-/// embeds the master track instead of keeping a reference to it      
-void GenericParticle::embedTrack() { 
-    track_.clear();
-    if (trackRef_.isNonnull()) track_.push_back(*trackRef_); // import
-    trackRef_ = reco::TrackRef(); // clear, to save space (zeroes compress better)
+/// embeds the master track instead of keeping a reference to it
+void GenericParticle::embedTrack() {
+  track_.clear();
+  if (trackRef_.isNonnull())
+    track_.push_back(*trackRef_);  // import
+  trackRef_ = reco::TrackRef();    // clear, to save space (zeroes compress better)
 }
 /// embeds the other tracks instead of keeping references
-void GenericParticle::embedTracks() { 
-    tracks_.clear();
-    tracks_.reserve(trackRefs_.size());
-    for (reco::TrackRefVector::const_iterator it = trackRefs_.begin(); it != trackRefs_.end(); ++it) {
-        if (it->isNonnull()) tracks_.push_back(**it); // embed track
-    }
-    trackRefs_ = reco::TrackRefVector(); // clear, to save space
+void GenericParticle::embedTracks() {
+  tracks_.clear();
+  tracks_.reserve(trackRefs_.size());
+  for (reco::TrackRefVector::const_iterator it = trackRefs_.begin(); it != trackRefs_.end(); ++it) {
+    if (it->isNonnull())
+      tracks_.push_back(**it);  // embed track
+  }
+  trackRefs_ = reco::TrackRefVector();  // clear, to save space
 }
-/// embeds the stand-alone track instead of keeping a reference to it      
-void GenericParticle::embedStandalone() { 
-    standaloneTrack_.clear();
-    if (standaloneTrackRef_.isNonnull()) standaloneTrack_.push_back(*standaloneTrackRef_); // import
-    standaloneTrackRef_ = reco::TrackRef(); // clear, to save space (zeroes compress better)
+/// embeds the stand-alone track instead of keeping a reference to it
+void GenericParticle::embedStandalone() {
+  standaloneTrack_.clear();
+  if (standaloneTrackRef_.isNonnull())
+    standaloneTrack_.push_back(*standaloneTrackRef_);  // import
+  standaloneTrackRef_ = reco::TrackRef();              // clear, to save space (zeroes compress better)
 }
-/// embeds the combined track instead of keeping a reference to it      
-void GenericParticle::embedCombined() { 
-    combinedTrack_.clear();
-    if (combinedTrackRef_.isNonnull()) combinedTrack_.push_back(*combinedTrackRef_); // import
-    combinedTrackRef_ = reco::TrackRef(); // clear, to save space (zeroes compress better)
+/// embeds the combined track instead of keeping a reference to it
+void GenericParticle::embedCombined() {
+  combinedTrack_.clear();
+  if (combinedTrackRef_.isNonnull())
+    combinedTrack_.push_back(*combinedTrackRef_);  // import
+  combinedTrackRef_ = reco::TrackRef();            // clear, to save space (zeroes compress better)
 }
-/// embeds the gsf track instead of keeping a reference to it      
-void GenericParticle::embedGsfTrack() { 
-    gsfTrack_.clear();
-    if (gsfTrackRef_.isNonnull()) gsfTrack_.push_back(*gsfTrackRef_); // import
-    gsfTrackRef_ = reco::GsfTrackRef(); // clear, to save space (zeroes compress better)
-}
-
-/// embeds the supercluster instead of keeping a reference to it      
-void GenericParticle::embedSuperCluster() { 
-    superCluster_.clear();
-    if (superClusterRef_.isNonnull()) superCluster_.push_back(*superClusterRef_); // import
-    superClusterRef_ = reco::SuperClusterRef(); // clear, to save space (zeroes compress better)
-}
-/// embeds the calotower instead of keeping a reference to it      
-void GenericParticle::embedCaloTower() { 
-    if (!caloTower_.empty()) CaloTowerCollection().swap(caloTower_); 
-    if (caloTowerRef_.isNonnull()) caloTower_.push_back(*caloTowerRef_); // import
-    caloTowerRef_ = CaloTowerRef(); // clear, to save space (zeroes compress better)
+/// embeds the gsf track instead of keeping a reference to it
+void GenericParticle::embedGsfTrack() {
+  gsfTrack_.clear();
+  if (gsfTrackRef_.isNonnull())
+    gsfTrack_.push_back(*gsfTrackRef_);  // import
+  gsfTrackRef_ = reco::GsfTrackRef();    // clear, to save space (zeroes compress better)
 }
 
+/// embeds the supercluster instead of keeping a reference to it
+void GenericParticle::embedSuperCluster() {
+  superCluster_.clear();
+  if (superClusterRef_.isNonnull())
+    superCluster_.push_back(*superClusterRef_);  // import
+  superClusterRef_ = reco::SuperClusterRef();    // clear, to save space (zeroes compress better)
+}
+/// embeds the calotower instead of keeping a reference to it
+void GenericParticle::embedCaloTower() {
+  if (!caloTower_.empty())
+    CaloTowerCollection().swap(caloTower_);
+  if (caloTowerRef_.isNonnull())
+    caloTower_.push_back(*caloTowerRef_);  // import
+  caloTowerRef_ = CaloTowerRef();          // clear, to save space (zeroes compress better)
+}
 
 void GenericParticle::fillInFrom(const reco::Candidate &cand) {
-    // first, kinematics & status
-    setCharge(cand.charge());
-    setP4(cand.polarP4());
-    setVertex(cand.vertex());
-    setPdgId(cand.pdgId());
-    setStatus(cand.status());
-    // then RECO part, if available
-    const reco::RecoCandidate *rc = dynamic_cast<const reco::RecoCandidate *>(&cand);
-    if (rc != nullptr) {
-        setTrack(rc->track());    
-        setGsfTrack(rc->gsfTrack());    
-        setStandAloneMuon(rc->standAloneMuon());    
-        setCombinedMuon(rc->combinedMuon());
-        setSuperCluster(rc->superCluster());    
-        setCaloTower(rc->caloTower());    
-        size_t ntracks = rc->numberOfTracks();
-        if (ntracks > 0) {
-            reco::TrackRefVector tracks;
-            for (size_t i = 0; i < ntracks; ++i) {
-                tracks.push_back(rc->track(i));
-            }
-            setTracks(tracks);
-        }
+  // first, kinematics & status
+  setCharge(cand.charge());
+  setP4(cand.polarP4());
+  setVertex(cand.vertex());
+  setPdgId(cand.pdgId());
+  setStatus(cand.status());
+  // then RECO part, if available
+  const reco::RecoCandidate *rc = dynamic_cast<const reco::RecoCandidate *>(&cand);
+  if (rc != nullptr) {
+    setTrack(rc->track());
+    setGsfTrack(rc->gsfTrack());
+    setStandAloneMuon(rc->standAloneMuon());
+    setCombinedMuon(rc->combinedMuon());
+    setSuperCluster(rc->superCluster());
+    setCaloTower(rc->caloTower());
+    size_t ntracks = rc->numberOfTracks();
+    if (ntracks > 0) {
+      reco::TrackRefVector tracks;
+      for (size_t i = 0; i < ntracks; ++i) {
+        tracks.push_back(rc->track(i));
+      }
+      setTracks(tracks);
     }
+  }
 }
 
-bool GenericParticle::overlap( const reco::Candidate &cand ) const {
-    const reco::RecoCandidate *rc = dynamic_cast<const reco::RecoCandidate *>(&cand);
-    if (rc != nullptr) {
-        if (rc->track().isNonnull()          && (track() == rc->track())) return true;
-        if (rc->gsfTrack().isNonnull()       && (gsfTrack() == rc->gsfTrack())) return true;
-        if (rc->standAloneMuon().isNonnull() && (standAloneMuon() == rc->standAloneMuon())) return true;
-        if (rc->combinedMuon().isNonnull()   && (combinedMuon() == rc->combinedMuon())) return true;
-        if (rc->superCluster().isNonnull()   && (superCluster() == rc->superCluster())) return true;
-        if (rc->caloTower().isNonnull()      && (caloTower() == rc->caloTower())) return true;
-   }
-    const GenericParticle *rc2 = dynamic_cast<const GenericParticle *>(&cand);
-    if (rc2 != nullptr) {
-        if (rc2->track().isNonnull()          && (track() == rc2->track())) return true;
-        if (rc2->gsfTrack().isNonnull()       && (gsfTrack() == rc2->gsfTrack())) return true;
-        if (rc2->standAloneMuon().isNonnull() && (standAloneMuon() == rc2->standAloneMuon())) return true;
-        if (rc2->combinedMuon().isNonnull()   && (combinedMuon() == rc2->combinedMuon())) return true;
-        if (rc2->superCluster().isNonnull()   && (superCluster() == rc2->superCluster())) return true;
-        if (rc2->caloTower().isNonnull()      && (caloTower() == rc2->caloTower())) return true;
-   }
-   return false;
+bool GenericParticle::overlap(const reco::Candidate &cand) const {
+  const reco::RecoCandidate *rc = dynamic_cast<const reco::RecoCandidate *>(&cand);
+  if (rc != nullptr) {
+    if (rc->track().isNonnull() && (track() == rc->track()))
+      return true;
+    if (rc->gsfTrack().isNonnull() && (gsfTrack() == rc->gsfTrack()))
+      return true;
+    if (rc->standAloneMuon().isNonnull() && (standAloneMuon() == rc->standAloneMuon()))
+      return true;
+    if (rc->combinedMuon().isNonnull() && (combinedMuon() == rc->combinedMuon()))
+      return true;
+    if (rc->superCluster().isNonnull() && (superCluster() == rc->superCluster()))
+      return true;
+    if (rc->caloTower().isNonnull() && (caloTower() == rc->caloTower()))
+      return true;
+  }
+  const GenericParticle *rc2 = dynamic_cast<const GenericParticle *>(&cand);
+  if (rc2 != nullptr) {
+    if (rc2->track().isNonnull() && (track() == rc2->track()))
+      return true;
+    if (rc2->gsfTrack().isNonnull() && (gsfTrack() == rc2->gsfTrack()))
+      return true;
+    if (rc2->standAloneMuon().isNonnull() && (standAloneMuon() == rc2->standAloneMuon()))
+      return true;
+    if (rc2->combinedMuon().isNonnull() && (combinedMuon() == rc2->combinedMuon()))
+      return true;
+    if (rc2->superCluster().isNonnull() && (superCluster() == rc2->superCluster()))
+      return true;
+    if (rc2->caloTower().isNonnull() && (caloTower() == rc2->caloTower()))
+      return true;
+  }
+  return false;
 }

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -9,218 +9,186 @@
 using namespace pat;
 
 /// default constructor
-Jet::Jet() :
-  PATObject<reco::Jet>(reco::Jet()),
-  embeddedCaloTowers_(false),
-  embeddedPFCandidates_(false),
-  jetCharge_(0.)
-{
-}
+Jet::Jet()
+    : PATObject<reco::Jet>(reco::Jet()), embeddedCaloTowers_(false), embeddedPFCandidates_(false), jetCharge_(0.) {}
 
 /// constructor from a reco::Jet
-Jet::Jet(const reco::Jet & aJet) :
-  PATObject<reco::Jet>(aJet),
-  embeddedCaloTowers_(false),
-  embeddedPFCandidates_(false),
-  jetCharge_(0.0)
-{
+Jet::Jet(const reco::Jet& aJet)
+    : PATObject<reco::Jet>(aJet), embeddedCaloTowers_(false), embeddedPFCandidates_(false), jetCharge_(0.0) {
   tryImportSpecific(aJet);
 }
 
 /// constructor from ref to reco::Jet
-Jet::Jet(const edm::Ptr<reco::Jet> & aJetRef) :
-  PATObject<reco::Jet>(aJetRef),
-  embeddedCaloTowers_(false),
-  embeddedPFCandidates_(false),
-  jetCharge_(0.0)
-{
+Jet::Jet(const edm::Ptr<reco::Jet>& aJetRef)
+    : PATObject<reco::Jet>(aJetRef), embeddedCaloTowers_(false), embeddedPFCandidates_(false), jetCharge_(0.0) {
   tryImportSpecific(*aJetRef);
 }
 
 /// constructor from ref to reco::Jet
-Jet::Jet(const edm::RefToBase<reco::Jet> & aJetRef) :
-  PATObject<reco::Jet>(aJetRef),
-  embeddedCaloTowers_(false),
-  embeddedPFCandidates_(false),
-  jetCharge_(0.0)
-{
+Jet::Jet(const edm::RefToBase<reco::Jet>& aJetRef)
+    : PATObject<reco::Jet>(aJetRef), embeddedCaloTowers_(false), embeddedPFCandidates_(false), jetCharge_(0.0) {
   tryImportSpecific(*aJetRef);
 }
 
 /// constructure from ref to pat::Jet
-Jet::Jet(const edm::RefToBase<pat::Jet> & aJetRef) :
-  Jet(*aJetRef)
-{
+Jet::Jet(const edm::RefToBase<pat::Jet>& aJetRef) : Jet(*aJetRef) {
   refToOrig_ = edm::Ptr<reco::Candidate>(aJetRef.id(), aJetRef.get(), aJetRef.key());
 }
 
 /// constructure from ref to pat::Jet
-Jet::Jet(const edm::Ptr<pat::Jet> & aJetRef) :
-  Jet(*aJetRef)
-{
-  refToOrig_ = aJetRef;
-}
+Jet::Jet(const edm::Ptr<pat::Jet>& aJetRef) : Jet(*aJetRef) { refToOrig_ = aJetRef; }
 
-std::ostream& 
-reco::operator<<(std::ostream& out, const pat::Jet& obj) 
-{
-  if(!out) return out;
-  
+std::ostream& reco::operator<<(std::ostream& out, const pat::Jet& obj) {
+  if (!out)
+    return out;
+
   out << "\tpat::Jet: ";
   out << std::setiosflags(std::ios::right);
   out << std::setiosflags(std::ios::fixed);
   out << std::setprecision(3);
-  out << " E/pT/eta/phi " 
-      << obj.energy()<<"/"
-      << obj.pt()<<"/"
-      << obj.eta()<<"/"
-      << obj.phi();
-  return out; 
+  out << " E/pT/eta/phi " << obj.energy() << "/" << obj.pt() << "/" << obj.eta() << "/" << obj.phi();
+  return out;
 }
 
 /// constructor helper that tries to import the specific info from the source jet
-void Jet::tryImportSpecific(const reco::Jet& source)
-{
-  const std::type_info & type = typeid(source);
-  if( type == typeid(reco::CaloJet) ){
-    specificCalo_.push_back( (static_cast<const reco::CaloJet&>(source)).getSpecific() );
-  } else if( type == typeid(reco::JPTJet) ){
-    reco::JPTJet const & jptJet = static_cast<reco::JPTJet const &>(source);
-    specificJPT_.push_back( jptJet.getSpecific() );
-    reco::CaloJet const * caloJet = nullptr;
-    if ( jptJet.getCaloJetRef().isNonnull() && jptJet.getCaloJetRef().isAvailable() ) {
-      caloJet = dynamic_cast<reco::CaloJet const *>( jptJet.getCaloJetRef().get() );
+void Jet::tryImportSpecific(const reco::Jet& source) {
+  const std::type_info& type = typeid(source);
+  if (type == typeid(reco::CaloJet)) {
+    specificCalo_.push_back((static_cast<const reco::CaloJet&>(source)).getSpecific());
+  } else if (type == typeid(reco::JPTJet)) {
+    reco::JPTJet const& jptJet = static_cast<reco::JPTJet const&>(source);
+    specificJPT_.push_back(jptJet.getSpecific());
+    reco::CaloJet const* caloJet = nullptr;
+    if (jptJet.getCaloJetRef().isNonnull() && jptJet.getCaloJetRef().isAvailable()) {
+      caloJet = dynamic_cast<reco::CaloJet const*>(jptJet.getCaloJetRef().get());
     }
-    if ( caloJet != nullptr ) {
-      specificCalo_.push_back( caloJet->getSpecific() );
+    if (caloJet != nullptr) {
+      specificCalo_.push_back(caloJet->getSpecific());
+    } else {
+      edm::LogWarning("OptionalProductNotFound")
+          << " in pat::Jet, Attempted to add Calo Specifics to JPT Jets, but failed."
+          << " Jet ID for JPT Jets will not be available for you." << std::endl;
     }
-    else {
-      edm::LogWarning("OptionalProductNotFound") << " in pat::Jet, Attempted to add Calo Specifics to JPT Jets, but failed."
-						 << " Jet ID for JPT Jets will not be available for you." << std::endl;
-    }
-  } else if( type == typeid(reco::PFJet) ){
-    specificPF_.push_back( (static_cast<const reco::PFJet&>(source)).getSpecific() );
+  } else if (type == typeid(reco::PFJet)) {
+    specificPF_.push_back((static_cast<const reco::PFJet&>(source)).getSpecific());
   }
 }
 
 /// destructor
-Jet::~Jet() {
-}
+Jet::~Jet() {}
 
 /// ============= CaloJet methods ============
 
-CaloTowerPtr Jet::getCaloConstituent (unsigned fIndex) const {
-    if (embeddedCaloTowers_) {
-      // Refactorized PAT access
-      if ( !caloTowersFwdPtr_.empty() ) {
-	return (fIndex < caloTowersFwdPtr_.size() ?
-		caloTowersFwdPtr_[fIndex].ptr() : CaloTowerPtr());
-      }
-      // Compatibility PAT access
-      else {
-	if ( !caloTowers_.empty() ) {
-	  return (fIndex < caloTowers_.size() ?
-		  CaloTowerPtr(&caloTowers_, fIndex) : CaloTowerPtr());
-
-	}
-      }
+CaloTowerPtr Jet::getCaloConstituent(unsigned fIndex) const {
+  if (embeddedCaloTowers_) {
+    // Refactorized PAT access
+    if (!caloTowersFwdPtr_.empty()) {
+      return (fIndex < caloTowersFwdPtr_.size() ? caloTowersFwdPtr_[fIndex].ptr() : CaloTowerPtr());
     }
-    // Non-embedded access
+    // Compatibility PAT access
     else {
-      Constituent dau = daughterPtr (fIndex);
-      const CaloTower* caloTower = dynamic_cast <const CaloTower*> (dau.get());
-      if (caloTower != nullptr) {
-	return CaloTowerPtr(dau.id(), caloTower, dau.key() );
+      if (!caloTowers_.empty()) {
+        return (fIndex < caloTowers_.size() ? CaloTowerPtr(&caloTowers_, fIndex) : CaloTowerPtr());
       }
-      else {
-	throw cms::Exception("Invalid Constituent") << "CaloJet constituent is not of CaloTower type";
-      }
-
     }
+  }
+  // Non-embedded access
+  else {
+    Constituent dau = daughterPtr(fIndex);
+    const CaloTower* caloTower = dynamic_cast<const CaloTower*>(dau.get());
+    if (caloTower != nullptr) {
+      return CaloTowerPtr(dau.id(), caloTower, dau.key());
+    } else {
+      throw cms::Exception("Invalid Constituent") << "CaloJet constituent is not of CaloTower type";
+    }
+  }
 
-    return CaloTowerPtr ();
+  return CaloTowerPtr();
 }
 
-
-
-std::vector<CaloTowerPtr> const & Jet::getCaloConstituents () const {
-  if ( !caloTowersTemp_.isSet() || !caloTowers_.empty() ) cacheCaloTowers();
+std::vector<CaloTowerPtr> const& Jet::getCaloConstituents() const {
+  if (!caloTowersTemp_.isSet() || !caloTowers_.empty())
+    cacheCaloTowers();
   return *caloTowersTemp_;
 }
 
-
 /// ============= PFJet methods ============
 
-reco::PFCandidatePtr Jet::getPFConstituent (unsigned fIndex) const {
-    if (embeddedPFCandidates_) {
-      // Refactorized PAT access
-      if ( !pfCandidatesFwdPtr_.empty() ) {
-	return (fIndex < pfCandidatesFwdPtr_.size() ?
-		pfCandidatesFwdPtr_[fIndex].ptr() : reco::PFCandidatePtr());
-      }
-      // Compatibility PAT access
-      else {
-	if ( !pfCandidates_.empty() ) {
-	  return (fIndex < pfCandidates_.size() ?
-		  reco::PFCandidatePtr(&pfCandidates_, fIndex) : reco::PFCandidatePtr());
-
-	}
-      }
+reco::PFCandidatePtr Jet::getPFConstituent(unsigned fIndex) const {
+  if (embeddedPFCandidates_) {
+    // Refactorized PAT access
+    if (!pfCandidatesFwdPtr_.empty()) {
+      return (fIndex < pfCandidatesFwdPtr_.size() ? pfCandidatesFwdPtr_[fIndex].ptr() : reco::PFCandidatePtr());
     }
-    // Non-embedded access
+    // Compatibility PAT access
     else {
-      Constituent dau = daughterPtr (fIndex);
-      const reco::PFCandidate* pfCandidate = dynamic_cast <const reco::PFCandidate*> (dau.get());
-      if (pfCandidate) {
-	return reco::PFCandidatePtr(dau.id(), pfCandidate, dau.key() );
+      if (!pfCandidates_.empty()) {
+        return (fIndex < pfCandidates_.size() ? reco::PFCandidatePtr(&pfCandidates_, fIndex) : reco::PFCandidatePtr());
       }
-      else {
-	throw cms::Exception("Invalid Constituent") << "PFJet constituent is not of PFCandidate type";
-      }
-
     }
+  }
+  // Non-embedded access
+  else {
+    Constituent dau = daughterPtr(fIndex);
+    const reco::PFCandidate* pfCandidate = dynamic_cast<const reco::PFCandidate*>(dau.get());
+    if (pfCandidate) {
+      return reco::PFCandidatePtr(dau.id(), pfCandidate, dau.key());
+    } else {
+      throw cms::Exception("Invalid Constituent") << "PFJet constituent is not of PFCandidate type";
+    }
+  }
 
-    return reco::PFCandidatePtr ();
+  return reco::PFCandidatePtr();
 }
 
-std::vector<reco::PFCandidatePtr> const & Jet::getPFConstituents () const {
-  if ( !pfCandidatesTemp_.isSet() || !pfCandidates_.empty() ) cachePFCandidates();
+std::vector<reco::PFCandidatePtr> const& Jet::getPFConstituents() const {
+  if (!pfCandidatesTemp_.isSet() || !pfCandidates_.empty())
+    cachePFCandidates();
   return *pfCandidatesTemp_;
 }
 
-const reco::Candidate * Jet::daughter(size_t i) const {
-  if (isCaloJet() || isJPTJet() ) {
-    if ( embeddedCaloTowers_ ) {
-      if ( !caloTowersFwdPtr_.empty() ) return caloTowersFwdPtr_[i].get();
-      else if ( !caloTowers_.empty() ) return &caloTowers_[i];
-      else return reco::Jet::daughter(i);
+const reco::Candidate* Jet::daughter(size_t i) const {
+  if (isCaloJet() || isJPTJet()) {
+    if (embeddedCaloTowers_) {
+      if (!caloTowersFwdPtr_.empty())
+        return caloTowersFwdPtr_[i].get();
+      else if (!caloTowers_.empty())
+        return &caloTowers_[i];
+      else
+        return reco::Jet::daughter(i);
     }
   }
   if (isPFJet()) {
-    if ( embeddedPFCandidates_ ) {
-      if ( !pfCandidatesFwdPtr_.empty() ) return pfCandidatesFwdPtr_[i].get();
-      else if ( !pfCandidates_.empty() ) return &pfCandidates_[i];
-      else return reco::Jet::daughter(i);
+    if (embeddedPFCandidates_) {
+      if (!pfCandidatesFwdPtr_.empty())
+        return pfCandidatesFwdPtr_[i].get();
+      else if (!pfCandidates_.empty())
+        return &pfCandidates_[i];
+      else
+        return reco::Jet::daughter(i);
     }
   }
-  if ( !subjetCollections_.empty() ) {
-    if ( !daughtersTemp_.isSet() ) cacheDaughters();
+  if (!subjetCollections_.empty()) {
+    if (!daughtersTemp_.isSet())
+      cacheDaughters();
     return daughtersTemp_->at(i).get();
   }
   return reco::Jet::daughter(i);
 }
 
-reco::CandidatePtr Jet::daughterPtr( size_t i ) const {
-  if ( !subjetCollections_.empty() ) {
-    if ( !daughtersTemp_.isSet() ) cacheDaughters();
+reco::CandidatePtr Jet::daughterPtr(size_t i) const {
+  if (!subjetCollections_.empty()) {
+    if (!daughtersTemp_.isSet())
+      cacheDaughters();
     return daughtersTemp_->at(i);
   }
   return reco::Jet::daughterPtr(i);
 }
 
-const reco::CompositePtrCandidate::daughters & Jet::daughterPtrVector() const {
-  if ( !subjetCollections_.empty() ) {
-    if ( !daughtersTemp_.isSet() ) cacheDaughters();
+const reco::CompositePtrCandidate::daughters& Jet::daughterPtrVector() const {
+  if (!subjetCollections_.empty()) {
+    if (!daughtersTemp_.isSet())
+      cacheDaughters();
     return *daughtersTemp_;
   }
   return reco::Jet::daughterPtrVector();
@@ -228,126 +196,126 @@ const reco::CompositePtrCandidate::daughters & Jet::daughterPtrVector() const {
 
 size_t Jet::numberOfDaughters() const {
   if (isCaloJet() || isJPTJet()) {
-    if ( embeddedCaloTowers_ ) {
-      if ( !caloTowersFwdPtr_.empty() ) return caloTowersFwdPtr_.size();
-      else if ( !caloTowers_.empty() ) return caloTowers_.size();
-      else return reco::Jet::numberOfDaughters();
+    if (embeddedCaloTowers_) {
+      if (!caloTowersFwdPtr_.empty())
+        return caloTowersFwdPtr_.size();
+      else if (!caloTowers_.empty())
+        return caloTowers_.size();
+      else
+        return reco::Jet::numberOfDaughters();
     }
   }
   if (isPFJet()) {
-    if ( embeddedPFCandidates_ ) {
-      if ( !pfCandidatesFwdPtr_.empty() ) return pfCandidatesFwdPtr_.size();
-      else if ( !pfCandidates_.empty() ) return pfCandidates_.size();
-      else return reco::Jet::numberOfDaughters();
+    if (embeddedPFCandidates_) {
+      if (!pfCandidatesFwdPtr_.empty())
+        return pfCandidatesFwdPtr_.size();
+      else if (!pfCandidates_.empty())
+        return pfCandidates_.size();
+      else
+        return reco::Jet::numberOfDaughters();
     }
   }
-  if ( !subjetCollections_.empty() ) {
-    if ( !daughtersTemp_.isSet() ) cacheDaughters();
+  if (!subjetCollections_.empty()) {
+    if (!daughtersTemp_.isSet())
+      cacheDaughters();
     return daughtersTemp_->size();
   }
   return reco::Jet::numberOfDaughters();
 }
 
 /// return the matched generated jet
-const reco::GenJet * Jet::genJet() const {
-  if (!genJet_.empty()) return  &(genJet_.front());
-  else if ( !genJetRef_.empty() ) return genJetRef_[0].get();
-  else return genJetFwdRef_.get();
+const reco::GenJet* Jet::genJet() const {
+  if (!genJet_.empty())
+    return &(genJet_.front());
+  else if (!genJetRef_.empty())
+    return genJetRef_[0].get();
+  else
+    return genJetFwdRef_.get();
 }
 
 /// return the parton-based flavour of the jet
-int Jet::partonFlavour() const {
-  return jetFlavourInfo_.getPartonFlavour();
-}
+int Jet::partonFlavour() const { return jetFlavourInfo_.getPartonFlavour(); }
 
 /// return the hadron-based flavour of the jet
-int Jet::hadronFlavour() const {
-  return jetFlavourInfo_.getHadronFlavour();
-}
+int Jet::hadronFlavour() const { return jetFlavourInfo_.getHadronFlavour(); }
 
 /// return the JetFlavourInfo of the jet
-const reco::JetFlavourInfo & Jet::jetFlavourInfo() const {
-  return jetFlavourInfo_;
-}
+const reco::JetFlavourInfo& Jet::jetFlavourInfo() const { return jetFlavourInfo_; }
 
 /// ============= Jet Energy Correction methods ============
 
 // initialize the jet to a given JEC level during creation starting from Uncorrected
-void Jet::initializeJEC(unsigned int level, const JetCorrFactors::Flavor& flavor, unsigned int set)
-{
+void Jet::initializeJEC(unsigned int level, const JetCorrFactors::Flavor& flavor, unsigned int set) {
   currentJECSet(set);
   currentJECLevel(level);
   currentJECFlavor(flavor);
-  setP4(jec_[set].correction(level, flavor)*p4());
+  setP4(jec_[set].correction(level, flavor) * p4());
 }
 
 /// return true if this jet carries the jet correction factors of a different set, for systematic studies
-int Jet::jecSet(const std::string& set) const
-{
-  for(std::vector<pat::JetCorrFactors>::const_iterator corrFactor=jec_.begin(); corrFactor!=jec_.end(); ++corrFactor)
-    if( corrFactor->jecSet()==set ){ return (corrFactor-jec_.begin()); }
+int Jet::jecSet(const std::string& set) const {
+  for (std::vector<pat::JetCorrFactors>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor)
+    if (corrFactor->jecSet() == set) {
+      return (corrFactor - jec_.begin());
+    }
   return -1;
 }
 
 /// all available label-names of all sets of jet energy corrections
-const std::vector<std::string> Jet::availableJECSets() const
-{
+const std::vector<std::string> Jet::availableJECSets() const {
   std::vector<std::string> sets;
-  for(std::vector<pat::JetCorrFactors>::const_iterator corrFactor=jec_.begin(); corrFactor!=jec_.end(); ++corrFactor)
+  for (std::vector<pat::JetCorrFactors>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor)
     sets.push_back(corrFactor->jecSet());
   return sets;
 }
 
-const std::vector<std::string> Jet::availableJECLevels(const int& set) const
-{
-  return set>=0 ? jec_.at(set).correctionLabels() : std::vector<std::string>();
+const std::vector<std::string> Jet::availableJECLevels(const int& set) const {
+  return set >= 0 ? jec_.at(set).correctionLabels() : std::vector<std::string>();
 }
 
 /// correction factor to the given level for a specific set
 /// of correction factors, starting from the current level
-float Jet::jecFactor(const std::string& level, const std::string& flavor, const std::string& set) const
-{
-  for(unsigned int idx=0; idx<jec_.size(); ++idx){
-    if(set.empty() || jec_.at(idx).jecSet()==set){
-      if(jec_[idx].jecLevel(level)>=0){
-	return jecFactor(jec_[idx].jecLevel(level), jec_[idx].jecFlavor(flavor), idx);
-      }
-      else{
-	throw cms::Exception("InvalidRequest") << "This JEC level " << level << " does not exist. \n";
+float Jet::jecFactor(const std::string& level, const std::string& flavor, const std::string& set) const {
+  for (unsigned int idx = 0; idx < jec_.size(); ++idx) {
+    if (set.empty() || jec_.at(idx).jecSet() == set) {
+      if (jec_[idx].jecLevel(level) >= 0) {
+        return jecFactor(jec_[idx].jecLevel(level), jec_[idx].jecFlavor(flavor), idx);
+      } else {
+        throw cms::Exception("InvalidRequest") << "This JEC level " << level << " does not exist. \n";
       }
     }
   }
   throw cms::Exception("InvalidRequest") << "This jet does not carry any jet energy correction factor information \n"
-					 << "for a jet energy correction set with label " << set << "\n";
+                                         << "for a jet energy correction set with label " << set << "\n";
 }
 
 /// correction factor to the given level for a specific set
 /// of correction factors, starting from the current level
-float Jet::jecFactor(const unsigned int& level, const JetCorrFactors::Flavor& flavor, const unsigned int& set) const
-{
-  if(!jecSetsAvailable()){
+float Jet::jecFactor(const unsigned int& level, const JetCorrFactors::Flavor& flavor, const unsigned int& set) const {
+  if (!jecSetsAvailable()) {
     throw cms::Exception("InvalidRequest") << "This jet does not carry any jet energy correction factor information \n";
   }
-  if(!jecSetAvailable(set)){
+  if (!jecSetAvailable(set)) {
     throw cms::Exception("InvalidRequest") << "This jet does not carry any jet energy correction factor information \n"
-					   << "for a jet energy correction set with index " << set << "\n";
+                                           << "for a jet energy correction set with index " << set << "\n";
   }
-  return jec_.at(set).correction(level, flavor)/jec_.at(currentJECSet_).correction(currentJECLevel_, currentJECFlavor_);
+  return jec_.at(set).correction(level, flavor) /
+         jec_.at(currentJECSet_).correction(currentJECLevel_, currentJECFlavor_);
 }
 
 /// copy of the jet with correction factor to target step for
 /// the set of correction factors, which is currently in use
-Jet Jet::correctedJet(const std::string& level, const std::string& flavor, const std::string& set) const
-{
+Jet Jet::correctedJet(const std::string& level, const std::string& flavor, const std::string& set) const {
   // rescale p4 of the jet; the update of current values is
   // done within the called jecFactor function
-  for(unsigned int idx=0; idx<jec_.size(); ++idx){
-    if(set.empty() || jec_.at(idx).jecSet()==set){
-      if(jec_[idx].jecLevel(level)>=0){
-	return correctedJet(jec_[idx].jecLevel(level), jec_[idx].jecFlavor(flavor), idx);
-      }
-      else{
-	throw cms::Exception("InvalidRequest") << "This JEC level " << level << " does not exist. \n";
+  for (unsigned int idx = 0; idx < jec_.size(); ++idx) {
+    if (set.empty() || jec_.at(idx).jecSet() == set) {
+      if (jec_[idx].jecLevel(level) >= 0) {
+        return correctedJet(jec_[idx].jecLevel(level), jec_[idx].jecFlavor(flavor), idx);
+      } else {
+        throw cms::Exception("InvalidRequest") << "This JEC level " << level << " does not exist. \n";
       }
     }
   }
@@ -356,28 +324,26 @@ Jet Jet::correctedJet(const std::string& level, const std::string& flavor, const
 
 /// copy of the jet with correction factor to target step for
 /// the set of correction factors, which is currently in use
-Jet Jet::correctedJet(const unsigned int& level, const JetCorrFactors::Flavor& flavor, const unsigned int& set) const
-{
+Jet Jet::correctedJet(const unsigned int& level, const JetCorrFactors::Flavor& flavor, const unsigned int& set) const {
   Jet correctedJet(*this);
   //rescale p4 of the jet
-  correctedJet.setP4(jecFactor(level, flavor, set)*p4());
+  correctedJet.setP4(jecFactor(level, flavor, set) * p4());
   // update current level, flavor and set
-  correctedJet.currentJECSet(set); correctedJet.currentJECLevel(level); correctedJet.currentJECFlavor(flavor);
+  correctedJet.currentJECSet(set);
+  correctedJet.currentJECLevel(level);
+  correctedJet.currentJECFlavor(flavor);
   return correctedJet;
 }
 
-
 /// ============= BTag information methods ============
 
-const std::vector<std::pair<std::string, float> > & Jet::getPairDiscri() const {
-   return pairDiscriVector_;
-}
+const std::vector<std::pair<std::string, float>>& Jet::getPairDiscri() const { return pairDiscriVector_; }
 
 /// get b discriminant from label name
-float Jet::bDiscriminator(const std::string & aLabel) const {
+float Jet::bDiscriminator(const std::string& aLabel) const {
   float discriminator = -1000.;
-  for(int i=(int(pairDiscriVector_.size())-1); i>=0; i--){
-    if(pairDiscriVector_[i].first == aLabel){
+  for (int i = (int(pairDiscriVector_.size()) - 1); i >= 0; i--) {
+    if (pairDiscriVector_[i].first == aLabel) {
       discriminator = pairDiscriVector_[i].second;
       break;
     }
@@ -385,178 +351,142 @@ float Jet::bDiscriminator(const std::string & aLabel) const {
   return discriminator;
 }
 
-const reco::BaseTagInfo * Jet::tagInfo(const std::string &label) const {
-  for(int i=(int(tagInfoLabels_.size())-1); i>=0; i--){
+const reco::BaseTagInfo* Jet::tagInfo(const std::string& label) const {
+  for (int i = (int(tagInfoLabels_.size()) - 1); i >= 0; i--) {
     if (tagInfoLabels_[i] == label) {
-      if ( !tagInfosFwdPtr_.empty() ) return tagInfosFwdPtr_[i].get();
-      else if ( !tagInfos_.empty() )  return & tagInfos_[i];
+      if (!tagInfosFwdPtr_.empty())
+        return tagInfosFwdPtr_[i].get();
+      else if (!tagInfos_.empty())
+        return &tagInfos_[i];
       return nullptr;
     }
   }
   return nullptr;
 }
 
-
-const reco::CandIPTagInfo *
-Jet::tagInfoCandIP(const std::string &label) const {
-    return tagInfoByTypeOrLabel<reco::CandIPTagInfo>(label);
+const reco::CandIPTagInfo* Jet::tagInfoCandIP(const std::string& label) const {
+  return tagInfoByTypeOrLabel<reco::CandIPTagInfo>(label);
 }
 
-const reco::TrackIPTagInfo *
-Jet::tagInfoTrackIP(const std::string &label) const {
-    return tagInfoByTypeOrLabel<reco::TrackIPTagInfo>(label);
+const reco::TrackIPTagInfo* Jet::tagInfoTrackIP(const std::string& label) const {
+  return tagInfoByTypeOrLabel<reco::TrackIPTagInfo>(label);
 }
 
-const reco::CandSoftLeptonTagInfo *
-Jet::tagInfoCandSoftLepton(const std::string &label) const {
-    return tagInfoByTypeOrLabel<reco::CandSoftLeptonTagInfo>(label);
+const reco::CandSoftLeptonTagInfo* Jet::tagInfoCandSoftLepton(const std::string& label) const {
+  return tagInfoByTypeOrLabel<reco::CandSoftLeptonTagInfo>(label);
 }
 
-const reco::SoftLeptonTagInfo *
-Jet::tagInfoSoftLepton(const std::string &label) const {
-    return tagInfoByTypeOrLabel<reco::SoftLeptonTagInfo>(label);
+const reco::SoftLeptonTagInfo* Jet::tagInfoSoftLepton(const std::string& label) const {
+  return tagInfoByTypeOrLabel<reco::SoftLeptonTagInfo>(label);
 }
 
-const reco::CandSecondaryVertexTagInfo *
-Jet::tagInfoCandSecondaryVertex(const std::string &label) const {
-    return tagInfoByTypeOrLabel<reco::CandSecondaryVertexTagInfo>(label);
+const reco::CandSecondaryVertexTagInfo* Jet::tagInfoCandSecondaryVertex(const std::string& label) const {
+  return tagInfoByTypeOrLabel<reco::CandSecondaryVertexTagInfo>(label);
 }
 
-const reco::SecondaryVertexTagInfo *
-Jet::tagInfoSecondaryVertex(const std::string &label) const {
-    return tagInfoByTypeOrLabel<reco::SecondaryVertexTagInfo>(label);
+const reco::SecondaryVertexTagInfo* Jet::tagInfoSecondaryVertex(const std::string& label) const {
+  return tagInfoByTypeOrLabel<reco::SecondaryVertexTagInfo>(label);
 }
 
-const reco::BoostedDoubleSVTagInfo *
-Jet::tagInfoBoostedDoubleSV(const std::string &label) const {
-    return tagInfoByTypeOrLabel<reco::BoostedDoubleSVTagInfo>(label);
+const reco::BoostedDoubleSVTagInfo* Jet::tagInfoBoostedDoubleSV(const std::string& label) const {
+  return tagInfoByTypeOrLabel<reco::BoostedDoubleSVTagInfo>(label);
 }
 
-void
-Jet::addTagInfo(const std::string &label,
-		const TagInfoFwdPtrCollection::value_type &info) {
-    std::string::size_type idx = label.find("TagInfos");
-    if (idx == std::string::npos) {
-      tagInfoLabels_.push_back(label);
-    } else {
-        tagInfoLabels_.push_back(label.substr(0,idx));
-    }
-    tagInfosFwdPtr_.push_back(info);
+void Jet::addTagInfo(const std::string& label, const TagInfoFwdPtrCollection::value_type& info) {
+  std::string::size_type idx = label.find("TagInfos");
+  if (idx == std::string::npos) {
+    tagInfoLabels_.push_back(label);
+  } else {
+    tagInfoLabels_.push_back(label.substr(0, idx));
+  }
+  tagInfosFwdPtr_.push_back(info);
 }
-
-
 
 /// method to return the JetCharge computed when creating the Jet
-float Jet::jetCharge() const {
-  return jetCharge_;
-}
+float Jet::jetCharge() const { return jetCharge_; }
 
 /// method to return a vector of refs to the tracks associated to this jet
-const reco::TrackRefVector & Jet::associatedTracks() const {
-  return associatedTracks_;
-}
+const reco::TrackRefVector& Jet::associatedTracks() const { return associatedTracks_; }
 
 /// method to set the vector of refs to the tracks associated to this jet
-void Jet::setAssociatedTracks(const reco::TrackRefVector &tracks) {
-    associatedTracks_ = tracks;
-}
+void Jet::setAssociatedTracks(const reco::TrackRefVector& tracks) { associatedTracks_ = tracks; }
 
 /// method to store the CaloJet constituents internally
-void Jet::setCaloTowers(const CaloTowerFwdPtrCollection & caloTowers) {
+void Jet::setCaloTowers(const CaloTowerFwdPtrCollection& caloTowers) {
   caloTowersFwdPtr_.reserve(caloTowers.size());
-  for(auto const& tower : caloTowers) {
-    caloTowersFwdPtr_.push_back( tower );
+  for (auto const& tower : caloTowers) {
+    caloTowersFwdPtr_.push_back(tower);
   }
   embeddedCaloTowers_ = true;
   caloTowersTemp_.reset();
 }
 
-
 /// method to store the CaloJet constituents internally
-void Jet::setPFCandidates(const PFCandidateFwdPtrCollection & pfCandidates) {
+void Jet::setPFCandidates(const PFCandidateFwdPtrCollection& pfCandidates) {
   pfCandidatesFwdPtr_.reserve(pfCandidates.size());
-  for(auto const& cand : pfCandidates) {
+  for (auto const& cand : pfCandidates) {
     pfCandidatesFwdPtr_.push_back(cand);
   }
   embeddedPFCandidates_ = true;
   pfCandidatesTemp_.reset();
 }
 
-
 /// method to set the matched generated jet reference, embedding if requested
-void Jet::setGenJetRef(const edm::FwdRef<reco::GenJetCollection> & gj)
-{
-  genJetFwdRef_ = gj;
-}
-
-
+void Jet::setGenJetRef(const edm::FwdRef<reco::GenJetCollection>& gj) { genJetFwdRef_ = gj; }
 
 /// method to set the parton-based flavour of the jet
-void Jet::setPartonFlavour(int partonFl) {
-  jetFlavourInfo_.setPartonFlavour(partonFl);
-}
+void Jet::setPartonFlavour(int partonFl) { jetFlavourInfo_.setPartonFlavour(partonFl); }
 
 /// method to set the hadron-based flavour of the jet
-void Jet::setHadronFlavour(int hadronFl) {
-  jetFlavourInfo_.setHadronFlavour(hadronFl);
-}
+void Jet::setHadronFlavour(int hadronFl) { jetFlavourInfo_.setHadronFlavour(hadronFl); }
 
 /// method to set the JetFlavourInfo of the jet
-void Jet::setJetFlavourInfo(const reco::JetFlavourInfo & jetFlavourInfo) {
-  jetFlavourInfo_ = jetFlavourInfo;
-}
+void Jet::setJetFlavourInfo(const reco::JetFlavourInfo& jetFlavourInfo) { jetFlavourInfo_ = jetFlavourInfo; }
 
 /// method to add a algolabel-discriminator pair
-void Jet::addBDiscriminatorPair(const std::pair<std::string, float> & thePair) {
-  pairDiscriVector_.push_back(thePair);
-}
+void Jet::addBDiscriminatorPair(const std::pair<std::string, float>& thePair) { pairDiscriVector_.push_back(thePair); }
 
 /// method to set the jet charge
-void Jet::setJetCharge(float jetCharge) {
-  jetCharge_ = jetCharge;
-}
-
-
+void Jet::setJetCharge(float jetCharge) { jetCharge_ = jetCharge; }
 
 /// method to cache the constituents to allow "user-friendly" access
 void Jet::cacheCaloTowers() const {
   // Clear the cache
   // Here is where we've embedded constituents
-  std::unique_ptr<std::vector<CaloTowerPtr>> caloTowersTemp{ new std::vector<CaloTowerPtr>{}};
-  if ( embeddedCaloTowers_ ) {
+  std::unique_ptr<std::vector<CaloTowerPtr>> caloTowersTemp{new std::vector<CaloTowerPtr>{}};
+  if (embeddedCaloTowers_) {
     // Refactorized PAT access
-    if ( !caloTowersFwdPtr_.empty() ) {
+    if (!caloTowersFwdPtr_.empty()) {
       caloTowersTemp->reserve(caloTowersFwdPtr_.size());
-      for ( CaloTowerFwdPtrVector::const_iterator ibegin=caloTowersFwdPtr_.begin(),
-	      iend = caloTowersFwdPtr_.end(),
-	      icalo = ibegin;
-	    icalo != iend; ++icalo ) {
-	caloTowersTemp->emplace_back( icalo->ptr()  );
+      for (CaloTowerFwdPtrVector::const_iterator ibegin = caloTowersFwdPtr_.begin(),
+                                                 iend = caloTowersFwdPtr_.end(),
+                                                 icalo = ibegin;
+           icalo != iend;
+           ++icalo) {
+        caloTowersTemp->emplace_back(icalo->ptr());
       }
     }
     // Compatibility access
-    else if ( !caloTowers_.empty() ) {
+    else if (!caloTowers_.empty()) {
       caloTowersTemp->reserve(caloTowers_.size());
-      for ( CaloTowerCollection::const_iterator ibegin=caloTowers_.begin(),
-	      iend = caloTowers_.end(),
-	      icalo = ibegin;
-	    icalo != iend; ++icalo ) {
-	caloTowersTemp->emplace_back( &caloTowers_, icalo - ibegin  );
+      for (CaloTowerCollection::const_iterator ibegin = caloTowers_.begin(), iend = caloTowers_.end(), icalo = ibegin;
+           icalo != iend;
+           ++icalo) {
+        caloTowersTemp->emplace_back(&caloTowers_, icalo - ibegin);
       }
     }
   }
   // Non-embedded access
   else {
     const auto nDaughters = numberOfDaughters();
-    caloTowersTemp->reserve(nDaughters);    
-    for ( unsigned fIndex = 0; fIndex < nDaughters; ++fIndex ) {
-      Constituent const & dau = daughterPtr (fIndex);
-      const CaloTower* caloTower = dynamic_cast <const CaloTower*> (dau.get());
+    caloTowersTemp->reserve(nDaughters);
+    for (unsigned fIndex = 0; fIndex < nDaughters; ++fIndex) {
+      Constituent const& dau = daughterPtr(fIndex);
+      const CaloTower* caloTower = dynamic_cast<const CaloTower*>(dau.get());
       if (caloTower) {
-	caloTowersTemp->emplace_back( dau.id(), caloTower,dau.key()  );
-      }
-      else {
-	throw cms::Exception("Invalid Constituent") << "CaloJet constituent is not of CaloTower type";
+        caloTowersTemp->emplace_back(dau.id(), caloTower, dau.key());
+      } else {
+        throw cms::Exception("Invalid Constituent") << "CaloJet constituent is not of CaloTower type";
       }
     }
   }
@@ -565,28 +495,29 @@ void Jet::cacheCaloTowers() const {
 
 /// method to cache the constituents to allow "user-friendly" access
 void Jet::cachePFCandidates() const {
-
-  std::unique_ptr<std::vector<reco::PFCandidatePtr>> pfCandidatesTemp{ new std::vector<reco::PFCandidatePtr>{}};
+  std::unique_ptr<std::vector<reco::PFCandidatePtr>> pfCandidatesTemp{new std::vector<reco::PFCandidatePtr>{}};
   // Here is where we've embedded constituents
-  if ( embeddedPFCandidates_ ) {
+  if (embeddedPFCandidates_) {
     // Refactorized PAT access
-    if ( !pfCandidatesFwdPtr_.empty() ) {
+    if (!pfCandidatesFwdPtr_.empty()) {
       pfCandidatesTemp->reserve(pfCandidatesFwdPtr_.size());
-      for ( PFCandidateFwdPtrCollection::const_iterator ibegin=pfCandidatesFwdPtr_.begin(),
-	      iend = pfCandidatesFwdPtr_.end(),
-	      ipf = ibegin;
-	    ipf != iend; ++ipf ) {
-	pfCandidatesTemp->emplace_back( ipf->ptr()  );
+      for (PFCandidateFwdPtrCollection::const_iterator ibegin = pfCandidatesFwdPtr_.begin(),
+                                                       iend = pfCandidatesFwdPtr_.end(),
+                                                       ipf = ibegin;
+           ipf != iend;
+           ++ipf) {
+        pfCandidatesTemp->emplace_back(ipf->ptr());
       }
     }
     // Compatibility access
-    else if ( !pfCandidates_.empty() ) {
+    else if (!pfCandidates_.empty()) {
       pfCandidatesTemp->reserve(pfCandidates_.size());
-      for ( reco::PFCandidateCollection::const_iterator ibegin=pfCandidates_.begin(),
-	      iend = pfCandidates_.end(),
-	      ipf = ibegin;
-	    ipf != iend; ++ipf ) {
-	pfCandidatesTemp->emplace_back( &pfCandidates_, ipf - ibegin  );
+      for (reco::PFCandidateCollection::const_iterator ibegin = pfCandidates_.begin(),
+                                                       iend = pfCandidates_.end(),
+                                                       ipf = ibegin;
+           ipf != iend;
+           ++ipf) {
+        pfCandidatesTemp->emplace_back(&pfCandidates_, ipf - ibegin);
       }
     }
   }
@@ -594,64 +525,61 @@ void Jet::cachePFCandidates() const {
   else {
     const auto nDaughters = numberOfDaughters();
     pfCandidatesTemp->reserve(nDaughters);
-    for ( unsigned fIndex = 0; fIndex < nDaughters; ++fIndex ) {
-      Constituent const & dau = daughterPtr (fIndex);
-      const reco::PFCandidate* pfCandidate = dynamic_cast <const reco::PFCandidate*> (dau.get());
+    for (unsigned fIndex = 0; fIndex < nDaughters; ++fIndex) {
+      Constituent const& dau = daughterPtr(fIndex);
+      const reco::PFCandidate* pfCandidate = dynamic_cast<const reco::PFCandidate*>(dau.get());
       if (pfCandidate) {
-	pfCandidatesTemp->emplace_back( dau.id(), pfCandidate,dau.key() );
-      }
-      else {
-	throw cms::Exception("Invalid Constituent") << "PFJet constituent is not of PFCandidate type";
+        pfCandidatesTemp->emplace_back(dau.id(), pfCandidate, dau.key());
+      } else {
+        throw cms::Exception("Invalid Constituent") << "PFJet constituent is not of PFCandidate type";
       }
     }
   }
   // Set the cache
   pfCandidatesTemp_.set(std::move(pfCandidatesTemp));
 }
- 
+
 /// method to cache the daughters to allow "user-friendly" access
 void Jet::cacheDaughters() const {
-    // Jets in MiniAOD produced via JetSubstructurePacker contain a mixture of subjets and particles as daughters
-    std::unique_ptr<std::vector<reco::CandidatePtr>> daughtersTemp{ new std::vector<reco::CandidatePtr>{}};
-    const std::vector<reco::CandidatePtr> & jdaus = reco::Jet::daughterPtrVector();
-    for (const reco::CandidatePtr & dau : jdaus) {
-      if (dau->isJet()) {
-        const reco::Jet *subjet = dynamic_cast<const reco::Jet *>(&*dau);
-        if (subjet) {
-          const std::vector<reco::CandidatePtr> & sjdaus = subjet->daughterPtrVector();
-          daughtersTemp->insert(daughtersTemp->end(), sjdaus.begin(), sjdaus.end());
-        }
-      } else
-        daughtersTemp->push_back( dau );
-    }
-    daughtersTemp_.set(std::move(daughtersTemp));
+  // Jets in MiniAOD produced via JetSubstructurePacker contain a mixture of subjets and particles as daughters
+  std::unique_ptr<std::vector<reco::CandidatePtr>> daughtersTemp{new std::vector<reco::CandidatePtr>{}};
+  const std::vector<reco::CandidatePtr>& jdaus = reco::Jet::daughterPtrVector();
+  for (const reco::CandidatePtr& dau : jdaus) {
+    if (dau->isJet()) {
+      const reco::Jet* subjet = dynamic_cast<const reco::Jet*>(&*dau);
+      if (subjet) {
+        const std::vector<reco::CandidatePtr>& sjdaus = subjet->daughterPtrVector();
+        daughtersTemp->insert(daughtersTemp->end(), sjdaus.begin(), sjdaus.end());
+      }
+    } else
+      daughtersTemp->push_back(dau);
+  }
+  daughtersTemp_.set(std::move(daughtersTemp));
 }
 
-
 /// Access to subjet list
-pat::JetPtrCollection const & Jet::subjets( unsigned int index) const { 
-  if ( index < subjetCollections_.size() ) 
-    return subjetCollections_[index]; 
+pat::JetPtrCollection const& Jet::subjets(unsigned int index) const {
+  if (index < subjetCollections_.size())
+    return subjetCollections_[index];
   else {
     throw cms::Exception("OutOfRange") << "Index " << index << " is out of range" << std::endl;
   }
 }
 
-
 /// String access to subjet list
-pat::JetPtrCollection const & Jet::subjets( std::string const & label ) const { 
-  auto found = find( subjetLabels_.begin(), subjetLabels_.end(), label );
-  if ( found != subjetLabels_.end() ){
-    auto index = std::distance( subjetLabels_.begin(), found );
-    return subjetCollections_[index]; 
-  }
-  else {
-    throw cms::Exception("SubjetsNotFound") << "Label " << label << " does not match any subjet collection" << std::endl;
+pat::JetPtrCollection const& Jet::subjets(std::string const& label) const {
+  auto found = find(subjetLabels_.begin(), subjetLabels_.end(), label);
+  if (found != subjetLabels_.end()) {
+    auto index = std::distance(subjetLabels_.begin(), found);
+    return subjetCollections_[index];
+  } else {
+    throw cms::Exception("SubjetsNotFound")
+        << "Label " << label << " does not match any subjet collection" << std::endl;
   }
 }
 
 /// Add new set of subjets
-void Jet::addSubjets( pat::JetPtrCollection const & pieces, std::string const & label  ) {
-  subjetCollections_.push_back( pieces );
-  subjetLabels_.push_back( label );
+void Jet::addSubjets(pat::JetPtrCollection const& pieces, std::string const& label) {
+  subjetCollections_.push_back(pieces);
+  subjetLabels_.push_back(label);
 }

--- a/DataFormats/PatCandidates/src/JetCorrFactors.cc
+++ b/DataFormats/PatCandidates/src/JetCorrFactors.cc
@@ -7,120 +7,119 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/PatCandidates/interface/JetCorrFactors.h"
 
-
 using namespace pat;
 
-
-JetCorrFactors::JetCorrFactors(const std::string& label, const std::vector<CorrectionFactor>& jec): label_(label), jec_(jec)
-{
-  for(std::vector<CorrectionFactor>::const_iterator corrFactor=jec.begin(); corrFactor!=jec.end(); ++corrFactor){
-    if(!isValid(*corrFactor)){
-      throw cms::Exception("InvalidRequest") << "You try to create a CorrectionFactor which is neither flavor dependent nor \n"
-					     << "flavor independent. The CorrectionFactor should obey the following rules:  \n"
-					     << "\n"
-					     << " * CorrectionFactor is a std::pair<std::string, std::vector<float> >.      \n"
-					     << " * The std::string holds the label of the correction level (following the  \n"
-					     << "   conventions of JetMET.                                                  \n"
-					     << " * The std::vector<float> holds the correction factors, these factors are  \n"
-					     << "   up to the given level. They include all previous correction steps.      \n"
-					     << " * The vector has the length *1* for flavor independent correction factors \n"
-					     << "   or *5* for flavor dependent correction factors.                         \n"
-					     << " * The expected order of flavor dependent correction factors is: NONE,     \n"
-					     << "   GLUON, UDS, CHARM, BOTTOM. If follows the JetMET conventions and is     \n"
-					     << "   in the Flavor enumerator of the JetCorrFactos class.                    \n"
-					     << " * For flavor depdendent correction factors the first entry in the vector  \n"
-					     << "   (corresponding to NONE) is invalid and should be set to -1. It will not \n"
-					     << "   be considered by the class structure though.                            \n"
-					     << "\n"
-					     << "Make sure that all elements of the argument vector to this contructor are  \n"
-					     << "in accordance with these rules.\n";
+JetCorrFactors::JetCorrFactors(const std::string& label, const std::vector<CorrectionFactor>& jec)
+    : label_(label), jec_(jec) {
+  for (std::vector<CorrectionFactor>::const_iterator corrFactor = jec.begin(); corrFactor != jec.end(); ++corrFactor) {
+    if (!isValid(*corrFactor)) {
+      throw cms::Exception("InvalidRequest")
+          << "You try to create a CorrectionFactor which is neither flavor dependent nor \n"
+          << "flavor independent. The CorrectionFactor should obey the following rules:  \n"
+          << "\n"
+          << " * CorrectionFactor is a std::pair<std::string, std::vector<float> >.      \n"
+          << " * The std::string holds the label of the correction level (following the  \n"
+          << "   conventions of JetMET.                                                  \n"
+          << " * The std::vector<float> holds the correction factors, these factors are  \n"
+          << "   up to the given level. They include all previous correction steps.      \n"
+          << " * The vector has the length *1* for flavor independent correction factors \n"
+          << "   or *5* for flavor dependent correction factors.                         \n"
+          << " * The expected order of flavor dependent correction factors is: NONE,     \n"
+          << "   GLUON, UDS, CHARM, BOTTOM. If follows the JetMET conventions and is     \n"
+          << "   in the Flavor enumerator of the JetCorrFactos class.                    \n"
+          << " * For flavor depdendent correction factors the first entry in the vector  \n"
+          << "   (corresponding to NONE) is invalid and should be set to -1. It will not \n"
+          << "   be considered by the class structure though.                            \n"
+          << "\n"
+          << "Make sure that all elements of the argument vector to this contructor are  \n"
+          << "in accordance with these rules.\n";
     }
   }
 }
 
-std::string 
-JetCorrFactors::jecFlavor(const Flavor& flavor) const
-{
+std::string JetCorrFactors::jecFlavor(const Flavor& flavor) const {
   std::map<Flavor, std::string> flavors;
-  flavors[UDS]="uds"; flavors[CHARM]="charm"; flavors[BOTTOM]="bottom"; flavors[GLUON]="gluon"; flavors[NONE]="none"; 
+  flavors[UDS] = "uds";
+  flavors[CHARM] = "charm";
+  flavors[BOTTOM] = "bottom";
+  flavors[GLUON] = "gluon";
+  flavors[NONE] = "none";
   return flavors.find(flavor)->second;
 }
 
-JetCorrFactors::Flavor 
-JetCorrFactors::jecFlavor(std::string flavor) const
-{
+JetCorrFactors::Flavor JetCorrFactors::jecFlavor(std::string flavor) const {
   std::map<std::string, Flavor> flavors;
-  std::transform(flavor.begin(), flavor.end(), flavor.begin(), [&](int c){ return std::tolower(c);} );
-  flavors["uds"]=UDS; flavors["charm"]=CHARM; flavors["bottom"]=BOTTOM; flavors["gluon"]=GLUON; flavors["none"]=NONE;
-  if(flavors.find(flavor)==flavors.end()){
+  std::transform(flavor.begin(), flavor.end(), flavor.begin(), [&](int c) { return std::tolower(c); });
+  flavors["uds"] = UDS;
+  flavors["charm"] = CHARM;
+  flavors["bottom"] = BOTTOM;
+  flavors["gluon"] = GLUON;
+  flavors["none"] = NONE;
+  if (flavors.find(flavor) == flavors.end()) {
     throw cms::Exception("InvalidRequest") << "You ask for a flavor, which does not exist. Available flavors are: \n"
-					   << "'uds', 'charm', 'bottom', 'gluon', 'none', (not case sensitive).   \n";
+                                           << "'uds', 'charm', 'bottom', 'gluon', 'none', (not case sensitive).   \n";
   }
   return flavors.find(flavor)->second;
 }
 
-int  
-JetCorrFactors::jecLevel(const std::string& level) const
-{
-  for(std::vector<CorrectionFactor>::const_iterator corrFactor=jec_.begin(); corrFactor!=jec_.end(); ++corrFactor){
-    if(corrFactor->first==level) return (corrFactor-jec_.begin());
+int JetCorrFactors::jecLevel(const std::string& level) const {
+  for (std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor) {
+    if (corrFactor->first == level)
+      return (corrFactor - jec_.begin());
   }
   return -1;
 }
 
-float 
-JetCorrFactors::correction(unsigned int level, Flavor flavor) const 
-{
-  if(!(level<jec_.size())){
+float JetCorrFactors::correction(unsigned int level, Flavor flavor) const {
+  if (!(level < jec_.size())) {
     throw cms::Exception("InvalidRequest") << "You try to call a jet energy correction level wich does not exist. \n"
-					   << "Available jet energy correction levels are:                        \n" 
-					   << correctionLabelString();    
+                                           << "Available jet energy correction levels are:                        \n"
+                                           << correctionLabelString();
   }
-  if(flavorDependent(jec_.at(level)) && flavor==NONE){
+  if (flavorDependent(jec_.at(level)) && flavor == NONE) {
     throw cms::Exception("InvalidRequest") << "You try to call a flavor dependent jet energy correction level:    \n"
-					   << "level : " << level << " label: " << jec_.at(level).first << "      \n"
-					   << "You need to specify one of the following flavors: GLUON, UDS,      \n"
-					   << "CHARM, BOTTOM. \n";
+                                           << "level : " << level << " label: " << jec_.at(level).first << "      \n"
+                                           << "You need to specify one of the following flavors: GLUON, UDS,      \n"
+                                           << "CHARM, BOTTOM. \n";
   }
   return flavorDependent(jec_.at(level)) ? jec_.at(level).second.at(flavor) : jec_.at(level).second.at(0);
 }
 
-std::string 
-JetCorrFactors::correctionLabelString() const 
-{
+std::string JetCorrFactors::correctionLabelString() const {
   std::string labels;
-  for(std::vector<CorrectionFactor>::const_iterator corrFactor=jec_.begin(); corrFactor!=jec_.end(); ++corrFactor){
-    std::stringstream idx; idx << (corrFactor-jec_.begin());
+  for (std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor) {
+    std::stringstream idx;
+    idx << (corrFactor - jec_.begin());
     labels.append(idx.str()).append(" ").append(corrFactor->first).append("\n");
   }
   return labels;
 }
 
-std::vector<std::string> 
-JetCorrFactors::correctionLabels() const 
-{
+std::vector<std::string> JetCorrFactors::correctionLabels() const {
   std::vector<std::string> labels;
-  for(std::vector<CorrectionFactor>::const_iterator corrFactor=jec_.begin(); corrFactor!=jec_.end(); ++corrFactor){
+  for (std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor) {
     labels.push_back(corrFactor->first);
   }
   return labels;
 }
 
-void
-JetCorrFactors::print() const
-{
-  edm::LogInfo message( "JetCorrFactors" );
-  for(std::vector<CorrectionFactor>::const_iterator corrFactor=jec_.begin(); corrFactor!=jec_.end(); ++corrFactor){
-    unsigned int corrFactorIdx=corrFactor-jec_.begin();
+void JetCorrFactors::print() const {
+  edm::LogInfo message("JetCorrFactors");
+  for (std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor) {
+    unsigned int corrFactorIdx = corrFactor - jec_.begin();
     message << std::setw(3) << corrFactorIdx << "  " << corrFactor->first;
-    if( flavorDependent(*corrFactor) ){
-      for(std::vector<float>::const_iterator flavor=corrFactor->second.begin(); flavor!=corrFactor->second.end(); ++flavor){
-	unsigned int flavorIdx=flavor-corrFactor->second.begin();
-	message << std::setw(10) << correction(corrFactorIdx, (Flavor)flavorIdx);
+    if (flavorDependent(*corrFactor)) {
+      for (std::vector<float>::const_iterator flavor = corrFactor->second.begin(); flavor != corrFactor->second.end();
+           ++flavor) {
+        unsigned int flavorIdx = flavor - corrFactor->second.begin();
+        message << std::setw(10) << correction(corrFactorIdx, (Flavor)flavorIdx);
       }
-    }
-    else{
-      message << std::setw(10) << correction (corrFactor-jec_.begin(), NONE); 
+    } else {
+      message << std::setw(10) << correction(corrFactor - jec_.begin(), NONE);
     }
     message << "\n";
   }

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -3,133 +3,123 @@
 
 #include "DataFormats/PatCandidates/interface/MET.h"
 
-
 using namespace pat;
 
-
 /// default constructor
-MET::MET() {
+MET::MET() { initCorMap(); }
+
+/// constructor from reco::MET
+MET::MET(const reco::MET &aMET) : PATObject<reco::MET>(aMET) {
+  const reco::CaloMET *calo = dynamic_cast<const reco::CaloMET *>(&aMET);
+  if (calo != nullptr)
+    caloMET_.push_back(calo->getSpecific());
+  const reco::PFMET *pf = dynamic_cast<const reco::PFMET *>(&aMET);
+  if (pf != nullptr)
+    pfMET_.push_back(pf->getSpecific());
+  const pat::MET *pm = dynamic_cast<const pat::MET *>(&aMET);
+  if (pm != nullptr)
+    this->operator=(*pm);
+
+  metSig_ = 0.;
   initCorMap();
 }
 
-
-/// constructor from reco::MET
-MET::MET(const reco::MET & aMET) : PATObject<reco::MET>(aMET) {
-    const reco::CaloMET * calo = dynamic_cast<const reco::CaloMET *>(&aMET);
-    if (calo != nullptr) caloMET_.push_back(calo->getSpecific());
-    const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(&aMET);
-    if (pf != nullptr) pfMET_.push_back(pf->getSpecific());
-    const pat::MET * pm = dynamic_cast<const pat::MET *>(&aMET);
-    if (pm != nullptr) this->operator=(*pm);
-
-    metSig_ =0.;
-    initCorMap();
-}
-
-
 /// constructor from ref to reco::MET
-MET::MET(const edm::RefToBase<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETRef) {
-    const reco::CaloMET * calo = dynamic_cast<const reco::CaloMET *>(aMETRef.get());
-    if (calo != nullptr) caloMET_.push_back(calo->getSpecific());
-    const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
-    if (pf != nullptr) pfMET_.push_back(pf->getSpecific());
-    const pat::MET * pm = dynamic_cast<const pat::MET *>(aMETRef.get());
-    if (pm != nullptr) this->operator=(*pm);
+MET::MET(const edm::RefToBase<reco::MET> &aMETRef) : PATObject<reco::MET>(aMETRef) {
+  const reco::CaloMET *calo = dynamic_cast<const reco::CaloMET *>(aMETRef.get());
+  if (calo != nullptr)
+    caloMET_.push_back(calo->getSpecific());
+  const reco::PFMET *pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
+  if (pf != nullptr)
+    pfMET_.push_back(pf->getSpecific());
+  const pat::MET *pm = dynamic_cast<const pat::MET *>(aMETRef.get());
+  if (pm != nullptr)
+    this->operator=(*pm);
 
-    metSig_ =0.;
-    initCorMap();
+  metSig_ = 0.;
+  initCorMap();
 }
 
 /// constructor from ref to reco::MET
-MET::MET(const edm::Ptr<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETRef) {
-    const reco::CaloMET * calo = dynamic_cast<const reco::CaloMET *>(aMETRef.get());
-    if (calo != nullptr) caloMET_.push_back(calo->getSpecific());
-    const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
-    if (pf != nullptr) pfMET_.push_back(pf->getSpecific());
-    const pat::MET * pm = dynamic_cast<const pat::MET *>(aMETRef.get());
-    if (pm != nullptr) this->operator=(*pm);
+MET::MET(const edm::Ptr<reco::MET> &aMETRef) : PATObject<reco::MET>(aMETRef) {
+  const reco::CaloMET *calo = dynamic_cast<const reco::CaloMET *>(aMETRef.get());
+  if (calo != nullptr)
+    caloMET_.push_back(calo->getSpecific());
+  const reco::PFMET *pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
+  if (pf != nullptr)
+    pfMET_.push_back(pf->getSpecific());
+  const pat::MET *pm = dynamic_cast<const pat::MET *>(aMETRef.get());
+  if (pm != nullptr)
+    this->operator=(*pm);
 
-    metSig_ =0.;
-    initCorMap();
+  metSig_ = 0.;
+  initCorMap();
 }
 
 /// copy constructor
-MET::MET(MET const& iOther):
-PATObject<reco::MET>(iOther),
-genMET_(iOther.genMET_),
-caloMET_(iOther.caloMET_),
-pfMET_(iOther.pfMET_),
-metSig_(iOther.metSig_),
-uncertaintiesRaw_(iOther.uncertaintiesRaw_), //74X reading compatibility
-uncertaintiesType1_(iOther.uncertaintiesType1_), //74X compatibility
-uncertaintiesType1p2_(iOther.uncertaintiesType1p2_), //74X compatibility
-uncertainties_(iOther.uncertainties_),
-corrections_(iOther.corrections_),
-caloPackedMet_(iOther.caloPackedMet_) {
-
+MET::MET(MET const &iOther)
+    : PATObject<reco::MET>(iOther),
+      genMET_(iOther.genMET_),
+      caloMET_(iOther.caloMET_),
+      pfMET_(iOther.pfMET_),
+      metSig_(iOther.metSig_),
+      uncertaintiesRaw_(iOther.uncertaintiesRaw_),          //74X reading compatibility
+      uncertaintiesType1_(iOther.uncertaintiesType1_),      //74X compatibility
+      uncertaintiesType1p2_(iOther.uncertaintiesType1p2_),  //74X compatibility
+      uncertainties_(iOther.uncertainties_),
+      corrections_(iOther.corrections_),
+      caloPackedMet_(iOther.caloPackedMet_) {
   initCorMap();
 }
 
-/// constructor for corrected mets, keeping track of srcMET informations, 
+/// constructor for corrected mets, keeping track of srcMET informations,
 // old uncertainties discarded on purpose to avoid confusion
-MET::MET(const reco::MET & corMET, const MET& srcMET ):
-PATObject<reco::MET>(corMET),
-genMET_(srcMET.genMET_),
-caloMET_(srcMET.caloMET_),
-pfMET_(srcMET.pfMET_),
-metSig_(srcMET.metSig_),
-caloPackedMet_(srcMET.caloPackedMet_) {
-
+MET::MET(const reco::MET &corMET, const MET &srcMET)
+    : PATObject<reco::MET>(corMET),
+      genMET_(srcMET.genMET_),
+      caloMET_(srcMET.caloMET_),
+      pfMET_(srcMET.pfMET_),
+      metSig_(srcMET.metSig_),
+      caloPackedMet_(srcMET.caloPackedMet_) {
   setSignificanceMatrix(srcMET.getSignificanceMatrix());
 
   initCorMap();
 }
 
 /// destructor
-MET::~MET() {
+MET::~MET() {}
 
-}
+MET &MET::operator=(MET const &iOther) {
+  PATObject<reco::MET>::operator=(iOther);
+  genMET_ = iOther.genMET_;
+  caloMET_ = iOther.caloMET_;
+  pfMET_ = iOther.pfMET_;
+  uncertaintiesRaw_ = iOther.uncertaintiesRaw_;  //74X compatibility
+  uncertaintiesType1_ = iOther.uncertaintiesType1_;
+  uncertaintiesType1p2_ = iOther.uncertaintiesType1p2_;
+  uncertainties_ = iOther.uncertainties_;
+  corrections_ = iOther.corrections_;
+  metSig_ = iOther.metSig_;
+  caloPackedMet_ = iOther.caloPackedMet_;
 
-MET& MET::operator=(MET const& iOther) {
-   PATObject<reco::MET>::operator=(iOther);
-   genMET_ = iOther.genMET_;
-   caloMET_ =iOther.caloMET_;
-   pfMET_ =iOther.pfMET_;
-   uncertaintiesRaw_ = iOther.uncertaintiesRaw_; //74X compatibility
-   uncertaintiesType1_ = iOther.uncertaintiesType1_;
-   uncertaintiesType1p2_ = iOther.uncertaintiesType1p2_;
-   uncertainties_ = iOther.uncertainties_;
-   corrections_ = iOther.corrections_;
-   metSig_ = iOther.metSig_;
-   caloPackedMet_ = iOther.caloPackedMet_;
-
-   return *this;
+  return *this;
 }
 
 /// return the generated MET from neutrinos
-const reco::GenMET * MET::genMET() const {
-  return (!genMET_.empty() ? &genMET_.front() : nullptr );
-}
+const reco::GenMET *MET::genMET() const { return (!genMET_.empty() ? &genMET_.front() : nullptr); }
 
 /// method to set the generated MET
-void MET::setGenMET(const reco::GenMET & gm) {
+void MET::setGenMET(const reco::GenMET &gm) {
   genMET_.clear();
   genMET_.push_back(gm);
 }
 
-
 //Method to set the MET significance
-void MET::setMETSignificance(const double& metSig) {
-  metSig_ = metSig;
-}
+void MET::setMETSignificance(const double &metSig) { metSig_ = metSig; }
 
-double MET::metSignificance() const {
-  return metSig_;
-}
+double MET::metSignificance() const { return metSig_; }
 
-void
-MET::initCorMap() {
-
+void MET::initCorMap() {
   std::vector<MET::METCorrectionType> tmpRaw;
   std::vector<MET::METCorrectionType> tmpType1;
   std::vector<MET::METCorrectionType> tmpType01;
@@ -140,9 +130,9 @@ MET::initCorMap() {
   std::vector<MET::METCorrectionType> tmpType01Smear;
   std::vector<MET::METCorrectionType> tmpType1SmearXY;
   std::vector<MET::METCorrectionType> tmpType01SmearXY;
-  
+
   tmpRaw.push_back(MET::None);
-  
+
   tmpType1.push_back(MET::T1);
   tmpType01.push_back(MET::T1);
   tmpType1XY.push_back(MET::T1);
@@ -156,7 +146,7 @@ MET::initCorMap() {
   tmpType01XY.push_back(MET::T0);
   tmpType01Smear.push_back(MET::T0);
   tmpType01SmearXY.push_back(MET::T0);
-  
+
   tmpType1Smear.push_back(MET::Smear);
   tmpType01Smear.push_back(MET::Smear);
   tmpType1SmearXY.push_back(MET::Smear);
@@ -178,7 +168,7 @@ MET::initCorMap() {
   corMap_[MET::Type01Smear] = tmpType01Smear;
   corMap_[MET::Type1SmearXY] = tmpType1SmearXY;
   corMap_[MET::Type01SmearXY] = tmpType01SmearXY;
-  
+
   //specific calo case
   std::vector<MET::METCorrectionType> tmpRawCalo;
   tmpRawCalo.push_back(MET::Calo);
@@ -195,267 +185,246 @@ MET::initCorMap() {
   corMap_[MET::RawTrk] = tmpRawTrk;
 }
 
-const MET::PackedMETUncertainty
-MET::findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const {
-
+const MET::PackedMETUncertainty MET::findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const {
   //find corrections shifts =============================
   std::map<MET::METCorrectionLevel, std::vector<MET::METCorrectionType> >::const_iterator itCor_ = corMap_.find(cor);
-  if(itCor_==corMap_.end() ) throw cms::Exception("Unsupported", "Specified MET correction scheme does not exist");
+  if (itCor_ == corMap_.end())
+    throw cms::Exception("Unsupported", "Specified MET correction scheme does not exist");
 
-  bool isSmeared=false;
+  bool isSmeared = false;
   MET::PackedMETUncertainty totShift;
-  unsigned int scor=itCor_->second.size();
-  for(unsigned int i=0; i<scor;i++) {
-    totShift.add( corrections_[ itCor_->second[i] ].dpx(),
-  		  corrections_[ itCor_->second[i] ].dpy(),
-  		  corrections_[ itCor_->second[i] ].dsumEt() );
+  unsigned int scor = itCor_->second.size();
+  for (unsigned int i = 0; i < scor; i++) {
+    totShift.add(corrections_[itCor_->second[i]].dpx(),
+                 corrections_[itCor_->second[i]].dpy(),
+                 corrections_[itCor_->second[i]].dsumEt());
 
-    if(itCor_->first>=MET::Type1Smear)
-      isSmeared=true;
+    if (itCor_->first >= MET::Type1Smear)
+      isSmeared = true;
   }
-
-  
 
   //find uncertainty shift =============================
 
   if (uncertainties_.empty())
-      return totShift;
+    return totShift;
 
-  if(shift>=MET::METUncertaintySize) throw cms::Exception("Unsupported", "MET uncertainty does not exist");
-  if(isSmeared && shift<=MET::JetResDown) shift = (MET::METUncertainty)(MET::METUncertaintySize+shift+1);
-							  
-  totShift.add( uncertainties_[ shift ].dpx(),
-  		uncertainties_[ shift ].dpy(),
-  		uncertainties_[ shift ].dsumEt() );
+  if (shift >= MET::METUncertaintySize)
+    throw cms::Exception("Unsupported", "MET uncertainty does not exist");
+  if (isSmeared && shift <= MET::JetResDown)
+    shift = (MET::METUncertainty)(MET::METUncertaintySize + shift + 1);
+
+  totShift.add(uncertainties_[shift].dpx(), uncertainties_[shift].dpy(), uncertainties_[shift].dsumEt());
 
   return totShift;
 }
 
-
-MET::Vector2 MET::shiftedP2(MET::METUncertainty shift, MET::METCorrectionLevel cor)  const {
-  
+MET::Vector2 MET::shiftedP2(MET::METUncertainty shift, MET::METCorrectionLevel cor) const {
   Vector2 vo;
 
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
-    if(cor!=MET::METCorrectionLevel::RawCalo) {
+  if (!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
+    if (cor != MET::METCorrectionLevel::RawCalo) {
       vo = shiftedP2_74x(shift, cor);
     } else {
-      Vector2 ret{ caloPackedMet_.dpx(), caloPackedMet_.dpy() };
+      Vector2 ret{caloPackedMet_.dpx(), caloPackedMet_.dpy()};
       vo = ret;
     }
-  }
-  else {
-    const MET::PackedMETUncertainty& v = findMETTotalShift(cor,shift);
-    Vector2 ret{ (px() + v.dpx()), (py() + v.dpy()) };
+  } else {
+    const MET::PackedMETUncertainty &v = findMETTotalShift(cor, shift);
+    Vector2 ret{(px() + v.dpx()), (py() + v.dpy())};
     //return ret;
     vo = ret;
   }
   return vo;
 }
-MET::Vector MET::shiftedP3(MET::METUncertainty shift, MET::METCorrectionLevel cor)  const {
-
+MET::Vector MET::shiftedP3(MET::METUncertainty shift, MET::METCorrectionLevel cor) const {
   Vector vo;
 
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
-    if(cor!=MET::METCorrectionLevel::RawCalo) {
+  if (!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
+    if (cor != MET::METCorrectionLevel::RawCalo) {
       vo = shiftedP3_74x(shift, cor);
     } else {
       Vector tmp(caloPackedMet_.dpx(), caloPackedMet_.dpy(), 0);
       vo = tmp;
     }
-  }
-  else {
-    const MET::PackedMETUncertainty& v = findMETTotalShift(cor,shift);
+  } else {
+    const MET::PackedMETUncertainty &v = findMETTotalShift(cor, shift);
     //return Vector(px() + v.dpx(), py() + v.dpy(), 0);
     Vector tmp(px() + v.dpx(), py() + v.dpy(), 0);
     vo = tmp;
   }
   return vo;
 }
-MET::LorentzVector MET::shiftedP4(METUncertainty shift, MET::METCorrectionLevel cor)  const {
-
+MET::LorentzVector MET::shiftedP4(METUncertainty shift, MET::METCorrectionLevel cor) const {
   LorentzVector vo;
 
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
-    if(cor!=MET::METCorrectionLevel::RawCalo) {
+  if (!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
+    if (cor != MET::METCorrectionLevel::RawCalo) {
       vo = shiftedP4_74x(shift, cor);
     } else {
       double x = caloPackedMet_.dpx(), y = caloPackedMet_.dpy();
-      LorentzVector tmp(x, y, 0, std::hypot(x,y));
-      vo =  tmp;
+      LorentzVector tmp(x, y, 0, std::hypot(x, y));
+      vo = tmp;
     }
-  }
-  else {
-    const MET::PackedMETUncertainty& v = findMETTotalShift(cor,shift);
+  } else {
+    const MET::PackedMETUncertainty &v = findMETTotalShift(cor, shift);
     double x = px() + v.dpx(), y = py() + v.dpy();
     //return LorentzVector(x, y, 0, std::hypot(x,y));
-    LorentzVector tmp(x, y, 0, std::hypot(x,y));
-    vo =  tmp;
+    LorentzVector tmp(x, y, 0, std::hypot(x, y));
+    vo = tmp;
   }
   return vo;
 }
 double MET::shiftedSumEt(MET::METUncertainty shift, MET::METCorrectionLevel cor) const {
-
   double sumEto;
 
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
-    if(cor!=MET::METCorrectionLevel::RawCalo) {
+  if (!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
+    if (cor != MET::METCorrectionLevel::RawCalo) {
       sumEto = shiftedSumEt_74x(shift, cor);
     } else {
       sumEto = caloPackedMet_.dsumEt();
     }
-  }
-  else {
-    const MET::PackedMETUncertainty& v = findMETTotalShift(cor,shift);
+  } else {
+    const MET::PackedMETUncertainty &v = findMETTotalShift(cor, shift);
     //return sumEt() + v.dsumEt();
     sumEto = sumEt() + v.dsumEt();
   }
   return sumEto;
 }
 
-MET::Vector2 MET::corP2(MET::METCorrectionLevel cor)  const {
-  return shiftedP2(MET::NoShift, cor );
-}
-MET::Vector MET::corP3(MET::METCorrectionLevel cor)  const {
-  return shiftedP3(MET::NoShift, cor );
-}
-MET::LorentzVector MET::corP4(MET::METCorrectionLevel cor)  const {
-  return shiftedP4(MET::NoShift, cor );
-}
-double MET::corSumEt(MET::METCorrectionLevel cor) const {
-  return shiftedSumEt(MET::NoShift, cor );
-}
+MET::Vector2 MET::corP2(MET::METCorrectionLevel cor) const { return shiftedP2(MET::NoShift, cor); }
+MET::Vector MET::corP3(MET::METCorrectionLevel cor) const { return shiftedP3(MET::NoShift, cor); }
+MET::LorentzVector MET::corP4(MET::METCorrectionLevel cor) const { return shiftedP4(MET::NoShift, cor); }
+double MET::corSumEt(MET::METCorrectionLevel cor) const { return shiftedSumEt(MET::NoShift, cor); }
 
-MET::Vector2 MET::uncorP2()  const {
-  return shiftedP2(MET::NoShift, MET::Raw );
-}
-MET::Vector MET::uncorP3()  const {
-  return shiftedP3(MET::NoShift, MET::Raw );
-}
-MET::LorentzVector MET::uncorP4()  const {
-  return shiftedP4(MET::NoShift, MET::Raw );
-}
-double MET::uncorSumEt() const {
-  return shiftedSumEt(MET::NoShift, MET::Raw );
-}
-
+MET::Vector2 MET::uncorP2() const { return shiftedP2(MET::NoShift, MET::Raw); }
+MET::Vector MET::uncorP3() const { return shiftedP3(MET::NoShift, MET::Raw); }
+MET::LorentzVector MET::uncorP4() const { return shiftedP4(MET::NoShift, MET::Raw); }
+double MET::uncorSumEt() const { return shiftedSumEt(MET::NoShift, MET::Raw); }
 
 void MET::setUncShift(double px, double py, double sumEt, METUncertainty shift, bool isSmeared) {
-  if (uncertainties_.empty()) { 
+  if (uncertainties_.empty()) {
     uncertainties_.resize(METUncertainty::METFullUncertaintySize);
   }
 
-  if(isSmeared && shift<=MET::JetResDown) {
+  if (isSmeared && shift <= MET::JetResDown) {
     //changing reference to only get the uncertainty shift and not the smeared one
     // which is performed independently
-    shift = (MET::METUncertainty)(METUncertainty::METUncertaintySize+shift+1);
-    const PackedMETUncertainty& ref = uncertainties_[METUncertainty::NoShift];
-    uncertainties_[shift].set(px + ref.dpx() - this->px(), py + ref.dpy() - this->py(), sumEt + ref.dsumEt() - this->sumEt() );
-  }
-  else
+    shift = (MET::METUncertainty)(METUncertainty::METUncertaintySize + shift + 1);
+    const PackedMETUncertainty &ref = uncertainties_[METUncertainty::NoShift];
+    uncertainties_[shift].set(
+        px + ref.dpx() - this->px(), py + ref.dpy() - this->py(), sumEt + ref.dsumEt() - this->sumEt());
+  } else
     uncertainties_[shift].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
-  
 }
 
 void MET::setCorShift(double px, double py, double sumEt, MET::METCorrectionType level) {
   if (corrections_.empty()) {
     corrections_.resize(MET::METCorrectionType::METCorrectionTypeSize);
   }
-  
+
   corrections_[level].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
 }
 
-
 MET::Vector2 MET::caloMETP2() const {
-  return shiftedP2(MET::METUncertainty::NoShift, MET::METCorrectionLevel::RawCalo );
+  return shiftedP2(MET::METUncertainty::NoShift, MET::METCorrectionLevel::RawCalo);
 }
 
-double MET::caloMETPt() const {
-  return caloMETP2().pt();
-}
+double MET::caloMETPt() const { return caloMETP2().pt(); }
 
-double MET::caloMETPhi() const {
-  return caloMETP2().phi();
-}
+double MET::caloMETPhi() const { return caloMETP2().phi(); }
 
-double MET::caloMETSumEt() const {
-  return shiftedSumEt(MET::NoShift, MET::RawCalo );
-}
+double MET::caloMETSumEt() const { return shiftedSumEt(MET::NoShift, MET::RawCalo); }
 
 // functions to access to 74X samples ========================================================
-MET::Vector2 MET::shiftedP2_74x(MET::METUncertainty shift, MET::METCorrectionLevel level)  const {
-  if (level != Type1 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples \n");
-    const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ :  uncertaintiesRaw_);
-    if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
-    if (v.size() == 1) {
-        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)\n");
-        return Vector2{ (px() + v.front().dpx()), (py() + v.front().dpy()) };
-    }
-    Vector2 ret{ (px() + v[shift].dpx()), (py() + v[shift].dpy()) };
-    return ret;
+MET::Vector2 MET::shiftedP2_74x(MET::METUncertainty shift, MET::METCorrectionLevel level) const {
+  if (level != Type1 && level != Raw)
+    throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples \n");
+  const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
+  if (v.empty())
+    throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
+  if (v.size() == 1) {
+    if (shift != MET::METUncertainty::NoShift)
+      throw cms::Exception(
+          "Unsupported",
+          "MET uncertainties not available for the specified correction type (only central value available)\n");
+    return Vector2{(px() + v.front().dpx()), (py() + v.front().dpy())};
+  }
+  Vector2 ret{(px() + v[shift].dpx()), (py() + v[shift].dpy())};
+  return ret;
 }
 
-MET::Vector MET::shiftedP3_74x(MET::METUncertainty shift, MET::METCorrectionLevel level)  const {
-  if (level != Type1 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples \n");
-    const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ :  uncertaintiesRaw_);
-    if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
-    if (v.size() == 1) {
-        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)\n");
-        return Vector(px() + v.front().dpx(), py() + v.front().dpy(), 0);
-    }
-    return Vector(px() + v[shift].dpx(), py() + v[shift].dpy(), 0);
+MET::Vector MET::shiftedP3_74x(MET::METUncertainty shift, MET::METCorrectionLevel level) const {
+  if (level != Type1 && level != Raw)
+    throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples \n");
+  const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
+  if (v.empty())
+    throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
+  if (v.size() == 1) {
+    if (shift != MET::METUncertainty::NoShift)
+      throw cms::Exception(
+          "Unsupported",
+          "MET uncertainties not available for the specified correction type (only central value available)\n");
+    return Vector(px() + v.front().dpx(), py() + v.front().dpy(), 0);
+  }
+  return Vector(px() + v[shift].dpx(), py() + v[shift].dpy(), 0);
 }
 
-MET::LorentzVector MET::shiftedP4_74x(METUncertainty shift, MET::METCorrectionLevel level)  const {
-  if (level != Type1 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples\n");
-    const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
-    if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
-    if (v.size() == 1) {
-        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)\n");
-        double x = px() + v.front().dpx(), y = py() + v.front().dpy();
-        return LorentzVector(x, y, 0, std::hypot(x,y));
-    }
-    double x = px() + v[shift].dpx(), y = py() + v[shift].dpy();
-    return LorentzVector(x, y, 0, std::hypot(x,y));
+MET::LorentzVector MET::shiftedP4_74x(METUncertainty shift, MET::METCorrectionLevel level) const {
+  if (level != Type1 && level != Raw)
+    throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples\n");
+  const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
+  if (v.empty())
+    throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
+  if (v.size() == 1) {
+    if (shift != MET::METUncertainty::NoShift)
+      throw cms::Exception(
+          "Unsupported",
+          "MET uncertainties not available for the specified correction type (only central value available)\n");
+    double x = px() + v.front().dpx(), y = py() + v.front().dpy();
+    return LorentzVector(x, y, 0, std::hypot(x, y));
+  }
+  double x = px() + v[shift].dpx(), y = py() + v[shift].dpy();
+  return LorentzVector(x, y, 0, std::hypot(x, y));
 }
 
 double MET::shiftedSumEt_74x(MET::METUncertainty shift, MET::METCorrectionLevel level) const {
-  if (level != Type1 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples\n");
-    const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
-    if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
-    if (v.size() == 1) {
-        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)\n");
-        return sumEt() + v.front().dsumEt();
-    }
-    return sumEt() + v[shift].dsumEt();
+  if (level != Type1 && level != Raw)
+    throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw and Type1 in 74X samples\n");
+  const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : uncertaintiesRaw_);
+  if (v.empty())
+    throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type\n");
+  if (v.size() == 1) {
+    if (shift != MET::METUncertainty::NoShift)
+      throw cms::Exception(
+          "Unsupported",
+          "MET uncertainties not available for the specified correction type (only central value available)\n");
+    return sumEt() + v.front().dsumEt();
+  }
+  return sumEt() + v[shift].dsumEt();
 }
-
-
-
 
 #include "DataFormats/Math/interface/libminifloat.h"
 
 void MET::PackedMETUncertainty::pack() {
-  packedDpx_  =  MiniFloatConverter::float32to16(dpx_);
-  packedDpy_  =  MiniFloatConverter::float32to16(dpy_);
-  packedDSumEt_  =  MiniFloatConverter::float32to16(dsumEt_);
+  packedDpx_ = MiniFloatConverter::float32to16(dpx_);
+  packedDpy_ = MiniFloatConverter::float32to16(dpy_);
+  packedDSumEt_ = MiniFloatConverter::float32to16(dsumEt_);
 }
-void  MET::PackedMETUncertainty::unpack() const {
-  unpacked_=true;
-  dpx_=MiniFloatConverter::float16to32(packedDpx_);
-  dpy_=MiniFloatConverter::float16to32(packedDpy_);
-  dsumEt_=MiniFloatConverter::float16to32(packedDSumEt_);
+void MET::PackedMETUncertainty::unpack() const {
+  unpacked_ = true;
+  dpx_ = MiniFloatConverter::float16to32(packedDpx_);
+  dpy_ = MiniFloatConverter::float16to32(packedDpy_);
+  dsumEt_ = MiniFloatConverter::float16to32(packedDSumEt_);
 }
-

--- a/DataFormats/PatCandidates/src/MHT.cc
+++ b/DataFormats/PatCandidates/src/MHT.cc
@@ -1,35 +1,13 @@
 #include "DataFormats/PatCandidates/interface/MHT.h"
 
-void
-pat::MHT::setNumberOfMuons(const double & numberOfMuons)
-{
-  number_of_muons_ = numberOfMuons;
-}
+void pat::MHT::setNumberOfMuons(const double& numberOfMuons) { number_of_muons_ = numberOfMuons; }
 
-double
-pat::MHT::getNumberOfMuons() const
-{
-  return number_of_muons_;
-}
+double pat::MHT::getNumberOfMuons() const { return number_of_muons_; }
 
-void 
-pat::MHT::setNumberOfJets(const double & numberOfJets)
-{
-  number_of_jets_ = numberOfJets;
-}
+void pat::MHT::setNumberOfJets(const double& numberOfJets) { number_of_jets_ = numberOfJets; }
 
-double
-pat::MHT::getNumberOfJets() const{
-  return number_of_jets_;
-}
+double pat::MHT::getNumberOfJets() const { return number_of_jets_; }
 
-void 
-pat::MHT::setNumberOfElectrons(const double & numberOfElectrons){
-  number_of_electrons_ = numberOfElectrons;
-}
+void pat::MHT::setNumberOfElectrons(const double& numberOfElectrons) { number_of_electrons_ = numberOfElectrons; }
 
-double 
-pat::MHT::getNumberOfElectrons() const{
-  return number_of_electrons_;
-}
-
+double pat::MHT::getNumberOfElectrons() const { return number_of_electrons_; }

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -9,152 +9,141 @@
 
 using namespace pat;
 
-
 /// default constructor
-Muon::Muon() :
-    Lepton<reco::Muon>(),
-    embeddedMuonBestTrack_(false),
-    embeddedTunePMuonBestTrack_(false),
-    embeddedTrack_(false),
-    embeddedStandAloneMuon_(false),
-    embeddedCombinedMuon_(false),
-    embeddedTCMETMuonCorrs_(false),
-    embeddedCaloMETMuonCorrs_(false),
-    embeddedPickyMuon_(false),
-    embeddedTpfmsMuon_(false),
-    embeddedDytMuon_(false),
-    embeddedPFCandidate_(false),
-    pfCandidateRef_(),
-    cachedNormChi2_(false),
-    normChi2_(0.0),
-    cachedNumberOfValidHits_(false),
-    numberOfValidHits_(0),
-    pfEcalEnergy_(0),
-    jetPtRatio_(0),
-    jetPtRel_(0),
-    mvaValue_(0),
-    lowptMvaValue_(0),
-    softMvaValue_(0)
-{
+Muon::Muon()
+    : Lepton<reco::Muon>(),
+      embeddedMuonBestTrack_(false),
+      embeddedTunePMuonBestTrack_(false),
+      embeddedTrack_(false),
+      embeddedStandAloneMuon_(false),
+      embeddedCombinedMuon_(false),
+      embeddedTCMETMuonCorrs_(false),
+      embeddedCaloMETMuonCorrs_(false),
+      embeddedPickyMuon_(false),
+      embeddedTpfmsMuon_(false),
+      embeddedDytMuon_(false),
+      embeddedPFCandidate_(false),
+      pfCandidateRef_(),
+      cachedNormChi2_(false),
+      normChi2_(0.0),
+      cachedNumberOfValidHits_(false),
+      numberOfValidHits_(0),
+      pfEcalEnergy_(0),
+      jetPtRatio_(0),
+      jetPtRel_(0),
+      mvaValue_(0),
+      lowptMvaValue_(0),
+      softMvaValue_(0) {
   initImpactParameters();
   initSimInfo();
 }
 
 /// constructor from reco::Muon
-Muon::Muon(const reco::Muon & aMuon) :
-    Lepton<reco::Muon>(aMuon),
-    embeddedMuonBestTrack_(false),
-    embeddedTunePMuonBestTrack_(false),
-    embeddedTrack_(false),
-    embeddedStandAloneMuon_(false),
-    embeddedCombinedMuon_(false),
-    embeddedTCMETMuonCorrs_(false),
-    embeddedCaloMETMuonCorrs_(false),
-    embeddedPickyMuon_(false),
-    embeddedTpfmsMuon_(false),
-    embeddedDytMuon_(false),
-    embeddedPFCandidate_(false),
-    pfCandidateRef_(),
-    cachedNormChi2_(false),
-    normChi2_(0.0),
-    cachedNumberOfValidHits_(false),
-    numberOfValidHits_(0),
-    pfEcalEnergy_(0),
-    jetPtRatio_(0),
-    jetPtRel_(0),
-    mvaValue_(0),
-    lowptMvaValue_(0),
-    softMvaValue_(0)
-{
+Muon::Muon(const reco::Muon& aMuon)
+    : Lepton<reco::Muon>(aMuon),
+      embeddedMuonBestTrack_(false),
+      embeddedTunePMuonBestTrack_(false),
+      embeddedTrack_(false),
+      embeddedStandAloneMuon_(false),
+      embeddedCombinedMuon_(false),
+      embeddedTCMETMuonCorrs_(false),
+      embeddedCaloMETMuonCorrs_(false),
+      embeddedPickyMuon_(false),
+      embeddedTpfmsMuon_(false),
+      embeddedDytMuon_(false),
+      embeddedPFCandidate_(false),
+      pfCandidateRef_(),
+      cachedNormChi2_(false),
+      normChi2_(0.0),
+      cachedNumberOfValidHits_(false),
+      numberOfValidHits_(0),
+      pfEcalEnergy_(0),
+      jetPtRatio_(0),
+      jetPtRel_(0),
+      mvaValue_(0),
+      lowptMvaValue_(0),
+      softMvaValue_(0) {
   initImpactParameters();
   initSimInfo();
 }
 
 /// constructor from ref to reco::Muon
-Muon::Muon(const edm::RefToBase<reco::Muon> & aMuonRef) :
-    Lepton<reco::Muon>(aMuonRef),
-    embeddedMuonBestTrack_(false),
-    embeddedTunePMuonBestTrack_(false),
-    embeddedTrack_(false),
-    embeddedStandAloneMuon_(false),
-    embeddedCombinedMuon_(false),
-    embeddedTCMETMuonCorrs_(false),
-    embeddedCaloMETMuonCorrs_(false),
-    embeddedPickyMuon_(false),
-    embeddedTpfmsMuon_(false),
-    embeddedDytMuon_(false),
-    embeddedPFCandidate_(false),
-    pfCandidateRef_(),
-    cachedNormChi2_(false),
-    normChi2_(0.0),
-    cachedNumberOfValidHits_(false),
-    numberOfValidHits_(0),
-    pfEcalEnergy_(0),
-    jetPtRatio_(0),
-    jetPtRel_(0),
-    mvaValue_(0),
-    lowptMvaValue_(0),
-    softMvaValue_(0)
-{
+Muon::Muon(const edm::RefToBase<reco::Muon>& aMuonRef)
+    : Lepton<reco::Muon>(aMuonRef),
+      embeddedMuonBestTrack_(false),
+      embeddedTunePMuonBestTrack_(false),
+      embeddedTrack_(false),
+      embeddedStandAloneMuon_(false),
+      embeddedCombinedMuon_(false),
+      embeddedTCMETMuonCorrs_(false),
+      embeddedCaloMETMuonCorrs_(false),
+      embeddedPickyMuon_(false),
+      embeddedTpfmsMuon_(false),
+      embeddedDytMuon_(false),
+      embeddedPFCandidate_(false),
+      pfCandidateRef_(),
+      cachedNormChi2_(false),
+      normChi2_(0.0),
+      cachedNumberOfValidHits_(false),
+      numberOfValidHits_(0),
+      pfEcalEnergy_(0),
+      jetPtRatio_(0),
+      jetPtRel_(0),
+      mvaValue_(0),
+      lowptMvaValue_(0),
+      softMvaValue_(0) {
   initImpactParameters();
   initSimInfo();
 }
 
 /// constructor from ref to reco::Muon
-Muon::Muon(const edm::Ptr<reco::Muon> & aMuonRef) :
-    Lepton<reco::Muon>(aMuonRef),
-    embeddedMuonBestTrack_(false),
-    embeddedTunePMuonBestTrack_(false),
-    embeddedTrack_(false),
-    embeddedStandAloneMuon_(false),
-    embeddedCombinedMuon_(false),
-    embeddedTCMETMuonCorrs_(false),
-    embeddedCaloMETMuonCorrs_(false),
-    embeddedPickyMuon_(false),
-    embeddedTpfmsMuon_(false),
-    embeddedDytMuon_(false),
-    embeddedPFCandidate_(false),
-    pfCandidateRef_(),
-    cachedNormChi2_(false),
-    normChi2_(0.0),
-    cachedNumberOfValidHits_(false),
-    numberOfValidHits_(0),
-    pfEcalEnergy_(0),
-    jetPtRatio_(0),
-    jetPtRel_(0),
-    mvaValue_(0),
-    lowptMvaValue_(0),
-    softMvaValue_(0)
-{
+Muon::Muon(const edm::Ptr<reco::Muon>& aMuonRef)
+    : Lepton<reco::Muon>(aMuonRef),
+      embeddedMuonBestTrack_(false),
+      embeddedTunePMuonBestTrack_(false),
+      embeddedTrack_(false),
+      embeddedStandAloneMuon_(false),
+      embeddedCombinedMuon_(false),
+      embeddedTCMETMuonCorrs_(false),
+      embeddedCaloMETMuonCorrs_(false),
+      embeddedPickyMuon_(false),
+      embeddedTpfmsMuon_(false),
+      embeddedDytMuon_(false),
+      embeddedPFCandidate_(false),
+      pfCandidateRef_(),
+      cachedNormChi2_(false),
+      normChi2_(0.0),
+      cachedNumberOfValidHits_(false),
+      numberOfValidHits_(0),
+      pfEcalEnergy_(0),
+      jetPtRatio_(0),
+      jetPtRel_(0),
+      mvaValue_(0),
+      lowptMvaValue_(0),
+      softMvaValue_(0) {
   initImpactParameters();
   initSimInfo();
 }
 
 /// destructor
-Muon::~Muon() {
-}
+Muon::~Muon() {}
 
-std::ostream& 
-reco::operator<<(std::ostream& out, const pat::Muon& obj) 
-{
-  if(!out) return out;
-  
+std::ostream& reco::operator<<(std::ostream& out, const pat::Muon& obj) {
+  if (!out)
+    return out;
+
   out << "\tpat::Muon: ";
   out << std::setiosflags(std::ios::right);
   out << std::setiosflags(std::ios::fixed);
   out << std::setprecision(3);
-  out << " E/pT/eta/phi " 
-      << obj.energy()<<"/"
-      << obj.pt()<<"/"
-      << obj.eta()<<"/"
-      << obj.phi();
-  return out; 
+  out << " E/pT/eta/phi " << obj.energy() << "/" << obj.pt() << "/" << obj.eta() << "/" << obj.phi();
+  return out;
 }
 
 // initialize impact parameter container vars
 void Muon::initImpactParameters() {
-  std::fill(ip_, ip_+IpTypeSize, 0.0f);
-  std::fill(eip_, eip_+IpTypeSize, 0.0f);
+  std::fill(ip_, ip_ + IpTypeSize, 0.0f);
+  std::fill(eip_, eip_ + IpTypeSize, 0.0f);
   cachedIP_ = 0;
 }
 
@@ -174,7 +163,6 @@ void Muon::initSimInfo() {
   simPhi_ = 0.0;
 }
 
-
 /// reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
 reco::TrackRef Muon::track() const {
   if (embeddedTrack_) {
@@ -184,7 +172,6 @@ reco::TrackRef Muon::track() const {
   }
 }
 
-
 /// reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
 reco::TrackRef Muon::standAloneMuon() const {
   if (embeddedStandAloneMuon_) {
@@ -193,7 +180,6 @@ reco::TrackRef Muon::standAloneMuon() const {
     return reco::Muon::outerTrack();
   }
 }
-
 
 /// reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
 reco::TrackRef Muon::combinedMuon() const {
@@ -231,7 +217,7 @@ reco::TrackRef Muon::dytTrack() const {
   }
 }
 
-/// reference to Track giving best momentum (global PFlow algo) 
+/// reference to Track giving best momentum (global PFlow algo)
 reco::TrackRef Muon::muonBestTrack() const {
   if (!muonBestTrack_.empty()) {
     return reco::TrackRef(&muonBestTrack_, 0);
@@ -240,7 +226,7 @@ reco::TrackRef Muon::muonBestTrack() const {
   }
 }
 
-/// reference to Track giving best momentum (muon only) 
+/// reference to Track giving best momentum (muon only)
 reco::TrackRef Muon::tunePMuonBestTrack() const {
   if (!tunePMuonBestTrack_.empty()) {
     return reco::TrackRef(&tunePMuonBestTrack_, 0);
@@ -250,9 +236,6 @@ reco::TrackRef Muon::tunePMuonBestTrack() const {
     return reco::Muon::tunePMuonBestTrack();
   }
 }
-
-
-
 
 /// reference to the source IsolatedPFCandidates
 reco::PFCandidateRef Muon::pfCandidateRef() const {
@@ -264,10 +247,13 @@ reco::PFCandidateRef Muon::pfCandidateRef() const {
 }
 
 /// reference to the parent PF candidate for use in TopProjector
-reco::CandidatePtr Muon::sourceCandidatePtr( size_type i ) const {
-  if(pfCandidateRef_.isNonnull() && i==0 ) return reco::CandidatePtr(edm::refToPtr(pfCandidateRef_) );
-  if(refToOrig_.isNonnull() &&  pfCandidateRef_.isNonnull() && i==1 ) return refToOrig_;
-  if(refToOrig_.isNonnull() && ! pfCandidateRef_.isNonnull() && i==0 ) return refToOrig_;
+reco::CandidatePtr Muon::sourceCandidatePtr(size_type i) const {
+  if (pfCandidateRef_.isNonnull() && i == 0)
+    return reco::CandidatePtr(edm::refToPtr(pfCandidateRef_));
+  if (refToOrig_.isNonnull() && pfCandidateRef_.isNonnull() && i == 1)
+    return refToOrig_;
+  if (refToOrig_.isNonnull() && !pfCandidateRef_.isNonnull() && i == 0)
+    return refToOrig_;
   return reco::CandidatePtr();
 }
 
@@ -277,19 +263,39 @@ void Muon::embedMuonBestTrack(bool force) {
   embeddedMuonBestTrack_ = false;
   bool alreadyEmbedded = false;
   if (!force) {
-      switch (muonBestTrackType()) {
-        case None: alreadyEmbedded = true; break;
-        case InnerTrack: if (embeddedTrack_) alreadyEmbedded = true; break;
-        case OuterTrack: if (embeddedStandAloneMuon_) alreadyEmbedded = true; break;
-        case CombinedTrack: if (embeddedCombinedMuon_) alreadyEmbedded = true; break;
-        case TPFMS: if (embeddedTpfmsMuon_) alreadyEmbedded = true; break;
-        case Picky: if (embeddedPickyMuon_) alreadyEmbedded = true; break;
-        case DYT: if (embeddedDytMuon_) alreadyEmbedded = true; break;
-      }
+    switch (muonBestTrackType()) {
+      case None:
+        alreadyEmbedded = true;
+        break;
+      case InnerTrack:
+        if (embeddedTrack_)
+          alreadyEmbedded = true;
+        break;
+      case OuterTrack:
+        if (embeddedStandAloneMuon_)
+          alreadyEmbedded = true;
+        break;
+      case CombinedTrack:
+        if (embeddedCombinedMuon_)
+          alreadyEmbedded = true;
+        break;
+      case TPFMS:
+        if (embeddedTpfmsMuon_)
+          alreadyEmbedded = true;
+        break;
+      case Picky:
+        if (embeddedPickyMuon_)
+          alreadyEmbedded = true;
+        break;
+      case DYT:
+        if (embeddedDytMuon_)
+          alreadyEmbedded = true;
+        break;
+    }
   }
   if (force || !alreadyEmbedded) {
-      muonBestTrack_.push_back(*reco::Muon::muonBestTrack());
-      embeddedMuonBestTrack_ = true;
+    muonBestTrack_.push_back(*reco::Muon::muonBestTrack());
+    embeddedMuonBestTrack_ = true;
   }
 }
 
@@ -299,52 +305,70 @@ void Muon::embedTunePMuonBestTrack(bool force) {
   bool alreadyEmbedded = false;
   embeddedTunePMuonBestTrack_ = false;
   if (!force) {
-      switch (tunePMuonBestTrackType()) {
-          case None: alreadyEmbedded = true; break;
-          case InnerTrack: if (embeddedTrack_) alreadyEmbedded = true; break;
-          case OuterTrack: if (embeddedStandAloneMuon_) alreadyEmbedded = true; break;
-          case CombinedTrack: if (embeddedCombinedMuon_) alreadyEmbedded = true; break;
-          case TPFMS: if (embeddedTpfmsMuon_) alreadyEmbedded = true; break;
-          case Picky: if (embeddedPickyMuon_) alreadyEmbedded = true; break;
-          case DYT: if (embeddedDytMuon_) alreadyEmbedded = true; break;
-      }
-      if (muonBestTrackType() == tunePMuonBestTrackType()) {
-          if (embeddedMuonBestTrack_) alreadyEmbedded = true;
-      }
+    switch (tunePMuonBestTrackType()) {
+      case None:
+        alreadyEmbedded = true;
+        break;
+      case InnerTrack:
+        if (embeddedTrack_)
+          alreadyEmbedded = true;
+        break;
+      case OuterTrack:
+        if (embeddedStandAloneMuon_)
+          alreadyEmbedded = true;
+        break;
+      case CombinedTrack:
+        if (embeddedCombinedMuon_)
+          alreadyEmbedded = true;
+        break;
+      case TPFMS:
+        if (embeddedTpfmsMuon_)
+          alreadyEmbedded = true;
+        break;
+      case Picky:
+        if (embeddedPickyMuon_)
+          alreadyEmbedded = true;
+        break;
+      case DYT:
+        if (embeddedDytMuon_)
+          alreadyEmbedded = true;
+        break;
+    }
+    if (muonBestTrackType() == tunePMuonBestTrackType()) {
+      if (embeddedMuonBestTrack_)
+        alreadyEmbedded = true;
+    }
   }
   if (force || !alreadyEmbedded) {
-      tunePMuonBestTrack_.push_back(*reco::Muon::tunePMuonBestTrack());
-      embeddedTunePMuonBestTrack_ = true;
+    tunePMuonBestTrack_.push_back(*reco::Muon::tunePMuonBestTrack());
+    embeddedTunePMuonBestTrack_ = true;
   }
 }
-
 
 /// embed the Track reconstructed in the tracker only
 void Muon::embedTrack() {
   track_.clear();
   if (reco::Muon::innerTrack().isNonnull()) {
-      track_.push_back(*reco::Muon::innerTrack());
-      embeddedTrack_ = true;
+    track_.push_back(*reco::Muon::innerTrack());
+    embeddedTrack_ = true;
   }
 }
-
 
 /// embed the Track reconstructed in the muon detector only
 void Muon::embedStandAloneMuon() {
   standAloneMuon_.clear();
   if (reco::Muon::outerTrack().isNonnull()) {
-      standAloneMuon_.push_back(*reco::Muon::outerTrack());
-      embeddedStandAloneMuon_ = true;
+    standAloneMuon_.push_back(*reco::Muon::outerTrack());
+    embeddedStandAloneMuon_ = true;
   }
 }
-
 
 /// embed the Track reconstructed in both tracked and muon detector
 void Muon::embedCombinedMuon() {
   combinedMuon_.clear();
   if (reco::Muon::globalTrack().isNonnull()) {
-      combinedMuon_.push_back(*reco::Muon::globalTrack());
-      embeddedCombinedMuon_ = true;
+    combinedMuon_.push_back(*reco::Muon::globalTrack());
+    embeddedCombinedMuon_ = true;
   }
 }
 
@@ -395,8 +419,8 @@ void Muon::embedDytMuon() {
 /// embed the IsolatedPFCandidate pointed to by pfCandidateRef_
 void Muon::embedPFCandidate() {
   pfCandidate_.clear();
-  if ( pfCandidateRef_.isAvailable() && pfCandidateRef_.isNonnull()) {
-    pfCandidate_.push_back( *pfCandidateRef_ );
+  if (pfCandidateRef_.isAvailable() && pfCandidateRef_.isNonnull()) {
+    pfCandidate_.push_back(*pfCandidateRef_);
     embeddedPFCandidate_ = true;
   }
 }
@@ -406,13 +430,12 @@ bool Muon::muonID(const std::string& name) const {
   return muon::isGoodMuon(*this, st);
 }
 
-
-/// Norm chi2 gives the normalized chi2 of the global track. 
+/// Norm chi2 gives the normalized chi2 of the global track.
 /// The user can choose to cache this info so they can drop the
 /// global track, or they can use the track itself if it is present
-/// in the event. 
+/// in the event.
 double Muon::normChi2() const {
-  if ( cachedNormChi2_ ) {
+  if (cachedNormChi2_) {
     return normChi2_;
   } else {
     reco::TrackRef t = globalTrack();
@@ -423,9 +446,9 @@ double Muon::normChi2() const {
 /// numberOfValidHits returns the number of valid hits on the global track.
 /// The user can choose to cache this info so they can drop the
 /// global track, or they can use the track itself if it is present
-/// in the event. 
+/// in the event.
 unsigned int Muon::numberOfValidHits() const {
-  if ( cachedNumberOfValidHits_ ) {
+  if (cachedNumberOfValidHits_) {
     return numberOfValidHits_;
   } else {
     reco::TrackRef t = innerTrack();
@@ -437,51 +460,35 @@ unsigned int Muon::numberOfValidHits() const {
 // IpType defines the type of the impact parameter
 double Muon::dB(IpType type_) const {
   // more IP types (new)
-  if ( cachedIP_ & (1 << int(type_))) {
+  if (cachedIP_ & (1 << int(type_))) {
     return ip_[type_];
   } else {
     return std::numeric_limits<double>::max();
   }
 }
 
-
 // embed various impact parameters with errors
 // IpType defines the type of the impact parameter
 double Muon::edB(IpType type_) const {
   // more IP types (new)
-  if ( cachedIP_ & (1 << int(type_))) {
+  if (cachedIP_ & (1 << int(type_))) {
     return eip_[type_];
   } else {
     return std::numeric_limits<double>::max();
   }
 }
 
-
 double Muon::segmentCompatibility(reco::Muon::ArbitrationType arbitrationType) const {
-   return muon::segmentCompatibility(*this, arbitrationType);
+  return muon::segmentCompatibility(*this, arbitrationType);
 }
 
 // Selectors
-bool Muon::isTightMuon(const reco::Vertex&vtx) const {
-  return muon::isTightMuon(*this, vtx);
-}
+bool Muon::isTightMuon(const reco::Vertex& vtx) const { return muon::isTightMuon(*this, vtx); }
 
-bool Muon::isLooseMuon() const {
-  return muon::isLooseMuon(*this);
+bool Muon::isLooseMuon() const { return muon::isLooseMuon(*this); }
 
-}
+bool Muon::isMediumMuon() const { return muon::isMediumMuon(*this); }
 
-bool Muon::isMediumMuon() const {
-  return muon::isMediumMuon(*this);
+bool Muon::isSoftMuon(const reco::Vertex& vtx) const { return muon::isSoftMuon(*this, vtx); }
 
-}
-
-bool Muon::isSoftMuon(const reco::Vertex& vtx) const {
-  return muon::isSoftMuon(*this, vtx);
-}
-
-
-bool Muon::isHighPtMuon(const reco::Vertex& vtx) const{
-  return muon::isHighPtMuon(*this, vtx);
-}
-
+bool Muon::isHighPtMuon(const reco::Vertex& vtx) const { return muon::isHighPtMuon(*this, vtx); }

--- a/DataFormats/PatCandidates/src/PATTauDiscriminator.cc
+++ b/DataFormats/PatCandidates/src/PATTauDiscriminator.cc
@@ -1,3 +1,3 @@
 #include "DataFormats/PatCandidates/interface/PATTauDiscriminator.h"
 
-pat::PATTauDiscriminator::PATTauDiscriminator() : PATTauDiscriminatorBase() {};
+pat::PATTauDiscriminator::PATTauDiscriminator() : PATTauDiscriminatorBase(){};

--- a/DataFormats/PatCandidates/src/PFParticle.cc
+++ b/DataFormats/PatCandidates/src/PFParticle.cc
@@ -3,11 +3,8 @@
 
 #include "DataFormats/PatCandidates/interface/PFParticle.h"
 
-
 using namespace pat;
 
-
 /// constructor from PFParticleType
-PFParticle::PFParticle(const edm::RefToBase<reco::PFCandidate>& aPFParticle) : PATObject<reco::PFCandidate>(aPFParticle) {
-}
-
+PFParticle::PFParticle(const edm::RefToBase<reco::PFCandidate>& aPFParticle)
+    : PATObject<reco::PFCandidate>(aPFParticle) {}

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -12,15 +12,13 @@ std::once_flag pat::PackedCandidate::covariance_load_flag;
 
 void pat::PackedCandidate::pack(bool unpackAfterwards) {
   packedPt_ = MiniFloatConverter::float32to16(p4_.load()->Pt());
-  packedEta_ = int16_t(std::round(p4_.load()->Eta() / 6.0f *
-                                  std::numeric_limits<int16_t>::max()));
-  packedPhi_ = int16_t(std::round(p4_.load()->Phi() / 3.2f *
-                                  std::numeric_limits<int16_t>::max()));
+  packedEta_ = int16_t(std::round(p4_.load()->Eta() / 6.0f * std::numeric_limits<int16_t>::max()));
+  packedPhi_ = int16_t(std::round(p4_.load()->Phi() / 3.2f * std::numeric_limits<int16_t>::max()));
   packedM_ = MiniFloatConverter::float32to16(p4_.load()->M());
   if (unpackAfterwards) {
     delete p4_.exchange(nullptr);
     delete p4c_.exchange(nullptr);
-    unpack(); // force the values to match with the packed ones
+    unpack();  // force the values to match with the packed ones
   }
 }
 
@@ -28,12 +26,10 @@ void pat::PackedCandidate::packVtx(bool unpackAfterwards) {
   reco::VertexRef pvRef = vertexRef();
   Point pv = pvRef.isNonnull() ? pvRef->position() : Point();
   float dxPV = vertex_.load()->X() - pv.X(),
-        dyPV = vertex_.load()->Y() - pv.Y(); //, rPV = std::hypot(dxPV, dyPV);
+        dyPV = vertex_.load()->Y() - pv.Y();  //, rPV = std::hypot(dxPV, dyPV);
   float s = std::sin(float(p4_.load()->Phi()) + dphi_),
-        c = std::cos(
-            float(p4_.load()->Phi() +
-                  dphi_)); // not the fastest option, but we're in reduced
-                           // precision already, so let's avoid more roundoffs
+        c = std::cos(float(p4_.load()->Phi() + dphi_));  // not the fastest option, but we're in reduced
+                                                         // precision already, so let's avoid more roundoffs
   dxy_ = -dxPV * s + dyPV * c;
   // if we want to go back to the full x,y,z we need to store also
   // float dl = dxPV * c + dyPV * s;
@@ -41,12 +37,9 @@ void pat::PackedCandidate::packVtx(bool unpackAfterwards) {
   float pzpt = p4_.load()->Pz() / p4_.load()->Pt();
   dz_ = vertex_.load()->Z() - pv.Z() - (dxPV * c + dyPV * s) * pzpt;
   packedDxy_ = MiniFloatConverter::float32to16(dxy_ * 100);
-  packedDz_ = pvRef.isNonnull()
-                  ? MiniFloatConverter::float32to16(dz_ * 100)
-                  : int16_t(std::round(dz_ / 40.f *
-                                       std::numeric_limits<int16_t>::max()));
-  packedDPhi_ =
-      int16_t(std::round(dphi_ / 3.2f * std::numeric_limits<int16_t>::max()));
+  packedDz_ = pvRef.isNonnull() ? MiniFloatConverter::float32to16(dz_ * 100)
+                                : int16_t(std::round(dz_ / 40.f * std::numeric_limits<int16_t>::max()));
+  packedDPhi_ = int16_t(std::round(dphi_ / 3.2f * std::numeric_limits<int16_t>::max()));
   packedDEta_ = MiniFloatConverter::float32to16(deta_);
   packedDTrkPt_ = MiniFloatConverter::float32to16(dtrkpt_);
 
@@ -58,18 +51,15 @@ void pat::PackedCandidate::packVtx(bool unpackAfterwards) {
 
 void pat::PackedCandidate::unpack() const {
   float pt = MiniFloatConverter::float16to32(packedPt_);
-  double shift =
-      (pt < 1. ? 0.1 * pt : 0.1 / pt); // shift particle phi to break
-                                       // degeneracies in angular separations
-  double sign = ((int(pt * 10) % 2 == 0)
-                     ? 1
-                     : -1); // introduce a pseudo-random sign of the shift
-  double phi =
-      int16_t(packedPhi_) * 3.2f / std::numeric_limits<int16_t>::max() +
-      sign * shift * 3.2 / std::numeric_limits<int16_t>::max();
-  auto p4 = std::make_unique<PolarLorentzVector>(
-      pt, int16_t(packedEta_) * 6.0f / std::numeric_limits<int16_t>::max(), phi,
-      MiniFloatConverter::float16to32(packedM_));
+  double shift = (pt < 1. ? 0.1 * pt : 0.1 / pt);    // shift particle phi to break
+                                                     // degeneracies in angular separations
+  double sign = ((int(pt * 10) % 2 == 0) ? 1 : -1);  // introduce a pseudo-random sign of the shift
+  double phi = int16_t(packedPhi_) * 3.2f / std::numeric_limits<int16_t>::max() +
+               sign * shift * 3.2 / std::numeric_limits<int16_t>::max();
+  auto p4 = std::make_unique<PolarLorentzVector>(pt,
+                                                 int16_t(packedEta_) * 6.0f / std::numeric_limits<int16_t>::max(),
+                                                 phi,
+                                                 MiniFloatConverter::float16to32(packedM_));
   auto p4c = std::make_unique<LorentzVector>(*p4);
   PolarLorentzVector *expectp4 = nullptr;
   if (p4_.compare_exchange_strong(expectp4, p4.get())) {
@@ -84,8 +74,7 @@ void pat::PackedCandidate::unpack() const {
   }
 }
 
-void pat::PackedCandidate::packCovariance(
-    const reco::TrackBase::CovarianceMatrix &m, bool unpackAfterwards) {
+void pat::PackedCandidate::packCovariance(const reco::TrackBase::CovarianceMatrix &m, bool unpackAfterwards) {
   packedCovariance_.dptdpt = packCovarianceElement(m, 0, 0);
   packedCovariance_.detadeta = packCovarianceElement(m, 1, 1);
   packedCovariance_.dphidphi = packCovarianceElement(m, 2, 2);
@@ -135,16 +124,14 @@ void pat::PackedCandidate::unpackVtx() const {
   deta_ = MiniFloatConverter::float16to32(packedDEta_);
   dtrkpt_ = MiniFloatConverter::float16to32(packedDTrkPt_);
   dxy_ = MiniFloatConverter::float16to32(packedDxy_) / 100.;
-  dz_ = pvRef.isNonnull()
-            ? MiniFloatConverter::float16to32(packedDz_) / 100.
-            : int16_t(packedDz_) * 40.f / std::numeric_limits<int16_t>::max();
+  dz_ = pvRef.isNonnull() ? MiniFloatConverter::float16to32(packedDz_) / 100.
+                          : int16_t(packedDz_) * 40.f / std::numeric_limits<int16_t>::max();
   Point pv = pvRef.isNonnull() ? pvRef->position() : Point();
   float phi = p4_.load()->Phi() + dphi_, s = std::sin(phi), c = std::cos(phi);
-  auto vertex = std::make_unique<Point>(
-      pv.X() - dxy_ * s, pv.Y() + dxy_ * c,
-      pv.Z() +
-          dz_); // for our choice of using the PCA to the PV, by definition the
-                // remaining term -(dx*cos(phi) + dy*sin(phi))*(pz/pt) is zero
+  auto vertex = std::make_unique<Point>(pv.X() - dxy_ * s,
+                                        pv.Y() + dxy_ * c,
+                                        pv.Z() + dz_);  // for our choice of using the PCA to the PV, by definition the
+                                                        // remaining term -(dx*cos(phi) + dy*sin(phi))*(pz/pt) is zero
 
   Point *expected = nullptr;
   if (vertex_.compare_exchange_strong(expected, vertex.get())) {
@@ -163,41 +150,39 @@ pat::PackedCandidate::~PackedCandidate() {
 float pat::PackedCandidate::dxy(const Point &p) const {
   maybeUnpackBoth();
   const float phi = float(p4_.load()->Phi()) + dphi_;
-  return -(vertex_.load()->X() - p.X()) * std::sin(phi) +
-         (vertex_.load()->Y() - p.Y()) * std::cos(phi);
+  return -(vertex_.load()->X() - p.X()) * std::sin(phi) + (vertex_.load()->Y() - p.Y()) * std::cos(phi);
 }
 float pat::PackedCandidate::dz(const Point &p) const {
   maybeUnpackBoth();
   const float phi = float(p4_.load()->Phi()) + dphi_;
-  const float pzpt =
-      deta_ ? std::sinh(etaAtVtx()) : p4_.load()->Pz() / p4_.load()->Pt();
+  const float pzpt = deta_ ? std::sinh(etaAtVtx()) : p4_.load()->Pz() / p4_.load()->Pt();
   return (vertex_.load()->Z() - p.Z()) -
-         ((vertex_.load()->X() - p.X()) * std::cos(phi) +
-          (vertex_.load()->Y() - p.Y()) * std::sin(phi)) *
-             pzpt;
+         ((vertex_.load()->X() - p.X()) * std::cos(phi) + (vertex_.load()->Y() - p.Y()) * std::sin(phi)) * pzpt;
 }
 
 void pat::PackedCandidate::unpackTrk() const {
   maybeUnpackBoth();
   math::RhoEtaPhiVector p3(ptTrk(), etaAtVtx(), phiAtVtx());
   maybeUnpackCovariance();
-  int numberOfStripLayers = stripLayersWithMeasurement(),
-      numberOfPixelLayers = pixelLayersWithMeasurement();
+  int numberOfStripLayers = stripLayersWithMeasurement(), numberOfPixelLayers = pixelLayersWithMeasurement();
   int numberOfPixelHits = this->numberOfPixelHits();
   int numberOfHits = this->numberOfHits();
 
   int ndof = numberOfHits + numberOfPixelHits - 5;
   LostInnerHits innerLost = lostInnerHits();
 
-  auto track = std::make_unique<reco::Track>(
-      normalizedChi2_ * ndof, ndof, *vertex_,
-      math::XYZVector(p3.x(), p3.y(), p3.z()), charge(), *(m_.load()),
-      reco::TrackBase::undefAlgorithm, reco::TrackBase::loose);
+  auto track = std::make_unique<reco::Track>(normalizedChi2_ * ndof,
+                                             ndof,
+                                             *vertex_,
+                                             math::XYZVector(p3.x(), p3.y(), p3.z()),
+                                             charge(),
+                                             *(m_.load()),
+                                             reco::TrackBase::undefAlgorithm,
+                                             reco::TrackBase::loose);
   int i = 0;
-  if (firstHit_ == 0) { // Backward compatible
+  if (firstHit_ == 0) {  // Backward compatible
     if (innerLost == validHitInFirstPixelBarrelLayer) {
-      track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0,
-                                     TrackingRecHit::valid);
+      track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0, TrackingRecHit::valid);
       i = 1;
     }
   } else {
@@ -213,11 +198,9 @@ void pat::PackedCandidate::unpackTrk() const {
     // (B2, B3, B4, F1, ...)
     for (; i < numberOfPixelLayers; i++) {
       if (i <= 3) {
-        track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, i + 1, 0,
-                                       TrackingRecHit::valid);
+        track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, i + 1, 0, TrackingRecHit::valid);
       } else {
-        track->appendTrackerHitPattern(PixelSubdetector::PixelEndcap, i - 3, 0,
-                                       TrackingRecHit::valid);
+        track->appendTrackerHitPattern(PixelSubdetector::PixelEndcap, i - 3, 0, TrackingRecHit::valid);
       }
     }
   } else {
@@ -226,21 +209,16 @@ void pat::PackedCandidate::unpackTrk() const {
     int iOffset = 0;
     if (firstHit_ != 0 && reco::HitPattern::pixelHitFilter(firstHit_)) {
       iOffset = reco::HitPattern::getLayer(firstHit_);
-      if (reco::HitPattern::getSubStructure(firstHit_) ==
-          PixelSubdetector::PixelEndcap)
+      if (reco::HitPattern::getSubStructure(firstHit_) == PixelSubdetector::PixelEndcap)
         iOffset += 3;
     } else {
       iOffset = 1;
     }
     for (; i < numberOfPixelLayers; i++) {
       if (i + iOffset <= 2) {
-        track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel,
-                                       i + iOffset + 1, 0,
-                                       TrackingRecHit::valid);
+        track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, i + iOffset + 1, 0, TrackingRecHit::valid);
       } else {
-        track->appendTrackerHitPattern(PixelSubdetector::PixelEndcap,
-                                       i + iOffset - 3 + 1, 0,
-                                       TrackingRecHit::valid);
+        track->appendTrackerHitPattern(PixelSubdetector::PixelEndcap, i + iOffset - 3 + 1, 0, TrackingRecHit::valid);
       }
     }
   }
@@ -248,14 +226,15 @@ void pat::PackedCandidate::unpackTrk() const {
   // avoid increasing the layer count
   for (; i < numberOfPixelHits; i++) {
     if (firstHit_ != 0 && reco::HitPattern::pixelHitFilter(firstHit_)) {
-      track->appendTrackerHitPattern(
-          reco::HitPattern::getSubStructure(firstHit_),
-          reco::HitPattern::getLayer(firstHit_), 0, TrackingRecHit::valid);
+      track->appendTrackerHitPattern(reco::HitPattern::getSubStructure(firstHit_),
+                                     reco::HitPattern::getLayer(firstHit_),
+                                     0,
+                                     TrackingRecHit::valid);
     } else {
-      track->appendTrackerHitPattern(
-          PixelSubdetector::PixelBarrel,
-          (innerLost == validHitInFirstPixelBarrelLayer ? 1 : 2), 0,
-          TrackingRecHit::valid);
+      track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel,
+                                     (innerLost == validHitInFirstPixelBarrelLayer ? 1 : 2),
+                                     0,
+                                     TrackingRecHit::valid);
     }
   }
   // now start adding strip layers, putting one hit on each layer so that the
@@ -277,49 +256,42 @@ void pat::PackedCandidate::unpackTrk() const {
   }
   for (int sl = slOffset; sl < numberOfStripLayers + slOffset; ++sl, ++i) {
     if (sl < 4)
-      track->appendTrackerHitPattern(StripSubdetector::TIB, sl + 1, 1,
-                                     TrackingRecHit::valid);
+      track->appendTrackerHitPattern(StripSubdetector::TIB, sl + 1, 1, TrackingRecHit::valid);
     else if (sl < 4 + 3)
-      track->appendTrackerHitPattern(StripSubdetector::TID, (sl - 4) + 1, 1,
-                                     TrackingRecHit::valid);
+      track->appendTrackerHitPattern(StripSubdetector::TID, (sl - 4) + 1, 1, TrackingRecHit::valid);
     else if (sl < 7 + 6)
-      track->appendTrackerHitPattern(StripSubdetector::TOB, (sl - 7) + 1, 1,
-                                     TrackingRecHit::valid);
+      track->appendTrackerHitPattern(StripSubdetector::TOB, (sl - 7) + 1, 1, TrackingRecHit::valid);
     else if (sl < 13 + 9)
-      track->appendTrackerHitPattern(StripSubdetector::TEC, (sl - 13) + 1, 1,
-                                     TrackingRecHit::valid);
+      track->appendTrackerHitPattern(StripSubdetector::TEC, (sl - 13) + 1, 1, TrackingRecHit::valid);
     else
-      break; // wtf?
+      break;  // wtf?
   }
   // finally we account for extra strip hits beyond the one-per-layer added
   // above. we put them all on TIB1, to avoid incrementing the number of
   // layersWithMeasurement.
   for (; i < numberOfHits; i++) {
     if (reco::HitPattern::stripHitFilter(firstHit_)) {
-      track->appendTrackerHitPattern(
-          reco::HitPattern::getSubStructure(firstHit_),
-          reco::HitPattern::getLayer(firstHit_), 1, TrackingRecHit::valid);
-    } else {
-      track->appendTrackerHitPattern(StripSubdetector::TIB, 1, 1,
+      track->appendTrackerHitPattern(reco::HitPattern::getSubStructure(firstHit_),
+                                     reco::HitPattern::getLayer(firstHit_),
+                                     1,
                                      TrackingRecHit::valid);
+    } else {
+      track->appendTrackerHitPattern(StripSubdetector::TIB, 1, 1, TrackingRecHit::valid);
     }
   }
 
   switch (innerLost) {
-  case validHitInFirstPixelBarrelLayer:
-    break;
-  case noLostInnerHits:
-    break;
-  case oneLostInnerHit:
-    track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0,
-                                   TrackingRecHit::missing_inner);
-    break;
-  case moreLostInnerHits:
-    track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0,
-                                   TrackingRecHit::missing_inner);
-    track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 2, 0,
-                                   TrackingRecHit::missing_inner);
-    break;
+    case validHitInFirstPixelBarrelLayer:
+      break;
+    case noLostInnerHits:
+      break;
+    case oneLostInnerHit:
+      track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0, TrackingRecHit::missing_inner);
+      break;
+    case moreLostInnerHits:
+      track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0, TrackingRecHit::missing_inner);
+      track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 2, 0, TrackingRecHit::missing_inner);
+      break;
   };
 
   if (trackHighPurity())
@@ -334,9 +306,8 @@ void pat::PackedCandidate::unpackTrk() const {
 //// Everything below is just trivial implementations of reco::Candidate methods
 
 const reco::CandidateBaseRef &pat::PackedCandidate::masterClone() const {
-  throw cms::Exception("Invalid Reference")
-      << "this Candidate has no master clone reference."
-      << "Can't call masterClone() method.\n";
+  throw cms::Exception("Invalid Reference") << "this Candidate has no master clone reference."
+                                            << "Can't call masterClone() method.\n";
 }
 
 bool pat::PackedCandidate::hasMasterClone() const { return false; }
@@ -344,9 +315,8 @@ bool pat::PackedCandidate::hasMasterClone() const { return false; }
 bool pat::PackedCandidate::hasMasterClonePtr() const { return false; }
 
 const reco::CandidatePtr &pat::PackedCandidate::masterClonePtr() const {
-  throw cms::Exception("Invalid Reference")
-      << "this Candidate has no master clone ptr."
-      << "Can't call masterClonePtr() method.\n";
+  throw cms::Exception("Invalid Reference") << "this Candidate has no master clone ptr."
+                                            << "Can't call masterClonePtr() method.\n";
 }
 
 size_t pat::PackedCandidate::numberOfDaughters() const { return 0; }
@@ -358,16 +328,11 @@ bool pat::PackedCandidate::overlap(const reco::Candidate &o) const {
   //  return  p4() == o.p4() && charge() == o.charge();
 }
 
-const reco::Candidate *pat::PackedCandidate::daughter(size_type) const {
-  return nullptr;
-}
+const reco::Candidate *pat::PackedCandidate::daughter(size_type) const { return nullptr; }
 
-const reco::Candidate *pat::PackedCandidate::mother(size_type) const {
-  return nullptr;
-}
+const reco::Candidate *pat::PackedCandidate::mother(size_type) const { return nullptr; }
 
-const reco::Candidate *
-pat::PackedCandidate::daughter(const std::string &) const {
+const reco::Candidate *pat::PackedCandidate::daughter(const std::string &) const {
   throw edm::Exception(edm::errors::UnimplementedFeature)
       << "This Candidate type does not implement daughter(std::string). "
       << "Please use CompositeCandidate or NamedCompositeCandidate.\n";
@@ -408,8 +373,7 @@ void pat::PackedCandidate::setPuppiWeight(float p, float p_nolep) {
   // Set both weights at once to avoid misconfigured weights if called in the
   // wrong order
   packedPuppiweight_ = std::numeric_limits<uint8_t>::max() * p;
-  packedPuppiweightNoLepDiff_ =
-      std::numeric_limits<int8_t>::max() * (p_nolep - p);
+  packedPuppiweightNoLepDiff_ = std::numeric_limits<int8_t>::max() * (p_nolep - p);
 }
 
 float pat::PackedCandidate::puppiWeight() const {
@@ -417,30 +381,24 @@ float pat::PackedCandidate::puppiWeight() const {
 }
 
 float pat::PackedCandidate::puppiWeightNoLep() const {
-  return 1.f * packedPuppiweightNoLepDiff_ /
-             std::numeric_limits<int8_t>::max() +
+  return 1.f * packedPuppiweightNoLepDiff_ / std::numeric_limits<int8_t>::max() +
          1.f * packedPuppiweight_ / std::numeric_limits<uint8_t>::max();
 }
 
 void pat::PackedCandidate::setRawCaloFraction(float p) {
   if (100 * p > std::numeric_limits<uint8_t>::max())
-    rawCaloFraction_ =
-        std::numeric_limits<uint8_t>::max(); // Set to overflow value
+    rawCaloFraction_ = std::numeric_limits<uint8_t>::max();  // Set to overflow value
   else
     rawCaloFraction_ = 100 * p;
 }
 
-void pat::PackedCandidate::setRawHcalFraction(float p) {
-  rawHcalFraction_ = 100 * p;
-}
+void pat::PackedCandidate::setRawHcalFraction(float p) { rawHcalFraction_ = 100 * p; }
 
 void pat::PackedCandidate::setCaloFraction(float p) { caloFraction_ = 100 * p; }
 
 void pat::PackedCandidate::setHcalFraction(float p) { hcalFraction_ = 100 * p; }
 
-void pat::PackedCandidate::setIsIsolatedChargedHadron(bool p) {
-  isIsolatedChargedHadron_ = p;
-}
+void pat::PackedCandidate::setIsIsolatedChargedHadron(bool p) { isIsolatedChargedHadron_ = p; }
 
 void pat::PackedCandidate::setDTimeAssociatedPV(float aTime, float aTimeError) {
   if (aTime == 0 && aTimeError == 0) {
@@ -451,7 +409,7 @@ void pat::PackedCandidate::setDTimeAssociatedPV(float aTime, float aTimeError) {
     packedTime_ = packTimeNoError(aTime);
   } else {
     packedTimeError_ = packTimeError(aTimeError);
-    aTimeError = unpackTimeError(packedTimeError_); // for reproducibility
+    aTimeError = unpackTimeError(packedTimeError_);  // for reproducibility
     packedTime_ = packTimeWithError(aTime, aTimeError);
   }
 }
@@ -466,16 +424,10 @@ uint8_t pat::PackedCandidate::packTimeError(float timeError) {
   //      maximum value 0.5 ns      (packed as 255)
   //      constant *relative* precision of about 2%
   return std::max<uint8_t>(
-      std::min(std::round(std::ldexp(std::log2(timeError / MIN_TIMEERROR),
-                                     +EXPO_TIMEERROR)),
-               255.f),
-      1);
+      std::min(std::round(std::ldexp(std::log2(timeError / MIN_TIMEERROR), +EXPO_TIMEERROR)), 255.f), 1);
 }
 float pat::PackedCandidate::unpackTimeError(uint8_t timeError) {
-  return timeError > 0
-             ? MIN_TIMEERROR *
-                   std::exp2(std::ldexp(float(timeError), -EXPO_TIMEERROR))
-             : -1.0f;
+  return timeError > 0 ? MIN_TIMEERROR * std::exp2(std::ldexp(float(timeError), -EXPO_TIMEERROR)) : -1.0f;
 }
 float pat::PackedCandidate::unpackTimeNoError(int16_t time) {
   if (time == 0)
@@ -491,17 +443,14 @@ int16_t pat::PackedCandidate::packTimeNoError(float time) {
   //    12 bits cover by far any plausible value (+/-2047 corresponds to about
   //    +/- 0.8 ms!) constant *relative* ~1% precision
   if (std::abs(time) < MIN_TIME_NOERROR)
-    return 0; // prevent underflows
-  float fpacked = std::ldexp(std::log2(std::abs(time / MIN_TIME_NOERROR)),
-                             +EXPO_TIME_NOERROR);
+    return 0;  // prevent underflows
+  float fpacked = std::ldexp(std::log2(std::abs(time / MIN_TIME_NOERROR)), +EXPO_TIME_NOERROR);
   return (time > 0 ? +1 : -1) * std::min(std::round(fpacked), 2047.f);
 }
-float pat::PackedCandidate::unpackTimeWithError(int16_t time,
-                                                uint8_t timeError) {
+float pat::PackedCandidate::unpackTimeWithError(int16_t time, uint8_t timeError) {
   if (time % 2 == 0) {
     // no overflow: drop rightmost bit and unpack in units of timeError
-    return std::ldexp(unpackTimeError(timeError), EXPO_TIME_WITHERROR) *
-           float(time / 2);
+    return std::ldexp(unpackTimeError(timeError), EXPO_TIME_WITHERROR) * float(time / 2);
   } else {
     // overflow: drop rightmost bit, unpack using the noError encoding
     return pat::PackedCandidate::unpackTimeNoError(time / 2);
@@ -516,13 +465,11 @@ int16_t pat::PackedCandidate::packTimeWithError(float time, float timeError) {
   // out-of-time, or mis-reconstructed, as timeError is O(20ps) and the beam
   // spot witdth is O(200ps)
   float fpacked = std::round(time / std::ldexp(timeError, EXPO_TIME_WITHERROR));
-  if (std::abs(fpacked) < 16383.f) { // 16383 = (2^14 - 1) = largest absolute
-                                     // value for a signed 15 bit integer
-    return int16_t(fpacked) * 2; // make it even, and fit in a signed 16 bit int
+  if (std::abs(fpacked) < 16383.f) {  // 16383 = (2^14 - 1) = largest absolute
+                                      // value for a signed 15 bit integer
+    return int16_t(fpacked) * 2;      // make it even, and fit in a signed 16 bit int
   } else {
-    int16_t packed = packTimeNoError(time); // encode
-    return packed * 2 +
-           (time > 0 ? +1
-                     : -1); // make it odd, to signal that there was an overlow
+    int16_t packed = packTimeNoError(time);    // encode
+    return packed * 2 + (time > 0 ? +1 : -1);  // make it odd, to signal that there was an overlow
   }
 }

--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -2,144 +2,121 @@
 #include "DataFormats/Math/interface/libminifloat.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
-
-
 void pat::PackedGenParticle::pack(bool unpackAfterwards) {
-    packedPt_  =  MiniFloatConverter::float32to16(p4_.load()->Pt());
-    packedY_ =  int16_t(p4_.load()->Rapidity()/6.0f*std::numeric_limits<int16_t>::max());
-    packedPhi_ =  int16_t(p4_.load()->Phi()/3.2f*std::numeric_limits<int16_t>::max());
-    packedM_   =  MiniFloatConverter::float32to16(p4_.load()->M());
-    if (unpackAfterwards) {
-      delete p4_.exchange(nullptr);
-      delete p4c_.exchange(nullptr);
-      unpack(); // force the values to match with the packed ones
-    }
+  packedPt_ = MiniFloatConverter::float32to16(p4_.load()->Pt());
+  packedY_ = int16_t(p4_.load()->Rapidity() / 6.0f * std::numeric_limits<int16_t>::max());
+  packedPhi_ = int16_t(p4_.load()->Phi() / 3.2f * std::numeric_limits<int16_t>::max());
+  packedM_ = MiniFloatConverter::float32to16(p4_.load()->M());
+  if (unpackAfterwards) {
+    delete p4_.exchange(nullptr);
+    delete p4c_.exchange(nullptr);
+    unpack();  // force the values to match with the packed ones
+  }
 }
 
-
 void pat::PackedGenParticle::unpack() const {
-    float y = int16_t(packedY_)*6.0f/std::numeric_limits<int16_t>::max();
-    float pt=MiniFloatConverter::float16to32(packedPt_);
-    float m=MiniFloatConverter::float16to32(packedM_);
-    float pz = std::tanh(y)*std::sqrt((m*m+pt*pt)/(1.-std::tanh(y)*std::tanh(y)));
-    float eta = 0;
-    if(pt != 0.) {
-      eta = std::asinh(pz/pt);
-    }
-    double shift = (pt<1. ? 0.1*pt : 0.1/pt); // shift particle phi to break degeneracies in angular separations
-    double sign = ( ( int(pt*10) % 2 == 0 ) ? 1 : -1 ); // introduce a pseudo-random sign of the shift
-    double phi = int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max() + sign*shift*3.2/std::numeric_limits<int16_t>::max();
-    auto p4 = std::make_unique<PolarLorentzVector>(pt,eta,phi,m);
-    PolarLorentzVector* expectp4 = nullptr;
-    if(p4_.compare_exchange_strong(expectp4,p4.get())) {
-      p4.release();
-    }
-    auto p4c = std::make_unique<LorentzVector>(*p4_);
-    LorentzVector* expectp4c = nullptr;
-    if(p4c_.compare_exchange_strong(expectp4c,p4c.get())) {
-      p4c.release();
-    }
+  float y = int16_t(packedY_) * 6.0f / std::numeric_limits<int16_t>::max();
+  float pt = MiniFloatConverter::float16to32(packedPt_);
+  float m = MiniFloatConverter::float16to32(packedM_);
+  float pz = std::tanh(y) * std::sqrt((m * m + pt * pt) / (1. - std::tanh(y) * std::tanh(y)));
+  float eta = 0;
+  if (pt != 0.) {
+    eta = std::asinh(pz / pt);
+  }
+  double shift = (pt < 1. ? 0.1 * pt : 0.1 / pt);    // shift particle phi to break degeneracies in angular separations
+  double sign = ((int(pt * 10) % 2 == 0) ? 1 : -1);  // introduce a pseudo-random sign of the shift
+  double phi = int16_t(packedPhi_) * 3.2f / std::numeric_limits<int16_t>::max() +
+               sign * shift * 3.2 / std::numeric_limits<int16_t>::max();
+  auto p4 = std::make_unique<PolarLorentzVector>(pt, eta, phi, m);
+  PolarLorentzVector* expectp4 = nullptr;
+  if (p4_.compare_exchange_strong(expectp4, p4.get())) {
+    p4.release();
+  }
+  auto p4c = std::make_unique<LorentzVector>(*p4_);
+  LorentzVector* expectp4c = nullptr;
+  if (p4c_.compare_exchange_strong(expectp4c, p4c.get())) {
+    p4c.release();
+  }
 }
 
 pat::PackedGenParticle::~PackedGenParticle() {
   delete p4_.load();
   delete p4c_.load();
- }
-
-
-float pat::PackedGenParticle::dxy(const Point &p) const {
-	unpack();
-	return -(vertex_.X()-p.X()) * std::sin(float(p4_.load()->Phi())) + (vertex_.Y()-p.Y()) * std::cos(float(p4_.load()->Phi()));
-}
-float pat::PackedGenParticle::dz(const Point &p) const {
-    unpack();
-    return (vertex_.Z()-p.X())  - ((vertex_.X()-p.X()) * std::cos(float(p4_.load()->Phi())) + (vertex_.Y()-p.Y()) * std::sin(float(p4_.load()->Phi()))) * p4_.load()->Pz()/p4_.load()->Pt();
 }
 
+float pat::PackedGenParticle::dxy(const Point& p) const {
+  unpack();
+  return -(vertex_.X() - p.X()) * std::sin(float(p4_.load()->Phi())) +
+         (vertex_.Y() - p.Y()) * std::cos(float(p4_.load()->Phi()));
+}
+float pat::PackedGenParticle::dz(const Point& p) const {
+  unpack();
+  return (vertex_.Z() - p.X()) - ((vertex_.X() - p.X()) * std::cos(float(p4_.load()->Phi())) +
+                                  (vertex_.Y() - p.Y()) * std::sin(float(p4_.load()->Phi()))) *
+                                     p4_.load()->Pz() / p4_.load()->Pt();
+}
 
 //// Everything below is just trivial implementations of reco::Candidate methods
 
-const reco::CandidateBaseRef & pat::PackedGenParticle::masterClone() const {
-  throw cms::Exception("Invalid Reference")
-    << "this Candidate has no master clone reference."
-    << "Can't call masterClone() method.\n";
+const reco::CandidateBaseRef& pat::PackedGenParticle::masterClone() const {
+  throw cms::Exception("Invalid Reference") << "this Candidate has no master clone reference."
+                                            << "Can't call masterClone() method.\n";
 }
 
-bool pat::PackedGenParticle::hasMasterClone() const {
-  return false;
+bool pat::PackedGenParticle::hasMasterClone() const { return false; }
+
+bool pat::PackedGenParticle::hasMasterClonePtr() const { return false; }
+
+const reco::CandidatePtr& pat::PackedGenParticle::masterClonePtr() const {
+  throw cms::Exception("Invalid Reference") << "this Candidate has no master clone ptr."
+                                            << "Can't call masterClonePtr() method.\n";
 }
 
-bool pat::PackedGenParticle::hasMasterClonePtr() const {
-  return false;
-}
+size_t pat::PackedGenParticle::numberOfDaughters() const { return 0; }
 
-
-const reco::CandidatePtr & pat::PackedGenParticle::masterClonePtr() const {
-  throw cms::Exception("Invalid Reference")
-    << "this Candidate has no master clone ptr."
-    << "Can't call masterClonePtr() method.\n";
-}
-
-size_t pat::PackedGenParticle::numberOfDaughters() const { 
-  return 0; 
-}
-
-size_t pat::PackedGenParticle::numberOfMothers() const { 
-  if(motherRef().isNonnull())   return 1; 
+size_t pat::PackedGenParticle::numberOfMothers() const {
+  if (motherRef().isNonnull())
+    return 1;
   return 0;
 }
 
-bool pat::PackedGenParticle::overlap( const reco::Candidate & o ) const { 
-  return  p4() == o.p4() && vertex() == o.vertex() && charge() == o.charge();
-//  return  p4() == o.p4() && charge() == o.charge();
+bool pat::PackedGenParticle::overlap(const reco::Candidate& o) const {
+  return p4() == o.p4() && vertex() == o.vertex() && charge() == o.charge();
+  //  return  p4() == o.p4() && charge() == o.charge();
 }
 
-const reco::Candidate * pat::PackedGenParticle::daughter( size_type ) const {
-  return nullptr;
-}
+const reco::Candidate* pat::PackedGenParticle::daughter(size_type) const { return nullptr; }
 
-const reco::Candidate * pat::PackedGenParticle::mother( size_type ) const {
-  return motherRef().get();
-}
+const reco::Candidate* pat::PackedGenParticle::mother(size_type) const { return motherRef().get(); }
 
-const reco::Candidate * pat::PackedGenParticle::daughter(const std::string&) const {
+const reco::Candidate* pat::PackedGenParticle::daughter(const std::string&) const {
   throw edm::Exception(edm::errors::UnimplementedFeature)
-    << "This Candidate type does not implement daughter(std::string). "
-    << "Please use CompositeCandidate or NamedCompositeCandidate.\n";
+      << "This Candidate type does not implement daughter(std::string). "
+      << "Please use CompositeCandidate or NamedCompositeCandidate.\n";
 }
 
-reco::Candidate * pat::PackedGenParticle::daughter(const std::string&) {
+reco::Candidate* pat::PackedGenParticle::daughter(const std::string&) {
   throw edm::Exception(edm::errors::UnimplementedFeature)
-    << "This Candidate type does not implement daughter(std::string). "
-    << "Please use CompositeCandidate or NamedCompositeCandidate.\n";
+      << "This Candidate type does not implement daughter(std::string). "
+      << "Please use CompositeCandidate or NamedCompositeCandidate.\n";
 }
 
+reco::Candidate* pat::PackedGenParticle::daughter(size_type) { return nullptr; }
 
+double pat::PackedGenParticle::vertexChi2() const { return 0; }
 
-reco::Candidate * pat::PackedGenParticle::daughter( size_type ) {
-  return nullptr;
-}
+double pat::PackedGenParticle::vertexNdof() const { return 0; }
 
-double pat::PackedGenParticle::vertexChi2() const {
-  return 0;
-}
-
-double pat::PackedGenParticle::vertexNdof() const {
-  return 0;
-}
-
-double pat::PackedGenParticle::vertexNormalizedChi2() const {
-  return 0;
-}
+double pat::PackedGenParticle::vertexNormalizedChi2() const { return 0; }
 
 double pat::PackedGenParticle::vertexCovariance(int i, int j) const {
   throw edm::Exception(edm::errors::UnimplementedFeature)
-    << "reco::ConcreteCandidate does not implement vertex covariant matrix.\n";
+      << "reco::ConcreteCandidate does not implement vertex covariant matrix.\n";
 }
 
-void pat::PackedGenParticle::fillVertexCovariance(CovarianceMatrix & err) const {
+void pat::PackedGenParticle::fillVertexCovariance(CovarianceMatrix& err) const {
   throw edm::Exception(edm::errors::UnimplementedFeature)
-    << "reco::ConcreteCandidate does not implement vertex covariant matrix.\n";
+      << "reco::ConcreteCandidate does not implement vertex covariant matrix.\n";
 }
 
 bool pat::PackedGenParticle::isElectron() const { return false; }
@@ -160,10 +137,6 @@ bool pat::PackedGenParticle::isConvertedPhoton() const { return false; }
 
 bool pat::PackedGenParticle::isJet() const { return false; }
 
-bool pat::PackedGenParticle::longLived() const {return false;}
+bool pat::PackedGenParticle::longLived() const { return false; }
 
-bool pat::PackedGenParticle::massConstraint() const {return false;}
-
-
-
-
+bool pat::PackedGenParticle::massConstraint() const { return false; }

--- a/DataFormats/PatCandidates/src/PackedTriggerPrescales.cc
+++ b/DataFormats/PatCandidates/src/PackedTriggerPrescales.cc
@@ -2,39 +2,39 @@
 #include "DataFormats/Common/interface/RefProd.h"
 #include <cstring>
 
-pat::PackedTriggerPrescales::PackedTriggerPrescales(const edm::Handle<edm::TriggerResults> & handle) :
-    prescaleValues_(), 
-    triggerResults_(edm::RefProd<edm::TriggerResults>(handle).refCore()),
-    triggerNames_(nullptr)
-{
-    prescaleValues_.resize(handle->size(),0);
+pat::PackedTriggerPrescales::PackedTriggerPrescales(const edm::Handle<edm::TriggerResults> &handle)
+    : prescaleValues_(), triggerResults_(edm::RefProd<edm::TriggerResults>(handle).refCore()), triggerNames_(nullptr) {
+  prescaleValues_.resize(handle->size(), 0);
 }
 
 int pat::PackedTriggerPrescales::getPrescaleForIndex(int index) const {
-    if (unsigned(index) >= triggerResults().size()) throw cms::Exception("InvalidReference", "Index out of bounds");
-    return prescaleValues_[index];
+  if (unsigned(index) >= triggerResults().size())
+    throw cms::Exception("InvalidReference", "Index out of bounds");
+  return prescaleValues_[index];
 }
 
-int pat::PackedTriggerPrescales::getPrescaleForName(const std::string & name, bool prefixOnly) const {
-    if (triggerNames_ == nullptr) throw cms::Exception("LogicError", "getPrescaleForName called without having called setTriggerNames first");
-    if (prefixOnly) {
-        const std::vector<std::string> &names = triggerNames_->triggerNames();
-        size_t siz = name.length()-1;
-        while (siz > 0 && (name[siz] == '*' || name[siz] == '\0')) siz--;
-        for (unsigned int i = 0, n = names.size(); i < n; ++i) {
-            if (strncmp(name.c_str(), names[i].c_str(), siz) == 0) {
-                return getPrescaleForIndex(i);
-            }
-        }
-        throw cms::Exception("InvalidReference", "Index out of bounds");
-    } else {
-        int index = triggerNames_->triggerIndex(name);
-        return getPrescaleForIndex(index);
+int pat::PackedTriggerPrescales::getPrescaleForName(const std::string &name, bool prefixOnly) const {
+  if (triggerNames_ == nullptr)
+    throw cms::Exception("LogicError", "getPrescaleForName called without having called setTriggerNames first");
+  if (prefixOnly) {
+    const std::vector<std::string> &names = triggerNames_->triggerNames();
+    size_t siz = name.length() - 1;
+    while (siz > 0 && (name[siz] == '*' || name[siz] == '\0'))
+      siz--;
+    for (unsigned int i = 0, n = names.size(); i < n; ++i) {
+      if (strncmp(name.c_str(), names[i].c_str(), siz) == 0) {
+        return getPrescaleForIndex(i);
+      }
     }
+    throw cms::Exception("InvalidReference", "Index out of bounds");
+  } else {
+    int index = triggerNames_->triggerIndex(name);
+    return getPrescaleForIndex(index);
+  }
 }
 
 void pat::PackedTriggerPrescales::addPrescaledTrigger(int index, int prescale) {
-    if (unsigned(index) >= triggerResults().size()) throw cms::Exception("InvalidReference", "Index out of bounds");
-    prescaleValues_[index] = prescale;
+  if (unsigned(index) >= triggerResults().size())
+    throw cms::Exception("InvalidReference", "Index out of bounds");
+  prescaleValues_[index] = prescale;
 }
-

--- a/DataFormats/PatCandidates/src/ParametrizationHelper.cc
+++ b/DataFormats/PatCandidates/src/ParametrizationHelper.cc
@@ -6,515 +6,561 @@
 #include <Math/DisplacementVector3D.h>
 #include <Math/Functions.h>
 
-using namespace std; 
+using namespace std;
 
 //pat::helper::ParametrizationHelper::POLAR_ZERO();
 //pat::helper::ParametrizationHelper::CARTESIAN_ZERO();
 
-pat::CandKinResolution::Parametrization 
-pat::helper::ParametrizationHelper::fromString(const std::string &name) {
-    using namespace std;
+pat::CandKinResolution::Parametrization pat::helper::ParametrizationHelper::fromString(const std::string &name) {
+  using namespace std;
 
-    typedef pat::CandKinResolution::Parametrization Parametrization;
+  typedef pat::CandKinResolution::Parametrization Parametrization;
 
-    static map<string,Parametrization> const parMaps = {
-      {"Cart"          , pat::CandKinResolution::Cart},
-      {"ECart"         , pat::CandKinResolution::ECart},  
-      {"MCCart"        , pat::CandKinResolution::MCCart},  
-      {"Spher"         , pat::CandKinResolution::Spher},  
-      {"ESpher"        , pat::CandKinResolution::ESpher},  
-      {"MCSpher"       , pat::CandKinResolution::MCSpher},  
-      {"MCPInvSpher"   , pat::CandKinResolution::MCPInvSpher},  
-      {"EtEtaPhi"      , pat::CandKinResolution::EtEtaPhi},  
-      {"EtThetaPhi"    , pat::CandKinResolution::EtThetaPhi},
-      {"MomDev"        , pat::CandKinResolution::MomDev},
-      {"EMomDev"       , pat::CandKinResolution::EMomDev},
-      {"MCMomDev"      , pat::CandKinResolution::MCMomDev},
-      {"EScaledMomDev" , pat::CandKinResolution::EScaledMomDev}
-    };
-    map<string,Parametrization>::const_iterator itP = parMaps.find(name);
-    if (itP == parMaps.end()) {
-        throw cms::Exception("StringResolutionProvider") << "Bad parametrization '" << name.c_str() << "'";
-    }
-    return itP->second;
+  static map<string, Parametrization> const parMaps = {{"Cart", pat::CandKinResolution::Cart},
+                                                       {"ECart", pat::CandKinResolution::ECart},
+                                                       {"MCCart", pat::CandKinResolution::MCCart},
+                                                       {"Spher", pat::CandKinResolution::Spher},
+                                                       {"ESpher", pat::CandKinResolution::ESpher},
+                                                       {"MCSpher", pat::CandKinResolution::MCSpher},
+                                                       {"MCPInvSpher", pat::CandKinResolution::MCPInvSpher},
+                                                       {"EtEtaPhi", pat::CandKinResolution::EtEtaPhi},
+                                                       {"EtThetaPhi", pat::CandKinResolution::EtThetaPhi},
+                                                       {"MomDev", pat::CandKinResolution::MomDev},
+                                                       {"EMomDev", pat::CandKinResolution::EMomDev},
+                                                       {"MCMomDev", pat::CandKinResolution::MCMomDev},
+                                                       {"EScaledMomDev", pat::CandKinResolution::EScaledMomDev}};
+  map<string, Parametrization>::const_iterator itP = parMaps.find(name);
+  if (itP == parMaps.end()) {
+    throw cms::Exception("StringResolutionProvider") << "Bad parametrization '" << name.c_str() << "'";
+  }
+  return itP->second;
 }
 
-const char * 
-pat::helper::ParametrizationHelper::name(pat::CandKinResolution::Parametrization param) {
-    switch (param) {
-        case pat::CandKinResolution::Cart:          return "Cart";  
-        case pat::CandKinResolution::ECart:         return "ECart";  
-        case pat::CandKinResolution::MCCart:        return "MCCart";  
-        case pat::CandKinResolution::Spher:         return "Spher";  
-        case pat::CandKinResolution::ESpher:        return "ESpher";  
-        case pat::CandKinResolution::MCSpher:       return "MCSpher";  
-        case pat::CandKinResolution::MCPInvSpher:   return "MCPInvSpher";  
-        case pat::CandKinResolution::EtEtaPhi:      return "EtEtaPhi";  
-        case pat::CandKinResolution::EtThetaPhi:    return "EtThetaPhi";
-        case pat::CandKinResolution::MomDev:        return "MomDev";
-        case pat::CandKinResolution::EMomDev:       return "EMomDev";
-        case pat::CandKinResolution::MCMomDev:      return "MCMomDev";
-        case pat::CandKinResolution::EScaledMomDev: return "EScaledMomDev";
-        case pat::CandKinResolution::Invalid:       return "Invalid";
-        default: return "UNKNOWN";
-    }
-}
- 
-math::PtEtaPhiMLorentzVector 
-pat::helper::ParametrizationHelper::polarP4fromParameters(pat::CandKinResolution::Parametrization parametrization, 
-            const AlgebraicVector4 &parameters,
-            const math::PtEtaPhiMLorentzVector &initialP4) {
-    math::PtEtaPhiMLorentzVector  ret;
-    ROOT::Math::CylindricalEta3D<double> converter;
-    double m2;
-    switch (parametrization) {
-        // ======= CARTESIAN ==========
-        case pat::CandKinResolution::Cart:
-            ret = math::XYZTLorentzVector(parameters[0], parameters[1], parameters[2], 
-                    sqrt(parameters[0]*parameters[0] + 
-                        parameters[1]*parameters[1] + 
-                        parameters[2]*parameters[2] + 
-                        parameters[3]*parameters[3])  );
-            ret.SetM(parameters[3]); // to be sure about roundoffs
-            break;
-        case pat::CandKinResolution::MCCart:
-            ret = math::XYZTLorentzVector(parameters[0], parameters[1], parameters[2], 
-                    sqrt(parameters[0]*parameters[0] + 
-                        parameters[1]*parameters[1] + 
-                        parameters[2]*parameters[2] + 
-                        initialP4.mass()*initialP4.mass())  );
-            ret.SetM(initialP4.mass()); // to be sure about roundoffs
-            break;
-        case pat::CandKinResolution::ECart:    
-            ret = math::XYZTLorentzVector(parameters[0], parameters[1], parameters[2], parameters[3]);
-            break;
-        // ======= SPHERICAL ==========
-        case pat::CandKinResolution::Spher:  
-            converter = ROOT::Math::Polar3D<double>(parameters[0], parameters[1], 0); 
-            ret.SetCoordinates(converter.Rho(),converter.Eta(),parameters[2],parameters[3]);
-            break;
-        case pat::CandKinResolution::MCSpher:    // same as above
-            converter = ROOT::Math::Polar3D<double>(parameters[0], parameters[1], 0); 
-            ret.SetCoordinates(converter.Rho(),converter.Eta(),parameters[2],initialP4.mass());
-            break;
-        case pat::CandKinResolution::ESpher:        //  
-            converter = ROOT::Math::Polar3D<double>(parameters[0], parameters[1], 0); 
-            m2 = - parameters[0]*parameters[0] + parameters[3]*parameters[3];
-            ret.SetCoordinates(converter.Rho(),converter.Eta(),parameters[2],(m2 > 0 ? sqrt(m2) : 0.0));
-            break;
-        case pat::CandKinResolution::MCPInvSpher:   //  
-            converter = ROOT::Math::Polar3D<double>(1.0/parameters[0], parameters[1], 0); 
-            ret.SetCoordinates(converter.Rho(),converter.Eta(),parameters[2],initialP4.mass());
-            break;
-        // ======= HEP CYLINDRICAL ==========
-        case pat::CandKinResolution::EtThetaPhi: 
-            converter = ROOT::Math::Polar3D<double>(1.0, parameters[1], 0); 
-            ret.SetCoordinates(parameters[0],converter.Eta(),parameters[2],0);
-            break;
-        case pat::CandKinResolution::EtEtaPhi:      // as simple as that
-            ret.SetCoordinates(parameters[0], parameters[1], parameters[2], 0);
-            break;
-        // ======= MomentumDeviates ==========
-        case pat::CandKinResolution::MomDev:
-        case pat::CandKinResolution::EMomDev:
-        case pat::CandKinResolution::MCMomDev:
-        case pat::CandKinResolution::EScaledMomDev:
-            {
-                ROOT::Math::DisplacementVector3D< ROOT::Math::Cartesian3D<double> > p = initialP4.Vect(), uz(0,0,1), uph, uth;
-                uph = uz.Cross(p).Unit();
-                uth = p.Cross(uph).Unit();
-                p *= parameters[0]; 
-                p += uth * parameters[1] + uph * parameters[2];
-                if (parametrization == pat::CandKinResolution::MomDev) {
-                    ret.SetCoordinates(p.Rho(), p.Eta(), p.Phi(), initialP4.mass() * parameters[3]);
-                } else if (parametrization == pat::CandKinResolution::EMomDev) {
-                    double m2 = ROOT::Math::Square(parameters[3] * initialP4.energy()) - p.Mag2();
-                    ret.SetCoordinates(p.Rho(), p.Eta(), p.Phi(), (m2 > 0 ? sqrt(m2) : 0.0));
-                } else if (parametrization == pat::CandKinResolution::EScaledMomDev) {
-                    double m2 = ROOT::Math::Square(p.R()*initialP4.E()/initialP4.P()) - p.Mag2();
-                    ret.SetCoordinates(p.Rho(), p.Eta(), p.Phi(), (m2 > 0 ? sqrt(m2) : 0.0));
-                } else if (parametrization == pat::CandKinResolution::MCMomDev) {
-                    ret.SetCoordinates(p.Rho(), p.Eta(), p.Phi(), initialP4.mass());
-                }
-                break;
-            }
-        // ======= OTHER ==========
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolEta not yet implemented for parametrization " << parametrization ;
-    }
-    return ret;
+const char *pat::helper::ParametrizationHelper::name(pat::CandKinResolution::Parametrization param) {
+  switch (param) {
+    case pat::CandKinResolution::Cart:
+      return "Cart";
+    case pat::CandKinResolution::ECart:
+      return "ECart";
+    case pat::CandKinResolution::MCCart:
+      return "MCCart";
+    case pat::CandKinResolution::Spher:
+      return "Spher";
+    case pat::CandKinResolution::ESpher:
+      return "ESpher";
+    case pat::CandKinResolution::MCSpher:
+      return "MCSpher";
+    case pat::CandKinResolution::MCPInvSpher:
+      return "MCPInvSpher";
+    case pat::CandKinResolution::EtEtaPhi:
+      return "EtEtaPhi";
+    case pat::CandKinResolution::EtThetaPhi:
+      return "EtThetaPhi";
+    case pat::CandKinResolution::MomDev:
+      return "MomDev";
+    case pat::CandKinResolution::EMomDev:
+      return "EMomDev";
+    case pat::CandKinResolution::MCMomDev:
+      return "MCMomDev";
+    case pat::CandKinResolution::EScaledMomDev:
+      return "EScaledMomDev";
+    case pat::CandKinResolution::Invalid:
+      return "Invalid";
+    default:
+      return "UNKNOWN";
+  }
 }
 
-math::XYZTLorentzVector 
-pat::helper::ParametrizationHelper::p4fromParameters(pat::CandKinResolution::Parametrization parametrization, 
-            const AlgebraicVector4 &parameters,
-            const math::XYZTLorentzVector &initialP4) {
-    math::XYZTLorentzVector ret;
-    switch (parametrization) {
-        // ======= CARTESIAN ==========
-        case pat::CandKinResolution::Cart:
-            ret.SetCoordinates(parameters[0], parameters[1], parameters[2], 
-                    sqrt(parameters[0]*parameters[0] + 
-                        parameters[1]*parameters[1] + 
-                        parameters[2]*parameters[2] + 
-                        parameters[3]*parameters[3])  );
-            break;
-        case pat::CandKinResolution::MCCart: // same as above
-            ret.SetCoordinates(parameters[0], parameters[1], parameters[2], 
-                    sqrt(parameters[0]*parameters[0] + 
-                        parameters[1]*parameters[1] + 
-                        parameters[2]*parameters[2] + 
-                        initialP4.mass()*initialP4.mass())  );
-            break;
-        case pat::CandKinResolution::ECart:    
-            ret.SetCoordinates(parameters[0], parameters[1], parameters[2], parameters[3]);
-            break;
-        // ======= MomentumDeviates ==========
-        case pat::CandKinResolution::MomDev:
-        case pat::CandKinResolution::EMomDev:
-        case pat::CandKinResolution::MCMomDev:
-        case pat::CandKinResolution::EScaledMomDev:
-            {
-                ROOT::Math::DisplacementVector3D< ROOT::Math::Cartesian3D<double> > p = initialP4.Vect(), uz(0,0,1), uph, uth;
-                uph = uz.Cross(p).Unit();
-                uth = p.Cross(uph).Unit();
-                p *= parameters[0]; 
-                p += uth * parameters[1] + uph * parameters[2];
-                if (parametrization == pat::CandKinResolution::MomDev) {
-                    ret.SetCoordinates(p.X(), p.Y(), p.Z(), sqrt(p.Mag2() + ROOT::Math::Square(initialP4.mass() * parameters[3])) );
-                } else if (parametrization == pat::CandKinResolution::EMomDev) {
-                    ret.SetCoordinates(p.X(), p.Y(), p.Z(), parameters[3] * initialP4.energy());
-                } else if (parametrization == pat::CandKinResolution::EMomDev) {
-                    ret.SetCoordinates(p.X(), p.Y(), p.Z(), p.R() * initialP4.E()/initialP4.P());
-                } else {
-                    ret.SetCoordinates(p.X(), p.Y(), p.Z(), sqrt(p.Mag2() + initialP4.mass()*initialP4.mass()));
-                }
-                break;
-            }
-        // ======= ALL OTHERS ==========
-        default:
-            ret = polarP4fromParameters(parametrization, parameters, math::PtEtaPhiMLorentzVector(initialP4));
+math::PtEtaPhiMLorentzVector pat::helper::ParametrizationHelper::polarP4fromParameters(
+    pat::CandKinResolution::Parametrization parametrization,
+    const AlgebraicVector4 &parameters,
+    const math::PtEtaPhiMLorentzVector &initialP4) {
+  math::PtEtaPhiMLorentzVector ret;
+  ROOT::Math::CylindricalEta3D<double> converter;
+  double m2;
+  switch (parametrization) {
+    // ======= CARTESIAN ==========
+    case pat::CandKinResolution::Cart:
+      ret = math::XYZTLorentzVector(parameters[0],
+                                    parameters[1],
+                                    parameters[2],
+                                    sqrt(parameters[0] * parameters[0] + parameters[1] * parameters[1] +
+                                         parameters[2] * parameters[2] + parameters[3] * parameters[3]));
+      ret.SetM(parameters[3]);  // to be sure about roundoffs
+      break;
+    case pat::CandKinResolution::MCCart:
+      ret = math::XYZTLorentzVector(parameters[0],
+                                    parameters[1],
+                                    parameters[2],
+                                    sqrt(parameters[0] * parameters[0] + parameters[1] * parameters[1] +
+                                         parameters[2] * parameters[2] + initialP4.mass() * initialP4.mass()));
+      ret.SetM(initialP4.mass());  // to be sure about roundoffs
+      break;
+    case pat::CandKinResolution::ECart:
+      ret = math::XYZTLorentzVector(parameters[0], parameters[1], parameters[2], parameters[3]);
+      break;
+    // ======= SPHERICAL ==========
+    case pat::CandKinResolution::Spher:
+      converter = ROOT::Math::Polar3D<double>(parameters[0], parameters[1], 0);
+      ret.SetCoordinates(converter.Rho(), converter.Eta(), parameters[2], parameters[3]);
+      break;
+    case pat::CandKinResolution::MCSpher:  // same as above
+      converter = ROOT::Math::Polar3D<double>(parameters[0], parameters[1], 0);
+      ret.SetCoordinates(converter.Rho(), converter.Eta(), parameters[2], initialP4.mass());
+      break;
+    case pat::CandKinResolution::ESpher:  //
+      converter = ROOT::Math::Polar3D<double>(parameters[0], parameters[1], 0);
+      m2 = -parameters[0] * parameters[0] + parameters[3] * parameters[3];
+      ret.SetCoordinates(converter.Rho(), converter.Eta(), parameters[2], (m2 > 0 ? sqrt(m2) : 0.0));
+      break;
+    case pat::CandKinResolution::MCPInvSpher:  //
+      converter = ROOT::Math::Polar3D<double>(1.0 / parameters[0], parameters[1], 0);
+      ret.SetCoordinates(converter.Rho(), converter.Eta(), parameters[2], initialP4.mass());
+      break;
+    // ======= HEP CYLINDRICAL ==========
+    case pat::CandKinResolution::EtThetaPhi:
+      converter = ROOT::Math::Polar3D<double>(1.0, parameters[1], 0);
+      ret.SetCoordinates(parameters[0], converter.Eta(), parameters[2], 0);
+      break;
+    case pat::CandKinResolution::EtEtaPhi:  // as simple as that
+      ret.SetCoordinates(parameters[0], parameters[1], parameters[2], 0);
+      break;
+    // ======= MomentumDeviates ==========
+    case pat::CandKinResolution::MomDev:
+    case pat::CandKinResolution::EMomDev:
+    case pat::CandKinResolution::MCMomDev:
+    case pat::CandKinResolution::EScaledMomDev: {
+      ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> > p = initialP4.Vect(), uz(0, 0, 1), uph, uth;
+      uph = uz.Cross(p).Unit();
+      uth = p.Cross(uph).Unit();
+      p *= parameters[0];
+      p += uth * parameters[1] + uph * parameters[2];
+      if (parametrization == pat::CandKinResolution::MomDev) {
+        ret.SetCoordinates(p.Rho(), p.Eta(), p.Phi(), initialP4.mass() * parameters[3]);
+      } else if (parametrization == pat::CandKinResolution::EMomDev) {
+        double m2 = ROOT::Math::Square(parameters[3] * initialP4.energy()) - p.Mag2();
+        ret.SetCoordinates(p.Rho(), p.Eta(), p.Phi(), (m2 > 0 ? sqrt(m2) : 0.0));
+      } else if (parametrization == pat::CandKinResolution::EScaledMomDev) {
+        double m2 = ROOT::Math::Square(p.R() * initialP4.E() / initialP4.P()) - p.Mag2();
+        ret.SetCoordinates(p.Rho(), p.Eta(), p.Phi(), (m2 > 0 ? sqrt(m2) : 0.0));
+      } else if (parametrization == pat::CandKinResolution::MCMomDev) {
+        ret.SetCoordinates(p.Rho(), p.Eta(), p.Phi(), initialP4.mass());
+      }
+      break;
     }
-    return ret;
+    // ======= OTHER ==========
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolEta not yet implemented for parametrization " << parametrization;
+  }
+  return ret;
+}
+
+math::XYZTLorentzVector pat::helper::ParametrizationHelper::p4fromParameters(
+    pat::CandKinResolution::Parametrization parametrization,
+    const AlgebraicVector4 &parameters,
+    const math::XYZTLorentzVector &initialP4) {
+  math::XYZTLorentzVector ret;
+  switch (parametrization) {
+    // ======= CARTESIAN ==========
+    case pat::CandKinResolution::Cart:
+      ret.SetCoordinates(parameters[0],
+                         parameters[1],
+                         parameters[2],
+                         sqrt(parameters[0] * parameters[0] + parameters[1] * parameters[1] +
+                              parameters[2] * parameters[2] + parameters[3] * parameters[3]));
+      break;
+    case pat::CandKinResolution::MCCart:  // same as above
+      ret.SetCoordinates(parameters[0],
+                         parameters[1],
+                         parameters[2],
+                         sqrt(parameters[0] * parameters[0] + parameters[1] * parameters[1] +
+                              parameters[2] * parameters[2] + initialP4.mass() * initialP4.mass()));
+      break;
+    case pat::CandKinResolution::ECart:
+      ret.SetCoordinates(parameters[0], parameters[1], parameters[2], parameters[3]);
+      break;
+    // ======= MomentumDeviates ==========
+    case pat::CandKinResolution::MomDev:
+    case pat::CandKinResolution::EMomDev:
+    case pat::CandKinResolution::MCMomDev:
+    case pat::CandKinResolution::EScaledMomDev: {
+      ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> > p = initialP4.Vect(), uz(0, 0, 1), uph, uth;
+      uph = uz.Cross(p).Unit();
+      uth = p.Cross(uph).Unit();
+      p *= parameters[0];
+      p += uth * parameters[1] + uph * parameters[2];
+      if (parametrization == pat::CandKinResolution::MomDev) {
+        ret.SetCoordinates(p.X(), p.Y(), p.Z(), sqrt(p.Mag2() + ROOT::Math::Square(initialP4.mass() * parameters[3])));
+      } else if (parametrization == pat::CandKinResolution::EMomDev) {
+        ret.SetCoordinates(p.X(), p.Y(), p.Z(), parameters[3] * initialP4.energy());
+      } else if (parametrization == pat::CandKinResolution::EMomDev) {
+        ret.SetCoordinates(p.X(), p.Y(), p.Z(), p.R() * initialP4.E() / initialP4.P());
+      } else {
+        ret.SetCoordinates(p.X(), p.Y(), p.Z(), sqrt(p.Mag2() + initialP4.mass() * initialP4.mass()));
+      }
+      break;
+    }
+    // ======= ALL OTHERS ==========
+    default:
+      ret = polarP4fromParameters(parametrization, parameters, math::PtEtaPhiMLorentzVector(initialP4));
+  }
+  return ret;
 }
 
 template <typename T>
-void
-pat::helper::ParametrizationHelper::setParametersFromAnyVector(pat::CandKinResolution::Parametrization parametrization, 
-            AlgebraicVector4 &ret, 
-            const T &p4) {
-    switch (parametrization) {
-        // ======= CARTESIAN ==========
-        case pat::CandKinResolution::Cart:
-            ret[0] = p4.px(); ret[1] = p4.py(); ret[2] = p4.pz(); ret[3] = p4.mass();
-            break;
-        case pat::CandKinResolution::MCCart: 
-            ret[0] = p4.px(); ret[1] = p4.py(); ret[2] = p4.pz(); ret[3] = p4.mass();        
-            break;
-        case pat::CandKinResolution::ECart:    
-            ret[0] = p4.px(); ret[1] = p4.py(); ret[2] = p4.pz(); ret[3] = p4.energy();        
-            break;
-        // ======= SPHERICAL ==========
-       case pat::CandKinResolution::Spher:  
-            ret[0] = p4.P(); ret[1] = p4.theta(); ret[2] = p4.phi(); ret[3] = p4.mass();        
-            break;
-       case pat::CandKinResolution::MCSpher: 
-            ret[0] = p4.P(); ret[1] = p4.theta(); ret[2] = p4.phi(); ret[3] = p4.mass();
-            break;
-       case pat::CandKinResolution::ESpher:
-            ret[0] = p4.P(); ret[1] = p4.theta(); ret[2] = p4.phi(); ret[3] = p4.energy();        
-            break;
-        case pat::CandKinResolution::MCPInvSpher:  
-            ret[0] = 1.0/p4.P(); ret[1] = p4.theta(); ret[2] = p4.phi(); ret[3] = p4.mass();
-            break;
-        // ======= HEP CYLINDRICAL ==========
-        case pat::CandKinResolution::EtThetaPhi: 
-            ret[0] = p4.pt(); ret[1] = p4.theta(); ret[2] = p4.phi(); ret[3] = 0;
-            break;
-        case pat::CandKinResolution::EtEtaPhi:
-            ret[0] = p4.pt(); ret[1] = p4.eta(); ret[2] = p4.phi();   ret[3] = 0;
-            break;
-        // ======= DEVIATES ==========
-        case pat::CandKinResolution::MomDev:
-        case pat::CandKinResolution::EMomDev:
-             ret[0] = 1.0; ret[1] = 0.0; ret[2] = 0.0; ret[3] = 1.0;
-             break;
-        case pat::CandKinResolution::MCMomDev:
-             ret[0] = 1.0; ret[1] = 0.0; ret[2] = 0.0; ret[3] = p4.mass();
-             break;
-        case pat::CandKinResolution::EScaledMomDev:
-             ret[0] = 1.0; ret[1] = 0.0; ret[2] = 0.0; ret[3] = p4.E()/p4.P();
-             break;
-        // ======= OTHER ==========
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolEta not yet implemented for parametrization " << parametrization ;
+void pat::helper::ParametrizationHelper::setParametersFromAnyVector(
+    pat::CandKinResolution::Parametrization parametrization, AlgebraicVector4 &ret, const T &p4) {
+  switch (parametrization) {
+    // ======= CARTESIAN ==========
+    case pat::CandKinResolution::Cart:
+      ret[0] = p4.px();
+      ret[1] = p4.py();
+      ret[2] = p4.pz();
+      ret[3] = p4.mass();
+      break;
+    case pat::CandKinResolution::MCCart:
+      ret[0] = p4.px();
+      ret[1] = p4.py();
+      ret[2] = p4.pz();
+      ret[3] = p4.mass();
+      break;
+    case pat::CandKinResolution::ECart:
+      ret[0] = p4.px();
+      ret[1] = p4.py();
+      ret[2] = p4.pz();
+      ret[3] = p4.energy();
+      break;
+      // ======= SPHERICAL ==========
+    case pat::CandKinResolution::Spher:
+      ret[0] = p4.P();
+      ret[1] = p4.theta();
+      ret[2] = p4.phi();
+      ret[3] = p4.mass();
+      break;
+    case pat::CandKinResolution::MCSpher:
+      ret[0] = p4.P();
+      ret[1] = p4.theta();
+      ret[2] = p4.phi();
+      ret[3] = p4.mass();
+      break;
+    case pat::CandKinResolution::ESpher:
+      ret[0] = p4.P();
+      ret[1] = p4.theta();
+      ret[2] = p4.phi();
+      ret[3] = p4.energy();
+      break;
+    case pat::CandKinResolution::MCPInvSpher:
+      ret[0] = 1.0 / p4.P();
+      ret[1] = p4.theta();
+      ret[2] = p4.phi();
+      ret[3] = p4.mass();
+      break;
+    // ======= HEP CYLINDRICAL ==========
+    case pat::CandKinResolution::EtThetaPhi:
+      ret[0] = p4.pt();
+      ret[1] = p4.theta();
+      ret[2] = p4.phi();
+      ret[3] = 0;
+      break;
+    case pat::CandKinResolution::EtEtaPhi:
+      ret[0] = p4.pt();
+      ret[1] = p4.eta();
+      ret[2] = p4.phi();
+      ret[3] = 0;
+      break;
+    // ======= DEVIATES ==========
+    case pat::CandKinResolution::MomDev:
+    case pat::CandKinResolution::EMomDev:
+      ret[0] = 1.0;
+      ret[1] = 0.0;
+      ret[2] = 0.0;
+      ret[3] = 1.0;
+      break;
+    case pat::CandKinResolution::MCMomDev:
+      ret[0] = 1.0;
+      ret[1] = 0.0;
+      ret[2] = 0.0;
+      ret[3] = p4.mass();
+      break;
+    case pat::CandKinResolution::EScaledMomDev:
+      ret[0] = 1.0;
+      ret[1] = 0.0;
+      ret[2] = 0.0;
+      ret[3] = p4.E() / p4.P();
+      break;
+    // ======= OTHER ==========
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolEta not yet implemented for parametrization " << parametrization;
+  }
+}
+
+void pat::helper::ParametrizationHelper::setParametersFromP4(pat::CandKinResolution::Parametrization parametrization,
+                                                             AlgebraicVector4 &v,
+                                                             const math::PtEtaPhiMLorentzVector &p4) {
+  setParametersFromAnyVector(parametrization, v, p4);
+}
+
+void pat::helper::ParametrizationHelper::setParametersFromP4(pat::CandKinResolution::Parametrization parametrization,
+                                                             AlgebraicVector4 &v,
+                                                             const math::XYZTLorentzVector &p4) {
+  setParametersFromAnyVector(parametrization, v, p4);
+}
+
+AlgebraicVector4 pat::helper::ParametrizationHelper::parametersFromP4(
+    pat::CandKinResolution::Parametrization parametrization, const math::PtEtaPhiMLorentzVector &p4) {
+  AlgebraicVector4 ret;
+  setParametersFromP4(parametrization, ret, p4);
+  return ret;
+}
+
+AlgebraicVector4 pat::helper::ParametrizationHelper::parametersFromP4(
+    pat::CandKinResolution::Parametrization parametrization, const math::XYZTLorentzVector &p4) {
+  AlgebraicVector4 ret;
+  setParametersFromP4(parametrization, ret, p4);
+  return ret;
+}
+
+AlgebraicVector4 pat::helper::ParametrizationHelper::diffToParameters(
+    pat::CandKinResolution::Parametrization parametrization,
+    const math::PtEtaPhiMLorentzVector &p4ini,
+    const math::PtEtaPhiMLorentzVector &p4fin) {
+  AlgebraicVector4 ret;
+  switch (parametrization) {
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart:
+      ret = parametersFromP4(parametrization, p4fin) - parametersFromP4(parametrization, p4ini);
+      break;
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::MCPInvSpher:
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi:
+      ret = parametersFromP4(parametrization, p4fin) - parametersFromP4(parametrization, p4ini);
+      while (ret[2] > +M_PI)
+        ret[2] -= (2 * M_PI);
+      while (ret[2] < -M_PI)
+        ret[2] += (2 * M_PI);
+      break;
+    case pat::CandKinResolution::MCMomDev:
+    case pat::CandKinResolution::MomDev:
+    case pat::CandKinResolution::EMomDev:
+    case pat::CandKinResolution::EScaledMomDev:
+      return diffToParameters(parametrization, math::XYZTLorentzVector(p4ini), math::XYZTLorentzVector(p4fin));
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "diffToParameters not yet implemented for parametrization " << parametrization;
+  }
+  return ret;
+}
+
+AlgebraicVector4 pat::helper::ParametrizationHelper::diffToParameters(
+    pat::CandKinResolution::Parametrization parametrization,
+    const math::XYZTLorentzVector &p4ini,
+    const math::XYZTLorentzVector &p4fin) {
+  AlgebraicVector4 ret;
+  switch (parametrization) {
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart:
+    case pat::CandKinResolution::Spher:
+      ret = parametersFromP4(parametrization, p4fin) - parametersFromP4(parametrization, p4ini);
+      break;
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::MCPInvSpher:
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi:
+      ret = parametersFromP4(parametrization, p4fin) - parametersFromP4(parametrization, p4ini);
+      while (ret[2] > +M_PI)
+        ret[2] -= (2 * M_PI);
+      while (ret[2] < -M_PI)
+        ret[2] += (2 * M_PI);
+      break;
+    case pat::CandKinResolution::MCMomDev:
+    case pat::CandKinResolution::MomDev:
+    case pat::CandKinResolution::EMomDev:
+    case pat::CandKinResolution::EScaledMomDev: {
+      typedef ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> > V3Cart;
+      V3Cart p1 = p4ini.Vect(), p2 = p4fin.Vect();
+      V3Cart ur = p1.Unit();
+      V3Cart uz(0, 0, 1);
+      V3Cart uph = uz.Cross(ur).Unit();
+      V3Cart uth = ur.Cross(uph).Unit();
+      ret[0] = p2.Dot(ur) / p1.R() - 1.0;
+      ret[1] = (p2 - p1).Dot(uth);
+      ret[2] = (p2 - p1).Dot(uph);
+      if (parametrization == pat::CandKinResolution::MomDev) {
+        ret[3] = p4fin.mass() / p4ini.mass() - 1.0;
+      } else if (parametrization == pat::CandKinResolution::EMomDev) {
+        ret[3] = p4fin.energy() / p4ini.energy() - 1.0;
+      }
+    } break;
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "diffToParameters not yet implemented for parametrization " << parametrization;
+  }
+  return ret;
+}
+
+bool pat::helper::ParametrizationHelper::isAlwaysMassless(pat::CandKinResolution::Parametrization parametrization) {
+  switch (parametrization) {
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart:
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::MCPInvSpher:
+    case pat::CandKinResolution::MCMomDev:
+    case pat::CandKinResolution::MomDev:
+    case pat::CandKinResolution::EMomDev:
+    case pat::CandKinResolution::EScaledMomDev:
+      return false;
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi:
+      return true;
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "isAlwaysMassless not yet implemented for parametrization " << parametrization;
+  }
+}
+
+bool pat::helper::ParametrizationHelper::isAlwaysMassive(pat::CandKinResolution::Parametrization parametrization) {
+  switch (parametrization) {
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart:
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::MCPInvSpher:
+    case pat::CandKinResolution::MCMomDev:
+    case pat::CandKinResolution::EMomDev:
+    case pat::CandKinResolution::EScaledMomDev:
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi:
+      return false;
+    case pat::CandKinResolution::MomDev:
+      return true;
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "isAlwaysMassless not yet implemented for parametrization " << parametrization;
+  }
+}
+
+bool pat::helper::ParametrizationHelper::isMassConstrained(pat::CandKinResolution::Parametrization parametrization) {
+  switch (parametrization) {
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::EMomDev:
+    case pat::CandKinResolution::EScaledMomDev:
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi:
+    case pat::CandKinResolution::MomDev:
+      return false;
+    case pat::CandKinResolution::MCCart:
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::MCPInvSpher:
+    case pat::CandKinResolution::MCMomDev:
+      return true;
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "isAlwaysMassless not yet implemented for parametrization " << parametrization;
+  }
+}
+
+bool pat::helper::ParametrizationHelper::isPhysical(pat::CandKinResolution::Parametrization parametrization,
+                                                    const AlgebraicVector4 &parameters,
+                                                    const math::PtEtaPhiMLorentzVector &initialP4) {
+  switch (parametrization) {
+    // ======= CARTESIAN ==========
+    case pat::CandKinResolution::Cart:
+      return parameters[3] >= 0;  // M >= 0
+    case pat::CandKinResolution::MCCart:
+      return true;
+    case pat::CandKinResolution::ECart:
+      return (parameters[0] * parameters[0] + parameters[1] * parameters[1] + parameters[2] * parameters[2] <=
+              parameters[3] * parameters[3]);  // E >= P
+    case pat::CandKinResolution::Spher:
+      return (parameters[0] >= 0) &&   // P >= 0
+             (parameters[3] >= 0) &&   // M >= 0
+             (parameters[1] >= 0) &&   // theta >= 0
+             (parameters[1] <= M_PI);  // theta <= pi
+    case pat::CandKinResolution::MCSpher:
+      return (parameters[0] >= 0) &&              // P >= 0
+             (parameters[1] >= 0) &&              // theta >= 0
+             (parameters[1] <= M_PI);             // theta <= pi
+    case pat::CandKinResolution::ESpher:          //
+      return (parameters[0] >= 0) &&              // P >= 0
+             (parameters[3] >= parameters[0]) &&  // E >= P
+             (parameters[1] >= 0) &&              // theta >= 0
+             (parameters[1] <= M_PI);             // theta <= PI
+    case pat::CandKinResolution::MCPInvSpher:     //
+      return (parameters[0] > 0) &&               // 1/P > 0
+             (parameters[1] >= 0) &&              // theta >= 0
+             (parameters[1] <= M_PI);             // theta <= pi
+    // ======= HEP CYLINDRICAL ==========
+    case pat::CandKinResolution::EtThetaPhi:
+      return (parameters[0] > 0) &&         // Et >= 0
+             (parameters[1] >= 0) &&        // theta >= 0
+             (parameters[1] <= M_PI);       // theta <= pi
+    case pat::CandKinResolution::EtEtaPhi:  // as simple as that
+      return (parameters[0] > 0);           // Et >= 0
+    // ======= MomentumDeviates ==========
+    case pat::CandKinResolution::MomDev:
+      return (parameters[0] >= 0) &&  // P >= 0
+             (parameters[3] >= 0);    // m/M0 >= 0
+    case pat::CandKinResolution::MCMomDev:
+      return (parameters[0] >= 0);  // P >= 0
+    case pat::CandKinResolution::EMomDev:
+    case pat::CandKinResolution::EScaledMomDev: {
+      if (parameters[0] <= 0)
+        return false;
+      ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> > p = initialP4.Vect(), uz(0, 0, 1), uph, uth;
+      uph = uz.Cross(p).Unit();
+      uth = p.Cross(uph).Unit();
+      p *= parameters[0];
+      p += uth * parameters[1] + uph * parameters[2];
+      if (parametrization == pat::CandKinResolution::EMomDev) {
+        if (parameters[3] < 0)
+          return false;
+        double m2 = ROOT::Math::Square(parameters[3] * initialP4.energy()) - p.Mag2();
+        if (m2 < 0)
+          return false;
+      } else if (parametrization == pat::CandKinResolution::EScaledMomDev) {
+        if (parameters[3] < 0)
+          return false;
+        double m2 = ROOT::Math::Square(p.R() * initialP4.E() / initialP4.P()) - p.Mag2();
+        if (m2 < 0)
+          return false;
+      }
+      return true;
     }
+    // ======= OTHER ==========
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolEta not yet implemented for parametrization " << parametrization;
+  }
 }
-
-void 
-pat::helper::ParametrizationHelper::setParametersFromP4(pat::CandKinResolution::Parametrization parametrization, 
-        AlgebraicVector4 &v, const math::PtEtaPhiMLorentzVector &p4) {
-    setParametersFromAnyVector(parametrization, v, p4);
-}
-
-void 
-pat::helper::ParametrizationHelper::setParametersFromP4(pat::CandKinResolution::Parametrization parametrization, 
-        AlgebraicVector4 &v, const math::XYZTLorentzVector &p4) {
-    setParametersFromAnyVector(parametrization, v, p4);
-}
-
-AlgebraicVector4 
-pat::helper::ParametrizationHelper::parametersFromP4(pat::CandKinResolution::Parametrization parametrization, const math::PtEtaPhiMLorentzVector &p4) {
-    AlgebraicVector4 ret;
-    setParametersFromP4(parametrization, ret, p4);
-    return ret;
-}
-
-AlgebraicVector4 
-pat::helper::ParametrizationHelper::parametersFromP4(pat::CandKinResolution::Parametrization parametrization, const math::XYZTLorentzVector &p4) {
-    AlgebraicVector4 ret;
-    setParametersFromP4(parametrization, ret, p4);
-    return ret;
-}
-
-AlgebraicVector4 
-pat::helper::ParametrizationHelper::diffToParameters(pat::CandKinResolution::Parametrization parametrization, 
-                const math::PtEtaPhiMLorentzVector &p4ini, const math::PtEtaPhiMLorentzVector &p4fin) 
-{
-    AlgebraicVector4 ret;
-    switch (parametrization) {
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:    
-        case pat::CandKinResolution::MCCart:
-            ret = parametersFromP4(parametrization,p4fin) - parametersFromP4(parametrization,p4ini);
-            break;
-        case pat::CandKinResolution::Spher: 
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::MCSpher:
-        case pat::CandKinResolution::MCPInvSpher:
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi:
-            ret = parametersFromP4(parametrization,p4fin) - parametersFromP4(parametrization,p4ini);
-            while(ret[2] > +M_PI) ret[2] -= (2*M_PI);
-            while(ret[2] < -M_PI) ret[2] += (2*M_PI);
-            break;
-        case pat::CandKinResolution::MCMomDev:
-        case pat::CandKinResolution::MomDev:
-        case pat::CandKinResolution::EMomDev:
-        case pat::CandKinResolution::EScaledMomDev:
-            return diffToParameters(parametrization,
-                                    math::XYZTLorentzVector(p4ini),
-                                    math::XYZTLorentzVector(p4fin));
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "diffToParameters not yet implemented for parametrization " << parametrization ;
-    }
-    return ret;
-}
-
-
-AlgebraicVector4 
-pat::helper::ParametrizationHelper::diffToParameters(pat::CandKinResolution::Parametrization parametrization, 
-                const math::XYZTLorentzVector &p4ini, const math::XYZTLorentzVector &p4fin) 
-{
-    AlgebraicVector4 ret;
-    switch (parametrization) {
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:    
-        case pat::CandKinResolution::MCCart:
-        case pat::CandKinResolution::Spher: 
-            ret = parametersFromP4(parametrization,p4fin) - parametersFromP4(parametrization,p4ini);
-            break;
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::MCSpher:
-        case pat::CandKinResolution::MCPInvSpher:
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi:
-            ret = parametersFromP4(parametrization,p4fin) - parametersFromP4(parametrization,p4ini);
-            while(ret[2] > +M_PI) ret[2] -= (2*M_PI);
-            while(ret[2] < -M_PI) ret[2] += (2*M_PI);
-            break;
-        case pat::CandKinResolution::MCMomDev:
-        case pat::CandKinResolution::MomDev:
-        case pat::CandKinResolution::EMomDev:
-        case pat::CandKinResolution::EScaledMomDev:
-            {
-                typedef ROOT::Math::DisplacementVector3D< ROOT::Math::Cartesian3D<double> > V3Cart;
-                V3Cart p1 = p4ini.Vect(), p2 = p4fin.Vect();
-                V3Cart ur = p1.Unit(); 
-                V3Cart uz(0,0,1);
-                V3Cart uph = uz.Cross(ur).Unit();
-                V3Cart uth = ur.Cross(uph).Unit();
-                ret[0] = p2.Dot(ur)/p1.R() - 1.0;
-                ret[1] = (p2 - p1).Dot(uth);
-                ret[2] = (p2 - p1).Dot(uph);
-                if (parametrization == pat::CandKinResolution::MomDev) {
-                    ret[3] = p4fin.mass()/p4ini.mass() - 1.0;
-                } else if (parametrization == pat::CandKinResolution::EMomDev) {
-                    ret[3] = p4fin.energy()/p4ini.energy() - 1.0;
-                }
-            }
-            break;
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "diffToParameters not yet implemented for parametrization " << parametrization ;
-    }
-    return ret;
-}
-
-bool
-pat::helper::ParametrizationHelper::isAlwaysMassless(pat::CandKinResolution::Parametrization parametrization) 
-{
-    switch (parametrization) {
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:    
-        case pat::CandKinResolution::MCCart:
-        case pat::CandKinResolution::Spher: 
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::MCSpher:
-        case pat::CandKinResolution::MCPInvSpher:
-        case pat::CandKinResolution::MCMomDev:
-        case pat::CandKinResolution::MomDev:
-        case pat::CandKinResolution::EMomDev:
-        case pat::CandKinResolution::EScaledMomDev:
-            return false;
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi:
-            return true;
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "isAlwaysMassless not yet implemented for parametrization " << parametrization ;
-    }
-}
-
-bool
-pat::helper::ParametrizationHelper::isAlwaysMassive(pat::CandKinResolution::Parametrization parametrization) 
-{
-    switch (parametrization) {
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:    
-        case pat::CandKinResolution::MCCart:
-        case pat::CandKinResolution::Spher: 
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::MCSpher:
-        case pat::CandKinResolution::MCPInvSpher:
-        case pat::CandKinResolution::MCMomDev:
-        case pat::CandKinResolution::EMomDev:
-        case pat::CandKinResolution::EScaledMomDev:
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi:
-            return false;
-        case pat::CandKinResolution::MomDev:
-            return true;
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "isAlwaysMassless not yet implemented for parametrization " << parametrization ;
-    }
-}
-
-bool
-pat::helper::ParametrizationHelper::isMassConstrained(pat::CandKinResolution::Parametrization parametrization) 
-{
-    switch (parametrization) {
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:    
-        case pat::CandKinResolution::Spher: 
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::EMomDev:
-        case pat::CandKinResolution::EScaledMomDev:
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi:
-        case pat::CandKinResolution::MomDev:
-            return false;
-        case pat::CandKinResolution::MCCart:
-        case pat::CandKinResolution::MCSpher:
-        case pat::CandKinResolution::MCPInvSpher:
-        case pat::CandKinResolution::MCMomDev:
-            return true;
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "isAlwaysMassless not yet implemented for parametrization " << parametrization ;
-    }
-}
-
-bool
-pat::helper::ParametrizationHelper::isPhysical(pat::CandKinResolution::Parametrization parametrization, 
-            const AlgebraicVector4 &parameters,
-            const math::PtEtaPhiMLorentzVector &initialP4) {
-    switch (parametrization) {
-        // ======= CARTESIAN ==========
-        case pat::CandKinResolution::Cart:
-            return parameters[3] >= 0; // M >= 0
-        case pat::CandKinResolution::MCCart:
-            return true;
-        case pat::CandKinResolution::ECart: 
-            return (parameters[0]*parameters[0] + parameters[1]*parameters[1] + parameters[2]*parameters[2] <= parameters[3]*parameters[3]); // E >= P
-        case pat::CandKinResolution::Spher:  
-            return (parameters[0] >= 0   ) && // P >= 0
-                   (parameters[3] >= 0   ) && // M >= 0
-                   (parameters[1] >= 0   ) && // theta >= 0
-                   (parameters[1] <= M_PI);   // theta <= pi
-        case pat::CandKinResolution::MCSpher:    
-            return (parameters[0] >= 0   ) && // P >= 0
-                   (parameters[1] >= 0   ) && // theta >= 0
-                   (parameters[1] <= M_PI);   // theta <= pi
-        case pat::CandKinResolution::ESpher:        //  
-            return (parameters[0] >= 0            ) && // P >= 0
-                   (parameters[3] >= parameters[0]) && // E >= P
-                   (parameters[1] >= 0            ) && // theta >= 0
-                   (parameters[1] <= M_PI         ) ;  // theta <= PI
-       case pat::CandKinResolution::MCPInvSpher:   //  
-            return (parameters[0] >  0   ) && // 1/P > 0
-                   (parameters[1] >= 0   ) && // theta >= 0
-                   (parameters[1] <= M_PI);   // theta <= pi
-        // ======= HEP CYLINDRICAL ==========
-        case pat::CandKinResolution::EtThetaPhi: 
-            return (parameters[0] >  0   ) && // Et >= 0
-                   (parameters[1] >= 0   ) && // theta >= 0
-                   (parameters[1] <= M_PI);   // theta <= pi
-        case pat::CandKinResolution::EtEtaPhi:      // as simple as that
-            return (parameters[0] >  0); // Et >= 0
-        // ======= MomentumDeviates ==========
-        case pat::CandKinResolution::MomDev:
-            return (parameters[0] >= 0) && // P >= 0
-                   (parameters[3] >= 0);   // m/M0 >= 0
-        case pat::CandKinResolution::MCMomDev:
-            return (parameters[0] >= 0); // P >= 0
-        case pat::CandKinResolution::EMomDev:
-        case pat::CandKinResolution::EScaledMomDev:
-            {
-                if (parameters[0] <= 0) return false;
-                ROOT::Math::DisplacementVector3D< ROOT::Math::Cartesian3D<double> > p = initialP4.Vect(), uz(0,0,1), uph, uth;
-                uph = uz.Cross(p).Unit();
-                uth = p.Cross(uph).Unit();
-                p *= parameters[0]; 
-                p += uth * parameters[1] + uph * parameters[2];
-                if (parametrization == pat::CandKinResolution::EMomDev) {
-                    if (parameters[3] < 0) return false;
-                    double m2 = ROOT::Math::Square(parameters[3] * initialP4.energy()) - p.Mag2();
-                    if (m2 < 0) return false;
-                } else if (parametrization == pat::CandKinResolution::EScaledMomDev) {
-                    if (parameters[3] < 0) return false;
-                    double m2 = ROOT::Math::Square(p.R()*initialP4.E()/initialP4.P()) - p.Mag2();
-                    if (m2 < 0) return false;
-                }
-                return true;
-            }
-        // ======= OTHER ==========
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolEta not yet implemented for parametrization " << parametrization ;
-    }
-}
-
-

--- a/DataFormats/PatCandidates/src/Particle.cc
+++ b/DataFormats/PatCandidates/src/Particle.cc
@@ -3,20 +3,15 @@
 
 #include "DataFormats/PatCandidates/interface/Particle.h"
 
-
 using namespace pat;
 
-
 /// default constructor
-Particle::Particle() : PATObject<reco::LeafCandidate>(reco::LeafCandidate(0, reco::LeafCandidate::LorentzVector(0, 0, 0, 0), reco::LeafCandidate::Point(0,0,0))) {
-}
-
+Particle::Particle()
+    : PATObject<reco::LeafCandidate>(reco::LeafCandidate(
+          0, reco::LeafCandidate::LorentzVector(0, 0, 0, 0), reco::LeafCandidate::Point(0, 0, 0))) {}
 
 /// constructor from reco::LeafCandidate
-Particle::Particle(const reco::LeafCandidate & aParticle) : PATObject<reco::LeafCandidate>(aParticle) {
-}
-
+Particle::Particle(const reco::LeafCandidate& aParticle) : PATObject<reco::LeafCandidate>(aParticle) {}
 
 /// destructor
-Particle::~Particle() {
-}
+Particle::~Particle() {}

--- a/DataFormats/PatCandidates/src/Photon.cc
+++ b/DataFormats/PatCandidates/src/Photon.cc
@@ -4,185 +4,169 @@
 #include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/Common/interface/RefToPtr.h"
 
-
 using pat::Photon;
 
-
 /// default constructor
-Photon::Photon() :
-    PATObject<reco::Photon>(reco::Photon()),
-    embeddedSuperCluster_(false),
-    embeddedSeedCluster_(false),
-    embeddedRecHits_(false),
-    passElectronVeto_(false),
-    hasPixelSeed_(false),
-    seedEnergy_(0.0),
-    eMax_(0.0),
-    e2nd_(0.0),
-    e3x3_(0.0),
-    eTop_(0.0),
-    eBottom_(0.0),
-    eLeft_(0.0),
-    eRight_(0.0),
-    see_(-999.),
-    spp_(-999.),
-    sep_(-999.),
-    maxDR_(-999.),
-    maxDRDPhi_(-999.),
-    maxDRDEta_(-999.),
-    maxDRRawEnergy_(-999.),
-    subClusRawE1_(-999.),
-    subClusRawE2_(-999.),
-    subClusRawE3_(-999.),
-    subClusDPhi1_(-999.),
-    subClusDPhi2_(-999.),
-    subClusDPhi3_(-999.),
-    subClusDEta1_(-999.),
-    subClusDEta2_(-999.),
-    subClusDEta3_(-999.),
-    cryEta_(-999.),
-    cryPhi_(-999),
-    iEta_(-999),
-    iPhi_(-999)
-{
-}
+Photon::Photon()
+    : PATObject<reco::Photon>(reco::Photon()),
+      embeddedSuperCluster_(false),
+      embeddedSeedCluster_(false),
+      embeddedRecHits_(false),
+      passElectronVeto_(false),
+      hasPixelSeed_(false),
+      seedEnergy_(0.0),
+      eMax_(0.0),
+      e2nd_(0.0),
+      e3x3_(0.0),
+      eTop_(0.0),
+      eBottom_(0.0),
+      eLeft_(0.0),
+      eRight_(0.0),
+      see_(-999.),
+      spp_(-999.),
+      sep_(-999.),
+      maxDR_(-999.),
+      maxDRDPhi_(-999.),
+      maxDRDEta_(-999.),
+      maxDRRawEnergy_(-999.),
+      subClusRawE1_(-999.),
+      subClusRawE2_(-999.),
+      subClusRawE3_(-999.),
+      subClusDPhi1_(-999.),
+      subClusDPhi2_(-999.),
+      subClusDPhi3_(-999.),
+      subClusDEta1_(-999.),
+      subClusDEta2_(-999.),
+      subClusDEta3_(-999.),
+      cryEta_(-999.),
+      cryPhi_(-999),
+      iEta_(-999),
+      iPhi_(-999) {}
 
 /// constructor from reco::Photon
-Photon::Photon(const reco::Photon & aPhoton) :
-    PATObject<reco::Photon>(aPhoton),
-    embeddedSuperCluster_(false),
-    embeddedSeedCluster_(false),
-    embeddedRecHits_(false),
-    passElectronVeto_(false),
-    hasPixelSeed_(false),
-    seedEnergy_(0.0),
-    eMax_(0.0),
-    e2nd_(0.0),
-    e3x3_(0.0),
-    eTop_(0.0),
-    eBottom_(0.0),
-    eLeft_(0.0),
-    eRight_(0.0),
-    see_(-999.),
-    spp_(-999.),
-    sep_(-999.),
-    maxDR_(-999.),
-    maxDRDPhi_(-999.),
-    maxDRDEta_(-999.),
-    maxDRRawEnergy_(-999.),
-    subClusRawE1_(-999.),
-    subClusRawE2_(-999.),
-    subClusRawE3_(-999.),
-    subClusDPhi1_(-999.),
-    subClusDPhi2_(-999.),
-    subClusDPhi3_(-999.),
-    subClusDEta1_(-999.),
-    subClusDEta2_(-999.),
-    subClusDEta3_(-999.),
-    cryEta_(-999.),
-    cryPhi_(-999),
-    iEta_(-999),
-    iPhi_(-999)
-{
-}
+Photon::Photon(const reco::Photon& aPhoton)
+    : PATObject<reco::Photon>(aPhoton),
+      embeddedSuperCluster_(false),
+      embeddedSeedCluster_(false),
+      embeddedRecHits_(false),
+      passElectronVeto_(false),
+      hasPixelSeed_(false),
+      seedEnergy_(0.0),
+      eMax_(0.0),
+      e2nd_(0.0),
+      e3x3_(0.0),
+      eTop_(0.0),
+      eBottom_(0.0),
+      eLeft_(0.0),
+      eRight_(0.0),
+      see_(-999.),
+      spp_(-999.),
+      sep_(-999.),
+      maxDR_(-999.),
+      maxDRDPhi_(-999.),
+      maxDRDEta_(-999.),
+      maxDRRawEnergy_(-999.),
+      subClusRawE1_(-999.),
+      subClusRawE2_(-999.),
+      subClusRawE3_(-999.),
+      subClusDPhi1_(-999.),
+      subClusDPhi2_(-999.),
+      subClusDPhi3_(-999.),
+      subClusDEta1_(-999.),
+      subClusDEta2_(-999.),
+      subClusDEta3_(-999.),
+      cryEta_(-999.),
+      cryPhi_(-999),
+      iEta_(-999),
+      iPhi_(-999) {}
 
 /// constructor from ref to reco::Photon
-Photon::Photon(const edm::RefToBase<reco::Photon> & aPhotonRef) :
-    PATObject<reco::Photon>(aPhotonRef),
-    embeddedSuperCluster_(false),
-    embeddedSeedCluster_(false),
-    embeddedRecHits_(false),
-    passElectronVeto_(false),
-    hasPixelSeed_(false),
-    seedEnergy_(0.0),
-    eMax_(0.0),
-    e2nd_(0.0),
-    e3x3_(0.0),
-    eTop_(0.0),
-    eBottom_(0.0),
-    eLeft_(0.0),
-    eRight_(0.0),
-    see_(-999.),
-    spp_(-999.),
-    sep_(-999.),
-    maxDR_(-999.),
-    maxDRDPhi_(-999.),
-    maxDRDEta_(-999.),
-    maxDRRawEnergy_(-999.),
-    subClusRawE1_(-999.),
-    subClusRawE2_(-999.),
-    subClusRawE3_(-999.),
-    subClusDPhi1_(-999.),
-    subClusDPhi2_(-999.),
-    subClusDPhi3_(-999.),
-    subClusDEta1_(-999.),
-    subClusDEta2_(-999.),
-    subClusDEta3_(-999.),
-    cryEta_(-999.),
-    cryPhi_(-999),
-    iEta_(-999),
-    iPhi_(-999)
-{
-}
+Photon::Photon(const edm::RefToBase<reco::Photon>& aPhotonRef)
+    : PATObject<reco::Photon>(aPhotonRef),
+      embeddedSuperCluster_(false),
+      embeddedSeedCluster_(false),
+      embeddedRecHits_(false),
+      passElectronVeto_(false),
+      hasPixelSeed_(false),
+      seedEnergy_(0.0),
+      eMax_(0.0),
+      e2nd_(0.0),
+      e3x3_(0.0),
+      eTop_(0.0),
+      eBottom_(0.0),
+      eLeft_(0.0),
+      eRight_(0.0),
+      see_(-999.),
+      spp_(-999.),
+      sep_(-999.),
+      maxDR_(-999.),
+      maxDRDPhi_(-999.),
+      maxDRDEta_(-999.),
+      maxDRRawEnergy_(-999.),
+      subClusRawE1_(-999.),
+      subClusRawE2_(-999.),
+      subClusRawE3_(-999.),
+      subClusDPhi1_(-999.),
+      subClusDPhi2_(-999.),
+      subClusDPhi3_(-999.),
+      subClusDEta1_(-999.),
+      subClusDEta2_(-999.),
+      subClusDEta3_(-999.),
+      cryEta_(-999.),
+      cryPhi_(-999),
+      iEta_(-999),
+      iPhi_(-999) {}
 
 /// constructor from ref to reco::Photon
-Photon::Photon(const edm::Ptr<reco::Photon> & aPhotonRef) :
-    PATObject<reco::Photon>(aPhotonRef),
-    embeddedSuperCluster_(false),
-    embeddedSeedCluster_(false),
-    embeddedRecHits_(false),
-    passElectronVeto_(false),
-    hasPixelSeed_(false),
-    seedEnergy_(0.0),
-    eMax_(0.0),
-    e2nd_(0.0),
-    e3x3_(0.0),
-    eTop_(0.0),
-    eBottom_(0.0),
-    eLeft_(0.0),
-    eRight_(0.0),
-    see_(-999.),
-    spp_(-999.),
-    sep_(-999.),
-    maxDR_(-999.),
-    maxDRDPhi_(-999.),
-    maxDRDEta_(-999.),
-    maxDRRawEnergy_(-999.),
-    subClusRawE1_(-999.),
-    subClusRawE2_(-999.),
-    subClusRawE3_(-999.),
-    subClusDPhi1_(-999.),
-    subClusDPhi2_(-999.),
-    subClusDPhi3_(-999.),
-    subClusDEta1_(-999.),
-    subClusDEta2_(-999.),
-    subClusDEta3_(-999.),
-    cryEta_(-999.),
-    cryPhi_(-999),
-    iEta_(-999),
-    iPhi_(-999)
-{
-}
+Photon::Photon(const edm::Ptr<reco::Photon>& aPhotonRef)
+    : PATObject<reco::Photon>(aPhotonRef),
+      embeddedSuperCluster_(false),
+      embeddedSeedCluster_(false),
+      embeddedRecHits_(false),
+      passElectronVeto_(false),
+      hasPixelSeed_(false),
+      seedEnergy_(0.0),
+      eMax_(0.0),
+      e2nd_(0.0),
+      e3x3_(0.0),
+      eTop_(0.0),
+      eBottom_(0.0),
+      eLeft_(0.0),
+      eRight_(0.0),
+      see_(-999.),
+      spp_(-999.),
+      sep_(-999.),
+      maxDR_(-999.),
+      maxDRDPhi_(-999.),
+      maxDRDEta_(-999.),
+      maxDRRawEnergy_(-999.),
+      subClusRawE1_(-999.),
+      subClusRawE2_(-999.),
+      subClusRawE3_(-999.),
+      subClusDPhi1_(-999.),
+      subClusDPhi2_(-999.),
+      subClusDPhi3_(-999.),
+      subClusDEta1_(-999.),
+      subClusDEta2_(-999.),
+      subClusDEta3_(-999.),
+      cryEta_(-999.),
+      cryPhi_(-999),
+      iEta_(-999),
+      iPhi_(-999) {}
 
 /// destructor
-Photon::~Photon() {
-}
+Photon::~Photon() {}
 
-std::ostream& 
-reco::operator<<(std::ostream& out, const pat::Photon& obj) 
-{
-  if(!out) return out;
-  
+std::ostream& reco::operator<<(std::ostream& out, const pat::Photon& obj) {
+  if (!out)
+    return out;
+
   out << "\tpat::Photon: ";
   out << std::setiosflags(std::ios::right);
   out << std::setiosflags(std::ios::fixed);
   out << std::setprecision(3);
-  out << " E/pT/eta/phi " 
-      << obj.energy()<<"/"
-      << obj.pt()<<"/"
-      << obj.eta()<<"/"
-      << obj.phi();
-  return out; 
+  out << " E/pT/eta/phi " << obj.energy() << "/" << obj.pt() << "/" << obj.eta() << "/" << obj.phi();
+  return out;
 }
 
 /// override the superCluster method from CaloJet, to access the internal storage of the supercluster
@@ -190,30 +174,30 @@ reco::operator<<(std::ostream& out, const pat::Photon& obj)
 reco::SuperClusterRef Photon::superCluster() const {
   if (embeddedSuperCluster_) {
     if (embeddedSeedCluster_ || !basicClusters_.empty() || !preshowerClusters_.empty()) {
-        if (!superClusterRelinked_.isSet()) {
-            std::unique_ptr<std::vector<reco::SuperCluster> > sc(new std::vector<reco::SuperCluster>(superCluster_));
-            if (embeddedSeedCluster_ && !(*sc)[0].seed().isAvailable()) {
-                (*sc)[0].setSeed(seed());
-            }
-            if (!basicClusters_.empty() && !(*sc)[0].clusters().isAvailable()) {
-                reco::CaloClusterPtrVector clusters;
-                for (unsigned int iclus=0; iclus<basicClusters_.size(); ++iclus) {
-                    clusters.push_back(reco::CaloClusterPtr(&basicClusters_,iclus));
-                }
-                (*sc)[0].setClusters(clusters);
-            }
-            if (!preshowerClusters_.empty() && !(*sc)[0].preshowerClusters().isAvailable()) {
-                reco::CaloClusterPtrVector clusters;
-                for (unsigned int iclus=0; iclus<preshowerClusters_.size(); ++iclus) {
-                    clusters.push_back(reco::CaloClusterPtr(&preshowerClusters_,iclus));
-                }
-                (*sc)[0].setPreshowerClusters(clusters);
-            }
-            superClusterRelinked_.set(std::move(sc));
+      if (!superClusterRelinked_.isSet()) {
+        std::unique_ptr<std::vector<reco::SuperCluster> > sc(new std::vector<reco::SuperCluster>(superCluster_));
+        if (embeddedSeedCluster_ && !(*sc)[0].seed().isAvailable()) {
+          (*sc)[0].setSeed(seed());
         }
-        return reco::SuperClusterRef(&*superClusterRelinked_, 0);
+        if (!basicClusters_.empty() && !(*sc)[0].clusters().isAvailable()) {
+          reco::CaloClusterPtrVector clusters;
+          for (unsigned int iclus = 0; iclus < basicClusters_.size(); ++iclus) {
+            clusters.push_back(reco::CaloClusterPtr(&basicClusters_, iclus));
+          }
+          (*sc)[0].setClusters(clusters);
+        }
+        if (!preshowerClusters_.empty() && !(*sc)[0].preshowerClusters().isAvailable()) {
+          reco::CaloClusterPtrVector clusters;
+          for (unsigned int iclus = 0; iclus < preshowerClusters_.size(); ++iclus) {
+            clusters.push_back(reco::CaloClusterPtr(&preshowerClusters_, iclus));
+          }
+          (*sc)[0].setPreshowerClusters(clusters);
+        }
+        superClusterRelinked_.set(std::move(sc));
+      }
+      return reco::SuperClusterRef(&*superClusterRelinked_, 0);
     } else {
-        return reco::SuperClusterRef(&superCluster_, 0);
+      return reco::SuperClusterRef(&superCluster_, 0);
     }
   } else {
     return reco::Photon::superCluster();
@@ -222,8 +206,8 @@ reco::SuperClusterRef Photon::superCluster() const {
 
 /// direct access to the seed cluster
 reco::CaloClusterPtr Photon::seed() const {
-  if(embeddedSeedCluster_){
-    return reco::CaloClusterPtr(&seedCluster_,0);
+  if (embeddedSeedCluster_) {
+    return reco::CaloClusterPtr(&seedCluster_, 0);
   } else {
     return reco::Photon::superCluster()->seed();
   }
@@ -233,8 +217,8 @@ reco::CaloClusterPtr Photon::seed() const {
 void Photon::embedSuperCluster() {
   superCluster_.clear();
   if (reco::Photon::superCluster().isNonnull()) {
-      superCluster_.push_back(*reco::Photon::superCluster());
-      embeddedSuperCluster_ = true;
+    superCluster_.push_back(*reco::Photon::superCluster());
+    embeddedSuperCluster_ = true;
   }
 }
 
@@ -250,39 +234,40 @@ void Photon::embedSeedCluster() {
 /// Stores the electron's BasicCluster (reco::CaloCluster) internally
 void Photon::embedBasicClusters() {
   basicClusters_.clear();
-  if (reco::Photon::superCluster().isNonnull()){
+  if (reco::Photon::superCluster().isNonnull()) {
     reco::CaloCluster_iterator itscl = reco::Photon::superCluster()->clustersBegin();
     reco::CaloCluster_iterator itsclE = reco::Photon::superCluster()->clustersEnd();
-    for(;itscl!=itsclE;++itscl){
-      basicClusters_.push_back( **itscl ) ;
-    } 
+    for (; itscl != itsclE; ++itscl) {
+      basicClusters_.push_back(**itscl);
+    }
   }
 }
 
 /// Stores the electron's PreshowerCluster (reco::CaloCluster) internally
 void Photon::embedPreshowerClusters() {
   preshowerClusters_.clear();
-  if (reco::Photon::superCluster().isNonnull()){
+  if (reco::Photon::superCluster().isNonnull()) {
     reco::CaloCluster_iterator itscl = reco::Photon::superCluster()->preshowerClustersBegin();
     reco::CaloCluster_iterator itsclE = reco::Photon::superCluster()->preshowerClustersEnd();
-    for(;itscl!=itsclE;++itscl){
-      preshowerClusters_.push_back( **itscl ) ;
+    for (; itscl != itsclE; ++itscl) {
+      preshowerClusters_.push_back(**itscl);
     }
   }
 }
 
 // method to store the RecHits internally
-void Photon::embedRecHits(const EcalRecHitCollection * rechits) {
-  if (rechits!=nullptr) {
+void Photon::embedRecHits(const EcalRecHitCollection* rechits) {
+  if (rechits != nullptr) {
     recHits_ = *rechits;
     embeddedRecHits_ = true;
   }
 }
 
 // method to retrieve a photon ID (or throw)
-Bool_t Photon::photonID(const std::string & name) const {
+Bool_t Photon::photonID(const std::string& name) const {
   for (std::vector<IdPair>::const_iterator it = photonIDs_.begin(), ed = photonIDs_.end(); it != ed; ++it) {
-    if (it->first == name) return it->second;
+    if (it->first == name)
+      return it->second;
   }
   cms::Exception ex("Key not found");
   ex << "pat::Photon: the ID " << name << " can't be found in this pat::Photon.\n";
@@ -294,29 +279,29 @@ Bool_t Photon::photonID(const std::string & name) const {
   throw ex;
 }
 // check if an ID is there
-bool Photon::isPhotonIDAvailable(const std::string & name) const {
+bool Photon::isPhotonIDAvailable(const std::string& name) const {
   for (std::vector<IdPair>::const_iterator it = photonIDs_.begin(), ed = photonIDs_.end(); it != ed; ++it) {
-    if (it->first == name) return true;
+    if (it->first == name)
+      return true;
   }
   return false;
 }
 
-
 edm::RefVector<pat::PackedCandidateCollection> Photon::associatedPackedPFCandidates() const {
-    edm::RefVector<pat::PackedCandidateCollection> ret(packedPFCandidates_.id());
-    for (uint16_t idx : associatedPackedFCandidateIndices_) {
-        ret.push_back(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, idx));
-    }
-    return ret;
+  edm::RefVector<pat::PackedCandidateCollection> ret(packedPFCandidates_.id());
+  for (uint16_t idx : associatedPackedFCandidateIndices_) {
+    ret.push_back(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, idx));
+  }
+  return ret;
 }
 
 /// Returns the reference to the parent PF candidate with index i.
 /// For use in TopProjector.
-reco::CandidatePtr Photon::sourceCandidatePtr( size_type i ) const {
-    if (i >= associatedPackedFCandidateIndices_.size()) {
-        return reco::CandidatePtr();
-    } else {
-        return reco::CandidatePtr(edm::refToPtr(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, associatedPackedFCandidateIndices_[i])));
-    }
+reco::CandidatePtr Photon::sourceCandidatePtr(size_type i) const {
+  if (i >= associatedPackedFCandidateIndices_.size()) {
+    return reco::CandidatePtr();
+  } else {
+    return reco::CandidatePtr(edm::refToPtr(
+        edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, associatedPackedFCandidateIndices_[i])));
+  }
 }
-

--- a/DataFormats/PatCandidates/src/ResolutionHelper.cc
+++ b/DataFormats/PatCandidates/src/ResolutionHelper.cc
@@ -5,554 +5,531 @@
 
 using namespace std;  // faster sqrt, sqrt, pow(x,2)....
 
-void
-pat::helper::ResolutionHelper::rescaleForKinFitter(pat::CandKinResolution::Parametrization parametrization, 
-        AlgebraicSymMatrix44 &covariance, 
-        const math::XYZTLorentzVector &initialP4)
-{
-    double inv;
-    switch (parametrization) {
-        case pat::CandKinResolution::Cart:         
-        case pat::CandKinResolution::Spher:  
-            // for us parameter[3] = mass, for KinFitter parameter[3] = mass/initialP4.mass();
-            inv = 1.0/initialP4.mass();
-            for (int i = 0; i < 4; i++) {
-                covariance(3,i) *= inv;
-            }
-            covariance(3,3) *= inv; 
-            break;
-        case pat::CandKinResolution::ESpher:       
-             // for us parameter[3] = energy, for KinFitter parameter[3] = energy/initialP4.energy();
-            inv = 1.0/initialP4.energy();
-            for (int i = 0; i < 4; i++) {
-                covariance(3,i) *= inv;
-            }
-            covariance(3,3) *= inv; 
-            break;
-       default:
-            ;// nothing to do
-    }
+void pat::helper::ResolutionHelper::rescaleForKinFitter(pat::CandKinResolution::Parametrization parametrization,
+                                                        AlgebraicSymMatrix44 &covariance,
+                                                        const math::XYZTLorentzVector &initialP4) {
+  double inv;
+  switch (parametrization) {
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::Spher:
+      // for us parameter[3] = mass, for KinFitter parameter[3] = mass/initialP4.mass();
+      inv = 1.0 / initialP4.mass();
+      for (int i = 0; i < 4; i++) {
+        covariance(3, i) *= inv;
+      }
+      covariance(3, 3) *= inv;
+      break;
+    case pat::CandKinResolution::ESpher:
+      // for us parameter[3] = energy, for KinFitter parameter[3] = energy/initialP4.energy();
+      inv = 1.0 / initialP4.energy();
+      for (int i = 0; i < 4; i++) {
+        covariance(3, i) *= inv;
+      }
+      covariance(3, 3) *= inv;
+      break;
+    default:;  // nothing to do
+  }
 }
 
 double pat::helper::ResolutionHelper::getResolP(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)
-{
-    switch (parametrization) {
-        // ==== CARTESIAN ====
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:
-        case pat::CandKinResolution::MCCart:
-            {
-                // p2 = px^2 + py^2 + pz^2
-                // dp/dp_i = p_i/p ==> it is a unit vector!
-                AlgebraicVector3 derivs(p4.X(), p4.Y(), p4.Z());
-                derivs.Unit(); 
-                return sqrt(ROOT::Math::Similarity(derivs, covariance.Sub<AlgebraicSymMatrix33>(0,0)));
-            }
-        // ==== SPHERICAL (P)  ====
-        case pat::CandKinResolution::Spher:  
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::MCSpher:      
-            return sqrt(covariance(0,0));
-        // ==== SPHERICAL (1/P)  ====
-        case pat::CandKinResolution::MCPInvSpher:
-            return sqrt(covariance(0,0)) * (p4.P2());
-        // ==== HEP CYLINDRICAL (with Pt = Et, P = E) ====
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi:     
-            return  getResolE(parametrization,covariance,p4);
-        // ==== OTHER ====
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolP not yet implemented for parametrization " << parametrization ;
+                                                const AlgebraicSymMatrix44 &covariance,
+                                                const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    // ==== CARTESIAN ====
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart: {
+      // p2 = px^2 + py^2 + pz^2
+      // dp/dp_i = p_i/p ==> it is a unit vector!
+      AlgebraicVector3 derivs(p4.X(), p4.Y(), p4.Z());
+      derivs.Unit();
+      return sqrt(ROOT::Math::Similarity(derivs, covariance.Sub<AlgebraicSymMatrix33>(0, 0)));
     }
+    // ==== SPHERICAL (P)  ====
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::MCSpher:
+      return sqrt(covariance(0, 0));
+    // ==== SPHERICAL (1/P)  ====
+    case pat::CandKinResolution::MCPInvSpher:
+      return sqrt(covariance(0, 0)) * (p4.P2());
+    // ==== HEP CYLINDRICAL (with Pt = Et, P = E) ====
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi:
+      return getResolE(parametrization, covariance, p4);
+    // ==== OTHER ====
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolP not yet implemented for parametrization " << parametrization;
+  }
 }
 double pat::helper::ResolutionHelper::getResolPt(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)  
-{
-     switch (parametrization) {
-        // ==== CARTESIAN ====
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:
-        case pat::CandKinResolution::MCCart:
-            {
-                double pti2 = 1.0/(p4.Perp2());
-                return sqrt(   (  covariance(0,0) * p4.Px()*p4.Px() +
-                                  covariance(1,1) * p4.Py()*p4.Py() +
-                                2*covariance(0,1) * p4.Px()*p4.Py()) * pti2 );
-            }
-        // ==== SPHERICAL (P, Theta)  ====
-        case pat::CandKinResolution::Spher:  
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::MCSpher:      
-            {
-                // pt = p * sin(theta)
-                double a = sin(p4.Theta());
-                double b = p4.P() * cos(p4.Theta());
-                return sqrt(a*a*covariance(0,0)  + b*b*covariance(1,1) + 2*a*b*covariance(0,1));
-            }
-        // ==== SPHERICAL (1/P)  ====
-        case pat::CandKinResolution::MCPInvSpher:
-            {
-                // pt = (1/pi) * sin(theta)
-                double p = p4.P(); 
-                double a = - (p*p) * sin(p4.Theta());
-                double b = p * cos(p4.Theta());
-                return sqrt(a*a*covariance(0,0)  + b*b*covariance(1,1) + 2*a*b*covariance(0,1));
-            }
-        // ==== HEP CYLINDRICAL (with Pt = Et) ====
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi:
-            return sqrt(covariance(0,0));
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolPt not yet implemented for parametrization " << parametrization ;
+                                                 const AlgebraicSymMatrix44 &covariance,
+                                                 const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    // ==== CARTESIAN ====
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart: {
+      double pti2 = 1.0 / (p4.Perp2());
+      return sqrt((covariance(0, 0) * p4.Px() * p4.Px() + covariance(1, 1) * p4.Py() * p4.Py() +
+                   2 * covariance(0, 1) * p4.Px() * p4.Py()) *
+                  pti2);
     }
+    // ==== SPHERICAL (P, Theta)  ====
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::MCSpher: {
+      // pt = p * sin(theta)
+      double a = sin(p4.Theta());
+      double b = p4.P() * cos(p4.Theta());
+      return sqrt(a * a * covariance(0, 0) + b * b * covariance(1, 1) + 2 * a * b * covariance(0, 1));
+    }
+    // ==== SPHERICAL (1/P)  ====
+    case pat::CandKinResolution::MCPInvSpher: {
+      // pt = (1/pi) * sin(theta)
+      double p = p4.P();
+      double a = -(p * p) * sin(p4.Theta());
+      double b = p * cos(p4.Theta());
+      return sqrt(a * a * covariance(0, 0) + b * b * covariance(1, 1) + 2 * a * b * covariance(0, 1));
+    }
+    // ==== HEP CYLINDRICAL (with Pt = Et) ====
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi:
+      return sqrt(covariance(0, 0));
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolPt not yet implemented for parametrization " << parametrization;
+  }
 }
 
 double pat::helper::ResolutionHelper::getResolPInv(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)  
-{
-     switch (parametrization) {
-        // ==== SPHERICAL (P)  ====
-        case pat::CandKinResolution::Spher:  
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::MCSpher:      
-            return 1.0/p4.P2() * sqrt(covariance(0,0));
-        // ==== SPHERICAL (1/P)  ====
-        case pat::CandKinResolution::MCPInvSpher:
-            return sqrt(covariance(0,0));
-        // ==== OTHER ====
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:
-        case pat::CandKinResolution::MCCart:
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi:
-            return 1.0/p4.P2() * getResolP(parametrization, covariance, p4);
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolPInv not yet implemented for parametrization " << parametrization ;
-    }
+                                                   const AlgebraicSymMatrix44 &covariance,
+                                                   const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    // ==== SPHERICAL (P)  ====
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::MCSpher:
+      return 1.0 / p4.P2() * sqrt(covariance(0, 0));
+    // ==== SPHERICAL (1/P)  ====
+    case pat::CandKinResolution::MCPInvSpher:
+      return sqrt(covariance(0, 0));
+    // ==== OTHER ====
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart:
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi:
+      return 1.0 / p4.P2() * getResolP(parametrization, covariance, p4);
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolPInv not yet implemented for parametrization " << parametrization;
+  }
 }
 
 double pat::helper::ResolutionHelper::getResolPx(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)  
-{
-     switch (parametrization) {
-        // ==== CARTESIAN ====
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:
-        case pat::CandKinResolution::MCCart:
-            return sqrt(covariance(0,0));
-        // ==== SPHERICAL (P)  ====
-        case pat::CandKinResolution::Spher:  
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::MCSpher:      
-        case pat::CandKinResolution::MCPInvSpher:
-            {
-                // Px = P * sin(theta) * cos(phi)
-                double p = p4.P();
-                AlgebraicVector3 derivs; 
-                derivs[0] = sin(p4.Theta()) * cos(p4.Phi()); // now let's hope gcc does common subexpr optimiz.
-                if (parametrization == pat::CandKinResolution::MCPInvSpher) {
-                    derivs[0] *= -(p*p);
-                } 
-                derivs[1] = p *  cos(p4.Theta()) * cos(p4.Phi()); 
-                derivs[2] = p *  sin(p4.Theta()) * -sin(p4.Phi()); 
-                return sqrt(ROOT::Math::Similarity(derivs, covariance.Sub<AlgebraicSymMatrix33>(0,0)));
-            }
-        // ==== HEP CYLINDRICAL (with Pt = Et) ====
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi:
-            {
-                // Px = Pt * cos(phi)
-                double a = cos(p4.Phi());
-                double b = - p4.Pt() * sin(p4.Phi());
-                return sqrt(a*a*covariance(0,0) + 2*a*b*covariance(2,0) + b*b*covariance(2,2));
-            }
-        // ==== OTHERS ====
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolPx not yet implemented for parametrization " << parametrization ;
+                                                 const AlgebraicSymMatrix44 &covariance,
+                                                 const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    // ==== CARTESIAN ====
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart:
+      return sqrt(covariance(0, 0));
+    // ==== SPHERICAL (P)  ====
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::MCPInvSpher: {
+      // Px = P * sin(theta) * cos(phi)
+      double p = p4.P();
+      AlgebraicVector3 derivs;
+      derivs[0] = sin(p4.Theta()) * cos(p4.Phi());  // now let's hope gcc does common subexpr optimiz.
+      if (parametrization == pat::CandKinResolution::MCPInvSpher) {
+        derivs[0] *= -(p * p);
+      }
+      derivs[1] = p * cos(p4.Theta()) * cos(p4.Phi());
+      derivs[2] = p * sin(p4.Theta()) * -sin(p4.Phi());
+      return sqrt(ROOT::Math::Similarity(derivs, covariance.Sub<AlgebraicSymMatrix33>(0, 0)));
     }
+    // ==== HEP CYLINDRICAL (with Pt = Et) ====
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi: {
+      // Px = Pt * cos(phi)
+      double a = cos(p4.Phi());
+      double b = -p4.Pt() * sin(p4.Phi());
+      return sqrt(a * a * covariance(0, 0) + 2 * a * b * covariance(2, 0) + b * b * covariance(2, 2));
+    }
+    // ==== OTHERS ====
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolPx not yet implemented for parametrization " << parametrization;
+  }
 }
 double pat::helper::ResolutionHelper::getResolPy(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)  
-{
-     switch (parametrization) {
-        // ==== CARTESIAN ====
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:
-        case pat::CandKinResolution::MCCart:
-            return sqrt(covariance(1,1));
-        // ==== SPHERICAL (P)  ====
-        case pat::CandKinResolution::Spher:  
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::MCSpher:      
-        case pat::CandKinResolution::MCPInvSpher:
-            {
-                // Py = P * sin(theta) * sin(phi)
-                double p = p4.P();
-                AlgebraicVector3 derivs; 
-                derivs[0] = sin(p4.Theta()) * sin(p4.Phi()); // now let's hope gcc does common subexpr optimiz.
-                if (parametrization == pat::CandKinResolution::MCPInvSpher) {
-                    derivs[0] *= -(p*p);
-                }
-                derivs[1] = p *  cos(p4.Theta()) * sin(p4.Phi()); 
-                derivs[2] = p *  sin(p4.Theta()) * cos(p4.Phi()); 
-                return sqrt(ROOT::Math::Similarity(derivs, covariance.Sub<AlgebraicSymMatrix33>(0,0)));
-            }
-        // ==== HEP CYLINDRICAL (with Pt = Et) ====
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi:
-            {
-                // Py = Pt * sin(phi)
-                double a = sin(p4.Phi());
-                double b = p4.Pt() * cos(p4.Phi());
-                return sqrt(a*a*covariance(0,0) + 2*a*b*covariance(2,0) + b*b*covariance(2,2));
-            }
-        // ==== OTHERS ====
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolPy not yet implemented for parametrization " << parametrization ;
+                                                 const AlgebraicSymMatrix44 &covariance,
+                                                 const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    // ==== CARTESIAN ====
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart:
+      return sqrt(covariance(1, 1));
+    // ==== SPHERICAL (P)  ====
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::MCPInvSpher: {
+      // Py = P * sin(theta) * sin(phi)
+      double p = p4.P();
+      AlgebraicVector3 derivs;
+      derivs[0] = sin(p4.Theta()) * sin(p4.Phi());  // now let's hope gcc does common subexpr optimiz.
+      if (parametrization == pat::CandKinResolution::MCPInvSpher) {
+        derivs[0] *= -(p * p);
+      }
+      derivs[1] = p * cos(p4.Theta()) * sin(p4.Phi());
+      derivs[2] = p * sin(p4.Theta()) * cos(p4.Phi());
+      return sqrt(ROOT::Math::Similarity(derivs, covariance.Sub<AlgebraicSymMatrix33>(0, 0)));
     }
+    // ==== HEP CYLINDRICAL (with Pt = Et) ====
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi: {
+      // Py = Pt * sin(phi)
+      double a = sin(p4.Phi());
+      double b = p4.Pt() * cos(p4.Phi());
+      return sqrt(a * a * covariance(0, 0) + 2 * a * b * covariance(2, 0) + b * b * covariance(2, 2));
+    }
+    // ==== OTHERS ====
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolPy not yet implemented for parametrization " << parametrization;
+  }
 }
 double pat::helper::ResolutionHelper::getResolPz(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)  
-{
-     switch (parametrization) {
-        // ==== CARTESIAN ====
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:
-        case pat::CandKinResolution::MCCart:
-            return sqrt(covariance(2,2));
-        // ==== SPHERICAL (P)  ====
-        case pat::CandKinResolution::Spher:  
-        case pat::CandKinResolution::ESpher:
-        case pat::CandKinResolution::MCSpher:      
-            {
-                // Pz = P * cos(theta) 
-                double a = cos(p4.Theta());
-                double b = -p4.P() * sin(p4.Theta());
-                return sqrt(a*a*covariance(0,0) + 2*a*b*covariance(1,0) + b*b*covariance(1,1));
-            }
-        case pat::CandKinResolution::MCPInvSpher:
-            {
-                // Pz = P * cos(theta) 
-                double p = p4.P(); 
-                double a = -p*p*cos(p4.Theta());
-                double b = -p * sin(p4.Theta());
-                return sqrt(a*a*covariance(0,0) + 2*a*b*covariance(1,0) + b*b*covariance(1,1));
-            }
-        // ==== HEP CYLINDRICAL (with Pt = Et) ====
-        case pat::CandKinResolution::EtThetaPhi: 
-            {
-                // Pz = Pt * ctg(theta)    d ctg(x) = -1/sin^2(x)    
-                double s = sin(p4.Theta()), c = cos(p4.Theta());
-                double a = c/s;
-                double b = - p4.Pt() / (s*s);
-                return sqrt(a*a*covariance(0,0) + 2*a*b*covariance(1,0) + b*b*covariance(1,1));
-            }
-        case pat::CandKinResolution::EtEtaPhi:
-            {
-                // Pz = Pt * sinh(eta)
-                double a = sinh(p4.Eta());
-                double b = p4.Et() * cosh(p4.Eta());
-                return sqrt(a*a*covariance(0,0) + 2*a*b*covariance(1,0) + b*b*covariance(1,1));
-            }
-        // ==== OTHERS ====
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolPz not yet implemented for parametrization " << parametrization ;
+                                                 const AlgebraicSymMatrix44 &covariance,
+                                                 const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    // ==== CARTESIAN ====
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart:
+      return sqrt(covariance(2, 2));
+    // ==== SPHERICAL (P)  ====
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::ESpher:
+    case pat::CandKinResolution::MCSpher: {
+      // Pz = P * cos(theta)
+      double a = cos(p4.Theta());
+      double b = -p4.P() * sin(p4.Theta());
+      return sqrt(a * a * covariance(0, 0) + 2 * a * b * covariance(1, 0) + b * b * covariance(1, 1));
     }
+    case pat::CandKinResolution::MCPInvSpher: {
+      // Pz = P * cos(theta)
+      double p = p4.P();
+      double a = -p * p * cos(p4.Theta());
+      double b = -p * sin(p4.Theta());
+      return sqrt(a * a * covariance(0, 0) + 2 * a * b * covariance(1, 0) + b * b * covariance(1, 1));
+    }
+    // ==== HEP CYLINDRICAL (with Pt = Et) ====
+    case pat::CandKinResolution::EtThetaPhi: {
+      // Pz = Pt * ctg(theta)    d ctg(x) = -1/sin^2(x)
+      double s = sin(p4.Theta()), c = cos(p4.Theta());
+      double a = c / s;
+      double b = -p4.Pt() / (s * s);
+      return sqrt(a * a * covariance(0, 0) + 2 * a * b * covariance(1, 0) + b * b * covariance(1, 1));
+    }
+    case pat::CandKinResolution::EtEtaPhi: {
+      // Pz = Pt * sinh(eta)
+      double a = sinh(p4.Eta());
+      double b = p4.Et() * cosh(p4.Eta());
+      return sqrt(a * a * covariance(0, 0) + 2 * a * b * covariance(1, 0) + b * b * covariance(1, 1));
+    }
+    // ==== OTHERS ====
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolPz not yet implemented for parametrization " << parametrization;
+  }
 }
 
 double pat::helper::ResolutionHelper::getResolE(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)
-{
-    switch (parametrization) {
-        // ======= ENERGY BASED ==========
-        case pat::CandKinResolution::ECart:    
-        case pat::CandKinResolution::ESpher:
-            return sqrt(covariance(3,3));
-            // ======= ET BASED ==========
-        case pat::CandKinResolution::EtThetaPhi: 
-            {
-                // E = Et/Sin(theta)
-                double a = 1.0/sin(p4.Theta()); // dE/dEt
-                double b = - a*a* p4.Et() * cos(p4.Theta()); // dE/dTh
-                return sqrt(a*a*covariance(0,0) + b*b*covariance(1,1) + 2*a*b*covariance(0,1));
-            }
-        case pat::CandKinResolution::EtEtaPhi: 
-            {
-                // E = Et/Sin(Theta(eta))
-                double th = p4.Theta();
-                double a = 1.0/sin(th); // dE/dEt
-                double b =  a* p4.Et() * cos(th);   // dE/dEta: dTh/dEta = - 1.0/sin(theta) = - dE/dEt
-                return sqrt(a*a*covariance(0,0) + b*b*covariance(1,1) + 2*a*b*covariance(0,1));
-            }
-            // ======= MASS BASED ==========
-        case pat::CandKinResolution::Cart:
-            {
-                AlgebraicVector4 xoE(p4.X(), p4.Y(), p4.Z(), p4.M()); 
-                xoE *= 1/p4.E();
-                return sqrt(ROOT::Math::Similarity(xoE, covariance));
-            }
-        case pat::CandKinResolution::MCCart:
-            {
-                AlgebraicVector4 xoE(p4.X(), p4.Y(), p4.Z(), 0);
-                xoE *= 1/p4.E();
-                return sqrt(ROOT::Math::Similarity(xoE, covariance));
-            }
-        case pat::CandKinResolution::Spher:  
-            {
-                // E = sqrt(P^2 + m^2)
-                double einv = 1.0/p4.E();
-                double a  = p4.P()*einv; // dE/dP
-                double b  = p4.M()*einv; // dE/dm
-                return sqrt(a*a*covariance(0,0) + b*b*covariance(3,3) + 2*a*b*covariance(0,3));
-            }
-        case pat::CandKinResolution::MCSpher:  
-            {
-                // E = sqrt(P^2 + m^2); |dE/dP| = |P/E| = P/E
-                return p4.P()/p4.E() * sqrt(covariance(0,0));
-            }
-        case pat::CandKinResolution::MCPInvSpher:   //  
-            {
-                // E = sqrt(P^2 + m^2); |dE/d(1/P)| = P^2 |dE/dP| = P^3/E
-                double p = p4.P();
-                return p*p*p/p4.E()*sqrt(covariance(0,0));
-            }
-            // ======= OTHER ==========
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolE not yet implemented for parametrization " << parametrization ;
+                                                const AlgebraicSymMatrix44 &covariance,
+                                                const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    // ======= ENERGY BASED ==========
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::ESpher:
+      return sqrt(covariance(3, 3));
+      // ======= ET BASED ==========
+    case pat::CandKinResolution::EtThetaPhi: {
+      // E = Et/Sin(theta)
+      double a = 1.0 / sin(p4.Theta());               // dE/dEt
+      double b = -a * a * p4.Et() * cos(p4.Theta());  // dE/dTh
+      return sqrt(a * a * covariance(0, 0) + b * b * covariance(1, 1) + 2 * a * b * covariance(0, 1));
     }
+    case pat::CandKinResolution::EtEtaPhi: {
+      // E = Et/Sin(Theta(eta))
+      double th = p4.Theta();
+      double a = 1.0 / sin(th);          // dE/dEt
+      double b = a * p4.Et() * cos(th);  // dE/dEta: dTh/dEta = - 1.0/sin(theta) = - dE/dEt
+      return sqrt(a * a * covariance(0, 0) + b * b * covariance(1, 1) + 2 * a * b * covariance(0, 1));
+    }
+      // ======= MASS BASED ==========
+    case pat::CandKinResolution::Cart: {
+      AlgebraicVector4 xoE(p4.X(), p4.Y(), p4.Z(), p4.M());
+      xoE *= 1 / p4.E();
+      return sqrt(ROOT::Math::Similarity(xoE, covariance));
+    }
+    case pat::CandKinResolution::MCCart: {
+      AlgebraicVector4 xoE(p4.X(), p4.Y(), p4.Z(), 0);
+      xoE *= 1 / p4.E();
+      return sqrt(ROOT::Math::Similarity(xoE, covariance));
+    }
+    case pat::CandKinResolution::Spher: {
+      // E = sqrt(P^2 + m^2)
+      double einv = 1.0 / p4.E();
+      double a = p4.P() * einv;  // dE/dP
+      double b = p4.M() * einv;  // dE/dm
+      return sqrt(a * a * covariance(0, 0) + b * b * covariance(3, 3) + 2 * a * b * covariance(0, 3));
+    }
+    case pat::CandKinResolution::MCSpher: {
+      // E = sqrt(P^2 + m^2); |dE/dP| = |P/E| = P/E
+      return p4.P() / p4.E() * sqrt(covariance(0, 0));
+    }
+    case pat::CandKinResolution::MCPInvSpher:  //
+    {
+      // E = sqrt(P^2 + m^2); |dE/d(1/P)| = P^2 |dE/dP| = P^3/E
+      double p = p4.P();
+      return p * p * p / p4.E() * sqrt(covariance(0, 0));
+    }
+      // ======= OTHER ==========
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolE not yet implemented for parametrization " << parametrization;
+  }
 }
 
 double pat::helper::ResolutionHelper::getResolEt(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)  
-{
-    switch (parametrization) {
-        // ======= ENERGY BASED ==========
-        case pat::CandKinResolution::ECart:    
-            {
-                // Et^2 = E^2 * (Pt^2/P^2)  
-                double pt2 = p4.Perp2();
-                double pz2 = ROOT::Math::Square(p4.Pz()), p2 = pt2 + pz2;
-                double e2OverP4 = ROOT::Math::Square(p4.E()/p2);
-                AlgebraicVector4 derivs(p4.Px(), p4.Py(), p4.Pz(), p4.E());
-                derivs    *= (1.0/p4.Et());
-                derivs[0] *=  pz2 * e2OverP4;
-                derivs[1] *=  pz2 * e2OverP4;
-                derivs[2] *= -pt2 * e2OverP4;
-                derivs[3] *=  pt2/p2;
-                return sqrt(ROOT::Math::Similarity(derivs, covariance));
-            }
-        case pat::CandKinResolution::ESpher:
-            {
-                // Et = E * Sin(Theta)
-                double st = sin(p4.Theta()), ct = cos(p4.Theta());
-                return sqrt(  st*st                         * covariance(3,3) +
-                              ROOT::Math::Square(ct*p4.E()) * covariance(1,1) + 
-                              2*st*ct*p4.E()                * covariance(1,3)
-                        );
-            }
-            // ======= ET BASED ==========
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi: 
-            return sqrt(covariance(0,0));
-            // ======= MASS BASED ==========
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::MCCart:
-            {
-                // Et^2 = E^2 Sin^2(th) = (p^2 + m^2) * (pt^2) / p^2
-                double pt2 = p4.Perp2();
-                double p2  = pt2 + ROOT::Math::Square(p4.Pz());
-                double e2  = p2 + p4.M2();
-                double s2  = pt2/p2, pi2 = 1.0/p2;
-                double et  = sqrt(e2 * s2);
-                AlgebraicVector4 derivs(p4.Px(), p4.Py(), p4.Pz(), p4.M());
-                derivs *= 1.0/et;
-                derivs[0] *= (s2 + e2*pi2*(1.0 - pt2*pi2) );   /// dEt/dPx * Et
-                derivs[1] *= (s2 + e2*pi2*(1.0 - pt2*pi2) );   /// dEt/dPx * Et
-                derivs[2] *= (s2 - e2*pt2*pi2*pi2);    /// dEt/dPx * Et
-                if (parametrization == pat::CandKinResolution::Cart) {
-                    derivs[3] *= s2;
-                    return sqrt(ROOT::Math::Similarity(derivs, covariance));
-                } else {
-                    derivs[3] = 0;
-                    return sqrt(ROOT::Math::Similarity(derivs, covariance)); // test if Sub<33> is faster
-                }
-            }
-        case pat::CandKinResolution::Spher:  
-            {
-                // Et = E sin(theta); dE/dM = M/E, dE/dP = P/E
-                double s = sin(p4.Theta()), c = cos(p4.Theta());
-                double e = p4.E(); 
-                AlgebraicVector4 derivs( p4.P()/e * s, e * c, 0, p4.M()/e * s);
-                return sqrt(ROOT::Math::Similarity(derivs, covariance));
-            }
-        case pat::CandKinResolution::MCSpher:
-            {
-                // Et = E sin(theta); dE/dP = P/E
-                double s = sin(p4.Theta()), c = cos(p4.Theta());
-                double e = p4.E(); 
-                double a = p4.P()* s / e;
-                double b = e * c;
-                return sqrt(a*a*covariance(0,0) + b*b*covariance(1,1) + 2*a*b*covariance(0,1));
-            }
-        case pat::CandKinResolution::MCPInvSpher:   
-            {
-                // Et = E sin(theta); dE/dP = P/E -> dE/d(1/P) = - P^2 dE/dP = - P^3 / E
-                double s = sin(p4.Theta()), c = cos(p4.Theta());
-                double p = p4.P(), e = p4.E(); 
-                double a = ( - p * p * p / e ) * s;
-                double b = e * c;
-                return sqrt(a*a*covariance(0,0) + b*b*covariance(1,1) + 2*a*b*covariance(0,1));
-            }
-            // ======= OTHER ==========
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolEt not yet implemented for parametrization " << parametrization ;
+                                                 const AlgebraicSymMatrix44 &covariance,
+                                                 const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    // ======= ENERGY BASED ==========
+    case pat::CandKinResolution::ECart: {
+      // Et^2 = E^2 * (Pt^2/P^2)
+      double pt2 = p4.Perp2();
+      double pz2 = ROOT::Math::Square(p4.Pz()), p2 = pt2 + pz2;
+      double e2OverP4 = ROOT::Math::Square(p4.E() / p2);
+      AlgebraicVector4 derivs(p4.Px(), p4.Py(), p4.Pz(), p4.E());
+      derivs *= (1.0 / p4.Et());
+      derivs[0] *= pz2 * e2OverP4;
+      derivs[1] *= pz2 * e2OverP4;
+      derivs[2] *= -pt2 * e2OverP4;
+      derivs[3] *= pt2 / p2;
+      return sqrt(ROOT::Math::Similarity(derivs, covariance));
     }
+    case pat::CandKinResolution::ESpher: {
+      // Et = E * Sin(Theta)
+      double st = sin(p4.Theta()), ct = cos(p4.Theta());
+      return sqrt(st * st * covariance(3, 3) + ROOT::Math::Square(ct * p4.E()) * covariance(1, 1) +
+                  2 * st * ct * p4.E() * covariance(1, 3));
+    }
+      // ======= ET BASED ==========
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi:
+      return sqrt(covariance(0, 0));
+      // ======= MASS BASED ==========
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::MCCart: {
+      // Et^2 = E^2 Sin^2(th) = (p^2 + m^2) * (pt^2) / p^2
+      double pt2 = p4.Perp2();
+      double p2 = pt2 + ROOT::Math::Square(p4.Pz());
+      double e2 = p2 + p4.M2();
+      double s2 = pt2 / p2, pi2 = 1.0 / p2;
+      double et = sqrt(e2 * s2);
+      AlgebraicVector4 derivs(p4.Px(), p4.Py(), p4.Pz(), p4.M());
+      derivs *= 1.0 / et;
+      derivs[0] *= (s2 + e2 * pi2 * (1.0 - pt2 * pi2));  /// dEt/dPx * Et
+      derivs[1] *= (s2 + e2 * pi2 * (1.0 - pt2 * pi2));  /// dEt/dPx * Et
+      derivs[2] *= (s2 - e2 * pt2 * pi2 * pi2);          /// dEt/dPx * Et
+      if (parametrization == pat::CandKinResolution::Cart) {
+        derivs[3] *= s2;
+        return sqrt(ROOT::Math::Similarity(derivs, covariance));
+      } else {
+        derivs[3] = 0;
+        return sqrt(ROOT::Math::Similarity(derivs, covariance));  // test if Sub<33> is faster
+      }
+    }
+    case pat::CandKinResolution::Spher: {
+      // Et = E sin(theta); dE/dM = M/E, dE/dP = P/E
+      double s = sin(p4.Theta()), c = cos(p4.Theta());
+      double e = p4.E();
+      AlgebraicVector4 derivs(p4.P() / e * s, e * c, 0, p4.M() / e * s);
+      return sqrt(ROOT::Math::Similarity(derivs, covariance));
+    }
+    case pat::CandKinResolution::MCSpher: {
+      // Et = E sin(theta); dE/dP = P/E
+      double s = sin(p4.Theta()), c = cos(p4.Theta());
+      double e = p4.E();
+      double a = p4.P() * s / e;
+      double b = e * c;
+      return sqrt(a * a * covariance(0, 0) + b * b * covariance(1, 1) + 2 * a * b * covariance(0, 1));
+    }
+    case pat::CandKinResolution::MCPInvSpher: {
+      // Et = E sin(theta); dE/dP = P/E -> dE/d(1/P) = - P^2 dE/dP = - P^3 / E
+      double s = sin(p4.Theta()), c = cos(p4.Theta());
+      double p = p4.P(), e = p4.E();
+      double a = (-p * p * p / e) * s;
+      double b = e * c;
+      return sqrt(a * a * covariance(0, 0) + b * b * covariance(1, 1) + 2 * a * b * covariance(0, 1));
+    }
+      // ======= OTHER ==========
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolEt not yet implemented for parametrization " << parametrization;
+  }
 }
-
 
 double pat::helper::ResolutionHelper::getResolM(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)  
-{
-    switch (parametrization) {
-        // ====== MASS CONSTRAINED =====
-        case pat::CandKinResolution::MCSpher:
-        case pat::CandKinResolution::MCPInvSpher:   
-        case pat::CandKinResolution::MCCart:
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::EtEtaPhi: 
-            return 0;
-        // ======= MASS BASED ==========
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::Spher:  
-            return sqrt(covariance(3,3));
-        // ======= ENERGY BASED ==========
-        case pat::CandKinResolution::ESpher:
-            { // M^2 = E^2 - P^2
-              double dMdE = p4.E()/p4.M(), dMdP = - p4.P()/p4.M();
-              return sqrt(  dMdP*dMdP*covariance(0,0) +
-                          2*dMdP*dMdE*covariance(0,3) +
-                            dMdE*dMdE*covariance(3,3));
-            }
-        case pat::CandKinResolution::ECart:    
-            { // M^2 = E^2 - sum_i P_i^2
-                AlgebraicVector4 derivs(-p4.Px(), -p4.Py(), -p4.Pz(), p4.E());
-                derivs *= 1.0/p4.M();
-                return sqrt(ROOT::Math::Similarity(derivs, covariance));
-            }
-            throw cms::Exception("Not Implemented") << "getResolM not yet implemented for parametrization " << parametrization ;
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolM not yet implemented for parametrization " << parametrization ;
+                                                const AlgebraicSymMatrix44 &covariance,
+                                                const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    // ====== MASS CONSTRAINED =====
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::MCPInvSpher:
+    case pat::CandKinResolution::MCCart:
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::EtEtaPhi:
+      return 0;
+    // ======= MASS BASED ==========
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::Spher:
+      return sqrt(covariance(3, 3));
+    // ======= ENERGY BASED ==========
+    case pat::CandKinResolution::ESpher: {  // M^2 = E^2 - P^2
+      double dMdE = p4.E() / p4.M(), dMdP = -p4.P() / p4.M();
+      return sqrt(dMdP * dMdP * covariance(0, 0) + 2 * dMdP * dMdE * covariance(0, 3) + dMdE * dMdE * covariance(3, 3));
     }
+    case pat::CandKinResolution::ECart: {  // M^2 = E^2 - sum_i P_i^2
+      AlgebraicVector4 derivs(-p4.Px(), -p4.Py(), -p4.Pz(), p4.E());
+      derivs *= 1.0 / p4.M();
+      return sqrt(ROOT::Math::Similarity(derivs, covariance));
+    }
+      throw cms::Exception("Not Implemented")
+          << "getResolM not yet implemented for parametrization " << parametrization;
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolM not yet implemented for parametrization " << parametrization;
+  }
 }
 
-inline double DetaDtheta(double theta) { 
-    // y  = -ln(tg(x/2)) =>
-    // y' = - 1/tg(x/2) * 1/(cos(x/2))^2 * 1/2 = - 1 / (2 * sin(x/2) * cos(x/2)) = -1/sin(x) 
-    return -1.0/sin(theta);
+inline double DetaDtheta(double theta) {
+  // y  = -ln(tg(x/2)) =>
+  // y' = - 1/tg(x/2) * 1/(cos(x/2))^2 * 1/2 = - 1 / (2 * sin(x/2) * cos(x/2)) = -1/sin(x)
+  return -1.0 / sin(theta);
 }
-inline double DthetaDeta(double eta) { 
-    // y = 2 atan(exp(-x))
-    // y' = 2 * 1/(1+exp^2) * exp(-x) * (-1) = - 2 * exp/(1+exp^2) = - 2 / (exp + 1/exp)
-    double e = exp(-eta);
-    return -2.0/(e + 1.0/e);
+inline double DthetaDeta(double eta) {
+  // y = 2 atan(exp(-x))
+  // y' = 2 * 1/(1+exp^2) * exp(-x) * (-1) = - 2 * exp/(1+exp^2) = - 2 / (exp + 1/exp)
+  double e = exp(-eta);
+  return -2.0 / (e + 1.0 / e);
 }
 
 double pat::helper::ResolutionHelper::getResolEta(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)
-{
-    switch (parametrization) {
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:
-        case pat::CandKinResolution::MCCart:
-            // dEta = dTheta * dEta/dTheta 
-            return abs(DetaDtheta(p4.Theta())) * getResolTheta(parametrization, covariance, p4);
-        case pat::CandKinResolution::ESpher:        //  all the ones which have
-        case pat::CandKinResolution::MCPInvSpher:   //  theta as parameter 1
-        case pat::CandKinResolution::MCSpher:      
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::Spher:  
-            return sqrt(covariance(1,1))*abs(DetaDtheta(p4.Theta()));
-        case pat::CandKinResolution::EtEtaPhi:      // as simple as that
-            return sqrt(covariance(1,1));
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolEta not yet implemented for parametrization " << parametrization ;
-    }
+                                                  const AlgebraicSymMatrix44 &covariance,
+                                                  const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart:
+      // dEta = dTheta * dEta/dTheta
+      return abs(DetaDtheta(p4.Theta())) * getResolTheta(parametrization, covariance, p4);
+    case pat::CandKinResolution::ESpher:       //  all the ones which have
+    case pat::CandKinResolution::MCPInvSpher:  //  theta as parameter 1
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::Spher:
+      return sqrt(covariance(1, 1)) * abs(DetaDtheta(p4.Theta()));
+    case pat::CandKinResolution::EtEtaPhi:  // as simple as that
+      return sqrt(covariance(1, 1));
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolEta not yet implemented for parametrization " << parametrization;
+  }
 }
 double pat::helper::ResolutionHelper::getResolTheta(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)  
-{
-    switch (parametrization) {
-        case pat::CandKinResolution::Cart:
-        case pat::CandKinResolution::ECart:
-        case pat::CandKinResolution::MCCart:
-            {
-                // theta = acos( pz / p )        ; d acos(x) = - 1 / sqrt( 1 - x*x) dx = - p/pt dx
-                double pt2 = p4.Perp2();
-                double p   = p4.P(), pi = 1.0/p, pi3 = pi*pi*pi;
-                double dacos = - p/sqrt(pt2);
-                AlgebraicVector3 derivs;
-                derivs[0] = -p4.Px() * p4.Pz() * dacos * pi3;
-                derivs[1] = -p4.Py() * p4.Pz() * dacos * pi3;
-                derivs[2] =  pt2 * dacos * pi3;
-                return sqrt(ROOT::Math::Similarity(derivs, covariance.Sub<AlgebraicSymMatrix33>(0,0)));
-            }
-        case pat::CandKinResolution::ESpher:        //  all the ones which have
-        case pat::CandKinResolution::MCPInvSpher:   //  theta as parameter 1
-        case pat::CandKinResolution::MCSpher:      
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::Spher:  
-            return sqrt(covariance(1,1)); 
-        case pat::CandKinResolution::EtEtaPhi:      
-            return sqrt(covariance(1,1))*abs(DthetaDeta(p4.Eta())); 
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolTheta not yet implemented for parametrization " << parametrization ;
+                                                    const AlgebraicSymMatrix44 &covariance,
+                                                    const pat::CandKinResolution::LorentzVector &p4) {
+  switch (parametrization) {
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart: {
+      // theta = acos( pz / p )        ; d acos(x) = - 1 / sqrt( 1 - x*x) dx = - p/pt dx
+      double pt2 = p4.Perp2();
+      double p = p4.P(), pi = 1.0 / p, pi3 = pi * pi * pi;
+      double dacos = -p / sqrt(pt2);
+      AlgebraicVector3 derivs;
+      derivs[0] = -p4.Px() * p4.Pz() * dacos * pi3;
+      derivs[1] = -p4.Py() * p4.Pz() * dacos * pi3;
+      derivs[2] = pt2 * dacos * pi3;
+      return sqrt(ROOT::Math::Similarity(derivs, covariance.Sub<AlgebraicSymMatrix33>(0, 0)));
     }
+    case pat::CandKinResolution::ESpher:       //  all the ones which have
+    case pat::CandKinResolution::MCPInvSpher:  //  theta as parameter 1
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::Spher:
+      return sqrt(covariance(1, 1));
+    case pat::CandKinResolution::EtEtaPhi:
+      return sqrt(covariance(1, 1)) * abs(DthetaDeta(p4.Eta()));
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolTheta not yet implemented for parametrization " << parametrization;
+  }
 }
 double pat::helper::ResolutionHelper::getResolPhi(pat::CandKinResolution::Parametrization parametrization,
-        const AlgebraicSymMatrix44 &covariance, const pat::CandKinResolution::LorentzVector &p4)  
-{
-    double pt2 = p4.Perp2();
-    switch (parametrization) {
-        case pat::CandKinResolution::Cart:         
-        case pat::CandKinResolution::ECart:        
-        case pat::CandKinResolution::MCCart:
-            return sqrt( ROOT::Math::Square(p4.Px()) * covariance(1,1) +
-                         ROOT::Math::Square(p4.Py()) * covariance(0,0) +
-                         -2*p4.Px()*p4.Py()          * covariance(0,1)
-                    )/pt2;
-        case pat::CandKinResolution::ESpher:        //  all the ones which have
-        case pat::CandKinResolution::MCPInvSpher:   //  phi as parameter 2
-        case pat::CandKinResolution::MCSpher:      
-        case pat::CandKinResolution::EtThetaPhi: 
-        case pat::CandKinResolution::Spher:  
-        case pat::CandKinResolution::EtEtaPhi:      
-            return sqrt(covariance(2,2)); 
-        case pat::CandKinResolution::Invalid:
-            throw cms::Exception("Invalid parametrization") << parametrization;
-        default:
-            throw cms::Exception("Not Implemented") << "getResolPhi not yet implemented for parametrization " << parametrization ;
-    }
+                                                  const AlgebraicSymMatrix44 &covariance,
+                                                  const pat::CandKinResolution::LorentzVector &p4) {
+  double pt2 = p4.Perp2();
+  switch (parametrization) {
+    case pat::CandKinResolution::Cart:
+    case pat::CandKinResolution::ECart:
+    case pat::CandKinResolution::MCCart:
+      return sqrt(ROOT::Math::Square(p4.Px()) * covariance(1, 1) + ROOT::Math::Square(p4.Py()) * covariance(0, 0) +
+                  -2 * p4.Px() * p4.Py() * covariance(0, 1)) /
+             pt2;
+    case pat::CandKinResolution::ESpher:       //  all the ones which have
+    case pat::CandKinResolution::MCPInvSpher:  //  phi as parameter 2
+    case pat::CandKinResolution::MCSpher:
+    case pat::CandKinResolution::EtThetaPhi:
+    case pat::CandKinResolution::Spher:
+    case pat::CandKinResolution::EtEtaPhi:
+      return sqrt(covariance(2, 2));
+    case pat::CandKinResolution::Invalid:
+      throw cms::Exception("Invalid parametrization") << parametrization;
+    default:
+      throw cms::Exception("Not Implemented")
+          << "getResolPhi not yet implemented for parametrization " << parametrization;
+  }
 }

--- a/DataFormats/PatCandidates/src/StringMap.cc
+++ b/DataFormats/PatCandidates/src/StringMap.cc
@@ -1,35 +1,27 @@
 #include "DataFormats/PatCandidates/interface/StringMap.h"
 
-void StringMap::add(const std::string &string, int32_t value) {
-    entries_.push_back(value_type(string,value));
-}
+void StringMap::add(const std::string &string, int32_t value) { entries_.push_back(value_type(string, value)); }
 
-void StringMap::sort() {
-    std::sort(entries_.begin(), entries_.end());
-}
+void StringMap::sort() { std::sort(entries_.begin(), entries_.end()); }
 
-void StringMap::clear() {
-    entries_.clear();
-}
+void StringMap::clear() { entries_.clear(); }
 
 int32_t StringMap::operator[](const std::string &string) const {
-    vector_type::const_iterator match =  std::lower_bound(entries_.begin(), entries_.end(), string, MatchByString());
-    return (match == end() ? -1 : match->second);
+  vector_type::const_iterator match = std::lower_bound(entries_.begin(), entries_.end(), string, MatchByString());
+  return (match == end() ? -1 : match->second);
 }
 
-const std::string & StringMap::operator[](int32_t number) const {
-    static const std::string empty_;
-    vector_type::const_iterator match = find(number);
-    return (match == end() ? empty_ : match->first);
+const std::string &StringMap::operator[](int32_t number) const {
+  static const std::string empty_;
+  vector_type::const_iterator match = find(number);
+  return (match == end() ? empty_ : match->first);
 }
 
 StringMap::const_iterator StringMap::find(const std::string &string) const {
-    vector_type::const_iterator match =  std::lower_bound(entries_.begin(), entries_.end(), string, MatchByString());
-    return (match->first == string ? match : end());
+  vector_type::const_iterator match = std::lower_bound(entries_.begin(), entries_.end(), string, MatchByString());
+  return (match->first == string ? match : end());
 }
 
 StringMap::const_iterator StringMap::find(int32_t number) const {
-    return std::find_if(entries_.begin(), entries_.end(), MatchByNumber(number)); 
+  return std::find_if(entries_.begin(), entries_.end(), MatchByNumber(number));
 }
-
-

--- a/DataFormats/PatCandidates/src/Tau.cc
+++ b/DataFormats/PatCandidates/src/Tau.cc
@@ -9,162 +9,149 @@
 
 using namespace pat;
 
-
 /// default constructor
-Tau::Tau() :
-    Lepton<reco::BaseTau>()
-    ,embeddedIsolationTracks_(false)
-    ,embeddedLeadTrack_(false)
-    ,embeddedSignalTracks_(false)
-    ,embeddedLeadPFCand_(false)
-    ,embeddedLeadPFChargedHadrCand_(false)
-    ,embeddedLeadPFNeutralCand_(false)
-    ,embeddedSignalPFCands_(false)
-    ,embeddedSignalPFChargedHadrCands_(false)
-    ,embeddedSignalPFNeutralHadrCands_(false)
-    ,embeddedSignalPFGammaCands_(false)
-    ,embeddedIsolationPFCands_(false)
-    ,embeddedIsolationPFChargedHadrCands_(false)
-    ,embeddedIsolationPFNeutralHadrCands_(false)
-    ,embeddedIsolationPFGammaCands_(false)
-{
-}
+Tau::Tau()
+    : Lepton<reco::BaseTau>(),
+      embeddedIsolationTracks_(false),
+      embeddedLeadTrack_(false),
+      embeddedSignalTracks_(false),
+      embeddedLeadPFCand_(false),
+      embeddedLeadPFChargedHadrCand_(false),
+      embeddedLeadPFNeutralCand_(false),
+      embeddedSignalPFCands_(false),
+      embeddedSignalPFChargedHadrCands_(false),
+      embeddedSignalPFNeutralHadrCands_(false),
+      embeddedSignalPFGammaCands_(false),
+      embeddedIsolationPFCands_(false),
+      embeddedIsolationPFChargedHadrCands_(false),
+      embeddedIsolationPFNeutralHadrCands_(false),
+      embeddedIsolationPFGammaCands_(false) {}
 
 /// constructor from reco::BaseTau
-Tau::Tau(const reco::BaseTau & aTau) :
-    Lepton<reco::BaseTau>(aTau)
-    ,embeddedIsolationTracks_(false)
-    ,embeddedLeadTrack_(false)
-    ,embeddedSignalTracks_(false)
-    ,embeddedLeadPFCand_(false)
-    ,embeddedLeadPFChargedHadrCand_(false)
-    ,embeddedLeadPFNeutralCand_(false)
-    ,embeddedSignalPFCands_(false)
-    ,embeddedSignalPFChargedHadrCands_(false)
-    ,embeddedSignalPFNeutralHadrCands_(false)
-    ,embeddedSignalPFGammaCands_(false)
-    ,embeddedIsolationPFCands_(false)
-    ,embeddedIsolationPFChargedHadrCands_(false)
-    ,embeddedIsolationPFNeutralHadrCands_(false)
-    ,embeddedIsolationPFGammaCands_(false)
-{
-    initFromBaseTau(aTau);
+Tau::Tau(const reco::BaseTau& aTau)
+    : Lepton<reco::BaseTau>(aTau),
+      embeddedIsolationTracks_(false),
+      embeddedLeadTrack_(false),
+      embeddedSignalTracks_(false),
+      embeddedLeadPFCand_(false),
+      embeddedLeadPFChargedHadrCand_(false),
+      embeddedLeadPFNeutralCand_(false),
+      embeddedSignalPFCands_(false),
+      embeddedSignalPFChargedHadrCands_(false),
+      embeddedSignalPFNeutralHadrCands_(false),
+      embeddedSignalPFGammaCands_(false),
+      embeddedIsolationPFCands_(false),
+      embeddedIsolationPFChargedHadrCands_(false),
+      embeddedIsolationPFNeutralHadrCands_(false),
+      embeddedIsolationPFGammaCands_(false) {
+  initFromBaseTau(aTau);
 }
 
 /// constructor from ref to reco::BaseTau
-Tau::Tau(const edm::RefToBase<reco::BaseTau> & aTauRef) :
-    Lepton<reco::BaseTau>(aTauRef)
-    ,embeddedIsolationTracks_(false)
-    ,embeddedLeadTrack_(false)
-    ,embeddedSignalTracks_(false)
-    ,embeddedLeadPFCand_(false)
-    ,embeddedLeadPFChargedHadrCand_(false)
-    ,embeddedLeadPFNeutralCand_(false)
-    ,embeddedSignalPFCands_(false)
-    ,embeddedSignalPFChargedHadrCands_(false)
-    ,embeddedSignalPFNeutralHadrCands_(false)
-    ,embeddedSignalPFGammaCands_(false)
-    ,embeddedIsolationPFCands_(false)
-    ,embeddedIsolationPFChargedHadrCands_(false)
-    ,embeddedIsolationPFNeutralHadrCands_(false)
-    ,embeddedIsolationPFGammaCands_(false)
-{
-    initFromBaseTau(*aTauRef);
+Tau::Tau(const edm::RefToBase<reco::BaseTau>& aTauRef)
+    : Lepton<reco::BaseTau>(aTauRef),
+      embeddedIsolationTracks_(false),
+      embeddedLeadTrack_(false),
+      embeddedSignalTracks_(false),
+      embeddedLeadPFCand_(false),
+      embeddedLeadPFChargedHadrCand_(false),
+      embeddedLeadPFNeutralCand_(false),
+      embeddedSignalPFCands_(false),
+      embeddedSignalPFChargedHadrCands_(false),
+      embeddedSignalPFNeutralHadrCands_(false),
+      embeddedSignalPFGammaCands_(false),
+      embeddedIsolationPFCands_(false),
+      embeddedIsolationPFChargedHadrCands_(false),
+      embeddedIsolationPFNeutralHadrCands_(false),
+      embeddedIsolationPFGammaCands_(false) {
+  initFromBaseTau(*aTauRef);
 }
 
 /// constructor from ref to reco::BaseTau
-Tau::Tau(const edm::Ptr<reco::BaseTau> & aTauRef) :
-    Lepton<reco::BaseTau>(aTauRef)
-    ,embeddedIsolationTracks_(false)
-    ,embeddedLeadTrack_(false)
-    ,embeddedSignalTracks_(false)
-    ,embeddedLeadPFCand_(false)
-    ,embeddedLeadPFChargedHadrCand_(false)
-    ,embeddedLeadPFNeutralCand_(false)
-    ,embeddedSignalPFCands_(false)
-    ,embeddedSignalPFChargedHadrCands_(false)
-    ,embeddedSignalPFNeutralHadrCands_(false)
-    ,embeddedSignalPFGammaCands_(false)
-    ,embeddedIsolationPFCands_(false)
-    ,embeddedIsolationPFChargedHadrCands_(false)
-    ,embeddedIsolationPFNeutralHadrCands_(false)
-    ,embeddedIsolationPFGammaCands_(false)
-{
-    initFromBaseTau(*aTauRef);
+Tau::Tau(const edm::Ptr<reco::BaseTau>& aTauRef)
+    : Lepton<reco::BaseTau>(aTauRef),
+      embeddedIsolationTracks_(false),
+      embeddedLeadTrack_(false),
+      embeddedSignalTracks_(false),
+      embeddedLeadPFCand_(false),
+      embeddedLeadPFChargedHadrCand_(false),
+      embeddedLeadPFNeutralCand_(false),
+      embeddedSignalPFCands_(false),
+      embeddedSignalPFChargedHadrCands_(false),
+      embeddedSignalPFNeutralHadrCands_(false),
+      embeddedSignalPFGammaCands_(false),
+      embeddedIsolationPFCands_(false),
+      embeddedIsolationPFChargedHadrCands_(false),
+      embeddedIsolationPFNeutralHadrCands_(false),
+      embeddedIsolationPFGammaCands_(false) {
+  initFromBaseTau(*aTauRef);
 }
 
 void Tau::initFromBaseTau(const reco::BaseTau& aTau) {
-    const reco::PFTau * pfTau = dynamic_cast<const reco::PFTau *>(&aTau);
-    if (pfTau != nullptr){
-      // If PFTau is made from PackedCandidates, directly fill slimmed version
-      // without PFSpecific
-      const pat::PackedCandidate* pc = dynamic_cast<const pat::PackedCandidate*>(pfTau->leadChargedHadrCand().get());
-      if (pc != nullptr) {
-        for (const auto& ptr : pfTau->signalChargedHadrCands())
-          signalChargedHadrCandPtrs_.push_back(ptr);
+  const reco::PFTau* pfTau = dynamic_cast<const reco::PFTau*>(&aTau);
+  if (pfTau != nullptr) {
+    // If PFTau is made from PackedCandidates, directly fill slimmed version
+    // without PFSpecific
+    const pat::PackedCandidate* pc = dynamic_cast<const pat::PackedCandidate*>(pfTau->leadChargedHadrCand().get());
+    if (pc != nullptr) {
+      for (const auto& ptr : pfTau->signalChargedHadrCands())
+        signalChargedHadrCandPtrs_.push_back(ptr);
 
-        for (const auto& ptr : pfTau->signalNeutrHadrCands())
-          signalNeutralHadrCandPtrs_.push_back(ptr);
+      for (const auto& ptr : pfTau->signalNeutrHadrCands())
+        signalNeutralHadrCandPtrs_.push_back(ptr);
 
-        for (const auto& ptr : pfTau->signalGammaCands())
-          signalGammaCandPtrs_.push_back(ptr);
+      for (const auto& ptr : pfTau->signalGammaCands())
+        signalGammaCandPtrs_.push_back(ptr);
 
-        for (const auto& ptr : pfTau->isolationChargedHadrCands())
-          isolationChargedHadrCandPtrs_.push_back(ptr);
+      for (const auto& ptr : pfTau->isolationChargedHadrCands())
+        isolationChargedHadrCandPtrs_.push_back(ptr);
 
-        for (const auto& ptr : pfTau->isolationNeutrHadrCands())
-          isolationNeutralHadrCandPtrs_.push_back(ptr);
+      for (const auto& ptr : pfTau->isolationNeutrHadrCands())
+        isolationNeutralHadrCandPtrs_.push_back(ptr);
 
-        for (const auto& ptr : pfTau->isolationGammaCands())
-          isolationGammaCandPtrs_.push_back(ptr);
-      }
-      else {
-        pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
-      }
-      pfEssential_.push_back(pat::tau::TauPFEssential(*pfTau));
+      for (const auto& ptr : pfTau->isolationGammaCands())
+        isolationGammaCandPtrs_.push_back(ptr);
+    } else {
+      pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
     }
-    const reco::CaloTau * caloTau = dynamic_cast<const reco::CaloTau *>(&aTau);
-    if (caloTau != nullptr) caloSpecific_.push_back(pat::tau::TauCaloSpecific(*caloTau));
+    pfEssential_.push_back(pat::tau::TauPFEssential(*pfTau));
+  }
+  const reco::CaloTau* caloTau = dynamic_cast<const reco::CaloTau*>(&aTau);
+  if (caloTau != nullptr)
+    caloSpecific_.push_back(pat::tau::TauCaloSpecific(*caloTau));
 }
 
 /// destructor
-Tau::~Tau() {
-}
+Tau::~Tau() {}
 
-std::ostream& 
-reco::operator<<(std::ostream& out, const pat::Tau& obj) 
-{
-  if(!out) return out;
-  
+std::ostream& reco::operator<<(std::ostream& out, const pat::Tau& obj) {
+  if (!out)
+    return out;
+
   out << "\tpat::Tau: ";
   out << std::setiosflags(std::ios::right);
   out << std::setiosflags(std::ios::fixed);
   out << std::setprecision(3);
-  out << " E/pT/eta/phi " 
-      << obj.energy()<<"/"
-      << obj.pt()<<"/"
-      << obj.eta()<<"/"
-      << obj.phi();
-  return out; 
+  out << " E/pT/eta/phi " << obj.energy() << "/" << obj.pt() << "/" << obj.eta() << "/" << obj.phi();
+  return out;
 }
 
 /// override the reco::BaseTau::isolationTracks method, to access the internal storage of the track
-const reco::TrackRefVector & Tau::isolationTracks() const {
+const reco::TrackRefVector& Tau::isolationTracks() const {
   if (embeddedIsolationTracks_) {
     if (!isolationTracksTransientRefVector_.isSet()) {
-	std::unique_ptr<reco::TrackRefVector> trackRefVec{ new reco::TrackRefVector{}};
-	trackRefVec->reserve(isolationTracks_.size());
-        for (unsigned int i = 0; i < isolationTracks_.size(); i++) {
-          trackRefVec->push_back(reco::TrackRef(&isolationTracks_, i));
-        }
-	isolationTracksTransientRefVector_.set(std::move(trackRefVec));
+      std::unique_ptr<reco::TrackRefVector> trackRefVec{new reco::TrackRefVector{}};
+      trackRefVec->reserve(isolationTracks_.size());
+      for (unsigned int i = 0; i < isolationTracks_.size(); i++) {
+        trackRefVec->push_back(reco::TrackRef(&isolationTracks_, i));
+      }
+      isolationTracksTransientRefVector_.set(std::move(trackRefVec));
     }
     return *isolationTracksTransientRefVector_;
   } else {
     return reco::BaseTau::isolationTracks();
   }
 }
-
 
 /// override the reco::BaseTau::track method, to access the internal storage of the track
 reco::TrackRef Tau::leadTrack() const {
@@ -175,24 +162,22 @@ reco::TrackRef Tau::leadTrack() const {
   }
 }
 
-
 /// override the reco::BaseTau::track method, to access the internal storage of the track
-const reco::TrackRefVector & Tau::signalTracks() const {
+const reco::TrackRefVector& Tau::signalTracks() const {
   if (embeddedSignalTracks_) {
     if (!signalTracksTransientRefVector_.isSet()) {
-        std::unique_ptr<reco::TrackRefVector> trackRefVec{ new reco::TrackRefVector{} };
-        trackRefVec->reserve(signalTracks_.size());
-        for (unsigned int i = 0; i < signalTracks_.size(); i++) {
-          trackRefVec->push_back(reco::TrackRef(&signalTracks_, i));
-        }
-	signalTracksTransientRefVector_.set(std::move(trackRefVec));
+      std::unique_ptr<reco::TrackRefVector> trackRefVec{new reco::TrackRefVector{}};
+      trackRefVec->reserve(signalTracks_.size());
+      for (unsigned int i = 0; i < signalTracks_.size(); i++) {
+        trackRefVec->push_back(reco::TrackRef(&signalTracks_, i));
+      }
+      signalTracksTransientRefVector_.set(std::move(trackRefVec));
     }
     return *signalTracksTransientRefVector_;
   } else {
     return reco::BaseTau::signalTracks();
   }
 }
-
 
 /// method to store the isolation tracks internally
 void Tau::embedIsolationTracks() {
@@ -204,19 +189,17 @@ void Tau::embedIsolationTracks() {
   embeddedIsolationTracks_ = true;
 }
 
-
 /// method to store the isolation tracks internally
 void Tau::embedLeadTrack() {
   leadTrack_.clear();
   if (reco::BaseTau::leadTrack().isNonnull()) {
-      leadTrack_.push_back(*reco::BaseTau::leadTrack());
-      embeddedLeadTrack_ = true;
+    leadTrack_.push_back(*reco::BaseTau::leadTrack());
+    embeddedLeadTrack_ = true;
   }
 }
 
-
 /// method to store the isolation tracks internally
-void Tau::embedSignalTracks(){
+void Tau::embedSignalTracks() {
   signalTracks_.clear();
   reco::TrackRefVector trackRefVec = reco::BaseTau::signalTracks();
   for (unsigned int i = 0; i < trackRefVec.size(); i++) {
@@ -225,7 +208,6 @@ void Tau::embedSignalTracks(){
   embeddedSignalTracks_ = true;
 }
 
-
 /// method to set the matched generated jet
 void Tau::setGenJet(const reco::GenJetRef& gj) {
   genJet_.clear();
@@ -233,15 +215,13 @@ void Tau::setGenJet(const reco::GenJetRef& gj) {
 }
 
 /// return the matched generated jet
-const reco::GenJet * Tau::genJet() const {
-  return (!genJet_.empty() ? &genJet_.front() : nullptr);
-}
-
+const reco::GenJet* Tau::genJet() const { return (!genJet_.empty() ? &genJet_.front() : nullptr); }
 
 // method to retrieve a tau ID (or throw)
-float Tau::tauID(const std::string & name) const {
+float Tau::tauID(const std::string& name) const {
   for (std::vector<IdPair>::const_iterator it = tauIDs_.begin(), ed = tauIDs_.end(); it != ed; ++it) {
-    if (it->first == name) return it->second;
+    if (it->first == name)
+      return it->second;
   }
   cms::Exception ex("Key not found");
   ex << "pat::Tau: the ID " << name << " can't be found in this pat::Tau.\n";
@@ -253,125 +233,142 @@ float Tau::tauID(const std::string & name) const {
   throw ex;
 }
 // check if an ID is there
-bool Tau::isTauIDAvailable(const std::string & name) const {
+bool Tau::isTauIDAvailable(const std::string& name) const {
   for (std::vector<IdPair>::const_iterator it = tauIDs_.begin(), ed = tauIDs_.end(); it != ed; ++it) {
-    if (it->first == name) return true;
+    if (it->first == name)
+      return true;
   }
   return false;
 }
 
-
-const pat::tau::TauPFSpecific & Tau::pfSpecific() const {
-  if (!isPFTau()) throw cms::Exception("Type Error") << "Requesting a PFTau-specific information from a pat::Tau which wasn't made from a PFTau.\n";
-  return pfSpecific_[0]; 
+const pat::tau::TauPFSpecific& Tau::pfSpecific() const {
+  if (!isPFTau())
+    throw cms::Exception("Type Error")
+        << "Requesting a PFTau-specific information from a pat::Tau which wasn't made from a PFTau.\n";
+  return pfSpecific_[0];
 }
 
-const pat::tau::TauPFEssential & Tau::pfEssential() const {
-  if (pfEssential_.empty()) throw cms::Exception("Type Error") << "Requesting a PFTau-specific information from a pat::Tau which wasn't made from a PFTau.\n";
-  return pfEssential_[0]; 
+const pat::tau::TauPFEssential& Tau::pfEssential() const {
+  if (pfEssential_.empty())
+    throw cms::Exception("Type Error")
+        << "Requesting a PFTau-specific information from a pat::Tau which wasn't made from a PFTau.\n";
+  return pfEssential_[0];
 }
 
-
-const pat::tau::TauCaloSpecific & Tau::caloSpecific() const {
-  if (!isCaloTau()) throw cms::Exception("Type Error") << "Requesting a CaloTau-specific information from a pat::Tau which wasn't made from a CaloTau.\n";
-  return caloSpecific_[0]; 
+const pat::tau::TauCaloSpecific& Tau::caloSpecific() const {
+  if (!isCaloTau())
+    throw cms::Exception("Type Error")
+        << "Requesting a CaloTau-specific information from a pat::Tau which wasn't made from a CaloTau.\n";
+  return caloSpecific_[0];
 }
 
-reco::Candidate::LorentzVector Tau::p4Jet() const
-{
-  if ( isCaloTau() ) return caloSpecific().p4Jet_;
-  if ( isPFTau()   ) return reco::Candidate::LorentzVector(pfEssential().p4Jet_);
-  throw cms::Exception("Type Error") << "Requesting a CaloTau/PFTau-specific information from a pat::Tau which wasn't made from either a CaloTau or a PFTau.\n";
+reco::Candidate::LorentzVector Tau::p4Jet() const {
+  if (isCaloTau())
+    return caloSpecific().p4Jet_;
+  if (isPFTau())
+    return reco::Candidate::LorentzVector(pfEssential().p4Jet_);
+  throw cms::Exception("Type Error") << "Requesting a CaloTau/PFTau-specific information from a pat::Tau which wasn't "
+                                        "made from either a CaloTau or a PFTau.\n";
 }
 
-float Tau::dxy_Sig() const
-{
-  if ( pfEssential().dxy_error_ != 0 ) return (pfEssential().dxy_/pfEssential().dxy_error_);
-  else return 0.;
+float Tau::dxy_Sig() const {
+  if (pfEssential().dxy_error_ != 0)
+    return (pfEssential().dxy_ / pfEssential().dxy_error_);
+  else
+    return 0.;
 }
 
-pat::tau::TauPFEssential::CovMatrix Tau::flightLengthCov() const
-{
+pat::tau::TauPFEssential::CovMatrix Tau::flightLengthCov() const {
   pat::tau::TauPFEssential::CovMatrix cov;
   const pat::tau::TauPFEssential::CovMatrix& sv = secondaryVertexCov();
   const pat::tau::TauPFEssential::CovMatrix& pv = primaryVertexCov();
-  for ( int i = 0; i < dimension; ++i ) {
-    for ( int j = 0; j < dimension; ++j ) {
-      cov(i,j) = sv(i,j) + pv(i,j);
+  for (int i = 0; i < dimension; ++i) {
+    for (int j = 0; j < dimension; ++j) {
+      cov(i, j) = sv(i, j) + pv(i, j);
     }
   }
   return cov;
 }
 
-float Tau::ip3d_Sig() const
-{
-	if( pfEssential().ip3d_error_ != 0 ) return (pfEssential().ip3d_/pfEssential().ip3d_error_);
-	else return 0.;
+float Tau::ip3d_Sig() const {
+  if (pfEssential().ip3d_error_ != 0)
+    return (pfEssential().ip3d_ / pfEssential().ip3d_error_);
+  else
+    return 0.;
 }
 
-float Tau::etaetaMoment() const
-{
-  if ( isCaloTau() ) return caloSpecific().etaetaMoment_;
-  if ( isPFTau()   ) return pfSpecific().etaetaMoment_;
-  throw cms::Exception("Type Error") << "Requesting a CaloTau/PFTau-specific information from a pat::Tau which wasn't made from either a CaloTau or a PFTau.\n";
+float Tau::etaetaMoment() const {
+  if (isCaloTau())
+    return caloSpecific().etaetaMoment_;
+  if (isPFTau())
+    return pfSpecific().etaetaMoment_;
+  throw cms::Exception("Type Error") << "Requesting a CaloTau/PFTau-specific information from a pat::Tau which wasn't "
+                                        "made from either a CaloTau or a PFTau.\n";
 }
 
-float Tau::phiphiMoment() const
-{
-  if ( isCaloTau() ) return caloSpecific().phiphiMoment_;
-  if ( isPFTau()   ) return pfSpecific().phiphiMoment_;
-  throw cms::Exception("Type Error") << "Requesting a CaloTau/PFTau-specific information from a pat::Tau which wasn't made from either a CaloTau or a PFTau.\n";
+float Tau::phiphiMoment() const {
+  if (isCaloTau())
+    return caloSpecific().phiphiMoment_;
+  if (isPFTau())
+    return pfSpecific().phiphiMoment_;
+  throw cms::Exception("Type Error") << "Requesting a CaloTau/PFTau-specific information from a pat::Tau which wasn't "
+                                        "made from either a CaloTau or a PFTau.\n";
 }
 
-float Tau::etaphiMoment() const
-{
-  if ( isCaloTau() ) return caloSpecific().etaphiMoment_;
-  if ( isPFTau()   ) return pfSpecific().etaphiMoment_;
-  throw cms::Exception("Type Error") << "Requesting a CaloTau/PFTau-specific information from a pat::Tau which wasn't made from either a CaloTau or a PFTau.\n";
+float Tau::etaphiMoment() const {
+  if (isCaloTau())
+    return caloSpecific().etaphiMoment_;
+  if (isPFTau())
+    return pfSpecific().etaphiMoment_;
+  throw cms::Exception("Type Error") << "Requesting a CaloTau/PFTau-specific information from a pat::Tau which wasn't "
+                                        "made from either a CaloTau or a PFTau.\n";
 }
 
-void Tau::setDecayMode(int decayMode)
-{
-  if (!isPFTau()) throw cms::Exception("Type Error") << "Requesting a PFTau-specific information from a pat::Tau which wasn't made from a PFTau.\n";
+void Tau::setDecayMode(int decayMode) {
+  if (!isPFTau())
+    throw cms::Exception("Type Error")
+        << "Requesting a PFTau-specific information from a pat::Tau which wasn't made from a PFTau.\n";
   pfEssential_[0].decayMode_ = decayMode;
-} 
+}
 
 /// method to store the leading candidate internally
 void Tau::embedLeadPFCand() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   leadPFCand_.clear();
-  if (pfSpecific_[0].leadPFCand_.isNonnull() ) {
-    leadPFCand_.push_back(*static_cast<const reco::PFCandidate*>(&*pfSpecific_[0].leadPFCand_)); //already set in C-tor
+  if (pfSpecific_[0].leadPFCand_.isNonnull()) {
+    leadPFCand_.push_back(*static_cast<const reco::PFCandidate*>(&*pfSpecific_[0].leadPFCand_));  //already set in C-tor
     embeddedLeadPFCand_ = true;
   }
 }
 /// method to store the leading candidate internally
 void Tau::embedLeadPFChargedHadrCand() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   leadPFChargedHadrCand_.clear();
-  if (pfSpecific_[0].leadPFChargedHadrCand_.isNonnull() ) {
-    leadPFChargedHadrCand_.push_back(*static_cast<const reco::PFCandidate*>(&*pfSpecific_[0].leadPFChargedHadrCand_)); //already set in C-tor
+  if (pfSpecific_[0].leadPFChargedHadrCand_.isNonnull()) {
+    leadPFChargedHadrCand_.push_back(
+        *static_cast<const reco::PFCandidate*>(&*pfSpecific_[0].leadPFChargedHadrCand_));  //already set in C-tor
     embeddedLeadPFChargedHadrCand_ = true;
   }
 }
 /// method to store the leading candidate internally
 void Tau::embedLeadPFNeutralCand() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   leadPFNeutralCand_.clear();
-  if (pfSpecific_[0].leadPFNeutralCand_.isNonnull() ) {
-    leadPFNeutralCand_.push_back(*static_cast<const reco::PFCandidate*>(&*pfSpecific_[0].leadPFNeutralCand_)); //already set in C-tor
+  if (pfSpecific_[0].leadPFNeutralCand_.isNonnull()) {
+    leadPFNeutralCand_.push_back(
+        *static_cast<const reco::PFCandidate*>(&*pfSpecific_[0].leadPFNeutralCand_));  //already set in C-tor
     embeddedLeadPFNeutralCand_ = true;
   }
 }
 
 void Tau::embedSignalPFCands() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFCands_;
@@ -381,7 +378,7 @@ void Tau::embedSignalPFCands() {
   embeddedSignalPFCands_ = true;
 }
 void Tau::embedSignalPFChargedHadrCands() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFChargedHadrCands_;
@@ -391,7 +388,7 @@ void Tau::embedSignalPFChargedHadrCands() {
   embeddedSignalPFChargedHadrCands_ = true;
 }
 void Tau::embedSignalPFNeutralHadrCands() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFNeutrHadrCands_;
@@ -401,7 +398,7 @@ void Tau::embedSignalPFNeutralHadrCands() {
   embeddedSignalPFNeutralHadrCands_ = true;
 }
 void Tau::embedSignalPFGammaCands() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFGammaCands_;
@@ -412,7 +409,7 @@ void Tau::embedSignalPFGammaCands() {
 }
 
 void Tau::embedIsolationPFCands() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFCands_;
@@ -423,7 +420,7 @@ void Tau::embedIsolationPFCands() {
 }
 
 void Tau::embedIsolationPFChargedHadrCands() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFChargedHadrCands_;
@@ -433,7 +430,7 @@ void Tau::embedIsolationPFChargedHadrCands() {
   embeddedIsolationPFChargedHadrCands_ = true;
 }
 void Tau::embedIsolationPFNeutralHadrCands() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFNeutrHadrCands_;
@@ -443,7 +440,7 @@ void Tau::embedIsolationPFNeutralHadrCands() {
   embeddedIsolationPFNeutralHadrCands_ = true;
 }
 void Tau::embedIsolationPFGammaCands() {
-  if (!isPFTau() ) {//additional check with warning in pat::tau producer
+  if (!isPFTau()) {  //additional check with warning in pat::tau producer
     return;
   }
   std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFGammaCands_;
@@ -454,9 +451,10 @@ void Tau::embedIsolationPFGammaCands() {
 }
 
 reco::PFRecoTauChargedHadronRef Tau::leadTauChargedHadronCandidate() const {
-  if(!isPFTau() ) throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
-  if ( !pfSpecific().signalTauChargedHadronCandidates_.empty() ) {
-    return reco::PFRecoTauChargedHadronRef(&pfSpecific().signalTauChargedHadronCandidates_,0);
+  if (!isPFTau())
+    throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
+  if (!pfSpecific().signalTauChargedHadronCandidates_.empty()) {
+    return reco::PFRecoTauChargedHadronRef(&pfSpecific().signalTauChargedHadronCandidates_, 0);
   } else {
     return reco::PFRecoTauChargedHadronRef();
   }
@@ -469,43 +467,49 @@ const reco::PFCandidatePtr convertToPFCandidatePtr(const reco::CandidatePtr& ptr
   return reco::PFCandidatePtr();
 }
 
-const reco::PFCandidatePtr Tau::leadPFChargedHadrCand() const { 
-  if(!embeddedLeadPFChargedHadrCand_){
-    if(pfSpecific_.empty()) return reco::PFCandidatePtr(); 
-    else return convertToPFCandidatePtr(pfSpecific().leadPFChargedHadrCand_); 
-  }else
-    return reco::PFCandidatePtr(&leadPFChargedHadrCand_,0);
+const reco::PFCandidatePtr Tau::leadPFChargedHadrCand() const {
+  if (!embeddedLeadPFChargedHadrCand_) {
+    if (pfSpecific_.empty())
+      return reco::PFCandidatePtr();
+    else
+      return convertToPFCandidatePtr(pfSpecific().leadPFChargedHadrCand_);
+  } else
+    return reco::PFCandidatePtr(&leadPFChargedHadrCand_, 0);
 }
 
-const reco::PFCandidatePtr Tau::leadPFNeutralCand() const { 
-  if(!embeddedLeadPFNeutralCand_){
-    if(pfSpecific_.empty()) return reco::PFCandidatePtr();
-    else return convertToPFCandidatePtr(pfSpecific().leadPFNeutralCand_);
-  }else
-    return reco::PFCandidatePtr(&leadPFNeutralCand_,0);
+const reco::PFCandidatePtr Tau::leadPFNeutralCand() const {
+  if (!embeddedLeadPFNeutralCand_) {
+    if (pfSpecific_.empty())
+      return reco::PFCandidatePtr();
+    else
+      return convertToPFCandidatePtr(pfSpecific().leadPFNeutralCand_);
+  } else
+    return reco::PFCandidatePtr(&leadPFNeutralCand_, 0);
 }
 
-const reco::PFCandidatePtr Tau::leadPFCand() const { 
-  if(!embeddedLeadPFCand_){
-    if(pfSpecific_.empty()) return reco::PFCandidatePtr();
+const reco::PFCandidatePtr Tau::leadPFCand() const {
+  if (!embeddedLeadPFCand_) {
+    if (pfSpecific_.empty())
+      return reco::PFCandidatePtr();
     return convertToPFCandidatePtr(pfSpecific().leadPFCand_);
-  }else
-    return reco::PFCandidatePtr(&leadPFCand_,0);
+  } else
+    return reco::PFCandidatePtr(&leadPFCand_, 0);
 }
 
-const std::vector<reco::PFCandidatePtr>& Tau::signalPFCands() const { 
+const std::vector<reco::PFCandidatePtr>& Tau::signalPFCands() const {
   if (embeddedSignalPFCands_) {
-   if (!signalPFCandsTransientPtrs_.isSet()) {
+    if (!signalPFCandsTransientPtrs_.isSet()) {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       aPtrs->reserve(signalPFCands_.size());
       for (unsigned int i = 0; i < signalPFCands_.size(); i++) {
-	aPtrs->push_back(reco::PFCandidatePtr(&signalPFCands_, i) );
+        aPtrs->push_back(reco::PFCandidatePtr(&signalPFCands_, i));
       }
       signalPFCandsTransientPtrs_.set(std::move(aPtrs));
     }
     return *signalPFCandsTransientPtrs_;
   } else {
-    if(pfSpecific_.empty() || pfSpecific().selectedSignalPFCands_.empty() || !pfSpecific().selectedSignalPFCands_.front().isAvailable()){
+    if (pfSpecific_.empty() || pfSpecific().selectedSignalPFCands_.empty() ||
+        !pfSpecific().selectedSignalPFCands_.front().isAvailable()) {
       // this part of code is called when reading from patTuple or miniAOD
       // it returns empty collection in correct format so it can be substituted by reco::Candidates if available
       if (!signalPFCandsTransientPtrs_.isSet()) {
@@ -513,23 +517,25 @@ const std::vector<reco::PFCandidatePtr>& Tau::signalPFCands() const {
         signalPFCandsTransientPtrs_.set(std::move(aPtrs));
       }
       return *signalPFCandsTransientPtrs_;
-    } else return pfSpecific().selectedSignalPFCands_;
+    } else
+      return pfSpecific().selectedSignalPFCands_;
   }
 }
 
 const std::vector<reco::PFCandidatePtr>& Tau::signalPFChargedHadrCands() const {
   if (embeddedSignalPFChargedHadrCands_) {
-   if (!signalPFChargedHadrCandsTransientPtrs_.isSet()) {
-      std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{ new std::vector<reco::PFCandidatePtr>{}};
+    if (!signalPFChargedHadrCandsTransientPtrs_.isSet()) {
+      std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       aPtrs->reserve(signalPFChargedHadrCands_.size());
       for (unsigned int i = 0; i < signalPFChargedHadrCands_.size(); i++) {
-	aPtrs->push_back(reco::PFCandidatePtr(&signalPFChargedHadrCands_, i) );
+        aPtrs->push_back(reco::PFCandidatePtr(&signalPFChargedHadrCands_, i));
       }
       signalPFChargedHadrCandsTransientPtrs_.set(std::move(aPtrs));
     }
     return *signalPFChargedHadrCandsTransientPtrs_;
   } else {
-    if(pfSpecific_.empty() || pfSpecific().selectedSignalPFChargedHadrCands_.empty() || !pfSpecific().selectedSignalPFChargedHadrCands_.front().isAvailable()){
+    if (pfSpecific_.empty() || pfSpecific().selectedSignalPFChargedHadrCands_.empty() ||
+        !pfSpecific().selectedSignalPFChargedHadrCands_.front().isAvailable()) {
       // this part of code is called when reading from patTuple or miniAOD
       // it returns empty collection in correct format so it can be substituted by reco::Candidates if available
       if (!signalPFChargedHadrCandsTransientPtrs_.isSet()) {
@@ -537,23 +543,25 @@ const std::vector<reco::PFCandidatePtr>& Tau::signalPFChargedHadrCands() const {
         signalPFChargedHadrCandsTransientPtrs_.set(std::move(aPtrs));
       }
       return *signalPFChargedHadrCandsTransientPtrs_;
-    } else return pfSpecific().selectedSignalPFChargedHadrCands_;
+    } else
+      return pfSpecific().selectedSignalPFChargedHadrCands_;
   }
-} 
+}
 
 const std::vector<reco::PFCandidatePtr>& Tau::signalPFNeutrHadrCands() const {
   if (embeddedSignalPFNeutralHadrCands_) {
-   if (!signalPFNeutralHadrCandsTransientPtrs_.isSet()) {
+    if (!signalPFNeutralHadrCandsTransientPtrs_.isSet()) {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       aPtrs->reserve(signalPFNeutralHadrCands_.size());
       for (unsigned int i = 0; i < signalPFNeutralHadrCands_.size(); i++) {
-	aPtrs->push_back(reco::PFCandidatePtr(&signalPFNeutralHadrCands_, i) );
+        aPtrs->push_back(reco::PFCandidatePtr(&signalPFNeutralHadrCands_, i));
       }
       signalPFNeutralHadrCandsTransientPtrs_.set(std::move(aPtrs));
     }
     return *signalPFNeutralHadrCandsTransientPtrs_;
   } else {
-    if(pfSpecific_.empty() || pfSpecific().selectedSignalPFNeutrHadrCands_.empty() || !pfSpecific().selectedSignalPFNeutrHadrCands_.front().isAvailable()){
+    if (pfSpecific_.empty() || pfSpecific().selectedSignalPFNeutrHadrCands_.empty() ||
+        !pfSpecific().selectedSignalPFNeutrHadrCands_.front().isAvailable()) {
       // this part of code is called when reading from patTuple or miniAOD
       // it returns empty collection in correct format so it can be substituted by reco::Candidates if available
       if (!signalPFNeutralHadrCandsTransientPtrs_.isSet()) {
@@ -561,23 +569,25 @@ const std::vector<reco::PFCandidatePtr>& Tau::signalPFNeutrHadrCands() const {
         signalPFNeutralHadrCandsTransientPtrs_.set(std::move(aPtrs));
       }
       return *signalPFNeutralHadrCandsTransientPtrs_;
-    } else return pfSpecific().selectedSignalPFNeutrHadrCands_;
+    } else
+      return pfSpecific().selectedSignalPFNeutrHadrCands_;
   }
-} 
+}
 
 const std::vector<reco::PFCandidatePtr>& Tau::signalPFGammaCands() const {
   if (embeddedSignalPFGammaCands_) {
-   if (!signalPFGammaCandsTransientPtrs_.isSet()) {
-      std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{ new std::vector<reco::PFCandidatePtr>{}};
+    if (!signalPFGammaCandsTransientPtrs_.isSet()) {
+      std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       aPtrs->reserve(signalPFGammaCands_.size());
       for (unsigned int i = 0; i < signalPFGammaCands_.size(); i++) {
-	aPtrs->push_back(reco::PFCandidatePtr(&signalPFGammaCands_, i) );
+        aPtrs->push_back(reco::PFCandidatePtr(&signalPFGammaCands_, i));
       }
       signalPFGammaCandsTransientPtrs_.set(std::move(aPtrs));
     }
     return *signalPFGammaCandsTransientPtrs_;
   } else {
-    if(pfSpecific_.empty() || pfSpecific().selectedSignalPFGammaCands_.empty() || !pfSpecific().selectedSignalPFGammaCands_.front().isAvailable()){
+    if (pfSpecific_.empty() || pfSpecific().selectedSignalPFGammaCands_.empty() ||
+        !pfSpecific().selectedSignalPFGammaCands_.front().isAvailable()) {
       // this part of code is called when reading from patTuple or miniAOD
       // it returns empty collection in correct format so it can be substituted by reco::Candidates if available
       if (!signalPFGammaCandsTransientPtrs_.isSet()) {
@@ -585,33 +595,37 @@ const std::vector<reco::PFCandidatePtr>& Tau::signalPFGammaCands() const {
         signalPFGammaCandsTransientPtrs_.set(std::move(aPtrs));
       }
       return *signalPFGammaCandsTransientPtrs_;
-    } else return pfSpecific().selectedSignalPFGammaCands_;
+    } else
+      return pfSpecific().selectedSignalPFGammaCands_;
   }
 }
 
-const std::vector<reco::PFRecoTauChargedHadron> & Tau::signalTauChargedHadronCandidates() const {
-  if(pfSpecific_.empty()) throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
+const std::vector<reco::PFRecoTauChargedHadron>& Tau::signalTauChargedHadronCandidates() const {
+  if (pfSpecific_.empty())
+    throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
   return pfSpecific().signalTauChargedHadronCandidates_;
 }
 
-const std::vector<reco::RecoTauPiZero> & Tau::signalPiZeroCandidates() const {
-  if(pfSpecific_.empty()) throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
+const std::vector<reco::RecoTauPiZero>& Tau::signalPiZeroCandidates() const {
+  if (pfSpecific_.empty())
+    throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
   return pfSpecific().signalPiZeroCandidates_;
 }
 
 const std::vector<reco::PFCandidatePtr>& Tau::isolationPFCands() const {
   if (embeddedIsolationPFCands_) {
-  if (!isolationPFCandsTransientPtrs_.isSet()) {
-      std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{ new std::vector<reco::PFCandidatePtr>{}};
+    if (!isolationPFCandsTransientPtrs_.isSet()) {
+      std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       aPtrs->reserve(isolationPFCands_.size());
       for (unsigned int i = 0; i < isolationPFCands_.size(); i++) {
-	aPtrs->push_back(reco::PFCandidatePtr(&isolationPFCands_, i) );
+        aPtrs->push_back(reco::PFCandidatePtr(&isolationPFCands_, i));
       }
       isolationPFCandsTransientPtrs_.set(std::move(aPtrs));
     }
     return *isolationPFCandsTransientPtrs_;
   } else {
-    if(pfSpecific_.empty() || pfSpecific().selectedIsolationPFCands_.empty() || !pfSpecific().selectedIsolationPFCands_.front().isAvailable()){
+    if (pfSpecific_.empty() || pfSpecific().selectedIsolationPFCands_.empty() ||
+        !pfSpecific().selectedIsolationPFCands_.front().isAvailable()) {
       // this part of code is called when reading from patTuple or miniAOD
       // it returns empty collection in correct format so it can be substituted by reco::Candidates if available
       if (!isolationPFCandsTransientPtrs_.isSet()) {
@@ -619,23 +633,25 @@ const std::vector<reco::PFCandidatePtr>& Tau::isolationPFCands() const {
         isolationPFCandsTransientPtrs_.set(std::move(aPtrs));
       }
       return *isolationPFCandsTransientPtrs_;
-    } else return pfSpecific().selectedIsolationPFCands_;
+    } else
+      return pfSpecific().selectedIsolationPFCands_;
   }
-} 
+}
 
 const std::vector<reco::PFCandidatePtr>& Tau::isolationPFChargedHadrCands() const {
   if (embeddedIsolationPFChargedHadrCands_) {
-   if (!isolationPFChargedHadrCandsTransientPtrs_.isSet()) {
-      std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{ new std::vector<reco::PFCandidatePtr>{}};
+    if (!isolationPFChargedHadrCandsTransientPtrs_.isSet()) {
+      std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       aPtrs->reserve(isolationPFChargedHadrCands_.size());
       for (unsigned int i = 0; i < isolationPFChargedHadrCands_.size(); i++) {
-	aPtrs->push_back(reco::PFCandidatePtr(&isolationPFChargedHadrCands_, i) );
+        aPtrs->push_back(reco::PFCandidatePtr(&isolationPFChargedHadrCands_, i));
       }
       isolationPFChargedHadrCandsTransientPtrs_.set(std::move(aPtrs));
     }
     return *isolationPFChargedHadrCandsTransientPtrs_;
   } else {
-    if(pfSpecific_.empty() || pfSpecific().selectedIsolationPFChargedHadrCands_.empty() || !pfSpecific().selectedIsolationPFChargedHadrCands_.front().isAvailable()){
+    if (pfSpecific_.empty() || pfSpecific().selectedIsolationPFChargedHadrCands_.empty() ||
+        !pfSpecific().selectedIsolationPFChargedHadrCands_.front().isAvailable()) {
       // this part of code is called when reading from patTuple or miniAOD
       // it returns empty collection in correct format so it can be substituted by reco::Candidates if available
       if (!isolationPFChargedHadrCandsTransientPtrs_.isSet()) {
@@ -643,23 +659,25 @@ const std::vector<reco::PFCandidatePtr>& Tau::isolationPFChargedHadrCands() cons
         isolationPFChargedHadrCandsTransientPtrs_.set(std::move(aPtrs));
       }
       return *isolationPFChargedHadrCandsTransientPtrs_;
-    } else return pfSpecific().selectedIsolationPFChargedHadrCands_;
+    } else
+      return pfSpecific().selectedIsolationPFChargedHadrCands_;
   }
 }
 
 const std::vector<reco::PFCandidatePtr>& Tau::isolationPFNeutrHadrCands() const {
   if (embeddedIsolationPFNeutralHadrCands_) {
     if (!isolationPFNeutralHadrCandsTransientPtrs_.isSet()) {
-      std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{ new std::vector<reco::PFCandidatePtr>{}};
+      std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       aPtrs->reserve(isolationPFNeutralHadrCands_.size());
       for (unsigned int i = 0; i < isolationPFNeutralHadrCands_.size(); i++) {
-	aPtrs->push_back(reco::PFCandidatePtr(&isolationPFNeutralHadrCands_, i) );
+        aPtrs->push_back(reco::PFCandidatePtr(&isolationPFNeutralHadrCands_, i));
       }
       isolationPFNeutralHadrCandsTransientPtrs_.set(std::move(aPtrs));
     }
     return *isolationPFNeutralHadrCandsTransientPtrs_;
   } else {
-    if(pfSpecific_.empty() || pfSpecific().selectedIsolationPFNeutrHadrCands_.empty() || !pfSpecific().selectedIsolationPFNeutrHadrCands_.front().isAvailable()){
+    if (pfSpecific_.empty() || pfSpecific().selectedIsolationPFNeutrHadrCands_.empty() ||
+        !pfSpecific().selectedIsolationPFNeutrHadrCands_.front().isAvailable()) {
       // this part of code is called when reading from patTuple or miniAOD
       // it returns empty collection in correct format so it can be substituted by reco::Candidates if available
       if (!isolationPFNeutralHadrCandsTransientPtrs_.isSet()) {
@@ -667,9 +685,10 @@ const std::vector<reco::PFCandidatePtr>& Tau::isolationPFNeutrHadrCands() const 
         isolationPFNeutralHadrCandsTransientPtrs_.set(std::move(aPtrs));
       }
       return *isolationPFNeutralHadrCandsTransientPtrs_;
-    } else return pfSpecific().selectedIsolationPFNeutrHadrCands_;
+    } else
+      return pfSpecific().selectedIsolationPFNeutrHadrCands_;
   }
-} 
+}
 
 const std::vector<reco::PFCandidatePtr>& Tau::isolationPFGammaCands() const {
   if (embeddedIsolationPFGammaCands_) {
@@ -677,13 +696,14 @@ const std::vector<reco::PFCandidatePtr>& Tau::isolationPFGammaCands() const {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       aPtrs->reserve(isolationPFGammaCands_.size());
       for (unsigned int i = 0; i < isolationPFGammaCands_.size(); i++) {
-	aPtrs->push_back(reco::PFCandidatePtr(&isolationPFGammaCands_, i) );
+        aPtrs->push_back(reco::PFCandidatePtr(&isolationPFGammaCands_, i));
       }
       isolationPFGammaCandsTransientPtrs_.set(std::move(aPtrs));
     }
     return *isolationPFGammaCandsTransientPtrs_;
   } else {
-    if(pfSpecific_.empty() || pfSpecific().selectedIsolationPFGammaCands_.empty() || !pfSpecific().selectedIsolationPFGammaCands_.front().isAvailable()){
+    if (pfSpecific_.empty() || pfSpecific().selectedIsolationPFGammaCands_.empty() ||
+        !pfSpecific().selectedIsolationPFGammaCands_.front().isAvailable()) {
       // this part of code is called when reading from patTuple or miniAOD
       // it returns empty collection in correct format so it can be substituted by reco::Candidates if available
       if (!isolationPFGammaCandsTransientPtrs_.isSet()) {
@@ -691,17 +711,20 @@ const std::vector<reco::PFCandidatePtr>& Tau::isolationPFGammaCands() const {
         isolationPFGammaCandsTransientPtrs_.set(std::move(aPtrs));
       }
       return *isolationPFGammaCandsTransientPtrs_;
-    } else return pfSpecific().selectedIsolationPFGammaCands_;
+    } else
+      return pfSpecific().selectedIsolationPFGammaCands_;
   }
 }
 
-const std::vector<reco::PFRecoTauChargedHadron> & Tau::isolationTauChargedHadronCandidates() const {
-  if(pfSpecific_.empty()) throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
+const std::vector<reco::PFRecoTauChargedHadron>& Tau::isolationTauChargedHadronCandidates() const {
+  if (pfSpecific_.empty())
+    throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
   return pfSpecific().isolationTauChargedHadronCandidates_;
 }
 
-const std::vector<reco::RecoTauPiZero> & Tau::isolationPiZeroCandidates() const {
-  if(pfSpecific_.empty()) throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
+const std::vector<reco::RecoTauPiZero>& Tau::isolationPiZeroCandidates() const {
+  if (pfSpecific_.empty())
+    throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
   return pfSpecific().isolationPiZeroCandidates_;
 }
 
@@ -709,136 +732,125 @@ const std::vector<reco::RecoTauPiZero> & Tau::isolationPiZeroCandidates() const 
 /// (copied from DataFormats/PatCandidates/src/Jet.cc)
 
 // initialize the jet to a given JEC level during creation starting from Uncorrected
-void Tau::initializeJEC(unsigned int level, unsigned int set)
-{
+void Tau::initializeJEC(unsigned int level, unsigned int set) {
   currentJECSet(set);
   currentJECLevel(level);
-  setP4(jec_[set].correction(level)*p4());
+  setP4(jec_[set].correction(level) * p4());
 }
 
 /// return true if this jet carries the jet correction factors of a different set, for systematic studies
-int Tau::jecSet(const std::string& set) const
-{
-  for ( std::vector<pat::TauJetCorrFactors>::const_iterator corrFactor = jec_.begin(); 
-	corrFactor != jec_.end(); ++corrFactor ) {
-    if ( corrFactor->jecSet() == set ) return corrFactor-jec_.begin(); 
+int Tau::jecSet(const std::string& set) const {
+  for (std::vector<pat::TauJetCorrFactors>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor) {
+    if (corrFactor->jecSet() == set)
+      return corrFactor - jec_.begin();
   }
   return -1;
 }
 
 /// all available label-names of all sets of jet energy corrections
-const std::vector<std::string> Tau::availableJECSets() const
-{
+const std::vector<std::string> Tau::availableJECSets() const {
   std::vector<std::string> sets;
-  for ( std::vector<pat::TauJetCorrFactors>::const_iterator corrFactor = jec_.begin(); 
-	corrFactor != jec_.end(); ++corrFactor ) {
+  for (std::vector<pat::TauJetCorrFactors>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor) {
     sets.push_back(corrFactor->jecSet());
   }
   return sets;
 }
 
-const std::vector<std::string> Tau::availableJECLevels(const int& set) const
-{
-  return set>=0 ? jec_.at(set).correctionLabels() : std::vector<std::string>();
+const std::vector<std::string> Tau::availableJECLevels(const int& set) const {
+  return set >= 0 ? jec_.at(set).correctionLabels() : std::vector<std::string>();
 }
 
 /// correction factor to the given level for a specific set
 /// of correction factors, starting from the current level
-float Tau::jecFactor(const std::string& level, const std::string& set) const
-{
-  for ( unsigned int idx = 0; idx < jec_.size(); ++idx ) {
-    if ( set.empty() || jec_.at(idx).jecSet() == set ){
-      if ( jec_[idx].jecLevel(level) >= 0 ) 
-	return jecFactor(jec_[idx].jecLevel(level), idx);
+float Tau::jecFactor(const std::string& level, const std::string& set) const {
+  for (unsigned int idx = 0; idx < jec_.size(); ++idx) {
+    if (set.empty() || jec_.at(idx).jecSet() == set) {
+      if (jec_[idx].jecLevel(level) >= 0)
+        return jecFactor(jec_[idx].jecLevel(level), idx);
       else
-	throw cms::Exception("InvalidRequest") 
-	  << "This JEC level " << level << " does not exist. \n";
+        throw cms::Exception("InvalidRequest") << "This JEC level " << level << " does not exist. \n";
     }
   }
-  throw cms::Exception("InvalidRequest") 
-    << "This jet does not carry any jet energy correction factor information \n"
-    << "for a jet energy correction set with label " << set << "\n";
+  throw cms::Exception("InvalidRequest") << "This jet does not carry any jet energy correction factor information \n"
+                                         << "for a jet energy correction set with label " << set << "\n";
 }
 
 /// correction factor to the given level for a specific set
 /// of correction factors, starting from the current level
-float Tau::jecFactor(const unsigned int& level, const unsigned int& set) const
-{
-  if ( !jecSetsAvailable() )
-    throw cms::Exception("InvalidRequest") 
-      << "This jet does not carry any jet energy correction factor information \n";
-  if ( !jecSetAvailable(set) )
-    throw cms::Exception("InvalidRequest") 
-      << "This jet does not carry any jet energy correction factor information \n"
-      << "for a jet energy correction set with index " << set << "\n";
-  return jec_.at(set).correction(level)/jec_.at(currentJECSet_).correction(currentJECLevel_);
+float Tau::jecFactor(const unsigned int& level, const unsigned int& set) const {
+  if (!jecSetsAvailable())
+    throw cms::Exception("InvalidRequest") << "This jet does not carry any jet energy correction factor information \n";
+  if (!jecSetAvailable(set))
+    throw cms::Exception("InvalidRequest") << "This jet does not carry any jet energy correction factor information \n"
+                                           << "for a jet energy correction set with index " << set << "\n";
+  return jec_.at(set).correction(level) / jec_.at(currentJECSet_).correction(currentJECLevel_);
 }
 
 /// copy of the jet with correction factor to target step for
 /// the set of correction factors, which is currently in use
-Tau Tau::correctedTauJet(const std::string& level, const std::string& set) const
-{
+Tau Tau::correctedTauJet(const std::string& level, const std::string& set) const {
   // rescale p4 of the jet; the update of current values is
   // done within the called jecFactor function
-  for ( unsigned int idx = 0; idx < jec_.size(); ++idx ) {
-    if ( set.empty() || jec_.at(idx).jecSet() == set ) {
-      if ( jec_[idx].jecLevel(level) >= 0 ) 
-	return correctedTauJet(jec_[idx].jecLevel(level), idx);
+  for (unsigned int idx = 0; idx < jec_.size(); ++idx) {
+    if (set.empty() || jec_.at(idx).jecSet() == set) {
+      if (jec_[idx].jecLevel(level) >= 0)
+        return correctedTauJet(jec_[idx].jecLevel(level), idx);
       else
-	throw cms::Exception("InvalidRequest") 
-	  << "This JEC level " << level << " does not exist. \n";
+        throw cms::Exception("InvalidRequest") << "This JEC level " << level << " does not exist. \n";
     }
   }
-  throw cms::Exception("InvalidRequest") 
-    << "This JEC set " << set << " does not exist. \n";
+  throw cms::Exception("InvalidRequest") << "This JEC set " << set << " does not exist. \n";
 }
 
 /// copy of the jet with correction factor to target step for
 /// the set of correction factors, which is currently in use
-Tau Tau::correctedTauJet(const unsigned int& level, const unsigned int& set) const
-{
+Tau Tau::correctedTauJet(const unsigned int& level, const unsigned int& set) const {
   Tau correctedTauJet(*this);
   //rescale p4 of the jet
-  correctedTauJet.setP4(jecFactor(level, set)*p4());
+  correctedTauJet.setP4(jecFactor(level, set) * p4());
   // update current level and set
-  correctedTauJet.currentJECSet(set); 
-  correctedTauJet.currentJECLevel(level); 
+  correctedTauJet.currentJECSet(set);
+  correctedTauJet.currentJECLevel(level);
   return correctedTauJet;
 }
 
-
-
 /// ----- Methods returning associated PFCandidates that work on PAT+AOD, PAT+embedding and miniAOD -----
-/// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD 
+/// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD
 // return the leading candidate from signal(PF)ChargedHadrCandPtrs_ collection
 const reco::CandidatePtr Tau::leadChargedHadrCand() const {
-    const reco::PFCandidatePtr leadPF = leadPFChargedHadrCand();
-    if (leadPF.isAvailable() || signalChargedHadrCandPtrs_.isNull()) return leadPF;
-    reco::CandidatePtr ret;
-    for (const reco::CandidatePtr & p : signalChargedHadrCandPtrs_) {
-        if (ret.isNull() || (p->pt() > ret->pt())) ret = p;
-    }
-    return ret;
-
+  const reco::PFCandidatePtr leadPF = leadPFChargedHadrCand();
+  if (leadPF.isAvailable() || signalChargedHadrCandPtrs_.isNull())
+    return leadPF;
+  reco::CandidatePtr ret;
+  for (const reco::CandidatePtr& p : signalChargedHadrCandPtrs_) {
+    if (ret.isNull() || (p->pt() > ret->pt()))
+      ret = p;
+  }
+  return ret;
 }
 
-/// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD 
+/// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD
 const reco::CandidatePtr Tau::leadNeutralCand() const {
-    const reco::PFCandidatePtr leadPF = leadPFNeutralCand();
-    if (leadPF.isAvailable() || signalNeutralHadrCandPtrs_.isNull()) return leadPF;
-    reco::CandidatePtr ret;
-    for (const reco::CandidatePtr & p : signalNeutralHadrCandPtrs_) {
-        if (ret.isNull() || (p->pt() > ret->pt())) ret = p;
-    }
-    return ret;
-
+  const reco::PFCandidatePtr leadPF = leadPFNeutralCand();
+  if (leadPF.isAvailable() || signalNeutralHadrCandPtrs_.isNull())
+    return leadPF;
+  reco::CandidatePtr ret;
+  for (const reco::CandidatePtr& p : signalNeutralHadrCandPtrs_) {
+    if (ret.isNull() || (p->pt() > ret->pt()))
+      ret = p;
+  }
+  return ret;
 }
 
-/// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD 
+/// return the PFCandidate if available (reference or embedded), or the PackedPFCandidate on miniAOD
 const reco::CandidatePtr Tau::leadCand() const {
-    const reco::PFCandidatePtr leadPF = leadPFCand();
-    if (leadPF.isAvailable() || !Tau::ExistSignalCands()) return leadPF;
-    else return Tau::signalCands()[0];
+  const reco::PFCandidatePtr leadPF = leadPFCand();
+  if (leadPF.isAvailable() || !Tau::ExistSignalCands())
+    return leadPF;
+  else
+    return Tau::signalCands()[0];
 }
 
 /// check that there is at least one non-zero collection of candidate ptrs
@@ -848,158 +860,190 @@ bool Tau::ExistSignalCands() const {
 }
 
 bool Tau::ExistIsolationCands() const {
-  return !(isolationChargedHadrCandPtrs_.isNull() && isolationNeutralHadrCandPtrs_.isNull() && isolationGammaCandPtrs_.isNull());
+  return !(isolationChargedHadrCandPtrs_.isNull() && isolationNeutralHadrCandPtrs_.isNull() &&
+           isolationGammaCandPtrs_.isNull());
 }
 
 /// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
-/// note that the vector is returned by value. 
+/// note that the vector is returned by value.
 
 reco::CandidatePtrVector Tau::signalCands() const {
-    std::vector<reco::PFCandidatePtr> r0 = signalPFCands();
-    reco::CandidatePtrVector ret;
-    if(!Tau::ExistSignalCands() || (!r0.empty() && r0.front().isAvailable())) {
-      for (const auto & p : r0) ret.push_back(p);
-      return ret;
-    } else {
-      /// the isolationCands pointers are not saved in miniAOD, so the collection is created dynamically by glueing together 3 sub-collection and re-ordering 
-      reco::CandidatePtrVector ret2;
-      std::vector<std::pair<float,size_t> > pt_index;
-      size_t index=0;
-      for (const auto & p : signalChargedHadrCandPtrs_){ ret2.push_back(p); pt_index.push_back(std::make_pair(p->pt(),index)); index++;}
-      for (const auto & p : signalNeutralHadrCandPtrs_){ ret2.push_back(p); pt_index.push_back(std::make_pair(p->pt(),index)); index++;}
-      for (const auto & p : signalGammaCandPtrs_){ ret2.push_back(p); pt_index.push_back(std::make_pair(p->pt(),index)); index++;}
-      std::sort(pt_index.begin(),pt_index.end(),
-	        boost::bind(&std::pair<float,size_t>::first,_1) >
-		boost::bind(&std::pair<float,size_t>::first,_2));
-      for( const auto & p : pt_index){
-	ret.push_back(ret2[p.second]);
-      }
-      return ret;
-    }
-}
-
-/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-/// note that the vector is returned by value.
-reco::CandidatePtrVector Tau::signalChargedHadrCands() const {
-   std::vector<reco::PFCandidatePtr> r0 = signalPFChargedHadrCands();
-   if(signalChargedHadrCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
-        reco::CandidatePtrVector ret;
-        for (const auto & p : r0) ret.push_back(p);
-	return ret;
-   } else {
-        return signalChargedHadrCandPtrs_;
-   }
-}
-
-
-/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-/// note that the vector is returned by value.
-reco::CandidatePtrVector Tau::signalNeutrHadrCands() const {
-   std::vector<reco::PFCandidatePtr> r0 = signalPFNeutrHadrCands();
-   if(signalNeutralHadrCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
-        reco::CandidatePtrVector ret;
-        for (const auto & p : r0) ret.push_back(p);
-	return ret;
-   } else {
-        return signalNeutralHadrCandPtrs_;
-   }
-}
-
-/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
-/// note that the vector is returned by value.
-reco::CandidatePtrVector Tau::signalGammaCands() const {
-   std::vector<reco::PFCandidatePtr> r0 = signalPFGammaCands();
-   if(signalGammaCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
-        reco::CandidatePtrVector ret;
-        for (const auto & p : r0) ret.push_back(p);
-	return ret;
-   } else {
-        return signalGammaCandPtrs_;
-   }
-}
-
-/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
-/// note that the vector is returned by value. 
-reco::CandidatePtrVector Tau::isolationCands() const {
-  std::vector<reco::PFCandidatePtr> r0 = isolationPFCands();
+  std::vector<reco::PFCandidatePtr> r0 = signalPFCands();
   reco::CandidatePtrVector ret;
-  if(!Tau::ExistIsolationCands() || (!r0.empty() && r0.front().isAvailable())) {
-    for (const auto & p : r0) ret.push_back(p);
+  if (!Tau::ExistSignalCands() || (!r0.empty() && r0.front().isAvailable())) {
+    for (const auto& p : r0)
+      ret.push_back(p);
     return ret;
   } else {
     /// the isolationCands pointers are not saved in miniAOD, so the collection is created dynamically by glueing together 3 sub-collection and re-ordering
     reco::CandidatePtrVector ret2;
-    std::vector<std::pair<float,size_t> > pt_index;
-    size_t index=0;
-    for (const auto & p : isolationChargedHadrCandPtrs_){ ret2.push_back(p); pt_index.push_back(std::make_pair(p->pt(),index)); index++;}
-    for (const auto & p : isolationNeutralHadrCandPtrs_){ ret2.push_back(p); pt_index.push_back(std::make_pair(p->pt(),index)); index++;}
-    for (const auto & p : isolationGammaCandPtrs_){ ret2.push_back(p); pt_index.push_back(std::make_pair(p->pt(),index)); index++;}
-    std::sort(pt_index.begin(),pt_index.end(),
-	      boost::bind(&std::pair<float,size_t>::first,_1) >
-	      boost::bind(&std::pair<float,size_t>::first,_2));
-    for( const auto & p : pt_index){
+    std::vector<std::pair<float, size_t> > pt_index;
+    size_t index = 0;
+    for (const auto& p : signalChargedHadrCandPtrs_) {
+      ret2.push_back(p);
+      pt_index.push_back(std::make_pair(p->pt(), index));
+      index++;
+    }
+    for (const auto& p : signalNeutralHadrCandPtrs_) {
+      ret2.push_back(p);
+      pt_index.push_back(std::make_pair(p->pt(), index));
+      index++;
+    }
+    for (const auto& p : signalGammaCandPtrs_) {
+      ret2.push_back(p);
+      pt_index.push_back(std::make_pair(p->pt(), index));
+      index++;
+    }
+    std::sort(pt_index.begin(),
+              pt_index.end(),
+              boost::bind(&std::pair<float, size_t>::first, _1) > boost::bind(&std::pair<float, size_t>::first, _2));
+    for (const auto& p : pt_index) {
       ret.push_back(ret2[p.second]);
     }
     return ret;
   }
 }
 
-/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
+/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+/// note that the vector is returned by value.
+reco::CandidatePtrVector Tau::signalChargedHadrCands() const {
+  std::vector<reco::PFCandidatePtr> r0 = signalPFChargedHadrCands();
+  if (signalChargedHadrCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
+    reco::CandidatePtrVector ret;
+    for (const auto& p : r0)
+      ret.push_back(p);
+    return ret;
+  } else {
+    return signalChargedHadrCandPtrs_;
+  }
+}
+
+/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+/// note that the vector is returned by value.
+reco::CandidatePtrVector Tau::signalNeutrHadrCands() const {
+  std::vector<reco::PFCandidatePtr> r0 = signalPFNeutrHadrCands();
+  if (signalNeutralHadrCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
+    reco::CandidatePtrVector ret;
+    for (const auto& p : r0)
+      ret.push_back(p);
+    return ret;
+  } else {
+    return signalNeutralHadrCandPtrs_;
+  }
+}
+
+/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+/// note that the vector is returned by value.
+reco::CandidatePtrVector Tau::signalGammaCands() const {
+  std::vector<reco::PFCandidatePtr> r0 = signalPFGammaCands();
+  if (signalGammaCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
+    reco::CandidatePtrVector ret;
+    for (const auto& p : r0)
+      ret.push_back(p);
+    return ret;
+  } else {
+    return signalGammaCandPtrs_;
+  }
+}
+
+/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
+/// note that the vector is returned by value.
+reco::CandidatePtrVector Tau::isolationCands() const {
+  std::vector<reco::PFCandidatePtr> r0 = isolationPFCands();
+  reco::CandidatePtrVector ret;
+  if (!Tau::ExistIsolationCands() || (!r0.empty() && r0.front().isAvailable())) {
+    for (const auto& p : r0)
+      ret.push_back(p);
+    return ret;
+  } else {
+    /// the isolationCands pointers are not saved in miniAOD, so the collection is created dynamically by glueing together 3 sub-collection and re-ordering
+    reco::CandidatePtrVector ret2;
+    std::vector<std::pair<float, size_t> > pt_index;
+    size_t index = 0;
+    for (const auto& p : isolationChargedHadrCandPtrs_) {
+      ret2.push_back(p);
+      pt_index.push_back(std::make_pair(p->pt(), index));
+      index++;
+    }
+    for (const auto& p : isolationNeutralHadrCandPtrs_) {
+      ret2.push_back(p);
+      pt_index.push_back(std::make_pair(p->pt(), index));
+      index++;
+    }
+    for (const auto& p : isolationGammaCandPtrs_) {
+      ret2.push_back(p);
+      pt_index.push_back(std::make_pair(p->pt(), index));
+      index++;
+    }
+    std::sort(pt_index.begin(),
+              pt_index.end(),
+              boost::bind(&std::pair<float, size_t>::first, _1) > boost::bind(&std::pair<float, size_t>::first, _2));
+    for (const auto& p : pt_index) {
+      ret.push_back(ret2[p.second]);
+    }
+    return ret;
+  }
+}
+
+/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
 /// note that the vector is returned by value.
 reco::CandidatePtrVector Tau::isolationChargedHadrCands() const {
-   std::vector<reco::PFCandidatePtr> r0 = isolationPFChargedHadrCands();
-   if(isolationChargedHadrCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
-        reco::CandidatePtrVector ret;
-        for (const auto & p : r0) ret.push_back(p);
-	return ret;
-   } else {
-        return isolationChargedHadrCandPtrs_;
-   }
+  std::vector<reco::PFCandidatePtr> r0 = isolationPFChargedHadrCands();
+  if (isolationChargedHadrCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
+    reco::CandidatePtrVector ret;
+    for (const auto& p : r0)
+      ret.push_back(p);
+    return ret;
+  } else {
+    return isolationChargedHadrCandPtrs_;
+  }
 }
 
-/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
+/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
 /// note that the vector is returned by value.
 reco::CandidatePtrVector Tau::isolationNeutrHadrCands() const {
-   reco::CandidatePtrVector ret;
-   std::vector<reco::PFCandidatePtr> r0 = isolationPFNeutrHadrCands();
-   if(isolationNeutralHadrCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
-        reco::CandidatePtrVector ret;
-        for (const auto & p : r0) ret.push_back(p);
-	return ret;
-   } else {
-        return isolationNeutralHadrCandPtrs_;
-   }
+  reco::CandidatePtrVector ret;
+  std::vector<reco::PFCandidatePtr> r0 = isolationPFNeutrHadrCands();
+  if (isolationNeutralHadrCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
+    reco::CandidatePtrVector ret;
+    for (const auto& p : r0)
+      ret.push_back(p);
+    return ret;
+  } else {
+    return isolationNeutralHadrCandPtrs_;
+  }
 }
 
-/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD 
+/// return the PFCandidates if available (reference or embedded), or the PackedPFCandidate on miniAOD
 /// note that the vector is returned by value.
 reco::CandidatePtrVector Tau::isolationGammaCands() const {
-   std::vector<reco::PFCandidatePtr> r0 = isolationPFGammaCands();
-   if(isolationGammaCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
-        reco::CandidatePtrVector ret;
-        for (const auto & p : r0) ret.push_back(p);
-	return ret;
-   } else {
-        return isolationGammaCandPtrs_;
-   }
+  std::vector<reco::PFCandidatePtr> r0 = isolationPFGammaCands();
+  if (isolationGammaCandPtrs_.isNull() || (!r0.empty() && r0.front().isAvailable())) {
+    reco::CandidatePtrVector ret;
+    for (const auto& p : r0)
+      ret.push_back(p);
+    return ret;
+  } else {
+    return isolationGammaCandPtrs_;
+  }
 }
 
-
-
-/// ----- Top Projection business ------- 
+/// ----- Top Projection business -------
 /// get the number of non-null PFCandidates
 size_t Tau::numberOfSourceCandidatePtrs() const {
-  if (Tau::ExistSignalCands()) return Tau::signalCands().size();
-  else if(pfSpecific_.empty()) return 0; 
-  else return pfSpecific().selectedSignalPFCands_.size();
+  if (Tau::ExistSignalCands())
+    return Tau::signalCands().size();
+  else if (pfSpecific_.empty())
+    return 0;
+  else
+    return pfSpecific().selectedSignalPFCands_.size();
 }
 /// get the source candidate pointer with index i
-reco::CandidatePtr Tau::sourceCandidatePtr( size_type i ) const {
-  if (Tau::ExistSignalCands()) return Tau::signalCands()[i];
-  else if(pfSpecific_.empty()) return reco::CandidatePtr();
-  else return pfSpecific().selectedSignalPFCands_[i];
+reco::CandidatePtr Tau::sourceCandidatePtr(size_type i) const {
+  if (Tau::ExistSignalCands())
+    return Tau::signalCands()[i];
+  else if (pfSpecific_.empty())
+    return reco::CandidatePtr();
+  else
+    return pfSpecific().selectedSignalPFCands_[i];
 }
-
-
-
-

--- a/DataFormats/PatCandidates/src/TauCaloSpecific.cc
+++ b/DataFormats/PatCandidates/src/TauCaloSpecific.cc
@@ -1,16 +1,15 @@
 #include "DataFormats/PatCandidates/interface/TauCaloSpecific.h"
 
-pat::tau::TauCaloSpecific::TauCaloSpecific(const reco::CaloTau &tau) :
-    CaloTauTagInfoRef_(tau.caloTauTagInfoRef()),
-    leadTracksignedSipt_(tau.leadTracksignedSipt()),
-    leadTrackHCAL3x3hitsEtSum_(tau.leadTrackHCAL3x3hitsEtSum()),
-    leadTrackHCAL3x3hottesthitDEta_(tau.leadTrackHCAL3x3hottesthitDEta()),
-    signalTracksInvariantMass_(tau.signalTracksInvariantMass()),
-    TracksInvariantMass_(tau.TracksInvariantMass()), 
-    isolationTracksPtSum_(tau.isolationTracksPtSum()),
-    isolationECALhitsEtSum_(tau.isolationECALhitsEtSum()),
-    maximumHCALhitEt_(tau.maximumHCALhitEt())
-{
+pat::tau::TauCaloSpecific::TauCaloSpecific(const reco::CaloTau &tau)
+    : CaloTauTagInfoRef_(tau.caloTauTagInfoRef()),
+      leadTracksignedSipt_(tau.leadTracksignedSipt()),
+      leadTrackHCAL3x3hitsEtSum_(tau.leadTrackHCAL3x3hitsEtSum()),
+      leadTrackHCAL3x3hottesthitDEta_(tau.leadTrackHCAL3x3hottesthitDEta()),
+      signalTracksInvariantMass_(tau.signalTracksInvariantMass()),
+      TracksInvariantMass_(tau.TracksInvariantMass()),
+      isolationTracksPtSum_(tau.isolationTracksPtSum()),
+      isolationECALhitsEtSum_(tau.isolationECALhitsEtSum()),
+      maximumHCALhitEt_(tau.maximumHCALhitEt()) {
   p4Jet_ = tau.caloTauTagInfoRef()->calojetRef()->p4();
   reco::Jet::EtaPhiMoments etaPhiStatistics = tau.caloTauTagInfoRef()->calojetRef()->etaPhiStatistics();
   etaetaMoment_ = etaPhiStatistics.etaEtaMoment;

--- a/DataFormats/PatCandidates/src/TauJetCorrFactors.cc
+++ b/DataFormats/PatCandidates/src/TauJetCorrFactors.cc
@@ -10,64 +10,53 @@
 using namespace pat;
 
 TauJetCorrFactors::TauJetCorrFactors(const std::string& label, const std::vector<CorrectionFactor>& jec)
-  : label_(label), 
-    jec_(jec)
-{}
+    : label_(label), jec_(jec) {}
 
-int  
-TauJetCorrFactors::jecLevel(const std::string& level) const
-{
-  for ( std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); 
-	corrFactor != jec_.end(); ++corrFactor ) {
-    if ( corrFactor->first == level ) return (corrFactor-jec_.begin());
+int TauJetCorrFactors::jecLevel(const std::string& level) const {
+  for (std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor) {
+    if (corrFactor->first == level)
+      return (corrFactor - jec_.begin());
   }
   return -1;
 }
 
-float 
-TauJetCorrFactors::correction(unsigned int level) const 
-{
-  if ( !(level < jec_.size()) ) {
-    throw cms::Exception("InvalidRequest") 
-      << "You try to call a jet energy correction level wich does not exist. \n"
-      << "Available jet energy correction levels are:                        \n" 
-      << correctionLabelString();    
+float TauJetCorrFactors::correction(unsigned int level) const {
+  if (!(level < jec_.size())) {
+    throw cms::Exception("InvalidRequest") << "You try to call a jet energy correction level wich does not exist. \n"
+                                           << "Available jet energy correction levels are:                        \n"
+                                           << correctionLabelString();
   }
   return jec_.at(level).second;
 }
 
-std::string 
-TauJetCorrFactors::correctionLabelString() const 
-{
+std::string TauJetCorrFactors::correctionLabelString() const {
   std::string labels;
-  for ( std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); 
-	corrFactor != jec_.end(); ++corrFactor ) {
-    std::stringstream idx; idx << (corrFactor-jec_.begin());
+  for (std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor) {
+    std::stringstream idx;
+    idx << (corrFactor - jec_.begin());
     labels.append(idx.str()).append(" ").append(corrFactor->first).append("\n");
   }
   return labels;
 }
 
-std::vector<std::string> 
-TauJetCorrFactors::correctionLabels() const 
-{
+std::vector<std::string> TauJetCorrFactors::correctionLabels() const {
   std::vector<std::string> labels;
-  for ( std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); 
-	corrFactor != jec_.end(); ++corrFactor ) {
+  for (std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor) {
     labels.push_back(corrFactor->first);
   }
   return labels;
 }
 
-void
-TauJetCorrFactors::print() const
-{
+void TauJetCorrFactors::print() const {
   edm::LogInfo message("JetCorrFactors");
-  for ( std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); 
-	corrFactor != jec_.end(); ++corrFactor ) {
-    unsigned int corrFactorIdx = corrFactor-jec_.begin();
+  for (std::vector<CorrectionFactor>::const_iterator corrFactor = jec_.begin(); corrFactor != jec_.end();
+       ++corrFactor) {
+    unsigned int corrFactorIdx = corrFactor - jec_.begin();
     message << std::setw(3) << corrFactorIdx << "  " << corrFactor->first;
-    message << std::setw(10) << correction (corrFactor-jec_.begin()); 
+    message << std::setw(10) << correction(corrFactor - jec_.begin());
     message << "\n";
   }
 }

--- a/DataFormats/PatCandidates/src/TauPFEssential.cc
+++ b/DataFormats/PatCandidates/src/TauPFEssential.cc
@@ -2,27 +2,27 @@
 
 #include "DataFormats/JetReco/interface/Jet.h"
 
-pat::tau::TauPFEssential::TauPFEssential(const reco::PFTau& tau) :
-    p4Jet_(reco::Candidate::LorentzVector()),
-    p4CorrJet_(reco::Candidate::LorentzVector()),
-    decayMode_(tau.decayMode()),
-    dxy_(0.),
-    dxy_error_(1.e+3),
-    hasSV_(false),
-    ip3d_(0.),
-    ip3d_error_(1.e+3),
-    ecalEnergy_(0.),
-    hcalEnergy_(0.),
-    leadingTrackNormChi2_(1.e+3),
-    phiAtEcalEntrance_(0.),
-    etaAtEcalEntrance_(0.),
-    ecalEnergyLeadChargedHadrCand_(0.),
-    hcalEnergyLeadChargedHadrCand_(0.),
-    etaAtEcalEntranceLeadChargedCand_(0.),
-    ptLeadChargedCand_(0.),
-    emFraction_(0.)
-{
-  if ( tau.jetRef().isAvailable() && tau.jetRef().isNonnull() ) { // CV: add protection to ease transition to new CMSSW 4_2_x RecoTauTags
+pat::tau::TauPFEssential::TauPFEssential(const reco::PFTau& tau)
+    : p4Jet_(reco::Candidate::LorentzVector()),
+      p4CorrJet_(reco::Candidate::LorentzVector()),
+      decayMode_(tau.decayMode()),
+      dxy_(0.),
+      dxy_error_(1.e+3),
+      hasSV_(false),
+      ip3d_(0.),
+      ip3d_error_(1.e+3),
+      ecalEnergy_(0.),
+      hcalEnergy_(0.),
+      leadingTrackNormChi2_(1.e+3),
+      phiAtEcalEntrance_(0.),
+      etaAtEcalEntrance_(0.),
+      ecalEnergyLeadChargedHadrCand_(0.),
+      hcalEnergyLeadChargedHadrCand_(0.),
+      etaAtEcalEntranceLeadChargedCand_(0.),
+      ptLeadChargedCand_(0.),
+      emFraction_(0.) {
+  if (tau.jetRef().isAvailable() &&
+      tau.jetRef().isNonnull()) {  // CV: add protection to ease transition to new CMSSW 4_2_x RecoTauTags
     p4Jet_ = tau.jetRef()->p4();
   }
 }

--- a/DataFormats/PatCandidates/src/TauPFSpecific.cc
+++ b/DataFormats/PatCandidates/src/TauPFSpecific.cc
@@ -2,53 +2,53 @@
 
 #include "DataFormats/JetReco/interface/Jet.h"
 
-pat::tau::TauPFSpecific::TauPFSpecific(const reco::PFTau& tau) :
-    // reference to PFJet from which PFTau was made
-    pfJetRef_(tau.jetRef()),
-    // Leading track/charged candidate
-    leadPFChargedHadrCand_(tau.leadPFChargedHadrCand()),    
-    leadPFChargedHadrCandsignedSipt_(tau.leadPFChargedHadrCandsignedSipt()),
-    // Leading neutral candidate
-    leadPFNeutralCand_(tau.leadPFNeutralCand()), 
-    // Leading charged or neutral candidate
-    leadPFCand_(tau.leadPFCand()), 
-    // Signal cone
-    selectedSignalPFCands_(tau.signalPFCands()), 
-    selectedSignalPFChargedHadrCands_(tau.signalPFChargedHadrCands()), 
-    selectedSignalPFNeutrHadrCands_(tau.signalPFNeutrHadrCands()), 
-    selectedSignalPFGammaCands_(tau.signalPFGammaCands()),
-    signalTauChargedHadronCandidates_(tau.signalTauChargedHadronCandidates()),
-    signalPiZeroCandidates_(tau.signalPiZeroCandidates()),
-    // Isolation cone
-    selectedIsolationPFCands_(tau.isolationPFCands()), 
-    selectedIsolationPFChargedHadrCands_(tau.isolationPFChargedHadrCands()), 
-    selectedIsolationPFNeutrHadrCands_(tau.isolationPFNeutrHadrCands()), 
-    selectedIsolationPFGammaCands_(tau.isolationPFGammaCands()),
-    isolationTauChargedHadronCandidates_(tau.isolationTauChargedHadronCandidates()),
-    isolationPiZeroCandidates_(tau.isolationPiZeroCandidates()),
-    isolationPFChargedHadrCandsPtSum_(tau.isolationPFChargedHadrCandsPtSum()),    
-    isolationPFGammaCandsEtSum_(tau.isolationPFGammaCandsEtSum()),
-    // Other useful variables 
-    maximumHCALPFClusterEt_(tau.maximumHCALPFClusterEt()),
-    emFraction_(tau.emFraction()),
-    hcalTotOverPLead_(tau.hcalTotOverPLead()),
-    hcalMaxOverPLead_(tau.hcalMaxOverPLead()),
-    hcal3x3OverPLead_(tau.hcal3x3OverPLead()),
-    ecalStripSumEOverPLead_(tau.ecalStripSumEOverPLead()),
-    bremsRecoveryEOverPLead_(tau.bremsRecoveryEOverPLead()),
-    // Electron rejection variables
-    electronPreIDTrack_(tau.electronPreIDTrack()),
-    electronPreIDOutput_(tau.electronPreIDOutput()),
-    electronPreIDDecision_(tau.electronPreIDDecision()),
-    // Muon rejection variables
-    caloComp_(tau.caloComp()),
-    segComp_(tau.segComp()),
-    muonDecision_(tau.muonDecision()),
-    // Variables specific to dynamic strip reconstruction
-    bendCorrMass_(tau.bendCorrMass()),
-    signalConeSize_(tau.signalConeSize())
-{
-  if ( tau.jetRef().isAvailable() && tau.jetRef().isNonnull() ) { // CV: add protection to ease transition to new CMSSW 4_2_x RecoTauTags
+pat::tau::TauPFSpecific::TauPFSpecific(const reco::PFTau& tau)
+    :  // reference to PFJet from which PFTau was made
+      pfJetRef_(tau.jetRef()),
+      // Leading track/charged candidate
+      leadPFChargedHadrCand_(tau.leadPFChargedHadrCand()),
+      leadPFChargedHadrCandsignedSipt_(tau.leadPFChargedHadrCandsignedSipt()),
+      // Leading neutral candidate
+      leadPFNeutralCand_(tau.leadPFNeutralCand()),
+      // Leading charged or neutral candidate
+      leadPFCand_(tau.leadPFCand()),
+      // Signal cone
+      selectedSignalPFCands_(tau.signalPFCands()),
+      selectedSignalPFChargedHadrCands_(tau.signalPFChargedHadrCands()),
+      selectedSignalPFNeutrHadrCands_(tau.signalPFNeutrHadrCands()),
+      selectedSignalPFGammaCands_(tau.signalPFGammaCands()),
+      signalTauChargedHadronCandidates_(tau.signalTauChargedHadronCandidates()),
+      signalPiZeroCandidates_(tau.signalPiZeroCandidates()),
+      // Isolation cone
+      selectedIsolationPFCands_(tau.isolationPFCands()),
+      selectedIsolationPFChargedHadrCands_(tau.isolationPFChargedHadrCands()),
+      selectedIsolationPFNeutrHadrCands_(tau.isolationPFNeutrHadrCands()),
+      selectedIsolationPFGammaCands_(tau.isolationPFGammaCands()),
+      isolationTauChargedHadronCandidates_(tau.isolationTauChargedHadronCandidates()),
+      isolationPiZeroCandidates_(tau.isolationPiZeroCandidates()),
+      isolationPFChargedHadrCandsPtSum_(tau.isolationPFChargedHadrCandsPtSum()),
+      isolationPFGammaCandsEtSum_(tau.isolationPFGammaCandsEtSum()),
+      // Other useful variables
+      maximumHCALPFClusterEt_(tau.maximumHCALPFClusterEt()),
+      emFraction_(tau.emFraction()),
+      hcalTotOverPLead_(tau.hcalTotOverPLead()),
+      hcalMaxOverPLead_(tau.hcalMaxOverPLead()),
+      hcal3x3OverPLead_(tau.hcal3x3OverPLead()),
+      ecalStripSumEOverPLead_(tau.ecalStripSumEOverPLead()),
+      bremsRecoveryEOverPLead_(tau.bremsRecoveryEOverPLead()),
+      // Electron rejection variables
+      electronPreIDTrack_(tau.electronPreIDTrack()),
+      electronPreIDOutput_(tau.electronPreIDOutput()),
+      electronPreIDDecision_(tau.electronPreIDDecision()),
+      // Muon rejection variables
+      caloComp_(tau.caloComp()),
+      segComp_(tau.segComp()),
+      muonDecision_(tau.muonDecision()),
+      // Variables specific to dynamic strip reconstruction
+      bendCorrMass_(tau.bendCorrMass()),
+      signalConeSize_(tau.signalConeSize()) {
+  if (tau.jetRef().isAvailable() &&
+      tau.jetRef().isNonnull()) {  // CV: add protection to ease transition to new CMSSW 4_2_x RecoTauTags
     reco::Jet::EtaPhiMoments etaPhiStatistics = tau.jetRef()->etaPhiStatistics();
     etaetaMoment_ = etaPhiStatistics.etaEtaMoment;
     phiphiMoment_ = etaPhiStatistics.phiPhiMoment;

--- a/DataFormats/PatCandidates/src/TriggerAlgorithm.cc
+++ b/DataFormats/PatCandidates/src/TriggerAlgorithm.cc
@@ -1,89 +1,91 @@
 //
 //
 
-
 #include "DataFormats/PatCandidates/interface/TriggerAlgorithm.h"
-
 
 using namespace pat;
 
-
 // Constructors and Destructor
 
-
 // Default constructor
-TriggerAlgorithm::TriggerAlgorithm() :
-  name_(),
-  alias_(),
-  logic_(),
-  tech_(),
-  bit_(),
-  gtlResult_(),
-  prescale_(),
-  mask_(),
-  decisionBeforeMask_(),
-  decisionAfterMask_()
-{
+TriggerAlgorithm::TriggerAlgorithm()
+    : name_(),
+      alias_(),
+      logic_(),
+      tech_(),
+      bit_(),
+      gtlResult_(),
+      prescale_(),
+      mask_(),
+      decisionBeforeMask_(),
+      decisionAfterMask_() {
   conditionKeys_.clear();
 }
-
 
 // Constructor from algorithm name only
-TriggerAlgorithm::TriggerAlgorithm( const std::string & name ) :
-  name_( name ),
-  alias_(),
-  logic_(),
-  tech_(),
-  bit_(),
-  gtlResult_(),
-  prescale_(),
-  mask_(),
-  decisionBeforeMask_(),
-  decisionAfterMask_()
-{
+TriggerAlgorithm::TriggerAlgorithm(const std::string& name)
+    : name_(name),
+      alias_(),
+      logic_(),
+      tech_(),
+      bit_(),
+      gtlResult_(),
+      prescale_(),
+      mask_(),
+      decisionBeforeMask_(),
+      decisionAfterMask_() {
   conditionKeys_.clear();
 }
-
 
 // Constructors from values
-TriggerAlgorithm::TriggerAlgorithm( const std::string & name, const std::string & alias, bool tech, unsigned bit, unsigned prescale, bool mask, bool decisionBeforeMask, bool decisionAfterMask ) :
-  name_( name ),
-  alias_( alias),
-  logic_(),
-  tech_( tech ),
-  bit_( bit ),
-  gtlResult_(),
-  prescale_( prescale ),
-  mask_( mask ),
-  decisionBeforeMask_( decisionBeforeMask ),
-  decisionAfterMask_( decisionAfterMask )
-{
+TriggerAlgorithm::TriggerAlgorithm(const std::string& name,
+                                   const std::string& alias,
+                                   bool tech,
+                                   unsigned bit,
+                                   unsigned prescale,
+                                   bool mask,
+                                   bool decisionBeforeMask,
+                                   bool decisionAfterMask)
+    : name_(name),
+      alias_(alias),
+      logic_(),
+      tech_(tech),
+      bit_(bit),
+      gtlResult_(),
+      prescale_(prescale),
+      mask_(mask),
+      decisionBeforeMask_(decisionBeforeMask),
+      decisionAfterMask_(decisionAfterMask) {
   conditionKeys_.clear();
 }
-TriggerAlgorithm::TriggerAlgorithm( const std::string & name, const std::string & alias, bool tech, unsigned bit, bool gtlResult, unsigned prescale, bool mask, bool decisionBeforeMask, bool decisionAfterMask ) :
-  name_( name ),
-  alias_( alias),
-  logic_(),
-  tech_( tech ),
-  bit_( bit ),
-  gtlResult_( gtlResult ),
-  prescale_( prescale ),
-  mask_( mask ),
-  decisionBeforeMask_( decisionBeforeMask ),
-  decisionAfterMask_( decisionAfterMask )
-{
+TriggerAlgorithm::TriggerAlgorithm(const std::string& name,
+                                   const std::string& alias,
+                                   bool tech,
+                                   unsigned bit,
+                                   bool gtlResult,
+                                   unsigned prescale,
+                                   bool mask,
+                                   bool decisionBeforeMask,
+                                   bool decisionAfterMask)
+    : name_(name),
+      alias_(alias),
+      logic_(),
+      tech_(tech),
+      bit_(bit),
+      gtlResult_(gtlResult),
+      prescale_(prescale),
+      mask_(mask),
+      decisionBeforeMask_(decisionBeforeMask),
+      decisionAfterMask_(decisionAfterMask) {
   conditionKeys_.clear();
 }
-
 
 // Methods
 
-
 // Checks, if a certain trigger condition collection index is assigned
-bool TriggerAlgorithm::hasConditionKey( unsigned conditionKey ) const
-{
-  for ( size_t iO = 0; iO < conditionKeys().size(); ++iO ) {
-    if ( conditionKeys().at( iO ) == conditionKey ) {
+bool TriggerAlgorithm::hasConditionKey(unsigned conditionKey) const {
+  for (size_t iO = 0; iO < conditionKeys().size(); ++iO) {
+    if (conditionKeys().at(iO) == conditionKey) {
       return true;
     }
   }

--- a/DataFormats/PatCandidates/src/TriggerCondition.cc
+++ b/DataFormats/PatCandidates/src/TriggerCondition.cc
@@ -1,81 +1,56 @@
 //
 //
 
-
 #include "DataFormats/PatCandidates/interface/TriggerCondition.h"
-
 
 using namespace pat;
 
-
 // Constructors and Destructor
 
-
 // Default constructor
-TriggerCondition::TriggerCondition() :
-  name_()
-, accept_()
-, category_()
-, type_()
-{
+TriggerCondition::TriggerCondition() : name_(), accept_(), category_(), type_() {
   triggerObjectTypes_.clear();
   objectKeys_.clear();
 }
-
 
 // Constructor from condition name "only"
-TriggerCondition::TriggerCondition( const std::string & name ) :
-  name_( name )
-, accept_()
-, category_()
-, type_()
-{
+TriggerCondition::TriggerCondition(const std::string& name) : name_(name), accept_(), category_(), type_() {
   triggerObjectTypes_.clear();
   objectKeys_.clear();
 }
-
 
 // Constructor from values
-TriggerCondition::TriggerCondition( const std::string & name, bool accept ) :
-  name_( name )
-, accept_( accept )
-, category_()
-, type_()
-{
+TriggerCondition::TriggerCondition(const std::string& name, bool accept)
+    : name_(name), accept_(accept), category_(), type_() {
   triggerObjectTypes_.clear();
   objectKeys_.clear();
 }
-
 
 // Methods
 
-
 // Get the trigger object types
-std::vector< int > TriggerCondition::triggerObjectTypes() const
-{
-  std::vector< int > triggerObjectTypes;
-  for ( size_t iT = 0; iT < triggerObjectTypes_.size(); ++iT ) {
-    triggerObjectTypes.push_back( int( triggerObjectTypes_.at( iT ) ) );
+std::vector<int> TriggerCondition::triggerObjectTypes() const {
+  std::vector<int> triggerObjectTypes;
+  for (size_t iT = 0; iT < triggerObjectTypes_.size(); ++iT) {
+    triggerObjectTypes.push_back(int(triggerObjectTypes_.at(iT)));
   }
   return triggerObjectTypes;
 }
 
-
 // Checks, if a certain trigger object type is assigned
-bool TriggerCondition::hasTriggerObjectType( trigger::TriggerObjectType triggerObjectType ) const
-{
-  for ( size_t iT = 0; iT < triggerObjectTypes_.size(); ++iT ) {
-    if ( triggerObjectTypes_.at( iT ) == triggerObjectType ) return true;
+bool TriggerCondition::hasTriggerObjectType(trigger::TriggerObjectType triggerObjectType) const {
+  for (size_t iT = 0; iT < triggerObjectTypes_.size(); ++iT) {
+    if (triggerObjectTypes_.at(iT) == triggerObjectType)
+      return true;
   }
   return false;
 }
 
-
 // Checks, if a certain trigger object collection index is assigned
-bool TriggerCondition::hasObjectKey( unsigned objectKey ) const
-{
-  for ( size_t iO = 0; iO < objectKeys_.size(); ++iO ) {
-    if ( objectKeys_.at( iO ) == objectKey ) return true;
+bool TriggerCondition::hasObjectKey(unsigned objectKey) const {
+  for (size_t iO = 0; iO < objectKeys_.size(); ++iO) {
+    if (objectKeys_.at(iO) == objectKey)
+      return true;
   }
   return false;
 }

--- a/DataFormats/PatCandidates/src/TriggerEvent.cc
+++ b/DataFormats/PatCandidates/src/TriggerEvent.cc
@@ -1,516 +1,477 @@
 //
 //
 
-
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"
-
 
 using namespace pat;
 
-
 // Constructors and Destructor
 
-
 // Default constructor
-TriggerEvent::TriggerEvent() :
-  nameL1Menu_(),
-  nameHltTable_(),
-  run_(),
-  accept_(),
-  error_(),
-  physDecl_(),
-  lhcFill_(),
-  beamMode_(),
-  beamMomentum_(),
-  intensityBeam1_(),
-  intensityBeam2_(),
-  bstMasterStatus_(),
-  turnCount_(),
-  bCurrentStart_(),
-  bCurrentStop_(),
-  bCurrentAvg_()
-{
+TriggerEvent::TriggerEvent()
+    : nameL1Menu_(),
+      nameHltTable_(),
+      run_(),
+      accept_(),
+      error_(),
+      physDecl_(),
+      lhcFill_(),
+      beamMode_(),
+      beamMomentum_(),
+      intensityBeam1_(),
+      intensityBeam2_(),
+      bstMasterStatus_(),
+      turnCount_(),
+      bCurrentStart_(),
+      bCurrentStop_(),
+      bCurrentAvg_() {
   objectMatchResults_.clear();
 }
-
 
 // Constructor from values, HLT only
-TriggerEvent::TriggerEvent( const std::string & nameHltTable, bool run, bool accept, bool error, bool physDecl ) :
-  nameL1Menu_(),
-  nameHltTable_( nameHltTable ),
-  run_( run ),
-  accept_( accept ),
-  error_( error ),
-  physDecl_( physDecl ) ,
-  lhcFill_(),
-  beamMode_(),
-  beamMomentum_(),
-  intensityBeam1_(),
-  intensityBeam2_(),
-  bstMasterStatus_(),
-  turnCount_(),
-  bCurrentStart_(),
-  bCurrentStop_(),
-  bCurrentAvg_()
-{
+TriggerEvent::TriggerEvent(const std::string& nameHltTable, bool run, bool accept, bool error, bool physDecl)
+    : nameL1Menu_(),
+      nameHltTable_(nameHltTable),
+      run_(run),
+      accept_(accept),
+      error_(error),
+      physDecl_(physDecl),
+      lhcFill_(),
+      beamMode_(),
+      beamMomentum_(),
+      intensityBeam1_(),
+      intensityBeam2_(),
+      bstMasterStatus_(),
+      turnCount_(),
+      bCurrentStart_(),
+      bCurrentStop_(),
+      bCurrentAvg_() {
   objectMatchResults_.clear();
 }
-
 
 // Constructor from values, HLT and L1/GT
-TriggerEvent::TriggerEvent( const std::string & nameL1Menu, const std::string & nameHltTable, bool run, bool accept, bool error, bool physDecl ) :
-  nameL1Menu_( nameL1Menu ),
-  nameHltTable_( nameHltTable ),
-  run_( run ),
-  accept_( accept ),
-  error_( error ),
-  physDecl_( physDecl ) ,
-  lhcFill_(),
-  beamMode_(),
-  beamMomentum_(),
-  intensityBeam1_(),
-  intensityBeam2_(),
-  bstMasterStatus_(),
-  turnCount_(),
-  bCurrentStart_(),
-  bCurrentStop_(),
-  bCurrentAvg_()
-{
+TriggerEvent::TriggerEvent(
+    const std::string& nameL1Menu, const std::string& nameHltTable, bool run, bool accept, bool error, bool physDecl)
+    : nameL1Menu_(nameL1Menu),
+      nameHltTable_(nameHltTable),
+      run_(run),
+      accept_(accept),
+      error_(error),
+      physDecl_(physDecl),
+      lhcFill_(),
+      beamMode_(),
+      beamMomentum_(),
+      intensityBeam1_(),
+      intensityBeam2_(),
+      bstMasterStatus_(),
+      turnCount_(),
+      bCurrentStart_(),
+      bCurrentStop_(),
+      bCurrentAvg_() {
   objectMatchResults_.clear();
 }
-
 
 // Methods
 
-
 // Get a vector of references to all L1 algorithms
-const TriggerAlgorithmRefVector TriggerEvent::algorithmRefs() const
-{
+const TriggerAlgorithmRefVector TriggerEvent::algorithmRefs() const {
   TriggerAlgorithmRefVector theAlgorithms;
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    const std::string nameAlgorithm( iAlgorithm->name() );
-    const TriggerAlgorithmRef algorithmRef( algorithms_, indexAlgorithm( nameAlgorithm ) );
-    theAlgorithms.push_back( algorithmRef );
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    const std::string nameAlgorithm(iAlgorithm->name());
+    const TriggerAlgorithmRef algorithmRef(algorithms_, indexAlgorithm(nameAlgorithm));
+    theAlgorithms.push_back(algorithmRef);
   }
   return theAlgorithms;
 }
 
-
 // Get a pointer to a certain L1 algorithm by name
-const TriggerAlgorithm * TriggerEvent::algorithm( const std::string & nameAlgorithm ) const
-{
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    if ( nameAlgorithm == iAlgorithm->name() ) return &*iAlgorithm;
+const TriggerAlgorithm* TriggerEvent::algorithm(const std::string& nameAlgorithm) const {
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    if (nameAlgorithm == iAlgorithm->name())
+      return &*iAlgorithm;
   }
   return nullptr;
 }
 
-
 // Get a reference to a certain L1 algorithm by name
-const TriggerAlgorithmRef TriggerEvent::algorithmRef( const std::string & nameAlgorithm ) const
-{
-  for ( TriggerAlgorithmRefVector::const_iterator iAlgorithm = algorithmRefs().begin(); iAlgorithm != algorithmRefs().end(); ++iAlgorithm ) {
-    if ( nameAlgorithm == ( *iAlgorithm )->name() ) return *iAlgorithm;
+const TriggerAlgorithmRef TriggerEvent::algorithmRef(const std::string& nameAlgorithm) const {
+  for (TriggerAlgorithmRefVector::const_iterator iAlgorithm = algorithmRefs().begin();
+       iAlgorithm != algorithmRefs().end();
+       ++iAlgorithm) {
+    if (nameAlgorithm == (*iAlgorithm)->name())
+      return *iAlgorithm;
   }
   return TriggerAlgorithmRef();
 }
 
-
 // Get the name of a certain L1 algorithm in the event collection by bit number physics or technical algorithms,
-std::string TriggerEvent::nameAlgorithm( const unsigned bitAlgorithm, const bool techAlgorithm ) const
-{
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    if ( bitAlgorithm == iAlgorithm->bit() && techAlgorithm == iAlgorithm->techTrigger() ) return iAlgorithm->name();
+std::string TriggerEvent::nameAlgorithm(const unsigned bitAlgorithm, const bool techAlgorithm) const {
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    if (bitAlgorithm == iAlgorithm->bit() && techAlgorithm == iAlgorithm->techTrigger())
+      return iAlgorithm->name();
   }
-  return std::string( "" );
+  return std::string("");
 }
 
-
 // Get the index of a certain L1 algorithm in the event collection by name
-unsigned TriggerEvent::indexAlgorithm( const std::string & nameAlgorithm ) const
-{
-  unsigned iAlgorithm( 0 );
-  while ( iAlgorithm < algorithms()->size() && algorithms()->at( iAlgorithm ).name() != nameAlgorithm ) ++iAlgorithm;
+unsigned TriggerEvent::indexAlgorithm(const std::string& nameAlgorithm) const {
+  unsigned iAlgorithm(0);
+  while (iAlgorithm < algorithms()->size() && algorithms()->at(iAlgorithm).name() != nameAlgorithm)
+    ++iAlgorithm;
   return iAlgorithm;
 }
 
-
 // Get a vector of references to all succeeding L1 algorithms
-TriggerAlgorithmRefVector TriggerEvent::acceptedAlgorithms() const
-{
+TriggerAlgorithmRefVector TriggerEvent::acceptedAlgorithms() const {
   TriggerAlgorithmRefVector theAcceptedAlgorithms;
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    if ( iAlgorithm->decision() ) {
-      const std::string nameAlgorithm( iAlgorithm->name() );
-      const TriggerAlgorithmRef algorithmRef( algorithms_, indexAlgorithm( nameAlgorithm ) );
-      theAcceptedAlgorithms.push_back( algorithmRef );
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    if (iAlgorithm->decision()) {
+      const std::string nameAlgorithm(iAlgorithm->name());
+      const TriggerAlgorithmRef algorithmRef(algorithms_, indexAlgorithm(nameAlgorithm));
+      theAcceptedAlgorithms.push_back(algorithmRef);
     }
   }
   return theAcceptedAlgorithms;
 }
-
 
 // Get a vector of references to all L1 algorithms succeeding on the GTL board
-TriggerAlgorithmRefVector TriggerEvent::acceptedAlgorithmsGtl() const
-{
+TriggerAlgorithmRefVector TriggerEvent::acceptedAlgorithmsGtl() const {
   TriggerAlgorithmRefVector theAcceptedAlgorithms;
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    if ( iAlgorithm->gtlResult() ) {
-      const std::string nameAlgorithm( iAlgorithm->name() );
-      const TriggerAlgorithmRef algorithmRef( algorithms_, indexAlgorithm( nameAlgorithm ) );
-      theAcceptedAlgorithms.push_back( algorithmRef );
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    if (iAlgorithm->gtlResult()) {
+      const std::string nameAlgorithm(iAlgorithm->name());
+      const TriggerAlgorithmRef algorithmRef(algorithms_, indexAlgorithm(nameAlgorithm));
+      theAcceptedAlgorithms.push_back(algorithmRef);
     }
   }
   return theAcceptedAlgorithms;
 }
 
-
 // Get a vector of references to all technical L1 algorithms
-TriggerAlgorithmRefVector TriggerEvent::techAlgorithms() const
-{
+TriggerAlgorithmRefVector TriggerEvent::techAlgorithms() const {
   TriggerAlgorithmRefVector theTechAlgorithms;
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    if ( iAlgorithm->techTrigger() ) {
-      const std::string nameAlgorithm( iAlgorithm->name() );
-      const TriggerAlgorithmRef algorithmRef( algorithms_, indexAlgorithm( nameAlgorithm ) );
-      theTechAlgorithms.push_back( algorithmRef );
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    if (iAlgorithm->techTrigger()) {
+      const std::string nameAlgorithm(iAlgorithm->name());
+      const TriggerAlgorithmRef algorithmRef(algorithms_, indexAlgorithm(nameAlgorithm));
+      theTechAlgorithms.push_back(algorithmRef);
     }
   }
   return theTechAlgorithms;
 }
 
-
 // Get a vector of references to all succeeding technical L1 algorithms
-TriggerAlgorithmRefVector TriggerEvent::acceptedTechAlgorithms() const
-{
+TriggerAlgorithmRefVector TriggerEvent::acceptedTechAlgorithms() const {
   TriggerAlgorithmRefVector theAcceptedTechAlgorithms;
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    if ( iAlgorithm->techTrigger() && iAlgorithm->decision() ) {
-      const std::string nameAlgorithm( iAlgorithm->name() );
-      const TriggerAlgorithmRef algorithmRef( algorithms_, indexAlgorithm( nameAlgorithm ) );
-      theAcceptedTechAlgorithms.push_back( algorithmRef );
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    if (iAlgorithm->techTrigger() && iAlgorithm->decision()) {
+      const std::string nameAlgorithm(iAlgorithm->name());
+      const TriggerAlgorithmRef algorithmRef(algorithms_, indexAlgorithm(nameAlgorithm));
+      theAcceptedTechAlgorithms.push_back(algorithmRef);
     }
   }
   return theAcceptedTechAlgorithms;
 }
-
 
 // Get a vector of references to all technical L1 algorithms succeeding on the GTL board
-TriggerAlgorithmRefVector TriggerEvent::acceptedTechAlgorithmsGtl() const
-{
+TriggerAlgorithmRefVector TriggerEvent::acceptedTechAlgorithmsGtl() const {
   TriggerAlgorithmRefVector theAcceptedTechAlgorithms;
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    if ( iAlgorithm->techTrigger() && iAlgorithm->gtlResult() ) {
-      const std::string nameAlgorithm( iAlgorithm->name() );
-      const TriggerAlgorithmRef algorithmRef( algorithms_, indexAlgorithm( nameAlgorithm ) );
-      theAcceptedTechAlgorithms.push_back( algorithmRef );
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    if (iAlgorithm->techTrigger() && iAlgorithm->gtlResult()) {
+      const std::string nameAlgorithm(iAlgorithm->name());
+      const TriggerAlgorithmRef algorithmRef(algorithms_, indexAlgorithm(nameAlgorithm));
+      theAcceptedTechAlgorithms.push_back(algorithmRef);
     }
   }
   return theAcceptedTechAlgorithms;
 }
 
-
 // Get a vector of references to all physics L1 algorithms
-TriggerAlgorithmRefVector TriggerEvent::physAlgorithms() const
-{
+TriggerAlgorithmRefVector TriggerEvent::physAlgorithms() const {
   TriggerAlgorithmRefVector thePhysAlgorithms;
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    if ( ! iAlgorithm->techTrigger() ) {
-      const std::string nameAlgorithm( iAlgorithm->name() );
-      const TriggerAlgorithmRef algorithmRef( algorithms_, indexAlgorithm( nameAlgorithm ) );
-      thePhysAlgorithms.push_back( algorithmRef );
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    if (!iAlgorithm->techTrigger()) {
+      const std::string nameAlgorithm(iAlgorithm->name());
+      const TriggerAlgorithmRef algorithmRef(algorithms_, indexAlgorithm(nameAlgorithm));
+      thePhysAlgorithms.push_back(algorithmRef);
     }
   }
   return thePhysAlgorithms;
 }
 
-
 // Get a vector of references to all succeeding physics L1 algorithms
-TriggerAlgorithmRefVector TriggerEvent::acceptedPhysAlgorithms() const
-{
+TriggerAlgorithmRefVector TriggerEvent::acceptedPhysAlgorithms() const {
   TriggerAlgorithmRefVector theAcceptedPhysAlgorithms;
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    if ( ! iAlgorithm->techTrigger() && iAlgorithm->decision() ) {
-      const std::string nameAlgorithm( iAlgorithm->name() );
-      const TriggerAlgorithmRef algorithmRef( algorithms_, indexAlgorithm( nameAlgorithm ) );
-      theAcceptedPhysAlgorithms.push_back( algorithmRef );
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    if (!iAlgorithm->techTrigger() && iAlgorithm->decision()) {
+      const std::string nameAlgorithm(iAlgorithm->name());
+      const TriggerAlgorithmRef algorithmRef(algorithms_, indexAlgorithm(nameAlgorithm));
+      theAcceptedPhysAlgorithms.push_back(algorithmRef);
     }
   }
   return theAcceptedPhysAlgorithms;
 }
-
 
 // Get a vector of references to all physics L1 algorithms succeeding on the GTL board
-TriggerAlgorithmRefVector TriggerEvent::acceptedPhysAlgorithmsGtl() const
-{
+TriggerAlgorithmRefVector TriggerEvent::acceptedPhysAlgorithmsGtl() const {
   TriggerAlgorithmRefVector theAcceptedPhysAlgorithms;
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    if ( ! iAlgorithm->techTrigger() && iAlgorithm->gtlResult() ) {
-      const std::string nameAlgorithm( iAlgorithm->name() );
-      const TriggerAlgorithmRef algorithmRef( algorithms_, indexAlgorithm( nameAlgorithm ) );
-      theAcceptedPhysAlgorithms.push_back( algorithmRef );
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    if (!iAlgorithm->techTrigger() && iAlgorithm->gtlResult()) {
+      const std::string nameAlgorithm(iAlgorithm->name());
+      const TriggerAlgorithmRef algorithmRef(algorithms_, indexAlgorithm(nameAlgorithm));
+      theAcceptedPhysAlgorithms.push_back(algorithmRef);
     }
   }
   return theAcceptedPhysAlgorithms;
 }
 
-
 // Get a vector of references to all L1 conditions
-const TriggerConditionRefVector TriggerEvent::conditionRefs() const
-{
+const TriggerConditionRefVector TriggerEvent::conditionRefs() const {
   TriggerConditionRefVector theConditions;
-  for ( TriggerConditionCollection::const_iterator iCondition = conditions()->begin(); iCondition != conditions()->end(); ++iCondition ) {
-    const std::string nameCondition( iCondition->name() );
-    const TriggerConditionRef conditionRef( conditions_, indexCondition( nameCondition ) );
-    theConditions.push_back( conditionRef );
+  for (TriggerConditionCollection::const_iterator iCondition = conditions()->begin(); iCondition != conditions()->end();
+       ++iCondition) {
+    const std::string nameCondition(iCondition->name());
+    const TriggerConditionRef conditionRef(conditions_, indexCondition(nameCondition));
+    theConditions.push_back(conditionRef);
   }
   return theConditions;
 }
 
-
 // Get a pointer to a certain L1 condition by name
-const TriggerCondition * TriggerEvent::condition( const std::string & nameCondition ) const
-{
-  for ( TriggerConditionCollection::const_iterator iCondition = conditions()->begin(); iCondition != conditions()->end(); ++iCondition ) {
-    if ( nameCondition == iCondition->name() ) return &*iCondition;
+const TriggerCondition* TriggerEvent::condition(const std::string& nameCondition) const {
+  for (TriggerConditionCollection::const_iterator iCondition = conditions()->begin(); iCondition != conditions()->end();
+       ++iCondition) {
+    if (nameCondition == iCondition->name())
+      return &*iCondition;
   }
   return nullptr;
 }
 
-
 // Get a reference to a certain L1 condition by name
-const TriggerConditionRef TriggerEvent::conditionRef( const std::string & nameCondition ) const
-{
-  for ( TriggerConditionRefVector::const_iterator iCondition = conditionRefs().begin(); iCondition != conditionRefs().end(); ++iCondition ) {
-    if ( nameCondition == ( *iCondition )->name() ) return *iCondition;
+const TriggerConditionRef TriggerEvent::conditionRef(const std::string& nameCondition) const {
+  for (TriggerConditionRefVector::const_iterator iCondition = conditionRefs().begin();
+       iCondition != conditionRefs().end();
+       ++iCondition) {
+    if (nameCondition == (*iCondition)->name())
+      return *iCondition;
   }
   return TriggerConditionRef();
 }
 
-
 // Get the index of a certain L1 condition in the event collection by name
-unsigned TriggerEvent::indexCondition( const std::string & nameCondition ) const
-{
-  unsigned iCondition( 0 );
-  while ( iCondition < conditions()->size() && conditions()->at( iCondition ).name() != nameCondition ) ++iCondition;
+unsigned TriggerEvent::indexCondition(const std::string& nameCondition) const {
+  unsigned iCondition(0);
+  while (iCondition < conditions()->size() && conditions()->at(iCondition).name() != nameCondition)
+    ++iCondition;
   return iCondition;
 }
 
-
 // Get a vector of references to all succeeding L1 conditions
-TriggerConditionRefVector TriggerEvent::acceptedConditions() const
-{
+TriggerConditionRefVector TriggerEvent::acceptedConditions() const {
   TriggerConditionRefVector theAcceptedConditions;
-  for ( TriggerConditionCollection::const_iterator iCondition = conditions()->begin(); iCondition != conditions()->end(); ++iCondition ) {
-    if ( iCondition->wasAccept() ) {
-      const std::string nameCondition( iCondition->name() );
-      const TriggerConditionRef conditionRef( conditions_, indexCondition( nameCondition ) );
-      theAcceptedConditions.push_back( conditionRef );
+  for (TriggerConditionCollection::const_iterator iCondition = conditions()->begin(); iCondition != conditions()->end();
+       ++iCondition) {
+    if (iCondition->wasAccept()) {
+      const std::string nameCondition(iCondition->name());
+      const TriggerConditionRef conditionRef(conditions_, indexCondition(nameCondition));
+      theAcceptedConditions.push_back(conditionRef);
     }
   }
   return theAcceptedConditions;
 }
 
-
 // Get a vector of references to all HLT paths
-const TriggerPathRefVector TriggerEvent::pathRefs() const
-{
+const TriggerPathRefVector TriggerEvent::pathRefs() const {
   TriggerPathRefVector thePaths;
-  for ( TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath ) {
-    const std::string namePath( iPath->name() );
-    const TriggerPathRef pathRef( paths_, indexPath( namePath ) );
-    thePaths.push_back( pathRef );
+  for (TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath) {
+    const std::string namePath(iPath->name());
+    const TriggerPathRef pathRef(paths_, indexPath(namePath));
+    thePaths.push_back(pathRef);
   }
   return thePaths;
 }
 
-
 // Get a pointer to a certain HLT path by name
-const TriggerPath * TriggerEvent::path( const std::string & namePath ) const
-{
-  for ( TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath ) {
-    if ( namePath == iPath->name() ) return &*iPath;
+const TriggerPath* TriggerEvent::path(const std::string& namePath) const {
+  for (TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath) {
+    if (namePath == iPath->name())
+      return &*iPath;
   }
   return nullptr;
 }
 
-
 // Get a reference to a certain HLT path by name
-const TriggerPathRef TriggerEvent::pathRef( const std::string & namePath ) const
-{
-  for ( TriggerPathRefVector::const_iterator iPath = pathRefs().begin(); iPath != pathRefs().end(); ++iPath ) {
-    if ( namePath == ( *iPath )->name() ) return *iPath;
+const TriggerPathRef TriggerEvent::pathRef(const std::string& namePath) const {
+  for (TriggerPathRefVector::const_iterator iPath = pathRefs().begin(); iPath != pathRefs().end(); ++iPath) {
+    if (namePath == (*iPath)->name())
+      return *iPath;
   }
   return TriggerPathRef();
 }
 
-
 // Get the index of a certain HLT path in the event collection by name
-unsigned TriggerEvent::indexPath( const std::string & namePath ) const
-{
-  unsigned iPath( 0 );
-  while ( iPath < paths()->size() && paths()->at( iPath ).name() != namePath ) ++iPath;
+unsigned TriggerEvent::indexPath(const std::string& namePath) const {
+  unsigned iPath(0);
+  while (iPath < paths()->size() && paths()->at(iPath).name() != namePath)
+    ++iPath;
   return iPath;
 }
 
-
 // Get a vector of references to all succeeding HLT paths
-TriggerPathRefVector TriggerEvent::acceptedPaths() const
-{
+TriggerPathRefVector TriggerEvent::acceptedPaths() const {
   TriggerPathRefVector theAcceptedPaths;
-  for ( TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath ) {
-    if ( iPath->wasAccept() ) {
-      const std::string namePath( iPath->name() );
-      const TriggerPathRef pathRef( paths_, indexPath( namePath ) );
-      theAcceptedPaths.push_back( pathRef );
+  for (TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath) {
+    if (iPath->wasAccept()) {
+      const std::string namePath(iPath->name());
+      const TriggerPathRef pathRef(paths_, indexPath(namePath));
+      theAcceptedPaths.push_back(pathRef);
     }
   }
   return theAcceptedPaths;
 }
 
-
 // Get a vector of references to all HLT filters
-const TriggerFilterRefVector TriggerEvent::filterRefs() const
-{
+const TriggerFilterRefVector TriggerEvent::filterRefs() const {
   TriggerFilterRefVector theFilters;
-  for ( TriggerFilterCollection::const_iterator iFilter = filters()->begin(); iFilter != filters()->end(); ++iFilter ) {
-    const std::string labelFilter( iFilter->label() );
-    const TriggerFilterRef filterRef( filters_, indexFilter( labelFilter ) );
-    theFilters.push_back( filterRef );
+  for (TriggerFilterCollection::const_iterator iFilter = filters()->begin(); iFilter != filters()->end(); ++iFilter) {
+    const std::string labelFilter(iFilter->label());
+    const TriggerFilterRef filterRef(filters_, indexFilter(labelFilter));
+    theFilters.push_back(filterRef);
   }
   return theFilters;
 }
 
-
 // Get a pointer to a certain HLT filter by label
-const TriggerFilter * TriggerEvent::filter( const std::string & labelFilter ) const
-{
-  for ( TriggerFilterCollection::const_iterator iFilter = filters()->begin(); iFilter != filters()->end(); ++iFilter ) {
-    if ( labelFilter == iFilter->label() ) return &*iFilter;
+const TriggerFilter* TriggerEvent::filter(const std::string& labelFilter) const {
+  for (TriggerFilterCollection::const_iterator iFilter = filters()->begin(); iFilter != filters()->end(); ++iFilter) {
+    if (labelFilter == iFilter->label())
+      return &*iFilter;
   }
   return nullptr;
 }
 
-
 // Get a reference to a certain HLT filter by label
-const TriggerFilterRef TriggerEvent::filterRef( const std::string & labelFilter ) const
-{
-  for ( TriggerFilterRefVector::const_iterator iFilter = filterRefs().begin(); iFilter != filterRefs().end(); ++iFilter ) {
-    if ( labelFilter == ( *iFilter )->label() ) return *iFilter;
+const TriggerFilterRef TriggerEvent::filterRef(const std::string& labelFilter) const {
+  for (TriggerFilterRefVector::const_iterator iFilter = filterRefs().begin(); iFilter != filterRefs().end();
+       ++iFilter) {
+    if (labelFilter == (*iFilter)->label())
+      return *iFilter;
   }
   return TriggerFilterRef();
 }
 
-
 // Get the index of a certain HLT filter in the event collection by label
-unsigned TriggerEvent::indexFilter( const std::string & labelFilter ) const
-{
-  unsigned iFilter( 0 );
-  while ( iFilter < filters()->size() && filters()->at( iFilter ).label() != labelFilter ) ++iFilter;
+unsigned TriggerEvent::indexFilter(const std::string& labelFilter) const {
+  unsigned iFilter(0);
+  while (iFilter < filters()->size() && filters()->at(iFilter).label() != labelFilter)
+    ++iFilter;
   return iFilter;
 }
 
-
 // Get a vector of references to all succeeding HLT filters
-TriggerFilterRefVector TriggerEvent::acceptedFilters() const
-{
+TriggerFilterRefVector TriggerEvent::acceptedFilters() const {
   TriggerFilterRefVector theAcceptedFilters;
-  for ( TriggerFilterCollection::const_iterator iFilter = filters()->begin(); iFilter != filters()->end(); ++iFilter ) {
-    if ( iFilter->status() == 1 ) {
-      const std::string labelFilter( iFilter->label() );
-      const TriggerFilterRef filterRef( filters_, indexFilter( labelFilter ) );
-      theAcceptedFilters.push_back( filterRef );
+  for (TriggerFilterCollection::const_iterator iFilter = filters()->begin(); iFilter != filters()->end(); ++iFilter) {
+    if (iFilter->status() == 1) {
+      const std::string labelFilter(iFilter->label());
+      const TriggerFilterRef filterRef(filters_, indexFilter(labelFilter));
+      theAcceptedFilters.push_back(filterRef);
     }
   }
   return theAcceptedFilters;
 }
 
-
 // Get a vector of references to all trigger objects
-const TriggerObjectRefVector TriggerEvent::objectRefs() const
-{
+const TriggerObjectRefVector TriggerEvent::objectRefs() const {
   TriggerObjectRefVector theObjects;
-  for ( unsigned iObject = 0; iObject < objects()->size(); ++iObject ) {
-    const TriggerObjectRef objectRef( objects_, iObject );
-    theObjects.push_back( objectRef );
+  for (unsigned iObject = 0; iObject < objects()->size(); ++iObject) {
+    const TriggerObjectRef objectRef(objects_, iObject);
+    theObjects.push_back(objectRef);
   }
   return theObjects;
 }
 
-
 // Get a vector of references to all trigger objects by trigger object type
-TriggerObjectRefVector TriggerEvent::objects( trigger::TriggerObjectType triggerObjectType ) const
-{
+TriggerObjectRefVector TriggerEvent::objects(trigger::TriggerObjectType triggerObjectType) const {
   TriggerObjectRefVector theObjects;
-  for ( unsigned iObject = 0; iObject < objects()->size(); ++iObject ) {
-    if ( objects()->at( iObject ).hasTriggerObjectType( triggerObjectType ) ) {
-      const TriggerObjectRef objectRef( objects_, iObject );
-      theObjects.push_back( objectRef );
+  for (unsigned iObject = 0; iObject < objects()->size(); ++iObject) {
+    if (objects()->at(iObject).hasTriggerObjectType(triggerObjectType)) {
+      const TriggerObjectRef objectRef(objects_, iObject);
+      theObjects.push_back(objectRef);
     }
   }
   return theObjects;
 }
 
-
 // Get a vector of references to all conditions assigned to a certain algorithm given by name
-TriggerConditionRefVector TriggerEvent::algorithmConditions( const std::string & nameAlgorithm ) const
-{
+TriggerConditionRefVector TriggerEvent::algorithmConditions(const std::string& nameAlgorithm) const {
   TriggerConditionRefVector theAlgorithmConditions;
-  if ( const TriggerAlgorithm * algorithmPtr = algorithm( nameAlgorithm ) ) {
-    for ( unsigned iC = 0; iC < algorithmPtr->conditionKeys().size(); ++iC ) {
-      const TriggerConditionRef conditionRef( conditions_, algorithmPtr->conditionKeys().at( iC ) );
-      theAlgorithmConditions.push_back( conditionRef );
+  if (const TriggerAlgorithm* algorithmPtr = algorithm(nameAlgorithm)) {
+    for (unsigned iC = 0; iC < algorithmPtr->conditionKeys().size(); ++iC) {
+      const TriggerConditionRef conditionRef(conditions_, algorithmPtr->conditionKeys().at(iC));
+      theAlgorithmConditions.push_back(conditionRef);
     }
   }
   return theAlgorithmConditions;
 }
 
-
 // Checks, if a condition is assigned to a certain algorithm given by name
-bool TriggerEvent::conditionInAlgorithm( const TriggerConditionRef & conditionRef, const std::string & nameAlgorithm ) const
-{
-  TriggerConditionRefVector theConditions = algorithmConditions( nameAlgorithm );
-  for ( TriggerConditionRefVectorIterator iCondition = theConditions.begin(); iCondition != theConditions.end(); ++iCondition ) {
-    if ( conditionRef == *iCondition ) return true;
+bool TriggerEvent::conditionInAlgorithm(const TriggerConditionRef& conditionRef,
+                                        const std::string& nameAlgorithm) const {
+  TriggerConditionRefVector theConditions = algorithmConditions(nameAlgorithm);
+  for (TriggerConditionRefVectorIterator iCondition = theConditions.begin(); iCondition != theConditions.end();
+       ++iCondition) {
+    if (conditionRef == *iCondition)
+      return true;
   }
   return false;
 }
 
-
 // Get a vector of references to all algorithms, which have a certain condition assigned
-TriggerAlgorithmRefVector TriggerEvent::conditionAlgorithms( const TriggerConditionRef & conditionRef ) const
-{
+TriggerAlgorithmRefVector TriggerEvent::conditionAlgorithms(const TriggerConditionRef& conditionRef) const {
   TriggerAlgorithmRefVector theConditionAlgorithms;
-  size_t cAlgorithms( 0 );
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    const std::string nameAlgorithm( iAlgorithm->name() );
-    if ( conditionInAlgorithm( conditionRef, nameAlgorithm ) ) {
-      const TriggerAlgorithmRef algorithmRef( algorithms_, cAlgorithms );
-      theConditionAlgorithms.push_back( algorithmRef );
+  size_t cAlgorithms(0);
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    const std::string nameAlgorithm(iAlgorithm->name());
+    if (conditionInAlgorithm(conditionRef, nameAlgorithm)) {
+      const TriggerAlgorithmRef algorithmRef(algorithms_, cAlgorithms);
+      theConditionAlgorithms.push_back(algorithmRef);
     }
     ++cAlgorithms;
   }
   return theConditionAlgorithms;
 }
 
-
 // Get a list of all trigger object collections used in a certain condition given by name
-std::vector< std::string > TriggerEvent::conditionCollections( const std::string & nameCondition ) const
-{
-  std::vector< std::string > theConditionCollections;
-  if ( const TriggerCondition * conditionPtr = condition( nameCondition ) ) {
-    for ( unsigned iObject = 0; iObject < objects()->size(); ++iObject ) {
-      if ( conditionPtr->hasObjectKey( iObject ) ) {
-        bool found( false );
-        std::string objectCollection( objects()->at( iObject ).collection() );
-        for ( std::vector< std::string >::const_iterator iC = theConditionCollections.begin(); iC != theConditionCollections.end(); ++iC ) {
-          if ( *iC == objectCollection ) {
+std::vector<std::string> TriggerEvent::conditionCollections(const std::string& nameCondition) const {
+  std::vector<std::string> theConditionCollections;
+  if (const TriggerCondition* conditionPtr = condition(nameCondition)) {
+    for (unsigned iObject = 0; iObject < objects()->size(); ++iObject) {
+      if (conditionPtr->hasObjectKey(iObject)) {
+        bool found(false);
+        std::string objectCollection(objects()->at(iObject).collection());
+        for (std::vector<std::string>::const_iterator iC = theConditionCollections.begin();
+             iC != theConditionCollections.end();
+             ++iC) {
+          if (*iC == objectCollection) {
             found = true;
             break;
           }
         }
-        if ( ! found ) {
-          theConditionCollections.push_back( objectCollection );
+        if (!found) {
+          theConditionCollections.push_back(objectCollection);
         }
       }
     }
@@ -518,164 +479,153 @@ std::vector< std::string > TriggerEvent::conditionCollections( const std::string
   return theConditionCollections;
 }
 
-
 // Get a vector of references to all objects, which were used in a certain condition given by name
-TriggerObjectRefVector TriggerEvent::conditionObjects( const std::string & nameCondition ) const
-{
+TriggerObjectRefVector TriggerEvent::conditionObjects(const std::string& nameCondition) const {
   TriggerObjectRefVector theConditionObjects;
-  if ( const TriggerCondition * conditionPtr = condition( nameCondition ) ) {
-    for ( unsigned iObject = 0; iObject < objects()->size(); ++iObject ) {
-      if ( conditionPtr->hasObjectKey( iObject ) ) {
-        const TriggerObjectRef objectRef( objects_, iObject );
-        theConditionObjects.push_back( objectRef );
+  if (const TriggerCondition* conditionPtr = condition(nameCondition)) {
+    for (unsigned iObject = 0; iObject < objects()->size(); ++iObject) {
+      if (conditionPtr->hasObjectKey(iObject)) {
+        const TriggerObjectRef objectRef(objects_, iObject);
+        theConditionObjects.push_back(objectRef);
       }
     }
   }
   return theConditionObjects;
 }
 
-
 // Checks, if an object was used in a certain condition given by name
-bool TriggerEvent::objectInCondition( const TriggerObjectRef & objectRef, const std::string & nameCondition ) const {
-  if ( const TriggerCondition * conditionPtr = condition( nameCondition ) ) return conditionPtr->hasObjectKey( objectRef.key() );
+bool TriggerEvent::objectInCondition(const TriggerObjectRef& objectRef, const std::string& nameCondition) const {
+  if (const TriggerCondition* conditionPtr = condition(nameCondition))
+    return conditionPtr->hasObjectKey(objectRef.key());
   return false;
 }
 
-
 // Get a vector of references to all conditions, which have a certain object assigned
-TriggerConditionRefVector TriggerEvent::objectConditions( const TriggerObjectRef & objectRef ) const
-{
+TriggerConditionRefVector TriggerEvent::objectConditions(const TriggerObjectRef& objectRef) const {
   TriggerConditionRefVector theObjectConditions;
-  for ( TriggerConditionCollection::const_iterator iCondition = conditions()->begin(); iCondition != conditions()->end(); ++iCondition ) {
-    const std::string nameCondition( iCondition->name() );
-    if ( objectInCondition( objectRef, nameCondition ) ) {
-      const TriggerConditionRef conditionRef( conditions_, indexCondition( nameCondition ) );
-      theObjectConditions.push_back( conditionRef );
+  for (TriggerConditionCollection::const_iterator iCondition = conditions()->begin(); iCondition != conditions()->end();
+       ++iCondition) {
+    const std::string nameCondition(iCondition->name());
+    if (objectInCondition(objectRef, nameCondition)) {
+      const TriggerConditionRef conditionRef(conditions_, indexCondition(nameCondition));
+      theObjectConditions.push_back(conditionRef);
     }
   }
   return theObjectConditions;
 }
 
-
 // Get a vector of references to all objects, which were used in a certain algorithm given by name
-TriggerObjectRefVector TriggerEvent::algorithmObjects( const std::string & nameAlgorithm ) const
-{
-  TriggerObjectRefVector    theAlgorithmObjects;
-  TriggerConditionRefVector theConditions = algorithmConditions( nameAlgorithm );
-  for ( TriggerConditionRefVectorIterator iCondition = theConditions.begin(); iCondition != theConditions.end(); ++iCondition ) {
-    const std::string nameCondition( ( *iCondition )->name() );
-    TriggerObjectRefVector theObjects = conditionObjects( nameCondition );
-    for ( TriggerObjectRefVectorIterator iObject = theObjects.begin(); iObject != theObjects.end(); ++iObject ) {
-      theAlgorithmObjects.push_back( *iObject );
+TriggerObjectRefVector TriggerEvent::algorithmObjects(const std::string& nameAlgorithm) const {
+  TriggerObjectRefVector theAlgorithmObjects;
+  TriggerConditionRefVector theConditions = algorithmConditions(nameAlgorithm);
+  for (TriggerConditionRefVectorIterator iCondition = theConditions.begin(); iCondition != theConditions.end();
+       ++iCondition) {
+    const std::string nameCondition((*iCondition)->name());
+    TriggerObjectRefVector theObjects = conditionObjects(nameCondition);
+    for (TriggerObjectRefVectorIterator iObject = theObjects.begin(); iObject != theObjects.end(); ++iObject) {
+      theAlgorithmObjects.push_back(*iObject);
     }
   }
   return theAlgorithmObjects;
 }
 
-
 // Checks, if an object was used in a certain algorithm given by name
-bool TriggerEvent::objectInAlgorithm( const TriggerObjectRef & objectRef, const std::string & nameAlgorithm ) const
-{
-  TriggerConditionRefVector theConditions = algorithmConditions( nameAlgorithm );
-  for ( TriggerConditionRefVectorIterator iCondition = theConditions.begin(); iCondition != theConditions.end(); ++iCondition ) {
-    if ( objectInCondition( objectRef, ( *iCondition )->name() ) ) return true;
+bool TriggerEvent::objectInAlgorithm(const TriggerObjectRef& objectRef, const std::string& nameAlgorithm) const {
+  TriggerConditionRefVector theConditions = algorithmConditions(nameAlgorithm);
+  for (TriggerConditionRefVectorIterator iCondition = theConditions.begin(); iCondition != theConditions.end();
+       ++iCondition) {
+    if (objectInCondition(objectRef, (*iCondition)->name()))
+      return true;
   }
   return false;
 }
 
-
 // Get a vector of references to all algorithms, which have a certain object assigned
-TriggerAlgorithmRefVector TriggerEvent::objectAlgorithms( const TriggerObjectRef & objectRef ) const
-{
+TriggerAlgorithmRefVector TriggerEvent::objectAlgorithms(const TriggerObjectRef& objectRef) const {
   TriggerAlgorithmRefVector theObjectAlgorithms;
-  for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
-    const std::string nameAlgorithm( iAlgorithm->name() );
-    if ( objectInAlgorithm( objectRef, nameAlgorithm ) ) {
-      const TriggerAlgorithmRef algorithmRef( algorithms_, indexAlgorithm( nameAlgorithm ) );
-      theObjectAlgorithms.push_back( algorithmRef );
+  for (TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end();
+       ++iAlgorithm) {
+    const std::string nameAlgorithm(iAlgorithm->name());
+    if (objectInAlgorithm(objectRef, nameAlgorithm)) {
+      const TriggerAlgorithmRef algorithmRef(algorithms_, indexAlgorithm(nameAlgorithm));
+      theObjectAlgorithms.push_back(algorithmRef);
     }
   }
   return theObjectAlgorithms;
 }
 
-
 // Get a vector of references to all modules assigned to a certain path given by name
-TriggerFilterRefVector TriggerEvent::pathModules( const std::string & namePath, bool all ) const
-{
+TriggerFilterRefVector TriggerEvent::pathModules(const std::string& namePath, bool all) const {
   TriggerFilterRefVector thePathFilters;
-  if ( const TriggerPath * pathPtr = path( namePath ) ) {
-    if ( !pathPtr->modules().empty() ) {
+  if (const TriggerPath* pathPtr = path(namePath)) {
+    if (!pathPtr->modules().empty()) {
       const unsigned onePastLastFilter = all ? pathPtr->modules().size() : pathPtr->lastActiveFilterSlot() + 1;
-      for ( unsigned iM = 0; iM < onePastLastFilter; ++iM ) {
-        const std::string labelFilter( pathPtr->modules().at( iM ) );
-        const TriggerFilterRef filterRef( filters_, indexFilter( labelFilter ) );
-        thePathFilters.push_back( filterRef );
+      for (unsigned iM = 0; iM < onePastLastFilter; ++iM) {
+        const std::string labelFilter(pathPtr->modules().at(iM));
+        const TriggerFilterRef filterRef(filters_, indexFilter(labelFilter));
+        thePathFilters.push_back(filterRef);
       }
     }
   }
   return thePathFilters;
 }
 
-
 // Get a vector of references to all active HLT filters assigned to a certain path given by name
-TriggerFilterRefVector TriggerEvent::pathFilters( const std::string & namePath, bool firing ) const
-{
+TriggerFilterRefVector TriggerEvent::pathFilters(const std::string& namePath, bool firing) const {
   TriggerFilterRefVector thePathFilters;
-  if ( const TriggerPath * pathPtr = path( namePath ) ) {
-    for ( unsigned iF = 0; iF < pathPtr->filterIndices().size(); ++iF ) {
-      const TriggerFilterRef filterRef( filters_, pathPtr->filterIndices().at( iF ) );
-      if ( ( ! firing ) || filterRef->isFiring() ) thePathFilters.push_back( filterRef );
+  if (const TriggerPath* pathPtr = path(namePath)) {
+    for (unsigned iF = 0; iF < pathPtr->filterIndices().size(); ++iF) {
+      const TriggerFilterRef filterRef(filters_, pathPtr->filterIndices().at(iF));
+      if ((!firing) || filterRef->isFiring())
+        thePathFilters.push_back(filterRef);
     }
   }
   return thePathFilters;
 }
 
-
 // Checks, if a filter is assigned to and was run in a certain path given by name
-bool TriggerEvent::filterInPath( const TriggerFilterRef & filterRef, const std::string & namePath, bool firing ) const
-{
-  TriggerFilterRefVector theFilters = pathFilters( namePath, firing );
-  for ( TriggerFilterRefVectorIterator iFilter = theFilters.begin(); iFilter != theFilters.end(); ++iFilter ) {
-    if ( filterRef == *iFilter ) return true;
+bool TriggerEvent::filterInPath(const TriggerFilterRef& filterRef, const std::string& namePath, bool firing) const {
+  TriggerFilterRefVector theFilters = pathFilters(namePath, firing);
+  for (TriggerFilterRefVectorIterator iFilter = theFilters.begin(); iFilter != theFilters.end(); ++iFilter) {
+    if (filterRef == *iFilter)
+      return true;
   }
   return false;
 }
 
-
 // Get a vector of references to all paths, which have a certain filter assigned
-TriggerPathRefVector TriggerEvent::filterPaths( const TriggerFilterRef & filterRef, bool firing ) const
-{
+TriggerPathRefVector TriggerEvent::filterPaths(const TriggerFilterRef& filterRef, bool firing) const {
   TriggerPathRefVector theFilterPaths;
-  size_t cPaths( 0 );
-  for ( TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath ) {
-    const std::string namePath( iPath->name() );
-    if ( filterInPath( filterRef, namePath, firing ) ) {
-      const TriggerPathRef pathRef( paths_, cPaths );
-      theFilterPaths.push_back( pathRef );
+  size_t cPaths(0);
+  for (TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath) {
+    const std::string namePath(iPath->name());
+    if (filterInPath(filterRef, namePath, firing)) {
+      const TriggerPathRef pathRef(paths_, cPaths);
+      theFilterPaths.push_back(pathRef);
     }
     ++cPaths;
   }
   return theFilterPaths;
 }
 
-
 // Get a list of all trigger object collections used in a certain filter given by name
-std::vector< std::string > TriggerEvent::filterCollections( const std::string & labelFilter ) const
-{
-  std::vector< std::string > theFilterCollections;
-  if ( const TriggerFilter * filterPtr = filter( labelFilter ) ) {
-    for ( unsigned iObject = 0; iObject < objects()->size(); ++iObject ) {
-      if ( filterPtr->hasObjectKey( iObject ) ) {
-        bool found( false );
-        const std::string objectCollection( objects()->at( iObject ).collection() );
-        for ( std::vector< std::string >::const_iterator iC = theFilterCollections.begin(); iC != theFilterCollections.end(); ++iC ) {
-          if ( *iC == objectCollection ) {
+std::vector<std::string> TriggerEvent::filterCollections(const std::string& labelFilter) const {
+  std::vector<std::string> theFilterCollections;
+  if (const TriggerFilter* filterPtr = filter(labelFilter)) {
+    for (unsigned iObject = 0; iObject < objects()->size(); ++iObject) {
+      if (filterPtr->hasObjectKey(iObject)) {
+        bool found(false);
+        const std::string objectCollection(objects()->at(iObject).collection());
+        for (std::vector<std::string>::const_iterator iC = theFilterCollections.begin();
+             iC != theFilterCollections.end();
+             ++iC) {
+          if (*iC == objectCollection) {
             found = true;
             break;
           }
         }
-        if ( ! found ) {
-          theFilterCollections.push_back( objectCollection );
+        if (!found) {
+          theFilterCollections.push_back(objectCollection);
         }
       }
     }
@@ -683,111 +633,101 @@ std::vector< std::string > TriggerEvent::filterCollections( const std::string & 
   return theFilterCollections;
 }
 
-
 // Get a vector of references to all objects, which were used in a certain filter given by name
-TriggerObjectRefVector TriggerEvent::filterObjects( const std::string & labelFilter ) const
-{
+TriggerObjectRefVector TriggerEvent::filterObjects(const std::string& labelFilter) const {
   TriggerObjectRefVector theFilterObjects;
-  if ( const TriggerFilter * filterPtr = filter( labelFilter ) ) {
-    for ( unsigned iObject = 0; iObject < objects()->size(); ++iObject ) {
-      if ( filterPtr->hasObjectKey( iObject ) ) {
-        const TriggerObjectRef objectRef( objects_, iObject );
-        theFilterObjects.push_back( objectRef );
+  if (const TriggerFilter* filterPtr = filter(labelFilter)) {
+    for (unsigned iObject = 0; iObject < objects()->size(); ++iObject) {
+      if (filterPtr->hasObjectKey(iObject)) {
+        const TriggerObjectRef objectRef(objects_, iObject);
+        theFilterObjects.push_back(objectRef);
       }
     }
   }
   return theFilterObjects;
 }
 
-
 // Checks, if an object was used in a certain filter given by name
-bool TriggerEvent::objectInFilter( const TriggerObjectRef & objectRef, const std::string & labelFilter ) const {
-  if ( const TriggerFilter * filterPtr = filter( labelFilter ) ) return filterPtr->hasObjectKey( objectRef.key() );
+bool TriggerEvent::objectInFilter(const TriggerObjectRef& objectRef, const std::string& labelFilter) const {
+  if (const TriggerFilter* filterPtr = filter(labelFilter))
+    return filterPtr->hasObjectKey(objectRef.key());
   return false;
 }
 
-
 // Get a vector of references to all filters, which have a certain object assigned
-TriggerFilterRefVector TriggerEvent::objectFilters( const TriggerObjectRef & objectRef, bool firing ) const
-{
+TriggerFilterRefVector TriggerEvent::objectFilters(const TriggerObjectRef& objectRef, bool firing) const {
   TriggerFilterRefVector theObjectFilters;
-  for ( TriggerFilterCollection::const_iterator iFilter = filters()->begin(); iFilter != filters()->end(); ++iFilter ) {
-    const std::string labelFilter( iFilter->label() );
-    if ( objectInFilter( objectRef, labelFilter ) ) {
-      const TriggerFilterRef filterRef( filters_, indexFilter( labelFilter ) );
-      if ( ( ! firing ) || iFilter->isFiring() ) theObjectFilters.push_back( filterRef );
+  for (TriggerFilterCollection::const_iterator iFilter = filters()->begin(); iFilter != filters()->end(); ++iFilter) {
+    const std::string labelFilter(iFilter->label());
+    if (objectInFilter(objectRef, labelFilter)) {
+      const TriggerFilterRef filterRef(filters_, indexFilter(labelFilter));
+      if ((!firing) || iFilter->isFiring())
+        theObjectFilters.push_back(filterRef);
     }
   }
   return theObjectFilters;
 }
 
-
 // Get a vector of references to all objects, which were used in a certain path given by name
-TriggerObjectRefVector TriggerEvent::pathObjects( const std::string & namePath, bool firing ) const
-{
+TriggerObjectRefVector TriggerEvent::pathObjects(const std::string& namePath, bool firing) const {
   TriggerObjectRefVector thePathObjects;
-  TriggerFilterRefVector theFilters = pathFilters( namePath, firing );
-  for ( TriggerFilterRefVectorIterator iFilter = theFilters.begin(); iFilter != theFilters.end(); ++iFilter ) {
-    const std::string labelFilter( ( *iFilter )->label() );
-    TriggerObjectRefVector theObjects = filterObjects( labelFilter );
-    for ( TriggerObjectRefVectorIterator iObject = theObjects.begin(); iObject != theObjects.end(); ++iObject ) {
-      thePathObjects.push_back( *iObject );
+  TriggerFilterRefVector theFilters = pathFilters(namePath, firing);
+  for (TriggerFilterRefVectorIterator iFilter = theFilters.begin(); iFilter != theFilters.end(); ++iFilter) {
+    const std::string labelFilter((*iFilter)->label());
+    TriggerObjectRefVector theObjects = filterObjects(labelFilter);
+    for (TriggerObjectRefVectorIterator iObject = theObjects.begin(); iObject != theObjects.end(); ++iObject) {
+      thePathObjects.push_back(*iObject);
     }
   }
   return thePathObjects;
 }
 
-
 // Checks, if an object was used in a certain path given by name
-bool TriggerEvent::objectInPath( const TriggerObjectRef & objectRef, const std::string & namePath, bool firing ) const
-{
-  TriggerFilterRefVector theFilters = pathFilters( namePath, firing );
-  for ( TriggerFilterRefVectorIterator iFilter = theFilters.begin(); iFilter != theFilters.end(); ++iFilter ) {
-    if ( objectInFilter( objectRef, ( *iFilter )->label() ) ) return true;
+bool TriggerEvent::objectInPath(const TriggerObjectRef& objectRef, const std::string& namePath, bool firing) const {
+  TriggerFilterRefVector theFilters = pathFilters(namePath, firing);
+  for (TriggerFilterRefVectorIterator iFilter = theFilters.begin(); iFilter != theFilters.end(); ++iFilter) {
+    if (objectInFilter(objectRef, (*iFilter)->label()))
+      return true;
   }
   return false;
 }
 
-
 // Get a vector of references to all paths, which have a certain object assigned
-TriggerPathRefVector TriggerEvent::objectPaths( const TriggerObjectRef & objectRef, bool firing ) const
-{
+TriggerPathRefVector TriggerEvent::objectPaths(const TriggerObjectRef& objectRef, bool firing) const {
   TriggerPathRefVector theObjectPaths;
-  for ( TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath ) {
-    const std::string namePath( iPath->name() );
-    if ( objectInPath( objectRef, namePath, firing ) ) {
-      const TriggerPathRef pathRef( paths_, indexPath( namePath ) );
-      theObjectPaths.push_back( pathRef );
+  for (TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath) {
+    const std::string namePath(iPath->name());
+    if (objectInPath(objectRef, namePath, firing)) {
+      const TriggerPathRef pathRef(paths_, indexPath(namePath));
+      theObjectPaths.push_back(pathRef);
     }
   }
   return theObjectPaths;
 }
 
-
 // Add a pat::TriggerObjectMatch association
-bool TriggerEvent::addObjectMatchResult( const TriggerObjectMatchRefProd & trigMatches, const std::string & labelMatcher )
-{
-  if ( triggerObjectMatchResults()->find( labelMatcher ) == triggerObjectMatchResults()->end() ) {
-    objectMatchResults_[ labelMatcher ] = trigMatches;
+bool TriggerEvent::addObjectMatchResult(const TriggerObjectMatchRefProd& trigMatches, const std::string& labelMatcher) {
+  if (triggerObjectMatchResults()->find(labelMatcher) == triggerObjectMatchResults()->end()) {
+    objectMatchResults_[labelMatcher] = trigMatches;
     return true;
   }
   return false;
 }
 
-
 // Get a list of all linked trigger matches
-std::vector< std::string > TriggerEvent::triggerMatchers() const
-{
-  std::vector< std::string > theMatchers;
-  for ( TriggerObjectMatchContainer::const_iterator iMatch = triggerObjectMatchResults()->begin(); iMatch != triggerObjectMatchResults()->end(); ++iMatch ) theMatchers.push_back( iMatch->first );
+std::vector<std::string> TriggerEvent::triggerMatchers() const {
+  std::vector<std::string> theMatchers;
+  for (TriggerObjectMatchContainer::const_iterator iMatch = triggerObjectMatchResults()->begin();
+       iMatch != triggerObjectMatchResults()->end();
+       ++iMatch)
+    theMatchers.push_back(iMatch->first);
   return theMatchers;
 }
 
-
 // Get a pointer to a certain trigger match given by label
-const TriggerObjectMatch * TriggerEvent::triggerObjectMatchResult( const std::string & labelMatcher ) const
-{
-  const TriggerObjectMatchContainer::const_iterator iMatch( triggerObjectMatchResults()->find( labelMatcher ) );
-  if ( iMatch != triggerObjectMatchResults()->end() ) return iMatch->second.get();
+const TriggerObjectMatch* TriggerEvent::triggerObjectMatchResult(const std::string& labelMatcher) const {
+  const TriggerObjectMatchContainer::const_iterator iMatch(triggerObjectMatchResults()->find(labelMatcher));
+  if (iMatch != triggerObjectMatchResults()->end())
+    return iMatch->second.get();
   return nullptr;
 }

--- a/DataFormats/PatCandidates/src/TriggerFilter.cc
+++ b/DataFormats/PatCandidates/src/TriggerFilter.cc
@@ -1,90 +1,65 @@
 //
 //
 
-
 #include "DataFormats/PatCandidates/interface/TriggerFilter.h"
-
 
 using namespace pat;
 
-
 // Constructors and Destructor
 
-
 // Default constructor
-TriggerFilter::TriggerFilter() :
-  label_(),
-  type_(),
-  status_(),
-  saveTags_()
-{
+TriggerFilter::TriggerFilter() : label_(), type_(), status_(), saveTags_() {
   objectKeys_.clear();
   triggerObjectTypes_.clear();
 }
-
 
 // Constructor from std::string for filter label
-TriggerFilter::TriggerFilter( const std::string & label, int status, bool saveTags ) :
-  label_( label ),
-  type_(),
-  status_( status ),
-  saveTags_( saveTags )
-{
+TriggerFilter::TriggerFilter(const std::string& label, int status, bool saveTags)
+    : label_(label), type_(), status_(status), saveTags_(saveTags) {
   objectKeys_.clear();
   triggerObjectTypes_.clear();
 }
-
 
 // Constructor from edm::InputTag for filter label
-TriggerFilter::TriggerFilter( const edm::InputTag & tag, int status, bool saveTags ) :
-  label_( tag.label() ),
-  type_(),
-  status_( status ),
-  saveTags_( saveTags )
-{
+TriggerFilter::TriggerFilter(const edm::InputTag& tag, int status, bool saveTags)
+    : label_(tag.label()), type_(), status_(status), saveTags_(saveTags) {
   objectKeys_.clear();
   triggerObjectTypes_.clear();
 }
-
 
 // Methods
 
-
 // Set the filter status
-bool TriggerFilter::setStatus( int status )
-{
-  if ( status < -1 || 1 < status ) return false;
+bool TriggerFilter::setStatus(int status) {
+  if (status < -1 || 1 < status)
+    return false;
   status_ = status;
   return true;
 }
 
-
 // Get all trigger object type identifiers
-std::vector< int > TriggerFilter::triggerObjectTypes() const
-{
-  std::vector< int > triggerObjectTypes;
-  for ( size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo ) {
-    triggerObjectTypes.push_back( triggerObjectTypes_.at( iTo ) );
+std::vector<int> TriggerFilter::triggerObjectTypes() const {
+  std::vector<int> triggerObjectTypes;
+  for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
+    triggerObjectTypes.push_back(triggerObjectTypes_.at(iTo));
   }
   return triggerObjectTypes;
 }
 
-
 // Checks, if a certain trigger object collection index is assigned
-bool TriggerFilter::hasObjectKey( unsigned objectKey ) const
-{
-  for ( size_t iO = 0; iO < objectKeys().size(); ++iO ) {
-    if ( objectKeys().at( iO ) == objectKey ) return true;
+bool TriggerFilter::hasObjectKey(unsigned objectKey) const {
+  for (size_t iO = 0; iO < objectKeys().size(); ++iO) {
+    if (objectKeys().at(iO) == objectKey)
+      return true;
   }
   return false;
 }
 
-
 // Checks, if a certain trigger object type identifier is assigned
-bool TriggerFilter::hasTriggerObjectType( trigger::TriggerObjectType triggerObjectType ) const
-{
-  for ( size_t iO = 0; iO < triggerObjectTypes().size(); ++iO ) {
-    if ( triggerObjectTypes().at( iO ) == triggerObjectType ) return true;
+bool TriggerFilter::hasTriggerObjectType(trigger::TriggerObjectType triggerObjectType) const {
+  for (size_t iO = 0; iO < triggerObjectTypes().size(); ++iO) {
+    if (triggerObjectTypes().at(iO) == triggerObjectType)
+      return true;
   }
   return false;
 }

--- a/DataFormats/PatCandidates/src/TriggerObject.cc
+++ b/DataFormats/PatCandidates/src/TriggerObject.cc
@@ -5,158 +5,130 @@
 
 #include "FWCore/Utilities/interface/EDMException.h"
 
-
 using namespace pat;
-
 
 // Constructors and Destructor
 
-
 // Default constructor
-TriggerObject::TriggerObject() :
-  reco::LeafCandidate()
-{
-  triggerObjectTypes_.clear();
-}
-
+TriggerObject::TriggerObject() : reco::LeafCandidate() { triggerObjectTypes_.clear(); }
 
 // Constructor from trigger::TriggerObject
-TriggerObject::TriggerObject( const trigger::TriggerObject & trigObj ) :
-  reco::LeafCandidate( 0, trigObj.particle().p4(), reco::Particle::Point( 0., 0., 0. ), trigObj.id() ),
-  refToOrig_()
-{
+TriggerObject::TriggerObject(const trigger::TriggerObject& trigObj)
+    : reco::LeafCandidate(0, trigObj.particle().p4(), reco::Particle::Point(0., 0., 0.), trigObj.id()), refToOrig_() {
   triggerObjectTypes_.clear();
 }
-
 
 // Constructors from base class object
-TriggerObject::TriggerObject( const reco::LeafCandidate & leafCand ) :
-  reco::LeafCandidate( leafCand ),
-  refToOrig_()
-{
+TriggerObject::TriggerObject(const reco::LeafCandidate& leafCand) : reco::LeafCandidate(leafCand), refToOrig_() {
   triggerObjectTypes_.clear();
 }
-
 
 // Constructors from base candidate reference (for 'l1extra' particles)
-TriggerObject::TriggerObject( const reco::CandidateBaseRef & candRef ) :
-  reco::LeafCandidate( *candRef ),
-  refToOrig_( candRef )
-{
+TriggerObject::TriggerObject(const reco::CandidateBaseRef& candRef)
+    : reco::LeafCandidate(*candRef), refToOrig_(candRef) {
   triggerObjectTypes_.clear();
 }
-
 
 // Constructors from Lorentz-vectors and (optional) PDG ID
-TriggerObject::TriggerObject( const reco::Particle::LorentzVector & vec, int id ) :
-  reco::LeafCandidate( 0, vec, reco::Particle::Point( 0., 0., 0. ), id ),
-  refToOrig_()
-{
+TriggerObject::TriggerObject(const reco::Particle::LorentzVector& vec, int id)
+    : reco::LeafCandidate(0, vec, reco::Particle::Point(0., 0., 0.), id), refToOrig_() {
   triggerObjectTypes_.clear();
 }
-TriggerObject::TriggerObject( const reco::Particle::PolarLorentzVector & vec, int id ) :
-  reco::LeafCandidate( 0, vec, reco::Particle::Point( 0., 0., 0. ), id ),
-  refToOrig_()
-{
+TriggerObject::TriggerObject(const reco::Particle::PolarLorentzVector& vec, int id)
+    : reco::LeafCandidate(0, vec, reco::Particle::Point(0., 0., 0.), id), refToOrig_() {
   triggerObjectTypes_.clear();
 }
-
 
 // Methods
 
-
 // Get all trigger object type identifiers
-std::vector< int > TriggerObject::triggerObjectTypes() const
-{
-  std::vector< int > triggerObjectTypes;
-  for ( size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo ) {
-    triggerObjectTypes.push_back( triggerObjectTypes_.at( iTo ) );
+std::vector<int> TriggerObject::triggerObjectTypes() const {
+  std::vector<int> triggerObjectTypes;
+  for (size_t iTo = 0; iTo < triggerObjectTypes_.size(); ++iTo) {
+    triggerObjectTypes.push_back(triggerObjectTypes_.at(iTo));
   }
   return triggerObjectTypes;
 }
 
-
 // Checks, if a certain label of original collection is assigned
-bool TriggerObject::hasCollection( const std::string & collName ) const
-{
+bool TriggerObject::hasCollection(const std::string& collName) const {
   // True, if collection name is simply fine
-  if ( collName == collection_ ) return true;
+  if (collName == collection_)
+    return true;
   // Check, if collection name possibly fits in an edm::InputTag approach
-  const edm::InputTag collectionTag( collection_ );
-  const edm::InputTag collTag( collName );
+  const edm::InputTag collectionTag(collection_);
+  const edm::InputTag collTag(collName);
   // If evaluated collection tag contains a process name, it must have been found already by identity check
-  if ( collTag.process().empty() ) {
+  if (collTag.process().empty()) {
     // Check instance ...
-    if ( ( collTag.instance().empty() && collectionTag.instance().empty() ) || collTag.instance() == collectionTag.instance() ) {
+    if ((collTag.instance().empty() && collectionTag.instance().empty()) ||
+        collTag.instance() == collectionTag.instance()) {
       // ... and label
-      return ( collTag.label() == collectionTag.label() );
+      return (collTag.label() == collectionTag.label());
     }
   }
   return false;
 }
 
-
 // Checks, if a certain trigger object type identifier is assigned
-bool TriggerObject::hasTriggerObjectType( trigger::TriggerObjectType triggerObjectType ) const
-{
-  for ( size_t iF = 0; iF < triggerObjectTypes_.size(); ++iF ) {
-    if ( triggerObjectType == triggerObjectTypes_.at( iF ) ) return true;
+bool TriggerObject::hasTriggerObjectType(trigger::TriggerObjectType triggerObjectType) const {
+  for (size_t iF = 0; iF < triggerObjectTypes_.size(); ++iF) {
+    if (triggerObjectType == triggerObjectTypes_.at(iF))
+      return true;
   }
   return false;
 }
 
-
 // Special methods for 'l1extra' particles
-
 
 // Getters specific to the 'l1extra' particle types
 // Exceptions of type 'edm::errors::InvalidReference' are thrown,
 // if wrong particle type is requested
 
 // EM
-const l1extra::L1EmParticleRef TriggerObject::origL1EmRef() const
-{
+const l1extra::L1EmParticleRef TriggerObject::origL1EmRef() const {
   l1extra::L1EmParticleRef l1Ref;
   try {
-    l1Ref = origObjRef().castTo< l1extra::L1EmParticleRef >();
-  } catch ( edm::Exception const& X ) {
-    if ( X.categoryCode() != edm::errors::InvalidReference ) throw X;
+    l1Ref = origObjRef().castTo<l1extra::L1EmParticleRef>();
+  } catch (edm::Exception const& X) {
+    if (X.categoryCode() != edm::errors::InvalidReference)
+      throw X;
   }
   return l1Ref;
 }
 
 // EtMiss
-const l1extra::L1EtMissParticleRef TriggerObject::origL1EtMissRef() const
-{
+const l1extra::L1EtMissParticleRef TriggerObject::origL1EtMissRef() const {
   l1extra::L1EtMissParticleRef l1Ref;
   try {
-    l1Ref = origObjRef().castTo< l1extra::L1EtMissParticleRef >();
-  } catch ( edm::Exception const & X ) {
-    if ( X.categoryCode() != edm::errors::InvalidReference ) throw X;
+    l1Ref = origObjRef().castTo<l1extra::L1EtMissParticleRef>();
+  } catch (edm::Exception const& X) {
+    if (X.categoryCode() != edm::errors::InvalidReference)
+      throw X;
   }
   return l1Ref;
 }
 
 // Jet
-const l1extra::L1JetParticleRef TriggerObject::origL1JetRef() const
-{
+const l1extra::L1JetParticleRef TriggerObject::origL1JetRef() const {
   l1extra::L1JetParticleRef l1Ref;
   try {
-    l1Ref = origObjRef().castTo< l1extra::L1JetParticleRef >();
-  } catch ( edm::Exception const & X ) {
-    if ( X.categoryCode() != edm::errors::InvalidReference ) throw X;
+    l1Ref = origObjRef().castTo<l1extra::L1JetParticleRef>();
+  } catch (edm::Exception const& X) {
+    if (X.categoryCode() != edm::errors::InvalidReference)
+      throw X;
   }
   return l1Ref;
 }
 
 // Muon
-const l1extra::L1MuonParticleRef TriggerObject::origL1MuonRef() const
-{
+const l1extra::L1MuonParticleRef TriggerObject::origL1MuonRef() const {
   l1extra::L1MuonParticleRef l1Ref;
   try {
-    l1Ref = origObjRef().castTo< l1extra::L1MuonParticleRef >();
-  } catch ( edm::Exception const& X ) {
-    if ( X.categoryCode() != edm::errors::InvalidReference ) throw X;
+    l1Ref = origObjRef().castTo<l1extra::L1MuonParticleRef>();
+  } catch (edm::Exception const& X) {
+    if (X.categoryCode() != edm::errors::InvalidReference)
+      throw X;
   }
   return l1Ref;
 }

--- a/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
+++ b/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
@@ -13,118 +13,100 @@
 
 using namespace pat;
 
-
 // Const data members' definitions
-
 
 const char TriggerObjectStandAlone::wildcard_;
 
-
 // Constructors and Destructor
 
-
 // Default constructor
-TriggerObjectStandAlone::TriggerObjectStandAlone() :
-  TriggerObject()
-{
+TriggerObjectStandAlone::TriggerObjectStandAlone() : TriggerObject() {
   filterLabels_.clear();
   filterLabelIndices_.clear();
   pathNames_.clear();
   pathLastFilterAccepted_.clear();
   pathL3FilterAccepted_.clear();
 }
-
 
 // Constructor from pat::TriggerObject
-TriggerObjectStandAlone::TriggerObjectStandAlone( const TriggerObject & trigObj ) :
-  TriggerObject( trigObj )
-{
+TriggerObjectStandAlone::TriggerObjectStandAlone(const TriggerObject &trigObj) : TriggerObject(trigObj) {
   filterLabels_.clear();
   filterLabelIndices_.clear();
   pathNames_.clear();
   pathLastFilterAccepted_.clear();
   pathL3FilterAccepted_.clear();
 }
-
 
 // Constructor from trigger::TriggerObject
-TriggerObjectStandAlone::TriggerObjectStandAlone( const trigger::TriggerObject & trigObj ) :
-  TriggerObject( trigObj )
-{
+TriggerObjectStandAlone::TriggerObjectStandAlone(const trigger::TriggerObject &trigObj) : TriggerObject(trigObj) {
   filterLabels_.clear();
   filterLabelIndices_.clear();
   pathNames_.clear();
   pathLastFilterAccepted_.clear();
   pathL3FilterAccepted_.clear();
 }
-
 
 // Constructor from reco::Candidate
-TriggerObjectStandAlone::TriggerObjectStandAlone( const reco::LeafCandidate & leafCand ) :
-  TriggerObject( leafCand )
-{
+TriggerObjectStandAlone::TriggerObjectStandAlone(const reco::LeafCandidate &leafCand) : TriggerObject(leafCand) {
   filterLabels_.clear();
   filterLabelIndices_.clear();
   pathNames_.clear();
   pathLastFilterAccepted_.clear();
   pathL3FilterAccepted_.clear();
 }
-
 
 // Constructors from Lorentz-vectors and (optional) PDG ID
-TriggerObjectStandAlone::TriggerObjectStandAlone( const reco::Particle::LorentzVector & vec, int id ) :
-  TriggerObject( vec, id )
-{
+TriggerObjectStandAlone::TriggerObjectStandAlone(const reco::Particle::LorentzVector &vec, int id)
+    : TriggerObject(vec, id) {
   filterLabels_.clear();
   filterLabelIndices_.clear();
   pathNames_.clear();
   pathLastFilterAccepted_.clear();
   pathL3FilterAccepted_.clear();
 }
-TriggerObjectStandAlone::TriggerObjectStandAlone( const reco::Particle::PolarLorentzVector & vec, int id ) :
-  TriggerObject( vec, id )
-{
+TriggerObjectStandAlone::TriggerObjectStandAlone(const reco::Particle::PolarLorentzVector &vec, int id)
+    : TriggerObject(vec, id) {
   filterLabels_.clear();
   filterLabelIndices_.clear();
   pathNames_.clear();
   pathLastFilterAccepted_.clear();
   pathL3FilterAccepted_.clear();
 }
-
 
 // Private methods
 
-
 // Checks a string vector for occurence of a certain string, incl. wild-card mechanism
-bool TriggerObjectStandAlone::hasAnyName( const std::string & name, const std::vector< std::string > & nameVec ) const
-{
+bool TriggerObjectStandAlone::hasAnyName(const std::string &name, const std::vector<std::string> &nameVec) const {
   // Special cases first
   // Always false for empty vector to check
-  if ( nameVec.empty() ) return false;
+  if (nameVec.empty())
+    return false;
   // Always true for general wild-card(s)
-  if ( name.find_first_not_of( wildcard_ ) == std::string::npos ) return true;
+  if (name.find_first_not_of(wildcard_) == std::string::npos)
+    return true;
   // Split name to evaluate in parts, seperated by wild-cards
-  std::vector< std::string > namePartsVec;
-  boost::split( namePartsVec, name, boost::is_any_of( std::string( 1, wildcard_ ) ), boost::token_compress_on );
+  std::vector<std::string> namePartsVec;
+  boost::split(namePartsVec, name, boost::is_any_of(std::string(1, wildcard_)), boost::token_compress_on);
   // Iterate over vector of names to search
-  for ( std::vector< std::string >::const_iterator iVec = nameVec.begin(); iVec != nameVec.end(); ++iVec ) {
+  for (std::vector<std::string>::const_iterator iVec = nameVec.begin(); iVec != nameVec.end(); ++iVec) {
     // Not failed yet
-    bool failed( false );
+    bool failed(false);
     // Start searching at the first character
-    size_type index( 0 );
+    size_type index(0);
     // Iterate over evaluation name parts
-    for ( std::vector< std::string >::const_iterator iName = namePartsVec.begin(); iName != namePartsVec.end(); ++iName ) {
+    for (std::vector<std::string>::const_iterator iName = namePartsVec.begin(); iName != namePartsVec.end(); ++iName) {
       // Empty parts due to
       // - wild-card at beginning/end or
       // - multiple wild-cards (should be supressed by 'boost::token_compress_on')
-      if ( iName->length() == 0 ) continue;
+      if (iName->length() == 0)
+        continue;
       // Search from current index and
       // set index to found occurence
-      index = iVec->find( *iName, index );
+      index = iVec->find(*iName, index);
       // Failed and exit loop, if
       // - part not found
       // - part at beginning not found there
-      if ( index == std::string::npos || ( iName == namePartsVec.begin() && index > 0 ) ) {
+      if (index == std::string::npos || (iName == namePartsVec.begin() && index > 0)) {
         failed = true;
         break;
       }
@@ -132,310 +114,324 @@ bool TriggerObjectStandAlone::hasAnyName( const std::string & name, const std::v
       index += iName->length();
     }
     // Failed, if end of name not reached
-    if ( index < iVec->length() && namePartsVec.back().length() != 0 ) failed = true;
+    if (index < iVec->length() && namePartsVec.back().length() != 0)
+      failed = true;
     // Match found!
-    if ( ! failed ) return true;
+    if (!failed)
+      return true;
   }
   // No match found!
   return false;
 }
 
-
 // Adds a new HLT path or L1 algorithm name
-void TriggerObjectStandAlone::addPathOrAlgorithm( const std::string & name, bool pathLastFilterAccepted, bool pathL3FilterAccepted )
-{
+void TriggerObjectStandAlone::addPathOrAlgorithm(const std::string &name,
+                                                 bool pathLastFilterAccepted,
+                                                 bool pathL3FilterAccepted) {
   checkIfPathsAreUnpacked();
 
   // Check, if path is already assigned
-  if ( ! hasPathOrAlgorithm( name, false, false ) ) {
+  if (!hasPathOrAlgorithm(name, false, false)) {
     // The path itself
-    pathNames_.push_back( name );
+    pathNames_.push_back(name);
     // The corresponding usage of the trigger objects
-    pathLastFilterAccepted_.push_back( pathLastFilterAccepted );
-    pathL3FilterAccepted_.push_back( pathL3FilterAccepted );
-  // Enable status updates
-  } else if ( pathLastFilterAccepted || pathL3FilterAccepted ) {
+    pathLastFilterAccepted_.push_back(pathLastFilterAccepted);
+    pathL3FilterAccepted_.push_back(pathL3FilterAccepted);
+    // Enable status updates
+  } else if (pathLastFilterAccepted || pathL3FilterAccepted) {
     // Search for path
-    unsigned index( 0 );
-    while ( index < pathNames_.size() ) {
-      if ( pathNames_.at( index ) == name ) break;
+    unsigned index(0);
+    while (index < pathNames_.size()) {
+      if (pathNames_.at(index) == name)
+        break;
       ++index;
     }
     // Status update
-    if ( index < pathNames_.size() ) {
-      pathLastFilterAccepted_.at( index ) = pathLastFilterAccepted_.at( index ) || pathLastFilterAccepted;
-      pathL3FilterAccepted_.at( index )   = pathL3FilterAccepted_.at( index )   || pathL3FilterAccepted;
+    if (index < pathNames_.size()) {
+      pathLastFilterAccepted_.at(index) = pathLastFilterAccepted_.at(index) || pathLastFilterAccepted;
+      pathL3FilterAccepted_.at(index) = pathL3FilterAccepted_.at(index) || pathL3FilterAccepted;
     }
   }
 }
 
-
 // Gets all HLT path or L1 algorithm names
-std::vector< std::string > TriggerObjectStandAlone::pathsOrAlgorithms( bool pathLastFilterAccepted, bool pathL3FilterAccepted ) const
-{
+std::vector<std::string> TriggerObjectStandAlone::pathsOrAlgorithms(bool pathLastFilterAccepted,
+                                                                    bool pathL3FilterAccepted) const {
   checkIfPathsAreUnpacked();
 
   // Deal with older PAT-tuples, where trigger object usage is not available
-  if ( ! hasLastFilter() ) pathLastFilterAccepted = false;
-  if ( ! hasL3Filter() ) pathL3FilterAccepted = false;
+  if (!hasLastFilter())
+    pathLastFilterAccepted = false;
+  if (!hasL3Filter())
+    pathL3FilterAccepted = false;
   // All path names, if usage not restricted (not required or not available)
-  if ( ! pathLastFilterAccepted && ! pathL3FilterAccepted ) return pathNames_;
+  if (!pathLastFilterAccepted && !pathL3FilterAccepted)
+    return pathNames_;
   // Temp vector of path names
-  std::vector< std::string > paths;
+  std::vector<std::string> paths;
   // Loop over usage vector and fill corresponding paths into temp vector
-  for ( unsigned iPath = 0; iPath < pathNames_.size(); ++iPath ) {
-    if ( ( ! pathLastFilterAccepted || pathLastFilterAccepted_.at( iPath ) ) && ( ! pathL3FilterAccepted || pathL3FilterAccepted_.at( iPath ) ) ) paths.push_back( pathNames_.at( iPath ) ); // order matters in order to protect from empty vectors in old data
+  for (unsigned iPath = 0; iPath < pathNames_.size(); ++iPath) {
+    if ((!pathLastFilterAccepted || pathLastFilterAccepted_.at(iPath)) &&
+        (!pathL3FilterAccepted || pathL3FilterAccepted_.at(iPath)))
+      paths.push_back(pathNames_.at(iPath));  // order matters in order to protect from empty vectors in old data
   }
   // Return temp vector
   return paths;
 }
 
-
 // Checks, if a certain HLT filter label or L1 condition name is assigned
-bool TriggerObjectStandAlone::hasFilterOrCondition( const std::string & name ) const
-{
+bool TriggerObjectStandAlone::hasFilterOrCondition(const std::string &name) const {
   checkIfFiltersAreUnpacked();
 
   // Move to wild-card parser, if needed
-  if ( name.find( wildcard_ ) != std::string::npos ) return hasAnyName( name, filterLabels_ );
+  if (name.find(wildcard_) != std::string::npos)
+    return hasAnyName(name, filterLabels_);
   // Return, if filter label is assigned
-  return ( std::find( filterLabels_.begin(), filterLabels_.end(), name ) != filterLabels_.end() );
+  return (std::find(filterLabels_.begin(), filterLabels_.end(), name) != filterLabels_.end());
 }
 
-
 // Checks, if a certain path name is assigned
-bool TriggerObjectStandAlone::hasPathOrAlgorithm( const std::string & name, bool pathLastFilterAccepted, bool pathL3FilterAccepted ) const
-{
+bool TriggerObjectStandAlone::hasPathOrAlgorithm(const std::string &name,
+                                                 bool pathLastFilterAccepted,
+                                                 bool pathL3FilterAccepted) const {
   checkIfPathsAreUnpacked();
 
   // Move to wild-card parser, if needed
-  if ( name.find( wildcard_ ) != std::string::npos ) return hasAnyName( name, pathsOrAlgorithms( pathLastFilterAccepted, pathL3FilterAccepted ) );
+  if (name.find(wildcard_) != std::string::npos)
+    return hasAnyName(name, pathsOrAlgorithms(pathLastFilterAccepted, pathL3FilterAccepted));
   // Deal with older PAT-tuples, where trigger object usage is not available
-  if ( ! hasLastFilter() ) pathLastFilterAccepted = false;
-  if ( ! hasL3Filter() ) pathL3FilterAccepted = false;
+  if (!hasLastFilter())
+    pathLastFilterAccepted = false;
+  if (!hasL3Filter())
+    pathL3FilterAccepted = false;
   // Check, if path name is assigned at all
-  std::vector< std::string >::const_iterator match( std::find( pathNames_.begin(), pathNames_.end(), name ) );
+  std::vector<std::string>::const_iterator match(std::find(pathNames_.begin(), pathNames_.end(), name));
   // False, if path name not assigned
-  if ( match == pathNames_.end() ) return false;
-  if ( ! pathLastFilterAccepted && ! pathL3FilterAccepted ) return true;
-  bool foundLastFilter( pathLastFilterAccepted ? pathLastFilterAccepted_.at( match - pathNames_.begin() ) : true );
-  bool foundL3Filter( pathL3FilterAccepted ? pathL3FilterAccepted_.at( match - pathNames_.begin() ) : true );
+  if (match == pathNames_.end())
+    return false;
+  if (!pathLastFilterAccepted && !pathL3FilterAccepted)
+    return true;
+  bool foundLastFilter(pathLastFilterAccepted ? pathLastFilterAccepted_.at(match - pathNames_.begin()) : true);
+  bool foundL3Filter(pathL3FilterAccepted ? pathL3FilterAccepted_.at(match - pathNames_.begin()) : true);
   // Return for assigned path name, if trigger object usage meets requirement
-  return ( foundLastFilter && foundL3Filter );
+  return (foundLastFilter && foundL3Filter);
 }
-
 
 // Methods
 
-
 // Gets the pat::TriggerObject (parent class)
-TriggerObject TriggerObjectStandAlone::triggerObject()
-{
+TriggerObject TriggerObjectStandAlone::triggerObject() {
   // Create a TriggerObjects
-  TriggerObject theObj( p4(), pdgId() );
+  TriggerObject theObj(p4(), pdgId());
   // Set its collection and trigger objects types (no c'tor for that)
-  theObj.setCollection( collection() );
-  for ( size_t i = 0; i < triggerObjectTypes().size(); ++i ) theObj.addTriggerObjectType( triggerObjectTypes().at( i ) );
+  theObj.setCollection(collection());
+  for (size_t i = 0; i < triggerObjectTypes().size(); ++i)
+    theObj.addTriggerObjectType(triggerObjectTypes().at(i));
   // Return TriggerObject
   return theObj;
 }
 
-
 // Checks, if a certain label of original collection is assigned (method overrides)
-bool TriggerObjectStandAlone::hasCollection( const std::string & collName ) const
-{
+bool TriggerObjectStandAlone::hasCollection(const std::string &collName) const {
   // Move to wild-card parser, if needed only
-  if ( collName.find( wildcard_ ) != std::string::npos ) {
+  if (collName.find(wildcard_) != std::string::npos) {
     // True, if collection name is simply fine
-    if ( hasAnyName( collName, std::vector< std::string >( 1, collection() ) ) ) return true;
+    if (hasAnyName(collName, std::vector<std::string>(1, collection())))
+      return true;
     // Check, if collection name possibly fits in an edm::InputTag approach
-    const edm::InputTag collectionTag( collection() );
-    const edm::InputTag collTag( collName );
+    const edm::InputTag collectionTag(collection());
+    const edm::InputTag collTag(collName);
     // If evaluated collection tag contains a process name, it must have been found already by identity check
-    if ( collTag.process().empty() ) {
+    if (collTag.process().empty()) {
       // Check instance ...
-      if ( ( collTag.instance().empty() && collectionTag.instance().empty() ) || hasAnyName( collTag.instance(), std::vector< std::string >( 1, collectionTag.instance() ) ) ) {
+      if ((collTag.instance().empty() && collectionTag.instance().empty()) ||
+          hasAnyName(collTag.instance(), std::vector<std::string>(1, collectionTag.instance()))) {
         // ... and label
-        return hasAnyName( collTag.label(), std::vector< std::string >( 1, collectionTag.label() ) );
+        return hasAnyName(collTag.label(), std::vector<std::string>(1, collectionTag.label()));
       }
     }
     return false;
   }
   // Use parent class's method otherwise
-  return TriggerObject::hasCollection( collName );
+  return TriggerObject::hasCollection(collName);
 }
-
 
 bool TriggerObjectStandAlone::checkIfPathsAreUnpacked(bool throwIfPacked) const {
-   bool unpacked = (!pathNames_.empty() || pathIndices_.empty());
-   if (!unpacked && throwIfPacked) throw cms::Exception("RuntimeError", "This TriggerObjectStandAlone object has packed trigger path names. Before accessing path names you must call unpackPathNames with an edm::TriggerNames object. You can get the latter from the edm::Event or fwlite::Event and the TriggerResults\n");
-   return unpacked;
+  bool unpacked = (!pathNames_.empty() || pathIndices_.empty());
+  if (!unpacked && throwIfPacked)
+    throw cms::Exception("RuntimeError",
+                         "This TriggerObjectStandAlone object has packed trigger path names. Before accessing path "
+                         "names you must call unpackPathNames with an edm::TriggerNames object. You can get the latter "
+                         "from the edm::Event or fwlite::Event and the TriggerResults\n");
+  return unpacked;
 }
 bool TriggerObjectStandAlone::checkIfFiltersAreUnpacked(bool throwIfPacked) const {
-   bool unpacked = filterLabelIndices_.empty();
-   if (!unpacked && throwIfPacked) throw cms::Exception("RuntimeError", "This TriggerObjectStandAlone object has packed trigger filter labels. Before accessing path names you must call unpackFilterLabels with an edm::EventBase object. Both the edm::Event or fwlite::Event are derived from edm::EventBase and can be passed\n");
-   return unpacked;
+  bool unpacked = filterLabelIndices_.empty();
+  if (!unpacked && throwIfPacked)
+    throw cms::Exception("RuntimeError",
+                         "This TriggerObjectStandAlone object has packed trigger filter labels. Before accessing path "
+                         "names you must call unpackFilterLabels with an edm::EventBase object. Both the edm::Event or "
+                         "fwlite::Event are derived from edm::EventBase and can be passed\n");
+  return unpacked;
 }
 
-
-
 void TriggerObjectStandAlone::packPathNames(const edm::TriggerNames &names) {
-    if (!pathIndices_.empty()) {
-        if (!pathNames_.empty()) {
-            throw cms::Exception("RuntimeError", "Error, trying to pack a partially packed TriggerObjectStandAlone");
-        } else {
-            return;
-        }
+  if (!pathIndices_.empty()) {
+    if (!pathNames_.empty()) {
+      throw cms::Exception("RuntimeError", "Error, trying to pack a partially packed TriggerObjectStandAlone");
+    } else {
+      return;
     }
-    bool ok = true;
-    unsigned int n = pathNames_.size(), end = names.size();
-    std::vector<uint16_t> indices(n); 
-    for (unsigned int i = 0; i < n; ++i) {
-        uint16_t id = names.triggerIndex(pathNames_[i]);
-        if (id >= end) {
-            static std::atomic<int> _warn(0);
-            if (++_warn < 5) edm::LogWarning("TriggerObjectStandAlone::packPathNames()") << "Warning: can't resolve '" << pathNames_[i] << "' to a path index" << std::endl;
-            ok = false; break;
-        } else {
-            indices[i] = id;
-        }
+  }
+  bool ok = true;
+  unsigned int n = pathNames_.size(), end = names.size();
+  std::vector<uint16_t> indices(n);
+  for (unsigned int i = 0; i < n; ++i) {
+    uint16_t id = names.triggerIndex(pathNames_[i]);
+    if (id >= end) {
+      static std::atomic<int> _warn(0);
+      if (++_warn < 5)
+        edm::LogWarning("TriggerObjectStandAlone::packPathNames()")
+            << "Warning: can't resolve '" << pathNames_[i] << "' to a path index" << std::endl;
+      ok = false;
+      break;
+    } else {
+      indices[i] = id;
     }
-    if (ok) {
-        pathIndices_.swap(indices);
-        pathNames_.clear();
-    }
+  }
+  if (ok) {
+    pathIndices_.swap(indices);
+    pathNames_.clear();
+  }
 }
 
 void TriggerObjectStandAlone::unpackPathNames(const edm::TriggerNames &names) {
-    if (!pathNames_.empty()) {
-        if (!pathIndices_.empty()) {
-            throw cms::Exception("RuntimeError", "Error, trying to unpack a partially unpacked TriggerObjectStandAlone");
-        } else {
-            return;
-        }
+  if (!pathNames_.empty()) {
+    if (!pathIndices_.empty()) {
+      throw cms::Exception("RuntimeError", "Error, trying to unpack a partially unpacked TriggerObjectStandAlone");
+    } else {
+      return;
     }
-    unsigned int n = pathIndices_.size(), end = names.size();
-    std::vector<std::string> paths(n); 
-    for (unsigned int i = 0; i < n; ++i) {
-        if (pathIndices_[i] >= end) throw cms::Exception("RuntimeError", "Error, path index out of bounds");
-        paths[i] = names.triggerName(pathIndices_[i]);
+  }
+  unsigned int n = pathIndices_.size(), end = names.size();
+  std::vector<std::string> paths(n);
+  for (unsigned int i = 0; i < n; ++i) {
+    if (pathIndices_[i] >= end)
+      throw cms::Exception("RuntimeError", "Error, path index out of bounds");
+    paths[i] = names.triggerName(pathIndices_[i]);
+  }
+  pathIndices_.clear();
+  pathNames_.swap(paths);
+}
+
+void TriggerObjectStandAlone::packFilterLabels(const std::vector<std::string> &names) {
+  if (!filterLabelIndices_.empty()) {
+    throw cms::Exception("RuntimeError",
+                         "Error, trying to pack filter labels for an already packed TriggerObjectStandAlone");
+  }
+  std::vector<std::string> unmatched;
+  std::vector<uint16_t> indices;
+  indices.reserve(filterLabels_.size());
+
+  auto nStart = names.begin(), nEnd = names.end();
+  for (unsigned int i = 0, n = filterLabels_.size(); i < n; ++i) {
+    auto match = std::lower_bound(nStart, nEnd, filterLabels_[i]);
+    if (match != nEnd && *match == filterLabels_[i]) {
+      indices.push_back(match - nStart);
+    } else {
+      static std::atomic<int> _warn(0);
+      if (++_warn < 5)
+        edm::LogWarning("TriggerObjectStandAlone::packFilterLabels()")
+            << "Warning: can't resolve '" << filterLabels_[i] << "' to a label index. idx: " << i << std::endl;
+      unmatched.push_back(std::move(filterLabels_[i]));
     }
-    pathIndices_.clear();
-    pathNames_.swap(paths);
+  }
+  std::sort(indices.begin(), indices.end());  // try reduce enthropy
+  filterLabelIndices_.swap(indices);
+  filterLabels_.swap(unmatched);
 }
 
-void TriggerObjectStandAlone::packFilterLabels(const std::vector<std::string> &names)  {
-    if (!filterLabelIndices_.empty()) {
-        throw cms::Exception("RuntimeError", "Error, trying to pack filter labels for an already packed TriggerObjectStandAlone");
-    }
-    std::vector<std::string> unmatched;
-    std::vector<uint16_t> indices;
-    indices.reserve(filterLabels_.size());
-   
-    auto nStart = names.begin(), nEnd = names.end();
-    for (unsigned int i = 0, n = filterLabels_.size(); i < n; ++i) {
-        auto match = std::lower_bound(nStart, nEnd, filterLabels_[i]);
-        if (match != nEnd && *match == filterLabels_[i]) {
-            indices.push_back(match - nStart);
-        } else {
-            static std::atomic<int> _warn(0);
-            if(++_warn < 5) edm::LogWarning("TriggerObjectStandAlone::packFilterLabels()") << "Warning: can't resolve '" << filterLabels_[i] << "' to a label index. idx: " << i <<std::endl;
-            unmatched.push_back(std::move(filterLabels_[i]));
-        }
-    }
-    std::sort(indices.begin(), indices.end()); // try reduce enthropy
-    filterLabelIndices_.swap(indices);
-    filterLabels_.swap(unmatched);
+void TriggerObjectStandAlone::unpackNamesAndLabels(const edm::EventBase &event, const edm::TriggerResults &res) {
+  unpackPathNames(event.triggerNames(res));
+  unpackFilterLabels(event, res);
 }
 
-void TriggerObjectStandAlone::unpackNamesAndLabels(const edm::EventBase & event,const edm::TriggerResults &res)
-{
- unpackPathNames(event.triggerNames(res));
- unpackFilterLabels(event,res);
-
+void TriggerObjectStandAlone::unpackFilterLabels(const edm::EventBase &event, const edm::TriggerResults &res) {
+  unpackFilterLabels(*allLabels(psetId_, event, res));
 }
 
-void TriggerObjectStandAlone::unpackFilterLabels(const edm::EventBase & event,const edm::TriggerResults &res)  {
-  unpackFilterLabels(*allLabels(psetId_,event,res));
-}
+void TriggerObjectStandAlone::unpackFilterLabels(const std::vector<std::string> &labels) {
+  if (filterLabelIndices_.empty())
+    return;
 
-void TriggerObjectStandAlone::unpackFilterLabels(const std::vector<std::string> &labels)  {
-    if (filterLabelIndices_.empty()) return;
-
-    std::vector<std::string> mylabels(filterLabels_);
-    for (unsigned int i = 0, n = filterLabelIndices_.size(), m = labels.size(); i < n; ++i) {
-        if (filterLabelIndices_[i] >= m) throw cms::Exception("RuntimeError", "Error, filter label index out of bounds");
-        mylabels.push_back(labels[filterLabelIndices_[i]]);
-    }
-    filterLabelIndices_.clear();
-    filterLabels_.swap(mylabels);
+  std::vector<std::string> mylabels(filterLabels_);
+  for (unsigned int i = 0, n = filterLabelIndices_.size(), m = labels.size(); i < n; ++i) {
+    if (filterLabelIndices_[i] >= m)
+      throw cms::Exception("RuntimeError", "Error, filter label index out of bounds");
+    mylabels.push_back(labels[filterLabelIndices_[i]]);
+  }
+  filterLabelIndices_.clear();
+  filterLabels_.swap(mylabels);
 }
-void TriggerObjectStandAlone::packFilterLabels(const edm::EventBase &event,const edm::TriggerResults &res)  {
-   packFilterLabels(*allLabels(psetId_,event,res));
+void TriggerObjectStandAlone::packFilterLabels(const edm::EventBase &event, const edm::TriggerResults &res) {
+  packFilterLabels(*allLabels(psetId_, event, res));
 }
-
 
 void TriggerObjectStandAlone::packP4() {
-    setP4(reco::Particle::PolarLorentzVector(
-                MiniFloatConverter::reduceMantissaToNbitsRounding<14>(pt()),
-                MiniFloatConverter::reduceMantissaToNbitsRounding<11>(eta()),
-                MiniFloatConverter::reduceMantissaToNbits<11>(phi()),
-                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(mass()) ));
+  setP4(reco::Particle::PolarLorentzVector(MiniFloatConverter::reduceMantissaToNbitsRounding<14>(pt()),
+                                           MiniFloatConverter::reduceMantissaToNbitsRounding<11>(eta()),
+                                           MiniFloatConverter::reduceMantissaToNbits<11>(phi()),
+                                           MiniFloatConverter::reduceMantissaToNbitsRounding<8>(mass())));
 }
 
 namespace {
- struct key_hash {
-          std::size_t operator()(edm::ParameterSetID const& iKey) const{
-             return iKey.smallHash();
-          }
-       };
+  struct key_hash {
+    std::size_t operator()(edm::ParameterSetID const &iKey) const { return iKey.smallHash(); }
+  };
   typedef tbb::concurrent_unordered_map<edm::ParameterSetID, std::vector<std::string>, key_hash> AllLabelsMap;
   CMS_THREAD_SAFE AllLabelsMap allLabelsMap;
+}  // namespace
+
+std::vector<std::string> const *TriggerObjectStandAlone::allLabels(edm::ParameterSetID const &psetid,
+                                                                   const edm::EventBase &event,
+                                                                   const edm::TriggerResults &res) const {
+  // If TriggerNames was already created and cached here in the map,
+  // then look it up and return that one
+  AllLabelsMap::const_iterator iter = allLabelsMap.find(psetid);
+  if (iter != allLabelsMap.end()) {
+    return &iter->second;
+  }
+
+  const auto &triggerNames = event.triggerNames(res);
+  edm::ParameterSet const *pset = nullptr;
+  //getting the ParameterSet from the event ensures that the registry is filled
+  if (nullptr != (pset = event.parameterSet(psetid))) {
+    using namespace std;
+    using namespace edm;
+    using namespace trigger;
+
+    const unsigned int n(triggerNames.size());
+    std::set<std::string> saveTags;
+    for (unsigned int i = 0; i != n; ++i) {
+      if (pset->existsAs<vector<string> >(triggerNames.triggerName(i), true)) {
+        auto modules = pset->getParameter<vector<string> >(triggerNames.triggerName(i));
+        for (size_t m = 0; m < modules.size(); m++) {
+          auto module = modules[m];
+          auto moduleStrip = module.front() != '-' ? module : module.substr(1);
+
+          if (pset->exists(moduleStrip)) {
+            const auto &modulePSet = pset->getParameterSet(moduleStrip);
+            if (modulePSet.existsAs<bool>("saveTags", true) and modulePSet.getParameter<bool>("saveTags")) {
+              saveTags.insert(moduleStrip);
+            }
+          }
+        }
+      }
+    }
+    std::vector<std::string> allModules(saveTags.begin(), saveTags.end());
+    std::pair<AllLabelsMap::iterator, bool> ret =
+        allLabelsMap.insert(std::pair<edm::ParameterSetID, std::vector<std::string> >(psetid, allModules));
+    return &(ret.first->second);
+  }
+  return nullptr;
 }
-
-std::vector<std::string>  const* TriggerObjectStandAlone::allLabels(edm::ParameterSetID const& psetid, const edm::EventBase &event,const edm::TriggerResults &res) const {
-
-      // If TriggerNames was already created and cached here in the map,
-      // then look it up and return that one
-      AllLabelsMap::const_iterator iter =
-         allLabelsMap.find(psetid);
-      if (iter != allLabelsMap.end()) {
-         return &iter->second;
-      }
-
-      const auto&   triggerNames= event.triggerNames(res); 
-      edm::ParameterSet const* pset=nullptr;
-      //getting the ParameterSet from the event ensures that the registry is filled
-      if (nullptr!=(pset=event.parameterSet(psetid ))) {
-   	using namespace std;
-	using namespace edm;
-   	using namespace trigger;
-
-
- 	const unsigned int n(triggerNames.size());
-	std::set<std::string> saveTags;
-   	for (unsigned int i=0;i!=n; ++i) {
-     	    if (pset->existsAs<vector<string> >(triggerNames.triggerName(i),true)) {
-       		auto modules = pset->getParameter<vector<string> >(triggerNames.triggerName(i));
-		for(size_t m=0; m < modules.size(); m++){
-		    auto module=modules[m];
-		    auto moduleStrip=module.front()!='-' ? module : module.substr(1);
- 
-		    if (pset->exists(moduleStrip)) {
-			const auto& modulePSet= pset->getParameterSet(moduleStrip);
-			if (modulePSet.existsAs<bool>("saveTags",true) and 
-			    modulePSet.getParameter<bool>("saveTags") ) {
-			    saveTags.insert(moduleStrip);
-			}
-		    }	
-		}
-     	    }
-   	}
-   	std::vector<std::string> allModules(saveTags.begin(),saveTags.end());
-         std::pair<AllLabelsMap::iterator, bool> ret =
-               allLabelsMap.insert(std::pair<edm::ParameterSetID, std::vector<std::string> >(psetid, allModules));
-         return &(ret.first->second);
-      }
-      return nullptr;
-   }
-

--- a/DataFormats/PatCandidates/src/TriggerPath.cc
+++ b/DataFormats/PatCandidates/src/TriggerPath.cc
@@ -1,83 +1,62 @@
 //
 //
 
-
 #include "DataFormats/PatCandidates/interface/TriggerPath.h"
-
 
 using namespace pat;
 
-
 // Constructors and Destructor
 
-
 // Default constructor
-TriggerPath::TriggerPath() :
-  name_(),
-  index_(),
-  prescale_(),
-  run_(),
-  accept_(),
-  error_(),
-  lastActiveFilterSlot_(),
-  l3Filters_( 0 )
-{
+TriggerPath::TriggerPath()
+    : name_(), index_(), prescale_(), run_(), accept_(), error_(), lastActiveFilterSlot_(), l3Filters_(0) {
   modules_.clear();
   filterIndices_.clear();
 }
-
 
 // Constructor from path name only
-TriggerPath::TriggerPath( const std::string & name ) :
-  name_( name ),
-  index_(),
-  prescale_(),
-  run_(),
-  accept_(),
-  error_(),
-  lastActiveFilterSlot_(),
-  l3Filters_( 0 )
-{
+TriggerPath::TriggerPath(const std::string& name)
+    : name_(name), index_(), prescale_(), run_(), accept_(), error_(), lastActiveFilterSlot_(), l3Filters_(0) {
   modules_.clear();
   filterIndices_.clear();
 }
-
 
 // Constructor from values
-TriggerPath::TriggerPath( const std::string & name, unsigned index, unsigned prescale, bool run, bool accept, bool error, unsigned lastActiveFilterSlot, unsigned l3Filters ) :
-  name_( name ),
-  index_( index ),
-  prescale_( prescale ),
-  run_( run ),
-  accept_( accept ),
-  error_( error ),
-  lastActiveFilterSlot_( lastActiveFilterSlot ),
-  l3Filters_( l3Filters )
-{
+TriggerPath::TriggerPath(const std::string& name,
+                         unsigned index,
+                         unsigned prescale,
+                         bool run,
+                         bool accept,
+                         bool error,
+                         unsigned lastActiveFilterSlot,
+                         unsigned l3Filters)
+    : name_(name),
+      index_(index),
+      prescale_(prescale),
+      run_(run),
+      accept_(accept),
+      error_(error),
+      lastActiveFilterSlot_(lastActiveFilterSlot),
+      l3Filters_(l3Filters) {
   modules_.clear();
   filterIndices_.clear();
 }
-
 
 // Methods
 
-
 // Get the index of a certain module
-int TriggerPath::indexModule( const std::string & name ) const
-{
-  if ( modules_.begin() == modules_.end() ) return -1;
-  return ( std::find( modules_.begin(), modules_.end(), name ) - modules_.begin() );
+int TriggerPath::indexModule(const std::string& name) const {
+  if (modules_.begin() == modules_.end())
+    return -1;
+  return (std::find(modules_.begin(), modules_.end(), name) - modules_.begin());
 }
 
-
 // Get names of all L1 seeds with a certain decision
-std::vector< std::string > TriggerPath::l1Seeds( const bool decision ) const
-{
-
-  std::vector< std::string > seeds;
-  for ( L1SeedCollection::const_iterator iSeed = l1Seeds().begin(); iSeed != l1Seeds().end(); ++iSeed ) {
-    if ( iSeed->first == decision ) seeds.push_back( iSeed->second );
+std::vector<std::string> TriggerPath::l1Seeds(const bool decision) const {
+  std::vector<std::string> seeds;
+  for (L1SeedCollection::const_iterator iSeed = l1Seeds().begin(); iSeed != l1Seeds().end(); ++iSeed) {
+    if (iSeed->first == decision)
+      seeds.push_back(iSeed->second);
   }
   return seeds;
-
 }

--- a/DataFormats/PatCandidates/src/VIDCutFlowResult.cc
+++ b/DataFormats/PatCandidates/src/VIDCutFlowResult.cc
@@ -9,16 +9,12 @@ namespace vid {
 
   CutFlowResult::CutFlowResult(const std::string& name,
                                const std::string& hash,
-                               const std::map<std::string,unsigned>& n2idx,
+                               const std::map<std::string, unsigned>& n2idx,
                                const std::vector<double>& values,
                                unsigned bitmap,
-                               unsigned mask) : 
-    name_(name),
-    hash_(hash),
-    bitmap_(bitmap), 
-    mask_(mask),
-    values_(values) {
-    for( const auto& val : n2idx ) {
+                               unsigned mask)
+      : name_(name), hash_(hash), bitmap_(bitmap), mask_(mask), values_(values) {
+    for (const auto& val : n2idx) {
       names_.push_back(val.first);
       indices_.push_back(val.second);
     }
@@ -26,126 +22,107 @@ namespace vid {
 
   const std::string& CutFlowResult::getNameAtIndex(const unsigned idx) const {
     unsigned internal_idx = 0;
-    for( const auto& value : indices_ ) {
-      if( value == idx ) return names_[internal_idx];
+    for (const auto& value : indices_) {
+      if (value == idx)
+        return names_[internal_idx];
       ++internal_idx;
     }
-    throw cms::Exception("IndexNotFound")
-      << "index = " << idx << " has no corresponding cut name!";
+    throw cms::Exception("IndexNotFound") << "index = " << idx << " has no corresponding cut name!";
     return empty_str;
   }
 
   bool CutFlowResult::getCutResultByIndex(const unsigned idx) const {
-    if( idx >= indices_.size() ) {
-        throw cms::Exception("OutOfBounds")
-          << idx << " is out of bounds for this cut flow!";
+    if (idx >= indices_.size()) {
+      throw cms::Exception("OutOfBounds") << idx << " is out of bounds for this cut flow!";
     }
     return getCutBit(idx);
   }
 
   bool CutFlowResult::getCutResultByName(const std::string& name) const {
-    auto found_name = std::lower_bound(names_.begin(),names_.end(),name);
-    if( found_name == names_.end() || *found_name != name ) {
-      throw cms::Exception("UnknownName")
-        << "Cut name: " << name 
-        << " is not known for this cutflow!";
+    auto found_name = std::lower_bound(names_.begin(), names_.end(), name);
+    if (found_name == names_.end() || *found_name != name) {
+      throw cms::Exception("UnknownName") << "Cut name: " << name << " is not known for this cutflow!";
     }
-    return getCutBit(indices_[std::distance(names_.begin(),found_name)]);
+    return getCutBit(indices_[std::distance(names_.begin(), found_name)]);
   }
 
   bool CutFlowResult::isCutMasked(const unsigned idx) const {
-    if( idx >= indices_.size() ) {
-        throw cms::Exception("OutOfBounds")
-          << idx << " is out of bounds for this cut flow!";
+    if (idx >= indices_.size()) {
+      throw cms::Exception("OutOfBounds") << idx << " is out of bounds for this cut flow!";
     }
     return getMaskBit(idx);
   }
 
   bool CutFlowResult::isCutMasked(const std::string& name) const {
-    auto found_name = std::lower_bound(names_.begin(),names_.end(),name);
-    if( found_name == names_.end() || *found_name != name ) {
-      throw cms::Exception("UnknownName")
-        << "Cut name: " << name 
-        << " is not known for this cutflow!";
+    auto found_name = std::lower_bound(names_.begin(), names_.end(), name);
+    if (found_name == names_.end() || *found_name != name) {
+      throw cms::Exception("UnknownName") << "Cut name: " << name << " is not known for this cutflow!";
     }
-    return getMaskBit(indices_[std::distance(names_.begin(),found_name)]);
+    return getMaskBit(indices_[std::distance(names_.begin(), found_name)]);
   }
 
   double CutFlowResult::getValueCutUpon(const unsigned idx) const {
-    if( idx >= indices_.size() ) {
-        throw cms::Exception("OutOfBounds")
-          << idx << " is out of bounds for this cut flow!";
+    if (idx >= indices_.size()) {
+      throw cms::Exception("OutOfBounds") << idx << " is out of bounds for this cut flow!";
     }
-    return getCutValue(idx);    
-  }
-  
-  double CutFlowResult::getValueCutUpon(const std::string& name) const {
-    auto found_name = std::lower_bound(names_.begin(),names_.end(),name);
-    if( found_name == names_.end() || *found_name != name ) {
-      throw cms::Exception("UnknownName")
-        << "Cut name: " << name 
-        << " is not known for this cutflow!";
-    }
-    return getCutValue(indices_[std::distance(names_.begin(),found_name)]);
+    return getCutValue(idx);
   }
 
-  CutFlowResult CutFlowResult::
-  getCutFlowResultMasking(const std::vector<unsigned>& idxs) const {
+  double CutFlowResult::getValueCutUpon(const std::string& name) const {
+    auto found_name = std::lower_bound(names_.begin(), names_.end(), name);
+    if (found_name == names_.end() || *found_name != name) {
+      throw cms::Exception("UnknownName") << "Cut name: " << name << " is not known for this cutflow!";
+    }
+    return getCutValue(indices_[std::distance(names_.begin(), found_name)]);
+  }
+
+  CutFlowResult CutFlowResult::getCutFlowResultMasking(const std::vector<unsigned>& idxs) const {
     unsigned bitmap = bitmap_;
     unsigned mask = mask_;
-    for( const unsigned idx : idxs ) {
-      if( idx >= indices_.size() ) {
-        throw cms::Exception("OutOfBounds")
-          << idx << " is out of bounds for this cut flow!";
+    for (const unsigned idx : idxs) {
+      if (idx >= indices_.size()) {
+        throw cms::Exception("OutOfBounds") << idx << " is out of bounds for this cut flow!";
       }
       mask = mask | 1 << idx;
     }
     bitmap = bitmap | mask;
-    return CutFlowResult(name_,empty_str,names_,indices_,values_,bitmap,mask);
+    return CutFlowResult(name_, empty_str, names_, indices_, values_, bitmap, mask);
   }
 
-  CutFlowResult CutFlowResult::
-  getCutFlowResultMasking(const std::vector<std::string>& names) const {
+  CutFlowResult CutFlowResult::getCutFlowResultMasking(const std::vector<std::string>& names) const {
     unsigned bitmap = bitmap_;
     unsigned mask = mask_;
-    for( const std::string& name : names ) {
-      auto found_name = std::lower_bound(names_.begin(),names_.end(),name);
-      if( found_name == names_.end() || *found_name != name ) {
-        throw cms::Exception("UnknownName")
-          << "Cut name: " << name 
-          << " is not known for this cutflow!";
+    for (const std::string& name : names) {
+      auto found_name = std::lower_bound(names_.begin(), names_.end(), name);
+      if (found_name == names_.end() || *found_name != name) {
+        throw cms::Exception("UnknownName") << "Cut name: " << name << " is not known for this cutflow!";
       }
-      mask = mask | 1 << indices_[std::distance(names_.begin(),found_name)];
+      mask = mask | 1 << indices_[std::distance(names_.begin(), found_name)];
     }
     bitmap = bitmap | mask;
-    return CutFlowResult(name_,empty_str,names_,indices_,values_,bitmap,mask);
+    return CutFlowResult(name_, empty_str, names_, indices_, values_, bitmap, mask);
   }
 
-  CutFlowResult CutFlowResult::
-  getCutFlowResultMasking(const unsigned idx) const {
+  CutFlowResult CutFlowResult::getCutFlowResultMasking(const unsigned idx) const {
     unsigned bitmap = bitmap_;
     unsigned mask = mask_;
-    if( idx >= indices_.size() ) {
-      throw cms::Exception("OutOfBounds")
-        << idx << " is out of bounds for this cut flow!";
+    if (idx >= indices_.size()) {
+      throw cms::Exception("OutOfBounds") << idx << " is out of bounds for this cut flow!";
     }
     mask = mask | 1 << idx;
     bitmap = bitmap | mask;
-    return CutFlowResult(name_,empty_str,names_,indices_,values_,bitmap,mask);
+    return CutFlowResult(name_, empty_str, names_, indices_, values_, bitmap, mask);
   }
-  
-  CutFlowResult CutFlowResult::
-  getCutFlowResultMasking(const std::string& name) const {
+
+  CutFlowResult CutFlowResult::getCutFlowResultMasking(const std::string& name) const {
     unsigned bitmap = bitmap_;
     unsigned mask = mask_;
-    auto found_name = std::lower_bound(names_.begin(),names_.end(),name);
-    if( found_name == names_.end() || *found_name != name ) {
-      throw cms::Exception("UnknownName")
-        << "Cut name: " << name 
-        << " is not known for this cutflow!";
+    auto found_name = std::lower_bound(names_.begin(), names_.end(), name);
+    if (found_name == names_.end() || *found_name != name) {
+      throw cms::Exception("UnknownName") << "Cut name: " << name << " is not known for this cutflow!";
     }
-    mask = mask | 1 << indices_[std::distance(names_.begin(),found_name)];
+    mask = mask | 1 << indices_[std::distance(names_.begin(), found_name)];
     bitmap = bitmap | mask;
-    return CutFlowResult(name_,empty_str,names_,indices_,values_,bitmap,mask);
+    return CutFlowResult(name_, empty_str, names_, indices_, values_, bitmap, mask);
   }
-}
+}  // namespace vid

--- a/DataFormats/PatCandidates/src/Vertexing.cc
+++ b/DataFormats/PatCandidates/src/Vertexing.cc
@@ -2,10 +2,10 @@
 
 using pat::VertexAssociation;
 
-void VertexAssociation::setDistances(const AlgebraicVector3 & dist, const AlgebraicSymMatrix33 &err) {
-    setDz( Measurement1DFloat( std::abs(dist[2]) , std::sqrt(err(2,2)) ) );
+void VertexAssociation::setDistances(const AlgebraicVector3 &dist, const AlgebraicSymMatrix33 &err) {
+  setDz(Measurement1DFloat(std::abs(dist[2]), std::sqrt(err(2, 2))));
 
-    AlgebraicVector3 dist2D(dist[0], dist[1], 0);
-    float d2 = dist2D[0]*dist2D[0] + dist2D[1]*dist2D[1];
-    setDr( Measurement1DFloat( sqrt(d2), sqrt(ROOT::Math::Similarity(dist2D, err)/d2) ) );
+  AlgebraicVector3 dist2D(dist[0], dist[1], 0);
+  float d2 = dist2D[0] * dist2D[0] + dist2D[1] * dist2D[1];
+  setDr(Measurement1DFloat(sqrt(d2), sqrt(ROOT::Math::Similarity(dist2D, err) / d2)));
 }

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -23,4 +23,3 @@
 #include "DataFormats/PatCandidates/interface/PFIsolation.h"
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "DataFormats/PatCandidates/interface/PATTauDiscriminator.h"
-

--- a/DataFormats/PatCandidates/src/classes_other.h
+++ b/DataFormats/PatCandidates/src/classes_other.h
@@ -22,4 +22,3 @@
 #include "DataFormats/PatCandidates/interface/VIDCutFlowResult.h"
 
 #include "DataFormats/PatCandidates/interface/HcalDepthEnergyFractions.h"
-

--- a/DataFormats/PatCandidates/src/classes_trigger.h
+++ b/DataFormats/PatCandidates/src/classes_trigger.h
@@ -8,4 +8,3 @@
 #include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 #include <iterator>
 #include <vector>
-

--- a/DataFormats/PatCandidates/src/throwMissingLabel.cc
+++ b/DataFormats/PatCandidates/src/throwMissingLabel.cc
@@ -4,14 +4,14 @@
 #include <iostream>
 
 namespace pat {
-  void throwMissingLabel(const std::string& what, const std::string& bad_label,
+  void throwMissingLabel(const std::string& what,
+                         const std::string& bad_label,
                          const std::vector<std::string>& available) {
-    cms::Exception ex(std::string("Unknown")+what);
-    ex << "Requested " << what << " " << bad_label 
-       << " is not available! Possible " << what << "s are: " << std::endl;
-    for( const auto& name : available ) {
+    cms::Exception ex(std::string("Unknown") + what);
+    ex << "Requested " << what << " " << bad_label << " is not available! Possible " << what << "s are: " << std::endl;
+    for (const auto& name : available) {
       ex << name << ' ';
     }
     throw ex;
   }
-}
+}  // namespace pat

--- a/DataFormats/PatCandidates/test/testKinParametrizations.cc
+++ b/DataFormats/PatCandidates/test/testKinParametrizations.cc
@@ -6,7 +6,6 @@
 #include "DataFormats/PatCandidates/interface/ParametrizationHelper.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
-
 class testKinParametrizations : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testKinParametrizations);
 
@@ -53,235 +52,285 @@ class testKinParametrizations : public CppUnit::TestFixture {
   CPPUNIT_TEST(testVecVec2Diff_EScaledMomDev);
 
   CPPUNIT_TEST_SUITE_END();
+
 public:
   void setUp() {}
   void tearDown() {}
 
-  void testTrivialVec2Par_Cart() ;
-  void testTrivialVec2Par_ECart() ;
-  void testTrivialVec2Par_Spher() ;
-  void testTrivialVec2Par_ESpher() ;
-  void testTrivialVec2Par_MomDev() ;
-  void testTrivialVec2Par_EMomDev() ;
-  void testTrivialVec2Par_MCCart() ;
-  void testTrivialVec2Par_MCSpher() ;
-  void testTrivialVec2Par_MCPInvSpher() ;
-  void testTrivialVec2Par_EtEtaPhi() ;
-  void testTrivialVec2Par_EtThetaPhi() ;
-  void testTrivialVec2Par_MCMomDev() ;
-  void testTrivialVec2Par_EScaledMomDev() ;
+  void testTrivialVec2Par_Cart();
+  void testTrivialVec2Par_ECart();
+  void testTrivialVec2Par_Spher();
+  void testTrivialVec2Par_ESpher();
+  void testTrivialVec2Par_MomDev();
+  void testTrivialVec2Par_EMomDev();
+  void testTrivialVec2Par_MCCart();
+  void testTrivialVec2Par_MCSpher();
+  void testTrivialVec2Par_MCPInvSpher();
+  void testTrivialVec2Par_EtEtaPhi();
+  void testTrivialVec2Par_EtThetaPhi();
+  void testTrivialVec2Par_MCMomDev();
+  void testTrivialVec2Par_EScaledMomDev();
 
-  void testVecDiff2Par_Cart() ;
-  void testVecDiff2Par_ECart() ;
-  void testVecDiff2Par_Spher() ;
-  void testVecDiff2Par_ESpher() ;
-  void testVecDiff2Par_MomDev() ;
-  void testVecDiff2Par_EMomDev() ;
-  void testVecDiff2Par_MCCart() ;
-  void testVecDiff2Par_MCSpher() ;
-  void testVecDiff2Par_MCPInvSpher() ;
-  void testVecDiff2Par_EtEtaPhi() ;
-  void testVecDiff2Par_EtThetaPhi() ;
-  void testVecDiff2Par_MCMomDev() ;
-  void testVecDiff2Par_EScaledMomDev() ;
+  void testVecDiff2Par_Cart();
+  void testVecDiff2Par_ECart();
+  void testVecDiff2Par_Spher();
+  void testVecDiff2Par_ESpher();
+  void testVecDiff2Par_MomDev();
+  void testVecDiff2Par_EMomDev();
+  void testVecDiff2Par_MCCart();
+  void testVecDiff2Par_MCSpher();
+  void testVecDiff2Par_MCPInvSpher();
+  void testVecDiff2Par_EtEtaPhi();
+  void testVecDiff2Par_EtThetaPhi();
+  void testVecDiff2Par_MCMomDev();
+  void testVecDiff2Par_EScaledMomDev();
 
-  void testVecVec2Diff_Cart() ;
-  void testVecVec2Diff_ECart() ;
-  void testVecVec2Diff_Spher() ;
-  void testVecVec2Diff_ESpher() ;
-  void testVecVec2Diff_MomDev() ;
-  void testVecVec2Diff_EMomDev() ;
-  void testVecVec2Diff_MCCart() ;
-  void testVecVec2Diff_MCSpher() ;
-  void testVecVec2Diff_MCPInvSpher() ;
-  void testVecVec2Diff_EtEtaPhi() ;
-  void testVecVec2Diff_EtThetaPhi() ;
-  void testVecVec2Diff_MCMomDev() ;
-  void testVecVec2Diff_EScaledMomDev() ;
+  void testVecVec2Diff_Cart();
+  void testVecVec2Diff_ECart();
+  void testVecVec2Diff_Spher();
+  void testVecVec2Diff_ESpher();
+  void testVecVec2Diff_MomDev();
+  void testVecVec2Diff_EMomDev();
+  void testVecVec2Diff_MCCart();
+  void testVecVec2Diff_MCSpher();
+  void testVecVec2Diff_MCPInvSpher();
+  void testVecVec2Diff_EtEtaPhi();
+  void testVecVec2Diff_EtThetaPhi();
+  void testVecVec2Diff_MCMomDev();
+  void testVecVec2Diff_EScaledMomDev();
 
-  typedef math::XYZTLorentzVector      P4C;
+  typedef math::XYZTLorentzVector P4C;
   typedef math::PtEtaPhiMLorentzVector P4P;
-  typedef AlgebraicVector4             V4;
+  typedef AlgebraicVector4 V4;
+
 private:
   typedef pat::CandKinResolution::Parametrization Parametrization;
-  bool testTrivialVec2Par(Parametrization p, int tries=100000) ;
-  bool testVecDiff2Par(Parametrization p, int tries=100000) ;
-  bool testVecVec2Diff(Parametrization p, int tries=100000) ;
+  bool testTrivialVec2Par(Parametrization p, int tries = 100000);
+  bool testVecDiff2Par(Parametrization p, int tries = 100000);
+  bool testVecVec2Diff(Parametrization p, int tries = 100000);
 
   // Utilities
-  static double r(double val=1.0) { return rand()*val/double(RAND_MAX); }
-  static double r(double from, double to) { return rand()*(to-from)/double(RAND_MAX) + from; }
-  static P4P r4(double m=-1) {
-    double mass = (m != -1 ? m :  (r() > .3 ? r(.1,30) : 0) );
-    return P4P( r(5,25), r(-2.5,5), r(-M_PI,M_PI), mass );
+  static double r(double val = 1.0) { return rand() * val / double(RAND_MAX); }
+  static double r(double from, double to) { return rand() * (to - from) / double(RAND_MAX) + from; }
+  static P4P r4(double m = -1) {
+    double mass = (m != -1 ? m : (r() > .3 ? r(.1, 30) : 0));
+    return P4P(r(5, 25), r(-2.5, 5), r(-M_PI, M_PI), mass);
   }
-  static P4P p4near(const P4P &p, double d=0.2) {
-    double mass = (p.mass() == 0 ? 0 : p.mass()*r(1-d,1+d)); 
-    return P4P( p.pt()*r(1-d,1+d), p.eta()+r(-d,+d), p.phi()+r(-d,+d), mass );  
+  static P4P p4near(const P4P &p, double d = 0.2) {
+    double mass = (p.mass() == 0 ? 0 : p.mass() * r(1 - d, 1 + d));
+    return P4P(p.pt() * r(1 - d, 1 + d), p.eta() + r(-d, +d), p.phi() + r(-d, +d), mass);
   }
-  static V4 v4near(const V4 &v4, double d=0.2) {
+  static V4 v4near(const V4 &v4, double d = 0.2) {
     V4 ret;
-    ret[0] = v4[0]*r(1-d,1+d);
-    ret[1] = v4[1]*r(1-d,1+d);
-    ret[2] = v4[2]*r(1-d,1+d);
-    ret[3] = v4[3]*r(1-d,1+d);
+    ret[0] = v4[0] * r(1 - d, 1 + d);
+    ret[1] = v4[1] * r(1 - d, 1 + d);
+    ret[2] = v4[2] * r(1 - d, 1 + d);
+    ret[3] = v4[3] * r(1 - d, 1 + d);
     return ret;
   }
-  static P4C r4c(double m=-1) { return P4C(r4()); }
-  static bool d(double x, double y, double eps=1e-6) {  return std::abs(x-y) < eps*(1+std::abs(x)+std::abs(y));  }
-  static bool d4(P4P &p1, P4P &p2, double eps=1e-6) {
-    return d(p1.E() , p2.E() , eps) &&
-           d(p1.Px(), p2.Px(), eps) && 
-           d(p1.Py(), p2.Py(), eps) && 
-           d(p1.Pz(), p2.Pz(), eps);
+  static P4C r4c(double m = -1) { return P4C(r4()); }
+  static bool d(double x, double y, double eps = 1e-6) {
+    return std::abs(x - y) < eps * (1 + std::abs(x) + std::abs(y));
   }
-  static bool d4(P4C &p1, P4C &p2, double eps=1e-6) {
-    return d(p1.Pt() , p2.Pt() , eps) &&
-           d(p1.Eta(), p2.Eta(), eps) && 
-           d(p1.M()  , p2.M()  , eps)  &&
+  static bool d4(P4P &p1, P4P &p2, double eps = 1e-6) {
+    return d(p1.E(), p2.E(), eps) && d(p1.Px(), p2.Px(), eps) && d(p1.Py(), p2.Py(), eps) && d(p1.Pz(), p2.Pz(), eps);
+  }
+  static bool d4(P4C &p1, P4C &p2, double eps = 1e-6) {
+    return d(p1.Pt(), p2.Pt(), eps) && d(p1.Eta(), p2.Eta(), eps) && d(p1.M(), p2.M(), eps) &&
            (deltaPhi(p1.Phi(), p2.Py()) < eps);
   }
-  static bool d4(const V4 &v1, const V4 &v2, double eps=1e-6) {
-    return d(v1[0],v2[0], eps) &&
-           d(v1[1],v2[1], eps) &&
-           d(v1[2],v2[2], eps) &&
-           d(v1[3],v2[3], eps);
+  static bool d4(const V4 &v1, const V4 &v2, double eps = 1e-6) {
+    return d(v1[0], v2[0], eps) && d(v1[1], v2[1], eps) && d(v1[2], v2[2], eps) && d(v1[3], v2[3], eps);
   }
-
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testKinParametrizations);
 
 bool testKinParametrizations::testTrivialVec2Par(Parametrization par, int tries) {
-    using namespace pat::helper::ParametrizationHelper;
-    srand(37);
-    for (int i = 0; i < tries; ++i) {
-        P4P p1 = r4(isAlwaysMassless(par) ? 0 : (r() > .3 ? r(.1,30) : 0) );
-        V4  v4 = parametersFromP4(par, p1);
-        P4P p2 = polarP4fromParameters(par, v4, p1);
-        if (!d4(p1,p2)) {
-            std::cerr << "\nFailure: (try " << i << "):" <<
-                                    "\n  p1 = " << p1 <<
-                                    "\n  p2 = " << p2 <<
-                                    "\n  v4 = " << v4 << std::endl;
-            return false;
-        }
+  using namespace pat::helper::ParametrizationHelper;
+  srand(37);
+  for (int i = 0; i < tries; ++i) {
+    P4P p1 = r4(isAlwaysMassless(par) ? 0 : (r() > .3 ? r(.1, 30) : 0));
+    V4 v4 = parametersFromP4(par, p1);
+    P4P p2 = polarP4fromParameters(par, v4, p1);
+    if (!d4(p1, p2)) {
+      std::cerr << "\nFailure: (try " << i << "):"
+                << "\n  p1 = " << p1 << "\n  p2 = " << p2 << "\n  v4 = " << v4 << std::endl;
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 
 bool testKinParametrizations::testVecVec2Diff(Parametrization par, int tries) {
-    using namespace pat::helper::ParametrizationHelper;
-    srand(37);
-    for (int i = 0; i < tries; ++i) {
-        P4P p1 = r4(isAlwaysMassless(par) ? 0 : 
-                    (isAlwaysMassive(par) ? r(.1,30) :
-                     (r() > .3 ? r(.1,30) : 0) ) );
-        V4  v1 = parametersFromP4(par, p1), v2;
-        int phystries = 0;
-        do {
-            v2 = v4near(v1);
-            if (dimension(par) == 3) v2[3] = v1[3]; // keep constraint
-            phystries++;
-        } while (!isPhysical(par,v2,p1) && (phystries < 50)) ;
-        if (!isPhysical(par,v2,p1)) {
-            std::cerr << "\nFailure (try " << i << "/" << phystries << "):" <<
-                                    "\n  p1  = " << p1 <<
-                                    "\n  v1  = " << v1 <<
-                                    "\n  v2  = " << v2 <<
-                                    std::endl;
-            return false;
-        }
-        V4  dv1 = v2 - v1;
-        P4P p2 = polarP4fromParameters(par, v2, p1);
-        V4  dv2 = diffToParameters(par, p1, p2);
-        if (!d4(dv1,dv2)) {
-            std::cerr << "\nFailure (try " << i << "):" <<
-                                    "\n  p1  = " << p1 <<
-                                    "\n  v1  = " << v1 <<
-                                    "\n  dv1 = " << dv1 <<
-                                    "\n  v2  = " << v2 << 
-                                    "\n  p2  = " << p2 <<
-                                    "\n  dv2 = " << dv2 <<
-                                    std::endl;
-            return false;
-        }
+  using namespace pat::helper::ParametrizationHelper;
+  srand(37);
+  for (int i = 0; i < tries; ++i) {
+    P4P p1 = r4(isAlwaysMassless(par) ? 0 : (isAlwaysMassive(par) ? r(.1, 30) : (r() > .3 ? r(.1, 30) : 0)));
+    V4 v1 = parametersFromP4(par, p1), v2;
+    int phystries = 0;
+    do {
+      v2 = v4near(v1);
+      if (dimension(par) == 3)
+        v2[3] = v1[3];  // keep constraint
+      phystries++;
+    } while (!isPhysical(par, v2, p1) && (phystries < 50));
+    if (!isPhysical(par, v2, p1)) {
+      std::cerr << "\nFailure (try " << i << "/" << phystries << "):"
+                << "\n  p1  = " << p1 << "\n  v1  = " << v1 << "\n  v2  = " << v2 << std::endl;
+      return false;
     }
-    return true;
+    V4 dv1 = v2 - v1;
+    P4P p2 = polarP4fromParameters(par, v2, p1);
+    V4 dv2 = diffToParameters(par, p1, p2);
+    if (!d4(dv1, dv2)) {
+      std::cerr << "\nFailure (try " << i << "):"
+                << "\n  p1  = " << p1 << "\n  v1  = " << v1 << "\n  dv1 = " << dv1 << "\n  v2  = " << v2
+                << "\n  p2  = " << p2 << "\n  dv2 = " << dv2 << std::endl;
+      return false;
+    }
+  }
+  return true;
 }
-
 
 bool testKinParametrizations::testVecDiff2Par(Parametrization par, int tries) {
-    using namespace pat::helper::ParametrizationHelper;
-    srand(37);
-    for (int i = 0; i < tries; ++i) {
-        P4P p1 = r4(isAlwaysMassless(par) ? 0 : 
-                    (isAlwaysMassive(par) ? r(.1,30) :
-                     (r() > .3 ? r(.1,30) : 0) ) );
-        V4  v1 = parametersFromP4(par, p1);
-        P4P p2 = p4near(p1);
-        if (isMassConstrained(par)) {
-            p2.SetM(p1.mass());
-        } else if (par == pat::CandKinResolution::EScaledMomDev) {
-            // This is more tricky to get
-            p2 = P4C(p2.px(), p2.py(), p2.pz(), p1.E()/p1.P()*p2.P() );
-        }
-        V4  dv = diffToParameters(par, p1, p2);
-        V4  v2 = v1 + dv;
-        P4P p3 = polarP4fromParameters(par, v2, p1);
-        if (!d4(p3,p2)) {
-            std::cerr << "\nFailure: (try " << i << "):" <<
-                                    "\n  p1 = " << p1 <<
-                                    "\n  v1 = " << v1 <<
-                                    "\n  p2 = " << p2 <<
-                                    "\n  dv = " << dv <<
-                                    "\n  v2 = " << v2 << 
-                                    "\n  p3 = " << p3 <<
-                                    std::endl;
-            return false;
-        }
+  using namespace pat::helper::ParametrizationHelper;
+  srand(37);
+  for (int i = 0; i < tries; ++i) {
+    P4P p1 = r4(isAlwaysMassless(par) ? 0 : (isAlwaysMassive(par) ? r(.1, 30) : (r() > .3 ? r(.1, 30) : 0)));
+    V4 v1 = parametersFromP4(par, p1);
+    P4P p2 = p4near(p1);
+    if (isMassConstrained(par)) {
+      p2.SetM(p1.mass());
+    } else if (par == pat::CandKinResolution::EScaledMomDev) {
+      // This is more tricky to get
+      p2 = P4C(p2.px(), p2.py(), p2.pz(), p1.E() / p1.P() * p2.P());
     }
-    return true;
+    V4 dv = diffToParameters(par, p1, p2);
+    V4 v2 = v1 + dv;
+    P4P p3 = polarP4fromParameters(par, v2, p1);
+    if (!d4(p3, p2)) {
+      std::cerr << "\nFailure: (try " << i << "):"
+                << "\n  p1 = " << p1 << "\n  v1 = " << v1 << "\n  p2 = " << p2 << "\n  dv = " << dv << "\n  v2 = " << v2
+                << "\n  p3 = " << p3 << std::endl;
+      return false;
+    }
+  }
+  return true;
 }
 
-void testKinParametrizations::testTrivialVec2Par_Cart() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::Cart)); }
-void testKinParametrizations::testTrivialVec2Par_ECart() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::ECart)); }
-void testKinParametrizations::testTrivialVec2Par_Spher() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::Spher)); }
-void testKinParametrizations::testTrivialVec2Par_ESpher() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::ESpher)); }
-void testKinParametrizations::testTrivialVec2Par_MomDev() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::MomDev)); }
-void testKinParametrizations::testTrivialVec2Par_EMomDev() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::EMomDev)); }
-void testKinParametrizations::testTrivialVec2Par_MCCart() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::MCCart)); }
-void testKinParametrizations::testTrivialVec2Par_MCSpher() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::MCSpher)); }
-void testKinParametrizations::testTrivialVec2Par_MCPInvSpher() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::MCPInvSpher)); }
-void testKinParametrizations::testTrivialVec2Par_EtEtaPhi() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::EtEtaPhi)); }
-void testKinParametrizations::testTrivialVec2Par_EtThetaPhi() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::EtThetaPhi)); }
-void testKinParametrizations::testTrivialVec2Par_MCMomDev() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::MCMomDev)); }
-void testKinParametrizations::testTrivialVec2Par_EScaledMomDev() { CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::EScaledMomDev)); }
+void testKinParametrizations::testTrivialVec2Par_Cart() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::Cart));
+}
+void testKinParametrizations::testTrivialVec2Par_ECart() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::ECart));
+}
+void testKinParametrizations::testTrivialVec2Par_Spher() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::Spher));
+}
+void testKinParametrizations::testTrivialVec2Par_ESpher() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::ESpher));
+}
+void testKinParametrizations::testTrivialVec2Par_MomDev() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::MomDev));
+}
+void testKinParametrizations::testTrivialVec2Par_EMomDev() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::EMomDev));
+}
+void testKinParametrizations::testTrivialVec2Par_MCCart() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::MCCart));
+}
+void testKinParametrizations::testTrivialVec2Par_MCSpher() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::MCSpher));
+}
+void testKinParametrizations::testTrivialVec2Par_MCPInvSpher() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::MCPInvSpher));
+}
+void testKinParametrizations::testTrivialVec2Par_EtEtaPhi() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::EtEtaPhi));
+}
+void testKinParametrizations::testTrivialVec2Par_EtThetaPhi() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::EtThetaPhi));
+}
+void testKinParametrizations::testTrivialVec2Par_MCMomDev() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::MCMomDev));
+}
+void testKinParametrizations::testTrivialVec2Par_EScaledMomDev() {
+  CPPUNIT_ASSERT(testTrivialVec2Par(pat::CandKinResolution::EScaledMomDev));
+}
 
 void testKinParametrizations::testVecDiff2Par_Cart() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::Cart)); }
-void testKinParametrizations::testVecDiff2Par_ECart() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::ECart)); }
-void testKinParametrizations::testVecDiff2Par_Spher() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::Spher)); }
-void testKinParametrizations::testVecDiff2Par_ESpher() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::ESpher)); }
-void testKinParametrizations::testVecDiff2Par_MCCart() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::MCCart)); }
-void testKinParametrizations::testVecDiff2Par_MCSpher() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::MCSpher)); }
-void testKinParametrizations::testVecDiff2Par_MCPInvSpher() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::MCPInvSpher)); }
-void testKinParametrizations::testVecDiff2Par_EtEtaPhi() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::EtEtaPhi)); }
-void testKinParametrizations::testVecDiff2Par_EtThetaPhi() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::EtThetaPhi)); }
-void testKinParametrizations::testVecDiff2Par_MomDev() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::MomDev)); }
-void testKinParametrizations::testVecDiff2Par_EMomDev() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::EMomDev)); }
-void testKinParametrizations::testVecDiff2Par_MCMomDev() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::MCMomDev)); }
-void testKinParametrizations::testVecDiff2Par_EScaledMomDev() { CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::EScaledMomDev)); }
+void testKinParametrizations::testVecDiff2Par_ECart() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::ECart));
+}
+void testKinParametrizations::testVecDiff2Par_Spher() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::Spher));
+}
+void testKinParametrizations::testVecDiff2Par_ESpher() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::ESpher));
+}
+void testKinParametrizations::testVecDiff2Par_MCCart() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::MCCart));
+}
+void testKinParametrizations::testVecDiff2Par_MCSpher() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::MCSpher));
+}
+void testKinParametrizations::testVecDiff2Par_MCPInvSpher() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::MCPInvSpher));
+}
+void testKinParametrizations::testVecDiff2Par_EtEtaPhi() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::EtEtaPhi));
+}
+void testKinParametrizations::testVecDiff2Par_EtThetaPhi() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::EtThetaPhi));
+}
+void testKinParametrizations::testVecDiff2Par_MomDev() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::MomDev));
+}
+void testKinParametrizations::testVecDiff2Par_EMomDev() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::EMomDev));
+}
+void testKinParametrizations::testVecDiff2Par_MCMomDev() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::MCMomDev));
+}
+void testKinParametrizations::testVecDiff2Par_EScaledMomDev() {
+  CPPUNIT_ASSERT(testVecDiff2Par(pat::CandKinResolution::EScaledMomDev));
+}
 
 void testKinParametrizations::testVecVec2Diff_Cart() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::Cart)); }
-void testKinParametrizations::testVecVec2Diff_ECart() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::ECart)); }
-void testKinParametrizations::testVecVec2Diff_Spher() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::Spher)); }
-void testKinParametrizations::testVecVec2Diff_ESpher() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::ESpher)); }
-void testKinParametrizations::testVecVec2Diff_MCCart() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::MCCart)); }
-void testKinParametrizations::testVecVec2Diff_MCSpher() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::MCSpher)); }
-void testKinParametrizations::testVecVec2Diff_MCPInvSpher() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::MCPInvSpher)); }
-void testKinParametrizations::testVecVec2Diff_EtEtaPhi() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::EtEtaPhi)); }
-void testKinParametrizations::testVecVec2Diff_EtThetaPhi() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::EtThetaPhi)); }
-void testKinParametrizations::testVecVec2Diff_MomDev() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::MomDev)); }
-void testKinParametrizations::testVecVec2Diff_EMomDev() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::EMomDev)); }
-void testKinParametrizations::testVecVec2Diff_MCMomDev() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::MCMomDev)); }
-void testKinParametrizations::testVecVec2Diff_EScaledMomDev() { CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::EScaledMomDev)); }
+void testKinParametrizations::testVecVec2Diff_ECart() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::ECart));
+}
+void testKinParametrizations::testVecVec2Diff_Spher() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::Spher));
+}
+void testKinParametrizations::testVecVec2Diff_ESpher() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::ESpher));
+}
+void testKinParametrizations::testVecVec2Diff_MCCart() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::MCCart));
+}
+void testKinParametrizations::testVecVec2Diff_MCSpher() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::MCSpher));
+}
+void testKinParametrizations::testVecVec2Diff_MCPInvSpher() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::MCPInvSpher));
+}
+void testKinParametrizations::testVecVec2Diff_EtEtaPhi() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::EtEtaPhi));
+}
+void testKinParametrizations::testVecVec2Diff_EtThetaPhi() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::EtThetaPhi));
+}
+void testKinParametrizations::testVecVec2Diff_MomDev() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::MomDev));
+}
+void testKinParametrizations::testVecVec2Diff_EMomDev() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::EMomDev));
+}
+void testKinParametrizations::testVecVec2Diff_MCMomDev() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::MCMomDev));
+}
+void testKinParametrizations::testVecVec2Diff_EScaledMomDev() {
+  CPPUNIT_ASSERT(testVecVec2Diff(pat::CandKinResolution::EScaledMomDev));
+}

--- a/DataFormats/PatCandidates/test/testKinResolutions.cc
+++ b/DataFormats/PatCandidates/test/testKinResolutions.cc
@@ -54,857 +54,847 @@ class testKinResolutions : public CppUnit::TestFixture {
   CPPUNIT_TEST(testDependentVars_EScaledMomDev);
 
   CPPUNIT_TEST_SUITE_END();
+
 public:
   void setUp() {}
   void tearDown() {}
 
-  void testTrivialMatrix_Cart() ;
-  void testTrivialMatrix_ECart() ;
-  void testTrivialMatrix_Spher() ;
-  void testTrivialMatrix_ESpher() ;
-  void testTrivialMatrix_MomDev() ;
-  void testTrivialMatrix_EMomDev() ;
-  void testTrivialMatrix_MCCart() ;
-  void testTrivialMatrix_MCSpher() ;
-  void testTrivialMatrix_MCPInvSpher() ;
-  void testTrivialMatrix_EtEtaPhi() ;
-  void testTrivialMatrix_EtThetaPhi() ;
-  void testTrivialMatrix_MCMomDev() ;
-  void testTrivialMatrix_EScaledMomDev() ;
+  void testTrivialMatrix_Cart();
+  void testTrivialMatrix_ECart();
+  void testTrivialMatrix_Spher();
+  void testTrivialMatrix_ESpher();
+  void testTrivialMatrix_MomDev();
+  void testTrivialMatrix_EMomDev();
+  void testTrivialMatrix_MCCart();
+  void testTrivialMatrix_MCSpher();
+  void testTrivialMatrix_MCPInvSpher();
+  void testTrivialMatrix_EtEtaPhi();
+  void testTrivialMatrix_EtThetaPhi();
+  void testTrivialMatrix_MCMomDev();
+  void testTrivialMatrix_EScaledMomDev();
 
-  void testIndependentVars_Cart() ;
-  void testIndependentVars_ECart() ;
-  void testIndependentVars_Spher() ;
-  void testIndependentVars_ESpher() ;
-  void testIndependentVars_MomDev() ;
-  void testIndependentVars_EMomDev() ;
-  void testIndependentVars_MCCart() ;
-  void testIndependentVars_MCSpher() ;
-  void testIndependentVars_MCPInvSpher() ;
-  void testIndependentVars_EtEtaPhi() ;
-  void testIndependentVars_EtThetaPhi() ;
-  void testIndependentVars_MCMomDev() ;
-  void testIndependentVars_EScaledMomDev() ;
+  void testIndependentVars_Cart();
+  void testIndependentVars_ECart();
+  void testIndependentVars_Spher();
+  void testIndependentVars_ESpher();
+  void testIndependentVars_MomDev();
+  void testIndependentVars_EMomDev();
+  void testIndependentVars_MCCart();
+  void testIndependentVars_MCSpher();
+  void testIndependentVars_MCPInvSpher();
+  void testIndependentVars_EtEtaPhi();
+  void testIndependentVars_EtThetaPhi();
+  void testIndependentVars_MCMomDev();
+  void testIndependentVars_EScaledMomDev();
 
-  void testDependentVars_Cart() ;
-  void testDependentVars_ECart() ;
-  void testDependentVars_Spher() ;
-  void testDependentVars_ESpher() ;
-  void testDependentVars_MomDev() ;
-  void testDependentVars_EMomDev() ;
-  void testDependentVars_MCCart() ;
-  void testDependentVars_MCSpher() ;
-  void testDependentVars_MCPInvSpher() ;
-  void testDependentVars_EtEtaPhi() ;
-  void testDependentVars_EtThetaPhi() ;
-  void testDependentVars_MCMomDev() ;
-  void testDependentVars_EScaledMomDev() ;
+  void testDependentVars_Cart();
+  void testDependentVars_ECart();
+  void testDependentVars_Spher();
+  void testDependentVars_ESpher();
+  void testDependentVars_MomDev();
+  void testDependentVars_EMomDev();
+  void testDependentVars_MCCart();
+  void testDependentVars_MCSpher();
+  void testDependentVars_MCPInvSpher();
+  void testDependentVars_EtEtaPhi();
+  void testDependentVars_EtThetaPhi();
+  void testDependentVars_MCMomDev();
+  void testDependentVars_EScaledMomDev();
 
-
-  typedef math::XYZTLorentzVector      P4C;
+  typedef math::XYZTLorentzVector P4C;
   typedef math::PtEtaPhiMLorentzVector P4P;
-  typedef AlgebraicVector4             V4;
-  typedef AlgebraicSymMatrix44         M4;
+  typedef AlgebraicVector4 V4;
+  typedef AlgebraicSymMatrix44 M4;
+
 private:
   typedef pat::CandKinResolution::Parametrization Parametrization;
 
   /// check if resol 'f' for param 'p' throws an exception or not
   /// it won't even look at the value
-  template<typename Func> bool testIfThrows(Parametrization p, Func f);
+  template <typename Func>
+  bool testIfThrows(Parametrization p, Func f);
 
   /// check that resol 'f' for param 'p' is the square root of covariance(index,index)
-  template<typename Func> bool testTrivialMatrix(Parametrization p, Func f, int index, int tries=10);
+  template <typename Func>
+  bool testTrivialMatrix(Parametrization p, Func f, int index, int tries = 10);
 
   /// check that resol 'f' for param p is independent from the coordinate 'index'
   /// that is, if covariance(i,j) is null except for (index,index), resol 'f' must be zero
-  template<typename Func> bool testIsIndependent(Parametrization p, Func f, int index, int tries=10);
+  template <typename Func>
+  bool testIsIndependent(Parametrization p, Func f, int index, int tries = 10);
 
   /// check that resol 'f' for param p is independent from any coordinate index except 'self'
-  template<typename Func> bool testFullyIndependent(Parametrization p, Func f, int self, int tries=10);
+  template <typename Func>
+  bool testFullyIndependent(Parametrization p, Func f, int self, int tries = 10);
 
   /// check the correctness of the derivative of some var the parameter, with respect to the numerical derivative
   /// computed symmetrically with step 'eps'.
-  bool testDiagonalDerivativeM    (Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativeEta  (Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativeTheta(Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativePhi  (Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativeEt   (Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativeE    (Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativeP    (Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativePt   (Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativePx   (Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativePy   (Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativePz   (Parametrization p, int index, double eps = 1e-5, int tries=200);
-  bool testDiagonalDerivativePInv (Parametrization p, int index, double eps = 1e-5, int tries=200);
+  bool testDiagonalDerivativeM(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativeEta(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativeTheta(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativePhi(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativeEt(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativeE(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativeP(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativePt(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativePx(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativePy(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativePz(Parametrization p, int index, double eps = 1e-5, int tries = 200);
+  bool testDiagonalDerivativePInv(Parametrization p, int index, double eps = 1e-5, int tries = 200);
 
   /// check the correctness of the relative signs of two derivative of some var the parameter
-  bool testOffDiagonalDerivativeM    (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativeEta  (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativeTheta(Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativePhi  (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativeEt   (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativeE    (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativeP    (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativePt   (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativePx   (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativePy   (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativePz   (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
-  bool testOffDiagonalDerivativePInv (Parametrization p, int i, int j, double eps = 1e-5, int tries=200);
+  bool testOffDiagonalDerivativeM(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativeEta(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativeTheta(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativePhi(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativeEt(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativeE(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativeP(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativePt(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativePx(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativePy(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativePz(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
+  bool testOffDiagonalDerivativePInv(Parametrization p, int i, int j, double eps = 1e-5, int tries = 200);
 
-
-  double getVarEta  (P4P &p4) const { return p4.Eta();   }
+  double getVarEta(P4P &p4) const { return p4.Eta(); }
   double getVarTheta(P4P &p4) const { return p4.Theta(); }
-  double getVarPhi  (P4P &p4) const { return p4.Phi();   }
-  double getVarEt   (P4P &p4) const { return p4.Et();    }
-  double getVarE    (P4P &p4) const { return p4.E();     }
-  double getVarP    (P4P &p4) const { return p4.P();     }
-  double getVarPt   (P4P &p4) const { return p4.Pt();    }
-  double getVarPx   (P4P &p4) const { return p4.Px();    }
-  double getVarPy   (P4P &p4) const { return p4.Py();    }
-  double getVarPz   (P4P &p4) const { return p4.Pz();    }
-  double getVarM    (P4P &p4) const { return p4.M();     }
-  double getVarPInv (P4P &p4) const { return 1.0/p4.P(); }
-
+  double getVarPhi(P4P &p4) const { return p4.Phi(); }
+  double getVarEt(P4P &p4) const { return p4.Et(); }
+  double getVarE(P4P &p4) const { return p4.E(); }
+  double getVarP(P4P &p4) const { return p4.P(); }
+  double getVarPt(P4P &p4) const { return p4.Pt(); }
+  double getVarPx(P4P &p4) const { return p4.Px(); }
+  double getVarPy(P4P &p4) const { return p4.Py(); }
+  double getVarPz(P4P &p4) const { return p4.Pz(); }
+  double getVarM(P4P &p4) const { return p4.M(); }
+  double getVarPInv(P4P &p4) const { return 1.0 / p4.P(); }
 
   // Utilities
-  static double r(double val=1.0) { return rand()*val/double(RAND_MAX); }
-  static double r(double from, double to) { return rand()*(to-from)/double(RAND_MAX) + from; }
-  static P4P r4(double m=-1) {
-    double mass = (m != -1 ? m :  (r() > .3 ? r(.1,30) : 0) );
-    return P4P( r(5,25), r(-2.5,5), r(-M_PI,M_PI), mass );
+  static double r(double val = 1.0) { return rand() * val / double(RAND_MAX); }
+  static double r(double from, double to) { return rand() * (to - from) / double(RAND_MAX) + from; }
+  static P4P r4(double m = -1) {
+    double mass = (m != -1 ? m : (r() > .3 ? r(.1, 30) : 0));
+    return P4P(r(5, 25), r(-2.5, 5), r(-M_PI, M_PI), mass);
   }
   static M4 diag(size_t dim) {
     M4 ret;
-    for (size_t i = 0; i < dim; ++i) ret(i,i) = r(.1,10);
+    for (size_t i = 0; i < dim; ++i)
+      ret(i, i) = r(.1, 10);
     return ret;
   }
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testKinResolutions);
 
-template<typename Func>
-bool
-testKinResolutions::testIfThrows(Parametrization p, Func f) {
-    srand(37);
-    P4C p4;
-    M4  mat = diag(pat::helper::ParametrizationHelper::dimension(p));
-    double y = f(p,mat,p4);
-    return (y != 1e37); // so that it doesn't count as unused
+template <typename Func>
+bool testKinResolutions::testIfThrows(Parametrization p, Func f) {
+  srand(37);
+  P4C p4;
+  M4 mat = diag(pat::helper::ParametrizationHelper::dimension(p));
+  double y = f(p, mat, p4);
+  return (y != 1e37);  // so that it doesn't count as unused
 }
 
 using pat::helper::ParametrizationHelper::name;
 
-template<typename Func>
-bool
-testKinResolutions::testTrivialMatrix(Parametrization p, Func f, int index, int tries) {
-    srand(37);
-    using namespace pat::helper::ParametrizationHelper;
-    for (int i = 0; i < tries; ++i) {
-        P4C p4;
-        M4  mat = diag(dimension(p));
-        double x = sqrt(mat(index,index));
-        double y = f(p,mat,p4);
-        if (std::abs(x-y) > (std::abs(x)+std::abs(y)+1) * 1e-6) {
-            std::cerr << "Error for parametrization " << name(p) << ", index = " << index <<
-                         "\n x = " << x << ", y = " << y << std::endl;
-            return false;
-        }
+template <typename Func>
+bool testKinResolutions::testTrivialMatrix(Parametrization p, Func f, int index, int tries) {
+  srand(37);
+  using namespace pat::helper::ParametrizationHelper;
+  for (int i = 0; i < tries; ++i) {
+    P4C p4;
+    M4 mat = diag(dimension(p));
+    double x = sqrt(mat(index, index));
+    double y = f(p, mat, p4);
+    if (std::abs(x - y) > (std::abs(x) + std::abs(y) + 1) * 1e-6) {
+      std::cerr << "Error for parametrization " << name(p) << ", index = " << index << "\n x = " << x << ", y = " << y
+                << std::endl;
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 
-template<typename Func>
+template <typename Func>
 bool testKinResolutions::testIsIndependent(Parametrization par, Func f, int index, int tries) {
-    double delta = 0.001;
-    using namespace pat::helper::ParametrizationHelper;
-    srand(37);
-    for (int i = 0; i < tries; ++i) {
-        P4P p1 = r4(isAlwaysMassless(par) ? 0 :
-                    (isAlwaysMassive(par) ? r(.1,30) :
-                     (r() > .3 ? r(.1,30) : 0) ) );
-//         V4  v1  = parametersFromP4(par, p1), v2; // warning from gcc461: variable 'v1' set but not used [-Wunused-but-set-variable]
-        M4  mat;
-        mat(index,index) = delta*delta;
-        double exp = f(par,mat,P4C(p1));
-        if (exp != 0) return false;
-    }
-    return true;
+  double delta = 0.001;
+  using namespace pat::helper::ParametrizationHelper;
+  srand(37);
+  for (int i = 0; i < tries; ++i) {
+    P4P p1 = r4(isAlwaysMassless(par) ? 0 : (isAlwaysMassive(par) ? r(.1, 30) : (r() > .3 ? r(.1, 30) : 0)));
+    //         V4  v1  = parametersFromP4(par, p1), v2; // warning from gcc461: variable 'v1' set but not used [-Wunused-but-set-variable]
+    M4 mat;
+    mat(index, index) = delta * delta;
+    double exp = f(par, mat, P4C(p1));
+    if (exp != 0)
+      return false;
+  }
+  return true;
 }
-template<typename Func>
+template <typename Func>
 bool testKinResolutions::testFullyIndependent(Parametrization par, Func f, int self, int tries) {
-    for (int i = 0; i <= 3; ++i) {
-        if (i == self) continue;
-        if (!testIsIndependent(par,f,i,tries)) return false;
-    }
-    return true;
+  for (int i = 0; i <= 3; ++i) {
+    if (i == self)
+      continue;
+    if (!testIsIndependent(par, f, i, tries))
+      return false;
+  }
+  return true;
 }
 
-#define IMPL_testDiagonalDerivative(VAR) \
-bool    		\
-testKinResolutions::testDiagonalDerivative ## VAR (Parametrization par, int index, double delta, int tries) {    				\
-    using namespace pat::helper::ParametrizationHelper;    											\
-    using namespace pat::helper::ResolutionHelper;         											\
-    srand(37);    								                                        			\
-    int skips = 0, glitches = 0;	                                        								\
-    for (int i = 0; i < tries; ++i) {    										                	\
-        P4P p1 = r4(isAlwaysMassless(par) ? 0 : r(.1,30));  						        		                \
-        M4  mat;     										                                        	\
-        mat(index,index) = 1;    										                        	\
-        double exp = getResol ## VAR(par,mat,P4C(p1)); /* should be |dV/dX_i|, where V is the variable on which 'f' gets the resolution */  	\
-        /* now let's compute the derivative numerically */											\
-        V4  v  = parametersFromP4(par, p1), vplus = v, vminus = v;										\
-        vplus[index] += delta; vminus[index] -= delta;										        	\
-        if (isPhysical(par,vplus,p1) && (isPhysical(par,vminus,p1))) {										\
-            P4P pplus  = polarP4fromParameters(par, vplus , p1);										\
-            P4P pminus = polarP4fromParameters(par, vminus, p1);										\
-            double yplus = getVar ## VAR(pplus), yminus = getVar ## VAR(pminus);	                                                	\
-            double num = (yplus - yminus)/(2*delta);                                                                            		\
-            double diff =  std::abs(std::abs(num) - exp)/(std::abs(num) + std::abs(exp) + 1);	                                            	\
-            if (diff > 2e-4) {	                                                                                                        	\
-                std::cout << "\nError for  " # VAR "\n" <<	                                                                           	\
-                             "  par = " << name(par) << ", index = " << index << "\n" <<                                              		\
-                             "  p4 = " << p1 << ",\n  expected = " << exp << ", numeric = " << num << ", diff = " << diff << std::endl;		\
-                glitches++;                                                                                                        		\
-                if ((diff > 3e-2) || (glitches > std::max(tries/10, 10))) return false;                                                         \
-            }	                                                                                                                                \
-        } else skips++;                                                                                                                    	\
-   }    	                                                                                                                        	\
-   if (double(skips)/tries >= 0.1) {                                                                                                           	\
-      std::cout << "Error for  " # VAR "\n" << "  par = " << name(par) << ", index = " << index << "\n"                                        	\
-        	   "Unphysical momenta " << skips << " over " << tries << std::endl;                                                            \
-   }    	                                                                                                                        	\
-   return (double(skips)/tries < 0.1);                                                                                               		\
-}
-IMPL_testDiagonalDerivative(M    )
-IMPL_testDiagonalDerivative(Eta  )
-IMPL_testDiagonalDerivative(Theta)
-IMPL_testDiagonalDerivative(Phi  )
-IMPL_testDiagonalDerivative(Et   )
-IMPL_testDiagonalDerivative(E    )
-IMPL_testDiagonalDerivative(P    )
-IMPL_testDiagonalDerivative(Pt   )
-IMPL_testDiagonalDerivative(Px   )
-IMPL_testDiagonalDerivative(Py   )
-IMPL_testDiagonalDerivative(Pz   )
-IMPL_testDiagonalDerivative(PInv )
+#define IMPL_testDiagonalDerivative(VAR)                                                                            \
+  bool testKinResolutions::testDiagonalDerivative##VAR(Parametrization par, int index, double delta, int tries) {   \
+    using namespace pat::helper::ParametrizationHelper;                                                             \
+    using namespace pat::helper::ResolutionHelper;                                                                  \
+    srand(37);                                                                                                      \
+    int skips = 0, glitches = 0;                                                                                    \
+    for (int i = 0; i < tries; ++i) {                                                                               \
+      P4P p1 = r4(isAlwaysMassless(par) ? 0 : r(.1, 30));                                                           \
+      M4 mat;                                                                                                       \
+      mat(index, index) = 1;                                                                                        \
+      double exp = getResol##VAR(                                                                                   \
+          par, mat, P4C(p1)); /* should be |dV/dX_i|, where V is the variable on which 'f' gets the resolution */   \
+      /* now let's compute the derivative numerically */                                                            \
+      V4 v = parametersFromP4(par, p1), vplus = v, vminus = v;                                                      \
+      vplus[index] += delta;                                                                                        \
+      vminus[index] -= delta;                                                                                       \
+      if (isPhysical(par, vplus, p1) && (isPhysical(par, vminus, p1))) {                                            \
+        P4P pplus = polarP4fromParameters(par, vplus, p1);                                                          \
+        P4P pminus = polarP4fromParameters(par, vminus, p1);                                                        \
+        double yplus = getVar##VAR(pplus), yminus = getVar##VAR(pminus);                                            \
+        double num = (yplus - yminus) / (2 * delta);                                                                \
+        double diff = std::abs(std::abs(num) - exp) / (std::abs(num) + std::abs(exp) + 1);                          \
+        if (diff > 2e-4) {                                                                                          \
+          std::cout << "\nError for  " #VAR "\n"                                                                    \
+                    << "  par = " << name(par) << ", index = " << index << "\n"                                     \
+                    << "  p4 = " << p1 << ",\n  expected = " << exp << ", numeric = " << num << ", diff = " << diff \
+                    << std::endl;                                                                                   \
+          glitches++;                                                                                               \
+          if ((diff > 3e-2) || (glitches > std::max(tries / 10, 10)))                                               \
+            return false;                                                                                           \
+        }                                                                                                           \
+      } else                                                                                                        \
+        skips++;                                                                                                    \
+    }                                                                                                               \
+    if (double(skips) / tries >= 0.1) {                                                                             \
+      std::cout << "Error for  " #VAR "\n"                                                                          \
+                << "  par = " << name(par) << ", index = " << index                                                 \
+                << "\n"                                                                                             \
+                   "Unphysical momenta "                                                                            \
+                << skips << " over " << tries << std::endl;                                                         \
+    }                                                                                                               \
+    return (double(skips) / tries < 0.1);                                                                           \
+  }
+IMPL_testDiagonalDerivative(M) IMPL_testDiagonalDerivative(Eta) IMPL_testDiagonalDerivative(Theta)
+    IMPL_testDiagonalDerivative(Phi) IMPL_testDiagonalDerivative(Et) IMPL_testDiagonalDerivative(E)
+        IMPL_testDiagonalDerivative(P) IMPL_testDiagonalDerivative(Pt) IMPL_testDiagonalDerivative(Px)
+            IMPL_testDiagonalDerivative(Py) IMPL_testDiagonalDerivative(Pz) IMPL_testDiagonalDerivative(PInv)
 
-#define IMPL_testOffDiagonalDerivative(VAR) \
-bool    		\
-testKinResolutions::testOffDiagonalDerivative ## VAR (Parametrization par, int i, int j, double delta, int tries) {    				\
-    using namespace pat::helper::ParametrizationHelper;    											\
-    using namespace pat::helper::ResolutionHelper;         											\
-    srand(37);    								                                        			\
-    int skips = 0, glitches = 0;	                                        								\
-    for (int it = 0; it < tries; ++it) {    										                	\
-        P4P p1 = r4(isAlwaysMassless(par) ? 0 : r(.1,30));  						        		                \
-        M4  mat;     										                                        	\
-        mat(i,i) = 1;                   									                        	\
-        double vi = getResol ## VAR(par,mat,P4C(p1)); /* should be |dV/dX_i|, where V is the variable on which 'f' gets the resolution */  	\
-        mat(i,i) = 0; mat(j,j) = 1;          									                        	\
-        double vj = getResol ## VAR(par,mat,P4C(p1)); /* should be |dV/dX_j|, where V is the variable on which 'f' gets the resolution */  	\
-        mat(i,i) = 2; mat(j,j) = 2; mat(i,j) = 1; 								                        	\
-        double vij = getResol ## VAR(par,mat,P4C(p1)); /* should be sqrt(2)*(|dV/dX_i|^2+|dV/dx_j|^2 + 2 dV/dX_i dV_dX_j ) */             	\
-        /* now let's compute the derivative numerically */											\
-        V4  v  = parametersFromP4(par, p1), vplus_i = v, vminus_i = v, vplus_j = v, vminus_j = v;						\
-        vplus_i[i] += delta; vminus_i[i] -= delta;										        	\
-        vplus_j[j] += delta; vminus_j[j] -= delta;										        	\
-        if (isPhysical(par,vplus_i,p1) && (isPhysical(par,vminus_i,p1)) && 									\
-            isPhysical(par,vplus_j,p1) && (isPhysical(par,vminus_j,p1))) {									\
-            P4P pplus_i  = polarP4fromParameters(par, vplus_i , p1);										\
-            P4P pplus_j  = polarP4fromParameters(par, vplus_j , p1);										\
-            P4P pminus_i = polarP4fromParameters(par, vminus_i, p1);										\
-            P4P pminus_j = polarP4fromParameters(par, vminus_j, p1);										\
-            double yplus_i = getVar ## VAR(pplus_i), yminus_i = getVar ## VAR(pminus_i);	                                               	\
-            double yplus_j = getVar ## VAR(pplus_j), yminus_j = getVar ## VAR(pminus_j);	                                               	\
-            double num_i = (yplus_i - yminus_i)/(2*delta);                                                                            		\
-            double num_j = (yplus_j - yminus_j)/(2*delta);                                                                            		\
-            if (num_i < 0) vi = - vi;                                                                                                           \
-            if (num_j < 0) vj = - vj;                                                                                                           \
-            double num = std::sqrt( 2*(vi*vi + vj*vj + vi*vj) );	                                                                    	\
-            double diff =  std::abs(std::abs(num) - vij)/(std::abs(num) + std::abs(vij) + 1);	                                            	\
-            if (diff > 1e-4) {	                                                                                                        	\
-                std::cout << "\nError for  " # VAR "\n" <<	                                                                           	\
-                             "  par = " << name(par) << ", i = " << i << ", j= " << j << "\n" <<                                              	\
-                             "  p4 = " << p1 << ",\n  expected = " << vij << ", numeric = " << num << ", diff = " << diff << std::endl;		\
-                glitches++;                                                                                                        		\
-                if ((diff > 3e-2) || (glitches > std::max(tries/10, 10))) return false;                                                         \
-            }	                                                                                                                                \
-        } else skips++;                                                                                                                    	\
-   }    	                                                                                                                        	\
-   if (double(skips)/tries >= 0.1) {                                                                                                           	\
-      std::cout << "Error for  " # VAR "\n" << "  par = " << name(par) << ", i = " << i << ", j= " << j << "\n"                                 \
-        	   "Unphysical momenta " << skips << " over " << tries << std::endl;                                                            \
-   }    	                                                                                                                        	\
-   return (double(skips)/tries < 0.1);                                                                                               		\
-}
-IMPL_testOffDiagonalDerivative(M    )
-IMPL_testOffDiagonalDerivative(Eta  )
-IMPL_testOffDiagonalDerivative(Theta)
-IMPL_testOffDiagonalDerivative(Phi  )
-IMPL_testOffDiagonalDerivative(Et   )
-IMPL_testOffDiagonalDerivative(E    )
-IMPL_testOffDiagonalDerivative(P    )
-IMPL_testOffDiagonalDerivative(Pt   )
-IMPL_testOffDiagonalDerivative(Px   )
-IMPL_testOffDiagonalDerivative(Py   )
-IMPL_testOffDiagonalDerivative(Pz   )
-IMPL_testOffDiagonalDerivative(PInv )
+#define IMPL_testOffDiagonalDerivative(VAR)                                                                         \
+  bool testKinResolutions::testOffDiagonalDerivative##VAR(                                                          \
+      Parametrization par, int i, int j, double delta, int tries) {                                                 \
+    using namespace pat::helper::ParametrizationHelper;                                                             \
+    using namespace pat::helper::ResolutionHelper;                                                                  \
+    srand(37);                                                                                                      \
+    int skips = 0, glitches = 0;                                                                                    \
+    for (int it = 0; it < tries; ++it) {                                                                            \
+      P4P p1 = r4(isAlwaysMassless(par) ? 0 : r(.1, 30));                                                           \
+      M4 mat;                                                                                                       \
+      mat(i, i) = 1;                                                                                                \
+      double vi = getResol##VAR(                                                                                    \
+          par, mat, P4C(p1)); /* should be |dV/dX_i|, where V is the variable on which 'f' gets the resolution */   \
+      mat(i, i) = 0;                                                                                                \
+      mat(j, j) = 1;                                                                                                \
+      double vj = getResol##VAR(                                                                                    \
+          par, mat, P4C(p1)); /* should be |dV/dX_j|, where V is the variable on which 'f' gets the resolution */   \
+      mat(i, i) = 2;                                                                                                \
+      mat(j, j) = 2;                                                                                                \
+      mat(i, j) = 1;                                                                                                \
+      double vij =                                                                                                  \
+          getResol##VAR(par, mat, P4C(p1)); /* should be sqrt(2)*(|dV/dX_i|^2+|dV/dx_j|^2 + 2 dV/dX_i dV_dX_j ) */  \
+      /* now let's compute the derivative numerically */                                                            \
+      V4 v = parametersFromP4(par, p1), vplus_i = v, vminus_i = v, vplus_j = v, vminus_j = v;                       \
+      vplus_i[i] += delta;                                                                                          \
+      vminus_i[i] -= delta;                                                                                         \
+      vplus_j[j] += delta;                                                                                          \
+      vminus_j[j] -= delta;                                                                                         \
+      if (isPhysical(par, vplus_i, p1) && (isPhysical(par, vminus_i, p1)) && isPhysical(par, vplus_j, p1) &&        \
+          (isPhysical(par, vminus_j, p1))) {                                                                        \
+        P4P pplus_i = polarP4fromParameters(par, vplus_i, p1);                                                      \
+        P4P pplus_j = polarP4fromParameters(par, vplus_j, p1);                                                      \
+        P4P pminus_i = polarP4fromParameters(par, vminus_i, p1);                                                    \
+        P4P pminus_j = polarP4fromParameters(par, vminus_j, p1);                                                    \
+        double yplus_i = getVar##VAR(pplus_i), yminus_i = getVar##VAR(pminus_i);                                    \
+        double yplus_j = getVar##VAR(pplus_j), yminus_j = getVar##VAR(pminus_j);                                    \
+        double num_i = (yplus_i - yminus_i) / (2 * delta);                                                          \
+        double num_j = (yplus_j - yminus_j) / (2 * delta);                                                          \
+        if (num_i < 0)                                                                                              \
+          vi = -vi;                                                                                                 \
+        if (num_j < 0)                                                                                              \
+          vj = -vj;                                                                                                 \
+        double num = std::sqrt(2 * (vi * vi + vj * vj + vi * vj));                                                  \
+        double diff = std::abs(std::abs(num) - vij) / (std::abs(num) + std::abs(vij) + 1);                          \
+        if (diff > 1e-4) {                                                                                          \
+          std::cout << "\nError for  " #VAR "\n"                                                                    \
+                    << "  par = " << name(par) << ", i = " << i << ", j= " << j << "\n"                             \
+                    << "  p4 = " << p1 << ",\n  expected = " << vij << ", numeric = " << num << ", diff = " << diff \
+                    << std::endl;                                                                                   \
+          glitches++;                                                                                               \
+          if ((diff > 3e-2) || (glitches > std::max(tries / 10, 10)))                                               \
+            return false;                                                                                           \
+        }                                                                                                           \
+      } else                                                                                                        \
+        skips++;                                                                                                    \
+    }                                                                                                               \
+    if (double(skips) / tries >= 0.1) {                                                                             \
+      std::cout << "Error for  " #VAR "\n"                                                                          \
+                << "  par = " << name(par) << ", i = " << i << ", j= " << j                                         \
+                << "\n"                                                                                             \
+                   "Unphysical momenta "                                                                            \
+                << skips << " over " << tries << std::endl;                                                         \
+    }                                                                                                               \
+    return (double(skips) / tries < 0.1);                                                                           \
+  }
+                IMPL_testOffDiagonalDerivative(M) IMPL_testOffDiagonalDerivative(Eta)
+                    IMPL_testOffDiagonalDerivative(Theta) IMPL_testOffDiagonalDerivative(Phi)
+                        IMPL_testOffDiagonalDerivative(Et) IMPL_testOffDiagonalDerivative(E)
+                            IMPL_testOffDiagonalDerivative(P) IMPL_testOffDiagonalDerivative(Pt)
+                                IMPL_testOffDiagonalDerivative(Px) IMPL_testOffDiagonalDerivative(Py)
+                                    IMPL_testOffDiagonalDerivative(Pz) IMPL_testOffDiagonalDerivative(PInv)
 
+#define ASSERT_DIAGONAL(PARAM, RESOL, INDEX)                                                                    \
+  if (!testTrivialMatrix(pat::CandKinResolution::PARAM, RESOL, INDEX)) {                                        \
+    CPPUNIT_NS::Asserter::fail("Resolution " #RESOL " for Parametrization " #PARAM " is not covariance(" #INDEX \
+                               "," #INDEX ")",                                                                  \
+                               CPPUNIT_SOURCELINE());                                                           \
+  }
 
-#define ASSERT_DIAGONAL(PARAM,RESOL,INDEX)                              \
-if (!testTrivialMatrix(pat::CandKinResolution::PARAM, RESOL , INDEX)) { \
-     CPPUNIT_NS::Asserter::fail("Resolution " # RESOL                   \
-                                " for Parametrization " # PARAM         \
-                                " is not covariance("#INDEX","#INDEX")",\
-                                CPPUNIT_SOURCELINE());                  \
-}
-
-#define ASSERT_FULLY_INDEPENDENT(PARAM,RESOL,INDEX)                        \
-if (!testFullyIndependent(pat::CandKinResolution::PARAM, RESOL , INDEX)) { \
-     CPPUNIT_NS::Asserter::fail("Resolution " # RESOL                      \
-                                " for Parametrization " # PARAM            \
-                                " is not only function of " #INDEX,        \
-                                CPPUNIT_SOURCELINE());                     \
-}
-
+#define ASSERT_FULLY_INDEPENDENT(PARAM, RESOL, INDEX)                                                                  \
+  if (!testFullyIndependent(pat::CandKinResolution::PARAM, RESOL, INDEX)) {                                            \
+    CPPUNIT_NS::Asserter::fail("Resolution " #RESOL " for Parametrization " #PARAM " is not only function of " #INDEX, \
+                               CPPUNIT_SOURCELINE());                                                                  \
+  }
 
 // Derivatives must not throw exceptions
-#define ASSERT_HAS_DERIVATIVE(PARAM,RESOL) \
-   CPPUNIT_ASSERT_NO_THROW(testIfThrows(pat::CandKinResolution::PARAM, RESOL));
+#define ASSERT_HAS_DERIVATIVE(PARAM, RESOL) CPPUNIT_ASSERT_NO_THROW(testIfThrows(pat::CandKinResolution::PARAM, RESOL));
 // And we can check their independence from some coordinate
-#define ASSERT_HAS_INDEP_DERIVATIVE(PARAM,RESOL,INDEX)                  \
-  if (!testIsIndependent(pat::CandKinResolution::PARAM, RESOL , INDEX)) {  \
-     CPPUNIT_NS::Asserter::fail("Resolution " # RESOL                      \
-                                " for Parametrization " # PARAM            \
-                                " is correlated to " #INDEX,               \
-                                CPPUNIT_SOURCELINE());                     \
+#define ASSERT_HAS_INDEP_DERIVATIVE(PARAM, RESOL, INDEX)                                                        \
+  if (!testIsIndependent(pat::CandKinResolution::PARAM, RESOL, INDEX)) {                                        \
+    CPPUNIT_NS::Asserter::fail("Resolution " #RESOL " for Parametrization " #PARAM " is correlated to " #INDEX, \
+                               CPPUNIT_SOURCELINE());                                                           \
   }
-#define ASSERT_CHECK_DERIVATIVE(PARAM,VAR,INDEX)                                  \
-  if (!testDiagonalDerivative ## VAR(pat::CandKinResolution::PARAM, INDEX)) {     \
-       CPPUNIT_NS::Asserter::fail("Resolution on " # VAR                          \
-                                  " for Parametrization " # PARAM                 \
-                                  " has wrong derivative w.r.t. " #INDEX,         \
-                                  CPPUNIT_SOURCELINE());                          \
+#define ASSERT_CHECK_DERIVATIVE(PARAM, VAR, INDEX)                                  \
+  if (!testDiagonalDerivative##VAR(pat::CandKinResolution::PARAM, INDEX)) {         \
+    CPPUNIT_NS::Asserter::fail("Resolution on " #VAR " for Parametrization " #PARAM \
+                               " has wrong derivative w.r.t. " #INDEX,              \
+                               CPPUNIT_SOURCELINE());                               \
   }
-#define ASSERT_CHECK_DERIVATIVE2(PARAM,VAR,I,J)                                   \
-  if (!testOffDiagonalDerivative ## VAR(pat::CandKinResolution::PARAM,I,J)) {     \
-       CPPUNIT_NS::Asserter::fail("Resolution on " # VAR                          \
-                                  " for Parametrization " # PARAM                 \
-                                  " has wrong derivative w.r.t. " #I "," # J,     \
-                                  CPPUNIT_SOURCELINE());                          \
+#define ASSERT_CHECK_DERIVATIVE2(PARAM, VAR, I, J)                                                                     \
+  if (!testOffDiagonalDerivative##VAR(pat::CandKinResolution::PARAM, I, J)) {                                          \
+    CPPUNIT_NS::Asserter::fail("Resolution on " #VAR " for Parametrization " #PARAM " has wrong derivative w.r.t. " #I \
+                               "," #J,                                                                                 \
+                               CPPUNIT_SOURCELINE());                                                                  \
   }
 
-
-#define ASSERT_CHECK_DERIVATIVES(PARAM,VAR)                       \
-  ASSERT_CHECK_DERIVATIVE(PARAM,VAR,0)                            \
-  ASSERT_CHECK_DERIVATIVE(PARAM,VAR,1)                            \
-  ASSERT_CHECK_DERIVATIVE(PARAM,VAR,2)                            \
-  ASSERT_CHECK_DERIVATIVE2(PARAM,VAR,0,1)                         \
-  ASSERT_CHECK_DERIVATIVE2(PARAM,VAR,0,2)                         \
-  ASSERT_CHECK_DERIVATIVE2(PARAM,VAR,1,2)                         \
-  if (dimension(pat::CandKinResolution::PARAM) == 4) {            \
-    ASSERT_CHECK_DERIVATIVE(PARAM,VAR,3)                          \
-    ASSERT_CHECK_DERIVATIVE2(PARAM,VAR,0,3)                       \
-    ASSERT_CHECK_DERIVATIVE2(PARAM,VAR,1,3)                       \
-    ASSERT_CHECK_DERIVATIVE2(PARAM,VAR,2,3)                       \
+#define ASSERT_CHECK_DERIVATIVES(PARAM, VAR)           \
+  ASSERT_CHECK_DERIVATIVE(PARAM, VAR, 0)               \
+  ASSERT_CHECK_DERIVATIVE(PARAM, VAR, 1)               \
+  ASSERT_CHECK_DERIVATIVE(PARAM, VAR, 2)               \
+  ASSERT_CHECK_DERIVATIVE2(PARAM, VAR, 0, 1)           \
+  ASSERT_CHECK_DERIVATIVE2(PARAM, VAR, 0, 2)           \
+  ASSERT_CHECK_DERIVATIVE2(PARAM, VAR, 1, 2)           \
+  if (dimension(pat::CandKinResolution::PARAM) == 4) { \
+    ASSERT_CHECK_DERIVATIVE(PARAM, VAR, 3)             \
+    ASSERT_CHECK_DERIVATIVE2(PARAM, VAR, 0, 3)         \
+    ASSERT_CHECK_DERIVATIVE2(PARAM, VAR, 1, 3)         \
+    ASSERT_CHECK_DERIVATIVE2(PARAM, VAR, 2, 3)         \
   }
 
+#define ASSERT_NOT_IMPLEMENTED(PARAM, RESOL)                                       \
+  do {                                                                             \
+    bool cpputExceptionThrown_ = false;                                            \
+    try {                                                                          \
+      testTrivialMatrix(pat::CandKinResolution::PARAM, RESOL, 0, 1);               \
+    } catch (const cms::Exception &e) {                                            \
+      if (e.category() == "Not Implemented")                                       \
+        cpputExceptionThrown_ = true;                                              \
+    }                                                                              \
+                                                                                   \
+    if (cpputExceptionThrown_)                                                     \
+      break;                                                                       \
+                                                                                   \
+    CPPUNIT_NS::Asserter::fail("Resolution " #RESOL " for Parametrization " #PARAM \
+                               " Not implemented but not throwing",                \
+                               CPPUNIT_SOURCELINE());                              \
+  } while (false)
 
-#define ASSERT_NOT_IMPLEMENTED(PARAM,RESOL)                             \
-do {                                                                    \
-      bool cpputExceptionThrown_ = false;                               \
-      try {                                                             \
-         testTrivialMatrix(pat::CandKinResolution::PARAM, RESOL ,0,1);  \
-      } catch ( const cms::Exception &e ) {                             \
-         if (e.category() == "Not Implemented")                         \
-                cpputExceptionThrown_ = true;                           \
-      }                                                                 \
-                                                                        \
-      if ( cpputExceptionThrown_ )                                      \
-         break;                                                         \
-                                                                        \
-      CPPUNIT_NS::Asserter::fail("Resolution " # RESOL                  \
-                                 " for Parametrization " # PARAM        \
-                                 " Not implemented but not throwing",   \
-                                 CPPUNIT_SOURCELINE());                 \
-   } while ( false )
-
-using namespace pat::helper::ResolutionHelper;
+                                        using namespace pat::helper::ResolutionHelper;
 using pat::helper::ParametrizationHelper::dimension;
 
 void testKinResolutions::testTrivialMatrix_Cart() {
-    ASSERT_DIAGONAL(Cart, getResolPx     , 0);
-    ASSERT_DIAGONAL(Cart, getResolPy     , 1);
-    ASSERT_DIAGONAL(Cart, getResolPz     , 2);
-    ASSERT_DIAGONAL(Cart, getResolM      , 3);
-    ASSERT_HAS_DERIVATIVE(Cart, getResolEta);
-    ASSERT_HAS_DERIVATIVE(Cart, getResolTheta);
-    ASSERT_HAS_DERIVATIVE(Cart, getResolPhi);
-    ASSERT_HAS_DERIVATIVE(Cart, getResolEt);
-    ASSERT_HAS_DERIVATIVE(Cart, getResolE);
-    ASSERT_HAS_DERIVATIVE(Cart, getResolP);
-    ASSERT_HAS_DERIVATIVE(Cart, getResolPt);
-    ASSERT_HAS_DERIVATIVE(Cart, getResolPInv);
+  ASSERT_DIAGONAL(Cart, getResolPx, 0);
+  ASSERT_DIAGONAL(Cart, getResolPy, 1);
+  ASSERT_DIAGONAL(Cart, getResolPz, 2);
+  ASSERT_DIAGONAL(Cart, getResolM, 3);
+  ASSERT_HAS_DERIVATIVE(Cart, getResolEta);
+  ASSERT_HAS_DERIVATIVE(Cart, getResolTheta);
+  ASSERT_HAS_DERIVATIVE(Cart, getResolPhi);
+  ASSERT_HAS_DERIVATIVE(Cart, getResolEt);
+  ASSERT_HAS_DERIVATIVE(Cart, getResolE);
+  ASSERT_HAS_DERIVATIVE(Cart, getResolP);
+  ASSERT_HAS_DERIVATIVE(Cart, getResolPt);
+  ASSERT_HAS_DERIVATIVE(Cart, getResolPInv);
 }
 void testKinResolutions::testTrivialMatrix_ECart() {
-    ASSERT_DIAGONAL(ECart, getResolPx     , 0);
-    ASSERT_DIAGONAL(ECart, getResolPy     , 1);
-    ASSERT_DIAGONAL(ECart, getResolPz     , 2);
-    ASSERT_DIAGONAL(ECart, getResolE      , 3);
-    ASSERT_HAS_DERIVATIVE(ECart, getResolEta);
-    ASSERT_HAS_DERIVATIVE(ECart, getResolTheta);
-    ASSERT_HAS_DERIVATIVE(ECart, getResolPhi);
-    ASSERT_HAS_DERIVATIVE(ECart, getResolEt);
-    ASSERT_HAS_DERIVATIVE(ECart, getResolM);
-    ASSERT_HAS_DERIVATIVE(ECart, getResolP);
-    ASSERT_HAS_DERIVATIVE(ECart, getResolPt);
-    ASSERT_HAS_DERIVATIVE(ECart, getResolPInv);
+  ASSERT_DIAGONAL(ECart, getResolPx, 0);
+  ASSERT_DIAGONAL(ECart, getResolPy, 1);
+  ASSERT_DIAGONAL(ECart, getResolPz, 2);
+  ASSERT_DIAGONAL(ECart, getResolE, 3);
+  ASSERT_HAS_DERIVATIVE(ECart, getResolEta);
+  ASSERT_HAS_DERIVATIVE(ECart, getResolTheta);
+  ASSERT_HAS_DERIVATIVE(ECart, getResolPhi);
+  ASSERT_HAS_DERIVATIVE(ECart, getResolEt);
+  ASSERT_HAS_DERIVATIVE(ECart, getResolM);
+  ASSERT_HAS_DERIVATIVE(ECart, getResolP);
+  ASSERT_HAS_DERIVATIVE(ECart, getResolPt);
+  ASSERT_HAS_DERIVATIVE(ECart, getResolPInv);
 }
 
 void testKinResolutions::testTrivialMatrix_Spher() {
-    ASSERT_DIAGONAL(Spher, getResolP      , 0);
-    ASSERT_DIAGONAL(Spher, getResolTheta  , 1);
-    ASSERT_DIAGONAL(Spher, getResolPhi    , 2);
-    ASSERT_DIAGONAL(Spher, getResolM      , 3);
-    ASSERT_HAS_DERIVATIVE(Spher, getResolEta);
-    ASSERT_HAS_DERIVATIVE(Spher, getResolEt);
-    ASSERT_HAS_DERIVATIVE(Spher, getResolE);
-    ASSERT_HAS_DERIVATIVE(Spher, getResolPt);
-    ASSERT_HAS_DERIVATIVE(Spher, getResolPInv);
-    ASSERT_HAS_DERIVATIVE(Spher, getResolPx);
-    ASSERT_HAS_DERIVATIVE(Spher, getResolPy);
-    ASSERT_HAS_DERIVATIVE(Spher, getResolPz);
+  ASSERT_DIAGONAL(Spher, getResolP, 0);
+  ASSERT_DIAGONAL(Spher, getResolTheta, 1);
+  ASSERT_DIAGONAL(Spher, getResolPhi, 2);
+  ASSERT_DIAGONAL(Spher, getResolM, 3);
+  ASSERT_HAS_DERIVATIVE(Spher, getResolEta);
+  ASSERT_HAS_DERIVATIVE(Spher, getResolEt);
+  ASSERT_HAS_DERIVATIVE(Spher, getResolE);
+  ASSERT_HAS_DERIVATIVE(Spher, getResolPt);
+  ASSERT_HAS_DERIVATIVE(Spher, getResolPInv);
+  ASSERT_HAS_DERIVATIVE(Spher, getResolPx);
+  ASSERT_HAS_DERIVATIVE(Spher, getResolPy);
+  ASSERT_HAS_DERIVATIVE(Spher, getResolPz);
 }
 
 void testKinResolutions::testTrivialMatrix_ESpher() {
-    ASSERT_DIAGONAL(ESpher, getResolP      , 0);
-    ASSERT_DIAGONAL(ESpher, getResolTheta  , 1);
-    ASSERT_DIAGONAL(ESpher, getResolPhi    , 2);
-    ASSERT_DIAGONAL(ESpher, getResolE      , 3);
-    ASSERT_HAS_DERIVATIVE(ESpher, getResolEta);
-    ASSERT_HAS_DERIVATIVE(ESpher, getResolEt);
-    ASSERT_HAS_DERIVATIVE(ESpher, getResolM);
-    ASSERT_HAS_DERIVATIVE(ESpher, getResolPt);
-    ASSERT_HAS_DERIVATIVE(ESpher, getResolPInv);
-    ASSERT_HAS_DERIVATIVE(ESpher, getResolPx);
-    ASSERT_HAS_DERIVATIVE(ESpher, getResolPy);
-    ASSERT_HAS_DERIVATIVE(ESpher, getResolPz);
+  ASSERT_DIAGONAL(ESpher, getResolP, 0);
+  ASSERT_DIAGONAL(ESpher, getResolTheta, 1);
+  ASSERT_DIAGONAL(ESpher, getResolPhi, 2);
+  ASSERT_DIAGONAL(ESpher, getResolE, 3);
+  ASSERT_HAS_DERIVATIVE(ESpher, getResolEta);
+  ASSERT_HAS_DERIVATIVE(ESpher, getResolEt);
+  ASSERT_HAS_DERIVATIVE(ESpher, getResolM);
+  ASSERT_HAS_DERIVATIVE(ESpher, getResolPt);
+  ASSERT_HAS_DERIVATIVE(ESpher, getResolPInv);
+  ASSERT_HAS_DERIVATIVE(ESpher, getResolPx);
+  ASSERT_HAS_DERIVATIVE(ESpher, getResolPy);
+  ASSERT_HAS_DERIVATIVE(ESpher, getResolPz);
 }
 
 void testKinResolutions::testTrivialMatrix_MomDev() {
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolEta);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolTheta);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPhi);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolEt);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolE);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolP);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPt);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPInv);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPx);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPy);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPz);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolM);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolEta);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolTheta);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPhi);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolEt);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolE);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolP);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPt);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPInv);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPx);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPy);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPz);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolM);
 }
 
 void testKinResolutions::testTrivialMatrix_EMomDev() {
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolEta);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolTheta);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPhi);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolEt);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolE);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolP);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPt);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPInv);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPx);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPy);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPz);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolM);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolEta);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolTheta);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPhi);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolEt);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolE);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolP);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPt);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPInv);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPx);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPy);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPz);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolM);
 }
 
 void testKinResolutions::testTrivialMatrix_MCCart() {
-    ASSERT_DIAGONAL(MCCart, getResolPx     , 0);
-    ASSERT_DIAGONAL(MCCart, getResolPy     , 1);
-    ASSERT_DIAGONAL(MCCart, getResolPz     , 2);
-    ASSERT_HAS_DERIVATIVE(MCCart, getResolEta);
-    ASSERT_HAS_DERIVATIVE(MCCart, getResolTheta);
-    ASSERT_HAS_DERIVATIVE(MCCart, getResolPhi);
-    ASSERT_HAS_DERIVATIVE(MCCart, getResolEt);
-    ASSERT_HAS_DERIVATIVE(MCCart, getResolE);
-    ASSERT_HAS_DERIVATIVE(MCCart, getResolP);
-    ASSERT_HAS_DERIVATIVE(MCCart, getResolPt);
-    ASSERT_HAS_DERIVATIVE(MCCart, getResolPInv);
+  ASSERT_DIAGONAL(MCCart, getResolPx, 0);
+  ASSERT_DIAGONAL(MCCart, getResolPy, 1);
+  ASSERT_DIAGONAL(MCCart, getResolPz, 2);
+  ASSERT_HAS_DERIVATIVE(MCCart, getResolEta);
+  ASSERT_HAS_DERIVATIVE(MCCart, getResolTheta);
+  ASSERT_HAS_DERIVATIVE(MCCart, getResolPhi);
+  ASSERT_HAS_DERIVATIVE(MCCart, getResolEt);
+  ASSERT_HAS_DERIVATIVE(MCCart, getResolE);
+  ASSERT_HAS_DERIVATIVE(MCCart, getResolP);
+  ASSERT_HAS_DERIVATIVE(MCCart, getResolPt);
+  ASSERT_HAS_DERIVATIVE(MCCart, getResolPInv);
 }
 
 void testKinResolutions::testTrivialMatrix_MCSpher() {
-    ASSERT_DIAGONAL(MCSpher, getResolP      , 0);
-    ASSERT_DIAGONAL(MCSpher, getResolTheta  , 1);
-    ASSERT_DIAGONAL(MCSpher, getResolPhi    , 2);
-    ASSERT_HAS_DERIVATIVE(MCSpher, getResolEta);
-    ASSERT_HAS_DERIVATIVE(MCSpher, getResolEt);
-    ASSERT_HAS_DERIVATIVE(MCSpher, getResolE);
-    ASSERT_HAS_DERIVATIVE(MCSpher, getResolPt);
-    ASSERT_HAS_DERIVATIVE(MCSpher, getResolPInv);
-    ASSERT_HAS_DERIVATIVE(MCSpher, getResolPx);
-    ASSERT_HAS_DERIVATIVE(MCSpher, getResolPy);
-    ASSERT_HAS_DERIVATIVE(MCSpher, getResolPz);
+  ASSERT_DIAGONAL(MCSpher, getResolP, 0);
+  ASSERT_DIAGONAL(MCSpher, getResolTheta, 1);
+  ASSERT_DIAGONAL(MCSpher, getResolPhi, 2);
+  ASSERT_HAS_DERIVATIVE(MCSpher, getResolEta);
+  ASSERT_HAS_DERIVATIVE(MCSpher, getResolEt);
+  ASSERT_HAS_DERIVATIVE(MCSpher, getResolE);
+  ASSERT_HAS_DERIVATIVE(MCSpher, getResolPt);
+  ASSERT_HAS_DERIVATIVE(MCSpher, getResolPInv);
+  ASSERT_HAS_DERIVATIVE(MCSpher, getResolPx);
+  ASSERT_HAS_DERIVATIVE(MCSpher, getResolPy);
+  ASSERT_HAS_DERIVATIVE(MCSpher, getResolPz);
 }
 
 void testKinResolutions::testTrivialMatrix_MCPInvSpher() {
-    ASSERT_DIAGONAL(MCPInvSpher, getResolPInv   , 0);
-    ASSERT_DIAGONAL(MCPInvSpher, getResolTheta  , 1);
-    ASSERT_DIAGONAL(MCPInvSpher, getResolPhi    , 2);
-    ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolEta);
-    ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolEt);
-    ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolE);
-    ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolP);
-    ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolPt);
-    ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolPx);
-    ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolPy);
-    ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolPz);
+  ASSERT_DIAGONAL(MCPInvSpher, getResolPInv, 0);
+  ASSERT_DIAGONAL(MCPInvSpher, getResolTheta, 1);
+  ASSERT_DIAGONAL(MCPInvSpher, getResolPhi, 2);
+  ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolEta);
+  ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolEt);
+  ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolE);
+  ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolP);
+  ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolPt);
+  ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolPx);
+  ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolPy);
+  ASSERT_HAS_DERIVATIVE(MCPInvSpher, getResolPz);
 }
 
 void testKinResolutions::testTrivialMatrix_EtEtaPhi() {
-    ASSERT_DIAGONAL(EtEtaPhi, getResolEt     , 0);
-    ASSERT_DIAGONAL(EtEtaPhi, getResolPt     , 0); // Et == Pt
-    ASSERT_DIAGONAL(EtEtaPhi, getResolEta    , 1);
-    ASSERT_DIAGONAL(EtEtaPhi, getResolPhi    , 2);
-    ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolTheta);
-    ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolE);
-    ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolP);
-    ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolPInv);
-    ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolPx);
-    ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolPy);
-    ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolPz);
+  ASSERT_DIAGONAL(EtEtaPhi, getResolEt, 0);
+  ASSERT_DIAGONAL(EtEtaPhi, getResolPt, 0);  // Et == Pt
+  ASSERT_DIAGONAL(EtEtaPhi, getResolEta, 1);
+  ASSERT_DIAGONAL(EtEtaPhi, getResolPhi, 2);
+  ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolTheta);
+  ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolE);
+  ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolP);
+  ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolPInv);
+  ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolPx);
+  ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolPy);
+  ASSERT_HAS_DERIVATIVE(EtEtaPhi, getResolPz);
 }
 
 void testKinResolutions::testTrivialMatrix_EtThetaPhi() {
-    ASSERT_DIAGONAL(EtThetaPhi, getResolEt     , 0);
-    ASSERT_DIAGONAL(EtThetaPhi, getResolPt     , 0); // Et == Pt
-    ASSERT_DIAGONAL(EtThetaPhi, getResolTheta  , 1);
-    ASSERT_DIAGONAL(EtThetaPhi, getResolPhi    , 2);
-    ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolEta);
-    ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolE);
-    ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolP);
-    ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolPInv);
-    ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolPx);
-    ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolPy);
-    ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolPz);
+  ASSERT_DIAGONAL(EtThetaPhi, getResolEt, 0);
+  ASSERT_DIAGONAL(EtThetaPhi, getResolPt, 0);  // Et == Pt
+  ASSERT_DIAGONAL(EtThetaPhi, getResolTheta, 1);
+  ASSERT_DIAGONAL(EtThetaPhi, getResolPhi, 2);
+  ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolEta);
+  ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolE);
+  ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolP);
+  ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolPInv);
+  ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolPx);
+  ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolPy);
+  ASSERT_HAS_DERIVATIVE(EtThetaPhi, getResolPz);
 }
 
 void testKinResolutions::testTrivialMatrix_MCMomDev() {
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolEta);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolTheta);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPhi);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolEt);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolE);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolP);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPt);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPInv);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPx);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPy);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPz);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolEta);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolTheta);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPhi);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolEt);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolE);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolP);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPt);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPInv);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPx);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPy);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPz);
 }
 
 void testKinResolutions::testTrivialMatrix_EScaledMomDev() {
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolEta);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolTheta);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPhi);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolEt);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolE);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolP);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPt);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPInv);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPx);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPy);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPz);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolM);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolEta);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolTheta);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPhi);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolEt);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolE);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolP);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPt);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPInv);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPx);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPy);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPz);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolM);
 }
-
 
 void testKinResolutions::testIndependentVars_Cart() {
-    ASSERT_FULLY_INDEPENDENT(Cart, getResolPx     , 0);
-    ASSERT_FULLY_INDEPENDENT(Cart, getResolPy     , 1);
-    ASSERT_FULLY_INDEPENDENT(Cart, getResolPz     , 2);
-    ASSERT_FULLY_INDEPENDENT(Cart, getResolM      , 3);
-    ASSERT_HAS_INDEP_DERIVATIVE(Cart, getResolEta,   3); // Angles Don't
-    ASSERT_HAS_INDEP_DERIVATIVE(Cart, getResolTheta, 3); // depend on
-    ASSERT_HAS_INDEP_DERIVATIVE(Cart, getResolPhi,   3); // the mass
+  ASSERT_FULLY_INDEPENDENT(Cart, getResolPx, 0);
+  ASSERT_FULLY_INDEPENDENT(Cart, getResolPy, 1);
+  ASSERT_FULLY_INDEPENDENT(Cart, getResolPz, 2);
+  ASSERT_FULLY_INDEPENDENT(Cart, getResolM, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(Cart, getResolEta, 3);    // Angles Don't
+  ASSERT_HAS_INDEP_DERIVATIVE(Cart, getResolTheta, 3);  // depend on
+  ASSERT_HAS_INDEP_DERIVATIVE(Cart, getResolPhi, 3);    // the mass
 }
 void testKinResolutions::testIndependentVars_ECart() {
-    ASSERT_FULLY_INDEPENDENT(ECart, getResolPx     , 0);
-    ASSERT_FULLY_INDEPENDENT(ECart, getResolPy     , 1);
-    ASSERT_FULLY_INDEPENDENT(ECart, getResolPz     , 2);
-    ASSERT_FULLY_INDEPENDENT(ECart, getResolE      , 3);
-    ASSERT_HAS_INDEP_DERIVATIVE(ECart, getResolEta,   3); // Angles
-    ASSERT_HAS_INDEP_DERIVATIVE(ECart, getResolTheta, 3); // Don't depend
-    ASSERT_HAS_INDEP_DERIVATIVE(ECart, getResolPhi,   3); // on the energy
+  ASSERT_FULLY_INDEPENDENT(ECart, getResolPx, 0);
+  ASSERT_FULLY_INDEPENDENT(ECart, getResolPy, 1);
+  ASSERT_FULLY_INDEPENDENT(ECart, getResolPz, 2);
+  ASSERT_FULLY_INDEPENDENT(ECart, getResolE, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(ECart, getResolEta, 3);    // Angles
+  ASSERT_HAS_INDEP_DERIVATIVE(ECart, getResolTheta, 3);  // Don't depend
+  ASSERT_HAS_INDEP_DERIVATIVE(ECart, getResolPhi, 3);    // on the energy
 }
 
 void testKinResolutions::testIndependentVars_Spher() {
-    ASSERT_FULLY_INDEPENDENT(Spher, getResolP      , 0);
-    ASSERT_FULLY_INDEPENDENT(Spher, getResolTheta  , 1);
-    ASSERT_FULLY_INDEPENDENT(Spher, getResolPhi    , 2);
-    ASSERT_FULLY_INDEPENDENT(Spher, getResolM      , 3);
+  ASSERT_FULLY_INDEPENDENT(Spher, getResolP, 0);
+  ASSERT_FULLY_INDEPENDENT(Spher, getResolTheta, 1);
+  ASSERT_FULLY_INDEPENDENT(Spher, getResolPhi, 2);
+  ASSERT_FULLY_INDEPENDENT(Spher, getResolM, 3);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolEta, 0); // Eta
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolEta, 2); // Depends
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolEta, 3); // Only On Theta
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolEta, 0);  // Eta
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolEta, 2);  // Depends
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolEta, 3);  // Only On Theta
 
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolEt,  2); // E, Et
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolE,   2); // Don't depend on Phi
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolEt, 2);  // E, Et
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolE, 2);   // Don't depend on Phi
 
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPt,   2); // Pt indep from
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPt,   3); // Phi and M
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPt, 2);  // Pt indep from
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPt, 3);  // Phi and M
 
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPInv, 1); // PInv dep
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPInv, 2); // Only on
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPInv, 3); // P
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPInv, 1);  // PInv dep
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPInv, 2);  // Only on
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPInv, 3);  // P
 
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPx, 3); // Px, Py, Pz
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPy, 3); // Indep from
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPz, 3); // Mass
-    ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPz, 3); // Pz also on Phi
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPx, 3);  // Px, Py, Pz
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPy, 3);  // Indep from
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPz, 3);  // Mass
+  ASSERT_HAS_INDEP_DERIVATIVE(Spher, getResolPz, 3);  // Pz also on Phi
 }
 
 void testKinResolutions::testIndependentVars_ESpher() {
-    ASSERT_FULLY_INDEPENDENT(ESpher, getResolP      , 0);
-    ASSERT_FULLY_INDEPENDENT(ESpher, getResolTheta  , 1);
-    ASSERT_FULLY_INDEPENDENT(ESpher, getResolPhi    , 2);
-    ASSERT_FULLY_INDEPENDENT(ESpher, getResolE      , 3);
+  ASSERT_FULLY_INDEPENDENT(ESpher, getResolP, 0);
+  ASSERT_FULLY_INDEPENDENT(ESpher, getResolTheta, 1);
+  ASSERT_FULLY_INDEPENDENT(ESpher, getResolPhi, 2);
+  ASSERT_FULLY_INDEPENDENT(ESpher, getResolE, 3);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolEta, 0); // Eta
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolEta, 2); // Depends
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolEta, 3); // Only On Theta
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolEta, 0);  // Eta
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolEta, 2);  // Depends
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolEta, 3);  // Only On Theta
 
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolEt,  2); // Et indep from Phi
-    //ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolEt,  2); // FIXME And from P??
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolEt, 2);  // Et indep from Phi
+  //ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolEt,  2); // FIXME And from P??
 
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolM,   2); // Don't depend on Phi
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolM,   1); // Nor on Theta
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolM, 2);  // Don't depend on Phi
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolM, 1);  // Nor on Theta
 
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPt,   2); // Pt indep from
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPt,   3); // Phi and E
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPt, 2);  // Pt indep from
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPt, 3);  // Phi and E
 
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPInv, 1); // PInv dep
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPInv, 2); // Only on
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPInv, 3); // P
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPInv, 1);  // PInv dep
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPInv, 2);  // Only on
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPInv, 3);  // P
 
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPx, 3); // Px, Py, Pz
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPy, 3); // Indep from
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPz, 3); // Energy
-    ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPz, 3); // Pz also on Phi
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPx, 3);  // Px, Py, Pz
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPy, 3);  // Indep from
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPz, 3);  // Energy
+  ASSERT_HAS_INDEP_DERIVATIVE(ESpher, getResolPz, 3);  // Pz also on Phi
 }
 
 void testKinResolutions::testIndependentVars_MomDev() {
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolEta);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolTheta);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPhi);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolEt);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolE);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolP);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPt);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPInv);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPx);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPy);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolPz);
-    ASSERT_NOT_IMPLEMENTED(MomDev, getResolM);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolEta);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolTheta);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPhi);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolEt);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolE);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolP);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPt);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPInv);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPx);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPy);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolPz);
+  ASSERT_NOT_IMPLEMENTED(MomDev, getResolM);
 }
 
 void testKinResolutions::testIndependentVars_EMomDev() {
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolEta);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolTheta);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPhi);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolEt);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolE);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolP);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPt);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPInv);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPx);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPy);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPz);
-    ASSERT_NOT_IMPLEMENTED(EMomDev, getResolM);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolEta);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolTheta);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPhi);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolEt);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolE);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolP);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPt);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPInv);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPx);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPy);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolPz);
+  ASSERT_NOT_IMPLEMENTED(EMomDev, getResolM);
 }
 
 void testKinResolutions::testIndependentVars_MCCart() {
-    ASSERT_FULLY_INDEPENDENT(MCCart, getResolPx     , 0);
-    ASSERT_FULLY_INDEPENDENT(MCCart, getResolPy     , 1);
-    ASSERT_FULLY_INDEPENDENT(MCCart, getResolPz     , 2);
+  ASSERT_FULLY_INDEPENDENT(MCCart, getResolPx, 0);
+  ASSERT_FULLY_INDEPENDENT(MCCart, getResolPy, 1);
+  ASSERT_FULLY_INDEPENDENT(MCCart, getResolPz, 2);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolPhi,   2); // Phi doesn't depend on Pz
+  ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolPhi, 2);  // Phi doesn't depend on Pz
 
-    ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolEta,   3); // nothing
-    ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolTheta, 3); // depends
-    ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolPhi,   3); // on M
-    ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolEt,    3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolE,     3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolP,     3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolPt,    3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolPInv,  3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolEta, 3);    // nothing
+  ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolTheta, 3);  // depends
+  ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolPhi, 3);    // on M
+  ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolEt, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolE, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolP, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolPt, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCCart, getResolPInv, 3);
 }
 
 void testKinResolutions::testIndependentVars_MCSpher() {
-    ASSERT_FULLY_INDEPENDENT(MCSpher, getResolP      , 0);
-    ASSERT_FULLY_INDEPENDENT(MCSpher, getResolTheta  , 1);
-    ASSERT_FULLY_INDEPENDENT(MCSpher, getResolPhi    , 2);
+  ASSERT_FULLY_INDEPENDENT(MCSpher, getResolP, 0);
+  ASSERT_FULLY_INDEPENDENT(MCSpher, getResolTheta, 1);
+  ASSERT_FULLY_INDEPENDENT(MCSpher, getResolPhi, 2);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEta,  3); // everything
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEt,   3); // indep from
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE,    3); // mass
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPt,   3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPInv, 3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPx,   3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPy,   3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPz,   3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEta, 3);  // everything
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEt, 3);   // indep from
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE, 3);    // mass
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPt, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPInv, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPx, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPy, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPz, 3);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEta,  2); // Most things
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEt,   2); // Indep from Phi
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE,    2);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPt,   2);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPInv, 2);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPz,   2);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEta, 2);  // Most things
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEt, 2);   // Indep from Phi
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE, 2);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPt, 2);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPInv, 2);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPz, 2);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE,    1); // E, 1/P
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPInv, 1); // dep only on P
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE, 1);     // E, 1/P
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPInv, 1);  // dep only on P
 }
 
 void testKinResolutions::testIndependentVars_MCPInvSpher() {
-    ASSERT_FULLY_INDEPENDENT(MCPInvSpher, getResolPInv   , 0);
-    ASSERT_FULLY_INDEPENDENT(MCPInvSpher, getResolTheta  , 1);
-    ASSERT_FULLY_INDEPENDENT(MCPInvSpher, getResolPhi    , 2);
+  ASSERT_FULLY_INDEPENDENT(MCPInvSpher, getResolPInv, 0);
+  ASSERT_FULLY_INDEPENDENT(MCPInvSpher, getResolTheta, 1);
+  ASSERT_FULLY_INDEPENDENT(MCPInvSpher, getResolPhi, 2);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEta,  3); // everything
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEt,   3); // indep from
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE,    3); // mass
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPt,   3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolP,    3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPx,   3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPy,   3);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPz,   3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEta, 3);  // everything
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEt, 3);   // indep from
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE, 3);    // mass
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPt, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolP, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPx, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPy, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPz, 3);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEta,  2); // Most things
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEt,   2); // Indep from Phi
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE,    2);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPt,   2);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolP,    2);
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPz,   2);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEta, 2);  // Most things
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolEt, 2);   // Indep from Phi
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE, 2);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPt, 2);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolP, 2);
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolPz, 2);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE,    1); // E, P
-    ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolP,    1); // dep only on 1/P
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolE, 1);  // E, P
+  ASSERT_HAS_INDEP_DERIVATIVE(MCSpher, getResolP, 1);  // dep only on 1/P
 }
 
 void testKinResolutions::testIndependentVars_EtEtaPhi() {
-    ASSERT_FULLY_INDEPENDENT(EtEtaPhi, getResolEt     , 0);
-    ASSERT_FULLY_INDEPENDENT(EtEtaPhi, getResolPt     , 0); // Et == Pt
-    ASSERT_FULLY_INDEPENDENT(EtEtaPhi, getResolEta    , 1);
-    ASSERT_FULLY_INDEPENDENT(EtEtaPhi, getResolPhi    , 2);
+  ASSERT_FULLY_INDEPENDENT(EtEtaPhi, getResolEt, 0);
+  ASSERT_FULLY_INDEPENDENT(EtEtaPhi, getResolPt, 0);  // Et == Pt
+  ASSERT_FULLY_INDEPENDENT(EtEtaPhi, getResolEta, 1);
+  ASSERT_FULLY_INDEPENDENT(EtEtaPhi, getResolPhi, 2);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolTheta, 3); // All indep
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolE,     3); // From the mass
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolP,     3); // (which is also
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPInv,  3); // always zero)
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPx,    3);
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPy,    3);
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPz,    3);
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolTheta, 3);  // All indep
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolE, 3);      // From the mass
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolP, 3);      // (which is also
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPInv, 3);   // always zero)
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPx, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPy, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPz, 3);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolTheta, 2); // Most things
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolE,     2); // Indep from
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolP,     2); // Phi
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPInv,  2);
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPz,    2);
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolTheta, 2);  // Most things
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolE, 2);      // Indep from
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolP, 2);      // Phi
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPInv, 2);
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPz, 2);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPx,    1); // Px, Py
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPy,    1); // Indep from Eta
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPx, 1);  // Px, Py
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPy, 1);  // Indep from Eta
 
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolTheta, 0); // Theta indep from Et
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolTheta, 0);  // Theta indep from Et
 }
 
 void testKinResolutions::testIndependentVars_EtThetaPhi() {
-    ASSERT_FULLY_INDEPENDENT(EtThetaPhi, getResolEt     , 0);
-    ASSERT_FULLY_INDEPENDENT(EtThetaPhi, getResolPt     , 0); // Et == Pt
-    ASSERT_FULLY_INDEPENDENT(EtThetaPhi, getResolTheta  , 1);
-    ASSERT_FULLY_INDEPENDENT(EtThetaPhi, getResolPhi    , 2);
+  ASSERT_FULLY_INDEPENDENT(EtThetaPhi, getResolEt, 0);
+  ASSERT_FULLY_INDEPENDENT(EtThetaPhi, getResolPt, 0);  // Et == Pt
+  ASSERT_FULLY_INDEPENDENT(EtThetaPhi, getResolTheta, 1);
+  ASSERT_FULLY_INDEPENDENT(EtThetaPhi, getResolPhi, 2);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolEta,   3); // All indep
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolE,     3); // From the mass
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolP,     3); // (which is also
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPInv,  3); // always zero)
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPx,    3);
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPy,    3);
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPz,    3);
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolEta, 3);   // All indep
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolE, 3);     // From the mass
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolP, 3);     // (which is also
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPInv, 3);  // always zero)
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPx, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPy, 3);
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPz, 3);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolEta,   2); // Most things
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolE,     2); // Indep from
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolP,     2); // Phi
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPInv,  2);
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPz,    2);
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolEta, 2);  // Most things
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolE, 2);    // Indep from
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolP, 2);    // Phi
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPInv, 2);
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPz, 2);
 
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPx,    1); // Px, Py
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPy,    1); // Indep from Theta
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPx, 1);  // Px, Py
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolPy, 1);  // Indep from Theta
 
-    ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolEta,   0); // Eta indep from Et
+  ASSERT_HAS_INDEP_DERIVATIVE(EtEtaPhi, getResolEta, 0);  // Eta indep from Et
 }
 
 void testKinResolutions::testIndependentVars_MCMomDev() {
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolEta);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolTheta);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPhi);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolEt);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolE);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolP);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPt);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPInv);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPx);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPy);
-    ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPz);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolEta);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolTheta);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPhi);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolEt);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolE);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolP);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPt);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPInv);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPx);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPy);
+  ASSERT_NOT_IMPLEMENTED(MCMomDev, getResolPz);
 }
 
 void testKinResolutions::testIndependentVars_EScaledMomDev() {
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolEta);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolTheta);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPhi);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolEt);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolE);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolP);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPt);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPInv);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPx);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPy);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPz);
-    ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolM);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolEta);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolTheta);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPhi);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolEt);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolE);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolP);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPt);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPInv);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPx);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPy);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolPz);
+  ASSERT_NOT_IMPLEMENTED(EScaledMomDev, getResolM);
 }
 
-#define IMPL_testDependentVars(PAR)                     \
-void testKinResolutions::testDependentVars_ ## PAR() {  \
-    ASSERT_CHECK_DERIVATIVES(PAR, Eta)                  \
-    ASSERT_CHECK_DERIVATIVES(PAR, Theta)                \
-    ASSERT_CHECK_DERIVATIVES(PAR, Phi)                  \
-    ASSERT_CHECK_DERIVATIVES(PAR, Et)                   \
-    ASSERT_CHECK_DERIVATIVES(PAR, E)                    \
-    ASSERT_CHECK_DERIVATIVES(PAR, P)                    \
-    ASSERT_CHECK_DERIVATIVES(PAR, Pt)                   \
-    ASSERT_CHECK_DERIVATIVES(PAR, PInv)                 \
-    ASSERT_CHECK_DERIVATIVES(PAR, Px)                   \
-    ASSERT_CHECK_DERIVATIVES(PAR, Py)                   \
-    ASSERT_CHECK_DERIVATIVES(PAR, Pz)                   \
-    ASSERT_CHECK_DERIVATIVES(PAR, M)                    \
-}
+#define IMPL_testDependentVars(PAR)                    \
+  void testKinResolutions::testDependentVars_##PAR() { \
+    ASSERT_CHECK_DERIVATIVES(PAR, Eta)                 \
+    ASSERT_CHECK_DERIVATIVES(PAR, Theta)               \
+    ASSERT_CHECK_DERIVATIVES(PAR, Phi)                 \
+    ASSERT_CHECK_DERIVATIVES(PAR, Et)                  \
+    ASSERT_CHECK_DERIVATIVES(PAR, E)                   \
+    ASSERT_CHECK_DERIVATIVES(PAR, P)                   \
+    ASSERT_CHECK_DERIVATIVES(PAR, Pt)                  \
+    ASSERT_CHECK_DERIVATIVES(PAR, PInv)                \
+    ASSERT_CHECK_DERIVATIVES(PAR, Px)                  \
+    ASSERT_CHECK_DERIVATIVES(PAR, Py)                  \
+    ASSERT_CHECK_DERIVATIVES(PAR, Pz)                  \
+    ASSERT_CHECK_DERIVATIVES(PAR, M)                   \
+  }
 
-IMPL_testDependentVars(Cart)
-IMPL_testDependentVars(ECart)
-IMPL_testDependentVars(Spher)
-IMPL_testDependentVars(ESpher)
-IMPL_testDependentVars(MCCart)
-IMPL_testDependentVars(MCSpher)
-IMPL_testDependentVars(MCPInvSpher)
-IMPL_testDependentVars(EtEtaPhi)
-IMPL_testDependentVars(EtThetaPhi)
-//IMPL_testDependentVars(MomDev)
-//IMPL_testDependentVars(EMomDev)
-//IMPL_testDependentVars(MCMomDev)
-//IMPL_testDependentVars(EScaledMomDev)
-void testKinResolutions::testDependentVars_MomDev() {}
+IMPL_testDependentVars(Cart) IMPL_testDependentVars(ECart) IMPL_testDependentVars(Spher) IMPL_testDependentVars(ESpher)
+    IMPL_testDependentVars(MCCart) IMPL_testDependentVars(MCSpher) IMPL_testDependentVars(MCPInvSpher)
+        IMPL_testDependentVars(EtEtaPhi) IMPL_testDependentVars(EtThetaPhi)
+    //IMPL_testDependentVars(MomDev)
+    //IMPL_testDependentVars(EMomDev)
+    //IMPL_testDependentVars(MCMomDev)
+    //IMPL_testDependentVars(EScaledMomDev)
+    void testKinResolutions::testDependentVars_MomDev() {}
 void testKinResolutions::testDependentVars_EMomDev() {}
-void testKinResolutions::testDependentVars_MCMomDev() { }
+void testKinResolutions::testDependentVars_MCMomDev() {}
 void testKinResolutions::testDependentVars_EScaledMomDev() {}
-
-

--- a/DataFormats/PatCandidates/test/testPackedCandidate.cc
+++ b/DataFormats/PatCandidates/test/testPackedCandidate.cc
@@ -17,11 +17,12 @@ class testPackedCandidate : public CppUnit::TestFixture {
   CPPUNIT_TEST(testQualityFlags);
 
   CPPUNIT_TEST_SUITE_END();
+
 public:
   void setUp() {}
   void tearDown() {}
 
-  void testDefaultConstructor() ;
+  void testDefaultConstructor();
   void testCopyConstructor();
   void testPackUnpack();
   void testSimulateReadFromRoot();
@@ -34,22 +35,19 @@ private:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testPackedCandidate);
 
-
-
 void testPackedCandidate::testDefaultConstructor() {
-
   pat::PackedCandidate pc;
 
-  CPPUNIT_ASSERT(pc.polarP4() == pat::PackedCandidate::PolarLorentzVector(0,0,0,0));
-  CPPUNIT_ASSERT(pc.p4() == pat::PackedCandidate::LorentzVector(0,0,0,0) );
-  CPPUNIT_ASSERT(pc.vertex() == pat::PackedCandidate::Point(0,0,0));
+  CPPUNIT_ASSERT(pc.polarP4() == pat::PackedCandidate::PolarLorentzVector(0, 0, 0, 0));
+  CPPUNIT_ASSERT(pc.p4() == pat::PackedCandidate::LorentzVector(0, 0, 0, 0));
+  CPPUNIT_ASSERT(pc.vertex() == pat::PackedCandidate::Point(0, 0, 0));
 }
 
 void testPackedCandidate::testCopyConstructor() {
-  pat::PackedCandidate::LorentzVector lv(1.,0.5,0., std::sqrt(1.+0.25 +0.120*0.120));
+  pat::PackedCandidate::LorentzVector lv(1., 0.5, 0., std::sqrt(1. + 0.25 + 0.120 * 0.120));
   pat::PackedCandidate::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
 
-  pat::PackedCandidate::Point v(0.01,0.02,0.);
+  pat::PackedCandidate::Point v(0.01, 0.02, 0.);
 
   //invalid Refs use a special key
   pat::PackedCandidate pc(lv, v, 1., 1., 1., 11, reco::VertexRefProd(), reco::VertexRef().key());
@@ -68,80 +66,71 @@ void testPackedCandidate::testCopyConstructor() {
   CPPUNIT_ASSERT(&copy_pc.polarP4() != &pc.polarP4());
   CPPUNIT_ASSERT(&copy_pc.p4() != &pc.p4());
   CPPUNIT_ASSERT(&copy_pc.vertex() != &pc.vertex());
-
 }
 
 static bool tolerance(double iLHS, double iRHS, double fraction) {
-  return std::abs(iLHS-iRHS) <= fraction*std::abs(iLHS+iRHS)/2.;
+  return std::abs(iLHS - iRHS) <= fraction * std::abs(iLHS + iRHS) / 2.;
 }
 
-
-void 
-testPackedCandidate::testPackUnpack() {
-
-  pat::PackedCandidate::LorentzVector lv(1.,1.,0., std::sqrt(2.+0.120*0.120));
+void testPackedCandidate::testPackUnpack() {
+  pat::PackedCandidate::LorentzVector lv(1., 1., 0., std::sqrt(2. + 0.120 * 0.120));
   pat::PackedCandidate::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
 
-  pat::PackedCandidate::Point v(-0.005,0.005,0.1); 
-  float trkPt=plv.Pt()+0.5;
-  float trkEta=plv.Eta()-0.1;
-  float trkPhi=-3./4.*3.1416;
-
+  pat::PackedCandidate::Point v(-0.005, 0.005, 0.1);
+  float trkPt = plv.Pt() + 0.5;
+  float trkEta = plv.Eta() - 0.1;
+  float trkPhi = -3. / 4. * 3.1416;
 
   //invalid Refs use a special key
-  pat::PackedCandidate pc(lv, v, trkPt,trkEta,trkPhi, 11, reco::VertexRefProd(), reco::VertexRef().key());
+  pat::PackedCandidate pc(lv, v, trkPt, trkEta, trkPhi, 11, reco::VertexRefProd(), reco::VertexRef().key());
 
   pc.pack(true);
   pc.packVtx(true);
 
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.vertex().X(),v.X(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.vertex().Y(),v.Y(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.vertex().Z(),v.Z(), 0.01));  
-//AR : this cannot be called unless track details are set
-//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().pt(),trkPt,0.001));
-//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().eta(),trkEta,0.001));
-//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().phi(),trkPhi,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(), plv.Pt(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(), plv.Eta(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(), plv.Phi(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(), plv.M(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(), lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(), lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(), lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(), lv.E(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().X(), v.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().Y(), v.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().Z(), v.Z(), 0.01));
+  //AR : this cannot be called unless track details are set
+  //  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().pt(),trkPt,0.001));
+  //  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().eta(),trkEta,0.001));
+  //  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().phi(),trkPhi,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.ptTrk(), trkPt, 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(), trkEta, 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(), trkPhi, 0.001));
   //Check again after a setP4
-  pc.setP4(plv*2);
-  CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.001));
-  pc.setP4(lv*3);
-  CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.001));
-  pc.setPz(pc.p4().Pz()+3.3);
-  CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.005));
-  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.005));
-  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.005));
+  pc.setP4(plv * 2);
+  CPPUNIT_ASSERT(tolerance(pc.ptTrk(), trkPt, 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(), trkEta, 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(), trkPhi, 0.001));
+  pc.setP4(lv * 3);
+  CPPUNIT_ASSERT(tolerance(pc.ptTrk(), trkPt, 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(), trkEta, 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(), trkPhi, 0.001));
+  pc.setPz(pc.p4().Pz() + 3.3);
+  CPPUNIT_ASSERT(tolerance(pc.ptTrk(), trkPt, 0.005));
+  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(), trkEta, 0.005));
+  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(), trkPhi, 0.005));
 }
 
 void testPackedCandidate::testSimulateReadFromRoot() {
-
-  
-
-  pat::PackedCandidate::LorentzVector lv(1.,1.,0., std::sqrt(2. +0.120*0.120));
+  pat::PackedCandidate::LorentzVector lv(1., 1., 0., std::sqrt(2. + 0.120 * 0.120));
   pat::PackedCandidate::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
-  pat::PackedCandidate::Point v(-0.005,0.005,0.1);
+  pat::PackedCandidate::Point v(-0.005, 0.005, 0.1);
 
-  float trkPt=plv.Pt()+0.5;
-  float trkEta=plv.Eta()-0.1;
-  float trkPhi=-3./4.*3.1416;
-
+  float trkPt = plv.Pt() + 0.5;
+  float trkEta = plv.Eta() - 0.1;
+  float trkPhi = -3. / 4. * 3.1416;
 
   //invalid Refs use a special key
-  pat::PackedCandidate pc(lv, v, trkPt,trkEta,trkPhi, 11, reco::VertexRefProd(), reco::VertexRef().key());
+  pat::PackedCandidate pc(lv, v, trkPt, trkEta, trkPhi, 11, reco::VertexRefProd(), reco::VertexRef().key());
 
   //  CPPUNIT_ASSERT(pc.polarP4() == plv);
   //  CPPUNIT_ASSERT(pc.p4() == lv);
@@ -155,166 +144,240 @@ void testPackedCandidate::testSimulateReadFromRoot() {
   delete pc.track_.exchange(nullptr);
   delete pc.m_.exchange(nullptr);
 
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.vertex().X(),v.X(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.vertex().Y(),v.Y(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.vertex().Z(),v.Z(), 0.01));
-//AR : this cannot be called unless track details are set
-//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().pt(),trkPt,0.001));
-//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().eta(),trkEta,0.001));
-//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().phi(),trkPhi,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.001));
-  
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(), plv.Pt(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(), plv.Eta(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(), plv.Phi(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(), plv.M(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(), lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(), lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(), lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(), lv.E(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().X(), v.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().Y(), v.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().Z(), v.Z(), 0.01));
+  //AR : this cannot be called unless track details are set
+  //  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().pt(),trkPt,0.001));
+  //  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().eta(),trkEta,0.001));
+  //  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().phi(),trkPhi,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.ptTrk(), trkPt, 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(), trkEta, 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(), trkPhi, 0.001));
 }
-
 
 void testPackedCandidate::testPackUnpackTime() {
-  bool debug = false; // turn this on in order to get a printout of the numerical precision you get for the timing in the various encodings
+  bool debug =
+      false;  // turn this on in order to get a printout of the numerical precision you get for the timing in the various encodings
 
-  if (debug) std::cout << std::endl;
-  if (debug) std::cout << "Minimum time error: " << pat::PackedCandidate::unpackTimeError(1) << std::endl;
-  if (debug) std::cout << "Maximum time error: " << pat::PackedCandidate::unpackTimeError(255) << std::endl;
-  float avgres = 0; int navg = 0;
+  if (debug)
+    std::cout << std::endl;
+  if (debug)
+    std::cout << "Minimum time error: " << pat::PackedCandidate::unpackTimeError(1) << std::endl;
+  if (debug)
+    std::cout << "Maximum time error: " << pat::PackedCandidate::unpackTimeError(255) << std::endl;
+  float avgres = 0;
+  int navg = 0;
   for (int i = 2; i < 255; ++i) {
     float unp = pat::PackedCandidate::unpackTimeError(i);
-    float res = 0.5*(pat::PackedCandidate::unpackTimeError(i+1)-pat::PackedCandidate::unpackTimeError(i-1));
-    avgres += (res/unp); navg++;
-    if (debug) std::cout << " i = " << i << " unp = " << unp << " quant error = " << res << "  packed = " << int(pat::PackedCandidate::packTimeError(unp+0.3*res)) << " and " << int(pat::PackedCandidate::packTimeError(unp-0.3*res)) << std::endl;
-    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeError(unp+0.3*res) == i);
-    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeError(unp-0.3*res) == i);
+    float res = 0.5 * (pat::PackedCandidate::unpackTimeError(i + 1) - pat::PackedCandidate::unpackTimeError(i - 1));
+    avgres += (res / unp);
+    navg++;
+    if (debug)
+      std::cout << " i = " << i << " unp = " << unp << " quant error = " << res
+                << "  packed = " << int(pat::PackedCandidate::packTimeError(unp + 0.3 * res)) << " and "
+                << int(pat::PackedCandidate::packTimeError(unp - 0.3 * res)) << std::endl;
+    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeError(unp + 0.3 * res) == i);
+    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeError(unp - 0.3 * res) == i);
   }
-  if (debug) std::cout << "Average rel uncertainty: " << (avgres/navg) << std::endl;
-  if (debug) std::cout << std::endl;
+  if (debug)
+    std::cout << "Average rel uncertainty: " << (avgres / navg) << std::endl;
+  if (debug)
+    std::cout << std::endl;
 
-  if (debug) std::cout << "Zero time standalone (pos): " << pat::PackedCandidate::unpackTimeNoError(0) << std::endl;
-  if (debug) std::cout << "Minimum time standalone (pos): " << pat::PackedCandidate::unpackTimeNoError(+1) << std::endl;
-  if (debug) std::cout << "Minimum time standalone (neg): " << pat::PackedCandidate::unpackTimeNoError(-1) << std::endl;
-  if (debug) std::cout << "Maximum time standalone, 8 bits (pos): " << pat::PackedCandidate::unpackTimeNoError(+255) << std::endl;
-  if (debug) std::cout << "Maximum time standalone, 8 bits (neg): " << pat::PackedCandidate::unpackTimeNoError(-255) << std::endl;
-  if (debug) std::cout << "Maximum time standalone, 10 bits (pos): " << pat::PackedCandidate::unpackTimeNoError(+1023) << std::endl;
-  if (debug) std::cout << "Maximum time standalone, 10 bits (neg): " << pat::PackedCandidate::unpackTimeNoError(-1023) << std::endl;
-  if (debug) std::cout << "Maximum time standalone, 11 bits (pos): " << pat::PackedCandidate::unpackTimeNoError(+2047) << std::endl;
-  if (debug) std::cout << "Maximum time standalone, 11 bits (neg): " << pat::PackedCandidate::unpackTimeNoError(-2047) << std::endl;
-  avgres = 0; navg = 0;
+  if (debug)
+    std::cout << "Zero time standalone (pos): " << pat::PackedCandidate::unpackTimeNoError(0) << std::endl;
+  if (debug)
+    std::cout << "Minimum time standalone (pos): " << pat::PackedCandidate::unpackTimeNoError(+1) << std::endl;
+  if (debug)
+    std::cout << "Minimum time standalone (neg): " << pat::PackedCandidate::unpackTimeNoError(-1) << std::endl;
+  if (debug)
+    std::cout << "Maximum time standalone, 8 bits (pos): " << pat::PackedCandidate::unpackTimeNoError(+255)
+              << std::endl;
+  if (debug)
+    std::cout << "Maximum time standalone, 8 bits (neg): " << pat::PackedCandidate::unpackTimeNoError(-255)
+              << std::endl;
+  if (debug)
+    std::cout << "Maximum time standalone, 10 bits (pos): " << pat::PackedCandidate::unpackTimeNoError(+1023)
+              << std::endl;
+  if (debug)
+    std::cout << "Maximum time standalone, 10 bits (neg): " << pat::PackedCandidate::unpackTimeNoError(-1023)
+              << std::endl;
+  if (debug)
+    std::cout << "Maximum time standalone, 11 bits (pos): " << pat::PackedCandidate::unpackTimeNoError(+2047)
+              << std::endl;
+  if (debug)
+    std::cout << "Maximum time standalone, 11 bits (neg): " << pat::PackedCandidate::unpackTimeNoError(-2047)
+              << std::endl;
+  avgres = 0;
+  navg = 0;
   for (int i = 2; i < 2040; i *= 1.5) {
     float unp = pat::PackedCandidate::unpackTimeNoError(i);
-    float res = 0.5*(pat::PackedCandidate::unpackTimeNoError(i+1)-pat::PackedCandidate::unpackTimeNoError(i-1));
-    avgres += (res/unp); navg++;
-    if (debug) std::cout << " i = +" << i << " unp = +" << unp << " quant error = " << res << "  packed = " << int(pat::PackedCandidate::packTimeNoError(unp+0.3*res)) << " and +" << int(pat::PackedCandidate::packTimeNoError(unp-0.3*res)) << std::endl;
-    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeNoError(unp+0.3*res) == i);
-    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeNoError(unp-0.3*res) == i);
+    float res = 0.5 * (pat::PackedCandidate::unpackTimeNoError(i + 1) - pat::PackedCandidate::unpackTimeNoError(i - 1));
+    avgres += (res / unp);
+    navg++;
+    if (debug)
+      std::cout << " i = +" << i << " unp = +" << unp << " quant error = " << res
+                << "  packed = " << int(pat::PackedCandidate::packTimeNoError(unp + 0.3 * res)) << " and +"
+                << int(pat::PackedCandidate::packTimeNoError(unp - 0.3 * res)) << std::endl;
+    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeNoError(unp + 0.3 * res) == i);
+    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeNoError(unp - 0.3 * res) == i);
     unp = pat::PackedCandidate::unpackTimeNoError(-i);
-    res = 0.5*(pat::PackedCandidate::unpackTimeNoError(-i+1)-pat::PackedCandidate::unpackTimeNoError(-i-1));
-    avgres += std::abs(res/unp); navg++;
-    if (debug) std::cout << " i = " << -i << " unp = " << unp << " quant error = " << res << "  packed = " << int(pat::PackedCandidate::packTimeNoError(unp+0.3*res)) << " and " << int(pat::PackedCandidate::packTimeNoError(unp-0.3*res)) << std::endl;
-    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeNoError(unp+0.3*res) == -i);
-    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeNoError(unp-0.3*res) == -i);
+    res = 0.5 * (pat::PackedCandidate::unpackTimeNoError(-i + 1) - pat::PackedCandidate::unpackTimeNoError(-i - 1));
+    avgres += std::abs(res / unp);
+    navg++;
+    if (debug)
+      std::cout << " i = " << -i << " unp = " << unp << " quant error = " << res
+                << "  packed = " << int(pat::PackedCandidate::packTimeNoError(unp + 0.3 * res)) << " and "
+                << int(pat::PackedCandidate::packTimeNoError(unp - 0.3 * res)) << std::endl;
+    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeNoError(unp + 0.3 * res) == -i);
+    CPPUNIT_ASSERT(pat::PackedCandidate::packTimeNoError(unp - 0.3 * res) == -i);
   }
-  if (debug) std::cout << "Average rel uncertainty: " << (avgres/navg) << std::endl;
-  if (debug) std::cout << std::endl;
+  if (debug)
+    std::cout << "Average rel uncertainty: " << (avgres / navg) << std::endl;
+  if (debug)
+    std::cout << std::endl;
 
   for (float aTimeErr = 2.0e-3; aTimeErr <= 1000e-3; aTimeErr *= std::sqrt(5.f)) {
-      uint8_t packedTimeErr = pat::PackedCandidate::packTimeError(aTimeErr);
-      float unpackedTimeErr = pat::PackedCandidate::unpackTimeError(packedTimeErr);
-      if (debug) std::cout << "For a timeError of " << aTimeErr << " ns (uint8: " << unsigned(packedTimeErr) << ", unpack " << unpackedTimeErr << ")" << std::endl;
-      if (debug) std::cout << "Minimum time (pos): " << pat::PackedCandidate::unpackTimeWithError(+1, packedTimeErr) << std::endl;
-      if (debug) std::cout << "Minimum time (neg): " << pat::PackedCandidate::unpackTimeWithError(-1, packedTimeErr) << std::endl;
-      if (debug) std::cout << "Maximum time 8 bits (pos): " << pat::PackedCandidate::unpackTimeWithError(+254, packedTimeErr) << std::endl;
-      if (debug) std::cout << "Maximum time 8 bits (neg): " << pat::PackedCandidate::unpackTimeWithError(-254, packedTimeErr) << std::endl;
-      if (debug) std::cout << "Maximum time 10 bits (pos): " << pat::PackedCandidate::unpackTimeWithError(+1022, packedTimeErr) << std::endl;
-      if (debug) std::cout << "Maximum time 10 bits (neg): " << pat::PackedCandidate::unpackTimeWithError(-1022, packedTimeErr) << std::endl;
-      if (debug) std::cout << "Maximum time 12 bits (pos): " << pat::PackedCandidate::unpackTimeWithError(+4094, packedTimeErr) << std::endl;
-      if (debug) std::cout << "Maximum time 12 bits (neg): " << pat::PackedCandidate::unpackTimeWithError(-4094, packedTimeErr) << std::endl;
-      avgres = 0; navg = 0;
-      for (int i = 2; i < 4096; i *= 3) {
-        float unp = pat::PackedCandidate::unpackTimeWithError(i,packedTimeErr);
-        float res = 0.5*(pat::PackedCandidate::unpackTimeWithError(i+2,packedTimeErr)-pat::PackedCandidate::unpackTimeWithError(i-2,packedTimeErr));
-        avgres += (res); navg++;
-        if (debug) std::cout << " i = +" << i << " unp = +" << unp << " quant error = " << res << "  packed = +" << int(pat::PackedCandidate::packTimeWithError(unp+0.2*res, unpackedTimeErr)) << " and +" << int(pat::PackedCandidate::packTimeWithError(unp-0.2*res, unpackedTimeErr)) << std::endl;
-        CPPUNIT_ASSERT(pat::PackedCandidate::packTimeWithError(unp+0.2*res,unpackedTimeErr) == i);
-        CPPUNIT_ASSERT(pat::PackedCandidate::packTimeWithError(unp-0.2*res,unpackedTimeErr) == i);
-        unp = pat::PackedCandidate::unpackTimeWithError(-i,packedTimeErr);
-        res = 0.5*(pat::PackedCandidate::unpackTimeWithError(-i+2,packedTimeErr)-pat::PackedCandidate::unpackTimeWithError(-i-2,packedTimeErr));
-        avgres += std::abs(res); navg++;
-        if (debug) std::cout << " i = " << -i << " unp = " << unp << " quant error = " << res << "  packed = " << int(pat::PackedCandidate::packTimeWithError(unp+0.2*res, unpackedTimeErr)) << " and " << int(pat::PackedCandidate::packTimeWithError(unp-0.2*res, unpackedTimeErr)) << std::endl;
-        CPPUNIT_ASSERT(pat::PackedCandidate::packTimeWithError(unp+0.2*res,unpackedTimeErr) == -i);
-        CPPUNIT_ASSERT(pat::PackedCandidate::packTimeWithError(unp-0.2*res,unpackedTimeErr) == -i);
-      }
-      if (debug) std::cout << "Average abs uncertainty: " << (avgres/navg) << std::endl;
-      if (debug) std::cout << "Now testing overflows: " << std::endl;
-      avgres = 0; navg = 0;
-      for (float aTime = aTimeErr; aTime <= 200; aTime *= std::sqrt(5.f)) {
-        int i = pat::PackedCandidate::packTimeWithError(aTime,unpackedTimeErr);
-        float res = 0.5*std::abs(pat::PackedCandidate::unpackTimeWithError(i+2,packedTimeErr)-pat::PackedCandidate::unpackTimeWithError(i-2,packedTimeErr));
-        float unp = pat::PackedCandidate::unpackTimeWithError(i,packedTimeErr);
-        if (debug) std::cout << " t = +" << aTime << " i = +" << i << "   quant error = " << res << " unpacked = +" << unp << "   diff/res = " << (aTime-unp)/res << std::endl;
-        CPPUNIT_ASSERT(std::abs(unp-aTime) < res);
-        avgres = std::max(avgres,std::abs(res/unp));
-        i = pat::PackedCandidate::packTimeWithError(-aTime,unpackedTimeErr);
-        res = 0.5*std::abs(pat::PackedCandidate::unpackTimeWithError(i+2,packedTimeErr)-pat::PackedCandidate::unpackTimeWithError(i-2,packedTimeErr));
-        unp = pat::PackedCandidate::unpackTimeWithError(i,packedTimeErr);
-        if (debug) std::cout << " t = " << -aTime << " i = " << i << "   quant error = " << res << " unpacked = " << unp << "   diff/res = " << (-aTime-unp)/res << std::endl;
-        CPPUNIT_ASSERT(std::abs(unp+aTime) < res);
-        avgres = std::max(avgres,std::abs(res/unp));
-      }
-      if (debug) std::cout << "Worst rel uncertainty: " << (avgres) << std::endl;
-      if (debug) std::cout << std::endl;
-
-  }  
-  if (debug) std::cout << std::endl;
+    uint8_t packedTimeErr = pat::PackedCandidate::packTimeError(aTimeErr);
+    float unpackedTimeErr = pat::PackedCandidate::unpackTimeError(packedTimeErr);
+    if (debug)
+      std::cout << "For a timeError of " << aTimeErr << " ns (uint8: " << unsigned(packedTimeErr) << ", unpack "
+                << unpackedTimeErr << ")" << std::endl;
+    if (debug)
+      std::cout << "Minimum time (pos): " << pat::PackedCandidate::unpackTimeWithError(+1, packedTimeErr) << std::endl;
+    if (debug)
+      std::cout << "Minimum time (neg): " << pat::PackedCandidate::unpackTimeWithError(-1, packedTimeErr) << std::endl;
+    if (debug)
+      std::cout << "Maximum time 8 bits (pos): " << pat::PackedCandidate::unpackTimeWithError(+254, packedTimeErr)
+                << std::endl;
+    if (debug)
+      std::cout << "Maximum time 8 bits (neg): " << pat::PackedCandidate::unpackTimeWithError(-254, packedTimeErr)
+                << std::endl;
+    if (debug)
+      std::cout << "Maximum time 10 bits (pos): " << pat::PackedCandidate::unpackTimeWithError(+1022, packedTimeErr)
+                << std::endl;
+    if (debug)
+      std::cout << "Maximum time 10 bits (neg): " << pat::PackedCandidate::unpackTimeWithError(-1022, packedTimeErr)
+                << std::endl;
+    if (debug)
+      std::cout << "Maximum time 12 bits (pos): " << pat::PackedCandidate::unpackTimeWithError(+4094, packedTimeErr)
+                << std::endl;
+    if (debug)
+      std::cout << "Maximum time 12 bits (neg): " << pat::PackedCandidate::unpackTimeWithError(-4094, packedTimeErr)
+                << std::endl;
+    avgres = 0;
+    navg = 0;
+    for (int i = 2; i < 4096; i *= 3) {
+      float unp = pat::PackedCandidate::unpackTimeWithError(i, packedTimeErr);
+      float res = 0.5 * (pat::PackedCandidate::unpackTimeWithError(i + 2, packedTimeErr) -
+                         pat::PackedCandidate::unpackTimeWithError(i - 2, packedTimeErr));
+      avgres += (res);
+      navg++;
+      if (debug)
+        std::cout << " i = +" << i << " unp = +" << unp << " quant error = " << res << "  packed = +"
+                  << int(pat::PackedCandidate::packTimeWithError(unp + 0.2 * res, unpackedTimeErr)) << " and +"
+                  << int(pat::PackedCandidate::packTimeWithError(unp - 0.2 * res, unpackedTimeErr)) << std::endl;
+      CPPUNIT_ASSERT(pat::PackedCandidate::packTimeWithError(unp + 0.2 * res, unpackedTimeErr) == i);
+      CPPUNIT_ASSERT(pat::PackedCandidate::packTimeWithError(unp - 0.2 * res, unpackedTimeErr) == i);
+      unp = pat::PackedCandidate::unpackTimeWithError(-i, packedTimeErr);
+      res = 0.5 * (pat::PackedCandidate::unpackTimeWithError(-i + 2, packedTimeErr) -
+                   pat::PackedCandidate::unpackTimeWithError(-i - 2, packedTimeErr));
+      avgres += std::abs(res);
+      navg++;
+      if (debug)
+        std::cout << " i = " << -i << " unp = " << unp << " quant error = " << res
+                  << "  packed = " << int(pat::PackedCandidate::packTimeWithError(unp + 0.2 * res, unpackedTimeErr))
+                  << " and " << int(pat::PackedCandidate::packTimeWithError(unp - 0.2 * res, unpackedTimeErr))
+                  << std::endl;
+      CPPUNIT_ASSERT(pat::PackedCandidate::packTimeWithError(unp + 0.2 * res, unpackedTimeErr) == -i);
+      CPPUNIT_ASSERT(pat::PackedCandidate::packTimeWithError(unp - 0.2 * res, unpackedTimeErr) == -i);
+    }
+    if (debug)
+      std::cout << "Average abs uncertainty: " << (avgres / navg) << std::endl;
+    if (debug)
+      std::cout << "Now testing overflows: " << std::endl;
+    avgres = 0;
+    navg = 0;
+    for (float aTime = aTimeErr; aTime <= 200; aTime *= std::sqrt(5.f)) {
+      int i = pat::PackedCandidate::packTimeWithError(aTime, unpackedTimeErr);
+      float res = 0.5 * std::abs(pat::PackedCandidate::unpackTimeWithError(i + 2, packedTimeErr) -
+                                 pat::PackedCandidate::unpackTimeWithError(i - 2, packedTimeErr));
+      float unp = pat::PackedCandidate::unpackTimeWithError(i, packedTimeErr);
+      if (debug)
+        std::cout << " t = +" << aTime << " i = +" << i << "   quant error = " << res << " unpacked = +" << unp
+                  << "   diff/res = " << (aTime - unp) / res << std::endl;
+      CPPUNIT_ASSERT(std::abs(unp - aTime) < res);
+      avgres = std::max(avgres, std::abs(res / unp));
+      i = pat::PackedCandidate::packTimeWithError(-aTime, unpackedTimeErr);
+      res = 0.5 * std::abs(pat::PackedCandidate::unpackTimeWithError(i + 2, packedTimeErr) -
+                           pat::PackedCandidate::unpackTimeWithError(i - 2, packedTimeErr));
+      unp = pat::PackedCandidate::unpackTimeWithError(i, packedTimeErr);
+      if (debug)
+        std::cout << " t = " << -aTime << " i = " << i << "   quant error = " << res << " unpacked = " << unp
+                  << "   diff/res = " << (-aTime - unp) / res << std::endl;
+      CPPUNIT_ASSERT(std::abs(unp + aTime) < res);
+      avgres = std::max(avgres, std::abs(res / unp));
+    }
+    if (debug)
+      std::cout << "Worst rel uncertainty: " << (avgres) << std::endl;
+    if (debug)
+      std::cout << std::endl;
+  }
+  if (debug)
+    std::cout << std::endl;
 }
 
-
 void testPackedCandidate::testQualityFlags() {
-
-  const std::vector<pat::PackedCandidate::PVAssociationQuality> pvAssocVals = { 
-    pat::PackedCandidate::NotReconstructedPrimary,pat::PackedCandidate::OtherDeltaZ,pat::PackedCandidate::CompatibilityBTag,pat::PackedCandidate::CompatibilityDz,pat::PackedCandidate::UsedInFitLoose,pat::PackedCandidate::UsedInFitTight
-  };
+  const std::vector<pat::PackedCandidate::PVAssociationQuality> pvAssocVals = {
+      pat::PackedCandidate::NotReconstructedPrimary,
+      pat::PackedCandidate::OtherDeltaZ,
+      pat::PackedCandidate::CompatibilityBTag,
+      pat::PackedCandidate::CompatibilityDz,
+      pat::PackedCandidate::UsedInFitLoose,
+      pat::PackedCandidate::UsedInFitTight};
   const std::vector<pat::PackedCandidate::LostInnerHits> lostHitsVals = {
-    pat::PackedCandidate::validHitInFirstPixelBarrelLayer,pat::PackedCandidate::noLostInnerHits,pat::PackedCandidate::oneLostInnerHit,pat::PackedCandidate::moreLostInnerHits
-  };
-  const std::vector<bool> trackQualVals = {false,true};
-  const std::vector<bool> glbMuonVals={false,true};
-  const std::vector<bool> staMuonVals={false,true};
-  const std::vector<bool> goodEGVals={false,true};
-  
+      pat::PackedCandidate::validHitInFirstPixelBarrelLayer,
+      pat::PackedCandidate::noLostInnerHits,
+      pat::PackedCandidate::oneLostInnerHit,
+      pat::PackedCandidate::moreLostInnerHits};
+  const std::vector<bool> trackQualVals = {false, true};
+  const std::vector<bool> glbMuonVals = {false, true};
+  const std::vector<bool> staMuonVals = {false, true};
+  const std::vector<bool> goodEGVals = {false, true};
+
   pat::PackedCandidate cand;
 
-  for(auto pvAssoc : pvAssocVals){
-    for(auto lostHits : lostHitsVals){
-      for(auto trackQual : trackQualVals){
-	for(auto glbMuon : glbMuonVals){
-	  for(auto staMuon : staMuonVals){
-	    for(auto goodEGamma : goodEGVals){
-	      cand.setMuonID(staMuon,glbMuon);
-	      cand.setGoodEgamma(goodEGamma);
-	      cand.setAssociationQuality(pvAssoc);
-	      cand.setLostInnerHits(lostHits);
-	      cand.setTrackHighPurity(trackQual);
-	      
-	      CPPUNIT_ASSERT(lostHits==cand.lostInnerHits());
-	      CPPUNIT_ASSERT(goodEGamma==cand.isGoodEgamma());
-	      CPPUNIT_ASSERT(staMuon==cand.isStandAloneMuon());
-	      CPPUNIT_ASSERT(glbMuon==cand.isGlobalMuon());
-	      CPPUNIT_ASSERT(trackQual==cand.trackHighPurity());
-	      CPPUNIT_ASSERT(pvAssoc==cand.pvAssociationQuality());
+  for (auto pvAssoc : pvAssocVals) {
+    for (auto lostHits : lostHitsVals) {
+      for (auto trackQual : trackQualVals) {
+        for (auto glbMuon : glbMuonVals) {
+          for (auto staMuon : staMuonVals) {
+            for (auto goodEGamma : goodEGVals) {
+              cand.setMuonID(staMuon, glbMuon);
+              cand.setGoodEgamma(goodEGamma);
+              cand.setAssociationQuality(pvAssoc);
+              cand.setLostInnerHits(lostHits);
+              cand.setTrackHighPurity(trackQual);
 
-	    }
-	  }
-	}
+              CPPUNIT_ASSERT(lostHits == cand.lostInnerHits());
+              CPPUNIT_ASSERT(goodEGamma == cand.isGoodEgamma());
+              CPPUNIT_ASSERT(staMuon == cand.isStandAloneMuon());
+              CPPUNIT_ASSERT(glbMuon == cand.isGlobalMuon());
+              CPPUNIT_ASSERT(trackQual == cand.trackHighPurity());
+              CPPUNIT_ASSERT(pvAssoc == cand.pvAssociationQuality());
+            }
+          }
+        }
       }
     }
   }
 }
-	      
-	      
-	    

--- a/DataFormats/PatCandidates/test/testPackedGenParticle.cc
+++ b/DataFormats/PatCandidates/test/testPackedGenParticle.cc
@@ -15,30 +15,27 @@ class testPackedGenParticle : public CppUnit::TestFixture {
   CPPUNIT_TEST(testSimulateReadFromRoot);
 
   CPPUNIT_TEST_SUITE_END();
+
 public:
   void setUp() {}
   void tearDown() {}
 
-  void testDefaultConstructor() ;
+  void testDefaultConstructor();
   void testCopyConstructor();
   void testPackUnpack();
   void testSimulateReadFromRoot();
-
 
 private:
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testPackedGenParticle);
 
-
-
 void testPackedGenParticle::testDefaultConstructor() {
-
   pat::PackedGenParticle pc;
 
-  CPPUNIT_ASSERT(pc.polarP4() == pat::PackedGenParticle::PolarLorentzVector(0,0,0,0));
-  CPPUNIT_ASSERT(pc.p4() == pat::PackedGenParticle::LorentzVector(0,0,0,0) );
-  CPPUNIT_ASSERT(pc.vertex() == pat::PackedGenParticle::Point(0,0,0));
+  CPPUNIT_ASSERT(pc.polarP4() == pat::PackedGenParticle::PolarLorentzVector(0, 0, 0, 0));
+  CPPUNIT_ASSERT(pc.p4() == pat::PackedGenParticle::LorentzVector(0, 0, 0, 0));
+  CPPUNIT_ASSERT(pc.vertex() == pat::PackedGenParticle::Point(0, 0, 0));
   CPPUNIT_ASSERT(pc.packedPt_ == 0);
   CPPUNIT_ASSERT(pc.packedY_ == 0);
   CPPUNIT_ASSERT(pc.packedPhi_ == 0);
@@ -46,25 +43,25 @@ void testPackedGenParticle::testDefaultConstructor() {
 }
 
 static bool tolerance(double iLHS, double iRHS, double fraction) {
-  return std::abs(iLHS-iRHS) <= fraction*std::abs(iLHS+iRHS)/2.;
+  return std::abs(iLHS - iRHS) <= fraction * std::abs(iLHS + iRHS) / 2.;
 }
 
 void testPackedGenParticle::testCopyConstructor() {
-  pat::PackedGenParticle::LorentzVector lv(1.,0.5,0., std::sqrt(1.+0.25 +0.120*0.120));
+  pat::PackedGenParticle::LorentzVector lv(1., 0.5, 0., std::sqrt(1. + 0.25 + 0.120 * 0.120));
   pat::PackedGenParticle::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
 
-  pat::PackedGenParticle::Point v(0.01,0.02,0.);
+  pat::PackedGenParticle::Point v(0.01, 0.02, 0.);
 
-  pat::PackedGenParticle pc(reco::GenParticle(-1.,lv,v,11,0,false), edm::Ref<reco::GenParticleCollection>() );
+  pat::PackedGenParticle pc(reco::GenParticle(-1., lv, v, 11, 0, false), edm::Ref<reco::GenParticleCollection>());
 
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(), plv.Pt(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(), plv.Eta(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(), plv.Phi(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(), plv.M(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(), lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(), lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(), lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(), lv.E(), 0.001));
   //CPPUNIT_ASSERT(pc.vertex() == v);
 
   pat::PackedGenParticle copy_pc(pc);
@@ -84,70 +81,64 @@ void testPackedGenParticle::testCopyConstructor() {
   CPPUNIT_ASSERT(&copy_pc.packedY_ != &pc.packedY_);
   CPPUNIT_ASSERT(&copy_pc.packedPhi_ != &pc.packedPhi_);
   CPPUNIT_ASSERT(&copy_pc.packedM_ != &pc.packedM_);
-
 }
 
-void 
-testPackedGenParticle::testPackUnpack() {
-
-  pat::PackedGenParticle::LorentzVector lv(1.,1.,0., std::sqrt(2.+0.120*0.120));
+void testPackedGenParticle::testPackUnpack() {
+  pat::PackedGenParticle::LorentzVector lv(1., 1., 0., std::sqrt(2. + 0.120 * 0.120));
   pat::PackedGenParticle::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
 
-  pat::PackedGenParticle::Point v(-0.005,0.005,0.1);
+  pat::PackedGenParticle::Point v(-0.005, 0.005, 0.1);
 
-  pat::PackedGenParticle pc(reco::GenParticle(-1.,lv,v,11,0,false), edm::Ref<reco::GenParticleCollection>() );
+  pat::PackedGenParticle pc(reco::GenParticle(-1., lv, v, 11, 0, false), edm::Ref<reco::GenParticleCollection>());
 
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(), plv.Pt(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(), plv.Eta(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(), plv.Phi(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(), plv.M(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(), lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(), lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(), lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(), lv.E(), 0.001));
 
   pc.pack();
 
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(), plv.Pt(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(), plv.Eta(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(), plv.Phi(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(), plv.M(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(), lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(), lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(), lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(), lv.E(), 0.001));
 }
 
 void testPackedGenParticle::testSimulateReadFromRoot() {
-
-  pat::PackedGenParticle::LorentzVector lv(1.,1.,0., std::sqrt(2. +0.120*0.120));
+  pat::PackedGenParticle::LorentzVector lv(1., 1., 0., std::sqrt(2. + 0.120 * 0.120));
   pat::PackedGenParticle::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
 
-  pat::PackedGenParticle::Point v(-0.005,0.005,0.1);
+  pat::PackedGenParticle::Point v(-0.005, 0.005, 0.1);
 
-  pat::PackedGenParticle pc(reco::GenParticle(-1.,lv,v,11,0,false),edm::Ref<reco::GenParticleCollection>() );
+  pat::PackedGenParticle pc(reco::GenParticle(-1., lv, v, 11, 0, false), edm::Ref<reco::GenParticleCollection>());
 
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(), plv.Pt(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(), plv.Eta(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(), plv.Phi(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(), plv.M(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(), lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(), lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(), lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(), lv.E(), 0.001));
 
   //When reading back from ROOT, these were not stored and are nulled out
   delete pc.p4_.exchange(nullptr);
   delete pc.p4c_.exchange(nullptr);
 
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(),plv.Phi(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(),plv.M(),0.001) );
-  CPPUNIT_ASSERT(tolerance(pc.p4().X(),lv.X(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Y(),lv.Y(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().Z(),lv.Z(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
-  
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(), plv.Pt(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(), plv.Eta(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().Phi(), plv.Phi(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.polarP4().M(), plv.M(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().X(), lv.X(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Y(), lv.Y(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().Z(), lv.Z(), 0.001));
+  CPPUNIT_ASSERT(tolerance(pc.p4().E(), lv.E(), 0.001));
 }
-


### PR DESCRIPTION

Applying code-format for CMSSW category analysis,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/434//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


