### PR TITLE
Closeby Workflows with TICL Variations in runTheMatrix

### DIFF
--- a/Configuration/Generator/python/CloseByParticle_Photon_ERZRanges_cfi.py
+++ b/Configuration/Generator/python/CloseByParticle_Photon_ERZRanges_cfi.py
@@ -1,26 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
 generator = cms.EDProducer("CloseByParticleGunProducer",
-    PGunParameters = cms.PSet(PartID = cms.vint32(22, 11, 13, 111),
+    PGunParameters = cms.PSet(PartID = cms.vint32(22),
         EnMin = cms.double(25.),
         EnMax = cms.double(200.),
         RMin = cms.double(60),
         RMax = cms.double(120),
         ZMin = cms.double(320),
-        ZMax = cms.double(650),
-        Delta = cms.double(2.5),
+        ZMax = cms.double(321),
+        Delta = cms.double(10),
         Pointing = cms.bool(True),
         Overlapping = cms.bool(False),
         RandomShoot = cms.bool(False),
-        NParticles = cms.int32(5),
+        NParticles = cms.int32(2),
         MaxEta = cms.double(2.7),
         MinEta = cms.double(1.7),
-        MaxPhi = cms.double(3.14159265359/6.),
-        MinPhi = cms.double(-3.14159265359/6.),
-                          
+        MaxPhi = cms.double(3.14159265359),
+        MinPhi = cms.double(-3.14159265359),
+
     ),
-    Verbosity = cms.untracked.int32(10),
-    
+    Verbosity = cms.untracked.int32(0),
+
     psethack = cms.string('random particles in phi and r windows'),
     AddAntiParticle = cms.bool(False),
     firstRun = cms.untracked.uint32(1)

--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -23,7 +23,7 @@ numWFIB.extend([24034.0]) #2023D28
 numWFIB.extend([27434.0,27434.21,27634.21]) #2023D35, prodlike, prodlike PU
 numWFIB.extend([27834.0]) #2023D38
 numWFIB.extend([28634.0]) #2023D40
-numWFIB.extend([29034.0]) #2023D41
+numWFIB.extend([29034.0,29093.52]) #2023D41,2023D41+TICL
 numWFIB.extend([29434.0]) #2023D42
 numWFIB.extend([29834.0]) #2023D43
 for numWF in numWFIB:

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2089,6 +2089,12 @@ step3_HIPM = {
     '--era': 'Run2_2016_HIPM'
 }
 step3Up2015Defaults_trackingOnly = merge([step3_trackingOnly, remove(step3Up2015Defaults, "--runUnscheduled")])
+step3_TICLOnly = {
+    '--customise' : 'RecoHGCal/TICL/ticl_iterations.TICL_iterations'
+}
+step3_TICLFullReco = {
+    '--customise' : 'RecoHGCal/TICL/ticl_iterations.TICL_iterations_withReco'
+}
 
 # mask away - to be removed once we'll migrate the matrix to be fully unscheduled for RECO step
 #unSchOverrides={'--runUnscheduled':'','-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@miniAODDQM','--eventcontent':'RECOSIM,MINIAODSIM,DQM','--datatier':'GEN-SIM-RECO,MINIAODSIM,DQMIO'}
@@ -3265,6 +3271,14 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
         stepName = step + upgradeSteps['ParkingBPH']['suffix']
         if 'Reco' in step and 'Run2_2018' in upgradeStepDict[step][k]['--era']:
             upgradeStepDict[stepName][k] = merge([{'--era': 'Run2_2018,bParking'}, upgradeStepDict[step][k]])
+
+    for step in upgradeSteps['TICLOnly']['steps']:
+        stepName = step + upgradeSteps['TICLOnly']['suffix']
+        if 'Reco' in step: upgradeStepDict[stepName][k] = merge([step3_TICLOnly, upgradeStepDict[step][k]])
+
+    for step in upgradeSteps['TICLFullReco']['steps']:
+        stepName = step + upgradeSteps['TICLFullReco']['suffix']
+        if 'Reco' in step: upgradeStepDict[stepName][k] = merge([step3_TICLFullReco, upgradeStepDict[step][k]])
 
     # setup PU
     if k2 in PUDataSets:

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -89,6 +89,16 @@ for year in upgradeKeys:
                 elif '2018' in key:
                     workflows[numWF+upgradeSteps['pixelTrackingOnly']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['pixelTrackingOnly']]
 
+            # special workflows for HGCAL/TICL
+            if (upgradeDatasetFromFragment[frag]=="CloseByParticleGun"):
+                TICLVariations = ['TICLOnly', 'TICLFullReco']
+                # Skip Hharvesting for TICLOnly
+                for tv in TICLVariations:
+                    if 'TICLOnly' in tv:
+                        stepList[tv] = [s for s in stepList[tv] if ("HARVEST" not in s)]
+                for tv in TICLVariations:
+                    workflows[numWF+upgradeSteps[tv]['offset']] = [ upgradeDatasetFromFragment[frag], stepList[tv]]
+
             # special workflows for HE
             if upgradeDatasetFromFragment[frag]=="TTbar_13" and '2018' in key:
                 workflows[numWF+upgradeSteps['heCollapse']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['heCollapse']]

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -90,7 +90,7 @@ for year in upgradeKeys:
                     workflows[numWF+upgradeSteps['pixelTrackingOnly']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['pixelTrackingOnly']]
 
             # special workflows for HGCAL/TICL
-            if (upgradeDatasetFromFragment[frag]=="CloseByParticleGun"):
+            if (upgradeDatasetFromFragment[frag]=="CloseByParticleGun") and ('2023' in key):
                 TICLVariations = ['TICLOnly', 'TICLFullReco']
                 # Skip Hharvesting for TICLOnly
                 for tv in TICLVariations:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -239,6 +239,24 @@ upgradeSteps['Premix'] = {
     'suffix': '_Premix',
     'offset': 0.97,
 }
+upgradeSteps['TICLOnly'] = {
+    'steps' : [
+        'RecoFull',
+        'RecoFullGlobal',
+    ],
+    'PU' : [],
+    'suffix' : '_TICLOnly',
+    'offset' : 0.51,
+}
+upgradeSteps['TICLFullReco'] = {
+    'steps' : [
+        'RecoFull',
+        'RecoFullGlobal',
+    ],
+    'PU' : [],
+    'suffix' : '_TICLFullReco',
+    'offset' : 0.52,
+}
 # Premix stage2 is derived from baseline+PU in relval_upgrade.py
 premixS2_offset = 0.98
 # Premix combined stage1+stage2 is derived for Premix+PU and baseline+PU in relval_upgrade.py
@@ -576,6 +594,7 @@ upgradeFragments=['FourMuPt_1_200_pythia8_cfi',
                   'SingleGammaPt25Eta1p7_2p7_cfi',
                   'SingleElectronPt15Eta1p7_2p7_cfi',
                   'ZTT_All_hadronic_14TeV_TuneCUETP8M1_cfi',
+                  'CloseByParticle_Photon_ERZRanges_cfi',
 ]
 
 howMuches={'FourMuPt_1_200_pythia8_cfi':Kby(10,100),
@@ -671,6 +690,7 @@ howMuches={'FourMuPt_1_200_pythia8_cfi':Kby(10,100),
            'SingleGammaPt25Eta1p7_2p7_cfi':Kby(9,100),
            'SingleElectronPt15Eta1p7_2p7_cfi':Kby(9,100),
            'ZTT_All_hadronic_14TeV_TuneCUETP8M1_cfi':Kby(9,50),
+           'CloseByParticle_Photon_ERZRanges_cfi':Kby(9,100),
 }
 
 upgradeDatasetFromFragment={'FourMuPt_1_200_pythia8_cfi': 'FourMuPt1_200',
@@ -766,4 +786,5 @@ upgradeDatasetFromFragment={'FourMuPt_1_200_pythia8_cfi': 'FourMuPt1_200',
                             'SingleGammaPt25Eta1p7_2p7_cfi':'SingleGammaPt25Eta1p7_2p7',
                             'SingleElectronPt15Eta1p7_2p7_cfi':'SingleElectronPt15Eta1p7_2p7',
                             'ZTT_All_hadronic_14TeV_TuneCUETP8M1_cfi': 'ZTT_14',
+                            'CloseByParticle_Photon_ERZRanges_cfi': 'CloseByParticleGun',
 }


### PR DESCRIPTION
#### PR description:

This PR does the following:

   * Fix the Closeby snippet to match the name with the actual particles generated
   * Add Closeby Workflow to the upgrade session of runTheMatrix
   * Add 2 variations to this workflow that will add TICL to the full Reco (.52) or run TICL reconstruction alone (.51)

This PR, in order to be fully tested, needs #27382.

Since runTheMatrix is a little outside of my area of expertise, please provide alternative solutions if you are not satisfied with this PR.

Finally, given the deadline of the 6th Patatrack hackathon next week, it would be nice to have an IB with this and #27382 integrated.

#### PR validation:

```
runTheMatrix.py -l limited -i all --ibeos
```

and

```
runTheMatrix.py -w upgrade -l 29093.51,29093.52
```
