### PR TITLE
Fix missing links in Calibration/HcalCalibAlgos

### DIFF
--- a/Calibration/HcalCalibAlgos/plugins/BuildFile.xml
+++ b/Calibration/HcalCalibAlgos/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
 <use   name="DataFormats/L1GlobalTrigger"/>
 <use   name="DataFormats/ParticleFlowReco"/>
 <use   name="DataFormats/TrackReco"/>
+<use   name="DataFormats/HcalIsolatedTrack"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>

--- a/Calibration/HcalCalibAlgos/test/BuildFile.xml
+++ b/Calibration/HcalCalibAlgos/test/BuildFile.xml
@@ -13,6 +13,7 @@
 <use   name="DataFormats/L1GlobalTrigger"/>
 <use   name="DataFormats/ParticleFlowReco"/>
 <use   name="DataFormats/TrackReco"/>
+<use   name="DataFormats/HcalIsolatedTrack"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>


### PR DESCRIPTION
#### PR description:

Need to link with DataFormats/HcalIsolatedTrack in order for UBSAN to work.

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-25-2300 IB.