### PR TITLE
Fixed missing link in DQM/SiPixelPhase1Common

### DIFF
--- a/DQM/SiPixelPhase1Common/BuildFile.xml
+++ b/DQM/SiPixelPhase1Common/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/SiPixelDetId"/>
+<use   name="DataFormats/TrackerRecHit2D"/>
 <use   name="DQMServices/Core"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="CalibTracker/Records"/>


### PR DESCRIPTION
#### PR description:

Need to link with DataFormats/TrackerRecHit2D so UBSAN works.

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-28-2300 IB.