### PR TITLE
Fix RegressionTest unit test after integration of PR 27299

### DIFF
--- a/DetectorDescription/RegressionTest/test/run_DOMCount.sh
+++ b/DetectorDescription/RegressionTest/test/run_DOMCount.sh
@@ -12,7 +12,6 @@ echo "Normal output of DOMCount is written to file tmp/${SCRAM_ARCH}/run_DOMCoun
 cfiFiles=Geometry/CMSCommonData/cmsIdealGeometryXML_cfi
 cfiFiles="${cfiFiles} Geometry/CMSCommonData/cmsIdealGeometry2015XML_cfi"
 cfiFiles="${cfiFiles} Geometry/CMSCommonData/cmsIdealGeometry2015devXML_cfi"
-cfiFiles="${cfiFiles} Geometry/CMSCommonData/cmsIdealGeometryAPD1XML_cfi"
 cfiFiles="${cfiFiles} Geometry/CMSCommonData/cmsIdealGeometryGFlashXML_cfi"
 cfiFiles="${cfiFiles} Geometry/CMSCommonData/cmsIdealGeometryHFLibraryXML_cfi"
 cfiFiles="${cfiFiles} Geometry/CMSCommonData/cmsIdealGeometryHFParametrizeXML_cfi"


### PR DESCRIPTION
#### PR description:

In #27299 the configuration 
```
 Geometry/CMSCommonData/python/cmsIdealGeometryAPD1XML_cfi.py
```
has been removed as no more needed. But a unit test in DetectorDescription/RegressionTest was still using it, and it fails in CMSSW_11_0_X_2019-06-27-1100. This PR removes that configuration from the test.

#### PR validation:

```DetectorDescription/RegressionTest/test/run_DOMCount.sh``` runs successfully. 