### PR TITLE
Fixed missing link in ElectroWeakAnalysis/ZEE

### DIFF
--- a/ElectroWeakAnalysis/ZEE/BuildFile.xml
+++ b/ElectroWeakAnalysis/ZEE/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/PatCandidates"/>
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/Scalers"/>
 <use   name="Geometry/CaloGeometry"/>
 <use   name="Geometry/CaloTopology"/>
 <use   name="CommonTools/UtilAlgos"/>


### PR DESCRIPTION
#### PR description:

Need to link to DataFormats/Scalers so UBSAN will work

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-25-2300 IB.