### PR TITLE
Fixed missing link in Geometry/DTGeometryBuilder

### DIFF
--- a/Geometry/DTGeometryBuilder/plugins/BuildFile.xml
+++ b/Geometry/DTGeometryBuilder/plugins/BuildFile.xml
@@ -16,6 +16,7 @@
 <library name="DTGeometryValidationPlugins" file="DTGeometryValidate.cc">
   <use name="Fireworks/Core"/>
   <use name="Geometry/DTGeometry"/>
+  <use name="rootgeom"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 


### PR DESCRIPTION
#### PR description:

Need to link with ROOT's libGeom so UBSAN will work.

#### PR validation:

Compiles and links using the CMSSW_11_0_UBSAN_X_2019-06-28-2300 IB.