### PR TITLE
updated FastSim treatment of long-lived charginos in the muon system

### DIFF
--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -204,7 +204,7 @@ void CalorimetryManager::reconstructTrack(FSimTrack& myTrack, RandomEngineAndDis
           reconstructHCAL(myTrack, random);
       }
     }  // electron or photon
-    else if (pid == 13) {
+    else if (pid == 13 || pid == 1000024) {
       MuonMipSimulation(myTrack, random);
     }
     // Simulate energy smearing for hadrons (i.e., everything
@@ -454,7 +454,7 @@ void CalorimetryManager::reconstructHCAL(const FSimTrack& myTrack, RandomEngineA
   double EGen = myTrack.hcalEntrance().e();
   double emeas = 0.;
 
-  if (pid == 13) {
+  if (pid == 13 || pid == 1000024) {
     emeas = myHDResponse_->responseHCAL(0, EGen, pathEta, 2, random);  // 2=muon
     if (debug_)
       LogInfo("FastCalorimetry") << "CalorimetryManager::reconstructHCAL - MUON !!!" << std::endl;
@@ -1205,7 +1205,7 @@ void CalorimetryManager::loadMuonSimTracks(edm::SimTrackContainer& muons) const 
   unsigned size = muons.size();
   for (unsigned i = 0; i < size; ++i) {
     int id = muons[i].trackId();
-    if (abs(muons[i].type()) != 13)
+    if (abs(muons[i].type()) != 13 && abs(muons[i].type()) != 1000024)
       continue;
     // identify the corresponding muon in the local collection
 

--- a/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
+++ b/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
@@ -168,9 +168,9 @@ void MuonSimHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
     // Decaying hadrons are now in the list, and so are their muon daughter
     // Ignore the hadrons here.
     int pid = mySimTrack.type();
-    if (abs(pid) != 13)
+    if (abs(pid) != 13 && abs(pid) != 1000024)
       continue;
-
+    std::cout << "pid in muon sim hit producer is " << pid << std::endl;
     double t0 = 0;
     GlobalPoint initialPosition;
     int ivert = mySimTrack.vertIndex();

--- a/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
+++ b/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
@@ -170,7 +170,6 @@ void MuonSimHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
     int pid = mySimTrack.type();
     if (abs(pid) != 13 && abs(pid) != 1000024)
       continue;
-    std::cout << "pid in muon sim hit producer is " << pid << std::endl;
     double t0 = 0;
     GlobalPoint initialPosition;
     int ivert = mySimTrack.vertIndex();


### PR DESCRIPTION
#### PR description:

A few lines in FastSimulation have been updated to allow muon sim tracks to arise from long-lived charginos. The calorimeters and muon system now generate hits and energy depositions as if it the chargino were a muon instead of not at all.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
