### PR TITLE
Fixed missing link in CondCore/SiStripPlugins

### DIFF
--- a/CondCore/SiStripPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiStripPlugins/plugins/BuildFile.xml
@@ -65,6 +65,7 @@
   <use   name="CondCore/CondDB"/>
   <use   name="CondFormats/Common"/>
   <use   name="CondFormats/SiStripObjects"/>
+  <use   name="CalibFormats/SiStripObjects"/>
   <use   name="CalibTracker/StandaloneTrackerTopology"/>
   <use   name="CalibTracker/SiStripCommon"/>
 </library>


### PR DESCRIPTION
#### PR description:

Need to link with CalibFormats/SiStripObjects for UBSAN to work.

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-25-2300 IB.