### PR TITLE
Make cms.optional etal work with python 3

### DIFF
--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from builtins import range
+from builtins import range, object
 import inspect
 import six
 

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -60,7 +60,7 @@ class _ProxyParameter(_ParameterTypeBase):
             return setattr(v,name,value)
         else:
             return object.__setattr__(self, name, value)
-    def __nonzero__(self):
+    def __bool__(self):
         v = self.__dict__.get('_ProxyParameter__value',None)
         return _builtin_bool(v)
     def dumpPython(self, options=PrintOptions()):


### PR DESCRIPTION
#### PR description:

python 3 uses __bool__ as a builtin member function rather than __nonzero__. Use builtin compatibility module to deal with the difference.

#### PR validation:

- confirmed the problem in _DEVEL using workflow 1, step 3 configuration
- tested change in CMSSW_11_0_DEVEL_X_2019-06-27-2300 by rerunning the failing config
- tested change in CMSSW_11_0_X_2019-06-27-2300 by rerunning the failing config