### PR TITLE
Backport bug fix in the alternative Geant4 physics list for exotic particles 

### DIFF
--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h
@@ -6,7 +6,6 @@
 #include <string>
 
 class G4ProcessHelper;
-class G4Decay;
 class CustomParticleFactory;
 
 class CustomPhysicsListSS : public G4VPhysicsConstructor {
@@ -18,7 +17,6 @@ public:
   void ConstructProcess() override;
 
 private:
-  static G4ThreadLocal std::unique_ptr<G4Decay> fDecayProcess;
   static G4ThreadLocal std::unique_ptr<G4ProcessHelper> myHelper;
 
   std::unique_ptr<CustomParticleFactory> fParticleFactory;


### PR DESCRIPTION
#### PR description:
Some Geant4 users recently reported this problem. A check inside CMSSW allowing to identify, that we have similar problem in alternative exotic physics constructor CustomPhysicsListSS, which never used in production. The fix should be back-ported to legacy.

#### PR validation:
Private

#### if this PR is a backport please specify the original PR: #27204

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
