### PR TITLE
Remove localDensity from the EventContent for HGCAL

### DIFF
--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
@@ -73,16 +73,17 @@ phase2_hgcal.toModify( RecoLocalCaloFEVT, outputCommands = RecoLocalCaloFEVT.out
         'keep *_hgcalLayerClusters_*_*',
         'keep *_hgcalMultiClusters_*_*',
         'keep *_iterHGCalMultiClusters_*_*',
-
+        'drop DetIdfloatstdmap_hgcalLayerClusters_*_*',
     ]
 )
 phase2_hgcal.toModify( RecoLocalCaloRECO,
     outputCommands = RecoLocalCaloRECO.outputCommands + ['keep *_HGCalRecHit_*_*',
                                                          'keep *_hgcalLayerClusters_*_*',
+                                                         'drop DetIdfloatstdmap_hgcalLayerClusters_*_*',
                                                          'keep *_hgcalMultiClusters_*_*',
                                                          'keep *_iterHGCalMultiClusters_*_*'] )
 # don't modify AOD for HGCal yet, need "reduced" rechits collection first (i.e. requires reconstruction)
-phase2_hgcal.toModify( RecoLocalCaloAOD, outputCommands = RecoLocalCaloAOD.outputCommands + ['keep *_HGCalRecHit_*_*','keep *_hgcalLayerClusters_*_*'] )
+phase2_hgcal.toModify( RecoLocalCaloAOD, outputCommands = RecoLocalCaloAOD.outputCommands + ['keep *_HGCalRecHit_*_*','keep *_hgcalLayerClusters_*_*','drop DetIdfloatstdmap_hgcalLayerClusters_*_*'])
 
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
@@ -83,7 +83,10 @@ phase2_hgcal.toModify( RecoLocalCaloRECO,
                                                          'keep *_hgcalMultiClusters_*_*',
                                                          'keep *_iterHGCalMultiClusters_*_*'] )
 # don't modify AOD for HGCal yet, need "reduced" rechits collection first (i.e. requires reconstruction)
-phase2_hgcal.toModify( RecoLocalCaloAOD, outputCommands = RecoLocalCaloAOD.outputCommands + ['keep *_HGCalRecHit_*_*','keep *_hgcalLayerClusters_*_*','drop DetIdfloatstdmap_hgcalLayerClusters_*_*'])
+phase2_hgcal.toModify( RecoLocalCaloAOD,
+    outputCommands = RecoLocalCaloAOD.outputCommands + ['keep *_HGCalRecHit_*_*',
+                                                        'keep *_hgcalLayerClusters_*_*',
+                                                        'drop DetIdfloatstdmap_hgcalLayerClusters_*_*'])
 
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018


### PR DESCRIPTION
#### PR description:

Drop the local density map used internally by the CLUE algorithm from the EventContent.

#### PR validation:

Tested with Phase2 workflows in runTheMatrix.
