### PR TITLE
Fix package dependency problems in Alignment

### DIFF
--- a/Alignment/CommonAlignment/interface/AlignableObjectId.h
+++ b/Alignment/CommonAlignment/interface/AlignableObjectId.h
@@ -7,8 +7,6 @@
 class TrackerGeometry;
 class DTGeometry;
 class CSCGeometry;
-class AlignableTracker;
-class AlignableMuon;
 
 /// Allows conversion between type and name, and vice-versa
 class AlignableObjectId {
@@ -38,7 +36,10 @@ public:
 
   static Geometry commonGeometry(Geometry, Geometry);
   static AlignableObjectId commonObjectIdProvider(const AlignableObjectId&, const AlignableObjectId&);
-  static AlignableObjectId commonObjectIdProvider(const AlignableTracker*, const AlignableMuon*);
+  template <typename TRACKER, typename MUON>
+  static AlignableObjectId commonObjectIdProvider(const TRACKER*, const MUON*);
+  template <typename TRACKER>
+  static AlignableObjectId commonObjectIdProvider(const TRACKER*, std::nullptr_t);
 
 private:
   static Geometry trackerGeometry(const TrackerGeometry*);
@@ -47,5 +48,18 @@ private:
   const entry* entries_{nullptr};
   Geometry geometry_{Geometry::Unspecified};
 };
+
+template <typename TRACKER, typename MUON>
+AlignableObjectId AlignableObjectId ::commonObjectIdProvider(const TRACKER* tracker, const MUON* muon) {
+  auto trackerGeometry = (tracker ? tracker->objectIdProvider().geometry() : AlignableObjectId::Geometry::General);
+  auto muonGeometry = (muon ? muon->objectIdProvider().geometry() : AlignableObjectId::Geometry::General);
+  return AlignableObjectId::commonGeometry(trackerGeometry, muonGeometry);
+}
+
+template <typename T>
+AlignableObjectId AlignableObjectId ::commonObjectIdProvider(const T* tracker, std::nullptr_t) {
+  auto trackerGeometry = (tracker ? tracker->objectIdProvider().geometry() : AlignableObjectId::Geometry::General);
+  return AlignableObjectId::commonGeometry(trackerGeometry, AlignableObjectId::Geometry::General);
+}
 
 #endif

--- a/Alignment/CommonAlignment/src/AlignableObjectId.cc
+++ b/Alignment/CommonAlignment/src/AlignableObjectId.cc
@@ -4,8 +4,6 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
-#include "Alignment/MuonAlignment/interface/AlignableMuon.h"
 
 struct AlignableObjectId::entry {
   align::StructureType type;
@@ -322,11 +320,4 @@ AlignableObjectId::Geometry AlignableObjectId ::commonGeometry(Geometry first, G
 AlignableObjectId AlignableObjectId ::commonObjectIdProvider(const AlignableObjectId &first,
                                                              const AlignableObjectId &second) {
   return AlignableObjectId{commonGeometry(first.geometry(), second.geometry())};
-}
-
-AlignableObjectId AlignableObjectId ::commonObjectIdProvider(const AlignableTracker *tracker,
-                                                             const AlignableMuon *muon) {
-  auto trackerGeometry = (tracker ? tracker->objectIdProvider().geometry() : AlignableObjectId::Geometry::General);
-  auto muonGeometry = (muon ? muon->objectIdProvider().geometry() : AlignableObjectId::Geometry::General);
-  return AlignableObjectId::commonGeometry(trackerGeometry, muonGeometry);
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeLabelerBase.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeLabelerBase.cc
@@ -14,6 +14,9 @@
 #include "Alignment/CommonAlignmentParametrization/interface/RigidBodyAlignmentParameters.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationBase.h"
 
+#include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
+#include "Alignment/MuonAlignment/interface/AlignableMuon.h"
+
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // NOTE: Changing '+14' makes older binary files unreadable...

--- a/Alignment/SurveyAnalysis/BuildFile.xml
+++ b/Alignment/SurveyAnalysis/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="Alignment/CommonAlignment"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="DataFormats/SiStripDetId"/>
+<use   name="Geometry/DTGeometry"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Utilities"/>

--- a/Alignment/TrackerAlignment/plugins/BuildFile.xml
+++ b/Alignment/TrackerAlignment/plugins/BuildFile.xml
@@ -71,6 +71,7 @@
   <use   name="DataFormats/SiPixelDetId"/>
   <use   name="DataFormats/SiStripDetId"/>
   <use   name="DataFormats/SiStripCluster"/>
+  <use   name="DataFormats/MuonReco"/>
   <use   name="CondFormats/DataRecord"/>
   <use   name="CondFormats/SiStripObjects"/>
   <use   name="MagneticField/Engine"/>


### PR DESCRIPTION
#### PR description:

- Fixed circular dependency between CommonAlignment and TrackerAlignment/MuonAlignment
- Fixed missing links needed for UBSAN to work
#### PR validation:

Code compiles and links in the CMSSW_11_0_UBSAN_X_2019-06-25-2300 IB.