### PR TITLE
HGCAL TICL time compatibility for doublets building

### DIFF
--- a/RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h
+++ b/RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h
@@ -11,6 +11,7 @@
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "DataFormats/HGCalReco/interface/TICLLayerTile.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 
 namespace edm {
   class Event;
@@ -28,6 +29,7 @@ namespace ticl {
                                 const edm::EventSetup& es,
                                 const std::vector<reco::CaloCluster>& layerClusters,
                                 const std::vector<float>& mask,
+				const edm::ValueMap<float> &layerClustersTime,
                                 const TICLLayerTiles& tiles,
                                 std::vector<Trackster>& result) = 0;
     enum VerbosityLevel { None = 0, Basic, Advanced, Expert, Guru };

--- a/RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h
+++ b/RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h
@@ -29,7 +29,7 @@ namespace ticl {
                                 const edm::EventSetup& es,
                                 const std::vector<reco::CaloCluster>& layerClusters,
                                 const std::vector<float>& mask,
-				const edm::ValueMap<float> &layerClustersTime,
+                                const edm::ValueMap<float>& layerClustersTime,
                                 const TICLLayerTiles& tiles,
                                 std::vector<Trackster>& result) = 0;
     enum VerbosityLevel { None = 0, Basic, Advanced, Expert, Guru };

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -5,18 +5,21 @@
 #include "PatternRecognitionbyCA.h"
 #include "HGCDoublet.h"
 #include "HGCGraph.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 
 void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
                                       int nEtaBins,
                                       int nPhiBins,
                                       const std::vector<reco::CaloCluster> &layerClusters,
                                       const std::vector<float> &mask,
+				      const edm::ValueMap<float> &layerClustersTime,
                                       int deltaIEta,
                                       int deltaIPhi,
                                       float minCosTheta,
                                       float minCosPointing,
                                       int missing_layers,
-                                      int maxNumberOfLayers) {
+                                      int maxNumberOfLayers,
+				      float maxDeltaTime) {
   isOuterClusterOfDoublets_.clear();
   isOuterClusterOfDoublets_.resize(layerClusters.size());
   allDoublets_.clear();
@@ -53,6 +56,8 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
                     if (mask[innerClusterId] == 0.)
                       continue;
                     auto doubletId = allDoublets_.size();
+		    if(maxDeltaTime != -1 &&
+		       !areTimeCompatible(innerClusterId, outerClusterId, layerClustersTime, maxDeltaTime)) continue;
                     allDoublets_.emplace_back(innerClusterId, outerClusterId, doubletId, &layerClusters);
                     if (verbosity_ > Advanced) {
                       LogDebug("HGCGraph")
@@ -88,6 +93,17 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
                          << allDoublets_.size() << std::endl;
   }
   // #endif
+}
+
+bool HGCGraph::areTimeCompatible(int innerIdx, int outerIdx,
+				 const edm::ValueMap<float> &layerClustersTime, float maxDeltaTime){
+
+  float timeIn = layerClustersTime.get(innerIdx);
+  float timeOut = layerClustersTime.get(outerIdx);
+
+  if(timeIn == -99 || timeOut == -99) return true;
+  if(std::abs(timeIn - timeOut) < maxDeltaTime) return true;
+  else return false;
 }
 
 void HGCGraph::findNtuplets(std::vector<HGCDoublet::HGCntuplet> &foundNtuplets,

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -12,14 +12,14 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
                                       int nPhiBins,
                                       const std::vector<reco::CaloCluster> &layerClusters,
                                       const std::vector<float> &mask,
-				      const edm::ValueMap<float> &layerClustersTime,
+                                      const edm::ValueMap<float> &layerClustersTime,
                                       int deltaIEta,
                                       int deltaIPhi,
                                       float minCosTheta,
                                       float minCosPointing,
                                       int missing_layers,
                                       int maxNumberOfLayers,
-				      float maxDeltaTime) {
+                                      float maxDeltaTime) {
   isOuterClusterOfDoublets_.clear();
   isOuterClusterOfDoublets_.resize(layerClusters.size());
   allDoublets_.clear();
@@ -56,8 +56,9 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
                     if (mask[innerClusterId] == 0.)
                       continue;
                     auto doubletId = allDoublets_.size();
-		    if(maxDeltaTime != -1 &&
-		       !areTimeCompatible(innerClusterId, outerClusterId, layerClustersTime, maxDeltaTime)) continue;
+                    if (maxDeltaTime != -1 &&
+                        !areTimeCompatible(innerClusterId, outerClusterId, layerClustersTime, maxDeltaTime))
+                      continue;
                     allDoublets_.emplace_back(innerClusterId, outerClusterId, doubletId, &layerClusters);
                     if (verbosity_ > Advanced) {
                       LogDebug("HGCGraph")
@@ -95,15 +96,19 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
   // #endif
 }
 
-bool HGCGraph::areTimeCompatible(int innerIdx, int outerIdx,
-				 const edm::ValueMap<float> &layerClustersTime, float maxDeltaTime){
-
+bool HGCGraph::areTimeCompatible(int innerIdx,
+                                 int outerIdx,
+                                 const edm::ValueMap<float> &layerClustersTime,
+                                 float maxDeltaTime) {
   float timeIn = layerClustersTime.get(innerIdx);
   float timeOut = layerClustersTime.get(outerIdx);
 
-  if(timeIn == -99 || timeOut == -99) return true;
-  if(std::abs(timeIn - timeOut) < maxDeltaTime) return true;
-  else return false;
+  if (timeIn == -99 || timeOut == -99)
+    return true;
+  if (std::abs(timeIn - timeOut) < maxDeltaTime)
+    return true;
+  else
+    return false;
 }
 
 void HGCGraph::findNtuplets(std::vector<HGCDoublet::HGCntuplet> &foundNtuplets,

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -103,12 +103,7 @@ bool HGCGraph::areTimeCompatible(int innerIdx,
   float timeIn = layerClustersTime.get(innerIdx);
   float timeOut = layerClustersTime.get(outerIdx);
 
-  if (timeIn == -99 || timeOut == -99)
-    return true;
-  if (std::abs(timeIn - timeOut) < maxDeltaTime)
-    return true;
-  else
-    return false;
+  return (timeIn == -99 || timeOut == -99 || std::abs(timeIn - timeOut) < maxDeltaTime);
 }
 
 void HGCGraph::findNtuplets(std::vector<HGCDoublet::HGCntuplet> &foundNtuplets,

--- a/RecoHGCal/TICL/plugins/HGCGraph.h
+++ b/RecoHGCal/TICL/plugins/HGCGraph.h
@@ -16,12 +16,17 @@ public:
                               int nPhiBins,
                               const std::vector<reco::CaloCluster> &layerClusters,
                               const std::vector<float> &mask,
+			      const edm::ValueMap<float> &layerClustersTime,
                               int deltaIEta,
                               int deltaIPhi,
                               float minCosThetai,
                               float maxCosPointing,
                               int missing_layers,
-                              int maxNumberOfLayers);
+			      int maxNumberOfLayers,
+			      float maxDeltaTime);
+
+  bool areTimeCompatible(int innerIdx, int outerIdx,
+			 const edm::ValueMap<float> &layerClustersTime, float maxDeltaTime);
 
   std::vector<HGCDoublet> &getAllDoublets() { return allDoublets_; }
   void findNtuplets(std::vector<HGCDoublet::HGCntuplet> &foundNtuplets, const unsigned int minClustersPerNtuplet);

--- a/RecoHGCal/TICL/plugins/HGCGraph.h
+++ b/RecoHGCal/TICL/plugins/HGCGraph.h
@@ -16,17 +16,16 @@ public:
                               int nPhiBins,
                               const std::vector<reco::CaloCluster> &layerClusters,
                               const std::vector<float> &mask,
-			      const edm::ValueMap<float> &layerClustersTime,
+                              const edm::ValueMap<float> &layerClustersTime,
                               int deltaIEta,
                               int deltaIPhi,
                               float minCosThetai,
                               float maxCosPointing,
                               int missing_layers,
-			      int maxNumberOfLayers,
-			      float maxDeltaTime);
+                              int maxNumberOfLayers,
+                              float maxDeltaTime);
 
-  bool areTimeCompatible(int innerIdx, int outerIdx,
-			 const edm::ValueMap<float> &layerClustersTime, float maxDeltaTime);
+  bool areTimeCompatible(int innerIdx, int outerIdx, const edm::ValueMap<float> &layerClustersTime, float maxDeltaTime);
 
   std::vector<HGCDoublet> &getAllDoublets() { return allDoublets_; }
   void findNtuplets(std::vector<HGCDoublet::HGCntuplet> &foundNtuplets, const unsigned int minClustersPerNtuplet);

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -16,6 +16,7 @@ PatternRecognitionbyCA::PatternRecognitionbyCA(const edm::ParameterSet &conf) : 
   min_cos_pointing_ = conf.getParameter<double>("min_cos_pointing");
   missing_layers_ = conf.getParameter<int>("missing_layers");
   min_clusters_per_ntuplet_ = conf.getParameter<int>("min_clusters_per_ntuplet");
+  max_delta_time_ = conf.getParameter<double>("max_delta_time");
 }
 
 PatternRecognitionbyCA::~PatternRecognitionbyCA(){};
@@ -24,6 +25,7 @@ void PatternRecognitionbyCA::makeTracksters(const edm::Event &ev,
                                             const edm::EventSetup &es,
                                             const std::vector<reco::CaloCluster> &layerClusters,
                                             const std::vector<float> &mask,
+					    const edm::ValueMap<float> &layerClustersTime,
                                             const TICLLayerTiles &tiles,
                                             std::vector<Trackster> &result) {
   rhtools_.getEventSetup(es);
@@ -40,12 +42,14 @@ void PatternRecognitionbyCA::makeTracksters(const edm::Event &ev,
                                     ticl::constants::nPhiBins,
                                     layerClusters,
                                     mask,
+				    layerClustersTime,
                                     2,
                                     2,
                                     min_cos_theta_,
                                     min_cos_pointing_,
                                     missing_layers_,
-                                    rhtools_.lastLayerFH());
+				    rhtools_.lastLayerFH(),
+				    max_delta_time_);
   theGraph_->findNtuplets(foundNtuplets, min_clusters_per_ntuplet_);
   //#ifdef FP_DEBUG
   const auto &doublets = theGraph_->getAllDoublets();

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -25,7 +25,7 @@ void PatternRecognitionbyCA::makeTracksters(const edm::Event &ev,
                                             const edm::EventSetup &es,
                                             const std::vector<reco::CaloCluster> &layerClusters,
                                             const std::vector<float> &mask,
-					    const edm::ValueMap<float> &layerClustersTime,
+                                            const edm::ValueMap<float> &layerClustersTime,
                                             const TICLLayerTiles &tiles,
                                             std::vector<Trackster> &result) {
   rhtools_.getEventSetup(es);
@@ -42,14 +42,14 @@ void PatternRecognitionbyCA::makeTracksters(const edm::Event &ev,
                                     ticl::constants::nPhiBins,
                                     layerClusters,
                                     mask,
-				    layerClustersTime,
+                                    layerClustersTime,
                                     2,
                                     2,
                                     min_cos_theta_,
                                     min_cos_pointing_,
                                     missing_layers_,
-				    rhtools_.lastLayerFH(),
-				    max_delta_time_);
+                                    rhtools_.lastLayerFH(),
+                                    max_delta_time_);
   theGraph_->findNtuplets(foundNtuplets, min_clusters_per_ntuplet_);
   //#ifdef FP_DEBUG
   const auto &doublets = theGraph_->getAllDoublets();

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -19,6 +19,7 @@ namespace ticl {
                         const edm::EventSetup& es,
                         const std::vector<reco::CaloCluster>& layerClusters,
                         const std::vector<float>& mask,
+			const edm::ValueMap<float> &layerClustersTime,
                         const TICLLayerTiles& tiles,
                         std::vector<Trackster>& result) override;
 
@@ -29,6 +30,7 @@ namespace ticl {
     float min_cos_pointing_;
     int missing_layers_;
     int min_clusters_per_ntuplet_;
+    float max_delta_time_;
   };
 }  // namespace ticl
 #endif

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -19,7 +19,7 @@ namespace ticl {
                         const edm::EventSetup& es,
                         const std::vector<reco::CaloCluster>& layerClusters,
                         const std::vector<float>& mask,
-			const edm::ValueMap<float> &layerClustersTime,
+                        const edm::ValueMap<float>& layerClustersTime,
                         const TICLLayerTiles& tiles,
                         std::vector<Trackster>& result) override;
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.cc
@@ -5,6 +5,7 @@ void ticl::PatternRecognitionbyMultiClusters::makeTracksters(const edm::Event& e
                                                              const edm::EventSetup& es,
                                                              const std::vector<reco::CaloCluster>& layerClusters,
                                                              const std::vector<float>& mask,
+							     const edm::ValueMap<float> &layerClustersTime,
                                                              const TICLLayerTiles& tiles,
                                                              std::vector<Trackster>& result) {
   LogDebug("HGCPatterRecoTrackster") << "making Tracksters" << std::endl;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.cc
@@ -5,7 +5,7 @@ void ticl::PatternRecognitionbyMultiClusters::makeTracksters(const edm::Event& e
                                                              const edm::EventSetup& es,
                                                              const std::vector<reco::CaloCluster>& layerClusters,
                                                              const std::vector<float>& mask,
-							     const edm::ValueMap<float> &layerClustersTime,
+                                                             const edm::ValueMap<float>& layerClustersTime,
                                                              const TICLLayerTiles& tiles,
                                                              std::vector<Trackster>& result) {
   LogDebug("HGCPatterRecoTrackster") << "making Tracksters" << std::endl;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
@@ -23,6 +23,7 @@ namespace ticl {
                         const edm::EventSetup& es,
                         const std::vector<reco::CaloCluster>& layerClusters,
                         const std::vector<float>& mask,
+			const edm::ValueMap<float> &layerClustersTime,
                         const TICLLayerTiles& tiles,
                         std::vector<Trackster>& result) override;
   };

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
@@ -23,7 +23,7 @@ namespace ticl {
                         const edm::EventSetup& es,
                         const std::vector<reco::CaloCluster>& layerClusters,
                         const std::vector<float>& mask,
-			const edm::ValueMap<float> &layerClustersTime,
+                        const edm::ValueMap<float>& layerClustersTime,
                         const TICLLayerTiles& tiles,
                         std::vector<Trackster>& result) override;
   };

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -36,6 +36,7 @@ private:
   edm::EDGetTokenT<std::vector<reco::CaloCluster>> clusters_token_;
   edm::EDGetTokenT<std::vector<float>> filtered_layerclusters_mask_token_;
   edm::EDGetTokenT<std::vector<float>> original_layerclusters_mask_token_;
+  edm::EDGetTokenT<edm::ValueMap<float>> clustersTime_token_;
   edm::EDGetTokenT<TICLLayerTiles> layer_clusters_tiles_token_;
 
   std::unique_ptr<PatternRecognitionAlgoBase> myAlgo_;
@@ -47,6 +48,7 @@ TrackstersProducer::TrackstersProducer(const edm::ParameterSet& ps)
   clusters_token_ = consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layer_clusters"));
   filtered_layerclusters_mask_token_ = consumes<std::vector<float>>(ps.getParameter<edm::InputTag>("filtered_mask"));
   original_layerclusters_mask_token_ = consumes<std::vector<float>>(ps.getParameter<edm::InputTag>("original_mask"));
+  clustersTime_token_ = consumes<edm::ValueMap<float>>(ps.getParameter<edm::InputTag>("time_layerclusters"));
   layer_clusters_tiles_token_ = consumes<TICLLayerTiles>(ps.getParameter<edm::InputTag>("layer_clusters_tiles"));
   produces<std::vector<Trackster>>();
   produces<std::vector<float>>();  // Mask to be applied at the next iteration
@@ -58,12 +60,14 @@ void TrackstersProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.add<edm::InputTag>("layer_clusters", edm::InputTag("hgcalLayerClusters"));
   desc.add<edm::InputTag>("filtered_mask", edm::InputTag("FilteredLayerClusters", "iterationLabelGoesHere"));
   desc.add<edm::InputTag>("original_mask", edm::InputTag("hgcalLayerClusters", "InitialLayerClustersMask"));
+  desc.add<edm::InputTag>("time_layerclusters", edm::InputTag("hgcalLayerClusters","timeLayerCluster"));
   desc.add<edm::InputTag>("layer_clusters_tiles", edm::InputTag("TICLLayerTileProducer"));
   desc.add<int>("algo_verbosity", 0);
   desc.add<double>("min_cos_theta", 0.915);
   desc.add<double>("min_cos_pointing", -1.);
   desc.add<int>("missing_layers", 0);
   desc.add<int>("min_clusters_per_ntuplet", 10);
+  desc.add<double>("max_delta_time", 0.09);
   descriptions.add("trackstersProducer", desc);
 }
 
@@ -74,17 +78,20 @@ void TrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<std::vector<reco::CaloCluster>> cluster_h;
   edm::Handle<std::vector<float>> filtered_layerclusters_mask_h;
   edm::Handle<std::vector<float>> original_layerclusters_mask_h;
+  edm::Handle<edm::ValueMap<float>> time_clusters_h;
   edm::Handle<TICLLayerTiles> layer_clusters_tiles_h;
 
   evt.getByToken(clusters_token_, cluster_h);
   evt.getByToken(filtered_layerclusters_mask_token_, filtered_layerclusters_mask_h);
   evt.getByToken(original_layerclusters_mask_token_, original_layerclusters_mask_h);
+  evt.getByToken(clustersTime_token_, time_clusters_h);
   evt.getByToken(layer_clusters_tiles_token_, layer_clusters_tiles_h);
 
   const auto& layerClusters = *cluster_h;
   const auto& inputClusterMask = *filtered_layerclusters_mask_h;
+  const auto& layerClustersTimes = *time_clusters_h;
   const auto& layer_clusters_tiles = *layer_clusters_tiles_h;
-  myAlgo_->makeTracksters(evt, es, layerClusters, inputClusterMask, layer_clusters_tiles, *result);
+  myAlgo_->makeTracksters(evt, es, layerClusters, inputClusterMask, layerClustersTimes, layer_clusters_tiles, *result);
 
   // Now update the global mask and put it into the event
   output_mask->reserve(original_layerclusters_mask_h->size());

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -60,7 +60,7 @@ void TrackstersProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.add<edm::InputTag>("layer_clusters", edm::InputTag("hgcalLayerClusters"));
   desc.add<edm::InputTag>("filtered_mask", edm::InputTag("FilteredLayerClusters", "iterationLabelGoesHere"));
   desc.add<edm::InputTag>("original_mask", edm::InputTag("hgcalLayerClusters", "InitialLayerClustersMask"));
-  desc.add<edm::InputTag>("time_layerclusters", edm::InputTag("hgcalLayerClusters","timeLayerCluster"));
+  desc.add<edm::InputTag>("time_layerclusters", edm::InputTag("hgcalLayerClusters", "timeLayerCluster"));
   desc.add<edm::InputTag>("layer_clusters_tiles", edm::InputTag("TICLLayerTileProducer"));
   desc.add<int>("algo_verbosity", 0);
   desc.add<double>("min_cos_theta", 0.915);


### PR DESCRIPTION
Add time compatibility between layer clusters when building doublets 
- only apply if both inner and outer considered layer clusters have time information
- parameter for dT cut is configurable 

@rovere @felicepantaleo @Shameena01 