### PR TITLE
Initialize local variable in PTraj_t test

### DIFF
--- a/DataFormats/TrajectoryState/test/PTraj_t.cpp
+++ b/DataFormats/TrajectoryState/test/PTraj_t.cpp
@@ -12,7 +12,7 @@ namespace {
 
 namespace {
   void verify(DetId id, sn::Side ss) {
-    LocalTrajectoryParameters tp;
+    LocalTrajectoryParameters tp(0., 0., 0., 0., 0., 0.);
     PTrajectoryStateOnDet p(tp, 0., id, ss);
     assert(p.detId() == id);
     assert(p.surfaceSide() == ss);


### PR DESCRIPTION
#### PR description:

UBSAN gave a compiler warning that an uninitialized value was being used.

#### PR validation:

With the change the compiler warning goes away under the UBSAN IB.