### PR TITLE
[GCC9] fix warning about initializing base class in copy constructor

### DIFF
--- a/DataFormats/GeometrySurface/interface/Surface.h
+++ b/DataFormats/GeometrySurface/interface/Surface.h
@@ -56,7 +56,10 @@ protected:
       : Base(pos, rot), theMediumProperties(mp), theBounds(bounds) {}
 
   Surface(const Surface& iSurface)
-      :  ReferenceCountedInConditions(iSurface), Base(iSurface), theMediumProperties(iSurface.theMediumProperties), theBounds(iSurface.theBounds) {}
+      : ReferenceCountedInConditions(iSurface),
+        Base(iSurface),
+        theMediumProperties(iSurface.theMediumProperties),
+        theBounds(iSurface.theBounds) {}
 
   Surface(Surface&& iSurface)
       : Base(iSurface), theMediumProperties(iSurface.theMediumProperties), theBounds(std::move(iSurface.theBounds)) {}

--- a/DataFormats/GeometrySurface/interface/Surface.h
+++ b/DataFormats/GeometrySurface/interface/Surface.h
@@ -56,7 +56,7 @@ protected:
       : Base(pos, rot), theMediumProperties(mp), theBounds(bounds) {}
 
   Surface(const Surface& iSurface)
-      : Base(iSurface), theMediumProperties(iSurface.theMediumProperties), theBounds(iSurface.theBounds) {}
+      :  ReferenceCountedInConditions(iSurface), Base(iSurface), theMediumProperties(iSurface.theMediumProperties), theBounds(iSurface.theBounds) {}
 
   Surface(Surface&& iSurface)
       : Base(iSurface), theMediumProperties(iSurface.theMediumProperties), theBounds(std::move(iSurface.theBounds)) {}

--- a/DataFormats/GeometrySurface/interface/Surface.h
+++ b/DataFormats/GeometrySurface/interface/Surface.h
@@ -62,7 +62,10 @@ protected:
         theBounds(iSurface.theBounds) {}
 
   Surface(Surface&& iSurface)
-      : Base(iSurface), theMediumProperties(iSurface.theMediumProperties), theBounds(std::move(iSurface.theBounds)) {}
+      : ReferenceCountedInConditions(iSurface),
+        Base(iSurface),
+        theMediumProperties(iSurface.theMediumProperties),
+        theBounds(std::move(iSurface.theBounds)) {}
 
 public:
   /** Returns the side of the surface on which the point is.


### PR DESCRIPTION
#### PR description:

This should fix the following GCC 9 compilation warning
```
DataFormats/GeometrySurface/interface/Surface.h:58:3: warning: base class 'class BasicReferenceCounted' should be explicitly initialized in the copy constructor [-Wextra]
    58 |   Surface(const Surface& iSurface)
```
#### PR validation:

Local compilation in gcc 9 Ibs shows that warnings is gone