### PR TITLE
Fix SiPixelGenError Interpolation for Irradiation Bias Correction

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelGenError.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelGenError.h
@@ -10,6 +10,7 @@
 //  V2.10 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
 //  V2.20 - Add directory path selection to the ascii pushfile method
 //  V2.21 - Move templateStore to the heap, fix variable name in pushfile()
+//  V2.30 - Fix interpolation of IrradiationBias corrections
 
 // Build the template storage structure from several pieces
 

--- a/CondFormats/SiPixelTransient/src/SiPixelGenError.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelGenError.cc
@@ -1,5 +1,5 @@
 //
-//  SiPixelGenError.cc  Version 2.20
+//  SiPixelGenError.cc  Version 2.30
 //
 //  Object stores Lorentz widths, bias corrections, and errors for the Generic Algorithm
 //
@@ -10,6 +10,7 @@
 //  V2.10 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
 //  V2.20 - Add directory path selection to the ascii pushfile method
 //  V2.21 - Move templateStore to the heap, fix variable name in pushfile()
+//  V2.30 - Fix interpolation of IrradiationBias corrections
 
 //#include <stdlib.h>
 //#include <stdio.h>
@@ -754,6 +755,23 @@ int SiPixelGenError::qbin(int id,
   sy1 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].syone + yratio * thePixelTemp_[index].enty[ihigh].syone;
   sy2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].sytwo + yratio * thePixelTemp_[index].enty[ihigh].sytwo;
 
+  if (irradiationCorrections) {
+    auto yavggen = (1.f - yratio) * thePixelTemp_[index].enty[ilow].yavggen[binq] +
+                   yratio * thePixelTemp_[index].enty[ihigh].yavggen[binq];
+    if (flip_y) {
+      yavggen = -yavggen;
+    }
+    deltay = yavggen;
+    dy1 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].dyone + yratio * thePixelTemp_[index].enty[ihigh].dyone;
+    if (flip_y) {
+      dy1 = -dy1;
+    }
+    dy2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].dytwo + yratio * thePixelTemp_[index].enty[ihigh].dytwo;
+    if (flip_y) {
+      dy2 = -dy2;
+    }
+  }
+
   // next, loop over all x-angle entries, first, find relevant y-slices
 
   auto iylow = 0;
@@ -812,21 +830,6 @@ int SiPixelGenError::qbin(int id,
                             xxratio * thePixelTemp_[index].entx[iyhigh][ihigh].xrmsgen[binq]);
 
   if (irradiationCorrections) {
-    auto yavggen = (1.f - yratio) * thePixelTemp_[index].enty[ilow].yavggen[binq] +
-                   yratio * thePixelTemp_[index].enty[ihigh].yavggen[binq];
-    if (flip_y) {
-      yavggen = -yavggen;
-    }
-    deltay = yavggen;
-    dy1 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].dyone + yratio * thePixelTemp_[index].enty[ihigh].dyone;
-    if (flip_y) {
-      dy1 = -dy1;
-    }
-    dy2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].dytwo + yratio * thePixelTemp_[index].enty[ihigh].dytwo;
-    if (flip_y) {
-      dy2 = -dy2;
-    }
-
     auto xavggen = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index].entx[iylow][ilow].xavggen[binq] +
                                       xxratio * thePixelTemp_[index].entx[iylow][ihigh].xavggen[binq]) +
                    yxratio * ((1.f - xxratio) * thePixelTemp_[index].entx[iyhigh][ilow].xavggen[binq] +


### PR DESCRIPTION
#### PR description:

This PR is intended to fix a bug in the GenError object that is responsible for the poor performance of the generic reconstruction with Irradiation Bias Correction switched on. This is very relevant for the performance of the Pixel detector in Run3 studies.
The fix has been provided by M. Swartz and JHU group (@pmaksim1 @cmantill @OzAmram )

#### PR validation:

Enclosed are the plots illustrating the issue and the performance after the fix is applied. 
Results are shown for templates and generic reconstruction with and without the Irradiation Bias Correction and with the bug [left hand side] and with the bug fixed [right hand side]. As you can see, without the  bug fix the resolution in the central region is significantly degraded,

![image](https://user-images.githubusercontent.com/5082376/60272564-b8b7b480-98f4-11e9-941e-4c3d5c31ae49.png)

#### if this PR is a backport please specify the original PR:

This PR is not a backport, but it should be ported to 10_6_X as well, to be used for the `Run3Summer19DR` production studies. 

cc:
@tvami @tsusa @leaca