### PR TITLE
Fix ADC range for HGC scintillators

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -188,9 +188,9 @@ hgchebackDigitizer = cms.PSet(
             # 0 only ADC, 1 ADC with pulse shape, 2 ADC+TDC with pulse shape
             fwVersion       = cms.uint32(0),
             # n bits for the ADC (same as the silicon ROC)
-            adcNbits        = cms.uint32(10),
+            adcNbits        = cms.uint32(12),
             # ADC saturation : in this case we use the same variable but fC=MIP
-            adcSaturation_fC = cms.double(68.5), #value chosen to have 1MIP at 15ADC
+            adcSaturation_fC = cms.double(275.0), #value chosen to have 1MIP at 15ADC
             # threshold for digi production : in this case we use the same variable but fC=MIP
             adcThreshold_fC = cms.double(0.5),
             thresholdFollowsMIP = cms.bool(False)

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -178,7 +178,7 @@ hgchebackDigitizer = cms.PSet(
         scaleByArea   = cms.bool(True),
         noise         = cms.PSet(refToPSet_ = cms.string("HGCAL_noise_heback")), #scales both for scint raddam and sipm dark current
         calibDigis    = cms.bool(True),
-        keV2MIP       = cms.double(1./500.0),
+        keV2MIP       = cms.double(1./675.0),
         doTimeSamples = cms.bool(False),
         nPEperMIP = cms.double(21.0),
         nTotalPE  = cms.double(7500),

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -264,7 +264,7 @@ void HGCHEbackDigitizer::runRealisticDigitizer(std::unique_ptr<HGCalDigiCollecti
       //const float nPixelTot = nPixel + sqrt(nPixel) * CLHEP::RandGaussQ::shoot(engine, 0., 0.05); //FDG: just a note for now, par to be defined
 
       //scale to calibrated response depending on the calibDigis_ flag
-      float totalMIPs = calibDigis_ ? (float)npe / scaledPePerMip : nPixel / nPEperMIP_;
+      float totalMIPs = calibDigis_ ? std::max((npe - meanN), 0.f) / scaledPePerMip : nPixel / nPEperMIP_;
 
       if (debug && totalIniMIPs > 0) {
         LogDebug("HGCHEbackDigitizer") << "npeS: " << npeS << " npeN: " << npeN << " npe: " << npe


### PR DESCRIPTION
The ADC range was fixed to [0, 68.5] MIPs which isn't enough for large energy deposits. the range is now extended to 275 MIPs. the current implementation of the readout electronics for the HGC scintillators is a simplistic one so this choice is arbitrary.

this PR also includes:
- updated conversion of the kev2mip factor --> transparent for the reco as rechits are autocalibrated
- subtraction of the pedestal mean at digi level --> this is following some discussion we had recently and it is relevant for aged scenario only


the PR was validated locally and passes:
`scram build code-checks`
`scram b runtests`
`runTheMatrix.py -l limited -i all --ibeos` (still running)

@rovere @jingyucms @pfs @cseez