### PR TITLE
Fixed missing link in PhysicsTools/PatAlgos

### DIFF
--- a/PhysicsTools/PatAlgos/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/BuildFile.xml
@@ -11,6 +11,7 @@
 <use   name="DataFormats/TauReco"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/VertexReco"/>
+<use   name="JetMETCorrections/JetCorrector"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>


### PR DESCRIPTION

#### PR description:

Need to link with JetMETCorrections/JetCorrector to make UBSAN work.

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-25-2300 IB.