### PR TITLE
Added missing link to Aligment/CommonAlignmentProducer

### DIFF
--- a/Alignment/CommonAlignmentProducer/BuildFile.xml
+++ b/Alignment/CommonAlignmentProducer/BuildFile.xml
@@ -20,6 +20,7 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/RecoCandidate"/>
 <use   name="DataFormats/Math"/>
+<use   name="DataFormats/MuonReco"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/Utilities"/>


### PR DESCRIPTION
#### PR description:

Need to link with DataFormats/MuonReco for UBSAN to work.

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-28-2300 IB.