### PR TITLE
Fixed off by 1 error in testSuperCluster

### DIFF
--- a/DataFormats/EgammaReco/test/testSuperCluster.cppunit.cc
+++ b/DataFormats/EgammaReco/test/testSuperCluster.cppunit.cc
@@ -86,7 +86,7 @@ void testSuperCluster::CopyCtorTest() {
 
   OrphanHandle<CaloClusterCollection> handle(&clusters, pid);
 
-  CaloClusterPtr pc1(handle, 1), pc2(handle, 2), pc3(handle, 3);
+  CaloClusterPtr pc1(handle, 0), pc2(handle, 1), pc3(handle, 2);
 
   SuperCluster sc(5.0, math::XYZPoint(0, 0, 0));
   sc.setSeed(pc1);


### PR DESCRIPTION
#### PR description:

Ptr indicies start at 0, not 1.
This problem was found by UBSAN.

#### PR validation:

Code compiles and runs without UBSAN errors using the CMSSW_11_0_UBSAN_X_2019-06-25-2300 IB.