### PR TITLE
Added missing links to Alignment/CommonAlignmentMonitor plugins

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/BuildFile.xml
+++ b/Alignment/CommonAlignmentMonitor/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 
 <library   name="AlignmentMonitorTemplate" file="AlignmentMonitorTemplate.cc">
   <use   name="Alignment/CommonAlignmentMonitor"/>
+  <use   name="Alignment/CommonAlignmentAlgorithm"/>
   <use   name="TrackingTools/TrackFitters"/>
   <use   name="rootcore"/>
   <use   name="roothistmatrix"/>
@@ -13,6 +14,9 @@
 <library   name="AlignmentMonitorGeneric" file="AlignmentMonitorGeneric.cc">
   <use   name="Alignment/CommonAlignment"/>
   <use   name="Alignment/CommonAlignmentMonitor"/>
+  <use   name="Alignment/TrackerAlignment"/>
+  <use   name="Alignment/MuonAlignment"/>
+  <use   name="Alignment/CommonAlignmentAlgorithm"/>
   <use   name="TrackingTools/TrackFitters"/>
   <use   name="DataFormats/GeometrySurface"/>
   <use   name="rootcore"/>
@@ -57,6 +61,9 @@
 </library>
 
 <library   name="AlignmentMonitorSurvey" file="AlignmentMonitorSurvey.cc">
+  <use   name="Alignment/TrackerAlignment"/>
+  <use   name="Alignment/MuonAlignment"/>
+  <use   name="Alignment/CommonAlignmentAlgorithm"/>
   <use   name="Alignment/CommonAlignment"/>
   <use   name="Alignment/CommonAlignmentMonitor"/>
   <flags   EDM_PLUGIN="1"/>


### PR DESCRIPTION
#### PR description:

The links are necessary to allow UBSAN to work.

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-28-2300 IB.