### PR TITLE
Fix missing link in MuonAnalysis/MuonAssociators

### DIFF
--- a/MuonAnalysis/MuonAssociators/plugins/BuildFile.xml
+++ b/MuonAnalysis/MuonAssociators/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="SimMuon/MCTruth"/>
 <use   name="SimTracker/Records"/>
 <use   name="SimTracker/TrackAssociation"/>
+<use   name="SimDataFormats/Associations"/>
 <use   name="MuonAnalysis/MuonAssociators"/>
 <export>
 </export>


### PR DESCRIPTION
#### PR description:

Need to link with SimDataFormats/Associations to make UBSAN work.

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-25-2300 IB.