### PR TITLE
Fix uninitialized variable warnings in CSCDQM_Detector

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Detector.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Detector.cc
@@ -151,6 +151,7 @@ namespace cscdqm {
     Address adr, iadr;
     adr.mask.side = adr.mask.station = adr.mask.ring = adr.mask.chamber = true;
     adr.mask.layer = adr.mask.cfeb = adr.mask.hv = false;
+    adr.layer = adr.cfeb = adr.hv = 0;
     adr.side = side;
     adr.station = station;
     adr.ring = ring;

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Detector.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Detector.h
@@ -108,24 +108,6 @@ namespace cscdqm {
       return true;
     };
 
-    const Address* operator=(const Address& a) {
-      mask.side = a.mask.side;
-      side = a.side;
-      mask.station = a.mask.station;
-      station = a.station;
-      mask.ring = a.mask.ring;
-      ring = a.ring;
-      mask.chamber = a.mask.chamber;
-      chamber = a.chamber;
-      mask.layer = a.mask.layer;
-      layer = a.layer;
-      mask.cfeb = a.mask.cfeb;
-      cfeb = a.cfeb;
-      mask.hv = a.mask.hv;
-      hv = a.hv;
-      return this;
-    };
-
     friend std::ostream& operator<<(std::ostream& out, const Address& adr) {
       out << adr.name();
       return out;


### PR DESCRIPTION

#### PR description:

When compiling with UBSAN the code was getting compiler warnings.
Using the default operator= and initializing all variables solved the problem.

#### PR validation:

When compiled under the CMSSW_11_0_UBSAN_X_2019-06-28-2300 IB, the warnings are now gone.