### PR TITLE
Use ESGetToken in JetTagComputerESProducer<T>

### DIFF
--- a/RecoBTag/CTagging/interface/CharmTagger.h
+++ b/RecoBTag/CTagging/interface/CharmTagger.h
@@ -1,11 +1,10 @@
 #ifndef RecoBTag_CTagging_CharmTagger_h
 #define RecoBTag_CTagging_CharmTagger_h
 
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
-#include <mutex>
-#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h"
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
@@ -19,8 +18,13 @@
 
 class CharmTagger : public JetTagComputer {
 public:
+  struct Tokens {
+    Tokens(const edm::ParameterSet& configuration, edm::ESConsumesCollector&& cc);
+    edm::ESGetToken<GBRForest, GBRWrapperRcd> gbrForest_;
+  };
+
   /// explicit ctor
-  CharmTagger(const edm::ParameterSet&);
+  CharmTagger(const edm::ParameterSet&, Tokens);
   ~CharmTagger() override;  //{}
   float discriminator(const TagInfoHelper& tagInfo) const override;
   void initialize(const JetTagComputerRecord& record) override;
@@ -41,12 +45,11 @@ private:
   std::vector<MVAVar> variables_;
 
   std::string mva_name_;
-  bool use_condDB_;
-  std::string gbrForest_label_;
   edm::FileInPath weight_file_;
   bool use_GBRForest_;
   bool use_adaBoost_;
   bool defaultValueNoTracks_;
+  Tokens tokens_;
 };
 
 #endif

--- a/RecoBTag/CTagging/src/CharmTagger.cc
+++ b/RecoBTag/CTagging/src/CharmTagger.cc
@@ -3,7 +3,7 @@
 #include "DataFormats/BTauReco/interface/CandSoftLeptonTagInfo.h"
 #include "DataFormats/BTauReco/interface/CandIPTagInfo.h"
 #include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 
 #include <iostream>
@@ -12,15 +12,24 @@
 #include <map>
 #include <iostream>
 
-CharmTagger::CharmTagger(const edm::ParameterSet &configuration)
+CharmTagger::Tokens::Tokens(const edm::ParameterSet &configuration, edm::ESConsumesCollector &&cc) {
+  if (configuration.getParameter<bool>("useCondDB")) {
+    cc.setConsumes(gbrForest_,
+                   edm::ESInputTag{"",
+                                   configuration.existsAs<std::string>("gbrForestLabel")
+                                       ? configuration.getParameter<std::string>("gbrForestLabel")
+                                       : ""});
+  }
+}
+
+CharmTagger::CharmTagger(const edm::ParameterSet &configuration, Tokens tokens)
     : sl_computer_(configuration.getParameter<edm::ParameterSet>("slComputerCfg")),
       mva_name_(configuration.getParameter<std::string>("mvaName")),
-      use_condDB_(configuration.getParameter<bool>("useCondDB")),
-      gbrForest_label_(configuration.getParameter<std::string>("gbrForestLabel")),
       weight_file_(configuration.getParameter<edm::FileInPath>("weightFile")),
       use_GBRForest_(configuration.getParameter<bool>("useGBRForest")),
       use_adaBoost_(configuration.getParameter<bool>("useAdaBoost")),
-      defaultValueNoTracks_(configuration.getParameter<bool>("defaultValueNoTracks")) {
+      defaultValueNoTracks_(configuration.getParameter<bool>("defaultValueNoTracks")),
+      tokens_{std::move(tokens)} {
   vpset vars_definition = configuration.getParameter<vpset>("variables");
   for (auto &var : vars_definition) {
     MVAVar mva_var;
@@ -50,13 +59,8 @@ void CharmTagger::initialize(const JetTagComputerRecord &record) {
   }
   std::vector<std::string> spectators;
 
-  if (use_condDB_) {
-    const GBRWrapperRcd &gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
-
-    edm::ESHandle<GBRForest> gbrForestHandle;
-    gbrWrapperRecord.get(gbrForest_label_.c_str(), gbrForestHandle);
-
-    mvaID_->initializeGBRForest(gbrForestHandle.product(), variable_names, spectators, use_adaBoost_);
+  if (tokens_.gbrForest_.isInitialized()) {
+    mvaID_->initializeGBRForest(&record.get(tokens_.gbrForest_), variable_names, spectators, use_adaBoost_);
   } else {
     mvaID_->initialize("Color:Silent:Error",
                        mva_name_,

--- a/RecoBTag/Combined/interface/CandidateChargeBTagComputer.h
+++ b/RecoBTag/Combined/interface/CandidateChargeBTagComputer.h
@@ -1,8 +1,8 @@
 #ifndef RecoBTag_Combined_CandidateChargeBTagComputer_h
 #define RecoBTag_Combined_CandidateChargeBTagComputer_h
 
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
 #include "DataFormats/BTauReco/interface/CandIPTagInfo.h"
 #include "DataFormats/BTauReco/interface/CandSecondaryVertexTagInfo.h"
@@ -15,20 +15,24 @@
 
 class CandidateChargeBTagComputer : public JetTagComputer {
 public:
-  CandidateChargeBTagComputer(const edm::ParameterSet &parameters);
+  struct Tokens {
+    Tokens(const edm::ParameterSet &parameters, edm::ESConsumesCollector &&cc);
+    edm::ESGetToken<GBRForest, GBRWrapperRcd> gbrForest_;
+  };
+
+  CandidateChargeBTagComputer(const edm::ParameterSet &parameters, Tokens tokens);
   ~CandidateChargeBTagComputer() override;
   void initialize(const JetTagComputerRecord &record) override;
   float discriminator(const TagInfoHelper &tagInfo) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  const bool useCondDB_;
-  const std::string gbrForestLabel_;
   const edm::FileInPath weightFile_;
   const bool useAdaBoost_;
   std::unique_ptr<TMVAEvaluator> mvaID;
   const double jetChargeExp_;
   const double svChargeExp_;
+  const Tokens tokens_;
 };
 
 #endif  // RecoBTag_Combined_CandidateChargeBTagComputer_h

--- a/RecoBTag/Combined/interface/CombinedMVAV2JetTagComputer.h
+++ b/RecoBTag/Combined/interface/CombinedMVAV2JetTagComputer.h
@@ -9,6 +9,7 @@
 #include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
+#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 
 class CombinedMVAV2JetTagComputer : public JetTagComputer {

--- a/RecoBTag/Combined/interface/CombinedMVAV2JetTagComputer.h
+++ b/RecoBTag/Combined/interface/CombinedMVAV2JetTagComputer.h
@@ -6,14 +6,20 @@
 #include <vector>
 #include <map>
 
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 
 class CombinedMVAV2JetTagComputer : public JetTagComputer {
 public:
-  CombinedMVAV2JetTagComputer(const edm::ParameterSet &parameters);
+  struct Tokens {
+    Tokens(const edm::ParameterSet &parameters, edm::ESConsumesCollector &&cc);
+    edm::ESGetToken<GBRForest, GBRWrapperRcd> gbrForest_;
+    std::vector<edm::ESGetToken<JetTagComputer, JetTagComputerRecord> > computers_;
+  };
+
+  CombinedMVAV2JetTagComputer(const edm::ParameterSet &parameters, Tokens tokens);
   ~CombinedMVAV2JetTagComputer() override;
 
   void initialize(const JetTagComputerRecord &record) override;
@@ -23,15 +29,13 @@ public:
 private:
   std::vector<const JetTagComputer *> computers;
 
-  const std::vector<std::string> inputComputerNames;
   const std::string mvaName;
   const std::vector<std::string> variables;
   const std::vector<std::string> spectators;
-  const bool useCondDB;
-  const std::string gbrForestLabel;
   const edm::FileInPath weightFile;
   const bool useGBRForest;
   const bool useAdaBoost;
+  const Tokens tokens;
 
   std::unique_ptr<TMVAEvaluator> mvaID;
 };

--- a/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
+++ b/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
@@ -12,9 +12,6 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
 #include "RecoBTag/Combined/interface/CombinedMVAV2JetTagComputer.h"
-#include "CondFormats/DataRecord/interface/BTauGenericMVAJetTagComputerRcd.h"
-#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
-#include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
 
 using namespace reco;
 

--- a/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
+++ b/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
@@ -7,8 +7,6 @@
 #include <map>
 
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/JetReco/interface/Jet.h"
@@ -20,20 +18,30 @@
 
 using namespace reco;
 
-CombinedMVAV2JetTagComputer::CombinedMVAV2JetTagComputer(const edm::ParameterSet &params)
-    :
+CombinedMVAV2JetTagComputer::Tokens::Tokens(const edm::ParameterSet &params, edm::ESConsumesCollector &&cc) {
+  if (params.getParameter<bool>("useCondDB")) {
+    cc.setConsumes(
+        gbrForest_,
+        edm::ESInputTag{
+            "",
+            params.existsAs<std::string>("gbrForestLabel") ? params.getParameter<std::string>("gbrForestLabel") : ""});
+  }
+  const auto &inputComputerNames = params.getParameter<std::vector<std::string> >("jetTagComputers");
+  computers_.resize(inputComputerNames.size());
+  for (size_t i = 0; i < inputComputerNames.size(); ++i) {
+    cc.setConsumes(computers_[i], edm::ESInputTag{"", inputComputerNames[i]});
+  }
+}
 
-      inputComputerNames(params.getParameter<std::vector<std::string> >("jetTagComputers")),
-      mvaName(params.getParameter<std::string>("mvaName")),
+CombinedMVAV2JetTagComputer::CombinedMVAV2JetTagComputer(const edm::ParameterSet &params, Tokens tokens)
+    : mvaName(params.getParameter<std::string>("mvaName")),
       variables(params.getParameter<std::vector<std::string> >("variables")),
       spectators(params.getParameter<std::vector<std::string> >("spectators")),
-      useCondDB(params.getParameter<bool>("useCondDB")),
-      gbrForestLabel(params.existsAs<std::string>("gbrForestLabel") ? params.getParameter<std::string>("gbrForestLabel")
-                                                                    : ""),
       weightFile(params.existsAs<edm::FileInPath>("weightFile") ? params.getParameter<edm::FileInPath>("weightFile")
                                                                 : edm::FileInPath()),
       useGBRForest(params.existsAs<bool>("useGBRForest") ? params.getParameter<bool>("useGBRForest") : false),
-      useAdaBoost(params.existsAs<bool>("useAdaBoost") ? params.getParameter<bool>("useAdaBoost") : false)
+      useAdaBoost(params.existsAs<bool>("useAdaBoost") ? params.getParameter<bool>("useAdaBoost") : false),
+      tokens(std::move(tokens))
 
 {
   uses(0, "ipTagInfos");
@@ -46,24 +54,17 @@ CombinedMVAV2JetTagComputer::CombinedMVAV2JetTagComputer(const edm::ParameterSet
 CombinedMVAV2JetTagComputer::~CombinedMVAV2JetTagComputer() {}
 
 void CombinedMVAV2JetTagComputer::initialize(const JetTagComputerRecord &record) {
-  mvaID.reset(new TMVAEvaluator());
+  mvaID = std::make_unique<TMVAEvaluator>();
 
-  if (useCondDB) {
-    const GBRWrapperRcd &gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
-
-    edm::ESHandle<GBRForest> gbrForestHandle;
-    gbrWrapperRecord.get(gbrForestLabel.c_str(), gbrForestHandle);
-
-    mvaID->initializeGBRForest(gbrForestHandle.product(), variables, spectators, useAdaBoost);
+  if (tokens.gbrForest_.isInitialized()) {
+    mvaID->initializeGBRForest(&record.get(tokens.gbrForest_), variables, spectators, useAdaBoost);
   } else {
     mvaID->initialize(
         "Color:Silent:Error", mvaName, weightFile.fullPath(), variables, spectators, useGBRForest, useAdaBoost);
   }
-  for (auto &name : inputComputerNames) {
-    edm::ESHandle<JetTagComputer> computerHandle;
-    record.get(name, computerHandle);
-    const JetTagComputer *comp = computerHandle.product();
-    computers.push_back(comp);
+  computers.reserve(tokens.computers_.size());
+  for (const auto &token : tokens.computers_) {
+    computers.push_back(&record.get(token));
   }
 }
 

--- a/RecoBTag/ImpactParameter/interface/PromptTrackCountingComputer.h
+++ b/RecoBTag/ImpactParameter/interface/PromptTrackCountingComputer.h
@@ -15,6 +15,8 @@
 
 class PromptTrackCountingComputer : public JetTagComputer {
 public:
+  using Tokens = void;
+
   PromptTrackCountingComputer(const edm::ParameterSet& parameters) {
     m_nthTrack = parameters.getParameter<int>("nthTrack");
     m_ipType = parameters.getParameter<int>("impactParameterType");

--- a/RecoBTag/ImpactParameter/interface/TemplatedJetBProbabilityComputer.h
+++ b/RecoBTag/ImpactParameter/interface/TemplatedJetBProbabilityComputer.h
@@ -13,6 +13,8 @@
 template <class Container, class Base>
 class TemplatedJetBProbabilityComputer : public JetTagComputer {
 public:
+  using Tokens = void;
+
   typedef reco::IPTagInfo<Container, Base> TagInfo;
 
   TemplatedJetBProbabilityComputer(const edm::ParameterSet& parameters) {

--- a/RecoBTag/ImpactParameter/interface/TemplatedJetProbabilityComputer.h
+++ b/RecoBTag/ImpactParameter/interface/TemplatedJetProbabilityComputer.h
@@ -14,6 +14,8 @@
 template <class Container, class Base>
 class TemplatedJetProbabilityComputer : public JetTagComputer {
 public:
+  using Tokens = void;
+
   typedef reco::IPTagInfo<Container, Base> TagInfo;
 
   TemplatedJetProbabilityComputer(const edm::ParameterSet& parameters) {

--- a/RecoBTag/ImpactParameter/interface/TemplatedTrackCountingComputer.h
+++ b/RecoBTag/ImpactParameter/interface/TemplatedTrackCountingComputer.h
@@ -11,6 +11,8 @@
 template <class Container, class Base>
 class TemplatedTrackCountingComputer : public JetTagComputer {
 public:
+  using Tokens = void;
+
   typedef reco::IPTagInfo<Container, Base> TagInfo;
 
   TemplatedTrackCountingComputer(const edm::ParameterSet& parameters) {

--- a/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
@@ -1,23 +1,29 @@
 #ifndef RecoBTag_SecondaryVertex_CandidateBoostedDoubleSecondaryVertexComputer_h
 #define RecoBTag_SecondaryVertex_CandidateBoostedDoubleSecondaryVertexComputer_h
 
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
+#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 
 class CandidateBoostedDoubleSecondaryVertexComputer : public JetTagComputer {
 public:
-  CandidateBoostedDoubleSecondaryVertexComputer(const edm::ParameterSet &parameters);
+  struct Tokens {
+    Tokens(const edm::ParameterSet &parameters, edm::ESConsumesCollector &&cc);
+    edm::ESGetToken<GBRForest, GBRWrapperRcd> gbrForest_;
+  };
+
+  CandidateBoostedDoubleSecondaryVertexComputer(const edm::ParameterSet &parameters, Tokens tokens);
 
   void initialize(const JetTagComputerRecord &) override;
   float discriminator(const TagInfoHelper &tagInfos) const override;
 
 private:
-  const bool useCondDB_;
-  const std::string gbrForestLabel_;
   const edm::FileInPath weightFile_;
   const bool useGBRForest_;
   const bool useAdaBoost_;
+  const Tokens tokens_;
 
   std::unique_ptr<TMVAEvaluator> mvaID;
 };

--- a/RecoBTag/SecondaryVertex/interface/TemplatedSimpleSecondaryVertexComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/TemplatedSimpleSecondaryVertexComputer.h
@@ -16,6 +16,8 @@
 template <class IPTI, class VTX>
 class TemplatedSimpleSecondaryVertexComputer : public JetTagComputer {
 public:
+  using Tokens = void;
+
   typedef reco::TemplatedSecondaryVertexTagInfo<IPTI, VTX> TagInfo;
 
   TemplatedSimpleSecondaryVertexComputer(const edm::ParameterSet &parameters)

--- a/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
@@ -1,24 +1,30 @@
 #include "RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/DataRecord/interface/BTauGenericMVAJetTagComputerRcd.h"
-#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 #include "DataFormats/BTauReco/interface/BoostedDoubleSVTagInfo.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
 
+CandidateBoostedDoubleSecondaryVertexComputer::Tokens::Tokens(const edm::ParameterSet& parameters,
+                                                              edm::ESConsumesCollector&& cc) {
+  if (parameters.getParameter<bool>("useCondDB")) {
+    cc.setConsumes(gbrForest_,
+                   edm::ESInputTag{"",
+                                   parameters.existsAs<std::string>("gbrForestLabel")
+                                       ? parameters.getParameter<std::string>("gbrForestLabel")
+                                       : ""});
+  }
+}
+
 CandidateBoostedDoubleSecondaryVertexComputer::CandidateBoostedDoubleSecondaryVertexComputer(
-    const edm::ParameterSet& parameters)
-    : useCondDB_(parameters.getParameter<bool>("useCondDB")),
-      gbrForestLabel_(parameters.existsAs<std::string>("gbrForestLabel")
-                          ? parameters.getParameter<std::string>("gbrForestLabel")
-                          : ""),
-      weightFile_(parameters.existsAs<edm::FileInPath>("weightFile")
+    const edm::ParameterSet& parameters, Tokens tokens)
+    : weightFile_(parameters.existsAs<edm::FileInPath>("weightFile")
                       ? parameters.getParameter<edm::FileInPath>("weightFile")
                       : edm::FileInPath()),
       useGBRForest_(parameters.existsAs<bool>("useGBRForest") ? parameters.getParameter<bool>("useGBRForest") : false),
-      useAdaBoost_(parameters.existsAs<bool>("useAdaBoost") ? parameters.getParameter<bool>("useAdaBoost") : false) {
+      useAdaBoost_(parameters.existsAs<bool>("useAdaBoost") ? parameters.getParameter<bool>("useAdaBoost") : false),
+      tokens_{std::move(tokens)} {
   uses(0, "svTagInfos");
 
   mvaID.reset(new TMVAEvaluator());
@@ -56,13 +62,8 @@ void CandidateBoostedDoubleSecondaryVertexComputer::initialize(const JetTagCompu
   // book TMVA readers
   std::vector<std::string> spectators({"massPruned", "flavour", "nbHadrons", "ptPruned", "etaPruned"});
 
-  if (useCondDB_) {
-    const GBRWrapperRcd& gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
-
-    edm::ESHandle<GBRForest> gbrForestHandle;
-    gbrWrapperRecord.get(gbrForestLabel_.c_str(), gbrForestHandle);
-
-    mvaID->initializeGBRForest(gbrForestHandle.product(), variables, spectators, useAdaBoost_);
+  if (tokens_.gbrForest_.isInitialized()) {
+    mvaID->initializeGBRForest(&record.get(tokens_.gbrForest_), variables, spectators, useAdaBoost_);
   } else
     mvaID->initialize(
         "Color:Silent:Error", "BDT", weightFile_.fullPath(), variables, spectators, useGBRForest_, useAdaBoost_);

--- a/RecoBTag/SoftLepton/interface/ElectronTagger.h
+++ b/RecoBTag/SoftLepton/interface/ElectronTagger.h
@@ -1,10 +1,12 @@
 #ifndef RecoBTag_SoftLepton_ElectronTagger_h
 #define RecoBTag_SoftLepton_ElectronTagger_h
 
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
+#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 
 /** \class ElectronTagger
  *
@@ -15,18 +17,22 @@
 
 class ElectronTagger : public JetTagComputer {
 public:
+  struct Tokens {
+    Tokens(const edm::ParameterSet &cfg, edm::ESConsumesCollector &&cc);
+    edm::ESGetToken<GBRForest, GBRWrapperRcd> gbrForest_;
+  };
+
   /// explicit ctor
-  ElectronTagger(const edm::ParameterSet &);
+  ElectronTagger(const edm::ParameterSet &, Tokens);
   void initialize(const JetTagComputerRecord &) override;
   float discriminator(const TagInfoHelper &tagInfo) const override;
 
 private:
   const btag::LeptonSelector m_selector;
-  const bool m_useCondDB;
-  const std::string m_gbrForestLabel;
   const edm::FileInPath m_weightFile;
   const bool m_useGBRForest;
   const bool m_useAdaBoost;
+  const Tokens m_tokens;
 
   std::unique_ptr<TMVAEvaluator> mvaID;
 };

--- a/RecoBTag/SoftLepton/interface/LeptonTaggerByIP.h
+++ b/RecoBTag/SoftLepton/interface/LeptonTaggerByIP.h
@@ -15,6 +15,8 @@
 
 class LeptonTaggerByIP : public JetTagComputer {
 public:
+  using Tokens = void;
+
   /// explicit ctor
   explicit LeptonTaggerByIP(const edm::ParameterSet& configuration)
       : m_use3d(configuration.getParameter<bool>("use3d")), m_selector(configuration) {

--- a/RecoBTag/SoftLepton/interface/LeptonTaggerByPt.h
+++ b/RecoBTag/SoftLepton/interface/LeptonTaggerByPt.h
@@ -15,6 +15,8 @@
 
 class LeptonTaggerByPt : public JetTagComputer {
 public:
+  using Tokens = void;
+
   /// explicit ctor
   explicit LeptonTaggerByPt(const edm::ParameterSet& configuration) : m_selector(configuration) { uses("slTagInfos"); }
 

--- a/RecoBTag/SoftLepton/interface/LeptonTaggerDistance.h
+++ b/RecoBTag/SoftLepton/interface/LeptonTaggerDistance.h
@@ -13,6 +13,8 @@
 
 class LeptonTaggerDistance : public JetTagComputer {
 public:
+  using Tokens = void;
+
   /// default ctor
   LeptonTaggerDistance(void) : m_maxDistance(0.5) { uses("slTagInfos"); }
 

--- a/RecoBTag/SoftLepton/interface/MuonTagger.h
+++ b/RecoBTag/SoftLepton/interface/MuonTagger.h
@@ -5,6 +5,7 @@
 #ifndef RecoBTag_SoftLepton_MuonTagger_h
 #define RecoBTag_SoftLepton_MuonTagger_h
 
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
@@ -13,17 +14,21 @@
 
 class MuonTagger : public JetTagComputer {
 public:
-  MuonTagger(const edm::ParameterSet&);
+  struct Tokens {
+    Tokens(const edm::ParameterSet& cfg, edm::ESConsumesCollector&& cc);
+    edm::ESGetToken<GBRForest, GBRWrapperRcd> gbrForest_;
+  };
+
+  MuonTagger(const edm::ParameterSet&, Tokens);
   void initialize(const JetTagComputerRecord&) override;
   float discriminator(const TagInfoHelper& tagInfo) const override;
 
 private:
   btag::LeptonSelector m_selector;
-  const bool m_useCondDB;
-  const std::string m_gbrForestLabel;
   const edm::FileInPath m_weightFile;
   const bool m_useGBRForest;
   const bool m_useAdaBoost;
+  const Tokens m_tokens;
 
   std::unique_ptr<TMVAEvaluator> mvaID;
 };

--- a/RecoBTag/SoftLepton/interface/MuonTagger.h
+++ b/RecoBTag/SoftLepton/interface/MuonTagger.h
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
+#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
 #include <memory>

--- a/RecoBTag/SoftLepton/interface/MuonTaggerNoIP.h
+++ b/RecoBTag/SoftLepton/interface/MuonTaggerNoIP.h
@@ -16,6 +16,8 @@
 
 class MuonTaggerNoIP : public JetTagComputer {
 public:
+  using Tokens = void;
+
   /// explicit ctor
   explicit MuonTaggerNoIP(const edm::ParameterSet& configuration) : m_selector(configuration) { uses("slTagInfos"); }
 

--- a/RecoBTag/SoftLepton/src/MuonTagger.cc
+++ b/RecoBTag/SoftLepton/src/MuonTagger.cc
@@ -5,7 +5,6 @@
 #include <limits>
 #include <random>
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "CondFormats/DataRecord/interface/BTauGenericMVAJetTagComputerRcd.h"
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
@@ -14,15 +13,22 @@
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
 #include "RecoBTag/SoftLepton/interface/MuonTagger.h"
 
-MuonTagger::MuonTagger(const edm::ParameterSet& cfg)
+MuonTagger::Tokens::Tokens(const edm::ParameterSet& cfg, edm::ESConsumesCollector&& cc) {
+  if (cfg.getParameter<bool>("useCondDB")) {
+    cc.setConsumes(
+        gbrForest_,
+        edm::ESInputTag{
+            "", cfg.existsAs<std::string>("gbrForestLabel") ? cfg.getParameter<std::string>("gbrForestLabel") : ""});
+  }
+}
+
+MuonTagger::MuonTagger(const edm::ParameterSet& cfg, Tokens tokens)
     : m_selector(cfg),
-      m_useCondDB(cfg.getParameter<bool>("useCondDB")),
-      m_gbrForestLabel(cfg.existsAs<std::string>("gbrForestLabel") ? cfg.getParameter<std::string>("gbrForestLabel")
-                                                                   : ""),
       m_weightFile(cfg.existsAs<edm::FileInPath>("weightFile") ? cfg.getParameter<edm::FileInPath>("weightFile")
                                                                : edm::FileInPath()),
       m_useGBRForest(cfg.existsAs<bool>("useGBRForest") ? cfg.getParameter<bool>("useGBRForest") : false),
-      m_useAdaBoost(cfg.existsAs<bool>("useAdaBoost") ? cfg.getParameter<bool>("useAdaBoost") : false) {
+      m_useAdaBoost(cfg.existsAs<bool>("useAdaBoost") ? cfg.getParameter<bool>("useAdaBoost") : false),
+      m_tokens{std::move(tokens)} {
   uses("smTagInfos");
   mvaID.reset(new TMVAEvaluator());
 }
@@ -33,13 +39,8 @@ void MuonTagger::initialize(const JetTagComputerRecord& record) {
       {"TagInfo1.sip3d", "TagInfo1.sip2d", "TagInfo1.ptRel", "TagInfo1.deltaR", "TagInfo1.ratio"});
   std::vector<std::string> spectators;
 
-  if (m_useCondDB) {
-    const GBRWrapperRcd& gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
-
-    edm::ESHandle<GBRForest> gbrForestHandle;
-    gbrWrapperRecord.get(m_gbrForestLabel.c_str(), gbrForestHandle);
-
-    mvaID->initializeGBRForest(gbrForestHandle.product(), variables, spectators, m_useAdaBoost);
+  if (m_tokens.gbrForest_.isInitialized()) {
+    mvaID->initializeGBRForest(&record.get(m_tokens.gbrForest_), variables, spectators, m_useAdaBoost);
   } else
     mvaID->initialize(
         "Color:Silent:Error", "BDT", m_weightFile.fullPath(), variables, spectators, m_useGBRForest, m_useAdaBoost);

--- a/RecoBTag/SoftLepton/src/MuonTagger.cc
+++ b/RecoBTag/SoftLepton/src/MuonTagger.cc
@@ -5,8 +5,6 @@
 #include <limits>
 #include <random>
 
-#include "CondFormats/DataRecord/interface/BTauGenericMVAJetTagComputerRcd.h"
-#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
 #include "DataFormats/BTauReco/interface/SoftLeptonTagInfo.h"
 #include "DataFormats/BTauReco/interface/CandSoftLeptonTagInfo.h"

--- a/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"
@@ -15,7 +15,12 @@ class JetTagComputerRecord;
 
 class GenericMVAJetTagComputer : public JetTagComputer {
 public:
-  GenericMVAJetTagComputer(const edm::ParameterSet &parameters);
+  struct Tokens {
+    Tokens(const edm::ParameterSet &parameters, edm::ESConsumesCollector &&cc);
+    edm::ESGetToken<PhysicsTools::Calibration::MVAComputerContainer, JetTagComputerRecord> calib_;
+  };
+
+  GenericMVAJetTagComputer(const edm::ParameterSet &parameters, Tokens tokens);
   ~GenericMVAJetTagComputer() override;
 
   void initialize(const JetTagComputerRecord &) override;
@@ -28,7 +33,7 @@ public:
 private:
   std::unique_ptr<TagInfoMVACategorySelector> categorySelector_;
   GenericMVAComputerCache computerCache_;
-  std::string recordLabel_;
+  Tokens tokens_;
 };
 
 #endif  // RecoBTau_JetTagComputer_GenericMVAJetTagComputer_h

--- a/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h
@@ -5,6 +5,7 @@
 
 #include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/DataRecord/interface/BTauGenericMVAJetTagComputerRcd.h"
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
@@ -17,7 +18,7 @@ class GenericMVAJetTagComputer : public JetTagComputer {
 public:
   struct Tokens {
     Tokens(const edm::ParameterSet &parameters, edm::ESConsumesCollector &&cc);
-    edm::ESGetToken<PhysicsTools::Calibration::MVAComputerContainer, JetTagComputerRecord> calib_;
+    edm::ESGetToken<PhysicsTools::Calibration::MVAComputerContainer, BTauGenericMVAJetTagComputerRcd> calib_;
   };
 
   GenericMVAJetTagComputer(const edm::ParameterSet &parameters, Tokens tokens);

--- a/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputerWrapper.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputerWrapper.h
@@ -48,8 +48,8 @@ template <class Provider,
           const char *ti4 = btau_dummy::none>
 class GenericMVAJetTagComputerWrapper : public GenericMVAJetTagComputer, private Provider {
 public:
-  GenericMVAJetTagComputerWrapper(const edm::ParameterSet &params)
-      : GenericMVAJetTagComputer(params), Provider(params) {
+  GenericMVAJetTagComputerWrapper(const edm::ParameterSet &params, Tokens tokens)
+      : GenericMVAJetTagComputer(params, std::move(tokens)), Provider(params) {
     uses(0, ti1);
     uses(1, ti2);
     uses(2, ti3);
@@ -69,8 +69,8 @@ template <class Provider, class TI1, const char *ti1, class TI2, const char *ti2
 class GenericMVAJetTagComputerWrapper<Provider, TI1, ti1, TI2, ti2, TI3, ti3, btau_dummy::Null, btau_dummy::none>
     : public GenericMVAJetTagComputer, private Provider {
 public:
-  GenericMVAJetTagComputerWrapper(const edm::ParameterSet &params)
-      : GenericMVAJetTagComputer(params), Provider(params) {
+  GenericMVAJetTagComputerWrapper(const edm::ParameterSet &params, Tokens tokens)
+      : GenericMVAJetTagComputer(params, std::move(tokens)), Provider(params) {
     uses(0, ti1);
     uses(1, ti2);
     uses(2, ti3);
@@ -96,8 +96,8 @@ class GenericMVAJetTagComputerWrapper<Provider,
                                       btau_dummy::none> : public GenericMVAJetTagComputer,
                                                           private Provider {
 public:
-  GenericMVAJetTagComputerWrapper(const edm::ParameterSet &params)
-      : GenericMVAJetTagComputer(params), Provider(params) {
+  GenericMVAJetTagComputerWrapper(const edm::ParameterSet &params, Tokens tokens)
+      : GenericMVAJetTagComputer(params, std::move(tokens)), Provider(params) {
     uses(0, ti1);
     uses(1, ti2);
   }
@@ -122,8 +122,8 @@ class GenericMVAJetTagComputerWrapper<Provider,
                                       btau_dummy::none> : public GenericMVAJetTagComputer,
                                                           private Provider {
 public:
-  GenericMVAJetTagComputerWrapper(const edm::ParameterSet &params)
-      : GenericMVAJetTagComputer(params), Provider(params) {
+  GenericMVAJetTagComputerWrapper(const edm::ParameterSet &params, Tokens tokens)
+      : GenericMVAJetTagComputer(params, std::move(tokens)), Provider(params) {
     uses(0, ti1);
   }
 
@@ -147,8 +147,8 @@ class GenericMVAJetTagComputerWrapper<Provider,
                                       btau_dummy::none> : public GenericMVAJetTagComputer,
                                                           private Provider {
 public:
-  GenericMVAJetTagComputerWrapper(const edm::ParameterSet &params)
-      : GenericMVAJetTagComputer(params), Provider(params) {}
+  GenericMVAJetTagComputerWrapper(const edm::ParameterSet &params, Tokens tokens)
+      : GenericMVAJetTagComputer(params, std::move(tokens)), Provider(params) {}
 
 protected:
   reco::TaggingVariableList taggingVariables(const TagInfoHelper &info) const override {

--- a/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
+++ b/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
@@ -11,7 +11,7 @@
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 
 /**
- * The idea here is to provide to implementations for
+ * The idea here is to provide two implementations for
  * JetTagConmputerESProducer: one for those ConcreteJetTagComputers
  * that consume ES products and thus need the ESGetTokens, and one for
  * those that do not. All ConcreteJetTagComputers are required to have
@@ -26,7 +26,7 @@
  * Those that do not need ESGetTokens should define the nested type as
  * void, and in this case no further modifications are needed.
  */
-namespace jetTagComputerESProducerImpl {
+namespace jet_tag_computer_esproducer_impl {
   template <typename ConcreteJetTagComputer, bool>
   class JetTagComputerESProducer : public edm::ESProducer {
   private:
@@ -72,10 +72,10 @@ namespace jetTagComputerESProducerImpl {
   private:
     const edm::ParameterSet m_pset;
   };
-}  // namespace jetTagComputerESProducerImpl
+}  // namespace jet_tag_computer_esproducer_impl
 
 template <typename T>
 using JetTagComputerESProducer =
-    jetTagComputerESProducerImpl::JetTagComputerESProducer<T, std::is_same_v<typename T::Tokens, void>>;
+    jet_tag_computer_esproducer_impl::JetTagComputerESProducer<T, std::is_same_v<typename T::Tokens, void>>;
 
 #endif  // RecoBTau_JetTagComputerESProducer_h

--- a/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
+++ b/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
@@ -10,28 +10,72 @@
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 
-template <typename ConcreteJetTagComputer>
-class JetTagComputerESProducer : public edm::ESProducer {
-private:
-  // check that the template parameter inherits from JetTagComputer
-  static_assert(std::is_convertible_v<ConcreteJetTagComputer*, JetTagComputer*>);
+/**
+ * The idea here is to provide to implementations for
+ * JetTagConmputerESProducer: one for those ConcreteJetTagComputers
+ * that consume ES products and thus need the ESGetTokens, and one for
+ * those that do not. All ConcreteJetTagComputers are required to have
+ * a nested type called 'Tokens'.
+ *
+ * Those that need the ESGetTokens should define the nested type as a
+ * struct/class containing the ESGetTokens and a constructor taking
+ * edm::ParameterSet and edm::ESConsumesCollector as arguments. In
+ * this case the constructor of ConcreteJetTagComputer takes this
+ * 'Tokens' object as an additional argument.
+ *
+ * Those that do not need ESGetTokens should define the nested type as
+ * void, and in this case no further modifications are needed.
+ */
+namespace jetTagComputerESProducerImpl {
+  template <typename ConcreteJetTagComputer, bool>
+  class JetTagComputerESProducer : public edm::ESProducer {
+  private:
+    // check that the template parameter inherits from JetTagComputer
+    static_assert(std::is_convertible_v<ConcreteJetTagComputer*, JetTagComputer*>);
 
-public:
-  JetTagComputerESProducer(const edm::ParameterSet& pset) : m_pset(pset) {
-    setWhatProduced(this, m_pset.getParameter<std::string>("@module_label"));
-  }
+  public:
+    using Tokens = typename ConcreteJetTagComputer::Tokens;
 
-  ~JetTagComputerESProducer() override {}
+    JetTagComputerESProducer(const edm::ParameterSet& pset)
+        : m_tokens(pset, setWhatProduced(this, pset.getParameter<std::string>("@module_label"))), m_pset(pset) {}
 
-  std::unique_ptr<JetTagComputer> produce(const JetTagComputerRecord& record) {
-    std::unique_ptr<JetTagComputer> jetTagComputer = std::make_unique<ConcreteJetTagComputer>(m_pset);
-    jetTagComputer->initialize(record);
-    jetTagComputer->setupDone();
-    return jetTagComputer;
-  }
+    std::unique_ptr<JetTagComputer> produce(const JetTagComputerRecord& record) {
+      std::unique_ptr<JetTagComputer> jetTagComputer = std::make_unique<ConcreteJetTagComputer>(m_pset, m_tokens);
+      jetTagComputer->initialize(record);
+      jetTagComputer->setupDone();
+      return jetTagComputer;
+    }
 
-private:
-  edm::ParameterSet m_pset;
-};
+  private:
+    const Tokens m_tokens;
+    const edm::ParameterSet m_pset;
+  };
+
+  template <typename ConcreteJetTagComputer>
+  class JetTagComputerESProducer<ConcreteJetTagComputer, true> : public edm::ESProducer {
+  private:
+    // check that the template parameter inherits from JetTagComputer
+    static_assert(std::is_convertible_v<ConcreteJetTagComputer*, JetTagComputer*>);
+
+  public:
+    JetTagComputerESProducer(const edm::ParameterSet& pset) : m_pset(pset) {
+      setWhatProduced(this, pset.getParameter<std::string>("@module_label"));
+    }
+
+    std::unique_ptr<JetTagComputer> produce(const JetTagComputerRecord& record) {
+      std::unique_ptr<JetTagComputer> jetTagComputer = std::make_unique<ConcreteJetTagComputer>(m_pset);
+      jetTagComputer->initialize(record);
+      jetTagComputer->setupDone();
+      return jetTagComputer;
+    }
+
+  private:
+    const edm::ParameterSet m_pset;
+  };
+}  // namespace jetTagComputerESProducerImpl
+
+template <typename T>
+using JetTagComputerESProducer =
+    jetTagComputerESProducerImpl::JetTagComputerESProducer<T, std::is_same_v<typename T::Tokens, void>>;
 
 #endif  // RecoBTau_JetTagComputerESProducer_h

--- a/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
+++ b/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
@@ -2,9 +2,8 @@
 #define RecoBTau_JetTagComputerESProducer_h
 
 #include <string>
-#include <boost/static_assert.hpp>
-#include <boost/type_traits.hpp>
 #include <memory>
+#include <type_traits>
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,7 +14,7 @@ template <typename ConcreteJetTagComputer>
 class JetTagComputerESProducer : public edm::ESProducer {
 private:
   // check that the template parameter inherits from JetTagComputer
-  static_assert((boost::is_convertible<ConcreteJetTagComputer*, JetTagComputer*>::value));
+  static_assert(std::is_convertible_v<ConcreteJetTagComputer*, JetTagComputer*>);
 
 public:
   JetTagComputerESProducer(const edm::ParameterSet& pset) : m_pset(pset) {

--- a/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
@@ -6,7 +6,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/PhysicsToolsObjects/interface/MVAComputer.h"
-#include "CondFormats/DataRecord/interface/BTauGenericMVAJetTagComputerRcd.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"

--- a/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
@@ -4,7 +4,6 @@
 #include <memory>
 
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/PhysicsToolsObjects/interface/MVAComputer.h"
 #include "CondFormats/DataRecord/interface/BTauGenericMVAJetTagComputerRcd.h"
@@ -33,22 +32,18 @@ static std::vector<std::string> getCalibrationLabels(const edm::ParameterSet &pa
   }
 }
 
-GenericMVAJetTagComputer::GenericMVAJetTagComputer(const edm::ParameterSet &params)
-    : computerCache_(getCalibrationLabels(params, categorySelector_)),
-      recordLabel_(params.getParameter<std::string>("recordLabel")) {}
+GenericMVAJetTagComputer::Tokens::Tokens(const edm::ParameterSet &params, edm::ESConsumesCollector &&cc) {
+  cc.setConsumes(calib_, edm::ESInputTag{"", params.getParameter<std::string>("recordLabel")});
+}
+
+GenericMVAJetTagComputer::GenericMVAJetTagComputer(const edm::ParameterSet &params, Tokens tokens)
+    : computerCache_(getCalibrationLabels(params, categorySelector_)), tokens_{std::move(tokens)} {}
 
 GenericMVAJetTagComputer::~GenericMVAJetTagComputer() {}
 
 void GenericMVAJetTagComputer::initialize(const JetTagComputerRecord &record) {
-  const BTauGenericMVAJetTagComputerRcd &dependentRecord = record.getRecord<BTauGenericMVAJetTagComputerRcd>();
-
-  // retrieve MVAComputer calibration container
-  edm::ESHandle<Calibration::MVAComputerContainer> calibHandle;
-  dependentRecord.get(recordLabel_, calibHandle);
-  const Calibration::MVAComputerContainer *calib = calibHandle.product();
-
   // check for updates
-  computerCache_.update(calib);
+  computerCache_.update(&record.get(tokens_.calib_));
 }
 
 float GenericMVAJetTagComputer::discriminator(const TagInfoHelper &info) const {


### PR DESCRIPTION
#### PR description:

This PR makes `JetTagComputerESProducer<T>` to use `ESGetToken`s for ESProduct retrieval (as part of #26748). This is done by requiring the `T` to have a nested type `Tokens` that then does the `consumes` call and holds the `ESGetToken`s and is then passed to the constructor of `T` (in case `T` does not consume any ESProducts, it can define `Tokens` as `void` and have no further effect).

In principle I think a "maker" pattern would have been more applicable (`T` would be a "maker" that would be used to produce the concrete `JetTagComputer` in `JetTagComputerESProducer<T>::produce()`), but that would have been much heavier refactoring to which I did not want to go.

#### PR validation:

Code compiles.