### PR TITLE
Fixed missing link in Fireworks/Core

### DIFF
--- a/Fireworks/Core/BuildFile.xml
+++ b/Fireworks/Core/BuildFile.xml
@@ -25,6 +25,7 @@
 <use name="rootinteractive"/>
 <use name="rootgraphics"/>
 <use name="sigcpp"/>
+<use name="rootged"/>
 <lib name="Thread"/>
 <lib name="Eve"/>
 <lib name="Geom"/>


### PR DESCRIPTION
Need to link with rootged in order for UBSAN to work.

#### PR description:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-25-2300 IB.