### PR TITLE
DataFormat for DT Phase-2 Trigger Primitives - backport

### DIFF
--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h
@@ -1,0 +1,57 @@
+//-------------------------------------------------
+//
+//   Class L1Phase2MuDTPhContainer
+//
+//   Description: trigger primtive data for the
+//                muon barrel Phase2 trigger
+//
+//
+//   Author List: Federica Primavera  Bologna INFN
+//
+//
+//--------------------------------------------------
+#ifndef L1Phase2MuDTPhContainer_H
+#define L1Phase2MuDTPhContainer_H
+
+//------------------------------------
+// Collaborating Class Declarations --
+//------------------------------------
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h"
+
+//----------------------
+// Base Class Headers --
+//----------------------
+#include <vector>
+
+//---------------
+// C++ Headers --
+//---------------
+
+//              ---------------------
+//              -- Class Interface --
+//              ---------------------
+
+
+class L1Phase2MuDTPhContainer {
+
+ public:
+
+  typedef std::vector<L1Phase2MuDTPhDigi>  Segment_Container;
+  typedef Segment_Container::const_iterator   Segment_iterator;
+
+  //  Constructor
+  L1Phase2MuDTPhContainer();
+
+  void setContainer(const Segment_Container& inputSegments);
+
+  Segment_Container const* getContainer() const;
+
+    
+ private:
+
+  Segment_Container m_segments; 
+
+};
+
+#endif
+

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h
@@ -1,0 +1,83 @@
+//-------------------------------------------------
+//
+//   Class L1Phase2MuDTPhDigi	
+//
+//   Description: trigger primtive data for the
+//                muon barrel Phase2 trigger
+//
+//
+//   Author List: Federica Primavera  Bologna INFN
+//
+//
+//--------------------------------------------------
+#ifndef L1Phase2MuDTPhDigi_H
+#define L1Phase2MuDTPhDigi_H
+
+//------------------------------------
+// Collaborating Class Declarations --
+//------------------------------------
+
+
+//----------------------
+// Base Class Headers --
+//----------------------
+
+
+//---------------
+// C++ Headers --
+//---------------
+
+
+//              ---------------------
+//              -- Class Interface --
+//              ---------------------
+
+class L1Phase2MuDTPhDigi 
+{
+
+ public:
+
+  //  Constructors
+  L1Phase2MuDTPhDigi();
+  
+  L1Phase2MuDTPhDigi( int bx, int wh, int sc, int st, int phi, int phib,
+		      int qual, int idx, int t0, int chi2, int rpc=-10);
+  
+  // Operations
+  int bxNum()       const;
+
+  int whNum()       const;
+  int scNum()       const;
+  int stNum()       const;
+
+  int phi()         const;
+  int phiBend()     const;
+
+  int quality()     const;
+  int index()       const;
+   
+  int t0()          const;
+  int chi2()        const;
+
+  int rpcFlag()      const;
+  
+
+ private:
+
+  int m_bx;
+  int m_wheel;
+  int m_sector;
+  int m_station;
+  int m_phiAngle;
+  int m_phiBending;
+
+  int m_qualityCode;
+  int m_index;
+  
+  int m_t0;
+  int m_chi2;
+  
+  int m_rpcFlag;
+};
+
+#endif

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h
@@ -40,7 +40,7 @@ class L1Phase2MuDTPhDigi
   //  Constructors
   L1Phase2MuDTPhDigi();
   
-  L1Phase2MuDTPhDigi( int bx, int wh, int sc, int st, int phi, int phib,
+  L1Phase2MuDTPhDigi( int bx, int wh, int sc, int st, int sl, int phi, int phib,
 		      int qual, int idx, int t0, int chi2, int rpc=-10);
   
   // Operations
@@ -49,6 +49,7 @@ class L1Phase2MuDTPhDigi
   int whNum()       const;
   int scNum()       const;
   int stNum()       const;
+  int slNum()       const;
 
   int phi()         const;
   int phiBend()     const;
@@ -68,6 +69,8 @@ class L1Phase2MuDTPhDigi
   int m_wheel;
   int m_sector;
   int m_station;
+  int m_superlayer;
+
   int m_phiAngle;
   int m_phiBending;
 

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTPhContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTPhContainer.cc
@@ -1,0 +1,48 @@
+//-------------------------------------------------
+//
+//   Class L1MuDTChambContainer
+//
+//   Description: trigger primtive data for the
+//                muon barrel Phase2 trigger
+//
+//
+//   Author List: Federica Primavera  Bologna INFN
+//
+//
+//--------------------------------------------------
+
+//-----------------------
+// This Class's Header --
+//-----------------------
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h"
+
+//-------------------------------
+// Collaborating Class Headers --
+//-------------------------------
+
+
+//---------------
+// C++ Headers --
+//---------------
+
+//-------------------
+// Initializations --
+//-------------------
+
+
+//----------------
+// Constructors --
+//----------------
+L1Phase2MuDTPhContainer::L1Phase2MuDTPhContainer() {}
+
+//--------------
+// Operations --
+//--------------
+void L1Phase2MuDTPhContainer::setContainer(const Segment_Container& inputSegments) {
+
+  m_segments = inputSegments;
+}
+
+L1Phase2MuDTPhContainer::Segment_Container const* L1Phase2MuDTPhContainer::getContainer() const {
+  return &m_segments;
+}

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTPhDigi.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTPhDigi.cc
@@ -1,0 +1,109 @@
+//-------------------------------------------------
+//
+//   Class L1MuDTChambPhDigi
+//
+//   Description: trigger primtive data for the
+//                muon barrel Phase2 trigger
+//
+//
+//   Author List: Federica Primavera  Bologna INFN
+//
+//
+//--------------------------------------------------
+
+//-----------------------
+// This Class's Header --
+//-----------------------
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h"
+
+//-------------------------------
+// Collaborating Class Headers --
+//-------------------------------
+
+
+//---------------
+// C++ Headers --
+//---------------
+
+//-------------------
+// Initializations --
+//-------------------
+
+
+//----------------
+// Constructors --
+//----------------
+L1Phase2MuDTPhDigi::L1Phase2MuDTPhDigi() :
+  m_bx(-100), m_wheel(0), m_sector(0), m_station(0), m_phiAngle(0), m_phiBending(0),
+  m_qualityCode(-1), m_index(0), m_t0(0), m_chi2(0), m_rpcFlag(-10)
+{
+
+}
+
+
+L1Phase2MuDTPhDigi::L1Phase2MuDTPhDigi( int bx, int wh, int sc, int st, int phi, int phib,
+					int qual, int idx, int t0, int chi2, int rpc) :
+  m_bx(bx), m_wheel(wh), m_sector(sc), m_station(st), m_phiAngle(phi), m_phiBending(phib),
+  m_qualityCode(qual), m_index(idx), m_t0(t0), m_chi2(chi2), m_rpcFlag(rpc)
+{
+ 
+}
+
+
+//--------------
+// Operations --
+//--------------
+int L1Phase2MuDTPhDigi::bxNum() const 
+{
+  return m_bx;
+}
+
+int L1Phase2MuDTPhDigi::whNum() const 
+{
+  return m_wheel;
+}
+
+int L1Phase2MuDTPhDigi::scNum() const 
+{
+  return m_sector;
+}
+
+int L1Phase2MuDTPhDigi::stNum() const 
+{
+  return m_station;
+}
+
+int L1Phase2MuDTPhDigi::phi() const 
+{
+  return m_phiAngle;
+}
+
+int L1Phase2MuDTPhDigi::phiBend() const 
+{
+  return m_phiBending;
+}
+
+int L1Phase2MuDTPhDigi::quality() const 
+{
+  return m_qualityCode;
+}
+
+int L1Phase2MuDTPhDigi::index() const
+{
+  return m_index;
+}
+
+int L1Phase2MuDTPhDigi::t0() const 
+{
+  return m_t0;
+}
+
+int L1Phase2MuDTPhDigi::chi2() const 
+{
+  return m_chi2;
+}
+
+int L1Phase2MuDTPhDigi::rpcFlag() const 
+{
+  return m_rpcFlag;
+}

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTPhDigi.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTPhDigi.cc
@@ -34,17 +34,17 @@
 // Constructors --
 //----------------
 L1Phase2MuDTPhDigi::L1Phase2MuDTPhDigi() :
-  m_bx(-100), m_wheel(0), m_sector(0), m_station(0), m_phiAngle(0), m_phiBending(0),
-  m_qualityCode(-1), m_index(0), m_t0(0), m_chi2(0), m_rpcFlag(-10)
+  m_bx(-100), m_wheel(0), m_sector(0), m_station(0), m_superlayer(0), m_phiAngle(0), 
+  m_phiBending(0), m_qualityCode(-1), m_index(0), m_t0(0), m_chi2(0), m_rpcFlag(-10)
 {
 
 }
 
 
-L1Phase2MuDTPhDigi::L1Phase2MuDTPhDigi( int bx, int wh, int sc, int st, int phi, int phib,
+L1Phase2MuDTPhDigi::L1Phase2MuDTPhDigi( int bx, int wh, int sc, int st, int sl, int phi, int phib,
 					int qual, int idx, int t0, int chi2, int rpc) :
-  m_bx(bx), m_wheel(wh), m_sector(sc), m_station(st), m_phiAngle(phi), m_phiBending(phib),
-  m_qualityCode(qual), m_index(idx), m_t0(t0), m_chi2(chi2), m_rpcFlag(rpc)
+  m_bx(bx), m_wheel(wh), m_sector(sc), m_station(st), m_superlayer(sl), m_phiAngle(phi), 
+  m_phiBending(phib), m_qualityCode(qual), m_index(idx), m_t0(t0), m_chi2(chi2), m_rpcFlag(rpc)
 {
  
 }
@@ -71,6 +71,11 @@ int L1Phase2MuDTPhDigi::scNum() const
 int L1Phase2MuDTPhDigi::stNum() const 
 {
   return m_station;
+}
+
+int L1Phase2MuDTPhDigi::slNum() const 
+{
+  return m_superlayer;
 }
 
 int L1Phase2MuDTPhDigi::phi() const 

--- a/DataFormats/L1DTTrackFinder/src/classes.h
+++ b/DataFormats/L1DTTrackFinder/src/classes.h
@@ -4,5 +4,7 @@
 #include <DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h>
 #include <DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h>
 #include <DataFormats/L1DTTrackFinder/interface/L1MuDTTrackContainer.h>
+#include <DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h>
+#include <DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h>
 #include <DataFormats/Common/interface/Wrapper.h>
 

--- a/DataFormats/L1DTTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1DTTrackFinder/src/classes_def.xml
@@ -14,7 +14,7 @@
  </class>
 
  <class name="L1Phase2MuDTPhDigi" ClassVersion="3">
-  <version ClassVersion="3" checksum="851692670"/>
+  <version ClassVersion="3" checksum="1236020577"/>
  </class>
 
  <class name="std::vector<L1MuDTChambPhDigi>"/>

--- a/DataFormats/L1DTTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1DTTrackFinder/src/classes_def.xml
@@ -13,9 +13,15 @@
   <version ClassVersion="10" checksum="3559343241"/>
  </class>
 
+ <class name="L1Phase2MuDTPhDigi" ClassVersion="3">
+  <version ClassVersion="3" checksum="851692670"/>
+ </class>
+
  <class name="std::vector<L1MuDTChambPhDigi>"/>
  <class name="std::vector<L1MuDTChambThDigi>"/>
  <class name="std::vector<L1MuDTTrackCand>"/>
+
+ <class name="std::vector<L1Phase2MuDTPhDigi>"/>
 
  <class name="L1MuDTChambPhContainer" ClassVersion="10">
   <version ClassVersion="10" checksum="407874824"/>
@@ -27,8 +33,14 @@
   <version ClassVersion="10" checksum="1310842826"/>
  </class>
 
+ <class name="L1Phase2MuDTPhContainer" ClassVersion="3">
+  <version ClassVersion="3" checksum="2858706077"/>
+ </class>
+
  <class name="edm::Wrapper<L1MuDTChambPhContainer>" splitLevel="0"/>
  <class name="edm::Wrapper<L1MuDTChambThContainer>" splitLevel="0"/>
  <class name="edm::Wrapper<L1MuDTTrackContainer>"/>
+
+ <class name="edm::Wrapper<L1Phase2MuDTPhContainer>" splitLevel="0"/>
 
 </lcgdict>


### PR DESCRIPTION
#### PR description:
This PR adds a DataFormat for the DT Trigger Primitives for Phase-2. The inclusion of the format in CMSSW is a preliminary step to simplify the development of emulators, as well as the one of the DQM and unpacker programs for the DT Slice Test.

#### PR validation:
No real testing was made, apart from trying to fill the collection using preliminary versions of the emulator code, that are presently only available in private branches.

#### if this PR is a backport please specify the original PR:
This is the strict equivalent backport of the already merged PR #26806  in master 