### PR TITLE
Fixed missing link in DQM/CastorMonitor

### DIFF
--- a/DQM/CastorMonitor/BuildFile.xml
+++ b/DQM/CastorMonitor/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="CondFormats/CastorObjects"/>
 <use   name="CalibFormats/CastorObjects"/>
 <use   name="DataFormats/JetReco"/>
+<use   name="DataFormats/CastorReco"/>
 <use   name="EventFilter/CastorRawToDigi"/>
 <use   name="Geometry/CaloGeometry"/>
 <use   name="FWCore/ParameterSet"/>


### PR DESCRIPTION

#### PR description:

Need to link with DataFormats/CastorReco so UBSAN will work.

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-25-2300 IB.