### PR TITLE
Avoid dereferencing nullptr in propagate_const

### DIFF
--- a/FWCore/Utilities/interface/propagate_const.h
+++ b/FWCore/Utilities/interface/propagate_const.h
@@ -61,14 +61,26 @@ namespace edm {
     }
 
     // ---------- const member functions ---------------------
-    element_type const* get() const { return &(*m_value); }
+    element_type const* get() const {
+      if constexpr (std::is_pointer<T>::value) {
+        return m_value;
+      } else {
+        return m_value.get();
+      }
+    }
     element_type const* operator->() const { return this->get(); }
     element_type const& operator*() const { return *m_value; }
 
     operator element_type const*() const { return this->get(); }
 
     // ---------- member functions ---------------------------
-    element_type* get() { return &(*m_value); }
+    element_type* get() {
+      if constexpr (std::is_pointer<T>::value) {
+        return m_value;
+      } else {
+        return m_value.get();
+      }
+    }
     element_type* operator->() { return this->get(); }
     element_type& operator*() { return *m_value; }
 


### PR DESCRIPTION

#### PR description:

UBSAN found that when the smart pointer held by propagate_const was null, we were dereferencing that nullptr during the call to get.

#### PR validation:

Compiles and running simple cmsRun job under CMSSW_11_0_UBSAN_X_2019-06-25-2300 no longer reports the UBSAN error.