### PR TITLE
Added missing link to Calibration/IsolatedParticles

### DIFF
--- a/Calibration/IsolatedParticles/plugins/BuildFile.xml
+++ b/Calibration/IsolatedParticles/plugins/BuildFile.xml
@@ -37,6 +37,7 @@
 <use   name="HLTrigger/HLTcore"/>
 <use   name="HLTrigger/Timer"/>
 <use   name="Calibration/IsolatedParticles"/>
+<use   name="DataFormats/HcalIsolatedTrack"/>
 <flags   EDM_PLUGIN="1"/>
 <library   name="CalibrationIsolatedTracksNxN" file="IsolatedTracksNxN.cc"> </library>
 <library   name="CalibrationIsolatedTracksCone" file="IsolatedTracksCone.cc"> </library>


### PR DESCRIPTION
#### PR description:

Need to link with DataFormats/HcalIsolatedTrack so UBSAN works.

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-25-2300 IB.