### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/RecoJets/JetProducers/interface/AnomalousTower.h
+++ b/RecoJets/JetProducers/interface/AnomalousTower.h
@@ -4,24 +4,23 @@
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 
-class AnomalousTower
-{
+class AnomalousTower {
 public:
-    explicit AnomalousTower(const edm::ParameterSet&);
-    virtual ~AnomalousTower() {}
+  explicit AnomalousTower(const edm::ParameterSet&);
+  virtual ~AnomalousTower() {}
 
-    // operator() returns "true" if the tower is anomalous
-    virtual bool operator()(const reco::Candidate& input) const;
+  // operator() returns "true" if the tower is anomalous
+  virtual bool operator()(const reco::Candidate& input) const;
 
 private:
-    AnomalousTower() = delete;
+  AnomalousTower() = delete;
 
-    const unsigned maxBadEcalCells;          // maximum number of bad ECAL cells
-    const unsigned maxRecoveredEcalCells;    // maximum number of recovered ECAL cells
-    const unsigned maxProblematicEcalCells;  // maximum number of problematic ECAL cells
-    const unsigned maxBadHcalCells;          // maximum number of bad HCAL cells
-    const unsigned maxRecoveredHcalCells;    // maximum number of recovered HCAL cells
-    const unsigned maxProblematicHcalCells;  // maximum number of problematic HCAL cells
+  const unsigned maxBadEcalCells;          // maximum number of bad ECAL cells
+  const unsigned maxRecoveredEcalCells;    // maximum number of recovered ECAL cells
+  const unsigned maxProblematicEcalCells;  // maximum number of problematic ECAL cells
+  const unsigned maxBadHcalCells;          // maximum number of bad HCAL cells
+  const unsigned maxRecoveredHcalCells;    // maximum number of recovered HCAL cells
+  const unsigned maxProblematicHcalCells;  // maximum number of problematic HCAL cells
 };
 
-#endif // RecoJets_JetProducers_AnomalousTower_h
+#endif  // RecoJets_JetProducers_AnomalousTower_h

--- a/RecoJets/JetProducers/interface/BackgroundEstimator.h
+++ b/RecoJets/JetProducers/interface/BackgroundEstimator.h
@@ -5,169 +5,166 @@
 #include <fastjet/RangeDefinition.hh>
 #include <iostream>
 
-namespace fastjet{
+namespace fastjet {
 
+  /// \class BackgroundEstimator
+  /// Class to estimate the density of the background per unit area
+  ///
+  /// The default behaviour of this class is to compute the global
+  /// properties of the background as it is done in ClusterSequenceArea.
+  /// On top of that, we provide methods to specify an explicit set of
+  /// jets to use or a list of jets to exclude.
+  /// We also provide all sorts of additional information regarding
+  /// the background estimation like the jets that have been used or
+  /// the number of pure-ghost jets.
+  ///
+  /// Default behaviour:
+  ///   by default the list of included jets is the inclusive jets from
+  ///   the given ClusterSequence; the list of explicitly excluded jets
+  ///   is empty; we use 4-vector area
+  ///
+  /// Beware:
+  ///   by default, to correctly handle partially empty events, the
+  ///   class attempts to calculate an "empty area", based
+  ///   (schematically) on
+  ///
+  ///          range.total_area() - sum_{jets_in_range} jets.area()
+  ///
+  ///   For ranges with small areas, this can be innacurate (particularly
+  ///   relevant in dense events where empty_area should be zero and ends
+  ///   up not being zero).
+  ///
+  ///   This calculation of empty area can be avoided if you supply a
+  ///   ClusterSequenceArea class with explicit ghosts
+  ///   (ActiveAreaExplicitGhosts). This is _recommended_!
+  ///
+  class BackgroundEstimator {
+  public:
+    /// default ctor
+    /// \param csa      the ClusterSequenceArea to use
+    /// \param range    the range over which jets will be considered
+    BackgroundEstimator(const ClusterSequenceAreaBase &csa, const RangeDefinition &range);
 
-/// \class BackgroundEstimator
-/// Class to estimate the density of the background per unit area
-///
-/// The default behaviour of this class is to compute the global 
-/// properties of the background as it is done in ClusterSequenceArea.
-/// On top of that, we provide methods to specify an explicit set of
-/// jets to use or a list of jets to exclude.
-/// We also provide all sorts of additional information regarding
-/// the background estimation like the jets that have been used or
-/// the number of pure-ghost jets.
-///
-/// Default behaviour:
-///   by default the list of included jets is the inclusive jets from
-///   the given ClusterSequence; the list of explicitly excluded jets 
-///   is empty; we use 4-vector area
-///
-/// Beware: 
-///   by default, to correctly handle partially empty events, the
-///   class attempts to calculate an "empty area", based
-///   (schematically) on
-///
-///          range.total_area() - sum_{jets_in_range} jets.area()
-///  
-///   For ranges with small areas, this can be innacurate (particularly 
-///   relevant in dense events where empty_area should be zero and ends
-///   up not being zero).
-///
-///   This calculation of empty area can be avoided if you supply a
-///   ClusterSequenceArea class with explicit ghosts
-///   (ActiveAreaExplicitGhosts). This is _recommended_!
-///
- class BackgroundEstimator{
-public:
-  /// default ctor
-  /// \param csa      the ClusterSequenceArea to use
-  /// \param range    the range over which jets will be considered
-  BackgroundEstimator(const ClusterSequenceAreaBase &csa, const RangeDefinition &range);
-  
-  /// default dtor
-  ~BackgroundEstimator();
+    /// default dtor
+    ~BackgroundEstimator();
 
-  // retrieving information
-  //-----------------------  
+    // retrieving information
+    //-----------------------
 
-  /// get the median rho
-  double median_rho(){ 
-    _recompute_if_needed();
-    return _median_rho;
-  }
+    /// get the median rho
+    double median_rho() {
+      _recompute_if_needed();
+      return _median_rho;
+    }
 
-  /// synonym for median rho [[do we have this? Both?]]
-  double rho() {return median_rho();}
+    /// synonym for median rho [[do we have this? Both?]]
+    double rho() { return median_rho(); }
 
-  /// get the sigma
-  double sigma() {
-    _recompute_if_needed();
-    return _sigma;
-  }
-  
-  /// get the median area of the jets used to actually compute the background properties
-  double mean_area(){
-    _recompute_if_needed();
-    return _mean_area;
-  }
-  
-  /// get the number of jets used to actually compute the background properties
-  unsigned int n_jets_used(){
-    _recompute_if_needed();
-    return _n_jets_used;
-  }
-  
-  /// get the number of jets (within the given range) that have been
-  /// explicitly excluded when computing the background properties
-  unsigned int n_jets_excluded(){
-    _recompute_if_needed();
-    return _n_jets_excluded;
-  }
-  
-  /// get the number of empty jets used when computing the background properties;
-  /// (it is deduced from the empty area with an assumption about the average
-  /// area of jets)
-  double n_empty_jets(){
-    _recompute_if_needed();
-    return _n_empty_jets;
-  }
+    /// get the sigma
+    double sigma() {
+      _recompute_if_needed();
+      return _sigma;
+    }
 
-  /// returns the estimate of the area (within Range) that is not occupied
-  /// by the jets (excluded jets are removed from this count)
-  double empty_area(){
-    _recompute_if_needed();
-    return _empty_area;
-  }
+    /// get the median area of the jets used to actually compute the background properties
+    double mean_area() {
+      _recompute_if_needed();
+      return _mean_area;
+    }
 
-  // configuring behaviour
-  //----------------------  
+    /// get the number of jets used to actually compute the background properties
+    unsigned int n_jets_used() {
+      _recompute_if_needed();
+      return _n_jets_used;
+    }
 
-  /// reset to default values
-  /// set the list of included jets to the inclusive jets and clear the excluded ones
-  void reset();
+    /// get the number of jets (within the given range) that have been
+    /// explicitly excluded when computing the background properties
+    unsigned int n_jets_excluded() {
+      _recompute_if_needed();
+      return _n_jets_excluded;
+    }
 
-  /// specify if one uses the scalar or 4-vector area
-  ///  \param use_it             whether one uses the 4-vector area or not (true by default)
-  void set_use_area_4vector(bool use_it = true){
-    _use_area_4vector = use_it;
-  }
-  
-  /// set the list of included jets
-  ///  \param included_jets      the list of jets to include
-  ///  \param all_from_included  when true, we'll assume that the cluster sequence inclusive jets 
-  ///                            give all the potential jets in the range. In practice this means 
-  ///                            that the empty area will be computed from the inclusive jets rather
-  ///                            than from the 'included_jets'. You can overwrite the default value 
-  ///                            and send it to 'false' e.g. when the included_jets you provide are
-  ///                            themselves a list of inclusive jets.
-  void set_included_jets(const std::vector<PseudoJet> &included_jets, bool all_from_inclusive = true){
-    _included_jets = included_jets;
-    _all_from_inclusive = all_from_inclusive;
-    _uptodate = false;
-  }
-  
-  /// set the list of explicitly excluded jets
-  ///  \param excluded_jets      the list of jets that have to be explicitly excluded
-  void set_excluded_jets(const std::vector<PseudoJet> &excluded_jets){
-    _excluded_jets = excluded_jets;
-    _uptodate = false;  
-  }
-  
-private:
-  /// do the actual job
-  void _compute();
-  
-  /// check if the properties need to be recomputed 
-  /// and do so if needed
-  void _recompute_if_needed(){
-    if (!_uptodate)
-      _compute();
-    _uptodate = true;
-  }
-  
-  // the information needed to do the computation
-  const ClusterSequenceAreaBase &_csa;      ///< cluster sequence to get jets and areas from
-  const RangeDefinition &_range;            ///< range to compute the background in
-  std::vector<PseudoJet> _included_jets;    ///< jets to be used
-  std::vector<PseudoJet> _excluded_jets;    ///< jets to be excluded
-  bool _all_from_inclusive;                 ///< when true, we'll assume that the incl jets are the complete set
-  bool _use_area_4vector;
-  
-  // the actual results of the computation
-  double _median_rho;		            ///< background estimated density per unit area
-  double _sigma;		            ///< background estimated fluctuations
-  double _mean_area;		            ///< mean area of the jets used to estimate the background
-  unsigned int _n_jets_used;                ///< number of jets used to estimate the background
-  unsigned int _n_jets_excluded;            ///< number of jets that have explicitly been excluded
-  double _n_empty_jets;                     ///< number of empty (pure-ghost) jets
-  double _empty_area;                       ///< the empty (pure-ghost/unclustered) area!
+    /// get the number of empty jets used when computing the background properties;
+    /// (it is deduced from the empty area with an assumption about the average
+    /// area of jets)
+    double n_empty_jets() {
+      _recompute_if_needed();
+      return _n_empty_jets;
+    }
 
-  // internal variables
-  bool _uptodate;                           ///< true when the background computation is up-to-date
-};
+    /// returns the estimate of the area (within Range) that is not occupied
+    /// by the jets (excluded jets are removed from this count)
+    double empty_area() {
+      _recompute_if_needed();
+      return _empty_area;
+    }
 
-} // namespace
+    // configuring behaviour
+    //----------------------
+
+    /// reset to default values
+    /// set the list of included jets to the inclusive jets and clear the excluded ones
+    void reset();
+
+    /// specify if one uses the scalar or 4-vector area
+    ///  \param use_it             whether one uses the 4-vector area or not (true by default)
+    void set_use_area_4vector(bool use_it = true) { _use_area_4vector = use_it; }
+
+    /// set the list of included jets
+    ///  \param included_jets      the list of jets to include
+    ///  \param all_from_included  when true, we'll assume that the cluster sequence inclusive jets
+    ///                            give all the potential jets in the range. In practice this means
+    ///                            that the empty area will be computed from the inclusive jets rather
+    ///                            than from the 'included_jets'. You can overwrite the default value
+    ///                            and send it to 'false' e.g. when the included_jets you provide are
+    ///                            themselves a list of inclusive jets.
+    void set_included_jets(const std::vector<PseudoJet> &included_jets, bool all_from_inclusive = true) {
+      _included_jets = included_jets;
+      _all_from_inclusive = all_from_inclusive;
+      _uptodate = false;
+    }
+
+    /// set the list of explicitly excluded jets
+    ///  \param excluded_jets      the list of jets that have to be explicitly excluded
+    void set_excluded_jets(const std::vector<PseudoJet> &excluded_jets) {
+      _excluded_jets = excluded_jets;
+      _uptodate = false;
+    }
+
+  private:
+    /// do the actual job
+    void _compute();
+
+    /// check if the properties need to be recomputed
+    /// and do so if needed
+    void _recompute_if_needed() {
+      if (!_uptodate)
+        _compute();
+      _uptodate = true;
+    }
+
+    // the information needed to do the computation
+    const ClusterSequenceAreaBase &_csa;    ///< cluster sequence to get jets and areas from
+    const RangeDefinition &_range;          ///< range to compute the background in
+    std::vector<PseudoJet> _included_jets;  ///< jets to be used
+    std::vector<PseudoJet> _excluded_jets;  ///< jets to be excluded
+    bool _all_from_inclusive;               ///< when true, we'll assume that the incl jets are the complete set
+    bool _use_area_4vector;
+
+    // the actual results of the computation
+    double _median_rho;             ///< background estimated density per unit area
+    double _sigma;                  ///< background estimated fluctuations
+    double _mean_area;              ///< mean area of the jets used to estimate the background
+    unsigned int _n_jets_used;      ///< number of jets used to estimate the background
+    unsigned int _n_jets_excluded;  ///< number of jets that have explicitly been excluded
+    double _n_empty_jets;           ///< number of empty (pure-ghost) jets
+    double _empty_area;             ///< the empty (pure-ghost/unclustered) area!
+
+    // internal variables
+    bool _uptodate;  ///< true when the background computation is up-to-date
+  };
+
+}  // namespace fastjet
 
 #endif

--- a/RecoJets/JetProducers/interface/CastorJetIDHelper.h
+++ b/RecoJets/JetProducers/interface/CastorJetIDHelper.h
@@ -1,7 +1,6 @@
 #ifndef RecoJets_JetProducers_interface_CastorJetIDHelper_h
 #define RecoJets_JetProducers_interface_CastorJetIDHelper_h
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/JetReco/interface/BasicJet.h"
@@ -11,46 +10,40 @@ namespace reco {
   namespace helper {
 
     class CastorJetIDHelper {
-
-    public : 
+    public:
       // construction
       CastorJetIDHelper();
-      ~CastorJetIDHelper() {} 
+      ~CastorJetIDHelper() {}
 
-
-      void initValues ();
+      void initValues();
 
       // interface
-      void calculate( const edm::Event& event, const reco::BasicJet &jet );
+      void calculate(const edm::Event& event, const reco::BasicJet& jet);
 
       // member access
-     
-      double emEnergy()          const    { return    emEnergy_;}           
-      double hadEnergy()          const    { return    hadEnergy_;}           
-      double    fem()       const    { return    fem_;}
-      double width() const    { return    width_;}  
-      double depth() const    { return    depth_;}  
-      double fhot() const    { return    fhot_;}  
-      double sigmaz() const    { return    sigmaz_;}  
-      int nTowers()           const    { return    nTowers_;}
-      
-  
-    private:
 
-     
+      double emEnergy() const { return emEnergy_; }
+      double hadEnergy() const { return hadEnergy_; }
+      double fem() const { return fem_; }
+      double width() const { return width_; }
+      double depth() const { return depth_; }
+      double fhot() const { return fhot_; }
+      double sigmaz() const { return sigmaz_; }
+      int nTowers() const { return nTowers_; }
+
+    private:
       // helper functions
-      double phiangle (double testphi);
+      double phiangle(double testphi);
 
       double emEnergy_;
-      double hadEnergy_; 
+      double hadEnergy_;
       double fem_;
       double width_;
       double depth_;
       double fhot_;
       double sigmaz_;
       int nTowers_;
-
     };
-  }
-}
+  }  // namespace helper
+}  // namespace reco
 #endif

--- a/RecoJets/JetProducers/interface/ECFAdder.h
+++ b/RecoJets/JetProducers/interface/ECFAdder.h
@@ -12,28 +12,27 @@
 #include "fastjet/contrib/EnergyCorrelator.hh"
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 
+class ECFAdder : public edm::stream::EDProducer<> {
+public:
+  explicit ECFAdder(const edm::ParameterSet& iConfig);
 
-class ECFAdder : public edm::stream::EDProducer<> { 
- public:
-    explicit ECFAdder(const edm::ParameterSet& iConfig);
-    
-    void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
-    float getECF(unsigned index, const edm::Ptr<reco::Jet> & object) const;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  float getECF(unsigned index, const edm::Ptr<reco::Jet>& object) const;
 
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    
- private:	
-    edm::InputTag                          src_;
-    edm::EDGetTokenT<edm::View<reco::Jet>> src_token_;
-    std::vector<unsigned>                  Njets_;
-    std::vector<std::string>               cuts_;
-    std::string                            ecftype_;     // Options: ECF (or empty); C; D; N; M; U;
-    std::vector<std::string>               variables_;
-    double                                 alpha_; 
-    double                                 beta_ ;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    std::vector< std::shared_ptr<fastjet::FunctionOfPseudoJet<double> > > routine_;    
-    std::vector< StringCutObjectSelector<reco::Jet> >   selectors_;
+private:
+  edm::InputTag src_;
+  edm::EDGetTokenT<edm::View<reco::Jet>> src_token_;
+  std::vector<unsigned> Njets_;
+  std::vector<std::string> cuts_;
+  std::string ecftype_;  // Options: ECF (or empty); C; D; N; M; U;
+  std::vector<std::string> variables_;
+  double alpha_;
+  double beta_;
+
+  std::vector<std::shared_ptr<fastjet::FunctionOfPseudoJet<double>>> routine_;
+  std::vector<StringCutObjectSelector<reco::Jet>> selectors_;
 };
 
 #endif

--- a/RecoJets/JetProducers/interface/JetIDHelper.h
+++ b/RecoJets/JetProducers/interface/JetIDHelper.h
@@ -21,112 +21,118 @@ namespace reco {
   namespace helper {
 
     class JetIDHelper {
-
-    public : 
+    public:
       // construction
       JetIDHelper() {}
-      JetIDHelper( edm::ParameterSet const & pset, edm::ConsumesCollector&& iC );
-      ~JetIDHelper() {} 
+      JetIDHelper(edm::ParameterSet const &pset, edm::ConsumesCollector &&iC);
+      ~JetIDHelper() {}
 
-      void fillDescription(edm::ParameterSetDescription& iDesc);
+      void fillDescription(edm::ParameterSetDescription &iDesc);
 
-      void initValues ();
+      void initValues();
 
       // interface
-      void calculate( const edm::Event& event, const edm::EventSetup& setup, const reco::CaloJet &jet, const int iDbg = 0 );
+      void calculate(const edm::Event &event,
+                     const edm::EventSetup &setup,
+                     const reco::CaloJet &jet,
+                     const int iDbg = 0);
 
       // member access
-      
+
       // these require RecHits, so can not be evaluated from AOD
-      double fHPD()          const    { return    fHPD_;}           
-      double fRBX()          const    { return    fRBX_;}           
-      int    n90Hits()       const    { return    n90Hits_;}
-      double fSubDetector1() const    { return    fSubDetector1_;}  
-      double fSubDetector2() const    { return    fSubDetector2_;}  
-      double fSubDetector3() const    { return    fSubDetector3_;}  
-      double fSubDetector4() const    { return    fSubDetector4_;}  
-      double fEB()           const    { return    fEB_;}
-      double fEE()           const    { return    fEE_;}
-      double fHB()           const    { return    fHB_;}
-      double fHE()           const    { return    fHE_;}
-      double fHO()           const    { return    fHO_;}
-      double fLong()         const    { return    fLong_;}
-      double fShort()        const    { return    fShort_;}
-      double fLSbad()        const    { return    fLS_;}  
-      double fHFOOT()        const    { return    fHFOOT_;}  
+      double fHPD() const { return fHPD_; }
+      double fRBX() const { return fRBX_; }
+      int n90Hits() const { return n90Hits_; }
+      double fSubDetector1() const { return fSubDetector1_; }
+      double fSubDetector2() const { return fSubDetector2_; }
+      double fSubDetector3() const { return fSubDetector3_; }
+      double fSubDetector4() const { return fSubDetector4_; }
+      double fEB() const { return fEB_; }
+      double fEE() const { return fEE_; }
+      double fHB() const { return fHB_; }
+      double fHE() const { return fHE_; }
+      double fHO() const { return fHO_; }
+      double fLong() const { return fLong_; }
+      double fShort() const { return fShort_; }
+      double fLSbad() const { return fLS_; }
+      double fHFOOT() const { return fHFOOT_; }
       // these are tower based
-      double restrictedEMF() const    { return    restrictedEMF_;}
-      int    nHCALTowers()   const    { return    nHCALTowers_;}    
-      int    nECALTowers()   const    { return    nECALTowers_;}    
+      double restrictedEMF() const { return restrictedEMF_; }
+      int nHCALTowers() const { return nHCALTowers_; }
+      int nECALTowers() const { return nECALTowers_; }
       // tower based approximations / inferior options
-      double approximatefHPD() const { return    approximatefHPD_;}           
-      double approximatefRBX() const { return    approximatefRBX_;}           
-      int    hitsInN90()        const { return    hitsInN90_;}        
- 
-      struct subtower { // contents of a sub-detector's tower
-	double E;
-	int Nhit;
-	
-	subtower( double xE, int xN ) { E = xE; Nhit = xN; }
+      double approximatefHPD() const { return approximatefHPD_; }
+      double approximatefRBX() const { return approximatefRBX_; }
+      int hitsInN90() const { return hitsInN90_; }
+
+      struct subtower {  // contents of a sub-detector's tower
+        double E;
+        int Nhit;
+
+        subtower(double xE, int xN) {
+          E = xE;
+          Nhit = xN;
+        }
       };
-      
-  
+
     private:
-
-     
       // helper functions
-      void classifyJetComponents( const edm::Event& event, const edm::EventSetup& setup,
-				  const reco::CaloJet &jet, 
-				  std::vector< double > &energies,
-				  std::vector< double > &subdet_energies,
-				  std::vector< double > &Ecal_energies, std::vector< double > &Hcal_energies, 
-				  std::vector< double > &HO_energies,
-				  std::vector< double > &HPD_energies,  std::vector< double > &RBX_energies,
-				  double& LS_bad_energy, double& HF_OOT_energy, const int iDbg = 0);
+      void classifyJetComponents(const edm::Event &event,
+                                 const edm::EventSetup &setup,
+                                 const reco::CaloJet &jet,
+                                 std::vector<double> &energies,
+                                 std::vector<double> &subdet_energies,
+                                 std::vector<double> &Ecal_energies,
+                                 std::vector<double> &Hcal_energies,
+                                 std::vector<double> &HO_energies,
+                                 std::vector<double> &HPD_energies,
+                                 std::vector<double> &RBX_energies,
+                                 double &LS_bad_energy,
+                                 double &HF_OOT_energy,
+                                 const int iDbg = 0);
 
-      void classifyJetTowers( const edm::Event& event, const reco::CaloJet &jet, 
-			      std::vector< subtower > &subtowers,      
-			      std::vector< subtower > &Ecal_subtowers, 
-			      std::vector< subtower > &Hcal_subtowers, 
-			      std::vector< subtower > &HO_subtowers,
-			      std::vector< double > &HPD_energies,  
-			      std::vector< double > &RBX_energies,
-			      const int iDbg = 0);
+      void classifyJetTowers(const edm::Event &event,
+                             const reco::CaloJet &jet,
+                             std::vector<subtower> &subtowers,
+                             std::vector<subtower> &Ecal_subtowers,
+                             std::vector<subtower> &Hcal_subtowers,
+                             std::vector<subtower> &HO_subtowers,
+                             std::vector<double> &HPD_energies,
+                             std::vector<double> &RBX_energies,
+                             const int iDbg = 0);
 
-      unsigned int nCarrying( double fraction, const std::vector< double >& descending_energies );
-      unsigned int hitsInNCarrying( double fraction, const std::vector< subtower >& descending_towers );
-      
-      enum Region{
-	unknown_region = -1,
-	HFneg, HEneg, HBneg, HBpos, HEpos, HFpos };
-      
-      int HBHE_oddness( int iEta, int depth );
-      Region HBHE_region( uint32_t );
+      unsigned int nCarrying(double fraction, const std::vector<double> &descending_energies);
+      unsigned int hitsInNCarrying(double fraction, const std::vector<subtower> &descending_towers);
+
+      enum Region { unknown_region = -1, HFneg, HEneg, HBneg, HBpos, HEpos, HFpos };
+
+      int HBHE_oddness(int iEta, int depth);
+      Region HBHE_region(uint32_t);
       // tower-based. -1 means can't figure it out
-      int HBHE_oddness( int iEta );
-      Region region( int iEta );
+      int HBHE_oddness(int iEta);
+      Region region(int iEta);
 
       double fHPD_;
       double fRBX_;
-      int    n90Hits_;
+      int n90Hits_;
       double fSubDetector1_;
       double fSubDetector2_;
       double fSubDetector3_;
       double fSubDetector4_;
       double restrictedEMF_;
-      int    nHCALTowers_;
-      int    nECALTowers_;
+      int nHCALTowers_;
+      int nECALTowers_;
       double approximatefHPD_;
       double approximatefRBX_;
-      int    hitsInN90_;
+      int hitsInN90_;
       double approximatefSubDetector1_;
       double approximatefSubDetector2_;
       double approximatefSubDetector3_;
       double approximatefSubDetector4_;
-      
+
       double fEB_, fEE_, fHB_, fHE_, fHO_, fLong_, fShort_;
       double fLS_, fHFOOT_;
-      
+
       bool useRecHits_;
       edm::InputTag hbheRecHitsColl_;
       edm::InputTag hoRecHitsColl_;
@@ -141,9 +147,7 @@ namespace reco {
       edm::EDGetTokenT<HFRecHitCollection> input_HFRecHits_token_;
       edm::EDGetTokenT<EBRecHitCollection> input_EBRecHits_token_;
       edm::EDGetTokenT<EERecHitCollection> input_EERecHits_token_;
-
-
     };
-  }
-}
+  }  // namespace helper
+}  // namespace reco
 #endif

--- a/RecoJets/JetProducers/interface/JetMatchingTools.h
+++ b/RecoJets/JetProducers/interface/JetMatchingTools.h
@@ -18,79 +18,76 @@ namespace edm {
 namespace reco {
   class CaloJet;
   class GenJet;
-}
+}  // namespace reco
 
 class CaloTower;
 class CaloRecHit;
 class DetId;
-class PCaloHit; 
+class PCaloHit;
 
 class JetMatchingTools {
- public:
+public:
   struct JetConstituent {
     DetId id;
     double energy;
 
     JetConstituent() {}
     ~JetConstituent() {}
-    JetConstituent(const JetConstituent &j) : id(j.id), energy(j.energy) {}
-    JetConstituent(const EcalRecHit &ehit) : id(ehit.detid()), energy(ehit.energy()) {}
-    JetConstituent(const CaloRecHit &ehit) : id(ehit.detid()), energy(ehit.energy()) {}
+    JetConstituent(const JetConstituent& j) : id(j.id), energy(j.energy) {}
+    JetConstituent(const EcalRecHit& ehit) : id(ehit.detid()), energy(ehit.energy()) {}
+    JetConstituent(const CaloRecHit& ehit) : id(ehit.detid()), energy(ehit.energy()) {}
   };
 
-  JetMatchingTools (const edm::Event& fEvent, edm::ConsumesCollector&& iC );
-  ~JetMatchingTools ();
+  JetMatchingTools(const edm::Event& fEvent, edm::ConsumesCollector&& iC);
+  ~JetMatchingTools();
 
   /// get towers contributing to CaloJet
-  std::vector <const CaloTower*> getConstituents (const reco::CaloJet& fJet ) ;
+  std::vector<const CaloTower*> getConstituents(const reco::CaloJet& fJet);
   /// get CaloRecHits contributing to the tower
-  std::vector <JetConstituent> getConstituentHits(const CaloTower& fTower);
+  std::vector<JetConstituent> getConstituentHits(const CaloTower& fTower);
   /// get cells contributing to the tower
-  std::vector <DetId> getConstituentIds (const CaloTower& fTower) ;
+  std::vector<DetId> getConstituentIds(const CaloTower& fTower);
   /// get PCaloHits contributing to the detId
-  std::vector <const PCaloHit*> getPCaloHits (DetId fId) ;
+  std::vector<const PCaloHit*> getPCaloHits(DetId fId);
   /// GEANT track ID
-  int getTrackId (const PCaloHit& fHit) ;
+  int getTrackId(const PCaloHit& fHit);
   /// convert trackId to SimTrack
-  const SimTrack* getTrack (unsigned fSimTrackId);
+  const SimTrack* getTrack(unsigned fSimTrackId);
   /// Generator ID
-  int generatorId (unsigned fSimTrackId) ;
+  int generatorId(unsigned fSimTrackId);
   /// GenParticle
-  const reco::GenParticle* getGenParticle (int fGeneratorId);
+  const reco::GenParticle* getGenParticle(int fGeneratorId);
   /// GenParticles for CaloJet
-  std::vector <const reco::GenParticle*> getGenParticles (const reco::CaloJet& fJet, bool fVerbose = true);
+  std::vector<const reco::GenParticle*> getGenParticles(const reco::CaloJet& fJet, bool fVerbose = true);
   /// GenParticles for GenJet
-  std::vector <const reco::GenParticle*> getGenParticles (const reco::GenJet& fJet);
+  std::vector<const reco::GenParticle*> getGenParticles(const reco::GenJet& fJet);
 
   // reverse propagation
   /// CaloSimHits
-  std::vector <const PCaloHit*> getPCaloHits (int fGeneratorId);
+  std::vector<const PCaloHit*> getPCaloHits(int fGeneratorId);
   /// CaloTowers
-  std::vector <const CaloTower*> getCaloTowers (int fGeneratorId);
+  std::vector<const CaloTower*> getCaloTowers(int fGeneratorId);
 
   /// energy in broken links
-  double lostEnergyFraction (const reco::CaloJet& fJet );
+  double lostEnergyFraction(const reco::CaloJet& fJet);
 
   /// energy overlap
-  double overlapEnergyFraction (const std::vector <const reco::GenParticle*>& fObject, 
-				const std::vector <const reco::GenParticle*>& fReference) const;
+  double overlapEnergyFraction(const std::vector<const reco::GenParticle*>& fObject,
+                               const std::vector<const reco::GenParticle*>& fReference) const;
 
+  const EBRecHitCollection* getEBRecHitCollection();
+  const EERecHitCollection* getEERecHitCollection();
+  const HBHERecHitCollection* getHBHERecHitCollection();
+  const HORecHitCollection* getHORecHitCollection();
+  const HFRecHitCollection* getHFRecHitCollection();
+  const edm::PCaloHitContainer* getEBSimHitCollection();
+  const edm::PCaloHitContainer* getEESimHitCollection();
+  const edm::PCaloHitContainer* getHcalSimHitCollection();
+  const edm::SimTrackContainer* getSimTrackCollection();
+  const edm::SimVertexContainer* getSimVertexCollection();
+  const reco::CandidateCollection* getGenParticlesCollection();
 
-  const EBRecHitCollection* getEBRecHitCollection ();
-  const EERecHitCollection* getEERecHitCollection ();
-  const HBHERecHitCollection* getHBHERecHitCollection ();
-  const HORecHitCollection* getHORecHitCollection ();
-  const HFRecHitCollection* getHFRecHitCollection ();
-  const edm::PCaloHitContainer* getEBSimHitCollection ();
-  const edm::PCaloHitContainer* getEESimHitCollection ();
-  const edm::PCaloHitContainer* getHcalSimHitCollection ();
-  const edm::SimTrackContainer* getSimTrackCollection ();
-  const edm::SimVertexContainer* getSimVertexCollection ();
-  const reco::CandidateCollection* getGenParticlesCollection ();
-
-
-  
- private:
+private:
   const edm::Event* mEvent;
   const EBRecHitCollection* mEBRecHitCollection;
   const EERecHitCollection* mEERecHitCollection;
@@ -115,7 +112,6 @@ class JetMatchingTools {
   edm::EDGetTokenT<edm::SimTrackContainer> input_simtrack_token_;
   edm::EDGetTokenT<edm::SimVertexContainer> input_simvertex_token_;
   edm::EDGetTokenT<reco::CandidateCollection> input_cands_token_;
-
 };
 
 #endif

--- a/RecoJets/JetProducers/interface/JetMuonHitsIDHelper.h
+++ b/RecoJets/JetProducers/interface/JetMuonHitsIDHelper.h
@@ -11,38 +11,34 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 
-
 namespace reco {
 
   namespace helper {
 
     class JetMuonHitsIDHelper {
-
-    public : 
+    public:
       // construction
       JetMuonHitsIDHelper() {}
-      JetMuonHitsIDHelper( edm::ParameterSet const & pset,  edm::ConsumesCollector&& iC );
-      ~JetMuonHitsIDHelper() {} 
+      JetMuonHitsIDHelper(edm::ParameterSet const& pset, edm::ConsumesCollector&& iC);
+      ~JetMuonHitsIDHelper() {}
 
       void fillDescription(edm::ParameterSetDescription& iDesc);
 
-      void initValues ();
+      void initValues();
 
       // interface
-      void calculate( const edm::Event& event, const edm::EventSetup & isetup, 
-		      const reco::Jet &jet, const int iDbg = 0 );
+      void calculate(const edm::Event& event, const edm::EventSetup& isetup, const reco::Jet& jet, const int iDbg = 0);
 
       // access
-      int numberOfHits1RPC() const { return numberOfHits1RPC_;}
-      int numberOfHits2RPC() const { return numberOfHits2RPC_;}
-      int numberOfHits3RPC() const { return numberOfHits3RPC_;}
-      int numberOfHits4RPC() const { return numberOfHits4RPC_;}
-      int numberOfHitsRPC () const { return numberOfHitsRPC_ ;}
-  
-    private:
+      int numberOfHits1RPC() const { return numberOfHits1RPC_; }
+      int numberOfHits2RPC() const { return numberOfHits2RPC_; }
+      int numberOfHits3RPC() const { return numberOfHits3RPC_; }
+      int numberOfHits4RPC() const { return numberOfHits4RPC_; }
+      int numberOfHitsRPC() const { return numberOfHitsRPC_; }
 
-      edm::InputTag rpcRecHits_; // collection of rpc rechits
-      bool          isRECO_;     // if this is RECO this will run, else nothing will be added
+    private:
+      edm::InputTag rpcRecHits_;  // collection of rpc rechits
+      bool isRECO_;               // if this is RECO this will run, else nothing will be added
 
       int numberOfHits1RPC_;
       int numberOfHits2RPC_;
@@ -51,8 +47,7 @@ namespace reco {
       int numberOfHitsRPC_;
 
       edm::EDGetTokenT<RPCRecHitCollection> input_rpchits_token_;
-
     };
-  }
-}
+  }  // namespace helper
+}  // namespace reco
 #endif

--- a/RecoJets/JetProducers/interface/JetSpecific.h
+++ b/RecoJets/JetProducers/interface/JetSpecific.h
@@ -1,7 +1,6 @@
 #ifndef RecoJets_JetProducers_interface_JetSpecific_h
 #define RecoJets_JetProducers_interface_JetSpecific_h
 
-
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
@@ -13,75 +12,67 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
-
-
 class CaloSubdetectorGeometry;
-
 
 namespace reco {
 
-  //______________________________________________________________________________    
+  //______________________________________________________________________________
   // Helper methods to write out specific types
 
   /// Make CaloJet specifics. Assumes PseudoJet is made from CaloTowerCandidates
-  bool makeSpecific(std::vector<reco::CandidatePtr> const & towers, 
-		    const CaloSubdetectorGeometry* towerGeometry,
-		    reco::CaloJet::Specific* caloJetSpecific,
-		    const HcalTopology &topology);
+  bool makeSpecific(std::vector<reco::CandidatePtr> const& towers,
+                    const CaloSubdetectorGeometry* towerGeometry,
+                    reco::CaloJet::Specific* caloJetSpecific,
+                    const HcalTopology& topology);
 
-  void writeSpecific(reco::CaloJet & jet,
-		     reco::Particle::LorentzVector const & p4,
-		     reco::Particle::Point const & point, 
-		     std::vector<reco::CandidatePtr> const & constituents,
-		     edm::EventSetup const & c  );
+  void writeSpecific(reco::CaloJet& jet,
+                     reco::Particle::LorentzVector const& p4,
+                     reco::Particle::Point const& point,
+                     std::vector<reco::CandidatePtr> const& constituents,
+                     edm::EventSetup const& c);
 
-  
   /// Make PFlowJet specifics. Assumes PseudoJet is made from ParticleFlowCandidates
-  bool makeSpecific(std::vector<reco::CandidatePtr> const & particles, 
-		    reco::PFJet::Specific* pfJetSpecific);
+  bool makeSpecific(std::vector<reco::CandidatePtr> const& particles, reco::PFJet::Specific* pfJetSpecific);
 
-  void writeSpecific(reco::PFJet  & jet,
-		     reco::Particle::LorentzVector const & p4,
-		     reco::Particle::Point const & point, 
-		     std::vector<reco::CandidatePtr> const & constituents,
-		     edm::EventSetup const & c  );
-  
-  
+  void writeSpecific(reco::PFJet& jet,
+                     reco::Particle::LorentzVector const& p4,
+                     reco::Particle::Point const& point,
+                     std::vector<reco::CandidatePtr> const& constituents,
+                     edm::EventSetup const& c);
+
   /// Make GenJet specifics. Assumes PseudoJet is made from HepMCCandidate
-  bool makeSpecific(std::vector<reco::CandidatePtr> const & mcparticles, 
-		    reco::GenJet::Specific* genJetSpecific);
+  bool makeSpecific(std::vector<reco::CandidatePtr> const& mcparticles, reco::GenJet::Specific* genJetSpecific);
 
-  void writeSpecific(reco::GenJet  & jet,
-		     reco::Particle::LorentzVector const & p4,
-		     reco::Particle::Point const & point, 
-		     std::vector<reco::CandidatePtr> const & constituents,
-		     edm::EventSetup const & c  );
-  
+  void writeSpecific(reco::GenJet& jet,
+                     reco::Particle::LorentzVector const& p4,
+                     reco::Particle::Point const& point,
+                     std::vector<reco::CandidatePtr> const& constituents,
+                     edm::EventSetup const& c);
+
   /// Make TrackJet. Assumes constituents point to tracks, through RecoChargedCandidates.
-  void writeSpecific(reco::TrackJet  & jet,
-		     reco::Particle::LorentzVector const & p4,
-		     reco::Particle::Point const & point, 
-		     std::vector<reco::CandidatePtr> const & constituents,
-		     edm::EventSetup const & c  );  
+  void writeSpecific(reco::TrackJet& jet,
+                     reco::Particle::LorentzVector const& p4,
+                     reco::Particle::Point const& point,
+                     std::vector<reco::CandidatePtr> const& constituents,
+                     edm::EventSetup const& c);
 
-/// Make PFClusterJet. Assumes PseudoJet is made from PFCluster
-  void writeSpecific(reco::PFClusterJet  & jet,
-		     reco::Particle::LorentzVector const & p4,
-		     reco::Particle::Point const & point, 
-		     std::vector<reco::CandidatePtr> const & constituents,
-		     edm::EventSetup const & c  );
-  
-  /// Make BasicJet. Assumes nothing about the jet. 
-  void writeSpecific(reco::BasicJet  & jet,
-		     reco::Particle::LorentzVector const & p4,
-		     reco::Particle::Point const & point, 
-		     std::vector<reco::CandidatePtr> const & constituents,
-		     edm::EventSetup const & c  );
-  
+  /// Make PFClusterJet. Assumes PseudoJet is made from PFCluster
+  void writeSpecific(reco::PFClusterJet& jet,
+                     reco::Particle::LorentzVector const& p4,
+                     reco::Particle::Point const& point,
+                     std::vector<reco::CandidatePtr> const& constituents,
+                     edm::EventSetup const& c);
+
+  /// Make BasicJet. Assumes nothing about the jet.
+  void writeSpecific(reco::BasicJet& jet,
+                     reco::Particle::LorentzVector const& p4,
+                     reco::Particle::Point const& point,
+                     std::vector<reco::CandidatePtr> const& constituents,
+                     edm::EventSetup const& c);
+
   /// converts eta to the corresponding HCAL subdetector.
-  HcalSubdetector hcalSubdetector(int iEta, const HcalTopology &topology);
+  HcalSubdetector hcalSubdetector(int iEta, const HcalTopology& topology);
 
-
-}
+}  // namespace reco
 
 #endif

--- a/RecoJets/JetProducers/interface/MVAJetPuId.h
+++ b/RecoJets/JetProducers/interface/MVAJetPuId.h
@@ -1,82 +1,78 @@
 #ifndef RecoJets_JetProducers_plugins_MVAJetPuId_h
 #define RecoJets_JetProducers_plugins_MVAJetPuId_h
- 
+
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
+
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
- 
+
 #include "DataFormats/JetReco/interface/PileupJetIdentifier.h"
 
-
 class MVAJetPuId {
+  static constexpr int NWPs = 3;
+  static constexpr int NPts = 4;
+  static constexpr int NEtas = 4;
 
+public:
+  enum version_t { USER = -1, CATEv0 = 0 };
 
-	static constexpr int NWPs = 3;
-	static constexpr int NPts = 4;
-	static constexpr int NEtas = 4;
-	
-	public:
-		enum version_t { USER=-1, CATEv0=0 };
+  MVAJetPuId(int version = CATEv0,
+             const std::string &tmvaWeight = "",
+             const std::string &tmvaMethod = "",
+             Float_t impactParTkThreshod_ = 1.,
+             const std::vector<std::string> &tmvaVariables = std::vector<std::string>());
+  MVAJetPuId(const edm::ParameterSet &ps);
+  ~MVAJetPuId();
 
-		MVAJetPuId(int version=CATEv0, const std::string & tmvaWeight="", const std::string & tmvaMethod="", 
-				Float_t impactParTkThreshod_=1., const std::vector<std::string> & tmvaVariables= std::vector<std::string>());
-		MVAJetPuId(const edm::ParameterSet & ps); 
-		~MVAJetPuId(); 
+  PileupJetIdentifier computeIdVariables(const reco::Jet *jet,
+                                         float jec,
+                                         const reco::Vertex *,
+                                         const reco::VertexCollection &,
+                                         double rho,
+                                         bool calculateMva = false);
 
-		PileupJetIdentifier computeIdVariables(const reco::Jet * jet, 
-				float jec, const reco::Vertex *, const reco::VertexCollection &,double rho,
-				bool calculateMva=false);
+  void set(const PileupJetIdentifier &);
+  PileupJetIdentifier computeMva();
+  const std::string method() const { return tmvaMethod_; }
 
-		void set(const PileupJetIdentifier &);
-		PileupJetIdentifier computeMva();
-		const std::string method() const { return tmvaMethod_; }
+  std::string dumpVariables() const;
 
-		std::string dumpVariables() const;
+  typedef std::map<std::string, std::pair<float *, float> > variables_list_t;
 
-		typedef std::map<std::string,std::pair<float *,float> > variables_list_t;
+  std::pair<int, int> getJetIdKey(float jetPt, float jetEta);
+  int computeCutIDflag(float betaStarClassic, float dR2Mean, float nvtx, float jetPt, float jetEta);
+  int computeIDflag(float mva, float jetPt, float jetEta);
+  int computeIDflag(float mva, int ptId, int etaId);
 
-		std::pair<int,int> getJetIdKey(float jetPt, float jetEta);
-		int computeCutIDflag(float betaStarClassic,float dR2Mean,float nvtx, float jetPt, float jetEta);
-		int computeIDflag   (float mva, float jetPt, float jetEta);
-		int computeIDflag   (float mva,int ptId,int etaId);
+  const variables_list_t &getVariables() const { return variables_; };
 
-		const variables_list_t & getVariables() const { return variables_; };
+protected:
+  void setup();
+  void runMva();
+  void bookReader();
+  void resetVariables();
+  void initVariables();
 
+  PileupJetIdentifier internalId_;
+  variables_list_t variables_;
 
-	
+  TMVA::Reader *reader_;
+  std::string tmvaWeights_, tmvaMethod_;
+  std::vector<std::string> tmvaVariables_;
+  std::vector<std::string> tmvaSpectators_;
+  std::map<std::string, std::string> tmvaNames_;
 
-	protected:
-
-
-		void setup(); 
-		void runMva(); 
-		void bookReader();  
-		void resetVariables();
-		void initVariables();
-	
-
-		PileupJetIdentifier internalId_;
-		variables_list_t variables_;
-
-		TMVA::Reader * reader_;
-		std::string    tmvaWeights_, tmvaMethod_; 
-		std::vector<std::string>  tmvaVariables_;
-		std::vector<std::string>  tmvaSpectators_;
-		std::map<std::string,std::string>  tmvaNames_;
-
-		Int_t   version_;
-		Float_t impactParTkThreshod_;
-		bool    cutBased_;
-		Float_t mvacut_     [NWPs][NEtas][NPts]; //Keep the array fixed
-		Float_t rmsCut_     [NWPs][NEtas][NPts]; //Keep the array fixed
-		Float_t betaStarCut_[NWPs][NEtas][NPts]; //Keep the array fixed
+  Int_t version_;
+  Float_t impactParTkThreshod_;
+  bool cutBased_;
+  Float_t mvacut_[NWPs][NEtas][NPts];       //Keep the array fixed
+  Float_t rmsCut_[NWPs][NEtas][NPts];       //Keep the array fixed
+  Float_t betaStarCut_[NWPs][NEtas][NPts];  //Keep the array fixed
 };
 
 #endif
-

--- a/RecoJets/JetProducers/interface/NjettinessAdder.h
+++ b/RecoJets/JetProducers/interface/NjettinessAdder.h
@@ -11,65 +11,58 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "fastjet/contrib/Njettiness.hh"
 
+class NjettinessAdder : public edm::stream::EDProducer<> {
+public:
+  enum MeasureDefinition_t {
+    NormalizedMeasure = 0,      // (beta,R0)
+    UnnormalizedMeasure,        // (beta)
+    OriginalGeometricMeasure,   // (beta)
+    NormalizedCutoffMeasure,    // (beta,R0,Rcutoff)
+    UnnormalizedCutoffMeasure,  // (beta,Rcutoff)
+    GeometricCutoffMeasure,     // (beta,Rcutoff)
+    N_MEASURE_DEFINITIONS
+  };
+  enum AxesDefinition_t {
+    KT_Axes = 0,
+    CA_Axes,
+    AntiKT_Axes,  // (axAxesR0)
+    WTA_KT_Axes,
+    WTA_CA_Axes,
+    Manual_Axes,
+    OnePass_KT_Axes,
+    OnePass_CA_Axes,
+    OnePass_AntiKT_Axes,  // (axAxesR0)
+    OnePass_WTA_KT_Axes,
+    OnePass_WTA_CA_Axes,
+    OnePass_Manual_Axes,
+    MultiPass_Axes,
+    N_AXES_DEFINITIONS
+  };
 
-class NjettinessAdder : public edm::stream::EDProducer<> { 
- public:
+  explicit NjettinessAdder(const edm::ParameterSet& iConfig);
 
-    enum MeasureDefinition_t {
-        NormalizedMeasure=0,       // (beta,R0) 
-        UnnormalizedMeasure,       // (beta) 
-        OriginalGeometricMeasure,  // (beta) 
-        NormalizedCutoffMeasure,   // (beta,R0,Rcutoff) 
-        UnnormalizedCutoffMeasure, // (beta,Rcutoff) 
-        GeometricCutoffMeasure,    // (beta,Rcutoff) 
-	N_MEASURE_DEFINITIONS
-    };
-    enum AxesDefinition_t {
-      KT_Axes=0,
-      CA_Axes,
-      AntiKT_Axes,   // (axAxesR0)
-      WTA_KT_Axes,
-      WTA_CA_Axes,
-      Manual_Axes,
-      OnePass_KT_Axes,
-      OnePass_CA_Axes,
-      OnePass_AntiKT_Axes,   // (axAxesR0)
-      OnePass_WTA_KT_Axes,
-      OnePass_WTA_CA_Axes,
-      OnePass_Manual_Axes,
-      MultiPass_Axes,
-      N_AXES_DEFINITIONS
-    };
+  ~NjettinessAdder() override {}
 
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  float getTau(unsigned num, const edm::Ptr<reco::Jet>& object) const;
 
+private:
+  edm::InputTag src_;
+  edm::EDGetTokenT<edm::View<reco::Jet>> src_token_;
+  std::vector<unsigned> Njets_;
 
-    explicit NjettinessAdder(const edm::ParameterSet& iConfig);
-    
-    ~NjettinessAdder() override {}
-    
-    void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override ;
-    float getTau(unsigned num, const edm::Ptr<reco::Jet> & object) const;
-    
- private:	
-    edm::InputTag                          src_;
-    edm::EDGetTokenT<edm::View<reco::Jet>> src_token_;
-    std::vector<unsigned>                  Njets_;
+  // Measure definition :
+  unsigned measureDefinition_;
+  double beta_;
+  double R0_;
+  double Rcutoff_;
 
-    // Measure definition : 
-    unsigned                               measureDefinition_;
-    double                                 beta_ ;
-    double                                 R0_;
-    double                                 Rcutoff_;
+  // Axes definition :
+  unsigned axesDefinition_;
+  int nPass_;
+  double akAxesR0_;
 
-    // Axes definition : 
-    unsigned                               axesDefinition_;
-    int                                    nPass_;
-    double                                 akAxesR0_;
-
-
-
-    std::unique_ptr<fastjet::contrib::Njettiness>   routine_; 
-
+  std::unique_ptr<fastjet::contrib::Njettiness> routine_;
 };
 
 #endif

--- a/RecoJets/JetProducers/interface/PileUpSubtractor.h
+++ b/RecoJets/JetProducers/interface/PileUpSubtractor.h
@@ -20,77 +20,78 @@
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
-class PileUpSubtractor{
-  
- public:
+class PileUpSubtractor {
+public:
+  typedef boost::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
+  typedef boost::shared_ptr<fastjet::GhostedAreaSpec> ActiveAreaSpecPtr;
+  typedef boost::shared_ptr<fastjet::RangeDefinition> RangeDefPtr;
+  typedef boost::shared_ptr<fastjet::JetDefinition> JetDefPtr;
 
-  typedef boost::shared_ptr<fastjet::ClusterSequence>        ClusterSequencePtr;
-  typedef boost::shared_ptr<fastjet::GhostedAreaSpec>        ActiveAreaSpecPtr;
-  typedef boost::shared_ptr<fastjet::RangeDefinition>        RangeDefPtr;
-  typedef boost::shared_ptr<fastjet::JetDefinition>          JetDefPtr;
-  
-  PileUpSubtractor(const edm::ParameterSet& iConfig,  edm::ConsumesCollector && iC); 
-  virtual ~PileUpSubtractor(){;}
-  
-  virtual void setDefinition(JetDefPtr const & jetDef);
+  PileUpSubtractor(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
+  virtual ~PileUpSubtractor() { ; }
+
+  virtual void setDefinition(JetDefPtr const& jetDef);
   virtual void reset(std::vector<edm::Ptr<reco::Candidate> >& input,
-	     std::vector<fastjet::PseudoJet>& towers,
-	     std::vector<fastjet::PseudoJet>& output);
-  virtual void setupGeometryMap(edm::Event& iEvent,const edm::EventSetup& iSetup);
-  virtual void calculatePedestal(std::vector<fastjet::PseudoJet> const & coll);
-  virtual void subtractPedestal(std::vector<fastjet::PseudoJet> & coll);
-  virtual void calculateOrphanInput(std::vector<fastjet::PseudoJet> & orphanInput);
+                     std::vector<fastjet::PseudoJet>& towers,
+                     std::vector<fastjet::PseudoJet>& output);
+  virtual void setupGeometryMap(edm::Event& iEvent, const edm::EventSetup& iSetup);
+  virtual void calculatePedestal(std::vector<fastjet::PseudoJet> const& coll);
+  virtual void subtractPedestal(std::vector<fastjet::PseudoJet>& coll);
+  virtual void calculateOrphanInput(std::vector<fastjet::PseudoJet>& orphanInput);
   virtual void offsetCorrectJets();
-  virtual double getMeanAtTower(const reco::CandidatePtr & in) const;
-  virtual double getSigmaAtTower(const reco::CandidatePtr & in) const;
-  virtual double getPileUpAtTower(const reco::CandidatePtr & in) const;
-  virtual double getPileUpEnergy(int ijet) const {return jetOffset_[ijet];}
+  virtual double getMeanAtTower(const reco::CandidatePtr& in) const;
+  virtual double getSigmaAtTower(const reco::CandidatePtr& in) const;
+  virtual double getPileUpAtTower(const reco::CandidatePtr& in) const;
+  virtual double getPileUpEnergy(int ijet) const { return jetOffset_[ijet]; }
   virtual double getCone(double cone, double eta, double phi, double& et, double& pu);
-  int getN(const reco::CandidatePtr & in) const;
-  int getNwithJets(const reco::CandidatePtr & in) const;
+  int getN(const reco::CandidatePtr& in) const;
+  int getNwithJets(const reco::CandidatePtr& in) const;
 
-  int ieta(const reco::CandidatePtr & in) const;
-  int iphi(const reco::CandidatePtr & in) const;
+  int ieta(const reco::CandidatePtr& in) const;
+  int iphi(const reco::CandidatePtr& in) const;
 
- protected:
-
+protected:
   // From jet producer
-  JetDefPtr                       fjJetDefinition_;  // fastjet jet definition
-  ClusterSequencePtr              fjClusterSeq_;    // fastjet cluster sequence
-  std::vector<edm::Ptr<reco::Candidate> >*       inputs_;          // input candidates
-  std::vector<fastjet::PseudoJet>* fjInputs_;        // fastjet inputs
-  std::vector<fastjet::PseudoJet>* fjJets_;          // fastjet jets
-  std::vector<fastjet::PseudoJet> fjOriginalInputs_;        // to back-up unsubtracted fastjet inputs
+  JetDefPtr fjJetDefinition_;                         // fastjet jet definition
+  ClusterSequencePtr fjClusterSeq_;                   // fastjet cluster sequence
+  std::vector<edm::Ptr<reco::Candidate> >* inputs_;   // input candidates
+  std::vector<fastjet::PseudoJet>* fjInputs_;         // fastjet inputs
+  std::vector<fastjet::PseudoJet>* fjJets_;           // fastjet jets
+  std::vector<fastjet::PseudoJet> fjOriginalInputs_;  // to back-up unsubtracted fastjet inputs
 
   // PU subtraction parameters
-  bool     reRunAlgo_;
-  bool     doAreaFastjet_;
-  bool     doRhoFastjet_;
-  double   jetPtMin_;
-  double   puPtMin_;
+  bool reRunAlgo_;
+  bool doAreaFastjet_;
+  bool doRhoFastjet_;
+  double jetPtMin_;
+  double puPtMin_;
 
   double ghostEtaMax;
-  int    activeAreaRepeats;
+  int activeAreaRepeats;
   double ghostArea;
 
-  double                nSigmaPU_;                  // number of sigma for pileup
-  double                radiusPU_;                  // pileup radius
-  ActiveAreaSpecPtr               fjActiveArea_;    // fastjet active area definition
-  CaloGeometry const *  geo_;                       // geometry
-  int                   ietamax_;                   // maximum eta in geometry
-  int                   ietamin_;                   // minimum eta in geometry
-  std::vector<HcalDetId> allgeomid_;                // all det ids in the geometry
-  std::map<int,int>     geomtowers_;                // map of geometry towers to det id
-  std::map<int,int>     ntowersWithJets_;           // number of towers with jets
-  std::map<int,double>  esigma_;                    // energy sigma
-  std::map<int,double>  emean_;                     // energy mean
+  double nSigmaPU_;                     // number of sigma for pileup
+  double radiusPU_;                     // pileup radius
+  ActiveAreaSpecPtr fjActiveArea_;      // fastjet active area definition
+  CaloGeometry const* geo_;             // geometry
+  int ietamax_;                         // maximum eta in geometry
+  int ietamin_;                         // minimum eta in geometry
+  std::vector<HcalDetId> allgeomid_;    // all det ids in the geometry
+  std::map<int, int> geomtowers_;       // map of geometry towers to det id
+  std::map<int, int> ntowersWithJets_;  // number of towers with jets
+  std::map<int, double> esigma_;        // energy sigma
+  std::map<int, double> emean_;         // energy mean
 
-  std::vector<double>   jetOffset_;
-
+  std::vector<double> jetOffset_;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-namespace edm {class ParameterSet; class EventSetup; class ConsumesCollector;}
-typedef edmplugin::PluginFactory<PileUpSubtractor *(const edm::ParameterSet &, edm::ConsumesCollector &&)> PileUpSubtractorFactory;
+namespace edm {
+  class ParameterSet;
+  class EventSetup;
+  class ConsumesCollector;
+}  // namespace edm
+typedef edmplugin::PluginFactory<PileUpSubtractor*(const edm::ParameterSet&, edm::ConsumesCollector&&)>
+    PileUpSubtractorFactory;
 
 #endif

--- a/RecoJets/JetProducers/interface/PileupJPTJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJPTJetIdAlgo.h
@@ -7,44 +7,41 @@
 #include <string>
 #include <memory>
 #include <map>
-#include<fstream>
-#include<iomanip>
-#include<iostream>
-#include<vector>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
 namespace edm {
   class Event;
   class EventSetup;
   class ParameterSet;
-}
+}  // namespace edm
 // For MVA analysis
 
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
 
-namespace cms
-{
+namespace cms {
 
-class PileupJPTJetIdAlgo
-{
-public:  
+  class PileupJPTJetIdAlgo {
+  public:
+    PileupJPTJetIdAlgo(const edm::ParameterSet& fParameters);
 
-  PileupJPTJetIdAlgo(const edm::ParameterSet& fParameters);
+    virtual ~PileupJPTJetIdAlgo();
 
-  virtual ~PileupJPTJetIdAlgo();
+    void bookMVAReader();
 
-  void bookMVAReader(); 
+    float fillJPTBlock(const reco::JPTJet* jet);
 
-  float fillJPTBlock(const reco::JPTJet* jet 
-                  );
-private:
-     int verbosity;
-// Variables for multivariate analysis
+  private:
+    int verbosity;
+    // Variables for multivariate analysis
 
-     float Nvtx,PtJ,EtaJ,Beta,MultCalo,dAxis1c,dAxis2c,MultTr,dAxis1t,dAxis2t;
-     TMVA::Reader * reader_; 
-     TMVA::Reader * readerF_;
-     std::string    tmvaWeights_, tmvaWeightsF_, tmvaMethod_;
-};
-}
+    float Nvtx, PtJ, EtaJ, Beta, MultCalo, dAxis1c, dAxis2c, MultTr, dAxis1t, dAxis2t;
+    TMVA::Reader* reader_;
+    TMVA::Reader* readerF_;
+    std::string tmvaWeights_, tmvaWeightsF_, tmvaMethod_;
+  };
+}  // namespace cms
 #endif

--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -21,91 +21,88 @@
 // ----------------------------------------------------------------------------------------------------
 class PileupJetIdAlgo {
 public:
-	enum version_t { USER=-1, PHILv0=0 };
+  enum version_t { USER = -1, PHILv0 = 0 };
 
-	class AlgoGBRForestsAndConstants;
+  class AlgoGBRForestsAndConstants;
 
-	PileupJetIdAlgo(AlgoGBRForestsAndConstants const* cache);
-	~PileupJetIdAlgo(); 
-	
-	PileupJetIdentifier computeIdVariables(const reco::Jet * jet, 
-					       float jec, const reco::Vertex *, const reco::VertexCollection &, double rho, bool usePuppi);
+  PileupJetIdAlgo(AlgoGBRForestsAndConstants const* cache);
+  ~PileupJetIdAlgo();
 
-	void set(const PileupJetIdentifier &);
-        float getMVAval(const std::vector<std::string> &, const std::unique_ptr<const GBRForest> &);
-	PileupJetIdentifier computeMva();
-	const std::string method() const { return cache_->tmvaMethod(); }
+  PileupJetIdentifier computeIdVariables(
+      const reco::Jet* jet, float jec, const reco::Vertex*, const reco::VertexCollection&, double rho, bool usePuppi);
 
-	std::string dumpVariables() const;
+  void set(const PileupJetIdentifier&);
+  float getMVAval(const std::vector<std::string>&, const std::unique_ptr<const GBRForest>&);
+  PileupJetIdentifier computeMva();
+  const std::string method() const { return cache_->tmvaMethod(); }
 
-	typedef std::map<std::string,std::pair<float *,float> > variables_list_t;
+  std::string dumpVariables() const;
 
-	std::pair<int,int> getJetIdKey(float jetPt, float jetEta);
-	int computeCutIDflag(float betaStarClassic,float dR2Mean,float nvtx, float jetPt, float jetEta);
-	int computeIDflag   (float mva, float jetPt, float jetEta);
-	int computeIDflag   (float mva,int ptId,int etaId);
+  typedef std::map<std::string, std::pair<float*, float>> variables_list_t;
 
-	/// const PileupJetIdentifier::variables_list_t & getVariables() const { return variables_; };
-	const variables_list_t & getVariables() const { return variables_; };
+  std::pair<int, int> getJetIdKey(float jetPt, float jetEta);
+  int computeCutIDflag(float betaStarClassic, float dR2Mean, float nvtx, float jetPt, float jetEta);
+  int computeIDflag(float mva, float jetPt, float jetEta);
+  int computeIDflag(float mva, int ptId, int etaId);
 
-        // In multithreaded mode, each PileupIdAlgo object will get duplicated
-        // on every stream. Some of the data it contains never changes after
-        // construction and can be shared by all streams. This nested class contains
-        // the data members that can be shared across streams. In particular
-        // the GBRForests take significant time to initialize and can be shared.
-        class AlgoGBRForestsAndConstants {
-        public:
+  /// const PileupJetIdentifier::variables_list_t & getVariables() const { return variables_; };
+  const variables_list_t& getVariables() const { return variables_; };
 
-          AlgoGBRForestsAndConstants(edm::ParameterSet const&, bool runMvas);
+  // In multithreaded mode, each PileupIdAlgo object will get duplicated
+  // on every stream. Some of the data it contains never changes after
+  // construction and can be shared by all streams. This nested class contains
+  // the data members that can be shared across streams. In particular
+  // the GBRForests take significant time to initialize and can be shared.
+  class AlgoGBRForestsAndConstants {
+  public:
+    AlgoGBRForestsAndConstants(edm::ParameterSet const&, bool runMvas);
 
-          std::unique_ptr<const GBRForest> const& reader() const { return reader_; }
-          std::vector<std::unique_ptr<const GBRForest>> const& etaReader() const { return etaReader_; }
-          bool cutBased() const { return cutBased_; }
-          bool etaBinnedWeights() const { return etaBinnedWeights_; }
-          bool runMvas() const { return runMvas_; }
-          int  nEtaBins() const { return nEtaBins_; }
-          std::vector<double> const& jEtaMin() const { return jEtaMin_; }
-          std::vector<double> const& jEtaMax() const { return jEtaMax_; }
-          std::string const& label() const { return label_; }
-          std::string const& tmvaMethod() const { return tmvaMethod_; }
-          std::vector<std::string> const& tmvaVariables() const { return tmvaVariables_; }
-          std::vector<std::vector<std::string>> const& tmvaEtaVariables() const { return tmvaEtaVariables_; }
+    std::unique_ptr<const GBRForest> const& reader() const { return reader_; }
+    std::vector<std::unique_ptr<const GBRForest>> const& etaReader() const { return etaReader_; }
+    bool cutBased() const { return cutBased_; }
+    bool etaBinnedWeights() const { return etaBinnedWeights_; }
+    bool runMvas() const { return runMvas_; }
+    int nEtaBins() const { return nEtaBins_; }
+    std::vector<double> const& jEtaMin() const { return jEtaMin_; }
+    std::vector<double> const& jEtaMax() const { return jEtaMax_; }
+    std::string const& label() const { return label_; }
+    std::string const& tmvaMethod() const { return tmvaMethod_; }
+    std::vector<std::string> const& tmvaVariables() const { return tmvaVariables_; }
+    std::vector<std::vector<std::string>> const& tmvaEtaVariables() const { return tmvaEtaVariables_; }
 
-          typedef float array_t[3][4][4];
-          array_t const& mvacut() const { return mvacut_; }
-          array_t const& rmsCut() const { return rmsCut_; }
-          array_t const& betaStarCut() const { return betaStarCut_; }
+    typedef float array_t[3][4][4];
+    array_t const& mvacut() const { return mvacut_; }
+    array_t const& rmsCut() const { return rmsCut_; }
+    array_t const& betaStarCut() const { return betaStarCut_; }
 
-        private:
+  private:
+    std::unique_ptr<const GBRForest> reader_;
+    std::vector<std::unique_ptr<const GBRForest>> etaReader_;
+    bool cutBased_;
+    bool etaBinnedWeights_;
+    bool runMvas_;
+    int nEtaBins_;
+    std::vector<double> jEtaMin_;
+    std::vector<double> jEtaMax_;
+    std::string label_;
+    std::string tmvaMethod_;
+    std::vector<std::string> tmvaVariables_;
+    std::vector<std::vector<std::string>> tmvaEtaVariables_;
 
-          std::unique_ptr<const GBRForest> reader_;
-          std::vector<std::unique_ptr<const GBRForest>> etaReader_;
-          bool cutBased_;
-          bool etaBinnedWeights_;
-          bool runMvas_;
-          int  nEtaBins_;
-          std::vector<double> jEtaMin_;
-          std::vector<double> jEtaMax_;
-          std::string label_;
-          std::string tmvaMethod_;
-          std::vector<std::string> tmvaVariables_;
-          std::vector<std::vector<std::string>> tmvaEtaVariables_;
+    float mvacut_[3][4][4];       //Keep the array fixed
+    float rmsCut_[3][4][4];       //Keep the array fixed
+    float betaStarCut_[3][4][4];  //Keep the array fixed
 
-          float mvacut_     [3][4][4]; //Keep the array fixed
-          float rmsCut_     [3][4][4]; //Keep the array fixed
-          float betaStarCut_[3][4][4]; //Keep the array fixed
-
-          std::map<std::string,std::string> tmvaNames_;
-        };
+    std::map<std::string, std::string> tmvaNames_;
+  };
 
 protected:
+  void runMva();
+  void resetVariables();
+  void initVariables();
 
-	void runMva(); 
-	void resetVariables();
-	void initVariables();
-
-	PileupJetIdentifier internalId_;
-	variables_list_t variables_;
-	AlgoGBRForestsAndConstants const* cache_;
+  PileupJetIdentifier internalId_;
+  variables_list_t variables_;
+  AlgoGBRForestsAndConstants const* cache_;
 };
 #endif

--- a/RecoJets/JetProducers/interface/QGTagger.h
+++ b/RecoJets/JetProducers/interface/QGTagger.h
@@ -13,25 +13,26 @@
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 #include "RecoJets/JetAlgorithms/interface/QGLikelihoodCalculator.h"
 
-class QGTagger : public edm::global::EDProducer<>{
-   public:
-      explicit QGTagger(const edm::ParameterSet&);
-      ~QGTagger() override{ delete qgLikelihood;};
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+class QGTagger : public edm::global::EDProducer<> {
+public:
+  explicit QGTagger(const edm::ParameterSet&);
+  ~QGTagger() override { delete qgLikelihood; };
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-      std::tuple<int, float, float> calcVariables(const reco::Jet*, edm::Handle<reco::VertexCollection>&, bool) const;
-      template <typename T> void putInEvent(const std::string&, const edm::Handle<edm::View<reco::Jet>>&, std::vector<T>*, edm::Event&) const;
-      bool isPackedCandidate(const reco::Jet* jet) const;
+private:
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  std::tuple<int, float, float> calcVariables(const reco::Jet*, edm::Handle<reco::VertexCollection>&, bool) const;
+  template <typename T>
+  void putInEvent(const std::string&, const edm::Handle<edm::View<reco::Jet>>&, std::vector<T>*, edm::Event&) const;
+  bool isPackedCandidate(const reco::Jet* jet) const;
 
-      edm::EDGetTokenT<edm::View<reco::Jet>> 	jetsToken;
-      edm::EDGetTokenT<reco::JetCorrector> 	jetCorrectorToken;
-      edm::EDGetTokenT<reco::VertexCollection> 	vertexToken;
-      edm::EDGetTokenT<double> 			rhoToken;
-      std::string 				jetsLabel, systLabel;
-      const bool 				useQC, useJetCorr, produceSyst;
-      QGLikelihoodCalculator *			qgLikelihood;
+  edm::EDGetTokenT<edm::View<reco::Jet>> jetsToken;
+  edm::EDGetTokenT<reco::JetCorrector> jetCorrectorToken;
+  edm::EDGetTokenT<reco::VertexCollection> vertexToken;
+  edm::EDGetTokenT<double> rhoToken;
+  std::string jetsLabel, systLabel;
+  const bool useQC, useJetCorr, produceSyst;
+  QGLikelihoodCalculator* qgLikelihood;
 };
 
 #endif

--- a/RecoJets/JetProducers/interface/QjetsAdder.h
+++ b/RecoJets/JetProducers/interface/QjetsAdder.h
@@ -10,40 +10,38 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "RecoJets/JetAlgorithms/interface/QjetsPlugin.h"
 
-class QjetsAdder : public edm::EDProducer { 
+class QjetsAdder : public edm::EDProducer {
 public:
-  explicit QjetsAdder(const edm::ParameterSet& iConfig) :
-    src_(iConfig.getParameter<edm::InputTag>("src")),
-    src_token_(consumes<edm::View<reco::Jet>>(src_)),
-    qjetsAlgo_( iConfig.getParameter<double>("zcut"),
-		iConfig.getParameter<double>("dcutfctr"),
-		iConfig.getParameter<double>("expmin"),
-		iConfig.getParameter<double>("expmax"),
-		iConfig.getParameter<double>("rigidity")),
-    ntrial_(iConfig.getParameter<int>("ntrial")),
-    cutoff_(iConfig.getParameter<double>("cutoff")), 
-    jetRad_(iConfig.getParameter<double>("jetRad")), 
-    mJetAlgo_(iConfig.getParameter<std::string>("jetAlgo")) ,
-    QjetsPreclustering_(iConfig.getParameter<int>("preclustering")) 
-  {
-    produces<edm::ValueMap<float> >("QjetsVolatility");
+  explicit QjetsAdder(const edm::ParameterSet& iConfig)
+      : src_(iConfig.getParameter<edm::InputTag>("src")),
+        src_token_(consumes<edm::View<reco::Jet>>(src_)),
+        qjetsAlgo_(iConfig.getParameter<double>("zcut"),
+                   iConfig.getParameter<double>("dcutfctr"),
+                   iConfig.getParameter<double>("expmin"),
+                   iConfig.getParameter<double>("expmax"),
+                   iConfig.getParameter<double>("rigidity")),
+        ntrial_(iConfig.getParameter<int>("ntrial")),
+        cutoff_(iConfig.getParameter<double>("cutoff")),
+        jetRad_(iConfig.getParameter<double>("jetRad")),
+        mJetAlgo_(iConfig.getParameter<std::string>("jetAlgo")),
+        QjetsPreclustering_(iConfig.getParameter<int>("preclustering")) {
+    produces<edm::ValueMap<float>>("QjetsVolatility");
   }
-  
-  ~QjetsAdder() override {}
-  
-  void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override ;
 
-private:	
-  edm::InputTag src_ ;
+  ~QjetsAdder() override {}
+
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+private:
+  edm::InputTag src_;
   edm::EDGetTokenT<edm::View<reco::Jet>> src_token_;
-  QjetsPlugin   qjetsAlgo_ ;
-  int           ntrial_;
-  double        cutoff_;
-  double        jetRad_;
-  std::string   mJetAlgo_;
-  int           QjetsPreclustering_;
+  QjetsPlugin qjetsAlgo_;
+  int ntrial_;
+  double cutoff_;
+  double jetRad_;
+  std::string mJetAlgo_;
+  int QjetsPreclustering_;
   edm::Service<edm::RandomNumberGenerator> rng_;
 };
-
 
 #endif

--- a/RecoJets/JetProducers/interface/VirtualJetProducerHelper.h
+++ b/RecoJets/JetProducers/interface/VirtualJetProducerHelper.h
@@ -10,37 +10,38 @@ namespace reco {
 
     namespace VirtualJetProducerHelper {
 
-// Area of intersection of two unit-radius disks with centers separated by r12.
-inline  double intersection(double r12)
-{
-  if (r12 == 0)         return M_PI;
-  if (r12 >= 2)         return 0;
-  return 2 * std::acos(0.5*r12) - 0.5*r12*sqrt(std::max(0.0 , 4 - r12*r12));
-}
+      // Area of intersection of two unit-radius disks with centers separated by r12.
+      inline double intersection(double r12) {
+        if (r12 == 0)
+          return M_PI;
+        if (r12 >= 2)
+          return 0;
+        return 2 * std::acos(0.5 * r12) - 0.5 * r12 * sqrt(std::max(0.0, 4 - r12 * r12));
+      }
 
-// Area of intersection of three unit-radius disks with centers separated by r12, r23, r13.
-inline double intersection(double r12, double r23, double r13) 
-{
-  if (r12 >= 2 || r23 >= 2 || r13 >= 2) return 0;
-  const double          r12_2   = r12*r12;
-  const double          r13_2   = r13*r13;
-  const double          temp    = (r12_2 + r13_2 - r23*r23);
-  const double          T2      = std::max(0.0 , 4*r12_2*r13_2 - temp*temp);
-  const double          common  = 0.5*( intersection(r12) + intersection(r13) + intersection(r23) - M_PI + 0.5*sqrt(T2) );
-  return common;
-}
-inline double intersection(double r12, double r23, double r13, double a12, double a23, double a13)
-{
-  if (r12 >= 2 || r23 >= 2 || r13 >= 2) return 0;
-  const double          r12_2   = r12*r12;
-  const double          r13_2   = r13*r13;
-  const double          temp    = (r12_2 + r13_2 - r23*r23);
-  const double          T2	= std::max(0.0 , 4*r12_2*r13_2 - temp*temp);
-  const double          common  = 0.5*( a12 + a13 + a23 - M_PI + 0.5*sqrt(T2) );
-  return common;
-}
+      // Area of intersection of three unit-radius disks with centers separated by r12, r23, r13.
+      inline double intersection(double r12, double r23, double r13) {
+        if (r12 >= 2 || r23 >= 2 || r13 >= 2)
+          return 0;
+        const double r12_2 = r12 * r12;
+        const double r13_2 = r13 * r13;
+        const double temp = (r12_2 + r13_2 - r23 * r23);
+        const double T2 = std::max(0.0, 4 * r12_2 * r13_2 - temp * temp);
+        const double common = 0.5 * (intersection(r12) + intersection(r13) + intersection(r23) - M_PI + 0.5 * sqrt(T2));
+        return common;
+      }
+      inline double intersection(double r12, double r23, double r13, double a12, double a23, double a13) {
+        if (r12 >= 2 || r23 >= 2 || r13 >= 2)
+          return 0;
+        const double r12_2 = r12 * r12;
+        const double r13_2 = r13 * r13;
+        const double temp = (r12_2 + r13_2 - r23 * r23);
+        const double T2 = std::max(0.0, 4 * r12_2 * r13_2 - temp * temp);
+        const double common = 0.5 * (a12 + a13 + a23 - M_PI + 0.5 * sqrt(T2));
+        return common;
+      }
 
-    }
-  }
-}
+    }  // namespace VirtualJetProducerHelper
+  }    // namespace helper
+}  // namespace reco
 #endif

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.cc
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.cc
@@ -2,7 +2,7 @@
 //
 // Package:    BasicToPFJet
 // Class:      BasicToPFJet
-// 
+//
 /**\class BasicToPFJet BasicToPFJet.cc UserCode/BasicToPFJet/plugins/BasicToPFJet.cc
 
  Description: converts reco::BasicJets to reco::PFJets and adds the new PFJetCollection to the event. Originally designed
@@ -31,24 +31,20 @@
 //include header file
 #include "RecoJets/JetProducers/plugins/BasicToPFJet.h"
 
-BasicToPFJet::BasicToPFJet(const edm::ParameterSet& PSet) :
-  src_ (PSet.getParameter<edm::InputTag>("src")),
-  inputToken_ (consumes<reco::BasicJetCollection>(src_))
-{
+BasicToPFJet::BasicToPFJet(const edm::ParameterSet& PSet)
+    : src_(PSet.getParameter<edm::InputTag>("src")), inputToken_(consumes<reco::BasicJetCollection>(src_)) {
   produces<reco::PFJetCollection>();
 }
 
-BasicToPFJet::~BasicToPFJet(){}
+BasicToPFJet::~BasicToPFJet() {}
 
-
-void BasicToPFJet::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
+void BasicToPFJet::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src",edm::InputTag(""));
-  descriptions.add("BasicToPFJet",desc);
+  desc.add<edm::InputTag>("src", edm::InputTag(""));
+  descriptions.add("BasicToPFJet", desc);
 }
 
-void BasicToPFJet::produce( edm::Event& Event, const edm::EventSetup& EventSetup){
-
+void BasicToPFJet::produce(edm::Event& Event, const edm::EventSetup& EventSetup) {
   //first get the basic jet collection
   edm::Handle<reco::BasicJetCollection> BasicJetColl;
   Event.getByToken(inputToken_, BasicJetColl);
@@ -63,8 +59,8 @@ void BasicToPFJet::produce( edm::Event& Event, const edm::EventSetup& EventSetup
   reco::BasicJetCollection::const_iterator i = BasicJetColl->begin();
 
   //loop over basic jets and convert them to pfjets
-  for(; i!=BasicJetColl->end(); i++){
-    reco::PFJet pfjet(i->p4(),i->vertex(),specific);
+  for (; i != BasicJetColl->end(); i++) {
+    reco::PFJet pfjet(i->p4(), i->vertex(), specific);
     PFJetColl->push_back(pfjet);
   }
 
@@ -72,6 +68,5 @@ void BasicToPFJet::produce( edm::Event& Event, const edm::EventSetup& EventSetup
   Event.put(std::move(PFJetColl));
 }
 
- 
 //define as plug-in for the framework
 DEFINE_FWK_MODULE(BasicToPFJet);

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.h
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.h
@@ -8,20 +8,16 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/JetReco/interface/BasicJet.h"
 
-
 class BasicToPFJet : public edm::EDProducer {
-
- public:
-
+public:
   explicit BasicToPFJet(const edm::ParameterSet& PSet);
   ~BasicToPFJet() override;
-  void produce(edm::Event & event, const edm::EventSetup & EventSetup) override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  void produce(edm::Event& event, const edm::EventSetup& EventSetup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
+private:
   edm::InputTag src_;
   const edm::EDGetTokenT<reco::BasicJetCollection> inputToken_;
 };
-
 
 #endif

--- a/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
+++ b/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
@@ -40,15 +40,15 @@
 #include <iostream>
 #include <iomanip>
 
-class BoostedTauSeedsProducer : public edm::stream::EDProducer<>
-{
- public:
+class BoostedTauSeedsProducer : public edm::stream::EDProducer<> {
+public:
   explicit BoostedTauSeedsProducer(const edm::ParameterSet&);
   ~BoostedTauSeedsProducer() override {}
   void produce(edm::Event&, const edm::EventSetup&) override;
 
- private:
-  typedef edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>, std::vector<reco::PFCandidate>, unsigned int> > JetToPFCandidateAssociation;
+private:
+  typedef edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>, std::vector<reco::PFCandidate>, unsigned int> >
+      JetToPFCandidateAssociation;
 
   std::string moduleLabel_;
 
@@ -60,83 +60,80 @@ class BoostedTauSeedsProducer : public edm::stream::EDProducer<>
 };
 
 BoostedTauSeedsProducer::BoostedTauSeedsProducer(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
   srcSubjets_ = consumes<JetView>(cfg.getParameter<edm::InputTag>("subjetSrc"));
   srcPFCandidates_ = consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("pfCandidateSrc"));
 
-  verbosity_ = ( cfg.exists("verbosity") ) ?
-    cfg.getParameter<int>("verbosity") : 0;
+  verbosity_ = (cfg.exists("verbosity")) ? cfg.getParameter<int>("verbosity") : 0;
 
   produces<reco::PFJetCollection>();
   produces<JetToPFCandidateAssociation>("pfCandAssocMapForIsolation");
   //produces<JetToPFCandidateAssociation>("pfCandAssocMapForIsoDepositVetos");
 }
 
-namespace
-{
+namespace {
   typedef std::vector<std::unordered_set<uint32_t> > JetToConstitMap;
-  
-  reco::PFJet convertToPFJet(const reco::Jet& jet, const reco::Jet::Constituents& jetConstituents)
-  {    
+
+  reco::PFJet convertToPFJet(const reco::Jet& jet, const reco::Jet::Constituents& jetConstituents) {
     // CV: code for filling pfJetSpecific objects taken from
     //        RecoParticleFlow/PFRootEvent/src/JetMaker.cc
     double chargedHadronEnergy = 0.;
     double neutralHadronEnergy = 0.;
-    double chargedEmEnergy     = 0.;
-    double neutralEmEnergy     = 0.;
-    double chargedMuEnergy     = 0.;
-    int    chargedMultiplicity = 0;
-    int    neutralMultiplicity = 0;
-    int    muonMultiplicity    = 0;
-    for ( auto const & jetConstituent : jetConstituents) {
+    double chargedEmEnergy = 0.;
+    double neutralEmEnergy = 0.;
+    double chargedMuEnergy = 0.;
+    int chargedMultiplicity = 0;
+    int neutralMultiplicity = 0;
+    int muonMultiplicity = 0;
+    for (auto const& jetConstituent : jetConstituents) {
       const reco::PFCandidate* pfCandidate = dynamic_cast<const reco::PFCandidate*>(jetConstituent.get());
-      if ( pfCandidate ) {
-	switch ( pfCandidate->particleId() ) {
-	case reco::PFCandidate::h :          // charged hadron
-	  chargedHadronEnergy += pfCandidate->energy();
-	  ++chargedMultiplicity;
-	  break;           
-	case reco::PFCandidate::e :          // electron 
-	  chargedEmEnergy += pfCandidate->energy(); 
-	  ++chargedMultiplicity;
-	  break;
-	case reco::PFCandidate::mu :         // muon
-	  chargedMuEnergy += pfCandidate->energy();
-	  ++chargedMultiplicity;
-	  ++muonMultiplicity;
-	  break;
-	case reco::PFCandidate::gamma :     // photon
-	case reco::PFCandidate::egamma_HF : // electromagnetic in HF
-	  neutralEmEnergy += pfCandidate->energy();
-	  ++neutralMultiplicity;
-	  break;
-	case reco::PFCandidate::h0 :        // neutral hadron
-	case reco::PFCandidate::h_HF :      // hadron in HF
-	  neutralHadronEnergy += pfCandidate->energy();
-	  ++neutralMultiplicity;
-	  break;
-	default:
-	  edm::LogWarning("convertToPFJet") 
-	    << "PFCandidate: Pt = " << pfCandidate->pt() << ", eta = " << pfCandidate->eta() << ", phi = " << pfCandidate->phi() 
-	    << " has invalid particleID = " << pfCandidate->particleId() << " !!" << std::endl;
-	  break;
-	}
+      if (pfCandidate) {
+        switch (pfCandidate->particleId()) {
+          case reco::PFCandidate::h:  // charged hadron
+            chargedHadronEnergy += pfCandidate->energy();
+            ++chargedMultiplicity;
+            break;
+          case reco::PFCandidate::e:  // electron
+            chargedEmEnergy += pfCandidate->energy();
+            ++chargedMultiplicity;
+            break;
+          case reco::PFCandidate::mu:  // muon
+            chargedMuEnergy += pfCandidate->energy();
+            ++chargedMultiplicity;
+            ++muonMultiplicity;
+            break;
+          case reco::PFCandidate::gamma:      // photon
+          case reco::PFCandidate::egamma_HF:  // electromagnetic in HF
+            neutralEmEnergy += pfCandidate->energy();
+            ++neutralMultiplicity;
+            break;
+          case reco::PFCandidate::h0:    // neutral hadron
+          case reco::PFCandidate::h_HF:  // hadron in HF
+            neutralHadronEnergy += pfCandidate->energy();
+            ++neutralMultiplicity;
+            break;
+          default:
+            edm::LogWarning("convertToPFJet")
+                << "PFCandidate: Pt = " << pfCandidate->pt() << ", eta = " << pfCandidate->eta()
+                << ", phi = " << pfCandidate->phi() << " has invalid particleID = " << pfCandidate->particleId()
+                << " !!" << std::endl;
+            break;
+        }
       } else {
-	edm::LogWarning("convertToPFJet") 
-	  << "Jet constituent: Pt = " << jetConstituent->pt() << ", eta = " << jetConstituent->eta() << ", phi = " <<jetConstituent->phi() 
-	  << " is not of type PFCandidate !!" << std::endl;
+        edm::LogWarning("convertToPFJet")
+            << "Jet constituent: Pt = " << jetConstituent->pt() << ", eta = " << jetConstituent->eta()
+            << ", phi = " << jetConstituent->phi() << " is not of type PFCandidate !!" << std::endl;
       }
     }
     reco::PFJet::Specific pfJetSpecific;
     pfJetSpecific.mChargedHadronEnergy = chargedHadronEnergy;
     pfJetSpecific.mNeutralHadronEnergy = neutralHadronEnergy;
-    pfJetSpecific.mChargedEmEnergy     = chargedEmEnergy;
-    pfJetSpecific.mChargedMuEnergy     = chargedMuEnergy;
-    pfJetSpecific.mNeutralEmEnergy     = neutralEmEnergy;
+    pfJetSpecific.mChargedEmEnergy = chargedEmEnergy;
+    pfJetSpecific.mChargedMuEnergy = chargedMuEnergy;
+    pfJetSpecific.mNeutralEmEnergy = neutralEmEnergy;
     pfJetSpecific.mChargedMultiplicity = chargedMultiplicity;
     pfJetSpecific.mNeutralMultiplicity = neutralMultiplicity;
-    pfJetSpecific.mMuonMultiplicity    = muonMultiplicity;
+    pfJetSpecific.mMuonMultiplicity = muonMultiplicity;
 
     reco::PFJet pfJet(jet.p4(), jet.vertex(), pfJetSpecific, jetConstituents);
     pfJet.setJetArea(jet.jetArea());
@@ -144,70 +141,75 @@ namespace
     return pfJet;
   }
 
-  void getJetConstituents(const reco::Jet& jet, reco::Jet::Constituents& jet_and_subjetConstituents)
-  {
+  void getJetConstituents(const reco::Jet& jet, reco::Jet::Constituents& jet_and_subjetConstituents) {
     reco::Jet::Constituents jetConstituents = jet.getJetConstituents();
-    for ( auto const & jetConstituent : jetConstituents ) {
+    for (auto const& jetConstituent : jetConstituents) {
       const reco::Jet* subjet = dynamic_cast<const reco::Jet*>(jetConstituent.get());
-      if ( subjet ) {
-	getJetConstituents(*subjet, jet_and_subjetConstituents);
-      } else { 
-	jet_and_subjetConstituents.push_back(jetConstituent);
+      if (subjet) {
+        getJetConstituents(*subjet, jet_and_subjetConstituents);
+      } else {
+        jet_and_subjetConstituents.push_back(jetConstituent);
       }
     }
   }
 
-  std::vector<reco::PFCandidateRef> getPFCandidates_exclJetConstituents(const reco::Jet& jet, const edm::Handle<reco::PFCandidateCollection>& pfCandidates, const JetToConstitMap::value_type& constitmap, const reco::Jet::Constituents& jetConstituents, double /*dRmatch*/, bool invert)
-  { 
+  std::vector<reco::PFCandidateRef> getPFCandidates_exclJetConstituents(
+      const reco::Jet& jet,
+      const edm::Handle<reco::PFCandidateCollection>& pfCandidates,
+      const JetToConstitMap::value_type& constitmap,
+      const reco::Jet::Constituents& jetConstituents,
+      double /*dRmatch*/,
+      bool invert) {
     //const double dRmatch2 = dRmatch*dRmatch; // comment out for now in case someone needs a dR-based search again
-    auto const & collection_cand = (*pfCandidates);
+    auto const& collection_cand = (*pfCandidates);
     std::vector<reco::PFCandidateRef> pfCandidates_exclJetConstituents;
     size_t numPFCandidates = pfCandidates->size();
-    for ( size_t pfCandidateIdx = 0; pfCandidateIdx < numPFCandidates; ++pfCandidateIdx ) {
-      if(!(deltaR2(collection_cand[pfCandidateIdx], jet)<1.0)) continue;
-      bool isJetConstituent = constitmap.count(pfCandidateIdx);      
-      if ( !(isJetConstituent^invert) ) {
-	reco::PFCandidateRef pfCandidate(pfCandidates, pfCandidateIdx);
-	pfCandidates_exclJetConstituents.push_back(pfCandidate);
+    for (size_t pfCandidateIdx = 0; pfCandidateIdx < numPFCandidates; ++pfCandidateIdx) {
+      if (!(deltaR2(collection_cand[pfCandidateIdx], jet) < 1.0))
+        continue;
+      bool isJetConstituent = constitmap.count(pfCandidateIdx);
+      if (!(isJetConstituent ^ invert)) {
+        reco::PFCandidateRef pfCandidate(pfCandidates, pfCandidateIdx);
+        pfCandidates_exclJetConstituents.push_back(pfCandidate);
       }
     }
     return pfCandidates_exclJetConstituents;
   }
 
-  void printJetConstituents(const std::string& label, const reco::Jet::Constituents& jetConstituents)
-  {
+  void printJetConstituents(const std::string& label, const reco::Jet::Constituents& jetConstituents) {
     std::cout << "#" << label << " = " << jetConstituents.size() << ":" << std::endl;
     unsigned idx = 0;
-    for ( auto const & jetConstituent : jetConstituents ) {
-      std::cout << " jetConstituent #" << idx << ": Pt = " << (*jetConstituent).pt() << ", eta = " << (*jetConstituent).eta() << ", phi = " << (*jetConstituent).phi() << std::endl;
+    for (auto const& jetConstituent : jetConstituents) {
+      std::cout << " jetConstituent #" << idx << ": Pt = " << (*jetConstituent).pt()
+                << ", eta = " << (*jetConstituent).eta() << ", phi = " << (*jetConstituent).phi() << std::endl;
       ++idx;
     }
   }
-}
+}  // namespace
 
-void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-  if ( verbosity_ >= 1 ) {
+void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  if (verbosity_ >= 1) {
     std::cout << "<BoostedTauSeedsProducer::produce (moduleLabel = " << moduleLabel_ << ")>:" << std::endl;
   }
 
   edm::Handle<JetView> subjets;
   evt.getByToken(srcSubjets_, subjets);
-  if ( verbosity_ >= 1 ) {
+  if (verbosity_ >= 1) {
     std::cout << "#subjets = " << subjets->size() << std::endl;
   }
-  assert((subjets->size() % 2) == 0); // CV: ensure that subjets come in pairs
-  
+  assert((subjets->size() % 2) == 0);  // CV: ensure that subjets come in pairs
+
   edm::Handle<reco::PFCandidateCollection> pfCandidates;
   evt.getByToken(srcPFCandidates_, pfCandidates);
-  if ( verbosity_ >= 1 ) {
+  if (verbosity_ >= 1) {
     std::cout << "#pfCandidates = " << pfCandidates->size() << std::endl;
   }
-  
+
   auto selectedSubjets = std::make_unique<reco::PFJetCollection>();
   edm::RefProd<reco::PFJetCollection> selectedSubjetRefProd = evt.getRefBeforePut<reco::PFJetCollection>();
 
-  auto selectedSubjetPFCandidateAssociationForIsolation = std::make_unique<JetToPFCandidateAssociation>(&evt.productGetter());
+  auto selectedSubjetPFCandidateAssociationForIsolation =
+      std::make_unique<JetToPFCandidateAssociation>(&evt.productGetter());
   //auto selectedSubjetPFCandidateAssociationForIsoDepositVetos = std::make_unique<JetToPFCandidateAssociation>(&evt.productGetter());
 
   // cache for jet->pfcandidate
@@ -215,33 +217,35 @@ void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es
 
   // fill constituents map
   const auto& thesubjets = *subjets;
-  for( unsigned i = 0; i < thesubjets.size(); ++i ) {
-    for ( unsigned j = 0; j < thesubjets[i].numberOfDaughters(); ++j ) {
+  for (unsigned i = 0; i < thesubjets.size(); ++i) {
+    for (unsigned j = 0; j < thesubjets[i].numberOfDaughters(); ++j) {
       constitmap[i].emplace(thesubjets[i].daughterPtr(j).key());
     }
   }
 
-  for ( size_t idx = 0; idx < (subjets->size() / 2); ++idx ) {
-    const reco::Jet* subjet1 = &subjets->at(2*idx);
-    const reco::Jet* subjet2 = &subjets->at(2*idx + 1);
+  for (size_t idx = 0; idx < (subjets->size() / 2); ++idx) {
+    const reco::Jet* subjet1 = &subjets->at(2 * idx);
+    const reco::Jet* subjet2 = &subjets->at(2 * idx + 1);
     assert(subjet1 && subjet2);
-    if ( verbosity_ >= 1 ) {
+    if (verbosity_ >= 1) {
       std::cout << "processing jet #" << idx << ":" << std::endl;
-      std::cout << " subjet1: Pt = " << subjet1->pt() << ", eta = " << subjet1->eta() << ", phi = " << subjet1->phi() << ", mass = " << subjet1->mass() 
-		<< " (#constituents = " << subjet1->nConstituents() << ", area = " << subjet1->jetArea() << ")" << std::endl;
-      std::cout << " subjet2: Pt = " << subjet2->pt() << ", eta = " << subjet2->eta() << ", phi = " << subjet2->phi() << ", mass = " << subjet2->mass() 
-		<< " (#constituents = " << subjet2->nConstituents() << ", area = " << subjet2->jetArea() << ")" << std::endl;
+      std::cout << " subjet1: Pt = " << subjet1->pt() << ", eta = " << subjet1->eta() << ", phi = " << subjet1->phi()
+                << ", mass = " << subjet1->mass() << " (#constituents = " << subjet1->nConstituents()
+                << ", area = " << subjet1->jetArea() << ")" << std::endl;
+      std::cout << " subjet2: Pt = " << subjet2->pt() << ", eta = " << subjet2->eta() << ", phi = " << subjet2->phi()
+                << ", mass = " << subjet2->mass() << " (#constituents = " << subjet2->nConstituents()
+                << ", area = " << subjet2->jetArea() << ")" << std::endl;
     }
 
-    if ( !(subjet1->nConstituents() >= 1 && subjet1->pt() > 1. &&
-	   subjet2->nConstituents() >= 1 && subjet2->pt() > 1.) ) continue; // CV: skip pathological cases
+    if (!(subjet1->nConstituents() >= 1 && subjet1->pt() > 1. && subjet2->nConstituents() >= 1 && subjet2->pt() > 1.))
+      continue;  // CV: skip pathological cases
 
     // find PFCandidate constituents of each subjet
     reco::Jet::Constituents subjetConstituents1;
-    getJetConstituents(*subjet1, subjetConstituents1);    
+    getJetConstituents(*subjet1, subjetConstituents1);
     reco::Jet::Constituents subjetConstituents2;
     getJetConstituents(*subjet2, subjetConstituents2);
-    if ( verbosity_ >= 1 ) {
+    if (verbosity_ >= 1) {
       printJetConstituents("subjetConstituents1", subjetConstituents1);
       printJetConstituents("subjetConstituents2", subjetConstituents2);
     }
@@ -250,21 +254,23 @@ void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es
     edm::Ref<reco::PFJetCollection> subjetRef1(selectedSubjetRefProd, selectedSubjets->size() - 1);
     selectedSubjets->push_back(convertToPFJet(*subjet2, subjetConstituents2));
     edm::Ref<reco::PFJetCollection> subjetRef2(selectedSubjetRefProd, selectedSubjets->size() - 1);
-        
+
     // find all PFCandidates that are not constituents of the **other** subjet
-    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet1 = getPFCandidates_exclJetConstituents(*subjet1, pfCandidates, constitmap[2*idx], subjetConstituents2, 1.e-4, false);
-    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet2 = getPFCandidates_exclJetConstituents(*subjet2, pfCandidates, constitmap[2*idx+1], subjetConstituents1, 1.e-4, false);
-    if ( verbosity_ >= 1 ) {
+    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet1 = getPFCandidates_exclJetConstituents(
+        *subjet1, pfCandidates, constitmap[2 * idx], subjetConstituents2, 1.e-4, false);
+    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet2 = getPFCandidates_exclJetConstituents(
+        *subjet2, pfCandidates, constitmap[2 * idx + 1], subjetConstituents1, 1.e-4, false);
+    if (verbosity_ >= 1) {
       std::cout << "#pfCandidatesNotInSubjet1 = " << pfCandidatesNotInSubjet1.size() << std::endl;
       std::cout << "#pfCandidatesNotInSubjet2 = " << pfCandidatesNotInSubjet2.size() << std::endl;
     }
 
-    // build JetToPFCandidateAssociation 
+    // build JetToPFCandidateAssociation
     // (key = subjet, value = collection of PFCandidates that are not constituents of subjet)
-    for(auto const& pfCandidate : pfCandidatesNotInSubjet1 ) {
+    for (auto const& pfCandidate : pfCandidatesNotInSubjet1) {
       selectedSubjetPFCandidateAssociationForIsolation->insert(subjetRef1, pfCandidate);
     }
-    for(auto const& pfCandidate : pfCandidatesNotInSubjet2 ) {
+    for (auto const& pfCandidate : pfCandidatesNotInSubjet2) {
       selectedSubjetPFCandidateAssociationForIsolation->insert(subjetRef2, pfCandidate);
     }
   }

--- a/RecoJets/JetProducers/plugins/CATopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CATopJetProducer.cc
@@ -2,176 +2,166 @@
 #include "RecoJets/JetProducers/plugins/CATopJetProducer.h"
 #include "RecoJets/JetProducers/plugins/FastjetJetProducer.h"
 
-
 using namespace edm;
 using namespace cms;
 using namespace reco;
 using namespace std;
 
-CATopJetProducer::CATopJetProducer(edm::ParameterSet const& conf):
-       FastjetJetProducer( conf ),
-       tagAlgo_(conf.getParameter<int>("tagAlgo")),
-       ptMin_(conf.getParameter<double>("jetPtMin")),
-       centralEtaCut_(conf.getParameter<double>("centralEtaCut")),
-       verbose_(conf.getParameter<bool>("verbose"))
-{
-
-	if (tagAlgo_ == CA_TOPTAGGER ) {
-		
-		legacyCMSTopTagger_ = std::unique_ptr<CATopJetAlgorithm>(
-			new CATopJetAlgorithm(src_,
-			conf.getParameter<bool>  ("verbose"),              
-       			conf.getParameter<int>	("algorithm"),                  // 0 = KT, 1 = CA, 2 = anti-KT
-     			conf.getParameter<int>   ("useAdjacency"),              	// choose adjacency requirement:
-				                                                //  0 = no adjacency
-                				                                //  1 = deltar adjacency 
-                                				                //  2 = modified adjacency
-                                                				//  3 = calotower neirest neigbor based adjacency (untested)
-		       conf.getParameter<double>("centralEtaCut"),             	// eta for defining "central" jets
-		       conf.getParameter<double>("jetPtMin"),                  	// min jet pt
-		       conf.getParameter<std::vector<double> >("sumEtBins"),    // sumEt bins over which cuts may vary. vector={bin 0 lower bound, bin 1 lower bound, ...} 
-		       conf.getParameter<std::vector<double> >("rBins"),       	// Jet distance paramter R. R values depend on sumEt bins.
-		       conf.getParameter<std::vector<double> >("ptFracBins"),  	// fraction of hard jet pt that subjet must have (deltap)
-		       conf.getParameter<std::vector<double> >("deltarBins"),  	// Applicable only if useAdjacency=1. deltar adjacency values for each sumEtBin
-		       conf.getParameter<std::vector<double> >("nCellBins"),	// Applicable only if useAdjacency=3. number of cells to consider two subjets adjacent
-		       conf.getParameter<double>("inputEtMin"),                	// seed threshold - NOT USED
-		       conf.getParameter<bool>  ("useMaxTower"),               	// use max tower as adjacency criterion, otherwise use centroid - NOT USED
-		       conf.getParameter<double>("sumEtEtaCut"),               	// eta for event SumEt - NOT USED
-  			conf.getParameter<double>("etFrac")                    	// fraction of event sumEt / 2 for a jet to be considered "hard" -NOT USED
-      		));
-	}
-	else if (tagAlgo_ == FJ_CMS_TOPTAG ) {
-		fjCMSTopTagger_ = std::unique_ptr<fastjet::CMSTopTagger>(
-			new fastjet::CMSTopTagger(conf.getParameter<double> ("ptFrac"),
-						  conf.getParameter<double> ("rFrac"),
-						  conf.getParameter<double> ("adjacencyParam"))
-		);
-	}
-	else if (tagAlgo_ == FJ_JHU_TOPTAG ) {
-		fjJHUTopTagger_ = std::unique_ptr<fastjet::JHTopTagger>(
-			new fastjet::JHTopTagger(conf.getParameter<double>("ptFrac"),
-						 conf.getParameter<double>("deltaRCut"),
-						 conf.getParameter<double>("cosThetaWMax")
-						 )
-		);
-	}
-	else if (tagAlgo_ == FJ_NSUB_TAG ) {
-		
-		fastjet::JetDefinition::Plugin *plugin = new fastjet::SISConePlugin(0.6, 0.75);
-		fastjet::JetDefinition NsubJetDef(plugin);
-		fjNSUBTagger_ = std::unique_ptr<fastjet::RestFrameNSubjettinessTagger>(
-			new fastjet::RestFrameNSubjettinessTagger(NsubJetDef,
-								  conf.getParameter<double>("tau2Cut"),
-								  conf.getParameter<double>("cosThetaSCut"),
-								  conf.getParameter<bool>("useExclusive")
-								  )
-		);
-	}
-				
-		
-
-
-
+CATopJetProducer::CATopJetProducer(edm::ParameterSet const& conf)
+    : FastjetJetProducer(conf),
+      tagAlgo_(conf.getParameter<int>("tagAlgo")),
+      ptMin_(conf.getParameter<double>("jetPtMin")),
+      centralEtaCut_(conf.getParameter<double>("centralEtaCut")),
+      verbose_(conf.getParameter<bool>("verbose")) {
+  if (tagAlgo_ == CA_TOPTAGGER) {
+    legacyCMSTopTagger_ = std::unique_ptr<CATopJetAlgorithm>(new CATopJetAlgorithm(
+        src_,
+        conf.getParameter<bool>("verbose"),
+        conf.getParameter<int>("algorithm"),         // 0 = KT, 1 = CA, 2 = anti-KT
+        conf.getParameter<int>("useAdjacency"),      // choose adjacency requirement:
+                                                     //  0 = no adjacency
+                                                     //  1 = deltar adjacency
+                                                     //  2 = modified adjacency
+                                                     //  3 = calotower neirest neigbor based adjacency (untested)
+        conf.getParameter<double>("centralEtaCut"),  // eta for defining "central" jets
+        conf.getParameter<double>("jetPtMin"),       // min jet pt
+        conf.getParameter<std::vector<double>>(
+            "sumEtBins"),  // sumEt bins over which cuts may vary. vector={bin 0 lower bound, bin 1 lower bound, ...}
+        conf.getParameter<std::vector<double>>("rBins"),  // Jet distance paramter R. R values depend on sumEt bins.
+        conf.getParameter<std::vector<double>>("ptFracBins"),  // fraction of hard jet pt that subjet must have (deltap)
+        conf.getParameter<std::vector<double>>(
+            "deltarBins"),  // Applicable only if useAdjacency=1. deltar adjacency values for each sumEtBin
+        conf.getParameter<std::vector<double>>(
+            "nCellBins"),  // Applicable only if useAdjacency=3. number of cells to consider two subjets adjacent
+        conf.getParameter<double>("inputEtMin"),  // seed threshold - NOT USED
+        conf.getParameter<bool>(
+            "useMaxTower"),  // use max tower as adjacency criterion, otherwise use centroid - NOT USED
+        conf.getParameter<double>("sumEtEtaCut"),  // eta for event SumEt - NOT USED
+        conf.getParameter<double>("etFrac")  // fraction of event sumEt / 2 for a jet to be considered "hard" -NOT USED
+        ));
+  } else if (tagAlgo_ == FJ_CMS_TOPTAG) {
+    fjCMSTopTagger_ =
+        std::unique_ptr<fastjet::CMSTopTagger>(new fastjet::CMSTopTagger(conf.getParameter<double>("ptFrac"),
+                                                                         conf.getParameter<double>("rFrac"),
+                                                                         conf.getParameter<double>("adjacencyParam")));
+  } else if (tagAlgo_ == FJ_JHU_TOPTAG) {
+    fjJHUTopTagger_ =
+        std::unique_ptr<fastjet::JHTopTagger>(new fastjet::JHTopTagger(conf.getParameter<double>("ptFrac"),
+                                                                       conf.getParameter<double>("deltaRCut"),
+                                                                       conf.getParameter<double>("cosThetaWMax")));
+  } else if (tagAlgo_ == FJ_NSUB_TAG) {
+    fastjet::JetDefinition::Plugin* plugin = new fastjet::SISConePlugin(0.6, 0.75);
+    fastjet::JetDefinition NsubJetDef(plugin);
+    fjNSUBTagger_ = std::unique_ptr<fastjet::RestFrameNSubjettinessTagger>(
+        new fastjet::RestFrameNSubjettinessTagger(NsubJetDef,
+                                                  conf.getParameter<double>("tau2Cut"),
+                                                  conf.getParameter<double>("cosThetaSCut"),
+                                                  conf.getParameter<bool>("useExclusive")));
+  }
 }
 
-void CATopJetProducer::produce(  edm::Event & e, const edm::EventSetup & c ) 
-{
-  FastjetJetProducer::produce(e, c);
-}
+void CATopJetProducer::produce(edm::Event& e, const edm::EventSetup& c) { FastjetJetProducer::produce(e, c); }
 
-void CATopJetProducer::runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  if ( !doAreaFastjet_ && !doRhoFastjet_) {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs_, *fjJetDefinition_ ) );
+void CATopJetProducer::runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  if (!doAreaFastjet_ && !doRhoFastjet_) {
+    fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, *fjJetDefinition_));
   } else if (voronoiRfact_ <= 0) {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceArea( fjInputs_, *fjJetDefinition_ , *fjAreaDefinition_ ) );
+    fjClusterSeq_ =
+        ClusterSequencePtr(new fastjet::ClusterSequenceArea(fjInputs_, *fjJetDefinition_, *fjAreaDefinition_));
   } else {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
+    fjClusterSeq_ = ClusterSequencePtr(
+        new fastjet::ClusterSequenceVoronoiArea(fjInputs_, *fjJetDefinition_, fastjet::VoronoiAreaSpec(voronoiRfact_)));
   }
 
-  if (tagAlgo_ == CA_TOPTAGGER){
-	(*legacyCMSTopTagger_).run( fjInputs_, fjJets_, fjClusterSeq_ );
-	
+  if (tagAlgo_ == CA_TOPTAGGER) {
+    (*legacyCMSTopTagger_).run(fjInputs_, fjJets_, fjClusterSeq_);
+
+  } else {
+    //Run the jet clustering
+    vector<fastjet::PseudoJet> inclusiveJets = fjClusterSeq_->inclusive_jets(ptMin_);
+
+    if (verbose_)
+      cout << "Getting central jets" << endl;
+    // Find the transient central jets
+    vector<fastjet::PseudoJet> centralJets;
+    for (unsigned int i = 0; i < inclusiveJets.size(); i++) {
+      if (inclusiveJets[i].perp() > ptMin_ && fabs(inclusiveJets[i].rapidity()) < centralEtaCut_) {
+        centralJets.push_back(inclusiveJets[i]);
+      }
+    }
+
+    fastjet::CMSTopTagger& CMSTagger = *fjCMSTopTagger_;
+    fastjet::JHTopTagger& JHUTagger = *fjJHUTopTagger_;
+    fastjet::RestFrameNSubjettinessTagger& NSUBTagger = *fjNSUBTagger_;
+
+    vector<fastjet::PseudoJet>::iterator jetIt = centralJets.begin(), centralJetsEnd = centralJets.end();
+    if (verbose_)
+      cout << "Loop over jets" << endl;
+    for (; jetIt != centralJetsEnd; ++jetIt) {
+      if (verbose_)
+        cout << "CMS FJ jet pt: " << (*jetIt).perp() << endl;
+
+      fastjet::PseudoJet taggedJet;
+      if (tagAlgo_ == FJ_CMS_TOPTAG)
+        taggedJet = CMSTagger.result(*jetIt);
+      else if (tagAlgo_ == FJ_JHU_TOPTAG)
+        taggedJet = JHUTagger.result(*jetIt);
+      else if (tagAlgo_ == FJ_NSUB_TAG)
+        taggedJet = NSUBTagger.result(*jetIt);
+      else
+        cout << "NOT A VALID TAGGING ALGORITHM CHOICE!" << endl;
+
+      if (taggedJet != 0)
+        fjJets_.push_back(taggedJet);
+    }
   }
-  else {
-	
-	//Run the jet clustering
-	vector<fastjet::PseudoJet> inclusiveJets = fjClusterSeq_->inclusive_jets(ptMin_);
-
-	if ( verbose_ ) cout << "Getting central jets" << endl;
-	// Find the transient central jets
-	vector<fastjet::PseudoJet> centralJets;
-	for (unsigned int i = 0; i < inclusiveJets.size(); i++) {
-		
-		if (inclusiveJets[i].perp() > ptMin_ && fabs(inclusiveJets[i].rapidity()) < centralEtaCut_) {
-			centralJets.push_back(inclusiveJets[i]);
-		}
-	}
-
-	fastjet::CMSTopTagger & CMSTagger = *fjCMSTopTagger_;
-	fastjet::JHTopTagger & JHUTagger = *fjJHUTopTagger_;
-	fastjet::RestFrameNSubjettinessTagger & NSUBTagger = *fjNSUBTagger_;
-
-
-	vector<fastjet::PseudoJet>::iterator jetIt = centralJets.begin(), centralJetsEnd = centralJets.end();
-	if ( verbose_ )cout<<"Loop over jets"<<endl;
-	for ( ; jetIt != centralJetsEnd; ++jetIt ) {
-		
-		if (verbose_) cout << "CMS FJ jet pt: " << (*jetIt).perp() << endl;
-
-		fastjet::PseudoJet taggedJet;
-		if (tagAlgo_ == FJ_CMS_TOPTAG) taggedJet = CMSTagger.result(*jetIt);
-		else if (tagAlgo_ == FJ_JHU_TOPTAG) taggedJet = JHUTagger.result(*jetIt);
-		else if (tagAlgo_ == FJ_NSUB_TAG) taggedJet = NSUBTagger.result(*jetIt);
-		else cout << "NOT A VALID TAGGING ALGORITHM CHOICE!" << endl;
-
-		if (taggedJet != 0) fjJets_.push_back(taggedJet);
-	}
-  }
-} 
+}
 
 void CATopJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
-	edm::ParameterSetDescription desc;
-	/// Cambridge-Aachen top jet producer parameters
-	desc.add<int>("tagAlgo",	0); 			// choice of top tagging algorithm
-    	desc.add<double>("centralEtaCut", 	2.5 );        	// eta for defining "central" jets                                     
-    	desc.add<bool >("verbose", 	false );        	
-	desc.add<string>("jetCollInstanceName",	"caTopSubJets"); 	// subjet collection
-	desc.add<int>("algorithm",	1); 			// 0 = KT, 1 = CA, 2 = anti-KT
-	desc.add<int>("useAdjacency", 	2); 			// veto adjacent subjets: 
-								// 0,	no adjacency
-								//  1,	deltar adjacency 
-								//  2,	modified adjacency
-								//  3,	calotower neirest neigbor based adjacency (untested)
-	vector<double>  sumEtBinsDefault={0.,1600.,2600.};
-	desc.add<vector<double>>("sumEtBins",  sumEtBinsDefault); 	// sumEt bins over which cuts vary. vector={bin 0 lower bound, bin 1 lower bound, ...} 
-	vector<double>  rBinsDefault(3,0.8);
-	desc.add<vector<double>>("rBins",      rBinsDefault); 		// Jet distance paramter R. R values depend on sumEt bins.
-	vector<double>  ptFracBinsDefault(3,0.05);
-	desc.add<vector<double>>("ptFracBins", ptFracBinsDefault); 	// minimum fraction of central jet pt for subjets (deltap)
-	vector<double>  deltarBinsDefault(3,0.019);
-	desc.add<vector<double>>("deltarBins", deltarBinsDefault); 	// Applicable only if useAdjacency=1. deltar adjacency values for each sumEtBin
-	vector<double>  nCellBinsDefault(3,1.9);
-	desc.add<vector<double>>("nCellBins",  nCellBinsDefault); 	// Applicable only if useAdjacency=3. number of cells apart for two subjets to be considered "independent"
-	desc.add<bool>("useMaxTower", 	false); 			// use max tower in adjacency criterion, otherwise use centroid - NOT USED
-	desc.add<double>("sumEtEtaCut",    3.0); 			// eta for event SumEt - NOT USED                                                 
-	desc.add<double>("etFrac", 	   0.7); 			// fraction of event sumEt / 2 for a jet to be considered "hard" - NOT USED
-	desc.add<double>("ptFrac", 	   0.05); 
-	desc.add<double>("rFrac",          0.); 
-	desc.add<double>("adjacencyParam", 0.); 
-	desc.add<double>("deltaRCut", 	   0.19); 
-	desc.add<double>("cosThetaWMax",   0.7); 
-	desc.add<double>("tau2Cut",        0.); 
-	desc.add<double>("cosThetaSCut",   0.); 
-	desc.add<bool>("useExclusive", 	false); 
-	////// From FastjetJetProducer
-	FastjetJetProducer::fillDescriptionsFromFastJetProducer(desc);
-	///// From VirtualJetProducer
-	VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(desc);
-	/////////////////////
-	descriptions.add("CATopJetProducer",desc);
-
+  edm::ParameterSetDescription desc;
+  /// Cambridge-Aachen top jet producer parameters
+  desc.add<int>("tagAlgo", 0);             // choice of top tagging algorithm
+  desc.add<double>("centralEtaCut", 2.5);  // eta for defining "central" jets
+  desc.add<bool>("verbose", false);
+  desc.add<string>("jetCollInstanceName", "caTopSubJets");  // subjet collection
+  desc.add<int>("algorithm", 1);                            // 0 = KT, 1 = CA, 2 = anti-KT
+  desc.add<int>("useAdjacency", 2);                         // veto adjacent subjets:
+                                                            // 0,	no adjacency
+                                                            //  1,	deltar adjacency
+                                                            //  2,	modified adjacency
+                                                            //  3,	calotower neirest neigbor based adjacency (untested)
+  vector<double> sumEtBinsDefault = {0., 1600., 2600.};
+  desc.add<vector<double>>(
+      "sumEtBins",
+      sumEtBinsDefault);  // sumEt bins over which cuts vary. vector={bin 0 lower bound, bin 1 lower bound, ...}
+  vector<double> rBinsDefault(3, 0.8);
+  desc.add<vector<double>>("rBins", rBinsDefault);  // Jet distance paramter R. R values depend on sumEt bins.
+  vector<double> ptFracBinsDefault(3, 0.05);
+  desc.add<vector<double>>("ptFracBins", ptFracBinsDefault);  // minimum fraction of central jet pt for subjets (deltap)
+  vector<double> deltarBinsDefault(3, 0.019);
+  desc.add<vector<double>>(
+      "deltarBins", deltarBinsDefault);  // Applicable only if useAdjacency=1. deltar adjacency values for each sumEtBin
+  vector<double> nCellBinsDefault(3, 1.9);
+  desc.add<vector<double>>(
+      "nCellBins",
+      nCellBinsDefault);  // Applicable only if useAdjacency=3. number of cells apart for two subjets to be considered "independent"
+  desc.add<bool>("useMaxTower", false);  // use max tower in adjacency criterion, otherwise use centroid - NOT USED
+  desc.add<double>("sumEtEtaCut", 3.0);  // eta for event SumEt - NOT USED
+  desc.add<double>("etFrac", 0.7);       // fraction of event sumEt / 2 for a jet to be considered "hard" - NOT USED
+  desc.add<double>("ptFrac", 0.05);
+  desc.add<double>("rFrac", 0.);
+  desc.add<double>("adjacencyParam", 0.);
+  desc.add<double>("deltaRCut", 0.19);
+  desc.add<double>("cosThetaWMax", 0.7);
+  desc.add<double>("tau2Cut", 0.);
+  desc.add<double>("cosThetaSCut", 0.);
+  desc.add<bool>("useExclusive", false);
+  ////// From FastjetJetProducer
+  FastjetJetProducer::fillDescriptionsFromFastJetProducer(desc);
+  ///// From VirtualJetProducer
+  VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(desc);
+  /////////////////////
+  descriptions.add("CATopJetProducer", desc);
 }
 //define this as a plug-in
 DEFINE_FWK_MODULE(CATopJetProducer);

--- a/RecoJets/JetProducers/plugins/CATopJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CATopJetProducer.h
@@ -1,7 +1,6 @@
 #ifndef RecoJets_JetProducers_CATopJetProducer_h
 #define RecoJets_JetProducers_CATopJetProducer_h
 
-
 /* *********************************************************
 
 
@@ -40,9 +39,6 @@
 
  ************************************************************/
 
-
-
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/View.h"
@@ -71,45 +67,31 @@
 #include <fastjet/tools/RestFrameNSubjettinessTagger.hh>
 #include "fastjet/SISConePlugin.hh"
 
-
-namespace cms
-{
-  class CATopJetProducer : public FastjetJetProducer
-  {
+namespace cms {
+  class CATopJetProducer : public FastjetJetProducer {
   public:
-
     CATopJetProducer(const edm::ParameterSet& ps);
 
     ~CATopJetProducer() override {}
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    void produce( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-    void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
+    void runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   private:
-    std::unique_ptr<CATopJetAlgorithm>        legacyCMSTopTagger_;         /// The algorithm to do the work
-    std::unique_ptr<fastjet::CMSTopTagger>     fjCMSTopTagger_;    // The FastJet implementation of the CMS tagger
-    std::unique_ptr<fastjet::JHTopTagger>     fjJHUTopTagger_;
-    std::unique_ptr<fastjet::RestFrameNSubjettinessTagger>   fjNSUBTagger_;
-
-
+    std::unique_ptr<CATopJetAlgorithm> legacyCMSTopTagger_;  /// The algorithm to do the work
+    std::unique_ptr<fastjet::CMSTopTagger> fjCMSTopTagger_;  // The FastJet implementation of the CMS tagger
+    std::unique_ptr<fastjet::JHTopTagger> fjJHUTopTagger_;
+    std::unique_ptr<fastjet::RestFrameNSubjettinessTagger> fjNSUBTagger_;
 
     int tagAlgo_;
     double ptMin_;
     double centralEtaCut_;
     bool verbose_;
-    enum tagalgos {
-	CA_TOPTAGGER,
-	FJ_CMS_TOPTAG,
-	FJ_JHU_TOPTAG,
-	FJ_NSUB_TAG
-    };
-
-
+    enum tagalgos { CA_TOPTAGGER, FJ_CMS_TOPTAG, FJ_JHU_TOPTAG, FJ_NSUB_TAG };
   };
 
-}
-
+}  // namespace cms
 
 #endif

--- a/RecoJets/JetProducers/plugins/CATopJetTagger.cc
+++ b/RecoJets/JetProducers/plugins/CATopJetTagger.cc
@@ -13,35 +13,26 @@ using namespace edm;
 // static data member definitions
 //
 
-
 //
 // constructors and destructor
 //
-CATopJetTagger::CATopJetTagger(const edm::ParameterSet& iConfig):
-  src_(iConfig.getParameter<InputTag>("src") ),
-  TopMass_(iConfig.getParameter<double>("TopMass") ),
-  WMass_(iConfig.getParameter<double>("WMass") ),
-  verbose_(iConfig.getParameter<bool>("verbose") ),
-  input_jet_token_(consumes<edm::View<reco::Jet> >(src_))
-{
+CATopJetTagger::CATopJetTagger(const edm::ParameterSet& iConfig)
+    : src_(iConfig.getParameter<InputTag>("src")),
+      TopMass_(iConfig.getParameter<double>("TopMass")),
+      WMass_(iConfig.getParameter<double>("WMass")),
+      verbose_(iConfig.getParameter<bool>("verbose")),
+      input_jet_token_(consumes<edm::View<reco::Jet> >(src_)) {
   produces<CATopJetTagInfoCollection>();
 }
 
-
-CATopJetTagger::~CATopJetTagger()
-{
-}
-
+CATopJetTagger::~CATopJetTagger() {}
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-CATopJetTagger::produce( edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-
+void CATopJetTagger::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   // Set up output list
   auto tagInfos = std::make_unique<CATopJetTagInfoCollection>();
 
@@ -50,32 +41,31 @@ CATopJetTagger::produce( edm::StreamID, edm::Event& iEvent, const edm::EventSetu
   iEvent.getByToken(input_jet_token_, pBasicJets);
 
   // Get a convenient handle
-  View<Jet> const & hardJets = *pBasicJets;
+  View<Jet> const& hardJets = *pBasicJets;
 
-  CATopJetHelper helper( TopMass_, WMass_ );
-   
+  CATopJetHelper helper(TopMass_, WMass_);
+
   // Now loop over the hard jets and do kinematic cuts
-  View<Jet>::const_iterator ihardJet = hardJets.begin(),
-    ihardJetEnd = hardJets.end();
+  View<Jet>::const_iterator ihardJet = hardJets.begin(), ihardJetEnd = hardJets.end();
   size_t iihardJet = 0;
-  for ( ; ihardJet != ihardJetEnd; ++ihardJet, ++iihardJet ) {
-
-    if ( verbose_ ) edm::LogInfo("CATopJetTagger") << "Processing ihardJet with pt = " << ihardJet->pt() << endl;
+  for (; ihardJet != ihardJetEnd; ++ihardJet, ++iihardJet) {
+    if (verbose_)
+      edm::LogInfo("CATopJetTagger") << "Processing ihardJet with pt = " << ihardJet->pt() << endl;
 
     // Initialize output variables
     // Get a ref to the hard jet
-    RefToBase<Jet> ref( pBasicJets, iihardJet );    
+    RefToBase<Jet> ref(pBasicJets, iihardJet);
     // Get properties
-    CATopJetProperties properties = helper( *ihardJet );
-    
+    CATopJetProperties properties = helper(*ihardJet);
+
     CATopJetTagInfo tagInfo;
-    tagInfo.insert( ref, properties );
-    tagInfos->push_back( tagInfo );
-  }// end loop over hard jets
-  
+    tagInfo.insert(ref, properties);
+    tagInfos->push_back(tagInfo);
+  }  // end loop over hard jets
+
   iEvent.put(std::move(tagInfos));
- 
-  return;   
+
+  return;
 }
 
 //define this as a plug-in

--- a/RecoJets/JetProducers/plugins/CATopJetTagger.h
+++ b/RecoJets/JetProducers/plugins/CATopJetTagger.h
@@ -5,7 +5,7 @@
 //
 // Package:    CATopJetTagger
 // Class:      CATopJetTagger
-// 
+//
 /**\class CATopJetTagger CATopJetTagger.cc TopQuarkAnalysis/TopJetProducers/src/CATopJetTagger.cc
 
  Description: This is a tagger to identify boosted top quark jets.
@@ -25,7 +25,6 @@
 //         Created:  Thu Jul  3 00:19:30 CDT 2008
 //
 //
-
 
 // system include files
 #include <memory>
@@ -57,32 +56,27 @@
 #include <TH2.h>
 #include <TTree.h>
 
-
 //
 // class decleration
 //
 
 class CATopJetTagger : public edm::global::EDProducer<> {
- public:
+public:
   explicit CATopJetTagger(const edm::ParameterSet&);
   ~CATopJetTagger() override;
-  
-  
- private:
-  void produce( edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-  
+
+private:
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
   // ----------member data ---------------------------
-  
-  const edm::InputTag   src_;
-  
-  const double      TopMass_;
-  const double      WMass_;
-  const bool        verbose_;
+
+  const edm::InputTag src_;
+
+  const double TopMass_;
+  const double WMass_;
+  const bool verbose_;
 
   const edm::EDGetTokenT<edm::View<reco::Jet> > input_jet_token_;
-
 };
-
-
 
 #endif

--- a/RecoJets/JetProducers/plugins/CMSInsideOutJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CMSInsideOutJetProducer.cc
@@ -16,7 +16,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -28,7 +27,6 @@
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 
-
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
@@ -36,7 +34,6 @@
 #include "fastjet/CMSIterativeConePlugin.hh"
 #include "fastjet/ATLASConePlugin.hh"
 #include "fastjet/CDFMidPointPlugin.hh"
-
 
 #include <iostream>
 #include <memory>
@@ -46,54 +43,38 @@
 
 using namespace std;
 
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // construction / destruction
 ////////////////////////////////////////////////////////////////////////////////
 
 //______________________________________________________________________________
 CMSInsideOutJetProducer::CMSInsideOutJetProducer(const edm::ParameterSet& iConfig)
-  : VirtualJetProducer( iConfig ),
-    alg_( iConfig.getParameter<double>("seedObjectPt"),
-	  iConfig.getParameter<double>("growthParameter"), 
-	  iConfig.getParameter<double>("maxSize"), 
-	  iConfig.getParameter<double>("minSize") )
-{
-}
-
+    : VirtualJetProducer(iConfig),
+      alg_(iConfig.getParameter<double>("seedObjectPt"),
+           iConfig.getParameter<double>("growthParameter"),
+           iConfig.getParameter<double>("maxSize"),
+           iConfig.getParameter<double>("minSize")) {}
 
 //______________________________________________________________________________
-CMSInsideOutJetProducer::~CMSInsideOutJetProducer()
-{
-} 
-
+CMSInsideOutJetProducer::~CMSInsideOutJetProducer() {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-void CMSInsideOutJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & iSetup )
-{
-  VirtualJetProducer::produce( iEvent, iSetup );
+void CMSInsideOutJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  VirtualJetProducer::produce(iEvent, iSetup);
 }
 
 //______________________________________________________________________________
-void CMSInsideOutJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iSetup)
-{
-
+void CMSInsideOutJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup const& iSetup) {
   fjJets_.clear();
 
-  alg_.run( fjInputs_, fjJets_ );
+  alg_.run(fjInputs_, fjJets_);
 }
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // define as cmssw plugin
 ////////////////////////////////////////////////////////////////////////////////
 
 DEFINE_FWK_MODULE(CMSInsideOutJetProducer);
-
-
-

--- a/RecoJets/JetProducers/plugins/CMSInsideOutJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CMSInsideOutJetProducer.h
@@ -12,15 +12,10 @@
  *
  */
 
-
-
 #include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
 #include "RecoJets/JetAlgorithms/interface/CMSInsideOutAlgorithm.h"
 
-
-class CMSInsideOutJetProducer : public VirtualJetProducer
-{
-
+class CMSInsideOutJetProducer : public VirtualJetProducer {
 public:
   //
   // construction/destruction
@@ -28,16 +23,14 @@ public:
   explicit CMSInsideOutJetProducer(const edm::ParameterSet& iConfig);
   ~CMSInsideOutJetProducer() override;
 
-  void produce( edm::Event & iEvent, const edm::EventSetup & iSetup ) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-  
 protected:
-
   //
   // member functions
   //
 
-  void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
+  void runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   CMSInsideOutAlgorithm alg_;
 };

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -10,23 +10,18 @@ using namespace reco;
 using namespace edm;
 using namespace cms;
 
-CSJetProducer::CSJetProducer(edm::ParameterSet const& conf):
-  VirtualJetProducer( conf ),
-  csRParam_(-1.0),
-  csAlpha_(0.)
-{
+CSJetProducer::CSJetProducer(edm::ParameterSet const& conf) : VirtualJetProducer(conf), csRParam_(-1.0), csAlpha_(0.) {
   //get eta range, rho and rhom map
-  etaToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "etaMap" ));
-  rhoToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "rho" ));
-  rhomToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "rhom" ));
+  etaToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>("etaMap"));
+  rhoToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>("rho"));
+  rhomToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>("rhom"));
   csRParam_ = conf.getParameter<double>("csRParam");
   csAlpha_ = conf.getParameter<double>("csAlpha");
 }
 
-void CSJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & iSetup )
-{
+void CSJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // use the default production from one collection
-  VirtualJetProducer::produce( iEvent, iSetup );
+  VirtualJetProducer::produce(iEvent, iSetup);
   //use runAlgorithm of this class
 
   //Delete allocated memory. It is allocated every time runAlgorithm is called
@@ -34,15 +29,16 @@ void CSJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & iSetup
 }
 
 //______________________________________________________________________________
-void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iSetup)
-{
+void CSJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup const& iSetup) {
   // run algorithm
-  if ( !doAreaFastjet_ && !doRhoFastjet_) {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs_, *fjJetDefinition_ ) );
+  if (!doAreaFastjet_ && !doRhoFastjet_) {
+    fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, *fjJetDefinition_));
   } else if (voronoiRfact_ <= 0) {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceArea( fjInputs_, *fjJetDefinition_ , *fjAreaDefinition_ ) );
+    fjClusterSeq_ =
+        ClusterSequencePtr(new fastjet::ClusterSequenceArea(fjInputs_, *fjJetDefinition_, *fjAreaDefinition_));
   } else {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
+    fjClusterSeq_ = ClusterSequencePtr(
+        new fastjet::ClusterSequenceVoronoiArea(fjInputs_, *fjJetDefinition_, fastjet::VoronoiAreaSpec(voronoiRfact_)));
   }
 
   fjJets_.clear();
@@ -52,101 +48,102 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
   edm::Handle<std::vector<double>> etaRanges;
   edm::Handle<std::vector<double>> rhoRanges;
   edm::Handle<std::vector<double>> rhomRanges;
-  
+
   iEvent.getByToken(etaToken_, etaRanges);
   iEvent.getByToken(rhoToken_, rhoRanges);
   iEvent.getByToken(rhomToken_, rhomRanges);
 
   //Check if size of eta and background density vectors is the same
   unsigned int bkgVecSize = etaRanges->size();
-  if(bkgVecSize<1) { throw cms::Exception("WrongBkgInput") << "Producer needs vector with background estimates\n"; }
-  if(bkgVecSize != (rhoRanges->size()+1) || bkgVecSize != (rhomRanges->size()+1) ) {
-    throw cms::Exception("WrongBkgInput") << "Size of etaRanges (" << bkgVecSize << ") and rhoRanges (" << rhoRanges->size() << ") and/or rhomRanges (" << rhomRanges->size() << ") vectors inconsistent\n";
+  if (bkgVecSize < 1) {
+    throw cms::Exception("WrongBkgInput") << "Producer needs vector with background estimates\n";
+  }
+  if (bkgVecSize != (rhoRanges->size() + 1) || bkgVecSize != (rhomRanges->size() + 1)) {
+    throw cms::Exception("WrongBkgInput")
+        << "Size of etaRanges (" << bkgVecSize << ") and rhoRanges (" << rhoRanges->size() << ") and/or rhomRanges ("
+        << rhomRanges->size() << ") vectors inconsistent\n";
   }
 
-  
   //Allow the background densities to change within the jet
 
-  for(fastjet::PseudoJet& ijet : tempJets ) {
-  
+  for (fastjet::PseudoJet& ijet : tempJets) {
     //----------------------------------------------------------------------
     // sift ghosts and particles in the input jet
     std::vector<fastjet::PseudoJet> particles, ghosts;
     fastjet::SelectorIsPureGhost().sift(ijet.constituents(), ghosts, particles);
-    unsigned long nParticles=particles.size();
-    if(nParticles==0) continue; //don't subtract ghost jets
-    
+    unsigned long nParticles = particles.size();
+    if (nParticles == 0)
+      continue;  //don't subtract ghost jets
+
     //assign rho and rhom to ghosts according to local eta-dependent map
-    double rho  = 1e-6;
+    double rho = 1e-6;
     double rhom = 1e-6;
-    for(fastjet::PseudoJet& ighost : ghosts) {
-      
-      if(ighost.eta()<=etaRanges->at(0) || bkgVecSize==1) {
+    for (fastjet::PseudoJet& ighost : ghosts) {
+      if (ighost.eta() <= etaRanges->at(0) || bkgVecSize == 1) {
         rho = rhoRanges->at(0);
         rhom = rhomRanges->at(0);
-      } else if(ighost.eta()>=etaRanges->at(bkgVecSize-1)) {
-        rho = rhoRanges->at(bkgVecSize-2);
-        rhom = rhomRanges->at(bkgVecSize-2);
+      } else if (ighost.eta() >= etaRanges->at(bkgVecSize - 1)) {
+        rho = rhoRanges->at(bkgVecSize - 2);
+        rhom = rhomRanges->at(bkgVecSize - 2);
       } else {
-        for(unsigned int ie = 0; ie<(bkgVecSize-1); ie++) {
-          if(ighost.eta()>=etaRanges->at(ie) && ighost.eta()<etaRanges->at(ie+1)) {
+        for (unsigned int ie = 0; ie < (bkgVecSize - 1); ie++) {
+          if (ighost.eta() >= etaRanges->at(ie) && ighost.eta() < etaRanges->at(ie + 1)) {
             rho = rhoRanges->at(ie);
             rhom = rhomRanges->at(ie);
             break;
           }
         }
       }
-      double pt = rho*ighost.area();
-      double mass_squared=std::pow(rhom*ighost.area()+pt,2)-std::pow(pt,2);
-      double mass=0;
-      if (mass_squared>0) mass=sqrt(mass_squared);
-      ighost.reset_momentum_PtYPhiM(pt,ighost.rap(),ighost.phi(),mass);
+      double pt = rho * ighost.area();
+      double mass_squared = std::pow(rhom * ighost.area() + pt, 2) - std::pow(pt, 2);
+      double mass = 0;
+      if (mass_squared > 0)
+        mass = sqrt(mass_squared);
+      ighost.reset_momentum_PtYPhiM(pt, ighost.rap(), ighost.phi(), mass);
     }
 
     //----------------------------------------------------------------------
     //from here use official fastjet contrib package
-    
+
     fastjet::contrib::ConstituentSubtractor subtractor;
-    subtractor.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR); // distance in eta-phi plane
-    subtractor.set_max_distance(csRParam_); // free parameter for the maximal allowed distance between particle i and ghost k
-    subtractor.set_alpha(csAlpha_);  // free parameter for the distance measure (the exponent of particle pt). Note that in older versions of the package alpha was multiplied by two but in newer versions this is not the case anymore
+    subtractor.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR);  // distance in eta-phi plane
+    subtractor.set_max_distance(
+        csRParam_);  // free parameter for the maximal allowed distance between particle i and ghost k
+    subtractor.set_alpha(
+        csAlpha_);  // free parameter for the distance measure (the exponent of particle pt). Note that in older versions of the package alpha was multiplied by two but in newer versions this is not the case anymore
     subtractor.set_do_mass_subtraction(true);
     subtractor.set_remove_all_zero_pt_particles(true);
 
-    std::vector<fastjet::PseudoJet> subtracted_particles = subtractor.do_subtraction(particles,ghosts);
+    std::vector<fastjet::PseudoJet> subtracted_particles = subtractor.do_subtraction(particles, ghosts);
 
     //Create subtracted jets
-    fastjet::PseudoJet subtracted_jet=join(subtracted_particles);
-    if(subtracted_jet.perp()>0.)
-      fjJets_.push_back( subtracted_jet );
+    fastjet::PseudoJet subtracted_jet = join(subtracted_particles);
+    if (subtracted_jet.perp() > 0.)
+      fjJets_.push_back(subtracted_jet);
   }
-  fjJets_ = fastjet::sorted_by_pt(fjJets_); 
+  fjJets_ = fastjet::sorted_by_pt(fjJets_);
 }
 
 void CSJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription descCSJetProducer;
   ////// From CSJetProducer
   fillDescriptionsFromCSJetProducer(descCSJetProducer);
   ///// From VirtualJetProducer
-  descCSJetProducer.add<string>("jetCollInstanceName", ""    );
+  descCSJetProducer.add<string>("jetCollInstanceName", "");
   VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(descCSJetProducer);
-  descCSJetProducer.add<bool> ("sumRecHits", false);
-  
+  descCSJetProducer.add<bool>("sumRecHits", false);
+
   /////////////////////
-  descriptions.add("CSJetProducer",descCSJetProducer);
-  
+  descriptions.add("CSJetProducer", descCSJetProducer);
 }
 
 void CSJetProducer::fillDescriptionsFromCSJetProducer(edm::ParameterSetDescription& desc) {
+  desc.add<double>("csRParam", -1.);
+  desc.add<double>("csAlpha", 2.);
 
-  desc.add<double>("csRParam",-1.);
-  desc.add<double>("csAlpha",2.);
-
-  desc.add<edm::InputTag>("etaMap",edm::InputTag("hiFJRhoProducer","mapEtaEdges") );
-  desc.add<edm::InputTag>("rho",edm::InputTag("hiFJRhoProducer","mapToRho") );
-  desc.add<edm::InputTag>("rhom",edm::InputTag("hiFJRhoProducer","mapToRhoM") );
-
+  desc.add<edm::InputTag>("etaMap", edm::InputTag("hiFJRhoProducer", "mapEtaEdges"));
+  desc.add<edm::InputTag>("rho", edm::InputTag("hiFJRhoProducer", "mapToRho"));
+  desc.add<edm::InputTag>("rhom", edm::InputTag("hiFJRhoProducer", "mapToRhoM"));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/RecoJets/JetProducers/plugins/CSJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.h
@@ -16,34 +16,29 @@
 
  ************************************************************/
 
-
 #include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
 
-namespace cms
-{
-  class CSJetProducer : public VirtualJetProducer
-  {
+namespace cms {
+  class CSJetProducer : public VirtualJetProducer {
   public:
-
     CSJetProducer(const edm::ParameterSet& ps);
 
     ~CSJetProducer() override {}
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     static void fillDescriptionsFromCSJetProducer(edm::ParameterSetDescription& desc);
 
-    void produce( edm::Event & iEvent, const edm::EventSetup & iSetup ) override;
-    
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
   protected:
+    void runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-    void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
-
-    double csRParam_;           /// for constituent subtraction : R parameter
-    double csAlpha_;            /// for HI constituent subtraction : alpha (power of pt in metric)
+    double csRParam_;  /// for constituent subtraction : R parameter
+    double csAlpha_;   /// for HI constituent subtraction : alpha (power of pt in metric)
 
     //input rho and rho_m + eta map
-    edm::EDGetTokenT<std::vector<double>>                       etaToken_;
-    edm::EDGetTokenT<std::vector<double>>                       rhoToken_;
-    edm::EDGetTokenT<std::vector<double>>                       rhomToken_;
+    edm::EDGetTokenT<std::vector<double>> etaToken_;
+    edm::EDGetTokenT<std::vector<double>> rhoToken_;
+    edm::EDGetTokenT<std::vector<double>> rhomToken_;
   };
-}
+}  // namespace cms
 #endif

--- a/RecoJets/JetProducers/plugins/CastorJetIDProducer.cc
+++ b/RecoJets/JetProducers/plugins/CastorJetIDProducer.cc
@@ -7,7 +7,6 @@
 // constants, enums and typedefs
 //
 
-
 //
 // static data member definitions
 //
@@ -15,68 +14,54 @@
 //
 // constructors and destructor
 //
-CastorJetIDProducer::CastorJetIDProducer(const edm::ParameterSet& iConfig) :
-  src_       ( iConfig.getParameter<edm::InputTag>("src") ),
-  helper_    ( )
-{
-  produces< reco::CastorJetIDValueMap >();
+CastorJetIDProducer::CastorJetIDProducer(const edm::ParameterSet& iConfig)
+    : src_(iConfig.getParameter<edm::InputTag>("src")), helper_() {
+  produces<reco::CastorJetIDValueMap>();
 
   input_jet_token_ = consumes<edm::View<reco::BasicJet> >(src_);
-
 }
 
-
-CastorJetIDProducer::~CastorJetIDProducer()
-{
-}
-
+CastorJetIDProducer::~CastorJetIDProducer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-CastorJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
+void CastorJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get the input jets
-  edm::Handle< edm::View<reco::BasicJet> > h_jets;
-  iEvent.getByToken( input_jet_token_, h_jets );
+  edm::Handle<edm::View<reco::BasicJet> > h_jets;
+  iEvent.getByToken(input_jet_token_, h_jets);
 
   // allocate the jet--->jetid value map
   auto castorjetIdValueMap = std::make_unique<reco::CastorJetIDValueMap>();
   // instantiate the filler with the map
   reco::CastorJetIDValueMap::Filler filler(*castorjetIdValueMap);
-  
+
   // allocate the vector of ids
   size_t njets = h_jets->size();
-  std::vector<reco::CastorJetID>  ids (njets);
-   
+  std::vector<reco::CastorJetID> ids(njets);
+
   // loop over the jets
-  for ( edm::View<reco::BasicJet>::const_iterator jetsBegin = h_jets->begin(),
-	  jetsEnd = h_jets->end(),
-	  ijet = jetsBegin;
-	ijet != jetsEnd; ++ijet ) {
-
+  for (edm::View<reco::BasicJet>::const_iterator jetsBegin = h_jets->begin(), jetsEnd = h_jets->end(), ijet = jetsBegin;
+       ijet != jetsEnd;
+       ++ijet) {
     // get the id from each jet
-    helper_.calculate( iEvent, *ijet );
+    helper_.calculate(iEvent, *ijet);
 
-    ids[ijet-jetsBegin].emEnergy               =  helper_.emEnergy();
-    ids[ijet-jetsBegin].hadEnergy               =  helper_.hadEnergy();
-    ids[ijet-jetsBegin].fem            =  helper_.fem();
-    ids[ijet-jetsBegin].depth      =  helper_.depth();
-    ids[ijet-jetsBegin].width      =  helper_.width();
-    ids[ijet-jetsBegin].fhot      =  helper_.fhot();
-    ids[ijet-jetsBegin].sigmaz      =  helper_.sigmaz();
-    ids[ijet-jetsBegin].nTowers      =  helper_.nTowers(); 
-
-
+    ids[ijet - jetsBegin].emEnergy = helper_.emEnergy();
+    ids[ijet - jetsBegin].hadEnergy = helper_.hadEnergy();
+    ids[ijet - jetsBegin].fem = helper_.fem();
+    ids[ijet - jetsBegin].depth = helper_.depth();
+    ids[ijet - jetsBegin].width = helper_.width();
+    ids[ijet - jetsBegin].fhot = helper_.fhot();
+    ids[ijet - jetsBegin].sigmaz = helper_.sigmaz();
+    ids[ijet - jetsBegin].nTowers = helper_.nTowers();
   }
-  
+
   // set up the map
-  filler.insert( h_jets, ids.begin(), ids.end() );
- 
+  filler.insert(h_jets, ids.begin(), ids.end());
+
   // fill the vals
   filler.fill();
 

--- a/RecoJets/JetProducers/plugins/CastorJetIDProducer.h
+++ b/RecoJets/JetProducers/plugins/CastorJetIDProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    CastorJetIDProducer
 // Class:      CastorJetIDProducer
-// 
+//
 /**\class CastorJetIDProducer CastorJetIDProducer.cc RecoJets/JetProducers/plugins/CastorJetIDProducer.cc
 
  Description: Produces a value map of jet---> jet Id
@@ -17,7 +17,6 @@
 //         Created:  Thu Sep 17 12:18:18 CDT 2009
 //
 //
-
 
 // system include files
 #include <memory>
@@ -39,20 +38,18 @@
 //
 
 class CastorJetIDProducer : public edm::stream::EDProducer<> {
-   public:
+public:
+  explicit CastorJetIDProducer(const edm::ParameterSet&);
+  ~CastorJetIDProducer() override;
 
-      explicit CastorJetIDProducer(const edm::ParameterSet&);
-      ~CastorJetIDProducer() override;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      
-      // ----------member data ---------------------------
-      edm::InputTag                 src_;          // input jet source
-      reco::helper::CastorJetIDHelper     helper_; // castor jet id helper algorithm
+  // ----------member data ---------------------------
+  edm::InputTag src_;                       // input jet source
+  reco::helper::CastorJetIDHelper helper_;  // castor jet id helper algorithm
 
-      edm::EDGetTokenT<edm::View<reco::BasicJet> > input_jet_token_;
+  edm::EDGetTokenT<edm::View<reco::BasicJet> > input_jet_token_;
 };
-
 
 #endif

--- a/RecoJets/JetProducers/plugins/CompoundJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CompoundJetProducer.cc
@@ -9,136 +9,118 @@ using namespace reco;
 using namespace edm;
 using namespace cms;
 
-CompoundJetProducer::CompoundJetProducer(edm::ParameterSet const& conf):
-  VirtualJetProducer( conf )
-{
-
+CompoundJetProducer::CompoundJetProducer(edm::ParameterSet const& conf) : VirtualJetProducer(conf) {
   produces<reco::BasicJetCollection>();
   // the subjet collections are set through the config file in the "jetCollInstanceName" field.
 }
 
-
-void CompoundJetProducer::inputTowers( ) 
-{
+void CompoundJetProducer::inputTowers() {
   fjCompoundJets_.clear();
   VirtualJetProducer::inputTowers();
 }
 
-void CompoundJetProducer::output(edm::Event & iEvent, edm::EventSetup const& iSetup)
-{
-  // Write jets and constitutents. Will use fjJets_. 
-  switch( jetTypeE ) {
-  case JetType::CaloJet :
-    writeCompoundJets<reco::CaloJet>( iEvent, iSetup );
-    break;
-  case JetType::PFJet :
-    writeCompoundJets<reco::PFJet>( iEvent, iSetup );
-    break;
-  case JetType::GenJet :
-    writeCompoundJets<reco::GenJet>( iEvent, iSetup );
-    break;
-  case JetType::BasicJet :
-    writeCompoundJets<reco::BasicJet>( iEvent, iSetup );
-    break;
-  default:
-    throw cms::Exception("InvalidInput") << "invalid jet type in CompoundJetProducer\n";
-    break;
+void CompoundJetProducer::output(edm::Event& iEvent, edm::EventSetup const& iSetup) {
+  // Write jets and constitutents. Will use fjJets_.
+  switch (jetTypeE) {
+    case JetType::CaloJet:
+      writeCompoundJets<reco::CaloJet>(iEvent, iSetup);
+      break;
+    case JetType::PFJet:
+      writeCompoundJets<reco::PFJet>(iEvent, iSetup);
+      break;
+    case JetType::GenJet:
+      writeCompoundJets<reco::GenJet>(iEvent, iSetup);
+      break;
+    case JetType::BasicJet:
+      writeCompoundJets<reco::BasicJet>(iEvent, iSetup);
+      break;
+    default:
+      throw cms::Exception("InvalidInput") << "invalid jet type in CompoundJetProducer\n";
+      break;
   };
-
 }
 
 /// function template to write out the outputs
-template< class T>
-void CompoundJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetup const& iSetup)
-{
-
+template <class T>
+void CompoundJetProducer::writeCompoundJets(edm::Event& iEvent, edm::EventSetup const& iSetup) {
   // get a list of output jets
   auto jetCollection = std::make_unique<reco::BasicJetCollection>();
   // get a list of output subjets
   auto subjetCollection = std::make_unique<std::vector<T>>();
 
   // This will store the handle for the subjets after we write them
-  edm::OrphanHandle< std::vector<T> > subjetHandleAfterPut;
+  edm::OrphanHandle<std::vector<T>> subjetHandleAfterPut;
   // this is the mapping of subjet to hard jet
-  std::vector< std::vector<int> > indices;
+  std::vector<std::vector<int>> indices;
   // this is the list of hardjet 4-momenta
   std::vector<math::XYZTLorentzVector> p4_hardJets;
   // this is the hardjet areas
   std::vector<double> area_hardJets;
 
-
   // Loop over the hard jets
-  std::vector<CompoundPseudoJet>::const_iterator it = fjCompoundJets_.begin(),
-    iEnd = fjCompoundJets_.end(),
-    iBegin = fjCompoundJets_.begin();
-  indices.resize( fjCompoundJets_.size() );
-  for ( ; it != iEnd; ++it ) {
+  std::vector<CompoundPseudoJet>::const_iterator it = fjCompoundJets_.begin(), iEnd = fjCompoundJets_.end(),
+                                                 iBegin = fjCompoundJets_.begin();
+  indices.resize(fjCompoundJets_.size());
+  for (; it != iEnd; ++it) {
     int jetIndex = it - iBegin;
     fastjet::PseudoJet localJet = it->hardJet();
     // Get the 4-vector for the hard jet
-    p4_hardJets.push_back( math::XYZTLorentzVector(localJet.px(), localJet.py(), localJet.pz(), localJet.e() ));
-    area_hardJets.push_back( it->hardJetArea() );
+    p4_hardJets.push_back(math::XYZTLorentzVector(localJet.px(), localJet.py(), localJet.pz(), localJet.e()));
+    area_hardJets.push_back(it->hardJetArea());
 
     // create the subjet list
-    std::vector<CompoundPseudoSubJet>::const_iterator itSubJetBegin = it->subjets().begin(),
-      itSubJet = itSubJetBegin, itSubJetEnd = it->subjets().end();
-    for (; itSubJet != itSubJetEnd; ++itSubJet ){
-
+    std::vector<CompoundPseudoSubJet>::const_iterator itSubJetBegin = it->subjets().begin(), itSubJet = itSubJetBegin,
+                                                      itSubJetEnd = it->subjets().end();
+    for (; itSubJet != itSubJetEnd; ++itSubJet) {
       fastjet::PseudoJet subjet = itSubJet->subjet();
-      math::XYZTLorentzVector p4Subjet(subjet.px(), subjet.py(), subjet.pz(), subjet.e() );
-      reco::Particle::Point point(0,0,0);
+      math::XYZTLorentzVector p4Subjet(subjet.px(), subjet.py(), subjet.pz(), subjet.e());
+      reco::Particle::Point point(0, 0, 0);
 
       // This will hold ptr's to the subjets
       std::vector<reco::CandidatePtr> subjetConstituents;
 
       // Get the transient subjet constituents from fastjet
-      std::vector<int> const & subjetFastjetConstituentIndices = itSubJet->constituents();
+      std::vector<int> const& subjetFastjetConstituentIndices = itSubJet->constituents();
       std::vector<int>::const_iterator fastSubIt = subjetFastjetConstituentIndices.begin(),
-	transConstEnd = subjetFastjetConstituentIndices.end();
-      for ( ; fastSubIt != transConstEnd; ++fastSubIt ) {
-	// Add a ptr to this constituent
-	if ( *fastSubIt < static_cast<int>(inputs_.size()) ) 
-	  subjetConstituents.push_back( inputs_[*fastSubIt] );
+                                       transConstEnd = subjetFastjetConstituentIndices.end();
+      for (; fastSubIt != transConstEnd; ++fastSubIt) {
+        // Add a ptr to this constituent
+        if (*fastSubIt < static_cast<int>(inputs_.size()))
+          subjetConstituents.push_back(inputs_[*fastSubIt]);
       }
 
       // This holds the subjet-to-hardjet mapping
-      indices[jetIndex].push_back( subjetCollection->size() );      
-
+      indices[jetIndex].push_back(subjetCollection->size());
 
       // Add the concrete subjet type to the subjet list to write to event record
       T jet;
-      reco::writeSpecific( jet, p4Subjet, point, subjetConstituents, iSetup);
-      jet.setJetArea( itSubJet->subjetArea() );
-      subjetCollection->push_back( jet );
-
+      reco::writeSpecific(jet, p4Subjet, point, subjetConstituents, iSetup);
+      jet.setJetArea(itSubJet->subjetArea());
+      subjetCollection->push_back(jet);
     }
   }
   // put subjets into event record
   subjetHandleAfterPut = iEvent.put(std::move(subjetCollection), jetCollInstanceName_);
-  
-  
-  // Now create the hard jets with ptr's to the subjets as constituents
-  std::vector<math::XYZTLorentzVector>::const_iterator ip4 = p4_hardJets.begin(),
-    ip4Begin = p4_hardJets.begin(),
-    ip4End = p4_hardJets.end();
 
-  for ( ; ip4 != ip4End; ++ip4 ) {
+  // Now create the hard jets with ptr's to the subjets as constituents
+  std::vector<math::XYZTLorentzVector>::const_iterator ip4 = p4_hardJets.begin(), ip4Begin = p4_hardJets.begin(),
+                                                       ip4End = p4_hardJets.end();
+
+  for (; ip4 != ip4End; ++ip4) {
     int p4_index = ip4 - ip4Begin;
-    std::vector<int> & ind = indices[p4_index];
+    std::vector<int>& ind = indices[p4_index];
     std::vector<reco::CandidatePtr> i_hardJetConstituents;
     // Add the subjets to the hard jet
-    for( std::vector<int>::const_iterator isub = ind.begin();
-	 isub != ind.end(); ++isub ) {
-      reco::CandidatePtr candPtr( subjetHandleAfterPut, *isub, false );
-      i_hardJetConstituents.push_back( candPtr );
-    }   
-    reco::Particle::Point point(0,0,0);
-    reco::BasicJet toput( *ip4, point, i_hardJetConstituents);
-    toput.setJetArea( area_hardJets[ip4 - ip4Begin] );
-    jetCollection->push_back( toput );
+    for (std::vector<int>::const_iterator isub = ind.begin(); isub != ind.end(); ++isub) {
+      reco::CandidatePtr candPtr(subjetHandleAfterPut, *isub, false);
+      i_hardJetConstituents.push_back(candPtr);
+    }
+    reco::Particle::Point point(0, 0, 0);
+    reco::BasicJet toput(*ip4, point, i_hardJetConstituents);
+    toput.setJetArea(area_hardJets[ip4 - ip4Begin]);
+    jetCollection->push_back(toput);
   }
-  
+
   // put hard jets into event record
   iEvent.put(std::move(jetCollection));
-
 }

--- a/RecoJets/JetProducers/plugins/CompoundJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CompoundJetProducer.h
@@ -31,43 +31,32 @@ Modifications:
 
  ************************************************************/
 
-
 #include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
 
 #include "RecoJets/JetAlgorithms/interface/CompoundPseudoJet.h"
 
-namespace cms
-{
-  class CompoundJetProducer : public VirtualJetProducer
-  {
+namespace cms {
+  class CompoundJetProducer : public VirtualJetProducer {
   public:
-
     CompoundJetProducer(const edm::ParameterSet& ps);
 
     ~CompoundJetProducer() override {}
-    
-  protected:
-    std::vector<CompoundPseudoJet> fjCompoundJets_; /// compound fastjet::PseudoJets
 
   protected:
+    std::vector<CompoundPseudoJet> fjCompoundJets_;  /// compound fastjet::PseudoJets
 
-    // overridden inputTowers method. Resets fjCompoundJets_ and 
+  protected:
+    // overridden inputTowers method. Resets fjCompoundJets_ and
     // calls VirtualJetProducer::inputTowers
     void inputTowers() override;
 
     /// Overridden output method. For the compound jet producer, this will
-    /// call the "writeCompoundJets" function template. 
-    void output( edm::Event & iEvent, edm::EventSetup const& iSetup ) override;
-    template< typename T >
-    void writeCompoundJets( edm::Event & iEvent, edm::EventSetup const& iSetup);
-
-
+    /// call the "writeCompoundJets" function template.
+    void output(edm::Event& iEvent, edm::EventSetup const& iSetup) override;
+    template <typename T>
+    void writeCompoundJets(edm::Event& iEvent, edm::EventSetup const& iSetup);
   };
 
-
-
-  
-}
-
+}  // namespace cms
 
 #endif

--- a/RecoJets/JetProducers/plugins/ECFAdder.cc
+++ b/RecoJets/JetProducers/plugins/ECFAdder.cc
@@ -6,145 +6,123 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-ECFAdder::ECFAdder(const edm::ParameterSet& iConfig) :
-  src_(iConfig.getParameter<edm::InputTag>("src")),
-  src_token_(consumes<edm::View<reco::Jet>>(src_)),
-  Njets_(iConfig.getParameter<std::vector<unsigned> >("Njets")),
-  cuts_(iConfig.getParameter<std::vector<std::string>>("cuts")),
-  ecftype_(iConfig.getParameter<std::string>("ecftype")),
-  alpha_(iConfig.getParameter<double>("alpha")),
-  beta_(iConfig.getParameter<double>("beta"))
-{
-
-  if ( cuts_.size() != Njets_.size() ) {
+ECFAdder::ECFAdder(const edm::ParameterSet& iConfig)
+    : src_(iConfig.getParameter<edm::InputTag>("src")),
+      src_token_(consumes<edm::View<reco::Jet>>(src_)),
+      Njets_(iConfig.getParameter<std::vector<unsigned>>("Njets")),
+      cuts_(iConfig.getParameter<std::vector<std::string>>("cuts")),
+      ecftype_(iConfig.getParameter<std::string>("ecftype")),
+      alpha_(iConfig.getParameter<double>("alpha")),
+      beta_(iConfig.getParameter<double>("beta")) {
+  if (cuts_.size() != Njets_.size()) {
     throw cms::Exception("ConfigurationError") << "cuts and Njets must be the same size in ECFAdder" << std::endl;
   }
 
-    for ( std::vector<unsigned>::const_iterator n = Njets_.begin(); n != Njets_.end(); ++n )
-      {
-	std::ostringstream ecfN_str;
-	std::shared_ptr<fastjet::FunctionOfPseudoJet<double> > pfunc;
+  for (std::vector<unsigned>::const_iterator n = Njets_.begin(); n != Njets_.end(); ++n) {
+    std::ostringstream ecfN_str;
+    std::shared_ptr<fastjet::FunctionOfPseudoJet<double>> pfunc;
 
-	if ( ecftype_ == "ECF" || ecftype_.empty() ) {
-	  ecfN_str << "ecf" << *n;
-	  pfunc.reset( new fastjet::contrib::EnergyCorrelator( *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R ) );
-	}
-	else if ( ecftype_ == "C" ) {
-	  ecfN_str << "ecfC" << *n;
-	  pfunc.reset( new fastjet::contrib::EnergyCorrelatorCseries( *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R ) );
-	}
-	else if ( ecftype_ == "D" ) {
-	  ecfN_str << "ecfD" << *n;
-	  pfunc.reset( new fastjet::contrib::EnergyCorrelatorGeneralizedD2( alpha_, beta_, fastjet::contrib::EnergyCorrelator::pt_R ) );
-	}
-	else if ( ecftype_ == "N" ) {
-	  ecfN_str << "ecfN" << *n;
-	  pfunc.reset( new fastjet::contrib::EnergyCorrelatorNseries( *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R ) );
-	}
-	else if ( ecftype_ == "M" ) {
-	  ecfN_str << "ecfM" << *n;
-	  pfunc.reset( new fastjet::contrib::EnergyCorrelatorMseries( *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R ) );
-	}
-	else if ( ecftype_ == "U" ) {
-	  ecfN_str << "ecfU" << *n;
-	  pfunc.reset( new fastjet::contrib::EnergyCorrelatorUseries( *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R ) );
-	}
-	variables_.push_back(ecfN_str.str());
-	produces<edm::ValueMap<float> >(ecfN_str.str());
-	routine_.push_back(pfunc);
+    if (ecftype_ == "ECF" || ecftype_.empty()) {
+      ecfN_str << "ecf" << *n;
+      pfunc.reset(new fastjet::contrib::EnergyCorrelator(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+    } else if (ecftype_ == "C") {
+      ecfN_str << "ecfC" << *n;
+      pfunc.reset(new fastjet::contrib::EnergyCorrelatorCseries(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+    } else if (ecftype_ == "D") {
+      ecfN_str << "ecfD" << *n;
+      pfunc.reset(
+          new fastjet::contrib::EnergyCorrelatorGeneralizedD2(alpha_, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+    } else if (ecftype_ == "N") {
+      ecfN_str << "ecfN" << *n;
+      pfunc.reset(new fastjet::contrib::EnergyCorrelatorNseries(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+    } else if (ecftype_ == "M") {
+      ecfN_str << "ecfM" << *n;
+      pfunc.reset(new fastjet::contrib::EnergyCorrelatorMseries(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+    } else if (ecftype_ == "U") {
+      ecfN_str << "ecfU" << *n;
+      pfunc.reset(new fastjet::contrib::EnergyCorrelatorUseries(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+    }
+    variables_.push_back(ecfN_str.str());
+    produces<edm::ValueMap<float>>(ecfN_str.str());
+    routine_.push_back(pfunc);
 
-
-	
-	selectors_.push_back( StringCutObjectSelector<reco::Jet>( cuts_[ n - Njets_.begin()] ) );
-      }
-
-
-
+    selectors_.push_back(StringCutObjectSelector<reco::Jet>(cuts_[n - Njets_.begin()]));
+  }
 }
 
-void ECFAdder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+void ECFAdder::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // read input collection
-  edm::Handle<edm::View<reco::Jet> > jets;
+  edm::Handle<edm::View<reco::Jet>> jets;
   iEvent.getByToken(src_token_, jets);
-  
-  unsigned i=0;
-  for ( std::vector<unsigned>::const_iterator n = Njets_.begin(); n != Njets_.end(); ++n )
-    {
-      // prepare room for output
-      std::vector<float> ecfN;
-      ecfN.reserve(jets->size());
 
-      for ( typename edm::View<reco::Jet>::const_iterator jetIt = jets->begin() ; jetIt != jets->end() ; ++jetIt ) {
+  unsigned i = 0;
+  for (std::vector<unsigned>::const_iterator n = Njets_.begin(); n != Njets_.end(); ++n) {
+    // prepare room for output
+    std::vector<float> ecfN;
+    ecfN.reserve(jets->size());
 
-	edm::Ptr<reco::Jet> jetPtr = jets->ptrAt(jetIt - jets->begin());
+    for (typename edm::View<reco::Jet>::const_iterator jetIt = jets->begin(); jetIt != jets->end(); ++jetIt) {
+      edm::Ptr<reco::Jet> jetPtr = jets->ptrAt(jetIt - jets->begin());
 
-	
-	float t= -1.0;
-	if ( selectors_[n - Njets_.begin()] (*jetIt) )
-	  t = getECF( i, jetPtr );	
+      float t = -1.0;
+      if (selectors_[n - Njets_.begin()](*jetIt))
+        t = getECF(i, jetPtr);
 
-	ecfN.push_back(t);
-      }
-
-      auto outT = std::make_unique<edm::ValueMap<float>>();
-      edm::ValueMap<float>::Filler fillerT(*outT);
-      fillerT.insert(jets, ecfN.begin(), ecfN.end());
-      fillerT.fill();
-
-      iEvent.put(std::move(outT),variables_[i]);
-      ++i;
+      ecfN.push_back(t);
     }
+
+    auto outT = std::make_unique<edm::ValueMap<float>>();
+    edm::ValueMap<float>::Filler fillerT(*outT);
+    fillerT.insert(jets, ecfN.begin(), ecfN.end());
+    fillerT.fill();
+
+    iEvent.put(std::move(outT), variables_[i]);
+    ++i;
+  }
 }
 
-float ECFAdder::getECF(unsigned index, const edm::Ptr<reco::Jet> & object) const
-{
+float ECFAdder::getECF(unsigned index, const edm::Ptr<reco::Jet>& object) const {
   std::vector<fastjet::PseudoJet> FJparticles;
-  for (unsigned k = 0; k < object->numberOfDaughters(); ++k)
-    {
-      const reco::CandidatePtr & dp = object->daughterPtr(k);
-      if ( dp.isNonnull() && dp.isAvailable() ){
-
-	// Here, the daughters are the "end" node, so this is a PFJet
-	if ( dp->numberOfDaughters() == 0 ) {
-	  FJparticles.push_back( fastjet::PseudoJet( dp->px(), dp->py(), dp->pz(), dp->energy() ) );
-	} else { // Otherwise, this is a BasicJet, so you need to descend further.
-	  auto subjet = dynamic_cast<reco::Jet const * >( dp.get() );
-	  for ( unsigned l = 0; l < subjet->numberOfDaughters(); ++l ) {
-	    if ( subjet != nullptr ) {
-	      const reco::CandidatePtr & ddp = subjet->daughterPtr(l);
-	      FJparticles.push_back( fastjet::PseudoJet( ddp->px(), ddp->py(), ddp->pz(), ddp->energy() ) );	      
-	    } else {
-	      edm::LogWarning("MissingJetConstituent") << "BasicJet constituent required for ECF computation is missing!";
-	    }
-	  }
-	} // end if basic jet
-      } // end if daughter pointer is nonnull and available
-      else
-	edm::LogWarning("MissingJetConstituent") << "Jet constituent required for ECF computation is missing!";
-    }
-  if ( FJparticles.size() > Njets_[index] )
-    {
-      return routine_[index]->result(join(FJparticles));
-    }
-  else
-    {
-      return -1.0;
-    }
+  for (unsigned k = 0; k < object->numberOfDaughters(); ++k) {
+    const reco::CandidatePtr& dp = object->daughterPtr(k);
+    if (dp.isNonnull() && dp.isAvailable()) {
+      // Here, the daughters are the "end" node, so this is a PFJet
+      if (dp->numberOfDaughters() == 0) {
+        FJparticles.push_back(fastjet::PseudoJet(dp->px(), dp->py(), dp->pz(), dp->energy()));
+      } else {  // Otherwise, this is a BasicJet, so you need to descend further.
+        auto subjet = dynamic_cast<reco::Jet const*>(dp.get());
+        for (unsigned l = 0; l < subjet->numberOfDaughters(); ++l) {
+          if (subjet != nullptr) {
+            const reco::CandidatePtr& ddp = subjet->daughterPtr(l);
+            FJparticles.push_back(fastjet::PseudoJet(ddp->px(), ddp->py(), ddp->pz(), ddp->energy()));
+          } else {
+            edm::LogWarning("MissingJetConstituent") << "BasicJet constituent required for ECF computation is missing!";
+          }
+        }
+      }  // end if basic jet
+    }    // end if daughter pointer is nonnull and available
+    else
+      edm::LogWarning("MissingJetConstituent") << "Jet constituent required for ECF computation is missing!";
+  }
+  if (FJparticles.size() > Njets_[index]) {
+    return routine_[index]->result(join(FJparticles));
+  } else {
+    return -1.0;
+  }
 }
-
 
 // ParameterSet description for module
-void ECFAdder::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void ECFAdder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription iDesc;
   iDesc.setComment("Energy Correlation Functions adder");
 
   iDesc.add<edm::InputTag>("src", edm::InputTag("no default"))->setComment("input collection");
-  iDesc.add<std::vector<unsigned> >("Njets", {1,2,3} )->setComment("Number of jets to emulate");
-  iDesc.add<std::vector<std::string>> ("cuts", {"", "", ""})->setComment("Jet selections for each N value. Size must match Njets.");
-  iDesc.add<double>("alpha",1.0)->setComment("alpha factor, only valid for N2");
-  iDesc.add<double>("beta",1.0)->setComment("angularity factor");
-  iDesc.add<std::string>("ecftype","")->setComment("ECF type: ECF or empty; C; D; N; M; U;");
+  iDesc.add<std::vector<unsigned>>("Njets", {1, 2, 3})->setComment("Number of jets to emulate");
+  iDesc.add<std::vector<std::string>>("cuts", {"", "", ""})
+      ->setComment("Jet selections for each N value. Size must match Njets.");
+  iDesc.add<double>("alpha", 1.0)->setComment("alpha factor, only valid for N2");
+  iDesc.add<double>("beta", 1.0)->setComment("angularity factor");
+  iDesc.add<std::string>("ecftype", "")->setComment("ECF type: ECF or empty; C; D; N; M; U;");
   descriptions.add("ECFAdder", iDesc);
 }
 

--- a/RecoJets/JetProducers/plugins/ECFAdder.cc
+++ b/RecoJets/JetProducers/plugins/ECFAdder.cc
@@ -25,7 +25,7 @@ ECFAdder::ECFAdder(const edm::ParameterSet& iConfig) :
 	std::ostringstream ecfN_str;
 	std::shared_ptr<fastjet::FunctionOfPseudoJet<double> > pfunc;
 
-	if ( ecftype_ == "ECF" || ecftype_ == "" ) {
+	if ( ecftype_ == "ECF" || ecftype_.empty() ) {
 	  ecfN_str << "ecf" << *n;
 	  pfunc.reset( new fastjet::contrib::EnergyCorrelator( *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R ) );
 	}

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -52,143 +52,136 @@
 using namespace std;
 using namespace edm;
 
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // construction / destruction
 ////////////////////////////////////////////////////////////////////////////////
 
 //______________________________________________________________________________
-FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig):
-	VirtualJetProducer( iConfig )
-{
-	useOnlyVertexTracks_ = iConfig.getParameter<bool>("UseOnlyVertexTracks");
-	useOnlyOnePV_ 	= iConfig.getParameter<bool>("UseOnlyOnePV");
-	dzTrVtxMax_          = iConfig.getParameter<double>("DzTrVtxMax");
-	dxyTrVtxMax_          = iConfig.getParameter<double>("DxyTrVtxMax");
-	minVtxNdof_ = iConfig.getParameter<int>("MinVtxNdof");
-	maxVtxZ_ = iConfig.getParameter<double>("MaxVtxZ");
+FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig) : VirtualJetProducer(iConfig) {
+  useOnlyVertexTracks_ = iConfig.getParameter<bool>("UseOnlyVertexTracks");
+  useOnlyOnePV_ = iConfig.getParameter<bool>("UseOnlyOnePV");
+  dzTrVtxMax_ = iConfig.getParameter<double>("DzTrVtxMax");
+  dxyTrVtxMax_ = iConfig.getParameter<double>("DxyTrVtxMax");
+  minVtxNdof_ = iConfig.getParameter<int>("MinVtxNdof");
+  maxVtxZ_ = iConfig.getParameter<double>("MaxVtxZ");
 
-	useMassDropTagger_ = iConfig.getParameter<bool>("useMassDropTagger");
-	muCut_ = iConfig.getParameter<double>("muCut");
-	yCut_ = iConfig.getParameter<double>("yCut");
+  useMassDropTagger_ = iConfig.getParameter<bool>("useMassDropTagger");
+  muCut_ = iConfig.getParameter<double>("muCut");
+  yCut_ = iConfig.getParameter<double>("yCut");
 
-	useFiltering_ = iConfig.getParameter<bool>("useFiltering");
-	rFilt_ = iConfig.getParameter<double>("rFilt");
-	nFilt_ = iConfig.getParameter<int>("nFilt");
-	useDynamicFiltering_ = iConfig.getParameter<bool>("useDynamicFiltering");
-        if ( useDynamicFiltering_ ) rFiltDynamic_ = DynamicRfiltPtr(new DynamicRfilt(rFilt_, rFiltFactor_));
-	rFiltFactor_ = iConfig.getParameter<double>("rFiltFactor");
+  useFiltering_ = iConfig.getParameter<bool>("useFiltering");
+  rFilt_ = iConfig.getParameter<double>("rFilt");
+  nFilt_ = iConfig.getParameter<int>("nFilt");
+  useDynamicFiltering_ = iConfig.getParameter<bool>("useDynamicFiltering");
+  if (useDynamicFiltering_)
+    rFiltDynamic_ = DynamicRfiltPtr(new DynamicRfilt(rFilt_, rFiltFactor_));
+  rFiltFactor_ = iConfig.getParameter<double>("rFiltFactor");
 
-	useTrimming_ = iConfig.getParameter<bool>("useTrimming");
-	trimPtFracMin_ = iConfig.getParameter<double>("trimPtFracMin");
+  useTrimming_ = iConfig.getParameter<bool>("useTrimming");
+  trimPtFracMin_ = iConfig.getParameter<double>("trimPtFracMin");
 
-	usePruning_ = iConfig.getParameter<bool>("usePruning");
-	zCut_ = iConfig.getParameter<double>("zcut");
-	RcutFactor_ = iConfig.getParameter<double>("rcut_factor");
-	nFilt_ = iConfig.getParameter<int>("nFilt");
-	useKtPruning_ = iConfig.getParameter<bool>("useKtPruning");
+  usePruning_ = iConfig.getParameter<bool>("usePruning");
+  zCut_ = iConfig.getParameter<double>("zcut");
+  RcutFactor_ = iConfig.getParameter<double>("rcut_factor");
+  nFilt_ = iConfig.getParameter<int>("nFilt");
+  useKtPruning_ = iConfig.getParameter<bool>("useKtPruning");
 
-	useCMSBoostedTauSeedingAlgorithm_ = iConfig.getParameter<bool>("useCMSBoostedTauSeedingAlgorithm");
-	subjetPtMin_ = iConfig.getParameter<double>("subjetPtMin");
-	muMin_ = iConfig.getParameter<double>("muMin");
-	muMax_ = iConfig.getParameter<double>("muMax");
-	yMin_ = iConfig.getParameter<double>("yMin");
-	yMax_ = iConfig.getParameter<double>("yMax");
-	dRMin_ = iConfig.getParameter<double>("dRMin");
-	dRMax_ = iConfig.getParameter<double>("dRMax");
-	maxDepth_ = iConfig.getParameter<int>("maxDepth");
+  useCMSBoostedTauSeedingAlgorithm_ = iConfig.getParameter<bool>("useCMSBoostedTauSeedingAlgorithm");
+  subjetPtMin_ = iConfig.getParameter<double>("subjetPtMin");
+  muMin_ = iConfig.getParameter<double>("muMin");
+  muMax_ = iConfig.getParameter<double>("muMax");
+  yMin_ = iConfig.getParameter<double>("yMin");
+  yMax_ = iConfig.getParameter<double>("yMax");
+  dRMin_ = iConfig.getParameter<double>("dRMin");
+  dRMax_ = iConfig.getParameter<double>("dRMax");
+  maxDepth_ = iConfig.getParameter<int>("maxDepth");
 
+  useConstituentSubtraction_ = iConfig.getParameter<bool>("useConstituentSubtraction");
+  csRho_EtaMax_ = iConfig.getParameter<double>("csRho_EtaMax");
+  csRParam_ = iConfig.getParameter<double>("csRParam");
 
-	useConstituentSubtraction_ = iConfig.getParameter<bool>("useConstituentSubtraction");
-	csRho_EtaMax_ = iConfig.getParameter<double>("csRho_EtaMax");
-	csRParam_ = iConfig.getParameter<double>("csRParam");
+  useSoftDrop_ = iConfig.getParameter<bool>("useSoftDrop");
+  zCut_ = iConfig.getParameter<double>("zcut");
+  beta_ = iConfig.getParameter<double>("beta");
+  R0_ = iConfig.getParameter<double>("R0");
 
-	useSoftDrop_ = iConfig.getParameter<bool>("useSoftDrop");
-	zCut_ = iConfig.getParameter<double>("zcut");
-	beta_ = iConfig.getParameter<double>("beta");
-	R0_ = iConfig.getParameter<double>("R0");
+  correctShape_ = iConfig.getParameter<bool>("correctShape");
+  gridMaxRapidity_ = iConfig.getParameter<double>("gridMaxRapidity");
+  gridSpacing_ = iConfig.getParameter<double>("gridSpacing");
 
-	correctShape_ = iConfig.getParameter<bool>("correctShape");
-	gridMaxRapidity_ = iConfig.getParameter<double>("gridMaxRapidity");
-	gridSpacing_ = iConfig.getParameter<double>("gridSpacing");
+  input_chrefcand_token_ =
+      consumes<edm::View<reco::RecoChargedRefCandidate>>(iConfig.getParameter<edm::InputTag>("src"));
 
-	input_chrefcand_token_ = consumes<edm::View<reco::RecoChargedRefCandidate> >(iConfig.getParameter<edm::InputTag>("src"));
+  if (useFiltering_ || useTrimming_ || usePruning_ || useMassDropTagger_ || useCMSBoostedTauSeedingAlgorithm_ ||
+      useConstituentSubtraction_ || useSoftDrop_ || correctShape_)
+    useExplicitGhosts_ = true;
 
-	if ( useFiltering_ ||
-			useTrimming_ ||
-			usePruning_ ||
-			useMassDropTagger_ ||
-			useCMSBoostedTauSeedingAlgorithm_ ||
-			useConstituentSubtraction_ ||
-			useSoftDrop_ ||
-			correctShape_
-	   ) useExplicitGhosts_ = true;
+  ////// adding exceptions
 
-	////// adding exceptions
-	
-	if ( ( useMassDropTagger_ ) && ( ( muCut_ == -1 ) || ( yCut_ == -1 ) ) ) 
-		throw cms::Exception("useMassDropTagger") << "Parameters muCut and/or yCut for Mass Drop are not defined." << std::endl;
-	
-	if ( ( useFiltering_ ) && ( ( rFilt_ == -1 ) || ( nFilt_ == -1 ) ) ) {
-		throw cms::Exception("useFiltering") << "Parameters rFilt and/or nFilt for Filtering are not defined." << std::endl;
-		if ( ( useDynamicFiltering_ ) && ( rFiltFactor_ == -1 ) ) 
-			throw cms::Exception("useDynamicFiltering") << "Parameters rFiltFactor for DynamicFiltering is not defined." << std::endl;
-	}
+  if ((useMassDropTagger_) && ((muCut_ == -1) || (yCut_ == -1)))
+    throw cms::Exception("useMassDropTagger")
+        << "Parameters muCut and/or yCut for Mass Drop are not defined." << std::endl;
 
-	if ( ( useTrimming_ ) && ( ( rFilt_ == -1 ) || ( trimPtFracMin_ == -1 ) ) ) 
-		throw cms::Exception("useTrimming") << "Parameters rFilt and/or trimPtFracMin for Trimming are not defined." << std::endl;
-	
-	if ( ( usePruning_ ) && ( ( zCut_ == -1 ) || ( RcutFactor_ == -1 )  || ( nFilt_ == -1 )) ) 
-		throw cms::Exception("usePruning") << "Parameters zCut and/or RcutFactor and/or nFilt for Pruning are not defined." << std::endl;
-	
-	if ( ( useCMSBoostedTauSeedingAlgorithm_ ) && ( ( subjetPtMin_ == -1 ) || ( maxDepth_ == -1 ) ||
-				( muMin_ == -1 )  || ( muMax_ == -1 ) ||
-				( yMin_ == -1 )  || ( yMax_ == -1 ) ||
-				( dRMin_ == -1 )  || ( dRMax_ == -1 ) ) )
-		throw cms::Exception("useCMSBoostedTauSeedingAlgorithm") << "Parameters subjetPtMin, muMin, muMax, yMin, yMax, dRmin, dRmax, maxDepth for CMSBoostedTauSeedingAlgorithm are not defined." << std::endl;
+  if ((useFiltering_) && ((rFilt_ == -1) || (nFilt_ == -1))) {
+    throw cms::Exception("useFiltering") << "Parameters rFilt and/or nFilt for Filtering are not defined." << std::endl;
+    if ((useDynamicFiltering_) && (rFiltFactor_ == -1))
+      throw cms::Exception("useDynamicFiltering")
+          << "Parameters rFiltFactor for DynamicFiltering is not defined." << std::endl;
+  }
 
-	if ( useConstituentSubtraction_ && ( fjAreaDefinition_.get() == nullptr ) ) 
-		throw cms::Exception("AreaMustBeSet") << "Logic error. The area definition must be set if you use constituent subtraction." << std::endl;
+  if ((useTrimming_) && ((rFilt_ == -1) || (trimPtFracMin_ == -1)))
+    throw cms::Exception("useTrimming") << "Parameters rFilt and/or trimPtFracMin for Trimming are not defined."
+                                        << std::endl;
 
-	if ( ( useConstituentSubtraction_ ) && ( ( csRho_EtaMax_ == -1 ) || ( csRParam_ == -1 ) ) ) 
-		throw cms::Exception("useConstituentSubtraction") << "Parameters csRho_EtaMax and/or csRParam for ConstituentSubtraction are not defined." << std::endl;
-	
-	if ( useSoftDrop_ && usePruning_ ) 
-		throw cms::Exception("PruningAndSoftDrop") << "Logic error. Soft drop is a generalized pruning, do not run them together." << std::endl;  
+  if ((usePruning_) && ((zCut_ == -1) || (RcutFactor_ == -1) || (nFilt_ == -1)))
+    throw cms::Exception("usePruning") << "Parameters zCut and/or RcutFactor and/or nFilt for Pruning are not defined."
+                                       << std::endl;
 
-	if ( ( useSoftDrop_ ) && ( ( zCut_ == -1 ) || ( beta_ == -1 )  || ( R0_ == -1 )) ) 
-		throw cms::Exception("useSoftDrop") << "Parameters zCut and/or beta and/or R0 for SoftDrop are not defined." << std::endl;
-	
-	if ( ( correctShape_ ) && ( ( gridMaxRapidity_ == -1 ) || ( gridSpacing_ == -1 )) ) 
-		throw cms::Exception("correctShape") << "Parameters gridMaxRapidity and/or gridSpacing for SoftDrop are not defined." << std::endl;
-  
+  if ((useCMSBoostedTauSeedingAlgorithm_) &&
+      ((subjetPtMin_ == -1) || (maxDepth_ == -1) || (muMin_ == -1) || (muMax_ == -1) || (yMin_ == -1) ||
+       (yMax_ == -1) || (dRMin_ == -1) || (dRMax_ == -1)))
+    throw cms::Exception("useCMSBoostedTauSeedingAlgorithm")
+        << "Parameters subjetPtMin, muMin, muMax, yMin, yMax, dRmin, dRmax, maxDepth for CMSBoostedTauSeedingAlgorithm "
+           "are not defined."
+        << std::endl;
+
+  if (useConstituentSubtraction_ && (fjAreaDefinition_.get() == nullptr))
+    throw cms::Exception("AreaMustBeSet")
+        << "Logic error. The area definition must be set if you use constituent subtraction." << std::endl;
+
+  if ((useConstituentSubtraction_) && ((csRho_EtaMax_ == -1) || (csRParam_ == -1)))
+    throw cms::Exception("useConstituentSubtraction")
+        << "Parameters csRho_EtaMax and/or csRParam for ConstituentSubtraction are not defined." << std::endl;
+
+  if (useSoftDrop_ && usePruning_)
+    throw cms::Exception("PruningAndSoftDrop")
+        << "Logic error. Soft drop is a generalized pruning, do not run them together." << std::endl;
+
+  if ((useSoftDrop_) && ((zCut_ == -1) || (beta_ == -1) || (R0_ == -1)))
+    throw cms::Exception("useSoftDrop") << "Parameters zCut and/or beta and/or R0 for SoftDrop are not defined."
+                                        << std::endl;
+
+  if ((correctShape_) && ((gridMaxRapidity_ == -1) || (gridSpacing_ == -1)))
+    throw cms::Exception("correctShape")
+        << "Parameters gridMaxRapidity and/or gridSpacing for SoftDrop are not defined." << std::endl;
 }
 
-
 //______________________________________________________________________________
-FastjetJetProducer::~FastjetJetProducer()
-{
-} 
-
+FastjetJetProducer::~FastjetJetProducer() {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-void FastjetJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & iSetup )
-{
-
+void FastjetJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // for everything but track jets
   if (!makeTrackJet(jetTypeE)) {
- 
-     // use the default production from one collection
-     VirtualJetProducer::produce( iEvent, iSetup );
+    // use the default production from one collection
+    VirtualJetProducer::produce(iEvent, iSetup);
 
-  } else { // produce trackjets from tracks grouped per primary vertex
+  } else {  // produce trackjets from tracks grouped per primary vertex
 
     produceTrackJets(iEvent, iSetup);
-  
   }
 
   // fjClusterSeq_ retains quite a lot of memory - about 1 to 7Mb at 200 pileup
@@ -198,140 +191,149 @@ void FastjetJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & i
   fjClusterSeq_.reset();
 }
 
+void FastjetJetProducer::produceTrackJets(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // read in the track candidates
+  edm::Handle<edm::View<reco::RecoChargedRefCandidate>> inputsHandle;
+  iEvent.getByToken(input_chrefcand_token_, inputsHandle);
 
-void FastjetJetProducer::produceTrackJets( edm::Event & iEvent, const edm::EventSetup & iSetup )
-{
+  // make collection with pointers so we can play around with it
+  std::vector<edm::Ptr<reco::RecoChargedRefCandidate>> allInputs;
+  std::vector<edm::Ptr<reco::Candidate>> origInputs;
+  for (size_t i = 0; i < inputsHandle->size(); ++i) {
+    allInputs.push_back(inputsHandle->ptrAt(i));
+    origInputs.push_back(inputsHandle->ptrAt(i));
+  }
 
-    // read in the track candidates
-  edm::Handle<edm::View<reco::RecoChargedRefCandidate> > inputsHandle;
-    iEvent.getByToken(input_chrefcand_token_, inputsHandle);
+  // read in the PV collection
+  edm::Handle<reco::VertexCollection> pvCollection;
+  iEvent.getByToken(input_vertex_token_, pvCollection);
+  // define the overall output jet container
+  auto jets = std::make_unique<std::vector<reco::TrackJet>>();
 
-    // make collection with pointers so we can play around with it
-    std::vector<edm::Ptr<reco::RecoChargedRefCandidate> > allInputs;
-    std::vector<edm::Ptr<reco::Candidate> > origInputs;
-    for (size_t i = 0; i < inputsHandle->size(); ++i) {
-      allInputs.push_back(inputsHandle->ptrAt(i));
-      origInputs.push_back(inputsHandle->ptrAt(i));
+  // loop over the good vertices, clustering for each vertex separately
+  for (reco::VertexCollection::const_iterator itVtx = pvCollection->begin(); itVtx != pvCollection->end(); ++itVtx) {
+    if (itVtx->isFake() || itVtx->ndof() < minVtxNdof_ || fabs(itVtx->z()) > maxVtxZ_)
+      continue;
+
+    // clear the intermediate containers
+    inputs_.clear();
+    fjInputs_.clear();
+    fjJets_.clear();
+
+    // if only vertex-associated tracks should be used
+    if (useOnlyVertexTracks_) {
+      // loop over the tracks associated to the vertex
+      for (reco::Vertex::trackRef_iterator itTr = itVtx->tracks_begin(); itTr != itVtx->tracks_end(); ++itTr) {
+        // whether a match was found in the track candidate input
+        bool found = false;
+        // loop over input track candidates
+        for (std::vector<edm::Ptr<reco::RecoChargedRefCandidate>>::iterator itIn = allInputs.begin();
+             itIn != allInputs.end();
+             ++itIn) {
+          // match the input track candidate to the track from the vertex
+          reco::TrackRef trref(itTr->castTo<reco::TrackRef>());
+          // check if the tracks match
+          if ((*itIn)->track() == trref) {
+            found = true;
+            // add this track candidate to the input for clustering
+            inputs_.push_back(*itIn);
+            // erase the track candidate from the total list of input, so we don't reuse it later
+            allInputs.erase(itIn);
+            // found the candidate track corresponding to the vertex track, so stop the loop
+            break;
+          }  // end if match found
+        }    // end loop over input tracks
+        // give an info message in case no match is found (can happen if candidates are subset of tracks used for clustering)
+        if (!found)
+          edm::LogInfo("FastjetTrackJetProducer")
+              << "Ignoring a track at vertex which is not in input track collection!";
+      }  // end loop over tracks associated to vertex
+      // if all inpt track candidates should be used
+    } else {
+      // loop over input track candidates
+      for (std::vector<edm::Ptr<reco::RecoChargedRefCandidate>>::iterator itIn = allInputs.begin();
+           itIn != allInputs.end();
+           ++itIn) {
+        // check if the track is close enough to the vertex
+        float dz = (*itIn)->track()->dz(itVtx->position());
+        float dxy = (*itIn)->track()->dxy(itVtx->position());
+        if (fabs(dz) > dzTrVtxMax_)
+          continue;
+        if (fabs(dxy) > dxyTrVtxMax_)
+          continue;
+        bool closervtx = false;
+        // now loop over the good vertices a second time
+        for (reco::VertexCollection::const_iterator itVtx2 = pvCollection->begin(); itVtx2 != pvCollection->end();
+             ++itVtx2) {
+          if (itVtx->isFake() || itVtx->ndof() < minVtxNdof_ || fabs(itVtx->z()) > maxVtxZ_)
+            continue;
+          // and check this track is closer to any other vertex (if more than 1 vertex considered)
+          if (!useOnlyOnePV_ && itVtx != itVtx2 && fabs((*itIn)->track()->dz(itVtx2->position())) < fabs(dz)) {
+            closervtx = true;
+            break;  // 1 closer vertex makes the track already not matched, so break
+          }
+        }
+        // don't add this track if another vertex is found closer
+        if (closervtx)
+          continue;
+        // add this track candidate to the input for clustering
+        inputs_.push_back(*itIn);
+        // erase the track candidate from the total list of input, so we don't reuse it later
+        allInputs.erase(itIn);
+        // take a step back in the loop since we just erased
+        --itIn;
+      }
     }
 
-    // read in the PV collection
-    edm::Handle<reco::VertexCollection> pvCollection;
-    iEvent.getByToken(input_vertex_token_, pvCollection);
-    // define the overall output jet container
-    auto jets = std::make_unique<std::vector<reco::TrackJet>>();
+    // convert candidates in inputs_ to fastjet::PseudoJets in fjInputs_
+    fjInputs_.reserve(inputs_.size());
+    inputTowers();
+    LogDebug("FastjetTrackJetProducer") << "Inputted towers\n";
 
-    // loop over the good vertices, clustering for each vertex separately
-    for (reco::VertexCollection::const_iterator itVtx = pvCollection->begin(); itVtx != pvCollection->end(); ++itVtx) {
-      if (itVtx->isFake() || itVtx->ndof() < minVtxNdof_ || fabs(itVtx->z()) > maxVtxZ_) continue;
+    // run algorithm, using fjInputs_, modifying fjJets_ and allocating fjClusterSeq_
+    runAlgorithm(iEvent, iSetup);
+    LogDebug("FastjetTrackJetProducer") << "Ran algorithm\n";
 
-      // clear the intermediate containers
-      inputs_.clear();
-      fjInputs_.clear();
-      fjJets_.clear();
+    // convert our jets and add to the overall jet vector
+    for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
+      // get the constituents from fastjet
+      std::vector<fastjet::PseudoJet> fjConstituents = sorted_by_pt(fjClusterSeq_->constituents(fjJets_[ijet]));
+      // convert them to CandidatePtr vector
+      std::vector<reco::CandidatePtr> constituents = getConstituents(fjConstituents);
+      // fill the trackjet
+      reco::TrackJet jet;
+      // write the specifics to the jet (simultaneously sets 4-vector, vertex).
+      writeSpecific(
+          jet,
+          reco::Particle::LorentzVector(fjJets_[ijet].px(), fjJets_[ijet].py(), fjJets_[ijet].pz(), fjJets_[ijet].E()),
+          vertex_,
+          constituents,
+          iSetup);
+      jet.setJetArea(0);
+      jet.setPileup(0);
+      jet.setPrimaryVertex(edm::Ref<reco::VertexCollection>(pvCollection, (int)(itVtx - pvCollection->begin())));
+      jet.setVertex(itVtx->position());
+      jets->push_back(jet);
+    }
 
-      // if only vertex-associated tracks should be used
-      if (useOnlyVertexTracks_) {
-        // loop over the tracks associated to the vertex
-        for (reco::Vertex::trackRef_iterator itTr = itVtx->tracks_begin(); itTr != itVtx->tracks_end(); ++itTr) {
-          // whether a match was found in the track candidate input
-          bool found = false;
-          // loop over input track candidates
-          for (std::vector<edm::Ptr<reco::RecoChargedRefCandidate> >::iterator itIn = allInputs.begin(); itIn != allInputs.end(); ++itIn) {
-            // match the input track candidate to the track from the vertex
-            reco::TrackRef trref(itTr->castTo<reco::TrackRef>());
-            // check if the tracks match
-            if ((*itIn)->track() == trref) {
-              found = true;
-              // add this track candidate to the input for clustering
-              inputs_.push_back(*itIn);
-              // erase the track candidate from the total list of input, so we don't reuse it later
-              allInputs.erase(itIn);
-              // found the candidate track corresponding to the vertex track, so stop the loop
-              break;
-            } // end if match found
-          } // end loop over input tracks
-          // give an info message in case no match is found (can happen if candidates are subset of tracks used for clustering)
-          if (!found) edm::LogInfo("FastjetTrackJetProducer") << "Ignoring a track at vertex which is not in input track collection!";
-        } // end loop over tracks associated to vertex
-      // if all inpt track candidates should be used
-      } else {
-        // loop over input track candidates
-        for (std::vector<edm::Ptr<reco::RecoChargedRefCandidate> >::iterator itIn = allInputs.begin(); itIn != allInputs.end(); ++itIn) {
-          // check if the track is close enough to the vertex
-          float dz = (*itIn)->track()->dz(itVtx->position());
-          float dxy = (*itIn)->track()->dxy(itVtx->position());
-          if (fabs(dz) > dzTrVtxMax_) continue;
-          if (fabs(dxy) > dxyTrVtxMax_) continue;
-          bool closervtx = false;
-          // now loop over the good vertices a second time
-          for (reco::VertexCollection::const_iterator itVtx2 = pvCollection->begin(); itVtx2 != pvCollection->end(); ++itVtx2) {
-            if (itVtx->isFake() || itVtx->ndof() < minVtxNdof_ || fabs(itVtx->z()) > maxVtxZ_) continue;
-            // and check this track is closer to any other vertex (if more than 1 vertex considered)
-            if (!useOnlyOnePV_ &&
-                itVtx != itVtx2 &&
-                fabs((*itIn)->track()->dz(itVtx2->position())) < fabs(dz)) {
-              closervtx = true;
-              break; // 1 closer vertex makes the track already not matched, so break
-            }
-          }
-          // don't add this track if another vertex is found closer
-          if (closervtx) continue;
-          // add this track candidate to the input for clustering
-          inputs_.push_back(*itIn);
-          // erase the track candidate from the total list of input, so we don't reuse it later
-          allInputs.erase(itIn);
-          // take a step back in the loop since we just erased
-          --itIn;
-        }
-      }
+    if (useOnlyOnePV_)
+      break;  // stop vertex loop if only one vertex asked for
+  }           // end loop over vertices
 
-      // convert candidates in inputs_ to fastjet::PseudoJets in fjInputs_
-      fjInputs_.reserve(inputs_.size());
-      inputTowers();
-      LogDebug("FastjetTrackJetProducer") << "Inputted towers\n";
+  // put the jets in the collection
+  LogDebug("FastjetTrackJetProducer") << "Put " << jets->size() << " jets in the event.\n";
+  iEvent.put(std::move(jets));
 
-      // run algorithm, using fjInputs_, modifying fjJets_ and allocating fjClusterSeq_
-      runAlgorithm(iEvent, iSetup);
-      LogDebug("FastjetTrackJetProducer") << "Ran algorithm\n";
-
-      // convert our jets and add to the overall jet vector
-      for (unsigned int ijet=0;ijet<fjJets_.size();++ijet) {
-        // get the constituents from fastjet
-        std::vector<fastjet::PseudoJet> fjConstituents = sorted_by_pt(fjClusterSeq_->constituents(fjJets_[ijet]));
-        // convert them to CandidatePtr vector
-        std::vector<reco::CandidatePtr> constituents = getConstituents(fjConstituents);
-        // fill the trackjet
-        reco::TrackJet jet;
-        // write the specifics to the jet (simultaneously sets 4-vector, vertex).
-        writeSpecific( jet,
-                       reco::Particle::LorentzVector(fjJets_[ijet].px(), fjJets_[ijet].py(), fjJets_[ijet].pz(), fjJets_[ijet].E()),
-                       vertex_, constituents, iSetup);
-        jet.setJetArea(0);
-        jet.setPileup(0);
-        jet.setPrimaryVertex(edm::Ref<reco::VertexCollection>(pvCollection, (int) (itVtx-pvCollection->begin())));
-        jet.setVertex(itVtx->position());
-        jets->push_back(jet);
-      }
-
-      if (useOnlyOnePV_) break; // stop vertex loop if only one vertex asked for
-    } // end loop over vertices
-
-    // put the jets in the collection
-    LogDebug("FastjetTrackJetProducer") << "Put " << jets->size() << " jets in the event.\n";
-    iEvent.put(std::move(jets));
-
-    // Clear the work vectors so that memory is free for other modules.
-    // Use the trick of swapping with an empty vector so that the memory
-    // is actually given back rather than silently kept.
-    decltype(fjInputs_)().swap(fjInputs_);
-    decltype(fjJets_)().swap(fjJets_);
-    decltype(inputs_)().swap(inputs_);  
+  // Clear the work vectors so that memory is free for other modules.
+  // Use the trick of swapping with an empty vector so that the memory
+  // is actually given back rather than silently kept.
+  decltype(fjInputs_)().swap(fjInputs_);
+  decltype(fjJets_)().swap(fjJets_);
+  decltype(inputs_)().swap(inputs_);
 }
 
-
 //______________________________________________________________________________
-void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iSetup)
-{
+void FastjetJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup const& iSetup) {
   // run algorithm
   /*
   fjInputs_.clear();
@@ -352,166 +354,169 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
   fin.close();
   */
 
-  if ( !doAreaFastjet_ && !doRhoFastjet_) {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs_, *fjJetDefinition_ ) );
+  if (!doAreaFastjet_ && !doRhoFastjet_) {
+    fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, *fjJetDefinition_));
   } else if (voronoiRfact_ <= 0) {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceArea( fjInputs_, *fjJetDefinition_ , *fjAreaDefinition_ ) );
+    fjClusterSeq_ =
+        ClusterSequencePtr(new fastjet::ClusterSequenceArea(fjInputs_, *fjJetDefinition_, *fjAreaDefinition_));
   } else {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
+    fjClusterSeq_ = ClusterSequencePtr(
+        new fastjet::ClusterSequenceVoronoiArea(fjInputs_, *fjJetDefinition_, fastjet::VoronoiAreaSpec(voronoiRfact_)));
   }
 
-  if ( !(useMassDropTagger_ || useCMSBoostedTauSeedingAlgorithm_ || useTrimming_ || useFiltering_ || usePruning_ || useSoftDrop_ || useConstituentSubtraction_ ) ) {
+  if (!(useMassDropTagger_ || useCMSBoostedTauSeedingAlgorithm_ || useTrimming_ || useFiltering_ || usePruning_ ||
+        useSoftDrop_ || useConstituentSubtraction_)) {
     fjJets_ = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
   } else {
     fjJets_.clear();
 
-
     transformer_coll transformers;
-
 
     std::vector<fastjet::PseudoJet> tempJets = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
 
     unique_ptr<fastjet::JetMedianBackgroundEstimator> bge_rho;
-    if ( useConstituentSubtraction_ ) {
-      fastjet::Selector rho_range =  fastjet::SelectorAbsRapMax(csRho_EtaMax_);
-      bge_rho = unique_ptr<fastjet::JetMedianBackgroundEstimator> (new  fastjet::JetMedianBackgroundEstimator(rho_range, fastjet::JetDefinition(fastjet::kt_algorithm, csRParam_), *fjAreaDefinition_) );
+    if (useConstituentSubtraction_) {
+      fastjet::Selector rho_range = fastjet::SelectorAbsRapMax(csRho_EtaMax_);
+      bge_rho = unique_ptr<fastjet::JetMedianBackgroundEstimator>(new fastjet::JetMedianBackgroundEstimator(
+          rho_range, fastjet::JetDefinition(fastjet::kt_algorithm, csRParam_), *fjAreaDefinition_));
       bge_rho->set_particles(fjInputs_);
-      fastjet::contrib::ConstituentSubtractor * constituentSubtractor = new fastjet::contrib::ConstituentSubtractor(bge_rho.get());
+      fastjet::contrib::ConstituentSubtractor* constituentSubtractor =
+          new fastjet::contrib::ConstituentSubtractor(bge_rho.get());
 
-      transformers.push_back( transformer_ptr(constituentSubtractor) );
+      transformers.push_back(transformer_ptr(constituentSubtractor));
     };
-    if ( useMassDropTagger_ ) {
-      fastjet::MassDropTagger * md_tagger = new fastjet::MassDropTagger ( muCut_, yCut_ );
-      transformers.push_back( transformer_ptr(md_tagger) );
+    if (useMassDropTagger_) {
+      fastjet::MassDropTagger* md_tagger = new fastjet::MassDropTagger(muCut_, yCut_);
+      transformers.push_back(transformer_ptr(md_tagger));
     }
-    if ( useCMSBoostedTauSeedingAlgorithm_ ) {
-      fastjet::contrib::CMSBoostedTauSeedingAlgorithm * tau_tagger = 
-	new fastjet::contrib::CMSBoostedTauSeedingAlgorithm ( subjetPtMin_, muMin_, muMax_, yMin_, yMax_, dRMin_, dRMax_, maxDepth_, verbosity_ );
-      transformers.push_back( transformer_ptr(tau_tagger ));
+    if (useCMSBoostedTauSeedingAlgorithm_) {
+      fastjet::contrib::CMSBoostedTauSeedingAlgorithm* tau_tagger = new fastjet::contrib::CMSBoostedTauSeedingAlgorithm(
+          subjetPtMin_, muMin_, muMax_, yMin_, yMax_, dRMin_, dRMax_, maxDepth_, verbosity_);
+      transformers.push_back(transformer_ptr(tau_tagger));
     }
-    if ( useTrimming_ ) {
-      fastjet::Filter * trimmer = new fastjet::Filter(fastjet::JetDefinition(fastjet::kt_algorithm, rFilt_), fastjet::SelectorPtFractionMin(trimPtFracMin_));
-      transformers.push_back( transformer_ptr(trimmer) );
-    } 
-    if ( (useFiltering_) && (!useDynamicFiltering_) ) {
-      fastjet::Filter * filter = new fastjet::Filter(fastjet::JetDefinition(fastjet::cambridge_algorithm, rFilt_), fastjet::SelectorNHardest(nFilt_));
-      transformers.push_back( transformer_ptr(filter));
-    } 
-
-    if ( (usePruning_)  && (!useKtPruning_) ) {
-      fastjet::Pruner * pruner = new fastjet::Pruner(fastjet::cambridge_algorithm, zCut_, RcutFactor_);
-      transformers.push_back( transformer_ptr(pruner ));
+    if (useTrimming_) {
+      fastjet::Filter* trimmer = new fastjet::Filter(fastjet::JetDefinition(fastjet::kt_algorithm, rFilt_),
+                                                     fastjet::SelectorPtFractionMin(trimPtFracMin_));
+      transformers.push_back(transformer_ptr(trimmer));
+    }
+    if ((useFiltering_) && (!useDynamicFiltering_)) {
+      fastjet::Filter* filter = new fastjet::Filter(fastjet::JetDefinition(fastjet::cambridge_algorithm, rFilt_),
+                                                    fastjet::SelectorNHardest(nFilt_));
+      transformers.push_back(transformer_ptr(filter));
     }
 
-    if ( useDynamicFiltering_ ){
-      fastjet::Filter * filter = new fastjet::Filter( fastjet::Filter(&*rFiltDynamic_, fastjet::SelectorNHardest(nFilt_)));
-      transformers.push_back( transformer_ptr(filter));
+    if ((usePruning_) && (!useKtPruning_)) {
+      fastjet::Pruner* pruner = new fastjet::Pruner(fastjet::cambridge_algorithm, zCut_, RcutFactor_);
+      transformers.push_back(transformer_ptr(pruner));
     }
 
-    if ( useKtPruning_ ) {
-      fastjet::Pruner * pruner = new fastjet::Pruner(fastjet::kt_algorithm, zCut_, RcutFactor_);
-      transformers.push_back( transformer_ptr(pruner ));
+    if (useDynamicFiltering_) {
+      fastjet::Filter* filter =
+          new fastjet::Filter(fastjet::Filter(&*rFiltDynamic_, fastjet::SelectorNHardest(nFilt_)));
+      transformers.push_back(transformer_ptr(filter));
     }
 
-    if ( useSoftDrop_ ) {
-      fastjet::contrib::SoftDrop * sd = new fastjet::contrib::SoftDrop(beta_, zCut_, R0_ );
-      transformers.push_back( transformer_ptr(sd) );
+    if (useKtPruning_) {
+      fastjet::Pruner* pruner = new fastjet::Pruner(fastjet::kt_algorithm, zCut_, RcutFactor_);
+      transformers.push_back(transformer_ptr(pruner));
+    }
+
+    if (useSoftDrop_) {
+      fastjet::contrib::SoftDrop* sd = new fastjet::contrib::SoftDrop(beta_, zCut_, R0_);
+      transformers.push_back(transformer_ptr(sd));
     }
 
     unique_ptr<fastjet::Subtractor> subtractor;
     unique_ptr<fastjet::GridMedianBackgroundEstimator> bge_rho_grid;
-    if ( correctShape_ ) {
-      bge_rho_grid = unique_ptr<fastjet::GridMedianBackgroundEstimator> (new  fastjet::GridMedianBackgroundEstimator(gridMaxRapidity_, gridSpacing_) );
+    if (correctShape_) {
+      bge_rho_grid = unique_ptr<fastjet::GridMedianBackgroundEstimator>(
+          new fastjet::GridMedianBackgroundEstimator(gridMaxRapidity_, gridSpacing_));
       bge_rho_grid->set_particles(fjInputs_);
-      subtractor = unique_ptr<fastjet::Subtractor>( new fastjet::Subtractor(  bge_rho_grid.get()) );
+      subtractor = unique_ptr<fastjet::Subtractor>(new fastjet::Subtractor(bge_rho_grid.get()));
       subtractor->set_use_rho_m();
       //subtractor->use_common_bge_for_rho_and_rhom(true);
     }
 
-
-    for ( std::vector<fastjet::PseudoJet>::const_iterator ijet = tempJets.begin(),
-	    ijetEnd = tempJets.end(); ijet != ijetEnd; ++ijet ) {
-
+    for (std::vector<fastjet::PseudoJet>::const_iterator ijet = tempJets.begin(), ijetEnd = tempJets.end();
+         ijet != ijetEnd;
+         ++ijet) {
       fastjet::PseudoJet transformedJet = *ijet;
       bool passed = true;
-      for ( transformer_coll::const_iterator itransf = transformers.begin(),
-	      itransfEnd = transformers.end(); itransf != itransfEnd; ++itransf ) {
-	if ( transformedJet != 0 ) {
-	  transformedJet = (**itransf)(transformedJet);
-	} else {
-	  passed=false;
-	}
+      for (transformer_coll::const_iterator itransf = transformers.begin(), itransfEnd = transformers.end();
+           itransf != itransfEnd;
+           ++itransf) {
+        if (transformedJet != 0) {
+          transformedJet = (**itransf)(transformedJet);
+        } else {
+          passed = false;
+        }
       }
 
-      if ( correctShape_ ) {
-	transformedJet = (*subtractor)(transformedJet);
+      if (correctShape_) {
+        transformedJet = (*subtractor)(transformedJet);
       }
 
-      if ( passed ) {
-	fjJets_.push_back( transformedJet );
+      if (passed) {
+        fjJets_.push_back(transformedJet);
       }
     }
   }
-
 }
 
 //______________________________________________________________________________
 void FastjetJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription descFastjetJetProducer;
+  ////// From FastjetJetProducer
+  fillDescriptionsFromFastJetProducer(descFastjetJetProducer);
+  ///// From VirtualJetProducer
+  VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(descFastjetJetProducer);
+  ////
+  descFastjetJetProducer.add<string>("jetCollInstanceName", "");
+  descFastjetJetProducer.add<bool>("sumRecHits", false);
 
-	edm::ParameterSetDescription descFastjetJetProducer;
-	////// From FastjetJetProducer
-	fillDescriptionsFromFastJetProducer(descFastjetJetProducer);
-	///// From VirtualJetProducer
-	VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(descFastjetJetProducer);
-        ////
-	descFastjetJetProducer.add<string>("jetCollInstanceName", ""	);
-	descFastjetJetProducer.add<bool> ("sumRecHits", false);
-
-	/////////////////////
-	descriptions.add("FastjetJetProducer",descFastjetJetProducer);
-
+  /////////////////////
+  descriptions.add("FastjetJetProducer", descFastjetJetProducer);
 }
 
-void FastjetJetProducer::fillDescriptionsFromFastJetProducer(edm::ParameterSetDescription& desc)
-{
-	desc.add<bool>("useMassDropTagger",     false);
-	desc.add<bool>("useFiltering",	        false);
-	desc.add<bool>("useDynamicFiltering",	false);
-	desc.add<bool>("useTrimming",	false);
-	desc.add<bool>("usePruning",	false);
-	desc.add<bool>("useCMSBoostedTauSeedingAlgorithm", false);
-	desc.add<bool>("useKtPruning",	false);
-	desc.add<bool>("useConstituentSubtraction", false);
-	desc.add<bool>("useSoftDrop",	false);
-	desc.add<bool>("correctShape",	false);
-	desc.add<bool>("UseOnlyVertexTracks",	false);
-	desc.add<bool>("UseOnlyOnePV",	false);
-	desc.add<double>("muCut",	-1.0);
-	desc.add<double>("yCut",	-1.0);
-	desc.add<double>("rFilt",	-1.0);
-	desc.add<double>("rFiltFactor",	-1.0);
-	desc.add<double>("trimPtFracMin",-1.0);
-	desc.add<double>("zcut",	-1.0);
-	desc.add<double>("rcut_factor",	-1.0);
-	desc.add<double>("csRho_EtaMax",-1.0);
-	desc.add<double>("csRParam",	-1.0);
-	desc.add<double>("beta",	-1.0);
-	desc.add<double>("R0",	-1.0);
-	desc.add<double>("gridMaxRapidity",	-1.0); // For fixed-grid rho
-	desc.add<double>("gridSpacing",	-1.0);  // For fixed-grid rho
-	desc.add<double>("DzTrVtxMax",	999999.);  
-	desc.add<double>("DxyTrVtxMax",	999999.);  
-	desc.add<double>("MaxVtxZ",	15.0);  
-	desc.add<double>("subjetPtMin",	-1.0);
-	desc.add<double>("muMin",	-1.0);
-	desc.add<double>("muMax",	-1.0);
-	desc.add<double>("yMin",	-1.0);
-	desc.add<double>("yMax",	-1.0);
-	desc.add<double>("dRMin",	-1.0);
-	desc.add<double>("dRMax",	-1.0);
-	desc.add<int>("maxDepth",	-1);
-	desc.add<int>("nFilt",       	-1);
-	desc.add<int>("MinVtxNdof",	5);
+void FastjetJetProducer::fillDescriptionsFromFastJetProducer(edm::ParameterSetDescription& desc) {
+  desc.add<bool>("useMassDropTagger", false);
+  desc.add<bool>("useFiltering", false);
+  desc.add<bool>("useDynamicFiltering", false);
+  desc.add<bool>("useTrimming", false);
+  desc.add<bool>("usePruning", false);
+  desc.add<bool>("useCMSBoostedTauSeedingAlgorithm", false);
+  desc.add<bool>("useKtPruning", false);
+  desc.add<bool>("useConstituentSubtraction", false);
+  desc.add<bool>("useSoftDrop", false);
+  desc.add<bool>("correctShape", false);
+  desc.add<bool>("UseOnlyVertexTracks", false);
+  desc.add<bool>("UseOnlyOnePV", false);
+  desc.add<double>("muCut", -1.0);
+  desc.add<double>("yCut", -1.0);
+  desc.add<double>("rFilt", -1.0);
+  desc.add<double>("rFiltFactor", -1.0);
+  desc.add<double>("trimPtFracMin", -1.0);
+  desc.add<double>("zcut", -1.0);
+  desc.add<double>("rcut_factor", -1.0);
+  desc.add<double>("csRho_EtaMax", -1.0);
+  desc.add<double>("csRParam", -1.0);
+  desc.add<double>("beta", -1.0);
+  desc.add<double>("R0", -1.0);
+  desc.add<double>("gridMaxRapidity", -1.0);  // For fixed-grid rho
+  desc.add<double>("gridSpacing", -1.0);      // For fixed-grid rho
+  desc.add<double>("DzTrVtxMax", 999999.);
+  desc.add<double>("DxyTrVtxMax", 999999.);
+  desc.add<double>("MaxVtxZ", 15.0);
+  desc.add<double>("subjetPtMin", -1.0);
+  desc.add<double>("muMin", -1.0);
+  desc.add<double>("muMax", -1.0);
+  desc.add<double>("yMin", -1.0);
+  desc.add<double>("yMax", -1.0);
+  desc.add<double>("dRMin", -1.0);
+  desc.add<double>("dRMax", -1.0);
+  desc.add<int>("maxDepth", -1);
+  desc.add<int>("nFilt", -1);
+  desc.add<int>("MinVtxNdof", 5);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -519,4 +524,3 @@ void FastjetJetProducer::fillDescriptionsFromFastJetProducer(edm::ParameterSetDe
 ////////////////////////////////////////////////////////////////////////////////
 
 DEFINE_FWK_MODULE(FastjetJetProducer);
-

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.h
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.h
@@ -16,17 +16,19 @@
 //   min(Rmax, deltaR_factor * deltaR(j1,j2))
 // where j1 and j2 are the 2 subjets of j
 // if the jet does not have exactly 2 pieces, Rmax is used.
-class DynamicRfilt : public fastjet::FunctionOfPseudoJet<double>{
+class DynamicRfilt : public fastjet::FunctionOfPseudoJet<double> {
 public:
   // default ctor
-  DynamicRfilt(double Rmax, double deltaR_factor) : _Rmax(Rmax), _deltaR_factor(deltaR_factor){}
+  DynamicRfilt(double Rmax, double deltaR_factor) : _Rmax(Rmax), _deltaR_factor(deltaR_factor) {}
 
   // action of the function
-  double result(const fastjet::PseudoJet &j) const override{
-    if (! j.has_pieces()) return _Rmax;
+  double result(const fastjet::PseudoJet& j) const override {
+    if (!j.has_pieces())
+      return _Rmax;
 
     std::vector<fastjet::PseudoJet> pieces = j.pieces();
-    if (pieces.size() != 2) return _Rmax;
+    if (pieces.size() != 2)
+      return _Rmax;
 
     double deltaR = pieces[0].delta_R(pieces[1]);
     return std::min(_Rmax, _deltaR_factor * deltaR);
@@ -36,14 +38,10 @@ private:
   double _Rmax, _deltaR_factor;
 };
 
-
-
-class FastjetJetProducer : public VirtualJetProducer
-{
-
+class FastjetJetProducer : public VirtualJetProducer {
 public:
   // typedefs
-  typedef fastjet::Transformer         transformer;
+  typedef fastjet::Transformer transformer;
   typedef std::unique_ptr<transformer> transformer_ptr;
   typedef std::vector<transformer_ptr> transformer_coll;
   //
@@ -54,22 +52,20 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   static void fillDescriptionsFromFastJetProducer(edm::ParameterSetDescription& desc);
 
-  void produce( edm::Event & iEvent, const edm::EventSetup & iSetup ) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   // typedefs
-  typedef boost::shared_ptr<DynamicRfilt>  DynamicRfiltPtr;
+  typedef boost::shared_ptr<DynamicRfilt> DynamicRfiltPtr;
 
 protected:
-
   //
   // member functions
   //
 
-  virtual void produceTrackJets( edm::Event & iEvent, const edm::EventSetup & iSetup );
-  void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
+  virtual void produceTrackJets(edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
- private:
-
+private:
   // trackjet clustering parameters
   bool useOnlyVertexTracks_;
   bool useOnlyOnePV_;
@@ -79,47 +75,43 @@ protected:
   float maxVtxZ_;
 
   // jet trimming parameters
-  bool useMassDropTagger_;    /// Mass-drop tagging for boosted Higgs
-  bool useFiltering_;         /// Jet filtering technique
-  bool useDynamicFiltering_;  /// Use dynamic filtering radius (as in arXiv:0802.2470)
-  bool useTrimming_;          /// Jet trimming technique
-  bool usePruning_;           /// Jet pruning technique
-  bool useCMSBoostedTauSeedingAlgorithm_; /// algorithm for seeding reconstruction of boosted Taus (similar to mass-drop tagging)
-  bool useKtPruning_;         /// Use Kt clustering algorithm for pruning (default is Cambridge/Aachen)
-  bool useConstituentSubtraction_; /// constituent subtraction technique
-  bool useSoftDrop_;          /// Soft drop
-  bool correctShape_;         /// Correct the shape of the jets
-  double muCut_;              /// for mass-drop tagging, m0/mjet (m0 = mass of highest mass subjet)
-  double yCut_;               /// for mass-drop tagging, symmetry cut: min(pt1^2,pt2^2) * dR(1,2) / mjet > ycut
-  double rFilt_;              /// for filtering, trimming: dR scale of sub-clustering
-  DynamicRfiltPtr rFiltDynamic_; /// for dynamic filtering radius (as in arXiv:0802.2470)
-  double rFiltFactor_;        /// for dynamic filtering radius (as in arXiv:0802.2470)
-  int    nFilt_;              /// for filtering, pruning: number of subjets expected
-  double trimPtFracMin_;      /// for trimming: constituent minimum pt fraction of full jet
-  double zCut_;               /// for pruning OR soft drop: constituent minimum pt fraction of parent cluster
-  double RcutFactor_;         /// for pruning: constituent dR * pt/2m < rcut_factor
-  double csRho_EtaMax_;       /// for constituent subtraction : maximum rapidity for ghosts
-  double csRParam_;           /// for constituent subtraction : R parameter for KT alg in jet median background estimator
-  double beta_;               /// for soft drop : beta (angular exponent)
-  double R0_;                 /// for soft drop : R0 (angular distance normalization - should be set to jet radius in most cases)
-  double gridMaxRapidity_;    /// for shape subtraction, get the fixed-grid rho
-  double gridSpacing_;        /// for shape subtraction, get the grid spacing
+  bool useMassDropTagger_;                 /// Mass-drop tagging for boosted Higgs
+  bool useFiltering_;                      /// Jet filtering technique
+  bool useDynamicFiltering_;               /// Use dynamic filtering radius (as in arXiv:0802.2470)
+  bool useTrimming_;                       /// Jet trimming technique
+  bool usePruning_;                        /// Jet pruning technique
+  bool useCMSBoostedTauSeedingAlgorithm_;  /// algorithm for seeding reconstruction of boosted Taus (similar to mass-drop tagging)
+  bool useKtPruning_;                      /// Use Kt clustering algorithm for pruning (default is Cambridge/Aachen)
+  bool useConstituentSubtraction_;  /// constituent subtraction technique
+  bool useSoftDrop_;                /// Soft drop
+  bool correctShape_;               /// Correct the shape of the jets
+  double muCut_;                    /// for mass-drop tagging, m0/mjet (m0 = mass of highest mass subjet)
+  double yCut_;                     /// for mass-drop tagging, symmetry cut: min(pt1^2,pt2^2) * dR(1,2) / mjet > ycut
+  double rFilt_;                    /// for filtering, trimming: dR scale of sub-clustering
+  DynamicRfiltPtr rFiltDynamic_;    /// for dynamic filtering radius (as in arXiv:0802.2470)
+  double rFiltFactor_;              /// for dynamic filtering radius (as in arXiv:0802.2470)
+  int nFilt_;                       /// for filtering, pruning: number of subjets expected
+  double trimPtFracMin_;            /// for trimming: constituent minimum pt fraction of full jet
+  double zCut_;                     /// for pruning OR soft drop: constituent minimum pt fraction of parent cluster
+  double RcutFactor_;               /// for pruning: constituent dR * pt/2m < rcut_factor
+  double csRho_EtaMax_;             /// for constituent subtraction : maximum rapidity for ghosts
+  double csRParam_;  /// for constituent subtraction : R parameter for KT alg in jet median background estimator
+  double beta_;      /// for soft drop : beta (angular exponent)
+  double R0_;        /// for soft drop : R0 (angular distance normalization - should be set to jet radius in most cases)
+  double gridMaxRapidity_;  /// for shape subtraction, get the fixed-grid rho
+  double gridSpacing_;      /// for shape subtraction, get the grid spacing
 
-
-  double subjetPtMin_;        /// for CMSBoostedTauSeedingAlgorithm : subjet pt min
-  double muMin_;              /// for CMSBoostedTauSeedingAlgorithm : min mass-drop
-  double muMax_;              /// for CMSBoostedTauSeedingAlgorithm : max mass-drop
-  double yMin_;               /// for CMSBoostedTauSeedingAlgorithm : min asymmetry
-  double yMax_;               /// for CMSBoostedTauSeedingAlgorithm : max asymmetry
-  double dRMin_;              /// for CMSBoostedTauSeedingAlgorithm : min dR
-  double dRMax_;              /// for CMSBoostedTauSeedingAlgorithm : max dR
-  int    maxDepth_;           /// for CMSBoostedTauSeedingAlgorithm : max depth for descending into clustering sequence
-
+  double subjetPtMin_;  /// for CMSBoostedTauSeedingAlgorithm : subjet pt min
+  double muMin_;        /// for CMSBoostedTauSeedingAlgorithm : min mass-drop
+  double muMax_;        /// for CMSBoostedTauSeedingAlgorithm : max mass-drop
+  double yMin_;         /// for CMSBoostedTauSeedingAlgorithm : min asymmetry
+  double yMax_;         /// for CMSBoostedTauSeedingAlgorithm : max asymmetry
+  double dRMin_;        /// for CMSBoostedTauSeedingAlgorithm : min dR
+  double dRMax_;        /// for CMSBoostedTauSeedingAlgorithm : max dR
+  int maxDepth_;        /// for CMSBoostedTauSeedingAlgorithm : max depth for descending into clustering sequence
 
   // tokens for the data access
   edm::EDGetTokenT<edm::View<reco::RecoChargedRefCandidate> > input_chrefcand_token_;
-    
 };
-
 
 #endif

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducer.cc
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducer.cc
@@ -7,33 +7,34 @@ using namespace std;
 FixedGridRhoProducer::FixedGridRhoProducer(const edm::ParameterSet& iConfig) {
   pfCandidatesTag_ = iConfig.getParameter<edm::InputTag>("pfCandidatesTag");
   string etaRegion = iConfig.getParameter<string>("EtaRegion");
-  if (etaRegion=="Central") myEtaRegion = FixedGridEnergyDensity::Central;
-  else if (etaRegion=="Forward") myEtaRegion = FixedGridEnergyDensity::Forward;
-  else if (etaRegion=="All") myEtaRegion = FixedGridEnergyDensity::All;
+  if (etaRegion == "Central")
+    myEtaRegion = FixedGridEnergyDensity::Central;
+  else if (etaRegion == "Forward")
+    myEtaRegion = FixedGridEnergyDensity::Forward;
+  else if (etaRegion == "All")
+    myEtaRegion = FixedGridEnergyDensity::All;
   else {
-    edm::LogWarning("FixedGridRhoProducer") << "Wrong EtaRegion parameter: " << etaRegion << ". Using EtaRegion = Central";  
+    edm::LogWarning("FixedGridRhoProducer")
+        << "Wrong EtaRegion parameter: " << etaRegion << ". Using EtaRegion = Central";
     myEtaRegion = FixedGridEnergyDensity::Central;
   }
   produces<double>();
 
   input_pfcoll_token_ = consumes<reco::PFCandidateCollection>(pfCandidatesTag_);
-
 }
 
-FixedGridRhoProducer::~FixedGridRhoProducer(){} 
+FixedGridRhoProducer::~FixedGridRhoProducer() {}
 
 void FixedGridRhoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<reco::PFCandidateCollection> pfColl;
+  iEvent.getByToken(input_pfcoll_token_, pfColl);
 
-   edm::Handle<reco::PFCandidateCollection> pfColl;
-   iEvent.getByToken(input_pfcoll_token_, pfColl);
+  algo = new FixedGridEnergyDensity(pfColl.product());
 
-   algo = new FixedGridEnergyDensity(pfColl.product());
+  double result = algo->fixedGridRho(myEtaRegion);
+  iEvent.put(std::make_unique<double>(result));
 
-   double result = algo->fixedGridRho(myEtaRegion);
-   iEvent.put(std::make_unique<double>(result));
-
-   delete algo;
- 
+  delete algo;
 }
 
 DEFINE_FWK_MODULE(FixedGridRhoProducer);

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducer.h
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducer.h
@@ -7,21 +7,18 @@
 #include "RecoJets/JetAlgorithms/interface/FixedGridEnergyDensity.h"
 
 class FixedGridRhoProducer : public edm::stream::EDProducer<> {
-
- public:
+public:
   explicit FixedGridRhoProducer(const edm::ParameterSet& iConfig);
   ~FixedGridRhoProducer() override;
 
- private:
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   edm::InputTag pfCandidatesTag_;
   FixedGridEnergyDensity::EtaRegion myEtaRegion;
-  FixedGridEnergyDensity* algo; 
+  FixedGridEnergyDensity* algo;
 
   edm::EDGetTokenT<reco::PFCandidateCollection> input_pfcoll_token_;
-
 };
-
 
 #endif

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjet.cc
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjet.cc
@@ -6,30 +6,26 @@
 
 using namespace std;
 
-FixedGridRhoProducerFastjet::FixedGridRhoProducerFastjet(const edm::ParameterSet& iConfig) :
-  bge_( iConfig.getParameter<double>("maxRapidity"),
-	iConfig.getParameter<double>("gridSpacing") )
-{
+FixedGridRhoProducerFastjet::FixedGridRhoProducerFastjet(const edm::ParameterSet& iConfig)
+    : bge_(iConfig.getParameter<double>("maxRapidity"), iConfig.getParameter<double>("gridSpacing")) {
   pfCandidatesTag_ = iConfig.getParameter<edm::InputTag>("pfCandidatesTag");
   produces<double>();
 
   input_pfcoll_token_ = consumes<edm::View<reco::Candidate> >(pfCandidatesTag_);
-
 }
 
-FixedGridRhoProducerFastjet::~FixedGridRhoProducerFastjet(){} 
+FixedGridRhoProducerFastjet::~FixedGridRhoProducerFastjet() {}
 
 void FixedGridRhoProducerFastjet::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
-   edm::Handle< edm::View<reco::Candidate> > pfColl;
-   iEvent.getByToken(input_pfcoll_token_, pfColl);
-   std::vector<fastjet::PseudoJet> inputs;
-   for ( edm::View<reco::Candidate>::const_iterator ibegin = pfColl->begin(),
-	   iend = pfColl->end(), i = ibegin; i != iend; ++i ){
-     inputs.push_back( fastjet::PseudoJet(i->px(), i->py(), i->pz(), i->energy()) );
-   }
-   bge_.set_particles(inputs);
-   iEvent.put(std::make_unique<double>(bge_.rho()));
+  edm::Handle<edm::View<reco::Candidate> > pfColl;
+  iEvent.getByToken(input_pfcoll_token_, pfColl);
+  std::vector<fastjet::PseudoJet> inputs;
+  for (edm::View<reco::Candidate>::const_iterator ibegin = pfColl->begin(), iend = pfColl->end(), i = ibegin; i != iend;
+       ++i) {
+    inputs.push_back(fastjet::PseudoJet(i->px(), i->py(), i->pz(), i->energy()));
+  }
+  bge_.set_particles(inputs);
+  iEvent.put(std::make_unique<double>(bge_.rho()));
 }
 
 DEFINE_FWK_MODULE(FixedGridRhoProducerFastjet);

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjet.h
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjet.h
@@ -8,22 +8,18 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "fastjet/tools/GridMedianBackgroundEstimator.hh"
 
-
 class FixedGridRhoProducerFastjet : public edm::stream::EDProducer<> {
-
- public:
+public:
   explicit FixedGridRhoProducerFastjet(const edm::ParameterSet& iConfig);
   ~FixedGridRhoProducerFastjet() override;
 
- private:
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   edm::InputTag pfCandidatesTag_;
   fastjet::GridMedianBackgroundEstimator bge_;
 
   edm::EDGetTokenT<edm::View<reco::Candidate> > input_pfcoll_token_;
-
 };
-
 
 #endif

--- a/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
@@ -8,31 +8,29 @@ using namespace cms;
 using namespace reco;
 using namespace std;
 
-HTTTopJetProducer::HTTTopJetProducer(edm::ParameterSet const& conf):
-       FastjetJetProducer( conf ),
-       optimalR_(false),
-       qJets_(false),
-       minFatjetPt_(200.),
-       minSubjetPt_(20.),
-       minCandPt_(200.),
-       maxFatjetAbsEta_(2.5),
-       subjetMass_(30.),
-       muCut_(0.8),
-       filtR_(0.3),
-       filtN_(5),       
-       mode_(0),
-       minCandMass_(150.),
-       maxCandMass_(200.),
-       massRatioWidth_(15),
-       minM23Cut_(0.35),
-       minM13Cut_(0.2),
-       maxM13Cut_(1.3),
-       maxR_(1.5),
-       minR_(0.5),
-       rejectMinR_(false),
-       verbose_(false )
-{
-  
+HTTTopJetProducer::HTTTopJetProducer(edm::ParameterSet const& conf)
+    : FastjetJetProducer(conf),
+      optimalR_(false),
+      qJets_(false),
+      minFatjetPt_(200.),
+      minSubjetPt_(20.),
+      minCandPt_(200.),
+      maxFatjetAbsEta_(2.5),
+      subjetMass_(30.),
+      muCut_(0.8),
+      filtR_(0.3),
+      filtN_(5),
+      mode_(0),
+      minCandMass_(150.),
+      maxCandMass_(200.),
+      massRatioWidth_(15),
+      minM23Cut_(0.35),
+      minM13Cut_(0.2),
+      maxM13Cut_(1.3),
+      maxR_(1.5),
+      minR_(0.5),
+      rejectMinR_(false),
+      verbose_(false) {
   // Read in all the options from the configuration
   optimalR_ = conf.getParameter<bool>("optimalR");
   qJets_ = conf.getParameter<bool>("qJets");
@@ -55,42 +53,33 @@ HTTTopJetProducer::HTTTopJetProducer(edm::ParameterSet const& conf):
   minR_ = conf.getParameter<double>("minR");
   rejectMinR_ = conf.getParameter<bool>("rejectMinR");
   verbose_ = conf.getParameter<bool>("verbose");
-  
+
   // Create the tagger-wrapper
   produces<HTTTopJetTagInfoCollection>();
 
   // Signal to the VirtualJetProducer that we have to add HTT information
   fromHTTTopJetProducer_ = true;
-  
-  fjHEPTopTagger_ = std::unique_ptr<fastjet::HEPTopTaggerV2>(new fastjet::HEPTopTaggerV2(
-										       optimalR_,
-										       qJets_,
-										       minSubjetPt_, 
-										       minCandPt_,
-										       subjetMass_, 	    
-										       muCut_, 		    
-										       filtR_,
-										       filtN_,
-										       mode_, 		    
-										       minCandMass_, 	    
-										       maxCandMass_, 	    
-										       massRatioWidth_, 	    
-										       minM23Cut_, 	    
-										       minM13Cut_, 	    
-										       maxM13Cut_,
-										       rejectMinR_
-										       )); 
-  
+
+  fjHEPTopTagger_ = std::unique_ptr<fastjet::HEPTopTaggerV2>(new fastjet::HEPTopTaggerV2(optimalR_,
+                                                                                         qJets_,
+                                                                                         minSubjetPt_,
+                                                                                         minCandPt_,
+                                                                                         subjetMass_,
+                                                                                         muCut_,
+                                                                                         filtR_,
+                                                                                         filtN_,
+                                                                                         mode_,
+                                                                                         minCandMass_,
+                                                                                         maxCandMass_,
+                                                                                         massRatioWidth_,
+                                                                                         minM23Cut_,
+                                                                                         minM13Cut_,
+                                                                                         maxM13Cut_,
+                                                                                         rejectMinR_));
 }
 
-		
-
-
-
-void HTTTopJetProducer::produce(  edm::Event & e, const edm::EventSetup & c ) 
-{
-
-  if (qJets_){
+void HTTTopJetProducer::produce(edm::Event& e, const edm::EventSetup& c) {
+  if (qJets_) {
     edm::Service<edm::RandomNumberGenerator> rng;
     CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
     fjHEPTopTagger_->set_rng(engine);
@@ -99,140 +88,134 @@ void HTTTopJetProducer::produce(  edm::Event & e, const edm::EventSetup & c )
   FastjetJetProducer::produce(e, c);
 }
 
-void HTTTopJetProducer::runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
-  if ( !doAreaFastjet_ && !doRhoFastjet_) {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs_, *fjJetDefinition_ ) );
+void HTTTopJetProducer::runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  if (!doAreaFastjet_ && !doRhoFastjet_) {
+    fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, *fjJetDefinition_));
   } else if (voronoiRfact_ <= 0) {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceArea( fjInputs_, *fjJetDefinition_ , *fjAreaDefinition_ ) );
+    fjClusterSeq_ =
+        ClusterSequencePtr(new fastjet::ClusterSequenceArea(fjInputs_, *fjJetDefinition_, *fjAreaDefinition_));
   } else {
-    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
+    fjClusterSeq_ = ClusterSequencePtr(
+        new fastjet::ClusterSequenceVoronoiArea(fjInputs_, *fjJetDefinition_, fastjet::VoronoiAreaSpec(voronoiRfact_)));
   }
 
   //Run the jet clustering
   vector<fastjet::PseudoJet> inclusiveJets = fjClusterSeq_->inclusive_jets(minFatjetPt_);
 
-  if ( verbose_ ) cout << "Getting central jets" << endl;
+  if (verbose_)
+    cout << "Getting central jets" << endl;
   // Find the transient central jets
   vector<fastjet::PseudoJet> centralJets;
   for (unsigned int i = 0; i < inclusiveJets.size(); i++) {
-    
     if (inclusiveJets[i].perp() > minFatjetPt_ && fabs(inclusiveJets[i].rapidity()) < maxFatjetAbsEta_) {
       centralJets.push_back(inclusiveJets[i]);
     }
   }
 
-  fastjet::HEPTopTaggerV2 & HEPTagger = *fjHEPTopTagger_;
+  fastjet::HEPTopTaggerV2& HEPTagger = *fjHEPTopTagger_;
 
   vector<fastjet::PseudoJet>::iterator jetIt = centralJets.begin(), centralJetsEnd = centralJets.end();
-  if ( verbose_ )cout<<"Loop over jets"<<endl;
-  for ( ; jetIt != centralJetsEnd; ++jetIt ) {
-    
-    if (verbose_) cout << "CMS FJ jet pt: " << (*jetIt).perp() << endl;
-    
+  if (verbose_)
+    cout << "Loop over jets" << endl;
+  for (; jetIt != centralJetsEnd; ++jetIt) {
+    if (verbose_)
+      cout << "CMS FJ jet pt: " << (*jetIt).perp() << endl;
+
     fastjet::PseudoJet taggedJet;
 
     taggedJet = HEPTagger.result(*jetIt);
 
-    if (taggedJet != 0){
-      fjJets_.push_back(taggedJet);           
+    if (taggedJet != 0) {
+      fjJets_.push_back(taggedJet);
     }
   }
-  
 }
 
-void HTTTopJetProducer::addHTTTopJetTagInfoCollection( edm::Event& iEvent, 
-						       const edm::EventSetup& iSetup,
-						       edm::OrphanHandle<reco::BasicJetCollection> & oh){
-
-
+void HTTTopJetProducer::addHTTTopJetTagInfoCollection(edm::Event& iEvent,
+                                                      const edm::EventSetup& iSetup,
+                                                      edm::OrphanHandle<reco::BasicJetCollection>& oh) {
   // Set up output list
   auto tagInfos = std::make_unique<HTTTopJetTagInfoCollection>();
 
   // Loop over jets
-  for (size_t ij=0; ij != fjJets_.size(); ij++){
-
+  for (size_t ij = 0; ij != fjJets_.size(); ij++) {
     HTTTopJetProperties properties;
     HTTTopJetTagInfo tagInfo;
 
     // Black magic:
     // In the standard CA treatment the RefToBase is made from the handle directly
-    // Since we only have a OrphanHandle (the JetCollection is created by this process) 
+    // Since we only have a OrphanHandle (the JetCollection is created by this process)
     // we have to take the detour via the Ref
-    edm::Ref<reco::BasicJetCollection> ref(oh, ij);  
-    edm::RefToBase<reco::Jet> rtb(ref);  
-    
-    fastjet::HEPTopTaggerV2Structure *s = (fastjet::HEPTopTaggerV2Structure*) fjJets_[ij].structure_non_const_ptr();
-      
-    properties.fjMass           = s->fj_mass();
-    properties.fjPt             = s->fj_pt();
-    properties.fjEta            = s->fj_eta();
-    properties.fjPhi            = s->fj_phi();
-    
-    properties.topMass           = s->top_mass();
-    properties.unfilteredMass	 = s->unfiltered_mass();
-    properties.prunedMass	 = s->pruned_mass();
-    properties.fRec		 = s->fRec();
-    properties.massRatioPassed   = s->mass_ratio_passed();
-    
-    properties.ropt	          = s->ropt();
-    properties.roptCalc           = s->roptCalc();
-    properties.ptForRoptCalc      = s->ptForRoptCalc();
-    
-    properties.tau1Unfiltered     = s->Tau1Unfiltered();
-    properties.tau2Unfiltered	  = s->Tau2Unfiltered();
-    properties.tau3Unfiltered	  = s->Tau3Unfiltered();
-    properties.tau1Filtered	  = s->Tau1Filtered();
-    properties.tau2Filtered	  = s->Tau2Filtered();
-    properties.tau3Filtered	  = s->Tau3Filtered();
-    properties.qWeight		  = s->qweight();
-    properties.qEpsilon		  = s->qepsilon(); 
-    properties.qSigmaM            = s->qsigmaM();
+    edm::Ref<reco::BasicJetCollection> ref(oh, ij);
+    edm::RefToBase<reco::Jet> rtb(ref);
 
-    tagInfo.insert(rtb, properties );
-    tagInfos->push_back( tagInfo );   
+    fastjet::HEPTopTaggerV2Structure* s = (fastjet::HEPTopTaggerV2Structure*)fjJets_[ij].structure_non_const_ptr();
+
+    properties.fjMass = s->fj_mass();
+    properties.fjPt = s->fj_pt();
+    properties.fjEta = s->fj_eta();
+    properties.fjPhi = s->fj_phi();
+
+    properties.topMass = s->top_mass();
+    properties.unfilteredMass = s->unfiltered_mass();
+    properties.prunedMass = s->pruned_mass();
+    properties.fRec = s->fRec();
+    properties.massRatioPassed = s->mass_ratio_passed();
+
+    properties.ropt = s->ropt();
+    properties.roptCalc = s->roptCalc();
+    properties.ptForRoptCalc = s->ptForRoptCalc();
+
+    properties.tau1Unfiltered = s->Tau1Unfiltered();
+    properties.tau2Unfiltered = s->Tau2Unfiltered();
+    properties.tau3Unfiltered = s->Tau3Unfiltered();
+    properties.tau1Filtered = s->Tau1Filtered();
+    properties.tau2Filtered = s->Tau2Filtered();
+    properties.tau3Filtered = s->Tau3Filtered();
+    properties.qWeight = s->qweight();
+    properties.qEpsilon = s->qepsilon();
+    properties.qSigmaM = s->qsigmaM();
+
+    tagInfo.insert(rtb, properties);
+    tagInfos->push_back(tagInfo);
   }
 
   iEvent.put(std::move(tagInfos));
-  
 };
 
 void HTTTopJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
 
-	edm::ParameterSetDescription desc;
+  desc.add<bool>("optimalR", true);
+  desc.add<bool>("qJets", false);
+  desc.add<double>("minFatjetPt", 200.);
+  desc.add<double>("minSubjetPt", 0.);
+  desc.add<double>("minCandPt", 0.);
+  desc.add<double>("maxFatjetAbsEta", 99.);
+  desc.add<double>("subjetMass", 30.);
+  desc.add<double>("filtR", 0.3);
+  desc.add<int>("filtN", 5);
+  desc.add<int>("mode", 4);
+  desc.add<double>("minCandMass", 0.);
+  desc.add<double>("maxCandMass", 999999.);
+  desc.add<double>("massRatioWidth", 999999.);
+  desc.add<double>("minM23Cut", 0.);
+  desc.add<double>("minM13Cut", 0.);
+  desc.add<double>("maxM13Cut", 999999.);
+  desc.add<double>("maxR", 1.5);
+  desc.add<double>("minR", 0.5);
+  desc.add<bool>("rejectMinR", false);
+  desc.add<bool>("verbose", false);
 
-        desc.add<bool>  ("optimalR",       true);
-        desc.add<bool>  ("qJets",         false);
-        desc.add<double>("minFatjetPt",    200.);
-        desc.add<double>("minSubjetPt",      0.);
-        desc.add<double>("minCandPt",        0.);
-        desc.add<double>("maxFatjetAbsEta", 99.);
-        desc.add<double>("subjetMass",      30.);
-        desc.add<double>("filtR",           0.3);
-        desc.add<int>   ("filtN",             5);
-        desc.add<int>   ("mode",              4);
-        desc.add<double>("minCandMass",      0.);
-        desc.add<double>("maxCandMass",   999999.);
-        desc.add<double>("massRatioWidth",999999.);
-        desc.add<double>("minM23Cut",        0.);
-        desc.add<double>("minM13Cut",        0.);
-        desc.add<double>("maxM13Cut",   999999.);
-        desc.add<double>("maxR",            1.5);
-        desc.add<double>("minR",            0.5);
-        desc.add<bool>  ("rejectMinR",    false);
-        desc.add<bool>  ("verbose",       false);
+  desc.add<int>("algorithm", 1);  // where is it needed?
 
-        desc.add<int>   ("algorithm",         1);  // where is it needed?
+  ////// From FastjetJetProducer
+  FastjetJetProducer::fillDescriptionsFromFastJetProducer(desc);
+  ///// From VirtualJetProducer
+  desc.add<std::string>("jetCollInstanceName", "SubJets");
+  VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(desc);
 
-	////// From FastjetJetProducer
-	FastjetJetProducer::fillDescriptionsFromFastJetProducer(desc);
-	///// From VirtualJetProducer
-	desc.add<std::string> ("jetCollInstanceName","SubJets");
-	VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(desc);
-
-	descriptions.add("HTTTopJetProducer",desc);
-
+  descriptions.add("HTTTopJetProducer", desc);
 }
 
 //define this as a plug-in

--- a/RecoJets/JetProducers/plugins/HTTTopJetProducer.h
+++ b/RecoJets/JetProducers/plugins/HTTTopJetProducer.h
@@ -1,7 +1,6 @@
 #ifndef RecoJets_JetProducers_HTTTopJetProducer_h
 #define RecoJets_JetProducers_HTTTopJetProducer_h
 
-
 /* *********************************************************
 
 
@@ -40,9 +39,6 @@
 
  ************************************************************/
 
-
-
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/View.h"
@@ -73,77 +69,71 @@
 
 #include "fastjet/SISConePlugin.hh"
 
-
-namespace cms
-{
-  class HTTTopJetProducer : public FastjetJetProducer
-  {
+namespace cms {
+  class HTTTopJetProducer : public FastjetJetProducer {
   public:
-
     HTTTopJetProducer(const edm::ParameterSet& ps);
 
     ~HTTTopJetProducer() override {}
 
-    void produce( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-    void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
+    void runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-    void addHTTTopJetTagInfoCollection( edm::Event& iEvent, 
-						const edm::EventSetup& iSetup,
-						edm::OrphanHandle<reco::BasicJetCollection> & oh) override;
+    void addHTTTopJetTagInfoCollection(edm::Event& iEvent,
+                                       const edm::EventSetup& iSetup,
+                                       edm::OrphanHandle<reco::BasicJetCollection>& oh) override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
-    std::unique_ptr<fastjet::HEPTopTaggerV2>        fjHEPTopTagger_;
+    std::unique_ptr<fastjet::HEPTopTaggerV2> fjHEPTopTagger_;
 
-    // Below are all configurable options. 
+    // Below are all configurable options.
     // Parenthesis indicates if this is enforced by the tagger itself or by the producer
 
-    bool optimalR_; // Should the MultiR version of the tagger be used? (tagger)
-    bool qJets_; // Should Q-jets be used? (tagger/producer)
+    bool optimalR_;  // Should the MultiR version of the tagger be used? (tagger)
+    bool qJets_;     // Should Q-jets be used? (tagger/producer)
 
-    double minFatjetPt_; // Only process fatjets larger pT with the tagger [GeV] (producer)
-    double minSubjetPt_; // Minimal pT for subjets [GeV] (tagger)
-    double minCandPt_;   // Minimal pT to return a candidate [GeV] (tagger)
- 
-    double maxFatjetAbsEta_; // Only process fatjets with smaller |eta| with the tagger. (producer)
+    double minFatjetPt_;  // Only process fatjets larger pT with the tagger [GeV] (producer)
+    double minSubjetPt_;  // Minimal pT for subjets [GeV] (tagger)
+    double minCandPt_;    // Minimal pT to return a candidate [GeV] (tagger)
 
-    double subjetMass_; // Mass above which subjets are further unclustered (tagger)
-    double muCut_; // Mass drop threshold (tagger)
+    double maxFatjetAbsEta_;  // Only process fatjets with smaller |eta| with the tagger. (producer)
 
-    double filtR_; // maximal filtering radius
-    int filtN_; // number of filtered subjets to use
-    
+    double subjetMass_;  // Mass above which subjets are further unclustered (tagger)
+    double muCut_;       // Mass drop threshold (tagger)
+
+    double filtR_;  // maximal filtering radius
+    int filtN_;     // number of filtered subjets to use
+
     // HEPTopTagger Mode (tagger):
     // 0: do 2d-plane, return candidate with delta m_top minimal
     // 1: return candidate with delta m_top minimal IF passes 2d plane
     // 2: do 2d-plane, return candidate with max dj_sum
     // 3: return candidate with max dj_sum IF passes 2d plane
     // 4: return candidate built from leading three subjets after unclustering IF passes 2d plane
-    // Note: Original HTT was mode==1    
-    int mode_; 
+    // Note: Original HTT was mode==1
+    int mode_;
 
     // Top Quark mass window in GeV (tagger)
     double minCandMass_;
     double maxCandMass_;
-    
-    double massRatioWidth_; // One sided width of the A-shaped window around m_W/m_top in % (tagger)
-    double minM23Cut_; // minimal value of m23/m123 (tagger)
-    double minM13Cut_; // minimal value of atan(m13/m12) (tagger)
-    double maxM13Cut_; // maximal value of atan(m13/m12) (tagger)
 
-    double maxR_; // maximal fatjet size for MultiR tagger (tagger)
-    double minR_; // minimal fatjet size for MultiR tagger (tagger)
-        
-    bool rejectMinR_; // set Ropt to zero when the candidate never
-		      // leaves the window around the initial mass
+    double massRatioWidth_;  // One sided width of the A-shaped window around m_W/m_top in % (tagger)
+    double minM23Cut_;       // minimal value of m23/m123 (tagger)
+    double minM13Cut_;       // minimal value of atan(m13/m12) (tagger)
+    double maxM13Cut_;       // maximal value of atan(m13/m12) (tagger)
+
+    double maxR_;  // maximal fatjet size for MultiR tagger (tagger)
+    double minR_;  // minimal fatjet size for MultiR tagger (tagger)
+
+    bool rejectMinR_;  // set Ropt to zero when the candidate never
+                       // leaves the window around the initial mass
 
     bool verbose_;
-
   };
 
-}
-
+}  // namespace cms
 
 #endif

--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
@@ -46,112 +46,96 @@
 
 using namespace std;
 
-InputGenJetsParticleSelector::InputGenJetsParticleSelector(const edm::ParameterSet &params ):
-  inTag(params.getParameter<edm::InputTag>("src")),
-  prunedInTag(params.exists("prunedGenParticles") ? params.getParameter<edm::InputTag>("prunedGenParticles") : edm::InputTag("prunedGenParticles")),
-  partonicFinalState(params.getParameter<bool>("partonicFinalState")),
-  excludeResonances(params.getParameter<bool>("excludeResonances")),
-  tausAsJets(params.getParameter<bool>("tausAsJets")),
-  ptMin(0.0){
+InputGenJetsParticleSelector::InputGenJetsParticleSelector(const edm::ParameterSet &params)
+    : inTag(params.getParameter<edm::InputTag>("src")),
+      prunedInTag(params.exists("prunedGenParticles") ? params.getParameter<edm::InputTag>("prunedGenParticles")
+                                                      : edm::InputTag("prunedGenParticles")),
+      partonicFinalState(params.getParameter<bool>("partonicFinalState")),
+      excludeResonances(params.getParameter<bool>("excludeResonances")),
+      tausAsJets(params.getParameter<bool>("tausAsJets")),
+      ptMin(0.0) {
   if (params.exists("ignoreParticleIDs"))
-    setIgnoredParticles(params.getParameter<std::vector<unsigned int> >
-			("ignoreParticleIDs"));
-  setExcludeFromResonancePids(params.getParameter<std::vector<unsigned int> >
-			("excludeFromResonancePids"));
-  isMiniAOD = ( params.exists("isMiniAOD") ? params.getParameter<bool>("isMiniAOD") : (inTag.label()=="packedGenParticles") );
+    setIgnoredParticles(params.getParameter<std::vector<unsigned int> >("ignoreParticleIDs"));
+  setExcludeFromResonancePids(params.getParameter<std::vector<unsigned int> >("excludeFromResonancePids"));
+  isMiniAOD =
+      (params.exists("isMiniAOD") ? params.getParameter<bool>("isMiniAOD") : (inTag.label() == "packedGenParticles"));
 
-  if (isMiniAOD && partonicFinalState){
-    edm::LogError("PartonicFinalStateFromMiniAOD") << "Partonic final state not supported for MiniAOD. Falling back to the stable particle selection.";
+  if (isMiniAOD && partonicFinalState) {
+    edm::LogError("PartonicFinalStateFromMiniAOD")
+        << "Partonic final state not supported for MiniAOD. Falling back to the stable particle selection.";
     partonicFinalState = false;
   }
 
-  produces <reco::CandidatePtrVector> ();
+  produces<reco::CandidatePtrVector>();
 
   input_genpartcoll_token_ = consumes<reco::CandidateView>(inTag);
-  if(isMiniAOD)
+  if (isMiniAOD)
     input_prunedgenpartcoll_token_ = consumes<reco::CandidateView>(prunedInTag);
-      
 }
 
-InputGenJetsParticleSelector::~InputGenJetsParticleSelector(){}
+InputGenJetsParticleSelector::~InputGenJetsParticleSelector() {}
 
-void InputGenJetsParticleSelector::setIgnoredParticles(const std::vector<unsigned int> &particleIDs)
-{
+void InputGenJetsParticleSelector::setIgnoredParticles(const std::vector<unsigned int> &particleIDs) {
   ignoreParticleIDs = particleIDs;
   std::sort(ignoreParticleIDs.begin(), ignoreParticleIDs.end());
 }
 
-void InputGenJetsParticleSelector::setExcludeFromResonancePids(const std::vector<unsigned int> &particleIDs)
-{
+void InputGenJetsParticleSelector::setExcludeFromResonancePids(const std::vector<unsigned int> &particleIDs) {
   excludeFromResonancePids = particleIDs;
-  std::sort( excludeFromResonancePids.begin(), excludeFromResonancePids.end());
+  std::sort(excludeFromResonancePids.begin(), excludeFromResonancePids.end());
 }
 
-bool InputGenJetsParticleSelector::isParton(int pdgId) const{
+bool InputGenJetsParticleSelector::isParton(int pdgId) const {
   pdgId = (pdgId > 0 ? pdgId : -pdgId) % 10000;
-  return (pdgId > 0 && pdgId < 6) ||
-    pdgId == 9 || (tausAsJets && pdgId == 15) || pdgId == 21;
+  return (pdgId > 0 && pdgId < 6) || pdgId == 9 || (tausAsJets && pdgId == 15) || pdgId == 21;
   // tops are not considered "regular" partons
   // but taus eventually are (since they may hadronize later)
 }
 
-bool InputGenJetsParticleSelector::isHadron(int pdgId)
-{
+bool InputGenJetsParticleSelector::isHadron(int pdgId) {
   pdgId = (pdgId > 0 ? pdgId : -pdgId) % 10000;
-  return (pdgId > 100 && pdgId < 900) ||
-    (pdgId > 1000 && pdgId < 9000);
+  return (pdgId > 100 && pdgId < 900) || (pdgId > 1000 && pdgId < 9000);
 }
 
-bool InputGenJetsParticleSelector::isResonance(int pdgId)
-{
+bool InputGenJetsParticleSelector::isResonance(int pdgId) {
   // gauge bosons and tops
   pdgId = (pdgId > 0 ? pdgId : -pdgId) % 10000;
-  return (pdgId > 21 && pdgId <= 42) || pdgId == 6 || pdgId == 7 || pdgId == 8 ;  //BUG! was 21. 22=gamma..
+  return (pdgId > 21 && pdgId <= 42) || pdgId == 6 || pdgId == 7 || pdgId == 8;  //BUG! was 21. 22=gamma..
 }
 
-bool InputGenJetsParticleSelector::isIgnored(int pdgId) const
-{
+bool InputGenJetsParticleSelector::isIgnored(int pdgId) const {
   pdgId = pdgId > 0 ? pdgId : -pdgId;
   std::vector<unsigned int>::const_iterator pos =
-    std::lower_bound(ignoreParticleIDs.begin(),
-		     ignoreParticleIDs.end(),
-		     (unsigned int)pdgId);
+      std::lower_bound(ignoreParticleIDs.begin(), ignoreParticleIDs.end(), (unsigned int)pdgId);
   return pos != ignoreParticleIDs.end() && *pos == (unsigned int)pdgId;
 }
 
-bool InputGenJetsParticleSelector::isExcludedFromResonance(int pdgId) const
-{
+bool InputGenJetsParticleSelector::isExcludedFromResonance(int pdgId) const {
   pdgId = pdgId > 0 ? pdgId : -pdgId;
   std::vector<unsigned int>::const_iterator pos =
-    std::lower_bound(excludeFromResonancePids.begin(),
-		     excludeFromResonancePids.end(),
-		     (unsigned int)pdgId);
+      std::lower_bound(excludeFromResonancePids.begin(), excludeFromResonancePids.end(), (unsigned int)pdgId);
   return pos != excludeFromResonancePids.end() && *pos == (unsigned int)pdgId;
- 
 }
 
-static unsigned int partIdx(const InputGenJetsParticleSelector::ParticleVector &p,
-			       const reco::Candidate *particle)
-{
-  InputGenJetsParticleSelector::ParticleVector::const_iterator pos =
-    std::lower_bound(p.begin(), p.end(), particle);
+static unsigned int partIdx(const InputGenJetsParticleSelector::ParticleVector &p, const reco::Candidate *particle) {
+  InputGenJetsParticleSelector::ParticleVector::const_iterator pos = std::lower_bound(p.begin(), p.end(), particle);
   if (pos == p.end() || *pos != particle)
-    throw cms::Exception("CorruptedData")
-      << "reco::GenEvent corrupted: Unlisted particles"
-      " in decay tree." << std::endl;
+    throw cms::Exception("CorruptedData") << "reco::GenEvent corrupted: Unlisted particles"
+                                             " in decay tree."
+                                          << std::endl;
 
   return pos - p.begin();
 }
-    
-static void invalidateTree(InputGenJetsParticleSelector::ParticleBitmap &invalid,
-			   const InputGenJetsParticleSelector::ParticleVector &p,
-			   const reco::Candidate *particle)
-{
-  unsigned int npart=particle->numberOfDaughters();
-  if (!npart) return;
 
-  for (unsigned int i=0;i<npart;++i){
-    unsigned int idx=partIdx(p,particle->daughter(i));
+static void invalidateTree(InputGenJetsParticleSelector::ParticleBitmap &invalid,
+                           const InputGenJetsParticleSelector::ParticleVector &p,
+                           const reco::Candidate *particle) {
+  unsigned int npart = particle->numberOfDaughters();
+  if (!npart)
+    return;
+
+  for (unsigned int i = 0; i < npart; ++i) {
+    unsigned int idx = partIdx(p, particle->daughter(i));
     if (invalid[idx])
       continue;
     invalid[idx] = true;
@@ -159,167 +143,150 @@ static void invalidateTree(InputGenJetsParticleSelector::ParticleBitmap &invalid
     invalidateTree(invalid, p, particle->daughter(i));
   }
 }
-  
-  
-int InputGenJetsParticleSelector::testPartonChildren
-(InputGenJetsParticleSelector::ParticleBitmap &invalid,
- const InputGenJetsParticleSelector::ParticleVector &p,
- const reco::Candidate *particle) const
-{
-  unsigned int npart=particle->numberOfDaughters();
-  if (!npart) {return 0;}
 
-  for (unsigned int i=0;i<npart;++i){
-    unsigned int idx = partIdx(p,particle->daughter(i));
+int InputGenJetsParticleSelector::testPartonChildren(InputGenJetsParticleSelector::ParticleBitmap &invalid,
+                                                     const InputGenJetsParticleSelector::ParticleVector &p,
+                                                     const reco::Candidate *particle) const {
+  unsigned int npart = particle->numberOfDaughters();
+  if (!npart) {
+    return 0;
+  }
+
+  for (unsigned int i = 0; i < npart; ++i) {
+    unsigned int idx = partIdx(p, particle->daughter(i));
     if (invalid[idx])
       continue;
-    if (isParton((particle->daughter(i)->pdgId()))){
+    if (isParton((particle->daughter(i)->pdgId()))) {
       return 1;
     }
-    if (isHadron((particle->daughter(i)->pdgId()))){
+    if (isHadron((particle->daughter(i)->pdgId()))) {
       return -1;
     }
-    int result = testPartonChildren(invalid,p,particle->daughter(i));
-    if (result) return result;
+    int result = testPartonChildren(invalid, p, particle->daughter(i));
+    if (result)
+      return result;
   }
   return 0;
 }
 
-InputGenJetsParticleSelector::ResonanceState
-InputGenJetsParticleSelector::fromResonance(ParticleBitmap &invalid,
-							   const ParticleVector &p,
-							   const reco::Candidate *particle) const
-{
+InputGenJetsParticleSelector::ResonanceState InputGenJetsParticleSelector::fromResonance(
+    ParticleBitmap &invalid, const ParticleVector &p, const reco::Candidate *particle) const {
   unsigned int idx = partIdx(p, particle);
   int id = particle->pdgId();
 
-  if (invalid[idx]) return kIndirect;
-      
-  if (isResonance(id) && (particle->status() == 3 || particle->status() == 22) ){
+  if (invalid[idx])
+    return kIndirect;
+
+  if (isResonance(id) && (particle->status() == 3 || particle->status() == 22)) {
     return kDirect;
   }
 
-  
   if (!isIgnored(id) && (isParton(id)))
     return kNo;
-  
-  
-  
-  unsigned int nMo=particle->numberOfMothers();
+
+  unsigned int nMo = particle->numberOfMothers();
   if (!nMo)
     return kNo;
-  
 
-  for(unsigned int i=0;i<nMo;++i){
-    ResonanceState result = fromResonance(invalid,p,particle->mother(i));
-    switch(result) {
-    case kNo:
-      break;
-    case kDirect:
-      if (particle->mother(i)->pdgId()==id || isResonance(id))
-	return kDirect;
-      if(!isExcludedFromResonance(id))
-	break;
-    case kIndirect:
-      return kIndirect;
+  for (unsigned int i = 0; i < nMo; ++i) {
+    ResonanceState result = fromResonance(invalid, p, particle->mother(i));
+    switch (result) {
+      case kNo:
+        break;
+      case kDirect:
+        if (particle->mother(i)->pdgId() == id || isResonance(id))
+          return kDirect;
+        if (!isExcludedFromResonance(id))
+          break;
+      case kIndirect:
+        return kIndirect;
     }
   }
-return kNo;
+  return kNo;
 }
 
-    
 bool InputGenJetsParticleSelector::hasPartonChildren(ParticleBitmap &invalid,
-						     const ParticleVector &p,
-						     const reco::Candidate *particle) const {
+                                                     const ParticleVector &p,
+                                                     const reco::Candidate *particle) const {
   return testPartonChildren(invalid, p, particle) > 0;
 }
-    
+
 //######################################################
 //function NEEDED and called per EVENT by FRAMEWORK:
-void InputGenJetsParticleSelector::produce (edm::StreamID, edm::Event &evt, const edm::EventSetup &evtSetup) const{
-
- 
+void InputGenJetsParticleSelector::produce(edm::StreamID, edm::Event &evt, const edm::EventSetup &evtSetup) const {
   auto selected_ = std::make_unique<reco::CandidatePtrVector>();
-    
-  ParticleVector particles;
-  
-  edm::Handle<reco::CandidateView> prunedGenParticles;
-  if(isMiniAOD)
-  {
-    evt.getByToken(input_prunedgenpartcoll_token_, prunedGenParticles );
 
-    for (edm::View<reco::Candidate>::const_iterator iter=prunedGenParticles->begin();iter!=prunedGenParticles->end();++iter)
-    {
-      if(iter->status()!=1) // to avoid double-counting, skipping stable particles already contained in the collection of PackedGenParticles
+  ParticleVector particles;
+
+  edm::Handle<reco::CandidateView> prunedGenParticles;
+  if (isMiniAOD) {
+    evt.getByToken(input_prunedgenpartcoll_token_, prunedGenParticles);
+
+    for (edm::View<reco::Candidate>::const_iterator iter = prunedGenParticles->begin();
+         iter != prunedGenParticles->end();
+         ++iter) {
+      if (iter->status() !=
+          1)  // to avoid double-counting, skipping stable particles already contained in the collection of PackedGenParticles
         particles.push_back(&*iter);
     }
   }
 
   edm::Handle<reco::CandidateView> genParticles;
-  evt.getByToken(input_genpartcoll_token_, genParticles );
+  evt.getByToken(input_genpartcoll_token_, genParticles);
 
-  std::map<const reco::Candidate*,size_t> particlePtrIdxMap;
+  std::map<const reco::Candidate *, size_t> particlePtrIdxMap;
 
-  for (edm::View<reco::Candidate>::const_iterator iter=genParticles->begin();iter!=genParticles->end();++iter){
+  for (edm::View<reco::Candidate>::const_iterator iter = genParticles->begin(); iter != genParticles->end(); ++iter) {
     particles.push_back(&*iter);
     particlePtrIdxMap[&*iter] = (iter - genParticles->begin());
   }
-  
+
   std::sort(particles.begin(), particles.end());
   unsigned int size = particles.size();
-  
+
   ParticleBitmap selected(size, false);
   ParticleBitmap invalid(size, false);
 
-  for(unsigned int i = 0; i < size; i++) {
+  for (unsigned int i = 0; i < size; i++) {
     const reco::Candidate *particle = particles[i];
     if (invalid[i])
       continue;
-    if (particle->status() == 1) // selecting stable particles
+    if (particle->status() == 1)  // selecting stable particles
       selected[i] = true;
     if (partonicFinalState && isParton(particle->pdgId())) {
-	  
-      if (particle->numberOfDaughters()==0 &&
-	  particle->status() != 1) {
-	// some brokenness in event...
-	invalid[i] = true;
-      }
-      else if (!hasPartonChildren(invalid, particles,
-				  particle)) {
-	selected[i] = true;
-	invalidateTree(invalid, particles,particle); //this?!?
+      if (particle->numberOfDaughters() == 0 && particle->status() != 1) {
+        // some brokenness in event...
+        invalid[i] = true;
+      } else if (!hasPartonChildren(invalid, particles, particle)) {
+        selected[i] = true;
+        invalidateTree(invalid, particles, particle);  //this?!?
       }
     }
-	
   }
 
-  for(size_t idx = 0; idx < size; ++idx){ 
+  for (size_t idx = 0; idx < size; ++idx) {
     const reco::Candidate *particle = particles[idx];
-    if (!selected[idx] || invalid[idx]){
+    if (!selected[idx] || invalid[idx]) {
       continue;
     }
-	
-    if (excludeResonances &&
-	fromResonance(invalid, particles, particle)) {
+
+    if (excludeResonances && fromResonance(invalid, particles, particle)) {
       invalid[idx] = true;
       //cout<<"[INPUTSELECTOR] Invalidates FROM RESONANCE!: ["<<setw(4)<<idx<<"] "<<particle->pdgId()<<" "<<particle->pt()<<endl;
       continue;
     }
-	
-    if (isIgnored(particle->pdgId())){
+
+    if (isIgnored(particle->pdgId())) {
       continue;
     }
 
-   
-    if (particle->pt() >= ptMin){
+    if (particle->pt() >= ptMin) {
       selected_->push_back(genParticles->ptrAt(particlePtrIdxMap[particle]));
       //cout<<"Finally we have: ["<<setw(4)<<idx<<"] "<<setw(4)<<particle->pdgId()<<" "<<particle->pt()<<endl;
     }
   }
   evt.put(std::move(selected_));
 }
-      
-      
-  
+
 //define this as a plug-in
 DEFINE_FWK_MODULE(InputGenJetsParticleSelector);

--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.h
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.h
@@ -24,30 +24,26 @@
 #include "DataFormats/Common/interface/EDProductfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 class InputGenJetsParticleSelector : public edm::global::EDProducer<> {
   // collection type
- public:
-  typedef std::vector<bool>     ParticleBitmap;
-  typedef std::vector<const reco::Candidate*> ParticleVector;
-      
-  InputGenJetsParticleSelector(const edm::ParameterSet & ); 
-  ~InputGenJetsParticleSelector() override; 
-  // select object from a collection and 
+public:
+  typedef std::vector<bool> ParticleBitmap;
+  typedef std::vector<const reco::Candidate *> ParticleVector;
+
+  InputGenJetsParticleSelector(const edm::ParameterSet &);
+  ~InputGenJetsParticleSelector() override;
+  // select object from a collection and
   // possibly event content
-  void produce (edm::StreamID, edm::Event &evt, const edm::EventSetup &evtSetup) const override;
-      
+  void produce(edm::StreamID, edm::Event &evt, const edm::EventSetup &evtSetup) const override;
+
   bool getPartonicFinalState() const { return partonicFinalState; }
   bool getExcludeResonances() const { return excludeResonances; }
   bool getTausAndJets() const { return tausAsJets; }
   double getPtMin() const { return ptMin; }
-  const std::vector<unsigned int> &getIgnoredParticles() const
-    { return ignoreParticleIDs; }
-  
-  void setPartonicFinalState(bool flag = true)
-  { partonicFinalState = flag; }
-  void setExcludeResonances(bool flag = true)
-  { excludeResonances = flag; }
+  const std::vector<unsigned int> &getIgnoredParticles() const { return ignoreParticleIDs; }
+
+  void setPartonicFinalState(bool flag = true) { partonicFinalState = flag; }
+  void setExcludeResonances(bool flag = true) { excludeResonances = flag; }
   void setTausAsJets(bool flag = true) { tausAsJets = flag; }
   void setPtMin(double ptMin) { this->ptMin = ptMin; }
   bool isParton(int pdgId) const;
@@ -55,47 +51,35 @@ class InputGenJetsParticleSelector : public edm::global::EDProducer<> {
   static bool isResonance(int pdgId);
 
   bool isIgnored(int pdgId) const;
-  bool hasPartonChildren(ParticleBitmap &invalid,
-			 const ParticleVector &p,
-			 const reco::Candidate *particle) const;
-  
-  enum ResonanceState {
-    kNo = 0,
-    kDirect,
-    kIndirect
-  };
-  ResonanceState fromResonance(ParticleBitmap &invalid,
-			       const ParticleVector &p,
-			       const reco::Candidate *particle) const;
-  
-  
+  bool hasPartonChildren(ParticleBitmap &invalid, const ParticleVector &p, const reco::Candidate *particle) const;
+
+  enum ResonanceState { kNo = 0, kDirect, kIndirect };
+  ResonanceState fromResonance(ParticleBitmap &invalid, const ParticleVector &p, const reco::Candidate *particle) const;
+
   // iterators over selected objects: collection begin
-  
- private:
+
+private:
   //container selected_;  //container required by selector
-  InputGenJetsParticleSelector(){} //should not be used!
-  
+  InputGenJetsParticleSelector() {}  //should not be used!
+
   edm::InputTag inTag;
   edm::InputTag prunedInTag;
-  int testPartonChildren(ParticleBitmap &invalid,
-			 const ParticleVector &p,
-			 const reco::Candidate *particle) const;
-  
-  std::vector<unsigned int>	ignoreParticleIDs;
+  int testPartonChildren(ParticleBitmap &invalid, const ParticleVector &p, const reco::Candidate *particle) const;
+
+  std::vector<unsigned int> ignoreParticleIDs;
   std::vector<unsigned int> excludeFromResonancePids;
   void setExcludeFromResonancePids(const std::vector<unsigned int> &particleIDs);
   void setIgnoredParticles(const std::vector<unsigned int> &particleIDs);
   bool isExcludedFromResonance(int pdgId) const;
-  
-  bool			partonicFinalState;
-  bool			excludeResonances;
-  bool			tausAsJets;
-  bool			isMiniAOD;
-  double		ptMin;
-  
+
+  bool partonicFinalState;
+  bool excludeResonances;
+  bool tausAsJets;
+  bool isMiniAOD;
+  double ptMin;
+
   edm::EDGetTokenT<reco::CandidateView> input_genpartcoll_token_;
   edm::EDGetTokenT<reco::CandidateView> input_prunedgenpartcoll_token_;
-  
 };
 
 #endif

--- a/RecoJets/JetProducers/plugins/JetIDProducer.cc
+++ b/RecoJets/JetProducers/plugins/JetIDProducer.cc
@@ -7,7 +7,6 @@
 // constants, enums and typedefs
 //
 
-
 //
 // static data member definitions
 //
@@ -15,88 +14,77 @@
 //
 // constructors and destructor
 //
-JetIDProducer::JetIDProducer(const edm::ParameterSet& iConfig) :
-  src_       ( iConfig.getParameter<edm::InputTag>("src") ),
-  helper_    ( iConfig, consumesCollector() ),
-  muHelper_  ( iConfig, consumesCollector() )
-{
-  produces< reco::JetIDValueMap >();
+JetIDProducer::JetIDProducer(const edm::ParameterSet& iConfig)
+    : src_(iConfig.getParameter<edm::InputTag>("src")),
+      helper_(iConfig, consumesCollector()),
+      muHelper_(iConfig, consumesCollector()) {
+  produces<reco::JetIDValueMap>();
 
   input_jet_token_ = consumes<edm::View<reco::CaloJet> >(src_);
-
 }
 
-
-JetIDProducer::~JetIDProducer()
-{
-}
-
+JetIDProducer::~JetIDProducer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-JetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
+void JetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get the input jets
-  edm::Handle< edm::View<reco::CaloJet> > h_jets;
-  iEvent.getByToken( input_jet_token_, h_jets );
+  edm::Handle<edm::View<reco::CaloJet> > h_jets;
+  iEvent.getByToken(input_jet_token_, h_jets);
 
   // allocate the jet--->jetid value map
   auto jetIdValueMap = std::make_unique<reco::JetIDValueMap>();
   // instantiate the filler with the map
   reco::JetIDValueMap::Filler filler(*jetIdValueMap);
-  
+
   // allocate the vector of ids
   size_t njets = h_jets->size();
-  std::vector<reco::JetID>  ids (njets);
-   
+  std::vector<reco::JetID> ids(njets);
+
   // loop over the jets
-  for ( edm::View<reco::CaloJet>::const_iterator jetsBegin = h_jets->begin(),
-	  jetsEnd = h_jets->end(),
-	  ijet = jetsBegin;
-	ijet != jetsEnd; ++ijet ) {
-
+  for (edm::View<reco::CaloJet>::const_iterator jetsBegin = h_jets->begin(), jetsEnd = h_jets->end(), ijet = jetsBegin;
+       ijet != jetsEnd;
+       ++ijet) {
     // get the id from each jet
-    helper_.calculate( iEvent, iSetup, *ijet );
+    helper_.calculate(iEvent, iSetup, *ijet);
 
-    muHelper_.calculate( iEvent, iSetup, *ijet );
+    muHelper_.calculate(iEvent, iSetup, *ijet);
 
-    ids[ijet-jetsBegin].fHPD               =  helper_.fHPD();
-    ids[ijet-jetsBegin].fRBX               =  helper_.fRBX();
-    ids[ijet-jetsBegin].n90Hits            =  helper_.n90Hits();
-    ids[ijet-jetsBegin].fSubDetector1      =  helper_.fSubDetector1();
-    ids[ijet-jetsBegin].fSubDetector2      =  helper_.fSubDetector2();
-    ids[ijet-jetsBegin].fSubDetector3      =  helper_.fSubDetector3();
-    ids[ijet-jetsBegin].fSubDetector4      =  helper_.fSubDetector4();
-    ids[ijet-jetsBegin].restrictedEMF      =  helper_.restrictedEMF();
-    ids[ijet-jetsBegin].nHCALTowers        =  helper_.nHCALTowers();
-    ids[ijet-jetsBegin].nECALTowers        =  helper_.nECALTowers();
-    ids[ijet-jetsBegin].approximatefHPD    =  helper_.approximatefHPD();
-    ids[ijet-jetsBegin].approximatefRBX    =  helper_.approximatefRBX();
-    ids[ijet-jetsBegin].hitsInN90          =  helper_.hitsInN90();    
+    ids[ijet - jetsBegin].fHPD = helper_.fHPD();
+    ids[ijet - jetsBegin].fRBX = helper_.fRBX();
+    ids[ijet - jetsBegin].n90Hits = helper_.n90Hits();
+    ids[ijet - jetsBegin].fSubDetector1 = helper_.fSubDetector1();
+    ids[ijet - jetsBegin].fSubDetector2 = helper_.fSubDetector2();
+    ids[ijet - jetsBegin].fSubDetector3 = helper_.fSubDetector3();
+    ids[ijet - jetsBegin].fSubDetector4 = helper_.fSubDetector4();
+    ids[ijet - jetsBegin].restrictedEMF = helper_.restrictedEMF();
+    ids[ijet - jetsBegin].nHCALTowers = helper_.nHCALTowers();
+    ids[ijet - jetsBegin].nECALTowers = helper_.nECALTowers();
+    ids[ijet - jetsBegin].approximatefHPD = helper_.approximatefHPD();
+    ids[ijet - jetsBegin].approximatefRBX = helper_.approximatefRBX();
+    ids[ijet - jetsBegin].hitsInN90 = helper_.hitsInN90();
 
-    ids[ijet-jetsBegin].numberOfHits2RPC   = muHelper_.numberOfHits2RPC();
-    ids[ijet-jetsBegin].numberOfHits3RPC   = muHelper_.numberOfHits3RPC();
-    ids[ijet-jetsBegin].numberOfHitsRPC    = muHelper_.numberOfHitsRPC();
-    
-    ids[ijet-jetsBegin].fEB     = helper_.fEB   ();
-    ids[ijet-jetsBegin].fEE     = helper_.fEE   ();
-    ids[ijet-jetsBegin].fHB     = helper_.fHB   (); 
-    ids[ijet-jetsBegin].fHE     = helper_.fHE   (); 
-    ids[ijet-jetsBegin].fHO     = helper_.fHO   (); 
-    ids[ijet-jetsBegin].fLong   = helper_.fLong ();
-    ids[ijet-jetsBegin].fShort  = helper_.fShort();
-    ids[ijet-jetsBegin].fLS     = helper_.fLSbad   ();
-    ids[ijet-jetsBegin].fHFOOT  = helper_.fHFOOT();
+    ids[ijet - jetsBegin].numberOfHits2RPC = muHelper_.numberOfHits2RPC();
+    ids[ijet - jetsBegin].numberOfHits3RPC = muHelper_.numberOfHits3RPC();
+    ids[ijet - jetsBegin].numberOfHitsRPC = muHelper_.numberOfHitsRPC();
+
+    ids[ijet - jetsBegin].fEB = helper_.fEB();
+    ids[ijet - jetsBegin].fEE = helper_.fEE();
+    ids[ijet - jetsBegin].fHB = helper_.fHB();
+    ids[ijet - jetsBegin].fHE = helper_.fHE();
+    ids[ijet - jetsBegin].fHO = helper_.fHO();
+    ids[ijet - jetsBegin].fLong = helper_.fLong();
+    ids[ijet - jetsBegin].fShort = helper_.fShort();
+    ids[ijet - jetsBegin].fLS = helper_.fLSbad();
+    ids[ijet - jetsBegin].fHFOOT = helper_.fHFOOT();
   }
-  
+
   // set up the map
-  filler.insert( h_jets, ids.begin(), ids.end() );
- 
+  filler.insert(h_jets, ids.begin(), ids.end());
+
   // fill the vals
   filler.fill();
 

--- a/RecoJets/JetProducers/plugins/JetIDProducer.h
+++ b/RecoJets/JetProducers/plugins/JetIDProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    JetIDProducer
 // Class:      JetIDProducer
-// 
+//
 /**\class JetIDProducer JetIDProducer.cc RecoJets/JetProducers/plugins/JetIDProducer.cc
 
  Description: Produces a value map of jet---> jet Id
@@ -20,7 +20,6 @@
 //         Created:  Thu Sep 17 12:18:18 CDT 2009
 //
 //
-
 
 // system include files
 #include <memory>
@@ -43,22 +42,19 @@
 //
 
 class JetIDProducer : public edm::stream::EDProducer<> {
-   public:
+public:
+  explicit JetIDProducer(const edm::ParameterSet&);
+  ~JetIDProducer() override;
 
-      explicit JetIDProducer(const edm::ParameterSet&);
-      ~JetIDProducer() override;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      
-      // ----------member data ---------------------------
-      edm::InputTag                 src_;         // input jet source
-      reco::helper::JetIDHelper     helper_;      // jet id helper algorithm
-      reco::helper::JetMuonHitsIDHelper muHelper_;    // jet id from muon rechits helper algorithm
-      
-      edm::EDGetTokenT<edm::View<reco::CaloJet> > input_jet_token_;
+  // ----------member data ---------------------------
+  edm::InputTag src_;                           // input jet source
+  reco::helper::JetIDHelper helper_;            // jet id helper algorithm
+  reco::helper::JetMuonHitsIDHelper muHelper_;  // jet id from muon rechits helper algorithm
 
+  edm::EDGetTokenT<edm::View<reco::CaloJet> > input_jet_token_;
 };
-
 
 #endif

--- a/RecoJets/JetProducers/plugins/MVAJetPuIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/MVAJetPuIdProducer.cc
@@ -1,5 +1,5 @@
 #include <memory>
-#include "FWCore/Framework/interface/Frameworkfwd.h" 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -20,195 +20,189 @@
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
-
-class MVAJetPuIdProducer : public edm::stream::EDProducer <> {
+class MVAJetPuIdProducer : public edm::stream::EDProducer<> {
 public:
-   explicit MVAJetPuIdProducer(const edm::ParameterSet&);
+  explicit MVAJetPuIdProducer(const edm::ParameterSet &);
 
-   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-   void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
+  void initJetEnergyCorrector(const edm::EventSetup &iSetup, bool isData);
 
-   void initJetEnergyCorrector(const edm::EventSetup &iSetup, bool isData);
+  edm::InputTag jets_, vertexes_, jetids_, rho_;
+  std::string jec_;
+  bool runMvas_, produceJetIds_, inputIsCorrected_, applyJec_;
+  std::vector<std::pair<std::string, MVAJetPuId *>> algos_;
 
-   edm::InputTag jets_, vertexes_, jetids_, rho_;
-   std::string jec_;
-   bool runMvas_, produceJetIds_, inputIsCorrected_, applyJec_;
-   std::vector<std::pair<std::string, MVAJetPuId *> > algos_;
+  bool residualsFromTxt_;
+  edm::FileInPath residualsTxt_;
+  FactorizedJetCorrector *jecCor_;
+  std::vector<JetCorrectorParameters> jetCorPars_;
 
-   bool residualsFromTxt_;
-   edm::FileInPath residualsTxt_;
-   FactorizedJetCorrector *jecCor_;
-   std::vector<JetCorrectorParameters> jetCorPars_;
-
-   edm::EDGetTokenT<edm::View<reco::Jet> > input_jet_token_;
-   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;
-   edm::EDGetTokenT<edm::ValueMap<StoredPileupJetIdentifier> > input_vm_pujetid_token_;
-   edm::EDGetTokenT<double> input_rho_token_;
-
+  edm::EDGetTokenT<edm::View<reco::Jet>> input_jet_token_;
+  edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;
+  edm::EDGetTokenT<edm::ValueMap<StoredPileupJetIdentifier>> input_vm_pujetid_token_;
+  edm::EDGetTokenT<double> input_rho_token_;
 };
 
- 
-MVAJetPuIdProducer::MVAJetPuIdProducer(const edm::ParameterSet& iConfig)
-{
-     runMvas_ = iConfig.getParameter<bool>("runMvas");
-     produceJetIds_ = iConfig.getParameter<bool>("produceJetIds");
-     jets_ = iConfig.getParameter<edm::InputTag>("jets");
-     vertexes_ = iConfig.getParameter<edm::InputTag>("vertexes");
-     jetids_  = iConfig.getParameter<edm::InputTag>("jetids");
-     inputIsCorrected_ = iConfig.getParameter<bool>("inputIsCorrected");
-     applyJec_ = iConfig.getParameter<bool>("applyJec");
-     jec_ =  iConfig.getParameter<std::string>("jec");
-     rho_ = iConfig.getParameter<edm::InputTag>("rho");
-     residualsFromTxt_ = iConfig.getParameter<bool>("residualsFromTxt");
-     if(residualsFromTxt_) residualsTxt_ = iConfig.getParameter<edm::FileInPath>("residualsTxt");
-     std::vector<edm::ParameterSet> algos = iConfig.getParameter<std::vector<edm::ParameterSet> >("algos");
-     
-     jecCor_ = nullptr;
- 
-     if( ! runMvas_ ) assert( algos.size() == 1 );
-     
-     if( produceJetIds_ ) {
-         produces<edm::ValueMap<StoredPileupJetIdentifier> > ("");
-     }
-     for(std::vector<edm::ParameterSet>::iterator it=algos.begin(); it!=algos.end(); ++it) {
-         std::string label = it->getParameter<std::string>("label");
-         algos_.push_back( std::make_pair(label,new MVAJetPuId(*it)) );
-         if( runMvas_ ) {
-             produces<edm::ValueMap<float> > (label+"Discriminant");
-             produces<edm::ValueMap<int> > (label+"Id");
-         }
-     }
- 
-     input_jet_token_ = consumes<edm::View<reco::Jet> >(jets_);
-     input_vertex_token_ = consumes<reco::VertexCollection>(vertexes_);
-     input_vm_pujetid_token_ = consumes<edm::ValueMap<StoredPileupJetIdentifier> >(jetids_);
-     input_rho_token_ = consumes<double>(rho_); 
- 
- }
- 
- 
- void
- MVAJetPuIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
- {
-     using namespace edm;
-     using namespace std;
-     using namespace reco;
-     
-     Handle<View<Jet> > jetHandle;
-     iEvent.getByToken(input_jet_token_,jetHandle);
-     const View<Jet> & jets = *jetHandle;
-     Handle<VertexCollection> vertexHandle;
-     if(  produceJetIds_ ) {
-             iEvent.getByToken(input_vertex_token_, vertexHandle);
-     }
-     const VertexCollection & vertexes = *(vertexHandle.product());
-     Handle<ValueMap<StoredPileupJetIdentifier> > vmap;
-     if( ! produceJetIds_ ) {
-         iEvent.getByToken(input_vm_pujetid_token_, vmap);
-     }
-     edm::Handle< double > rhoH;
-     double rho = 0.;
-     
-     vector<StoredPileupJetIdentifier> ids; 
-     map<string, vector<float> > mvas;
-     map<string, vector<int> > idflags;
- 
-     VertexCollection::const_iterator vtx;
-     if( produceJetIds_ ) {
-         vtx = vertexes.begin();
-         while( vtx != vertexes.end() && ( vtx->isFake() || vtx->ndof() < 4 ) ) {
-             ++vtx;
-         }
-         if( vtx == vertexes.end() ) { vtx = vertexes.begin(); }
+MVAJetPuIdProducer::MVAJetPuIdProducer(const edm::ParameterSet &iConfig) {
+  runMvas_ = iConfig.getParameter<bool>("runMvas");
+  produceJetIds_ = iConfig.getParameter<bool>("produceJetIds");
+  jets_ = iConfig.getParameter<edm::InputTag>("jets");
+  vertexes_ = iConfig.getParameter<edm::InputTag>("vertexes");
+  jetids_ = iConfig.getParameter<edm::InputTag>("jetids");
+  inputIsCorrected_ = iConfig.getParameter<bool>("inputIsCorrected");
+  applyJec_ = iConfig.getParameter<bool>("applyJec");
+  jec_ = iConfig.getParameter<std::string>("jec");
+  rho_ = iConfig.getParameter<edm::InputTag>("rho");
+  residualsFromTxt_ = iConfig.getParameter<bool>("residualsFromTxt");
+  if (residualsFromTxt_)
+    residualsTxt_ = iConfig.getParameter<edm::FileInPath>("residualsTxt");
+  std::vector<edm::ParameterSet> algos = iConfig.getParameter<std::vector<edm::ParameterSet>>("algos");
+
+  jecCor_ = nullptr;
+
+  if (!runMvas_)
+    assert(algos.size() == 1);
+
+  if (produceJetIds_) {
+    produces<edm::ValueMap<StoredPileupJetIdentifier>>("");
+  }
+  for (std::vector<edm::ParameterSet>::iterator it = algos.begin(); it != algos.end(); ++it) {
+    std::string label = it->getParameter<std::string>("label");
+    algos_.push_back(std::make_pair(label, new MVAJetPuId(*it)));
+    if (runMvas_) {
+      produces<edm::ValueMap<float>>(label + "Discriminant");
+      produces<edm::ValueMap<int>>(label + "Id");
     }
-    
-    for ( unsigned int i=0; i<jets.size(); ++i ) {
-        vector<pair<string,MVAJetPuId *> >::iterator algoi = algos_.begin();
-        MVAJetPuId * ialgo = algoi->second;
-        
-        const Jet & jet = jets[i];
-         
-         float jec = 0.;
-         if( applyJec_ ) {
-             if( rho == 0. ) {
-                 iEvent.getByToken(input_rho_token_,rhoH);
-                 rho = *rhoH;
-             }
-             jecCor_->setJetPt(jet.pt());
-             jecCor_->setJetEta(jet.eta());
-             jecCor_->setJetA(jet.jetArea());
-             jecCor_->setRho(rho);
-             jec = jecCor_->getCorrection();
-         }
-         
-         bool applyJec = applyJec_ || !inputIsCorrected_;
-         reco::Jet * corrJet = nullptr;
-         if( applyJec ) {
-             float scale = jec;
-                         corrJet = dynamic_cast<reco::Jet *>( jet.clone() );
-             corrJet->scaleEnergy(scale);
-         }
-         const reco::Jet * theJet = ( applyJec ? corrJet : &jet );
-         PileupJetIdentifier puIdentifier;
-         if( produceJetIds_ ) {
-             puIdentifier = ialgo->computeIdVariables(theJet, jec,  &(*vtx), vertexes, runMvas_);
-             ids.push_back( puIdentifier );
-         } else {
-             puIdentifier = (*vmap)[jets.refAt(i)]; 
-             puIdentifier.jetPt(theJet->pt());    /*make sure JEC is applied when computing the MVA*/
-             puIdentifier.jetEta(theJet->eta());
-             puIdentifier.jetPhi(theJet->phi());
-             ialgo->set(puIdentifier); 
-             puIdentifier = ialgo->computeMva();
-         }
-         
-         if( runMvas_ ) {
-             for( ; algoi!=algos_.end(); ++algoi) {
-                 ialgo = algoi->second;
-                 ialgo->set(puIdentifier);
-                 PileupJetIdentifier id = ialgo->computeMva();
-                 mvas[algoi->first].push_back( id.mva() );
-                 idflags[algoi->first].push_back( id.idFlag() );
-             }
-         }
-         
-         if( corrJet ) { delete corrJet; }
-     }
-     
-     if( runMvas_ ) {
-         for(vector<pair<string,MVAJetPuId *> >::iterator ialgo = algos_.begin(); ialgo!=algos_.end(); ++ialgo) {
-             vector<float> & mva = mvas[ialgo->first];
-             auto mvaout = std::make_unique<ValueMap<float>>();
-             ValueMap<float>::Filler mvafiller(*mvaout);
-             mvafiller.insert(jetHandle,mva.begin(),mva.end());
-             mvafiller.fill();
-             iEvent.put(std::move(mvaout),ialgo->first+"Discriminant");
-             
-             vector<int> & idflag = idflags[ialgo->first];
-             auto idflagout = std::make_unique<ValueMap<int>>();
-             ValueMap<int>::Filler idflagfiller(*idflagout);
-             idflagfiller.insert(jetHandle,idflag.begin(),idflag.end());
-             idflagfiller.fill();
-             iEvent.put(std::move(idflagout),ialgo->first+"Id");
-         }
-     }
-     if( produceJetIds_ ) {
-         assert( jetHandle->size() == ids.size() );
-         auto idsout = std::make_unique<ValueMap<StoredPileupJetIdentifier>>();
-         ValueMap<StoredPileupJetIdentifier>::Filler idsfiller(*idsout);
-         idsfiller.insert(jetHandle,ids.begin(),ids.end());
-         idsfiller.fill();
-         iEvent.put(std::move(idsout));
-     }
- }
- 
- 
- 
- void
- MVAJetPuIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  }
+
+  input_jet_token_ = consumes<edm::View<reco::Jet>>(jets_);
+  input_vertex_token_ = consumes<reco::VertexCollection>(vertexes_);
+  input_vm_pujetid_token_ = consumes<edm::ValueMap<StoredPileupJetIdentifier>>(jetids_);
+  input_rho_token_ = consumes<double>(rho_);
+}
+
+void MVAJetPuIdProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
+  using namespace std;
+  using namespace reco;
+
+  Handle<View<Jet>> jetHandle;
+  iEvent.getByToken(input_jet_token_, jetHandle);
+  const View<Jet> &jets = *jetHandle;
+  Handle<VertexCollection> vertexHandle;
+  if (produceJetIds_) {
+    iEvent.getByToken(input_vertex_token_, vertexHandle);
+  }
+  const VertexCollection &vertexes = *(vertexHandle.product());
+  Handle<ValueMap<StoredPileupJetIdentifier>> vmap;
+  if (!produceJetIds_) {
+    iEvent.getByToken(input_vm_pujetid_token_, vmap);
+  }
+  edm::Handle<double> rhoH;
+  double rho = 0.;
+
+  vector<StoredPileupJetIdentifier> ids;
+  map<string, vector<float>> mvas;
+  map<string, vector<int>> idflags;
+
+  VertexCollection::const_iterator vtx;
+  if (produceJetIds_) {
+    vtx = vertexes.begin();
+    while (vtx != vertexes.end() && (vtx->isFake() || vtx->ndof() < 4)) {
+      ++vtx;
+    }
+    if (vtx == vertexes.end()) {
+      vtx = vertexes.begin();
+    }
+  }
+
+  for (unsigned int i = 0; i < jets.size(); ++i) {
+    vector<pair<string, MVAJetPuId *>>::iterator algoi = algos_.begin();
+    MVAJetPuId *ialgo = algoi->second;
+
+    const Jet &jet = jets[i];
+
+    float jec = 0.;
+    if (applyJec_) {
+      if (rho == 0.) {
+        iEvent.getByToken(input_rho_token_, rhoH);
+        rho = *rhoH;
+      }
+      jecCor_->setJetPt(jet.pt());
+      jecCor_->setJetEta(jet.eta());
+      jecCor_->setJetA(jet.jetArea());
+      jecCor_->setRho(rho);
+      jec = jecCor_->getCorrection();
+    }
+
+    bool applyJec = applyJec_ || !inputIsCorrected_;
+    reco::Jet *corrJet = nullptr;
+    if (applyJec) {
+      float scale = jec;
+      corrJet = dynamic_cast<reco::Jet *>(jet.clone());
+      corrJet->scaleEnergy(scale);
+    }
+    const reco::Jet *theJet = (applyJec ? corrJet : &jet);
+    PileupJetIdentifier puIdentifier;
+    if (produceJetIds_) {
+      puIdentifier = ialgo->computeIdVariables(theJet, jec, &(*vtx), vertexes, runMvas_);
+      ids.push_back(puIdentifier);
+    } else {
+      puIdentifier = (*vmap)[jets.refAt(i)];
+      puIdentifier.jetPt(theJet->pt()); /*make sure JEC is applied when computing the MVA*/
+      puIdentifier.jetEta(theJet->eta());
+      puIdentifier.jetPhi(theJet->phi());
+      ialgo->set(puIdentifier);
+      puIdentifier = ialgo->computeMva();
+    }
+
+    if (runMvas_) {
+      for (; algoi != algos_.end(); ++algoi) {
+        ialgo = algoi->second;
+        ialgo->set(puIdentifier);
+        PileupJetIdentifier id = ialgo->computeMva();
+        mvas[algoi->first].push_back(id.mva());
+        idflags[algoi->first].push_back(id.idFlag());
+      }
+    }
+
+    if (corrJet) {
+      delete corrJet;
+    }
+  }
+
+  if (runMvas_) {
+    for (vector<pair<string, MVAJetPuId *>>::iterator ialgo = algos_.begin(); ialgo != algos_.end(); ++ialgo) {
+      vector<float> &mva = mvas[ialgo->first];
+      auto mvaout = std::make_unique<ValueMap<float>>();
+      ValueMap<float>::Filler mvafiller(*mvaout);
+      mvafiller.insert(jetHandle, mva.begin(), mva.end());
+      mvafiller.fill();
+      iEvent.put(std::move(mvaout), ialgo->first + "Discriminant");
+
+      vector<int> &idflag = idflags[ialgo->first];
+      auto idflagout = std::make_unique<ValueMap<int>>();
+      ValueMap<int>::Filler idflagfiller(*idflagout);
+      idflagfiller.insert(jetHandle, idflag.begin(), idflag.end());
+      idflagfiller.fill();
+      iEvent.put(std::move(idflagout), ialgo->first + "Id");
+    }
+  }
+  if (produceJetIds_) {
+    assert(jetHandle->size() == ids.size());
+    auto idsout = std::make_unique<ValueMap<StoredPileupJetIdentifier>>();
+    ValueMap<StoredPileupJetIdentifier>::Filler idsfiller(*idsout);
+    idsfiller.insert(jetHandle, ids.begin(), ids.end());
+    idsfiller.fill();
+    iEvent.put(std::move(idsout));
+  }
+}
+
+void MVAJetPuIdProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<bool>("runMvas", true);
   desc.add<bool>("inputIsCorrected", true);
@@ -220,120 +214,131 @@ MVAJetPuIdProducer::MVAJetPuIdProducer(const edm::ParameterSet& iConfig)
   desc.add<edm::InputTag>("jetids", edm::InputTag(""));
   desc.add<edm::InputTag>("rho", edm::InputTag("hltFixedGridRhoFastjetAll"));
   desc.add<edm::InputTag>("jets", edm::InputTag("hltAK4PFJetsCorrected"));
-    edm::ParameterSetDescription vpsd1;
-    vpsd1.add<std::vector<std::string>>("tmvaVariables", {
-      "rho",
-      "nParticles",
-      "nCharged",
-      "majW",
-      "minW",
-      "frac01",
-      "frac02",
-      "frac03",
-      "frac04",
-      "ptD",
-      "beta",
-      "betaStar",
-      "dR2Mean",
-      "pull",
-      "jetR",
-      "jetRchg",
-    });
-    vpsd1.add<std::string>("tmvaMethod", "JetID");
-    vpsd1.add<bool>("cutBased", false);
-    vpsd1.add<std::string>("tmvaWeights", "RecoJets/JetProducers/data/MVAJetPuID.weights.xml.gz");
-    vpsd1.add<std::vector<std::string>>("tmvaSpectators", {
-      "jetEta",
-      "jetPt",
-    });
-    vpsd1.add<std::string>("label", "CATEv0");
-    vpsd1.add<int>("version", -1);
-    {
-      edm::ParameterSetDescription psd0;
-      psd0.add<std::vector<double>>("Pt2030_Tight", {
-        0.73,
-        0.05,
-        -0.26,
-        -0.42,
-      });
-      psd0.add<std::vector<double>>("Pt2030_Loose", {
-        -0.63,
-        -0.6,
-        -0.55,
-        -0.45,
-      });
-      psd0.add<std::vector<double>>("Pt3050_Medium", {
-        0.1,
-        -0.36,
-        -0.54,
-        -0.54,
-      });
-      psd0.add<std::vector<double>>("Pt1020_Tight", {
-        -0.83,
-        -0.81,
-        -0.74,
-        -0.81,
-      });
-      psd0.add<std::vector<double>>("Pt2030_Medium", {
-        0.1,
-        -0.36,
-        -0.54,
-        -0.54,
-      });
-      psd0.add<std::vector<double>>("Pt010_Tight", {
-        -0.83,
-        -0.81,
-        -0.74,
-        -0.81,
-      });
-      psd0.add<std::vector<double>>("Pt1020_Loose", {
-        -0.95,
-        -0.96,
-        -0.94,
-        -0.95,
-      });
-      psd0.add<std::vector<double>>("Pt010_Medium", {
-        -0.83,
-        -0.92,
-        -0.9,
-        -0.92,
-      });
-      psd0.add<std::vector<double>>("Pt1020_Medium", {
-        -0.83,
-        -0.92,
-        -0.9,
-        -0.92,
-      });
-      psd0.add<std::vector<double>>("Pt010_Loose", {
-        -0.95,
-        -0.96,
-        -0.94,
-        -0.95,
-      });
-      psd0.add<std::vector<double>>("Pt3050_Loose", {
-        -0.63,
-        -0.6,
-        -0.55,
-        -0.45,
-      });
-      psd0.add<std::vector<double>>("Pt3050_Tight", {
-        0.73,
-        0.05,
-        -0.26,
-        -0.42,
-      });
-      vpsd1.add<edm::ParameterSetDescription>("JetIdParams", psd0);
-    }
-    vpsd1.add<double>("impactParTkThreshold", 1.0);
-    std::vector<edm::ParameterSet> temp1;
-    temp1.reserve(1);
+  edm::ParameterSetDescription vpsd1;
+  vpsd1.add<std::vector<std::string>>("tmvaVariables",
+                                      {
+                                          "rho",
+                                          "nParticles",
+                                          "nCharged",
+                                          "majW",
+                                          "minW",
+                                          "frac01",
+                                          "frac02",
+                                          "frac03",
+                                          "frac04",
+                                          "ptD",
+                                          "beta",
+                                          "betaStar",
+                                          "dR2Mean",
+                                          "pull",
+                                          "jetR",
+                                          "jetRchg",
+                                      });
+  vpsd1.add<std::string>("tmvaMethod", "JetID");
+  vpsd1.add<bool>("cutBased", false);
+  vpsd1.add<std::string>("tmvaWeights", "RecoJets/JetProducers/data/MVAJetPuID.weights.xml.gz");
+  vpsd1.add<std::vector<std::string>>("tmvaSpectators",
+                                      {
+                                          "jetEta",
+                                          "jetPt",
+                                      });
+  vpsd1.add<std::string>("label", "CATEv0");
+  vpsd1.add<int>("version", -1);
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::vector<double>>("Pt2030_Tight",
+                                  {
+                                      0.73,
+                                      0.05,
+                                      -0.26,
+                                      -0.42,
+                                  });
+    psd0.add<std::vector<double>>("Pt2030_Loose",
+                                  {
+                                      -0.63,
+                                      -0.6,
+                                      -0.55,
+                                      -0.45,
+                                  });
+    psd0.add<std::vector<double>>("Pt3050_Medium",
+                                  {
+                                      0.1,
+                                      -0.36,
+                                      -0.54,
+                                      -0.54,
+                                  });
+    psd0.add<std::vector<double>>("Pt1020_Tight",
+                                  {
+                                      -0.83,
+                                      -0.81,
+                                      -0.74,
+                                      -0.81,
+                                  });
+    psd0.add<std::vector<double>>("Pt2030_Medium",
+                                  {
+                                      0.1,
+                                      -0.36,
+                                      -0.54,
+                                      -0.54,
+                                  });
+    psd0.add<std::vector<double>>("Pt010_Tight",
+                                  {
+                                      -0.83,
+                                      -0.81,
+                                      -0.74,
+                                      -0.81,
+                                  });
+    psd0.add<std::vector<double>>("Pt1020_Loose",
+                                  {
+                                      -0.95,
+                                      -0.96,
+                                      -0.94,
+                                      -0.95,
+                                  });
+    psd0.add<std::vector<double>>("Pt010_Medium",
+                                  {
+                                      -0.83,
+                                      -0.92,
+                                      -0.9,
+                                      -0.92,
+                                  });
+    psd0.add<std::vector<double>>("Pt1020_Medium",
+                                  {
+                                      -0.83,
+                                      -0.92,
+                                      -0.9,
+                                      -0.92,
+                                  });
+    psd0.add<std::vector<double>>("Pt010_Loose",
+                                  {
+                                      -0.95,
+                                      -0.96,
+                                      -0.94,
+                                      -0.95,
+                                  });
+    psd0.add<std::vector<double>>("Pt3050_Loose",
+                                  {
+                                      -0.63,
+                                      -0.6,
+                                      -0.55,
+                                      -0.45,
+                                  });
+    psd0.add<std::vector<double>>("Pt3050_Tight",
+                                  {
+                                      0.73,
+                                      0.05,
+                                      -0.26,
+                                      -0.42,
+                                  });
+    vpsd1.add<edm::ParameterSetDescription>("JetIdParams", psd0);
+  }
+  vpsd1.add<double>("impactParTkThreshold", 1.0);
+  std::vector<edm::ParameterSet> temp1;
+  temp1.reserve(1);
 
-    desc.addVPSet("algos", vpsd1, temp1);
+  desc.addVPSet("algos", vpsd1, temp1);
 
   descriptions.add("MVAJetPuIdProducer", desc);
+}
 
- }
- 
 DEFINE_FWK_MODULE(MVAJetPuIdProducer);
-
-

--- a/RecoJets/JetProducers/plugins/NjettinessAdder.cc
+++ b/RecoJets/JetProducers/plugins/NjettinessAdder.cc
@@ -1,126 +1,149 @@
 #include "RecoJets/JetProducers/interface/NjettinessAdder.h"
 
-
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-NjettinessAdder::NjettinessAdder(const edm::ParameterSet& iConfig) :
-  src_(iConfig.getParameter<edm::InputTag>("src")),
-  src_token_(consumes<edm::View<reco::Jet>>(src_)),
-  Njets_(iConfig.getParameter<std::vector<unsigned> >("Njets")),
-  measureDefinition_(iConfig.getParameter<unsigned >("measureDefinition")),
-  beta_(iConfig.getParameter<double>("beta")),
-  R0_(iConfig.getParameter<double>("R0")),
-  Rcutoff_(iConfig.getParameter<double>("Rcutoff")),
-  axesDefinition_(iConfig.getParameter< unsigned >("axesDefinition")),
-  nPass_(iConfig.getParameter<int>("nPass")),
-  akAxesR0_(iConfig.getParameter<double>("akAxesR0"))
-{
-  for ( std::vector<unsigned>::const_iterator n = Njets_.begin(); n != Njets_.end(); ++n )
-    {
-      std::ostringstream tauN_str;
-      tauN_str << "tau" << *n;
+NjettinessAdder::NjettinessAdder(const edm::ParameterSet& iConfig)
+    : src_(iConfig.getParameter<edm::InputTag>("src")),
+      src_token_(consumes<edm::View<reco::Jet>>(src_)),
+      Njets_(iConfig.getParameter<std::vector<unsigned>>("Njets")),
+      measureDefinition_(iConfig.getParameter<unsigned>("measureDefinition")),
+      beta_(iConfig.getParameter<double>("beta")),
+      R0_(iConfig.getParameter<double>("R0")),
+      Rcutoff_(iConfig.getParameter<double>("Rcutoff")),
+      axesDefinition_(iConfig.getParameter<unsigned>("axesDefinition")),
+      nPass_(iConfig.getParameter<int>("nPass")),
+      akAxesR0_(iConfig.getParameter<double>("akAxesR0")) {
+  for (std::vector<unsigned>::const_iterator n = Njets_.begin(); n != Njets_.end(); ++n) {
+    std::ostringstream tauN_str;
+    tauN_str << "tau" << *n;
 
-      produces<edm::ValueMap<float> >(tauN_str.str());
-    }
-
+    produces<edm::ValueMap<float>>(tauN_str.str());
+  }
 
   // Get the measure definition
-  fastjet::contrib::NormalizedMeasure          normalizedMeasure        (beta_,R0_);
-  fastjet::contrib::UnnormalizedMeasure        unnormalizedMeasure      (beta_);
-  fastjet::contrib::OriginalGeometricMeasure   geometricMeasure         (beta_);// changed in 1.020
-  fastjet::contrib::NormalizedCutoffMeasure    normalizedCutoffMeasure  (beta_,R0_,Rcutoff_);
-  fastjet::contrib::UnnormalizedCutoffMeasure  unnormalizedCutoffMeasure(beta_,Rcutoff_);
+  fastjet::contrib::NormalizedMeasure normalizedMeasure(beta_, R0_);
+  fastjet::contrib::UnnormalizedMeasure unnormalizedMeasure(beta_);
+  fastjet::contrib::OriginalGeometricMeasure geometricMeasure(beta_);  // changed in 1.020
+  fastjet::contrib::NormalizedCutoffMeasure normalizedCutoffMeasure(beta_, R0_, Rcutoff_);
+  fastjet::contrib::UnnormalizedCutoffMeasure unnormalizedCutoffMeasure(beta_, Rcutoff_);
   //fastjet::contrib::GeometricCutoffMeasure     geometricCutoffMeasure   (beta_,Rcutoff_); // removed in 1.020
 
-  fastjet::contrib::MeasureDefinition const * measureDef = nullptr;
-  switch ( measureDefinition_ ) {
-  case UnnormalizedMeasure : measureDef = &unnormalizedMeasure; break;
-  case OriginalGeometricMeasure    : measureDef = &geometricMeasure; break;// changed in 1.020
-  case NormalizedCutoffMeasure : measureDef = &normalizedCutoffMeasure; break;
-  case UnnormalizedCutoffMeasure : measureDef = &unnormalizedCutoffMeasure; break;
-  //case GeometricCutoffMeasure : measureDef = &geometricCutoffMeasure; break; // removed in 1.020
-  case NormalizedMeasure : default : measureDef = &normalizedMeasure; break;
-  } 
+  fastjet::contrib::MeasureDefinition const* measureDef = nullptr;
+  switch (measureDefinition_) {
+    case UnnormalizedMeasure:
+      measureDef = &unnormalizedMeasure;
+      break;
+    case OriginalGeometricMeasure:
+      measureDef = &geometricMeasure;
+      break;  // changed in 1.020
+    case NormalizedCutoffMeasure:
+      measureDef = &normalizedCutoffMeasure;
+      break;
+    case UnnormalizedCutoffMeasure:
+      measureDef = &unnormalizedCutoffMeasure;
+      break;
+    //case GeometricCutoffMeasure : measureDef = &geometricCutoffMeasure; break; // removed in 1.020
+    case NormalizedMeasure:
+    default:
+      measureDef = &normalizedMeasure;
+      break;
+  }
 
   // Get the axes definition
-  fastjet::contrib::KT_Axes             kt_axes; 
-  fastjet::contrib::CA_Axes             ca_axes; 
-  fastjet::contrib::AntiKT_Axes         antikt_axes   (akAxesR0_);
-  fastjet::contrib::WTA_KT_Axes         wta_kt_axes; 
-  fastjet::contrib::WTA_CA_Axes         wta_ca_axes; 
-  fastjet::contrib::OnePass_KT_Axes     onepass_kt_axes;
-  fastjet::contrib::OnePass_CA_Axes     onepass_ca_axes;
-  fastjet::contrib::OnePass_AntiKT_Axes onepass_antikt_axes   (akAxesR0_);
+  fastjet::contrib::KT_Axes kt_axes;
+  fastjet::contrib::CA_Axes ca_axes;
+  fastjet::contrib::AntiKT_Axes antikt_axes(akAxesR0_);
+  fastjet::contrib::WTA_KT_Axes wta_kt_axes;
+  fastjet::contrib::WTA_CA_Axes wta_ca_axes;
+  fastjet::contrib::OnePass_KT_Axes onepass_kt_axes;
+  fastjet::contrib::OnePass_CA_Axes onepass_ca_axes;
+  fastjet::contrib::OnePass_AntiKT_Axes onepass_antikt_axes(akAxesR0_);
   fastjet::contrib::OnePass_WTA_KT_Axes onepass_wta_kt_axes;
   fastjet::contrib::OnePass_WTA_CA_Axes onepass_wta_ca_axes;
-  fastjet::contrib::MultiPass_Axes      multipass_axes (nPass_);
+  fastjet::contrib::MultiPass_Axes multipass_axes(nPass_);
 
-  fastjet::contrib::AxesDefinition const * axesDef = nullptr;
-  switch ( axesDefinition_ ) {
-  case  KT_Axes : default : axesDef = &kt_axes; break;
-  case  CA_Axes : axesDef = &ca_axes; break; 
-  case  AntiKT_Axes : axesDef = &antikt_axes; break;
-  case  WTA_KT_Axes : axesDef = &wta_kt_axes; break; 
-  case  WTA_CA_Axes : axesDef = &wta_ca_axes; break; 
-  case  OnePass_KT_Axes : axesDef = &onepass_kt_axes; break;
-  case  OnePass_CA_Axes : axesDef = &onepass_ca_axes; break; 
-  case  OnePass_AntiKT_Axes : axesDef = &onepass_antikt_axes; break;
-  case  OnePass_WTA_KT_Axes : axesDef = &onepass_wta_kt_axes; break; 
-  case  OnePass_WTA_CA_Axes : axesDef = &onepass_wta_ca_axes; break; 
-  case  MultiPass_Axes : axesDef = &multipass_axes; break;
+  fastjet::contrib::AxesDefinition const* axesDef = nullptr;
+  switch (axesDefinition_) {
+    case KT_Axes:
+    default:
+      axesDef = &kt_axes;
+      break;
+    case CA_Axes:
+      axesDef = &ca_axes;
+      break;
+    case AntiKT_Axes:
+      axesDef = &antikt_axes;
+      break;
+    case WTA_KT_Axes:
+      axesDef = &wta_kt_axes;
+      break;
+    case WTA_CA_Axes:
+      axesDef = &wta_ca_axes;
+      break;
+    case OnePass_KT_Axes:
+      axesDef = &onepass_kt_axes;
+      break;
+    case OnePass_CA_Axes:
+      axesDef = &onepass_ca_axes;
+      break;
+    case OnePass_AntiKT_Axes:
+      axesDef = &onepass_antikt_axes;
+      break;
+    case OnePass_WTA_KT_Axes:
+      axesDef = &onepass_wta_kt_axes;
+      break;
+    case OnePass_WTA_CA_Axes:
+      axesDef = &onepass_wta_ca_axes;
+      break;
+    case MultiPass_Axes:
+      axesDef = &multipass_axes;
+      break;
   };
 
-  routine_ = std::unique_ptr<fastjet::contrib::Njettiness> ( new fastjet::contrib::Njettiness( *axesDef, *measureDef ) );
-      
+  routine_ = std::unique_ptr<fastjet::contrib::Njettiness>(new fastjet::contrib::Njettiness(*axesDef, *measureDef));
 }
 
-void NjettinessAdder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+void NjettinessAdder::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // read input collection
-  edm::Handle<edm::View<reco::Jet> > jets;
+  edm::Handle<edm::View<reco::Jet>> jets;
   iEvent.getByToken(src_token_, jets);
-  
-  for ( std::vector<unsigned>::const_iterator n = Njets_.begin(); n != Njets_.end(); ++n )
-    {
-      std::ostringstream tauN_str;
-      tauN_str << "tau" << *n;
 
-      // prepare room for output
-      std::vector<float> tauN;
-      tauN.reserve(jets->size());
+  for (std::vector<unsigned>::const_iterator n = Njets_.begin(); n != Njets_.end(); ++n) {
+    std::ostringstream tauN_str;
+    tauN_str << "tau" << *n;
 
-      for ( typename edm::View<reco::Jet>::const_iterator jetIt = jets->begin() ; jetIt != jets->end() ; ++jetIt ) {
+    // prepare room for output
+    std::vector<float> tauN;
+    tauN.reserve(jets->size());
 
-	edm::Ptr<reco::Jet> jetPtr = jets->ptrAt(jetIt - jets->begin());
+    for (typename edm::View<reco::Jet>::const_iterator jetIt = jets->begin(); jetIt != jets->end(); ++jetIt) {
+      edm::Ptr<reco::Jet> jetPtr = jets->ptrAt(jetIt - jets->begin());
 
-	float t=getTau( *n, jetPtr );
+      float t = getTau(*n, jetPtr);
 
-	tauN.push_back(t);
-      }
-
-      auto outT = std::make_unique<edm::ValueMap<float>>();
-      edm::ValueMap<float>::Filler fillerT(*outT);
-      fillerT.insert(jets, tauN.begin(), tauN.end());
-      fillerT.fill();
-
-      iEvent.put(std::move(outT),tauN_str.str());
+      tauN.push_back(t);
     }
+
+    auto outT = std::make_unique<edm::ValueMap<float>>();
+    edm::ValueMap<float>::Filler fillerT(*outT);
+    fillerT.insert(jets, tauN.begin(), tauN.end());
+    fillerT.fill();
+
+    iEvent.put(std::move(outT), tauN_str.str());
+  }
 }
 
-float NjettinessAdder::getTau(unsigned num, const edm::Ptr<reco::Jet> & object) const
-{
+float NjettinessAdder::getTau(unsigned num, const edm::Ptr<reco::Jet>& object) const {
   std::vector<fastjet::PseudoJet> FJparticles;
-  for (unsigned k = 0; k < object->numberOfDaughters(); ++k)
-    {
-      const reco::CandidatePtr & dp = object->daughterPtr(k);
-      if ( dp.isNonnull() && dp.isAvailable() )
-	FJparticles.push_back( fastjet::PseudoJet( dp->px(), dp->py(), dp->pz(), dp->energy() ) );
-      else
-	edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
-    }
+  for (unsigned k = 0; k < object->numberOfDaughters(); ++k) {
+    const reco::CandidatePtr& dp = object->daughterPtr(k);
+    if (dp.isNonnull() && dp.isAvailable())
+      FJparticles.push_back(fastjet::PseudoJet(dp->px(), dp->py(), dp->pz(), dp->energy()));
+    else
+      edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
+  }
 
-  return routine_->getTau(num, FJparticles); 
+  return routine_->getTau(num, FJparticles);
 }
-
-
 
 DEFINE_FWK_MODULE(NjettinessAdder);

--- a/RecoJets/JetProducers/plugins/PUFilter.cc
+++ b/RecoJets/JetProducers/plugins/PUFilter.cc
@@ -17,52 +17,47 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "DataFormats/Common/interface/ValueMap.h"
-class PUFilter : public edm::global::EDProducer <> {
-   public:
-      explicit PUFilter(const edm::ParameterSet&);
+class PUFilter : public edm::global::EDProducer<> {
+public:
+  explicit PUFilter(const edm::ParameterSet&);
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      const edm::EDGetTokenT<edm::View<reco::PFJet> > jetsToken_;
-      const edm::EDGetTokenT<edm::ValueMap<int> > jetPuIdToken_;
-      void produce(edm::StreamID , edm::Event& , const edm::EventSetup & ) const override;
-     };
+private:
+  const edm::EDGetTokenT<edm::View<reco::PFJet>> jetsToken_;
+  const edm::EDGetTokenT<edm::ValueMap<int>> jetPuIdToken_;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+};
 
-
-PUFilter::PUFilter(const edm::ParameterSet& iConfig):
-jetsToken_( consumes<edm::View<reco::PFJet> > (iConfig.getParameter<edm::InputTag>("Jets") ) ),
-jetPuIdToken_( consumes<edm::ValueMap<int> > (iConfig.getParameter<edm::InputTag>("JetPUID") ) )
-{
-   produces<std::vector<reco::PFJet> > ();
+PUFilter::PUFilter(const edm::ParameterSet& iConfig)
+    : jetsToken_(consumes<edm::View<reco::PFJet>>(iConfig.getParameter<edm::InputTag>("Jets"))),
+      jetPuIdToken_(consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("JetPUID"))) {
+  produces<std::vector<reco::PFJet>>();
 }
 
+void PUFilter::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  using namespace edm;
 
-void
-PUFilter::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup & iSetup) const
-{
-   using namespace edm;
+  Handle<edm::View<reco::PFJet>> jetsH;
+  Handle<edm::ValueMap<int>> id_decisions;
 
-  Handle<edm::View<reco::PFJet> > jetsH;
-  Handle< edm::ValueMap<int> > id_decisions;
-  
-  iEvent.getByToken( jetsToken_, jetsH );
-  iEvent.getByToken( jetPuIdToken_, id_decisions );
-  
+  iEvent.getByToken(jetsToken_, jetsH);
+  iEvent.getByToken(jetPuIdToken_, id_decisions);
+
   auto goodjets = std::make_unique<std::vector<reco::PFJet>>();
-  for( size_t i = 0; i < jetsH->size(); ++i ) {
+  for (size_t i = 0; i < jetsH->size(); ++i) {
     auto jet = jetsH->refAt(i);
-    if((*id_decisions)[jet]) goodjets->push_back(*jet);
+    if ((*id_decisions)[jet])
+      goodjets->push_back(*jet);
   }
   iEvent.put(std::move(goodjets));
 }
 
-void
-PUFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-    edm::ParameterSetDescription desc;
+void PUFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("Jets", edm::InputTag("hltAK4PFJetsCorrected"));
-  desc.add<edm::InputTag>("JetPUID", edm::InputTag("MVAJetPuIdProducer","CATEv0Id"));
-  descriptions.add("PUFilter",desc);
+  desc.add<edm::InputTag>("JetPUID", edm::InputTag("MVAJetPuIdProducer", "CATEv0Id"));
+  descriptions.add("PUFilter", desc);
   desc.setUnknown();
 }
 DEFINE_FWK_MODULE(PUFilter);

--- a/RecoJets/JetProducers/plugins/PileupJPTJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJPTJetIdProducer.cc
@@ -18,103 +18,99 @@
 #include "DataFormats/JetReco/interface/JPTJetCollection.h"
 #include "DataFormats/JetReco/interface/JPTJet.h"
 
-
 // ------------------------------------------------------------------------------------------
 class PileupJPTJetIdProducer : public edm::EDProducer {
 public:
-	explicit PileupJPTJetIdProducer(const edm::ParameterSet&);
-	~PileupJPTJetIdProducer() override;
+  explicit PileupJPTJetIdProducer(const edm::ParameterSet&);
+  ~PileupJPTJetIdProducer() override;
 
 private:
-	void produce(edm::Event&, const edm::EventSetup&) override;
-      
-	edm::InputTag jets_;
-        edm::EDGetTokenT<edm::View<reco::JPTJet> > input_token_;
-             bool allowMissingInputs_;
-             int verbosity;
-        cms::PileupJPTJetIdAlgo* pualgo;
-	
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  edm::InputTag jets_;
+  edm::EDGetTokenT<edm::View<reco::JPTJet>> input_token_;
+  bool allowMissingInputs_;
+  int verbosity;
+  cms::PileupJPTJetIdAlgo* pualgo;
 };
 
 // ------------------------------------------------------------------------------------------
-PileupJPTJetIdProducer::PileupJPTJetIdProducer(const edm::ParameterSet& iConfig)
-{
-	jets_ = iConfig.getParameter<edm::InputTag>("jets");
-	input_token_ = consumes<edm::View<reco::JPTJet> >(jets_);
-        verbosity   = iConfig.getParameter<int>("Verbosity");
-        allowMissingInputs_=iConfig.getUntrackedParameter<bool>("AllowMissingInputs",false);
-        pualgo = new cms::PileupJPTJetIdAlgo(iConfig); 
-        pualgo->bookMVAReader();
-	produces<edm::ValueMap<float> > ("JPTPUDiscriminant");
-	produces<edm::ValueMap<int> > ("JPTPUId");
+PileupJPTJetIdProducer::PileupJPTJetIdProducer(const edm::ParameterSet& iConfig) {
+  jets_ = iConfig.getParameter<edm::InputTag>("jets");
+  input_token_ = consumes<edm::View<reco::JPTJet>>(jets_);
+  verbosity = iConfig.getParameter<int>("Verbosity");
+  allowMissingInputs_ = iConfig.getUntrackedParameter<bool>("AllowMissingInputs", false);
+  pualgo = new cms::PileupJPTJetIdAlgo(iConfig);
+  pualgo->bookMVAReader();
+  produces<edm::ValueMap<float>>("JPTPUDiscriminant");
+  produces<edm::ValueMap<int>>("JPTPUId");
 }
 
-
+// ------------------------------------------------------------------------------------------
+PileupJPTJetIdProducer::~PileupJPTJetIdProducer() {}
 
 // ------------------------------------------------------------------------------------------
-PileupJPTJetIdProducer::~PileupJPTJetIdProducer()
-{
-}
+void PileupJPTJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
+  using namespace reco;
+  edm::Handle<View<JPTJet>> jets;
+  iEvent.getByToken(input_token_, jets);
+  vector<float> mva;
+  vector<int> idflag;
+  for (unsigned int i = 0; i < jets->size(); ++i) {
+    int b = -1;
+    const JPTJet& jet = jets->at(i);
 
+    float mvapu = pualgo->fillJPTBlock(&jet);
 
-// ------------------------------------------------------------------------------------------
-void
-PileupJPTJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    using namespace edm;
-    using namespace std;
-    using namespace reco;
-    edm::Handle<View<JPTJet> > jets;
-    iEvent.getByToken(input_token_, jets);
-    vector<float> mva;
-    vector<int> idflag;
-    for ( unsigned int i=0; i<jets->size(); ++i ) {
-        int b = -1;
-        const JPTJet & jet = jets->at(i);
+    mva.push_back(mvapu);
 
-        float mvapu = pualgo->fillJPTBlock(&jet);
+    // Get PUid type
+    ///|eta|<2.6
+    //WP 95% JPT PUID > 0.3
+    //WP 90% JPT PUID > 0.7
+    //WP 80% JPT PUID > 0.9
 
-        mva.push_back(mvapu);
+    //|eta|>=2.6
+    //WP 90% JPT PUID > -0.55
+    //WP 80% JPT PUID > -0.3
+    //WP 70% JPT PUID > -0.1
 
-  // Get PUid type
-///|eta|<2.6
-//WP 95% JPT PUID > 0.3
-//WP 90% JPT PUID > 0.7
-//WP 80% JPT PUID > 0.9
-
-//|eta|>=2.6
-//WP 90% JPT PUID > -0.55
-//WP 80% JPT PUID > -0.3
-//WP 70% JPT PUID > -0.1
-        
-        if(fabs(jet.eta()) < 2.6 ) {
-           if( mvapu > 0.3 ) b = 0;
-           if( mvapu > 0.7 ) b = 1;
-           if( mvapu > 0.9 ) b = 2;
-        } else {
-           if( mvapu > -0.55 ) b = 0;
-           if( mvapu > -0.3 ) b = 1;
-           if( mvapu > -0.1 ) b = 2;
-        }
-
-        idflag.push_back(b); 
-
-       if(verbosity > 0) std::cout<<" PUID producer::Corrected JPT Jet is "<<jet.pt()<<" "<<jet.eta()<<" "<<jet.phi()<<" "<<jet.getSpecific().Zch<<std::endl; 
-    
+    if (fabs(jet.eta()) < 2.6) {
+      if (mvapu > 0.3)
+        b = 0;
+      if (mvapu > 0.7)
+        b = 1;
+      if (mvapu > 0.9)
+        b = 2;
+    } else {
+      if (mvapu > -0.55)
+        b = 0;
+      if (mvapu > -0.3)
+        b = 1;
+      if (mvapu > -0.1)
+        b = 2;
     }
-     
-    auto mvaout = std::make_unique<ValueMap<float>>();
-    ValueMap<float>::Filler mvafiller(*mvaout);
-    mvafiller.insert(jets,mva.begin(),mva.end());
-    mvafiller.fill();
-    iEvent.put(std::move(mvaout),"JPTPUDiscriminant");
 
-    auto idflagout = std::make_unique<ValueMap<int>>();
-    ValueMap<int>::Filler idflagfiller(*idflagout);
-    idflagfiller.insert(jets,idflag.begin(),idflag.end());
-    idflagfiller.fill();
-    iEvent.put(std::move(idflagout),"JPTPUId");
-       
+    idflag.push_back(b);
+
+    if (verbosity > 0)
+      std::cout << " PUID producer::Corrected JPT Jet is " << jet.pt() << " " << jet.eta() << " " << jet.phi() << " "
+                << jet.getSpecific().Zch << std::endl;
+  }
+
+  auto mvaout = std::make_unique<ValueMap<float>>();
+  ValueMap<float>::Filler mvafiller(*mvaout);
+  mvafiller.insert(jets, mva.begin(), mva.end());
+  mvafiller.fill();
+  iEvent.put(std::move(mvaout), "JPTPUDiscriminant");
+
+  auto idflagout = std::make_unique<ValueMap<int>>();
+  ValueMap<int>::Filler idflagfiller(*idflagout);
+  idflagfiller.insert(jets, idflag.begin(), idflag.end());
+  idflagfiller.fill();
+  iEvent.put(std::move(idflagout), "JPTPUId");
 }
 
 //define this as a plug-in

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    PileupJetIdProducer
 // Class:      PileupJetIdProducer
-// 
+//
 /**\class PileupJetIdProducer PileupJetIdProducer.cc CMGTools/PileupJetIdProducer/src/PileupJetIdProducer.cc
 
 Description: [one line class summary]
@@ -18,20 +18,19 @@ Implementation:
 
 #include "RecoJets/JetProducers/plugins/PileupJetIdProducer.h"
 
-GBRForestsAndConstants::GBRForestsAndConstants(edm::ParameterSet const& iConfig) :
-  runMvas_(iConfig.getParameter<bool>("runMvas")),
-  produceJetIds_(iConfig.getParameter<bool>("produceJetIds")),
-  inputIsCorrected_(iConfig.getParameter<bool>("inputIsCorrected")),
-  applyJec_(iConfig.getParameter<bool>("applyJec")),
-  jec_(iConfig.getParameter<std::string>("jec")),
-  residualsFromTxt_(iConfig.getParameter<bool>("residualsFromTxt")),
-  usePuppi_(iConfig.getParameter<bool>("usePuppi")) {
-
+GBRForestsAndConstants::GBRForestsAndConstants(edm::ParameterSet const& iConfig)
+    : runMvas_(iConfig.getParameter<bool>("runMvas")),
+      produceJetIds_(iConfig.getParameter<bool>("produceJetIds")),
+      inputIsCorrected_(iConfig.getParameter<bool>("inputIsCorrected")),
+      applyJec_(iConfig.getParameter<bool>("applyJec")),
+      jec_(iConfig.getParameter<std::string>("jec")),
+      residualsFromTxt_(iConfig.getParameter<bool>("residualsFromTxt")),
+      usePuppi_(iConfig.getParameter<bool>("usePuppi")) {
   if (residualsFromTxt_) {
     residualsTxt_ = iConfig.getParameter<edm::FileInPath>("residualsTxt");
   }
 
-  std::vector<edm::ParameterSet> algos = iConfig.getParameter<std::vector<edm::ParameterSet> >("algos");
+  std::vector<edm::ParameterSet> algos = iConfig.getParameter<std::vector<edm::ParameterSet>>("algos");
   for (auto const& algoPset : algos) {
     vAlgoGBRForestsAndConstants_.emplace_back(algoPset, runMvas_);
   }
@@ -42,229 +41,218 @@ GBRForestsAndConstants::GBRForestsAndConstants(edm::ParameterSet const& iConfig)
 }
 
 // ------------------------------------------------------------------------------------------
-PileupJetIdProducer::PileupJetIdProducer(const edm::ParameterSet& iConfig, GBRForestsAndConstants const* globalCache)
-{
-	if ( globalCache->produceJetIds() ) {
-		produces<edm::ValueMap<StoredPileupJetIdentifier> > ("");
-	}
-	for (auto const& algoGBRForestsAndConstants : globalCache->vAlgoGBRForestsAndConstants()) {
-		std::string const& label = algoGBRForestsAndConstants.label();
-		algos_.emplace_back(label, std::make_unique<PileupJetIdAlgo>(&algoGBRForestsAndConstants));
-		if ( globalCache->runMvas() ) {
-			produces<edm::ValueMap<float> > (label+"Discriminant");
-			produces<edm::ValueMap<int> > (label+"Id");
-		}
-	}
+PileupJetIdProducer::PileupJetIdProducer(const edm::ParameterSet& iConfig, GBRForestsAndConstants const* globalCache) {
+  if (globalCache->produceJetIds()) {
+    produces<edm::ValueMap<StoredPileupJetIdentifier>>("");
+  }
+  for (auto const& algoGBRForestsAndConstants : globalCache->vAlgoGBRForestsAndConstants()) {
+    std::string const& label = algoGBRForestsAndConstants.label();
+    algos_.emplace_back(label, std::make_unique<PileupJetIdAlgo>(&algoGBRForestsAndConstants));
+    if (globalCache->runMvas()) {
+      produces<edm::ValueMap<float>>(label + "Discriminant");
+      produces<edm::ValueMap<int>>(label + "Id");
+    }
+  }
 
-	input_jet_token_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("jets"));
-	input_vertex_token_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexes"));
-	input_vm_pujetid_token_ = consumes<edm::ValueMap<StoredPileupJetIdentifier> >(iConfig.getParameter<edm::InputTag>("jetids"));
-	input_rho_token_ = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
+  input_jet_token_ = consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jets"));
+  input_vertex_token_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexes"));
+  input_vm_pujetid_token_ =
+      consumes<edm::ValueMap<StoredPileupJetIdentifier>>(iConfig.getParameter<edm::InputTag>("jetids"));
+  input_rho_token_ = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
 }
 
-
+// ------------------------------------------------------------------------------------------
+PileupJetIdProducer::~PileupJetIdProducer() {}
 
 // ------------------------------------------------------------------------------------------
-PileupJetIdProducer::~PileupJetIdProducer()
-{
+void PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  GBRForestsAndConstants const* gc = globalCache();
+
+  using namespace edm;
+  using namespace std;
+  using namespace reco;
+
+  // Input jets
+  Handle<View<Jet>> jetHandle;
+  iEvent.getByToken(input_jet_token_, jetHandle);
+  const View<Jet>& jets = *jetHandle;
+  // vertexes
+  Handle<VertexCollection> vertexHandle;
+  if (gc->produceJetIds()) {
+    iEvent.getByToken(input_vertex_token_, vertexHandle);
+  }
+  const VertexCollection& vertexes = *(vertexHandle.product());
+  // input variables
+  Handle<ValueMap<StoredPileupJetIdentifier>> vmap;
+  if (!gc->produceJetIds()) {
+    iEvent.getByToken(input_vm_pujetid_token_, vmap);
+  }
+  // rho
+  edm::Handle<double> rhoH;
+  double rho = 0.;
+
+  // products
+  vector<StoredPileupJetIdentifier> ids;
+  map<string, vector<float>> mvas;
+  map<string, vector<int>> idflags;
+
+  VertexCollection::const_iterator vtx;
+  if (gc->produceJetIds()) {
+    // require basic quality cuts on the vertexes
+    vtx = vertexes.begin();
+    while (vtx != vertexes.end() && (vtx->isFake() || vtx->ndof() < 4)) {
+      ++vtx;
+    }
+    if (vtx == vertexes.end()) {
+      vtx = vertexes.begin();
+    }
+  }
+
+  // Loop over input jets
+  bool ispat = true;
+  for (unsigned int i = 0; i < jets.size(); ++i) {
+    // Pick the first algo to compute the input variables
+    auto algoi = algos_.begin();
+    PileupJetIdAlgo* ialgo = algoi->second.get();
+
+    const Jet& jet = jets.at(i);
+    const pat::Jet* patjet = nullptr;
+    if (ispat) {
+      patjet = dynamic_cast<const pat::Jet*>(&jet);
+      ispat = patjet != nullptr;
+    }
+
+    // Get jet energy correction
+    float jec = 0.;
+    if (gc->applyJec()) {
+      // If haven't done it get rho from the event
+      if (rho == 0.) {
+        iEvent.getByToken(input_rho_token_, rhoH);
+        rho = *rhoH;
+      }
+      // jet corrector
+      if (not jecCor_) {
+        initJetEnergyCorrector(iSetup, iEvent.isRealData());
+      }
+      if (ispat) {
+        jecCor_->setJetPt(patjet->correctedJet(0).pt());
+      } else {
+        jecCor_->setJetPt(jet.pt());
+      }
+      jecCor_->setJetEta(jet.eta());
+      jecCor_->setJetA(jet.jetArea());
+      jecCor_->setRho(rho);
+      jec = jecCor_->getCorrection();
+    }
+    // If it was requested AND the input is an uncorrected jet apply the JEC
+    bool applyJec = gc->applyJec() && (ispat || !gc->inputIsCorrected());
+    std::unique_ptr<reco::Jet> corrJet;
+
+    if (applyJec) {
+      float scale = jec;
+      if (ispat) {
+        corrJet.reset(new pat::Jet(patjet->correctedJet(0)));
+      } else {
+        corrJet.reset(dynamic_cast<reco::Jet*>(jet.clone()));
+      }
+      corrJet->scaleEnergy(scale);
+    }
+    const reco::Jet* theJet = (applyJec ? corrJet.get() : &jet);
+
+    PileupJetIdentifier puIdentifier;
+    if (gc->produceJetIds()) {
+      // Compute the input variables
+      puIdentifier = ialgo->computeIdVariables(theJet, jec, &(*vtx), vertexes, rho, gc->usePuppi());
+      ids.push_back(puIdentifier);
+    } else {
+      // Or read it from the value map
+      puIdentifier = (*vmap)[jets.refAt(i)];
+      puIdentifier.jetPt(theJet->pt());  // make sure JEC is applied when computing the MVA
+      puIdentifier.jetEta(theJet->eta());
+      puIdentifier.jetPhi(theJet->phi());
+      ialgo->set(puIdentifier);
+      puIdentifier = ialgo->computeMva();
+    }
+
+    if (gc->runMvas()) {
+      // Compute the MVA and WP
+      mvas[algoi->first].push_back(puIdentifier.mva());
+      idflags[algoi->first].push_back(puIdentifier.idFlag());
+      for (++algoi; algoi != algos_.end(); ++algoi) {
+        ialgo = algoi->second.get();
+        ialgo->set(puIdentifier);
+        PileupJetIdentifier id = ialgo->computeMva();
+        mvas[algoi->first].push_back(id.mva());
+        idflags[algoi->first].push_back(id.idFlag());
+      }
+    }
+  }
+
+  // Produce the output value maps
+  if (gc->runMvas()) {
+    for (const auto& ialgo : algos_) {
+      // MVA
+      vector<float>& mva = mvas[ialgo.first];
+      auto mvaout = std::make_unique<ValueMap<float>>();
+      ValueMap<float>::Filler mvafiller(*mvaout);
+      mvafiller.insert(jetHandle, mva.begin(), mva.end());
+      mvafiller.fill();
+      iEvent.put(std::move(mvaout), ialgo.first + "Discriminant");
+
+      // WP
+      vector<int>& idflag = idflags[ialgo.first];
+      auto idflagout = std::make_unique<ValueMap<int>>();
+      ValueMap<int>::Filler idflagfiller(*idflagout);
+      idflagfiller.insert(jetHandle, idflag.begin(), idflag.end());
+      idflagfiller.fill();
+      iEvent.put(std::move(idflagout), ialgo.first + "Id");
+    }
+  }
+  // input variables
+  if (gc->produceJetIds()) {
+    assert(jetHandle->size() == ids.size());
+    auto idsout = std::make_unique<ValueMap<StoredPileupJetIdentifier>>();
+    ValueMap<StoredPileupJetIdentifier>::Filler idsfiller(*idsout);
+    idsfiller.insert(jetHandle, ids.begin(), ids.end());
+    idsfiller.fill();
+    iEvent.put(std::move(idsout));
+  }
 }
 
-
 // ------------------------------------------------------------------------------------------
-void
-PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-	GBRForestsAndConstants const* gc = globalCache();
-
-	using namespace edm;
-	using namespace std;
-	using namespace reco;
-	
-	// Input jets
-	Handle<View<Jet> > jetHandle;
-	iEvent.getByToken(input_jet_token_,jetHandle);
-	const View<Jet> & jets = *jetHandle;
-	// vertexes 
-	Handle<VertexCollection> vertexHandle;
-	if(  gc->produceJetIds() ) {
-	        iEvent.getByToken(input_vertex_token_, vertexHandle);
-	}
-	const VertexCollection & vertexes = *(vertexHandle.product());
-	// input variables
-	Handle<ValueMap<StoredPileupJetIdentifier> > vmap;
-	if( ! gc->produceJetIds() ) {
-		iEvent.getByToken(input_vm_pujetid_token_, vmap);
-	}
-	// rho
-	edm::Handle< double > rhoH;
-	double rho = 0.;
-	
-	// products
-	vector<StoredPileupJetIdentifier> ids; 
-	map<string, vector<float> > mvas;
-	map<string, vector<int> > idflags;
-
-	VertexCollection::const_iterator vtx;
-	if( gc->produceJetIds() ) {
-		// require basic quality cuts on the vertexes
-		vtx = vertexes.begin();
-		while( vtx != vertexes.end() && ( vtx->isFake() || vtx->ndof() < 4 ) ) {
-			++vtx;
-		}
-		if( vtx == vertexes.end() ) { vtx = vertexes.begin(); }
-	}
-	
-	// Loop over input jets
-	bool ispat = true;
-	for ( unsigned int i=0; i<jets.size(); ++i ) {
-		// Pick the first algo to compute the input variables
-		auto algoi = algos_.begin();
-		PileupJetIdAlgo * ialgo = algoi->second.get();
-		
-		const Jet & jet = jets.at(i);
-		const pat::Jet * patjet = nullptr;
-		if(ispat) {
-		    patjet=dynamic_cast<const pat::Jet *>(&jet);
-		    ispat = patjet != nullptr;
-		}
-		
-		// Get jet energy correction
-		float jec = 0.;
-		if( gc->applyJec() ) {
-			// If haven't done it get rho from the event
-			if( rho == 0. ) {
-				iEvent.getByToken(input_rho_token_,rhoH);
-				rho = *rhoH;
-			}
-			// jet corrector
-			if( not jecCor_ ) {
-				initJetEnergyCorrector( iSetup, iEvent.isRealData() );
-			}
-			if( ispat ) {
-				jecCor_->setJetPt(patjet->correctedJet(0).pt());
-			} else {
-			        jecCor_->setJetPt(jet.pt());
-			}
-			jecCor_->setJetEta(jet.eta());
-			jecCor_->setJetA(jet.jetArea());
-			jecCor_->setRho(rho);
-			jec = jecCor_->getCorrection();
-		}
-		// If it was requested AND the input is an uncorrected jet apply the JEC
-		bool applyJec = gc->applyJec() && ( ispat || !gc->inputIsCorrected() );
-		std::unique_ptr<reco::Jet> corrJet;
-		
-		if( applyJec ) {
-			float scale = jec;
-			if( ispat ) {
-				corrJet.reset(new pat::Jet(patjet->correctedJet(0))) ;
-			} else {
-				corrJet.reset(dynamic_cast<reco::Jet *>( jet.clone() ));
-			}
-			corrJet->scaleEnergy(scale);
-		}
-		const reco::Jet * theJet = ( applyJec ? corrJet.get() : &jet );
-	
-		PileupJetIdentifier puIdentifier;
-		if( gc->produceJetIds() ) {
-		        // Compute the input variables
-		        puIdentifier = ialgo->computeIdVariables(theJet, jec,  &(*vtx), vertexes, rho,gc->usePuppi());
-			ids.push_back( puIdentifier );
-		} else {
-		        // Or read it from the value map
-			puIdentifier = (*vmap)[jets.refAt(i)]; 
-			puIdentifier.jetPt(theJet->pt());    // make sure JEC is applied when computing the MVA
-			puIdentifier.jetEta(theJet->eta());
-			puIdentifier.jetPhi(theJet->phi());
-			ialgo->set(puIdentifier); 
-			puIdentifier = ialgo->computeMva();
-		}
-	
-		if( gc->runMvas() ) {
-		        // Compute the MVA and WP
-			mvas[algoi->first].push_back( puIdentifier.mva() );
-			idflags[algoi->first].push_back( puIdentifier.idFlag() );
-			for( ++algoi; algoi!=algos_.end(); ++algoi) {
-                                ialgo = algoi->second.get();
-				ialgo->set(puIdentifier);
-				PileupJetIdentifier id = ialgo->computeMva();
-				mvas[algoi->first].push_back( id.mva() );
-				idflags[algoi->first].push_back( id.idFlag() );
-			}
-		}
-	}
-	
-	// Produce the output value maps
-	if( gc->runMvas() ) {
-                for( const auto& ialgo : algos_) {
-			// MVA
-			vector<float> & mva = mvas[ialgo.first];
-			auto mvaout = std::make_unique<ValueMap<float>>();
-			ValueMap<float>::Filler mvafiller(*mvaout);
-			mvafiller.insert(jetHandle,mva.begin(),mva.end());
-			mvafiller.fill();
-			iEvent.put(std::move(mvaout),ialgo.first+"Discriminant");
-			
-			// WP
-			vector<int> & idflag = idflags[ialgo.first];
-			auto idflagout = std::make_unique<ValueMap<int>>();
-			ValueMap<int>::Filler idflagfiller(*idflagout);
-			idflagfiller.insert(jetHandle,idflag.begin(),idflag.end());
-			idflagfiller.fill();
-			iEvent.put(std::move(idflagout),ialgo.first+"Id");
-		}
-	}
-	// input variables
-	if( gc->produceJetIds() ) {
-		assert( jetHandle->size() == ids.size() );
-		auto idsout = std::make_unique<ValueMap<StoredPileupJetIdentifier>>();
-		ValueMap<StoredPileupJetIdentifier>::Filler idsfiller(*idsout);
-		idsfiller.insert(jetHandle,ids.begin(),ids.end());
-		idsfiller.fill();
-		iEvent.put(std::move(idsout));
-	}
+void PileupJetIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
 }
 
-
-
 // ------------------------------------------------------------------------------------------
-void
-PileupJetIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-	//The following says we do not know what parameters are allowed so do no validation
-	// Please change this to state exactly what you do use, even if it is no parameters
-	edm::ParameterSetDescription desc;
-	desc.setUnknown();
-	descriptions.addDefault(desc);
-}
+void PileupJetIdProducer::initJetEnergyCorrector(const edm::EventSetup& iSetup, bool isData) {
+  GBRForestsAndConstants const* gc = globalCache();
 
+  //jet energy correction levels to apply on raw jet
+  std::vector<std::string> jecLevels;
+  jecLevels.push_back("L1FastJet");
+  jecLevels.push_back("L2Relative");
+  jecLevels.push_back("L3Absolute");
+  if (isData && !gc->residualsFromTxt())
+    jecLevels.push_back("L2L3Residual");
 
-// ------------------------------------------------------------------------------------------
-void 
-PileupJetIdProducer::initJetEnergyCorrector(const edm::EventSetup &iSetup, bool isData)
-{
-	GBRForestsAndConstants const* gc = globalCache();
+  //check the corrector parameters needed according to the correction levels
+  edm::ESHandle<JetCorrectorParametersCollection> parameters;
+  iSetup.get<JetCorrectionsRecord>().get(gc->jec(), parameters);
+  for (std::vector<std::string>::const_iterator ll = jecLevels.begin(); ll != jecLevels.end(); ++ll) {
+    const JetCorrectorParameters& ip = (*parameters)[*ll];
+    jetCorPars_.push_back(ip);
+  }
+  if (isData && gc->residualsFromTxt()) {
+    jetCorPars_.push_back(JetCorrectorParameters(gc->residualsTxt().fullPath()));
+  }
 
-	//jet energy correction levels to apply on raw jet
-	std::vector<std::string> jecLevels;
-	jecLevels.push_back("L1FastJet");
-	jecLevels.push_back("L2Relative");
-	jecLevels.push_back("L3Absolute");
-	if(isData && ! gc->residualsFromTxt() ) jecLevels.push_back("L2L3Residual");
-
-	//check the corrector parameters needed according to the correction levels
-	edm::ESHandle<JetCorrectorParametersCollection> parameters;
-	iSetup.get<JetCorrectionsRecord>().get(gc->jec(),parameters);
-	for(std::vector<std::string>::const_iterator ll = jecLevels.begin(); ll != jecLevels.end(); ++ll)
-	{ 
-		const JetCorrectorParameters& ip = (*parameters)[*ll];
-		jetCorPars_.push_back(ip); 
-	} 
-	if( isData && gc->residualsFromTxt() ) {
-		jetCorPars_.push_back(JetCorrectorParameters(gc->residualsTxt().fullPath()));
-	}
-	
-	//instantiate the jet corrector
-	jecCor_ = std::make_unique<FactorizedJetCorrector>(jetCorPars_);
+  //instantiate the jet corrector
+  jecCor_ = std::make_unique<FactorizedJetCorrector>(jetCorPars_);
 }
 //define this as a plug-in
 DEFINE_FWK_MODULE(PileupJetIdProducer);

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    PileupJetIdProducer
 // Class:      PileupJetIdProducer
-// 
+//
 /**\class PileupJetIdProducer PileupJetIdProducer.cc CMGTools/PileupJetIdProducer/src/PileupJetIdProducer.cc
 
 Description: Produces a value map of jet --> pileup jet ID
@@ -18,7 +18,6 @@ Implementation:
 //         Created:  Wed Apr 18 15:48:47 CEST 2012
 //
 //
-
 
 // system include files
 #include <memory>
@@ -49,7 +48,6 @@ Implementation:
 
 class GBRForestsAndConstants {
 public:
-
   GBRForestsAndConstants(edm::ParameterSet const&);
 
   std::vector<PileupJetIdAlgo::AlgoGBRForestsAndConstants> const& vAlgoGBRForestsAndConstants() const {
@@ -66,7 +64,6 @@ public:
   bool usePuppi() const { return usePuppi_; }
 
 private:
-
   std::vector<PileupJetIdAlgo::AlgoGBRForestsAndConstants> vAlgoGBRForestsAndConstants_;
 
   bool runMvas_;
@@ -90,24 +87,22 @@ public:
     return std::make_unique<GBRForestsAndConstants>(pset);
   }
 
-  static void globalEndJob(GBRForestsAndConstants*) { }
+  static void globalEndJob(GBRForestsAndConstants*) {}
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-      
 
-  void initJetEnergyCorrector(const edm::EventSetup &iSetup, bool isData);
+  void initJetEnergyCorrector(const edm::EventSetup& iSetup, bool isData);
 
-  std::vector<std::pair<std::string, std::unique_ptr<PileupJetIdAlgo>> > algos_;
-	
+  std::vector<std::pair<std::string, std::unique_ptr<PileupJetIdAlgo>>> algos_;
+
   std::unique_ptr<FactorizedJetCorrector> jecCor_;
   std::vector<JetCorrectorParameters> jetCorPars_;
 
-  edm::EDGetTokenT<edm::View<reco::Jet> > input_jet_token_;
+  edm::EDGetTokenT<edm::View<reco::Jet>> input_jet_token_;
   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;
-  edm::EDGetTokenT<edm::ValueMap<StoredPileupJetIdentifier> > input_vm_pujetid_token_;
+  edm::EDGetTokenT<edm::ValueMap<StoredPileupJetIdentifier>> input_vm_pujetid_token_;
   edm::EDGetTokenT<double> input_rho_token_;
-
 };
 
 #endif

--- a/RecoJets/JetProducers/plugins/PtMinJetSelector.h
+++ b/RecoJets/JetProducers/plugins/PtMinJetSelector.h
@@ -20,8 +20,7 @@
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/JetReco/interface/BasicJetCollection.h"
 
-typedef SingleObjectSelector <reco::CaloJetCollection, PtMinSelector> PtMinCaloJetSelector;
-typedef SingleObjectSelector <reco::GenJetCollection, PtMinSelector> PtMinGenJetSelector;
-typedef SingleObjectSelector <reco::PFJetCollection, PtMinSelector> PtMinPFJetSelector;
-typedef SingleObjectSelector <reco::BasicJetCollection, PtMinSelector> PtMinBasicJetSelector;
-
+typedef SingleObjectSelector<reco::CaloJetCollection, PtMinSelector> PtMinCaloJetSelector;
+typedef SingleObjectSelector<reco::GenJetCollection, PtMinSelector> PtMinGenJetSelector;
+typedef SingleObjectSelector<reco::PFJetCollection, PtMinSelector> PtMinPFJetSelector;
+typedef SingleObjectSelector<reco::BasicJetCollection, PtMinSelector> PtMinBasicJetSelector;

--- a/RecoJets/JetProducers/plugins/QGTagger.cc
+++ b/RecoJets/JetProducers/plugins/QGTagger.cc
@@ -25,22 +25,21 @@
  * If the input jets are uncorrected, the jecService should be provided, so jet are corrected on the fly before the algorithm is applied
  * Authors: andrea.carlo.marini@cern.ch, tom.cornelis@cern.ch, cms-qg-workinggroup@cern.ch
  */
-QGTagger::QGTagger(const edm::ParameterSet& iConfig) :
-  jetsToken( 		consumes<edm::View<reco::Jet>>(		iConfig.getParameter<edm::InputTag>("srcJets"))),
-  jetCorrectorToken(	consumes<reco::JetCorrector>(		iConfig.getParameter<edm::InputTag>("jec"))),
-  vertexToken(		consumes<reco::VertexCollection>(	iConfig.getParameter<edm::InputTag>("srcVertexCollection"))),
-  rhoToken(		consumes<double>(			iConfig.getParameter<edm::InputTag>("srcRho"))),
-  jetsLabel(							iConfig.getParameter<std::string>("jetsLabel")),
-  systLabel(							iConfig.getParameter<std::string>("systematicsLabel")),
-  useQC(							iConfig.getParameter<bool>("useQualityCuts")),
-  useJetCorr(							!iConfig.getParameter<edm::InputTag>("jec").label().empty()),
-  produceSyst(							!systLabel.empty())
-{
+QGTagger::QGTagger(const edm::ParameterSet& iConfig)
+    : jetsToken(consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("srcJets"))),
+      jetCorrectorToken(consumes<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("jec"))),
+      vertexToken(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("srcVertexCollection"))),
+      rhoToken(consumes<double>(iConfig.getParameter<edm::InputTag>("srcRho"))),
+      jetsLabel(iConfig.getParameter<std::string>("jetsLabel")),
+      systLabel(iConfig.getParameter<std::string>("systematicsLabel")),
+      useQC(iConfig.getParameter<bool>("useQualityCuts")),
+      useJetCorr(!iConfig.getParameter<edm::InputTag>("jec").label().empty()),
+      produceSyst(!systLabel.empty()) {
   produces<edm::ValueMap<float>>("qgLikelihood");
   produces<edm::ValueMap<float>>("axis2");
   produces<edm::ValueMap<int>>("mult");
   produces<edm::ValueMap<float>>("ptD");
-  if(produceSyst){
+  if (produceSyst) {
     produces<edm::ValueMap<float>>("qgLikelihoodSmearedQuark");
     produces<edm::ValueMap<float>>("qgLikelihoodSmearedGluon");
     produces<edm::ValueMap<float>>("qgLikelihoodSmearedAll");
@@ -48,72 +47,84 @@ QGTagger::QGTagger(const edm::ParameterSet& iConfig) :
   qgLikelihood = new QGLikelihoodCalculator();
 }
 
-
 /// Produce qgLikelihood using {mult, ptD, -log(axis2)}
 void QGTagger::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-  std::vector<float>* qgProduct 		= new std::vector<float>;
-  std::vector<float>* axis2Product 		= new std::vector<float>;
-  std::vector<int>*   multProduct 		= new std::vector<int>;
-  std::vector<float>* ptDProduct 		= new std::vector<float>;
-  std::vector<float>* smearedQuarkProduct 	= new std::vector<float>;
-  std::vector<float>* smearedGluonProduct 	= new std::vector<float>;
-  std::vector<float>* smearedAllProduct 	= new std::vector<float>;
+  std::vector<float>* qgProduct = new std::vector<float>;
+  std::vector<float>* axis2Product = new std::vector<float>;
+  std::vector<int>* multProduct = new std::vector<int>;
+  std::vector<float>* ptDProduct = new std::vector<float>;
+  std::vector<float>* smearedQuarkProduct = new std::vector<float>;
+  std::vector<float>* smearedGluonProduct = new std::vector<float>;
+  std::vector<float>* smearedAllProduct = new std::vector<float>;
 
-  edm::Handle<edm::View<reco::Jet>> jets;				iEvent.getByToken(jetsToken, 		jets);
-  edm::Handle<reco::JetCorrector> jetCorr;		if(useJetCorr)	iEvent.getByToken(jetCorrectorToken, 	jetCorr);
-  edm::Handle<reco::VertexCollection> vertexCollection;			iEvent.getByToken(vertexToken, 		vertexCollection);
-  edm::Handle<double> rho;						iEvent.getByToken(rhoToken, 		rho);
+  edm::Handle<edm::View<reco::Jet>> jets;
+  iEvent.getByToken(jetsToken, jets);
+  edm::Handle<reco::JetCorrector> jetCorr;
+  if (useJetCorr)
+    iEvent.getByToken(jetCorrectorToken, jetCorr);
+  edm::Handle<reco::VertexCollection> vertexCollection;
+  iEvent.getByToken(vertexToken, vertexCollection);
+  edm::Handle<double> rho;
+  iEvent.getByToken(rhoToken, rho);
 
   edm::ESHandle<QGLikelihoodObject> QGLParamsColl;
-  QGLikelihoodRcd const & rcdhandle = iSetup.get<QGLikelihoodRcd>();
+  QGLikelihoodRcd const& rcdhandle = iSetup.get<QGLikelihoodRcd>();
   rcdhandle.get(jetsLabel, QGLParamsColl);
 
   edm::ESHandle<QGLikelihoodSystematicsObject> QGLSystColl;
-  if(produceSyst){
-    QGLikelihoodSystematicsRcd const & systrcdhandle = iSetup.get<QGLikelihoodSystematicsRcd>();
+  if (produceSyst) {
+    QGLikelihoodSystematicsRcd const& systrcdhandle = iSetup.get<QGLikelihoodSystematicsRcd>();
     systrcdhandle.get(systLabel, QGLSystColl);
   }
 
   bool weStillNeedToCheckJetCandidates = true;
   bool weAreUsingPackedCandidates = false;
-  for(auto jet = jets->begin(); jet != jets->end(); ++jet){
-    if(weStillNeedToCheckJetCandidates) {
+  for (auto jet = jets->begin(); jet != jets->end(); ++jet) {
+    if (weStillNeedToCheckJetCandidates) {
       weAreUsingPackedCandidates = isPackedCandidate(&*jet);
       weStillNeedToCheckJetCandidates = false;
     }
-    float pt = (useJetCorr ? jet->pt()*jetCorr->correction(*jet) : jet->pt());
+    float pt = (useJetCorr ? jet->pt() * jetCorr->correction(*jet) : jet->pt());
 
-    float ptD, axis2; int mult;
+    float ptD, axis2;
+    int mult;
     std::tie(mult, ptD, axis2) = calcVariables(&*jet, vertexCollection, weAreUsingPackedCandidates);
 
     float qgValue;
-    if(mult > 2) qgValue = qgLikelihood->computeQGLikelihood(QGLParamsColl, pt, jet->eta(), *rho, {(float) mult, ptD, -std::log(axis2)});
-    else         qgValue = -1;
+    if (mult > 2)
+      qgValue =
+          qgLikelihood->computeQGLikelihood(QGLParamsColl, pt, jet->eta(), *rho, {(float)mult, ptD, -std::log(axis2)});
+    else
+      qgValue = -1;
 
     qgProduct->push_back(qgValue);
-    if(produceSyst){
+    if (produceSyst) {
       smearedQuarkProduct->push_back(qgLikelihood->systematicSmearing(QGLSystColl, pt, jet->eta(), *rho, qgValue, 0));
       smearedGluonProduct->push_back(qgLikelihood->systematicSmearing(QGLSystColl, pt, jet->eta(), *rho, qgValue, 1));
-      smearedAllProduct->push_back(qgLikelihood->systematicSmearing(  QGLSystColl, pt, jet->eta(), *rho, qgValue, 2));
+      smearedAllProduct->push_back(qgLikelihood->systematicSmearing(QGLSystColl, pt, jet->eta(), *rho, qgValue, 2));
     }
     axis2Product->push_back(axis2);
     multProduct->push_back(mult);
     ptDProduct->push_back(ptD);
   }
 
-  putInEvent("qgLikelihood", jets, qgProduct,    iEvent);
-  putInEvent("axis2",        jets, axis2Product, iEvent);
-  putInEvent("mult",         jets, multProduct,  iEvent);
-  putInEvent("ptD",          jets, ptDProduct,   iEvent);
-  if(produceSyst){
+  putInEvent("qgLikelihood", jets, qgProduct, iEvent);
+  putInEvent("axis2", jets, axis2Product, iEvent);
+  putInEvent("mult", jets, multProduct, iEvent);
+  putInEvent("ptD", jets, ptDProduct, iEvent);
+  if (produceSyst) {
     putInEvent("qgLikelihoodSmearedQuark", jets, smearedQuarkProduct, iEvent);
     putInEvent("qgLikelihoodSmearedGluon", jets, smearedGluonProduct, iEvent);
-    putInEvent("qgLikelihoodSmearedAll",   jets, smearedAllProduct,   iEvent);
+    putInEvent("qgLikelihoodSmearedAll", jets, smearedAllProduct, iEvent);
   }
 }
 
 /// Function to put product into event
-template <typename T> void QGTagger::putInEvent(const std::string& name, const edm::Handle<edm::View<reco::Jet>>& jets, std::vector<T>* product, edm::Event& iEvent) const {
+template <typename T>
+void QGTagger::putInEvent(const std::string& name,
+                          const edm::Handle<edm::View<reco::Jet>>& jets,
+                          std::vector<T>* product,
+                          edm::Event& iEvent) const {
   auto out = std::make_unique<edm::ValueMap<T>>();
   typename edm::ValueMap<T>::Filler filler(*out);
   filler.insert(jets, product->begin(), product->end());
@@ -122,60 +133,74 @@ template <typename T> void QGTagger::putInEvent(const std::string& name, const e
   delete product;
 }
 
-
 /// Function to tell us if we are using packedCandidates, only test for first candidate
 bool QGTagger::isPackedCandidate(const reco::Jet* jet) const {
-  for(auto candidate : jet->getJetConstituentsQuick()){
-    if(typeid(pat::PackedCandidate)==typeid(*candidate)) return true;
-    else if(typeid(reco::PFCandidate)==typeid(*candidate)) return false;
-    else throw cms::Exception("WrongJetCollection", "Jet constituents are not particle flow candidates");
+  for (auto candidate : jet->getJetConstituentsQuick()) {
+    if (typeid(pat::PackedCandidate) == typeid(*candidate))
+      return true;
+    else if (typeid(reco::PFCandidate) == typeid(*candidate))
+      return false;
+    else
+      throw cms::Exception("WrongJetCollection", "Jet constituents are not particle flow candidates");
   }
   return false;
 }
 
-
 /// Calculation of axis2, mult and ptD
-std::tuple<int, float, float> QGTagger::calcVariables(const reco::Jet *jet, edm::Handle<reco::VertexCollection>& vC, bool weAreUsingPackedCandidates) const {
+std::tuple<int, float, float> QGTagger::calcVariables(const reco::Jet* jet,
+                                                      edm::Handle<reco::VertexCollection>& vC,
+                                                      bool weAreUsingPackedCandidates) const {
   float sum_weight = 0., sum_deta = 0., sum_dphi = 0., sum_deta2 = 0., sum_dphi2 = 0., sum_detadphi = 0., sum_pt = 0.;
   int mult = 0;
 
   //Loop over the jet constituents
-  for(auto daughter : jet->getJetConstituentsQuick()){
-    if(weAreUsingPackedCandidates){											//packed candidate situation
+  for (auto daughter : jet->getJetConstituentsQuick()) {
+    if (weAreUsingPackedCandidates) {  //packed candidate situation
       auto part = static_cast<const pat::PackedCandidate*>(daughter);
 
-      if(part->charge()){
-        if(!(part->fromPV() > 1 && part->trackHighPurity())) continue;
-        if(useQC){
-          if((part->dz()*part->dz())/(part->dzError()*part->dzError()) > 25.) continue;
-          if((part->dxy()*part->dxy())/(part->dxyError()*part->dxyError()) < 25.) ++mult;
-        } else ++mult;
+      if (part->charge()) {
+        if (!(part->fromPV() > 1 && part->trackHighPurity()))
+          continue;
+        if (useQC) {
+          if ((part->dz() * part->dz()) / (part->dzError() * part->dzError()) > 25.)
+            continue;
+          if ((part->dxy() * part->dxy()) / (part->dxyError() * part->dxyError()) < 25.)
+            ++mult;
+        } else
+          ++mult;
       } else {
-        if(part->pt() < 1.0) continue;
+        if (part->pt() < 1.0)
+          continue;
         ++mult;
       }
     } else {
       auto part = static_cast<const reco::PFCandidate*>(daughter);
 
       reco::TrackRef itrk = part->trackRef();
-      if(itrk.isNonnull()){												//Track exists --> charged particle
-        auto vtxLead  = vC->begin();
-        auto vtxClose = vC->begin();											//Search for closest vertex to track
-        for(auto vtx = vC->begin(); vtx != vC->end(); ++vtx){
-          if(fabs(itrk->dz(vtx->position())) < fabs(itrk->dz(vtxClose->position()))) vtxClose = vtx;
+      if (itrk.isNonnull()) {  //Track exists --> charged particle
+        auto vtxLead = vC->begin();
+        auto vtxClose = vC->begin();  //Search for closest vertex to track
+        for (auto vtx = vC->begin(); vtx != vC->end(); ++vtx) {
+          if (fabs(itrk->dz(vtx->position())) < fabs(itrk->dz(vtxClose->position())))
+            vtxClose = vtx;
         }
-        if(!(vtxClose == vtxLead && itrk->quality(reco::TrackBase::qualityByName("highPurity")))) continue;
+        if (!(vtxClose == vtxLead && itrk->quality(reco::TrackBase::qualityByName("highPurity"))))
+          continue;
 
-        if(useQC){													//If useQC, require dz and d0 cuts
+        if (useQC) {  //If useQC, require dz and d0 cuts
           float dz = itrk->dz(vtxClose->position());
           float d0 = itrk->dxy(vtxClose->position());
-          float dz_sigma_square = pow(itrk->dzError(),2) + pow(vtxClose->zError(),2);
-          float d0_sigma_square = pow(itrk->d0Error(),2) + pow(vtxClose->xError(),2) + pow(vtxClose->yError(),2);
-          if(dz*dz/dz_sigma_square > 25.) continue;
-          if(d0*d0/d0_sigma_square < 25.) ++mult;
-        } else ++mult;
-      } else {														//No track --> neutral particle
-        if(part->pt() < 1.0) continue;											//Only use neutrals with pt > 1 GeV
+          float dz_sigma_square = pow(itrk->dzError(), 2) + pow(vtxClose->zError(), 2);
+          float d0_sigma_square = pow(itrk->d0Error(), 2) + pow(vtxClose->xError(), 2) + pow(vtxClose->yError(), 2);
+          if (dz * dz / dz_sigma_square > 25.)
+            continue;
+          if (d0 * d0 / d0_sigma_square < 25.)
+            ++mult;
+        } else
+          ++mult;
+      } else {  //No track --> neutral particle
+        if (part->pt() < 1.0)
+          continue;  //Only use neutrals with pt > 1 GeV
         ++mult;
       }
     }
@@ -183,38 +208,37 @@ std::tuple<int, float, float> QGTagger::calcVariables(const reco::Jet *jet, edm:
     float deta = daughter->eta() - jet->eta();
     float dphi = reco::deltaPhi(daughter->phi(), jet->phi());
     float partPt = daughter->pt();
-    float weight = partPt*partPt;
+    float weight = partPt * partPt;
 
     sum_weight += weight;
     sum_pt += partPt;
-    sum_deta += deta*weight;
-    sum_dphi += dphi*weight;
-    sum_deta2 += deta*deta*weight;
-    sum_detadphi += deta*dphi*weight;
-    sum_dphi2 += dphi*dphi*weight;
+    sum_deta += deta * weight;
+    sum_dphi += dphi * weight;
+    sum_deta2 += deta * deta * weight;
+    sum_detadphi += deta * dphi * weight;
+    sum_dphi2 += dphi * dphi * weight;
   }
 
   //Calculate axis2 and ptD
   float a = 0., b = 0., c = 0.;
   float ave_deta = 0., ave_dphi = 0., ave_deta2 = 0., ave_dphi2 = 0.;
-  if(sum_weight > 0){
-    ave_deta = sum_deta/sum_weight;
-    ave_dphi = sum_dphi/sum_weight;
-    ave_deta2 = sum_deta2/sum_weight;
-    ave_dphi2 = sum_dphi2/sum_weight;
-    a = ave_deta2 - ave_deta*ave_deta;                          
-    b = ave_dphi2 - ave_dphi*ave_dphi;                          
-    c = -(sum_detadphi/sum_weight - ave_deta*ave_dphi);                
+  if (sum_weight > 0) {
+    ave_deta = sum_deta / sum_weight;
+    ave_dphi = sum_dphi / sum_weight;
+    ave_deta2 = sum_deta2 / sum_weight;
+    ave_dphi2 = sum_dphi2 / sum_weight;
+    a = ave_deta2 - ave_deta * ave_deta;
+    b = ave_dphi2 - ave_dphi * ave_dphi;
+    c = -(sum_detadphi / sum_weight - ave_deta * ave_dphi);
   }
-  float delta = sqrt(fabs((a-b)*(a-b)+4*c*c));
-  float axis2 = (a+b-delta > 0 ?  sqrt(0.5*(a+b-delta)) : 0);
-  float ptD   = (sum_weight > 0 ? sqrt(sum_weight)/sum_pt : 0);
+  float delta = sqrt(fabs((a - b) * (a - b) + 4 * c * c));
+  float axis2 = (a + b - delta > 0 ? sqrt(0.5 * (a + b - delta)) : 0);
+  float ptD = (sum_weight > 0 ? sqrt(sum_weight) / sum_pt : 0);
   return std::make_tuple(mult, ptD, axis2);
 }
 
-
 /// Descriptions method
-void QGTagger::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
+void QGTagger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("srcJets");
   desc.add<edm::InputTag>("srcRho");
@@ -223,9 +247,8 @@ void QGTagger::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
   desc.add<bool>("useQualityCuts");
   desc.add<edm::InputTag>("jec", edm::InputTag())->setComment("Jet correction service: only applied when non-empty");
   desc.add<edm::InputTag>("srcVertexCollection")->setComment("Ignored for miniAOD, possible to keep empty");
-  descriptions.add("QGTagger",  desc);
+  descriptions.add("QGTagger", desc);
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(QGTagger);

--- a/RecoJets/JetProducers/plugins/QGTagger.cc
+++ b/RecoJets/JetProducers/plugins/QGTagger.cc
@@ -34,7 +34,7 @@ QGTagger::QGTagger(const edm::ParameterSet& iConfig) :
   systLabel(							iConfig.getParameter<std::string>("systematicsLabel")),
   useQC(							iConfig.getParameter<bool>("useQualityCuts")),
   useJetCorr(							!iConfig.getParameter<edm::InputTag>("jec").label().empty()),
-  produceSyst(							systLabel != "")
+  produceSyst(							!systLabel.empty())
 {
   produces<edm::ValueMap<float>>("qgLikelihood");
   produces<edm::ValueMap<float>>("axis2");

--- a/RecoJets/JetProducers/plugins/QjetsAdder.cc
+++ b/RecoJets/JetProducers/plugins/QjetsAdder.cc
@@ -8,20 +8,20 @@
 
 using namespace std;
 
-void QjetsAdder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+void QjetsAdder::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // read input collection
   //edm::Handle<edm::View<pat::Jet> > jets;
-  edm::Handle<edm::View<reco::Jet> > jets;
+  edm::Handle<edm::View<reco::Jet>> jets;
   iEvent.getByToken(src_token_, jets);
 
   // prepare room for output
-  std::vector<float> QjetsVolatility;       QjetsVolatility.reserve(jets->size());
+  std::vector<float> QjetsVolatility;
+  QjetsVolatility.reserve(jets->size());
 
-  for ( typename edm::View<reco::Jet>::const_iterator jetIt = jets->begin() ; jetIt != jets->end() ; ++jetIt ) {
+  for (typename edm::View<reco::Jet>::const_iterator jetIt = jets->begin(); jetIt != jets->end(); ++jetIt) {
     reco::Jet newCand(*jetIt);
 
-    if(newCand.pt()<cutoff_)
-    {
+    if (newCand.pt() < cutoff_) {
       QjetsVolatility.push_back(-1);
       continue;
     }
@@ -29,20 +29,25 @@ void QjetsAdder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
     //refill and recluster
     vector<fastjet::PseudoJet> allconstits;
     //for (unsigned k=0; k < newCand.getPFConstituents().size(); k++){
-    for (unsigned k=0; k < newCand.getJetConstituents().size(); k++){
+    for (unsigned k = 0; k < newCand.getJetConstituents().size(); k++) {
       const edm::Ptr<reco::Candidate> thisParticle = newCand.getJetConstituents().at(k);
-      allconstits.push_back( fastjet::PseudoJet( thisParticle->px(), thisParticle->py(), thisParticle->pz(), thisParticle->energy() ) );
+      allconstits.push_back(
+          fastjet::PseudoJet(thisParticle->px(), thisParticle->py(), thisParticle->pz(), thisParticle->energy()));
     }
 
     fastjet::JetDefinition jetDef(fastjet::cambridge_algorithm, jetRad_);
-    if (mJetAlgo_== "AK") jetDef.set_jet_algorithm( fastjet::antikt_algorithm );
-    else if (mJetAlgo_ == "CA") jetDef.set_jet_algorithm( fastjet::cambridge_algorithm );
-    else throw cms::Exception("GroomedJetFiller") << " unknown jet algorithm " << std::endl;
+    if (mJetAlgo_ == "AK")
+      jetDef.set_jet_algorithm(fastjet::antikt_algorithm);
+    else if (mJetAlgo_ == "CA")
+      jetDef.set_jet_algorithm(fastjet::cambridge_algorithm);
+    else
+      throw cms::Exception("GroomedJetFiller") << " unknown jet algorithm " << std::endl;
 
     fastjet::ClusterSequence thisClustering_basic(allconstits, jetDef);
     std::vector<fastjet::PseudoJet> out_jets_basic = sorted_by_pt(thisClustering_basic.inclusive_jets(cutoff_));
     //std::cout << newCand.pt() << " " << out_jets_basic.size() <<std::endl;
-    if(out_jets_basic.size()!=1){ // jet reclustering did not return exactly 1 jet, most likely due to the higher cutoff or large cone size. Use a recognizeable default value for this jet
+    if (out_jets_basic.size() !=
+        1) {  // jet reclustering did not return exactly 1 jet, most likely due to the higher cutoff or large cone size. Use a recognizeable default value for this jet
       QjetsVolatility.push_back(-1);
       continue;
     }
@@ -53,48 +58,50 @@ void QjetsAdder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
     std::vector<double> qjetmass;
 
     vector<fastjet::PseudoJet> constits;
-    unsigned int nqjetconstits = out_jets_basic.at(0).constituents().size(); // there should always be exactly one reclsutered jet => always "at(0)"
-    if (nqjetconstits < (unsigned int) QjetsPreclustering_) constits = out_jets_basic.at(0).constituents();
-    else constits = out_jets_basic.at(0).associated_cluster_sequence()->exclusive_subjets_up_to(out_jets_basic.at(0),QjetsPreclustering_);
+    unsigned int nqjetconstits = out_jets_basic.at(0)
+                                     .constituents()
+                                     .size();  // there should always be exactly one reclsutered jet => always "at(0)"
+    if (nqjetconstits < (unsigned int)QjetsPreclustering_)
+      constits = out_jets_basic.at(0).constituents();
+    else
+      constits = out_jets_basic.at(0).associated_cluster_sequence()->exclusive_subjets_up_to(out_jets_basic.at(0),
+                                                                                             QjetsPreclustering_);
 
     edm::Service<edm::RandomNumberGenerator> rng;
     CLHEP::HepRandomEngine* engine = &rng->getEngine(iEvent.streamID());
     qjetsAlgo_.SetRNEngine(engine);
     // create probabilistic recusterings
-    for(unsigned int ii = 0 ; ii < (unsigned int) ntrial_ ; ii++){
+    for (unsigned int ii = 0; ii < (unsigned int)ntrial_; ii++) {
       //qjetsAlgo_.SetRandSeed(iEvent.id().event()*100 + (jetIt - jets->begin())*ntrial_ + ii );// set random seed for reprudcibility. We need a smarted scheme
       fastjet::ClusterSequence qjet_seq(constits, qjet_def);
       vector<fastjet::PseudoJet> inclusive_jets2 = sorted_by_pt(qjet_seq.inclusive_jets(cutoff_));
-      if (!inclusive_jets2.empty()){ // fill the massvalue only if the reclustering was successfull
-	qjetmass.push_back(inclusive_jets2[0].m());
+      if (!inclusive_jets2.empty()) {  // fill the massvalue only if the reclustering was successfull
+        qjetmass.push_back(inclusive_jets2[0].m());
       }
 
-    }//end loop on trials
+    }  //end loop on trials
 
-    if (qjetmass.empty()) {//protection against dummy case
+    if (qjetmass.empty()) {  //protection against dummy case
       QjetsVolatility.push_back(-1);
       continue;
     }
 
-    double mean = std::accumulate( qjetmass.begin( ) , qjetmass.end( ) , 0 ) /qjetmass.size() ;
+    double mean = std::accumulate(qjetmass.begin(), qjetmass.end(), 0) / qjetmass.size();
     float totalsquared = 0.;
-    for (unsigned int i = 0; i < qjetmass.size(); i++){
-      totalsquared += (qjetmass[i] - mean)*(qjetmass[i] - mean) ;
+    for (unsigned int i = 0; i < qjetmass.size(); i++) {
+      totalsquared += (qjetmass[i] - mean) * (qjetmass[i] - mean);
     }
-    float variance = sqrt( totalsquared/qjetmass.size() );  
-    
-    QjetsVolatility.push_back(variance/mean);
-  }//end loop on jets
+    float variance = sqrt(totalsquared / qjetmass.size());
+
+    QjetsVolatility.push_back(variance / mean);
+  }  //end loop on jets
 
   auto outQJV = std::make_unique<edm::ValueMap<float>>();
   edm::ValueMap<float>::Filler fillerQJV(*outQJV);
   fillerQJV.insert(jets, QjetsVolatility.begin(), QjetsVolatility.end());
   fillerQJV.fill();
 
-  iEvent.put(std::move(outQJV),"QjetsVolatility");
+  iEvent.put(std::move(outQJV), "QjetsVolatility");
 }
-
-
-
 
 DEFINE_FWK_MODULE(QjetsAdder);

--- a/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
@@ -12,160 +12,149 @@ using namespace edm;
 using namespace cms;
 
 namespace {
-   bool checkHydro(const reco::GenParticle * p){
-      const Candidate* m1 = p->mother();
-      while(m1){
-	 int pdg = abs(m1->pdgId());
-	 int st = m1->status();
-	 LogDebug("SubEventMothers")<<"Pdg ID : "<<pdg<<endl;
-	 if(st == 3 || pdg < 9 || pdg == 21){
-	    LogDebug("SubEventMothers")<<"Sub-Collision  Found! Pdg ID : "<<pdg<<endl;
-	    return false;
-	 }
-         const Candidate* m = m1->mother();
-	 m1 = m;
-	 if(!m1) LogDebug("SubEventMothers")<<"No Mother, particle is : "<<pdg<<" with status "<<st<<endl;
+  bool checkHydro(const reco::GenParticle* p) {
+    const Candidate* m1 = p->mother();
+    while (m1) {
+      int pdg = abs(m1->pdgId());
+      int st = m1->status();
+      LogDebug("SubEventMothers") << "Pdg ID : " << pdg << endl;
+      if (st == 3 || pdg < 9 || pdg == 21) {
+        LogDebug("SubEventMothers") << "Sub-Collision  Found! Pdg ID : " << pdg << endl;
+        return false;
       }
-      //      return true;
-      return true; // Debugging - to be changed
-   }
-}
+      const Candidate* m = m1->mother();
+      m1 = m;
+      if (!m1)
+        LogDebug("SubEventMothers") << "No Mother, particle is : " << pdg << " with status " << st << endl;
+    }
+    //      return true;
+    return true;  // Debugging - to be changed
+  }
+}  // namespace
 
-SubEventGenJetProducer::SubEventGenJetProducer(edm::ParameterSet const& conf):
-  VirtualJetProducer( conf )
-{
-   //   mapSrc_ = conf.getParameter<edm::InputTag>( "srcMap");
-   ignoreHydro_ = conf.getUntrackedParameter<bool>("ignoreHydro", true);
-   produces<reco::BasicJetCollection>();
+SubEventGenJetProducer::SubEventGenJetProducer(edm::ParameterSet const& conf) : VirtualJetProducer(conf) {
+  //   mapSrc_ = conf.getParameter<edm::InputTag>( "srcMap");
+  ignoreHydro_ = conf.getUntrackedParameter<bool>("ignoreHydro", true);
+  produces<reco::BasicJetCollection>();
   // the subjet collections are set through the config file in the "jetCollInstanceName" field.
 
-   input_cand_token_ = consumes<reco::CandidateView>(src_);
-
+  input_cand_token_ = consumes<reco::CandidateView>(src_);
 }
 
+void SubEventGenJetProducer::inputTowers() {
+  std::vector<edm::Ptr<reco::Candidate>>::const_iterator inBegin = inputs_.begin(), inEnd = inputs_.end(), i = inBegin;
+  for (; i != inEnd; ++i) {
+    reco::CandidatePtr input = inputs_[i - inBegin];
+    if (edm::isNotFinite(input->pt()))
+      continue;
+    if (input->et() < inputEtMin_)
+      continue;
+    if (input->energy() < inputEMin_)
+      continue;
+    if (isAnomalousTower(input))
+      continue;
 
-void SubEventGenJetProducer::inputTowers( ) 
-{
-   std::vector<edm::Ptr<reco::Candidate> >::const_iterator inBegin = inputs_.begin(),
-      inEnd = inputs_.end(), i = inBegin;
-   for (; i != inEnd; ++i ) {
-      reco::CandidatePtr input = inputs_[i - inBegin];
-      if (edm::isNotFinite(input->pt()))           continue;
-      if (input->et()    <inputEtMin_)  continue;
-      if (input->energy()<inputEMin_)   continue;
-      if (isAnomalousTower(input))      continue;
+    edm::Ptr<reco::Candidate> p = inputs_[i - inBegin];
+    const GenParticle* pref = dynamic_cast<const GenParticle*>(p.get());
+    int subevent = pref->collisionId();
+    LogDebug("SubEventContainers") << "SubEvent is : " << subevent << endl;
+    LogDebug("SubEventContainers") << "SubSize is : " << subInputs_.size() << endl;
 
-      edm::Ptr<reco::Candidate> p = inputs_[i - inBegin];
-      const GenParticle * pref = dynamic_cast<const GenParticle *>(p.get());
-      int subevent = pref->collisionId();
-      LogDebug("SubEventContainers")<<"SubEvent is : "<<subevent<<endl;
-      LogDebug("SubEventContainers")<<"SubSize is : "<<subInputs_.size()<<endl;
+    if (subevent >= (int)subInputs_.size()) {
+      hydroTag_.resize(subevent + 1, -1);
+      subInputs_.resize(subevent + 1);
+      LogDebug("SubEventContainers") << "SubSize is : " << subInputs_.size() << endl;
+      LogDebug("SubEventContainers") << "HydroTagSize is : " << hydroTag_.size() << endl;
+    }
 
-      if(subevent >= (int)subInputs_.size()){ 
-	 hydroTag_.resize(subevent+1, -1);
-         subInputs_.resize(subevent+1);
-      LogDebug("SubEventContainers")<<"SubSize is : "<<subInputs_.size()<<endl;
-      LogDebug("SubEventContainers")<<"HydroTagSize is : "<<hydroTag_.size()<<endl;
-      }
+    LogDebug("SubEventContainers") << "HydroTag is : " << hydroTag_[subevent] << endl;
+    if (hydroTag_[subevent] != 0)
+      hydroTag_[subevent] = (int)checkHydro(pref);
 
-      LogDebug("SubEventContainers")<<"HydroTag is : "<<hydroTag_[subevent]<<endl;
-      if(hydroTag_[subevent] != 0) hydroTag_[subevent] = (int)checkHydro(pref);
+    subInputs_[subevent].push_back(fastjet::PseudoJet(input->px(), input->py(), input->pz(), input->energy()));
 
-      subInputs_[subevent].push_back(fastjet::PseudoJet(input->px(),input->py(),input->pz(),
-						input->energy()));
-
-      subInputs_[subevent].back().set_user_index(i - inBegin);
-
-   }
-
+    subInputs_[subevent].back().set_user_index(i - inBegin);
+  }
 }
 
-void SubEventGenJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
-   LogDebug("VirtualJetProducer") << "Entered produce\n";
+void SubEventGenJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  LogDebug("VirtualJetProducer") << "Entered produce\n";
 
-   fjJets_.clear();
-   subInputs_.clear();
-   nSubParticles_.clear();
-   hydroTag_.clear();
-   inputs_.clear();
+  fjJets_.clear();
+  subInputs_.clear();
+  nSubParticles_.clear();
+  hydroTag_.clear();
+  inputs_.clear();
 
-   // get inputs and convert them to the fastjet format (fastjet::PeudoJet)
-   edm::Handle<reco::CandidateView> inputsHandle;
-   iEvent.getByToken(input_cand_token_, inputsHandle);
-   for (size_t i = 0; i < inputsHandle->size(); ++i) {
-     inputs_.push_back(inputsHandle->ptrAt(i));
-   }
-   LogDebug("VirtualJetProducer") << "Got inputs\n";
+  // get inputs and convert them to the fastjet format (fastjet::PeudoJet)
+  edm::Handle<reco::CandidateView> inputsHandle;
+  iEvent.getByToken(input_cand_token_, inputsHandle);
+  for (size_t i = 0; i < inputsHandle->size(); ++i) {
+    inputs_.push_back(inputsHandle->ptrAt(i));
+  }
+  LogDebug("VirtualJetProducer") << "Got inputs\n";
 
-   inputTowers();
-   // Convert candidates to fastjet::PseudoJets.
-   // Also correct to Primary Vertex. Will modify fjInputs_
-   // and use inputs_
+  inputTowers();
+  // Convert candidates to fastjet::PseudoJets.
+  // Also correct to Primary Vertex. Will modify fjInputs_
+  // and use inputs_
 
-   ////////////////
+  ////////////////
 
-   auto jets = std::make_unique<std::vector<GenJet>>();
-   subJets_ = jets.get();
+  auto jets = std::make_unique<std::vector<GenJet>>();
+  subJets_ = jets.get();
 
-   LogDebug("VirtualJetProducer") << "Inputted towers\n";
+  LogDebug("VirtualJetProducer") << "Inputted towers\n";
 
-   size_t nsub = subInputs_.size();
+  size_t nsub = subInputs_.size();
 
-   for(size_t isub = 0; isub < nsub; ++isub){
-      if(ignoreHydro_ && hydroTag_[isub]) continue;
-      fjJets_.clear();
-      fjInputs_.clear();
-      fjInputs_ = subInputs_[isub];
-      runAlgorithm( iEvent, iSetup );
-   }
+  for (size_t isub = 0; isub < nsub; ++isub) {
+    if (ignoreHydro_ && hydroTag_[isub])
+      continue;
+    fjJets_.clear();
+    fjInputs_.clear();
+    fjInputs_ = subInputs_[isub];
+    runAlgorithm(iEvent, iSetup);
+  }
 
-   //Finalize
-   LogDebug("SubEventJetProducer") << "Wrote jets\n";
+  //Finalize
+  LogDebug("SubEventJetProducer") << "Wrote jets\n";
 
-   iEvent.put(std::move(jets));  
-   return;
+  iEvent.put(std::move(jets));
+  return;
 }
 
-void SubEventGenJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iSetup)
-{
-   // run algorithm
-   fjJets_.clear();
+void SubEventGenJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup const& iSetup) {
+  // run algorithm
+  fjJets_.clear();
 
-   fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs_, *fjJetDefinition_ ) );
-   fjJets_ = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
-   
-   using namespace reco;
+  fjClusterSeq_ = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs_, *fjJetDefinition_));
+  fjJets_ = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
 
-   for (unsigned int ijet=0;ijet<fjJets_.size();++ijet) {
-      
-      GenJet jet;
-      const fastjet::PseudoJet& fjJet = fjJets_[ijet];
+  using namespace reco;
 
-      std::vector<fastjet::PseudoJet> fjConstituents =
-	 sorted_by_pt(fjClusterSeq_->constituents(fjJet));
+  for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
+    GenJet jet;
+    const fastjet::PseudoJet& fjJet = fjJets_[ijet];
 
-      std::vector<CandidatePtr> constituents =
-	 getConstituents(fjConstituents);
+    std::vector<fastjet::PseudoJet> fjConstituents = sorted_by_pt(fjClusterSeq_->constituents(fjJet));
 
-    double px=fjJet.px();
-    double py=fjJet.py();
-    double pz=fjJet.pz();
-    double E=fjJet.E();
-    double jetArea=0.0;
-    double pu=0.;
+    std::vector<CandidatePtr> constituents = getConstituents(fjConstituents);
 
-    writeSpecific( jet,
-		   Particle::LorentzVector(px, py, pz, E),
-		   vertex_,
-		   constituents, iSetup);
-    
-    jet.setJetArea (jetArea);
-    jet.setPileup (pu);
-    
+    double px = fjJet.px();
+    double py = fjJet.py();
+    double pz = fjJet.pz();
+    double E = fjJet.E();
+    double jetArea = 0.0;
+    double pu = 0.;
+
+    writeSpecific(jet, Particle::LorentzVector(px, py, pz, E), vertex_, constituents, iSetup);
+
+    jet.setJetArea(jetArea);
+    jet.setPileup(pu);
+
     subJets_->push_back(jet);
-   }   
+  }
 }
 
 DEFINE_FWK_MODULE(SubEventGenJetProducer);
-
-

--- a/RecoJets/JetProducers/plugins/SubEventGenJetProducer.h
+++ b/RecoJets/JetProducers/plugins/SubEventGenJetProducer.h
@@ -14,36 +14,30 @@
 #include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
 
-namespace cms
-{
-  class SubEventGenJetProducer : public VirtualJetProducer
-  {
+namespace cms {
+  class SubEventGenJetProducer : public VirtualJetProducer {
   public:
-
     SubEventGenJetProducer(const edm::ParameterSet& ps);
     ~SubEventGenJetProducer() override {}
     void produce(edm::Event&, const edm::EventSetup&) override;
     void runAlgorithm(edm::Event&, const edm::EventSetup&) override;
-    
-  protected:
-   std::vector<std::vector<fastjet::PseudoJet> > subInputs_;
-   std::vector<reco::GenJet>* subJets_;
-   std::vector<int> hydroTag_;
-   std::vector<int> nSubParticles_;
-   bool ignoreHydro_;
 
   protected:
+    std::vector<std::vector<fastjet::PseudoJet> > subInputs_;
+    std::vector<reco::GenJet>* subJets_;
+    std::vector<int> hydroTag_;
+    std::vector<int> nSubParticles_;
+    bool ignoreHydro_;
 
-    // overridden inputTowers method. Resets fjCompoundJets_ and 
+  protected:
+    // overridden inputTowers method. Resets fjCompoundJets_ and
     // calls VirtualJetProducer::inputTowers
     void inputTowers() override;
 
   private:
     edm::EDGetTokenT<reco::CandidateView> input_cand_token_;
-  
   };
-  
-}
 
+}  // namespace cms
 
 #endif

--- a/RecoJets/JetProducers/plugins/SubJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubJetProducer.cc
@@ -5,32 +5,22 @@ using namespace edm;
 using namespace cms;
 using namespace reco;
 
-SubJetProducer::SubJetProducer(edm::ParameterSet const& conf):
-  CompoundJetProducer( conf ),
-  alg_(conf.getParameter<double>("jetPtMin"),
-       conf.getParameter<int>("nSubjets"),
-       conf.getParameter<double>("zcut"),
-       conf.getParameter<double>("rcut_factor"),
-       fjJetDefinition_,
-       doAreaFastjet_,
-       fjActiveArea_,
-       voronoiRfact_
-       )
-{
-}
+SubJetProducer::SubJetProducer(edm::ParameterSet const& conf)
+    : CompoundJetProducer(conf),
+      alg_(conf.getParameter<double>("jetPtMin"),
+           conf.getParameter<int>("nSubjets"),
+           conf.getParameter<double>("zcut"),
+           conf.getParameter<double>("rcut_factor"),
+           fjJetDefinition_,
+           doAreaFastjet_,
+           fjActiveArea_,
+           voronoiRfact_) {}
 
-void SubJetProducer::produce(  edm::Event & e, const edm::EventSetup & c )
-{
-  CompoundJetProducer::produce(e, c);
-}
-  
-void SubJetProducer::runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void SubJetProducer::produce(edm::Event& e, const edm::EventSetup& c) { CompoundJetProducer::produce(e, c); }
 
-  alg_.run( fjInputs_, 
-	    fjCompoundJets_ );
+void SubJetProducer::runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  alg_.run(fjInputs_, fjCompoundJets_);
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(SubJetProducer);

--- a/RecoJets/JetProducers/plugins/SubJetProducer.h
+++ b/RecoJets/JetProducers/plugins/SubJetProducer.h
@@ -6,24 +6,20 @@
 #include "RecoJets/JetAlgorithms/interface/SubJetAlgorithm.h"
 #include "RecoJets/JetAlgorithms/interface/CompoundPseudoJet.h"
 
-namespace cms
-{
-  class SubJetProducer : public CompoundJetProducer
-  {
+namespace cms {
+  class SubJetProducer : public CompoundJetProducer {
   public:
-
     SubJetProducer(const edm::ParameterSet& ps);
 
     ~SubJetProducer() override {}
-    
-    void produce( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
-    
-    void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
+
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+    void runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   private:
-    SubJetAlgorithm        alg_;         /// The algorithm to do the work
-
+    SubJetAlgorithm alg_;  /// The algorithm to do the work
   };
 
-}
+}  // namespace cms
 #endif

--- a/RecoJets/JetProducers/plugins/SubjetFilterJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubjetFilterJetProducer.cc
@@ -4,7 +4,7 @@
 // -----------------------
 //
 // For a description of the Subjet/Filter algorithm, see e.g.
-// http://arXiv.org/abs/0802.2470 
+// http://arXiv.org/abs/0802.2470
 //
 // This implementation is largely based on fastjet_boosted_higgs.cc provided
 // with the fastjet package.
@@ -17,21 +17,18 @@
 // correspond to the subjets, while all remaining correspond to the filterjets.
 //
 // The real work is done in RecoJets/JetAlgorithms/src/SubjetFilterAlgorithm.cc
-//       
+//
 // see: https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideSubjetFilterJetProducer
 //
 //                       David Lopes-Pegna                 <david.lopes@cern.ch>
 //            25/11/2009 Philipp Schieferdecker <philipp.schieferdecker@cern.ch>
 ////////////////////////////////////////////////////////////////////////////////
 
-
 #include "SubjetFilterJetProducer.h"
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 using namespace std;
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // construction / destruction
@@ -39,170 +36,142 @@ using namespace std;
 
 //______________________________________________________________________________
 SubjetFilterJetProducer::SubjetFilterJetProducer(const edm::ParameterSet& iConfig)
-  : VirtualJetProducer(iConfig)
-  , alg_(iConfig.getParameter<string>  ("@module_label"),
-	 iConfig.getParameter<string>  ("jetAlgorithm"),
-	 iConfig.getParameter<unsigned>("nFatMax"),
-	 iConfig.getParameter<double>  ("rParam"),
-	 iConfig.getParameter<double>  ("rFilt"),
-	 iConfig.getParameter<double>  ("jetPtMin"),
-	 iConfig.getParameter<double>  ("massDropCut"),
-	 iConfig.getParameter<double>  ("asymmCut"),
-	 iConfig.getParameter<bool>    ("asymmCutLater"),
-	 iConfig.getParameter<bool>    ("doAreaFastjet"),
-	 iConfig.getParameter<double>  ("Ghost_EtaMax"),
-	 iConfig.getParameter<int>     ("Active_Area_Repeats"),
-	 iConfig.getParameter<double>  ("GhostArea"),
-	 iConfig.getUntrackedParameter<bool>("verbose",false))
-{
+    : VirtualJetProducer(iConfig),
+      alg_(iConfig.getParameter<string>("@module_label"),
+           iConfig.getParameter<string>("jetAlgorithm"),
+           iConfig.getParameter<unsigned>("nFatMax"),
+           iConfig.getParameter<double>("rParam"),
+           iConfig.getParameter<double>("rFilt"),
+           iConfig.getParameter<double>("jetPtMin"),
+           iConfig.getParameter<double>("massDropCut"),
+           iConfig.getParameter<double>("asymmCut"),
+           iConfig.getParameter<bool>("asymmCutLater"),
+           iConfig.getParameter<bool>("doAreaFastjet"),
+           iConfig.getParameter<double>("Ghost_EtaMax"),
+           iConfig.getParameter<int>("Active_Area_Repeats"),
+           iConfig.getParameter<double>("GhostArea"),
+           iConfig.getUntrackedParameter<bool>("verbose", false)) {
   produces<reco::BasicJetCollection>("fat");
-  makeProduces(moduleLabel_,"sub");
-  makeProduces(moduleLabel_,"filter");
+  makeProduces(moduleLabel_, "sub");
+  makeProduces(moduleLabel_, "filter");
 }
-
 
 //______________________________________________________________________________
-SubjetFilterJetProducer::~SubjetFilterJetProducer()
-{
-  
-}
-
+SubjetFilterJetProducer::~SubjetFilterJetProducer() {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of member functions
 ////////////////////////////////////////////////////////////////////////////////
 
 //______________________________________________________________________________
-void SubjetFilterJetProducer::produce(edm::Event& iEvent,
-				      const edm::EventSetup& iSetup)
-{
-  VirtualJetProducer::produce(iEvent,iSetup);
+void SubjetFilterJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  VirtualJetProducer::produce(iEvent, iSetup);
 }
 
+//______________________________________________________________________________
+void SubjetFilterJetProducer::endJob() { cout << alg_.summary() << endl; }
 
 //______________________________________________________________________________
-void SubjetFilterJetProducer::endJob()
-{
-  cout<<alg_.summary()<<endl;
-}
-
-
-//______________________________________________________________________________
-void SubjetFilterJetProducer::runAlgorithm(edm::Event& iEvent,
-					   const edm::EventSetup& iSetup)
-{
+void SubjetFilterJetProducer::runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   alg_.run(fjInputs_, fjCompoundJets_, iSetup);
 }
 
-
 //______________________________________________________________________________
-void SubjetFilterJetProducer::inputTowers()
-{
+void SubjetFilterJetProducer::inputTowers() {
   fjCompoundJets_.clear();
   VirtualJetProducer::inputTowers();
 }
 
-
 //______________________________________________________________________________
-void SubjetFilterJetProducer::output(edm::Event& iEvent,
-				     edm::EventSetup const& iSetup)
-{
-  // Write jets and constitutents. Will use fjCompoundJets_. 
-  switch( jetTypeE ) {
-  case JetType::CaloJet :
-    writeCompoundJets<reco::CaloJet>( iEvent, iSetup );
-    break;
-  case JetType::PFJet :
-    writeCompoundJets<reco::PFJet>( iEvent, iSetup );
-    break;
-  case JetType::GenJet :
-    writeCompoundJets<reco::GenJet>( iEvent, iSetup );
-    break;
-  case JetType::BasicJet :
-    writeCompoundJets<reco::BasicJet>( iEvent, iSetup );
-    break;
-  default:
-    edm::LogError("InvalidInput")<<" invalid jet type in SubjetFilterJetProducer\n";
-    break;
+void SubjetFilterJetProducer::output(edm::Event& iEvent, edm::EventSetup const& iSetup) {
+  // Write jets and constitutents. Will use fjCompoundJets_.
+  switch (jetTypeE) {
+    case JetType::CaloJet:
+      writeCompoundJets<reco::CaloJet>(iEvent, iSetup);
+      break;
+    case JetType::PFJet:
+      writeCompoundJets<reco::PFJet>(iEvent, iSetup);
+      break;
+    case JetType::GenJet:
+      writeCompoundJets<reco::GenJet>(iEvent, iSetup);
+      break;
+    case JetType::BasicJet:
+      writeCompoundJets<reco::BasicJet>(iEvent, iSetup);
+      break;
+    default:
+      edm::LogError("InvalidInput") << " invalid jet type in SubjetFilterJetProducer\n";
+      break;
   };
-  
 }
 
-
 //______________________________________________________________________________
-template< class T>
-void SubjetFilterJetProducer::writeCompoundJets(edm::Event& iEvent,
-						const edm::EventSetup& iSetup)
-{
+template <class T>
+void SubjetFilterJetProducer::writeCompoundJets(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto fatJets = std::make_unique<reco::BasicJetCollection>();
-  auto subJets = std::make_unique< vector<T>>();
-  auto filterJets = std::make_unique< vector<T>>();
+  auto subJets = std::make_unique<vector<T>>();
+  auto filterJets = std::make_unique<vector<T>>();
 
-  edm::OrphanHandle< vector<T> > subJetsAfterPut;
-  edm::OrphanHandle< vector<T> > filterJetsAfterPut;
-  
-  vector< vector<int> > subIndices(fjCompoundJets_.size());
-  vector< vector<int> > filterIndices(fjCompoundJets_.size());
-  
+  edm::OrphanHandle<vector<T>> subJetsAfterPut;
+  edm::OrphanHandle<vector<T>> filterJetsAfterPut;
+
+  vector<vector<int>> subIndices(fjCompoundJets_.size());
+  vector<vector<int>> filterIndices(fjCompoundJets_.size());
+
   vector<math::XYZTLorentzVector> p4FatJets;
-  vector<double>                  areaFatJets;
-  
+  vector<double> areaFatJets;
+
   vector<CompoundPseudoJet>::const_iterator itBegin(fjCompoundJets_.begin());
   vector<CompoundPseudoJet>::const_iterator itEnd(fjCompoundJets_.end());
   vector<CompoundPseudoJet>::const_iterator it(itBegin);
-  
-  for (;it!=itEnd;++it) {
 
-    int jetIndex = it-itBegin;
+  for (; it != itEnd; ++it) {
+    int jetIndex = it - itBegin;
     fastjet::PseudoJet fatJet = it->hardJet();
-    p4FatJets.push_back(math::XYZTLorentzVector(fatJet.px(),fatJet.py(),
-						fatJet.pz(),fatJet.e()));
+    p4FatJets.push_back(math::XYZTLorentzVector(fatJet.px(), fatJet.py(), fatJet.pz(), fatJet.e()));
     areaFatJets.push_back(it->hardJetArea());
-    
+
     vector<CompoundPseudoSubJet>::const_iterator itSubBegin(it->subjets().begin());
     vector<CompoundPseudoSubJet>::const_iterator itSubEnd(it->subjets().end());
     vector<CompoundPseudoSubJet>::const_iterator itSub(itSubBegin);
-    
-    for (; itSub!=itSubEnd;++itSub) {
-      int subJetIndex = itSub-itSubBegin;
+
+    for (; itSub != itSubEnd; ++itSub) {
+      int subJetIndex = itSub - itSubBegin;
       fastjet::PseudoJet fjSubJet = itSub->subjet();
-      math::XYZTLorentzVector p4SubJet(fjSubJet.px(),fjSubJet.py(),
-				       fjSubJet.pz(),fjSubJet.e());
-      reco::Particle::Point point(0,0,0);
-      
+      math::XYZTLorentzVector p4SubJet(fjSubJet.px(), fjSubJet.py(), fjSubJet.pz(), fjSubJet.e());
+      reco::Particle::Point point(0, 0, 0);
+
       vector<reco::CandidatePtr> subJetConstituents;
       const vector<int>& subJetConstituentIndices = itSub->constituents();
       vector<int>::const_iterator itIndexBegin(subJetConstituentIndices.begin());
       vector<int>::const_iterator itIndexEnd(subJetConstituentIndices.end());
       vector<int>::const_iterator itIndex(itIndexBegin);
-      for (;itIndex!=itIndexEnd;++itIndex)
-	if ((*itIndex) < static_cast<int>(inputs_.size())) 
-	  subJetConstituents.push_back(inputs_[*itIndex]);
-      
+      for (; itIndex != itIndexEnd; ++itIndex)
+        if ((*itIndex) < static_cast<int>(inputs_.size()))
+          subJetConstituents.push_back(inputs_[*itIndex]);
+
       T subJet;
-      reco::writeSpecific(subJet,p4SubJet,point,subJetConstituents,iSetup);
+      reco::writeSpecific(subJet, p4SubJet, point, subJetConstituents, iSetup);
       subJet.setJetArea(itSub->subjetArea());
-      
-      if (subJetIndex<2) {
-	subIndices[jetIndex].push_back(subJets->size());
-	subJets->push_back(subJet);
-      }
-      else {
-	filterIndices[jetIndex].push_back(filterJets->size());
-	filterJets->push_back(subJet);
+
+      if (subJetIndex < 2) {
+        subIndices[jetIndex].push_back(subJets->size());
+        subJets->push_back(subJet);
+      } else {
+        filterIndices[jetIndex].push_back(filterJets->size());
+        filterJets->push_back(subJet);
       }
     }
   }
-  
-  subJetsAfterPut    = iEvent.put(std::move(subJets),   "sub");
-  filterJetsAfterPut = iEvent.put(std::move(filterJets),"filter");
-  
+
+  subJetsAfterPut = iEvent.put(std::move(subJets), "sub");
+  filterJetsAfterPut = iEvent.put(std::move(filterJets), "filter");
+
   vector<math::XYZTLorentzVector>::const_iterator itP4Begin(p4FatJets.begin());
   vector<math::XYZTLorentzVector>::const_iterator itP4End(p4FatJets.end());
   vector<math::XYZTLorentzVector>::const_iterator itP4(itP4Begin);
-  for (;itP4!=itP4End;++itP4) {
-    int fatIndex = itP4-itP4Begin;
-    vector<int>& fatToSub    = subIndices[fatIndex];
+  for (; itP4 != itP4End; ++itP4) {
+    int fatIndex = itP4 - itP4Begin;
+    vector<int>& fatToSub = subIndices[fatIndex];
     vector<int>& fatToFilter = filterIndices[fatIndex];
 
     vector<reco::CandidatePtr> i_fatJetConstituents;
@@ -210,31 +179,29 @@ void SubjetFilterJetProducer::writeCompoundJets(edm::Event& iEvent,
     vector<int>::const_iterator itSubBegin(fatToSub.begin());
     vector<int>::const_iterator itSubEnd(fatToSub.end());
     vector<int>::const_iterator itSub(itSubBegin);
-    for(;itSub!=itSubEnd;++itSub) {
-      reco::CandidatePtr candPtr(subJetsAfterPut,(*itSub),false);
+    for (; itSub != itSubEnd; ++itSub) {
+      reco::CandidatePtr candPtr(subJetsAfterPut, (*itSub), false);
       i_fatJetConstituents.push_back(candPtr);
     }
 
     vector<int>::const_iterator itFilterBegin(fatToFilter.begin());
     vector<int>::const_iterator itFilterEnd(fatToFilter.end());
     vector<int>::const_iterator itFilter(itFilterBegin);
-    for(;itFilter!=itFilterEnd;++itFilter) {
-      reco::CandidatePtr candPtr(filterJetsAfterPut,(*itFilter),false);
+    for (; itFilter != itFilterEnd; ++itFilter) {
+      reco::CandidatePtr candPtr(filterJetsAfterPut, (*itFilter), false);
       i_fatJetConstituents.push_back(candPtr);
     }
 
-    reco::Particle::Point point(0,0,0);
-    fatJets->push_back(reco::BasicJet((*itP4),point,i_fatJetConstituents));
+    reco::Particle::Point point(0, 0, 0);
+    fatJets->push_back(reco::BasicJet((*itP4), point, i_fatJetConstituents));
     fatJets->back().setJetArea(areaFatJets[fatIndex]);
   }
-  
-  iEvent.put(std::move(fatJets),"fat");
-}
 
+  iEvent.put(std::move(fatJets), "fat");
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // DEFINE THIS AS A CMSSW FWK PLUGIN
 ////////////////////////////////////////////////////////////////////////////////
 
 DEFINE_FWK_MODULE(SubjetFilterJetProducer);
-

--- a/RecoJets/JetProducers/plugins/SubjetFilterJetProducer.h
+++ b/RecoJets/JetProducers/plugins/SubjetFilterJetProducer.h
@@ -1,7 +1,6 @@
 #ifndef RECOJETS_JETPRODUCERS_SUBJETFILTERJETPRODUCER_H
 #define RECOJETS_JETPRODUCERS_SUBJETFILTERJETPRODUCER_H 1
 
-
 /*
   The plugin produces the output of the Subjet/Filter jet reconstruction
   algorithm which was first proposed here: http://arXiv.org/abs/0802.2470
@@ -15,23 +14,19 @@
 
 */
 
-
 #include "VirtualJetProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "RecoJets/JetAlgorithms/interface/CompoundPseudoJet.h"
 #include "RecoJets/JetAlgorithms/interface/SubjetFilterAlgorithm.h"
 
-
-class SubjetFilterJetProducer : public VirtualJetProducer
-{
+class SubjetFilterJetProducer : public VirtualJetProducer {
   //
   // construction / destruction
   //
 public:
   SubjetFilterJetProducer(const edm::ParameterSet& ps);
   ~SubjetFilterJetProducer() override;
-  
-  
+
   //
   // member functions
   //
@@ -40,18 +35,16 @@ public:
   void endJob();
   void runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   void inputTowers() override;
-  void output(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
-  template<class T>
-  void writeCompoundJets(edm::Event& iEvent,const edm::EventSetup& iSetup);
-  
-  
+  void output(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  template <class T>
+  void writeCompoundJets(edm::Event& iEvent, const edm::EventSetup& iSetup);
+
   //
   // member data
   //
 private:
-  SubjetFilterAlgorithm           alg_;
-  std::vector<CompoundPseudoJet>  fjCompoundJets_;
+  SubjetFilterAlgorithm alg_;
+  std::vector<CompoundPseudoJet> fjCompoundJets_;
 };
-
 
 #endif

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -55,65 +55,51 @@
 using namespace std;
 using namespace edm;
 
-
 namespace reco {
   namespace helper {
     struct GreaterByPtPseudoJet {
-      bool operator()( const fastjet::PseudoJet & t1, const fastjet::PseudoJet & t2 ) const {
+      bool operator()(const fastjet::PseudoJet& t1, const fastjet::PseudoJet& t2) const {
         return t1.perp2() > t2.perp2();
       }
     };
 
-  }
-}                                                                                        
+  }  // namespace helper
+}  // namespace reco
 
 //______________________________________________________________________________
-const char *const VirtualJetProducer::JetType::names[] = {
-  "BasicJet","GenJet","CaloJet","PFJet","TrackJet","PFClusterJet"
-};
-
+const char* const VirtualJetProducer::JetType::names[] = {
+    "BasicJet", "GenJet", "CaloJet", "PFJet", "TrackJet", "PFClusterJet"};
 
 //______________________________________________________________________________
-VirtualJetProducer::JetType::Type
-VirtualJetProducer::JetType::byName(const string &name)
-{
-  const char *const *pos = std::find(names, names + LastJetType, name);
+VirtualJetProducer::JetType::Type VirtualJetProducer::JetType::byName(const string& name) {
+  const char* const* pos = std::find(names, names + LastJetType, name);
   if (pos == names + LastJetType) {
-    std::string errorMessage="Requested jetType not supported: "+name+"\n";
-    throw cms::Exception("Configuration",errorMessage);
+    std::string errorMessage = "Requested jetType not supported: " + name + "\n";
+    throw cms::Exception("Configuration", errorMessage);
   }
-  return (Type)(pos-names);
+  return (Type)(pos - names);
 }
 
-
-void VirtualJetProducer::makeProduces( std::string alias, std::string tag )
-{
-
-
-  if ( writeCompound_ ) {
+void VirtualJetProducer::makeProduces(std::string alias, std::string tag) {
+  if (writeCompound_) {
     produces<reco::BasicJetCollection>();
   }
 
-  if ( writeJetsWithConst_ ) {
+  if (writeJetsWithConst_) {
     produces<reco::PFCandidateCollection>(tag).setBranchAlias(alias);
     produces<reco::PFJetCollection>();
   } else {
     if (makeCaloJet(jetTypeE)) {
       produces<reco::CaloJetCollection>(tag).setBranchAlias(alias);
-    }
-    else if (makePFJet(jetTypeE)) {
+    } else if (makePFJet(jetTypeE)) {
       produces<reco::PFJetCollection>(tag).setBranchAlias(alias);
-    }
-    else if (makeGenJet(jetTypeE)) {
+    } else if (makeGenJet(jetTypeE)) {
       produces<reco::GenJetCollection>(tag).setBranchAlias(alias);
-    }
-    else if (makeTrackJet(jetTypeE)) {
+    } else if (makeTrackJet(jetTypeE)) {
       produces<reco::TrackJetCollection>(tag).setBranchAlias(alias);
-    }
-    else if (makePFClusterJet(jetTypeE)) {
+    } else if (makePFClusterJet(jetTypeE)) {
       produces<reco::PFClusterJetCollection>(tag).setBranchAlias(alias);
-    }
-    else if (makeBasicJet(jetTypeE)) {
+    } else if (makeBasicJet(jetTypeE)) {
       produces<reco::BasicJetCollection>(tag).setBranchAlias(alias);
     }
   }
@@ -125,197 +111,198 @@ void VirtualJetProducer::makeProduces( std::string alias, std::string tag )
 
 //______________________________________________________________________________
 VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
+  moduleLabel_ = iConfig.getParameter<string>("@module_label");
+  src_ = iConfig.getParameter<edm::InputTag>("src");
+  srcPVs_ = iConfig.getParameter<edm::InputTag>("srcPVs");
+  jetType_ = iConfig.getParameter<string>("jetType");
+  jetAlgorithm_ = iConfig.getParameter<string>("jetAlgorithm");
+  rParam_ = iConfig.getParameter<double>("rParam");
+  inputEtMin_ = iConfig.getParameter<double>("inputEtMin");
+  inputEMin_ = iConfig.getParameter<double>("inputEMin");
+  jetPtMin_ = iConfig.getParameter<double>("jetPtMin");
+  doPVCorrection_ = iConfig.getParameter<bool>("doPVCorrection");
+  doAreaFastjet_ = iConfig.getParameter<bool>("doAreaFastjet");
+  doRhoFastjet_ = iConfig.getParameter<bool>("doRhoFastjet");
+  jetCollInstanceName_ = iConfig.getParameter<string>("jetCollInstanceName");
+  doPUOffsetCorr_ = iConfig.getParameter<bool>("doPUOffsetCorr");
+  puSubtractorName_ = iConfig.getParameter<string>("subtractorName");
+  useExplicitGhosts_ =
+      iConfig.getParameter<bool>("useExplicitGhosts");  // use explicit ghosts in the fastjet clustering sequence?
+  doAreaDiskApprox_ = iConfig.getParameter<bool>("doAreaDiskApprox");
+  voronoiRfact_ = iConfig.getParameter<double>(
+      "voronoiRfact");  // Voronoi-based area calculation allows for an empirical scale factor
+  rhoEtaMax_ = iConfig.getParameter<double>(
+      "Rho_EtaMax");  // do fasjet area / rho calcluation? => accept corresponding parameters
+  ghostEtaMax_ = iConfig.getParameter<double>("Ghost_EtaMax");
+  activeAreaRepeats_ = iConfig.getParameter<int>("Active_Area_Repeats");
+  ghostArea_ = iConfig.getParameter<double>("GhostArea");
+  restrictInputs_ = iConfig.getParameter<bool>("restrictInputs");  // restrict inputs to first "maxInputs" towers?
+  maxInputs_ = iConfig.getParameter<unsigned int>("maxInputs");
+  writeCompound_ = iConfig.getParameter<bool>(
+      "writeCompound");  // Check to see if we are writing compound jets for substructure and jet grooming
+  writeJetsWithConst_ = iConfig.getParameter<bool>("writeJetsWithConst");  //write subtracted jet constituents
+  doFastJetNonUniform_ = iConfig.getParameter<bool>("doFastJetNonUniform");
+  puCenters_ = iConfig.getParameter<vector<double>>("puCenters");
+  puWidth_ = iConfig.getParameter<double>("puWidth");
+  nExclude_ = iConfig.getParameter<unsigned int>("nExclude");
+  useDeterministicSeed_ = iConfig.getParameter<bool>("useDeterministicSeed");
+  minSeed_ = iConfig.getParameter<unsigned int>("minSeed");
+  verbosity_ = iConfig.getParameter<int>("verbosity");
 
-	moduleLabel_   		= iConfig.getParameter<string>  ("@module_label");
-        src_                    = iConfig.getParameter<edm::InputTag>("src");
-        srcPVs_                 = iConfig.getParameter<edm::InputTag>("srcPVs");
-	jetType_       		= iConfig.getParameter<string> 	("jetType");
-	jetAlgorithm_  		= iConfig.getParameter<string>  ("jetAlgorithm");
-	rParam_        		= iConfig.getParameter<double>  ("rParam");
-	inputEtMin_    		= iConfig.getParameter<double>  ("inputEtMin");
-	inputEMin_     		= iConfig.getParameter<double>  ("inputEMin");
-	jetPtMin_      		= iConfig.getParameter<double>  ("jetPtMin");
-	doPVCorrection_		= iConfig.getParameter<bool>    ("doPVCorrection");
-	doAreaFastjet_ 		= iConfig.getParameter<bool>    ("doAreaFastjet");
-	doRhoFastjet_  		= iConfig.getParameter<bool>    ("doRhoFastjet");
-	jetCollInstanceName_ 	= iConfig.getParameter<string>	("jetCollInstanceName");
-	doPUOffsetCorr_		= iConfig.getParameter<bool>	("doPUOffsetCorr");
-	puSubtractorName_  	= iConfig.getParameter<string>	("subtractorName");
-	useExplicitGhosts_ 	= iConfig.getParameter<bool>	("useExplicitGhosts");  // use explicit ghosts in the fastjet clustering sequence?
-	doAreaDiskApprox_ 	= iConfig.getParameter<bool>	("doAreaDiskApprox");
-	voronoiRfact_     	= iConfig.getParameter<double>	("voronoiRfact"); 	// Voronoi-based area calculation allows for an empirical scale factor
-	rhoEtaMax_		= iConfig.getParameter<double>	("Rho_EtaMax"); 		// do fasjet area / rho calcluation? => accept corresponding parameters
-	ghostEtaMax_ 		= iConfig.getParameter<double>	("Ghost_EtaMax");
-	activeAreaRepeats_ 	= iConfig.getParameter<int> 	("Active_Area_Repeats");
-	ghostArea_ 		= iConfig.getParameter<double> 	("GhostArea");
-	restrictInputs_ 	= iConfig.getParameter<bool>	("restrictInputs"); 	// restrict inputs to first "maxInputs" towers?
-	maxInputs_      	= iConfig.getParameter<unsigned int>("maxInputs");
-	writeCompound_ 		= iConfig.getParameter<bool>	("writeCompound"); 	// Check to see if we are writing compound jets for substructure and jet grooming
-        writeJetsWithConst_     = iConfig.getParameter<bool>("writeJetsWithConst"); //write subtracted jet constituents
-	doFastJetNonUniform_ 	= iConfig.getParameter<bool>   	("doFastJetNonUniform");
-	puCenters_ 		= iConfig.getParameter<vector<double> >("puCenters");
-	puWidth_ 		= iConfig.getParameter<double>	("puWidth");
-	nExclude_ 		= iConfig.getParameter<unsigned int>("nExclude");
-	useDeterministicSeed_ 	= iConfig.getParameter<bool>	("useDeterministicSeed");
-	minSeed_ 		= iConfig.getParameter<unsigned int>("minSeed");
-	verbosity_ 		= iConfig.getParameter<int>	("verbosity");
+  anomalousTowerDef_ = unique_ptr<AnomalousTower>(new AnomalousTower(iConfig));
 
-	anomalousTowerDef_ = unique_ptr<AnomalousTower>(new AnomalousTower(iConfig));
+  input_vertex_token_ = consumes<reco::VertexCollection>(srcPVs_);
+  input_candidateview_token_ = consumes<reco::CandidateView>(src_);
+  input_candidatefwdptr_token_ =
+      consumes<vector<edm::FwdPtr<reco::PFCandidate>>>(iConfig.getParameter<edm::InputTag>("src"));
+  input_packedcandidatefwdptr_token_ =
+      consumes<vector<edm::FwdPtr<pat::PackedCandidate>>>(iConfig.getParameter<edm::InputTag>("src"));
+  input_gencandidatefwdptr_token_ =
+      consumes<vector<edm::FwdPtr<reco::GenParticle>>>(iConfig.getParameter<edm::InputTag>("src"));
+  input_packedgencandidatefwdptr_token_ =
+      consumes<vector<edm::FwdPtr<pat::PackedGenParticle>>>(iConfig.getParameter<edm::InputTag>("src"));
 
-	input_vertex_token_ = consumes<reco::VertexCollection>(srcPVs_);
-	input_candidateview_token_ = consumes<reco::CandidateView>(src_);
-	input_candidatefwdptr_token_ = consumes<vector<edm::FwdPtr<reco::PFCandidate> > >(iConfig.getParameter<edm::InputTag>("src"));
-	input_packedcandidatefwdptr_token_ = consumes<vector<edm::FwdPtr<pat::PackedCandidate> > >(iConfig.getParameter<edm::InputTag>("src"));
-	input_gencandidatefwdptr_token_ = consumes<vector<edm::FwdPtr<reco::GenParticle> > >(iConfig.getParameter<edm::InputTag>("src"));
-	input_packedgencandidatefwdptr_token_ = consumes<vector<edm::FwdPtr<pat::PackedGenParticle> > >(iConfig.getParameter<edm::InputTag>("src"));
-	
-	//
-	// additional parameters to think about:
-	// - overlap threshold (set to 0.75 for the time being)
-	// - p parameter for generalized kT (set to -2 for the time being)
-	// - fastjet PU subtraction parameters (not yet considered)
-	//
-	if (jetAlgorithm_=="Kt") 
-		fjJetDefinition_= JetDefPtr(new fastjet::JetDefinition(fastjet::kt_algorithm,rParam_));
+  //
+  // additional parameters to think about:
+  // - overlap threshold (set to 0.75 for the time being)
+  // - p parameter for generalized kT (set to -2 for the time being)
+  // - fastjet PU subtraction parameters (not yet considered)
+  //
+  if (jetAlgorithm_ == "Kt")
+    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(fastjet::kt_algorithm, rParam_));
 
-	else if (jetAlgorithm_=="CambridgeAachen")
-		fjJetDefinition_= JetDefPtr(new fastjet::JetDefinition(fastjet::cambridge_algorithm,rParam_) );
+  else if (jetAlgorithm_ == "CambridgeAachen")
+    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(fastjet::cambridge_algorithm, rParam_));
 
-	else if (jetAlgorithm_=="AntiKt")
-		fjJetDefinition_= JetDefPtr( new fastjet::JetDefinition(fastjet::antikt_algorithm,rParam_) );
+  else if (jetAlgorithm_ == "AntiKt")
+    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(fastjet::antikt_algorithm, rParam_));
 
-	else if (jetAlgorithm_=="GeneralizedKt") 
-		fjJetDefinition_= JetDefPtr( new fastjet::JetDefinition(fastjet::genkt_algorithm,rParam_,-2) );
+  else if (jetAlgorithm_ == "GeneralizedKt")
+    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(fastjet::genkt_algorithm, rParam_, -2));
 
-	else if (jetAlgorithm_=="SISCone") {
+  else if (jetAlgorithm_ == "SISCone") {
+    fjPlugin_ = PluginPtr(new fastjet::SISConePlugin(rParam_, 0.75, 0, 0.0, false, fastjet::SISConePlugin::SM_pttilde));
+    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
 
-		fjPlugin_ = PluginPtr( new fastjet::SISConePlugin(rParam_,0.75,0,0.0,false,fastjet::SISConePlugin::SM_pttilde) );
-		fjJetDefinition_= JetDefPtr( new fastjet::JetDefinition(&*fjPlugin_) );
+  } else if (jetAlgorithm_ == "IterativeCone") {
+    fjPlugin_ = PluginPtr(new fastjet::CMSIterativeConePlugin(rParam_, 1.0));
+    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
 
-	} else if (jetAlgorithm_=="IterativeCone") {
+  } else if (jetAlgorithm_ == "CDFMidPoint") {
+    fjPlugin_ = PluginPtr(new fastjet::CDFMidPointPlugin(rParam_, 0.75));
+    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
 
-		fjPlugin_ = PluginPtr(new fastjet::CMSIterativeConePlugin(rParam_,1.0));
-		fjJetDefinition_= JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
+  } else if (jetAlgorithm_ == "ATLASCone") {
+    fjPlugin_ = PluginPtr(new fastjet::ATLASConePlugin(rParam_));
+    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
 
-	} else if (jetAlgorithm_=="CDFMidPoint") {
+  } else {
+    throw cms::Exception("Invalid jetAlgorithm") << "Jet algorithm for VirtualJetProducer is invalid, Abort!\n";
+  }
 
-		fjPlugin_ = PluginPtr(new fastjet::CDFMidPointPlugin(rParam_,0.75));
-		fjJetDefinition_= JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
+  jetTypeE = JetType::byName(jetType_);
 
-	} else if (jetAlgorithm_=="ATLASCone") {
+  if (doPUOffsetCorr_) {
+    if (puSubtractorName_.empty()) {
+      LogWarning("VirtualJetProducer")
+          << "Pile Up correction on; however, pile up type is not specified. Using default... \n";
+      subtractor_ = boost::shared_ptr<PileUpSubtractor>(new PileUpSubtractor(iConfig, consumesCollector()));
+    } else
+      subtractor_ = boost::shared_ptr<PileUpSubtractor>(
+          PileUpSubtractorFactory::get()->create(puSubtractorName_, iConfig, consumesCollector()));
+  }
 
-		fjPlugin_ = PluginPtr(new fastjet::ATLASConePlugin(rParam_));
-		fjJetDefinition_= JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
+  // do approximate disk-based area calculation => warn if conflicting request
+  if (doAreaDiskApprox_ && doAreaFastjet_)
+    throw cms::Exception("Conflicting area calculations")
+        << "Both the calculation of jet area via fastjet and via an analytical disk approximation have been requested. "
+           "Please decide on one.\n";
 
-	} else {
-		throw cms::Exception("Invalid jetAlgorithm") <<"Jet algorithm for VirtualJetProducer is invalid, Abort!\n";
-	}
+  if (doAreaFastjet_ || doRhoFastjet_) {
+    if (voronoiRfact_ <= 0) {
+      fjActiveArea_ = ActiveAreaSpecPtr(new fastjet::GhostedAreaSpec(ghostEtaMax_, activeAreaRepeats_, ghostArea_));
 
-	jetTypeE=JetType::byName(jetType_);
+      if (!useExplicitGhosts_) {
+        fjAreaDefinition_ = AreaDefinitionPtr(new fastjet::AreaDefinition(fastjet::active_area, *fjActiveArea_));
+      } else {
+        fjAreaDefinition_ =
+            AreaDefinitionPtr(new fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, *fjActiveArea_));
+      }
+    }
+    fjSelector_ = SelectorPtr(new fastjet::Selector(fastjet::SelectorAbsRapMax(rhoEtaMax_)));
+  }
 
-	if ( doPUOffsetCorr_  ) {
-		if(puSubtractorName_.empty()){
-			LogWarning("VirtualJetProducer") << "Pile Up correction on; however, pile up type is not specified. Using default... \n";
-			subtractor_ =  boost::shared_ptr<PileUpSubtractor>(new PileUpSubtractor(iConfig, consumesCollector()));
-		} else subtractor_ =  boost::shared_ptr<PileUpSubtractor>(
-				PileUpSubtractorFactory::get()->create( puSubtractorName_, iConfig, consumesCollector()));
-	}
+  if ((doFastJetNonUniform_) && (puCenters_.empty()))
+    throw cms::Exception("doFastJetNonUniform")
+        << "Parameter puCenters for doFastJetNonUniform is not defined." << std::endl;
 
-	// do approximate disk-based area calculation => warn if conflicting request
-	if (doAreaDiskApprox_ && doAreaFastjet_)
-		throw cms::Exception("Conflicting area calculations") << "Both the calculation of jet area via fastjet and via an analytical disk approximation have been requested. Please decide on one.\n";
-
-	if ( doAreaFastjet_ || doRhoFastjet_ ) {
-
-		if (voronoiRfact_ <= 0) {
-			fjActiveArea_     = ActiveAreaSpecPtr(new fastjet::GhostedAreaSpec(ghostEtaMax_,activeAreaRepeats_,ghostArea_));
-			
-
-			if ( !useExplicitGhosts_ ) {
-				fjAreaDefinition_ = AreaDefinitionPtr( new fastjet::AreaDefinition(fastjet::active_area, *fjActiveArea_ ) );
-			} else {
-				fjAreaDefinition_ = AreaDefinitionPtr( new fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, *fjActiveArea_ ) );
-			}
-		}
-		fjSelector_ =  SelectorPtr( new fastjet::Selector( fastjet::SelectorAbsRapMax(rhoEtaMax_) ) );
-	} 
-
-	if( ( doFastJetNonUniform_ ) && ( puCenters_.empty() ) ) 
-		throw cms::Exception("doFastJetNonUniform") << "Parameter puCenters for doFastJetNonUniform is not defined." << std::endl;
-  
-        // make the "produces" statements
-        makeProduces( moduleLabel_, jetCollInstanceName_ );
-	produces<vector<double> >("rhos");
-	produces<vector<double> >("sigmas");
-	produces<double>("rho");
-	produces<double>("sigma");
-
-  
+  // make the "produces" statements
+  makeProduces(moduleLabel_, jetCollInstanceName_);
+  produces<vector<double>>("rhos");
+  produces<vector<double>>("sigmas");
+  produces<double>("rho");
+  produces<double>("sigma");
 }
 
 //______________________________________________________________________________
-VirtualJetProducer::~VirtualJetProducer()
-{
-} 
-
+VirtualJetProducer::~VirtualJetProducer() {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of member functions
 ////////////////////////////////////////////////////////////////////////////////
 
 //______________________________________________________________________________
-void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
-{
-
+void VirtualJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // If requested, set the fastjet random seed to a deterministic function
-  // of the run/lumi/event. 
+  // of the run/lumi/event.
   // NOTE!!! The fastjet random number sequence is a global singleton.
   // Thus, we have to create an object and get access to the global singleton
-  // in order to change it. 
-  if ( useDeterministicSeed_ ) {
+  // in order to change it.
+  if (useDeterministicSeed_) {
     fastjet::GhostedAreaSpec gas;
     std::vector<int> seeds(2);
-    unsigned int runNum_uint = static_cast <unsigned int> (iEvent.id().run());
-    unsigned int evNum_uint = static_cast <unsigned int> (iEvent.id().event()); 
-    seeds[0] = std::max(runNum_uint,minSeed_ + 3) + 3 * evNum_uint;
-    seeds[1] = std::max(runNum_uint,minSeed_ + 5) + 5 * evNum_uint;
+    unsigned int runNum_uint = static_cast<unsigned int>(iEvent.id().run());
+    unsigned int evNum_uint = static_cast<unsigned int>(iEvent.id().event());
+    seeds[0] = std::max(runNum_uint, minSeed_ + 3) + 3 * evNum_uint;
+    seeds[1] = std::max(runNum_uint, minSeed_ + 5) + 5 * evNum_uint;
     gas.set_random_status(seeds);
   }
 
   LogDebug("VirtualJetProducer") << "Entered produce\n";
   //determine signal vertex2
-  vertex_=reco::Jet::Point(0,0,0);
-  if ( (makeCaloJet(jetTypeE) || makePFJet(jetTypeE)) &&doPVCorrection_) {
+  vertex_ = reco::Jet::Point(0, 0, 0);
+  if ((makeCaloJet(jetTypeE) || makePFJet(jetTypeE)) && doPVCorrection_) {
     LogDebug("VirtualJetProducer") << "Adding PV info\n";
     edm::Handle<reco::VertexCollection> pvCollection;
-    iEvent.getByToken(input_vertex_token_ , pvCollection);
-    if (!pvCollection->empty()) vertex_=pvCollection->begin()->position();
+    iEvent.getByToken(input_vertex_token_, pvCollection);
+    if (!pvCollection->empty())
+      vertex_ = pvCollection->begin()->position();
   }
 
   // For Pileup subtraction using offset correction:
   // set up geometry map
-  if ( doPUOffsetCorr_ ) {
-     subtractor_->setupGeometryMap(iEvent, iSetup);
+  if (doPUOffsetCorr_) {
+    subtractor_->setupGeometryMap(iEvent, iSetup);
   }
 
   // clear data
   LogDebug("VirtualJetProducer") << "Clear data\n";
   fjInputs_.clear();
   fjJets_.clear();
-  inputs_.clear();  
-  
+  inputs_.clear();
+
   // get inputs and convert them to the fastjet format (fastjet::PeudoJet)
   edm::Handle<reco::CandidateView> inputsHandle;
-  
-  edm::Handle< std::vector<edm::FwdPtr<reco::PFCandidate> > > pfinputsHandleAsFwdPtr; 
-  edm::Handle< std::vector<edm::FwdPtr<pat::PackedCandidate> > > packedinputsHandleAsFwdPtr; 
-  edm::Handle< std::vector<edm::FwdPtr<reco::GenParticle> > > geninputsHandleAsFwdPtr; 
-  edm::Handle< std::vector<edm::FwdPtr<pat::PackedGenParticle> > > packedgeninputsHandleAsFwdPtr; 
-  
+
+  edm::Handle<std::vector<edm::FwdPtr<reco::PFCandidate>>> pfinputsHandleAsFwdPtr;
+  edm::Handle<std::vector<edm::FwdPtr<pat::PackedCandidate>>> packedinputsHandleAsFwdPtr;
+  edm::Handle<std::vector<edm::FwdPtr<reco::GenParticle>>> geninputsHandleAsFwdPtr;
+  edm::Handle<std::vector<edm::FwdPtr<pat::PackedGenParticle>>> packedgeninputsHandleAsFwdPtr;
+
   bool isView = iEvent.getByToken(input_candidateview_token_, inputsHandle);
-  if ( isView ) {
-    if ( inputsHandle->empty()) {
-      output( iEvent, iSetup );
+  if (isView) {
+    if (inputsHandle->empty()) {
+      output(iEvent, iSetup);
       return;
     }
     for (size_t i = 0; i < inputsHandle->size(); ++i) {
@@ -326,66 +313,62 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
     bool isPFFwdPtr = iEvent.getByToken(input_packedcandidatefwdptr_token_, packedinputsHandleAsFwdPtr);
     bool isGen = iEvent.getByToken(input_gencandidatefwdptr_token_, geninputsHandleAsFwdPtr);
     bool isGenFwdPtr = iEvent.getByToken(input_packedgencandidatefwdptr_token_, packedgeninputsHandleAsFwdPtr);
-    
-    if ( isPF ) {
-      if ( pfinputsHandleAsFwdPtr->empty()) {
-	output( iEvent, iSetup );
-	return;
+
+    if (isPF) {
+      if (pfinputsHandleAsFwdPtr->empty()) {
+        output(iEvent, iSetup);
+        return;
       }
       for (size_t i = 0; i < pfinputsHandleAsFwdPtr->size(); ++i) {
-	if ( (*pfinputsHandleAsFwdPtr)[i].ptr().isAvailable() ) {
-	  inputs_.push_back( (*pfinputsHandleAsFwdPtr)[i].ptr() );
-	}
-	else if ( (*pfinputsHandleAsFwdPtr)[i].backPtr().isAvailable() ) {
-	  inputs_.push_back( (*pfinputsHandleAsFwdPtr)[i].backPtr() );
-	}
+        if ((*pfinputsHandleAsFwdPtr)[i].ptr().isAvailable()) {
+          inputs_.push_back((*pfinputsHandleAsFwdPtr)[i].ptr());
+        } else if ((*pfinputsHandleAsFwdPtr)[i].backPtr().isAvailable()) {
+          inputs_.push_back((*pfinputsHandleAsFwdPtr)[i].backPtr());
+        }
       }
-    } else if ( isPFFwdPtr ) {
-      if ( packedinputsHandleAsFwdPtr->empty()) {
-	output( iEvent, iSetup );
-	return;
+    } else if (isPFFwdPtr) {
+      if (packedinputsHandleAsFwdPtr->empty()) {
+        output(iEvent, iSetup);
+        return;
       }
       for (size_t i = 0; i < packedinputsHandleAsFwdPtr->size(); ++i) {
-	if ( (*packedinputsHandleAsFwdPtr)[i].ptr().isAvailable() ) {
-	  inputs_.push_back( (*packedinputsHandleAsFwdPtr)[i].ptr() );
-	}
-	else if ( (*packedinputsHandleAsFwdPtr)[i].backPtr().isAvailable() ) {
-	  inputs_.push_back( (*packedinputsHandleAsFwdPtr)[i].backPtr() );
-	}
+        if ((*packedinputsHandleAsFwdPtr)[i].ptr().isAvailable()) {
+          inputs_.push_back((*packedinputsHandleAsFwdPtr)[i].ptr());
+        } else if ((*packedinputsHandleAsFwdPtr)[i].backPtr().isAvailable()) {
+          inputs_.push_back((*packedinputsHandleAsFwdPtr)[i].backPtr());
+        }
       }
-    } else if ( isGen ) {
-      if ( geninputsHandleAsFwdPtr->empty()) {
-	output( iEvent, iSetup );
-	return;
+    } else if (isGen) {
+      if (geninputsHandleAsFwdPtr->empty()) {
+        output(iEvent, iSetup);
+        return;
       }
       for (size_t i = 0; i < geninputsHandleAsFwdPtr->size(); ++i) {
-	if ( (*geninputsHandleAsFwdPtr)[i].ptr().isAvailable() ) {
-	  inputs_.push_back( (*geninputsHandleAsFwdPtr)[i].ptr() );
-	}
-	else if ( (*geninputsHandleAsFwdPtr)[i].backPtr().isAvailable() ) {
-	  inputs_.push_back( (*geninputsHandleAsFwdPtr)[i].backPtr() );
-	}
+        if ((*geninputsHandleAsFwdPtr)[i].ptr().isAvailable()) {
+          inputs_.push_back((*geninputsHandleAsFwdPtr)[i].ptr());
+        } else if ((*geninputsHandleAsFwdPtr)[i].backPtr().isAvailable()) {
+          inputs_.push_back((*geninputsHandleAsFwdPtr)[i].backPtr());
+        }
       }
-    } else if ( isGenFwdPtr ) {
-      if ( geninputsHandleAsFwdPtr->empty()) {
-	output( iEvent, iSetup );
-	return;
+    } else if (isGenFwdPtr) {
+      if (geninputsHandleAsFwdPtr->empty()) {
+        output(iEvent, iSetup);
+        return;
       }
       for (size_t i = 0; i < packedgeninputsHandleAsFwdPtr->size(); ++i) {
-	if ( (*packedgeninputsHandleAsFwdPtr)[i].ptr().isAvailable() ) {
-	  inputs_.push_back( (*packedgeninputsHandleAsFwdPtr)[i].ptr() );
-	}
-	else if ( (*packedgeninputsHandleAsFwdPtr)[i].backPtr().isAvailable() ) {
-	  inputs_.push_back( (*packedgeninputsHandleAsFwdPtr)[i].backPtr() );
-	}
+        if ((*packedgeninputsHandleAsFwdPtr)[i].ptr().isAvailable()) {
+          inputs_.push_back((*packedgeninputsHandleAsFwdPtr)[i].ptr());
+        } else if ((*packedgeninputsHandleAsFwdPtr)[i].backPtr().isAvailable()) {
+          inputs_.push_back((*packedgeninputsHandleAsFwdPtr)[i].backPtr());
+        }
       }
-    }
-    else {
-	throw cms::Exception("Invalid Jet Inputs") <<"Did not specify appropriate inputs for VirtualJetProducer, Abort!\n";    
+    } else {
+      throw cms::Exception("Invalid Jet Inputs")
+          << "Did not specify appropriate inputs for VirtualJetProducer, Abort!\n";
     }
   }
   LogDebug("VirtualJetProducer") << "Got inputs\n";
-  
+
   // Convert candidates to fastjet::PseudoJets.
   // Also correct to Primary Vertex. Will modify fjInputs_
   // and use inputs_
@@ -394,17 +377,17 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   LogDebug("VirtualJetProducer") << "Inputted towers\n";
 
   // For Pileup subtraction using offset correction:
-  // Subtract pedestal. 
-  if ( doPUOffsetCorr_ ) {
-     subtractor_->setDefinition(fjJetDefinition_);
-     subtractor_->reset(inputs_,fjInputs_,fjJets_);
-     subtractor_->calculatePedestal(fjInputs_); 
-     subtractor_->subtractPedestal(fjInputs_);    
-     LogDebug("VirtualJetProducer") << "Subtracted pedestal\n";
+  // Subtract pedestal.
+  if (doPUOffsetCorr_) {
+    subtractor_->setDefinition(fjJetDefinition_);
+    subtractor_->reset(inputs_, fjInputs_, fjJets_);
+    subtractor_->calculatePedestal(fjInputs_);
+    subtractor_->subtractPedestal(fjInputs_);
+    LogDebug("VirtualJetProducer") << "Subtracted pedestal\n";
   }
-  // Run algorithm. Will modify fjJets_ and allocate fjClusterSeq_. 
+  // Run algorithm. Will modify fjJets_ and allocate fjClusterSeq_.
   // This will use fjInputs_
-  runAlgorithm( iEvent, iSetup );
+  runAlgorithm(iEvent, iSetup);
 
   // if ( doPUOffsetCorr_ ) {
   //    subtractor_->setAlgorithm(fjClusterSeq_);
@@ -415,9 +398,9 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   // Now we find jets and need to recalculate their energy,
   // mark towers participated in jet,
   // remove occupied towers from the list and recalculate mean and sigma
-  // put the initial towers collection to the jet,   
-  // and subtract from initial towers in jet recalculated mean and sigma of towers 
-  if ( doPUOffsetCorr_ ) {
+  // put the initial towers collection to the jet,
+  // and subtract from initial towers in jet recalculated mean and sigma of towers
+  if (doPUOffsetCorr_) {
     LogDebug("VirtualJetProducer") << "Do PUOffsetCorr\n";
     vector<fastjet::PseudoJet> orphanInput;
     subtractor_->calculateOrphanInput(orphanInput);
@@ -426,334 +409,326 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   }
   // Write the output jets.
   // This will (by default) call the member function template
-  // "writeJets", but can be overridden. 
+  // "writeJets", but can be overridden.
   // this will use inputs_
-  output( iEvent, iSetup );
+  output(iEvent, iSetup);
   LogDebug("VirtualJetProducer") << "Wrote jets\n";
-  
+
   // Clear the work vectors so that memory is free for other modules.
   // Use the trick of swapping with an empty vector so that the memory
   // is actually given back rather than silently kept.
   decltype(fjInputs_)().swap(fjInputs_);
   decltype(fjJets_)().swap(fjJets_);
-  decltype(inputs_)().swap(inputs_);  
+  decltype(inputs_)().swap(inputs_);
 
   return;
 }
 
 //______________________________________________________________________________
-  
-void VirtualJetProducer::inputTowers( )
-{
-  auto inBegin = inputs_.begin(),
-    inEnd = inputs_.end(), i = inBegin;
-  for (; i != inEnd; ++i ) {
-    auto const & input = **i;
-    // std::cout << "CaloTowerVI jets " << input->pt() << " " << input->et() << ' '<< input->energy() << ' ' << (isAnomalousTower(input) ? " bad" : " ok") << std::endl; 
-    if (edm::isNotFinite(input.pt()))           continue;
-    if (input.et()    <inputEtMin_)  continue;
-    if (input.energy()<inputEMin_)   continue;
-    if (isAnomalousTower(*i))      continue;
+
+void VirtualJetProducer::inputTowers() {
+  auto inBegin = inputs_.begin(), inEnd = inputs_.end(), i = inBegin;
+  for (; i != inEnd; ++i) {
+    auto const& input = **i;
+    // std::cout << "CaloTowerVI jets " << input->pt() << " " << input->et() << ' '<< input->energy() << ' ' << (isAnomalousTower(input) ? " bad" : " ok") << std::endl;
+    if (edm::isNotFinite(input.pt()))
+      continue;
+    if (input.et() < inputEtMin_)
+      continue;
+    if (input.energy() < inputEMin_)
+      continue;
+    if (isAnomalousTower(*i))
+      continue;
     // Change by SRR : this is no longer an error nor warning, this can happen with PU mitigation algos.
     // Also switch to something more numerically safe. (VI: 10^-42GeV????)
-    if (input.pt() < 100 * std::numeric_limits<double>::epsilon() ) { 
+    if (input.pt() < 100 * std::numeric_limits<double>::epsilon()) {
       continue;
     }
-    if (makeCaloJet(jetTypeE)&&doPVCorrection_) {
-      const CaloTower & tower = dynamic_cast<const CaloTower &>(input);
-      auto const &  ct = tower.p4(vertex_);  // very expensive as computed in eta/phi
-      fjInputs_.emplace_back(ct.px(),ct.py(),ct.pz(),ct.energy());
+    if (makeCaloJet(jetTypeE) && doPVCorrection_) {
+      const CaloTower& tower = dynamic_cast<const CaloTower&>(input);
+      auto const& ct = tower.p4(vertex_);  // very expensive as computed in eta/phi
+      fjInputs_.emplace_back(ct.px(), ct.py(), ct.pz(), ct.energy());
       //std::cout << "tower:" << *tower << '\n';
-    }
-    else {
+    } else {
       /*
       if(makePFJet(jetTypeE)) {
 	reco::PFCandidate& pfc = (reco::PFCandidate&)input;
 	std::cout << "PF cand:" << pfc << '\n';
       }
       */
-      fjInputs_.emplace_back(input.px(),input.py(),input.pz(),
-					     input.energy());
+      fjInputs_.emplace_back(input.px(), input.py(), input.pz(), input.energy());
     }
     fjInputs_.back().set_user_index(i - inBegin);
   }
 
-  if ( restrictInputs_ && fjInputs_.size() > maxInputs_ ) {
-    reco::helper::GreaterByPtPseudoJet   pTComparator;
+  if (restrictInputs_ && fjInputs_.size() > maxInputs_) {
+    reco::helper::GreaterByPtPseudoJet pTComparator;
     std::sort(fjInputs_.begin(), fjInputs_.end(), pTComparator);
     fjInputs_.resize(maxInputs_);
-    edm::LogWarning("JetRecoTooManyEntries") << "Too many inputs in the event, limiting to first " << maxInputs_ << ". Output is suspect.";
+    edm::LogWarning("JetRecoTooManyEntries")
+        << "Too many inputs in the event, limiting to first " << maxInputs_ << ". Output is suspect.";
   }
 }
 
 //______________________________________________________________________________
-bool VirtualJetProducer::isAnomalousTower(reco::CandidatePtr input)
-{
-  if (!makeCaloJet(jetTypeE)) 
-      return false;
+bool VirtualJetProducer::isAnomalousTower(reco::CandidatePtr input) {
+  if (!makeCaloJet(jetTypeE))
+    return false;
   else
-      return (*anomalousTowerDef_)(*input);
+    return (*anomalousTowerDef_)(*input);
 }
 
 //------------------------------------------------------------------------------
-// This is pure virtual. 
+// This is pure virtual.
 //______________________________________________________________________________
 // void VirtualJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iSetup,
 //                                        std::vector<edm::Ptr<reco::Candidate> > const & inputs_);
 
 //______________________________________________________________________________
-void VirtualJetProducer::copyConstituents(const vector<fastjet::PseudoJet>& fjConstituents,
-                                          reco::Jet* jet)
-{
-  for (unsigned int i=0;i<fjConstituents.size();++i) { 
+void VirtualJetProducer::copyConstituents(const vector<fastjet::PseudoJet>& fjConstituents, reco::Jet* jet) {
+  for (unsigned int i = 0; i < fjConstituents.size(); ++i) {
     int index = fjConstituents[i].user_index();
-    if ( index >= 0 && static_cast<unsigned int>(index) < inputs_.size() )
+    if (index >= 0 && static_cast<unsigned int>(index) < inputs_.size())
       jet->addDaughter(inputs_[index]);
   }
 }
 
-
 //______________________________________________________________________________
-vector<reco::CandidatePtr>
-VirtualJetProducer::getConstituents(const vector<fastjet::PseudoJet>&fjConstituents)
-{
-  vector<reco::CandidatePtr> result; result.reserve(fjConstituents.size()/2);
-  for (unsigned int i=0;i<fjConstituents.size();i++) {
+vector<reco::CandidatePtr> VirtualJetProducer::getConstituents(const vector<fastjet::PseudoJet>& fjConstituents) {
+  vector<reco::CandidatePtr> result;
+  result.reserve(fjConstituents.size() / 2);
+  for (unsigned int i = 0; i < fjConstituents.size(); i++) {
     auto index = fjConstituents[i].user_index();
-    if ( index >= 0 && static_cast<unsigned int>(index) < inputs_.size() ) {
+    if (index >= 0 && static_cast<unsigned int>(index) < inputs_.size()) {
       result.emplace_back(inputs_[index]);
     }
   }
   return result;
 }
 
-
 //_____________________________________________________________________________
 
-void VirtualJetProducer::output(edm::Event & iEvent, edm::EventSetup const& iSetup)
-{
+void VirtualJetProducer::output(edm::Event& iEvent, edm::EventSetup const& iSetup) {
   // Write jets and constitutents. Will use fjJets_, inputs_
   // and fjClusterSeq_
 
-  if ( writeCompound_ ) {
+  if (writeCompound_) {
     // Write jets and subjets
-    switch( jetTypeE ) {
-    case JetType::CaloJet :
-      writeCompoundJets<reco::CaloJet>( iEvent, iSetup );
-      break;
-    case JetType::PFJet :
-      writeCompoundJets<reco::PFJet>( iEvent, iSetup );
-      break;
-    case JetType::GenJet :
-      writeCompoundJets<reco::GenJet>( iEvent, iSetup );
-      break;
-    case JetType::BasicJet :
-      writeCompoundJets<reco::BasicJet>( iEvent, iSetup );
-      break;
-    default:
-      throw cms::Exception("InvalidInput") << "invalid jet type in CompoundJetProducer\n";
-      break;
+    switch (jetTypeE) {
+      case JetType::CaloJet:
+        writeCompoundJets<reco::CaloJet>(iEvent, iSetup);
+        break;
+      case JetType::PFJet:
+        writeCompoundJets<reco::PFJet>(iEvent, iSetup);
+        break;
+      case JetType::GenJet:
+        writeCompoundJets<reco::GenJet>(iEvent, iSetup);
+        break;
+      case JetType::BasicJet:
+        writeCompoundJets<reco::BasicJet>(iEvent, iSetup);
+        break;
+      default:
+        throw cms::Exception("InvalidInput") << "invalid jet type in CompoundJetProducer\n";
+        break;
     };
-  } else if ( writeJetsWithConst_ ) {
+  } else if (writeJetsWithConst_) {
     // Write jets and new constituents.
-    writeJetsWithConstituents<reco::PFJet>( iEvent, iSetup );
+    writeJetsWithConstituents<reco::PFJet>(iEvent, iSetup);
   } else {
-    switch( jetTypeE ) {
-    case JetType::CaloJet :
-      writeJets<reco::CaloJet>( iEvent, iSetup);
-      break;
-    case JetType::PFJet :
-      writeJets<reco::PFJet>( iEvent, iSetup);
-      break;
-    case JetType::GenJet :
-      writeJets<reco::GenJet>( iEvent, iSetup);
-      break;
-    case JetType::TrackJet :
-      writeJets<reco::TrackJet>( iEvent, iSetup);
-      break;
-    case JetType::PFClusterJet :
-      writeJets<reco::PFClusterJet>( iEvent, iSetup);
-      break;
-    case JetType::BasicJet :
-      writeJets<reco::BasicJet>( iEvent, iSetup);
-      break;
-    default:
-           throw cms::Exception("InvalidInput") << "invalid jet type in VirtualJetProducer\n";
-      break;
+    switch (jetTypeE) {
+      case JetType::CaloJet:
+        writeJets<reco::CaloJet>(iEvent, iSetup);
+        break;
+      case JetType::PFJet:
+        writeJets<reco::PFJet>(iEvent, iSetup);
+        break;
+      case JetType::GenJet:
+        writeJets<reco::GenJet>(iEvent, iSetup);
+        break;
+      case JetType::TrackJet:
+        writeJets<reco::TrackJet>(iEvent, iSetup);
+        break;
+      case JetType::PFClusterJet:
+        writeJets<reco::PFClusterJet>(iEvent, iSetup);
+        break;
+      case JetType::BasicJet:
+        writeJets<reco::BasicJet>(iEvent, iSetup);
+        break;
+      default:
+        throw cms::Exception("InvalidInput") << "invalid jet type in VirtualJetProducer\n";
+        break;
     };
   }
-  
 }
 
 namespace {
-template< typename T >
-struct Area { static float get(T const &) {return 0;}};
+  template <typename T>
+  struct Area {
+    static float get(T const&) { return 0; }
+  };
 
-template<>
-struct Area<reco::CaloJet>{ static float get(reco::CaloJet const & jet) {
-   return jet.getSpecific().mTowersArea;
-}
-};
-}
+  template <>
+  struct Area<reco::CaloJet> {
+    static float get(reco::CaloJet const& jet) { return jet.getSpecific().mTowersArea; }
+  };
+}  // namespace
 
-template< typename T >
-void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& iSetup )
-{
-  // std::cout << "writeJets " << typeid(T).name() 
+template <typename T>
+void VirtualJetProducer::writeJets(edm::Event& iEvent, edm::EventSetup const& iSetup) {
+  // std::cout << "writeJets " << typeid(T).name()
   //          << (doRhoFastjet_ ? " doRhoFastjet " : "")
   //          << (doAreaFastjet_ ? " doAreaFastjet " : "")
   //          << (doAreaDiskApprox_ ? " doAreaDiskApprox " : "")
   //          << std::endl;
 
   if (doRhoFastjet_) {
-    // declare jet collection without the two jets, 
+    // declare jet collection without the two jets,
     // for unbiased background estimation.
     std::vector<fastjet::PseudoJet> fjexcluded_jets;
-    fjexcluded_jets=fjJets_;
-    
-    if(fjexcluded_jets.size()>2) fjexcluded_jets.resize(nExclude_);
-    
-    if(doFastJetNonUniform_){
+    fjexcluded_jets = fjJets_;
+
+    if (fjexcluded_jets.size() > 2)
+      fjexcluded_jets.resize(nExclude_);
+
+    if (doFastJetNonUniform_) {
       auto rhos = std::make_unique<std::vector<double>>();
       auto sigmas = std::make_unique<std::vector<double>>();
       int nEta = puCenters_.size();
       rhos->reserve(nEta);
       sigmas->reserve(nEta);
       fastjet::ClusterSequenceAreaBase const* clusterSequenceWithArea =
-        dynamic_cast<fastjet::ClusterSequenceAreaBase const *> ( fjClusterSeq_.get() );
+          dynamic_cast<fastjet::ClusterSequenceAreaBase const*>(fjClusterSeq_.get());
 
-      if (clusterSequenceWithArea ==nullptr ){
-	if (!fjJets_.empty()) {
-	  throw cms::Exception("LogicError")<<"fjClusterSeq is not initialized while inputs are present\n ";
-	}
+      if (clusterSequenceWithArea == nullptr) {
+        if (!fjJets_.empty()) {
+          throw cms::Exception("LogicError") << "fjClusterSeq is not initialized while inputs are present\n ";
+        }
       } else {
-	for(int ie = 0; ie < nEta; ++ie){
-	  double eta = puCenters_[ie];
-	  double etamin=eta-puWidth_;
-	  double etamax=eta+puWidth_;
-	  fastjet::RangeDefinition range_rho(etamin,etamax);
-	  fastjet::BackgroundEstimator bkgestim(*clusterSequenceWithArea,range_rho);
-	  bkgestim.set_excluded_jets(fjexcluded_jets);
-	  rhos->push_back(bkgestim.rho());
-	  sigmas->push_back(bkgestim.sigma());
-	}
+        for (int ie = 0; ie < nEta; ++ie) {
+          double eta = puCenters_[ie];
+          double etamin = eta - puWidth_;
+          double etamax = eta + puWidth_;
+          fastjet::RangeDefinition range_rho(etamin, etamax);
+          fastjet::BackgroundEstimator bkgestim(*clusterSequenceWithArea, range_rho);
+          bkgestim.set_excluded_jets(fjexcluded_jets);
+          rhos->push_back(bkgestim.rho());
+          sigmas->push_back(bkgestim.sigma());
+        }
       }
-      iEvent.put(std::move(rhos),"rhos");
-      iEvent.put(std::move(sigmas),"sigmas");
-    }else{
+      iEvent.put(std::move(rhos), "rhos");
+      iEvent.put(std::move(sigmas), "sigmas");
+    } else {
       auto rho = std::make_unique<double>(0.0);
       auto sigma = std::make_unique<double>(0.0);
       double mean_area = 0;
-      
+
       fastjet::ClusterSequenceAreaBase const* clusterSequenceWithArea =
-        dynamic_cast<fastjet::ClusterSequenceAreaBase const *> ( fjClusterSeq_.get() );
-      if (clusterSequenceWithArea ==nullptr ){
-	if (!fjJets_.empty()) {
-	  throw cms::Exception("LogicError")<<"fjClusterSeq is not initialized while inputs are present\n ";
-	}
+          dynamic_cast<fastjet::ClusterSequenceAreaBase const*>(fjClusterSeq_.get());
+      if (clusterSequenceWithArea == nullptr) {
+        if (!fjJets_.empty()) {
+          throw cms::Exception("LogicError") << "fjClusterSeq is not initialized while inputs are present\n ";
+        }
       } else {
-	clusterSequenceWithArea->get_median_rho_and_sigma(*fjSelector_,false,*rho,*sigma,mean_area);
-	if((*rho < 0)|| (edm::isNotFinite(*rho))) {
-	  edm::LogError("BadRho") << "rho value is " << *rho << " area:" << mean_area << " and n_empty_jets: " << clusterSequenceWithArea->n_empty_jets(*fjSelector_) << " with range " << fjSelector_->description()
-				  <<". Setting rho to rezo.";
-	  *rho = 0;
-	}
+        clusterSequenceWithArea->get_median_rho_and_sigma(*fjSelector_, false, *rho, *sigma, mean_area);
+        if ((*rho < 0) || (edm::isNotFinite(*rho))) {
+          edm::LogError("BadRho") << "rho value is " << *rho << " area:" << mean_area
+                                  << " and n_empty_jets: " << clusterSequenceWithArea->n_empty_jets(*fjSelector_)
+                                  << " with range " << fjSelector_->description() << ". Setting rho to rezo.";
+          *rho = 0;
+        }
       }
-      iEvent.put(std::move(rho),"rho");
-      iEvent.put(std::move(sigma),"sigma");
+      iEvent.put(std::move(rho), "rho");
+      iEvent.put(std::move(sigma), "sigma");
     }
-  } // doRhoFastjet_
-  
+  }  // doRhoFastjet_
+
   // produce output jet collection
-  
+
   using namespace reco;
 
-  // allocate fjJets_.size() Ts in vector  
+  // allocate fjJets_.size() Ts in vector
   auto jets = std::make_unique<std::vector<T>>(fjJets_.size());
-  
+
   // Distance between jet centers and overlap area -- for disk-based area calculation
-  using RIJ = std::pair<double,double>; 
-  std::vector<RIJ>   rijStorage(fjJets_.size()*(fjJets_.size()/2));
-  RIJ * rij[fjJets_.size()];
-  unsigned int k=0;
-  for (unsigned int ijet=0;ijet<fjJets_.size();++ijet) {
-     rij[ijet] = &rijStorage[k]; k+=ijet;
+  using RIJ = std::pair<double, double>;
+  std::vector<RIJ> rijStorage(fjJets_.size() * (fjJets_.size() / 2));
+  RIJ* rij[fjJets_.size()];
+  unsigned int k = 0;
+  for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
+    rij[ijet] = &rijStorage[k];
+    k += ijet;
   }
 
-  float etaJ[fjJets_.size()],  phiJ[fjJets_.size()];
+  float etaJ[fjJets_.size()], phiJ[fjJets_.size()];
 
-  auto orParam_ = 1./rParam_;
-  // fill jets 
-  for (unsigned int ijet=0;ijet<fjJets_.size();++ijet) {
-    auto & jet = (*jets)[ijet];
+  auto orParam_ = 1. / rParam_;
+  // fill jets
+  for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
+    auto& jet = (*jets)[ijet];
     // get the fastjet jet
     const fastjet::PseudoJet& fjJet = fjJets_[ijet];
     // get the constituents from fastjet
-    std::vector<fastjet::PseudoJet> const & fjConstituents = fastjet::sorted_by_pt(fjJet.constituents());
+    std::vector<fastjet::PseudoJet> const& fjConstituents = fastjet::sorted_by_pt(fjJet.constituents());
     // convert them to CandidatePtr vector
-    std::vector<CandidatePtr> const & constituents = getConstituents(fjConstituents);
+    std::vector<CandidatePtr> const& constituents = getConstituents(fjConstituents);
 
     // write the specifics to the jet (simultaneously sets 4-vector, vertex).
     // These are overridden functions that will call the appropriate
     // specific allocator.
-    writeSpecific(jet,
-                  Particle::LorentzVector(fjJet.px(),
-                                          fjJet.py(),
-                                          fjJet.pz(),
-                                          fjJet.E()),
-                  vertex_,
-                  constituents, iSetup);
+    writeSpecific(
+        jet, Particle::LorentzVector(fjJet.px(), fjJet.py(), fjJet.pz(), fjJet.E()), vertex_, constituents, iSetup);
     phiJ[ijet] = jet.phi();
     etaJ[ijet] = jet.eta();
   }
 
-   // calcuate the jet area
-  for (unsigned int ijet=0;ijet<fjJets_.size();++ijet) {
+  // calcuate the jet area
+  for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
     // calcuate the jet area
-    double jetArea=0.0;
+    double jetArea = 0.0;
     // get the fastjet jet
-    const auto & fjJet = fjJets_[ijet];
-    if ( doAreaFastjet_ && fjJet.has_area() ) {
+    const auto& fjJet = fjJets_[ijet];
+    if (doAreaFastjet_ && fjJet.has_area()) {
       jetArea = fjJet.area();
+    } else if (doAreaDiskApprox_) {
+      // Here it is assumed that fjJets_ is in decreasing order of pT,
+      // which should happen in FastjetJetProducer::runAlgorithm()
+      jetArea = M_PI;
+      RIJ* distance = rij[ijet];
+      for (unsigned jJet = 0; jJet < ijet; ++jJet) {
+        distance[jJet].first = std::sqrt(reco::deltaR2(etaJ[ijet], phiJ[ijet], etaJ[jJet], phiJ[jJet])) * orParam_;
+        distance[jJet].second = reco::helper::VirtualJetProducerHelper::intersection(distance[jJet].first);
+        jetArea -= distance[jJet].second;
+        for (unsigned kJet = 0; kJet < jJet; ++kJet) {
+          jetArea += reco::helper::VirtualJetProducerHelper::intersection(distance[jJet].first,
+                                                                          distance[kJet].first,
+                                                                          rij[jJet][kJet].first,
+                                                                          distance[jJet].second,
+                                                                          distance[kJet].second,
+                                                                          rij[jJet][kJet].second);
+        }  // end loop over harder jets
+      }    // end loop over harder jets
+      jetArea *= (rParam_ * rParam_);
     }
-    else if ( doAreaDiskApprox_ ) {
-      // Here it is assumed that fjJets_ is in decreasing order of pT, 
-      // which should happen in FastjetJetProducer::runAlgorithm() 
-      jetArea   = M_PI;
-        RIJ *  distance  = rij[ijet];
-        for (unsigned jJet = 0; jJet < ijet; ++jJet) {
-          distance[jJet].first      = std::sqrt(reco::deltaR2(etaJ[ijet],phiJ[ijet], etaJ[jJet],phiJ[jJet]))*orParam_;
-          distance[jJet].second = reco::helper::VirtualJetProducerHelper::intersection(distance[jJet].first);
-          jetArea            -=distance[jJet].second;
-          for (unsigned kJet = 0; kJet < jJet; ++kJet) {
-            jetArea          += reco::helper::VirtualJetProducerHelper::intersection(distance[jJet].first, distance[kJet].first, rij[jJet][kJet].first, 
-                                                                                     distance[jJet].second, distance[kJet].second, rij[jJet][kJet].second);
-          } // end loop over harder jets
-        } // end loop over harder jets
-      jetArea  *= (rParam_*rParam_);
-    } 
-    auto & jet = (*jets)[ijet]; 
-    jet.setJetArea (jetArea);
-    
-    if(doPUOffsetCorr_){
-      jet.setPileup(subtractor_->getPileUpEnergy(ijet));
-    }else{
-      jet.setPileup (0.0);
-    }
-        
-   // std::cout << "area " << ijet << " " << jetArea << " " << Area<T>::get(jet) << std::endl;
-   // std::cout << "JetVI " << ijet << ' '<< jet.pt() << " " << jet.et() << ' '<< jet.energy() << ' '<< jet.mass() << std::endl;
+    auto& jet = (*jets)[ijet];
+    jet.setJetArea(jetArea);
 
+    if (doPUOffsetCorr_) {
+      jet.setPileup(subtractor_->getPileUpEnergy(ijet));
+    } else {
+      jet.setPileup(0.0);
+    }
+
+    // std::cout << "area " << ijet << " " << jetArea << " " << Area<T>::get(jet) << std::endl;
+    // std::cout << "JetVI " << ijet << ' '<< jet.pt() << " " << jet.et() << ' '<< jet.energy() << ' '<< jet.mass() << std::endl;
   }
   // put the jets in the collection
-  iEvent.put(std::move(jets),jetCollInstanceName_);
+  iEvent.put(std::move(jets), jetCollInstanceName_);
 }
 
 /// function template to write out the outputs
-template< class T>
-void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetup const& iSetup)
-{
-  if ( verbosity_ >= 1 ) { 
+template <class T>
+void VirtualJetProducer::writeCompoundJets(edm::Event& iEvent, edm::EventSetup const& iSetup) {
+  if (verbosity_ >= 1) {
     std::cout << "<VirtualJetProducer::writeCompoundJets (moduleLabel = " << moduleLabel_ << ")>:" << std::endl;
   }
 
@@ -763,143 +738,143 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
   auto subjetCollection = std::make_unique<std::vector<T>>();
 
   // This will store the handle for the subjets after we write them
-  edm::OrphanHandle< std::vector<T> > subjetHandleAfterPut;
+  edm::OrphanHandle<std::vector<T>> subjetHandleAfterPut;
   // this is the mapping of subjet to hard jet
-  std::vector< std::vector<int> > indices;
+  std::vector<std::vector<int>> indices;
   // this is the list of hardjet 4-momenta
   std::vector<math::XYZTLorentzVector> p4_hardJets;
   // this is the hardjet areas
   std::vector<double> area_hardJets;
 
   // Loop over the hard jets
-  std::vector<fastjet::PseudoJet>::const_iterator it = fjJets_.begin(),
-    iEnd = fjJets_.end(),
-    iBegin = fjJets_.begin();
-  indices.resize( fjJets_.size() );
-  for ( ; it != iEnd; ++it ) {
-    fastjet::PseudoJet const & localJet = *it;
+  std::vector<fastjet::PseudoJet>::const_iterator it = fjJets_.begin(), iEnd = fjJets_.end(), iBegin = fjJets_.begin();
+  indices.resize(fjJets_.size());
+  for (; it != iEnd; ++it) {
+    fastjet::PseudoJet const& localJet = *it;
     unsigned int jetIndex = it - iBegin;
     // Get the 4-vector for the hard jet
-    p4_hardJets.push_back( math::XYZTLorentzVector(localJet.px(), localJet.py(), localJet.pz(), localJet.e() ));
+    p4_hardJets.push_back(math::XYZTLorentzVector(localJet.px(), localJet.py(), localJet.pz(), localJet.e()));
     double localJetArea = 0.0;
-    if ( doAreaFastjet_ && localJet.has_area() ) {
+    if (doAreaFastjet_ && localJet.has_area()) {
       localJetArea = localJet.area();
     }
-    area_hardJets.push_back( localJetArea );
+    area_hardJets.push_back(localJetArea);
 
     // create the subjet list
     std::vector<fastjet::PseudoJet> constituents;
-    if ( it->has_pieces() ) {
+    if (it->has_pieces()) {
       constituents = it->pieces();
-    } else if ( it->has_constituents() ) {
+    } else if (it->has_constituents()) {
       constituents = it->constituents();
     }
 
-    std::vector<fastjet::PseudoJet>::const_iterator itSubJetBegin = constituents.begin(),
-      itSubJet = itSubJetBegin, itSubJetEnd = constituents.end();
-    for (; itSubJet != itSubJetEnd; ++itSubJet ){
-
-      fastjet::PseudoJet const & subjet = *itSubJet;      
-      if ( verbosity_ >= 1 ) {
-	std::cout << "subjet #" << (itSubJet - itSubJetBegin) << ": Pt = " << subjet.pt() << ", eta = " << subjet.eta() << ", phi = " << subjet.phi() << ", mass = " << subjet.m() 
-		  << " (#constituents = " << subjet.constituents().size() << ")" << std::endl;
-	std::vector<fastjet::PseudoJet> subjet_constituents = subjet.constituents();
-	int idx_constituent = 0;
-	for ( std::vector<fastjet::PseudoJet>::const_iterator constituent = subjet_constituents.begin();
-	      constituent != subjet_constituents.end(); ++constituent ) {
-	  if ( constituent->pt() < 1.e-3 ) continue; // CV: skip ghosts
-	  std::cout << "  constituent #" << idx_constituent << ": Pt = " << constituent->pt() << ", eta = " << constituent->eta() << ", phi = " << constituent->phi() << "," 
-		    << " mass = " << constituent->m() << std::endl;
-	  ++idx_constituent;
-	}
+    std::vector<fastjet::PseudoJet>::const_iterator itSubJetBegin = constituents.begin(), itSubJet = itSubJetBegin,
+                                                    itSubJetEnd = constituents.end();
+    for (; itSubJet != itSubJetEnd; ++itSubJet) {
+      fastjet::PseudoJet const& subjet = *itSubJet;
+      if (verbosity_ >= 1) {
+        std::cout << "subjet #" << (itSubJet - itSubJetBegin) << ": Pt = " << subjet.pt() << ", eta = " << subjet.eta()
+                  << ", phi = " << subjet.phi() << ", mass = " << subjet.m()
+                  << " (#constituents = " << subjet.constituents().size() << ")" << std::endl;
+        std::vector<fastjet::PseudoJet> subjet_constituents = subjet.constituents();
+        int idx_constituent = 0;
+        for (std::vector<fastjet::PseudoJet>::const_iterator constituent = subjet_constituents.begin();
+             constituent != subjet_constituents.end();
+             ++constituent) {
+          if (constituent->pt() < 1.e-3)
+            continue;  // CV: skip ghosts
+          std::cout << "  constituent #" << idx_constituent << ": Pt = " << constituent->pt()
+                    << ", eta = " << constituent->eta() << ", phi = " << constituent->phi() << ","
+                    << " mass = " << constituent->m() << std::endl;
+          ++idx_constituent;
+        }
       }
 
-      if ( verbosity_ >= 1 ) {
-	std::cout << "subjet #" << (itSubJet - itSubJetBegin) << ": Pt = " << subjet.pt() << ", eta = " << subjet.eta() << ", phi = " << subjet.phi() << ", mass = " << subjet.m() 
-		  << " (#constituents = " << subjet.constituents().size() << ")" << std::endl;
-	std::vector<fastjet::PseudoJet> subjet_constituents = subjet.constituents();
-	int idx_constituent = 0;
-	for ( std::vector<fastjet::PseudoJet>::const_iterator constituent = subjet_constituents.begin();
-	      constituent != subjet_constituents.end(); ++constituent ) {
-	  if ( constituent->pt() < 1.e-3 ) continue; // CV: skip ghosts
-	  std::cout << " constituent #" << idx_constituent << ": Pt = " << constituent->pt() << ", eta = " << constituent->eta() << ", phi = " << constituent->phi() << "," 
-		    << " mass = " << constituent->m() << std::endl;
-	  ++idx_constituent;
-	}
+      if (verbosity_ >= 1) {
+        std::cout << "subjet #" << (itSubJet - itSubJetBegin) << ": Pt = " << subjet.pt() << ", eta = " << subjet.eta()
+                  << ", phi = " << subjet.phi() << ", mass = " << subjet.m()
+                  << " (#constituents = " << subjet.constituents().size() << ")" << std::endl;
+        std::vector<fastjet::PseudoJet> subjet_constituents = subjet.constituents();
+        int idx_constituent = 0;
+        for (std::vector<fastjet::PseudoJet>::const_iterator constituent = subjet_constituents.begin();
+             constituent != subjet_constituents.end();
+             ++constituent) {
+          if (constituent->pt() < 1.e-3)
+            continue;  // CV: skip ghosts
+          std::cout << " constituent #" << idx_constituent << ": Pt = " << constituent->pt()
+                    << ", eta = " << constituent->eta() << ", phi = " << constituent->phi() << ","
+                    << " mass = " << constituent->m() << std::endl;
+          ++idx_constituent;
+        }
       }
 
-      math::XYZTLorentzVector p4Subjet(subjet.px(), subjet.py(), subjet.pz(), subjet.e() );
-      reco::Particle::Point point(0,0,0);
+      math::XYZTLorentzVector p4Subjet(subjet.px(), subjet.py(), subjet.pz(), subjet.e());
+      reco::Particle::Point point(0, 0, 0);
 
       // This will hold ptr's to the subjets
       std::vector<reco::CandidatePtr> subjetConstituents;
 
       // Get the transient subjet constituents from fastjet
       std::vector<fastjet::PseudoJet> subjetFastjetConstituents = subjet.constituents();
-      std::vector<reco::CandidatePtr> constituents =
-	getConstituents(subjetFastjetConstituents );    
+      std::vector<reco::CandidatePtr> constituents = getConstituents(subjetFastjetConstituents);
 
-      indices[jetIndex].push_back( subjetCollection->size() );
+      indices[jetIndex].push_back(subjetCollection->size());
 
       // Add the concrete subjet type to the subjet list to write to event record
       T jet;
-      reco::writeSpecific( jet, p4Subjet, point, constituents, iSetup);
+      reco::writeSpecific(jet, p4Subjet, point, constituents, iSetup);
       double subjetArea = 0.0;
-      if ( doAreaFastjet_ && itSubJet->has_area() ){
-	subjetArea = itSubJet->area();
+      if (doAreaFastjet_ && itSubJet->has_area()) {
+        subjetArea = itSubJet->area();
       }
-      jet.setJetArea( subjetArea );
-      subjetCollection->push_back( jet );
+      jet.setJetArea(subjetArea);
+      subjetCollection->push_back(jet);
     }
   }
 
   // put subjets into event record
   subjetHandleAfterPut = iEvent.put(std::move(subjetCollection), jetCollInstanceName_);
-  
-  // Now create the hard jets with ptr's to the subjets as constituents
-  std::vector<math::XYZTLorentzVector>::const_iterator ip4 = p4_hardJets.begin(),
-    ip4Begin = p4_hardJets.begin(),
-    ip4End = p4_hardJets.end();
 
-  for ( ; ip4 != ip4End; ++ip4 ) {
+  // Now create the hard jets with ptr's to the subjets as constituents
+  std::vector<math::XYZTLorentzVector>::const_iterator ip4 = p4_hardJets.begin(), ip4Begin = p4_hardJets.begin(),
+                                                       ip4End = p4_hardJets.end();
+
+  for (; ip4 != ip4End; ++ip4) {
     int p4_index = ip4 - ip4Begin;
-    std::vector<int> & ind = indices[p4_index];
+    std::vector<int>& ind = indices[p4_index];
     std::vector<reco::CandidatePtr> i_hardJetConstituents;
     // Add the subjets to the hard jet
-    for( std::vector<int>::const_iterator isub = ind.begin();
-	 isub != ind.end(); ++isub ) {
-      reco::CandidatePtr candPtr( subjetHandleAfterPut, *isub, false );
-      i_hardJetConstituents.push_back( candPtr );
-    }   
-    reco::Particle::Point point(0,0,0);
-    reco::BasicJet toput( *ip4, point, i_hardJetConstituents);
-    toput.setJetArea( area_hardJets[ip4 - ip4Begin] );
-    jetCollection->push_back( toput );
+    for (std::vector<int>::const_iterator isub = ind.begin(); isub != ind.end(); ++isub) {
+      reco::CandidatePtr candPtr(subjetHandleAfterPut, *isub, false);
+      i_hardJetConstituents.push_back(candPtr);
+    }
+    reco::Particle::Point point(0, 0, 0);
+    reco::BasicJet toput(*ip4, point, i_hardJetConstituents);
+    toput.setJetArea(area_hardJets[ip4 - ip4Begin]);
+    jetCollection->push_back(toput);
   }
 
   // put hard jets into event record
   // Store the Orphan handle for adding HTT information
-  edm::OrphanHandle<reco::BasicJetCollection>  oh = iEvent.put(std::move(jetCollection));
+  edm::OrphanHandle<reco::BasicJetCollection> oh = iEvent.put(std::move(jetCollection));
 
-  if (fromHTTTopJetProducer_){
-    addHTTTopJetTagInfoCollection( iEvent, iSetup, oh);
+  if (fromHTTTopJetProducer_) {
+    addHTTTopJetTagInfoCollection(iEvent, iSetup, oh);
   }
-
 }
 
 /// function template to write out the outputs
-template< class T>
-void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::EventSetup const& iSetup)
-{
-  if ( verbosity_ >= 1 ) {
+template <class T>
+void VirtualJetProducer::writeJetsWithConstituents(edm::Event& iEvent, edm::EventSetup const& iSetup) {
+  if (verbosity_ >= 1) {
     std::cout << "<VirtualJetProducer::writeJetsWithConstituents (moduleLabel = " << moduleLabel_ << ")>:" << std::endl;
   }
 
   // get a list of output jets  MV: make this compatible with template
   auto jetCollection = std::make_unique<reco::PFJetCollection>();
-  
+
   // this is the mapping of jet to constituents
-  std::vector< std::vector<int> > indices;
+  std::vector<std::vector<int>> indices;
   // this is the list of jet 4-momenta
   std::vector<math::XYZTLorentzVector> p4_Jets;
   // this is the jet areas
@@ -907,40 +882,38 @@ void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::E
 
   // get a list of output constituents
   auto constituentCollection = std::make_unique<reco::PFCandidateCollection>();
-  
+
   // This will store the handle for the constituents after we write them
   edm::OrphanHandle<reco::PFCandidateCollection> constituentHandleAfterPut;
-    
+
   // Loop over the jets and extract constituents
   std::vector<fastjet::PseudoJet> constituentsSub;
-  std::vector<fastjet::PseudoJet>::const_iterator it = fjJets_.begin(),
-    iEnd = fjJets_.end(),
-    iBegin = fjJets_.begin();
-  indices.resize( fjJets_.size() );
+  std::vector<fastjet::PseudoJet>::const_iterator it = fjJets_.begin(), iEnd = fjJets_.end(), iBegin = fjJets_.begin();
+  indices.resize(fjJets_.size());
 
-  for ( ; it != iEnd; ++it ) {
-    fastjet::PseudoJet const & localJet = *it;
+  for (; it != iEnd; ++it) {
+    fastjet::PseudoJet const& localJet = *it;
     unsigned int jetIndex = it - iBegin;
     // Get the 4-vector for the hard jet
-    p4_Jets.push_back( math::XYZTLorentzVector(localJet.px(), localJet.py(), localJet.pz(), localJet.e() ));
+    p4_Jets.push_back(math::XYZTLorentzVector(localJet.px(), localJet.py(), localJet.pz(), localJet.e()));
     double localJetArea = 0.0;
-    if ( doAreaFastjet_ && localJet.has_area() ) {
+    if (doAreaFastjet_ && localJet.has_area()) {
       localJetArea = localJet.area();
     }
-    area_Jets.push_back( localJetArea );
+    area_Jets.push_back(localJetArea);
 
     // create the constituent list
-    std::vector<fastjet::PseudoJet> constituents,ghosts;
-    if ( it->has_pieces() )
+    std::vector<fastjet::PseudoJet> constituents, ghosts;
+    if (it->has_pieces())
       constituents = it->pieces();
-    else if ( it->has_constituents() )
-      fastjet::SelectorIsPureGhost().sift(it->constituents(), ghosts, constituents); //filter out ghosts
+    else if (it->has_constituents())
+      fastjet::SelectorIsPureGhost().sift(it->constituents(), ghosts, constituents);  //filter out ghosts
 
     //loop over constituents of jet (can be subjets or normal constituents)
     indices[jetIndex].reserve(constituents.size());
-    constituentsSub.reserve(constituentsSub.size()+constituents.size());
+    constituentsSub.reserve(constituentsSub.size() + constituents.size());
     for (fastjet::PseudoJet const& constit : constituents) {
-      indices[jetIndex].push_back( constituentsSub.size() );
+      indices[jetIndex].push_back(constituentsSub.size());
       constituentsSub.push_back(constit);
     }
   }
@@ -950,36 +923,35 @@ void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::E
   for (fastjet::PseudoJet const& constit : constituentsSub) {
     auto orig = inputs_[constit.user_index()];
     auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(orig->pdgId());
-    reco::PFCandidate pCand( reco::PFCandidate(orig->charge(), orig->p4(), id) );
+    reco::PFCandidate pCand(reco::PFCandidate(orig->charge(), orig->p4(), id));
     math::XYZTLorentzVector pVec;
-    pVec.SetPxPyPzE(constit.px(),constit.py(),constit.pz(),constit.e());
+    pVec.SetPxPyPzE(constit.px(), constit.py(), constit.pz(), constit.e());
     pCand.setP4(pVec);
-    pCand.setSourceCandidatePtr( orig->sourceCandidatePtr(0) );
+    pCand.setSourceCandidatePtr(orig->sourceCandidatePtr(0));
     constituentCollection->push_back(pCand);
   }
   // put constituents into event record
-  constituentHandleAfterPut = iEvent.put(std::move(constituentCollection), jetCollInstanceName_ );
+  constituentHandleAfterPut = iEvent.put(std::move(constituentCollection), jetCollInstanceName_);
 
   // Now create the jets with ptr's to the constituents
-  std::vector<math::XYZTLorentzVector>::const_iterator ip4 = p4_Jets.begin(),
-    ip4Begin = p4_Jets.begin(),
-    ip4End = p4_Jets.end();
+  std::vector<math::XYZTLorentzVector>::const_iterator ip4 = p4_Jets.begin(), ip4Begin = p4_Jets.begin(),
+                                                       ip4End = p4_Jets.end();
 
-  for ( ; ip4 != ip4End; ++ip4 ) {
+  for (; ip4 != ip4End; ++ip4) {
     int p4_index = ip4 - ip4Begin;
-    std::vector<int> & ind = indices[p4_index];
+    std::vector<int>& ind = indices[p4_index];
     std::vector<reco::CandidatePtr> i_jetConstituents;
     // Add the constituents to the jet
-    for( std::vector<int>::const_iterator iconst = ind.begin(); iconst != ind.end(); ++iconst ) {
-      reco::CandidatePtr candPtr( constituentHandleAfterPut, *iconst, false );
-      i_jetConstituents.push_back( candPtr );
+    for (std::vector<int>::const_iterator iconst = ind.begin(); iconst != ind.end(); ++iconst) {
+      reco::CandidatePtr candPtr(constituentHandleAfterPut, *iconst, false);
+      i_jetConstituents.push_back(candPtr);
     }
-    if(!i_jetConstituents.empty()) { //only keep jets which have constituents after subtraction
-      reco::Particle::Point point(0,0,0);
+    if (!i_jetConstituents.empty()) {  //only keep jets which have constituents after subtraction
+      reco::Particle::Point point(0, 0, 0);
       reco::PFJet jet;
-      reco::writeSpecific(jet,*ip4,point,i_jetConstituents,iSetup);
-      jet.setJetArea( area_Jets[ip4 - ip4Begin] );
-      jetCollection->emplace_back( jet );
+      reco::writeSpecific(jet, *ip4, point, i_jetConstituents, iSetup);
+      jet.setJetArea(area_Jets[ip4 - ip4Begin]);
+      jetCollection->emplace_back(jet);
     }
   }
 
@@ -989,59 +961,57 @@ void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::E
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void VirtualJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  fillDescriptionsFromVirtualJetProducer(desc);
+  desc.add<string>("jetCollInstanceName", "");
 
-	edm::ParameterSetDescription desc;
-        fillDescriptionsFromVirtualJetProducer(desc);
-	desc.add<string>("jetCollInstanceName", ""	);
-
-        // addDefault must be used here instead of add unless
-        // all the classes that inherit from this class redefine
-        // the fillDescriptions function. Otherwise, the autogenerated
-        // cfi filenames are the same and conflict.
-	descriptions.addDefault(desc);
+  // addDefault must be used here instead of add unless
+  // all the classes that inherit from this class redefine
+  // the fillDescriptions function. Otherwise, the autogenerated
+  // cfi filenames are the same and conflict.
+  descriptions.addDefault(desc);
 }
 
-void VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(edm::ParameterSetDescription& desc)
-{
-	desc.add<edm::InputTag>("src",		edm::InputTag("particleFlow") );
-	desc.add<edm::InputTag>("srcPVs",	edm::InputTag("") );
-	desc.add<string>("jetType",		"PFJet" );
-	desc.add<string>("jetAlgorithm",	"AntiKt" );
-	desc.add<double>("rParam",		0.4 );
-	desc.add<double>("inputEtMin",		0.0 );
-	desc.add<double>("inputEMin",		0.0 );
-	desc.add<double>("jetPtMin",		5. );
-	desc.add<bool> 	("doPVCorrection",	false );
-	desc.add<bool> 	("doAreaFastjet",	false );
-	desc.add<bool>  ("doRhoFastjet",	false );
-	desc.add<bool> 	("doPUOffsetCorr", 	false	);
-	desc.add<double>("puPtMin",             10.);
-        desc.add<double>("nSigmaPU",            1.0 );
-        desc.add<double>("radiusPU",            0.5 );
-	desc.add<string>("subtractorName", 	""	);
-	desc.add<bool> 	("useExplicitGhosts", 	false	);
-	desc.add<bool> 	("doAreaDiskApprox", 	false 	);
-	desc.add<double>("voronoiRfact", 	-0.9 	);
-	desc.add<double>("Rho_EtaMax", 	 	4.4 	);
-	desc.add<double>("Ghost_EtaMax",	5. 	);
-	desc.add<int> 	("Active_Area_Repeats",	1 	);
-	desc.add<double>("GhostArea",	 	0.01 	);
-	desc.add<bool> 	("restrictInputs", 	false 	);
-	desc.add<unsigned int> 	("maxInputs", 	1 	);
-	desc.add<bool> 	("writeCompound", 	false 	);
-        desc.add<bool> 	("writeJetsWithConst", 	false 	);
-	desc.add<bool> 	("doFastJetNonUniform", false 	);
-	desc.add<bool> 	("useDeterministicSeed",false 	);
-	desc.add<unsigned int> 	("minSeed", 	14327 	);
-	desc.add<int> 	("verbosity", 		0 	);
-	desc.add<double>("puWidth",	 	0. 	);
-	desc.add<unsigned int>("nExclude", 	0 	);
-	desc.add<unsigned int>("maxBadEcalCells", 	9999999	);
-	desc.add<unsigned int>("maxBadHcalCells",	9999999 );
-	desc.add<unsigned int>("maxProblematicEcalCells",	9999999 );
-	desc.add<unsigned int>("maxProblematicHcalCells",	9999999 );
-	desc.add<unsigned int>("maxRecoveredEcalCells",	9999999 );
-	desc.add<unsigned int>("maxRecoveredHcalCells",	9999999 );
-	vector<double>  puCentersDefault;
-	desc.add<vector<double>>("puCenters", 	puCentersDefault);
+void VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(edm::ParameterSetDescription& desc) {
+  desc.add<edm::InputTag>("src", edm::InputTag("particleFlow"));
+  desc.add<edm::InputTag>("srcPVs", edm::InputTag(""));
+  desc.add<string>("jetType", "PFJet");
+  desc.add<string>("jetAlgorithm", "AntiKt");
+  desc.add<double>("rParam", 0.4);
+  desc.add<double>("inputEtMin", 0.0);
+  desc.add<double>("inputEMin", 0.0);
+  desc.add<double>("jetPtMin", 5.);
+  desc.add<bool>("doPVCorrection", false);
+  desc.add<bool>("doAreaFastjet", false);
+  desc.add<bool>("doRhoFastjet", false);
+  desc.add<bool>("doPUOffsetCorr", false);
+  desc.add<double>("puPtMin", 10.);
+  desc.add<double>("nSigmaPU", 1.0);
+  desc.add<double>("radiusPU", 0.5);
+  desc.add<string>("subtractorName", "");
+  desc.add<bool>("useExplicitGhosts", false);
+  desc.add<bool>("doAreaDiskApprox", false);
+  desc.add<double>("voronoiRfact", -0.9);
+  desc.add<double>("Rho_EtaMax", 4.4);
+  desc.add<double>("Ghost_EtaMax", 5.);
+  desc.add<int>("Active_Area_Repeats", 1);
+  desc.add<double>("GhostArea", 0.01);
+  desc.add<bool>("restrictInputs", false);
+  desc.add<unsigned int>("maxInputs", 1);
+  desc.add<bool>("writeCompound", false);
+  desc.add<bool>("writeJetsWithConst", false);
+  desc.add<bool>("doFastJetNonUniform", false);
+  desc.add<bool>("useDeterministicSeed", false);
+  desc.add<unsigned int>("minSeed", 14327);
+  desc.add<int>("verbosity", 0);
+  desc.add<double>("puWidth", 0.);
+  desc.add<unsigned int>("nExclude", 0);
+  desc.add<unsigned int>("maxBadEcalCells", 9999999);
+  desc.add<unsigned int>("maxBadHcalCells", 9999999);
+  desc.add<unsigned int>("maxProblematicEcalCells", 9999999);
+  desc.add<unsigned int>("maxProblematicHcalCells", 9999999);
+  desc.add<unsigned int>("maxRecoveredEcalCells", 9999999);
+  desc.add<unsigned int>("maxRecoveredHcalCells", 9999999);
+  vector<double> puCentersDefault;
+  desc.add<vector<double>>("puCenters", puCentersDefault);
 }

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -33,9 +33,7 @@
 #include <vector>
 #include <boost/shared_ptr.hpp>
 
-
-class dso_hidden VirtualJetProducer : public edm::stream::EDProducer<>
-{
+class dso_hidden VirtualJetProducer : public edm::stream::EDProducer<> {
 protected:
   //
   // typedefs & structs
@@ -50,31 +48,18 @@ protected:
       PFClusterJet,
       LastJetType  // no real type, technical
     };
-    static const char *const names[];
-    static Type byName(const std::string &name);
+    static const char* const names[];
+    static Type byName(const std::string& name);
   };
-    
+
   JetType::Type jetTypeE;
 
-  inline bool makeCaloJet(const JetType::Type &fTag) {
-    return fTag == JetType::CaloJet;
-  }
-  inline bool makePFJet(const JetType::Type &fTag) {
-    return fTag == JetType::PFJet;
-  }
-  inline bool makeGenJet(const JetType::Type &fTag) {
-    return fTag == JetType::GenJet;
-  }
-  inline bool makeTrackJet(const JetType::Type &fTag) {
-    return fTag == JetType::TrackJet;
-  }
-  inline bool makePFClusterJet(const JetType::Type &fTag) {
-    return fTag == JetType::PFClusterJet;
-  }
-  inline bool makeBasicJet(const JetType::Type &fTag) {
-    return fTag == JetType::BasicJet;
-  }
-  
+  inline bool makeCaloJet(const JetType::Type& fTag) { return fTag == JetType::CaloJet; }
+  inline bool makePFJet(const JetType::Type& fTag) { return fTag == JetType::PFJet; }
+  inline bool makeGenJet(const JetType::Type& fTag) { return fTag == JetType::GenJet; }
+  inline bool makeTrackJet(const JetType::Type& fTag) { return fTag == JetType::TrackJet; }
+  inline bool makePFClusterJet(const JetType::Type& fTag) { return fTag == JetType::PFClusterJet; }
+  inline bool makeBasicJet(const JetType::Type& fTag) { return fTag == JetType::BasicJet; }
 
   //
   // construction/destruction
@@ -84,147 +69,147 @@ public:
   ~VirtualJetProducer() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   static void fillDescriptionsFromVirtualJetProducer(edm::ParameterSetDescription& desc);
-  
+
   // typedefs
-  typedef boost::shared_ptr<fastjet::ClusterSequence>        ClusterSequencePtr;
-  typedef boost::shared_ptr<fastjet::JetDefinition::Plugin>  PluginPtr;
-  typedef boost::shared_ptr<fastjet::JetDefinition>          JetDefPtr;
-  typedef boost::shared_ptr<fastjet::GhostedAreaSpec>        ActiveAreaSpecPtr;
-  typedef boost::shared_ptr<fastjet::AreaDefinition>         AreaDefinitionPtr;
-  typedef boost::shared_ptr<fastjet::Selector>               SelectorPtr;
-  
+  typedef boost::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
+  typedef boost::shared_ptr<fastjet::JetDefinition::Plugin> PluginPtr;
+  typedef boost::shared_ptr<fastjet::JetDefinition> JetDefPtr;
+  typedef boost::shared_ptr<fastjet::GhostedAreaSpec> ActiveAreaSpecPtr;
+  typedef boost::shared_ptr<fastjet::AreaDefinition> AreaDefinitionPtr;
+  typedef boost::shared_ptr<fastjet::Selector> SelectorPtr;
+
   //
   // member functions
   //
 public:
-  void  produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  std::string   jetType() const { return jetType_; }
-  
-protected:
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  std::string jetType() const { return jetType_; }
 
+protected:
   //
   // Internal methods for jet production.
-  // The user can either use the defaults, or override all of these methods. 
+  // The user can either use the defaults, or override all of these methods.
   //
 
   // This method creates the "produces" statement in the constructor.
   // The default is to produce a single jet collection as per the user's request
-  // (Calo,PF,Basic, or Gen). 
-  virtual void makeProduces( std::string s, std::string tag = "" );
+  // (Calo,PF,Basic, or Gen).
+  virtual void makeProduces(std::string s, std::string tag = "");
 
   // This method inputs the constituents from "inputs" and modifies
-  // fjInputs. 
+  // fjInputs.
   virtual void inputTowers();
 
   // This checks if the tower is anomalous (if a calo tower).
   virtual bool isAnomalousTower(reco::CandidatePtr input);
 
   // This will copy the fastjet constituents to the jet itself.
-  virtual void copyConstituents(const std::vector<fastjet::PseudoJet>&fjConstituents,
-				reco::Jet* jet);
+  virtual void copyConstituents(const std::vector<fastjet::PseudoJet>& fjConstituents, reco::Jet* jet);
 
   // This will run the actual algorithm. This method is pure virtual and
-  // has no default. 
-  virtual void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup) = 0;
+  // has no default.
+  virtual void runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) = 0;
 
   // This will allow making the HTTTopJetTagInfoCollection
-  virtual void addHTTTopJetTagInfoCollection( edm::Event& iEvent, 
-					      const edm::EventSetup& iSetup,
-					      edm::OrphanHandle<reco::BasicJetCollection> & oh){};
- 
-  // Do the offset correction. 
-  // Only runs if "doPUOffsetCorrection_" is true.  
-  void offsetCorrectJets(std::vector<fastjet::PseudoJet> & orphanInput);
+  virtual void addHTTTopJetTagInfoCollection(edm::Event& iEvent,
+                                             const edm::EventSetup& iSetup,
+                                             edm::OrphanHandle<reco::BasicJetCollection>& oh){};
 
-  // This will write the jets to the event. 
+  // Do the offset correction.
+  // Only runs if "doPUOffsetCorrection_" is true.
+  void offsetCorrectJets(std::vector<fastjet::PseudoJet>& orphanInput);
+
+  // This will write the jets to the event.
   // The default is to write out the single jet collection in the default "produces"
-  // statement. 
+  // statement.
   // This is a function template that can be called for the six types
-  // CaloJet, PFJet, GenJet, TrackJet, PFClusterJet, BasicJet. 
-  // This is not suitable for compound jets. 
+  // CaloJet, PFJet, GenJet, TrackJet, PFClusterJet, BasicJet.
+  // This is not suitable for compound jets.
   // Note: The "output" method is virtual and can be overriden.
-  // The default behavior is to call the function template "writeJets". 
-  virtual void output(  edm::Event & iEvent, edm::EventSetup const& iSetup );
-  template< typename T >
-  void writeJets( edm::Event & iEvent, edm::EventSetup const& iSetup );
-  
-  template< typename T>
-  void writeCompoundJets(  edm::Event & iEvent, edm::EventSetup const& iSetup);
+  // The default behavior is to call the function template "writeJets".
+  virtual void output(edm::Event& iEvent, edm::EventSetup const& iSetup);
+  template <typename T>
+  void writeJets(edm::Event& iEvent, edm::EventSetup const& iSetup);
 
-  template< typename T>
-    void writeJetsWithConstituents(  edm::Event & iEvent, edm::EventSetup const& iSetup);
+  template <typename T>
+  void writeCompoundJets(edm::Event& iEvent, edm::EventSetup const& iSetup);
+
+  template <typename T>
+  void writeJetsWithConstituents(edm::Event& iEvent, edm::EventSetup const& iSetup);
 
   // This method copies the constituents from the fjConstituents method
-  // to an output of CandidatePtr's. 
-  virtual std::vector<reco::CandidatePtr>
-    getConstituents(const std::vector<fastjet::PseudoJet>&fjConstituents);
-  
+  // to an output of CandidatePtr's.
+  virtual std::vector<reco::CandidatePtr> getConstituents(const std::vector<fastjet::PseudoJet>& fjConstituents);
+
   //
   // member data
   //
 protected:
-  std::string           moduleLabel_;               // label for this module
-  edm::InputTag         src_;                       // input constituent source
-  edm::InputTag         srcPVs_;                    // primary vertex source
-  std::string           jetType_;                   // type of jet (Calo,PF,Basic,Gen)
-  std::string           jetAlgorithm_;              // the jet algorithm to use
-  double                rParam_;                    // the R parameter to use
-  double                inputEtMin_;                // minimum et of input constituents
-  double                inputEMin_;                 // minimum e of input constituents
-  double                jetPtMin_;                  // minimum jet pt
-  bool                  doPVCorrection_;            // correct to primary vertex? 
+  std::string moduleLabel_;   // label for this module
+  edm::InputTag src_;         // input constituent source
+  edm::InputTag srcPVs_;      // primary vertex source
+  std::string jetType_;       // type of jet (Calo,PF,Basic,Gen)
+  std::string jetAlgorithm_;  // the jet algorithm to use
+  double rParam_;             // the R parameter to use
+  double inputEtMin_;         // minimum et of input constituents
+  double inputEMin_;          // minimum e of input constituents
+  double jetPtMin_;           // minimum jet pt
+  bool doPVCorrection_;       // correct to primary vertex?
 
   // for restricting inputs due to processing time
-  bool                  restrictInputs_;            // restrict inputs to first "maxInputs" inputs.
-  unsigned int          maxInputs_;                 // maximum number of inputs. 
+  bool restrictInputs_;     // restrict inputs to first "maxInputs" inputs.
+  unsigned int maxInputs_;  // maximum number of inputs.
 
   // for fastjet jet area calculation
-  bool                  doAreaFastjet_;             // calculate area w/ fastjet?
-  bool                  useExplicitGhosts_;         // use explicit ghosts in fastjet clustering sequence
-  bool                  doAreaDiskApprox_;          // calculate area w/ disk approximation (only makes sense for anti-KT)?
+  bool doAreaFastjet_;      // calculate area w/ fastjet?
+  bool useExplicitGhosts_;  // use explicit ghosts in fastjet clustering sequence
+  bool doAreaDiskApprox_;   // calculate area w/ disk approximation (only makes sense for anti-KT)?
   // for fastjet rho calculation
-  bool                  doRhoFastjet_;              // calculate rho w/ fastjet?
-  bool                  doFastJetNonUniform_;       // choice of eta-dependent PU calculation
-  double                voronoiRfact_;              // negative to calculate rho using active area (ghosts); otherwise calculates Voronoi area with this effective scale factor
+  bool doRhoFastjet_;         // calculate rho w/ fastjet?
+  bool doFastJetNonUniform_;  // choice of eta-dependent PU calculation
+  double
+      voronoiRfact_;  // negative to calculate rho using active area (ghosts); otherwise calculates Voronoi area with this effective scale factor
 
-  double                rhoEtaMax_;                 // Eta range of jets to be considered for Rho calculation; Should be at most (jet acceptance - jet radius)
-  double                ghostEtaMax_;               // default Ghost_EtaMax should be 5
-  int                   activeAreaRepeats_;         // default Active_Area_Repeats 1
-  double                ghostArea_;                 // default GhostArea 0.01
+  double
+      rhoEtaMax_;  // Eta range of jets to be considered for Rho calculation; Should be at most (jet acceptance - jet radius)
+  double ghostEtaMax_;     // default Ghost_EtaMax should be 5
+  int activeAreaRepeats_;  // default Active_Area_Repeats 1
+  double ghostArea_;       // default GhostArea 0.01
 
   // for pileup offset correction
-  bool                  doPUOffsetCorr_;            // add the pileup calculation from offset correction? 
-  std::string           puSubtractorName_;
+  bool doPUOffsetCorr_;  // add the pileup calculation from offset correction?
+  std::string puSubtractorName_;
 
-  std::vector<edm::Ptr<reco::Candidate> > inputs_;  // input candidates [View, PtrVector and CandCollection have limitations]
-  reco::Particle::Point           vertex_;          // Primary vertex 
-  ClusterSequencePtr              fjClusterSeq_;    // fastjet cluster sequence
-  JetDefPtr                       fjJetDefinition_; // fastjet jet definition
-  PluginPtr                       fjPlugin_;        // fastjet plugin
-  ActiveAreaSpecPtr               fjActiveArea_;    // fastjet active area definition
-  AreaDefinitionPtr               fjAreaDefinition_;// fastjet area definition
-  SelectorPtr                     fjSelector_;      // selector for range definition
-  std::vector<fastjet::PseudoJet> fjInputs_;        // fastjet inputs
-  std::vector<fastjet::PseudoJet> fjJets_;          // fastjet jets
+  std::vector<edm::Ptr<reco::Candidate> >
+      inputs_;                                // input candidates [View, PtrVector and CandCollection have limitations]
+  reco::Particle::Point vertex_;              // Primary vertex
+  ClusterSequencePtr fjClusterSeq_;           // fastjet cluster sequence
+  JetDefPtr fjJetDefinition_;                 // fastjet jet definition
+  PluginPtr fjPlugin_;                        // fastjet plugin
+  ActiveAreaSpecPtr fjActiveArea_;            // fastjet active area definition
+  AreaDefinitionPtr fjAreaDefinition_;        // fastjet area definition
+  SelectorPtr fjSelector_;                    // selector for range definition
+  std::vector<fastjet::PseudoJet> fjInputs_;  // fastjet inputs
+  std::vector<fastjet::PseudoJet> fjJets_;    // fastjet jets
 
   // Parameters of the eta-dependent rho calculation
-  std::vector<double>             puCenters_;
-  double                          puWidth_;
-  unsigned int                    nExclude_;
+  std::vector<double> puCenters_;
+  double puWidth_;
+  unsigned int nExclude_;
 
-  std::string                     jetCollInstanceName_;       // instance name for output jet collection
-  bool                            writeCompound_;    // write compound jets (i.e. jets of jets)
-  bool                            writeJetsWithConst_;    // write jets with constituents
-  boost::shared_ptr<PileUpSubtractor>  subtractor_;
+  std::string jetCollInstanceName_;  // instance name for output jet collection
+  bool writeCompound_;               // write compound jets (i.e. jets of jets)
+  bool writeJetsWithConst_;          // write jets with constituents
+  boost::shared_ptr<PileUpSubtractor> subtractor_;
 
-  bool                            useDeterministicSeed_; // If desired, use a deterministic seed to fastjet
-  unsigned int                    minSeed_;              // minimum seed to use, useful for MC generation
+  bool useDeterministicSeed_;  // If desired, use a deterministic seed to fastjet
+  unsigned int minSeed_;       // minimum seed to use, useful for MC generation
 
-  int                   verbosity_;                 // flag to enable/disable debug output
-  bool                  fromHTTTopJetProducer_ = false;   // for running the v2.0 HEPTopTagger
+  int verbosity_;                       // flag to enable/disable debug output
+  bool fromHTTTopJetProducer_ = false;  // for running the v2.0 HEPTopTagger
 
 private:
-  std::unique_ptr<AnomalousTower>   anomalousTowerDef_;  // anomalous tower definition
+  std::unique_ptr<AnomalousTower> anomalousTowerDef_;  // anomalous tower definition
 
   // tokens for the data access
   edm::EDGetTokenT<reco::CandidateView> input_candidateview_token_;
@@ -232,14 +217,9 @@ private:
   edm::EDGetTokenT<std::vector<edm::FwdPtr<pat::PackedCandidate> > > input_packedcandidatefwdptr_token_;
   edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::GenParticle> > > input_gencandidatefwdptr_token_;
   edm::EDGetTokenT<std::vector<edm::FwdPtr<pat::PackedGenParticle> > > input_packedgencandidatefwdptr_token_;
-  
- protected:
+
+protected:
   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;
-  
 };
-
-
-
-
 
 #endif

--- a/RecoJets/JetProducers/src/AnomalousTower.cc
+++ b/RecoJets/JetProducers/src/AnomalousTower.cc
@@ -2,7 +2,7 @@
 #include "RecoJets/JetProducers/interface/AnomalousTower.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
 
-#define init_param(type, varname) varname (ps.getParameter< type >( #varname ))
+#define init_param(type, varname) varname(ps.getParameter<type>(#varname))
 
 AnomalousTower::AnomalousTower(const edm::ParameterSet& ps)
     : init_param(unsigned, maxBadEcalCells),
@@ -10,20 +10,15 @@ AnomalousTower::AnomalousTower(const edm::ParameterSet& ps)
       init_param(unsigned, maxProblematicEcalCells),
       init_param(unsigned, maxBadHcalCells),
       init_param(unsigned, maxRecoveredHcalCells),
-      init_param(unsigned, maxProblematicHcalCells)
-{
-}
+      init_param(unsigned, maxProblematicHcalCells) {}
 
-bool AnomalousTower::operator()(const reco::Candidate& input) const
-{
-    const CaloTower* tower = dynamic_cast<const CaloTower*>(&input);
-    if (tower)
-        return tower->numBadEcalCells()         > maxBadEcalCells         ||
-               tower->numRecoveredEcalCells()   > maxRecoveredEcalCells   ||
-               tower->numProblematicEcalCells() > maxProblematicEcalCells ||
-               tower->numBadHcalCells()         > maxBadHcalCells         ||
-               tower->numRecoveredHcalCells()   > maxRecoveredHcalCells   ||
-               tower->numProblematicHcalCells() > maxProblematicHcalCells;
-    else
-        return false;
+bool AnomalousTower::operator()(const reco::Candidate& input) const {
+  const CaloTower* tower = dynamic_cast<const CaloTower*>(&input);
+  if (tower)
+    return tower->numBadEcalCells() > maxBadEcalCells || tower->numRecoveredEcalCells() > maxRecoveredEcalCells ||
+           tower->numProblematicEcalCells() > maxProblematicEcalCells || tower->numBadHcalCells() > maxBadHcalCells ||
+           tower->numRecoveredHcalCells() > maxRecoveredHcalCells ||
+           tower->numProblematicHcalCells() > maxProblematicHcalCells;
+  else
+    return false;
 }

--- a/RecoJets/JetProducers/src/CastorJetIDHelper.cc
+++ b/RecoJets/JetProducers/src/CastorJetIDHelper.cc
@@ -10,82 +10,76 @@
 #include <numeric>
 #include <iostream>
 
+reco::helper::CastorJetIDHelper::CastorJetIDHelper() { initValues(); }
 
-reco::helper::CastorJetIDHelper::CastorJetIDHelper()
-{
- 
-  initValues();
-}
-  
-void reco::helper::CastorJetIDHelper::initValues()
-{
-      emEnergy_ = 0.0;
-      hadEnergy_ = 0.0; 
-      fem_ = 0.0;
-      width_ = 0.0;
-      depth_ = 0.0;
-      fhot_ = 0.0;
-      sigmaz_ = 0.0;
-      nTowers_ = 0;
+void reco::helper::CastorJetIDHelper::initValues() {
+  emEnergy_ = 0.0;
+  hadEnergy_ = 0.0;
+  fem_ = 0.0;
+  width_ = 0.0;
+  depth_ = 0.0;
+  fhot_ = 0.0;
+  sigmaz_ = 0.0;
+  nTowers_ = 0;
 }
 
-
-void reco::helper::CastorJetIDHelper::calculate( const edm::Event& event, const reco::BasicJet &jet )
-{
+void reco::helper::CastorJetIDHelper::calculate(const edm::Event& event, const reco::BasicJet& jet) {
   initValues();
-  
+
   // calculate Castor JetID properties
- 
-		double zmean = 0.;
-		double z2mean = 0.;
-	
-		std::vector<CandidatePtr> ccp = jet.getJetConstituents();
-		std::vector<CandidatePtr>::const_iterator itParticle;
-   		for (itParticle=ccp.begin();itParticle!=ccp.end();++itParticle){	    
-        		const CastorTower* castorcand = dynamic_cast<const CastorTower*>(itParticle->get());
-			emEnergy_ += castorcand->emEnergy();
-			hadEnergy_ += castorcand->hadEnergy();
-			depth_ += castorcand->depth()*castorcand->energy();
-			width_ += pow(phiangle(castorcand->phi() - jet.phi()),2)*castorcand->energy();
-      			fhot_ += castorcand->fhot()*castorcand->energy();
-			
-			// loop over rechits
-      			for (edm::RefVector<edm::SortedCollection<CastorRecHit> >::iterator it = castorcand->rechitsBegin(); it != castorcand->rechitsEnd(); it++) {
-	                         edm::Ref<edm::SortedCollection<CastorRecHit> > rechit_p = *it;	                        
-	                         double Erechit = rechit_p->energy();
-	                         HcalCastorDetId id = rechit_p->id();
-	                         int module = id.module();	                                
-                                 double zrechit = 0;	 
-                                 if (module < 3) zrechit = -14390 - 24.75 - 49.5*(module-1);	 
-                                 if (module > 2) zrechit = -14390 - 99 - 49.5 - 99*(module-3);	 
-                                 zmean += Erechit*zrechit;	 
-                                 z2mean += Erechit*zrechit*zrechit;
-      			} // end loop over rechits
-			
-			nTowers_++;
-		}
-		//cout << "" << endl;
-		
-		depth_ = depth_/jet.energy();
-		width_ = sqrt(width_/jet.energy());
-		fhot_ = fhot_/jet.energy();
-		fem_ = emEnergy_/jet.energy();
-		
-		zmean = zmean/jet.energy();
-    		z2mean = z2mean/jet.energy();
-    		double sigmaz2 = z2mean - zmean*zmean;
-    		if(sigmaz2 > 0) sigmaz_ = sqrt(sigmaz2);
 
-  
+  double zmean = 0.;
+  double z2mean = 0.;
+
+  std::vector<CandidatePtr> ccp = jet.getJetConstituents();
+  std::vector<CandidatePtr>::const_iterator itParticle;
+  for (itParticle = ccp.begin(); itParticle != ccp.end(); ++itParticle) {
+    const CastorTower* castorcand = dynamic_cast<const CastorTower*>(itParticle->get());
+    emEnergy_ += castorcand->emEnergy();
+    hadEnergy_ += castorcand->hadEnergy();
+    depth_ += castorcand->depth() * castorcand->energy();
+    width_ += pow(phiangle(castorcand->phi() - jet.phi()), 2) * castorcand->energy();
+    fhot_ += castorcand->fhot() * castorcand->energy();
+
+    // loop over rechits
+    for (edm::RefVector<edm::SortedCollection<CastorRecHit> >::iterator it = castorcand->rechitsBegin();
+         it != castorcand->rechitsEnd();
+         it++) {
+      edm::Ref<edm::SortedCollection<CastorRecHit> > rechit_p = *it;
+      double Erechit = rechit_p->energy();
+      HcalCastorDetId id = rechit_p->id();
+      int module = id.module();
+      double zrechit = 0;
+      if (module < 3)
+        zrechit = -14390 - 24.75 - 49.5 * (module - 1);
+      if (module > 2)
+        zrechit = -14390 - 99 - 49.5 - 99 * (module - 3);
+      zmean += Erechit * zrechit;
+      z2mean += Erechit * zrechit * zrechit;
+    }  // end loop over rechits
+
+    nTowers_++;
+  }
+  //cout << "" << endl;
+
+  depth_ = depth_ / jet.energy();
+  width_ = sqrt(width_ / jet.energy());
+  fhot_ = fhot_ / jet.energy();
+  fem_ = emEnergy_ / jet.energy();
+
+  zmean = zmean / jet.energy();
+  z2mean = z2mean / jet.energy();
+  double sigmaz2 = z2mean - zmean * zmean;
+  if (sigmaz2 > 0)
+    sigmaz_ = sqrt(sigmaz2);
 }
 
 // help function to calculate phi within [-pi,+pi]
-double reco::helper::CastorJetIDHelper::phiangle (double testphi) {
+double reco::helper::CastorJetIDHelper::phiangle(double testphi) {
   double phi = testphi;
-  while (phi>M_PI) phi -= (2*M_PI);
-  while (phi<-M_PI) phi += (2*M_PI);
+  while (phi > M_PI)
+    phi -= (2 * M_PI);
+  while (phi < -M_PI)
+    phi += (2 * M_PI);
   return phi;
 }
-
-
-

--- a/RecoJets/JetProducers/src/JetIDHelper.cc
+++ b/RecoJets/JetProducers/src/JetIDHelper.cc
@@ -9,10 +9,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-
 #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
-// JetIDHelper needs a much more detailed description that the one in HcalTopology, 
+// JetIDHelper needs a much more detailed description that the one in HcalTopology,
 // so to be consistent, all needed constants are hardwired in JetIDHelper.cc itself
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
@@ -31,49 +30,44 @@ namespace reco {
 
     // select2nd exists only in some std and boost implementations, so let's control our own fate
     // and it can't be a non-static member function.
-    static double select2nd (std::map<int,double>::value_type const &pair) {return pair.second;}
-    
-    bool hasNonPositiveE( reco::helper::JetIDHelper::subtower x ) {
-      return x.E <= 0;
-    }
-    
-    bool subtower_has_greater_E( reco::helper::JetIDHelper::subtower i, 
-				 reco::helper::JetIDHelper::subtower j ) { return i.E > j.E; }
-    std::atomic<int> JetIDHelper::sanity_checks_left_{100};
-  }
-}
+    static double select2nd(std::map<int, double>::value_type const &pair) { return pair.second; }
 
-reco::helper::JetIDHelper::JetIDHelper( edm::ParameterSet const & pset, edm::ConsumesCollector&& iC )
-{
+    bool hasNonPositiveE(reco::helper::JetIDHelper::subtower x) { return x.E <= 0; }
+
+    bool subtower_has_greater_E(reco::helper::JetIDHelper::subtower i, reco::helper::JetIDHelper::subtower j) {
+      return i.E > j.E;
+    }
+    std::atomic<int> JetIDHelper::sanity_checks_left_{100};
+  }  // namespace helper
+}  // namespace reco
+
+reco::helper::JetIDHelper::JetIDHelper(edm::ParameterSet const &pset, edm::ConsumesCollector &&iC) {
   useRecHits_ = pset.getParameter<bool>("useRecHits");
-  if( useRecHits_ ) {
+  if (useRecHits_) {
     hbheRecHitsColl_ = pset.getParameter<edm::InputTag>("hbheRecHitsColl");
-    hoRecHitsColl_   = pset.getParameter<edm::InputTag>("hoRecHitsColl");
-    hfRecHitsColl_   = pset.getParameter<edm::InputTag>("hfRecHitsColl");
-    ebRecHitsColl_   = pset.getParameter<edm::InputTag>("ebRecHitsColl");
-    eeRecHitsColl_   = pset.getParameter<edm::InputTag>("eeRecHitsColl");   
+    hoRecHitsColl_ = pset.getParameter<edm::InputTag>("hoRecHitsColl");
+    hfRecHitsColl_ = pset.getParameter<edm::InputTag>("hfRecHitsColl");
+    ebRecHitsColl_ = pset.getParameter<edm::InputTag>("ebRecHitsColl");
+    eeRecHitsColl_ = pset.getParameter<edm::InputTag>("eeRecHitsColl");
   }
   initValues();
 
-  input_HBHERecHits_token_ = iC.consumes<HBHERecHitCollection>(hbheRecHitsColl_); 
-  input_HORecHits_token_ = iC.consumes<HORecHitCollection>(hoRecHitsColl_);   
-  input_HFRecHits_token_ = iC.consumes<HFRecHitCollection>(hfRecHitsColl_);   
-  input_EBRecHits_token_ = iC.consumes<EBRecHitCollection>(ebRecHitsColl_);   
-  input_EERecHits_token_ = iC.consumes<EERecHitCollection>(eeRecHitsColl_);   
-
-
+  input_HBHERecHits_token_ = iC.consumes<HBHERecHitCollection>(hbheRecHitsColl_);
+  input_HORecHits_token_ = iC.consumes<HORecHitCollection>(hoRecHitsColl_);
+  input_HFRecHits_token_ = iC.consumes<HFRecHitCollection>(hfRecHitsColl_);
+  input_EBRecHits_token_ = iC.consumes<EBRecHitCollection>(ebRecHitsColl_);
+  input_EERecHits_token_ = iC.consumes<EERecHitCollection>(eeRecHitsColl_);
 }
-  
-void reco::helper::JetIDHelper::initValues()
-{
-  fHPD_= -1.0;
-  fRBX_= -1.0;
+
+void reco::helper::JetIDHelper::initValues() {
+  fHPD_ = -1.0;
+  fRBX_ = -1.0;
   n90Hits_ = -1;
-  fSubDetector1_= -1.0;
-  fSubDetector2_= -1.0;
-  fSubDetector3_= -1.0;
-  fSubDetector4_= -1.0;
-  restrictedEMF_= -1.0;
+  fSubDetector1_ = -1.0;
+  fSubDetector2_ = -1.0;
+  fSubDetector3_ = -1.0;
+  fSubDetector4_ = -1.0;
+  restrictedEMF_ = -1.0;
   nHCALTowers_ = -1;
   nECALTowers_ = -1;
   approximatefHPD_ = -1.0;
@@ -83,38 +77,38 @@ void reco::helper::JetIDHelper::initValues()
   fLS_ = fHFOOT_ = -1.0;
 }
 
-void reco::helper::JetIDHelper::fillDescription(edm::ParameterSetDescription& iDesc)
-{
-  iDesc.ifValue( edm::ParameterDescription<bool>("useRecHits", true, true),
-		 true >> (edm::ParameterDescription<edm::InputTag>("hbheRecHitsColl", edm::InputTag(), true) and
-			  edm::ParameterDescription<edm::InputTag>("hoRecHitsColl", edm::InputTag(), true) and
-			  edm::ParameterDescription<edm::InputTag>("hfRecHitsColl", edm::InputTag(), true) and
-			  edm::ParameterDescription<edm::InputTag>("ebRecHitsColl", edm::InputTag(), true) and
-			  edm::ParameterDescription<edm::InputTag>("eeRecHitsColl", edm::InputTag(), true)
-			  ) 
-                 )->setComment("If using RecHits to calculate the precise jet ID variables that need them, "
-			       "their sources need to be specified");
+void reco::helper::JetIDHelper::fillDescription(edm::ParameterSetDescription &iDesc) {
+  iDesc
+      .ifValue(edm::ParameterDescription<bool>("useRecHits", true, true),
+               true >> (edm::ParameterDescription<edm::InputTag>("hbheRecHitsColl", edm::InputTag(), true) and
+                        edm::ParameterDescription<edm::InputTag>("hoRecHitsColl", edm::InputTag(), true) and
+                        edm::ParameterDescription<edm::InputTag>("hfRecHitsColl", edm::InputTag(), true) and
+                        edm::ParameterDescription<edm::InputTag>("ebRecHitsColl", edm::InputTag(), true) and
+                        edm::ParameterDescription<edm::InputTag>("eeRecHitsColl", edm::InputTag(), true)))
+      ->setComment(
+          "If using RecHits to calculate the precise jet ID variables that need them, "
+          "their sources need to be specified");
 }
 
-
-void reco::helper::JetIDHelper::calculate( const edm::Event& event, const edm::EventSetup& setup, const reco::CaloJet &jet, const int iDbg )
-{
+void reco::helper::JetIDHelper::calculate(const edm::Event &event,
+                                          const edm::EventSetup &setup,
+                                          const reco::CaloJet &jet,
+                                          const int iDbg) {
   initValues();
 
   // --------------------------------------------------
   // 1) jet ID variable derived from existing fractions
   // --------------------------------------------------
 
-  double E_EM = TMath::Max( float(0.), jet.emEnergyInHF() )
-              + TMath::Max( float(0.), jet.emEnergyInEB() )
-              + TMath::Max( float(0.), jet.emEnergyInEE() );
-  double E_Had = TMath::Max( float(0.), jet.hadEnergyInHB() )
-               + TMath::Max( float(0.), jet.hadEnergyInHE() )
-               + TMath::Max( float(0.), jet.hadEnergyInHO() )
-               + TMath::Max( float(0.), jet.hadEnergyInHF() );
-  if( E_Had + E_EM > 0 ) restrictedEMF_ = E_EM / ( E_EM + E_Had );
-  if( iDbg > 1 ) cout<<"jet pT: "<<jet.pt()<<", eT: "<<jet.et()<<", E: "
-		     <<jet.energy()<<" rEMF: "<<restrictedEMF_<<endl;
+  double E_EM = TMath::Max(float(0.), jet.emEnergyInHF()) + TMath::Max(float(0.), jet.emEnergyInEB()) +
+                TMath::Max(float(0.), jet.emEnergyInEE());
+  double E_Had = TMath::Max(float(0.), jet.hadEnergyInHB()) + TMath::Max(float(0.), jet.hadEnergyInHE()) +
+                 TMath::Max(float(0.), jet.hadEnergyInHO()) + TMath::Max(float(0.), jet.hadEnergyInHF());
+  if (E_Had + E_EM > 0)
+    restrictedEMF_ = E_EM / (E_EM + E_Had);
+  if (iDbg > 1)
+    cout << "jet pT: " << jet.pt() << ", eT: " << jet.et() << ", E: " << jet.energy() << " rEMF: " << restrictedEMF_
+         << endl;
 
   // ------------------------
   // 2) tower based variables
@@ -122,299 +116,341 @@ void reco::helper::JetIDHelper::calculate( const edm::Event& event, const edm::E
   vector<subtower> subtowers, Ecal_subtowers, Hcal_subtowers, HO_subtowers;
   vector<double> HPD_energies, RBX_energies;
 
-  classifyJetTowers( event, jet, 
-		     subtowers, Ecal_subtowers, Hcal_subtowers, HO_subtowers, 
-		     HPD_energies, RBX_energies, iDbg );
-  if( iDbg > 1 ) {
-    cout<<"E:";
-    for (unsigned int i=0; i<subtowers.size(); ++i) cout<<" "<<subtowers[i].E<<","<<subtowers[i].Nhit;
-    cout<<"\nECal_E:";
-    for (unsigned int i=0; i<Ecal_subtowers.size(); ++i) cout<<" "<<Ecal_subtowers[i].E<<","<<Ecal_subtowers[i].Nhit;
-    cout<<"\nHCal_E:";
-    for (unsigned int i=0; i<Hcal_subtowers.size(); ++i) cout<<" "<<Hcal_subtowers[i].E<<","<<Hcal_subtowers[i].Nhit;
-    cout<<"\nHO_E:";
-    for (unsigned int i=0; i<HO_subtowers.size(); ++i) cout<<" "<<HO_subtowers[i].E<<","<<HO_subtowers[i].Nhit;
-    cout<<"\nHPD_E:";
-    for (unsigned int i=0; i<HPD_energies.size(); ++i) cout<<" "<<HPD_energies[i];
-    cout<<"\nRBX_E:";
-    for (unsigned int i=0; i<RBX_energies.size(); ++i) cout<<" "<<RBX_energies[i];
-    cout<<endl;
+  classifyJetTowers(
+      event, jet, subtowers, Ecal_subtowers, Hcal_subtowers, HO_subtowers, HPD_energies, RBX_energies, iDbg);
+  if (iDbg > 1) {
+    cout << "E:";
+    for (unsigned int i = 0; i < subtowers.size(); ++i)
+      cout << " " << subtowers[i].E << "," << subtowers[i].Nhit;
+    cout << "\nECal_E:";
+    for (unsigned int i = 0; i < Ecal_subtowers.size(); ++i)
+      cout << " " << Ecal_subtowers[i].E << "," << Ecal_subtowers[i].Nhit;
+    cout << "\nHCal_E:";
+    for (unsigned int i = 0; i < Hcal_subtowers.size(); ++i)
+      cout << " " << Hcal_subtowers[i].E << "," << Hcal_subtowers[i].Nhit;
+    cout << "\nHO_E:";
+    for (unsigned int i = 0; i < HO_subtowers.size(); ++i)
+      cout << " " << HO_subtowers[i].E << "," << HO_subtowers[i].Nhit;
+    cout << "\nHPD_E:";
+    for (unsigned int i = 0; i < HPD_energies.size(); ++i)
+      cout << " " << HPD_energies[i];
+    cout << "\nRBX_E:";
+    for (unsigned int i = 0; i < RBX_energies.size(); ++i)
+      cout << " " << RBX_energies[i];
+    cout << endl;
   }
 
   // counts
-  hitsInN90_ = hitsInNCarrying( 0.9, subtowers );
+  hitsInN90_ = hitsInNCarrying(0.9, subtowers);
   nHCALTowers_ = Hcal_subtowers.size();
   vector<subtower>::const_iterator it;
-  it = find_if( Ecal_subtowers.begin(), Ecal_subtowers.end(), hasNonPositiveE );
-  nECALTowers_ = it - Ecal_subtowers.begin(); // ignores negative energies from HF!
+  it = find_if(Ecal_subtowers.begin(), Ecal_subtowers.end(), hasNonPositiveE);
+  nECALTowers_ = it - Ecal_subtowers.begin();  // ignores negative energies from HF!
 
   // energy fractions
   double max_HPD_energy = 0., max_RBX_energy = 0.;
-  std::vector<double>::const_iterator it_max_HPD_energy = std::max_element( HPD_energies.begin(), HPD_energies.end() );
-  std::vector<double>::const_iterator it_max_RBX_energy = std::max_element( RBX_energies.begin(), RBX_energies.end() );
-  if ( it_max_HPD_energy != HPD_energies.end() ) {
+  std::vector<double>::const_iterator it_max_HPD_energy = std::max_element(HPD_energies.begin(), HPD_energies.end());
+  std::vector<double>::const_iterator it_max_RBX_energy = std::max_element(RBX_energies.begin(), RBX_energies.end());
+  if (it_max_HPD_energy != HPD_energies.end()) {
     max_HPD_energy = *it_max_HPD_energy;
   }
-  if ( it_max_RBX_energy != RBX_energies.end() ) {
+  if (it_max_RBX_energy != RBX_energies.end()) {
     max_RBX_energy = *it_max_RBX_energy;
   }
-  if( jet.energy() > 0 ) {
-    if( !HPD_energies.empty() ) approximatefHPD_ = max_HPD_energy / jet.energy();
-    if( !RBX_energies.empty() ) approximatefRBX_ = max_HPD_energy / jet.energy();
+  if (jet.energy() > 0) {
+    if (!HPD_energies.empty())
+      approximatefHPD_ = max_HPD_energy / jet.energy();
+    if (!RBX_energies.empty())
+      approximatefRBX_ = max_HPD_energy / jet.energy();
   }
 
   // -----------------------
   // 3) cell based variables
   // -----------------------
-  if( useRecHits_ ) {
+  if (useRecHits_) {
     vector<double> energies, subdet_energies, Ecal_energies, Hcal_energies, HO_energies;
     double LS_bad_energy, HF_OOT_energy;
-    classifyJetComponents( event, setup, jet, 
-			   energies, subdet_energies, Ecal_energies, Hcal_energies, HO_energies, 
-			   HPD_energies, RBX_energies, LS_bad_energy, HF_OOT_energy, iDbg );
+    classifyJetComponents(event,
+                          setup,
+                          jet,
+                          energies,
+                          subdet_energies,
+                          Ecal_energies,
+                          Hcal_energies,
+                          HO_energies,
+                          HPD_energies,
+                          RBX_energies,
+                          LS_bad_energy,
+                          HF_OOT_energy,
+                          iDbg);
 
     // counts
-    n90Hits_ = nCarrying( 0.9, energies );
+    n90Hits_ = nCarrying(0.9, energies);
 
     // energy fractions
-    if( jet.energy() > 0 ) {
-      if( !HPD_energies.empty() ) fHPD_ = max_HPD_energy / jet.energy();
-      if( !RBX_energies.empty() ) fRBX_ = max_RBX_energy / jet.energy();
-      if( !subdet_energies.empty() ) fSubDetector1_ = subdet_energies.at( 0 ) / jet.energy();
-      if( subdet_energies.size() > 1 ) fSubDetector2_ = subdet_energies.at( 1 ) / jet.energy();
-      if( subdet_energies.size() > 2 ) fSubDetector3_ = subdet_energies.at( 2 ) / jet.energy();
-      if( subdet_energies.size() > 3 ) fSubDetector4_ = subdet_energies.at( 3 ) / jet.energy();
+    if (jet.energy() > 0) {
+      if (!HPD_energies.empty())
+        fHPD_ = max_HPD_energy / jet.energy();
+      if (!RBX_energies.empty())
+        fRBX_ = max_RBX_energy / jet.energy();
+      if (!subdet_energies.empty())
+        fSubDetector1_ = subdet_energies.at(0) / jet.energy();
+      if (subdet_energies.size() > 1)
+        fSubDetector2_ = subdet_energies.at(1) / jet.energy();
+      if (subdet_energies.size() > 2)
+        fSubDetector3_ = subdet_energies.at(2) / jet.energy();
+      if (subdet_energies.size() > 3)
+        fSubDetector4_ = subdet_energies.at(3) / jet.energy();
       fLS_ = LS_bad_energy / jet.energy();
       fHFOOT_ = HF_OOT_energy / jet.energy();
 
-      if( iDbg > 0 && sanity_checks_left_.load(std::memory_order_acquire) > 0 ) {
-	--sanity_checks_left_;
-	double EH_sum = accumulate( Ecal_energies.begin(), Ecal_energies.end(), 0. );
-	EH_sum = accumulate( Hcal_energies.begin(), Hcal_energies.end(), EH_sum );
-	double EHO_sum = accumulate( HO_energies.begin(), HO_energies.end(), EH_sum );
-	if( jet.energy() > 0.001 && abs( EH_sum/jet.energy() - 1 ) > 0.01 && abs( EHO_sum/jet.energy() - 1 ) > 0.01 )
-	  edm::LogWarning("BadInput")<<"Jet energy ("<<jet.energy()
-				     <<") does not match the total energy in the recHits ("<<EHO_sum
-				     <<", or without HO: "<<EH_sum<<") . Are these the right recHits? "
-				     <<"Were jet energy corrections mistakenly applied before jet ID? A bug?";
-	if( iDbg > 1 ) cout<<"Sanity check - E: "<<jet.energy()<<" =? EH_sum: "<<EH_sum<<" / EHO_sum: "<<EHO_sum<<endl;
+      if (iDbg > 0 && sanity_checks_left_.load(std::memory_order_acquire) > 0) {
+        --sanity_checks_left_;
+        double EH_sum = accumulate(Ecal_energies.begin(), Ecal_energies.end(), 0.);
+        EH_sum = accumulate(Hcal_energies.begin(), Hcal_energies.end(), EH_sum);
+        double EHO_sum = accumulate(HO_energies.begin(), HO_energies.end(), EH_sum);
+        if (jet.energy() > 0.001 && abs(EH_sum / jet.energy() - 1) > 0.01 && abs(EHO_sum / jet.energy() - 1) > 0.01)
+          edm::LogWarning("BadInput") << "Jet energy (" << jet.energy()
+                                      << ") does not match the total energy in the recHits (" << EHO_sum
+                                      << ", or without HO: " << EH_sum << ") . Are these the right recHits? "
+                                      << "Were jet energy corrections mistakenly applied before jet ID? A bug?";
+        if (iDbg > 1)
+          cout << "Sanity check - E: " << jet.energy() << " =? EH_sum: " << EH_sum << " / EHO_sum: " << EHO_sum << endl;
       }
     }
 
-    if( iDbg > 1 ) {
-      cout<<"DBG - fHPD: "<<fHPD_<<", fRBX: "<<fRBX_<<", nh90: "<<n90Hits_<<", fLS: "<<fLS_<<", fHFOOT: "<<fHFOOT_<<endl;
-      cout<<"    -~fHPD: "<<approximatefHPD_<<", ~fRBX: "<<approximatefRBX_
-	  <<", hits in n90: "<<hitsInN90_<<endl;
-      cout<<"    - nHCALTowers: "<<nHCALTowers_<<", nECALTowers: "<<nECALTowers_
-	  <<"; subdet fractions: "<<fSubDetector1_<<", "<<fSubDetector2_<<", "<<fSubDetector3_<<", "<<fSubDetector4_<<endl;
+    if (iDbg > 1) {
+      cout << "DBG - fHPD: " << fHPD_ << ", fRBX: " << fRBX_ << ", nh90: " << n90Hits_ << ", fLS: " << fLS_
+           << ", fHFOOT: " << fHFOOT_ << endl;
+      cout << "    -~fHPD: " << approximatefHPD_ << ", ~fRBX: " << approximatefRBX_ << ", hits in n90: " << hitsInN90_
+           << endl;
+      cout << "    - nHCALTowers: " << nHCALTowers_ << ", nECALTowers: " << nECALTowers_
+           << "; subdet fractions: " << fSubDetector1_ << ", " << fSubDetector2_ << ", " << fSubDetector3_ << ", "
+           << fSubDetector4_ << endl;
     }
   }
 }
 
-
-unsigned int reco::helper::JetIDHelper::nCarrying( double fraction, const std::vector< double >& descending_energies )
-{
+unsigned int reco::helper::JetIDHelper::nCarrying(double fraction, const std::vector<double> &descending_energies) {
   double totalE = 0;
-  for( unsigned int i = 0; i < descending_energies.size(); ++i ) totalE += descending_energies[ i ];
+  for (unsigned int i = 0; i < descending_energies.size(); ++i)
+    totalE += descending_energies[i];
 
   double runningE = 0;
   unsigned int NC = descending_energies.size();
-  
+
   // slightly odd loop structure avoids round-off problems when runningE never catches up with totalE
-  for( unsigned int i = descending_energies.size(); i > 0; --i ) {
-    runningE += descending_energies[ i-1 ];
-    if (runningE < ( 1-fraction ) * totalE) NC = i-1;
+  for (unsigned int i = descending_energies.size(); i > 0; --i) {
+    runningE += descending_energies[i - 1];
+    if (runningE < (1 - fraction) * totalE)
+      NC = i - 1;
   }
   return NC;
 }
 
-
-unsigned int reco::helper::JetIDHelper::hitsInNCarrying( double fraction, const std::vector< subtower >& descending_towers )
-{
+unsigned int reco::helper::JetIDHelper::hitsInNCarrying(double fraction,
+                                                        const std::vector<subtower> &descending_towers) {
   double totalE = 0;
-  for( unsigned int i = 0; i < descending_towers.size(); ++i ) totalE += descending_towers[ i ].E;
+  for (unsigned int i = 0; i < descending_towers.size(); ++i)
+    totalE += descending_towers[i].E;
 
   double runningE = 0;
   unsigned int NH = 0;
-  
+
   // slightly odd loop structure avoids round-off problems when runningE never catches up with totalE
-  for( unsigned int i = descending_towers.size(); i > 0; --i ) {
-    runningE += descending_towers[ i-1 ].E;
-    if (runningE >= ( 1-fraction ) * totalE) NH += descending_towers[ i-1 ].Nhit;
+  for (unsigned int i = descending_towers.size(); i > 0; --i) {
+    runningE += descending_towers[i - 1].E;
+    if (runningE >= (1 - fraction) * totalE)
+      NH += descending_towers[i - 1].Nhit;
   }
   return NH;
 }
 
-void reco::helper::JetIDHelper::classifyJetComponents( const edm::Event& event, const edm::EventSetup& setup,
-						       const reco::CaloJet &jet, 
-						       vector< double > &energies,      
-						       vector< double > &subdet_energies,      
-						       vector< double > &Ecal_energies, 
-						       vector< double > &Hcal_energies, 
-						       vector< double > &HO_energies,
-						       vector< double > &HPD_energies,  
-						       vector< double > &RBX_energies,
-						       double& LS_bad_energy, double& HF_OOT_energy, const int iDbg )
-{
-  energies.clear(); subdet_energies.clear(); Ecal_energies.clear(); Hcal_energies.clear(); HO_energies.clear();
-  HPD_energies.clear(); RBX_energies.clear();
+void reco::helper::JetIDHelper::classifyJetComponents(const edm::Event &event,
+                                                      const edm::EventSetup &setup,
+                                                      const reco::CaloJet &jet,
+                                                      vector<double> &energies,
+                                                      vector<double> &subdet_energies,
+                                                      vector<double> &Ecal_energies,
+                                                      vector<double> &Hcal_energies,
+                                                      vector<double> &HO_energies,
+                                                      vector<double> &HPD_energies,
+                                                      vector<double> &RBX_energies,
+                                                      double &LS_bad_energy,
+                                                      double &HF_OOT_energy,
+                                                      const int iDbg) {
+  energies.clear();
+  subdet_energies.clear();
+  Ecal_energies.clear();
+  Hcal_energies.clear();
+  HO_energies.clear();
+  HPD_energies.clear();
+  RBX_energies.clear();
   LS_bad_energy = HF_OOT_energy = 0.;
-  
-  edm::ESHandle<HcalTopology> theHcalTopology;
-  setup.get<HcalRecNumberingRecord>().get( theHcalTopology );
 
-  std::map< int, double > HPD_energy_map, RBX_energy_map;
-  vector< double > EB_energies, EE_energies, HB_energies, HE_energies, short_energies, long_energies;
+  edm::ESHandle<HcalTopology> theHcalTopology;
+  setup.get<HcalRecNumberingRecord>().get(theHcalTopology);
+
+  std::map<int, double> HPD_energy_map, RBX_energy_map;
+  vector<double> EB_energies, EE_energies, HB_energies, HE_energies, short_energies, long_energies;
   edm::Handle<HBHERecHitCollection> HBHERecHits;
   edm::Handle<HORecHitCollection> HORecHits;
   edm::Handle<HFRecHitCollection> HFRecHits;
   edm::Handle<EBRecHitCollection> EBRecHits;
   edm::Handle<EERecHitCollection> EERecHits;
   // the jet only contains DetIds, so first read recHit collection
-  event.getByToken(input_HBHERecHits_token_, HBHERecHits );
-  event.getByToken(input_HORecHits_token_, HORecHits );
-  event.getByToken(input_HFRecHits_token_, HFRecHits );
-  event.getByToken(input_EBRecHits_token_, EBRecHits );
-  event.getByToken(input_EERecHits_token_, EERecHits );
-  if( iDbg > 2 ) cout<<"# of rechits found - HBHE: "<<HBHERecHits->size()
-		     <<", HO: "<<HORecHits->size()<<", HF: "<<HFRecHits->size()
-		     <<", EB: "<<EBRecHits->size()<<", EE: "<<EERecHits->size()<<endl;
+  event.getByToken(input_HBHERecHits_token_, HBHERecHits);
+  event.getByToken(input_HORecHits_token_, HORecHits);
+  event.getByToken(input_HFRecHits_token_, HFRecHits);
+  event.getByToken(input_EBRecHits_token_, EBRecHits);
+  event.getByToken(input_EERecHits_token_, EERecHits);
+  if (iDbg > 2)
+    cout << "# of rechits found - HBHE: " << HBHERecHits->size() << ", HO: " << HORecHits->size()
+         << ", HF: " << HFRecHits->size() << ", EB: " << EBRecHits->size() << ", EE: " << EERecHits->size() << endl;
 
-  vector< CaloTowerPtr > towers = jet.getCaloConstituents ();
+  vector<CaloTowerPtr> towers = jet.getCaloConstituents();
   int nTowers = towers.size();
-  if( iDbg > 9 ) cout<<"In classifyJetComponents. # of towers found: "<<nTowers<<endl;
+  if (iDbg > 9)
+    cout << "In classifyJetComponents. # of towers found: " << nTowers << endl;
 
-  for( int iTower = 0; iTower <nTowers ; iTower++ ) {
-
-    CaloTowerPtr& tower = towers[iTower];
+  for (int iTower = 0; iTower < nTowers; iTower++) {
+    CaloTowerPtr &tower = towers[iTower];
 
     int nCells = tower->constituentsSize();
-    if( iDbg ) cout<<"tower #"<<iTower<<" has "<<nCells<<" cells. "
-		   <<"It's at iEta: "<<tower->ieta()<<", iPhi: "<<tower->iphi()<<endl;
+    if (iDbg)
+      cout << "tower #" << iTower << " has " << nCells << " cells. "
+           << "It's at iEta: " << tower->ieta() << ", iPhi: " << tower->iphi() << endl;
 
-    const vector< DetId >& cellIDs = tower->constituents();  // cell == recHit
-  
-    for( int iCell = 0; iCell < nCells; ++iCell ) {
+    const vector<DetId> &cellIDs = tower->constituents();  // cell == recHit
+
+    for (int iCell = 0; iCell < nCells; ++iCell) {
       DetId::Detector detNum = cellIDs[iCell].det();
-      if( detNum == DetId::Hcal ) {
-	HcalDetId HcalID = cellIDs[ iCell ];
-	HcalSubdetector HcalNum = HcalID.subdet();
-	double hitE = 0;
-	if( HcalNum == HcalOuter ) {
-	  HORecHitCollection::const_iterator theRecHit=HORecHits->find(HcalID);
-	  if (theRecHit == HORecHits->end()) {
-	    edm::LogWarning("UnexpectedEventContents")<<"Can't find the HO recHit with ID: "<<HcalID;
-	    continue;
-	  }
-	  hitE = theRecHit->energy();
-	  HO_energies.push_back( hitE );
-	    
-	} else if( HcalNum == HcalForward ) {
-	  
-	  HFRecHitCollection::const_iterator theRecHit=HFRecHits->find( HcalID );	    
-	  if( theRecHit == HFRecHits->end() ) {
-	    edm::LogWarning("UnexpectedEventContents")<<"Can't find the HF recHit with ID: "<<HcalID;
-	    continue;
-	  }
-	  hitE = theRecHit->energy();
-	  if( iDbg>4 ) cout 
-			 << "hit #"<<iCell<<" is  HF , E: "<<hitE<<" iEta: "<<theRecHit->id().ieta()
-			 <<", depth: "<<theRecHit->id().depth()<<", iPhi: "
-			 <<theRecHit->id().iphi();
-	  
-	  if( HcalID.depth() == 1 ) 
-	    long_energies.push_back( hitE );
-	  else
-	    short_energies.push_back( hitE );
-	  
-	  uint32_t flags = theRecHit->flags();
-	  if( flags & (1<<HcalCaloFlagLabels::HFLongShort) ) LS_bad_energy += hitE;
-	  if( flags & ( (1<<HcalCaloFlagLabels::HFDigiTime) | 
-			(3<<HcalCaloFlagLabels::HFTimingTrustBits) | 
-			(1<<HcalCaloFlagLabels::TimingSubtractedBit) |
-			(1<<HcalCaloFlagLabels::TimingAddedBit) |
-			(1<<HcalCaloFlagLabels::TimingErrorBit) ) ) HF_OOT_energy += hitE;
-	  if( iDbg>4 && flags ) cout<<"flags: "<<flags
-				    <<" -> LS_bad_energy: "<<LS_bad_energy<<", HF_OOT_energy: "<<HF_OOT_energy<<endl; 
+      if (detNum == DetId::Hcal) {
+        HcalDetId HcalID = cellIDs[iCell];
+        HcalSubdetector HcalNum = HcalID.subdet();
+        double hitE = 0;
+        if (HcalNum == HcalOuter) {
+          HORecHitCollection::const_iterator theRecHit = HORecHits->find(HcalID);
+          if (theRecHit == HORecHits->end()) {
+            edm::LogWarning("UnexpectedEventContents") << "Can't find the HO recHit with ID: " << HcalID;
+            continue;
+          }
+          hitE = theRecHit->energy();
+          HO_energies.push_back(hitE);
 
-	} else { // HBHE
-	  
-	  HBHERecHitCollection::const_iterator theRecHit = HBHERecHits->find( HcalID );	    
-	  if( theRecHit == HBHERecHits->end() ) {
-	    edm::LogWarning("UnexpectedEventContents")<<"Can't find the HBHE recHit with ID: "<<HcalID; 
-	    continue;
-	  }
-	  hitE = theRecHit->energy();
-	  int iEta = theRecHit->id().ieta();
-	  int depth = theRecHit->id().depth();
-	  Region region = HBHE_region( theRecHit->id().rawId() );
-	  int hitIPhi = theRecHit->id().iphi();
-	  if( iDbg>3 ) cout<<"hit #"<<iCell<<" is HBHE, E: "<<hitE<<" iEta: "<<iEta
-			   <<", depth: "<<depth<<", iPhi: "<<theRecHit->id().iphi()
-			   <<" -> "<<region;
+        } else if (HcalNum == HcalForward) {
+          HFRecHitCollection::const_iterator theRecHit = HFRecHits->find(HcalID);
+          if (theRecHit == HFRecHits->end()) {
+            edm::LogWarning("UnexpectedEventContents") << "Can't find the HF recHit with ID: " << HcalID;
+            continue;
+          }
+          hitE = theRecHit->energy();
+          if (iDbg > 4)
+            cout << "hit #" << iCell << " is  HF , E: " << hitE << " iEta: " << theRecHit->id().ieta()
+                 << ", depth: " << theRecHit->id().depth() << ", iPhi: " << theRecHit->id().iphi();
 
-	  if(theHcalTopology->mergedDepth29(theRecHit->id()))
-	    hitE /= 2;  // Depth 3 at the HE forward edge is split over tower 28 & 29, and jet reco. assigns half each
-	  
-	  int iHPD = 100 * region;
-	  int iRBX = 100 * region + ((hitIPhi + 1) % 72) / 4; // 71,72,1,2 are in the same RBX module
-	  
-	  if( std::abs( iEta ) >= 21 ) {
-	    if( (0x1 & hitIPhi) == 0 ) {
-	      edm::LogError("CodeAssumptionsViolated")<<"Bug?! Jet ID code assumes no even iPhi recHits at HE edges";
-	      return;
-	    }
-	    bool oddnessIEta = HBHE_oddness( iEta, depth );
-	    bool upperIPhi = (( hitIPhi%4 ) == 1 || ( hitIPhi%4 ) == 2); // the upper iPhi indices in the HE wedge
-	    // remap the iPhi so it fits the one in the inner HE regions, change in needed in two cases:
-	    // 1) in the upper iPhis of the module, the even iEtas belong to the higher iPhi
-	    // 2) in the loewr iPhis of the module, the odd  iEtas belong to the higher iPhi
-	    if( upperIPhi != oddnessIEta ) ++hitIPhi; 
-	    // note that hitIPhi could not be 72 before, so it's still in the legal range [1,72]
-	  }
-	  iHPD += hitIPhi;
-	  
-	  // book the energies
-	  HPD_energy_map[ iHPD ] += hitE;
-	  RBX_energy_map[ iRBX ] += hitE;
-	  if( iDbg > 5 ) cout<<" --> H["<<iHPD<<"]="<<HPD_energy_map[iHPD]
-			     <<", R["<<iRBX<<"]="<<RBX_energy_map[iRBX];
-	  if( iDbg > 1 ) cout<<endl;
-	  
-	  if( region == HBneg || region == HBpos )
-	    HB_energies.push_back( hitE );
-	  else
-	    HE_energies.push_back( hitE );
-	  
-	} // if HBHE
-	if( hitE == 0 ) edm::LogWarning("UnexpectedEventContents")<<"HCal hitE==0? (or unknown subdetector?)";
-	
-      } // if HCAL 
-	
+          if (HcalID.depth() == 1)
+            long_energies.push_back(hitE);
+          else
+            short_energies.push_back(hitE);
+
+          uint32_t flags = theRecHit->flags();
+          if (flags & (1 << HcalCaloFlagLabels::HFLongShort))
+            LS_bad_energy += hitE;
+          if (flags & ((1 << HcalCaloFlagLabels::HFDigiTime) | (3 << HcalCaloFlagLabels::HFTimingTrustBits) |
+                       (1 << HcalCaloFlagLabels::TimingSubtractedBit) | (1 << HcalCaloFlagLabels::TimingAddedBit) |
+                       (1 << HcalCaloFlagLabels::TimingErrorBit)))
+            HF_OOT_energy += hitE;
+          if (iDbg > 4 && flags)
+            cout << "flags: " << flags << " -> LS_bad_energy: " << LS_bad_energy << ", HF_OOT_energy: " << HF_OOT_energy
+                 << endl;
+
+        } else {  // HBHE
+
+          HBHERecHitCollection::const_iterator theRecHit = HBHERecHits->find(HcalID);
+          if (theRecHit == HBHERecHits->end()) {
+            edm::LogWarning("UnexpectedEventContents") << "Can't find the HBHE recHit with ID: " << HcalID;
+            continue;
+          }
+          hitE = theRecHit->energy();
+          int iEta = theRecHit->id().ieta();
+          int depth = theRecHit->id().depth();
+          Region region = HBHE_region(theRecHit->id().rawId());
+          int hitIPhi = theRecHit->id().iphi();
+          if (iDbg > 3)
+            cout << "hit #" << iCell << " is HBHE, E: " << hitE << " iEta: " << iEta << ", depth: " << depth
+                 << ", iPhi: " << theRecHit->id().iphi() << " -> " << region;
+
+          if (theHcalTopology->mergedDepth29(theRecHit->id()))
+            hitE /= 2;  // Depth 3 at the HE forward edge is split over tower 28 & 29, and jet reco. assigns half each
+
+          int iHPD = 100 * region;
+          int iRBX = 100 * region + ((hitIPhi + 1) % 72) / 4;  // 71,72,1,2 are in the same RBX module
+
+          if (std::abs(iEta) >= 21) {
+            if ((0x1 & hitIPhi) == 0) {
+              edm::LogError("CodeAssumptionsViolated") << "Bug?! Jet ID code assumes no even iPhi recHits at HE edges";
+              return;
+            }
+            bool oddnessIEta = HBHE_oddness(iEta, depth);
+            bool upperIPhi = ((hitIPhi % 4) == 1 || (hitIPhi % 4) == 2);  // the upper iPhi indices in the HE wedge
+            // remap the iPhi so it fits the one in the inner HE regions, change in needed in two cases:
+            // 1) in the upper iPhis of the module, the even iEtas belong to the higher iPhi
+            // 2) in the loewr iPhis of the module, the odd  iEtas belong to the higher iPhi
+            if (upperIPhi != oddnessIEta)
+              ++hitIPhi;
+            // note that hitIPhi could not be 72 before, so it's still in the legal range [1,72]
+          }
+          iHPD += hitIPhi;
+
+          // book the energies
+          HPD_energy_map[iHPD] += hitE;
+          RBX_energy_map[iRBX] += hitE;
+          if (iDbg > 5)
+            cout << " --> H[" << iHPD << "]=" << HPD_energy_map[iHPD] << ", R[" << iRBX << "]=" << RBX_energy_map[iRBX];
+          if (iDbg > 1)
+            cout << endl;
+
+          if (region == HBneg || region == HBpos)
+            HB_energies.push_back(hitE);
+          else
+            HE_energies.push_back(hitE);
+
+        }  // if HBHE
+        if (hitE == 0)
+          edm::LogWarning("UnexpectedEventContents") << "HCal hitE==0? (or unknown subdetector?)";
+
+      }  // if HCAL
+
       else if (detNum == DetId::Ecal) {
-	
-	int EcalNum =  cellIDs[iCell].subdetId();
-	double hitE = 0;
-	if( EcalNum == 1 ){
-	  EBDetId EcalID = cellIDs[iCell];
-	  EBRecHitCollection::const_iterator theRecHit=EBRecHits->find(EcalID);
-	  if( theRecHit == EBRecHits->end() ) {edm::LogWarning("UnexpectedEventContents")
-	      <<"Can't find the EB recHit with ID: "<<EcalID; continue;}
-	  hitE = theRecHit->energy();
-	  EB_energies.push_back( hitE );
-	} else if(  EcalNum == 2 ){
-	  EEDetId EcalID = cellIDs[iCell];
-	  EERecHitCollection::const_iterator theRecHit=EERecHits->find(EcalID);
-	  if( theRecHit == EERecHits->end() ) {edm::LogWarning("UnexpectedEventContents")
-	      <<"Can't find the EE recHit with ID: "<<EcalID; continue;}
-	  hitE = theRecHit->energy();
-	  EE_energies.push_back( hitE );
-	}
-	if( hitE == 0 ) edm::LogWarning("UnexpectedEventContents")<<"ECal hitE==0? (or unknown subdetector?)";
-	if( iDbg > 6 ) cout<<"EcalNum: "<<EcalNum<<" hitE: "<<hitE<<endl;
-      } // 
-    } // loop on cells
-  } // loop on towers
+        int EcalNum = cellIDs[iCell].subdetId();
+        double hitE = 0;
+        if (EcalNum == 1) {
+          EBDetId EcalID = cellIDs[iCell];
+          EBRecHitCollection::const_iterator theRecHit = EBRecHits->find(EcalID);
+          if (theRecHit == EBRecHits->end()) {
+            edm::LogWarning("UnexpectedEventContents") << "Can't find the EB recHit with ID: " << EcalID;
+            continue;
+          }
+          hitE = theRecHit->energy();
+          EB_energies.push_back(hitE);
+        } else if (EcalNum == 2) {
+          EEDetId EcalID = cellIDs[iCell];
+          EERecHitCollection::const_iterator theRecHit = EERecHits->find(EcalID);
+          if (theRecHit == EERecHits->end()) {
+            edm::LogWarning("UnexpectedEventContents") << "Can't find the EE recHit with ID: " << EcalID;
+            continue;
+          }
+          hitE = theRecHit->energy();
+          EE_energies.push_back(hitE);
+        }
+        if (hitE == 0)
+          edm::LogWarning("UnexpectedEventContents") << "ECal hitE==0? (or unknown subdetector?)";
+        if (iDbg > 6)
+          cout << "EcalNum: " << EcalNum << " hitE: " << hitE << endl;
+      }  //
+    }    // loop on cells
+  }      // loop on towers
 
   /* Disabling check until HO is accounted for in EMF. Check was used in CMSSW_2, where HE was excluded.
   double expHcalE = jet.energy() * (1-jet.emEnergyFraction());
@@ -423,51 +459,51 @@ void reco::helper::JetIDHelper::classifyJetComponents( const edm::Event& event, 
       ( totHcalE - expHcalE ) / ( totHcalE + expHcalE ) > 0.0001 ) {
     edm::LogWarning("CodeAssumptionsViolated")<<"failed to account for all Hcal energies"
 					      <<totHcalE<<"!="<<expHcalE;
-					      } */   
+					      } */
   // concatenate Hcal and Ecal lists
-  Hcal_energies.insert( Hcal_energies.end(), HB_energies.begin(), HB_energies.end() );
-  Hcal_energies.insert( Hcal_energies.end(), HE_energies.begin(), HE_energies.end() );
-  Hcal_energies.insert( Hcal_energies.end(), short_energies.begin(), short_energies.end() );
-  Hcal_energies.insert( Hcal_energies.end(), long_energies.begin(), long_energies.end() );
-  Ecal_energies.insert( Ecal_energies.end(), EB_energies.begin(), EB_energies.end() );
-  Ecal_energies.insert( Ecal_energies.end(), EE_energies.begin(), EE_energies.end() );
+  Hcal_energies.insert(Hcal_energies.end(), HB_energies.begin(), HB_energies.end());
+  Hcal_energies.insert(Hcal_energies.end(), HE_energies.begin(), HE_energies.end());
+  Hcal_energies.insert(Hcal_energies.end(), short_energies.begin(), short_energies.end());
+  Hcal_energies.insert(Hcal_energies.end(), long_energies.begin(), long_energies.end());
+  Ecal_energies.insert(Ecal_energies.end(), EB_energies.begin(), EB_energies.end());
+  Ecal_energies.insert(Ecal_energies.end(), EE_energies.begin(), EE_energies.end());
 
   // sort the energies
   // std::sort( Hcal_energies.begin(), Hcal_energies.end(), greater<double>() );
   // std::sort( Ecal_energies.begin(), Ecal_energies.end(), greater<double>() );
 
   // put the energy sums (the 2nd entry in each pair of the maps) into the output vectors and sort them
-  std::transform( HPD_energy_map.begin(), HPD_energy_map.end(), 
-		  std::inserter (HPD_energies, HPD_energies.end()), select2nd ); 
+  std::transform(
+      HPD_energy_map.begin(), HPD_energy_map.end(), std::inserter(HPD_energies, HPD_energies.end()), select2nd);
   //		  std::select2nd<std::map<int,double>::value_type>());
   // std::sort( HPD_energies.begin(), HPD_energies.end(), greater<double>() );
-  std::transform( RBX_energy_map.begin(), RBX_energy_map.end(), 
-		  std::inserter (RBX_energies, RBX_energies.end()), select2nd );
+  std::transform(
+      RBX_energy_map.begin(), RBX_energy_map.end(), std::inserter(RBX_energies, RBX_energies.end()), select2nd);
   //		  std::select2nd<std::map<int,double>::value_type>());
   // std::sort( RBX_energies.begin(), RBX_energies.end(), greater<double>() );
 
-  energies.insert( energies.end(), Hcal_energies.begin(), Hcal_energies.end() );
-  energies.insert( energies.end(), Ecal_energies.begin(), Ecal_energies.end() );
-  energies.insert( energies.end(), HO_energies.begin(), HO_energies.end() );
-  std::sort( energies.begin(), energies.end(), greater<double>() );
+  energies.insert(energies.end(), Hcal_energies.begin(), Hcal_energies.end());
+  energies.insert(energies.end(), Ecal_energies.begin(), Ecal_energies.end());
+  energies.insert(energies.end(), HO_energies.begin(), HO_energies.end());
+  std::sort(energies.begin(), energies.end(), greater<double>());
 
   // prepare sub detector energies, then turn them into fractions
-  fEB_ = std::accumulate( EB_energies.begin(), EB_energies.end(), 0. );
-  fEE_ = std::accumulate( EE_energies.begin(), EE_energies.end(), 0. );
-  fHB_ = std::accumulate( HB_energies.begin(), HB_energies.end(), 0. );
-  fHE_ = std::accumulate( HE_energies.begin(), HE_energies.end(), 0. );
-  fHO_ = std::accumulate( HO_energies.begin(), HO_energies.end(), 0. );
-  fShort_ = std::accumulate( short_energies.begin(), short_energies.end(), 0. );
-  fLong_ = std::accumulate( long_energies.begin(), long_energies.end(), 0. );
-  subdet_energies.push_back( fEB_ );
-  subdet_energies.push_back( fEE_ );
-  subdet_energies.push_back( fHB_ );
-  subdet_energies.push_back( fHE_ );
-  subdet_energies.push_back( fHO_ );
-  subdet_energies.push_back( fShort_ );
-  subdet_energies.push_back( fLong_ );
-  std::sort( subdet_energies.begin(), subdet_energies.end(), greater<double>() );
-  if( jet.energy() > 0 ) {
+  fEB_ = std::accumulate(EB_energies.begin(), EB_energies.end(), 0.);
+  fEE_ = std::accumulate(EE_energies.begin(), EE_energies.end(), 0.);
+  fHB_ = std::accumulate(HB_energies.begin(), HB_energies.end(), 0.);
+  fHE_ = std::accumulate(HE_energies.begin(), HE_energies.end(), 0.);
+  fHO_ = std::accumulate(HO_energies.begin(), HO_energies.end(), 0.);
+  fShort_ = std::accumulate(short_energies.begin(), short_energies.end(), 0.);
+  fLong_ = std::accumulate(long_energies.begin(), long_energies.end(), 0.);
+  subdet_energies.push_back(fEB_);
+  subdet_energies.push_back(fEE_);
+  subdet_energies.push_back(fHB_);
+  subdet_energies.push_back(fHE_);
+  subdet_energies.push_back(fHO_);
+  subdet_energies.push_back(fShort_);
+  subdet_energies.push_back(fLong_);
+  std::sort(subdet_energies.begin(), subdet_energies.end(), greater<double>());
+  if (jet.energy() > 0) {
     fEB_ /= jet.energy();
     fEE_ /= jet.energy();
     fHB_ /= jet.energy();
@@ -476,160 +512,175 @@ void reco::helper::JetIDHelper::classifyJetComponents( const edm::Event& event, 
     fShort_ /= jet.energy();
     fLong_ /= jet.energy();
   } else {
-    if( fEB_ > 0 || fEE_ > 0 || fHB_ > 0 || fHE_ > 0 || fHO_ > 0 || fShort_ > 0 || fLong_ > 0 )
-      edm::LogError("UnexpectedEventContents")<<"Jet ID Helper found energy in subdetectors and jet E <= 0";
-  }      
+    if (fEB_ > 0 || fEE_ > 0 || fHB_ > 0 || fHE_ > 0 || fHO_ > 0 || fShort_ > 0 || fLong_ > 0)
+      edm::LogError("UnexpectedEventContents") << "Jet ID Helper found energy in subdetectors and jet E <= 0";
+  }
 }
 
-void reco::helper::JetIDHelper::classifyJetTowers( const edm::Event& event, const reco::CaloJet &jet, 
-						   vector< subtower > &subtowers,      
-						   vector< subtower > &Ecal_subtowers, 
-						   vector< subtower > &Hcal_subtowers, 
-						   vector< subtower > &HO_subtowers,
-						   vector< double > &HPD_energies,  
-						   vector< double > &RBX_energies,
-						   const int iDbg )
-{
-  subtowers.clear(); Ecal_subtowers.clear(); Hcal_subtowers.clear(); HO_subtowers.clear();
-  HPD_energies.clear(); RBX_energies.clear();
+void reco::helper::JetIDHelper::classifyJetTowers(const edm::Event &event,
+                                                  const reco::CaloJet &jet,
+                                                  vector<subtower> &subtowers,
+                                                  vector<subtower> &Ecal_subtowers,
+                                                  vector<subtower> &Hcal_subtowers,
+                                                  vector<subtower> &HO_subtowers,
+                                                  vector<double> &HPD_energies,
+                                                  vector<double> &RBX_energies,
+                                                  const int iDbg) {
+  subtowers.clear();
+  Ecal_subtowers.clear();
+  Hcal_subtowers.clear();
+  HO_subtowers.clear();
+  HPD_energies.clear();
+  RBX_energies.clear();
 
-  std::map< int, double > HPD_energy_map, RBX_energy_map;
+  std::map<int, double> HPD_energy_map, RBX_energy_map;
 
-  vector< CaloTowerPtr > towers = jet.getCaloConstituents ();
+  vector<CaloTowerPtr> towers = jet.getCaloConstituents();
   int nTowers = towers.size();
-  if( iDbg > 9 ) cout<<"classifyJetTowers started. # of towers found: "<<nTowers<<endl;
+  if (iDbg > 9)
+    cout << "classifyJetTowers started. # of towers found: " << nTowers << endl;
 
-  for( int iTower = 0; iTower <nTowers ; iTower++ ) {
-
-    CaloTowerPtr& tower = towers[iTower];
+  for (int iTower = 0; iTower < nTowers; iTower++) {
+    CaloTowerPtr &tower = towers[iTower];
 
     int nEM = 0, nHad = 0, nHO = 0;
-    const vector< DetId >& cellIDs = tower->constituents();  // cell == recHit
+    const vector<DetId> &cellIDs = tower->constituents();  // cell == recHit
     int nCells = cellIDs.size();
-    if( iDbg ) cout<<"tower #"<<iTower<<" has "<<nCells<<" cells. "
-		   <<"It's at iEta: "<<tower->ieta()<<", iPhi: "<<tower->iphi()<<endl;
-  
-    for( int iCell = 0; iCell < nCells; ++iCell ) {
+    if (iDbg)
+      cout << "tower #" << iTower << " has " << nCells << " cells. "
+           << "It's at iEta: " << tower->ieta() << ", iPhi: " << tower->iphi() << endl;
+
+    for (int iCell = 0; iCell < nCells; ++iCell) {
       DetId::Detector detNum = cellIDs[iCell].det();
-      if( detNum == DetId::Hcal ) {
-	HcalDetId HcalID = cellIDs[ iCell ];
-	HcalSubdetector HcalNum = HcalID.subdet();
-	if( HcalNum == HcalOuter ) {
-	  ++nHO;
-	} else {
-	  ++nHad;
-	}
-      }	else if (detNum == DetId::Ecal) {
-	++nEM;
+      if (detNum == DetId::Hcal) {
+        HcalDetId HcalID = cellIDs[iCell];
+        HcalSubdetector HcalNum = HcalID.subdet();
+        if (HcalNum == HcalOuter) {
+          ++nHO;
+        } else {
+          ++nHad;
+        }
+      } else if (detNum == DetId::Ecal) {
+        ++nEM;
       }
     }
 
     double E_em = tower->emEnergy();
-    if( E_em != 0 ) Ecal_subtowers.push_back( subtower( E_em, nEM ) );
-      
+    if (E_em != 0)
+      Ecal_subtowers.push_back(subtower(E_em, nEM));
+
     double E_HO = tower->outerEnergy();
-    if( E_HO != 0 ) HO_subtowers.push_back( subtower( E_HO, nHO ) );
-      
+    if (E_HO != 0)
+      HO_subtowers.push_back(subtower(E_HO, nHO));
+
     double E_had = tower->hadEnergy();
-    if( E_had != 0 ) {
-      Hcal_subtowers.push_back( subtower( E_had, nHad ) );
+    if (E_had != 0) {
+      Hcal_subtowers.push_back(subtower(E_had, nHad));
       // totHcalE += E_had;
-      
+
       int iEta = tower->ieta();
-      Region reg = region( iEta );
+      Region reg = region(iEta);
       int iPhi = tower->iphi();
-      if( iDbg>3 ) cout<<"tower has E_had: "<<E_had<<" iEta: "<<iEta
-		       <<", iPhi: "<<iPhi<<" -> "<<reg;
-      
-      if( reg == HEneg || reg == HBneg || reg == HBpos || reg == HEpos ) {
-	int oddnessIEta = HBHE_oddness( iEta );
-	if( oddnessIEta < 0 ) break; // can't assign this tower to a single readout component
-	
-	int iHPD = 100 * reg;
-	int iRBX = 100 * reg + ((iPhi + 1) % 72) / 4; // 71,72,1,2 are in the same RBX module
-	
-	if(( reg == HEneg || reg == HEpos ) && std::abs( iEta ) >= 21 ) { // at low-granularity edge of HE
-	  if( (0x1 & iPhi) == 0 ) {
-	    edm::LogError("CodeAssumptionsViolated")<<
-	      "Bug?! Jet ID code assumes no even iPhi recHits at HE edges";
-	    return;
-	  }
-	  bool boolOddnessIEta = oddnessIEta;
-	  bool upperIPhi = (( iPhi%4 ) == 1 || ( iPhi%4 ) == 2); // the upper iPhi indices in the HE wedge
-	  // remap the iPhi so it fits the one in the inner HE regions, change in needed in two cases:
-	  // 1) in the upper iPhis of the module, the even IEtas belong to the higher iPhi
-	  // 2) in the loewr iPhis of the module, the odd  IEtas belong to the higher iPhi
-	  if( upperIPhi != boolOddnessIEta ) ++iPhi; 
-	  // note that iPhi could not be 72 before, so it's still in the legal range [1,72]
-	} // if at low-granularity edge of HE
-	iHPD += iPhi;
-	
-	// book the energies
-	HPD_energy_map[ iHPD ] += E_had;
-	RBX_energy_map[ iRBX ] += E_had;
-	if( iDbg > 5 ) cout<<" --> H["<<iHPD<<"]="<<HPD_energy_map[iHPD]
-			   <<", R["<<iRBX<<"]="<<RBX_energy_map[iRBX];
-      } // HBHE
-    } // E_had > 0
-  } // loop on towers
+      if (iDbg > 3)
+        cout << "tower has E_had: " << E_had << " iEta: " << iEta << ", iPhi: " << iPhi << " -> " << reg;
+
+      if (reg == HEneg || reg == HBneg || reg == HBpos || reg == HEpos) {
+        int oddnessIEta = HBHE_oddness(iEta);
+        if (oddnessIEta < 0)
+          break;  // can't assign this tower to a single readout component
+
+        int iHPD = 100 * reg;
+        int iRBX = 100 * reg + ((iPhi + 1) % 72) / 4;  // 71,72,1,2 are in the same RBX module
+
+        if ((reg == HEneg || reg == HEpos) && std::abs(iEta) >= 21) {  // at low-granularity edge of HE
+          if ((0x1 & iPhi) == 0) {
+            edm::LogError("CodeAssumptionsViolated") << "Bug?! Jet ID code assumes no even iPhi recHits at HE edges";
+            return;
+          }
+          bool boolOddnessIEta = oddnessIEta;
+          bool upperIPhi = ((iPhi % 4) == 1 || (iPhi % 4) == 2);  // the upper iPhi indices in the HE wedge
+          // remap the iPhi so it fits the one in the inner HE regions, change in needed in two cases:
+          // 1) in the upper iPhis of the module, the even IEtas belong to the higher iPhi
+          // 2) in the loewr iPhis of the module, the odd  IEtas belong to the higher iPhi
+          if (upperIPhi != boolOddnessIEta)
+            ++iPhi;
+          // note that iPhi could not be 72 before, so it's still in the legal range [1,72]
+        }  // if at low-granularity edge of HE
+        iHPD += iPhi;
+
+        // book the energies
+        HPD_energy_map[iHPD] += E_had;
+        RBX_energy_map[iRBX] += E_had;
+        if (iDbg > 5)
+          cout << " --> H[" << iHPD << "]=" << HPD_energy_map[iHPD] << ", R[" << iRBX << "]=" << RBX_energy_map[iRBX];
+      }  // HBHE
+    }    // E_had > 0
+  }      // loop on towers
 
   // sort the subtowers
   // std::sort( Hcal_subtowers.begin(), Hcal_subtowers.end(), subtower_has_greater_E );
   // std::sort( Ecal_subtowers.begin(), Ecal_subtowers.end(), subtower_has_greater_E );
 
   // put the energy sums (the 2nd entry in each pair of the maps) into the output vectors and sort them
-  std::transform( HPD_energy_map.begin(), HPD_energy_map.end(), 
-		  std::inserter (HPD_energies, HPD_energies.end()), select2nd ); 
+  std::transform(
+      HPD_energy_map.begin(), HPD_energy_map.end(), std::inserter(HPD_energies, HPD_energies.end()), select2nd);
   //		  std::select2nd<std::map<int,double>::value_type>());
   // std::sort( HPD_energies.begin(), HPD_energies.end(), greater<double>() );
-  std::transform( RBX_energy_map.begin(), RBX_energy_map.end(), 
-		  std::inserter (RBX_energies, RBX_energies.end()), select2nd );
+  std::transform(
+      RBX_energy_map.begin(), RBX_energy_map.end(), std::inserter(RBX_energies, RBX_energies.end()), select2nd);
   //		  std::select2nd<std::map<int,double>::value_type>());
   // std::sort( RBX_energies.begin(), RBX_energies.end(), greater<double>() );
 
-  subtowers.insert( subtowers.end(), Hcal_subtowers.begin(), Hcal_subtowers.end() );
-  subtowers.insert( subtowers.end(), Ecal_subtowers.begin(), Ecal_subtowers.end() );
-  subtowers.insert( subtowers.end(), HO_subtowers.begin(), HO_subtowers.end() );
-  std::sort( subtowers.begin(), subtowers.end(), subtower_has_greater_E );
+  subtowers.insert(subtowers.end(), Hcal_subtowers.begin(), Hcal_subtowers.end());
+  subtowers.insert(subtowers.end(), Ecal_subtowers.begin(), Ecal_subtowers.end());
+  subtowers.insert(subtowers.end(), HO_subtowers.begin(), HO_subtowers.end());
+  std::sort(subtowers.begin(), subtowers.end(), subtower_has_greater_E);
 }
 
 // ---------------------------------------------------------------------------------------------------------
 // private helper functions to figure out detector & readout geometry as needed
 
-int reco::helper::JetIDHelper::HBHE_oddness( int iEta, int depth )
-{
- int ae = TMath::Abs( iEta );
- if( ae == 29 && depth == 1 ) ae += 1; // observed that: hits are at depths 1 & 2; 1 goes with the even pattern
- return ae & 0x1;
+int reco::helper::JetIDHelper::HBHE_oddness(int iEta, int depth) {
+  int ae = TMath::Abs(iEta);
+  if (ae == 29 && depth == 1)
+    ae += 1;  // observed that: hits are at depths 1 & 2; 1 goes with the even pattern
+  return ae & 0x1;
 }
 
-reco::helper::JetIDHelper::Region reco::helper::JetIDHelper::HBHE_region( uint32_t rawid )
-{
+reco::helper::JetIDHelper::Region reco::helper::JetIDHelper::HBHE_region(uint32_t rawid) {
   HcalDetId id(rawid);
-  if( id.subdet() == HcalEndcap)
-    {
-      if( id.ieta() < 0 ) return HEneg;
-      else return HEpos;
-    }
-  if( id.subdet() == HcalBarrel && id.ieta() < 0) return HBneg;
-  return HBpos;  
+  if (id.subdet() == HcalEndcap) {
+    if (id.ieta() < 0)
+      return HEneg;
+    else
+      return HEpos;
+  }
+  if (id.subdet() == HcalBarrel && id.ieta() < 0)
+    return HBneg;
+  return HBpos;
 }
 
-int reco::helper::JetIDHelper::HBHE_oddness( int iEta )
-{
- int ae = TMath::Abs( iEta );
- if( ae == 29 ) return -1; // can't figure it out without RecHits
- return ae & 0x1;
+int reco::helper::JetIDHelper::HBHE_oddness(int iEta) {
+  int ae = TMath::Abs(iEta);
+  if (ae == 29)
+    return -1;  // can't figure it out without RecHits
+  return ae & 0x1;
 }
 
-reco::helper::JetIDHelper::Region reco::helper::JetIDHelper::region( int iEta )
-{
-  if( iEta == 16 || iEta == -16 ) return unknown_region; // both HB and HE cells belong to these towers
-  if( iEta == 29 || iEta == -29 ) return unknown_region; // both HE and HF cells belong to these towers
-  if( iEta <= -30 ) return HFneg;
-  if( iEta >=  30 ) return HFpos;
-  if( iEta <= -17 ) return HEneg;
-  if( iEta >=  17 ) return HEpos;
-  if( iEta < 0 ) return HBneg;
+reco::helper::JetIDHelper::Region reco::helper::JetIDHelper::region(int iEta) {
+  if (iEta == 16 || iEta == -16)
+    return unknown_region;  // both HB and HE cells belong to these towers
+  if (iEta == 29 || iEta == -29)
+    return unknown_region;  // both HE and HF cells belong to these towers
+  if (iEta <= -30)
+    return HFneg;
+  if (iEta >= 30)
+    return HFpos;
+  if (iEta <= -17)
+    return HEneg;
+  if (iEta >= 17)
+    return HEpos;
+  if (iEta < 0)
+    return HBneg;
   return HBpos;
 }

--- a/RecoJets/JetProducers/src/JetMatchingTools.cc
+++ b/RecoJets/JetProducers/src/JetMatchingTools.cc
@@ -16,313 +16,316 @@ using namespace edm;
 
 namespace {
   template <class T>
-  const typename T::value_type* getHit (const T& fCollection, DetId fId) {
-    typename T::const_iterator hit = fCollection.find (fId);
-    if (hit != fCollection.end()) return &*hit;
+  const typename T::value_type* getHit(const T& fCollection, DetId fId) {
+    typename T::const_iterator hit = fCollection.find(fId);
+    if (hit != fCollection.end())
+      return &*hit;
     return nullptr;
   }
 
-  std::vector <const PCaloHit*> getSimHits (const PCaloHitContainer& fCollection, DetId fId) {
-    std::vector <const PCaloHit*> result;
-    for (unsigned i = 0; i < fCollection.size (); ++i) {
+  std::vector<const PCaloHit*> getSimHits(const PCaloHitContainer& fCollection, DetId fId) {
+    std::vector<const PCaloHit*> result;
+    for (unsigned i = 0; i < fCollection.size(); ++i) {
       if (fCollection[i].id() == fId.rawId()) {
-        result.push_back (&(fCollection[i]));
+        result.push_back(&(fCollection[i]));
       }
     }
     return result;
   }
+}  // namespace
+
+JetMatchingTools::JetMatchingTools(const edm::Event& fEvent, edm::ConsumesCollector&& iC)
+    : mEvent(&fEvent),
+      mEBRecHitCollection(nullptr),
+      mEERecHitCollection(nullptr),
+      mHBHERecHitCollection(nullptr),
+      mHORecHitCollection(nullptr),
+      mHFRecHitCollection(nullptr),
+      mEBSimHitCollection(nullptr),
+      mEESimHitCollection(nullptr),
+      mHcalSimHitCollection(nullptr),
+      mSimTrackCollection(nullptr),
+      mSimVertexCollection(nullptr),
+      mGenParticleCollection(nullptr) {
+  input_ebrechits_token_ = iC.mayConsume<EBRecHitCollection>(edm::InputTag("ecalRecHit:EcalRecHitsEB"));
+  input_eerechits_token_ = iC.mayConsume<EERecHitCollection>(edm::InputTag("ecalRecHit:EcalRecHitsEE"));
+  input_hbherechits_token_ = iC.mayConsume<HBHERecHitCollection>(edm::InputTag("hbhereco"));
+  input_horechits_token_ = iC.mayConsume<HORecHitCollection>(edm::InputTag("horeco"));
+  input_hfrechits_token_ = iC.mayConsume<HFRecHitCollection>(edm::InputTag("hfreco"));
+  input_pcalohits_ebcal_token_ = iC.mayConsume<edm::PCaloHitContainer>(edm::InputTag("g4SimHits:EcalHitsEB"));
+  input_pcalohits_eecal_token_ = iC.mayConsume<edm::PCaloHitContainer>(edm::InputTag("g4SimHits:EcalHitsEE"));
+  input_pcalohits_hcal_token_ = iC.mayConsume<edm::PCaloHitContainer>(edm::InputTag("g4SimHits:HcalHits"));
+  input_simtrack_token_ = iC.mayConsume<edm::SimTrackContainer>(edm::InputTag("g4SimHits"));
+  input_simvertex_token_ = iC.mayConsume<edm::SimVertexContainer>(edm::InputTag("g4SimHits"));
+  input_cands_token_ = iC.mayConsume<reco::CandidateCollection>(edm::InputTag("genParticleCandidates"));
 }
 
-JetMatchingTools::JetMatchingTools (const edm::Event& fEvent, edm::ConsumesCollector&& iC )
-  : mEvent (&fEvent),
-    mEBRecHitCollection (nullptr),
-    mEERecHitCollection (nullptr),
-    mHBHERecHitCollection (nullptr),
-    mHORecHitCollection (nullptr),
-    mHFRecHitCollection (nullptr),
-    mEBSimHitCollection (nullptr),
-    mEESimHitCollection (nullptr),
-    mHcalSimHitCollection (nullptr),
-    mSimTrackCollection (nullptr),
-    mSimVertexCollection (nullptr),
-    mGenParticleCollection (nullptr)
-{
+JetMatchingTools::~JetMatchingTools() {}
 
-  input_ebrechits_token_ =	 iC.mayConsume<EBRecHitCollection>(edm::InputTag ("ecalRecHit:EcalRecHitsEB")); 
-  input_eerechits_token_ =	 iC.mayConsume<EERecHitCollection>(edm::InputTag ("ecalRecHit:EcalRecHitsEE"));       
-  input_hbherechits_token_ =	 iC.mayConsume<HBHERecHitCollection>(edm::InputTag ("hbhereco"));     
-  input_horechits_token_ =	 iC.mayConsume<HORecHitCollection>(edm::InputTag ("horeco"));       
-  input_hfrechits_token_ =	 iC.mayConsume<HFRecHitCollection>(edm::InputTag ("hfreco"));       
-  input_pcalohits_ebcal_token_ =  iC.mayConsume<edm::PCaloHitContainer>(edm::InputTag ("g4SimHits:EcalHitsEB"));  
-  input_pcalohits_eecal_token_ =  iC.mayConsume<edm::PCaloHitContainer>(edm::InputTag ("g4SimHits:EcalHitsEE"));    
-  input_pcalohits_hcal_token_ =  iC.mayConsume<edm::PCaloHitContainer>(edm::InputTag ("g4SimHits:HcalHits"));
-  input_simtrack_token_ =	 iC.mayConsume<edm::SimTrackContainer>(edm::InputTag ("g4SimHits"));   
-  input_simvertex_token_ =	 iC.mayConsume<edm::SimVertexContainer>(edm::InputTag ("g4SimHits"));  
-  input_cands_token_ =           iC.mayConsume<reco::CandidateCollection>(edm::InputTag ("genParticleCandidates"));
-
-}
-
-JetMatchingTools::~JetMatchingTools () {}
-
-const EBRecHitCollection* JetMatchingTools::getEBRecHitCollection () {
+const EBRecHitCollection* JetMatchingTools::getEBRecHitCollection() {
   if (!mEBRecHitCollection) {
     edm::Handle<EBRecHitCollection> recHits;
-    mEvent->getByToken (input_ebrechits_token_, recHits);
+    mEvent->getByToken(input_ebrechits_token_, recHits);
     mEBRecHitCollection = &*recHits;
   }
   return mEBRecHitCollection;
 }
-const EERecHitCollection* JetMatchingTools::getEERecHitCollection () {
+const EERecHitCollection* JetMatchingTools::getEERecHitCollection() {
   if (!mEERecHitCollection) {
     edm::Handle<EERecHitCollection> recHits;
-    mEvent->getByToken (input_eerechits_token_, recHits);
+    mEvent->getByToken(input_eerechits_token_, recHits);
     mEERecHitCollection = &*recHits;
   }
   return mEERecHitCollection;
 }
-const HBHERecHitCollection* JetMatchingTools::getHBHERecHitCollection () {
+const HBHERecHitCollection* JetMatchingTools::getHBHERecHitCollection() {
   if (!mHBHERecHitCollection) {
     edm::Handle<HBHERecHitCollection> recHits;
-    mEvent->getByToken (input_hbherechits_token_, recHits);
+    mEvent->getByToken(input_hbherechits_token_, recHits);
     mHBHERecHitCollection = &*recHits;
   }
   return mHBHERecHitCollection;
 }
-const HORecHitCollection* JetMatchingTools::getHORecHitCollection () {
+const HORecHitCollection* JetMatchingTools::getHORecHitCollection() {
   if (!mHORecHitCollection) {
     edm::Handle<HORecHitCollection> recHits;
-    mEvent->getByToken (input_horechits_token_, recHits);
+    mEvent->getByToken(input_horechits_token_, recHits);
     mHORecHitCollection = &*recHits;
   }
   return mHORecHitCollection;
 }
-const HFRecHitCollection* JetMatchingTools::getHFRecHitCollection () {
+const HFRecHitCollection* JetMatchingTools::getHFRecHitCollection() {
   if (!mHFRecHitCollection) {
     edm::Handle<HFRecHitCollection> recHits;
-    mEvent->getByToken (input_hfrechits_token_, recHits);
+    mEvent->getByToken(input_hfrechits_token_, recHits);
     mHFRecHitCollection = &*recHits;
   }
   return mHFRecHitCollection;
 }
-const PCaloHitContainer* JetMatchingTools::getEBSimHitCollection () {
+const PCaloHitContainer* JetMatchingTools::getEBSimHitCollection() {
   if (!mEBSimHitCollection) {
     edm::Handle<PCaloHitContainer> simHits;
-    mEvent->getByToken (input_pcalohits_ebcal_token_, simHits);
+    mEvent->getByToken(input_pcalohits_ebcal_token_, simHits);
     mEBSimHitCollection = &*simHits;
   }
   return mEBSimHitCollection;
 }
-const PCaloHitContainer* JetMatchingTools::getEESimHitCollection () {
+const PCaloHitContainer* JetMatchingTools::getEESimHitCollection() {
   if (!mEESimHitCollection) {
     edm::Handle<PCaloHitContainer> simHits;
-    mEvent->getByToken (input_pcalohits_eecal_token_, simHits);
+    mEvent->getByToken(input_pcalohits_eecal_token_, simHits);
     mEESimHitCollection = &*simHits;
   }
   return mEESimHitCollection;
 }
-const PCaloHitContainer* JetMatchingTools::getHcalSimHitCollection () {
+const PCaloHitContainer* JetMatchingTools::getHcalSimHitCollection() {
   if (!mHcalSimHitCollection) {
     edm::Handle<PCaloHitContainer> simHits;
-    mEvent->getByToken (input_pcalohits_hcal_token_, simHits);
+    mEvent->getByToken(input_pcalohits_hcal_token_, simHits);
     mHcalSimHitCollection = &*simHits;
   }
   return mHcalSimHitCollection;
 }
-const SimTrackContainer* JetMatchingTools::getSimTrackCollection () {
+const SimTrackContainer* JetMatchingTools::getSimTrackCollection() {
   if (!mSimTrackCollection) {
     edm::Handle<SimTrackContainer> simHits;
-    mEvent->getByToken (input_simtrack_token_, simHits);
+    mEvent->getByToken(input_simtrack_token_, simHits);
     mSimTrackCollection = &*simHits;
   }
   return mSimTrackCollection;
 }
-const SimVertexContainer* JetMatchingTools::getSimVertexCollection () {
+const SimVertexContainer* JetMatchingTools::getSimVertexCollection() {
   if (!mSimVertexCollection) {
     edm::Handle<SimVertexContainer> simHits;
-    mEvent->getByToken (input_simvertex_token_, simHits);
+    mEvent->getByToken(input_simvertex_token_, simHits);
     mSimVertexCollection = &*simHits;
   }
   return mSimVertexCollection;
 }
-const reco::CandidateCollection* JetMatchingTools::getGenParticlesCollection () {
+const reco::CandidateCollection* JetMatchingTools::getGenParticlesCollection() {
   if (!mGenParticleCollection) {
     edm::Handle<reco::CandidateCollection> handle;
-    mEvent->getByToken (input_cands_token_, handle);
+    mEvent->getByToken(input_cands_token_, handle);
     mGenParticleCollection = &*handle;
   }
   return mGenParticleCollection;
 }
 
-  /// get towers contributing to CaloJet
-std::vector <const CaloTower*> JetMatchingTools::getConstituents (const reco::CaloJet& fJet ) {
-  std::vector <const CaloTower*> result;
-  std::vector<CaloTowerPtr> constituents = fJet.getCaloConstituents ();
-  for (unsigned i = 0; i < constituents.size(); ++i) result.push_back (&*(constituents[i]));
+/// get towers contributing to CaloJet
+std::vector<const CaloTower*> JetMatchingTools::getConstituents(const reco::CaloJet& fJet) {
+  std::vector<const CaloTower*> result;
+  std::vector<CaloTowerPtr> constituents = fJet.getCaloConstituents();
+  for (unsigned i = 0; i < constituents.size(); ++i)
+    result.push_back(&*(constituents[i]));
   return result;
 }
 
 /// get CaloRecHits contributing to the tower
-std::vector<JetMatchingTools::JetConstituent> JetMatchingTools::getConstituentHits (const CaloTower& fTower) {
+std::vector<JetMatchingTools::JetConstituent> JetMatchingTools::getConstituentHits(const CaloTower& fTower) {
   std::vector<JetConstituent> result;
 
   for (unsigned i = 0; i < fTower.constituentsSize(); ++i) {
-    DetId id = fTower.constituent (i);
+    DetId id = fTower.constituent(i);
 
-    if (id.det () == DetId::Ecal) {
-      const EcalRecHit *hit = nullptr;
+    if (id.det() == DetId::Ecal) {
+      const EcalRecHit* hit = nullptr;
 
-      if ((EcalSubdetector) id.subdetId () == EcalBarrel) {
-        hit = getHit (*getEBRecHitCollection (), id);
-      } 
-      else if ((EcalSubdetector) id.subdetId () == EcalEndcap) {
-        hit = getHit (*getEERecHitCollection (), id);
+      if ((EcalSubdetector)id.subdetId() == EcalBarrel) {
+        hit = getHit(*getEBRecHitCollection(), id);
+      } else if ((EcalSubdetector)id.subdetId() == EcalEndcap) {
+        hit = getHit(*getEERecHitCollection(), id);
       }
 
       assert(hit != nullptr);
-      if (hit) result.push_back(JetConstituent(*hit));
-      else std::cerr << "Can not find rechit for id " << id.rawId () << std::endl;
-    } else if (id.det () == DetId::Hcal) {
+      if (hit)
+        result.push_back(JetConstituent(*hit));
+      else
+        std::cerr << "Can not find rechit for id " << id.rawId() << std::endl;
+    } else if (id.det() == DetId::Hcal) {
       const CaloRecHit* hit = nullptr;
 
-      if ((HcalSubdetector) id.subdetId () == HcalBarrel || (HcalSubdetector) id.subdetId () == HcalEndcap) {
-        hit = getHit (*getHBHERecHitCollection (), id);
+      if ((HcalSubdetector)id.subdetId() == HcalBarrel || (HcalSubdetector)id.subdetId() == HcalEndcap) {
+        hit = getHit(*getHBHERecHitCollection(), id);
+      } else if ((HcalSubdetector)id.subdetId() == HcalOuter) {
+        hit = getHit(*getHORecHitCollection(), id);
       }
-      else if ((HcalSubdetector) id.subdetId () == HcalOuter) {
-        hit = getHit (*getHORecHitCollection (), id);
-      }
-      if ((HcalSubdetector) id.subdetId () == HcalForward) {
-        hit = getHit (*getHFRecHitCollection (), id);
+      if ((HcalSubdetector)id.subdetId() == HcalForward) {
+        hit = getHit(*getHFRecHitCollection(), id);
       }
 
-      if (hit) result.push_back(JetConstituent(*hit));
-      else std::cerr << "Can not find rechit for id " << id.rawId () << std::endl;
+      if (hit)
+        result.push_back(JetConstituent(*hit));
+      else
+        std::cerr << "Can not find rechit for id " << id.rawId() << std::endl;
     }
   }
 
   return result;
 }
 
-  /// get cells contributing to the tower
-std::vector <DetId> JetMatchingTools::getConstituentIds (const CaloTower& fTower) {
-  std::vector <DetId> result;
+/// get cells contributing to the tower
+std::vector<DetId> JetMatchingTools::getConstituentIds(const CaloTower& fTower) {
+  std::vector<DetId> result;
   for (unsigned i = 0; i < fTower.constituentsSize(); ++i) {
-    DetId id = fTower.constituent (i);
-    result.push_back (id);
+    DetId id = fTower.constituent(i);
+    result.push_back(id);
   }
   return result;
 }
 /// get PCaloHits contributing to the detId
-std::vector <const PCaloHit*> JetMatchingTools::getPCaloHits (DetId fId) {
-  std::vector <const PCaloHit*> result;
-  if (fId.det () == DetId::Ecal) {
-    if ((EcalSubdetector) fId.subdetId () == EcalBarrel) {
-      result = getSimHits (*getEBSimHitCollection (), fId);
-    } 
-    else if ((EcalSubdetector) fId.subdetId () == EcalEndcap) {
-      result = getSimHits (*getEESimHitCollection (), fId);
+std::vector<const PCaloHit*> JetMatchingTools::getPCaloHits(DetId fId) {
+  std::vector<const PCaloHit*> result;
+  if (fId.det() == DetId::Ecal) {
+    if ((EcalSubdetector)fId.subdetId() == EcalBarrel) {
+      result = getSimHits(*getEBSimHitCollection(), fId);
+    } else if ((EcalSubdetector)fId.subdetId() == EcalEndcap) {
+      result = getSimHits(*getEESimHitCollection(), fId);
     }
-  }
-  else if (fId.det () == DetId::Hcal) {
-    result = getSimHits (*getHcalSimHitCollection (), fId);
+  } else if (fId.det() == DetId::Hcal) {
+    result = getSimHits(*getHcalSimHitCollection(), fId);
   }
   return result;
 }
-  /// GEANT track ID
-int JetMatchingTools::getTrackId (const PCaloHit& fHit) {
-  return fHit.geantTrackId ();
-}
+/// GEANT track ID
+int JetMatchingTools::getTrackId(const PCaloHit& fHit) { return fHit.geantTrackId(); }
 /// convert trackId to SimTrack
-const SimTrack* JetMatchingTools::getTrack (unsigned fSimTrackId) {
-  for (unsigned i = 0; i < getSimTrackCollection ()->size (); ++i) {
-    if ((*getSimTrackCollection ())[i].trackId() == fSimTrackId) return &(*getSimTrackCollection ())[i];
+const SimTrack* JetMatchingTools::getTrack(unsigned fSimTrackId) {
+  for (unsigned i = 0; i < getSimTrackCollection()->size(); ++i) {
+    if ((*getSimTrackCollection())[i].trackId() == fSimTrackId)
+      return &(*getSimTrackCollection())[i];
   }
   return nullptr;
 }
-  /// Generator ID
-int JetMatchingTools::generatorId (unsigned fSimTrackId) {
-  const SimTrack* track = getTrack (fSimTrackId);
-  if (!track) return -1;
-  while (track->noGenpart ()) {
-    if (track->noVertex ()) {
+/// Generator ID
+int JetMatchingTools::generatorId(unsigned fSimTrackId) {
+  const SimTrack* track = getTrack(fSimTrackId);
+  if (!track)
+    return -1;
+  while (track->noGenpart()) {
+    if (track->noVertex()) {
       std::cerr << "JetMatchingTools::generatorId-> No vertex for track " << *track << std::endl;
       return -1;
     }
-    const SimVertex* vertex = &((*getSimVertexCollection ())[track->vertIndex ()]);
+    const SimVertex* vertex = &((*getSimVertexCollection())[track->vertIndex()]);
     if (vertex->noParent()) {
       std::cerr << "JetMatchingTools::generatorId-> No track for vertex " << *vertex << std::endl;
       return -1;
     }
-    track = getTrack (vertex->parentIndex ());
+    track = getTrack(vertex->parentIndex());
   }
-  return track->genpartIndex ();
+  return track->genpartIndex();
 }
 
-  /// GenParticle
-const reco::GenParticle* JetMatchingTools::getGenParticle (int fGeneratorId) {
-  if (fGeneratorId > int (getGenParticlesCollection ()->size())) {
-    std::cerr << "JetMatchingTools::getGenParticle-> requested index " << fGeneratorId << " is grater then container size " << getGenParticlesCollection ()->size() << std::endl;
+/// GenParticle
+const reco::GenParticle* JetMatchingTools::getGenParticle(int fGeneratorId) {
+  if (fGeneratorId > int(getGenParticlesCollection()->size())) {
+    std::cerr << "JetMatchingTools::getGenParticle-> requested index " << fGeneratorId
+              << " is grater then container size " << getGenParticlesCollection()->size() << std::endl;
     return nullptr;
   }
-  return reco::GenJet::genParticle ( &(*getGenParticlesCollection ())[fGeneratorId-1]); // knowhow: index is shifted by 1
+  return reco::GenJet::genParticle(
+      &(*getGenParticlesCollection())[fGeneratorId - 1]);  // knowhow: index is shifted by 1
 }
 
 /// GenParticles for CaloJet
-std::vector <const reco::GenParticle*> JetMatchingTools::getGenParticles (const reco::CaloJet& fJet, bool fVerbose) {
-  std::set <const reco::GenParticle*> result;
+std::vector<const reco::GenParticle*> JetMatchingTools::getGenParticles(const reco::CaloJet& fJet, bool fVerbose) {
+  std::set<const reco::GenParticle*> result;
   // follow the chain
-  std::vector <const CaloTower*> towers = getConstituents (fJet) ;
-  for (unsigned itower = 0; itower < towers.size (); ++itower) {
-    std::vector <DetId> detids = getConstituentIds (*(towers[itower])) ;
+  std::vector<const CaloTower*> towers = getConstituents(fJet);
+  for (unsigned itower = 0; itower < towers.size(); ++itower) {
+    std::vector<DetId> detids = getConstituentIds(*(towers[itower]));
     for (unsigned iid = 0; iid < detids.size(); ++iid) {
-      std::vector <const PCaloHit*> phits = getPCaloHits (detids[iid]);
+      std::vector<const PCaloHit*> phits = getPCaloHits(detids[iid]);
       for (unsigned iphit = 0; iphit < phits.size(); ++iphit) {
-        int trackId = getTrackId (*(phits[iphit]));
+        int trackId = getTrackId(*(phits[iphit]));
         if (trackId >= 0) {
-          int genId = generatorId (trackId);
+          int genId = generatorId(trackId);
           if (genId >= 0) {
-            const reco::GenParticle* genPart = getGenParticle (genId);
+            const reco::GenParticle* genPart = getGenParticle(genId);
             if (genPart) {
-              result.insert (genPart);
+              result.insert(genPart);
+            } else if (fVerbose) {
+              std::cerr << "JetMatchingTools::getGenParticles-> Can not convert genId " << genId << " to GenParticle"
+                        << std::endl;
             }
-            else if (fVerbose) {
-              std::cerr << "JetMatchingTools::getGenParticles-> Can not convert genId " << genId << " to GenParticle" << std::endl;
-            }
+          } else if (fVerbose) {
+            std::cerr << "JetMatchingTools::getGenParticles-> Can not convert trackId " << trackId << " to genId"
+                      << std::endl;
           }
-          else if (fVerbose) {
-            std::cerr << "JetMatchingTools::getGenParticles-> Can not convert trackId " << trackId << " to genId" << std::endl;
-          }
-        }
-        else if (fVerbose) {
-          std::cerr << "JetMatchingTools::getGenParticles-> Unknown trackId for PCaloHit " << *(phits[iphit]) << std::endl;
+        } else if (fVerbose) {
+          std::cerr << "JetMatchingTools::getGenParticles-> Unknown trackId for PCaloHit " << *(phits[iphit])
+                    << std::endl;
         }
       }
     }
   }
-  return std::vector <const reco::GenParticle*> (result.begin (), result.end());
+  return std::vector<const reco::GenParticle*>(result.begin(), result.end());
 }
 
 /// GenParticles for GenJet
-std::vector <const reco::GenParticle*> JetMatchingTools::getGenParticles (const reco::GenJet& fJet) {
-  return fJet.getGenConstituents ();
+std::vector<const reco::GenParticle*> JetMatchingTools::getGenParticles(const reco::GenJet& fJet) {
+  return fJet.getGenConstituents();
 }
 
-  /// energy in broken links
-double JetMatchingTools::lostEnergyFraction (const reco::CaloJet& fJet ) {
+/// energy in broken links
+double JetMatchingTools::lostEnergyFraction(const reco::CaloJet& fJet) {
   double totalEnergy = 0;
   double lostEnergy = 0;
   // follow the chain
-  std::vector <const CaloTower*> towers = getConstituents (fJet) ;
-  for (unsigned itower = 0; itower < towers.size (); ++itower) {
+  std::vector<const CaloTower*> towers = getConstituents(fJet);
+  for (unsigned itower = 0; itower < towers.size(); ++itower) {
     std::vector<JetConstituent> recHits = getConstituentHits(*(towers[itower]));
     for (unsigned ihit = 0; ihit < recHits.size(); ++ihit) {
       double foundSimEnergy = 0;
       double lostSimEnergy = 0;
-      std::vector <const PCaloHit*> phits = getPCaloHits (recHits[ihit].id);
+      std::vector<const PCaloHit*> phits = getPCaloHits(recHits[ihit].id);
       for (unsigned iphit = 0; iphit < phits.size(); ++iphit) {
-        double simEnergy = phits[iphit]->energy ();
-        int trackId = getTrackId (*(phits[iphit]));
-        if (trackId < 0 || generatorId (trackId) < 0)   lostSimEnergy += simEnergy;
-        else   foundSimEnergy += simEnergy;
+        double simEnergy = phits[iphit]->energy();
+        int trackId = getTrackId(*(phits[iphit]));
+        if (trackId < 0 || generatorId(trackId) < 0)
+          lostSimEnergy += simEnergy;
+        else
+          foundSimEnergy += simEnergy;
       }
       if (foundSimEnergy > 0 || lostSimEnergy > 0) {
         totalEnergy += recHits[ihit].energy;
@@ -333,15 +336,17 @@ double JetMatchingTools::lostEnergyFraction (const reco::CaloJet& fJet ) {
   return lostEnergy / totalEnergy;
 }
 
-  /// energy overlap
-double JetMatchingTools::overlapEnergyFraction (const std::vector <const reco::GenParticle*>& fObject, 
-                                                const std::vector <const reco::GenParticle*>& fReference) const {
-  if (fObject.empty()) return 0;
+/// energy overlap
+double JetMatchingTools::overlapEnergyFraction(const std::vector<const reco::GenParticle*>& fObject,
+                                               const std::vector<const reco::GenParticle*>& fReference) const {
+  if (fObject.empty())
+    return 0;
   double totalEnergy = 0;
   double overlapEnergy = 0;
   for (unsigned i = 0; i < fObject.size(); ++i) {
-    totalEnergy += fObject [i]->energy();
-    if (find (fReference.begin(), fReference.end(), fObject [i]) != fReference.end ()) overlapEnergy += fObject [i]->energy();
+    totalEnergy += fObject[i]->energy();
+    if (find(fReference.begin(), fReference.end(), fObject[i]) != fReference.end())
+      overlapEnergy += fObject[i]->energy();
   }
   return overlapEnergy / totalEnergy;
 }

--- a/RecoJets/JetProducers/src/JetMuonHitsIDHelper.cc
+++ b/RecoJets/JetProducers/src/JetMuonHitsIDHelper.cc
@@ -29,10 +29,8 @@
 
 using namespace std;
 
-
-reco::helper::JetMuonHitsIDHelper::JetMuonHitsIDHelper( edm::ParameterSet const & pset, edm::ConsumesCollector&& iC )
-{
-  isRECO_ = true; // This will be "true" initially, then if the product isn't found, set to false once
+reco::helper::JetMuonHitsIDHelper::JetMuonHitsIDHelper(edm::ParameterSet const& pset, edm::ConsumesCollector&& iC) {
+  isRECO_ = true;  // This will be "true" initially, then if the product isn't found, set to false once
   numberOfHits1RPC_ = 0;
   numberOfHits2RPC_ = 0;
   numberOfHits3RPC_ = 0;
@@ -41,16 +39,12 @@ reco::helper::JetMuonHitsIDHelper::JetMuonHitsIDHelper( edm::ParameterSet const 
   rpcRecHits_ = pset.getParameter<edm::InputTag>("rpcRecHits");
 
   input_rpchits_token_ = iC.consumes<RPCRecHitCollection>(rpcRecHits_);
- 
 }
 
-
-
-
-void reco::helper::JetMuonHitsIDHelper::calculate( const edm::Event& event, const edm::EventSetup & iSetup, 
-						   const reco::Jet &jet, const int iDbg )
-{
-
+void reco::helper::JetMuonHitsIDHelper::calculate(const edm::Event& event,
+                                                  const edm::EventSetup& iSetup,
+                                                  const reco::Jet& jet,
+                                                  const int iDbg) {
   // initialize
   numberOfHits1RPC_ = 0;
   numberOfHits2RPC_ = 0;
@@ -58,20 +52,18 @@ void reco::helper::JetMuonHitsIDHelper::calculate( const edm::Event& event, cons
   numberOfHits4RPC_ = 0;
   numberOfHitsRPC_ = 0;
 
-
-  if ( isRECO_ ) { // This will be "true" initially, then if the product isn't found, set to false once
+  if (isRECO_) {  // This will be "true" initially, then if the product isn't found, set to false once
 
     // Get tracking geometry
     edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
-    iSetup.get<GlobalTrackingGeometryRecord> ().get(trackingGeometry);
-    
+    iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+
     //####READ RPC RecHits Collection########
     //#In config: RpcRecHits     = cms.InputTag("rpcRecHits")
     edm::Handle<RPCRecHitCollection> rpcRecHits_handle;
     event.getByToken(input_rpchits_token_, rpcRecHits_handle);
 
-
-    if ( ! rpcRecHits_handle.isValid()  ) {
+    if (!rpcRecHits_handle.isValid()) {
       // don't throw exception if not running on RECO
       edm::LogWarning("DataNotAvailable") << "JetMuonHitsIDHelper will not be run at all, this is not a RECO file.";
       isRECO_ = false;
@@ -79,28 +71,27 @@ void reco::helper::JetMuonHitsIDHelper::calculate( const edm::Event& event, cons
     }
 
     //####calculate rpc  variables for each jet########
-    
-    for (  RPCRecHitCollection::const_iterator itRPC = rpcRecHits_handle->begin(),
-	     itRPCEnd = rpcRecHits_handle->end();
-	   itRPC != itRPCEnd; ++itRPC) {
-      RPCRecHit const & hit = *itRPC;
+
+    for (RPCRecHitCollection::const_iterator itRPC = rpcRecHits_handle->begin(), itRPCEnd = rpcRecHits_handle->end();
+         itRPC != itRPCEnd;
+         ++itRPC) {
+      RPCRecHit const& hit = *itRPC;
       DetId detid = hit.geographicalId();
       LocalPoint lp = hit.localPosition();
       const GeomDet* gd = trackingGeometry->idToDet(detid);
       GlobalPoint gp = gd->toGlobal(lp);
-      double dR2 = reco::deltaR(jet.eta(), jet.phi(), 
-				static_cast<double>( gp.eta() ), static_cast<double>(gp.phi()) );
+      double dR2 = reco::deltaR(jet.eta(), jet.phi(), static_cast<double>(gp.eta()), static_cast<double>(gp.phi()));
       if (dR2 < 0.5) {
-	RPCDetId rpcChamberId = (RPCDetId) detid;
-	numberOfHitsRPC_++;
-	if (rpcChamberId.station() == 1)
-	  numberOfHits1RPC_++;
-	if (rpcChamberId.station() == 2)
-	  numberOfHits2RPC_++;
-	if (rpcChamberId.station() == 3)
-	  numberOfHits3RPC_++;
-	if (rpcChamberId.station() == 4)
-	  numberOfHits4RPC_++;
+        RPCDetId rpcChamberId = (RPCDetId)detid;
+        numberOfHitsRPC_++;
+        if (rpcChamberId.station() == 1)
+          numberOfHits1RPC_++;
+        if (rpcChamberId.station() == 2)
+          numberOfHits2RPC_++;
+        if (rpcChamberId.station() == 3)
+          numberOfHits3RPC_++;
+        if (rpcChamberId.station() == 4)
+          numberOfHits4RPC_++;
       }
     }
   }

--- a/RecoJets/JetProducers/src/JetSpecific.cc
+++ b/RecoJets/JetProducers/src/JetSpecific.cc
@@ -5,9 +5,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
-
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
@@ -25,118 +23,104 @@
 
 #include <cmath>
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of global functions
 ////////////////////////////////////////////////////////////////////////////////
 
-//______________________________________________________________________________    
+//______________________________________________________________________________
 // Overloaded methods to write out specific types
 
-
 // CaloJet
-void reco::writeSpecific(reco::CaloJet & jet,
-			 reco::Particle::LorentzVector const & p4,
-			 reco::Particle::Point const & point, 
-			 std::vector<reco::CandidatePtr> const & constituents,
-			 edm::EventSetup const & c  )
-{
+void reco::writeSpecific(reco::CaloJet& jet,
+                         reco::Particle::LorentzVector const& p4,
+                         reco::Particle::Point const& point,
+                         std::vector<reco::CandidatePtr> const& constituents,
+                         edm::EventSetup const& c) {
   // Get geometry
   edm::ESHandle<CaloGeometry> geometry;
   c.get<CaloGeometryRecord>().get(geometry);
-  const CaloSubdetectorGeometry* towerGeometry = 
-    geometry->getSubdetectorGeometry(DetId::Calo, CaloTowerDetId::SubdetId);
+  const CaloSubdetectorGeometry* towerGeometry =
+      geometry->getSubdetectorGeometry(DetId::Calo, CaloTowerDetId::SubdetId);
 
   edm::ESHandle<HcalTopology> topology;
   c.get<HcalRecNumberingRecord>().get(topology);
 
   // Make the specific
   reco::CaloJet::Specific specific;
-  makeSpecific (constituents, towerGeometry, &specific, *topology);
+  makeSpecific(constituents, towerGeometry, &specific, *topology);
   // Set the calo jet
-  jet = reco::CaloJet( p4, point, specific, constituents);  
+  jet = reco::CaloJet(p4, point, specific, constituents);
 }
-  
 
-    
 // BasicJet
-void reco::writeSpecific(reco::BasicJet  & jet,
-			 reco::Particle::LorentzVector const & p4,
-			 reco::Particle::Point const & point, 
-			 std::vector<reco::CandidatePtr> const & constituents,
-			 edm::EventSetup const & c  )
-{
-  jet = reco::BasicJet( p4, point, constituents);  
+void reco::writeSpecific(reco::BasicJet& jet,
+                         reco::Particle::LorentzVector const& p4,
+                         reco::Particle::Point const& point,
+                         std::vector<reco::CandidatePtr> const& constituents,
+                         edm::EventSetup const& c) {
+  jet = reco::BasicJet(p4, point, constituents);
 }
-    
-// GenJet
-void reco::writeSpecific(reco::GenJet  & jet,
-			 reco::Particle::LorentzVector const & p4,
-			 reco::Particle::Point const & point, 
-			 std::vector<reco::CandidatePtr> const & constituents,
-			 edm::EventSetup const & c  )
-{
 
+// GenJet
+void reco::writeSpecific(reco::GenJet& jet,
+                         reco::Particle::LorentzVector const& p4,
+                         reco::Particle::Point const& point,
+                         std::vector<reco::CandidatePtr> const& constituents,
+                         edm::EventSetup const& c) {
   // Make the specific
   reco::GenJet::Specific specific;
-  makeSpecific (constituents, &specific);
+  makeSpecific(constituents, &specific);
   // Set to the jet
-  jet = reco::GenJet( p4, point, specific, constituents);  
+  jet = reco::GenJet(p4, point, specific, constituents);
 }
-    
+
 // PFJet
-void reco::writeSpecific(reco::PFJet  & jet,
-			 reco::Particle::LorentzVector const & p4,
-			 reco::Particle::Point const & point, 
-			 std::vector<reco::CandidatePtr> const & constituents,
-			 edm::EventSetup const & c  )
-{
+void reco::writeSpecific(reco::PFJet& jet,
+                         reco::Particle::LorentzVector const& p4,
+                         reco::Particle::Point const& point,
+                         std::vector<reco::CandidatePtr> const& constituents,
+                         edm::EventSetup const& c) {
   // Make the specific
   reco::PFJet::Specific specific;
-  makeSpecific (constituents, &specific);
+  makeSpecific(constituents, &specific);
   // now make jet charge
   int charge = 0.;
-  for ( std::vector<reco::CandidatePtr>::const_iterator ic = constituents.begin(),
-	  icend = constituents.end();
-	ic != icend; ++ic ) {
+  for (std::vector<reco::CandidatePtr>::const_iterator ic = constituents.begin(), icend = constituents.end();
+       ic != icend;
+       ++ic) {
     charge += (*ic)->charge();
   }
-  jet = reco::PFJet( p4, point, specific, constituents);  
-  jet.setCharge( charge );
+  jet = reco::PFJet(p4, point, specific, constituents);
+  jet.setCharge(charge);
 }
-    
 
 // TrackJet
-void reco::writeSpecific(reco::TrackJet & jet,
-			 reco::Particle::LorentzVector const & p4,
-			 reco::Particle::Point const & point, 
-			 std::vector<reco::CandidatePtr> const & constituents,
-			 edm::EventSetup const & c  )
-{
-  jet = reco::TrackJet(p4, point, constituents);  
+void reco::writeSpecific(reco::TrackJet& jet,
+                         reco::Particle::LorentzVector const& p4,
+                         reco::Particle::Point const& point,
+                         std::vector<reco::CandidatePtr> const& constituents,
+                         edm::EventSetup const& c) {
+  jet = reco::TrackJet(p4, point, constituents);
 }
-    
-// PFClusterJet
-void reco::writeSpecific(reco::PFClusterJet & jet,
-			 reco::Particle::LorentzVector const & p4,
-			 reco::Particle::Point const & point, 
-			 std::vector<reco::CandidatePtr> const & constituents,
-			 edm::EventSetup const & c  )
-{
-  jet = reco::PFClusterJet( p4, point, constituents);  
-}
-  
 
+// PFClusterJet
+void reco::writeSpecific(reco::PFClusterJet& jet,
+                         reco::Particle::LorentzVector const& p4,
+                         reco::Particle::Point const& point,
+                         std::vector<reco::CandidatePtr> const& constituents,
+                         edm::EventSetup const& c) {
+  jet = reco::PFClusterJet(p4, point, constituents);
+}
 
 //______________________________________________________________________________
-bool reco::makeSpecific(std::vector<reco::CandidatePtr> const & towers,
-			const CaloSubdetectorGeometry* towerGeometry,
-			CaloJet::Specific* caloJetSpecific,
-			const HcalTopology &topology)
-{
-  if (nullptr==caloJetSpecific) return false;
+bool reco::makeSpecific(std::vector<reco::CandidatePtr> const& towers,
+                        const CaloSubdetectorGeometry* towerGeometry,
+                        CaloJet::Specific* caloJetSpecific,
+                        const HcalTopology& topology) {
+  if (nullptr == caloJetSpecific)
+    return false;
 
-  // 1.- Loop over the tower Ids, 
+  // 1.- Loop over the tower Ids,
   // 2.- Get the corresponding CaloTower
   // 3.- Calculate the different CaloJet specific quantities
   std::vector<double> eECal_i;
@@ -151,10 +135,10 @@ bool reco::makeSpecific(std::vector<reco::CandidatePtr> const & towers,
   double eInEB = 0.;
   double eInEE = 0.;
   double jetArea = 0.;
-  
+
   std::vector<reco::CandidatePtr>::const_iterator itTower;
-  for (itTower=towers.begin();itTower!=towers.end();++itTower) {
-    if ( itTower->isNull() || !itTower->isAvailable() ) { 
+  for (itTower = towers.begin(); itTower != towers.end(); ++itTower) {
+    if (itTower->isNull() || !itTower->isAvailable()) {
       edm::LogWarning("DataNotFound") << " JetSpecific: Tower is invalid\n";
       continue;
     }
@@ -164,40 +148,38 @@ bool reco::makeSpecific(std::vector<reco::CandidatePtr> const & towers,
       eECal_i.push_back(tower->emEnergy());
       eInEm += tower->emEnergy();
       //Array of energy in HCAL Towers:
-      eHCal_i.push_back(tower->hadEnergy()); 
+      eHCal_i.push_back(tower->hadEnergy());
       eInHad += tower->hadEnergy();
-      
+
       //  figure out contributions
-      switch (reco::hcalSubdetector(tower->id().ieta(),topology)) {
-      case HcalBarrel:
-	eInHB += tower->hadEnergy(); 
-	eInHO += tower->outerEnergy();
-	eInEB += tower->emEnergy();
-	break;
-      case HcalEndcap:
-	eInHE += tower->hadEnergy();
-	eInEE += tower->emEnergy();
-	break;
-      case HcalForward:
-	eHadInHF += tower->hadEnergy();
-	eEmInHF += tower->emEnergy();
-	break;
-      default:
-	break;
+      switch (reco::hcalSubdetector(tower->id().ieta(), topology)) {
+        case HcalBarrel:
+          eInHB += tower->hadEnergy();
+          eInHO += tower->outerEnergy();
+          eInEB += tower->emEnergy();
+          break;
+        case HcalEndcap:
+          eInHE += tower->hadEnergy();
+          eInEE += tower->emEnergy();
+          break;
+        case HcalForward:
+          eHadInHF += tower->hadEnergy();
+          eEmInHF += tower->emEnergy();
+          break;
+        default:
+          break;
       }
       // get area of the tower (++ minus --)
       auto geometry = towerGeometry->getGeometry(tower->id());
       if (geometry) {
-	jetArea += geometry->etaSpan() * geometry->phiSpan();
+        jetArea += geometry->etaSpan() * geometry->phiSpan();
+      } else {
+        edm::LogWarning("DataNotFound") << "reco::makeCaloJetSpecific: Geometry for cell " << tower->id()
+                                        << " can not be found. Ignoring cell\n";
       }
-      else {
-	edm::LogWarning("DataNotFound") <<"reco::makeCaloJetSpecific: Geometry for cell "
-					<<tower->id()<<" can not be found. Ignoring cell\n";
-      }
-    }
-    else {
-      edm::LogWarning("DataNotFound")<<"reco::makeCaloJetSpecific: Constituent is not of "
-				     <<"CaloTower type\n";
+    } else {
+      edm::LogWarning("DataNotFound") << "reco::makeCaloJetSpecific: Constituent is not of "
+                                      << "CaloTower type\n";
     }
   }
 
@@ -212,262 +194,251 @@ bool reco::makeSpecific(std::vector<reco::CandidatePtr> const & towers,
   if (towerEnergy > 0) {
     caloJetSpecific->mEnergyFractionHadronic = eInHad / towerEnergy;
     caloJetSpecific->mEnergyFractionEm = eInEm / towerEnergy;
-  }
-  else { // HO only jet
+  } else {  // HO only jet
     caloJetSpecific->mEnergyFractionHadronic = 1.;
     caloJetSpecific->mEnergyFractionEm = 0.;
   }
   caloJetSpecific->mTowersArea = jetArea;
   caloJetSpecific->mMaxEInEmTowers = 0;
   caloJetSpecific->mMaxEInHadTowers = 0;
-  
+
   //Sort the arrays
   sort(eECal_i.begin(), eECal_i.end(), std::greater<double>());
   sort(eHCal_i.begin(), eHCal_i.end(), std::greater<double>());
-  
+
   if (!towers.empty()) {
     //Highest value in the array is the first element of the array
-    caloJetSpecific->mMaxEInEmTowers  = eECal_i.front(); 
+    caloJetSpecific->mMaxEInEmTowers = eECal_i.front();
     caloJetSpecific->mMaxEInHadTowers = eHCal_i.front();
   }
-  
+
   return true;
 }
 
-
 //______________________________________________________________________________
-bool reco::makeSpecific(std::vector<reco::CandidatePtr> const & particles,	   
-			PFJet::Specific* pfJetSpecific)
-{
-  if (nullptr==pfJetSpecific) return false;
-  
-  // 1.- Loop over PFCandidates, 
+bool reco::makeSpecific(std::vector<reco::CandidatePtr> const& particles, PFJet::Specific* pfJetSpecific) {
+  if (nullptr == pfJetSpecific)
+    return false;
+
+  // 1.- Loop over PFCandidates,
   // 2.- Get the corresponding PFCandidate
   // 3.- Calculate the different PFJet specific quantities
-  
-  float chargedHadronEnergy=0.;
-  float neutralHadronEnergy=0.;
-  float photonEnergy=0.;
-  float electronEnergy=0.;
-  float muonEnergy=0.;
-  float HFHadronEnergy=0.;
-  float HFEMEnergy=0.;
-  int   chargedHadronMultiplicity=0;
-  int   neutralHadronMultiplicity=0;
-  int   photonMultiplicity=0;
-  int   electronMultiplicity=0;
-  int   muonMultiplicity=0;
-  int   HFHadronMultiplicity=0;
-  int   HFEMMultiplicity=0;
 
-  float chargedEmEnergy=0.;
-  float neutralEmEnergy=0.;
-  float chargedMuEnergy=0.;
-  int   chargedMultiplicity=0;
-  int   neutralMultiplicity=0;
+  float chargedHadronEnergy = 0.;
+  float neutralHadronEnergy = 0.;
+  float photonEnergy = 0.;
+  float electronEnergy = 0.;
+  float muonEnergy = 0.;
+  float HFHadronEnergy = 0.;
+  float HFEMEnergy = 0.;
+  int chargedHadronMultiplicity = 0;
+  int neutralHadronMultiplicity = 0;
+  int photonMultiplicity = 0;
+  int electronMultiplicity = 0;
+  int muonMultiplicity = 0;
+  int HFHadronMultiplicity = 0;
+  int HFEMMultiplicity = 0;
 
-  float HOEnergy=0.;
-  
+  float chargedEmEnergy = 0.;
+  float neutralEmEnergy = 0.;
+  float chargedMuEnergy = 0.;
+  int chargedMultiplicity = 0;
+  int neutralMultiplicity = 0;
+
+  float HOEnergy = 0.;
+
   std::vector<reco::CandidatePtr>::const_iterator itParticle;
-  for (itParticle=particles.begin();itParticle!=particles.end();++itParticle){
-    if ( itParticle->isNull() || !itParticle->isAvailable() ) { 
+  for (itParticle = particles.begin(); itParticle != particles.end(); ++itParticle) {
+    if (itParticle->isNull() || !itParticle->isAvailable()) {
       edm::LogWarning("DataNotFound") << " JetSpecific: PF Particle is invalid\n";
       continue;
-    }    
+    }
     const Candidate* pfCand = itParticle->get();
     if (pfCand) {
-
       const PFCandidate* pfCandCast = dynamic_cast<const PFCandidate*>(pfCand);
       if (pfCandCast)
         HOEnergy += pfCandCast->hoEnergy();
 
       switch (std::abs(pfCand->pdgId())) {
-      case 211: //PFCandidate::h:       // charged hadron
-	chargedHadronEnergy += pfCand->energy();
-	chargedHadronMultiplicity++;
-	chargedMultiplicity++;
-	break;
+        case 211:  //PFCandidate::h:       // charged hadron
+          chargedHadronEnergy += pfCand->energy();
+          chargedHadronMultiplicity++;
+          chargedMultiplicity++;
+          break;
 
-      case 130: //PFCandidate::h0 :    // neutral hadron
-	neutralHadronEnergy += pfCand->energy();
-	neutralHadronMultiplicity++;
-	neutralMultiplicity++;
-      break;
+        case 130:  //PFCandidate::h0 :    // neutral hadron
+          neutralHadronEnergy += pfCand->energy();
+          neutralHadronMultiplicity++;
+          neutralMultiplicity++;
+          break;
 
-      case 22: //PFCandidate::gamma:   // photon
-	photonEnergy += pfCand->energy();
-	photonMultiplicity++;
-	neutralEmEnergy += pfCand->energy();
-	neutralMultiplicity++;
-      break;
+        case 22:  //PFCandidate::gamma:   // photon
+          photonEnergy += pfCand->energy();
+          photonMultiplicity++;
+          neutralEmEnergy += pfCand->energy();
+          neutralMultiplicity++;
+          break;
 
-      case 11: // PFCandidate::e:       // electron 
-	electronEnergy += pfCand->energy();
-	electronMultiplicity++;
-	chargedEmEnergy += pfCand->energy(); 
-	chargedMultiplicity++;
-	break;
+        case 11:  // PFCandidate::e:       // electron
+          electronEnergy += pfCand->energy();
+          electronMultiplicity++;
+          chargedEmEnergy += pfCand->energy();
+          chargedMultiplicity++;
+          break;
 
-      case 13: //PFCandidate::mu:      // muon
-	muonEnergy += pfCand->energy();
-	muonMultiplicity++;
-	chargedMuEnergy += pfCand->energy();
-	chargedMultiplicity++;
-	break;
+        case 13:  //PFCandidate::mu:      // muon
+          muonEnergy += pfCand->energy();
+          muonMultiplicity++;
+          chargedMuEnergy += pfCand->energy();
+          chargedMultiplicity++;
+          break;
 
-      case 1: // PFCandidate::h_HF :    // hadron in HF
-	HFHadronEnergy += pfCand->energy();
-	HFHadronMultiplicity++;
-	neutralHadronEnergy += pfCand->energy();
-	neutralMultiplicity++;
-	break;
+        case 1:  // PFCandidate::h_HF :    // hadron in HF
+          HFHadronEnergy += pfCand->energy();
+          HFHadronMultiplicity++;
+          neutralHadronEnergy += pfCand->energy();
+          neutralMultiplicity++;
+          break;
 
-      case 2: //PFCandidate::egamma_HF :    // electromagnetic in HF
-	HFEMEnergy += pfCand->energy();
-	HFEMMultiplicity++;
-	neutralEmEnergy += pfCand->energy();
-	neutralMultiplicity++;
-	break;
-	
+        case 2:  //PFCandidate::egamma_HF :    // electromagnetic in HF
+          HFEMEnergy += pfCand->energy();
+          HFEMMultiplicity++;
+          neutralEmEnergy += pfCand->energy();
+          neutralMultiplicity++;
+          break;
 
-      default:
-	edm::LogWarning("DataNotFound") <<"reco::makePFJetSpecific: Unknown PFCandidate::ParticleType: "
-					<<pfCand->pdgId()<<" is ignored\n";
-	break;
+        default:
+          edm::LogWarning("DataNotFound")
+              << "reco::makePFJetSpecific: Unknown PFCandidate::ParticleType: " << pfCand->pdgId() << " is ignored\n";
+          break;
       }
-    }
-    else {
-      edm::LogWarning("DataNotFound") <<"reco::makePFJetSpecific: Referred constituent is not "
-				      <<"a PFCandidate\n";
+    } else {
+      edm::LogWarning("DataNotFound") << "reco::makePFJetSpecific: Referred constituent is not "
+                                      << "a PFCandidate\n";
     }
   }
-  
-  pfJetSpecific->mChargedHadronEnergy=chargedHadronEnergy;
-  pfJetSpecific->mNeutralHadronEnergy= neutralHadronEnergy;
-  pfJetSpecific->mPhotonEnergy= photonEnergy;
-  pfJetSpecific->mElectronEnergy= electronEnergy;
-  pfJetSpecific->mMuonEnergy= muonEnergy;
-  pfJetSpecific->mHFHadronEnergy= HFHadronEnergy;
-  pfJetSpecific->mHFEMEnergy= HFEMEnergy;
 
-  pfJetSpecific->mChargedHadronMultiplicity=chargedHadronMultiplicity;
-  pfJetSpecific->mNeutralHadronMultiplicity= neutralHadronMultiplicity;
-  pfJetSpecific->mPhotonMultiplicity= photonMultiplicity;
-  pfJetSpecific->mElectronMultiplicity= electronMultiplicity;
-  pfJetSpecific->mMuonMultiplicity= muonMultiplicity;
-  pfJetSpecific->mHFHadronMultiplicity= HFHadronMultiplicity;
-  pfJetSpecific->mHFEMMultiplicity= HFEMMultiplicity;
+  pfJetSpecific->mChargedHadronEnergy = chargedHadronEnergy;
+  pfJetSpecific->mNeutralHadronEnergy = neutralHadronEnergy;
+  pfJetSpecific->mPhotonEnergy = photonEnergy;
+  pfJetSpecific->mElectronEnergy = electronEnergy;
+  pfJetSpecific->mMuonEnergy = muonEnergy;
+  pfJetSpecific->mHFHadronEnergy = HFHadronEnergy;
+  pfJetSpecific->mHFEMEnergy = HFEMEnergy;
 
-  pfJetSpecific->mChargedEmEnergy=chargedEmEnergy;
-  pfJetSpecific->mChargedMuEnergy=chargedMuEnergy;
-  pfJetSpecific->mNeutralEmEnergy=neutralEmEnergy;
-  pfJetSpecific->mChargedMultiplicity=chargedMultiplicity;
-  pfJetSpecific->mNeutralMultiplicity=neutralMultiplicity;
+  pfJetSpecific->mChargedHadronMultiplicity = chargedHadronMultiplicity;
+  pfJetSpecific->mNeutralHadronMultiplicity = neutralHadronMultiplicity;
+  pfJetSpecific->mPhotonMultiplicity = photonMultiplicity;
+  pfJetSpecific->mElectronMultiplicity = electronMultiplicity;
+  pfJetSpecific->mMuonMultiplicity = muonMultiplicity;
+  pfJetSpecific->mHFHadronMultiplicity = HFHadronMultiplicity;
+  pfJetSpecific->mHFEMMultiplicity = HFEMMultiplicity;
 
-  pfJetSpecific->mHOEnergy= HOEnergy;
+  pfJetSpecific->mChargedEmEnergy = chargedEmEnergy;
+  pfJetSpecific->mChargedMuEnergy = chargedMuEnergy;
+  pfJetSpecific->mNeutralEmEnergy = neutralEmEnergy;
+  pfJetSpecific->mChargedMultiplicity = chargedMultiplicity;
+  pfJetSpecific->mNeutralMultiplicity = neutralMultiplicity;
+
+  pfJetSpecific->mHOEnergy = HOEnergy;
 
   return true;
 }
 
-
 //______________________________________________________________________________
-bool reco::makeSpecific(std::vector<reco::CandidatePtr> const & mcparticles, 
-			GenJet::Specific* genJetSpecific)
-{
-  if (nullptr==genJetSpecific) return false;
+bool reco::makeSpecific(std::vector<reco::CandidatePtr> const& mcparticles, GenJet::Specific* genJetSpecific) {
+  if (nullptr == genJetSpecific)
+    return false;
 
-  std::vector<reco::CandidatePtr>::const_iterator itMcParticle=mcparticles.begin();
-  for (;itMcParticle!=mcparticles.end();++itMcParticle) {
-    if ( itMcParticle->isNull() || !itMcParticle->isAvailable() ) { 
+  std::vector<reco::CandidatePtr>::const_iterator itMcParticle = mcparticles.begin();
+  for (; itMcParticle != mcparticles.end(); ++itMcParticle) {
+    if (itMcParticle->isNull() || !itMcParticle->isAvailable()) {
       edm::LogWarning("DataNotFound") << " JetSpecific: MC Particle is invalid\n";
       continue;
     }
 
-    
     const Candidate* candidate = itMcParticle->get();
-    if (candidate->hasMasterClone()) candidate = candidate->masterClone().get();
+    if (candidate->hasMasterClone())
+      candidate = candidate->masterClone().get();
     //const GenParticle* genParticle = GenJet::genParticle(candidate);
 
-    
     if (candidate) {
       double e = candidate->energy();
 
       // Legacy calo-like definitions
-      switch (std::abs (candidate->pdgId ())) {
-        case 22: // photon
-        case 11: // e
-	  genJetSpecific->m_EmEnergy += e;
-	  break;
-        case 211: // pi
-        case 321: // K
-        case 130: // KL
-        case 2212: // p
-        case 2112: // n
-	  genJetSpecific->m_HadEnergy += e;
-	  break;
-        case 13: // muon
-        case 12: // nu_e
-        case 14: // nu_mu
-        case 16: // nu_tau	
-	  genJetSpecific->m_InvisibleEnergy += e;
-	  break;
-        default: 
-	  genJetSpecific->m_AuxiliaryEnergy += e;
+      switch (std::abs(candidate->pdgId())) {
+        case 22:  // photon
+        case 11:  // e
+          genJetSpecific->m_EmEnergy += e;
+          break;
+        case 211:   // pi
+        case 321:   // K
+        case 130:   // KL
+        case 2212:  // p
+        case 2112:  // n
+          genJetSpecific->m_HadEnergy += e;
+          break;
+        case 13:  // muon
+        case 12:  // nu_e
+        case 14:  // nu_mu
+        case 16:  // nu_tau
+          genJetSpecific->m_InvisibleEnergy += e;
+          break;
+        default:
+          genJetSpecific->m_AuxiliaryEnergy += e;
       }
 
       // PF-like definitions
-      switch (std::abs (candidate->pdgId ())) {
-        case 11: //electron
-	  genJetSpecific->m_ChargedEmEnergy += e;
-	  ++(genJetSpecific->m_ChargedEmMultiplicity); 
-	  break;
-        case 13: // muon
-	  genJetSpecific->m_MuonEnergy += e;
-	  ++(genJetSpecific->m_MuonMultiplicity);
-        case 211: //pi+-
-        case 321: //K
-        case 2212: //p
-        case 3222: //Sigma+
-        case 3112: //Sigma-
-        case 3312: //Xi-
-        case 3334: //Omega-
-	  genJetSpecific->m_ChargedHadronEnergy += e;
-	  ++(genJetSpecific->m_ChargedHadronMultiplicity);
-	  break;
-        case 310: //KS0
-        case 130: //KL0
-        case 3122: //Lambda0
-        case 3212: //Sigma0
-        case 3322: //Xi0
-        case 2112: //n0
-	  genJetSpecific->m_NeutralHadronEnergy += e;
-	  ++(genJetSpecific->m_NeutralHadronMultiplicity);
-	  break;
-        case 22: //photon
-	  genJetSpecific->m_NeutralEmEnergy += e;
-	  ++(genJetSpecific->m_NeutralEmMultiplicity);
-	  break;
-      }	 
-    } // end if found a candidate
+      switch (std::abs(candidate->pdgId())) {
+        case 11:  //electron
+          genJetSpecific->m_ChargedEmEnergy += e;
+          ++(genJetSpecific->m_ChargedEmMultiplicity);
+          break;
+        case 13:  // muon
+          genJetSpecific->m_MuonEnergy += e;
+          ++(genJetSpecific->m_MuonMultiplicity);
+        case 211:   //pi+-
+        case 321:   //K
+        case 2212:  //p
+        case 3222:  //Sigma+
+        case 3112:  //Sigma-
+        case 3312:  //Xi-
+        case 3334:  //Omega-
+          genJetSpecific->m_ChargedHadronEnergy += e;
+          ++(genJetSpecific->m_ChargedHadronMultiplicity);
+          break;
+        case 310:   //KS0
+        case 130:   //KL0
+        case 3122:  //Lambda0
+        case 3212:  //Sigma0
+        case 3322:  //Xi0
+        case 2112:  //n0
+          genJetSpecific->m_NeutralHadronEnergy += e;
+          ++(genJetSpecific->m_NeutralHadronMultiplicity);
+          break;
+        case 22:  //photon
+          genJetSpecific->m_NeutralEmEnergy += e;
+          ++(genJetSpecific->m_NeutralEmMultiplicity);
+          break;
+      }
+    }  // end if found a candidate
     else {
-      edm::LogWarning("DataNotFound") <<"reco::makeGenJetSpecific: Referred  GenParticleCandidate "
-				      <<"is not available in the event\n";
+      edm::LogWarning("DataNotFound") << "reco::makeGenJetSpecific: Referred  GenParticleCandidate "
+                                      << "is not available in the event\n";
     }
-  }// end for loop over MC particles
-  
+  }  // end for loop over MC particles
+
   return true;
 }
 
-
 //______________________________________________________________________________
-HcalSubdetector reco::hcalSubdetector(int iEta, const HcalTopology &topology)
-{
+HcalSubdetector reco::hcalSubdetector(int iEta, const HcalTopology& topology) {
   int eta = std::abs(iEta);
-  if      (eta <= topology.lastHBRing()) return HcalBarrel;
-  else if (eta <= topology.lastHERing()) return HcalEndcap;
-  else if (eta <= topology.lastHFRing()) return HcalForward;
+  if (eta <= topology.lastHBRing())
+    return HcalBarrel;
+  else if (eta <= topology.lastHERing())
+    return HcalEndcap;
+  else if (eta <= topology.lastHFRing())
+    return HcalForward;
   return HcalEmpty;
 }
-
-
-

--- a/RecoJets/JetProducers/src/MVAJetPuId.cc
+++ b/RecoJets/JetProducers/src/MVAJetPuId.cc
@@ -13,555 +13,562 @@
 
 const float large_val = std::numeric_limits<float>::max();
 
+MVAJetPuId::MVAJetPuId(const edm::ParameterSet &ps) {
+  impactParTkThreshod_ = 1.;
 
-MVAJetPuId::MVAJetPuId(const edm::ParameterSet & ps) 
-{
-	impactParTkThreshod_ = 1.;
-
-	tmvaWeights_         = edm::FileInPath(ps.getParameter<std::string>("tmvaWeights")).fullPath(); 
-	tmvaMethod_          = ps.getParameter<std::string>("tmvaMethod");
-	tmvaVariables_       = ps.getParameter<std::vector<std::string> >("tmvaVariables");
-	tmvaSpectators_      = ps.getParameter<std::vector<std::string> >("tmvaSpectators");
-	version_             = ps.getParameter<int>("version");
-	reader_              = nullptr;
-	edm::ParameterSet jetConfig = ps.getParameter<edm::ParameterSet>("JetIdParams");
-	for(int i0 = 0; i0 < NWPs; i0++) { 
-		std::string lCutType                            = "Tight";
-		if(i0 == PileupJetIdentifier::kMedium) lCutType = "Medium";
-		if(i0 == PileupJetIdentifier::kLoose)  lCutType = "Loose";
-		for(int i1 = 0; i1 < 1; i1++) {
-			std::vector<double> pt010  = jetConfig.getParameter<std::vector<double> >(("Pt010_" +lCutType).c_str());
-			std::vector<double> pt1020 = jetConfig.getParameter<std::vector<double> >(("Pt1020_"+lCutType).c_str());
-			std::vector<double> pt2030 = jetConfig.getParameter<std::vector<double> >(("Pt2030_"+lCutType).c_str());
-			std::vector<double> pt3050 = jetConfig.getParameter<std::vector<double> >(("Pt3050_"+lCutType).c_str());
-			for(int i2 = 0; i2 < NPts; i2++) mvacut_[i0][0][i2] = pt010 [i2];
-			for(int i2 = 0; i2 < NPts; i2++) mvacut_[i0][1][i2] = pt1020[i2];
-			for(int i2 = 0; i2 < NPts; i2++) mvacut_[i0][2][i2] = pt2030[i2];
-			for(int i2 = 0; i2 < NPts; i2++) mvacut_[i0][3][i2] = pt3050[i2];
-
-		}
-	}
-	setup();
+  tmvaWeights_ = edm::FileInPath(ps.getParameter<std::string>("tmvaWeights")).fullPath();
+  tmvaMethod_ = ps.getParameter<std::string>("tmvaMethod");
+  tmvaVariables_ = ps.getParameter<std::vector<std::string> >("tmvaVariables");
+  tmvaSpectators_ = ps.getParameter<std::vector<std::string> >("tmvaSpectators");
+  version_ = ps.getParameter<int>("version");
+  reader_ = nullptr;
+  edm::ParameterSet jetConfig = ps.getParameter<edm::ParameterSet>("JetIdParams");
+  for (int i0 = 0; i0 < NWPs; i0++) {
+    std::string lCutType = "Tight";
+    if (i0 == PileupJetIdentifier::kMedium)
+      lCutType = "Medium";
+    if (i0 == PileupJetIdentifier::kLoose)
+      lCutType = "Loose";
+    for (int i1 = 0; i1 < 1; i1++) {
+      std::vector<double> pt010 = jetConfig.getParameter<std::vector<double> >(("Pt010_" + lCutType).c_str());
+      std::vector<double> pt1020 = jetConfig.getParameter<std::vector<double> >(("Pt1020_" + lCutType).c_str());
+      std::vector<double> pt2030 = jetConfig.getParameter<std::vector<double> >(("Pt2030_" + lCutType).c_str());
+      std::vector<double> pt3050 = jetConfig.getParameter<std::vector<double> >(("Pt3050_" + lCutType).c_str());
+      for (int i2 = 0; i2 < NPts; i2++)
+        mvacut_[i0][0][i2] = pt010[i2];
+      for (int i2 = 0; i2 < NPts; i2++)
+        mvacut_[i0][1][i2] = pt1020[i2];
+      for (int i2 = 0; i2 < NPts; i2++)
+        mvacut_[i0][2][i2] = pt2030[i2];
+      for (int i2 = 0; i2 < NPts; i2++)
+        mvacut_[i0][3][i2] = pt3050[i2];
+    }
+  }
+  setup();
 }
-
-
-
-
 
 MVAJetPuId::MVAJetPuId(int version,
-		const std::string & tmvaWeights, 
-		const std::string & tmvaMethod, 
-		Float_t impactParTkThreshod,
-		const std::vector<std::string> & tmvaVariables
-		) 
-{
-	impactParTkThreshod_ = impactParTkThreshod;
-	tmvaWeights_         = tmvaWeights;
-	tmvaMethod_          = tmvaMethod;
-	tmvaVariables_       = tmvaVariables;
-	version_             = version;
+                       const std::string &tmvaWeights,
+                       const std::string &tmvaMethod,
+                       Float_t impactParTkThreshod,
+                       const std::vector<std::string> &tmvaVariables) {
+  impactParTkThreshod_ = impactParTkThreshod;
+  tmvaWeights_ = tmvaWeights;
+  tmvaMethod_ = tmvaMethod;
+  tmvaVariables_ = tmvaVariables;
+  version_ = version;
 
-	reader_              = nullptr;
+  reader_ = nullptr;
 
-	setup();
+  setup();
 }
 
+void MVAJetPuId::setup() {
+  initVariables();
 
+  tmvaVariables_.clear();
+  tmvaVariables_.push_back("rho");
+  tmvaVariables_.push_back("nParticles");
+  tmvaVariables_.push_back("nCharged");
+  tmvaVariables_.push_back("majW");
+  tmvaVariables_.push_back("minW");
+  tmvaVariables_.push_back("frac01");
+  tmvaVariables_.push_back("frac02");
+  tmvaVariables_.push_back("frac03");
+  tmvaVariables_.push_back("frac04");
+  tmvaVariables_.push_back("ptD");
+  tmvaVariables_.push_back("beta");
+  tmvaVariables_.push_back("betaStar");
+  tmvaVariables_.push_back("dR2Mean");
+  tmvaVariables_.push_back("pull");
+  tmvaVariables_.push_back("jetR");
+  tmvaVariables_.push_back("jetRchg");
 
-void MVAJetPuId::setup()
-{
-	initVariables();
-
-
-	tmvaVariables_.clear();
-	tmvaVariables_.push_back( "rho"  );
-	tmvaVariables_.push_back( "nParticles" );
-	tmvaVariables_.push_back( "nCharged" );
-	tmvaVariables_.push_back( "majW"   );
-	tmvaVariables_.push_back( "minW"   );
-	tmvaVariables_.push_back( "frac01"    );
-	tmvaVariables_.push_back( "frac02" );
-	tmvaVariables_.push_back( "frac03"   );
-	tmvaVariables_.push_back( "frac04"  );
-	tmvaVariables_.push_back( "ptD"  );
-	tmvaVariables_.push_back( "beta"   );
-	tmvaVariables_.push_back( "betaStar"  );
-	tmvaVariables_.push_back( "dR2Mean"  );
-	tmvaVariables_.push_back( "pull" );
-	tmvaVariables_.push_back( "jetR");
-	tmvaVariables_.push_back( "jetRchg");
-
-	tmvaNames_["rho"] = "rho";
-	tmvaNames_["nParticles"] = "nParticles";
-	tmvaNames_["nCharged"] = "nCharged";
-	tmvaNames_["majW"] = "majW";
-	tmvaNames_["minW"] = "minW";
-	tmvaNames_["frac01"] = "frac01";
-	tmvaNames_["frac02"] = "frac02";
-	tmvaNames_["frac03"] = "frac03";
-	tmvaNames_["frac04"] = "frac04";
-	tmvaNames_["ptD"] = "ptD";
-	tmvaNames_["beta"] = "beta";
-	tmvaNames_["betaStar"] = "betaStar";
-	tmvaNames_["dR2Mean"] = "dR2Mean";
-	tmvaNames_["pull"] = "pull";  
-	tmvaNames_["jetR"] = "jetR";  
-	tmvaNames_["jetRchg"] = "jetRchg";
+  tmvaNames_["rho"] = "rho";
+  tmvaNames_["nParticles"] = "nParticles";
+  tmvaNames_["nCharged"] = "nCharged";
+  tmvaNames_["majW"] = "majW";
+  tmvaNames_["minW"] = "minW";
+  tmvaNames_["frac01"] = "frac01";
+  tmvaNames_["frac02"] = "frac02";
+  tmvaNames_["frac03"] = "frac03";
+  tmvaNames_["frac04"] = "frac04";
+  tmvaNames_["ptD"] = "ptD";
+  tmvaNames_["beta"] = "beta";
+  tmvaNames_["betaStar"] = "betaStar";
+  tmvaNames_["dR2Mean"] = "dR2Mean";
+  tmvaNames_["pull"] = "pull";
+  tmvaNames_["jetR"] = "jetR";
+  tmvaNames_["jetRchg"] = "jetRchg";
 }
 
-
-
-MVAJetPuId::~MVAJetPuId() 
-{
-	if( reader_ ) {
-		delete reader_;
-	}
+MVAJetPuId::~MVAJetPuId() {
+  if (reader_) {
+    delete reader_;
+  }
 }
 
-
-void Assign(const std::vector<float> & vec, float & a, float & b, float & c, float & d )
-{
-	size_t sz = vec.size();
-	a = ( sz > 0 ? vec[0] : 0. );
-	b = ( sz > 1 ? vec[1] : 0. );
-	c = ( sz > 2 ? vec[2] : 0. );
-	d = ( sz > 3 ? vec[3] : 0. );
+void Assign(const std::vector<float> &vec, float &a, float &b, float &c, float &d) {
+  size_t sz = vec.size();
+  a = (sz > 0 ? vec[0] : 0.);
+  b = (sz > 1 ? vec[1] : 0.);
+  c = (sz > 2 ? vec[2] : 0.);
+  d = (sz > 3 ? vec[3] : 0.);
 }
 
-
-void SetPtEtaPhi(const reco::Candidate & p, float & pt, float & eta, float &phi )
-{
-	pt  = p.pt();
-	eta = p.eta();
-	phi = p.phi();
+void SetPtEtaPhi(const reco::Candidate &p, float &pt, float &eta, float &phi) {
+  pt = p.pt();
+  eta = p.eta();
+  phi = p.phi();
 }
 
-
-void MVAJetPuId::bookReader()
-{
-	reader_ = new TMVA::Reader("!Color:Silent");
-	assert( ! tmvaMethod_.empty() && !  tmvaWeights_.empty() );
-	for(std::vector<std::string>::iterator it=tmvaVariables_.begin(); it!=tmvaVariables_.end(); ++it) {
-		if(  tmvaNames_[*it].empty() ) { 
-			tmvaNames_[*it] = *it;
-		}
-		reader_->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
-	}
-	for(std::vector<std::string>::iterator it=tmvaSpectators_.begin(); it!=tmvaSpectators_.end(); ++it) {
-		if(  tmvaNames_[*it].empty() ) { 
-			tmvaNames_[*it] = *it;
-		}
-		reader_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
-	}
-	reco::details::loadTMVAWeights(reader_,  tmvaMethod_, tmvaWeights_ ); 
+void MVAJetPuId::bookReader() {
+  reader_ = new TMVA::Reader("!Color:Silent");
+  assert(!tmvaMethod_.empty() && !tmvaWeights_.empty());
+  for (std::vector<std::string>::iterator it = tmvaVariables_.begin(); it != tmvaVariables_.end(); ++it) {
+    if (tmvaNames_[*it].empty()) {
+      tmvaNames_[*it] = *it;
+    }
+    reader_->AddVariable(*it, variables_[tmvaNames_[*it]].first);
+  }
+  for (std::vector<std::string>::iterator it = tmvaSpectators_.begin(); it != tmvaSpectators_.end(); ++it) {
+    if (tmvaNames_[*it].empty()) {
+      tmvaNames_[*it] = *it;
+    }
+    reader_->AddSpectator(*it, variables_[tmvaNames_[*it]].first);
+  }
+  reco::details::loadTMVAWeights(reader_, tmvaMethod_, tmvaWeights_);
 }
 
+void MVAJetPuId::set(const PileupJetIdentifier &id) { internalId_ = id; }
 
-void MVAJetPuId::set(const PileupJetIdentifier & id)
-{
-	internalId_ = id;
+void MVAJetPuId::runMva() {
+  if (!reader_) {
+    bookReader();
+  }
+  if (fabs(internalId_.jetEta_) < 5.0)
+    internalId_.mva_ = reader_->EvaluateMVA(tmvaMethod_.c_str());
+  if (fabs(internalId_.jetEta_) >= 5.0)
+    internalId_.mva_ = -2.;
+  internalId_.idFlag_ = computeIDflag(internalId_.mva_, internalId_.jetPt_, internalId_.jetEta_);
 }
 
+std::pair<int, int> MVAJetPuId::getJetIdKey(float jetPt, float jetEta) {
+  int ptId = 0;
+  if (jetPt > 10 && jetPt < 20)
+    ptId = 1;
+  if (jetPt >= 20 && jetPt < 30)
+    ptId = 2;
+  if (jetPt >= 30)
+    ptId = 3;
 
-void MVAJetPuId::runMva()
-{
-  	if( ! reader_ ) { bookReader();}
-	if(fabs(internalId_.jetEta_) <  5.0) internalId_.mva_ = reader_->EvaluateMVA( tmvaMethod_.c_str() );
-	if(fabs(internalId_.jetEta_) >= 5.0) internalId_.mva_ = -2.;
-	internalId_.idFlag_ = computeIDflag(internalId_.mva_,internalId_.jetPt_,internalId_.jetEta_);
+  int etaId = 0;
+  if (fabs(jetEta) > 2.5 && fabs(jetEta) < 2.75)
+    etaId = 1;
+  if (fabs(jetEta) >= 2.75 && fabs(jetEta) < 3.0)
+    etaId = 2;
+  if (fabs(jetEta) >= 3.0 && fabs(jetEta) < 5.0)
+    etaId = 3;
+  return std::pair<int, int>(ptId, etaId);
 }
 
-std::pair<int,int> MVAJetPuId::getJetIdKey(float jetPt, float jetEta)
-{
-	int ptId = 0;                                                                                                                                    
-	if(jetPt > 10 && jetPt < 20) ptId = 1;                                                                                 
-	if(jetPt >= 20 && jetPt < 30) ptId = 2;                                                                                 
-	if(jetPt >= 30              ) ptId = 3;                                                                                          
-
-	int etaId = 0;                                                                                                                                   
-	if(fabs(jetEta) > 2.5  && fabs(jetEta) < 2.75) etaId = 1;                                                              
-	if(fabs(jetEta) >= 2.75 && fabs(jetEta) < 3.0 ) etaId = 2;                                                              
-	if(fabs(jetEta) >= 3.0  && fabs(jetEta) < 5.0 ) etaId = 3;                                 
-	return std::pair<int,int>(ptId,etaId);
+int MVAJetPuId::computeIDflag(float mva, float jetPt, float jetEta) {
+  std::pair<int, int> jetIdKey = getJetIdKey(jetPt, jetEta);
+  return computeIDflag(mva, jetIdKey.first, jetIdKey.second);
 }
 
-
-int MVAJetPuId::computeIDflag(float mva, float jetPt, float jetEta)
-{
-	std::pair<int,int> jetIdKey = getJetIdKey(jetPt,jetEta);
-	return computeIDflag(mva,jetIdKey.first,jetIdKey.second);
+int MVAJetPuId::computeIDflag(float mva, int ptId, int etaId) {
+  int idFlag(0);
+  if (mva > mvacut_[PileupJetIdentifier::kTight][ptId][etaId])
+    idFlag += 1 << PileupJetIdentifier::kTight;
+  if (mva > mvacut_[PileupJetIdentifier::kMedium][ptId][etaId])
+    idFlag += 1 << PileupJetIdentifier::kMedium;
+  if (mva > mvacut_[PileupJetIdentifier::kLoose][ptId][etaId])
+    idFlag += 1 << PileupJetIdentifier::kLoose;
+  return idFlag;
 }
 
-int MVAJetPuId::computeIDflag(float mva,int ptId,int etaId)
-{
-	int idFlag(0);
-	if(mva > mvacut_[PileupJetIdentifier::kTight ][ptId][etaId]) idFlag += 1 << PileupJetIdentifier::kTight;
-	if(mva > mvacut_[PileupJetIdentifier::kMedium][ptId][etaId]) idFlag += 1 << PileupJetIdentifier::kMedium;
-	if(mva > mvacut_[PileupJetIdentifier::kLoose ][ptId][etaId]) idFlag += 1 << PileupJetIdentifier::kLoose;
-	return idFlag;
+PileupJetIdentifier MVAJetPuId::computeMva() {
+  runMva();
+  return PileupJetIdentifier(internalId_);
 }
 
-PileupJetIdentifier MVAJetPuId::computeMva()
-{
-	runMva();
-	return PileupJetIdentifier(internalId_);
+PileupJetIdentifier MVAJetPuId::computeIdVariables(const reco::Jet *jet,
+                                                   float jec,
+                                                   const reco::Vertex *vtx,
+                                                   const reco::VertexCollection &allvtx,
+                                                   double rho,
+                                                   bool calculateMva) {
+  typedef std::vector<reco::PFCandidatePtr> constituents_type;
+  typedef std::vector<reco::PFCandidatePtr>::iterator constituents_iterator;
+
+  resetVariables();
+
+  const reco::PFJet *pfjet = dynamic_cast<const reco::PFJet *>(jet);
+
+  if (jec < 0.) {
+    jec = 1.;
+  }
+
+  constituents_type constituents = pfjet->getPFConstituents();
+
+  reco::PFCandidatePtr lLead, lSecond, lLeadNeut, lLeadEm, lLeadCh, lTrail;
+  std::vector<float> frac, fracCh, fracEm, fracNeut;
+  constexpr int ncones = 4;
+  std::array<float, ncones> cones{{0.1, 0.2, 0.3, 0.4}};
+  std::array<float *, ncones> coneFracs{
+      {&internalId_.frac01_, &internalId_.frac02_, &internalId_.frac03_, &internalId_.frac04_}};
+  TMatrixDSym covMatrix(2);
+  covMatrix = 0.;
+
+  reco::TrackRef impactTrack;
+  float jetPt = jet->pt() / jec;  // use uncorrected pt for shape variables
+  float sumPt = 0., sumPt2 = 0., sumTkPt = 0., sumPtCh = 0, sumPtNe = 0;
+  float sum_deta = 0;
+  float sum_dphi = 0;
+  float sum_deta2 = 0;
+  float sum_detadphi = 0;
+  float sum_dphi2 = 0;
+  SetPtEtaPhi(
+      *jet, internalId_.jetPt_, internalId_.jetEta_, internalId_.jetPhi_);  // use corrected pt for jet kinematics
+  internalId_.jetM_ = jet->mass();
+  internalId_.rho_ = rho;  //allvtx.size();
+  for (constituents_iterator it = constituents.begin(); it != constituents.end(); ++it) {
+    reco::PFCandidatePtr &icand = *it;
+    float candPt = icand->pt();
+    float candPtFrac = candPt / jetPt;
+    float candDr = reco::deltaR(**it, *jet);
+    float candDeta = fabs((*it)->eta() - jet->eta());
+    float candDphi = reco::deltaPhi(**it, *jet);
+    float candPtDr = candPt * candDr;
+    size_t icone = std::lower_bound(&cones[0], &cones[ncones], candDr) - &cones[0];
+    float weight2 = candPt * candPt;
+
+    if (lLead.isNull() || candPt > lLead->pt()) {
+      lSecond = lLead;
+      lLead = icand;
+    } else if ((lSecond.isNull() || candPt > lSecond->pt()) && (candPt < lLead->pt())) {
+      lSecond = icand;
+    }
+
+    //internalId_.dRMean_     += candPtDr;
+    internalId_.dR2Mean_ += candPtDr * candPtDr;
+
+    internalId_.ptD_ += candPt * candPt;
+    sumPt += candPt;
+    sumPt2 += candPt * candPt;
+    sum_deta += candDeta * weight2;
+    sum_dphi += candDphi * weight2;
+    sum_deta2 += candDeta * candDeta * weight2;
+    sum_detadphi += candDeta * candDphi * weight2;
+    sum_dphi2 += candDphi * candDphi * weight2;
+    //Teta         += candPt * candDR * candDeta;
+    //Tphi         += candPt * candDR * candDphi;
+
+    frac.push_back(candPtFrac);
+    if (icone < ncones) {
+      *coneFracs[icone] += candPt;
+    }
+
+    if (icand->particleId() == reco::PFCandidate::h0) {
+      if (lLeadNeut.isNull() || candPt > lLeadNeut->pt()) {
+        lLeadNeut = icand;
+      }
+      internalId_.dRMeanNeut_ += candPtDr;
+      fracNeut.push_back(candPtFrac);
+      sumPtNe += candPt;
+    }
+
+    if (icand->particleId() == reco::PFCandidate::gamma) {
+      if (lLeadEm.isNull() || candPt > lLeadEm->pt()) {
+        lLeadEm = icand;
+      }
+      internalId_.dRMeanEm_ += candPtDr;
+      fracEm.push_back(candPtFrac);
+      sumPtNe += candPt;
+    }
+
+    if (icand->trackRef().isNonnull() && icand->trackRef().isAvailable()) {
+      if (lLeadCh.isNull() || candPt > lLeadCh->pt()) {
+        lLeadCh = icand;
+      }
+      //internalId_.jetRchg_  += candPtDr;
+      fracCh.push_back(candPtFrac);
+      sumPtCh += candPt;
+    }
+
+    if (icand->trackRef().isNonnull() && icand->trackRef().isAvailable()) {
+      float tkpt = icand->trackRef()->pt();
+      sumTkPt += tkpt;
+      bool inVtx0 =
+          find(vtx->tracks_begin(), vtx->tracks_end(), reco::TrackBaseRef(icand->trackRef())) != vtx->tracks_end();
+      bool inAnyOther = false;
+
+      double dZ0 = fabs(icand->trackRef()->dz(vtx->position()));
+      double dZ = dZ0;
+      for (reco::VertexCollection::const_iterator vi = allvtx.begin(); vi != allvtx.end(); ++vi) {
+        const reco::Vertex &iv = *vi;
+        if (iv.isFake() || iv.ndof() < 4) {
+          continue;
+        }
+
+        bool isVtx0 = (iv.position() - vtx->position()).r() < 0.02;
+
+        if (!isVtx0 && !inAnyOther) {
+          inAnyOther =
+              find(iv.tracks_begin(), iv.tracks_end(), reco::TrackBaseRef(icand->trackRef())) != iv.tracks_end();
+        }
+
+        dZ = std::min(dZ, fabs(icand->trackRef()->dz(iv.position())));
+      }
+      if (inVtx0 && !inAnyOther) {
+        internalId_.betaClassic_ += tkpt;
+      } else if (!inVtx0 && inAnyOther) {
+        internalId_.betaStarClassic_ += tkpt;
+      }
+
+      if (dZ0 < 0.2) {
+        internalId_.beta_ += tkpt;
+      } else if (dZ < 0.2) {
+        internalId_.betaStar_ += tkpt;
+      }
+    }
+
+    if (lTrail.isNull() || candPt < lTrail->pt()) {
+      lTrail = icand;
+    }
+  }
+
+  assert(lLead.isNonnull());
+  if (lSecond.isNull()) {
+    lSecond = lTrail;
+  }
+  if (lLeadNeut.isNull()) {
+    lLeadNeut = lTrail;
+  }
+  if (lLeadEm.isNull()) {
+    lLeadEm = lTrail;
+  }
+  if (lLeadCh.isNull()) {
+    lLeadCh = lTrail;
+  }
+  impactTrack = lLeadCh->trackRef();
+
+  internalId_.nCharged_ = pfjet->chargedMultiplicity();
+  internalId_.nNeutrals_ = pfjet->neutralMultiplicity();
+  internalId_.chgEMfrac_ = pfjet->chargedEmEnergy() / jet->energy();
+  internalId_.neuEMfrac_ = pfjet->neutralEmEnergy() / jet->energy();
+  internalId_.chgHadrfrac_ = pfjet->chargedHadronEnergy() / jet->energy();
+  internalId_.neuHadrfrac_ = pfjet->neutralHadronEnergy() / jet->energy();
+
+  if (impactTrack.isNonnull() && impactTrack.isAvailable()) {
+    internalId_.d0_ = fabs(impactTrack->dxy(vtx->position()));
+    internalId_.dZ_ = fabs(impactTrack->dz(vtx->position()));
+  } else {
+    internalId_.nParticles_ = constituents.size();
+    SetPtEtaPhi(*lLead, internalId_.leadPt_, internalId_.leadEta_, internalId_.leadPhi_);
+    SetPtEtaPhi(*lSecond, internalId_.secondPt_, internalId_.secondEta_, internalId_.secondPhi_);
+    SetPtEtaPhi(*lLeadNeut, internalId_.leadNeutPt_, internalId_.leadNeutEta_, internalId_.leadNeutPhi_);
+    SetPtEtaPhi(*lLeadEm, internalId_.leadEmPt_, internalId_.leadEmEta_, internalId_.leadEmPhi_);
+    SetPtEtaPhi(*lLeadCh, internalId_.leadChPt_, internalId_.leadChEta_, internalId_.leadChPhi_);
+    std::sort(frac.begin(), frac.end(), std::greater<float>());
+    std::sort(fracCh.begin(), fracCh.end(), std::greater<float>());
+    std::sort(fracEm.begin(), fracEm.end(), std::greater<float>());
+    std::sort(fracNeut.begin(), fracNeut.end(), std::greater<float>());
+    Assign(frac, internalId_.leadFrac_, internalId_.secondFrac_, internalId_.thirdFrac_, internalId_.fourthFrac_);
+
+    //covMatrix(0,0) /= sumPt2;
+    //covMatrix(0,1) /= sumPt2;
+    //covMatrix(1,1) /= sumPt2;
+    //covMatrix(1,0)  = covMatrix(0,1);
+    //internalId_.etaW_ = sqrt(covMatrix(0,0));
+    //internalId_.phiW_ = sqrt(covMatrix(1,1));
+    //internalId_.jetW_ = 0.5*(internalId_.etaW_+internalId_.phiW_);
+    //TVectorD eigVals(2); eigVals = TMatrixDSymEigen(covMatrix).GetEigenValues();
+    //
+    if (internalId_.majW_ < internalId_.minW_) {
+      std::swap(internalId_.majW_, internalId_.minW_);
+    }
+
+    //internalId_.dRLeadCent_ = reco::deltaR(*jet,*lLead);
+    if (lSecond.isNonnull()) {
+      internalId_.dRLead2nd_ = reco::deltaR(*jet, *lSecond);
+    }
+    internalId_.dRMeanNeut_ /= jetPt;
+    internalId_.dRMeanEm_ /= jetPt;
+    //internalId_.jetRchg_   /= jetPt;
+    internalId_.dR2Mean_ /= sumPt2;
+    for (size_t ic = 0; ic < ncones; ++ic) {
+      *coneFracs[ic] /= jetPt;
+    }
+
+    double ptMean = sumPt / internalId_.nParticles_;
+    double ptRMS = 0;
+    for (unsigned int i0 = 0; i0 < frac.size(); i0++) {
+      ptRMS += (frac[i0] - ptMean) * (frac[i0] - ptMean);
+    }
+    ptRMS /= internalId_.nParticles_;
+    ptRMS = sqrt(ptRMS);
+    internalId_.jetRchg_ = internalId_.leadChPt_ / sumPt;
+    internalId_.jetR_ = internalId_.leadPt_ / sumPt;
+
+    internalId_.ptMean_ = ptMean;
+    internalId_.ptRMS_ = ptRMS / jetPt;
+    internalId_.pt2A_ = sqrt(internalId_.ptD_ / internalId_.nParticles_) / jetPt;
+    internalId_.ptD_ = sqrt(internalId_.ptD_) / sumPt;
+    internalId_.sumPt_ = sumPt;
+    internalId_.sumChPt_ = sumPtCh;
+    internalId_.sumNePt_ = sumPtNe;
+    if (sumPt > 0) {
+      internalId_.beta_ /= sumPt;
+      internalId_.betaStar_ /= sumPt;
+    } else {
+      assert(internalId_.beta_ == 0. && internalId_.betaStar_ == 0.);
+    }
+    float ave_deta = sum_deta / sumPt2;
+    float ave_dphi = sum_dphi / sumPt2;
+    float ave_deta2 = sum_deta2 / sumPt2;
+    float ave_dphi2 = sum_dphi2 / sumPt2;
+    float a = ave_deta2 - ave_deta * ave_deta;
+    float b = ave_dphi2 - ave_dphi * ave_dphi;
+    float c = -(sum_detadphi / sumPt2 - ave_deta * ave_dphi);
+    float axis1 = 0;
+    float axis2 = 0;
+    if ((((a - b) * (a - b) + 4 * c * c)) > 0) {
+      float delta = sqrt(((a - b) * (a - b) + 4 * c * c));
+      if (a + b + delta > 0) {
+        axis1 = sqrt(0.5 * (a + b + delta));
+      }
+      if (a + b - delta > 0) {
+        axis2 = sqrt(0.5 * (a + b - delta));
+      }
+    } else {
+      axis1 = -1;
+      axis2 = -1;
+    }
+    internalId_.majW_ = axis1;  //sqrt(fabs(eigVals(0)));
+    internalId_.minW_ = axis2;  //sqrt(fabs(eigVals(1)));
+    //compute Pull
+
+    float ddetaR_sum(0.0), ddphiR_sum(0.0);
+    for (int i = 0; i < internalId_.nParticles_; ++i) {
+      reco::PFCandidatePtr part = pfjet->getPFConstituent(i);
+      float weight = part->pt() * part->pt();
+      float deta = part->eta() - jet->eta();
+      float dphi = reco::deltaPhi(*part, *jet);
+      float ddeta, ddphi, ddR;
+      ddeta = deta - ave_deta;
+      ddphi = reco::deltaPhi(dphi, ave_dphi);  //2*atan(tan((dphi - ave_dphi)/2.)) ;
+      ddR = sqrt(ddeta * ddeta + ddphi * ddphi);
+      ddetaR_sum += ddR * ddeta * weight;
+      ddphiR_sum += ddR * ddphi * weight;
+    }
+    if (sumPt2 > 0) {
+      float ddetaR_ave = ddetaR_sum / sumPt2;
+      float ddphiR_ave = ddphiR_sum / sumPt2;
+      internalId_.dRMean_ = sqrt(ddetaR_ave * ddetaR_ave + ddphiR_ave * ddphiR_ave);
+    }
+  }
+
+  if (calculateMva) {
+    runMva();
+  }
+
+  return PileupJetIdentifier(internalId_);
 }
 
-PileupJetIdentifier MVAJetPuId::computeIdVariables(const reco::Jet * jet, float jec, const reco::Vertex * vtx,
-		const reco::VertexCollection & allvtx, double rho,
-		bool calculateMva) 
-{
-
-	typedef std::vector <reco::PFCandidatePtr> constituents_type;
-	typedef std::vector <reco::PFCandidatePtr>::iterator constituents_iterator;
-
-	resetVariables();
-
-	const reco::PFJet * pfjet = dynamic_cast<const reco::PFJet *>(jet);
-
-	if( jec < 0. ) {
-		jec = 1.;
-	}
-
-	constituents_type constituents = pfjet->getPFConstituents();
-
-	reco::PFCandidatePtr lLead, lSecond, lLeadNeut, lLeadEm, lLeadCh, lTrail;
-	std::vector<float> frac, fracCh, fracEm, fracNeut;
-	constexpr int ncones = 4;
-	std::array<float, ncones> cones{ {0.1,0.2,0.3,0.4}};
-	std::array<float *, ncones> coneFracs{ {&internalId_.frac01_,&internalId_.frac02_,&internalId_.frac03_,&internalId_.frac04_}};
-	TMatrixDSym covMatrix(2); covMatrix = 0.;
-
-	reco::TrackRef impactTrack;
-	float jetPt = jet->pt() / jec; // use uncorrected pt for shape variables
-	float sumPt = 0., sumPt2 = 0., sumTkPt = 0.,sumPtCh=0,sumPtNe = 0; float sum_deta =0 ; float sum_dphi =0 ; float sum_deta2 =0 ; float sum_detadphi =0 ; float sum_dphi2=0;
-	SetPtEtaPhi(*jet,internalId_.jetPt_,internalId_.jetEta_,internalId_.jetPhi_); // use corrected pt for jet kinematics
-	internalId_.jetM_ = jet->mass(); 
-	internalId_.rho_ = rho;//allvtx.size();
-	for(constituents_iterator it=constituents.begin(); it!=constituents.end(); ++it) {
-		reco::PFCandidatePtr & icand = *it;
-		float candPt = icand->pt();
-		float candPtFrac = candPt/jetPt;
-		float candDr   = reco::deltaR(**it,*jet);
-		float candDeta = fabs( (*it)->eta() - jet->eta() );
-		float candDphi = reco::deltaPhi(**it,*jet);
-		float candPtDr = candPt * candDr;
-		size_t icone = std::lower_bound(&cones[0],&cones[ncones],candDr) - &cones[0];
-		float weight2 = candPt * candPt;
-
-
-		if( lLead.isNull() || candPt > lLead->pt() ) {
-			lSecond = lLead;
-			lLead = icand; 
-		} else if( (lSecond.isNull() || candPt > lSecond->pt()) && (candPt < lLead->pt()) ) {
-			lSecond = icand;
-		}
-
-		//internalId_.dRMean_     += candPtDr;
-		internalId_.dR2Mean_    += candPtDr*candPtDr;
-
-		internalId_.ptD_ += candPt*candPt;
-		sumPt += candPt;
-		sumPt2 += candPt*candPt;
-		sum_deta     += candDeta*weight2;
-		sum_dphi     += candDphi*weight2;
-		sum_deta2    += candDeta*candDeta*weight2;
-		sum_detadphi += candDeta*candDphi*weight2;
-		sum_dphi2    += candDphi*candDphi*weight2;
-		//Teta         += candPt * candDR * candDeta;
-		//Tphi         += candPt * candDR * candDphi;
-
-
-
-		frac.push_back(candPtFrac);
-		if( icone < ncones ) { *coneFracs[icone] += candPt; }
-
-
-		if( icand->particleId() == reco::PFCandidate::h0 ) {
-			if (lLeadNeut.isNull() || candPt > lLeadNeut->pt()) { lLeadNeut = icand; }
-			internalId_.dRMeanNeut_ += candPtDr;
-			fracNeut.push_back(candPtFrac);
-			sumPtNe               += candPt;
-		}
-
-		if( icand->particleId() == reco::PFCandidate::gamma ) {
-			if(lLeadEm.isNull() || candPt > lLeadEm->pt())  { lLeadEm = icand; }
-			internalId_.dRMeanEm_ += candPtDr;
-			fracEm.push_back(candPtFrac);
-			sumPtNe               += candPt;
-		}
-
-		if(  icand->trackRef().isNonnull() && icand->trackRef().isAvailable() ) {
-			if (lLeadCh.isNull() || candPt > lLeadCh->pt()) { lLeadCh = icand; }
-			//internalId_.jetRchg_  += candPtDr;
-			fracCh.push_back(candPtFrac);
-			sumPtCh                += candPt;
-		}
-
-		if(  icand->trackRef().isNonnull() && icand->trackRef().isAvailable() ) {
-			float tkpt = icand->trackRef()->pt(); 
-			sumTkPt += tkpt;
-			bool inVtx0 = find( vtx->tracks_begin(), vtx->tracks_end(), reco::TrackBaseRef(icand->trackRef()) ) != vtx->tracks_end();
-			bool inAnyOther = false;
-
-			double dZ0 = fabs(icand->trackRef()->dz(vtx->position()));
-			double dZ = dZ0;
-			for(reco::VertexCollection::const_iterator  vi=allvtx.begin(); vi!=allvtx.end(); ++vi ) {
-				const reco::Vertex & iv = *vi;
-				if( iv.isFake() || iv.ndof() < 4 ) { continue; }
-
-				bool isVtx0  = (iv.position() - vtx->position()).r() < 0.02;
-
-				if( ! isVtx0 && ! inAnyOther ) {
-					inAnyOther = find( iv.tracks_begin(), iv.tracks_end(), reco::TrackBaseRef(icand->trackRef()) ) != iv.tracks_end();
-				}
-
-				dZ = std::min(dZ,fabs(icand->trackRef()->dz(iv.position())));
-			}
-			if( inVtx0 && ! inAnyOther ) {
-				internalId_.betaClassic_ += tkpt;
-			} else if( ! inVtx0 && inAnyOther ) {
-				internalId_.betaStarClassic_ += tkpt;
-			}
-
-			if( dZ0 < 0.2 ) {
-				internalId_.beta_ += tkpt;
-			} else if( dZ < 0.2 ) {
-				internalId_.betaStar_ += tkpt;
-			}
-		} 
-
-		if( lTrail.isNull() || candPt < lTrail->pt() ) {
-			lTrail = icand; 
-		}
-	}
-
-	assert( lLead.isNonnull() );
-	if ( lSecond.isNull() )   { lSecond   = lTrail; }
-	if ( lLeadNeut.isNull() ) { lLeadNeut = lTrail; }
-	if ( lLeadEm.isNull() )   { lLeadEm   = lTrail; }
-	if ( lLeadCh.isNull() )   { lLeadCh   = lTrail; }
-	impactTrack = lLeadCh->trackRef();
-
-	internalId_.nCharged_    = pfjet->chargedMultiplicity();
-	internalId_.nNeutrals_   = pfjet->neutralMultiplicity();
-	internalId_.chgEMfrac_   = pfjet->chargedEmEnergy()    /jet->energy();
-	internalId_.neuEMfrac_   = pfjet->neutralEmEnergy()    /jet->energy();
-	internalId_.chgHadrfrac_ = pfjet->chargedHadronEnergy()/jet->energy();
-	internalId_.neuHadrfrac_ = pfjet->neutralHadronEnergy()/jet->energy();
-
-	if( impactTrack.isNonnull() && impactTrack.isAvailable() ) {
-		internalId_.d0_ = fabs(impactTrack->dxy(vtx->position()));
-		internalId_.dZ_ = fabs(impactTrack->dz(vtx->position()));
-	}else{ 
-		internalId_.nParticles_ = constituents.size(); 
-		SetPtEtaPhi(*lLead,internalId_.leadPt_,internalId_.leadEta_,internalId_.leadPhi_);                 
-		SetPtEtaPhi(*lSecond,internalId_.secondPt_,internalId_.secondEta_,internalId_.secondPhi_);        
-		SetPtEtaPhi(*lLeadNeut,internalId_.leadNeutPt_,internalId_.leadNeutEta_,internalId_.leadNeutPhi_); 
-		SetPtEtaPhi(*lLeadEm,internalId_.leadEmPt_,internalId_.leadEmEta_,internalId_.leadEmPhi_);        
-		SetPtEtaPhi(*lLeadCh,internalId_.leadChPt_,internalId_.leadChEta_,internalId_.leadChPhi_);         
-		std::sort(frac.begin(),frac.end(),std::greater<float>());
-		std::sort(fracCh.begin(),fracCh.end(),std::greater<float>());
-		std::sort(fracEm.begin(),fracEm.end(),std::greater<float>());
-		std::sort(fracNeut.begin(),fracNeut.end(),std::greater<float>());
-		Assign(frac,    internalId_.leadFrac_,    internalId_.secondFrac_,    internalId_.thirdFrac_,    internalId_.fourthFrac_);
-
-		//covMatrix(0,0) /= sumPt2;
-		//covMatrix(0,1) /= sumPt2;
-		//covMatrix(1,1) /= sumPt2;
-		//covMatrix(1,0)  = covMatrix(0,1);
-		//internalId_.etaW_ = sqrt(covMatrix(0,0));
-		//internalId_.phiW_ = sqrt(covMatrix(1,1));
-		//internalId_.jetW_ = 0.5*(internalId_.etaW_+internalId_.phiW_);
-		//TVectorD eigVals(2); eigVals = TMatrixDSymEigen(covMatrix).GetEigenValues();
-		//	
-		if( internalId_.majW_ < internalId_.minW_ ) { std::swap(internalId_.majW_,internalId_.minW_); }
-
-		//internalId_.dRLeadCent_ = reco::deltaR(*jet,*lLead);
-		if( lSecond.isNonnull() ) { internalId_.dRLead2nd_  = reco::deltaR(*jet,*lSecond); }
-		internalId_.dRMeanNeut_ /= jetPt;
-		internalId_.dRMeanEm_   /= jetPt;
-		//internalId_.jetRchg_   /= jetPt;
-		internalId_.dR2Mean_    /= sumPt2;
-		for(size_t ic=0; ic<ncones; ++ic){
-			*coneFracs[ic]     /= jetPt;
-		}
-
-		double ptMean = sumPt/internalId_.nParticles_;
-		double ptRMS  = 0;
-		for(unsigned int i0 = 0; i0 < frac.size(); i0++) {ptRMS+=(frac[i0]-ptMean)*(frac[i0]-ptMean);}
-		ptRMS/=internalId_.nParticles_;
-		ptRMS=sqrt(ptRMS);
-		internalId_.jetRchg_ = internalId_.leadChPt_/sumPt;
-		internalId_.jetR_ = internalId_.leadPt_/sumPt;
-
-		internalId_.ptMean_  = ptMean;
-		internalId_.ptRMS_   = ptRMS/jetPt;
-		internalId_.pt2A_    = sqrt( internalId_.ptD_     /internalId_.nParticles_)/jetPt;
-		internalId_.ptD_     = sqrt( internalId_.ptD_)    / sumPt;
-		internalId_.sumPt_   = sumPt;
-		internalId_.sumChPt_ = sumPtCh;
-		internalId_.sumNePt_ = sumPtNe;
-		if (sumPt > 0) {
-			internalId_.beta_     /= sumPt;
-			internalId_.betaStar_ /= sumPt;
-		} else {
-			assert( internalId_.beta_ == 0. && internalId_.betaStar_ == 0.);
-		}
-		float ave_deta = sum_deta/sumPt2;
-		float ave_dphi = sum_dphi/sumPt2;
-		float ave_deta2 = sum_deta2/sumPt2;
-		float ave_dphi2 = sum_dphi2/sumPt2;
-		float a = ave_deta2-ave_deta*ave_deta;
-		float b = ave_dphi2-ave_dphi*ave_dphi;
-		float c = -(sum_detadphi/sumPt2-ave_deta*ave_dphi);
-		float axis1=0; float axis2=0;
-		if((((a-b)*(a-b)+4*c*c))>0) {
-		float delta = sqrt(((a-b)*(a-b)+4*c*c));
-		if (a+b+delta > 0) {
-			axis1 = sqrt(0.5*(a+b+delta));
-		}
-		if (a+b-delta > 0) {
-			axis2 = sqrt(0.5*(a+b-delta));
-		}
-		}
-		else {
-	 	   axis1=-1;
-		   axis2=-1;
-		}
-		internalId_.majW_ = axis1; //sqrt(fabs(eigVals(0)));
-		internalId_.minW_ = axis2;//sqrt(fabs(eigVals(1)));
-		//compute Pull
-
-		float ddetaR_sum(0.0), ddphiR_sum(0.0);
-		for(int i=0; i<internalId_.nParticles_; ++i) {
-			reco::PFCandidatePtr part = pfjet->getPFConstituent(i);
-			float weight =part->pt()*part->pt() ;
-			float deta = part->eta() - jet->eta();
-			float dphi = reco::deltaPhi(*part, *jet);
-			float ddeta, ddphi, ddR;
-			ddeta = deta - ave_deta ;
-			ddphi = reco::deltaPhi(dphi,ave_dphi);//2*atan(tan((dphi - ave_dphi)/2.)) ;
-			ddR = sqrt(ddeta*ddeta + ddphi*ddphi);
-			ddetaR_sum += ddR*ddeta*weight;
-			ddphiR_sum += ddR*ddphi*weight;
-		}if (sumPt2 > 0) {
-			float ddetaR_ave = ddetaR_sum/sumPt2;
-			float ddphiR_ave = ddphiR_sum/sumPt2;
-			internalId_.dRMean_ = sqrt(ddetaR_ave*ddetaR_ave+ddphiR_ave*ddphiR_ave);
-		}
-
-
-
-	}
-
-	if( calculateMva ) {
-		runMva();
-	}
-
-	return PileupJetIdentifier(internalId_);
+std::string MVAJetPuId::dumpVariables() const {
+  std::stringstream out;
+  for (variables_list_t::const_iterator it = variables_.begin(); it != variables_.end(); ++it) {
+    out << std::setw(15) << it->first << std::setw(3) << "=" << std::setw(5) << *it->second.first << " ("
+        << std::setw(5) << it->second.second << ")" << std::endl;
+  }
+  return out.str();
 }
 
-std::string MVAJetPuId::dumpVariables() const
-{
-	std::stringstream out;
-	for(variables_list_t::const_iterator it=variables_.begin(); 
-			it!=variables_.end(); ++it ) {
-		out << std::setw(15) << it->first << std::setw(3) << "=" 
-			<< std::setw(5) << *it->second.first 
-			<< " (" << std::setw(5) << it->second.second << ")" << std::endl;
-	}
-	return out.str();
+void MVAJetPuId::resetVariables() {
+  internalId_.idFlag_ = 0;
+  for (variables_list_t::iterator it = variables_.begin(); it != variables_.end(); ++it) {
+    *it->second.first = it->second.second;
+  }
 }
 
-void MVAJetPuId::resetVariables()
-{
-	internalId_.idFlag_    = 0;
-	for(variables_list_t::iterator it=variables_.begin(); 
-			it!=variables_.end(); ++it ) {
-		*it->second.first = it->second.second;
-	}
-}
+#define INIT_VARIABLE(NAME, TMVANAME, VAL) \
+  internalId_.NAME##_ = VAL;               \
+  variables_[#NAME] = std::make_pair(&internalId_.NAME##_, VAL);
 
-#define INIT_VARIABLE(NAME,TMVANAME,VAL)    \
-	internalId_.NAME ## _ = VAL; \
-variables_[ # NAME   ] = std::make_pair(& internalId_.NAME ## _, VAL);
+void MVAJetPuId::initVariables() {
+  internalId_.idFlag_ = 0;
+  INIT_VARIABLE(mva, "", -100.);
 
-void MVAJetPuId::initVariables()
-{
-	internalId_.idFlag_    = 0;
-	INIT_VARIABLE(mva        , "", -100.);
+  INIT_VARIABLE(jetPt, "jetPt", 0.);
+  INIT_VARIABLE(jetEta, "jetEta", large_val);
+  INIT_VARIABLE(jetPhi, "", large_val);
+  INIT_VARIABLE(jetM, "", 0.);
+  INIT_VARIABLE(nCharged, "nCharged", 0.);
+  INIT_VARIABLE(nNeutrals, "", 0.);
 
-	INIT_VARIABLE(jetPt      , "jetPt", 0.);
-	INIT_VARIABLE(jetEta     , "jetEta", large_val);
-	INIT_VARIABLE(jetPhi     , "", large_val);
-	INIT_VARIABLE(jetM       , "", 0.);
-	INIT_VARIABLE(nCharged   , "nCharged", 0.);
-	INIT_VARIABLE(nNeutrals  , "", 0.);
+  INIT_VARIABLE(chgEMfrac, "", 0.);
+  INIT_VARIABLE(neuEMfrac, "", 0.);
+  INIT_VARIABLE(chgHadrfrac, "", 0.);
+  INIT_VARIABLE(neuHadrfrac, "", 0.);
 
-	INIT_VARIABLE(chgEMfrac  , "", 0.);
-	INIT_VARIABLE(neuEMfrac  , "", 0.);
-	INIT_VARIABLE(chgHadrfrac, "", 0.);
-	INIT_VARIABLE(neuHadrfrac, "", 0.);
+  INIT_VARIABLE(d0, "", -1000.);
+  INIT_VARIABLE(dZ, "", -1000.);
+  INIT_VARIABLE(nParticles, "nParticles", 0.);
 
-	INIT_VARIABLE(d0         , ""    , -1000.);   
-	INIT_VARIABLE(dZ         , ""    , -1000.);  
-	INIT_VARIABLE(nParticles , "nParticles"  , 0.);  
+  INIT_VARIABLE(leadPt, "", 0.);
+  INIT_VARIABLE(leadEta, "", large_val);
+  INIT_VARIABLE(leadPhi, "", large_val);
+  INIT_VARIABLE(secondPt, "", 0.);
+  INIT_VARIABLE(secondEta, "", large_val);
+  INIT_VARIABLE(secondPhi, "", large_val);
+  INIT_VARIABLE(leadNeutPt, "", 0.);
+  INIT_VARIABLE(leadNeutEta, "", large_val);
 
-	INIT_VARIABLE(leadPt     , ""    , 0.);  
-	INIT_VARIABLE(leadEta    , ""   , large_val);  
-	INIT_VARIABLE(leadPhi    , ""   , large_val);  
-	INIT_VARIABLE(secondPt   , ""    , 0.);  
-	INIT_VARIABLE(secondEta  , ""   , large_val);  
-	INIT_VARIABLE(secondPhi  , ""   , large_val);  
-	INIT_VARIABLE(leadNeutPt , ""    , 0.);  
-	INIT_VARIABLE(leadNeutEta, ""   , large_val);  
+  INIT_VARIABLE(jetR, "jetR", 0.);
+  INIT_VARIABLE(pull, "pull", 0.);
+  INIT_VARIABLE(jetRchg, "jetRchg", 0.);
+  INIT_VARIABLE(dR2Mean, "dR2Mean", 0.);
 
-	INIT_VARIABLE(jetR , "jetR"   , 0.);  
-	INIT_VARIABLE(pull     , "pull"    , 0.);  
-	INIT_VARIABLE(jetRchg   , "jetRchg"   , 0.);  
-	INIT_VARIABLE(dR2Mean    , "dR2Mean"         , 0.);  
+  INIT_VARIABLE(ptD, "ptD", 0.);
+  INIT_VARIABLE(ptMean, "", 0.);
+  INIT_VARIABLE(ptRMS, "", 0.);
+  INIT_VARIABLE(pt2A, "", 0.);
+  INIT_VARIABLE(ptDCh, "", 0.);
+  INIT_VARIABLE(ptDNe, "", 0.);
+  INIT_VARIABLE(sumPt, "", 0.);
+  INIT_VARIABLE(sumChPt, "", 0.);
+  INIT_VARIABLE(sumNePt, "", 0.);
+  INIT_VARIABLE(secondFrac, "", 0.);
+  INIT_VARIABLE(thirdFrac, "", 0.);
+  INIT_VARIABLE(fourthFrac, "", 0.);
+  INIT_VARIABLE(leadChFrac, "", 0.);
+  INIT_VARIABLE(secondChFrac, "", 0.);
+  INIT_VARIABLE(thirdChFrac, "", 0.);
+  INIT_VARIABLE(fourthChFrac, "", 0.);
+  INIT_VARIABLE(leadNeutFrac, "", 0.);
+  INIT_VARIABLE(secondNeutFrac, "", 0.);
+  INIT_VARIABLE(thirdNeutFrac, "", 0.);
+  INIT_VARIABLE(fourthNeutFrac, "", 0.);
+  INIT_VARIABLE(leadEmFrac, "", 0.);
+  INIT_VARIABLE(secondEmFrac, "", 0.);
+  INIT_VARIABLE(thirdEmFrac, "", 0.);
+  INIT_VARIABLE(fourthEmFrac, "", 0.);
+  INIT_VARIABLE(jetW, "", 1.);
+  INIT_VARIABLE(etaW, "", 1.);
+  INIT_VARIABLE(phiW, "", 1.);
+  INIT_VARIABLE(majW, "majW", 1.);
+  INIT_VARIABLE(minW, "minW", 1.);
+  INIT_VARIABLE(frac01, "frac01", 0.);
+  INIT_VARIABLE(frac02, "frac02", 0.);
+  INIT_VARIABLE(frac03, "frac03", 0.);
+  INIT_VARIABLE(frac04, "frac04", 0.);
 
-	INIT_VARIABLE(ptD        , "ptD", 0.);
-	INIT_VARIABLE(ptMean     , "", 0.);
-	INIT_VARIABLE(ptRMS      , "", 0.);
-	INIT_VARIABLE(pt2A       , "", 0.);
-	INIT_VARIABLE(ptDCh      , "", 0.);
-	INIT_VARIABLE(ptDNe      , "", 0.);
-	INIT_VARIABLE(sumPt      , "", 0.);
-	INIT_VARIABLE(sumChPt    , "", 0.);
-	INIT_VARIABLE(sumNePt    , "", 0.);
-	INIT_VARIABLE(secondFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthFrac  ,"" ,0.);  
-	INIT_VARIABLE(leadChFrac    ,"" ,0.);  
-	INIT_VARIABLE(secondChFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdChFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthChFrac  ,"" ,0.);  
-	INIT_VARIABLE(leadNeutFrac    ,"" ,0.);  
-	INIT_VARIABLE(secondNeutFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdNeutFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthNeutFrac  ,"" ,0.);  
-	INIT_VARIABLE(leadEmFrac    ,"" ,0.);  
-	INIT_VARIABLE(secondEmFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdEmFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthEmFrac  ,"" ,0.);  
-	INIT_VARIABLE(jetW  ,"" ,1.);  
-	INIT_VARIABLE(etaW  ,"" ,1.);  
-	INIT_VARIABLE(phiW  ,"" ,1.);  
-	INIT_VARIABLE(majW  ,"majW" ,1.);  
-	INIT_VARIABLE(minW  ,"minW" ,1.);  
-	INIT_VARIABLE(frac01    ,"frac01" ,0.);  
-	INIT_VARIABLE(frac02    ,"frac02" ,0.);  
-	INIT_VARIABLE(frac03    ,"frac03" ,0.);  
-	INIT_VARIABLE(frac04    ,"frac04" ,0.);  
-
-	INIT_VARIABLE(beta   ,"beta" ,0.);  
-	INIT_VARIABLE(betaStar   ,"betaStar" ,0.);  
-	INIT_VARIABLE(betaClassic   ,"betaClassic" ,0.);  
-	INIT_VARIABLE(betaStarClassic   ,"betaStarClassic" ,0.);  
-	INIT_VARIABLE(rho   ,"rho" ,0.);  
-
+  INIT_VARIABLE(beta, "beta", 0.);
+  INIT_VARIABLE(betaStar, "betaStar", 0.);
+  INIT_VARIABLE(betaClassic, "betaClassic", 0.);
+  INIT_VARIABLE(betaStarClassic, "betaStarClassic", 0.);
+  INIT_VARIABLE(rho, "rho", 0.);
 }
 #undef INIT_VARIABLE
-

--- a/RecoJets/JetProducers/src/PileUpSubtractor.cc
+++ b/RecoJets/JetProducers/src/PileUpSubtractor.cc
@@ -15,74 +15,69 @@
 #include <map>
 using namespace std;
 
-PileUpSubtractor::PileUpSubtractor(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) {
+PileUpSubtractor::PileUpSubtractor(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) {
+  geo_ = nullptr;
+  doAreaFastjet_ = iConfig.getParameter<bool>("doAreaFastjet");
+  doRhoFastjet_ = iConfig.getParameter<bool>("doRhoFastjet");
+  nSigmaPU_ = iConfig.getParameter<double>("nSigmaPU");
+  radiusPU_ = iConfig.getParameter<double>("radiusPU");
+  jetPtMin_ = iConfig.getParameter<double>("jetPtMin");
+  puPtMin_ = iConfig.getParameter<double>("puPtMin");
+  ghostEtaMax = iConfig.getParameter<double>("Ghost_EtaMax");
+  activeAreaRepeats = iConfig.getParameter<int>("Active_Area_Repeats");
+  ghostArea = iConfig.getParameter<double>("GhostArea");
 
-	geo_ = nullptr;
-	doAreaFastjet_	= iConfig.getParameter<bool>("doAreaFastjet");
-	doRhoFastjet_	= iConfig.getParameter<bool>("doRhoFastjet");
-	nSigmaPU_	= iConfig.getParameter<double>("nSigmaPU");
-	radiusPU_	= iConfig.getParameter<double>("radiusPU");
-	jetPtMin_	= iConfig.getParameter<double>("jetPtMin");
-	puPtMin_	= iConfig.getParameter<double>("puPtMin");
-	ghostEtaMax 	= iConfig.getParameter<double>("Ghost_EtaMax");
-	activeAreaRepeats = iConfig.getParameter<int>("Active_Area_Repeats");
-	ghostArea 	= iConfig.getParameter<double>("GhostArea");
-
-	if ( doAreaFastjet_ || doRhoFastjet_ ) {
-		fjActiveArea_ =  ActiveAreaSpecPtr(new fastjet::ActiveAreaSpec(ghostEtaMax,
-									     activeAreaRepeats,
-									     ghostArea));
-		if ( ( ghostEtaMax < 0 ) || ( activeAreaRepeats < 0 ) || ( ghostArea < 0 ) )  
-			throw cms::Exception("doAreaFastjet or doRhoFastjet") << "Parameters ghostEtaMax, activeAreaRepeats or ghostArea for doAreaFastjet/doRhoFastjet are not defined." << std::endl;
-	} 
-
+  if (doAreaFastjet_ || doRhoFastjet_) {
+    fjActiveArea_ = ActiveAreaSpecPtr(new fastjet::ActiveAreaSpec(ghostEtaMax, activeAreaRepeats, ghostArea));
+    if ((ghostEtaMax < 0) || (activeAreaRepeats < 0) || (ghostArea < 0))
+      throw cms::Exception("doAreaFastjet or doRhoFastjet")
+          << "Parameters ghostEtaMax, activeAreaRepeats or ghostArea for doAreaFastjet/doRhoFastjet are not defined."
+          << std::endl;
+  }
 }
 
 void PileUpSubtractor::reset(std::vector<edm::Ptr<reco::Candidate> >& input,
-			     std::vector<fastjet::PseudoJet>& towers,
-			     std::vector<fastjet::PseudoJet>& output){
-  
+                             std::vector<fastjet::PseudoJet>& towers,
+                             std::vector<fastjet::PseudoJet>& output) {
   inputs_ = &input;
   fjInputs_ = &towers;
   fjJets_ = &output;
   fjOriginalInputs_ = (*fjInputs_);
-  for (unsigned int i = 0; i < fjInputs_->size(); ++i){
+  for (unsigned int i = 0; i < fjInputs_->size(); ++i) {
     fjOriginalInputs_[i].set_user_index((*fjInputs_)[i].user_index());
   }
-  
 }
 
-void PileUpSubtractor::setDefinition(JetDefPtr const & jetDef){
-  fjJetDefinition_ = JetDefPtr( new fastjet::JetDefinition( *jetDef ) );
+void PileUpSubtractor::setDefinition(JetDefPtr const& jetDef) {
+  fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(*jetDef));
 }
 
-void PileUpSubtractor::setupGeometryMap(edm::Event& iEvent,const edm::EventSetup& iSetup)
-{
+void PileUpSubtractor::setupGeometryMap(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  LogDebug("PileUpSubtractor") << "The subtractor setting up geometry...\n";
 
-  LogDebug("PileUpSubtractor")<<"The subtractor setting up geometry...\n";
-
-  if(geo_ == nullptr) {
+  if (geo_ == nullptr) {
     edm::ESHandle<CaloGeometry> pG;
     iSetup.get<CaloGeometryRecord>().get(pG);
     geo_ = pG.product();
-    std::vector<DetId> alldid =  geo_->getValidDetIds();
+    std::vector<DetId> alldid = geo_->getValidDetIds();
 
     int ietaold = -10000;
     ietamax_ = -10000;
     ietamin_ = 10000;
-    for(std::vector<DetId>::const_iterator did=alldid.begin(); did != alldid.end(); did++){
-      if( (*did).det() == DetId::Hcal ){
+    for (std::vector<DetId>::const_iterator did = alldid.begin(); did != alldid.end(); did++) {
+      if ((*did).det() == DetId::Hcal) {
         HcalDetId hid = HcalDetId(*did);
-        if( (hid).depth() == 1 ) {
-	  allgeomid_.push_back(*did);
+        if ((hid).depth() == 1) {
+          allgeomid_.push_back(*did);
 
-          if((hid).ieta() != ietaold){
+          if ((hid).ieta() != ietaold) {
             ietaold = (hid).ieta();
             geomtowers_[(hid).ieta()] = 1;
-            if((hid).ieta() > ietamax_) ietamax_ = (hid).ieta();
-            if((hid).ieta() < ietamin_) ietamin_ = (hid).ieta();
-          }
-          else{
+            if ((hid).ieta() > ietamax_)
+              ietamax_ = (hid).ieta();
+            if ((hid).ieta() < ietamin_)
+              ietamin_ = (hid).ieta();
+          } else {
             geomtowers_[(hid).ieta()]++;
           }
         }
@@ -90,287 +85,264 @@ void PileUpSubtractor::setupGeometryMap(edm::Event& iEvent,const edm::EventSetup
     }
   }
 
-  for (int i = ietamin_; i<ietamax_+1; i++) {
+  for (int i = ietamin_; i < ietamax_ + 1; i++) {
     ntowersWithJets_[i] = 0;
   }
 }
 
 //
-// Calculate mean E and sigma from jet collection "coll".  
+// Calculate mean E and sigma from jet collection "coll".
 //
-void PileUpSubtractor::calculatePedestal( vector<fastjet::PseudoJet> const & coll )
-{
-  LogDebug("PileUpSubtractor")<<"The subtractor calculating pedestals...\n";
-  map<int,double> emean2;
-  map<int,int> ntowers;
-    
+void PileUpSubtractor::calculatePedestal(vector<fastjet::PseudoJet> const& coll) {
+  LogDebug("PileUpSubtractor") << "The subtractor calculating pedestals...\n";
+  map<int, double> emean2;
+  map<int, int> ntowers;
+
   int ietaold = -10000;
   int ieta0 = -100;
-   
+
   // Initial values for emean_, emean2, esigma_, ntowers
 
-  for(int i = ietamin_; i < ietamax_+1; i++)
-    {
-      emean_[i] = 0.;
-      emean2[i] = 0.;
-      esigma_[i] = 0.;
-      ntowers[i] = 0;
-    }
-    
-  for (vector<fastjet::PseudoJet>::const_iterator input_object = coll.begin (),
-	 fjInputsEnd = coll.end();  
-       input_object != fjInputsEnd; ++input_object) {
-     const reco::CandidatePtr & originalTower=(*inputs_)[ input_object->user_index()];
-    ieta0 = ieta( originalTower );
-    double Original_Et = originalTower->et();
-  if( ieta0-ietaold != 0 )
-      {
-        emean_[ieta0] = emean_[ieta0]+Original_Et;
-        emean2[ieta0] = emean2[ieta0]+Original_Et*Original_Et;
-        ntowers[ieta0] = 1;
-        ietaold = ieta0;
-      }
-  else
-      {
-        emean_[ieta0] = emean_[ieta0]+Original_Et;
-        emean2[ieta0] = emean2[ieta0]+Original_Et*Original_Et;
-        ntowers[ieta0]++;
-      }
+  for (int i = ietamin_; i < ietamax_ + 1; i++) {
+    emean_[i] = 0.;
+    emean2[i] = 0.;
+    esigma_[i] = 0.;
+    ntowers[i] = 0;
   }
 
-  for(map<int,int>::const_iterator gt = geomtowers_.begin(); gt != geomtowers_.end(); gt++)    
-    {
-      int it = (*gt).first;
-       
-      double e1 = (*(emean_.find(it))).second;
-      double e2 = (*emean2.find(it)).second;
-      int nt = (*gt).second - (*(ntowersWithJets_.find(it))).second;
-
-      LogDebug("PileUpSubtractor")<<" ieta : "<<it<<" number of towers : "<<nt<<" e1 : "<<e1<<" e2 : "<<e2<<"\n";
-      if(nt > 0) {
-	emean_[it] = e1/nt;
-	double eee = e2/nt - e1*e1/(nt*nt);    
-	if(eee<0.) eee = 0.;
-	esigma_[it] = nSigmaPU_*sqrt(eee);
-      }
-      else
-	{
-          emean_[it] = 0.;
-          esigma_[it] = 0.;
-	}
-      LogDebug("PileUpSubtractor")<<" ieta : "<<it<<" Pedestals : "<<emean_[it]<<"  "<<esigma_[it]<<"\n";
+  for (vector<fastjet::PseudoJet>::const_iterator input_object = coll.begin(), fjInputsEnd = coll.end();
+       input_object != fjInputsEnd;
+       ++input_object) {
+    const reco::CandidatePtr& originalTower = (*inputs_)[input_object->user_index()];
+    ieta0 = ieta(originalTower);
+    double Original_Et = originalTower->et();
+    if (ieta0 - ietaold != 0) {
+      emean_[ieta0] = emean_[ieta0] + Original_Et;
+      emean2[ieta0] = emean2[ieta0] + Original_Et * Original_Et;
+      ntowers[ieta0] = 1;
+      ietaold = ieta0;
+    } else {
+      emean_[ieta0] = emean_[ieta0] + Original_Et;
+      emean2[ieta0] = emean2[ieta0] + Original_Et * Original_Et;
+      ntowers[ieta0]++;
     }
-}
+  }
 
+  for (map<int, int>::const_iterator gt = geomtowers_.begin(); gt != geomtowers_.end(); gt++) {
+    int it = (*gt).first;
+
+    double e1 = (*(emean_.find(it))).second;
+    double e2 = (*emean2.find(it)).second;
+    int nt = (*gt).second - (*(ntowersWithJets_.find(it))).second;
+
+    LogDebug("PileUpSubtractor") << " ieta : " << it << " number of towers : " << nt << " e1 : " << e1 << " e2 : " << e2
+                                 << "\n";
+    if (nt > 0) {
+      emean_[it] = e1 / nt;
+      double eee = e2 / nt - e1 * e1 / (nt * nt);
+      if (eee < 0.)
+        eee = 0.;
+      esigma_[it] = nSigmaPU_ * sqrt(eee);
+    } else {
+      emean_[it] = 0.;
+      esigma_[it] = 0.;
+    }
+    LogDebug("PileUpSubtractor") << " ieta : " << it << " Pedestals : " << emean_[it] << "  " << esigma_[it] << "\n";
+  }
+}
 
 //
 // Subtract mean and sigma from fjInputs_
-//    
-void PileUpSubtractor::subtractPedestal(vector<fastjet::PseudoJet> & coll)
-{
-
-  LogDebug("PileUpSubtractor")<<"The subtractor subtracting pedestals...\n";
+//
+void PileUpSubtractor::subtractPedestal(vector<fastjet::PseudoJet>& coll) {
+  LogDebug("PileUpSubtractor") << "The subtractor subtracting pedestals...\n";
 
   int it = -100;
-  for (vector<fastjet::PseudoJet>::iterator input_object = coll.begin (),
-	 fjInputsEnd = coll.end(); 
-       input_object != fjInputsEnd; ++input_object) {
-    
-     reco::CandidatePtr const & itow =  (*inputs_)[ input_object->user_index() ];
-    
-    it = ieta( itow );
-    
+  for (vector<fastjet::PseudoJet>::iterator input_object = coll.begin(), fjInputsEnd = coll.end();
+       input_object != fjInputsEnd;
+       ++input_object) {
+    reco::CandidatePtr const& itow = (*inputs_)[input_object->user_index()];
+
+    it = ieta(itow);
+
     double etnew = itow->et() - (*(emean_.find(it))).second - (*(esigma_.find(it))).second;
-    float mScale = etnew/input_object->Et(); 
-    if(etnew < 0.) mScale = 0.;
-    
-    math::XYZTLorentzVectorD towP4(input_object->px()*mScale, input_object->py()*mScale,
-				   input_object->pz()*mScale, input_object->e()*mScale);
-    
+    float mScale = etnew / input_object->Et();
+    if (etnew < 0.)
+      mScale = 0.;
+
+    math::XYZTLorentzVectorD towP4(input_object->px() * mScale,
+                                   input_object->py() * mScale,
+                                   input_object->pz() * mScale,
+                                   input_object->e() * mScale);
+
     int index = input_object->user_index();
-    input_object->reset_momentum ( towP4.px(),
-				   towP4.py(),
-				   towP4.pz(),
-				   towP4.energy() );
+    input_object->reset_momentum(towP4.px(), towP4.py(), towP4.pz(), towP4.energy());
     input_object->set_user_index(index);
   }
 }
 
-void PileUpSubtractor::calculateOrphanInput(vector<fastjet::PseudoJet> & orphanInput) 
-{
-
-  LogDebug("PileUpSubtractor")<<"The subtractor calculating orphan input...\n";
+void PileUpSubtractor::calculateOrphanInput(vector<fastjet::PseudoJet>& orphanInput) {
+  LogDebug("PileUpSubtractor") << "The subtractor calculating orphan input...\n";
 
   (*fjInputs_) = fjOriginalInputs_;
 
-  vector<int> jettowers; // vector of towers indexed by "user_index"
-  vector<pair<int,int> >  excludedTowers; // vector of excluded ieta, iphi values
+  vector<int> jettowers;                   // vector of towers indexed by "user_index"
+  vector<pair<int, int> > excludedTowers;  // vector of excluded ieta, iphi values
 
-  vector <fastjet::PseudoJet>::iterator pseudojetTMP = fjJets_->begin (),
-    fjJetsEnd = fjJets_->end();
-  for (; pseudojetTMP != fjJetsEnd ; ++pseudojetTMP) {
-    if(pseudojetTMP->perp() < puPtMin_) continue;
+  vector<fastjet::PseudoJet>::iterator pseudojetTMP = fjJets_->begin(), fjJetsEnd = fjJets_->end();
+  for (; pseudojetTMP != fjJetsEnd; ++pseudojetTMP) {
+    if (pseudojetTMP->perp() < puPtMin_)
+      continue;
 
     // find towers within radiusPU_ of this jet
-    for(vector<HcalDetId>::const_iterator im = allgeomid_.begin(); im != allgeomid_.end(); im++)
-      {
-	double dr = reco::deltaR(geo_->getPosition((DetId)(*im)),(*pseudojetTMP));
-	vector<pair<int,int> >::const_iterator exclude = find(excludedTowers.begin(),excludedTowers.end(),pair<int,int>(im->ieta(),im->iphi()));
-	if( dr < radiusPU_ && exclude == excludedTowers.end()) {
-	  ntowersWithJets_[(*im).ieta()]++;     
-	  excludedTowers.push_back(pair<int,int>(im->ieta(),im->iphi()));
-	}
+    for (vector<HcalDetId>::const_iterator im = allgeomid_.begin(); im != allgeomid_.end(); im++) {
+      double dr = reco::deltaR(geo_->getPosition((DetId)(*im)), (*pseudojetTMP));
+      vector<pair<int, int> >::const_iterator exclude =
+          find(excludedTowers.begin(), excludedTowers.end(), pair<int, int>(im->ieta(), im->iphi()));
+      if (dr < radiusPU_ && exclude == excludedTowers.end()) {
+        ntowersWithJets_[(*im).ieta()]++;
+        excludedTowers.push_back(pair<int, int>(im->ieta(), im->iphi()));
       }
-    vector<fastjet::PseudoJet>::const_iterator it = fjInputs_->begin(),
-      fjInputsEnd = fjInputs_->end();
-      
-    for (; it != fjInputsEnd; ++it ) {
+    }
+    vector<fastjet::PseudoJet>::const_iterator it = fjInputs_->begin(), fjInputsEnd = fjInputs_->end();
+
+    for (; it != fjInputsEnd; ++it) {
       int index = it->user_index();
       int ie = ieta((*inputs_)[index]);
       int ip = iphi((*inputs_)[index]);
-      vector<pair<int,int> >::const_iterator exclude = find(excludedTowers.begin(),excludedTowers.end(),pair<int,int>(ie,ip));
-      if(exclude != excludedTowers.end()) {
-	jettowers.push_back(index);
-      } //dr < radiusPU_
-    } // initial input collection  
-  } // pseudojets
-  
+      vector<pair<int, int> >::const_iterator exclude =
+          find(excludedTowers.begin(), excludedTowers.end(), pair<int, int>(ie, ip));
+      if (exclude != excludedTowers.end()) {
+        jettowers.push_back(index);
+      }  //dr < radiusPU_
+    }    // initial input collection
+  }      // pseudojets
+
   //
-  // Create a new collections from the towers not included in jets 
+  // Create a new collections from the towers not included in jets
   //
-  for(vector<fastjet::PseudoJet>::const_iterator it = fjInputs_->begin(),
-	fjInputsEnd = fjInputs_->end(); it != fjInputsEnd; ++it ) {
+  for (vector<fastjet::PseudoJet>::const_iterator it = fjInputs_->begin(), fjInputsEnd = fjInputs_->end();
+       it != fjInputsEnd;
+       ++it) {
     int index = it->user_index();
-    vector<int>::const_iterator itjet = find(jettowers.begin(),jettowers.end(),index);
-    if( itjet == jettowers.end() ){
+    vector<int>::const_iterator itjet = find(jettowers.begin(), jettowers.end(), index);
+    if (itjet == jettowers.end()) {
       const reco::CandidatePtr& originalTower = (*inputs_)[index];
-      fastjet::PseudoJet orphan(originalTower->px(),originalTower->py(),originalTower->pz(),originalTower->energy());
+      fastjet::PseudoJet orphan(originalTower->px(), originalTower->py(), originalTower->pz(), originalTower->energy());
       orphan.set_user_index(index);
 
-      orphanInput.push_back(orphan); 
+      orphanInput.push_back(orphan);
     }
   }
 }
 
-
-void PileUpSubtractor::offsetCorrectJets() 
-{
-  LogDebug("PileUpSubtractor")<<"The subtractor correcting jets...\n";
+void PileUpSubtractor::offsetCorrectJets() {
+  LogDebug("PileUpSubtractor") << "The subtractor correcting jets...\n";
   jetOffset_.clear();
   using namespace reco;
- 
-  //    
+
+  //
   // Reestimate energy of jet (energy of jet with initial map)
   //
   jetOffset_.reserve(fjJets_->size());
-  vector<fastjet::PseudoJet>::iterator pseudojetTMP = fjJets_->begin (),
-    jetsEnd = fjJets_->end();
+  vector<fastjet::PseudoJet>::iterator pseudojetTMP = fjJets_->begin(), jetsEnd = fjJets_->end();
   for (; pseudojetTMP != jetsEnd; ++pseudojetTMP) {
     int ijet = pseudojetTMP - fjJets_->begin();
     jetOffset_[ijet] = 0;
-    
-    std::vector<fastjet::PseudoJet> towers =
-      fastjet::sorted_by_pt( pseudojetTMP->constituents() );
-    double newjetet = 0.;	
-    for(vector<fastjet::PseudoJet>::const_iterator ito = towers.begin(),
-	  towEnd = towers.end(); 
-	ito != towEnd; 
-	++ito)
-      {
-	const reco::CandidatePtr& originalTower = (*inputs_)[ito->user_index()];
-	int it = ieta( originalTower );
-	double Original_Et = originalTower->et();
-	double etnew = Original_Et - (*emean_.find(it)).second - (*esigma_.find(it)).second; 
-	if(etnew < 0.) etnew = 0;
-	newjetet = newjetet + etnew;
-	jetOffset_[ijet] += Original_Et - etnew;
-      }
-    double mScale = newjetet/pseudojetTMP->Et();
-    LogDebug("PileUpSubtractor")<<"pseudojetTMP->Et() : "<<pseudojetTMP->Et()<<'\n';
-    LogDebug("PileUpSubtractor")<<"newjetet : "<<newjetet<<'\n';
-    LogDebug("PileUpSubtractor")<<"jetOffset_[ijet] : "<<jetOffset_[ijet]<<'\n';
-    LogDebug("PileUpSubtractor")<<"pseudojetTMP->Et() - jetOffset_[ijet] : "<<pseudojetTMP->Et() - jetOffset_[ijet]<<'\n';
-    LogDebug("PileUpSubtractor")<<"Scale is : "<<mScale<<'\n';
+
+    std::vector<fastjet::PseudoJet> towers = fastjet::sorted_by_pt(pseudojetTMP->constituents());
+    double newjetet = 0.;
+    for (vector<fastjet::PseudoJet>::const_iterator ito = towers.begin(), towEnd = towers.end(); ito != towEnd; ++ito) {
+      const reco::CandidatePtr& originalTower = (*inputs_)[ito->user_index()];
+      int it = ieta(originalTower);
+      double Original_Et = originalTower->et();
+      double etnew = Original_Et - (*emean_.find(it)).second - (*esigma_.find(it)).second;
+      if (etnew < 0.)
+        etnew = 0;
+      newjetet = newjetet + etnew;
+      jetOffset_[ijet] += Original_Et - etnew;
+    }
+    double mScale = newjetet / pseudojetTMP->Et();
+    LogDebug("PileUpSubtractor") << "pseudojetTMP->Et() : " << pseudojetTMP->Et() << '\n';
+    LogDebug("PileUpSubtractor") << "newjetet : " << newjetet << '\n';
+    LogDebug("PileUpSubtractor") << "jetOffset_[ijet] : " << jetOffset_[ijet] << '\n';
+    LogDebug("PileUpSubtractor") << "pseudojetTMP->Et() - jetOffset_[ijet] : " << pseudojetTMP->Et() - jetOffset_[ijet]
+                                 << '\n';
+    LogDebug("PileUpSubtractor") << "Scale is : " << mScale << '\n';
     int cshist = pseudojetTMP->cluster_hist_index();
-    pseudojetTMP->reset_momentum(pseudojetTMP->px()*mScale, pseudojetTMP->py()*mScale,
-				 pseudojetTMP->pz()*mScale, pseudojetTMP->e()*mScale);
+    pseudojetTMP->reset_momentum(pseudojetTMP->px() * mScale,
+                                 pseudojetTMP->py() * mScale,
+                                 pseudojetTMP->pz() * mScale,
+                                 pseudojetTMP->e() * mScale);
     pseudojetTMP->set_cluster_hist_index(cshist);
-    
   }
 }
 
-double PileUpSubtractor::getCone(double cone, double eta, double phi, double& et, double& pu){
+double PileUpSubtractor::getCone(double cone, double eta, double phi, double& et, double& pu) {
   pu = 0;
-  
-  for(vector<HcalDetId>::const_iterator im = allgeomid_.begin(); im != allgeomid_.end(); im++){
-     if( im->depth() != 1 ) continue;    
+
+  for (vector<HcalDetId>::const_iterator im = allgeomid_.begin(); im != allgeomid_.end(); im++) {
+    if (im->depth() != 1)
+      continue;
     const GlobalPoint& point = geo_->getPosition((DetId)(*im));
-    double dr = reco::deltaR(point.eta(),point.phi(),eta,phi);      
-    if( dr < cone){
-      pu += (*emean_.find(im->ieta())).second+(*esigma_.find(im->ieta())).second;
+    double dr = reco::deltaR(point.eta(), point.phi(), eta, phi);
+    if (dr < cone) {
+      pu += (*emean_.find(im->ieta())).second + (*esigma_.find(im->ieta())).second;
     }
   }
-  
+
   return pu;
 }
 
-double PileUpSubtractor::getMeanAtTower(const reco::CandidatePtr & in) const{
+double PileUpSubtractor::getMeanAtTower(const reco::CandidatePtr& in) const {
   int it = ieta(in);
   return (*emean_.find(it)).second;
 }
 
-double PileUpSubtractor::getSigmaAtTower(const reco::CandidatePtr & in) const {
-   int it = ieta(in);
-   return (*esigma_.find(it)).second;
+double PileUpSubtractor::getSigmaAtTower(const reco::CandidatePtr& in) const {
+  int it = ieta(in);
+  return (*esigma_.find(it)).second;
 }
 
-double PileUpSubtractor::getPileUpAtTower(const reco::CandidatePtr & in) const {
+double PileUpSubtractor::getPileUpAtTower(const reco::CandidatePtr& in) const {
   int it = ieta(in);
   return (*emean_.find(it)).second + (*esigma_.find(it)).second;
 }
 
-int PileUpSubtractor::getN(const reco::CandidatePtr & in) const {
-   int it = ieta(in);
-   
-   int n = (*(geomtowers_.find(it))).second - (*(ntowersWithJets_.find(it))).second;
-   return n;
+int PileUpSubtractor::getN(const reco::CandidatePtr& in) const {
+  int it = ieta(in);
 
+  int n = (*(geomtowers_.find(it))).second - (*(ntowersWithJets_.find(it))).second;
+  return n;
 }
 
-int PileUpSubtractor::getNwithJets(const reco::CandidatePtr & in) const {
-   int it = ieta(in);
-   int n = (*(ntowersWithJets_.find(it))).second;
-   return n;
-
+int PileUpSubtractor::getNwithJets(const reco::CandidatePtr& in) const {
+  int it = ieta(in);
+  int n = (*(ntowersWithJets_.find(it))).second;
+  return n;
 }
 
-
-int PileUpSubtractor::ieta(const reco::CandidatePtr & in) const {
+int PileUpSubtractor::ieta(const reco::CandidatePtr& in) const {
   int it = 0;
   const CaloTower* ctc = dynamic_cast<const CaloTower*>(in.get());
-  if(ctc){
+  if (ctc) {
     it = ctc->id().ieta();
-  } else
-    {
-      throw cms::Exception("Invalid Constituent") << "CaloJet constituent is not of CaloTower type";
-    }
+  } else {
+    throw cms::Exception("Invalid Constituent") << "CaloJet constituent is not of CaloTower type";
+  }
   return it;
 }
 
-int PileUpSubtractor::iphi(const reco::CandidatePtr & in) const {
+int PileUpSubtractor::iphi(const reco::CandidatePtr& in) const {
   int it = 0;
   const CaloTower* ctc = dynamic_cast<const CaloTower*>(in.get());
-  if(ctc){
+  if (ctc) {
     it = ctc->id().iphi();
-  } else
-    {
-      throw cms::Exception("Invalid Constituent") << "CaloJet constituent is not of CaloTower type";
-    }
+  } else {
+    throw cms::Exception("Invalid Constituent") << "CaloJet constituent is not of CaloTower type";
+  }
   return it;
 }
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-EDM_REGISTER_PLUGINFACTORY(PileUpSubtractorFactory,"PileUpSubtractorFactory");
-
-
-
+EDM_REGISTER_PLUGINFACTORY(PileUpSubtractorFactory, "PileUpSubtractorFactory");

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -1,6 +1,6 @@
-#include<fstream>
-#include<iomanip>
-#include<iostream>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
 
 // DataFormat //
 
@@ -21,7 +21,6 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/Math/interface/Vector3D.h"
-
 
 // FWCore //
 
@@ -48,251 +47,253 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 using namespace std;
-namespace cms
-{
-  
-  PileupJPTJetIdAlgo::PileupJPTJetIdAlgo(const edm::ParameterSet& iConfig)
-  {
-    
-    verbosity   = iConfig.getParameter<int>("Verbosity");
-    tmvaWeights_         = edm::FileInPath(iConfig.getParameter<std::string>("tmvaWeightsCentral")).fullPath();
-    tmvaWeightsF_         = edm::FileInPath(iConfig.getParameter<std::string>("tmvaWeightsForward")).fullPath();
-    tmvaMethod_          = iConfig.getParameter<std::string>("tmvaMethod");
+namespace cms {
 
+  PileupJPTJetIdAlgo::PileupJPTJetIdAlgo(const edm::ParameterSet& iConfig) {
+    verbosity = iConfig.getParameter<int>("Verbosity");
+    tmvaWeights_ = edm::FileInPath(iConfig.getParameter<std::string>("tmvaWeightsCentral")).fullPath();
+    tmvaWeightsF_ = edm::FileInPath(iConfig.getParameter<std::string>("tmvaWeightsForward")).fullPath();
+    tmvaMethod_ = iConfig.getParameter<std::string>("tmvaMethod");
   }
-  
-  PileupJPTJetIdAlgo::~PileupJPTJetIdAlgo()
-  {
-  //  std::cout<<" JetPlusTrack destructor "<<std::endl;
+
+  PileupJPTJetIdAlgo::~PileupJPTJetIdAlgo() {
+    //  std::cout<<" JetPlusTrack destructor "<<std::endl;
   }
-  
-  void PileupJPTJetIdAlgo::bookMVAReader()
-  {
-    
-// Read TMVA tree
-//    std::string mvaw     = "RecoJets/JetProducers/data/TMVAClassification_BDTG.weights.xml";       
-//    std::string mvawF     = "RecoJets/JetProducers/data/TMVAClassification_BDTG.weights_F.xml";
-//    tmvaWeights_         = edm::FileInPath(mvaw).fullPath();
-//    tmvaWeightsF_         = edm::FileInPath(mvawF).fullPath();
-//    tmvaMethod_          = "BDTG method";
 
-    if(verbosity>0) std::cout<<" TMVA method "<<tmvaMethod_.c_str()<<" "<<tmvaWeights_.c_str()<<std::endl;
-    reader_ = new TMVA::Reader( "!Color:!Silent" );
+  void PileupJPTJetIdAlgo::bookMVAReader() {
+    // Read TMVA tree
+    //    std::string mvaw     = "RecoJets/JetProducers/data/TMVAClassification_BDTG.weights.xml";
+    //    std::string mvawF     = "RecoJets/JetProducers/data/TMVAClassification_BDTG.weights_F.xml";
+    //    tmvaWeights_         = edm::FileInPath(mvaw).fullPath();
+    //    tmvaWeightsF_         = edm::FileInPath(mvawF).fullPath();
+    //    tmvaMethod_          = "BDTG method";
 
-    reader_->AddVariable( "Nvtx", &Nvtx );
-    reader_->AddVariable( "PtJ", &PtJ );
-    reader_->AddVariable( "EtaJ", &EtaJ );
-    reader_->AddVariable( "Beta", &Beta );
-    reader_->AddVariable( "MultCalo", &MultCalo );
-    reader_->AddVariable( "dAxis1c", &dAxis1c );
-    reader_->AddVariable( "dAxis2c", &dAxis2c );
-    reader_->AddVariable( "MultTr", &MultTr );
-    reader_->AddVariable( "dAxis1t", &dAxis1t );
-    reader_->AddVariable( "dAxis2t", &dAxis2t );
+    if (verbosity > 0)
+      std::cout << " TMVA method " << tmvaMethod_.c_str() << " " << tmvaWeights_.c_str() << std::endl;
+    reader_ = new TMVA::Reader("!Color:!Silent");
+
+    reader_->AddVariable("Nvtx", &Nvtx);
+    reader_->AddVariable("PtJ", &PtJ);
+    reader_->AddVariable("EtaJ", &EtaJ);
+    reader_->AddVariable("Beta", &Beta);
+    reader_->AddVariable("MultCalo", &MultCalo);
+    reader_->AddVariable("dAxis1c", &dAxis1c);
+    reader_->AddVariable("dAxis2c", &dAxis2c);
+    reader_->AddVariable("MultTr", &MultTr);
+    reader_->AddVariable("dAxis1t", &dAxis1t);
+    reader_->AddVariable("dAxis2t", &dAxis2t);
 
     reco::details::loadTMVAWeights(reader_, tmvaMethod_, tmvaWeights_);
 
     //std::cout<<" Method booked "<<std::endl;
 
+    readerF_ = new TMVA::Reader("!Color:!Silent");
 
-    readerF_ = new TMVA::Reader( "!Color:!Silent" );
-
-    readerF_->AddVariable( "Nvtx", &Nvtx );
-    readerF_->AddVariable( "PtJ", &PtJ );
-    readerF_->AddVariable( "EtaJ", &EtaJ );
-    readerF_->AddVariable( "MultCalo", &MultCalo );
-    readerF_->AddVariable( "dAxis1c", &dAxis1c );
-    readerF_->AddVariable( "dAxis2c", &dAxis2c );
+    readerF_->AddVariable("Nvtx", &Nvtx);
+    readerF_->AddVariable("PtJ", &PtJ);
+    readerF_->AddVariable("EtaJ", &EtaJ);
+    readerF_->AddVariable("MultCalo", &MultCalo);
+    readerF_->AddVariable("dAxis1c", &dAxis1c);
+    readerF_->AddVariable("dAxis2c", &dAxis2c);
 
     reco::details::loadTMVAWeights(readerF_, tmvaMethod_, tmvaWeightsF_);
 
-   // std::cout<<" Method booked F "<<std::endl;
+    // std::cout<<" Method booked F "<<std::endl;
   }
 
-float PileupJPTJetIdAlgo::fillJPTBlock(const reco::JPTJet* jet
-                                      )
-{
-
-      if (verbosity > 0) { 
-	std::cout<<"================================    JET LOOP  ====================  "   <<  std::endl;
-	std::cout<<"================    jetPt   =  "   << (*jet).pt()  <<  std::endl;
-	std::cout<<"================    jetEta   =  "   << (*jet).eta()  <<  std::endl;
-      }      
+  float PileupJPTJetIdAlgo::fillJPTBlock(const reco::JPTJet* jet) {
+    if (verbosity > 0) {
+      std::cout << "================================    JET LOOP  ====================  " << std::endl;
+      std::cout << "================    jetPt   =  " << (*jet).pt() << std::endl;
+      std::cout << "================    jetEta   =  " << (*jet).eta() << std::endl;
+    }
 
     edm::RefToBase<reco::Jet> jptjetRef = jet->getCaloJetRef();
-    reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);
- 
+    reco::CaloJet const* rawcalojet = dynamic_cast<reco::CaloJet const*>(&*jptjetRef);
 
-      int ncalotowers=0.;
-      double sumpt=0.;
-      double dphi2=0.;
-      double deta2=0.;
-      double dphi1=0.;
-      double dphideta=0.;     
-      double deta1=0.;
-      double EE=0.;
-      double HE=0.;
-      double EELong=0.;
-      double EEShort=0.;
- 
-      std::vector <CaloTowerPtr> calotwrs = (*rawcalojet).getCaloConstituents();
+    int ncalotowers = 0.;
+    double sumpt = 0.;
+    double dphi2 = 0.;
+    double deta2 = 0.;
+    double dphi1 = 0.;
+    double dphideta = 0.;
+    double deta1 = 0.;
+    double EE = 0.;
+    double HE = 0.;
+    double EELong = 0.;
+    double EEShort = 0.;
 
-      if (verbosity > 0) { std::cout<<"=======    CaloTowerPtr DONE   ==  "   <<  std::endl;}      
-      
-      for(std::vector <CaloTowerPtr>::const_iterator icalot = calotwrs.begin();
-	                                             icalot!= calotwrs.end(); icalot++) {
-	ncalotowers++;
-	
-	double  deta=(*jet).eta()-(*icalot)->eta();
-	double  dphi=(*jet).phi()-(*icalot)->phi();
+    std::vector<CaloTowerPtr> calotwrs = (*rawcalojet).getCaloConstituents();
 
-	if(dphi > M_PI ) dphi = dphi-2.*M_PI;
-	if(dphi < -1.*M_PI ) dphi = dphi+2.*M_PI;
+    if (verbosity > 0) {
+      std::cout << "=======    CaloTowerPtr DONE   ==  " << std::endl;
+    }
 
-       if (verbosity > 0)  std::cout<<" CaloTower jet eta "<<(*jet).eta()<<" tower eta "<<(*icalot)->eta()<<" jet phi "<<(*jet).phi()<<" tower phi "<<(*icalot)->phi()<<" dphi "<<dphi<<" "<<(*icalot)->pt()<<" ieta "<<(*icalot)->ieta()<<" "<<abs((*icalot)->ieta())<<std::endl;
+    for (std::vector<CaloTowerPtr>::const_iterator icalot = calotwrs.begin(); icalot != calotwrs.end(); icalot++) {
+      ncalotowers++;
 
-	
-        if(abs((*icalot)->ieta())<30) EE = EE + (*icalot)->emEnergy();
-        if(abs((*icalot)->ieta())<30) HE = HE + (*icalot)->hadEnergy();
-        if(abs((*icalot)->ieta())>29) EELong = EELong + (*icalot)->emEnergy();
-        if(abs((*icalot)->ieta())>29) EEShort = EEShort + (*icalot)->hadEnergy();
+      double deta = (*jet).eta() - (*icalot)->eta();
+      double dphi = (*jet).phi() - (*icalot)->phi();
 
-	sumpt = sumpt + (*icalot)->pt();
-	dphi2 = dphi2 + dphi*dphi*(*icalot)->pt();
-	deta2 = deta2 + deta*deta*(*icalot)->pt();	
-	dphi1 = dphi1 + dphi*(*icalot)->pt();
-        deta1 = deta1 + deta*(*icalot)->pt();	
-        dphideta = dphideta + dphi*deta*(*icalot)->pt();	
+      if (dphi > M_PI)
+        dphi = dphi - 2. * M_PI;
+      if (dphi < -1. * M_PI)
+        dphi = dphi + 2. * M_PI;
 
-      } // calojet constituents
-      
-            
-      if( sumpt > 0.) {
-		      deta1 = deta1/sumpt;
-		      dphi1 = dphi1/sumpt;
-		      deta2 = deta2/sumpt;
-		      dphi2 = dphi2/sumpt;
-		      dphideta = dphideta/sumpt;
+      if (verbosity > 0)
+        std::cout << " CaloTower jet eta " << (*jet).eta() << " tower eta " << (*icalot)->eta() << " jet phi "
+                  << (*jet).phi() << " tower phi " << (*icalot)->phi() << " dphi " << dphi << " " << (*icalot)->pt()
+                  << " ieta " << (*icalot)->ieta() << " " << abs((*icalot)->ieta()) << std::endl;
+
+      if (abs((*icalot)->ieta()) < 30)
+        EE = EE + (*icalot)->emEnergy();
+      if (abs((*icalot)->ieta()) < 30)
+        HE = HE + (*icalot)->hadEnergy();
+      if (abs((*icalot)->ieta()) > 29)
+        EELong = EELong + (*icalot)->emEnergy();
+      if (abs((*icalot)->ieta()) > 29)
+        EEShort = EEShort + (*icalot)->hadEnergy();
+
+      sumpt = sumpt + (*icalot)->pt();
+      dphi2 = dphi2 + dphi * dphi * (*icalot)->pt();
+      deta2 = deta2 + deta * deta * (*icalot)->pt();
+      dphi1 = dphi1 + dphi * (*icalot)->pt();
+      deta1 = deta1 + deta * (*icalot)->pt();
+      dphideta = dphideta + dphi * deta * (*icalot)->pt();
+
+    }  // calojet constituents
+
+    if (sumpt > 0.) {
+      deta1 = deta1 / sumpt;
+      dphi1 = dphi1 / sumpt;
+      deta2 = deta2 / sumpt;
+      dphi2 = dphi2 / sumpt;
+      dphideta = dphideta / sumpt;
+    }
+
+    // W.r.t. principal axis
+
+    double detavar = deta2 - deta1 * deta1;
+    double dphivar = dphi2 - dphi1 * dphi1;
+    double dphidetacov = dphideta - deta1 * dphi1;
+
+    double det = (detavar - dphivar) * (detavar - dphivar) + 4 * dphidetacov * dphidetacov;
+    det = sqrt(det);
+    double x1 = (detavar + dphivar + det) / 2.;
+    double x2 = (detavar + dphivar - det) / 2.;
+
+    if (verbosity > 0)
+      std::cout << " ncalo " << ncalotowers << " deta2 " << deta2 << " dphi2 " << dphi2 << " deta1 " << deta1
+                << " dphi1 " << dphi1 << " detavar " << detavar << " dphivar " << dphivar << " dphidetacov "
+                << dphidetacov << " sqrt(det) " << sqrt(det) << " x1 " << x1 << " x2 " << x2 << std::endl;
+
+    // For jets with |eta|<2 take also tracks shape
+    int ntracks = 0.;
+    double sumpttr = 0.;
+    double dphitr2 = 0.;
+    double detatr2 = 0.;
+    double dphitr1 = 0.;
+    double detatr1 = 0.;
+    double dphidetatr = 0.;
+
+    const reco::TrackRefVector pioninin = (*jet).getPionsInVertexInCalo();
+
+    for (reco::TrackRefVector::const_iterator it = pioninin.begin(); it != pioninin.end(); it++) {
+      if ((*it)->pt() > 0.5 && ((*it)->ptError() / (*it)->pt()) < 0.05) {
+        ntracks++;
+        sumpttr = sumpttr + (*it)->pt();
+        double deta = (*jet).eta() - (*it)->eta();
+        double dphi = (*jet).phi() - (*it)->phi();
+
+        if (dphi > M_PI)
+          dphi = dphi - 2. * M_PI;
+        if (dphi < -1. * M_PI)
+          dphi = dphi + 2. * M_PI;
+
+        dphitr2 = dphitr2 + dphi * dphi * (*it)->pt();
+        detatr2 = detatr2 + deta * deta * (*it)->pt();
+        dphitr1 = dphitr1 + dphi * (*it)->pt();
+        detatr1 = detatr1 + deta * (*it)->pt();
+        dphidetatr = dphidetatr + dphi * deta * (*it)->pt();
+        if (verbosity > 0)
+          std::cout << " Tracks-in-in " << (*it)->pt() << " " << (*it)->eta() << " " << (*it)->phi() << " in jet "
+                    << (*jet).eta() << " " << (*jet).phi() << " jet pt " << (*jet).pt() << std::endl;
       }
-      
-  // W.r.t. principal axis
+    }  // pioninin
 
-      double detavar = deta2-deta1*deta1;
-      double dphivar = dphi2-dphi1*dphi1;
-      double dphidetacov = dphideta - deta1*dphi1;
-      
-      double det = (detavar-dphivar)*(detavar-dphivar)+4*dphidetacov*dphidetacov;
-      det = sqrt(det);
-      double x1 = (detavar+dphivar+det)/2.;
-      double x2 = (detavar+dphivar-det)/2.;
-      
-      
-  
-if (verbosity > 0)  
-std::cout<<" ncalo "<<ncalotowers<<" deta2 "<<deta2<<" dphi2 "<<dphi2<<" deta1 "<<deta1<<" dphi1 "<<dphi1<<" detavar "<<detavar<<" dphivar "<<dphivar<<" dphidetacov "<<dphidetacov<<" sqrt(det) "<<sqrt(det)<<" x1 "<<x1<<" x2 "<<x2<<std::endl;
+    const reco::TrackRefVector pioninout = (*jet).getPionsInVertexOutCalo();
 
- 
-// For jets with |eta|<2 take also tracks shape
-      int ntracks=0.;
-      double sumpttr=0.;
-      double dphitr2=0.;
-      double detatr2=0.;
-      double dphitr1=0.;
-      double detatr1=0.;
-      double dphidetatr=0.;     
+    for (reco::TrackRefVector::const_iterator it = pioninout.begin(); it != pioninout.end(); it++) {
+      if ((*it)->pt() > 0.5 && ((*it)->ptError() / (*it)->pt()) < 0.05) {
+        ntracks++;
+        sumpttr = sumpttr + (*it)->pt();
+        double deta = (*jet).eta() - (*it)->eta();
+        double dphi = (*jet).phi() - (*it)->phi();
 
-      const reco::TrackRefVector pioninin = (*jet).getPionsInVertexInCalo();
-      
-      for(reco::TrackRefVector::const_iterator it = pioninin.begin(); it != pioninin.end(); it++) {      
-            if ((*it)->pt() > 0.5 && ((*it)->ptError()/(*it)->pt()) < 0.05 )
-              {              
-                 ntracks++;
-		 sumpttr = sumpttr + (*it)->pt();	
-		 double  deta=(*jet).eta()-(*it)->eta();
-	         double  dphi=(*jet).phi()-(*it)->phi();
+        if (dphi > M_PI)
+          dphi = dphi - 2. * M_PI;
+        if (dphi < -1. * M_PI)
+          dphi = dphi + 2. * M_PI;
 
-	         if(dphi > M_PI ) dphi = dphi-2.*M_PI;
-	         if(dphi < -1.*M_PI ) dphi = dphi+2.*M_PI;
-
-	         dphitr2 = dphitr2 + dphi*dphi*(*it)->pt();
-	         detatr2 = detatr2 + deta*deta*(*it)->pt();	
-	         dphitr1 = dphitr1 + dphi*(*it)->pt();
-                 detatr1 = detatr1 + deta*(*it)->pt();	
-                 dphidetatr = dphidetatr + dphi*deta*(*it)->pt();
-        if(verbosity>0) std::cout<<" Tracks-in-in "<<(*it)->pt()<<" "<<(*it)->eta()<<" "<<(*it)->phi()<<" in jet "<<(*jet).eta()<<" "<<
-         (*jet).phi()<<" jet pt "<<(*jet).pt()<<std::endl;	
-              }
-      }// pioninin
-      
-      
-       const reco::TrackRefVector pioninout = (*jet).getPionsInVertexOutCalo();
-      
-      for(reco::TrackRefVector::const_iterator it = pioninout.begin(); it != pioninout.end(); it++) {      
-            if ((*it)->pt() > 0.5 && ((*it)->ptError()/(*it)->pt()) < 0.05 )
-              {              
-                 ntracks++;
-		 sumpttr = sumpttr + (*it)->pt();	
-		 double  deta=(*jet).eta()-(*it)->eta();
-	         double  dphi=(*jet).phi()-(*it)->phi();
-
-	         if(dphi > M_PI ) dphi = dphi-2.*M_PI;
-	         if(dphi < -1.*M_PI ) dphi = dphi+2.*M_PI;
-
-	         dphitr2 = dphitr2 + dphi*dphi*(*it)->pt();
-	         detatr2 = detatr2 + deta*deta*(*it)->pt();	
-	         dphitr1 = dphitr1 + dphi*(*it)->pt();
-                 detatr1 = detatr1 + deta*(*it)->pt();	
-                 dphidetatr = dphidetatr + dphi*deta*(*it)->pt();	
-        if(verbosity>0) std::cout<<" Tracks-in-in "<<(*it)->pt()<<" "<<(*it)->eta()<<" "<<(*it)->phi()<<" in jet "<<(*jet).eta()<<" "<< 
-         (*jet).phi()<<" jet pt "<<(*jet).pt()<<std::endl;
-              }
-      }// pioninout
-
-      if(verbosity>0) std::cout<<" Number of tracks in-in and in-out "<<pioninin.size()<<" "<<pioninout.size()<<std::endl;
-
-      	       
-      if( sumpttr > 0.) {
-		      detatr1 = detatr1/sumpttr;
-		      dphitr1 = dphitr1/sumpttr;
-		      detatr2 = detatr2/sumpttr;
-		      dphitr2 = dphitr2/sumpttr;
-		      dphidetatr = dphidetatr/sumpttr;
+        dphitr2 = dphitr2 + dphi * dphi * (*it)->pt();
+        detatr2 = detatr2 + deta * deta * (*it)->pt();
+        dphitr1 = dphitr1 + dphi * (*it)->pt();
+        detatr1 = detatr1 + deta * (*it)->pt();
+        dphidetatr = dphidetatr + dphi * deta * (*it)->pt();
+        if (verbosity > 0)
+          std::cout << " Tracks-in-in " << (*it)->pt() << " " << (*it)->eta() << " " << (*it)->phi() << " in jet "
+                    << (*jet).eta() << " " << (*jet).phi() << " jet pt " << (*jet).pt() << std::endl;
       }
+    }  // pioninout
 
-  // W.r.t. principal axis
+    if (verbosity > 0)
+      std::cout << " Number of tracks in-in and in-out " << pioninin.size() << " " << pioninout.size() << std::endl;
 
-      double detavart = detatr2-detatr1*detatr1;
-      double dphivart = dphitr2-dphitr1*dphitr1;
-      double dphidetacovt = dphidetatr - detatr1*dphitr1;
-      
-      double dettr = (detavart-dphivart)*(detavart-dphivart)+4*dphidetacovt*dphidetacovt;
-      dettr = sqrt(dettr);
-      double x1tr = (detavart+dphivart+dettr)/2.;
-      double x2tr = (detavart+dphivart-dettr)/2.;
-     
-        if (verbosity > 0) std::cout<<" ntracks "<<ntracks<<" detatr2 "<<detatr2<<" dphitr2 "<<dphitr2<<" detatr1 "<<detatr1<<" dphitr1 "<<dphitr1<<" detavart "<<detavart<<" dphivart "<<dphivart<<" dphidetacovt "<<dphidetacovt<<" sqrt(det) "<<sqrt(dettr)<<" x1tr "<<x1tr<<" x2tr "<<x2tr<<std::endl;
- 
-// Multivariate analisis
-      PtJ = (*jet).pt();          
-      EtaJ = (*jet).eta();
-      Beta = (*jet).getSpecific().Zch;
-      dAxis2c = x2;
-      dAxis1c = x1;
-      dAxis2t = x2tr;
-      dAxis1t = x1tr;
-      MultCalo = ncalotowers;
-      MultTr = ntracks;
+    if (sumpttr > 0.) {
+      detatr1 = detatr1 / sumpttr;
+      dphitr1 = dphitr1 / sumpttr;
+      detatr2 = detatr2 / sumpttr;
+      dphitr2 = dphitr2 / sumpttr;
+      dphidetatr = dphidetatr / sumpttr;
+    }
 
-     float mva_ = 1.;
-     if(fabs(EtaJ)<2.6) {
-       mva_ = reader_->EvaluateMVA( "BDTG method" );
+    // W.r.t. principal axis
+
+    double detavart = detatr2 - detatr1 * detatr1;
+    double dphivart = dphitr2 - dphitr1 * dphitr1;
+    double dphidetacovt = dphidetatr - detatr1 * dphitr1;
+
+    double dettr = (detavart - dphivart) * (detavart - dphivart) + 4 * dphidetacovt * dphidetacovt;
+    dettr = sqrt(dettr);
+    double x1tr = (detavart + dphivart + dettr) / 2.;
+    double x2tr = (detavart + dphivart - dettr) / 2.;
+
+    if (verbosity > 0)
+      std::cout << " ntracks " << ntracks << " detatr2 " << detatr2 << " dphitr2 " << dphitr2 << " detatr1 " << detatr1
+                << " dphitr1 " << dphitr1 << " detavart " << detavart << " dphivart " << dphivart << " dphidetacovt "
+                << dphidetacovt << " sqrt(det) " << sqrt(dettr) << " x1tr " << x1tr << " x2tr " << x2tr << std::endl;
+
+    // Multivariate analisis
+    PtJ = (*jet).pt();
+    EtaJ = (*jet).eta();
+    Beta = (*jet).getSpecific().Zch;
+    dAxis2c = x2;
+    dAxis1c = x1;
+    dAxis2t = x2tr;
+    dAxis1t = x1tr;
+    MultCalo = ncalotowers;
+    MultTr = ntracks;
+
+    float mva_ = 1.;
+    if (fabs(EtaJ) < 2.6) {
+      mva_ = reader_->EvaluateMVA("BDTG method");
       // std::cout<<" MVA analysis "<<mva_<<std::endl;
-      } else {
-        mva_ = readerF_->EvaluateMVA( "BDTG method" );
+    } else {
+      mva_ = readerF_->EvaluateMVA("BDTG method");
       // std::cout<<" MVA analysis Forward "<<mva_<<std::endl;
-      }
-  if (verbosity > 0) std::cout<<"=======  Computed MVA =  " << 
-                                           mva_  <<std::endl;   
-  return mva_;
-} // fillJPTBlock
-} // namespace
+    }
+    if (verbosity > 0)
+      std::cout << "=======  Computed MVA =  " << mva_ << std::endl;
+    return mva_;
+  }  // fillJPTBlock
+}  // namespace cms

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -18,17 +18,15 @@ const float large_val = std::numeric_limits<float>::max();
 
 // ------------------------------------------------------------------------------------------
 
-PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::ParameterSet const& ps, bool runMvas) :
-  cutBased_(ps.getParameter<bool>("cutBased")),
-  etaBinnedWeights_(false),
-  runMvas_(runMvas),
-  nEtaBins_(0),
-  label_(ps.getParameter<std::string>("label")),
-  mvacut_{},
-  rmsCut_{},
-  betaStarCut_{}
- {
-
+PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::ParameterSet const& ps, bool runMvas)
+    : cutBased_(ps.getParameter<bool>("cutBased")),
+      etaBinnedWeights_(false),
+      runMvas_(runMvas),
+      nEtaBins_(0),
+      label_(ps.getParameter<std::string>("label")),
+      mvacut_{},
+      rmsCut_{},
+      betaStarCut_{} {
   std::vector<edm::FileInPath> tmvaEtaWeights;
   std::vector<std::string> tmvaSpectators;
   int version;
@@ -36,15 +34,15 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
   if (!cutBased_) {
     etaBinnedWeights_ = ps.getParameter<bool>("etaBinnedWeights");
     if (etaBinnedWeights_) {
-      const std::vector<edm::ParameterSet>& trainings = ps.getParameter<std::vector <edm::ParameterSet> >("trainings");
+      const std::vector<edm::ParameterSet>& trainings = ps.getParameter<std::vector<edm::ParameterSet> >("trainings");
       nEtaBins_ = ps.getParameter<int>("nEtaBins");
       for (int v = 0; v < nEtaBins_; v++) {
         tmvaEtaWeights.push_back(trainings.at(v).getParameter<edm::FileInPath>("tmvaWeights"));
-        jEtaMin_.push_back( trainings.at(v).getParameter<double>("jEtaMin") );
-        jEtaMax_.push_back( trainings.at(v).getParameter<double>("jEtaMax") );
+        jEtaMin_.push_back(trainings.at(v).getParameter<double>("jEtaMin"));
+        jEtaMax_.push_back(trainings.at(v).getParameter<double>("jEtaMax"));
       }
       for (int v = 0; v < nEtaBins_; v++) {
-        tmvaEtaVariables_.push_back( trainings.at(v).getParameter<std::vector<std::string> >("tmvaVariables") );
+        tmvaEtaVariables_.push_back(trainings.at(v).getParameter<std::vector<std::string> >("tmvaVariables"));
       }
     } else {
       tmvaVariables_ = ps.getParameter<std::vector<std::string> >("tmvaVariables");
@@ -58,45 +56,62 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
 
   edm::ParameterSet jetConfig = ps.getParameter<edm::ParameterSet>("JetIdParams");
   for (int i0 = 0; i0 < 3; i0++) {
-    std::string lCutType                             = "Tight";
-    if (i0 == PileupJetIdentifier::kMedium) lCutType = "Medium";
-    if (i0 == PileupJetIdentifier::kLoose)  lCutType = "Loose";
+    std::string lCutType = "Tight";
+    if (i0 == PileupJetIdentifier::kMedium)
+      lCutType = "Medium";
+    if (i0 == PileupJetIdentifier::kLoose)
+      lCutType = "Loose";
     int nCut = 1;
-    if(cutBased_) nCut++;
+    if (cutBased_)
+      nCut++;
     for (int i1 = 0; i1 < nCut; i1++) {
       std::string lFullCutType = lCutType;
-      if (cutBased_ && i1 == 0) lFullCutType = "BetaStar"+ lCutType;
-      if (cutBased_ && i1 == 1) lFullCutType = "RMS"     + lCutType;
-      std::vector<double> pt010  = jetConfig.getParameter<std::vector<double> >(("Pt010_" +lFullCutType).c_str());
-      std::vector<double> pt1020 = jetConfig.getParameter<std::vector<double> >(("Pt1020_"+lFullCutType).c_str());
-      std::vector<double> pt2030 = jetConfig.getParameter<std::vector<double> >(("Pt2030_"+lFullCutType).c_str());
-      std::vector<double> pt3050 = jetConfig.getParameter<std::vector<double> >(("Pt3050_"+lFullCutType).c_str());
+      if (cutBased_ && i1 == 0)
+        lFullCutType = "BetaStar" + lCutType;
+      if (cutBased_ && i1 == 1)
+        lFullCutType = "RMS" + lCutType;
+      std::vector<double> pt010 = jetConfig.getParameter<std::vector<double> >(("Pt010_" + lFullCutType).c_str());
+      std::vector<double> pt1020 = jetConfig.getParameter<std::vector<double> >(("Pt1020_" + lFullCutType).c_str());
+      std::vector<double> pt2030 = jetConfig.getParameter<std::vector<double> >(("Pt2030_" + lFullCutType).c_str());
+      std::vector<double> pt3050 = jetConfig.getParameter<std::vector<double> >(("Pt3050_" + lFullCutType).c_str());
       if (!cutBased_) {
-        for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][0][i2] = pt010 [i2];
-        for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][1][i2] = pt1020[i2];
-        for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][2][i2] = pt2030[i2];
-        for (int i2 = 0; i2 < 4; i2++) mvacut_[i0][3][i2] = pt3050[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          mvacut_[i0][0][i2] = pt010[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          mvacut_[i0][1][i2] = pt1020[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          mvacut_[i0][2][i2] = pt2030[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          mvacut_[i0][3][i2] = pt3050[i2];
       }
       if (cutBased_ && i1 == 0) {
-        for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][0][i2] = pt010 [i2];
-        for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][1][i2] = pt1020[i2];
-        for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][2][i2] = pt2030[i2];
-        for (int i2 = 0; i2 < 4; i2++) betaStarCut_[i0][3][i2] = pt3050[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          betaStarCut_[i0][0][i2] = pt010[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          betaStarCut_[i0][1][i2] = pt1020[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          betaStarCut_[i0][2][i2] = pt2030[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          betaStarCut_[i0][3][i2] = pt3050[i2];
       }
       if (cutBased_ && i1 == 1) {
-        for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][0][i2] = pt010 [i2];
-        for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][1][i2] = pt1020[i2];
-        for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][2][i2] = pt2030[i2];
-        for (int i2 = 0; i2 < 4; i2++) rmsCut_[i0][3][i2] = pt3050[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          rmsCut_[i0][0][i2] = pt010[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          rmsCut_[i0][1][i2] = pt1020[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          rmsCut_[i0][2][i2] = pt2030[i2];
+        for (int i2 = 0; i2 < 4; i2++)
+          rmsCut_[i0][3][i2] = pt3050[i2];
       }
     }
   }
 
-  if ( ! cutBased_ ) {
-    assert( tmvaMethod_.empty() || ((! tmvaVariables_.empty() || ( !tmvaEtaVariables_.empty() )) && version == USER) );
+  if (!cutBased_) {
+    assert(tmvaMethod_.empty() || ((!tmvaVariables_.empty() || (!tmvaEtaVariables_.empty())) && version == USER));
   }
 
-  if (( ! cutBased_ ) && (runMvas_)) {
+  if ((!cutBased_) && (runMvas_)) {
     if (etaBinnedWeights_) {
       for (int v = 0; v < nEtaBins_; v++) {
         etaReader_.push_back(createGBRForest(tmvaEtaWeights.at(v)));
@@ -107,66 +122,56 @@ PileupJetIdAlgo::AlgoGBRForestsAndConstants::AlgoGBRForestsAndConstants(edm::Par
   }
 }
 
-PileupJetIdAlgo::PileupJetIdAlgo(AlgoGBRForestsAndConstants const* cache) :
-  cache_(cache) {
+PileupJetIdAlgo::PileupJetIdAlgo(AlgoGBRForestsAndConstants const* cache) : cache_(cache) { initVariables(); }
 
-  initVariables();
+// ------------------------------------------------------------------------------------------
+PileupJetIdAlgo::~PileupJetIdAlgo() {}
+
+// ------------------------------------------------------------------------------------------
+void assign(const std::vector<float>& vec, float& a, float& b, float& c, float& d) {
+  size_t sz = vec.size();
+  a = (sz > 0 ? vec[0] : 0.);
+  b = (sz > 1 ? vec[1] : 0.);
+  c = (sz > 2 ? vec[2] : 0.);
+  d = (sz > 3 ? vec[3] : 0.);
+}
+// ------------------------------------------------------------------------------------------
+void setPtEtaPhi(const reco::Candidate& p, float& pt, float& eta, float& phi) {
+  pt = p.pt();
+  eta = p.eta();
+  phi = p.phi();
 }
 
 // ------------------------------------------------------------------------------------------
-PileupJetIdAlgo::~PileupJetIdAlgo() 
-{
-}
-
-// ------------------------------------------------------------------------------------------
-void assign(const std::vector<float> & vec, float & a, float & b, float & c, float & d )
-{
-	size_t sz = vec.size();
-	a = ( sz > 0 ? vec[0] : 0. );
-	b = ( sz > 1 ? vec[1] : 0. );
-	c = ( sz > 2 ? vec[2] : 0. );
-	d = ( sz > 3 ? vec[3] : 0. );
-}
-// ------------------------------------------------------------------------------------------
-void setPtEtaPhi(const reco::Candidate & p, float & pt, float & eta, float &phi )
-{
-	pt  = p.pt();
-	eta = p.eta();
-	phi = p.phi();
-}
-
-// ------------------------------------------------------------------------------------------
-void PileupJetIdAlgo::set(const PileupJetIdentifier & id)
-{
-	internalId_ = id;
-}
+void PileupJetIdAlgo::set(const PileupJetIdentifier& id) { internalId_ = id; }
 
 // ------------------------------------------------------------------------------------------
 
-float PileupJetIdAlgo::getMVAval(const std::vector<std::string> &varList, const std::unique_ptr<const GBRForest> &reader)
-{
-        std::vector<float> vars;
-        for(std::vector<std::string>::const_iterator it=varList.begin(); it!=varList.end(); ++it) {
-            std::pair<float *,float> var = variables_.at(*it);
-            vars.push_back( *var.first );
-        }
-        return reader->GetClassifier(vars.data());
+float PileupJetIdAlgo::getMVAval(const std::vector<std::string>& varList,
+                                 const std::unique_ptr<const GBRForest>& reader) {
+  std::vector<float> vars;
+  for (std::vector<std::string>::const_iterator it = varList.begin(); it != varList.end(); ++it) {
+    std::pair<float*, float> var = variables_.at(*it);
+    vars.push_back(*var.first);
+  }
+  return reader->GetClassifier(vars.data());
 }
 
-void PileupJetIdAlgo::runMva()
-{
-  if( cache_->cutBased() ) {
-    internalId_.idFlag_ = computeCutIDflag(internalId_.betaStarClassic_,internalId_.dR2Mean_,internalId_.nvtx_,internalId_.jetPt_,internalId_.jetEta_);
+void PileupJetIdAlgo::runMva() {
+  if (cache_->cutBased()) {
+    internalId_.idFlag_ = computeCutIDflag(
+        internalId_.betaStarClassic_, internalId_.dR2Mean_, internalId_.nvtx_, internalId_.jetPt_, internalId_.jetEta_);
   } else {
-    if(std::abs(internalId_.jetEta_) >= 5.0) {
+    if (std::abs(internalId_.jetEta_) >= 5.0) {
       internalId_.mva_ = -2.;
     } else {
-      if(cache_->etaBinnedWeights()){
-        if(std::abs(internalId_.jetEta_) > cache_->jEtaMax().at(cache_->nEtaBins() - 1)) {
+      if (cache_->etaBinnedWeights()) {
+        if (std::abs(internalId_.jetEta_) > cache_->jEtaMax().at(cache_->nEtaBins() - 1)) {
           internalId_.mva_ = -2.;
         } else {
-          for(int v = 0; v < cache_->nEtaBins(); v++){
-            if(std::abs(internalId_.jetEta_) >= cache_->jEtaMin().at(v) && std::abs(internalId_.jetEta_) < cache_->jEtaMax().at(v)) {
+          for (int v = 0; v < cache_->nEtaBins(); v++) {
+            if (std::abs(internalId_.jetEta_) >= cache_->jEtaMin().at(v) &&
+                std::abs(internalId_.jetEta_) < cache_->jEtaMax().at(v)) {
               internalId_.mva_ = getMVAval(cache_->tmvaEtaVariables().at(v), cache_->etaReader().at(v));
               break;
             }
@@ -176,629 +181,688 @@ void PileupJetIdAlgo::runMva()
         internalId_.mva_ = getMVAval(cache_->tmvaVariables(), cache_->reader());
       }
     }
-    internalId_.idFlag_ = computeIDflag(internalId_.mva_,internalId_.jetPt_,internalId_.jetEta_);
+    internalId_.idFlag_ = computeIDflag(internalId_.mva_, internalId_.jetPt_, internalId_.jetEta_);
   }
 }
 
 // ------------------------------------------------------------------------------------------
-std::pair<int,int> PileupJetIdAlgo::getJetIdKey(float jetPt, float jetEta)
-{
+std::pair<int, int> PileupJetIdAlgo::getJetIdKey(float jetPt, float jetEta) {
   int ptId = 0;
-  if(jetPt >= 10 && jetPt < 20) ptId = 1;                                                                                 
-  if(jetPt >= 20 && jetPt < 30) ptId = 2;                                                                                 
-  if(jetPt >= 30              ) ptId = 3;                                                                                          
-  
+  if (jetPt >= 10 && jetPt < 20)
+    ptId = 1;
+  if (jetPt >= 20 && jetPt < 30)
+    ptId = 2;
+  if (jetPt >= 30)
+    ptId = 3;
+
   int etaId = 0;
-  if(std::abs(jetEta) >= 2.5  && std::abs(jetEta) < 2.75) etaId = 1;                                                              
-  if(std::abs(jetEta) >= 2.75 && std::abs(jetEta) < 3.0 ) etaId = 2;                                                              
-  if(std::abs(jetEta) >= 3.0  && std::abs(jetEta) < 5.0 ) etaId = 3;                                 
+  if (std::abs(jetEta) >= 2.5 && std::abs(jetEta) < 2.75)
+    etaId = 1;
+  if (std::abs(jetEta) >= 2.75 && std::abs(jetEta) < 3.0)
+    etaId = 2;
+  if (std::abs(jetEta) >= 3.0 && std::abs(jetEta) < 5.0)
+    etaId = 3;
 
-  return std::pair<int,int>(ptId,etaId);
+  return std::pair<int, int>(ptId, etaId);
 }
 // ------------------------------------------------------------------------------------------
-int PileupJetIdAlgo::computeCutIDflag(float betaStarClassic,float dR2Mean,float nvtx, float jetPt, float jetEta)
-{
-  std::pair<int,int> jetIdKey = getJetIdKey(jetPt,jetEta);
-  float betaStarModified = betaStarClassic/log(nvtx-0.64);
+int PileupJetIdAlgo::computeCutIDflag(float betaStarClassic, float dR2Mean, float nvtx, float jetPt, float jetEta) {
+  std::pair<int, int> jetIdKey = getJetIdKey(jetPt, jetEta);
+  float betaStarModified = betaStarClassic / log(nvtx - 0.64);
   int idFlag(0);
-  if(betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kTight ][jetIdKey.first][jetIdKey.second] &&
-     dR2Mean          < cache_->rmsCut()     [PileupJetIdentifier::kTight ][jetIdKey.first][jetIdKey.second]
-     ) idFlag += 1 <<  PileupJetIdentifier::kTight;
+  if (betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kTight][jetIdKey.first][jetIdKey.second] &&
+      dR2Mean < cache_->rmsCut()[PileupJetIdentifier::kTight][jetIdKey.first][jetIdKey.second])
+    idFlag += 1 << PileupJetIdentifier::kTight;
 
-  if(betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kMedium ][jetIdKey.first][jetIdKey.second] &&
-     dR2Mean          < cache_->rmsCut()     [PileupJetIdentifier::kMedium ][jetIdKey.first][jetIdKey.second]
-     ) idFlag += 1 <<  PileupJetIdentifier::kMedium;
-  
-  if(betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kLoose  ][jetIdKey.first][jetIdKey.second] &&
-     dR2Mean          < cache_->rmsCut()     [PileupJetIdentifier::kLoose  ][jetIdKey.first][jetIdKey.second]
-     ) idFlag += 1 <<  PileupJetIdentifier::kLoose;
+  if (betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kMedium][jetIdKey.first][jetIdKey.second] &&
+      dR2Mean < cache_->rmsCut()[PileupJetIdentifier::kMedium][jetIdKey.first][jetIdKey.second])
+    idFlag += 1 << PileupJetIdentifier::kMedium;
+
+  if (betaStarModified < cache_->betaStarCut()[PileupJetIdentifier::kLoose][jetIdKey.first][jetIdKey.second] &&
+      dR2Mean < cache_->rmsCut()[PileupJetIdentifier::kLoose][jetIdKey.first][jetIdKey.second])
+    idFlag += 1 << PileupJetIdentifier::kLoose;
   return idFlag;
 }
 // ------------------------------------------------------------------------------------------
-int PileupJetIdAlgo::computeIDflag(float mva, float jetPt, float jetEta)
-{
-  std::pair<int,int> jetIdKey = getJetIdKey(jetPt,jetEta);
-  return computeIDflag(mva,jetIdKey.first,jetIdKey.second);
+int PileupJetIdAlgo::computeIDflag(float mva, float jetPt, float jetEta) {
+  std::pair<int, int> jetIdKey = getJetIdKey(jetPt, jetEta);
+  return computeIDflag(mva, jetIdKey.first, jetIdKey.second);
 }
 
 // ------------------------------------------------------------------------------------------
-int PileupJetIdAlgo::computeIDflag(float mva,int ptId,int etaId)
-{
+int PileupJetIdAlgo::computeIDflag(float mva, int ptId, int etaId) {
   int idFlag(0);
-  if(mva > cache_->mvacut()[PileupJetIdentifier::kTight ][ptId][etaId]) idFlag += 1 << PileupJetIdentifier::kTight;
-  if(mva > cache_->mvacut()[PileupJetIdentifier::kMedium][ptId][etaId]) idFlag += 1 << PileupJetIdentifier::kMedium;
-  if(mva > cache_->mvacut()[PileupJetIdentifier::kLoose ][ptId][etaId]) idFlag += 1 << PileupJetIdentifier::kLoose;
+  if (mva > cache_->mvacut()[PileupJetIdentifier::kTight][ptId][etaId])
+    idFlag += 1 << PileupJetIdentifier::kTight;
+  if (mva > cache_->mvacut()[PileupJetIdentifier::kMedium][ptId][etaId])
+    idFlag += 1 << PileupJetIdentifier::kMedium;
+  if (mva > cache_->mvacut()[PileupJetIdentifier::kLoose][ptId][etaId])
+    idFlag += 1 << PileupJetIdentifier::kLoose;
   return idFlag;
 }
 
-
 // ------------------------------------------------------------------------------------------
-PileupJetIdentifier PileupJetIdAlgo::computeMva()
-{
-	runMva();
-	return PileupJetIdentifier(internalId_);
+PileupJetIdentifier PileupJetIdAlgo::computeMva() {
+  runMva();
+  return PileupJetIdentifier(internalId_);
 }
 
 // ------------------------------------------------------------------------------------------
-PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, float jec, const reco::Vertex * vtx,
-							const reco::VertexCollection & allvtx, double rho, bool usePuppi) 
-{
-	
-	// initialize all variables to 0
-	resetVariables();
-	
-	// loop over constituents, accumulate sums and find leading candidates
-	const pat::Jet * patjet = dynamic_cast<const pat::Jet *>(jet);
-	const reco::PFJet * pfjet = dynamic_cast<const reco::PFJet *>(jet);
-	assert( patjet != nullptr || pfjet != nullptr );
-	if( patjet != nullptr && jec == 0. ) { // if this is a pat jet and no jec has been passed take the jec from the object
-	  jec = patjet->pt()/patjet->correctedJet(0).pt();
-	}
-	if( jec <= 0. ) {
-	  jec = 1.;
-	}
-	
-	const reco::Candidate* lLead = nullptr, *lSecond = nullptr, *lLeadNeut = nullptr, *lLeadEm = nullptr, *lLeadCh = nullptr, *lTrail = nullptr;
-	std::vector<float> frac, fracCh, fracEm, fracNeut;
-	float cones[] = { 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7 };
-	size_t ncones = sizeof(cones)/sizeof(float);
-	float * coneFracs[]     = { &internalId_.frac01_, &internalId_.frac02_, &internalId_.frac03_, &internalId_.frac04_, 
-				    &internalId_.frac05_,  &internalId_.frac06_,  &internalId_.frac07_ };
-	float * coneEmFracs[]   = { &internalId_.emFrac01_, &internalId_.emFrac02_, &internalId_.emFrac03_, &internalId_.emFrac04_, 
-				    &internalId_.emFrac05_, &internalId_.emFrac06_, &internalId_.emFrac07_ }; 
-	float * coneNeutFracs[] = { &internalId_.neutFrac01_, &internalId_.neutFrac02_, &internalId_.neutFrac03_, &internalId_.neutFrac04_, 
-				    &internalId_.neutFrac05_, &internalId_.neutFrac06_, &internalId_.neutFrac07_ }; 
-	float * coneChFracs[]   = { &internalId_.chFrac01_, &internalId_.chFrac02_, &internalId_.chFrac03_, &internalId_.chFrac04_, 
-				    &internalId_.chFrac05_, &internalId_.chFrac06_, &internalId_.chFrac07_ }; 
-	TMatrixDSym covMatrix(2); covMatrix = 0.;
-	float jetPt = jet->pt() / jec; // use uncorrected pt for shape variables
-	float sumPt = 0., sumPt2 = 0., sumTkPt = 0.,sumPtCh=0,sumPtNe = 0;
-	float multNeut = 0.0;
-	setPtEtaPhi(*jet,internalId_.jetPt_,internalId_.jetEta_,internalId_.jetPhi_); // use corrected pt for jet kinematics
-	internalId_.jetM_ = jet->mass(); 
-	internalId_.nvtx_ = allvtx.size();
-	internalId_.rho_ = rho;
+PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
+                                                        float jec,
+                                                        const reco::Vertex* vtx,
+                                                        const reco::VertexCollection& allvtx,
+                                                        double rho,
+                                                        bool usePuppi) {
+  // initialize all variables to 0
+  resetVariables();
 
-	float dRmin(1000);
+  // loop over constituents, accumulate sums and find leading candidates
+  const pat::Jet* patjet = dynamic_cast<const pat::Jet*>(jet);
+  const reco::PFJet* pfjet = dynamic_cast<const reco::PFJet*>(jet);
+  assert(patjet != nullptr || pfjet != nullptr);
+  if (patjet != nullptr && jec == 0.) {  // if this is a pat jet and no jec has been passed take the jec from the object
+    jec = patjet->pt() / patjet->correctedJet(0).pt();
+  }
+  if (jec <= 0.) {
+    jec = 1.;
+  }
 
-	for ( unsigned i = 0; i < jet->numberOfSourceCandidatePtrs(); ++i ) {
-	  reco::CandidatePtr pfJetConstituent = jet->sourceCandidatePtr(i);
-  
-	  const reco::Candidate* icand = pfJetConstituent.get();
-	  const pat::PackedCandidate* lPack = dynamic_cast<const pat::PackedCandidate *>( icand );
-	  const reco::PFCandidate *lPF=dynamic_cast<const reco::PFCandidate*>( icand );
-	  bool isPacked = true;
-	  if (lPack == nullptr){
-	    isPacked = false;
-	  }
-	    float candPuppiWeight = 1.0;
-	    if (usePuppi && isPacked) candPuppiWeight = lPack->puppiWeight();
-	    float candPt = (icand->pt())*candPuppiWeight;
-	    float candPtFrac = candPt/jetPt;
-	    float candDr   = reco::deltaR(*icand,*jet);
-	    float candDeta = icand->eta() - jet->eta();
-	    float candDphi = reco::deltaPhi(*icand,*jet);
-	    float candPtDr = candPt * candDr;
-	    size_t icone = std::lower_bound(&cones[0],&cones[ncones],candDr) - &cones[0];
+  const reco::Candidate *lLead = nullptr, *lSecond = nullptr, *lLeadNeut = nullptr, *lLeadEm = nullptr,
+                        *lLeadCh = nullptr, *lTrail = nullptr;
+  std::vector<float> frac, fracCh, fracEm, fracNeut;
+  float cones[] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7};
+  size_t ncones = sizeof(cones) / sizeof(float);
+  float* coneFracs[] = {&internalId_.frac01_,
+                        &internalId_.frac02_,
+                        &internalId_.frac03_,
+                        &internalId_.frac04_,
+                        &internalId_.frac05_,
+                        &internalId_.frac06_,
+                        &internalId_.frac07_};
+  float* coneEmFracs[] = {&internalId_.emFrac01_,
+                          &internalId_.emFrac02_,
+                          &internalId_.emFrac03_,
+                          &internalId_.emFrac04_,
+                          &internalId_.emFrac05_,
+                          &internalId_.emFrac06_,
+                          &internalId_.emFrac07_};
+  float* coneNeutFracs[] = {&internalId_.neutFrac01_,
+                            &internalId_.neutFrac02_,
+                            &internalId_.neutFrac03_,
+                            &internalId_.neutFrac04_,
+                            &internalId_.neutFrac05_,
+                            &internalId_.neutFrac06_,
+                            &internalId_.neutFrac07_};
+  float* coneChFracs[] = {&internalId_.chFrac01_,
+                          &internalId_.chFrac02_,
+                          &internalId_.chFrac03_,
+                          &internalId_.chFrac04_,
+                          &internalId_.chFrac05_,
+                          &internalId_.chFrac06_,
+                          &internalId_.chFrac07_};
+  TMatrixDSym covMatrix(2);
+  covMatrix = 0.;
+  float jetPt = jet->pt() / jec;  // use uncorrected pt for shape variables
+  float sumPt = 0., sumPt2 = 0., sumTkPt = 0., sumPtCh = 0, sumPtNe = 0;
+  float multNeut = 0.0;
+  setPtEtaPhi(
+      *jet, internalId_.jetPt_, internalId_.jetEta_, internalId_.jetPhi_);  // use corrected pt for jet kinematics
+  internalId_.jetM_ = jet->mass();
+  internalId_.nvtx_ = allvtx.size();
+  internalId_.rho_ = rho;
 
-	    if(candDr < dRmin) dRmin = candDr;
+  float dRmin(1000);
 
-		// // all particles
-		if( lLead == nullptr || candPt > lLead->pt() ) {
-			lSecond = lLead;
-			lLead = icand; 
-		} else if( (lSecond == nullptr || candPt > lSecond->pt()) && (candPt < lLead->pt()) ) {
-			lSecond = icand;
-		}
+  for (unsigned i = 0; i < jet->numberOfSourceCandidatePtrs(); ++i) {
+    reco::CandidatePtr pfJetConstituent = jet->sourceCandidatePtr(i);
 
-		// // average shapes
-		internalId_.dRMean_     += candPtDr;
-		internalId_.dR2Mean_    += candPtDr*candPtDr;
-		covMatrix(0,0) += candPt*candPt*candDeta*candDeta;
-		covMatrix(0,1) += candPt*candPt*candDeta*candDphi;
-		covMatrix(1,1) += candPt*candPt*candDphi*candDphi;
-		internalId_.ptD_ += candPt*candPt;
-		sumPt += candPt;
-		sumPt2 += candPt*candPt;
-		
-		// single most energetic candiates and jet shape profiles
-		frac.push_back(candPtFrac);
-		
-		if( icone < ncones ) { *coneFracs[icone] += candPt; }
-	
-		// neutrals
-		if( abs(icand->pdgId()) == 130) {
-			if (lLeadNeut == nullptr || candPt > lLeadNeut->pt()) { lLeadNeut = icand; }
-			internalId_.dRMeanNeut_ += candPtDr;
-			fracNeut.push_back(candPtFrac);
-			if( icone < ncones ) { *coneNeutFracs[icone] += candPt; }
-			internalId_.ptDNe_    += candPt*candPt;
-			sumPtNe               += candPt;
-			multNeut += candPuppiWeight;
-		}
-		// EM candidated
-		if( icand->pdgId() == 22 ) {
-			if(lLeadEm == nullptr || candPt > lLeadEm->pt())  { lLeadEm = icand; }
-			internalId_.dRMeanEm_ += candPtDr;
-			fracEm.push_back(candPtFrac);
-			if( icone < ncones ) { *coneEmFracs[icone] += candPt; }
-			internalId_.ptDNe_    += candPt*candPt;
-			sumPtNe               += candPt;
-			multNeut += candPuppiWeight;
-		}
-		if((abs(icand->pdgId()) == 1) || (abs(icand->pdgId()) == 2)) multNeut += candPuppiWeight;
+    const reco::Candidate* icand = pfJetConstituent.get();
+    const pat::PackedCandidate* lPack = dynamic_cast<const pat::PackedCandidate*>(icand);
+    const reco::PFCandidate* lPF = dynamic_cast<const reco::PFCandidate*>(icand);
+    bool isPacked = true;
+    if (lPack == nullptr) {
+      isPacked = false;
+    }
+    float candPuppiWeight = 1.0;
+    if (usePuppi && isPacked)
+      candPuppiWeight = lPack->puppiWeight();
+    float candPt = (icand->pt()) * candPuppiWeight;
+    float candPtFrac = candPt / jetPt;
+    float candDr = reco::deltaR(*icand, *jet);
+    float candDeta = icand->eta() - jet->eta();
+    float candDphi = reco::deltaPhi(*icand, *jet);
+    float candPtDr = candPt * candDr;
+    size_t icone = std::lower_bound(&cones[0], &cones[ncones], candDr) - &cones[0];
 
-		// Charged  particles
-		if(  icand->charge() != 0 ) {
-		        if (lLeadCh == nullptr || candPt > lLeadCh->pt()) { 
-			  lLeadCh = icand;
-			
-			  const reco::Track* pfTrk = icand->bestTrack();
-			  if (lPF && std::abs(icand->pdgId()) == 13 && pfTrk == nullptr){
-			    reco::MuonRef lmuRef = lPF->muonRef();
-			    if (lmuRef.isNonnull()){
-			      const reco::Muon& lmu = *lmuRef.get();
-			      pfTrk = lmu.bestTrack();
-			      edm::LogWarning("BadMuon")<<"Found a PFCandidate muon without a trackRef: falling back to Muon::bestTrack ";
-			    }
-			  }
-			  if(pfTrk==nullptr) { //protection against empty pointers for the miniAOD case
-			    //To handle the electron case
-			    if(isPacked) {
-			      internalId_.d0_ = std::abs(lPack->dxy(vtx->position()));
-			      internalId_.dZ_ = std::abs(lPack->dz(vtx->position()));
-			    }
-			    else if(lPF!=nullptr) {
-			      pfTrk=(lPF->trackRef().get()==nullptr)?lPF->gsfTrackRef().get():lPF->trackRef().get();
-			      internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
-			      internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
-			    }
-			  }
-			  else {
-			    internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
-			    internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
-			  }
-			}
-			internalId_.dRMeanCh_  += candPtDr;
-			internalId_.ptDCh_     += candPt*candPt;
-			fracCh.push_back(candPtFrac);
-			if( icone < ncones ) { *coneChFracs[icone] += candPt; }
-			sumPtCh                += candPt;
-		}
-		// // beta and betastar		
-		if( icand->charge() != 0 ) {
-		      if (!isPacked){
-			   if(lPF->trackRef().isNonnull() ) { 
-	      			float tkpt = candPt;
-				sumTkPt += tkpt;
-				// 'classic' beta definition based on track-vertex association
-				bool inVtx0 = vtx->trackWeight ( lPF->trackRef()) > 0 ;
+    if (candDr < dRmin)
+      dRmin = candDr;
 
-				bool inAnyOther = false;
-				// alternative beta definition based on track-vertex distance of closest approach
-				double dZ0 = std::abs(lPF->trackRef()->dz(vtx->position()));
-				double dZ = dZ0;
-				for(reco::VertexCollection::const_iterator  vi=allvtx.begin(); vi!=allvtx.end(); ++vi ) {
-				    const reco::Vertex & iv = *vi;
-				    if( iv.isFake() || iv.ndof() < 4 ) { continue; }
-				        // the primary vertex may have been copied by the user: check identity by position
-				        bool isVtx0  = (iv.position() - vtx->position()).r() < 0.02;
-					// 'classic' beta definition: check if the track is associated with
-					// any vertex other than the primary one
-					if( ! isVtx0 && ! inAnyOther ) {
-					  inAnyOther =  vtx->trackWeight ( lPF->trackRef()) <= 0 ;
-					}
-					// alternative beta: find closest vertex to the track
-					dZ = std::min(dZ,std::abs(lPF->trackRef()->dz(iv.position())));
-				}
-				// classic beta/betaStar
-				if( inVtx0 && ! inAnyOther ) {
-				    internalId_.betaClassic_ += tkpt;
-				} else if( ! inVtx0 && inAnyOther ) {
-				    internalId_.betaStarClassic_ += tkpt;
-				}
-				// alternative beta/betaStar
-				if( dZ0 < 0.2 ) {
-				    internalId_.beta_ += tkpt;
-				} else if( dZ < 0.2 ) {
-				    internalId_.betaStar_ += tkpt;
-				}
-			   } 
-		        }
-			else{
-			        float tkpt = candPt;
-			        sumTkPt += tkpt;
-				bool inVtx0 = false; 
-				bool inVtxOther = false; 
-				double dZ0=9999.;
-				double dZ_tmp = 9999.;
-				for (unsigned vtx_i = 0 ; vtx_i < allvtx.size() ; vtx_i++ ) {
-         			        auto iv = allvtx[vtx_i];
+    // // all particles
+    if (lLead == nullptr || candPt > lLead->pt()) {
+      lSecond = lLead;
+      lLead = icand;
+    } else if ((lSecond == nullptr || candPt > lSecond->pt()) && (candPt < lLead->pt())) {
+      lSecond = icand;
+    }
 
-					if (iv.isFake())
-						continue;
+    // // average shapes
+    internalId_.dRMean_ += candPtDr;
+    internalId_.dR2Mean_ += candPtDr * candPtDr;
+    covMatrix(0, 0) += candPt * candPt * candDeta * candDeta;
+    covMatrix(0, 1) += candPt * candPt * candDeta * candDphi;
+    covMatrix(1, 1) += candPt * candPt * candDphi * candDphi;
+    internalId_.ptD_ += candPt * candPt;
+    sumPt += candPt;
+    sumPt2 += candPt * candPt;
 
-					// Match to vertex in case of copy as above
-                                        bool isVtx0  = (iv.position() - vtx->position()).r() < 0.02;
+    // single most energetic candiates and jet shape profiles
+    frac.push_back(candPtFrac);
 
-					if (isVtx0) {
-					    if (lPack->fromPV(vtx_i) == pat::PackedCandidate::PVUsedInFit) inVtx0 = true;
-					    if (lPack->fromPV(vtx_i) == 0) inVtxOther = true;
-					    dZ0 = lPack->dz(iv.position());
-					}
+    if (icone < ncones) {
+      *coneFracs[icone] += candPt;
+    }
 
-					if (fabs(lPack->dz(iv.position())) < fabs(dZ_tmp)) {
-						dZ_tmp = lPack->dz(iv.position());
-					}
-				}
-				if (inVtx0){
-					internalId_.betaClassic_ += tkpt;
-				} else if (inVtxOther){
-					internalId_.betaStarClassic_ += tkpt;
-				}
-				if (fabs(dZ0) < 0.2){
-					internalId_.beta_ += tkpt;
-				} else if (fabs(dZ_tmp) < 0.2){
-					internalId_.betaStar_ += tkpt;
-				}
-			}
-		}
+    // neutrals
+    if (abs(icand->pdgId()) == 130) {
+      if (lLeadNeut == nullptr || candPt > lLeadNeut->pt()) {
+        lLeadNeut = icand;
+      }
+      internalId_.dRMeanNeut_ += candPtDr;
+      fracNeut.push_back(candPtFrac);
+      if (icone < ncones) {
+        *coneNeutFracs[icone] += candPt;
+      }
+      internalId_.ptDNe_ += candPt * candPt;
+      sumPtNe += candPt;
+      multNeut += candPuppiWeight;
+    }
+    // EM candidated
+    if (icand->pdgId() == 22) {
+      if (lLeadEm == nullptr || candPt > lLeadEm->pt()) {
+        lLeadEm = icand;
+      }
+      internalId_.dRMeanEm_ += candPtDr;
+      fracEm.push_back(candPtFrac);
+      if (icone < ncones) {
+        *coneEmFracs[icone] += candPt;
+      }
+      internalId_.ptDNe_ += candPt * candPt;
+      sumPtNe += candPt;
+      multNeut += candPuppiWeight;
+    }
+    if ((abs(icand->pdgId()) == 1) || (abs(icand->pdgId()) == 2))
+      multNeut += candPuppiWeight;
 
-		// trailing candidate
-		if( lTrail == nullptr || candPt < lTrail->pt() ) {
-			lTrail = icand; 
-		}
-	
-	}
+    // Charged  particles
+    if (icand->charge() != 0) {
+      if (lLeadCh == nullptr || candPt > lLeadCh->pt()) {
+        lLeadCh = icand;
 
-	// // Finalize all variables
-	assert( !(lLead == nullptr) );
-
-	if ( lSecond == nullptr )   { lSecond   = lTrail; }
-	if ( lLeadNeut == nullptr ) { lLeadNeut = lTrail; }
-	if ( lLeadEm == nullptr )   { lLeadEm   = lTrail; }
-	if ( lLeadCh == nullptr )   { lLeadCh   = lTrail; }
-	
-	if( patjet != nullptr ) { // to enable running on MiniAOD slimmedJets
-	 internalId_.nCharged_    = patjet->chargedMultiplicity();
-	 internalId_.nNeutrals_   = patjet->neutralMultiplicity();
-	 internalId_.chgEMfrac_   = patjet->chargedEmEnergy()    /jet->energy();
-	 internalId_.neuEMfrac_   = patjet->neutralEmEnergy()    /jet->energy();
-	 internalId_.chgHadrfrac_ = patjet->chargedHadronEnergy()/jet->energy();
-	 internalId_.neuHadrfrac_ = patjet->neutralHadronEnergy()/jet->energy();
-	 if (usePuppi) internalId_.nNeutrals_ = multNeut;
-	} else {
-	 internalId_.nCharged_    = pfjet->chargedMultiplicity();
-	 internalId_.nNeutrals_   = pfjet->neutralMultiplicity();
-	 internalId_.chgEMfrac_   = pfjet->chargedEmEnergy()    /jet->energy();
-	 internalId_.neuEMfrac_   = pfjet->neutralEmEnergy()    /jet->energy();
-	 internalId_.chgHadrfrac_ = pfjet->chargedHadronEnergy()/jet->energy();
-	 internalId_.neuHadrfrac_ = pfjet->neutralHadronEnergy()/jet->energy();
-	}
-        internalId_.nParticles_   = jet->nConstituents();
-
-	///////////////////////pull variable///////////////////////////////////
-	float sumW2(0.0);
-	float sum_deta(0.0),sum_dphi(0.0);
-	float ave_deta(0.0), ave_dphi(0.0);
-	for (size_t j = 0; j < jet->numberOfDaughters(); j++) {
-	  const auto& part = jet->daughterPtr(j);
-	  if (!(part.isAvailable() && part.isNonnull()) ){
-            continue;
-	  }
-
-	  float partPuppiWeight=1.0;
-	  if (usePuppi){
-	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part.get() );
-	    if (partpack!=nullptr)  partPuppiWeight = partpack->puppiWeight();
-	  }
-
-	  float weight = (part->pt())*partPuppiWeight;
-	  float weight2 = weight * weight;
-	  sumW2        += weight2;
-	  float deta = part->eta() - jet->eta();
-	  float dphi = reco::deltaPhi(*part, *jet);
-	  sum_deta     += deta*weight2;
-	  sum_dphi     += dphi*weight2;
-	  if (sumW2 > 0) {
-	    ave_deta = sum_deta/sumW2;
-	    ave_dphi = sum_dphi/sumW2;
-	  }
-	}
-
-	float ddetaR_sum(0.0), ddphiR_sum(0.0), pull_tmp(0.0);
-	for (size_t i = 0; i < jet->numberOfDaughters(); i++) {
-	  const auto& part = jet->daughterPtr(i);
-	  if (!(part.isAvailable() && part.isNonnull()) ){
-            continue;
+        const reco::Track* pfTrk = icand->bestTrack();
+        if (lPF && std::abs(icand->pdgId()) == 13 && pfTrk == nullptr) {
+          reco::MuonRef lmuRef = lPF->muonRef();
+          if (lmuRef.isNonnull()) {
+            const reco::Muon& lmu = *lmuRef.get();
+            pfTrk = lmu.bestTrack();
+            edm::LogWarning("BadMuon")
+                << "Found a PFCandidate muon without a trackRef: falling back to Muon::bestTrack ";
           }
- 
-	  float partPuppiWeight=1.0;
-	  if (usePuppi){
-	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part.get() );
-	    if (partpack!=nullptr)  partPuppiWeight = partpack->puppiWeight();
-	  }
+        }
+        if (pfTrk == nullptr) {  //protection against empty pointers for the miniAOD case
+          //To handle the electron case
+          if (isPacked) {
+            internalId_.d0_ = std::abs(lPack->dxy(vtx->position()));
+            internalId_.dZ_ = std::abs(lPack->dz(vtx->position()));
+          } else if (lPF != nullptr) {
+            pfTrk = (lPF->trackRef().get() == nullptr) ? lPF->gsfTrackRef().get() : lPF->trackRef().get();
+            internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
+            internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
+          }
+        } else {
+          internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
+          internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
+        }
+      }
+      internalId_.dRMeanCh_ += candPtDr;
+      internalId_.ptDCh_ += candPt * candPt;
+      fracCh.push_back(candPtFrac);
+      if (icone < ncones) {
+        *coneChFracs[icone] += candPt;
+      }
+      sumPtCh += candPt;
+    }
+    // // beta and betastar
+    if (icand->charge() != 0) {
+      if (!isPacked) {
+        if (lPF->trackRef().isNonnull()) {
+          float tkpt = candPt;
+          sumTkPt += tkpt;
+          // 'classic' beta definition based on track-vertex association
+          bool inVtx0 = vtx->trackWeight(lPF->trackRef()) > 0;
 
-	  float weight = partPuppiWeight*(part->pt())*partPuppiWeight*(part->pt());
-	  float deta = part->eta() - jet->eta();
-	  float dphi = reco::deltaPhi(*part, *jet);
-	  float ddeta, ddphi, ddR;
-	  ddeta = deta - ave_deta ;
-	  ddphi = dphi-ave_dphi;
-	  ddR = sqrt(ddeta*ddeta + ddphi*ddphi);
-	  ddetaR_sum += ddR*ddeta*weight;
-	  ddphiR_sum += ddR*ddphi*weight;
-	}
-	if (sumW2 > 0) {
-	  float ddetaR_ave = ddetaR_sum/sumW2;
-	  float ddphiR_ave = ddphiR_sum/sumW2;
-	  pull_tmp = sqrt(ddetaR_ave*ddetaR_ave+ddphiR_ave*ddphiR_ave);
-	}
-	internalId_.pull_ = pull_tmp;
-	///////////////////////////////////////////////////////////////////////
- 
+          bool inAnyOther = false;
+          // alternative beta definition based on track-vertex distance of closest approach
+          double dZ0 = std::abs(lPF->trackRef()->dz(vtx->position()));
+          double dZ = dZ0;
+          for (reco::VertexCollection::const_iterator vi = allvtx.begin(); vi != allvtx.end(); ++vi) {
+            const reco::Vertex& iv = *vi;
+            if (iv.isFake() || iv.ndof() < 4) {
+              continue;
+            }
+            // the primary vertex may have been copied by the user: check identity by position
+            bool isVtx0 = (iv.position() - vtx->position()).r() < 0.02;
+            // 'classic' beta definition: check if the track is associated with
+            // any vertex other than the primary one
+            if (!isVtx0 && !inAnyOther) {
+              inAnyOther = vtx->trackWeight(lPF->trackRef()) <= 0;
+            }
+            // alternative beta: find closest vertex to the track
+            dZ = std::min(dZ, std::abs(lPF->trackRef()->dz(iv.position())));
+          }
+          // classic beta/betaStar
+          if (inVtx0 && !inAnyOther) {
+            internalId_.betaClassic_ += tkpt;
+          } else if (!inVtx0 && inAnyOther) {
+            internalId_.betaStarClassic_ += tkpt;
+          }
+          // alternative beta/betaStar
+          if (dZ0 < 0.2) {
+            internalId_.beta_ += tkpt;
+          } else if (dZ < 0.2) {
+            internalId_.betaStar_ += tkpt;
+          }
+        }
+      } else {
+        float tkpt = candPt;
+        sumTkPt += tkpt;
+        bool inVtx0 = false;
+        bool inVtxOther = false;
+        double dZ0 = 9999.;
+        double dZ_tmp = 9999.;
+        for (unsigned vtx_i = 0; vtx_i < allvtx.size(); vtx_i++) {
+          auto iv = allvtx[vtx_i];
 
-	setPtEtaPhi(*lLead,internalId_.leadPt_,internalId_.leadEta_,internalId_.leadPhi_);                 
-	setPtEtaPhi(*lSecond,internalId_.secondPt_,internalId_.secondEta_,internalId_.secondPhi_);	      
-	setPtEtaPhi(*lLeadNeut,internalId_.leadNeutPt_,internalId_.leadNeutEta_,internalId_.leadNeutPhi_); 
-	setPtEtaPhi(*lLeadEm,internalId_.leadEmPt_,internalId_.leadEmEta_,internalId_.leadEmPhi_);	      
-	setPtEtaPhi(*lLeadCh,internalId_.leadChPt_,internalId_.leadChEta_,internalId_.leadChPhi_);         
+          if (iv.isFake())
+            continue;
 
-	std::sort(frac.begin(),frac.end(),std::greater<float>());
-	std::sort(fracCh.begin(),fracCh.end(),std::greater<float>());
-	std::sort(fracEm.begin(),fracEm.end(),std::greater<float>());
-	std::sort(fracNeut.begin(),fracNeut.end(),std::greater<float>());
-	assign(frac,    internalId_.leadFrac_,    internalId_.secondFrac_,    internalId_.thirdFrac_,    internalId_.fourthFrac_);
-	assign(fracCh,  internalId_.leadChFrac_,  internalId_.secondChFrac_,  internalId_.thirdChFrac_,  internalId_.fourthChFrac_);
-	assign(fracEm,  internalId_.leadEmFrac_,  internalId_.secondEmFrac_,  internalId_.thirdEmFrac_,  internalId_.fourthEmFrac_);
-	assign(fracNeut,internalId_.leadNeutFrac_,internalId_.secondNeutFrac_,internalId_.thirdNeutFrac_,internalId_.fourthNeutFrac_);
-	
-	covMatrix(0,0) /= sumPt2;
-	covMatrix(0,1) /= sumPt2;
-	covMatrix(1,1) /= sumPt2;
-	covMatrix(1,0)  = covMatrix(0,1);
-	internalId_.etaW_ = sqrt(covMatrix(0,0));
-	internalId_.phiW_ = sqrt(covMatrix(1,1));
-	internalId_.jetW_ = 0.5*(internalId_.etaW_+internalId_.phiW_);
-	TVectorD eigVals(2); eigVals = TMatrixDSymEigen(covMatrix).GetEigenValues();
-	internalId_.majW_ = sqrt(std::abs(eigVals(0)));
-	internalId_.minW_ = sqrt(std::abs(eigVals(1)));
-	if( internalId_.majW_ < internalId_.minW_ ) { std::swap(internalId_.majW_,internalId_.minW_); }
-	
-	internalId_.dRLeadCent_ = reco::deltaR(*jet,*lLead);
-	if( lSecond == nullptr ) { internalId_.dRLead2nd_  = reco::deltaR(*jet,*lSecond); }
-	internalId_.dRMean_     /= jetPt;
-	internalId_.dRMeanNeut_ /= jetPt;
-	internalId_.dRMeanEm_   /= jetPt;
-	internalId_.dRMeanCh_   /= jetPt;
-	internalId_.dR2Mean_    /= sumPt2;
+          // Match to vertex in case of copy as above
+          bool isVtx0 = (iv.position() - vtx->position()).r() < 0.02;
 
-	for(size_t ic=0; ic<ncones; ++ic){
-		*coneFracs[ic]     /= jetPt;
-		*coneEmFracs[ic]   /= jetPt;
-		*coneNeutFracs[ic] /= jetPt;
-		*coneChFracs[ic]   /= jetPt;
-	}
-	//http://jets.physics.harvard.edu/qvg/
-	double ptMean = sumPt/internalId_.nParticles_;
-	double ptRMS  = 0;
-	for(unsigned int i0 = 0; i0 < frac.size(); i0++) {ptRMS+=(frac[i0]-ptMean)*(frac[i0]-ptMean);}
-	ptRMS/=internalId_.nParticles_;
-	ptRMS=sqrt(ptRMS);
-	
-	internalId_.ptMean_  = ptMean;
-	internalId_.ptRMS_   = ptRMS/jetPt;
-	internalId_.pt2A_    = sqrt( internalId_.ptD_     /internalId_.nParticles_)/jetPt;
-	internalId_.ptD_     = sqrt( internalId_.ptD_)    / sumPt;
-	internalId_.ptDCh_   = sqrt( internalId_.ptDCh_)  / sumPtCh;
-	internalId_.ptDNe_   = sqrt( internalId_.ptDNe_)  / sumPtNe;
-	internalId_.sumPt_   = sumPt;
-	internalId_.sumChPt_ = sumPtCh;
-	internalId_.sumNePt_ = sumPtNe;
+          if (isVtx0) {
+            if (lPack->fromPV(vtx_i) == pat::PackedCandidate::PVUsedInFit)
+              inVtx0 = true;
+            if (lPack->fromPV(vtx_i) == 0)
+              inVtxOther = true;
+            dZ0 = lPack->dz(iv.position());
+          }
 
-	internalId_.jetR_    = lLead->pt()/sumPt;
-	internalId_.jetRchg_ = lLeadCh->pt()/sumPt;
-	internalId_.dRMatch_ = dRmin;
+          if (fabs(lPack->dz(iv.position())) < fabs(dZ_tmp)) {
+            dZ_tmp = lPack->dz(iv.position());
+          }
+        }
+        if (inVtx0) {
+          internalId_.betaClassic_ += tkpt;
+        } else if (inVtxOther) {
+          internalId_.betaStarClassic_ += tkpt;
+        }
+        if (fabs(dZ0) < 0.2) {
+          internalId_.beta_ += tkpt;
+        } else if (fabs(dZ_tmp) < 0.2) {
+          internalId_.betaStar_ += tkpt;
+        }
+      }
+    }
 
-	if( sumTkPt != 0. ) {
-		internalId_.beta_     /= sumTkPt;
-		internalId_.betaStar_ /= sumTkPt;
-		internalId_.betaClassic_ /= sumTkPt;
-		internalId_.betaStarClassic_ /= sumTkPt;
-	} else {
-		assert( internalId_.beta_ == 0. && internalId_.betaStar_ == 0.&& internalId_.betaClassic_ == 0. && internalId_.betaStarClassic_ == 0. );
-	}
+    // trailing candidate
+    if (lTrail == nullptr || candPt < lTrail->pt()) {
+      lTrail = icand;
+    }
+  }
 
-	if( cache_->runMvas() ) {
-		runMva();
-	}
-	
-	return PileupJetIdentifier(internalId_);
+  // // Finalize all variables
+  assert(!(lLead == nullptr));
+
+  if (lSecond == nullptr) {
+    lSecond = lTrail;
+  }
+  if (lLeadNeut == nullptr) {
+    lLeadNeut = lTrail;
+  }
+  if (lLeadEm == nullptr) {
+    lLeadEm = lTrail;
+  }
+  if (lLeadCh == nullptr) {
+    lLeadCh = lTrail;
+  }
+
+  if (patjet != nullptr) {  // to enable running on MiniAOD slimmedJets
+    internalId_.nCharged_ = patjet->chargedMultiplicity();
+    internalId_.nNeutrals_ = patjet->neutralMultiplicity();
+    internalId_.chgEMfrac_ = patjet->chargedEmEnergy() / jet->energy();
+    internalId_.neuEMfrac_ = patjet->neutralEmEnergy() / jet->energy();
+    internalId_.chgHadrfrac_ = patjet->chargedHadronEnergy() / jet->energy();
+    internalId_.neuHadrfrac_ = patjet->neutralHadronEnergy() / jet->energy();
+    if (usePuppi)
+      internalId_.nNeutrals_ = multNeut;
+  } else {
+    internalId_.nCharged_ = pfjet->chargedMultiplicity();
+    internalId_.nNeutrals_ = pfjet->neutralMultiplicity();
+    internalId_.chgEMfrac_ = pfjet->chargedEmEnergy() / jet->energy();
+    internalId_.neuEMfrac_ = pfjet->neutralEmEnergy() / jet->energy();
+    internalId_.chgHadrfrac_ = pfjet->chargedHadronEnergy() / jet->energy();
+    internalId_.neuHadrfrac_ = pfjet->neutralHadronEnergy() / jet->energy();
+  }
+  internalId_.nParticles_ = jet->nConstituents();
+
+  ///////////////////////pull variable///////////////////////////////////
+  float sumW2(0.0);
+  float sum_deta(0.0), sum_dphi(0.0);
+  float ave_deta(0.0), ave_dphi(0.0);
+  for (size_t j = 0; j < jet->numberOfDaughters(); j++) {
+    const auto& part = jet->daughterPtr(j);
+    if (!(part.isAvailable() && part.isNonnull())) {
+      continue;
+    }
+
+    float partPuppiWeight = 1.0;
+    if (usePuppi) {
+      const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate*>(part.get());
+      if (partpack != nullptr)
+        partPuppiWeight = partpack->puppiWeight();
+    }
+
+    float weight = (part->pt()) * partPuppiWeight;
+    float weight2 = weight * weight;
+    sumW2 += weight2;
+    float deta = part->eta() - jet->eta();
+    float dphi = reco::deltaPhi(*part, *jet);
+    sum_deta += deta * weight2;
+    sum_dphi += dphi * weight2;
+    if (sumW2 > 0) {
+      ave_deta = sum_deta / sumW2;
+      ave_dphi = sum_dphi / sumW2;
+    }
+  }
+
+  float ddetaR_sum(0.0), ddphiR_sum(0.0), pull_tmp(0.0);
+  for (size_t i = 0; i < jet->numberOfDaughters(); i++) {
+    const auto& part = jet->daughterPtr(i);
+    if (!(part.isAvailable() && part.isNonnull())) {
+      continue;
+    }
+
+    float partPuppiWeight = 1.0;
+    if (usePuppi) {
+      const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate*>(part.get());
+      if (partpack != nullptr)
+        partPuppiWeight = partpack->puppiWeight();
+    }
+
+    float weight = partPuppiWeight * (part->pt()) * partPuppiWeight * (part->pt());
+    float deta = part->eta() - jet->eta();
+    float dphi = reco::deltaPhi(*part, *jet);
+    float ddeta, ddphi, ddR;
+    ddeta = deta - ave_deta;
+    ddphi = dphi - ave_dphi;
+    ddR = sqrt(ddeta * ddeta + ddphi * ddphi);
+    ddetaR_sum += ddR * ddeta * weight;
+    ddphiR_sum += ddR * ddphi * weight;
+  }
+  if (sumW2 > 0) {
+    float ddetaR_ave = ddetaR_sum / sumW2;
+    float ddphiR_ave = ddphiR_sum / sumW2;
+    pull_tmp = sqrt(ddetaR_ave * ddetaR_ave + ddphiR_ave * ddphiR_ave);
+  }
+  internalId_.pull_ = pull_tmp;
+  ///////////////////////////////////////////////////////////////////////
+
+  setPtEtaPhi(*lLead, internalId_.leadPt_, internalId_.leadEta_, internalId_.leadPhi_);
+  setPtEtaPhi(*lSecond, internalId_.secondPt_, internalId_.secondEta_, internalId_.secondPhi_);
+  setPtEtaPhi(*lLeadNeut, internalId_.leadNeutPt_, internalId_.leadNeutEta_, internalId_.leadNeutPhi_);
+  setPtEtaPhi(*lLeadEm, internalId_.leadEmPt_, internalId_.leadEmEta_, internalId_.leadEmPhi_);
+  setPtEtaPhi(*lLeadCh, internalId_.leadChPt_, internalId_.leadChEta_, internalId_.leadChPhi_);
+
+  std::sort(frac.begin(), frac.end(), std::greater<float>());
+  std::sort(fracCh.begin(), fracCh.end(), std::greater<float>());
+  std::sort(fracEm.begin(), fracEm.end(), std::greater<float>());
+  std::sort(fracNeut.begin(), fracNeut.end(), std::greater<float>());
+  assign(frac, internalId_.leadFrac_, internalId_.secondFrac_, internalId_.thirdFrac_, internalId_.fourthFrac_);
+  assign(
+      fracCh, internalId_.leadChFrac_, internalId_.secondChFrac_, internalId_.thirdChFrac_, internalId_.fourthChFrac_);
+  assign(
+      fracEm, internalId_.leadEmFrac_, internalId_.secondEmFrac_, internalId_.thirdEmFrac_, internalId_.fourthEmFrac_);
+  assign(fracNeut,
+         internalId_.leadNeutFrac_,
+         internalId_.secondNeutFrac_,
+         internalId_.thirdNeutFrac_,
+         internalId_.fourthNeutFrac_);
+
+  covMatrix(0, 0) /= sumPt2;
+  covMatrix(0, 1) /= sumPt2;
+  covMatrix(1, 1) /= sumPt2;
+  covMatrix(1, 0) = covMatrix(0, 1);
+  internalId_.etaW_ = sqrt(covMatrix(0, 0));
+  internalId_.phiW_ = sqrt(covMatrix(1, 1));
+  internalId_.jetW_ = 0.5 * (internalId_.etaW_ + internalId_.phiW_);
+  TVectorD eigVals(2);
+  eigVals = TMatrixDSymEigen(covMatrix).GetEigenValues();
+  internalId_.majW_ = sqrt(std::abs(eigVals(0)));
+  internalId_.minW_ = sqrt(std::abs(eigVals(1)));
+  if (internalId_.majW_ < internalId_.minW_) {
+    std::swap(internalId_.majW_, internalId_.minW_);
+  }
+
+  internalId_.dRLeadCent_ = reco::deltaR(*jet, *lLead);
+  if (lSecond == nullptr) {
+    internalId_.dRLead2nd_ = reco::deltaR(*jet, *lSecond);
+  }
+  internalId_.dRMean_ /= jetPt;
+  internalId_.dRMeanNeut_ /= jetPt;
+  internalId_.dRMeanEm_ /= jetPt;
+  internalId_.dRMeanCh_ /= jetPt;
+  internalId_.dR2Mean_ /= sumPt2;
+
+  for (size_t ic = 0; ic < ncones; ++ic) {
+    *coneFracs[ic] /= jetPt;
+    *coneEmFracs[ic] /= jetPt;
+    *coneNeutFracs[ic] /= jetPt;
+    *coneChFracs[ic] /= jetPt;
+  }
+  //http://jets.physics.harvard.edu/qvg/
+  double ptMean = sumPt / internalId_.nParticles_;
+  double ptRMS = 0;
+  for (unsigned int i0 = 0; i0 < frac.size(); i0++) {
+    ptRMS += (frac[i0] - ptMean) * (frac[i0] - ptMean);
+  }
+  ptRMS /= internalId_.nParticles_;
+  ptRMS = sqrt(ptRMS);
+
+  internalId_.ptMean_ = ptMean;
+  internalId_.ptRMS_ = ptRMS / jetPt;
+  internalId_.pt2A_ = sqrt(internalId_.ptD_ / internalId_.nParticles_) / jetPt;
+  internalId_.ptD_ = sqrt(internalId_.ptD_) / sumPt;
+  internalId_.ptDCh_ = sqrt(internalId_.ptDCh_) / sumPtCh;
+  internalId_.ptDNe_ = sqrt(internalId_.ptDNe_) / sumPtNe;
+  internalId_.sumPt_ = sumPt;
+  internalId_.sumChPt_ = sumPtCh;
+  internalId_.sumNePt_ = sumPtNe;
+
+  internalId_.jetR_ = lLead->pt() / sumPt;
+  internalId_.jetRchg_ = lLeadCh->pt() / sumPt;
+  internalId_.dRMatch_ = dRmin;
+
+  if (sumTkPt != 0.) {
+    internalId_.beta_ /= sumTkPt;
+    internalId_.betaStar_ /= sumTkPt;
+    internalId_.betaClassic_ /= sumTkPt;
+    internalId_.betaStarClassic_ /= sumTkPt;
+  } else {
+    assert(internalId_.beta_ == 0. && internalId_.betaStar_ == 0. && internalId_.betaClassic_ == 0. &&
+           internalId_.betaStarClassic_ == 0.);
+  }
+
+  if (cache_->runMvas()) {
+    runMva();
+  }
+
+  return PileupJetIdentifier(internalId_);
 }
 
-
-
 // ------------------------------------------------------------------------------------------
-std::string PileupJetIdAlgo::dumpVariables() const
-{
-	std::stringstream out;
-	for(variables_list_t::const_iterator it=variables_.begin(); 
-	    it!=variables_.end(); ++it ) {
-		out << std::setw(15) << it->first << std::setw(3) << "=" 
-		    << std::setw(5) << *it->second.first 
-		    << " (" << std::setw(5) << it->second.second << ")" << std::endl;
-	}
-	return out.str();
+std::string PileupJetIdAlgo::dumpVariables() const {
+  std::stringstream out;
+  for (variables_list_t::const_iterator it = variables_.begin(); it != variables_.end(); ++it) {
+    out << std::setw(15) << it->first << std::setw(3) << "=" << std::setw(5) << *it->second.first << " ("
+        << std::setw(5) << it->second.second << ")" << std::endl;
+  }
+  return out.str();
 }
 
 // ------------------------------------------------------------------------------------------
-void PileupJetIdAlgo::resetVariables()
-{
-	internalId_.idFlag_    = 0;
-	for(variables_list_t::iterator it=variables_.begin(); 
-	    it!=variables_.end(); ++it ) {
-		*it->second.first = it->second.second;
-	}
+void PileupJetIdAlgo::resetVariables() {
+  internalId_.idFlag_ = 0;
+  for (variables_list_t::iterator it = variables_.begin(); it != variables_.end(); ++it) {
+    *it->second.first = it->second.second;
+  }
 }
 
 // ------------------------------------------------------------------------------------------
-#define INIT_VARIABLE(NAME,TMVANAME,VAL)	\
-	internalId_.NAME ## _ = VAL; \
-	variables_[ # NAME   ] = std::make_pair(& internalId_.NAME ## _, VAL);
+#define INIT_VARIABLE(NAME, TMVANAME, VAL) \
+  internalId_.NAME##_ = VAL;               \
+  variables_[#NAME] = std::make_pair(&internalId_.NAME##_, VAL);
 
 // ------------------------------------------------------------------------------------------
-void PileupJetIdAlgo::initVariables()
-{
-	internalId_.idFlag_    = 0;
-  	INIT_VARIABLE(mva        , "", -100.);
-	//INIT_VARIABLE(jetPt      , "jspt_1", 0.);
-	//INIT_VARIABLE(jetEta     , "jseta_1", large_val);
-	INIT_VARIABLE(jetPt      , "", 0.);
-	INIT_VARIABLE(jetEta     , "", large_val);
-	INIT_VARIABLE(jetPhi     , "jsphi_1", large_val);
-	INIT_VARIABLE(jetM       , "jm_1", 0.);
+void PileupJetIdAlgo::initVariables() {
+  internalId_.idFlag_ = 0;
+  INIT_VARIABLE(mva, "", -100.);
+  //INIT_VARIABLE(jetPt      , "jspt_1", 0.);
+  //INIT_VARIABLE(jetEta     , "jseta_1", large_val);
+  INIT_VARIABLE(jetPt, "", 0.);
+  INIT_VARIABLE(jetEta, "", large_val);
+  INIT_VARIABLE(jetPhi, "jsphi_1", large_val);
+  INIT_VARIABLE(jetM, "jm_1", 0.);
 
-	INIT_VARIABLE(nCharged   , "", 0.);
-	INIT_VARIABLE(nNeutrals  , "", 0.);
-	
-	INIT_VARIABLE(chgEMfrac  , "", 0.);
-	INIT_VARIABLE(neuEMfrac  , "", 0.);
-	INIT_VARIABLE(chgHadrfrac, "", 0.);
-	INIT_VARIABLE(neuHadrfrac, "", 0.);
-	
-	INIT_VARIABLE(d0         , "jd0_1"    , -1000.);   
-	INIT_VARIABLE(dZ         , "jdZ_1"    , -1000.);  
-	//INIT_VARIABLE(nParticles , "npart_1"  , 0.);  
-	INIT_VARIABLE(nParticles , ""  , 0.);  
-	
-	INIT_VARIABLE(leadPt     , "lpt_1"    , 0.);  
-	INIT_VARIABLE(leadEta    , "leta_1"   , large_val);  
-	INIT_VARIABLE(leadPhi    , "lphi_1"   , large_val);  
-	INIT_VARIABLE(secondPt   , "spt_1"    , 0.);  
-	INIT_VARIABLE(secondEta  , "seta_1"   , large_val);  
-	INIT_VARIABLE(secondPhi  , "sphi_1"   , large_val);  
-	INIT_VARIABLE(leadNeutPt , "lnept_1"    , 0.);  
-	INIT_VARIABLE(leadNeutEta, "lneeta_1"   , large_val);  
-	INIT_VARIABLE(leadNeutPhi, "lnephi_1"   , large_val);  
-	INIT_VARIABLE(leadEmPt   , "lempt_1"  , 0.);  
-	INIT_VARIABLE(leadEmEta  , "lemeta_1" , large_val);  
-	INIT_VARIABLE(leadEmPhi  , "lemphi_1" , large_val);  
-	INIT_VARIABLE(leadChPt   , "lchpt_1"  , 0.);  
-	INIT_VARIABLE(leadChEta  , "lcheta_1" , large_val);  
-	INIT_VARIABLE(leadChPhi  , "lchphi_1" , large_val);  
-	INIT_VARIABLE(leadFrac   , "lLfr_1"   , 0.);  
-	
-	INIT_VARIABLE(dRLeadCent , "drlc_1"   , 0.);  
-	INIT_VARIABLE(dRLead2nd  , "drls_1"   , 0.);  
-	INIT_VARIABLE(dRMean     , "drm_1"    , 0.);  
-	INIT_VARIABLE(dRMean     , ""    , 0.);  
-	INIT_VARIABLE(pull       , ""    , 0.);
-	INIT_VARIABLE(dRMeanNeut , "drmne_1"  , 0.);  
-	INIT_VARIABLE(dRMeanEm   , "drem_1"   , 0.);  
-	INIT_VARIABLE(dRMeanCh   , "drch_1"   , 0.);  
-	INIT_VARIABLE(dR2Mean    , ""         , 0.);  
-		
-	INIT_VARIABLE(ptD        , "", 0.);
-	INIT_VARIABLE(ptMean     , "", 0.);
-	INIT_VARIABLE(ptRMS      , "", 0.);
-	INIT_VARIABLE(pt2A       , "", 0.);
-	INIT_VARIABLE(ptDCh      , "", 0.);
-	INIT_VARIABLE(ptDNe      , "", 0.);
-	INIT_VARIABLE(sumPt      , "", 0.);
-	INIT_VARIABLE(sumChPt    , "", 0.);
-	INIT_VARIABLE(sumNePt    , "", 0.);
+  INIT_VARIABLE(nCharged, "", 0.);
+  INIT_VARIABLE(nNeutrals, "", 0.);
 
-	INIT_VARIABLE(secondFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthFrac  ,"" ,0.);  
+  INIT_VARIABLE(chgEMfrac, "", 0.);
+  INIT_VARIABLE(neuEMfrac, "", 0.);
+  INIT_VARIABLE(chgHadrfrac, "", 0.);
+  INIT_VARIABLE(neuHadrfrac, "", 0.);
 
-	INIT_VARIABLE(leadChFrac    ,"" ,0.);  
-	INIT_VARIABLE(secondChFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdChFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthChFrac  ,"" ,0.);  
+  INIT_VARIABLE(d0, "jd0_1", -1000.);
+  INIT_VARIABLE(dZ, "jdZ_1", -1000.);
+  //INIT_VARIABLE(nParticles , "npart_1"  , 0.);
+  INIT_VARIABLE(nParticles, "", 0.);
 
-	INIT_VARIABLE(leadNeutFrac    ,"" ,0.);  
-	INIT_VARIABLE(secondNeutFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdNeutFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthNeutFrac  ,"" ,0.);  
+  INIT_VARIABLE(leadPt, "lpt_1", 0.);
+  INIT_VARIABLE(leadEta, "leta_1", large_val);
+  INIT_VARIABLE(leadPhi, "lphi_1", large_val);
+  INIT_VARIABLE(secondPt, "spt_1", 0.);
+  INIT_VARIABLE(secondEta, "seta_1", large_val);
+  INIT_VARIABLE(secondPhi, "sphi_1", large_val);
+  INIT_VARIABLE(leadNeutPt, "lnept_1", 0.);
+  INIT_VARIABLE(leadNeutEta, "lneeta_1", large_val);
+  INIT_VARIABLE(leadNeutPhi, "lnephi_1", large_val);
+  INIT_VARIABLE(leadEmPt, "lempt_1", 0.);
+  INIT_VARIABLE(leadEmEta, "lemeta_1", large_val);
+  INIT_VARIABLE(leadEmPhi, "lemphi_1", large_val);
+  INIT_VARIABLE(leadChPt, "lchpt_1", 0.);
+  INIT_VARIABLE(leadChEta, "lcheta_1", large_val);
+  INIT_VARIABLE(leadChPhi, "lchphi_1", large_val);
+  INIT_VARIABLE(leadFrac, "lLfr_1", 0.);
 
-	INIT_VARIABLE(leadEmFrac    ,"" ,0.);  
-	INIT_VARIABLE(secondEmFrac  ,"" ,0.);  
-	INIT_VARIABLE(thirdEmFrac   ,"" ,0.);  
-	INIT_VARIABLE(fourthEmFrac  ,"" ,0.);  
+  INIT_VARIABLE(dRLeadCent, "drlc_1", 0.);
+  INIT_VARIABLE(dRLead2nd, "drls_1", 0.);
+  INIT_VARIABLE(dRMean, "drm_1", 0.);
+  INIT_VARIABLE(dRMean, "", 0.);
+  INIT_VARIABLE(pull, "", 0.);
+  INIT_VARIABLE(dRMeanNeut, "drmne_1", 0.);
+  INIT_VARIABLE(dRMeanEm, "drem_1", 0.);
+  INIT_VARIABLE(dRMeanCh, "drch_1", 0.);
+  INIT_VARIABLE(dR2Mean, "", 0.);
 
-	INIT_VARIABLE(jetW  ,"" ,1.);  
-	INIT_VARIABLE(etaW  ,"" ,1.);  
-	INIT_VARIABLE(phiW  ,"" ,1.);  
+  INIT_VARIABLE(ptD, "", 0.);
+  INIT_VARIABLE(ptMean, "", 0.);
+  INIT_VARIABLE(ptRMS, "", 0.);
+  INIT_VARIABLE(pt2A, "", 0.);
+  INIT_VARIABLE(ptDCh, "", 0.);
+  INIT_VARIABLE(ptDNe, "", 0.);
+  INIT_VARIABLE(sumPt, "", 0.);
+  INIT_VARIABLE(sumChPt, "", 0.);
+  INIT_VARIABLE(sumNePt, "", 0.);
 
-	INIT_VARIABLE(majW  ,"" ,1.);  
-	INIT_VARIABLE(minW  ,"" ,1.);  
+  INIT_VARIABLE(secondFrac, "", 0.);
+  INIT_VARIABLE(thirdFrac, "", 0.);
+  INIT_VARIABLE(fourthFrac, "", 0.);
 
-	INIT_VARIABLE(frac01    ,"" ,0.);  
-	INIT_VARIABLE(frac02    ,"" ,0.);  
-	INIT_VARIABLE(frac03    ,"" ,0.);  
-	INIT_VARIABLE(frac04    ,"" ,0.);
-	INIT_VARIABLE(frac05   ,"" ,0.);  
-	INIT_VARIABLE(frac06   ,"" ,0.);  
-	INIT_VARIABLE(frac07   ,"" ,0.);
-		
-	INIT_VARIABLE(chFrac01    ,"" ,0.);  
-	INIT_VARIABLE(chFrac02    ,"" ,0.);
-	INIT_VARIABLE(chFrac03    ,"" ,0.);  
-	INIT_VARIABLE(chFrac04    ,"" ,0.);  
-	INIT_VARIABLE(chFrac05   ,"" ,0.);  
-	INIT_VARIABLE(chFrac06   ,"" ,0.);  
-	INIT_VARIABLE(chFrac07   ,"" ,0.);  
+  INIT_VARIABLE(leadChFrac, "", 0.);
+  INIT_VARIABLE(secondChFrac, "", 0.);
+  INIT_VARIABLE(thirdChFrac, "", 0.);
+  INIT_VARIABLE(fourthChFrac, "", 0.);
 
-	INIT_VARIABLE(neutFrac01    ,"" ,0.);  
-	INIT_VARIABLE(neutFrac02    ,"" ,0.);  
-	INIT_VARIABLE(neutFrac03    ,"" ,0.);  
-	INIT_VARIABLE(neutFrac04    ,"" ,0.);  
-	INIT_VARIABLE(neutFrac05   ,"" ,0.);  
-	INIT_VARIABLE(neutFrac06   ,"" ,0.);  
-	INIT_VARIABLE(neutFrac07   ,"" ,0.);  
+  INIT_VARIABLE(leadNeutFrac, "", 0.);
+  INIT_VARIABLE(secondNeutFrac, "", 0.);
+  INIT_VARIABLE(thirdNeutFrac, "", 0.);
+  INIT_VARIABLE(fourthNeutFrac, "", 0.);
 
-	INIT_VARIABLE(emFrac01    ,"" ,0.);  
-	INIT_VARIABLE(emFrac02    ,"" ,0.);  
-	INIT_VARIABLE(emFrac03    ,"" ,0.);  
-	INIT_VARIABLE(emFrac04    ,"" ,0.);  
-	INIT_VARIABLE(emFrac05   ,"" ,0.);  
-	INIT_VARIABLE(emFrac06   ,"" ,0.);  
-	INIT_VARIABLE(emFrac07   ,"" ,0.);  
+  INIT_VARIABLE(leadEmFrac, "", 0.);
+  INIT_VARIABLE(secondEmFrac, "", 0.);
+  INIT_VARIABLE(thirdEmFrac, "", 0.);
+  INIT_VARIABLE(fourthEmFrac, "", 0.);
 
-	INIT_VARIABLE(beta   ,"" ,0.);  
-	INIT_VARIABLE(betaStar   ,"" ,0.);  
-	INIT_VARIABLE(betaClassic   ,"" ,0.);  
-	INIT_VARIABLE(betaStarClassic   ,"" ,0.);  
+  INIT_VARIABLE(jetW, "", 1.);
+  INIT_VARIABLE(etaW, "", 1.);
+  INIT_VARIABLE(phiW, "", 1.);
 
-	INIT_VARIABLE(nvtx   ,"" ,0.);  
-	INIT_VARIABLE(rho   ,"" ,0.);  
-	INIT_VARIABLE(nTrueInt   ,"" ,0.);
+  INIT_VARIABLE(majW, "", 1.);
+  INIT_VARIABLE(minW, "", 1.);
 
-	INIT_VARIABLE(jetR       , "", 0.);
-	INIT_VARIABLE(jetRchg    , "", 0.);
-	INIT_VARIABLE(dRMatch    , "", 0.);
-	
+  INIT_VARIABLE(frac01, "", 0.);
+  INIT_VARIABLE(frac02, "", 0.);
+  INIT_VARIABLE(frac03, "", 0.);
+  INIT_VARIABLE(frac04, "", 0.);
+  INIT_VARIABLE(frac05, "", 0.);
+  INIT_VARIABLE(frac06, "", 0.);
+  INIT_VARIABLE(frac07, "", 0.);
+
+  INIT_VARIABLE(chFrac01, "", 0.);
+  INIT_VARIABLE(chFrac02, "", 0.);
+  INIT_VARIABLE(chFrac03, "", 0.);
+  INIT_VARIABLE(chFrac04, "", 0.);
+  INIT_VARIABLE(chFrac05, "", 0.);
+  INIT_VARIABLE(chFrac06, "", 0.);
+  INIT_VARIABLE(chFrac07, "", 0.);
+
+  INIT_VARIABLE(neutFrac01, "", 0.);
+  INIT_VARIABLE(neutFrac02, "", 0.);
+  INIT_VARIABLE(neutFrac03, "", 0.);
+  INIT_VARIABLE(neutFrac04, "", 0.);
+  INIT_VARIABLE(neutFrac05, "", 0.);
+  INIT_VARIABLE(neutFrac06, "", 0.);
+  INIT_VARIABLE(neutFrac07, "", 0.);
+
+  INIT_VARIABLE(emFrac01, "", 0.);
+  INIT_VARIABLE(emFrac02, "", 0.);
+  INIT_VARIABLE(emFrac03, "", 0.);
+  INIT_VARIABLE(emFrac04, "", 0.);
+  INIT_VARIABLE(emFrac05, "", 0.);
+  INIT_VARIABLE(emFrac06, "", 0.);
+  INIT_VARIABLE(emFrac07, "", 0.);
+
+  INIT_VARIABLE(beta, "", 0.);
+  INIT_VARIABLE(betaStar, "", 0.);
+  INIT_VARIABLE(betaClassic, "", 0.);
+  INIT_VARIABLE(betaStarClassic, "", 0.);
+
+  INIT_VARIABLE(nvtx, "", 0.);
+  INIT_VARIABLE(rho, "", 0.);
+  INIT_VARIABLE(nTrueInt, "", 0.);
+
+  INIT_VARIABLE(jetR, "", 0.);
+  INIT_VARIABLE(jetRchg, "", 0.);
+  INIT_VARIABLE(dRMatch, "", 0.);
 }
 
 #undef INIT_VARIABLE

--- a/RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h
@@ -59,7 +59,6 @@ private:
   math::XYZVector B_;
   PFGeometry pfGeometry_;
   static constexpr double cos2ThetaV_Endcap_HiEnd_ = 0.99014;
-
 };
 
 #endif

--- a/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
@@ -33,7 +33,6 @@ PFTrackTransformer::PFTrackTransformer(const math::XYZVector& B) : B_(B) {
   LogInfo("PFTrackTransformer") << "PFTrackTransformer built";
 
   onlyprop_ = false;
-
 }
 
 PFTrackTransformer::~PFTrackTransformer() {}
@@ -132,7 +131,6 @@ bool PFTrackTransformer::addPoints(reco::PFRecTrack& pftrack,
     pftrack.addPoint(dummyPS2);
   }
 
-
   //ECAL entrance
   theOutParticle.propagateToEcalEntrance(false);
   if (theOutParticle.getSuccess() != 0) {
@@ -154,10 +152,10 @@ bool PFTrackTransformer::addPoints(reco::PFRecTrack& pftrack,
     if (PT > 5. && theOutParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_ && msgwarning)
       // Check consistent boundary as in CommonTools/BaseParticlePropagator/src/BaseParticlePropagator.cc
       // out of the HB/HE acceptance
-      // eta = 3.0 -> cos^2(theta) = 0.99014 - cos**2(theta) is faster to determine than eta 
+      // eta = 3.0 -> cos^2(theta) = 0.99014 - cos**2(theta) is faster to determine than eta
       LogWarning("PFTrackTransformer") << "KF TRACK " << pftrack << " PROPAGATION TO THE ECAL HAS FAILED\n"
-				       << "theOutParticle.particle() pt,eta: "
-				       << theOutParticle.particle().pt() << " " << theOutParticle.particle().eta();
+                                       << "theOutParticle.particle() pt,eta: " << theOutParticle.particle().pt() << " "
+                                       << theOutParticle.particle().eta();
     PFTrajectoryPoint dummyECAL;
     pftrack.addPoint(dummyECAL);
     PFTrajectoryPoint dummyMaxSh;
@@ -212,20 +210,20 @@ bool PFTrackTransformer::addPoints(reco::PFRecTrack& pftrack,
     }
   }
 
-   //VFcal(HF) entrance
-   theOutParticle.setMagneticField(0); // assume B=0 works ok for extrapolation to HF 
-   theOutParticle.propagateToVFcalEntrance(false);
-   if(theOutParticle.getSuccess()!=0){
-     pftrack.addPoint(PFTrajectoryPoint(-1,PFTrajectoryPoint::VFcalEntrance,
-					math::XYZPoint(theOutParticle.particle().vertex()),
-					math::XYZTLorentzVector(theOutParticle.particle().momentum())));
-   }
-   else{
-     PFTrajectoryPoint dummyVFcalentrance;
-     pftrack.addPoint(dummyVFcalentrance); 
-   }
+  //VFcal(HF) entrance
+  theOutParticle.setMagneticField(0);  // assume B=0 works ok for extrapolation to HF
+  theOutParticle.propagateToVFcalEntrance(false);
+  if (theOutParticle.getSuccess() != 0) {
+    pftrack.addPoint(PFTrajectoryPoint(-1,
+                                       PFTrajectoryPoint::VFcalEntrance,
+                                       math::XYZPoint(theOutParticle.particle().vertex()),
+                                       math::XYZTLorentzVector(theOutParticle.particle().momentum())));
+  } else {
+    PFTrajectoryPoint dummyVFcalentrance;
+    pftrack.addPoint(dummyVFcalentrance);
+  }
 
-   return true;
+  return true;
 }
 bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                            const reco::Track& track,
@@ -351,10 +349,10 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                            meanShower,
                                            math::XYZTLorentzVector(theOutParticle.particle().momentum())));
       } else {
-	if (PT > 5. && theOutParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+        if (PT > 5. && theOutParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
           LogWarning("PFTrackTransformer") << "GSF TRACK " << pftrack << " PROPAGATION TO THE ECAL HAS FAILED\n"
-					   << "theOutParticle.particle() pt,eta: "
-					   << theOutParticle.particle().pt() << " " << theOutParticle.particle().eta();
+                                           << "theOutParticle.particle() pt,eta: " << theOutParticle.particle().pt()
+                                           << " " << theOutParticle.particle().eta();
         PFTrajectoryPoint dummyECAL;
         pftrack.addPoint(dummyECAL);
         PFTrajectoryPoint dummyMaxSh;
@@ -369,7 +367,7 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                            math::XYZPoint(theOutParticle.particle().vertex()),
                                            math::XYZTLorentzVector(theOutParticle.particle().momentum())));
       else {
-	if (PT > 5. && theOutParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+        if (PT > 5. && theOutParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
           LogWarning("PFTrackTransformer") << "GSF TRACK " << pftrack << " PROPAGATION TO THE HCAL ENTRANCE HAS FAILED";
         PFTrajectoryPoint dummyHCALentrance;
         pftrack.addPoint(dummyHCALentrance);
@@ -382,7 +380,7 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                            math::XYZPoint(theOutParticle.particle().vertex()),
                                            math::XYZTLorentzVector(theOutParticle.particle().momentum())));
       else {
-	if (PT > 5. && theOutParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+        if (PT > 5. && theOutParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
           LogWarning("PFTrackTransformer") << "GSF TRACK " << pftrack << " PROPAGATION TO THE HCAL EXIT HAS FAILED";
         PFTrajectoryPoint dummyHCALexit;
         pftrack.addPoint(dummyHCALexit);
@@ -487,10 +485,10 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                       math::XYZTLorentzVector(theBremParticle.particle().momentum())));
     } else {
       if ((DP > 5.) && ((DP / SigmaDP) > 3) && theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
-	LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE ECAL HAS FAILED\n"
-					 << "theBremParticle.particle() pt,eta,cos2ThetaV: "
-					 << theBremParticle.particle().pt() << " " << theBremParticle.particle().eta() << " "
-					 << theBremParticle.particle().cos2ThetaV();
+        LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE ECAL HAS FAILED\n"
+                                         << "theBremParticle.particle() pt,eta,cos2ThetaV: "
+                                         << theBremParticle.particle().pt() << " " << theBremParticle.particle().eta()
+                                         << " " << theBremParticle.particle().cos2ThetaV();
       PFTrajectoryPoint dummyECAL;
       brem.addPoint(dummyECAL);
       PFTrajectoryPoint dummyMaxSh;
@@ -681,11 +679,12 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                     meanShower,
                                     math::XYZTLorentzVector(theBremParticle.particle().momentum())));
   } else {
-    if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) && theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+    if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) &&
+        theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
       LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE ECAL HAS FAILED\n"
-				       << "theBremParticle.particle() pt,eta,cos2ThetaV: "
-				       << theBremParticle.particle().pt() << " " << theBremParticle.particle().eta() << " "
-				       << theBremParticle.particle().cos2ThetaV();
+                                       << "theBremParticle.particle() pt,eta,cos2ThetaV: "
+                                       << theBremParticle.particle().pt() << " " << theBremParticle.particle().eta()
+                                       << " " << theBremParticle.particle().cos2ThetaV();
     PFTrajectoryPoint dummyECAL;
     brem.addPoint(dummyECAL);
     PFTrajectoryPoint dummyMaxSh;
@@ -700,7 +699,8 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                     math::XYZPoint(theBremParticle.particle().vertex()),
                                     math::XYZTLorentzVector(theBremParticle.particle().momentum())));
   else {
-    if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) && theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+    if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) &&
+        theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
       LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE HCAL ENTRANCE HAS FAILED";
     PFTrajectoryPoint dummyHCALentrance;
     brem.addPoint(dummyHCALentrance);
@@ -714,7 +714,8 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                     math::XYZPoint(theBremParticle.particle().vertex()),
                                     math::XYZTLorentzVector(theBremParticle.particle().momentum())));
   else {
-    if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) && theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+    if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) &&
+        theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
       LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE HCAL EXIT HAS FAILED";
     PFTrajectoryPoint dummyHCALexit;
     brem.addPoint(dummyHCALexit);
@@ -842,11 +843,12 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                       meanShower,
                                       math::XYZTLorentzVector(theBremParticle.particle().momentum())));
     } else {
-      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) && theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
-	LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE ECAL HAS FAILED\n"
-					 << "theBremParticle.particle() pt,eta,cos2ThetaV: "
-					 << theBremParticle.particle().pt() << " " << theBremParticle.particle().eta() << " "
-					 << theBremParticle.particle().cos2ThetaV();
+      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) &&
+          theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+        LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE ECAL HAS FAILED\n"
+                                         << "theBremParticle.particle() pt,eta,cos2ThetaV: "
+                                         << theBremParticle.particle().pt() << " " << theBremParticle.particle().eta()
+                                         << " " << theBremParticle.particle().cos2ThetaV();
       PFTrajectoryPoint dummyECAL;
       brem.addPoint(dummyECAL);
       PFTrajectoryPoint dummyMaxSh;
@@ -861,7 +863,8 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                       math::XYZPoint(theBremParticle.particle().vertex()),
                                       math::XYZTLorentzVector(theBremParticle.particle().momentum())));
     else {
-      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) && theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) &&
+          theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
         LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE HCAL ENTRANCE HAS FAILED";
       PFTrajectoryPoint dummyHCALentrance;
       brem.addPoint(dummyHCALentrance);
@@ -875,7 +878,8 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                       math::XYZPoint(theBremParticle.particle().vertex()),
                                       math::XYZTLorentzVector(theBremParticle.particle().momentum())));
     else {
-      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) && theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) &&
+          theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
         LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE HCAL EXIT HAS FAILED";
       PFTrajectoryPoint dummyHCALexit;
       brem.addPoint(dummyHCALexit);
@@ -976,8 +980,8 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
     } else {
       if (pTtot_out > 5. && theOutParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
         LogWarning("PFTrackTransformer") << "GSF TRACK " << pftrack << " PROPAGATION TO THE ECAL HAS FAILED\n"
-					 << "theOutParticle.particle() pt,eta: "
-					 << theOutParticle.particle().pt() << " " << theOutParticle.particle().eta();
+                                         << "theOutParticle.particle() pt,eta: " << theOutParticle.particle().pt()
+                                         << " " << theOutParticle.particle().eta();
 
       PFTrajectoryPoint dummyECAL;
       pftrack.addPoint(dummyECAL);
@@ -1094,11 +1098,12 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                       meanShower,
                                       math::XYZTLorentzVector(theBremParticle.particle().momentum())));
     } else {
-      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) && theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
-	LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE ECAL HAS FAILED\n"
-					 << "theBremParticle.particle() pt,eta,cos2ThetaV: "
-					 << theBremParticle.particle().pt() << " " << theBremParticle.particle().eta() << " "
-					 << theBremParticle.particle().cos2ThetaV();
+      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) &&
+          theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+        LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE ECAL HAS FAILED\n"
+                                         << "theBremParticle.particle() pt,eta,cos2ThetaV: "
+                                         << theBremParticle.particle().pt() << " " << theBremParticle.particle().eta()
+                                         << " " << theBremParticle.particle().cos2ThetaV();
       PFTrajectoryPoint dummyECAL;
       brem.addPoint(dummyECAL);
       PFTrajectoryPoint dummyMaxSh;
@@ -1113,7 +1118,8 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                       math::XYZPoint(theBremParticle.particle().vertex()),
                                       math::XYZTLorentzVector(theBremParticle.particle().momentum())));
     else {
-      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) && theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) &&
+          theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
         LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE HCAL ENTRANCE HAS FAILED";
       PFTrajectoryPoint dummyHCALentrance;
       brem.addPoint(dummyHCALentrance);
@@ -1126,8 +1132,9 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
                                       math::XYZPoint(theBremParticle.particle().vertex()),
                                       math::XYZTLorentzVector(theBremParticle.particle().momentum())));
     else {
-      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) && theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
-	LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE HCAL EXIT HAS FAILED";
+      if ((dp_tang > 5.) && ((dp_tang / sdp_tang) > 3) &&
+          theBremParticle.particle().cos2ThetaV() < cos2ThetaV_Endcap_HiEnd_)
+        LogWarning("PFTrackTransformer") << "BREM " << brem << " PROPAGATION TO THE HCAL EXIT HAS FAILED";
       PFTrajectoryPoint dummyHCALexit;
       brem.addPoint(dummyHCALexit);
     }


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/441//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


